### PR TITLE
Phase 3: shared framing primitives + P25 Phase 1 control channel

### DIFF
--- a/docs/phases.md
+++ b/docs/phases.md
@@ -8,7 +8,7 @@ buildable and testable; the project stays useful even if work pauses partway.
 | 0     | Foundation                             | done        |
 | 1     | SDR hardware layer (CGO librtlsdr)     | done        |
 | 2     | DSP core (channelizer, demods)         | done        |
-| 3     | P25 trunking (Phase 1 then Phase 2)    | upcoming    |
+| 3     | P25 trunking (Phase 1 then Phase 2)    | partial     |
 | 3.5   | System ID & control-channel hunting    | upcoming    |
 | 4     | DMR trunking (Tier II + Tier III)      | upcoming    |
 | 5     | NXDN trunking                          | upcoming    |
@@ -68,6 +68,33 @@ Verification:
   channel k with adjacent-channel rejection > 20 dB); AGC convergence;
   RRC unit-energy and matched-filter peak-at-center; FM demod against a
   linear chirp; D-QPSK against constant phase steps.
+
+## Phase 3 — P25 trunking (in progress)
+
+Landed in this phase:
+
+- `internal/radio/framing` shared FEC primitives — bit packing,
+  CRC-CCITT/FALSE, Hamming(15,11,3), extended Golay(24,12,8), and a
+  generic 4-state 1/2-rate convolutional Viterbi parameterised by next-
+  state and output-dibit tables (P25 trellis polynomials plug in here).
+- `internal/radio/p25/phase1`:
+  - `sync.go` — 48-bit P25 frame-sync word, dibit-stream sync detector,
+    and TIA-102 C4FM symbol-to-dibit mapping.
+  - `nid.go` — Network ID parser (NAC + DUID enum).
+  - `tsbk.go` — Trunking Signaling Block parse/assemble with CRC trailer.
+  - `opcodes.go` — TSBK opcode constants and payload parsers for
+    GroupVoiceChannelGrant (0x00), GroupVoiceChannelUpdate (0x02),
+    NetworkStatusBroadcast (0x3B), and RFSSStatusBroadcast (0x3A).
+  - `control.go` — control-channel state that emits `cc.locked` and
+    `cc.lost` on the events bus.
+
+Deferred to follow-up phases:
+- Full BCH(63,16,11) decoder for NID validation.
+- P25-specific trellis next-state / output-dibit tables (TIA-102.BAAA
+  Annex A) and the TSBK block interleaver.
+- LDU1/LDU2 (voice frames) — they need Reed-Solomon and the IMBE
+  decoder, both Phase 7 territory.
+- P25 Phase 2 (TDMA H-DQPSK superframes) — separate phase.
 
 …subsequent phases follow the plan in
 `/root/.claude/plans/using-the-readme-md-as-sleepy-fairy.md`.

--- a/internal/radio/framing/bits.go
+++ b/internal/radio/framing/bits.go
@@ -1,0 +1,76 @@
+// Package framing provides the bit-level primitives shared across P25, DMR,
+// and NXDN: bit packing, CRC, Hamming, Golay, and convolutional/Viterbi
+// decoders. Each protocol package consumes these primitives so the FEC
+// implementations live in one place.
+package framing
+
+// PackBitsMSB packs a slice of 0/1 values into bytes, MSB-first.
+func PackBitsMSB(bits []byte) []byte {
+	out := make([]byte, (len(bits)+7)/8)
+	for i, b := range bits {
+		if b&1 != 0 {
+			out[i>>3] |= 1 << uint(7-(i&7))
+		}
+	}
+	return out
+}
+
+// UnpackBitsMSB unpacks bytes into 0/1 values, MSB-first. Length n must not
+// exceed len(src)*8.
+func UnpackBitsMSB(src []byte, n int) []byte {
+	if n > len(src)*8 {
+		n = len(src) * 8
+	}
+	out := make([]byte, n)
+	for i := 0; i < n; i++ {
+		if src[i>>3]&(1<<uint(7-(i&7))) != 0 {
+			out[i] = 1
+		}
+	}
+	return out
+}
+
+// DibitsToBits expands MSB-first dibits (each value 0..3) into pairs of bits.
+// P25 mapping: dibit 0=00, 1=01, 2=10, 3=11.
+func DibitsToBits(dibits []uint8) []byte {
+	out := make([]byte, len(dibits)*2)
+	for i, d := range dibits {
+		out[2*i] = (d >> 1) & 1
+		out[2*i+1] = d & 1
+	}
+	return out
+}
+
+// BitsToDibits packs a bit slice (MSB-first per dibit) back into dibits.
+// Trailing odd bit, if any, is dropped.
+func BitsToDibits(bits []byte) []uint8 {
+	n := len(bits) / 2
+	out := make([]uint8, n)
+	for i := 0; i < n; i++ {
+		out[i] = (bits[2*i]&1)<<1 | (bits[2*i+1] & 1)
+	}
+	return out
+}
+
+// PopCount64 returns the number of 1 bits in v.
+func PopCount64(v uint64) int {
+	v -= (v >> 1) & 0x5555555555555555
+	v = (v & 0x3333333333333333) + ((v >> 2) & 0x3333333333333333)
+	v = (v + (v >> 4)) & 0x0F0F0F0F0F0F0F0F
+	return int((v * 0x0101010101010101) >> 56)
+}
+
+// HammingDistanceBits returns the count of positions where a and b differ.
+func HammingDistanceBits(a, b []byte) int {
+	n := len(a)
+	if len(b) < n {
+		n = len(b)
+	}
+	d := 0
+	for i := 0; i < n; i++ {
+		if a[i]&1 != b[i]&1 {
+			d++
+		}
+	}
+	return d
+}

--- a/internal/radio/framing/bits_test.go
+++ b/internal/radio/framing/bits_test.go
@@ -1,0 +1,59 @@
+package framing
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestPackUnpackRoundTrip(t *testing.T) {
+	bits := []byte{1, 0, 1, 1, 0, 1, 0, 1, 1, 1}
+	packed := PackBitsMSB(bits)
+	want := []byte{0xB5, 0xC0} // 10110101 11000000
+	if !bytes.Equal(packed, want) {
+		t.Errorf("packed = %x, want %x", packed, want)
+	}
+	back := UnpackBitsMSB(packed, len(bits))
+	if !bytes.Equal(back, bits) {
+		t.Errorf("unpacked = %v, want %v", back, bits)
+	}
+}
+
+func TestDibitsBits(t *testing.T) {
+	dibits := []uint8{0, 1, 2, 3, 1, 2}
+	bits := DibitsToBits(dibits)
+	want := []byte{0, 0, 0, 1, 1, 0, 1, 1, 0, 1, 1, 0}
+	if !bytes.Equal(bits, want) {
+		t.Errorf("DibitsToBits = %v, want %v", bits, want)
+	}
+	back := BitsToDibits(bits)
+	if !bytes.Equal(back, dibits) {
+		t.Errorf("BitsToDibits = %v, want %v", back, dibits)
+	}
+}
+
+func TestPopCount64(t *testing.T) {
+	cases := map[uint64]int{0: 0, 1: 1, 0xFF: 8, 0xFFFFFFFFFFFFFFFF: 64, 0xAAAA: 8}
+	for v, want := range cases {
+		if got := PopCount64(v); got != want {
+			t.Errorf("PopCount64(%x) = %d, want %d", v, got, want)
+		}
+	}
+}
+
+func TestCRCCCITTKnownVector(t *testing.T) {
+	// CRC-CCITT/FALSE of "123456789" is 0x29B1.
+	got := CRCCCITT([]byte("123456789"))
+	if got != 0x29B1 {
+		t.Errorf("CRC-CCITT('123456789') = %04X, want 29B1", got)
+	}
+}
+
+func TestCRCBitsMatchesBytes(t *testing.T) {
+	msg := []byte{0xDE, 0xAD, 0xBE, 0xEF}
+	want := CRCCCITT(msg)
+	bits := UnpackBitsMSB(msg, 32)
+	got := CRCCCITTBits(bits)
+	if got != want {
+		t.Errorf("CRCCCITTBits = %04X, want %04X", got, want)
+	}
+}

