### PR TITLE
voice + cmd/gophertrunk: out-of-band raw → WAV decode (gophertrunk decode)

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,13 @@ make integration   # boots the wired daemon end-to-end (no SDR needed)
 ./bin/gophertrunk version
 ./bin/gophertrunk sdr list                # enumerates attached dongles
 ./bin/gophertrunk run -config config.yaml
+
+# Out-of-band: decode a captured .raw frame sidecar to a WAV using
+# the pure-Go IMBE / AMBE+2 vocoders. The .raw sidecar is written
+# alongside each call's WAV when the recorder's raw-frames option
+# is enabled.
+./bin/gophertrunk decode -in call.raw -out call.wav -vocoder imbe
+./bin/gophertrunk decode -list-vocoders
 ```
 
 A starter [`config.example.yaml`](config.example.yaml) is in the

--- a/cmd/gophertrunk/decode.go
+++ b/cmd/gophertrunk/decode.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/MattCheramie/GopherTrunk/internal/voice"
+)
+
+// runDecode is the entry point for `gophertrunk decode`. It reads
+// a captured .raw vocoder-frame sidecar and writes a playable WAV
+// using one of the registered vocoder backends. Operators use this
+// to decode frames after a session — the daemon stores raw frames
+// alongside each call so post-processing can defer the
+// vocoder-choice decision.
+//
+// Usage:
+//
+//	gophertrunk decode -in <path> -out <path> [-vocoder <name>]
+//	cat session.raw | gophertrunk decode -vocoder imbe -out out.wav
+//	gophertrunk decode -in session.raw -out out.wav -vocoder ambe2
+//
+// The vocoder defaults to "imbe" since P25 Phase 1 is the most
+// common digital protocol on US public-safety bands. The
+// available names match the keys registered in
+// voice.DefaultRegistry — typically "imbe", "ambe2", and "null".
+func runDecode(args []string) {
+	fs := flag.NewFlagSet("decode", flag.ExitOnError)
+	in := fs.String("in", "-", "raw vocoder-frame input path; '-' reads stdin")
+	out := fs.String("out", "", "WAV output path (required; must be a regular file for the WAV header to be patched)")
+	vocoderName := fs.String("vocoder", "imbe", "vocoder name from the registry (imbe, ambe2, null, ...)")
+	listVocoders := fs.Bool("list-vocoders", false, "print the registered vocoder names and exit")
+	fs.Usage = func() {
+		fmt.Fprintln(fs.Output(), `gophertrunk decode — decode a captured raw vocoder-frame stream into a WAV.
+
+USAGE:
+  gophertrunk decode -in <path> -out <path> [-vocoder <name>]
+
+EXAMPLES:
+  # Decode an IMBE .raw sidecar from a P25 Phase 1 capture
+  gophertrunk decode -in call.raw -out call.wav -vocoder imbe
+
+  # Decode AMBE+2 frames piped from a fixture script
+  cat dmr.raw | gophertrunk decode -vocoder ambe2 -out dmr.wav
+
+  # List the vocoder names this binary knows about
+  gophertrunk decode -list-vocoders
+
+FLAGS:`)
+		fs.PrintDefaults()
+	}
+	_ = fs.Parse(args)
+
+	if *listVocoders {
+		fmt.Println(strings.Join(voice.DefaultRegistry.Names(), "\n"))
+		return
+	}
+
+	if *out == "" {
+		fmt.Fprintln(os.Stderr, "decode: -out is required")
+		fs.Usage()
+		os.Exit(2)
+	}
+
+	reader, closer, err := openInput(*in)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "decode: open input: %v\n", err)
+		os.Exit(1)
+	}
+	defer closer()
+
+	outFile, err := os.Create(*out)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "decode: create output: %v\n", err)
+		os.Exit(1)
+	}
+	defer outFile.Close()
+
+	frames, decodeErr := voice.DecodeStream(reader, *vocoderName, outFile)
+	if errors.Is(decodeErr, voice.ErrPartialFrame) {
+		fmt.Fprintf(os.Stderr, "decode: input ended mid-frame after %d complete frames; WAV truncated to that point\n", frames)
+		// Don't exit non-zero — the WAV is playable up to the
+		// partial trailer, which is the operator-friendly outcome.
+	} else if decodeErr != nil {
+		fmt.Fprintf(os.Stderr, "decode: %v\n", decodeErr)
+		os.Exit(1)
+	}
+	fmt.Printf("decoded %d frame(s) → %s (%d ms of audio)\n",
+		frames, *out, frames*20)
+}
+
+// openInput returns a Reader for the chosen path. "-" maps to
+// stdin; everything else is opened as a regular file. The closer
+// is a no-op for stdin and a file-close otherwise.
+func openInput(path string) (io.Reader, func(), error) {
+	if path == "-" {
+		return os.Stdin, func() {}, nil
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	return f, func() { f.Close() }, nil
+}

--- a/cmd/gophertrunk/main.go
+++ b/cmd/gophertrunk/main.go
@@ -40,6 +40,8 @@ func main() {
 		runSDR(os.Args[2:])
 	case "tui":
 		runTUI(os.Args[2:])
+	case "decode":
+		runDecode(os.Args[2:])
 	case "daemon", "run":
 		runDaemon(os.Args[2:])
 	case "help", "--help", "-h":
@@ -56,6 +58,7 @@ USAGE:
   gophertrunk [run] [-config path]    run the daemon (default)
   gophertrunk sdr list                list discovered SDR devices
   gophertrunk tui [-server URL]       open the read-only operator TUI
+  gophertrunk decode [flags]          decode a captured .raw frame stream into a WAV
   gophertrunk version                 print build version
   gophertrunk help                    show this message`)
 }

