### PR TITLE
internal/voice/mbe: extract shared MBE-family synthesis core

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,48 +78,57 @@ to its own package and lands independently.
   default builds without a CGO dependency. Core US patents are
   expired; the algorithm is implementable from TIA-102.BABA. The
   `mbelib` build-tagged path already covers IMBE for operators with
-  libmbe installed. Status: skeleton + Vocoder interface registered
-  as `imbe` (the canonical name; the pure-Go decoder is the sole
-  IMBE backend in default builds); per-vector channel-coding FEC inverse
-  (Golay(23,12) for u_0..u_3 + Hamming(15,11) for u_4..u_6 + no-FEC
-  u_7 passthrough) is in (`internal/voice/imbe/channel.go`); the
-  TIA-102.BABA §7.4 u_0-keyed LCG pseudo-random scrambler is in
-  (`scrambler.go`); full §5.3 / §5.4 / Annex E parameter unpack
-  (b_0 → ω₀ + L + K + Vl voicing + Gm PRBA gains + Cik spectral
-  coefficients + Tl log-amplitude residuals via two inverse DCTs)
-  is in (`params.go` / `tables.go`); §6.1 cross-frame log2(Ml)
-  prediction (eqs. 75-77 — γ = 0.65 interpolation of prev-frame
-  harmonics at l · ω₀_curr/ω₀_prev positions, DC-bias removal,
-  Tl residual addition) is in on a `SynthState` that the
-  excitation step extends (`synth.go`); §6.2 amplitude prep
-  (log2(Ml) → linear Ml = 2^log2(Ml), the R_M0 = Σ Ml² and
-  R_M1 = Σ Ml² · cos(ω₀·l) spectral moments, and a voicing-fraction
-  summary that the synthesis combiner consumes) is in (`amps.go`);
-  §6.3 voiced harmonic generator (per-harmonic sinusoid at l · ω₀
-  with linear amp tilt M_prev → M_curr + quadratic phase
-  integration of the ω₀ drift, dual-frame iteration so
-  voiced↔unvoiced transitions fade in / out cleanly) is in
-  (`synth_voiced.go`, `SynthState` extended with `PrevPhase` +
-  `PrevMl`); §6.4 unvoiced excitation (256-point FFT spectrum
-  shaping — bins under voiced harmonics zeroed, bins under
-  unvoiced harmonics scaled by Ml[l], bins outside [1..L]
-  zeroed, conjugate-mirror invariant preserved so the IFFT
-  output stays real-valued) is in (`synth_unvoiced.go`);
-  caller supplies the noise buffer so unit tests stay
-  deterministic; the §6.4 overlap-add synthesis window
-  (256-sample periodic Hann × IFFT, 96-sample tail threaded
-  through `SynthState.PrevUnvoicedTail` so frame boundaries are
-  click-free) is in via `SynthUnvoicedOverlapAdd`; the §6.2
-  spectral-amplitude enhancement (per-harmonic W_l =
-  (0.96 · num/den)^0.25 clamped to [0.5, 1.2] for mid/high-band
-  harmonics + low-band W = 1, followed by an energy-preserving
-  rescale that holds R_M0 stable) is in (`enhance.go`); the
-  output gain calibration is now a per-frame fast-attack /
-  slow-release peak-envelope tracker on the Decoder (target peak
-  24000, attack 0.4, release 0.02, gain clamped to [10, 1e5])
-  with first-frame seeding, freeze-on-silence, and Reset clearing
-  — replaces the prior `pcmGain = 4096` magic constant with
-  consistent loudness across speech-pause-speech transitions.
+  libmbe installed. The synthesis half of the pipeline (cross-frame
+  log-amplitude prediction, voiced harmonic generator, unvoiced
+  FFT excitation + overlap-add window, §6.2 spectral-amplitude
+  enhancement, per-frame AGC) lives in `internal/voice/mbe/` so
+  the in-progress AMBE+2 decoder can consume the same primitives
+  via `mbe.SynthState` + `mbe.Params`. Status: skeleton + Vocoder
+  interface registered as `imbe` (the canonical name; the pure-Go
+  decoder is the sole IMBE backend in default builds); per-vector
+  channel-coding FEC inverse (Golay(23,12) for u_0..u_3 +
+  Hamming(15,11) for u_4..u_6 + no-FEC u_7 passthrough) is in
+  (`internal/voice/imbe/channel.go`); the TIA-102.BABA §7.4
+  u_0-keyed LCG pseudo-random scrambler is in
+  (`internal/voice/imbe/scrambler.go`); full §5.3 / §5.4 / Annex E
+  parameter unpack (b_0 → ω₀ + L + K + Vl voicing + Gm PRBA
+  gains + Cik spectral coefficients + Tl log-amplitude residuals
+  via two inverse DCTs) is in
+  (`internal/voice/imbe/params.go` / `tables.go`); §6.1 cross-frame
+  log2(Ml) prediction (eqs. 75-77 — γ = 0.65 interpolation of
+  prev-frame harmonics at l · ω₀_curr/ω₀_prev positions, DC-bias
+  removal, Tl residual addition) is in on a `SynthState` that the
+  excitation step extends (`internal/voice/mbe/synth.go`); §6.2
+  amplitude prep (log2(Ml) → linear Ml = 2^log2(Ml), the
+  R_M0 = Σ Ml² and R_M1 = Σ Ml² · cos(ω₀·l) spectral moments, and
+  a voicing-fraction summary that the synthesis combiner consumes)
+  is in (`internal/voice/mbe/amps.go`); §6.3 voiced harmonic
+  generator (per-harmonic sinusoid at l · ω₀ with linear amp tilt
+  M_prev → M_curr + quadratic phase integration of the ω₀ drift,
+  dual-frame iteration so voiced↔unvoiced transitions fade in /
+  out cleanly) is in (`internal/voice/mbe/synth_voiced.go`,
+  `SynthState` extended with `PrevPhase` + `PrevMl`); §6.4 unvoiced
+  excitation (256-point FFT spectrum shaping — bins under voiced
+  harmonics zeroed, bins under unvoiced harmonics scaled by Ml[l],
+  bins outside [1..L] zeroed, conjugate-mirror invariant preserved
+  so the IFFT output stays real-valued) is in
+  (`internal/voice/mbe/synth_unvoiced.go`); caller supplies the
+  noise buffer so unit tests stay deterministic; the §6.4
+  overlap-add synthesis window (256-sample periodic Hann × IFFT,
+  96-sample tail threaded through `SynthState.PrevUnvoicedTail` so
+  frame boundaries are click-free) is in via
+  `SynthUnvoicedOverlapAdd`; the §6.2 spectral-amplitude
+  enhancement (per-harmonic W_l = (0.96 · num/den)^0.25 clamped to
+  [0.5, 1.2] for mid/high-band harmonics + low-band W = 1, followed
+  by an energy-preserving rescale that holds R_M0 stable) is in
+  (`internal/voice/mbe/enhance.go`); the output gain calibration is
+  a per-frame fast-attack / slow-release peak-envelope tracker
+  shared with AMBE+2 (target peak 24000, attack 0.4, release 0.02,
+  gain clamped to [10, 1e5]) with first-frame seeding,
+  freeze-on-silence, and Reset clearing — replaces the prior
+  `pcmGain = 4096` magic constant with consistent loudness across
+  speech-pause-speech transitions
+  (`internal/voice/mbe/agc.go`).
   **`Decode()` emits real audio**: 88 info bits → params →
   §6.1 prediction → linear Ml → §6.2 enhancement → §6.3 voiced
   harmonic sum + §6.4 unvoiced excitation with overlap-add
@@ -132,12 +141,12 @@ to its own package and lands independently.
   Three decoder constructors are exposed: `New()` seeds the
   unvoiced noise source from a fixed default for reproducibility;
   `NewWithSeed(seed)` lets parallel calls + production callers