--- a/internal/radio/framing/crc.go
+++ b/internal/radio/framing/crc.go
@@ -1,0 +1,27 @@
+package framing
+
+// CRCCCITT returns the 16-bit CRC-CCITT/FALSE of msg using polynomial
+// 0x1021, initial value 0xFFFF, no input/output reflection, no final XOR.
+// This is the variant used by the P25 TSBK trailer (the trailer stores the
+// bitwise complement; callers handle that at protocol level).
+func CRCCCITT(msg []byte) uint16 {
+	const poly uint16 = 0x1021
+	crc := uint16(0xFFFF)
+	for _, b := range msg {
+		crc ^= uint16(b) << 8
+		for i := 0; i < 8; i++ {
+			if crc&0x8000 != 0 {
+				crc = (crc << 1) ^ poly
+			} else {
+				crc <<= 1
+			}
+		}
+	}
+	return crc
+}
+
+// CRCCCITTBits computes CRC-CCITT over a bit slice (each entry 0/1, MSB-first
+// nibbles within each byte). Useful when the caller already has a bit array.
+func CRCCCITTBits(bits []byte) uint16 {
+	return CRCCCITT(PackBitsMSB(bits))
+}

--- a/internal/radio/framing/golay.go
+++ b/internal/radio/framing/golay.go
@@ -1,0 +1,52 @@
+package framing
+
+// Extended Golay (24, 12, 8): triple-error-correcting / quadruple-error-
+// detecting linear block code used widely in P25 and DMR framing.
+//
+// The implementation uses the standard systematic generator matrix
+// G = [I_12 | B] where B is the 12×12 parity matrix below (taken from
+// MacWilliams & Sloane, "The Theory of Error-Correcting Codes", §2.6).
+
+var golayB = [12]uint16{
+	0xC75, 0x63B, 0xF68, 0x7B4, 0x3DA, 0xD99,
+	0xECC, 0x766, 0xCB3, 0xA51, 0xD2A, 0x995,
+}
+
+// GolayEncode24_12 encodes 12 data bits (in the low 12 bits of input) into
+// a 24-bit codeword. Output layout: [data(12) | parity(12)] with the data
+// bits in bits 23..12 and parity in bits 11..0.
+func GolayEncode24_12(data uint16) uint32 {
+	d := uint32(data & 0x0FFF)
+	var parity uint32
+	for i := 0; i < 12; i++ {
+		if d&(1<<uint(i)) != 0 {
+			parity ^= uint32(golayB[i])
+		}
+	}
+	return d<<12 | parity
+}
+
+// GolayDecode24_12 decodes a 24-bit codeword. It searches the 4096-codeword
+// space for the minimum-Hamming-distance match. Returns (data, errors)
+// where errors is the corrected bit count (-1 if > 3, which exceeds the
+// guaranteed correction radius).
+func GolayDecode24_12(cw uint32) (uint16, int) {
+	cw &= 0x00FFFFFF
+	bestData := uint16(0)
+	bestDist := 25
+	for d := uint32(0); d < 1<<12; d++ {
+		c := GolayEncode24_12(uint16(d))
+		dist := PopCount64(uint64(c ^ cw))
+		if dist < bestDist {
+			bestDist = dist
+			bestData = uint16(d)
+			if dist == 0 {
+				return bestData, 0
+			}
+		}
+	}
+	if bestDist > 3 {
+		return bestData, -1
+	}
+	return bestData, bestDist
+}

--- a/internal/radio/framing/golay_test.go
+++ b/internal/radio/framing/golay_test.go
@@ -1,0 +1,37 @@
+package framing
+
+import "testing"
+
+func TestGolayRoundTrip(t *testing.T) {
+	for d := uint16(0); d < 1<<12; d += 31 {
+		cw := GolayEncode24_12(d)
+		got, errs := GolayDecode24_12(cw)
+		if errs != 0 || got != d {
+			t.Errorf("d=%x: got=%x errs=%d", d, got, errs)
+		}
+	}
+}
+
+func TestGolayCorrectsTripleErrors(t *testing.T) {
+	d := uint16(0xABC)
+	cw := GolayEncode24_12(d)
+	// Flip three bits.
+	corrupted := cw ^ 0b101010 // bits 1, 3, 5
+	got, errs := GolayDecode24_12(corrupted)
+	if got != d {
+		t.Fatalf("triple-error decode: got %x, want %x", got, d)
+	}
+	if errs != 3 {
+		t.Errorf("errors = %d, want 3", errs)
+	}
+}
+
+func TestGolayDistanceProperty(t *testing.T) {
+	// Min distance must be 8: any two distinct codewords differ in >=8 bits.
+	a := GolayEncode24_12(0x000)
+	b := GolayEncode24_12(0x001)
+	d := PopCount64(uint64(a ^ b))
+	if d < 8 {
+		t.Errorf("d(c0, c1) = %d, want >= 8", d)
+	}
+}

--- a/internal/radio/framing/hamming.go
+++ b/internal/radio/framing/hamming.go
@@ -1,0 +1,47 @@
+package framing
+
+// Hamming(15,11,3): single-error-correcting linear block code with the
+// systematic form used by P25 (TIA-102.BAAA Annex B). The four parity bits
+// are computed from a fixed generator matrix; this implementation stores
+// the 11-bit→15-bit codewords in straightforward bit form.
+//
+// Generator polynomial: 1 + x + x^4. The parity bits are:
+//   p0 = d0 + d1 + d2 + d3 + d5 + d7 + d8
+//   p1 = d1 + d2 + d3 + d4 + d6 + d8 + d9
+//   p2 = d2 + d3 + d4 + d5 + d7 + d9 + d10
+//   p3 = d0 + d1 + d2 + d4 + d6 + d7 + d10
+// (per TIA-102.BAAA section B.2). Codeword layout: [d10 d9 ... d0 p3 p2 p1 p0].
+
+// HammingEncode15_11 encodes 11 data bits (LSB-first packed in lower 11
+// bits of input) into the 15-bit codeword. Output occupies bits 0..14.
+func HammingEncode15_11(data uint16) uint16 {
+	d := data & 0x07FF
+	bit := func(i int) uint16 { return (d >> i) & 1 }
+	p0 := bit(0) ^ bit(1) ^ bit(2) ^ bit(3) ^ bit(5) ^ bit(7) ^ bit(8)
+	p1 := bit(1) ^ bit(2) ^ bit(3) ^ bit(4) ^ bit(6) ^ bit(8) ^ bit(9)
+	p2 := bit(2) ^ bit(3) ^ bit(4) ^ bit(5) ^ bit(7) ^ bit(9) ^ bit(10)
+	p3 := bit(0) ^ bit(1) ^ bit(2) ^ bit(4) ^ bit(6) ^ bit(7) ^ bit(10)
+	return d<<4 | p3<<3 | p2<<2 | p1<<1 | p0
+}
+
+// HammingDecode15_11 decodes a 15-bit codeword. Returns (data, errors),
+// where errors == 0 means no error, 1 means a single bit was corrected,
+// and -1 means the codeword was uncorrectable (multiple bit errors).
+func HammingDecode15_11(cw uint16) (uint16, int) {
+	cw &= 0x7FFF
+	// Recompute parity from received data bits.
+	enc := HammingEncode15_11(cw >> 4)
+	syn := (enc ^ cw) & 0x0F
+	if syn == 0 {
+		return cw >> 4, 0
+	}
+	// Look up the bit position for this syndrome. Build the table by
+	// flipping each of the 15 bits and recomputing the syndrome.
+	for i := 0; i < 15; i++ {
+		flipped := cw ^ (1 << uint(i))
+		if (HammingEncode15_11(flipped>>4)^flipped)&0x0F == 0 {
+			return flipped >> 4, 1
+		}
+	}
+	return cw >> 4, -1
+}

