### PR TITLE
EDACS / GE-Marc CCW decoder (Roadmap item 2 — third trunked system)

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,11 +134,25 @@ What's wired:
   are honest deferrals — the package's doc comment lists them
   explicitly so a contributor can pick them up. Same pattern as
   the P25 trellis-tables / TSBK-interleaver gap.
+- **EDACS / GE-Marc.** `internal/radio/edacs/` — 40-bit Control
+  Channel Word (CCW) parser, command enum
+  (Idle, GroupVoiceGrant, ProVoiceGrant, IndividualCall,
+  DataGrant, SystemID, AdjacentSite, Emergency, Affiliation,
+  Encryption), per-command payload accessors that surface
+  encrypted / emergency status flags, an `LCN → Hz` band-plan
+  resolver mirroring the Motorola one, and a control-channel
+  state machine that publishes `cc.locked` on SystemID and
+  `grant` (with `trunking.Grant.Protocol = "edacs"`) on voice
+  grants. Tests cover CCW round-trip in bytes + bits, command
+  + LCN + status extraction, the per-command accessors
+  (including the ProVoice flag), both band-plan strategies,
+  sync detection with tolerance, and the full control-channel
+  emission path. The 9600-baud GMSK demodulator + the
+  interleaved Reed-Solomon-derived FEC are honest deferrals,
+  spelled out in the package's doc comment.
 
 Still ahead:
 
-- **EDACS / GE-Marc (9600 baud control channel).** Public format;
-  similar shape to Motorola Type II.
 - **LTR (Logic Trunked Radio).** Each repeater carries its own
   status word at 300 baud; no central control channel. The engine
   supports the per-repeater "trunk-as-conventional" pattern via the

--- a/internal/radio/edacs/bandplan.go
+++ b/internal/radio/edacs/bandplan.go
@@ -1,0 +1,43 @@
+package edacs
+
+import (
+	"errors"
+	"fmt"
+)
+
+// BandPlan resolves an EDACS Logical Channel Number (LCN) to a
+// frequency in Hz. EDACS deployments commonly use a linear plan over
+// 800 / 900 MHz NPSPAC bands; some VHF / UHF systems use irregular
+// per-LCN tables. Mirror of internal/radio/motorola/bandplan.go.
+type Resolver interface {
+	Frequency(lcn uint8) (uint32, error)
+}
+
+// LinearBandPlan applies freq = BaseHz + (lcn + Offset) * SpacingHz.
+type LinearBandPlan struct {
+	BaseHz    uint32
+	SpacingHz uint32
+	Offset    int // signed; supports negative offsets
+}
+
+func (b LinearBandPlan) Frequency(lcn uint8) (uint32, error) {
+	if b.SpacingHz == 0 {
+		return 0, errors.New("edacs/bandplan: SpacingHz must be > 0")
+	}
+	idx := int(lcn) + b.Offset
+	if idx < 0 {
+		return 0, fmt.Errorf("edacs/bandplan: LCN %d + offset %d went negative", lcn, b.Offset)
+	}
+	return b.BaseHz + uint32(idx)*b.SpacingHz, nil
+}
+
+// TableBandPlan looks up explicit (lcn → Hz) entries.
+type TableBandPlan map[uint8]uint32
+
+func (t TableBandPlan) Frequency(lcn uint8) (uint32, error) {
+	hz, ok := t[lcn]
+	if !ok {
+		return 0, fmt.Errorf("edacs/bandplan: LCN %d not in table", lcn)
+	}
+	return hz, nil
+}

