### PR TITLE
P25 Phase 1: IdentifierUpdate band-plan + live grant emission

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ gRPC, HTTP/SSE, or WebSocket.
 | Hardware          | CGO `librtlsdr` binding, multi-device pool, role assignment, per-device gain (`auto` / tenths-of-dB) + PPM + bias-tee (5 V LNA power, e.g. NESDR Smart v5) applied at open time, DC blocker, IQ-imbalance correction, file-backed IQ replay (mock) |
 | DSP               | Polyphase channelizer, FIR + Kaiser LPF designer + RRC, CIC, halfband, AGC, rational resampler, FM / C4FM / H-DQPSK demods, Mueller-Müller clock recovery, frame-sync correlator |
 | FEC primitives    | CRC-CCITT/FALSE, CRC-6 (NXDN SACCH), Hamming(15,11,3), Hamming(13,9,3), Hamming(20,8) (DMR slot-type, t=3), extended Golay(24,12,8), BCH(63,16,11), BPTC(196,96), 4-state ½-rate Viterbi, 16-state K=5 ½-rate Viterbi (NXDN SACCH) |
-| P25 Phase 1       | 48-bit FSW + sync detector, NID parser (NAC + DUID) with BCH(63,16,11) error correction + even-parity check, full TSBK channel decode (TIA-102.BAAA Annex A 4-state ½-rate trellis + 98-dibit block deinterleaver) → CRC trailer validation, payload parsers for GroupVoiceChannelGrant / Update / NetworkStatus / RFSSStatus, control-channel state machine emitting `decode.error` events with `nid-bch` / `tsbk-trellis` / `tsbk-crc` stages |
+| P25 Phase 1       | 48-bit FSW + sync detector, NID parser (NAC + DUID) with BCH(63,16,11) error correction + even-parity check, full TSBK channel decode (TIA-102.BAAA Annex A 4-state ½-rate trellis + 98-dibit block deinterleaver) → CRC trailer validation, payload parsers for GroupVoiceChannelGrant / Update / NetworkStatus / RFSSStatus, IdentifierUpdate band-plan resolver, control-channel state machine emitting `protocol = "p25"` grants and `decode.error` events with `nid-bch` / `tsbk-trellis` / `tsbk-crc` / `no-bandplan` stages |
 | P25 Phase 2       | Outbound + inbound 20-dibit sync, 360 ms / 12-subframe superframe + SlotType enum, MAC PDU parser + opcode enum, GroupVoiceChannelGrant accessor, control-channel state machine emitting `protocol = "p25-phase2"` grants |
 | DMR (Tier III)    | All 9 ETSI sync patterns, burst layout (132 dibits), Color Code + Data Type via (20,8,7) shortened-Hamming slot-type FEC (corrects up to 3 bit errors per slot type), CSBK with CRC, payload parsers for TalkGroup/Private Voice grants + Aloha + AdjacentSiteStatus + SystemInfoBroadcast, control-channel state machine |
 | NXDN              | 192-dibit frame layout (4800 BFSK / 9600 4-FSK), LICH parse with parity + 16-bit doubled-wire decoder, FSW correlator, full SACCH channel decode (K=5 ½-rate convolutional Viterbi + 60-position sub-frame deinterleaver + 12-bit puncture undo + CRC-6 trailer), CAC parser with CRC, RCCH opcode enum + payload parsers, control-channel state machine |
@@ -47,14 +47,6 @@ control channel locks, the engine allocates a Voice device on a
 grant, the composer pulls IQ → PCM → WAV, and the call is logged to
 SQLite. The honest gaps:
 
-- **Live P25 grant emission** is the remaining wire-up: the TSBK
-  channel decode pipeline (NID BCH + Annex-A trellis + 98-dibit
-  block deinterleaver + CRC) is now end-to-end, and the parsed
-  GroupVoiceChannelGrant / Update / NetworkStatus / RFSSStatus
-  payload accessors are already in place; they need to feed a
-  band-plan resolver to publish full `protocol = "p25"` grants on
-  the bus. Decode failures at every FEC stage already publish
-  `decode.error` events that fan out to Prometheus.
 - **DMR Tier II** is mostly a configuration variation on the Tier
   III scaffolding that's already in place; both share the burst,
   slot-type, and BPTC pieces.
@@ -69,8 +61,7 @@ SQLite. The honest gaps:
   verify wiring; real DSP polish is follow-up work.
 
 The Go interfaces and event payloads carry digital protocols already,
-so dropping in a band-plan resolver and IMBE will light up the
-remaining paths without further changes elsewhere.
+so the remaining paths light up once IMBE drops in.
 
 ## Roadmap
 

--- a/internal/radio/p25/phase1/control.go
+++ b/internal/radio/p25/phase1/control.go
@@ -3,8 +3,10 @@ package phase1
 import (
 	"errors"
 	"log/slog"
+	"time"
 
 	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
 )
 
 // ControlChannel consumes a stream of P25 Phase 1 dibits (already
