### PR TITLE
FM de-emphasis: post-demod single-pole IIR + opt-in composer wiring

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ gRPC, HTTP/SSE, or WebSocket.
 | Area              | Component                                                  |
 | ----------------- | ---------------------------------------------------------- |
 | Hardware          | CGO `librtlsdr` binding, multi-device pool, role assignment, per-device gain (`auto` / tenths-of-dB) + PPM + bias-tee (5 V LNA power, e.g. NESDR Smart v5) applied at open time, DC blocker, IQ-imbalance correction, file-backed IQ replay (mock) |
-| DSP               | Polyphase channelizer, FIR + Kaiser LPF designer + RRC, CIC, halfband, AGC, rational resampler, FM / C4FM / H-DQPSK demods, Mueller-Müller clock recovery, frame-sync correlator |
+| DSP               | Polyphase channelizer, FIR + Kaiser LPF designer + RRC, CIC, halfband, AGC, rational resampler, FM / C4FM / H-DQPSK demods, single-pole IIR de-emphasis (75/50µs), Mueller-Müller clock recovery, frame-sync correlator |
 | FEC primitives    | CRC-CCITT/FALSE, CRC-6 (NXDN SACCH), Hamming(15,11,3), Hamming(13,9,3), Hamming(20,8) (DMR slot-type, t=3), extended Golay(24,12,8), BCH(63,16,11), BPTC(196,96), 4-state ½-rate Viterbi, 16-state K=5 ½-rate Viterbi (NXDN SACCH) |
 | P25 Phase 1       | 48-bit FSW + sync detector, NID parser (NAC + DUID) with BCH(63,16,11) error correction + even-parity check, full TSBK channel decode (TIA-102.BAAA Annex A 4-state ½-rate trellis + 98-dibit block deinterleaver) → CRC trailer validation, payload parsers for GroupVoiceChannelGrant / Update / NetworkStatus / RFSSStatus, IdentifierUpdate band-plan resolver, control-channel state machine emitting `protocol = "p25"` grants and `decode.error` events with `nid-bch` / `tsbk-trellis` / `tsbk-crc` / `no-bandplan` stages |
 | P25 Phase 2       | Outbound + inbound 20-dibit sync, 360 ms / 12-subframe superframe + SlotType enum, MAC PDU parser + opcode enum, GroupVoiceChannelGrant accessor, control-channel state machine emitting `protocol = "p25-phase2"` grants |
@@ -53,10 +53,10 @@ SQLite. The honest gaps:
   + raw-frame sidecar are in place; pure-Go IMBE is in progress
   ([patents have expired](docs/vocoders.md)) and AMBE+2 stays
   behind the `mbelib` build tag.
-- **Higher-fidelity audio**: the FM chain currently does naive
-  decimation rather than proper polyphase resampling, and skips
-  de-emphasis + post-demod LPF + AGC. Quality is good enough to
-  verify wiring; real DSP polish is follow-up work.
+- **Higher-fidelity audio**: the FM chain has opt-in 75/50µs
+  de-emphasis but still does naive decimation rather than proper
+  polyphase resampling, and skips a post-demod LPF + AGC. Quality is
+  good enough to verify wiring; real DSP polish is follow-up work.
 
 The Go interfaces and event payloads carry digital protocols already,
 so the remaining paths light up once IMBE drops in.
@@ -78,10 +78,9 @@ to its own package and lands independently.
 - **Yaesu System Fusion (C4FM, FICH).** Amateur-radio digital mode,
   public spec. New `internal/radio/ysf/` package following the
   D-STAR pattern: header parser + repeater state machine.
-- **Higher-fidelity FM voice chain.** The composer's per-call FM
-  chain currently does naive decimation rather than proper
-  polyphase resampling, and skips de-emphasis + post-demod LPF +
-  AGC. Quality is good enough to verify wiring; this is real DSP
+- **Higher-fidelity FM voice chain.** Opt-in 75/50µs de-emphasis is
+  in (`composer.DeEmphasisConfig`); still pending are proper
+  polyphase resampling, a post-demod LPF, and AGC. This is real DSP
   polish for production audio.
 
 ## Tech stack

