### PR TITLE
FM polyphase resampler: real-valued L/M resampler + opt-in composer wiring

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ gRPC, HTTP/SSE, or WebSocket.
 | Area              | Component                                                  |
 | ----------------- | ---------------------------------------------------------- |
 | Hardware          | CGO `librtlsdr` binding, multi-device pool, role assignment, per-device gain (`auto` / tenths-of-dB) + PPM + bias-tee (5 V LNA power, e.g. NESDR Smart v5) applied at open time, DC blocker, IQ-imbalance correction, file-backed IQ replay (mock) |
-| DSP               | Polyphase channelizer, FIR + Kaiser LPF designer + RRC, CIC, halfband, IQ + audio AGC (attack/release envelope follower for voice), rational resampler, FM / C4FM / H-DQPSK demods, single-pole IIR de-emphasis (75/50µs), Mueller-Müller clock recovery, frame-sync correlator |
+| DSP               | Polyphase channelizer, FIR + Kaiser LPF designer + RRC, CIC, halfband, IQ + audio AGC (attack/release envelope follower for voice), L/M polyphase resampler (complex IQ + real audio), FM / C4FM / H-DQPSK demods, single-pole IIR de-emphasis (75/50µs), Mueller-Müller clock recovery, frame-sync correlator |
 | FEC primitives    | CRC-CCITT/FALSE, CRC-6 (NXDN SACCH), Hamming(15,11,3), Hamming(13,9,3), Hamming(20,8) (DMR slot-type, t=3), extended Golay(24,12,8), BCH(63,16,11), BPTC(196,96), 4-state ½-rate Viterbi, 16-state K=5 ½-rate Viterbi (NXDN SACCH) |
 | P25 Phase 1       | 48-bit FSW + sync detector, NID parser (NAC + DUID) with BCH(63,16,11) error correction + even-parity check, full TSBK channel decode (TIA-102.BAAA Annex A 4-state ½-rate trellis + 98-dibit block deinterleaver) → CRC trailer validation, payload parsers for GroupVoiceChannelGrant / Update / NetworkStatus / RFSSStatus, IdentifierUpdate band-plan resolver, control-channel state machine emitting `protocol = "p25"` grants and `decode.error` events with `nid-bch` / `tsbk-trellis` / `tsbk-crc` / `no-bandplan` stages |
 | P25 Phase 2       | Outbound + inbound 20-dibit sync, 360 ms / 12-subframe superframe + SlotType enum, MAC PDU parser + opcode enum, GroupVoiceChannelGrant accessor, control-channel state machine emitting `protocol = "p25-phase2"` grants |
@@ -31,7 +31,7 @@ gRPC, HTTP/SSE, or WebSocket.
 | D-STAR            | Frame Sync + Slow Data sync, 41-byte PCH header parser (FLAG1 + RPT2 / RPT1 / UR / MY1 / MY2 + CRC-CCITT), IsGroupCall / IsEmergency / IsData accessors, repeater state machine emitting `protocol = "dstar"` grants on group transmissions |
 | Orchestration     | In-process pub/sub event bus, `System` model, JSON-on-disk last-known-CC cache, control-channel `Hunter` that retunes the SDR and parks on the first responsive frequency |
 | Trunking engine   | Cross-protocol `Grant` payload, Trunk-Recorder-format talkgroup DB (CSV + JSON), priority + preemption (emergency overrides, strict-higher), voice-device pool allocator, central state machine emitting `CallStart` / `CallEnd` events with a watchdog for silent calls |
