### PR TITLE
FM audio AGC: post-demod envelope-follower AGC + opt-in composer wiring

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ gRPC, HTTP/SSE, or WebSocket.
 | Area              | Component                                                  |
 | ----------------- | ---------------------------------------------------------- |
 | Hardware          | CGO `librtlsdr` binding, multi-device pool, role assignment, per-device gain (`auto` / tenths-of-dB) + PPM + bias-tee (5 V LNA power, e.g. NESDR Smart v5) applied at open time, DC blocker, IQ-imbalance correction, file-backed IQ replay (mock) |
-| DSP               | Polyphase channelizer, FIR + Kaiser LPF designer + RRC, CIC, halfband, AGC, rational resampler, FM / C4FM / H-DQPSK demods, single-pole IIR de-emphasis (75/50µs), Mueller-Müller clock recovery, frame-sync correlator |
+| DSP               | Polyphase channelizer, FIR + Kaiser LPF designer + RRC, CIC, halfband, IQ + audio AGC (attack/release envelope follower for voice), rational resampler, FM / C4FM / H-DQPSK demods, single-pole IIR de-emphasis (75/50µs), Mueller-Müller clock recovery, frame-sync correlator |
 | FEC primitives    | CRC-CCITT/FALSE, CRC-6 (NXDN SACCH), Hamming(15,11,3), Hamming(13,9,3), Hamming(20,8) (DMR slot-type, t=3), extended Golay(24,12,8), BCH(63,16,11), BPTC(196,96), 4-state ½-rate Viterbi, 16-state K=5 ½-rate Viterbi (NXDN SACCH) |
 | P25 Phase 1       | 48-bit FSW + sync detector, NID parser (NAC + DUID) with BCH(63,16,11) error correction + even-parity check, full TSBK channel decode (TIA-102.BAAA Annex A 4-state ½-rate trellis + 98-dibit block deinterleaver) → CRC trailer validation, payload parsers for GroupVoiceChannelGrant / Update / NetworkStatus / RFSSStatus, IdentifierUpdate band-plan resolver, control-channel state machine emitting `protocol = "p25"` grants and `decode.error` events with `nid-bch` / `tsbk-trellis` / `tsbk-crc` / `no-bandplan` stages |
 | P25 Phase 2       | Outbound + inbound 20-dibit sync, 360 ms / 12-subframe superframe + SlotType enum, MAC PDU parser + opcode enum, GroupVoiceChannelGrant accessor, control-channel state machine emitting `protocol = "p25-phase2"` grants |
@@ -31,7 +31,7 @@ gRPC, HTTP/SSE, or WebSocket.
 | D-STAR            | Frame Sync + Slow Data sync, 41-byte PCH header parser (FLAG1 + RPT2 / RPT1 / UR / MY1 / MY2 + CRC-CCITT), IsGroupCall / IsEmergency / IsData accessors, repeater state machine emitting `protocol = "dstar"` grants on group transmissions |
 | Orchestration     | In-process pub/sub event bus, `System` model, JSON-on-disk last-known-CC cache, control-channel `Hunter` that retunes the SDR and parks on the first responsive frequency |
 | Trunking engine   | Cross-protocol `Grant` payload, Trunk-Recorder-format talkgroup DB (CSV + JSON), priority + preemption (emergency overrides, strict-higher), voice-device pool allocator, central state machine emitting `CallStart` / `CallEnd` events with a watchdog for silent calls |
