### PR TITLE
Adaptive equalizer (LMS + CMA) for simulcast mitigation (Roadmap item 3 — partial)

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Each addition is a contained `internal/radio/<system>/` package that
 plugs into the engine via the existing event bus — no changes to
 the engine, recorder, composer, or API surfaces needed.
 
-### 3. Simulcast mitigation (the SDR-side equivalent of "True I/Q")
+### 3. Simulcast mitigation (the SDR-side equivalent of "True I/Q") 🟡 partial
 
 Premium hardware scanners advertise a "True I/Q" front-end that
 fights **simulcast distortion** — the audio garble you hear when
@@ -162,23 +162,44 @@ the symbols (it's effectively self-multipath). GopherTrunk runs on
 SDR hardware so it always has full I/Q access; the actual win
 versus a hardware scanner is what you do with it once you have it.
 
-Two complementary improvements:
+What's wired:
 
-- **Per-channel adaptive equalizer.** A new `internal/dsp/equalizer`
-  package implementing an LMS or RLS feed-forward equalizer slotted
-  between the channelizer and the demodulator. Fights inter-symbol
-  interference from multipath / simulcast delay spread. Most
-  effective on digital protocols (P25 / DMR / NXDN) where pilot
-  symbols give the equalizer something to lock to; for analog FM
-  the same multipath becomes audible artefacts that the equalizer
-  can soften via the IQ envelope.
+- **`internal/dsp/equalizer`** ships two adaptive equalizers for
+  the demod chain:
+  - **LMS** (`lms.go`) — complex tapped-delay-line FIR with the
+    standard Least-Mean-Squares update
+    `w[n+1] = w[n] + μ · x[n] · conj(e[n])`. Trained with a
+    reference symbol (training preamble) or in decision-directed
+    mode with the slicer's hard decision. Centre-spike init makes
+    a clean channel benign; on a 2-tap multipath QPSK channel the
+    test sweep drives MSE down by > 4× over 4 000 symbols.
+  - **CMA** (`cma.go`) — Constant Modulus Algorithm blind
+    equalizer (Godard/CMA-2 cost) for PSK-family signals where no
+    training preamble is available. Drives `|y|^2` toward a
+    configurable `R^2`; documented phase-blindness caveat.
+  - Both expose `Reset()`, `Taps()`, and a single-sample
+    `Process` so a chain stage can drop them in between the
+    channelizer and the symbol-time-recovery / demodulator stages.
+- Tests cover LMS convergence on a 2-tap multipath QPSK channel
+  (early vs late MSE), centre-spike reset, bad-config panics,
+  CMA constellation opening (RMS deviation of `|y|^2` from `R^2`
+  after settle), CMA reset, and delay-aligned passthrough on a
+  clean channel.
+
+Still ahead:
+
+- **Wiring into the composer chain** so a per-call equaliser slot
+  lights up automatically for protocols that benefit. This is the
+  natural follow-up once a digital protocol with pilot symbols
+  (P25 Phase 1 once the trellis tables land, Motorola Type II
+  once the MSK demod ships) is end-to-end.
 - **Multi-receiver IQ combining.** When two RTL-SDR dongles are
-  connected to antennas at different positions (or the same antenna
-  via a splitter), per-tower IQ streams can be coherently combined
-  via maximal-ratio or selection combining to recover the cleaner
-  stream. The `sdr.Pool` already supports multiple devices; the
-  composer's chain abstraction lets a "diversity combiner" stage
-  slot in ahead of the demodulator.
+  connected to antennas at different positions (or the same
+  antenna via a splitter), per-tower IQ streams can be coherently
+  combined via maximal-ratio or selection combining to recover
+  the cleaner stream. `sdr.Pool` already supports multiple
+  devices; the composer's chain abstraction lets a diversity
+  combiner stage slot in ahead of the demodulator.
 
 Both items live under `internal/dsp/` and wire into the existing
 demod chains without touching the trunking engine or higher

--- a/internal/dsp/equalizer/cma.go
+++ b/internal/dsp/equalizer/cma.go
@@ -1,0 +1,125 @@
+package equalizer
+
+// CMA is the Constant Modulus Algorithm — a blind adaptive equaliser
+// that requires no training sequence. It exploits the fact that
+// PSK-family signals (BPSK / QPSK / π/4-DQPSK / 8PSK) have a constant
+// modulus on the air; multipath / simulcast distortion blurs that
+// constant-magnitude property, and CMA drives the output back toward
+// it.
+//
+// Cost function and gradient (Godard / CMA-2):
+//
+//   J = E[(|y|^2 - R^2)^2]
+//   ∂J/∂w*  ∝  (|y|^2 - R^2) · y · conj(x)
+//   w[n+1]  =  w[n]  -  μ · (|y|^2 - R^2) · y · conj(x)
+//
+// Pick R^2 so the equilibrium weight scaling matches the expected
+// constellation. For unit-magnitude PSK use R^2 = 1; QPSK with
+// Gray-coded ±1±j has |y|^2 = 2 so R^2 = 2 is conventional.
+//
+// Caveats:
+//
+//   - CMA is phase-blind. After convergence the constellation may
+//     sit at any rotation; downstream symbol mapping must apply a
+//     constellation-aware phase recovery (a per-constellation rotator
+//     using known training symbols, or differential decoding).
+//   - On non-constant-modulus signals (FM, OQPSK, QAM) CMA's cost
+//     function isn't zero at the right answer; use LMS in
+//     decision-directed mode there.
+type CMA struct {
+	taps      []complex64
+	hist      []complex64
+	histPos   int
+	stepSize  float32
+	target    float32 // R^2
+}
+
+// NewCMA constructs a blind equaliser. `target` is the desired squared
+// modulus (R^2): use 1.0 for unit-modulus PSK, 2.0 for ±1±j QPSK.
+func NewCMA(taps int, stepSize, target float32) *CMA {
+	if taps <= 0 {
+		panic("equalizer: CMA taps must be > 0")
+	}
+	if target <= 0 {
+		panic("equalizer: CMA target must be > 0")
+	}
+	c := &CMA{
+		taps:     make([]complex64, taps),
+		hist:     make([]complex64, taps),
+		stepSize: stepSize,
+		target:   target,
+	}
+	c.taps[taps/2] = complex(1, 0)
+	return c
+}
+
+// Reset returns the equaliser to centre-spike initial state.
+func (c *CMA) Reset() {
+	for i := range c.taps {
+		c.taps[i] = 0
+	}
+	c.taps[len(c.taps)/2] = complex(1, 0)
+	for i := range c.hist {
+		c.hist[i] = 0
+	}
+	c.histPos = 0
+}
+
+// Taps returns a copy of the current weight vector.
+func (c *CMA) Taps() []complex64 {
+	out := make([]complex64, len(c.taps))
+	copy(out, c.taps)
+	return out
+}
+
+// Process consumes one input sample and returns the equalised output.
+// The error proxy (|y|^2 - R^2) is also returned for diagnostics /
+// convergence-monitoring; once it settles near zero the equaliser
+// has opened the constellation.
+func (c *CMA) Process(x complex64) (complex64, float32) {
+	c.hist[c.histPos] = x
+	c.histPos = (c.histPos + 1) % len(c.hist)
+
+	// FIR output (same convolution as LMS).
+	var yr, yi float32
+	idx := c.histPos - 1
+	if idx < 0 {
+		idx = len(c.hist) - 1
+	}
+	for i := 0; i < len(c.taps); i++ {
+		hr, hi := real(c.hist[idx]), imag(c.hist[idx])
+		tr, ti := real(c.taps[i]), imag(c.taps[i])
+		yr += tr*hr - ti*hi
+		yi += tr*hi + ti*hr
+		idx--
+		if idx < 0 {
+			idx = len(c.hist) - 1
+		}
+	}
+	y := complex(yr, yi)
+
+	// Error proxy = |y|^2 - R^2.
+	mag2 := yr*yr + yi*yi
+	err := mag2 - c.target
+
+	// Weight update: w_k -= μ · err · y · conj(x[n-k]).
+	mu := c.stepSize
+	idx = c.histPos - 1
+	if idx < 0 {
+		idx = len(c.hist) - 1
+	}
+	for i := 0; i < len(c.taps); i++ {
+		xr, xi := real(c.hist[idx]), imag(c.hist[idx])
+		// y · conj(x) = (yr + j*yi)(xr - j*xi) = (yr*xr + yi*xi) + j*(yi*xr - yr*xi)
+		ur := yr*xr + yi*xi
+		ui := yi*xr - yr*xi
+		// scale by err and step size, subtract.
+		tr, ti := real(c.taps[i]), imag(c.taps[i])
+		c.taps[i] = complex(tr-mu*err*ur, ti-mu*err*ui)
+		idx--
+		if idx < 0 {
+			idx = len(c.hist) - 1
+		}
+	}
+	return y, err
+}

--- a/internal/dsp/equalizer/equalizer.go
+++ b/internal/dsp/equalizer/equalizer.go
@@ -1,0 +1,25 @@
+// Package equalizer implements adaptive channel equalizers used to
+// fight simulcast distortion — the inter-symbol interference produced
+// when multiple transmitters cover the same frequency at slightly
+// different arrival delays at the receiver. Premium hardware scanners
+// market this capability as "True I/Q"; with an SDR we always have
+// I/Q, so the win is what we do with it.
+//
+// Two complementary algorithms ship here:
+//
+//   lms.go   Least-Mean-Squares adaptive FIR equalizer. Trained
+//            with reference (or decision-directed) symbols; fast to
+//            converge but needs a known training sequence (or a
+//            slicer it can trust).
+//   cma.go   Constant Modulus Algorithm — blind equalizer for
+//            constant-envelope modulations (PSK family). Drives the
+//            output toward a constant magnitude without ever needing
+//            a reference; useful when the upstream demod has no
+//            preamble to lock to.
+//
+// The package operates on complex64 IQ samples / symbols (matching
+// the rest of the DSP stack). Equalizers slot between the channelizer
+// and the symbol-time-recovery / demodulator stages of a per-call
+// chain — the demod-pipeline composer is the natural integration
+// point once a protocol decoder needs them on a real signal.
+package equalizer

--- a/internal/dsp/equalizer/equalizer_test.go
+++ b/internal/dsp/equalizer/equalizer_test.go
@@ -1,0 +1,236 @@
+package equalizer
+
+import (
+	"math"
+	"math/cmplx"
+	"math/rand"
+	"testing"
+)
+
+// genQPSK returns n unit-magnitude QPSK symbols deterministically
+// drawn from {±1±j}/√2. Constant-modulus, perfect for the equaliser
+// tests.
+func genQPSK(n int, seed int64) []complex64 {
+	r := rand.New(rand.NewSource(seed))
+	out := make([]complex64, n)
+	const inv = 0.7071067811865475 // 1/sqrt(2)
+	for i := range out {
+		var re, im float32
+		if r.Intn(2) == 0 {
+			re = inv
+		} else {
+			re = -inv
+		}
+		if r.Intn(2) == 0 {
+			im = inv
+		} else {
+			im = -inv
+		}
+		out[i] = complex(re, im)
+	}
+	return out
+}
+
+// passThroughChannel applies a 2-tap multipath model:
+// y[n] = x[n] + alpha * x[n-1].
+func passThroughChannel(x []complex64, alpha complex64) []complex64 {
+	y := make([]complex64, len(x))
+	for i := range x {
+		y[i] = x[i]
+		if i > 0 {
+			y[i] += complex(real(alpha)*real(x[i-1])-imag(alpha)*imag(x[i-1]),
+				real(alpha)*imag(x[i-1])+imag(alpha)*real(x[i-1]))
+		}
+	}
+	return y
+}
+
+// meanSquaredErr reports E[|a-b|^2] over the supplied prefix.
+func meanSquaredErr(a, b []complex64) float64 {
+	if len(a) != len(b) || len(a) == 0 {
+		return math.Inf(1)
+	}
+	var sum float64
+	for i := range a {
+		dr := float64(real(a[i]) - real(b[i]))
+		di := float64(imag(a[i]) - imag(b[i]))
+		sum += dr*dr + di*di
+	}
+	return sum / float64(len(a))
+}
+
+func TestLMSConvergesOnTwoTapChannel(t *testing.T) {
+	const n = 4000
+	tx := genQPSK(n, 42)
+	rx := passThroughChannel(tx, complex(0.5, 0))
+
+	// 11-tap symbol-spaced equaliser.
+	eq := NewLMS(11, 0.05)
+
+	// Train using known symbols; record |error|^2 over time.
+	earlyMSE := 0.0
+	const earlyWin = 200
+	for i := 0; i < earlyWin; i++ {
+		_, err := eq.Process(rx[i], tx[i])
+		earlyMSE += float64(real(err)*real(err) + imag(err)*imag(err))
+	}
+	earlyMSE /= earlyWin
+
+	for i := earlyWin; i < n-200; i++ {
+		eq.Process(rx[i], tx[i])
+	}
+
+	// After convergence, run another window without updates and
+	// measure the equalised MSE.
+	lateMSE := 0.0
+	const lateWin = 200
+	for i := n - lateWin; i < n; i++ {
+		y, _ := eq.Process(rx[i], tx[i])
+		dr := float64(real(tx[i]) - real(y))
+		di := float64(imag(tx[i]) - imag(y))
+		lateMSE += dr*dr + di*di
+	}
+	lateMSE /= lateWin
+
+	if lateMSE >= earlyMSE/4 {
+		t.Errorf("LMS did not converge: early MSE = %g, late MSE = %g (want late < early/4)",
+			earlyMSE, lateMSE)
+	}
+	if lateMSE > 0.05 {
+		t.Errorf("post-convergence MSE = %g, want < 0.05", lateMSE)
+	}
+}
+
+func TestLMSResetReturnsToPassThrough(t *testing.T) {
+	eq := NewLMS(7, 0.05)
+	// Drive the taps somewhere off-centre.
+	tx := genQPSK(200, 7)
+	rx := passThroughChannel(tx, complex(0.4, 0.1))
+	for i := range tx {
+		eq.Process(rx[i], tx[i])
+	}
+	// Reset and check the centre tap is 1+0j and the rest are 0.
+	eq.Reset()
+	taps := eq.Taps()
+	for i, tap := range taps {
+		want := complex64(0)
+		if i == len(taps)/2 {
+			want = complex(1, 0)
+		}
+		if tap != want {
+			t.Errorf("tap[%d] = %v, want %v", i, tap, want)
+		}
+	}
+}
+
+func TestLMSPanicsOnBadConfig(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic for taps=0")
+		}
+	}()
+	NewLMS(0, 0.01)
+}
+
+func TestCMAOpensConstantModulusConstellation(t *testing.T) {
+	const n = 8000
+	tx := genQPSK(n, 13)
+	rx := passThroughChannel(tx, complex(0.5, 0))
+
+	// Unit-modulus QPSK → R^2 = 1.
+	eq := NewCMA(11, 0.005, 1.0)
+	var lastErr float32
+	const settle = 4000
+	for i := 0; i < settle; i++ {
+		_, e := eq.Process(rx[i])
+		lastErr = e
+	}
+
+	// Measure the variance of |y|^2 around the target over a clean
+	// post-settle window.
+	const window = 2000
+	var sumDev float64
+	var sample float32
+	for i := settle; i < settle+window; i++ {
+		y, e := eq.Process(rx[i])
+		mag2 := real(y)*real(y) + imag(y)*imag(y)
+		dev := float64(mag2) - 1.0
+		sumDev += dev * dev
+		sample = e
+	}
+	rms := math.Sqrt(sumDev / float64(window))
+	_ = lastErr
+	_ = sample
+	if rms > 0.4 {
+		t.Errorf("CMA did not open the constellation: |y|^2 RMS deviation = %g, want < 0.4", rms)
+	}
+}
+
+func TestCMAResetReturnsToPassThrough(t *testing.T) {
+	eq := NewCMA(7, 0.005, 1.0)
+	tx := genQPSK(500, 7)
+	rx := passThroughChannel(tx, complex(0.3, 0.2))
+	for _, s := range rx {
+		eq.Process(s)
+	}
+	eq.Reset()
+	taps := eq.Taps()
+	for i, tap := range taps {
+		want := complex64(0)
+		if i == len(taps)/2 {
+			want = complex(1, 0)
+		}
+		if cmplx.Abs(complex128(tap-want)) > 1e-9 {
+			t.Errorf("tap[%d] = %v, want %v", i, tap, want)
+		}
+	}
+}
+
+func TestCMAPanicsOnBadConfig(t *testing.T) {
+	for _, tc := range []struct{ taps int; tgt float32 }{
+		{0, 1.0},
+		{5, 0.0},
+		{5, -1.0},
+	} {
+		func() {
+			defer func() {
+				if recover() == nil {
+					t.Errorf("expected panic for taps=%d target=%v", tc.taps, tc.tgt)
+				}
+			}()
+			NewCMA(tc.taps, 0.01, tc.tgt)
+		}()
+	}
+}
+
+func TestPassthroughIsBenignWithDelayAlignment(t *testing.T) {
+	// With α = 0 the channel is identity. A centre-spike-initialised
+	// equaliser produces a delayed copy of the input by construction
+	// (y[n] = x[n - N/2]); after that delay alignment the output
+	// should match the input essentially exactly when no training
+	// updates are made.
+	const taps = 7
+	const delay = taps / 2
+	tx := genQPSK(200, 99)
+	rx := passThroughChannel(tx, 0)
+	eq := NewLMS(taps, 0) // step size 0 → no updates
+	out := make([]complex64, len(tx))
+	for i := range tx {
+		y, _ := eq.Process(rx[i], 0) // desired ignored when stepSize is 0
+		out[i] = y
+	}
+	// Compare out[i] against tx[i-delay] for i >= delay; ignore the
+	// initial transient where history hasn't filled.
+	var mse float64
+	count := 0
+	for i := delay + 5; i < len(out); i++ {
+		dr := float64(real(out[i]) - real(tx[i-delay]))
+		di := float64(imag(out[i]) - imag(tx[i-delay]))
+		mse += dr*dr + di*di
+		count++
+	}
+	mse /= float64(count)
+	if mse > 1e-9 {
+		t.Errorf("identity channel passthrough MSE = %g, want ≈ 0", mse)
+	}
+}

