### PR TITLE
Pure-Go IMBE step 4b: linear amp conversion + spectral moments

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,9 +84,13 @@ to its own package and lands independently.
   prediction (eqs. 75-77 — γ = 0.65 interpolation of prev-frame
   harmonics at l · ω₀_curr/ω₀_prev positions, DC-bias removal,
   Tl residual addition) is in on a `SynthState` that the
-  excitation step extends (`synth.go`). Currently still emits
-  silence per frame; follow-up PR lands voiced/unvoiced
-  excitation + spectral shaping + 8 kHz PCM synthesis (§6.2-6.4).
+  excitation step extends (`synth.go`); §6.2 amplitude prep
+  (log2(Ml) → linear Ml = 2^log2(Ml), the R_M0 = Σ Ml² and
+  R_M1 = Σ Ml² · cos(ω₀·l) spectral moments, and a voicing-fraction
+  summary that the synthesis combiner consumes) is in (`amps.go`).
+  Currently still emits silence per frame; follow-up PRs land the
+  voiced harmonic generator (§6.3), unvoiced FFT excitation (§6.4),
+  and the §6.2 enhancement + final PCM combine.
 - **DVSI USB-3000 / AMBE-3003 hardware backend.** A `Vocoder`
   factory that opens a connected DVSI USB chip. Same plug-in shape
   as `internal/voice/mbelib`; the daemon picks the factory by name

--- a/internal/voice/imbe/amps.go
+++ b/internal/voice/imbe/amps.go
@@ -1,0 +1,113 @@
+package imbe
+
+import "math"
+
+// IMBE 4400 amplitude prep — TIA-102.BABA §6.2 entry path.
+//
+// Step 4a (synth.go) recovers log2(Ml)[1..L]. Before §6.2's
+// spectral enhancement and §6.3 / §6.4's voiced + unvoiced
+// excitation can run, those log-amplitudes need to be exponentiated
+// to linear Ml, and the synthesizer needs cheap derived quantities
+// (R_M0 = Σ Ml² for energy + enhancement, Vl voicing fraction for
+// AGC + voice-activity hints).
+//
+// This file ships those utility primitives. The voiced harmonic
+// generator (§6.3) and unvoiced FFT excitation (§6.4) land in
+// follow-up PRs and consume what's here.
+
+// AmplitudesFromLog2Ml fills dst[1..L] with the linear spectral
+// amplitudes Ml[l] = 2^log2Ml[l]. Indices outside [1..L] are zeroed
+// so that downstream loops over dst don't pick up stale values from
+// a previous frame's longer L. dst[0] is unused per the project's
+// 1-indexed convention.
+//
+// log2Ml[l] is the eq. 77 output (recovered log-amplitude). When
+// l falls outside [1..L] the corresponding index in dst is forced
+// to 0 — this matters because synthesis loops sometimes iterate
+// over a fixed [1..56] range and rely on out-of-range entries
+// being inert.
+func AmplitudesFromLog2Ml(log2Ml *[57]float64, L int, dst *[57]float64) {
+	for l := 0; l <= 56; l++ {
+		dst[l] = 0
+	}
+	if L < 1 {
+		return
+	}
+	if L > 56 {
+		L = 56
+	}
+	for l := 1; l <= L; l++ {
+		dst[l] = math.Exp2(log2Ml[l])
+	}
+}
+
+// FrameEnergy returns R_M0 = Σ_{l=1..L} Ml[l]². This is the
+// numerator of the §6.2 spectral-amplitude enhancement weight and
+// — more practically for now — a per-frame energy estimate that
+// lets the recorder + AGC distinguish voice from silence without
+// waiting for the full synthesizer to produce PCM.
+//
+// Returns 0 for L < 1 so callers can pass a Silent frame's L
+// without an extra guard.
+func FrameEnergy(M *[57]float64, L int) float64 {
+	if L < 1 {
+		return 0
+	}
+	if L > 56 {
+		L = 56
+	}
+	var sum float64
+	for l := 1; l <= L; l++ {
+		sum += M[l] * M[l]
+	}
+	return sum
+}
+
+// VoicingFraction returns the fraction of voiced harmonics in
+// Vl[1..L] — Σ Vl[l] / L. Used as a coarse voiced/unvoiced hint
+// for the upcoming synthesis combiner: pure-tone speech reports
+// near 1.0, fricatives / silence near 0.0, ordinary voiced speech
+// somewhere in between.
+//
+// Returns 0 for L < 1 so callers can pass a Silent frame without
+// an extra guard. Vl entries outside {0, 1} count as zero — the
+// upstream unpacker only writes 0 or 1, so any other value is a
+// programming error and falls through to the safe default.
+func VoicingFraction(Vl *[57]int, L int) float64 {
+	if L < 1 {
+		return 0
+	}
+	if L > 56 {
+		L = 56
+	}
+	var voiced int
+	for l := 1; l <= L; l++ {
+		if Vl[l] == 1 {
+			voiced++
+		}
+	}
+	return float64(voiced) / float64(L)
+}
+
+// SpectralCosineSum returns R_M1 = Σ_{l=1..L} Ml[l]² · cos(ω₀ · l).
+// This is the second moment used by the §6.2 enhancement weight
+// (alongside R_M0 from FrameEnergy). Lives here rather than being
+// inlined into the enhancer so tests can pin its closed-form
+// value at known inputs and the enhancer stays a one-line
+// plumbing layer over R_M0 / R_M1 / ω₀ / l when it lands.
+//
+// Returns 0 for L < 1 so Silent frames pass through without a
+// guard.
+func SpectralCosineSum(M *[57]float64, L int, w0 float64) float64 {
+	if L < 1 {
+		return 0
+	}
+	if L > 56 {
+		L = 56
+	}
+	var sum float64
+	for l := 1; l <= L; l++ {
+		sum += M[l] * M[l] * math.Cos(w0*float64(l))
+	}
+	return sum
+}