@@ -14,39 +16,88 @@ import (
 // Pipeline: dibit window → FSW detect → NID parse (BCH(63,16,11) +
 // even-parity check) → if DUID is TSDU and the buffer holds enough
 // dibits, deinterleave + Viterbi-decode the next 98-dibit TSBK block,
-// validate the CRC trailer, and (on success) log the parsed opcode.
-// CCLocked / CCLost events fan out on every corrected NID with a TSDU
-// DUID. Uncorrectable NIDs and TSBK CRC failures publish
-// KindDecodeError events so the metrics collector can count them; full
-// Grant emission from parsed TSBK opcodes lands in a follow-up that
-// adds the band-plan resolver.
+// validate the CRC trailer, and dispatch on the parsed opcode.
+//
+//   - OpIdentifierUpdate (0x3D) populates the band-plan slot for its
+//     Channel ID.
+//   - OpGroupVoiceChannelGrant (0x00) parses the channel/group/source
+//     payload, looks up the frequency in the band plan, and publishes
+//     a trunking.Grant with Protocol="p25" on the bus.
+//
+// CCLocked / CCLost events fan out on the first corrected NID with a
+// TSDU DUID. Uncorrectable NIDs and TSBK CRC failures publish
+// KindDecodeError; a grant whose Channel ID has no IdentifierUpdate
+// yet publishes KindDecodeError with stage="no-bandplan" so the
+// metric counter surfaces the gap.
 type ControlChannel struct {
-	bus     *events.Bus
-	log     *slog.Logger
-	det     *SyncDetector
-	freqHz  uint32
-	locked  bool
-	lastNAC uint16
+	bus        *events.Bus
+	log        *slog.Logger
+	det        *SyncDetector
+	systemName string
+	freqHz     uint32
+	bandPlan   *BandPlan
+	now        func() time.Time
+	locked     bool
+	lastNAC    uint16
 }
 
-func NewControlChannel(bus *events.Bus, log *slog.Logger, freqHz uint32) *ControlChannel {
+// Options configure a ControlChannel.
+type Options struct {
+	Bus         *events.Bus
+	Log         *slog.Logger
+	SystemName  string
+	FrequencyHz uint32
+	BandPlan    *BandPlan       // optional; a new empty BandPlan is used if nil
+	Now         func() time.Time
+}
+
+// New constructs a ControlChannel from Options. SystemName ends up on
+// every trunking.Grant the channel publishes; the daemon passes it
+// through from config.
+func New(opts Options) *ControlChannel {
+	log := opts.Log
 	if log == nil {
 		log = slog.Default()
 	}
+	bp := opts.BandPlan
+	if bp == nil {
+		bp = &BandPlan{}
+	}
+	now := opts.Now
+	if now == nil {
+		now = time.Now
+	}
 	return &ControlChannel{
-		bus:    bus,
-		log:    log,
-		det:    NewSyncDetector(4),
-		freqHz: freqHz,
+		bus:        opts.Bus,
+		log:        log,
+		det:        NewSyncDetector(4),
+		systemName: opts.SystemName,
+		freqHz:     opts.FrequencyHz,
+		bandPlan:   bp,
+		now:        now,
 	}
 }
 
-// LockState is the payload of CCLocked / CCLost events.
+// NewControlChannel keeps the legacy positional constructor working —
+// it's used by the existing FEC/decode tests that don't care about
+// grant publication. New callers should use New(Options{...}).
+func NewControlChannel(bus *events.Bus, log *slog.Logger, freqHz uint32) *ControlChannel {
+	return New(Options{Bus: bus, Log: log, FrequencyHz: freqHz})
+}
+
+// LockState is the payload of CCLocked / CCLost events. It satisfies
+// trunking.LockedPayload so the hunter can consume it without
+// importing this package (which would create an import cycle now that
+// phase1 publishes trunking.Grant events).
 type LockState struct {
 	FrequencyHz uint32
 	NAC         uint16
 	DUID        DUID
 }
+
+// LockedFrequencyHz / LockedNAC implement trunking.LockedPayload.
+func (s LockState) LockedFrequencyHz() uint32 { return s.FrequencyHz }
+func (s LockState) LockedNAC() uint16          { return s.NAC }
 
 // Process consumes a window of dibits and runs detection/parsing. baseIdx
 // is the absolute dibit index of dibits[0]. Returns the new baseIndex.
@@ -108,10 +159,73 @@ func (c *ControlChannel) Process(dibits []uint8, baseIdx int) int {
 			})
 			continue
 		}
-		c.log.Debug("tsbk decoded",
-			"opcode", tsbk.Opcode, "lb", tsbk.LB, "metric", metric, "nac", nid.NAC)
+		c.dispatchTSBK(tsbk, nid.NAC, metric)
 	}
 	return next