--- a/docs/vocoders.md
+++ b/docs/vocoders.md
@@ -43,7 +43,7 @@ type Vocoder interface {
 | ------------------------ | ------------ | -------- | ----------------------------------------------- |
 | `null` (silence)         | none         | yes      | Always available                                |
 | `imbe` (pure-Go, P25 P1) | none         | yes      | Producing intelligible audio; calibration TODO  |
-| `ambe2` (pure-Go)        | none         | yes      | Producing audio; calibration TODO; tones → silence |
+| `ambe2` (pure-Go)        | none         | yes      | Producing audio; calibration TODO; dual-tone → silence |
 | `dvsi` (USB-3000 chip)   | `-tags dvsi` | **no**   | Hardware backend, planned                       |
 
 The recorder always emits a raw-frame sidecar (`.raw` next to the WAV)
@@ -51,6 +51,30 @@ when configured, so users can run their own decoder on the captured
 frames without trusting the in-binary vocoders. This is the escape
 hatch for operators who want bit-exact mbelib / DSD-FME / OP25 output
 or who prefer to defer the decoding choice to post-processing.
+
+### Decoding a captured .raw sidecar
+
+The daemon ships a `decode` subcommand that runs the registered
+in-binary vocoders against a `.raw` frame stream out-of-band:
+
+```sh
+gophertrunk decode -in call.raw -out call.wav -vocoder imbe
+gophertrunk decode -in dmr.raw  -out dmr.wav  -vocoder ambe2
+gophertrunk decode -list-vocoders   # enumerate registered names
+```
+
+Stdin / stdout work for the input via `-in -`, so capture pipelines
+can stream into the decoder without a temporary file:
+
+```sh
+some-source | gophertrunk decode -vocoder imbe -out out.wav
+```
+
+The library function backing this — `voice.DecodeStream(in,
+vocoderName, out)` — is exported from `internal/voice` so other
+consumers (web UIs, batch processors, post-mortem analysis tools)
+can reuse the same decode path without spawning a binary. See
+`internal/voice/streamdecode.go`.
 
 ## Implementation notes
 

--- a/internal/voice/ambe2/streamdecode_integration_test.go
+++ b/internal/voice/ambe2/streamdecode_integration_test.go
@@ -1,0 +1,106 @@
+package ambe2
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/voice"
+)
+
+// memWriteSeeker mirrors the shape used by voice's wav_test.go so
+// ambe2-package tests can exercise voice.DecodeStream without
+// touching the filesystem.
+type memWriteSeeker struct {
+	buf []byte
+	pos int64
+}
+
+func (m *memWriteSeeker) Write(p []byte) (int, error) {
+	end := m.pos + int64(len(p))
+	if end > int64(len(m.buf)) {
+		grown := make([]byte, end)
+		copy(grown, m.buf)
+		m.buf = grown
+	}
+	copy(m.buf[m.pos:], p)
+	m.pos = end
+	return len(p), nil
+}
+
+func (m *memWriteSeeker) Seek(off int64, whence int) (int64, error) {
+	switch whence {
+	case io.SeekStart:
+		m.pos = off
+	case io.SeekCurrent:
+		m.pos += off
+	case io.SeekEnd:
+		m.pos = int64(len(m.buf)) + off
+	}
+	return m.pos, nil
+}
+
+const wavHeaderSize = 44
+
+// TestDecodeStreamThroughAmbe2: voice.DecodeStream with name
+// "ambe2" pulls the pure-Go AMBE+2 decoder out of the registry
+// and produces a playable WAV from a stream of synthetic AMBE+2
+// frames. Pins the out-of-band ".raw → .wav" pipeline operators
+// use to decode captured P25 P2 / DMR / NXDN frames after a
+// session.
+func TestDecodeStreamThroughAmbe2(t *testing.T) {
+	const n = 4
+	frame := make([]byte, FrameBytes) // all zero ⇒ b₀=0 voice
+	in := bytes.NewReader(bytes.Repeat(frame, n))
+	var sink memWriteSeeker
+	frames, err := voice.DecodeStream(in, VocoderName, &sink)
+	if err != nil {
+		t.Fatalf("voice.DecodeStream: %v", err)
+	}
+	if frames != n {
+		t.Errorf("frames = %d, want %d", frames, n)
+	}
+	wantBytes := wavHeaderSize + n*160*2
+	if len(sink.buf) != wantBytes {
+		t.Errorf("wrote %d bytes, want %d", len(sink.buf), wantBytes)
+	}
+	// AMBE+2 voice synthesis produces non-zero PCM through the
+	// shared mbe pipeline; confirm at least some samples are
+	// non-zero.
+	var nonZero int
+	for i := wavHeaderSize; i+1 < len(sink.buf); i += 2 {
+		if int16(binary.LittleEndian.Uint16(sink.buf[i:i+2])) != 0 {
+			nonZero++
+		}
+	}
+	if nonZero == 0 {
+		t.Error("all samples zero; AMBE+2 synthesis didn't run through DecodeStream")
+	}
+}
+
+// TestDecodeStreamToneFrameThroughAmbe2: a valid single-tone
+// AMBE+2 frame (b₁ ∈ [5, 122]) routed through DecodeStream
+// produces non-zero PCM (the synthSingleTone path). Pins that
+// out-of-band decode honours all the AMBE+2 frame paths, not just
+// voice.
+func TestDecodeStreamToneFrameThroughAmbe2(t *testing.T) {
+	in := bytes.NewReader(singleToneFrame(12, 200))
+	var sink memWriteSeeker
+	frames, err := voice.DecodeStream(in, VocoderName, &sink)
+	if err != nil {
+		t.Fatalf("voice.DecodeStream: %v", err)
+	}
+	if frames != 1 {
+		t.Errorf("frames = %d, want 1", frames)
+	}
+	var nonZero int
+	for i := wavHeaderSize; i+1 < len(sink.buf); i += 2 {
+		if int16(binary.LittleEndian.Uint16(sink.buf[i:i+2])) != 0 {
+			nonZero++
+		}
+	}
+	if nonZero == 0 {
+		t.Error("tone frame produced no audio through DecodeStream")
+	}
+}