-| Demod pipeline    | `internal/voice/composer` subscribes to `CallStart` events, opens the bound Voice device's IQ stream, runs an LPF → decimate → optional CMA equalizer → FM demod → optional 75/50µs de-emphasis → optional Kaiser audio LPF → decimate → int16 PCM chain into the recorder, and pings `Engine.Touch` every second so the silent-call watchdog leaves the call alone |
+| Demod pipeline    | `internal/voice/composer` subscribes to `CallStart` events, opens the bound Voice device's IQ stream, runs an LPF → decimate → optional CMA equalizer → FM demod → optional 75/50µs de-emphasis → optional Kaiser audio LPF → optional audio AGC → decimate → int16 PCM chain into the recorder, and pings `Engine.Touch` every second so the silent-call watchdog leaves the call alone |
 | Simulcast / "True I/Q" | `internal/dsp/equalizer` (LMS + CMA blind equalizers) for inter-symbol-interference / multipath mitigation, plus `internal/dsp/diversity` (Selection + maximal-ratio combiners over a shared `Combiner` interface) for multi-receiver IQ combining |
 | Tone-out alerting | `internal/voice/toneout` runs Goertzel filters against each Voice device's PCM stream, matches QC-II two-tone-sequential sequences against operator-configured profiles with per-tone duration + cooldown, and publishes `tone.alert` events that fan out through SSE / WebSocket / gRPC |
 | Voice recording   | `Vocoder` plugin interface + `NullVocoder` baseline, 16-bit PCM mono WAV writer with patched-length trailers, per-call recorder writing `<system>/<tg>/<UTC>_src<id>.wav` plus an optional raw-frame sidecar so users can BYO decoder; EDACS ProVoice grants always force a `.raw` sidecar (the vocoder is patent + trade-secret encumbered) so researchers can decode out-of-band |
@@ -54,10 +54,10 @@ SQLite. The honest gaps:
   ([patents have expired](docs/vocoders.md)) and AMBE+2 stays
   behind the `mbelib` build tag.
 - **Higher-fidelity audio**: the FM chain has opt-in 75/50µs
-  de-emphasis and a Kaiser-windowed audio LPF, but still does naive
-  decimation rather than proper polyphase resampling, and skips
-  AGC. Quality is good enough to verify wiring; real DSP polish is
-  follow-up work.
+  de-emphasis, a Kaiser-windowed audio LPF, and audio AGC. Still
+  pending is proper polyphase resampling rather than naive
+  decimation. Quality is good enough to verify wiring; real DSP
+  polish is follow-up work.
 
 The Go interfaces and event payloads carry digital protocols already,
 so the remaining paths light up once IMBE drops in.
@@ -80,9 +80,10 @@ to its own package and lands independently.
   public spec. New `internal/radio/ysf/` package following the
   D-STAR pattern: header parser + repeater state machine.
 - **Higher-fidelity FM voice chain.** Opt-in 75/50µs de-emphasis
-  (`composer.DeEmphasisConfig`) and a Kaiser-windowed audio LPF
-  (`composer.AudioLPFConfig`) are in. Still pending are proper
-  polyphase resampling and AGC for production audio.
+  (`composer.DeEmphasisConfig`), a Kaiser-windowed audio LPF
+  (`composer.AudioLPFConfig`), and audio AGC
+  (`composer.AudioAGCConfig`) are in. Still pending: proper
+  polyphase resampling for production audio.
 
 ## Tech stack
 

