### PR TITLE
LTR (Logic Trunked Radio) decoder (Roadmap item 2 — fourth trunked system)

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,13 +150,25 @@ What's wired:
   emission path. The 9600-baud GMSK demodulator + the
   interleaved Reed-Solomon-derived FEC are honest deferrals,
   spelled out in the package's doc comment.
+- **LTR (Logic Trunked Radio).** `internal/radio/ltr/` —
+  41-bit per-repeater Status word parser
+  (`Sync + Area + Group flag + Channel + Home + GroupID + Free
+  + FCS`), `Channel → Hz` band-plan resolver (linear and
+  table), and a per-repeater state machine that publishes
+  `cc.locked` on the first valid status and `grant` (with
+  `trunking.Grant.Protocol = "ltr"`) when a status indicates
+  an active call. Architecturally different from the
+  central-CC trunked systems above: each repeater is its own
+  conventional channel and carries its own status word at
+  300 bps under the in-band voice. Optional area filter so
+  one physical channel can host multiple LTR systems without
+  cross-talk. Tests cover status round-trip, area filtering,
+  active-call detection, no-republish-on-same-group, no-resolver
+  fallback, and the cc.locked / cc.lost emissions. The 300-baud
+  sub-audible status-word demodulator is the honest deferral.
 
 Still ahead:
 
-- **LTR (Logic Trunked Radio).** Each repeater carries its own
-  status word at 300 baud; no central control channel. The engine
-  supports the per-repeater "trunk-as-conventional" pattern via the
-  same `Grant` payload.
 - **MPT-1327.** UK / Commonwealth utility trunking; cleanly
   documented MAP-27 messages.
 - **P25 Phase 2 (TDMA H-DQPSK superframes).** The H-DQPSK demod and

--- a/internal/radio/ltr/bandplan.go
+++ b/internal/radio/ltr/bandplan.go
@@ -1,0 +1,47 @@
+package ltr
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Resolver maps an LTR Channel number (1..20 typically) to the
+// repeater's transmit frequency in Hz. LTR systems use a small
+// physical-channel space, often with non-uniform frequency
+// assignments — table-based resolution covers most real
+// deployments. A linear strategy is also provided for systems that
+// happen to lay out their channels uniformly.
+type Resolver interface {
+	Frequency(channel uint8) (uint32, error)
+}
+
+// LinearBandPlan applies freq = BaseHz + (channel + Offset) * SpacingHz.
+// LTR conventionally indexes channels from 1, so most operators set
+// Offset=-1 to make channel 1 land at BaseHz.
+type LinearBandPlan struct {
+	BaseHz    uint32
+	SpacingHz uint32
+	Offset    int // signed
+}
+
+func (b LinearBandPlan) Frequency(ch uint8) (uint32, error) {
+	if b.SpacingHz == 0 {
+		return 0, errors.New("ltr/bandplan: SpacingHz must be > 0")
+	}
+	idx := int(ch) + b.Offset
+	if idx < 0 {
+		return 0, fmt.Errorf("ltr/bandplan: channel %d + offset %d went negative", ch, b.Offset)
+	}
+	return b.BaseHz + uint32(idx)*b.SpacingHz, nil
+}
+
+// TableBandPlan looks up explicit (channel → Hz) entries.
+type TableBandPlan map[uint8]uint32
+
+func (t TableBandPlan) Frequency(ch uint8) (uint32, error) {
+	hz, ok := t[ch]
+	if !ok {
+		return 0, fmt.Errorf("ltr/bandplan: channel %d not in table", ch)
+	}
+	return hz, nil
+}

