### PR TITLE
internal/voice/ambe2: synthesis wire-up + cross-frame gamma

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,16 +58,19 @@ SQLite. The honest gaps:
   shipped — absolute-level calibration against a known-good
   reference decoder is the only remaining polish item. Pure-Go
   AMBE+2 lives under `internal/voice/ambe2/` and registers the
-  `ambe2` name on every default build; the 49-bit parameter
-  unpack is shipped (b₀..b₈ extraction, codebook lookups against
-  the auto-generated `AmbePlus*` tables, 8-point inverse DCT for
-  PRBA, four per-band inverse DCTs for Tl). Synthesis wire-up
-  via the shared `internal/voice/mbe/` pipeline is the remaining
-  piece — Decode still emits silence until the cross-frame
-  `gamma` bookkeeping lands. The AMBE+2 algorithm carries active
-  patents in some jurisdictions; re-implementing it in pure Go
-  does not change that posture — see
-  [docs/vocoders.md](docs/vocoders.md).
+  `ambe2` name on every default build; `Decode` now produces real
+  audio end-to-end via the shared `internal/voice/mbe/` synthesis
+  pipeline (49-bit parameter unpack → cross-frame gamma fold →
+  `mbe.PredictLog2Ml` → linear M → unvoiced `Unvc` scaling →
+  `mbe.EnhanceAmplitudes` → voiced + unvoiced OA synthesis →
+  state roll-forward → per-frame AGC). Remaining polish:
+  calibration against a DSD-FME-decoded DMR reference WAV (AGC
+  defaults are tuned for IMBE and AMBE+2 quantisation may need a
+  per-frame gain tweak); proper tone-frame synthesis (single +
+  dual sinewave) replacing the current silence-out path. The
+  AMBE+2 algorithm carries active patents in some jurisdictions;
+  re-implementing it in pure Go does not change that posture —
+  see [docs/vocoders.md](docs/vocoders.md).
 - **Higher-fidelity audio**: the FM chain now has opt-in 75/50µs
   de-emphasis, a Kaiser-windowed audio LPF, audio AGC, and a
   polyphase L/M audio resampler — the full polish stack ships.
@@ -174,30 +177,39 @@ to its own package and lands independently.
   20 ms / 160 PCM cadence, same harmonic + unvoiced FFT synthesis
   shape — so the synthesis half reuses `internal/voice/mbe/`
   directly. Only the front half (bit-level unpack from 49
-  information bits into `mbe.Params`) is AMBE+2-specific. The
-  AMBE+2 algorithm carries active patents in some jurisdictions;
-  re-implementing it in Go does not change that posture
+  information bits into `mbe.Params` plus the AMBE+2-specific
+  cross-frame gamma) is AMBE+2-specific. The AMBE+2 algorithm
+  carries active patents in some jurisdictions; re-implementing
+  it in Go does not change that posture
   ([docs/vocoders.md](docs/vocoders.md)). Status: skeleton +
   Vocoder interface registered as `ambe2` on the default build
-  (`internal/voice/ambe2/decoder.go`); the 49-bit parameter
-  unpack is in (`internal/voice/ambe2/params.go`) — bit
-  extraction for b₀..b₈, tone-frame detection (b₀ ∈ {0x7E,0x7F}),
-  fundamental + L from `AmbePlusLtable[b₀]`, voicing decisions
-  via `AmbePlusVuv[b₁][jl]`, gain delta from `AmbePlusDg[b₂]`,
+  (`internal/voice/ambe2/decoder.go`); 49-bit parameter unpack
+  is in (`internal/voice/ambe2/params.go`) — bit extraction for
+  b₀..b₈, tone-frame detection (b₀ ∈ {0x7E,0x7F}), fundamental
+  + L from `AmbePlusLtable[b₀]`, voicing decisions via
+  `AmbePlusVuv[b₁][jl]`, gain delta from `AmbePlusDg[b₂]`,
   PRBA24/PRBA58 → Gm → 8-point inverse DCT → Ri → first two
   Cik coefficients per band, HOC tables b₅..b₈ → remaining Cik
   rows, four per-band inverse DCTs producing the Tl[1..L]
   spectral residuals. Codebook tables are auto-generated from
   szechyjs/mbelib's `ambe3600x2400_const.h` under ISC
   (`internal/voice/ambe2/tables.go`,
-  `scripts/gen-ambe2-tables.sh`). Remaining: synthesis wire-up
-  via the shared `mbe.PredictLog2Ml` → `mbe.SynthVoiced` →
-  `mbe.SynthUnvoicedOverlapAdd` → `mbe.AGC.Apply` pipeline
-  threaded through a per-decoder cross-frame state that carries
-  the AMBE+2-specific `gamma` (overall gain) alongside the
-  shared `mbe.SynthState`; AGC calibration against a
-  DSD-FME-decoded DMR reference recording; full bad-frame
-  + tone-synthesis paths.
+  `scripts/gen-ambe2-tables.sh`). Synthesis is wired through
+  the shared `mbe` pipeline: `Decode()` resolves the absolute
+  gamma (gamma_curr = ΔG + 0.5·gamma_prev cached on the
+  Decoder), folds gamma + DC removal + 0.5·log2(L) into Tl so
+  the shared `mbe.PredictLog2Ml` produces AMBE+2-spec
+  log-amplitudes, applies the AMBE+2 unvoiced `Unvc` scaling
+  (0.2046/√ω₀) between log2Ml→Ml and the §6.2 enhancement,
+  then runs `mbe.SynthVoiced` + `mbe.SynthUnvoicedOverlapAdd`
+  + state roll-forward + per-frame AGC into int16 PCM. Tone
+  frames route through the §6.4 OA fade-out + state reset;
+  bad-frame replay uses the shared `mbe.MaxBadFrames` /
+  `mbe.BadFrameAttenuation`. **Remaining polish**: calibration
+  against a DSD-FME-decoded DMR reference recording (testdata
+  follow-up); proper tone-frame synthesis (single + dual
+  sinewave from preserved B1/B2) replacing the current silence
+  path.
 - **DVSI USB-3000 / AMBE-3003 hardware backend.** A `Vocoder`
   factory that opens a connected DVSI USB chip. Same plug-in shape
   as `internal/voice/ambe2`; the daemon picks the factory by name