--- a/internal/dsp/agc_audio.go
+++ b/internal/dsp/agc_audio.go
@@ -1,0 +1,136 @@
+package dsp
+
+import (
+	"math"
+	"time"
+)
+
+// AudioAGC is the real-valued counterpart of AGC, sized for the
+// post-demod chain in internal/voice/composer. The IQ-domain AGC
+// drives the *complex* baseband magnitude toward a target with a
+// single adaptation rate, which works because FM has a constant
+// envelope on air. After demod the signal is voice — bursty, with
+// short loud transients separated by quieter passages — so a single
+// rate either pumps badly (too fast) or never catches up (too slow).
+//
+// AudioAGC is a classic envelope-follower + gain stage:
+//
+//	abs   = |x|
+//	if abs > level: level += (1 - α_attack) × (abs - level)   // ramp up fast
+//	else:           level += (1 - α_release) × (abs - level)  // ramp down slow
+//	gain  = clamp(reference / max(level, floor), 0, MaxGain)
+//	y[n]  = x[n] × gain
+//
+// Attack / release are time constants (in samples after construction);
+// short attack catches transients before they clip, long release
+// keeps the gain steady through speech gaps so the output doesn't
+// pump. Reference is the target |y| ≈ Reference; pick something that
+// leaves headroom for downstream stages (typical 0.3 keeps int16
+// conversion comfortably under MaxInt16 at the existing 10 000-scale
+// in voice/composer).
+//
+// AudioAGC is not safe for concurrent Process calls — pin it to a
+// single demod goroutine and Reset between calls.
+type AudioAGC struct {
+	reference   float32
+	maxGain     float32
+	attackCoef  float32 // 1 - exp(-1/(attack × fs))
+	releaseCoef float32 // 1 - exp(-1/(release × fs))
+	floor       float32 // dead-air floor on the level estimate
+
+	level float32
+}
+
+// AudioAGCConfig configures NewAudioAGC. All time constants are in
+// real time; the constructor folds in the sample rate.
+type AudioAGCConfig struct {
+	Reference  float32       // target |output| (default 0.3)
+	Attack     time.Duration // ramp-up time constant (default 5 ms)
+	Release    time.Duration // ramp-down time constant (default 200 ms)
+	MaxGain    float32       // ceiling on adaptive gain (default 64.0)
+	SampleRate float64       // sample rate of the audio stream (Hz, required)
+}
+
+// NewAudioAGC builds an envelope-follower-based AGC. Bad parameters
+// trip a panic at startup so misconfiguration shows up loudly rather
+// than silently producing wrong audio.
+func NewAudioAGC(cfg AudioAGCConfig) *AudioAGC {
+	if cfg.SampleRate <= 0 {
+		panic("dsp: NewAudioAGC requires a positive sample rate")
+	}
+	if cfg.Reference <= 0 {
+		cfg.Reference = 0.3
+	}
+	if cfg.Attack <= 0 {
+		cfg.Attack = 5 * time.Millisecond
+	}
+	if cfg.Release <= 0 {
+		cfg.Release = 200 * time.Millisecond
+	}
+	if cfg.MaxGain <= 0 {
+		cfg.MaxGain = 64
+	}
+	attack := 1.0 - math.Exp(-1.0/(cfg.Attack.Seconds()*cfg.SampleRate))
+	release := 1.0 - math.Exp(-1.0/(cfg.Release.Seconds()*cfg.SampleRate))
+	return &AudioAGC{
+		reference:   cfg.Reference,
+		maxGain:     cfg.MaxGain,
+		attackCoef:  float32(attack),
+		releaseCoef: float32(release),
+		floor:       cfg.Reference / cfg.MaxGain,
+	}
+}
+
+// Reset clears the running envelope estimate so the next Process call
+// starts from silence (gain begins at MaxGain).
+func (a *AudioAGC) Reset() {
+	a.level = 0
+}
+
+// Gain returns the current adaptive gain. Useful for diagnostics; not
+// needed for normal operation.
+func (a *AudioAGC) Gain() float32 {
+	level := a.level
+	if level < a.floor {
+		level = a.floor
+	}
+	g := a.reference / level
+	if g > a.maxGain {
+		g = a.maxGain
+	}
+	return g
+}
+
+// Process applies the AGC to src and writes to dst (or appends to it).
+// dst is reused if it has enough capacity; in-place src == dst is
+// supported.
+func (a *AudioAGC) Process(dst, src []float32) []float32 {
+	if cap(dst) < len(src) {
+		dst = make([]float32, len(src))
+	} else {
+		dst = dst[:len(src)]
+	}
+	level := a.level
+	for i, x := range src {
+		abs := x
+		if abs < 0 {
+			abs = -abs
+		}
+		if abs > level {
+			level += a.attackCoef * (abs - level)
+		} else {
+			level += a.releaseCoef * (abs - level)
+		}
+		clamped := level
+		if clamped < a.floor {
+			clamped = a.floor
+		}
+		gain := a.reference / clamped
+		if gain > a.maxGain {
+			gain = a.maxGain
+		}
+		dst[i] = x * gain
+	}
+	a.level = level
+	return dst
+}

