### PR TITLE
Phase 6: Trunking engine — talkgroup DB + priority + grant follower

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,13 @@ and decodes the control channels of P25, DMR, and NXDN trunked radio systems
 — with the engine pieces that follow voice grants, hold talkgroups by
 priority, and stream metadata + audio to a frontend layered on top.
 
-> **Status: under active development.** Phases 0 – 5 of the build plan have
+> **Status: under active development.** Phases 0 – 6 of the build plan have
 > landed (foundation, SDR hardware, DSP core, P25 Phase 1 control channel,
-> system-ID & CC hunter, DMR Tier III CSBK, NXDN frame structure). The full
-> phased roadmap lives in [`docs/phases.md`](docs/phases.md); the
-> architectural overview is in [`docs/architecture.md`](docs/architecture.md).
+> system-ID & CC hunter, DMR Tier III CSBK, NXDN frame structure, and the
+> trunking engine — talkgroup DB + priority preemption + voice-device
+> allocator + grant follower). The full phased roadmap lives in
+> [`docs/phases.md`](docs/phases.md); the architectural overview is in
+> [`docs/architecture.md`](docs/architecture.md).
 
 ## What's built so far
 
@@ -24,14 +26,19 @@ priority, and stream metadata + audio to a frontend layered on top.
 | DMR (Tier III)    | All 9 ETSI sync patterns, burst layout (132 dibits), Color Code + Data Type, CSBK with CRC, payload parsers for TalkGroup/Private Voice grants + Aloha + AdjacentSiteStatus + SystemInfoBroadcast, control-channel state machine |
 | NXDN              | 192-dibit frame layout (4800 BFSK / 9600 4-FSK), LICH parse with parity + 16-bit doubled-wire decoder, FSW correlator, CAC parser with CRC, RCCH opcode enum + payload parsers, control-channel state machine |
 | Orchestration     | In-process pub/sub event bus, `System` model, JSON-on-disk last-known-CC cache, control-channel `Hunter` that retunes the SDR and parks on the first responsive frequency |
+| Trunking engine   | Cross-protocol `Grant` payload, Trunk-Recorder-format talkgroup DB (CSV + JSON), priority + preemption (emergency overrides, strict-higher), voice-device pool allocator, central state machine emitting `CallStart` / `CallEnd` events with a watchdog for silent calls |
 | Daemon            | `cmd/gophertrunk` with `version`, `sdr list`, and `run` subcommands; YAML config; `log/slog`; signal-driven shutdown |
 
 ## What's intentionally deferred
 
 The build plan calls these out by phase; the most visible items still ahead:
 
-- Wiring the demod pipeline → control-channel state machine inside the
-  daemon process (Phase 6 — the trunking engine).
+- Wiring the demod pipeline (channelizer → demod → protocol decoder) and
+  the trunking engine into `cmd/gophertrunk run` so the daemon does
+  end-to-end CC hunt → grant follow → audio.
+- A composer that subscribes to `CallStart` events, spins up a per-call
+  demod chain on the bound Voice device, calls `Engine.Touch` on each
+  voice frame, and `Engine.EndCall` on a release announcement.
 - BCH(63,16,11) for full P25 NID validation; P25-specific trellis tables and
   the TSBK block interleaver (so the P25 Phase 1 control channel can decode
   live captures end-to-end).

--- a/README.md
+++ b/README.md
@@ -1,18 +1,142 @@
-# GopherTrunk
-A headless, low-latency trunking engine that manages hardware pools and decodes P25/DMR control channels.
-GopherTrunk 📻🐹
-GopherTrunk is a high-performance, concurrent digital trunking scanner engine written in Go. It leverages the power of Go's goroutines to manage multiple RTL-SDR dongles simultaneously, allowing for seamless tracking of P25, DMR, and NXDN trunked radio systems.
-✨ Features
-Native Concurrency: Designed from the ground up to use Go channels for low-latency IQ data processing.
-Multi-SDR Pool: Auto-discovery and role assignment for multiple RTL-SDR devices (Control vs. Voice).
-Protocol Support (Planned):
-P25 Phase 1 & 2 (C4FM/QPSK)
-DMR (Tier II & III)
-NXDN (4800/9600 baud)
-Headless Architecture: Core engine runs as a daemon with a gRPC/Websocket API for frontend integration.
-Priority Tracking: Intelligent talkgroup preemption based on user-defined priority levels.
-🛠 Tech Stack
-Language: Go (Golang)
-Hardware Interface: libusb / CGO wrappers for RTL-SDR
-DSP: Custom Go-based polyphase channelizers and demodulators
-API: gRPC & Protobuf for metadata and audio streaming
+# GopherTrunk 📻🐹
+
+A headless, low-latency digital-trunking scanner engine in Go.
+
+GopherTrunk manages a pool of RTL-SDR dongles, runs a custom Go DSP pipeline,
+and decodes the control channels of P25, DMR, and NXDN trunked radio systems
+— with the engine pieces that follow voice grants, hold talkgroups by
+priority, and stream metadata + audio to a frontend layered on top.
+
+> **Status: under active development.** Phases 0 – 5 of the build plan have
+> landed (foundation, SDR hardware, DSP core, P25 Phase 1 control channel,
+> system-ID & CC hunter, DMR Tier III CSBK, NXDN frame structure). The full
+> phased roadmap lives in [`docs/phases.md`](docs/phases.md); the
+> architectural overview is in [`docs/architecture.md`](docs/architecture.md).
+
+## What's built so far
+
+| Area              | Component                                                  |
+| ----------------- | ---------------------------------------------------------- |
+| Hardware          | CGO `librtlsdr` binding, multi-device pool, role assignment, DC blocker, IQ-imbalance correction, file-backed IQ replay (mock) |
+| DSP               | Polyphase channelizer, FIR + Kaiser LPF designer + RRC, CIC, halfband, AGC, rational resampler, FM / C4FM / H-DQPSK demods, Mueller-Müller clock recovery, frame-sync correlator |
+| FEC primitives    | CRC-CCITT/FALSE, Hamming(15,11,3), Hamming(13,9,3), extended Golay(24,12,8), BPTC(196,96), 4-state ½-rate Viterbi |
+| P25 Phase 1       | 48-bit FSW + sync detector, NID parser (NAC + DUID), TSBK with CRC trailer, payload parsers for GroupVoiceChannelGrant / Update / NetworkStatus / RFSSStatus, control-channel state machine |
+| DMR (Tier III)    | All 9 ETSI sync patterns, burst layout (132 dibits), Color Code + Data Type, CSBK with CRC, payload parsers for TalkGroup/Private Voice grants + Aloha + AdjacentSiteStatus + SystemInfoBroadcast, control-channel state machine |
+| NXDN              | 192-dibit frame layout (4800 BFSK / 9600 4-FSK), LICH parse with parity + 16-bit doubled-wire decoder, FSW correlator, CAC parser with CRC, RCCH opcode enum + payload parsers, control-channel state machine |
+| Orchestration     | In-process pub/sub event bus, `System` model, JSON-on-disk last-known-CC cache, control-channel `Hunter` that retunes the SDR and parks on the first responsive frequency |
+| Daemon            | `cmd/gophertrunk` with `version`, `sdr list`, and `run` subcommands; YAML config; `log/slog`; signal-driven shutdown |
+
+## What's intentionally deferred
+
+The build plan calls these out by phase; the most visible items still ahead:
+
+- Wiring the demod pipeline → control-channel state machine inside the
+  daemon process (Phase 6 — the trunking engine).
+- BCH(63,16,11) for full P25 NID validation; P25-specific trellis tables and
+  the TSBK block interleaver (so the P25 Phase 1 control channel can decode
+  live captures end-to-end).
+- Hamming(20,8) over the DMR slot-type field; SACCH FEC + sub-frame
+  interleaver for NXDN.
+- Voice frame decoding — IMBE for P25 Phase 1 lands as Phase 7; AMBE+2
+  (P25 Phase 2 / DMR / NXDN) is gated behind a `mbelib` build tag for
+  patent-licensing clarity.
+- gRPC + WebSocket API surfaces (Phase 8), persistence + recording
+  (Phase 9), and hardening (metrics, reconnect, Docker — Phase 10).
+
+## ✨ Goals
+
+- **Native concurrency.** Goroutines + typed channels carry IQ from the
+  RTL-SDR async-read callback all the way through the DSP and protocol
+  pipelines.
+- **Multi-SDR pool.** Auto-discovery and Control / Voice role assignment
+  across multiple dongles, with serial-number hints honored.
+- **Protocols.** P25 Phase 1 & 2 (C4FM / H-DQPSK), DMR Tier II & III, NXDN
+  4800 / 9600 baud.
+- **Headless architecture.** Daemon with gRPC + WebSocket APIs for any
+  frontend; the engine itself stays API-agnostic via an in-process event
+  bus.
+- **Priority tracking.** Talkgroup preemption based on user-defined
+  priority levels; multi-site neighbor following.
+
+## 🛠 Tech stack
+
+- **Language:** Go 1.24+
+- **Hardware:** `libusb-1.0` + `librtlsdr` via CGO (custom thin binding)
+- **DSP:** `gonum/dsp/fourier` for FFT, custom polyphase channelizer,
+  filters, and demodulators
+- **Logging:** `log/slog` (stdlib)
+- **API (planned):** gRPC + Protobuf for metadata; server-streaming RPC
+  for audio; WebSocket bridge for browser frontends
+
+## Quick start
+
+### Prerequisites
+
+```sh
+sudo apt-get install librtlsdr-dev libusb-1.0-0-dev
+```
+
+See [`docs/hardware.md`](docs/hardware.md) for `udev` rules and DVB
+blacklisting on Linux.
+
+### Build and test
+
+```sh
+make build     # produces ./bin/gophertrunk
+make test      # go test -race ./...
+make vet
+```
+
+### Smoke test
+
+```sh
+./bin/gophertrunk version
+./bin/gophertrunk sdr list      # enumerates attached RTL-SDR dongles
+./bin/gophertrunk run --config config.yaml
+```
+
+A minimal `config.yaml`:
+
+```yaml
+log:
+  level: info
+  format: text
+sdr:
+  sample_rate: 2400000
+  devices:
+    - serial: "00000001"
+      role: control
+      ppm: -2
+trunking:
+  systems:
+    - name: ExampleP25
+      protocol: p25
+      control_channels: [851000000, 852000000]
+```
+
+## Repository layout
+
+```
+cmd/gophertrunk/        daemon entrypoint + sdr list CLI
+internal/sdr/           Driver interface, pool, CGO librtlsdr, mock
+internal/dsp/           Channelizer, filters, demods, sync, FFT
+internal/radio/         framing/ + p25/phase1/ + dmr/ + nxdn/
+internal/trunking/      System, last-known-CC cache, CC Hunter
+internal/events/        In-process pub/sub bus
+internal/config/        YAML loader
+docs/                   architecture.md · phases.md · hardware.md
+```
+
+## Contributing
+
+The project is being built phase by phase per
+[`docs/phases.md`](docs/phases.md). Each phase is independently buildable
+and testable. PRs that complete deferred items in earlier phases (the
+"deferred" lists in `docs/phases.md`) are very welcome — the most useful
+near-term targets are the BCH + P25 trellis tables (so the P25 control
+channel decodes live IQ end-to-end) and the demod-pipeline composer that
+glues SDR → channelizer → demod → control-channel state machine.
+
+## License
+
+See [`LICENSE`](LICENSE).

