### PR TITLE
MPT 1327 codeword decoder (Roadmap item 2 — fifth trunked system)

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,11 +166,27 @@ What's wired:
   active-call detection, no-republish-on-same-group, no-resolver
   fallback, and the cc.locked / cc.lost emissions. The 300-baud
   sub-audible status-word demodulator is the honest deferral.
+- **MPT 1327.** `internal/radio/mpt1327/` — 64-bit address-codeword
+  parser (38 information bits + 26 BCH parity, with BCH consumed
+  by the upstream FEC), CodewordKind enum
+  (Aloha / Ahoy / AhoyChan / GoToChannel / Ack / Disconnect /
+  Data / Emergency), per-kind payload accessors that surface
+  the GTC voice-grant channel + the AHYC system-broadcast
+  identifier, channel-number → Hz band-plan resolver
+  (linear and table), and a control-channel state machine that
+  publishes `cc.locked` on the first ALH or AHYC frame and
+  `grant` (with `trunking.Grant.Protocol = "mpt1327"`) on each
+  GoToChannel codeword. The grant's `GroupID` packs
+  `(prefix << 16) | ident` so prefixes that re-use idents stay
+  disambiguated. Tests cover codeword round-trip in bytes + bits,
+  Kind + payload extraction, both lock paths (ALH and AHYC),
+  the GTC grant publication, no-resolver fallback, data-codeword
+  filtering, and `MarkLost`. The 1200-baud FFSK demodulator and
+  BCH(63,38) decoder are honest deferrals, listed in the package's
+  doc comment.
 
 Still ahead:
 
-- **MPT-1327.** UK / Commonwealth utility trunking; cleanly
-  documented MAP-27 messages.
 - **P25 Phase 2 (TDMA H-DQPSK superframes).** The H-DQPSK demod and
   most framing primitives are already in place; what's missing is
   the TDMA superframe sync and the superframe / voice slot

