### PR TITLE
internal/voice/ambe2: single-tone synthesis + corrected tone-frame b1/b2

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,11 +63,14 @@ SQLite. The honest gaps:
   pipeline (49-bit parameter unpack → cross-frame gamma fold →
   `mbe.PredictLog2Ml` → linear M → unvoiced `Unvc` scaling →
   `mbe.EnhanceAmplitudes` → voiced + unvoiced OA synthesis →
-  state roll-forward → per-frame AGC). Remaining polish:
-  calibration against a DSD-FME-decoded DMR reference WAV (AGC
-  defaults are tuned for IMBE and AMBE+2 quantisation may need a
-  per-frame gain tweak); proper tone-frame synthesis (single +
-  dual sinewave) replacing the current silence-out path. The
+  state roll-forward → per-frame AGC). Single-tone synthesis
+  (b₁ ∈ [5, 122] ⇒ sinewave at b₁·31.25 Hz with phase carried
+  across frames) is wired; dual-tone (b₁ ∈ [128, 163]) still
+  routes through silence pending a frequency-pair lookup the
+  public spec doesn't document. Remaining polish: calibration
+  against a DSD-FME-decoded DMR reference WAV (AGC defaults are
+  tuned for IMBE and AMBE+2 quantisation may need a per-frame
+  gain tweak). The
   AMBE+2 algorithm carries active patents in some jurisdictions;
   re-implementing it in pure Go does not change that posture —
   see [docs/vocoders.md](docs/vocoders.md).
@@ -202,13 +205,18 @@ to its own package and lands independently.
   (0.2046/√ω₀) between log2Ml→Ml and the §6.2 enhancement,
   then runs `mbe.SynthVoiced` + `mbe.SynthUnvoicedOverlapAdd`
   + state roll-forward + per-frame AGC into int16 PCM. Tone
-  frames route through the §6.4 OA fade-out + state reset;
-  bad-frame replay uses the shared `mbe.MaxBadFrames` /
-  `mbe.BadFrameAttenuation`. **Remaining polish**: calibration
-  against a DSD-FME-decoded DMR reference recording (testdata
-  follow-up); proper tone-frame synthesis (single + dual
-  sinewave from preserved B1/B2) replacing the current silence
-  path.
+  frames (b₀ ∈ {0x7E, 0x7F}) decode b₁/b₂ via the
+  AMBE+2-specific bit layout (t5/t6/t7 table lookup on
+  info[6,7,8] feeding bits 5..7 of b₁); valid single-tone
+  indices (b₁ ∈ [5, 122]) synthesise a sinewave at b₁·31.25 Hz
+  scaled by b₂, with oscillator phase carried across frames in
+  the Decoder so a held tone is click-free. Dual-tone
+  (b₁ ∈ [128, 163]) and invalid tone indices route through the
+  §6.4 OA fade-out + state reset. Bad-frame replay uses the
+  shared `mbe.MaxBadFrames` / `mbe.BadFrameAttenuation`.
+  **Remaining polish**: calibration against a DSD-FME-decoded
+  DMR reference recording (testdata follow-up); dual-tone
+  synthesis once a frequency-pair lookup is sourced.
 - **DVSI USB-3000 / AMBE-3003 hardware backend.** A `Vocoder`
   factory that opens a connected DVSI USB chip. Same plug-in shape
   as `internal/voice/ambe2`; the daemon picks the factory by name

--- a/docs/vocoders.md
+++ b/docs/vocoders.md
@@ -90,9 +90,10 @@ This is exactly what SDR# / OP25 / DSD do. The key benefits:
 - Absolute-level calibration against a DSD-FME or OP25 reference
   recording for both `imbe` and `ambe2` decoders; AGC per-frame gain
   tweaks if real frames show systematic level offset.
-- Proper AMBE+2 tone-frame synthesis (single + dual sinewave) replacing
-  the current silence path — the tone-index extraction is already
-  preserved on `ambe2.Params.B1` / `B2` for the follow-up.
+- AMBE+2 dual-tone synthesis (b₁ ∈ [128, 163]) — single tones
+  already synthesise a sinewave at b₁·31.25 Hz with cross-frame
+  phase continuity; dual-tone requires an AMBE+2-specific
+  (b₁ → freq_a, freq_b) lookup the public spec doesn't document.
 - DVSI USB-3000 / AMBE-3003 hardware backend (`-tags dvsi`).
 - Optional Opus / FLAC re-encoding of the recorded WAVs to shrink
   long-running archives.