+}
+
+// dispatchTSBK routes a successfully-CRC'd TSBK to the right opcode
+// handler. Unknown opcodes are still useful for diagnostics — they're
+// logged at debug but not republished, since they're the bulk of what
+// a busy site emits and would drown signal in noise.
+func (c *ControlChannel) dispatchTSBK(t TSBK, nac uint16, metric int) {
+	switch t.Opcode {
+	case OpIdentifierUpdate:
+		u := ParseIdentifierUpdate(t.Payload)
+		c.bandPlan.Apply(u)
+		c.log.Debug("p25: identifier update",
+			"nac", nac, "id", u.ChannelID,
+			"base_hz", u.BaseHz, "spacing_hz", u.SpacingHz,
+			"tx_offset_hz", u.TxOffsetHz)
+	case OpGroupVoiceChannelGrant:
+		c.publishGroupGrant(ParseGroupVoiceChannelGrant(t.Payload), nac)
+	default:
+		c.log.Debug("tsbk decoded",
+			"opcode", t.Opcode, "lb", t.LB, "metric", metric, "nac", nac)
+	}
+}
+
+// publishGroupGrant resolves the grant's channel through the band
+// plan and publishes a trunking.Grant on the bus. If the channel ID
+// hasn't been seen yet, a `decode.error` with stage="no-bandplan"
+// is published instead — the engine can't do anything with a
+// zero-frequency grant, and surfacing this lets operators see when
+// a site's IdentifierUpdate cadence is too slow for their capture.
+func (c *ControlChannel) publishGroupGrant(g GroupVoiceChannelGrant, nac uint16) {
+	freq, err := c.bandPlan.Frequency(g.ChannelID, g.ChannelNumber)
+	if err != nil {
+		c.log.Debug("p25: grant before identifier update",
+			"nac", nac, "id", g.ChannelID, "num", g.ChannelNumber, "err", err)
+		c.bus.Publish(events.Event{
+			Kind:    events.KindDecodeError,
+			Payload: events.DecodeError{Protocol: "p25", Stage: "no-bandplan"},
+		})
+		return
+	}
+	// SVC_OPTIONS bit layout per TIA-102.AABF: bit 7 = Emergency,
+	// bit 6 = Protected (encryption indicator).
+	emergency := g.ServiceOptions&0x80 != 0
+	encrypted := g.ServiceOptions&0x40 != 0
+	c.bus.Publish(events.Event{
+		Kind: events.KindGrant,
+		Payload: trunking.Grant{
+			System:      c.systemName,
+			Protocol:    "p25",
+			GroupID:     uint32(g.GroupAddress),
+			SourceID:    g.SourceID,
+			FrequencyHz: freq,
+			ChannelID:   g.ChannelID,
+			ChannelNum:  g.ChannelNumber,
+			Encrypted:   encrypted,
+			Emergency:   emergency,
+			At:          c.now(),
+		},
+	})
+	c.log.Debug("p25: grant",
+		"system", c.systemName, "nac", nac,
+		"tg", g.GroupAddress, "src", g.SourceID,
+		"id", g.ChannelID, "num", g.ChannelNumber, "freq_hz", freq,
+		"enc", encrypted, "emer", emergency)
 }
 
 // MarkLost publishes a CCLost event for the current frequency and resets

--- a/internal/radio/p25/phase1/control_test.go
+++ b/internal/radio/p25/phase1/control_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
 )
 
 // buildLockedStream constructs a synthetic dibit window that places the