--- a/internal/dsp/filter/deemph.go
+++ b/internal/dsp/filter/deemph.go
@@ -1,0 +1,89 @@
+package filter
+
+import (
+	"math"
+	"time"
+)
+
+// DeEmphasis is the single-pole IIR low-pass that recovers the
+// pre-emphasized treble curve broadcast FM transmitters apply for SNR.
+// The transmitter pre-emphasizes (boosts highs) with a single-pole
+// high-shelf characterized by time constant τ; the receiver inverts
+// with the matching low-pass:
+//
+//	H(s) = 1 / (1 + sτ)
+//
+// Discretized impulse-invariant at sample rate fs, the difference
+// equation is:
+//
+//	α   = exp(-1 / (τ × fs))
+//	y[n] = (1 - α) × x[n] + α × y[n-1]
+//
+// The DC gain is unity, the −3 dB cutoff is fc = 1 / (2π τ).
+//
+// Use NewDeEmphasisUS for the 75 µs constant standard in NA, or
+// NewDeEmphasisEU for the 50 µs constant used in most of the world.
+//
+// DeEmphasis is *not* safe for concurrent Process calls — pin it to
+// a single demod goroutine and Reset between calls.
+type DeEmphasis struct {
+	alpha    float32 // feedback weight (close to 1 for treble suppression)
+	oneMinus float32 // input weight (1 - alpha)
+	prev     float32 // last output sample (state)
+}
+
+// Common pre-emphasis time constants. Pass to NewDeEmphasis with the
+// PCM sample rate the filter will see.
+const (
+	DeEmphasis75us = 75 * time.Microsecond // FM broadcast in North America
+	DeEmphasis50us = 50 * time.Microsecond // FM broadcast in Europe / most other regions
+)
+
+// NewDeEmphasis builds a de-emphasis filter tuned to time constant τ
+// at the given sample rate. Both must be positive; the constructor
+// panics otherwise so misconfiguration trips at startup rather than
+// silently producing wrong audio.
+func NewDeEmphasis(tau time.Duration, sampleRate float64) *DeEmphasis {
+	if tau <= 0 {
+		panic("filter: NewDeEmphasis requires a positive time constant")
+	}
+	if sampleRate <= 0 {
+		panic("filter: NewDeEmphasis requires a positive sample rate")
+	}
+	tauSec := tau.Seconds()
+	alpha := math.Exp(-1.0 / (tauSec * sampleRate))
+	return &DeEmphasis{
+		alpha:    float32(alpha),
+		oneMinus: float32(1.0 - alpha),
+	}
+}
+
+// NewDeEmphasisUS is shorthand for NewDeEmphasis(DeEmphasis75us, sampleRate).
+func NewDeEmphasisUS(sampleRate float64) *DeEmphasis {
+	return NewDeEmphasis(DeEmphasis75us, sampleRate)
+}
+
+// Reset clears the filter's running state. Call between calls so
+// stale audio from one transmission doesn't bleed into the next.
+func (d *DeEmphasis) Reset() {
+	d.prev = 0
+}
+
+// Process applies the filter to src and writes the result to dst (or
+// appends to it). dst is reused if it has enough capacity. In-place
+// operation (dst == src) is supported.
+func (d *DeEmphasis) Process(dst, src []float32) []float32 {
+	if cap(dst) >= len(src) {
+		dst = dst[:len(src)]
+	} else {
+		dst = make([]float32, len(src))
+	}
+	prev := d.prev
+	for i, x := range src {
+		y := d.oneMinus*x + d.alpha*prev
+		dst[i] = y
+		prev = y
+	}
+	d.prev = prev
+	return dst
+}

