### PR TITLE
Windows installer + release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,208 @@
+name: Release
+
+# Builds Windows + Linux artifacts when a SemVer tag is pushed (or
+# when the workflow is triggered manually from the Actions tab) and
+# uploads them to a GitHub Release.
+#
+# The Windows job runs on a Windows runner so cgo can link against
+# librtlsdr's Windows port. MSYS2 supplies the toolchain + headers +
+# DLLs; Inno Setup turns the bundled directory into a single setup.exe
+# the user can run on Windows 11.
+#
+# Outputs in the GitHub Release:
+#
+#   gophertrunk-<ver>-windows-amd64-setup.exe   one-click installer
+#   gophertrunk-<ver>-windows-amd64.zip         portable ZIP (no installer)
+#   gophertrunk-<ver>-linux-amd64.tar.gz        Linux tarball
+#   SHA256SUMS                                  per-file SHA-256 checksums
+on:
+  push:
+    tags:
+      - "v*.*.*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish (e.g. v0.1.0). Must start with 'v'."
+        required: true
+        default: "v0.0.0"
+
+permissions:
+  contents: write
+
+jobs:
+  windows:
+    name: Build Windows installer
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Compute version
+        id: version
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "version=${{ github.event.inputs.version }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64
+          update: true
+          install: >-
+            git
+            zip
+            mingw-w64-x86_64-toolchain
+            mingw-w64-x86_64-pkgconf
+            mingw-w64-x86_64-rtl-sdr
+            mingw-w64-x86_64-libusb
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+
+      - name: Build gophertrunk.exe
+        env:
+          CGO_ENABLED: "1"
+          CC: x86_64-w64-mingw32-gcc
+        run: |
+          export PATH="/mingw64/bin:$PATH"
+          VERSION="${{ steps.version.outputs.version }}"
+          mkdir -p dist/staging
+          go build \
+            -trimpath \
+            -ldflags "-X github.com/MattCheramie/GopherTrunk/internal/version.Version=${VERSION}" \
+            -o dist/staging/gophertrunk.exe \
+            ./cmd/gophertrunk
+
+      - name: Bundle DLLs and docs
+        run: |
+          set -eu
+          STAGE=dist/staging
+          # Runtime DLLs the cgo binding pulls in. Inside the MSYS2
+          # MINGW64 shell, /mingw64/bin/ is the canonical location
+          # regardless of where MSYS2 actually got installed on disk.
+          for dll in \
+            librtlsdr.dll \
+            libusb-1.0.dll \
+            libwinpthread-1.dll \
+            libgcc_s_seh-1.dll
+          do
+            if [ -f "/mingw64/bin/$dll" ]; then
+              cp "/mingw64/bin/$dll" "$STAGE/"
+            else
+              echo "warning: $dll not found in MINGW64 bin"
+            fi
+          done
+          cp README.md LICENSE config.example.yaml "$STAGE/"
+          cp docs/install-windows.md "$STAGE/INSTALL-WINDOWS.md"
+
+      - name: Build portable ZIP
+        run: |
+          set -eu
+          VERSION="${{ steps.version.outputs.version }}"
+          NAME="gophertrunk-${VERSION}-windows-amd64"
+          mkdir -p "dist/${NAME}"
+          cp -r dist/staging/. "dist/${NAME}/"
+          (cd dist && zip -r "${NAME}.zip" "${NAME}")
+
+      - name: Build Inno Setup installer
+        uses: Minionguyjpro/Inno-Setup-Action@v1.2.5
+        with:
+          path: installer/windows/gophertrunk.iss
+          options: /DAppVersion=${{ steps.version.outputs.version }} /Qp
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: windows-amd64
+          path: |
+            dist/*.zip
+            dist/*setup.exe
+
+  linux:
+    name: Build Linux tarball
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+
+      - name: Install librtlsdr
+        run: sudo apt-get update && sudo apt-get install -y librtlsdr-dev libusb-1.0-0-dev
+
+      - name: Compute version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "version=${{ github.event.inputs.version }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build gophertrunk
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          NAME="gophertrunk-${VERSION}-linux-amd64"
+          mkdir -p "dist/${NAME}"
+          go build \
+            -trimpath \
+            -ldflags "-X github.com/MattCheramie/GopherTrunk/internal/version.Version=${VERSION}" \
+            -o "dist/${NAME}/gophertrunk" \
+            ./cmd/gophertrunk
+          cp README.md LICENSE config.example.yaml "dist/${NAME}/"
+          (cd dist && tar -czf "${NAME}.tar.gz" "${NAME}")
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: linux-amd64
+          path: dist/*.tar.gz
+
+  release:
+    name: Publish GitHub Release
+    needs: [windows, linux]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+
+      - name: Flatten artifact tree
+        run: |
+          set -eu
+          mkdir -p out
+          find dist -type f \( -name '*.zip' -o -name '*.exe' -o -name '*.tar.gz' \) \
+            -exec cp {} out/ \;
+          (cd out && sha256sum * > SHA256SUMS)
+          ls -la out
+
+      - name: Compute version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "version=${{ github.event.inputs.version }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.version.outputs.version }}
+          name: GopherTrunk ${{ steps.version.outputs.version }}
+          generate_release_notes: true
+          files: |
+            out/*
+          body: |
+            ## Install
+
+            **Windows 11:** download `gophertrunk-${{ steps.version.outputs.version }}-windows-amd64-setup.exe` and double-click. The installer adds GopherTrunk to your Start Menu and bundles the librtlsdr / libusb runtime DLLs. After install, follow [INSTALL-WINDOWS.md](https://github.com/MattCheramie/GopherTrunk/blob/main/docs/install-windows.md) to install the WinUSB driver via Zadig — the OS won't see your RTL-SDR until you do this once.
+
+            **Linux:** extract `gophertrunk-${{ steps.version.outputs.version }}-linux-amd64.tar.gz` and run `./gophertrunk`. Requires `librtlsdr` + `libusb-1.0` from your package manager.
+
+            All artifacts are SHA-256-checksummed in `SHA256SUMS`.

--- a/README.md
+++ b/README.md
@@ -116,6 +116,26 @@ to its own package and lands independently.
 
 ## Quick start
 
+### Download a prebuilt release
+
+Each tagged release publishes installers / archives on the
+[**Releases page**][releases]:
+
+| Platform   | File                                                   | What it is                                              |
+| ---------- | ------------------------------------------------------ | ------------------------------------------------------- |
+| Windows 11 | `gophertrunk-<ver>-windows-amd64-setup.exe`            | One-click installer (Inno Setup, bundles librtlsdr DLLs) |
+| Windows 11 | `gophertrunk-<ver>-windows-amd64.zip`                  | Portable ZIP — same files, no installer                  |
+| Linux      | `gophertrunk-<ver>-linux-amd64.tar.gz`                 | Tarballed binary + sample config                         |
+
+Windows users: after running the installer, follow
+[`docs/install-windows.md`](docs/install-windows.md) to swap the
+RTL-SDR driver to WinUSB via Zadig — the OS won't see your dongle
+until that's done. The installer's last page links there too.
+
+[releases]: https://github.com/MattCheramie/GopherTrunk/releases
+
+### Build from source
+
 ### Prerequisites
 
 ```sh

--- a/docs/install-windows.md
+++ b/docs/install-windows.md
@@ -1,0 +1,144 @@
+# Installing GopherTrunk on Windows 11
+
+This is the path the prebuilt installer lays down for you. Five
+minutes from a fresh download to a working `gophertrunk sdr list`.
+
+## 1. Download the installer
+
+Go to the **[GopherTrunk releases page]** and download the
+asset named:
+
+```
+gophertrunk-<version>-windows-amd64-setup.exe
+```
+
+If you'd rather skip the installer and run from a folder, grab the
+matching `gophertrunk-<version>-windows-amd64.zip` and extract it
+anywhere — the contents are the same.
+
+[GopherTrunk releases page]: https://github.com/MattCheramie/GopherTrunk/releases
+
+> **Why is the download blocked?** Windows SmartScreen sometimes
+> warns on installers it hasn't seen before. Click **More info →
+> Run anyway**, or right-click the file → Properties → check
+> **Unblock**. The installer is unsigned today; signing is on the
+> roadmap.
+
+## 2. Run the installer
+
+Double-click `setup.exe` and accept the defaults. The installer:
+
+- Copies `gophertrunk.exe` to `C:\Program Files\GopherTrunk\`
+  alongside the librtlsdr / libusb runtime DLLs.
+- Adds Start Menu entries for the daemon, the config template,
+  and these instructions.
+- Optionally adds `C:\Program Files\GopherTrunk` to your system
+  PATH so you can run `gophertrunk` from any PowerShell window
+  (off by default — tick the "Add GopherTrunk to my PATH"
+  checkbox during install if you want it).
+
+When the wizard finishes, it'll offer to open this document and a
+console window. Both are harmless to skip.
+
+## 3. Install the WinUSB driver via Zadig (one-time, for each dongle)
+
+Windows ships an RTL-SDR DVB-T receiver driver by default — that
+driver is what you'd use to watch broadcast TV, and it's the wrong
+driver for SDR work. We need to swap it for **WinUSB** on a
+per-device basis. The standard tool is **Zadig**:
+
+1. Plug in the RTL-SDR dongle.
+2. Download Zadig from <https://zadig.akeo.ie> (single .exe, no
+   install). Run it as **Administrator**.
+3. **Options → List All Devices** so the RTL-SDR shows up.
+4. From the dropdown, pick the dongle. It'll typically appear as
+   **Bulk-In, Interface (Interface 0)** or **RTL2832U**.
+5. With **WinUSB** selected as the target driver, click
+   **Replace Driver** (or **Install Driver**, first time).
+6. Wait ~10 seconds for the success dialog.
+
+You only do this once per dongle. If you ever want the dongle to
+work as a TV tuner again, run Zadig in reverse and pick the
+manufacturer driver.
+
+## 4. Verify everything works
+
+Open **Windows Terminal** (or PowerShell) and run:
+
+```powershell
+gophertrunk version
+gophertrunk sdr list
+```
+
+`sdr list` should print one line per attached dongle with its
+driver, index, serial, tuner, product string, and the gain settings
+the tuner exposes. If you see `no SDR devices found` and you're
+sure the dongle is plugged in, the WinUSB driver swap probably
+didn't take — re-run Zadig with **Options → List All Devices**
+checked and verify the "Driver" column shows **WinUSB** for your
+dongle.
+
+If you didn't tick the PATH option during install, run from the
+install folder instead:
+
+```powershell
+cd "C:\Program Files\GopherTrunk"
+.\gophertrunk.exe sdr list
+```
+
+## 5. Configure and start the daemon
+
+The installer drops a starter config at:
+
+```
+C:\Program Files\GopherTrunk\config.example.yaml
+```
+
+Copy it somewhere writable — your home directory is fine — and
+edit the device serial + control-channel frequencies:
+
+```powershell
+cp "C:\Program Files\GopherTrunk\config.example.yaml" "$HOME\gophertrunk.yaml"
+notepad "$HOME\gophertrunk.yaml"
+```
+
+Then run the daemon against it:
+
+```powershell
+gophertrunk run -config "$HOME\gophertrunk.yaml"
+```
+
+Logs stream to the terminal. Press `Ctrl+C` to stop cleanly.
+
+For a long-running setup, register GopherTrunk as a Windows service
+with [NSSM](https://nssm.cc) — that's the simplest path until a
+native service manifest ships:
+
+```powershell
+nssm install GopherTrunk "C:\Program Files\GopherTrunk\gophertrunk.exe" `
+  run -config "C:\ProgramData\GopherTrunk\config.yaml"
+nssm set GopherTrunk AppDirectory "C:\Program Files\GopherTrunk"
+nssm start GopherTrunk
+```
+
+## Uninstall
+
+**Settings → Apps → Installed apps → GopherTrunk → Uninstall.**
+The uninstaller removes the install folder and every Start Menu
+entry, and undoes the PATH change if you opted in. Recordings
+under your call-log directory are left alone.
+
+## Troubleshooting
+
+| Symptom                                | Likely cause                                       |
+| -------------------------------------- | -------------------------------------------------- |
+| `gophertrunk` not recognised           | PATH wasn't added — open a fresh terminal or run from `C:\Program Files\GopherTrunk` directly. |
+| `sdr list` prints nothing              | Zadig WinUSB swap didn't take — see step 3.        |
+| `LIBUSB_ERROR_ACCESS` on stream        | The DVB driver re-attached itself — re-run Zadig. |
+| `librtlsdr.dll was not found`          | The installer's DLL bundle was tampered with — reinstall. |
+| Smart Screen blocks the installer      | Right-click → Properties → Unblock, or **More info → Run anyway**. |
+
+For anything else: open an issue at
+<https://github.com/MattCheramie/GopherTrunk/issues> with the
+`gophertrunk version` output and the first few lines of the
+daemon log.

--- a/installer/windows/gophertrunk.iss
+++ b/installer/windows/gophertrunk.iss
@@ -1,0 +1,112 @@
+; Inno Setup script for the GopherTrunk Windows installer.
+;
+; Driven from the GitHub Actions release workflow with:
+;
+;   iscc /DAppVersion=v0.1.0 installer/windows/gophertrunk.iss
+;
+; The workflow stages the .exe + DLLs + docs under dist\staging\ first
+; (see .github/workflows/release.yml). This script consumes that
+; directory and produces a single setup.exe under dist\ named
+; gophertrunk-<version>-windows-amd64-setup.exe.
+;
+; Inno Setup is a freely-distributed Windows installer compiler. Docs:
+; https://jrsoftware.org/isinfo.php
+
+#ifndef AppVersion
+  #define AppVersion "v0.0.0-dev"
+#endif
+
+[Setup]
+AppId={{B6B6CC9A-3A70-4B23-8E2E-8E0C7A2F4B30}
+AppName=GopherTrunk
+AppVersion={#AppVersion}
+AppPublisher=GopherTrunk contributors
+AppPublisherURL=https://github.com/MattCheramie/GopherTrunk
+AppSupportURL=https://github.com/MattCheramie/GopherTrunk/issues
+AppUpdatesURL=https://github.com/MattCheramie/GopherTrunk/releases
+DefaultDirName={autopf}\GopherTrunk
+DefaultGroupName=GopherTrunk
+DisableProgramGroupPage=yes
+LicenseFile=..\..\LICENSE
+OutputDir=..\..\dist
+OutputBaseFilename=gophertrunk-{#AppVersion}-windows-amd64-setup
+Compression=lzma
+SolidCompression=yes
+WizardStyle=modern
+ArchitecturesAllowed=x64compatible
+ArchitecturesInstallIn64BitMode=x64compatible
+PrivilegesRequired=admin
+ChangesEnvironment=yes
+UninstallDisplayIcon={app}\gophertrunk.exe
+
+[Languages]
+Name: "english"; MessagesFile: "compiler:Default.isl"
+
+[Tasks]
+Name: "addtopath"; Description: "Add GopherTrunk to my PATH (so I can run ""gophertrunk"" from any terminal)"; GroupDescription: "PATH"; Flags: unchecked
+Name: "desktopicon"; Description: "Create a &desktop shortcut"; GroupDescription: "Additional shortcuts:"; Flags: unchecked
+
+[Files]
+Source: "..\..\dist\staging\gophertrunk.exe";  DestDir: "{app}"; Flags: ignoreversion
+Source: "..\..\dist\staging\librtlsdr.dll";    DestDir: "{app}"; Flags: ignoreversion skipifsourcedoesntexist
+Source: "..\..\dist\staging\libusb-1.0.dll";   DestDir: "{app}"; Flags: ignoreversion skipifsourcedoesntexist
+Source: "..\..\dist\staging\libwinpthread-1.dll"; DestDir: "{app}"; Flags: ignoreversion skipifsourcedoesntexist
+Source: "..\..\dist\staging\libgcc_s_seh-1.dll";  DestDir: "{app}"; Flags: ignoreversion skipifsourcedoesntexist
+Source: "..\..\dist\staging\config.example.yaml"; DestDir: "{app}"; Flags: ignoreversion
+Source: "..\..\dist\staging\README.md";        DestDir: "{app}"; Flags: ignoreversion
+Source: "..\..\dist\staging\LICENSE";          DestDir: "{app}"; Flags: ignoreversion
+Source: "..\..\dist\staging\INSTALL-WINDOWS.md"; DestDir: "{app}"; Flags: ignoreversion
+
+[Icons]
+Name: "{group}\GopherTrunk (PowerShell)"; Filename: "{cmd}"; \
+  Parameters: "/k cd /d ""{app}"" && gophertrunk help"; \
+  WorkingDir: "{app}"; \
+  Comment: "Open a console with GopherTrunk on PATH"
+Name: "{group}\Configuration template (open in Notepad)"; \
+  Filename: "notepad.exe"; \
+  Parameters: """{app}\config.example.yaml"""
+Name: "{group}\Windows install instructions"; \
+  Filename: "{app}\INSTALL-WINDOWS.md"
+Name: "{group}\Visit project on GitHub"; \
+  Filename: "https://github.com/MattCheramie/GopherTrunk"
+Name: "{group}\Uninstall GopherTrunk"; Filename: "{uninstallexe}"
+Name: "{autodesktop}\GopherTrunk"; Filename: "{cmd}"; \
+  Parameters: "/k cd /d ""{app}"" && gophertrunk help"; \
+  WorkingDir: "{app}"; \
+  Tasks: desktopicon
+
+[Registry]
+; Append the install dir to the system PATH if the user opted in. Inno
+; Setup re-broadcasts WM_SETTINGCHANGE so already-open shells pick it
+; up after the next launch.
+Root: HKLM; Subkey: "SYSTEM\CurrentControlSet\Control\Session Manager\Environment"; \
+  ValueType: expandsz; ValueName: "Path"; \
+  ValueData: "{olddata};{app}"; \
+  Check: NeedsAddPath('{app}'); \
+  Tasks: addtopath
+
+[Run]
+Filename: "{app}\INSTALL-WINDOWS.md"; \
+  Description: "Open the Windows install instructions (Zadig + first run)"; \
+  Flags: postinstall shellexec skipifsilent
+Filename: "{cmd}"; \
+  Parameters: "/k cd /d ""{app}"" && gophertrunk help"; \
+  Description: "Open a console window in the install dir"; \
+  Flags: postinstall skipifsilent unchecked
+
+[Code]
+function NeedsAddPath(Param: string): boolean;
+var
+  OrigPath: string;
+begin
+  if not RegQueryStringValue(HKEY_LOCAL_MACHINE,
+    'SYSTEM\CurrentControlSet\Control\Session Manager\Environment',
+    'Path', OrigPath)
+  then begin
+    Result := True;
+    exit;
+  end;
+  // Pos returns 0 if the substring isn't found.
+  Result := Pos(';' + ExpandConstant(Param) + ';',
+                ';' + OrigPath + ';') = 0;
+end;


### PR DESCRIPTION
## Summary

Adds the infrastructure to produce a downloadable Windows 11 installer (and matching portable ZIP + Linux tarball) on every tagged release.

When a SemVer tag is pushed (`git tag v0.1.0 && git push origin v0.1.0`) or the workflow is triggered manually from the Actions tab, the pipeline produces:

| File | What it is |
| ---- | ---------- |
| `gophertrunk-<ver>-windows-amd64-setup.exe` | One-click Inno Setup installer (bundles librtlsdr + libusb DLLs) |
| `gophertrunk-<ver>-windows-amd64.zip` | Portable ZIP — same files, no installer |
| `gophertrunk-<ver>-linux-amd64.tar.gz` | Linux tarball |
| `SHA256SUMS` | Per-file SHA-256 checksums |

The Windows job runs on a `windows-latest` runner with MSYS2 + MINGW64 supplying the librtlsdr / libusb development files for cgo. After cgo links the `.exe`, the workflow stages the binary plus the runtime DLLs (`librtlsdr.dll`, `libusb-1.0.dll`, `libwinpthread-1.dll`, `libgcc_s_seh-1.dll`) and operator docs, ZIPs the result, then runs Inno Setup against `installer/windows/gophertrunk.iss` to produce a real Windows 11 setup wizard.

### What's in the PR

- **`.github/workflows/release.yml`** — three-job pipeline (windows + linux + release-publish). Triggered by `v*.*.*` tags or `workflow_dispatch`. Auto-generates release notes and writes a short install blurb pointing at `docs/install-windows.md` into the release body.
- **`installer/windows/gophertrunk.iss`** — Inno Setup script. Installs to `Program Files\GopherTrunk`, creates Start Menu entries (PowerShell launcher, config-template editor, install-docs link, GitHub link, uninstall), an opt-in PATH addition, an opt-in desktop shortcut, and ships the bundled DLLs. Driven by `/DAppVersion=<ver>` from the workflow.
- **`docs/install-windows.md`** — operator-facing Windows 11 guide. Walks through download → SmartScreen unblock → installer wizard → one-time Zadig WinUSB driver swap → `gophertrunk sdr list` verification → config copy → NSSM-as-service tip → troubleshooting table.
- **`README.md`** — adds a "Download a prebuilt release" subsection at the top of *Quick start* with the per-platform asset table and a link to `docs/install-windows.md`.

### How to actually get a Windows installer after this lands

1. Merge this PR.
2. From the repo root: `git tag v0.1.0 && git push origin v0.1.0` — or use the **Actions → Release → Run workflow** button on github.com.
3. Wait for the workflow (~10 min). It uploads everything to <https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.1.0>.
4. On Windows 11, download `gophertrunk-v0.1.0-windows-amd64-setup.exe`, double-click, follow the wizard. The wizard's last page links the install doc that walks through Zadig.

The installer is **unsigned today**, so SmartScreen will warn the first time a user runs it (right-click → Properties → Unblock, or *More info → Run anyway*). Code signing is on the roadmap.

## Test plan

- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `go test -count=1 ./...`
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` — workflow YAML parses
- [x] `GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build` — sanity cross-compile produces a real `PE32+ executable (console) x86-64`
- [ ] **End-to-end**: merge, push a tag, verify the workflow produces a runnable `setup.exe` on Windows 11

https://claude.ai/code/session_01MQSV8EVnH6nsGUpcWep7UF

---
_Generated by [Claude Code](https://claude.ai/code/session_01MQSV8EVnH6nsGUpcWep7UF)_