### PR TITLE
Pure-Go IMBE step 5d: frame-repeat on bad-frame indicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,13 +127,18 @@ to its own package and lands independently.
   Two decoder constructors are exposed: `New()` seeds the
   unvoiced noise source from a fixed default for reproducibility;
   `NewWithSeed(seed)` lets parallel calls + production callers
-  spread noise. Bad-b_0 frames return graceful silence without
-  disturbing the prediction history. **Remaining audio polish**:
-  enhancement filter tuning + frame-repeat on bad-frame indicator
-  + comparison-tuning the synthesis output level against an
-  mbelib reference — the AGC keeps levels consistent but the
-  absolute calibration to mbelib output is still a future
-  follow-up.
+  spread noise. **Frame-repeat on bad-frame indicator**: a bad
+  frame (UnpackParams error from upstream FEC slip) following a
+  good frame replays the cached params with M scaled by 0.7 per
+  consecutive bad frame; up to 6 consecutive bad frames bridge
+  ~120 ms of weak signal before Decode emits silence + clears the
+  cache. The repeat path freezes the AGC envelope so the
+  attenuation is audible (signals signal degradation). **Remaining
+  audio polish**: comparison-tuning the synthesis output level
+  against an mbelib reference (the AGC keeps levels consistent
+  but the absolute calibration to mbelib output is still a future
+  follow-up); enhancement filter tuning if real-world frames show
+  mid-band envelope drift.
 - **DVSI USB-3000 / AMBE-3003 hardware backend.** A `Vocoder`
   factory that opens a connected DVSI USB chip. Same plug-in shape
   as `internal/voice/mbelib`; the daemon picks the factory by name

--- a/internal/voice/imbe/decoder.go
+++ b/internal/voice/imbe/decoder.go
@@ -58,13 +58,33 @@ const (
 	agcMinGain    = 10.0
 	agcMaxGain    = 1e5
 	agcNoiseFloor = 1e-3
+
+	// MaxBadFrames is the number of consecutive bad frames the
+	// frame-repeat path will replay before giving up and emitting
+	// silence + clearing state. The TIA-102.BABA spec range is
+	// 1..6; mbelib uses 6, which gives the upstream P25 LDU FEC
+	// roughly 120 ms of grace before the audio path drops out
+	// completely. After MaxBadFrames bad frames the cumulative
+	// attenuation is BadFrameAttenuation^6 ≈ 0.118 — quiet enough
+	// that an extended bad streak fades naturally rather than
+	// looping the same envelope.
+	MaxBadFrames = 6
+
+	// BadFrameAttenuation is the per-frame multiplier applied to
+	// the cached last-good amplitudes during a frame-repeat. A
+	// single bad frame plays at 70% of the prev good frame's
+	// amplitudes; six in a row taper to ~12%. This is a balance
+	// between hiding the FEC slip (no abrupt mute) and signalling
+	// the listener that signal is degrading (audible volume drop).
+	BadFrameAttenuation = 0.7
 )
 
 // Decoder is the pure-Go IMBE 4400 decoder. It owns one SynthState
 // (cross-frame log2(Ml) prediction memory + voiced phase + amp
 // memory), one math/rand source for the §6.4 unvoiced excitation
-// noise, and one AGC envelope tracker — all per-call so concurrent
-// calls on different decoders don't share state.
+// noise, one AGC envelope tracker, and a one-frame cache of the
+// last-good parameters for the frame-repeat path — all per-call
+// so concurrent calls on different decoders don't share state.
 //
 // Decode() runs the full TIA-102.BABA pipeline:
 //   - bytes → 88 info bits
