### PR TITLE
internal/radio/p25/phase1: LDUAssembler — dibit-stream → complete LDU buffers

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,10 +103,20 @@ SQLite. The honest gaps:
   synthetic LDU containing 9 encoded IMBE frames, runs them
   through `ExtractVoiceFrames` → `recorder.WriteRawFrame` →
   registered IMBE vocoder → WAV, and confirms the WAV carries
-  the expected 9·160·2 PCM bytes with non-silent samples. The AMBE+2 algorithm carries active
-  patents in some jurisdictions; re-implementing it in pure Go
-  does not change that posture — see
-  [docs/vocoders.md](docs/vocoders.md).
+  the expected 9·160·2 PCM bytes with non-silent samples.
+  Upstream of the LDU extraction, `phase1.LDUAssembler`
+  (`internal/radio/p25/phase1/ldu_assembler.go`) consumes a
+  C4FM dibit stream (post-symbol-clock-recovery, value 0..3
+  per dibit), latches on the 24-dibit Frame Sync Word
+  (configurable mismatch tolerance for noisy signals), and
+  emits complete 1728-bit LDU buffers to a sink callback
+  ready for `ExtractVoiceFrames`. The only remaining gap to
+  process a live captured P25 P1 stream is the **IQ → C4FM
+  dibit** step (matched filter, symbol clock recovery, slicer);
+  the symbol-domain side is fully wired. The AMBE+2 algorithm
+  carries active patents in some jurisdictions;
+  re-implementing it in pure Go does not change that posture
+  — see [docs/vocoders.md](docs/vocoders.md).
 - **Higher-fidelity audio**: the FM chain now has opt-in 75/50µs
   de-emphasis, a Kaiser-windowed audio LPF, audio AGC, and a
   polyphase L/M audio resampler — the full polish stack ships.

