### PR TITLE
Pure-Go IMBE step 5b: §6.2 spectral-amplitude enhancement

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,12 +104,16 @@ to its own package and lands independently.
   deterministic; the §6.4 overlap-add synthesis window
   (256-sample periodic Hann × IFFT, 96-sample tail threaded
   through `SynthState.PrevUnvoicedTail` so frame boundaries are
-  click-free) is in via `SynthUnvoicedOverlapAdd`. **`Decode()`
-  now emits real audio**: it runs the full pipeline (88 info
-  bits → params → §6.1 prediction → linear Ml → §6.3 voiced
+  click-free) is in via `SynthUnvoicedOverlapAdd`; the §6.2
+  spectral-amplitude enhancement (per-harmonic W_l =
+  (0.96 · num/den)^0.25 clamped to [0.5, 1.2] for mid/high-band
+  harmonics + low-band W = 1, followed by an energy-preserving
+  rescale that holds R_M0 stable) is in (`enhance.go`).
+  **`Decode()` emits real audio**: 88 info bits → params →
+  §6.1 prediction → linear Ml → §6.2 enhancement → §6.3 voiced
   harmonic sum + §6.4 unvoiced excitation with overlap-add
   additive into one buffer → state roll-forward → hard-clip ×
-  placeholder gain → int16 PCM at 8 kHz). Silence-window frames
+  placeholder gain → int16 PCM at 8 kHz. Silence-window frames
   (b_0 ∈ [216, 219]) still fade the prev unvoiced tail through
   the overlap region before resetting state — no click on the
   silence boundary. Two decoder constructors are exposed:
@@ -117,11 +121,11 @@ to its own package and lands independently.
   for reproducibility; `NewWithSeed(seed)` lets parallel calls
   + production callers spread noise. Bad-b_0 frames return
   graceful silence without disturbing the prediction history.
-  **Remaining audio polish**: the §6.2 spectral-amplitude
-  enhancement and a spec-derived gain calibration (replacing
-  the placeholder pcmGain = 4096) — without them the spectral
-  envelope tilts slightly differently from mbelib output, and
-  the absolute level is approximate.
+  **Remaining audio polish**: a spec-derived gain calibration
+  (replacing the placeholder pcmGain = 4096), enhancement
+  filter tuning, and frame-repeat on bad-frame indicator —
+  the absolute output level still differs slightly from mbelib's
+  reference until 5c lands.
 - **DVSI USB-3000 / AMBE-3003 hardware backend.** A `Vocoder`
   factory that opens a connected DVSI USB chip. Same plug-in shape
   as `internal/voice/mbelib`; the daemon picks the factory by name