-| Demod pipeline    | `internal/voice/composer` subscribes to `CallStart` events, opens the bound Voice device's IQ stream, runs an LPF → decimate → optional CMA equalizer → FM demod → optional 75/50µs de-emphasis → optional Kaiser audio LPF → optional audio AGC → decimate → int16 PCM chain into the recorder, and pings `Engine.Touch` every second so the silent-call watchdog leaves the call alone |
+| Demod pipeline    | `internal/voice/composer` subscribes to `CallStart` events, opens the bound Voice device's IQ stream, runs an LPF → decimate → optional CMA equalizer → FM demod → optional 75/50µs de-emphasis → optional Kaiser audio LPF → optional audio AGC → optional polyphase L/M resample (or naive decimate fallback) → int16 PCM chain into the recorder, and pings `Engine.Touch` every second so the silent-call watchdog leaves the call alone |
 | Simulcast / "True I/Q" | `internal/dsp/equalizer` (LMS + CMA blind equalizers) for inter-symbol-interference / multipath mitigation, plus `internal/dsp/diversity` (Selection + maximal-ratio combiners over a shared `Combiner` interface) for multi-receiver IQ combining |
 | Tone-out alerting | `internal/voice/toneout` runs Goertzel filters against each Voice device's PCM stream, matches QC-II two-tone-sequential sequences against operator-configured profiles with per-tone duration + cooldown, and publishes `tone.alert` events that fan out through SSE / WebSocket / gRPC |
 | Voice recording   | `Vocoder` plugin interface + `NullVocoder` baseline, 16-bit PCM mono WAV writer with patched-length trailers, per-call recorder writing `<system>/<tg>/<UTC>_src<id>.wav` plus an optional raw-frame sidecar so users can BYO decoder; EDACS ProVoice grants always force a `.raw` sidecar (the vocoder is patent + trade-secret encumbered) so researchers can decode out-of-band |
@@ -53,11 +53,11 @@ SQLite. The honest gaps:
   + raw-frame sidecar are in place; pure-Go IMBE is in progress
   ([patents have expired](docs/vocoders.md)) and AMBE+2 stays
   behind the `mbelib` build tag.
-- **Higher-fidelity audio**: the FM chain has opt-in 75/50µs
-  de-emphasis, a Kaiser-windowed audio LPF, and audio AGC. Still
-  pending is proper polyphase resampling rather than naive
-  decimation. Quality is good enough to verify wiring; real DSP
-  polish is follow-up work.
+- **Higher-fidelity audio**: the FM chain now has opt-in 75/50µs
+  de-emphasis, a Kaiser-windowed audio LPF, audio AGC, and a
+  polyphase L/M audio resampler — the full polish stack ships.
+  Defaults stay analog-FM-friendly so digital protocols and
+  passthrough callers see no behavior change.
 
 The Go interfaces and event payloads carry digital protocols already,
 so the remaining paths light up once IMBE drops in.
@@ -79,11 +79,11 @@ to its own package and lands independently.
 - **Yaesu System Fusion (C4FM, FICH).** Amateur-radio digital mode,
   public spec. New `internal/radio/ysf/` package following the
   D-STAR pattern: header parser + repeater state machine.
-- **Higher-fidelity FM voice chain.** Opt-in 75/50µs de-emphasis
-  (`composer.DeEmphasisConfig`), a Kaiser-windowed audio LPF
-  (`composer.AudioLPFConfig`), and audio AGC
-  (`composer.AudioAGCConfig`) are in. Still pending: proper
-  polyphase resampling for production audio.
+- **Higher-fidelity FM voice chain.** ✅ Shipped: opt-in 75/50µs
+  de-emphasis (`composer.DeEmphasisConfig`), Kaiser-windowed audio
+  LPF (`composer.AudioLPFConfig`), audio AGC
+  (`composer.AudioAGCConfig`), and polyphase L/M audio resampler
+  (`composer.AudioResamplerConfig`).
 
 ## Tech stack
 

