### PR TITLE
FM audio LPF: Kaiser-windowed FIR + real-valued FIR primitive + decode-error doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ gRPC, HTTP/SSE, or WebSocket.
 | FEC primitives    | CRC-CCITT/FALSE, CRC-6 (NXDN SACCH), Hamming(15,11,3), Hamming(13,9,3), Hamming(20,8) (DMR slot-type, t=3), extended Golay(24,12,8), BCH(63,16,11), BPTC(196,96), 4-state ½-rate Viterbi, 16-state K=5 ½-rate Viterbi (NXDN SACCH) |
 | P25 Phase 1       | 48-bit FSW + sync detector, NID parser (NAC + DUID) with BCH(63,16,11) error correction + even-parity check, full TSBK channel decode (TIA-102.BAAA Annex A 4-state ½-rate trellis + 98-dibit block deinterleaver) → CRC trailer validation, payload parsers for GroupVoiceChannelGrant / Update / NetworkStatus / RFSSStatus, IdentifierUpdate band-plan resolver, control-channel state machine emitting `protocol = "p25"` grants and `decode.error` events with `nid-bch` / `tsbk-trellis` / `tsbk-crc` / `no-bandplan` stages |
 | P25 Phase 2       | Outbound + inbound 20-dibit sync, 360 ms / 12-subframe superframe + SlotType enum, MAC PDU parser + opcode enum, GroupVoiceChannelGrant accessor, control-channel state machine emitting `protocol = "p25-phase2"` grants |
-| DMR (Tier III)    | All 9 ETSI sync patterns, burst layout (132 dibits), Color Code + Data Type via (20,8,7) shortened-Hamming slot-type FEC (corrects up to 3 bit errors per slot type), CSBK with CRC, payload parsers for TalkGroup/Private Voice grants (LCN + timeslot) + Aloha + AdjacentSiteStatus + SystemInfoBroadcast, LCN → Hz band-plan resolver (linear + table forms), control-channel state machine emitting `protocol = "dmr-tier3"` grants |
-| DMR (Tier II)     | Shares the burst / slot-type / BPTC(196,96) layers with Tier III; adds a 72-bit Full Link Control parser (FLCO enum: GroupVoiceChannelUser / UnitToUnitVoice / TalkerAlias / GPS / Terminator) and a per-repeater conventional-mode state machine that decodes Voice LC Header bursts and emits `protocol = "dmr-tier2"` grants on the bus, deduped per call and cleared on Terminator-with-LC |
+| DMR (Tier III)    | All 9 ETSI sync patterns, burst layout (132 dibits), Color Code + Data Type via (20,8,7) shortened-Hamming slot-type FEC (corrects up to 3 bit errors per slot type), CSBK with CRC, payload parsers for TalkGroup/Private Voice grants (LCN + timeslot) + Aloha + AdjacentSiteStatus + SystemInfoBroadcast, LCN → Hz band-plan resolver (linear + table forms), control-channel state machine emitting `protocol = "dmr-tier3"` grants and `decode.error` events with `no-bandplan` stage |
+| DMR (Tier II)     | Shares the burst / slot-type / BPTC(196,96) layers with Tier III; adds a 72-bit Full Link Control parser (FLCO enum: GroupVoiceChannelUser / UnitToUnitVoice / TalkerAlias / GPS / Terminator) and a per-repeater conventional-mode state machine that decodes Voice LC Header bursts and emits `protocol = "dmr-tier2"` grants on the bus (deduped per call, cleared on Terminator-with-LC) and `decode.error` events with `voiceheader-bptc` stage |
 | NXDN              | 192-dibit frame layout (4800 BFSK / 9600 4-FSK), LICH parse with parity + 16-bit doubled-wire decoder, FSW correlator, full SACCH channel decode (K=5 ½-rate convolutional Viterbi + 60-position sub-frame deinterleaver + 12-bit puncture undo + CRC-6 trailer), CAC parser with CRC, RCCH opcode enum + payload parsers, control-channel state machine |
 | Motorola Type II  | OSW parser, opcode constants, LCN → Hz band-plan resolver (linear + table), control-channel state machine emitting `protocol = "motorola"` grants |
 | EDACS / GE-Marc   | 40-bit CCW parser, command enum (Idle / GroupVoiceGrant / ProVoiceGrant / IndividualCall / DataGrant / SystemID / AdjacentSite / Emergency / Affiliation / Encryption), per-command accessors with encrypted / emergency flags, LCN → Hz resolver, control-channel state machine emitting `protocol = "edacs"` grants |
