### PR TITLE
DMR Tier II: FLC parser + conventional-mode grant emission

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A headless, low-latency digital-trunking scanner engine in Go.
 
 GopherTrunk manages a pool of RTL-SDR dongles, runs a custom Go DSP
 pipeline, decodes the signalling layers of every major trunked-radio
-family (P25 Phase 1 / Phase 2, DMR Tier III, NXDN, Motorola Type II /
+family (P25 Phase 1 / Phase 2, DMR Tier II / III, NXDN, Motorola Type II /
 SmartZone, EDACS / GE-Marc, LTR, MPT 1327, dPMR Mode 3, TETRA TMO)
 plus the D-STAR amateur repeater header, follows voice grants by
 talkgroup priority, and streams metadata + audio to any frontend over
@@ -20,6 +20,7 @@ gRPC, HTTP/SSE, or WebSocket.
 | P25 Phase 1       | 48-bit FSW + sync detector, NID parser (NAC + DUID) with BCH(63,16,11) error correction + even-parity check, full TSBK channel decode (TIA-102.BAAA Annex A 4-state ½-rate trellis + 98-dibit block deinterleaver) → CRC trailer validation, payload parsers for GroupVoiceChannelGrant / Update / NetworkStatus / RFSSStatus, IdentifierUpdate band-plan resolver, control-channel state machine emitting `protocol = "p25"` grants and `decode.error` events with `nid-bch` / `tsbk-trellis` / `tsbk-crc` / `no-bandplan` stages |
 | P25 Phase 2       | Outbound + inbound 20-dibit sync, 360 ms / 12-subframe superframe + SlotType enum, MAC PDU parser + opcode enum, GroupVoiceChannelGrant accessor, control-channel state machine emitting `protocol = "p25-phase2"` grants |
 | DMR (Tier III)    | All 9 ETSI sync patterns, burst layout (132 dibits), Color Code + Data Type via (20,8,7) shortened-Hamming slot-type FEC (corrects up to 3 bit errors per slot type), CSBK with CRC, payload parsers for TalkGroup/Private Voice grants + Aloha + AdjacentSiteStatus + SystemInfoBroadcast, control-channel state machine |
+| DMR (Tier II)     | Shares the burst / slot-type / BPTC(196,96) layers with Tier III; adds a 72-bit Full Link Control parser (FLCO enum: GroupVoiceChannelUser / UnitToUnitVoice / TalkerAlias / GPS / Terminator) and a per-repeater conventional-mode state machine that decodes Voice LC Header bursts and emits `protocol = "dmr-tier2"` grants on the bus, deduped per call and cleared on Terminator-with-LC |
 | NXDN              | 192-dibit frame layout (4800 BFSK / 9600 4-FSK), LICH parse with parity + 16-bit doubled-wire decoder, FSW correlator, full SACCH channel decode (K=5 ½-rate convolutional Viterbi + 60-position sub-frame deinterleaver + 12-bit puncture undo + CRC-6 trailer), CAC parser with CRC, RCCH opcode enum + payload parsers, control-channel state machine |
 | Motorola Type II  | OSW parser, opcode constants, LCN → Hz band-plan resolver (linear + table), control-channel state machine emitting `protocol = "motorola"` grants |
 | EDACS / GE-Marc   | 40-bit CCW parser, command enum (Idle / GroupVoiceGrant / ProVoiceGrant / IndividualCall / DataGrant / SystemID / AdjacentSite / Emergency / Affiliation / Encryption), per-command accessors with encrypted / emergency flags, LCN → Hz resolver, control-channel state machine emitting `protocol = "edacs"` grants |
@@ -47,9 +48,6 @@ control channel locks, the engine allocates a Voice device on a
 grant, the composer pulls IQ → PCM → WAV, and the call is logged to
 SQLite. The honest gaps:
 
-- **DMR Tier II** is mostly a configuration variation on the Tier
-  III scaffolding that's already in place; both share the burst,
-  slot-type, and BPTC pieces.
 - **Digital voice** (P25 Phase 1 IMBE; AMBE+2 for P25 Phase 2 / DMR
   / NXDN) is gated on the vocoders. The `Vocoder` plugin interface
   + raw-frame sidecar are in place; pure-Go IMBE is in progress

--- a/internal/radio/dmr/flc.go
+++ b/internal/radio/dmr/flc.go
@@ -1,0 +1,130 @@
+package dmr
+
+import (
+	"errors"
+	"fmt"
+)
+
+// FLCO is the 6-bit Full Link Control Opcode field.
+type FLCO uint8
+
+// FLCO values per ETSI TS 102 361-2 §7.1.1 Table 7.1. Only the most
+// commonly-seen voice-call opcodes are listed here; vendor extensions
+// live behind FID != 0.
+const (
+	FLCOGroupVoiceUser FLCO = 0x00 // Group voice channel user
+	FLCOUnitToUnitVoice FLCO = 0x03 // Unit-to-Unit voice channel user
+	FLCOTalkerAlias    FLCO = 0x04 // Talker alias header
+	FLCOGPS            FLCO = 0x08 // GPS info
+	FLCOTerminator     FLCO = 0x30 // Terminator
+)
+
+func (o FLCO) String() string {
+	switch o {
+	case FLCOGroupVoiceUser:
+		return "GroupVoiceChannelUser"
+	case FLCOUnitToUnitVoice:
+		return "UnitToUnitVoiceChannelUser"
+	case FLCOTalkerAlias:
+		return "TalkerAlias"
+	case FLCOGPS:
+		return "GPSInfo"
+	case FLCOTerminator:
+		return "Terminator"
+	default:
+		return fmt.Sprintf("FLCO(%02X)", uint8(o))
+	}
+}
+
+// FLC is a parsed 72-bit Full Link Control PDU. The Voice LC Header
+// burst (DataType 0x1) and the Terminator with LC burst (DataType
+// 0x2) both carry an FLC followed by a 24-bit RS(12,9) parity trailer
+// inside the BPTC(196,96) info block.
+//
+// Layout per ETSI TS 102 361-2 §7.1 (9 octets / 72 bits):
+//
+//	octet 0 : PF(1) | Reserved(1) | FLCO(6)
+//	octet 1 : FID
+//	octet 2 : ServiceOptions
+//	octet 3-5 : Destination address (24-bit; group address for
+//	            FLCOGroupVoiceUser, subscriber for FLCOUnitToUnitVoice)
+//	octet 6-8 : Source address (24-bit subscriber)
+type FLC struct {
+	PF             bool
+	FLCO           FLCO
+	FID            uint8
+	ServiceOptions uint8
+	DstAddr        uint32 // 24-bit
+	SrcAddr        uint32 // 24-bit
+}
+
+// ErrFLCLength is returned by ParseFLC when the supplied buffer is
+// shorter than the 9 FLC octets.
+var ErrFLCLength = errors.New("dmr: FLC requires 9 octets")
+
+// ParseFLC decodes the leading 9 octets of a BPTC(196,96)-recovered
+// info block as a Full Link Control PDU. The remaining 3 octets carry
+// the RS(12,9) parity trailer; verifying it is intentionally
+// out-of-scope for this pass — the BPTC layer already supplies error
+// correction over the same bits, and adding RS(12,9) over hexadecimal
+// symbols is a separate, self-contained piece of work.
+func ParseFLC(info []byte) (FLC, error) {
+	if len(info) < 9 {
+		return FLC{}, fmt.Errorf("%w, got %d", ErrFLCLength, len(info))
+	}
+	return FLC{
+		PF:             info[0]&0x80 != 0,
+		FLCO:           FLCO(info[0] & 0x3F),
+		FID:            info[1],
+		ServiceOptions: info[2],
+		DstAddr:        uint32(info[3])<<16 | uint32(info[4])<<8 | uint32(info[5]),
+		SrcAddr:        uint32(info[6])<<16 | uint32(info[7])<<8 | uint32(info[8]),
+	}, nil
+}
+
+// AssembleFLC packs an FLC into 9 octets (the data-symbol portion of
+// the 12-octet RS(12,9) frame). RS parity is not generated here;
+// callers building synthetic streams concatenate three zero octets to
+// reach the 12-byte info block expected by BPTC encode.
+func AssembleFLC(f FLC) []byte {
+	out := make([]byte, 9)
+	out[0] = byte(f.FLCO) & 0x3F
+	if f.PF {
+		out[0] |= 0x80
+	}
+	out[1] = f.FID
+	out[2] = f.ServiceOptions
+	out[3] = byte(f.DstAddr >> 16)
+	out[4] = byte(f.DstAddr >> 8)
+	out[5] = byte(f.DstAddr)
+	out[6] = byte(f.SrcAddr >> 16)
+	out[7] = byte(f.SrcAddr >> 8)
+	out[8] = byte(f.SrcAddr)
+	return out
+}
+
+// GroupVoiceChannelUser is the structured shape of an FLC whose FLCO
+// is FLCOGroupVoiceUser. Mirrors the EDACS / P25 voice-grant accessor
+// pattern: pure data, no parsing side-effects.
+type GroupVoiceChannelUser struct {
+	GroupAddress uint32 // 24-bit
+	SourceID     uint32 // 24-bit
+	Encrypted    bool
+	Emergency    bool
+}
+
+// AsGroupVoiceUser decodes the FLC into the typed group-voice payload
+// when its FLCO matches; otherwise (zero, false). ServiceOptions bit 7
+// is the emergency flag and bit 6 is the privacy/encrypted flag, per
+// §7.2.1 Table 7.13.
+func (f FLC) AsGroupVoiceUser() (GroupVoiceChannelUser, bool) {
+	if f.FLCO != FLCOGroupVoiceUser {
+		return GroupVoiceChannelUser{}, false
+	}
+	return GroupVoiceChannelUser{
+		GroupAddress: f.DstAddr,
+		SourceID:     f.SrcAddr,
+		Emergency:    f.ServiceOptions&0x80 != 0,
+		Encrypted:    f.ServiceOptions&0x40 != 0,
+	}, true
+}

--- a/internal/radio/dmr/flc_test.go
+++ b/internal/radio/dmr/flc_test.go
@@ -1,0 +1,81 @@
+package dmr
+
+import "testing"
+
+func TestFLCRoundTripGroupVoiceUser(t *testing.T) {
+	in := FLC{
+		PF:             false,
+		FLCO:           FLCOGroupVoiceUser,
+		FID:            0x00,
+		ServiceOptions: 0xC0, // emergency + encrypted
+		DstAddr:        0x00ABCD, // talkgroup
+		SrcAddr:        0x123456, // subscriber
+	}
+	out, err := ParseFLC(AssembleFLC(in))
+	if err != nil {
+		t.Fatalf("ParseFLC: %v", err)
+	}
+	if out != in {
+		t.Errorf("round-trip:\n got %+v\nwant %+v", out, in)
+	}
+}
+
+func TestFLCRoundTripUnitToUnit(t *testing.T) {
+	in := FLC{
+		FLCO:    FLCOUnitToUnitVoice,
+		FID:     0x10,
+		DstAddr: 0xFEDCBA,
+		SrcAddr: 0x00DEAD,
+	}
+	out, err := ParseFLC(AssembleFLC(in))
+	if err != nil {
+		t.Fatalf("ParseFLC: %v", err)
+	}
+	if out != in {
+		t.Errorf("round-trip mismatch: %+v != %+v", out, in)
+	}
+}
+
+func TestFLCRejectsShortBuffer(t *testing.T) {
+	if _, err := ParseFLC(make([]byte, 8)); err == nil {
+		t.Error("expected error for 8-byte buffer")
+	}
+}
+
+func TestFLCAsGroupVoiceUser(t *testing.T) {
+	f := FLC{
+		FLCO:           FLCOGroupVoiceUser,
+		ServiceOptions: 0x80, // emergency only
+		DstAddr:        0x000064,
+		SrcAddr:        0x100200,
+	}
+	g, ok := f.AsGroupVoiceUser()
+	if !ok {
+		t.Fatal("expected ok")
+	}
+	if g.GroupAddress != 0x64 || g.SourceID != 0x100200 {
+		t.Errorf("addresses = %x/%x", g.GroupAddress, g.SourceID)
+	}
+	if !g.Emergency || g.Encrypted {
+		t.Errorf("flags = emer=%v enc=%v, want emer=true enc=false", g.Emergency, g.Encrypted)
+	}
+
+	// Wrong opcode → no group-voice projection.
+	if _, ok := (FLC{FLCO: FLCOTerminator}).AsGroupVoiceUser(); ok {
+		t.Error("Terminator FLC reported as group-voice user")
+	}
+}
+
+func TestFLCOStringCoversKnownAndUnknown(t *testing.T) {
+	cases := map[FLCO]string{
+		FLCOGroupVoiceUser:  "GroupVoiceChannelUser",
+		FLCOUnitToUnitVoice: "UnitToUnitVoiceChannelUser",
+		FLCOTerminator:      "Terminator",
+		FLCO(0x2A):          "FLCO(2A)",
+	}
+	for code, want := range cases {
+		if got := code.String(); got != want {
+			t.Errorf("%X.String() = %s, want %s", uint8(code), got, want)
+		}
+	}
+}

--- a/internal/radio/dmr/tier2/conventional.go
+++ b/internal/radio/dmr/tier2/conventional.go
@@ -1,0 +1,158 @@
+// Package tier2 decodes DMR Tier II conventional traffic. Tier II
+// runs without a control channel: a repeater carries voice + signaling
+// on a fixed frequency, and the start of every transmission is marked
+// by a Voice LC Header burst whose 96-bit BPTC info block carries a
+// Full Link Control PDU (source, destination, group/private flag).
+//
+// ConventionalChannel is the per-repeater state machine that watches
+// for those headers and republishes them as protocol-agnostic
+// trunking.Grant events. Compared to Tier III (internal/radio/dmr/tier3)
+// the wire format is identical at the burst + slot-type + BPTC layers
+// — only the call-setup mechanism differs (embedded LC vs. CSBK).
+package tier2
+
+import (
+	"log/slog"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/dmr"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// ConventionalChannel ingests bursts from one Tier II repeater
+// frequency and emits a trunking.Grant the first time a Voice LC
+// Header burst announces a new (talkgroup, source) tuple. Subsequent
+// header bursts within the same superframe are de-duplicated so a
+// long transmission produces exactly one grant. A Terminator with
+// Link Control burst clears the state so the next transmission
+// triggers a fresh grant.
+type ConventionalChannel struct {
+	bus        *events.Bus
+	log        *slog.Logger
+	systemName string
+	freqHz     uint32
+	now        func() time.Time
+
+	inCall  bool
+	lastTG  uint32
+	lastSrc uint32
+}
+
+// Options configure a ConventionalChannel.
+type Options struct {
+	Bus         *events.Bus
+	Log         *slog.Logger
+	SystemName  string
+	FrequencyHz uint32
+	Now         func() time.Time
+}
+
+// New constructs a ConventionalChannel.
+func New(opts Options) *ConventionalChannel {
+	log := opts.Log
+	if log == nil {
+		log = slog.Default()
+	}
+	now := opts.Now
+	if now == nil {
+		now = time.Now
+	}
+	return &ConventionalChannel{
+		bus:        opts.Bus,
+		log:        log,
+		systemName: opts.SystemName,
+		freqHz:     opts.FrequencyHz,
+		now:        now,
+	}
+}
+
+// IngestBurst hands one DMR burst (with its already-decoded slot type)
+// to the state machine. Bursts whose data type isn't a Voice LC
+// Header or Terminator-with-LC are ignored: voice payload bursts (B-F)
+// don't carry a fresh FLC, and CSBK bursts belong to Tier III.
+func (c *ConventionalChannel) IngestBurst(b *dmr.Burst, slot dmr.SlotType) {
+	switch slot.DataType {
+	case dmr.DTVoiceLCHeader:
+		c.handleVoiceHeader(b, slot)
+	case dmr.DTTerminatorWithLC:
+		c.handleTerminator()
+	}
+}
+
+func (c *ConventionalChannel) handleVoiceHeader(b *dmr.Burst, slot dmr.SlotType) {
+	bits, errs := framing.DecodeBPTC196_96(b.PayloadBits())
+	if errs < 0 {
+		c.log.Debug("dmr/tier2: voice header BPTC uncorrectable")
+		c.bus.Publish(events.Event{
+			Kind:    events.KindDecodeError,
+			Payload: events.DecodeError{Protocol: "dmr-tier2", Stage: "voiceheader-bptc"},
+		})
+		return
+	}
+	flc, err := dmr.ParseFLC(infoBitsToBytes(bits))
+	if err != nil {
+		c.log.Debug("dmr/tier2: FLC parse failed", "err", err)
+		return
+	}
+	gv, ok := flc.AsGroupVoiceUser()
+	if !ok {
+		// Unit-to-unit and other opcodes are out of scope for this
+		// pass — the engine's grant model is talkgroup-keyed.
+		c.log.Debug("dmr/tier2: non-group FLCO ignored", "flco", flc.FLCO)
+		return
+	}
+	if c.inCall && c.lastTG == gv.GroupAddress && c.lastSrc == gv.SourceID {
+		// Same call's repeated Voice LC Header — dedupe.
+		return
+	}
+	c.inCall = true
+	c.lastTG = gv.GroupAddress
+	c.lastSrc = gv.SourceID
+	c.bus.Publish(events.Event{
+		Kind: events.KindGrant,
+		Payload: trunking.Grant{
+			System:      c.systemName,
+			Protocol:    "dmr-tier2",
+			GroupID:     gv.GroupAddress,
+			SourceID:    gv.SourceID,
+			FrequencyHz: c.freqHz,
+			ChannelID:   slot.ColorCode,
+			Encrypted:   gv.Encrypted,
+			Emergency:   gv.Emergency,
+			At:          c.now(),
+		},
+	})
+	c.log.Debug("dmr/tier2: grant",
+		"system", c.systemName, "freq_hz", c.freqHz,
+		"cc", slot.ColorCode, "tg", gv.GroupAddress, "src", gv.SourceID,
+		"enc", gv.Encrypted, "emer", gv.Emergency)
+}
+
+func (c *ConventionalChannel) handleTerminator() {
+	if !c.inCall {
+		return
+	}
+	c.inCall = false
+	c.lastTG = 0
+	c.lastSrc = 0
+	c.log.Debug("dmr/tier2: terminator")
+}
+
+// infoBitsToBytes packs a 96-bit slice (each entry 0/1, MSB-first)
+// into 12 bytes — the same shape ParseFLC expects for its leading 9
+// octets, with the trailing 3 octets carrying RS(12,9) parity that
+// this package intentionally ignores for now.
+func infoBitsToBytes(bits []byte) []byte {
+	if len(bits) != 96 {
+		panic("dmr/tier2: infoBitsToBytes requires 96 bits")
+	}
+	out := make([]byte, 12)
+	for i := 0; i < 96; i++ {
+		if bits[i]&1 != 0 {
+			out[i>>3] |= 1 << uint(7-(i&7))
+		}
+	}
+	return out
+}

--- a/internal/radio/dmr/tier2/conventional_test.go
+++ b/internal/radio/dmr/tier2/conventional_test.go
@@ -1,0 +1,181 @@
+package tier2
+
+import (
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/dmr"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// burstWithFLC builds a Voice-LC-Header-shaped burst whose 96-bit
+// info block is the supplied FLC followed by 3 zero RS-parity octets.
+// Three zero octets aren't a valid RS(12,9) parity, but parseFLC
+// ignores the trailer so this is sufficient for state-machine tests.
+func burstWithFLC(f dmr.FLC) *dmr.Burst {
+	flcBytes := dmr.AssembleFLC(f)
+	info := make([]byte, 12)
+	copy(info, flcBytes) // bytes 9..11 stay zero (RS placeholder)
+
+	bits := make([]byte, 96)
+	for i := 0; i < 96; i++ {
+		bits[i] = (info[i>>3] >> uint(7-(i&7))) & 1
+	}
+	channel := framing.EncodeBPTC196_96(bits)
+
+	var b dmr.Burst
+	for i := 0; i < dmr.HalfPayloadDibits; i++ {
+		b.Dibits[i] = (channel[2*i] << 1) | channel[2*i+1]
+	}
+	for i := 0; i < dmr.HalfPayloadDibits; i++ {
+		b.Dibits[dmr.BurstDibits-dmr.HalfPayloadDibits+i] =
+			(channel[2*(dmr.HalfPayloadDibits+i)] << 1) | channel[2*(dmr.HalfPayloadDibits+i)+1]
+	}
+	return &b
+}
+
+func TestConventionalPublishesGrantOnVoiceLCHeader(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{
+		Bus:         bus,
+		SystemName:  "TestRepeater",
+		FrequencyHz: 451_000_000,
+		Now:         func() time.Time { return time.Unix(1_700_000_000, 0).UTC() },
+	})
+	flc := dmr.FLC{
+		FLCO:           dmr.FLCOGroupVoiceUser,
+		FID:            0x00,
+		ServiceOptions: 0xC0, // emergency + encrypted
+		DstAddr:        0x000064,
+		SrcAddr:        0x100200,
+	}
+	cc.IngestBurst(burstWithFLC(flc), dmr.SlotType{ColorCode: 5, DataType: dmr.DTVoiceLCHeader})
+
+	select {
+	case ev := <-sub.C:
+		if ev.Kind != events.KindGrant {
+			t.Fatalf("kind = %s", ev.Kind)
+		}
+		g, ok := ev.Payload.(trunking.Grant)
+		if !ok {
+			t.Fatalf("payload type = %T", ev.Payload)
+		}
+		if g.System != "TestRepeater" || g.Protocol != "dmr-tier2" {
+			t.Errorf("identity = %s/%s", g.System, g.Protocol)
+		}
+		if g.GroupID != 0x64 || g.SourceID != 0x100200 {
+			t.Errorf("group/source = %d/%d", g.GroupID, g.SourceID)
+		}
+		if g.FrequencyHz != 451_000_000 || g.ChannelID != 5 {
+			t.Errorf("freq/cc = %d/%d", g.FrequencyHz, g.ChannelID)
+		}
+		if !g.Encrypted || !g.Emergency {
+			t.Errorf("flags = enc=%v emer=%v, want both", g.Encrypted, g.Emergency)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("no grant event")
+	}
+}
+
+func TestConventionalDedupsRepeatedVoiceLCHeader(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, SystemName: "S", FrequencyHz: 1})
+	flc := dmr.FLC{FLCO: dmr.FLCOGroupVoiceUser, DstAddr: 0x42, SrcAddr: 0x100}
+	slot := dmr.SlotType{ColorCode: 1, DataType: dmr.DTVoiceLCHeader}
+
+	cc.IngestBurst(burstWithFLC(flc), slot) // first header → grant
+	cc.IngestBurst(burstWithFLC(flc), slot) // dedup → no event
+	cc.IngestBurst(burstWithFLC(flc), slot) // dedup → no event
+
+	count := 0
+	timeout := time.After(150 * time.Millisecond)
+	for {
+		select {
+		case <-sub.C:
+			count++
+		case <-timeout:
+			if count != 1 {
+				t.Errorf("got %d grant events, want 1 (dedup expected)", count)
+			}
+			return
+		}
+	}
+}
+
+func TestConventionalNewCallAfterTerminator(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, SystemName: "S", FrequencyHz: 1})
+	flc := dmr.FLC{FLCO: dmr.FLCOGroupVoiceUser, DstAddr: 0x42, SrcAddr: 0x100}
+	hdr := dmr.SlotType{ColorCode: 1, DataType: dmr.DTVoiceLCHeader}
+	term := dmr.SlotType{ColorCode: 1, DataType: dmr.DTTerminatorWithLC}
+
+	cc.IngestBurst(burstWithFLC(flc), hdr) // grant 1
+	cc.IngestBurst(burstWithFLC(flc), term) // call ended
+	cc.IngestBurst(burstWithFLC(flc), hdr) // grant 2 (state cleared)
+
+	count := 0
+	timeout := time.After(150 * time.Millisecond)
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind == events.KindGrant {
+				count++
+			}
+		case <-timeout:
+			if count != 2 {
+				t.Errorf("got %d grants across two calls, want 2", count)
+			}
+			return
+		}
+	}
+}
+
+func TestConventionalIgnoresNonHeaderBursts(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, SystemName: "S", FrequencyHz: 1})
+	flc := dmr.FLC{FLCO: dmr.FLCOGroupVoiceUser, DstAddr: 0x42}
+	cc.IngestBurst(burstWithFLC(flc), dmr.SlotType{ColorCode: 1, DataType: dmr.DTCSBK})
+
+	select {
+	case ev := <-sub.C:
+		t.Errorf("unexpected event for CSBK burst: %s", ev.Kind)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestConventionalIgnoresNonGroupFLCO(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, SystemName: "S", FrequencyHz: 1})
+	// Unit-to-unit calls are intentionally not republished as grants
+	// in this PR; the engine's grant model is talkgroup-keyed.
+	flc := dmr.FLC{FLCO: dmr.FLCOUnitToUnitVoice, DstAddr: 0x100, SrcAddr: 0x200}
+	cc.IngestBurst(burstWithFLC(flc), dmr.SlotType{ColorCode: 1, DataType: dmr.DTVoiceLCHeader})
+
+	select {
+	case ev := <-sub.C:
+		t.Errorf("unit-to-unit FLCO produced an event: %s", ev.Kind)
+	case <-time.After(50 * time.Millisecond):
+	}
+}