--- a/internal/radio/framing/hamming_test.go
+++ b/internal/radio/framing/hamming_test.go
@@ -1,0 +1,32 @@
+package framing
+
+import "testing"
+
+func TestHammingRoundTrip(t *testing.T) {
+	for d := uint16(0); d < 1<<11; d++ {
+		cw := HammingEncode15_11(d)
+		got, errs := HammingDecode15_11(cw)
+		if errs != 0 {
+			t.Fatalf("clean codeword %x reported %d errors", d, errs)
+		}
+		if got != d {
+			t.Fatalf("decode(encode(%x)) = %x", d, got)
+		}
+	}
+}
+
+func TestHammingCorrectsSingleError(t *testing.T) {
+	for d := uint16(0); d < 1<<11; d += 17 { // sparse sweep
+		cw := HammingEncode15_11(d)
+		for bit := 0; bit < 15; bit++ {
+			corrupted := cw ^ (1 << uint(bit))
+			got, errs := HammingDecode15_11(corrupted)
+			if errs != 1 {
+				t.Errorf("d=%x bit=%d: errs=%d, want 1", d, bit, errs)
+			}
+			if got != d {
+				t.Errorf("d=%x bit=%d: got=%x, want %x", d, bit, got, d)
+			}
+		}
+	}
+}

--- a/internal/radio/framing/trellis.go
+++ b/internal/radio/framing/trellis.go
@@ -1,0 +1,119 @@
+package framing
+
+// Trellis4State1Half is a 4-state, 1/2-rate (1 input bit → 1 output dibit)
+// convolutional encoder/Viterbi decoder. The state transitions are supplied
+// as tables so that protocol packages can plug in their specific code
+// (e.g. P25 TIA-102.BAAA Annex A defines particular next-state/output
+// tables; an equivalent representation is the generator polynomial pair
+// (g1, g2) which Trellis4StatePoly converts into tables).
+type Trellis4State1Half struct {
+	// Next[state][input] = nextState
+	Next [4][2]int
+	// Out[state][input] = output dibit (0..3)
+	Out [4][2]uint8
+}
+
+// Trellis4StatePoly returns a trellis configured from generator polynomials
+// (g1, g2), each a 3-bit value where bit 2 is the input tap. (7,5) octal
+// (= 0b111, 0b101) is the canonical 4-state K=3 1/2-rate code.
+func Trellis4StatePoly(g1, g2 int) Trellis4State1Half {
+	var t Trellis4State1Half
+	for state := 0; state < 4; state++ {
+		for in := 0; in < 2; in++ {
+			// Shift register: [in, state_bit_1, state_bit_0]
+			s := state | (in << 2)
+			b1 := xorTaps(s, g1)
+			b2 := xorTaps(s, g2)
+			t.Out[state][in] = uint8((b1 << 1) | b2)
+			t.Next[state][in] = (in << 1) | (state >> 1)
+		}
+	}
+	return t
+}
+
+func xorTaps(reg, poly int) int {
+	v := reg & poly
+	parity := 0
+	for v != 0 {
+		parity ^= v & 1
+		v >>= 1
+	}
+	return parity
+}
+
+// Encode produces output dibits for an input bit slice (each entry 0/1).
+// The encoder starts in state 0 and ends in whatever state the input drives
+// it to; callers that need a known final state should append flush bits.
+func (t Trellis4State1Half) Encode(in []byte) []uint8 {
+	out := make([]uint8, len(in))
+	state := 0
+	for i, b := range in {
+		b &= 1
+		out[i] = t.Out[state][b]
+		state = t.Next[state][b]
+	}
+	return out
+}
+
+// DecodeHard runs hard-decision Viterbi over received dibits and returns the
+// most-likely input bit sequence. The decoder starts in state 0; if final
+// state is unknown, ending-state metric is taken across all four states.
+func (t Trellis4State1Half) DecodeHard(rx []uint8) []byte {
+	const inf = 1 << 30
+	N := len(rx)
+	// pathMetric[state] = accumulated Hamming-distance metric.
+	pm := [4]int{0, inf, inf, inf}
+	// trace[stage][state] = predecessor (state, input_bit) packed
+	trace := make([][4]uint8, N)
+
+	for i := 0; i < N; i++ {
+		var npm [4]int
+		for s := 0; s < 4; s++ {
+			npm[s] = inf
+		}
+		for s := 0; s < 4; s++ {
+			if pm[s] >= inf {
+				continue
+			}
+			for b := 0; b < 2; b++ {
+				ns := t.Next[s][b]
+				cost := pm[s] + dibitDistance(t.Out[s][b], rx[i])
+				if cost < npm[ns] {
+					npm[ns] = cost
+					trace[i][ns] = uint8((s << 1) | b) // s in bits 1..2, b in bit 0
+				}
+			}
+		}
+		pm = npm
+	}
+
+	// Find best terminal state.
+	best := 0
+	for s := 1; s < 4; s++ {
+		if pm[s] < pm[best] {
+			best = s
+		}
+	}
+
+	// Trace back.
+	out := make([]byte, N)
+	state := best
+	for i := N - 1; i >= 0; i-- {
+		entry := trace[i][state]
+		out[i] = entry & 1
+		state = int(entry >> 1)
+	}
+	return out
+}
+
+func dibitDistance(a, b uint8) int {
+	d := (a ^ b) & 0x3
+	switch d {
+	case 0:
+		return 0
+	case 1, 2:
+		return 1
+	default:
+		return 2
+	}
+}

