### PR TITLE
Pure-Go IMBE step 5e: AGCConfig + NewWithConfig for tunable AGC

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,21 +124,27 @@ to its own package and lands independently.
   before resetting SynthState — no click on the silence
   boundary, and the AGC envelope is preserved across the
   silence so the next non-silent frame applies the same gain.
-  Two decoder constructors are exposed: `New()` seeds the
+  Three decoder constructors are exposed: `New()` seeds the
   unvoiced noise source from a fixed default for reproducibility;
   `NewWithSeed(seed)` lets parallel calls + production callers
-  spread noise. **Frame-repeat on bad-frame indicator**: a bad
-  frame (UnpackParams error from upstream FEC slip) following a
-  good frame replays the cached params with M scaled by 0.7 per
-  consecutive bad frame; up to 6 consecutive bad frames bridge
-  ~120 ms of weak signal before Decode emits silence + clears the
-  cache. The repeat path freezes the AGC envelope so the
-  attenuation is audible (signals signal degradation). **Remaining
-  audio polish**: comparison-tuning the synthesis output level
-  against an mbelib reference (the AGC keeps levels consistent
-  but the absolute calibration to mbelib output is still a future
-  follow-up); enhancement filter tuning if real-world frames show
-  mid-band envelope drift.
+  spread noise across decoders; `NewWithConfig(seed, AGCConfig{...})`
+  takes a public `AGCConfig` (TargetPeak / Attack / Release /
+  MinGain / MaxGain / NoiseFloor) so operators can dial level +
+  responsiveness for their downstream chain — zero-value fields
+  backfill from `DefaultAGCConfig()` so partial overrides like
+  `AGCConfig{TargetPeak: 16000}` (drop level by ~3 dB) keep the
+  rest of the defaults. **Frame-repeat on bad-frame indicator**:
+  a bad frame (UnpackParams error from upstream FEC slip)
+  following a good frame replays the cached params with M scaled
+  by 0.7 per consecutive bad frame; up to 6 consecutive bad
+  frames bridge ~120 ms of weak signal before Decode emits silence
+  + clears the cache. The repeat path freezes the AGC envelope
+  so the attenuation is audible (signals signal degradation).
+  **Remaining audio polish**: comparison-tuning the absolute
+  output level against an mbelib reference (the AGC keeps
+  intra-stream levels consistent but mbelib-bit-equivalent
+  calibration is still a future follow-up); enhancement filter
+  tuning if real-world frames show mid-band envelope drift.
 - **DVSI USB-3000 / AMBE-3003 hardware backend.** A `Vocoder`
   factory that opens a connected DVSI USB chip. Same plug-in shape
   as `internal/voice/mbelib`; the daemon picks the factory by name

