### PR TITLE
YSF (Yaesu System Fusion): FSW correlator + frame layout + state machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ GopherTrunk manages a pool of RTL-SDR dongles, runs a custom Go DSP
 pipeline, decodes the signalling layers of every major trunked-radio
 family (P25 Phase 1 / Phase 2, DMR Tier II / III, NXDN, Motorola Type II /
 SmartZone, EDACS / GE-Marc, LTR, MPT 1327, dPMR Mode 3, TETRA TMO)
-plus the D-STAR amateur repeater header, follows voice grants by
-talkgroup priority, and streams metadata + audio to any frontend over
-gRPC, HTTP/SSE, or WebSocket.
+plus the D-STAR + Yaesu System Fusion amateur modes, follows voice
+grants by talkgroup priority, and streams metadata + audio to any
+frontend over gRPC, HTTP/SSE, or WebSocket.
 
 ## Features
 
@@ -29,6 +29,7 @@ gRPC, HTTP/SSE, or WebSocket.
 | dPMR (Mode 3)     | FS1 / FS2 / FS3 24-dibit sync, 80-bit CSBK parser, MessageType enum (RegistrationRequest / Response, VoiceServiceAllocation, IndividualVoiceAllocation, DataServiceAllocation, ServiceRequest, StandingServiceStatus, Release, Idle), AsVoiceGrant + AsSiteBroadcast accessors, PMR446 default band-plan, control-channel state machine emitting `protocol = "dpmr"` grants |
 | TETRA (TMO)       | Normal + extended training-sequence sync, generic Layer-3 PDU parser (4-bit Discriminator + type + payload), CMCE D-CONNECT / D-TX-GRANTED / D-RELEASE accessors, MLE-SYSINFO accessor (MCC / MNC / Location Area), TETRA-380 / 410 / 800 carrier resolver, control-channel state machine emitting `protocol = "tetra"` grants |
 | D-STAR            | Frame Sync + Slow Data sync, 41-byte PCH header parser (FLAG1 + RPT2 / RPT1 / UR / MY1 / MY2 + CRC-CCITT), IsGroupCall / IsEmergency / IsData accessors, repeater state machine emitting `protocol = "dstar"` grants on group transmissions |
+| YSF (Yaesu System Fusion) | 4800-baud C4FM, 480-dibit / 100 ms frame layout (FSW / FICH / DCH offsets), 40-bit FSW correlator with mismatch tolerance, per-frequency state machine emitting `cc.locked` on sync detect (FICH parse + grant emission is a follow-up — Trellis decode lands separately) |
 | Orchestration     | In-process pub/sub event bus, `System` model, JSON-on-disk last-known-CC cache, control-channel `Hunter` that retunes the SDR and parks on the first responsive frequency |
 | Trunking engine   | Cross-protocol `Grant` payload, Trunk-Recorder-format talkgroup DB (CSV + JSON), priority + preemption (emergency overrides, strict-higher), voice-device pool allocator, central state machine emitting `CallStart` / `CallEnd` events with a watchdog for silent calls |
 | Demod pipeline    | `internal/voice/composer` subscribes to `CallStart` events, opens the bound Voice device's IQ stream, runs an LPF → decimate → optional CMA equalizer → FM demod → optional 75/50µs de-emphasis → optional Kaiser audio LPF → optional audio AGC → optional polyphase L/M resample (or naive decimate fallback) → int16 PCM chain into the recorder, and pings `Engine.Touch` every second so the silent-call watchdog leaves the call alone |
@@ -76,9 +77,11 @@ to its own package and lands independently.
   factory that opens a connected DVSI USB chip. Same plug-in shape
   as `internal/voice/mbelib`; the daemon picks the factory by name
   from `voice.DefaultRegistry`.
-- **Yaesu System Fusion (C4FM, FICH).** Amateur-radio digital mode,
-  public spec. New `internal/radio/ysf/` package following the
-  D-STAR pattern: header parser + repeater state machine.
+- **YSF FICH decode + grant emission.** The `internal/radio/ysf/`
+  package ships sync detection + frame layout; the FICH (Frame
+  Information Channel) carries Trellis-encoded Frame Type / Call
+  Sign Mode / Frame Number bits that the next pass will decode +
+  republish as `protocol = "ysf"` grants on the bus.
 - **Higher-fidelity FM voice chain.** ✅ Shipped: opt-in 75/50µs
   de-emphasis (`composer.DeEmphasisConfig`), Kaiser-windowed audio
   LPF (`composer.AudioLPFConfig`), audio AGC

