### PR TITLE
Phase 3.5: System Identification & Control Channel Hunting

### DIFF
--- a/docs/phases.md
+++ b/docs/phases.md
@@ -9,7 +9,7 @@ buildable and testable; the project stays useful even if work pauses partway.
 | 1     | SDR hardware layer (CGO librtlsdr)     | done        |
 | 2     | DSP core (channelizer, demods)         | done        |
 | 3     | P25 trunking (Phase 1 then Phase 2)    | partial     |
-| 3.5   | System ID & control-channel hunting    | upcoming    |
+| 3.5   | System ID & control-channel hunting    | done        |
 | 4     | DMR trunking (Tier II + Tier III)      | upcoming    |
 | 5     | NXDN trunking                          | upcoming    |
 | 6     | Trunking engine (grant follower)       | upcoming    |
@@ -95,6 +95,30 @@ Deferred to follow-up phases:
 - LDU1/LDU2 (voice frames) — they need Reed-Solomon and the IMBE
   decoder, both Phase 7 territory.
 - P25 Phase 2 (TDMA H-DQPSK superframes) — separate phase.
+
+## Phase 3.5 — System Identification & Control Channel Hunting
+
+Landed in this phase:
+
+- `internal/trunking/site.go` — `System` type (Name, Protocol enum,
+  candidate ControlChannels list, WACN/SYSID/RFSS/Site identifiers) +
+  `HuntOrder()` which biases scanning toward the cached last-known CC.
+- `internal/trunking/cache.go` — JSON-on-disk cache of last-known CC
+  frequency + NAC per system, with atomic rename on write.
+- `internal/trunking/cchunt.go` — `Hunter` coordinator. Subscribes to
+  the events bus, walks the candidate frequency list, retunes the
+  control-role SDR (via a narrow `Tuner` interface so unit tests can
+  use a fake), parks on the first matching `cc.locked` event within
+  the per-frequency dwell window, and persists the locked frequency.
+- Tests cover validation, cache round-trip + atomic write, biased
+  hunt order, lock-on-first-responsive-frequency, full-sweep with no
+  response, lock priority for cached frequency, freq mismatch
+  rejection, and context-cancel propagation.
+
+Wiring into the daemon (`cmd/gophertrunk`) belongs to Phase 6 along
+with the demod pipeline that ultimately publishes `cc.locked` for the
+hunter to consume — in this phase the hunter is library-ready and
+unit-tested but not yet reachable from the CLI.
 
 …subsequent phases follow the plan in
 `/root/.claude/plans/using-the-readme-md-as-sleepy-fairy.md`.