--- a/internal/radio/mpt1327/bandplan.go
+++ b/internal/radio/mpt1327/bandplan.go
@@ -1,0 +1,44 @@
+package mpt1327
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Resolver maps an MPT 1327 channel number (the lower 13 bits of a
+// GTC codeword's Function field) to a frequency in Hz. MPT 1327
+// systems use vendor- and country-specific channel plans; both
+// linear and table-backed strategies are exposed, mirroring the
+// other protocol packages.
+type Resolver interface {
+	Frequency(channel uint16) (uint32, error)
+}
+
+// LinearBandPlan applies freq = BaseHz + (channel + Offset) * SpacingHz.
+type LinearBandPlan struct {
+	BaseHz    uint32
+	SpacingHz uint32
+	Offset    int
+}
+
+func (b LinearBandPlan) Frequency(ch uint16) (uint32, error) {
+	if b.SpacingHz == 0 {
+		return 0, errors.New("mpt1327/bandplan: SpacingHz must be > 0")
+	}
+	idx := int(ch) + b.Offset
+	if idx < 0 {
+		return 0, fmt.Errorf("mpt1327/bandplan: channel %d + offset %d went negative", ch, b.Offset)
+	}
+	return b.BaseHz + uint32(idx)*b.SpacingHz, nil
+}
+
+// TableBandPlan looks up explicit (channel → Hz) entries.
+type TableBandPlan map[uint16]uint32
+
+func (t TableBandPlan) Frequency(ch uint16) (uint32, error) {
+	hz, ok := t[ch]
+	if !ok {
+		return 0, fmt.Errorf("mpt1327/bandplan: channel %d not in table", ch)
+	}
+	return hz, nil
+}

--- a/internal/radio/mpt1327/codeword.go
+++ b/internal/radio/mpt1327/codeword.go
@@ -1,0 +1,98 @@
+package mpt1327
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Codeword is one MPT 1327 address / data codeword — 38 information
+// bits packed into the upper 38 bits of a 64-bit transmission unit
+// (the lower 26 bits hold the BCH(63,38) parity, which the upstream
+// FEC consumes before this package sees the codeword).
+//
+// Field layout in the 38-bit info portion:
+//
+//   bit 37 (1 bit)   Type    — 0 = address codeword, 1 = data
+//                              codeword. Address codewords carry
+//                              trunked signalling; data codewords
+//                              transport short messages and aren't
+//                              the focus here.
+//   bits 36..30 (7) Prefix  — area code prefix.
+//   bits 29..17 (13) Ident   — radio / fleet identity (the address).
+//   bits 16..0  (17) Function — opcode-specific information bits.
+//                              Decoded by the per-codeword accessors
+//                              in opcodes.go.
+//
+// As with the other protocol packages, the field positions follow
+// the most-cited public reference; vendor extensions repurpose the
+// Function field's sub-layout. Cross-check before trusting live
+// captures.
+type Codeword struct {
+	Type     CodewordType // 1-bit
+	Prefix   uint8        // 7-bit
+	Ident    uint16       // 13-bit
+	Function uint32       // 17-bit
+}
+
+// AssembleCodeword packs a Codeword into 5 bytes (40 bits, with the
+// upper 38 bits carrying the codeword and the bottom 2 bits zero-
+// padded). Used by tests and for any future encoder work.
+func AssembleCodeword(c Codeword) []byte {
+	var v uint64
+	v |= uint64(c.Type&1) << 37
+	v |= uint64(c.Prefix&0x7F) << 30
+	v |= uint64(c.Ident&0x1FFF) << 17
+	v |= uint64(c.Function & 0x1FFFF)
+	v <<= (40 - 38) // left-align into 5 bytes for clean MSB-first transport
+	return []byte{
+		byte((v >> 32) & 0xFF),
+		byte((v >> 24) & 0xFF),
+		byte((v >> 16) & 0xFF),
+		byte((v >> 8) & 0xFF),
+		byte(v & 0xFF),
+	}
+}
+
+// ParseCodeword reads 5 bytes (the upper 38 bits MSB-first as
+// produced by AssembleCodeword) into a Codeword.
+func ParseCodeword(info []byte) (Codeword, error) {
+	if len(info) != 5 {
+		return Codeword{}, fmt.Errorf("mpt1327: codeword info must be 5 bytes, got %d", len(info))
+	}
+	v := uint64(info[0])<<32 | uint64(info[1])<<24 | uint64(info[2])<<16 |
+		uint64(info[3])<<8 | uint64(info[4])
+	v >>= (40 - 38)
+	return Codeword{
+		Type:     CodewordType((v >> 37) & 1),
+		Prefix:   uint8((v >> 30) & 0x7F),
+		Ident:    uint16((v >> 17) & 0x1FFF),
+		Function: uint32(v & 0x1FFFF),
+	}, nil
+}
+
+// CodewordFromBits packs 38 MSB-first bits (each entry 0/1) into a
+// Codeword.
+func CodewordFromBits(bits []byte) (Codeword, error) {
+	if len(bits) != 38 {
+		return Codeword{}, errors.New("mpt1327: codeword requires 38 bits")
+	}
+	info := make([]byte, 5)
+	for i := 0; i < 38; i++ {
+		if bits[i]&1 != 0 {
+			info[i>>3] |= 1 << uint(7-(i&7))
+		}
+	}
+	return ParseCodeword(info)
+}
+
+// CodewordBits returns the 38 MSB-first bits of a Codeword.
+func CodewordBits(c Codeword) []byte {
+	bytes := AssembleCodeword(c)
+	out := make([]byte, 38)
+	for i := 0; i < 38; i++ {
+		if bytes[i>>3]&(1<<uint(7-(i&7))) != 0 {
+			out[i] = 1
+		}
+	}
+	return out
+}

--- a/internal/radio/mpt1327/control.go
+++ b/internal/radio/mpt1327/control.go
@@ -1,0 +1,160 @@
+package mpt1327
+
+import (
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// LockState is the payload of cc.locked / cc.lost events emitted by
+// the MPT 1327 control-channel state machine.
+type LockState struct {
+	FrequencyHz uint32
+	SystemID    uint16 // first AHYC's Function payload, when seen
+	Prefix      uint8  // first valid codeword's prefix
+}
+
+// ControlChannel ingests MPT 1327 codewords from a single control
+// channel, emits cc.locked the first time a valid Aloha (ALH) or
+// AHYC broadcast arrives on a freshly-tuned device, and republishes
+// GTC voice grants as events.KindGrant carrying a `trunking.Grant`
+// payload with `Protocol = "mpt1327"`. Same shape as the Motorola /
+// EDACS / LTR control channels.
+type ControlChannel struct {
+	bus        *events.Bus
+	log        *slog.Logger
+	systemName string
+	freqHz     uint32
+	resolver   Resolver
+	now        func() time.Time
+
+	mu     sync.Mutex
+	locked bool
+	last   LockState
+}
+
+// Options configure a ControlChannel.
+type Options struct {
+	Bus         *events.Bus
+	Log         *slog.Logger
+	SystemName  string
+	FrequencyHz uint32
+	Resolver    Resolver
+	Now         func() time.Time
+}
+
+// New constructs a ControlChannel.
+func New(opts Options) *ControlChannel {
+	log := opts.Log
+	if log == nil {
+		log = slog.Default()
+	}
+	now := opts.Now
+	if now == nil {
+		now = time.Now
+	}
+	return &ControlChannel{
+		bus:        opts.Bus,
+		log:        log,
+		systemName: opts.SystemName,
+		freqHz:     opts.FrequencyHz,
+		resolver:   opts.Resolver,
+		now:        now,
+	}
+}
+
+// Ingest hands a single decoded codeword to the state machine. Real
+// captures arrive via an upstream FFSK demod + BCH decoder; tests
+// publish codewords directly.
+func (c *ControlChannel) Ingest(w Codeword) {
+	if w.Type != TypeAddress {
+		// Data codewords carry short-message payloads we don't
+		// follow at the trunking layer.
+		return
+	}
+	switch w.Kind() {
+	case KindAloha:
+		c.maybeLock(LockState{
+			FrequencyHz: c.freqHz,
+			Prefix:      w.Prefix,
+		})
+	case KindAhoyChan:
+		if a, ok := w.AsAhoyChannel(); ok {
+			c.maybeLock(LockState{
+				FrequencyHz: c.freqHz,
+				SystemID:    a.System,
+				Prefix:      w.Prefix,
+			})
+		}
+	case KindGoToChan:
+		if g, ok := w.AsGoToChannel(); ok {
+			c.publishGrant(g)
+		}
+	}
+}
+
+func (c *ControlChannel) publishGrant(g GoToChannel) {
+	if c.bus == nil {
+		return
+	}
+	freq := uint32(0)
+	if c.resolver != nil {
+		if hz, err := c.resolver.Frequency(g.Channel); err == nil {
+			freq = hz
+		} else {
+			c.log.Debug("mpt1327: band-plan resolution failed",
+				"channel", g.Channel, "err", err)
+		}
+	}
+	// MPT 1327 doesn't carry a single "talkgroup" the way the central-
+	// CC trunked systems do — the called party is identified by
+	// (Prefix, Ident). We surface Ident as GroupID so downstream
+	// consumers (the engine, the recorder) get something useful, and
+	// fold Prefix into the high 16 bits of GroupID for disambiguation
+	// when Idents repeat across prefixes.
+	groupID := uint32(g.Prefix)<<16 | uint32(g.Ident)
+	c.bus.Publish(events.Event{
+		Kind: events.KindGrant,
+		Payload: trunking.Grant{
+			System:      c.systemName,
+			Protocol:    "mpt1327",
+			GroupID:     groupID,
+			FrequencyHz: freq,
+			ChannelNum:  g.Channel,
+			At:          c.now(),
+		},
+	})
+	c.log.Debug("mpt1327: grant",
+		"system", c.systemName,
+		"prefix", g.Prefix, "ident", g.Ident,
+		"channel", g.Channel, "freq_hz", freq)
+}
+
+func (c *ControlChannel) maybeLock(s LockState) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.locked && c.last == s {
+		return
+	}
+	c.locked = true
+	c.last = s
+	c.bus.Publish(events.Event{Kind: events.KindCCLocked, Payload: s})
+	c.log.Info("mpt1327 cc locked",
+		"freq", s.FrequencyHz, "sys", s.SystemID, "prefix", s.Prefix,
+		"system", c.systemName)
+}
+
+// MarkLost publishes cc.lost and resets the locked flag. The trunking
+// engine's hunter calls this when the control channel goes silent.
+func (c *ControlChannel) MarkLost() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !c.locked {
+		return
+	}
+	c.locked = false
+	c.bus.Publish(events.Event{Kind: events.KindCCLost, Payload: c.last})
+}