### PR DESCRIPTION
## Summary

Closes the README's "DMR Tier II is mostly a configuration variation"
gap. Tier II conventional shares the burst / slot-type / BPTC(196,96)
layers with the existing Tier III scaffolding, but the call-setup
mechanism is different: there's no control channel. A repeater carries
voice + signaling on a fixed frequency and the start of every
transmission is announced by a **Voice LC Header** burst whose 96-bit
BPTC info block carries a 72-bit **Full Link Control** PDU.

### What changed

- **`internal/radio/dmr/flc.go`** — new Full Link Control parser per
  ETSI TS 102 361-2 §7.1. FLCO enum (GroupVoiceUser / UnitToUnitVoice
  / TalkerAlias / GPS / Terminator), `FLC` struct
  (PF / FID / ServiceOptions / DstAddr / SrcAddr), and
  `AsGroupVoiceUser()` projection that lifts Encrypted + Emergency from
  `ServiceOptions` bits 6/7. `ParseFLC` consumes the leading 9 octets
  of a BPTC-recovered 96-bit info block; the trailing 3 octets carry
  RS(12,9) parity that this PR intentionally skips — BPTC already
  corrects bit errors over the same span, and RS(12,9) over hex
  symbols is a separate self-contained piece of work.
- **`internal/radio/dmr/tier2/conventional.go`** — new package +
  state machine. `ConventionalChannel.IngestBurst` dispatches by slot
  `DataType`:
  - `DTVoiceLCHeader` → BPTC196_96 → FLC parse → publishes
    `trunking.Grant{Protocol: "dmr-tier2"}` the first time a
    (talkgroup, source) pair appears. Same-call repeats are deduped
    by the (TG, src) tuple.
  - `DTTerminatorWithLC` → clears state so the next transmission
    triggers a fresh grant.
  - BPTC failures publish a `decode.error` with
    `stage="voiceheader-bptc"`.