--- a/internal/dsp/equalizer/lms.go
+++ b/internal/dsp/equalizer/lms.go
@@ -1,0 +1,124 @@
+package equalizer
+
+// LMS is a complex-valued tapped-delay-line adaptive equalizer trained
+// with the standard Least-Mean-Squares update rule:
+//
+//   y[n]   = sum_k w_k(n) * x[n-k]              // FIR output
+//   e[n]   = d[n] - y[n]                        // training error
+//   w[n+1] = w[n] + μ · x[n] · conj(e[n])       // weight update
+//
+// Notes:
+//
+//   - The reference signal d[n] can be a true training preamble or, in
+//     decision-directed mode, the slicer's hard decision on y[n].
+//   - μ (StepSize) sets the trade-off between convergence speed and
+//     mean-squared-error floor; 0.005 to 0.05 are reasonable starting
+//     points for symbol-spaced channels.
+//   - Initialised to a centre spike: w_{N/2}(0) = 1, others zero. That
+//     starts the equaliser as a pass-through so a benign channel
+//     stays roughly intact while training begins.
+//
+// The struct is not safe for concurrent use; one equaliser belongs
+// to one demod chain.
+type LMS struct {
+	taps      []complex64
+	hist      []complex64
+	histPos   int
+	stepSize  float32
+}
+
+// NewLMS constructs an equaliser with `taps` complex weights and the
+// supplied step size. taps must be > 0; an odd taps count is
+// recommended so the centre spike is well-defined.
+func NewLMS(taps int, stepSize float32) *LMS {
+	if taps <= 0 {
+		panic("equalizer: LMS taps must be > 0")
+	}
+	e := &LMS{
+		taps:     make([]complex64, taps),
+		hist:     make([]complex64, taps),
+		stepSize: stepSize,
+	}
+	e.taps[taps/2] = complex(1, 0) // centre-spike init
+	return e
+}
+
+// Reset returns the equaliser to its centre-spike initial state.
+func (e *LMS) Reset() {
+	for i := range e.taps {
+		e.taps[i] = 0
+	}
+	e.taps[len(e.taps)/2] = complex(1, 0)
+	for i := range e.hist {
+		e.hist[i] = 0
+	}
+	e.histPos = 0
+}
+
+// Taps returns a copy of the current weight vector. Useful in tests
+// and when an operator wants to inspect what the equaliser has
+// learned (or stash and restore taps across calls on the same
+// channel).
+func (e *LMS) Taps() []complex64 {
+	out := make([]complex64, len(e.taps))
+	copy(out, e.taps)
+	return out
+}
+
+// SetStepSize updates μ. Larger steps converge faster but settle to a
+// noisier weight vector.
+func (e *LMS) SetStepSize(step float32) { e.stepSize = step }
+
+// Process consumes one input sample x and updates the filter. The
+// `desired` argument is the reference / training symbol; in
+// decision-directed mode supply the upstream slicer's hard decision
+// on the previous output. Returns the equalised output y[n] and the
+// instantaneous error e[n].
+func (e *LMS) Process(x, desired complex64) (complex64, complex64) {
+	// Push x into the history buffer.
+	e.hist[e.histPos] = x
+	e.histPos = (e.histPos + 1) % len(e.hist)
+
+	// FIR output: y = sum_k taps[k] * hist_in_chronological_order[k].
+	// The most recent sample is at hist[histPos-1] (mod N).
+	var yr, yi float32
+	idx := e.histPos - 1
+	if idx < 0 {
+		idx = len(e.hist) - 1
+	}
+	for i := 0; i < len(e.taps); i++ {
+		hr, hi := real(e.hist[idx]), imag(e.hist[idx])
+		tr, ti := real(e.taps[i]), imag(e.taps[i])
+		yr += tr*hr - ti*hi
+		yi += tr*hi + ti*hr
+		idx--
+		if idx < 0 {
+			idx = len(e.hist) - 1
+		}
+	}
+	y := complex(yr, yi)
+
+	// Error e = d - y.
+	err := complex(real(desired)-yr, imag(desired)-yi)
+
+	// Weight update: w_k += μ * x[n-k] * conj(e).
+	mu := e.stepSize
+	er, ei := real(err), imag(err) // conj(err) = (er, -ei)
+	idx = e.histPos - 1
+	if idx < 0 {
+		idx = len(e.hist) - 1
+	}
+	for i := 0; i < len(e.taps); i++ {
+		xr, xi := real(e.hist[idx]), imag(e.hist[idx])
+		// (xr + j*xi) * (er - j*ei) = (xr*er + xi*ei) + j*(xi*er - xr*ei)
+		ur := xr*er + xi*ei
+		ui := xi*er - xr*ei
+		tr, ti := real(e.taps[i]), imag(e.taps[i])
+		e.taps[i] = complex(tr+mu*ur, ti+mu*ui)
+		idx--
+		if idx < 0 {
+			idx = len(e.hist) - 1
+		}
+	}
+	return y, err
+}


