### PR TITLE
GopherTrunk Phases 0–2: foundation, SDR hardware, DSP core

### DIFF
--- a/docs/phases.md
+++ b/docs/phases.md
@@ -7,7 +7,7 @@ buildable and testable; the project stays useful even if work pauses partway.
 | ----- | -------------------------------------- | ----------- |
 | 0     | Foundation                             | done        |
 | 1     | SDR hardware layer (CGO librtlsdr)     | done        |
-| 2     | DSP core (channelizer, demods)         | upcoming    |
+| 2     | DSP core (channelizer, demods)         | done        |
 | 3     | P25 trunking (Phase 1 then Phase 2)    | upcoming    |
 | 3.5   | System ID & control-channel hunting    | upcoming    |
 | 4     | DMR trunking (Tier II + Tier III)      | upcoming    |
@@ -48,12 +48,26 @@ Verification:
 
 ## Phase 2 — DSP Core
 
-- `internal/dsp/filter` (FIR, CIC, halfband).
-- `internal/dsp/channelizer` polyphase channelizer over an FFT abstraction
-  (`internal/dsp/fft` wrapping `gonum.org/v1/gonum/dsp/fourier`).
-- `internal/dsp/demod` (FM, C4FM, H-DQPSK).
-- `internal/dsp/sync` (Mueller-Müller, Gardner, frame correlator).
-- Verification: golden vectors generated against GNU Radio reference.
+- `internal/dsp/window` standard window functions (Hann, Hamming, Blackman,
+  Kaiser, Rect).
+- `internal/dsp/fft` swappable FFT plan interface, default backend wraps
+  `gonum.org/v1/gonum/dsp/fourier`.
+- `internal/dsp/filter` FIR (with stateful history), Kaiser-window LPF
+  designer, root-raised-cosine pulse shaping, CIC decimator, halfband LPF.
+- `internal/dsp/agc` AGC feedback loop.
+- `internal/dsp/resampler` polyphase rational resampler (L/M).
+- `internal/dsp/channelizer` M-channel critically-sampled polyphase
+  channelizer; FFT-rotated branch outputs.
+- `internal/dsp/demod` quadrature FM, C4FM (RRC matched filter + 4-level
+  slicer), H-DQPSK (differential QPSK with configurable rotation).
+- `internal/dsp/sync` Mueller-Müller symbol-timing recovery and a
+  correlator-based frame sync.
+- Verification (no external golden vectors required): impulse response
+  equality for FIR; passband/stopband power tests for Kaiser LPF; tone
+  steering verified for the channelizer (positive +k·Fs/M tone lands in
+  channel k with adjacent-channel rejection > 20 dB); AGC convergence;
+  RRC unit-energy and matched-filter peak-at-center; FM demod against a
+  linear chirp; D-QPSK against constant phase steps.
 
 …subsequent phases follow the plan in
 `/root/.claude/plans/using-the-readme-md-as-sleepy-fairy.md`.

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,9 @@
 module github.com/MattCheramie/GopherTrunk
 
-go 1.24
+go 1.24.0
+
+toolchain go1.24.7
 
 require gopkg.in/yaml.v3 v3.0.1
