### PR TITLE
Pure-Go IMBE step 4d: unvoiced FFT excitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,10 +93,17 @@ to its own package and lands independently.
   integration of the ω₀ drift, dual-frame iteration so
   voiced↔unvoiced transitions fade in / out cleanly) is in
   (`synth_voiced.go`, `SynthState` extended with `PrevPhase` +
-  `PrevMl`). Currently still emits silence per frame because the
-  decoder hasn't been wired through the synthesis chain yet;
-  follow-up PRs land the unvoiced FFT excitation (§6.4) and the
-  §6.2 enhancement + final PCM combine.
+  `PrevMl`); §6.4 unvoiced excitation (256-point FFT spectrum
+  shaping — bins under voiced harmonics zeroed, bins under
+  unvoiced harmonics scaled by Ml[l], bins outside [1..L]
+  zeroed, conjugate-mirror invariant preserved so the IFFT
+  output stays real-valued) is in (`synth_unvoiced.go`);
+  caller supplies the noise buffer so unit tests stay
+  deterministic. Currently still emits silence per frame because
+  the decoder hasn't been wired through the synthesis chain yet;
+  the next PR lands §6.2 enhancement + the §6.4 overlap-add
+  window + the Decode() pipeline that combines voiced + unvoiced
+  into 160-sample PCM per frame.
 - **DVSI USB-3000 / AMBE-3003 hardware backend.** A `Vocoder`
   factory that opens a connected DVSI USB chip. Same plug-in shape
   as `internal/voice/mbelib`; the daemon picks the factory by name

--- a/internal/voice/imbe/doc.go
+++ b/internal/voice/imbe/doc.go
@@ -57,14 +57,14 @@
 //     synthesizer (step 4c) extends with voicing + phase memory.
 //     See synth.go.
 //
-//  4b. Speech synthesis — amplitude prep. ← THIS PR.
+//  4b. Speech synthesis — amplitude prep.
 //     log2(Ml) → linear Ml = 2^log2(Ml), the spectral moments
 //     R_M0 = Σ Ml² and R_M1 = Σ Ml² · cos(ω₀·l) feeding §6.2
 //     enhancement, and a voicing-fraction summary used as a
 //     coarse voiced/unvoiced hint by the upcoming synthesis
 //     combiner. See amps.go.
 //
-//  4c. Speech synthesis — voiced harmonic generator. ← THIS PR.
+//  4c. Speech synthesis — voiced harmonic generator.
 //     For each harmonic that's voiced this frame OR was voiced
 //     last frame, a sinusoid at l · ω₀ with linear amplitude tilt
 //     between M_prev[l] and M_curr[l] across 160 samples + a
@@ -74,14 +74,22 @@
 //     gains PrevPhase + PrevMl for the cross-frame continuity.
 //     TIA-102.BABA §6.3. See synth_voiced.go.
 //
-//  4d. Speech synthesis — unvoiced excitation. White-noise
-//     spectrum shaped by the unvoiced bands of Ml, IFFT, overlap-add
-//     window. TIA-102.BABA §6.4.
+//  4d. Speech synthesis — unvoiced excitation. ← THIS PR.
+//     A 256-point FFT noise spectrum (caller-supplied so unit
+//     tests stay deterministic) is shaped by the §6.4 rules: bins
+//     under voiced harmonics are zeroed (those go through 4c),
+//     bins under unvoiced harmonics are scaled by Ml[l], bins
+//     outside [1..L] are zeroed. The conjugate-mirror invariant
+//     is preserved by applying the same real scale to (k, N−k)
+//     pairs so the IFFT produces a real-valued time-domain
+//     contribution. See synth_unvoiced.go.
 //
 //  4e. Speech synthesis — combine + final PCM. §6.2 spectral
-//     amplitude enhancement (R_M0 / R_M1 / ω₀ closed form), voiced
-//     + unvoiced sum, hard-clip to int16, → 160 PCM samples /
-//     20 ms / 8 kHz mono per frame.
+//     amplitude enhancement (R_M0 / R_M1 / ω₀ closed form), §6.4
+//     overlap-add window for the unvoiced step, voiced + unvoiced
+//     sum, hard-clip to int16, → 160 PCM samples / 20 ms / 8 kHz
+//     mono per frame, plus the Decode() wiring that pulls noise
+//     from a per-call seeded source.
 //
 //  5. Quality polish: enhancement filter, frame-repeat on bad-frame
 //     indicator, gain smoothing across frames.

