### PR TITLE
Motorola Type II / SmartZone OSW decoder (Roadmap item 2 — partial)

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,23 +103,38 @@ Future work: live-frequency refinement (track the actually-matched
 bin rather than the configured one), DTMF / concurrent multi-tone
 profiles, and a Prometheus counter for fired alerts.
 
-### 2. TrunkTracker-style multi-system grant following
+### 2. TrunkTracker-style multi-system grant following 🟡 partial
 
 Marketed by Uniden as TrunkTracker, this is exactly what the engine
 already does for the protocols we currently decode: parse a control
 channel, see a Group Voice Channel Grant, retune a Voice SDR, follow
-the call. The architecture covers it; what's missing is **decoders
+the call. The architecture covers it; what's needed is **decoders
 for additional trunking systems** so the existing
 `events.KindGrant` → engine pipeline carries them.
 
-Targets, easiest to hardest:
+What's wired:
 
-- **Motorola Type II / SmartZone (3600 baud).** Best documented
-  legacy trunked system; an OSW (Outbound Status Word) decoder
-  fits in `internal/radio/motorola/` and publishes a `Grant` with
-  the existing `Protocol="motorola"` tag. The hardest piece is
-  the channel-number → Hz band-plan mapping, which is per-system
-  config (matches what the P25 work already needs).
+- **Motorola Type II / SmartZone.** `internal/radio/motorola/` —
+  OSW (Outbound Status Word) parser, opcode constants
+  (GroupVoiceChannelGrant, GroupVoiceChannelGrantUpdate,
+  AdjacentSiteStatus, SystemIDExtended, Idle, Encryption,
+  Emergency), an `LCN → Hz` band-plan resolver with linear and
+  table strategies, and a control-channel state machine that
+  ingests OSWs and publishes `cc.locked` (on
+  SystemIDExtended) and `grant` (on the voice-grant opcodes) on
+  the events bus, with the `trunking.Grant.Protocol` tag set to
+  `"motorola"`. Same shape as the P25 / DMR / NXDN packages.
+  Tests cover OSW round-trip, opcode + LCN extraction, the
+  per-grant-type accessors, both band-plan strategies, sync
+  detection with tolerance, and the control-channel emission path.
+- The Motorola **MSK demodulator** + **BCH(64,16,11)** error
+  corrector that turn IQ into the bits the OSW parser consumes
+  are honest deferrals — the package's doc comment lists them
+  explicitly so a contributor can pick them up. Same pattern as
+  the P25 trellis-tables / TSBK-interleaver gap.
+
+Still ahead:
+
 - **EDACS / GE-Marc (9600 baud control channel).** Public format;
   similar shape to Motorola Type II.
 - **LTR (Logic Trunked Radio).** Each repeater carries its own

--- a/internal/radio/motorola/bandplan.go
+++ b/internal/radio/motorola/bandplan.go
@@ -1,0 +1,51 @@
+package motorola
+
+import (
+	"errors"
+	"fmt"
+)
+
+// BandPlan resolves a Motorola Logical Channel Number (LCN) to a
+// frequency in Hz. Two strategies cover the bulk of real systems:
+//
+//   - Linear: freq = base + (lcn + offset) * spacing — typical for
+//     800 / 900 MHz NPSPAC and many state-wide SmartZone systems.
+//   - Table:  explicit per-LCN entries — for VHF / UHF systems whose
+//     channel plan doesn't follow a single linear formula.
+//
+// Use whichever matches the operator's configured system. The control
+// state machine takes a `Resolver` interface so live captures can
+// switch between them per System without code changes.
+type Resolver interface {
+	Frequency(lcn uint16) (uint32, error)
+}
+
+// LinearBandPlan applies freq = BaseHz + (lcn + Offset) * SpacingHz.
+type LinearBandPlan struct {
+	BaseHz    uint32
+	SpacingHz uint32
+	Offset    int // signed; supports negative offsets used by some plans
+}
+
+func (b LinearBandPlan) Frequency(lcn uint16) (uint32, error) {
+	if b.SpacingHz == 0 {
+		return 0, errors.New("motorola/bandplan: SpacingHz must be > 0")
+	}
+	idx := int(lcn) + b.Offset
+	if idx < 0 {
+		return 0, fmt.Errorf("motorola/bandplan: LCN %d + offset %d went negative", lcn, b.Offset)
+	}
+	return b.BaseHz + uint32(idx)*b.SpacingHz, nil
+}
+
+// TableBandPlan looks up explicit (lcn → Hz) entries. Useful for
+// VHF / UHF systems with non-linear channel plans.
+type TableBandPlan map[uint16]uint32
+
+func (t TableBandPlan) Frequency(lcn uint16) (uint32, error) {
+	hz, ok := t[lcn]
+	if !ok {
+		return 0, fmt.Errorf("motorola/bandplan: LCN %d not in table", lcn)
+	}
+	return hz, nil
+}

