### PR TITLE
YSF FICH parser: 32-bit Frame Information Channel + CRC-16 + CCITT init param

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ frontend over gRPC, HTTP/SSE, or WebSocket.
 | dPMR (Mode 3)     | FS1 / FS2 / FS3 24-dibit sync, 80-bit CSBK parser, MessageType enum (RegistrationRequest / Response, VoiceServiceAllocation, IndividualVoiceAllocation, DataServiceAllocation, ServiceRequest, StandingServiceStatus, Release, Idle), AsVoiceGrant + AsSiteBroadcast accessors, PMR446 default band-plan, control-channel state machine emitting `protocol = "dpmr"` grants |
 | TETRA (TMO)       | Normal + extended training-sequence sync, generic Layer-3 PDU parser (4-bit Discriminator + type + payload), CMCE D-CONNECT / D-TX-GRANTED / D-RELEASE accessors, MLE-SYSINFO accessor (MCC / MNC / Location Area), TETRA-380 / 410 / 800 carrier resolver, control-channel state machine emitting `protocol = "tetra"` grants |
 | D-STAR            | Frame Sync + Slow Data sync, 41-byte PCH header parser (FLAG1 + RPT2 / RPT1 / UR / MY1 / MY2 + CRC-CCITT), IsGroupCall / IsEmergency / IsData accessors, repeater state machine emitting `protocol = "dstar"` grants on group transmissions |
-| YSF (Yaesu System Fusion) | 4800-baud C4FM, 480-dibit / 100 ms frame layout (FSW / FICH / DCH offsets), 40-bit FSW correlator with mismatch tolerance, per-frequency state machine emitting `cc.locked` on sync detect (FICH parse + grant emission is a follow-up — Trellis decode lands separately) |
+| YSF (Yaesu System Fusion) | 4800-baud C4FM, 480-dibit / 100 ms frame layout (FSW / FICH / DCH offsets), 40-bit FSW correlator with mismatch tolerance, 32-bit Frame Information Channel parser (FrameType / CallType / Frame Number / Frame Total / DataType / VoIP / Squelch fields) with CRC-16 trailer, per-frequency state machine emitting `cc.locked` on sync detect (Trellis FEC + grant emission is a follow-up) |
 | Orchestration     | In-process pub/sub event bus, `System` model, JSON-on-disk last-known-CC cache, control-channel `Hunter` that retunes the SDR and parks on the first responsive frequency |
 | Trunking engine   | Cross-protocol `Grant` payload, Trunk-Recorder-format talkgroup DB (CSV + JSON), priority + preemption (emergency overrides, strict-higher), voice-device pool allocator, central state machine emitting `CallStart` / `CallEnd` events with a watchdog for silent calls |
 | Demod pipeline    | `internal/voice/composer` subscribes to `CallStart` events, opens the bound Voice device's IQ stream, runs an LPF → decimate → optional CMA equalizer → FM demod → optional 75/50µs de-emphasis → optional Kaiser audio LPF → optional audio AGC → optional polyphase L/M resample (or naive decimate fallback) → int16 PCM chain into the recorder, and pings `Engine.Touch` every second so the silent-call watchdog leaves the call alone |
@@ -77,11 +77,11 @@ to its own package and lands independently.
   factory that opens a connected DVSI USB chip. Same plug-in shape
   as `internal/voice/mbelib`; the daemon picks the factory by name
   from `voice.DefaultRegistry`.
-- **YSF FICH decode + grant emission.** The `internal/radio/ysf/`
-  package ships sync detection + frame layout; the FICH (Frame
-  Information Channel) carries Trellis-encoded Frame Type / Call
-  Sign Mode / Frame Number bits that the next pass will decode +
-  republish as `protocol = "ysf"` grants on the bus.
+- **YSF Trellis decode + grant emission.** Sync, frame layout, and
+  the post-FEC FICH bit-level parser are in; what's left is the
+  K=5 ½-rate Viterbi Trellis decoder over the on-air 100-bit FICH
+  region and the control-channel wiring that publishes
+  `protocol = "ysf"` grants on the bus when a Header FICH lands.
 - **Higher-fidelity FM voice chain.** ✅ Shipped: opt-in 75/50µs
   de-emphasis (`composer.DeEmphasisConfig`), Kaiser-windowed audio
   LPF (`composer.AudioLPFConfig`), audio AGC