--- a/internal/dsp/agc_audio_test.go
+++ b/internal/dsp/agc_audio_test.go
@@ -1,0 +1,171 @@
+package dsp
+
+import (
+	"math"
+	"testing"
+	"time"
+)
+
+func TestAudioAGCConvergesOnSteadySine(t *testing.T) {
+	// Drive a steady 1 kHz sinusoid at amplitude 0.05 (well below the
+	// 0.3 reference) through the AGC. After enough samples for the
+	// release time constant to settle, the output RMS should match
+	// the reference within a small margin.
+	const fs = 48_000.0
+	a := NewAudioAGC(AudioAGCConfig{
+		Reference:  0.3,
+		Attack:     5 * time.Millisecond,
+		Release:    50 * time.Millisecond, // shortened so test settles fast
+		MaxGain:    64,
+		SampleRate: fs,
+	})
+	n := int(fs * 0.5) // 500 ms — plenty for 50 ms release
+	in := make([]float32, n)
+	for i := range in {
+		in[i] = 0.05 * float32(math.Sin(2*math.Pi*1000*float64(i)/fs))
+	}
+	out := a.Process(nil, in)
+
+	// Measure RMS over the last 100 ms (steady-state).
+	settled := n - int(fs*0.1)
+	var ss float64
+	for _, y := range out[settled:] {
+		ss += float64(y) * float64(y)
+	}
+	rms := math.Sqrt(ss / float64(n-settled))
+
+	// A pure sine at peak A has RMS A/√2. The AGC drives |y| toward
+	// reference, so the output RMS should be ≈ 0.3/√2 ≈ 0.212.
+	want := 0.3 / math.Sqrt2
+	if rms < want*0.7 || rms > want*1.3 {
+		t.Errorf("steady-state output RMS = %.3f, want ≈ %.3f", rms, want)
+	}
+}
+
+func TestAudioAGCAttackCatchesTransient(t *testing.T) {
+	// Hand the AGC a long quiet stretch followed by a loud transient
+	// and check that it tames the transient — peak output during the
+	// loud section should not exceed reference × MaxGain (clamp) and
+	// should settle close to reference within the attack window.
+	const fs = 48_000.0
+	a := NewAudioAGC(AudioAGCConfig{
+		Reference:  0.3,
+		Attack:     5 * time.Millisecond,
+		Release:    200 * time.Millisecond,
+		MaxGain:    64,
+		SampleRate: fs,
+	})
+	n := int(fs * 0.05)
+	loud := make([]float32, n)
+	for i := range loud {
+		loud[i] = 1.0 // unit amplitude — 3.3× reference, would clip without AGC
+	}
+	out := a.Process(nil, loud)
+
+	// During steady-state of the loud burst, output should be ≈ reference.
+	settled := n - int(fs*0.01) // last 10 ms
+	var sum float32
+	for _, y := range out[settled:] {
+		if y < 0 {
+			y = -y
+		}
+		sum += y
+	}
+	mean := sum / float32(n-settled)
+	if mean < 0.2 || mean > 0.4 {
+		t.Errorf("steady-state |y| during loud burst = %.3f, want ≈ 0.3", mean)
+	}
+}
+
+func TestAudioAGCReleaseRampUpIsSlow(t *testing.T) {
+	// Hand the AGC a loud signal, then a quiet one. The gain on the
+	// quiet section should not jump to MaxGain instantly — the
+	// release coefficient is small so the level estimate decays
+	// gradually. Concretely, at the start of the quiet section the
+	// effective gain should still be roughly what the loud section
+	// produced.
+	const fs = 48_000.0
+	a := NewAudioAGC(AudioAGCConfig{
+		Reference:  0.3,
+		Attack:     5 * time.Millisecond,
+		Release:    200 * time.Millisecond,
+		MaxGain:    64,
+		SampleRate: fs,
+	})
+	loud := make([]float32, int(fs*0.1))
+	for i := range loud {
+		loud[i] = 1.0
+	}
+	a.Process(nil, loud)
+	gainAfterLoud := a.Gain()
+
+	quiet := make([]float32, 256) // ~5 ms — much less than release
+	for i := range quiet {
+		quiet[i] = 0.001
+	}
+	a.Process(nil, quiet)
+	gainAfter256Quiet := a.Gain()
+
+	// Gain should still be close to the loud-section gain (release is
+	// 200 ms, we only ran 5 ms of quiet).
+	ratio := gainAfter256Quiet / gainAfterLoud
+	if ratio > 1.5 {
+		t.Errorf("gain ratio after 5 ms quiet = %.2f, want ≤ 1.5 (release should be slow)", ratio)
+	}
+}
+
+func TestAudioAGCResetClearsState(t *testing.T) {
+	a := NewAudioAGC(AudioAGCConfig{Reference: 0.3, SampleRate: 48_000})
+	in := make([]float32, 1024)
+	for i := range in {
+		in[i] = 1.0
+	}
+	a.Process(nil, in)
+	a.Reset()
+	if a.level != 0 {
+		t.Errorf("after Reset, level = %f, want 0", a.level)
+	}
+	// Right after Reset, gain should be MaxGain (level is at floor).
+	if g := a.Gain(); g != a.maxGain {
+		t.Errorf("post-reset gain = %f, want maxGain = %f", g, a.maxGain)
+	}
+}
+
+func TestAudioAGCInPlace(t *testing.T) {
+	a := NewAudioAGC(AudioAGCConfig{Reference: 0.3, SampleRate: 48_000})
+	buf := []float32{0.05, 0.05, 0.05, 0.05}
+	out := a.Process(buf, buf)
+	if &out[0] != &buf[0] {
+		t.Error("Process(buf, buf) should reuse the slice")
+	}
+}
+
+func TestAudioAGCDefaultsApplied(t *testing.T) {
+	// Zero-valued config (except SampleRate) should hit defaults.
+	a := NewAudioAGC(AudioAGCConfig{SampleRate: 48_000})
+	if a.reference != 0.3 {
+		t.Errorf("reference = %f, want default 0.3", a.reference)
+	}
+	if a.maxGain != 64 {
+		t.Errorf("maxGain = %f, want default 64", a.maxGain)
+	}
+	if a.attackCoef <= 0 || a.attackCoef >= 1 {
+		t.Errorf("attackCoef out of range: %f", a.attackCoef)
+	}
+	if a.releaseCoef <= 0 || a.releaseCoef >= 1 {
+		t.Errorf("releaseCoef out of range: %f", a.releaseCoef)
+	}
+	if a.releaseCoef >= a.attackCoef {
+		t.Errorf("releaseCoef (%f) should be smaller than attackCoef (%f)",
+			a.releaseCoef, a.attackCoef)
+	}
+}
+
+func TestAudioAGCRejectsZeroSampleRate(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic for zero sample rate")
+		}
+	}()
+	_ = NewAudioAGC(AudioAGCConfig{Reference: 0.3})
+}