--- a/internal/radio/mpt1327/mpt1327.go
+++ b/internal/radio/mpt1327/mpt1327.go
@@ -1,0 +1,46 @@
+// Package mpt1327 decodes MPT 1327 trunked control-channel signaling
+// — the UK / Commonwealth utility trunking system standardised by the
+// UK Department of Trade and Industry's Code of Practice MPT 1327
+// (1988). Still in deployment for taxis, transport, and government
+// utility fleets across Europe, Australia, New Zealand, and parts of
+// Asia, Africa, and South America.
+//
+// Wire format: continuous 1200 baud FFSK on the control channel,
+// 64-bit codewords back-to-back. Each codeword is 38 information
+// bits + a 26-bit BCH(63,38)-derived check (folded into a 64-bit
+// transmission unit). Address codewords carry trunked signalling;
+// data codewords (signalled by the leading codeword-type bit)
+// transport short messages.
+//
+// Files:
+//
+//   codeword.go  Codeword = {Type, Prefix, Ident, Function} packed
+//                into the upper 38 bits of a 64-bit transmission
+//                unit. Round-trip assemble / parse helpers and bit
+//                accessors.
+//   opcodes.go   CodewordKind enum + per-kind payload accessors
+//                — Aloha (ALH) idle, Address Hang Up Yes (AHY)
+//                paging, Aloha Hang Up Yes Channel (AHYC) broadcast,
+//                Go To Channel (GTC) voice grant, Disconnect
+//                Unique-to-Line (DUL), Acknowledge (ACK).
+//   bandplan.go  Channel number → Hz resolver. MPT 1327 channel
+//                numbering is system-specific; both linear and
+//                table strategies are exposed.
+//   control.go   Control-channel state machine that ingests
+//                codewords, locks on the first valid Aloha (ALH)
+//                or AHYC broadcast, and republishes GTC grants as
+//                events.KindGrant with Protocol="mpt1327".
+//
+// What's NOT yet wired (honest deferrals):
+//
+//   - The 1200-baud FFSK demodulator that produces the bit stream
+//     this package consumes. MPT 1327 uses Audio FFSK with 1200 Hz
+//     and 1800 Hz mark/space — same family as classic POCSAG /
+//     ZVEI but a different bit rate.
+//   - BCH(63,38) decode of the 26-bit check field. The codeword
+//     parser here assumes the upstream caller has already corrected
+//     errors.
+//   - Slot-frame / sub-slot synchronisation. MPT 1327 codewords
+//     are scheduled in fixed sub-slots; multi-codeword decoding
+//     assumes the caller has aligned slot boundaries.
+package mpt1327

