### PR TITLE
dPMR Mode 3 trunked-signalling decoder (Roadmap item 4 — protocols)

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,8 +320,29 @@ Vocoders:
 
 Protocols:
 
-- **dPMR (digital PMR446)** — public ETSI TS 102 658 spec, similar
-  framing to NXDN. A natural addition once NXDN's SACCH FEC lands.
+- ✅ **dPMR (digital PMR446)** — `internal/radio/dpmr/` — Mode 3
+  trunked signalling per ETSI TS 102 658. Ships FS1 / FS2 / FS3
+  24-dibit sync constants and a tolerant `SyncDetector` matching
+  the Phase 1 / DMR / NXDN shape, an 80-bit `CSBK` parser
+  (5-bit message type + 3-bit flags + 24-bit source + 24-bit
+  destination + 8-bit service info + 16-bit opcode-specific
+  field), a `MessageType` enum (RegistrationRequest / Response,
+  VoiceServiceAllocation, IndividualVoiceAllocation,
+  DataServiceAllocation, ServiceRequest, StandingServiceStatus,
+  Release, Idle), per-message accessors that surface
+  group / emergency / encryption flags from the 3-bit Flags
+  field, a `LinearBandPlan` / `TableBandPlan` channel resolver
+  (PMR446 default 446 006 250 Hz @ 6.25 kHz spacing), and a
+  control-channel state machine that publishes `cc.locked` on
+  StandingServiceStatus (or the first voice grant) and `grant`
+  with `trunking.Grant.Protocol = "dpmr"` on voice allocations.
+  Tests cover CSBK byte + bit round-trip, flag accessors,
+  AsVoiceGrant / AsSiteBroadcast extraction, IsIdle, sync
+  constants distinctness + exact + tolerant matching + noise
+  rejection, both band-plan strategies, and the full
+  cc.locked / grant / cc.lost emission path. The 4FSK demodulator,
+  CSBK FEC + interleaver, and AMBE+2 vocoder are honest
+  deferrals listed in the package's doc comment.
 - **TETRA** — full public spec (ETSI TS 100 392); large undertaking
   but well-defined.
 - **D-STAR / Yaesu System Fusion** — amateur-radio digital modes