--- a/internal/voice/imbe/decoder.go
+++ b/internal/voice/imbe/decoder.go
@@ -140,9 +140,12 @@ func (d *Decoder) Decode(frame []byte) ([]int16, error) {
 		var log2M [57]float64
 		PredictLog2Ml(&d.state, p, &log2M)
 
-		// §6.2 amplitude prep: log2(Ml) → linear Ml.
+		// log2(Ml) → linear Ml, then §6.2 spectral-amplitude
+		// enhancement (per-harmonic weight from R_M0 + R_M1, plus
+		// energy-preserving rescale).
 		var M [57]float64
 		AmplitudesFromLog2Ml(&log2M, p.L, &M)
+		EnhanceAmplitudes(p, &M)
 
 		// §6.3: voiced harmonic generator (additive into pcm).
 		SynthVoiced(&d.state, p, &M, pcm)

--- a/internal/voice/imbe/doc.go
+++ b/internal/voice/imbe/doc.go
@@ -110,10 +110,17 @@
 //     including silence frames where the prev tail still fades
 //     out before the state is cleared. See synth_unvoiced.go.
 //
-//  5b. §6.2 spectral-amplitude enhancement. Per-harmonic Ml
-//     multiplier from the closed-form weight over R_M0 + R_M1 +
-//     ω₀ + l (§6.2). Boosts harmonics the model under-represents
-//     so the spectral envelope tilts correctly.
+//  5b. §6.2 spectral-amplitude enhancement. ← THIS PR.
+//     Per-harmonic Ml multiplier W_l from the closed-form weight
+//     over R_M0 + R_M1 + ω₀ + l: low-band harmonics (8·l ≤ L) are
+//     left at W = 1; mid- and high-band harmonics get
+//     W = (0.96 · num/den)^0.25 clamped to [0.5, 1.2]. After the
+//     per-harmonic multiply, frame energy is renormalized so
+//     R_M0 (total power) is preserved — gives the synthesizer a
+//     stable amplitude across frames. Boosts harmonics the model
+//     under-represents so the spectral envelope tilts more
+//     naturally on playback. Wired into Decoder.Decode between
+//     AmplitudesFromLog2Ml and SynthVoiced. See enhance.go.
 //
 //  5c. Spec-derived gain calibration. Replaces the placeholder
 //     pcmGain = 4096 with the gain that makes mbelib + imbe-go

--- a/internal/voice/imbe/enhance.go
+++ b/internal/voice/imbe/enhance.go
@@ -1,0 +1,122 @@
+package imbe
+
+import "math"
+
+// IMBE 4400 spectral-amplitude enhancement — TIA-102.BABA §6.2.
+//
+// After §6.1 cross-frame log-amplitude recovery (synth.go) and the
+// log2(Ml) → linear Ml conversion (amps.go), the synthesizer's
+// per-harmonic amplitudes carry the spec's quantized envelope but
+// not the spec's "compensated" envelope. §6.2 boosts harmonics that
+// the model under-represents (typically mid-band harmonics whose
+// energy gets averaged into adjacent bands by the PRBA + HOC
+// pipeline) so the spectral envelope tilts more naturally on
+// playback.
+//
+// The enhancement is a per-harmonic multiplier W_l that depends on
+// the spectral moments R_M0 = Σ Ml² and R_M1 = Σ Ml² · cos(ω₀·l)
+// and the harmonic position. Low-frequency harmonics (l ≤ L/8) and
+// the very-high-frequency band are left at W = 1; mid-band harmonics
+// get a weight derived from the closed-form below, clamped to a
+// safe range so the enhancement doesn't blow up on degenerate
+// frames.
+//
+// After the per-harmonic multiply, total frame energy is renormalized
+// so R_M0 (the integrated power across all L harmonics) is preserved.
+// That keeps the absolute amplitude of the synthesized output stable
+// across frames where the enhancement happens to redistribute energy
+// significantly.
+//
+// Algorithmic reference: TIA-102.BABA §6.2 + szechyjs/mbelib's
+// mbe_spectralAmpEnhance equivalent (ISC-licensed; attribution in
+// tables.go). Exact constants in the closed form (the 0.96 scale, the
+// W ∈ [0.5, 1.2] clamp, the L/8 lower-band cutoff) follow common
+// public references; spec-tuning to bit-match mbelib output is part
+// of step 5c (gain calibration).
+
+// EnhanceWMin / EnhanceWMax bound the per-harmonic enhancement
+// weight so a frame whose R_M0² − R_M1² approaches zero (a
+// near-pure-tone spectrum) doesn't produce a runaway W_l. The
+// [0.5, 1.2] band is the standard published range.
+const (
+	EnhanceWMin = 0.5
+	EnhanceWMax = 1.2
+)
+
+// EnhanceAmplitudes applies the §6.2 spectral-amplitude enhancement
+// to M[1..L] in place: each Ml gets multiplied by a per-harmonic
+// weight W_l, then the entire frame is rescaled so total energy
+// (Σ Ml²) is preserved.
+//
+// The per-harmonic weight is:
+//
+//	if 8·l ≤ L:        W_l = 1.0          (low band: untouched)
+//	else:
+//	    c = cos(ω₀ · l)
+//	    num = R_M0² + R_M1² − 2·R_M0·R_M1·c
+//	    den = R_M0 · (R_M0² − R_M1²)
+//	    if den ≤ 0:    W_l = 1.0          (degenerate frame: skip)
+//	    else:
+//	        ξ = 0.96 · num / den
+//	        W_l = ξ^0.25
+//	        clamped to [EnhanceWMin, EnhanceWMax]
+//
+// Silent + zero-L frames + degenerate (R_M0 ≤ 0) frames are no-ops
+// so callers can invoke unconditionally on the synthesis path.
+func EnhanceAmplitudes(p Params, M *[57]float64) {
+	if p.Silent || p.L == 0 {
+		return
+	}
+	L := p.L
+	if L > 56 {
+		L = 56
+	}
+
+	rm0 := FrameEnergy(M, L)
+	if rm0 <= 0 {
+		// Degenerate frame (e.g., all-zero amplitudes): nothing to
+		// enhance, nothing to rescale.
+		return
+	}
+	rm1 := SpectralCosineSum(M, L, p.W0)
+
+	// Pre-compute the closed-form denominator. R_M0² − R_M1² ≥ 0 by
+	// Cauchy-Schwarz when M_l² are non-negative weights, but the
+	// strict inequality fails on a pure tone (one nonzero harmonic)
+	// where R_M1² = R_M0². Guard against the sign + zero edge.
+	rm0Sq := rm0 * rm0
+	rm1Sq := rm1 * rm1
+	den := rm0 * (rm0Sq - rm1Sq)
+
+	for l := 1; l <= L; l++ {
+		if 8*l <= L {
+			// Low-band harmonic: leave M[l] alone (W_l = 1).
+			continue
+		}
+		w := 1.0
+		if den > 0 {
+			c := math.Cos(p.W0 * float64(l))
+			num := rm0Sq + rm1Sq - 2*rm0*rm1*c
+			xi := 0.96 * num / den
+			if xi > 0 {
+				w = math.Pow(xi, 0.25)
+				if w < EnhanceWMin {
+					w = EnhanceWMin
+				} else if w > EnhanceWMax {
+					w = EnhanceWMax
+				}
+			}
+		}
+		M[l] *= w
+	}
+
+	// Energy preservation: rescale so Σ M_enhanced² = R_M0_orig.
+	enhSq := FrameEnergy(M, L)
+	if enhSq <= 0 {
+		return
+	}
+	scale := math.Sqrt(rm0 / enhSq)
+	for l := 1; l <= L; l++ {
+		M[l] *= scale
+	}
+}

--- a/internal/voice/imbe/enhance_test.go
+++ b/internal/voice/imbe/enhance_test.go
@@ -1,0 +1,316 @@
+package imbe
+
+import (
+	"math"
+	"testing"
+)
+
+const enhanceEpsilon = 1e-9
+
+// TestEnhanceAmplitudesSilentNoOp: silent frames leave M untouched
+// so callers can invoke unconditionally on the synthesis path.
+func TestEnhanceAmplitudesSilentNoOp(t *testing.T) {
+	p := Params{Header: Header{Silent: true}}
+	var M [57]float64
+	for l := 1; l <= 10; l++ {
+		M[l] = float64(l) * 0.1
+	}
+	want := M
+	EnhanceAmplitudes(p, &M)
+	if M != want {
+		t.Errorf("Silent: M mutated; got %v want %v", M, want)
+	}
+}
+
+// TestEnhanceAmplitudesZeroLNoOp: L = 0 frames leave M untouched.
+func TestEnhanceAmplitudesZeroLNoOp(t *testing.T) {
+	p := Params{Header: Header{W0: 0.1, L: 0}}
+	var M [57]float64
+	for l := 1; l <= 10; l++ {
+		M[l] = 1.0
+	}
+	want := M
+	EnhanceAmplitudes(p, &M)
+	if M != want {
+		t.Errorf("L=0: M mutated; got %v want %v", M, want)
+	}
+}
+
+// TestEnhanceAmplitudesAllZeroNoOp: a degenerate frame with R_M0
+// = 0 (every M[l] = 0) is left alone — there's nothing to enhance
+// or rescale.
+func TestEnhanceAmplitudesAllZeroNoOp(t *testing.T) {
+	p := Params{Header: Header{W0: math.Pi / 30, L: 10, K: 4}}
+	var M [57]float64
+	want := M
+	EnhanceAmplitudes(p, &M)
+	if M != want {
+		t.Errorf("All-zero M: mutated; got %v want %v", M, want)
+	}
+}
+
+// TestEnhanceAmplitudesEnergyPreserved: regardless of input, the
+// total energy R_M0 = Σ M_l² before and after enhancement must
+// agree (the per-harmonic multiply followed by the global rescale
+// normalizes to the original total energy). Pins the energy
+// preservation contract that makes the §6.2 enhancement safe to
+// drop into the synthesis path.
+func TestEnhanceAmplitudesEnergyPreserved(t *testing.T) {
+	p := Params{Header: Header{W0: math.Pi / 30, L: 12, K: 5}}
+	var M [57]float64
+	// Skewed input: amplitudes vary by 10x across harmonics.
+	M[1] = 0.5
+	M[2] = 1.0
+	M[3] = 0.3
+	M[4] = 2.0
+	M[5] = 0.8
+	M[6] = 0.4
+	M[7] = 1.5
+	M[8] = 0.9
+	M[9] = 0.2
+	M[10] = 1.1
+	M[11] = 0.6
+	M[12] = 0.7
+	rm0Before := FrameEnergy(&M, p.L)
+
+	EnhanceAmplitudes(p, &M)
+	rm0After := FrameEnergy(&M, p.L)
+
+	if math.Abs(rm0Before-rm0After) > 1e-9 {
+		t.Errorf("energy not preserved: before=%v after=%v",
+			rm0Before, rm0After)
+	}
+}
+
+// TestEnhanceAmplitudesUniformBoundedAndNonzero: a uniform-amplitude
+// spectrum doesn't pass through *unchanged* (per-harmonic W depends
+// on cos(ω₀·l), which varies across l), but every harmonic must stay
+// strictly positive and within a sane envelope. Pins that uniform
+// input doesn't degenerate into zeros + that enhancement reshapes
+// rather than destroys.
+func TestEnhanceAmplitudesUniformBoundedAndNonzero(t *testing.T) {
+	p := Params{Header: Header{W0: math.Pi / 30, L: 16, K: 6}}
+	var M [57]float64
+	for l := 1; l <= p.L; l++ {
+		M[l] = 1.0
+	}
+
+	EnhanceAmplitudes(p, &M)
+
+	for l := 1; l <= p.L; l++ {
+		if M[l] <= 0 {
+			t.Errorf("uniform input l=%d: M=%v, want > 0", l, M[l])
+		}
+		// With a global rescale that preserves R_M0 = L = 16 and W
+		// clamped in [0.5, 1.2], no harmonic can scale by more than
+		// ~2.4× either direction even after the rescale.
+		if M[l] > 5 || M[l] < 0.05 {
+			t.Errorf("uniform input l=%d: M=%v out of sane envelope [0.05, 5]",
+				l, M[l])
+		}
+	}
+}
+
+// TestEnhanceAmplitudesLowBandUntouchedBeforeRescale: harmonics with
+// 8·l ≤ L are in the "low band" the §6.2 algorithm leaves at W = 1.
+// They still get the global energy-preservation rescale, so the
+// ratio between two low-band harmonics is preserved exactly.
+func TestEnhanceAmplitudesLowBandUntouchedBeforeRescale(t *testing.T) {
+	// L = 16 → low band is l ≤ 2 (since 8·2 = 16 ≤ 16, but 8·3 = 24 > 16).
+	p := Params{Header: Header{W0: math.Pi / 30, L: 16, K: 6}}
+	var M [57]float64
+	for l := 1; l <= p.L; l++ {
+		M[l] = 1.0
+	}
+	M[1] = 0.7
+	M[2] = 0.3
+
+	EnhanceAmplitudes(p, &M)
+
+	// Ratio M[1] / M[2] should still be 0.7 / 0.3 since both got
+	// the same global rescale and no per-harmonic weight (W = 1 for
+	// both — they're both in the low band).
+	got := M[1] / M[2]
+	want := 0.7 / 0.3
+	if math.Abs(got-want) > 1e-6 {
+		t.Errorf("low-band ratio = %v, want %v", got, want)
+	}
+}
+
+// TestEnhanceAmplitudesPreservesMidbandHarmonicCount: the
+// enhancement may not zero any of the L harmonics — the W clamp
+// at EnhanceWMin = 0.5 ensures every harmonic comes out positive
+// for any non-degenerate frame. Pins that the §6.2 step doesn't
+// accidentally silence harmonics.
+func TestEnhanceAmplitudesPreservesMidbandHarmonicCount(t *testing.T) {
+	p := Params{Header: Header{W0: math.Pi / 22, L: 22, K: 8}}
+	var M [57]float64
+	// Steeply skewed spectrum to exercise the clamp boundary.
+	for l := 1; l <= p.L; l++ {
+		M[l] = math.Pow(2, -float64(l)/3) // M[1]=0.79, M[22]=6e-3
+	}
+	EnhanceAmplitudes(p, &M)
+	for l := 1; l <= p.L; l++ {
+		if M[l] <= 0 {
+			t.Errorf("M[%d] = %v after enhancement; should stay positive",
+				l, M[l])
+		}
+	}
+}
+
+// TestEnhanceWMinMaxBound: a hand-picked frame produces a per-harmonic
+// W that without clamping would fall outside [EnhanceWMin,
+// EnhanceWMax]. Verify the clamp keeps the eventual M[l] / M_orig[l]
+// (compensated for global rescale) within a sane band.
+func TestEnhanceWMinMaxBound(t *testing.T) {
+	// A near-pure-tone spectrum (most energy on one harmonic) makes
+	// R_M1² ≈ R_M0², which sends den → 0 and would blow up xi if
+	// unclamped.
+	p := Params{Header: Header{W0: math.Pi / 30, L: 12, K: 5}}
+	var M [57]float64
+	M[1] = 10.0
+	for l := 2; l <= p.L; l++ {
+		M[l] = 0.01
+	}
+	rm0Before := FrameEnergy(&M, p.L)
+
+	EnhanceAmplitudes(p, &M)
+
+	rm0After := FrameEnergy(&M, p.L)
+	if math.Abs(rm0Before-rm0After) > 1e-6 {
+		t.Errorf("near-pure-tone: energy not preserved %v → %v",
+			rm0Before, rm0After)
+	}
+	for l := 1; l <= p.L; l++ {
+		if math.IsNaN(M[l]) || math.IsInf(M[l], 0) {
+			t.Errorf("M[%d] = %v (NaN / Inf) — clamp didn't catch the den→0 case",
+				l, M[l])
+		}
+	}
+}
+
+// TestEnhanceAmplitudesAtOrPastClampHigh: a frame where the
+// closed-form weight exceeds EnhanceWMax should get clamped down.
+// Hard to engineer the exact w > 1.2 case from a clean input —
+// instead just verify the bound holds across a sweep of L values
+// + skewed amplitude profiles (no per-harmonic ratio after
+// enhancement should jump by more than EnhanceWMax / EnhanceWMin
+// = 2.4× compared to the global rescale).
+func TestEnhanceAmplitudesAtOrPastClampHigh(t *testing.T) {
+	for _, L := range []int{10, 20, 30, 40, 56} {
+		p := Params{Header: Header{W0: math.Pi / float64(L+5), L: L, K: 4}}
+		var M [57]float64
+		for l := 1; l <= L; l++ {
+			M[l] = 1.0 + 0.5*math.Sin(float64(l)) // varied
+		}
+		var orig [57]float64
+		copy(orig[:], M[:])
+
+		EnhanceAmplitudes(p, &M)
+
+		// Each harmonic ratio M[l] / M_orig[l] is W_l × global_scale.
+		// The largest and smallest ratios across l differ by at most
+		// EnhanceWMax / EnhanceWMin (the W bounds; global_scale is
+		// constant across l).
+		var minR, maxR = math.MaxFloat64, 0.0
+		for l := 1; l <= L; l++ {
+			if orig[l] == 0 {
+				continue
+			}
+			r := M[l] / orig[l]
+			if r < minR {
+				minR = r
+			}
+			if r > maxR {
+				maxR = r
+			}
+		}
+		if maxR/minR > EnhanceWMax/EnhanceWMin+1e-9 {
+			t.Errorf("L=%d: ratio span %v exceeds W clamp ratio %v",
+				L, maxR/minR, EnhanceWMax/EnhanceWMin)
+		}
+	}
+}
+
+// TestDecodeOutputChangesWithEnhancement: a deterministic Decode
+// run with the §6.2 enhancement enabled should produce *different*
+// PCM output than the synthesizer would have without it. Pins
+// "enhancement is wired into the audio path" rather than being a
+// silent no-op. We can't toggle enhancement off easily without a
+// test fixture, so instead verify: a frame that the enhancement
+// modifies M for produces audio whose RMS is sane (not zero, not
+// saturated).
+func TestDecodeOutputChangesWithEnhancement(t *testing.T) {
+	d := New()
+	frame := make([]byte, FrameBytes) // valid b_0 = 0 frame
+	out, err := d.Decode(frame)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	var sumSq float64
+	for _, s := range out {
+		v := float64(s)
+		sumSq += v * v
+	}
+	rms := math.Sqrt(sumSq / float64(len(out)))
+	if rms == 0 {
+		t.Fatal("decoded output is fully silent; enhancement may have zeroed M")
+	}
+	if rms > 32000 {
+		t.Errorf("rms = %v, want < 32000 (sanity envelope)", rms)
+	}
+}
+
+// TestEnhanceClosedFormSmallCase verifies the per-harmonic weight
+// formula on a hand-derived input where every step can be checked
+// analytically. L = 4 is below 8·1 (= 8), so all 4 harmonics are
+// in the *enhancement* band (8·l > L for all l in 1..4).
+//
+// Inputs: ω₀ = π/2, M = [1, 2, 1, 0.5].
+//
+//	M² = [1, 4, 1, 0.25]; R_M0 = 6.25.
+//	cos(ω₀·l) for l=1..4 = [0, -1, 0, 1]; R_M1 = M²·cos = [0, -4, 0, 0.25] → -3.75.
+//	R_M0² = 39.0625; R_M1² = 14.0625.
+//	den = R_M0 · (R_M0² − R_M1²) = 6.25 · 25 = 156.25.
+//
+// l=1: c=0; num = 39.0625 + 14.0625 − 0 = 53.125; ξ = 0.96·53.125/156.25 = 0.3264; W₁ = 0.3264^0.25.
+// l=2: c=-1; num = 53.125 − 2·6.25·(-3.75)·(-1) = 53.125 − 46.875 = 6.25; ξ = 0.96·6.25/156.25 = 0.0384;
+//      W₂ = 0.0384^0.25 ≈ 0.443 → clamped to 0.5.
+// l=3: same as l=1 → W₃ = W₁.
+// l=4: c=1; num = 53.125 + 46.875 = 100; ξ = 0.96·100/156.25 = 0.6144; W₄ = 0.6144^0.25.
+//
+// Verify pre-rescale ratios (rescale is a global multiplier so
+// M[a]·W[b] / (M[b]·W[a]) is preserved).
+func TestEnhanceClosedFormSmallCase(t *testing.T) {
+	p := Params{Header: Header{W0: math.Pi / 2, L: 4, K: 2}}
+	var M [57]float64
+	M[1] = 1.0
+	M[2] = 2.0
+	M[3] = 1.0
+	M[4] = 0.5
+
+	EnhanceAmplitudes(p, &M)
+
+	// W₁ and W₃ should be identical (same closed-form inputs).
+	r1 := M[1] / 1.0
+	r3 := M[3] / 1.0
+	if math.Abs(r1-r3) > 1e-9 {
+		t.Errorf("W₁ ≠ W₃ — closed form differs for symmetric harmonics: r1=%v r3=%v",
+			r1, r3)
+	}
+
+	// W₄ should be larger than W₁ (ξ₄ > ξ₁ by the closed form;
+	// pow preserves order on positive values).
+	r4 := M[4] / 0.5
+	if r4 <= r1 {
+		t.Errorf("W₄ should be > W₁: r1=%v r4=%v", r1, r4)
+	}
+
+	// W₂ should be the smallest (clamped at 0.5; W₁ and W₄ both
+	// land above 0.5 by the closed form).
+	r2 := M[2] / 2.0
+	if r2 >= r1 || r2 >= r4 {
+		t.Errorf("W₂ should be smallest (clamped): r1=%v r2=%v r4=%v",
+			r1, r2, r4)
+	}
+}


### PR DESCRIPTION
## Summary
Twelfth PR in the IMBE 4400 thread. Second quality polish PR after the audible-voice milestone: lands the §6.2 per-harmonic spectral-amplitude enhancement so the synthesizer's envelope tilts more naturally on playback, with an energy-preserving rescale that keeps total frame power R_M0 stable.

The §6.2 closed form for each harmonic:

```
if 8·l ≤ L:        W_l = 1.0          (low band: untouched)
else:
    c = cos(ω₀ · l)
    num = R_M0² + R_M1² − 2·R_M0·R_M1·c
    den = R_M0 · (R_M0² − R_M1²)
    if den ≤ 0:    W_l = 1.0          (degenerate frame: skip)
    else:
        ξ = 0.96 · num / den
        W_l = ξ^0.25 clamped to [0.5, 1.2]
```

After the per-harmonic multiply, M is rescaled so `Σ M_enhanced² = R_M0_orig`.

## Changes
- **`internal/voice/imbe/enhance.go`** (new) — `EnhanceWMin = 0.5` / `EnhanceWMax = 1.2` constants, `EnhanceAmplitudes(p, M)` in-place per-harmonic multiplier + global rescale. Reuses `FrameEnergy` + `SpectralCosineSum` from amps.go (step 4b) for the R_M0 / R_M1 inputs. Silent + zero-L + all-zero-amp frames are no-ops.
- **`internal/voice/imbe/decoder.go`** — `Decode()` invokes `EnhanceAmplitudes` between `AmplitudesFromLog2Ml` and `SynthVoiced`. Self-contained; no `SynthState` changes.
- **`internal/voice/imbe/doc.go`** — roadmap step 5b marked shipped; step 5c (spec-derived gain calibration) becomes the next polish piece.
- **`README.md`** — IMBE roadmap entry now lists §6.2 enhancement alongside the prior pieces; Decode pipeline summary reflects enhancement; remaining-polish list narrowed to gain calibration + frame-repeat.

## Test plan
- [x] Silent + zero-L + all-zero-M frames are no-ops (M unchanged).
- [x] Energy preservation: R_M0 before == R_M0 after for a skewed input.
- [x] Uniform-amplitude input stays bounded + nonzero in `[0.05, 5]` envelope (uniform M doesn't pass through unchanged because R_M1 ≠ 0 generally).
- [x] Low-band ratio preserved: harmonics with 8·l ≤ L share the same global rescale + W = 1, so M[1]/M[2] is exactly the input ratio.
- [x] Mid-band positivity: a steeply skewed M doesn't get any harmonic zeroed (clamp at `EnhanceWMin` keeps everything > 0).
- [x] Near-pure-tone frame (`R_M1² ≈ R_M0²`, den → 0): no NaN / Inf, energy still preserved.
- [x] Per-harmonic ratio span across L ∈ {10, 20, 30, 40, 56}: `max(M[l]/M_orig[l]) / min(...) ≤ EnhanceWMax / EnhanceWMin = 2.4`.
- [x] Closed-form small case (`L = 4`, `ω₀ = π/2`, `M = [1, 2, 1, 0.5]`): hand-derived expectations — W₁ == W₃, W₄ > W₁, W₂ smallest (clamped at 0.5).
- [x] `TestDecodeOutputChangesWithEnhancement` — end-to-end Decode produces sane RMS audio with enhancement enabled.
- [x] All previously-merged IMBE tests still pass.
- [x] Full `go test ./...` green (rtlsdr CGO build failure is a pre-existing environment issue — librtlsdr not installed — unrelated to this change).

---
_Generated by [Claude Code](https://claude.ai/code/session_01JmSJLqDwr8jLuKtbkzGXNE)_