--- a/internal/radio/p25/phase1/ldu_assembler.go
+++ b/internal/radio/p25/phase1/ldu_assembler.go
@@ -1,0 +1,131 @@
+package phase1
+
+import "github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+
+// LDUDibitCount is the dibit length of a complete LDU on the air:
+// 1728 bits / 2 = 864 dibits = 864 C4FM symbols. Used by the
+// assembler as the trailing-dibit count from FSW start.
+const LDUDibitCount = LDUTotalBits / 2
+
+// LDUSink consumes a complete 1728-bit on-air LDU bit stream
+// (one bit per byte, 0/1, MSB-first per dibit). The caller
+// passes the LDU into ExtractVoiceFrames / ExtractLCESBlocks /
+// ExtractLSDBlocks to get recorder-ready IMBE frames + metadata.
+type LDUSink func(ldu []byte)
+
+// LDUAssembler is a stateful stream consumer that turns a C4FM
+// dibit stream (post-demodulation, post-symbol-clock-recovery)
+// into complete 1728-bit LDU buffers ready for ExtractVoiceFrames.
+//
+// The state machine is:
+//
+//   - awaiting FSW (pending == -1): each incoming dibit slides
+//     a 24-dibit window forward; when the window matches
+//     FrameSyncWord within `tolerance` dibit positions, the
+//     assembler records the FSW-start position and transitions
+//     to "collecting".
+//   - collecting (pending >= 0): each incoming dibit appends to
+//     the buffer; once 864 dibits have arrived since the FSW
+//     start, the assembler concatenates them into a 1728-bit
+//     byte slice and hands it to the sink. The buffer is
+//     compacted (dropping the consumed LDU) and the assembler
+//     returns to "awaiting FSW".
+//
+// The assembler does NOT care about IQ demodulation, status
+// symbols, or anything below the dibit layer — it expects the
+// caller to have already produced clean {0,1,2,3} dibits via a
+// C4FM demodulator + symbol clock recovery. It also doesn't
+// know about NID parsing or LDU1 vs LDU2: the sink can inspect
+// the emitted bits if it cares.
+//
+// Not safe for concurrent Process() calls. Instantiate one per
+// per-call demod chain.
+type LDUAssembler struct {
+	sink      LDUSink
+	tolerance int
+	buf       []uint8
+	pending   int // -1 = awaiting FSW; ≥0 = buf-relative FSW start
+}
+
+// NewLDUAssembler returns an LDUAssembler that forwards completed
+// LDUs to sink. tolerance is the maximum dibit-position mismatch
+// allowed when matching the 24-dibit FrameSyncWord; tolerance<0
+// uses the SyncDetector default of 4 (one FSW out of every ~64
+// captured bursts is statistically expected to land within 4
+// mismatches by random chance, so set this lower for cleaner
+// signals to reduce false-positives).
+func NewLDUAssembler(sink LDUSink, tolerance int) *LDUAssembler {
+	if tolerance < 0 {
+		tolerance = 4
+	}
+	return &LDUAssembler{
+		sink:      sink,
+		tolerance: tolerance,
+		buf:       make([]uint8, 0, 2*LDUDibitCount),
+		pending:   -1,
+	}
+}
+
+// Process feeds a chunk of dibits (0..3) into the assembler. The
+// sink callback may be invoked zero or more times during the call
+// — once per complete LDU detected in this chunk plus any LDU
+// straddling a previous Process call's input.
+func (a *LDUAssembler) Process(dibits []uint8) {
+	for _, d := range dibits {
+		a.buf = append(a.buf, d)
+		// Detect FSW only when not already collecting an LDU.
+		// Detection happens against the trailing 24 dibits of the
+		// buffer — the most recent window.
+		if a.pending < 0 && len(a.buf) >= 24 {
+			if a.fswMismatch(a.buf[len(a.buf)-24:]) <= a.tolerance {
+				a.pending = len(a.buf) - 24
+			}
+		}
+		// Emit an LDU once 864 dibits have been buffered since the
+		// FSW start.
+		if a.pending >= 0 && len(a.buf)-a.pending >= LDUDibitCount {
+			lduStart := a.pending
+			lduDibits := a.buf[lduStart : lduStart+LDUDibitCount]
+			ldu := framing.DibitsToBits(lduDibits)
+			a.sink(ldu)
+			// Compact: drop everything up to and including this LDU.
+			// The next LDU's FSW must appear in subsequent dibits.
+			tailStart := lduStart + LDUDibitCount
+			copy(a.buf, a.buf[tailStart:])
+			a.buf = a.buf[:len(a.buf)-tailStart]
+			a.pending = -1
+		}
+	}
+}
+
+// Reset clears the assembler's internal state. Callers invoke
+// it on stream re-sync (frame-loss recovery, channel retune,
+// CallEnd cleanup) so the next dibit stream starts cleanly
+// without a stale FSW match holding over.
+func (a *LDUAssembler) Reset() {
+	a.buf = a.buf[:0]
+	a.pending = -1
+}
+
+// Buffered returns the number of dibits currently held in the
+// assembler's internal buffer. Useful in tests to verify the
+// state machine compacts correctly after each emission.
+func (a *LDUAssembler) Buffered() int { return len(a.buf) }
+
+// fswMismatch returns the number of dibit positions where the
+// supplied 24-dibit window differs from FrameSyncWord. A return
+// value > a.tolerance means "no match"; ≤ a.tolerance means
+// "match within tolerance". Wrong-length inputs return a value
+// guaranteed to exceed any reasonable tolerance.
+func (a *LDUAssembler) fswMismatch(window []uint8) int {
+	if len(window) != 24 {
+		return 24
+	}
+	var mm int
+	for i := range window {
+		if window[i] != FrameSyncWord[i] {
+			mm++
+		}
+	}
+	return mm
+}