--- a/docs/phases.md
+++ b/docs/phases.md
@@ -12,7 +12,7 @@ buildable and testable; the project stays useful even if work pauses partway.
 | 3.5   | System ID & control-channel hunting    | done        |
 | 4     | DMR trunking (Tier II + Tier III)      | partial     |
 | 5     | NXDN trunking                          | partial     |
-| 6     | Trunking engine (grant follower)       | upcoming    |
+| 6     | Trunking engine (grant follower)       | partial     |
 | 7a    | Voice passthrough (FM, raw frames)     | upcoming    |
 | 7b    | IMBE (P25 Phase 1, default)            | upcoming    |
 | 7c    | AMBE+2 (mbelib build tag, DVSI)        | upcoming    |
@@ -209,6 +209,71 @@ Deferred to follow-up phases:
 - Full RCCH state machine (paging, channel-grant follow, neighbor-
   list reaction) — Phase 6 along with the engine.
 - Voice frame AMBE+2 payloads — Phase 7.
+
+## Phase 6 — Trunking Engine (in progress)
+
+Landed in this phase:
+
+- `internal/trunking/grant.go` — Cross-protocol `Grant` payload type
+  (System, Protocol, GroupID, SourceID, FrequencyHz, ChannelID/Num,
+  Encrypted, Emergency, DataCall) used by P25/DMR/NXDN decoders to
+  publish to the events bus, plus `EndReason` enum and the
+  `CallStart` / `CallEnd` event payloads consumed by the API and
+  recorder layers.
+- `internal/trunking/talkgroup.go` — `TalkGroup` model + thread-safe
+  `TalkgroupDB` with Trunk-Recorder-style CSV loader (Decimal /
+  Alpha Tag / Mode / Tag / Group / Priority / Lockout — including
+  the "L" priority sentinel for inferred lockouts) and a JSON
+  loader.
+- `internal/trunking/priority.go` — `EffectivePriority(grant,
+  talkgroup)` + `CanPreempt(active, incoming)` with the
+  Trunk-Recorder convention: lower number = higher priority,
+  emergency = priority 0 (above everything), strict-higher
+  preemption (equal does NOT preempt), and lockout drops the
+  incoming grant outright.
+- `internal/trunking/voicepool.go` — `VoicePool` allocator over the
+  Voice-role SDR list (using the existing `Tuner` interface).
+  `FindFree` for first-fit allocation, `LowestPriorityActive` for
+  preemption decisions, `Bind` retunes + records an `ActiveCall`,
+  `Release` frees, `Touch` refreshes the watchdog timestamp.
+- `internal/trunking/engine.go` — Central state machine. Subscribes
+  to `events.KindGrant` at construction time so callers can publish
+  before `Run` starts, dispatches grants through lookup → priority
+  → pool, emits `events.KindCallStart` / `events.KindCallEnd`,
+  preempts strictly-lower-priority calls when the pool is full, and
+  runs a watchdog that ends silent calls after `CallTimeout`
+  (default 30 s).
+
+Tests cover Grant string formatting, talkgroup CSV + JSON round-
+trip including the Trunk-Recorder priority "L" sentinel, priority +
+preemption logic across emergency / lockout / equal / nil-talkgroup
+cases, voice-pool allocation + retuning + release + lowest-priority
+selection + watchdog touch, the engine's grant dispatch path
+(start-on-grant, drop-locked-out, drop-zero-frequency,
+preempt-lower-priority, hold-on-equal, emergency-preempts-anything,
+explicit EndCall, watchdog timeout via injected clock), and the Run
+loop dispatching events published on the bus.
+
+Bug caught and fixed during testing: the engine originally
+subscribed to the bus inside `Run`, which lost any grant published
+between `NewEngine` and the first `Run` iteration; moved the
+subscription into `NewEngine` with a paired `Close()` so the engine
+is reachable as soon as it's constructed.
+
+Deferred to follow-up phases:
+- Wiring protocol decoders (P25 phase1 / DMR tier3 / NXDN) to
+  publish `events.KindGrant` when they decode an actual grant
+  opcode — this is gated on completing the Phase 3 / 4 / 5
+  channel-coding deferrals (P25 trellis tables + interleaver, DMR
+  slot-type Hamming(20,8), NXDN SACCH FEC) and on a band-plan
+  resolver that converts (channel ID, channel number) → Hz.
+- Demod-pipeline composer that subscribes to `CallStart` events,
+  tunes a per-call demod chain on the bound Voice device, calls
+  `Engine.Touch` on every voice frame, and `Engine.EndCall` on
+  voice-channel release announcements or PTT-off.
+- Multi-site neighbor list + affiliation-based site selection
+  (extension to `internal/trunking/site.go`).
+- Daemon-side wiring of the Engine into `cmd/gophertrunk run`.
 
 …subsequent phases follow the plan in
 `/root/.claude/plans/using-the-readme-md-as-sleepy-fairy.md`.