@@ -13,13 +14,19 @@ import (
 // TSBK channel block (single Last-Block TSBK with the supplied opcode).
 // Tail dibits are zero-padded.
 func buildLockedStream(offset int, nac uint16, duid DUID, op Opcode) []uint8 {
+	return buildLockedStreamWithTSBK(offset, nac, duid, TSBK{LB: true, Opcode: op})
+}
+
+// buildLockedStreamWithTSBK is the variant that takes a fully-formed
+// TSBK so callers can carry a payload (used by the IdentifierUpdate +
+// grant publication tests).
+func buildLockedStreamWithTSBK(offset int, nac uint16, duid DUID, tsbk TSBK) []uint8 {
 	out := make([]uint8, offset+24+32+98+16)
 	copy(out[offset:], FrameSyncWord[:])
 	bits := EncodeNIDBits(nac, duid)
 	for i := 0; i < 32; i++ {
 		out[offset+24+i] = (bits[2*i] << 1) | bits[2*i+1]
 	}
-	tsbk := TSBK{LB: true, Opcode: op}
 	channel := EncodeTSBKChannel(AssembleTSBK(tsbk))
 	copy(out[offset+24+32:], channel)
 	return out
@@ -123,6 +130,108 @@ func TestControlChannelPublishesDecodeErrorOnUncorrectableNID(t *testing.T) {
 			return
 		case <-deadline:
 			t.Fatal("no decode-error event published")
+		}
+	}
+}
+
+func TestControlChannelAppliesIdentifierUpdateAndPublishesGrant(t *testing.T) {
+	bus := events.NewBus(16)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	// Build a stream with two TSBKs back-to-back: an IdentifierUpdate
+	// for ChannelID 1 (12.5 kHz spacing, base 851 MHz) followed by a
+	// GroupVoiceChannelGrant on (ID=1, Number=16) which should resolve
+	// to 851.2 MHz on the bus.
+	identTSBK := TSBK{LB: false, Opcode: OpIdentifierUpdate}
+	identTSBK.Payload = AssembleIdentifierUpdate(IdentifierUpdate{
+		ChannelID: 1, SpacingHz: 12_500, BaseHz: 851_000_000,
+	})
+
+	grantPayload := [8]byte{
+		0xC0,                               // service options: emergency + encrypted
+		(1 << 4) | 0x00, 0x10,              // channel = ID 1, number 0x010 (=16)
+		0x12, 0x34,                         // group address 0x1234
+		0xAB, 0xCD, 0xEF,                   // source ID 0xABCDEF
+	}
+	grantTSBK := TSBK{LB: true, Opcode: OpGroupVoiceChannelGrant, Payload: grantPayload}
+
+	stream1 := buildLockedStreamWithTSBK(10, 0x293, DUIDTrunkingSignaling, identTSBK)
+	stream2 := buildLockedStreamWithTSBK(0, 0x293, DUIDTrunkingSignaling, grantTSBK)
+
+	cc := New(Options{
+		Bus:         bus,
+		SystemName:  "TestSys",
+		FrequencyHz: 851_000_000,
+		Now:         func() time.Time { return time.Unix(1_700_000_000, 0).UTC() },
+	})
+	cc.Process(stream1, 0)
+	cc.Process(stream2, len(stream1))
+
+	// Drain events; assert exactly one Grant event lands and looks right.
+	var got *trunking.Grant
+	deadline := time.After(time.Second)
+	for got == nil {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind == events.KindGrant {
+				g := ev.Payload.(trunking.Grant)
+				got = &g
+			}
+		case <-deadline:
+			t.Fatal("no grant event published")
+		}
+	}
+	if got.System != "TestSys" || got.Protocol != "p25" {
+		t.Errorf("identity = %s/%s", got.System, got.Protocol)
+	}
+	if got.GroupID != 0x1234 || got.SourceID != 0xABCDEF {
+		t.Errorf("group/source = %d/%d, want 4660/11259375", got.GroupID, got.SourceID)
+	}
+	if got.ChannelID != 1 || got.ChannelNum != 0x010 {
+		t.Errorf("channel = %d.%d, want 1.16", got.ChannelID, got.ChannelNum)
+	}
+	if got.FrequencyHz != 851_200_000 {
+		t.Errorf("freq = %d, want 851_200_000", got.FrequencyHz)
+	}
+	if !got.Encrypted || !got.Emergency {
+		t.Errorf("flags = enc=%v emer=%v, want both", got.Encrypted, got.Emergency)
+	}
+	if got.At.Unix() != 1_700_000_000 {
+		t.Errorf("At = %v, want injected Now", got.At)
+	}
+}
+
+func TestControlChannelGrantBeforeIdentifierUpdateEmitsDecodeError(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	grantPayload := [8]byte{0x00, 0x20, 0x05, 0x00, 0x42, 0, 0, 0}
+	grantTSBK := TSBK{LB: true, Opcode: OpGroupVoiceChannelGrant, Payload: grantPayload}
+	stream := buildLockedStreamWithTSBK(10, 0x111, DUIDTrunkingSignaling, grantTSBK)
+
+	cc := New(Options{Bus: bus, SystemName: "S", FrequencyHz: 1})
+	cc.Process(stream, 0)
+
+	deadline := time.After(time.Second)
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind == events.KindGrant {
+				t.Fatalf("unexpected grant emitted without band-plan: %+v", ev.Payload)
+			}
+			if ev.Kind != events.KindDecodeError {
+				continue
+			}
+			de := ev.Payload.(events.DecodeError)
+			if de.Protocol == "p25" && de.Stage == "no-bandplan" {
+				return
+			}
+		case <-deadline:
+			t.Fatal("no decode-error with stage=no-bandplan")
 		}
 	}
 }