--- a/internal/radio/mpt1327/mpt1327_test.go
+++ b/internal/radio/mpt1327/mpt1327_test.go
@@ -1,0 +1,310 @@
+package mpt1327
+
+import (
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// makeCodeword builds an address codeword of the supplied kind with
+// the given prefix / ident / lower-13-bit payload.
+func makeCodeword(kind CodewordKind, prefix uint8, ident uint16, payload uint16) Codeword {
+	function := (uint32(kind) & 0xF) << 13
+	function |= uint32(payload) & 0x1FFF
+	return Codeword{
+		Type:     TypeAddress,
+		Prefix:   prefix,
+		Ident:    ident,
+		Function: function,
+	}
+}
+
+func TestCodewordAssembleParseRoundTrip(t *testing.T) {
+	in := Codeword{
+		Type:     TypeAddress,
+		Prefix:   0x42,
+		Ident:    0x1A1B,
+		Function: (uint32(KindGoToChan) << 13) | 0x1234,
+	}
+	bytes := AssembleCodeword(in)
+	if len(bytes) != 5 {
+		t.Fatalf("AssembleCodeword = %d bytes", len(bytes))
+	}
+	got, err := ParseCodeword(bytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != in {
+		t.Errorf("round-trip = %+v, want %+v", got, in)
+	}
+}
+
+func TestCodewordFromBitsRoundTrip(t *testing.T) {
+	in := makeCodeword(KindAhoyChan, 0x55, 0x0ABC, 0x0DEF)
+	bits := CodewordBits(in)
+	if len(bits) != 38 {
+		t.Fatalf("CodewordBits len = %d", len(bits))
+	}
+	got, err := CodewordFromBits(bits)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != in {
+		t.Errorf("round-trip = %+v", got)
+	}
+}
+
+func TestCodewordFromBitsRejectsBadLength(t *testing.T) {
+	if _, err := CodewordFromBits(make([]byte, 37)); err == nil {
+		t.Error("expected error for 37 bits")
+	}
+}
+
+func TestCodewordKindAndPayload(t *testing.T) {
+	c := makeCodeword(KindGoToChan, 0x01, 0x100, 0x123)
+	if c.Kind() != KindGoToChan {
+		t.Errorf("Kind = %s, want GoToChannel", c.Kind())
+	}
+	if c.FunctionPayload() != 0x123 {
+		t.Errorf("payload = %X", c.FunctionPayload())
+	}
+}
+
+func TestIsAloha(t *testing.T) {
+	if !makeCodeword(KindAloha, 0, 0, 0).IsAloha() {
+		t.Error("ALH codeword not flagged as aloha")
+	}
+	if makeCodeword(KindGoToChan, 0, 0, 0).IsAloha() {
+		t.Error("GTC codeword flagged as aloha")
+	}
+}
+
+func TestAsGoToChannel(t *testing.T) {
+	c := makeCodeword(KindGoToChan, 0x42, 0x1234, 0x0789)
+	g, ok := c.AsGoToChannel()
+	if !ok {
+		t.Fatal("expected grant")
+	}
+	if g.Prefix != 0x42 || g.Ident != 0x1234 || g.Channel != 0x0789 {
+		t.Errorf("grant = %+v", g)
+	}
+
+	// Aloha shouldn't masquerade as a grant.
+	if _, ok := makeCodeword(KindAloha, 0, 0, 0).AsGoToChannel(); ok {
+		t.Error("ALH reported a grant")
+	}
+	// Data codewords shouldn't either.
+	if _, ok := (Codeword{Type: TypeData, Function: uint32(KindGoToChan) << 13}).AsGoToChannel(); ok {
+		t.Error("data codeword reported a grant")
+	}
+}
+
+func TestAsAhoyChannel(t *testing.T) {
+	c := makeCodeword(KindAhoyChan, 0x07, 0x0050, 0x00CD)
+	a, ok := c.AsAhoyChannel()
+	if !ok {
+		t.Fatal("expected AHYC")
+	}
+	if a.Prefix != 0x07 || a.Ident != 0x0050 || a.System != 0x00CD {
+		t.Errorf("ahyc = %+v", a)
+	}
+}
+
+func TestKindString(t *testing.T) {
+	cases := map[CodewordKind]string{
+		KindAloha:     "Aloha",
+		KindGoToChan:  "GoToChannel",
+		KindAhoyChan:  "AhoyChan",
+		KindAck:       "Ack",
+		CodewordKind(0xD): "CodewordKind(D)",
+	}
+	for k, want := range cases {
+		if got := k.String(); got != want {
+			t.Errorf("Kind(%X).String() = %s, want %s", uint8(k), got, want)
+		}
+	}
+}
+
+func TestCodewordTypeString(t *testing.T) {
+	if TypeAddress.String() != "Address" || TypeData.String() != "Data" {
+		t.Errorf("unexpected type strings: %s / %s", TypeAddress.String(), TypeData.String())
+	}
+}
+
+func TestLinearBandPlan(t *testing.T) {
+	bp := LinearBandPlan{BaseHz: 165_000_000, SpacingHz: 12_500, Offset: -1}
+	if hz, _ := bp.Frequency(1); hz != 165_000_000 {
+		t.Errorf("ch 1 → %d, want 165M", hz)
+	}
+	if hz, _ := bp.Frequency(100); hz != 165_000_000+99*12_500 {
+		t.Errorf("ch 100 → %d", hz)
+	}
+	if _, err := (LinearBandPlan{BaseHz: 1, SpacingHz: 0}).Frequency(1); err == nil {
+		t.Error("zero spacing should error")
+	}
+	if _, err := (LinearBandPlan{BaseHz: 1, SpacingHz: 12_500, Offset: -10}).Frequency(1); err == nil {
+		t.Error("negative effective offset should error")
+	}
+}
+
+func TestTableBandPlan(t *testing.T) {
+	bp := TableBandPlan{1: 165_000_000, 5: 165_062_500}
+	if hz, _ := bp.Frequency(1); hz != 165_000_000 {
+		t.Errorf("ch 1 → %d", hz)
+	}
+	if _, err := bp.Frequency(99); err == nil {
+		t.Error("missing channel should error")
+	}
+}
+
+func TestControlChannelEmitsLockOnAloha(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{
+		Bus:         bus,
+		SystemName:  "TestMPT",
+		FrequencyHz: 165_000_000,
+	})
+	cc.Ingest(makeCodeword(KindAloha, 0x42, 0, 0))
+
+	select {
+	case ev := <-sub.C:
+		if ev.Kind != events.KindCCLocked {
+			t.Fatalf("kind = %s", ev.Kind)
+		}
+		ls, ok := ev.Payload.(LockState)
+		if !ok || ls.FrequencyHz != 165_000_000 || ls.Prefix != 0x42 {
+			t.Errorf("lock state = %+v", ev.Payload)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("no event")
+	}
+}
+
+func TestControlChannelEmitsLockOnAhoyChan(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, SystemName: "X", FrequencyHz: 1})
+	cc.Ingest(makeCodeword(KindAhoyChan, 0x05, 0x100, 0x0ABC))
+
+	ev := <-sub.C
+	if ev.Kind != events.KindCCLocked {
+		t.Fatalf("kind = %s", ev.Kind)
+	}
+	if ls, ok := ev.Payload.(LockState); !ok || ls.SystemID != 0x0ABC {
+		t.Errorf("lock = %+v", ev.Payload)
+	}
+}
+
+func TestControlChannelPublishesGrant(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{
+		Bus:         bus,
+		SystemName:  "TestMPT",
+		FrequencyHz: 165_000_000,
+		Resolver: LinearBandPlan{
+			BaseHz: 165_000_000, SpacingHz: 12_500, Offset: -1,
+		},
+	})
+	// Lock first.
+	cc.Ingest(makeCodeword(KindAloha, 0x01, 0, 0))
+	if ev := <-sub.C; ev.Kind != events.KindCCLocked {
+		t.Fatalf("first event = %s, want cc.locked", ev.Kind)
+	}
+	// Now publish a GTC grant — channel 5.
+	cc.Ingest(makeCodeword(KindGoToChan, 0x42, 0x1234, 5))
+
+	select {
+	case ev := <-sub.C:
+		if ev.Kind != events.KindGrant {
+			t.Fatalf("kind = %s", ev.Kind)
+		}
+		g, ok := ev.Payload.(trunking.Grant)
+		if !ok {
+			t.Fatalf("payload = %T", ev.Payload)
+		}
+		if g.System != "TestMPT" || g.Protocol != "mpt1327" {
+			t.Errorf("identity = %+v", g)
+		}
+		// GroupID = (prefix << 16) | ident = (0x42 << 16) | 0x1234.
+		if g.GroupID != (0x42<<16)|0x1234 {
+			t.Errorf("group = %X, want %X", g.GroupID, (0x42<<16)|0x1234)
+		}
+		if g.ChannelNum != 5 {
+			t.Errorf("channel = %d", g.ChannelNum)
+		}
+		// LinearBandPlan: ch 5 with offset -1 → idx 4 → 165M + 50_000.
+		if g.FrequencyHz != 165_050_000 {
+			t.Errorf("freq = %d, want 165_050_000", g.FrequencyHz)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("no grant")
+	}
+}
+
+func TestControlChannelGrantWithoutResolverHasZeroFreq(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, SystemName: "X", FrequencyHz: 1})
+	cc.Ingest(makeCodeword(KindGoToChan, 0x10, 0x0050, 7))
+	ev := <-sub.C
+	g := ev.Payload.(trunking.Grant)
+	if g.FrequencyHz != 0 {
+		t.Errorf("freq = %d, want 0", g.FrequencyHz)
+	}
+	if g.ChannelNum != 7 {
+		t.Errorf("channel = %d", g.ChannelNum)
+	}
+}
+
+func TestControlChannelIgnoresDataCodewords(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, SystemName: "X", FrequencyHz: 1})
+	cc.Ingest(Codeword{Type: TypeData, Function: uint32(KindGoToChan) << 13})
+
+	select {
+	case ev := <-sub.C:
+		t.Errorf("data codeword produced an event: %s", ev.Kind)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestControlChannelMarkLost(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, SystemName: "X", FrequencyHz: 1})
+	cc.Ingest(makeCodeword(KindAloha, 0x42, 0, 0))
+	<-sub.C // cc.locked
+
+	cc.MarkLost()
+	select {
+	case ev := <-sub.C:
+		if ev.Kind != events.KindCCLost {
+			t.Errorf("kind = %s, want cc.lost", ev.Kind)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("no cc.lost")
+	}
+}