--- a/internal/radio/edacs/ccw.go
+++ b/internal/radio/edacs/ccw.go
@@ -1,0 +1,93 @@
+package edacs
+
+import (
+	"errors"
+	"fmt"
+)
+
+// CCW is one EDACS Control Channel Word — a 40-bit information block
+// that rides every EDACS control-channel slot after sync detection
+// and the interleaved Reed-Solomon-derived FEC have been removed.
+//
+// Field layout follows the most-cited public reference:
+//
+//   bits 39..36 (4 bits)  Command  — operation type (voice grant,
+//                                    data grant, system, idle, ...).
+//   bits 35..32 (4 bits)  Status   — per-command flag bits
+//                                    (encryption, emergency, etc.).
+//   bits 31..16 (16 bits) Address  — talkgroup / radio ID / site ID,
+//                                    interpretation depends on
+//                                    Command.
+//   bits 15..11 (5 bits)  LCN      — logical channel number; voice
+//                                    grants reference the band plan.
+//   bits 10..0  (11 bits) Aux      — command-specific auxiliary
+//                                    parameter.
+//
+// Higher-level helpers in opcodes.go interpret these fields per
+// command so callers don't need to touch the bit packing directly.
+type CCW struct {
+	Command Command
+	Status  uint8  // 4-bit
+	Address uint16 // 16-bit
+	LCN     uint8  // 5-bit
+	Aux     uint16 // 11-bit
+}
+
+// AssembleCCW packs a CCW into 5 bytes (40 bits) MSB-first. Used by
+// tests and for any future encoder work.
+func AssembleCCW(c CCW) []byte {
+	cmd := uint64(c.Command) & 0xF
+	status := uint64(c.Status) & 0xF
+	addr := uint64(c.Address) & 0xFFFF
+	lcn := uint64(c.LCN) & 0x1F
+	aux := uint64(c.Aux) & 0x7FF
+	v := cmd<<36 | status<<32 | addr<<16 | lcn<<11 | aux
+	return []byte{
+		byte((v >> 32) & 0xFF),
+		byte((v >> 24) & 0xFF),
+		byte((v >> 16) & 0xFF),
+		byte((v >> 8) & 0xFF),
+		byte(v & 0xFF),
+	}
+}
+
+// ParseCCW reads 5 bytes (40 bits MSB-first) into a CCW.
+func ParseCCW(info []byte) (CCW, error) {
+	if len(info) != 5 {
+		return CCW{}, fmt.Errorf("edacs: CCW info must be 5 bytes, got %d", len(info))
+	}
+	v := uint64(info[0])<<32 | uint64(info[1])<<24 | uint64(info[2])<<16 | uint64(info[3])<<8 | uint64(info[4])
+	return CCW{
+		Command: Command((v >> 36) & 0xF),
+		Status:  uint8((v >> 32) & 0xF),
+		Address: uint16((v >> 16) & 0xFFFF),
+		LCN:     uint8((v >> 11) & 0x1F),
+		Aux:     uint16(v & 0x7FF),
+	}, nil
+}
+
+// CCWFromBits packs 40 MSB-first bits (each entry 0/1) into a CCW.
+func CCWFromBits(bits []byte) (CCW, error) {
+	if len(bits) != 40 {
+		return CCW{}, errors.New("edacs: CCW requires 40 bits")
+	}
+	info := make([]byte, 5)
+	for i := 0; i < 40; i++ {
+		if bits[i]&1 != 0 {
+			info[i>>3] |= 1 << uint(7-(i&7))
+		}
+	}
+	return ParseCCW(info)
+}
+
+// CCWBits returns the 40 MSB-first bits of a CCW.
+func CCWBits(c CCW) []byte {
+	bytes := AssembleCCW(c)
+	out := make([]byte, 40)
+	for i := 0; i < 40; i++ {
+		if bytes[i>>3]&(1<<uint(7-(i&7))) != 0 {
+			out[i] = 1
+		}
+	}
+	return out
+}

