### PR TITLE
Pure-Go IMBE step 4c: voiced harmonic generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,10 +87,16 @@ to its own package and lands independently.
   excitation step extends (`synth.go`); §6.2 amplitude prep
   (log2(Ml) → linear Ml = 2^log2(Ml), the R_M0 = Σ Ml² and
   R_M1 = Σ Ml² · cos(ω₀·l) spectral moments, and a voicing-fraction
-  summary that the synthesis combiner consumes) is in (`amps.go`).
-  Currently still emits silence per frame; follow-up PRs land the
-  voiced harmonic generator (§6.3), unvoiced FFT excitation (§6.4),
-  and the §6.2 enhancement + final PCM combine.
+  summary that the synthesis combiner consumes) is in (`amps.go`);
+  §6.3 voiced harmonic generator (per-harmonic sinusoid at l · ω₀
+  with linear amp tilt M_prev → M_curr + quadratic phase
+  integration of the ω₀ drift, dual-frame iteration so
+  voiced↔unvoiced transitions fade in / out cleanly) is in
+  (`synth_voiced.go`, `SynthState` extended with `PrevPhase` +
+  `PrevMl`). Currently still emits silence per frame because the
+  decoder hasn't been wired through the synthesis chain yet;
+  follow-up PRs land the unvoiced FFT excitation (§6.4) and the
+  §6.2 enhancement + final PCM combine.
 - **DVSI USB-3000 / AMBE-3003 hardware backend.** A `Vocoder`
   factory that opens a connected DVSI USB chip. Same plug-in shape
   as `internal/voice/mbelib`; the daemon picks the factory by name

--- a/internal/voice/imbe/doc.go
+++ b/internal/voice/imbe/doc.go
@@ -64,11 +64,15 @@
 //     coarse voiced/unvoiced hint by the upcoming synthesis
 //     combiner. See amps.go.
 //
-//  4c. Speech synthesis — voiced harmonic generator. For each
-//     Vl[l] = 1 harmonic, a sinusoid at l · ω₀ with phase
-//     continuity across frames + linear amplitude tilt between
-//     prev-frame Ml and curr-frame Ml over the 160-sample frame.
-//     TIA-102.BABA §6.3.
+//  4c. Speech synthesis — voiced harmonic generator. ← THIS PR.
+//     For each harmonic that's voiced this frame OR was voiced
+//     last frame, a sinusoid at l · ω₀ with linear amplitude tilt
+//     between M_prev[l] and M_curr[l] across 160 samples + a
+//     quadratic phase term that integrates the linear ω₀ drift.
+//     The dual-frame iteration gives clean fade-in / fade-out on
+//     voicing transitions without click artifacts. SynthState
+//     gains PrevPhase + PrevMl for the cross-frame continuity.
+//     TIA-102.BABA §6.3. See synth_voiced.go.
 //
 //  4d. Speech synthesis — unvoiced excitation. White-noise
 //     spectrum shaped by the unvoiced bands of Ml, IFFT, overlap-add

--- a/internal/voice/imbe/synth.go
+++ b/internal/voice/imbe/synth.go
@@ -26,7 +26,9 @@ const PredictionGain = 0.65
 
 // SynthState carries inter-frame memory needed by the synthesizer.
 // Step 4a uses PrevW0 / PrevL / PrevLog2Ml for the eq. 75-77
-// log-amplitude prediction; step 4b adds voicing + phase memory.
+// log-amplitude prediction; step 4c adds PrevMl + PrevPhase for the
+// §6.3 voiced harmonic generator (linear-amp tilt + quadratic-phase
+// continuity).
 //
 // Zero value is the "fresh stream / no prev frame" starting state —
 // what the decoder presents to the first IMBE frame on a call.
@@ -35,6 +37,8 @@ type SynthState struct {
 	PrevW0     float64    // ω₀ from the previous decoded frame (rad/sample); 0 ⇒ no prev frame
 	PrevL      int        // L from the previous decoded frame (1-indexed slice extent)
 	PrevLog2Ml [57]float64 // log2(Ml) at indices [1..PrevL]; [0] + tail unused
+	PrevMl     [57]float64 // linear Ml at end of prev frame; 0 if was unvoiced / absent
+	PrevPhase  [57]float64 // accumulated phase per harmonic in [0, 2π)
 }
 
 // Reset clears all inter-frame memory. Callers invoke it on stream