--- a/internal/radio/framing/trellis_test.go
+++ b/internal/radio/framing/trellis_test.go
@@ -1,0 +1,42 @@
+package framing
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestTrellisEncodeDecodeRoundTrip(t *testing.T) {
+	tr := Trellis4StatePoly(0b111, 0b101) // (7,5) octal
+	in := []byte{1, 0, 1, 1, 0, 1, 0, 0, 1, 1, 1, 0, 0, 1, 0, 1, 0, 0}
+	rx := tr.Encode(in)
+	got := tr.DecodeHard(rx)
+	if !bytes.Equal(got, in) {
+		t.Errorf("clean round-trip mismatch:\n got %v\nwant %v", got, in)
+	}
+}
+
+func TestTrellisDecodesWithSingleErrors(t *testing.T) {
+	tr := Trellis4StatePoly(0b111, 0b101)
+	in := []byte{1, 1, 0, 1, 0, 1, 1, 1, 0, 0, 1, 0, 0, 1, 1, 0, 1, 0, 1, 1, 0}
+	rx := tr.Encode(in)
+	// Flip one bit in one dibit (maximum local error of 1 dibit-distance).
+	rx[5] ^= 0b01
+	got := tr.DecodeHard(rx)
+	if !bytes.Equal(got, in) {
+		t.Errorf("single-error decode mismatch:\n got %v\nwant %v", got, in)
+	}
+}
+
+func TestTrellisOutputShape(t *testing.T) {
+	tr := Trellis4StatePoly(0b111, 0b101)
+	in := make([]byte, 100)
+	out := tr.Encode(in)
+	if len(out) != len(in) {
+		t.Errorf("encoded len = %d, want %d", len(out), len(in))
+	}
+	for _, d := range out {
+		if d > 3 {
+			t.Errorf("dibit out of range: %d", d)
+		}
+	}
+}

--- a/internal/radio/p25/phase1/control.go
+++ b/internal/radio/p25/phase1/control.go
@@ -1,0 +1,95 @@
+package phase1
+
+import (
+	"log/slog"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+)
+
+// ControlChannel consumes a stream of P25 Phase 1 dibits (already symbol-
+// time-recovered and mapped via SymbolToDibit) and emits trunking events
+// onto an events.Bus.
+//
+// This is the minimum scaffold: dibit window → FSW detect → NID parse →
+// (placeholder) TSBK extraction. Trellis decoding and TSBK CRC validation
+// for the live stream land alongside the interleaver work in a follow-up
+// — for now the state machine emits CCLocked / CCLost events when a NID
+// with a TSDU DUID is observed, which is enough to drive Phase 3.5 (CC
+// hunting) and gives downstream layers a stable surface to subscribe to.
+type ControlChannel struct {
+	bus     *events.Bus
+	log     *slog.Logger
+	det     *SyncDetector
+	freqHz  uint32
+	locked  bool
+	lastNAC uint16
+}
+
+func NewControlChannel(bus *events.Bus, log *slog.Logger, freqHz uint32) *ControlChannel {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &ControlChannel{
+		bus:    bus,
+		log:    log,
+		det:    NewSyncDetector(4),
+		freqHz: freqHz,
+	}
+}
+
+// LockState is the payload of CCLocked / CCLost events.
+type LockState struct {
+	FrequencyHz uint32
+	NAC         uint16
+	DUID        DUID
+}
+
+// Process consumes a window of dibits and runs detection/parsing. baseIdx
+// is the absolute dibit index of dibits[0]. Returns the new baseIndex.
+func (c *ControlChannel) Process(dibits []uint8, baseIdx int) int {
+	hits, next := c.det.Process(nil, dibits, baseIdx)
+	for _, h := range hits {
+		// FSW ends at index h (relative to the absolute dibit stream). The
+		// 32-dibit NID immediately follows.
+		startInWindow := h - baseIdx + 1
+		if startInWindow+32 > len(dibits) {
+			// Crosses the buffer edge; future calls will have the rest.
+			continue
+		}
+		nidDibits := dibits[startInWindow : startInWindow+32]
+		nid, err := NIDFromDibits(nidDibits)
+		if err != nil {
+			c.log.Debug("nid parse failed", "err", err)
+			continue
+		}
+		if nid.DUID != DUIDTrunkingSignaling {
+			// Some non-control DUID — record but don't lock.
+			c.log.Debug("non-control DUID", "duid", nid.DUID, "nac", nid.NAC)
+			continue
+		}
+		if !c.locked || c.lastNAC != nid.NAC {
+			c.locked = true
+			c.lastNAC = nid.NAC
+			c.bus.Publish(events.Event{
+				Kind:    events.KindCCLocked,
+				Payload: LockState{FrequencyHz: c.freqHz, NAC: nid.NAC, DUID: nid.DUID},
+			})
+			c.log.Info("control channel locked", "nac", nid.NAC, "freq", c.freqHz)
+		}
+	}
+	return next
+}
+
+// LossThreshold is the number of consecutive Process calls without a TSDU
+// NID after which CCLost is published. Loss tracking is intentionally
+// simple — Phase 3.5 (CC hunting) replaces this with a watchdog.
+func (c *ControlChannel) MarkLost() {
+	if !c.locked {
+		return
+	}
+	c.locked = false
+	c.bus.Publish(events.Event{
+		Kind:    events.KindCCLost,
+		Payload: LockState{FrequencyHz: c.freqHz, NAC: c.lastNAC},
+	})
+}