--- a/internal/dsp/resampler_real.go
+++ b/internal/dsp/resampler_real.go
@@ -1,0 +1,130 @@
+package dsp
+
+import (
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/filter"
+)
+
+// RealResampler is the real-valued counterpart of Resampler. Same
+// polyphase decomposition, same L/M rate, but operates on float32
+// audio instead of complex64 IQ. Sized for the post-demod chain in
+// internal/voice/composer where the FM demod hands real audio to a
+// resampler that retunes 48 kHz → 8 kHz (or arbitrary rational
+// ratios) with proper anti-aliasing built into the polyphase
+// prototype filter.
+//
+// The complex Resampler stays where it is — IQ paths still want it.
+// Splitting them keeps each loop hot on the right data type without
+// the complex64 ↔ float32 conversion overhead that an interface
+// would impose.
+//
+// RealResampler is not safe for concurrent Process calls — pin it
+// to a single demod goroutine and Reset between calls.
+type RealResampler struct {
+	L, M     int
+	branches [][]float32 // length L; each branch is a phase of the prototype
+	hist     []float32
+	histPos  int
+	branchN  int // taps per branch
+	idx      int // commutator state (0..L-1)
+	mCount   int // decimator state (0..M-1)
+}
+
+// NewRealResampler builds a real-valued resampler with rate L/M
+// using a Kaiser-window LPF of total length tapsPerBranch*L. Cutoff
+// is min(0.5/L, 0.5/M) so the prototype rejects images and aliases
+// for both the interpolation and decimation steps. Bad parameters
+// trip a panic at construction so misconfiguration shows up loudly.
+func NewRealResampler(L, M, tapsPerBranch int, beta float64) *RealResampler {
+	if L <= 0 || M <= 0 || tapsPerBranch <= 0 {
+		panic("dsp: NewRealResampler requires positive L, M, tapsPerBranch")
+	}
+	N := tapsPerBranch * L
+	if N%2 == 0 {
+		N++
+	}
+	cutoff := 0.5 / float64(maxInt(L, M))
+	proto := filter.LowpassKaiser(N, cutoff, beta)
+	// Compensate for interpolator gain loss of 1/L.
+	for i := range proto {
+		proto[i] *= float32(L)
+	}
+	branches := make([][]float32, L)
+	taps := (len(proto) + L - 1) / L
+	for b := 0; b < L; b++ {
+		row := make([]float32, taps)
+		for k := 0; k < taps; k++ {
+			j := k*L + b
+			if j < len(proto) {
+				row[k] = proto[j]
+			}
+		}
+		branches[b] = row
+	}
+	return &RealResampler{
+		L: L, M: M,
+		branches: branches,
+		branchN:  taps,
+		hist:     make([]float32, taps),
+	}
+}
+
+// Reset clears the running history and commutator state so the next
+// Process call starts from silence.
+func (r *RealResampler) Reset() {
+	for i := range r.hist {
+		r.hist[i] = 0
+	}
+	r.histPos = 0
+	r.idx = 0
+	r.mCount = 0
+}
+
+// Process consumes len(src) input samples and returns approximately
+// len(src)*L/M output samples. dst is reused if it has capacity.
+func (r *RealResampler) Process(dst, src []float32) []float32 {
+	want := len(src)*r.L/r.M + 8
+	if cap(dst) < want {
+		dst = make([]float32, 0, want)
+	} else {
+		dst = dst[:0]
+	}
+	for _, x := range src {
+		r.hist[r.histPos] = x
+		r.histPos++
+		if r.histPos == r.branchN {
+			r.histPos = 0
+		}
+		// Walk the L commutator phases for this single input sample.
+		for p := 0; p < r.L; p++ {
+			if r.mCount == 0 {
+				dst = append(dst, r.computeBranch(r.idx))
+			}
+			r.idx++
+			if r.idx == r.L {
+				r.idx = 0
+			}
+			r.mCount++
+			if r.mCount == r.M {
+				r.mCount = 0
+			}
+		}
+	}
+	return dst
+}
+
+func (r *RealResampler) computeBranch(b int) float32 {
+	row := r.branches[b]
+	var acc float32
+	idx := r.histPos - 1
+	if idx < 0 {
+		idx = r.branchN - 1
+	}
+	for k := 0; k < r.branchN; k++ {
+		acc += row[k] * r.hist[idx]
+		idx--
+		if idx < 0 {
+			idx = r.branchN - 1
+		}
+	}
+	return acc
+}