--- a/internal/voice/imbe/streamdecode_integration_test.go
+++ b/internal/voice/imbe/streamdecode_integration_test.go
@@ -1,0 +1,107 @@
+package imbe
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/voice"
+)
+
+// memWriteSeeker mirrors the shape used by voice's wav_test.go so
+// imbe-package tests can exercise voice.DecodeStream without
+// touching the filesystem. The voice package's memWriteSeeker is
+// test-internal so we redefine here.
+type memWriteSeeker struct {
+	buf []byte
+	pos int64
+}
+
+func (m *memWriteSeeker) Write(p []byte) (int, error) {
+	end := m.pos + int64(len(p))
+	if end > int64(len(m.buf)) {
+		grown := make([]byte, end)
+		copy(grown, m.buf)
+		m.buf = grown
+	}
+	copy(m.buf[m.pos:], p)
+	m.pos = end
+	return len(p), nil
+}
+
+func (m *memWriteSeeker) Seek(off int64, whence int) (int64, error) {
+	switch whence {
+	case io.SeekStart:
+		m.pos = off
+	case io.SeekCurrent:
+		m.pos += off
+	case io.SeekEnd:
+		m.pos = int64(len(m.buf)) + off
+	}
+	return m.pos, nil
+}
+
+const wavHeaderSize = 44
+
+// TestDecodeStreamThroughImbe: voice.DecodeStream with name "imbe"
+// pulls the pure-Go IMBE decoder out of the registry and produces
+// a playable WAV from a stream of synthetic IMBE frames. Pins the
+// out-of-band ".raw → .wav" pipeline operators use to decode
+// captured frames after a session.
+func TestDecodeStreamThroughImbe(t *testing.T) {
+	const n = 5
+	frame := make([]byte, FrameBytes) // all zero ⇒ b₀=0 voice
+	in := bytes.NewReader(bytes.Repeat(frame, n))
+	var sink memWriteSeeker
+	frames, err := voice.DecodeStream(in, VocoderName, &sink)
+	if err != nil {
+		t.Fatalf("voice.DecodeStream: %v", err)
+	}
+	if frames != n {
+		t.Errorf("frames = %d, want %d", frames, n)
+	}
+	// One IMBE frame at 8 kHz / 20 ms = 160 samples × 2 bytes per
+	// sample. Plus the 44-byte WAV header.
+	wantBytes := wavHeaderSize + n*160*2
+	if len(sink.buf) != wantBytes {
+		t.Errorf("wrote %d bytes, want %d", len(sink.buf), wantBytes)
+	}
+	// Confirm the WAV's data-chunk length matches.
+	dataSize := binary.LittleEndian.Uint32(sink.buf[40:44])
+	if dataSize != uint32(n*160*2) {
+		t.Errorf("data chunk size = %d, want %d", dataSize, n*160*2)
+	}
+	// Confirm at least some samples are non-zero (synthesis ran).
+	var nonZero int
+	for i := wavHeaderSize; i+1 < len(sink.buf); i += 2 {
+		if int16(binary.LittleEndian.Uint16(sink.buf[i:i+2])) != 0 {
+			nonZero++
+		}
+	}
+	if nonZero == 0 {
+		t.Error("all samples zero; IMBE synthesis didn't run through DecodeStream")
+	}
+}
+
+// TestDecodeStreamSilenceFrameThroughImbe: a single IMBE silence-
+// window frame (b₀=216) decodes to all-zero PCM through the
+// stream API. Mirrors the per-decoder TestDecodeReturnsSilenceForB0SilenceFrame.
+func TestDecodeStreamSilenceFrameThroughImbe(t *testing.T) {
+	frame := make([]byte, FrameBytes)
+	frame[0] = 0xD8 // b₀ = 216 (silence window)
+	var sink memWriteSeeker
+	frames, err := voice.DecodeStream(bytes.NewReader(frame), VocoderName, &sink)
+	if err != nil {
+		t.Fatalf("voice.DecodeStream: %v", err)
+	}
+	if frames != 1 {
+		t.Errorf("frames = %d, want 1", frames)
+	}
+	for i := wavHeaderSize; i+1 < len(sink.buf); i += 2 {
+		if s := int16(binary.LittleEndian.Uint16(sink.buf[i : i+2])); s != 0 {
+			t.Fatalf("sample[%d] = %d, want 0 (silence frame)",
+				(i-wavHeaderSize)/2, s)
+		}
+	}
+}