@@ -77,10 +97,29 @@ const (
 //   - Update{Log2Ml,VoicedState}: roll state forward
 //   - applyAGC: per-frame fast-attack / slow-release peak tracker
 //     scaling to agcTargetPeak, then int16 clip
+//
+// On a bad frame (UnpackParams returns ErrInvalidFundamental, etc.),
+// Decode replays the last good frame's amplitudes scaled by
+// BadFrameAttenuation^badFrameCount. After MaxBadFrames consecutive
+// bad frames the cache is cleared and Decode returns silence so an
+// extended bad streak fades naturally instead of looping the same
+// envelope forever.
 type Decoder struct {
 	state SynthState
 	rng   *rand.Rand
 	agc   float64 // smoothed peak envelope; 0 = fresh (next frame seeds it)
+
+	// One-frame cache for the frame-repeat path. Populated after a
+	// good non-silent frame; consumed by the bad-frame path; cleared
+	// on silence-window frames + on Reset + when MaxBadFrames is
+	// exceeded.
+	lastGoodParams Params
+	lastGoodLog2M  [57]float64
+	lastGoodM      [57]float64
+
+	// Consecutive bad-frame count. Increments once per replay,
+	// resets to 0 on every good non-silent frame.
+	badFrameCount int
 }
 
 // New returns a fresh Decoder. The unvoiced-excitation noise source
@@ -114,11 +153,21 @@ func (d *Decoder) FrameSize() int { return FrameBytes }
 // runs the full TIA-102.BABA pipeline, and returns 160 int16 PCM
 // samples at 8 kHz.
 //
-// Frames with an invalid fundamental-frequency parameter (b_0 ≥ 220
-// or b_0 in {208..215}) decode as silence so the upstream P25 LDU
-// FEC slip doesn't crash the audio path; on these frames the
-// SynthState is left untouched so the next valid frame picks up
-// from the last-known-good prediction history.
+// Frame disposition:
+//
+//   - good non-silent frame: full synthesis pipeline; cache p +
+//     log2M + M for the next bad frame's repeat path; reset
+//     badFrameCount.
+//   - silence-window frame (b_0 ∈ [216, 219]): emit §6.4 OA tail
+//     fade-out into pcm[0..95]; reset SynthState + last-good cache
+//     + badFrameCount; AGC envelope preserved across the silence.
+//   - bad frame (UnpackParams error) with cached last-good frame
+//     and badFrameCount < MaxBadFrames: replay last-good params
+//     with M scaled by BadFrameAttenuation^badFrameCount; AGC
+//     freezes so the attenuation is audible (signals signal loss).
+//   - bad frame with no cache, or after MaxBadFrames consecutive
+//     bad frames: emit silence; clear last-good cache + reset
+//     SynthState; AGC envelope preserved.
 func (d *Decoder) Decode(frame []byte) ([]int16, error) {
 	if len(frame) != FrameBytes {
 		return nil, fmt.Errorf("imbe: frame must be %d bytes (88 bits), got %d", FrameBytes, len(frame))
@@ -126,58 +175,93 @@ func (d *Decoder) Decode(frame []byte) ([]int16, error) {
 
 	info := unpackInfoBits(frame)
 	out := make([]int16, SamplesPerFrame)
-
-	p, err := UnpackParams(info)
-	if err != nil {
-		// Bad frame — graceful silence. State preserved so the next
-		// valid frame's cross-frame prediction has the previous
-		// good frame's history.
-		return out, nil
-	}
-
 	pcm := make([]float64, SamplesPerFrame)
 
-	if p.Silent {
+	p, err := UnpackParams(info)
+
+	switch {
+	case err != nil && d.lastGoodParams.L > 0 && d.badFrameCount < MaxBadFrames:
+		// Frame repeat: replay the last-good params with progressive
+		// per-frame attenuation. Synthesis still runs (so OA tail +
+		// phase memory continue rolling forward), AGC freezes so the
+		// attenuation is audible.
+		d.badFrameCount++
+		atten := math.Pow(BadFrameAttenuation, float64(d.badFrameCount))
+		repeatedM := d.lastGoodM
+		for l := 1; l <= d.lastGoodParams.L; l++ {
+			repeatedM[l] *= atten
+		}
+		d.synthFrame(d.lastGoodParams, &d.lastGoodLog2M, &repeatedM, pcm)
+		d.applyAGC(pcm, out, true)
+		return out, nil
+
+	case err != nil:
+		// Bad frame with no cache, or bad-frame budget exhausted:
+		// emit silence + clear cache + reset SynthState. AGC envelope
+		// preserved so audio level is consistent when good frames
+		// return.
+		d.state.Reset()
+		d.clearLastGood()
+		d.applyAGC(pcm, out, true)
+		return out, nil
+
+	case p.Silent:
 		// b_0 ∈ [216, 219]: explicit silence indicator. Run the §6.4
 		// overlap-add with no new noise so the prev-frame unvoiced
 		// tail still fades into pcm[0..95] (no click on the silence
-		// boundary), then reset all cross-frame state so the next
-		// non-silent frame starts from a clean baseline (§6.1
-		// prediction needs no prev-frame anchor on a silence
-		// boundary).
+		// boundary), then reset SynthState + last-good cache so the
+		// next non-silent frame starts from a clean baseline.
 		SynthUnvoicedOverlapAdd(&d.state, p, nil, nil, pcm)
 		d.state.Reset()
-	} else {
-		// §6.1: cross-frame log-amplitude recovery.
-		var log2M [57]float64
-		PredictLog2Ml(&d.state, p, &log2M)
-
-		// log2(Ml) → linear Ml, then §6.2 spectral-amplitude
-		// enhancement (per-harmonic weight from R_M0 + R_M1, plus
-		// energy-preserving rescale).
-		var M [57]float64
-		AmplitudesFromLog2Ml(&log2M, p.L, &M)
-		EnhanceAmplitudes(p, &M)
-
-		// §6.3: voiced harmonic generator (additive into pcm).
-		SynthVoiced(&d.state, p, &M, pcm)
-
-		// §6.4: unvoiced FFT excitation with overlap-add (additive
-		// into pcm). Threads PrevUnvoicedTail through SynthState so
-		// frame boundaries are click-free.
-		noise := make([]float64, UnvoicedFFTSize)
-		for i := range noise {
-			noise[i] = d.rng.NormFloat64()
-		}
-		SynthUnvoicedOverlapAdd(&d.state, p, &M, noise, pcm)
-
-		// Roll cross-frame state forward.
-		d.state.UpdateLog2Ml(p, &log2M)
-		d.state.UpdateVoicedState(p, &M)
+		d.clearLastGood()
+		d.applyAGC(pcm, out, true)
+		return out, nil
 	}
 
-	d.applyAGC(pcm, out, p.Silent)
+	// Good non-silent frame.
+	d.badFrameCount = 0
+	var log2M [57]float64
+	PredictLog2Ml(&d.state, p, &log2M)
+
+	var M [57]float64
+	AmplitudesFromLog2Ml(&log2M, p.L, &M)
+	EnhanceAmplitudes(p, &M)
+
+	d.synthFrame(p, &log2M, &M, pcm)
+
+	// Cache for the frame-repeat path on a future bad frame.
+	d.lastGoodParams = p
+	d.lastGoodLog2M = log2M
+	d.lastGoodM = M
+
+	d.applyAGC(pcm, out, false)
 	return out, nil
+}
+
+// synthFrame runs the §6.3 voiced + §6.4 unvoiced overlap-add legs
+// of the pipeline and rolls SynthState forward by log2M / M. Used
+// by both the good-frame path and the bad-frame replay path so the
+// two share identical synthesis behavior — the only difference is
+// what M values get fed in.
+func (d *Decoder) synthFrame(p Params, log2M *[57]float64, M *[57]float64, pcm []float64) {
+	SynthVoiced(&d.state, p, M, pcm)
+	noise := make([]float64, UnvoicedFFTSize)
+	for i := range noise {
+		noise[i] = d.rng.NormFloat64()
+	}
+	SynthUnvoicedOverlapAdd(&d.state, p, M, noise, pcm)
+	d.state.UpdateLog2Ml(p, log2M)
+	d.state.UpdateVoicedState(p, M)
+}
+
+// clearLastGood resets the frame-repeat cache + bad-frame counter.
+// Called on silence-window frames, on the bad-frame budget being
+// exceeded, and from the public Reset.
+func (d *Decoder) clearLastGood() {
+	d.lastGoodParams = Params{}
+	d.lastGoodLog2M = [57]float64{}
+	d.lastGoodM = [57]float64{}
+	d.badFrameCount = 0
 }
 
 // applyAGC tracks the per-frame peak with fast-attack / slow-release
@@ -257,15 +341,17 @@ func unpackInfoBits(frame []byte) []byte {
 
 // Reset clears all per-call synthesis state — the cross-frame
 // log-amplitude prediction history, the voiced harmonic phase +
-// amplitude memory, the §6.4 overlap-add tail, and the AGC
-// envelope. Callers invoke it on stream re-sync (e.g., a frame-
-// loss event from the upstream P25 LDU decoder) so the next frame
-// starts from a clean baseline. The noise source is intentionally
-// not re-seeded — noise reproducibility is a constructor concern
-// (New / NewWithSeed), not a per-call concern.
+// amplitude memory, the §6.4 overlap-add tail, the AGC envelope,
+// and the frame-repeat cache + bad-frame counter. Callers invoke
+// it on stream re-sync (e.g., a frame-loss event from the upstream
+// P25 LDU decoder) so the next frame starts from a clean baseline.
+// The noise source is intentionally not re-seeded — noise
+// reproducibility is a constructor concern (New / NewWithSeed),
+// not a per-call concern.
 func (d *Decoder) Reset() {
 	d.state.Reset()
 	d.agc = 0
+	d.clearLastGood()
 }
 
 // Close releases any resources held by the decoder. The pure-Go

--- a/internal/voice/imbe/decoder_test.go
+++ b/internal/voice/imbe/decoder_test.go
@@ -543,3 +543,206 @@ func TestAGCDoesNotPumpOnConstantInput(t *testing.T) {
 			stddev/mean)
 	}
 }
+
+// badFrame returns an 11-byte frame whose b_0 = 208 — an invalid
+// fundamental-frequency parameter that UnpackParams rejects with
+// ErrInvalidFundamental.
+func badFrame() []byte {
+	f := make([]byte, FrameBytes)
+	f[0] = 0xD0 // 0b11010000 → b_0 packs to 208 (invalid)
+	return f
+}
+
+// TestFrameRepeatOnBadFrameAfterGood: a bad frame following a good
+// frame replays the cached params with attenuation — the output
+// must be non-zero (proving the repeat actually synthesized rather
+// than emitting silence).
+func TestFrameRepeatOnBadFrameAfterGood(t *testing.T) {
+	d := New()
+	if _, err := d.Decode(make([]byte, FrameBytes)); err != nil {
+		t.Fatalf("good seed: %v", err)
+	}
+	if d.lastGoodParams.L == 0 {
+		t.Fatal("good frame didn't populate the repeat cache; test setup invalid")
+	}
+	out, err := d.Decode(badFrame())
+	if err != nil {
+		t.Fatalf("bad frame Decode: %v", err)
+	}
+	if agcPeak(out) == 0 {
+		t.Fatal("bad-frame output is fully silent; expected repeat to synthesize")
+	}
+	if d.badFrameCount != 1 {
+		t.Errorf("badFrameCount = %d after one bad frame, want 1", d.badFrameCount)
+	}
+}
+
+// TestFrameRepeatProgressiveAttenuation: after a good frame, six
+// consecutive bad frames produce outputs whose peaks should be
+// non-strictly decreasing (each frame attenuates by 0.7 of the
+// previous, but AGC freezing means the *gain* is fixed across
+// frames so the peaks track the synthesizer's float output).
+//
+// The strict decrease can occasionally flip due to noise variance
+// in the §6.4 unvoiced step, so test that the *trend* is
+// downward: peak[5] < peak[0].
+func TestFrameRepeatProgressiveAttenuation(t *testing.T) {
+	d := New()
+	if _, err := d.Decode(make([]byte, FrameBytes)); err != nil {
+		t.Fatalf("good seed: %v", err)
+	}
+	var peaks [MaxBadFrames]int
+	for i := 0; i < MaxBadFrames; i++ {
+		out, err := d.Decode(badFrame())
+		if err != nil {
+			t.Fatalf("bad frame %d: %v", i, err)
+		}
+		peaks[i] = agcPeak(out)
+	}
+	if peaks[MaxBadFrames-1] >= peaks[0] {
+		t.Errorf("peaks didn't trend down: peaks=%v (first %d, last %d)",
+			peaks, peaks[0], peaks[MaxBadFrames-1])
+	}
+}
+
+// TestFrameRepeatExhaustedBudgetForcesSilence: after MaxBadFrames
+// consecutive bad-frame replays, the next bad frame must hit the
+// "no cache or budget exhausted" path → silence + cache cleared.
+func TestFrameRepeatExhaustedBudgetForcesSilence(t *testing.T) {
+	d := New()
+	if _, err := d.Decode(make([]byte, FrameBytes)); err != nil {
+		t.Fatalf("good seed: %v", err)
+	}
+	for i := 0; i < MaxBadFrames; i++ {
+		if _, err := d.Decode(badFrame()); err != nil {
+			t.Fatalf("bad frame %d: %v", i, err)
+		}
+	}
+	// Next bad frame: budget exhausted (count == MaxBadFrames),
+	// silence + clear.
+	out, err := d.Decode(badFrame())
+	if err != nil {
+		t.Fatalf("budget-exhausted Decode: %v", err)
+	}
+	for i, s := range out {
+		if s != 0 {
+			t.Fatalf("budget-exhausted sample[%d] = %d, want 0", i, s)
+		}
+	}
+	if d.lastGoodParams.L != 0 {
+		t.Errorf("lastGoodParams.L = %d after budget exhaustion, want 0",
+			d.lastGoodParams.L)
+	}
+	if d.badFrameCount != 0 {
+		t.Errorf("badFrameCount = %d after clear, want 0", d.badFrameCount)
+	}
+}
+
+// TestFrameRepeatCounterResetsOnGoodFrame: counter goes good → bad
+// (count=1) → bad (count=2) → good (count=0). Pins that a single
+// good frame inside a bad streak resets the budget so the next
+// bad streak gets a fresh budget.
+func TestFrameRepeatCounterResetsOnGoodFrame(t *testing.T) {
+	d := New()
+	if _, err := d.Decode(make([]byte, FrameBytes)); err != nil {
+		t.Fatalf("good seed: %v", err)
+	}
+	if _, err := d.Decode(badFrame()); err != nil {
+		t.Fatalf("bad1: %v", err)
+	}
+	if _, err := d.Decode(badFrame()); err != nil {
+		t.Fatalf("bad2: %v", err)
+	}
+	if d.badFrameCount != 2 {
+		t.Fatalf("badFrameCount = %d after 2 bads, want 2", d.badFrameCount)
+	}
+	if _, err := d.Decode(make([]byte, FrameBytes)); err != nil {
+		t.Fatalf("recovery: %v", err)
+	}
+	if d.badFrameCount != 0 {
+		t.Errorf("badFrameCount = %d after recovery, want 0", d.badFrameCount)
+	}
+	if d.lastGoodParams.L == 0 {
+		t.Error("lastGoodParams cleared after recovery; should be repopulated")
+	}
+}
+
+// TestSilenceFrameClearsRepeatCache: a silence-window frame clears
+// the last-good cache, so a subsequent bad frame can't repeat the
+// pre-silence content (we'd want fresh-state behavior across the
+// silence boundary).
+func TestSilenceFrameClearsRepeatCache(t *testing.T) {
+	d := New()
+	if _, err := d.Decode(make([]byte, FrameBytes)); err != nil {
+		t.Fatalf("good seed: %v", err)
+	}
+	silence := make([]byte, FrameBytes)
+	silence[0] = 0xD8
+	if _, err := d.Decode(silence); err != nil {
+		t.Fatalf("silence: %v", err)
+	}
+	if d.lastGoodParams.L != 0 {
+		t.Errorf("lastGoodParams.L = %d after silence, want 0",
+			d.lastGoodParams.L)
+	}
+	if d.badFrameCount != 0 {
+		t.Errorf("badFrameCount = %d after silence, want 0", d.badFrameCount)
+	}
+	// Bad frame after silence → silence (no cache).
+	out, err := d.Decode(badFrame())
+	if err != nil {
+		t.Fatalf("post-silence bad: %v", err)
+	}
+	for i, s := range out {
+		if s != 0 {
+			t.Fatalf("post-silence bad[%d] = %d, want 0", i, s)
+		}
+	}
+}
+
+// TestResetClearsFrameRepeatCache: explicit Reset() clears the
+// last-good cache + counter alongside SynthState + AGC. Pins the
+// "Reset = clean slate" contract.
+func TestResetClearsFrameRepeatCache(t *testing.T) {
+	d := New()
+	if _, err := d.Decode(make([]byte, FrameBytes)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := d.Decode(badFrame()); err != nil {
+		t.Fatal(err)
+	}
+	if d.lastGoodParams.L == 0 || d.badFrameCount == 0 {
+		t.Fatal("test setup invalid: cache empty before Reset")
+	}
+	d.Reset()
+	if d.lastGoodParams.L != 0 {
+		t.Errorf("after Reset: lastGoodParams.L = %d, want 0",
+			d.lastGoodParams.L)
+	}
+	if d.badFrameCount != 0 {
+		t.Errorf("after Reset: badFrameCount = %d, want 0", d.badFrameCount)
+	}
+}
+
+// TestFrameRepeatFreezesAGC: a bad-frame replay must not perturb
+// the AGC envelope (the freeze contract is what makes the
+// attenuation audible — without it AGC would partially compensate).
+func TestFrameRepeatFreezesAGC(t *testing.T) {
+	d := New()
+	for i := 0; i < 5; i++ {
+		if _, err := d.Decode(make([]byte, FrameBytes)); err != nil {
+			t.Fatalf("warmup %d: %v", i, err)
+		}
+	}
+	envBefore := d.agc
+	if envBefore == 0 {
+		t.Fatal("envelope is zero after warmup; test setup invalid")
+	}
+	if _, err := d.Decode(badFrame()); err != nil {
+		t.Fatalf("bad frame: %v", err)
+	}
+	if d.agc != envBefore {
+		t.Errorf("after bad-frame replay: agc shifted from %v to %v (want exact preservation)",
+			envBefore, d.agc)
+	}
+}

--- a/internal/voice/imbe/doc.go
+++ b/internal/voice/imbe/doc.go
@@ -136,8 +136,24 @@
 //     speech-pause-speech transitions emerge at consistent
 //     loudness without audible level pumping. See decoder.go.
 //
-//  5d. Robustness polish: enhancement filter, frame-repeat on
-//     bad-frame indicator, gain smoothing across frames.
+//  5d. Frame-repeat on bad-frame indicator. ← THIS PR.
+//     When UnpackParams returns an error (FEC slip, invalid b_0,
+//     etc.) and a previous good frame is cached, Decode replays
+//     that frame's params with M scaled by
+//     BadFrameAttenuation^badFrameCount. After MaxBadFrames
+//     consecutive replays the cache clears and Decode emits
+//     silence so an extended bad streak fades naturally instead of
+//     looping the same envelope. The repeat path freezes the AGC
+//     envelope so the attenuation is audible — without freeze the
+//     AGC would partially compensate, hiding the signal-loss cue.
+//     See decoder.go.
+//
+//  5e. Remaining polish: comparison-tuning the synthesis output
+//     level against an mbelib reference (the AGC keeps levels
+//     consistent but absolute calibration to mbelib output is still
+//     a follow-up); enhancement filter tuning if real-world frames
+//     show mid-band envelope drift; phase-aware bad-frame fade-in
+//     when good frames return after a streak.
 //
 // Patent + licensing context lives in docs/vocoders.md. The core US
 // IMBE patents have expired; this implementation is built from the


### PR DESCRIPTION
## Summary
Fourteenth PR in the IMBE 4400 thread. Fourth quality polish PR after the audible-voice milestone: replaces the "bad frame → graceful silence" behavior with a TIA-102.BABA-style frame-repeat path. When `UnpackParams` returns an error (FEC slip from the upstream P25 LDU decoder, invalid b_0, etc.) and a previous good frame is cached, `Decode` replays that frame's params with M scaled by `BadFrameAttenuation^badFrameCount`. After `MaxBadFrames` consecutive replays the cache clears and `Decode` emits silence so an extended bad streak fades naturally instead of looping the same envelope.

Materially improves audio during weak-signal conditions: a single slipped frame produces a 70%-amplitude continuation instead of a 20 ms gap; six consecutive bad frames bridge ~120 ms of poor reception with progressively quieter audio (signalling signal degradation while keeping speech intelligible).

## Frame disposition
| Input | Disposition |
| --- | --- |
| Good non-silent | Full pipeline; cache p + log2M + M; reset counter. |
| Silence-window (b_0 ∈ [216, 219]) | OA tail fade-out into pcm[0..95]; clear cache; reset SynthState. |
| Bad with cache + count < MaxBadFrames | Replay cached params with M scaled by 0.7^count; AGC freezes. |
| Bad with no cache or count == MaxBadFrames | Silence; clear cache; reset SynthState. |

## Changes
- **`internal/voice/imbe/decoder.go`** —
  - `MaxBadFrames = 6` + `BadFrameAttenuation = 0.7` constants.
  - `Decoder` gains `lastGoodParams` + `lastGoodLog2M[57]` + `lastGoodM[57]` + `badFrameCount`.
  - `Decode()` restructured with a switch: cleanly handles all four paths above. Extracted `synthFrame` helper so good-frame and replay-frame paths share identical synthesis behavior.
  - `clearLastGood` helper resets the cache + counter (called from silence path, budget-exhausted path, `Reset`).
  - Replay path passes `freezeEnvelope = true` to `applyAGC` so the attenuation is audible.
  - `Reset()` clears cache + counter alongside `SynthState` + AGC.
- **`internal/voice/imbe/decoder_test.go`** — 7 new tests + `badFrame()` helper.
- **`internal/voice/imbe/doc.go`** — step 5d marked shipped; step 5e enumerates remaining polish (mbelib level calibration + enhancement filter tuning + phase-aware bad-frame fade-in).
- **`README.md`** — IMBE roadmap entry describes the frame-repeat behavior; remaining-polish list narrowed.

## Test plan
- [x] `TestFrameRepeatOnBadFrameAfterGood` — bad frame after good produces non-zero PCM (replay synthesizes).
- [x] `TestFrameRepeatProgressiveAttenuation` — 6 consecutive bad frames produce trending-down peaks.
- [x] `TestFrameRepeatExhaustedBudgetForcesSilence` — after `MaxBadFrames` replays, next bad frame → silence + cleared cache + counter.
- [x] `TestFrameRepeatCounterResetsOnGoodFrame` — good frame inside a bad streak resets the counter.
- [x] `TestSilenceFrameClearsRepeatCache` — silence-window frame clears cache; subsequent bad frame → silence (no replay).
- [x] `TestResetClearsFrameRepeatCache` — explicit `Reset` zeroes cache + counter.
- [x] `TestFrameRepeatFreezesAGC` — replay leaves `d.agc` exactly unchanged.
- [x] All previously-merged IMBE tests still pass (the existing `TestDecodeBadB0ReturnsSilenceNoError` still holds — fresh decoder with no cache → silence path).
- [x] Full `go test ./...` green (rtlsdr CGO build failure is a pre-existing environment issue — librtlsdr not installed — unrelated to this change).

---
_Generated by [Claude Code](https://claude.ai/code/session_01JmSJLqDwr8jLuKtbkzGXNE)_