### PR DESCRIPTION
Next roadmap item — **simulcast mitigation** — partial: the
algorithmic core (LMS + CMA adaptive equalizers) is wired in. These
are the SDR-side equivalent of what Uniden markets as "True I/Q":
fighting the inter-symbol interference produced when multiple
transmitters cover the same frequency at slightly different arrival
delays at the receiver.

## What this delivers

### `internal/dsp/equalizer/` (new package)

- **`lms.go`** — Least-Mean-Squares adaptive FIR equalizer.
  Complex tapped-delay-line with the standard update rule
  `w[n+1] = w[n] + μ · x[n] · conj(e[n])`. Trained with a
  reference symbol (training preamble) or in decision-directed
  mode with the upstream slicer's hard decision. Centre-spike init
  makes a clean channel benign by construction (output = delayed
  input).
- **`cma.go`** — Constant Modulus Algorithm (Godard / CMA-2) blind
  equalizer for PSK-family signals where no training preamble is
  available. Drives `|y|^2` toward a configurable `R^2` so the
  constellation opens. Documents the phase-blindness caveat —
  downstream code must apply constellation-aware phase recovery
  (or differential decoding) since CMA is rotation-agnostic at
  convergence.
- Both equalizers expose `Reset()`, `Taps()`, and a single-sample
  `Process` so a chain stage can drop them in between the
  channelizer and the symbol-time-recovery / demodulator stages.

