### PR TITLE
Pure-Go IMBE step 4a: cross-frame log2(Ml) prediction

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,10 +80,13 @@ to its own package and lands independently.
   (`scrambler.go`); full §5.3 / §5.4 / Annex E parameter unpack
   (b_0 → ω₀ + L + K + Vl voicing + Gm PRBA gains + Cik spectral
   coefficients + Tl log-amplitude residuals via two inverse DCTs)
-  is in (`params.go` / `tables.go`). Currently emits silence per
-  frame; follow-up PRs land speech synthesis
-  inverse, parameter unpacking, and speech synthesis layers in
-  that order so each step ships testable progress.
+  is in (`params.go` / `tables.go`); §6.1 cross-frame log2(Ml)
+  prediction (eqs. 75-77 — γ = 0.65 interpolation of prev-frame
+  harmonics at l · ω₀_curr/ω₀_prev positions, DC-bias removal,
+  Tl residual addition) is in on a `SynthState` that the
+  excitation step extends (`synth.go`). Currently still emits
+  silence per frame; follow-up PR lands voiced/unvoiced
+  excitation + spectral shaping + 8 kHz PCM synthesis (§6.2-6.4).
 - **DVSI USB-3000 / AMBE-3003 hardware backend.** A `Vocoder`
   factory that opens a connected DVSI USB chip. Same plug-in shape
   as `internal/voice/mbelib`; the daemon picks the factory by name

--- a/internal/voice/imbe/doc.go
+++ b/internal/voice/imbe/doc.go
@@ -38,7 +38,7 @@
 //     positions {0..5, 85, 86}; ω₀ + L + K all derive from it
 //     per TIA-102.BABA §5.3 / Annex E. See params.go.
 //
-//  3b. Parameter unpacking — voicing + gain + spectral. ← THIS PR.
+//  3b. Parameter unpacking — voicing + gain + spectral.
 //     Re-orders the remaining 79 bits via bo[L9] into the bb[v][p]
 //     layout, then extracts Vl[1..L] voicing decisions, the b_2
 //     gain index → Gm[1] = B2[b_2], the 5 PRBA gain blocks
@@ -47,11 +47,20 @@
 //     DCT-IIs (over Gm and over Cik) produce Tl[1..L], the
 //     pre-prediction log-amplitude residuals. The cross-frame
 //     log2Ml prediction (eq. 75-77) needs prev-frame state and
-//     lives in the synthesizer (step 4).
+//     lives in the synthesizer (step 4a).
 //
-//  4. Speech synthesis. Voiced harmonic sum + unvoiced random
-//     excitation + spectral-amplitude shaping → 160 PCM samples /
-//     20 ms / 8 kHz mono per frame. Per TIA-102.BABA Section 6.
+//  4a. Speech synthesis — cross-frame log-amplitude recovery. ← THIS PR.
+//     TIA-102.BABA §6.1 eqs. 75-77: predict at curr-frame harmonic
+//     positions by interpolating prev-frame log2(Ml) at l ·
+//     ω₀_curr/ω₀_prev (γ = 0.65 scale), subtract the prediction's
+//     DC bias, then add Tl[l]. Lives on a SynthState that the
+//     synthesizer (step 4b) extends with voicing + phase memory.
+//     See synth.go.
+//
+//  4b. Speech synthesis — excitation + PCM. Voiced harmonic sum +
+//     unvoiced random excitation + spectral-amplitude shaping →
+//     160 PCM samples / 20 ms / 8 kHz mono per frame. Per
+//     TIA-102.BABA §6.2-6.4.
 //
 //  5. Quality polish: enhancement filter, frame-repeat on bad-frame
 //     indicator, gain smoothing across frames.