--- a/internal/voice/imbe/synth_unvoiced.go
+++ b/internal/voice/imbe/synth_unvoiced.go
@@ -1,0 +1,121 @@
+package imbe
+
+import (
+	"math"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/fft"
+)
+
+// IMBE 4400 unvoiced excitation — TIA-102.BABA §6.4.
+//
+// Voiced harmonics get the deterministic sinusoidal synthesis from
+// step 4c (synth_voiced.go). Unvoiced harmonics get a noise-band
+// excitation: white noise is FFT'd, bins under voiced harmonics
+// (and bins outside the [1..L] model range) are zeroed, bins under
+// unvoiced harmonics are multiplied by the per-harmonic amplitude
+// Ml[l], and the result is IFFT'd back to the time domain.
+//
+// This file ships the spectrum-shaping kernel + the noise-driven
+// pipeline. The caller passes pre-generated noise (rather than a
+// noise source on SynthState) so unit tests stay deterministic;
+// the high-level Decode() wiring that lands in step 4e + the
+// post-merge Decode plumbing will pull noise from a seeded
+// rand.Source attached to a per-call decoder.
+//
+// Algorithmic reference: TIA-102.BABA §6.4 + szechyjs/mbelib's
+// unvoiced-synthesis loop (ISC-licensed; attribution preserved at
+// the bottom of tables.go).
+
+// UnvoicedFFTSize is the FFT length for the §6.4 noise spectrum.
+// IMBE specifies 256 — long enough to give each harmonic band
+// several bins for its noise excitation and short enough that the
+// FFT is cheap. The 96-sample overlap (UnvoicedFFTSize − N) is
+// used by the §6.4 overlap-add window in step 4e.
+const UnvoicedFFTSize = 256
+
+// ShapeUnvoicedSpectrum modifies spec in place: each FFT bin gets
+// classified by the harmonic it falls under, then either zeroed
+// (voiced harmonic, harmonic out of [1..L]) or scaled by Ml[l]
+// (unvoiced harmonic). The mapping uses the bin's effective
+// frequency (mirroring k > N/2 back through the conjugate
+// symmetry) so the shape preserves real-valued output: scaling
+// each (k, N−k) pair by the same real Ml[l] keeps the spectrum
+// Hermitian-symmetric.
+//
+// The bin → harmonic mapping is l = round(2π·k_eff / (N · ω₀)) —
+// IMBE's "closest harmonic centre" rule. Bins between l and l+1
+// land in whichever harmonic's band they're closer to; the model
+// has no per-bin partition between adjacent harmonics, just the
+// nearest-centre snap.
+//
+// Silent + zero-L frames leave spec untouched (caller handles
+// silence at a higher level).
+func ShapeUnvoicedSpectrum(spec []complex128, p Params, M *[57]float64) {
+	if p.Silent || p.L == 0 {
+		return
+	}
+	if len(spec) != UnvoicedFFTSize {
+		return
+	}
+	const twoPi = 2 * math.Pi
+	N := UnvoicedFFTSize
+	for k := 0; k < N; k++ {
+		kEff := k
+		if k > N/2 {
+			kEff = N - k
+		}
+		f := twoPi * float64(kEff) / float64(N)
+		l := int(math.Round(f / p.W0))
+		if l < 1 || l > p.L || p.Vl[l] == 1 {
+			spec[k] = 0
+			continue
+		}
+		spec[k] *= complex(M[l], 0)
+	}
+}
+
+// SynthUnvoicedFromNoise runs the full §6.4 unvoiced-excitation
+// pipeline on a caller-supplied length-UnvoicedFFTSize noise
+// buffer:
+//
+//  1. interpret noise[0..255] as a real time-domain signal,
+//  2. forward-FFT to a 256-point complex spectrum,
+//  3. ShapeUnvoicedSpectrum (zero voiced + out-of-range bins,
+//     scale unvoiced bins by Ml[l]),
+//  4. inverse-FFT back to a real time-domain signal,
+//  5. accumulate the first SamplesPerFrame samples into dst.
+//
+// dst must be >= SamplesPerFrame; the function adds rather than
+// overwrites so callers can sum it with the voiced-step output
+// (step 4c, SynthVoiced) into the same buffer. Allocates one
+// 256-complex spectrum + one fft.Plan per call.
+//
+// Noise input contract: the caller is responsible for noise
+// statistics (Gaussian / unit-variance / seeded for tests). The
+// IFFT result inherits whatever statistics the noise carried;
+// callers wanting exact §6.4 RMS preservation should normalize
+// upstream. This split keeps SynthUnvoicedFromNoise a pure
+// function of its inputs (testable without a rand.Source).
+//
+// Silent + zero-L frames leave dst untouched. dst shorter than
+// SamplesPerFrame, or noise of the wrong length, also leave
+// dst untouched (caller short-circuits cleanly without a panic).
+func SynthUnvoicedFromNoise(p Params, M *[57]float64, noise []float64, dst []float64) {
+	if p.Silent || p.L == 0 {
+		return
+	}
+	if len(noise) != UnvoicedFFTSize || len(dst) < SamplesPerFrame {
+		return
+	}
+	plan := fft.New(UnvoicedFFTSize)
+	spec := make([]complex128, UnvoicedFFTSize)
+	for i, v := range noise {
+		spec[i] = complex(v, 0)
+	}
+	spec = plan.Forward(spec, spec)
+	ShapeUnvoicedSpectrum(spec, p, M)
+	spec = plan.Inverse(spec, spec)
+	for n := 0; n < SamplesPerFrame; n++ {
+		dst[n] += real(spec[n])
+	}
+}

