### PR TITLE
Re-add per-PR Windows installer workflow

### DIFF
--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -1,0 +1,113 @@
+name: Windows installer (PR)
+
+# Builds the Windows installer (.exe) on every pull request so
+# regressions in the cgo build, the bundled DLL set, or the Inno
+# Setup script surface before merge — not at the next release tag.
+#
+# This intentionally mirrors the windows job in release.yml rather
+# than sharing one. The release job is tightly coupled to tag-shaped
+# version strings and to the artifact layout the Release page
+# expects; PR builds use a synthetic version and only upload the
+# installer .exe (not the portable ZIP), so duplication is cheaper
+# than the abstraction.
+#
+# Concurrency cancels any in-flight run for the same PR when a new
+# commit is pushed, so quick rebases don't burn idle Windows runner
+# minutes.
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+
+concurrency:
+  group: installer-pr-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  installer:
+    name: Build Windows installer
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Compute version
+        id: version
+        shell: bash
+        run: |
+          # Synthetic version for PR builds: pr-<number>-<short-sha>.
+          # Filename-safe; gets stamped into the binary's version
+          # string and the installer's AppVersion.
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            SHA=$(echo "${{ github.event.pull_request.head.sha }}" | cut -c1-7)
+            echo "version=pr-${{ github.event.pull_request.number }}-${SHA}" >> "$GITHUB_OUTPUT"
+          else
+            SHA=$(echo "${GITHUB_SHA}" | cut -c1-7)
+            echo "version=manual-${SHA}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64
+          update: true
+          install: >-
+            git
+            mingw-w64-x86_64-toolchain
+            mingw-w64-x86_64-pkgconf
+            mingw-w64-x86_64-rtl-sdr
+            mingw-w64-x86_64-libusb
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+
+      - name: Build gophertrunk.exe
+        env:
+          CGO_ENABLED: "1"
+          CC: x86_64-w64-mingw32-gcc
+        run: |
+          export PATH="/mingw64/bin:$PATH"
+          VERSION="${{ steps.version.outputs.version }}"
+          mkdir -p dist/staging
+          go build \
+            -trimpath \
+            -ldflags "-X github.com/MattCheramie/GopherTrunk/internal/version.Version=${VERSION}" \
+            -o dist/staging/gophertrunk.exe \
+            ./cmd/gophertrunk
+
+      - name: Bundle DLLs and docs
+        run: |
+          set -eu
+          STAGE=dist/staging
+          for dll in \
+            librtlsdr.dll \
+            libusb-1.0.dll \
+            libwinpthread-1.dll \
+            libgcc_s_seh-1.dll
+          do
+            if [ -f "/mingw64/bin/$dll" ]; then
+              cp "/mingw64/bin/$dll" "$STAGE/"
+            else
+              echo "warning: $dll not found in MINGW64 bin"
+            fi
+          done
+          cp README.md LICENSE config.example.yaml "$STAGE/"
+          cp docs/install-windows.md "$STAGE/INSTALL-WINDOWS.md"
+
+      - name: Build Inno Setup installer
+        uses: Minionguyjpro/Inno-Setup-Action@v1.2.5
+        with:
+          path: installer/windows/gophertrunk.iss
+          options: /DAppVersion=${{ steps.version.outputs.version }} /Qp
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: windows-installer-${{ steps.version.outputs.version }}
+          path: dist/*setup.exe
+          retention-days: 14
+          if-no-files-found: error

--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -55,6 +55,11 @@ jobs:
         with:
           msystem: MINGW64
           update: true
+          # Inherit the runner's Windows PATH so the Go binary
+          # placed by actions/setup-go is visible inside the msys2
+          # shell (default `minimal` strips it and `go build` fails
+          # with "command not found").
+          path-type: inherit
           install: >-
             git
             mingw-w64-x86_64-toolchain

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,10 @@ jobs:
         with:
           msystem: MINGW64
           update: true
+          # Inherit the runner's Windows PATH so the Go binary
+          # placed by actions/setup-go is visible inside the msys2
+          # shell (default `minimal` strips it).
+          path-type: inherit
           install: >-
             git
             zip


### PR DESCRIPTION
## Summary

Re-adds the per-PR Windows installer workflow. I'd added this on the read-only-TUI branch in commit `1f3e3ae`, but it was dropped during PR #28's merge into `main` — so it never ran on later PRs (which is why no installer check-runs appeared on PR #29).

The workflow mirrors the `windows` job in `release.yml` rather than sharing one. The release job is tightly coupled to tag-shaped version strings and the artifact layout the Release page expects; PR-time builds use a synthetic `pr-<num>-<sha>` version and only upload the installer `.exe` (not the portable ZIP — `release.yml` owns that for tagged releases), so the duplication is cheaper than the abstraction.

## What it does

- Triggers: `pull_request` (opened/synchronize/reopened) + manual `workflow_dispatch`
- Runner: `windows-latest` with the MSYS2/MINGW64 toolchain, exactly matching `release.yml`
- Builds `gophertrunk.exe` with cgo, bundles librtlsdr + libusb DLLs, runs Inno Setup
- Version stamp: `pr-<number>-<short-sha>` (filename-safe, unique per PR head)
- Uploads `dist/*setup.exe` as a 14-day artifact; `if-no-files-found: error` so a silent installer-script break still fails the run
- `concurrency: installer-pr-<num>` with `cancel-in-progress` so a quick rebase cancels the prior Windows job (those runners aren't free)

## What it deliberately doesn't do

- No portable ZIP — `release.yml` owns that for tagged releases
- No release publication — PR builds aren't releases
- No `paths-ignore` filter — runs on every PR per the original ask, even doc-only ones (let me know if you want me to add `paths-ignore: ['**.md', 'docs/**']` later to save runner time)

## Test plan

- [x] YAML syntax-checked locally (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] Once this PR is open, the workflow itself will run on this PR — that's the canonical green-or-red test. If it fails, the failure logs will be visible from the Actions tab and I'll iterate

https://claude.ai/code/session_01MQSV8EVnH6nsGUpcWep7UF


---
_Generated by [Claude Code](https://claude.ai/code/session_01MQSV8EVnH6nsGUpcWep7UF)_