--- a/internal/voice/imbe/synth_voiced.go
+++ b/internal/voice/imbe/synth_voiced.go
@@ -1,0 +1,155 @@
+package imbe
+
+import "math"
+
+// IMBE 4400 voiced harmonic generator — TIA-102.BABA §6.3.
+//
+// Step 4a recovered log2(Ml) from cross-frame prediction; step 4b
+// converted that to linear Ml. This step turns those amplitudes
+// into the voiced portion of the 8 kHz output PCM by summing one
+// sinusoid per voiced harmonic, with phase + amplitude continuity
+// across frame boundaries.
+//
+// The §6.3 model for one frame of length N = SamplesPerFrame = 160:
+//
+//	a(n) = (1 − n/N) · M_prev[l] + (n/N) · M_curr[l]                   (eq. 88)
+//	θ(n) = θ_prev[l] + n · l · ω₀_prev + l · (ω₀_curr − ω₀_prev) · n²/(2N)
+//	s_v(n) = Σ_{l: voiced this or last frame} a(n) · cos(θ(n))         (eq. 89)
+//
+// M_prev[l] is the prev-frame linear amplitude (0 if the harmonic
+// was unvoiced or the stream just started); M_curr[l] is the
+// current-frame linear amplitude (0 if currently unvoiced). This
+// dual-frame iteration gives a clean fade-in on unvoiced→voiced
+// transitions and a fade-out on voiced→unvoiced transitions
+// without click artifacts.
+//
+// On the first frame (s.PrevW0 == 0) the prev-ω₀ collapses to the
+// curr-ω₀ so the quadratic phase term is zero — the harmonic
+// starts at its target frequency, no synthetic frequency sweep.
+//
+// Algorithmic reference: TIA-102.BABA §6.3 + szechyjs/mbelib's
+// voiced-synthesis loop (ISC-licensed; attribution preserved at
+// the bottom of tables.go).
+
+// SynthVoiced fills dst[0..N−1] (N = SamplesPerFrame = 160) with the
+// voiced contribution for the current frame, summed across every
+// harmonic that's voiced this frame OR was voiced last frame
+// (the latter for fade-out continuity).
+//
+// dst must have length >= SamplesPerFrame; the function adds to
+// existing values rather than overwriting so the caller can sum
+// the unvoiced step's output (4d) into the same buffer. The
+// function does not allocate.
+//
+// SynthVoiced does not mutate s — callers invoke
+// (s).UpdateVoicedState afterward to roll phase + amplitude
+// memory forward for the next frame.
+//
+// Silence + zero-L frames short-circuit (dst left as the caller
+// initialized it). The caller is expected to have called
+// (s).Reset() first on a Silent frame so the next non-silent
+// frame starts from a clean state.
+func SynthVoiced(s *SynthState, p Params, M *[57]float64, dst []float64) {
+	if p.Silent || p.L == 0 {
+		return
+	}
+	if len(dst) < SamplesPerFrame {
+		return
+	}
+
+	// Effective prev ω₀: a fresh-stream first frame uses the curr
+	// ω₀ so the quadratic phase term collapses to zero.
+	prevW0 := s.PrevW0
+	if prevW0 == 0 {
+		prevW0 = p.W0
+	}
+
+	Lmax := p.L
+	if s.PrevL > Lmax {
+		Lmax = s.PrevL
+	}
+	if Lmax > 56 {
+		Lmax = 56
+	}
+
+	const N = SamplesPerFrame
+	const invN = 1.0 / float64(N)
+	const invDoubleN = 1.0 / (2 * float64(N))
+
+	for l := 1; l <= Lmax; l++ {
+		prevAmp := s.PrevMl[l]
+		var currAmp float64
+		if l <= p.L && p.Vl[l] == 1 {
+			currAmp = M[l]
+		}
+		if prevAmp == 0 && currAmp == 0 {
+			continue
+		}
+
+		lf := float64(l)
+		thetaBase := s.PrevPhase[l]
+		// Linear phase coefficient (n^1) and quadratic (n^2):
+		//   θ(n) = θ₀ + a·n + b·n²
+		// a = l · ω_prev, b = l · (ω_curr − ω_prev) / (2N)
+		a := lf * prevW0
+		b := lf * (p.W0 - prevW0) * invDoubleN
+		dAmp := currAmp - prevAmp
+		for n := 0; n < N; n++ {
+			nf := float64(n)
+			amp := prevAmp + dAmp*(nf*invN)
+			phase := thetaBase + a*nf + b*nf*nf
+			dst[n] += amp * math.Cos(phase)
+		}
+	}
+}
+
+// UpdateVoicedState rolls the per-harmonic synthesis memory forward
+// by the closed-form average-frequency phase increment
+//
+//	Δθ_l = N · l · (ω_prev + ω_curr) / 2
+//
+// (the integral of the linear-frequency tilt over n=[0..N], so the
+// next frame's θ_prev[l] equals what θ(n=N) would have been on this
+// frame), wraps it into [0, 2π), and stores the current-frame
+// linear amplitudes in PrevMl (zeroed for harmonics that are
+// unvoiced this frame, so the next frame's fade-in math sees a
+// clean zero baseline).
+//
+// Silence + zero-L frames are a no-op so callers can invoke this
+// unconditionally on the synthesis path.
+func (s *SynthState) UpdateVoicedState(p Params, M *[57]float64) {
+	if p.Silent || p.L == 0 {
+		return
+	}
+	prevW0 := s.PrevW0
+	if prevW0 == 0 {
+		prevW0 = p.W0
+	}
+
+	Lmax := p.L
+	if s.PrevL > Lmax {
+		Lmax = s.PrevL
+	}
+	if Lmax > 56 {
+		Lmax = 56
+	}
+
+	const halfN = float64(SamplesPerFrame) * 0.5
+	const twoPi = 2 * math.Pi
+
+	var newPrevPhase, newPrevMl [57]float64
+	for l := 1; l <= Lmax; l++ {
+		lf := float64(l)
+		delta := lf * (prevW0 + p.W0) * halfN
+		ph := math.Mod(s.PrevPhase[l]+delta, twoPi)
+		if ph < 0 {
+			ph += twoPi
+		}
+		newPrevPhase[l] = ph
+		if l <= p.L && p.Vl[l] == 1 {
+			newPrevMl[l] = M[l]
+		}
+	}
+	s.PrevPhase = newPrevPhase
+	s.PrevMl = newPrevMl
+}

