### PR TITLE
Add operator mutation endpoints + TUI write controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,9 +221,11 @@ disconnect:
 | `?` | toggle help |
 | `q` / `Ctrl+C` | quit |
 
-v1 is a viewer only. End-call, set-priority, lockout, retention-sweep
-and tone-detector reset land in a clearly-scoped follow-up PR; see
-[`docs/tui.md`](docs/tui.md) for the full reference.
+For mutation actions (end-call, set-priority, lockout,
+retention-sweep, tone-detector reset) start the daemon with
+`api.allow_mutations: true` and the TUI with `--write`. Both ends
+gate independently because the HTTP API has no authentication.
+See [`docs/tui.md`](docs/tui.md) for the full reference.
 
 ## Documentation
 

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -232,19 +232,27 @@ func NewDaemon(cfg config.Config, version string, log *slog.Logger) (*Daemon, er
 	// HTTP API — optional.
 	if cfg.API.HTTPAddr != "" {
 		opts := api.ServerOptions{
-			Addr:       cfg.API.HTTPAddr,
-			Bus:        d.bus,
-			Engine:     d.engine,
-			Talkgroups: d.talkgroups,
-			Systems:    d.systems,
-			Log:        log,
-			Version:    version,
+			Addr:           cfg.API.HTTPAddr,
+			Bus:            d.bus,
+			Engine:         d.engine,
+			Mutator:        d.engine,
+			Talkgroups:     d.talkgroups,
+			Systems:        d.systems,
+			Log:            log,
+			Version:        version,
+			AllowMutations: cfg.API.AllowMutations,
 		}
 		if d.db != nil {
 			opts.History = api.HistoryFromStorage(d.db)
 		}
 		if d.metrics != nil {
 			opts.MetricsHandler = d.metrics.Handler()
+		}
+		if d.retention != nil {
+			opts.Retention = d.retention
+		}
+		if d.toneout != nil {
+			opts.Tones = d.toneout
 		}
 		srv, err := api.NewServer(opts)
 		if err != nil {

--- a/cmd/gophertrunk/tui.go
+++ b/cmd/gophertrunk/tui.go
@@ -20,10 +20,11 @@ func runTUI(args []string) {
 	insecure := fs.Bool("insecure", false, "skip TLS verification (https only)")
 	timeout := fs.Duration("timeout", 5*time.Second, "per-request timeout")
 	noColor := fs.Bool("no-color", false, "disable ANSI colours")
+	write := fs.Bool("write", false, "enable mutation keybindings (end call, set priority/lockout, retention sweep, tone reset). Daemon must also have api.allow_mutations: true.")
 	_ = fs.Parse(args)
 
 	cli := client.New(*server, *timeout, *insecure)
-	m := tui.New(cli, tui.Options{NoColor: *noColor})
+	m := tui.New(cli, tui.Options{NoColor: *noColor, Write: *write})
 	prog := tea.NewProgram(m, tea.WithAltScreen(), tea.WithMouseCellMotion())
 	if _, err := prog.Run(); err != nil {
 		fmt.Fprintf(os.Stderr, "tui: %v\n", err)

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -9,6 +9,11 @@ log:
 api:
   http_addr: "127.0.0.1:8080"   # HTTP REST + SSE + WebSocket
   grpc_addr: "127.0.0.1:50051"  # gRPC
+  # Off by default. Set true to expose the operator mutation
+  # endpoints (end call, set talkgroup priority/lockout, retention
+  # sweep, tone-out detector reset). The HTTP API has no auth, so
+  # only enable when the listener is bound to a trusted interface.
+  allow_mutations: false
 
 metrics:
   enabled: true     # mounts /metrics on the HTTP API

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -95,13 +95,60 @@ A long-lived `/api/v1/events` SSE stream complements the polls, so
 instantly. If the SSE stream drops, the TUI shows a transient toast
 and reconnects with exponential backoff (1 s → 30 s cap).
 
-## Limitations (v1)
+## Mutations
 
-The first release is **read-only**. Mutation actions (end an active
-call, change a talkgroup's priority or lockout, sweep retention,
-reset the tone detector) need new daemon endpoints and a
-`api.allow_mutations` gate, and land in a follow-up PR. The TUI's
-keybindings for those actions are reserved but not bound yet.
+The TUI can drive five operator actions when both sides opt in:
+
+```bash
+# Daemon side: enable in config.yaml.
+api:
+  http_addr: 127.0.0.1:8080   # bind to loopback if you can
+  allow_mutations: true
+
+# TUI side: pass --write to surface the keybindings.
+gophertrunk tui --write
+```
+
+Both ends are gated separately on purpose. The daemon's HTTP API
+has no authentication today, so any host that can reach the
+listener can call mutations once the gate is open — bind to
+`127.0.0.1` and trust the operator before flipping it on.
+
+| Panel | Key | Action | Confirm? |
+| --- | --- | --- | --- |
+| Active calls | `e` | End the highlighted call (`POST /api/v1/calls/{serial}/end`, reason=manual) | yes |
+| Talkgroups | `l` | Toggle lockout on the highlighted talkgroup (`PATCH /api/v1/talkgroups/{id}`) | no — reversible |
+| Talkgroups | `+` / `-` | Bump priority up / down (clamped 0–99) | no |
+| Tone alerts | `R` | Reset tone-out match progress on the highlighted device (`POST /api/v1/devices/{serial}/tone-reset`) | yes |
+| Metrics | `S` | Run a retention sweep now (`POST /api/v1/retention/sweep`) | yes |
+
+When a key requires confirmation, a centered modal opens. The
+modal captures keyboard focus until you press:
+
+- `y` or `Enter` — fire the action and close the modal
+- `n` or `Esc` — cancel and close the modal
+
+On success the status bar shows `<label> ok` and the dependent
+read panels (active calls + talkgroups) refresh immediately rather
+than waiting for the next poll tick. On failure the status bar
+shows the HTTP error.
+
+The TUI fetches `GET /api/v1/mutations` once at startup to learn
+which subsystems the daemon has wired (engine / retention / tone
+detector). If the daemon doesn't recognise the route (older build),
+the TUI assumes mutations are off and `--write` is a no-op.
+
+### Endpoints reference
+
+| Method | Path | Body | Notes |
+| --- | --- | --- | --- |
+| `GET` | `/api/v1/mutations` | — | Capability probe. Always 200. |
+| `POST` | `/api/v1/calls/{deviceSerial}/end` | `{"reason":"manual"}` | 404 if no active call on that device. |
+| `PATCH` | `/api/v1/talkgroups/{id}` | `{"priority":3,"lockout":true}` | Both fields optional; supply at least one. Returns the updated TalkgroupDTO. |
+| `POST` | `/api/v1/retention/sweep` | — | Synchronous; 503 if no call-log persistence configured. |
+| `POST` | `/api/v1/devices/{serial}/tone-reset` | — | 503 if the tone-out detector isn't wired. |
+
+Every mutation endpoint returns `403 Forbidden` with `{"error":"mutations disabled (set api.allow_mutations: true to enable)"}` when the daemon was started without the gate.
 
 ## Troubleshooting
 

--- a/internal/api/handlers_mutations.go
+++ b/internal/api/handlers_mutations.go
@@ -1,0 +1,186 @@
+package api
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strconv"
+
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// handleMutationStatus reports whether the daemon was started with
+// mutations enabled. Always returns 200 — clients use this to
+// light up write-side keybindings without having to probe for 403s.
+func (s *Server) handleMutationStatus(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, map[string]any{
+		"allow_mutations":  s.allowMutations,
+		"engine_writable":  s.mutator != nil,
+		"retention_writable": s.retention != nil,
+		"tones_writable":   s.tones != nil,
+	})
+}
+
+// endCallRequest is the body of POST /api/v1/calls/{deviceSerial}/end.
+// reason is optional; defaults to "manual".
+type endCallRequest struct {
+	Reason string `json:"reason"`
+}
+
+// handleEndCall forces the engine to release the call held on the
+// given device serial, publishing a CallEnd event with the supplied
+// reason (default: "manual").
+//
+//   POST /api/v1/calls/00000001/end
+//   Content-Type: application/json
+//   {"reason":"manual"}
+//
+// Responses:
+//   200 {"ok":true,"device_serial":"...","reason":"manual"}
+//   404 if no active call holds the device
+//   503 if the daemon doesn't have an EngineMutator wired
+func (s *Server) handleEndCall(w http.ResponseWriter, r *http.Request) {
+	if s.mutator == nil {
+		writeError(w, http.StatusServiceUnavailable, "engine not wired for mutations")
+		return
+	}
+	serial := r.PathValue("deviceSerial")
+	if serial == "" {
+		writeError(w, http.StatusBadRequest, "deviceSerial required")
+		return
+	}
+	var req endCallRequest
+	if r.Body != nil && r.ContentLength != 0 {
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil && err != io.EOF {
+			writeError(w, http.StatusBadRequest, "invalid json body")
+			return
+		}
+	}
+	reason := parseEndReason(req.Reason)
+	ok := s.mutator.EndCall(serial, reason)
+	if !ok {
+		writeError(w, http.StatusNotFound, "no active call on that device")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"ok":            true,
+		"device_serial": serial,
+		"reason":        reason.String(),
+	})
+}
+
+func parseEndReason(s string) trunking.EndReason {
+	switch s {
+	case "", "manual":
+		return trunking.EndReasonManual
+	case "normal":
+		return trunking.EndReasonNormal
+	case "lockout":
+		return trunking.EndReasonLockout
+	case "preempted":
+		return trunking.EndReasonPreempted
+	case "timeout":
+		return trunking.EndReasonTimeout
+	case "error":
+		return trunking.EndReasonError
+	}
+	return trunking.EndReasonManual
+}
+
+// updateTalkgroupRequest is the PATCH body shape. Both fields are
+// pointers so JSON-omitted fields aren't accidentally zeroed: only
+// supplied fields are applied.
+type updateTalkgroupRequest struct {
+	Priority *int  `json:"priority"`
+	Lockout  *bool `json:"lockout"`
+}
+
+// handleUpdateTalkgroup updates a talkgroup's mutable policy fields
+// (priority and/or lockout). The full updated record is returned.
+//
+//   PATCH /api/v1/talkgroups/42
+//   Content-Type: application/json
+//   {"priority":3,"lockout":false}
+//
+// Responses:
+//   200 with the updated TalkgroupDTO
+//   400 if the id can't be parsed or the body is malformed
+//   404 if no such talkgroup exists
+func (s *Server) handleUpdateTalkgroup(w http.ResponseWriter, r *http.Request) {
+	idStr := r.PathValue("id")
+	id, err := strconv.ParseUint(idStr, 10, 32)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid talkgroup id")
+		return
+	}
+	var req updateTalkgroupRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid json body")
+		return
+	}
+	if req.Priority == nil && req.Lockout == nil {
+		writeError(w, http.StatusBadRequest, "supply priority and/or lockout")
+		return
+	}
+	ok := s.talkgroups.UpdateFields(uint32(id), func(tg *trunking.TalkGroup) {
+		if req.Priority != nil {
+			tg.Priority = *req.Priority
+		}
+		if req.Lockout != nil {
+			tg.Lockout = *req.Lockout
+		}
+	})
+	if !ok {
+		writeError(w, http.StatusNotFound, "talkgroup not found")
+		return
+	}
+	tg := s.talkgroups.Lookup(uint32(id))
+	writeJSON(w, http.StatusOK, talkgroupToDTO(tg))
+}
+
+// handleRetentionSweep kicks off one immediate retention sweep
+// (call-log rows + recordings, depending on what's configured).
+// The sweep runs synchronously inside the request — typical sweep
+// runs are sub-second; if a deployment outgrows that we'll move
+// it to a goroutine + 202.
+//
+//   POST /api/v1/retention/sweep
+//
+// Responses:
+//   200 {"ok":true}
+//   503 if the daemon doesn't have a Retention wired (e.g. no
+//       call-log persistence configured)
+func (s *Server) handleRetentionSweep(w http.ResponseWriter, r *http.Request) {
+	if s.retention == nil {
+		writeError(w, http.StatusServiceUnavailable, "retention not wired")
+		return
+	}
+	s.retention.SweepOnce(r.Context())
+	writeJSON(w, http.StatusOK, map[string]any{"ok": true})
+}
+
+// handleToneReset clears per-device tone-out match progress for a
+// given device, leaving the cooldown clock intact (so an in-flight
+// false alarm doesn't immediately re-fire).
+//
+//   POST /api/v1/devices/00000001/tone-reset
+//
+// Responses:
+//   200 {"ok":true,"device_serial":"..."}
+//   503 if the daemon doesn't have a tone detector wired
+func (s *Server) handleToneReset(w http.ResponseWriter, r *http.Request) {
+	if s.tones == nil {
+		writeError(w, http.StatusServiceUnavailable, "tone detector not wired")
+		return
+	}
+	serial := r.PathValue("serial")
+	if serial == "" {
+		writeError(w, http.StatusBadRequest, "serial required")
+		return
+	}
+	s.tones.ResetDevice(serial)
+	writeJSON(w, http.StatusOK, map[string]any{
+		"ok":            true,
+		"device_serial": serial,
+	})
+}

--- a/internal/api/handlers_mutations_test.go
+++ b/internal/api/handlers_mutations_test.go
@@ -1,0 +1,328 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// fakeMutator records EndCall calls and returns whatever the test
+// pre-loads into pending.
+type fakeMutator struct {
+	mu      sync.Mutex
+	pending map[string]bool // serial -> EndCall returns true
+	called  []endCallRecord
+}
+
+type endCallRecord struct {
+	Serial string
+	Reason trunking.EndReason
+}
+
+func (f *fakeMutator) EndCall(serial string, reason trunking.EndReason) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.called = append(f.called, endCallRecord{Serial: serial, Reason: reason})
+	return f.pending[serial]
+}
+
+type fakeRetention struct {
+	mu     sync.Mutex
+	swept  int
+}
+
+func (f *fakeRetention) SweepOnce(_ context.Context) {
+	f.mu.Lock()
+	f.swept++
+	f.mu.Unlock()
+}
+
+type fakeTones struct {
+	mu     sync.Mutex
+	resets []string
+}
+
+func (f *fakeTones) ResetDevice(serial string) {
+	f.mu.Lock()
+	f.resets = append(f.resets, serial)
+	f.mu.Unlock()
+}
+
+func TestMutations_Disabled_ReturnForbidden(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	base, teardown := mkServer(t, ServerOptions{
+		Bus:            bus,
+		AllowMutations: false, // explicit
+		Mutator:        &fakeMutator{pending: map[string]bool{"abc": true}},
+		Retention:      &fakeRetention{},
+		Tones:          &fakeTones{},
+	})
+	defer teardown()
+
+	for _, c := range []struct {
+		method, path string
+	}{
+		{"POST", "/api/v1/calls/abc/end"},
+		{"PATCH", "/api/v1/talkgroups/42"},
+		{"POST", "/api/v1/retention/sweep"},
+		{"POST", "/api/v1/devices/abc/tone-reset"},
+	} {
+		req, _ := http.NewRequest(c.method, base+c.path, nil)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("%s %s: %v", c.method, c.path, err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusForbidden {
+			t.Errorf("%s %s: status=%d, want 403", c.method, c.path, resp.StatusCode)
+		}
+	}
+}
+
+func TestMutationStatus_AlwaysExposed(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	base, teardown := mkServer(t, ServerOptions{
+		Bus:            bus,
+		AllowMutations: true,
+		Mutator:        &fakeMutator{},
+		Retention:      &fakeRetention{},
+	})
+	defer teardown()
+
+	resp, err := http.Get(base + "/api/v1/mutations")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("status=%d", resp.StatusCode)
+	}
+	var body map[string]bool
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatal(err)
+	}
+	if !body["allow_mutations"] {
+		t.Errorf("allow_mutations = false")
+	}
+	if !body["engine_writable"] {
+		t.Errorf("engine_writable = false")
+	}
+	if !body["retention_writable"] {
+		t.Errorf("retention_writable = false")
+	}
+	if body["tones_writable"] {
+		t.Errorf("tones_writable = true (none wired)")
+	}
+}
+
+func TestEndCall_OK(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	mut := &fakeMutator{pending: map[string]bool{"abc": true}}
+	base, teardown := mkServer(t, ServerOptions{
+		Bus: bus, AllowMutations: true, Mutator: mut,
+	})
+	defer teardown()
+
+	body := strings.NewReader(`{"reason":"manual"}`)
+	resp, err := http.Post(base+"/api/v1/calls/abc/end", "application/json", body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("status=%d", resp.StatusCode)
+	}
+	if len(mut.called) != 1 || mut.called[0].Serial != "abc" || mut.called[0].Reason != trunking.EndReasonManual {
+		t.Errorf("EndCall not invoked correctly: %+v", mut.called)
+	}
+}
+
+func TestEndCall_NotFound(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	base, teardown := mkServer(t, ServerOptions{
+		Bus: bus, AllowMutations: true, Mutator: &fakeMutator{pending: map[string]bool{}},
+	})
+	defer teardown()
+
+	resp, err := http.Post(base+"/api/v1/calls/missing/end", "application/json", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 404 {
+		t.Errorf("status=%d, want 404", resp.StatusCode)
+	}
+}
+
+func TestUpdateTalkgroup_AppliesPriorityAndLockout(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	tgs := trunking.NewTalkgroupDB()
+	tgs.Add(&trunking.TalkGroup{ID: 42, AlphaTag: "Dispatch", Priority: 5, Lockout: false})
+	base, teardown := mkServer(t, ServerOptions{
+		Bus:            bus,
+		AllowMutations: true,
+		Talkgroups:     tgs,
+	})
+	defer teardown()
+
+	body := bytes.NewReader([]byte(`{"priority":2,"lockout":true}`))
+	req, _ := http.NewRequest(http.MethodPatch, base+"/api/v1/talkgroups/42", body)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("status=%d", resp.StatusCode)
+	}
+	tg := tgs.Lookup(42)
+	if tg.Priority != 2 || !tg.Lockout {
+		t.Errorf("update not applied: %+v", tg)
+	}
+}
+
+func TestUpdateTalkgroup_NotFound(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	base, teardown := mkServer(t, ServerOptions{
+		Bus: bus, AllowMutations: true, Talkgroups: trunking.NewTalkgroupDB(),
+	})
+	defer teardown()
+
+	body := bytes.NewReader([]byte(`{"priority":1}`))
+	req, _ := http.NewRequest(http.MethodPatch, base+"/api/v1/talkgroups/999", body)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 404 {
+		t.Errorf("status=%d, want 404", resp.StatusCode)
+	}
+}
+
+func TestUpdateTalkgroup_RejectsEmptyBody(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	tgs := trunking.NewTalkgroupDB()
+	tgs.Add(&trunking.TalkGroup{ID: 42})
+	base, teardown := mkServer(t, ServerOptions{
+		Bus: bus, AllowMutations: true, Talkgroups: tgs,
+	})
+	defer teardown()
+
+	body := bytes.NewReader([]byte(`{}`))
+	req, _ := http.NewRequest(http.MethodPatch, base+"/api/v1/talkgroups/42", body)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 400 {
+		t.Errorf("status=%d, want 400", resp.StatusCode)
+	}
+}
+
+func TestRetentionSweep_Invokes(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	ret := &fakeRetention{}
+	base, teardown := mkServer(t, ServerOptions{
+		Bus: bus, AllowMutations: true, Retention: ret,
+	})
+	defer teardown()
+
+	resp, err := http.Post(base+"/api/v1/retention/sweep", "application/json", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("status=%d", resp.StatusCode)
+	}
+	if ret.swept != 1 {
+		t.Errorf("SweepOnce called %d times, want 1", ret.swept)
+	}
+}
+
+func TestRetentionSweep_Unwired(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	base, teardown := mkServer(t, ServerOptions{
+		Bus: bus, AllowMutations: true,
+	})
+	defer teardown()
+
+	resp, err := http.Post(base+"/api/v1/retention/sweep", "application/json", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != 503 {
+		t.Errorf("status=%d, want 503", resp.StatusCode)
+	}
+}
+
+func TestToneReset_Invokes(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	tn := &fakeTones{}
+	base, teardown := mkServer(t, ServerOptions{
+		Bus: bus, AllowMutations: true, Tones: tn,
+	})
+	defer teardown()
+
+	resp, err := http.Post(base+"/api/v1/devices/00000001/tone-reset", "application/json", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("status=%d", resp.StatusCode)
+	}
+	if len(tn.resets) != 1 || tn.resets[0] != "00000001" {
+		t.Errorf("ResetDevice not called correctly: %+v", tn.resets)
+	}
+}
+
+func TestTalkgroupDB_UpdateFields(t *testing.T) {
+	db := trunking.NewTalkgroupDB()
+	db.Add(&trunking.TalkGroup{ID: 1, Priority: 5})
+
+	ok := db.UpdateFields(1, func(tg *trunking.TalkGroup) {
+		tg.Priority = 3
+		tg.Lockout = true
+	})
+	if !ok {
+		t.Fatalf("UpdateFields returned false for existing id")
+	}
+	got := db.Lookup(1)
+	if got.Priority != 3 || !got.Lockout {
+		t.Errorf("UpdateFields did not apply: %+v", got)
+	}
+
+	if db.UpdateFields(999, func(*trunking.TalkGroup) {}) {
+		t.Errorf("UpdateFields(missing) returned true")
+	}
+	if !db.Delete(1) {
+		t.Errorf("Delete(existing) returned false")
+	}
+	if db.Delete(999) {
+		t.Errorf("Delete(missing) returned true")
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -20,18 +20,45 @@ type EngineSnapshot interface {
 	ActiveCalls() []*trunking.ActiveCall
 }
 
+// EngineMutator is the optional write side of the engine. Daemons
+// that have AllowMutations enabled supply a real engine; tests can
+// inject a fake. When nil the end-call route returns 503.
+type EngineMutator interface {
+	EndCall(deviceSerial string, reason trunking.EndReason) bool
+}
+
+// RetentionSweeper is the optional write side of the retention
+// system: kick off one ad-hoc sweep. The daemon supplies the real
+// sweeper from internal/storage; tests can fake it.
+type RetentionSweeper interface {
+	SweepOnce(ctx context.Context)
+}
+
+// ToneDetectorReset is the optional write side of the tone-out
+// detector: clear per-device match progress without throwing away
+// the cooldown clock. Daemons that wire the detector supply the
+// real impl; tests can fake it.
+type ToneDetectorReset interface {
+	ResetDevice(serial string)
+}
+
 // Server hosts the GopherTrunk HTTP/SSE/WebSocket API. A separate gRPC
 // server (internal/api/grpc.go) shares the same in-process state.
 type Server struct {
 	addr       string
 	bus        *events.Bus
 	engine     EngineSnapshot
+	mutator    EngineMutator
+	retention  RetentionSweeper
+	tones      ToneDetectorReset
 	talkgroups *trunking.TalkgroupDB
 	systems    []trunking.System
 	history    HistoryQuery
 	metrics    http.Handler
 	log        *slog.Logger
 	version    string
+
+	allowMutations bool
 
 	mu     sync.Mutex
 	srv    *http.Server
@@ -96,6 +123,19 @@ type ServerOptions struct {
 	Log            *slog.Logger
 	// Version is reported by GET /api/v1/version.
 	Version string
+	// AllowMutations gates the write endpoints. Off by default —
+	// the HTTP API has no authentication, so mutations are unsafe
+	// to expose unless the operator explicitly opts in.
+	AllowMutations bool
+	// Mutator is the engine's write side (end call). Optional;
+	// when nil the corresponding routes return 503.
+	Mutator EngineMutator
+	// Retention is the storage sweeper's write side (run a sweep
+	// now). Optional.
+	Retention RetentionSweeper
+	// Tones is the tone-out detector's write side (reset per-device
+	// match state). Optional.
+	Tones ToneDetectorReset
 }
 
 // NewServer constructs a server but does not yet bind a listener; call
@@ -115,15 +155,19 @@ func NewServer(opts ServerOptions) (*Server, error) {
 		opts.Talkgroups = trunking.NewTalkgroupDB()
 	}
 	return &Server{
-		addr:       opts.Addr,
-		bus:        opts.Bus,
-		engine:     opts.Engine,
-		talkgroups: opts.Talkgroups,
-		systems:    append([]trunking.System(nil), opts.Systems...),
-		history:    opts.History,
-		metrics:    opts.MetricsHandler,
-		log:        log,
-		version:    opts.Version,
+		addr:           opts.Addr,
+		bus:            opts.Bus,
+		engine:         opts.Engine,
+		mutator:        opts.Mutator,
+		retention:      opts.Retention,
+		tones:          opts.Tones,
+		talkgroups:     opts.Talkgroups,
+		systems:        append([]trunking.System(nil), opts.Systems...),
+		history:        opts.History,
+		metrics:        opts.MetricsHandler,
+		log:            log,
+		version:        opts.Version,
+		allowMutations: opts.AllowMutations,
 	}, nil
 }
 
@@ -192,7 +236,31 @@ func (s *Server) routes() *http.ServeMux {
 	if s.metrics != nil {
 		mux.Handle("GET /metrics", s.metrics)
 	}
+
+	// Mutation routes — wrapped in s.gate so a non-AllowMutations
+	// daemon returns 403 without dispatching to the handler. The
+	// gate also reports the daemon's mutation capability via
+	// GET /api/v1/mutations so clients can light up keybindings.
+	mux.HandleFunc("GET /api/v1/mutations", s.handleMutationStatus)
+	mux.HandleFunc("POST /api/v1/calls/{deviceSerial}/end", s.gate(s.handleEndCall))
+	mux.HandleFunc("PATCH /api/v1/talkgroups/{id}", s.gate(s.handleUpdateTalkgroup))
+	mux.HandleFunc("POST /api/v1/retention/sweep", s.gate(s.handleRetentionSweep))
+	mux.HandleFunc("POST /api/v1/devices/{serial}/tone-reset", s.gate(s.handleToneReset))
+
 	return mux
+}
+
+// gate wraps a handler so it short-circuits with 403 when the
+// daemon was started without api.allow_mutations. The body carries
+// the same {"error":"..."} envelope existing 4xx handlers use.
+func (s *Server) gate(h http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !s.allowMutations {
+			writeError(w, http.StatusForbidden, "mutations disabled (set api.allow_mutations: true to enable)")
+			return
+		}
+		h(w, r)
+	}
 }
 
 func writeJSON(w http.ResponseWriter, status int, body any) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -52,9 +52,16 @@ type SystemConfig struct {
 // APIConfig controls the HTTP REST + SSE + WebSocket and gRPC servers.
 // Both addresses are TCP listen specifiers (":8080", "127.0.0.1:9000",
 // etc.). An empty value disables that surface.
+//
+// AllowMutations gates the write endpoints (end call, set talkgroup
+// priority/lockout, retention sweep, tone-detector reset). Off by
+// default — the daemon's HTTP API has no authentication, so any
+// network-reachable instance is unauthenticated by definition. Only
+// turn this on if you trust everything that can reach the listener.
 type APIConfig struct {
-	HTTPAddr string `yaml:"http_addr"`
-	GRPCAddr string `yaml:"grpc_addr"`
+	HTTPAddr       string `yaml:"http_addr"`
+	GRPCAddr       string `yaml:"grpc_addr"`
+	AllowMutations bool   `yaml:"allow_mutations"`
 }
 
 // StorageConfig configures the SQLite call log. An empty Path disables

--- a/internal/trunking/grant.go
+++ b/internal/trunking/grant.go
@@ -54,6 +54,7 @@ const (
 	EndReasonLockout              // talkgroup is locked out by policy
 	EndReasonNoVoiceSDR           // every Voice-role SDR was busy
 	EndReasonError
+	EndReasonManual // operator ended the call via API / TUI
 )
 
 func (r EndReason) String() string {
@@ -70,6 +71,8 @@ func (r EndReason) String() string {
 		return "no-voice-sdr"
 	case EndReasonError:
 		return "error"
+	case EndReasonManual:
+		return "manual"
 	default:
 		return "unknown"
 	}

--- a/internal/trunking/talkgroup.go
+++ b/internal/trunking/talkgroup.go
@@ -50,6 +50,33 @@ func (d *TalkgroupDB) Add(tg *TalkGroup) {
 	d.tgs[tg.ID] = tg
 }
 
+// UpdateFields applies fn to the talkgroup with the given id under
+// the write lock. Returns false if no such talkgroup exists. Used
+// by the API to mutate Priority / Lockout without exposing the raw
+// pointer to outside callers.
+func (d *TalkgroupDB) UpdateFields(id uint32, fn func(*TalkGroup)) bool {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	tg, ok := d.tgs[id]
+	if !ok {
+		return false
+	}
+	fn(tg)
+	return true
+}
+
+// Delete removes the talkgroup with the given id. Returns false
+// if no such talkgroup exists.
+func (d *TalkgroupDB) Delete(id uint32) bool {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if _, ok := d.tgs[id]; !ok {
+		return false
+	}
+	delete(d.tgs, id)
+	return true
+}
+
 // All returns a snapshot of every talkgroup in the DB.
 func (d *TalkgroupDB) All() []*TalkGroup {
 	d.mu.RLock()

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -22,6 +22,10 @@ import (
 // Options controls the TUI's startup behaviour.
 type Options struct {
 	NoColor bool
+	// Write enables the TUI's mutation keybindings. AND-ed with
+	// the daemon's /api/v1/mutations capability — both must agree
+	// for write-side keys to fire.
+	Write bool
 }
 
 // Model is the root bubbletea model.
@@ -40,6 +44,8 @@ type Model struct {
 	eventCh    <-chan client.Event
 	sseCancel  func()
 	sseRetries int
+
+	confirm *confirmModal
 
 	historyLoaded bool
 	toastUntil    time.Time
@@ -85,6 +91,7 @@ func (m *Model) Init() tea.Cmd {
 		cmdPollActive(m.cli),
 		cmdPollMetrics(m.cli),
 		cmdPollHistory(m.cli, client.HistoryFilter{Limit: 100}),
+		cmdMutationStatus(m.cli),
 		connectSSE(m.cli),
 	)
 }
@@ -105,6 +112,21 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.width = msg.Width
 		m.height = msg.Height
 	case tea.KeyMsg:
+		// Modal capture: when a confirmation is pending, every key
+		// goes to the modal — global nav and panels are frozen.
+		if m.confirm != nil {
+			switch msg.String() {
+			case "y", "Y", "enter":
+				req := m.confirm.req
+				m.confirm = nil
+				return m, m.dispatchWrite(req)
+			case "n", "N", "esc":
+				m.confirm = nil
+				m.toast("cancelled")
+				return m, nil
+			}
+			return m, nil // swallow other keys while modal is up
+		}
 		// Quit & global navigation always win.
 		switch {
 		case key.Matches(msg, m.keys.Quit):
@@ -226,6 +248,40 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.toast("event stream disconnected — reconnecting in " + backoff.Truncate(time.Second).String())
 		cmds = append(cmds, tea.Tick(backoff, func(time.Time) tea.Msg { return connectSSE(m.cli)() }))
+
+	case pollMutationStatusMsg:
+		// /api/v1/mutations only fails on a network error; an
+		// older daemon that doesn't know the route yields a
+		// zero-value status. WriteEnabled is the AND of the
+		// daemon's allow_mutations and the TUI's --write flag.
+		m.shared.Mutations = msg.s
+		m.shared.WriteEnabled = m.opts.Write && msg.s.AllowMutations
+
+	case panels.WriteActionMsg:
+		if !m.shared.WriteEnabled {
+			m.toast("mutations disabled — pass --write to the TUI and api.allow_mutations: true to the daemon")
+			return m, nil
+		}
+		// requestConfirm either fires the request now or stashes
+		// it for the modal. The returned Cmd is non-nil only on
+		// the immediate-fire path.
+		if cmd := m.requestConfirm(msg.Request); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
+
+	case writeResultMsg:
+		if msg.Err != nil {
+			m.toast(fmt.Sprintf("%s: %v", msg.Label, msg.Err))
+		} else if msg.Label != "" {
+			m.toast(msg.Label + " ok")
+		}
+		// Refresh the dependent surfaces immediately so the UI
+		// reflects the mutation without waiting for the next
+		// poll tick.
+		cmds = append(cmds,
+			cmdPollActive(m.cli),
+			cmdPollTalkgroups(m.cli),
+		)
 	}
 
 	// Forward to active panel.
@@ -258,7 +314,11 @@ func (m *Model) View() string {
 		bodyH = 4
 	}
 	body := m.panels[m.active].View(m.width, bodyH, true, m.shared)
-	return lipgloss.JoinVertical(lipgloss.Left, tabs, body, status)
+	full := lipgloss.JoinVertical(lipgloss.Left, tabs, body, status)
+	if m.confirm != nil {
+		return m.renderModal(m.width, m.height, full)
+	}
+	return full
 }
 
 func (m *Model) renderTabs() string {
@@ -301,4 +361,35 @@ func (m *Model) renderStatusBar() string {
 func (m *Model) toast(s string) {
 	m.shared.Toast = s
 	m.toastUntil = time.Now().Add(4 * time.Second)
+}
+
+// dispatchWrite turns a state.WriteRequest into the matching write
+// Cmd. The Cmd's outcome arrives back as writeResultMsg, which the
+// Update loop surfaces as a toast and uses to refresh dependent
+// reads.
+func (m *Model) dispatchWrite(r state.WriteRequest) tea.Cmd {
+	switch r.Kind {
+	case state.WriteKindEndCall:
+		if r.EndCall == nil {
+			return nil
+		}
+		return cmdEndCall(m.cli, r.EndCall.DeviceSerial, r.EndCall.Reason, r.Label)
+	case state.WriteKindUpdateTalkgroup:
+		if r.UpdateTalkgroup == nil {
+			return nil
+		}
+		return cmdUpdateTalkgroup(m.cli,
+			r.UpdateTalkgroup.ID,
+			r.UpdateTalkgroup.Priority,
+			r.UpdateTalkgroup.Lockout,
+			r.Label)
+	case state.WriteKindSweepRetention:
+		return cmdSweepRetention(m.cli)
+	case state.WriteKindResetTone:
+		if r.ResetTone == nil {
+			return nil
+		}
+		return cmdResetTone(m.cli, r.ResetTone.DeviceSerial)
+	}
+	return nil
 }

--- a/internal/tui/client/write.go
+++ b/internal/tui/client/write.go
@@ -1,0 +1,140 @@
+package client
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// MutationStatus mirrors GET /api/v1/mutations. The TUI fetches it
+// once at startup to decide which write keybindings to expose. A
+// daemon that doesn't know the route (older build) returns 404 and
+// the TUI treats that as "no mutations".
+type MutationStatus struct {
+	AllowMutations    bool `json:"allow_mutations"`
+	EngineWritable    bool `json:"engine_writable"`
+	RetentionWritable bool `json:"retention_writable"`
+	TonesWritable     bool `json:"tones_writable"`
+}
+
+// MutationStatus calls GET /api/v1/mutations. Returns a zero-value
+// status (and a nil error) if the daemon doesn't know the route.
+func (c *Client) MutationStatus(ctx context.Context) (MutationStatus, error) {
+	var s MutationStatus
+	err := c.getJSON(ctx, "/api/v1/mutations", &s)
+	if err != nil {
+		var herr *HTTPError
+		if asHTTPErr(err, &herr) && herr.Status == http.StatusNotFound {
+			return MutationStatus{}, nil
+		}
+		return MutationStatus{}, err
+	}
+	return s, nil
+}
+
+// EndCall calls POST /api/v1/calls/{deviceSerial}/end. reason is
+// optional; defaults to "manual".
+func (c *Client) EndCall(ctx context.Context, deviceSerial, reason string) error {
+	if deviceSerial == "" {
+		return fmt.Errorf("client: deviceSerial required")
+	}
+	body := map[string]string{"reason": reason}
+	return c.do(ctx, http.MethodPost,
+		"/api/v1/calls/"+deviceSerial+"/end",
+		body, nil)
+}
+
+// UpdateTalkgroup calls PATCH /api/v1/talkgroups/{id}. Pass nil for
+// fields you don't want to change.
+func (c *Client) UpdateTalkgroup(ctx context.Context, id uint32, priority *int, lockout *bool) (TalkgroupDTO, error) {
+	body := map[string]any{}
+	if priority != nil {
+		body["priority"] = *priority
+	}
+	if lockout != nil {
+		body["lockout"] = *lockout
+	}
+	if len(body) == 0 {
+		return TalkgroupDTO{}, fmt.Errorf("client: supply priority and/or lockout")
+	}
+	var out TalkgroupDTO
+	if err := c.do(ctx, http.MethodPatch,
+		fmt.Sprintf("/api/v1/talkgroups/%d", id),
+		body, &out); err != nil {
+		return TalkgroupDTO{}, err
+	}
+	return out, nil
+}
+
+// SweepRetention calls POST /api/v1/retention/sweep.
+func (c *Client) SweepRetention(ctx context.Context) error {
+	return c.do(ctx, http.MethodPost, "/api/v1/retention/sweep", nil, nil)
+}
+
+// ResetToneDevice calls POST /api/v1/devices/{serial}/tone-reset.
+func (c *Client) ResetToneDevice(ctx context.Context, serial string) error {
+	if serial == "" {
+		return fmt.Errorf("client: serial required")
+	}
+	return c.do(ctx, http.MethodPost,
+		"/api/v1/devices/"+serial+"/tone-reset",
+		nil, nil)
+}
+
+// do is the generic JSON request/response helper for write methods.
+// Responses with 2xx + a non-nil out get JSON-decoded; nil out
+// discards the body. Non-2xx returns *HTTPError.
+func (c *Client) do(ctx context.Context, method, path string, in any, out any) error {
+	ctx, cancel := c.withTimeout(ctx)
+	defer cancel()
+	var bodyR *bytes.Reader
+	if in != nil {
+		buf, err := json.Marshal(in)
+		if err != nil {
+			return err
+		}
+		bodyR = bytes.NewReader(buf)
+	}
+	var req *http.Request
+	var err error
+	if bodyR != nil {
+		req, err = http.NewRequestWithContext(ctx, method, c.base+path, bodyR)
+	} else {
+		req, err = http.NewRequestWithContext(ctx, method, c.base+path, nil)
+	}
+	if err != nil {
+		return err
+	}
+	req.Header.Set("User-Agent", userAgent)
+	req.Header.Set("Accept", "application/json")
+	if in != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := c.hc.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode/100 != 2 {
+		return c.httpErr(method, req.URL.String(), resp)
+	}
+	if out == nil {
+		return nil
+	}
+	return json.NewDecoder(resp.Body).Decode(out)
+}
+
+// asHTTPErr is a tiny wrapper around errors.As that avoids dragging
+// the import into the call site.
+func asHTTPErr(err error, target **HTTPError) bool {
+	if err == nil {
+		return false
+	}
+	if h, ok := err.(*HTTPError); ok {
+		*target = h
+		return true
+	}
+	return false
+}

--- a/internal/tui/client/write_test.go
+++ b/internal/tui/client/write_test.go
@@ -1,0 +1,168 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestEndCall_PostsBody(t *testing.T) {
+	var got struct {
+		Method, Path, Body string
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got.Method = r.Method
+		got.Path = r.URL.Path
+		body, _ := io.ReadAll(r.Body)
+		got.Body = string(body)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+	c := New(srv.URL, time.Second, false)
+
+	if err := c.EndCall(context.Background(), "00000001", "manual"); err != nil {
+		t.Fatal(err)
+	}
+	if got.Method != "POST" {
+		t.Errorf("method = %s", got.Method)
+	}
+	if got.Path != "/api/v1/calls/00000001/end" {
+		t.Errorf("path = %s", got.Path)
+	}
+	if !strings.Contains(got.Body, `"reason":"manual"`) {
+		t.Errorf("body = %s", got.Body)
+	}
+}
+
+func TestEndCall_403_SurfacesHTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(403)
+		_, _ = w.Write([]byte(`{"error":"mutations disabled"}`))
+	}))
+	defer srv.Close()
+	c := New(srv.URL, time.Second, false)
+	err := c.EndCall(context.Background(), "abc", "")
+	if err == nil {
+		t.Fatal("want error")
+	}
+	var herr *HTTPError
+	if !asHTTPErr(err, &herr) {
+		t.Fatalf("want *HTTPError, got %T", err)
+	}
+	if herr.Status != 403 {
+		t.Errorf("status = %d", herr.Status)
+	}
+}
+
+func TestUpdateTalkgroup_OmitsNilFields(t *testing.T) {
+	var body string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		buf, _ := io.ReadAll(r.Body)
+		body = string(buf)
+		_, _ = w.Write([]byte(`{"id":42,"alpha_tag":"x","priority":3}`))
+	}))
+	defer srv.Close()
+	c := New(srv.URL, time.Second, false)
+	pri := 3
+	out, err := c.UpdateTalkgroup(context.Background(), 42, &pri, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.ID != 42 {
+		t.Errorf("ID = %d", out.ID)
+	}
+	if !strings.Contains(body, `"priority":3`) {
+		t.Errorf("body = %s", body)
+	}
+	if strings.Contains(body, `"lockout"`) {
+		t.Errorf("body should omit lockout when nil: %s", body)
+	}
+}
+
+func TestUpdateTalkgroup_RequiresAtLeastOneField(t *testing.T) {
+	c := New("http://example.invalid", time.Second, false)
+	_, err := c.UpdateTalkgroup(context.Background(), 42, nil, nil)
+	if err == nil {
+		t.Fatal("want error when both fields are nil")
+	}
+}
+
+func TestSweepRetention_PostsEmpty(t *testing.T) {
+	got := struct {
+		method, path string
+		bodyLen      int
+	}{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got.method, got.path = r.Method, r.URL.Path
+		body, _ := io.ReadAll(r.Body)
+		got.bodyLen = len(body)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+	c := New(srv.URL, time.Second, false)
+	if err := c.SweepRetention(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if got.method != "POST" || got.path != "/api/v1/retention/sweep" {
+		t.Errorf("method=%s path=%s", got.method, got.path)
+	}
+	if got.bodyLen != 0 {
+		t.Errorf("body should be empty, got %d bytes", got.bodyLen)
+	}
+}
+
+func TestResetToneDevice_PathHasSerial(t *testing.T) {
+	var path string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path = r.URL.Path
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+	c := New(srv.URL, time.Second, false)
+	if err := c.ResetToneDevice(context.Background(), "00000001"); err != nil {
+		t.Fatal(err)
+	}
+	if path != "/api/v1/devices/00000001/tone-reset" {
+		t.Errorf("path = %s", path)
+	}
+}
+
+func TestMutationStatus_Decodes(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]bool{
+			"allow_mutations":    true,
+			"engine_writable":    true,
+			"retention_writable": false,
+			"tones_writable":     true,
+		})
+	}))
+	defer srv.Close()
+	c := New(srv.URL, time.Second, false)
+	s, err := c.MutationStatus(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !s.AllowMutations || !s.EngineWritable || s.RetentionWritable || !s.TonesWritable {
+		t.Errorf("decoded unexpectedly: %+v", s)
+	}
+}
+
+func TestMutationStatus_404_ReturnsZero(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+	c := New(srv.URL, time.Second, false)
+	s, err := c.MutationStatus(context.Background())
+	if err != nil {
+		t.Fatalf("404 should not return error, got %v", err)
+	}
+	if s != (MutationStatus{}) {
+		t.Errorf("want zero MutationStatus on 404, got %+v", s)
+	}
+}