--- a/internal/voice/ambe2/decoder.go
+++ b/internal/voice/ambe2/decoder.go
@@ -2,6 +2,7 @@ package ambe2
 
 import (
 	"fmt"
+	"math"
 	"math/rand"
 
 	"github.com/MattCheramie/GopherTrunk/internal/voice"
@@ -16,10 +17,10 @@ const (
 	// its FEC and produced the bare AMBE+2 information bits.
 	InfoBits = 49
 
-	// FrameBytes is the byte count callers pass to Decode: 49
-	// bits round up to 7 bytes with 7 unused trailing bits.
-	// Matches what the libmbe wrapper accepted so upstream callers
-	// don't need to repack.
+	// FrameBytes is the byte count callers pass to Decode: 49 bits
+	// round up to 7 bytes with 7 unused trailing bits. Matches what
+	// the libmbe wrapper accepted so upstream callers don't need to
+	// repack.
 	FrameBytes = 7
 
 	// VocoderName is the registry key the daemon resolves at
@@ -36,15 +37,33 @@ const (
 // the frame-repeat path — all per-call so concurrent calls on
 // different decoders don't share state.
 //
-// Decode currently emits silence; PR-D plugs in parameter
-// unpacking and PR-E wires the shared mbe synthesis pipeline.
-// The recorder + call pipeline can connect to this decoder
-// today and start receiving real audio for free as the later
-// pieces land.
+// AMBE+2 has one cross-frame quantity that IMBE lacks: the
+// overall gamma (gain). Each frame's absolute gamma is
+//
+//	gamma_curr = DeltaGamma_curr + 0.5 * gamma_prev
+//
+// where DeltaGamma is the per-frame value decoded from
+// AmbePlusDg[b₂]. prevGamma below caches the previous frame's
+// resolved gamma so this frame's UnpackParams output can be
+// folded into the shared mbe.Params shape (see foldGammaIntoTl).
 type Decoder struct {
 	state mbe.SynthState
 	rng   *rand.Rand
 	agc   *mbe.AGC
+
+	// AMBE+2-specific cross-frame state. The absolute gamma each
+	// frame is DeltaGamma + 0.5*prevGamma; this caches the
+	// resolved gamma so the next frame's fold has it available.
+	prevGamma float64
+
+	// One-frame cache for the bad-frame replay path. Holds the
+	// post-fold mbe.Params (Tl values already centered + gamma
+	// folded in) so a replay can call mbe.PredictLog2Ml + the
+	// shared synthesis primitives without re-running the fold.
+	lastGoodParams mbe.Params
+	lastGoodLog2M  [mbe.MaxL + 1]float64
+	lastGoodM      [mbe.MaxL + 1]float64
+	badFrameCount  int
 }
 
 // New returns a fresh Decoder. The unvoiced-excitation noise
@@ -58,10 +77,7 @@ func New() *Decoder {
 }
 
 // NewWithSeed constructs a Decoder with an explicit seed for the
-// internal noise source. Lets tests pin output across runs and
-// lets production callers spread noise across decoders so two
-// parallel calls don't share the same noise stream. AGC parameters
-// use mbe.DefaultAGCConfig.
+// internal noise source. AGC parameters use mbe.DefaultAGCConfig.
 func NewWithSeed(seed int64) *Decoder {
 	return NewWithConfig(seed, mbe.DefaultAGCConfig())
 }
@@ -84,28 +100,212 @@ func (d *Decoder) Name() string { return VocoderName }
 // information bits with 7 trailing padding bits).
 func (d *Decoder) FrameSize() int { return FrameBytes }
 
-// Decode reads 49 information bits from frame and returns 160
-// int16 PCM samples at 8 kHz. Currently emits silence: the
-// parameter unpack (PR-D) and synthesis wire-up (PR-E) land in
-// follow-up PRs. Validates the frame length so callers wiring up
-// today get a clear error on a malformed frame and the contract
-// stays stable when synthesis lands.
+// Decode reads 49 information bits (post-FEC, MSB-first packed
+// into the first 49 bits of a 7-byte frame; trailing 7 bits
+// ignored) and returns 160 int16 PCM samples at 8 kHz.
+//
+// Frame disposition:
+//
+//   - good voice frame: full synthesis pipeline (UnpackParams →
+//     gamma fold → mbe.PredictLog2Ml → mbe.AmplitudesFromLog2Ml →
+//     unvoiced scaling → mbe.EnhanceAmplitudes → mbe.SynthVoiced
+//     + mbe.SynthUnvoicedOverlapAdd → state update → AGC). Caches
+//     params + log2M + M for the next bad frame's replay; resets
+//     badFrameCount.
+//   - tone frame (b₀ ∈ {0x7E, 0x7F}) or silence: emits the §6.4 OA
+//     tail fade-out into pcm[0..95]; resets SynthState +
+//     last-good cache + prevGamma + badFrameCount; AGC envelope
+//     preserved.
+//   - bad frame (UnpackParams error) with cached last-good frame
+//     and badFrameCount < mbe.MaxBadFrames: replays last-good
+//     params with M scaled by mbe.BadFrameAttenuation^badFrameCount;
+//     AGC freezes so the attenuation is audible.
+//   - bad frame with no cache, or after mbe.MaxBadFrames consecutive
+//     bad frames: emits silence; clears caches; AGC envelope
+//     preserved.
+//
+// Bad-frame replay is largely defensive — AmbePlusLtable guarantees
+// every voice b₀ resolves to a valid L ∈ [9, 56], so UnpackParams
+// only returns an error on a wrong-length input (which Decode
+// catches earlier). The structural path is retained to match the
+// imbe Decoder's shape and to give future protocol-layer FEC
+// signaling a place to land.
 func (d *Decoder) Decode(frame []byte) ([]int16, error) {
 	if len(frame) != FrameBytes {
 		return nil, fmt.Errorf("ambe2: frame must be %d bytes (49 bits + 7 padding), got %d", FrameBytes, len(frame))
 	}
-	return make([]int16, mbe.SamplesPerFrame), nil
+
+	info := unpackInfoBits(frame)
+	out := make([]int16, mbe.SamplesPerFrame)
+	pcm := make([]float64, mbe.SamplesPerFrame)
+
+	p, err := UnpackParams(info)
+
+	switch {
+	case err != nil && d.lastGoodParams.L > 0 && d.badFrameCount < mbe.MaxBadFrames:
+		// Frame repeat: replay the last-good params with progressive
+		// per-frame attenuation.
+		d.badFrameCount++
+		atten := math.Pow(mbe.BadFrameAttenuation, float64(d.badFrameCount))
+		repeatedM := d.lastGoodM
+		for l := 1; l <= d.lastGoodParams.L; l++ {
+			repeatedM[l] *= atten
+		}
+		d.synthFrame(d.lastGoodParams, &d.lastGoodLog2M, &repeatedM, pcm)
+		d.agc.Apply(pcm, out, true)
+		return out, nil
+
+	case err != nil:
+		// Bad frame with no cache or budget exhausted: emit silence
+		// + clear state.
+		d.state.Reset()
+		d.clearLastGood()
+		d.prevGamma = 0
+		d.agc.Apply(pcm, out, true)
+		return out, nil
+
+	case p.Tone || p.Silent:
+		// Tone-frame path: for now, emit the OA tail fade-out into
+		// pcm[0..95] and reset state. Proper tone synthesis (single +
+		// dual sinewave) is a follow-up; the tone-index extraction is
+		// already preserved on p.B1/p.B2 for that work. Silent
+		// frames (invalid tone index) hit the same path.
+		mbe.SynthUnvoicedOverlapAdd(&d.state, p.Params, nil, nil, pcm)
+		d.state.Reset()
+		d.clearLastGood()
+		d.prevGamma = 0
+		d.agc.Apply(pcm, out, true)
+		return out, nil
+	}
+
+	// Good voice frame.
+	d.badFrameCount = 0
+
+	// Combine the per-frame delta with prev-frame gamma to recover
+	// the absolute gain, then fold gamma + DC removal into Tl so
+	// the shared mbe.PredictLog2Ml produces AMBE+2-spec output
+	// without needing an AMBE+2-aware variant.
+	gamma := p.DeltaGamma + 0.5*d.prevGamma
+	folded := foldGammaIntoTl(p, gamma)
+
+	var log2M [mbe.MaxL + 1]float64
+	mbe.PredictLog2Ml(&d.state, folded, &log2M)
+
+	var M [mbe.MaxL + 1]float64
+	mbe.AmplitudesFromLog2Ml(&log2M, folded.L, &M)
+
+	// AMBE+2-specific unvoiced amplitude scaling: unvoiced harmonics
+	// are attenuated by Unvc = 0.2046/√w₀ before spectral
+	// enhancement + synthesis. mbelib applies this between the
+	// log2Ml→Ml conversion and the §6.2 enhancement, so we mirror
+	// that ordering.
+	for l := 1; l <= folded.L; l++ {
+		if folded.Vl[l] == 0 {
+			M[l] *= p.Unvc
+		}
+	}
+
+	mbe.EnhanceAmplitudes(folded, &M)
+
+	d.synthFrame(folded, &log2M, &M, pcm)
+
+	// Cache for the frame-repeat path on a future bad frame.
+	d.lastGoodParams = folded
+	d.lastGoodLog2M = log2M
+	d.lastGoodM = M
+	d.prevGamma = gamma
+
+	d.agc.Apply(pcm, out, false)
+	return out, nil
+}
+
+// synthFrame runs the §6.3 voiced + §6.4 unvoiced overlap-add legs
+// of the shared mbe synthesis and rolls SynthState forward. Used
+// by both the good-frame path and the bad-frame replay path so the
+// two share identical synthesis behaviour — only the M values
+// differ between the two.
+func (d *Decoder) synthFrame(p mbe.Params, log2M *[mbe.MaxL + 1]float64, M *[mbe.MaxL + 1]float64, pcm []float64) {
+	mbe.SynthVoiced(&d.state, p, M, pcm)
+	noise := make([]float64, mbe.UnvoicedFFTSize)
+	for i := range noise {
+		noise[i] = d.rng.NormFloat64()
+	}
+	mbe.SynthUnvoicedOverlapAdd(&d.state, p, M, noise, pcm)
+	d.state.UpdateLog2Ml(p, log2M)
+	d.state.UpdateVoicedState(p, M)
+}
+
+// clearLastGood resets the frame-repeat cache + bad-frame counter.
+func (d *Decoder) clearLastGood() {
+	d.lastGoodParams = mbe.Params{}
+	d.lastGoodLog2M = [mbe.MaxL + 1]float64{}
+	d.lastGoodM = [mbe.MaxL + 1]float64{}
+	d.badFrameCount = 0
+}
+
+// unpackInfoBits expands the 7-byte (MSB-first) packed frame into a
+// 49-element 0/1 byte slice — the shape UnpackParams expects. The
+// trailing 7 bits of byte 6 are padding and ignored.
+func unpackInfoBits(frame []byte) []byte {
+	info := make([]byte, InfoBits)
+	for i := 0; i < InfoBits; i++ {
+		info[i] = (frame[i/8] >> (7 - uint(i)%8)) & 1
+	}
+	return info
+}
+
+// foldGammaIntoTl projects ambe2.Params into mbe.Params with the
+// AMBE+2-specific gamma folded into Tl. The shared mbe.PredictLog2Ml
+// expects the IMBE-style form
+//
+//	log2Ml[l] = γ·(prev_interp[l] − mean_prev_interp) + Tl[l]
+//
+// whereas AMBE+2's spec form is
+//
+//	log2Ml[l] = γ·(prev_interp[l] − mean_prev_interp)
+//	            + (Tl[l] − mean(Tl))
+//	            + (gamma − 0.5·log2(L))
+//
+// Folding Tl_folded[l] = Tl[l] − mean(Tl) + (gamma − 0.5·log2(L))
+// up front makes the shared core produce the right output without
+// an AMBE+2-aware variant.
+//
+// gamma is the absolute gain (DeltaGamma + 0.5·prev_gamma); the
+// caller (Decoder.Decode) resolves it from cross-frame state.
+//
+// Silence + zero-L frames are returned as-is (Tl untouched) so
+// callers don't need an extra guard.
+func foldGammaIntoTl(p Params, gamma float64) mbe.Params {
+	if p.L == 0 {
+		return p.Params
+	}
+	var meanTl float64
+	for l := 1; l <= p.L; l++ {
+		meanTl += p.Tl[l]
+	}
+	meanTl /= float64(p.L)
+
+	bigGamma := gamma - 0.5*math.Log2(float64(p.L))
+
+	folded := p.Params // value copy of the embedded mbe.Params
+	for l := 1; l <= p.L; l++ {
+		folded.Tl[l] = p.Tl[l] - meanTl + bigGamma
+	}
+	return folded
 }
 
 // Reset clears all per-call synthesis state — the cross-frame
 // log-amplitude prediction history, the voiced harmonic phase +
-// amplitude memory, the §6.4 overlap-add tail, and the AGC
-// envelope. Callers invoke it on stream re-sync (e.g., a
-// frame-loss event from the upstream P25 P2 / DMR / NXDN
-// decoder) so the next frame starts from a clean baseline.
+// amplitude memory, the §6.4 overlap-add tail, the AMBE+2 gamma
+// memory, the AGC envelope, and the frame-repeat cache + bad-frame
+// counter. Callers invoke it on stream re-sync (e.g., a frame-loss
+// event from the upstream P25 P2 / DMR / NXDN decoder) so the
+// next frame starts from a clean baseline.
 func (d *Decoder) Reset() {
 	d.state.Reset()
 	d.agc.Reset()
+	d.clearLastGood()
+	d.prevGamma = 0
 }
 
 // Close releases any resources held by the decoder. The pure-Go

--- a/internal/voice/ambe2/decoder_test.go
+++ b/internal/voice/ambe2/decoder_test.go
@@ -1,6 +1,7 @@
 package ambe2
 
 import (
+	"math"
 	"testing"
 
 	"github.com/MattCheramie/GopherTrunk/internal/voice"
@@ -32,15 +33,14 @@ func TestDecoderFrameSize(t *testing.T) {
 	}
 }
 
-// TestDecodeReturnsSilenceSkeleton: the skeleton decoder emits
-// silence per frame until PR-D plugs in parameter unpacking and
-// PR-E wires synthesis. Output length must be exactly
-// mbe.SamplesPerFrame (160) so the recorder + call pipeline can
-// wire to this decoder today and start receiving real audio for
-// free as the later pieces land.
-func TestDecodeReturnsSilenceSkeleton(t *testing.T) {
+// TestDecodeProducesAudioForValidFrame: an all-zero info-bit frame
+// decodes to b₀=0 (lowest valid fundamental, L=9, all Vl=0); the
+// shared mbe.SynthUnvoicedOverlapAdd produces noise in the 9
+// harmonic bands. Output must be non-zero. Pins the "synthesizer
+// is wired up" milestone.
+func TestDecodeProducesAudioForValidFrame(t *testing.T) {
 	d := New()
-	frame := make([]byte, FrameBytes)
+	frame := make([]byte, FrameBytes) // all zero ⇒ b₀=0 voice frame
 	out, err := d.Decode(frame)
 	if err != nil {
 		t.Fatalf("Decode: %v", err)
@@ -48,9 +48,62 @@ func TestDecodeReturnsSilenceSkeleton(t *testing.T) {
 	if len(out) != mbe.SamplesPerFrame {
 		t.Errorf("len(out) = %d, want %d", len(out), mbe.SamplesPerFrame)
 	}
+	var nonzero int
+	for _, s := range out {
+		if s != 0 {
+			nonzero++
+		}
+	}
+	if nonzero == 0 {
+		t.Fatal("all-zero output for a valid voice frame; expected synthesis to produce non-zero PCM")
+	}
+}
+
+// TestDecodeToneFrameReturnsSilenceNonOverlapRegion: a tone-frame
+// indicator (b₀ ∈ {0x7E, 0x7F}) currently routes through the
+// silence path — emit prev-frame OA tail into pcm[0..95] and clear
+// state. The non-overlap region pcm[96..159] must be exactly
+// silent (no new synthesis happens on a tone frame). After this
+// frame the SynthState fields are zero, so a second tone frame
+// produces fully-silent output.
+func TestDecodeToneFrameReturnsSilenceNonOverlapRegion(t *testing.T) {
+	d := New()
+	// Tone frame: info[0..5] = 1, info[48] = 0 ⇒ b₀ = 0x7E.
+	frame := make([]byte, FrameBytes)
+	frame[0] = 0xFC // bits 0..5 = 1
+	out, err := d.Decode(frame)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if len(out) != mbe.SamplesPerFrame {
+		t.Errorf("len(out) = %d, want %d", len(out), mbe.SamplesPerFrame)
+	}
+	// pcm[96..159] (the non-overlap region) must be silent on a
+	// tone frame — no new synthesis runs.
+	for i := mbe.SamplesPerFrame - 64; i < mbe.SamplesPerFrame; i++ {
+		if out[i] != 0 {
+			t.Errorf("sample[%d] = %d, want 0 (non-overlap region on tone frame)", i, out[i])
+		}
+	}
+}
+
+// TestDecodeToneAfterToneIsFullySilent: a second tone-frame after
+// a tone frame produces all-zero PCM. Pins that the silence path
+// clears the OA tail so a perpetual silence stream stays silent.
+func TestDecodeToneAfterToneIsFullySilent(t *testing.T) {
+	d := New()
+	frame := make([]byte, FrameBytes)
+	frame[0] = 0xFC // b₀ = 0x7E (tone)
+	if _, err := d.Decode(frame); err != nil {
+		t.Fatalf("first tone: %v", err)
+	}
+	out, err := d.Decode(frame)
+	if err != nil {
+		t.Fatalf("second tone: %v", err)
+	}
 	for i, s := range out {
 		if s != 0 {
-			t.Fatalf("sample[%d] = %d, want 0 (skeleton emits silence)", i, s)
+			t.Fatalf("sample[%d] = %d, want 0 (perpetual tone/silence)", i, s)
 		}
 	}
 }
@@ -119,5 +172,249 @@ func TestNewWithConfigUsesCustomAGC(t *testing.T) {
 	}
 	if got.Attack != def.Attack {
 		t.Errorf("Attack = %v, want default %v", got.Attack, def.Attack)
+	}
+}
+
+// agcPeak returns the absolute peak of an int16 slice. Used by AGC
+// tests to verify per-frame normalisation.
+func agcPeak(out []int16) int {
+	var peak int
+	for _, s := range out {
+		v := int(s)
+		if v < 0 {
+			v = -v
+		}
+		if v > peak {
+			peak = v
+		}
+	}
+	return peak
+}
+
+// TestDecodeDeterministicAcrossDecoders: two decoders constructed
+// via New() (default seed) must produce byte-identical PCM for the
+// same input frame stream. Pins the reproducibility contract that
+// makes audio diffs across PRs reviewable.
+func TestDecodeDeterministicAcrossDecoders(t *testing.T) {
+	a, b := New(), New()
+	frame := make([]byte, FrameBytes)
+	outA, err := a.Decode(frame)
+	if err != nil {
+		t.Fatalf("a.Decode: %v", err)
+	}
+	outB, err := b.Decode(frame)
+	if err != nil {
+		t.Fatalf("b.Decode: %v", err)
+	}
+	for i := range outA {
+		if outA[i] != outB[i] {
+			t.Fatalf("non-deterministic at i=%d: a=%d b=%d", i, outA[i], outB[i])
+		}
+	}
+}
+
+// TestNewWithSeedDifferentSeedsDifferentOutput: distinct seeds give
+// distinct unvoiced noise so decoded output for the same frame must
+// differ.
+func TestNewWithSeedDifferentSeedsDifferentOutput(t *testing.T) {
+	a := NewWithSeed(1)
+	b := NewWithSeed(2)
+	frame := make([]byte, FrameBytes)
+	outA, err := a.Decode(frame)
+	if err != nil {
+		t.Fatalf("a: %v", err)
+	}
+	outB, err := b.Decode(frame)
+	if err != nil {
+		t.Fatalf("b: %v", err)
+	}
+	for i := range outA {
+		if outA[i] != outB[i] {
+			return
+		}
+	}
+	t.Error("two distinct seeds produced byte-identical output; seeding is a no-op")
+}
+
+// TestDecodeRollsCrossFrameState: two consecutive decodes on the
+// same input frame must produce *different* PCM — frame 1 starts
+// from no prev state, frame 2's mbe.PredictLog2Ml sees frame 1's
+// state and the cross-frame gamma evolves. Pins that state-rolling
+// happens across both mbe.SynthState and ambe2's prevGamma.
+func TestDecodeRollsCrossFrameState(t *testing.T) {
+	d := New()
+	frame := make([]byte, FrameBytes)
+	out1, err := d.Decode(frame)
+	if err != nil {
+		t.Fatalf("frame1: %v", err)
+	}
+	out2, err := d.Decode(frame)
+	if err != nil {
+		t.Fatalf("frame2: %v", err)
+	}
+	for i := range out1 {
+		if out1[i] != out2[i] {
+			return
+		}
+	}
+	t.Error("two consecutive decodes produced identical output; cross-frame state isn't rolling")
+}
+
+// frameWithB2 returns a 7-byte voice frame whose b₂ is non-zero
+// (so DeltaGamma = AmbePlusDg[b₂] ≠ 0). Used by state-rolling
+// tests that need a frame which actually advances prevGamma.
+// info[43] (the LSB of b₂) packs into byte 5, bit position
+// 7 − (43%8) = 7 − 3 = 4. b₀ stays 0 (voice frame, lowest L).
+func frameWithB2() []byte {
+	frame := make([]byte, FrameBytes)
+	frame[5] |= 1 << 4 // info[43] = 1 ⇒ b₂ = 1
+	return frame
+}
+
+// TestResetClearsCrossFrameState: after Reset the decoder behaves
+// as if it had just been constructed — prevGamma is zero, the
+// mbe.SynthState fields are zero, the AGC envelope is zero, and
+// the frame-repeat cache is empty.
+func TestResetClearsCrossFrameState(t *testing.T) {
+	d := New()
+	if _, err := d.Decode(frameWithB2()); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if d.state.PrevW0 == 0 {
+		t.Fatal("prev frame didn't establish synth state; test setup invalid")
+	}
+	if d.prevGamma == 0 {
+		t.Fatal("prev frame didn't establish gamma; test setup invalid")
+	}
+	d.Reset()
+	if d.state.PrevW0 != 0 || d.state.PrevL != 0 {
+		t.Errorf("after Reset: PrevW0=%v PrevL=%d, want 0/0", d.state.PrevW0, d.state.PrevL)
+	}
+	if d.prevGamma != 0 {
+		t.Errorf("after Reset: prevGamma=%v, want 0", d.prevGamma)
+	}
+	if d.agc.Envelope() != 0 {
+		t.Errorf("after Reset: AGC envelope=%v, want 0", d.agc.Envelope())
+	}
+	if d.lastGoodParams.L != 0 {
+		t.Errorf("after Reset: lastGoodParams.L=%d, want 0", d.lastGoodParams.L)
+	}
+}
+
+// TestDecodeToneFrameClearsState: a tone frame resets the
+// SynthState + prevGamma + last-good cache so the next non-tone
+// frame starts from a clean baseline. Pins that the silence-path
+// state-clear actually runs.
+func TestDecodeToneFrameClearsState(t *testing.T) {
+	d := New()
+	// Seed with a good voice frame whose b₂ ≠ 0 so prevGamma is
+	// established (AmbePlusDg[0] = 0).
+	if _, err := d.Decode(frameWithB2()); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if d.prevGamma == 0 || d.state.PrevW0 == 0 {
+		t.Fatal("seed didn't establish state; test setup invalid")
+	}
+	// Tone frame (b₀ = 0x7E).
+	tone := make([]byte, FrameBytes)
+	tone[0] = 0xFC
+	if _, err := d.Decode(tone); err != nil {
+		t.Fatalf("tone: %v", err)
+	}
+	if d.prevGamma != 0 {
+		t.Errorf("after tone: prevGamma=%v, want 0", d.prevGamma)
+	}
+	if d.state.PrevW0 != 0 || d.state.PrevL != 0 {
+		t.Errorf("after tone: PrevW0=%v PrevL=%d, want 0/0",
+			d.state.PrevW0, d.state.PrevL)
+	}
+	if d.lastGoodParams.L != 0 {
+		t.Errorf("after tone: lastGoodParams.L=%d, want 0", d.lastGoodParams.L)
+	}
+}
+
+// TestAGCConvergesTowardTarget: feeding the same valid frame
+// repeatedly drives the AGC envelope toward the per-frame peak so
+// the converged output peak sits near AGCConfig.TargetPeak. Pins
+// the AGC is actually adapting on AMBE+2 (the synthesis primitives
+// are shared with IMBE but AMBE+2's per-frame amplitudes can be
+// systematically different — operator-tunable AGC is the safety
+// valve).
+func TestAGCConvergesTowardTarget(t *testing.T) {
+	d := New()
+	frame := make([]byte, FrameBytes)
+	var lastPeak int
+	for i := 0; i < 30; i++ {
+		out, err := d.Decode(frame)
+		if err != nil {
+			t.Fatalf("frame %d: %v", i, err)
+		}
+		lastPeak = agcPeak(out)
+	}
+	target := mbe.DefaultAGCConfig().TargetPeak
+	const tol = 0.5 // loose: noise variance + AMBE+2 quantization
+	lo := int(target * (1 - tol))
+	hi := int(target * (1 + tol))
+	if lastPeak < lo || lastPeak > hi {
+		t.Errorf("converged peak = %d, want in [%d, %d] (target=%v ±%.0f%%)",
+			lastPeak, lo, hi, target, tol*100)
+	}
+}
+
+// TestDecodeOutputIsBoundedAcrossFramePatterns: every PCM sample
+// must be a valid int16 across a range of frame patterns. Catches
+// gain regressions that send the synthesizer into NaN / Inf land
+// before the int16 cast, and AGC envelope blow-ups.
+func TestDecodeOutputIsBoundedAcrossFramePatterns(t *testing.T) {
+	d := New()
+	patterns := [][]byte{
+		make([]byte, FrameBytes),
+		{0x55, 0xAA, 0x55, 0xAA, 0x55, 0xAA, 0x55},
+		{0xAA, 0x55, 0xAA, 0x55, 0xAA, 0x55, 0xAA},
+		{0x00, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00},
+	}
+	for round := 0; round < 10; round++ {
+		for fi, frame := range patterns {
+			out, err := d.Decode(frame)
+			if err != nil {
+				t.Fatalf("Decode pattern %d round %d: %v", fi, round, err)
+			}
+			// int16 is by construction in [-32768, 32767]; this also
+			// catches NaN / Inf which would have failed earlier at the
+			// int16 cast.
+			_ = out
+			if math.IsNaN(d.agc.Envelope()) || math.IsInf(d.agc.Envelope(), 0) {
+				t.Fatalf("AGC envelope = %v after pattern %d round %d", d.agc.Envelope(), fi, round)
+			}
+			if math.IsNaN(d.prevGamma) || math.IsInf(d.prevGamma, 0) {
+				t.Fatalf("prevGamma = %v after pattern %d round %d", d.prevGamma, fi, round)
+			}
+		}
+	}
+}
+
+// TestPrevGammaCrossFrameAccumulation: gamma_curr = ΔG_curr +
+// 0.5·gamma_prev. Feed a frame with non-zero ΔG twice and verify
+// the second frame's resolved gamma matches the closed form.
+// Using b₂ = 1 (AmbePlusDg[1] ≈ 0.1182) means both frames carry
+// real gain and the 0.5· recursive term is exercised numerically.
+func TestPrevGammaCrossFrameAccumulation(t *testing.T) {
+	d := New()
+	frame := frameWithB2() // b₂ = 1 ⇒ ΔG = AmbePlusDg[1] ≠ 0
+	if _, err := d.Decode(frame); err != nil {
+		t.Fatalf("frame 1: %v", err)
+	}
+	gamma1 := d.prevGamma
+	wantGamma1 := AmbePlusDg[1] // first frame: prevGamma starts at 0
+	if math.Abs(gamma1-wantGamma1) > 1e-12 {
+		t.Errorf("frame 1 prevGamma = %v, want %v", gamma1, wantGamma1)
+	}
+	if _, err := d.Decode(frame); err != nil {
+		t.Fatalf("frame 2: %v", err)
+	}
+	gamma2 := d.prevGamma
+	wantGamma2 := AmbePlusDg[1] + 0.5*gamma1
+	if math.Abs(gamma2-wantGamma2) > 1e-12 {
+		t.Errorf("frame 2 prevGamma = %v, want %v", gamma2, wantGamma2)
 	}
 }

--- a/internal/voice/ambe2/doc.go
+++ b/internal/voice/ambe2/doc.go
@@ -20,38 +20,48 @@
 // that posture. Operators in licence-restrictive jurisdictions
 // should evaluate before deploying.
 //
-// Roadmap (each item lands as its own self-contained PR so review
-// stays tractable):
+// Roadmap (each item landed as its own self-contained PR so review
+// stayed tractable):
 //
-//  1. Skeleton + Vocoder interface integration. ← THIS PR.
-//     Decoder satisfies voice.Vocoder, registers as "ambe2" in
-//     voice.DefaultRegistry unconditionally on the default build,
-//     and emits silence per frame so the full call pipeline can
-//     wire to it now and start receiving audio for free as the
-//     later pieces land. FrameSize is 7 bytes (49 information
-//     bits + 7 padding) matching the libmbe wrapper's contract.
+//  1. Skeleton + Vocoder interface integration. Decoder satisfies
+//     voice.Vocoder, registers as "ambe2" in voice.DefaultRegistry
+//     unconditionally on the default build. FrameSize is 7 bytes
+//     (49 information bits + 7 padding) matching the libmbe
+//     wrapper's contract.
 //
-//  2. Parameter unpacking — 49 bits → mbe.Params. The largest
-//     single PR of the AMBE+2 work. Reads b₀ → ω₀ + L from a
-//     scattered bit position layout; voicing-pattern table
-//     lookup → Vl[1..L]; gain-vector index → log-amplitude offset
-//     feeding the gain block; two-stage spectral VQ index → DCT
-//     residual coefficients per band; DCT-II → Tl[1..L].
-//     Reference: szechyjs/mbelib's mbe_decodeAmbe2400Parms in
-//     ambe3600x2400.c, with constants from
-//     ambe3600x2450_const.h (ISC-licensed code; algorithm
+//  2. Parameter unpacking — 49 bits → ambe2.Params (mbe.Params +
+//     AMBE+2-specific DeltaGamma / Unvc / Tone / B0..B8). Reads
+//     b₀ → ω₀ + L from a scattered bit position layout;
+//     voicing-pattern table lookup → Vl[1..L]; gain-vector index →
+//     log-amplitude offset feeding the gain block; two-stage
+//     spectral VQ index → DCT residual coefficients per band;
+//     DCT-II → Tl[1..L]. Reference: szechyjs/mbelib's
+//     mbe_decodeAmbe2400Parms in ambe3600x2400.c with constants
+//     from ambe3600x2400_const.h (ISC-licensed code; algorithm
 //     patents are a separate concern — see docs/vocoders.md).
 //
-//  3. Synthesis wire-up + bad-frame handling + calibration.
-//     Decode() runs the shared mbe pipeline:
-//     UnpackParams → mbe.PredictLog2Ml → mbe.AmplitudesFromLog2Ml
-//     → mbe.EnhanceAmplitudes → mbe.SynthVoiced
-//     → mbe.SynthUnvoicedOverlapAdd → mbe.SynthState.Update…
-//     → mbe.AGC.Apply. AMBE+2-specific silence-frame indicator +
-//     frame-repeat-on-bad-frame using shared mbe.MaxBadFrames /
-//     BadFrameAttenuation. Calibration loop against a DSD-FME or
-//     OP25 reference WAV at testdata/. Tune the per-frame gain
-//     constant if AGC shows systematic level offset — AGC
-//     defaults are tuned for IMBE and AMBE+2 quantization may
-//     produce different per-frame energy.
+//  3. Synthesis wire-up + bad-frame handling. ← THIS PR.
+//     Decode() runs the shared mbe pipeline: UnpackParams → gamma
+//     fold (DC removal + 0.5·prev_gamma recursion + 0.5·log2(L)
+//     offset) → mbe.PredictLog2Ml → mbe.AmplitudesFromLog2Ml →
+//     unvoiced amplitude scaling by Unvc → mbe.EnhanceAmplitudes
+//     → mbe.SynthVoiced + mbe.SynthUnvoicedOverlapAdd →
+//     SynthState.Update… → mbe.AGC.Apply. AMBE+2-specific
+//     tone-frame path (b₀ ∈ {0x7E, 0x7F}) routes through the §6.4
+//     OA fade-out + state reset; bad-frame replay uses the shared
+//     mbe.MaxBadFrames / mbe.BadFrameAttenuation. The cross-frame
+//     gamma (gamma_curr = ΔG + 0.5·gamma_prev) lives on the
+//     Decoder; the per-frame fold rewrites Tl so the shared
+//     mbe.PredictLog2Ml produces AMBE+2-spec output without an
+//     AMBE+2-aware variant.
+//
+//  4. Remaining polish: calibration against a DSD-FME or OP25
+//     reference WAV at testdata/ (capture a known DMR voice frame
+//     + decode through both, compare RMS + cross-correlation);
+//     tune the per-frame gain constant if AGC shows systematic
+//     level offset against the reference (AGC defaults are tuned
+//     for IMBE and AMBE+2 quantization may produce different
+//     per-frame energy); proper tone-frame synthesis (single +
+//     dual sinewave from the preserved B1/B2 indices) replacing
+//     the current silence-out path.
 package ambe2


### PR DESCRIPTION
## Summary

PR-E of the [mbelib replacement plan](https://claude.ai/code/session_01SvuTSKyeTrSX9V352L9GVH). `ambe2.Decoder.Decode` now produces real audio end-to-end through the shared `internal/voice/mbe/` synthesis pipeline. **After this PR the daemon decodes AMBE+2 voice frames (P25 Phase 2 / DMR / NXDN) on every default build with no CGO dependency.**

### Pipeline

```
bytes → 49 info bits (unpackInfoBits)
  → UnpackParams → ambe2.Params (W0, L, Vl, Tl, DeltaGamma, Unvc)
  → gamma = DeltaGamma + 0.5·prevGamma   (cross-frame)
  → foldGammaIntoTl: Tl − mean(Tl) + gamma − 0.5·log2(L)
  → mbe.PredictLog2Ml                  → log2M[1..L]
  → mbe.AmplitudesFromLog2Ml           → M[1..L]
  → for unvoiced l: M[l] *= Unvc        (AMBE+2 §6.2 scaling)
  → mbe.EnhanceAmplitudes              → M' enhanced
  → mbe.SynthVoiced + SynthUnvoicedOverlapAdd
  → SynthState.Update{Log2Ml,VoicedState}
  → mbe.AGC.Apply                       → int16 PCM (160 samples)
```

### Key design choice — `foldGammaIntoTl`

AMBE+2's spec form is

> `log2Ml[l] = γ·(prev_interp[l] − mean) + (Tl[l] − mean(Tl)) + (gamma − 0.5·log2(L))`

vs. IMBE's

> `log2Ml[l] = γ·(prev_interp[l] − mean) + Tl[l]`

The difference is an additive offset that's constant across `l`. Folding it into Tl up front (`Tl_folded[l] = Tl[l] − mean(Tl) + gamma − 0.5·log2(L)`) lets the shared `mbe.PredictLog2Ml` produce AMBE+2-spec output without an AMBE+2-aware variant. The gamma itself needs cross-frame state (`prev_gamma`), which lives on the Decoder, so the fold runs inside `Decode`.

### Frame paths

- **Voice frame**: full pipeline; cache `(foldedParams, log2M, M)`; advance `prevGamma`.
- **Tone frame** (b₀ ∈ {0x7E, 0x7F}): §6.4 OA fade-out into `pcm[0..95]`; reset `SynthState` + last-good cache + `prevGamma`; AGC envelope preserved across silence.
- **Bad frame**: replay last-good with `mbe.BadFrameAttenuation^n` up to `mbe.MaxBadFrames`; AGC frozen so attenuation is audible. Defensive path (in practice unreached today; structural symmetry with imbe Decoder).

### Tests (32 total; +10 over PR-D)

- `TestDecodeProducesAudioForValidFrame` — non-zero PCM out for the all-zero (b₀=0) voice frame.
- `TestDecodeToneFrameReturnsSilenceNonOverlapRegion`, `TestDecodeToneAfterToneIsFullySilent` — tone-frame silence path.
- `TestDecodeDeterministicAcrossDecoders`, `TestNewWithSeedDifferentSeedsDifferentOutput` — seeding contract.
- `TestDecodeRollsCrossFrameState` — consecutive frames differ (state evolves).
- `TestResetClearsCrossFrameState`, `TestDecodeToneFrameClearsState` — Reset + tone-frame state-clear.
- `TestAGCConvergesTowardTarget` — AGC envelope drives output peak toward `TargetPeak` (±50% loose tol for AMBE+2's per-frame quantisation variance).
- `TestDecodeOutputIsBoundedAcrossFramePatterns` — NaN/Inf regression guard across 4 patterns × 10 rounds.
- `TestPrevGammaCrossFrameAccumulation` — closed-form check of `gamma_curr = ΔG + 0.5·gamma_prev` for b₂=1.
- Removed `TestDecodeReturnsSilenceSkeleton` (stale).

### Remaining polish (not in this PR)

- Calibration against a DSD-FME-decoded DMR reference recording; AGC per-frame gain tweak if real frames show systematic level offset.
- Proper tone-frame synthesis (single + dual sinewave from preserved `B1`/`B2` indices) replacing the current silence path.

The AMBE+2 algorithm carries active patents in some jurisdictions; re-implementing it in pure Go does not change that posture — see `docs/vocoders.md`.

## Test plan

- [x] `go vet ./internal/voice/...` clean
- [x] `go test -race -count=1 ./internal/voice/...` all pass — 32 ambe2 tests, full voice tree green
- [x] AGC envelope converges within ±50% of `TargetPeak` for the all-zero voice frame after 30 frames
- [x] Cross-frame gamma matches closed-form recursion (`gamma_curr = ΔG + 0.5·gamma_prev`)
- [ ] After merge: capture a DMR voice frame, run through `ambe2.Decoder.Decode`, listen-test against a DSD-FME reference

## Files

```
README.md                            |  64 ++++---
internal/voice/ambe2/decoder.go      | 248 ++++++++++++++++++++++++---
internal/voice/ambe2/decoder_test.go | 313 ++++++++++++++++++++++++++++++++++-
internal/voice/ambe2/doc.go          |  70 ++++----
```

https://claude.ai/code/session_01SvuTSKyeTrSX9V352L9GVH

---
_Generated by [Claude Code](https://claude.ai/code/session_01SvuTSKyeTrSX9V352L9GVH)_