### PR TITLE
Pure-Go IMBE step 2b: u_0-keyed PRBS scrambler

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,9 +75,10 @@ to its own package and lands independently.
   libmbe installed. Status: skeleton + Vocoder interface registered
   as `imbe-go`; per-vector channel-coding FEC inverse
   (Golay(23,12) for u_0..u_3 + Hamming(15,11) for u_4..u_6 + no-FEC
-  u_7 passthrough) is in (`internal/voice/imbe/channel.go`).
-  Currently emits silence per frame; follow-up PRs land the rest
-  of channel-coding
+  u_7 passthrough) is in (`internal/voice/imbe/channel.go`); the
+  TIA-102.BABA §7.4 u_0-keyed LCG pseudo-random scrambler is in
+  (`scrambler.go`). Currently emits silence per frame; follow-up
+  PRs land the rest of channel-coding
   inverse, parameter unpacking, and speech synthesis layers in
   that order so each step ships testable progress.
 - **DVSI USB-3000 / AMBE-3003 hardware backend.** A `Vocoder`

--- a/internal/voice/imbe/doc.go
+++ b/internal/voice/imbe/doc.go
@@ -14,19 +14,23 @@
 //     full call pipeline can wire to it now and start receiving
 //     audio for free as the later pieces land.
 //
-//  2. Channel coding inverse — per-vector FEC. ← THIS PR.
+//  2. Channel coding inverse — per-vector FEC.
 //     144 channel bits → 88 information bits via Golay(23,12,7)
 //     for u_0..u_3 + Hamming(15,11,3) for u_4..u_6 + a
-//     no-FEC u_7 passthrough. See channel.go. Operates on
-//     already-deinterleaved + already-descrambled channel bits;
-//     the deinterleaver permutation (TIA-102.BABA §7.5) and the
-//     u_0-keyed pseudo-random scrambler (§7.4) land in step 2b.
+//     no-FEC u_7 passthrough. See channel.go.
 //
-//  2b. Channel coding inverse — deinterleaver + scrambler. The
-//     144-bit interleaver permutation that scatters codeword bits
-//     across the frame, plus the PRBS keyed off u_0 that whitens
-//     u_1..u_6. Self-contained follow-up so the per-bit table can
-//     be reviewed independently of the FEC math above.
+//  2b. Channel coding inverse — pseudo-random scrambler. ← THIS PR.
+//     XORs a 114-bit u_0-keyed LCG PRBS (TIA-102.BABA §7.4) over
+//     the channel bits of u_1..u_6 to whiten the spectrum. u_0
+//     stays unscrambled because it carries the seed; u_7 stays
+//     unscrambled per the spec. See scrambler.go.
+//
+//     Note: there is no separate "bit interleaver" inside the IMBE
+//     codec — the §7.5 ordering is satisfied by how the upstream
+//     P25 LDU1 / LDU2 frame decoder extracts the 144 bits from a
+//     voice frame (a P25 phase1 layer concern, not an IMBE one).
+//     channel.go's per-vector layout already matches the order the
+//     upstream extractor will hand it.
 //
 //  3. Parameter unpacking. 88 information bits → IMBE model
 //     parameters (b_0..b_7+ vectors): fundamental frequency,

