### PR TITLE
Phase 0+1: foundation and SDR hardware layer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+      - name: Install librtlsdr
+        run: sudo apt-get update && sudo apt-get install -y librtlsdr-dev libusb-1.0-0-dev
+      - run: go vet ./...
+      - run: go build ./...
+      - run: go test -race -count=1 ./...

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+/bin/
+/dist/
+*.test
+*.out
+*.prof
+*.cfile
+!testdata/**/*.cfile
+.idea/
+.vscode/
+*.swp
+.DS_Store

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,34 @@
+VERSION ?= $(shell git describe --tags --dirty --always 2>/dev/null || echo dev)
+LDFLAGS := -X github.com/MattCheramie/GopherTrunk/internal/version.Version=$(VERSION)
+TAGS    ?=
+
+GO      ?= go
+PKGS    := ./...
+
+.PHONY: all build test lint tidy vet clean run proto
+
+all: build
+
+build:
+	$(GO) build -tags "$(TAGS)" -ldflags "$(LDFLAGS)" -o bin/gophertrunk ./cmd/gophertrunk
+
+test:
+	$(GO) test -tags "$(TAGS)" -race -count=1 $(PKGS)
+
+vet:
+	$(GO) vet -tags "$(TAGS)" $(PKGS)
+
+lint: vet
+	@command -v staticcheck >/dev/null && staticcheck $(PKGS) || echo "staticcheck not installed; skipping"
+
+tidy:
+	$(GO) mod tidy
+
+clean:
+	rm -rf bin/ dist/
+
+run: build
+	./bin/gophertrunk
+
+proto:
+	@echo "proto generation lands in Phase 8"

--- a/cmd/gophertrunk/main.go
+++ b/cmd/gophertrunk/main.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/MattCheramie/GopherTrunk/internal/config"
+	gtlog "github.com/MattCheramie/GopherTrunk/internal/log"
+	"github.com/MattCheramie/GopherTrunk/internal/sdr"
+	_ "github.com/MattCheramie/GopherTrunk/internal/sdr/rtlsdr"
+	"github.com/MattCheramie/GopherTrunk/internal/version"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		runDaemon(os.Args[1:])
+		return
+	}
+	switch os.Args[1] {
+	case "version", "--version", "-v":
+		fmt.Println(version.Version)
+	case "sdr":
+		runSDR(os.Args[2:])
+	case "daemon", "run":
+		runDaemon(os.Args[2:])
+	case "help", "--help", "-h":
+		printUsage()
+	default:
+		runDaemon(os.Args[1:])
+	}
+}
+
+func printUsage() {
+	fmt.Fprintln(os.Stderr, `gophertrunk — headless P25/DMR/NXDN trunking engine
+
+USAGE:
+  gophertrunk [run] [-config path]    run the daemon (default)
+  gophertrunk sdr list                list discovered SDR devices
+  gophertrunk version                 print build version
+  gophertrunk help                    show this message`)
+}
+
+func runDaemon(args []string) {
+	fs := flag.NewFlagSet("daemon", flag.ExitOnError)
+	cfgPath := fs.String("config", "", "path to YAML config (optional)")
+	logLevel := fs.String("log-level", "", "override log level (debug|info|warn|error)")
+	logFormat := fs.String("log-format", "", "override log format (text|json)")
+	_ = fs.Parse(args)
+
+	cfg, err := config.Load(*cfgPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "config: %v\n", err)
+		os.Exit(2)
+	}
+	if *logLevel != "" {
+		cfg.Log.Level = *logLevel
+	}
+	if *logFormat != "" {
+		cfg.Log.Format = *logFormat
+	}
+	logger := gtlog.New(cfg.Log.Level, cfg.Log.Format)
+
+	logger.Info("gophertrunk starting", "version", version.Version)
+
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+
+	if len(cfg.SDR.Devices) > 0 {
+		pool := sdr.NewPool(logger)
+		var hints []sdr.Hint
+		for _, d := range cfg.SDR.Devices {
+			hints = append(hints, sdr.Hint{Serial: d.Serial, Role: sdr.ParseRole(d.Role)})
+		}
+		if err := pool.Open(hints); err != nil {
+			logger.Warn("sdr pool open failed", "err", err)
+		} else {
+			defer pool.Close()
+			for _, e := range pool.Entries() {
+				logger.Info("sdr ready", "driver", e.Info.Driver, "serial", e.Info.Serial, "role", e.Role.String())
+			}
+		}
+	} else {
+		logger.Info("no SDR devices configured; idling. Configure devices in YAML to begin.")
+	}
+
+	<-ctx.Done()
+	logger.Info("shutting down")
+}
+
+func runSDR(args []string) {
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "usage: gophertrunk sdr list")
+		os.Exit(2)
+	}
+	switch args[0] {
+	case "list":
+		listSDRs()
+	default:
+		fmt.Fprintf(os.Stderr, "unknown sdr subcommand: %s\n", args[0])
+		os.Exit(2)
+	}
+}
+
+func listSDRs() {
+	infos := sdr.EnumerateAll()
+	if len(infos) == 0 {
+		fmt.Println("no SDR devices found")
+		return
+	}
+	fmt.Printf("%-8s  %-3s  %-16s  %-8s  %-8s  gains(0.1 dB)\n", "DRIVER", "IDX", "SERIAL", "TUNER", "PRODUCT")
+	for _, i := range infos {
+		fmt.Printf("%-8s  %-3d  %-16s  %-8s  %-8s  %v\n",
+			i.Driver, i.Index, truncate(i.Serial, 16), truncate(i.TunerName, 8), truncate(i.Product, 8), i.Gains)
+	}
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n]
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,79 @@
+# GopherTrunk Architecture
+
+GopherTrunk is a headless, low-latency trunking-radio engine that manages a
+pool of RTL-SDR dongles and decodes P25, DMR, and NXDN trunked systems. The
+engine is structured as a set of pipelined goroutines connected by typed
+channels, with a registry-based driver model so that mock IQ files and real
+hardware are interchangeable.
+
+## Layered overview
+
+```
+              ┌────────────────────────────────────────────┐
+              │  cmd/gophertrunk  ── daemon + sdr list CLI │
+              └───────────────┬────────────────────────────┘
+                              │
+       ┌──────────────────────┼──────────────────────────┐
+       │                      │                          │
+┌──────▼──────┐        ┌──────▼──────┐            ┌──────▼──────┐
+│  internal/  │        │  internal/  │            │  internal/  │
+│   config    │        │     log     │            │   events    │
+└─────────────┘        └─────────────┘            └─────────────┘
+
+┌──────────────────────────────────────────────────────────────┐
+│  internal/sdr (Phase 1)                                      │
+│    Driver registry → rtlsdr (CGO), mock (file replay)        │
+│    Pool: enumerates, opens, role-assigns, supervises         │
+└──────────────────────────────────────────────────────────────┘
+                              │
+                              ▼ chan []complex64
+┌──────────────────────────────────────────────────────────────┐
+│  internal/dsp (Phase 2)  filters · channelizer · demod · sync│
+└──────────────────────────────────────────────────────────────┘
+                              │
+                              ▼ symbol streams
+┌──────────────────────────────────────────────────────────────┐
+│  internal/radio (Phases 3–5)  framing · p25 · dmr · nxdn     │
+└──────────────────────────────────────────────────────────────┘
+                              │
+                              ▼ control-channel events
+┌──────────────────────────────────────────────────────────────┐
+│  internal/trunking (Phase 6) engine · grant · priority · site│
+└──────────────────────────────────────────────────────────────┘
+                              │
+                              ▼ events.Bus
+┌──────────────────────────────────────────────────────────────┐
+│  internal/voice (Phase 7) recorder · imbe · mbelib (-tags)   │
+│  internal/api    (Phase 8) gRPC server · WebSocket bridge    │
+│  internal/storage (Phase 9) SQLite call log · audio files    │
+│  internal/metrics (Phase 10) Prometheus exporter             │
+└──────────────────────────────────────────────────────────────┘
+```
+
+## Concurrency model
+
+- Each opened device owns one async-read goroutine that pushes
+  `[]complex64` chunks (~6 ms each at 2.4 MS/s) onto a buffered channel.
+- DSP stages compose as channels-in / channels-out. Each stage runs in its
+  own goroutine; back-pressure flows naturally through buffered channels.
+- The trunking engine consumes parsed control-channel events and emits
+  domain events onto an in-process pub/sub bus (`internal/events`).
+- API surfaces (gRPC, WebSocket) subscribe to the bus; they never call into
+  the engine directly. This keeps the engine API-agnostic and the API
+  testable in isolation.
+
+## Driver registry
+
+`internal/sdr` maintains a process-global registry. Each backend (CGO
+librtlsdr, file-replay mock, future HackRF/Airspy) calls `sdr.Register` from
+its `init()` so the binary's import set chooses what hardware it can talk
+to. `cmd/gophertrunk` blank-imports the drivers it ships with.
+
+## Build tags
+
+- *(default)* — links librtlsdr, no AMBE+2 vocoder.
+- `-tags mbelib` — links libmbe via CGO for AMBE+2 (P25 P2 / DMR / NXDN
+  voice). Off by default for distribution-license clarity.
+
+See `docs/phases.md` for the phased build roadmap and `docs/hardware.md`
+for the hardware setup checklist.