--- a/internal/voice/imbe/synth.go
+++ b/internal/voice/imbe/synth.go
@@ -1,0 +1,125 @@
+package imbe
+
+// IMBE 4400 speech synthesis — TIA-102.BABA §6.1 cross-frame
+// log-amplitude recovery.
+//
+// Step 3b (params.go) emits Tl[1..L], the *pre-prediction* spectral
+// log-amplitude residuals. The harmonic log-amplitudes log2(Ml) the
+// synthesizer drives into voiced + unvoiced excitation are recovered
+// via a one-tap inter-frame prediction over the previous frame's
+// harmonics (eqs. 75-77 in §6.1).
+//
+// This file ships step 4a: the cross-frame log2(Ml) recovery.
+// Voiced + unvoiced excitation, spectral shaping, and 8 kHz PCM
+// synthesis (§6.2-6.4) land in step 4b on the same SynthState so
+// frame-to-frame phase + voicing memory has a home.
+//
+// Algorithmic reference: szechyjs/mbelib's mbe_spectralAmpDecode
+// (ISC-licensed; attribution preserved at the bottom of tables.go).
+
+// PredictionGain is the inter-frame prediction coefficient γ from
+// eq. 75 (TIA-102.BABA §6.1). The spec fixes it at 0.65: high
+// enough that the harmonic envelope evolves smoothly across frames,
+// low enough that a pathological prev frame can't dominate the
+// current spectrum.
+const PredictionGain = 0.65
+
+// SynthState carries inter-frame memory needed by the synthesizer.
+// Step 4a uses PrevW0 / PrevL / PrevLog2Ml for the eq. 75-77
+// log-amplitude prediction; step 4b adds voicing + phase memory.
+//
+// Zero value is the "fresh stream / no prev frame" starting state —
+// what the decoder presents to the first IMBE frame on a call.
+// Slices are 1-indexed to match TIA-102.BABA / mbelib conventions.
+type SynthState struct {
+	PrevW0     float64    // ω₀ from the previous decoded frame (rad/sample); 0 ⇒ no prev frame
+	PrevL      int        // L from the previous decoded frame (1-indexed slice extent)
+	PrevLog2Ml [57]float64 // log2(Ml) at indices [1..PrevL]; [0] + tail unused
+}
+
+// Reset clears all inter-frame memory. Callers invoke it on stream
+// re-sync (frame-loss event from the upstream P25 LDU decoder) and
+// on the silence-frame indicator b_0 ∈ [216, 219] so the next
+// non-silent frame starts from a clean state.
+func (s *SynthState) Reset() {
+	*s = SynthState{}
+}
+
+// PredictLog2Ml recovers log2(Ml)[1..L] from the current frame's Tl
+// residuals and the prev-frame state in s, per TIA-102.BABA §6.1
+// equations 75-77:
+//
+//	eq. 75 — predict at curr-frame harmonic positions:
+//	    log2(M̂)[l] = γ · interp(log2(M_prev), l · ω₀_curr / ω₀_prev)
+//	eq. 76 — average the prediction over the current L:
+//	    ave = (1/L) · Σ log2(M̂)[l]
+//	eq. 77 — combine prediction + residual, removing the prediction's
+//	         DC bias so Tl carries the only intentional offset:
+//	    log2(Ml)[l] = log2(M̂)[l] + Tl[l] − ave
+//
+// Writes log2(Ml) into dst[1..L]; dst[0] and dst[L+1..56] are left
+// untouched. Does not mutate s — callers invoke UpdateLog2Ml to
+// roll prev-frame state forward once the synthesizer has consumed
+// the prediction.
+//
+// First-frame behavior: when PrevL == 0 the prediction term is
+// zero, so log2(Ml)[l] = Tl[l].
+//
+// Silence frames: the caller should Reset() s before invoking this
+// for b_0 ∈ [216, 219] frames; this function short-circuits on
+// p.Silent || p.L == 0 so dst stays untouched.
+func PredictLog2Ml(s *SynthState, p Params, dst *[57]float64) {
+	if p.Silent || p.L == 0 {
+		return
+	}
+	L := p.L
+
+	var pred [57]float64
+	if s.PrevL > 0 && s.PrevW0 > 0 {
+		ratio := p.W0 / s.PrevW0
+		for l := 1; l <= L; l++ {
+			pos := float64(l) * ratio
+			if pos < 1 {
+				pos = 1
+			}
+			if pos > float64(s.PrevL) {
+				pos = float64(s.PrevL)
+			}
+			k := int(pos)
+			if k < 1 {
+				k = 1
+			}
+			frac := pos - float64(k)
+			k1 := k + 1
+			if k1 > s.PrevL {
+				k1 = s.PrevL
+			}
+			pred[l] = PredictionGain *
+				((1-frac)*s.PrevLog2Ml[k] + frac*s.PrevLog2Ml[k1])
+		}
+	}
+
+	var ave float64
+	for l := 1; l <= L; l++ {
+		ave += pred[l]
+	}
+	ave /= float64(L)
+
+	for l := 1; l <= L; l++ {
+		dst[l] = pred[l] + p.Tl[l] - ave
+	}
+}
+
+// UpdateLog2Ml rolls the prev-frame state forward: copies log2(Ml)
+// from src[1..L] into s.PrevLog2Ml (clearing the rest), and stores
+// the current ω₀ + L. Callers invoke it after the synthesizer has
+// consumed the prediction so the next frame's PredictLog2Ml has the
+// right history.
+func (s *SynthState) UpdateLog2Ml(p Params, src *[57]float64) {
+	s.PrevW0 = p.W0
+	s.PrevL = p.L
+	s.PrevLog2Ml = [57]float64{}
+	for l := 1; l <= p.L; l++ {
+		s.PrevLog2Ml[l] = src[l]
+	}
+}