--- a/internal/tui/cmds.go
+++ b/internal/tui/cmds.go
@@ -100,3 +100,42 @@ func connectSSE(cli *client.Client) tea.Cmd {
 		return sseUpMsg{ch: ch, cancel: cancel}
 	}
 }
+
+func cmdMutationStatus(cli *client.Client) tea.Cmd {
+	return func() tea.Msg {
+		s, err := cli.MutationStatus(context.Background())
+		return pollMutationStatusMsg{s: s, err: err}
+	}
+}
+
+// Write-side Cmd builders. Each returns a tea.Cmd that runs the
+// HTTP request and surfaces the outcome as writeResultMsg, which
+// the root model turns into a toast.
+
+func cmdEndCall(cli *client.Client, deviceSerial, reason, label string) tea.Cmd {
+	return func() tea.Msg {
+		err := cli.EndCall(context.Background(), deviceSerial, reason)
+		return writeResultMsg{Label: label, Err: err}
+	}
+}
+
+func cmdUpdateTalkgroup(cli *client.Client, id uint32, priority *int, lockout *bool, label string) tea.Cmd {
+	return func() tea.Msg {
+		_, err := cli.UpdateTalkgroup(context.Background(), id, priority, lockout)
+		return writeResultMsg{Label: label, Err: err}
+	}
+}
+
+func cmdSweepRetention(cli *client.Client) tea.Cmd {
+	return func() tea.Msg {
+		err := cli.SweepRetention(context.Background())
+		return writeResultMsg{Label: "retention sweep", Err: err}
+	}
+}
+
+func cmdResetTone(cli *client.Client, deviceSerial string) tea.Cmd {
+	return func() tea.Msg {
+		err := cli.ResetToneDevice(context.Background(), deviceSerial)
+		return writeResultMsg{Label: "reset tone detector for " + deviceSerial, Err: err}
+	}
+}