--- a/internal/radio/mpt1327/opcodes.go
+++ b/internal/radio/mpt1327/opcodes.go
@@ -1,0 +1,125 @@
+package mpt1327
+
+import "fmt"
+
+// CodewordType is the 1-bit Codeword.Type field — 0 = address
+// codeword (trunked signalling), 1 = data codeword (short messages).
+type CodewordType uint8
+
+const (
+	TypeAddress CodewordType = 0
+	TypeData    CodewordType = 1
+)
+
+func (t CodewordType) String() string {
+	switch t {
+	case TypeAddress:
+		return "Address"
+	case TypeData:
+		return "Data"
+	default:
+		return fmt.Sprintf("CodewordType(%d)", uint8(t))
+	}
+}
+
+// CodewordKind enumerates the address-codeword sub-types most useful
+// for trunking follow-along. The kind is decoded from the upper 4
+// bits of the 17-bit Function field, which the spec calls the
+// "Address Categorisation" subfield.
+type CodewordKind uint8
+
+const (
+	KindUnknown   CodewordKind = 0x0
+	KindAloha     CodewordKind = 0x1 // ALH  — control-channel idle
+	KindAhoy      CodewordKind = 0x2 // AHY  — paging / inquiry
+	KindAhoyChan  CodewordKind = 0x3 // AHYC — broadcast / system info
+	KindGoToChan  CodewordKind = 0x4 // GTC  — voice grant ("go to channel")
+	KindAck       CodewordKind = 0x5 // ACK
+	KindDisconnect CodewordKind = 0x6 // DUL — disconnect-unique-to-line
+	KindData      CodewordKind = 0x7 // SAMO / data-request shorthand
+	KindEmergency CodewordKind = 0xE
+)
+
+func (k CodewordKind) String() string {
+	switch k {
+	case KindAloha:
+		return "Aloha"
+	case KindAhoy:
+		return "Ahoy"
+	case KindAhoyChan:
+		return "AhoyChan"
+	case KindGoToChan:
+		return "GoToChannel"
+	case KindAck:
+		return "Ack"
+	case KindDisconnect:
+		return "Disconnect"
+	case KindData:
+		return "Data"
+	case KindEmergency:
+		return "Emergency"
+	default:
+		return fmt.Sprintf("CodewordKind(%X)", uint8(k))
+	}
+}
+
+// Kind returns the CodewordKind embedded in the Function field's
+// upper 4 bits (Address Categorisation subfield).
+func (c Codeword) Kind() CodewordKind {
+	return CodewordKind((c.Function >> 13) & 0xF)
+}
+
+// FunctionPayload returns the lower 13 bits of the Function field —
+// the subfield that carries kind-specific data. For GTC this is the
+// assigned channel number; for AHYC it carries broadcast info.
+func (c Codeword) FunctionPayload() uint16 {
+	return uint16(c.Function & 0x1FFF)
+}
+
+// IsAloha reports whether the codeword is an ALH idle frame on the
+// control channel.
+func (c Codeword) IsAloha() bool { return c.Kind() == KindAloha }
+
+// GoToChannel is the high-level shape of an MPT 1327 GTC voice grant.
+// The codeword's Prefix + Ident form the called party; the lower 13
+// bits of Function carry the assigned channel number that the
+// receiving radio retunes to.
+type GoToChannel struct {
+	Prefix  uint8
+	Ident   uint16
+	Channel uint16
+}
+
+// AsGoToChannel returns the structured grant if the codeword is a
+// GTC, otherwise (zero, false).
+func (c Codeword) AsGoToChannel() (GoToChannel, bool) {
+	if c.Type != TypeAddress || c.Kind() != KindGoToChan {
+		return GoToChannel{}, false
+	}
+	return GoToChannel{
+		Prefix:  c.Prefix,
+		Ident:   c.Ident,
+		Channel: c.FunctionPayload(),
+	}, true
+}
+
+// AhoyChannel describes an AHYC system broadcast. The Function
+// payload carries a sub-system identifier the engine treats as the
+// SystemID for cc.locked events.
+type AhoyChannel struct {
+	Prefix uint8
+	Ident  uint16
+	System uint16
+}
+
+// AsAhoyChannel returns the structured AHYC if applicable.
+func (c Codeword) AsAhoyChannel() (AhoyChannel, bool) {
+	if c.Type != TypeAddress || c.Kind() != KindAhoyChan {
+		return AhoyChannel{}, false
+	}
+	return AhoyChannel{
+		Prefix: c.Prefix,
+		Ident:  c.Ident,
+		System: c.FunctionPayload(),
+	}, true
+}


