### PR TITLE
EDACS ProVoice: force .raw sidecar for out-of-band decode

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ gRPC, HTTP/SSE, or WebSocket.
 | Demod pipeline    | `internal/voice/composer` subscribes to `CallStart` events, opens the bound Voice device's IQ stream, runs an LPF → decimate → optional CMA equalizer → FM demod → decimate → int16 PCM chain into the recorder, and pings `Engine.Touch` every second so the silent-call watchdog leaves the call alone |
 | Simulcast / "True I/Q" | `internal/dsp/equalizer` (LMS + CMA blind equalizers) for inter-symbol-interference / multipath mitigation, plus `internal/dsp/diversity` (Selection + maximal-ratio combiners over a shared `Combiner` interface) for multi-receiver IQ combining |
 | Tone-out alerting | `internal/voice/toneout` runs Goertzel filters against each Voice device's PCM stream, matches QC-II two-tone-sequential sequences against operator-configured profiles with per-tone duration + cooldown, and publishes `tone.alert` events that fan out through SSE / WebSocket / gRPC |
-| Voice recording   | `Vocoder` plugin interface + `NullVocoder` baseline, 16-bit PCM mono WAV writer with patched-length trailers, per-call recorder writing `<system>/<tg>/<UTC>_src<id>.wav` plus an optional raw-frame sidecar so users can BYO decoder |
+| Voice recording   | `Vocoder` plugin interface + `NullVocoder` baseline, 16-bit PCM mono WAV writer with patched-length trailers, per-call recorder writing `<system>/<tg>/<UTC>_src<id>.wav` plus an optional raw-frame sidecar so users can BYO decoder; EDACS ProVoice grants always force a `.raw` sidecar (the vocoder is patent + trade-secret encumbered) so researchers can decode out-of-band |
 | API               | `proto/*.proto` schemas under repo root; HTTP REST (`/api/v1/{health,version,systems,talkgroups,calls/active,calls/history}`); operator mutations gated behind `api.allow_mutations` (`GET /api/v1/mutations` capability probe; `POST /api/v1/calls/{serial}/end`; `PATCH /api/v1/talkgroups/{id}`; `POST /api/v1/retention/sweep`; `POST /api/v1/devices/{serial}/tone-reset`); Server-Sent Events stream (`/api/v1/events`); WebSocket bridge (`/api/v1/events/ws`); gRPC `SystemService` + `TalkgroupService` + `AudioService` over the same in-process state |
 | Persistence       | Pure-Go SQLite (`modernc.org/sqlite`) call log subscribing to `CallStart` / `CallEnd` events; newest-first history queries with system / group / time filters; retention sweeper that ages out DB rows and recorded `.wav` / `.raw` files past configurable cutoffs |
 | Observability     | Prometheus collector (events / calls / CC-locked / IQ-underrun / USB-reconnect / decode-error / SDR-attached / build-info series) exposed at `/metrics`; multi-stage `Dockerfile`; `docker-compose.yml` with RTL-SDR USB pass-through, healthcheck, and Prometheus scrape labels |
@@ -86,11 +86,6 @@ to its own package and lands independently.
   factory that opens a connected DVSI USB chip. Same plug-in shape
   as `internal/voice/mbelib`; the daemon picks the factory by name
   from `voice.DefaultRegistry`.
-- **ProVoice raw-frame export.** The EDACS package already flags
-  ProVoice grants. Wire the recorder so ProVoice calls produce a
-  `.raw` frame sidecar that researchers can decode out-of-band —
-  patent + trade-secret encumbrance makes a built-in decoder
-  impractical.
 - **Yaesu System Fusion (C4FM, FICH).** Amateur-radio digital mode,
   public spec. New `internal/radio/ysf/` package following the
   D-STAR pattern: header parser + repeater state machine.

--- a/internal/radio/edacs/control.go
+++ b/internal/radio/edacs/control.go
@@ -103,6 +103,7 @@ func (c *ControlChannel) publishGrant(g GroupVoiceGrant) {
 			ChannelNum:  uint16(g.LCN),
 			Encrypted:   g.Encrypted,
 			Emergency:   g.Emergency,
+			ProVoice:    g.ProVoice,
 			At:          c.now(),
 		},
 	})