- **`README.md`** — Tier II joins the protocols table, the supported-
  families line gains "DMR Tier II / III", and the matching Known Gaps
  bullet drops.

### Tests

- FLC Assemble/Parse round-trip for both `GroupVoiceUser` and
  `UnitToUnitVoice`; short-buffer rejection; `AsGroupVoiceUser`
  projection (flags + wrong-opcode reject); FLCO `String` coverage of
  known + unknown values.
- `ConventionalChannel`: synthetic BPTC-encoded Voice LC Header burst
  publishes a Grant with the right
  `System` / `Protocol` / `GroupID` / `SourceID` / `FrequencyHz` /
  `ColorCode` and `Encrypted`+`Emergency` flags; repeated headers
  dedupe to one Grant; a Terminator-with-LC clears state so the next
  header produces a second Grant; CSBK bursts are ignored (Tier III's
  job); UnitToUnit FLCO is intentionally not republished as a grant
  for now.
- All existing DMR + framing + trunking tests stay green; full
  `go test ./...` passes.

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./internal/radio/dmr/...` green
- [x] `go test ./...` (full suite, all packages green)
- [ ] Manual: feed a captured Tier II conventional repeater IQ stream
      through the daemon (or a synthetic burst stream over the events
      bus) and confirm `protocol="dmr-tier2"` grants appear with the
      expected TG / source / color code.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PHnwos5vaxtoDiSi32maZz)_