### PR DESCRIPTION
Last remaining trunked system on the TrunkTracker-style multi-system
path apart from P25 Phase 2. Joins Motorola Type II, EDACS, and LTR
in `internal/radio/`. MPT 1327 is the UK / Commonwealth utility
trunking system standardised by the UK DTI's Code of Practice
MPT 1327 (1988), still in deployment for taxis, transport, and
government utility fleets across Europe, Australia, NZ, and parts
of Asia, Africa, and South America.

## What this delivers

### `internal/radio/mpt1327/` (new package)

- **`mpt1327.go`** — package doc with the explicit deferral list
  (1200-baud FFSK demod, BCH(63,38) decode, slot-frame sync).
- **`codeword.go`** — `Codeword = {Type, Prefix: 7, Ident: 13,
  Function: 17}` packed into the upper 38 bits of a 64-bit
  transmission unit. Round-trip `AssembleCodeword` /
  `ParseCodeword` + bit-level helpers (`CodewordBits`,
  `CodewordFromBits`).
- **`opcodes.go`** — `CodewordType` (Address / Data) +
  `CodewordKind` enum from the upper 4 bits of `Function`:
  `Aloha`, `Ahoy`, `AhoyChan`, `GoToChannel`, `Ack`,
  `Disconnect`, `Data`, `Emergency`. `Kind()` and
  `FunctionPayload()` accessors. Per-kind structures:
  `GoToChannel` (Prefix + Ident + Channel) and `AhoyChannel`
  (Prefix + Ident + System) with `AsGoToChannel` /
  `AsAhoyChannel`.