@@ -31,7 +31,7 @@ gRPC, HTTP/SSE, or WebSocket.
 | D-STAR            | Frame Sync + Slow Data sync, 41-byte PCH header parser (FLAG1 + RPT2 / RPT1 / UR / MY1 / MY2 + CRC-CCITT), IsGroupCall / IsEmergency / IsData accessors, repeater state machine emitting `protocol = "dstar"` grants on group transmissions |
 | Orchestration     | In-process pub/sub event bus, `System` model, JSON-on-disk last-known-CC cache, control-channel `Hunter` that retunes the SDR and parks on the first responsive frequency |
 | Trunking engine   | Cross-protocol `Grant` payload, Trunk-Recorder-format talkgroup DB (CSV + JSON), priority + preemption (emergency overrides, strict-higher), voice-device pool allocator, central state machine emitting `CallStart` / `CallEnd` events with a watchdog for silent calls |
-| Demod pipeline    | `internal/voice/composer` subscribes to `CallStart` events, opens the bound Voice device's IQ stream, runs an LPF → decimate → optional CMA equalizer → FM demod → decimate → int16 PCM chain into the recorder, and pings `Engine.Touch` every second so the silent-call watchdog leaves the call alone |
+| Demod pipeline    | `internal/voice/composer` subscribes to `CallStart` events, opens the bound Voice device's IQ stream, runs an LPF → decimate → optional CMA equalizer → FM demod → optional 75/50µs de-emphasis → optional Kaiser audio LPF → decimate → int16 PCM chain into the recorder, and pings `Engine.Touch` every second so the silent-call watchdog leaves the call alone |
 | Simulcast / "True I/Q" | `internal/dsp/equalizer` (LMS + CMA blind equalizers) for inter-symbol-interference / multipath mitigation, plus `internal/dsp/diversity` (Selection + maximal-ratio combiners over a shared `Combiner` interface) for multi-receiver IQ combining |
 | Tone-out alerting | `internal/voice/toneout` runs Goertzel filters against each Voice device's PCM stream, matches QC-II two-tone-sequential sequences against operator-configured profiles with per-tone duration + cooldown, and publishes `tone.alert` events that fan out through SSE / WebSocket / gRPC |
 | Voice recording   | `Vocoder` plugin interface + `NullVocoder` baseline, 16-bit PCM mono WAV writer with patched-length trailers, per-call recorder writing `<system>/<tg>/<UTC>_src<id>.wav` plus an optional raw-frame sidecar so users can BYO decoder; EDACS ProVoice grants always force a `.raw` sidecar (the vocoder is patent + trade-secret encumbered) so researchers can decode out-of-band |
@@ -54,9 +54,10 @@ SQLite. The honest gaps:
   ([patents have expired](docs/vocoders.md)) and AMBE+2 stays
   behind the `mbelib` build tag.
 - **Higher-fidelity audio**: the FM chain has opt-in 75/50µs
-  de-emphasis but still does naive decimation rather than proper
-  polyphase resampling, and skips a post-demod LPF + AGC. Quality is
-  good enough to verify wiring; real DSP polish is follow-up work.
+  de-emphasis and a Kaiser-windowed audio LPF, but still does naive
+  decimation rather than proper polyphase resampling, and skips
+  AGC. Quality is good enough to verify wiring; real DSP polish is
+  follow-up work.
 
 The Go interfaces and event payloads carry digital protocols already,
 so the remaining paths light up once IMBE drops in.
@@ -78,10 +79,10 @@ to its own package and lands independently.
 - **Yaesu System Fusion (C4FM, FICH).** Amateur-radio digital mode,
   public spec. New `internal/radio/ysf/` package following the
   D-STAR pattern: header parser + repeater state machine.