--- a/internal/voice/imbe/decoder.go
+++ b/internal/voice/imbe/decoder.go
@@ -35,30 +35,6 @@ const (
 	// into the same binary; the daemon picks one in config.
 	VocoderName = "imbe-go"
 
-	// AGC parameters. The synthesizer's float output magnitude is
-	// stable per-frame (R_M0-preserving §6.2 enhancement holds total
-	// energy constant across a frame) but varies wildly between
-	// frames depending on Tl, voicing, and the §6.4 noise draw.
-	// Without an AGC every frame would be either clipped (loud frames)
-	// or near-silent (quiet frames). The AGC tracks the per-frame
-	// peak with fast-attack / slow-release smoothing, then scales each
-	// frame so the smoothed envelope hits agcTargetPeak.
-	//
-	// agcTargetPeak = 24000 sits ~3 dB below int16 max so the soft
-	// knee of the envelope tracker has headroom for transients.
-	// agcAttack > agcRelease so loud onsets are caught quickly while
-	// gain ramps back up slowly during quiet passages — standard
-	// AGC behavior that keeps speech intelligible without pumping.
-	// agcMinGain / agcMaxGain prevent the envelope from sending
-	// silence to full scale or compressing extreme transients to
-	// inaudible levels.
-	agcTargetPeak = 24000.0
-	agcAttack     = 0.4
-	agcRelease    = 0.02
-	agcMinGain    = 10.0
-	agcMaxGain    = 1e5
-	agcNoiseFloor = 1e-3
-
 	// MaxBadFrames is the number of consecutive bad frames the
 	// frame-repeat path will replay before giving up and emitting
 	// silence + clearing state. The TIA-102.BABA spec range is
@@ -78,6 +54,101 @@ const (
 	// the listener that signal is degrading (audible volume drop).
 	BadFrameAttenuation = 0.7
 )
+
+// AGCConfig holds the per-frame AGC parameters. The synthesizer's
+// float output magnitude is stable per-frame (R_M0-preserving §6.2
+// enhancement holds total energy constant across a frame) but
+// varies wildly between frames depending on Tl, voicing, and the
+// §6.4 noise draw. Without an AGC every frame would be either
+// clipped (loud frames) or near-silent (quiet frames). The AGC
+// tracks the per-frame peak with fast-attack / slow-release
+// smoothing, then scales each frame so the smoothed envelope hits
+// TargetPeak.
+//
+// Zero-value fields fall back to DefaultAGCConfig values, so a
+// caller can override only the field they care about (e.g.
+// AGCConfig{TargetPeak: 16000} to drop output level by 4 dB).
+//
+// The current AGC is a level-only design — disabling it entirely
+// means dropping back to a constant gain, which we don't expose as
+// a separate option (callers wanting that can pass equal Attack +
+// Release to fully smooth the envelope). The §6.2-derived
+// per-frame R_M0 normalization the synthesizer already does keeps
+// inter-frame magnitude variation modest enough that AGC is a
+// polish layer rather than the only loudness control.
+type AGCConfig struct {
+	// TargetPeak is the post-AGC peak amplitude target in int16
+	// units. Default 24000 (~3 dB below int16 max for transient
+	// headroom).
+	TargetPeak float64
+
+	// Attack is the per-frame envelope rise coefficient. Standard
+	// IIR coefficient: 1.0 = instant tracking, 0.0 = no update.
+	// Default 0.4 — fast enough to catch loud onsets without
+	// over-shoot.
+	Attack float64
+
+	// Release is the per-frame envelope fall coefficient. Smaller
+	// than Attack so gain ramps back up slowly during quiet
+	// passages — standard AGC behavior that keeps speech
+	// intelligible without pumping. Default 0.02.
+	Release float64
+
+	// MinGain bounds the lowest gain the AGC can apply, preventing
+	// runaway compression on extreme transients. Default 10.
+	MinGain float64
+
+	// MaxGain bounds the highest gain the AGC can apply, preventing
+	// silence from being amplified to full scale by a stale low
+	// envelope. Default 1e5.
+	MaxGain float64
+
+	// NoiseFloor is the per-frame peak threshold below which the
+	// envelope skips its update. Lets a §6.4 OA tail fade-out into
+	// silence without dragging the envelope down. Default 1e-3.
+	NoiseFloor float64
+}
+
+// DefaultAGCConfig returns the AGC parameters Decoder.applyAGC uses
+// when constructed via New() / NewWithSeed(). NewWithConfig callers
+// can take this struct, override individual fields, and pass it back
+// for partial-overrides.
+func DefaultAGCConfig() AGCConfig {
+	return AGCConfig{
+		TargetPeak: 24000.0,
+		Attack:     0.4,
+		Release:    0.02,
+		MinGain:    10.0,
+		MaxGain:    1e5,
+		NoiseFloor: 1e-3,
+	}
+}
+
+// withDefaults backfills any zero-value fields in cfg from
+// DefaultAGCConfig so partial-override calls don't have to specify
+// every parameter. Returns the merged config.
+func (cfg AGCConfig) withDefaults() AGCConfig {
+	d := DefaultAGCConfig()
+	if cfg.TargetPeak == 0 {
+		cfg.TargetPeak = d.TargetPeak
+	}
+	if cfg.Attack == 0 {
+		cfg.Attack = d.Attack
+	}
+	if cfg.Release == 0 {
+		cfg.Release = d.Release
+	}
+	if cfg.MinGain == 0 {
+		cfg.MinGain = d.MinGain
+	}
+	if cfg.MaxGain == 0 {
+		cfg.MaxGain = d.MaxGain
+	}
+	if cfg.NoiseFloor == 0 {
+		cfg.NoiseFloor = d.NoiseFloor
+	}
+	return cfg
+}
 
 // Decoder is the pure-Go IMBE 4400 decoder. It owns one SynthState
 // (cross-frame log2(Ml) prediction memory + voiced phase + amp
@@ -105,9 +176,10 @@ const (
 // extended bad streak fades naturally instead of looping the same
 // envelope forever.
 type Decoder struct {
-	state SynthState
-	rng   *rand.Rand
-	agc   float64 // smoothed peak envelope; 0 = fresh (next frame seeds it)
+	state  SynthState
+	rng    *rand.Rand
+	agc    float64   // smoothed peak envelope; 0 = fresh (next frame seeds it)
+	agcCfg AGCConfig // tunable AGC parameters; defaults via DefaultAGCConfig()
 
 	// One-frame cache for the frame-repeat path. Populated after a
 	// good non-silent frame; consumed by the bad-frame path; cleared
@@ -135,10 +207,21 @@ func New() *Decoder {
 // NewWithSeed constructs a Decoder with an explicit seed for the
 // internal noise source. Lets tests pin output across runs and lets
 // production callers spread noise across decoders so two parallel
-// calls don't share the same noise stream.
+// calls don't share the same noise stream. AGC parameters use
+// DefaultAGCConfig.
 func NewWithSeed(seed int64) *Decoder {
+	return NewWithConfig(seed, DefaultAGCConfig())
+}
+
+// NewWithConfig constructs a Decoder with an explicit noise seed +
+// AGC configuration. Zero-value fields in cfg fall back to
+// DefaultAGCConfig values, so callers can override only the
+// parameters they care about (e.g. AGCConfig{TargetPeak: 16000} to
+// drop the output level by ~3 dB without re-tuning attack/release).
+func NewWithConfig(seed int64, cfg AGCConfig) *Decoder {
 	return &Decoder{
-		rng: rand.New(rand.NewSource(seed)),
+		rng:    rand.New(rand.NewSource(seed)),
+		agcCfg: cfg.withDefaults(),
 	}
 }
 
@@ -266,29 +349,31 @@ func (d *Decoder) clearLastGood() {
 
 // applyAGC tracks the per-frame peak with fast-attack / slow-release
 // smoothing and scales pcm so the smoothed envelope hits
-// agcTargetPeak. Frames whose peak falls below agcNoiseFloor leave
-// the envelope unchanged so a tail fade-out into silence doesn't
-// drag the envelope up artificially.
+// d.agcCfg.TargetPeak. Frames whose peak falls below
+// d.agcCfg.NoiseFloor leave the envelope unchanged so a tail
+// fade-out into silence doesn't drag the envelope up artificially.
 //
 // First-frame seed: when d.agc == 0 (fresh decoder, post-Reset), the
 // envelope is initialised directly to peak rather than via the attack
 // coefficient. Without this seed the first frame would emerge ~2.5×
-// over-gained (envelope = 0.4 · peak ⇒ gain = target / (0.4 · peak)
-// ⇒ output peak = 2.5 · target ⇒ int16 saturation).
+// over-gained (envelope = Attack · peak ⇒ gain = TargetPeak /
+// (Attack · peak) ⇒ output peak = (1/Attack) · TargetPeak ⇒
+// int16 saturation at the default Attack = 0.4).
 //
 // Frozen mode (freezeEnvelope = true): apply the existing envelope's
 // gain without updating it. The Decode() silent path uses this so a
 // brief silence frame doesn't shift the AGC envelope based on the
-// small §6.4 overlap-add fade-out content. The first frame after
-// silence then applies the same gain as the last frame before
-// silence — no audible level jump on speech-pause-speech transitions.
-// Stream re-sync via the public Reset() does clear the envelope.
+// small §6.4 overlap-add fade-out content; the bad-frame replay
+// path uses it so the per-frame attenuation is audible (signals
+// signal degradation). Stream re-sync via the public Reset() does
+// clear the envelope.
 //
-// agcMinGain / agcMaxGain prevent the envelope from sending
-// silence to full scale or compressing extreme transients to
-// inaudible levels. After the gain multiply, samples beyond int16
-// range are hard-clipped at ±32767.
+// MinGain / MaxGain prevent the envelope from sending silence to
+// full scale or compressing extreme transients to inaudible levels.
+// After the gain multiply, samples beyond int16 range are
+// hard-clipped at ±32767.
 func (d *Decoder) applyAGC(pcm []float64, out []int16, freezeEnvelope bool) {
+	cfg := d.agcCfg
 	if !freezeEnvelope {
 		var peak float64
 		for _, v := range pcm {
@@ -296,27 +381,27 @@ func (d *Decoder) applyAGC(pcm []float64, out []int16, freezeEnvelope bool) {
 				peak = a
 			}
 		}
-		if d.agc == 0 && peak > agcNoiseFloor {
+		if d.agc == 0 && peak > cfg.NoiseFloor {
 			// First-frame seed: skip attack smoothing so the first frame
-			// lands at exactly agcTargetPeak instead of 2.5× over.
+			// lands at exactly TargetPeak instead of 1/Attack× over.
 			d.agc = peak
-		} else if peak > agcNoiseFloor {
-			coef := agcAttack
+		} else if peak > cfg.NoiseFloor {
+			coef := cfg.Attack
 			if peak < d.agc {
-				coef = agcRelease
+				coef = cfg.Release
 			}
 			d.agc += (peak - d.agc) * coef
 		}
 	}
 	envelope := d.agc
-	if envelope < agcNoiseFloor {
-		envelope = agcNoiseFloor
+	if envelope < cfg.NoiseFloor {
+		envelope = cfg.NoiseFloor
 	}
-	gain := agcTargetPeak / envelope
-	if gain < agcMinGain {
-		gain = agcMinGain
-	} else if gain > agcMaxGain {
-		gain = agcMaxGain
+	gain := cfg.TargetPeak / envelope
+	if gain < cfg.MinGain {
+		gain = cfg.MinGain
+	} else if gain > cfg.MaxGain {
+		gain = cfg.MaxGain
 	}
 	for i, v := range pcm {
 		s := v * gain

--- a/internal/voice/imbe/decoder_test.go
+++ b/internal/voice/imbe/decoder_test.go
@@ -395,12 +395,13 @@ func TestAGCConvergesTowardTarget(t *testing.T) {
 	}
 	// After convergence the peak should be within ~30% of the target
 	// (loose because the §6.4 noise draw varies per frame).
+	target := DefaultAGCConfig().TargetPeak
 	const tol = 0.3
-	lo := int(agcTargetPeak * (1 - tol))
-	hi := int(agcTargetPeak * (1 + tol))
+	lo := int(target * (1 - tol))
+	hi := int(target * (1 + tol))
 	if lastPeak < lo || lastPeak > hi {
 		t.Errorf("converged peak = %d, want in [%d, %d] (target=%v ±%.0f%%)",
-			lastPeak, lo, hi, agcTargetPeak, tol*100)
+			lastPeak, lo, hi, target, tol*100)
 	}
 }
 
@@ -721,6 +722,117 @@ func TestResetClearsFrameRepeatCache(t *testing.T) {
 	}
 	if d.badFrameCount != 0 {
 		t.Errorf("after Reset: badFrameCount = %d, want 0", d.badFrameCount)
+	}
+}
+
+// TestDefaultAGCConfigMatchesNew: a Decoder constructed via New()
+// uses the same AGC parameters as one constructed via
+// NewWithConfig(0, DefaultAGCConfig()). Pins that the old
+// constructors aren't accidentally divergent from the documented
+// defaults.
+func TestDefaultAGCConfigMatchesNew(t *testing.T) {
+	a := New()
+	b := NewWithConfig(0, DefaultAGCConfig())
+	if a.agcCfg != b.agcCfg {
+		t.Errorf("New().agcCfg = %+v, NewWithConfig(default).agcCfg = %+v",
+			a.agcCfg, b.agcCfg)
+	}
+	frame := make([]byte, FrameBytes)
+	outA, _ := a.Decode(frame)
+	outB, _ := b.Decode(frame)
+	for i := range outA {
+		if outA[i] != outB[i] {
+			t.Errorf("output diverges at i=%d: New=%d NewWithConfig(default)=%d",
+				i, outA[i], outB[i])
+			break
+		}
+	}
+}
+
+// TestAGCConfigZeroValueBackfillsDefaults: an AGCConfig{} (all zero)
+// passed to NewWithConfig backfills every field from
+// DefaultAGCConfig. Lets callers override one knob without
+// re-specifying everything.
+func TestAGCConfigZeroValueBackfillsDefaults(t *testing.T) {
+	d := NewWithConfig(0, AGCConfig{})
+	want := DefaultAGCConfig()
+	if d.agcCfg != want {
+		t.Errorf("zero-value cfg backfill = %+v, want %+v", d.agcCfg, want)
+	}
+}
+
+// TestAGCConfigPartialOverrideKeepsDefaults: an AGCConfig with one
+// field set inherits all other fields from DefaultAGCConfig. Pins
+// the partial-override pattern.
+func TestAGCConfigPartialOverrideKeepsDefaults(t *testing.T) {
+	custom := AGCConfig{TargetPeak: 12000}
+	d := NewWithConfig(0, custom)
+	def := DefaultAGCConfig()
+	if d.agcCfg.TargetPeak != 12000 {
+		t.Errorf("TargetPeak = %v, want 12000", d.agcCfg.TargetPeak)
+	}
+	if d.agcCfg.Attack != def.Attack {
+		t.Errorf("Attack = %v, want default %v (partial override)",
+			d.agcCfg.Attack, def.Attack)
+	}
+	if d.agcCfg.Release != def.Release {
+		t.Errorf("Release = %v, want default %v", d.agcCfg.Release, def.Release)
+	}
+	if d.agcCfg.MinGain != def.MinGain {
+		t.Errorf("MinGain = %v, want default %v", d.agcCfg.MinGain, def.MinGain)
+	}
+	if d.agcCfg.MaxGain != def.MaxGain {
+		t.Errorf("MaxGain = %v, want default %v", d.agcCfg.MaxGain, def.MaxGain)
+	}
+	if d.agcCfg.NoiseFloor != def.NoiseFloor {
+		t.Errorf("NoiseFloor = %v, want default %v",
+			d.agcCfg.NoiseFloor, def.NoiseFloor)
+	}
+}
+
+// TestAGCConfigCustomTargetShiftsOutputLevel: lowering TargetPeak
+// from 24000 to 8000 (3x quieter) makes the converged output peak
+// drop by roughly the same factor. Pins that the TargetPeak knob
+// actually controls output level.
+func TestAGCConfigCustomTargetShiftsOutputLevel(t *testing.T) {
+	frame := make([]byte, FrameBytes)
+	loudCfg := AGCConfig{TargetPeak: 24000}
+	quietCfg := AGCConfig{TargetPeak: 8000}
+	loud := NewWithConfig(0, loudCfg)
+	quiet := NewWithConfig(0, quietCfg)
+	// Warm both AGCs to convergence.
+	const warmup = 30
+	var loudPeak, quietPeak int
+	for i := 0; i < warmup; i++ {
+		out, _ := loud.Decode(frame)
+		loudPeak = agcPeak(out)
+		out, _ = quiet.Decode(frame)
+		quietPeak = agcPeak(out)
+	}
+	// Loud should be ~3× the quiet peak (within a generous tol —
+	// noise variance shifts each sample).
+	ratio := float64(loudPeak) / float64(quietPeak)
+	if ratio < 2.0 || ratio > 4.5 {
+		t.Errorf("loud/quiet peak ratio = %.2f (loud=%d quiet=%d), want ~3 ± loose",
+			ratio, loudPeak, quietPeak)
+	}
+}
+
+// TestAGCConfigPreservedAcrossReset: Reset clears the envelope but
+// keeps the configured cfg so subsequent frames use the same
+// tuning. Pins that callers don't have to re-specify cfg after
+// every stream re-sync.
+func TestAGCConfigPreservedAcrossReset(t *testing.T) {
+	cfg := AGCConfig{TargetPeak: 16000, Attack: 0.5}
+	d := NewWithConfig(0, cfg)
+	if _, err := d.Decode(make([]byte, FrameBytes)); err != nil {
+		t.Fatal(err)
+	}
+	d.Reset()
+	want := cfg.withDefaults()
+	if d.agcCfg != want {
+		t.Errorf("after Reset: agcCfg = %+v, want %+v (cfg preserved)",
+			d.agcCfg, want)
 	}
 }
 

--- a/internal/voice/imbe/doc.go
+++ b/internal/voice/imbe/doc.go
@@ -148,12 +148,24 @@
 //     AGC would partially compensate, hiding the signal-loss cue.
 //     See decoder.go.
 //
-//  5e. Remaining polish: comparison-tuning the synthesis output
-//     level against an mbelib reference (the AGC keeps levels
-//     consistent but absolute calibration to mbelib output is still
-//     a follow-up); enhancement filter tuning if real-world frames
-//     show mid-band envelope drift; phase-aware bad-frame fade-in
-//     when good frames return after a streak.
+//  5e. AGCConfig — tunable AGC parameters. ← THIS PR.
+//     Exposes a public AGCConfig struct (TargetPeak / Attack /
+//     Release / MinGain / MaxGain / NoiseFloor) and a NewWithConfig
+//     constructor so operators can dial level + responsiveness for
+//     their downstream chain. DefaultAGCConfig() returns the
+//     constants the previous PR pinned; zero-value fields in a
+//     caller-supplied cfg backfill from the defaults so partial
+//     overrides don't have to specify every knob. Replaces the
+//     prior package-level constants with cfg field reads in
+//     applyAGC. See decoder.go.
+//
+//  5f. Remaining polish: comparison-tuning the absolute synthesis
+//     output level against an mbelib reference (the AGC keeps
+//     intra-stream levels consistent but mbelib-bit-equivalent
+//     calibration is still a follow-up); enhancement filter tuning
+//     if real-world frames show mid-band envelope drift;
+//     phase-aware bad-frame fade-in when good frames return after
+//     a streak.
 //
 // Patent + licensing context lives in docs/vocoders.md. The core US
 // IMBE patents have expired; this implementation is built from the


### PR DESCRIPTION
## Summary
Fifteenth PR in the IMBE 4400 thread. Fifth quality polish PR after the audible-voice milestone: lifts the AGC parameters from unexported package-level constants into a public `AGCConfig` struct + `NewWithConfig` constructor so operators can dial output level + responsiveness for their downstream chain without forking the package. Mirrors the `AudioAGCConfig` / `DeEmphasisConfig` / `EqualizerConfig` pattern from `internal/voice/composer` for consistency across the voice subsystem.

```go
// Old API (still works — uses DefaultAGCConfig)
d := imbe.New()
d := imbe.NewWithSeed(42)

// New API: partial override
d := imbe.NewWithConfig(42, imbe.AGCConfig{
    TargetPeak: 16000,  // -3 dB from default
    // Attack, Release, MinGain, MaxGain, NoiseFloor backfill from defaults
})
```

## Changes
- **`internal/voice/imbe/decoder.go`** —
  - Removed the `agcTargetPeak` / `agcAttack` / `agcRelease` / `agcMinGain` / `agcMaxGain` / `agcNoiseFloor` unexported constants.
  - Added `AGCConfig` struct (six exported fields) + `DefaultAGCConfig()` helper + `(cfg AGCConfig).withDefaults()` for zero-value backfill.
  - Added `NewWithConfig(seed int64, cfg AGCConfig)` constructor; `NewWithSeed` delegates to it with `DefaultAGCConfig`; `New` chain unchanged.
  - `Decoder` gains an unexported `agcCfg AGCConfig` field, preserved across `Reset`.
  - `applyAGC` reads parameters from `d.agcCfg` instead of package constants.
- **`internal/voice/imbe/decoder_test.go`** — 5 new tests; existing `TestAGCConvergesTowardTarget` switched from the removed constant to `DefaultAGCConfig().TargetPeak`.
- **`internal/voice/imbe/doc.go`** — step 5e marked shipped; step 5f enumerates remaining polish.
- **`README.md`** — IMBE roadmap entry lists the three decoder constructors + AGCConfig knob set + partial-override pattern.

## Test plan
- [x] `TestDefaultAGCConfigMatchesNew` — `New()` and `NewWithConfig(0, DefaultAGCConfig())` produce byte-identical output for the same frame stream.
- [x] `TestAGCConfigZeroValueBackfillsDefaults` — `AGCConfig{}` backfills every parameter from `DefaultAGCConfig`.
- [x] `TestAGCConfigPartialOverrideKeepsDefaults` — `AGCConfig{TargetPeak: 12000}` keeps Attack / Release / MinGain / MaxGain / NoiseFloor at defaults.
- [x] `TestAGCConfigCustomTargetShiftsOutputLevel` — `TargetPeak: 8000` vs `24000` (3× quieter) reduces converged output peak by roughly the same factor.
- [x] `TestAGCConfigPreservedAcrossReset` — `Reset` clears envelope + state + frame-repeat cache but keeps `agcCfg`.
- [x] All previously-merged IMBE tests still pass — the constructor chain preserves byte-identical output for the default path.
- [x] Full `go test ./...` green (rtlsdr CGO build failure is a pre-existing environment issue — librtlsdr not installed — unrelated to this change).

---
_Generated by [Claude Code](https://claude.ai/code/session_01JmSJLqDwr8jLuKtbkzGXNE)_