--- a/internal/radio/dpmr/bandplan.go
+++ b/internal/radio/dpmr/bandplan.go
@@ -1,0 +1,45 @@
+package dpmr
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Resolver maps a dPMR channel number (the 16-bit Extra field of a
+// voice-allocation CSBK) to a frequency in Hz. dPMR systems use
+// 6.25 kHz channel spacing by default; both linear and table-backed
+// strategies are exposed, mirroring the other protocol packages.
+type Resolver interface {
+	Frequency(channel uint16) (uint32, error)
+}
+
+// LinearBandPlan applies freq = BaseHz + (channel + Offset) * SpacingHz.
+// For PMR446 the canonical layout is BaseHz = 446_006_250, SpacingHz =
+// 6_250, Offset = -1 so channel 1 = 446 006 250 Hz.
+type LinearBandPlan struct {
+	BaseHz    uint32
+	SpacingHz uint32
+	Offset    int
+}
+
+func (b LinearBandPlan) Frequency(ch uint16) (uint32, error) {
+	if b.SpacingHz == 0 {
+		return 0, errors.New("dpmr/bandplan: SpacingHz must be > 0")
+	}
+	idx := int(ch) + b.Offset
+	if idx < 0 {
+		return 0, fmt.Errorf("dpmr/bandplan: channel %d + offset %d went negative", ch, b.Offset)
+	}
+	return b.BaseHz + uint32(idx)*b.SpacingHz, nil
+}
+
+// TableBandPlan looks up explicit (channel → Hz) entries.
+type TableBandPlan map[uint16]uint32
+
+func (t TableBandPlan) Frequency(ch uint16) (uint32, error) {
+	hz, ok := t[ch]
+	if !ok {
+		return 0, fmt.Errorf("dpmr/bandplan: channel %d not in table", ch)
+	}
+	return hz, nil
+}

--- a/internal/radio/dpmr/control.go
+++ b/internal/radio/dpmr/control.go
@@ -1,0 +1,151 @@
+package dpmr
+
+import (
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// LockState is the payload of cc.locked / cc.lost events emitted by
+// the dPMR Mode 3 control-channel state machine.
+type LockState struct {
+	FrequencyHz uint32
+	SystemID    uint32 // first StandingServiceStatus' DestID, when seen
+}
+
+// ControlChannel ingests CSBKs from a single dPMR Mode 3 control
+// channel, emits cc.locked the first time a valid StandingServiceStatus
+// (or any non-idle CSBK) arrives on a freshly-tuned device, and
+// republishes voice grants as events.KindGrant carrying a
+// `trunking.Grant` payload with `Protocol = "dpmr"`. Same shape as the
+// Motorola / EDACS / LTR / MPT 1327 / P25 Phase 2 control channels.
+type ControlChannel struct {
+	bus        *events.Bus
+	log        *slog.Logger
+	systemName string
+	freqHz     uint32
+	resolver   Resolver
+	now        func() time.Time
+
+	mu     sync.Mutex
+	locked bool
+	last   LockState
+}
+
+// Options configure a ControlChannel.
+type Options struct {
+	Bus         *events.Bus
+	Log         *slog.Logger
+	SystemName  string
+	FrequencyHz uint32
+	Resolver    Resolver
+	Now         func() time.Time
+}
+
+// New constructs a ControlChannel.
+func New(opts Options) *ControlChannel {
+	log := opts.Log
+	if log == nil {
+		log = slog.Default()
+	}
+	now := opts.Now
+	if now == nil {
+		now = time.Now
+	}
+	return &ControlChannel{
+		bus:        opts.Bus,
+		log:        log,
+		systemName: opts.SystemName,
+		freqHz:     opts.FrequencyHz,
+		resolver:   opts.Resolver,
+		now:        now,
+	}
+}
+
+// Ingest hands a single decoded CSBK to the state machine. Real
+// captures arrive via an upstream 4FSK demod + FEC; tests publish
+// CSBKs directly.
+func (c *ControlChannel) Ingest(b CSBK) {
+	if b.IsIdle() {
+		return
+	}
+	if sb, ok := b.AsSiteBroadcast(); ok {
+		c.maybeLock(LockState{FrequencyHz: c.freqHz, SystemID: sb.SystemID})
+		return
+	}
+	if g, ok := b.AsVoiceGrant(); ok {
+		// Even if we haven't seen a SiteBroadcast yet, a voice grant on
+		// the CC is enough to declare the channel locked.
+		c.maybeLock(LockState{FrequencyHz: c.freqHz})
+		c.publishGrant(g)
+	}
+}
+
+func (c *ControlChannel) publishGrant(g VoiceGrant) {
+	if c.bus == nil {
+		return
+	}
+	freq := uint32(0)
+	if c.resolver != nil {
+		if hz, err := c.resolver.Frequency(g.Channel); err == nil {
+			freq = hz
+		} else {
+			c.log.Debug("dpmr: band-plan resolution failed",
+				"channel", g.Channel, "err", err)
+		}
+	}
+	c.bus.Publish(events.Event{
+		Kind: events.KindGrant,
+		Payload: trunking.Grant{
+			System:      c.systemName,
+			Protocol:    "dpmr",
+			GroupID:     g.DestID,
+			SourceID:    g.SourceID,
+			FrequencyHz: freq,
+			ChannelNum:  g.Channel,
+			Encrypted:   g.Encrypted,
+			Emergency:   g.Emergency,
+			At:          c.now(),
+		},
+	})
+	c.log.Debug("dpmr: grant",
+		"system", c.systemName,
+		"src", g.SourceID, "dst", g.DestID,
+		"channel", g.Channel, "freq_hz", freq,
+		"group", g.Group, "enc", g.Encrypted, "emer", g.Emergency)
+}
+
+func (c *ControlChannel) maybeLock(s LockState) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.locked && c.last == s {
+		return
+	}
+	// Preserve a previously-learned SystemID if the new state has none.
+	if c.locked && s.SystemID == 0 && c.last.SystemID != 0 {
+		s.SystemID = c.last.SystemID
+		if c.last == s {
+			return
+		}
+	}
+	c.locked = true
+	c.last = s
+	c.bus.Publish(events.Event{Kind: events.KindCCLocked, Payload: s})
+	c.log.Info("dpmr cc locked",
+		"freq", s.FrequencyHz, "sys", s.SystemID, "system", c.systemName)
+}
+
+// MarkLost publishes cc.lost and resets the locked flag. The trunking
+// engine's hunter calls this when the control channel goes silent.
+func (c *ControlChannel) MarkLost() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !c.locked {
+		return
+	}
+	c.locked = false
+	c.bus.Publish(events.Event{Kind: events.KindCCLost, Payload: c.last})
+}