--- a/internal/radio/motorola/control.go
+++ b/internal/radio/motorola/control.go
@@ -1,0 +1,149 @@
+package motorola
+
+import (
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// LockState is the payload of cc.locked / cc.lost events emitted by
+// the Motorola control-channel state machine.
+type LockState struct {
+	FrequencyHz uint32
+	SystemID    uint16
+}
+
+// ControlChannel ingests OSWs from a single SmartZone control channel,
+// emits cc.locked the first time it sees a System-ID announcement on
+// a freshly-tuned device, and republishes voice grants as
+// events.KindGrant carrying a `trunking.Grant` payload.
+//
+// The state machine is intentionally minimal: it watches for system
+// identification (so a stale device → frequency mapping doesn't fire
+// false locks) and for the two voice-grant opcodes. Adjacent-site
+// reactions, neighbour-list maintenance, and roaming live in the
+// engine layer once the higher-level state machine wants them.
+type ControlChannel struct {
+	bus        *events.Bus
+	log        *slog.Logger
+	systemName string
+	freqHz     uint32
+	resolver   Resolver
+	now        func() time.Time
+
+	mu     sync.Mutex
+	locked bool
+	last   LockState
+}
+
+// Options configure a ControlChannel.
+type Options struct {
+	Bus        *events.Bus
+	Log        *slog.Logger
+	SystemName string
+	// FrequencyHz is the control-channel frequency this state machine
+	// is bound to. Carried in cc.locked / cc.lost payloads.
+	FrequencyHz uint32
+	// Resolver maps grant LCNs to voice-channel frequencies. Required
+	// when grant events should carry an actual Hz; optional otherwise.
+	Resolver Resolver
+	Now      func() time.Time
+}
+
+// New constructs a ControlChannel.
+func New(opts Options) *ControlChannel {
+	log := opts.Log
+	if log == nil {
+		log = slog.Default()
+	}
+	now := opts.Now
+	if now == nil {
+		now = time.Now
+	}
+	return &ControlChannel{
+		bus:        opts.Bus,
+		log:        log,
+		systemName: opts.SystemName,
+		freqHz:     opts.FrequencyHz,
+		resolver:   opts.Resolver,
+		now:        now,
+	}
+}
+
+// Ingest hands a single decoded OSW to the state machine. Real
+// captures arrive via an upstream MSK demod + BCH decoder; tests
+// publish OSWs directly.
+func (c *ControlChannel) Ingest(o OSW) {
+	if o.IsIdle() {
+		return
+	}
+
+	if sys, ok := o.AsSystemID(); ok {
+		c.maybeLock(LockState{FrequencyHz: c.freqHz, SystemID: sys.ID})
+		return
+	}
+	if grant, ok := o.AsGroupVoiceChannelGrant(); ok {
+		c.publishGrant(grant)
+		return
+	}
+}
+
+func (c *ControlChannel) publishGrant(g GroupVoiceChannelGrant) {
+	if c.bus == nil {
+		return
+	}
+	freq := uint32(0)
+	if c.resolver != nil {
+		if hz, err := c.resolver.Frequency(g.LCN); err == nil {
+			freq = hz
+		} else {
+			c.log.Debug("motorola: band-plan resolution failed", "lcn", g.LCN, "err", err)
+		}
+	}
+	c.bus.Publish(events.Event{
+		Kind: events.KindGrant,
+		Payload: trunking.Grant{
+			System:        c.systemName,
+			Protocol:      "motorola",
+			GroupID:       uint32(g.GroupAddress),
+			FrequencyHz:   freq,
+			ChannelID:     0, // Motorola LCNs carry no separate band-ID; we
+			// represent the LCN in ChannelNumber so downstream
+			// consumers that don't yet have a band plan still see
+			// something useful.
+			ChannelNum: g.LCN,
+			At:         c.now(),
+		},
+	})
+	c.log.Debug("motorola: grant",
+		"system", c.systemName, "tg", g.GroupAddress,
+		"lcn", g.LCN, "freq_hz", freq)
+}
+
+func (c *ControlChannel) maybeLock(s LockState) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.locked && c.last == s {
+		return
+	}
+	c.locked = true
+	c.last = s
+	c.bus.Publish(events.Event{Kind: events.KindCCLocked, Payload: s})
+	c.log.Info("motorola cc locked",
+		"freq", s.FrequencyHz, "sys", s.SystemID, "system", c.systemName)
+}
+
+// MarkLost publishes cc.lost and resets the locked flag. The trunking
+// engine's hunter calls this when the control channel goes silent.
+func (c *ControlChannel) MarkLost() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !c.locked {
+		return
+	}
+	c.locked = false
+	c.bus.Publish(events.Event{Kind: events.KindCCLost, Payload: c.last})
+}