--- a/internal/radio/edacs/control.go
+++ b/internal/radio/edacs/control.go
@@ -1,0 +1,138 @@
+package edacs
+
+import (
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// LockState is the payload of cc.locked / cc.lost events emitted by
+// the EDACS control-channel state machine.
+type LockState struct {
+	FrequencyHz uint32
+	SystemID    uint16
+}
+
+// ControlChannel ingests CCWs from a single EDACS control channel,
+// emits cc.locked the first time it sees a System-ID announcement on
+// a freshly-tuned device, and republishes voice grants as
+// events.KindGrant carrying a `trunking.Grant` payload. Mirrors the
+// shape of internal/radio/motorola/control.go.
+type ControlChannel struct {
+	bus        *events.Bus
+	log        *slog.Logger
+	systemName string
+	freqHz     uint32
+	resolver   Resolver
+	now        func() time.Time
+
+	mu     sync.Mutex
+	locked bool
+	last   LockState
+}
+
+// Options configure a ControlChannel.
+type Options struct {
+	Bus         *events.Bus
+	Log         *slog.Logger
+	SystemName  string
+	FrequencyHz uint32
+	Resolver    Resolver
+	Now         func() time.Time
+}
+
+// New constructs a ControlChannel.
+func New(opts Options) *ControlChannel {
+	log := opts.Log
+	if log == nil {
+		log = slog.Default()
+	}
+	now := opts.Now
+	if now == nil {
+		now = time.Now
+	}
+	return &ControlChannel{
+		bus:        opts.Bus,
+		log:        log,
+		systemName: opts.SystemName,
+		freqHz:     opts.FrequencyHz,
+		resolver:   opts.Resolver,
+		now:        now,
+	}
+}
+
+// Ingest hands a single decoded CCW to the state machine. Real
+// captures arrive via an upstream GMSK demod + FEC; tests publish
+// CCWs directly.
+func (c *ControlChannel) Ingest(w CCW) {
+	if w.IsIdle() {
+		return
+	}
+	if sys, ok := w.AsSystemID(); ok {
+		c.maybeLock(LockState{FrequencyHz: c.freqHz, SystemID: sys.ID})
+		return
+	}
+	if grant, ok := w.AsGroupVoiceGrant(); ok {
+		c.publishGrant(grant)
+		return
+	}
+}
+
+func (c *ControlChannel) publishGrant(g GroupVoiceGrant) {
+	if c.bus == nil {
+		return
+	}
+	freq := uint32(0)
+	if c.resolver != nil {
+		if hz, err := c.resolver.Frequency(g.LCN); err == nil {
+			freq = hz
+		} else {
+			c.log.Debug("edacs: band-plan resolution failed", "lcn", g.LCN, "err", err)
+		}
+	}
+	c.bus.Publish(events.Event{
+		Kind: events.KindGrant,
+		Payload: trunking.Grant{
+			System:      c.systemName,
+			Protocol:    "edacs",
+			GroupID:     uint32(g.GroupAddress),
+			FrequencyHz: freq,
+			ChannelNum:  uint16(g.LCN),
+			Encrypted:   g.Encrypted,
+			Emergency:   g.Emergency,
+			At:          c.now(),
+		},
+	})
+	c.log.Debug("edacs: grant",
+		"system", c.systemName, "tg", g.GroupAddress,
+		"lcn", g.LCN, "freq_hz", freq,
+		"provoice", g.ProVoice, "enc", g.Encrypted, "emer", g.Emergency)
+}
+
+func (c *ControlChannel) maybeLock(s LockState) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.locked && c.last == s {
+		return
+	}
+	c.locked = true
+	c.last = s
+	c.bus.Publish(events.Event{Kind: events.KindCCLocked, Payload: s})
+	c.log.Info("edacs cc locked",
+		"freq", s.FrequencyHz, "sys", s.SystemID, "system", c.systemName)
+}
+
+// MarkLost publishes cc.lost and resets the locked flag. The trunking
+// engine's hunter calls this when the control channel goes silent.
+func (c *ControlChannel) MarkLost() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !c.locked {
+		return
+	}
+	c.locked = false
+	c.bus.Publish(events.Event{Kind: events.KindCCLost, Payload: c.last})
+}

--- a/internal/radio/edacs/edacs.go
+++ b/internal/radio/edacs/edacs.go
@@ -1,0 +1,36 @@
+// Package edacs decodes Enhanced Digital Access Communications System
+// trunked control channels (also marketed as GE-Marc / Ericsson EDACS).
+// EDACS uses a continuous 9600-baud control channel over which 40-bit
+// Control Channel Words (CCWs) flow, prefaced by a sync sequence and
+// protected by an interleaved Reed-Solomon-derived FEC.
+//
+// Files:
+//
+//   sync.go       Standard EDACS control-channel sync word + a
+//                 sliding correlator over a bit stream.
+//   ccw.go        CCW = {Command, Status, Address, LCN, Aux} packed
+//                 into 40 bits. Round-trip assemble / parse helpers.
+//   opcodes.go    Command enum + per-command payload accessors
+//                 (Group Voice Grant, Data Grant, System ID,
+//                 Adjacent Site, Idle).
+//   bandplan.go   LCN → Hz resolver. Linear and table strategies,
+//                 same shape as the Motorola package's resolver.
+//   control.go    Control-channel state machine ingesting CCWs and
+//                 emitting cc.locked / grant events on the bus.
+//
+// What's NOT yet wired (honest deferrals so a contributor can pick
+// these up):
+//
+//   - The 9600-baud GMSK demodulator that turns IQ into the bits this
+//     package consumes. Same shape gap as the Motorola MSK demod.
+//   - The interleaved-Reed-Solomon FEC over each CCW. The CCW parser
+//     here assumes the upstream caller has already corrected errors.
+//   - EDACS ProVoice voice frames (the digital-voice variant uses a
+//     proprietary AMBE-derived vocoder; see docs/vocoders.md).
+//   - Vendor-specific command extensions. The Command list focuses on
+//     the standard EDACS subset that carries voice grants and system
+//     identification.
+//
+// All of the above slot into the existing engine + recorder + composer
+// pipeline through events.KindGrant once they ship.
+package edacs

