### PR TITLE
Pure-Go IMBE: promote registry name from "imbe-go" to "imbe"

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,8 @@ to its own package and lands independently.
   expired; the algorithm is implementable from TIA-102.BABA. The
   `mbelib` build-tagged path already covers IMBE for operators with
   libmbe installed. Status: skeleton + Vocoder interface registered
-  as `imbe-go`; per-vector channel-coding FEC inverse
+  as `imbe` (the canonical name; the pure-Go decoder is the sole
+  IMBE backend in default builds); per-vector channel-coding FEC inverse
   (Golay(23,12) for u_0..u_3 + Hamming(15,11) for u_4..u_6 + no-FEC
   u_7 passthrough) is in (`internal/voice/imbe/channel.go`); the
   TIA-102.BABA §7.4 u_0-keyed LCG pseudo-random scrambler is in
@@ -144,11 +145,12 @@ to its own package and lands independently.
   frames bridge ~120 ms of weak signal before Decode emits silence
   + clears the cache. The repeat path freezes the AGC envelope
   so the attenuation is audible (signals signal degradation).
-  **Remaining audio polish**: comparison-tuning the absolute
-  output level against an mbelib reference (the AGC keeps
-  intra-stream levels consistent but mbelib-bit-equivalent
-  calibration is still a future follow-up); enhancement filter
-  tuning if real-world frames show mid-band envelope drift.
+  **Remaining audio polish**: absolute-level calibration against a
+  known-good reference decoder (DSD-FME or OP25 — capture a P25
+  Phase 1 voice exchange, decode through both, compare RMS +
+  cross-correlation against the reference WAV under
+  `internal/voice/imbe/testdata/`); enhancement filter tuning if
+  real-world frames show mid-band envelope drift.
 - **DVSI USB-3000 / AMBE-3003 hardware backend.** A `Vocoder`
   factory that opens a connected DVSI USB chip. Same plug-in shape
   as `internal/voice/mbelib`; the daemon picks the factory by name

--- a/cmd/gophertrunk/main.go
+++ b/cmd/gophertrunk/main.go
@@ -14,11 +14,9 @@ import (
 	_ "github.com/MattCheramie/GopherTrunk/internal/sdr/rtlsdr"
 	"github.com/MattCheramie/GopherTrunk/internal/version"
 
-	// Blank import: pulls in the pure-Go IMBE skeleton + future
-	// channel-coding / parameter-decode / synthesis layers so the
-	// daemon registers the "imbe-go" vocoder name regardless of
-	// build tags. The decoder currently emits silence; later PRs
-	// turn on real audio without changing this import.
+	// Blank import: pulls in the pure-Go IMBE decoder so the daemon
+	// registers the "imbe" vocoder name regardless of build tags.
+	// This is the sole IMBE backend in default builds.
 	_ "github.com/MattCheramie/GopherTrunk/internal/voice/imbe"
 
 	// Blank import: under default builds this pulls in the stub

--- a/internal/voice/imbe/decoder.go
+++ b/internal/voice/imbe/decoder.go
@@ -31,9 +31,9 @@ const (
 	FrameDurationMs = 20
 
 	// VocoderName is the registry key the daemon resolves at startup.
-	// Distinct from mbelib's "imbe" so both backends can be linked
-	// into the same binary; the daemon picks one in config.
-	VocoderName = "imbe-go"
+	// This is the canonical "imbe" name; the pure-Go decoder is the
+	// sole IMBE backend in default builds.
+	VocoderName = "imbe"
 
 	// MaxBadFrames is the number of consecutive bad frames the
 	// frame-repeat path will replay before giving up and emitting

--- a/internal/voice/imbe/decoder_test.go
+++ b/internal/voice/imbe/decoder_test.go
@@ -20,8 +20,8 @@ func TestDecoderRegistered(t *testing.T) {
 
 func TestDecoderName(t *testing.T) {
 	d := New()
-	if d.Name() != "imbe-go" {
-		t.Errorf("Name() = %q, want %q", d.Name(), "imbe-go")
+	if d.Name() != "imbe" {
+		t.Errorf("Name() = %q, want %q", d.Name(), "imbe")
 	}
 }
 

--- a/internal/voice/imbe/doc.go
+++ b/internal/voice/imbe/doc.go
@@ -9,10 +9,11 @@
 // stays tractable):
 //
 //  1. Skeleton + Vocoder interface integration. Decoder satisfies
-//     voice.Vocoder, registers as "imbe-go" in
-//     voice.DefaultRegistry, and emits silence per frame so the
-//     full call pipeline can wire to it now and start receiving
-//     audio for free as the later pieces land.
+//     voice.Vocoder, registers as "imbe" in voice.DefaultRegistry
+//     (the canonical name; the pure-Go decoder is the sole IMBE
+//     backend), and emits silence per frame so the full call
+//     pipeline can wire to it now and start receiving audio for
+//     free as the later pieces land.
 //
 //  2. Channel coding inverse — per-vector FEC.
 //     144 channel bits → 88 information bits via Golay(23,12,7)
@@ -159,13 +160,13 @@
 //     prior package-level constants with cfg field reads in
 //     applyAGC. See decoder.go.
 //
-//  5f. Remaining polish: comparison-tuning the absolute synthesis
-//     output level against an mbelib reference (the AGC keeps
-//     intra-stream levels consistent but mbelib-bit-equivalent
-//     calibration is still a follow-up); enhancement filter tuning
-//     if real-world frames show mid-band envelope drift;
-//     phase-aware bad-frame fade-in when good frames return after
-//     a streak.
+//  5f. Remaining polish: absolute-level calibration against a
+//     known-good reference decoder (DSD-FME / OP25 — capture a P25
+//     Phase 1 voice exchange, decode through both, compare RMS +
+//     cross-correlation against the reference WAV under
+//     internal/voice/imbe/testdata/); enhancement filter tuning if
+//     real-world frames show mid-band envelope drift; phase-aware
+//     bad-frame fade-in when good frames return after a streak.
 //
 // Patent + licensing context lives in docs/vocoders.md. The core US
 // IMBE patents have expired; this implementation is built from the


### PR DESCRIPTION
PR-A of the mbelib replacement plan. The pure-Go IMBE decoder now
owns the canonical "imbe" registry key, since it is becoming the
sole IMBE backend in default builds. Updates the VocoderName
constant, the test literals, the package roadmap, the main.go
blank-import comment, and the README roadmap entry.

Drops the "calibrate absolute output level against an mbelib
reference" wording from doc.go step 5f and README's remaining-polish
list; replaces it with DSD-FME / OP25 as the calibration source
(libmbe is on the way out). Fixture-building under
internal/voice/imbe/testdata/ remains a follow-up.

The libmbe wrapper at internal/voice/mbelib still registers "imbe"
when built with -tags mbelib; the collision is harmless during the
transition because default builds don't compile that path. PR-F of
the plan deletes the mbelib package and resolves the collision
permanently.

https://claude.ai/code/session_01SvuTSKyeTrSX9V352L9GVH