-- **Higher-fidelity FM voice chain.** Opt-in 75/50µs de-emphasis is
-  in (`composer.DeEmphasisConfig`); still pending are proper
-  polyphase resampling, a post-demod LPF, and AGC. This is real DSP
-  polish for production audio.
+- **Higher-fidelity FM voice chain.** Opt-in 75/50µs de-emphasis
+  (`composer.DeEmphasisConfig`) and a Kaiser-windowed audio LPF
+  (`composer.AudioLPFConfig`) are in. Still pending are proper
+  polyphase resampling and AGC for production audio.
 
 ## Tech stack
 

--- a/internal/dsp/filter/firreal.go
+++ b/internal/dsp/filter/firreal.go
@@ -1,0 +1,68 @@
+package filter
+
+// RealFIR is the real-valued counterpart of FIR. Same circular-buffer
+// convolution shape, but operates on float32 audio samples instead of
+// complex IQ. Sized for the post-demod chain in
+// internal/voice/composer where the FM demod hands real audio to a
+// band-limiting LPF before the second decimation to PCM.
+//
+// Like FIR, it isn't safe for concurrent Process calls — pin it to a
+// single demod goroutine and Reset between calls.
+type RealFIR struct {
+	taps    []float32
+	hist    []float32
+	histPos int
+}
+
+// NewRealFIR copies taps into a new filter and allocates the matching
+// history ring. The constructor panics on an empty tap slice so a
+// misconfiguration trips at startup.
+func NewRealFIR(taps []float32) *RealFIR {
+	if len(taps) == 0 {
+		panic("filter: NewRealFIR requires at least one tap")
+	}
+	cp := make([]float32, len(taps))
+	copy(cp, taps)
+	return &RealFIR{taps: cp, hist: make([]float32, len(taps))}
+}
+
+// Reset clears the internal history so the next Process starts fresh.
+func (f *RealFIR) Reset() {
+	for i := range f.hist {
+		f.hist[i] = 0
+	}
+	f.histPos = 0
+}
+
+// Process consumes one input slice and returns an output slice of the
+// same length. dst is reused if it has enough capacity. In-place
+// operation (dst == src) is supported.
+func (f *RealFIR) Process(dst, src []float32) []float32 {
+	if cap(dst) < len(src) {
+		dst = make([]float32, len(src))
+	} else {
+		dst = dst[:len(src)]
+	}
+	N := len(f.taps)
+	for i, x := range src {
+		f.hist[f.histPos] = x
+		f.histPos++
+		if f.histPos == N {
+			f.histPos = 0
+		}
+		var acc float32
+		idx := f.histPos - 1
+		if idx < 0 {
+			idx = N - 1
+		}
+		for k := 0; k < N; k++ {
+			acc += f.taps[k] * f.hist[idx]
+			idx--
+			if idx < 0 {
+				idx = N - 1
+			}
+		}
+		dst[i] = acc
+	}
+	return dst
+}