--- a/internal/tui/modal.go
+++ b/internal/tui/modal.go
@@ -1,0 +1,59 @@
+package tui
+
+import (
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/MattCheramie/GopherTrunk/internal/tui/state"
+)
+
+// confirmModal is the modal overlay shown when a panel issues a
+// WriteRequest with Confirm != "". It captures keyboard focus until
+// the operator presses y/Enter (run the action) or n/Esc (cancel).
+type confirmModal struct {
+	prompt string
+	label  string
+	req    state.WriteRequest
+}
+
+// activeModal returns true when there's a confirmation pending.
+func (m *Model) activeModal() bool { return m.confirm != nil }
+
+// requestConfirm stores the request and triggers the modal overlay,
+// or runs the request immediately when Confirm is empty.
+func (m *Model) requestConfirm(r state.WriteRequest) tea.Cmd {
+	if r.Confirm == "" {
+		return m.dispatchWrite(r)
+	}
+	m.confirm = &confirmModal{prompt: r.Confirm, label: r.Label, req: r}
+	return nil
+}
+
+// renderModal draws a centered confirmation box over the body.
+// width and height are the full screen dimensions.
+func (m *Model) renderModal(width, height int, behind string) string {
+	if m.confirm == nil {
+		return behind
+	}
+	box := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.Color("196")).
+		Padding(1, 2).
+		Background(lipgloss.Color("236")).
+		Foreground(lipgloss.Color("231"))
+
+	header := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("196")).Render("Confirm action")
+	body := m.confirm.prompt
+	footer := lipgloss.NewStyle().Foreground(lipgloss.Color("245")).Render("y/enter: confirm   n/esc: cancel")
+	contents := strings.Join([]string{header, "", body, "", footer}, "\n")
+	rendered := box.Render(contents)
+
+	return lipgloss.Place(width, height,
+		lipgloss.Center, lipgloss.Center,
+		rendered,
+		lipgloss.WithWhitespaceChars(" "),
+		lipgloss.WithWhitespaceForeground(lipgloss.Color("236")),
+	)
+}