--- a/internal/voice/imbe/amps_test.go
+++ b/internal/voice/imbe/amps_test.go
@@ -1,0 +1,269 @@
+package imbe
+
+import (
+	"math"
+	"testing"
+)
+
+func TestAmplitudesFromLog2MlZeroLogIsUnit(t *testing.T) {
+	var log2M [57]float64
+	for l := 1; l <= 30; l++ {
+		log2M[l] = 0
+	}
+	var dst [57]float64
+	AmplitudesFromLog2Ml(&log2M, 30, &dst)
+	for l := 1; l <= 30; l++ {
+		if !almostEqual(dst[l], 1.0) {
+			t.Errorf("dst[%d] = %v, want 1.0 (2^0)", l, dst[l])
+		}
+	}
+}
+
+func TestAmplitudesFromLog2MlPositivePowers(t *testing.T) {
+	var log2M [57]float64
+	log2M[1] = 1  // 2^1 = 2
+	log2M[2] = 2  // 2^2 = 4
+	log2M[3] = -1 // 2^-1 = 0.5
+	log2M[4] = -3 // 2^-3 = 0.125
+	var dst [57]float64
+	AmplitudesFromLog2Ml(&log2M, 4, &dst)
+	want := []float64{0, 2, 4, 0.5, 0.125}
+	for l := 1; l <= 4; l++ {
+		if !almostEqual(dst[l], want[l]) {
+			t.Errorf("dst[%d] = %v, want %v", l, dst[l], want[l])
+		}
+	}
+}
+
+// TestAmplitudesFromLog2MlClearsTail confirms that AmplitudesFromLog2Ml
+// zeroes the indices past L — the contract that lets synthesis loops
+// iterate over a fixed [1..56] range without reading stale values
+// from a previous frame's longer L.
+func TestAmplitudesFromLog2MlClearsTail(t *testing.T) {
+	var log2M [57]float64
+	dst := [57]float64{}
+	for i := range dst {
+		dst[i] = 999 // sentinel
+	}
+	AmplitudesFromLog2Ml(&log2M, 5, &dst)
+	for l := 6; l <= 56; l++ {
+		if dst[l] != 0 {
+			t.Errorf("dst[%d] = %v, want 0 (cleared past L=5)", l, dst[l])
+		}
+	}
+	if dst[0] != 0 {
+		t.Errorf("dst[0] = %v, want 0 (1-indexed convention)", dst[0])
+	}
+}
+
+// TestAmplitudesFromLog2MlSilentLPath: L < 1 should leave dst all-zero
+// (the function still scrubs the tail). Lets callers pass a Silent
+// frame's L = 0 without an extra guard.
+func TestAmplitudesFromLog2MlSilentLPath(t *testing.T) {
+	var log2M [57]float64
+	log2M[1] = 5 // arbitrary
+	dst := [57]float64{}
+	for i := range dst {
+		dst[i] = 999
+	}
+	AmplitudesFromLog2Ml(&log2M, 0, &dst)
+	for l := 0; l <= 56; l++ {
+		if dst[l] != 0 {
+			t.Errorf("dst[%d] = %v, want 0 (Silent path)", l, dst[l])
+		}
+	}
+}
+
+// TestAmplitudesFromLog2MlClampsHighL: an L > 56 (caller bug or
+// future-proofing) should clamp at 56, not blow past the array
+// bounds. The struct extents are pinned at [57] so this protects
+// the contract.
+func TestAmplitudesFromLog2MlClampsHighL(t *testing.T) {
+	var log2M [57]float64
+	for l := 1; l <= 56; l++ {
+		log2M[l] = 0 // → 1.0
+	}
+	var dst [57]float64
+	AmplitudesFromLog2Ml(&log2M, 99, &dst)
+	for l := 1; l <= 56; l++ {
+		if !almostEqual(dst[l], 1.0) {
+			t.Errorf("dst[%d] = %v, want 1.0 (L clamped to 56)", l, dst[l])
+		}
+	}
+}
+
+func TestFrameEnergyUnitAmplitudesEqualsL(t *testing.T) {
+	var M [57]float64
+	for l := 1; l <= 20; l++ {
+		M[l] = 1.0
+	}
+	got := FrameEnergy(&M, 20)
+	if !almostEqual(got, 20.0) {
+		t.Errorf("FrameEnergy = %v, want 20.0 (unit Ml × L=20)", got)
+	}
+}
+
+func TestFrameEnergyKnownValues(t *testing.T) {
+	var M [57]float64
+	M[1] = 1
+	M[2] = 2
+	M[3] = 3
+	got := FrameEnergy(&M, 3)
+	want := 1.0 + 4.0 + 9.0
+	if !almostEqual(got, want) {
+		t.Errorf("FrameEnergy = %v, want %v", got, want)
+	}
+}
+
+func TestFrameEnergyIgnoresPastL(t *testing.T) {
+	var M [57]float64
+	M[1] = 1
+	M[2] = 1
+	M[3] = 99 // should be ignored
+	got := FrameEnergy(&M, 2)
+	if !almostEqual(got, 2.0) {
+		t.Errorf("FrameEnergy = %v, want 2.0 (M[3] past L)", got)
+	}
+}
+
+func TestFrameEnergyZeroL(t *testing.T) {
+	var M [57]float64
+	M[1] = 99
+	if got := FrameEnergy(&M, 0); got != 0 {
+		t.Errorf("FrameEnergy(L=0) = %v, want 0", got)
+	}
+}
+
+func TestVoicingFractionAllVoiced(t *testing.T) {
+	var Vl [57]int
+	for l := 1; l <= 12; l++ {
+		Vl[l] = 1
+	}
+	got := VoicingFraction(&Vl, 12)
+	if !almostEqual(got, 1.0) {
+		t.Errorf("VoicingFraction = %v, want 1.0", got)
+	}
+}
+
+func TestVoicingFractionAllUnvoiced(t *testing.T) {
+	var Vl [57]int
+	got := VoicingFraction(&Vl, 12)
+	if got != 0 {
+		t.Errorf("VoicingFraction = %v, want 0", got)
+	}
+}
+
+func TestVoicingFractionMixed(t *testing.T) {
+	var Vl [57]int
+	// 4 voiced of 10 → 0.4
+	Vl[1] = 1
+	Vl[3] = 1
+	Vl[5] = 1
+	Vl[7] = 1
+	got := VoicingFraction(&Vl, 10)
+	if !almostEqual(got, 0.4) {
+		t.Errorf("VoicingFraction = %v, want 0.4", got)
+	}
+}
+
+func TestVoicingFractionIgnoresPastL(t *testing.T) {
+	var Vl [57]int
+	Vl[1] = 1
+	Vl[2] = 1
+	Vl[3] = 1 // past L
+	got := VoicingFraction(&Vl, 2)
+	if !almostEqual(got, 1.0) {
+		t.Errorf("VoicingFraction = %v, want 1.0 (Vl[3] past L)", got)
+	}
+}
+
+func TestVoicingFractionZeroL(t *testing.T) {
+	var Vl [57]int
+	Vl[1] = 1
+	if got := VoicingFraction(&Vl, 0); got != 0 {
+		t.Errorf("VoicingFraction(L=0) = %v, want 0", got)
+	}
+}
+
+// TestVoicingFractionRejectsBogusVl: Vl entries outside {0, 1} count
+// as zero (defensive — upstream only writes 0/1, so anything else
+// is a programming bug and we fail closed rather than over-counting).
+func TestVoicingFractionRejectsBogusVl(t *testing.T) {
+	var Vl [57]int
+	Vl[1] = 2 // bogus
+	Vl[2] = -1
+	Vl[3] = 1
+	got := VoicingFraction(&Vl, 3)
+	if !almostEqual(got, 1.0/3.0) {
+		t.Errorf("VoicingFraction = %v, want 1/3 (bogus Vl ignored)", got)
+	}
+}
+
+// TestSpectralCosineSumAtZeroOmega: ω₀ = 0 ⇒ cos(0) = 1 ⇒ R_M1
+// equals R_M0. A handy degeneracy check for the §6.2 weight
+// formula — the enhancement weight collapses cleanly at the limit.
+func TestSpectralCosineSumAtZeroOmega(t *testing.T) {
+	var M [57]float64
+	for l := 1; l <= 5; l++ {
+		M[l] = float64(l) // 1, 2, 3, 4, 5
+	}
+	rm0 := FrameEnergy(&M, 5)
+	rm1 := SpectralCosineSum(&M, 5, 0)
+	if !almostEqual(rm0, rm1) {
+		t.Errorf("R_M0 = %v, R_M1 = %v at ω₀=0; want equal", rm0, rm1)
+	}
+}
+
+// TestSpectralCosineSumAtPiOmega: ω₀ = π ⇒ cos(πl) alternates
+// (-1)^l ⇒ R_M1 = Σ Ml² · (-1)^l. With M[l] = 1 for l in 1..4,
+// R_M1 = -1 + 1 - 1 + 1 = 0. Pins the alternating-cosine path.
+func TestSpectralCosineSumAtPiOmega(t *testing.T) {
+	var M [57]float64
+	for l := 1; l <= 4; l++ {
+		M[l] = 1
+	}
+	got := SpectralCosineSum(&M, 4, math.Pi)
+	if !almostEqual(got, 0) {
+		t.Errorf("R_M1 = %v, want 0 (alternating with even count)", got)
+	}
+}
+
+func TestSpectralCosineSumZeroL(t *testing.T) {
+	var M [57]float64
+	M[1] = 99
+	if got := SpectralCosineSum(&M, 0, 1.0); got != 0 {
+		t.Errorf("SpectralCosineSum(L=0) = %v, want 0", got)
+	}
+}
+
+// TestEndToEndPathFromTl: integration between the just-shipped
+// step 4a (PredictLog2Ml) and this step's helpers. A first frame
+// with Tl[l] = log2(l+1) goes through PredictLog2Ml (no prev-state
+// shortcut) → AmplitudesFromLog2Ml → FrameEnergy. Confirms the
+// pipeline shape the synthesizer will use one frame at a time.
+func TestEndToEndPathFromTl(t *testing.T) {
+	var s SynthState
+	p := Params{Header: Header{W0: math.Pi / 30, L: 4, K: 2}}
+	for l := 1; l <= p.L; l++ {
+		p.Tl[l] = math.Log2(float64(l + 1))
+	}
+	var log2M [57]float64
+	PredictLog2Ml(&s, p, &log2M)
+
+	var M [57]float64
+	AmplitudesFromLog2Ml(&log2M, p.L, &M)
+
+	want := []float64{0, 2, 3, 4, 5}
+	for l := 1; l <= p.L; l++ {
+		if !almostEqual(M[l], want[l]) {
+			t.Errorf("M[%d] = %v, want %v (2^Tl[%d] for first frame)",
+				l, M[l], want[l], l)
+		}
+	}
+
+	// Energy = 4 + 9 + 16 + 25 = 54
+	got := FrameEnergy(&M, p.L)
+	if !almostEqual(got, 54) {
+		t.Errorf("FrameEnergy = %v, want 54", got)
+	}
+}