--- a/internal/radio/p25/phase1/identifier.go
+++ b/internal/radio/p25/phase1/identifier.go
@@ -1,0 +1,130 @@
+package phase1
+
+import (
+	"errors"
+	"fmt"
+)
+
+// IdentifierUpdate carries a P25 IDENT_UP TSBK (opcode 0x3D), the
+// "Identifier Update" announcement that defines the band plan for one
+// channel-ID slot. A site repeats these periodically alongside its
+// status broadcasts; the receiver accumulates them and uses each slot
+// to translate a (Channel ID, Channel Number) pair from a voice grant
+// into a downlink frequency.
+//
+// Field units come straight from TIA-102.AABF Table 14:
+//
+//	BandwidthHz   = BW    × 125  Hz
+//	SpacingHz     = STEP  × 125  Hz   (channel step)
+//	TxOffsetHz    = OFF   × 250 kHz   (signed; sign-extended from 9-bit)
+//	BaseHz        = FREQ  × 5    Hz
+//
+// Only the standard 700/800/900 MHz form is parsed here (opcode 0x3D).
+// VHF/UHF (0x34) and Phase-2 TDMA (0x33) variants encode the same
+// fields with different bit packings and are out of scope for this
+// pass; lighting them up is incremental.
+type IdentifierUpdate struct {
+	ChannelID   uint8  // 4-bit slot identifier (0..15)
+	BandwidthHz uint32 // channel bandwidth
+	SpacingHz   uint32 // channel-to-channel step
+	TxOffsetHz  int64  // signed transmit offset (uplink = downlink + offset)
+	BaseHz      uint64 // downlink base frequency for channel 0
+}
+
+// ParseIdentifierUpdate decodes the 8-byte payload of opcode 0x3D
+// (OpIdentifierUpdate). The bit layout is, MSB first:
+//
+//	[ ChanID(4) | BW(9) | OFF(9) | STEP(10) | FREQ(32) ]
+func ParseIdentifierUpdate(p [8]byte) IdentifierUpdate {
+	chanID := p[0] >> 4
+	bw := uint16(p[0]&0x0F)<<5 | uint16(p[1])>>3
+	offRaw := uint16(p[1]&0x07)<<6 | uint16(p[2])>>2
+	step := uint16(p[2]&0x03)<<8 | uint16(p[3])
+	freq5Hz := uint32(p[4])<<24 | uint32(p[5])<<16 | uint32(p[6])<<8 | uint32(p[7])
+
+	// Sign-extend OFF (9 bits, two's complement).
+	off := int16(offRaw)
+	if off&0x100 != 0 {
+		off -= 0x200
+	}
+	return IdentifierUpdate{
+		ChannelID:   chanID,
+		BandwidthHz: uint32(bw) * 125,
+		SpacingHz:   uint32(step) * 125,
+		TxOffsetHz:  int64(off) * 250_000,
+		BaseHz:      uint64(freq5Hz) * 5,
+	}
+}
+
+// AssembleIdentifierUpdate is the inverse of ParseIdentifierUpdate;
+// useful for synthetic test streams. Out-of-range fields are silently
+// truncated to their on-air widths, matching the ParseTSBK contract.
+func AssembleIdentifierUpdate(u IdentifierUpdate) [8]byte {
+	bw := uint16(u.BandwidthHz/125) & 0x1FF
+	step := uint16(u.SpacingHz/125) & 0x3FF
+	off := uint16(u.TxOffsetHz/250_000) & 0x1FF
+	freq5 := uint32(u.BaseHz / 5)
+
+	var p [8]byte
+	p[0] = (u.ChannelID&0x0F)<<4 | byte(bw>>5)
+	p[1] = byte(bw<<3) | byte(off>>6)
+	p[2] = byte(off<<2) | byte(step>>8)
+	p[3] = byte(step)
+	p[4] = byte(freq5 >> 24)
+	p[5] = byte(freq5 >> 16)
+	p[6] = byte(freq5 >> 8)
+	p[7] = byte(freq5)
+	return p
+}
+
+// ErrUnknownChannelID is returned by BandPlan.Frequency when no
+// IdentifierUpdate has been observed for the requested channel ID.
+// The control channel maps this to a `decode.error` with
+// stage="no-bandplan" so the gap is visible in metrics.
+var ErrUnknownChannelID = errors.New("p25/phase1: no IdentifierUpdate for channel ID")
+
+// BandPlan accumulates IdentifierUpdate state — one slot per Channel
+// ID — and resolves voice-grant (ChannelID, ChannelNumber) tuples to
+// downlink frequencies. Zero-value BandPlan{} is ready to use; not
+// safe for concurrent Apply / Frequency without external locking, but
+// the control channel reads/writes from a single goroutine so that's
+// the natural usage shape.
+type BandPlan struct {
+	slots [16]IdentifierUpdate
+	known [16]bool
+}
+
+// Apply records (or replaces) the band-plan slot for u.ChannelID.
+func (b *BandPlan) Apply(u IdentifierUpdate) {
+	if int(u.ChannelID) >= len(b.slots) {
+		return
+	}
+	b.slots[u.ChannelID] = u
+	b.known[u.ChannelID] = true
+}
+
+// Frequency returns the downlink frequency in Hz for the given
+// channel ID + channel number, or ErrUnknownChannelID if no
+// IdentifierUpdate has been seen for that ID.
+func (b *BandPlan) Frequency(channelID uint8, channelNumber uint16) (uint32, error) {
+	if int(channelID) >= len(b.slots) || !b.known[channelID] {
+		return 0, fmt.Errorf("%w: id=%d", ErrUnknownChannelID, channelID)
+	}
+	u := b.slots[channelID]
+	hz := u.BaseHz + uint64(channelNumber)*uint64(u.SpacingHz)
+	// P25 sits well below 4.29 GHz; guard anyway so a malformed
+	// IdentifierUpdate can't silently wrap.
+	if hz > 0xFFFFFFFF {
+		return 0, fmt.Errorf("p25/phase1: resolved frequency %d Hz overflows uint32", hz)
+	}
+	return uint32(hz), nil
+}
+
+// Known reports whether an IdentifierUpdate slot has been recorded.
+// Intended for tests + diagnostics.
+func (b *BandPlan) Known(channelID uint8) bool {
+	if int(channelID) >= len(b.known) {
+		return false
+	}
+	return b.known[channelID]
+}