--- a/internal/radio/ysf/control.go
+++ b/internal/radio/ysf/control.go
@@ -1,0 +1,89 @@
+package ysf
+
+import (
+	"log/slog"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+)
+
+// LockState is the payload of cc.locked / cc.lost events emitted by
+// the YSF state machine. Until the FICH decoder lands, the only
+// information carried is the tuned frequency — site / call-sign /
+// frame-type fields will accrete onto this struct as the FICH path
+// stabilises. LockState satisfies trunking.LockedPayload so the
+// hunter can consume it without importing this package.
+type LockState struct {
+	FrequencyHz uint32
+}
+
+// LockedFrequencyHz / LockedNAC implement trunking.LockedPayload.
+// YSF doesn't have a P25-style NAC; LockedNAC returns 0 and the
+// hunter treats it as a don't-care.
+func (s LockState) LockedFrequencyHz() uint32 { return s.FrequencyHz }
+func (s LockState) LockedNAC() uint16          { return 0 }
+
+// ControlChannel ingests a stream of YSF dibits, runs the FSW
+// detector, and publishes cc.locked the first time the sync word
+// correlates on a freshly-tuned device. Lock events repeat with
+// every fresh sync hit only when they would change state — once
+// locked, repeated hits are suppressed until MarkLost runs.
+//
+// FICH decode lives behind a follow-up PR; until then a YSF lock
+// just tells the orchestration layer "there's a transmission here"
+// without telling it who or what.
+type ControlChannel struct {
+	bus    *events.Bus
+	log    *slog.Logger
+	det    *SyncDetector
+	freqHz uint32
+	locked bool
+}
+
+// NewControlChannel constructs a YSF control channel scanner.
+// freqHz is the receive frequency the SDR is tuned to; it ends up
+// on every cc.locked event.
+func NewControlChannel(bus *events.Bus, log *slog.Logger, freqHz uint32) *ControlChannel {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &ControlChannel{
+		bus:    bus,
+		log:    log,
+		det:    NewSyncDetector(2),
+		freqHz: freqHz,
+	}
+}
+
+// Process consumes a window of dibits and runs sync detection.
+// baseIdx is the absolute dibit index of dibits[0]. Returns the new
+// baseIndex (matches the NXDN / P25 detector contracts).
+func (c *ControlChannel) Process(dibits []uint8, baseIdx int) int {
+	hits, next := c.det.Process(nil, dibits, baseIdx)
+	for range hits {
+		c.maybeLock()
+	}
+	return next
+}
+
+func (c *ControlChannel) maybeLock() {
+	if c.locked {
+		return
+	}
+	c.locked = true
+	state := LockState{FrequencyHz: c.freqHz}
+	c.bus.Publish(events.Event{Kind: events.KindCCLocked, Payload: state})
+	c.log.Info("ysf cc locked", "freq", state.FrequencyHz)
+}
+
+// MarkLost publishes cc.lost and resets the locked flag. Wired up by
+// the engine's watchdog when the FSW stops correlating.
+func (c *ControlChannel) MarkLost() {
+	if !c.locked {
+		return
+	}
+	c.locked = false
+	c.bus.Publish(events.Event{
+		Kind:    events.KindCCLost,
+		Payload: LockState{FrequencyHz: c.freqHz},
+	})
+}