--- a/internal/voice/imbe/doc.go
+++ b/internal/voice/imbe/doc.go
@@ -49,18 +49,35 @@
 //     log2Ml prediction (eq. 75-77) needs prev-frame state and
 //     lives in the synthesizer (step 4a).
 //
-//  4a. Speech synthesis — cross-frame log-amplitude recovery. ← THIS PR.
+//  4a. Speech synthesis — cross-frame log-amplitude recovery.
 //     TIA-102.BABA §6.1 eqs. 75-77: predict at curr-frame harmonic
 //     positions by interpolating prev-frame log2(Ml) at l ·
 //     ω₀_curr/ω₀_prev (γ = 0.65 scale), subtract the prediction's
 //     DC bias, then add Tl[l]. Lives on a SynthState that the
-//     synthesizer (step 4b) extends with voicing + phase memory.
+//     synthesizer (step 4c) extends with voicing + phase memory.
 //     See synth.go.
 //
-//  4b. Speech synthesis — excitation + PCM. Voiced harmonic sum +
-//     unvoiced random excitation + spectral-amplitude shaping →
-//     160 PCM samples / 20 ms / 8 kHz mono per frame. Per
-//     TIA-102.BABA §6.2-6.4.
+//  4b. Speech synthesis — amplitude prep. ← THIS PR.
+//     log2(Ml) → linear Ml = 2^log2(Ml), the spectral moments
+//     R_M0 = Σ Ml² and R_M1 = Σ Ml² · cos(ω₀·l) feeding §6.2
+//     enhancement, and a voicing-fraction summary used as a
+//     coarse voiced/unvoiced hint by the upcoming synthesis
+//     combiner. See amps.go.
+//
+//  4c. Speech synthesis — voiced harmonic generator. For each
+//     Vl[l] = 1 harmonic, a sinusoid at l · ω₀ with phase
+//     continuity across frames + linear amplitude tilt between
+//     prev-frame Ml and curr-frame Ml over the 160-sample frame.
+//     TIA-102.BABA §6.3.
+//
+//  4d. Speech synthesis — unvoiced excitation. White-noise
+//     spectrum shaped by the unvoiced bands of Ml, IFFT, overlap-add
+//     window. TIA-102.BABA §6.4.
+//
+//  4e. Speech synthesis — combine + final PCM. §6.2 spectral
+//     amplitude enhancement (R_M0 / R_M1 / ω₀ closed form), voiced
+//     + unvoiced sum, hard-clip to int16, → 160 PCM samples /
+//     20 ms / 8 kHz mono per frame.
 //
 //  5. Quality polish: enhancement filter, frame-repeat on bad-frame
 //     indicator, gain smoothing across frames.