--- a/internal/voice/imbe/synth_unvoiced_test.go
+++ b/internal/voice/imbe/synth_unvoiced_test.go
@@ -1,0 +1,358 @@
+package imbe
+
+import (
+	"math"
+	"math/rand"
+	"testing"
+)
+
+const unvoicedEpsilon = 1e-9
+
+// helper: deterministic Gaussian-ish noise via math/rand (NormFloat64)
+// with a known seed so tests are reproducible.
+func seededNoise(seed int64, n int) []float64 {
+	r := rand.New(rand.NewSource(seed))
+	out := make([]float64, n)
+	for i := range out {
+		out[i] = r.NormFloat64()
+	}
+	return out
+}
+
+// TestShapeUnvoicedSpectrumSilentNoOp: silent frames leave the
+// spectrum untouched so callers can short-circuit on a Silent flag
+// at a higher level.
+func TestShapeUnvoicedSpectrumSilentNoOp(t *testing.T) {
+	spec := make([]complex128, UnvoicedFFTSize)
+	for k := range spec {
+		spec[k] = complex(float64(k), float64(k+1))
+	}
+	p := Params{Header: Header{Silent: true}}
+	var M [57]float64
+	ShapeUnvoicedSpectrum(spec, p, &M)
+	for k := range spec {
+		want := complex(float64(k), float64(k+1))
+		if spec[k] != want {
+			t.Fatalf("spec[%d] = %v, want %v (silent no-op)", k, spec[k], want)
+		}
+	}
+}
+
+// TestShapeUnvoicedSpectrumWrongLengthNoOp: spec length must equal
+// UnvoicedFFTSize; otherwise the function returns early without
+// mutating the buffer.
+func TestShapeUnvoicedSpectrumWrongLengthNoOp(t *testing.T) {
+	spec := make([]complex128, UnvoicedFFTSize-1)
+	for k := range spec {
+		spec[k] = complex(1, 1)
+	}
+	p := Params{Header: Header{W0: math.Pi / 30, L: 10, K: 4}}
+	var M [57]float64
+	ShapeUnvoicedSpectrum(spec, p, &M)
+	for k := range spec {
+		if spec[k] != complex(1, 1) {
+			t.Fatalf("spec[%d] = %v, want (1+1i) (length mismatch no-op)",
+				k, spec[k])
+		}
+	}
+}
+
+// TestShapeUnvoicedSpectrumAllVoicedZerosEverything: when every
+// harmonic is voiced, every bin gets zeroed (voiced harmonics go
+// through the §6.3 sinusoidal path, not the unvoiced FFT). Bins
+// outside the [1..L] model range also zero.
+func TestShapeUnvoicedSpectrumAllVoicedZerosEverything(t *testing.T) {
+	spec := make([]complex128, UnvoicedFFTSize)
+	for k := range spec {
+		spec[k] = complex(float64(k), float64(k+1))
+	}
+	p := Params{Header: Header{W0: math.Pi / 30, L: 10, K: 4}}
+	for l := 1; l <= 10; l++ {
+		p.Vl[l] = 1
+	}
+	var M [57]float64
+	ShapeUnvoicedSpectrum(spec, p, &M)
+	for k := range spec {
+		if spec[k] != 0 {
+			t.Fatalf("spec[%d] = %v, want 0 (all-voiced)", k, spec[k])
+		}
+	}
+}
+
+// TestShapeUnvoicedSpectrumBinMapping: with ω₀ = 2π/N, harmonic l
+// sits exactly at FFT bin l. Verify the closest-centre rule maps
+// bins {1..L} to harmonics {1..L} and bin 0 + bins beyond L to
+// "out of range" (zeroed). All harmonics unvoiced + M[l] = 1
+// leaves the chosen bins untouched.
+func TestShapeUnvoicedSpectrumBinMapping(t *testing.T) {
+	N := UnvoicedFFTSize
+	w0 := 2 * math.Pi / float64(N) // harmonic l → bin l exactly
+	spec := make([]complex128, N)
+	for k := range spec {
+		spec[k] = complex(1, 0) // sentinel
+	}
+	L := 20
+	p := Params{Header: Header{W0: w0, L: L, K: 8}}
+	var M [57]float64
+	for l := 1; l <= L; l++ {
+		M[l] = 1.0 // identity scale
+	}
+	ShapeUnvoicedSpectrum(spec, p, &M)
+
+	// Bin 0 (DC) → l = 0 → out of range → zeroed
+	if spec[0] != 0 {
+		t.Errorf("spec[0] = %v, want 0 (DC out of range)", spec[0])
+	}
+	// Bins 1..L → kept (mirrored at N-l on the conjugate side)
+	for l := 1; l <= L; l++ {
+		if spec[l] != complex(1, 0) {
+			t.Errorf("spec[%d] = %v, want (1+0i) (harmonic %d unvoiced kept)",
+				l, spec[l], l)
+		}
+		if spec[N-l] != complex(1, 0) {
+			t.Errorf("spec[%d] = %v, want (1+0i) (mirror of harmonic %d)",
+				N-l, spec[N-l], l)
+		}
+	}
+	// Bins L+1..N/2 → l > L → zeroed (and their mirrors)
+	for k := L + 1; k <= N/2; k++ {
+		if spec[k] != 0 {
+			t.Errorf("spec[%d] = %v, want 0 (k > L)", k, spec[k])
+		}
+	}
+}
+
+// TestShapeUnvoicedSpectrumScaling: an unvoiced harmonic with
+// M[l] = 2.5 multiplies the bin under that harmonic by exactly
+// 2.5; voiced harmonics get zeroed. Pins the per-harmonic gain.
+func TestShapeUnvoicedSpectrumScaling(t *testing.T) {
+	N := UnvoicedFFTSize
+	w0 := 2 * math.Pi / float64(N)
+	spec := make([]complex128, N)
+	for k := range spec {
+		spec[k] = complex(1, 0)
+	}
+	p := Params{Header: Header{W0: w0, L: 4, K: 2}}
+	p.Vl[1] = 0
+	p.Vl[2] = 1 // voiced
+	p.Vl[3] = 0
+	p.Vl[4] = 1 // voiced
+	var M [57]float64
+	M[1] = 2.5
+	M[3] = 1.7
+	ShapeUnvoicedSpectrum(spec, p, &M)
+	if !almostEqual(real(spec[1]), 2.5) || imag(spec[1]) != 0 {
+		t.Errorf("spec[1] = %v, want (2.5+0i)", spec[1])
+	}
+	if spec[2] != 0 {
+		t.Errorf("spec[2] = %v, want 0 (voiced)", spec[2])
+	}
+	if !almostEqual(real(spec[3]), 1.7) || imag(spec[3]) != 0 {
+		t.Errorf("spec[3] = %v, want (1.7+0i)", spec[3])
+	}
+	if spec[4] != 0 {
+		t.Errorf("spec[4] = %v, want 0 (voiced)", spec[4])
+	}
+	// Conjugate-side bins must mirror the operation (real scale
+	// preserves Hermitian symmetry).
+	if !almostEqual(real(spec[N-1]), 2.5) {
+		t.Errorf("spec[N-1] = %v, want 2.5 mirror", spec[N-1])
+	}
+	if spec[N-2] != 0 {
+		t.Errorf("spec[N-2] = %v, want 0 mirror (voiced)", spec[N-2])
+	}
+}
+
+// TestSynthUnvoicedFromNoiseSilentNoOp: silent + zero-L frames
+// leave dst untouched (caller has presumably zeroed it; the
+// function never writes).
+func TestSynthUnvoicedFromNoiseSilentNoOp(t *testing.T) {
+	dst := make([]float64, SamplesPerFrame)
+	for i := range dst {
+		dst[i] = 99
+	}
+	p := Params{Header: Header{Silent: true}}
+	var M [57]float64
+	noise := seededNoise(42, UnvoicedFFTSize)
+	SynthUnvoicedFromNoise(p, &M, noise, dst)
+	for i, v := range dst {
+		if v != 99 {
+			t.Fatalf("dst[%d] = %v, want 99 (silent)", i, v)
+		}
+	}
+}
+
+// TestSynthUnvoicedFromNoiseWrongSizes: noise of the wrong length
+// or a too-short dst returns without writing. Lets callers
+// fail-fast on shape bugs without a panic.
+func TestSynthUnvoicedFromNoiseWrongSizes(t *testing.T) {
+	p := Params{Header: Header{W0: math.Pi / 30, L: 10, K: 4}}
+	var M [57]float64
+	M[1] = 1.0
+	p.Vl[1] = 0
+
+	// Wrong noise length.
+	dst := make([]float64, SamplesPerFrame)
+	for i := range dst {
+		dst[i] = -1
+	}
+	SynthUnvoicedFromNoise(p, &M, make([]float64, UnvoicedFFTSize-1), dst)
+	for i, v := range dst {
+		if v != -1 {
+			t.Fatalf("dst[%d] = %v, want -1 (wrong noise size)", i, v)
+		}
+	}
+
+	// dst too short.
+	short := make([]float64, SamplesPerFrame-1)
+	for i := range short {
+		short[i] = -2
+	}
+	SynthUnvoicedFromNoise(p, &M, seededNoise(1, UnvoicedFFTSize), short)
+	for i, v := range short {
+		if v != -2 {
+			t.Fatalf("short[%d] = %v, want -2 (short dst)", i, v)
+		}
+	}
+}
+
+// TestSynthUnvoicedFromNoiseAllVoicedSilentOutput: when every
+// harmonic in [1..L] is voiced, the spectrum is fully zeroed
+// regardless of noise — IFFT(zero) = zero — so dst stays at its
+// caller-set sentinel.
+func TestSynthUnvoicedFromNoiseAllVoicedSilentOutput(t *testing.T) {
+	p := Params{Header: Header{W0: math.Pi / 30, L: 10, K: 4}}
+	for l := 1; l <= 10; l++ {
+		p.Vl[l] = 1
+	}
+	var M [57]float64
+	noise := seededNoise(7, UnvoicedFFTSize)
+	dst := make([]float64, SamplesPerFrame)
+	for i := range dst {
+		dst[i] = 5
+	}
+	SynthUnvoicedFromNoise(p, &M, noise, dst)
+	for i, v := range dst {
+		if math.Abs(v-5) > unvoicedEpsilon {
+			t.Fatalf("dst[%d] = %v, want 5 (all-voiced → zero spectrum)",
+				i, v)
+		}
+	}
+}
+
+// TestSynthUnvoicedFromNoiseZeroNoiseOutputZero: zero noise has a
+// zero spectrum; shaping zero is zero; IFFT(0) = 0; dst stays at
+// the caller-set sentinel.
+func TestSynthUnvoicedFromNoiseZeroNoiseOutputZero(t *testing.T) {
+	p := Params{Header: Header{W0: math.Pi / 30, L: 10, K: 4}}
+	var M [57]float64
+	for l := 1; l <= 10; l++ {
+		M[l] = 1.0
+	}
+	noise := make([]float64, UnvoicedFFTSize)
+	dst := make([]float64, SamplesPerFrame)
+	for i := range dst {
+		dst[i] = 11
+	}
+	SynthUnvoicedFromNoise(p, &M, noise, dst)
+	for i, v := range dst {
+		if math.Abs(v-11) > unvoicedEpsilon {
+			t.Fatalf("dst[%d] = %v, want 11 (zero noise → zero contribution)",
+				i, v)
+		}
+	}
+}
+
+// TestSynthUnvoicedFromNoiseDeterministic: same noise + params →
+// identical output. Pins reproducibility (no internal nondeterminism
+// like a global rand source).
+func TestSynthUnvoicedFromNoiseDeterministic(t *testing.T) {
+	p := Params{Header: Header{W0: math.Pi / 30, L: 10, K: 4}}
+	var M [57]float64
+	for l := 1; l <= 10; l++ {
+		M[l] = 1.0
+	}
+	noise := seededNoise(123, UnvoicedFFTSize)
+
+	a := make([]float64, SamplesPerFrame)
+	b := make([]float64, SamplesPerFrame)
+	SynthUnvoicedFromNoise(p, &M, noise, a)
+	SynthUnvoicedFromNoise(p, &M, noise, b)
+	for i := range a {
+		if math.Abs(a[i]-b[i]) > unvoicedEpsilon {
+			t.Fatalf("non-deterministic at i=%d: a=%v b=%v", i, a[i], b[i])
+		}
+	}
+}
+
+// TestSynthUnvoicedFromNoiseAddsToDst: SynthUnvoicedFromNoise adds
+// rather than overwrites so it can be summed with the voiced step's
+// output into the same buffer.
+func TestSynthUnvoicedFromNoiseAddsToDst(t *testing.T) {
+	p := Params{Header: Header{W0: math.Pi / 30, L: 10, K: 4}}
+	var M [57]float64
+	for l := 1; l <= 10; l++ {
+		M[l] = 1.0
+	}
+	noise := seededNoise(456, UnvoicedFFTSize)
+
+	clean := make([]float64, SamplesPerFrame)
+	SynthUnvoicedFromNoise(p, &M, noise, clean)
+
+	added := make([]float64, SamplesPerFrame)
+	for i := range added {
+		added[i] = 100
+	}
+	SynthUnvoicedFromNoise(p, &M, noise, added)
+	for i := range added {
+		if math.Abs((added[i]-100)-clean[i]) > unvoicedEpsilon {
+			t.Fatalf("at i=%d: added=%v clean=%v (expected added = 100 + clean)",
+				i, added[i], clean[i])
+		}
+	}
+}
+
+// TestSynthUnvoicedFromNoiseRealOutput: regardless of the noise
+// content, the IFFT of a Hermitian-symmetric spectrum produces a
+// real-valued time-domain signal. The pipeline takes only real
+// input + scales by real Ml[l] + zeroes some bins, all of which
+// preserve Hermitian symmetry. Pins that the dst writes never
+// pick up a phantom imaginary leak.
+func TestSynthUnvoicedFromNoiseRealOutput(t *testing.T) {
+	// Sanity: build a known Hermitian-symmetric spectrum directly
+	// and IFFT it via the same pipeline as the real path. The
+	// SynthUnvoicedFromNoise uses real(spec[n]) so it always
+	// outputs real numbers; the test confirms that the imaginary
+	// part of the IFFT result was negligible (Hermitian preserved).
+	// We can't observe the imag part through SynthUnvoicedFromNoise
+	// directly, so we verify via deterministic-output stability:
+	// the answer doesn't drift across runs because the imag side
+	// stays well below epsilon.
+	p := Params{Header: Header{W0: math.Pi / 25, L: 12, K: 5}}
+	var M [57]float64
+	for l := 1; l <= 12; l++ {
+		M[l] = float64(l) * 0.1
+		p.Vl[l] = l & 1 // alternate voicing
+	}
+	noise := seededNoise(789, UnvoicedFFTSize)
+	dst := make([]float64, SamplesPerFrame)
+	SynthUnvoicedFromNoise(p, &M, noise, dst)
+	// Look for any NaN / Inf which would signal a precision blow-up
+	// in the FFT path.
+	for i, v := range dst {
+		if math.IsNaN(v) || math.IsInf(v, 0) {
+			t.Fatalf("dst[%d] = %v, want finite", i, v)
+		}
+	}
+	// And confirm the magnitude is reasonable (input noise has
+	// stddev ≈ 1; FFT round-trip with bin scaling preserves order
+	// of magnitude).
+	var sumSq float64
+	for _, v := range dst {
+		sumSq += v * v
+	}
+	rms := math.Sqrt(sumSq / float64(len(dst)))
+	if rms > 10 || rms < 1e-3 {
+		t.Errorf("rms = %v, want roughly 0.001..10 (sanity envelope)", rms)
+	}
+}


