### PR TITLE
mbelib: one-command install via scripts/install-mbelib.sh + make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ TAGS    ?=
 GO      ?= go
 PKGS    := ./...
 
-.PHONY: all build test integration lint tidy vet clean run proto
+.PHONY: all build test integration lint tidy vet clean run proto mbelib-install
 
 all: build
 
@@ -35,6 +35,15 @@ clean:
 
 run: build
 	./bin/gophertrunk
+
+# mbelib-install builds + system-installs szechyjs/mbelib so
+# `make build TAGS=mbelib` (and `make test TAGS=mbelib`) can link
+# the libmbe.so / mbelib.h that internal/voice/mbelib's CGO wrapper
+# requires. AMBE+2 (DMR / NXDN / P25 Phase 2 vocoder) is patent-
+# encumbered; building this library is at the operator's
+# discretion. See docs/vocoders.md for the licensing situation.
+mbelib-install:
+	scripts/install-mbelib.sh
 
 # Regenerate Go bindings under internal/api/pb/v1 from proto/*.proto.
 # Requires:

--- a/README.md
+++ b/README.md
@@ -53,9 +53,13 @@ SQLite. The honest gaps:
   / NXDN) is gated on the vocoders. The `Vocoder` plugin interface
   + raw-frame sidecar are in place; pure-Go IMBE now produces
   intelligible audio end-to-end ([patents have expired](docs/vocoders.md)),
-  with §6.4 overlap-add windowing + §6.2 spectral enhancement +
-  spec-derived gain calibration as quality follow-ups. AMBE+2
-  stays behind the `mbelib` build tag.
+  with operator-tunable AGC + §6.4 overlap-add windowing + §6.2
+  spectral enhancement + frame-repeat on bad-frame indicator
+  shipped — only mbelib-bit-equivalent absolute-level calibration
+  remains as a follow-up. AMBE+2 stays behind the `mbelib` build
+  tag; operators who hold (or don't need) the patent licence run
+  `make mbelib-install && make build TAGS=mbelib` to get both
+  IMBE + AMBE+2 via the C reference implementation.
 - **Higher-fidelity audio**: the FM chain now has opt-in 75/50µs
   de-emphasis, a Kaiser-windowed audio LPF, audio AGC, and a
   polyphase L/M audio resampler — the full polish stack ships.

--- a/docs/vocoders.md
+++ b/docs/vocoders.md
@@ -72,15 +72,48 @@ links no extra libraries. CI exercises the stub path only — the
 wrapper is verified at build time when an operator opts in.
 
 If `make build TAGS=mbelib` fails with `mbelib.h: No such file or
-directory`, install the library:
+directory`, install the library. The repo ships an automated
+installer that wraps the documented build-from-source procedure:
+
+```sh
+make mbelib-install        # clones, builds, sudo-installs, ldconfig
+make build TAGS=mbelib
+```
+
+Override the install prefix or skip sudo (for non-root /
+container builds) by setting environment variables on the script
+directly:
+
+```sh
+PREFIX=$HOME/.local USE_SUDO=0 scripts/install-mbelib.sh
+```
+
+After install, the library lands at:
+
+- `$PREFIX/include/mbelib.h`
+- `$PREFIX/lib/libmbe.so` (+ `.so.1`, `.so.1.3`, `.a`)
+- `$PREFIX/lib/pkgconfig/libmbe.pc`
+
+The CGO wrapper at `internal/voice/mbelib/cgo_mbelib.go` links
+via the explicit `#cgo LDFLAGS: -lmbe -lm` directive (not
+pkg-config), so non-default install prefixes need their `lib`
+directory on `LD_LIBRARY_PATH` (or in `/etc/ld.so.conf.d/`)
+before `go test -tags mbelib` will load the shared object at
+runtime.
+
+Verify the install end-to-end with:
+
+```sh
+make test TAGS=mbelib              # exercises internal/voice/mbelib
+```
+
+The doing-by-hand equivalent of `make mbelib-install` is:
 
 ```sh
 git clone https://github.com/szechyjs/mbelib && cd mbelib
 mkdir build && cd build && cmake .. && make && sudo make install
 sudo ldconfig
 ```
-
-Then re-run the build.
 
 ## Why a plugin model
 