--- a/internal/radio/motorola/motorola.go
+++ b/internal/radio/motorola/motorola.go
@@ -1,0 +1,39 @@
+// Package motorola decodes Motorola Type II / SmartZone trunked control
+// channels. The SmartZone control channel transmits 84-bit Outbound
+// Status Words (OSWs) at 3600 baud over an MSK-modulated carrier;
+// after sync detection and BCH(64,16,11) error correction, each OSW
+// reduces to 32 information bits split as a 16-bit address and a
+// 16-bit command/opcode field.
+//
+// What's wired here:
+//
+//   sync.go      Standard Motorola control-channel sync words and a
+//                sliding correlator over a bit stream.
+//   osw.go       OSW assemble/parse over the 32 information bits.
+//   opcodes.go   Opcode constants + per-opcode payload accessors
+//                (Group Voice Channel Grant, Adjacent Site,
+//                System ID, Idle).
+//   bandplan.go  Logical Channel Number → frequency (Hz) resolver
+//                with linear and table-backed strategies.
+//   control.go   Control-channel state machine ingesting OSWs and
+//                emitting cc.locked / grant events on the bus.
+//
+// What's NOT yet wired (honest deferrals so a contributor can pick
+// these up):
+//
+//   - The MSK demodulator that turns IQ from a 3600-baud control
+//     channel into the bits this package consumes. The DSP package
+//     has FM / C4FM / H-DQPSK; MSK is a special-case CPFSK that fits
+//     in the same shape.
+//   - BCH(64,16,11) decoder for the OSW FEC. The information-bit
+//     parser here assumes the upstream caller has already corrected
+//     errors.
+//   - Type I sub-band decoding. Type II is the modern variant and
+//     the focus here; Type I support layers on top.
+//   - Vendor-specific opcode coverage. The opcode list focuses on
+//     the SmartZone subset that carries voice grants and system
+//     identification.
+//
+// All of the above slot into the existing engine + recorder + composer
+// pipeline through events.KindGrant once they ship.
+package motorola