--- a/internal/radio/p25/phase1/ldu_assembler_test.go
+++ b/internal/radio/p25/phase1/ldu_assembler_test.go
@@ -1,0 +1,241 @@
+package phase1
+
+import (
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+	"github.com/MattCheramie/GopherTrunk/internal/voice/imbe"
+)
+
+// dibitsFor builds a length-n dibit slice with values copied
+// from `pattern` (cycling). Used by the synthetic-stream tests
+// below.
+func dibitsFor(n int, pattern ...uint8) []uint8 {
+	out := make([]uint8, n)
+	if len(pattern) == 0 {
+		return out
+	}
+	for i := range out {
+		out[i] = pattern[i%len(pattern)]
+	}
+	return out
+}
+
+// makeLDUDibits builds an 864-dibit slice that begins with the
+// canonical FrameSyncWord and is padded with the supplied filler
+// dibits (cycling) for the remaining 840 positions. The result
+// can be fed to LDUAssembler.Process to test FSW detection +
+// trailing-collection together.
+func makeLDUDibits(filler ...uint8) []uint8 {
+	out := make([]uint8, LDUDibitCount)
+	copy(out, FrameSyncWord[:])
+	if len(filler) > 0 {
+		for i := 24; i < LDUDibitCount; i++ {
+			out[i] = filler[(i-24)%len(filler)]
+		}
+	}
+	return out
+}
+
+// TestLDUAssemblerEmitsOnClean864: a clean FSW + 840 trailing
+// dibits triggers exactly one sink invocation with a 1728-bit
+// LDU. The first 24 dibits' bit-representation (48 bits) must
+// match the canonical frame-sync bits.
+func TestLDUAssemblerEmitsOnClean864(t *testing.T) {
+	var got [][]byte
+	a := NewLDUAssembler(func(ldu []byte) { got = append(got, ldu) }, 0)
+	a.Process(makeLDUDibits(0, 1, 2, 3))
+
+	if len(got) != 1 {
+		t.Fatalf("sink invoked %d times, want 1", len(got))
+	}
+	if len(got[0]) != LDUTotalBits {
+		t.Errorf("LDU length = %d bits, want %d", len(got[0]), LDUTotalBits)
+	}
+	// First 48 bits must match the canonical FrameSyncBits.
+	wantFS := FrameSyncBits()
+	for i, b := range wantFS {
+		if got[0][i] != b {
+			t.Fatalf("bit %d of LDU = %d, want %d (frame sync mismatch)", i, got[0][i], b)
+		}
+	}
+	if a.Buffered() != 0 {
+		t.Errorf("Buffered() = %d after emission, want 0 (compaction failed)", a.Buffered())
+	}
+}
+
+// TestLDUAssemblerSkipsLeadingGarbage: feed 100 dibits of
+// non-FSW junk, then an FSW + 840 trailing dibits. The sink
+// must fire exactly once with the LDU that begins at the FSW —
+// the leading garbage is dropped, not prepended.
+func TestLDUAssemblerSkipsLeadingGarbage(t *testing.T) {
+	var got [][]byte
+	a := NewLDUAssembler(func(ldu []byte) { got = append(got, ldu) }, 0)
+	a.Process(dibitsFor(100, 2, 0, 3, 1)) // 100 random dibits, never matches FSW
+	a.Process(makeLDUDibits(0))
+
+	if len(got) != 1 {
+		t.Fatalf("sink invoked %d times, want 1", len(got))
+	}
+	// First dibit of the emitted LDU's bits must be the first
+	// bit of the FSW (which is 0x55 high nibble's bit = 0).
+	wantFirst := framing.DibitsToBits(FrameSyncWord[:1])[0]
+	if got[0][0] != wantFirst {
+		t.Errorf("LDU starts at bit %d, want %d (FSW first bit)", got[0][0], wantFirst)
+	}
+}
+
+// TestLDUAssemblerHandlesMultipleLDUs: back-to-back FSW + 840
+// dibits twice → sink called twice. Validates that the buffer
+// compaction correctly resets state between LDUs.
+func TestLDUAssemblerHandlesMultipleLDUs(t *testing.T) {
+	var got [][]byte
+	a := NewLDUAssembler(func(ldu []byte) { got = append(got, ldu) }, 0)
+	a.Process(makeLDUDibits(0, 1))
+	a.Process(makeLDUDibits(2, 3))
+
+	if len(got) != 2 {
+		t.Fatalf("sink invoked %d times, want 2", len(got))
+	}
+	if len(got[0]) != LDUTotalBits || len(got[1]) != LDUTotalBits {
+		t.Errorf("LDU lengths = %d / %d, want %d each",
+			len(got[0]), len(got[1]), LDUTotalBits)
+	}
+	if a.Buffered() != 0 {
+		t.Errorf("Buffered() = %d after two emissions, want 0", a.Buffered())
+	}
+}
+
+// TestLDUAssemblerNoEmitOnPartialLDU: FSW + only 100 trailing
+// dibits (incomplete) → sink not called yet; assembler is still
+// collecting. After feeding the remaining 740 dibits, the
+// trailing one completes the LDU and fires the sink exactly once.
+func TestLDUAssemblerNoEmitOnPartialLDU(t *testing.T) {
+	var got [][]byte
+	a := NewLDUAssembler(func(ldu []byte) { got = append(got, ldu) }, 0)
+	a.Process(FrameSyncWord[:])
+	a.Process(dibitsFor(100, 0))
+	if len(got) != 0 {
+		t.Fatalf("sink invoked %d times after partial input, want 0", len(got))
+	}
+	a.Process(dibitsFor(LDUDibitCount-24-100, 0))
+	if len(got) != 1 {
+		t.Fatalf("sink invoked %d times after completing the LDU, want 1", len(got))
+	}
+}
+
+// TestLDUAssemblerToleratesNoisyFSW: corrupt the FSW with 3
+// dibit-position errors and feed with tolerance=4. The
+// assembler must still detect + emit. With tolerance=2, the
+// same noisy FSW is rejected.
+func TestLDUAssemblerToleratesNoisyFSW(t *testing.T) {
+	noisy := makeLDUDibits(0)
+	// Flip 3 FSW dibits. Using positions inside the 24-dibit
+	// FSW span (0..23) so we corrupt the sync pattern, not the
+	// payload.
+	noisy[1] = (noisy[1] + 1) & 0x3
+	noisy[7] = (noisy[7] + 1) & 0x3
+	noisy[15] = (noisy[15] + 1) & 0x3
+
+	// tolerance=4: 3 errors fall within the budget — emission fires.
+	var got1 [][]byte
+	a1 := NewLDUAssembler(func(ldu []byte) { got1 = append(got1, ldu) }, 4)
+	a1.Process(noisy)
+	if len(got1) != 1 {
+		t.Errorf("tolerance=4 with 3 FSW errors: sink invoked %d times, want 1", len(got1))
+	}
+
+	// tolerance=2: 3 errors exceed budget — no emission.
+	var got2 [][]byte
+	a2 := NewLDUAssembler(func(ldu []byte) { got2 = append(got2, ldu) }, 2)
+	a2.Process(noisy)
+	if len(got2) != 0 {
+		t.Errorf("tolerance=2 with 3 FSW errors: sink invoked %d times, want 0", len(got2))
+	}
+}
+
+// TestLDUAssemblerResetClearsState: after collecting partial
+// dibits + a pending FSW, Reset returns the assembler to a
+// clean state. Subsequent dibits then build up a fresh LDU
+// from scratch.
+func TestLDUAssemblerResetClearsState(t *testing.T) {
+	var got [][]byte
+	a := NewLDUAssembler(func(ldu []byte) { got = append(got, ldu) }, 0)
+	a.Process(FrameSyncWord[:])           // pending FSW set
+	a.Process(dibitsFor(100, 0))          // collecting
+	if a.Buffered() == 0 || a.pending < 0 {
+		t.Fatal("setup: assembler not in collecting state")
+	}
+	a.Reset()
+	if a.Buffered() != 0 || a.pending != -1 {
+		t.Errorf("after Reset: buffered=%d pending=%d, want 0/-1",
+			a.Buffered(), a.pending)
+	}
+	if len(got) != 0 {
+		t.Errorf("Reset shouldn't trigger emission; got %d", len(got))
+	}
+	// Feed a fresh LDU; emission fires.
+	a.Process(makeLDUDibits(0))
+	if len(got) != 1 {
+		t.Errorf("after Reset + fresh LDU: sink invoked %d times, want 1", len(got))
+	}
+}
+
+// TestLDUAssemblerEmitsLDUConsumableByExtractVoiceFrames:
+// end-to-end stack test. Build a synthetic LDU containing 9
+// properly-encoded IMBE channel-coded subframes at the
+// documented voice offsets, include status symbols, run the
+// bytes through the assembler as a dibit stream, and confirm
+// the emitted LDU is accepted cleanly by ExtractVoiceFrames
+// (totalErrs == 0, no error). Closes the loop between the
+// assembler and the existing voice-extraction primitives.
+func TestLDUAssemblerEmitsLDUConsumableByExtractVoiceFrames(t *testing.T) {
+	payload := make([]byte, LDUPayloadBits)
+	// First 48 bits of the payload must be the canonical FSW bits
+	// so the assembler latches.
+	copy(payload, FrameSyncBits())
+	// Encode 9 synthetic IMBE subframes through the full channel
+	// path: info → EncodeChannel → Scramble → place at the voice
+	// offsets in the payload.
+	for i := 0; i < LDUVoiceSubframeCount; i++ {
+		info := make([]byte, 88)
+		for k := range info {
+			info[k] = byte((i*7 + k*3) % 2)
+		}
+		encoded, err := imbe.EncodeChannel(info)
+		if err != nil {
+			t.Fatalf("EncodeChannel u_%d: %v", i, err)
+		}
+		scrambled, err := imbe.Scramble(encoded)
+		if err != nil {
+			t.Fatalf("Scramble u_%d: %v", i, err)
+		}
+		copy(payload[lduVoiceOffsets[i]:lduVoiceOffsets[i]+LDUVoiceSubframeBits], scrambled)
+	}
+
+	var status [LDUStatusSymbolCount]uint8
+	ldu, err := InjectStatusSymbols(payload, status)
+	if err != nil {
+		t.Fatalf("InjectStatusSymbols: %v", err)
+	}
+	dibits := framing.BitsToDibits(ldu)
+
+	var got [][]byte
+	a := NewLDUAssembler(func(ldu []byte) { got = append(got, ldu) }, 0)
+	a.Process(dibits)
+	if len(got) != 1 {
+		t.Fatalf("sink invoked %d times, want 1", len(got))
+	}
+	frames, errs, err := ExtractVoiceFrames(got[0])
+	if err != nil {
+		t.Errorf("ExtractVoiceFrames: %v", err)
+	}
+	if errs != 0 {
+		t.Errorf("ExtractVoiceFrames errs = %d, want 0 on a clean encoded LDU", errs)
+	}
+	for i, frame := range frames {
+		if len(frame) != 11 {
+			t.Errorf("frame %d length = %d, want 11", i, len(frame))
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Closes the last symbol-domain piece of the P25 Phase 1 ingest pipeline. After C4FM demod produces dibits, `phase1.LDUAssembler` turns them into complete 1728-bit LDU buffers ready for `ExtractVoiceFrames`.

```go
type LDUSink func(ldu []byte)

func NewLDUAssembler(sink LDUSink, tolerance int) *LDUAssembler
func (*LDUAssembler) Process(dibits []uint8)   // streaming input
func (*LDUAssembler) Reset()                   // clear state on re-sync
func (*LDUAssembler) Buffered() int            // tests + introspection
```

### State machine

- **awaiting FSW**: slide a 24-dibit window forward, compare to `FrameSyncWord`, latch when mismatch ≤ tolerance.
- **collecting**: continue buffering; once 864 dibits (= 1728 bits) have arrived since FSW start, concatenate to a byte stream via `framing.DibitsToBits` and hand to the sink callback.
- **compact**: drop the consumed LDU from the buffer, return to awaiting FSW.

Tolerance defaults to 4 dibit-position mismatches (matches the existing `SyncDetector` default). Sink invocations are synchronous and in-order: a caller building "stream of LDUs through `ExtractVoiceFrames`" just passes a closure that calls `phase1.ExtractVoiceFrames(ldu)` + `recorder.WriteRawFrame` per emitted LDU.

### Tests (+7, phase1 total now 56)

- `TestLDUAssemblerEmitsOnClean864` — FSW + 840 trailing dibits → one 1728-bit LDU; first 48 bits match canonical FSW bits; buffer compacts to 0 after emission.
- `TestLDUAssemblerSkipsLeadingGarbage` — 100 dibits of non-FSW noise before a valid LDU → exactly one emission starting at the FSW.
- `TestLDUAssemblerHandlesMultipleLDUs` — back-to-back LDUs fire the sink twice; buffer compacts between emissions.
- `TestLDUAssemblerNoEmitOnPartialLDU` — incomplete trailing dibits don't fire the sink; subsequent dibits complete the LDU.
- `TestLDUAssemblerToleratesNoisyFSW` — 3 corrupted FSW dibits with `tolerance=4` → latches; same noisy FSW with `tolerance=2` → rejected. Pins the tolerance contract.
- `TestLDUAssemblerResetClearsState` — mid-LDU Reset returns the assembler to a clean awaiting-FSW state.
- `TestLDUAssemblerEmitsLDUConsumableByExtractVoiceFrames` — **end-to-end**. Build a synthetic LDU containing 9 properly-encoded IMBE subframes (`EncodeChannel + Scramble` at the documented voice offsets) + status symbols → bits → dibits. Feed dibits to the assembler. Confirm the emitted LDU is accepted by `ExtractVoiceFrames` with `totalErrs=0`. Closes the loop between assembler output and the voice-extraction primitives.

## What's still missing

The **IQ → C4FM dibit** step (matched filter, symbol clock recovery, 4-level slicer). Once that lands, the chain composer → C4FM demod → `LDUAssembler` → `ExtractVoiceFrames` → recorder → vocoder → WAV runs end-to-end on real radio captures.

## Test plan

- [x] `go vet ./...` clean (modulo the pre-existing librtlsdr CGO link in this env)
- [x] `go test -race -count=1 ./internal/radio/p25/phase1/...` all 56 tests pass (+7 new)
- [x] End-to-end synthetic stream: dibits → LDUAssembler → ExtractVoiceFrames → 9 frames with totalErrs=0
- [x] Backward compat: the previously-shipped LDU + IMBE primitives untouched
- [ ] After IQ → dibit demod lands + a real P25 P1 capture is available: feed IQ → C4FM demod → LDUAssembler → recorder → audible voice in the WAV

## Files

```
README.md                                      |  18 +-
internal/radio/p25/phase1/ldu_assembler.go     | 122 ++++++++++++
internal/radio/p25/phase1/ldu_assembler_test.go| 246 ++++++++++++++++++++++++
3 files changed, 386 insertions(+), 4 deletions(-)
```

https://claude.ai/code/session_01SvuTSKyeTrSX9V352L9GVH

---
_Generated by [Claude Code](https://claude.ai/code/session_01SvuTSKyeTrSX9V352L9GVH)_