--- a/internal/voice/streamdecode.go
+++ b/internal/voice/streamdecode.go
@@ -1,0 +1,96 @@
+package voice
+
+import (
+	"errors"
+	"fmt"
+	"io"
+)
+
+// ErrPartialFrame is returned by DecodeStream when the input ends
+// in the middle of a vocoder frame — the trailing bytes don't make
+// up a complete frame for the chosen vocoder. Callers can inspect
+// the byte count returned alongside the error to decide whether
+// the partial trailer is recoverable (typically: it isn't).
+var ErrPartialFrame = errors.New("voice: input ended mid-frame")
+
+// DecodeStream reads vocoder frames from in, decodes each via the
+// named vocoder from DefaultRegistry, and writes 8 kHz / 16-bit /
+// mono PCM as a WAV stream to out. Returns the number of frames
+// decoded successfully.
+//
+// out must be an io.WriteSeeker so the WAV header length fields
+// can be patched on close (file handles satisfy this; in-memory
+// callers can wrap a bytes.Buffer with a seeker shim).
+//
+// Frame size is determined by the chosen vocoder via FrameSize().
+// Input must be an exact multiple of that frame size; trailing
+// bytes are reported via ErrPartialFrame after the leading
+// complete frames have been written.
+//
+// On a per-frame Decode error, DecodeStream stops and returns the
+// number of frames decoded so far + the error. The WAV is closed
+// (length fields patched) before returning so callers get a
+// playable file even on partial decode.
+func DecodeStream(in io.Reader, vocoderName string, out io.WriteSeeker) (int, error) {
+	v, err := DefaultRegistry.New(vocoderName)
+	if err != nil {
+		return 0, err
+	}
+	defer v.Close()
+	return DecodeStreamWithVocoder(in, v, out)
+}
+
+// DecodeStreamWithVocoder is the lower-level entry point: callers
+// supply a constructed Vocoder (so they can pin reproducibility
+// via NewWithSeed or tune AGC via NewWithConfig before handing it
+// off). Behaviour matches DecodeStream — see that function's doc
+// for the contract.
+//
+// The Vocoder is not Reset before use; the caller controls
+// initial state. The caller is responsible for closing v.
+func DecodeStreamWithVocoder(in io.Reader, v Vocoder, out io.WriteSeeker) (int, error) {
+	frameSize := v.FrameSize()
+	if frameSize <= 0 {
+		return 0, fmt.Errorf("voice: vocoder %q reports invalid FrameSize=%d", v.Name(), frameSize)
+	}
+
+	wav, err := NewWavWriter(out, pcmHzDefault)
+	if err != nil {
+		return 0, err
+	}
+
+	frame := make([]byte, frameSize)
+	frames := 0
+	for {
+		// io.ReadFull returns io.EOF if zero bytes were read,
+		// io.ErrUnexpectedEOF on a partial read.
+		_, err := io.ReadFull(in, frame)
+		if err == io.EOF {
+			break
+		}
+		if err == io.ErrUnexpectedEOF {
+			_ = wav.Close()
+			return frames, ErrPartialFrame
+		}
+		if err != nil {
+			_ = wav.Close()
+			return frames, err
+		}
+
+		samples, err := v.Decode(frame)
+		if err != nil {
+			_ = wav.Close()
+			return frames, fmt.Errorf("voice: decode frame %d: %w", frames, err)
+		}
+		if err := wav.WriteSamples(samples); err != nil {
+			_ = wav.Close()
+			return frames, fmt.Errorf("voice: write frame %d: %w", frames, err)
+		}
+		frames++
+	}
+
+	if err := wav.Close(); err != nil {
+		return frames, err
+	}
+	return frames, nil
+}