--- a/internal/tui/modal_test.go
+++ b/internal/tui/modal_test.go
@@ -1,0 +1,159 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/MattCheramie/GopherTrunk/internal/tui/client"
+	"github.com/MattCheramie/GopherTrunk/internal/tui/panels"
+	"github.com/MattCheramie/GopherTrunk/internal/tui/state"
+)
+
+// newWriteModel returns a model with --write enabled and a daemon
+// that has reported allow_mutations=true. Used by the modal-flow
+// tests below.
+func newWriteModel(t *testing.T) *Model {
+	t.Helper()
+	cli := client.New("http://example.invalid", time.Second, false)
+	m := New(cli, Options{NoColor: true, Write: true})
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = updated.(*Model)
+	updated, _ = m.Update(pollMutationStatusMsg{
+		s: client.MutationStatus{AllowMutations: true, EngineWritable: true},
+	})
+	return updated.(*Model)
+}
+
+func TestWriteAction_DisabledShowsToast(t *testing.T) {
+	cli := client.New("http://example.invalid", time.Second, false)
+	m := New(cli, Options{NoColor: true, Write: false})
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = updated.(*Model)
+	// Daemon disagrees too; WriteEnabled stays false.
+	updated, _ = m.Update(pollMutationStatusMsg{s: client.MutationStatus{AllowMutations: false}})
+	m = updated.(*Model)
+
+	req := state.WriteRequest{
+		Confirm: "test",
+		Label:   "test action",
+		Kind:    state.WriteKindEndCall,
+		EndCall: &state.EndCallReq{DeviceSerial: "abc"},
+	}
+	updated, cmd := m.Update(panels.WriteActionMsg{Request: req})
+	m = updated.(*Model)
+	if cmd != nil {
+		t.Errorf("disabled write should not yield a Cmd")
+	}
+	if m.confirm != nil {
+		t.Errorf("disabled write should not open modal")
+	}
+	if !strings.Contains(m.shared.Toast, "mutations disabled") {
+		t.Errorf("toast = %q", m.shared.Toast)
+	}
+}
+
+func TestWriteAction_OpensConfirmModal(t *testing.T) {
+	m := newWriteModel(t)
+	req := state.WriteRequest{
+		Confirm: "End call on device abc?",
+		Label:   "ended call on abc",
+		Kind:    state.WriteKindEndCall,
+		EndCall: &state.EndCallReq{DeviceSerial: "abc"},
+	}
+	updated, cmd := m.Update(panels.WriteActionMsg{Request: req})
+	m = updated.(*Model)
+	if m.confirm == nil {
+		t.Fatal("confirm modal not opened")
+	}
+	if !strings.Contains(m.confirm.prompt, "abc") {
+		t.Errorf("prompt = %q", m.confirm.prompt)
+	}
+	if cmd != nil {
+		t.Errorf("modal-pending request should defer Cmd, got non-nil")
+	}
+}
+
+func TestModal_EscCancels(t *testing.T) {
+	m := newWriteModel(t)
+	// Open a modal.
+	updated, _ := m.Update(panels.WriteActionMsg{Request: state.WriteRequest{
+		Confirm: "Sweep?",
+		Label:   "sweep",
+		Kind:    state.WriteKindSweepRetention,
+		SweepRetention: &state.SweepRetentionReq{},
+	}})
+	m = updated.(*Model)
+	if m.confirm == nil {
+		t.Fatal("modal not opened")
+	}
+	// ESC closes without firing.
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	m = updated.(*Model)
+	if m.confirm != nil {
+		t.Errorf("esc should clear modal")
+	}
+	if cmd != nil {
+		t.Errorf("esc should not yield a Cmd, got %T", cmd)
+	}
+	if !strings.Contains(m.shared.Toast, "cancel") {
+		t.Errorf("toast = %q", m.shared.Toast)
+	}
+}
+
+func TestModal_YConfirmsAndDispatches(t *testing.T) {
+	m := newWriteModel(t)
+	// Open a modal that resolves to an EndCall request — the
+	// dispatcher will build a Cmd for it. The Cmd will fail at
+	// runtime (no daemon at example.invalid) but we only assert
+	// that a Cmd is returned, not its result.
+	updated, _ := m.Update(panels.WriteActionMsg{Request: state.WriteRequest{
+		Confirm: "End?",
+		Label:   "ended",
+		Kind:    state.WriteKindEndCall,
+		EndCall: &state.EndCallReq{DeviceSerial: "abc"},
+	}})
+	m = updated.(*Model)
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(*Model)
+	if m.confirm != nil {
+		t.Errorf("enter should clear modal")
+	}
+	if cmd == nil {
+		t.Fatal("enter should yield a Cmd to fire the action")
+	}
+}
+
+func TestModal_SwallowsOtherKeys(t *testing.T) {
+	m := newWriteModel(t)
+	updated, _ := m.Update(panels.WriteActionMsg{Request: state.WriteRequest{
+		Confirm: "?", Label: "x",
+		Kind:           state.WriteKindSweepRetention,
+		SweepRetention: &state.SweepRetentionReq{},
+	}})
+	m = updated.(*Model)
+	before := m.active
+	// Pressing a digit (which would normally switch panels) is swallowed.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("5")})
+	m = updated.(*Model)
+	if m.active != before {
+		t.Errorf("modal should swallow panel-switch key; active changed %v->%v", before, m.active)
+	}
+	if m.confirm == nil {
+		t.Errorf("modal closed unexpectedly on '5'")
+	}
+}
+
+func TestWriteResult_TogglesPollRefresh(t *testing.T) {
+	m := newWriteModel(t)
+	updated, cmd := m.Update(writeResultMsg{Label: "test"})
+	m = updated.(*Model)
+	if cmd == nil {
+		t.Fatal("writeResultMsg should schedule refresh Cmds")
+	}
+	if !strings.Contains(m.shared.Toast, "test ok") {
+		t.Errorf("toast = %q", m.shared.Toast)
+	}
+}