--- a/internal/radio/edacs/edacs_test.go
+++ b/internal/radio/edacs/edacs_test.go
@@ -1,0 +1,304 @@
+package edacs
+
+import (
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+func TestCCWAssembleParseRoundTrip(t *testing.T) {
+	in := CCW{
+		Command: CmdGroupVoiceGrant,
+		Status:  0x3, // emergency + encrypted
+		Address: 0x1234,
+		LCN:     17,
+		Aux:     0x055,
+	}
+	bytes := AssembleCCW(in)
+	if len(bytes) != 5 {
+		t.Fatalf("AssembleCCW = %d bytes", len(bytes))
+	}
+	got, err := ParseCCW(bytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != in {
+		t.Errorf("round-trip = %+v, want %+v", got, in)
+	}
+}
+
+func TestCCWFromBitsRoundTrip(t *testing.T) {
+	in := CCW{Command: CmdSystemID, Status: 0xA, Address: 0xBEEF, LCN: 4, Aux: 0x123}
+	bits := CCWBits(in)
+	if len(bits) != 40 {
+		t.Fatalf("CCWBits len = %d", len(bits))
+	}
+	got, err := CCWFromBits(bits)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != in {
+		t.Errorf("round-trip = %+v", got)
+	}
+}
+
+func TestCCWFromBitsRejectsBadLength(t *testing.T) {
+	if _, err := CCWFromBits(make([]byte, 39)); err == nil {
+		t.Error("expected error for 39 bits")
+	}
+}
+
+func TestCommandStringCoversKnownAndUnknown(t *testing.T) {
+	cases := map[Command]string{
+		CmdIdle:            "Idle",
+		CmdGroupVoiceGrant: "GroupVoiceGrant",
+		CmdProVoiceGrant:   "ProVoiceGrant",
+		CmdSystemID:        "SystemID",
+		CmdAdjacentSite:    "AdjacentSite",
+		Command(0xC):       "Command(C)",
+	}
+	for c, want := range cases {
+		if got := c.String(); got != want {
+			t.Errorf("Command(%X).String() = %s, want %s", uint8(c), got, want)
+		}
+	}
+}
+
+func TestStatusFlags(t *testing.T) {
+	c := CCW{Status: 0x3}
+	if !c.IsEncrypted() || !c.IsEmergency() {
+		t.Errorf("status 0x3 should set both flags: enc=%v emer=%v",
+			c.IsEncrypted(), c.IsEmergency())
+	}
+	plain := CCW{Status: 0x0}
+	if plain.IsEncrypted() || plain.IsEmergency() {
+		t.Errorf("status 0x0 should clear both flags")
+	}
+}
+
+func TestAsGroupVoiceGrant(t *testing.T) {
+	c := CCW{Command: CmdGroupVoiceGrant, Status: 0x1, Address: 0x1234, LCN: 5}
+	g, ok := c.AsGroupVoiceGrant()
+	if !ok {
+		t.Fatal("expected grant")
+	}
+	if g.GroupAddress != 0x1234 || g.LCN != 5 || !g.Encrypted || g.Emergency || g.ProVoice {
+		t.Errorf("grant = %+v", g)
+	}
+
+	pv := CCW{Command: CmdProVoiceGrant, Status: 0x2, Address: 0x4321, LCN: 9}
+	pg, ok := pv.AsGroupVoiceGrant()
+	if !ok || !pg.ProVoice || !pg.Emergency || pg.Encrypted {
+		t.Errorf("provoice grant = %+v ok=%v", pg, ok)
+	}
+
+	// Idle isn't a grant.
+	if _, ok := (CCW{Command: CmdIdle}).AsGroupVoiceGrant(); ok {
+		t.Error("idle CCW reported a grant")
+	}
+}
+
+func TestAsSystemIDAndAdjacent(t *testing.T) {
+	sys := CCW{Command: CmdSystemID, Address: 0xCAFE, Aux: 0x42}
+	if s, ok := sys.AsSystemID(); !ok || s.ID != 0xCAFE || s.Aux != 0x42 {
+		t.Errorf("system id = %+v ok=%v", s, ok)
+	}
+
+	adj := CCW{Command: CmdAdjacentSite, Address: 0x0017, LCN: 3}
+	if a, ok := adj.AsAdjacentSite(); !ok || a.SiteID != 0x17 || a.LCN != 3 {
+		t.Errorf("adjacent = %+v ok=%v", a, ok)
+	}
+}
+
+func TestIsIdle(t *testing.T) {
+	if !(CCW{Command: CmdIdle}).IsIdle() {
+		t.Error("CmdIdle should be idle")
+	}
+	if (CCW{Command: CmdGroupVoiceGrant}).IsIdle() {
+		t.Error("voice grant flagged as idle")
+	}
+}
+
+func TestLinearBandPlan(t *testing.T) {
+	bp := LinearBandPlan{BaseHz: 851_000_000, SpacingHz: 25_000, Offset: 0}
+	if hz, _ := bp.Frequency(0); hz != 851_000_000 {
+		t.Errorf("LCN 0 → %d", hz)
+	}
+	if hz, _ := bp.Frequency(10); hz != 851_250_000 {
+		t.Errorf("LCN 10 → %d", hz)
+	}
+	if _, err := (LinearBandPlan{BaseHz: 1, SpacingHz: 0}).Frequency(1); err == nil {
+		t.Error("zero spacing should error")
+	}
+	if _, err := (LinearBandPlan{BaseHz: 1, SpacingHz: 25_000, Offset: -3}).Frequency(1); err == nil {
+		t.Error("negative effective offset should error")
+	}
+}
+
+func TestTableBandPlan(t *testing.T) {
+	bp := TableBandPlan{1: 154_115_000, 2: 154_205_000}
+	if hz, _ := bp.Frequency(1); hz != 154_115_000 {
+		t.Errorf("LCN 1 → %d", hz)
+	}
+	if _, err := bp.Frequency(99); err == nil {
+		t.Error("missing LCN should error")
+	}
+}
+
+func TestSyncDetectorMatchesCleanSync(t *testing.T) {
+	det := NewSyncDetector(OutboundSyncBits(), 0)
+	stream := make([]byte, 80)
+	copy(stream[15:], OutboundSyncBits())
+	hits, _ := det.Process(nil, stream, 0)
+	if len(hits) != 1 || hits[0] != 15+SyncBits-1 {
+		t.Errorf("hits = %v, want [%d]", hits, 15+SyncBits-1)
+	}
+}
+
+func TestSyncDetectorTolerance(t *testing.T) {
+	stream := make([]byte, 80)
+	copy(stream[5:], OutboundSyncBits())
+	stream[7] ^= 1
+	stream[15] ^= 1
+
+	det := NewSyncDetector(OutboundSyncBits(), 2)
+	hits, _ := det.Process(nil, stream, 0)
+	if len(hits) != 1 {
+		t.Errorf("hits = %v, want 1 with tolerance 2", hits)
+	}
+
+	det0 := NewSyncDetector(OutboundSyncBits(), 0)
+	hits0, _ := det0.Process(nil, stream, 0)
+	if len(hits0) != 0 {
+		t.Errorf("hits = %v, want 0 with tolerance 0", hits0)
+	}
+}
+
+func TestControlChannelEmitsLockOnSystemID(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{
+		Bus:         bus,
+		SystemName:  "TestSys",
+		FrequencyHz: 851_000_000,
+	})
+	cc.Ingest(CCW{Command: CmdSystemID, Address: 0xCAFE, Aux: 0x12})
+
+	select {
+	case ev := <-sub.C:
+		if ev.Kind != events.KindCCLocked {
+			t.Fatalf("kind = %s", ev.Kind)
+		}
+		ls, ok := ev.Payload.(LockState)
+		if !ok || ls.SystemID != 0xCAFE || ls.FrequencyHz != 851_000_000 {
+			t.Errorf("lock state = %+v", ev.Payload)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("no event")
+	}
+}
+
+func TestControlChannelPublishesGrant(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{
+		Bus:         bus,
+		SystemName:  "TestSys",
+		FrequencyHz: 851_000_000,
+		Resolver: LinearBandPlan{
+			BaseHz: 866_000_000, SpacingHz: 25_000, Offset: 0,
+		},
+	})
+	cc.Ingest(CCW{
+		Command: CmdGroupVoiceGrant, Status: 0x3,
+		Address: 0x1234, LCN: 8,
+	})
+
+	select {
+	case ev := <-sub.C:
+		if ev.Kind != events.KindGrant {
+			t.Fatalf("kind = %s", ev.Kind)
+		}
+		g, ok := ev.Payload.(trunking.Grant)
+		if !ok {
+			t.Fatalf("payload type = %T", ev.Payload)
+		}
+		if g.System != "TestSys" || g.Protocol != "edacs" {
+			t.Errorf("grant identity = %+v", g)
+		}
+		if g.GroupID != 0x1234 || g.ChannelNum != 8 {
+			t.Errorf("grant group/lcn = %+v", g)
+		}
+		if g.FrequencyHz != 866_200_000 {
+			t.Errorf("grant freq = %d, want 866_200_000", g.FrequencyHz)
+		}
+		if !g.Encrypted || !g.Emergency {
+			t.Errorf("expected encrypted+emergency flags: %+v", g)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("no grant event")
+	}
+}
+
+func TestControlChannelGrantWithoutResolverHasZeroFreq(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, SystemName: "X", FrequencyHz: 1})
+	cc.Ingest(CCW{Command: CmdGroupVoiceGrant, Address: 0x100, LCN: 1})
+	ev := <-sub.C
+	g := ev.Payload.(trunking.Grant)
+	if g.FrequencyHz != 0 {
+		t.Errorf("freq = %d, want 0 (no resolver)", g.FrequencyHz)
+	}
+	if g.ChannelNum != 1 {
+		t.Errorf("LCN = %d, want 1", g.ChannelNum)
+	}
+}
+
+func TestControlChannelIgnoresIdle(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, SystemName: "X", FrequencyHz: 1})
+	cc.Ingest(CCW{Command: CmdIdle, Aux: 0x42})
+
+	select {
+	case ev := <-sub.C:
+		t.Errorf("idle CCW produced an event: %s", ev.Kind)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestControlChannelMarkLost(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, SystemName: "X", FrequencyHz: 1})
+	cc.Ingest(CCW{Command: CmdSystemID, Address: 0x42})
+	<-sub.C // CCLocked
+
+	cc.MarkLost()
+	select {
+	case ev := <-sub.C:
+		if ev.Kind != events.KindCCLost {
+			t.Errorf("kind = %s, want cc.lost", ev.Kind)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("no cc.lost")
+	}
+}

