### PR TITLE
Pure-Go IMBE step 3b: Vl + Gm + Cik + Tl unpacking

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,12 +77,11 @@ to its own package and lands independently.
   (Golay(23,12) for u_0..u_3 + Hamming(15,11) for u_4..u_6 + no-FEC
   u_7 passthrough) is in (`internal/voice/imbe/channel.go`); the
   TIA-102.BABA §7.4 u_0-keyed LCG pseudo-random scrambler is in
-  (`scrambler.go`); the §5.3 parameter-unpack header
-  (b_0 → ω₀ + L + K, plus the full ba / hoba / bo / ImbeJi /
-  quantstep / standdev / B2 quantization tables transcribed from
-  mbelib) is in (`params.go` / `tables.go`). Currently emits
-  silence per frame; follow-up PRs land voicing + gain + spectral
-  amplitudes
+  (`scrambler.go`); full §5.3 / §5.4 / Annex E parameter unpack
+  (b_0 → ω₀ + L + K + Vl voicing + Gm PRBA gains + Cik spectral
+  coefficients + Tl log-amplitude residuals via two inverse DCTs)
+  is in (`params.go` / `tables.go`). Currently emits silence per
+  frame; follow-up PRs land speech synthesis
   inverse, parameter unpacking, and speech synthesis layers in
   that order so each step ships testable progress.
 - **DVSI USB-3000 / AMBE-3003 hardware backend.** A `Vocoder`

--- a/internal/voice/imbe/doc.go
+++ b/internal/voice/imbe/doc.go
@@ -32,20 +32,22 @@
 //     channel.go's per-vector layout already matches the order the
 //     upstream extractor will hand it.
 //
-//  3. Parameter unpacking — header. ← THIS PR.
+//  3. Parameter unpacking — header.
 //     88 information bits → IMBE Header { W0, L, K, Silent }. The
 //     b_0 fundamental-frequency parameter lives at scattered
 //     positions {0..5, 85, 86}; ω₀ + L + K all derive from it
-//     per TIA-102.BABA §5.3 / Annex E. The full
-//     TIA-102.BABA / mbelib quantization tables (ba, hoba, bo,
-//     ImbeJi, quantstep, standdev, B2) ship in tables.go ready
-//     for the spectral-amplitude follow-up.
+//     per TIA-102.BABA §5.3 / Annex E. See params.go.
 //
-//  3b. Parameter unpacking — voicing + gain + spectral. Read the
-//     remaining 79 bits via the bo[L9] re-order, then extract
-//     Vl[1..L] voicing decisions, the b_2 gain index, and the
-//     PRBA + HOC spectral amplitude blocks per §5.3 / §5.4.
-//     Inverse DCTs over Gm and Cik land here too.
+//  3b. Parameter unpacking — voicing + gain + spectral. ← THIS PR.
+//     Re-orders the remaining 79 bits via bo[L9] into the bb[v][p]
+//     layout, then extracts Vl[1..L] voicing decisions, the b_2
+//     gain index → Gm[1] = B2[b_2], the 5 PRBA gain blocks
+//     Gm[2..6] (Annex E eq. 68), and the HOC spectral coefficients
+//     Cik via hoba[L9] × quantstep × standdev (§5.4). Two inverse
+//     DCT-IIs (over Gm and over Cik) produce Tl[1..L], the
+//     pre-prediction log-amplitude residuals. The cross-frame
+//     log2Ml prediction (eq. 75-77) needs prev-frame state and
+//     lives in the synthesizer (step 4).
 //
 //  4. Speech synthesis. Voiced harmonic sum + unvoiced random
 //     excitation + spectral-amplitude shaping → 160 PCM samples /