--- a/internal/radio/motorola/motorola_test.go
+++ b/internal/radio/motorola/motorola_test.go
@@ -1,0 +1,282 @@
+package motorola
+
+import (
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+func TestOSWAssembleParseRoundTrip(t *testing.T) {
+	in := OSW{Address: 0x1234, Command: 0x308A}
+	bytes := AssembleOSW(in)
+	if len(bytes) != 4 {
+		t.Fatalf("AssembleOSW = %d bytes", len(bytes))
+	}
+	got, err := ParseOSW(bytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != in {
+		t.Errorf("round-trip = %+v, want %+v", got, in)
+	}
+}
+
+func TestOSWFromBitsRoundTrip(t *testing.T) {
+	in := OSW{Address: 0xABCD, Command: 0x080F}
+	bits := OSWBits(in)
+	if len(bits) != 32 {
+		t.Fatalf("OSWBits len = %d", len(bits))
+	}
+	got, err := OSWFromBits(bits)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != in {
+		t.Errorf("round-trip = %+v", got)
+	}
+}
+
+func TestOpcodeAndLCN(t *testing.T) {
+	// Command = 0x308A → opcode 0x308 (Group Voice Channel Grant), LCN 0xA
+	o := OSW{Address: 0x1234, Command: 0x308A}
+	if o.Opcode() != OpGroupVoiceChannelGrant {
+		t.Errorf("Opcode = %s, want GroupVoiceChannelGrant", o.Opcode())
+	}
+	if o.LCN() != 0xA {
+		t.Errorf("LCN = %X, want A", o.LCN())
+	}
+}
+
+func TestAsGroupVoiceChannelGrant(t *testing.T) {
+	o := OSW{Address: 0x1234, Command: 0x308A}
+	g, ok := o.AsGroupVoiceChannelGrant()
+	if !ok {
+		t.Fatal("expected grant")
+	}
+	if g.GroupAddress != 0x1234 || g.LCN != 0xA {
+		t.Errorf("grant = %+v", g)
+	}
+
+	// Idle isn't a grant.
+	if _, ok := (OSW{Command: 0x28D0}).AsGroupVoiceChannelGrant(); ok {
+		t.Error("idle OSW reported a grant")
+	}
+}
+
+func TestAsSystemIDAndAdjacent(t *testing.T) {
+	sysOSW := OSW{Address: 0xCAFE, Command: 0x0805}
+	if s, ok := sysOSW.AsSystemID(); !ok || s.ID != 0xCAFE || s.Class != 5 {
+		t.Errorf("system id = %+v ok=%v", s, ok)
+	}
+
+	adjOSW := OSW{Address: 0x0042, Command: 0x31B7}
+	if a, ok := adjOSW.AsAdjacentSite(); !ok || a.SiteID != 0x42 || a.LCN != 7 {
+		t.Errorf("adjacent = %+v ok=%v", a, ok)
+	}
+}
+
+func TestIsIdle(t *testing.T) {
+	for _, c := range []uint16{0x28D0, 0x290F} {
+		if !(OSW{Command: c}).IsIdle() {
+			t.Errorf("Command %04X should be idle", c)
+		}
+	}
+	if (OSW{Command: 0x308A}).IsIdle() {
+		t.Error("voice grant flagged as idle")
+	}
+}
+
+func TestOpcodeString(t *testing.T) {
+	cases := map[Opcode]string{
+		OpGroupVoiceChannelGrant: "GroupVoiceChannelGrant",
+		OpAdjacentSiteStatus:     "AdjacentSiteStatus",
+		OpSystemIDExtended:       "SystemIDExtended",
+		OpIdle1:                  "Idle",
+		Opcode(0x999):            "Opcode(999)",
+	}
+	for op, want := range cases {
+		if got := op.String(); got != want {
+			t.Errorf("Opcode(%X).String() = %s, want %s", uint16(op), got, want)
+		}
+	}
+}
+
+func TestLinearBandPlan(t *testing.T) {
+	bp := LinearBandPlan{BaseHz: 851_000_000, SpacingHz: 25_000, Offset: 0}
+	if hz, _ := bp.Frequency(0); hz != 851_000_000 {
+		t.Errorf("LCN 0 → %d", hz)
+	}
+	if hz, _ := bp.Frequency(10); hz != 851_250_000 {
+		t.Errorf("LCN 10 → %d", hz)
+	}
+	bp2 := LinearBandPlan{BaseHz: 851_000_000, SpacingHz: 25_000, Offset: -3}
+	if _, err := bp2.Frequency(1); err == nil {
+		t.Error("negative effective offset should error")
+	}
+	if _, err := (LinearBandPlan{BaseHz: 1, SpacingHz: 0}).Frequency(1); err == nil {
+		t.Error("zero spacing should error")
+	}
+}
+
+func TestTableBandPlan(t *testing.T) {
+	bp := TableBandPlan{1: 154_115_000, 2: 154_205_000}
+	if hz, _ := bp.Frequency(1); hz != 154_115_000 {
+		t.Errorf("LCN 1 → %d", hz)
+	}
+	if _, err := bp.Frequency(99); err == nil {
+		t.Error("missing LCN should error")
+	}
+}
+
+func TestSyncDetectorMatchesCleanSync(t *testing.T) {
+	det := NewSyncDetector(OutboundSyncBits(), 0)
+	stream := make([]byte, 80)
+	copy(stream[20:], OutboundSyncBits())
+	hits, _ := det.Process(nil, stream, 0)
+	if len(hits) != 1 || hits[0] != 20+SyncBits-1 {
+		t.Errorf("hits = %v, want [%d]", hits, 20+SyncBits-1)
+	}
+}
+
+func TestSyncDetectorTolerance(t *testing.T) {
+	stream := make([]byte, 80)
+	copy(stream[5:], OutboundSyncBits())
+	stream[7] ^= 1
+	stream[15] ^= 1
+
+	det := NewSyncDetector(OutboundSyncBits(), 2)
+	hits, _ := det.Process(nil, stream, 0)
+	if len(hits) != 1 {
+		t.Errorf("hits = %v, want 1 with tolerance 2", hits)
+	}
+
+	det2 := NewSyncDetector(OutboundSyncBits(), 0)
+	hits2, _ := det2.Process(nil, stream, 0)
+	if len(hits2) != 0 {
+		t.Errorf("hits = %v, want 0 with tolerance 0", hits2)
+	}
+}
+
+func TestControlChannelEmitsLockOnSystemID(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{
+		Bus:         bus,
+		SystemName:  "TestSys",
+		FrequencyHz: 851_000_000,
+	})
+	cc.Ingest(OSW{Address: 0xCAFE, Command: 0x0800})
+
+	select {
+	case ev := <-sub.C:
+		if ev.Kind != events.KindCCLocked {
+			t.Fatalf("kind = %s", ev.Kind)
+		}
+		ls, ok := ev.Payload.(LockState)
+		if !ok || ls.SystemID != 0xCAFE || ls.FrequencyHz != 851_000_000 {
+			t.Errorf("lock state = %+v", ev.Payload)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("no event")
+	}
+}
+
+func TestControlChannelPublishesGrant(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{
+		Bus:         bus,
+		SystemName:  "TestSys",
+		FrequencyHz: 851_000_000,
+		Resolver: LinearBandPlan{
+			BaseHz: 866_000_000, SpacingHz: 25_000, Offset: 0,
+		},
+	})
+	cc.Ingest(OSW{Address: 0x1234, Command: 0x3088}) // grant; LCN=8
+
+	select {
+	case ev := <-sub.C:
+		if ev.Kind != events.KindGrant {
+			t.Fatalf("kind = %s", ev.Kind)
+		}
+		g, ok := ev.Payload.(trunking.Grant)
+		if !ok {
+			t.Fatalf("payload type = %T", ev.Payload)
+		}
+		if g.System != "TestSys" || g.Protocol != "motorola" {
+			t.Errorf("grant identity = %+v", g)
+		}
+		if g.GroupID != 0x1234 || g.ChannelNum != 8 {
+			t.Errorf("grant group/lcn = %+v", g)
+		}
+		if g.FrequencyHz != 866_200_000 {
+			t.Errorf("grant freq = %d, want 866_200_000", g.FrequencyHz)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("no grant event")
+	}
+}
+
+func TestControlChannelGrantWithoutResolverHasZeroFreq(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, SystemName: "X", FrequencyHz: 1})
+	cc.Ingest(OSW{Address: 0x100, Command: 0x3081})
+	ev := <-sub.C
+	g := ev.Payload.(trunking.Grant)
+	if g.FrequencyHz != 0 {
+		t.Errorf("freq = %d, want 0 (no resolver)", g.FrequencyHz)
+	}
+	if g.ChannelNum != 1 {
+		t.Errorf("LCN = %d, want 1", g.ChannelNum)
+	}
+}
+
+func TestControlChannelIgnoresIdle(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, SystemName: "X", FrequencyHz: 1})
+	cc.Ingest(OSW{Command: 0x28D0}) // idle
+	cc.Ingest(OSW{Command: 0x290F}) // idle
+
+	select {
+	case ev := <-sub.C:
+		t.Errorf("idle OSW produced an event: %s", ev.Kind)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestControlChannelMarkLost(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, SystemName: "X", FrequencyHz: 1})
+	cc.Ingest(OSW{Address: 0x42, Command: 0x0800})
+	<-sub.C // CCLocked
+
+	cc.MarkLost()
+	select {
+	case ev := <-sub.C:
+		if ev.Kind != events.KindCCLost {
+			t.Errorf("kind = %s, want cc.lost", ev.Kind)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("no cc.lost")
+	}
+}

