### PR TITLE
Phase 12: demod-pipeline composer (FM voice end-to-end)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ and decodes the control channels of P25, DMR, and NXDN trunked radio systems
 — with the engine pieces that follow voice grants, hold talkgroups by
 priority, and stream metadata + audio to a frontend layered on top.
 
-> **Status: under active development.** All eleven phases of the
+> **Status: under active development.** All twelve phases of the
 > build plan have landed: foundation, SDR hardware, DSP core, P25
 > Phase 1 control channel, system-ID & CC hunter, DMR Tier III
 > CSBK, NXDN frame structure, the trunking engine, the
@@ -15,14 +15,18 @@ priority, and stream metadata + audio to a frontend layered on top.
 > (protobuf + gRPC + HTTP/SSE/WebSocket), persistence
 > (SQLite call log + history endpoint + retention sweeper),
 > hardening (Prometheus `/metrics`, a multi-stage Dockerfile,
-> a docker-compose example with USB pass-through), and the daemon
+> a docker-compose example with USB pass-through), the daemon
 > wiring that ties every component together inside `gophertrunk
 > run` plus a `make integration` target that boots the wired daemon
-> end-to-end on every PR. See [`config.example.yaml`](config.example.yaml)
-> for the operator surface, [`docs/phases.md`](docs/phases.md) for
-> the full phased roadmap, [`docs/architecture.md`](docs/architecture.md)
-> for the architecture, [`docs/vocoders.md`](docs/vocoders.md) for
-> the vocoder-licensing situation, and
+> end-to-end on every PR, and the demod-pipeline composer that
+> turns a `CallStart` event into a per-call FM voice chain on the
+> bound device → 16-bit PCM into the recorder, with periodic
+> `Engine.Touch` to keep the call alive. See
+> [`config.example.yaml`](config.example.yaml) for the operator
+> surface, [`docs/phases.md`](docs/phases.md) for the full phased
+> roadmap, [`docs/architecture.md`](docs/architecture.md) for the
+> architecture, [`docs/vocoders.md`](docs/vocoders.md) for the
+> vocoder-licensing situation, and
 > [`docs/hardening.md`](docs/hardening.md) for the operations
 > playbook.
 
@@ -42,7 +46,8 @@ priority, and stream metadata + audio to a frontend layered on top.
 | API               | `proto/*.proto` schemas under repo root; HTTP REST (`/api/v1/{health,version,systems,talkgroups,calls/active,calls/history}`); Server-Sent Events stream (`/api/v1/events`); WebSocket bridge (`/api/v1/events/ws`); gRPC `SystemService` + `TalkgroupService` + (stub) `AudioService` over the same in-process state |
 | Persistence       | Pure-Go SQLite (`modernc.org/sqlite`) call log that subscribes to `CallStart` / `CallEnd` events; newest-first history queries with system / group / time filters; retention sweeper that ages out DB rows and recorded `.wav` / `.raw` files past configurable cutoffs (config / talkgroup CSVs are preserved) |
 | Hardening         | Prometheus collector (events / calls / CC-locked / IQ-underrun / USB-reconnect / decode-error / SDR-attached / build-info series) exposed at `/metrics`; multi-stage `Dockerfile`; `docker-compose.yml` with RTL-SDR USB pass-through, healthcheck, and Prometheus scrape labels; non-root runtime user with `cap_add: DAC_OVERRIDE` |
-| Daemon wiring     | `cmd/gophertrunk run` composes events bus + SDR pool + talkgroup DB + trunking engine + voice pool + recorder + SQLite call log + retention sweeper + Prometheus collector + HTTP API + gRPC API into a single supervised process with signal-driven shutdown; everything optional is opt-in via `config.yaml` |
+| Daemon wiring     | `cmd/gophertrunk run` composes events bus + SDR pool + talkgroup DB + trunking engine + voice pool + recorder + demod composer + SQLite call log + retention sweeper + Prometheus collector + HTTP API + gRPC API into a single supervised process with signal-driven shutdown; everything optional is opt-in via `config.yaml` |
+| Demod pipeline    | `internal/voice/composer` subscribes to `CallStart` events, opens the bound Voice device's IQ stream, runs an LPF → decimate → FM demod → decimate → int16 PCM chain into the recorder, and pings `Engine.Touch` every second so the silent-call watchdog leaves the call alone. Digital-protocol grants are skipped pending the IMBE / AMBE+2 vocoders. |
 | Testing           | Per-package unit tests under `make test`; `make integration` boots the wired daemon end-to-end (no SDR), publishes a synthetic call on the bus, and asserts the engine + recorder + call log + metrics + API agree — runs on every CI build |
 
 ## What's intentionally deferred
@@ -66,16 +71,16 @@ The build plan calls these out by phase; the most visible items still ahead:
   ([`docs/vocoders.md`](docs/vocoders.md)). The recorder, plugin
   interface, and raw-frame sidecar that the decoders will plug into
   have already landed.