--- a/internal/dsp/resampler_real_test.go
+++ b/internal/dsp/resampler_real_test.go
@@ -1,0 +1,126 @@
+package dsp
+
+import (
+	"math"
+	"testing"
+)
+
+func TestRealResamplerOutputRateMatchesLOverM(t *testing.T) {
+	cases := []struct{ L, M int }{
+		{1, 6},  // 48k → 8k (composer audio path)
+		{1, 5},  // 40k → 8k
+		{441, 480}, // 48k → 44.1k (rational, common audio rate)
+		{2, 1},  // upsample by 2
+	}
+	for _, c := range cases {
+		r := NewRealResampler(c.L, c.M, 16, 8.6)
+		in := make([]float32, 2_000)
+		out := r.Process(nil, in)
+		want := len(in) * c.L / c.M
+		// ±2 is OK to absorb the commutator startup transient.
+		if abs := absInt(len(out) - want); abs > 2 {
+			t.Errorf("L=%d M=%d: got %d output samples, want ≈ %d", c.L, c.M, len(out), want)
+		}
+	}
+}
+
+func TestRealResamplerPassesPassbandSinusoid(t *testing.T) {
+	// 48 kHz → 8 kHz (M=6). A 1 kHz sinusoid is well inside the
+	// resampler's prototype passband; output should reproduce it
+	// (close to unit amplitude) without aliasing artefacts.
+	const inFs = 48_000.0
+	r := NewRealResampler(1, 6, 32, 8.6)
+	settling := 4096
+	n := settling + 8192
+	in := make([]float32, n)
+	for i := range in {
+		in[i] = float32(math.Sin(2 * math.Pi * 1000 * float64(i) / inFs))
+	}
+	out := r.Process(nil, in)
+
+	// Output rate is 8 kHz; settling samples in input ≈ settling/6 in
+	// output. Skip them, then measure RMS of the output and compare to
+	// expected RMS of a 1 kHz sinusoid (1/√2).
+	skip := settling / 6
+	var ss float64
+	for _, y := range out[skip:] {
+		ss += float64(y) * float64(y)
+	}
+	rms := math.Sqrt(ss / float64(len(out)-skip))
+	want := 1 / math.Sqrt2
+	if rms < want*0.9 || rms > want*1.1 {
+		t.Errorf("1 kHz passband output RMS = %.3f, want ≈ %.3f", rms, want)
+	}
+}
+
+func TestRealResamplerRejectsAliasingFromAboveNyquist(t *testing.T) {
+	// 48 kHz → 8 kHz. Output Nyquist is 4 kHz; the prototype
+	// rejects anything above 4 kHz so a 12 kHz input sinusoid (which
+	// would alias down to 4 kHz under naive decimation) should be
+	// heavily attenuated in the output.
+	const inFs = 48_000.0
+	r := NewRealResampler(1, 6, 32, 8.6)
+	settling := 4096
+	n := settling + 8192
+	in := make([]float32, n)
+	for i := range in {
+		in[i] = float32(math.Sin(2 * math.Pi * 12_000 * float64(i) / inFs))
+	}
+	out := r.Process(nil, in)
+
+	skip := settling / 6
+	var ss float64
+	for _, y := range out[skip:] {
+		ss += float64(y) * float64(y)
+	}
+	rms := math.Sqrt(ss / float64(len(out)-skip))
+	// Want at least 30 dB rejection on a clean stopband signal.
+	if rms > 0.05 {
+		t.Errorf("12 kHz stopband output RMS = %.3f, want < 0.05 (≥ 26 dB)", rms)
+	}
+}
+
+func TestRealResamplerResetClearsState(t *testing.T) {
+	r := NewRealResampler(1, 4, 16, 8.6)
+	in := make([]float32, 256)
+	for i := range in {
+		in[i] = 1
+	}
+	r.Process(nil, in)
+	r.Reset()
+	if r.histPos != 0 || r.idx != 0 || r.mCount != 0 {
+		t.Errorf("post-Reset state non-zero: histPos=%d idx=%d mCount=%d",
+			r.histPos, r.idx, r.mCount)
+	}
+	for i, h := range r.hist {
+		if h != 0 {
+			t.Errorf("post-Reset hist[%d] = %f, want 0", i, h)
+			break
+		}
+	}
+}
+
+func TestRealResamplerPanicsOnBadParams(t *testing.T) {
+	cases := []struct{ L, M, taps int }{
+		{0, 1, 16},
+		{1, 0, 16},
+		{1, 1, 0},
+	}
+	for _, c := range cases {
+		func() {
+			defer func() {
+				if r := recover(); r == nil {
+					t.Errorf("expected panic for L=%d M=%d taps=%d", c.L, c.M, c.taps)
+				}
+			}()
+			_ = NewRealResampler(c.L, c.M, c.taps, 8.6)
+		}()
+	}
+}
+
+func absInt(a int) int {
+	if a < 0 {
+		return -a
+	}
+	return a
+}

--- a/internal/voice/composer/composer.go
+++ b/internal/voice/composer/composer.go
@@ -7,7 +7,8 @@
 // opens its IQ stream, and starts a goroutine that runs an FM
 // passthrough chain (LPF → decimate → quadrature FM demod → optional
 // post-demod de-emphasis → optional Kaiser audio LPF → optional