--- a/internal/radio/dpmr/csbk.go
+++ b/internal/radio/dpmr/csbk.go
@@ -1,0 +1,108 @@
+package dpmr
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+)
+
+// CSBK (Common Signalling Block) is the 80-bit Mode 3 signalling unit
+// the control channel transmits between voice grants. After FEC
+// removal the structured layout is:
+//
+//   bits  0..4   (5)  Message type      (see opcodes.go)
+//   bits  5..7   (3)  Format / flags    (reserved + emergency + group)
+//   bits  8..31  (24) Source ID         (calling subscriber)
+//   bits 32..55  (24) Destination ID    (callee — group or subscriber)
+//   bits 56..63  (8)  Service info      (priority / payload type)
+//   bits 64..79  (16) Opcode-specific   (channel number, status, …)
+//
+// Field layout follows ETSI TS 102 658 §6.5; vendor extensions
+// repurpose Service info and the trailing 16 bits, so cross-check
+// before trusting live captures.
+type CSBK struct {
+	Type        MessageType
+	Flags       uint8  // 3-bit
+	SourceID    uint32 // 24-bit
+	DestID      uint32 // 24-bit
+	ServiceInfo uint8
+	Extra       uint16 // opcode-specific 16-bit field (e.g. channel number)
+}
+
+// AssembleCSBK packs a CSBK into 10 bytes (80 bits, MSB-first across
+// the byte boundaries described above). Used by tests and by any
+// future encoder work.
+func AssembleCSBK(c CSBK) []byte {
+	out := make([]byte, 10)
+	out[0] = (uint8(c.Type)&0x1F)<<3 | (c.Flags & 0x07)
+	out[1] = byte((c.SourceID >> 16) & 0xFF)
+	out[2] = byte((c.SourceID >> 8) & 0xFF)
+	out[3] = byte(c.SourceID & 0xFF)
+	out[4] = byte((c.DestID >> 16) & 0xFF)
+	out[5] = byte((c.DestID >> 8) & 0xFF)
+	out[6] = byte(c.DestID & 0xFF)
+	out[7] = c.ServiceInfo
+	binary.BigEndian.PutUint16(out[8:10], c.Extra)
+	return out
+}
+
+// ParseCSBK consumes 10 bytes (80 bits, as packed by AssembleCSBK)
+// into a CSBK.
+func ParseCSBK(info []byte) (CSBK, error) {
+	if len(info) != 10 {
+		return CSBK{}, fmt.Errorf("dpmr: CSBK info must be 10 bytes, got %d", len(info))
+	}
+	return CSBK{
+		Type:        MessageType((info[0] >> 3) & 0x1F),
+		Flags:       info[0] & 0x07,
+		SourceID:    uint32(info[1])<<16 | uint32(info[2])<<8 | uint32(info[3]),
+		DestID:      uint32(info[4])<<16 | uint32(info[5])<<8 | uint32(info[6]),
+		ServiceInfo: info[7],
+		Extra:       binary.BigEndian.Uint16(info[8:10]),
+	}, nil
+}
+
+// CSBKFromBits packs 80 MSB-first bits (each entry 0/1) into a CSBK.
+func CSBKFromBits(bits []byte) (CSBK, error) {
+	if len(bits) != 80 {
+		return CSBK{}, errors.New("dpmr: CSBK requires 80 bits")
+	}
+	info := make([]byte, 10)
+	for i := 0; i < 80; i++ {
+		if bits[i]&1 != 0 {
+			info[i>>3] |= 1 << uint(7-(i&7))
+		}
+	}
+	return ParseCSBK(info)
+}
+
+// CSBKBits returns the 80 MSB-first bits of a CSBK.
+func CSBKBits(c CSBK) []byte {
+	bytes := AssembleCSBK(c)
+	out := make([]byte, 80)
+	for i := 0; i < 80; i++ {
+		if bytes[i>>3]&(1<<uint(7-(i&7))) != 0 {
+			out[i] = 1
+		}
+	}
+	return out
+}
+
+// Flag bits inside the 3-bit Flags field.
+const (
+	FlagGroupCall byte = 0x4
+	FlagEmergency byte = 0x2
+	FlagEncrypted byte = 0x1
+)
+
+// IsGroup reports whether the CSBK Flags field marks the call as a
+// group (rather than individual) call.
+func (c CSBK) IsGroup() bool { return c.Flags&FlagGroupCall != 0 }
+
+// IsEmergency reports whether the Flags field marks the call as
+// emergency.
+func (c CSBK) IsEmergency() bool { return c.Flags&FlagEmergency != 0 }
+
+// IsEncrypted reports whether the Flags field marks the call as
+// encrypted.
+func (c CSBK) IsEncrypted() bool { return c.Flags&FlagEncrypted != 0 }

--- a/internal/radio/dpmr/dpmr.go
+++ b/internal/radio/dpmr/dpmr.go
@@ -1,0 +1,48 @@
+// Package dpmr decodes dPMR (digital PMR446 / ETSI TS 102 658) Mode 3
+// trunking signalling. dPMR is a 4-level FSK protocol designed for
+// 6.25 kHz channel spacing — the digital successor to analogue PMR446
+// in Europe and a sibling of NXDN in framing philosophy. Three
+// operating modes are defined:
+//
+//   Mode 1   peer-to-peer (no infrastructure)
+//   Mode 2   managed direct (no repeater, but a dispatch channel)
+//   Mode 3   centralised trunking (a dedicated control channel that
+//            grants voice / data calls onto traffic channels)
+//
+// This package targets Mode 3 — the only mode where the standard
+// "see CC opcode → retune Voice device → follow grant" loop applies.
+// Modes 1 and 2 don't have a control channel for the engine to hunt.
+//
+// What this package gives you:
+//
+//   sync.go      Frame Sync 1 / 2 / 3 constants and a tolerant
+//                SyncDetector matching the shape used by the other
+//                trunked-protocol packages.
+//   csbk.go      CSBK (Common Signalling Block) parser — 80-bit
+//                signalling unit with a 5-bit message type, source
+//                and destination IDs, and opcode-specific fields.
+//   opcodes.go   MessageType enum + per-message accessors
+//                (VoiceServiceAllocation, IndividualCall,
+//                DataServiceAllocation, Status, Release, …).
+//   bandplan.go  Channel-number → Hz resolver, linear and table.
+//   control.go   State machine that ingests CSBKs and publishes
+//                events.KindCCLocked / events.KindGrant on the bus
+//                with `trunking.Grant.Protocol = "dpmr"`.
+//
+// What's NOT yet wired (honest deferrals):
+//
+//   - The 4FSK demodulator + symbol-clock recovery for dPMR's
+//     2400 sym/sec air interface. internal/dsp/demod/c4fm.go is the
+//     closest fit; matched-filter parameters differ slightly.
+//   - The interleaver + FEC over CSBK bits. Mode 3 CSBKs use a
+//     short-block cyclic code with rate-3/4 convolutional outer
+//     coding; the parsing here assumes the upstream caller has
+//     already corrected errors.
+//   - Voice frame extraction → AMBE+2 vocoder. The vocoder lives
+//     behind the `mbelib` build tag (see internal/voice/mbelib).
+//
+// As with the other trunking packages: ship a clean structured
+// surface now, leave the analogue / FEC pieces as named follow-ups
+// so the trunking engine can consume the events end-to-end against
+// fixtures.
+package dpmr