--- a/internal/radio/motorola/opcodes.go
+++ b/internal/radio/motorola/opcodes.go
@@ -1,0 +1,131 @@
+package motorola
+
+import "fmt"
+
+// Opcode is the 12-bit operation field carried in the upper 12 bits
+// of the OSW.Command word (the lower 4 bits are an opcode-specific
+// parameter — typically the LCN / channel index for voice grants).
+//
+// Constants reflect the SmartZone subset most useful for trunking
+// follow-along; the full Motorola opcode space is much larger and
+// vendor-extended. Add to the list as needed.
+type Opcode uint16
+
+const (
+	OpUnknown                      Opcode = 0x000
+	OpGroupVoiceChannelGrant       Opcode = 0x308
+	OpGroupVoiceChannelGrantUpdate Opcode = 0x309
+	OpPrivateCallGrant             Opcode = 0x30B
+	OpAdjacentSiteStatus           Opcode = 0x31B
+	OpSystemIDExtended             Opcode = 0x080
+	OpDataChannelGrant             Opcode = 0x310
+	OpAffiliationResponse          Opcode = 0x320
+	OpIdle1                        Opcode = 0x28D
+	OpIdle2                        Opcode = 0x290
+	OpEncryption                   Opcode = 0x140
+	OpEmergency                    Opcode = 0x300
+)
+
+func (o Opcode) String() string {
+	switch o {
+	case OpGroupVoiceChannelGrant:
+		return "GroupVoiceChannelGrant"
+	case OpGroupVoiceChannelGrantUpdate:
+		return "GroupVoiceChannelGrantUpdate"
+	case OpPrivateCallGrant:
+		return "PrivateCallGrant"
+	case OpAdjacentSiteStatus:
+		return "AdjacentSiteStatus"
+	case OpSystemIDExtended:
+		return "SystemIDExtended"
+	case OpDataChannelGrant:
+		return "DataChannelGrant"
+	case OpAffiliationResponse:
+		return "AffiliationResponse"
+	case OpIdle1, OpIdle2:
+		return "Idle"
+	case OpEncryption:
+		return "Encryption"
+	case OpEmergency:
+		return "Emergency"
+	default:
+		return fmt.Sprintf("Opcode(%03X)", uint16(o))
+	}
+}
+
+// Opcode returns the 12-bit operation field encoded in OSW.Command.
+func (o OSW) Opcode() Opcode { return Opcode(o.Command >> 4) }
+
+// LCN returns the 4-bit logical-channel-number nibble that voice and
+// data grants pack into the bottom of OSW.Command.
+func (o OSW) LCN() uint16 { return o.Command & 0x000F }
+
+// IsIdle reports whether this OSW is one of the recognised
+// channel-idle / heartbeat opcodes.
+func (o OSW) IsIdle() bool {
+	op := o.Opcode()
+	return op == OpIdle1 || op == OpIdle2
+}
+
+// GroupVoiceChannelGrant is the high-level shape of a voice grant. The
+// Address field of the OSW carries the talkgroup; the LCN nibble
+// references an entry in the operator-supplied band plan.
+type GroupVoiceChannelGrant struct {
+	GroupAddress uint16
+	LCN          uint16
+}
+
+// AsGroupVoiceChannelGrant returns the structured grant if the OSW's
+// opcode is one of the voice-grant variants, otherwise (zero, false).
+func (o OSW) AsGroupVoiceChannelGrant() (GroupVoiceChannelGrant, bool) {
+	switch o.Opcode() {
+	case OpGroupVoiceChannelGrant, OpGroupVoiceChannelGrantUpdate:
+	default:
+		return GroupVoiceChannelGrant{}, false
+	}
+	return GroupVoiceChannelGrant{
+		GroupAddress: o.Address,
+		LCN:          o.LCN(),
+	}, true
+}
+
+// SystemID is the opaque identifier carried by OpSystemIDExtended
+// announcements. Address fields hold the system identifier; the
+// command field's high 12 bits are the opcode and low 4 are a
+// per-system "system-ID type" nibble.
+type SystemID struct {
+	ID    uint16
+	Class uint8 // low nibble of OSW.Command (system-ID variant)
+}
+
+// AsSystemID returns the structured system identifier if this is a
+// SystemIDExtended OSW, otherwise (zero, false).
+func (o OSW) AsSystemID() (SystemID, bool) {
+	if o.Opcode() != OpSystemIDExtended {
+		return SystemID{}, false
+	}
+	return SystemID{
+		ID:    o.Address,
+		Class: uint8(o.Command & 0x0F),
+	}, true
+}
+
+// AdjacentSite is a neighbour-site announcement. Site ID is in the
+// Address field; the LCN nibble references this site's control
+// channel within the operator's band plan.
+type AdjacentSite struct {
+	SiteID uint16
+	LCN    uint16
+}
+
+// AsAdjacentSite returns the structured adjacent-site descriptor if
+// this is an OpAdjacentSiteStatus OSW.
+func (o OSW) AsAdjacentSite() (AdjacentSite, bool) {
+	if o.Opcode() != OpAdjacentSiteStatus {
+		return AdjacentSite{}, false
+	}
+	return AdjacentSite{
+		SiteID: o.Address,
+		LCN:    o.LCN(),
+	}, true
+}