--- a/internal/radio/edacs/opcodes.go
+++ b/internal/radio/edacs/opcodes.go
@@ -1,0 +1,122 @@
+package edacs
+
+import "fmt"
+
+// Command is the 4-bit operation field carried in CCW.Command. The
+// EDACS standard reserves the full 4-bit space; this enum covers the
+// subset most useful for trunking follow-along.
+type Command uint8
+
+const (
+	CmdIdle              Command = 0x0
+	CmdGroupVoiceGrant   Command = 0x1
+	CmdProVoiceGrant     Command = 0x2 // EDACS ProVoice (digital)
+	CmdIndividualCall    Command = 0x3
+	CmdDataGrant         Command = 0x4
+	CmdSystemID          Command = 0x5
+	CmdAdjacentSite      Command = 0x6
+	CmdEmergency         Command = 0x7
+	CmdAffiliation       Command = 0x8
+	CmdEncryption        Command = 0x9
+	CmdReserved          Command = 0xF
+)
+
+func (c Command) String() string {
+	switch c {
+	case CmdIdle:
+		return "Idle"
+	case CmdGroupVoiceGrant:
+		return "GroupVoiceGrant"
+	case CmdProVoiceGrant:
+		return "ProVoiceGrant"
+	case CmdIndividualCall:
+		return "IndividualCall"
+	case CmdDataGrant:
+		return "DataGrant"
+	case CmdSystemID:
+		return "SystemID"
+	case CmdAdjacentSite:
+		return "AdjacentSite"
+	case CmdEmergency:
+		return "Emergency"
+	case CmdAffiliation:
+		return "Affiliation"
+	case CmdEncryption:
+		return "Encryption"
+	default:
+		return fmt.Sprintf("Command(%X)", uint8(c))
+	}
+}
+
+// IsIdle reports whether the CCW is the channel-idle / heartbeat
+// command.
+func (c CCW) IsIdle() bool { return c.Command == CmdIdle }
+
+// IsEncrypted reads bit 0 of the Status nibble — EDACS reserves the
+// low Status bit as the encryption flag for voice grants.
+func (c CCW) IsEncrypted() bool { return c.Status&0x1 != 0 }
+
+// IsEmergency reads bit 1 of the Status nibble — EDACS sets it for
+// emergency calls layered onto a regular voice grant.
+func (c CCW) IsEmergency() bool { return c.Status&0x2 != 0 }
+
+// GroupVoiceGrant is the high-level shape of an EDACS voice grant.
+// Address holds the talkgroup; LCN references an entry in the
+// operator-supplied band plan.
+type GroupVoiceGrant struct {
+	GroupAddress uint16
+	LCN          uint8
+	Encrypted    bool
+	Emergency    bool
+	ProVoice     bool // true when the grant came from a CmdProVoiceGrant
+}
+
+// AsGroupVoiceGrant returns the structured grant if the CCW's command
+// is one of the voice-grant variants, otherwise (zero, false).
+func (c CCW) AsGroupVoiceGrant() (GroupVoiceGrant, bool) {
+	switch c.Command {
+	case CmdGroupVoiceGrant, CmdProVoiceGrant:
+	default:
+		return GroupVoiceGrant{}, false
+	}
+	return GroupVoiceGrant{
+		GroupAddress: c.Address,
+		LCN:          c.LCN,
+		Encrypted:    c.IsEncrypted(),
+		Emergency:    c.IsEmergency(),
+		ProVoice:     c.Command == CmdProVoiceGrant,
+	}, true
+}
+
+// SystemID is the opaque identifier carried by CmdSystemID
+// announcements. Address holds the system identifier; the Aux field
+// carries an EDACS site / network identifier subfield.
+type SystemID struct {
+	ID  uint16
+	Aux uint16
+}
+
+// AsSystemID returns the structured system identifier if this is a
+// CmdSystemID CCW, otherwise (zero, false).
+func (c CCW) AsSystemID() (SystemID, bool) {
+	if c.Command != CmdSystemID {
+		return SystemID{}, false
+	}
+	return SystemID{ID: c.Address, Aux: c.Aux}, true
+}
+
+// AdjacentSite is a neighbour-site announcement. Address holds the
+// adjacent site ID; LCN is that site's control-channel index.
+type AdjacentSite struct {
+	SiteID uint16
+	LCN    uint8
+}
+
+// AsAdjacentSite returns the structured adjacent-site descriptor if
+// this is a CmdAdjacentSite CCW.
+func (c CCW) AsAdjacentSite() (AdjacentSite, bool) {
+	if c.Command != CmdAdjacentSite {
+		return AdjacentSite{}, false
+	}
+	return AdjacentSite{SiteID: c.Address, LCN: c.LCN}, true
+}