--- a/internal/voice/composer/composer.go
+++ b/internal/voice/composer/composer.go
@@ -6,10 +6,11 @@
 // from the bus. On a CallStart it looks up the Voice device by serial,
 // opens its IQ stream, and starts a goroutine that runs an FM
 // passthrough chain (LPF → decimate → quadrature FM demod → optional
-// post-demod de-emphasis → optional post-demod audio LPF → coarse
-// resample → int16 PCM → recorder.WritePCM). The chain also calls
-// Engine.Touch on a one-second cadence so the engine's silent-call
-// watchdog doesn't kill the call mid-conversation.
+// post-demod de-emphasis → optional Kaiser audio LPF → optional
+// audio AGC → coarse resample → int16 PCM → recorder.WritePCM). The
+// chain also calls Engine.Touch on a one-second cadence so the
+// engine's silent-call watchdog doesn't kill the call
+// mid-conversation.
 //
 // Digital protocols (P25 / DMR / NXDN) need vocoders that haven't
 // landed yet — IMBE for P25 Phase 1 is in progress and AMBE+2 stays
@@ -27,6 +28,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/MattCheramie/GopherTrunk/internal/dsp"
 	"github.com/MattCheramie/GopherTrunk/internal/dsp/demod"
 	"github.com/MattCheramie/GopherTrunk/internal/dsp/equalizer"
 	"github.com/MattCheramie/GopherTrunk/internal/dsp/filter"
