### PR TITLE
internal/voice/ambe2: pure-Go AMBE+2 skeleton + interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,11 +55,15 @@ SQLite. The honest gaps:
   intelligible audio end-to-end ([patents have expired](docs/vocoders.md)),
   with operator-tunable AGC + §6.4 overlap-add windowing + §6.2
   spectral enhancement + frame-repeat on bad-frame indicator
-  shipped — only mbelib-bit-equivalent absolute-level calibration
-  remains as a follow-up. AMBE+2 stays behind the `mbelib` build
-  tag; operators who hold (or don't need) the patent licence run
-  `make mbelib-install && make build TAGS=mbelib` to get both
-  IMBE + AMBE+2 via the C reference implementation.
+  shipped — absolute-level calibration against a known-good
+  reference decoder is the only remaining polish item. Pure-Go
+  AMBE+2 is scaffolded under `internal/voice/ambe2/` and registers
+  the `ambe2` name on every default build; the skeleton emits
+  silence pending follow-up PRs that plug in 49-bit parameter
+  unpacking and wire the shared `internal/voice/mbe/` synthesis
+  pipeline. The AMBE+2 algorithm carries active patents in some
+  jurisdictions; re-implementing it in pure Go does not change
+  that posture — see [docs/vocoders.md](docs/vocoders.md).
 - **Higher-fidelity audio**: the FM chain now has opt-in 75/50µs
   de-emphasis, a Kaiser-windowed audio LPF, audio AGC, and a
   polyphase L/M audio resampler — the full polish stack ships.
@@ -160,9 +164,31 @@ to its own package and lands independently.
   cross-correlation against the reference WAV under
   `internal/voice/imbe/testdata/`); enhancement filter tuning if
   real-world frames show mid-band envelope drift.
+- **Pure-Go AMBE+2 vocoder.** A native-Go AMBE+2 2400 bps decoder
+  for P25 Phase 2, DMR (Tier II / III), and NXDN voice frames.
+  AMBE+2 is the same MBE-family algorithm as IMBE — same 8 kHz /
+  20 ms / 160 PCM cadence, same harmonic + unvoiced FFT synthesis
+  shape — so the synthesis half reuses `internal/voice/mbe/`
+  directly. Only the front half (bit-level unpack from 49
+  information bits into `mbe.Params`) is AMBE+2-specific. The
+  AMBE+2 algorithm carries active patents in some jurisdictions;
+  re-implementing it in Go does not change that posture
+  ([docs/vocoders.md](docs/vocoders.md)). Status: skeleton +
+  Vocoder interface registered as `ambe2` on the default build
+  (`internal/voice/ambe2/decoder.go`), `Decode` emits silence
+  pending parameter unpack + synthesis wiring. **Roadmap**:
+  parameter unpack (b₀ → ω₀ + L + voicing-pattern table → Vl,
+  gain VQ → gain block, two-stage spectral VQ → DCT residuals
+  → Tl) — codebook tables transcribed from szechyjs/mbelib's
+  `ambe3600x2400.c` / `ambe3600x2450_const.h` under ISC; synthesis
+  wire-up via the shared `mbe.PredictLog2Ml` → `mbe.SynthVoiced`
+  → `mbe.SynthUnvoicedOverlapAdd` → `mbe.AGC.Apply` pipeline +
+  the shared `mbe.MaxBadFrames` / `mbe.BadFrameAttenuation`
+  frame-repeat path; AGC calibration against a DSD-FME-decoded
+  DMR reference recording.
 - **DVSI USB-3000 / AMBE-3003 hardware backend.** A `Vocoder`
   factory that opens a connected DVSI USB chip. Same plug-in shape
-  as `internal/voice/mbelib`; the daemon picks the factory by name
+  as `internal/voice/ambe2`; the daemon picks the factory by name
   from `voice.DefaultRegistry`.
 - **YSF Trellis decode + grant emission.** Sync, frame layout, and
   the post-FEC FICH bit-level parser are in; what's left is the