--- a/internal/radio/motorola/osw.go
+++ b/internal/radio/motorola/osw.go
@@ -1,0 +1,70 @@
+package motorola
+
+import (
+	"encoding/binary"
+	"fmt"
+)
+
+// OSW is one Outbound Status Word — a 32-bit information block that
+// rides every Motorola Type II / SmartZone control-channel frame
+// after sync, BCH(64,16,11) error correction, and de-interleaving.
+//
+// Field layout follows the most-cited public reference: the upper 16
+// bits carry an Address (talkgroup or radio ID, depending on opcode);
+// the lower 16 bits carry a Command field that combines a 12-bit
+// opcode with a 4-bit per-opcode parameter (typically the LCN for
+// voice grants).
+//
+// The package's higher-level helpers (in opcodes.go) interpret the
+// Command field per-opcode so callers don't need to know the
+// bit-packing.
+type OSW struct {
+	Address uint16
+	Command uint16
+}
+
+// AssembleOSW packs an OSW into 4 bytes (32 bits) MSB-first. Used by
+// tests and for any future encoder work.
+func AssembleOSW(o OSW) []byte {
+	out := make([]byte, 4)
+	binary.BigEndian.PutUint16(out[0:2], o.Address)
+	binary.BigEndian.PutUint16(out[2:4], o.Command)
+	return out
+}
+
+// ParseOSW reads 4 bytes (32 bits MSB-first) into an OSW.
+func ParseOSW(info []byte) (OSW, error) {
+	if len(info) != 4 {
+		return OSW{}, fmt.Errorf("motorola: OSW info must be 4 bytes, got %d", len(info))
+	}
+	return OSW{
+		Address: binary.BigEndian.Uint16(info[0:2]),
+		Command: binary.BigEndian.Uint16(info[2:4]),
+	}, nil
+}
+
+// OSWFromBits packs 32 MSB-first bits (each entry 0/1) into an OSW.
+func OSWFromBits(bits []byte) (OSW, error) {
+	if len(bits) != 32 {
+		return OSW{}, fmt.Errorf("motorola: OSW requires 32 bits, got %d", len(bits))
+	}
+	info := make([]byte, 4)
+	for i := 0; i < 32; i++ {
+		if bits[i]&1 != 0 {
+			info[i>>3] |= 1 << uint(7-(i&7))
+		}
+	}
+	return ParseOSW(info)
+}
+
+// OSWBits returns the 32 MSB-first bits of an OSW.
+func OSWBits(o OSW) []byte {
+	bytes := AssembleOSW(o)
+	out := make([]byte, 32)
+	for i := 0; i < 32; i++ {
+		if bytes[i>>3]&(1<<uint(7-(i&7))) != 0 {
+			out[i] = 1
+		}
+	}
+	return out
+}