--- a/internal/radio/edacs/edacs_test.go
+++ b/internal/radio/edacs/edacs_test.go
@@ -248,6 +248,44 @@ func TestControlChannelPublishesGrant(t *testing.T) {
 	}
 }
 
+func TestControlChannelPropagatesProVoiceFlag(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{
+		Bus:         bus,
+		SystemName:  "TestSys",
+		FrequencyHz: 851_000_000,
+		Resolver:    LinearBandPlan{BaseHz: 866_000_000, SpacingHz: 25_000},
+	})
+	cc.Ingest(CCW{Command: CmdProVoiceGrant, Address: 0x4321, LCN: 9})
+
+	select {
+	case ev := <-sub.C:
+		g, ok := ev.Payload.(trunking.Grant)
+		if !ok {
+			t.Fatalf("payload type = %T", ev.Payload)
+		}
+		if !g.ProVoice {
+			t.Errorf("ProVoice flag not set on trunking.Grant: %+v", g)
+		}
+		if g.GroupID != 0x4321 || g.ChannelNum != 9 {
+			t.Errorf("identity wrong: %+v", g)
+		}
+		// Plain GroupVoiceGrants must not have ProVoice set; verify the
+		// flag is grant-type-specific, not always-on.
+		cc.Ingest(CCW{Command: CmdGroupVoiceGrant, Address: 0x100, LCN: 1})
+		ev2 := <-sub.C
+		if g2 := ev2.Payload.(trunking.Grant); g2.ProVoice {
+			t.Errorf("regular GroupVoiceGrant flagged ProVoice: %+v", g2)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("no grant event")
+	}
+}
+
 func TestControlChannelGrantWithoutResolverHasZeroFreq(t *testing.T) {
 	bus := events.NewBus(8)
 	defer bus.Close()

--- a/internal/trunking/grant.go
+++ b/internal/trunking/grant.go
@@ -24,7 +24,13 @@ type Grant struct {
 	Encrypted   bool
 	Emergency   bool
 	DataCall    bool // false = voice call (default)
-	At          time.Time
+	// ProVoice marks the grant as an EDACS ProVoice (digital) call. The
+	// vocoder is patent + trade-secret encumbered so we cannot ship a
+	// built-in decoder; the recorder treats this flag as a directive to
+	// emit a `.raw` frame sidecar regardless of its global WriteRaw
+	// setting, so researchers can decode out-of-band.
+	ProVoice bool
+	At       time.Time
 }
 
 // String renders a one-line summary of a Grant for log output.
@@ -38,6 +44,9 @@ func (g Grant) String() string {
 	}
 	if g.DataCall {
 		flags += "D"
+	}
+	if g.ProVoice {
+		flags += "P"
 	}
 	return fmt.Sprintf("%s/%s tg=%d src=%d freq=%d %s", g.System, g.Protocol, g.GroupID, g.SourceID, g.FrequencyHz, flags)
 }

--- a/internal/voice/composer/composer.go
+++ b/internal/voice/composer/composer.go
@@ -13,9 +13,9 @@
 // Digital protocols (P25 / DMR / NXDN) need vocoders that haven't
 // landed yet — IMBE for P25 Phase 1 is in progress and AMBE+2 stays
 // behind a build tag. Until they ship, a digital grant produces no