- **`bandplan.go`** — `Resolver` interface with
  `LinearBandPlan{BaseHz, SpacingHz, Offset}` (offset typically
  `-1` so channel 1 lands at `BaseHz`) and `TableBandPlan`.
- **`control.go`** — `ControlChannel` state machine. Locks on the
  first ALH or AHYC broadcast (the AHYC system identifier is
  carried in `LockState.SystemID`); publishes `events.KindGrant`
  with `Protocol="mpt1327"` on each `GoToChannel` codeword.
  Because MPT 1327 doesn't carry a single talkgroup the way the
  central-CC trunked systems do, the grant's `GroupID` packs
  `(prefix << 16) | ident` so prefixes that re-use idents stay
  disambiguated. Data codewords are silently dropped. `MarkLost`
  mirrors the other protocols' watchdog hook.

## Test plan
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `go test -race -count=1 ./...`
- [x] `make integration`
- [x] Codeword round-trip (bytes + bits), length validation
- [x] `Kind` extraction from the Function field
- [x] `FunctionPayload` returns the lower 13 bits
- [x] `IsAloha` recognition + `Kind.String()` coverage
- [x] `AsGoToChannel` returns the structured grant for
      address-type GTC codewords; rejects ALH and data-type
      codewords
- [x] `AsAhoyChannel` returns the structured AHYC for
      address-type AHYC codewords