--- a/scripts/install-mbelib.sh
+++ b/scripts/install-mbelib.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# install-mbelib.sh — clone, build, and system-install the szechyjs
+# mbelib library so `make build TAGS=mbelib` (and `make test
+# TAGS=mbelib`) can link the libmbe.so / mbelib.h that the
+# internal/voice/mbelib CGO wrapper requires.
+#
+# mbelib isn't packaged in standard distros, so the documented
+# install path in docs/vocoders.md is "build from source". This
+# script wraps that procedure so dev + CI environments can opt in
+# with a single command:
+#
+#     scripts/install-mbelib.sh
+#     make build TAGS=mbelib
+#
+# Override the install prefix or skip sudo by setting:
+#
+#     PREFIX=$HOME/.local USE_SUDO=0 scripts/install-mbelib.sh
+#
+# Patent + licensing context lives in docs/vocoders.md. AMBE+2 (the
+# DMR / NXDN / P25 Phase 2 vocoder) is patent-encumbered; building
+# this library is at the operator's discretion. The default
+# GopherTrunk binary doesn't link mbelib at all.
+set -euo pipefail
+
+REPO_URL="${REPO_URL:-https://github.com/szechyjs/mbelib.git}"
+REPO_REF="${REPO_REF:-master}"
+PREFIX="${PREFIX:-/usr/local}"
+BUILD_DIR="${BUILD_DIR:-$(mktemp -d -t mbelib-build-XXXXXX)}"
+USE_SUDO="${USE_SUDO:-1}"
+
+log() { printf '==> %s\n' "$*" >&2; }
+
+# Pick a sudo helper based on USE_SUDO + whether we're already root.
+if [[ "$USE_SUDO" == "1" && "$(id -u)" != "0" ]]; then
+  SUDO=sudo
+else
+  SUDO=
+fi
+
+# Required tools — fail fast with a clear message rather than a
+# cryptic mid-build error.
+for tool in git cmake make cc; do
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    log "missing required tool: $tool"
+    log "install with your distro's package manager (e.g. apt-get install build-essential cmake git)"
+    exit 1
+  fi
+done
+
+log "cloning $REPO_URL ($REPO_REF) into $BUILD_DIR"
+git clone --depth 1 --branch "$REPO_REF" "$REPO_URL" "$BUILD_DIR/mbelib"
+
+log "configuring (prefix=$PREFIX)"
+mkdir -p "$BUILD_DIR/mbelib/build"
+cd "$BUILD_DIR/mbelib/build"
+cmake -DCMAKE_INSTALL_PREFIX="$PREFIX" ..
+
+log "building"
+make -j"$(nproc 2>/dev/null || echo 2)"
+
+log "installing to $PREFIX (sudo=${USE_SUDO})"
+$SUDO make install
+$SUDO ldconfig 2>/dev/null || true
+
+# Verify the install — header + shared object + pkg-config file.
+if [[ ! -f "$PREFIX/include/mbelib.h" ]]; then
+  log "FAIL: $PREFIX/include/mbelib.h missing after install"
+  exit 2
+fi
+if ! ls "$PREFIX/lib"/libmbe* >/dev/null 2>&1; then
+  log "FAIL: $PREFIX/lib/libmbe* missing after install"
+  exit 2
+fi
+
+log "installed:"
+ls -1 "$PREFIX/include/mbelib.h" "$PREFIX/lib"/libmbe* "$PREFIX/lib/pkgconfig/libmbe.pc" 2>/dev/null
+
+log "done — build with: make build TAGS=mbelib"


### PR DESCRIPTION
## Summary
mbelib (the szechyjs C library backing the AMBE+2 + reference IMBE decoders behind `-tags mbelib`) isn't packaged in standard distros, so the documented install path in `docs/vocoders.md` was a manual `git clone … cmake … sudo make install …` sequence. This PR wraps that procedure so dev + CI environments opt in with one command:

```sh
make mbelib-install
make build TAGS=mbelib
```

Verified end-to-end on this branch: the script clones szechyjs/mbelib master, builds via cmake + make, installs `libmbe.so` + `mbelib.h` to `/usr/local`, runs `ldconfig`, and prints the resulting paths. After install, `go test -tags mbelib ./internal/voice/mbelib/...` passes and the IMBE + AMBE+2 factories register through `voice.DefaultRegistry` as expected.

## Changes
- **`scripts/install-mbelib.sh`** (new, executable) —
  - `set -euo pipefail`; clear "missing tool" diagnostics for git / cmake / make / cc.
  - Configurable via env vars: `REPO_URL`, `REPO_REF` (default `master`), `PREFIX` (default `/usr/local`), `BUILD_DIR` (default a fresh `mktemp`), `USE_SUDO` (default `1`; set to `0` for non-root / container builds).
  - Sudo helper auto-skips when running as root or when `USE_SUDO=0` — lets the script run cleanly inside Docker images that don't have sudo installed.
  - Verifies the install end-to-end: checks `$PREFIX/include/mbelib.h` + `$PREFIX/lib/libmbe*` exist before reporting success.
- **`Makefile`** — new `mbelib-install` phony target shells out to the script.
- **`docs/vocoders.md`** — replaced the manual snippet with a `make mbelib-install` reference; documented `PREFIX` / `USE_SUDO` overrides; listed resulting install paths; noted the CGO wrapper links via `-lmbe` (not pkg-config) so non-default prefixes need `LD_LIBRARY_PATH` set.
- **`README.md`** — Status & known gaps updated to reflect the IMBE polish PRs that landed (operator-tunable AGC + §6.4 OA + §6.2 enhancement + frame-repeat shipped); mbelib one-liner mentioned inline so operators can find the build path without digging into `docs/vocoders.md`.

## Test plan
- [x] `make mbelib-install` succeeds end-to-end (clones, builds, installs, ldconfigs, verifies install paths).
- [x] `go test -tags mbelib ./internal/voice/mbelib/...` green after install.
- [x] IMBE + AMBE+2 factories register through `voice.DefaultRegistry` and decode 160-sample PCM frames (smoke-tested via temporary cmd binary).
- [x] No code changes — only build tooling + docs + install script. `go test ./...` is unaffected (still green excluding the pre-existing rtlsdr CGO build failure unrelated to this change).

---
_Generated by [Claude Code](https://claude.ai/code/session_01JmSJLqDwr8jLuKtbkzGXNE)_