--- a/internal/voice/streamdecode_test.go
+++ b/internal/voice/streamdecode_test.go
@@ -1,0 +1,185 @@
+package voice
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"io"
+	"testing"
+)
+
+// nullFrameSize is the frame size we use for NullVocoder-driven
+// tests. Anything > 0 works; 11 mirrors the IMBE contract so the
+// tests read naturally to a future maintainer who's seen the imbe
+// package.
+const nullFrameSize = 11
+
+func TestDecodeStreamUnknownVocoder(t *testing.T) {
+	var sink memWriteSeeker
+	frames, err := DecodeStream(bytes.NewReader(nil), "no-such-vocoder", &sink)
+	if err == nil {
+		t.Fatal("expected an error for unknown vocoder")
+	}
+	if frames != 0 {
+		t.Errorf("frames = %d, want 0 on registry miss", frames)
+	}
+}
+
+// TestDecodeStreamEmptyInput: zero input bytes still produce a
+// valid (zero-length data chunk) WAV header so callers always get
+// a playable file. We use the always-registered "null" vocoder so
+// the voice package's tests don't depend on imbe / ambe2 (which
+// would create an import cycle).
+func TestDecodeStreamEmptyInput(t *testing.T) {
+	var sink memWriteSeeker
+	frames, err := DecodeStream(bytes.NewReader(nil), "null", &sink)
+	if err != nil {
+		t.Fatalf("DecodeStream: %v", err)
+	}
+	if frames != 0 {
+		t.Errorf("frames = %d, want 0", frames)
+	}
+	if len(sink.buf) != wavHeaderSize {
+		t.Errorf("wrote %d bytes, want exactly the %d-byte header", len(sink.buf), wavHeaderSize)
+	}
+	if string(sink.buf[0:4]) != "RIFF" {
+		t.Errorf("missing RIFF magic")
+	}
+	dataSize := binary.LittleEndian.Uint32(sink.buf[40:44])
+	if dataSize != 0 {
+		t.Errorf("data chunk size = %d, want 0 for empty input", dataSize)
+	}
+}
+
+func TestDecodeStreamMultipleFrames(t *testing.T) {
+	const n = 4
+	v := NewNullVocoder(nullFrameSize)
+	in := bytes.NewReader(make([]byte, n*nullFrameSize))
+	var sink memWriteSeeker
+	frames, err := DecodeStreamWithVocoder(in, v, &sink)
+	if err != nil {
+		t.Fatalf("DecodeStreamWithVocoder: %v", err)
+	}
+	if frames != n {
+		t.Errorf("frames = %d, want %d", frames, n)
+	}
+	// NullVocoder emits 160 zero samples per frame; total payload =
+	// n * 160 * 2 bytes.
+	wantBytes := wavHeaderSize + n*pcmHzDefault*frameDurationMs/1000*2
+	if len(sink.buf) != wantBytes {
+		t.Errorf("wrote %d bytes, want %d", len(sink.buf), wantBytes)
+	}
+	// All samples must be zero (NullVocoder emits silence).
+	for i := wavHeaderSize; i+1 < len(sink.buf); i += 2 {
+		s := int16(binary.LittleEndian.Uint16(sink.buf[i : i+2]))
+		if s != 0 {
+			t.Fatalf("sample[%d] = %d, want 0", (i-wavHeaderSize)/2, s)
+		}
+	}
+}
+
+func TestDecodeStreamPartialFrameReturnsError(t *testing.T) {
+	v := NewNullVocoder(nullFrameSize)
+	// One full frame + 3 trailing bytes (incomplete next frame).
+	in := bytes.NewReader(append(make([]byte, nullFrameSize), 0xAA, 0xBB, 0xCC))
+	var sink memWriteSeeker
+	frames, err := DecodeStreamWithVocoder(in, v, &sink)
+	if !errors.Is(err, ErrPartialFrame) {
+		t.Errorf("err = %v, want ErrPartialFrame", err)
+	}
+	if frames != 1 {
+		t.Errorf("frames = %d, want 1 (one complete frame written before the partial)", frames)
+	}
+	// WAV must still be closed (header patched) so the file is
+	// playable up to the partial point.
+	dataSize := binary.LittleEndian.Uint32(sink.buf[40:44])
+	wantData := uint32(pcmHzDefault * frameDurationMs / 1000 * 2)
+	if dataSize != wantData {
+		t.Errorf("data chunk size = %d, want %d (one frame written before partial)",
+			dataSize, wantData)
+	}
+}
+
+// TestDecodeStreamWavSampleRateIs8kHz: pin the WAV header's
+// sample-rate / channel / bits-per-sample fields so future
+// plumbing changes don't accidentally produce wrongly-labelled
+// WAVs (which most players would re-pitch or refuse).
+func TestDecodeStreamWavSampleRateIs8kHz(t *testing.T) {
+	var sink memWriteSeeker
+	v := NewNullVocoder(nullFrameSize)
+	if _, err := DecodeStreamWithVocoder(bytes.NewReader(make([]byte, nullFrameSize)), v, &sink); err != nil {
+		t.Fatalf("DecodeStream: %v", err)
+	}
+	rate := binary.LittleEndian.Uint32(sink.buf[24:28])
+	if rate != pcmHzDefault {
+		t.Errorf("sample rate = %d, want %d", rate, pcmHzDefault)
+	}
+	bps := binary.LittleEndian.Uint16(sink.buf[34:36])
+	if bps != wavBitsPerSample {
+		t.Errorf("bits per sample = %d, want %d", bps, wavBitsPerSample)
+	}
+	channels := binary.LittleEndian.Uint16(sink.buf[22:24])
+	if channels != wavChannels {
+		t.Errorf("channel count = %d, want %d", channels, wavChannels)
+	}
+}
+
+// TestDecodeStreamRejectsZeroFrameSizeVocoder: a hostile or buggy
+// Vocoder that reports FrameSize() == 0 must be rejected up front
+// — the read loop would otherwise spin forever on empty reads.
+func TestDecodeStreamRejectsZeroFrameSizeVocoder(t *testing.T) {
+	v := NewNullVocoder(0)
+	var sink memWriteSeeker
+	_, err := DecodeStreamWithVocoder(bytes.NewReader(nil), v, &sink)
+	if err == nil {
+		t.Fatal("expected error for FrameSize=0 vocoder")
+	}
+}
+
+// TestDecodeStreamPropagatesReadError: an io.Reader returning a
+// non-EOF / non-ErrUnexpectedEOF error mid-stream surfaces to the
+// caller along with the count of frames written so far.
+func TestDecodeStreamPropagatesReadError(t *testing.T) {
+	v := NewNullVocoder(nullFrameSize)
+	in := &errReader{
+		readN:    nullFrameSize, // first read succeeds (one frame)
+		errAfter: errors.New("synthetic mid-stream error"),
+	}
+	var sink memWriteSeeker
+	frames, err := DecodeStreamWithVocoder(in, v, &sink)
+	if err == nil || err.Error() != "synthetic mid-stream error" {
+		t.Errorf("err = %v, want synthetic mid-stream error", err)
+	}
+	if frames != 1 {
+		t.Errorf("frames = %d, want 1 (one frame written before the read error)", frames)
+	}
+}
+
+// errReader returns readN bytes (zeroed) on its first Read, then
+// errAfter on subsequent reads. Used to test mid-stream error
+// propagation.
+type errReader struct {
+	readN    int
+	errAfter error
+	served   bool
+}
+
+func (r *errReader) Read(p []byte) (int, error) {
+	if !r.served {
+		r.served = true
+		n := r.readN
+		if n > len(p) {
+			n = len(p)
+		}
+		// p is already zero from the caller's make([]byte, …) but
+		// be explicit for clarity.
+		for i := 0; i < n; i++ {
+			p[i] = 0
+		}
+		return n, nil
+	}
+	return 0, r.errAfter
+}
+
+// silence the "unused import" warning when test files are pruned.
+var _ = io.Discard


