### PR TITLE
Pure-Go IMBE step 5c: per-frame AGC for output gain calibration

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,24 +108,32 @@ to its own package and lands independently.
   spectral-amplitude enhancement (per-harmonic W_l =
   (0.96 · num/den)^0.25 clamped to [0.5, 1.2] for mid/high-band
   harmonics + low-band W = 1, followed by an energy-preserving
-  rescale that holds R_M0 stable) is in (`enhance.go`).
+  rescale that holds R_M0 stable) is in (`enhance.go`); the
+  output gain calibration is now a per-frame fast-attack /
+  slow-release peak-envelope tracker on the Decoder (target peak
+  24000, attack 0.4, release 0.02, gain clamped to [10, 1e5])
+  with first-frame seeding, freeze-on-silence, and Reset clearing
+  — replaces the prior `pcmGain = 4096` magic constant with
+  consistent loudness across speech-pause-speech transitions.
   **`Decode()` emits real audio**: 88 info bits → params →
   §6.1 prediction → linear Ml → §6.2 enhancement → §6.3 voiced
   harmonic sum + §6.4 unvoiced excitation with overlap-add
-  additive into one buffer → state roll-forward → hard-clip ×
-  placeholder gain → int16 PCM at 8 kHz. Silence-window frames
-  (b_0 ∈ [216, 219]) still fade the prev unvoiced tail through
-  the overlap region before resetting state — no click on the
-  silence boundary. Two decoder constructors are exposed:
-  `New()` seeds the unvoiced noise source from a fixed default
-  for reproducibility; `NewWithSeed(seed)` lets parallel calls
-  + production callers spread noise. Bad-b_0 frames return
-  graceful silence without disturbing the prediction history.
-  **Remaining audio polish**: a spec-derived gain calibration
-  (replacing the placeholder pcmGain = 4096), enhancement
-  filter tuning, and frame-repeat on bad-frame indicator —
-  the absolute output level still differs slightly from mbelib's
-  reference until 5c lands.
+  additive into one buffer → state roll-forward → per-frame AGC
+  → int16 PCM at 8 kHz. Silence-window frames (b_0 ∈ [216, 219])
+  still fade the prev unvoiced tail through the overlap region
+  before resetting SynthState — no click on the silence
+  boundary, and the AGC envelope is preserved across the
+  silence so the next non-silent frame applies the same gain.
+  Two decoder constructors are exposed: `New()` seeds the
+  unvoiced noise source from a fixed default for reproducibility;
+  `NewWithSeed(seed)` lets parallel calls + production callers
+  spread noise. Bad-b_0 frames return graceful silence without
+  disturbing the prediction history. **Remaining audio polish**:
+  enhancement filter tuning + frame-repeat on bad-frame indicator
+  + comparison-tuning the synthesis output level against an
+  mbelib reference — the AGC keeps levels consistent but the
+  absolute calibration to mbelib output is still a future
+  follow-up.
 - **DVSI USB-3000 / AMBE-3003 hardware backend.** A `Vocoder`
   factory that opens a connected DVSI USB chip. Same plug-in shape
   as `internal/voice/mbelib`; the daemon picks the factory by name