+
+require gonum.org/v1/gonum v0.17.0

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+gonum.org/v1/gonum v0.17.0 h1:VbpOemQlsSMrYmn7T2OUvQ4dqxQXU+ouZFQsZOx50z4=
+gonum.org/v1/gonum v0.17.0/go.mod h1:El3tOrEuMpv2UdMrbNlKEh9vd86bmQ6vqIcDwxEOc1E=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/internal/dsp/agc.go
+++ b/internal/dsp/agc.go
@@ -1,0 +1,57 @@
+package dsp
+
+import "math"
+
+// AGC is a feedback automatic-gain-control loop that drives the average
+// magnitude of a complex IQ stream toward Reference.
+type AGC struct {
+	Reference float32 // target output magnitude (default 1.0)
+	Rate      float32 // adaptation step (typical 1e-3 to 1e-2)
+	MaxGain   float32 // ceiling to avoid runaway on dead-air
+	gain      float32
+}
+
+func NewAGC(reference, rate, maxGain float32) *AGC {
+	if reference <= 0 {
+		reference = 1
+	}
+	if rate <= 0 {
+		rate = 1e-3
+	}
+	if maxGain <= 0 {
+		maxGain = 65536
+	}
+	return &AGC{Reference: reference, Rate: rate, MaxGain: maxGain, gain: 1}
+}
+
+func (a *AGC) Gain() float32 { return a.gain }
+
+func (a *AGC) Process(dst, src []complex64) []complex64 {
+	if cap(dst) < len(src) {
+		dst = make([]complex64, len(src))
+	} else {
+		dst = dst[:len(src)]
+	}
+	for i, s := range src {
+		out := complex(real(s)*a.gain, imag(s)*a.gain)
+		mag := float32(math.Hypot(float64(real(out)), float64(imag(out))))
+		// Update gain toward reference.
+		err := a.Reference - mag
+		a.gain += a.Rate * err / max32(mag, 1e-6)
+		if a.gain > a.MaxGain {
+			a.gain = a.MaxGain
+		}
+		if a.gain < 1e-6 {
+			a.gain = 1e-6
+		}
+		dst[i] = out
+	}
+	return dst
+}
+
+func max32(a, b float32) float32 {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/internal/dsp/agc_test.go
+++ b/internal/dsp/agc_test.go
@@ -1,0 +1,44 @@
+package dsp
+
+import (
+	"math"
+	"testing"
+)
+
+func TestAGCConvergence(t *testing.T) {
+	a := NewAGC(1.0, 5e-3, 1e6)
+	in := make([]complex64, 100_000)
+	for i := range in {
+		// Constant amplitude 0.01 — AGC should drive to ~100x gain.
+		in[i] = complex(0.01, 0)
+	}
+	out := a.Process(nil, in)
+	tail := out[len(out)-1024:]
+	var avg float64
+	for _, s := range tail {
+		avg += math.Hypot(float64(real(s)), float64(imag(s)))
+	}
+	avg /= float64(len(tail))
+	if avg < 0.9 || avg > 1.1 {
+		t.Errorf("AGC settled magnitude = %f, want ~1.0", avg)
+	}
+}
+
+func TestResamplerRateRoughlyMatches(t *testing.T) {
+	// 3/2 upsample: 1000 in → ~1500 out (after warmup).
+	r := NewResampler(3, 2, 8, 8.6)
+	in := make([]complex64, 4000)
+	for i := range in {
+		theta := 2 * math.Pi * 0.05 * float64(i)
+		in[i] = complex(float32(math.Cos(theta)), float32(math.Sin(theta)))
+	}
+	out := r.Process(nil, in)
+	want := len(in) * 3 / 2
+	diff := want - len(out)
+	if diff < 0 {
+		diff = -diff
+	}
+	if diff > 4 {
+		t.Errorf("len(out) = %d, want %d ± 4", len(out), want)
+	}
+}

--- a/internal/dsp/channelizer/polyphase.go
+++ b/internal/dsp/channelizer/polyphase.go
@@ -1,0 +1,125 @@
+// Package channelizer implements an M-channel critically-sampled polyphase
+// channelizer. One IQ stream at sample rate Fs is split into M evenly-spaced
+// baseband streams each at Fs/M.
+//
+// The implementation follows the standard textbook structure (e.g., Harris,
+// "Multirate Signal Processing for Communication Systems"): a prototype
+// lowpass filter is decomposed into M polyphase branches; for every M input
+// samples, each branch produces one sample, the M branch outputs are
+// FFT-rotated, and the result is M output samples — one per channel.
+package channelizer
+
+import (
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/fft"
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/filter"
+)
+
+type Polyphase struct {
+	m         int
+	taps      int          // taps per branch
+	branches  [][]float32  // [m][taps]
+	hist      [][]complex64 // [m][taps] ring buffer per branch
+	histPos   []int
+	commIdx   int          // next branch to receive an input sample
+	plan      fft.Plan
+	scratchIn []complex128
+}
+
+// New builds an M-channel channelizer using a Kaiser-window prototype LPF
+// with cutoff 1/(2M) and the given taps-per-branch and shape parameter.
+func New(channels, tapsPerBranch int, kaiserBeta float64) *Polyphase {
+	if channels < 2 {
+		panic("channelizer: channels must be >= 2")
+	}
+	N := channels * tapsPerBranch
+	if N%2 == 0 {
+		N++
+	}
+	proto := filter.LowpassKaiser(N, 0.5/float64(channels), kaiserBeta)
+	return NewWithPrototype(channels, proto)
+}
+
+// NewWithPrototype lets callers supply a custom prototype filter.
+func NewWithPrototype(channels int, proto []float32) *Polyphase {
+	branches := make([][]float32, channels)
+	tapsPer := (len(proto) + channels - 1) / channels
+	for b := 0; b < channels; b++ {
+		row := make([]float32, tapsPer)
+		for k := 0; k < tapsPer; k++ {
+			j := k*channels + b
+			if j < len(proto) {
+				row[k] = proto[j]
+			}
+		}
+		branches[b] = row
+	}
+	hist := make([][]complex64, channels)
+	histPos := make([]int, channels)
+	for i := range hist {
+		hist[i] = make([]complex64, tapsPer)
+	}
+	return &Polyphase{
+		m:         channels,
+		taps:      tapsPer,
+		branches:  branches,
+		hist:      hist,
+		histPos:   histPos,
+		plan:      fft.New(channels),
+		scratchIn: make([]complex128, channels),
+	}
+}
+
+// Channels returns the number of output channels M.
+func (p *Polyphase) Channels() int { return p.m }
+
+// Process consumes len(src) IQ samples. For every M input samples it emits
+// one output sample per channel; the result is dst[ch][k] for each channel.
+// dst is reused if it has the right shape.
+func (p *Polyphase) Process(dst [][]complex64, src []complex64) [][]complex64 {
+	if dst == nil || len(dst) != p.m {
+		dst = make([][]complex64, p.m)
+	}
+	for c := 0; c < p.m; c++ {
+		dst[c] = dst[c][:0]
+	}
+	for _, x := range src {
+		// Feed the incoming sample into branch p.commIdx. With a forward
+		// FFT (e^{-j2π m n / M}), input sample n going to branch n means
+		// that a positive tone at +m·Fs/M lands in output channel m.
+		b := p.commIdx
+		hpos := p.histPos[b]
+		p.hist[b][hpos] = x
+		p.histPos[b] = (hpos + 1) % p.taps
+
+		p.commIdx++
+		if p.commIdx == p.m {
+			p.commIdx = 0
+			// Compute one polyphase output per branch, then FFT.
+			for k := 0; k < p.m; k++ {
+				row := p.branches[k]
+				idx := p.histPos[k] - 1
+				if idx < 0 {
+					idx += p.taps
+				}
+				var accI, accQ float32
+				for n := 0; n < p.taps; n++ {
+					s := p.hist[k][idx]
+					h := row[n]
+					accI += h * real(s)
+					accQ += h * imag(s)
+					idx--
+					if idx < 0 {
+						idx = p.taps - 1
+					}
+				}
+				p.scratchIn[k] = complex(float64(accI), float64(accQ))
+			}
+			// FFT across branches → per-channel output sample.
+			freq := p.plan.Forward(nil, p.scratchIn)
+			for c := 0; c < p.m; c++ {
+				dst[c] = append(dst[c], complex(float32(real(freq[c])), float32(imag(freq[c]))))
+			}
+		}
+	}
+	return dst
+}

--- a/internal/dsp/channelizer/polyphase_test.go
+++ b/internal/dsp/channelizer/polyphase_test.go
@@ -1,0 +1,65 @@
+package channelizer
+
+import (
+	"math"
+	"testing"
+)
+
+// TestToneInChannel feeds a complex exponential at +k*Fs/M and verifies that
+// channel k receives the most power, with neighbors strongly attenuated.
+func TestToneInChannel(t *testing.T) {
+	const M = 8
+	const tapsPer = 16
+	ch := New(M, tapsPer, 9)
+
+	const N = 4096
+	in := make([]complex64, N)
+	const targetCh = 3
+	for i := 0; i < N; i++ {
+		theta := 2 * math.Pi * float64(targetCh) * float64(i) / float64(M)
+		in[i] = complex(float32(math.Cos(theta)), float32(math.Sin(theta)))
+	}
+
+	out := ch.Process(nil, in)
+	skip := tapsPer * 2 // skip transient
+	power := make([]float64, M)
+	for c := 0; c < M; c++ {
+		for i := skip; i < len(out[c]); i++ {
+			s := out[c][i]
+			power[c] += float64(real(s))*float64(real(s)) + float64(imag(s))*float64(imag(s))
+		}
+	}
+
+	maxIdx := 0
+	for c, p := range power {
+		if p > power[maxIdx] {
+			maxIdx = c
+		}
+	}
+	if maxIdx != targetCh {
+		t.Fatalf("peak in channel %d, want %d (powers=%v)", maxIdx, targetCh, power)
+	}
+	// Adjacent-channel rejection should be reasonable (>20 dB).
+	for c := 0; c < M; c++ {
+		if c == targetCh {
+			continue
+		}
+		ratio := power[targetCh] / (power[c] + 1e-30)
+		if ratio < 100 { // 20 dB
+			t.Errorf("channel %d leakage: ratio = %.1f, want >= 100", c, ratio)
+		}
+	}
+}
+
+func TestProcessDecimatesByM(t *testing.T) {
+	const M = 4
+	ch := New(M, 8, 8.6)
+	const N = 1024
+	in := make([]complex64, N)
+	out := ch.Process(nil, in)
+	for c := 0; c < M; c++ {
+		if got, want := len(out[c]), N/M; got != want {
+			t.Errorf("channel %d: len = %d, want %d", c, got, want)
+		}
+	}
+}

--- a/internal/dsp/demod/c4fm.go
+++ b/internal/dsp/demod/c4fm.go
@@ -1,0 +1,82 @@
+package demod
+
+import (
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/filter"
+)
+
+// C4FM is a four-level continuous-phase FSK demodulator (P25 Phase 1 control
+// channel). Operates on a real input stream produced by an FM discriminator;
+// applies an RRC matched filter and slices to the four-level alphabet
+// {+3, +1, -1, -3} (multiplied by a deviation scale).
+type C4FM struct {
+	rrc      []float32
+	hist     []float32
+	histPos  int
+	deviation float32
+}
+
+// NewC4FM returns a C4FM demod whose matched filter is an RRC with the given
+// samples-per-symbol, span (in symbols), and roll-off α. The deviation
+// scales slicer thresholds to the application; for P25 with 4800 sym/s and
+// ±1.8 kHz outer deviation, downstream code should set this empirically.
+func NewC4FM(sps, span int, alpha, deviation float64) *C4FM {
+	rrc := filter.RootRaisedCosine(sps, span, alpha)
+	return &C4FM{rrc: rrc, hist: make([]float32, len(rrc)), deviation: float32(deviation)}
+}
+
+// MatchedFilter applies the RRC filter and returns a same-length output.
+func (c *C4FM) MatchedFilter(dst, src []float32) []float32 {
+	if cap(dst) < len(src) {
+		dst = make([]float32, len(src))
+	} else {
+		dst = dst[:len(src)]
+	}
+	N := len(c.rrc)
+	for i, x := range src {
+		c.hist[c.histPos] = x
+		c.histPos = (c.histPos + 1) % N
+		var acc float32
+		idx := c.histPos - 1
+		if idx < 0 {
+			idx = N - 1
+		}
+		for k := 0; k < N; k++ {
+			acc += c.rrc[k] * c.hist[idx]
+			idx--
+			if idx < 0 {
+				idx = N - 1
+			}
+		}
+		dst[i] = acc
+	}
+	return dst
+}
+
+// Slice maps a soft sample to the four C4FM symbols {-3, -1, +1, +3}.
+// Threshold spacing is 2*deviation/3 so that ±deviation lands at ±1.5*scale.
+func (c *C4FM) Slice(soft float32) int {
+	d := c.deviation
+	switch {
+	case soft >= 2*d/3:
+		return 3
+	case soft >= 0:
+		return 1
+	case soft >= -2*d/3:
+		return -1
+	default:
+		return -3
+	}
+}
+
+// SliceMany applies Slice to a slice of soft samples.
+func (c *C4FM) SliceMany(dst []int8, src []float32) []int8 {
+	if cap(dst) < len(src) {
+		dst = make([]int8, len(src))
+	} else {
+		dst = dst[:len(src)]
+	}
+	for i, s := range src {
+		dst[i] = int8(c.Slice(s))
+	}
+	return dst
+}

--- a/internal/dsp/demod/demod_test.go
+++ b/internal/dsp/demod/demod_test.go
@@ -1,0 +1,63 @@
+package demod
+
+import (
+	"math"
+	"testing"
+)
+
+func TestFMDemodLinearChirp(t *testing.T) {
+	// Generate a complex exponential whose phase advances by a constant rate.
+	const N = 4096
+	const rate = 0.1 // radians per sample
+	in := make([]complex64, N)
+	phi := 0.0
+	for i := 0; i < N; i++ {
+		in[i] = complex(float32(math.Cos(phi)), float32(math.Sin(phi)))
+		phi += rate
+	}
+	d := NewFM()
+	out := d.Process(nil, in)
+	// Skip first sample (depends on init). Rest should be ~rate.
+	for i := 1; i < N; i++ {
+		if math.Abs(float64(out[i])-rate) > 1e-3 {
+			t.Fatalf("FM out[%d] = %f, want %f", i, out[i], rate)
+		}
+	}
+}
+
+func TestC4FMSlicer(t *testing.T) {
+	// Deviation = 3.0 → outer-symbol threshold ±2.0.
+	c := NewC4FM(8, 8, 0.2, 3.0)
+	cases := []struct {
+		in   float32
+		want int
+	}{
+		{2.5, 3}, {1.0, 1}, {0.5, 1}, {0.01, 1},
+		{-0.01, -1}, {-1.0, -1}, {-2.5, -3},
+		{2.001, 3}, {1.999, 1}, // threshold corner
+	}
+	for _, tc := range cases {
+		got := c.Slice(tc.in)
+		if got != tc.want {
+			t.Errorf("Slice(%f) = %d, want %d", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestDQPSKDibitsMatchPhaseSteps(t *testing.T) {
+	d := NewDQPSK()
+	// Build a signal whose phase advances by π/2 per symbol → dibit "01".
+	const N = 64
+	in := make([]complex64, N)
+	phi := 0.0
+	for i := 0; i < N; i++ {
+		in[i] = complex(float32(math.Cos(phi)), float32(math.Sin(phi)))
+		phi += math.Pi / 2
+	}
+	out := d.Decode(nil, in)
+	for i := 1; i < N; i++ {
+		if out[i] != 0b01 {
+			t.Errorf("out[%d] = %02b, want 01", i, out[i])
+		}
+	}
+}

--- a/internal/dsp/demod/dqpsk.go
+++ b/internal/dsp/demod/dqpsk.go
@@ -1,0 +1,56 @@
+package demod
+
+import "math"
+
+// DQPSK is a differential QPSK demodulator suitable for P25 Phase 2 H-DQPSK.
+// At each symbol time, output is the phase difference between the current
+// and previous IQ samples, mapped to one of the four dibits {00, 01, 10, 11}.
+//
+// For Phase 2 H-DQPSK, symbols rotate by π/4-multiples around an offset of
+// π/8 — call SetRotation(math.Pi/8) to compensate.
+type DQPSK struct {
+	last     complex64
+	rotation float64
+}
+
+func NewDQPSK() *DQPSK {
+	return &DQPSK{last: complex(1, 0)}
+}
+
+func (d *DQPSK) SetRotation(radians float64) { d.rotation = radians }
+
+// Decode emits one dibit per input sample. Caller should pre-decimate to
+// one-sample-per-symbol via a clock-recovery stage.
+func (d *DQPSK) Decode(dst []uint8, src []complex64) []uint8 {
+	if cap(dst) < len(src) {
+		dst = make([]uint8, len(src))
+	} else {
+		dst = dst[:len(src)]
+	}
+	for i, s := range src {
+		// Phase delta: arg(s * conj(last)) − rotation.
+		ar := real(s)*real(d.last) + imag(s)*imag(d.last)
+		ai := imag(s)*real(d.last) - real(s)*imag(d.last)
+		phi := math.Atan2(float64(ai), float64(ar)) - d.rotation
+		// Wrap to [-π, π].
+		for phi < -math.Pi {
+			phi += 2 * math.Pi
+		}
+		for phi >= math.Pi {
+			phi -= 2 * math.Pi
+		}
+		// Quadrant: nearest of {0, π/2, π, -π/2}.
+		switch {
+		case phi >= -math.Pi/4 && phi < math.Pi/4:
+			dst[i] = 0b00
+		case phi >= math.Pi/4 && phi < 3*math.Pi/4:
+			dst[i] = 0b01
+		case phi >= -3*math.Pi/4 && phi < -math.Pi/4:
+			dst[i] = 0b11
+		default:
+			dst[i] = 0b10
+		}
+		d.last = s
+	}
+	return dst
+}

--- a/internal/dsp/demod/fm.go
+++ b/internal/dsp/demod/fm.go
@@ -1,0 +1,30 @@
+// Package demod contains baseband demodulators that convert IQ streams into
+// real-valued symbol streams (or audio, for FM).
+package demod
+
+import "math"
+
+// FM is a quadrature FM discriminator. Output is the instantaneous phase
+// derivative computed via arg(z[n] * conj(z[n-1])), scaled into the range
+// [-pi, +pi] radians/sample. Multiply by Fs / (2π * Δf) to get audio.
+type FM struct {
+	last complex64
+}
+
+func NewFM() *FM { return &FM{last: complex(1, 0)} }
+
+func (f *FM) Process(dst []float32, src []complex64) []float32 {
+	if cap(dst) < len(src) {
+		dst = make([]float32, len(src))
+	} else {
+		dst = dst[:len(src)]
+	}
+	for i, s := range src {
+		// z[n] * conj(z[n-1]).
+		ar := real(s)*real(f.last) + imag(s)*imag(f.last)
+		ai := imag(s)*real(f.last) - real(s)*imag(f.last)
+		dst[i] = float32(math.Atan2(float64(ai), float64(ar)))
+		f.last = s
+	}
+	return dst
+}

--- a/internal/dsp/fft/fft.go
+++ b/internal/dsp/fft/fft.go
@@ -1,0 +1,82 @@
+// Package fft provides a swappable FFT abstraction. The default backend wraps
+// gonum's fourier.CmplxFFT; future backends (FFTW, hand-rolled SIMD) can
+// implement the Plan interface without disturbing call sites.
+package fft
+
+import (
+	"gonum.org/v1/gonum/dsp/fourier"
+)
+
+type Plan interface {
+	Size() int
+	Forward(out, in []complex128) []complex128
+	Inverse(out, in []complex128) []complex128
+}
+
+type gonumPlan struct {
+	n   int
+	fft *fourier.CmplxFFT
+}
+
+func New(n int) Plan {
+	return &gonumPlan{n: n, fft: fourier.NewCmplxFFT(n)}
+}
+
+func (p *gonumPlan) Size() int { return p.n }
+
+func (p *gonumPlan) Forward(out, in []complex128) []complex128 {
+	if len(in) != p.n {
+		panic("fft: input length != plan size")
+	}
+	if cap(out) < p.n {
+		out = make([]complex128, p.n)
+	} else {
+		out = out[:p.n]
+	}
+	res := p.fft.Coefficients(out, in)
+	return res
+}
+
+func (p *gonumPlan) Inverse(out, in []complex128) []complex128 {
+	if len(in) != p.n {
+		panic("fft: input length != plan size")
+	}
+	if cap(out) < p.n {
+		out = make([]complex128, p.n)
+	} else {
+		out = out[:p.n]
+	}
+	res := p.fft.Sequence(out, in)
+	// gonum's inverse returns N*x; normalize.
+	scale := complex(1/float64(p.n), 0)
+	for i := range res {
+		res[i] *= scale
+	}
+	return res
+}
+
+// Cmplx64ToCmplx128 / Cmplx128ToCmplx64 are convenience converters for the
+// IQ pipeline (which is complex64) at FFT boundaries (gonum is complex128).
+func Cmplx64ToCmplx128(dst []complex128, src []complex64) []complex128 {
+	if cap(dst) < len(src) {
+		dst = make([]complex128, len(src))
+	} else {
+		dst = dst[:len(src)]
+	}
+	for i, s := range src {
+		dst[i] = complex(float64(real(s)), float64(imag(s)))
+	}
+	return dst
+}
+
+func Cmplx128ToCmplx64(dst []complex64, src []complex128) []complex64 {
+	if cap(dst) < len(src) {
+		dst = make([]complex64, len(src))
+	} else {
+		dst = dst[:len(src)]
+	}
+	for i, s := range src {
+		dst[i] = complex(float32(real(s)), float32(imag(s)))
+	}
+	return dst
+}

--- a/internal/dsp/fft/fft_test.go
+++ b/internal/dsp/fft/fft_test.go
@@ -1,0 +1,58 @@
+package fft
+
+import (
+	"math"
+	"math/cmplx"
+	"testing"
+)
+
+func TestRoundTrip(t *testing.T) {
+	const n = 256
+	p := New(n)
+	in := make([]complex128, n)
+	for i := range in {
+		in[i] = complex(math.Sin(2*math.Pi*float64(i)*5/n), 0)
+	}
+	freq := p.Forward(nil, in)
+	back := p.Inverse(nil, freq)
+	for i := range in {
+		if cmplx.Abs(back[i]-in[i]) > 1e-9 {
+			t.Errorf("round-trip mismatch at %d: %v vs %v", i, back[i], in[i])
+		}
+	}
+}
+
+func TestTonePeak(t *testing.T) {
+	const n = 512
+	const bin = 17
+	p := New(n)
+	in := make([]complex128, n)
+	for i := range in {
+		theta := 2 * math.Pi * float64(bin) * float64(i) / float64(n)
+		in[i] = complex(math.Cos(theta), math.Sin(theta))
+	}
+	freq := p.Forward(nil, in)
+	var maxIdx int
+	var maxMag float64
+	for i, c := range freq {
+		m := cmplx.Abs(c)
+		if m > maxMag {
+			maxMag = m
+			maxIdx = i
+		}
+	}
+	if maxIdx != bin {
+		t.Errorf("peak at bin %d, want %d", maxIdx, bin)
+	}
+}
+
+func TestC64Roundtrip(t *testing.T) {
+	src := []complex64{1 + 2i, 3 + 4i, 5 + 6i}
+	mid := Cmplx64ToCmplx128(nil, src)
+	back := Cmplx128ToCmplx64(nil, mid)
+	for i := range src {
+		if back[i] != src[i] {
+			t.Errorf("[%d] %v != %v", i, back[i], src[i])
+		}
+	}
+}

--- a/internal/dsp/filter/cic.go
+++ b/internal/dsp/filter/cic.go
@@ -1,0 +1,61 @@
+package filter
+
+// CICDecimator is a multi-stage CIC decimator with rate factor R and N stages.
+// Output is at input/R rate. Suitable for an initial coarse decimation
+// before a sharper FIR; CIC has a sin(x)/x droop that should be compensated
+// by a downstream FIR.
+type CICDecimator struct {
+	r          int
+	n          int
+	integrator []int64 // I(z) = 1/(1 - z^-1), one per stage
+	combDelay  []int64 // comb tap state (one slot per stage)
+	count      int
+}
+
+func NewCICDecimator(rate, stages int) *CICDecimator {
+	if rate < 1 || stages < 1 {
+		panic("cic: rate and stages must be >= 1")
+	}
+	return &CICDecimator{
+		r:          rate,
+		n:          stages,
+		integrator: make([]int64, stages),
+		combDelay:  make([]int64, stages),
+	}
+}
+
+// ProcessReal decimates a real signal scaled into int16 (caller scales as
+// needed). Returns the decimated samples appended to dst.
+func (c *CICDecimator) ProcessReal(dst []int64, src []int64) []int64 {
+	for _, s := range src {
+		// Integrators
+		acc := s
+		for i := 0; i < c.n; i++ {
+			c.integrator[i] += acc
+			acc = c.integrator[i]
+		}
+		c.count++
+		if c.count == c.r {
+			c.count = 0
+			// Comb stages — z^-1 of the decimated signal.
+			y := acc
+			for i := 0; i < c.n; i++ {
+				prev := c.combDelay[i]
+				c.combDelay[i] = y
+				y = y - prev
+			}
+			dst = append(dst, y)
+		}
+	}
+	return dst
+}
+
+// Gain returns the DC gain of the cascade: R^N. Callers typically divide
+// the output by this value (or shift right by ceil(N*log2(R))).
+func (c *CICDecimator) Gain() int64 {
+	g := int64(1)
+	for i := 0; i < c.n; i++ {
+		g *= int64(c.r)
+	}
+	return g
+}

--- a/internal/dsp/filter/cic_test.go
+++ b/internal/dsp/filter/cic_test.go
@@ -1,0 +1,34 @@
+package filter
+
+import "testing"
+
+func TestCICDecimatesByR(t *testing.T) {
+	c := NewCICDecimator(8, 3)
+	in := make([]int64, 8000)
+	for i := range in {
+		in[i] = 1000
+	}
+	out := c.ProcessReal(nil, in)
+	if got, want := len(out), len(in)/8; got != want {
+		t.Fatalf("len(out) = %d, want %d", got, want)
+	}
+	// After enough samples, DC input × gain == steady-state output (within
+	// the comb-warmup transient).
+	stable := out[len(out)-1]
+	if stable != int64(1000)*c.Gain() {
+		t.Errorf("steady-state = %d, want %d", stable, int64(1000)*c.Gain())
+	}
+}
+
+func TestHalfbandZeroPattern(t *testing.T) {
+	taps := HalfbandLowpass(31)
+	mid := len(taps) / 2
+	for i, t0 := range taps {
+		if i == mid {
+			continue
+		}
+		if (i-mid)%2 == 0 && t0 != 0 {
+			t.Errorf("expected tap[%d] zero, got %f", i, t0)
+		}
+	}
+}

--- a/internal/dsp/filter/fir.go
+++ b/internal/dsp/filter/fir.go
@@ -1,0 +1,148 @@
+// Package filter implements the FIR/CIC/halfband primitives used by the DSP
+// pipeline. All filters operate on complex64 IQ samples or real float32
+// signals; coefficients are stored as float32.
+package filter
+
+import (
+	"math"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/window"
+)
+
+// FIR is a linear-phase finite-impulse-response filter for complex64 IQ.
+// It maintains an internal sample history so consecutive Process calls
+// produce a continuous output stream.
+type FIR struct {
+	taps    []float32
+	hist    []complex64
+	histPos int
+}
+
+func NewFIR(taps []float32) *FIR {
+	if len(taps) == 0 {
+		panic("filter: NewFIR requires at least one tap")
+	}
+	cp := make([]float32, len(taps))
+	copy(cp, taps)
+	return &FIR{taps: cp, hist: make([]complex64, len(taps))}
+}
+
+// Reset clears the internal history.
+func (f *FIR) Reset() {
+	for i := range f.hist {
+		f.hist[i] = 0
+	}
+	f.histPos = 0
+}
+
+// Process consumes one input slice and returns an output slice of the same
+// length. dst is reused if it has enough capacity.
+func (f *FIR) Process(dst, src []complex64) []complex64 {
+	if cap(dst) < len(src) {
+		dst = make([]complex64, len(src))
+	} else {
+		dst = dst[:len(src)]
+	}
+	N := len(f.taps)
+	for i, x := range src {
+		f.hist[f.histPos] = x
+		f.histPos++
+		if f.histPos == N {
+			f.histPos = 0
+		}
+		// Convolve: output is sum_{k} h[k] * hist[(histPos - 1 - k) mod N].
+		var accI, accQ float32
+		idx := f.histPos - 1
+		if idx < 0 {
+			idx = N - 1
+		}
+		for k := 0; k < N; k++ {
+			s := f.hist[idx]
+			h := f.taps[k]
+			accI += h * real(s)
+			accQ += h * imag(s)
+			idx--
+			if idx < 0 {
+				idx = N - 1
+			}
+		}
+		dst[i] = complex(accI, accQ)
+	}
+	return dst
+}
+
+// LowpassKaiser designs a length-N (odd) lowpass FIR with cutoff fc
+// (normalized; 0.5 = Nyquist) using a Kaiser window with shape beta.
+func LowpassKaiser(n int, fc, beta float64) []float32 {
+	if n%2 == 0 {
+		n++ // force odd for symmetric linear-phase filter
+	}
+	w := window.Kaiser(n, beta)
+	taps := make([]float32, n)
+	mid := (n - 1) / 2
+	for i := 0; i < n; i++ {
+		k := i - mid
+		var x float64
+		if k == 0 {
+			x = 2 * fc
+		} else {
+			x = math.Sin(2*math.Pi*fc*float64(k)) / (math.Pi * float64(k))
+		}
+		taps[i] = float32(x * w[i])
+	}
+	// Normalize DC gain to 1.
+	var sum float64
+	for _, t := range taps {
+		sum += float64(t)
+	}
+	if sum != 0 {
+		s := float32(1.0 / sum)
+		for i := range taps {
+			taps[i] *= s
+		}
+	}
+	return taps
+}
+
+// RootRaisedCosine returns the impulse response of a root-raised-cosine
+// pulse-shaping filter. sps = samples per symbol, nSymbols = total span,
+// alpha = roll-off (0 < alpha ≤ 1). The filter is normalized to unit energy.
+func RootRaisedCosine(sps, nSymbols int, alpha float64) []float32 {
+	N := sps*nSymbols + 1 // odd length
+	taps := make([]float32, N)
+	mid := (N - 1) / 2
+	T := 1.0 // symbol period
+	Ts := T / float64(sps)
+	for i := 0; i < N; i++ {
+		t := float64(i-mid) * Ts
+		taps[i] = float32(rrcSample(t, T, alpha))
+	}
+	// Unit-energy normalization.
+	var energy float64
+	for _, c := range taps {
+		energy += float64(c) * float64(c)
+	}
+	if energy > 0 {
+		k := float32(1.0 / math.Sqrt(energy))
+		for i := range taps {
+			taps[i] *= k
+		}
+	}
+	return taps
+}
+
+func rrcSample(t, T, alpha float64) float64 {
+	if t == 0 {
+		return (1.0/T)*(1.0-alpha) + (4*alpha)/(math.Pi*T)
+	}
+	denomZero := math.Abs(t) - T/(4*alpha)
+	if alpha != 0 && math.Abs(denomZero) < 1e-12 {
+		return (alpha / (T * math.Sqrt2)) *
+			((1+2/math.Pi)*math.Sin(math.Pi/(4*alpha)) +
+				(1-2/math.Pi)*math.Cos(math.Pi/(4*alpha)))
+	}
+	num := math.Sin(math.Pi*t*(1-alpha)/T) +
+		4*alpha*t/T*math.Cos(math.Pi*t*(1+alpha)/T)
+	den := math.Pi * t / T * (1 - math.Pow(4*alpha*t/T, 2))
+	return num / (T * den)
+}

--- a/internal/dsp/filter/fir_test.go
+++ b/internal/dsp/filter/fir_test.go
@@ -1,0 +1,96 @@
+package filter
+
+import (
+	"math"
+	"math/cmplx"
+	"testing"
+)
+
+func TestFIRImpulseResponse(t *testing.T) {
+	taps := []float32{0.1, 0.2, 0.3, 0.2, 0.1}
+	f := NewFIR(taps)
+	in := make([]complex64, 16)
+	in[0] = 1 + 0i
+	out := f.Process(nil, in)
+	for i, want := range taps {
+		got := real(out[i])
+		if math.Abs(float64(got-want)) > 1e-7 {
+			t.Errorf("out[%d] = %f, want %f", i, got, want)
+		}
+	}
+	for i := len(taps); i < len(out); i++ {
+		if cmplx.Abs(complex128(out[i])) > 1e-7 {
+			t.Errorf("out[%d] should be zero, got %v", i, out[i])
+		}
+	}
+}
+
+func TestLowpassKaiserPasses(t *testing.T) {
+	// Generate a 0.05-cycles/sample tone (well below cutoff 0.1) and verify
+	// it survives. Generate a 0.4-cycles/sample tone (above cutoff) and
+	// verify it's strongly attenuated.
+	taps := LowpassKaiser(101, 0.1, 8.6)
+	f := NewFIR(taps)
+
+	gen := func(freq float64, n int) []complex64 {
+		out := make([]complex64, n)
+		for i := 0; i < n; i++ {
+			theta := 2 * math.Pi * freq * float64(i)
+			out[i] = complex(float32(math.Cos(theta)), float32(math.Sin(theta)))
+		}
+		return out
+	}
+	measure := func(samples []complex64, skip int) float64 {
+		var p float64
+		for i := skip; i < len(samples); i++ {
+			a := math.Hypot(float64(real(samples[i])), float64(imag(samples[i])))
+			p += a * a
+		}
+		return p / float64(len(samples)-skip)
+	}
+
+	pass := f.Process(nil, gen(0.05, 4096))
+	f.Reset()
+	stop := f.Process(nil, gen(0.4, 4096))
+
+	pPass := measure(pass, 200)
+	pStop := measure(stop, 200)
+	if pPass < 0.9 {
+		t.Errorf("passband power = %f, want > 0.9", pPass)
+	}
+	if pStop > 0.01 {
+		t.Errorf("stopband power = %f, want < 0.01", pStop)
+	}
+}
+
+func TestRRCUnitEnergy(t *testing.T) {
+	taps := RootRaisedCosine(8, 8, 0.2)
+	var e float64
+	for _, c := range taps {
+		e += float64(c) * float64(c)
+	}
+	if math.Abs(e-1) > 1e-6 {
+		t.Errorf("RRC energy = %f, want 1", e)
+	}
+}
+
+func TestRRCMatchedFilterPeakAtCenter(t *testing.T) {
+	// RRC * RRC = RC; symbol-rate convolution should peak at the center.
+	rrc := RootRaisedCosine(4, 8, 0.3)
+	N := len(rrc)
+	conv := make([]float32, 2*N-1)
+	for i := 0; i < N; i++ {
+		for j := 0; j < N; j++ {
+			conv[i+j] += rrc[i] * rrc[j]
+		}
+	}
+	mid := N - 1
+	for i := 0; i < len(conv); i++ {
+		if i == mid {
+			continue
+		}
+		if math.Abs(float64(conv[i])) > math.Abs(float64(conv[mid])) {
+			t.Errorf("peak not at center: %d > %d", i, mid)
+		}
+	}
+}

--- a/internal/dsp/filter/halfband.go
+++ b/internal/dsp/filter/halfband.go
@@ -1,0 +1,53 @@
+package filter
+
+// HalfbandLowpass returns coefficients for a length-N halfband lowpass
+// suitable for ×2 decimation. Roughly half the taps are zero (every other
+// tap except the center). Designed via Kaiser window with cutoff at fs/4.
+func HalfbandLowpass(n int) []float32 {
+	if n%2 == 0 {
+		n++
+	}
+	taps := LowpassKaiser(n, 0.25, 8.6)
+	mid := (n - 1) / 2
+	for i := 0; i < n; i++ {
+		if i == mid {
+			continue
+		}
+		if (i-mid)%2 == 0 {
+			taps[i] = 0
+		}
+	}
+	return taps
+}
+
+// Halfband2x decimates by 2 using a halfband FIR. Internally it just routes
+// the decimated stream out of a regular FIR; we keep this as a convenience
+// because we know half the taps multiply by zero and could be skipped in a
+// SIMD pass later.
+type Halfband2x struct {
+	fir *FIR
+	tog bool
+}
+
+func NewHalfband2x(taps []float32) *Halfband2x { return &Halfband2x{fir: NewFIR(taps)} }
+
+func (h *Halfband2x) Process(dst, src []complex64) []complex64 {
+	full := h.fir.Process(nil, src)
+	out := dst[:0]
+	for i, s := range full {
+		if (i+boolToInt(h.tog))%2 == 0 {
+			out = append(out, s)
+		}
+	}
+	if len(src)%2 == 1 {
+		h.tog = !h.tog
+	}
+	return out
+}
+
+func boolToInt(b bool) int {
+	if b {
+		return 1
+	}
+	return 0
+}

--- a/internal/dsp/resampler.go
+++ b/internal/dsp/resampler.go
@@ -1,0 +1,115 @@
+package dsp
+
+import (
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/filter"
+)
+
+// Resampler is a polyphase rational resampler with rate L/M. It interpolates
+// by L (using polyphase branches of an LPF) and decimates by M.
+type Resampler struct {
+	L, M     int
+	branches [][]float32 // length L; each branch is a phase of the prototype
+	hist     []complex64
+	histPos  int
+	branchN  int // taps per branch
+	idx      int // commutator state (0..L-1)
+	mCount   int // decimator state (0..M-1)
+}
+
+// NewResampler builds a resampler with rate L/M using a Kaiser-window LPF
+// of total length tapsPerBranch*L. Cutoff is min(0.5/L, 0.5/M) so that the
+// filter rejects images and aliases for both interpolation and decimation.
+func NewResampler(L, M, tapsPerBranch int, beta float64) *Resampler {
+	if L <= 0 || M <= 0 || tapsPerBranch <= 0 {
+		panic("resampler: L, M, tapsPerBranch must be positive")
+	}
+	N := tapsPerBranch * L
+	if N%2 == 0 {
+		N++
+	}
+	cutoff := 0.5 / float64(maxInt(L, M))
+	proto := filter.LowpassKaiser(N, cutoff, beta)
+	// Compensate for interpolator gain loss of 1/L.
+	for i := range proto {
+		proto[i] *= float32(L)
+	}
+	branches := make([][]float32, L)
+	taps := (len(proto) + L - 1) / L
+	for b := 0; b < L; b++ {
+		row := make([]float32, taps)
+		for k := 0; k < taps; k++ {
+			j := k*L + b
+			if j < len(proto) {
+				row[k] = proto[j]
+			}
+		}
+		branches[b] = row
+	}
+	return &Resampler{
+		L: L, M: M,
+		branches: branches,
+		branchN:  taps,
+		hist:     make([]complex64, taps),
+	}
+}
+
+// Process consumes len(src) input samples and returns approximately
+// len(src)*L/M output samples. dst is reused if it has capacity.
+func (r *Resampler) Process(dst, src []complex64) []complex64 {
+	if cap(dst) < len(src)*r.L/r.M+8 {
+		dst = make([]complex64, 0, len(src)*r.L/r.M+8)
+	} else {
+		dst = dst[:0]
+	}
+	for _, x := range src {
+		// Push into history.
+		r.hist[r.histPos] = x
+		r.histPos++
+		if r.histPos == r.branchN {
+			r.histPos = 0
+		}
+		// Walk the L commutator phases for this single input sample.
+		for p := 0; p < r.L; p++ {
+			if r.mCount == 0 {
+				out := r.computeBranch(r.idx)
+				dst = append(dst, out)
+			}
+			r.idx++
+			if r.idx == r.L {
+				r.idx = 0
+			}
+			r.mCount++
+			if r.mCount == r.M {
+				r.mCount = 0
+			}
+		}
+	}
+	return dst
+}
+
+func (r *Resampler) computeBranch(b int) complex64 {
+	row := r.branches[b]
+	var accI, accQ float32
+	idx := r.histPos - 1
+	if idx < 0 {
+		idx = r.branchN - 1
+	}
+	for k := 0; k < r.branchN; k++ {
+		s := r.hist[idx]
+		h := row[k]
+		accI += h * real(s)
+		accQ += h * imag(s)
+		idx--
+		if idx < 0 {
+			idx = r.branchN - 1
+		}
+	}
+	return complex(accI, accQ)
+}
+
+func maxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/internal/dsp/sync/clock.go
+++ b/internal/dsp/sync/clock.go
@@ -1,0 +1,69 @@
+// Package sync provides symbol-time recovery and frame sync correlators.
+package sync
+
+// MuellerMuller is a feedback symbol-timing recovery loop for real-valued
+// PAM signals. The loop adjusts a sub-sample symbol clock toward the
+// optimum sampling instant by minimizing |s[n] - sgn(s[n-1])*s[mid]|.
+//
+// Inputs are oversampled samples (e.g. 8 sps after the matched filter).
+// Output is one sample per recovered symbol.
+type MuellerMuller struct {
+	sps      float64 // nominal samples per symbol
+	mu       float64 // current sub-sample phase in [0, sps)
+	gain     float64 // loop gain
+	prevSym  float32
+	prevMid  float32
+	have     bool
+}
+
+func NewMuellerMuller(sps, gain float64) *MuellerMuller {
+	if sps < 2 {
+		panic("mm: sps must be >= 2")
+	}
+	if gain <= 0 {
+		gain = 0.1
+	}
+	return &MuellerMuller{sps: sps, gain: gain, mu: sps}
+}
+
+// Process consumes oversampled real samples and emits one recovered symbol
+// per nominal symbol period. dst is reused if it has capacity.
+func (m *MuellerMuller) Process(dst []float32, src []float32) []float32 {
+	if cap(dst) < len(src) {
+		dst = make([]float32, 0, len(src)/int(m.sps)+1)
+	} else {
+		dst = dst[:0]
+	}
+	for i := 1; i < len(src); i++ {
+		m.mu -= 1.0
+		if m.mu > 0 {
+			continue
+		}
+		// We've crossed a symbol boundary; interpolate at this point.
+		// Use linear interpolation between src[i-1] and src[i].
+		frac := 1.0 + m.mu // mu is in (-1, 0]; frac is in (0, 1]
+		sym := float32(float64(src[i-1])*(1-frac) + float64(src[i])*frac)
+
+		if m.have {
+			// Mueller-Muller error: e = sgn(prev)*current - sgn(current)*prev
+			err := sgn(m.prevSym)*float64(sym) - sgn(float32(sym))*float64(m.prevSym)
+			m.mu += m.sps + m.gain*err
+		} else {
+			m.mu += m.sps
+			m.have = true
+		}
+		m.prevSym = sym
+		dst = append(dst, sym)
+	}
+	return dst
+}
+
+func sgn(x float32) float64 {
+	if x > 0 {
+		return 1
+	}
+	if x < 0 {
+		return -1
+	}
+	return 0
+}

--- a/internal/dsp/sync/frame.go
+++ b/internal/dsp/sync/frame.go
@@ -1,0 +1,47 @@
+package sync
+
+// Correlator searches a stream of soft symbols for a known sync pattern by
+// running a sliding inner product. It returns the indices where the
+// correlation magnitude exceeds threshold.
+type Correlator struct {
+	pattern   []float32
+	threshold float32
+	hist      []float32
+	pos       int
+	primed    int
+}
+
+func NewCorrelator(pattern []float32, threshold float32) *Correlator {
+	cp := make([]float32, len(pattern))
+	copy(cp, pattern)
+	return &Correlator{
+		pattern:   cp,
+		threshold: threshold,
+		hist:      make([]float32, len(pattern)),
+	}
+}
+
+// Process scans src and appends to dst the absolute indices (relative to
+// the start of the first call to Process) where the pattern matches above
+// threshold. The input index for each sample increases by 1 across calls.
+func (c *Correlator) Process(dst []int, src []float32, baseIndex int) ([]int, int) {
+	N := len(c.pattern)
+	for i, x := range src {
+		c.hist[c.pos] = x
+		c.pos = (c.pos + 1) % N
+		if c.primed < N {
+			c.primed++
+			continue
+		}
+		var corr float32
+		idx := c.pos
+		for k := 0; k < N; k++ {
+			corr += c.hist[idx] * c.pattern[k]
+			idx = (idx + 1) % N
+		}
+		if corr >= c.threshold {
+			dst = append(dst, baseIndex+i)
+		}
+	}
+	return dst, baseIndex + len(src)
+}

--- a/internal/dsp/sync/sync_test.go
+++ b/internal/dsp/sync/sync_test.go
@@ -1,0 +1,93 @@
+package sync
+
+import (
+	"math"
+	"testing"
+)
+
+func TestMuellerMullerRecoversSymbolCount(t *testing.T) {
+	// Synthesize a 4-PAM signal at 8 sps with raised-cosine pulses peaking
+	// at the *start* of each symbol period so that boundary sampling lands
+	// on a non-zero gradient.
+	const sps = 8
+	const nSym = 300
+	src := make([]float32, nSym*sps)
+	want := make([]float32, nSym)
+	for i := 0; i < nSym; i++ {
+		v := float32([]int{-3, -1, 1, 3}[(i*5+3)%4])
+		want[i] = v
+		for k := 0; k < sps; k++ {
+			alpha := 0.5 + 0.5*math.Cos(math.Pi*float64(k)/float64(sps-1))
+			src[i*sps+k] = v * float32(alpha)
+		}
+	}
+	m := NewMuellerMuller(float64(sps), 0.02)
+	got := m.Process(nil, src)
+	if len(got) < nSym-3 || len(got) > nSym+3 {
+		t.Fatalf("symbol count = %d, want %d ± 3", len(got), nSym)
+	}
+
+	// After warmup, sliced polarity should match expected better than chance.
+	// Find the best alignment offset; the loop's first output corresponds
+	// to whatever symbol falls at its sub-sample lock point, which depends
+	// on the init phase.
+	const warm = 20
+	bestRate := 0.0
+	for shift := -2; shift <= 2; shift++ {
+		matches, total := 0, 0
+		for i := warm; i < len(got); i++ {
+			j := i + shift
+			if j < 0 || j >= len(want) {
+				continue
+			}
+			total++
+			if (got[i] > 0) == (want[j] > 0) {
+				matches++
+			}
+		}
+		if total > 0 {
+			rate := float64(matches) / float64(total)
+			if rate > bestRate {
+				bestRate = rate
+			}
+		}
+	}
+	if bestRate < 0.95 {
+		t.Errorf("best polarity match rate = %.2f, want > 0.95", bestRate)
+	}
+}
+
+func TestCorrelatorFindsPattern(t *testing.T) {
+	pattern := []float32{1, -1, 1, 1, -1}
+	noise := []float32{0, 0, 0.1, -0.1, 0}
+	stream := append([]float32{}, noise...)
+	stream = append(stream, pattern...)
+	stream = append(stream, noise...)
+	stream = append(stream, pattern...)
+
+	threshold := float32(0)
+	for _, p := range pattern {
+		threshold += p * p
+	}
+	threshold *= 0.9 // 90% of perfect-match correlation
+
+	c := NewCorrelator(pattern, threshold)
+	hits, _ := c.Process(nil, stream, 0)
+	if len(hits) < 2 {
+		t.Fatalf("hits = %v, want >= 2 matches", hits)
+	}
+	// The correlator emits a hit at the index of the *last* pattern sample.
+	expected := []int{len(noise) + len(pattern) - 1, len(noise) + len(pattern) + len(noise) + len(pattern) - 1}
+	for _, want := range expected {
+		found := false
+		for _, h := range hits {
+			if h == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("missing match at index %d (got %v)", want, hits)
+		}
+	}
+}

--- a/internal/dsp/window/window.go
+++ b/internal/dsp/window/window.go
@@ -1,0 +1,85 @@
+// Package window provides standard window functions for FIR design and FFT
+// pre-processing. All windows are symmetric and length-N.
+package window
+
+import "math"
+
+func Rect(n int) []float64 {
+	w := make([]float64, n)
+	for i := range w {
+		w[i] = 1
+	}
+	return w
+}
+
+func Hann(n int) []float64 {
+	w := make([]float64, n)
+	if n == 1 {
+		w[0] = 1
+		return w
+	}
+	for i := 0; i < n; i++ {
+		w[i] = 0.5 - 0.5*math.Cos(2*math.Pi*float64(i)/float64(n-1))
+	}
+	return w
+}
+
+func Hamming(n int) []float64 {
+	w := make([]float64, n)
+	if n == 1 {
+		w[0] = 1
+		return w
+	}
+	for i := 0; i < n; i++ {
+		w[i] = 0.54 - 0.46*math.Cos(2*math.Pi*float64(i)/float64(n-1))
+	}
+	return w
+}
+
+func Blackman(n int) []float64 {
+	w := make([]float64, n)
+	if n == 1 {
+		w[0] = 1
+		return w
+	}
+	for i := 0; i < n; i++ {
+		x := 2 * math.Pi * float64(i) / float64(n-1)
+		w[i] = 0.42 - 0.5*math.Cos(x) + 0.08*math.Cos(2*x)
+	}
+	return w
+}
+
+// Kaiser returns a length-N Kaiser window with shape parameter beta. Larger
+// beta → narrower main lobe + lower side lobes. Common values: 5 (~-37 dB),
+// 8.6 (~-65 dB), 14 (~-110 dB).
+func Kaiser(n int, beta float64) []float64 {
+	w := make([]float64, n)
+	if n == 1 {
+		w[0] = 1
+		return w
+	}
+	denom := i0(beta)
+	half := float64(n-1) / 2
+	for i := 0; i < n; i++ {
+		x := (float64(i) - half) / half
+		w[i] = i0(beta*math.Sqrt(1-x*x)) / denom
+	}
+	return w
+}
+
+// i0 evaluates the modified Bessel function of the first kind, order 0.
+// Series converges quickly for beta < ~50.
+func i0(x float64) float64 {
+	const eps = 1e-12
+	t := x / 2
+	sum := 1.0
+	term := 1.0
+	for k := 1; k < 100; k++ {
+		term *= (t / float64(k)) * (t / float64(k))
+		sum += term
+		if term < eps*sum {
+			break
+		}
+	}
+	return sum
+}

--- a/internal/dsp/window/window_test.go
+++ b/internal/dsp/window/window_test.go
@@ -1,0 +1,38 @@
+package window
+
+import (
+	"math"
+	"testing"
+)
+
+func TestSymmetry(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		w    []float64
+	}{
+		{"hann", Hann(33)},
+		{"hamming", Hamming(33)},
+		{"blackman", Blackman(33)},
+		{"kaiser", Kaiser(33, 8.6)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			n := len(tc.w)
+			for i := 0; i < n/2; i++ {
+				if math.Abs(tc.w[i]-tc.w[n-1-i]) > 1e-12 {
+					t.Errorf("asymmetric at %d: %f vs %f", i, tc.w[i], tc.w[n-1-i])
+				}
+			}
+		})
+	}
+}
+
+func TestKaiserPeakAtCenter(t *testing.T) {
+	w := Kaiser(65, 8.6)
+	mid := w[len(w)/2]
+	if mid < 0.999 {
+		t.Errorf("Kaiser midpoint = %f, want ~1", mid)
+	}
+	if w[0] > 0.01 || w[len(w)-1] > 0.01 {
+		t.Errorf("Kaiser endpoints not near zero: %f %f", w[0], w[len(w)-1])
+	}
+}


### PR DESCRIPTION
Builds out the GopherTrunk software described in `README.md` as a phased
roadmap. The full plan lives in `docs/phases.md`; this PR delivers Phases
0, 1, and 2.

## Phase 0 — Foundation
- Go 1.24 module, `Makefile` (`build`, `test`, `vet`, `lint`, `tidy`,
  `proto`), `.gitignore`, GitHub Actions CI that installs `librtlsdr-dev`
  + `libusb-1.0-0-dev` and runs `vet`/`build`/`test`.
- `cmd/gophertrunk` daemon scaffold with `version`, `sdr list`, `run`
  subcommands, `log/slog` logging, signal-driven shutdown.
- `internal/config` YAML loader with validation.
- `internal/events` in-process pub/sub bus reserved for the engine→API
  decoupling so we never have to retrofit it later.

## Phase 1 — SDR Hardware Layer
- `internal/sdr` driver registry, `Device` interface, `Pool` that opens
  every discovered device and assigns Control/Voice roles (with
  serial-number hints).
- `internal/sdr/rtlsdr` thin CGO binding to `librtlsdr` — async-read
  callback bridged to a Go channel of `complex64`; PPM, gain,
  sample-rate, and center-frequency controls; DC blocker and
  IQ-imbalance correction.
- `internal/sdr/mock` file-backed `u8` and `f32` IQ replay drivers used
  for offline tests and integration replay.
- `gophertrunk sdr list` enumerates attached dongles.

## Phase 2 — DSP Core
- `internal/dsp/window`: Hann/Hamming/Blackman/Kaiser.
- `internal/dsp/fft`: swappable `Plan` interface; default backend wraps
  `gonum.org/v1/gonum/dsp/fourier`.
- `internal/dsp/filter`: stateful FIR, Kaiser LPF designer,
  root-raised-cosine, CIC decimator, halfband LPF.
- `internal/dsp/agc` + `internal/dsp/resampler`: feedback AGC and
  polyphase rational L/M resampler.
- `internal/dsp/channelizer`: M-channel critically-sampled polyphase
  channelizer. Verified that a `+k·Fs/M` tone lands in output channel
  `k` with > 20 dB rejection in every other channel.
- `internal/dsp/demod`: quadrature FM, C4FM (RRC + 4-level slicer for
  P25 Phase 1), H-DQPSK (for P25 Phase 2).
- `internal/dsp/sync`: Mueller-Müller symbol-timing recovery,
  correlator-based frame sync.

## Test plan
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `go test -race -count=1 ./...`
- [x] `./bin/gophertrunk version`
- [x] `./bin/gophertrunk sdr list` (no hardware → "no SDR devices found")
- [x] `./bin/gophertrunk run` idles cleanly and shuts down on SIGTERM
- [ ] Manual hardware loop — see `docs/hardware.md` (run with a real
      RTL-SDR dongle attached and verify `sdr list` shows it)

## Roadmap (deferred)
Phases 3+ (P25/DMR/NXDN protocol decoders, trunking engine, voice
decoding, gRPC API, persistence, hardening) are tracked in
`docs/phases.md` and will land in follow-up PRs.

https://claude.ai/code/session_01MQSV8EVnH6nsGUpcWep7UF

---
_Generated by [Claude Code](https://claude.ai/code/session_01MQSV8EVnH6nsGUpcWep7UF)_