--- a/internal/radio/framing/crc.go
+++ b/internal/radio/framing/crc.go
@@ -5,8 +5,16 @@ package framing
 // This is the variant used by the P25 TSBK trailer (the trailer stores the
 // bitwise complement; callers handle that at protocol level).
 func CRCCCITT(msg []byte) uint16 {
+	return CRCCCITTWithInit(msg, 0xFFFF)
+}
+
+// CRCCCITTWithInit is the same CRC-CCITT (poly 0x1021, no reflection,
+// no final XOR) but with a caller-supplied initial value. Pass
+// 0xFFFF for the CCITT/FALSE variant the P25 TSBK trailer uses; pass
+// 0x0000 for the XMODEM / YSF FICH variant.
+func CRCCCITTWithInit(msg []byte, init uint16) uint16 {
 	const poly uint16 = 0x1021
-	crc := uint16(0xFFFF)
+	crc := init
 	for _, b := range msg {
 		crc ^= uint16(b) << 8
 		for i := 0; i < 8; i++ {

--- a/internal/radio/ysf/fich.go
+++ b/internal/radio/ysf/fich.go
@@ -1,0 +1,207 @@
+package ysf
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+
+	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+)
+
+// FICH carries the structured fields extracted from a Frame
+// Information Channel block. The Frame Sync Word identifies *that* a
+// YSF transmission is on-air; the FICH identifies *what kind* — call
+// type (group / radio ID), data type (voice / data variants), and the
+// frame's position inside its block + transmission sequence.
+//
+// On-air the FICH is 100 channel bits: 32 bits of information + 16
+// bits CRC, encoded with a K=5 ½-rate convolutional code (Trellis)
+// and interleaved across the FICH region of the frame. This package
+// ships the bit-level Parse / Assemble against the post-Trellis
+// 48-bit info+CRC pair; the Trellis decoder + control-channel
+// integration lands in a follow-up so the spec interpretation can
+// be reviewed independently of the FEC math.
+//
+// Bit layout (32 info bits, MSB-first, packed into 4 octets) per the
+// publicly documented Yaesu System Fusion specification — same shape
+// open-source decoders (DSDcc, MMDVMHost) use:
+//
+//	octet 0 bits 7..6  FT   (Frame Type)
+//	octet 0 bits 5..4  CT   (Call Type / Call Sign Mode)
+//	octet 0 bits 3..2  BN   (Block Number)
+//	octet 0 bits 1..0  BT   (Block Total)
+//	octet 1 bits 7..5  FN   (Frame Number)
+//	octet 1 bits 4..2  FT2  (Frame Total inside the block)
+//	octet 1 bits 1..0  DT   (Data Type)
+//	octet 2 bit  7     VoIP (1 = transmission carries WIRES-X / VoIP)
+//	octet 2 bits 6..5  DT2  (Data Type 2 / Mode-2 sub-field)
+//	octet 2 bit  4     SQM  (Squelch Mode: 0 = open, 1 = closed)
+//	octet 2 bits 3..0  SQ   (Squelch Code, high 4 bits)
+//	octet 3 bits 7..5  SQ   (Squelch Code, low 3 bits — 7 bits total)
+//	octet 3 bits 4..3  DEV  (Device / Reserved)
+//	octet 3 bits 2..0  ----  unused / reserved
+//
+// Octets 4..5 carry the CRC-16 trailer over octets 0..3, computed
+// with poly 0x1021 and initial value 0x0000 (XMODEM / CCITT-true).
+type FICH struct {
+	FrameType    FrameType
+	CallType     CallType
+	BlockNumber  uint8 // 2-bit BN
+	BlockTotal   uint8 // 2-bit BT
+	FrameNumber  uint8 // 3-bit FN within the current block
+	FrameTotal   uint8 // 3-bit FT total frames in the block
+	DataType     DataType
+	VoIP         bool
+	DataType2    uint8 // 2-bit DT2 / Mode-2 sub-field
+	SquelchMode  bool  // false = open carrier, true = code-squelch active
+	SquelchCode  uint8 // 7-bit SQ
+	Device       uint8 // 2-bit DEV / reserved
+}
+
+// FrameType is the 2-bit FT field — what kind of frame this is in
+// the transmission's lifecycle. (Confusingly the spec also uses "FT"
+// for "Frame Total"; this package exposes Frame Total as
+// FrameTotal to keep the two distinct.)
+type FrameType uint8
+
+const (
+	FrameTypeHeader     FrameType = 0x0 // start of transmission
+	FrameTypeComms      FrameType = 0x1 // mid-transmission voice / data
+	FrameTypeTerminator FrameType = 0x2 // end of transmission
+	FrameTypeTest       FrameType = 0x3 // test / loopback
+)
+
+func (f FrameType) String() string {
+	switch f {
+	case FrameTypeHeader:
+		return "Header"
+	case FrameTypeComms:
+		return "Communications"
+	case FrameTypeTerminator:
+		return "Terminator"
+	case FrameTypeTest:
+		return "Test"
+	default:
+		return fmt.Sprintf("FrameType(%X)", uint8(f))
+	}
+}
+
+// CallType is the 2-bit CT / Call Sign Mode field.
+type CallType uint8
+
+const (
+	CallTypeGroup    CallType = 0x0 // group call
+	CallTypeRadioID  CallType = 0x1 // private (radio-ID-addressed) call
+	CallTypeReserved CallType = 0x2
+	CallTypeReservedB CallType = 0x3
+)
+
+func (c CallType) String() string {
+	switch c {
+	case CallTypeGroup:
+		return "Group"
+	case CallTypeRadioID:
+		return "RadioID"
+	case CallTypeReserved, CallTypeReservedB:
+		return fmt.Sprintf("Reserved(%X)", uint8(c))
+	default:
+		return fmt.Sprintf("CallType(%X)", uint8(c))
+	}
+}
+
+// DataType is the 2-bit DT field — which mode the transmission's
+// payload is in. The "V/D mode 1" variants carry voice + data
+// multiplexed in the DCH region; the full-rate variants carry only
+// one of the two.
+type DataType uint8
+
+const (
+	DataTypeVDMode1     DataType = 0x0 // V/D mode 1 (½-rate voice + data)
+	DataTypeDataFR      DataType = 0x1 // Data Full Rate
+	DataTypeVDMode2     DataType = 0x2 // V/D mode 2
+	DataTypeVoiceFR     DataType = 0x3 // Voice Full Rate
+)
+
+func (d DataType) String() string {
+	switch d {
+	case DataTypeVDMode1:
+		return "VDMode1"
+	case DataTypeDataFR:
+		return "DataFullRate"
+	case DataTypeVDMode2:
+		return "VDMode2"
+	case DataTypeVoiceFR:
+		return "VoiceFullRate"
+	default:
+		return fmt.Sprintf("DataType(%X)", uint8(d))
+	}
+}
+
+// ErrFICHLength is returned by ParseFICH when the supplied buffer is
+// not exactly 6 octets (4 octets info + 2 octets CRC).
+var ErrFICHLength = errors.New("ysf: FICH info+CRC must be 6 octets")
+
+// CRCError is returned by ParseFICH when the trailer CRC doesn't
+// match the locally-computed CRC over the four info octets. The
+// partially-parsed FICH is still returned so callers can log
+// diagnostics.
+var CRCError = errors.New("ysf: FICH CRC mismatch")
+
+// ParseFICH consumes 6 octets (32 info bits + 16-bit CRC trailer)
+// and returns a parsed FICH. The 16-bit trailer is CRC-CCITT over
+// the leading 4 octets with initial value 0x0000.
+func ParseFICH(b []byte) (FICH, error) {
+	if len(b) != 6 {
+		return FICH{}, fmt.Errorf("%w, got %d", ErrFICHLength, len(b))
+	}
+	f := FICH{
+		FrameType:   FrameType(b[0] >> 6 & 0x3),
+		CallType:    CallType(b[0] >> 4 & 0x3),
+		BlockNumber: b[0] >> 2 & 0x3,
+		BlockTotal:  b[0] & 0x3,
+		FrameNumber: b[1] >> 5 & 0x7,
+		FrameTotal:  b[1] >> 2 & 0x7,
+		DataType:    DataType(b[1] & 0x3),
+		VoIP:        b[2]&0x80 != 0,
+		DataType2:   b[2] >> 5 & 0x3,
+		SquelchMode: b[2]&0x10 != 0,
+		// SQ (7 bits): bits 3..0 of octet 2 are the high 4 bits;
+		// bits 7..5 of octet 3 are the low 3 bits.
+		SquelchCode: (b[2]&0x0F)<<3 | b[3]>>5&0x7,
+		Device:      b[3] >> 3 & 0x3,
+	}
+	wantCRC := framing.CRCCCITTWithInit(b[:4], 0x0000)
+	gotCRC := binary.BigEndian.Uint16(b[4:6])
+	if wantCRC != gotCRC {
+		return f, CRCError
+	}
+	return f, nil
+}
+
+// AssembleFICH packs an FICH into the on-air 6-octet info+CRC layout.
+// Out-of-range fields are silently truncated to their bit widths so
+// the encoder doesn't panic on hand-built test vectors that exceed
+// the spec.
+func AssembleFICH(f FICH) []byte {
+	out := make([]byte, 6)
+	out[0] = byte(f.FrameType&0x3)<<6 |
+		byte(f.CallType&0x3)<<4 |
+		(f.BlockNumber&0x3)<<2 |
+		(f.BlockTotal & 0x3)
+	out[1] = (f.FrameNumber&0x7)<<5 |
+		(f.FrameTotal&0x7)<<2 |
+		byte(f.DataType&0x3)
+	sqHi := (f.SquelchCode >> 3) & 0x0F
+	sqLo := f.SquelchCode & 0x07
+	out[2] = sqHi
+	if f.VoIP {
+		out[2] |= 0x80
+	}
+	out[2] |= (f.DataType2 & 0x3) << 5
+	if f.SquelchMode {
+		out[2] |= 0x10
+	}
+	out[3] = sqLo<<5 | (f.Device&0x3)<<3
+	binary.BigEndian.PutUint16(out[4:6], framing.CRCCCITTWithInit(out[:4], 0x0000))
+	return out
+}

--- a/internal/radio/ysf/fich_test.go
+++ b/internal/radio/ysf/fich_test.go
@@ -1,0 +1,128 @@
+package ysf
+
+import "testing"
+
+func TestFICHRoundTripCoversAllFrameTypes(t *testing.T) {
+	cases := []FrameType{
+		FrameTypeHeader, FrameTypeComms, FrameTypeTerminator, FrameTypeTest,
+	}
+	for _, ft := range cases {
+		t.Run(ft.String(), func(t *testing.T) {
+			in := FICH{
+				FrameType:   ft,
+				CallType:    CallTypeGroup,
+				BlockNumber: 1,
+				BlockTotal:  3,
+				FrameNumber: 2,
+				FrameTotal:  5,
+				DataType:    DataTypeVDMode2,
+				VoIP:        false,
+				DataType2:   0,
+				SquelchMode: false,
+				SquelchCode: 0,
+				Device:      0,
+			}
+			out, err := ParseFICH(AssembleFICH(in))
+			if err != nil {
+				t.Fatalf("ParseFICH: %v", err)
+			}
+			if out != in {
+				t.Errorf("round-trip mismatch:\n got %+v\nwant %+v", out, in)
+			}
+		})
+	}
+}
+
+func TestFICHRoundTripExercisesAllFields(t *testing.T) {
+	// Every nontrivial field set to a different non-default value so a
+	// bit-packing typo will surface immediately.
+	in := FICH{
+		FrameType:   FrameTypeComms,
+		CallType:    CallTypeRadioID,
+		BlockNumber: 0x2,
+		BlockTotal:  0x3,
+		FrameNumber: 0x5,
+		FrameTotal:  0x7,
+		DataType:    DataTypeVoiceFR,
+		VoIP:        true,
+		DataType2:   0x2,
+		SquelchMode: true,
+		SquelchCode: 0x5A, // 7-bit value spanning octets 2/3
+		Device:      0x2,
+	}
+	out, err := ParseFICH(AssembleFICH(in))
+	if err != nil {
+		t.Fatalf("ParseFICH: %v", err)
+	}
+	if out != in {
+		t.Errorf("round-trip mismatch:\n got %+v\nwant %+v", out, in)
+	}
+}
+
+func TestFICHDetectsCRCError(t *testing.T) {
+	in := FICH{FrameType: FrameTypeHeader, CallType: CallTypeGroup}
+	b := AssembleFICH(in)
+	b[2] ^= 0x40 // flip a bit inside the info section
+	if _, err := ParseFICH(b); err != CRCError {
+		t.Errorf("err = %v, want CRCError", err)
+	}
+}
+
+func TestFICHRejectsWrongLength(t *testing.T) {
+	if _, err := ParseFICH(make([]byte, 5)); err == nil {
+		t.Error("ParseFICH accepted 5-byte input")
+	}
+	if _, err := ParseFICH(make([]byte, 7)); err == nil {
+		t.Error("ParseFICH accepted 7-byte input")
+	}
+}
+
+func TestFrameTypeStringCoverage(t *testing.T) {
+	cases := map[FrameType]string{
+		FrameTypeHeader:     "Header",
+		FrameTypeComms:      "Communications",
+		FrameTypeTerminator: "Terminator",
+		FrameTypeTest:       "Test",
+	}
+	for ft, want := range cases {
+		if got := ft.String(); got != want {
+			t.Errorf("%X.String() = %q, want %q", uint8(ft), got, want)
+		}
+	}
+}
+
+func TestCallTypeStringCoverage(t *testing.T) {
+	if got := CallTypeGroup.String(); got != "Group" {
+		t.Errorf("Group string = %q", got)
+	}
+	if got := CallTypeRadioID.String(); got != "RadioID" {
+		t.Errorf("RadioID string = %q", got)
+	}
+	if got := CallTypeReserved.String(); got != "Reserved(2)" {
+		t.Errorf("Reserved(2) string = %q", got)
+	}
+}
+
+func TestDataTypeStringCoverage(t *testing.T) {
+	cases := map[DataType]string{
+		DataTypeVDMode1: "VDMode1",
+		DataTypeDataFR:  "DataFullRate",
+		DataTypeVDMode2: "VDMode2",
+		DataTypeVoiceFR: "VoiceFullRate",
+	}
+	for dt, want := range cases {
+		if got := dt.String(); got != want {
+			t.Errorf("%X.String() = %q, want %q", uint8(dt), got, want)
+		}
+	}
+}
+
+func TestFICHCRCUsesXMODEMInit(t *testing.T) {
+	// All-zero info bytes should produce CRC = 0 with init=0x0000
+	// (regression guard against accidentally using the CCITT/FALSE
+	// 0xFFFF init shared with the rest of the codebase).
+	out := AssembleFICH(FICH{})
+	if out[4] != 0 || out[5] != 0 {
+		t.Errorf("all-zero info → CRC = %02X%02X, want 0000", out[4], out[5])
+	}
+}


### PR DESCRIPTION
## Summary

Second half of the YSF roadmap, building on PR #45's sync layer. The
FICH carries the structured fields that turn "there's a transmission
here" into "this is a Header burst opening a Group call from radio
ID X to talkgroup Y on V/D mode 2". This pass adds the bit-level
parser + CRC validator. **Trellis decoding** of the on-air 100
channel bits down to the 48-bit info+CRC pair and **grant emission**
from Header FICHs both stay as a separate, smaller follow-up — same
"parsers first, FEC second, control-channel wiring third" cadence
that landed P25 Phase 1 over PRs #4 / #34 / #37.

### What changed

- **`internal/radio/framing/crc.go`** — `CRCCCITT` (init=0xFFFF, the
  P25 TSBK variant) was hardcoded; generalize via
  `CRCCCITTWithInit` so YSF FICH can use the XMODEM / CCITT-true
  variant (init=0x0000) without duplicating the byte-by-byte loop.
  `CRCCCITT` is preserved as a thin shim — no caller change.
- **`internal/radio/ysf/fich.go`** — `FICH` struct exposes the
  publicly documented Yaesu FICH fields:
  - `FrameType` (Header / Comms / Terminator / Test)
  - `CallType` (Group / RadioID / 2 reserved)
  - `BlockNumber` / `BlockTotal`
  - `FrameNumber` / `FrameTotal`
  - `DataType` (V/D Mode 1 / Data FR / V/D Mode 2 / Voice FR)
  - `VoIP`
  - `DataType2`
  - `SquelchMode`
  - `SquelchCode` (7-bit, spans octets 2/3)
  - `Device`
  `ParseFICH` consumes 6 octets (4 info + 2 CRC) and returns
  `CRCError` when the trailer doesn't match. `AssembleFICH`
  produces the same layout for tests + future encoder paths. Layout
  matches what MMDVMHost / DSDcc use; the struct doc comment
  documents each bit position so future spec calibration is a
  one-edit change.
- **`README.md`** — YSF row in the protocols table grows to
  mention the FICH parser + per-field list; the roadmap entry
  tightens from "build the FICH parser" to "Trellis FEC + grant
  emission".

### Tests

- Round-trip per `FrameType` (Header / Comms / Terminator / Test)
  with otherwise-default fields.
- Round-trip with every nontrivial field set to a distinct
  non-default value (catches bit-packing typos that survive the
  per-FrameType variant).
- CRC mismatch on a flipped info bit returns `CRCError`.
- Length validation: 5- and 7-byte inputs rejected.
- Enum `String` coverage for `FrameType` / `CallType` (including
  the reserved values) / `DataType`.
- All-zero info → all-zero CRC (regression guard against
  accidentally using the CCITT/FALSE `0xFFFF` init that the rest
  of the codebase shares).
- All existing radio + framing + composer tests stay green; full
  `go test ./...` passes.

## Notes on parameters

The FICH bit layout matches what MMDVMHost / DSDcc / OP25 use for YSF.
Per-bit positions for VoIP, DT2, SquelchMode, SquelchCode and Device
are the most-cited interpretation — if a real off-air capture turns
up disagreements, the per-field bit positions in `fich.go` are a
one-edit calibration.

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./internal/radio/ysf/...` green
- [x] `go test ./internal/radio/framing/...` green
- [x] `go test ./...` (full suite, all packages green)
- [ ] Follow-up PR: K=5 ½-rate Viterbi (reuse the NXDN SACCH
      decoder by promoting it to `internal/radio/framing` and
      parameterizing on the polynomial pair) → wire the YSF
      ControlChannel to decode FICH and publish
      `protocol = "ysf"` grants on Header bursts.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PHnwos5vaxtoDiSi32maZz)_