--- a/internal/radio/dpmr/dpmr_test.go
+++ b/internal/radio/dpmr/dpmr_test.go
@@ -1,0 +1,428 @@
+package dpmr
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+func TestCSBKByteRoundTrip(t *testing.T) {
+	in := CSBK{
+		Type:        MsgVoiceServiceAllocation,
+		Flags:       FlagGroupCall | FlagEmergency,
+		SourceID:    0x123456,
+		DestID:      0xABCDEF,
+		ServiceInfo: 0x42,
+		Extra:       0x0123,
+	}
+	bytes := AssembleCSBK(in)
+	if len(bytes) != 10 {
+		t.Fatalf("AssembleCSBK len = %d, want 10", len(bytes))
+	}
+	out, err := ParseCSBK(bytes)
+	if err != nil {
+		t.Fatalf("ParseCSBK: %v", err)
+	}
+	if out != in {
+		t.Errorf("round-trip = %+v, want %+v", out, in)
+	}
+}
+
+func TestCSBKBitRoundTrip(t *testing.T) {
+	in := CSBK{
+		Type:     MsgIndividualVoiceAllocation,
+		Flags:    FlagEncrypted,
+		SourceID: 0x7FFFFF,
+		DestID:   0x000001,
+		Extra:    0xFFFF,
+	}
+	bits := CSBKBits(in)
+	if len(bits) != 80 {
+		t.Fatalf("CSBKBits len = %d, want 80", len(bits))
+	}
+	out, err := CSBKFromBits(bits)
+	if err != nil {
+		t.Fatalf("CSBKFromBits: %v", err)
+	}
+	if out != in {
+		t.Errorf("bits round-trip = %+v, want %+v", out, in)
+	}
+}
+
+func TestParseCSBKWrongLength(t *testing.T) {
+	if _, err := ParseCSBK(make([]byte, 9)); err == nil {
+		t.Error("expected error for len(info) < 10")
+	}
+}
+
+func TestCSBKFlagAccessors(t *testing.T) {
+	cases := []struct {
+		flags        byte
+		group, emer  bool
+		enc          bool
+	}{
+		{0x00, false, false, false},
+		{FlagGroupCall, true, false, false},
+		{FlagEmergency, false, true, false},
+		{FlagEncrypted, false, false, true},
+		{FlagGroupCall | FlagEmergency | FlagEncrypted, true, true, true},
+	}
+	for _, c := range cases {
+		csbk := CSBK{Flags: c.flags}
+		if csbk.IsGroup() != c.group ||
+			csbk.IsEmergency() != c.emer ||
+			csbk.IsEncrypted() != c.enc {
+			t.Errorf("flags %#02x: group=%v emer=%v enc=%v",
+				c.flags, csbk.IsGroup(), csbk.IsEmergency(), csbk.IsEncrypted())
+		}
+	}
+}
+
+func TestAsVoiceGrantExtractsFields(t *testing.T) {
+	csbk := CSBK{
+		Type:     MsgIndividualVoiceAllocation,
+		Flags:    FlagEmergency | FlagEncrypted,
+		SourceID: 0x100200,
+		DestID:   0x300400,
+		Extra:    1234,
+	}
+	g, ok := csbk.AsVoiceGrant()
+	if !ok {
+		t.Fatal("AsVoiceGrant returned !ok")
+	}
+	if g.SourceID != 0x100200 || g.DestID != 0x300400 || g.Channel != 1234 {
+		t.Errorf("VoiceGrant fields = %+v", g)
+	}
+	if !g.Emergency || !g.Encrypted {
+		t.Errorf("flags lost: %+v", g)
+	}
+	if g.Group {
+		t.Error("individual call should not be marked Group")
+	}
+}
+
+func TestAsVoiceGrantGroupForcesGroupFlag(t *testing.T) {
+	csbk := CSBK{Type: MsgVoiceServiceAllocation, Extra: 7}
+	g, ok := csbk.AsVoiceGrant()
+	if !ok || !g.Group {
+		t.Fatalf("group voice allocation: ok=%v group=%v", ok, g.Group)
+	}
+}
+
+func TestAsVoiceGrantWrongType(t *testing.T) {
+	csbk := CSBK{Type: MsgRegistrationRequest}
+	if _, ok := csbk.AsVoiceGrant(); ok {
+		t.Error("AsVoiceGrant returned ok for non-grant type")
+	}
+}
+
+func TestAsSiteBroadcast(t *testing.T) {
+	csbk := CSBK{
+		Type:   MsgStandingServiceStatus,
+		DestID: 0x000F00,
+		Extra:  0xCAFE,
+	}
+	sb, ok := csbk.AsSiteBroadcast()
+	if !ok {
+		t.Fatal("AsSiteBroadcast returned !ok")
+	}
+	if sb.SystemID != 0x000F00 || sb.Status != 0xCAFE {
+		t.Errorf("SiteBroadcast = %+v", sb)
+	}
+	other := CSBK{Type: MsgVoiceServiceAllocation}
+	if _, ok := other.AsSiteBroadcast(); ok {
+		t.Error("AsSiteBroadcast returned ok for non-broadcast type")
+	}
+}
+
+func TestIsIdle(t *testing.T) {
+	for _, tt := range []struct {
+		t    MessageType
+		want bool
+	}{
+		{MsgIdle, true},
+		{MsgRelease, true},
+		{MsgVoiceServiceAllocation, false},
+		{MsgRegistrationRequest, false},
+	} {
+		if got := (CSBK{Type: tt.t}).IsIdle(); got != tt.want {
+			t.Errorf("IsIdle(%s) = %v, want %v", tt.t, got, tt.want)
+		}
+	}
+}
+
+func TestSyncDibitsAndDetector(t *testing.T) {
+	for name, dibits := range map[string][]uint8{
+		"FS1": FS1Dibits(),
+		"FS2": FS2Dibits(),
+		"FS3": FS3Dibits(),
+	} {
+		if len(dibits) != SyncDibits {
+			t.Errorf("%s len = %d, want %d", name, len(dibits), SyncDibits)
+		}
+		for _, d := range dibits {
+			if d > 3 {
+				t.Errorf("%s contains dibit %d", name, d)
+			}
+		}
+	}
+	if reflect.DeepEqual(FS1Dibits(), FS2Dibits()) {
+		t.Error("FS1 and FS2 patterns are equal")
+	}
+	if reflect.DeepEqual(FS1Dibits(), FS3Dibits()) {
+		t.Error("FS1 and FS3 patterns are equal")
+	}
+}
+
+func TestSyncDetectorExactMatch(t *testing.T) {
+	pat := FS3Dibits()
+	det := NewSyncDetector(pat, 0)
+
+	stream := make([]uint8, 30+len(pat)+5)
+	copy(stream[30:], pat)
+	hits, _ := det.Process(nil, stream, 0)
+	if len(hits) != 1 {
+		t.Fatalf("hits = %v, want exactly 1", hits)
+	}
+	if hits[0] != 30+len(pat)-1 {
+		t.Errorf("hits[0] = %d, want %d", hits[0], 30+len(pat)-1)
+	}
+}
+
+func TestSyncDetectorTolerance(t *testing.T) {
+	pat := FS3Dibits()
+	det := NewSyncDetector(pat, 1)
+
+	const offset = 30
+	stream := make([]uint8, offset+len(pat)+5)
+	copy(stream[offset:], pat)
+	stream[offset+5] = (stream[offset+5] + 1) & 0x3
+	hits, _ := det.Process(nil, stream, 0)
+	if len(hits) != 1 {
+		t.Fatalf("hits = %v, want 1 (tolerance=1, one mismatch)", hits)
+	}
+}
+
+func TestSyncDetectorRejectsNoise(t *testing.T) {
+	pat := FS1Dibits()
+	det := NewSyncDetector(pat, 0)
+	stream := make([]uint8, 4*len(pat))
+	hits, _ := det.Process(nil, stream, 0)
+	if len(hits) != 0 {
+		t.Errorf("hits on zero stream = %v", hits)
+	}
+}
+
+func TestLinearBandPlan(t *testing.T) {
+	bp := LinearBandPlan{BaseHz: 446_006_250, SpacingHz: 6_250, Offset: -1}
+	hz, err := bp.Frequency(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hz != 446_006_250 {
+		t.Errorf("ch1 = %d, want 446006250", hz)
+	}
+	hz, err = bp.Frequency(8)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hz != 446_006_250+7*6_250 {
+		t.Errorf("ch8 = %d", hz)
+	}
+}
+
+func TestLinearBandPlanRejectsZeroSpacing(t *testing.T) {
+	bp := LinearBandPlan{BaseHz: 446_000_000}
+	if _, err := bp.Frequency(1); err == nil {
+		t.Error("expected error on zero SpacingHz")
+	}
+}
+
+func TestTableBandPlan(t *testing.T) {
+	bp := TableBandPlan{1: 446_006_250, 4: 446_025_000}
+	if hz, err := bp.Frequency(1); err != nil || hz != 446_006_250 {
+		t.Errorf("ch1 = %d/%v", hz, err)
+	}
+	if _, err := bp.Frequency(99); err == nil {
+		t.Error("expected error on missing channel")
+	}
+}
+
+// Test-helper: build a voice-allocation CSBK.
+func voiceCSBK(typ MessageType, src, dst uint32, ch uint16) CSBK {
+	return CSBK{Type: typ, SourceID: src, DestID: dst, Extra: ch}
+}
+
+func TestControlChannelEmitsLockOnSiteBroadcast(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, FrequencyHz: 446_018_750})
+	cc.Ingest(CSBK{Type: MsgStandingServiceStatus, DestID: 0x123456, Extra: 0x42})
+
+	select {
+	case ev := <-sub.C:
+		if ev.Kind != events.KindCCLocked {
+			t.Fatalf("kind = %s, want cc.locked", ev.Kind)
+		}
+		ls, ok := ev.Payload.(LockState)
+		if !ok || ls.FrequencyHz != 446_018_750 || ls.SystemID != 0x123456 {
+			t.Errorf("payload = %+v", ev.Payload)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("no cc.locked event")
+	}
+}
+
+func TestControlChannelEmitsGrant(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	bp := LinearBandPlan{BaseHz: 446_006_250, SpacingHz: 6_250, Offset: -1}
+	fixed := time.Date(2026, 5, 5, 12, 0, 0, 0, time.UTC)
+	cc := New(Options{
+		Bus:         bus,
+		SystemName:  "dpmr-sys",
+		FrequencyHz: 446_018_750,
+		Resolver:    bp,
+		Now:         func() time.Time { return fixed },
+	})
+
+	cc.Ingest(voiceCSBK(MsgVoiceServiceAllocation, 0x100, 0x200, 4))
+
+	// First event: cc.locked (synthesized when grant arrives without
+	// a prior SiteBroadcast).
+	select {
+	case ev := <-sub.C:
+		if ev.Kind != events.KindCCLocked {
+			t.Fatalf("first event kind = %s, want cc.locked", ev.Kind)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("no cc.locked event")
+	}
+
+	// Second event: grant.
+	select {
+	case ev := <-sub.C:
+		if ev.Kind != events.KindGrant {
+			t.Fatalf("second event kind = %s, want grant", ev.Kind)
+		}
+		g, ok := ev.Payload.(trunking.Grant)
+		if !ok {
+			t.Fatalf("grant payload type = %T", ev.Payload)
+		}
+		if g.Protocol != "dpmr" {
+			t.Errorf("Protocol = %q, want dpmr", g.Protocol)
+		}
+		if g.System != "dpmr-sys" {
+			t.Errorf("System = %q", g.System)
+		}
+		if g.GroupID != 0x200 || g.SourceID != 0x100 {
+			t.Errorf("GroupID = %X, SourceID = %X", g.GroupID, g.SourceID)
+		}
+		if g.ChannelNum != 4 {
+			t.Errorf("ChannelNum = %d", g.ChannelNum)
+		}
+		if g.FrequencyHz != 446_006_250+3*6_250 {
+			t.Errorf("FrequencyHz = %d", g.FrequencyHz)
+		}
+		if !g.At.Equal(fixed) {
+			t.Errorf("At = %v, want %v", g.At, fixed)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("no grant event")
+	}
+}
+
+func TestControlChannelGrantNoResolverFallsBackToZero(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, FrequencyHz: 446_018_750})
+	cc.Ingest(voiceCSBK(MsgVoiceServiceAllocation, 1, 2, 9))
+
+	<-sub.C // cc.locked
+	ev := <-sub.C
+	g := ev.Payload.(trunking.Grant)
+	if g.FrequencyHz != 0 {
+		t.Errorf("FrequencyHz = %d, want 0 (no resolver)", g.FrequencyHz)
+	}
+	if g.ChannelNum != 9 {
+		t.Errorf("ChannelNum = %d", g.ChannelNum)
+	}
+}
+
+func TestControlChannelSilentOnIdle(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, FrequencyHz: 446_018_750})
+	cc.Ingest(CSBK{Type: MsgIdle})
+	cc.Ingest(CSBK{Type: MsgRelease})
+	select {
+	case ev := <-sub.C:
+		t.Errorf("unexpected event on idle: %s", ev.Kind)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestControlChannelMarkLost(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, FrequencyHz: 446_018_750})
+	cc.Ingest(CSBK{Type: MsgStandingServiceStatus, DestID: 0xAABB})
+	<-sub.C // cc.locked
+
+	cc.MarkLost()
+	select {
+	case ev := <-sub.C:
+		if ev.Kind != events.KindCCLost {
+			t.Fatalf("kind = %s, want cc.lost", ev.Kind)
+		}
+		ls, ok := ev.Payload.(LockState)
+		if !ok || ls.SystemID != 0xAABB {
+			t.Errorf("LockState = %+v", ev.Payload)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("no cc.lost event")
+	}
+
+	// Second MarkLost is a no-op.
+	cc.MarkLost()
+	select {
+	case ev := <-sub.C:
+		t.Errorf("unexpected event after second MarkLost: %s", ev.Kind)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestControlChannelNoRepublishOnSameLockState(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, FrequencyHz: 446_018_750})
+	cc.Ingest(CSBK{Type: MsgStandingServiceStatus, DestID: 0xAABB})
+	<-sub.C // first cc.locked
+	cc.Ingest(CSBK{Type: MsgStandingServiceStatus, DestID: 0xAABB})
+	select {
+	case ev := <-sub.C:
+		t.Errorf("unexpected re-publish: %s", ev.Kind)
+	case <-time.After(50 * time.Millisecond):
+	}
+}