-// audio AGC → coarse resample → int16 PCM → recorder.WritePCM). The
+// audio AGC → optional polyphase resample (or coarse decimate) →
+// int16 PCM → recorder.WritePCM). The
 // chain also calls Engine.Touch on a one-second cadence so the
 // engine's silent-call watchdog doesn't kill the call
 // mid-conversation.
@@ -125,6 +126,15 @@ type Options struct {
 	// the same talkgroup so recordings don't whiplash. Off by
 	// default; analog FM systems opt in via daemon config.
 	AudioAGC AudioAGCConfig
+	// AudioResampler swaps the naive integer decimation that hands
+	// audio to the recorder for a polyphase L/M resampler with
+	// proper anti-aliasing built into the prototype filter. The
+	// resampler is sized from the intermediate-rate / PCM-rate ratio
+	// the chain already computes, so the caller only opts in
+	// (Enabled) and optionally tunes TapsPerBranch / Beta. Off by
+	// default; the existing AudioLPF + naive decimation produces
+	// equivalent audio when the two rates are integer multiples.
+	AudioResampler AudioResamplerConfig
 }
 
 // DeEmphasisConfig holds runtime knobs for the post-FM-demod
@@ -143,6 +153,17 @@ type AudioLPFConfig struct {
 	Enabled  bool
 	CutoffHz uint32
 	Taps     int
+}
+
+// AudioResamplerConfig holds runtime knobs for the polyphase audio
+// resampler. TapsPerBranch (default 16) controls the prototype
+// filter's per-branch length; Beta (default 8.6) is the Kaiser
+// window shape parameter — higher β = steeper transition, more
+// stopband rejection, longer impulse.
+type AudioResamplerConfig struct {
+	Enabled       bool
+	TapsPerBranch int
+	Beta          float64
 }
 
 // AudioAGCConfig holds runtime knobs for the post-demod audio AGC.
@@ -172,6 +193,7 @@ type Composer struct {
 	deemphCfg    DeEmphasisConfig
 	lpfCfg       AudioLPFConfig
 	agcCfg       AudioAGCConfig
+	resampCfg    AudioResamplerConfig
 
 	sub       *events.Subscription
 	runDone   chan struct{}
@@ -229,6 +251,14 @@ func New(opts Options) (*Composer, error) {
 	}
 	// AudioAGC defaults are applied inside dsp.NewAudioAGC, so the
 	// composer doesn't need to materialize them here.
+	if opts.AudioResampler.Enabled {
+		if opts.AudioResampler.TapsPerBranch <= 0 {
+			opts.AudioResampler.TapsPerBranch = 16
+		}
+		if opts.AudioResampler.Beta <= 0 {
+			opts.AudioResampler.Beta = 8.6
+		}
+	}
 	log := opts.Log
 	if log == nil {
 		log = slog.Default()
@@ -247,6 +277,7 @@ func New(opts Options) (*Composer, error) {
 		deemphCfg:  opts.DeEmphasis,
 		lpfCfg:     opts.AudioLPF,
 		agcCfg:     opts.AudioAGC,
+		resampCfg:  opts.AudioResampler,
 		chains:     make(map[string]*chain),
 		runDone:    make(chan struct{}),
 	}
@@ -455,6 +486,17 @@ func (c *Composer) runFMChain(ctx context.Context, serial string, iqCh <-chan []
 		})
 	}
 
+	// Optional polyphase audio resampler. Replaces the naive
+	// decimateAndConvert audio decimation with an L/M polyphase
+	// resampler whose prototype filter doubles as the anti-aliasing
+	// LPF. L and M come from the intermediate-rate / PCM-rate ratio
+	// the chain already computed (decim2 = M with L = 1 for the
+	// integer-multiple case), so callers only opt in.
+	var resamp *dsp.RealResampler
+	if c.resampCfg.Enabled {
+		resamp = dsp.NewRealResampler(1, decim2, c.resampCfg.TapsPerBranch, c.resampCfg.Beta)
+	}
+
 	touchTicker := time.NewTicker(c.touchEvery)
 	defer touchTicker.Stop()
 