--- a/internal/dsp/filter/deemph_test.go
+++ b/internal/dsp/filter/deemph_test.go
@@ -1,0 +1,140 @@
+package filter
+
+import (
+	"math"
+	"testing"
+	"time"
+)
+
+func TestDeEmphasisDCPassThrough(t *testing.T) {
+	// A constant-DC input must converge to the same DC output. The
+	// filter's DC gain is exactly unity by construction.
+	d := NewDeEmphasis(DeEmphasis75us, 48_000)
+	in := make([]float32, 4096)
+	for i := range in {
+		in[i] = 0.5
+	}
+	out := d.Process(nil, in)
+	last := out[len(out)-1]
+	if math.Abs(float64(last-0.5)) > 1e-3 {
+		t.Errorf("DC steady-state = %f, want 0.5", last)
+	}
+}
+
+func TestDeEmphasisStepResponseMonotonic(t *testing.T) {
+	d := NewDeEmphasis(DeEmphasis75us, 48_000)
+	in := make([]float32, 1024)
+	for i := range in {
+		in[i] = 1.0
+	}
+	out := d.Process(nil, in)
+	for i := 1; i < len(out); i++ {
+		if out[i] < out[i-1] {
+			t.Fatalf("step response non-monotonic at i=%d: %f → %f", i, out[i-1], out[i])
+		}
+	}
+	if out[len(out)-1] < 0.99 {
+		t.Errorf("step response did not converge: last sample = %f", out[len(out)-1])
+	}
+}
+
+func TestDeEmphasisAttenuatesHighFreq(t *testing.T) {
+	// At 75 µs the −3 dB cutoff is fc = 1 / (2π × 75e-6) ≈ 2.122 kHz.
+	// A 100 Hz sinusoid is well below cutoff and should pass with
+	// near-unit gain; a 6 kHz sinusoid is well above and should drop
+	// by ≥ 8 dB. We measure the ratio of mean-squared output to mean-
+	// squared input over the steady-state portion of the response.
+	const fs = 48_000.0
+	const settling = 4096 // samples to skip while the IIR settles
+
+	gain := func(freq float64) float64 {
+		d := NewDeEmphasis(DeEmphasis75us, fs)
+		n := settling + 8192
+		in := make([]float32, n)
+		for i := range in {
+			in[i] = float32(math.Sin(2 * math.Pi * freq * float64(i) / fs))
+		}
+		out := d.Process(nil, in)
+		var inE, outE float64
+		for i := settling; i < n; i++ {
+			inE += float64(in[i]) * float64(in[i])
+			outE += float64(out[i]) * float64(out[i])
+		}
+		return math.Sqrt(outE / inE)
+	}
+
+	low := gain(100)
+	high := gain(6_000)
+	if low < 0.97 || low > 1.01 {
+		t.Errorf("100 Hz gain = %.3f, want ≈1.0", low)
+	}
+	if high > 0.4 {
+		t.Errorf("6 kHz gain = %.3f, want < 0.4 (≥ 8 dB attenuation)", high)
+	}
+	if high >= low {
+		t.Errorf("expected high freq attenuated more than low: low=%.3f high=%.3f", low, high)
+	}
+}
+
+func TestDeEmphasisReset(t *testing.T) {
+	d := NewDeEmphasis(DeEmphasis75us, 48_000)
+	in := make([]float32, 1024)
+	for i := range in {
+		in[i] = 1.0
+	}
+	d.Process(nil, in)
+	d.Reset()
+	out := d.Process(nil, []float32{0})
+	if out[0] != 0 {
+		t.Errorf("after Reset, first output for x=0 should be 0, got %f", out[0])
+	}
+}
+
+func TestDeEmphasisInPlace(t *testing.T) {
+	d := NewDeEmphasis(DeEmphasis75us, 48_000)
+	buf := []float32{1, 1, 1, 1}
+	out := d.Process(buf, buf)
+	if &out[0] != &buf[0] {
+		t.Error("Process(buf, buf) should reuse buf for dst")
+	}
+	if out[0] == 1 {
+		t.Errorf("step input transient should be < 1 at first sample, got %f", out[0])
+	}
+}
+
+func TestDeEmphasisSampleRateCoeffs(t *testing.T) {
+	// Half the sample rate → α moves toward 0; oneMinus toward 1.
+	// The point of the check is to make sure the constructor actually
+	// uses fs (a regression guard), not to pin α to a specific value.
+	d48 := NewDeEmphasis(DeEmphasis75us, 48_000)
+	d24 := NewDeEmphasis(DeEmphasis75us, 24_000)
+	if d24.alpha >= d48.alpha {
+		t.Errorf("alpha at 24 kHz (%f) should be < alpha at 48 kHz (%f)", d24.alpha, d48.alpha)
+	}
+}
+
+func TestDeEmphasisRejectsBadParams(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic for non-positive time constant")
+		}
+	}()
+	_ = NewDeEmphasis(0, 48_000)
+}
+
+func TestDeEmphasisRejectsZeroSampleRate(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic for non-positive sample rate")
+		}
+	}()
+	_ = NewDeEmphasis(time.Millisecond, 0)
+}
+
+func TestDeEmphasisUSAlias(t *testing.T) {
+	a := NewDeEmphasisUS(48_000)
+	b := NewDeEmphasis(DeEmphasis75us, 48_000)
+	if a.alpha != b.alpha || a.oneMinus != b.oneMinus {
+		t.Errorf("US alias coefficients differ from explicit 75µs construction: %+v vs %+v", a, b)
+	}
+}