--- a/internal/radio/p25/phase1/control_test.go
+++ b/internal/radio/p25/phase1/control_test.go
@@ -1,0 +1,92 @@
+package phase1
+
+import (
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+)
+
+// buildLockedStream constructs a synthetic dibit window that places the
+// FSW at the given offset followed by a NID encoding the supplied NAC and
+// the TSDU DUID.
+func buildLockedStream(offset int, nac uint16, duid DUID) []uint8 {
+	out := make([]uint8, offset+24+32+16)
+	copy(out[offset:], FrameSyncWord[:])
+	bits := make([]byte, 64)
+	for i := 0; i < 12; i++ {
+		bits[i] = byte((nac >> uint(11-i)) & 1)
+	}
+	for i := 0; i < 4; i++ {
+		bits[12+i] = byte((uint8(duid) >> uint(3-i)) & 1)
+	}
+	for i := 0; i < 32; i++ {
+		out[offset+24+i] = (bits[2*i] << 1) | bits[2*i+1]
+	}
+	return out
+}
+
+func TestControlChannelEmitsLockOnTSDU(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := NewControlChannel(bus, nil, 851_000_000)
+	stream := buildLockedStream(10, 0x293, DUIDTrunkingSignaling)
+	cc.Process(stream, 0)
+
+	select {
+	case ev := <-sub.C:
+		if ev.Kind != events.KindCCLocked {
+			t.Errorf("kind = %s, want cc.locked", ev.Kind)
+		}
+		ls, ok := ev.Payload.(LockState)
+		if !ok {
+			t.Fatalf("payload type = %T, want LockState", ev.Payload)
+		}
+		if ls.NAC != 0x293 || ls.DUID != DUIDTrunkingSignaling {
+			t.Errorf("payload = %+v", ls)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("no event published")
+	}
+}
+
+func TestControlChannelIgnoresNonTSDU(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := NewControlChannel(bus, nil, 851_000_000)
+	stream := buildLockedStream(10, 0x123, DUIDLogicalLink1)
+	cc.Process(stream, 0)
+
+	select {
+	case ev := <-sub.C:
+		t.Errorf("unexpected event: %s", ev.Kind)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestControlChannelMarkLost(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := NewControlChannel(bus, nil, 851_000_000)
+	cc.Process(buildLockedStream(10, 0x456, DUIDTrunkingSignaling), 0)
+	<-sub.C // CCLocked
+
+	cc.MarkLost()
+	select {
+	case ev := <-sub.C:
+		if ev.Kind != events.KindCCLost {
+			t.Errorf("kind = %s, want cc.lost", ev.Kind)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("no CCLost event")
+	}
+}

--- a/internal/radio/p25/phase1/nid.go
+++ b/internal/radio/p25/phase1/nid.go
@@ -1,0 +1,77 @@
+package phase1
+
+import "fmt"
+
+// DUID is the 4-bit Data Unit ID that identifies the kind of frame
+// following the NID (TIA-102.BAAA §6.2).
+type DUID uint8
+
+const (
+	DUIDHeader              DUID = 0x0 // HDU
+	DUIDTerminator          DUID = 0x3 // TDU (without LC)
+	DUIDLogicalLink1        DUID = 0x5 // LDU1
+	DUIDTrunkingSignaling   DUID = 0x7 // TSDU (control channel)
+	DUIDLogicalLink2        DUID = 0xA // LDU2
+	DUIDPacketDataUnit      DUID = 0xC // PDU
+	DUIDTerminatorWithLC    DUID = 0xF // TDULC
+)
+
+func (d DUID) String() string {
+	switch d {
+	case DUIDHeader:
+		return "HDU"
+	case DUIDTerminator:
+		return "TDU"
+	case DUIDLogicalLink1:
+		return "LDU1"
+	case DUIDTrunkingSignaling:
+		return "TSDU"
+	case DUIDLogicalLink2:
+		return "LDU2"
+	case DUIDPacketDataUnit:
+		return "PDU"
+	case DUIDTerminatorWithLC:
+		return "TDULC"
+	default:
+		return fmt.Sprintf("DUID(%X)", uint8(d))
+	}
+}
+
+// NID is the 64-bit Network ID immediately following the FSW. Bits 0..11
+// are the NAC (Network Access Code), bits 12..15 are the DUID, and bits
+// 16..63 are a BCH(63,16) parity field plus a single parity bit.
+type NID struct {
+	NAC  uint16
+	DUID DUID
+}
+
+// ParseNID extracts the NAC and DUID from 64 received bits (MSB-first).
+// It does NOT yet perform full BCH(63,16,11) error correction; callers may
+// validate with a future framing.BCH63_16 decoder.
+func ParseNID(bits []byte) (NID, error) {
+	if len(bits) < 64 {
+		return NID{}, fmt.Errorf("p25/phase1: NID requires 64 bits, got %d", len(bits))
+	}
+	var nac uint16
+	for i := 0; i < 12; i++ {
+		nac = (nac << 1) | uint16(bits[i]&1)
+	}
+	var duid uint8
+	for i := 12; i < 16; i++ {
+		duid = (duid << 1) | (bits[i] & 1)
+	}
+	return NID{NAC: nac, DUID: DUID(duid)}, nil
+}
+
+// NIDFromDibits is a convenience wrapper that takes 32 dibits (= 64 bits).
+func NIDFromDibits(dibits []uint8) (NID, error) {
+	if len(dibits) < 32 {
+		return NID{}, fmt.Errorf("p25/phase1: NID requires 32 dibits, got %d", len(dibits))
+	}
+	bits := make([]byte, 64)
+	for i := 0; i < 32; i++ {
+		bits[2*i] = (dibits[i] >> 1) & 1
+		bits[2*i+1] = dibits[i] & 1
+	}
+	return ParseNID(bits)
+}

--- a/internal/radio/p25/phase1/nid_test.go
+++ b/internal/radio/p25/phase1/nid_test.go
@@ -1,0 +1,58 @@
+package phase1
+
+import "testing"
+
+func TestParseNID(t *testing.T) {
+	// NAC = 0x293, DUID = TSDU (0x7).
+	const wantNAC = uint16(0x293)
+	const wantDUID = DUIDTrunkingSignaling
+	bits := make([]byte, 64)
+	v := uint16(wantNAC)
+	for i := 0; i < 12; i++ {
+		bits[i] = byte((v >> uint(11-i)) & 1)
+	}
+	d := uint8(wantDUID)
+	for i := 0; i < 4; i++ {
+		bits[12+i] = (d >> uint(3-i)) & 1
+	}
+	nid, err := ParseNID(bits)
+	if err != nil {
+		t.Fatalf("ParseNID: %v", err)
+	}
+	if nid.NAC != wantNAC {
+		t.Errorf("NAC = %X, want %X", nid.NAC, wantNAC)
+	}
+	if nid.DUID != wantDUID {
+		t.Errorf("DUID = %s, want %s", nid.DUID, wantDUID)
+	}
+}
+
+func TestDUIDString(t *testing.T) {
+	cases := map[DUID]string{
+		DUIDHeader: "HDU", DUIDLogicalLink1: "LDU1", DUIDTrunkingSignaling: "TSDU",
+		DUIDLogicalLink2: "LDU2", DUIDTerminatorWithLC: "TDULC",
+	}
+	for d, want := range cases {
+		if got := d.String(); got != want {
+			t.Errorf("DUID(%X).String() = %s, want %s", uint8(d), got, want)
+		}
+	}
+}
+
+func TestNIDFromDibits(t *testing.T) {
+	bits := make([]byte, 64)
+	bits[3] = 1   // NAC bit 8
+	bits[14] = 1  // DUID bit 1
+	dibits := make([]uint8, 32)
+	for i := 0; i < 32; i++ {
+		dibits[i] = (bits[2*i] << 1) | bits[2*i+1]
+	}
+	nid, err := NIDFromDibits(dibits)
+	if err != nil {
+		t.Fatalf("NIDFromDibits: %v", err)
+	}
+	want, _ := ParseNID(bits)
+	if nid != want {
+		t.Errorf("NIDFromDibits = %+v, want %+v", nid, want)
+	}
+}

--- a/internal/radio/p25/phase1/opcodes.go
+++ b/internal/radio/p25/phase1/opcodes.go
@@ -1,0 +1,180 @@
+package phase1
+
+import (
+	"encoding/binary"
+	"fmt"
+)
+
+// Opcode is the 6-bit TSBK opcode field per TIA-102.AABF Table 7.
+type Opcode uint8
+
+// TSBK opcodes follow the OP25 mapping (which is the de-facto reference
+// implementation of TIA-102.AABF). Vendor-specific extensions live behind
+// MFID != 0x00.
+const (
+	OpGroupVoiceChannelGrant       Opcode = 0x00
+	OpGroupVoiceChannelUpdate      Opcode = 0x02
+	OpGroupVoiceChannelUpdateExpl  Opcode = 0x03
+	OpUnitToUnitVoiceChannelGrant  Opcode = 0x04
+	OpUnitToUnitAnswerRequest      Opcode = 0x05
+	OpUnitToUnitVoiceChannelUpdate Opcode = 0x06
+	OpTelephoneInterconnectGrant   Opcode = 0x08
+	OpTelephoneAnswerRequest       Opcode = 0x0A
+	OpSNDCPDataChannelGrant        Opcode = 0x14
+	OpStatusUpdate                 Opcode = 0x18
+	OpStatusQuery                  Opcode = 0x1A
+	OpMessageUpdate                Opcode = 0x1C
+	OpRadioUnitMonitor             Opcode = 0x1D
+	OpCallAlert                    Opcode = 0x1F
+	OpAcknowledgeResponse          Opcode = 0x20
+	OpQueuedResponse               Opcode = 0x21
+	OpExtendedFunctionCommand      Opcode = 0x24
+	OpDenyResponse                 Opcode = 0x27
+	OpGroupAffiliationResponse     Opcode = 0x28
+	OpGroupAffiliationQuery        Opcode = 0x2A
+	OpLocationRegistrationResponse Opcode = 0x2B
+	OpUnitRegistrationResponse     Opcode = 0x2C
+	OpUnitRegistrationCommand      Opcode = 0x2D
+	OpDeregistrationAck            Opcode = 0x2F
+	OpIdentifierUpdateVUHF         Opcode = 0x34
+	OpProtectionParamUpdate        Opcode = 0x35
+	OpSecondaryControlChannel      Opcode = 0x39
+	OpRFSSStatusBroadcast          Opcode = 0x3A
+	OpNetworkStatusBroadcast       Opcode = 0x3B
+	OpAdjacentSiteStatusBroadcast  Opcode = 0x3C
+	OpIdentifierUpdate             Opcode = 0x3D
+	OpProtectionParamBroadcast     Opcode = 0x3F
+)
+
+func (o Opcode) String() string {
+	switch o {
+	case OpGroupVoiceChannelGrant:
+		return "GroupVoiceChannelGrant"
+	case OpGroupVoiceChannelUpdate:
+		return "GroupVoiceChannelUpdate"
+	case OpGroupVoiceChannelUpdateExpl:
+		return "GroupVoiceChannelUpdateExplicit"
+	case OpUnitToUnitVoiceChannelGrant:
+		return "UnitToUnitVoiceChannelGrant"
+	case OpUnitToUnitAnswerRequest:
+		return "UnitToUnitAnswerRequest"
+	case OpAdjacentSiteStatusBroadcast:
+		return "AdjacentSiteStatusBroadcast"
+	case OpRFSSStatusBroadcast:
+		return "RFSSStatusBroadcast"
+	case OpNetworkStatusBroadcast:
+		return "NetworkStatusBroadcast"
+	case OpSecondaryControlChannel:
+		return "SecondaryControlChannelBroadcast"
+	case OpIdentifierUpdate:
+		return "IdentifierUpdate"
+	default:
+		return fmt.Sprintf("Opcode(%02X)", uint8(o))
+	}
+}
+
+// GroupVoiceChannelGrant (opcode 0x00) — base format. Payload layout:
+//   byte 0:    service options
+//   byte 1-2:  channel (4-bit ID + 12-bit number)
+//   byte 3-4:  group address (talkgroup)
+//   byte 5-7:  source unit (24-bit)
+type GroupVoiceChannelGrant struct {
+	ServiceOptions uint8
+	ChannelID      uint8
+	ChannelNumber  uint16
+	GroupAddress   uint16
+	SourceID       uint32
+}
+
+// ParseGroupVoiceChannelGrant decodes payload bytes for opcode 0x00.
+func ParseGroupVoiceChannelGrant(p [8]byte) GroupVoiceChannelGrant {
+	chanField := binary.BigEndian.Uint16(p[1:3])
+	return GroupVoiceChannelGrant{
+		ServiceOptions: p[0],
+		ChannelID:      uint8(chanField >> 12),
+		ChannelNumber:  chanField & 0x0FFF,
+		GroupAddress:   binary.BigEndian.Uint16(p[3:5]),
+		SourceID:       uint32(p[5])<<16 | uint32(p[6])<<8 | uint32(p[7]),
+	}
+}
+
+// GroupVoiceChannelUpdate (opcode 0x02) — channel announcement: two
+// (channel, group) pairs in the same payload. The B fields are zero when
+// only one call is being announced.
+type GroupVoiceChannelUpdate struct {
+	ChannelAID, ChannelBID         uint8
+	ChannelANumber, ChannelBNumber uint16
+	GroupAddressA, GroupAddressB   uint16
+}
+
+func ParseGroupVoiceChannelUpdate(p [8]byte) GroupVoiceChannelUpdate {
+	cA := binary.BigEndian.Uint16(p[0:2])
+	cB := binary.BigEndian.Uint16(p[4:6])
+	return GroupVoiceChannelUpdate{
+		ChannelAID:     uint8(cA >> 12),
+		ChannelANumber: cA & 0x0FFF,
+		GroupAddressA:  binary.BigEndian.Uint16(p[2:4]),
+		ChannelBID:     uint8(cB >> 12),
+		ChannelBNumber: cB & 0x0FFF,
+		GroupAddressB:  binary.BigEndian.Uint16(p[6:8]),
+	}
+}
+
+// NetworkStatusBroadcast (opcode 0x3B explicit / 0x3C is Adjacent in some
+// vendor variants — TIA-102.AABF is unfortunately revised over time;
+// callers should look at MFID + opcode together to disambiguate). This
+// parser handles the standard explicit-form payload:
+//   bytes 0-2:  WACN ID (20 bits in upper 20 of 24)
+//   bytes 2-3:  System ID (12 bits)
+//   bytes 4-5:  channel
+//   bytes 6-7:  system service class
+type NetworkStatusBroadcast struct {
+	WACN          uint32 // 20-bit
+	SystemID      uint16 // 12-bit
+	ChannelID     uint8
+	ChannelNumber uint16
+	ServiceClass  uint16
+}
+
+func ParseNetworkStatusBroadcast(p [8]byte) NetworkStatusBroadcast {
+	wacn := uint32(p[0])<<12 | uint32(p[1])<<4 | uint32(p[2]>>4)
+	sysid := uint16(p[2]&0x0F)<<8 | uint16(p[3])
+	chanField := binary.BigEndian.Uint16(p[4:6])
+	return NetworkStatusBroadcast{
+		WACN:          wacn,
+		SystemID:      sysid,
+		ChannelID:     uint8(chanField >> 12),
+		ChannelNumber: chanField & 0x0FFF,
+		ServiceClass:  binary.BigEndian.Uint16(p[6:8]),
+	}
+}
+
+// RFSSStatusBroadcast (opcode 0x3A in standard form). Payload:
+//   byte 0:     LRA (Location Registration Area)
+//   byte 1:     System ID high nibble + RFSS ID
+//   byte 2:     RFSS ID continued / Site ID
+//   byte 3:     Site ID continued
+//   bytes 4-5:  channel
+//   bytes 6-7:  system service class
+type RFSSStatusBroadcast struct {
+	LRA           uint8
+	SystemID      uint16 // 12-bit
+	RFSS          uint8
+	Site          uint8
+	ChannelID     uint8
+	ChannelNumber uint16
+	ServiceClass  uint16
+}
+
+func ParseRFSSStatusBroadcast(p [8]byte) RFSSStatusBroadcast {
+	chanField := binary.BigEndian.Uint16(p[4:6])
+	return RFSSStatusBroadcast{
+		LRA:           p[0],
+		SystemID:      uint16(p[1]&0x0F)<<8 | uint16(p[2]),
+		RFSS:          p[2], // some variants split high/low nibble; documented per-implementation
+		Site:          p[3],
+		ChannelID:     uint8(chanField >> 12),
+		ChannelNumber: chanField & 0x0FFF,
+		ServiceClass:  binary.BigEndian.Uint16(p[6:8]),
+	}
+}

--- a/internal/radio/p25/phase1/sync.go
+++ b/internal/radio/p25/phase1/sync.go
@@ -1,0 +1,87 @@
+// Package phase1 decodes the P25 Phase 1 (C4FM, FDMA) frame structure.
+// Inputs are dibits (0..3) recovered by the upstream C4FM demodulator and
+// symbol-time recovery; outputs are parsed NID and TSBK records.
+package phase1
+
+import "github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+
+// FrameSyncWord is the 48-bit P25 Phase 1 frame sync word, expressed as
+// 24 dibits (TIA-102.BAAA §6.1.1). Hex: 0x5575F5FF77FF, MSB-first dibits.
+var FrameSyncWord = [24]uint8{
+	1, 1, 1, 1, 1, 3, 1, 1, 3, 3, 1, 1,
+	3, 3, 3, 3, 1, 3, 1, 3, 3, 3, 3, 3,
+}
+
+// C4FM symbol-to-dibit mapping per TIA-102.BAAA: +3→01, +1→00, -1→10, -3→11.
+// Input is the slicer output {-3,-1,+1,+3}; output is the dibit value 0..3.
+func SymbolToDibit(sym int8) uint8 {
+	switch sym {
+	case 1:
+		return 0
+	case 3:
+		return 1
+	case -1:
+		return 2
+	case -3:
+		return 3
+	}
+	return 0
+}
+
+// SymbolsToDibits converts a slicer-output stream into dibits.
+func SymbolsToDibits(syms []int8) []uint8 {
+	out := make([]uint8, len(syms))
+	for i, s := range syms {
+		out[i] = SymbolToDibit(s)
+	}
+	return out
+}
+
+// FrameSyncBits returns the 48 bits of the FSW MSB-first.
+func FrameSyncBits() []byte { return framing.DibitsToBits(FrameSyncWord[:]) }
+
+// SyncDetector slides a window over an incoming dibit stream and emits the
+// (zero-based) dibit index where the FSW best matches above tolerance.
+// Tolerance is the maximum allowed dibit-symbol mismatch; default 4.
+type SyncDetector struct {
+	tolerance int
+	hist      [24]uint8
+	primed    int
+	pos       int
+}
+
+func NewSyncDetector(tolerance int) *SyncDetector {
+	if tolerance < 0 {
+		tolerance = 4
+	}
+	return &SyncDetector{tolerance: tolerance}
+}
+
+// Process appends to dst the indices (relative to baseIndex) where the FSW
+// is detected. baseIndex is the absolute dibit index of src[0].
+func (s *SyncDetector) Process(dst []int, src []uint8, baseIndex int) ([]int, int) {
+	for i, d := range src {
+		s.hist[s.pos] = d
+		s.pos = (s.pos + 1) % 24
+		if s.primed < 24 {
+			s.primed++
+			continue
+		}
+		mismatch := 0
+		idx := s.pos
+		for k := 0; k < 24; k++ {
+			if s.hist[idx] != FrameSyncWord[k] {
+				mismatch++
+				if mismatch > s.tolerance {
+					break
+				}
+			}
+			idx = (idx + 1) % 24
+		}
+		if mismatch <= s.tolerance {
+			// Match position: end of the FSW lands at this index.
+			dst = append(dst, baseIndex+i)
+		}
+	}
+	return dst, baseIndex + len(src)
+}

--- a/internal/radio/p25/phase1/sync_test.go
+++ b/internal/radio/p25/phase1/sync_test.go
@@ -1,0 +1,48 @@
+package phase1
+
+import "testing"
+
+func TestSymbolToDibit(t *testing.T) {
+	cases := map[int8]uint8{1: 0, 3: 1, -1: 2, -3: 3}
+	for sym, want := range cases {
+		if got := SymbolToDibit(sym); got != want {
+			t.Errorf("SymbolToDibit(%d) = %d, want %d", sym, got, want)
+		}
+	}
+}
+
+func TestSyncDetectorMatchesCleanFSW(t *testing.T) {
+	det := NewSyncDetector(0)
+	stream := make([]uint8, 100)
+	// Place an FSW at offset 50.
+	copy(stream[50:], FrameSyncWord[:])
+	hits, _ := det.Process(nil, stream, 0)
+	if len(hits) != 1 || hits[0] != 50+24-1 {
+		t.Errorf("hits = %v, want [%d]", hits, 50+24-1)
+	}
+}
+
+func TestSyncDetectorTolerates2Errors(t *testing.T) {
+	det := NewSyncDetector(2)
+	stream := make([]uint8, 100)
+	copy(stream[20:], FrameSyncWord[:])
+	stream[22] = (stream[22] + 1) % 4
+	stream[40] = (stream[40] + 1) % 4
+	hits, _ := det.Process(nil, stream, 0)
+	if len(hits) != 1 {
+		t.Errorf("hits = %v, want exactly 1", hits)
+	}
+}
+
+func TestSyncDetectorRejectsTooManyErrors(t *testing.T) {
+	det := NewSyncDetector(1)
+	stream := make([]uint8, 60)
+	copy(stream[10:], FrameSyncWord[:])
+	stream[12] = (stream[12] + 1) % 4
+	stream[14] = (stream[14] + 1) % 4
+	stream[16] = (stream[16] + 1) % 4
+	hits, _ := det.Process(nil, stream, 0)
+	if len(hits) != 0 {
+		t.Errorf("hits = %v, want []", hits)
+	}
+}

--- a/internal/radio/p25/phase1/tsbk.go
+++ b/internal/radio/p25/phase1/tsbk.go
@@ -1,0 +1,63 @@
+package phase1
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+)
+
+// TSBK is one Trunking Signaling Block parsed from the TSDU. The header
+// fields are common to every opcode; Payload holds the 8 opcode-specific
+// octets (bits 16..79 of the 96-bit info block).
+type TSBK struct {
+	LB      bool   // Last Block in TSDU sequence
+	P       bool   // Protected
+	Opcode  Opcode // 6-bit opcode
+	MFID    uint8  // Manufacturer ID (0x00 = standard)
+	Payload [8]byte
+}
+
+// CRCError is returned by ParseTSBK when the trailer CRC fails.
+var CRCError = fmt.Errorf("p25/phase1: TSBK CRC check failed")
+
+// ParseTSBK consumes 96 info bits (12 bytes) and returns a parsed block.
+// The trailer CRC is verified; CRCError is returned on mismatch (the
+// partially-parsed TSBK is still returned so callers can log the contents
+// for diagnostics).
+func ParseTSBK(info []byte) (TSBK, error) {
+	if len(info) != 12 {
+		return TSBK{}, fmt.Errorf("p25/phase1: TSBK info must be 12 bytes, got %d", len(info))
+	}
+	var t TSBK
+	t.LB = info[0]&0x80 != 0
+	t.P = info[0]&0x40 != 0
+	t.Opcode = Opcode(info[0] & 0x3F)
+	t.MFID = info[1]
+	copy(t.Payload[:], info[2:10])
+
+	storedCRC := binary.BigEndian.Uint16(info[10:12]) ^ 0xFFFF
+	want := framing.CRCCCITT(info[:10])
+	if storedCRC != want {
+		return t, CRCError
+	}
+	return t, nil
+}
+
+// AssembleTSBK constructs a 12-byte TSBK info block from the structured
+// fields. Used in tests and for any future encoder work.
+func AssembleTSBK(t TSBK) []byte {
+	out := make([]byte, 12)
+	if t.LB {
+		out[0] |= 0x80
+	}
+	if t.P {
+		out[0] |= 0x40
+	}
+	out[0] |= byte(t.Opcode) & 0x3F
+	out[1] = t.MFID
+	copy(out[2:10], t.Payload[:])
+	crc := framing.CRCCCITT(out[:10]) ^ 0xFFFF
+	binary.BigEndian.PutUint16(out[10:12], crc)
+	return out
+}

--- a/internal/radio/p25/phase1/tsbk_test.go
+++ b/internal/radio/p25/phase1/tsbk_test.go
@@ -1,0 +1,84 @@
+package phase1
+
+import (
+	"testing"
+)
+
+func TestTSBKAssembleParseRoundTrip(t *testing.T) {
+	in := TSBK{
+		LB:     true,
+		P:      false,
+		Opcode: OpGroupVoiceChannelGrant,
+		MFID:   0x00,
+		Payload: [8]byte{
+			0x80, 0x10, 0x05, 0x12, 0x34, 0xAB, 0xCD, 0xEF,
+		},
+	}
+	bytes := AssembleTSBK(in)
+	if len(bytes) != 12 {
+		t.Fatalf("AssembleTSBK = %d bytes, want 12", len(bytes))
+	}
+	out, err := ParseTSBK(bytes)
+	if err != nil {
+		t.Fatalf("ParseTSBK: %v", err)
+	}
+	if out != in {
+		t.Errorf("round-trip mismatch:\n got %+v\nwant %+v", out, in)
+	}
+}
+
+func TestTSBKDetectsCRCError(t *testing.T) {
+	in := TSBK{LB: true, Opcode: OpRFSSStatusBroadcast}
+	b := AssembleTSBK(in)
+	b[5] ^= 0x01
+	_, err := ParseTSBK(b)
+	if err != CRCError {
+		t.Errorf("expected CRCError, got %v", err)
+	}
+}
+
+func TestParseGroupVoiceChannelGrant(t *testing.T) {
+	p := [8]byte{0x80, 0x40, 0x05, 0x12, 0x34, 0xAB, 0xCD, 0xEF}
+	g := ParseGroupVoiceChannelGrant(p)
+	if g.ServiceOptions != 0x80 {
+		t.Errorf("ServiceOptions = %02X", g.ServiceOptions)
+	}
+	if g.ChannelID != 0x4 || g.ChannelNumber != 0x005 {
+		t.Errorf("Channel = %X.%03X, want 4.005", g.ChannelID, g.ChannelNumber)
+	}
+	if g.GroupAddress != 0x1234 {
+		t.Errorf("Group = %04X, want 1234", g.GroupAddress)
+	}
+	if g.SourceID != 0xABCDEF {
+		t.Errorf("Source = %06X, want ABCDEF", g.SourceID)
+	}
+}
+
+func TestParseNetworkStatusBroadcast(t *testing.T) {
+	// WACN = 0xABCDE (20-bit), SystemID = 0x123 (12-bit).
+	p := [8]byte{0xAB, 0xCD, 0xE1, 0x23, 0x40, 0x10, 0x00, 0x42}
+	n := ParseNetworkStatusBroadcast(p)
+	if n.WACN != 0xABCDE {
+		t.Errorf("WACN = %05X, want ABCDE", n.WACN)
+	}
+	if n.SystemID != 0x123 {
+		t.Errorf("SystemID = %03X, want 123", n.SystemID)
+	}
+	if n.ChannelID != 0x4 || n.ChannelNumber != 0x010 {
+		t.Errorf("Channel = %X.%03X", n.ChannelID, n.ChannelNumber)
+	}
+}
+
+func TestOpcodeString(t *testing.T) {
+	cases := map[Opcode]string{
+		OpGroupVoiceChannelGrant: "GroupVoiceChannelGrant",
+		OpRFSSStatusBroadcast:    "RFSSStatusBroadcast",
+		OpNetworkStatusBroadcast: "NetworkStatusBroadcast",
+		Opcode(0x42):             "Opcode(42)",
+	}
+	for op, want := range cases {
+		if got := op.String(); got != want {
+			t.Errorf("Opcode(%02X).String() = %s, want %s", uint8(op), got, want)
+		}
+	}
+}


### PR DESCRIPTION
Builds out Phase 3 from `docs/phases.md`: the FEC/framing primitives
that DMR/NXDN will reuse, plus the P25 Phase 1 control-channel
framing layer. No external dependencies added.

## `internal/radio/framing` — shared primitives
- `bits.go` — MSB-first bit packing, dibit↔bit, popcount, Hamming
  distance.
- `crc.go` — CRC-CCITT/FALSE (poly 0x1021, init 0xFFFF, no XOR).
  Verified against the standard `0x29B1` vector for `"123456789"`.
- `hamming.go` — Hamming(15,11,3) encoder + single-error-correcting
  decoder. Test sweeps every 11-bit input and every single-bit error
  position.
- `golay.go` — Extended Golay(24,12,8) encoder + minimum-distance
  decoder. Corrects up to three errors per the code's distance
  guarantee.
- `trellis.go` — Generic 4-state 1/2-rate convolutional encoder +
  hard-decision Viterbi, parameterised by next-state and output-dibit
  tables. The P25-specific trellis (TIA-102.BAAA Annex A) plugs in
  later by supplying its tables; the generic implementation is verified
  with the canonical (7,5)-octal polynomials.

## `internal/radio/p25/phase1` — P25 Phase 1 control channel
- `sync.go` — 48-bit Frame Sync Word as 24 dibits, sliding sync
  detector with configurable mismatch tolerance, and the TIA-102 C4FM
  symbol-to-dibit mapping (+3→01, +1→00, -1→10, -3→11).
- `nid.go` — Network ID parser: 12-bit NAC + 4-bit DUID enum
  (HDU/TDU/LDU1/TSDU/LDU2/PDU/TDULC) with `String()`.
- `tsbk.go` — Trunking Signaling Block parse/assemble. The 16-bit
  CRC trailer is stored as the bitwise complement per TIA-102.AABF.
- `opcodes.go` — TSBK opcode constants (OP25 mapping) and payload
  parsers for `GroupVoiceChannelGrant` (0x00),
  `GroupVoiceChannelUpdate` (0x02), `NetworkStatusBroadcast` (0x3B),
  and `RFSSStatusBroadcast` (0x3A).
- `control.go` — Control-channel state machine: consumes a dibit
  window, runs FSW detection, parses NIDs, and publishes
  `cc.locked` / `cc.lost` events on `internal/events.Bus`.

## Test plan
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `go test -race -count=1 ./...`
- [x] CRC against published vector for `"123456789"`
- [x] Hamming(15,11,3) full round-trip + single-error-correction sweep
- [x] Golay(24,12,8) round-trip + 3-bit error correction
- [x] Trellis encode→decode round-trip + 1-bit error tolerance
- [x] Sync detector locks on a clean FSW and tolerates configurable
      dibit mismatches
- [x] NID parse round-trip and `NIDFromDibits` helper
- [x] TSBK assemble/parse round-trip + CRC corruption detection
- [x] Per-opcode payload parsers decode synthetic fixtures
- [x] Control channel emits `cc.locked` on a TSDU-DUID NID and
      `cc.lost` on demand; ignores non-TSDU DUIDs

## Deferred to follow-up phases
- Full BCH(63,16,11) decoder for NID validation.
- P25-specific trellis tables (TIA-102.BAAA Annex A) and the TSBK
  block interleaver, so the control channel can run end-to-end on a
  live IQ recording.
- LDU1/LDU2 (voice frames) — they need Reed-Solomon and the IMBE
  decoder, both Phase 7 territory.
- P25 Phase 2 (TDMA H-DQPSK superframes) — separate phase.

https://claude.ai/code/session_01MQSV8EVnH6nsGUpcWep7UF

---
_Generated by [Claude Code](https://claude.ai/code/session_01MQSV8EVnH6nsGUpcWep7UF)_