### Tests
- LMS convergence on a 2-tap multipath QPSK channel: early-window
  vs late-window MSE drops by > 4× over 4 000 symbols, with
  late-MSE ≤ 0.05.
- LMS reset returns taps to the centre-spike initial state.
- LMS panics on `taps=0`.
- CMA constellation opening: post-settle `|y|^2` RMS deviation
  from `R^2` stays below 0.4.
- CMA reset returns taps to centre-spike.
- CMA panics on `taps=0` / `target ≤ 0`.
- Delay-aligned passthrough on an identity channel reads zero MSE
  (verifying the centre-spike init's delay penalty is exactly N/2
  samples and nothing else changes).

### Test plan
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `go test -race -count=1 ./...`
- [x] `make integration`

## Roadmap status

- ✅ **1. Tone-out alerting** — landed.
- 🟡 **2. TrunkTracker-style multi-system grant following** —
  Motorola OSW + opcodes + band plan + state machine partial.
- 🟡 **3. Simulcast mitigation** — LMS + CMA cores landed (this
  PR). Wiring the equaliser into the composer chain and
  multi-receiver IQ combining are honest follow-ups, called out
  in the README so a contributor can pick them up.
- 4. Expanding digital-mode coverage — vocoders + more protocols.

## Honest deferrals
- **Wiring into the composer chain** so a per-call equaliser slot
  lights up automatically for protocols that benefit. Natural
  follow-up once a digital protocol with pilot symbols (P25
  Phase 1 once the trellis tables land, Motorola Type II once the
  MSK demod ships) is end-to-end.
- **Multi-receiver IQ combining** — coherent maximal-ratio / selection
  combining across the existing `sdr.Pool` for diversity-antenna or
  -position deployments.

## Bug caught while writing tests
The first cut of the passthrough test compared `out[i]` to `tx[i]`
directly and failed because the centre-spike initialisation
introduces an `N/2`-sample delay by design. Replaced with a
delay-aligned check against `tx[i - N/2]` so the test actually
asserts what the architecture promises (clean channel + zero
training updates → exact passthrough modulo the delay).

https://claude.ai/code/session_01MQSV8EVnH6nsGUpcWep7UF

---
_Generated by [Claude Code](https://claude.ai/code/session_01MQSV8EVnH6nsGUpcWep7UF)_