--- a/internal/voice/imbe/synth_test.go
+++ b/internal/voice/imbe/synth_test.go
@@ -1,0 +1,281 @@
+package imbe
+
+import (
+	"math"
+	"testing"
+)
+
+const epsilon = 1e-9
+
+func almostEqual(a, b float64) bool {
+	return math.Abs(a-b) < epsilon
+}
+
+// TestPredictLog2MlFirstFrameIsTl confirms that with no prev-frame
+// state, the prediction term is zero and log2(Ml)[l] = Tl[l]. The
+// mean subtraction in eq. 77 is mean(pred[l]) = 0, not mean(Tl), so
+// Tl values pass through unchanged.
+func TestPredictLog2MlFirstFrameIsTl(t *testing.T) {
+	var s SynthState
+	p := Params{Header: Header{W0: math.Pi / 30, L: 20, K: 8}}
+	for l := 1; l <= p.L; l++ {
+		p.Tl[l] = float64(l) * 0.1
+	}
+	var dst [57]float64
+	PredictLog2Ml(&s, p, &dst)
+	for l := 1; l <= p.L; l++ {
+		want := float64(l) * 0.1
+		if !almostEqual(dst[l], want) {
+			t.Errorf("first frame dst[%d] = %v, want %v", l, dst[l], want)
+		}
+	}
+}
+
+// TestPredictLog2MlConstantPrevCancels: when prev-frame log2(Ml) is
+// constant c, the prediction is 0.65*c at every l and ave = 0.65*c
+// — they cancel in eq. 77 and dst = Tl. This pins the eq. 77 mean
+// subtraction (a flat-spectrum prev frame contributes no tilt to
+// the current frame).
+func TestPredictLog2MlConstantPrevCancels(t *testing.T) {
+	const c = 4.2
+	s := SynthState{PrevW0: math.Pi / 30, PrevL: 20}
+	for l := 1; l <= s.PrevL; l++ {
+		s.PrevLog2Ml[l] = c
+	}
+	p := Params{Header: Header{W0: math.Pi / 30, L: 20, K: 8}}
+	for l := 1; l <= p.L; l++ {
+		p.Tl[l] = float64(l) - 10.5 // arbitrary signed values
+	}
+	var dst [57]float64
+	PredictLog2Ml(&s, p, &dst)
+	for l := 1; l <= p.L; l++ {
+		if !almostEqual(dst[l], p.Tl[l]) {
+			t.Errorf("constant-prev dst[%d] = %v, want Tl[%d] = %v",
+				l, dst[l], l, p.Tl[l])
+		}
+	}
+}
+
+// TestPredictLog2MlSamePitchExactInterp: when ω₀_curr == ω₀_prev and
+// L_curr == L_prev, the interpolation index pos = l × 1.0 lands on
+// integer l for every harmonic — no fractional blending. Each
+// dst[l] = 0.65 × prev[l] + Tl[l] − mean(0.65 × prev). Checks the
+// integer-index path.
+func TestPredictLog2MlSamePitchExactInterp(t *testing.T) {
+	s := SynthState{PrevW0: math.Pi / 30, PrevL: 4}
+	prev := [5]float64{0, 1.0, 2.0, 3.0, 4.0} // 1-indexed
+	for l := 1; l <= s.PrevL; l++ {
+		s.PrevLog2Ml[l] = prev[l]
+	}
+	p := Params{Header: Header{W0: math.Pi / 30, L: 4, K: 2}}
+	// Tl all zero so dst directly reflects prediction - mean(prediction).
+	var dst [57]float64
+	PredictLog2Ml(&s, p, &dst)
+
+	predMean := PredictionGain * (1.0 + 2.0 + 3.0 + 4.0) / 4.0
+	for l := 1; l <= p.L; l++ {
+		want := PredictionGain*prev[l] - predMean
+		if !almostEqual(dst[l], want) {
+			t.Errorf("same-pitch dst[%d] = %v, want %v", l, dst[l], want)
+		}
+	}
+}
+
+// TestPredictLog2MlInterpolationFraction: when ω₀_curr / ω₀_prev =
+// 0.5, l=2 maps to prev-pos 1.0 and l=3 maps to prev-pos 1.5. The
+// fractional blend at l=3 is (0.5 × prev[1] + 0.5 × prev[2]). Pins
+// the fractional-index path.
+func TestPredictLog2MlInterpolationFraction(t *testing.T) {
+	s := SynthState{PrevW0: math.Pi / 30, PrevL: 4}
+	s.PrevLog2Ml[1] = 2.0
+	s.PrevLog2Ml[2] = 4.0
+	s.PrevLog2Ml[3] = 6.0
+	s.PrevLog2Ml[4] = 8.0
+	// Curr ω₀ is half of prev → curr harmonic l sits at prev pos l/2.
+	p := Params{Header: Header{W0: math.Pi / 60, L: 6, K: 3}}
+	var dst [57]float64
+	PredictLog2Ml(&s, p, &dst)
+
+	// Predicted-then-mean values at curr harmonics:
+	//  l=1 → pos=0.5 (clamped to 1) → prev[1] = 2
+	//  l=2 → pos=1.0 → prev[1] = 2
+	//  l=3 → pos=1.5 → 0.5×prev[1] + 0.5×prev[2] = 3
+	//  l=4 → pos=2.0 → prev[2] = 4
+	//  l=5 → pos=2.5 → 0.5×prev[2] + 0.5×prev[3] = 5
+	//  l=6 → pos=3.0 → prev[3] = 6
+	rawPred := [7]float64{0, 2, 2, 3, 4, 5, 6}
+	var sum float64
+	for l := 1; l <= 6; l++ {
+		sum += PredictionGain * rawPred[l]
+	}
+	mean := sum / 6.0
+	for l := 1; l <= p.L; l++ {
+		want := PredictionGain*rawPred[l] - mean // Tl is zero
+		if !almostEqual(dst[l], want) {
+			t.Errorf("interp dst[%d] = %v, want %v", l, dst[l], want)
+		}
+	}
+}
+
+// TestPredictLog2MlClampsBeyondPrevL: when curr L exceeds the
+// available prev-frame harmonics (e.g. pitch dropped sharply so we
+// have many more harmonics now), positions past PrevL clamp to the
+// last prev value. Pins the upper-bound clamp.
+func TestPredictLog2MlClampsBeyondPrevL(t *testing.T) {
+	s := SynthState{PrevW0: math.Pi / 10, PrevL: 3}
+	s.PrevLog2Ml[1] = 1.0
+	s.PrevLog2Ml[2] = 2.0
+	s.PrevLog2Ml[3] = 3.0
+	// Half pitch → curr L bigger; positions for high l exceed PrevL.
+	p := Params{Header: Header{W0: math.Pi / 20, L: 10, K: 4}}
+	var dst [57]float64
+	PredictLog2Ml(&s, p, &dst)
+
+	// Verify high harmonics see the last-prev value (3.0) before mean
+	// subtraction. Only check the relative tilt: dst[l] − dst[l′]
+	// matches the raw pred difference for l, l′ both past clamp.
+	// l=8 → pos=4.0 → clamped to 3 → 3.0
+	// l=9 → pos=4.5 → clamped to 3 → 3.0
+	// l=10 → pos=5.0 → clamped to 3 → 3.0
+	for _, l := range []int{8, 9, 10} {
+		if !almostEqual(dst[l], dst[8]) {
+			t.Errorf("clamp: dst[%d] = %v should equal dst[8] = %v",
+				l, dst[l], dst[8])
+		}
+	}
+}
+
+// TestPredictLog2MlSilentFrameLeavesDstUntouched: silence frames
+// short-circuit the prediction; dst keeps its prior contents so
+// callers can detect "no update happened". The synthesizer is
+// expected to either play silence or hold the last frame.
+func TestPredictLog2MlSilentFrameLeavesDstUntouched(t *testing.T) {
+	var s SynthState
+	p := Params{Header: Header{Silent: true}}
+	dst := [57]float64{}
+	for i := range dst {
+		dst[i] = 99 // sentinel
+	}
+	PredictLog2Ml(&s, p, &dst)
+	for i := range dst {
+		if dst[i] != 99 {
+			t.Errorf("silent frame mutated dst[%d] = %v, want sentinel 99",
+				i, dst[i])
+		}
+	}
+}
+
+// TestUpdateLog2MlRollsState: the helper copies log2(Ml)[1..L] into
+// PrevLog2Ml, stores ω₀ + L, and zeroes any prior PrevLog2Ml entries
+// past the new L (so a subsequent shorter-L frame doesn't leak old
+// high harmonics into the prediction).
+func TestUpdateLog2MlRollsState(t *testing.T) {
+	s := SynthState{PrevL: 30}
+	for l := 1; l <= 30; l++ {
+		s.PrevLog2Ml[l] = 99
+	}
+	p := Params{Header: Header{W0: 0.42, L: 5, K: 2}}
+	src := [57]float64{}
+	src[1] = 1
+	src[2] = 2
+	src[3] = 3
+	src[4] = 4
+	src[5] = 5
+	s.UpdateLog2Ml(p, &src)
+	if s.PrevW0 != 0.42 {
+		t.Errorf("PrevW0 = %v, want 0.42", s.PrevW0)
+	}
+	if s.PrevL != 5 {
+		t.Errorf("PrevL = %d, want 5", s.PrevL)
+	}
+	for l := 1; l <= 5; l++ {
+		if s.PrevLog2Ml[l] != float64(l) {
+			t.Errorf("PrevLog2Ml[%d] = %v, want %d", l, s.PrevLog2Ml[l], l)
+		}
+	}
+	for l := 6; l <= 56; l++ {
+		if s.PrevLog2Ml[l] != 0 {
+			t.Errorf("PrevLog2Ml[%d] = %v, want 0 (cleared past new L)",
+				l, s.PrevLog2Ml[l])
+		}
+	}
+}
+
+// TestResetClearsState: Reset zeroes everything so the next frame
+// behaves like the first frame on a fresh stream.
+func TestResetClearsState(t *testing.T) {
+	s := SynthState{PrevW0: 0.5, PrevL: 20}
+	for l := 1; l <= 20; l++ {
+		s.PrevLog2Ml[l] = float64(l)
+	}
+	s.Reset()
+	if s.PrevW0 != 0 || s.PrevL != 0 {
+		t.Errorf("Reset: PrevW0=%v PrevL=%d, want 0/0", s.PrevW0, s.PrevL)
+	}
+	for l := 0; l <= 56; l++ {
+		if s.PrevLog2Ml[l] != 0 {
+			t.Errorf("Reset: PrevLog2Ml[%d] = %v, want 0", l, s.PrevLog2Ml[l])
+		}
+	}
+}
+
+// TestPredictLog2MlTwoFrameSequence runs two consecutive frames
+// through Predict→Update to confirm the state machine threads
+// correctly: frame 2's prediction must see frame 1's log2(Ml).
+func TestPredictLog2MlTwoFrameSequence(t *testing.T) {
+	var s SynthState
+
+	// Frame 1: fresh state. dst1 = Tl1 (no prediction).
+	p1 := Params{Header: Header{W0: math.Pi / 30, L: 4, K: 2}}
+	for l := 1; l <= p1.L; l++ {
+		p1.Tl[l] = float64(l)
+	}
+	var dst1 [57]float64
+	PredictLog2Ml(&s, p1, &dst1)
+	for l := 1; l <= p1.L; l++ {
+		if !almostEqual(dst1[l], float64(l)) {
+			t.Fatalf("frame 1 dst[%d] = %v, want %d", l, dst1[l], l)
+		}
+	}
+	s.UpdateLog2Ml(p1, &dst1)
+
+	// Frame 2: same pitch + L; prev = {1,2,3,4}. With Tl2 = 0,
+	// dst2[l] = 0.65*l - mean(0.65*{1,2,3,4}) = 0.65*l - 0.65*2.5.
+	p2 := Params{Header: Header{W0: math.Pi / 30, L: 4, K: 2}}
+	var dst2 [57]float64
+	PredictLog2Ml(&s, p2, &dst2)
+	predMean := PredictionGain * (1.0 + 2.0 + 3.0 + 4.0) / 4.0
+	for l := 1; l <= p2.L; l++ {
+		want := PredictionGain*float64(l) - predMean
+		if !almostEqual(dst2[l], want) {
+			t.Errorf("frame 2 dst[%d] = %v, want %v", l, dst2[l], want)
+		}
+	}
+}
+
+// TestPredictLog2MlMeanCenteredOutput: regardless of prev-frame
+// content, when Tl is mean-centered the eq. 77 output is also
+// mean-centered (the prediction's DC bias is removed). Pins the
+// "Tl carries the only intentional offset" property.
+func TestPredictLog2MlMeanCenteredOutput(t *testing.T) {
+	s := SynthState{PrevW0: math.Pi / 25, PrevL: 8}
+	for l := 1; l <= s.PrevL; l++ {
+		s.PrevLog2Ml[l] = float64(l) * 1.7
+	}
+	p := Params{Header: Header{W0: math.Pi / 30, L: 6, K: 3}}
+	// Mean-centered Tl: sums to zero.
+	tlVals := []float64{-3, -1, 0, 0, 1, 3}
+	for l := 1; l <= p.L; l++ {
+		p.Tl[l] = tlVals[l-1]
+	}
+	var dst [57]float64
+	PredictLog2Ml(&s, p, &dst)
+
+	var sum float64
+	for l := 1; l <= p.L; l++ {
+		sum += dst[l]
+	}
+	if !almostEqual(sum, 0) {
+		t.Errorf("mean-centered Tl: sum(dst) = %v, want 0", sum)
+	}
+}