--- a/internal/radio/ltr/control.go
+++ b/internal/radio/ltr/control.go
@@ -1,0 +1,176 @@
+package ltr
+
+import (
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// LockState is the payload of cc.locked / cc.lost events emitted by
+// the LTR per-repeater state machine. LTR has no central control
+// channel, so "locked" here means "we're receiving valid status
+// words from the repeater on this frequency".
+type LockState struct {
+	FrequencyHz uint32
+	Area        uint8
+	Repeater    uint8 // home repeater number from the first valid status word
+}
+
+// ControlChannel ingests Status words from a single LTR repeater,
+// emits cc.locked the first time a valid status arrives on a
+// freshly-tuned device, and republishes any active call as a
+// `trunking.Grant` event with `Protocol = "ltr"`.
+//
+// The state machine is deliberately minimal: each ingested status
+// either confirms the lock, signals an active call (group flag set
+// + non-zero group ID), or is silently dropped (idle frame, or a
+// status word for a different area than we last locked to).
+type ControlChannel struct {
+	bus        *events.Bus
+	log        *slog.Logger
+	systemName string
+	freqHz     uint32
+	resolver   Resolver
+	now        func() time.Time
+	// expectedArea: when set, ignore status words for any other area
+	// (lets a single physical channel host multiple LTR systems).
+	expectedArea uint8
+	areaSet      bool
+
+	mu     sync.Mutex
+	locked bool
+	last   LockState
+	// activeGroup tracks the group currently announced as active so
+	// repeated grant frames during one call don't republish a new
+	// grant on every status word.
+	activeGroup uint16
+}
+
+// Options configure a ControlChannel.
+type Options struct {
+	Bus         *events.Bus
+	Log         *slog.Logger
+	SystemName  string
+	FrequencyHz uint32
+	Resolver    Resolver
+	// Area, when non-zero, restricts the state machine to status
+	// words whose Area field matches. Zero accepts every area.
+	Area uint8
+	Now  func() time.Time
+}
+
+// New constructs a ControlChannel.
+func New(opts Options) *ControlChannel {
+	log := opts.Log
+	if log == nil {
+		log = slog.Default()
+	}
+	now := opts.Now
+	if now == nil {
+		now = time.Now
+	}
+	return &ControlChannel{
+		bus:          opts.Bus,
+		log:          log,
+		systemName:   opts.SystemName,
+		freqHz:       opts.FrequencyHz,
+		resolver:     opts.Resolver,
+		now:          now,
+		expectedArea: opts.Area,
+		areaSet:      opts.Area != 0,
+	}
+}
+
+// Ingest hands one Status word to the state machine. Real captures
+// arrive from an upstream sub-audible 300-baud demod; tests publish
+// status words directly.
+func (c *ControlChannel) Ingest(s Status) {
+	if !s.Sync {
+		// Malformed frame; drop.
+		return
+	}
+	if c.areaSet && s.Area != c.expectedArea {
+		// A different LTR system is sharing the air; ignore.
+		return
+	}
+
+	c.maybeLock(LockState{
+		FrequencyHz: c.freqHz,
+		Area:        s.Area,
+		Repeater:    s.Home,
+	})
+
+	if !s.IsActive() {
+		c.mu.Lock()
+		c.activeGroup = 0
+		c.mu.Unlock()
+		return
+	}
+	c.mu.Lock()
+	if c.activeGroup == s.GroupID {
+		c.mu.Unlock()
+		return
+	}
+	c.activeGroup = s.GroupID
+	c.mu.Unlock()
+	c.publishGrant(s)
+}
+
+func (c *ControlChannel) publishGrant(s Status) {
+	if c.bus == nil {
+		return
+	}
+	freq := uint32(0)
+	if c.resolver != nil {
+		if hz, err := c.resolver.Frequency(s.Channel); err == nil {
+			freq = hz
+		} else {
+			c.log.Debug("ltr: band-plan resolution failed",
+				"channel", s.Channel, "err", err)
+		}
+	}
+	c.bus.Publish(events.Event{
+		Kind: events.KindGrant,
+		Payload: trunking.Grant{
+			System:      c.systemName,
+			Protocol:    "ltr",
+			GroupID:     uint32(s.GroupID),
+			FrequencyHz: freq,
+			ChannelNum:  uint16(s.Channel),
+			At:          c.now(),
+		},
+	})
+	c.log.Debug("ltr: grant",
+		"system", c.systemName, "tg", s.GroupID,
+		"channel", s.Channel, "home", s.Home, "freq_hz", freq)
+}
+
+func (c *ControlChannel) maybeLock(st LockState) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.locked && c.last == st {
+		return
+	}
+	c.locked = true
+	c.last = st
+	c.bus.Publish(events.Event{Kind: events.KindCCLocked, Payload: st})
+	c.log.Info("ltr cc locked",
+		"freq", st.FrequencyHz, "area", st.Area, "repeater", st.Repeater,
+		"system", c.systemName)
+}
+
+// MarkLost publishes cc.lost and resets the locked flag. The trunking
+// engine's hunter calls this when status words stop arriving.
+func (c *ControlChannel) MarkLost() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !c.locked {
+		return
+	}
+	c.locked = false
+	c.activeGroup = 0
+	c.bus.Publish(events.Event{Kind: events.KindCCLost, Payload: c.last})
+}