--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -1,0 +1,47 @@
+# Hardware Setup
+
+GopherTrunk ships with a CGO binding to librtlsdr. Building the daemon
+requires `librtlsdr-dev` and `libusb-1.0-0-dev` on the host.
+
+## Linux
+
+```sh
+sudo apt-get install librtlsdr-dev libusb-1.0-0-dev
+```
+
+Add a udev rule so non-root processes can claim the dongle:
+
+```
+# /etc/udev/rules.d/20-rtlsdr.rules
+SUBSYSTEM=="usb", ATTRS{idVendor}=="0bda", ATTRS{idProduct}=="2838", MODE="0666"
+```
+
+Reload udev (`sudo udevadm control --reload && sudo udevadm trigger`) and
+unplug/replug the dongle.
+
+Blacklist the kernel's DVB driver, which otherwise grabs the device first:
+
+```
+# /etc/modprobe.d/blacklist-dvb_usb_rtl28xxu.conf
+blacklist dvb_usb_rtl28xxu
+```
+
+## Verifying the build
+
+```sh
+make build
+./bin/gophertrunk sdr list
+```
+
+You should see one row per attached dongle with index, serial, tuner type
+(usually `R820T` or `R828D`), and the supported gain values.
+
+## Capturing IQ for replay
+
+`librtlsdr` ships `rtl_sdr` for raw captures:
+
+```sh
+rtl_sdr -f 851000000 -s 2400000 -g 49.6 -n 24000000 cc.cfile
+```
+
+Drop `.cfile` files under `testdata/iq/` to use them with the mock driver.

