### PR TITLE
internal/voice/imbe: phase-aware bad-frame fade-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,14 @@ to its own package and lands independently.
   frames bridge ~120 ms of weak signal before Decode emits silence
   + clears the cache. The repeat path freezes the AGC envelope
   so the attenuation is audible (signals signal degradation).
+  **Phase-aware fade-in**: when a bad-streak state clear is
+  followed by good frames returning, the next 3 frames run with
+  M scaled by `recoveryRampFactors = {0.4, 0.7, 1.0}` and the
+  AGC frozen so the listener eases back in over 60 ms rather
+  than jumping straight to full amplitude. The §6.3 voiced
+  harmonic generator's amplitude tilt 0 → factor·M[l] keeps the
+  first sample at exactly 0 regardless of phase coherence, so
+  there's no zero-crossing click on resumption.
   **Remaining audio polish**: absolute-level calibration against a
   known-good reference decoder (DSD-FME or OP25 — capture a P25
   Phase 1 voice exchange, decode through both, compare RMS +

--- a/internal/voice/imbe/decoder.go
+++ b/internal/voice/imbe/decoder.go
@@ -28,6 +28,26 @@ const (
 	VocoderName = "imbe"
 )
 
+// recoveryRampFactors scales the synthesised amplitudes M[1..L] for
+// the first len(recoveryRampFactors) good frames after a bad-streak
+// state clear. The ramp 0.4 → 0.7 → 1.0 across 60 ms (3 frames at
+// 20 ms each) eases the listener back in after silence rather than
+// jumping straight back to full amplitude — the §6.3 voiced
+// harmonic generator's per-frame amp interpolation provides 20 ms
+// of natural fade, but a 60 ms envelope ramp on top is more
+// musically natural after extended bit loss. The AGC is frozen
+// during recovery so the attenuation is audible (and not
+// compensated by the envelope tracker).
+//
+// Phase-aware: PrevPhase is zeroed by the state clear, so the
+// voiced harmonic generator starts every harmonic at phase 0.
+// The amplitude-tilt 0 → factor·M[l] keeps sample 0 at exactly 0
+// regardless of phase coherence, so there's no zero-crossing
+// click. Subsequent samples mix harmonics at phases that diverge
+// quickly per their ω₀·l·n term, decorrelating the energy
+// naturally.
+var recoveryRampFactors = [3]float64{0.4, 0.7, 1.0}
+
 // Decoder is the pure-Go IMBE 4400 decoder. It owns one
 // mbe.SynthState (cross-frame log2(Ml) prediction memory + voiced
 // phase + amp memory + §6.4 OA tail), one math/rand source for
@@ -43,6 +63,7 @@ const (
 //   - mbe.PredictLog2Ml: §6.1 cross-frame prediction
 //   - mbe.AmplitudesFromLog2Ml: log2(Ml) → linear Ml
 //   - mbe.EnhanceAmplitudes: §6.2 spectral-amplitude enhancement
+//   - recovery ramp (if applicable): scale M by recoveryRampFactors
 //   - mbe.SynthVoiced: §6.3 voiced harmonic generator
 //   - mbe.SynthUnvoicedOverlapAdd: §6.4 unvoiced FFT excitation + OA
 //   - mbe.SynthState.Update{Log2Ml,VoicedState}: roll state forward
@@ -54,7 +75,9 @@ const (
 // mbe.BadFrameAttenuation^badFrameCount. After mbe.MaxBadFrames
 // consecutive bad frames the cache is cleared and Decode returns
 // silence so an extended bad streak fades naturally instead of
-// looping the same envelope forever.
+// looping the same envelope forever. When good frames return after
+// such a clear, the recovery ramp eases the synthesiser back in
+// over 60 ms.
 type Decoder struct {
 	state mbe.SynthState
 	rng   *rand.Rand
@@ -71,6 +94,15 @@ type Decoder struct {
 	// Consecutive bad-frame count. Increments once per replay,
 	// resets to 0 on every good non-silent frame.
 	badFrameCount int
+
+	// recoveryFramesRemaining is the number of upcoming good frames
+	// that should run through the recovery ramp. Set to
+	// len(recoveryRampFactors) by the bad-streak budget-exhaust
+	// path; decremented each good frame; zero outside recovery.
+	// The ramp index is len(recoveryRampFactors) -
+	// recoveryFramesRemaining so the first recovery frame uses the
+	// smallest factor and the last uses 1.0 (full amplitude).
+	recoveryFramesRemaining int
 }
 
 // New returns a fresh Decoder. The unvoiced-excitation noise source
@@ -161,9 +193,13 @@ func (d *Decoder) Decode(frame []byte) ([]int16, error) {
 		// Bad frame with no cache, or bad-frame budget exhausted:
 		// emit silence + clear cache + reset SynthState. AGC envelope
 		// preserved so audio level is consistent when good frames
-		// return.
+		// return. Arm the recovery ramp so the first
+		// len(recoveryRampFactors) good frames after the clear fade
+		// back in at 0.4 → 0.7 → 1.0 amplitude rather than jumping
+		// straight to full level.
 		d.state.Reset()
 		d.clearLastGood()
+		d.recoveryFramesRemaining = len(recoveryRampFactors)
 		d.agc.Apply(pcm, out, true)
 		return out, nil
 
@@ -190,6 +226,30 @@ func (d *Decoder) Decode(frame []byte) ([]int16, error) {
 	mbe.AmplitudesFromLog2Ml(&log2M, m.L, &M)
 	mbe.EnhanceAmplitudes(m, &M)
 
+	// Recovery ramp after a bad-streak state clear: scale the post-
+	// enhancement amplitudes by recoveryRampFactors over the next
+	// len(recoveryRampFactors) good frames so the listener eases
+	// back in. The ramped M flows through synthesis (so SynthState's
+	// PrevMl reflects the actually-synthesised amplitudes) and is
+	// cached as lastGoodM for the bad-frame replay path. That keeps
+	// a fresh bad streak mid-recovery consistent with how the
+	// previous frame actually sounded — replaying from the
+	// pre-ramp full amplitude would create an audible jump.
+	recoveryFreezeAGC := false
+	if d.recoveryFramesRemaining > 0 {
+		idx := len(recoveryRampFactors) - d.recoveryFramesRemaining
+		factor := recoveryRampFactors[idx]
+		for l := 1; l <= m.L; l++ {
+			M[l] *= factor
+		}
+		d.recoveryFramesRemaining--
+		// Freeze the AGC during the ramp so the attenuation is
+		// audible — without freeze the envelope tracker would scale
+		// the output back up to TargetPeak and the listener would
+		// hear no fade-in.
+		recoveryFreezeAGC = true
+	}
+
 	d.synthFrame(m, &log2M, &M, pcm)
 
 	// Cache for the frame-repeat path on a future bad frame.
@@ -197,7 +257,7 @@ func (d *Decoder) Decode(frame []byte) ([]int16, error) {
 	d.lastGoodLog2M = log2M
 	d.lastGoodM = M
 
-	d.agc.Apply(pcm, out, false)
+	d.agc.Apply(pcm, out, recoveryFreezeAGC)
 	return out, nil
 }
 
@@ -250,6 +310,7 @@ func (d *Decoder) Reset() {
 	d.state.Reset()
 	d.agc.Reset()
 	d.clearLastGood()
+	d.recoveryFramesRemaining = 0
 }
 
 // Close releases any resources held by the decoder. The pure-Go

--- a/internal/voice/imbe/decoder_test.go
+++ b/internal/voice/imbe/decoder_test.go
@@ -837,6 +837,199 @@ func TestAGCConfigPreservedAcrossReset(t *testing.T) {
 	}
 }
 
+// TestRecoveryRampArmedOnBadStreakClear: after MaxBadFrames+1
+// consecutive bad frames the decoder hits the budget-exhaustion
+// branch (silence + state clear). That branch arms the recovery
+// ramp so the next len(recoveryRampFactors) good frames fade
+// back in. Pin that recoveryFramesRemaining is set to exactly
+// len(recoveryRampFactors) once the budget is exhausted.
+func TestRecoveryRampArmedOnBadStreakClear(t *testing.T) {
+	d := New()
+	if _, err := d.Decode(make([]byte, FrameBytes)); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	// MaxBadFrames consecutive bad replays — these stay within
+	// budget, so recoveryFramesRemaining is still 0.
+	for i := 0; i < mbe.MaxBadFrames; i++ {
+		if _, err := d.Decode(badFrame()); err != nil {
+			t.Fatalf("bad %d: %v", i, err)
+		}
+	}
+	if d.recoveryFramesRemaining != 0 {
+		t.Errorf("after %d bads (within budget): recoveryFramesRemaining = %d, want 0",
+			mbe.MaxBadFrames, d.recoveryFramesRemaining)
+	}
+	// One more bad frame trips the budget-exhaust branch.
+	if _, err := d.Decode(badFrame()); err != nil {
+		t.Fatalf("budget-exhaust: %v", err)
+	}
+	if d.recoveryFramesRemaining != len(recoveryRampFactors) {
+		t.Errorf("after budget exhaust: recoveryFramesRemaining = %d, want %d",
+			d.recoveryFramesRemaining, len(recoveryRampFactors))
+	}
+}
+
+// TestRecoveryRampNotArmedDuringBudgetedBadStreak: bad frames
+// within budget go through the replay path which DOES NOT arm
+// the recovery ramp — those frames are bridging signal loss with
+// the cached params, so a fade-in on top would double-attenuate.
+func TestRecoveryRampNotArmedDuringBudgetedBadStreak(t *testing.T) {
+	d := New()
+	if _, err := d.Decode(make([]byte, FrameBytes)); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	for i := 0; i < mbe.MaxBadFrames; i++ {
+		if _, err := d.Decode(badFrame()); err != nil {
+			t.Fatalf("bad %d: %v", i, err)
+		}
+		if d.recoveryFramesRemaining != 0 {
+			t.Errorf("after bad %d (within budget): "+
+				"recoveryFramesRemaining = %d, want 0",
+				i, d.recoveryFramesRemaining)
+		}
+	}
+}
+
+// TestRecoveryRampDecrementsOverGoodFrames: once armed, each
+// good frame decrements the recovery counter. After
+// len(recoveryRampFactors) good frames the counter is back to 0
+// and subsequent frames take the normal path.
+func TestRecoveryRampDecrementsOverGoodFrames(t *testing.T) {
+	d := New()
+	if _, err := d.Decode(make([]byte, FrameBytes)); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	// MaxBadFrames + 1 to trip budget exhaust.
+	for i := 0; i <= mbe.MaxBadFrames; i++ {
+		if _, err := d.Decode(badFrame()); err != nil {
+			t.Fatalf("bad %d: %v", i, err)
+		}
+	}
+	if d.recoveryFramesRemaining != len(recoveryRampFactors) {
+		t.Fatalf("setup: recoveryFramesRemaining = %d, want %d",
+			d.recoveryFramesRemaining, len(recoveryRampFactors))
+	}
+	// Walk through the recovery ramp.
+	for i := len(recoveryRampFactors); i > 0; i-- {
+		if d.recoveryFramesRemaining != i {
+			t.Errorf("before good frame %d: recoveryFramesRemaining = %d, want %d",
+				len(recoveryRampFactors)-i+1, d.recoveryFramesRemaining, i)
+		}
+		if _, err := d.Decode(make([]byte, FrameBytes)); err != nil {
+			t.Fatalf("good frame: %v", err)
+		}
+	}
+	if d.recoveryFramesRemaining != 0 {
+		t.Errorf("after %d good frames: recoveryFramesRemaining = %d, want 0",
+			len(recoveryRampFactors), d.recoveryFramesRemaining)
+	}
+	// Subsequent good frames don't underflow the counter.
+	if _, err := d.Decode(make([]byte, FrameBytes)); err != nil {
+		t.Fatalf("post-recovery good frame: %v", err)
+	}
+	if d.recoveryFramesRemaining != 0 {
+		t.Errorf("post-recovery: recoveryFramesRemaining = %d, want 0",
+			d.recoveryFramesRemaining)
+	}
+}
+
+// TestRecoveryRampAttenuatesOutput: with the AGC frozen during
+// recovery, the first good frame's output peak should be
+// noticeably lower than a fresh-decoder baseline at the same
+// frame index. A frame at recoveryRampFactors[0] = 0.4 should
+// produce roughly 0.4× the baseline output peak.
+//
+// Tolerance is loose: the §6.4 unvoiced noise + AGC envelope
+// state introduce per-frame variance, but the 0.4 vs 1.0 ratio
+// is large enough to detect even with that noise.
+func TestRecoveryRampAttenuatesOutput(t *testing.T) {
+	// Baseline: fresh decoder, decode one frame.
+	baseline := New()
+	baseOut, err := baseline.Decode(make([]byte, FrameBytes))
+	if err != nil {
+		t.Fatalf("baseline: %v", err)
+	}
+	basePeak := agcPeak(baseOut)
+
+	// Recovery: drive a decoder through bad-streak exhaustion,
+	// then decode one good frame. Use the same seed so the
+	// unvoiced noise stream matches the baseline.
+	rec := New()
+	if _, err := rec.Decode(make([]byte, FrameBytes)); err != nil {
+		t.Fatalf("rec seed: %v", err)
+	}
+	for i := 0; i <= mbe.MaxBadFrames; i++ {
+		if _, err := rec.Decode(badFrame()); err != nil {
+			t.Fatalf("rec bad %d: %v", i, err)
+		}
+	}
+	recOut, err := rec.Decode(make([]byte, FrameBytes))
+	if err != nil {
+		t.Fatalf("rec good: %v", err)
+	}
+	recPeak := agcPeak(recOut)
+
+	// Recovery peak should be substantially below baseline. The
+	// 0.4 factor + frozen AGC means the output is roughly
+	// 0.4·baseline, but the AGC envelope at the moment of freeze
+	// reflects the pre-bad-streak state which can drift slightly
+	// from baseline. Allow a wide window: recovery peak should be
+	// less than 70% of baseline.
+	if recPeak >= basePeak*7/10 {
+		t.Errorf("recovery peak = %d, baseline peak = %d "+
+			"(recovery/baseline = %.2f, want < 0.70)",
+			recPeak, basePeak, float64(recPeak)/float64(basePeak))
+	}
+}
+
+// TestRecoveryRampClearedByReset: explicit Reset on a decoder
+// mid-recovery clears the counter so the next stream's first
+// frame doesn't get attenuated. Pins the "Reset = clean slate"
+// contract.
+func TestRecoveryRampClearedByReset(t *testing.T) {
+	d := New()
+	if _, err := d.Decode(make([]byte, FrameBytes)); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	for i := 0; i <= mbe.MaxBadFrames; i++ {
+		if _, err := d.Decode(badFrame()); err != nil {
+			t.Fatalf("bad %d: %v", i, err)
+		}
+	}
+	if d.recoveryFramesRemaining == 0 {
+		t.Fatal("setup: recovery ramp not armed")
+	}
+	d.Reset()
+	if d.recoveryFramesRemaining != 0 {
+		t.Errorf("after Reset: recoveryFramesRemaining = %d, want 0",
+			d.recoveryFramesRemaining)
+	}
+}
+
+// TestRecoveryRampFactorsMonotonicallyIncrease: the ramp must be
+// non-decreasing (so each step eases the listener back without
+// regressing). Pins that any future re-tuning of the ramp keeps
+// the monotonic-increase property.
+func TestRecoveryRampFactorsMonotonicallyIncrease(t *testing.T) {
+	prev := 0.0
+	for i, f := range recoveryRampFactors {
+		if f < prev {
+			t.Errorf("recoveryRampFactors[%d] = %v < previous %v "+
+				"(ramp must be non-decreasing)", i, f, prev)
+		}
+		if f <= 0 || f > 1 {
+			t.Errorf("recoveryRampFactors[%d] = %v out of (0, 1]",
+				i, f)
+		}
+		prev = f
+	}
+	if recoveryRampFactors[len(recoveryRampFactors)-1] != 1.0 {
+		t.Errorf("ramp's last factor = %v, want exactly 1.0 "+
+			"(must reach full amplitude before normal operation resumes)",
+			recoveryRampFactors[len(recoveryRampFactors)-1])
+	}
+}
+
 // TestFrameRepeatFreezesAGC: a bad-frame replay must not perturb
 // the AGC envelope (the freeze contract is what makes the
 // attenuation audible — without it AGC would partially compensate).

--- a/internal/voice/imbe/doc.go
+++ b/internal/voice/imbe/doc.go
@@ -158,13 +158,27 @@
 //     prior package-level constants with cfg field reads in
 //     applyAGC. See decoder.go.
 //
-//  5f. Remaining polish: absolute-level calibration against a
+//  5f. Phase-aware bad-frame fade-in. After MaxBadFrames+1
+//     consecutive bad frames the SynthState clear leaves
+//     PrevPhase + PrevMl at zero; the next good frame's voiced
+//     harmonics start at phase 0 with a linear amplitude tilt
+//     0 → M[l] across 160 samples. The amplitude tilt naturally
+//     keeps sample 0 at exactly 0 regardless of phase coherence,
+//     but a 60 ms envelope ramp on top (recoveryRampFactors =
+//     {0.4, 0.7, 1.0}) eases the listener back in over three
+//     frames rather than jumping straight to full amplitude. The
+//     AGC freezes during recovery so the attenuation is audible.
+//     The ramped M is cached for the bad-frame replay path so a
+//     fresh bad streak mid-recovery replays from the actually-
+//     synthesised level rather than from full amplitude. See
+//     decoder.go.
+//
+//  5g. Remaining polish: absolute-level calibration against a
 //     known-good reference decoder (DSD-FME / OP25 — capture a P25
 //     Phase 1 voice exchange, decode through both, compare RMS +
 //     cross-correlation against the reference WAV under
 //     internal/voice/imbe/testdata/); enhancement filter tuning if
-//     real-world frames show mid-band envelope drift; phase-aware
-//     bad-frame fade-in when good frames return after a streak.
+//     real-world frames show mid-band envelope drift.
 //
 // Patent + licensing context lives in docs/vocoders.md. The core US
 // IMBE patents have expired; this implementation is built from the


### PR DESCRIPTION
## Summary

Step 5f from the IMBE roadmap. After `mbe.MaxBadFrames+1` consecutive bad frames the SynthState clear leaves `PrevPhase` + `PrevMl` at zero; the next good frame's voiced harmonics start at phase 0 with a linear amplitude tilt `0 → M[l]` across 160 samples. The amplitude tilt naturally keeps sample 0 at exactly 0 (no zero-crossing click), but a sudden return to full amplitude on frame N+1 is still audible as an abrupt level jump.

This PR layers a 60 ms envelope ramp on top: when the bad-streak budget-exhaust branch fires, it arms a `recoveryFramesRemaining` counter at `len(recoveryRampFactors)`. The next three good frames scale post-enhancement `M[1..L]` by `recoveryRampFactors = {0.4, 0.7, 1.0}` and freeze the AGC so the attenuation is audible rather than compensated.

### Why "phase-aware"

`PrevPhase[l]` is zeroed by the state clear and `PrevMl[l]` is also zero, so the §6.3 voiced harmonic generator's amplitude tilt `0 → factor·M[l]` gives sample 0 at exactly 0 regardless of harmonic phase coherence. Subsequent samples mix harmonics whose phases diverge per their `ω₀·l·n` term, decorrelating the energy naturally. The recovery ramp sits on top of that, easing the listener back over 60 ms rather than letting the per-frame interpolation provide just 20 ms of fade.

### Caching

The ramped `M` flows through synthesis and is stored as `lastGoodM`. A bad frame mid-recovery therefore replays from the actually-synthesised level rather than from full amplitude — a mid-recovery bad streak would otherwise produce a level jump in the bad-frame replay path because `mbe.SynthState.PrevMl` reflects the ramped synthesis output, not the unscaled M.

### Tests (+6 over previous 67; total now 73)

- `TestRecoveryRampArmedOnBadStreakClear`: budget-exhaust trips the arm; within-budget bads don't.
- `TestRecoveryRampNotArmedDuringBudgetedBadStreak`: each bad frame within budget keeps `recoveryFramesRemaining` at 0.
- `TestRecoveryRampDecrementsOverGoodFrames`: counter walks 3 → 2 → 1 → 0 over consecutive good frames; subsequent frames don't underflow.
- `TestRecoveryRampAttenuatesOutput`: a recovery frame's output peak is < 70 % of a fresh-decoder baseline (the 0.4× factor + frozen AGC produces an audible drop).
- `TestRecoveryRampClearedByReset`: explicit `Reset` zeros the counter mid-recovery.
- `TestRecoveryRampFactorsMonotonicallyIncrease`: the ramp must be non-decreasing, all values in `(0, 1]`, with the final factor exactly `1.0`.

### Docs

- `internal/voice/imbe/doc.go` roadmap step 5f is now the shipped phase-aware fade-in; the calibration follow-up moves to step 5g.
- `README.md` IMBE roadmap entry adds a "Phase-aware fade-in" paragraph between the existing frame-repeat description and the remaining-polish list.

## Test plan

- [x] `go vet ./internal/voice/...` clean
- [x] `go test -race -count=1 ./internal/voice/...` all pass (73 imbe + 40 ambe2 + others, all green)
- [x] Recovery frame's output peak < 70% of a fresh-decoder baseline at the same frame index
- [x] Within-budget bad-frame replays do not arm the recovery ramp
- [ ] After merge: capture a P25 P1 voice exchange with intentional FEC-loss windows; listen-test that signal recovery sounds natural rather than abrupt

## Files

```
README.md                           |   8 ++
internal/voice/imbe/decoder.go      |  67 ++++++++++++-
internal/voice/imbe/decoder_test.go | 193 ++++++++++++++++++++++++++++++++++++
internal/voice/imbe/doc.go          |  20 +++-
4 files changed, 282 insertions(+), 6 deletions(-)
```

https://claude.ai/code/session_01SvuTSKyeTrSX9V352L9GVH

---
_Generated by [Claude Code](https://claude.ai/code/session_01SvuTSKyeTrSX9V352L9GVH)_