--- a/internal/radio/ysf/control_test.go
+++ b/internal/radio/ysf/control_test.go
@@ -1,0 +1,131 @@
+package ysf
+
+import (
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// streamWithFSWAt returns a 480-dibit YSF frame skeleton with the
+// FSW placed at offset and the rest of the buffer zeroed.
+func streamWithFSWAt(offset int) []uint8 {
+	out := make([]uint8, FrameDibits)
+	copy(out[offset:], FSWPattern)
+	return out
+}
+
+func TestControlChannelEmitsLockOnSync(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := NewControlChannel(bus, nil, 444_525_000)
+	cc.Process(streamWithFSWAt(FSWOffset), 0)
+
+	select {
+	case ev := <-sub.C:
+		if ev.Kind != events.KindCCLocked {
+			t.Fatalf("kind = %s, want cc.locked", ev.Kind)
+		}
+		ls, ok := ev.Payload.(LockState)
+		if !ok {
+			t.Fatalf("payload type = %T, want LockState", ev.Payload)
+		}
+		if ls.FrequencyHz != 444_525_000 {
+			t.Errorf("freq = %d, want 444525000", ls.FrequencyHz)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("no event published")
+	}
+}
+
+func TestControlChannelDoesNotRelock(t *testing.T) {
+	// Two FSW hits in the same stream should produce exactly one
+	// cc.locked event (no relock until MarkLost).
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := NewControlChannel(bus, nil, 1)
+	stream := make([]uint8, FrameDibits*2)
+	copy(stream[10:], FSWPattern)
+	copy(stream[FrameDibits+10:], FSWPattern)
+	cc.Process(stream, 0)
+
+	count := 0
+	deadline := time.After(150 * time.Millisecond)
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind == events.KindCCLocked {
+				count++
+			}
+		case <-deadline:
+			if count != 1 {
+				t.Errorf("got %d cc.locked events, want 1 (no relock)", count)
+			}
+			return
+		}
+	}
+}
+
+func TestControlChannelMarkLost(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := NewControlChannel(bus, nil, 145_550_000)
+	cc.Process(streamWithFSWAt(0), 0)
+	<-sub.C // CCLocked
+
+	cc.MarkLost()
+	select {
+	case ev := <-sub.C:
+		if ev.Kind != events.KindCCLost {
+			t.Errorf("kind = %s, want cc.lost", ev.Kind)
+		}
+		ls, ok := ev.Payload.(LockState)
+		if !ok {
+			t.Fatalf("payload type = %T", ev.Payload)
+		}
+		if ls.FrequencyHz != 145_550_000 {
+			t.Errorf("freq = %d, want 145550000", ls.FrequencyHz)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("no cc.lost event")
+	}
+}
+
+func TestControlChannelMarkLostNoOpWhenUnlocked(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := NewControlChannel(bus, nil, 1)
+	cc.MarkLost()
+
+	select {
+	case ev := <-sub.C:
+		t.Errorf("MarkLost on never-locked channel emitted %s", ev.Kind)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestLockStateSatisfiesTrunkingLockedPayload(t *testing.T) {
+	// Compile-time check: the hunter consumes lock events through
+	// the trunking.LockedPayload interface, so YSF's LockState must
+	// satisfy it.
+	var lp trunking.LockedPayload = LockState{FrequencyHz: 100}
+	if lp.LockedFrequencyHz() != 100 {
+		t.Errorf("LockedFrequencyHz = %d, want 100", lp.LockedFrequencyHz())
+	}
+	if lp.LockedNAC() != 0 {
+		t.Errorf("LockedNAC = %d, want 0 (YSF has no NAC)", lp.LockedNAC())
+	}
+}

--- a/internal/radio/ysf/frame.go
+++ b/internal/radio/ysf/frame.go
@@ -1,0 +1,33 @@
+package ysf
+
+// Frame layout constants per the Yaesu System Fusion specification.
+// All values measured in dibits unless suffixed otherwise.
+const (
+	// FrameDibits is the length of one YSF frame on-air. 480 dibits
+	// = 960 bits = 100 ms at 4800 baud C4FM.
+	FrameDibits = 480
+
+	// FrameBits = FrameDibits * 2.
+	FrameBits = FrameDibits * 2
+
+	// FrameDurationMs is informational — every frame carries 100 ms of
+	// air time at the fixed 4800 sym/s rate.
+	FrameDurationMs = 100
+
+	// FICHDibits is the size of the encoded Frame Information Channel
+	// region. The 100-dibit field carries Trellis-encoded FICH bits;
+	// after Viterbi decode the recovered info is a much smaller field
+	// (handled by the future FICH decoder, not in this PR).
+	FICHDibits = 100
+
+	// PayloadDibits covers the DCH (Data CHannel) region — voice or
+	// data depending on the FICH's Frame Type field.
+	PayloadDibits = FrameDibits - FSWDibits - FICHDibits // 360
+)
+
+// Frame offsets for callers that want to slice a 480-dibit window.
+const (
+	FSWOffset     = 0
+	FICHOffset    = FSWOffset + FSWDibits  // 20
+	PayloadOffset = FICHOffset + FICHDibits // 120
+)

--- a/internal/radio/ysf/frame_test.go
+++ b/internal/radio/ysf/frame_test.go
@@ -1,0 +1,35 @@
+package ysf
+
+import "testing"
+
+func TestFrameLayoutAddsUp(t *testing.T) {
+	if got := FSWDibits + FICHDibits + PayloadDibits; got != FrameDibits {
+		t.Errorf("layout sum = %d, want %d", got, FrameDibits)
+	}
+}
+
+func TestFrameOffsetsContiguous(t *testing.T) {
+	if FSWOffset != 0 {
+		t.Errorf("FSWOffset = %d, want 0", FSWOffset)
+	}
+	if FICHOffset != FSWDibits {
+		t.Errorf("FICHOffset = %d, want %d", FICHOffset, FSWDibits)
+	}
+	if PayloadOffset != FSWDibits+FICHDibits {
+		t.Errorf("PayloadOffset = %d, want %d", PayloadOffset, FSWDibits+FICHDibits)
+	}
+	if PayloadOffset+PayloadDibits != FrameDibits {
+		t.Errorf("payload end = %d, want frame end %d",
+			PayloadOffset+PayloadDibits, FrameDibits)
+	}
+}
+
+func TestFrameDurationMatches4800Baud(t *testing.T) {
+	// 4800 sym/s × 0.1 s = 480 symbols. The FrameDurationMs constant
+	// should match what the symbol-rate / frame-length math implies.
+	const symbolRateHz = 4800
+	wantMs := FrameDibits * 1000 / symbolRateHz
+	if FrameDurationMs != wantMs {
+		t.Errorf("FrameDurationMs = %d, want %d at 4800 sym/s", FrameDurationMs, wantMs)
+	}
+}

--- a/internal/radio/ysf/sync.go
+++ b/internal/radio/ysf/sync.go
@@ -1,0 +1,100 @@
+// Package ysf decodes the wire format of Yaesu System Fusion, the
+// amateur-radio digital mode. YSF runs 4800-baud 4-level C4FM (the
+// same modulation P25 Phase 1 and NXDN-9600 use); each 100 ms frame
+// is 480 symbols / dibits / 960 bits, structured as:
+//
+//	dibits[0..19]    FSW (Frame Sync Word, 40 bits)
+//	dibits[20..119]  FICH (Frame Information Channel, Trellis-encoded)
+//	dibits[120..479] DCH (voice / data payload)
+//
+// This pass ships the sync detector + frame layout + a per-frequency
+// state machine that publishes cc.locked when the FSW correlates.
+// Full FICH decode (½-rate convolutional Viterbi + Yaesu-specific bit
+// packing) is a self-contained follow-up — landing the sync layer is
+// the first half of the same scaffolding NXDN / P25 Phase 1 use, and
+// gives the orchestration layer something to lock onto for ham
+// repeaters that operators want to see in the active-systems UI.
+package ysf
+
+// FSW is the 40-bit Frame Sync Word that opens every YSF frame. The
+// pattern is fixed by the Yaesu specification and matches what every
+// open-source decoder (DSDcc, MMDVMHost, OP25) uses on-air.
+const FSWBits uint64 = 0xD471C9634D
+
+// FSWDibits is the length of the FSW measured in dibits (20 dibits =
+// 40 bits = 5 bytes).
+const FSWDibits = 20
+
+// FSWPattern is the 20-dibit decomposition of FSWBits, MSB-first. The
+// sync detector compares dibit values directly against this slice.
+var FSWPattern = bitsToDibits(FSWBits, FSWDibits)
+
+func bitsToDibits(bits uint64, n int) []uint8 {
+	out := make([]uint8, n)
+	for i := 0; i < n; i++ {
+		shift := uint(2 * (n - 1 - i))
+		out[i] = uint8((bits >> shift) & 0x3)
+	}
+	return out
+}
+
+// SyncDetector slides a window over an incoming dibit stream and
+// emits the absolute index where the YSF FSW matches within the
+// configured tolerance. Mirrors the NXDN / P25 Phase 1 detectors;
+// callers should pre-map their slicer output to dibit values.
+type SyncDetector struct {
+	pattern   []uint8
+	tolerance int
+	hist      []uint8
+	primed    int
+	pos       int
+}
+
+// NewSyncDetector returns a detector keyed on the standard YSF FSW
+// pattern with the given max-mismatch tolerance. tolerance < 0 is
+// clamped to 1 (matches the NXDN detector default).
+func NewSyncDetector(tolerance int) *SyncDetector {
+	if tolerance < 0 {
+		tolerance = 1
+	}
+	return &SyncDetector{
+		pattern:   FSWPattern,
+		tolerance: tolerance,
+		hist:      make([]uint8, FSWDibits),
+	}
+}
+
+// Process scans src and appends the absolute dibit indices where the
+// FSW ends to dst. baseIndex is the absolute dibit index of src[0].
+// Returns the new baseIndex.
+func (s *SyncDetector) Process(dst []int, src []uint8, baseIndex int) ([]int, int) {
+	for i, d := range src {
+		s.hist[s.pos] = d
+		s.pos = (s.pos + 1) % FSWDibits
+		// Compare on every iteration where the history holds at
+		// least FSWDibits samples — including the one that just
+		// filled the buffer for the first time, so an FSW that
+		// sits at the very start of src still triggers a hit.
+		if s.primed < FSWDibits {
+			s.primed++
+		}
+		if s.primed < FSWDibits {
+			continue
+		}
+		errs := 0
+		idx := s.pos
+		for k := 0; k < FSWDibits; k++ {
+			if s.hist[idx] != s.pattern[k] {
+				errs++
+				if errs > s.tolerance {
+					break
+				}
+			}
+			idx = (idx + 1) % FSWDibits
+		}
+		if errs <= s.tolerance {
+			dst = append(dst, baseIndex+i)
+		}
+	}
+	return dst, baseIndex + len(src)
+}

--- a/internal/radio/ysf/sync_test.go
+++ b/internal/radio/ysf/sync_test.go
@@ -1,0 +1,66 @@
+package ysf
+
+import "testing"
+
+func TestFSWPatternRoundTrips(t *testing.T) {
+	if len(FSWPattern) != FSWDibits {
+		t.Fatalf("FSWPattern len = %d, want %d", len(FSWPattern), FSWDibits)
+	}
+	// Reassemble the pattern bits and compare against FSWBits.
+	var got uint64
+	for _, d := range FSWPattern {
+		got = (got << 2) | uint64(d&0x3)
+	}
+	if got != FSWBits {
+		t.Errorf("FSWPattern reassemble = %010X, want %010X", got, FSWBits)
+	}
+}
+
+func TestSyncDetectorMatchesCleanFSW(t *testing.T) {
+	det := NewSyncDetector(0)
+	stream := make([]uint8, 80)
+	copy(stream[15:], FSWPattern)
+	hits, _ := det.Process(nil, stream, 0)
+	if len(hits) != 1 {
+		t.Fatalf("hits = %v, want exactly 1", hits)
+	}
+	wantIdx := 15 + FSWDibits - 1
+	if hits[0] != wantIdx {
+		t.Errorf("hit index = %d, want %d (FSW ends here)", hits[0], wantIdx)
+	}
+}
+
+func TestSyncDetectorTolerance(t *testing.T) {
+	stream := make([]uint8, 80)
+	copy(stream[5:], FSWPattern)
+	// Flip 2 dibits inside the FSW window.
+	stream[7] ^= 1
+	stream[15] ^= 1
+
+	if hits, _ := NewSyncDetector(2).Process(nil, stream, 0); len(hits) != 1 {
+		t.Errorf("tolerance=2: hits = %v, want 1", hits)
+	}
+	if hits, _ := NewSyncDetector(0).Process(nil, stream, 0); len(hits) != 0 {
+		t.Errorf("tolerance=0: hits = %v, want 0 (corrupt FSW)", hits)
+	}
+}
+
+func TestSyncDetectorIgnoresUnrelatedStream(t *testing.T) {
+	det := NewSyncDetector(1)
+	// Pseudo-random dibits unlikely to match the FSW within tolerance.
+	stream := make([]uint8, 1024)
+	for i := range stream {
+		stream[i] = uint8(i*7) & 0x3
+	}
+	hits, _ := det.Process(nil, stream, 0)
+	if len(hits) != 0 {
+		t.Errorf("unrelated stream produced %d false hits: %v", len(hits), hits)
+	}
+}
+
+func TestSyncDetectorNegativeToleranceClampsToOne(t *testing.T) {
+	det := NewSyncDetector(-3)
+	if det.tolerance != 1 {
+		t.Errorf("negative tolerance: got %d, want 1 (clamp)", det.tolerance)
+	}
+}


### PR DESCRIPTION
## Summary

First half of the YSF (Yaesu System Fusion) roadmap entry. This PR
lands the sync layer + frame geometry + a per-frequency state machine
that publishes `cc.locked` when the 40-bit Frame Sync Word correlates
on a freshly-tuned device. **FICH (Frame Information Channel) decode
is a separate follow-up** — the Trellis convolutional code + Yaesu-
specific bit packing want their own self-contained pass, similar to
how P25 Phase 1 trellis + interleaver landed in PR #34 before the
band-plan-aware grant emission landed in PR #37.

### What changed

- **`internal/radio/ysf/sync.go`** —
  `FSWBits = 0xD471C9634D` (40 bits = 20 dibits, the canonical Yaesu
  pattern open-source decoders use). `SyncDetector` mirrors NXDN's
  circular-buffer correlator with a configurable mismatch tolerance,
  and **fixes an off-by-one in the prime-and-skip logic** (NXDN's
  tests don't trigger it because they always put the FSW at offset
  > 0; the new ControlChannel test caught it by placing the FSW at
  offset 0). Tolerance < 0 clamps to 1.
- **`internal/radio/ysf/frame.go`** — layout constants. 480 dibits
  per frame at 4800 baud C4FM (= 100 ms), with on-air structure
  `FSW(20) + FICH(100) + DCH(360)`. Offsets are exposed for the
  future FICH path.
- **`internal/radio/ysf/control.go`** — `ControlChannel.Process`
  runs the detector over a dibit window and publishes `cc.locked`
  the first time the FSW matches; subsequent hits are suppressed
  until `MarkLost` runs. `LockState` satisfies
  `trunking.LockedPayload` via `LockedFrequencyHz / LockedNAC`
  (returns 0 — YSF has no NAC) so the cc-hunter can consume YSF
  locks without importing the package.
- **`README.md`** — protocols table gains a YSF row that's explicit
  about what's shipped vs. pending; the roadmap entry rewords from
  "build the YSF package" to "land FICH decode + grant emission";
  the lede sentence calls out D-STAR + YSF together as the amateur
  modes covered.

### Tests

- FSW pattern reassembles to the canonical `0xD471C9634D` bit value.
- Clean FSW at offset 15 → exactly one hit at the right index.
- Tolerance honored: 2 dibit flips inside the FSW match at
  `tolerance=2`, miss at `tolerance=0`.
- Pseudo-random unrelated stream produces zero false hits.
- Negative tolerance clamps to 1.
- Frame layout sums to 480 dibits and offsets are contiguous.
- Frame duration matches what 480 dibits / 4800 baud implies.
- `ControlChannel` publishes `cc.locked` when FSW lands at offset 0
  (regression guard for the prime-and-skip off-by-one).
- Two FSW hits in the same stream produce only one `cc.locked`
  event (no relock until `MarkLost`).
- `MarkLost` publishes `cc.lost`; `MarkLost` on a never-locked
  channel is a no-op.
- `LockState` satisfies `trunking.LockedPayload` at compile time +
  reports the right frequency / a zero NAC.
- All existing radio + framing + composer tests stay green; full
  `go test ./...` passes.

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./internal/radio/ysf/...` green
- [x] `go test ./...` (full suite, all packages green)
- [ ] Manual: tune an SDR to a YSF repeater and confirm `cc.locked`
      events with the right frequency arrive when traffic starts.
- [ ] Follow-up PR: FICH Trellis decode + Frame Type / Call Sign
      Mode / Frame Number parse → publish `protocol = "ysf"` grants
      on the bus.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PHnwos5vaxtoDiSi32maZz)_