### PR TITLE
internal/voice/recorder: live-pipeline vocoder decode

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,10 +70,19 @@ SQLite. The honest gaps:
   public spec doesn't document. Remaining polish: calibration
   against a DSD-FME-decoded DMR reference WAV (AGC defaults are
   tuned for IMBE and AMBE+2 quantisation may need a per-frame
-  gain tweak). The
-  AMBE+2 algorithm carries active patents in some jurisdictions;
-  re-implementing it in pure Go does not change that posture —
-  see [docs/vocoders.md](docs/vocoders.md).
+  gain tweak). **Live-pipeline wiring**: when CallStart fires for
+  a digital protocol mapped in
+  `voice.DefaultVocoderForProtocol` (P25 Phase 1 → IMBE; P25
+  Phase 2 / DMR / NXDN / dPMR / TETRA → AMBE+2), the recorder
+  auto-instantiates the right vocoder and decodes each
+  WriteRawFrame into PCM that lands in the call's WAV alongside
+  the optional `.raw` sidecar. Operators can override the
+  mapping per-recorder via `RecorderOptions.VocoderForProtocol`
+  (pass an empty non-nil map to disable auto-decode entirely;
+  the `.raw` sidecar then becomes the only path for digital
+  voice). The AMBE+2 algorithm carries active patents in some
+  jurisdictions; re-implementing it in pure Go does not change
+  that posture — see [docs/vocoders.md](docs/vocoders.md).
 - **Higher-fidelity audio**: the FM chain now has opt-in 75/50µs
   de-emphasis, a Kaiser-windowed audio LPF, audio AGC, and a
   polyphase L/M audio resampler — the full polish stack ships.