--- a/internal/voice/imbe/synth_voiced_test.go
+++ b/internal/voice/imbe/synth_voiced_test.go
@@ -1,0 +1,375 @@
+package imbe
+
+import (
+	"math"
+	"testing"
+)
+
+const synthEpsilon = 1e-9
+
+// TestSynthVoicedFreshStreamUnvoiced: a fresh-state frame with no
+// voiced harmonics produces a fully-silent voiced contribution.
+// Pins the "no spurious carrier on the first frame" invariant.
+func TestSynthVoicedFreshStreamUnvoiced(t *testing.T) {
+	var s SynthState
+	p := Params{Header: Header{W0: math.Pi / 30, L: 10, K: 4}}
+	// All Vl[l] = 0 (default). M is irrelevant when unvoiced.
+	var M [57]float64
+	dst := make([]float64, SamplesPerFrame)
+	SynthVoiced(&s, p, &M, dst)
+	for n, v := range dst {
+		if v != 0 {
+			t.Errorf("dst[%d] = %v, want 0 (no voiced harmonics)", n, v)
+		}
+	}
+}
+
+// TestSynthVoicedFreshStreamSingleHarmonic: with prev_amp = 0,
+// curr_amp = 1, a single voiced harmonic l = 1 at constant ω₀
+// produces a ramping cos(l·ω₀·n) with linear amp tilt 0 → 1 across
+// the frame. Pins the fade-in path on a fresh stream.
+func TestSynthVoicedFreshStreamSingleHarmonic(t *testing.T) {
+	var s SynthState
+	w0 := math.Pi / 30
+	p := Params{Header: Header{W0: w0, L: 1, K: 1}}
+	p.Vl[1] = 1
+	var M [57]float64
+	M[1] = 1.0
+	dst := make([]float64, SamplesPerFrame)
+	SynthVoiced(&s, p, &M, dst)
+
+	N := float64(SamplesPerFrame)
+	for n := 0; n < SamplesPerFrame; n++ {
+		nf := float64(n)
+		amp := nf / N
+		phase := w0 * nf // prevW0 == w0 (fresh-stream collapse), quadratic term zero
+		want := amp * math.Cos(phase)
+		if math.Abs(dst[n]-want) > synthEpsilon {
+			t.Fatalf("dst[%d] = %v, want %v (fade-in cos at l=1)", n, dst[n], want)
+		}
+	}
+}
+
+// TestSynthVoicedSteadyState: when prev_amp = curr_amp = 1 and ω₀
+// is steady, the output is a pure cos(l·ω₀·n) sinusoid (the linear
+// amp tilt collapses to a constant 1). Pins the steady-state path.
+func TestSynthVoicedSteadyState(t *testing.T) {
+	w0 := math.Pi / 30
+	s := SynthState{
+		PrevW0:    w0,
+		PrevL:     1,
+		PrevPhase: [57]float64{},
+		PrevMl:    [57]float64{},
+	}
+	s.PrevMl[1] = 1.0
+	p := Params{Header: Header{W0: w0, L: 1, K: 1}}
+	p.Vl[1] = 1
+	var M [57]float64
+	M[1] = 1.0
+	dst := make([]float64, SamplesPerFrame)
+	SynthVoiced(&s, p, &M, dst)
+
+	for n := 0; n < SamplesPerFrame; n++ {
+		want := math.Cos(w0 * float64(n))
+		if math.Abs(dst[n]-want) > synthEpsilon {
+			t.Fatalf("dst[%d] = %v, want %v (steady cos)", n, dst[n], want)
+		}
+	}
+}
+
+// TestSynthVoicedFadeOut: a harmonic that was voiced last frame but
+// is unvoiced now fades from prev_amp → 0 across the frame. The
+// curr_amp = 0 case must still synthesize so the fade-out is
+// audible (no click on voiced→unvoiced transitions).
+func TestSynthVoicedFadeOut(t *testing.T) {
+	w0 := math.Pi / 30
+	s := SynthState{PrevW0: w0, PrevL: 1}
+	s.PrevMl[1] = 1.0
+	p := Params{Header: Header{W0: w0, L: 1, K: 1}}
+	// Vl[1] = 0 — curr unvoiced.
+	var M [57]float64
+	dst := make([]float64, SamplesPerFrame)
+	SynthVoiced(&s, p, &M, dst)
+
+	N := float64(SamplesPerFrame)
+	for n := 0; n < SamplesPerFrame; n++ {
+		nf := float64(n)
+		amp := 1.0 - nf/N // ramp 1 → ~0
+		want := amp * math.Cos(w0*nf)
+		if math.Abs(dst[n]-want) > synthEpsilon {
+			t.Fatalf("dst[%d] = %v, want %v (fade-out)", n, dst[n], want)
+		}
+	}
+}
+
+// TestSynthVoicedPhaseContinuity: synth two frames back-to-back
+// with the same ω₀ + voicing + amplitude, confirm the phase
+// at the start of frame 2 equals what θ(N) would have been on
+// frame 1 (no phase discontinuity at the boundary).
+func TestSynthVoicedPhaseContinuity(t *testing.T) {
+	var s SynthState
+	w0 := math.Pi / 17 // not a clean divisor of 2π so phase wrap is non-trivial
+	p := Params{Header: Header{W0: w0, L: 1, K: 1}}
+	p.Vl[1] = 1
+	var M [57]float64
+	M[1] = 1.0
+
+	dst1 := make([]float64, SamplesPerFrame)
+	SynthVoiced(&s, p, &M, dst1)
+	s.PrevW0 = p.W0
+	s.PrevL = p.L
+	s.UpdateVoicedState(p, &M)
+
+	dst2 := make([]float64, SamplesPerFrame)
+	SynthVoiced(&s, p, &M, dst2)
+
+	// Frame 1's last sample at n=N-1 has amp=(N-1)/N and phase=w0·(N-1).
+	// Frame 2's first sample at n=0 has amp=prevAmp=1 and phase=θ_prev.
+	// θ_prev = N · w0 (closed-form integral). So expected dst2[0]:
+	wantStart := math.Cos(w0 * float64(SamplesPerFrame))
+	if math.Abs(dst2[0]-wantStart) > synthEpsilon {
+		t.Errorf("frame 2 dst[0] = %v, want %v (phase continuity)",
+			dst2[0], wantStart)
+	}
+
+	// More generally, frame 2 sample n is cos(w0 · (N + n)) at amp 1.
+	for n := 0; n < SamplesPerFrame; n++ {
+		want := math.Cos(w0 * float64(SamplesPerFrame+n))
+		if math.Abs(dst2[n]-want) > 1e-7 {
+			t.Fatalf("frame 2 dst[%d] = %v, want %v", n, dst2[n], want)
+		}
+	}
+}
+
+// TestSynthVoicedMultiHarmonicSum: two voiced harmonics produce the
+// linear sum of their individual sinusoids. Pins the additive
+// contribution + the harmonic frequency relationship (l · ω₀).
+func TestSynthVoicedMultiHarmonicSum(t *testing.T) {
+	w0 := math.Pi / 30
+	s := SynthState{PrevW0: w0, PrevL: 2}
+	s.PrevMl[1] = 1.0
+	s.PrevMl[2] = 0.5
+	p := Params{Header: Header{W0: w0, L: 2, K: 1}}
+	p.Vl[1] = 1
+	p.Vl[2] = 1
+	var M [57]float64
+	M[1] = 1.0
+	M[2] = 0.5
+	dst := make([]float64, SamplesPerFrame)
+	SynthVoiced(&s, p, &M, dst)
+
+	for n := 0; n < SamplesPerFrame; n++ {
+		nf := float64(n)
+		want := 1.0*math.Cos(w0*nf) + 0.5*math.Cos(2*w0*nf)
+		if math.Abs(dst[n]-want) > synthEpsilon {
+			t.Fatalf("dst[%d] = %v, want %v (sum of two cosines)", n, dst[n], want)
+		}
+	}
+}
+
+// TestSynthVoicedQuadraticPhase: when ω₀ changes between frames,
+// the phase tilts quadratically across the frame. Verify at
+// n = N/2 the phase equals θ_prev + a·N/2 + b·(N/2)².
+func TestSynthVoicedQuadraticPhase(t *testing.T) {
+	wPrev := math.Pi / 30
+	wCurr := math.Pi / 15 // doubled
+	s := SynthState{PrevW0: wPrev, PrevL: 1}
+	s.PrevMl[1] = 1.0
+	p := Params{Header: Header{W0: wCurr, L: 1, K: 1}}
+	p.Vl[1] = 1
+	var M [57]float64
+	M[1] = 1.0
+	dst := make([]float64, SamplesPerFrame)
+	SynthVoiced(&s, p, &M, dst)
+
+	N := float64(SamplesPerFrame)
+	a := wPrev
+	b := (wCurr - wPrev) / (2 * N)
+	for _, n := range []int{0, 40, 80, 120, 159} {
+		nf := float64(n)
+		phase := a*nf + b*nf*nf
+		want := math.Cos(phase) // amp = 1 (steady prev=curr=1)
+		if math.Abs(dst[n]-want) > synthEpsilon {
+			t.Errorf("dst[%d] = %v, want %v (quadratic phase)", n, dst[n], want)
+		}
+	}
+}
+
+// TestSynthVoicedAddsToExistingDst: the function adds rather than
+// overwrites so the unvoiced step (4d) can sum into the same buffer.
+func TestSynthVoicedAddsToExistingDst(t *testing.T) {
+	var s SynthState
+	w0 := math.Pi / 30
+	p := Params{Header: Header{W0: w0, L: 1, K: 1}}
+	p.Vl[1] = 1
+	var M [57]float64
+	M[1] = 1.0
+	dst := make([]float64, SamplesPerFrame)
+	for n := range dst {
+		dst[n] = 7 // sentinel
+	}
+	SynthVoiced(&s, p, &M, dst)
+	// dst[0] = 7 + (0/N) · cos(0) = 7 + 0 = 7 (fade-in starts at zero amp).
+	if math.Abs(dst[0]-7) > synthEpsilon {
+		t.Errorf("dst[0] = %v, want 7 (sum into sentinel, amp=0 at n=0)", dst[0])
+	}
+	// dst[N-1] = 7 + (159/N) · cos(w0·159).
+	N := float64(SamplesPerFrame)
+	wantTail := 7.0 + (float64(SamplesPerFrame-1)/N)*math.Cos(w0*float64(SamplesPerFrame-1))
+	if math.Abs(dst[SamplesPerFrame-1]-wantTail) > synthEpsilon {
+		t.Errorf("dst[N-1] = %v, want %v (sum into sentinel)",
+			dst[SamplesPerFrame-1], wantTail)
+	}
+}
+
+// TestSynthVoicedSilentFrameLeavesDstUntouched: silent frames
+// short-circuit; dst keeps its prior contents. Caller is expected
+// to Reset() s on the silence indicator.
+func TestSynthVoicedSilentFrameLeavesDstUntouched(t *testing.T) {
+	var s SynthState
+	p := Params{Header: Header{Silent: true}}
+	var M [57]float64
+	dst := make([]float64, SamplesPerFrame)
+	for n := range dst {
+		dst[n] = 42
+	}
+	SynthVoiced(&s, p, &M, dst)
+	for n, v := range dst {
+		if v != 42 {
+			t.Errorf("dst[%d] = %v, want 42 (silent short-circuit)", n, v)
+		}
+	}
+}
+
+// TestSynthVoicedShortDstNoPanic: passing dst shorter than
+// SamplesPerFrame returns early without writing or panicking. Lets
+// callers fail-fast in unit tests without crashing the daemon.
+func TestSynthVoicedShortDstNoPanic(t *testing.T) {
+	var s SynthState
+	p := Params{Header: Header{W0: math.Pi / 30, L: 1, K: 1}}
+	p.Vl[1] = 1
+	var M [57]float64
+	M[1] = 1.0
+	dst := make([]float64, 100)
+	for n := range dst {
+		dst[n] = -1
+	}
+	SynthVoiced(&s, p, &M, dst)
+	for n, v := range dst {
+		if v != -1 {
+			t.Errorf("dst[%d] = %v, want -1 (short-buffer no-op)", n, v)
+		}
+	}
+}
+
+// TestUpdateVoicedStateAdvancesPhase: the phase increment is the
+// closed-form integral N · l · (ω_prev + ω_curr) / 2. Pins the
+// algebra without depending on SynthVoiced.
+func TestUpdateVoicedStateAdvancesPhase(t *testing.T) {
+	wPrev := 0.1
+	wCurr := 0.2
+	s := SynthState{PrevW0: wPrev, PrevL: 2, PrevPhase: [57]float64{0, 1.0, 0.5}}
+	p := Params{Header: Header{W0: wCurr, L: 2, K: 1}}
+	p.Vl[1] = 1
+	p.Vl[2] = 1
+	var M [57]float64
+	M[1] = 0.7
+	M[2] = 0.3
+	s.UpdateVoicedState(p, &M)
+
+	N := float64(SamplesPerFrame)
+	twoPi := 2 * math.Pi
+	for l := 1; l <= 2; l++ {
+		oldPhase := []float64{0, 1.0, 0.5}[l]
+		delta := float64(l) * (wPrev + wCurr) * N / 2
+		want := math.Mod(oldPhase+delta, twoPi)
+		if want < 0 {
+			want += twoPi
+		}
+		if math.Abs(s.PrevPhase[l]-want) > synthEpsilon {
+			t.Errorf("PrevPhase[%d] = %v, want %v", l, s.PrevPhase[l], want)
+		}
+	}
+}
+
+// TestUpdateVoicedStateZeroesUnvoiced: harmonics that are unvoiced
+// this frame get PrevMl = 0 so the next frame's fade-in has a clean
+// zero baseline.
+func TestUpdateVoicedStateZeroesUnvoiced(t *testing.T) {
+	s := SynthState{PrevW0: 0.1, PrevL: 3}
+	s.PrevMl[1] = 9
+	s.PrevMl[2] = 9
+	s.PrevMl[3] = 9
+	p := Params{Header: Header{W0: 0.1, L: 3, K: 1}}
+	p.Vl[1] = 1 // voiced
+	p.Vl[2] = 0 // unvoiced
+	p.Vl[3] = 1 // voiced
+	var M [57]float64
+	M[1] = 0.5
+	M[2] = 0.7 // ignored because unvoiced
+	M[3] = 0.9
+	s.UpdateVoicedState(p, &M)
+	if !almostEqual(s.PrevMl[1], 0.5) {
+		t.Errorf("PrevMl[1] = %v, want 0.5", s.PrevMl[1])
+	}
+	if s.PrevMl[2] != 0 {
+		t.Errorf("PrevMl[2] = %v, want 0 (unvoiced zeroed)", s.PrevMl[2])
+	}
+	if !almostEqual(s.PrevMl[3], 0.9) {
+		t.Errorf("PrevMl[3] = %v, want 0.9", s.PrevMl[3])
+	}
+}
+
+// TestUpdateVoicedStateSilentNoOp: silent frames don't roll state.
+func TestUpdateVoicedStateSilentNoOp(t *testing.T) {
+	s := SynthState{PrevPhase: [57]float64{0, 1.5}, PrevMl: [57]float64{0, 0.7}}
+	p := Params{Header: Header{Silent: true}}
+	var M [57]float64
+	s.UpdateVoicedState(p, &M)
+	if s.PrevPhase[1] != 1.5 || s.PrevMl[1] != 0.7 {
+		t.Errorf("Silent frame mutated state: phase=%v ml=%v",
+			s.PrevPhase[1], s.PrevMl[1])
+	}
+}
+
+// TestResetClearsVoicedFields confirms Reset() also clears the new
+// PrevMl + PrevPhase fields added in this PR (regression guard
+// against the SynthState extension drifting from Reset).
+func TestResetClearsVoicedFields(t *testing.T) {
+	s := SynthState{PrevW0: 0.1, PrevL: 5}
+	for l := 1; l <= 5; l++ {
+		s.PrevLog2Ml[l] = float64(l)
+		s.PrevMl[l] = float64(l)
+		s.PrevPhase[l] = float64(l) * 0.1
+	}
+	s.Reset()
+	for l := 0; l <= 56; l++ {
+		if s.PrevMl[l] != 0 {
+			t.Errorf("Reset: PrevMl[%d] = %v, want 0", l, s.PrevMl[l])
+		}
+		if s.PrevPhase[l] != 0 {
+			t.Errorf("Reset: PrevPhase[%d] = %v, want 0", l, s.PrevPhase[l])
+		}
+	}
+}
+
+// TestSynthVoicedZeroAmpSkipsHarmonic: a voiced harmonic with M[l]
+// = 0 and prev_amp = 0 contributes nothing to dst. Pins the
+// short-circuit optimization (skips the inner loop entirely).
+func TestSynthVoicedZeroAmpSkipsHarmonic(t *testing.T) {
+	var s SynthState
+	p := Params{Header: Header{W0: math.Pi / 30, L: 3, K: 1}}
+	p.Vl[1] = 1
+	p.Vl[2] = 0
+	p.Vl[3] = 1
+	var M [57]float64
+	M[1] = 0  // zero amp on a voiced harmonic — degenerate but possible
+	M[3] = 0  // ditto
+	dst := make([]float64, SamplesPerFrame)
+	SynthVoiced(&s, p, &M, dst)
+	for n, v := range dst {
+		if v != 0 {
+			t.Fatalf("dst[%d] = %v, want 0 (all amps zero)", n, v)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
Eighth PR in the IMBE 4400 thread (after merged #49 skeleton, #50 per-vector FEC, #51 PRBS scrambler, #52 header, #53 spectral unpack, #54 cross-frame log2(Ml) prediction, #55 amp prep). Lands the TIA-102.BABA §6.3 voiced harmonic generator: per-harmonic sinusoid sum at l · ω₀ with linear amplitude tilt and quadratic-phase ω₀ integration so the synthesizer evolves smoothly across frame boundaries.

The §6.3 model for one frame of N = 160 samples:

```
a(n) = (1 − n/N) · M_prev[l] + (n/N) · M_curr[l]                    (eq. 88)
θ(n) = θ_prev[l] + n · l · ω_prev + l · (ω_curr − ω_prev) · n²/(2N)
s_v(n) = Σ_{l: voiced this or last frame} a(n) · cos(θ(n))          (eq. 89)
```

The dual-frame iteration (every harmonic with nonzero amp this frame OR last) gives clean fade-in on unvoiced→voiced transitions and clean fade-out on voiced→unvoiced transitions without click artifacts.

## Changes
- **`internal/voice/imbe/synth.go`** — `SynthState` gains `PrevMl[57]` (linear Ml at end of prev frame, 0 if was unvoiced/absent) and `PrevPhase[57]` (accumulated phase per harmonic in [0, 2π)). Existing `Reset()` already does `*s = SynthState{}`, so the new fields zero for free.
- **`internal/voice/imbe/synth_voiced.go`** (new) —
  - `SynthVoiced(s, p, M, dst)`: writes the voiced contribution into `dst[0..159]`. Adds rather than overwrites so the unvoiced step (4d) can sum into the same buffer. First-frame `prevW0 == 0` collapses to `p.W0` so the quadratic phase term vanishes (harmonics start at their target frequency, no synthetic sweep). Skips harmonics with both `M_prev = M_curr = 0`.
  - `(s).UpdateVoicedState(p, M)`: rolls phase by the closed-form average-frequency integral `Δθ_l = N · l · (ω_prev + ω_curr) / 2`, wrapped into [0, 2π). `PrevMl[l]` gets curr `M[l]` for voiced harmonics, 0 for unvoiced — so next frame's fade-in math sees a clean baseline.
- **`internal/voice/imbe/doc.go`** — roadmap step 4c marked shipped; step 4d (§6.4 unvoiced FFT excitation) is the next focus.
- **`README.md`** — IMBE roadmap entry lists the §6.3 voiced harmonic generator alongside the prior pieces; follow-up scope narrows to §6.4 unvoiced excitation + §6.2 enhancement + final PCM combine. The decoder still emits silence per frame because the synthesis chain isn't wired through `Decode()` yet — that wiring lands alongside the unvoiced step.

## Test plan
- [x] Fresh-stream unvoiced frame → `dst` stays zero (no spurious carrier on the first frame).
- [x] Fresh-stream single harmonic `l=1, M=1, Vl=1` → `dst[n] = (n/N) · cos(ω₀·n)` (fade-in).
- [x] Steady state (prev=curr=1, ω₀ steady) → pure `cos(l·ω₀·n)` sinusoid (amp tilt collapsed).
- [x] Fade-out (was voiced, now unvoiced) → `dst[n] = (1 − n/N) · cos(ω₀·n)`.
- [x] Phase continuity across frames → frame 2 sample n equals `cos(ω₀ · (N + n))` (no boundary discontinuity).
- [x] Two-harmonic sum → `dst[n] = M[1]·cos(ω₀·n) + M[2]·cos(2ω₀·n)`.
- [x] Quadratic phase term → when ω_prev ≠ ω_curr, phase is `θ₀ + a·n + b·n²`, checked at `n ∈ {0, 40, 80, 120, 159}`.
- [x] Adds rather than overwrites → sentinel-prefilled `dst[0]` preserved (amp 0 at fade-in start) and `dst[N-1]` matches expected sum.
- [x] Silent frame leaves `dst` untouched.
- [x] `dst` shorter than `SamplesPerFrame` returns early without panic.
- [x] `UpdateVoicedState` advances phase by `N·l·(ω_prev+ω_curr)/2` for arbitrary inputs.
- [x] `UpdateVoicedState` zeroes `PrevMl` for unvoiced harmonics.
- [x] Silent `UpdateVoicedState` is a no-op.
- [x] `Reset()` clears the new `PrevMl` + `PrevPhase` fields (regression guard).
- [x] Zero-amp voiced harmonic skipped via the `M_prev = M_curr = 0` short-circuit.
- [x] Full `go test ./...` green (rtlsdr CGO build failure is a pre-existing environment issue — librtlsdr not installed — unrelated to this change).

---
_Generated by [Claude Code](https://claude.ai/code/session_01JmSJLqDwr8jLuKtbkzGXNE)_