--- a/docs/phases.md
+++ b/docs/phases.md
@@ -1,0 +1,59 @@
+# Build Phases
+
+GopherTrunk is being built incrementally. Each phase is independently
+buildable and testable; the project stays useful even if work pauses partway.
+
+| Phase | Title                                  | Status      |
+| ----- | -------------------------------------- | ----------- |
+| 0     | Foundation                             | done        |
+| 1     | SDR hardware layer (CGO librtlsdr)     | done        |
+| 2     | DSP core (channelizer, demods)         | upcoming    |
+| 3     | P25 trunking (Phase 1 then Phase 2)    | upcoming    |
+| 3.5   | System ID & control-channel hunting    | upcoming    |
+| 4     | DMR trunking (Tier II + Tier III)      | upcoming    |
+| 5     | NXDN trunking                          | upcoming    |
+| 6     | Trunking engine (grant follower)       | upcoming    |
+| 7a    | Voice passthrough (FM, raw frames)     | upcoming    |
+| 7b    | IMBE (P25 Phase 1, default)            | upcoming    |
+| 7c    | AMBE+2 (mbelib build tag, DVSI)        | upcoming    |
+| 8     | API (gRPC + WebSocket)                 | deferred    |
+| 9     | Persistence + recording                | upcoming    |
+| 10    | Hardening (metrics, reconnect, docker) | upcoming    |
+
+## Phase 0 — Foundation
+
+- `go.mod`, `Makefile`, `.gitignore`, `.github/workflows/ci.yml`.
+- `cmd/gophertrunk` daemon scaffold with `version`, `sdr list`, `run`.
+- `internal/config` YAML loader + validation.
+- `internal/log` `log/slog` factory.
+- `internal/events` in-process pub/sub bus.
+- `internal/version` build-time stamp.
+
+## Phase 1 — SDR Hardware Layer
+
+- `internal/sdr` driver registry, `Device` interface, `Pool` with role
+  assignment.
+- `internal/sdr/rtlsdr` thin CGO binding to librtlsdr; async read bridged
+  to `chan []complex64`; PPM, gain, sample-rate, center-freq controls;
+  DC blocker and IQ-imbalance correction in `calibrate.go`.
+- File-backed mock drivers (`u8` and `f32`) for offline replay and tests.
+
+Verification:
+- `go build ./...` (links `-lrtlsdr`).
+- `go test -race -count=1 ./...` covers config, events, calibration,
+  pool, mock device. CGO binding paths are exercised by `go vet ./...`.
+- `gophertrunk version` prints the embedded version.
+- `gophertrunk sdr list` enumerates attached dongles when present;
+  prints "no SDR devices found" otherwise.
+
+## Phase 2 — DSP Core
+
+- `internal/dsp/filter` (FIR, CIC, halfband).
+- `internal/dsp/channelizer` polyphase channelizer over an FFT abstraction
+  (`internal/dsp/fft` wrapping `gonum.org/v1/gonum/dsp/fourier`).
+- `internal/dsp/demod` (FM, C4FM, H-DQPSK).
+- `internal/dsp/sync` (Mueller-Müller, Gardner, frame correlator).
+- Verification: golden vectors generated against GNU Radio reference.
+
+…subsequent phases follow the plan in
+`/root/.claude/plans/using-the-readme-md-as-sleepy-fairy.md`.

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/MattCheramie/GopherTrunk
+
+go 1.24
+
+require gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,92 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+type Config struct {
+	Log      LogConfig      `yaml:"log"`
+	SDR      SDRConfig      `yaml:"sdr"`
+	Trunking TrunkingConfig `yaml:"trunking"`
+}
+
+type LogConfig struct {
+	Level  string `yaml:"level"`
+	Format string `yaml:"format"`
+}
+
+type SDRConfig struct {
+	SampleRate uint32          `yaml:"sample_rate"`
+	Devices    []DeviceConfig  `yaml:"devices"`
+}
+
+type DeviceConfig struct {
+	Serial string `yaml:"serial"`
+	Role   string `yaml:"role"`
+	PPM    int    `yaml:"ppm"`
+	Gain   string `yaml:"gain"`
+}
+
+type TrunkingConfig struct {
+	Systems []SystemConfig `yaml:"systems"`
+}
+
+type SystemConfig struct {
+	Name             string   `yaml:"name"`
+	Protocol         string   `yaml:"protocol"`
+	ControlChannels  []uint32 `yaml:"control_channels"`
+	TalkgroupFile    string   `yaml:"talkgroup_file"`
+}
+
+func Default() Config {
+	return Config{
+		Log: LogConfig{Level: "info", Format: "text"},
+		SDR: SDRConfig{SampleRate: 2_400_000},
+	}
+}
+
+func Load(path string) (Config, error) {
+	cfg := Default()
+	if path == "" {
+		return cfg, nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return cfg, fmt.Errorf("read config: %w", err)
+	}
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return cfg, fmt.Errorf("parse config: %w", err)
+	}
+	if err := cfg.Validate(); err != nil {
+		return cfg, err
+	}
+	return cfg, nil
+}
+
+func (c Config) Validate() error {
+	if c.SDR.SampleRate != 0 && (c.SDR.SampleRate < 225_000 || c.SDR.SampleRate > 3_200_000) {
+		return errors.New("sdr.sample_rate must be between 225 kHz and 3.2 MHz")
+	}
+	for i, d := range c.SDR.Devices {
+		switch d.Role {
+		case "", "control", "voice", "auto":
+		default:
+			return fmt.Errorf("sdr.devices[%d]: role must be control|voice|auto", i)
+		}
+	}
+	for i, s := range c.Trunking.Systems {
+		if s.Name == "" {
+			return fmt.Errorf("trunking.systems[%d]: name required", i)
+		}
+		switch s.Protocol {
+		case "p25", "dmr", "nxdn":
+		default:
+			return fmt.Errorf("trunking.systems[%d]: protocol must be p25|dmr|nxdn", i)
+		}
+	}
+	return nil
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,82 @@
+package config
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadDefault(t *testing.T) {
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatalf("Load(\"\"): %v", err)
+	}
+	if cfg.Log.Level != "info" {
+		t.Errorf("default log level = %q, want info", cfg.Log.Level)
+	}
+	if cfg.SDR.SampleRate != 2_400_000 {
+		t.Errorf("default sample rate = %d, want 2400000", cfg.SDR.SampleRate)
+	}
+}
+
+func TestLoadYAML(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cfg.yaml")
+	yaml := `
+log:
+  level: debug
+  format: json
+sdr:
+  sample_rate: 2400000
+  devices:
+    - serial: "00000001"
+      role: control
+      ppm: -2
+trunking:
+  systems:
+    - name: TestSystem
+      protocol: p25
+      control_channels: [851000000, 852000000]
+`
+	if err := writeFile(path, yaml); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Log.Level != "debug" {
+		t.Errorf("level = %q", cfg.Log.Level)
+	}
+	if len(cfg.SDR.Devices) != 1 || cfg.SDR.Devices[0].Role != "control" {
+		t.Errorf("devices = %+v", cfg.SDR.Devices)
+	}
+	if len(cfg.Trunking.Systems) != 1 || cfg.Trunking.Systems[0].Protocol != "p25" {
+		t.Errorf("systems = %+v", cfg.Trunking.Systems)
+	}
+}
+
+func TestValidate(t *testing.T) {
+	cases := []struct {
+		name    string
+		cfg     Config
+		wantErr bool
+	}{
+		{"ok", Default(), false},
+		{"bad sample rate", Config{SDR: SDRConfig{SampleRate: 100}}, true},
+		{"bad role", Config{SDR: SDRConfig{Devices: []DeviceConfig{{Role: "bogus"}}}}, true},
+		{"bad protocol", Config{Trunking: TrunkingConfig{Systems: []SystemConfig{{Name: "x", Protocol: "lte"}}}}, true},
+		{"missing name", Config{Trunking: TrunkingConfig{Systems: []SystemConfig{{Protocol: "p25"}}}}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.cfg.Validate()
+			if (err != nil) != tc.wantErr {
+				t.Errorf("err = %v, wantErr = %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func writeFile(path, data string) error {
+	return writeFileImpl(path, []byte(data))
+}

--- a/internal/config/helpers_test.go
+++ b/internal/config/helpers_test.go
@@ -1,0 +1,7 @@
+package config
+
+import "os"
+
+func writeFileImpl(path string, data []byte) error {
+	return os.WriteFile(path, data, 0o600)
+}

--- a/internal/events/bus.go
+++ b/internal/events/bus.go
@@ -1,0 +1,109 @@
+// Package events implements an in-process pub/sub bus used by the engine to
+// publish trunking events. A separate API surface (gRPC, WebSocket) subscribes
+// without coupling to the engine.
+package events
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+type Kind string
+
+const (
+	KindSDRAttached  Kind = "sdr.attached"
+	KindSDRDetached  Kind = "sdr.detached"
+	KindCCLocked     Kind = "cc.locked"
+	KindCCLost       Kind = "cc.lost"
+	KindCallStart    Kind = "call.start"
+	KindCallEnd      Kind = "call.end"
+	KindGrant        Kind = "grant"
+	KindError        Kind = "error"
+)
+
+type Event struct {
+	Kind      Kind
+	Timestamp time.Time
+	Payload   any
+}
+
+type Bus struct {
+	mu     sync.RWMutex
+	subs   map[uint64]chan Event
+	nextID atomic.Uint64
+	buffer int
+	closed bool
+}
+
+func NewBus(buffer int) *Bus {
+	if buffer <= 0 {
+		buffer = 64
+	}
+	return &Bus{subs: make(map[uint64]chan Event), buffer: buffer}
+}
+
+type Subscription struct {
+	id uint64
+	C  <-chan Event
+	b  *Bus
+}
+
+func (b *Bus) Subscribe() *Subscription {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.closed {
+		ch := make(chan Event)
+		close(ch)
+		return &Subscription{C: ch}
+	}
+	id := b.nextID.Add(1)
+	ch := make(chan Event, b.buffer)
+	b.subs[id] = ch
+	return &Subscription{id: id, C: ch, b: b}
+}
+
+func (s *Subscription) Close() {
+	if s.b == nil {
+		return
+	}
+	s.b.mu.Lock()
+	defer s.b.mu.Unlock()
+	if ch, ok := s.b.subs[s.id]; ok {
+		delete(s.b.subs, s.id)
+		close(ch)
+	}
+	s.b = nil
+}
+
+// Publish delivers e to every subscriber. Slow subscribers drop the event
+// rather than blocking the publisher; we count drops via the returned int.
+func (b *Bus) Publish(e Event) int {
+	if e.Timestamp.IsZero() {
+		e.Timestamp = time.Now()
+	}
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	dropped := 0
+	for _, ch := range b.subs {
+		select {
+		case ch <- e:
+		default:
+			dropped++
+		}
+	}
+	return dropped
+}
+
+func (b *Bus) Close() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.closed {
+		return
+	}
+	b.closed = true
+	for id, ch := range b.subs {
+		close(ch)
+		delete(b.subs, id)
+	}
+}

--- a/internal/events/bus_test.go
+++ b/internal/events/bus_test.go
@@ -1,0 +1,60 @@
+package events
+
+import (
+	"testing"
+	"time"
+)
+
+func TestBusFanout(t *testing.T) {
+	b := NewBus(4)
+	defer b.Close()
+
+	a := b.Subscribe()
+	defer a.Close()
+	c := b.Subscribe()
+	defer c.Close()
+
+	b.Publish(Event{Kind: KindCCLocked, Payload: "851000000"})
+
+	for _, sub := range []*Subscription{a, c} {
+		select {
+		case e := <-sub.C:
+			if e.Kind != KindCCLocked {
+				t.Errorf("kind = %q", e.Kind)
+			}
+			if e.Timestamp.IsZero() {
+				t.Errorf("timestamp not stamped")
+			}
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for event")
+		}
+	}
+}
+
+func TestBusUnsubscribe(t *testing.T) {
+	b := NewBus(2)
+	defer b.Close()
+	s := b.Subscribe()
+	s.Close()
+	b.Publish(Event{Kind: KindError})
+	select {
+	case _, ok := <-s.C:
+		if ok {
+			t.Fatal("received event after Close()")
+		}
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func TestBusDropsWhenSlow(t *testing.T) {
+	b := NewBus(1)
+	defer b.Close()
+	s := b.Subscribe()
+	defer s.Close()
+
+	b.Publish(Event{Kind: KindCallStart})
+	dropped := b.Publish(Event{Kind: KindCallEnd})
+	if dropped != 1 {
+		t.Errorf("dropped = %d, want 1", dropped)
+	}
+}

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -1,0 +1,29 @@
+package log
+
+import (
+	"log/slog"
+	"os"
+	"strings"
+)
+
+func New(level, format string) *slog.Logger {
+	var lvl slog.Level
+	switch strings.ToLower(level) {
+	case "debug":
+		lvl = slog.LevelDebug
+	case "warn":
+		lvl = slog.LevelWarn
+	case "error":
+		lvl = slog.LevelError
+	default:
+		lvl = slog.LevelInfo
+	}
+	opts := &slog.HandlerOptions{Level: lvl}
+	var h slog.Handler
+	if strings.EqualFold(format, "json") {
+		h = slog.NewJSONHandler(os.Stderr, opts)
+	} else {
+		h = slog.NewTextHandler(os.Stderr, opts)
+	}
+	return slog.New(h)
+}

--- a/internal/sdr/device.go
+++ b/internal/sdr/device.go
@@ -1,0 +1,67 @@
+// Package sdr defines the abstract Device interface for IQ sources and the
+// pool that supervises a fleet of dongles. Concrete drivers (RTL-SDR, mock,
+// future HackRF/Airspy) live in subpackages and register themselves here.
+package sdr
+
+import "context"
+
+type Role int
+
+const (
+	RoleAuto Role = iota
+	RoleControl
+	RoleVoice
+)
+
+func (r Role) String() string {
+	switch r {
+	case RoleControl:
+		return "control"
+	case RoleVoice:
+		return "voice"
+	default:
+		return "auto"
+	}
+}
+
+func ParseRole(s string) Role {
+	switch s {
+	case "control":
+		return RoleControl
+	case "voice":
+		return RoleVoice
+	default:
+		return RoleAuto
+	}
+}
+
+// Info describes a discovered device, returned by drivers' enumeration.
+type Info struct {
+	Driver       string
+	Index        int
+	Serial       string
+	Manufacturer string
+	Product      string
+	TunerName    string
+	Gains        []int
+}
+
+// Device is the per-dongle handle. Implementations must be safe for the
+// goroutines that call StreamIQ; concurrent SetCenterFreq during streaming
+// is allowed (the underlying USB transport handles it).
+type Device interface {
+	Info() Info
+	SetCenterFreq(hz uint32) error
+	SetSampleRate(hz uint32) error
+	SetGain(tenthDB int) error // -1 selects automatic gain control
+	SetPPM(ppm int) error
+	StreamIQ(ctx context.Context) (<-chan []complex64, error)
+	Close() error
+}
+
+// Driver is the factory each backend exposes.
+type Driver interface {
+	Name() string
+	Enumerate() ([]Info, error)
+	Open(idx int) (Device, error)
+}

--- a/internal/sdr/mock.go
+++ b/internal/sdr/mock.go
@@ -1,0 +1,214 @@
+package sdr
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"sync"
+	"time"
+)
+
+// MockDriver replays unsigned-8-bit IQ files (.cfile / .iq) from a directory.
+// Each file becomes one logical "device". Used for tests and offline replay.
+type MockDriver struct {
+	Files []string
+}
+
+const MockDriverName = "mock"
+
+func (m *MockDriver) Name() string { return MockDriverName }
+
+func (m *MockDriver) Enumerate() ([]Info, error) {
+	out := make([]Info, len(m.Files))
+	for i, f := range m.Files {
+		out[i] = Info{
+			Driver:    MockDriverName,
+			Index:     i,
+			Serial:    fmt.Sprintf("mock-%02d", i),
+			Product:   "MockIQ",
+			TunerName: "file",
+			Gains:     []int{0},
+		}
+		_ = f
+	}
+	return out, nil
+}
+
+func (m *MockDriver) Open(idx int) (Device, error) {
+	if idx < 0 || idx >= len(m.Files) {
+		return nil, fmt.Errorf("mock: index %d out of range", idx)
+	}
+	return &MockDevice{path: m.Files[idx], info: Info{Driver: MockDriverName, Index: idx, Serial: fmt.Sprintf("mock-%02d", idx)}, sampleRate: 2_400_000}, nil
+}
+
+// MockDevice replays a single .cfile in real time.
+type MockDevice struct {
+	path       string
+	info       Info
+	sampleRate uint32
+	mu         sync.Mutex
+	closed     bool
+}
+
+func (d *MockDevice) Info() Info                 { return d.info }
+func (d *MockDevice) SetCenterFreq(uint32) error { return nil }
+func (d *MockDevice) SetGain(int) error          { return nil }
+func (d *MockDevice) SetPPM(int) error           { return nil }
+func (d *MockDevice) SetSampleRate(hz uint32) error {
+	d.sampleRate = hz
+	return nil
+}
+
+func (d *MockDevice) Close() error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.closed = true
+	return nil
+}
+
+// StreamIQ reads the file in chunks of ~16 KiB and meters delivery to roughly
+// match the configured sample rate. Closing the channel signals EOF.
+func (d *MockDevice) StreamIQ(ctx context.Context) (<-chan []complex64, error) {
+	f, err := os.Open(d.path)
+	if err != nil {
+		return nil, err
+	}
+	out := make(chan []complex64, 8)
+	const chunkSamples = 8192
+	chunkBytes := chunkSamples * 2 // u8 IQ pairs
+
+	go func() {
+		defer close(out)
+		defer f.Close()
+		buf := make([]byte, chunkBytes)
+		ticker := time.NewTicker(time.Duration(float64(time.Second) * float64(chunkSamples) / float64(d.sampleRate)))
+		defer ticker.Stop()
+		for {
+			n, err := io.ReadFull(f, buf)
+			if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+				if n == 0 {
+					return
+				}
+			} else if err != nil {
+				return
+			}
+			samples := decodeU8(buf[:n])
+			select {
+			case <-ctx.Done():
+				return
+			case out <- samples:
+			}
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+			}
+		}
+	}()
+	return out, nil
+}
+
+func decodeU8(buf []byte) []complex64 {
+	n := len(buf) / 2
+	out := make([]complex64, n)
+	for i := 0; i < n; i++ {
+		i8 := float32(buf[2*i]) - 127.5
+		q8 := float32(buf[2*i+1]) - 127.5
+		out[i] = complex(i8/127.5, q8/127.5)
+	}
+	return out
+}
+
+// MockFloat32Driver replays interleaved-float32 IQ files (GNU Radio cfile).
+type MockFloat32Driver struct {
+	Files []string
+}
+
+const MockFloat32DriverName = "mock-f32"
+
+func (m *MockFloat32Driver) Name() string { return MockFloat32DriverName }
+
+func (m *MockFloat32Driver) Enumerate() ([]Info, error) {
+	out := make([]Info, len(m.Files))
+	for i := range m.Files {
+		out[i] = Info{Driver: MockFloat32DriverName, Index: i, Serial: fmt.Sprintf("mockf32-%02d", i), TunerName: "file"}
+	}
+	return out, nil
+}
+
+func (m *MockFloat32Driver) Open(idx int) (Device, error) {
+	if idx < 0 || idx >= len(m.Files) {
+		return nil, fmt.Errorf("mock-f32: index %d out of range", idx)
+	}
+	return &mockF32Device{path: m.Files[idx], info: Info{Driver: MockFloat32DriverName, Index: idx, Serial: fmt.Sprintf("mockf32-%02d", idx)}, sampleRate: 2_400_000}, nil
+}
+
+type mockF32Device struct {
+	path       string
+	info       Info
+	sampleRate uint32
+}
+
+func (d *mockF32Device) Info() Info                    { return d.info }
+func (d *mockF32Device) SetCenterFreq(uint32) error    { return nil }
+func (d *mockF32Device) SetGain(int) error             { return nil }
+func (d *mockF32Device) SetPPM(int) error              { return nil }
+func (d *mockF32Device) SetSampleRate(hz uint32) error { d.sampleRate = hz; return nil }
+func (d *mockF32Device) Close() error                  { return nil }
+
+func (d *mockF32Device) StreamIQ(ctx context.Context) (<-chan []complex64, error) {
+	f, err := os.Open(d.path)
+	if err != nil {
+		return nil, err
+	}
+	out := make(chan []complex64, 8)
+	const chunkSamples = 4096
+	go func() {
+		defer close(out)
+		defer f.Close()
+		buf := make([]byte, chunkSamples*8) // 2 * float32 per sample
+		ticker := time.NewTicker(time.Duration(float64(time.Second) * float64(chunkSamples) / float64(d.sampleRate)))
+		defer ticker.Stop()
+		for {
+			n, err := io.ReadFull(f, buf)
+			if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+				if n == 0 {
+					return
+				}
+			} else if err != nil {
+				return
+			}
+			samples := decodeF32(buf[:n])
+			select {
+			case <-ctx.Done():
+				return
+			case out <- samples:
+			}
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+			}
+		}
+	}()
+	return out, nil
+}
+
+func decodeF32(buf []byte) []complex64 {
+	n := len(buf) / 8
+	out := make([]complex64, n)
+	for i := 0; i < n; i++ {
+		ri := readF32LE(buf[8*i:])
+		qi := readF32LE(buf[8*i+4:])
+		out[i] = complex(ri, qi)
+	}
+	return out
+}
+
+func readF32LE(b []byte) float32 {
+	return math.Float32frombits(binary.LittleEndian.Uint32(b))
+}