--- a/internal/radio/ltr/ltr.go
+++ b/internal/radio/ltr/ltr.go
@@ -1,0 +1,39 @@
+// Package ltr decodes Logic Trunked Radio (LTR) — the legacy
+// distributed-trunking system invented by E.F. Johnson in the 1970s
+// and still in deployment for utility / industrial fleets. LTR is
+// architecturally different from the centrally-coordinated trunked
+// systems (P25, DMR, NXDN, Motorola Type II, EDACS): every repeater
+// transmits its own 41-bit status word at 300 bps, on top of the
+// in-band voice. There is no central control channel; an LTR scanner
+// follows calls by watching every repeater's status word and tuning
+// to whichever one currently announces the talkgroup of interest.
+//
+// Files:
+//
+//   status.go    41-bit Status word: Sync + Area + Group flag +
+//                Channel + Home repeater + Group ID + Free + FCS.
+//                Round-trip assemble / parse helpers and bit
+//                accessors.
+//   bandplan.go  Channel → Hz resolver. LTR uses 4-bit channel
+//                numbers (1..20 typically); the operator-supplied
+//                band plan maps each to the repeater's transmit
+//                frequency. Same Resolver shape as the
+//                motorola / edacs packages.
+//   control.go   Per-repeater state machine. Ingest each decoded
+//                Status word and republish it as a
+//                events.KindGrant when the status indicates an
+//                active call on this repeater, plus a one-shot
+//                events.KindCCLocked the first time we see a valid
+//                status from a given repeater (so the hunter can
+//                confirm we're tuned to the right place).
+//
+// What's NOT yet wired (honest deferrals):
+//
+//   - The 300-baud sub-audible status-word demodulator. It rides
+//     under the voice on most LTR repeaters and uses its own
+//     baseband decoding; the Status parser here assumes the upstream
+//     caller has already delivered 41 clean bits.
+//   - Manchester encoding / decoding of the on-air bit stream.
+//   - Repeater-pair coordination (LTR-Net) where status-word
+//     references can hop between physical sites.
+package ltr