--- a/internal/trunking/engine.go
+++ b/internal/trunking/engine.go
@@ -1,0 +1,246 @@
+package trunking
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+)
+
+// Engine is the central trunking state machine. It subscribes to
+// events.KindGrant, looks up the talkgroup, dispatches to the voice pool
+// (preempting lower-priority active calls when necessary), and emits
+// events.KindCallStart / events.KindCallEnd.
+//
+// The engine deliberately knows nothing about the demod pipeline — it
+// just tunes Voice devices and publishes structured events. Downstream
+// consumers (Phase 7 voice decoder, Phase 9 recorder) subscribe to the
+// CallStart / CallEnd events to do their work.
+type Engine struct {
+	bus        *events.Bus
+	log        *slog.Logger
+	pool       *VoicePool
+	talkgroups *TalkgroupDB
+	timeout    time.Duration
+	now        func() time.Time
+	sub        *events.Subscription
+
+	mu    sync.Mutex
+	calls map[string]*ActiveCall // by device serial; mirror of pool.active for fast access
+}
+
+// EngineOptions configure a new Engine.
+type EngineOptions struct {
+	Bus        *events.Bus
+	Log        *slog.Logger
+	VoicePool  *VoicePool
+	Talkgroups *TalkgroupDB
+	// CallTimeout is how long a call can run without a Touch before the
+	// watchdog ends it as EndReasonTimeout. Default 30 s.
+	CallTimeout time.Duration
+	// Now is injectable for tests; defaults to time.Now.
+	Now func() time.Time
+}
+
+// NewEngine validates opts and returns a ready-to-Run engine.
+func NewEngine(opts EngineOptions) (*Engine, error) {
+	if opts.Bus == nil {
+		return nil, errors.New("trunking/engine: events.Bus is required")
+	}
+	if opts.VoicePool == nil {
+		return nil, errors.New("trunking/engine: VoicePool is required")
+	}
+	if opts.Talkgroups == nil {
+		opts.Talkgroups = NewTalkgroupDB()
+	}
+	if opts.Log == nil {
+		opts.Log = slog.Default()
+	}
+	if opts.CallTimeout <= 0 {
+		opts.CallTimeout = 30 * time.Second
+	}
+	if opts.Now == nil {
+		opts.Now = time.Now
+	}
+	e := &Engine{
+		bus:        opts.Bus,
+		log:        opts.Log,
+		pool:       opts.VoicePool,
+		talkgroups: opts.Talkgroups,
+		timeout:    opts.CallTimeout,
+		now:        opts.Now,
+		calls:      make(map[string]*ActiveCall),
+	}
+	// Subscribe at construction time so callers can publish grants
+	// before Run starts without losing them.
+	e.sub = opts.Bus.Subscribe()
+	return e, nil
+}
+
+// Close releases the engine's subscription. Safe to call after Run returns.
+func (e *Engine) Close() {
+	if e.sub != nil {
+		e.sub.Close()
+		e.sub = nil
+	}
+}
+
+// Run drains grant events from the bus and runs the watchdog until ctx
+// cancels. Returns ctx.Err(). Run does NOT close the engine's
+// subscription; call Close when you're done with the engine.
+func (e *Engine) Run(ctx context.Context) error {
+	tick := time.NewTicker(500 * time.Millisecond)
+	defer tick.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			e.shutdown()
+			return ctx.Err()
+		case ev, ok := <-e.sub.C:
+			if !ok {
+				return nil
+			}
+			if ev.Kind != events.KindGrant {
+				continue
+			}
+			g, ok := ev.Payload.(Grant)
+			if !ok {
+				continue
+			}
+			e.HandleGrant(g)
+		case <-tick.C:
+			e.runWatchdog()
+		}
+	}
+}
+
+// HandleGrant is the engine's grant-dispatch entrypoint. It is exported
+// so tests can drive it directly without a running event loop.
+func (e *Engine) HandleGrant(g Grant) {
+	if g.At.IsZero() {
+		g.At = e.now()
+	}
+	if g.FrequencyHz == 0 {
+		e.log.Warn("dropping grant with zero frequency", "grant", g.String())
+		return
+	}
+	tg := e.talkgroups.Lookup(g.GroupID)
+	if tg != nil && tg.Lockout && !g.Emergency {
+		e.log.Info("grant locked out", "grant", g.String(), "tg", tg.AlphaTag)
+		return
+	}
+
+	// 1) Free device available? Allocate.
+	if free := e.pool.FindFree(); free != nil {
+		e.startCall(free, g, tg)
+		return
+	}
+	// 2) All busy. Look at the lowest-priority active call.
+	victim := e.pool.LowestPriorityActive()
+	if victim == nil {
+		// Shouldn't happen: pool was full but has no actives. Drop.
+		e.log.Warn("voice pool full but no actives", "grant", g.String())
+		return
+	}
+	if !CanPreempt(victim.Grant, victim.Talkgroup, g, tg) {
+		e.log.Info("no voice device available for grant", "grant", g.String())
+		return
+	}
+	// 3) Preempt: end victim, allocate freed device.
+	e.endCall(victim, EndReasonPreempted)
+	e.startCall(victim.Device, g, tg)
+}
+
+// EndCall is the explicit external signal that a call has ended (e.g.
+// the protocol decoder saw a channel-release announcement, or an upstream
+// test wants to release the device). reason is published in the CallEnd
+// event payload.
+func (e *Engine) EndCall(deviceSerial string, reason EndReason) bool {
+	e.mu.Lock()
+	ac, ok := e.calls[deviceSerial]
+	e.mu.Unlock()
+	if !ok {
+		return false
+	}
+	e.endCall(ac, reason)
+	return true
+}
+
+// Touch refreshes the LastHeardAt timestamp on the active call bound to
+// deviceSerial. The protocol decoder calls this every time it sees voice
+// activity on the followed frequency so the watchdog doesn't time it out.
+func (e *Engine) Touch(deviceSerial string) {
+	e.pool.Touch(deviceSerial, e.now())
+}
+
+// ActiveCalls returns a snapshot of every active call.
+func (e *Engine) ActiveCalls() []*ActiveCall { return e.pool.Active() }
+
+func (e *Engine) startCall(d *VoiceDevice, g Grant, tg *TalkGroup) {
+	ac, err := e.pool.Bind(d, g, tg, e.now())
+	if err != nil {
+		e.log.Warn("voice bind failed", "err", err, "grant", g.String())
+		return
+	}
+	e.mu.Lock()
+	e.calls[d.Serial] = ac
+	e.mu.Unlock()
+	e.bus.Publish(events.Event{
+		Kind: events.KindCallStart,
+		Payload: CallStart{
+			Grant:        g,
+			Talkgroup:    tg,
+			DeviceSerial: d.Serial,
+			StartedAt:    ac.StartedAt,
+		},
+	})
+	e.log.Info("call started",
+		"device", d.Serial,
+		"grant", g.String(),
+		"priority", EffectivePriority(g, tg))
+}
+
+func (e *Engine) endCall(ac *ActiveCall, reason EndReason) {
+	released := e.pool.Release(ac.Device.Serial)
+	if released == nil {
+		return // already released elsewhere
+	}
+	e.mu.Lock()
+	delete(e.calls, ac.Device.Serial)
+	e.mu.Unlock()
+	e.bus.Publish(events.Event{
+		Kind: events.KindCallEnd,
+		Payload: CallEnd{
+			Grant:        released.Grant,
+			Talkgroup:    released.Talkgroup,
+			DeviceSerial: ac.Device.Serial,
+			StartedAt:    released.StartedAt,
+			EndedAt:      e.now(),
+			Reason:       reason,
+		},
+	})
+	e.log.Info("call ended",
+		"device", ac.Device.Serial,
+		"grant", released.Grant.String(),
+		"reason", reason.String())
+}
+
+func (e *Engine) runWatchdog() {
+	now := e.now()
+	cutoff := now.Add(-e.timeout)
+	for _, ac := range e.pool.Active() {
+		if ac.LastHeardAt.Before(cutoff) {
+			e.endCall(ac, EndReasonTimeout)
+		}
+	}
+}
+
+func (e *Engine) shutdown() {
+	for _, ac := range e.pool.Active() {
+		e.endCall(ac, EndReasonNormal)
+	}
+}