--- a/internal/voice/imbe/decoder.go
+++ b/internal/voice/imbe/decoder.go
@@ -2,6 +2,7 @@ package imbe
 
 import (
 	"fmt"
+	"math"
 	"math/rand"
 
 	"github.com/MattCheramie/GopherTrunk/internal/voice"
@@ -34,41 +35,52 @@ const (
 	// into the same binary; the daemon picks one in config.
 	VocoderName = "imbe-go"
 
-	// pcmGain scales the float64 synthesis output before int16
-	// clipping. The voiced step sums L sinusoids of up to
-	// O(unit) amplitude each, so the instantaneous peak can reach
-	// ~L when all cosines align; with L ≤ 56, picking 4096 (2^12)
-	// gives ~3 bits of headroom for the typical mid-L voiced+unvoiced
-	// mix without constantly saturating int16. The §6.2 spectral
-	// amplitude enhancement (a follow-up polish PR) will replace
-	// this with the spec-derived gain.
-	pcmGain = 4096
+	// AGC parameters. The synthesizer's float output magnitude is
+	// stable per-frame (R_M0-preserving §6.2 enhancement holds total
+	// energy constant across a frame) but varies wildly between
+	// frames depending on Tl, voicing, and the §6.4 noise draw.
+	// Without an AGC every frame would be either clipped (loud frames)
+	// or near-silent (quiet frames). The AGC tracks the per-frame
+	// peak with fast-attack / slow-release smoothing, then scales each
+	// frame so the smoothed envelope hits agcTargetPeak.
+	//
+	// agcTargetPeak = 24000 sits ~3 dB below int16 max so the soft
+	// knee of the envelope tracker has headroom for transients.
+	// agcAttack > agcRelease so loud onsets are caught quickly while
+	// gain ramps back up slowly during quiet passages — standard
+	// AGC behavior that keeps speech intelligible without pumping.
+	// agcMinGain / agcMaxGain prevent the envelope from sending
+	// silence to full scale or compressing extreme transients to
+	// inaudible levels.
+	agcTargetPeak = 24000.0
+	agcAttack     = 0.4
+	agcRelease    = 0.02
+	agcMinGain    = 10.0
+	agcMaxGain    = 1e5
+	agcNoiseFloor = 1e-3
 )
 
 // Decoder is the pure-Go IMBE 4400 decoder. It owns one SynthState
 // (cross-frame log2(Ml) prediction memory + voiced phase + amp
-// memory) and one math/rand source for the §6.4 unvoiced excitation
-// noise — both per-call so concurrent calls on different decoders
-// don't share state.
+// memory), one math/rand source for the §6.4 unvoiced excitation
+// noise, and one AGC envelope tracker — all per-call so concurrent
+// calls on different decoders don't share state.
 //
 // Decode() runs the full TIA-102.BABA pipeline:
 //   - bytes → 88 info bits
 //   - UnpackParams: §5.3 / §5.4 / Annex E
 //   - PredictLog2Ml: §6.1 cross-frame prediction
 //   - AmplitudesFromLog2Ml: log2(Ml) → linear Ml
+//   - EnhanceAmplitudes: §6.2 spectral-amplitude enhancement
 //   - SynthVoiced: §6.3 voiced harmonic generator
-//   - SynthUnvoicedFromNoise: §6.4 unvoiced FFT excitation
+//   - SynthUnvoicedOverlapAdd: §6.4 unvoiced FFT excitation + OA
 //   - Update{Log2Ml,VoicedState}: roll state forward
-//   - hard-clip + scale to int16 PCM
-//
-// Audio quality is "first pass": the §6.4 overlap-add window and
-// §6.2 spectral amplitude enhancement are quality-polish steps that
-// land in subsequent PRs. Without them the output has frame-edge
-// click artifacts and untilted spectral envelope, but is otherwise
-// intelligible voice.
+//   - applyAGC: per-frame fast-attack / slow-release peak tracker
+//     scaling to agcTargetPeak, then int16 clip
 type Decoder struct {
 	state SynthState
 	rng   *rand.Rand
+	agc   float64 // smoothed peak envelope; 0 = fresh (next frame seeds it)
 }
 
 // New returns a fresh Decoder. The unvoiced-excitation noise source
@@ -164,11 +176,66 @@ func (d *Decoder) Decode(frame []byte) ([]int16, error) {
 		d.state.UpdateVoicedState(p, &M)
 	}
 
-	// Hard-clip + scale to int16. The pcmGain placeholder gives
-	// headroom; the §6.2 enhancement polish PR will replace it with
-	// the spec gain.
+	d.applyAGC(pcm, out, p.Silent)
+	return out, nil
+}
+
+// applyAGC tracks the per-frame peak with fast-attack / slow-release
+// smoothing and scales pcm so the smoothed envelope hits
+// agcTargetPeak. Frames whose peak falls below agcNoiseFloor leave
+// the envelope unchanged so a tail fade-out into silence doesn't
+// drag the envelope up artificially.
+//
+// First-frame seed: when d.agc == 0 (fresh decoder, post-Reset), the
+// envelope is initialised directly to peak rather than via the attack
+// coefficient. Without this seed the first frame would emerge ~2.5×
+// over-gained (envelope = 0.4 · peak ⇒ gain = target / (0.4 · peak)
+// ⇒ output peak = 2.5 · target ⇒ int16 saturation).
+//
+// Frozen mode (freezeEnvelope = true): apply the existing envelope's
+// gain without updating it. The Decode() silent path uses this so a
+// brief silence frame doesn't shift the AGC envelope based on the
+// small §6.4 overlap-add fade-out content. The first frame after
+// silence then applies the same gain as the last frame before
+// silence — no audible level jump on speech-pause-speech transitions.
+// Stream re-sync via the public Reset() does clear the envelope.
+//
+// agcMinGain / agcMaxGain prevent the envelope from sending
+// silence to full scale or compressing extreme transients to
+// inaudible levels. After the gain multiply, samples beyond int16
+// range are hard-clipped at ±32767.
+func (d *Decoder) applyAGC(pcm []float64, out []int16, freezeEnvelope bool) {
+	if !freezeEnvelope {
+		var peak float64
+		for _, v := range pcm {
+			if a := math.Abs(v); a > peak {
+				peak = a
+			}
+		}
+		if d.agc == 0 && peak > agcNoiseFloor {
+			// First-frame seed: skip attack smoothing so the first frame
+			// lands at exactly agcTargetPeak instead of 2.5× over.
+			d.agc = peak
+		} else if peak > agcNoiseFloor {
+			coef := agcAttack
+			if peak < d.agc {
+				coef = agcRelease
+			}
+			d.agc += (peak - d.agc) * coef
+		}
+	}
+	envelope := d.agc
+	if envelope < agcNoiseFloor {
+		envelope = agcNoiseFloor
+	}
+	gain := agcTargetPeak / envelope
+	if gain < agcMinGain {
+		gain = agcMinGain
+	} else if gain > agcMaxGain {
+		gain = agcMaxGain
+	}
 	for i, v := range pcm {
-		s := v * pcmGain
+		s := v * gain
 		if s > 32767 {
 			s = 32767
 		} else if s < -32768 {
@@ -176,7 +243,6 @@ func (d *Decoder) Decode(frame []byte) ([]int16, error) {
 		}
 		out[i] = int16(s)
 	}
-	return out, nil
 }
 
 // unpackInfoBits expands 11 bytes (MSB-first) into an 88-element
@@ -191,14 +257,15 @@ func unpackInfoBits(frame []byte) []byte {
 
 // Reset clears all per-call synthesis state — the cross-frame
 // log-amplitude prediction history, the voiced harmonic phase +
-// amplitude memory, and any future overlap-add tail. Callers
-// invoke it on stream re-sync (e.g., a frame-loss event from the
-// upstream P25 LDU decoder) so the next frame starts from a clean
-// baseline. The noise source is intentionally not re-seeded —
-// noise reproducibility is a constructor concern (New /
-// NewWithSeed), not a per-call concern.
+// amplitude memory, the §6.4 overlap-add tail, and the AGC
+// envelope. Callers invoke it on stream re-sync (e.g., a frame-
+// loss event from the upstream P25 LDU decoder) so the next frame
+// starts from a clean baseline. The noise source is intentionally
+// not re-seeded — noise reproducibility is a constructor concern
+// (New / NewWithSeed), not a per-call concern.
 func (d *Decoder) Reset() {
 	d.state.Reset()
+	d.agc = 0
 }
 
 // Close releases any resources held by the decoder. The pure-Go

--- a/internal/voice/imbe/decoder_test.go
+++ b/internal/voice/imbe/decoder_test.go
@@ -1,6 +1,7 @@
 package imbe
 
 import (
+	"math"
 	"testing"
 
 	"github.com/MattCheramie/GopherTrunk/internal/voice"
@@ -357,5 +358,188 @@ func TestDecodeOutputIsBounded(t *testing.T) {
 				t.Errorf("output longer than expected at pattern 0x%02X", fill)
 			}
 		}
+	}
+}
+
+// agcPeak finds the absolute peak in an int16 slice — used by AGC
+// tests to verify per-frame normalization.
+func agcPeak(out []int16) int {
+	var peak int
+	for _, s := range out {
+		v := int(s)
+		if v < 0 {
+			v = -v
+		}
+		if v > peak {
+			peak = v
+		}
+	}
+	return peak
+}
+
+// TestAGCConvergesTowardTarget: feeding the same valid frame
+// repeatedly drives the smoothed envelope toward the per-frame peak,
+// so by frame ~30 the output peak should sit close to agcTargetPeak.
+// Pins that the AGC actually adapts (rather than being a fixed
+// constant gain).
+func TestAGCConvergesTowardTarget(t *testing.T) {
+	d := New()
+	frame := make([]byte, FrameBytes) // valid b_0=0 frame
+	var lastPeak int
+	for i := 0; i < 30; i++ {
+		out, err := d.Decode(frame)
+		if err != nil {
+			t.Fatalf("frame %d: %v", i, err)
+		}
+		lastPeak = agcPeak(out)
+	}
+	// After convergence the peak should be within ~30% of the target
+	// (loose because the §6.4 noise draw varies per frame).
+	const tol = 0.3
+	lo := int(agcTargetPeak * (1 - tol))
+	hi := int(agcTargetPeak * (1 + tol))
+	if lastPeak < lo || lastPeak > hi {
+		t.Errorf("converged peak = %d, want in [%d, %d] (target=%v ±%.0f%%)",
+			lastPeak, lo, hi, agcTargetPeak, tol*100)
+	}
+}
+
+// TestAGCInitialFrameNotOverAmplified: the first frame on a fresh
+// decoder seeds the envelope from peak (since envelope starts at 0,
+// peak > envelope, so attack coefficient applies). Output peak on
+// frame 1 should be within int16 range and not produce all-zero or
+// all-saturated samples (which would indicate a divide-by-zero or
+// gain explosion at the first-frame edge).
+func TestAGCInitialFrameNotOverAmplified(t *testing.T) {
+	d := New()
+	frame := make([]byte, FrameBytes)
+	out, err := d.Decode(frame)
+	if err != nil {
+		t.Fatal(err)
+	}
+	peak := agcPeak(out)
+	if peak == 0 {
+		t.Error("first-frame peak = 0 (silent output, expected unvoiced excitation)")
+	}
+	if peak >= 32767 {
+		t.Errorf("first-frame peak = %d (clipped); AGC should land below int16 max", peak)
+	}
+}
+
+// TestAGCSilenceFramePreservesEnvelope: a silence-window frame
+// (b_0 ∈ [216, 219]) clears the §6.1/§6.3/§6.4 SynthState but
+// preserves the AGC envelope so the first frame after silence
+// applies the same gain as the last frame before silence (no
+// audible level jump on speech-pause-speech transitions). Public
+// Reset() does clear the envelope (covered separately).
+func TestAGCSilenceFramePreservesEnvelope(t *testing.T) {
+	d := New()
+	for i := 0; i < 5; i++ {
+		if _, err := d.Decode(make([]byte, FrameBytes)); err != nil {
+			t.Fatalf("seed frame %d: %v", i, err)
+		}
+	}
+	if d.agc == 0 {
+		t.Fatal("envelope is still zero after seed frames; test setup invalid")
+	}
+	envBefore := d.agc
+
+	silence := make([]byte, FrameBytes)
+	silence[0] = 0xD8
+	if _, err := d.Decode(silence); err != nil {
+		t.Fatalf("silence: %v", err)
+	}
+	// Envelope must not drift at all — silence path passes
+	// freezeEnvelope=true to applyAGC so the OA tail magnitude
+	// doesn't perturb the envelope.
+	if d.agc != envBefore {
+		t.Errorf("after silence: agc shifted from %v to %v (want exact preservation)",
+			envBefore, d.agc)
+	}
+}
+
+// TestAGCResetClearsEnvelope: the Reset method (e.g., called on
+// stream re-sync) must zero the envelope so the next frame's AGC
+// starts from a clean baseline.
+func TestAGCResetClearsEnvelope(t *testing.T) {
+	d := New()
+	if _, err := d.Decode(make([]byte, FrameBytes)); err != nil {
+		t.Fatal(err)
+	}
+	if d.agc == 0 {
+		t.Fatal("envelope is zero after one frame; test setup invalid")
+	}
+	d.Reset()
+	if d.agc != 0 {
+		t.Errorf("after Reset: agc = %v, want 0", d.agc)
+	}
+}
+
+// TestAGCBoundedOutputAcrossFramePatterns confirms the output stays
+// in valid int16 range for a range of frame patterns + frame
+// counts. Catches AGC regressions that send the gain to NaN or Inf.
+func TestAGCBoundedOutputAcrossFramePatterns(t *testing.T) {
+	d := New()
+	patterns := [][]byte{
+		make([]byte, FrameBytes),
+		{0x55, 0xAA, 0x55, 0xAA, 0x55, 0xAA, 0x55, 0xAA, 0x55, 0xAA, 0x55},
+		{0xAA, 0x55, 0xAA, 0x55, 0xAA, 0x55, 0xAA, 0x55, 0xAA, 0x55, 0xAA},
+	}
+	for round := 0; round < 10; round++ {
+		for _, frame := range patterns {
+			out, err := d.Decode(frame)
+			if err != nil {
+				t.Fatalf("Decode: %v", err)
+			}
+			for i, s := range out {
+				_ = i
+				_ = s // every int16 is by construction in [-32768, 32767]
+			}
+			// Cross-check that the AGC didn't NaN.
+			if math.IsNaN(d.agc) || math.IsInf(d.agc, 0) {
+				t.Fatalf("agc envelope = %v after round %d", d.agc, round)
+			}
+		}
+	}
+}
+
+// TestAGCDoesNotPumpOnConstantInput: feeding the same frame
+// repeatedly should produce stable output peaks across frames
+// (variance in peak across the last 10 frames < 30% of mean). The
+// fast-attack / slow-release smoothing is what avoids per-frame
+// pumping that would be audible as breathing.
+func TestAGCDoesNotPumpOnConstantInput(t *testing.T) {
+	d := New()
+	frame := make([]byte, FrameBytes)
+	// Warm up the envelope.
+	for i := 0; i < 30; i++ {
+		if _, err := d.Decode(frame); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Sample the next 10 frames' peaks.
+	var peaks [10]int
+	for i := range peaks {
+		out, err := d.Decode(frame)
+		if err != nil {
+			t.Fatal(err)
+		}
+		peaks[i] = agcPeak(out)
+	}
+	var sum int
+	for _, p := range peaks {
+		sum += p
+	}
+	mean := float64(sum) / float64(len(peaks))
+	var variance float64
+	for _, p := range peaks {
+		d := float64(p) - mean
+		variance += d * d
+	}
+	variance /= float64(len(peaks))
+	stddev := math.Sqrt(variance)
+	if stddev/mean > 0.3 {
+		t.Errorf("peak stddev/mean = %.3f, want < 0.30 (pumping check)",
+			stddev/mean)
 	}
 }

--- a/internal/voice/imbe/doc.go
+++ b/internal/voice/imbe/doc.go
@@ -122,10 +122,19 @@
 //     naturally on playback. Wired into Decoder.Decode between
 //     AmplitudesFromLog2Ml and SynthVoiced. See enhance.go.
 //
-//  5c. Spec-derived gain calibration. Replaces the placeholder
-//     pcmGain = 4096 with the gain that makes mbelib + imbe-go
-//     produce comparable output levels for the same input frame
-//     stream.
+//  5c. Output gain calibration via per-frame AGC. ← THIS PR.
+//     Replaces the placeholder pcmGain = 4096 constant scale with
+//     a fast-attack / slow-release peak-envelope tracker on the
+//     Decoder. Each frame's pcm peak updates the smoothed
+//     envelope (skipping update on near-silent peaks below
+//     agcNoiseFloor); gain = agcTargetPeak / envelope clamped to
+//     [agcMinGain, agcMaxGain]; samples beyond int16 range hard-clip.
+//     The first frame seeds the envelope directly to its peak so
+//     it lands at exactly agcTargetPeak instead of being 2.5×
+//     over-gained. Silence-window frames pass freezeEnvelope=true
+//     so the §6.4 OA fade-out tail doesn't perturb the envelope —
+//     speech-pause-speech transitions emerge at consistent
+//     loudness without audible level pumping. See decoder.go.
 //
 //  5d. Robustness polish: enhancement filter, frame-repeat on
 //     bad-frame indicator, gain smoothing across frames.


### PR DESCRIPTION
## Summary
Thirteenth PR in the IMBE 4400 thread. Third quality polish PR after the audible-voice milestone: replaces the placeholder `pcmGain = 4096` magic constant with a fast-attack / slow-release peak-envelope tracker on the Decoder. Each frame now lands at consistent loudness regardless of its natural synthesizer magnitude — speech-pause-speech transitions stay level, no audible pumping on adjacent frames.

## Design
- **Envelope tracker**: per-frame peak feeds a smoothed envelope via fast attack (0.4) on rising peaks, slow release (0.02) on falling peaks. Standard AGC behavior — catches transients without compressing them flat, ramps gain back up slowly during quiet passages.
- **Target peak**: 24000 (~3 dB below int16 max for transient headroom).
- **First-frame seed**: when `d.agc == 0` (fresh decoder / post-Reset), the envelope is set directly to the first frame's peak, avoiding the 2.5×-over-gained first frame that attack-only smoothing would produce.
- **Freeze-on-silence**: the silent-window path passes `freezeEnvelope = true` so the §6.4 OA fade-out content doesn't perturb the envelope. Speech-pause-speech transitions emerge at consistent loudness.
- **Bounds**: `agcMinGain = 10` / `agcMaxGain = 1e5` prevent the envelope from sending silence to full scale or compressing extreme transients to inaudibility.

## Changes
- **`internal/voice/imbe/decoder.go`** — `pcmGain` removed; AGC parameter block + `Decoder.agc` field + `applyAGC(pcm, out, freezeEnvelope)` method added. Decode silent path passes `freezeEnvelope = true`. Public `Reset()` clears both `SynthState` and AGC.
- **`internal/voice/imbe/decoder_test.go`** — 6 new AGC tests.
- **`internal/voice/imbe/doc.go`** — step 5c marked shipped; step 5d (robustness polish + mbelib level calibration) becomes the remaining IMBE work.
- **`README.md`** — IMBE roadmap entry describes the AGC; Decode pipeline summary updated; remaining-polish list narrowed.

## Test plan
- [x] `TestAGCConvergesTowardTarget` — 30 frames of the same input drive output peak within 30% of `agcTargetPeak`.
- [x] `TestAGCInitialFrameNotOverAmplified` — first-frame seed avoids int16 saturation.
- [x] `TestAGCSilenceFramePreservesEnvelope` — silence-window frame leaves `d.agc` exactly unchanged (`freezeEnvelope` contract).
- [x] `TestAGCResetClearsEnvelope` — explicit `Reset()` zeroes `d.agc`.
- [x] `TestAGCBoundedOutputAcrossFramePatterns` — multi-pattern multi-round test catches NaN / Inf in envelope or gain math.
- [x] `TestAGCDoesNotPumpOnConstantInput` — same frame repeated produces stable output peaks (stddev/mean < 0.30 over 10 frames after warmup).
- [x] All previously-merged decoder tests still pass.
- [x] Full `go test ./...` green (rtlsdr CGO build failure is a pre-existing environment issue — librtlsdr not installed — unrelated to this change).

---
_Generated by [Claude Code](https://claude.ai/code/session_01JmSJLqDwr8jLuKtbkzGXNE)_