--- a/docs/vocoders.md
+++ b/docs/vocoders.md
@@ -46,11 +46,60 @@ type Vocoder interface {
 | `ambe2` (pure-Go)        | none         | yes      | Producing audio; calibration TODO; dual-tone → silence |
 | `dvsi` (USB-3000 chip)   | `-tags dvsi` | **no**   | Hardware backend, planned                       |
 
-The recorder always emits a raw-frame sidecar (`.raw` next to the WAV)
-when configured, so users can run their own decoder on the captured
-frames without trusting the in-binary vocoders. This is the escape
-hatch for operators who want bit-exact mbelib / DSD-FME / OP25 output
-or who prefer to defer the decoding choice to post-processing.
+### Live-pipeline auto-decode
+
+When CallStart fires, the recorder maps `Grant.Protocol` to a
+vocoder name and instantiates a fresh vocoder per call. Each
+`WriteRawFrame` call decodes its frame and appends the resulting
+PCM to the call's WAV, alongside the optional `.raw` sidecar.
+
+Default mapping (see `voice.DefaultVocoderForProtocol`):
+
+| Grant.Protocol | Vocoder | Notes                            |
+| -------------- | ------- | -------------------------------- |
+| `p25`          | `imbe`  | P25 Phase 1 LDU1 / LDU2          |
+| `p25-phase2`   | `ambe2` | P25 Phase 2                      |
+| `dmr-tier2`    | `ambe2` | DMR Tier II conventional         |
+| `dmr-tier3`    | `ambe2` | DMR Tier III trunked             |
+| `nxdn`         | `ambe2` |                                  |
+| `dpmr`         | `ambe2` | dPMR Mode 3                      |
+| `tetra`        | `ambe2` |                                  |
+
+Analog protocols (`motorola`, `edacs`, `ltr`, `mpt1327`, etc.)
+have no entry — for those, the composer's FM chain feeds
+`WritePCM` directly. EDACS ProVoice (`Grant.ProVoice == true`)
+has no in-binary decoder either; it always gets a `.raw` sidecar
+regardless of the global `WriteRaw` flag, so researchers can
+decode out-of-band.
+
+Operators override the mapping via
+`RecorderOptions.VocoderForProtocol`:
+
+```go
+voice.NewRecorder(voice.RecorderOptions{
+    // …other fields…
+    // Replace the IMBE mapping with the silence vocoder for
+    // testing, leave AMBE+2 alone:
+    VocoderForProtocol: map[string]string{
+        "p25":        "null",
+        "p25-phase2": "ambe2",
+        // …other defaults…
+    },
+})
+```
+
+Pass an explicit empty (non-nil) map to disable auto-decode
+entirely — the `.raw` sidecar then becomes the only audio
+output for digital calls.
+
+### Raw sidecar (escape hatch)
+
+The recorder emits a raw-frame sidecar (`.raw` next to the WAV)
+when `WriteRaw` is enabled or for ProVoice grants, so users can
+run their own decoder on the captured frames without trusting
+the in-binary vocoders. This is the escape hatch for operators
+who want bit-exact mbelib / DSD-FME / OP25 output or who prefer
+to defer the decoding choice to post-processing.
 
 ### Decoding a captured .raw sidecar
 

--- a/internal/voice/composer/composer.go
+++ b/internal/voice/composer/composer.go
@@ -342,11 +342,15 @@ func (c *Composer) ActiveChains() []string {
 
 func (c *Composer) handleStart(parent context.Context, cs trunking.CallStart) {
 	if cs.Grant.Protocol != "" && cs.Grant.Protocol != "fm" && cs.Grant.Protocol != "analog" {
-		// Digital protocols need a vocoder we don't have yet. The
-		// recorder still gets the CallStart event itself, so the .raw
-		// sidecar (when configured) and the call_log row land. We
-		// simply don't push PCM.
-		c.log.Info("composer: digital protocol; skipping FM chain",
+		// Digital protocols are decoded out of the recorder's
+		// WriteRawFrame path: the recorder auto-instantiates the
+		// vocoder for the call's protocol (see
+		// voice.DefaultVocoderForProtocol) and writes the decoded
+		// PCM into the WAV. The composer's job for digital is the
+		// IQ → vocoder-frame extraction (in the protocol-specific
+		// radio decoder); FM demod doesn't apply because the IQ
+		// carries C4FM / H-DQPSK / 4FSK symbols, not analog audio.
+		c.log.Info("composer: digital protocol; FM chain bypassed (vocoder decode runs in recorder)",
 			"device", cs.DeviceSerial, "protocol", cs.Grant.Protocol,
 			"group", cs.Grant.GroupID)
 		return

--- a/internal/voice/imbe/recorder_integration_test.go
+++ b/internal/voice/imbe/recorder_integration_test.go
@@ -1,0 +1,120 @@
+package imbe
+
+import (
+	"context"
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+	"github.com/MattCheramie/GopherTrunk/internal/voice"
+)
+
+// TestRecorderDecodesP25IntoWav: end-to-end sanity check of the
+// live-pipeline wire-up. A CallStart with Grant.Protocol="p25"
+// opens a recorder session that auto-instantiates the in-binary
+// IMBE vocoder. WriteRawFrame on that session decodes each frame
+// and appends the resulting PCM to the WAV. The recorder's own
+// tests can't import imbe (cycle), so the integration assertion
+// lives here in the imbe package.
+func TestRecorderDecodesP25IntoWav(t *testing.T) {
+	bus := events.NewBus(8)
+	dir := t.TempDir()
+	rec, err := voice.NewRecorder(voice.RecorderOptions{
+		Bus:        bus,
+		OutDir:     dir,
+		SampleRate: 8000,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rec.Close()
+	defer bus.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go rec.Run(ctx)
+
+	cs := trunking.CallStart{
+		Grant: trunking.Grant{
+			System:   "S",
+			Protocol: "p25", // → DefaultVocoderForProtocol → "imbe"
+			GroupID:  100,
+			SourceID: 200,
+		},
+		DeviceSerial: "VOICE-1",
+		StartedAt:    time.Date(2026, 5, 5, 12, 0, 0, 0, time.UTC),
+	}
+	bus.Publish(events.Event{Kind: events.KindCallStart, Payload: cs})
+
+	// Wait for the recorder to open the session.
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if rec.HasSession("VOICE-1") {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if !rec.HasSession("VOICE-1") {
+		t.Fatal("session never opened")
+	}
+
+	// Feed N IMBE frames. Each frame is 11 bytes; the all-zero
+	// frame decodes to b₀=0, the lowest valid voice fundamental.
+	const n = 4
+	for i := 0; i < n; i++ {
+		if err := rec.WriteRawFrame("VOICE-1", make([]byte, FrameBytes)); err != nil {
+			t.Fatalf("WriteRawFrame: %v", err)
+		}
+	}
+
+	bus.Publish(events.Event{
+		Kind: events.KindCallEnd,
+		Payload: trunking.CallEnd{
+			Grant: cs.Grant, DeviceSerial: "VOICE-1",
+			StartedAt: cs.StartedAt, EndedAt: cs.StartedAt.Add(time.Second),
+			Reason: trunking.EndReasonNormal,
+		},
+	})
+	deadline = time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if !rec.HasSession("VOICE-1") {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	wavPath := filepath.Join(dir, "S", "100", "20260505T120000Z_src200.wav")
+	wavBytes, err := os.ReadFile(wavPath)
+	if err != nil {
+		t.Fatalf("read wav: %v", err)
+	}
+
+	// Each IMBE frame decodes to 160 16-bit samples; with N frames
+	// the data chunk is N·160·2 bytes.
+	wantData := uint32(n * 160 * 2)
+	dataSize := binary.LittleEndian.Uint32(wavBytes[40:44])
+	if dataSize != wantData {
+		t.Errorf("WAV data chunk size = %d, want %d", dataSize, wantData)
+	}
+	if uint32(len(wavBytes)) != 44+wantData {
+		t.Errorf("wav file size = %d, want %d", len(wavBytes), 44+wantData)
+	}
+
+	// Confirm at least one sample is non-zero — the IMBE pipeline
+	// produces synthesis output for valid voice frames, and a fully
+	// silent WAV would mean the vocoder didn't run.
+	var nonZero bool
+	for i := 44; i+1 < len(wavBytes); i += 2 {
+		if int16(binary.LittleEndian.Uint16(wavBytes[i:i+2])) != 0 {
+			nonZero = true
+			break
+		}
+	}
+	if !nonZero {
+		t.Error("wav has only silence samples; recorder→vocoder→wav path didn't fire")
+	}
+}

--- a/internal/voice/recorder.go
+++ b/internal/voice/recorder.go
@@ -18,9 +18,9 @@ import (
 // Recorder writes per-call audio + raw-frame files. It subscribes to
 // events.KindCallStart and events.KindCallEnd from the trunking engine,
 // opens a WAV (and optional raw-frame sidecar) for each new call, and
-// closes them on call end. A future demod-pipeline composer will push
-// PCM samples in via WritePCM and raw vocoder frames in via
-// WriteRawFrame, keyed by device serial.
+// closes them on call end. The demod-pipeline composer pushes PCM
+// samples in via WritePCM (analog protocols) and raw vocoder frames
+// in via WriteRawFrame (digital protocols), keyed by device serial.
 //
 // Layout under OutDir (Trunk-Recorder-style):
 //
@@ -32,16 +32,26 @@ import (
 // (external libmbe, DVSI hardware, etc.) without parsing surrounding
 // metadata.
 //
+// Per-call vocoder: when Grant.Protocol matches an entry in the
+// configured VocoderForProtocol map, the recorder instantiates a
+// fresh Vocoder from voice.DefaultRegistry on CallStart and decodes
+// each WriteRawFrame call through it, writing the resulting PCM into
+// the WAV. This makes captures of P25 / DMR / NXDN voice produce
+// playable WAVs alongside the optional raw sidecar — out-of-band
+// decode via `gophertrunk decode` remains available for operators
+// who want bit-exact mbelib / DSD-FME output.
+//
 // EDACS ProVoice grants (Grant.ProVoice == true) always force a `.raw`
-// sidecar even when WriteRaw is false. The vocoder is patent +
-// trade-secret encumbered so we cannot ship a built-in decoder; the
-// sidecar lets researchers feed frames into an external decoder.
+// sidecar even when WriteRaw is false. The ProVoice vocoder is patent
+// + trade-secret encumbered so we cannot ship a built-in decoder;
+// the sidecar lets researchers feed frames into an external decoder.
 type Recorder struct {
-	bus        *events.Bus
-	log        *slog.Logger
-	outDir     string
-	sampleRate uint32
-	writeRaw   bool
+	bus                *events.Bus
+	log                *slog.Logger
+	outDir             string
+	sampleRate         uint32
+	writeRaw           bool
+	vocoderForProtocol map[string]string
 
 	mu        sync.Mutex
 	sessions  map[string]*recordingSession // by device serial
@@ -57,6 +67,41 @@ type RecorderOptions struct {
 	OutDir     string
 	SampleRate uint32 // 8000 typical
 	WriteRaw   bool   // emit a .raw sidecar alongside each .wav
+
+	// VocoderForProtocol maps a Grant.Protocol value to a vocoder
+	// registry name used to decode raw frames into PCM that's
+	// written to the call's WAV. nil means "use the package
+	// defaults" (DefaultVocoderForProtocol). Pass an explicit empty
+	// (non-nil) map to disable auto-decode entirely; the .raw
+	// sidecar then becomes the only path for digital voice.
+	//
+	// Protocols not in the map produce no decoded audio — typically
+	// analog protocols (motorola, edacs, ltr, mpt1327) where the
+	// composer's FM chain feeds WritePCM directly, and ProVoice
+	// where no in-binary decoder is available.
+	VocoderForProtocol map[string]string
+}
+
+// DefaultVocoderForProtocol returns the Protocol → vocoder-name
+// mapping NewRecorder uses when RecorderOptions.VocoderForProtocol
+// is nil. The keys match the strings the radio decoders set on
+// Grant.Protocol; the values match factory names registered into
+// voice.DefaultRegistry by the imbe / ambe2 package init()s.
+//
+// Callers wanting to override one entry should start with a copy of
+// this map (DefaultVocoderForProtocol() returns a fresh map per
+// call) and mutate from there — RecorderOptions.VocoderForProtocol
+// is taken as-is, no merging.
+func DefaultVocoderForProtocol() map[string]string {
+	return map[string]string{
+		"p25":        "imbe",  // P25 Phase 1 — IMBE 4400
+		"p25-phase2": "ambe2", // P25 Phase 2 — AMBE+2 2400
+		"dmr-tier2":  "ambe2", // DMR Tier II conventional
+		"dmr-tier3":  "ambe2", // DMR Tier III trunked
+		"nxdn":       "ambe2",
+		"dpmr":       "ambe2", // dPMR Mode 3 (digital)
+		"tetra":      "ambe2", // TETRA voice
+	}
 }
 
 // NewRecorder validates options and returns a recorder ready to Run.
@@ -78,14 +123,19 @@ func NewRecorder(opts RecorderOptions) (*Recorder, error) {
 	if err := os.MkdirAll(opts.OutDir, 0o755); err != nil {
 		return nil, fmt.Errorf("voice/recorder: mkdir: %w", err)
 	}
+	vocoderMap := opts.VocoderForProtocol
+	if vocoderMap == nil {
+		vocoderMap = DefaultVocoderForProtocol()
+	}
 	r := &Recorder{
-		bus:        opts.Bus,
-		log:        opts.Log,
-		outDir:     opts.OutDir,
-		sampleRate: opts.SampleRate,
-		writeRaw:   opts.WriteRaw,
-		sessions:   make(map[string]*recordingSession),
-		runDone:    make(chan struct{}),
+		bus:                opts.Bus,
+		log:                opts.Log,
+		outDir:             opts.OutDir,
+		sampleRate:         opts.SampleRate,
+		writeRaw:           opts.WriteRaw,
+		vocoderForProtocol: vocoderMap,
+		sessions:           make(map[string]*recordingSession),
+		runDone:            make(chan struct{}),
 	}
 	r.sub = opts.Bus.Subscribe()
 	return r, nil
@@ -171,19 +221,44 @@ func (r *Recorder) WritePCM(deviceSerial string, samples []int16) error {
 	return s.wav.WriteSamples(samples)
 }
 
-// WriteRawFrame appends a raw vocoder frame to the per-call sidecar.
-// The session decides whether a sidecar exists: it is opened either when
-// WriteRaw is globally enabled or when the call's grant is flagged
-// ProVoice. Frames for a session without a sidecar are dropped silently.
+// WriteRawFrame consumes a raw vocoder frame for the named device
+// serial. Two outputs are produced when applicable:
+//
+//   - The .raw sidecar (when one was opened — see handleStart). The
+//     frame bytes are appended verbatim so external decoders can
+//     consume the file with no surrounding metadata.
+//   - The .wav (when a vocoder was instantiated for the call's
+//     Grant.Protocol). The frame is decoded into PCM and the
+//     samples are appended to the WAV. A per-frame Decode error is
+//     logged and the frame is dropped from PCM but still written to
+//     the sidecar.
+//
+// Frames for a session without either output (no sidecar, no
+// vocoder) are dropped silently.
 func (r *Recorder) WriteRawFrame(deviceSerial string, frame []byte) error {
 	r.mu.Lock()
 	s, ok := r.sessions[deviceSerial]
 	r.mu.Unlock()
-	if !ok || s.raw == nil {
+	if !ok {
 		return nil
 	}
-	_, err := s.raw.Write(frame)
-	return err
+	if s.raw != nil {
+		if _, err := s.raw.Write(frame); err != nil {
+			return err
+		}
+	}
+	if s.vocoder != nil {
+		samples, err := s.vocoder.Decode(frame)
+		if err != nil {
+			r.log.Warn("recorder: vocoder decode failed; dropping frame from PCM",
+				"device", deviceSerial, "vocoder", s.vocoder.Name(), "err", err)
+			return nil
+		}
+		if err := s.wav.WriteSamples(samples); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (r *Recorder) handleStart(cs trunking.CallStart) {
@@ -221,10 +296,26 @@ func (r *Recorder) handleStart(cs trunking.CallStart) {
 			s.rawPath = rawPath
 		}
 	}
+	// Instantiate a vocoder for the protocol if one is mapped.
+	// Construction failure (unknown registry name) logs a warning and
+	// proceeds with no auto-decode — the sidecar (if any) is still the
+	// safety net.
+	if name, ok := r.vocoderForProtocol[cs.Grant.Protocol]; ok && name != "" {
+		v, err := DefaultRegistry.New(name)
+		if err != nil {
+			r.log.Warn("recorder: cannot instantiate vocoder; auto-decode disabled for this call",
+				"device", cs.DeviceSerial, "protocol", cs.Grant.Protocol,
+				"vocoder", name, "err", err)
+		} else {
+			s.vocoder = v
+			s.vocoderName = name
+		}
+	}
 	r.sessions[cs.DeviceSerial] = s
 	r.log.Info("recorder: call started",
 		"device", cs.DeviceSerial, "wav", wavPath,
-		"tg", cs.Grant.GroupID, "provoice", cs.Grant.ProVoice)
+		"tg", cs.Grant.GroupID, "provoice", cs.Grant.ProVoice,
+		"vocoder", s.vocoderName)
 }
 
 func (r *Recorder) handleEnd(ce trunking.CallEnd) {
@@ -292,16 +383,23 @@ func sanitize(s string) string {
 }
 
 type recordingSession struct {
-	wav       *WavWriter
-	wavPath   string
-	raw       *os.File
-	rawPath   string
-	startedAt time.Time
+	wav         *WavWriter
+	wavPath     string
+	raw         *os.File
+	rawPath     string
+	vocoder     Vocoder
+	vocoderName string
+	startedAt   time.Time
 }
 
 func (s *recordingSession) close() error {
 	var firstErr error
-	if err := s.wav.Close(); err != nil {
+	if s.vocoder != nil {
+		if err := s.vocoder.Close(); err != nil {
+			firstErr = err
+		}
+	}
+	if err := s.wav.Close(); err != nil && firstErr == nil {
 		firstErr = err
 	}
 	if s.raw != nil {

--- a/internal/voice/recorder_test.go
+++ b/internal/voice/recorder_test.go
@@ -311,3 +311,286 @@ func TestSanitize(t *testing.T) {
 		}
 	}
 }
+
+// TestRecorderInstantiatesVocoderForMappedProtocol: a CallStart
+// with Grant.Protocol = "test-null" + a custom map mapping that
+// protocol to the always-registered "null" vocoder must produce
+// a session with an active vocoder. We use "null" (instead of
+// "imbe" or "ambe2") because the voice package can't import the
+// real decoder packages without creating a cycle — those
+// integration tests live in internal/voice/imbe and
+// internal/voice/ambe2.
+func TestRecorderInstantiatesVocoderForMappedProtocol(t *testing.T) {
+	bus := events.NewBus(8)
+	dir := t.TempDir()
+	r, err := NewRecorder(RecorderOptions{
+		Bus:                bus,
+		OutDir:             dir,
+		SampleRate:         8000,
+		WriteRaw:           true,
+		VocoderForProtocol: map[string]string{"test-null": "null"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+	defer bus.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go r.Run(ctx)
+
+	cs := trunking.CallStart{
+		Grant:        trunking.Grant{System: "S", Protocol: "test-null", GroupID: 1, SourceID: 1},
+		DeviceSerial: "VOICE-1",
+		StartedAt:    time.Date(2026, 5, 5, 0, 0, 0, 0, time.UTC),
+	}
+	bus.Publish(events.Event{Kind: events.KindCallStart, Payload: cs})
+
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if r.HasSession("VOICE-1") {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	// Inspect the session under the recorder's lock.
+	r.mu.Lock()
+	s, ok := r.sessions["VOICE-1"]
+	r.mu.Unlock()
+	if !ok {
+		t.Fatal("session not opened")
+	}
+	if s.vocoder == nil {
+		t.Errorf("vocoder = nil, want non-nil for protocol=test-null → null")
+	}
+	if s.vocoderName != "null" {
+		t.Errorf("vocoderName = %q, want %q", s.vocoderName, "null")
+	}
+}
+
+// TestRecorderWriteRawFrameDecodesIntoWav: feeding raw frames to
+// WriteRawFrame on a session with a NullVocoder writes silence
+// samples into the WAV. Pins that the decode → WAV path is wired.
+func TestRecorderWriteRawFrameDecodesIntoWav(t *testing.T) {
+	bus := events.NewBus(8)
+	dir := t.TempDir()
+	r, err := NewRecorder(RecorderOptions{
+		Bus:                bus,
+		OutDir:             dir,
+		SampleRate:         8000,
+		VocoderForProtocol: map[string]string{"test-null": "null"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+	defer bus.Close()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go r.Run(ctx)
+
+	cs := trunking.CallStart{
+		Grant:        trunking.Grant{System: "S", Protocol: "test-null", GroupID: 1, SourceID: 2},
+		DeviceSerial: "VOICE-1",
+		StartedAt:    time.Date(2026, 5, 5, 0, 0, 0, 0, time.UTC),
+	}
+	bus.Publish(events.Event{Kind: events.KindCallStart, Payload: cs})
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if r.HasSession("VOICE-1") {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	// NullVocoder.FrameSize is 11 by default (set by the
+	// package's init); send 3 frames worth of zero bytes.
+	for i := 0; i < 3; i++ {
+		if err := r.WriteRawFrame("VOICE-1", make([]byte, 11)); err != nil {
+			t.Fatalf("WriteRawFrame: %v", err)
+		}
+	}
+
+	bus.Publish(events.Event{
+		Kind: events.KindCallEnd,
+		Payload: trunking.CallEnd{
+			Grant: cs.Grant, DeviceSerial: "VOICE-1",
+			StartedAt: cs.StartedAt, EndedAt: cs.StartedAt.Add(time.Second),
+			Reason: trunking.EndReasonNormal,
+		},
+	})
+	deadline = time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if !r.HasSession("VOICE-1") {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	wavPath := filepath.Join(dir, "S", "1", "20260505T000000Z_src2.wav")
+	st, err := os.Stat(wavPath)
+	if err != nil {
+		t.Fatalf("wav at %s: %v", wavPath, err)
+	}
+	// 3 frames × 160 samples × 2 bytes = 960 bytes payload + 44 header.
+	wantSize := int64(wavHeaderSize + 3*160*2)
+	if st.Size() != wantSize {
+		t.Errorf("wav size = %d, want %d", st.Size(), wantSize)
+	}
+}
+
+// TestRecorderEmptyVocoderMapDisablesAutoDecode: passing a
+// non-nil but empty VocoderForProtocol disables auto-decode for
+// every protocol — the .raw sidecar (when enabled) is still the
+// only audio output for digital calls.
+func TestRecorderEmptyVocoderMapDisablesAutoDecode(t *testing.T) {
+	bus := events.NewBus(8)
+	dir := t.TempDir()
+	r, err := NewRecorder(RecorderOptions{
+		Bus:                bus,
+		OutDir:             dir,
+		SampleRate:         8000,
+		VocoderForProtocol: map[string]string{}, // explicit empty
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+	defer bus.Close()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go r.Run(ctx)
+
+	cs := trunking.CallStart{
+		Grant:        trunking.Grant{System: "S", Protocol: "p25", GroupID: 1, SourceID: 1},
+		DeviceSerial: "VOICE-1",
+		StartedAt:    time.Date(2026, 5, 5, 0, 0, 0, 0, time.UTC),
+	}
+	bus.Publish(events.Event{Kind: events.KindCallStart, Payload: cs})
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if r.HasSession("VOICE-1") {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	r.mu.Lock()
+	s, ok := r.sessions["VOICE-1"]
+	r.mu.Unlock()
+	if !ok {
+		t.Fatal("session not opened")
+	}
+	if s.vocoder != nil {
+		t.Errorf("vocoder = %v, want nil with empty VocoderForProtocol map", s.vocoderName)
+	}
+}
+
+// TestRecorderUnmappedProtocolSkipsVocoder: protocols not in the
+// map (typically analog protocols like "motorola" / "ltr") should
+// produce no vocoder. The composer's FM chain feeds WritePCM
+// directly for those calls.
+func TestRecorderUnmappedProtocolSkipsVocoder(t *testing.T) {
+	r, bus, _ := mkRecorder(t, false)
+	defer r.Close()
+	defer bus.Close()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go r.Run(ctx)
+
+	// "motorola" is intentionally absent from
+	// DefaultVocoderForProtocol — the trunking decoder publishes
+	// it for analog-passthrough calls.
+	cs := trunking.CallStart{
+		Grant:        trunking.Grant{System: "S", Protocol: "motorola", GroupID: 1, SourceID: 1},
+		DeviceSerial: "VOICE-1",
+		StartedAt:    time.Date(2026, 5, 5, 0, 0, 0, 0, time.UTC),
+	}
+	bus.Publish(events.Event{Kind: events.KindCallStart, Payload: cs})
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if r.HasSession("VOICE-1") {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	r.mu.Lock()
+	s, ok := r.sessions["VOICE-1"]
+	r.mu.Unlock()
+	if !ok {
+		t.Fatal("session not opened")
+	}
+	if s.vocoder != nil {
+		t.Errorf("vocoder = %q, want nil for unmapped protocol", s.vocoderName)
+	}
+}
+
+// TestRecorderUnknownVocoderNameLogsAndProceeds: a Protocol mapping
+// pointing at a registry name no factory has registered must not
+// panic — the recorder logs and continues with vocoder = nil.
+func TestRecorderUnknownVocoderNameLogsAndProceeds(t *testing.T) {
+	bus := events.NewBus(8)
+	dir := t.TempDir()
+	r, err := NewRecorder(RecorderOptions{
+		Bus:                bus,
+		OutDir:             dir,
+		SampleRate:         8000,
+		VocoderForProtocol: map[string]string{"x": "no-such-vocoder"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+	defer bus.Close()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go r.Run(ctx)
+
+	cs := trunking.CallStart{
+		Grant:        trunking.Grant{System: "S", Protocol: "x", GroupID: 1, SourceID: 1},
+		DeviceSerial: "VOICE-1",
+		StartedAt:    time.Date(2026, 5, 5, 0, 0, 0, 0, time.UTC),
+	}
+	bus.Publish(events.Event{Kind: events.KindCallStart, Payload: cs})
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if r.HasSession("VOICE-1") {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	r.mu.Lock()
+	s, ok := r.sessions["VOICE-1"]
+	r.mu.Unlock()
+	if !ok {
+		t.Fatal("session not opened")
+	}
+	if s.vocoder != nil {
+		t.Errorf("vocoder should be nil after registry miss, got %q", s.vocoderName)
+	}
+}
+
+// TestDefaultVocoderForProtocolMappings: pin the default
+// Protocol → vocoder mapping so a future refactor doesn't
+// silently drop a digital protocol from the auto-decode path.
+func TestDefaultVocoderForProtocolMappings(t *testing.T) {
+	got := DefaultVocoderForProtocol()
+	want := map[string]string{
+		"p25":        "imbe",
+		"p25-phase2": "ambe2",
+		"dmr-tier2":  "ambe2",
+		"dmr-tier3":  "ambe2",
+		"nxdn":       "ambe2",
+		"dpmr":       "ambe2",
+		"tetra":      "ambe2",
+	}
+	if len(got) != len(want) {
+		t.Errorf("len = %d, want %d", len(got), len(want))
+	}
+	for k, v := range want {
+		if g := got[k]; g != v {
+			t.Errorf("Default[%q] = %q, want %q", k, g, v)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Wires the registered IMBE / AMBE+2 vocoders into the **live call pipeline**. Until this PR the recorder kept a Vocoder-shaped hole: `WriteRawFrame` existed and would persist frames to a `.raw` sidecar when configured, but no upstream code routed the bytes through the registered vocoders. Operators got either an empty WAV (for digital calls) or had to BYO out-of-band decoder.

After this PR, when `CallStart` fires for a `Grant.Protocol` the recorder knows about, it auto-instantiates the right vocoder (via `voice.DefaultRegistry`) and pipes each `WriteRawFrame` frame through `Decode → WriteSamples` on the call's WAV. The `.raw` sidecar still gets the bare frame bytes when `WriteRaw` is enabled, so the BYO-decoder escape hatch survives.

### Default `Protocol → Vocoder` mapping

(`voice.DefaultVocoderForProtocol`)

| `Grant.Protocol` | Vocoder | Notes |
| --- | --- | --- |
| `p25` | `imbe` | P25 Phase 1 |
| `p25-phase2` | `ambe2` | P25 Phase 2 |
| `dmr-tier2` | `ambe2` | DMR conventional |
| `dmr-tier3` | `ambe2` | DMR trunked |
| `nxdn` | `ambe2` | |
| `dpmr` | `ambe2` | dPMR Mode 3 |
| `tetra` | `ambe2` | |

Analog protocols (`motorola`, `edacs`, `ltr`, `mpt1327`) are absent — the composer's FM chain feeds `WritePCM` directly. ProVoice has no in-binary decoder; it always gets a `.raw` sidecar regardless of `WriteRaw`.

### Override knob

```go
voice.NewRecorder(voice.RecorderOptions{
    // …other fields…
    VocoderForProtocol: map[string]string{ /* operator override */ },
})
```

`nil` uses defaults. An explicit empty (non-nil) map disables auto-decode entirely (sidecar becomes the only digital audio output). A registry miss for an unknown vocoder name logs a warning and proceeds with `vocoder = nil` so malformed configs degrade gracefully. Per-frame `Decode` errors are logged and dropped from PCM but still persisted to the sidecar — a single bad frame doesn't poison the rest of the call.

### Tests (+6)

`internal/voice/recorder_test.go` (+5):
- `TestRecorderInstantiatesVocoderForMappedProtocol`
- `TestRecorderWriteRawFrameDecodesIntoWav` — 3 frames through `NullVocoder` → 3×160 silence samples in the WAV (correctly patched data-chunk size).
- `TestRecorderEmptyVocoderMapDisablesAutoDecode`
- `TestRecorderUnmappedProtocolSkipsVocoder`
- `TestRecorderUnknownVocoderNameLogsAndProceeds`
- `TestDefaultVocoderForProtocolMappings` — pins the default map's contents so a future refactor doesn't silently drop a digital protocol.

`internal/voice/imbe/recorder_integration_test.go` (new, end-to-end):
- `TestRecorderDecodesP25IntoWav` — `CallStart` with `Protocol="p25"` + 4 IMBE frames via `WriteRawFrame` produces a WAV with the expected data-chunk size (`n×160×2` bytes) and at least some non-zero samples. Verifies the registry → recorder → vocoder → WAV path end-to-end.

### Composer log update

`composer.handleStart`'s "digital protocol; skipping FM chain" log message is updated — the digital path no longer ends with silence; the recorder picks up via `WriteRawFrame`.

### What this PR does *not* do

The IQ → vocoder-frame extraction in the radio decoders (P25 P1 LDU bit-extraction, DMR slot voice frames, etc.) is **not in scope**. That's per-protocol work and several more PRs. The vocoder pipeline is now waiting for those frames; once they arrive via `WriteRawFrame`, audio lands in the WAV.

## Test plan

- [x] `go vet ./internal/voice/...` clean
- [x] `go test -race -count=1 ./internal/voice/...` all pass — 11 recorder tests (+6 new), full voice tree green
- [x] Backward compat: existing `TestRecorderWritesPerCallWav` (which uses `Protocol="p25"`) still passes — registry lookup misses cleanly because the voice package can't import imbe (cycle), so `s.vocoder` stays nil and the test's WritePCM-driven flow is unchanged
- [ ] After merge: capture a P25 P1 session via the wired daemon (with frame extraction in place), confirm the WAV has decoded audio not just an FM-demod buffer

## Files

```
README.md                                          |  17 ++-
docs/vocoders.md                                   |  59 +++++++-
internal/voice/composer/composer.go                |  14 +-
internal/voice/imbe/recorder_integration_test.go   | 109 ++++++++++++++++
internal/voice/recorder.go                         | 162 ++++++++++++++++++----
internal/voice/recorder_test.go                    | 283 ++++++++++++++++++++++++++++++++++++
6 files changed, 609 insertions(+), 46 deletions(-)
```

https://claude.ai/code/session_01SvuTSKyeTrSX9V352L9GVH

---
_Generated by [Claude Code](https://claude.ai/code/session_01SvuTSKyeTrSX9V352L9GVH)_