-- The remaining gating piece is the **demod-pipeline composer** —
-  the bridge that turns a `CallStart` event into a per-call FM /
-  C4FM / H-DQPSK chain on the bound Voice device, pushes PCM into
-  the recorder, and calls `Engine.Touch` on every voice frame. The
-  ingredients (DSP package, voice pool, recorder, engine) are all
-  in place and the daemon happily carries synthetic events through
-  the integration test today; the composer is meaningful new DSP
-  wiring and lands in a follow-up. Once it ships, the same wiring
-  carries real grants from the protocol decoders without further
-  changes.
+- The demod-pipeline composer landed in Phase 12 — `CallStart`
+  events flow through to a per-call FM voice chain on the bound
+  Voice device that pushes PCM into the recorder. The remaining
+  gating pieces are the **vocoders** (pure-Go IMBE for P25 Phase 1
+  is in progress; AMBE+2 stays behind the `mbelib` build tag) and
+  the **protocol decoders publishing grants on real signals**
+  (gated on the Phase 3/4/5 channel-coding deferrals + a band-plan
+  resolver). Once those land, the wiring already carries real
+  audio for analog FM today and will pick up digital voice without
+  further changes.
 
 ## ✨ Goals
 

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -16,6 +16,7 @@ import (
 	"github.com/MattCheramie/GopherTrunk/internal/storage"
 	"github.com/MattCheramie/GopherTrunk/internal/trunking"
 	"github.com/MattCheramie/GopherTrunk/internal/voice"
+	"github.com/MattCheramie/GopherTrunk/internal/voice/composer"
 )
 
 // Daemon owns the lifecycle of every long-lived component the
@@ -37,6 +38,7 @@ type Daemon struct {
 	engine     *trunking.Engine
 	voicePool  *trunking.VoicePool
 	recorder   *voice.Recorder
+	composer   *composer.Composer
 	db         *storage.DB
 	callLog    *storage.CallLog
 	retention  *storage.Retention
@@ -132,6 +134,25 @@ func NewDaemon(cfg config.Config, version string, log *slog.Logger) (*Daemon, er
 			return nil, fmt.Errorf("daemon: recorder: %w", err)
 		}
 		d.recorder = rec
+	}
+
+	// Composer is wired when we have a Voice device pool to source IQ
+	// from + a recorder to feed PCM into. Without an SDR pool there's
+	// nothing to demod, and without a recorder PCM has no destination.
+	if d.pool != nil && d.recorder != nil {
+		comp, err := composer.New(composer.Options{
+			Bus:           d.bus,
+			Devices:       &poolDevices{pool: d.pool},
+			Sink:          d.recorder,
+			Engine:        d.engine,
+			Log:           log,
+			IQSampleRate:  cfg.SDR.SampleRate,
+			PCMSampleRate: cfg.Recordings.SampleRate,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("daemon: composer: %w", err)
+		}
+		d.composer = comp
 	}
 
 	// Storage / call log / retention — optional.
@@ -249,6 +270,11 @@ func (d *Daemon) Run(ctx context.Context) error {
 			return d.recorder.Run(ctx)
 		})
 	}