--- a/internal/voice/imbe/params.go
+++ b/internal/voice/imbe/params.go
@@ -32,12 +32,31 @@ import (
 // Header carries the IMBE model parameters that come straight off
 // b_0 — the fundamental frequency, the harmonic count, and the
 // derived voicing-decision count K. The wider Params struct that
-// holds Vl / Gm / spectral amplitudes lands in the follow-up.
+// holds Vl / Gm / spectral amplitudes embeds it.
 type Header struct {
 	W0     float64 // fundamental frequency in radians/sample
 	L      int     // number of harmonics (9..56)
 	K      int     // voicing-decision count (= ⌈(L+2)/3⌉ for L < 37, else 12)
 	Silent bool    // true when b_0 ∈ [216, 219] (silence-frame indicator)
+}
+
+// Params is the complete IMBE 4400 model-parameter unpack: Header
+// fields plus voicing decisions, the 6 PRBA gain values, the
+// spectral DCT coefficients per band, and the spectral
+// log-amplitude residuals Tl[1..L]. All slices use 1-based indexing
+// to match TIA-102.BABA §5.3 / Annex E and mbelib's reference
+// implementation — index 0 is unused.
+//
+// Tl is the residual *before* the inter-frame log-amplitude
+// prediction (eq. 75-77) — that prediction needs the previous
+// frame's L / log2Ml state, which lives in the synthesizer
+// (step 4), not here.
+type Params struct {
+	Header
+	Vl  [57]int        // Vl[1..L] voicing decisions (0=unvoiced, 1=voiced)
+	Gm  [7]float64     // Gm[1..6] PRBA gain block values
+	Cik [7][11]float64 // Cik[1..6][1..imbeJi[L9][i-1]] DCT coefficients
+	Tl  [57]float64    // Tl[1..L] spectral log-amplitude residuals
 }
 
 // ErrInfoLength is returned by UnpackHeader when the supplied
@@ -90,4 +109,136 @@ func UnpackHeader(info []byte) (Header, error) {
 		K = (L + 2) / 3
 	}
 	return Header{W0: w0, L: L, K: K}, nil
+}
+
+// UnpackParams reads the full 88-bit info buffer into a Params
+// struct: header (b_0 → ω₀ + L + K), voicing decisions Vl[1..L],
+// PRBA gain blocks Gm[1..6], spectral DCT coefficients Cik, and
+// the pre-prediction log-amplitude residuals Tl[1..L]. Returns
+// ErrInvalidFundamental for unusable b_0; for the silence window
+// returns Params{Silent: true} with all spectral fields zero.
+//
+// Algorithmic reference: szechyjs/mbelib's mbe_decodeImbe4400Parms
+// (ISC-licensed; attribution preserved in tables.go).
+func UnpackParams(info []byte) (Params, error) {
+	h, err := UnpackHeader(info)
+	if err != nil {
+		return Params{}, err
+	}
+	if h.Silent {
+		return Params{Header: h}, nil
+	}
+	L := h.L
+	K := h.K
+	L9 := L - 9
+
+	// Re-order the 79 scattered bits at info[6..84] into bb[v][p]
+	// using the bit-order table bo[L9]. Each entry says
+	// "info[6+i] belongs at vector bo[L9][i][0], bit position
+	// bo[L9][i][1]". Vectors range up to L+1 ≤ 57; bit positions
+	// up to 11 (Vl uses K ≤ 12 bits in vector 1).
+	var bb [58][12]byte
+	for i := 0; i < 79; i++ {
+		v := bo[L9][i][0]
+		p := bo[L9][i][1]
+		bb[v][p] = info[6+i]
+	}
+
+	p := Params{Header: h}
+
+	// Vl voicing decisions: walk bb[1][k] in groups of 3 with k
+	// starting at K-1 (MSB) and decrementing every third Vl. One
+	// voicing bit per group of three harmonics — that's how IMBE
+	// fits L harmonic decisions into a K = ⌈(L+2)/3⌉ field.
+	j := 1
+	k := K - 1
+	for i := 1; i <= L; i++ {
+		p.Vl[i] = int(bb[1][k])
+		if j == 3 {
+			j = 1
+			if k > 0 {
+				k--
+			}
+		} else {
+			j++
+		}
+	}
+
+	// Gm[1] = B2[b2], with b_2 = 6 bits in bb[2][5..0], MSB-first.
+	b2 := uint(bb[2][5])<<5 | uint(bb[2][4])<<4 | uint(bb[2][3])<<3 |
+		uint(bb[2][2])<<2 | uint(bb[2][1])<<1 | uint(bb[2][0])
+	p.Gm[1] = b2Table[b2]
+
+	// Gm[2..6] from the 5 PRBA blocks (Annex E eq. 68): each block
+	// reads `bits` bits MSB-first from bb[i+1], then dequantizes as
+	// step × (bm − 2^(bits−1) + 0.5).
+	for i := 2; i <= 6; i++ {
+		bits := int(ba[L9][i-2][0])
+		step := ba[L9][i-2][1]
+		var bm uint
+		for bIdx := bits - 1; bIdx >= 0; bIdx-- {
+			bm = bm<<1 | uint(bb[i+1][bIdx])
+		}
+		p.Gm[i] = step * (float64(bm) - float64(int(1)<<uint(bits-1)) + 0.5)
+	}
+
+	// Inverse 6-point DCT-II of Gm[1..6] → Ri[1..6]. a_1 = 1, a_m = 2 otherwise.
+	var Ri [7]float64
+	for i := 1; i <= 6; i++ {
+		sum := 0.0
+		for m := 1; m <= 6; m++ {
+			am := 2.0
+			if m == 1 {
+				am = 1.0
+			}
+			sum += am * p.Gm[m] * math.Cos(math.Pi*float64(m-1)*(float64(i)-0.5)/6.0)
+		}
+		Ri[i] = sum
+	}
+
+	// Cik[i][1] = Ri[i]; higher k from k=2..ji uses HOC bits per
+	// hoba[L9]. m walks the HOC slots 8, 9, ... reading from bb[m].
+	// Quantization per §5.4: (quantstep[bits-1] × standdev[k-2]) ×
+	// (bm − 2^(bits-1) + 0.5). bits = 0 ⇒ Cik = 0 (no bits
+	// allocated to that slot).
+	m := 8
+	for i := 1; i <= 6; i++ {
+		p.Cik[i][1] = Ri[i]
+		ji := imbeJi[L9][i-1]
+		for kk := 2; kk <= ji; kk++ {
+			bits := hoba[L9][m-8]
+			if bits == 0 {
+				p.Cik[i][kk] = 0
+			} else {
+				var bm uint
+				for bIdx := bits - 1; bIdx >= 0; bIdx-- {
+					bm = bm<<1 | uint(bb[m][bIdx])
+				}
+				p.Cik[i][kk] = (quantstep[bits-1] * standdev[kk-2]) *
+					(float64(bm) - float64(int(1)<<uint(bits-1)) + 0.5)
+			}
+			m++
+		}
+	}
+
+	// Inverse DCT-II of Cik[i][1..ji] → Tl[1..L].
+	l := 1
+	for i := 1; i <= 6; i++ {
+		ji := imbeJi[L9][i-1]
+		for jj := 1; jj <= ji; jj++ {
+			sum := 0.0
+			for kk := 1; kk <= ji; kk++ {
+				ak := 2.0
+				if kk == 1 {
+					ak = 1.0
+				}
+				sum += ak * p.Cik[i][kk] *
+					math.Cos(math.Pi*float64(kk-1)*(float64(jj)-0.5)/float64(ji))
+			}
+			p.Tl[l] = sum
+			l++
+		}
+	}
+
+	return p, nil
 }