- [x] `LinearBandPlan` with the MPT-typical `-1` offset, plus
      zero-spacing rejection and negative-effective-offset
      rejection
- [x] `TableBandPlan` lookup hit + miss
- [x] Control channel emits `cc.locked` on the first ALH frame
- [x] Control channel emits `cc.locked` on AHYC with the
      System payload carried in `LockState.SystemID`
- [x] Control channel publishes a `Grant` with the correct
      `(System, Protocol, GroupID, FrequencyHz, ChannelNum)`
      when a resolver is configured, with `GroupID` packing
      `(prefix << 16) | ident`
- [x] Grant publication without a resolver leaves
      `FrequencyHz=0` and carries the channel in `ChannelNum`
- [x] Data codewords (TypeData) produce no events
- [x] `MarkLost` publishes `cc.lost` after a prior lock

## Roadmap status
- ✅ **1. Tone-out alerting** — landed.
- 🟡 **2. TrunkTracker-style multi-system grant following** —
  Motorola, EDACS, LTR, and **MPT 1327** parsers + state
  machines in place. The respective on-air demodulators
  (3600-baud Motorola MSK, 9600-baud EDACS GMSK, 300-baud LTR
  sub-audible, 1200-baud MPT FFSK) and FECs are the gating
  pieces for live captures. **P25 Phase 2** is the last
  remaining trunked system under this item.
- 🟡 **3. Simulcast mitigation** — LMS + CMA cores landed.
- 4. Expanding digital-mode coverage — vocoders + more
  protocols.

## Honest caveats
- The 38-bit info layout follows the most-cited public
  reference. Same standing caveat as the other protocol
  packages: cross-check against an authoritative source
  (the MPT 1327 Code of Practice) before trusting live
  captures.
- The `(prefix << 16) | ident` packing into `GroupID` is a
  GopherTrunk choice for letting the engine's existing
  talkgroup-DB lookups still work; operators with multi-
  prefix MPT systems may want a separate per-prefix
  talkgroup table.

https://claude.ai/code/session_01MQSV8EVnH6nsGUpcWep7UF

---
_Generated by [Claude Code](https://claude.ai/code/session_01MQSV8EVnH6nsGUpcWep7UF)_