--- a/internal/sdr/mock_test.go
+++ b/internal/sdr/mock_test.go
@@ -1,0 +1,60 @@
+package sdr
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestMockDeviceReplaysU8(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "iq.cfile")
+	const samples = 8192
+	buf := make([]byte, samples*2)
+	for i := range buf {
+		buf[i] = byte(127 + (i % 7) - 3)
+	}
+	if err := os.WriteFile(path, buf, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	drv := &MockDriver{Files: []string{path}}
+	dev, err := drv.Open(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := dev.SetSampleRate(8_000_000); err != nil { // run faster than realtime
+		t.Fatal(err)
+	}
+	defer dev.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	ch, err := dev.StreamIQ(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := 0
+	for chunk := range ch {
+		got += len(chunk)
+		if got >= samples {
+			break
+		}
+	}
+	if got < samples {
+		t.Errorf("received %d samples, want >= %d", got, samples)
+	}
+}
+
+func TestMockDriverEnumerate(t *testing.T) {
+	drv := &MockDriver{Files: []string{"a.cfile", "b.cfile"}}
+	infos, err := drv.Enumerate()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(infos) != 2 || infos[1].Index != 1 {
+		t.Errorf("infos = %+v", infos)
+	}
+}

--- a/internal/sdr/pool.go
+++ b/internal/sdr/pool.go
@@ -1,0 +1,151 @@
+package sdr
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+)
+
+// PoolEntry tracks a single discovered-and-opened device along with its role.
+type PoolEntry struct {
+	Driver Driver
+	Device Device
+	Info   Info
+	Role   Role
+}
+
+// Pool holds a fleet of opened SDR devices and assigns roles.
+type Pool struct {
+	mu      sync.RWMutex
+	entries []*PoolEntry
+	log     *slog.Logger
+}
+
+func NewPool(logger *slog.Logger) *Pool {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Pool{log: logger}
+}
+
+// Hint guides role assignment when opening devices. Match by serial first;
+// fall back to first-found.
+type Hint struct {
+	Serial string
+	Role   Role
+}
+
+// Open enumerates every registered driver, opens devices that match the
+// supplied hints (or simply all of them when hints is empty), and assigns
+// roles. The first opened device gets RoleControl unless a hint says
+// otherwise; subsequent devices get RoleVoice.
+func (p *Pool) Open(hints []Hint) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if len(p.entries) > 0 {
+		return errors.New("pool already populated; close first")
+	}
+
+	type discovered struct {
+		drv  Driver
+		info Info
+	}
+	var all []discovered
+	for _, drv := range Drivers() {
+		infos, err := drv.Enumerate()
+		if err != nil {
+			p.log.Warn("driver enumerate failed", "driver", drv.Name(), "err", err)
+			continue
+		}
+		for _, info := range infos {
+			all = append(all, discovered{drv, info})
+		}
+	}
+	if len(all) == 0 {
+		return errors.New("no SDR devices discovered")
+	}
+
+	hintBySerial := map[string]Hint{}
+	controlClaimed := false
+	for _, h := range hints {
+		if h.Serial != "" {
+			hintBySerial[h.Serial] = h
+			if h.Role == RoleControl {
+				controlClaimed = true
+			}
+		}
+	}
+
+	for _, d := range all {
+		role := RoleAuto
+		if h, ok := hintBySerial[d.info.Serial]; ok {
+			role = h.Role
+		}
+		if role == RoleAuto {
+			if !controlClaimed {
+				role = RoleControl
+				controlClaimed = true
+			} else {
+				role = RoleVoice
+			}
+		}
+		dev, err := d.drv.Open(d.info.Index)
+		if err != nil {
+			p.log.Error("open device failed", "driver", d.drv.Name(), "index", d.info.Index, "err", err)
+			continue
+		}
+		p.entries = append(p.entries, &PoolEntry{Driver: d.drv, Device: dev, Info: d.info, Role: role})
+		p.log.Info("device opened", "driver", d.drv.Name(), "serial", d.info.Serial, "role", role.String())
+	}
+	if len(p.entries) == 0 {
+		return errors.New("no SDR devices opened")
+	}
+	return nil
+}
+
+func (p *Pool) Entries() []*PoolEntry {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	out := make([]*PoolEntry, len(p.entries))
+	copy(out, p.entries)
+	return out
+}
+
+// FirstByRole returns the first device with the given role, or nil.
+func (p *Pool) FirstByRole(r Role) *PoolEntry {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	for _, e := range p.entries {
+		if e.Role == r {
+			return e
+		}
+	}
+	return nil
+}
+
+// AllByRole returns every device with the given role.
+func (p *Pool) AllByRole(r Role) []*PoolEntry {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	var out []*PoolEntry
+	for _, e := range p.entries {
+		if e.Role == r {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+func (p *Pool) Close() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	var errs []error
+	for _, e := range p.entries {
+		if err := e.Device.Close(); err != nil {
+			errs = append(errs, fmt.Errorf("%s: %w", e.Info.Serial, err))
+		}
+	}
+	p.entries = nil
+	return errors.Join(errs...)
+}

--- a/internal/sdr/pool_test.go
+++ b/internal/sdr/pool_test.go
@@ -1,0 +1,104 @@
+package sdr
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+)
+
+type fakeDriver struct {
+	name  string
+	infos []Info
+}
+
+func (f *fakeDriver) Name() string                 { return f.name }
+func (f *fakeDriver) Enumerate() ([]Info, error)   { return f.infos, nil }
+func (f *fakeDriver) Open(idx int) (Device, error) { return &fakeDevice{info: f.infos[idx]}, nil }
+
+type fakeDevice struct {
+	info   Info
+	closed bool
+}
+
+func (d *fakeDevice) Info() Info                                            { return d.info }
+func (d *fakeDevice) SetCenterFreq(uint32) error                            { return nil }
+func (d *fakeDevice) SetSampleRate(uint32) error                            { return nil }
+func (d *fakeDevice) SetGain(int) error                                     { return nil }
+func (d *fakeDevice) SetPPM(int) error                                      { return nil }
+func (d *fakeDevice) StreamIQ(context.Context) (<-chan []complex64, error)  { return nil, io.EOF }
+func (d *fakeDevice) Close() error {
+	if d.closed {
+		return errors.New("already closed")
+	}
+	d.closed = true
+	return nil
+}
+
+func TestPoolAssignsRoles(t *testing.T) {
+	drv := &fakeDriver{name: "fake-pool", infos: []Info{
+		{Driver: "fake-pool", Index: 0, Serial: "AAA"},
+		{Driver: "fake-pool", Index: 1, Serial: "BBB"},
+		{Driver: "fake-pool", Index: 2, Serial: "CCC"},
+	}}
+	registryMu.Lock()
+	registry["fake-pool"] = drv
+	registryMu.Unlock()
+	t.Cleanup(func() {
+		registryMu.Lock()
+		delete(registry, "fake-pool")
+		registryMu.Unlock()
+	})
+
+	p := NewPool(nil)
+	if err := p.Open([]Hint{{Serial: "BBB", Role: RoleControl}}); err != nil {
+		t.Fatal(err)
+	}
+	defer p.Close()
+
+	entries := p.Entries()
+	if len(entries) != 3 {
+		t.Fatalf("entries = %d, want 3", len(entries))
+	}
+
+	roles := map[string]Role{}
+	for _, e := range entries {
+		roles[e.Info.Serial] = e.Role
+	}
+	if roles["BBB"] != RoleControl {
+		t.Errorf("BBB role = %v, want control", roles["BBB"])
+	}
+	// Non-hinted devices get auto assignment, with first device taking
+	// the still-unassigned control slot if no other hint claimed it.
+	// Here BBB is hinted control, so AAA and CCC should be voice.
+	if roles["AAA"] != RoleVoice || roles["CCC"] != RoleVoice {
+		t.Errorf("AAA=%v CCC=%v, want both voice", roles["AAA"], roles["CCC"])
+	}
+}
+
+func TestPoolFirstByRole(t *testing.T) {
+	drv := &fakeDriver{name: "fake-first", infos: []Info{
+		{Driver: "fake-first", Index: 0, Serial: "X"},
+		{Driver: "fake-first", Index: 1, Serial: "Y"},
+	}}
+	registryMu.Lock()
+	registry["fake-first"] = drv
+	registryMu.Unlock()
+	t.Cleanup(func() {
+		registryMu.Lock()
+		delete(registry, "fake-first")
+		registryMu.Unlock()
+	})
+
+	p := NewPool(nil)
+	if err := p.Open(nil); err != nil {
+		t.Fatal(err)
+	}
+	defer p.Close()
+	if e := p.FirstByRole(RoleControl); e == nil || e.Info.Serial != "X" {
+		t.Errorf("control = %+v, want X", e)
+	}
+	if e := p.FirstByRole(RoleVoice); e == nil || e.Info.Serial != "Y" {
+		t.Errorf("voice = %+v, want Y", e)
+	}
+}

--- a/internal/sdr/registry.go
+++ b/internal/sdr/registry.go
@@ -1,0 +1,52 @@
+package sdr
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+)
+
+var (
+	registryMu sync.RWMutex
+	registry   = map[string]Driver{}
+)
+
+func Register(d Driver) {
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	registry[d.Name()] = d
+}
+
+func Drivers() []Driver {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+	out := make([]Driver, 0, len(registry))
+	for _, d := range registry {
+		out = append(out, d)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name() < out[j].Name() })
+	return out
+}
+
+func DriverByName(name string) (Driver, error) {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+	d, ok := registry[name]
+	if !ok {
+		return nil, fmt.Errorf("sdr: unknown driver %q", name)
+	}
+	return d, nil
+}
+
+// EnumerateAll asks every registered driver to list its devices.
+func EnumerateAll() []Info {
+	var out []Info
+	for _, d := range Drivers() {
+		infos, err := d.Enumerate()
+		if err != nil {
+			continue
+		}
+		out = append(out, infos...)
+	}
+	return out
+}