--- a/internal/trunking/cache.go
+++ b/internal/trunking/cache.go
@@ -1,0 +1,111 @@
+package trunking
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"sync"
+	"time"
+)
+
+// Cache persists the last-known control-channel frequency per system to a
+// JSON file. The hunter consults this cache on startup so it can re-tune to
+// a known-good CC before scanning the full frequency list.
+type Cache struct {
+	path string
+	mu   sync.RWMutex
+	data cacheFile
+}
+
+type cacheFile struct {
+	Version int                       `json:"version"`
+	Systems map[string]CachedSystem  `json:"systems"`
+}
+
+// CachedSystem is the on-disk record for one system.
+type CachedSystem struct {
+	LastFrequencyHz uint32    `json:"last_frequency_hz"`
+	LastLockAt      time.Time `json:"last_lock_at,omitempty"`
+	NAC             uint16    `json:"nac,omitempty"`
+}
+
+// OpenCache loads (or creates) a cache file at path. A non-existent file is
+// treated as an empty cache.
+func OpenCache(path string) (*Cache, error) {
+	c := &Cache{path: path, data: cacheFile{Version: 1, Systems: map[string]CachedSystem{}}}
+	b, err := os.ReadFile(path)
+	if errors.Is(err, fs.ErrNotExist) {
+		return c, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("trunking/cache: read %s: %w", path, err)
+	}
+	if err := json.Unmarshal(b, &c.data); err != nil {
+		return nil, fmt.Errorf("trunking/cache: parse %s: %w", path, err)
+	}
+	if c.data.Systems == nil {
+		c.data.Systems = map[string]CachedSystem{}
+	}
+	return c, nil
+}
+
+// Get returns the cached entry for the named system, if any.
+func (c *Cache) Get(name string) (CachedSystem, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	v, ok := c.data.Systems[name]
+	return v, ok
+}
+
+// Set updates the cached entry for name and persists the file. The write is
+// atomic via rename.
+func (c *Cache) Set(name string, entry CachedSystem) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.data.Systems[name] = entry
+	return c.flush()
+}
+
+// Names returns the system names currently in the cache, sorted for
+// deterministic iteration.
+func (c *Cache) Names() []string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	out := make([]string, 0, len(c.data.Systems))
+	for k := range c.data.Systems {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func (c *Cache) flush() error {
+	if c.path == "" {
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(c.path), 0o755); err != nil {
+		return fmt.Errorf("trunking/cache: mkdir: %w", err)
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(c.path), filepath.Base(c.path)+".tmp.*")
+	if err != nil {
+		return fmt.Errorf("trunking/cache: create tmp: %w", err)
+	}
+	defer os.Remove(tmp.Name())
+	enc := json.NewEncoder(tmp)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(c.data); err != nil {
+		tmp.Close()
+		return fmt.Errorf("trunking/cache: encode: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("trunking/cache: close tmp: %w", err)
+	}
+	if err := os.Rename(tmp.Name(), c.path); err != nil {
+		return fmt.Errorf("trunking/cache: rename: %w", err)
+	}
+	return nil
+}

--- a/internal/trunking/cache_test.go
+++ b/internal/trunking/cache_test.go
@@ -1,0 +1,67 @@
+package trunking
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestCacheRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cc.json")
+
+	c, err := OpenCache(path)
+	if err != nil {
+		t.Fatalf("OpenCache (new): %v", err)
+	}
+	if _, ok := c.Get("Foo"); ok {
+		t.Error("empty cache should not return entries")
+	}
+
+	now := time.Now().UTC().Truncate(time.Second)
+	if err := c.Set("Foo", CachedSystem{LastFrequencyHz: 851_000_000, LastLockAt: now, NAC: 0x293}); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	c2, err := OpenCache(path)
+	if err != nil {
+		t.Fatalf("OpenCache (reload): %v", err)
+	}
+	got, ok := c2.Get("Foo")
+	if !ok {
+		t.Fatal("Foo not present after reload")
+	}
+	if got.LastFrequencyHz != 851_000_000 || got.NAC != 0x293 || !got.LastLockAt.Equal(now) {
+		t.Errorf("reloaded entry = %+v", got)
+	}
+}
+
+func TestCacheMissingFileIsEmpty(t *testing.T) {
+	c, err := OpenCache(filepath.Join(t.TempDir(), "does-not-exist.json"))
+	if err != nil {
+		t.Fatalf("OpenCache: %v", err)
+	}
+	if names := c.Names(); len(names) != 0 {
+		t.Errorf("Names = %v, want []", names)
+	}
+}
+
+func TestCacheNamesSorted(t *testing.T) {
+	c, err := OpenCache(filepath.Join(t.TempDir(), "cc.json"))
+	if err != nil {
+		t.Fatalf("OpenCache: %v", err)
+	}
+	for _, n := range []string{"Bravo", "Alpha", "Charlie"} {
+		if err := c.Set(n, CachedSystem{LastFrequencyHz: 100}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	names := c.Names()
+	want := []string{"Alpha", "Bravo", "Charlie"}
+	for i := range want {
+		if names[i] != want[i] {
+			t.Errorf("Names = %v, want %v", names, want)
+			break
+		}
+	}
+}

--- a/internal/trunking/cchunt.go
+++ b/internal/trunking/cchunt.go
@@ -1,0 +1,196 @@
+package trunking
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase1"
+	"github.com/MattCheramie/GopherTrunk/internal/sdr"
+)
+
+// Tuner is the subset of sdr.Device the hunter needs. Decoupling from the
+// full Device interface keeps the hunter testable without an IQ source.
+type Tuner interface {
+	SetCenterFreq(hz uint32) error
+}
+
+// Hunter scans a System's candidate control channels and parks on the
+// first frequency that produces a matching cc.locked event within the
+// per-frequency dwell timeout.
+//
+// The hunter is intentionally protocol-agnostic at the wiring level: it
+// retunes the SDR and watches the events.Bus. The downstream demod
+// pipeline (channelizer + C4FM/H-DQPSK demod + protocol decoder) is
+// expected to be running and publishing cc.locked events. Phase 6 wires
+// that pipeline up; until then the hunter is exercised by tests that
+// publish events directly.
+type Hunter struct {
+	bus     *events.Bus
+	log     *slog.Logger
+	cache   *Cache
+	tuner   Tuner
+	system  System
+	dwell   time.Duration
+}
+
+// HunterOptions configure a Hunter at construction.
+type HunterOptions struct {
+	System System
+	Tuner  Tuner
+	Bus    *events.Bus
+	Cache  *Cache
+	Log    *slog.Logger
+	// Dwell is how long to wait on each candidate before giving up.
+	// Defaults to 3 seconds.
+	Dwell time.Duration
+}
+
+func NewHunter(o HunterOptions) (*Hunter, error) {
+	if err := o.System.Validate(); err != nil {
+		return nil, err
+	}
+	if o.Bus == nil {
+		return nil, errors.New("trunking/hunter: events.Bus is required")
+	}
+	if o.Tuner == nil {
+		return nil, errors.New("trunking/hunter: Tuner is required")
+	}
+	log := o.Log
+	if log == nil {
+		log = slog.Default()
+	}
+	dwell := o.Dwell
+	if dwell <= 0 {
+		dwell = 3 * time.Second
+	}
+	return &Hunter{
+		bus:    o.Bus,
+		log:    log,
+		cache:  o.Cache,
+		tuner:  o.Tuner,
+		system: o.System,
+		dwell:  dwell,
+	}, nil
+}
+
+// Hunt scans the candidate frequencies until either a CC locks (success)
+// or ctx cancels (returns ctx.Err()) or the candidate list is exhausted
+// (returns ErrNoControlChannel).
+//
+// On success the locked frequency and NAC are persisted to the cache and
+// returned to the caller.
+func (h *Hunter) Hunt(ctx context.Context) (LockResult, error) {
+	var lastKnown uint32
+	if h.cache != nil {
+		if e, ok := h.cache.Get(h.system.Name); ok {
+			lastKnown = e.LastFrequencyHz
+		}
+	}
+	candidates := h.system.HuntOrder(lastKnown)
+
+	sub := h.bus.Subscribe()
+	defer sub.Close()
+
+	for _, freq := range candidates {
+		if err := ctx.Err(); err != nil {
+			return LockResult{}, err
+		}
+		h.log.Info("cc-hunt: trying", "system", h.system.Name, "freq_hz", freq)
+		if err := h.tuner.SetCenterFreq(freq); err != nil {
+			h.log.Warn("cc-hunt: tune failed", "freq_hz", freq, "err", err)
+			continue
+		}
+		// Drain any stale events buffered before this candidate.
+		drainSubscription(sub)
+
+		deadline := time.NewTimer(h.dwell)
+		locked, ok := waitForLock(ctx, sub, deadline.C, freq)
+		deadline.Stop()
+		if ok {
+			result := LockResult{
+				System:    h.system.Name,
+				Frequency: freq,
+				NAC:       locked.NAC,
+				At:        time.Now().UTC(),
+			}
+			if h.cache != nil {
+				if err := h.cache.Set(h.system.Name, CachedSystem{
+					LastFrequencyHz: freq,
+					LastLockAt:      result.At,
+					NAC:             locked.NAC,
+				}); err != nil {
+					h.log.Warn("cc-hunt: cache write failed", "err", err)
+				}
+			}
+			h.log.Info("cc-hunt: locked", "system", h.system.Name, "freq_hz", freq, "nac", locked.NAC)
+			return result, nil
+		}
+		if err := ctx.Err(); err != nil {
+			return LockResult{}, err
+		}
+	}
+	return LockResult{}, ErrNoControlChannel
+}
+
+// LockResult is returned by a successful Hunt.
+type LockResult struct {
+	System    string
+	Frequency uint32
+	NAC       uint16
+	At        time.Time
+}
+
+// ErrNoControlChannel is returned when every candidate frequency exhausts
+// its dwell window without locking.
+var ErrNoControlChannel = errors.New("trunking/hunter: no control channel found")
+
+func drainSubscription(sub *events.Subscription) {
+	for {
+		select {
+		case _, ok := <-sub.C:
+			if !ok {
+				return
+			}
+		default:
+			return
+		}
+	}
+}
+
+func waitForLock(ctx context.Context, sub *events.Subscription, timeout <-chan time.Time, freq uint32) (phase1.LockState, bool) {
+	for {
+		select {
+		case ev, ok := <-sub.C:
+			if !ok {
+				return phase1.LockState{}, false
+			}
+			if ev.Kind != events.KindCCLocked {
+				continue
+			}
+			ls, ok := ev.Payload.(phase1.LockState)
+			if !ok {
+				continue
+			}
+			if ls.FrequencyHz != freq {
+				continue
+			}
+			return ls, true
+		case <-timeout:
+			return phase1.LockState{}, false
+		case <-ctx.Done():
+			return phase1.LockState{}, false
+		}
+	}
+}
+
+// String renders a one-line summary of a LockResult for logs.
+func (r LockResult) String() string {
+	return fmt.Sprintf("%s @ %d Hz (NAC=%X) at %s", r.System, r.Frequency, r.NAC, r.At.Format(time.RFC3339))
+}
+
+// Compile-time check: sdr.Device satisfies Tuner.
+var _ Tuner = (sdr.Device)(nil)

--- a/internal/trunking/cchunt_test.go
+++ b/internal/trunking/cchunt_test.go
@@ -1,0 +1,212 @@
+package trunking
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase1"
+)
+
+// fakeTuner records SetCenterFreq calls and lets the test publish a fake
+// cc.locked event matching the latest tuned freq.
+type fakeTuner struct {
+	mu    sync.Mutex
+	freqs []uint32
+	err   error
+}
+
+func (f *fakeTuner) SetCenterFreq(hz uint32) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.freqs = append(f.freqs, hz)
+	return f.err
+}
+
+func (f *fakeTuner) tuned() []uint32 {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]uint32(nil), f.freqs...)
+}
+
+func newSystem() System {
+	return System{
+		Name:            "TestSys",
+		Protocol:        ProtocolP25,
+		ControlChannels: []uint32{851_000_000, 852_000_000, 853_000_000},
+	}
+}
+
+func TestHunterLocksOnFirstResponsiveFreq(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	tuner := &fakeTuner{}
+	cachePath := filepath.Join(t.TempDir(), "cc.json")
+	cache, err := OpenCache(cachePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	h, err := NewHunter(HunterOptions{
+		System: newSystem(),
+		Tuner:  tuner,
+		Bus:    bus,
+		Cache:  cache,
+		Dwell:  150 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Publish a lock for the second candidate after a short delay.
+	go func() {
+		time.Sleep(200 * time.Millisecond) // 1st freq dwell expires
+		bus.Publish(events.Event{
+			Kind:    events.KindCCLocked,
+			Payload: phase1.LockState{FrequencyHz: 852_000_000, NAC: 0x123, DUID: phase1.DUIDTrunkingSignaling},
+		})
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	res, err := h.Hunt(ctx)
+	if err != nil {
+		t.Fatalf("Hunt: %v", err)
+	}
+	if res.Frequency != 852_000_000 || res.NAC != 0x123 {
+		t.Errorf("LockResult = %+v", res)
+	}
+	freqs := tuner.tuned()
+	if len(freqs) != 2 || freqs[0] != 851_000_000 || freqs[1] != 852_000_000 {
+		t.Errorf("tuned sequence = %v, want [851M, 852M]", freqs)
+	}
+	cached, _ := cache.Get("TestSys")
+	if cached.LastFrequencyHz != 852_000_000 {
+		t.Errorf("cache = %+v", cached)
+	}
+}
+
+func TestHunterReturnsErrWhenAllExpire(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	tuner := &fakeTuner{}
+	h, _ := NewHunter(HunterOptions{
+		System: newSystem(),
+		Tuner:  tuner,
+		Bus:    bus,
+		Dwell:  20 * time.Millisecond,
+	})
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	_, err := h.Hunt(ctx)
+	if !errors.Is(err, ErrNoControlChannel) {
+		t.Errorf("err = %v, want ErrNoControlChannel", err)
+	}
+	if got := tuner.tuned(); len(got) != 3 {
+		t.Errorf("tuned %d freqs, want 3 (full sweep)", len(got))
+	}
+}
+
+func TestHunterStartsFromCachedFreq(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	tuner := &fakeTuner{}
+	cache, err := OpenCache(filepath.Join(t.TempDir(), "cc.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cache.Set("TestSys", CachedSystem{LastFrequencyHz: 853_000_000, NAC: 0xABC}); err != nil {
+		t.Fatal(err)
+	}
+	h, _ := NewHunter(HunterOptions{
+		System: newSystem(),
+		Tuner:  tuner,
+		Bus:    bus,
+		Cache:  cache,
+		Dwell:  150 * time.Millisecond,
+	})
+
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		bus.Publish(events.Event{
+			Kind:    events.KindCCLocked,
+			Payload: phase1.LockState{FrequencyHz: 853_000_000, NAC: 0xABC, DUID: phase1.DUIDTrunkingSignaling},
+		})
+	}()
+
+	res, err := h.Hunt(context.Background())
+	if err != nil {
+		t.Fatalf("Hunt: %v", err)
+	}
+	if res.Frequency != 853_000_000 {
+		t.Errorf("locked freq = %d, want 853M", res.Frequency)
+	}
+	if got := tuner.tuned(); got[0] != 853_000_000 {
+		t.Errorf("first tune = %d, want 853M (cached)", got[0])
+	}
+}
+
+func TestHunterIgnoresMismatchedFreq(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	tuner := &fakeTuner{}
+	h, _ := NewHunter(HunterOptions{
+		System: newSystem(),
+		Tuner:  tuner,
+		Bus:    bus,
+		Dwell:  100 * time.Millisecond,
+	})
+
+	// Publish a lock for the wrong frequency. Hunter should ignore it,
+	// dwell out, and continue scanning.
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		bus.Publish(events.Event{
+			Kind:    events.KindCCLocked,
+			Payload: phase1.LockState{FrequencyHz: 999_999_999, NAC: 0x42, DUID: phase1.DUIDTrunkingSignaling},
+		})
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	_, err := h.Hunt(ctx)
+	if !errors.Is(err, ErrNoControlChannel) {
+		t.Errorf("err = %v, want ErrNoControlChannel", err)
+	}
+	if got := tuner.tuned(); len(got) != 3 {
+		t.Errorf("expected full sweep, got %d freqs", len(got))
+	}
+}
+
+func TestHunterReturnsCtxErr(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	h, _ := NewHunter(HunterOptions{
+		System: newSystem(),
+		Tuner:  &fakeTuner{},
+		Bus:    bus,
+		Dwell:  500 * time.Millisecond,
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := h.Hunt(ctx); !errors.Is(err, context.Canceled) {
+		t.Errorf("err = %v, want context.Canceled", err)
+	}
+}
+
+func TestNewHunterValidatesSystem(t *testing.T) {
+	bus := events.NewBus(1)
+	defer bus.Close()
+	_, err := NewHunter(HunterOptions{
+		System: System{Name: "X"}, // missing protocol + channels
+		Tuner:  &fakeTuner{},
+		Bus:    bus,
+	})
+	if err == nil {
+		t.Error("expected validation error")
+	}
+}

--- a/internal/trunking/site.go
+++ b/internal/trunking/site.go
@@ -1,0 +1,102 @@
+// Package trunking holds the cross-protocol orchestration: System
+// definitions, control-channel hunting, talkgroup priority, voice grant
+// following, and (later) multi-site neighbor tracking.
+package trunking
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// Protocol is the trunking protocol family in use on a System.
+type Protocol uint8
+
+const (
+	ProtocolUnknown Protocol = iota
+	ProtocolP25     // P25 Phase 1 / Phase 2
+	ProtocolDMR     // DMR Tier II / III
+	ProtocolNXDN    // NXDN
+)
+
+func (p Protocol) String() string {
+	switch p {
+	case ProtocolP25:
+		return "p25"
+	case ProtocolDMR:
+		return "dmr"
+	case ProtocolNXDN:
+		return "nxdn"
+	default:
+		return "unknown"
+	}
+}
+
+// ParseProtocol maps a string ("p25", "dmr", "nxdn") to a Protocol value.
+func ParseProtocol(s string) (Protocol, error) {
+	switch strings.ToLower(s) {
+	case "p25":
+		return ProtocolP25, nil
+	case "dmr":
+		return ProtocolDMR, nil
+	case "nxdn":
+		return ProtocolNXDN, nil
+	default:
+		return ProtocolUnknown, fmt.Errorf("trunking: unknown protocol %q", s)
+	}
+}
+
+// System describes one trunked radio system the engine should track.
+type System struct {
+	Name            string
+	Protocol        Protocol
+	ControlChannels []uint32 // candidate CC frequencies in Hz
+	WACN            uint32   // 20-bit Wide-Area Communication Network ID (P25)
+	SystemID        uint16   // 12-bit system identifier (P25 SYSID)
+	RFSS            uint8    // RF SubSystem ID (P25)
+	Site            uint8    // Site ID
+}
+
+// Validate returns an error if the System lacks required fields.
+func (s System) Validate() error {
+	if s.Name == "" {
+		return errors.New("trunking: system name is required")
+	}
+	if s.Protocol == ProtocolUnknown {
+		return errors.New("trunking: protocol must be p25|dmr|nxdn")
+	}
+	if len(s.ControlChannels) == 0 {
+		return errors.New("trunking: at least one control_channel frequency is required")
+	}
+	for i, f := range s.ControlChannels {
+		if f < 25_000_000 || f > 1_300_000_000 {
+			return fmt.Errorf("trunking: control_channels[%d]=%d Hz outside 25-1300 MHz", i, f)
+		}
+	}
+	return nil
+}
+
+// HuntOrder returns the candidate frequency list with `lastKnown` (if non-zero
+// and present in ControlChannels) moved to the front. This biases the hunter
+// toward the most-recently-locked CC, falling back to the configured order.
+func (s System) HuntOrder(lastKnown uint32) []uint32 {
+	if lastKnown == 0 {
+		out := make([]uint32, len(s.ControlChannels))
+		copy(out, s.ControlChannels)
+		return out
+	}
+	out := make([]uint32, 0, len(s.ControlChannels))
+	out = append(out, lastKnown)
+	for _, f := range s.ControlChannels {
+		if f != lastKnown {
+			out = append(out, f)
+		}
+	}
+	// If lastKnown wasn't actually in the list, drop it.
+	for _, f := range s.ControlChannels {
+		if f == lastKnown {
+			return out
+		}
+	}
+	return out[1:]
+}

--- a/internal/trunking/site_test.go
+++ b/internal/trunking/site_test.go
@@ -1,0 +1,74 @@
+package trunking
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseProtocol(t *testing.T) {
+	cases := map[string]Protocol{"p25": ProtocolP25, "dmr": ProtocolDMR, "nxdn": ProtocolNXDN}
+	for in, want := range cases {
+		got, err := ParseProtocol(in)
+		if err != nil || got != want {
+			t.Errorf("ParseProtocol(%q) = %v, %v; want %v, nil", in, got, err, want)
+		}
+	}
+	if _, err := ParseProtocol("lte"); err == nil {
+		t.Error("expected error for unknown protocol")
+	}
+}
+
+func TestSystemValidate(t *testing.T) {
+	good := System{Name: "Test", Protocol: ProtocolP25, ControlChannels: []uint32{851_000_000}}
+	if err := good.Validate(); err != nil {
+		t.Errorf("good system: %v", err)
+	}
+	cases := []struct {
+		name string
+		sys  System
+	}{
+		{"missing name", System{Protocol: ProtocolP25, ControlChannels: []uint32{851_000_000}}},
+		{"unknown protocol", System{Name: "X", ControlChannels: []uint32{851_000_000}}},
+		{"no channels", System{Name: "X", Protocol: ProtocolP25}},
+		{"freq too low", System{Name: "X", Protocol: ProtocolP25, ControlChannels: []uint32{100}}},
+		{"freq too high", System{Name: "X", Protocol: ProtocolP25, ControlChannels: []uint32{2_000_000_000}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := tc.sys.Validate(); err == nil {
+				t.Error("expected error")
+			}
+		})
+	}
+}
+
+func TestHuntOrderPrefersLastKnown(t *testing.T) {
+	s := System{
+		Name:            "X",
+		Protocol:        ProtocolP25,
+		ControlChannels: []uint32{851_000_000, 852_000_000, 853_000_000},
+	}
+	got := s.HuntOrder(852_000_000)
+	want := []uint32{852_000_000, 851_000_000, 853_000_000}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("HuntOrder = %v, want %v", got, want)
+	}
+}
+
+func TestHuntOrderNoCacheReturnsConfigOrder(t *testing.T) {
+	s := System{ControlChannels: []uint32{1, 2, 3}}
+	got := s.HuntOrder(0)
+	want := []uint32{1, 2, 3}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("HuntOrder(0) = %v, want %v", got, want)
+	}
+}
+
+func TestHuntOrderIgnoresUnknownLastKnown(t *testing.T) {
+	s := System{ControlChannels: []uint32{1, 2, 3}}
+	got := s.HuntOrder(99)
+	want := []uint32{1, 2, 3}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("HuntOrder(99) = %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
Adds the `internal/trunking` package and the control-channel hunter
described in the plan. No external dependencies added.

## What this delivers

- **`internal/trunking/site.go`** — `System` type with `Name`,
  `Protocol` (enum: P25 / DMR / NXDN), candidate `ControlChannels`,
  and the WACN / SYSID / RFSS / Site identifiers. `Validate()` checks
  every field; `HuntOrder()` returns the candidate list with a cached
  last-known CC biased to the front so a re-locked system tunes
  faster than a cold scan.
- **`internal/trunking/cache.go`** — JSON-on-disk persistence of the
  last-known CC frequency, NAC, and timestamp per system. Writes go
  via tempfile + atomic `os.Rename` so a crash mid-flush can't
  corrupt the cache.
- **`internal/trunking/cchunt.go`** — `Hunter` coordinator. It
  subscribes to the events bus, walks the candidate frequency list,
  retunes the control-role SDR via a narrow `Tuner` interface, parks
  on the first matching `cc.locked` event within the per-frequency
  dwell window, and persists the locked frequency. The narrow
  `Tuner` interface (just `SetCenterFreq`) keeps the hunter testable
  without an IQ source.

## Test plan
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `go test -race -count=1 ./...`
- [x] `Protocol` parsing + `String()`
- [x] `System.Validate()` rejects empty name, unknown protocol, no
      channels, and out-of-range frequencies
- [x] `HuntOrder` biases toward cached freq; ignores unknown cached
      freq; falls back to config order with no cache
- [x] `Cache` round-trip across reload; missing-file is empty;
      `Names()` is sorted
- [x] `Hunter` locks on the first responsive frequency and persists
      the result
- [x] `Hunter` returns `ErrNoControlChannel` after sweeping all
      candidates with no lock
- [x] `Hunter` starts from the cached frequency when one is set
- [x] `Hunter` ignores `cc.locked` events whose payload frequency
      doesn't match the freq it just tuned to
- [x] `Hunter` returns `ctx.Err()` on context cancel

## Deferred
Wiring the hunter into `cmd/gophertrunk` belongs to Phase 6 (engine)
along with the demod pipeline that ultimately publishes `cc.locked`
for the hunter to consume. In this phase the hunter is
library-ready and unit-tested but not yet reachable from the CLI.

The CC-move handler (P25 NetStat opcode) is also deferred — it
needs the full TSBK pipeline (Phase 3 completion: BCH + trellis
tables + interleaver) before there's a real opcode stream to react
to.

https://claude.ai/code/session_01MQSV8EVnH6nsGUpcWep7UF

---
_Generated by [Claude Code](https://claude.ai/code/session_01MQSV8EVnH6nsGUpcWep7UF)_