--- a/internal/voice/imbe/params_spectral_test.go
+++ b/internal/voice/imbe/params_spectral_test.go
@@ -1,0 +1,167 @@
+package imbe
+
+import (
+	"errors"
+	"math"
+	"testing"
+)
+
+// putB0Info is a thin convenience wrapper: stamps a b_0 value into
+// scattered positions {0..5, 85, 86} of an 88-bit info buffer. The
+// remaining 79 "scattered" bits at positions [6..84] stay zero, so
+// the resulting Params have all bb[v][p] = 0, which means the
+// post-DCT Tl ends up identically zero (the dequantizer's −2^(b−1)
+// + 0.5 offset gets exactly cancelled by the DCT linear combination
+// when all bm = 0... actually not quite — see below).
+func putB0Info(b0 uint) []byte {
+	info := make([]byte, InfoBits)
+	info[0] = byte((b0 >> 7) & 1)
+	info[1] = byte((b0 >> 6) & 1)
+	info[2] = byte((b0 >> 5) & 1)
+	info[3] = byte((b0 >> 4) & 1)
+	info[4] = byte((b0 >> 3) & 1)
+	info[5] = byte((b0 >> 2) & 1)
+	info[85] = byte((b0 >> 1) & 1)
+	info[86] = byte(b0 & 1)
+	return info
+}
+
+func TestUnpackParamsPropagatesInvalidFundamental(t *testing.T) {
+	_, err := UnpackParams(putB0Info(208))
+	if !errors.Is(err, ErrInvalidFundamental) {
+		t.Errorf("err = %v, want ErrInvalidFundamental", err)
+	}
+}
+
+func TestUnpackParamsRejectsWrongLength(t *testing.T) {
+	if _, err := UnpackParams(make([]byte, InfoBits-1)); err == nil {
+		t.Error("UnpackParams accepted short info")
+	}
+}
+
+func TestUnpackParamsSilentReturnsZeroSpectral(t *testing.T) {
+	for _, b0 := range []uint{216, 217, 218, 219} {
+		p, err := UnpackParams(putB0Info(b0))
+		if err != nil {
+			t.Fatalf("b0=%d: err = %v", b0, err)
+		}
+		if !p.Silent {
+			t.Errorf("b0=%d: Silent=false", b0)
+		}
+		// All spectral fields must be zero in the silence frame.
+		for i := 1; i < len(p.Vl); i++ {
+			if p.Vl[i] != 0 {
+				t.Errorf("b0=%d: Vl[%d] = %d, want 0", b0, i, p.Vl[i])
+			}
+		}
+		for i, g := range p.Gm {
+			if g != 0 {
+				t.Errorf("b0=%d: Gm[%d] = %g, want 0", b0, i, g)
+			}
+		}
+		for i := 1; i < len(p.Tl); i++ {
+			if p.Tl[i] != 0 {
+				t.Errorf("b0=%d: Tl[%d] = %g, want 0", b0, i, p.Tl[i])
+			}
+		}
+	}
+}
+
+func TestUnpackParamsAllZeroInfoMatchesB2Index32(t *testing.T) {
+	// All-zero info → b_0 = 0 → header path succeeds. With every
+	// scattered bit = 0, b_2 = 0 (so Gm[1] = b2Table[0]), each
+	// PRBA bm = 0 (so Gm[i] = step × (0 − 2^(b−1) + 0.5)), every
+	// HOC bm = 0 (so Cik = quantstep × standdev × (0 − 2^(b-1) +
+	// 0.5)). Tl is the inverse-DCT of those — non-zero in general.
+	//
+	// What we *can* assert: every output is finite and Vl[1..L]
+	// are all 0 (vector-1 voicing field is zero).
+	info := putB0Info(0) // all-zero info except b_0 = 0
+	p, err := UnpackParams(info)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.Silent {
+		t.Error("b0=0: Silent=true, want false")
+	}
+	for i := 1; i <= p.L; i++ {
+		if p.Vl[i] != 0 {
+			t.Errorf("Vl[%d] = %d, want 0 (all-zero info)", i, p.Vl[i])
+		}
+	}
+	for i := 1; i <= 6; i++ {
+		if math.IsNaN(p.Gm[i]) || math.IsInf(p.Gm[i], 0) {
+			t.Errorf("Gm[%d] = %g, want finite", i, p.Gm[i])
+		}
+	}
+	for i := 1; i <= p.L; i++ {
+		if math.IsNaN(p.Tl[i]) || math.IsInf(p.Tl[i], 0) {
+			t.Errorf("Tl[%d] = %g, want finite", i, p.Tl[i])
+		}
+	}
+	// Tl[L+1..56] must remain at zero (we only fill up to L).
+	for i := p.L + 1; i < len(p.Tl); i++ {
+		if p.Tl[i] != 0 {
+			t.Errorf("Tl[%d] = %g (out of bounds), want 0", i, p.Tl[i])
+		}
+	}
+}
+
+func TestUnpackParamsGm1FromB2Field(t *testing.T) {
+	// b_2 lives in bb[2][0..5] after the bo[L9] re-order — so we
+	// can't drive it directly without knowing which info[6..84]
+	// positions land in bb[2]. Instead, drive a known b_2 by
+	// stamping all 79 scattered bits to 1 and comparing against
+	// what mbelib's pipeline would compute. With every scattered
+	// bit set, b_2 = 0b111111 = 63 and Gm[1] = b2Table[63]. (The
+	// last entry of B2 is 8.695827.)
+	info := putB0Info(0)
+	for i := 6; i <= 84; i++ {
+		info[i] = 1
+	}
+	p, err := UnpackParams(info)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := b2Table[63]
+	if math.Abs(p.Gm[1]-want) > 1e-9 {
+		t.Errorf("Gm[1] = %g, want %g (b2Table[63])", p.Gm[1], want)
+	}
+}
+
+func TestUnpackParamsTlLengthMatchesL(t *testing.T) {
+	// Tl is filled exactly L entries (indices 1..L). Sweep every
+	// valid b_0 and assert no Tl writes spilled past L.
+	for b0 := uint(0); b0 < 208; b0++ {
+		info := putB0Info(b0)
+		p, err := UnpackParams(info)
+		if err != nil {
+			t.Errorf("b0=%d: err = %v", b0, err)
+			continue
+		}
+		for i := p.L + 1; i < len(p.Tl); i++ {
+			if p.Tl[i] != 0 {
+				t.Errorf("b0=%d L=%d: Tl[%d] = %g, want 0", b0, p.L, i, p.Tl[i])
+				break
+			}
+		}
+	}
+}
+
+func TestUnpackParamsVlBitDistribution(t *testing.T) {
+	// With every scattered bit = 1, vector 1 is all 1s, so
+	// Vl[1..L] should all be 1.
+	info := putB0Info(0)
+	for i := 6; i <= 84; i++ {
+		info[i] = 1
+	}
+	p, err := UnpackParams(info)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 1; i <= p.L; i++ {
+		if p.Vl[i] != 1 {
+			t.Errorf("Vl[%d] = %d, want 1 (all-ones info)", i, p.Vl[i])
+		}
+	}
+}