--- a/internal/radio/edacs/sync.go
+++ b/internal/radio/edacs/sync.go
@@ -1,0 +1,80 @@
+package edacs
+
+// SyncWord is the 24-bit sync sequence prefacing each EDACS Control
+// Channel Word. Stored as MSB-first bits to mesh with the rest of the
+// radio stack's framing layer.
+//
+// The standard EDACS outbound control-channel sync is documented as
+// 0x55D5AA across multiple public reference implementations. As with
+// the other protocol packages, the constant is best-effort and should
+// be cross-checked against an authoritative reference before trusting
+// live captures.
+const (
+	OutboundSyncHex uint32 = 0x55D5AA
+	SyncBits               = 24
+)
+
+// OutboundSyncBits returns the 24 bits of the outbound sync MSB-first.
+func OutboundSyncBits() []byte {
+	out := make([]byte, SyncBits)
+	for i := 0; i < SyncBits; i++ {
+		out[i] = byte((OutboundSyncHex >> uint(SyncBits-1-i)) & 1)
+	}
+	return out
+}
+
+// SyncDetector slides a window over a 0/1 bit stream and reports
+// indices where the sync word matches within `tolerance` mismatched
+// bits. Same shape as the Motorola / NXDN / DMR / P25 sync detectors.
+type SyncDetector struct {
+	pattern   []byte
+	tolerance int
+	hist      []byte
+	primed    int
+	pos       int
+}
+
+// NewSyncDetector returns a detector for the supplied pattern. Pass
+// the length-24 result of OutboundSyncBits() unless you have a
+// vendor-specific sync to track.
+func NewSyncDetector(pattern []byte, tolerance int) *SyncDetector {
+	if tolerance < 0 {
+		tolerance = 1
+	}
+	cp := make([]byte, len(pattern))
+	copy(cp, pattern)
+	return &SyncDetector{
+		pattern:   cp,
+		tolerance: tolerance,
+		hist:      make([]byte, len(cp)),
+	}
+}
+
+// Process scans src and appends to dst the absolute bit indices where
+// the sync word ends within tolerance.
+func (s *SyncDetector) Process(dst []int, src []byte, baseIndex int) ([]int, int) {
+	n := len(s.pattern)
+	for i, b := range src {
+		s.hist[s.pos] = b & 1
+		s.pos = (s.pos + 1) % n
+		if s.primed < n {
+			s.primed++
+			continue
+		}
+		mismatch := 0
+		idx := s.pos
+		for k := 0; k < n; k++ {
+			if s.hist[idx] != s.pattern[k] {
+				mismatch++
+				if mismatch > s.tolerance {
+					break
+				}
+			}
+			idx = (idx + 1) % n
+		}
+		if mismatch <= s.tolerance {
+			dst = append(dst, baseIndex+i)
+		}
+	}
+	return dst, baseIndex + len(src)
+}