### PR DESCRIPTION
Sixth PR in the IMBE 4400 thread (#49 skeleton, #50 per-vector FEC,
#51 PRBS scrambler, #52 header, #53 spectral unpack). Lands the
TIA-102.BABA §6.1 cross-frame log-amplitude recovery — the bridge
between the Tl[1..L] residuals step 3b emits and the harmonic
log-amplitudes the synthesizer drives in step 4b. Closes the loop
on parameter recovery before voiced/unvoiced excitation lands.

* internal/voice/imbe/synth.go (new):
  - SynthState struct with PrevW0 / PrevL / PrevLog2Ml memory.
    Zero value = "fresh stream / no prev frame", which matches what
    the decoder presents on the first frame of a call. Slices are
    1-indexed to match TIA-102.BABA / mbelib conventions.
  - PredictionGain = 0.65 — the inter-frame coefficient γ from
    eq. 75. High enough that the harmonic envelope evolves
    smoothly across frames, low enough that a pathological prev
    frame can't dominate the current spectrum.
  - PredictLog2Ml(s, p, dst): implements eqs. 75-77 in three
    passes — interpolate prev-frame log2(Ml) at l · ω₀_curr/ω₀_prev
    positions (γ-scaled, with both lower clamp at 1 and upper
    clamp at PrevL), compute the prediction's mean over the
    current L, and write dst[l] = pred[l] + Tl[l] − ave so Tl
    carries the only intentional offset. Silent frames + L == 0
    short-circuit (dst left untouched). Does not mutate s.
  - (s).Reset() clears all inter-frame memory for stream re-sync
    + silence-frame events.
  - (s).UpdateLog2Ml(p, src) rolls prev-frame state forward,
    explicitly zeroing entries past the new L so a subsequent
    shorter-L frame doesn't leak old high harmonics into the next
    prediction.

* internal/voice/imbe/doc.go: roadmap split into 4a (this PR)
  and 4b (excitation + PCM). The pre-existing 3b note about
  "prediction lives in synthesizer (step 4)" updated to "step 4a".

* README.md: pure-Go IMBE roadmap entry now mentions §6.1
  prediction shipped on a SynthState; the follow-up scope line
  narrows to voiced/unvoiced excitation + spectral shaping +
  8 kHz PCM synthesis (§6.2-6.4).

Tests (synth_test.go):
- First frame (no prev state): dst[l] = Tl[l] (prediction zero,
  mean zero).
- Constant prev frame: prediction is 0.65 × c at every l, mean
  cancels in eq. 77 → dst = Tl. Pins the DC-bias removal.
- Same pitch + L: integer-index path (pos = l × 1.0 lands on
  integer l, no fractional blending).
- Half-pitch interp: ω₀_curr / ω₀_prev = 0.5 → l=3 maps to prev
  pos 1.5, fractional blend (0.5 × prev[1] + 0.5 × prev[2]).
  Pins the fractional-index path.
- Beyond-PrevL clamp: positions past PrevL clamp to the last
  prev value so dst values for clamped harmonics agree.
- Silent frame: dst stays at sentinel 99 (caller short-circuit
  is observable).
- UpdateLog2Ml: writes ω₀ + L + log2(Ml) into prev state, zeros
  PrevLog2Ml past the new L (catches state-leak between
  shrinking-L frames).
- Reset: zeroes everything.
- Two-frame Predict→Update sequence: frame 2's prediction sees
  frame 1's log2(Ml) — the state machine threads correctly.
- Mean-centered Tl + arbitrary prev: sum(dst) = 0, confirming
  Tl is the only intentional offset.
- Full `go test ./...` green (excluding pre-existing rtlsdr CGO
  build failure unrelated to this change).

Stacks on #53 (claude/imbe-param-unpack-spectral) — base that PR
to land step 3b first.

https://claude.ai/code/session_01JmSJLqDwr8jLuKtbkzGXNE