### PR TITLE
NXDN SACCH FEC: K=5 ½-rate Viterbi + sub-frame interleaver + CRC-6

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ gRPC, HTTP/SSE, or WebSocket.
 | ----------------- | ---------------------------------------------------------- |
 | Hardware          | CGO `librtlsdr` binding, multi-device pool, role assignment, per-device gain (`auto` / tenths-of-dB) + PPM + bias-tee (5 V LNA power, e.g. NESDR Smart v5) applied at open time, DC blocker, IQ-imbalance correction, file-backed IQ replay (mock) |
 | DSP               | Polyphase channelizer, FIR + Kaiser LPF designer + RRC, CIC, halfband, AGC, rational resampler, FM / C4FM / H-DQPSK demods, Mueller-Müller clock recovery, frame-sync correlator |
-| FEC primitives    | CRC-CCITT/FALSE, Hamming(15,11,3), Hamming(13,9,3), Hamming(20,8) (DMR slot-type, t=3), extended Golay(24,12,8), BCH(63,16,11), BPTC(196,96), 4-state ½-rate Viterbi |
+| FEC primitives    | CRC-CCITT/FALSE, CRC-6 (NXDN SACCH), Hamming(15,11,3), Hamming(13,9,3), Hamming(20,8) (DMR slot-type, t=3), extended Golay(24,12,8), BCH(63,16,11), BPTC(196,96), 4-state ½-rate Viterbi, 16-state K=5 ½-rate Viterbi (NXDN SACCH) |
 | P25 Phase 1       | 48-bit FSW + sync detector, NID parser (NAC + DUID) with BCH(63,16,11) error correction + even-parity check, full TSBK channel decode (TIA-102.BAAA Annex A 4-state ½-rate trellis + 98-dibit block deinterleaver) → CRC trailer validation, payload parsers for GroupVoiceChannelGrant / Update / NetworkStatus / RFSSStatus, control-channel state machine emitting `decode.error` events with `nid-bch` / `tsbk-trellis` / `tsbk-crc` stages |
 | P25 Phase 2       | Outbound + inbound 20-dibit sync, 360 ms / 12-subframe superframe + SlotType enum, MAC PDU parser + opcode enum, GroupVoiceChannelGrant accessor, control-channel state machine emitting `protocol = "p25-phase2"` grants |
 | DMR (Tier III)    | All 9 ETSI sync patterns, burst layout (132 dibits), Color Code + Data Type via (20,8,7) shortened-Hamming slot-type FEC (corrects up to 3 bit errors per slot type), CSBK with CRC, payload parsers for TalkGroup/Private Voice grants + Aloha + AdjacentSiteStatus + SystemInfoBroadcast, control-channel state machine |
-| NXDN              | 192-dibit frame layout (4800 BFSK / 9600 4-FSK), LICH parse with parity + 16-bit doubled-wire decoder, FSW correlator, CAC parser with CRC, RCCH opcode enum + payload parsers, control-channel state machine |
+| NXDN              | 192-dibit frame layout (4800 BFSK / 9600 4-FSK), LICH parse with parity + 16-bit doubled-wire decoder, FSW correlator, full SACCH channel decode (K=5 ½-rate convolutional Viterbi + 60-position sub-frame deinterleaver + 12-bit puncture undo + CRC-6 trailer), CAC parser with CRC, RCCH opcode enum + payload parsers, control-channel state machine |
 | Motorola Type II  | OSW parser, opcode constants, LCN → Hz band-plan resolver (linear + table), control-channel state machine emitting `protocol = "motorola"` grants |
 | EDACS / GE-Marc   | 40-bit CCW parser, command enum (Idle / GroupVoiceGrant / ProVoiceGrant / IndividualCall / DataGrant / SystemID / AdjacentSite / Emergency / Affiliation / Encryption), per-command accessors with encrypted / emergency flags, LCN → Hz resolver, control-channel state machine emitting `protocol = "edacs"` grants |
 | LTR               | 41-bit per-repeater Status word parser, Channel → Hz resolver, optional area filter, per-repeater state machine emitting `protocol = "ltr"` grants when a status indicates an active call |