### PR DESCRIPTION
## Summary
Fifth PR in the IMBE 4400 thread (after #49 skeleton, #50 per-vector FEC, #51 PRBS scrambler, #52 header). Lands the rest of parameter unpacking — bit re-order via `bo[L9]`, voicing decisions, the `b_2` gain index, the 5 PRBA gain blocks, and the HOC spectral coefficients — followed by the two inverse DCT-IIs that produce `Tl[1..L]`, the pre-prediction log-amplitude residuals.

The cross-frame `log2Ml` prediction (eq. 75–77) needs prev-frame state and lives in the synthesizer (step 4), not here.

## Changes
- **`internal/voice/imbe/params.go`** — `Params` struct embeds `Header` and adds `Vl[57]` (voicing decisions, 1-indexed), `Gm[7]` (PRBA gain values), `Cik[7][11]` (DCT coefficients per band), `Tl[57]` (log-amplitude residuals). New `UnpackParams(info []byte) (Params, error)` runs `UnpackHeader`, short-circuits on Silent frames, re-orders the 79 scattered bits at `info[6..84]` into `bb[v][p]` via `bo[L9]`, reads K voicing bits with the every-third-Vl decrement pattern from §5.3, decodes `b_2 → Gm[1] = b2Table[b_2]`, decodes `Gm[2..6]` from `ba[L9]` using Annex E eq. 68 dequantize, runs a 6-point inverse DCT-II over `Gm` to produce `Ri[1..6]`, fills `Cik[i][1] = Ri[i]`, reads HOC bits via `hoba[L9] × quantstep × standdev` (§5.4), then runs a per-band inverse DCT-II of length `ji = imbeJi[L9][i-1]` over `Cik` to produce `Tl[1..L]`.
- **`internal/voice/imbe/doc.go`** — roadmap step 3b marked shipped; step 4 (synthesis) becomes the next focus.
- **`README.md`** — pure-Go IMBE roadmap entry now lists the full §5.3 / §5.4 / Annex E parameter unpack alongside the channel-coding pieces.

## Test plan
- [x] `ErrInvalidFundamental` propagates from `UnpackHeader`
- [x] Wrong-length info buffers are rejected
- [x] `b_0 ∈ {216..219}` silence frames return zero `Vl`/`Gm`/`Tl`
- [x] All-zero info frame: `Vl[1..L]` all 0, `Gm` finite, `Tl` finite, `Tl[L+1..56]` untouched
- [x] All-ones scattered info → `b_2 = 63` → `Gm[1] = b2Table[63] = 8.695827` (pins the 6-bit MSB-first `b_2` read from `bb[2][5..0]`)
- [x] All-ones scattered info → `Vl[1..L]` all 1
- [x] Sweep all 208 valid `b_0`: `Tl` writes never spill past index `L` (catches off-by-ones in the i/j/k DCT loops)
- [x] Full `go test ./...` green

---
_Generated by [Claude Code](https://claude.ai/code/session_01JmSJLqDwr8jLuKtbkzGXNE)_