--- a/internal/voice/ambe2/decoder.go
+++ b/internal/voice/ambe2/decoder.go
@@ -56,6 +56,12 @@ type Decoder struct {
 	// resolved gamma so the next frame's fold has it available.
 	prevGamma float64
 
+	// Tone-frame sine oscillator phase. Carried across consecutive
+	// tone frames so a sustained tone at one frequency is
+	// click-free between frame boundaries. Cleared on any non-tone
+	// frame (voice / silence / dual-tone fallback) and on Reset.
+	tonePhase float64
+
 	// One-frame cache for the bad-frame replay path. Holds the
 	// post-fold mbe.Params (Tl values already centered + gamma
 	// folded in) so a replay can call mbe.PredictLog2Ml + the
@@ -164,22 +170,41 @@ func (d *Decoder) Decode(frame []byte) ([]int16, error) {
 		d.agc.Apply(pcm, out, true)
 		return out, nil
 
+	case p.Tone && !p.Silent && p.B1 >= 5 && p.B1 <= 122:
+		// Single tone: synthesise a sinewave at b1·31.25 Hz scaled
+		// by b2. Phase is carried across consecutive tone frames
+		// in d.tonePhase so a held tone is click-free. Voice
+		// SynthState resets — voice + tone state are orthogonal.
+		// AGC tracks (no freeze) so b2 volume changes are audible.
+		d.synthSingleTone(p.B1, p.B2, pcm)
+		d.state.Reset()
+		d.clearLastGood()
+		d.prevGamma = 0
+		d.agc.Apply(pcm, out, false)
+		return out, nil
+
 	case p.Tone || p.Silent:
-		// Tone-frame path: for now, emit the OA tail fade-out into
-		// pcm[0..95] and reset state. Proper tone synthesis (single +
-		// dual sinewave) is a follow-up; the tone-index extraction is
-		// already preserved on p.B1/p.B2 for that work. Silent
-		// frames (invalid tone index) hit the same path.
+		// Dual-tone (b1 in [128, 163]), invalid tone, or explicit
+		// silence: emit the §6.4 OA tail fade-out into pcm[0..95]
+		// and reset state. Dual-tone synthesis requires an
+		// AMBE+2-specific (b1, freq_a, freq_b) lookup table that
+		// the public spec doesn't document — those route through
+		// silence until a reference is available. Silent frames
+		// (invalid tone index) hit the same path.
 		mbe.SynthUnvoicedOverlapAdd(&d.state, p.Params, nil, nil, pcm)
 		d.state.Reset()
 		d.clearLastGood()
 		d.prevGamma = 0
+		d.tonePhase = 0
 		d.agc.Apply(pcm, out, true)
 		return out, nil
 	}
 
-	// Good voice frame.
+	// Good voice frame. Clear tonePhase so a tone → voice → tone
+	// sequence doesn't pick up the pre-voice phase on the second
+	// tone (the voice frame breaks oscillator continuity).
 	d.badFrameCount = 0
+	d.tonePhase = 0
 
 	// Combine the per-frame delta with prev-frame gamma to recover
 	// the absolute gain, then fold gamma + DC removal into Tl so
@@ -217,6 +242,44 @@ func (d *Decoder) Decode(frame []byte) ([]int16, error) {
 
 	d.agc.Apply(pcm, out, false)
 	return out, nil
+}
+
+// synthSingleTone fills pcm[0..mbe.SamplesPerFrame-1] with a
+// sinewave at b1·31.25 Hz scaled by b2-derived amplitude. The
+// oscillator phase is carried across frames in d.tonePhase so two
+// consecutive tone frames at the same b1 are click-free.
+//
+// b1 is the AMBE+2 single-tone index in [5, 122] (callers gate
+// for that range). The corresponding frequency is b1·31.25 Hz,
+// covering 156.25 Hz at b1=5 up to 3812.5 Hz at b1=122 — the
+// audible band an 8 kHz Nyquist supports.
+//
+// b2 is the 8-bit volume index from the AMBE+2 tone-frame
+// extraction. We map it to a peak amplitude of (b2/255)·8192 —
+// the absolute level is mostly cosmetic since the AGC normalises
+// to AGCConfig.TargetPeak, but the b2 scaling makes per-frame
+// volume changes audible within a single tone sequence (before
+// the AGC has time to compensate).
+func (d *Decoder) synthSingleTone(b1, b2 int, pcm []float64) {
+	const (
+		toneStepHz   = 31.25  // b1 step from §AMBE+2 tone-frame definition
+		peakAmpScale = 8192.0 // pre-AGC headroom for the synthesised tone
+		volMax       = 255.0  // b2 is 8-bit
+	)
+	freqHz := float64(b1) * toneStepHz
+	amp := peakAmpScale * float64(b2) / volMax
+	twoPi := 2 * math.Pi
+	phaseStep := twoPi * freqHz / float64(mbe.PCMSampleRate)
+	for n := 0; n < mbe.SamplesPerFrame; n++ {
+		pcm[n] = amp * math.Sin(d.tonePhase)
+		d.tonePhase += phaseStep
+	}
+	// Wrap phase to keep it bounded across long-running tone
+	// sequences so the float64 accumulator doesn't drift.
+	d.tonePhase = math.Mod(d.tonePhase, twoPi)
+	if d.tonePhase < 0 {
+		d.tonePhase += twoPi
+	}
 }
 
 // synthFrame runs the §6.3 voiced + §6.4 unvoiced overlap-add legs
@@ -306,6 +369,7 @@ func (d *Decoder) Reset() {
 	d.agc.Reset()
 	d.clearLastGood()
 	d.prevGamma = 0
+	d.tonePhase = 0
 }
 
 // Close releases any resources held by the decoder. The pure-Go

--- a/internal/voice/ambe2/decoder_test.go
+++ b/internal/voice/ambe2/decoder_test.go
@@ -393,6 +393,237 @@ func TestDecodeOutputIsBoundedAcrossFramePatterns(t *testing.T) {
 	}
 }
 