--- a/internal/dsp/filter/firreal_test.go
+++ b/internal/dsp/filter/firreal_test.go
@@ -1,0 +1,98 @@
+package filter
+
+import (
+	"math"
+	"testing"
+)
+
+func TestRealFIRDelta(t *testing.T) {
+	// A delta input through a unit-tap filter must reproduce the delta.
+	f := NewRealFIR([]float32{1})
+	out := f.Process(nil, []float32{1, 0, 0, 0})
+	if out[0] != 1 || out[1] != 0 || out[2] != 0 || out[3] != 0 {
+		t.Errorf("unit-tap delta response = %v", out)
+	}
+}
+
+func TestRealFIRImpulseMatchesTaps(t *testing.T) {
+	// Impulse response of an N-tap FIR is the tap sequence itself.
+	taps := []float32{0.1, 0.2, 0.3, 0.2, 0.1}
+	f := NewRealFIR(taps)
+	in := make([]float32, len(taps)+4)
+	in[0] = 1
+	out := f.Process(nil, in)
+	for i, want := range taps {
+		if math.Abs(float64(out[i]-want)) > 1e-6 {
+			t.Errorf("impulse[%d] = %f, want %f", i, out[i], want)
+		}
+	}
+	for i := len(taps); i < len(in); i++ {
+		if math.Abs(float64(out[i])) > 1e-6 {
+			t.Errorf("impulse tail [%d] = %f, want 0", i, out[i])
+		}
+	}
+}
+
+func TestRealFIRLPFKaiserPassbandStopband(t *testing.T) {
+	// 81-tap Kaiser LPF with fc = 0.1 (normalized, so 4.8 kHz at fs =
+	// 48 kHz). A 1 kHz sinusoid should pass with near-unit gain; a 12
+	// kHz sinusoid should be heavily attenuated.
+	const fs = 48_000.0
+	taps := LowpassKaiser(81, 4_800.0/fs, 8.6)
+	settling := len(taps) * 2
+
+	gainAt := func(freq float64) float64 {
+		f := NewRealFIR(taps)
+		n := settling + 4096
+		in := make([]float32, n)
+		for i := range in {
+			in[i] = float32(math.Sin(2 * math.Pi * freq * float64(i) / fs))
+		}
+		out := f.Process(nil, in)
+		var inE, outE float64
+		for i := settling; i < n; i++ {
+			inE += float64(in[i]) * float64(in[i])
+			outE += float64(out[i]) * float64(out[i])
+		}
+		return math.Sqrt(outE / inE)
+	}
+
+	pass := gainAt(1_000)
+	stop := gainAt(12_000)
+	if pass < 0.95 || pass > 1.05 {
+		t.Errorf("1 kHz passband gain = %.3f, want ≈1.0", pass)
+	}
+	if stop > 0.05 {
+		t.Errorf("12 kHz stopband gain = %.3f, want < 0.05 (≥ 26 dB)", stop)
+	}
+}
+
+func TestRealFIRReset(t *testing.T) {
+	f := NewRealFIR([]float32{0.5, 0.5})
+	f.Process(nil, []float32{1, 1, 1, 1})
+	f.Reset()
+	out := f.Process(nil, []float32{1})
+	// First sample after reset, with [0.5, 0.5] taps and zero history,
+	// should be 0.5 — not affected by the prior call's residue.
+	if math.Abs(float64(out[0]-0.5)) > 1e-6 {
+		t.Errorf("post-reset first sample = %f, want 0.5", out[0])
+	}
+}
+
+func TestRealFIRInPlace(t *testing.T) {
+	f := NewRealFIR([]float32{1})
+	buf := []float32{1, 2, 3}
+	out := f.Process(buf, buf)
+	if &out[0] != &buf[0] {
+		t.Error("Process(buf, buf) should reuse the slice")
+	}
+}
+
+func TestRealFIRRejectsEmptyTaps(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic for empty taps")
+		}
+	}()
+	_ = NewRealFIR(nil)
+}