--- a/internal/trunking/engine_test.go
+++ b/internal/trunking/engine_test.go
@@ -1,0 +1,300 @@
+package trunking
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+)
+
+type testBusCollector struct {
+	mu sync.Mutex
+	xs []events.Event
+}
+
+func (c *testBusCollector) drain(sub *events.Subscription, until int, deadline time.Duration) []events.Event {
+	t := time.NewTimer(deadline)
+	defer t.Stop()
+	for {
+		c.mu.Lock()
+		n := len(c.xs)
+		c.mu.Unlock()
+		if n >= until {
+			break
+		}
+		select {
+		case ev, ok := <-sub.C:
+			if !ok {
+				break
+			}
+			c.mu.Lock()
+			c.xs = append(c.xs, ev)
+			c.mu.Unlock()
+		case <-t.C:
+			return c.snapshot()
+		}
+	}
+	return c.snapshot()
+}
+
+func (c *testBusCollector) snapshot() []events.Event {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]events.Event, len(c.xs))
+	copy(out, c.xs)
+	return out
+}
+
+func mkEngine(t *testing.T, devices int) (*Engine, *VoicePool, *events.Bus, []*fakeVoiceTuner) {
+	t.Helper()
+	bus := events.NewBus(32)
+	pool, tuners := mkPool(devices)
+	e, err := NewEngine(EngineOptions{
+		Bus:         bus,
+		VoicePool:   pool,
+		Talkgroups:  NewTalkgroupDB(),
+		CallTimeout: 200 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return e, pool, bus, tuners
+}
+
+func TestEngineStartsCallOnGrant(t *testing.T) {
+	e, _, bus, tuners := mkEngine(t, 1)
+	defer bus.Close()
+
+	sub := bus.Subscribe()
+	defer sub.Close()
+	collector := &testBusCollector{}
+	go func() { collector.drain(sub, 1, 500*time.Millisecond) }()
+
+	g := Grant{System: "X", Protocol: "p25", GroupID: 100, FrequencyHz: 851_000_000}
+	e.HandleGrant(g)
+
+	evs := collector.drain(sub, 1, 500*time.Millisecond)
+	if len(evs) == 0 || evs[0].Kind != events.KindCallStart {
+		t.Fatalf("events = %+v", evs)
+	}
+	cs, ok := evs[0].Payload.(CallStart)
+	if !ok || cs.Grant.GroupID != 100 || cs.DeviceSerial != "A-voice" {
+		t.Errorf("CallStart payload = %+v", evs[0].Payload)
+	}
+	if got := tuners[0].tuned(); len(got) != 1 || got[0] != 851_000_000 {
+		t.Errorf("device retune = %v", got)
+	}
+}
+
+func TestEngineDropsLockedOutGrant(t *testing.T) {
+	e, _, bus, tuners := mkEngine(t, 1)
+	defer bus.Close()
+	e.talkgroups.Add(&TalkGroup{ID: 50, AlphaTag: "BLOCKED", Lockout: true})
+
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	e.HandleGrant(Grant{System: "X", Protocol: "p25", GroupID: 50, FrequencyHz: 1_000_000})
+
+	select {
+	case ev := <-sub.C:
+		t.Errorf("unexpected event for locked-out grant: %s", ev.Kind)
+	case <-time.After(50 * time.Millisecond):
+	}
+	if got := tuners[0].tuned(); len(got) != 0 {
+		t.Errorf("locked-out grant should not retune; got %v", got)
+	}
+}
+
+func TestEngineDropsZeroFrequencyGrant(t *testing.T) {
+	e, _, bus, _ := mkEngine(t, 1)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	e.HandleGrant(Grant{System: "X", GroupID: 100, FrequencyHz: 0})
+
+	select {
+	case ev := <-sub.C:
+		t.Errorf("unexpected event: %s", ev.Kind)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestEnginePreemptsLowerPriority(t *testing.T) {
+	e, _, bus, _ := mkEngine(t, 1)
+	defer bus.Close()
+	e.talkgroups.Add(&TalkGroup{ID: 100, Priority: 5, AlphaTag: "LOW"})
+	e.talkgroups.Add(&TalkGroup{ID: 200, Priority: 1, AlphaTag: "HIGH"})
+
+	sub := bus.Subscribe()
+	defer sub.Close()
+	collector := &testBusCollector{}
+
+	go collector.drain(sub, 3, 1*time.Second)
+
+	low := Grant{System: "X", Protocol: "p25", GroupID: 100, FrequencyHz: 851_000_000}
+	high := Grant{System: "X", Protocol: "p25", GroupID: 200, FrequencyHz: 852_000_000}
+
+	e.HandleGrant(low)
+	e.HandleGrant(high) // should preempt
+
+	evs := collector.drain(sub, 3, 1*time.Second)
+	if len(evs) < 3 {
+		t.Fatalf("got %d events, want >= 3 (start, end, start)", len(evs))
+	}
+	if evs[0].Kind != events.KindCallStart {
+		t.Errorf("evs[0] = %s, want call.start", evs[0].Kind)
+	}
+	if evs[1].Kind != events.KindCallEnd {
+		t.Errorf("evs[1] = %s, want call.end", evs[1].Kind)
+	} else if ce, ok := evs[1].Payload.(CallEnd); ok && ce.Reason != EndReasonPreempted {
+		t.Errorf("CallEnd reason = %s, want preempted", ce.Reason)
+	}
+	if evs[2].Kind != events.KindCallStart {
+		t.Errorf("evs[2] = %s, want call.start", evs[2].Kind)
+	} else if cs, ok := evs[2].Payload.(CallStart); ok && cs.Grant.GroupID != 200 {
+		t.Errorf("preempting grant.GroupID = %d, want 200", cs.Grant.GroupID)
+	}
+}
+
+func TestEngineDoesNotPreemptEqualPriority(t *testing.T) {
+	e, _, bus, _ := mkEngine(t, 1)
+	defer bus.Close()
+	e.talkgroups.Add(&TalkGroup{ID: 100, Priority: 3})
+	e.talkgroups.Add(&TalkGroup{ID: 200, Priority: 3})
+
+	g1 := Grant{GroupID: 100, FrequencyHz: 851_000_000}
+	g2 := Grant{GroupID: 200, FrequencyHz: 852_000_000}
+	e.HandleGrant(g1)
+	e.HandleGrant(g2) // should be dropped
+
+	if calls := e.ActiveCalls(); len(calls) != 1 || calls[0].Grant.GroupID != 100 {
+		t.Errorf("active = %+v, want only original call", calls)
+	}
+}
+
+func TestEngineEmergencyPreemptsAnything(t *testing.T) {
+	e, _, bus, _ := mkEngine(t, 1)
+	defer bus.Close()
+	e.talkgroups.Add(&TalkGroup{ID: 100, Priority: 1, AlphaTag: "TOP"})
+
+	g1 := Grant{GroupID: 100, FrequencyHz: 851_000_000}
+	emer := Grant{GroupID: 999, FrequencyHz: 853_000_000, Emergency: true}
+	e.HandleGrant(g1)
+	e.HandleGrant(emer)
+
+	calls := e.ActiveCalls()
+	if len(calls) != 1 || calls[0].Grant.GroupID != 999 {
+		t.Errorf("after emergency: active = %+v, want emergency call", calls)
+	}
+}
+
+func TestEngineExplicitEndCall(t *testing.T) {
+	e, pool, bus, _ := mkEngine(t, 1)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	g := Grant{GroupID: 100, FrequencyHz: 851_000_000}
+	e.HandleGrant(g)
+	d := pool.Active()[0].Device
+
+	if !e.EndCall(d.Serial, EndReasonNormal) {
+		t.Fatal("EndCall reported no active call")
+	}
+	if got := e.ActiveCalls(); len(got) != 0 {
+		t.Errorf("active after EndCall = %+v, want []", got)
+	}
+
+	// drain the call.start + call.end events
+	got := []events.Event{}
+	deadline := time.After(500 * time.Millisecond)
+loop:
+	for {
+		select {
+		case ev := <-sub.C:
+			got = append(got, ev)
+			if ev.Kind == events.KindCallEnd {
+				break loop
+			}
+		case <-deadline:
+			break loop
+		}
+	}
+	if len(got) < 2 {
+		t.Fatalf("events = %+v", got)
+	}
+	end, ok := got[len(got)-1].Payload.(CallEnd)
+	if !ok || end.Reason != EndReasonNormal {
+		t.Errorf("last event reason = %v", got[len(got)-1])
+	}
+}
+
+func TestEngineWatchdogTimesOutSilentCall(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	pool, _ := mkPool(1)
+	now := time.Unix(1000, 0)
+	clock := &fakeClock{t: now}
+	e, _ := NewEngine(EngineOptions{
+		Bus:         bus,
+		VoicePool:   pool,
+		Talkgroups:  NewTalkgroupDB(),
+		CallTimeout: 1 * time.Second,
+		Now:         clock.Now,
+	})
+
+	g := Grant{GroupID: 100, FrequencyHz: 851_000_000}
+	e.HandleGrant(g)
+	if len(e.ActiveCalls()) != 1 {
+		t.Fatal("call did not start")
+	}
+
+	// Advance the clock past the timeout and run the watchdog.
+	clock.t = clock.t.Add(2 * time.Second)
+	e.runWatchdog()
+	if got := e.ActiveCalls(); len(got) != 0 {
+		t.Errorf("watchdog should have ended the call; active = %+v", got)
+	}
+}
+
+func TestEngineRunDispatchesGrantEvents(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	pool, tuners := mkPool(1)
+	e, _ := NewEngine(EngineOptions{
+		Bus:         bus,
+		VoicePool:   pool,
+		Talkgroups:  NewTalkgroupDB(),
+		CallTimeout: 5 * time.Second,
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go e.Run(ctx)
+
+	bus.Publish(events.Event{
+		Kind:    events.KindGrant,
+		Payload: Grant{GroupID: 7, FrequencyHz: 851_000_000},
+	})
+
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if len(tuners[0].tuned()) > 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if got := tuners[0].tuned(); len(got) != 1 || got[0] != 851_000_000 {
+		t.Errorf("device retune = %v, want [851000000]", got)
+	}
+}
+
+type fakeClock struct {
+	t time.Time
+}
+
+func (c *fakeClock) Now() time.Time { return c.t }

--- a/internal/trunking/grant.go
+++ b/internal/trunking/grant.go
@@ -1,0 +1,100 @@
+package trunking
+
+import (
+	"fmt"
+	"time"
+)
+
+// Grant is the protocol-agnostic voice-channel grant payload published on
+// the events bus by P25/DMR/NXDN control-channel decoders. The trunking
+// engine subscribes to events of kind events.KindGrant and dispatches
+// them through the priority + voice-device pool.
+//
+// FrequencyHz must be filled in by the protocol layer (P25 derives it from
+// IdentifierUpdate band-plan TSBKs, DMR/NXDN from the configured System).
+// If FrequencyHz is zero, the engine logs and drops the grant.
+type Grant struct {
+	System      string // System name, matches trunking.System.Name
+	Protocol    string // "p25" / "dmr" / "nxdn"
+	GroupID     uint32 // talkgroup or destination subscriber address
+	SourceID    uint32 // originator (subscriber unit)
+	FrequencyHz uint32 // voice channel frequency
+	ChannelID   uint8  // raw channel ID (P25 band-plan ID, DMR LCN high)
+	ChannelNum  uint16 // raw channel number within the ID
+	Encrypted   bool
+	Emergency   bool
+	DataCall    bool // false = voice call (default)
+	At          time.Time
+}
+
+// String renders a one-line summary of a Grant for log output.
+func (g Grant) String() string {
+	flags := ""
+	if g.Encrypted {
+		flags += "E"
+	}
+	if g.Emergency {
+		flags += "!"
+	}
+	if g.DataCall {
+		flags += "D"
+	}
+	return fmt.Sprintf("%s/%s tg=%d src=%d freq=%d %s", g.System, g.Protocol, g.GroupID, g.SourceID, g.FrequencyHz, flags)
+}
+
+// EndReason classifies why a call ended; carried in CallEnd events so the
+// API layer can surface the cause to UIs.
+type EndReason uint8
+
+const (
+	EndReasonUnknown    EndReason = iota
+	EndReasonNormal               // CC announced channel release / talk-off
+	EndReasonTimeout              // engine watchdog fired (no recent activity)
+	EndReasonPreempted            // higher-priority grant kicked us off
+	EndReasonLockout              // talkgroup is locked out by policy
+	EndReasonNoVoiceSDR           // every Voice-role SDR was busy
+	EndReasonError
+)
+
+func (r EndReason) String() string {
+	switch r {
+	case EndReasonNormal:
+		return "normal"
+	case EndReasonTimeout:
+		return "timeout"
+	case EndReasonPreempted:
+		return "preempted"
+	case EndReasonLockout:
+		return "lockout"
+	case EndReasonNoVoiceSDR:
+		return "no-voice-sdr"
+	case EndReasonError:
+		return "error"
+	default:
+		return "unknown"
+	}
+}
+
+// CallStart is the payload of an events.KindCallStart event. The engine
+// publishes this once a Voice device has been retuned to the grant's
+// frequency; downstream pipelines (Phase 7 voice decoder, recorder) can
+// subscribe and start consuming IQ.
+type CallStart struct {
+	Grant        Grant
+	Talkgroup    *TalkGroup // resolved via the engine's TalkgroupDB; nil if unknown
+	DeviceSerial string     // which Voice SDR is following the call
+	StartedAt    time.Time
+}
+
+// CallEnd is the payload of an events.KindCallEnd event.
+type CallEnd struct {
+	Grant        Grant
+	Talkgroup    *TalkGroup
+	DeviceSerial string
+	StartedAt    time.Time
+	EndedAt      time.Time
+	Reason       EndReason
+}
+
+// Duration returns how long the call ran.
+func (c CallEnd) Duration() time.Duration { return c.EndedAt.Sub(c.StartedAt) }

--- a/internal/trunking/priority.go
+++ b/internal/trunking/priority.go
@@ -1,0 +1,39 @@
+package trunking
+
+// Priority resolution per Trunk-Recorder convention:
+//   - Talkgroup priority is an integer 1..10, lower = higher priority.
+//   - Priority 0 (the zero value) means "unset" → treated as lowest priority.
+//   - Lockout flag wins outright: a locked-out grant is dropped before
+//     priority comparison.
+//   - Emergency flag bumps priority to 0 (above the highest configured).
+
+const (
+	priorityEmergency = 0
+	priorityUnset     = 11 // anything ≥ 10 is "lowest"
+)
+
+// EffectivePriority returns the runtime priority used by the engine when
+// comparing grants. Lower number = higher priority.
+func EffectivePriority(g Grant, tg *TalkGroup) int {
+	if g.Emergency {
+		return priorityEmergency
+	}
+	if tg == nil || tg.Priority <= 0 {
+		return priorityUnset
+	}
+	return tg.Priority
+}
+
+// CanPreempt reports whether a new grant should kick an active call off a
+// Voice device. The rule is strict-higher: equal priority does NOT
+// preempt (so a stable call holds the device against same-priority grants).
+//
+// Returns false if the new grant is locked out by talkgroup policy — the
+// engine handles lockout earlier in the dispatch path, but the predicate
+// is defensive here so callers can compose freely.
+func CanPreempt(active Grant, activeTG *TalkGroup, incoming Grant, incomingTG *TalkGroup) bool {
+	if incomingTG != nil && incomingTG.Lockout {
+		return false
+	}
+	return EffectivePriority(incoming, incomingTG) < EffectivePriority(active, activeTG)
+}

--- a/internal/trunking/priority_test.go
+++ b/internal/trunking/priority_test.go
@@ -1,0 +1,58 @@
+package trunking
+
+import "testing"
+
+func TestEffectivePriority(t *testing.T) {
+	cases := []struct {
+		name string
+		g    Grant
+		tg   *TalkGroup
+		want int
+	}{
+		{"emergency overrides", Grant{Emergency: true}, &TalkGroup{Priority: 5}, 0},
+		{"set priority", Grant{}, &TalkGroup{Priority: 3}, 3},
+		{"nil talkgroup", Grant{}, nil, priorityUnset},
+		{"zero talkgroup priority", Grant{}, &TalkGroup{Priority: 0}, priorityUnset},
+		{"emergency with nil tg", Grant{Emergency: true}, nil, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := EffectivePriority(tc.g, tc.tg); got != tc.want {
+				t.Errorf("got %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCanPreempt(t *testing.T) {
+	high := &TalkGroup{Priority: 1}
+	mid := &TalkGroup{Priority: 5}
+	low := &TalkGroup{Priority: 9}
+	lockedOut := &TalkGroup{Priority: 1, Lockout: true}
+
+	cases := []struct {
+		name     string
+		active   *TalkGroup
+		incoming *TalkGroup
+		emer     bool
+		want     bool
+	}{
+		{"higher preempts lower", low, high, false, true},
+		{"lower does NOT preempt higher", high, low, false, false},
+		{"equal does NOT preempt", mid, mid, false, false},
+		{"emergency preempts everything", mid, mid, true, true},
+		{"locked out cannot preempt", high, lockedOut, false, false},
+		{"unset incoming does not preempt set", mid, nil, false, false},
+		{"set incoming preempts unset", nil, mid, false, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			activeG := Grant{}
+			incomingG := Grant{Emergency: tc.emer}
+			got := CanPreempt(activeG, tc.active, incomingG, tc.incoming)
+			if got != tc.want {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/trunking/talkgroup.go
+++ b/internal/trunking/talkgroup.go
@@ -1,0 +1,179 @@
+package trunking
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+// TalkGroup describes one talkgroup loaded from disk. The schema follows
+// the Trunk Recorder / RadioReference talkgroup CSV convention.
+type TalkGroup struct {
+	ID          uint32 `json:"id"`
+	AlphaTag    string `json:"alpha_tag"`
+	Description string `json:"description,omitempty"`
+	Tag         string `json:"tag,omitempty"`     // department / category
+	Group       string `json:"group,omitempty"`   // top-level group
+	Mode        string `json:"mode,omitempty"`    // D=digital, A=analog, M=mixed
+	Priority    int    `json:"priority,omitempty"` // 1 = highest, 10 = lowest, 0 = unset
+	Lockout     bool   `json:"lockout,omitempty"`
+}
+
+// TalkgroupDB is a thread-safe lookup over loaded talkgroups.
+type TalkgroupDB struct {
+	mu  sync.RWMutex
+	tgs map[uint32]*TalkGroup
+}
+
+// NewTalkgroupDB returns an empty DB.
+func NewTalkgroupDB() *TalkgroupDB {
+	return &TalkgroupDB{tgs: make(map[uint32]*TalkGroup)}
+}
+
+// Lookup returns the talkgroup record for id, or nil if unknown.
+func (d *TalkgroupDB) Lookup(id uint32) *TalkGroup {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	return d.tgs[id]
+}
+
+// Add or replace a single talkgroup record.
+func (d *TalkgroupDB) Add(tg *TalkGroup) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.tgs[tg.ID] = tg
+}
+
+// All returns a snapshot of every talkgroup in the DB.
+func (d *TalkgroupDB) All() []*TalkGroup {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	out := make([]*TalkGroup, 0, len(d.tgs))
+	for _, tg := range d.tgs {
+		out = append(out, tg)
+	}
+	return out
+}
+
+// Len returns the number of loaded talkgroups.
+func (d *TalkgroupDB) Len() int {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	return len(d.tgs)
+}
+
+// LoadCSV reads talkgroups from a Trunk-Recorder-style CSV.
+// Required column: a numeric DEC/Decimal column. Optional columns
+// (matched by header, case-insensitive): Alpha Tag, Description, Mode,
+// Tag, Group, Priority, Lockout.
+//
+// A "Y" / "yes" / "true" value in Lockout sets the flag. Lockout is also
+// inferred when Priority is set to a sentinel "L" value, matching common
+// community CSVs.
+func (d *TalkgroupDB) LoadCSV(r io.Reader) (int, error) {
+	cr := csv.NewReader(r)
+	cr.TrimLeadingSpace = true
+	cr.FieldsPerRecord = -1
+	header, err := cr.Read()
+	if err != nil {
+		return 0, fmt.Errorf("trunking: read csv header: %w", err)
+	}
+	colIdx := map[string]int{}
+	for i, h := range header {
+		colIdx[strings.ToLower(strings.TrimSpace(h))] = i
+	}
+	getDecCol := func() (int, bool) {
+		for _, name := range []string{"decimal", "dec"} {
+			if i, ok := colIdx[name]; ok {
+				return i, true
+			}
+		}
+		return 0, false
+	}
+	decCol, ok := getDecCol()
+	if !ok {
+		return 0, errors.New("trunking: csv missing required Decimal/DEC column")
+	}
+
+	loaded := 0
+	for {
+		row, err := cr.Read()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return loaded, fmt.Errorf("trunking: read csv row: %w", err)
+		}
+		if decCol >= len(row) {
+			continue
+		}
+		decStr := strings.TrimSpace(row[decCol])
+		if decStr == "" {
+			continue
+		}
+		idVal, err := strconv.ParseUint(decStr, 10, 32)
+		if err != nil {
+			continue // skip malformed rows
+		}
+		tg := &TalkGroup{ID: uint32(idVal)}
+		tg.AlphaTag = field(row, colIdx, "alpha tag", "alphatag", "alpha_tag")
+		tg.Description = field(row, colIdx, "description")
+		tg.Mode = field(row, colIdx, "mode")
+		tg.Tag = field(row, colIdx, "tag")
+		tg.Group = field(row, colIdx, "group", "category")
+		if pStr := field(row, colIdx, "priority"); pStr != "" {
+			if strings.EqualFold(pStr, "L") {
+				tg.Lockout = true
+			} else if p, err := strconv.Atoi(pStr); err == nil {
+				tg.Priority = p
+			}
+		}
+		if l := field(row, colIdx, "lockout"); l != "" {
+			switch strings.ToLower(l) {
+			case "y", "yes", "true", "1":
+				tg.Lockout = true
+			}
+		}
+		d.Add(tg)
+		loaded++
+	}
+	return loaded, nil
+}
+
+// LoadCSVFile is a thin wrapper over LoadCSV for a path on disk.
+func (d *TalkgroupDB) LoadCSVFile(path string) (int, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return 0, err
+	}
+	defer f.Close()
+	return d.LoadCSV(f)
+}
+
+// LoadJSON reads a JSON array of TalkGroup records.
+func (d *TalkgroupDB) LoadJSON(r io.Reader) (int, error) {
+	var arr []TalkGroup
+	if err := json.NewDecoder(r).Decode(&arr); err != nil {
+		return 0, fmt.Errorf("trunking: decode json: %w", err)
+	}
+	for i := range arr {
+		tg := arr[i]
+		d.Add(&tg)
+	}
+	return len(arr), nil
+}
+
+func field(row []string, idx map[string]int, names ...string) string {
+	for _, n := range names {
+		if i, ok := idx[n]; ok && i < len(row) {
+			return strings.TrimSpace(row[i])
+		}
+	}
+	return ""
+}

--- a/internal/trunking/talkgroup_test.go
+++ b/internal/trunking/talkgroup_test.go
@@ -1,0 +1,82 @@
+package trunking
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTalkgroupDBLookup(t *testing.T) {
+	d := NewTalkgroupDB()
+	d.Add(&TalkGroup{ID: 1234, AlphaTag: "FIRE-DISP", Priority: 2})
+	if tg := d.Lookup(1234); tg == nil || tg.AlphaTag != "FIRE-DISP" {
+		t.Errorf("Lookup(1234) = %+v", tg)
+	}
+	if tg := d.Lookup(9999); tg != nil {
+		t.Errorf("Lookup(9999) should be nil, got %+v", tg)
+	}
+	if got := d.Len(); got != 1 {
+		t.Errorf("Len = %d, want 1", got)
+	}
+}
+
+func TestLoadCSVTrunkRecorderFormat(t *testing.T) {
+	csv := `Decimal,Hex,Mode,Alpha Tag,Description,Tag,Group,Priority,Lockout
+1234,4D2,D,FIRE-DISP,Fire Dispatch,Fire,Multi,2,
+5678,162E,D,LOCK-ME,Test,Misc,Misc,L,
+9000,2328,D,EXPLICIT,Explicit lockout,Misc,Misc,3,Y
+`
+	d := NewTalkgroupDB()
+	n, err := d.LoadCSV(strings.NewReader(csv))
+	if err != nil {
+		t.Fatalf("LoadCSV: %v", err)
+	}
+	if n != 3 {
+		t.Errorf("loaded %d, want 3", n)
+	}
+	fire := d.Lookup(1234)
+	if fire == nil {
+		t.Fatal("FIRE-DISP not loaded")
+	}
+	if fire.AlphaTag != "FIRE-DISP" || fire.Priority != 2 || fire.Tag != "Fire" {
+		t.Errorf("FIRE-DISP = %+v", fire)
+	}
+
+	lk := d.Lookup(5678)
+	if lk == nil || !lk.Lockout {
+		t.Errorf("LOCK-ME priority=L should set Lockout: %+v", lk)
+	}
+
+	ex := d.Lookup(9000)
+	if ex == nil || !ex.Lockout || ex.Priority != 3 {
+		t.Errorf("EXPLICIT = %+v", ex)
+	}
+}
+
+func TestLoadCSVRequiresDecimal(t *testing.T) {
+	csv := `Hex,Alpha Tag
+4D2,FIRE
+`
+	d := NewTalkgroupDB()
+	_, err := d.LoadCSV(strings.NewReader(csv))
+	if err == nil {
+		t.Error("expected error for missing Decimal column")
+	}
+}
+
+func TestLoadJSON(t *testing.T) {
+	js := `[
+  {"id": 100, "alpha_tag": "OPS-1", "priority": 1},
+  {"id": 200, "alpha_tag": "OPS-2", "priority": 5, "lockout": true}
+]`
+	d := NewTalkgroupDB()
+	n, err := d.LoadJSON(strings.NewReader(js))
+	if err != nil {
+		t.Fatalf("LoadJSON: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("loaded %d, want 2", n)
+	}
+	if tg := d.Lookup(200); tg == nil || !tg.Lockout {
+		t.Errorf("OPS-2 lockout flag missing: %+v", tg)
+	}
+}

--- a/internal/trunking/voicepool.go
+++ b/internal/trunking/voicepool.go
@@ -1,0 +1,140 @@
+package trunking
+
+import (
+	"errors"
+	"sync"
+	"time"
+)
+
+// VoiceDevice is one Voice-role SDR available to the engine. The engine
+// retunes it via the embedded Tuner interface and tracks an optional
+// active call.
+type VoiceDevice struct {
+	Tuner  Tuner
+	Serial string
+}
+
+// VoicePool manages the set of Voice-role devices and the call currently
+// (if any) bound to each. It is safe for concurrent use.
+type VoicePool struct {
+	mu      sync.Mutex
+	devices []*VoiceDevice
+	active  map[string]*ActiveCall // by device serial
+}
+
+// ActiveCall describes a grant currently being followed on a specific
+// Voice device. The engine creates these via VoicePool.Bind.
+type ActiveCall struct {
+	Device      *VoiceDevice
+	Grant       Grant
+	Talkgroup   *TalkGroup
+	StartedAt   time.Time
+	LastHeardAt time.Time
+}
+
+// NewVoicePool returns a pool over the supplied devices. The order of
+// devices determines allocation preference (first-fit).
+func NewVoicePool(devices []*VoiceDevice) *VoicePool {
+	return &VoicePool{devices: devices, active: make(map[string]*ActiveCall)}
+}
+
+// Devices returns a snapshot of the device list.
+func (p *VoicePool) Devices() []*VoiceDevice {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	out := make([]*VoiceDevice, len(p.devices))
+	copy(out, p.devices)
+	return out
+}
+
+// FindFree returns the first device with no active call, or nil if every
+// device is busy. The pool lock is held only during the scan.
+func (p *VoicePool) FindFree() *VoiceDevice {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for _, d := range p.devices {
+		if _, busy := p.active[d.Serial]; !busy {
+			return d
+		}
+	}
+	return nil
+}
+
+// LowestPriorityActive returns the active call with the lowest priority
+// among all devices, or nil if no calls are active. Used by the engine
+// when deciding which call to preempt.
+func (p *VoicePool) LowestPriorityActive() *ActiveCall {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	var lowest *ActiveCall
+	for _, ac := range p.active {
+		if lowest == nil ||
+			EffectivePriority(ac.Grant, ac.Talkgroup) > EffectivePriority(lowest.Grant, lowest.Talkgroup) {
+			lowest = ac
+		}
+	}
+	return lowest
+}
+
+// Bind retunes the device to grant.FrequencyHz and records an active call.
+// Returns an error if the device is already busy or the tune fails.
+func (p *VoicePool) Bind(d *VoiceDevice, g Grant, tg *TalkGroup, now time.Time) (*ActiveCall, error) {
+	if d == nil {
+		return nil, errors.New("trunking: nil device")
+	}
+	p.mu.Lock()
+	if _, busy := p.active[d.Serial]; busy {
+		p.mu.Unlock()
+		return nil, errors.New("trunking: device already busy")
+	}
+	p.mu.Unlock()
+	if err := d.Tuner.SetCenterFreq(g.FrequencyHz); err != nil {
+		return nil, err
+	}
+	ac := &ActiveCall{
+		Device:      d,
+		Grant:       g,
+		Talkgroup:   tg,
+		StartedAt:   now,
+		LastHeardAt: now,
+	}
+	p.mu.Lock()
+	p.active[d.Serial] = ac
+	p.mu.Unlock()
+	return ac, nil
+}
+
+// Release marks the device free. Returns the freed ActiveCall (or nil if
+// the device wasn't busy).
+func (p *VoicePool) Release(serial string) *ActiveCall {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	ac, ok := p.active[serial]
+	if !ok {
+		return nil
+	}
+	delete(p.active, serial)
+	return ac
+}
+
+// Active returns a snapshot of every currently-bound call.
+func (p *VoicePool) Active() []*ActiveCall {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	out := make([]*ActiveCall, 0, len(p.active))
+	for _, ac := range p.active {
+		out = append(out, ac)
+	}
+	return out
+}
+
+// Touch updates the LastHeardAt timestamp for the given device. The engine
+// watchdog uses this to detect calls that have ended without an explicit
+// release announcement.
+func (p *VoicePool) Touch(serial string, now time.Time) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if ac, ok := p.active[serial]; ok {
+		ac.LastHeardAt = now
+	}
+}

--- a/internal/trunking/voicepool_test.go
+++ b/internal/trunking/voicepool_test.go
@@ -1,0 +1,146 @@
+package trunking
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+type fakeVoiceTuner struct {
+	mu     sync.Mutex
+	freqs  []uint32
+	failOn uint32
+}
+
+func (f *fakeVoiceTuner) SetCenterFreq(hz uint32) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.freqs = append(f.freqs, hz)
+	if f.failOn != 0 && hz == f.failOn {
+		return tuneError("forced failure")
+	}
+	return nil
+}
+
+// tuned returns a copy of the recorded center-frequency calls. Tests must
+// use this rather than reading the field directly to stay race-free.
+func (f *fakeVoiceTuner) tuned() []uint32 {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]uint32(nil), f.freqs...)
+}
+
+type tuneError string
+
+func (e tuneError) Error() string { return string(e) }
+
+func mkPool(n int) (*VoicePool, []*fakeVoiceTuner) {
+	tuners := make([]*fakeVoiceTuner, n)
+	devs := make([]*VoiceDevice, n)
+	for i := 0; i < n; i++ {
+		t := &fakeVoiceTuner{}
+		tuners[i] = t
+		devs[i] = &VoiceDevice{Tuner: t, Serial: serial(i)}
+	}
+	return NewVoicePool(devs), tuners
+}
+
+func serial(i int) string {
+	return string(rune('A' + i)) + "-voice"
+}
+
+func TestPoolFindFreeAndBind(t *testing.T) {
+	p, _ := mkPool(2)
+	now := time.Now()
+	if free := p.FindFree(); free == nil || free.Serial != "A-voice" {
+		t.Fatalf("FindFree = %+v", free)
+	}
+	d := p.FindFree()
+	ac, err := p.Bind(d, Grant{FrequencyHz: 851_000_000}, nil, now)
+	if err != nil {
+		t.Fatalf("Bind: %v", err)
+	}
+	if ac.Device != d {
+		t.Errorf("ac.Device != d")
+	}
+	if free := p.FindFree(); free == nil || free.Serial != "B-voice" {
+		t.Fatalf("after binding A, FindFree should return B; got %+v", free)
+	}
+}
+
+func TestPoolBindFailsWhenBusy(t *testing.T) {
+	p, _ := mkPool(1)
+	d := p.FindFree()
+	if _, err := p.Bind(d, Grant{FrequencyHz: 1}, nil, time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := p.Bind(d, Grant{FrequencyHz: 2}, nil, time.Now()); err == nil {
+		t.Error("expected busy error on second Bind")
+	}
+}
+
+func TestPoolBindRetunesDevice(t *testing.T) {
+	p, tuners := mkPool(1)
+	d := p.FindFree()
+	const freq = 853_000_000
+	if _, err := p.Bind(d, Grant{FrequencyHz: freq}, nil, time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	if got := tuners[0].tuned(); len(got) != 1 || got[0] != freq {
+		t.Errorf("tune sequence = %v, want [%d]", got, freq)
+	}
+}
+
+func TestPoolReleaseReturnsActiveCall(t *testing.T) {
+	p, _ := mkPool(1)
+	d := p.FindFree()
+	p.Bind(d, Grant{FrequencyHz: 1}, nil, time.Now())
+	if ac := p.Release(d.Serial); ac == nil {
+		t.Error("Release should return the freed ActiveCall")
+	}
+	if ac := p.Release(d.Serial); ac != nil {
+		t.Error("second Release should return nil")
+	}
+	if free := p.FindFree(); free == nil {
+		t.Error("after Release, device should be free again")
+	}
+}
+
+func TestLowestPriorityActiveSelectsLeastImportant(t *testing.T) {
+	p, _ := mkPool(3)
+	for i, prio := range []int{2, 7, 5} {
+		d := p.Devices()[i]
+		_, _ = p.Bind(d, Grant{FrequencyHz: uint32(100 + i)}, &TalkGroup{Priority: prio}, time.Now())
+	}
+	got := p.LowestPriorityActive()
+	if got == nil || got.Talkgroup.Priority != 7 {
+		t.Errorf("LowestPriorityActive = %+v, want talkgroup priority=7", got)
+	}
+}
+
+func TestTouchUpdatesLastHeard(t *testing.T) {
+	p, _ := mkPool(1)
+	d := p.FindFree()
+	start := time.Unix(1000, 0)
+	p.Bind(d, Grant{FrequencyHz: 1}, nil, start)
+	later := start.Add(5 * time.Second)
+	p.Touch(d.Serial, later)
+	for _, ac := range p.Active() {
+		if !ac.LastHeardAt.Equal(later) {
+			t.Errorf("LastHeardAt = %v, want %v", ac.LastHeardAt, later)
+		}
+	}
+}
+
+func TestBindFailsWhenTuneFails(t *testing.T) {
+	p, tuners := mkPool(1)
+	tuners[0].failOn = 999_999_999
+	d := p.FindFree()
+	_, err := p.Bind(d, Grant{FrequencyHz: 999_999_999}, nil, time.Now())
+	if err == nil {
+		t.Fatal("expected tune failure to propagate")
+	}
+	if free := p.FindFree(); free == nil {
+		t.Error("device should remain free after tune failure")
+	}
+}


### PR DESCRIPTION
Adds the central trunking-engine pieces from Phase 6 of the plan:
the cross-protocol grant payload, the talkgroup DB, priority
preemption logic, the voice-device allocator, and the state machine
that ties them together. Also rolls in the README polish from the
prior session.

## What this delivers

- **`grant.go`** — Cross-protocol `Grant` struct (System, Protocol,
  GroupID, SourceID, FrequencyHz, ChannelID/Num, Encrypted,
  Emergency, DataCall) for publication on `events.KindGrant`, plus
  the `EndReason` enum and `CallStart` / `CallEnd` event payloads
  that the API and recorder layers will consume.
- **`talkgroup.go`** — `TalkGroup` model + thread-safe `TalkgroupDB`
  with a Trunk-Recorder-format CSV loader (Decimal / Alpha Tag /
  Mode / Tag / Group / Priority / Lockout — including the "L"
  priority sentinel for inferred lockouts) and a JSON loader.
- **`priority.go`** — `EffectivePriority(grant, talkgroup)` +
  `CanPreempt(active, incoming)` with the Trunk-Recorder convention:
  lower number = higher priority, emergency = priority 0,
  strict-higher preemption, lockout drops the incoming grant.
- **`voicepool.go`** — `VoicePool` allocator over the Voice-role SDR
  list using the existing `Tuner` interface. `FindFree` for first-
  fit allocation, `LowestPriorityActive` for preemption decisions,
  `Bind` retunes + records an `ActiveCall`, `Release` frees, `Touch`
  refreshes the watchdog timestamp.
- **`engine.go`** — Central state machine. Subscribes to
  `events.KindGrant` at construction time (so callers can publish
  before `Run` starts), dispatches grants through lookup → priority
  → pool, emits `events.KindCallStart` / `events.KindCallEnd`,
  preempts strictly-lower-priority calls when the pool is full, and
  runs a watchdog that ends silent calls after `CallTimeout`
  (default 30 s).

## Test plan
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `go test -race -count=1 ./...`
- [x] Talkgroup CSV + JSON round-trip including the "L" priority
      sentinel and explicit Y/N lockout column
- [x] Priority + preemption: emergency / lockout / equal / nil-tg
- [x] Voice pool: first-fit allocate, retune, busy rejection, lowest-
      priority selection, watchdog touch, tune-failure recovery
- [x] Engine grant dispatch: start-on-grant, drop-locked-out,
      drop-zero-frequency, preempt-lower-priority, hold-on-equal,
      emergency-preempts-anything, explicit `EndCall`, watchdog
      timeout via injected clock
- [x] `Run` loop dispatching events published on the bus

## Bugs caught during testing
- Engine originally subscribed to the bus inside `Run`, losing any
  grant published between `NewEngine` and the first `Run` iteration.
  Moved the subscription into `NewEngine` with a paired `Close()` so
  the engine is reachable as soon as it's constructed.
- Race detector flagged direct reads of the fake tuner's `freqs`
  slice from outside the lock; added a synchronized `tuned()` getter.

## Also in this PR
README polish (table mapping subsystems to shipped components,
explicit "intentionally deferred" list, quickstart with apt-get
prereqs + Makefile + smoke commands + sample `config.yaml`).

## Deferred
- Protocol decoders publishing `events.KindGrant` when they decode
  an actual grant opcode (gated on Phase 3 / 4 / 5 channel-coding
  deferrals: P25 trellis tables + interleaver, DMR slot-type
  Hamming(20,8), NXDN SACCH FEC) and on a band-plan resolver that
  converts (channel ID, channel number) → Hz.
- A demod-pipeline composer that subscribes to `CallStart` events,
  spins up a per-call demod chain on the bound Voice device, calls
  `Engine.Touch` on each voice frame, and `Engine.EndCall` on a
  release announcement.
- Multi-site neighbor list + affiliation-based site selection.
- Daemon-side wiring of the engine into `cmd/gophertrunk run`.

https://claude.ai/code/session_01MQSV8EVnH6nsGUpcWep7UF

---
_Generated by [Claude Code](https://claude.ai/code/session_01MQSV8EVnH6nsGUpcWep7UF)_