+// singleToneFrame builds a 7-byte AMBE+2 tone frame with a chosen
+// single-tone b1 ∈ [5, 122] and 8-bit volume b2. The tone-frame
+// b1 packing uses the t5/t6/t7 table lookup for bits 5..7 — to
+// keep the test self-contained we force idx = 1 (info[6,7,8] =
+// 0,0,1) so those tables emit (0,0,0), letting bits 0..4 of b1
+// be set directly via info[9, 42, 43, 10, 11].
+func singleToneFrame(b1, b2 int) []byte {
+	if b1 < 0 || b1 > 31 {
+		panic("singleToneFrame test helper only emits b1 in [0, 31] (high bits via t-table idx=1 are forced 0)")
+	}
+	info := make([]byte, InfoBits)
+	// b0 = 0x7E (tone frame): info[0..5] = 1, info[48] = 0.
+	for i := 0; i <= 5; i++ {
+		info[i] = 1
+	}
+	// t-table idx = 1 → bits 5..7 of b1 = 0.
+	info[8] = 1
+	// b1 low 5 bits via info[9, 42, 43, 10, 11] (MSB-first: bit4 → 16).
+	info[9] = byte((b1 >> 4) & 1)
+	info[42] = byte((b1 >> 3) & 1)
+	info[43] = byte((b1 >> 2) & 1)
+	info[10] = byte((b1 >> 1) & 1)
+	info[11] = byte(b1 & 1)
+	// b2 (8 bits) via info[12, 13, 14, 15, 16, 44, 45, 17].
+	info[12] = byte((b2 >> 7) & 1)
+	info[13] = byte((b2 >> 6) & 1)
+	info[14] = byte((b2 >> 5) & 1)
+	info[15] = byte((b2 >> 4) & 1)
+	info[16] = byte((b2 >> 3) & 1)
+	info[44] = byte((b2 >> 2) & 1)
+	info[45] = byte((b2 >> 1) & 1)
+	info[17] = byte(b2 & 1)
+	// Pack info bits into 7 bytes MSB-first to mirror the wire format.
+	frame := make([]byte, FrameBytes)
+	for i := 0; i < InfoBits; i++ {
+		frame[i/8] |= info[i] << (7 - uint(i)%8)
+	}
+	return frame
+}
+
+// TestDecodeSingleToneFrameAudible: a valid single-tone frame
+// (b1 ∈ [5, 122]) synthesises a sinewave at b1·31.25 Hz scaled by
+// b2. Pins that the tone path actually produces audio rather than
+// routing through silence.
+func TestDecodeSingleToneFrameAudible(t *testing.T) {
+	d := New()
+	// b1 = 12 ⇒ 375 Hz; b2 = 128 ⇒ ~half-scale pre-AGC.
+	out, err := d.Decode(singleToneFrame(12, 128))
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if len(out) != mbe.SamplesPerFrame {
+		t.Errorf("len(out) = %d, want %d", len(out), mbe.SamplesPerFrame)
+	}
+	if agcPeak(out) == 0 {
+		t.Fatal("single-tone frame output is fully silent; tone synthesis didn't run")
+	}
+}
+
+// TestDecodeSingleToneFrameApproximateFrequency: count zero
+// crossings in a frame of a known-frequency tone and confirm the
+// count matches 2·f·(N/fs) ± 1 (zero crossings per cycle ×
+// number of cycles in the frame). For b1 = 16 ⇒ f = 500 Hz and
+// N = 160 samples at fs = 8000, expect 2·500·(160/8000) = 20
+// zero crossings. Loose tolerance handles the AGC's per-frame
+// gain (which doesn't change zero-crossing count anyway) plus
+// first-frame phase seeding.
+func TestDecodeSingleToneFrameApproximateFrequency(t *testing.T) {
+	d := New()
+	out, err := d.Decode(singleToneFrame(16, 200))
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	var crossings int
+	for i := 1; i < len(out); i++ {
+		if (out[i-1] < 0 && out[i] >= 0) || (out[i-1] >= 0 && out[i] < 0) {
+			crossings++
+		}
+	}
+	const wantCrossings = 20
+	if crossings < wantCrossings-2 || crossings > wantCrossings+2 {
+		t.Errorf("zero crossings = %d, want %d ±2 (b1=16 ⇒ 500 Hz, 160 samples @ 8 kHz)",
+			crossings, wantCrossings)
+	}
+}
+
+// TestDecodeSingleToneFramePhaseContinuity: two consecutive tone
+// frames at the same b1 should not click at the frame boundary.
+// The maximum absolute difference between consecutive samples
+// across the join (last sample of frame 1, first sample of frame
+// 2) should be on the same order as the maximum intra-frame
+// sample-to-sample difference — a click would manifest as a 2×+
+// jump.
+func TestDecodeSingleToneFramePhaseContinuity(t *testing.T) {
+	d := New()
+	frame := singleToneFrame(20, 200) // 625 Hz, mid volume
+	out1, err := d.Decode(frame)
+	if err != nil {
+		t.Fatalf("frame 1: %v", err)
+	}
+	out2, err := d.Decode(frame)
+	if err != nil {
+		t.Fatalf("frame 2: %v", err)
+	}
+	// Largest intra-frame sample-to-sample diff in frame 2 (after
+	// AGC has warmed up enough to give us a clean reference).
+	var maxIntra int
+	for i := 1; i < len(out2); i++ {
+		d := int(out2[i]) - int(out2[i-1])
+		if d < 0 {
+			d = -d
+		}
+		if d > maxIntra {
+			maxIntra = d
+		}
+	}
+	// Boundary diff.
+	boundary := int(out2[0]) - int(out1[len(out1)-1])
+	if boundary < 0 {
+		boundary = -boundary
+	}
+	// A click would be much larger than the intra-frame max. Allow
+	// 3× headroom for AGC level adjustment between the two frames.
+	if boundary > 3*maxIntra && boundary > 2000 {
+		t.Errorf("boundary diff = %d, intra-frame max = %d (likely click on frame boundary)",
+			boundary, maxIntra)
+	}
+}
+
+// TestDecodeSingleToneFrameVolumeScaling: feed two streams of
+// tones at the same frequency but different b2 (volume) values.
+// Before the AGC fully converges, the louder b2 should produce a
+// higher peak. Take the first frame's peak before the AGC
+// normalises everything to TargetPeak.
+func TestDecodeSingleToneFrameVolumeScaling(t *testing.T) {
+	loud := New()
+	quiet := New()
+	loudOut, err := loud.Decode(singleToneFrame(12, 255))
+	if err != nil {
+		t.Fatalf("loud: %v", err)
+	}
+	quietOut, err := quiet.Decode(singleToneFrame(12, 8))
+	if err != nil {
+		t.Fatalf("quiet: %v", err)
+	}
+	loudPeak := agcPeak(loudOut)
+	quietPeak := agcPeak(quietOut)
+	// First-frame AGC seed lands both at ~TargetPeak (24000), so
+	// the peaks themselves are close. What differs is the AGC
+	// envelope: loud frame's envelope is ≈ peakAmpScale, quiet
+	// frame's is much lower. Confirm both produced non-zero audio
+	// (silence-out wouldn't have).
+	if loudPeak == 0 || quietPeak == 0 {
+		t.Fatalf("expected non-zero peaks: loud=%d quiet=%d", loudPeak, quietPeak)
+	}
+	loudEnv := loud.agc.Envelope()
+	quietEnv := quiet.agc.Envelope()
+	if loudEnv <= quietEnv {
+		t.Errorf("loud envelope %v should exceed quiet envelope %v", loudEnv, quietEnv)
+	}
+}
+
+// TestDecodeDualToneFrameStaysSilent: dual-tone indices
+// (b1 ∈ [128, 163]) need an AMBE+2-specific frequency-pair lookup
+// the public spec doesn't document; until that lands they route
+// through the §6.4 OA fade-out + silence path. Pin that
+// behaviour so adding a dual-tone synthesis path later doesn't
+// silently break the silent-out contract for unsupported
+// indices.
+func TestDecodeDualToneFrameStaysSilent(t *testing.T) {
+	d := New()
+	// frame[0] = 0xFC ⇒ b0 = 0x7E (tone frame). info[6..8] = 0 ⇒
+	// idx = 0 ⇒ t7tab[0]<<7 = 0x80 = 128 (dual-tone). Other bits
+	// zero, so b1 = 128.
+	frame := make([]byte, FrameBytes)
+	frame[0] = 0xFC
+	out, err := d.Decode(frame)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	// Non-overlap region (pcm[96..159]) must be silent on a
+	// dual-tone frame — the silence path runs there.
+	for i := mbe.SamplesPerFrame - 64; i < mbe.SamplesPerFrame; i++ {
+		if out[i] != 0 {
+			t.Errorf("sample[%d] = %d, want 0 (dual-tone is silence)", i, out[i])
+		}
+	}
+}
+
+// TestDecodeToneToVoiceTransition: a tone followed by a voice
+// frame must produce voice audio (synth pipeline runs) and reset
+// the tone-phase accumulator. Pins that the orthogonal voice /
+// tone state machines don't interfere.
+func TestDecodeToneToVoiceTransition(t *testing.T) {
+	d := New()
+	if _, err := d.Decode(singleToneFrame(12, 200)); err != nil {
+		t.Fatalf("tone: %v", err)
+	}
+	if d.tonePhase == 0 {
+		t.Fatal("tone frame didn't advance tonePhase; test setup invalid")
+	}
+	// All-zero info ⇒ voice frame (b0 = 0).
+	out, err := d.Decode(make([]byte, FrameBytes))
+	if err != nil {
+		t.Fatalf("voice: %v", err)
+	}
+	if agcPeak(out) == 0 {
+		t.Fatal("voice frame after tone produced silence")
+	}
+	if d.tonePhase != 0 {
+		t.Errorf("voice frame didn't clear tonePhase: got %v", d.tonePhase)
+	}
+}
+
+// TestResetClearsTonePhase: Reset must zero d.tonePhase so a
+// stream re-sync doesn't carry the oscillator state into the
+// next call's tone frames.
+func TestResetClearsTonePhase(t *testing.T) {
+	d := New()
+	if _, err := d.Decode(singleToneFrame(12, 200)); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if d.tonePhase == 0 {
+		t.Fatal("seed didn't advance tonePhase; test setup invalid")
+	}
+	d.Reset()
+	if d.tonePhase != 0 {
+		t.Errorf("tonePhase = %v after Reset, want 0", d.tonePhase)
+	}
+}
+
 // TestPrevGammaCrossFrameAccumulation: gamma_curr = ΔG_curr +
 // 0.5·gamma_prev. Feed a frame with non-zero ΔG twice and verify
 // the second frame's resolved gamma matches the closed form.