--- a/internal/events/bus.go
+++ b/internal/events/bus.go
@@ -31,11 +31,15 @@ const (
 //
 // Stage taxonomy (extend, don't rename — these become Prometheus labels):
 //
-//   - "nid-bch"          P25 Phase 1 NID BCH(63,16,11)
-//   - "tsbk-trellis"     P25 Phase 1 TSBK ½-rate trellis
-//   - "tsbk-crc"         P25 Phase 1 TSBK CRC trailer
-//   - "slottype-hamming" DMR slot-type Hamming(20,8)
-//   - "sacch-trellis"    NXDN SACCH ½-rate trellis
+//   - "nid-bch"            P25 Phase 1 NID BCH(63,16,11)
+//   - "tsbk-trellis"       P25 Phase 1 TSBK ½-rate trellis
+//   - "tsbk-crc"           P25 Phase 1 TSBK CRC trailer
+//   - "no-bandplan"        Voice grant arrived for an unknown channel
+//                          ID / LCN (P25 IdentifierUpdate or DMR
+//                          Tier III LCN→Hz resolver hadn't seen it yet)
+//   - "slottype-hamming"   DMR slot-type Hamming(20,8)
+//   - "voiceheader-bptc"   DMR Tier II Voice LC Header BPTC(196,96)
+//   - "sacch-trellis"      NXDN SACCH ½-rate trellis
 type DecodeError struct {
 	Protocol string
 	Stage    string

--- a/internal/voice/composer/composer.go
+++ b/internal/voice/composer/composer.go
@@ -6,10 +6,10 @@
 // from the bus. On a CallStart it looks up the Voice device by serial,
 // opens its IQ stream, and starts a goroutine that runs an FM
 // passthrough chain (LPF → decimate → quadrature FM demod → optional
-// post-demod de-emphasis → coarse resample → int16 PCM →
-// recorder.WritePCM). The chain also calls Engine.Touch on a one-second
-// cadence so the engine's silent-call watchdog doesn't kill the call
-// mid-conversation.
+// post-demod de-emphasis → optional post-demod audio LPF → coarse
+// resample → int16 PCM → recorder.WritePCM). The chain also calls
+// Engine.Touch on a one-second cadence so the engine's silent-call
+// watchdog doesn't kill the call mid-conversation.
 //
 // Digital protocols (P25 / DMR / NXDN) need vocoders that haven't
 // landed yet — IMBE for P25 Phase 1 is in progress and AMBE+2 stays
@@ -109,6 +109,13 @@ type Options struct {
 	// pick TimeConstant (75µs in NA, 50µs in EU). Filter runs at the
 	// intermediate ~48 kHz rate, before the second decimation.
 	DeEmphasis DeEmphasisConfig
+	// AudioLPF configures a Kaiser-windowed FIR low-pass on the real
+	// audio after de-emphasis and before the decimation to PCM. The
+	// point is two-fold: band-limit voice to roughly 3.4 kHz (telephony
+	// quality, kills hiss + sub-carriers), and act as the
+	// anti-aliasing filter for the second decimation. Off by default;
+	// callers tune CutoffHz (typical 3400) and Taps (default 81).
+	AudioLPF AudioLPFConfig
 }
 
 // DeEmphasisConfig holds runtime knobs for the post-FM-demod
@@ -116,6 +123,17 @@ type Options struct {
 type DeEmphasisConfig struct {
 	Enabled      bool
 	TimeConstant time.Duration // typically 75µs (NA) or 50µs (EU)
+}
+
+// AudioLPFConfig holds runtime knobs for the post-demod audio
+// low-pass. CutoffHz is in Hz (relative to the intermediate rate the
+// FM demod emits). Taps controls the FIR length; longer = sharper
+// transition at the cost of latency. Both fall back to sane defaults
+// when zero.
+type AudioLPFConfig struct {
+	Enabled  bool
+	CutoffHz uint32
+	Taps     int
 }
 
 // Composer is the long-lived event-driven bridge.
@@ -132,6 +150,7 @@ type Composer struct {
 	touchEvery   time.Duration
 	eqCfg        EqualizerConfig
 	deemphCfg    DeEmphasisConfig
+	lpfCfg       AudioLPFConfig
 
 	sub       *events.Subscription
 	runDone   chan struct{}
@@ -179,6 +198,14 @@ func New(opts Options) (*Composer, error) {
 	if opts.DeEmphasis.Enabled && opts.DeEmphasis.TimeConstant <= 0 {
 		opts.DeEmphasis.TimeConstant = filter.DeEmphasis75us
 	}
+	if opts.AudioLPF.Enabled {
+		if opts.AudioLPF.CutoffHz == 0 {
+			opts.AudioLPF.CutoffHz = 3_400
+		}
+		if opts.AudioLPF.Taps <= 0 {
+			opts.AudioLPF.Taps = 81
+		}
+	}
 	log := opts.Log
 	if log == nil {
 		log = slog.Default()
@@ -195,6 +222,7 @@ func New(opts Options) (*Composer, error) {
 		touchEvery: opts.TouchInterval,
 		eqCfg:      opts.Equalizer,
 		deemphCfg:  opts.DeEmphasis,
+		lpfCfg:     opts.AudioLPF,
 		chains:     make(map[string]*chain),
 		runDone:    make(chan struct{}),
 	}
@@ -365,10 +393,24 @@ func (c *Composer) runFMChain(ctx context.Context, serial string, iqCh <-chan []
 	// treble for SNR; without the matching low-pass the recording
 	// sounds harsh. Filter runs on the real audio at the intermediate
 	// rate (~48 kHz) before the second naive decimation to PCM.
+	intermediateHzf := float64(c.iqHz) / float64(decim1)
 	var deemph *filter.DeEmphasis
 	if c.deemphCfg.Enabled {
-		intermediateHzf := float64(c.iqHz) / float64(decim1)
 		deemph = filter.NewDeEmphasis(c.deemphCfg.TimeConstant, intermediateHzf)
+	}
+
+	// Optional post-demod audio LPF. Two jobs: band-limit voice to
+	// ~3.4 kHz (telephony grade, kills hiss + sub-carriers like the
+	// 19 kHz pilot tone on broadcast FM if any leaks through) and
+	// act as the anti-aliasing filter for the decimation that
+	// follows. Cutoff is normalized against the intermediate rate.
+	var audioLPF *filter.RealFIR
+	if c.lpfCfg.Enabled {
+		fc := float64(c.lpfCfg.CutoffHz) / intermediateHzf
+		if fc >= 0.5 {
+			fc = 0.45
+		}
+		audioLPF = filter.NewRealFIR(filter.LowpassKaiser(c.lpfCfg.Taps, fc, 8.6))
 	}
 
 	touchTicker := time.NewTicker(c.touchEvery)
@@ -399,6 +441,9 @@ func (c *Composer) runFMChain(ctx context.Context, serial string, iqCh <-chan []
 			audio := fm.Process(nil, decimated)
 			if deemph != nil {
 				audio = deemph.Process(audio, audio)
+			}
+			if audioLPF != nil {
+				audio = audioLPF.Process(audio, audio)
 			}
 			pcm := decimateAndConvert(audio, decim2)
 			if c.sink != nil && len(pcm) > 0 {


### PR DESCRIPTION
## Summary

Pulls another item off the "Higher-fidelity audio" gap. After FM demod
+ optional de-emphasis, the audio is now band-limited by a Kaiser-
windowed FIR low-pass before the decimation to PCM. Two jobs:

- Trim voice to ~3.4 kHz (telephony grade) — kills hiss + sub-carriers
  that leak through after FM demod.
- Act as the anti-aliasing filter for the second decimation that
  follows, so naive decimation no longer aliases out-of-band content
  back into the audio range.

### What changed

- **`internal/dsp/filter/firreal.go`** — `RealFIR` mirrors `FIR`'s
  circular-buffer convolution shape but operates on `float32` audio.
  Constructor panics on empty taps; `Reset` clears state; `Process`
  supports in-place `src == dst`.
- **`internal/voice/composer/composer.go`** — new
  `AudioLPFConfig{Enabled, CutoffHz, Taps}` on `Options`. When
  enabled, the chain builds a Kaiser LPF tuned to
  `CutoffHz / intermediate-rate` (defaults: 3400 Hz, 81 taps, β=8.6)
  and applies it in-place between de-emphasis and the second
  decimation. Off by default — analog FM systems opt in via daemon
  config.
- **`internal/events/bus.go`** — extends the `DecodeError` stage
  taxonomy comment with `no-bandplan` and `voiceheader-bptc` (used
  by P25 Phase 1, DMR Tier III, and DMR Tier II) so the catalog
  matches what protocol packages actually publish.
- **`README.md`** — demod-pipeline + DSP feature rows now mention
  the audio LPF; Tier III + Tier II rows surface their
  `decode.error` stages so docs parallel P25 Phase 1's detail; both
  copies of the FM-polish gap entry shorten — only polyphase
  resampling and AGC remain pending.

### Tests

- `RealFIR` unit-tap delta pass-through.
- Impulse response equals the tap sequence (linear-phase sanity).
- Kaiser LPF passband (1 kHz) gain ≈ 1.0; stopband (12 kHz) gain
  < 0.05 (≥ 26 dB attenuation) at 81 taps, fc = 4.8 kHz, fs = 48 kHz.
- `Reset` clears state.
- In-place `Process(buf, buf)` reuses the slice.
- Empty-taps constructor panics.
- All existing composer / filter / events / radio tests stay green;
  full `go test ./...` passes.

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./internal/dsp/filter/... ./internal/voice/composer/...` green
- [x] `go test ./...` (full suite, all packages green)
- [ ] Manual: enable both `composer.DeEmphasisConfig{Enabled: true,
      TimeConstant: 75µs}` and
      `composer.AudioLPFConfig{Enabled: true, CutoffHz: 3400}` on an
      analog-FM site and listen — output should sound like a
      band-limited telephone-quality voice without the hiss the
      passthrough chain produced.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PHnwos5vaxtoDiSi32maZz)_