--- a/internal/radio/dpmr/opcodes.go
+++ b/internal/radio/dpmr/opcodes.go
@@ -1,0 +1,107 @@
+package dpmr
+
+import "fmt"
+
+// MessageType is the 5-bit Message Type field that opens every CSBK.
+// Values follow ETSI TS 102 658 §6.5.2; only the subset relevant to
+// trunked-grant follow-along is enumerated below.
+type MessageType uint8
+
+const (
+	MsgUnknown                    MessageType = 0x00
+	MsgRegistrationRequest        MessageType = 0x01
+	MsgRegistrationResponse       MessageType = 0x02
+	MsgVoiceServiceAllocation     MessageType = 0x03 // group voice channel grant
+	MsgIndividualVoiceAllocation  MessageType = 0x04 // unit-to-unit voice grant
+	MsgDataServiceAllocation      MessageType = 0x05
+	MsgServiceRequest             MessageType = 0x06
+	MsgStandingServiceStatus      MessageType = 0x07 // periodic site broadcast
+	MsgRelease                    MessageType = 0x0F
+	MsgIdle                       MessageType = 0x1F
+)
+
+// String returns a stable human-readable label for log output.
+func (m MessageType) String() string {
+	switch m {
+	case MsgRegistrationRequest:
+		return "RegistrationRequest"
+	case MsgRegistrationResponse:
+		return "RegistrationResponse"
+	case MsgVoiceServiceAllocation:
+		return "VoiceServiceAllocation"
+	case MsgIndividualVoiceAllocation:
+		return "IndividualVoiceAllocation"
+	case MsgDataServiceAllocation:
+		return "DataServiceAllocation"
+	case MsgServiceRequest:
+		return "ServiceRequest"
+	case MsgStandingServiceStatus:
+		return "StandingServiceStatus"
+	case MsgRelease:
+		return "Release"
+	case MsgIdle:
+		return "Idle"
+	default:
+		return fmt.Sprintf("MessageType(%02X)", uint8(m))
+	}
+}
+
+// VoiceGrant is the structured shape of a voice-allocation CSBK
+// (group or individual). The Extra field carries the channel number
+// the calling/called subscriber should retune to.
+type VoiceGrant struct {
+	SourceID  uint32 // 24-bit calling subscriber
+	DestID    uint32 // 24-bit destination (group or unit)
+	Channel   uint16 // physical channel number in the band-plan
+	Group     bool   // true when the call is to a group
+	Emergency bool
+	Encrypted bool
+}
+
+// AsVoiceGrant returns the structured grant if the CSBK message type
+// is a voice-allocation variant, otherwise (zero, false).
+func (c CSBK) AsVoiceGrant() (VoiceGrant, bool) {
+	switch c.Type {
+	case MsgVoiceServiceAllocation, MsgIndividualVoiceAllocation:
+	default:
+		return VoiceGrant{}, false
+	}
+	return VoiceGrant{
+		SourceID:  c.SourceID,
+		DestID:    c.DestID,
+		Channel:   c.Extra,
+		Group:     c.IsGroup() || c.Type == MsgVoiceServiceAllocation,
+		Emergency: c.IsEmergency(),
+		Encrypted: c.IsEncrypted(),
+	}, true
+}
+
+// SiteBroadcast is the structured shape of a StandingServiceStatus
+// CSBK — used by the state machine to declare the control channel
+// "locked" and learn the system's identifier.
+type SiteBroadcast struct {
+	SystemID uint32 // packed (DestID) — system / fleet identifier
+	Status   uint16 // Extra — opaque site status word
+}
+
+// AsSiteBroadcast returns the structured broadcast if the CSBK type
+// is StandingServiceStatus, otherwise (zero, false).
+func (c CSBK) AsSiteBroadcast() (SiteBroadcast, bool) {
+	if c.Type != MsgStandingServiceStatus {
+		return SiteBroadcast{}, false
+	}
+	return SiteBroadcast{
+		SystemID: c.DestID,
+		Status:   c.Extra,
+	}, true
+}
+
+// IsIdle reports whether the CSBK is an idle / release filler the
+// state machine should silently absorb.
+func (c CSBK) IsIdle() bool {
+	switch c.Type {
+	case MsgIdle, MsgRelease:
+		return true
+	}
+	return false
+}