--- a/internal/voice/imbe/scrambler.go
+++ b/internal/voice/imbe/scrambler.go
@@ -1,0 +1,103 @@
+package imbe
+
+import "fmt"
+
+// IMBE 4400 pseudo-random scrambler (TIA-102.BABA §7.4 / §7.4.1).
+// Whitens the channel bits of u_1..u_6 by XORing a 114-bit PRBS
+// derived from the 12 information bits of u_0. u_0 itself and u_7
+// are transmitted unscrambled — u_0 because it carries the seed,
+// u_7 because it's the unprotected least-sensitive bits.
+//
+// PRBS algorithm: a 16-bit linear-congruential generator with
+//
+//	multiplier = 173
+//	increment  = 13849
+//	modulus    = 65536
+//	seed       = u_0_info × 16
+//	bit[i]     = pr[i] >> 15  (high bit of the 16-bit state)
+//
+// matching the C reference implementation in mbelib's
+// mbe_demodulateImbe7200x4400Data (ISC-licensed, attribution
+// preserved at the bottom of this file). The generator is invoked
+// 115 times so pr[0] holds the seed × 16 and pr[1..114] supply 114
+// scrambling bits — one per scrambled channel bit.
+
+// PRBSLength is how many PRBS bits the generator yields per IMBE
+// frame: 23 bits × 3 (u_1..u_3) + 15 bits × 3 (u_4..u_6) = 114.
+// Plus pr[0] = seed, total 115 LCG iterations.
+const PRBSLength = 114
+
+// PRBSSeedFromU0 reads the 12 information bits of u_0 from a
+// 144-bit channel buffer and returns the 16-bit PRBS seed
+// (u_0_info × 16). The info bits are the first 12 bits of the u_0
+// region — the systematic data bits that GolayEncode23_12 places at
+// the high end of the codeword.
+func PRBSSeedFromU0(channel []byte) uint16 {
+	var info uint16
+	for i := 0; i < u0InfoBits; i++ {
+		info = (info << 1) | uint16(channel[u0Offset+i]&1)
+	}
+	return info << 4
+}
+
+// PRBS expands the 16-bit seed into PRBSLength scrambling bits.
+// The returned slice's value[i] is one of {0, 1}; XORing each with
+// the matching channel bit is the scramble (and descramble — XOR
+// is self-inverse).
+func PRBS(seed uint16) [PRBSLength]byte {
+	const mul, inc, mod uint32 = 173, 13849, 65536
+	state := uint32(seed)
+	var bits [PRBSLength]byte
+	for i := 0; i < PRBSLength; i++ {
+		state = (mul*state + inc) % mod
+		// high bit of the 16-bit state — equivalent to mbelib's
+		// `pr[i] / 32768`.
+		bits[i] = byte(state >> 15)
+	}
+	return bits
+}
+
+// Scramble applies the IMBE PRBS to the 144-bit channel buffer in
+// place: u_0 and u_7 are left untouched, u_1..u_3 (23 bits each)
+// and u_4..u_6 (15 bits each) are XORed with the PRBS. Returns
+// the channel buffer for chaining; the input is mutated. Returns
+// an error only if the buffer is the wrong length.
+//
+// Scramble and Descramble are the same operation (XOR is
+// self-inverse); the two names exist for documentation. A clean
+// frame round-trips: Scramble(Scramble(x)) == x.
+func Scramble(channel []byte) ([]byte, error) {
+	if len(channel) != ChannelBits {
+		return nil, fmt.Errorf("%w: got %d channel bits", ErrChannelLength, len(channel))
+	}
+	prbs := PRBS(PRBSSeedFromU0(channel))
+	k := 0
+	for _, region := range [][2]int{
+		{u1Offset, u1Bits},
+		{u2Offset, u2Bits},
+		{u3Offset, u3Bits},
+		{u4Offset, u4Bits},
+		{u5Offset, u5Bits},
+		{u6Offset, u6Bits},
+	} {
+		off, n := region[0], region[1]
+		for i := 0; i < n; i++ {
+			channel[off+i] ^= prbs[k]
+			k++
+		}
+	}
+	return channel, nil
+}
+
+// Descramble is an alias for Scramble. Both names are exported so
+// call sites read naturally on encode (Scramble) and decode
+// (Descramble) paths.
+func Descramble(channel []byte) ([]byte, error) {
+	return Scramble(channel)
+}
+
+// PRBS reference: szechyjs/mbelib mbe_demodulateImbe7200x4400Data
+// (imbe7200x4400.c). ISC license, copyright 2010 mbelib Author. The
+// LCG constants above (multiplier 173, increment 13849, modulus
+// 65536, output bit 15) come from that implementation, which in
+// turn implements TIA-102.BABA §7.4.