--- a/internal/voice/ambe2/doc.go
+++ b/internal/voice/ambe2/doc.go
@@ -55,13 +55,25 @@
 //     mbe.PredictLog2Ml produces AMBE+2-spec output without an
 //     AMBE+2-aware variant.
 //
-//  4. Remaining polish: calibration against a DSD-FME or OP25
+//  4. Single-tone synthesis. Tone frames (b₀ ∈ {0x7E, 0x7F}) with
+//     b₁ ∈ [5, 122] synthesise a sinewave at b₁·31.25 Hz scaled
+//     by the b₂ volume index. Oscillator phase is carried across
+//     consecutive tone frames in Decoder.tonePhase so held tones
+//     are click-free. The AMBE+2 tone-frame b₁/b₂ extraction
+//     uses a different bit layout than the voice-frame branch:
+//     b₁ is 8 bits with the upper 3 mapped via t5tab/t6tab/t7tab
+//     lookup on info[6,7,8]; b₂ is 8 bits scattered across
+//     info[12..17,44,45]. Reference: mbelib's
+//     mbe_decodeAmbe2400Parms tone branch.
+//
+//  5. Remaining polish: calibration against a DSD-FME or OP25
 //     reference WAV at testdata/ (capture a known DMR voice frame
 //     + decode through both, compare RMS + cross-correlation);
 //     tune the per-frame gain constant if AGC shows systematic
 //     level offset against the reference (AGC defaults are tuned
 //     for IMBE and AMBE+2 quantization may produce different