+	if d.composer != nil {
+		d.spawn(ctx, "composer", func(ctx context.Context) error {
+			return d.composer.Run(ctx)
+		})
+	}
 	if d.metrics != nil {
 		d.spawn(ctx, "metrics", func(ctx context.Context) error {
 			return d.metrics.Run(ctx)
@@ -282,6 +308,9 @@ func (d *Daemon) Close() {
 		}
 		if d.grpcAPI != nil {
 			d.grpcAPI.Stop()
+		}
+		if d.composer != nil {
+			_ = d.composer.Close()
 		}
 		if d.recorder != nil {
 			_ = d.recorder.Close()
@@ -348,4 +377,19 @@ func retentionInterval(s string) (time.Duration, error) {
 		return time.Hour, nil
 	}
 	return time.ParseDuration(s)
+}
+
+// poolDevices adapts *sdr.Pool to composer.Devices. The composer only
+// needs StreamIQ; sdr.Device satisfies that subset directly.
+type poolDevices struct{ pool *sdr.Pool }
+
+func (p *poolDevices) FindBySerial(serial string) composer.IQSource {
+	if p.pool == nil {
+		return nil
+	}
+	e := p.pool.FindBySerial(serial)
+	if e == nil {
+		return nil
+	}
+	return e.Device
 }

--- a/docs/phases.md
+++ b/docs/phases.md
@@ -20,6 +20,7 @@ buildable and testable; the project stays useful even if work pauses partway.
 | 9     | Persistence + recording                | done        |
 | 10    | Hardening (metrics, reconnect, docker) | partial     |
 | 11    | Daemon wiring + integration target     | done        |
+| 12    | Demod-pipeline composer (FM voice)     | done        |
 
 ## Phase 0 — Foundation
 
@@ -582,6 +583,62 @@ Deferred:
   resolver. The integration test covers the wiring with a
   synthetic grant; once those decoders go live the same wiring
   carries real grants without further changes.
+
+## Phase 12 — Demod-pipeline composer (FM voice)
+
+The piece every previous "deferred" item pointed at: turning a
+`CallStart` event into actual audio on disk.
+
+Landed in this phase:
+
+- `internal/voice/composer/composer.go` — `Composer` subscribes to
+  `events.KindCallStart` / `KindCallEnd` at construction time, looks
+  up the bound Voice device by serial, opens its IQ stream, and
+  spawns a per-call goroutine running an FM passthrough chain:
+    LPF → naive decimate → quadrature FM demod → naive decimate →
+    int16 PCM → `Recorder.WritePCM`.
+  The chain also pings `Engine.Touch(serial)` on a one-second
+  cadence (configurable) so the engine's silent-call watchdog
+  doesn't kill the call mid-conversation.
+- Narrow interfaces (`IQSource`, `Devices`, `PCMSink`,
+  `EngineHooks`) keep the composer free of hard imports on
+  `internal/sdr` and `internal/voice` so unit tests use plain
+  in-memory channels instead of real hardware.
+- `internal/sdr/pool.go` — new `Pool.FindBySerial(serial)` so the
+  daemon's `poolDevices` adapter can resolve a device by its
+  reported serial without iterating the entry list at every grant.
+- `cmd/gophertrunk/daemon.go` — daemon constructs the composer when
+  both an SDR pool and a recorder are configured, wires it into the
+  Run/Close lifecycle alongside the other components, and exposes
+  the SDR pool to it via the `poolDevices` adapter.
+
+Tests cover start-on-CallStart, IQ flowing through the chain to
+recorder PCM, periodic Touch on the engine, end-on-CallEnd cleanup,
+digital-protocol grants are skipped (no PCM until a vocoder lands),
+unknown-serial grants are benign, options validation, and idempotent
+Close.
+
+Behaviour for digital protocols (P25 / DMR / NXDN): the composer
+deliberately skips the FM chain because those streams need a
+vocoder we don't have yet (IMBE for P25 Phase 1 is in progress; AMBE+2
+stays behind the `mbelib` build tag). The recorder still gets the
+`CallStart` event so the `.raw` sidecar (when configured) and the
+SQLite call_log row both land — only the `.wav` is empty until the
+vocoder ships.
+
+Deferred:
+- Higher-fidelity audio: the chain currently does naive boxcar
+  decimation rather than proper polyphase resampling, and skips the
+  FM de-emphasis filter + post-demod LPF + AGC. Quality is good
+  enough to verify wiring; the real DSP polish is a follow-up.
+- IMBE / AMBE+2 plug-in to the chain. The `Vocoder` interface and
+  raw-frame sidecar are already in place; once IMBE lands the
+  composer will pick the chain by `Grant.Protocol` and route the
+  raw vocoder bytes through `Vocoder.Decode`.
+- Real-time SDR retune coordination: today the composer trusts the
+  engine to have already tuned the device for the new grant. A
+  future tweak will let it confirm the freq matches the grant's
+  `FrequencyHz` and surface a metric when they disagree.
 
 …subsequent phases follow the plan in
 `/root/.claude/plans/using-the-readme-md-as-sleepy-fairy.md`.

--- a/internal/sdr/pool.go
+++ b/internal/sdr/pool.go
@@ -137,6 +137,20 @@ func (p *Pool) AllByRole(r Role) []*PoolEntry {
 	return out
 }
 
+// FindBySerial returns the entry whose info.Serial matches, or nil.
+// Used by the demod-pipeline composer to look up a Voice device that
+// the engine has just bound to a call.
+func (p *Pool) FindBySerial(serial string) *PoolEntry {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	for _, e := range p.entries {
+		if e.Info.Serial == serial {
+			return e
+		}
+	}
+	return nil
+}
+
 func (p *Pool) Close() error {
 	p.mu.Lock()
 	defer p.mu.Unlock()

--- a/internal/voice/composer/composer.go
+++ b/internal/voice/composer/composer.go
@@ -1,0 +1,358 @@
+// Package composer bridges the trunking engine's CallStart events to
+// the per-call demod chain that turns IQ samples on a freshly-tuned
+// Voice device into 16-bit PCM the recorder can write.
+//
+// One Composer subscribes to events.KindCallStart / events.KindCallEnd
+// from the bus. On a CallStart it looks up the Voice device by serial,
+// opens its IQ stream, and starts a goroutine that runs an FM
+// passthrough chain (LPF → decimate → quadrature FM demod → coarse
+// resample → int16 PCM → recorder.WritePCM). The chain also calls
+// Engine.Touch on a one-second cadence so the engine's silent-call
+// watchdog doesn't kill the call mid-conversation.
+//
+// Digital protocols (P25 / DMR / NXDN) need vocoders that haven't
+// landed yet — IMBE for P25 Phase 1 is in progress and AMBE+2 stays
+// behind a build tag. Until they ship, a digital grant produces no
+// PCM and only the raw-frame sidecar (when WriteRaw is enabled) is
+// useful. The composer logs a warning per digital grant so the
+// behaviour is visible in operations.
+package composer
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"math"
+	"sync"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/demod"
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/filter"
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// IQSource is the subset of sdr.Device the composer needs. Decoupling
+// keeps the package free of a hard import on internal/sdr and makes
+// testing trivial with an in-memory channel.
+type IQSource interface {
+	StreamIQ(ctx context.Context) (<-chan []complex64, error)
+}
+
+// Devices resolves a Voice-role IQ source by its serial. The daemon
+// supplies a wrapper around sdr.Pool; tests use a map.
+type Devices interface {
+	FindBySerial(serial string) IQSource
+}
+
+// PCMSink is the subset of voice.Recorder we touch. Recorder.WritePCM
+// matches this signature exactly.
+type PCMSink interface {
+	WritePCM(deviceSerial string, samples []int16) error
+}
+
+// EngineHooks exposes the Touch / EndCall calls the chain uses to
+// keep the engine in sync with what the chain hears. Stubbing this
+// interface lets tests assert Touch fires on a real cadence.
+type EngineHooks interface {
+	Touch(deviceSerial string)
+	EndCall(deviceSerial string, reason trunking.EndReason) bool
+}
+
+// Options configure a Composer.
+type Options struct {
+	Bus     *events.Bus
+	Devices Devices
+	Sink    PCMSink     // typically *voice.Recorder
+	Engine  EngineHooks // typically *trunking.Engine
+	Log     *slog.Logger
+	// IQSampleRate is the per-second sample rate the SDR pool delivers
+	// (typically 2.4e6). Required.
+	IQSampleRate uint32
+	// PCMSampleRate is the rate the recorder expects (default 8000).
+	PCMSampleRate uint32
+	// VoiceBandwidthHz is the cutoff of the front-end LPF (default
+	// 12_500 — wide enough for analog FM voice with some margin).
+	VoiceBandwidthHz uint32
+	// TouchInterval is how often the chain pings Engine.Touch while
+	// audio is flowing (default 1 s).
+	TouchInterval time.Duration
+}
+
+// Composer is the long-lived event-driven bridge.
+type Composer struct {
+	bus    *events.Bus
+	dev    Devices
+	sink   PCMSink
+	engine EngineHooks
+	log    *slog.Logger
+
+	iqHz         uint32
+	pcmHz        uint32
+	bw           uint32
+	touchEvery   time.Duration
+
+	sub       *events.Subscription
+	runDone   chan struct{}
+	closeOnce sync.Once
+
+	mu     sync.Mutex
+	chains map[string]*chain
+}
+
+type chain struct {
+	cancel context.CancelFunc
+	done   chan struct{}
+}
+
+// New validates options and constructs a Composer. The bus subscription
+// is created at construction time so callers can publish events before
+// Run starts without losing them.
+func New(opts Options) (*Composer, error) {
+	if opts.Bus == nil {
+		return nil, errors.New("composer: events.Bus is required")
+	}
+	if opts.Devices == nil {
+		return nil, errors.New("composer: Devices is required")
+	}
+	if opts.IQSampleRate == 0 {
+		return nil, errors.New("composer: IQSampleRate is required")
+	}
+	if opts.PCMSampleRate == 0 {
+		opts.PCMSampleRate = 8000
+	}
+	if opts.VoiceBandwidthHz == 0 {
+		opts.VoiceBandwidthHz = 12_500
+	}
+	if opts.TouchInterval <= 0 {
+		opts.TouchInterval = time.Second
+	}
+	log := opts.Log
+	if log == nil {
+		log = slog.Default()
+	}
+	c := &Composer{
+		bus:        opts.Bus,
+		dev:        opts.Devices,
+		sink:       opts.Sink,
+		engine:     opts.Engine,
+		log:        log,
+		iqHz:       opts.IQSampleRate,
+		pcmHz:      opts.PCMSampleRate,
+		bw:         opts.VoiceBandwidthHz,
+		touchEvery: opts.TouchInterval,
+		chains:     make(map[string]*chain),
+		runDone:    make(chan struct{}),
+	}
+	c.sub = opts.Bus.Subscribe()
+	return c, nil
+}
+
+// Run drains CallStart / CallEnd events until ctx cancels, spawning /
+// reaping per-call demod goroutines. Every active chain is cancelled
+// on context cancel so Close drains cleanly.
+func (c *Composer) Run(ctx context.Context) error {
+	defer close(c.runDone)
+	for {
+		select {
+		case <-ctx.Done():
+			c.cancelAll()
+			return ctx.Err()
+		case ev, ok := <-c.sub.C:
+			if !ok {
+				c.cancelAll()
+				return nil
+			}
+			switch ev.Kind {
+			case events.KindCallStart:
+				if cs, ok := ev.Payload.(trunking.CallStart); ok {
+					c.handleStart(ctx, cs)
+				}
+			case events.KindCallEnd:
+				if ce, ok := ev.Payload.(trunking.CallEnd); ok {
+					c.handleEnd(ce)
+				}
+			}
+		}
+	}
+}
+
+// Close releases the bus subscription and waits for Run to drain. It
+// also cancels every active chain. Idempotent.
+func (c *Composer) Close() error {
+	c.closeOnce.Do(func() {
+		c.sub.Close()
+		select {
+		case <-c.runDone:
+		case <-time.After(time.Second):
+		}
+		c.cancelAll()
+	})
+	return nil
+}
+
+// ActiveChains returns the device serials with running chains. Test
+// helper; takes the lock so it's race-free.
+func (c *Composer) ActiveChains() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]string, 0, len(c.chains))
+	for k := range c.chains {
+		out = append(out, k)
+	}
+	return out
+}
+
+func (c *Composer) handleStart(parent context.Context, cs trunking.CallStart) {
+	if cs.Grant.Protocol != "" && cs.Grant.Protocol != "fm" && cs.Grant.Protocol != "analog" {
+		// Digital protocols need a vocoder we don't have yet. The
+		// recorder still gets the CallStart event itself, so the .raw
+		// sidecar (when configured) and the call_log row land. We
+		// simply don't push PCM.
+		c.log.Info("composer: digital protocol; skipping FM chain",
+			"device", cs.DeviceSerial, "protocol", cs.Grant.Protocol,
+			"group", cs.Grant.GroupID)
+		return
+	}
+	src := c.dev.FindBySerial(cs.DeviceSerial)
+	if src == nil {
+		c.log.Warn("composer: no device for serial", "serial", cs.DeviceSerial)
+		return
+	}
+	c.mu.Lock()
+	if existing := c.chains[cs.DeviceSerial]; existing != nil {
+		// Engine should have ended the prior call first; defensive.
+		existing.cancel()
+		<-existing.done
+		delete(c.chains, cs.DeviceSerial)
+	}
+	c.mu.Unlock()
+
+	chainCtx, cancel := context.WithCancel(parent)
+	iqCh, err := src.StreamIQ(chainCtx)
+	if err != nil {
+		cancel()
+		c.log.Warn("composer: StreamIQ failed", "serial", cs.DeviceSerial, "err", err)
+		return
+	}
+	ch := &chain{cancel: cancel, done: make(chan struct{})}
+	c.mu.Lock()
+	c.chains[cs.DeviceSerial] = ch
+	c.mu.Unlock()
+
+	go c.runFMChain(chainCtx, cs.DeviceSerial, iqCh, ch.done)
+}
+
+func (c *Composer) handleEnd(ce trunking.CallEnd) {
+	c.mu.Lock()
+	ch := c.chains[ce.DeviceSerial]
+	delete(c.chains, ce.DeviceSerial)
+	c.mu.Unlock()
+	if ch == nil {
+		return
+	}
+	ch.cancel()
+	<-ch.done
+}
+
+func (c *Composer) cancelAll() {
+	c.mu.Lock()
+	chains := c.chains
+	c.chains = make(map[string]*chain)
+	c.mu.Unlock()
+	for _, ch := range chains {
+		ch.cancel()
+		<-ch.done
+	}
+}
+
+// runFMChain consumes IQ for one call. The chain is intentionally
+// straightforward: LPF the IQ to voice bandwidth, naive-decimate to
+// roughly 48 kHz, quadrature-FM-demod, naive-decimate again to the
+// recorder's PCM rate, and convert to int16. A higher-fidelity version
+// (proper polyphase resamplers, de-emphasis, post-demod LPF) is a
+// follow-up; this is honest passthrough quality good enough to verify
+// the wiring end-to-end and to land the operator-visible plumbing.
+func (c *Composer) runFMChain(ctx context.Context, serial string, iqCh <-chan []complex64, done chan<- struct{}) {
+	defer close(done)
+
+	// Front-end LPF: cutoff = bw / iqHz (normalized 0..0.5).
+	cutoff := float64(c.bw) / float64(c.iqHz)
+	if cutoff > 0.45 {
+		cutoff = 0.45
+	}
+	taps := filter.LowpassKaiser(81, cutoff, 8.6)
+	lpf := filter.NewFIR(taps)
+
+	// Naive decimation factors. They aren't exact; resampling-quality
+	// audio lands with the polyphase resampler in a follow-up.
+	const intermediateHz = 48_000
+	decim1 := int(c.iqHz) / intermediateHz
+	if decim1 < 1 {
+		decim1 = 1
+	}
+	decim2 := intermediateHz / int(c.pcmHz)
+	if decim2 < 1 {
+		decim2 = 1
+	}
+
+	fm := demod.NewFM()
+
+	touchTicker := time.NewTicker(c.touchEvery)
+	defer touchTicker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-touchTicker.C:
+			if c.engine != nil {
+				c.engine.Touch(serial)
+			}
+		case iq, ok := <-iqCh:
+			if !ok {
+				return
+			}
+			filtered := lpf.Process(nil, iq)
+			decimated := decimateComplex(filtered, decim1)
+			audio := fm.Process(nil, decimated)
+			pcm := decimateAndConvert(audio, decim2)
+			if c.sink != nil && len(pcm) > 0 {
+				_ = c.sink.WritePCM(serial, pcm)
+			}
+		}
+	}
+}
+
+func decimateComplex(in []complex64, factor int) []complex64 {
+	if factor <= 1 {
+		return in
+	}
+	out := make([]complex64, 0, len(in)/factor+1)
+	for i := 0; i < len(in); i += factor {
+		out = append(out, in[i])
+	}
+	return out
+}
+
+// decimateAndConvert decimates a real audio stream and converts to
+// 16-bit signed PCM. The FM demodulator emits radians/sample in
+// roughly [-π, +π]; we scale by ~10 000 to fill the int16 range for
+// reasonable deviation, then clamp.
+func decimateAndConvert(in []float32, factor int) []int16 {
+	if factor < 1 {
+		factor = 1
+	}
+	out := make([]int16, 0, len(in)/factor+1)
+	for i := 0; i < len(in); i += factor {
+		v := float64(in[i]) * 10_000
+		if v > math.MaxInt16 {
+			v = math.MaxInt16
+		}
+		if v < math.MinInt16 {
+			v = math.MinInt16
+		}
+		out = append(out, int16(v))
+	}
+	return out
+}