--- a/cmd/gophertrunk/main.go
+++ b/cmd/gophertrunk/main.go
@@ -19,12 +19,13 @@ import (
 	// This is the sole IMBE backend in default builds.
 	_ "github.com/MattCheramie/GopherTrunk/internal/voice/imbe"
 
-	// Blank import: under default builds this pulls in the stub
-	// (no init effect); under `make build TAGS=mbelib` it pulls in
-	// the CGO wrapper that registers the `imbe` and `ambe2`
-	// vocoders against voice.DefaultRegistry. Either way, the
-	// daemon's import set picks the right path automatically.
-	_ "github.com/MattCheramie/GopherTrunk/internal/voice/mbelib"
+	// Blank import: pulls in the pure-Go AMBE+2 decoder so the
+	// daemon registers the "ambe2" vocoder name (P25 Phase 2, DMR,
+	// NXDN voice) regardless of build tags. The skeleton currently
+	// emits silence; PR-D plugs in 49-bit parameter unpacking and
+	// PR-E wires the shared mbe synthesis pipeline. See
+	// docs/vocoders.md for the AMBE+2 patent posture.
+	_ "github.com/MattCheramie/GopherTrunk/internal/voice/ambe2"
 )
 
 func main() {

--- a/internal/voice/ambe2/decoder.go
+++ b/internal/voice/ambe2/decoder.go
@@ -1,0 +1,122 @@
+package ambe2
+
+import (
+	"fmt"
+	"math/rand"
+
+	"github.com/MattCheramie/GopherTrunk/internal/voice"
+	"github.com/MattCheramie/GopherTrunk/internal/voice/mbe"
+)
+
+// Frame parameters per AMBE+2 2400 bps. Every frame carries 49
+// information bits over 20 ms of audio at 8 kHz mono.
+const (
+	// InfoBits is the per-frame information-bit count after the
+	// upstream protocol layer (P25 P2 / DMR / NXDN) has applied
+	// its FEC and produced the bare AMBE+2 information bits.
+	InfoBits = 49
+
+	// FrameBytes is the byte count callers pass to Decode: 49
+	// bits round up to 7 bytes with 7 unused trailing bits.
+	// Matches what the libmbe wrapper accepted so upstream callers
+	// don't need to repack.
+	FrameBytes = 7
+
+	// VocoderName is the registry key the daemon resolves at
+	// startup. Same name libmbe registered under so existing
+	// configs work without change.
+	VocoderName = "ambe2"
+)
+
+// Decoder is the pure-Go AMBE+2 2400 decoder. Mirrors the imbe
+// Decoder shape: one mbe.SynthState (cross-frame log2(Ml)
+// prediction + voiced phase + amp memory + §6.4 OA tail), one
+// math/rand source for the unvoiced excitation noise, one
+// *mbe.AGC, and a one-frame cache of the last-good params for
+// the frame-repeat path — all per-call so concurrent calls on
+// different decoders don't share state.
+//
+// Decode currently emits silence; PR-D plugs in parameter
+// unpacking and PR-E wires the shared mbe synthesis pipeline.
+// The recorder + call pipeline can connect to this decoder
+// today and start receiving real audio for free as the later
+// pieces land.
+type Decoder struct {
+	state mbe.SynthState
+	rng   *rand.Rand
+	agc   *mbe.AGC
+}
+
+// New returns a fresh Decoder. The unvoiced-excitation noise
+// source is seeded from a fixed default so two decoders
+// constructed via New() produce byte-identical output for the
+// same frame stream (useful for tests + reproducibility).
+// Production callers wanting genuinely-random noise across runs
+// should use NewWithSeed with a time-derived seed.
+func New() *Decoder {
+	return NewWithSeed(0)
+}
+
+// NewWithSeed constructs a Decoder with an explicit seed for the
+// internal noise source. Lets tests pin output across runs and
+// lets production callers spread noise across decoders so two
+// parallel calls don't share the same noise stream. AGC parameters
+// use mbe.DefaultAGCConfig.
+func NewWithSeed(seed int64) *Decoder {
+	return NewWithConfig(seed, mbe.DefaultAGCConfig())
+}
+
+// NewWithConfig constructs a Decoder with an explicit noise seed +
+// AGC configuration. Zero-value fields in cfg fall back to
+// mbe.DefaultAGCConfig values, so callers can override only the
+// parameters they care about. Mirrors imbe.NewWithConfig.
+func NewWithConfig(seed int64, cfg mbe.AGCConfig) *Decoder {
+	return &Decoder{
+		rng: rand.New(rand.NewSource(seed)),
+		agc: mbe.NewAGC(cfg),
+	}
+}
+
+// Name returns the registry key. Matches VocoderName.
+func (d *Decoder) Name() string { return VocoderName }
+
+// FrameSize returns the per-frame input byte count (7 bytes / 49
+// information bits with 7 trailing padding bits).
+func (d *Decoder) FrameSize() int { return FrameBytes }
+
+// Decode reads 49 information bits from frame and returns 160
+// int16 PCM samples at 8 kHz. Currently emits silence: the
+// parameter unpack (PR-D) and synthesis wire-up (PR-E) land in
+// follow-up PRs. Validates the frame length so callers wiring up
+// today get a clear error on a malformed frame and the contract
+// stays stable when synthesis lands.
+func (d *Decoder) Decode(frame []byte) ([]int16, error) {
+	if len(frame) != FrameBytes {
+		return nil, fmt.Errorf("ambe2: frame must be %d bytes (49 bits + 7 padding), got %d", FrameBytes, len(frame))
+	}
+	return make([]int16, mbe.SamplesPerFrame), nil
+}
+
+// Reset clears all per-call synthesis state — the cross-frame
+// log-amplitude prediction history, the voiced harmonic phase +
+// amplitude memory, the §6.4 overlap-add tail, and the AGC
+// envelope. Callers invoke it on stream re-sync (e.g., a
+// frame-loss event from the upstream P25 P2 / DMR / NXDN
+// decoder) so the next frame starts from a clean baseline.
+func (d *Decoder) Reset() {
+	d.state.Reset()
+	d.agc.Reset()
+}
+
+// Close releases any resources held by the decoder. The pure-Go
+// implementation holds none, so this is always a no-op.
+func (d *Decoder) Close() error { return nil }
+
+// Compile-time check that Decoder satisfies voice.Vocoder.
+var _ voice.Vocoder = (*Decoder)(nil)
+
+func init() {
+	voice.DefaultRegistry.Register(VocoderName, func() (voice.Vocoder, error) {
+		return New(), nil
+	})
+}

--- a/internal/voice/ambe2/decoder_test.go
+++ b/internal/voice/ambe2/decoder_test.go
@@ -1,0 +1,123 @@
+package ambe2
+
+import (
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/voice"
+	"github.com/MattCheramie/GopherTrunk/internal/voice/mbe"
+)
+
+func TestDecoderRegistered(t *testing.T) {
+	v, err := voice.DefaultRegistry.New(VocoderName)
+	if err != nil {
+		t.Fatalf("DefaultRegistry.New(%q): %v", VocoderName, err)
+	}
+	defer v.Close()
+	if v.Name() != VocoderName {
+		t.Errorf("Name() = %q, want %q", v.Name(), VocoderName)
+	}
+}
+
+func TestDecoderName(t *testing.T) {
+	d := New()
+	if d.Name() != "ambe2" {
+		t.Errorf("Name() = %q, want %q", d.Name(), "ambe2")
+	}
+}
+
+func TestDecoderFrameSize(t *testing.T) {
+	d := New()
+	if d.FrameSize() != FrameBytes {
+		t.Errorf("FrameSize() = %d, want %d", d.FrameSize(), FrameBytes)
+	}
+}
+
+// TestDecodeReturnsSilenceSkeleton: the skeleton decoder emits
+// silence per frame until PR-D plugs in parameter unpacking and
+// PR-E wires synthesis. Output length must be exactly
+// mbe.SamplesPerFrame (160) so the recorder + call pipeline can
+// wire to this decoder today and start receiving real audio for
+// free as the later pieces land.
+func TestDecodeReturnsSilenceSkeleton(t *testing.T) {
+	d := New()
+	frame := make([]byte, FrameBytes)
+	out, err := d.Decode(frame)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if len(out) != mbe.SamplesPerFrame {
+		t.Errorf("len(out) = %d, want %d", len(out), mbe.SamplesPerFrame)
+	}
+	for i, s := range out {
+		if s != 0 {
+			t.Fatalf("sample[%d] = %d, want 0 (skeleton emits silence)", i, s)
+		}
+	}
+}
+
+func TestDecodeRejectsShortFrame(t *testing.T) {
+	d := New()
+	if _, err := d.Decode(make([]byte, FrameBytes-1)); err == nil {
+		t.Error("expected error for short frame")
+	}
+	if _, err := d.Decode(make([]byte, FrameBytes+1)); err == nil {
+		t.Error("expected error for long frame")
+	}
+}
+
+func TestResetAndCloseAreSafe(t *testing.T) {
+	d := New()
+	d.Reset()
+	if err := d.Close(); err != nil {
+		t.Errorf("Close() = %v, want nil", err)
+	}
+	// Re-using after Close should still work — pure-Go decoder
+	// holds no resources, and the Vocoder contract doesn't forbid
+	// it for stateless implementations.
+	if _, err := d.Decode(make([]byte, FrameBytes)); err != nil {
+		t.Errorf("Decode after Close: %v", err)
+	}
+}
+
+func TestRegistryReturnsFreshInstancePerCall(t *testing.T) {
+	a, err := voice.DefaultRegistry.New(VocoderName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer a.Close()
+	b, err := voice.DefaultRegistry.New(VocoderName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer b.Close()
+	if a == b {
+		t.Error("expected each Registry.New call to return a fresh instance")
+	}
+}
+
+func TestNameAppearsInRegistryListing(t *testing.T) {
+	names := voice.DefaultRegistry.Names()
+	for _, n := range names {
+		if n == VocoderName {
+			return
+		}
+	}
+	t.Errorf("registry names %v missing %q", names, VocoderName)
+}
+
+// TestNewWithConfigUsesCustomAGC pins that operator-supplied AGC
+// tuning reaches the underlying *mbe.AGC instance. Mirrors the
+// imbe-side test so AMBE+2 grows the same customization surface
+// as it gains real synthesis.
+func TestNewWithConfigUsesCustomAGC(t *testing.T) {
+	custom := mbe.AGCConfig{TargetPeak: 16000}
+	d := NewWithConfig(0, custom)
+	def := mbe.DefaultAGCConfig()
+	got := d.agc.Config()
+	if got.TargetPeak != 16000 {
+		t.Errorf("TargetPeak = %v, want 16000", got.TargetPeak)
+	}
+	if got.Attack != def.Attack {
+		t.Errorf("Attack = %v, want default %v", got.Attack, def.Attack)
+	}
+}

--- a/internal/voice/ambe2/doc.go
+++ b/internal/voice/ambe2/doc.go
@@ -1,0 +1,57 @@
+// Package ambe2 is the in-progress pure-Go AMBE+2 2400 bps voice
+// decoder used by P25 Phase 2, DMR (Tier II / III), and NXDN voice
+// frames. The intent is to remove the CGO dependency on libmbe so
+// every default build has a working AMBE+2 path without a C
+// toolchain or system shared library.
+//
+// AMBE+2 is the same Multi-Band Excitation algorithm family as
+// IMBE — both produce 8 kHz / 20 ms / 160 int16 PCM by summing
+// voiced harmonics + an FFT-shaped unvoiced excitation. The
+// algorithm-shared synthesis primitives live in
+// internal/voice/mbe (PredictLog2Ml, SynthVoiced,
+// SynthUnvoicedOverlapAdd, EnhanceAmplitudes, AGC, …); this
+// package layers the AMBE+2-specific front half on top:
+// bit-level parameter unpack from 49 information bits into the
+// shared mbe.Params shape.
+//
+// Patent + licensing context lives in docs/vocoders.md. The
+// AMBE+2 algorithm itself is patent-encumbered in some
+// jurisdictions; re-implementing it in pure Go does not change
+// that posture. Operators in licence-restrictive jurisdictions
+// should evaluate before deploying.
+//
+// Roadmap (each item lands as its own self-contained PR so review
+// stays tractable):
+//
+//  1. Skeleton + Vocoder interface integration. ← THIS PR.
+//     Decoder satisfies voice.Vocoder, registers as "ambe2" in
+//     voice.DefaultRegistry unconditionally on the default build,
+//     and emits silence per frame so the full call pipeline can
+//     wire to it now and start receiving audio for free as the
+//     later pieces land. FrameSize is 7 bytes (49 information
+//     bits + 7 padding) matching the libmbe wrapper's contract.
+//
+//  2. Parameter unpacking — 49 bits → mbe.Params. The largest
+//     single PR of the AMBE+2 work. Reads b₀ → ω₀ + L from a
+//     scattered bit position layout; voicing-pattern table
+//     lookup → Vl[1..L]; gain-vector index → log-amplitude offset
+//     feeding the gain block; two-stage spectral VQ index → DCT
+//     residual coefficients per band; DCT-II → Tl[1..L].
+//     Reference: szechyjs/mbelib's mbe_decodeAmbe2400Parms in
+//     ambe3600x2400.c, with constants from
+//     ambe3600x2450_const.h (ISC-licensed code; algorithm
+//     patents are a separate concern — see docs/vocoders.md).
+//
+//  3. Synthesis wire-up + bad-frame handling + calibration.
+//     Decode() runs the shared mbe pipeline:
+//     UnpackParams → mbe.PredictLog2Ml → mbe.AmplitudesFromLog2Ml
+//     → mbe.EnhanceAmplitudes → mbe.SynthVoiced
+//     → mbe.SynthUnvoicedOverlapAdd → mbe.SynthState.Update…
+//     → mbe.AGC.Apply. AMBE+2-specific silence-frame indicator +
+//     frame-repeat-on-bad-frame using shared mbe.MaxBadFrames /
+//     BadFrameAttenuation. Calibration loop against a DSD-FME or
+//     OP25 reference WAV at testdata/. Tune the per-frame gain
+//     constant if AGC shows systematic level offset — AGC
+//     defaults are tuned for IMBE and AMBE+2 quantization may
+//     produce different per-frame energy.
+package ambe2


### PR DESCRIPTION
## Summary

PR-C of the [mbelib replacement plan](https://claude.ai/code/session_01SvuTSKyeTrSX9V352L9GVH). Scaffolds the pure-Go AMBE+2 2400 bps decoder for P25 Phase 2, DMR (Tier II / III), and NXDN voice frames. Decoder satisfies `voice.Vocoder`, registers as `ambe2` in `voice.DefaultRegistry` on the **default build**, and emits silence per frame so the call pipeline can wire to it today and start receiving real audio for free as PR-D / PR-E land.

- **Added** `internal/voice/ambe2/` with `doc.go` (package + roadmap), `decoder.go` (`Decoder` struct, `New()` / `NewWithSeed(seed)` / `NewWithConfig(seed, mbe.AGCConfig)`, `init()` registers `"ambe2"`), and `decoder_test.go` (registry registration, Name/FrameSize/Reset contracts, silence-output skeleton check, fresh-instance-per-call, AGC config plumbing).
- **Wired** in `cmd/gophertrunk/main.go`: the mbelib blank import is replaced with an ambe2 blank import. The mbelib package is no longer referenced from main; PR-F deletes it physically.
- **Frame contract**: `FrameSize = 7` bytes (49 information bits + 7 padding) matching the libmbe wrapper's contract so upstream callers don't need to repack frames as the AMBE+2 path migrates.
- **Decoder shape**: holds `mbe.SynthState` + `math/rand` source + `*mbe.AGC` today — ready for the synthesis pipeline that lands in PR-E.

After this PR the daemon registers `imbe`, `ambe2`, and `null` factories on every default build; AMBE+2 calls record silent audio until follow-ups plug in 49-bit parameter unpacking (PR-D) and the shared `mbe.*` synthesis pipeline (PR-E).

The AMBE+2 algorithm carries active patents in some jurisdictions; re-implementing it in pure Go does not change that posture — see `docs/vocoders.md`.

## Test plan

- [x] `go vet ./internal/voice/...` clean
- [x] `go test -race -count=1 ./internal/voice/...` all pass (incl. new ambe2 package)
- [x] Smoke: ambe2 Decoder emits silence (160 zero int16 samples) for any well-formed 7-byte frame; rejects short/long frames
- [ ] After merge: confirm `make build` still produces a daemon binary with `imbe`, `ambe2`, `null` factories registered

https://claude.ai/code/session_01SvuTSKyeTrSX9V352L9GVH

---
_Generated by [Claude Code](https://claude.ai/code/session_01SvuTSKyeTrSX9V352L9GVH)_