--- a/internal/radio/motorola/sync.go
+++ b/internal/radio/motorola/sync.go
@@ -1,0 +1,81 @@
+package motorola
+
+// SyncWord is the 24-bit sync sequence prefacing each Motorola Type II
+// SmartZone control-channel frame. Stored as MSB-first bits to mesh
+// with the rest of the radio stack's framing layer.
+//
+// The standard Motorola SmartZone outbound control-channel sync is
+// 0xA4D7AA (binary `1010 0100 1101 0111 1010 1010`) per public
+// reference implementations. As with the other protocol packages, the
+// constant is best-effort and should be cross-checked against an
+// authoritative reference before trusting live captures.
+const (
+	OutboundSyncHex uint32 = 0xA4D7AA
+	SyncBits               = 24
+)
+
+// OutboundSyncBits returns the 24 bits of the outbound sync MSB-first.
+func OutboundSyncBits() []byte {
+	out := make([]byte, SyncBits)
+	for i := 0; i < SyncBits; i++ {
+		out[i] = byte((OutboundSyncHex >> uint(SyncBits-1-i)) & 1)
+	}
+	return out
+}
+
+// SyncDetector slides a window over a 0/1 bit stream and reports
+// indices where the sync word matches within `tolerance` mismatched
+// bits. Mirrors the same shape used by the P25 / DMR / NXDN sync
+// detectors so the higher-level state machine stays consistent.
+type SyncDetector struct {
+	pattern   []byte
+	tolerance int
+	hist      []byte
+	primed    int
+	pos       int
+}
+
+// NewSyncDetector returns a detector for the supplied pattern. Pass
+// the length-24 result of OutboundSyncBits() unless you have a
+// vendor-specific sync to track.
+func NewSyncDetector(pattern []byte, tolerance int) *SyncDetector {
+	if tolerance < 0 {
+		tolerance = 1
+	}
+	cp := make([]byte, len(pattern))
+	copy(cp, pattern)
+	return &SyncDetector{
+		pattern:   cp,
+		tolerance: tolerance,
+		hist:      make([]byte, len(cp)),
+	}
+}
+
+// Process scans src and appends to dst the absolute bit indices where
+// the sync word ends within tolerance.
+func (s *SyncDetector) Process(dst []int, src []byte, baseIndex int) ([]int, int) {
+	n := len(s.pattern)
+	for i, b := range src {
+		s.hist[s.pos] = b & 1
+		s.pos = (s.pos + 1) % n
+		if s.primed < n {
+			s.primed++
+			continue
+		}
+		mismatch := 0
+		idx := s.pos
+		for k := 0; k < n; k++ {
+			if s.hist[idx] != s.pattern[k] {
+				mismatch++
+				if mismatch > s.tolerance {
+					break
+				}
+			}
+			idx = (idx + 1) % n
+		}
+		if mismatch <= s.tolerance {
+			dst = append(dst, baseIndex+i)
+		}
+	}
+	return dst, baseIndex + len(src)
+}