-  spread noise across decoders; `NewWithConfig(seed, AGCConfig{...})`
-  takes a public `AGCConfig` (TargetPeak / Attack / Release /
+  spread noise across decoders; `NewWithConfig(seed, mbe.AGCConfig{...})`
+  takes the shared `mbe.AGCConfig` (TargetPeak / Attack / Release /
   MinGain / MaxGain / NoiseFloor) so operators can dial level +
   responsiveness for their downstream chain — zero-value fields
-  backfill from `DefaultAGCConfig()` so partial overrides like
-  `AGCConfig{TargetPeak: 16000}` (drop level by ~3 dB) keep the
+  backfill from `mbe.DefaultAGCConfig()` so partial overrides like
+  `mbe.AGCConfig{TargetPeak: 16000}` (drop level by ~3 dB) keep the
   rest of the defaults. **Frame-repeat on bad-frame indicator**:
   a bad frame (UnpackParams error from upstream FEC slip)
   following a good frame replays the cached params with M scaled

--- a/internal/voice/imbe/decoder.go
+++ b/internal/voice/imbe/decoder.go
@@ -6,188 +6,67 @@ import (
 	"math/rand"
 
 	"github.com/MattCheramie/GopherTrunk/internal/voice"
+	"github.com/MattCheramie/GopherTrunk/internal/voice/mbe"
 )
 
 // Frame parameters per TIA-102.BABA. Every IMBE 4400 frame carries
-// 88 information bits over 20 ms of audio at 8 kHz mono.
+// 88 information bits over 20 ms of audio at 8 kHz mono. The
+// 20 ms / 8 kHz / 160 PCM cadence + the bad-frame replay constants
+// + the AGC config live on the shared internal/voice/mbe package
+// so AMBE+2 can consume the same primitives.
 const (
 	// InfoBits is the per-frame information-bit count after channel
 	// FEC has been applied + verified.
 	InfoBits = 88
 
 	// FrameBytes is InfoBits packed MSB-first into octets, rounded up.
-	// Matches the mbelib wrapper's frame length so callers can pass
-	// the same byte slice to either backend.
 	FrameBytes = 11
-
-	// SamplesPerFrame is the PCM count one Decode call produces.
-	// IMBE is fixed at 8 kHz × 20 ms = 160 samples.
-	SamplesPerFrame = 160
-
-	// PCMSampleRate is the recorder's expected output rate.
-	PCMSampleRate = 8000
-
-	// FrameDurationMs documents the 20 ms cadence.
-	FrameDurationMs = 20
 
 	// VocoderName is the registry key the daemon resolves at startup.
 	// This is the canonical "imbe" name; the pure-Go decoder is the
 	// sole IMBE backend in default builds.
 	VocoderName = "imbe"
-
-	// MaxBadFrames is the number of consecutive bad frames the
-	// frame-repeat path will replay before giving up and emitting
-	// silence + clearing state. The TIA-102.BABA spec range is
-	// 1..6; mbelib uses 6, which gives the upstream P25 LDU FEC
-	// roughly 120 ms of grace before the audio path drops out
-	// completely. After MaxBadFrames bad frames the cumulative
-	// attenuation is BadFrameAttenuation^6 ≈ 0.118 — quiet enough
-	// that an extended bad streak fades naturally rather than
-	// looping the same envelope.
-	MaxBadFrames = 6
-
-	// BadFrameAttenuation is the per-frame multiplier applied to
-	// the cached last-good amplitudes during a frame-repeat. A
-	// single bad frame plays at 70% of the prev good frame's
-	// amplitudes; six in a row taper to ~12%. This is a balance
-	// between hiding the FEC slip (no abrupt mute) and signalling
-	// the listener that signal is degrading (audible volume drop).
-	BadFrameAttenuation = 0.7
 )
 
-// AGCConfig holds the per-frame AGC parameters. The synthesizer's
-// float output magnitude is stable per-frame (R_M0-preserving §6.2
-// enhancement holds total energy constant across a frame) but
-// varies wildly between frames depending on Tl, voicing, and the
-// §6.4 noise draw. Without an AGC every frame would be either
-// clipped (loud frames) or near-silent (quiet frames). The AGC
-// tracks the per-frame peak with fast-attack / slow-release
-// smoothing, then scales each frame so the smoothed envelope hits
-// TargetPeak.
-//
-// Zero-value fields fall back to DefaultAGCConfig values, so a
-// caller can override only the field they care about (e.g.
-// AGCConfig{TargetPeak: 16000} to drop output level by 4 dB).
-//
-// The current AGC is a level-only design — disabling it entirely
-// means dropping back to a constant gain, which we don't expose as
-// a separate option (callers wanting that can pass equal Attack +
-// Release to fully smooth the envelope). The §6.2-derived
-// per-frame R_M0 normalization the synthesizer already does keeps
-// inter-frame magnitude variation modest enough that AGC is a
-// polish layer rather than the only loudness control.
-type AGCConfig struct {
-	// TargetPeak is the post-AGC peak amplitude target in int16
-	// units. Default 24000 (~3 dB below int16 max for transient
-	// headroom).
-	TargetPeak float64
-
-	// Attack is the per-frame envelope rise coefficient. Standard
-	// IIR coefficient: 1.0 = instant tracking, 0.0 = no update.
-	// Default 0.4 — fast enough to catch loud onsets without
-	// over-shoot.
-	Attack float64
-
-	// Release is the per-frame envelope fall coefficient. Smaller
-	// than Attack so gain ramps back up slowly during quiet
-	// passages — standard AGC behavior that keeps speech
-	// intelligible without pumping. Default 0.02.
-	Release float64
-
-	// MinGain bounds the lowest gain the AGC can apply, preventing
-	// runaway compression on extreme transients. Default 10.
-	MinGain float64
-
-	// MaxGain bounds the highest gain the AGC can apply, preventing
-	// silence from being amplified to full scale by a stale low
-	// envelope. Default 1e5.
-	MaxGain float64
-
-	// NoiseFloor is the per-frame peak threshold below which the
-	// envelope skips its update. Lets a §6.4 OA tail fade-out into
-	// silence without dragging the envelope down. Default 1e-3.
-	NoiseFloor float64
-}
-
-// DefaultAGCConfig returns the AGC parameters Decoder.applyAGC uses
-// when constructed via New() / NewWithSeed(). NewWithConfig callers
-// can take this struct, override individual fields, and pass it back
-// for partial-overrides.
-func DefaultAGCConfig() AGCConfig {
-	return AGCConfig{
-		TargetPeak: 24000.0,
-		Attack:     0.4,
-		Release:    0.02,
-		MinGain:    10.0,
-		MaxGain:    1e5,
-		NoiseFloor: 1e-3,
-	}
-}
-
-// withDefaults backfills any zero-value fields in cfg from
-// DefaultAGCConfig so partial-override calls don't have to specify
-// every parameter. Returns the merged config.
-func (cfg AGCConfig) withDefaults() AGCConfig {
-	d := DefaultAGCConfig()
-	if cfg.TargetPeak == 0 {
-		cfg.TargetPeak = d.TargetPeak
-	}
-	if cfg.Attack == 0 {
-		cfg.Attack = d.Attack
-	}
-	if cfg.Release == 0 {
-		cfg.Release = d.Release
-	}
-	if cfg.MinGain == 0 {
-		cfg.MinGain = d.MinGain
-	}
-	if cfg.MaxGain == 0 {
-		cfg.MaxGain = d.MaxGain
-	}
-	if cfg.NoiseFloor == 0 {
-		cfg.NoiseFloor = d.NoiseFloor
-	}
-	return cfg
-}
-
-// Decoder is the pure-Go IMBE 4400 decoder. It owns one SynthState
-// (cross-frame log2(Ml) prediction memory + voiced phase + amp
-// memory), one math/rand source for the §6.4 unvoiced excitation
-// noise, one AGC envelope tracker, and a one-frame cache of the
-// last-good parameters for the frame-repeat path — all per-call
-// so concurrent calls on different decoders don't share state.
+// Decoder is the pure-Go IMBE 4400 decoder. It owns one
+// mbe.SynthState (cross-frame log2(Ml) prediction memory + voiced
+// phase + amp memory + §6.4 OA tail), one math/rand source for
+// the unvoiced excitation noise, one *mbe.AGC, and a one-frame
+// cache of the last-good params for the frame-repeat path — all
+// per-call so concurrent calls on different decoders don't share
+// state.
 //
 // Decode() runs the full TIA-102.BABA pipeline:
 //   - bytes → 88 info bits
-//   - UnpackParams: §5.3 / §5.4 / Annex E
-//   - PredictLog2Ml: §6.1 cross-frame prediction
-//   - AmplitudesFromLog2Ml: log2(Ml) → linear Ml
-//   - EnhanceAmplitudes: §6.2 spectral-amplitude enhancement
-//   - SynthVoiced: §6.3 voiced harmonic generator
-//   - SynthUnvoicedOverlapAdd: §6.4 unvoiced FFT excitation + OA
-//   - Update{Log2Ml,VoicedState}: roll state forward
-//   - applyAGC: per-frame fast-attack / slow-release peak tracker
-//     scaling to agcTargetPeak, then int16 clip
+//   - UnpackParams: §5.3 / §5.4 / Annex E (this package)
+//   - p.MBE(): port to the shared mbe.Params shape
+//   - mbe.PredictLog2Ml: §6.1 cross-frame prediction
+//   - mbe.AmplitudesFromLog2Ml: log2(Ml) → linear Ml
+//   - mbe.EnhanceAmplitudes: §6.2 spectral-amplitude enhancement
+//   - mbe.SynthVoiced: §6.3 voiced harmonic generator
+//   - mbe.SynthUnvoicedOverlapAdd: §6.4 unvoiced FFT excitation + OA
+//   - mbe.SynthState.Update{Log2Ml,VoicedState}: roll state forward
+//   - mbe.AGC.Apply: per-frame fast-attack / slow-release peak
+//     tracker scaling to AGCConfig.TargetPeak, then int16 clip
 //
 // On a bad frame (UnpackParams returns ErrInvalidFundamental, etc.),
 // Decode replays the last good frame's amplitudes scaled by
-// BadFrameAttenuation^badFrameCount. After MaxBadFrames consecutive
-// bad frames the cache is cleared and Decode returns silence so an
-// extended bad streak fades naturally instead of looping the same
-// envelope forever.
+// mbe.BadFrameAttenuation^badFrameCount. After mbe.MaxBadFrames
+// consecutive bad frames the cache is cleared and Decode returns
+// silence so an extended bad streak fades naturally instead of
+// looping the same envelope forever.
 type Decoder struct {
-	state  SynthState
-	rng    *rand.Rand
-	agc    float64   // smoothed peak envelope; 0 = fresh (next frame seeds it)
-	agcCfg AGCConfig // tunable AGC parameters; defaults via DefaultAGCConfig()
+	state mbe.SynthState
+	rng   *rand.Rand
+	agc   *mbe.AGC
 
-	// One-frame cache for the frame-repeat path. Populated after a
-	// good non-silent frame; consumed by the bad-frame path; cleared
-	// on silence-window frames + on Reset + when MaxBadFrames is
-	// exceeded.
-	lastGoodParams Params
-	lastGoodLog2M  [57]float64
-	lastGoodM      [57]float64
+	// One-frame cache for the frame-repeat path. Holds the shared
+	// mbe.Params shape since the synthesis path consumes only that
+	// subset (W0/L/Silent/Vl/Tl); the IMBE-specific Gm/Cik
+	// intermediates are not needed for replay.
+	lastGoodParams mbe.Params
+	lastGoodLog2M  [mbe.MaxL + 1]float64
+	lastGoodM      [mbe.MaxL + 1]float64
 
 	// Consecutive bad-frame count. Increments once per replay,
 	// resets to 0 on every good non-silent frame.
@@ -208,20 +87,20 @@ func New() *Decoder {
 // internal noise source. Lets tests pin output across runs and lets
 // production callers spread noise across decoders so two parallel
 // calls don't share the same noise stream. AGC parameters use
-// DefaultAGCConfig.
+// mbe.DefaultAGCConfig.
 func NewWithSeed(seed int64) *Decoder {
-	return NewWithConfig(seed, DefaultAGCConfig())
+	return NewWithConfig(seed, mbe.DefaultAGCConfig())
 }
 
 // NewWithConfig constructs a Decoder with an explicit noise seed +
 // AGC configuration. Zero-value fields in cfg fall back to
-// DefaultAGCConfig values, so callers can override only the
-// parameters they care about (e.g. AGCConfig{TargetPeak: 16000} to
-// drop the output level by ~3 dB without re-tuning attack/release).
-func NewWithConfig(seed int64, cfg AGCConfig) *Decoder {
+// mbe.DefaultAGCConfig values, so callers can override only the
+// parameters they care about (e.g. mbe.AGCConfig{TargetPeak: 16000}
+// to drop the output level by ~3 dB without re-tuning attack/release).
+func NewWithConfig(seed int64, cfg mbe.AGCConfig) *Decoder {
 	return &Decoder{
-		rng:    rand.New(rand.NewSource(seed)),
-		agcCfg: cfg.withDefaults(),
+		rng: rand.New(rand.NewSource(seed)),
+		agc: mbe.NewAGC(cfg),
 	}
 }
 
@@ -245,10 +124,10 @@ func (d *Decoder) FrameSize() int { return FrameBytes }
 //     fade-out into pcm[0..95]; reset SynthState + last-good cache
 //     + badFrameCount; AGC envelope preserved across the silence.
 //   - bad frame (UnpackParams error) with cached last-good frame
-//     and badFrameCount < MaxBadFrames: replay last-good params
-//     with M scaled by BadFrameAttenuation^badFrameCount; AGC
+//     and badFrameCount < mbe.MaxBadFrames: replay last-good params
+//     with M scaled by mbe.BadFrameAttenuation^badFrameCount; AGC
 //     freezes so the attenuation is audible (signals signal loss).
-//   - bad frame with no cache, or after MaxBadFrames consecutive
+//   - bad frame with no cache, or after mbe.MaxBadFrames consecutive
 //     bad frames: emit silence; clear last-good cache + reset
 //     SynthState; AGC envelope preserved.
 func (d *Decoder) Decode(frame []byte) ([]int16, error) {
@@ -257,25 +136,25 @@ func (d *Decoder) Decode(frame []byte) ([]int16, error) {
 	}
 
 	info := unpackInfoBits(frame)
-	out := make([]int16, SamplesPerFrame)
-	pcm := make([]float64, SamplesPerFrame)
+	out := make([]int16, mbe.SamplesPerFrame)
+	pcm := make([]float64, mbe.SamplesPerFrame)
 
 	p, err := UnpackParams(info)
 
 	switch {
-	case err != nil && d.lastGoodParams.L > 0 && d.badFrameCount < MaxBadFrames:
+	case err != nil && d.lastGoodParams.L > 0 && d.badFrameCount < mbe.MaxBadFrames:
 		// Frame repeat: replay the last-good params with progressive
 		// per-frame attenuation. Synthesis still runs (so OA tail +
 		// phase memory continue rolling forward), AGC freezes so the
 		// attenuation is audible.
 		d.badFrameCount++
-		atten := math.Pow(BadFrameAttenuation, float64(d.badFrameCount))
+		atten := math.Pow(mbe.BadFrameAttenuation, float64(d.badFrameCount))
 		repeatedM := d.lastGoodM
 		for l := 1; l <= d.lastGoodParams.L; l++ {
 			repeatedM[l] *= atten
 		}
 		d.synthFrame(d.lastGoodParams, &d.lastGoodLog2M, &repeatedM, pcm)
-		d.applyAGC(pcm, out, true)
+		d.agc.Apply(pcm, out, true)
 		return out, nil
 
 	case err != nil:
@@ -285,7 +164,7 @@ func (d *Decoder) Decode(frame []byte) ([]int16, error) {
 		// return.
 		d.state.Reset()
 		d.clearLastGood()
-		d.applyAGC(pcm, out, true)
+		d.agc.Apply(pcm, out, true)
 		return out, nil
 
 	case p.Silent:
@@ -294,30 +173,31 @@ func (d *Decoder) Decode(frame []byte) ([]int16, error) {
 		// tail still fades into pcm[0..95] (no click on the silence
 		// boundary), then reset SynthState + last-good cache so the
 		// next non-silent frame starts from a clean baseline.
-		SynthUnvoicedOverlapAdd(&d.state, p, nil, nil, pcm)
+		mbe.SynthUnvoicedOverlapAdd(&d.state, p.MBE(), nil, nil, pcm)
 		d.state.Reset()
 		d.clearLastGood()
-		d.applyAGC(pcm, out, true)
+		d.agc.Apply(pcm, out, true)
 		return out, nil
 	}
 
 	// Good non-silent frame.
 	d.badFrameCount = 0
-	var log2M [57]float64
-	PredictLog2Ml(&d.state, p, &log2M)
+	m := p.MBE()
+	var log2M [mbe.MaxL + 1]float64
+	mbe.PredictLog2Ml(&d.state, m, &log2M)
 
-	var M [57]float64
-	AmplitudesFromLog2Ml(&log2M, p.L, &M)
-	EnhanceAmplitudes(p, &M)
+	var M [mbe.MaxL + 1]float64
+	mbe.AmplitudesFromLog2Ml(&log2M, m.L, &M)
+	mbe.EnhanceAmplitudes(m, &M)
 
-	d.synthFrame(p, &log2M, &M, pcm)
+	d.synthFrame(m, &log2M, &M, pcm)
 
 	// Cache for the frame-repeat path on a future bad frame.
-	d.lastGoodParams = p
+	d.lastGoodParams = m
 	d.lastGoodLog2M = log2M
 	d.lastGoodM = M
 
-	d.applyAGC(pcm, out, false)
+	d.agc.Apply(pcm, out, false)
 	return out, nil
 }
 
@@ -326,13 +206,13 @@ func (d *Decoder) Decode(frame []byte) ([]int16, error) {
 // by both the good-frame path and the bad-frame replay path so the
 // two share identical synthesis behavior — the only difference is
 // what M values get fed in.
-func (d *Decoder) synthFrame(p Params, log2M *[57]float64, M *[57]float64, pcm []float64) {
-	SynthVoiced(&d.state, p, M, pcm)
-	noise := make([]float64, UnvoicedFFTSize)
+func (d *Decoder) synthFrame(p mbe.Params, log2M *[mbe.MaxL + 1]float64, M *[mbe.MaxL + 1]float64, pcm []float64) {
+	mbe.SynthVoiced(&d.state, p, M, pcm)
+	noise := make([]float64, mbe.UnvoicedFFTSize)
 	for i := range noise {
 		noise[i] = d.rng.NormFloat64()
 	}
-	SynthUnvoicedOverlapAdd(&d.state, p, M, noise, pcm)
+	mbe.SynthUnvoicedOverlapAdd(&d.state, p, M, noise, pcm)
 	d.state.UpdateLog2Ml(p, log2M)
 	d.state.UpdateVoicedState(p, M)
 }
@@ -341,77 +221,10 @@ func (d *Decoder) synthFrame(p Params, log2M *[57]float64, M *[57]float64, pcm [
 // Called on silence-window frames, on the bad-frame budget being
 // exceeded, and from the public Reset.
 func (d *Decoder) clearLastGood() {
-	d.lastGoodParams = Params{}
-	d.lastGoodLog2M = [57]float64{}
-	d.lastGoodM = [57]float64{}
+	d.lastGoodParams = mbe.Params{}
+	d.lastGoodLog2M = [mbe.MaxL + 1]float64{}
+	d.lastGoodM = [mbe.MaxL + 1]float64{}
 	d.badFrameCount = 0
-}
-
-// applyAGC tracks the per-frame peak with fast-attack / slow-release
-// smoothing and scales pcm so the smoothed envelope hits
-// d.agcCfg.TargetPeak. Frames whose peak falls below
-// d.agcCfg.NoiseFloor leave the envelope unchanged so a tail
-// fade-out into silence doesn't drag the envelope up artificially.
-//
-// First-frame seed: when d.agc == 0 (fresh decoder, post-Reset), the
-// envelope is initialised directly to peak rather than via the attack
-// coefficient. Without this seed the first frame would emerge ~2.5×
-// over-gained (envelope = Attack · peak ⇒ gain = TargetPeak /
-// (Attack · peak) ⇒ output peak = (1/Attack) · TargetPeak ⇒
-// int16 saturation at the default Attack = 0.4).
-//
-// Frozen mode (freezeEnvelope = true): apply the existing envelope's
-// gain without updating it. The Decode() silent path uses this so a
-// brief silence frame doesn't shift the AGC envelope based on the
-// small §6.4 overlap-add fade-out content; the bad-frame replay
-// path uses it so the per-frame attenuation is audible (signals
-// signal degradation). Stream re-sync via the public Reset() does
-// clear the envelope.
-//
-// MinGain / MaxGain prevent the envelope from sending silence to
-// full scale or compressing extreme transients to inaudible levels.
-// After the gain multiply, samples beyond int16 range are
-// hard-clipped at ±32767.
-func (d *Decoder) applyAGC(pcm []float64, out []int16, freezeEnvelope bool) {
-	cfg := d.agcCfg
-	if !freezeEnvelope {
-		var peak float64
-		for _, v := range pcm {
-			if a := math.Abs(v); a > peak {
-				peak = a
-			}
-		}
-		if d.agc == 0 && peak > cfg.NoiseFloor {
-			// First-frame seed: skip attack smoothing so the first frame
-			// lands at exactly TargetPeak instead of 1/Attack× over.
-			d.agc = peak
-		} else if peak > cfg.NoiseFloor {
-			coef := cfg.Attack
-			if peak < d.agc {
-				coef = cfg.Release
-			}
-			d.agc += (peak - d.agc) * coef
-		}
-	}
-	envelope := d.agc
-	if envelope < cfg.NoiseFloor {
-		envelope = cfg.NoiseFloor
-	}
-	gain := cfg.TargetPeak / envelope
-	if gain < cfg.MinGain {
-		gain = cfg.MinGain
-	} else if gain > cfg.MaxGain {
-		gain = cfg.MaxGain
-	}
-	for i, v := range pcm {
-		s := v * gain
-		if s > 32767 {
-			s = 32767
-		} else if s < -32768 {
-			s = -32768
-		}
-		out[i] = int16(s)
-	}
 }
 
 // unpackInfoBits expands 11 bytes (MSB-first) into an 88-element
@@ -435,7 +248,7 @@ func unpackInfoBits(frame []byte) []byte {
 // not a per-call concern.
 func (d *Decoder) Reset() {
 	d.state.Reset()
-	d.agc = 0
+	d.agc.Reset()
 	d.clearLastGood()
 }
 

--- a/internal/voice/imbe/decoder_test.go
+++ b/internal/voice/imbe/decoder_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/MattCheramie/GopherTrunk/internal/voice"
+	"github.com/MattCheramie/GopherTrunk/internal/voice/mbe"
 )
 
 func TestDecoderRegistered(t *testing.T) {
@@ -44,8 +45,8 @@ func TestDecodeReturnsSilenceForB0SilenceFrame(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Decode: %v", err)
 	}
-	if len(out) != SamplesPerFrame {
-		t.Errorf("len(out) = %d, want %d", len(out), SamplesPerFrame)
+	if len(out) != mbe.SamplesPerFrame {
+		t.Errorf("len(out) = %d, want %d", len(out), mbe.SamplesPerFrame)
 	}
 	for i, s := range out {
 		if s != 0 {
@@ -99,8 +100,8 @@ func TestDecodeBadB0ReturnsSilenceNoError(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Decode: unexpected error %v on bad b_0", err)
 	}
-	if len(out) != SamplesPerFrame {
-		t.Errorf("len(out) = %d, want %d", len(out), SamplesPerFrame)
+	if len(out) != mbe.SamplesPerFrame {
+		t.Errorf("len(out) = %d, want %d", len(out), mbe.SamplesPerFrame)
 	}
 	for i, s := range out {
 		if s != 0 {
@@ -283,7 +284,7 @@ func TestDecodeSilenceFrameResetsState(t *testing.T) {
 	}
 	// dst[96..159] (the non-overlap region) must be silent — no
 	// new synthesis happens on a silent frame.
-	for i := 96; i < SamplesPerFrame; i++ {
+	for i := 96; i < mbe.SamplesPerFrame; i++ {
 		if out[i] != 0 {
 			t.Errorf("silence sample[%d] = %d, want 0 (non-overlap region)", i, out[i])
 		}
@@ -297,7 +298,7 @@ func TestDecodeSilenceFrameResetsState(t *testing.T) {
 	}
 	// Tail must be cleared so a *second* silence frame is fully
 	// silent (no perpetual fade-out loop).
-	for n := 0; n < UnvoicedTailSamples; n++ {
+	for n := 0; n < mbe.UnvoicedTailSamples; n++ {
 		if d.state.PrevUnvoicedTail[n] != 0 {
 			t.Errorf("PrevUnvoicedTail[%d] = %v, want 0 after silence",
 				n, d.state.PrevUnvoicedTail[n])
@@ -354,7 +355,7 @@ func TestDecodeOutputIsBounded(t *testing.T) {
 			// also catches NaN / Inf which would have failed earlier
 			// at the int16 cast.
 			_ = s
-			if i >= SamplesPerFrame {
+			if i >= mbe.SamplesPerFrame {
 				t.Errorf("output longer than expected at pattern 0x%02X", fill)
 			}
 		}
@@ -395,7 +396,7 @@ func TestAGCConvergesTowardTarget(t *testing.T) {
 	}
 	// After convergence the peak should be within ~30% of the target
 	// (loose because the §6.4 noise draw varies per frame).
-	target := DefaultAGCConfig().TargetPeak
+	target := mbe.DefaultAGCConfig().TargetPeak
 	const tol = 0.3
 	lo := int(target * (1 - tol))
 	hi := int(target * (1 + tol))
@@ -440,10 +441,10 @@ func TestAGCSilenceFramePreservesEnvelope(t *testing.T) {
 			t.Fatalf("seed frame %d: %v", i, err)
 		}
 	}
-	if d.agc == 0 {
+	if d.agc.Envelope() == 0 {
 		t.Fatal("envelope is still zero after seed frames; test setup invalid")
 	}
-	envBefore := d.agc
+	envBefore := d.agc.Envelope()
 
 	silence := make([]byte, FrameBytes)
 	silence[0] = 0xD8
@@ -453,9 +454,9 @@ func TestAGCSilenceFramePreservesEnvelope(t *testing.T) {
 	// Envelope must not drift at all — silence path passes
 	// freezeEnvelope=true to applyAGC so the OA tail magnitude
 	// doesn't perturb the envelope.
-	if d.agc != envBefore {
+	if d.agc.Envelope() != envBefore {
 		t.Errorf("after silence: agc shifted from %v to %v (want exact preservation)",
-			envBefore, d.agc)
+			envBefore, d.agc.Envelope())
 	}
 }
 
@@ -467,12 +468,12 @@ func TestAGCResetClearsEnvelope(t *testing.T) {
 	if _, err := d.Decode(make([]byte, FrameBytes)); err != nil {
 		t.Fatal(err)
 	}
-	if d.agc == 0 {
+	if d.agc.Envelope() == 0 {
 		t.Fatal("envelope is zero after one frame; test setup invalid")
 	}
 	d.Reset()
-	if d.agc != 0 {
-		t.Errorf("after Reset: agc = %v, want 0", d.agc)
+	if d.agc.Envelope() != 0 {
+		t.Errorf("after Reset: agc = %v, want 0", d.agc.Envelope())
 	}
 }
 
@@ -497,8 +498,8 @@ func TestAGCBoundedOutputAcrossFramePatterns(t *testing.T) {
 				_ = s // every int16 is by construction in [-32768, 32767]
 			}
 			// Cross-check that the AGC didn't NaN.
-			if math.IsNaN(d.agc) || math.IsInf(d.agc, 0) {
-				t.Fatalf("agc envelope = %v after round %d", d.agc, round)
+			if math.IsNaN(d.agc.Envelope()) || math.IsInf(d.agc.Envelope(), 0) {
+				t.Fatalf("agc envelope = %v after round %d", d.agc.Envelope(), round)
 			}
 		}
 	}
@@ -592,21 +593,21 @@ func TestFrameRepeatProgressiveAttenuation(t *testing.T) {
 	if _, err := d.Decode(make([]byte, FrameBytes)); err != nil {
 		t.Fatalf("good seed: %v", err)
 	}
-	var peaks [MaxBadFrames]int
-	for i := 0; i < MaxBadFrames; i++ {
+	var peaks [mbe.MaxBadFrames]int
+	for i := 0; i < mbe.MaxBadFrames; i++ {
 		out, err := d.Decode(badFrame())
 		if err != nil {
 			t.Fatalf("bad frame %d: %v", i, err)
 		}
 		peaks[i] = agcPeak(out)
 	}
-	if peaks[MaxBadFrames-1] >= peaks[0] {
+	if peaks[mbe.MaxBadFrames-1] >= peaks[0] {
 		t.Errorf("peaks didn't trend down: peaks=%v (first %d, last %d)",
-			peaks, peaks[0], peaks[MaxBadFrames-1])
+			peaks, peaks[0], peaks[mbe.MaxBadFrames-1])
 	}
 }
 
-// TestFrameRepeatExhaustedBudgetForcesSilence: after MaxBadFrames
+// TestFrameRepeatExhaustedBudgetForcesSilence: after mbe.MaxBadFrames
 // consecutive bad-frame replays, the next bad frame must hit the
 // "no cache or budget exhausted" path → silence + cache cleared.
 func TestFrameRepeatExhaustedBudgetForcesSilence(t *testing.T) {
@@ -614,12 +615,12 @@ func TestFrameRepeatExhaustedBudgetForcesSilence(t *testing.T) {
 	if _, err := d.Decode(make([]byte, FrameBytes)); err != nil {
 		t.Fatalf("good seed: %v", err)
 	}
-	for i := 0; i < MaxBadFrames; i++ {
+	for i := 0; i < mbe.MaxBadFrames; i++ {
 		if _, err := d.Decode(badFrame()); err != nil {
 			t.Fatalf("bad frame %d: %v", i, err)
 		}
 	}
-	// Next bad frame: budget exhausted (count == MaxBadFrames),
+	// Next bad frame: budget exhausted (count == mbe.MaxBadFrames),
 	// silence + clear.
 	out, err := d.Decode(badFrame())
 	if err != nil {
@@ -727,15 +728,15 @@ func TestResetClearsFrameRepeatCache(t *testing.T) {
 
 // TestDefaultAGCConfigMatchesNew: a Decoder constructed via New()
 // uses the same AGC parameters as one constructed via
-// NewWithConfig(0, DefaultAGCConfig()). Pins that the old
+// NewWithConfig(0, mbe.DefaultAGCConfig()). Pins that the old
 // constructors aren't accidentally divergent from the documented
 // defaults.
 func TestDefaultAGCConfigMatchesNew(t *testing.T) {
 	a := New()
-	b := NewWithConfig(0, DefaultAGCConfig())
-	if a.agcCfg != b.agcCfg {
+	b := NewWithConfig(0, mbe.DefaultAGCConfig())
+	if a.agc.Config() != b.agc.Config() {
 		t.Errorf("New().agcCfg = %+v, NewWithConfig(default).agcCfg = %+v",
-			a.agcCfg, b.agcCfg)
+			a.agc.Config(), b.agc.Config())
 	}
 	frame := make([]byte, FrameBytes)
 	outA, _ := a.Decode(frame)
@@ -749,44 +750,44 @@ func TestDefaultAGCConfigMatchesNew(t *testing.T) {
 	}
 }
 
-// TestAGCConfigZeroValueBackfillsDefaults: an AGCConfig{} (all zero)
+// TestAGCConfigZeroValueBackfillsDefaults: an mbe.AGCConfig{} (all zero)
 // passed to NewWithConfig backfills every field from
-// DefaultAGCConfig. Lets callers override one knob without
+// mbe.DefaultAGCConfig. Lets callers override one knob without
 // re-specifying everything.
 func TestAGCConfigZeroValueBackfillsDefaults(t *testing.T) {
-	d := NewWithConfig(0, AGCConfig{})
-	want := DefaultAGCConfig()
-	if d.agcCfg != want {
-		t.Errorf("zero-value cfg backfill = %+v, want %+v", d.agcCfg, want)
+	d := NewWithConfig(0, mbe.AGCConfig{})
+	want := mbe.DefaultAGCConfig()
+	if d.agc.Config() != want {
+		t.Errorf("zero-value cfg backfill = %+v, want %+v", d.agc.Config(), want)
 	}
 }
 
-// TestAGCConfigPartialOverrideKeepsDefaults: an AGCConfig with one
-// field set inherits all other fields from DefaultAGCConfig. Pins
+// TestAGCConfigPartialOverrideKeepsDefaults: an mbe.AGCConfig with one
+// field set inherits all other fields from mbe.DefaultAGCConfig. Pins
 // the partial-override pattern.
 func TestAGCConfigPartialOverrideKeepsDefaults(t *testing.T) {
-	custom := AGCConfig{TargetPeak: 12000}
+	custom := mbe.AGCConfig{TargetPeak: 12000}
 	d := NewWithConfig(0, custom)
-	def := DefaultAGCConfig()
-	if d.agcCfg.TargetPeak != 12000 {
-		t.Errorf("TargetPeak = %v, want 12000", d.agcCfg.TargetPeak)
+	def := mbe.DefaultAGCConfig()
+	if d.agc.Config().TargetPeak != 12000 {
+		t.Errorf("TargetPeak = %v, want 12000", d.agc.Config().TargetPeak)
 	}
-	if d.agcCfg.Attack != def.Attack {
+	if d.agc.Config().Attack != def.Attack {
 		t.Errorf("Attack = %v, want default %v (partial override)",
-			d.agcCfg.Attack, def.Attack)
+			d.agc.Config().Attack, def.Attack)
 	}
-	if d.agcCfg.Release != def.Release {
-		t.Errorf("Release = %v, want default %v", d.agcCfg.Release, def.Release)
+	if d.agc.Config().Release != def.Release {
+		t.Errorf("Release = %v, want default %v", d.agc.Config().Release, def.Release)
 	}
-	if d.agcCfg.MinGain != def.MinGain {
-		t.Errorf("MinGain = %v, want default %v", d.agcCfg.MinGain, def.MinGain)
+	if d.agc.Config().MinGain != def.MinGain {
+		t.Errorf("MinGain = %v, want default %v", d.agc.Config().MinGain, def.MinGain)
 	}
-	if d.agcCfg.MaxGain != def.MaxGain {
-		t.Errorf("MaxGain = %v, want default %v", d.agcCfg.MaxGain, def.MaxGain)
+	if d.agc.Config().MaxGain != def.MaxGain {
+		t.Errorf("MaxGain = %v, want default %v", d.agc.Config().MaxGain, def.MaxGain)
 	}
-	if d.agcCfg.NoiseFloor != def.NoiseFloor {
+	if d.agc.Config().NoiseFloor != def.NoiseFloor {
 		t.Errorf("NoiseFloor = %v, want default %v",
-			d.agcCfg.NoiseFloor, def.NoiseFloor)
+			d.agc.Config().NoiseFloor, def.NoiseFloor)
 	}
 }
 
@@ -796,8 +797,8 @@ func TestAGCConfigPartialOverrideKeepsDefaults(t *testing.T) {
 // actually controls output level.
 func TestAGCConfigCustomTargetShiftsOutputLevel(t *testing.T) {
 	frame := make([]byte, FrameBytes)
-	loudCfg := AGCConfig{TargetPeak: 24000}
-	quietCfg := AGCConfig{TargetPeak: 8000}
+	loudCfg := mbe.AGCConfig{TargetPeak: 24000}
+	quietCfg := mbe.AGCConfig{TargetPeak: 8000}
 	loud := NewWithConfig(0, loudCfg)
 	quiet := NewWithConfig(0, quietCfg)
 	// Warm both AGCs to convergence.
@@ -823,16 +824,16 @@ func TestAGCConfigCustomTargetShiftsOutputLevel(t *testing.T) {
 // tuning. Pins that callers don't have to re-specify cfg after
 // every stream re-sync.
 func TestAGCConfigPreservedAcrossReset(t *testing.T) {
-	cfg := AGCConfig{TargetPeak: 16000, Attack: 0.5}
+	cfg := mbe.AGCConfig{TargetPeak: 16000, Attack: 0.5}
 	d := NewWithConfig(0, cfg)
 	if _, err := d.Decode(make([]byte, FrameBytes)); err != nil {
 		t.Fatal(err)
 	}
 	d.Reset()
-	want := cfg.withDefaults()
-	if d.agcCfg != want {
+	want := cfg.WithDefaults()
+	if d.agc.Config() != want {
 		t.Errorf("after Reset: agcCfg = %+v, want %+v (cfg preserved)",
-			d.agcCfg, want)
+			d.agc.Config(), want)
 	}
 }
 
@@ -846,15 +847,15 @@ func TestFrameRepeatFreezesAGC(t *testing.T) {
 			t.Fatalf("warmup %d: %v", i, err)
 		}
 	}
-	envBefore := d.agc
+	envBefore := d.agc.Envelope()
 	if envBefore == 0 {
 		t.Fatal("envelope is zero after warmup; test setup invalid")
 	}
 	if _, err := d.Decode(badFrame()); err != nil {
 		t.Fatalf("bad frame: %v", err)
 	}
-	if d.agc != envBefore {
+	if d.agc.Envelope() != envBefore {
 		t.Errorf("after bad-frame replay: agc shifted from %v to %v (want exact preservation)",
-			envBefore, d.agc)
+			envBefore, d.agc.Envelope())
 	}
 }

--- a/internal/voice/imbe/enhance_integration_test.go
+++ b/internal/voice/imbe/enhance_integration_test.go
@@ -1,0 +1,35 @@
+package imbe
+
+import (
+	"math"
+	"testing"
+)
+
+// TestDecodeOutputChangesWithEnhancement: a deterministic Decode
+// run with the §6.2 enhancement enabled should produce non-silent,
+// non-saturated PCM. Pins that the shared mbe.EnhanceAmplitudes
+// step is wired into the IMBE Decode path rather than being a
+// silent no-op. We can't toggle enhancement off easily without a
+// test fixture, so instead verify a frame that the enhancement
+// modifies M for produces audio whose RMS is sane (not zero, not
+// saturated).
+func TestDecodeOutputChangesWithEnhancement(t *testing.T) {
+	d := New()
+	frame := make([]byte, FrameBytes) // valid b_0 = 0 frame
+	out, err := d.Decode(frame)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	var sumSq float64
+	for _, s := range out {
+		v := float64(s)
+		sumSq += v * v
+	}
+	rms := math.Sqrt(sumSq / float64(len(out)))
+	if rms == 0 {
+		t.Fatal("decoded output is fully silent; enhancement may have zeroed M")
+	}
+	if rms > 32000 {
+		t.Errorf("rms = %v, want < 32000 (sanity envelope)", rms)
+	}
+}

--- a/internal/voice/imbe/params.go
+++ b/internal/voice/imbe/params.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"fmt"
 	"math"
+
+	"github.com/MattCheramie/GopherTrunk/internal/voice/mbe"
 )
 
 // IMBE 4400 model parameter unpacking — TIA-102.BABA §5.3 / Annex E.
@@ -57,6 +59,24 @@ type Params struct {
 	Gm  [7]float64     // Gm[1..6] PRBA gain block values
 	Cik [7][11]float64 // Cik[1..6][1..imbeJi[L9][i-1]] DCT coefficients
 	Tl  [57]float64    // Tl[1..L] spectral log-amplitude residuals
+}
+
+// MBE returns the subset of this header the shared synthesis core
+// consumes (drops the IMBE-specific voicing-decision count K).
+func (h Header) MBE() mbe.Header {
+	return mbe.Header{W0: h.W0, L: h.L, Silent: h.Silent}
+}
+
+// MBE returns the IMBE Params projected to the shared mbe.Params
+// shape: header (without K) + Vl + Tl. The IMBE intermediates
+// Gm + Cik are dropped — the synthesis primitives in
+// internal/voice/mbe consume only what's preserved here.
+func (p Params) MBE() mbe.Params {
+	return mbe.Params{
+		Header: p.Header.MBE(),
+		Vl:     p.Vl,
+		Tl:     p.Tl,
+	}
 }
 
 // ErrInfoLength is returned by UnpackHeader when the supplied

--- a/internal/voice/mbe/agc.go
+++ b/internal/voice/mbe/agc.go
@@ -1,0 +1,221 @@
+package mbe
+
+import "math"
+
+// Bad-frame replay constants shared across MBE-family decoders.
+// When the upstream protocol layer's FEC reports a slip and the
+// decoder cannot recover an MBE Params from the frame bits, the
+// decoder replays the cached last-good params with a per-frame
+// attenuation; after MaxBadFrames consecutive replays the cache
+// clears and the decoder emits silence.
+const (
+	// MaxBadFrames is the number of consecutive bad frames the
+	// frame-repeat path replays before giving up and emitting
+	// silence + clearing state. The TIA-102.BABA spec range is
+	// 1..6; mbelib uses 6, which gives the upstream FEC roughly
+	// 120 ms of grace before the audio path drops out completely.
+	// After MaxBadFrames bad frames the cumulative attenuation is
+	// BadFrameAttenuation^6 ≈ 0.118 — quiet enough that an extended
+	// bad streak fades naturally rather than looping the same
+	// envelope.
+	MaxBadFrames = 6
+
+	// BadFrameAttenuation is the per-frame multiplier applied to
+	// the cached last-good amplitudes during a frame-repeat. A
+	// single bad frame plays at 70% of the prev good frame's
+	// amplitudes; six in a row taper to ~12%. Balance between
+	// hiding the FEC slip (no abrupt mute) and signalling the
+	// listener that signal is degrading (audible volume drop).
+	BadFrameAttenuation = 0.7
+)
+
+// AGCConfig holds the per-frame AGC parameters. The synthesizer's
+// float output magnitude is stable per-frame (the §6.2
+// enhancement's R_M0-preserving rescale holds total energy
+// constant across a frame) but varies wildly between frames
+// depending on Tl, voicing, and the §6.4 noise draw. Without an
+// AGC every frame would be either clipped (loud frames) or
+// near-silent (quiet frames). The AGC tracks the per-frame peak
+// with fast-attack / slow-release smoothing, then scales each
+// frame so the smoothed envelope hits TargetPeak.
+//
+// Zero-value fields fall back to DefaultAGCConfig values, so a
+// caller can override only the field they care about (e.g.
+// AGCConfig{TargetPeak: 16000} to drop output level by 4 dB).
+//
+// The current AGC is a level-only design — disabling it entirely
+// means dropping back to a constant gain, which we don't expose as
+// a separate option (callers wanting that can pass equal Attack +
+// Release to fully smooth the envelope).
+type AGCConfig struct {
+	// TargetPeak is the post-AGC peak amplitude target in int16
+	// units. Default 24000 (~3 dB below int16 max for transient
+	// headroom).
+	TargetPeak float64
+
+	// Attack is the per-frame envelope rise coefficient. Standard
+	// IIR coefficient: 1.0 = instant tracking, 0.0 = no update.
+	// Default 0.4 — fast enough to catch loud onsets without
+	// over-shoot.
+	Attack float64
+
+	// Release is the per-frame envelope fall coefficient. Smaller
+	// than Attack so gain ramps back up slowly during quiet
+	// passages — standard AGC behavior that keeps speech
+	// intelligible without pumping. Default 0.02.
+	Release float64
+
+	// MinGain bounds the lowest gain the AGC can apply, preventing
+	// runaway compression on extreme transients. Default 10.
+	MinGain float64
+
+	// MaxGain bounds the highest gain the AGC can apply, preventing
+	// silence from being amplified to full scale by a stale low
+	// envelope. Default 1e5.
+	MaxGain float64
+
+	// NoiseFloor is the per-frame peak threshold below which the
+	// envelope skips its update. Lets a §6.4 OA tail fade-out into
+	// silence without dragging the envelope down. Default 1e-3.
+	NoiseFloor float64
+}
+
+// DefaultAGCConfig returns the AGC parameters the IMBE / AMBE+2
+// decoders use when constructed without an explicit override.
+// Callers wanting a partial override can take this struct, mutate
+// individual fields, and pass it back; or pass an AGCConfig{}
+// with only the field they care about set — zero-value fields
+// backfill from the defaults via WithDefaults.
+func DefaultAGCConfig() AGCConfig {
+	return AGCConfig{
+		TargetPeak: 24000.0,
+		Attack:     0.4,
+		Release:    0.02,
+		MinGain:    10.0,
+		MaxGain:    1e5,
+		NoiseFloor: 1e-3,
+	}
+}
+
+// WithDefaults backfills any zero-value fields in cfg from
+// DefaultAGCConfig so partial-override calls don't have to specify
+// every parameter. Returns the merged config.
+func (cfg AGCConfig) WithDefaults() AGCConfig {
+	d := DefaultAGCConfig()
+	if cfg.TargetPeak == 0 {
+		cfg.TargetPeak = d.TargetPeak
+	}
+	if cfg.Attack == 0 {
+		cfg.Attack = d.Attack
+	}
+	if cfg.Release == 0 {
+		cfg.Release = d.Release
+	}
+	if cfg.MinGain == 0 {
+		cfg.MinGain = d.MinGain
+	}
+	if cfg.MaxGain == 0 {
+		cfg.MaxGain = d.MaxGain
+	}
+	if cfg.NoiseFloor == 0 {
+		cfg.NoiseFloor = d.NoiseFloor
+	}
+	return cfg
+}
+
+// AGC is the per-frame fast-attack / slow-release peak-envelope
+// tracker shared across MBE-family decoders. The smoothed envelope
+// scales each frame's float PCM to AGCConfig.TargetPeak; samples
+// beyond int16 range are hard-clipped at ±32767.
+//
+// Concurrent calls to Apply on the same AGC are not safe; each
+// decoder owns one AGC instance.
+type AGC struct {
+	cfg AGCConfig
+	env float64 // smoothed peak envelope; 0 = fresh (next frame seeds it)
+}
+
+// NewAGC constructs an AGC with the supplied config. Zero-value
+// fields in cfg backfill from DefaultAGCConfig.
+func NewAGC(cfg AGCConfig) *AGC {
+	return &AGC{cfg: cfg.WithDefaults()}
+}
+
+// Config returns the AGC's effective configuration (post-defaults
+// backfill).
+func (a *AGC) Config() AGCConfig { return a.cfg }
+
+// Envelope returns the current smoothed peak envelope. Useful for
+// tests + introspection; production callers don't normally read
+// it.
+func (a *AGC) Envelope() float64 { return a.env }
+
+// Reset clears the envelope so the next Apply call seeds from the
+// frame's peak again. Used on stream re-sync (e.g., a frame-loss
+// event from the upstream protocol decoder).
+func (a *AGC) Reset() { a.env = 0 }
+
+// Apply tracks the per-frame peak with fast-attack / slow-release
+// smoothing and writes pcm scaled to the config's TargetPeak into
+// out. Frames whose peak falls below cfg.NoiseFloor leave the
+// envelope unchanged so a tail fade-out into silence doesn't drag
+// the envelope up artificially.
+//
+// First-frame seed: when a.env == 0 (fresh AGC, post-Reset), the
+// envelope is initialised directly to peak rather than via the
+// attack coefficient. Without this seed the first frame would
+// emerge ~2.5× over-gained (envelope = Attack · peak ⇒ gain =
+// TargetPeak / (Attack · peak) ⇒ output peak = (1/Attack) ·
+// TargetPeak ⇒ int16 saturation at the default Attack = 0.4).
+//
+// Frozen mode (freezeEnvelope = true): apply the existing
+// envelope's gain without updating it. Callers use this on silence
+// frames so a brief silence doesn't shift the envelope based on
+// the small §6.4 OA tail content; bad-frame replays use it so the
+// per-frame attenuation is audible (signals signal degradation).
+//
+// MinGain / MaxGain prevent the envelope from sending silence to
+// full scale or compressing extreme transients to inaudible levels.
+// After the gain multiply, samples beyond int16 range are
+// hard-clipped at ±32767.
+func (a *AGC) Apply(pcm []float64, out []int16, freezeEnvelope bool) {
+	cfg := a.cfg
+	if !freezeEnvelope {
+		var peak float64
+		for _, v := range pcm {
+			if abs := math.Abs(v); abs > peak {
+				peak = abs
+			}
+		}
+		if a.env == 0 && peak > cfg.NoiseFloor {
+			// First-frame seed: skip attack smoothing so the first
+			// frame lands at exactly TargetPeak instead of 1/Attack× over.
+			a.env = peak
+		} else if peak > cfg.NoiseFloor {
+			coef := cfg.Attack
+			if peak < a.env {
+				coef = cfg.Release
+			}
+			a.env += (peak - a.env) * coef
+		}
+	}
+	envelope := a.env
+	if envelope < cfg.NoiseFloor {
+		envelope = cfg.NoiseFloor
+	}
+	gain := cfg.TargetPeak / envelope
+	if gain < cfg.MinGain {
+		gain = cfg.MinGain
+	} else if gain > cfg.MaxGain {
+		gain = cfg.MaxGain
+	}
+	for i, v := range pcm {
+		s := v * gain
+		if s > 32767 {
+			s = 32767
+		} else if s < -32768 {
+			s = -32768
+		}
+		out[i] = int16(s)
+	}
+}

--- a/internal/voice/mbe/amps.go
+++ b/internal/voice/mbe/amps.go
@@ -1,4 +1,4 @@
-package imbe
+package mbe
 
 import "math"
 

--- a/internal/voice/mbe/amps_test.go
+++ b/internal/voice/mbe/amps_test.go
@@ -1,4 +1,4 @@
-package imbe
+package mbe
 
 import (
 	"math"
@@ -243,7 +243,7 @@ func TestSpectralCosineSumZeroL(t *testing.T) {
 // pipeline shape the synthesizer will use one frame at a time.
 func TestEndToEndPathFromTl(t *testing.T) {
 	var s SynthState
-	p := Params{Header: Header{W0: math.Pi / 30, L: 4, K: 2}}
+	p := Params{Header: Header{W0: math.Pi / 30, L: 4}}
 	for l := 1; l <= p.L; l++ {
 		p.Tl[l] = math.Log2(float64(l + 1))
 	}

--- a/internal/voice/mbe/doc.go
+++ b/internal/voice/mbe/doc.go
@@ -1,0 +1,35 @@
+// Package mbe is the shared Multi-Band Excitation synthesis core
+// used by GopherTrunk's IMBE 4400 (P25 Phase 1) and AMBE+2 2400
+// (P25 Phase 2 / DMR / NXDN) decoders. The two vocoders differ in
+// their bit-level parameter unpacking (different bit budgets,
+// quantization tables, and codebook structures), but they both
+// drive the same MBE-family synthesis pipeline:
+//
+//   - cross-frame log2(Ml) prediction recovering harmonic
+//     log-amplitudes from per-frame Tl residuals (PredictLog2Ml,
+//     UpdateLog2Ml — TIA-102.BABA §6.1);
+//   - log2(Ml) → linear Ml exponentiation + spectral moments
+//     (AmplitudesFromLog2Ml, FrameEnergy, SpectralCosineSum —
+//     §6.2 entry path);
+//   - per-harmonic spectral-amplitude enhancement
+//     (EnhanceAmplitudes — §6.2);
+//   - voiced harmonic generator with cross-frame phase + amplitude
+//     continuity (SynthVoiced, UpdateVoicedState — §6.3);
+//   - unvoiced FFT excitation with §6.4 overlap-add synthesis
+//     window (SynthUnvoicedOverlapAdd, ShapeUnvoicedSpectrum —
+//     §6.4);
+//   - per-frame fast-attack / slow-release peak AGC (AGC,
+//     AGCConfig).
+//
+// Both decoders construct an mbe.Params from their bit-level unpack
+// (Header { W0, L, Silent } + Vl[1..L] + Tl[1..L]) and feed it
+// through the shared pipeline. Vocoder-specific intermediates
+// (IMBE's K voicing-decision count + Gm PRBA blocks + Cik DCT
+// coefficients; AMBE+2's two-stage VQ codebook indices) live on
+// the per-decoder Params types.
+//
+// Patent + licensing context lives in docs/vocoders.md. The IMBE
+// patents are expired; AMBE+2 carries active patents in some
+// jurisdictions. Re-implementing the algorithm in Go does not
+// change the patent posture.
+package mbe

--- a/internal/voice/mbe/enhance.go
+++ b/internal/voice/mbe/enhance.go
@@ -1,4 +1,4 @@
-package imbe
+package mbe
 
 import "math"
 

--- a/internal/voice/mbe/enhance_test.go
+++ b/internal/voice/mbe/enhance_test.go
@@ -1,4 +1,4 @@
-package imbe
+package mbe
 
 import (
 	"math"
@@ -40,7 +40,7 @@ func TestEnhanceAmplitudesZeroLNoOp(t *testing.T) {
 // = 0 (every M[l] = 0) is left alone — there's nothing to enhance
 // or rescale.
 func TestEnhanceAmplitudesAllZeroNoOp(t *testing.T) {
-	p := Params{Header: Header{W0: math.Pi / 30, L: 10, K: 4}}
+	p := Params{Header: Header{W0: math.Pi / 30, L: 10}}
 	var M [57]float64
 	want := M
 	EnhanceAmplitudes(p, &M)
@@ -56,7 +56,7 @@ func TestEnhanceAmplitudesAllZeroNoOp(t *testing.T) {
 // preservation contract that makes the §6.2 enhancement safe to
 // drop into the synthesis path.
 func TestEnhanceAmplitudesEnergyPreserved(t *testing.T) {
-	p := Params{Header: Header{W0: math.Pi / 30, L: 12, K: 5}}
+	p := Params{Header: Header{W0: math.Pi / 30, L: 12}}
 	var M [57]float64
 	// Skewed input: amplitudes vary by 10x across harmonics.
 	M[1] = 0.5
@@ -89,7 +89,7 @@ func TestEnhanceAmplitudesEnergyPreserved(t *testing.T) {
 // input doesn't degenerate into zeros + that enhancement reshapes
 // rather than destroys.
 func TestEnhanceAmplitudesUniformBoundedAndNonzero(t *testing.T) {
-	p := Params{Header: Header{W0: math.Pi / 30, L: 16, K: 6}}
+	p := Params{Header: Header{W0: math.Pi / 30, L: 16}}
 	var M [57]float64
 	for l := 1; l <= p.L; l++ {
 		M[l] = 1.0
@@ -117,7 +117,7 @@ func TestEnhanceAmplitudesUniformBoundedAndNonzero(t *testing.T) {
 // ratio between two low-band harmonics is preserved exactly.
 func TestEnhanceAmplitudesLowBandUntouchedBeforeRescale(t *testing.T) {
 	// L = 16 → low band is l ≤ 2 (since 8·2 = 16 ≤ 16, but 8·3 = 24 > 16).
-	p := Params{Header: Header{W0: math.Pi / 30, L: 16, K: 6}}
+	p := Params{Header: Header{W0: math.Pi / 30, L: 16}}
 	var M [57]float64
 	for l := 1; l <= p.L; l++ {
 		M[l] = 1.0
@@ -143,7 +143,7 @@ func TestEnhanceAmplitudesLowBandUntouchedBeforeRescale(t *testing.T) {
 // for any non-degenerate frame. Pins that the §6.2 step doesn't
 // accidentally silence harmonics.
 func TestEnhanceAmplitudesPreservesMidbandHarmonicCount(t *testing.T) {
-	p := Params{Header: Header{W0: math.Pi / 22, L: 22, K: 8}}
+	p := Params{Header: Header{W0: math.Pi / 22, L: 22}}
 	var M [57]float64
 	// Steeply skewed spectrum to exercise the clamp boundary.
 	for l := 1; l <= p.L; l++ {
@@ -166,7 +166,7 @@ func TestEnhanceWMinMaxBound(t *testing.T) {
 	// A near-pure-tone spectrum (most energy on one harmonic) makes
 	// R_M1² ≈ R_M0², which sends den → 0 and would blow up xi if
 	// unclamped.
-	p := Params{Header: Header{W0: math.Pi / 30, L: 12, K: 5}}
+	p := Params{Header: Header{W0: math.Pi / 30, L: 12}}
 	var M [57]float64
 	M[1] = 10.0
 	for l := 2; l <= p.L; l++ {
@@ -198,7 +198,7 @@ func TestEnhanceWMinMaxBound(t *testing.T) {
 // = 2.4× compared to the global rescale).
 func TestEnhanceAmplitudesAtOrPastClampHigh(t *testing.T) {
 	for _, L := range []int{10, 20, 30, 40, 56} {
-		p := Params{Header: Header{W0: math.Pi / float64(L+5), L: L, K: 4}}
+		p := Params{Header: Header{W0: math.Pi / float64(L+5), L: L}}
 		var M [57]float64
 		for l := 1; l <= L; l++ {
 			M[l] = 1.0 + 0.5*math.Sin(float64(l)) // varied
@@ -232,35 +232,6 @@ func TestEnhanceAmplitudesAtOrPastClampHigh(t *testing.T) {
 	}
 }
 
-// TestDecodeOutputChangesWithEnhancement: a deterministic Decode
-// run with the §6.2 enhancement enabled should produce *different*
-// PCM output than the synthesizer would have without it. Pins
-// "enhancement is wired into the audio path" rather than being a
-// silent no-op. We can't toggle enhancement off easily without a
-// test fixture, so instead verify: a frame that the enhancement
-// modifies M for produces audio whose RMS is sane (not zero, not
-// saturated).
-func TestDecodeOutputChangesWithEnhancement(t *testing.T) {
-	d := New()
-	frame := make([]byte, FrameBytes) // valid b_0 = 0 frame
-	out, err := d.Decode(frame)
-	if err != nil {
-		t.Fatalf("Decode: %v", err)
-	}
-	var sumSq float64
-	for _, s := range out {
-		v := float64(s)
-		sumSq += v * v
-	}
-	rms := math.Sqrt(sumSq / float64(len(out)))
-	if rms == 0 {
-		t.Fatal("decoded output is fully silent; enhancement may have zeroed M")
-	}
-	if rms > 32000 {
-		t.Errorf("rms = %v, want < 32000 (sanity envelope)", rms)
-	}
-}
-
 // TestEnhanceClosedFormSmallCase verifies the per-harmonic weight
 // formula on a hand-derived input where every step can be checked
 // analytically. L = 4 is below 8·1 (= 8), so all 4 harmonics are
@@ -282,7 +253,7 @@ func TestDecodeOutputChangesWithEnhancement(t *testing.T) {
 // Verify pre-rescale ratios (rescale is a global multiplier so
 // M[a]·W[b] / (M[b]·W[a]) is preserved).
 func TestEnhanceClosedFormSmallCase(t *testing.T) {
-	p := Params{Header: Header{W0: math.Pi / 2, L: 4, K: 2}}
+	p := Params{Header: Header{W0: math.Pi / 2, L: 4}}
 	var M [57]float64
 	M[1] = 1.0
 	M[2] = 2.0

--- a/internal/voice/mbe/frame.go
+++ b/internal/voice/mbe/frame.go
@@ -1,0 +1,22 @@
+package mbe
+
+// Frame parameters shared across MBE-family vocoders. Every IMBE
+// 4400 / AMBE+2 2400 frame carries 20 ms of audio at 8 kHz mono;
+// the synthesizer produces 160 int16 PCM samples per call.
+const (
+	// SamplesPerFrame is the PCM count one synthesis call produces.
+	// Fixed at 8 kHz × 20 ms = 160 samples for both IMBE and AMBE+2.
+	SamplesPerFrame = 160
+
+	// PCMSampleRate is the recorder's expected output rate.
+	PCMSampleRate = 8000
+
+	// FrameDurationMs documents the 20 ms cadence.
+	FrameDurationMs = 20
+
+	// MaxL is the upper bound on the harmonic count L for both
+	// IMBE (9..56) and AMBE+2. Slice indices use the 1-based
+	// convention from TIA-102.BABA — index 0 is unused. Storage
+	// arrays are sized [MaxL+1] so [1..MaxL] is addressable.
+	MaxL = 56
+)

--- a/internal/voice/mbe/params.go
+++ b/internal/voice/mbe/params.go
@@ -1,0 +1,29 @@
+package mbe
+
+// Header is the MBE-family frame header — fundamental frequency,
+// harmonic count, and silence indicator. Both IMBE and AMBE+2
+// produce these from their respective bit-level unpacks. Vocoder-
+// specific extensions (e.g., IMBE's K voicing-decision count) live
+// on the per-decoder Header types.
+type Header struct {
+	W0     float64 // fundamental frequency in radians/sample
+	L      int     // number of harmonics (IMBE 9..56; AMBE+2 similar)
+	Silent bool    // true when the frame is an explicit silence indicator
+}
+
+// Params is the parameter set the synthesis primitives consume:
+// header fields plus voicing decisions Vl[1..L] and the
+// pre-prediction spectral log-amplitude residuals Tl[1..L]. Slices
+// are 1-indexed per TIA-102.BABA — index 0 is unused.
+//
+// Both IMBE and AMBE+2 decoders construct an mbe.Params from their
+// bit-level unpack and feed it through PredictLog2Ml →
+// AmplitudesFromLog2Ml → EnhanceAmplitudes → SynthVoiced →
+// SynthUnvoicedOverlapAdd. Tl is the residual *before* the
+// inter-frame log-amplitude prediction (eq. 75-77); the prediction
+// reads previous-frame state from SynthState.
+type Params struct {
+	Header
+	Vl [MaxL + 1]int     // Vl[1..L] voicing decisions (0=unvoiced, 1=voiced)
+	Tl [MaxL + 1]float64 // Tl[1..L] spectral log-amplitude residuals
+}

--- a/internal/voice/mbe/synth.go
+++ b/internal/voice/mbe/synth.go
@@ -1,4 +1,4 @@
-package imbe
+package mbe
 
 // IMBE 4400 speech synthesis — TIA-102.BABA §6.1 cross-frame
 // log-amplitude recovery.

--- a/internal/voice/mbe/synth_test.go
+++ b/internal/voice/mbe/synth_test.go
@@ -1,4 +1,4 @@
-package imbe
+package mbe
 
 import (
 	"math"
@@ -17,7 +17,7 @@ func almostEqual(a, b float64) bool {
 // Tl values pass through unchanged.
 func TestPredictLog2MlFirstFrameIsTl(t *testing.T) {
 	var s SynthState
-	p := Params{Header: Header{W0: math.Pi / 30, L: 20, K: 8}}
+	p := Params{Header: Header{W0: math.Pi / 30, L: 20}}
 	for l := 1; l <= p.L; l++ {
 		p.Tl[l] = float64(l) * 0.1
 	}
@@ -42,7 +42,7 @@ func TestPredictLog2MlConstantPrevCancels(t *testing.T) {
 	for l := 1; l <= s.PrevL; l++ {
 		s.PrevLog2Ml[l] = c
 	}
-	p := Params{Header: Header{W0: math.Pi / 30, L: 20, K: 8}}
+	p := Params{Header: Header{W0: math.Pi / 30, L: 20}}
 	for l := 1; l <= p.L; l++ {
 		p.Tl[l] = float64(l) - 10.5 // arbitrary signed values
 	}
@@ -67,7 +67,7 @@ func TestPredictLog2MlSamePitchExactInterp(t *testing.T) {
 	for l := 1; l <= s.PrevL; l++ {
 		s.PrevLog2Ml[l] = prev[l]
 	}
-	p := Params{Header: Header{W0: math.Pi / 30, L: 4, K: 2}}
+	p := Params{Header: Header{W0: math.Pi / 30, L: 4}}
 	// Tl all zero so dst directly reflects prediction - mean(prediction).
 	var dst [57]float64
 	PredictLog2Ml(&s, p, &dst)
@@ -92,7 +92,7 @@ func TestPredictLog2MlInterpolationFraction(t *testing.T) {
 	s.PrevLog2Ml[3] = 6.0
 	s.PrevLog2Ml[4] = 8.0
 	// Curr ω₀ is half of prev → curr harmonic l sits at prev pos l/2.
-	p := Params{Header: Header{W0: math.Pi / 60, L: 6, K: 3}}
+	p := Params{Header: Header{W0: math.Pi / 60, L: 6}}
 	var dst [57]float64
 	PredictLog2Ml(&s, p, &dst)
 
@@ -127,7 +127,7 @@ func TestPredictLog2MlClampsBeyondPrevL(t *testing.T) {
 	s.PrevLog2Ml[2] = 2.0
 	s.PrevLog2Ml[3] = 3.0
 	// Half pitch → curr L bigger; positions for high l exceed PrevL.
-	p := Params{Header: Header{W0: math.Pi / 20, L: 10, K: 4}}
+	p := Params{Header: Header{W0: math.Pi / 20, L: 10}}
 	var dst [57]float64
 	PredictLog2Ml(&s, p, &dst)
 
@@ -174,7 +174,7 @@ func TestUpdateLog2MlRollsState(t *testing.T) {
 	for l := 1; l <= 30; l++ {
 		s.PrevLog2Ml[l] = 99
 	}
-	p := Params{Header: Header{W0: 0.42, L: 5, K: 2}}
+	p := Params{Header: Header{W0: 0.42, L: 5}}
 	src := [57]float64{}
 	src[1] = 1
 	src[2] = 2
@@ -226,7 +226,7 @@ func TestPredictLog2MlTwoFrameSequence(t *testing.T) {
 	var s SynthState
 
 	// Frame 1: fresh state. dst1 = Tl1 (no prediction).
-	p1 := Params{Header: Header{W0: math.Pi / 30, L: 4, K: 2}}
+	p1 := Params{Header: Header{W0: math.Pi / 30, L: 4}}
 	for l := 1; l <= p1.L; l++ {
 		p1.Tl[l] = float64(l)
 	}
@@ -241,7 +241,7 @@ func TestPredictLog2MlTwoFrameSequence(t *testing.T) {
 
 	// Frame 2: same pitch + L; prev = {1,2,3,4}. With Tl2 = 0,
 	// dst2[l] = 0.65*l - mean(0.65*{1,2,3,4}) = 0.65*l - 0.65*2.5.
-	p2 := Params{Header: Header{W0: math.Pi / 30, L: 4, K: 2}}
+	p2 := Params{Header: Header{W0: math.Pi / 30, L: 4}}
 	var dst2 [57]float64
 	PredictLog2Ml(&s, p2, &dst2)
 	predMean := PredictionGain * (1.0 + 2.0 + 3.0 + 4.0) / 4.0
@@ -262,7 +262,7 @@ func TestPredictLog2MlMeanCenteredOutput(t *testing.T) {
 	for l := 1; l <= s.PrevL; l++ {
 		s.PrevLog2Ml[l] = float64(l) * 1.7
 	}
-	p := Params{Header: Header{W0: math.Pi / 30, L: 6, K: 3}}
+	p := Params{Header: Header{W0: math.Pi / 30, L: 6}}
 	// Mean-centered Tl: sums to zero.
 	tlVals := []float64{-3, -1, 0, 0, 1, 3}
 	for l := 1; l <= p.L; l++ {

--- a/internal/voice/mbe/synth_unvoiced.go
+++ b/internal/voice/mbe/synth_unvoiced.go
@@ -1,4 +1,4 @@
-package imbe
+package mbe
 
 import (
 	"math"

--- a/internal/voice/mbe/synth_unvoiced_test.go
+++ b/internal/voice/mbe/synth_unvoiced_test.go
@@ -1,4 +1,4 @@
-package imbe
+package mbe
 
 import (
 	"math"
@@ -48,7 +48,7 @@ func TestShapeUnvoicedSpectrumWrongLengthNoOp(t *testing.T) {
 	for k := range spec {
 		spec[k] = complex(1, 1)
 	}
-	p := Params{Header: Header{W0: math.Pi / 30, L: 10, K: 4}}
+	p := Params{Header: Header{W0: math.Pi / 30, L: 10}}
 	var M [57]float64
 	ShapeUnvoicedSpectrum(spec, p, &M)
 	for k := range spec {
@@ -68,7 +68,7 @@ func TestShapeUnvoicedSpectrumAllVoicedZerosEverything(t *testing.T) {
 	for k := range spec {
 		spec[k] = complex(float64(k), float64(k+1))
 	}
-	p := Params{Header: Header{W0: math.Pi / 30, L: 10, K: 4}}
+	p := Params{Header: Header{W0: math.Pi / 30, L: 10}}
 	for l := 1; l <= 10; l++ {
 		p.Vl[l] = 1
 	}
@@ -94,7 +94,7 @@ func TestShapeUnvoicedSpectrumBinMapping(t *testing.T) {
 		spec[k] = complex(1, 0) // sentinel
 	}
 	L := 20
-	p := Params{Header: Header{W0: w0, L: L, K: 8}}
+	p := Params{Header: Header{W0: w0, L: L}}
 	var M [57]float64
 	for l := 1; l <= L; l++ {
 		M[l] = 1.0 // identity scale
@@ -134,7 +134,7 @@ func TestShapeUnvoicedSpectrumScaling(t *testing.T) {
 	for k := range spec {
 		spec[k] = complex(1, 0)
 	}
-	p := Params{Header: Header{W0: w0, L: 4, K: 2}}
+	p := Params{Header: Header{W0: w0, L: 4}}
 	p.Vl[1] = 0
 	p.Vl[2] = 1 // voiced
 	p.Vl[3] = 0
@@ -188,7 +188,7 @@ func TestSynthUnvoicedFromNoiseSilentNoOp(t *testing.T) {
 // or a too-short dst returns without writing. Lets callers
 // fail-fast on shape bugs without a panic.
 func TestSynthUnvoicedFromNoiseWrongSizes(t *testing.T) {
-	p := Params{Header: Header{W0: math.Pi / 30, L: 10, K: 4}}
+	p := Params{Header: Header{W0: math.Pi / 30, L: 10}}
 	var M [57]float64
 	M[1] = 1.0
 	p.Vl[1] = 0
@@ -223,7 +223,7 @@ func TestSynthUnvoicedFromNoiseWrongSizes(t *testing.T) {
 // regardless of noise — IFFT(zero) = zero — so dst stays at its
 // caller-set sentinel.
 func TestSynthUnvoicedFromNoiseAllVoicedSilentOutput(t *testing.T) {
-	p := Params{Header: Header{W0: math.Pi / 30, L: 10, K: 4}}
+	p := Params{Header: Header{W0: math.Pi / 30, L: 10}}
 	for l := 1; l <= 10; l++ {
 		p.Vl[l] = 1
 	}
@@ -246,7 +246,7 @@ func TestSynthUnvoicedFromNoiseAllVoicedSilentOutput(t *testing.T) {
 // zero spectrum; shaping zero is zero; IFFT(0) = 0; dst stays at
 // the caller-set sentinel.
 func TestSynthUnvoicedFromNoiseZeroNoiseOutputZero(t *testing.T) {
-	p := Params{Header: Header{W0: math.Pi / 30, L: 10, K: 4}}
+	p := Params{Header: Header{W0: math.Pi / 30, L: 10}}
 	var M [57]float64
 	for l := 1; l <= 10; l++ {
 		M[l] = 1.0
@@ -269,7 +269,7 @@ func TestSynthUnvoicedFromNoiseZeroNoiseOutputZero(t *testing.T) {
 // identical output. Pins reproducibility (no internal nondeterminism
 // like a global rand source).
 func TestSynthUnvoicedFromNoiseDeterministic(t *testing.T) {
-	p := Params{Header: Header{W0: math.Pi / 30, L: 10, K: 4}}
+	p := Params{Header: Header{W0: math.Pi / 30, L: 10}}
 	var M [57]float64
 	for l := 1; l <= 10; l++ {
 		M[l] = 1.0
@@ -291,7 +291,7 @@ func TestSynthUnvoicedFromNoiseDeterministic(t *testing.T) {
 // rather than overwrites so it can be summed with the voiced step's
 // output into the same buffer.
 func TestSynthUnvoicedFromNoiseAddsToDst(t *testing.T) {
-	p := Params{Header: Header{W0: math.Pi / 30, L: 10, K: 4}}
+	p := Params{Header: Header{W0: math.Pi / 30, L: 10}}
 	var M [57]float64
 	for l := 1; l <= 10; l++ {
 		M[l] = 1.0
@@ -330,7 +330,7 @@ func TestSynthUnvoicedFromNoiseRealOutput(t *testing.T) {
 	// directly, so we verify via deterministic-output stability:
 	// the answer doesn't drift across runs because the imag side
 	// stays well below epsilon.
-	p := Params{Header: Header{W0: math.Pi / 25, L: 12, K: 5}}
+	p := Params{Header: Header{W0: math.Pi / 25, L: 12}}
 	var M [57]float64
 	for l := 1; l <= 12; l++ {
 		M[l] = float64(l) * 0.1
@@ -393,7 +393,7 @@ func TestSynthesisWindowHannShape(t *testing.T) {
 // scaled by the window.
 func TestSynthUnvoicedOverlapAddFreshStream(t *testing.T) {
 	var s SynthState
-	p := Params{Header: Header{W0: math.Pi / 30, L: 10, K: 4}}
+	p := Params{Header: Header{W0: math.Pi / 30, L: 10}}
 	var M [57]float64
 	for l := 1; l <= 10; l++ {
 		M[l] = 1.0 // all unvoiced (Vl=0 default), unit amplitudes
@@ -423,7 +423,7 @@ func TestSynthUnvoicedOverlapAddFreshStream(t *testing.T) {
 // will pick up.
 func TestSynthUnvoicedOverlapAddStashesTail(t *testing.T) {
 	var s SynthState
-	p := Params{Header: Header{W0: math.Pi / 30, L: 10, K: 4}}
+	p := Params{Header: Header{W0: math.Pi / 30, L: 10}}
 	var M [57]float64
 	for l := 1; l <= 10; l++ {
 		M[l] = 1.0
@@ -462,7 +462,7 @@ func TestSynthUnvoicedOverlapAddSecondFrameUsesPrevTail(t *testing.T) {
 		s.PrevUnvoicedTail[n] = float64(n + 1) // distinctive sentinel
 	}
 	expectedTail := s.PrevUnvoicedTail
-	p := Params{Header: Header{W0: math.Pi / 30, L: 10, K: 4}}
+	p := Params{Header: Header{W0: math.Pi / 30, L: 10}}
 	var M [57]float64
 	for l := 1; l <= 10; l++ {
 		M[l] = 1.0
@@ -533,7 +533,7 @@ func TestSynthUnvoicedOverlapAddShortDstNoOp(t *testing.T) {
 	for n := 0; n < UnvoicedTailSamples; n++ {
 		s.PrevUnvoicedTail[n] = 5
 	}
-	p := Params{Header: Header{W0: math.Pi / 30, L: 10, K: 4}}
+	p := Params{Header: Header{W0: math.Pi / 30, L: 10}}
 	var M [57]float64
 	short := make([]float64, SamplesPerFrame-1)
 	SynthUnvoicedOverlapAdd(&s, p, &M, seededNoise(44, UnvoicedFFTSize), short)

--- a/internal/voice/mbe/synth_voiced.go
+++ b/internal/voice/mbe/synth_voiced.go
@@ -1,4 +1,4 @@
-package imbe
+package mbe
 
 import "math"
 

--- a/internal/voice/mbe/synth_voiced_test.go
+++ b/internal/voice/mbe/synth_voiced_test.go
@@ -1,4 +1,4 @@
-package imbe
+package mbe
 
 import (
 	"math"
@@ -12,7 +12,7 @@ const synthEpsilon = 1e-9
 // Pins the "no spurious carrier on the first frame" invariant.
 func TestSynthVoicedFreshStreamUnvoiced(t *testing.T) {
 	var s SynthState
-	p := Params{Header: Header{W0: math.Pi / 30, L: 10, K: 4}}
+	p := Params{Header: Header{W0: math.Pi / 30, L: 10}}
 	// All Vl[l] = 0 (default). M is irrelevant when unvoiced.
 	var M [57]float64
 	dst := make([]float64, SamplesPerFrame)
@@ -31,7 +31,7 @@ func TestSynthVoicedFreshStreamUnvoiced(t *testing.T) {
 func TestSynthVoicedFreshStreamSingleHarmonic(t *testing.T) {
 	var s SynthState
 	w0 := math.Pi / 30
-	p := Params{Header: Header{W0: w0, L: 1, K: 1}}
+	p := Params{Header: Header{W0: w0, L: 1}}
 	p.Vl[1] = 1
 	var M [57]float64
 	M[1] = 1.0
@@ -62,7 +62,7 @@ func TestSynthVoicedSteadyState(t *testing.T) {
 		PrevMl:    [57]float64{},
 	}
 	s.PrevMl[1] = 1.0
-	p := Params{Header: Header{W0: w0, L: 1, K: 1}}
+	p := Params{Header: Header{W0: w0, L: 1}}
 	p.Vl[1] = 1
 	var M [57]float64
 	M[1] = 1.0
@@ -85,7 +85,7 @@ func TestSynthVoicedFadeOut(t *testing.T) {
 	w0 := math.Pi / 30
 	s := SynthState{PrevW0: w0, PrevL: 1}
 	s.PrevMl[1] = 1.0
-	p := Params{Header: Header{W0: w0, L: 1, K: 1}}
+	p := Params{Header: Header{W0: w0, L: 1}}
 	// Vl[1] = 0 — curr unvoiced.
 	var M [57]float64
 	dst := make([]float64, SamplesPerFrame)
@@ -109,7 +109,7 @@ func TestSynthVoicedFadeOut(t *testing.T) {
 func TestSynthVoicedPhaseContinuity(t *testing.T) {
 	var s SynthState
 	w0 := math.Pi / 17 // not a clean divisor of 2π so phase wrap is non-trivial
-	p := Params{Header: Header{W0: w0, L: 1, K: 1}}
+	p := Params{Header: Header{W0: w0, L: 1}}
 	p.Vl[1] = 1
 	var M [57]float64
 	M[1] = 1.0
@@ -149,7 +149,7 @@ func TestSynthVoicedMultiHarmonicSum(t *testing.T) {
 	s := SynthState{PrevW0: w0, PrevL: 2}
 	s.PrevMl[1] = 1.0
 	s.PrevMl[2] = 0.5
-	p := Params{Header: Header{W0: w0, L: 2, K: 1}}
+	p := Params{Header: Header{W0: w0, L: 2}}
 	p.Vl[1] = 1
 	p.Vl[2] = 1
 	var M [57]float64
@@ -175,7 +175,7 @@ func TestSynthVoicedQuadraticPhase(t *testing.T) {
 	wCurr := math.Pi / 15 // doubled
 	s := SynthState{PrevW0: wPrev, PrevL: 1}
 	s.PrevMl[1] = 1.0
-	p := Params{Header: Header{W0: wCurr, L: 1, K: 1}}
+	p := Params{Header: Header{W0: wCurr, L: 1}}
 	p.Vl[1] = 1
 	var M [57]float64
 	M[1] = 1.0
@@ -200,7 +200,7 @@ func TestSynthVoicedQuadraticPhase(t *testing.T) {
 func TestSynthVoicedAddsToExistingDst(t *testing.T) {
 	var s SynthState
 	w0 := math.Pi / 30
-	p := Params{Header: Header{W0: w0, L: 1, K: 1}}
+	p := Params{Header: Header{W0: w0, L: 1}}
 	p.Vl[1] = 1
 	var M [57]float64
 	M[1] = 1.0
@@ -246,7 +246,7 @@ func TestSynthVoicedSilentFrameLeavesDstUntouched(t *testing.T) {
 // callers fail-fast in unit tests without crashing the daemon.
 func TestSynthVoicedShortDstNoPanic(t *testing.T) {
 	var s SynthState
-	p := Params{Header: Header{W0: math.Pi / 30, L: 1, K: 1}}
+	p := Params{Header: Header{W0: math.Pi / 30, L: 1}}
 	p.Vl[1] = 1
 	var M [57]float64
 	M[1] = 1.0
@@ -269,7 +269,7 @@ func TestUpdateVoicedStateAdvancesPhase(t *testing.T) {
 	wPrev := 0.1
 	wCurr := 0.2
 	s := SynthState{PrevW0: wPrev, PrevL: 2, PrevPhase: [57]float64{0, 1.0, 0.5}}
-	p := Params{Header: Header{W0: wCurr, L: 2, K: 1}}
+	p := Params{Header: Header{W0: wCurr, L: 2}}
 	p.Vl[1] = 1
 	p.Vl[2] = 1
 	var M [57]float64
@@ -300,7 +300,7 @@ func TestUpdateVoicedStateZeroesUnvoiced(t *testing.T) {
 	s.PrevMl[1] = 9
 	s.PrevMl[2] = 9
 	s.PrevMl[3] = 9
-	p := Params{Header: Header{W0: 0.1, L: 3, K: 1}}
+	p := Params{Header: Header{W0: 0.1, L: 3}}
 	p.Vl[1] = 1 // voiced
 	p.Vl[2] = 0 // unvoiced
 	p.Vl[3] = 1 // voiced
@@ -358,7 +358,7 @@ func TestResetClearsVoicedFields(t *testing.T) {
 // short-circuit optimization (skips the inner loop entirely).
 func TestSynthVoicedZeroAmpSkipsHarmonic(t *testing.T) {
 	var s SynthState
-	p := Params{Header: Header{W0: math.Pi / 30, L: 3, K: 1}}
+	p := Params{Header: Header{W0: math.Pi / 30, L: 3}}
 	p.Vl[1] = 1
 	p.Vl[2] = 0
 	p.Vl[3] = 1


### PR DESCRIPTION
## Summary

PR-B of the [mbelib replacement plan](https://claude.ai/code/session_01SvuTSKyeTrSX9V352L9GVH). The synthesis half of the IMBE pipeline is algorithm-shared with AMBE+2 (same MBE family); this PR moves the algorithm-agnostic primitives out of `internal/voice/imbe` into a new `internal/voice/mbe` package so the in-progress AMBE+2 decoder can consume the same code.

- **Moved** (`git mv` preserves history): `synth.go`, `synth_voiced.go`, `synth_unvoiced.go`, `amps.go`, `enhance.go` + matching `*_test.go` files.
- **Added** in `internal/voice/mbe/`: `doc.go`, `frame.go` (`SamplesPerFrame`/`MaxL` constants), `params.go` (`Header { W0, L, Silent }` + `Params { Header, Vl, Tl }`), `agc.go` (`AGCConfig`, `DefaultAGCConfig`, `AGC` type with `Apply`/`Envelope`/`Config`/`Reset`, `MaxBadFrames=6`, `BadFrameAttenuation=0.7`).
- **Inside `internal/voice/imbe`**: `decoder.go` consumes `mbe.SynthState` / `mbe.AGC` / `mbe.*` synthesis functions; `lastGoodParams` cache holds `mbe.Params`. `params.go` gains `MBE()` conversion methods on `Header` and `Params` so the IMBE unpacker's full output projects to the shared shape on each `Decode` call. `decoder_test.go` qualifies moved symbols and uses `*mbe.AGC` accessors. `enhance_integration_test.go` keeps the one Decoder-level test that calls `imbe.New()` in the imbe package.

## Test plan

- [x] `go vet ./internal/voice/...` clean
- [x] `go test -race -count=1 ./internal/voice/...` all pass
- [x] Test count preserved: 67 imbe + 74 mbe = 141 (matches pre-PR-B total)
- [x] `grep` for external callers of moved symbols shows none outside `internal/voice/{imbe,mbe}` — `voice.Vocoder` interface insulates downstream packages
- [ ] Manual: confirm a captured P25 Phase 1 IQ replay still produces the same PCM through the daemon (regression check on the synthesis port)

https://claude.ai/code/session_01SvuTSKyeTrSX9V352L9GVH

---
_Generated by [Claude Code](https://claude.ai/code/session_01SvuTSKyeTrSX9V352L9GVH)_