### PR DESCRIPTION
## Summary

Wires the registered IMBE / AMBE+2 vocoders into a user-facing path. Until now they were registered into `voice.DefaultRegistry` by package `init()` but **never invoked at runtime** — the call pipeline only writes PCM (from the FM demod chain) and a flat `.raw` frame sidecar. Operators who wanted decoded digital voice from a captured session had to bring their own external decoder.

This PR adds an out-of-band `gophertrunk decode` subcommand that runs the in-binary vocoders against a `.raw` frame stream and produces a WAV.

```sh
gophertrunk decode -in call.raw -out call.wav -vocoder imbe
gophertrunk decode -in dmr.raw  -out dmr.wav  -vocoder ambe2
gophertrunk decode -list-vocoders
cat session.raw | gophertrunk decode -vocoder imbe -out out.wav
```

### Library changes

`internal/voice/streamdecode.go`:
- `DecodeStream(in io.Reader, vocoderName string, out io.WriteSeeker) (int, error)` — registry lookup + per-frame decode + WAV writing. Returns the count of frames written.
- `DecodeStreamWithVocoder` — lower-level entry point taking a constructed Vocoder so callers can pin reproducibility via `NewWithSeed` or tune AGC via `NewWithConfig`.
- `ErrPartialFrame` sentinel for the "input ended mid-frame" case; the WAV is still closed cleanly so the playable prefix is preserved.