--- a/internal/voice/composer/composer.go
+++ b/internal/voice/composer/composer.go
@@ -5,10 +5,11 @@
 // One Composer subscribes to events.KindCallStart / events.KindCallEnd
 // from the bus. On a CallStart it looks up the Voice device by serial,
 // opens its IQ stream, and starts a goroutine that runs an FM
-// passthrough chain (LPF → decimate → quadrature FM demod → coarse
-// resample → int16 PCM → recorder.WritePCM). The chain also calls
-// Engine.Touch on a one-second cadence so the engine's silent-call
-// watchdog doesn't kill the call mid-conversation.
+// passthrough chain (LPF → decimate → quadrature FM demod → optional
+// post-demod de-emphasis → coarse resample → int16 PCM →
+// recorder.WritePCM). The chain also calls Engine.Touch on a one-second
+// cadence so the engine's silent-call watchdog doesn't kill the call
+// mid-conversation.
 //
 // Digital protocols (P25 / DMR / NXDN) need vocoders that haven't
 // landed yet — IMBE for P25 Phase 1 is in progress and AMBE+2 stays
@@ -102,6 +103,19 @@ type Options struct {
 	// front-end LPF and the FM demod. Off by default; flip Enabled
 	// to true and tune Taps / StepSize per site.
 	Equalizer EqualizerConfig
+	// DeEmphasis configures the post-demod single-pole IIR that
+	// recovers the pre-emphasized treble curve broadcast FM
+	// transmitters apply for SNR. Off by default — set Enabled and
+	// pick TimeConstant (75µs in NA, 50µs in EU). Filter runs at the
+	// intermediate ~48 kHz rate, before the second decimation.
+	DeEmphasis DeEmphasisConfig
+}
+
+// DeEmphasisConfig holds runtime knobs for the post-FM-demod
+// de-emphasis filter.
+type DeEmphasisConfig struct {
+	Enabled      bool
+	TimeConstant time.Duration // typically 75µs (NA) or 50µs (EU)
 }
 
 // Composer is the long-lived event-driven bridge.
@@ -117,6 +131,7 @@ type Composer struct {
 	bw           uint32
 	touchEvery   time.Duration
 	eqCfg        EqualizerConfig
+	deemphCfg    DeEmphasisConfig
 
 	sub       *events.Subscription
 	runDone   chan struct{}
@@ -161,6 +176,9 @@ func New(opts Options) (*Composer, error) {
 			opts.Equalizer.StepSize = 1e-4
 		}
 	}