@@ -116,6 +118,13 @@ type Options struct {
 	// anti-aliasing filter for the second decimation. Off by default;
 	// callers tune CutoffHz (typical 3400) and Taps (default 81).
 	AudioLPF AudioLPFConfig
+	// AudioAGC configures a real-valued envelope-follower-based AGC
+	// applied after the audio LPF (so the envelope follower sees a
+	// clean band-limited signal). The point is to level out the
+	// loudness difference between weak and strong transmitters on
+	// the same talkgroup so recordings don't whiplash. Off by
+	// default; analog FM systems opt in via daemon config.
+	AudioAGC AudioAGCConfig
 }
 
 // DeEmphasisConfig holds runtime knobs for the post-FM-demod
@@ -136,6 +145,17 @@ type AudioLPFConfig struct {
 	Taps     int
 }
 
+// AudioAGCConfig holds runtime knobs for the post-demod audio AGC.
+// Reference, Attack, Release, and MaxGain default to sane voice
+// values when zero.
+type AudioAGCConfig struct {
+	Enabled   bool
+	Reference float32       // target |output| (default 0.3)
+	Attack    time.Duration // ramp-up time constant (default 5 ms)
+	Release   time.Duration // ramp-down time constant (default 200 ms)
+	MaxGain   float32       // ceiling on adaptive gain (default 64.0)
+}
+
 // Composer is the long-lived event-driven bridge.
 type Composer struct {
 	bus    *events.Bus
@@ -151,6 +171,7 @@ type Composer struct {
 	eqCfg        EqualizerConfig
 	deemphCfg    DeEmphasisConfig
 	lpfCfg       AudioLPFConfig
+	agcCfg       AudioAGCConfig
 
 	sub       *events.Subscription
 	runDone   chan struct{}
@@ -206,6 +227,8 @@ func New(opts Options) (*Composer, error) {
 			opts.AudioLPF.Taps = 81
 		}
 	}
+	// AudioAGC defaults are applied inside dsp.NewAudioAGC, so the
+	// composer doesn't need to materialize them here.
 	log := opts.Log
 	if log == nil {
 		log = slog.Default()
@@ -223,6 +246,7 @@ func New(opts Options) (*Composer, error) {
 		eqCfg:      opts.Equalizer,
 		deemphCfg:  opts.DeEmphasis,
 		lpfCfg:     opts.AudioLPF,
+		agcCfg:     opts.AudioAGC,
 		chains:     make(map[string]*chain),
 		runDone:    make(chan struct{}),
 	}
@@ -413,6 +437,24 @@ func (c *Composer) runFMChain(ctx context.Context, serial string, iqCh <-chan []
 		audioLPF = filter.NewRealFIR(filter.LowpassKaiser(c.lpfCfg.Taps, fc, 8.6))
 	}
 
+	// Optional audio AGC. Sits after the LPF so the envelope
+	// follower sees a clean band-limited signal — pre-emphasis is
+	// already undone, hiss + sub-carriers already trimmed — which
+	// keeps the level estimate stable and prevents the AGC from
+	// chasing high-frequency garbage. Operates at the intermediate
+	// rate so attack/release time constants line up with what the
+	// caller configured.
+	var agc *dsp.AudioAGC
+	if c.agcCfg.Enabled {
+		agc = dsp.NewAudioAGC(dsp.AudioAGCConfig{
+			Reference:  c.agcCfg.Reference,
+			Attack:     c.agcCfg.Attack,
+			Release:    c.agcCfg.Release,
+			MaxGain:    c.agcCfg.MaxGain,
+			SampleRate: intermediateHzf,
+		})
+	}
+
 	touchTicker := time.NewTicker(c.touchEvery)
 	defer touchTicker.Stop()
 
@@ -444,6 +486,9 @@ func (c *Composer) runFMChain(ctx context.Context, serial string, iqCh <-chan []
 			}
 			if audioLPF != nil {
 				audio = audioLPF.Process(audio, audio)
+			}
+			if agc != nil {
+				audio = agc.Process(audio, audio)
 			}
 			pcm := decimateAndConvert(audio, decim2)
 			if c.sink != nil && len(pcm) > 0 {


### PR DESCRIPTION
## Summary

Pulls the AGC item off the "Higher-fidelity audio" gap. The IQ-domain
AGC already lived in `internal/dsp` (it drives the *complex* baseband
magnitude toward a target with a single adaptation rate, which works
because FM has a constant envelope on air). After demod the signal is
voice — bursty, with short loud transients separated by quieter
passages — so a single rate either pumps badly (too fast) or never
catches up (too slow). This PR adds the real-valued counterpart, sized
for voice with classic envelope-follower attack/release semantics.

> **Note on conflicts:** PR #41 (audio LPF) and this PR both touch
> `composer.go` + `README.md`. Conflicts will resolve at merge —
> whichever lands second carries the trivial union of both option
> structs and chain stages. The DSP primitives (`RealFIR` in #41,
> `AudioAGC` here) are independent files and don't overlap.

### What changed

- **`internal/dsp/agc_audio.go`** — `AudioAGC` is a classic envelope-
  follower + gain stage. Per sample: rectify, ramp the level estimate
  up fast (attack coefficient) when `|x|` exceeds it and down slow
  (release coefficient) when it doesn't, derive
  `gain = reference / max(level, floor)` clamped to `MaxGain`,
  multiply through. Voice-oriented defaults — reference 0.3 (leaves
  headroom for the 10 000-scale int16 conversion downstream), 5 ms
  attack, 200 ms release, 64× ceiling. Bad `SampleRate` panics at
  startup.
- **`internal/voice/composer/composer.go`** — new
  `AudioAGCConfig{Enabled, Reference, Attack, Release, MaxGain}` on
  `Options`. When enabled, the chain builds a `dsp.AudioAGC` at the
  intermediate (~48 kHz) rate and applies it in-place after
  de-emphasis and before the second decimation. Off by default —
  analog FM systems opt in via daemon config.
- **`README.md`** — DSP feature row distinguishes IQ vs. audio AGC;
  demod-pipeline row picks up the new stage; both copies of the
  FM-polish gap entry shorten — only polyphase resampling and a
  post-demod LPF remain pending.

### Tests

- Steady 1 kHz sinusoid at 0.05 amplitude → output RMS converges to
  `reference / √2` within ±30 % (this is a leveler, not a precision
  compressor).
- Loud unit-amplitude burst → mean `|output|` settles to ≈ reference.
- Quiet section right after a loud one → gain stays close to the
  loud-section gain (release time constant honored).
- `Reset` clears state; post-reset `Gain()` returns `MaxGain`.
- In-place `Process(buf, buf)` reuses the slice.
- Zero-config defaults are sane: reference 0.3, MaxGain 64,
  `releaseCoef` strictly < `attackCoef`.
- Zero `SampleRate` panics.
- All existing composer / dsp / radio tests stay green; full
  `go test ./...` passes.

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./internal/dsp/... ./internal/voice/composer/...` green
- [x] `go test ./...` (full suite, all packages green)
- [ ] Manual: enable
      `composer.AudioAGCConfig{Enabled: true, Reference: 0.3, Attack: 5ms, Release: 200ms}`
      on an analog-FM site that has both quiet and loud subscribers,
      confirm recordings level out instead of whiplashing.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PHnwos5vaxtoDiSi32maZz)_