@@ -58,7 +58,6 @@ SQLite. The honest gaps:
 - **DMR Tier II** is mostly a configuration variation on the Tier
   III scaffolding that's already in place; both share the burst,
   slot-type, and BPTC pieces.
-- **NXDN** wants the SACCH FEC + sub-frame interleaver.
 - **Digital voice** (P25 Phase 1 IMBE; AMBE+2 for P25 Phase 2 / DMR
   / NXDN) is gated on the vocoders. The `Vocoder` plugin interface
   + raw-frame sidecar are in place; pure-Go IMBE is in progress
@@ -100,12 +99,6 @@ to its own package and lands independently.
   polyphase resampling, and skips de-emphasis + post-demod LPF +
   AGC. Quality is good enough to verify wiring; this is real DSP
   polish for production audio.
-- **Live-CC bring-up FEC pieces.** Remaining: NXDN SACCH FEC +
-  sub-frame interleaver. (P25 Phase 1 NID BCH(63,16,11), TIA-102
-  Annex-A trellis + 98-dibit TSBK block interleaver, and DMR
-  slot-type Hamming(20,8) are all wired and publishing
-  `decode.error` events with stage-name labels through to
-  Prometheus.)
 
 ## Tech stack
 

--- a/internal/radio/nxdn/sacch.go
+++ b/internal/radio/nxdn/sacch.go
@@ -1,0 +1,326 @@
+package nxdn
+
+import (
+	"errors"
+	"fmt"
+)
+
+// NXDN Slow Associated Control Channel (SACCH) channel coding, per
+// NXDN Forum technical specification rev 1.4 §6.6 (cross-checked
+// against MMDVMHost NXDNSACCH.cpp).
+//
+// The SACCH carries per-frame signaling on RTCH/RDCH frames. Each
+// transmitted SACCH block is 60 bits, produced from 32 information
+// bits (26 payload + 6-bit CRC trailer) as follows:
+//
+//	32-bit info  (26 payload bits + 6-bit CRC over those 26)
+//	      │  append 4 zero tail bits
+//	      ▼
+//	36-bit input
+//	      │  K=5 1/2-rate convolutional encode (g1=0o31, g2=0o27)
+//	      ▼
+//	72 channel bits
+//	      │  drop 12 puncture positions
+//	      ▼
+//	60 bits
+//	      │  sub-frame interleave (60-position permutation)
+//	      ▼
+//	60 bits transmitted on-air
+//
+// The receive pipeline runs the inverse: deinterleave → depuncture
+// (fill punctured positions with a sentinel that contributes zero cost
+// in the Viterbi metric) → Viterbi decode 36 stages with end-state
+// constrained to 0 → strip the 4 tail bits → CRC-6 verify the 32-bit
+// info block.
+//
+// Tables sourced from MMDVMHost (NXDNConvolution.cpp, NXDNSACCH.cpp)
+// and f4exb/dsdcc (nxdn.cpp). The SACCH FEC parameters were
+// cross-checked against the published NXDN technical specification.
+
+// SACCHChannelBits is the number of bits transmitted per SACCH block.
+const SACCHChannelBits = 60
+
+// SACCHInfoBits is the number of information bits per SACCH block
+// (26 payload + 6 CRC trailer). Tail bits are an internal detail.
+const SACCHInfoBits = 32
+
+// sacchTailBits is the number of zero tail bits appended to the info
+// before convolutional encoding so the encoder ends in state 0 and the
+// receiver's Viterbi can use the terminal-state constraint.
+const sacchTailBits = 4
+
+// sacchPayloadBits is the number of bits the CRC-6 trailer protects
+// (the first 26 bits of the 32-bit info block).
+const sacchPayloadBits = 26
+
+// sacchInterleavePerm[i] = j means channel[i] = punctured[j] on the
+// encoder side. Equivalently, depunctured[j] = received[i] on the
+// decoder side after deinterleaving via the inverse permutation.
+//
+// Sourced from f4exb/dsdcc nxdn.cpp DSDNXDN::SACCH::m_Interleave[60].
+var sacchInterleavePerm = [60]int{
+	0, 12, 24, 36, 48,
+	1, 13, 25, 37, 49,
+	2, 14, 26, 38, 50,
+	3, 15, 27, 39, 51,
+	4, 16, 28, 40, 52,
+	5, 17, 29, 41, 53,
+	6, 18, 30, 42, 54,
+	7, 19, 31, 43, 55,
+	8, 20, 32, 44, 56,
+	9, 21, 33, 45, 57,
+	10, 22, 34, 46, 58,
+	11, 23, 35, 47, 59,
+}
+
+// sacchPuncturePositions are the indexes (within the 80-bit pre-
+// puncture stream) of the bits that get DROPPED to produce the 60-bit
+// transmitted block. Sourced from dsdcc m_PunctureList[12].
+var sacchPuncturePositions = [12]int{5, 11, 17, 23, 29, 35, 41, 47, 53, 59, 65, 71}
+
+// nxdn K=5 1/2-rate convolutional code generators (NXDN spec §6.6.2).
+//
+//	g1(D) = 1 + D^3 + D^4   (octal 31, hex 0x19)
+//	g2(D) = 1 + D + D^2 + D^4 (octal 27, hex 0x17)
+//
+// See MMDVMHost NXDNConvolution::encode.
+const (
+	nxdnConvG1 = 0x19
+	nxdnConvG2 = 0x17
+)
+
+// EncodeSACCH turns 32 information bits into the 60-bit SACCH channel
+// block. The input slice is bits (each entry 0/1), output is the same.
+// Useful for synthetic test streams.
+func EncodeSACCH(info []byte) []byte {
+	if len(info) != SACCHInfoBits {
+		panic(fmt.Sprintf("nxdn: SACCH info must be %d bits, got %d", SACCHInfoBits, len(info)))
+	}
+	const inputLen = SACCHInfoBits + sacchTailBits // 36 input bits
+	const preLen = inputLen * 2                    // 72 channel bits before puncturing
+	pre := make([]byte, preLen)
+	state := 0
+	for i := 0; i < inputLen; i++ {
+		var d byte
+		if i < SACCHInfoBits {
+			d = info[i] & 1
+		} // tail bits are zero by default
+		d1 := (state >> 3) & 1
+		d2 := (state >> 2) & 1
+		d3 := (state >> 1) & 1
+		d4 := state & 1
+		g1 := byte(int(d) ^ d3 ^ d4) & 1
+		g2 := byte(int(d) ^ d1 ^ d2 ^ d4) & 1
+		pre[2*i] = g1
+		pre[2*i+1] = g2
+		state = (int(d) << 3) | (d1 << 2) | (d2 << 1) | d3
+	}
+	punctured := puncture(pre)
+	out := make([]byte, SACCHChannelBits)
+	for i := 0; i < SACCHChannelBits; i++ {
+		out[i] = punctured[sacchInterleavePerm[i]]
+	}
+	return out
+}
+
+// ErrSACCHCRCFail is returned by DecodeSACCH when the K=5 Viterbi
+// decode succeeds structurally but the 6-bit CRC trailer does not
+// match the recovered payload — the corrected bits are still returned
+// so callers can log the rejected message.
+var ErrSACCHCRCFail = errors.New("nxdn: SACCH CRC-6 mismatch")
+
+// DecodeSACCH runs deinterleave → depuncture → Viterbi → CRC-6 over
+// the 60 received channel bits and returns the 36 decoded information
+// bits, the Viterbi path metric (sum of dibit-distance penalties; 0
+// means clean), and an error chained from ErrSACCHCRCFail if the CRC
+// trailer doesn't match.
+func DecodeSACCH(channel []byte) ([]byte, int, error) {
+	if len(channel) != SACCHChannelBits {
+		return nil, -1, fmt.Errorf("nxdn: SACCH channel must be %d bits, got %d", SACCHChannelBits, len(channel))
+	}
+	// Inverse interleave: punctured[perm[i]] = channel[i].
+	punctured := make([]byte, SACCHChannelBits)
+	for i := 0; i < SACCHChannelBits; i++ {
+		punctured[sacchInterleavePerm[i]] = channel[i]
+	}
+	pre := depuncture(punctured)
+	const stages = SACCHInfoBits + sacchTailBits // 36 Viterbi stages
+	allBits, metric := viterbiK5(pre, stages)
+	out := allBits[:SACCHInfoBits]
+	// CRC-6 over the first 26 bits = 18 SR + ... payload preceding the
+	// CRC trailer (per NXDN Single SACCH layout). We don't dictate
+	// payload semantics here; the caller selects which prefix to CRC.
+	if !VerifySACCHCRC6(out) {
+		return out, metric, ErrSACCHCRCFail
+	}
+	return out, metric, nil
+}
+
+// depunctureMark is the sentinel byte stored at puncture positions in
+// the depunctured stream. The K=5 Viterbi treats it as "no information"
+// — neither expected output value contributes path-metric cost — so the
+// surviving path is determined entirely by the other 60 received bits.
+const depunctureMark byte = 0xFF
+
+// puncture drops 12 fixed positions from the first 72 of the 80-bit
+// encoded stream, plus the trailing 8 tail bits (the encoder ends in
+// state 0 so the receiver can re-introduce them as zeros). Output: 60
+// transmitted bits.
+func puncture(in []byte) []byte {
+	out := make([]byte, 0, SACCHChannelBits)
+	punc := 0
+	for i := 0; i < 72; i++ {
+		if punc < len(sacchPuncturePositions) && sacchPuncturePositions[punc] == i {
+			punc++
+			continue
+		}
+		out = append(out, in[i])
+	}
+	return out
+}
+
+// depuncture is the receive-side inverse: insert "no-info" markers at
+// the 12 puncture positions to produce 72 bits the Viterbi decoder
+// consumes as 36 stages.
+func depuncture(in []byte) []byte {
+	out := make([]byte, 72)
+	src := 0
+	punc := 0
+	for i := 0; i < 72; i++ {
+		if punc < len(sacchPuncturePositions) && sacchPuncturePositions[punc] == i {
+			out[i] = depunctureMark
+			punc++
+			continue
+		}
+		out[i] = in[src]
+		src++
+	}
+	return out
+}
+
+// viterbiK5 runs hard-decision Viterbi over a K=5 1/2-rate
+// convolutional code with NXDN's polynomials. Input is `2*stages`
+// channel bits arranged as (g1, g2) pairs; output is `stages`
+// recovered input bits and the path metric of the surviving path.
+func viterbiK5(channel []byte, stages int) ([]byte, int) {
+	const numStates = 16
+	const inf = 1 << 30
+	pm := make([]int, numStates)
+	for i := range pm {
+		pm[i] = inf
+	}
+	pm[0] = 0
+	trace := make([][numStates]uint8, stages)
+
+	for s := 0; s < stages; s++ {
+		var npm [numStates]int
+		for i := range npm {
+			npm[i] = inf
+		}
+		rxG1 := channel[2*s]
+		rxG2 := channel[2*s+1]
+		for cur := 0; cur < numStates; cur++ {
+			if pm[cur] >= inf {
+				continue
+			}
+			d1 := (cur >> 3) & 1
+			d2 := (cur >> 2) & 1
+			d3 := (cur >> 1) & 1
+			d4 := cur & 1
+			for input := 0; input < 2; input++ {
+				g1 := byte(input^d3^d4) & 1
+				g2 := byte(input^d1^d2^d4) & 1
+				cost := pm[cur]
+				// Punctured positions contribute zero cost because the
+				// receiver had no information to correlate against;
+				// they're filled with depunctureMark to skip the bit-
+				// distance check below.
+				if rxG1 != depunctureMark && g1 != rxG1 {
+					cost++
+				}
+				if rxG2 != depunctureMark && g2 != rxG2 {
+					cost++
+				}
+				next := (input << 3) | (d1 << 2) | (d2 << 1) | d3
+				if cost < npm[next] {
+					npm[next] = cost
+					trace[s][next] = uint8((cur << 1) | input)
+				}
+			}
+		}
+		copy(pm, npm[:])
+	}
+
+	// Encoder is flushed back to state 0 by the 4 tail bits — use the
+	// terminal-state constraint and pick state 0 unconditionally. Even
+	// with channel errors the Viterbi remembers state 0 as a feasible
+	// terminus because the depuncturer marked the tail-output bits as
+	// no-info, so any path ending in state 0 has zero metric
+	// contribution from those slots.
+	final := 0
+	metric := pm[final]
+
+	out := make([]byte, stages)
+	state := final
+	for s := stages - 1; s >= 0; s-- {
+		entry := trace[s][state]
+		out[s] = entry & 1
+		state = int(entry >> 1)
+	}
+	return out, metric
+}
+
+// CRC-6 over a bit-stream with NXDN's polynomial g(x) = x^6 + x + 1
+// (= 0x43 with the implicit MSB). Standard sliding-XOR style.
+const crc6Poly = 0x43 // x^6 + x + 1, plus implicit x^6
+
+// SACCHCRC6 computes the 6-bit CRC over the first `nBits` bits of the
+// supplied bit slice (each entry 0/1), MSB-first. The 6-bit result
+// occupies the low bits of the returned byte.
+func SACCHCRC6(bits []byte, nBits int) byte {
+	if nBits > len(bits) {
+		nBits = len(bits)
+	}
+	var reg uint8
+	for i := 0; i < nBits; i++ {
+		bit := bits[i] & 1
+		fb := ((reg >> 5) ^ bit) & 1
+		reg = ((reg << 1) | fb) & 0x3F
+		if fb != 0 {
+			reg ^= crc6Poly & 0x3F
+		}
+	}
+	return reg & 0x3F
+}
+
+// VerifySACCHCRC6 checks that the trailing 6 bits of the supplied 32-
+// bit info block are the correct CRC-6 over the preceding 26 bits. Per
+// NXDN Single SACCH layout (§6.6): bits 0..25 are payload, bits 26..31
+// are the CRC-6 trailer.
+func VerifySACCHCRC6(info []byte) bool {
+	if len(info) != SACCHInfoBits {
+		return false
+	}
+	want := SACCHCRC6(info[:sacchPayloadBits], sacchPayloadBits)
+	var got byte
+	for i := 0; i < 6; i++ {
+		got = (got << 1) | (info[sacchPayloadBits+i] & 1)
+	}
+	return got == want
+}
+
+// AppendSACCHCRC6 returns a 32-bit info block built from the supplied
+// 26 payload bits plus a freshly-computed 6-bit CRC trailer. Useful in
+// tests and for any future encoder paths.
+func AppendSACCHCRC6(payload []byte) []byte {
+	if len(payload) != sacchPayloadBits {
+		panic("nxdn: SACCH payload must be 26 bits")
+	}
+	out := make([]byte, SACCHInfoBits)
+	copy(out, payload)
+	crc := SACCHCRC6(payload, sacchPayloadBits)
+	for i := 0; i < 6; i++ {
+		out[sacchPayloadBits+i] = (crc >> uint(5-i)) & 1
+	}
+	return out
+}