@@ -490,7 +532,15 @@ func (c *Composer) runFMChain(ctx context.Context, serial string, iqCh <-chan []
 			if agc != nil {
 				audio = agc.Process(audio, audio)
 			}
-			pcm := decimateAndConvert(audio, decim2)
+			var pcm []int16
+			if resamp != nil {
+				// Polyphase rate-conversion already emits at the
+				// PCM rate; convert in place without further
+				// decimation.
+				pcm = convertToPCM(resamp.Process(nil, audio))
+			} else {
+				pcm = decimateAndConvert(audio, decim2)
+			}
 			if c.sink != nil && len(pcm) > 0 {
 				_ = c.sink.WritePCM(serial, pcm)
 			}
@@ -527,6 +577,24 @@ func decimateAndConvert(in []float32, factor int) []int16 {
 			v = math.MinInt16
 		}
 		out = append(out, int16(v))
+	}
+	return out
+}
+
+// convertToPCM converts a float32 audio stream that's already at the
+// PCM sample rate (i.e. handed back from RealResampler) to 16-bit
+// signed PCM with the same scale + clamp decimateAndConvert uses.
+func convertToPCM(in []float32) []int16 {
+	out := make([]int16, len(in))
+	for i, x := range in {
+		v := float64(x) * 10_000
+		if v > math.MaxInt16 {
+			v = math.MaxInt16
+		}
+		if v < math.MinInt16 {
+			v = math.MinInt16
+		}
+		out[i] = int16(v)
 	}
 	return out
 }


### PR DESCRIPTION
## Summary

Closes the last item on the "Higher-fidelity audio" gap. The composer's
final audio decimation was naive (every Mth sample); the audio LPF
upstream made that safe by anti-aliasing first, but it doesn't
generalize to rational rates and computes filter taps for samples that
get discarded. This PR adds the real-valued counterpart of the existing
complex `Resampler` and wires it as an opt-in replacement for the
naive decimation.

The full FM polish stack (de-emphasis + LPF + AGC + polyphase
resampler) is now in.

### What changed

- **`internal/dsp/resampler_real.go`** — `RealResampler` mirrors the
  complex `Resampler`'s polyphase decomposition + Kaiser prototype
  (cutoff = `0.5 / max(L, M)` for both image and alias rejection),
  but operates on `float32` audio instead of `complex64` IQ. Same
  constructor shape; bad parameters panic at startup; `Reset` clears
  state. Splitting from the complex type keeps each loop hot on the
  right data type without a conversion penalty.
- **`internal/voice/composer/composer.go`** — new
  `AudioResamplerConfig{Enabled, TapsPerBranch, Beta}` on `Options`.
  When enabled, the chain builds
  `dsp.NewRealResampler(1, decim2, TapsPerBranch, Beta)` (defaults:
  16 taps/branch, β=8.6) and uses it in place of
  `decimateAndConvert`. A small `convertToPCM` helper factors the
  int16 conversion + clamp out so both paths share it. Off by
  default — passthrough callers and digital protocols see no
  behavior change.
- **`README.md`** — DSP feature row distinguishes complex IQ + real
  audio variants of the polyphase resampler; demod-pipeline row
  picks up the new optional stage; both copies of the FM-polish gap
  entry flip to "shipped" — the full polish stack is in.

### Tests

- Output rate matches `L/M` for integer ratios (1/6, 1/5, 2/1) and a
  rational ratio (441/480 → the 48 kHz → 44.1 kHz conversion most
  audio toolchains care about).
- 1 kHz passband sinusoid through 48 kHz → 8 kHz passes at near-unit
  RMS (`1/√2` expected for a sinusoid).
- 12 kHz stopband sinusoid through 48 kHz → 8 kHz drops below 0.05
  RMS (≥ 26 dB rejection — the alias would land at 4 kHz under naive
  decimation, so this is the real win).
- `Reset` clears history + commutator + decimator state.
- Bad parameters (zero `L`, `M`, or `TapsPerBranch`) panic.
- All existing composer / dsp / radio tests stay green; full
  `go test ./...` passes.

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./internal/dsp/... ./internal/voice/composer/...` green
- [x] `go test ./...` (full suite, all packages green)
- [ ] Manual: enable
      `composer.AudioResamplerConfig{Enabled: true}` alongside the
      LPF + AGC, listen on an analog FM site — should sound
      identical to the naive-decimation path on integer-ratio
      configs (48 kHz → 8 kHz) and aliased-content-free on
      rational-ratio configs.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PHnwos5vaxtoDiSi32maZz)_