--- a/internal/sdr/rtlsdr/calibrate.go
+++ b/internal/sdr/rtlsdr/calibrate.go
@@ -1,0 +1,56 @@
+package rtlsdr
+
+import "math"
+
+// DCBlocker subtracts a slowly-tracked DC bias from a complex sample stream.
+// Useful because RTL-SDR dongles park noticeable DC at the tuned center bin.
+type DCBlocker struct {
+	alpha float64
+	avgI  float64
+	avgQ  float64
+}
+
+func NewDCBlocker(alpha float64) *DCBlocker {
+	if alpha <= 0 || alpha >= 1 {
+		alpha = 0.001
+	}
+	return &DCBlocker{alpha: alpha}
+}
+
+func (d *DCBlocker) Process(in []complex64) {
+	for i, s := range in {
+		ri := float64(real(s))
+		qi := float64(imag(s))
+		d.avgI += d.alpha * (ri - d.avgI)
+		d.avgQ += d.alpha * (qi - d.avgQ)
+		in[i] = complex(float32(ri-d.avgI), float32(qi-d.avgQ))
+	}
+}
+
+// IQBalancer applies a single-coefficient IQ-imbalance correction
+// (gain + phase) measured against a calibration tone. Coefficients are 1.0
+// and 0.0 by default (passthrough).
+type IQBalancer struct {
+	GainQ float32 // amplitude scale for Q
+	Phase float32 // radians, applied to Q via Q' = Q*cos - I*sin
+}
+
+func (b IQBalancer) Process(in []complex64) {
+	cos := float32(math.Cos(float64(b.Phase)))
+	sin := float32(math.Sin(float64(b.Phase)))
+	gain := b.GainQ
+	if gain == 0 {
+		gain = 1
+	}
+	for i, s := range in {
+		ri := real(s)
+		qi := imag(s) * gain
+		in[i] = complex(ri, qi*cos-ri*sin)
+	}
+}
+
+// PPMToHz returns the absolute-Hz offset implied by a PPM value at the given
+// center frequency. Useful when reporting calibration results.
+func PPMToHz(ppm int, centerHz uint32) int64 {
+	return int64(ppm) * int64(centerHz) / 1_000_000
+}