--- a/internal/tui/msgs.go
+++ b/internal/tui/msgs.go
@@ -58,3 +58,16 @@ type sseUpMsg struct {
 
 // errToastMsg displays a transient error in the status bar.
 type errToastMsg struct{ msg string }
+
+// writeResultMsg carries the outcome of a write Cmd.
+type writeResultMsg struct {
+	Label string
+	Err   error
+}
+
+// pollMutationStatusMsg fetches /api/v1/mutations once at startup
+// to set shared.Mutations + WriteEnabled.
+type pollMutationStatusMsg struct {
+	s   client.MutationStatus
+	err error
+}

--- a/internal/tui/panels/active.go
+++ b/internal/tui/panels/active.go
@@ -23,10 +23,36 @@ func NewActive() *ActivePanel {
 	return &ActivePanel{tbl: t}
 }
 
-func (ActivePanel) Title() string       { return "Active calls" }
-func (ActivePanel) Keys() []key.Binding { return nil }
+func (ActivePanel) Title() string { return "Active calls" }
+
+var activeEndKey = key.NewBinding(key.WithKeys("e"), key.WithHelp("e", "end call"))
+
+func (ActivePanel) Keys() []key.Binding { return []key.Binding{activeEndKey} }
+
+func (p *ActivePanel) selectedCall(s *state.SharedState) (client.ActiveCallDTO, bool) {
+	idx := p.tbl.Cursor()
+	if idx < 0 || idx >= len(s.ActiveCalls) {
+		return client.ActiveCallDTO{}, false
+	}
+	return s.ActiveCalls[idx], true
+}
 
 func (p *ActivePanel) Update(msg tea.Msg, s *state.SharedState) (Panel, tea.Cmd) {
+	if km, ok := msg.(tea.KeyMsg); ok {
+		if key.Matches(km, activeEndKey) {
+			ac, found := p.selectedCall(s)
+			if !found {
+				return p, nil
+			}
+			req := state.WriteRequest{
+				Confirm: fmt.Sprintf("End call on device %s (TG %d)?", ac.DeviceSerial, ac.Grant.GroupID),
+				Label:   "ended call on " + ac.DeviceSerial,
+				Kind:    state.WriteKindEndCall,
+				EndCall: &state.EndCallReq{DeviceSerial: ac.DeviceSerial, Reason: "manual"},
+			}
+			return p, Emit(req)
+		}
+	}
 	// Refresh on every update — the polling cadence is 1 s and the
 	// table is small.
 	p.refresh(s.ActiveCalls)

--- a/internal/tui/panels/metrics.go
+++ b/internal/tui/panels/metrics.go
@@ -41,10 +41,22 @@ func NewMetrics() *MetricsPanel {
 	return &MetricsPanel{tbl: t}
 }
 
-func (MetricsPanel) Title() string       { return "Metrics" }
-func (MetricsPanel) Keys() []key.Binding { return nil }
+func (MetricsPanel) Title() string { return "Metrics" }
+
+var metricsSweepKey = key.NewBinding(key.WithKeys("S"), key.WithHelp("S", "retention sweep"))
+
+func (MetricsPanel) Keys() []key.Binding { return []key.Binding{metricsSweepKey} }
 
 func (p *MetricsPanel) Update(msg tea.Msg, s *state.SharedState) (Panel, tea.Cmd) {
+	if km, ok := msg.(tea.KeyMsg); ok && key.Matches(km, metricsSweepKey) {
+		req := state.WriteRequest{
+			Confirm:        "Run a retention sweep now?",
+			Label:          "retention sweep",
+			Kind:           state.WriteKindSweepRetention,
+			SweepRetention: &state.SweepRetentionReq{},
+		}
+		return p, Emit(req)
+	}
 	p.refresh(s.Metrics)
 	var cmd tea.Cmd
 	p.tbl, cmd = p.tbl.Update(msg)

--- a/internal/tui/panels/talkgroups.go
+++ b/internal/tui/panels/talkgroups.go
@@ -59,13 +59,36 @@ func NewTalkgroups() *TalkgroupsPanel {
 func (TalkgroupsPanel) Title() string { return "Talkgroups" }
 
 var (
-	tgFilterKey = key.NewBinding(key.WithKeys("/"), key.WithHelp("/", "filter"))
-	tgSortKey   = key.NewBinding(key.WithKeys("s"), key.WithHelp("s", "sort"))
-	tgEscKey    = key.NewBinding(key.WithKeys("esc"), key.WithHelp("esc", "exit filter"))
+	tgFilterKey   = key.NewBinding(key.WithKeys("/"), key.WithHelp("/", "filter"))
+	tgSortKey     = key.NewBinding(key.WithKeys("s"), key.WithHelp("s", "sort"))
+	tgEscKey      = key.NewBinding(key.WithKeys("esc"), key.WithHelp("esc", "exit filter"))
+	tgLockoutKey  = key.NewBinding(key.WithKeys("l"), key.WithHelp("l", "toggle lockout"))
+	tgPriUpKey    = key.NewBinding(key.WithKeys("+", "="), key.WithHelp("+", "priority up"))
+	tgPriDownKey  = key.NewBinding(key.WithKeys("-", "_"), key.WithHelp("-", "priority down"))
 )
 
 func (TalkgroupsPanel) Keys() []key.Binding {
-	return []key.Binding{tgFilterKey, tgSortKey}
+	return []key.Binding{tgFilterKey, tgSortKey, tgLockoutKey, tgPriUpKey, tgPriDownKey}
+}
+
+// selectedTalkgroup returns the currently-highlighted row's
+// underlying TalkgroupDTO, respecting the active filter+sort.
+func (p *TalkgroupsPanel) selectedTalkgroup(tgs []client.TalkgroupDTO) (client.TalkgroupDTO, bool) {
+	idx := p.tbl.Cursor()
+	rows := p.tbl.Rows()
+	if idx < 0 || idx >= len(rows) {
+		return client.TalkgroupDTO{}, false
+	}
+	// First column is the ID as a string. Map back to the source
+	// slice; refresh() never re-orders without invalidating the
+	// table, so this is safe.
+	idStr := rows[idx][0]
+	for _, tg := range tgs {
+		if fmt.Sprintf("%d", tg.ID) == idStr {
+			return tg, true
+		}
+	}
+	return client.TalkgroupDTO{}, false
 }
 
 // FilterValue exposes the current filter for testing.
@@ -106,6 +129,47 @@ func (p *TalkgroupsPanel) Update(msg tea.Msg, s *state.SharedState) (Panel, tea.
 			p.lastSort = -1 // force refresh
 			p.refresh(s.Talkgroups)
 			return p, nil
+		case key.Matches(m, tgLockoutKey):
+			tg, ok := p.selectedTalkgroup(s.Talkgroups)
+			if !ok {
+				return p, nil
+			}
+			next := !tg.Lockout
+			req := state.WriteRequest{
+				// No confirmation — toggling lockout is reversible.
+				Label: fmt.Sprintf("set lockout=%v on TG %d", next, tg.ID),
+				Kind:  state.WriteKindUpdateTalkgroup,
+				UpdateTalkgroup: &state.UpdateTalkgroupReq{
+					ID:      tg.ID,
+					Lockout: &next,
+				},
+			}
+			return p, Emit(req)
+		case key.Matches(m, tgPriUpKey), key.Matches(m, tgPriDownKey):
+			tg, ok := p.selectedTalkgroup(s.Talkgroups)
+			if !ok {
+				return p, nil
+			}
+			delta := 1
+			if key.Matches(m, tgPriDownKey) {
+				delta = -1
+			}
+			next := tg.Priority + delta
+			if next < 0 {
+				next = 0
+			}
+			if next > 99 {
+				next = 99
+			}
+			req := state.WriteRequest{
+				Label: fmt.Sprintf("set priority=%d on TG %d", next, tg.ID),
+				Kind:  state.WriteKindUpdateTalkgroup,
+				UpdateTalkgroup: &state.UpdateTalkgroupReq{
+					ID:       tg.ID,
+					Priority: &next,
+				},
+			}
+			return p, Emit(req)
 		}
 	}
 	if p.lastCount != len(s.Talkgroups) || p.lastSort != p.sortBy || p.lastQuery != p.filter.Value() {

--- a/internal/tui/panels/tones.go
+++ b/internal/tui/panels/tones.go
@@ -24,10 +24,38 @@ func NewTones() *TonesPanel {
 	return &TonesPanel{tbl: t}
 }
 
-func (TonesPanel) Title() string       { return "Tone alerts" }
-func (TonesPanel) Keys() []key.Binding { return nil }
+func (TonesPanel) Title() string { return "Tone alerts" }
+
+var toneResetKey = key.NewBinding(key.WithKeys("R"), key.WithHelp("R", "reset detector"))
+
+func (TonesPanel) Keys() []key.Binding { return []key.Binding{toneResetKey} }
+
+// selectedDevice extracts the device serial of the currently
+// highlighted row, returning ("", false) when the table is empty.
+func (p *TonesPanel) selectedDevice() (string, bool) {
+	idx := p.tbl.Cursor()
+	rows := p.tbl.Rows()
+	if idx < 0 || idx >= len(rows) {
+		return "", false
+	}
+	// Column 2 is "Device" per toneColumns.
+	return rows[idx][2], true
+}
 
 func (p *TonesPanel) Update(msg tea.Msg, s *state.SharedState) (Panel, tea.Cmd) {
+	if km, ok := msg.(tea.KeyMsg); ok && key.Matches(km, toneResetKey) {
+		serial, ok := p.selectedDevice()
+		if !ok {
+			return p, nil
+		}
+		req := state.WriteRequest{
+			Confirm: fmt.Sprintf("Reset tone-out match progress on device %s?", serial),
+			Label:   "reset tone detector for " + serial,
+			Kind:    state.WriteKindResetTone,
+			ResetTone: &state.ResetToneReq{DeviceSerial: serial},
+		}
+		return p, Emit(req)
+	}
 	if s.ToneAlerts != nil && s.ToneAlerts.Len() != p.last {
 		p.refresh(s)
 	}

--- a/internal/tui/panels/write.go
+++ b/internal/tui/panels/write.go
@@ -1,0 +1,21 @@
+package panels
+
+import (
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/MattCheramie/GopherTrunk/internal/tui/state"
+)
+
+// WriteActionMsg is what panels emit to ask the root model to run
+// a mutation. The root catches this exact type, so panels stay
+// decoupled from the root's modal mechanics and HTTP client.
+//
+// Exported so tests in other packages can assert on it; intended
+// to be opaque to consumers.
+type WriteActionMsg struct{ Request state.WriteRequest }
+
+// Emit returns a tea.Cmd that delivers the WriteActionMsg to the
+// root model.
+func Emit(r state.WriteRequest) tea.Cmd {
+	return func() tea.Msg { return WriteActionMsg{Request: r} }
+}

--- a/internal/tui/state/state.go
+++ b/internal/tui/state/state.go
@@ -75,4 +75,68 @@ type SharedState struct {
 	LastPoll time.Time
 	Toast    string
 	Server   string
+
+	// Write capability — populated at startup from the daemon's
+	// /api/v1/mutations endpoint AND-ed with the TUI's --write
+	// flag. Panels read this to decide whether write keybindings
+	// should fire actions or show a "mutations disabled" toast.
+	WriteEnabled bool
+	// Mutations exposes per-subsystem capability so panels can
+	// show finer-grained tooltips (e.g. "tone-out detector not
+	// wired" vs "mutations disabled at daemon").
+	Mutations client.MutationStatus
+}
+
+// WriteRequest is a plain-value command emitted by panels when the
+// operator presses a mutation keybinding. The root model unwraps
+// the embedded request type, optionally pops a confirmation modal,
+// and dispatches the matching client method.
+//
+// Panels can't build the write Cmds themselves (they don't hold a
+// client.Client), so the request shape is a typed value the root
+// resolves. Each request kind has its own struct so the root's
+// type switch is exhaustive.
+type WriteRequest struct {
+	Confirm string
+	Label   string
+	Kind    WriteKind
+
+	EndCall         *EndCallReq
+	UpdateTalkgroup *UpdateTalkgroupReq
+	SweepRetention  *SweepRetentionReq
+	ResetTone       *ResetToneReq
+}
+
+// WriteKind discriminates a WriteRequest's payload.
+type WriteKind int
+
+const (
+	WriteKindUnknown WriteKind = iota
+	WriteKindEndCall
+	WriteKindUpdateTalkgroup
+	WriteKindSweepRetention
+	WriteKindResetTone
+)
+
+// EndCallReq forces the engine to release the active call held on
+// the given device.
+type EndCallReq struct {
+	DeviceSerial string
+	Reason       string // optional; "" means "manual"
+}
+
+// UpdateTalkgroupReq mutates priority and/or lockout on a talkgroup.
+// Pointer fields allow "leave unchanged" semantics.
+type UpdateTalkgroupReq struct {
+	ID       uint32
+	Priority *int
+	Lockout  *bool
+}
+
+// SweepRetentionReq runs one immediate retention sweep.
+type SweepRetentionReq struct{}
+
+// ResetToneReq clears tone-out match progress on the given device.
+type ResetToneReq struct {
+	DeviceSerial string
 }


### PR DESCRIPTION
## Summary

Wires up the operator mutation actions that the read-only TUI (#28) explicitly deferred. Five surfaces become writable when the daemon is started with `api.allow_mutations: true` AND the TUI is started with `--write`:

| Panel | Key | Action |
| --- | --- | --- |
| Active calls | `e` | End the highlighted call (confirm) |
| Talkgroups | `l` | Toggle lockout (no confirm — reversible) |
| Talkgroups | `+` / `-` | Adjust priority 0–99 (no confirm) |
| Tone alerts | `R` | Reset tone-out match progress on the highlighted device (confirm) |
| Metrics | `S` | Run a retention sweep now (confirm) |

The two sides gate independently because the HTTP API has no authentication. Either gate being off keeps mutations off; turning the daemon flag on without `--write` still won't fire keys.

## Daemon side

- **New endpoints** in `internal/api/handlers_mutations.go`:
  - `GET /api/v1/mutations` — capability probe (always 200, never gated)
  - `POST /api/v1/calls/{deviceSerial}/end` body `{"reason":"manual"}`
  - `PATCH /api/v1/talkgroups/{id}` body `{"priority":3,"lockout":true}` (both optional, supply at least one)
  - `POST /api/v1/retention/sweep`
  - `POST /api/v1/devices/{serial}/tone-reset`
- **`gate()` middleware** in `internal/api/server.go` short-circuits with 403 + `{"error":"mutations disabled (set api.allow_mutations: true to enable)"}` when the flag is off. Read endpoints are unaffected.
- **`api.allow_mutations`** added to `APIConfig` (zero-value = off). Wired through `daemon.go` to `ServerOptions`. Documented in `config.example.yaml`.
- **Engine / Retention / Tones interfaces** added to `ServerOptions` (`EngineMutator`, `RetentionSweeper`, `ToneDetectorReset`) so the api package stays decoupled from the concrete impls. Daemon supplies the real ones; tests inject fakes.
- **`trunking.TalkgroupDB.UpdateFields(id, fn)`** for in-place priority/lockout edits under the existing write lock; complements the bulk-only `Add`. New `Delete(id)` helper too, in case a future PR wants single-record removal.
- **`trunking.EndReasonManual`** added so `CallEnd` events expose the operator-triggered case as `reason="manual"`.

## TUI side

- **Write client** (`internal/tui/client/write.go`): `EndCall`, `UpdateTalkgroup`, `SweepRetention`, `ResetToneDevice`, `MutationStatus`. JSON encode/decode + the existing `*HTTPError` mapping. `MutationStatus` swallows 404 so older daemons that don't recognise the route present as "mutations off".
- **Confirm modal** (`internal/tui/modal.go`): centred lipgloss box with red border. Captures keyboard focus until y/Enter (run) or n/Esc (cancel). Non-modal keys are swallowed while it's up so digit-jumps and table navigation don't leak through.
- **`state.WriteRequest`** is a plain-value command panels emit via `panels.Emit(req)`; the root model unwraps the discriminated union and dispatches the matching write Cmd. Panels stay decoupled from the HTTP client and the modal mechanics.
- **`--write` CLI flag** (`cmd/gophertrunk/tui.go`); without it, mutation keys hit the gate and toast "mutations disabled".
- **WriteEnabled** in SharedState is the AND of `--write` and the daemon's reported `allow_mutations`. Per-subsystem capability (engine / retention / tones) is also stored so a future PR can dim individual keys when their backend isn't wired.
- **Auto-refresh** after a successful mutation: the root model immediately re-fires `cmdPollActive` and `cmdPollTalkgroups` so the table updates without waiting for the next poll tick.

## Tests

- `internal/api/handlers_mutations_test.go` — gate-off returns 403 for all four routes; capability probe is always 200; end-call invokes the engine with the right reason; PATCH applies priority+lockout and rejects empty bodies; retention sweep counts invocations and 503s when unwired; tone reset records the serial. Plus a unit test for `TalkgroupDB.UpdateFields` / `Delete`.
- `internal/tui/client/write_test.go` — body shape for each method, omits-nil-fields for PATCH, requires-at-least-one-field guard, 403 surfaces typed `*HTTPError`, MutationStatus 404→zero.
- `internal/tui/modal_test.go` — write-disabled toast, modal opens on confirm-required request, Esc cancels without firing, Enter confirms and yields a Cmd, modal swallows other keys, writeResultMsg toasts and schedules refresh Cmds.

## Test plan

- [x] `go build ./...` and `go vet ./...` clean
- [x] `go test -race -count=1 ./...` — all packages pass
- [x] `make integration` — daemon end-to-end suite still passes
- [ ] Manual smoke: bring up the daemon with `allow_mutations: true`, run `gophertrunk tui --write`, exercise each binding against an active call / known talkgroup
- [ ] Verify 403 from a curl when `allow_mutations: false`

## Out of scope

- Authentication on the HTTP API. The gate is a safety mechanism, not auth — anyone who can reach the listener can call mutations once it's open. Adding auth (token middleware? mTLS?) is a bigger lift and a separate PR.
- A second confirmation step for irreversible mutations. The current modal is a single yes/no; if operators want a typed confirmation ("type END to continue") that's an easy follow-up.

https://claude.ai/code/session_01MQSV8EVnH6nsGUpcWep7UF


---
_Generated by [Claude Code](https://claude.ai/code/session_01MQSV8EVnH6nsGUpcWep7UF)_