-// PCM and only the raw-frame sidecar (when WriteRaw is enabled) is
-// useful. The composer logs a warning per digital grant so the
-// behaviour is visible in operations.
+// PCM and only the raw-frame sidecar (when WriteRaw is enabled, or
+// always for EDACS ProVoice grants) is useful. The composer logs a
+// warning per digital grant so the behaviour is visible in operations.
 package composer
 
 import (

--- a/internal/voice/recorder.go
+++ b/internal/voice/recorder.go
@@ -30,6 +30,11 @@ import (
 // The raw sidecar is appended once per WriteRawFrame call. It is
 // intentionally a flat concatenation of frames so users can BYO decoder
 // (mbelib, DVSI, etc.) without parsing surrounding metadata.
+//
+// EDACS ProVoice grants (Grant.ProVoice == true) always force a `.raw`
+// sidecar even when WriteRaw is false. The vocoder is patent +
+// trade-secret encumbered so we cannot ship a built-in decoder; the
+// sidecar lets researchers feed frames into an external decoder.
 type Recorder struct {
 	bus        *events.Bus
 	log        *slog.Logger
@@ -165,12 +170,11 @@ func (r *Recorder) WritePCM(deviceSerial string, samples []int16) error {
 	return s.wav.WriteSamples(samples)
 }
 
-// WriteRawFrame appends a raw vocoder frame to the per-call sidecar (if
-// WriteRaw is enabled). Otherwise it is a no-op.
+// WriteRawFrame appends a raw vocoder frame to the per-call sidecar.
+// The session decides whether a sidecar exists: it is opened either when
+// WriteRaw is globally enabled or when the call's grant is flagged
+// ProVoice. Frames for a session without a sidecar are dropped silently.
 func (r *Recorder) WriteRawFrame(deviceSerial string, frame []byte) error {
-	if !r.writeRaw {
-		return nil
-	}
 	r.mu.Lock()
 	s, ok := r.sessions[deviceSerial]
 	r.mu.Unlock()
@@ -204,7 +208,9 @@ func (r *Recorder) handleStart(cs trunking.CallStart) {
 		return
 	}
 	s := &recordingSession{wav: wav, wavPath: wavPath, startedAt: cs.StartedAt}
-	if r.writeRaw {
+	// ProVoice grants always get a sidecar — the vocoder isn't decodable
+	// in-process, so the .raw file is the only way to capture the call.
+	if r.writeRaw || cs.Grant.ProVoice {
 		rawPath := filepath.Join(dir, base+".raw")
 		raw, err := os.Create(rawPath)
 		if err != nil {
@@ -216,7 +222,8 @@ func (r *Recorder) handleStart(cs trunking.CallStart) {
 	}
 	r.sessions[cs.DeviceSerial] = s
 	r.log.Info("recorder: call started",
-		"device", cs.DeviceSerial, "wav", wavPath, "tg", cs.Grant.GroupID)
+		"device", cs.DeviceSerial, "wav", wavPath,
+		"tg", cs.Grant.GroupID, "provoice", cs.Grant.ProVoice)
 }
 
 func (r *Recorder) handleEnd(ce trunking.CallEnd) {

--- a/internal/voice/recorder_test.go
+++ b/internal/voice/recorder_test.go
@@ -157,6 +157,114 @@ func TestRecorderRawFrameSidecar(t *testing.T) {
 	}
 }
 
+func TestRecorderProVoiceForcesRawSidecar(t *testing.T) {
+	// Even with the recorder's global WriteRaw flag off, an EDACS
+	// ProVoice grant must open a .raw sidecar — that's the only useful
+	// output for an unstreamable vocoder.
+	r, bus, dir := mkRecorder(t, false)
+	defer r.Close()
+	defer bus.Close()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go r.Run(ctx)
+
+	cs := trunking.CallStart{
+		Grant: trunking.Grant{
+			System: "EDACS-Site", Protocol: "edacs", GroupID: 0x4321,
+			SourceID: 12, ProVoice: true,
+		},
+		DeviceSerial: "VOICE-1",
+		StartedAt:    time.Date(2026, 5, 5, 1, 2, 3, 0, time.UTC),
+	}
+	bus.Publish(events.Event{Kind: events.KindCallStart, Payload: cs})
+
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if r.HasSession("VOICE-1") {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	frame := []byte{0x11, 0x22, 0x33, 0x44}
+	if err := r.WriteRawFrame("VOICE-1", frame); err != nil {
+		t.Fatal(err)
+	}
+
+	bus.Publish(events.Event{
+		Kind: events.KindCallEnd,
+		Payload: trunking.CallEnd{
+			Grant: cs.Grant, DeviceSerial: "VOICE-1",
+			StartedAt: cs.StartedAt, EndedAt: cs.StartedAt.Add(time.Second),
+			Reason: trunking.EndReasonNormal,
+		},
+	})
+	deadline = time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if !r.HasSession("VOICE-1") {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	rawPath := filepath.Join(dir, "EDACS-Site", "17185", "20260505T010203Z_src12.raw")
+	data, err := os.ReadFile(rawPath)
+	if err != nil {
+		t.Fatalf("expected .raw sidecar at %s: %v", rawPath, err)
+	}
+	if len(data) != len(frame) {
+		t.Errorf("raw size = %d, want %d", len(data), len(frame))
+	}
+}
+
+func TestRecorderNonProVoiceSkipsRawWhenDisabled(t *testing.T) {
+	// Sanity check: with WriteRaw=false and a non-ProVoice grant, the
+	// recorder must not create a .raw sidecar.
+	r, bus, dir := mkRecorder(t, false)
+	defer r.Close()
+	defer bus.Close()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go r.Run(ctx)
+
+	cs := trunking.CallStart{
+		Grant:        trunking.Grant{System: "S", Protocol: "p25", GroupID: 7, SourceID: 1},
+		DeviceSerial: "VOICE-1",
+		StartedAt:    time.Date(2026, 5, 5, 0, 0, 0, 0, time.UTC),
+	}
+	bus.Publish(events.Event{Kind: events.KindCallStart, Payload: cs})
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if r.HasSession("VOICE-1") {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	// WriteRawFrame should be a silent drop with no sidecar open.
+	if err := r.WriteRawFrame("VOICE-1", []byte{0xAA}); err != nil {
+		t.Fatal(err)
+	}
+	bus.Publish(events.Event{
+		Kind: events.KindCallEnd,
+		Payload: trunking.CallEnd{
+			Grant: cs.Grant, DeviceSerial: "VOICE-1",
+			StartedAt: cs.StartedAt, EndedAt: cs.StartedAt.Add(time.Second),
+			Reason: trunking.EndReasonNormal,
+		},
+	})
+	deadline = time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if !r.HasSession("VOICE-1") {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	rawPath := filepath.Join(dir, "S", "7", "20260505T000000Z_src1.raw")
+	if _, err := os.Stat(rawPath); !os.IsNotExist(err) {
+		t.Errorf(".raw sidecar should not exist (WriteRaw=false, non-ProVoice): err=%v", err)
+	}
+}
+
 func TestRecorderClosesOpenSessions(t *testing.T) {
 	r, bus, _ := mkRecorder(t, false)
 	defer bus.Close()


### PR DESCRIPTION
## Summary

The EDACS package already classifies CCWs as `CmdProVoiceGrant` vs.
`CmdGroupVoiceGrant` and `GroupVoiceGrant.ProVoice` carries that bit
inside the EDACS package — but it died at the package boundary. The
recorder had no way to know a call was ProVoice, so a captured digital
call produced an empty WAV and nothing else.

This PR wires the flag through and lets the recorder do the right thing:

- `trunking.Grant` gains a `ProVoice bool` field (and `String()` adds a
  `P` flag character to match the existing `E`/`!`/`D` convention).
- `internal/radio/edacs.publishGrant` propagates `g.ProVoice` from the
  EDACS-internal struct onto the bus payload.
- `internal/voice/recorder.handleStart` opens a `.raw` sidecar when
  `WriteRaw` is true **or** the grant is ProVoice — the vocoder is
  patent + trade-secret encumbered so the sidecar is the only useful
  artefact for ProVoice traffic.
- `WriteRawFrame` no longer guards on the recorder's global flag; it
  defers to whether the per-session `.raw` file was opened. That keeps
  WriteRaw=false the default for analog systems while still capturing
  ProVoice frames automatically.

This closes the README's *ProVoice raw-frame export* roadmap entry.
Researchers can now point an external AMBE/ProVoice decoder at the
flat-concatenated `.raw` file produced alongside each ProVoice WAV.

## Tests

- `internal/radio/edacs.TestControlChannelPropagatesProVoiceFlag` —
  asserts `Grant.ProVoice` is set for `CmdProVoiceGrant` and stays
  clear for `CmdGroupVoiceGrant`.
- `internal/voice.TestRecorderProVoiceForcesRawSidecar` — recorder
  with `WriteRaw=false` still emits a `.raw` sidecar when the
  CallStart's grant is ProVoice; written frames land in the file.
- `internal/voice.TestRecorderNonProVoiceSkipsRawWhenDisabled` — the
  symmetric guard: `WriteRaw=false` + non-ProVoice still produces no
  `.raw` (no regression for analog calls).
- Existing recorder + EDACS + composer suites stay green; full
  `go test ./...` passes.

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./internal/voice/... ./internal/radio/edacs/... ./internal/trunking/...`
- [x] `go test ./...` (full suite)
- [ ] Manual: with `recordings.write_raw: false` in `config.yaml`, a
      synthetic EDACS ProVoice grant on the bus produces
      `<system>/<tg>/<UTC>_src<id>.raw` alongside the empty WAV.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PHnwos5vaxtoDiSi32maZz)_