--- a/internal/radio/dpmr/sync.go
+++ b/internal/radio/dpmr/sync.go
@@ -1,0 +1,93 @@
+package dpmr
+
+// dPMR sync words per ETSI TS 102 658 §4.4. Three distinct 48-bit
+// (24-dibit) patterns mark the three burst types Mode 3 uses:
+//
+//   FS1  start of a voice / data superframe
+//   FS2  middle synchronisation inside a superframe (every 4th burst)
+//   FS3  start of a CSBK (signalling) burst on the control channel
+//
+// All three are stored as canonical 48-bit hex constants; helpers
+// materialise the dibits MSB-first for the symbol-domain detector.
+const (
+	FS1Hex uint64 = 0x57FF5F75F575
+	FS2Hex uint64 = 0x5F7F77FD7DFD
+	FS3Hex uint64 = 0x7DDFFD5F55D5
+
+	SyncDibits = 24
+)
+
+// FS1Dibits returns the 24 dibits of FS1, MSB-first.
+func FS1Dibits() []uint8 { return hexToDibits(FS1Hex, SyncDibits) }
+
+// FS2Dibits returns the 24 dibits of FS2, MSB-first.
+func FS2Dibits() []uint8 { return hexToDibits(FS2Hex, SyncDibits) }
+
+// FS3Dibits returns the 24 dibits of FS3, MSB-first.
+func FS3Dibits() []uint8 { return hexToDibits(FS3Hex, SyncDibits) }
+
+func hexToDibits(hex uint64, n int) []uint8 {
+	out := make([]uint8, n)
+	for i := 0; i < n; i++ {
+		shift := uint(2 * (n - 1 - i))
+		out[i] = uint8((hex >> shift) & 0x3)
+	}
+	return out
+}
+
+// SyncDetector slides a window over a dibit stream and reports indices
+// where the configured pattern matches within `tolerance` dibit
+// mismatches. Same shape as the Phase 1 / DMR / NXDN sync detectors so
+// the higher-level state machine stays consistent.
+type SyncDetector struct {
+	pattern   []uint8
+	tolerance int
+	hist      []uint8
+	primed    int
+	pos       int
+}
+
+// NewSyncDetector accepts a 24-dibit pattern (typically FS1Dibits,
+// FS2Dibits, or FS3Dibits) and a tolerance. A zero tolerance demands
+// an exact match.
+func NewSyncDetector(pattern []uint8, tolerance int) *SyncDetector {
+	if tolerance < 0 {
+		tolerance = 1
+	}
+	cp := make([]uint8, len(pattern))
+	copy(cp, pattern)
+	return &SyncDetector{
+		pattern:   cp,
+		tolerance: tolerance,
+		hist:      make([]uint8, len(cp)),
+	}
+}
+
+// Process scans src and appends to dst the absolute dibit indices
+// where the sync pattern ends within tolerance.
+func (s *SyncDetector) Process(dst []int, src []uint8, baseIndex int) ([]int, int) {
+	n := len(s.pattern)
+	for i, d := range src {
+		s.hist[s.pos] = d
+		s.pos = (s.pos + 1) % n
+		if s.primed < n {
+			s.primed++
+			continue
+		}
+		mismatch := 0
+		idx := s.pos
+		for k := 0; k < n; k++ {
+			if s.hist[idx] != s.pattern[k] {
+				mismatch++
+				if mismatch > s.tolerance {
+					break
+				}
+			}
+			idx = (idx + 1) % n
+		}
+		if mismatch <= s.tolerance {
+			dst = append(dst, baseIndex+i)
+		}
+	}
+	return dst, baseIndex + len(src)
+}