-//     per-frame energy); proper tone-frame synthesis (single +
-//     dual sinewave from the preserved B1/B2 indices) replacing
-//     the current silence-out path.
+//     per-frame energy); dual-tone synthesis (b₁ ∈ [128, 163])
+//     requires an AMBE+2-specific (b₁ → freq_a, freq_b) lookup
+//     table the public spec doesn't document — those route
+//     through silence until a reference is available.
 package ambe2

--- a/internal/voice/ambe2/params.go
+++ b/internal/voice/ambe2/params.go
@@ -70,6 +70,20 @@ type Params struct {
 // info-bit slice isn't exactly InfoBits long.
 var ErrInfoLength = errors.New("ambe2: info buffer must be 49 bits")
 
+// Tone-frame b1 lookup tables, per szechyjs/mbelib's
+// mbe_decodeAmbe2400Parms tone branch. Three info bits at
+// positions [6, 7, 8] index these tables; the outputs become
+// bits 5..7 of the tone-frame b1. mbelib annotates the "V = verified,
+// G = guessed" status: bits 4..0 are verified against captured
+// frames; bits 7..5 derive from the (verified) DTMF tone-index
+// mapping. The numeric values below mirror mbelib's t5tab / t6tab /
+// t7tab arrays 1:1.
+var (
+	toneT5 = [8]int{0, 0, 1, 0, 1, 1, 0, 1}
+	toneT6 = [8]int{0, 0, 0, 1, 1, 1, 1, 0}
+	toneT7 = [8]int{1, 0, 0, 0, 0, 1, 1, 1}
+)
+
 // UnpackParams reads 49 information bits and produces the
 // AMBE+2 model-parameter struct. Bits are stored one per byte
 // (0/1) — the same shape the libmbe wrapper accepts and the
@@ -101,15 +115,24 @@ func UnpackParams(info []byte) (Params, error) {
 		int(info[48])
 
 	// Tone-frame branch — short-circuit and let the synthesizer
-	// handle tone vs. silence in PR-E. Preserve b1/b2 raw so the
-	// follow-up tone synthesis can read the tone index + volume.
+	// pick up the tone vs. silence handling. Tone frames carry a
+	// different b1/b2 bit layout than voice frames: b1 is 8 bits
+	// with the upper 3 bits coming from a t5/t6/t7 table lookup,
+	// b2 is 8 bits drawn from a different scatter pattern.
+	// Reference: mbelib mbe_decodeAmbe2400Parms tone branch.
 	if (b0 & 0x7E) == 0x7E {
-		b1 := int(info[38])<<3 | int(info[39])<<2 | int(info[40])<<1 | int(info[41])
-		b2 := int(info[6])<<5 | int(info[7])<<4 | int(info[8])<<3 |
-			int(info[9])<<2 | int(info[42])<<1 | int(info[43])
+		idx := int(info[6])<<2 | int(info[7])<<1 | int(info[8])
+		b1 := toneT7[idx]<<7 | toneT6[idx]<<6 | toneT5[idx]<<5 |
+			int(info[9])<<4 | int(info[42])<<3 | int(info[43])<<2 |
+			int(info[10])<<1 | int(info[11])
+		b2 := int(info[12])<<7 | int(info[13])<<6 | int(info[14])<<5 |
+			int(info[15])<<4 | int(info[16])<<3 | int(info[44])<<2 |
+			int(info[45])<<1 | int(info[17])
 		p := Params{Tone: true, B0: b0, B1: b1, B2: b2}
 		// mbelib flags an invalid tone index as silence; mirror that
 		// so the synthesizer's silence path runs cleanly.
+		// Valid single-tone range is [5, 122]; valid dual-tone
+		// range is [128, 163]; everything else is silence.
 		if b1 < 5 || (b1 > 122 && b1 < 128) || b1 > 163 {
 			p.Params.Silent = true
 		}

--- a/internal/voice/ambe2/params_test.go
+++ b/internal/voice/ambe2/params_test.go
@@ -138,12 +138,19 @@ func TestUnpackParamsToneFrameDetection(t *testing.T) {
 // TestUnpackParamsToneFrameInvalidIndexFlagsSilent: a tone frame with
 // b1 < 5 (or in the reserved windows) is flagged silent by mbelib;
 // we mirror that so the synthesizer's silence path runs cleanly.
+//
+// Reaching b1 = 0 requires the t5/t6/t7 table inputs to all map to
+// 0. From the tables, only idx = 1 (info[6,7,8] = 0,0,1) yields
+// (t5, t6, t7) = (0, 0, 0). With the remaining 5 b1 bits also
+// zero, b1 = 0 which falls in the invalid (< 5) window.
 func TestUnpackParamsToneFrameInvalidIndexFlagsSilent(t *testing.T) {
 	info := make([]byte, InfoBits)
-	// Tone frame, b1 = 0 (invalid: b1 < 5).
+	// Tone frame (b0 = 0x7E).
 	for i := 0; i <= 5; i++ {
 		info[i] = 1
 	}
+	// idx = 1 → all three t-tables emit 0 → high 3 bits of b1 = 0.
+	info[8] = 1
 	p, err := UnpackParams(info)
 	if err != nil {
 		t.Fatalf("UnpackParams: %v", err)
@@ -151,8 +158,54 @@ func TestUnpackParamsToneFrameInvalidIndexFlagsSilent(t *testing.T) {
 	if !p.Tone {
 		t.Fatal("expected Tone=true")
 	}
+	if p.B1 != 0 {
+		t.Errorf("B1 = %d, want 0 (invalid tone index)", p.B1)
+	}
 	if !p.Silent {
 		t.Errorf("tone frame with b1=0 should flag Silent=true (mbelib parity)")
+	}
+}
+
+// TestUnpackParamsToneFrameB1TableLookup: the t5/t6/t7 tables map
+// the 3-bit input (info[6,7,8]) to bits 5..7 of the tone-frame b1.
+// Pin the exact mapping mbelib transcribes from the AMBE+2 tone-
+// frame definition — a regression here changes which tone index a
+// frame decodes to, which would silently break tone synthesis.
+func TestUnpackParamsToneFrameB1TableLookup(t *testing.T) {
+	// (info[6], info[7], info[8]) → idx → bits 7,6,5 of b1 → high
+	// 3 bits as a single integer (bits[7..5] << 5).
+	cases := []struct {
+		i6, i7, i8 byte
+		wantHigh   int // (t7 << 7) | (t6 << 6) | (t5 << 5)
+	}{
+		{0, 0, 0, (1 << 7)},                     // idx 0: t7=1, t6=0, t5=0
+		{0, 0, 1, 0},                            // idx 1: all zero
+		{0, 1, 0, (1 << 5)},                     // idx 2: t5=1
+		{0, 1, 1, (1 << 6)},                     // idx 3: t6=1
+		{1, 0, 0, (1 << 6) | (1 << 5)},          // idx 4: t6=1, t5=1
+		{1, 0, 1, (1 << 7) | (1 << 6) | (1 << 5)}, // idx 5: all 1
+		{1, 1, 0, (1 << 7) | (1 << 6)},          // idx 6: t7=1, t6=1
+		{1, 1, 1, (1 << 7) | (1 << 5)},          // idx 7: t7=1, t5=1
+	}
+	for _, c := range cases {
+		info := make([]byte, InfoBits)
+		// Tone frame.
+		for i := 0; i <= 5; i++ {
+			info[i] = 1
+		}
+		info[6], info[7], info[8] = c.i6, c.i7, c.i8
+		p, err := UnpackParams(info)
+		if err != nil {
+			t.Fatalf("idx=(%d,%d,%d): %v", c.i6, c.i7, c.i8, err)
+		}
+		if !p.Tone {
+			t.Fatalf("idx=(%d,%d,%d): not flagged Tone", c.i6, c.i7, c.i8)
+		}
+		// Lower 5 bits of b1 come from info[9,42,43,10,11], all zero.
+		if p.B1 != c.wantHigh {
+			t.Errorf("info[6,7,8]=(%d,%d,%d): B1 = %d (0x%02X), want %d (0x%02X)",
+				c.i6, c.i7, c.i8, p.B1, p.B1, c.wantHigh, c.wantHigh)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Replaces the silence-out path for valid single-tone frames (b₁ ∈ [5, 122]) with sinewave synthesis at b₁·31.25 Hz scaled by b₂. Also fixes a **latent bug in PR-D's UnpackParams**: the tone-frame branch was reading b₁/b₂ via the voice-frame bit positions, but AMBE+2 uses a different layout for tone frames. The bug wasn't observable until tone synthesis actually consumed those values in this PR.

### Bit-extraction fix (`params.go`)

The tone-frame b₁ is 8 bits with the upper 3 mapped via three 8-element lookup tables (`t5tab` / `t6tab` / `t7tab`) keyed on `info[6,7,8]`; the lower 5 come from `info[9, 42, 43, 10, 11]`. b₂ is 8 bits scattered across `info[12..17, 44, 45]`. The previous PR-D code reused the voice-branch positions, which silently produced wrong B1/B2 values for tone frames.

Reference: mbelib's `mbe_decodeAmbe2400Parms` tone branch.

### Single-tone synthesis (`decoder.go`)

- `Decoder` gains a `tonePhase float64` oscillator state — carried across consecutive tone frames so a held tone is click-free across frame boundaries; cleared on any non-tone frame (voice / silence / dual-tone fallback) and on `Reset`.
- `synthSingleTone(b1, b2, pcm)` fills 160 samples with a sine at `b₁·31.25 Hz` (156.25 Hz at b₁=5 → 3812.5 Hz at b₁=122, within the 8 kHz Nyquist). b₂ scales pre-AGC amplitude to `(b₂/255)·8192`; the AGC normalises to `AGCConfig.TargetPeak` afterwards, so b₂ mostly controls per-frame relative dynamics within a tone sequence.
- AGC tracks the tone (no freeze) so volume changes between frames register in the envelope.
- Voice `SynthState` resets on tone frames — tone and voice state machines are orthogonal.

### Frame disposition

| Class | Condition | Behaviour |
| --- | --- | --- |
| Voice | b₀ < 0x7E | Synthesise via shared `mbe` pipeline |
| **Single tone** | **b₀ ∈ {0x7E, 0x7F}, b₁ ∈ [5, 122]** | **Synthesise sinewave (new)** |
| Dual tone | b₀ ∈ {0x7E, 0x7F}, b₁ ∈ [128, 163] | Silence-out with OA fade; AMBE+2-specific lookup follow-up |
| Invalid / silent | b₁ < 5, ∈ (122, 128), > 163 | Silence-out |
| Bad frame | UnpackParams error | Replay last good or silence |

### Tests (+8 over the previous 32; total now 40)

- `TestUnpackParamsToneFrameB1TableLookup`: pin the t5/t6/t7 → b₁ bits-5..7 mapping (all 8 idx values).
- `TestUnpackParamsToneFrameInvalidIndexFlagsSilent`: rewritten to use the corrected tone-extraction (`info[8]=1` → idx=1 → b₁ high bits = 0 → b₁ < 5 → Silent).
- `TestDecodeSingleToneFrameAudible`: non-zero PCM for b₁=12.
- `TestDecodeSingleToneFrameApproximateFrequency`: zero-crossing count for b₁=16 ⇒ 500 Hz matches `2·500·(160/8000) = 20 ± 2`.
- `TestDecodeSingleToneFramePhaseContinuity`: frame-boundary sample diff stays within ~3× the intra-frame max.
- `TestDecodeSingleToneFrameVolumeScaling`: b₂=255 vs b₂=8 yield different AGC envelopes after one frame.
- `TestDecodeDualToneFrameStaysSilent`: b₀=0x7E with idx=0 → b₁=128 (dual tone) still produces silence in `pcm[96..159]`.
- `TestDecodeToneToVoiceTransition`: tone → voice resets `tonePhase` and produces voice audio.
- `TestResetClearsTonePhase`: Reset zeros `tonePhase`.

A `singleToneFrame(b1, b2)` test helper builds frames MSB-first into 7 bytes; the b₁ helper is gated to `[0, 31]` since it forces t-table idx=1 (all t-outputs zero) for test clarity.

### Docs

- `internal/voice/ambe2/doc.go` roadmap step 4 now describes shipped single-tone synthesis + tone-frame bit layout; step 5 (remaining polish) lists dual-tone + calibration as open items.
- `README.md` digital-voice + roadmap entries updated to reflect tone synthesis state.
- `docs/vocoders.md` "Future work" trimmed to just dual-tone (single-tone is no longer pending).

## Test plan

- [x] `go vet ./internal/voice/...` clean
- [x] `go test -race -count=1 ./internal/voice/...` all pass — 40 ambe2 tests (+8 new), 141 across imbe/mbe (unchanged)
- [x] Zero-crossing count for b₁=16 matches expected 500 Hz tone within ±2
- [x] Frame-boundary phase continuity verified across two consecutive tone frames
- [ ] After merge: feed a captured DMR tone-frame sequence and listen-test the result against a DSD-FME reference

## Files

```
README.md                            |  32 +++--
docs/vocoders.md                     |   7 +-
internal/voice/ambe2/decoder.go      |  76 +++++++++++-
internal/voice/ambe2/decoder_test.go | 231 +++++++++++++++++++++++++++++++++++
internal/voice/ambe2/doc.go          |  20 ++-
internal/voice/ambe2/params.go       |  33 ++++-
internal/voice/ambe2/params_test.go  |  55 ++++++++-
7 files changed, 423 insertions(+), 31 deletions(-)
```

https://claude.ai/code/session_01SvuTSKyeTrSX9V352L9GVH

---
_Generated by [Claude Code](https://claude.ai/code/session_01SvuTSKyeTrSX9V352L9GVH)_