### PR DESCRIPTION
Second trunking protocol on the TrunkTracker-style multi-system
path, joining the existing Motorola Type II decoder. Same shape as
the other `internal/radio/*` packages: protocol-level CCW parser,
command set, band plan, and control state machine that publishes
`cc.locked` + `grant` events on the existing bus.

## What this delivers

### `internal/radio/edacs/` (new package)

- **`edacs.go`** — package doc with the explicit deferral list
  (9600-baud GMSK demod, interleaved RS-derived FEC, ProVoice
  voice frames, vendor-specific commands).
- **`sync.go`** — outbound sync word constant
  (`OutboundSyncHex = 0x55D5AA`) + a sliding correlator with
  configurable tolerance.
- **`ccw.go`** — `CCW = {Command: 4, Status: 4, Address: 16,
  LCN: 5, Aux: 11}` packed into 40 bits. Round-trip
  `AssembleCCW` / `ParseCCW` + bit-level helpers (`CCWBits`,
  `CCWFromBits`).
- **`opcodes.go`** — `Command` enum (`Idle`,
  `GroupVoiceGrant`, `ProVoiceGrant`, `IndividualCall`,
  `DataGrant`, `SystemID`, `AdjacentSite`, `Emergency`,
  `Affiliation`, `Encryption`). Status-flag accessors
  `IsEncrypted` / `IsEmergency` on bits 0/1 of `Status`.
  Per-command structures: `GroupVoiceGrant` (with a `ProVoice`
  flag distinguishing analog vs digital grants), `SystemID`,
  `AdjacentSite`, plus `AsGroupVoiceGrant` / `AsSystemID` /
  `AsAdjacentSite`.