--- a/internal/radio/p25/phase1/identifier_test.go
+++ b/internal/radio/p25/phase1/identifier_test.go
@@ -1,0 +1,88 @@
+package phase1
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestIdentifierUpdateRoundTrip700MHz(t *testing.T) {
+	// Realistic 700/800 MHz Phase 1 fixture: ChannelID 1, base 851.0
+	// MHz, 12.5 kHz spacing + bandwidth, -39 MHz transmit offset.
+	in := IdentifierUpdate{
+		ChannelID:   1,
+		BandwidthHz: 12_500,
+		SpacingHz:   12_500,
+		TxOffsetHz:  -39_000_000,
+		BaseHz:      851_000_000,
+	}
+	out := ParseIdentifierUpdate(AssembleIdentifierUpdate(in))
+	if out != in {
+		t.Errorf("round-trip mismatch:\n got %+v\nwant %+v", out, in)
+	}
+}
+
+func TestIdentifierUpdateRoundTripPositiveOffset(t *testing.T) {
+	// VHF-style fixture with a positive offset to exercise the sign
+	// bit. Spacing is 6.25 kHz; bandwidth differs from spacing.
+	in := IdentifierUpdate{
+		ChannelID:   5,
+		BandwidthHz: 6_250,
+		SpacingHz:   6_250,
+		TxOffsetHz:  5_000_000,
+		BaseHz:      154_000_000,
+	}
+	out := ParseIdentifierUpdate(AssembleIdentifierUpdate(in))
+	if out != in {
+		t.Errorf("round-trip mismatch: got %+v want %+v", out, in)
+	}
+}
+
+func TestBandPlanResolvesKnownChannel(t *testing.T) {
+	bp := &BandPlan{}
+	bp.Apply(IdentifierUpdate{
+		ChannelID: 1,
+		SpacingHz: 12_500,
+		BaseHz:    851_000_000,
+	})
+
+	// Channel 0 → base. Channel 16 → base + 16 × 12.5 kHz = 851.2 MHz.
+	if hz, err := bp.Frequency(1, 0); err != nil || hz != 851_000_000 {
+		t.Errorf("Frequency(1,0) = %d, %v; want 851_000_000, nil", hz, err)
+	}
+	if hz, err := bp.Frequency(1, 16); err != nil || hz != 851_200_000 {
+		t.Errorf("Frequency(1,16) = %d, %v; want 851_200_000, nil", hz, err)
+	}
+}
+
+func TestBandPlanUnknownChannelID(t *testing.T) {
+	bp := &BandPlan{}
+	_, err := bp.Frequency(7, 0)
+	if !errors.Is(err, ErrUnknownChannelID) {
+		t.Errorf("Frequency on empty plan: err = %v, want ErrUnknownChannelID", err)
+	}
+	if bp.Known(7) {
+		t.Error("Known(7) on empty plan should be false")
+	}
+}
+
+func TestBandPlanReplacesSlotOnNewIdentifierUpdate(t *testing.T) {
+	bp := &BandPlan{}
+	bp.Apply(IdentifierUpdate{ChannelID: 2, SpacingHz: 12_500, BaseHz: 851_000_000})
+	bp.Apply(IdentifierUpdate{ChannelID: 2, SpacingHz: 25_000, BaseHz: 852_000_000})
+
+	hz, err := bp.Frequency(2, 4)
+	if err != nil {
+		t.Fatalf("Frequency: %v", err)
+	}
+	if hz != 852_100_000 {
+		t.Errorf("hz = %d, want 852_100_000 (uses replaced slot)", hz)
+	}
+}
+
+func TestBandPlanRejectsOverflow(t *testing.T) {
+	bp := &BandPlan{}
+	bp.Apply(IdentifierUpdate{ChannelID: 0, SpacingHz: 1_000_000, BaseHz: 4_000_000_000})
+	if _, err := bp.Frequency(0, 1000); err == nil {
+		t.Error("expected overflow error for >4.29 GHz resolved frequency")
+	}
+}

--- a/internal/trunking/cchunt.go
+++ b/internal/trunking/cchunt.go
@@ -8,9 +8,19 @@ import (
 	"time"
 
 	"github.com/MattCheramie/GopherTrunk/internal/events"
-	"github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase1"
 	"github.com/MattCheramie/GopherTrunk/internal/sdr"
 )
+
+// LockedPayload is the protocol-neutral shape the hunter expects on
+// CCLocked events. Each radio package's LockState satisfies it via
+// methods, so the hunter can stay protocol-agnostic instead of
+// importing every radio package (which would also create import
+// cycles, since some radio packages now import this `trunking`
+// package to publish `Grant` events).
+type LockedPayload interface {
+	LockedFrequencyHz() uint32
+	LockedNAC() uint16
+}
 
 // Tuner is the subset of sdr.Device the hunter needs. Decoupling from the
 // full Device interface keeps the hunter testable without an IQ source.