--- a/internal/radio/nxdn/sacch_test.go
+++ b/internal/radio/nxdn/sacch_test.go
@@ -1,0 +1,151 @@
+package nxdn
+
+import (
+	"bytes"
+	"math/rand"
+	"testing"
+)
+
+func makeRandomPayload(seed int64, n int) []byte {
+	r := rand.New(rand.NewSource(seed))
+	out := make([]byte, n)
+	for i := range out {
+		out[i] = byte(r.Intn(2))
+	}
+	return out
+}
+
+func TestSACCHRoundTrip(t *testing.T) {
+	payload := makeRandomPayload(1, 26)
+	info := AppendSACCHCRC6(payload)
+	channel := EncodeSACCH(info)
+	if len(channel) != SACCHChannelBits {
+		t.Fatalf("encoded len = %d, want %d", len(channel), SACCHChannelBits)
+	}
+	got, metric, err := DecodeSACCH(channel)
+	if err != nil {
+		t.Fatalf("DecodeSACCH: %v", err)
+	}
+	if metric != 0 {
+		t.Errorf("clean channel metric = %d, want 0", metric)
+	}
+	if !bytes.Equal(got, info) {
+		t.Errorf("round-trip mismatch:\n got %v\nwant %v", got, info)
+	}
+}
+
+func TestSACCHRoundTripExhaustivePayloads(t *testing.T) {
+	for seed := int64(0); seed < 16; seed++ {
+		info := AppendSACCHCRC6(makeRandomPayload(seed, 26))
+		channel := EncodeSACCH(info)
+		got, _, err := DecodeSACCH(channel)
+		if err != nil {
+			t.Errorf("seed=%d: %v", seed, err)
+			continue
+		}
+		if !bytes.Equal(got, info) {
+			t.Errorf("seed=%d: round-trip failed", seed)
+		}
+	}
+}
+
+func TestSACCHCorrectsSingleBitErrors(t *testing.T) {
+	info := AppendSACCHCRC6(makeRandomPayload(7, 26))
+	for bit := 0; bit < SACCHChannelBits; bit++ {
+		channel := EncodeSACCH(info)
+		channel[bit] ^= 1
+		got, metric, err := DecodeSACCH(channel)
+		if err != nil {
+			t.Errorf("bit=%d: %v", bit, err)
+			continue
+		}
+		if metric == 0 {
+			t.Errorf("bit=%d: metric = 0 after error, want > 0", bit)
+		}
+		if !bytes.Equal(got, info) {
+			t.Errorf("bit=%d: error correction failed", bit)
+		}
+	}
+}
+
+func TestSACCHCorrectsScatteredErrors(t *testing.T) {
+	info := AppendSACCHCRC6(makeRandomPayload(13, 26))
+	channel := EncodeSACCH(info)
+	channel[7] ^= 1
+	channel[27] ^= 1
+	channel[51] ^= 1
+	got, metric, err := DecodeSACCH(channel)
+	if err != nil {
+		t.Fatalf("DecodeSACCH: %v", err)
+	}
+	if metric == 0 {
+		t.Errorf("metric = 0 after errors, want > 0")
+	}
+	if !bytes.Equal(got, info) {
+		t.Errorf("3-bit error correction failed")
+	}
+}
+
+func TestSACCHRejectsHeavyCorruption(t *testing.T) {
+	info := AppendSACCHCRC6(makeRandomPayload(21, 26))
+	channel := EncodeSACCH(info)
+	for i := range channel {
+		channel[i] ^= 1
+	}
+	_, _, err := DecodeSACCH(channel)
+	if err == nil {
+		t.Fatal("heavy corruption should surface an error")
+	}
+}
+
+func TestSACCHInterleaverIsBijection(t *testing.T) {
+	var seen [SACCHChannelBits]bool
+	for _, j := range sacchInterleavePerm {
+		if j < 0 || j >= SACCHChannelBits {
+			t.Fatalf("perm entry out of range: %d", j)
+		}
+		if seen[j] {
+			t.Fatalf("perm entry %d duplicated", j)
+		}
+		seen[j] = true
+	}
+}
+
+func TestSACCHPunctureBijection(t *testing.T) {
+	// Every puncture position is unique, in range, and ascending.
+	prev := -1
+	for _, p := range sacchPuncturePositions {
+		if p <= prev {
+			t.Errorf("puncture positions not strictly ascending: %d after %d", p, prev)
+		}
+		if p < 0 || p >= 80 {
+			t.Errorf("puncture position out of range: %d", p)
+		}
+		prev = p
+	}
+}
+
+func TestSACCHCRC6RoundTrip(t *testing.T) {
+	zero := make([]byte, 26)
+	if got := SACCHCRC6(zero, 26); got != 0 {
+		t.Errorf("CRC of all-zero = %#x, want 0", got)
+	}
+	for i := 0; i < 26; i++ {
+		bit := make([]byte, 26)
+		bit[i] = 1
+		if got := SACCHCRC6(bit, 26); got == 0 {
+			t.Errorf("CRC of single-bit payload at %d = 0; want non-zero", i)
+		}
+	}
+}
+
+func TestVerifySACCHCRC6(t *testing.T) {
+	info := AppendSACCHCRC6(makeRandomPayload(31, 26))
+	if !VerifySACCHCRC6(info) {
+		t.Fatal("VerifySACCHCRC6 rejected a freshly-encoded info block")
+	}
+	info[5] ^= 1
+	if VerifySACCHCRC6(info) {
+		t.Fatal("VerifySACCHCRC6 accepted a payload with a flipped bit")
+	}
+}