- **`bandplan.go`** — `Resolver` interface with two strategies:
  - `LinearBandPlan{BaseHz, SpacingHz, Offset}` for typical NPSPAC
    EDACS deployments.
  - `TableBandPlan{lcn → Hz}` for non-linear plans.
- **`control.go`** — `ControlChannel` state machine. `Ingest(CCW)`
  emits `events.KindCCLocked` on `SystemID` and
  `events.KindGrant` (carrying `trunking.Grant{Protocol:
  "edacs"}`) on voice grants, with `Encrypted` / `Emergency`
  flags propagated from the CCW status nibble. Resolves LCN
  through the supplied band plan; with no resolver,
  `FrequencyHz = 0` and `ChannelNum = lcn`. `MarkLost`
  mirrors the other protocols' watchdog hook.

## Test plan
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `go test -race -count=1 ./...`
- [x] `make integration`
- [x] CCW round-trip (bytes + bits), length validation
- [x] Command + LCN + status field extraction
- [x] Status flag accessors (`IsEncrypted`, `IsEmergency`)
- [x] Per-command structures (`AsGroupVoiceGrant` covering both
      analog `CmdGroupVoiceGrant` and digital `CmdProVoiceGrant`,
      `AsSystemID`, `AsAdjacentSite`)
- [x] `IsIdle` recognition + `Command.String()` coverage
- [x] `LinearBandPlan` with positive / negative offsets, zero
      spacing rejection
- [x] `TableBandPlan` lookup hit + miss
- [x] Sync detector clean match + tolerance + over-budget rejection
- [x] Control channel emits `cc.locked` on `SystemID`
- [x] Control channel publishes a `Grant` with the correct
      `(System, Protocol, GroupID, FrequencyHz, ChannelNum,
      Encrypted, Emergency)` when a resolver is configured
- [x] Grant publication without a resolver leaves `FrequencyHz=0`
      and carries the LCN in `ChannelNum`
- [x] Idle CCWs produce no events
- [x] `MarkLost` publishes `cc.lost` after a prior lock

## Roadmap status
- ✅ **1. Tone-out alerting** — landed.
- 🟡 **2. TrunkTracker-style multi-system grant following** —
  Motorola **and EDACS** parsers + control state machines now
  in place. **GMSK / MSK demod** + **FEC** are the gating
  pieces for live captures (called out in each package's doc).
  LTR / MPT-1327 / P25 Phase 2 still ahead.
- 🟡 **3. Simulcast mitigation** — LMS + CMA cores landed.
- 4. Expanding digital-mode coverage — vocoders + more
  protocols.

## Honest caveats
- The 40-bit CCW field layout follows the most-cited public
  reference. Same standing caveat as the Motorola, P25, DMR, and
  NXDN packages carry: cross-check against an authoritative
  source before trusting live captures.
- No code changes outside `internal/radio/edacs/` and the README;
  every other component already accepts grants via the events bus.

https://claude.ai/code/session_01MQSV8EVnH6nsGUpcWep7UF

---
_Generated by [Claude Code](https://claude.ai/code/session_01MQSV8EVnH6nsGUpcWep7UF)_