--- a/internal/voice/imbe/scrambler_test.go
+++ b/internal/voice/imbe/scrambler_test.go
@@ -1,0 +1,170 @@
+package imbe
+
+import (
+	"math/rand"
+	"testing"
+)
+
+func TestPRBSDeterministicForSeed(t *testing.T) {
+	// LCG with seed 0: pr[0] = 0, pr[1] = (173*0+13849) mod 65536 =
+	// 13849 (high bit 0), pr[2] = (173*13849+13849) mod 65536 =
+	// 50430 (high bit 1), pr[3] = (173*50430+13849) mod 65536.
+	bits := PRBS(0)
+	wantPrefix := []byte{0, 1} // pr[1] high bit, pr[2] high bit
+	for i, w := range wantPrefix {
+		if bits[i] != w {
+			t.Errorf("seed=0: bits[%d] = %d, want %d", i, bits[i], w)
+		}
+	}
+}
+
+func TestPRBSDifferentSeedsDifferentSequences(t *testing.T) {
+	a := PRBS(0)
+	b := PRBS(0x1234) // arbitrary non-zero seed
+	if a == b {
+		t.Error("different seeds produced identical PRBS sequences")
+	}
+}
+
+func TestPRBSSeedFromU0ReadsFirstTwelveBits(t *testing.T) {
+	channel := make([]byte, ChannelBits)
+	// Stamp a recognisable 12-bit pattern into u_0's info bits.
+	want := uint16(0x9AB) // 0b100110101011
+	for i := 0; i < u0InfoBits; i++ {
+		channel[u0Offset+i] = byte((want >> uint(u0InfoBits-1-i)) & 1)
+	}
+	got := PRBSSeedFromU0(channel)
+	if got != want<<4 {
+		t.Errorf("seed = %#x, want %#x (info bits << 4)", got, want<<4)
+	}
+}
+
+func TestScrambleRoundTripIsIdentity(t *testing.T) {
+	rng := rand.New(rand.NewSource(42))
+	for trial := 0; trial < 8; trial++ {
+		original := make([]byte, ChannelBits)
+		for i := range original {
+			original[i] = byte(rng.Intn(2))
+		}
+		work := append([]byte(nil), original...)
+		if _, err := Scramble(work); err != nil {
+			t.Fatalf("trial %d: Scramble: %v", trial, err)
+		}
+		if _, err := Descramble(work); err != nil {
+			t.Fatalf("trial %d: Descramble: %v", trial, err)
+		}
+		for i, b := range work {
+			if b != original[i] {
+				t.Fatalf("trial %d: bit %d = %d after round trip, want %d",
+					trial, i, b, original[i])
+			}
+		}
+	}
+}
+
+func TestScrambleLeavesU0AndU7Untouched(t *testing.T) {
+	// u_0 carries the seed (must be unscrambled) and u_7 is the
+	// unprotected least-sensitive bits (also unscrambled per
+	// TIA-102.BABA §7.4). Stamp recognisable patterns into both
+	// regions and verify Scramble doesn't disturb them.
+	channel := make([]byte, ChannelBits)
+	for i := 0; i < u0Bits; i++ {
+		channel[u0Offset+i] = byte((i * 7) & 1)
+	}
+	for i := 0; i < u7Bits; i++ {
+		channel[u7Offset+i] = byte((i * 5 & 1) ^ 1)
+	}
+	original := append([]byte(nil), channel...)
+
+	if _, err := Scramble(channel); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < u0Bits; i++ {
+		if channel[u0Offset+i] != original[u0Offset+i] {
+			t.Errorf("u_0 bit %d mutated by Scramble: %d → %d",
+				i, original[u0Offset+i], channel[u0Offset+i])
+		}
+	}
+	for i := 0; i < u7Bits; i++ {
+		if channel[u7Offset+i] != original[u7Offset+i] {
+			t.Errorf("u_7 bit %d mutated by Scramble: %d → %d",
+				i, original[u7Offset+i], channel[u7Offset+i])
+		}
+	}
+}
+
+func TestScrambleAffectsU1ThroughU6(t *testing.T) {
+	// Conversely, Scramble must touch *some* bits in u_1..u_6 for
+	// non-trivial seeds. Using a seed of all-1s in u_0 gives a
+	// non-zero PRBS; verify at least one bit in each scrambled
+	// region flips.
+	channel := make([]byte, ChannelBits)
+	for i := 0; i < u0InfoBits; i++ {
+		channel[u0Offset+i] = 1
+	}
+	original := append([]byte(nil), channel...)
+	if _, err := Scramble(channel); err != nil {
+		t.Fatal(err)
+	}
+	for _, region := range [][2]int{
+		{u1Offset, u1Bits},
+		{u2Offset, u2Bits},
+		{u3Offset, u3Bits},
+		{u4Offset, u4Bits},
+		{u5Offset, u5Bits},
+		{u6Offset, u6Bits},
+	} {
+		off, n := region[0], region[1]
+		flipped := false
+		for i := 0; i < n; i++ {
+			if channel[off+i] != original[off+i] {
+				flipped = true
+				break
+			}
+		}
+		if !flipped {
+			t.Errorf("region @ %d (%d bits) untouched by Scramble", off, n)
+		}
+	}
+}
+
+func TestScrambleRejectsWrongLength(t *testing.T) {
+	if _, err := Scramble(make([]byte, ChannelBits-1)); err == nil {
+		t.Error("Scramble accepted short channel")
+	}
+	if _, err := Descramble(make([]byte, ChannelBits+1)); err == nil {
+		t.Error("Descramble accepted long channel")
+	}
+}
+
+func TestScrambleThenDecodeChannelRecoversInfo(t *testing.T) {
+	// End-to-end self-consistency: encode → scramble (transmit) →
+	// descramble → decode recovers the original 88 info bits.
+	rng := rand.New(rand.NewSource(7))
+	info := make([]byte, InfoBits)
+	for i := range info {
+		info[i] = byte(rng.Intn(2))
+	}
+	channel, err := EncodeChannel(info)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Scramble(channel); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Descramble(channel); err != nil {
+		t.Fatal(err)
+	}
+	got, errs, err := DecodeChannel(channel)
+	if err != nil {
+		t.Fatalf("DecodeChannel: %v", err)
+	}
+	if errs != 0 {
+		t.Errorf("errs = %d, want 0", errs)
+	}
+	for i, b := range got {
+		if b != info[i] {
+			t.Fatalf("info bit %d differs after scramble/descramble round trip", i)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Third PR in the IMBE 4400 thread (after #49 skeleton + #50 per-vector
FEC). Adds the **§7.4 pseudo-random scrambler** that whitens the
channel bits of u_1..u_6 — the last piece of IMBE channel coding
before parameter unpacking.

### Scope clarification

While reading mbelib's `mbe_demodulateImbe7200x4400Data` to source
the PRBS algorithm, I discovered there is **no separate "bit
interleaver" inside the IMBE codec**. The §7.5 ordering is satisfied
by how the upstream P25 LDU1 / LDU2 frame decoder extracts the 144
bits from a voice frame (a P25 phase1 layer concern, not an IMBE
one). `channel.go`'s per-vector layout already matches the order the
upstream extractor will hand it. `doc.go` updates to reflect this —
step 2b reframed from "deinterleaver + scrambler" to just
"scrambler".

### What changed

- **`internal/voice/imbe/scrambler.go`** — PRBS is a 16-bit linear-
  congruential generator with `mul=173`, `inc=13849`, `mod=65536`,
  seed derived from u_0's 12 information bits × 16; bit *i* is the
  high bit of state *i*. `PRBSLength = 114` — the count of
  scrambled channel bits across u_1..u_6 (3×23 + 3×15).
  `PRBSSeedFromU0` reads the 12 systematic info bits at the start
  of the u_0 region. `Scramble` XORs the PRBS over u_1..u_6
  in-place (preserving u_0 as the seed-bearer + u_7 as the
  unprotected least-sensitive bits). `Descramble` is an alias —
  XOR is self-inverse.

  Source attribution to **mbelib (ISC-licensed)** at the bottom of
  the file; the LCG constants come from
  `mbe_demodulateImbe7200x4400Data`, which itself implements
  TIA-102.BABA §7.4.
- **`internal/voice/imbe/doc.go`** — roadmap step 2b reframed +
  marked "← THIS PR"; step 2 loses its marker; the bit-interleaver
  clarification is documented inline.
- **`README.md`** — pure-Go IMBE roadmap entry mentions the
  scrambler alongside the per-vector FEC.

### Tests

- PRBS for `seed=0` starts `{0, 1}` matching the LCG trace by hand
  (`pr[1]=13849` → high bit 0; `pr[2]=50430` → high bit 1).
- Different seeds produce different sequences.
- `PRBSSeedFromU0` reads the first 12 bits of the u_0 region
  MSB-first and shifts left 4 to form the 16-bit seed.
- `Scramble` round-trips (`Scramble` then `Descramble` = identity)
  across 8 random 144-bit inputs.
- u_0 (positions 0..22) and u_7 (positions 137..143) are
  bit-for-bit unchanged after `Scramble`.
- u_1..u_6 each see at least one bit flipped by `Scramble` for a
  non-zero seed (regression guard against accidentally skipping a
  region).
- Wrong-length channel buffers are rejected.
- End-to-end: `EncodeChannel` → `Scramble` → `Descramble` →
  `DecodeChannel` recovers the original 88 info bits with zero
  corrected errors. The clean-channel acceptance test for the
  whole IMBE channel-coding stack.
- Full `go test ./...` passes.

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./internal/voice/imbe/...` green
- [x] `go test ./...` (full suite, all packages green)
- [ ] Follow-up PR: step 3 — parameter unpacking (88 information
      bits → IMBE model parameters per TIA-102.BABA §5).

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PHnwos5vaxtoDiSi32maZz)_