### CLI changes

`cmd/gophertrunk/decode.go` + `cmd/gophertrunk/main.go`:
- Subcommand wired into the dispatcher and `printUsage`.
- Flags: `-in` (path or `-` for stdin), `-out` (required), `-vocoder` (default `imbe`), `-list-vocoders`.
- Partial-frame trailer prints a warning but exits 0 — the WAV up to that point is the operator-useful artefact.

### Tests (+11)

- `internal/voice/streamdecode_test.go` (7 tests): unknown vocoder; empty input (just-the-header WAV); N silent frames through `NullVocoder`; partial-frame trailer (`ErrPartialFrame` + valid playable prefix); WAV sample-rate / channel / bits-per-sample pin; `FrameSize=0` rejection; mid-stream `Read` error propagation. Voice-package tests use `NullVocoder` (registered by voice itself) to avoid the circular dep on imbe / ambe2.
- `internal/voice/imbe/streamdecode_integration_test.go` (2 tests): N voice frames → N×160 non-zero samples; silence frame → 160 zeros.
- `internal/voice/ambe2/streamdecode_integration_test.go` (2 tests): N voice frames → non-zero samples; single-tone frame (`b₁=12, b₂=200`) → non-zero PCM via `synthSingleTone`.

## Test plan

- [x] `go vet ./internal/voice/...` clean
- [x] `go test -race -count=1 ./internal/voice/...` all pass — 11 new DecodeStream tests across voice/imbe/ambe2
- [x] `gofmt -d` clean on all touched files
- [ ] After merge: `make build` (with librtlsdr installed) + run `gophertrunk decode -in <captured>.raw -out out.wav -vocoder imbe` against a real P25 P1 capture; confirm the WAV is intelligible

## Files

```
README.md                                          |   7 +
cmd/gophertrunk/decode.go                          | 108 ++++++++++++
cmd/gophertrunk/main.go                            |   3 +
docs/vocoders.md                                   |  26 ++-
internal/voice/ambe2/streamdecode_integration_test.go |  106 ++++++++++++
internal/voice/imbe/streamdecode_integration_test.go  |  107 ++++++++++++
internal/voice/streamdecode.go                     |  96 +++++++++++
internal/voice/streamdecode_test.go                | 185 +++++++++++++++++++++
8 files changed, 637 insertions(+), 1 deletion(-)
```

https://claude.ai/code/session_01SvuTSKyeTrSX9V352L9GVH

---
_Generated by [Claude Code](https://claude.ai/code/session_01SvuTSKyeTrSX9V352L9GVH)_