--- a/internal/sdr/rtlsdr/calibrate_test.go
+++ b/internal/sdr/rtlsdr/calibrate_test.go
@@ -1,0 +1,43 @@
+package rtlsdr
+
+import (
+	"math"
+	"testing"
+)
+
+func TestDCBlockerRemovesBias(t *testing.T) {
+	const n = 4096
+	in := make([]complex64, n)
+	for i := range in {
+		in[i] = complex(0.5, -0.3) // pure DC
+	}
+	d := NewDCBlocker(0.05)
+	for k := 0; k < 20; k++ {
+		buf := append([]complex64(nil), in...)
+		d.Process(buf)
+		if k == 19 {
+			// After convergence, output should be near zero.
+			var maxAbs float32
+			for _, s := range buf {
+				a := absComplex(s)
+				if a > maxAbs {
+					maxAbs = a
+				}
+			}
+			if maxAbs > 0.05 {
+				t.Errorf("residual after convergence = %f, want < 0.05", maxAbs)
+			}
+		}
+	}
+}
+
+func TestPPMToHz(t *testing.T) {
+	got := PPMToHz(50, 851_000_000)
+	if got != 42_550 {
+		t.Errorf("PPMToHz = %d, want 42550", got)
+	}
+}
+
+func absComplex(c complex64) float32 {
+	return float32(math.Hypot(float64(real(c)), float64(imag(c))))
+}