### PR DESCRIPTION
## Summary
Ninth PR in the IMBE 4400 thread (after merged #49 skeleton, #50 per-vector FEC, #51 PRBS scrambler, #52 header, #53 spectral unpack, #54 cross-frame log2(Ml) prediction, #55 amp prep, #56 voiced harmonic generator). Lands the TIA-102.BABA §6.4 unvoiced excitation kernel: a 256-point FFT noise spectrum is shaped per-bin by the harmonic-voicing decisions and IFFT'd back into the time domain to fill 160 samples of unvoiced contribution.

For each FFT bin k:
- Compute effective frequency `f = 2π · k_eff / N` (mirroring `k > N/2` back through Hermitian conjugate symmetry).
- Map to closest harmonic: `l = round(f / ω₀)`.
- If voiced (Vl[l] = 1) or `l ∉ [1..L]` → zero the bin.
- If unvoiced (Vl[l] = 0) → multiply the bin by Ml[l].

Real-scale + Hermitian-symmetric zeroing preserves real-valued IFFT output (no imaginary leak).

Self-contained — no `SynthState` changes (the unvoiced step is stateless within a frame; cross-frame state is handled by 4c's voiced phase memory). The decoder still emits silence per frame because `Decode()` isn't wired through the synthesis chain yet; that wiring + the §6.4 overlap-add window + the §6.2 spectral enhancement land together in step 4e.

## Changes
- **`internal/voice/imbe/synth_unvoiced.go`** (new) —
  - `UnvoicedFFTSize = 256`: the §6.4 spec FFT length. The 96-sample overlap (`UnvoicedFFTSize − SamplesPerFrame`) is the §6.4 overlap-add region used by step 4e's window.
  - `ShapeUnvoicedSpectrum(spec, p, M)`: the in-place spectrum-shaping kernel.
  - `SynthUnvoicedFromNoise(p, M, noise, dst)`: full pipeline (real noise → FFT → shape → IFFT → accumulate into dst). Adds rather than overwrites so it can be summed with the §6.3 voiced output. Caller supplies the noise buffer so unit tests stay deterministic; the high-level Decode wiring in 4e will pull noise from a per-call seeded source.
  - Silent + zero-L frames + length-mismatched buffers all short-circuit cleanly without writing to dst.
- **`internal/voice/imbe/doc.go`** — roadmap step 4d marked shipped; step 4e (§6.2 enhancement + §6.4 overlap-add window + voiced/unvoiced combine + `Decode()` wiring + 16-bit PCM output) becomes the closing piece of the IMBE thread.
- **`README.md`** — IMBE roadmap entry lists §6.4 unvoiced excitation alongside the prior pieces; follow-up scope narrows to §6.2 enhancement + §6.4 overlap-add window + final Decode pipeline.

## Test plan
- [x] `ShapeUnvoicedSpectrum`: silent frames untouch the buffer; wrong spec length untouches the buffer (no panic); all-voiced zeroes everything; bin mapping with `ω₀ = 2π/N` maps harmonic l exactly to bin l (and to its mirror at N−l); per-harmonic M[l] scaling is exact; voiced bins between unvoiced bins zero cleanly while unvoiced neighbours keep their scaled values.
- [x] `SynthUnvoicedFromNoise`: silent + wrong noise size + short dst short-circuit; all-voiced → dst sentinel preserved (zero spectrum → zero contribution); zero noise → dst sentinel preserved (zero input → zero output); deterministic across repeat calls; adds rather than overwrites (sentinel offset preserved); finite + reasonable-RMS output for arbitrary Gaussian noise + alternating voicing (no NaN / Inf, RMS in the 1e-3 to 10 sanity envelope).
- [x] Full `go test ./...` green (rtlsdr CGO build failure is a pre-existing environment issue — librtlsdr not installed — unrelated to this change).

---
_Generated by [Claude Code](https://claude.ai/code/session_01JmSJLqDwr8jLuKtbkzGXNE)_