+	if opts.DeEmphasis.Enabled && opts.DeEmphasis.TimeConstant <= 0 {
+		opts.DeEmphasis.TimeConstant = filter.DeEmphasis75us
+	}
 	log := opts.Log
 	if log == nil {
 		log = slog.Default()
@@ -176,6 +194,7 @@ func New(opts Options) (*Composer, error) {
 		bw:         opts.VoiceBandwidthHz,
 		touchEvery: opts.TouchInterval,
 		eqCfg:      opts.Equalizer,
+		deemphCfg:  opts.DeEmphasis,
 		chains:     make(map[string]*chain),
 		runDone:    make(chan struct{}),
 	}
@@ -342,6 +361,16 @@ func (c *Composer) runFMChain(ctx context.Context, serial string, iqCh <-chan []
 		eq = equalizer.NewCMA(c.eqCfg.Taps, c.eqCfg.StepSize, 1.0)
 	}
 
+	// Optional post-demod de-emphasis. The transmitter pre-emphasized
+	// treble for SNR; without the matching low-pass the recording
+	// sounds harsh. Filter runs on the real audio at the intermediate
+	// rate (~48 kHz) before the second naive decimation to PCM.
+	var deemph *filter.DeEmphasis
+	if c.deemphCfg.Enabled {
+		intermediateHzf := float64(c.iqHz) / float64(decim1)
+		deemph = filter.NewDeEmphasis(c.deemphCfg.TimeConstant, intermediateHzf)
+	}
+
 	touchTicker := time.NewTicker(c.touchEvery)
 	defer touchTicker.Stop()
 
@@ -368,6 +397,9 @@ func (c *Composer) runFMChain(ctx context.Context, serial string, iqCh <-chan []
 				decimated = equalized
 			}
 			audio := fm.Process(nil, decimated)
+			if deemph != nil {
+				audio = deemph.Process(audio, audio)
+			}
 			pcm := decimateAndConvert(audio, decim2)
 			if c.sink != nil && len(pcm) > 0 {
 				_ = c.sink.WritePCM(serial, pcm)


### PR DESCRIPTION
## Summary

Pulls one item off the "Higher-fidelity audio" gap. Broadcast FM
transmitters apply pre-emphasis (single-pole high-shelf) for SNR, and
without the matching de-emphasis on the receiver the recordings sound
harsh. This adds the standard 75/50µs RC low-pass and wires it into
the per-call FM chain as an opt-in stage.

### What changed

- **`internal/dsp/filter/deemph.go`** — `DeEmphasis` is the IIR
  `y[n] = (1−α)x[n] + α y[n−1]`, with `α = exp(−1 / (τ × fs))`. DC
  gain is unity by construction; the −3 dB cutoff is
  `fc = 1 / (2π τ)`. Constructor panics on non-positive τ or fs so
  misconfiguration trips at startup. `Reset` clears state so stale
  audio from one call doesn't bleed into the next. `NewDeEmphasisUS`
  is shorthand for the 75µs constant used in North America;
  `DeEmphasis75us` / `DeEmphasis50us` are named constants for callers
  that prefer the explicit form.
- **`internal/voice/composer/composer.go`** — new
  `DeEmphasisConfig{Enabled, TimeConstant}` on `Options`. When
  enabled, the chain builds the filter at the intermediate
  (~48 kHz) rate the FM demod emits and applies it in-place between
  demod and the second decimation. Disabled by default; analog FM
  systems opt in via daemon config and digital protocols leave it
  off.
- **`README.md`** — DSP feature row gains "single-pole IIR
  de-emphasis (75/50µs)"; both copies of the FM-polish gap entry
  shorten to call out what's now shipped vs. what's still pending
  (polyphase resampling, post-demod LPF, AGC).

### Tests

- DC steady-state input → unit-gain steady-state output.
- Step response converges monotonically toward 1.
- Frequency-response sanity at 75µs / fs = 48 kHz: 100 Hz passes near
  unity (≈ 1.0 ± 0.01); 6 kHz drops below 0.4 (≥ 8 dB attenuation);
  high-band gain strictly less than low-band gain.
- `Reset` zeroes state.
- In-place `Process(buf, buf)` reuses the slice.
- Sample-rate sensitivity: α at fs/2 strictly less than α at fs
  (regression guard against a constructor that ignores fs).
- Bad-param panics for τ ≤ 0 and fs ≤ 0.
- US alias matches explicit 75µs construction.

All existing composer + filter + DSP tests stay green; full
`go test ./...` passes.

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./internal/dsp/filter/... ./internal/voice/composer/...` green
- [x] `go test ./...` (full suite, all packages green)
- [ ] Manual: enable `composer.DeEmphasisConfig{Enabled: true,
      TimeConstant: 75µs}` on an analog-FM site and listen — high
      end should sound less harsh than the existing passthrough.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PHnwos5vaxtoDiSi32maZz)_