--- a/internal/sdr/rtlsdr/rtlsdr_cgo.go
+++ b/internal/sdr/rtlsdr/rtlsdr_cgo.go
@@ -1,0 +1,272 @@
+// Package rtlsdr is a thin CGO binding to librtlsdr. It exposes the subset
+// of the C API required by GopherTrunk: enumeration, tuning, sample rate,
+// gain, PPM, and an async read loop bridged to a Go channel of complex64.
+//
+// The build links against -lrtlsdr and requires librtlsdr-dev headers on
+// the build host. Runtime needs udev rules granting USB access (see
+// docs/hardware.md).
+package rtlsdr
+
+/*
+#cgo pkg-config: librtlsdr
+#include <rtl-sdr.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+extern void gophertrunk_rtlsdr_callback(unsigned char *buf, uint32_t len, void *ctx);
+
+// Wrapper that accepts the cgo.Handle as uintptr_t; this avoids the
+// uintptr->unsafe.Pointer conversion vet warning on the Go side.
+static int gt_rtlsdr_read_async(rtlsdr_dev_t *dev, uintptr_t handle,
+                                uint32_t buf_num, uint32_t buf_len) {
+    return rtlsdr_read_async(dev, gophertrunk_rtlsdr_callback,
+                             (void *)handle, buf_num, buf_len);
+}
+*/
+import "C"
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"runtime/cgo"
+	"sync"
+	"unsafe"
+
+	"github.com/MattCheramie/GopherTrunk/internal/sdr"
+)
+
+const driverName = "rtlsdr"
+
+// Default async-buffer geometry. 32 buffers × 16 KiB → ~6 ms at 2.4 MS/s.
+const (
+	asyncBufCount = 32
+	asyncBufLen   = 16 * 1024
+)
+
+func init() { sdr.Register(driver{}) }
+
+type driver struct{}
+
+func (driver) Name() string { return driverName }
+
+func (driver) Enumerate() ([]sdr.Info, error) {
+	count := int(C.rtlsdr_get_device_count())
+	out := make([]sdr.Info, 0, count)
+	for i := 0; i < count; i++ {
+		var manuf, prod, ser [256]C.char
+		C.rtlsdr_get_device_usb_strings(C.uint32_t(i), &manuf[0], &prod[0], &ser[0])
+		info := sdr.Info{
+			Driver:       driverName,
+			Index:        i,
+			Manufacturer: C.GoString(&manuf[0]),
+			Product:      C.GoString(&prod[0]),
+			Serial:       C.GoString(&ser[0]),
+		}
+		out = append(out, info)
+	}
+	return out, nil
+}
+
+func (driver) Open(idx int) (sdr.Device, error) {
+	var dev *C.rtlsdr_dev_t
+	if rc := C.rtlsdr_open(&dev, C.uint32_t(idx)); rc != 0 {
+		return nil, fmt.Errorf("rtlsdr_open(%d): rc=%d", idx, rc)
+	}
+	d := &Device{dev: dev, index: idx}
+	d.populateInfo()
+	d.populateGains()
+	return d, nil
+}
+
+// Device is a handle to one RTL-SDR dongle.
+type Device struct {
+	mu     sync.Mutex
+	dev    *C.rtlsdr_dev_t
+	index  int
+	info   sdr.Info
+	closed bool
+
+	// streaming state, owned while StreamIQ is running.
+	streamMu sync.Mutex
+	handle   cgo.Handle
+	out      chan []complex64
+	stopOnce sync.Once
+}
+
+func (d *Device) populateInfo() {
+	d.info = sdr.Info{Driver: driverName, Index: d.index}
+	var manuf, prod, ser [256]C.char
+	C.rtlsdr_get_usb_strings(d.dev, &manuf[0], &prod[0], &ser[0])
+	d.info.Manufacturer = C.GoString(&manuf[0])
+	d.info.Product = C.GoString(&prod[0])
+	d.info.Serial = C.GoString(&ser[0])
+	tuner := C.rtlsdr_get_tuner_type(d.dev)
+	d.info.TunerName = tunerName(tuner)
+}
+
+func (d *Device) populateGains() {
+	n := int(C.rtlsdr_get_tuner_gains(d.dev, nil))
+	if n <= 0 {
+		return
+	}
+	buf := make([]C.int, n)
+	C.rtlsdr_get_tuner_gains(d.dev, (*C.int)(unsafe.Pointer(&buf[0])))
+	d.info.Gains = make([]int, n)
+	for i, g := range buf {
+		d.info.Gains[i] = int(g)
+	}
+}
+
+func (d *Device) Info() sdr.Info { return d.info }
+
+func (d *Device) SetCenterFreq(hz uint32) error {
+	if rc := C.rtlsdr_set_center_freq(d.dev, C.uint32_t(hz)); rc != 0 {
+		return fmt.Errorf("rtlsdr_set_center_freq(%d): rc=%d", hz, rc)
+	}
+	return nil
+}
+
+func (d *Device) SetSampleRate(hz uint32) error {
+	if rc := C.rtlsdr_set_sample_rate(d.dev, C.uint32_t(hz)); rc != 0 {
+		return fmt.Errorf("rtlsdr_set_sample_rate(%d): rc=%d", hz, rc)
+	}
+	return nil
+}
+
+func (d *Device) SetGain(tenthDB int) error {
+	if tenthDB < 0 {
+		if rc := C.rtlsdr_set_tuner_gain_mode(d.dev, 0); rc != 0 {
+			return fmt.Errorf("rtlsdr_set_tuner_gain_mode(auto): rc=%d", rc)
+		}
+		return nil
+	}
+	if rc := C.rtlsdr_set_tuner_gain_mode(d.dev, 1); rc != 0 {
+		return fmt.Errorf("rtlsdr_set_tuner_gain_mode(manual): rc=%d", rc)
+	}
+	if rc := C.rtlsdr_set_tuner_gain(d.dev, C.int(tenthDB)); rc != 0 {
+		return fmt.Errorf("rtlsdr_set_tuner_gain(%d): rc=%d", tenthDB, rc)
+	}
+	return nil
+}
+
+func (d *Device) SetPPM(ppm int) error {
+	if rc := C.rtlsdr_set_freq_correction(d.dev, C.int(ppm)); rc != 0 && rc != -2 {
+		// -2 means "value unchanged" on librtlsdr; treat as success.
+		return fmt.Errorf("rtlsdr_set_freq_correction(%d): rc=%d", ppm, rc)
+	}
+	return nil
+}
+
+// StreamIQ resets the buffer, kicks off rtlsdr_read_async on a goroutine, and
+// returns a channel of complex64 samples. The channel closes when ctx cancels
+// or Close is called.
+func (d *Device) StreamIQ(ctx context.Context) (<-chan []complex64, error) {
+	d.streamMu.Lock()
+	defer d.streamMu.Unlock()
+	if d.out != nil {
+		return nil, errors.New("rtlsdr: stream already active")
+	}
+	if rc := C.rtlsdr_reset_buffer(d.dev); rc != 0 {
+		return nil, fmt.Errorf("rtlsdr_reset_buffer: rc=%d", rc)
+	}
+	out := make(chan []complex64, 8)
+	d.out = out
+	d.handle = cgo.NewHandle(d)
+	d.stopOnce = sync.Once{}
+
+	go func() {
+		C.gt_rtlsdr_read_async(
+			d.dev,
+			C.uintptr_t(d.handle),
+			C.uint32_t(asyncBufCount),
+			C.uint32_t(asyncBufLen),
+		)
+		d.streamMu.Lock()
+		if d.out != nil {
+			close(d.out)
+			d.out = nil
+		}
+		d.handle.Delete()
+		d.streamMu.Unlock()
+	}()
+
+	go func() {
+		<-ctx.Done()
+		d.cancelStream()
+	}()
+
+	return out, nil
+}
+
+func (d *Device) cancelStream() {
+	d.stopOnce.Do(func() {
+		C.rtlsdr_cancel_async(d.dev)
+	})
+}
+
+func (d *Device) deliver(buf []byte) {
+	// RTL-SDR delivers unsigned 8-bit IQ pairs. Convert to complex64 with a
+	// DC bias of 127.5 → range ~[-1, +1).
+	n := len(buf) / 2
+	out := make([]complex64, n)
+	for i := 0; i < n; i++ {
+		i8 := float32(buf[2*i]) - 127.5
+		q8 := float32(buf[2*i+1]) - 127.5
+		out[i] = complex(i8/127.5, q8/127.5)
+	}
+	select {
+	case d.out <- out:
+	default:
+		// Drop on overrun; consumer is too slow.
+	}
+}
+
+func (d *Device) Close() error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.closed {
+		return nil
+	}
+	d.closed = true
+	d.cancelStream()
+	if rc := C.rtlsdr_close(d.dev); rc != 0 {
+		return fmt.Errorf("rtlsdr_close: rc=%d", rc)
+	}
+	return nil
+}
+
+func tunerName(t C.enum_rtlsdr_tuner) string {
+	switch t {
+	case C.RTLSDR_TUNER_E4000:
+		return "E4000"
+	case C.RTLSDR_TUNER_FC0012:
+		return "FC0012"
+	case C.RTLSDR_TUNER_FC0013:
+		return "FC0013"
+	case C.RTLSDR_TUNER_FC2580:
+		return "FC2580"
+	case C.RTLSDR_TUNER_R820T:
+		return "R820T"
+	case C.RTLSDR_TUNER_R828D:
+		return "R828D"
+	default:
+		return "unknown"
+	}
+}
+
+//export gophertrunk_rtlsdr_callback
+func gophertrunk_rtlsdr_callback(buf *C.uchar, length C.uint32_t, ctx unsafe.Pointer) {
+	h := cgo.Handle(uintptr(ctx))
+	d, ok := h.Value().(*Device)
+	if !ok || d == nil {
+		return
+	}
+	// Copy the C buffer into a Go slice before returning; the callback
+	// reuses the buffer immediately on return.
+	n := int(length)
+	src := unsafe.Slice((*byte)(unsafe.Pointer(buf)), n)
+	cp := make([]byte, n)
+	copy(cp, src)
+	d.deliver(cp)
+}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,3 @@
+package version
+
+var Version = "dev"


### PR DESCRIPTION
Phase 0 — foundation:
- Go module, Makefile, .gitignore, CI workflow
- cmd/gophertrunk daemon scaffold with version, sdr list, run subcommands
- internal/config: YAML loader with validation
- internal/log: log/slog factory
- internal/events: in-process pub/sub bus

Phase 1 — SDR hardware layer:
- internal/sdr: Driver interface, registry, Pool with role assignment
- internal/sdr/rtlsdr: CGO binding to librtlsdr with async-read bridge,
  PPM/gain/freq/sample-rate controls, DC blocker, IQ-imbalance correction
- internal/sdr/mock: file-backed u8/f32 IQ replay drivers for tests

docs/architecture.md, docs/phases.md, docs/hardware.md describe the
phased roadmap from the build plan.