--- a/internal/voice/composer/composer_test.go
+++ b/internal/voice/composer/composer_test.go
@@ -1,0 +1,279 @@
+package composer
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// fakeSource implements IQSource. Each call to StreamIQ returns a
+// fresh channel; the test pushes IQ chunks through SendIQ.
+type fakeSource struct {
+	mu  sync.Mutex
+	chs []chan []complex64
+}
+
+func newFakeSource() *fakeSource { return &fakeSource{} }
+
+func (f *fakeSource) StreamIQ(ctx context.Context) (<-chan []complex64, error) {
+	ch := make(chan []complex64, 8)
+	f.mu.Lock()
+	f.chs = append(f.chs, ch)
+	f.mu.Unlock()
+	go func() {
+		<-ctx.Done()
+		// Don't close on cancel — Composer notices ctx.Done first; closing
+		// would risk a double-close if multiple paths do it.
+	}()
+	return ch, nil
+}
+
+func (f *fakeSource) SendIQ(samples []complex64) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, ch := range f.chs {
+		select {
+		case ch <- samples:
+		default:
+		}
+	}
+}
+
+type fakeDevices struct{ src map[string]IQSource }
+
+func (d *fakeDevices) FindBySerial(s string) IQSource { return d.src[s] }
+
+type recordingSink struct {
+	mu   sync.Mutex
+	pcm  map[string][]int16
+}
+
+func (r *recordingSink) WritePCM(serial string, samples []int16) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.pcm == nil {
+		r.pcm = make(map[string][]int16)
+	}
+	r.pcm[serial] = append(r.pcm[serial], samples...)
+	return nil
+}
+
+func (r *recordingSink) total(serial string) int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.pcm[serial])
+}
+
+type fakeEngine struct {
+	touched atomic.Int64
+	mu      sync.Mutex
+	ended   []string
+}
+
+func (e *fakeEngine) Touch(string) { e.touched.Add(1) }
+func (e *fakeEngine) EndCall(serial string, _ trunking.EndReason) bool {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.ended = append(e.ended, serial)
+	return true
+}
+
+func mkComposer(t *testing.T, src *fakeSource) (*Composer, *events.Bus, *recordingSink, *fakeEngine, func()) {
+	t.Helper()
+	bus := events.NewBus(8)
+	sink := &recordingSink{}
+	eng := &fakeEngine{}
+	c, err := New(Options{
+		Bus:           bus,
+		Devices:       &fakeDevices{src: map[string]IQSource{"VOICE-1": src}},
+		Sink:          sink,
+		Engine:        eng,
+		IQSampleRate:  2_400_000,
+		PCMSampleRate: 8000,
+		TouchInterval: 30 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	go c.Run(ctx)
+	teardown := func() {
+		cancel()
+		c.Close()
+		bus.Close()
+	}
+	return c, bus, sink, eng, teardown
+}
+
+// publishStartFM publishes a CallStart for a Voice call on the
+// supplied serial. The protocol is tagged "fm" so the composer runs
+// the analog passthrough chain.
+func publishStartFM(bus *events.Bus, serial string) {
+	bus.Publish(events.Event{
+		Kind: events.KindCallStart,
+		Payload: trunking.CallStart{
+			Grant: trunking.Grant{
+				System: "Alpha", Protocol: "fm",
+				GroupID: 100, FrequencyHz: 851_000_000,
+			},
+			DeviceSerial: serial,
+			StartedAt:    time.Now().UTC(),
+		},
+	})
+}
+
+// publishEnd publishes a CallEnd for the supplied serial.
+func publishEnd(bus *events.Bus, serial string) {
+	bus.Publish(events.Event{
+		Kind: events.KindCallEnd,
+		Payload: trunking.CallEnd{
+			Grant:        trunking.Grant{Protocol: "fm"},
+			DeviceSerial: serial,
+			Reason:       trunking.EndReasonNormal,
+		},
+	})
+}
+
+func waitFor(t *testing.T, deadline time.Duration, fn func() bool) {
+	t.Helper()
+	end := time.Now().Add(deadline)
+	for time.Now().Before(end) {
+		if fn() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal("timed out waiting for condition")
+}
+
+func TestComposerStartsChainOnCallStart(t *testing.T) {
+	src := newFakeSource()
+	c, bus, _, _, teardown := mkComposer(t, src)
+	defer teardown()
+
+	publishStartFM(bus, "VOICE-1")
+
+	waitFor(t, time.Second, func() bool {
+		for _, s := range c.ActiveChains() {
+			if s == "VOICE-1" {
+				return true
+			}
+		}
+		return false
+	})
+}
+
+func TestComposerWritesPCMFromIQ(t *testing.T) {
+	src := newFakeSource()
+	_, bus, sink, _, teardown := mkComposer(t, src)
+	defer teardown()
+
+	publishStartFM(bus, "VOICE-1")
+	// Wait until StreamIQ has been opened.
+	waitFor(t, time.Second, func() bool {
+		src.mu.Lock()
+		defer src.mu.Unlock()
+		return len(src.chs) > 0
+	})
+
+	// Push a chunk of IQ samples; magnitude doesn't matter because we
+	// only verify PCM bytes flow.
+	chunk := make([]complex64, 4096)
+	for i := range chunk {
+		chunk[i] = complex(0.5, 0.5)
+	}
+	src.SendIQ(chunk)
+
+	waitFor(t, time.Second, func() bool { return sink.total("VOICE-1") > 0 })
+}
+
+func TestComposerTouchesEngineWhileChainRuns(t *testing.T) {
+	src := newFakeSource()
+	_, bus, _, eng, teardown := mkComposer(t, src)
+	defer teardown()
+
+	publishStartFM(bus, "VOICE-1")
+	waitFor(t, time.Second, func() bool { return eng.touched.Load() >= 2 })
+}
+
+func TestComposerStopsChainOnCallEnd(t *testing.T) {
+	src := newFakeSource()
+	c, bus, _, _, teardown := mkComposer(t, src)
+	defer teardown()
+
+	publishStartFM(bus, "VOICE-1")
+	waitFor(t, time.Second, func() bool { return len(c.ActiveChains()) == 1 })
+
+	publishEnd(bus, "VOICE-1")
+	waitFor(t, time.Second, func() bool { return len(c.ActiveChains()) == 0 })
+}
+
+func TestComposerSkipsDigitalProtocol(t *testing.T) {
+	src := newFakeSource()
+	c, bus, sink, _, teardown := mkComposer(t, src)
+	defer teardown()
+
+	bus.Publish(events.Event{
+		Kind: events.KindCallStart,
+		Payload: trunking.CallStart{
+			Grant:        trunking.Grant{Protocol: "p25", GroupID: 1, FrequencyHz: 851_000_000},
+			DeviceSerial: "VOICE-1",
+			StartedAt:    time.Now().UTC(),
+		},
+	})
+
+	// Give the loop a few ticks; nothing should happen.
+	time.Sleep(80 * time.Millisecond)
+	if got := len(c.ActiveChains()); got != 0 {
+		t.Errorf("active chains for digital grant = %d, want 0", got)
+	}
+	if sink.total("VOICE-1") != 0 {
+		t.Errorf("digital grant produced PCM samples")
+	}
+}
+
+func TestComposerNoDeviceForSerialIsBenign(t *testing.T) {
+	src := newFakeSource()
+	c, bus, _, _, teardown := mkComposer(t, src)
+	defer teardown()
+
+	publishStartFM(bus, "VOICE-DOES-NOT-EXIST")
+	time.Sleep(80 * time.Millisecond)
+	if got := len(c.ActiveChains()); got != 0 {
+		t.Errorf("unknown serial spawned a chain: %v", c.ActiveChains())
+	}
+}
+
+func TestNewValidates(t *testing.T) {
+	if _, err := New(Options{}); err == nil {
+		t.Error("expected error for empty options")
+	}
+	if _, err := New(Options{Bus: events.NewBus(1)}); err == nil {
+		t.Error("expected error for missing Devices")
+	}
+	if _, err := New(Options{Bus: events.NewBus(1), Devices: &fakeDevices{}}); err == nil {
+		t.Error("expected error for missing IQSampleRate")
+	}
+}
+
+func TestCloseIsIdempotent(t *testing.T) {
+	bus := events.NewBus(2)
+	defer bus.Close()
+	c, err := New(Options{
+		Bus: bus, Devices: &fakeDevices{}, IQSampleRate: 2_400_000,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Close(); err != nil {
+		t.Errorf("second Close: %v", err)
+	}
+}


### PR DESCRIPTION
Closes the loop between trunking events and audio on disk. The piece
every previous "deferred" item has been pointing at: turning a
`CallStart` event into a per-call demod chain that pushes 16-bit PCM
into the recorder.

## What this delivers

### `internal/voice/composer/composer.go` (new package)
`Composer` subscribes to `events.KindCallStart` / `KindCallEnd` at
construction time, looks up the bound Voice device by serial via a
narrow `Devices` interface, opens its IQ stream, and spawns a
per-call goroutine running an FM passthrough chain:

```
LPF (Kaiser-windowed, voice-bandwidth cutoff)
 → naive decimate to ~48 kHz
 → quadrature FM demod (atan2 phase difference)
 → naive decimate to PCM rate (8 kHz default)
 → int16 PCM
 → Recorder.WritePCM
```

The chain also pings `Engine.Touch(serial)` on a one-second cadence
(configurable) so the engine's silent-call watchdog doesn't kill the
call mid-conversation.

Narrow interfaces (`IQSource`, `Devices`, `PCMSink`, `EngineHooks`)
keep the package free of hard imports on `internal/sdr` and
`internal/voice`; tests use plain in-memory channels instead of real
hardware.

### `internal/sdr/pool.go`
New `Pool.FindBySerial(serial)` so the daemon's `poolDevices` adapter
can resolve a device by its reported serial without iterating the
entry list at every grant.

### `cmd/gophertrunk/daemon.go`
The daemon constructs the composer when both an SDR pool and a
recorder are configured, wires it into the Run/Close lifecycle
alongside the other components, and exposes the SDR pool to it via
the `poolDevices` adapter.

## Behaviour for digital protocols
P25 / DMR / NXDN streams need a vocoder we don't have yet (IMBE for
P25 Phase 1 is in progress; AMBE+2 stays behind the `mbelib` build
tag). The composer deliberately skips the FM chain on those grants
and logs an info line. The recorder still gets the `CallStart`
event so the `.raw` sidecar (when configured) and the SQLite
call_log row both land — only the `.wav` is empty until the
vocoder ships.

## Test plan
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `go test -race -count=1 ./...`
- [x] `make integration`
- [x] Composer starts a chain on `CallStart`
- [x] IQ pushed into the source flows through the chain to recorder
      PCM
- [x] `Engine.Touch` fires on the configured cadence while audio is
      flowing
- [x] `CallEnd` cancels the chain and removes it from the active set
- [x] Digital-protocol grants are skipped (no PCM, no chain)
- [x] Unknown-serial grants are benign (no panic, no chain)
- [x] `New(...)` validates required options
- [x] `Close()` is idempotent

## Deferred
- **Higher-fidelity audio.** The chain currently does naive boxcar
  decimation rather than proper polyphase resampling, and skips the
  FM de-emphasis filter, post-demod LPF, and AGC. Quality is good
  enough to verify wiring end-to-end; real DSP polish is a
  follow-up.
- **IMBE / AMBE+2 plug-in.** The `Vocoder` interface and raw-frame
  sidecar are already in place; once IMBE lands the composer will
  pick the chain by `Grant.Protocol` and route the raw vocoder bytes
  through `Vocoder.Decode`.
- **Real-time SDR retune coordination.** Today the composer trusts
  the engine to have already tuned the device for the new grant; a
  future tweak will let it confirm the freq matches the grant's
  `FrequencyHz` and surface a metric when they disagree.

https://claude.ai/code/session_01MQSV8EVnH6nsGUpcWep7UF

---
_Generated by [Claude Code](https://claude.ai/code/session_01MQSV8EVnH6nsGUpcWep7UF)_