### PR DESCRIPTION
## Summary

Closes the last **"Live-CC bring-up FEC pieces"** item from the README's Status & known gaps section. Per NXDN Forum technical specification rev 1.4 §6.6, each transmitted SACCH block is 60 bits and now decodes end-to-end:

```
60 channel bits
     │  deinterleave (60-position sub-frame permutation)
     ▼
60 bits in coding order
     │  depuncture: insert 12 "no-info" markers at fixed positions
     ▼
72 bits
     │  16-state K=5 ½-rate Viterbi, terminal-state-constrained to state 0
     │  (g1 = 0o31 = x⁴+x³+1, g2 = 0o27 = x⁴+x²+x+1)
     ▼
36 bits (info + 4 tail) → strip tail
     ▼
32-bit info block (26 payload + 6-bit CRC trailer)
     │  CRC-6 verify (poly x⁶+x+1)
     ▼
✅ accepted, or ErrSACCHCRCFail
```

## Important: trellis is K=5, not K=3

The original plan referenced `framing.Trellis4StatePoly(7,5)` but that's the textbook K=3 NASA convolutional code. NXDN actually uses **K=5 (16 states)** with the polynomials g1=0o31, g2=0o27. The 16-state Viterbi is implemented directly in the `nxdn` package alongside the puncturer + interleaver tables — it's only used by NXDN today and putting it next to the perm tables keeps the spec citations in one place. If a future protocol needs the same shape, we can hoist it into `framing/`.