### PR DESCRIPTION
## Summary
Seventh PR in the IMBE 4400 thread (after merged #49 skeleton, #50 per-vector FEC, #51 PRBS scrambler, #52 header, #53 spectral unpack, #54 cross-frame log2(Ml) prediction). Lands the amplitude prep layer between §6.1 prediction (step 4a) and §6.2-6.4 synthesis (steps 4c-4e):

- **log2(Ml) → linear Ml** exponentiation, with a tail-clear contract so synthesis loops over a fixed `[1..56]` range don't pick up stale values from a previous frame's longer L.
- **R_M0 = Σ Ml²** spectral moment — numerator of the §6.2 enhancement weight + per-frame energy estimate the recorder + AGC can use to distinguish voice from silence without waiting for the full synthesizer.
- **R_M1 = Σ Ml² · cos(ω₀·l)** spectral moment — lives here so the §6.2 enhancer stays a one-line plumbing layer over R_M0 / R_M1 / ω₀ when it lands.
- **VoicingFraction(Vl, L)** — coarse voiced/unvoiced hint for the synthesis combiner. Pure-tone speech ≈ 1.0, fricatives / silence ≈ 0.0.

Self-contained — no `SynthState` changes, no behavior changes for the registered `imbe-go` decoder (still emits silence). Unblocks 4c (voiced harmonic generator) and 4e (§6.2 enhancement) by giving them a tested utility surface to build on.

## Changes
- **`internal/voice/imbe/amps.go`** (new) — `AmplitudesFromLog2Ml`, `FrameEnergy`, `SpectralCosineSum`, `VoicingFraction`. All defensively handle `L < 1` (Silent path) and `L > 56` (clamp).
- **`internal/voice/imbe/doc.go`** — roadmap step 4 split from one catch-all into 4a (shipped) / 4b (this) / 4c voiced generator (§6.3) / 4d unvoiced excitation (§6.4) / 4e §6.2 enhancement + final PCM combine.
- **`README.md`** — pure-Go IMBE roadmap entry now lists §6.2 amplitude prep alongside the prediction layer; follow-up scope narrows to voiced + unvoiced excitation + final enhancement and PCM combine.

## Test plan
- [x] `AmplitudesFromLog2Ml`: zero log → unit Ml; positive + negative log values give 2^x; tail past L cleared even when input had sentinels; L = 0 zeroes everything (Silent path); L > 56 clamps without OOB.
- [x] `FrameEnergy`: unit amplitudes × L = L; Σ M² closed form on `{1, 2, 3}` → 14; ignores entries past L; L = 0 returns 0.
- [x] `VoicingFraction`: all-voiced = 1.0; all-unvoiced = 0; mixed 4-of-10 = 0.4; entries past L ignored; bogus Vl values (2, -1) treated as zero — fail closed rather than over-counting.
- [x] `SpectralCosineSum`: ω₀ = 0 ⇒ R_M1 = R_M0 (cos(0) = 1 degeneracy); ω₀ = π with M[1..4] = 1 ⇒ R_M1 = -1 + 1 - 1 + 1 = 0 (alternating-cosine path); L = 0 returns 0.
- [x] End-to-end `PredictLog2Ml` → `AmplitudesFromLog2Ml` → `FrameEnergy`: fresh-frame Tl[l] = log2(l+1) gives M[l] = l+1 and energy = 4+9+16+25 = 54. Pins the pipeline shape the synthesizer will use.
- [x] Full `go test ./...` green (rtlsdr CGO build failure is a pre-existing environment issue — librtlsdr not installed — unrelated to this change).

---
_Generated by [Claude Code](https://claude.ai/code/session_01JmSJLqDwr8jLuKtbkzGXNE)_