### PR TITLE
Pure-Go IMBE: package skeleton + Vocoder interface integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,11 @@ to its own package and lands independently.
   default builds without a CGO dependency. Core US patents are
   expired; the algorithm is implementable from TIA-102.BABA. The
   `mbelib` build-tagged path already covers IMBE for operators with
-  libmbe installed.
+  libmbe installed. Status: the `internal/voice/imbe` skeleton is
+  in tree (registered as the `imbe-go` vocoder name, currently
+  emits silence per frame); follow-up PRs land the channel-coding
+  inverse, parameter unpacking, and speech synthesis layers in
+  that order so each step ships testable progress.
 - **DVSI USB-3000 / AMBE-3003 hardware backend.** A `Vocoder`
   factory that opens a connected DVSI USB chip. Same plug-in shape
   as `internal/voice/mbelib`; the daemon picks the factory by name

--- a/cmd/gophertrunk/main.go
+++ b/cmd/gophertrunk/main.go
@@ -14,6 +14,13 @@ import (
 	_ "github.com/MattCheramie/GopherTrunk/internal/sdr/rtlsdr"
 	"github.com/MattCheramie/GopherTrunk/internal/version"
 
+	// Blank import: pulls in the pure-Go IMBE skeleton + future
+	// channel-coding / parameter-decode / synthesis layers so the
+	// daemon registers the "imbe-go" vocoder name regardless of
+	// build tags. The decoder currently emits silence; later PRs
+	// turn on real audio without changing this import.
+	_ "github.com/MattCheramie/GopherTrunk/internal/voice/imbe"
+
 	// Blank import: under default builds this pulls in the stub
 	// (no init effect); under `make build TAGS=mbelib` it pulls in
 	// the CGO wrapper that registers the `imbe` and `ambe2`

--- a/internal/voice/imbe/decoder.go
+++ b/internal/voice/imbe/decoder.go
@@ -1,0 +1,92 @@
+package imbe
+
+import (
+	"fmt"
+
+	"github.com/MattCheramie/GopherTrunk/internal/voice"
+)
+
+// Frame parameters per TIA-102.BABA. Every IMBE 4400 frame carries
+// 88 information bits over 20 ms of audio at 8 kHz mono.
+const (
+	// InfoBits is the per-frame information-bit count after channel
+	// FEC has been applied + verified.
+	InfoBits = 88
+
+	// FrameBytes is InfoBits packed MSB-first into octets, rounded up.
+	// Matches the mbelib wrapper's frame length so callers can pass
+	// the same byte slice to either backend.
+	FrameBytes = 11
+
+	// SamplesPerFrame is the PCM count one Decode call produces.
+	// IMBE is fixed at 8 kHz × 20 ms = 160 samples.
+	SamplesPerFrame = 160
+
+	// PCMSampleRate is the recorder's expected output rate.
+	PCMSampleRate = 8000
+
+	// FrameDurationMs documents the 20 ms cadence.
+	FrameDurationMs = 20
+
+	// VocoderName is the registry key the daemon resolves at startup.
+	// Distinct from mbelib's "imbe" so both backends can be linked
+	// into the same binary; the daemon picks one in config.
+	VocoderName = "imbe-go"
+)
+
+// Decoder is the in-progress pure-Go IMBE decoder. The current
+// implementation accepts validly-sized frames and returns silence —
+// the channel-coding inverse, parameter unpacking, and speech
+// synthesis land in follow-up PRs (see doc.go for the sequence).
+// Wiring the daemon's recorder + composer to it now means the
+// audio path lights up for free as each follow-up merges.
+type Decoder struct {
+	// Reserved for future per-frame state (last fundamental
+	// frequency, last spectral amplitudes for frame-repeat on
+	// bad-frame indicator, voicing memory). Holding the field now
+	// keeps later PRs contained to logic changes.
+	silenceBuf [SamplesPerFrame]int16
+}
+
+// New returns a fresh Decoder. Each call gets its own instance so
+// the future per-call state stays isolated.
+func New() *Decoder {
+	return &Decoder{}
+}
+
+// Name returns the registry key. Matches VocoderName.
+func (d *Decoder) Name() string { return VocoderName }
+
+// FrameSize returns the per-frame input byte count (11 bytes / 88
+// bits, packed MSB-first).
+func (d *Decoder) FrameSize() int { return FrameBytes }
+
+// Decode validates the frame size and returns a frame's worth of
+// silence. When the synthesis layer lands, this stub becomes a
+// drop-in: callers see audio appear without changing how they
+// invoke the decoder.
+func (d *Decoder) Decode(frame []byte) ([]int16, error) {
+	if len(frame) != FrameBytes {
+		return nil, fmt.Errorf("imbe: frame must be %d bytes (88 bits), got %d", FrameBytes, len(frame))
+	}
+	out := make([]int16, SamplesPerFrame)
+	copy(out, d.silenceBuf[:])
+	return out, nil
+}
+
+// Reset clears any per-call state. No-op until the synthesis layer
+// adds frame-to-frame memory.
+func (d *Decoder) Reset() {}
+
+// Close releases any resources held by the decoder. The pure-Go
+// implementation holds none, so this is always a no-op.
+func (d *Decoder) Close() error { return nil }
+
+// Compile-time check that Decoder satisfies voice.Vocoder.
+var _ voice.Vocoder = (*Decoder)(nil)
+
+func init() {
+	voice.DefaultRegistry.Register(VocoderName, func() (voice.Vocoder, error) {
+		return New(), nil
+	})
+}

--- a/internal/voice/imbe/decoder_test.go
+++ b/internal/voice/imbe/decoder_test.go
@@ -1,0 +1,99 @@
+package imbe
+
+import (
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/voice"
+)
+
+func TestDecoderRegistered(t *testing.T) {
+	v, err := voice.DefaultRegistry.New(VocoderName)
+	if err != nil {
+		t.Fatalf("DefaultRegistry.New(%q): %v", VocoderName, err)
+	}
+	defer v.Close()
+	if v.Name() != VocoderName {
+		t.Errorf("Name() = %q, want %q", v.Name(), VocoderName)
+	}
+}
+
+func TestDecoderName(t *testing.T) {
+	d := New()
+	if d.Name() != "imbe-go" {
+		t.Errorf("Name() = %q, want %q", d.Name(), "imbe-go")
+	}
+}
+
+func TestDecoderFrameSize(t *testing.T) {
+	d := New()
+	if d.FrameSize() != 11 {
+		t.Errorf("FrameSize() = %d, want 11", d.FrameSize())
+	}
+}
+
+func TestDecodeReturnsSilenceForValidFrame(t *testing.T) {
+	d := New()
+	frame := make([]byte, FrameBytes) // contents irrelevant — stub returns silence
+	out, err := d.Decode(frame)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if len(out) != SamplesPerFrame {
+		t.Errorf("len(out) = %d, want %d", len(out), SamplesPerFrame)
+	}
+	for i, s := range out {
+		if s != 0 {
+			t.Fatalf("sample[%d] = %d, want 0 (stub silence)", i, s)
+		}
+	}
+}
+
+func TestDecodeRejectsShortFrame(t *testing.T) {
+	d := New()
+	if _, err := d.Decode(make([]byte, FrameBytes-1)); err == nil {
+		t.Error("expected error for short frame")
+	}
+	if _, err := d.Decode(make([]byte, FrameBytes+1)); err == nil {
+		t.Error("expected error for long frame")
+	}
+}
+
+func TestResetAndCloseAreSafe(t *testing.T) {
+	d := New()
+	d.Reset()
+	if err := d.Close(); err != nil {
+		t.Errorf("Close() = %v, want nil", err)
+	}
+	// Re-using after Close should still work — pure-Go decoder holds
+	// no resources, and the Vocoder contract doesn't forbid it for
+	// stateless implementations.
+	if _, err := d.Decode(make([]byte, FrameBytes)); err != nil {
+		t.Errorf("Decode after Close: %v", err)
+	}
+}
+
+func TestRegistryReturnsFreshInstancePerCall(t *testing.T) {
+	a, err := voice.DefaultRegistry.New(VocoderName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer a.Close()
+	b, err := voice.DefaultRegistry.New(VocoderName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer b.Close()
+	if a == b {
+		t.Error("expected each Registry.New call to return a fresh instance")
+	}
+}
+
+func TestNameAppearsInRegistryListing(t *testing.T) {
+	names := voice.DefaultRegistry.Names()
+	for _, n := range names {
+		if n == VocoderName {
+			return
+		}
+	}
+	t.Errorf("registry names %v missing %q", names, VocoderName)
+}

--- a/internal/voice/imbe/doc.go
+++ b/internal/voice/imbe/doc.go
@@ -1,0 +1,38 @@
+// Package imbe is the in-progress pure-Go IMBE 4400 bps voice
+// decoder used by P25 Phase 1 LDU1 / LDU2 frames. The intent is to
+// remove the CGO dependency on libmbe for the most-common digital
+// voice scanner setup; the build-tagged internal/voice/mbelib path
+// continues to exist for operators who prefer the C reference
+// implementation or want AMBE+2 (P25 Phase 2 / DMR / NXDN).
+//
+// Roadmap (each item lands as its own self-contained PR so review
+// stays tractable):
+//
+//  1. Skeleton + Vocoder interface integration. ← THIS PR.
+//     Decoder satisfies voice.Vocoder, registers as "imbe-go" in
+//     voice.DefaultRegistry, and emits silence per frame so the
+//     full call pipeline can wire to it now and start receiving
+//     audio for free as the later pieces land.
+//
+//  2. Channel coding inverse. 144 transmitted channel bits → 88
+//     information bits via Golay(23,12) + Hamming(15,11) + the
+//     IMBE-specific bit interleaver + pseudo-random scrambler.
+//     framing/golay + framing/hamming are already in tree.
+//
+//  3. Parameter unpacking. 88 information bits → IMBE model
+//     parameters (b_0..b_7+ vectors): fundamental frequency,
+//     voiced/unvoiced flags, gain, PRBA + HOC spectral coefficients.
+//     Per TIA-102.BABA Section 5.
+//
+//  4. Speech synthesis. Voiced harmonic sum + unvoiced random
+//     excitation + spectral-amplitude shaping → 160 PCM samples /
+//     20 ms / 8 kHz mono per frame. Per TIA-102.BABA Section 6.
+//
+//  5. Quality polish: enhancement filter, frame-repeat on bad-frame
+//     indicator, gain smoothing across frames.
+//
+// Patent + licensing context lives in docs/vocoders.md. The core US
+// IMBE patents have expired; this implementation is built from the
+// publicly-available TIA-102.BABA specification, with structural
+// reference to the open-source mbelib.
+package imbe


### PR DESCRIPTION
## Summary

First PR in the multi-step pure-Go IMBE 4400 thread that's been on the
roadmap since the project's start. Establishing the package + Vocoder
integration first means the daemon, recorder, and composer all wire to
the new vocoder name immediately, and **audio appears for free as the
channel-coding / parameter-decode / synthesis layers land in
subsequent PRs**. None of the actual patent-encumbered IMBE algorithms
ship in this PR — `Decode` just returns silence so the surface area is
verifiably no-op until the implementation pieces follow.

### What changed

- **`internal/voice/imbe/doc.go`** — package overview that pins the
  multi-PR roadmap so future reviewers land in the right context.
  Five-step plan: skeleton (this PR) → channel coding (Golay +
  Hamming + scrambler + interleaver, all primitives already in
  `framing`) → parameter unpacking (b_n vectors per TIA-102.BABA §5)
  → speech synthesis (TIA-102.BABA §6) → quality polish (enhancement
  filter, frame-repeat on bad-frame indicator, gain smoothing).
- **`internal/voice/imbe/decoder.go`** — `Decoder` satisfies
  `voice.Vocoder` and registers as `"imbe-go"` in
  `voice.DefaultRegistry` at init time. Distinct name from mbelib's
  `"imbe"` so both backends can link into the same binary; daemon
  config picks one. `Decode` validates the 11-byte frame size and
  emits 160 zero samples (8 kHz × 20 ms — the IMBE/AMBE+2 cadence
  the recorder expects). `Reset` and `Close` are no-ops.
- **`internal/voice/imbe/decoder_test.go`** — registration
  round-trip through `DefaultRegistry`, `FrameSize` / `Name`
  pinning, valid-frame silence output, short / long frame
  rejection, `Reset`/`Close` safety, fresh-instance-per-Registry-
  call invariant, name visible in `Names()` listing.
- **`cmd/gophertrunk/main.go`** — blank import alongside the
  existing mbelib one so the registration runs at startup. Comment
  explains the pure-Go path is unconditional and the registration
  doesn't depend on build tags (unlike mbelib).
- **`README.md`** — pure-Go IMBE roadmap entry shifts from "pending"
  to "scaffolding in place; FEC + decode in follow-ups", with the
  multi-PR sequence sketched so reviewers know what's coming.

### What's next

After this skeleton:

1. **PR-N+1: Channel coding inverse.** 144 transmitted channel bits
   → 88 information bits via Golay(23,12) + Hamming(15,11) + the
   IMBE-specific bit interleaver + pseudo-random scrambler. The FEC
   primitives are already in `internal/radio/framing`.
2. **PR-N+2: Parameter unpacking.** 88 information bits → IMBE model
   parameters (b_0..b_7+ vectors): fundamental frequency,
   voiced/unvoiced flags, gain, PRBA + HOC spectral coefficients.
3. **PR-N+3: Speech synthesis.** Voiced harmonic sum + unvoiced
   random excitation + spectral-amplitude shaping → 160 PCM samples
   per frame.
4. **PR-N+4: Quality polish.** Enhancement filter, frame-repeat on
   bad-frame indicator, gain smoothing across frames.

Each one ships as its own self-contained PR so review stays
tractable.

### Tests

- `DefaultRegistry.New("imbe-go")` returns a fresh `Decoder` whose
  `Name()` matches.
- `FrameSize() == 11` bytes (88 bits).
- `Decode` on an 11-byte frame returns 160 zero samples.
- Short / long frames produce errors.
- `Reset` + `Close` are safe; `Decode` after `Close` still works
  (the pure-Go path holds no resources).
- `DefaultRegistry.New` called twice returns distinct instances
  (per-call state isolation contract).
- `"imbe-go"` appears in `DefaultRegistry.Names()`.
- All existing voice / composer / radio tests stay green; full
  `go test ./...` passes.

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./internal/voice/imbe/...` green
- [x] `go test ./internal/voice/... ./cmd/gophertrunk/...` green
- [x] `go test ./...` (full suite, all packages green)
- [ ] Manual: confirm the daemon boots with the new blank import
      and `imbe-go` shows up under whatever vocoder-listing
      surface exists.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PHnwos5vaxtoDiSi32maZz)_