## What changed

- `internal/radio/nxdn/sacch.go` (new): `EncodeSACCH(info []byte) []byte`, `DecodeSACCH(channel []byte) (info []byte, metric int, err error)`, `SACCHCRC6` / `VerifySACCHCRC6` / `AppendSACCHCRC6` helpers, plus the puncturer + 60-position interleaver perm tables.
- `internal/radio/nxdn/sacch_test.go` (new): 8 tests covering round-trip, exhaustive payload sweep (16 distinct seeds), single-bit error correction across all 60 channel positions, 3-bit scattered-error correction, heavy-corruption rejection, interleaver bijection, puncture-position monotonicity, CRC-6 round-trip + flipped-bit detection.
- README — `NXDN` row in Features picks up the SACCH channel decode pipeline; FEC primitives row picks up CRC-6 + 16-state K=5 Viterbi; Status & gaps drops the SACCH item; Roadmap drops the "Live-CC bring-up FEC pieces" bullet entirely (the plan's last FEC item).

## Sources for the tables

- [g4klx/MMDVMHost `NXDNConvolution.cpp`](https://github.com/g4klx/MMDVMHost/blob/master/NXDNConvolution.cpp) — encoder loop with explicit g1/g2 generator equations
- [g4klx/MMDVMHost `NXDNSACCH.cpp`](https://github.com/g4klx/MMDVMHost/blob/master/NXDNSACCH.cpp) — confirms the 32-info-bit / 4-tail-bit / 12-puncture layout
- [f4exb/dsdcc `nxdn.cpp`](https://github.com/f4exb/dsdcc/blob/master/nxdn.cpp) — sub-frame interleaver and puncture-position tables
- NXDN Forum technical specification rev 1.4 §6.6 (the underlying spec)

## Test plan

- [x] `go build ./...` and `go vet ./...` clean
- [x] `make test` (race-enabled) — all 26 packages green
- [x] `make integration` — daemon end-to-end suite green
- [x] All 8 SACCH unit tests pass, including the across-all-60-positions single-bit error correction sweep

## What this doesn't do

- Doesn't wire `DecodeSACCH` into a live frame-ingest path. NXDN's full per-frame state machine (sync detect → LICH parse → SACCH ingest → superframe assembly → message dispatch) needs a frame-iterator that doesn't yet exist; that's a follow-up. The events.DecodeError taxonomy from PR #33 already pre-declares `sacch-trellis` as the stage label for that hand-off.
- Doesn't extend the SACCH pipeline to handle SACCH-Superframe (4-fragment reassembly with per-fragment CRC). The spec's Single-SACCH variant is what this PR covers; SACCH-Superframe is structurally similar but adds an outer reassembly layer.

https://claude.ai/code/session_01PHnwos5vaxtoDiSi32maZz

---
_Generated by [Claude Code](https://claude.ai/code/session_01PHnwos5vaxtoDiSi32maZz)_