--- a/internal/radio/ltr/ltr_test.go
+++ b/internal/radio/ltr/ltr_test.go
@@ -1,0 +1,296 @@
+package ltr
+
+import (
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+func TestStatusAssembleParseRoundTrip(t *testing.T) {
+	in := Status{
+		Sync: true, Area: 7, Group: true,
+		Channel: 5, Home: 5, GroupID: 42, Free: 3, FCS: 0xABC,
+	}
+	bytes := AssembleStatus(in)
+	if len(bytes) != 6 {
+		t.Fatalf("AssembleStatus = %d bytes", len(bytes))
+	}
+	got, err := ParseStatus(bytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != in {
+		t.Errorf("round-trip = %+v, want %+v", got, in)
+	}
+}
+
+func TestStatusFromBitsRoundTrip(t *testing.T) {
+	in := Status{
+		Sync: true, Area: 1, Group: false,
+		Channel: 12, Home: 12, GroupID: 200, Free: 7, FCS: 0x123,
+	}
+	bits := StatusBits(in)
+	if len(bits) != 41 {
+		t.Fatalf("StatusBits len = %d", len(bits))
+	}
+	got, err := StatusFromBits(bits)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != in {
+		t.Errorf("round-trip = %+v, want %+v", got, in)
+	}
+}
+
+func TestStatusFromBitsRejectsBadLength(t *testing.T) {
+	if _, err := StatusFromBits(make([]byte, 40)); err == nil {
+		t.Error("expected error for 40 bits")
+	}
+}
+
+func TestIsActive(t *testing.T) {
+	cases := []struct {
+		name string
+		s    Status
+		want bool
+	}{
+		{"group + non-zero id", Status{Group: true, GroupID: 42}, true},
+		{"group set + zero id", Status{Group: true, GroupID: 0}, false},
+		{"group clear", Status{Group: false, GroupID: 42}, false},
+		{"both clear", Status{}, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := c.s.IsActive(); got != c.want {
+				t.Errorf("IsActive() = %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+func TestLinearBandPlan(t *testing.T) {
+	bp := LinearBandPlan{BaseHz: 451_000_000, SpacingHz: 12_500, Offset: -1}
+	// Channel 1 with offset -1 → idx 0 → BaseHz exactly.
+	if hz, _ := bp.Frequency(1); hz != 451_000_000 {
+		t.Errorf("ch 1 → %d, want 451M", hz)
+	}
+	if hz, _ := bp.Frequency(20); hz != 451_237_500 {
+		t.Errorf("ch 20 → %d", hz)
+	}
+	if _, err := (LinearBandPlan{BaseHz: 1, SpacingHz: 0}).Frequency(1); err == nil {
+		t.Error("zero spacing should error")
+	}
+	if _, err := (LinearBandPlan{BaseHz: 1, SpacingHz: 12_500, Offset: -10}).Frequency(1); err == nil {
+		t.Error("negative effective offset should error")
+	}
+}
+
+func TestTableBandPlan(t *testing.T) {
+	bp := TableBandPlan{1: 461_000_000, 5: 461_062_500, 12: 461_175_000}
+	if hz, _ := bp.Frequency(5); hz != 461_062_500 {
+		t.Errorf("ch 5 → %d", hz)
+	}
+	if _, err := bp.Frequency(99); err == nil {
+		t.Error("missing channel should error")
+	}
+}
+
+// activeStatus returns a status word that announces a call for the
+// supplied group on the supplied channel.
+func activeStatus(group uint16, channel, home, area uint8) Status {
+	return Status{
+		Sync: true, Area: area, Group: true,
+		Channel: channel, Home: home, GroupID: group,
+		Free: 0, FCS: 0,
+	}
+}
+
+func TestControlChannelEmitsLockOnFirstStatus(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{
+		Bus:         bus,
+		SystemName:  "TestLTR",
+		FrequencyHz: 461_000_000,
+	})
+	cc.Ingest(activeStatus(0, 1, 1, 3))
+
+	select {
+	case ev := <-sub.C:
+		if ev.Kind != events.KindCCLocked {
+			t.Fatalf("kind = %s, want cc.locked", ev.Kind)
+		}
+		ls, ok := ev.Payload.(LockState)
+		if !ok || ls.FrequencyHz != 461_000_000 || ls.Area != 3 || ls.Repeater != 1 {
+			t.Errorf("lock state = %+v", ev.Payload)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("no event")
+	}
+}
+
+func TestControlChannelDropsBadSync(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, SystemName: "X", FrequencyHz: 1})
+	cc.Ingest(Status{Sync: false, Group: true, GroupID: 42, Channel: 1, Home: 1})
+
+	select {
+	case ev := <-sub.C:
+		t.Errorf("unsynced status produced an event: %s", ev.Kind)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestControlChannelFiltersByArea(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{
+		Bus: bus, SystemName: "X", FrequencyHz: 1,
+		Area: 5, // accept only area 5
+	})
+	// Wrong area: dropped.
+	cc.Ingest(activeStatus(42, 3, 3, 7))
+	// Right area: emits.
+	cc.Ingest(activeStatus(42, 3, 3, 5))
+
+	first := <-sub.C
+	if first.Kind != events.KindCCLocked {
+		t.Errorf("kind = %s, want cc.locked", first.Kind)
+	}
+	if ls, ok := first.Payload.(LockState); !ok || ls.Area != 5 {
+		t.Errorf("lock area = %+v", first.Payload)
+	}
+}
+
+func TestControlChannelPublishesGrant(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{
+		Bus:         bus,
+		SystemName:  "TestLTR",
+		FrequencyHz: 461_000_000,
+		Resolver: LinearBandPlan{
+			BaseHz: 461_000_000, SpacingHz: 12_500, Offset: -1,
+		},
+	})
+	cc.Ingest(activeStatus(42, 3, 3, 1))
+	// First event is the cc.locked.
+	if ev := <-sub.C; ev.Kind != events.KindCCLocked {
+		t.Fatalf("first kind = %s, want cc.locked", ev.Kind)
+	}
+	// Second event is the grant.
+	select {
+	case ev := <-sub.C:
+		if ev.Kind != events.KindGrant {
+			t.Fatalf("second kind = %s", ev.Kind)
+		}
+		g, ok := ev.Payload.(trunking.Grant)
+		if !ok {
+			t.Fatalf("payload type = %T", ev.Payload)
+		}
+		if g.System != "TestLTR" || g.Protocol != "ltr" {
+			t.Errorf("identity = %+v", g)
+		}
+		if g.GroupID != 42 || g.ChannelNum != 3 {
+			t.Errorf("group/channel = %+v", g)
+		}
+		// Channel 3 with offset -1, spacing 12.5 kHz → +25 kHz from base.
+		if g.FrequencyHz != 461_025_000 {
+			t.Errorf("freq = %d, want 461_025_000", g.FrequencyHz)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("no grant")
+	}
+}
+
+func TestControlChannelDoesNotRepublishSameGroup(t *testing.T) {
+	bus := events.NewBus(16)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, SystemName: "X", FrequencyHz: 1})
+	cc.Ingest(activeStatus(42, 1, 1, 0))
+	<-sub.C // cc.locked
+	<-sub.C // grant for tg 42
+
+	// Several more identical status words during the same call: no
+	// new grant events.
+	for i := 0; i < 5; i++ {
+		cc.Ingest(activeStatus(42, 1, 1, 0))
+	}
+	select {
+	case ev := <-sub.C:
+		t.Errorf("repeat status republished: %+v", ev)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	// A different group → new grant.
+	cc.Ingest(activeStatus(99, 2, 1, 0))
+	select {
+	case ev := <-sub.C:
+		if ev.Kind != events.KindGrant {
+			t.Errorf("kind = %s, want grant", ev.Kind)
+		}
+		if g, ok := ev.Payload.(trunking.Grant); ok && g.GroupID != 99 {
+			t.Errorf("group = %d, want 99", g.GroupID)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("no grant for new group")
+	}
+}
+
+func TestControlChannelGrantWithoutResolverHasZeroFreq(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, SystemName: "X", FrequencyHz: 1})
+	cc.Ingest(activeStatus(42, 1, 1, 0))
+	<-sub.C // cc.locked
+	ev := <-sub.C
+	g := ev.Payload.(trunking.Grant)
+	if g.FrequencyHz != 0 {
+		t.Errorf("freq = %d, want 0 (no resolver)", g.FrequencyHz)
+	}
+	if g.ChannelNum != 1 {
+		t.Errorf("channel = %d, want 1", g.ChannelNum)
+	}
+}
+
+func TestControlChannelMarkLost(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, SystemName: "X", FrequencyHz: 1})
+	cc.Ingest(activeStatus(0, 1, 1, 0))
+	<-sub.C // cc.locked
+
+	cc.MarkLost()
+	select {
+	case ev := <-sub.C:
+		if ev.Kind != events.KindCCLost {
+			t.Errorf("kind = %s, want cc.lost", ev.Kind)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("no cc.lost")
+	}
+}

--- a/internal/radio/ltr/status.go
+++ b/internal/radio/ltr/status.go
@@ -1,0 +1,127 @@
+package ltr
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Status is one LTR repeater status word — 41 bits transmitted
+// continuously at 300 bps under the in-band voice.
+//
+// Field layout (MSB-first across the 41-bit word):
+//
+//   bits 40..40 (1 bit)   Sync   — frame-start marker (always 1).
+//   bits 39..35 (5 bits)  Area   — area code (0..31). Multiple LTR
+//                                  systems on the same frequency are
+//                                  disambiguated by Area.
+//   bits 34..34 (1 bit)   Group  — the "F-bit". 1 = call is active
+//                                  on this repeater for the named
+//                                  group; 0 = idle / free.
+//   bits 33..30 (4 bits)  Chan   — physical channel number (1..20)
+//                                  this status word references.
+//   bits 29..25 (5 bits)  Home   — home-repeater number (1..20)
+//                                  for the active group.
+//   bits 24..17 (8 bits)  Group  — group / talkgroup ID (1..250).
+//   bits 16..12 (5 bits)  Free   — free-repeater hint
+//                                  (which repeater is currently
+//                                  unallocated, for handoff).
+//   bits 11..0  (12 bits) FCS    — frame check / parity. Computed
+//                                  by the encoder and verified by
+//                                  the decoder.
+//
+// As with the other protocol packages, the field positions follow
+// the most-cited public reference; some LTR-Net variants pack
+// fields slightly differently. Cross-check before trusting live
+// captures.
+type Status struct {
+	Sync    bool
+	Area    uint8  // 5-bit
+	Group   bool   // F-bit
+	Channel uint8  // 4-bit (1..20)
+	Home    uint8  // 5-bit (1..20)
+	GroupID uint16 // 8-bit (1..250)
+	Free    uint8  // 5-bit
+	FCS     uint16 // 12-bit
+}
+
+// AssembleStatus packs a Status into 6 bytes (48 bits, with the upper
+// 41 bits carrying the status word and the bottom 7 bits zero-padded).
+// Used by tests and for any future encoder work.
+func AssembleStatus(s Status) []byte {
+	var v uint64
+	if s.Sync {
+		v |= 1 << 40
+	}
+	v |= uint64(s.Area&0x1F) << 35
+	if s.Group {
+		v |= 1 << 34
+	}
+	v |= uint64(s.Channel&0x0F) << 30
+	v |= uint64(s.Home&0x1F) << 25
+	v |= uint64(s.GroupID&0xFF) << 17
+	v |= uint64(s.Free&0x1F) << 12
+	v |= uint64(s.FCS & 0x0FFF)
+	// Left-align into 6 bytes (48 bits) for clean MSB-first transport.
+	v <<= (48 - 41)
+	return []byte{
+		byte((v >> 40) & 0xFF),
+		byte((v >> 32) & 0xFF),
+		byte((v >> 24) & 0xFF),
+		byte((v >> 16) & 0xFF),
+		byte((v >> 8) & 0xFF),
+		byte(v & 0xFF),
+	}
+}
+
+// ParseStatus reads 6 bytes (the upper 41 bits MSB-first as produced
+// by AssembleStatus) into a Status.
+func ParseStatus(info []byte) (Status, error) {
+	if len(info) != 6 {
+		return Status{}, fmt.Errorf("ltr: status info must be 6 bytes, got %d", len(info))
+	}
+	v := uint64(info[0])<<40 | uint64(info[1])<<32 | uint64(info[2])<<24 |
+		uint64(info[3])<<16 | uint64(info[4])<<8 | uint64(info[5])
+	v >>= (48 - 41) // strip the trailing zero-padding
+	return Status{
+		Sync:    v&(1<<40) != 0,
+		Area:    uint8((v >> 35) & 0x1F),
+		Group:   v&(1<<34) != 0,
+		Channel: uint8((v >> 30) & 0x0F),
+		Home:    uint8((v >> 25) & 0x1F),
+		GroupID: uint16((v >> 17) & 0xFF),
+		Free:    uint8((v >> 12) & 0x1F),
+		FCS:     uint16(v & 0x0FFF),
+	}, nil
+}
+
+// StatusFromBits packs 41 MSB-first bits (each entry 0/1) into a
+// Status.
+func StatusFromBits(bits []byte) (Status, error) {
+	if len(bits) != 41 {
+		return Status{}, errors.New("ltr: status requires 41 bits")
+	}
+	info := make([]byte, 6)
+	for i := 0; i < 41; i++ {
+		if bits[i]&1 != 0 {
+			info[i>>3] |= 1 << uint(7-(i&7))
+		}
+	}
+	return ParseStatus(info)
+}
+
+// StatusBits returns the 41 MSB-first bits of a Status.
+func StatusBits(s Status) []byte {
+	bytes := AssembleStatus(s)
+	out := make([]byte, 41)
+	for i := 0; i < 41; i++ {
+		if bytes[i>>3]&(1<<uint(7-(i&7))) != 0 {
+			out[i] = 1
+		}
+	}
+	return out
+}
+
+// IsActive reports whether the status word indicates an active call
+// on this repeater. By convention LTR sets the Group ("F") bit to 1
+// while a group is transmitting and the GroupID is non-zero.
+func (s Status) IsActive() bool { return s.Group && s.GroupID != 0 }


### PR DESCRIPTION
Third trunked system on the TrunkTracker-style multi-system path,
joining the existing Motorola Type II and EDACS decoders. LTR is
architecturally different — there's no central control channel;
each repeater transmits its own 41-bit status word at 300 bps under
the in-band voice — but it slots into the existing engine via the
same `events.KindGrant` path.

## What this delivers

### `internal/radio/ltr/` (new package)

- **`ltr.go`** — package doc with the explicit deferral list
  (300-baud sub-audible status-word demod, Manchester decoding,
  LTR-Net cross-site coordination).
- **`status.go`** — `Status = {Sync: 1, Area: 5, Group: 1,
  Channel: 4, Home: 5, GroupID: 8, Free: 5, FCS: 12}` packed
  into 41 bits. Round-trip `AssembleStatus` / `ParseStatus` +
  bit-level helpers (`StatusBits`, `StatusFromBits`) and an
  `IsActive()` helper that flags any `Group=true + GroupID≠0`
  frame as a live call.
- **`bandplan.go`** — `Resolver` interface with
  `LinearBandPlan{BaseHz, SpacingHz, Offset}` (offset typically
  `-1` so channel 1 lands at `BaseHz`) and `TableBandPlan`.
- **`control.go`** — per-repeater state machine. Ingests status
  words, emits `events.KindCCLocked` the first time a valid
  status arrives (with `Area` + `Repeater` carried in
  `LockState`), and publishes `events.KindGrant` with
  `Protocol="ltr"` when the status announces an active call.
  Tracks the currently-active group so repeated status frames
  during one call don't cause duplicate grant events.
- **Optional `Area` filter** so a single physical channel can
  host multiple LTR systems without cross-talk.

## Test plan
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `go test -race -count=1 ./...`
- [x] `make integration`
- [x] Status round-trip (bytes + bits), length validation
- [x] `IsActive` across the four `(Group, GroupID)` combos
- [x] `LinearBandPlan` with the LTR-typical `-1` offset, plus
      zero-spacing rejection and negative-effective-offset
      rejection
- [x] `TableBandPlan` lookup hit + miss
- [x] Control channel emits `cc.locked` on the first valid
      status word
- [x] Bad-sync status words are silently dropped
- [x] `Area` filter — frames with the wrong area produce no
      events
- [x] Control channel publishes a `Grant` with the correct
      `(System, Protocol, GroupID, FrequencyHz, ChannelNum)`
      when a resolver is configured
- [x] Repeated active-status frames for the same group during
      one call do **not** republish a new grant; switching
      group does
- [x] Grant publication without a resolver leaves
      `FrequencyHz=0` and carries the channel in `ChannelNum`
- [x] `MarkLost` publishes `cc.lost` after a prior lock

## Roadmap status
- ✅ **1. Tone-out alerting** — landed.
- 🟡 **2. TrunkTracker-style multi-system grant following** —
  Motorola, EDACS, **and LTR** parsers + state machines now
  in place. **GMSK / MSK / 300-baud sub-audible** demodulators
  + FEC are the gating pieces for live captures (called out
  in each package's doc). MPT-1327 and P25 Phase 2 still
  ahead.
- 🟡 **3. Simulcast mitigation** — LMS + CMA cores landed.
- 4. Expanding digital-mode coverage — vocoders + more
  protocols.

## Honest caveats
- The 41-bit field layout follows the most-cited public
  reference. Same standing caveat as the other protocol
  packages: cross-check against an authoritative source before
  trusting live captures.
- LTR's "trunked" model is fundamentally different from the
  central-CC systems: LTR is a distributed scheme where each
  repeater advertises its own state. The `ControlChannel`
  type here represents a *single repeater's* state machine —
  scanning a multi-repeater LTR site means standing one of
  these up per repeater frequency.

https://claude.ai/code/session_01MQSV8EVnH6nsGUpcWep7UF

---
_Generated by [Claude Code](https://claude.ai/code/session_01MQSV8EVnH6nsGUpcWep7UF)_