### PR DESCRIPTION
## Summary

Adds the dPMR (digital PMR446) Mode 3 trunked-signalling decoder — the next protocol on Roadmap item 4 after NXDN. Mode 3 is the centralised-trunking mode where a dedicated control channel grants voice / data calls onto traffic channels; Modes 1 and 2 don't have a CC for the engine to hunt, so they're out of scope.

New `internal/radio/dpmr/` package, same shape as the other trunked-protocol packages:

- `sync.go` — FS1 / FS2 / FS3 24-dibit sync constants per ETSI TS 102 658 §4.4 + tolerant `SyncDetector`.
- `csbk.go` — 80-bit Common Signalling Block parser with byte + bit round-trips. Layout: 5-bit message type, 3-bit flags (Group / Emergency / Encrypted), 24-bit source + destination IDs, 8-bit service info, 16-bit opcode-specific `Extra` field.
- `opcodes.go` — `MessageType` enum (RegistrationRequest / Response, VoiceServiceAllocation, IndividualVoiceAllocation, DataServiceAllocation, ServiceRequest, StandingServiceStatus, Release, Idle) + `AsVoiceGrant` + `AsSiteBroadcast` + `IsIdle` accessors. `AsVoiceGrant` surfaces source / dest / channel / group / emergency / encrypted from the CSBK flags.
- `bandplan.go` — `LinearBandPlan` / `TableBandPlan` resolver. PMR446 default is base 446 006 250 Hz @ 6.25 kHz spacing, channel offset −1.
- `control.go` — state machine that publishes `cc.locked` on StandingServiceStatus (or the first voice grant) and `events.KindGrant` with `trunking.Grant.Protocol = "dpmr"` on voice allocations.

Honest deferrals listed in the package's doc comment: 4FSK demodulator, CSBK FEC + interleaver, AMBE+2 vocoder.

Tests cover CSBK byte + bit round-trip, `ParseCSBK` length validation, flag accessors, `AsVoiceGrant` field extraction (including the group-allocation case that forces the Group flag) + rejection on non-grant types, `AsSiteBroadcast`, `IsIdle`, sync constants distinctness + exact + tolerant matching + zero-stream rejection, both band-plan strategies, and the `cc.locked` / grant / no-resolver / `cc.lost` / no-republish-on-same-state emission paths.

README's Roadmap item 4 protocols list flips dPMR to ✅ landed and documents the package surface.

## Test plan

- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `go test -race -count=1 ./...` — all packages pass, including the new `internal/radio/dpmr`
- [x] `make integration` — wired daemon end-to-end smoke

https://claude.ai/code/session_01MQSV8EVnH6nsGUpcWep7UF

---
_Generated by [Claude Code](https://claude.ai/code/session_01MQSV8EVnH6nsGUpcWep7UF)_