@@ -109,22 +119,23 @@ func (h *Hunter) Hunt(ctx context.Context) (LockResult, error) {
 		locked, ok := waitForLock(ctx, sub, deadline.C, freq)
 		deadline.Stop()
 		if ok {
+			nac := locked.LockedNAC()
 			result := LockResult{
 				System:    h.system.Name,
 				Frequency: freq,
-				NAC:       locked.NAC,
+				NAC:       nac,
 				At:        time.Now().UTC(),
 			}
 			if h.cache != nil {
 				if err := h.cache.Set(h.system.Name, CachedSystem{
 					LastFrequencyHz: freq,
 					LastLockAt:      result.At,
-					NAC:             locked.NAC,
+					NAC:             nac,
 				}); err != nil {
 					h.log.Warn("cc-hunt: cache write failed", "err", err)
 				}
 			}
-			h.log.Info("cc-hunt: locked", "system", h.system.Name, "freq_hz", freq, "nac", locked.NAC)
+			h.log.Info("cc-hunt: locked", "system", h.system.Name, "freq_hz", freq, "nac", nac)
 			return result, nil
 		}
 		if err := ctx.Err(); err != nil {
@@ -159,28 +170,28 @@ func drainSubscription(sub *events.Subscription) {
 	}
 }
 
-func waitForLock(ctx context.Context, sub *events.Subscription, timeout <-chan time.Time, freq uint32) (phase1.LockState, bool) {
+func waitForLock(ctx context.Context, sub *events.Subscription, timeout <-chan time.Time, freq uint32) (LockedPayload, bool) {
 	for {
 		select {
 		case ev, ok := <-sub.C:
 			if !ok {
-				return phase1.LockState{}, false
+				return nil, false
 			}
 			if ev.Kind != events.KindCCLocked {
 				continue
 			}
-			ls, ok := ev.Payload.(phase1.LockState)
+			lp, ok := ev.Payload.(LockedPayload)
 			if !ok {
 				continue
 			}
-			if ls.FrequencyHz != freq {
+			if lp.LockedFrequencyHz() != freq {
 				continue
 			}
-			return ls, true
+			return lp, true
 		case <-timeout:
-			return phase1.LockState{}, false
+			return nil, false
 		case <-ctx.Done():
-			return phase1.LockState{}, false
+			return nil, false
 		}
 	}
 }

--- a/internal/trunking/cchunt_test.go
+++ b/internal/trunking/cchunt_test.go
@@ -1,4 +1,4 @@
-package trunking
+package trunking_test
 
 import (
 	"context"
@@ -10,6 +10,7 @@ import (
 
 	"github.com/MattCheramie/GopherTrunk/internal/events"
 	"github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase1"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
 )
 
 // fakeTuner records SetCenterFreq calls and lets the test publish a fake
@@ -33,10 +34,10 @@ func (f *fakeTuner) tuned() []uint32 {
 	return append([]uint32(nil), f.freqs...)
 }
 
-func newSystem() System {
-	return System{
+func newSystem() trunking.System {
+	return trunking.System{
 		Name:            "TestSys",
-		Protocol:        ProtocolP25,
+		Protocol:        trunking.ProtocolP25,
 		ControlChannels: []uint32{851_000_000, 852_000_000, 853_000_000},
 	}
 }
@@ -46,12 +47,12 @@ func TestHunterLocksOnFirstResponsiveFreq(t *testing.T) {
 	defer bus.Close()
 	tuner := &fakeTuner{}
 	cachePath := filepath.Join(t.TempDir(), "cc.json")
-	cache, err := OpenCache(cachePath)
+	cache, err := trunking.OpenCache(cachePath)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	h, err := NewHunter(HunterOptions{
+	h, err := trunking.NewHunter(trunking.HunterOptions{
 		System: newSystem(),
 		Tuner:  tuner,
 		Bus:    bus,
@@ -94,7 +95,7 @@ func TestHunterReturnsErrWhenAllExpire(t *testing.T) {
 	bus := events.NewBus(8)
 	defer bus.Close()
 	tuner := &fakeTuner{}
-	h, _ := NewHunter(HunterOptions{
+	h, _ := trunking.NewHunter(trunking.HunterOptions{
 		System: newSystem(),
 		Tuner:  tuner,
 		Bus:    bus,
@@ -103,7 +104,7 @@ func TestHunterReturnsErrWhenAllExpire(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
 	defer cancel()
 	_, err := h.Hunt(ctx)
-	if !errors.Is(err, ErrNoControlChannel) {
+	if !errors.Is(err, trunking.ErrNoControlChannel) {
 		t.Errorf("err = %v, want ErrNoControlChannel", err)
 	}
 	if got := tuner.tuned(); len(got) != 3 {
@@ -115,14 +116,14 @@ func TestHunterStartsFromCachedFreq(t *testing.T) {
 	bus := events.NewBus(8)
 	defer bus.Close()
 	tuner := &fakeTuner{}
-	cache, err := OpenCache(filepath.Join(t.TempDir(), "cc.json"))
+	cache, err := trunking.OpenCache(filepath.Join(t.TempDir(), "cc.json"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := cache.Set("TestSys", CachedSystem{LastFrequencyHz: 853_000_000, NAC: 0xABC}); err != nil {
+	if err := cache.Set("TestSys", trunking.CachedSystem{LastFrequencyHz: 853_000_000, NAC: 0xABC}); err != nil {
 		t.Fatal(err)
 	}
-	h, _ := NewHunter(HunterOptions{
+	h, _ := trunking.NewHunter(trunking.HunterOptions{
 		System: newSystem(),
 		Tuner:  tuner,
 		Bus:    bus,
@@ -154,7 +155,7 @@ func TestHunterIgnoresMismatchedFreq(t *testing.T) {
 	bus := events.NewBus(8)
 	defer bus.Close()
 	tuner := &fakeTuner{}
-	h, _ := NewHunter(HunterOptions{
+	h, _ := trunking.NewHunter(trunking.HunterOptions{
 		System: newSystem(),
 		Tuner:  tuner,
 		Bus:    bus,
@@ -174,7 +175,7 @@ func TestHunterIgnoresMismatchedFreq(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
 	_, err := h.Hunt(ctx)
-	if !errors.Is(err, ErrNoControlChannel) {
+	if !errors.Is(err, trunking.ErrNoControlChannel) {
 		t.Errorf("err = %v, want ErrNoControlChannel", err)
 	}
 	if got := tuner.tuned(); len(got) != 3 {
@@ -185,7 +186,7 @@ func TestHunterIgnoresMismatchedFreq(t *testing.T) {
 func TestHunterReturnsCtxErr(t *testing.T) {
 	bus := events.NewBus(8)
 	defer bus.Close()
-	h, _ := NewHunter(HunterOptions{
+	h, _ := trunking.NewHunter(trunking.HunterOptions{
 		System: newSystem(),
 		Tuner:  &fakeTuner{},
 		Bus:    bus,
@@ -201,8 +202,8 @@ func TestHunterReturnsCtxErr(t *testing.T) {
 func TestNewHunterValidatesSystem(t *testing.T) {
 	bus := events.NewBus(1)
 	defer bus.Close()
-	_, err := NewHunter(HunterOptions{
-		System: System{Name: "X"}, // missing protocol + channels
+	_, err := trunking.NewHunter(trunking.HunterOptions{
+		System: trunking.System{Name: "X"}, // missing protocol + channels
 		Tuner:  &fakeTuner{},
 		Bus:    bus,
 	})


### PR DESCRIPTION
## Summary

Closes the README's "Live P25 grant emission" gap. The TSBK pipeline
(NID BCH + Annex-A trellis + 98-dibit deinterleaver + CRC) was already
end-to-end; this PR teaches the control channel to track IDENT_UP
broadcasts, resolve voice-grant channels into RX frequencies, and
publish `protocol = "p25"` `trunking.Grant` events on the bus.

### What changed

- **`internal/radio/p25/phase1/identifier.go`** — new `IdentifierUpdate`
  struct + `Parse`/`Assemble` for opcode 0x3D (700/800/900 MHz form).
  Bit layout follows TIA-102.AABF Table 14:
  `ChannelID(4) | BW(9) | OFF(9) | STEP(10) | FREQ(32)`. `BandPlan`
  resolver indexes 16 slots and answers
  `Frequency(channelID, channelNum)`, returning
  `ErrUnknownChannelID` when no IDENT_UP for that ID has been seen.
- **`internal/radio/p25/phase1/control.go`** — switched to an `Options`
  constructor (legacy `NewControlChannel` still works, callers don't
  need to migrate). Holds band-plan state, dispatches CRC'd TSBKs by
  opcode. `OpIdentifierUpdate` feeds the resolver;
  `OpGroupVoiceChannelGrant` publishes a `trunking.Grant` with
  `ServiceOptions` decoded into `Encrypted` + `Emergency` flags. A
  grant whose `ChannelID` hasn't been announced yet emits a
  `decode.error` with `stage="no-bandplan"` so the metric counter
  surfaces the gap (e.g. when a site's IDENT_UP cadence is too slow).
- **Cycle break.** `phase1` now imports `trunking` (for the `Grant`
  payload), but `trunking/cchunt.go` was importing `phase1.LockState`,
  which would cycle. `phase1.LockState` gains
  `LockedFrequencyHz()` / `LockedNAC()` methods to satisfy a new
  `trunking.LockedPayload` interface; the hunter consumes the
  interface instead of the concrete type. `cchunt_test.go` moved to
  `package trunking_test` (external test) so it can keep importing
  `phase1` for the `LockState` fixture without re-introducing the
  cycle.
- **`README.md`** — moves P25 grant emission from "known gap" to the
  protocols table; refreshes the `decode.error` stage list to include
  `no-bandplan`.

### Tests

- `IdentifierUpdate` Assemble/Parse round-trip with a realistic
  700/800 MHz fixture (851 MHz base, 12.5 kHz spacing, −39 MHz tx
  offset) and a VHF fixture with a positive offset to exercise the
  9-bit signed encoding.
- `BandPlan` resolves known channel IDs, errors on unknown, replaces
  slots when a fresh IDENT_UP arrives, and refuses to wrap on
  >4.29 GHz overflow.
- `ControlChannelAppliesIdentifierUpdateAndPublishesGrant`: synthetic
  dibit stream with IDENT_UP then GroupVoiceChannelGrant publishes a
  `trunking.Grant` with the right
  `System`/`Protocol`/`GroupID`/`SourceID`/`ChannelID`/`ChannelNum`/`FrequencyHz`
  and Encrypted+Emergency flags lifted from `SVC_OPTIONS`.
- `ControlChannelGrantBeforeIdentifierUpdateEmitsDecodeError`:
  GroupVoiceChannelGrant arriving before any IDENT_UP publishes
  `decode.error` with `stage="no-bandplan"` and no `Grant` event.
- All existing P25 + trunking + voice/composer/recorder tests stay
  green. Full `go test ./...` passes.

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./internal/radio/p25/phase1/... ./internal/trunking/...`
- [x] `go test ./...` (full suite, all packages green)
- [ ] Manual: feed a captured 700/800 MHz P25 control-channel IQ
      stream through the daemon and confirm `protocol="p25"` grants
      land on the bus / Prometheus.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PHnwos5vaxtoDiSi32maZz)_