### PR DESCRIPTION
First trunking system on the TrunkTracker-style multi-system path:
**Motorola Type II / SmartZone**. Same shape as the existing P25 /
DMR / NXDN packages — protocol-level OSW parser, opcode set, band
plan, and control state machine that publishes `cc.locked` + `grant`
events on the existing bus.

## What this delivers

### `internal/radio/motorola/` (new package)

- **`motorola.go`** — package doc with the explicit deferral list
  (MSK demod, BCH(64,16,11), Type I, full opcode coverage) so
  contributors know exactly where to plug in next.
- **`sync.go`** — outbound sync word constant
  (`OutboundSyncHex = 0xA4D7AA`) + a sliding correlator with
  configurable mismatch tolerance, mirroring the same shape used
  by the P25 / DMR / NXDN sync detectors.
- **`osw.go`** — `OSW = {Address: 16, Command: 16}`. Round-trip
  `AssembleOSW` / `ParseOSW` over 4-byte info + bit-level helpers
  (`OSWBits`, `OSWFromBits`).
- **`opcodes.go`** — `Opcode` constants for the SmartZone subset:
  `GroupVoiceChannelGrant` (0x308), `GroupVoiceChannelGrantUpdate`
  (0x309), `AdjacentSiteStatus` (0x31B), `SystemIDExtended`
  (0x080), `Idle1` / `Idle2` (0x28D / 0x290), `Encryption` (0x140),
  `Emergency` (0x300), `DataChannelGrant` (0x310). Per-opcode
  accessors: `AsGroupVoiceChannelGrant`, `AsSystemID`,
  `AsAdjacentSite`.
- **`bandplan.go`** — `Resolver` interface with two strategies:
  - `LinearBandPlan{BaseHz, SpacingHz, Offset}` for typical
    NPSPAC / state-wide SmartZone plans.
  - `TableBandPlan{lcn → Hz}` for non-linear VHF / UHF plans.
- **`control.go`** — `ControlChannel` state machine. `Ingest(OSW)`
  emits `events.KindCCLocked` on `SystemIDExtended` and
  `events.KindGrant` (carrying `trunking.Grant{Protocol:
  "motorola"}`) on voice grants. The grant's `FrequencyHz` is
  resolved via the supplied band plan; with no resolver,
  `FrequencyHz=0` and `ChannelNum=lcn` so downstream consumers
  still see something useful. `MarkLost` mirrors the other
  protocols' watchdog hook.

## Test plan
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `go test -race -count=1 ./...`
- [x] `make integration`
- [x] OSW round-trip (bytes + bits)
- [x] Opcode + LCN extraction from `Command` field
- [x] `AsGroupVoiceChannelGrant`, `AsSystemID`, `AsAdjacentSite`
- [x] `IsIdle` recognition + `Opcode.String()` coverage
- [x] `LinearBandPlan` with positive / negative offsets, zero
      spacing rejection
- [x] `TableBandPlan` lookup hit + miss
- [x] Sync detector clean match + tolerance + over-budget rejection
- [x] Control channel emits `cc.locked` on `SystemIDExtended`
- [x] Control channel publishes a `Grant` with the correct
      `(System, Protocol, GroupID, FrequencyHz, ChannelNum)` when
      a resolver is configured
- [x] Grant publication without a resolver leaves `FrequencyHz=0`
      and carries the LCN in `ChannelNum`
- [x] Idle OSWs produce no events
- [x] `MarkLost` publishes `cc.lost` after a prior lock

## Roadmap status

The README's Roadmap section is updated:

- ✅ **1. Tone-out alerting** — landed.
- 🟡 **2. TrunkTracker-style multi-system grant following** —
  Motorola OSW parser + opcode set + band plan + control state
  machine all in place; **MSK demod** and **BCH(64,16,11)** are
  the gating pieces for live captures (called out in the package
  doc). EDACS / LTR / MPT-1327 / P25 Phase 2 still ahead.
- 3. Simulcast mitigation — DSP work.
- 4. Expanding digital-mode coverage — vocoders + more protocols.

## Honest caveats
- The OSW field layout (address-then-command, opcode in upper 12 bits
  of command, LCN in low 4) follows the most-cited public reference
  but should be cross-checked against an authoritative source before
  trusting live captures, same standing caveat as the P25 / DMR /
  NXDN packages carry.
- No code changes outside `internal/radio/motorola/` and the README;
  every other component already accepts grants via the events bus.

https://claude.ai/code/session_01MQSV8EVnH6nsGUpcWep7UF

---
_Generated by [Claude Code](https://claude.ai/code/session_01MQSV8EVnH6nsGUpcWep7UF)_