### PR TITLE
internal/sdr/rtlsdr/usb: pure-Go USB transport + mock + Linux USBDEVFS

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,32 @@ to its own package and lands independently.
   factory that opens a connected DVSI USB chip. Same plug-in shape
   as `internal/voice/ambe2`; the daemon picks the factory by name
   from `voice.DefaultRegistry`.
+- **Pure-Go RTL-SDR driver.** A `CGO_ENABLED=0` replacement for
+  the `librtlsdr` + `libusb-1.0` C dependency, mirroring the
+  mbelib → pure-Go IMBE/AMBE+2 migration. The driver layers a
+  platform USB transport (`internal/sdr/rtlsdr/usb/` — Linux
+  USBDEVFS ioctls on `/dev/bus/usb/BBB/DDD`, Windows WinUSB via
+  lazy-loaded DLL, macOS IOKit via `purego`) under a pure-Go
+  RTL2832U register / I2C layer and per-tuner drivers (R820T,
+  R820T2, R828D, E4000, FC0012, FC0013, FC2580). The
+  `sdr.Device` interface and IQ-format conversion at
+  `internal/sdr/rtlsdr/rtlsdr_cgo.go:225-240` are preserved
+  bit-identically so the DSP chain is untouched. Status: PR-01
+  landed — `internal/sdr/rtlsdr/usb/` exposes the `Transport` +
+  `Enumerator` interfaces, a record/replay `MockTransport` for
+  unit tests, and the Linux USBDEVFS backend (ioctl encoding,
+  sysfs enumeration with VID/PID filtering, vendor-IN/OUT control
+  transfers, 32-deep URB ring on the bulk-IN endpoint with a
+  dedicated reaper goroutine, claim/release/reset/close
+  lifecycle); non-Linux platforms compile with a clear
+  `ErrUnsupportedPlatform` stub. PRs 02-10 land the Windows
+  WinUSB backend, the macOS stub + IOKit follow-up, the
+  RTL2832U register/I2C layer, the R820T2 tuner, the wire-up
+  under the alternate driver name `rtlsdr-go`, the remaining
+  five tuners, the default flip, and the deletion of
+  `rtlsdr_cgo.go` + every `librtlsdr` apt / MSYS2 / DLL-bundling
+  step in `Dockerfile`, `.github/workflows/*.yml`,
+  `installer/gophertrunk.iss`, and the install docs.
 - **YSF Trellis decode + grant emission.** Sync, frame layout, and
   the post-FEC FICH bit-level parser are in; what's left is the
   K=5 ½-rate Viterbi Trellis decoder over the on-air 100-bit FICH
@@ -332,7 +358,8 @@ tests.
 ```
 cmd/gophertrunk/        daemon entrypoint + sdr list CLI + read-only TUI
 internal/tui/           bubbletea TUI: 8 read-only panels over REST+SSE
-internal/sdr/           Driver interface, pool, CGO librtlsdr, mock
+internal/sdr/           Driver interface, pool, CGO librtlsdr (→ pure-Go), mock
+internal/sdr/rtlsdr/usb/ Pure-Go USB transport: Linux USBDEVFS, mock
 internal/dsp/           Channelizer, filters, demods, sync, FFT
 internal/radio/         framing/ + p25/phase1/ + dmr/ + nxdn/
 internal/trunking/      System, talkgroup DB, priority, engine, CC hunter

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/prometheus/client_golang v1.23.2
+	golang.org/x/sys v0.42.0
 	gonum.org/v1/gonum v0.17.0
 	google.golang.org/grpc v1.81.0
 	google.golang.org/protobuf v1.36.11
@@ -50,7 +51,6 @@ require (
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	golang.org/x/net v0.51.0 // indirect
-	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/text v0.34.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260226221140-a57be14db171 // indirect
 	modernc.org/libc v1.72.0 // indirect

--- a/internal/sdr/rtlsdr/usb/usb.go
+++ b/internal/sdr/rtlsdr/usb/usb.go
@@ -1,0 +1,145 @@
+// Package usb is the platform-abstraction layer that the pure-Go RTL-SDR
+// driver speaks to. It exposes the minimal slice of USB the RTL2832U
+// demodulator needs — vendor control transfers in both directions and an
+// async bulk-IN endpoint — and nothing else.
+//
+// Each supported OS provides one implementation behind the [Enumerator]
+// interface returned by [DefaultEnumerator]:
+//
+//   - Linux uses USBDEVFS ioctls on /dev/bus/usb/BBB/DDD. See usb_linux.go.
+//   - Windows (PR-02) will use WinUSB via the system DLL.
+//   - macOS (PR-10) will use IOKit via purego.
+//
+// A non-platform [MockEnumerator]/[MockTransport] pair lives alongside the
+// real backends so the RTL2832U register layer and the tuner drivers can
+// be unit-tested without touching real hardware.
+package usb
+
+import (
+	"errors"
+)
+
+// Vendor request-type byte values for libusb-style control transfers.
+// RTL2832U firmware only speaks vendor requests; class/standard requests
+// are unused by the driver.
+const (
+	VendorOut uint8 = 0x40 // bmRequestType: host → device, vendor, device recipient
+	VendorIn  uint8 = 0xC0 // bmRequestType: device → host, vendor, device recipient
+)
+
+// Default async-bulk geometry the RTL-SDR driver uses. Held here so the
+// transport implementations can pre-validate caller inputs against a
+// known-good baseline; the driver still supplies the values explicitly.
+const (
+	DefaultRingBuffers = 32
+	DefaultBufferLen   = 16 * 1024
+)
+
+// Descriptor is the pre-resolved identity of a single USB device. Returned
+// by [Enumerator.List] without claiming the device, so enumeration is safe
+// to run without root privileges where sysfs permissions allow it.
+type Descriptor struct {
+	Bus          uint8  // USB bus number
+	Address      uint8  // device address on the bus
+	VID, PID     uint16 // vendor / product ID
+	Serial       string // iSerialNumber, may be empty
+	Manufacturer string // iManufacturer, may be empty
+	Product      string // iProduct, may be empty
+	// Path is the implementation-defined locator (e.g. /dev/bus/usb/001/007
+	// on Linux). Treat as opaque; pass back to [Enumerator.Open] verbatim.
+	Path string
+}
+
+// Transport is a claimed handle on a single USB device. Methods are not
+// goroutine-safe by default — the RTL-SDR driver serializes control
+// transfers through its own mutex — except that [Transport.StopBulkIn]
+// must be safe to call while a foreign goroutine is blocked inside the
+// bulk-IN reaper.
+type Transport interface {
+	// ControlIn issues a vendor-IN control transfer and returns up to n
+	// bytes of response. The returned slice's length equals the number
+	// of bytes the device actually delivered (≤ n).
+	ControlIn(bRequest uint8, wValue, wIndex uint16, n int, timeoutMs int) ([]byte, error)
+
+	// ControlOut issues a vendor-OUT control transfer.
+	ControlOut(bRequest uint8, wValue, wIndex uint16, data []byte, timeoutMs int) error
+
+	// ClaimInterface tells the kernel/driver that this transport owns
+	// the given USB interface number. Must be called before any I/O.
+	ClaimInterface(num int) error
+
+	// ReleaseInterface relinquishes the interface; the device stays
+	// open. Idempotent; calling on an unclaimed interface returns nil.
+	ReleaseInterface(num int) error
+
+	// StartBulkIn submits a ring of `ringBufs` bulk-IN URBs of `bufLen`
+	// bytes each on endpoint epAddr (e.g. 0x81 for RTL-SDR's IQ stream).
+	// onPacket is invoked from a dedicated reaper goroutine each time a
+	// URB completes; the slice passed to it is owned by the transport
+	// and reused once onPacket returns — callers must copy any bytes
+	// they wish to retain.
+	StartBulkIn(epAddr byte, ringBufs, bufLen int, onPacket func([]byte)) error
+
+	// StopBulkIn cancels every in-flight URB, drains the reaper, and
+	// returns once the goroutine has exited. Safe to call concurrently
+	// with reaper execution; idempotent.
+	StopBulkIn() error
+
+	// Reset performs a USB port reset. The device re-enumerates with
+	// the same address (best effort) but configuration is lost.
+	Reset() error
+
+	// Close releases the device handle. Implies StopBulkIn and
+	// ReleaseInterface for any still-held interfaces.
+	Close() error
+}
+
+// Enumerator discovers and opens USB devices on the host. One instance
+// represents one platform backend; obtained via [DefaultEnumerator].
+type Enumerator interface {
+	// Name identifies the backend (e.g. "usbdevfs", "winusb", "iokit",
+	// "mock"). Used in error messages and logs.
+	Name() string
+
+	// List returns every device that matches both vid and pid. A zero
+	// value for either acts as a wildcard.
+	List(vid, pid uint16) ([]Descriptor, error)
+
+	// Open claims a device identified by a Descriptor previously
+	// returned from List.
+	Open(d Descriptor) (Transport, error)
+}
+
+// Sentinel errors. Implementations may wrap these or return their own
+// types; callers compare with errors.Is.
+var (
+	// ErrUnsupportedPlatform is returned by [DefaultEnumerator] when the
+	// running OS has no USB backend compiled in.
+	ErrUnsupportedPlatform = errors.New("usb: backend not implemented on this platform")
+
+	// ErrBulkActive is returned by StartBulkIn when a stream is already
+	// running on the transport.
+	ErrBulkActive = errors.New("usb: bulk-IN already active")
+
+	// ErrBulkInactive is returned by StopBulkIn when no stream is
+	// running.
+	ErrBulkInactive = errors.New("usb: bulk-IN not active")
+
+	// ErrDeviceGone is returned by any operation after the device has
+	// been physically removed or the kernel has decided it's dead.
+	// Maps to ENODEV on Linux and ERROR_GEN_FAILURE on Windows.
+	ErrDeviceGone = errors.New("usb: device disconnected")
+
+	// ErrTimeout is returned when a control transfer didn't complete
+	// within the supplied timeoutMs window.
+	ErrTimeout = errors.New("usb: transfer timed out")
+
+	// ErrClosed is returned by methods invoked after Close.
+	ErrClosed = errors.New("usb: transport closed")
+)
+
+// DefaultEnumerator returns the platform's USB backend. On platforms
+// without a backend it returns one whose every method yields
+// [ErrUnsupportedPlatform]; this keeps higher layers compilable across
+// the OS matrix while the driver is iterated PR-by-PR.
+func DefaultEnumerator() Enumerator { return platformEnumerator() }

--- a/internal/sdr/rtlsdr/usb/usb_linux.go
+++ b/internal/sdr/rtlsdr/usb/usb_linux.go
@@ -1,0 +1,493 @@
+//go:build linux && (amd64 || arm64 || 386 || arm || riscv64 || loong64)
+
+package usb
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+// usbdevfsCtrltransfer mirrors struct usbdevfs_ctrltransfer in
+// <linux/usbdevice_fs.h>. The build tag above restricts this file to
+// architectures where Go's natural field alignment matches the kernel's
+// (asm-generic ioctl encoding + LP64/ILP32 with no pragma pack), so the
+// Go compiler's auto-padding produces a wire-identical struct.
+type usbdevfsCtrltransfer struct {
+	BmRequestType uint8
+	BRequest      uint8
+	WValue        uint16
+	WIndex        uint16
+	WLength       uint16
+	Timeout       uint32
+	Data          *byte
+}
+
+// usbdevfsURB mirrors struct usbdevfs_urb (without the trailing
+// iso_frame_desc flexible array — RTL-SDR only uses bulk).
+type usbdevfsURB struct {
+	Type            uint8
+	Endpoint        uint8
+	Status          int32
+	Flags           uint32
+	Buffer          *byte
+	BufferLength    int32
+	ActualLength    int32
+	StartFrame      int32
+	NumberOfPackets int32 // union with stream_id; unused for bulk
+	ErrorCount      int32
+	Signr           uint32
+	Usercontext     *byte
+}
+
+const (
+	usbdevfsURBTypeBULK = 3
+)
+
+// asm-generic ioctl encoding.
+const (
+	iocNRShift   = 0
+	iocTypeShift = 8
+	iocSizeShift = 16
+	iocDirShift  = 30
+
+	iocNone  = 0
+	iocWrite = 1
+	iocRead  = 2
+)
+
+func ioc(dir, typ, nr, size uintptr) uintptr {
+	return (dir << iocDirShift) | (typ << iocTypeShift) | (nr << iocNRShift) | (size << iocSizeShift)
+}
+
+var (
+	usbdevfsControl          = ioc(iocRead|iocWrite, 'U', 0, unsafe.Sizeof(usbdevfsCtrltransfer{}))
+	usbdevfsSubmitURB        = ioc(iocRead, 'U', 10, unsafe.Sizeof(usbdevfsURB{}))
+	usbdevfsDiscardURB       = ioc(iocNone, 'U', 11, 0)
+	usbdevfsReapURB          = ioc(iocWrite, 'U', 12, unsafe.Sizeof(uintptr(0)))
+	usbdevfsClaimInterface   = ioc(iocRead, 'U', 15, 4)
+	usbdevfsReleaseInterface = ioc(iocRead, 'U', 16, 4)
+	usbdevfsReset            = ioc(iocNone, 'U', 20, 0)
+)
+
+func platformEnumerator() Enumerator { return &linuxEnumerator{} }
+
+// linuxEnumerator walks /sys/bus/usb/devices for [Descriptor]s and opens
+// matching device nodes under /dev/bus/usb. Both roots can be overridden
+// from tests by setting [linuxEnumerator.sysfsRoot] / [linuxEnumerator.devfsRoot].
+type linuxEnumerator struct {
+	sysfsRoot string
+	devfsRoot string
+}
+
+func (l *linuxEnumerator) Name() string { return "usbdevfs" }
+
+func (l *linuxEnumerator) sysfs() string {
+	if l.sysfsRoot != "" {
+		return l.sysfsRoot
+	}
+	return "/sys/bus/usb/devices"
+}
+
+func (l *linuxEnumerator) devfs() string {
+	if l.devfsRoot != "" {
+		return l.devfsRoot
+	}
+	return "/dev/bus/usb"
+}
+
+func (l *linuxEnumerator) List(vid, pid uint16) ([]Descriptor, error) {
+	root := l.sysfs()
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("usbdevfs: read %s: %w", root, err)
+	}
+	var out []Descriptor
+	for _, e := range entries {
+		path := filepath.Join(root, e.Name())
+		v, ok1 := readHex16(filepath.Join(path, "idVendor"))
+		p, ok2 := readHex16(filepath.Join(path, "idProduct"))
+		if !ok1 || !ok2 {
+			continue
+		}
+		if vid != 0 && v != vid {
+			continue
+		}
+		if pid != 0 && p != pid {
+			continue
+		}
+		bus, busOK := readUint8(filepath.Join(path, "busnum"))
+		addr, addrOK := readUint8(filepath.Join(path, "devnum"))
+		if !busOK || !addrOK {
+			continue
+		}
+		d := Descriptor{
+			Bus:          bus,
+			Address:      addr,
+			VID:          v,
+			PID:          p,
+			Serial:       readTrim(filepath.Join(path, "serial")),
+			Manufacturer: readTrim(filepath.Join(path, "manufacturer")),
+			Product:      readTrim(filepath.Join(path, "product")),
+			Path:         filepath.Join(l.devfs(), fmt.Sprintf("%03d", bus), fmt.Sprintf("%03d", addr)),
+		}
+		out = append(out, d)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Bus != out[j].Bus {
+			return out[i].Bus < out[j].Bus
+		}
+		return out[i].Address < out[j].Address
+	})
+	return out, nil
+}
+
+func (l *linuxEnumerator) Open(d Descriptor) (Transport, error) {
+	path := d.Path
+	if path == "" {
+		path = filepath.Join(l.devfs(), fmt.Sprintf("%03d", d.Bus), fmt.Sprintf("%03d", d.Address))
+	}
+	fd, err := unix.Open(path, unix.O_RDWR|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return nil, fmt.Errorf("usbdevfs: open %s: %w", path, err)
+	}
+	return &linuxTransport{fd: fd, path: path, desc: d}, nil
+}
+
+// linuxTransport is the USBDEVFS-backed [Transport].
+type linuxTransport struct {
+	fd     int
+	path   string
+	desc   Descriptor
+	closed atomic.Bool
+
+	claimMu sync.Mutex
+	claimed []int
+
+	bulkMu        sync.Mutex
+	bulkActive    bool
+	bulkSlots     []*bulkSlot
+	bulkSubmitted int
+	bulkStopFlag  atomic.Int32
+	bulkDone      chan struct{}
+}
+
+type bulkSlot struct {
+	urb *usbdevfsURB
+	buf []byte
+}
+
+func (t *linuxTransport) ControlIn(bRequest uint8, wValue, wIndex uint16, n int, timeoutMs int) ([]byte, error) {
+	if t.closed.Load() {
+		return nil, ErrClosed
+	}
+	if n < 0 || n > 0xFFFF {
+		return nil, fmt.Errorf("usbdevfs: control IN length %d out of range", n)
+	}
+	var buf []byte
+	var dataPtr *byte
+	if n > 0 {
+		buf = make([]byte, n)
+		dataPtr = &buf[0]
+	}
+	ctrl := usbdevfsCtrltransfer{
+		BmRequestType: VendorIn,
+		BRequest:      bRequest,
+		WValue:        wValue,
+		WIndex:        wIndex,
+		WLength:       uint16(n),
+		Timeout:       uint32(timeoutMs),
+		Data:          dataPtr,
+	}
+	ret, _, errno := unix.Syscall(unix.SYS_IOCTL, uintptr(t.fd), usbdevfsControl, uintptr(unsafe.Pointer(&ctrl)))
+	if errno != 0 {
+		return nil, translateErrno(errno)
+	}
+	return buf[:int(ret)], nil
+}
+
+func (t *linuxTransport) ControlOut(bRequest uint8, wValue, wIndex uint16, data []byte, timeoutMs int) error {
+	if t.closed.Load() {
+		return ErrClosed
+	}
+	if len(data) > 0xFFFF {
+		return fmt.Errorf("usbdevfs: control OUT length %d out of range", len(data))
+	}
+	var dataPtr *byte
+	if len(data) > 0 {
+		dataPtr = &data[0]
+	}
+	ctrl := usbdevfsCtrltransfer{
+		BmRequestType: VendorOut,
+		BRequest:      bRequest,
+		WValue:        wValue,
+		WIndex:        wIndex,
+		WLength:       uint16(len(data)),
+		Timeout:       uint32(timeoutMs),
+		Data:          dataPtr,
+	}
+	_, _, errno := unix.Syscall(unix.SYS_IOCTL, uintptr(t.fd), usbdevfsControl, uintptr(unsafe.Pointer(&ctrl)))
+	if errno != 0 {
+		return translateErrno(errno)
+	}
+	return nil
+}
+
+func (t *linuxTransport) ClaimInterface(num int) error {
+	if t.closed.Load() {
+		return ErrClosed
+	}
+	n := uint32(num)
+	_, _, errno := unix.Syscall(unix.SYS_IOCTL, uintptr(t.fd), usbdevfsClaimInterface, uintptr(unsafe.Pointer(&n)))
+	if errno != 0 {
+		return translateErrno(errno)
+	}
+	t.claimMu.Lock()
+	t.claimed = append(t.claimed, num)
+	t.claimMu.Unlock()
+	return nil
+}
+
+func (t *linuxTransport) ReleaseInterface(num int) error {
+	if t.closed.Load() {
+		return nil
+	}
+	n := uint32(num)
+	_, _, errno := unix.Syscall(unix.SYS_IOCTL, uintptr(t.fd), usbdevfsReleaseInterface, uintptr(unsafe.Pointer(&n)))
+	t.claimMu.Lock()
+	for i, c := range t.claimed {
+		if c == num {
+			t.claimed = append(t.claimed[:i], t.claimed[i+1:]...)
+			break
+		}
+	}
+	t.claimMu.Unlock()
+	if errno != 0 && errno != unix.ENODEV {
+		return translateErrno(errno)
+	}
+	return nil
+}
+
+func (t *linuxTransport) Reset() error {
+	if t.closed.Load() {
+		return ErrClosed
+	}
+	_, _, errno := unix.Syscall(unix.SYS_IOCTL, uintptr(t.fd), usbdevfsReset, 0)
+	if errno != 0 {
+		return translateErrno(errno)
+	}
+	return nil
+}
+
+func (t *linuxTransport) StartBulkIn(epAddr byte, ringBufs, bufLen int, onPacket func([]byte)) error {
+	if t.closed.Load() {
+		return ErrClosed
+	}
+	if ringBufs <= 0 || bufLen <= 0 {
+		return fmt.Errorf("usbdevfs: invalid bulk ring geometry (bufs=%d len=%d)", ringBufs, bufLen)
+	}
+	t.bulkMu.Lock()
+	defer t.bulkMu.Unlock()
+	if t.bulkActive {
+		return ErrBulkActive
+	}
+	slots := make([]*bulkSlot, 0, ringBufs)
+	for i := 0; i < ringBufs; i++ {
+		buf := make([]byte, bufLen)
+		urb := &usbdevfsURB{
+			Type:         usbdevfsURBTypeBULK,
+			Endpoint:     epAddr,
+			Buffer:       &buf[0],
+			BufferLength: int32(bufLen),
+		}
+		_, _, errno := unix.Syscall(unix.SYS_IOCTL, uintptr(t.fd), usbdevfsSubmitURB, uintptr(unsafe.Pointer(urb)))
+		if errno != 0 {
+			for _, s := range slots {
+				_, _, _ = unix.Syscall(unix.SYS_IOCTL, uintptr(t.fd), usbdevfsDiscardURB, uintptr(unsafe.Pointer(s.urb)))
+			}
+			t.drainSubmitted(len(slots))
+			return fmt.Errorf("usbdevfs: SUBMITURB[%d]: %w", i, translateErrno(errno))
+		}
+		slots = append(slots, &bulkSlot{urb: urb, buf: buf})
+	}
+	t.bulkSlots = slots
+	t.bulkSubmitted = len(slots)
+	t.bulkActive = true
+	t.bulkStopFlag.Store(0)
+	t.bulkDone = make(chan struct{})
+
+	go t.reapLoop(onPacket, slots, t.bulkSubmitted, t.bulkDone)
+	return nil
+}
+
+// drainSubmitted reaps the given number of URBs without dispatching them;
+// used to recover from a partial StartBulkIn failure.
+func (t *linuxTransport) drainSubmitted(n int) {
+	for i := 0; i < n; i++ {
+		var ptr uintptr
+		_, _, errno := unix.Syscall(unix.SYS_IOCTL, uintptr(t.fd), usbdevfsReapURB, uintptr(unsafe.Pointer(&ptr)))
+		if errno != 0 && errno != unix.EINTR {
+			return
+		}
+	}
+}
+
+func (t *linuxTransport) reapLoop(onPacket func([]byte), slots []*bulkSlot, submitted int, done chan struct{}) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+	defer close(done)
+	remaining := submitted
+	for remaining > 0 {
+		var ptr uintptr
+		_, _, errno := unix.Syscall(unix.SYS_IOCTL, uintptr(t.fd), usbdevfsReapURB, uintptr(unsafe.Pointer(&ptr)))
+		if errno != 0 {
+			if errno == unix.EINTR {
+				continue
+			}
+			return
+		}
+		// The kernel returns the address of the URB we previously submitted.
+		// Don't deref the raw uintptr — look it up against our slot ring
+		// (whose entries Go's GC keeps alive) and use that pointer instead.
+		slot := findSlotByAddr(slots, ptr)
+		if slot == nil {
+			continue
+		}
+		urb := slot.urb
+		stop := t.bulkStopFlag.Load() != 0
+		if !stop {
+			if urb.Status == 0 && urb.ActualLength > 0 {
+				onPacket(slot.buf[:urb.ActualLength])
+			}
+			urb.ActualLength = 0
+			urb.Status = 0
+			_, _, errno = unix.Syscall(unix.SYS_IOCTL, uintptr(t.fd), usbdevfsSubmitURB, uintptr(unsafe.Pointer(urb)))
+			if errno != 0 {
+				remaining--
+			}
+			continue
+		}
+		remaining--
+	}
+}
+
+func (t *linuxTransport) StopBulkIn() error {
+	t.bulkMu.Lock()
+	if !t.bulkActive {
+		t.bulkMu.Unlock()
+		return ErrBulkInactive
+	}
+	t.bulkStopFlag.Store(1)
+	slots := t.bulkSlots
+	done := t.bulkDone
+	t.bulkActive = false
+	t.bulkMu.Unlock()
+
+	for _, s := range slots {
+		_, _, _ = unix.Syscall(unix.SYS_IOCTL, uintptr(t.fd), usbdevfsDiscardURB, uintptr(unsafe.Pointer(s.urb)))
+	}
+	<-done
+
+	t.bulkMu.Lock()
+	t.bulkSlots = nil
+	t.bulkSubmitted = 0
+	t.bulkMu.Unlock()
+	return nil
+}
+
+func (t *linuxTransport) Close() error {
+	if !t.closed.CompareAndSwap(false, true) {
+		return nil
+	}
+	t.bulkMu.Lock()
+	active := t.bulkActive
+	t.bulkMu.Unlock()
+	if active {
+		// Reset the closed flag transiently so StopBulkIn can run.
+		t.closed.Store(false)
+		_ = t.StopBulkIn()
+		t.closed.Store(true)
+	}
+	t.claimMu.Lock()
+	for _, num := range t.claimed {
+		n := uint32(num)
+		_, _, _ = unix.Syscall(unix.SYS_IOCTL, uintptr(t.fd), usbdevfsReleaseInterface, uintptr(unsafe.Pointer(&n)))
+	}
+	t.claimed = nil
+	t.claimMu.Unlock()
+	if t.fd >= 0 {
+		unix.Close(t.fd)
+		t.fd = -1
+	}
+	return nil
+}
+
+func findSlotByAddr(slots []*bulkSlot, addr uintptr) *bulkSlot {
+	for _, s := range slots {
+		if uintptr(unsafe.Pointer(s.urb)) == addr {
+			return s
+		}
+	}
+	return nil
+}
+
+func translateErrno(errno syscall.Errno) error {
+	switch errno {
+	case unix.ENODEV, unix.ENXIO, unix.ESHUTDOWN:
+		return ErrDeviceGone
+	case unix.ETIMEDOUT:
+		return ErrTimeout
+	default:
+		return errno
+	}
+}
+
+// ----------------------------------------------------------------------
+// sysfs helpers
+
+func readTrim(path string) string {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(b))
+}
+
+func readHex16(path string) (uint16, bool) {
+	s := readTrim(path)
+	if s == "" {
+		return 0, false
+	}
+	v, err := strconv.ParseUint(s, 16, 16)
+	if err != nil {
+		return 0, false
+	}
+	return uint16(v), true
+}
+
+func readUint8(path string) (uint8, bool) {
+	s := readTrim(path)
+	if s == "" {
+		return 0, false
+	}
+	v, err := strconv.ParseUint(s, 10, 8)
+	if err != nil {
+		return 0, false
+	}
+	return uint8(v), true
+}

--- a/internal/sdr/rtlsdr/usb/usb_linux_test.go
+++ b/internal/sdr/rtlsdr/usb/usb_linux_test.go
@@ -1,0 +1,184 @@
+//go:build linux && (amd64 || arm64 || 386 || arm || riscv64 || loong64)
+
+package usb
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"unsafe"
+)
+
+// fakeUSBDevice writes the sysfs files that linuxEnumerator.List reads.
+type fakeUSBDevice struct {
+	dir          string // sysfs entry name (e.g. "1-1.4")
+	vid, pid     string // hex strings without 0x prefix, lowercase
+	bus, dev     string // decimal
+	serial       string
+	manufacturer string
+	product      string
+	skipVID      bool // omit idVendor (simulates non-device sysfs entries)
+}
+
+func writeFakeSysfs(t *testing.T, devs []fakeUSBDevice) string {
+	t.Helper()
+	root := t.TempDir()
+	for _, d := range devs {
+		entry := filepath.Join(root, d.dir)
+		if err := os.MkdirAll(entry, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", entry, err)
+		}
+		write := func(name, val string) {
+			if val == "" {
+				return
+			}
+			if err := os.WriteFile(filepath.Join(entry, name), []byte(val+"\n"), 0o644); err != nil {
+				t.Fatalf("write %s/%s: %v", entry, name, err)
+			}
+		}
+		if !d.skipVID {
+			write("idVendor", d.vid)
+			write("idProduct", d.pid)
+		}
+		write("busnum", d.bus)
+		write("devnum", d.dev)
+		write("serial", d.serial)
+		write("manufacturer", d.manufacturer)
+		write("product", d.product)
+	}
+	return root
+}
+
+func TestLinuxEnumerator_ListParsesSysfs(t *testing.T) {
+	root := writeFakeSysfs(t, []fakeUSBDevice{
+		{dir: "1-1.4", vid: "0bda", pid: "2838", bus: "1", dev: "7",
+			serial: "00000001", manufacturer: "Realtek", product: "RTL2838UHIDIR"},
+		{dir: "1-2", vid: "0bda", pid: "2832", bus: "1", dev: "8",
+			serial: "00000002", manufacturer: "Realtek", product: "RTL2832U"},
+		{dir: "1-3", vid: "1d50", pid: "6089", bus: "1", dev: "9",
+			serial: "hackrf-one"},
+		{dir: "usb1", skipVID: true}, // root hub-style entry; must be skipped
+	})
+
+	e := &linuxEnumerator{sysfsRoot: root, devfsRoot: "/dev/bus/usb"}
+	all, err := e.List(0, 0)
+	if err != nil {
+		t.Fatalf("List(0,0): %v", err)
+	}
+	if got, want := len(all), 3; got != want {
+		t.Fatalf("List(0,0) len = %d, want %d (got %+v)", got, want, all)
+	}
+
+	rtl, err := e.List(0x0bda, 0)
+	if err != nil {
+		t.Fatalf("List vendor: %v", err)
+	}
+	if got, want := len(rtl), 2; got != want {
+		t.Fatalf("Realtek len = %d, want %d", got, want)
+	}
+
+	exact, err := e.List(0x0bda, 0x2838)
+	if err != nil {
+		t.Fatalf("List exact: %v", err)
+	}
+	if len(exact) != 1 {
+		t.Fatalf("exact match len = %d, want 1", len(exact))
+	}
+	d := exact[0]
+	if d.Bus != 1 || d.Address != 7 || d.VID != 0x0bda || d.PID != 0x2838 {
+		t.Errorf("descriptor = %+v, want {bus:1 addr:7 vid:0bda pid:2838}", d)
+	}
+	if d.Serial != "00000001" || d.Product != "RTL2838UHIDIR" || d.Manufacturer != "Realtek" {
+		t.Errorf("strings = (%q,%q,%q), want (Realtek,RTL2838UHIDIR,00000001)", d.Manufacturer, d.Product, d.Serial)
+	}
+	if d.Path != "/dev/bus/usb/001/007" {
+		t.Errorf("Path = %q, want /dev/bus/usb/001/007", d.Path)
+	}
+}
+
+func TestLinuxEnumerator_ListSortedByBusThenAddress(t *testing.T) {
+	root := writeFakeSysfs(t, []fakeUSBDevice{
+		{dir: "2-1", vid: "0bda", pid: "2832", bus: "2", dev: "3"},
+		{dir: "1-2", vid: "0bda", pid: "2832", bus: "1", dev: "9"},
+		{dir: "1-1", vid: "0bda", pid: "2832", bus: "1", dev: "2"},
+	})
+	e := &linuxEnumerator{sysfsRoot: root}
+	all, _ := e.List(0, 0)
+	if len(all) != 3 {
+		t.Fatalf("got %d descriptors", len(all))
+	}
+	if all[0].Bus != 1 || all[0].Address != 2 {
+		t.Errorf("first = %+v, want bus=1 addr=2", all[0])
+	}
+	if all[1].Bus != 1 || all[1].Address != 9 {
+		t.Errorf("second = %+v, want bus=1 addr=9", all[1])
+	}
+	if all[2].Bus != 2 || all[2].Address != 3 {
+		t.Errorf("third = %+v, want bus=2 addr=3", all[2])
+	}
+}
+
+func TestLinuxEnumerator_MissingRootReturnsNil(t *testing.T) {
+	e := &linuxEnumerator{sysfsRoot: filepath.Join(t.TempDir(), "does-not-exist")}
+	all, err := e.List(0, 0)
+	if err != nil {
+		t.Fatalf("List on missing root: %v", err)
+	}
+	if all != nil {
+		t.Errorf("descriptors = %v, want nil", all)
+	}
+}
+
+func TestLinuxEnumerator_BadHexSkipped(t *testing.T) {
+	root := writeFakeSysfs(t, []fakeUSBDevice{
+		{dir: "1-1", vid: "zzzz", pid: "2832", bus: "1", dev: "2"},
+		{dir: "1-2", vid: "0bda", pid: "2832", bus: "1", dev: "3"},
+	})
+	e := &linuxEnumerator{sysfsRoot: root}
+	all, _ := e.List(0, 0)
+	if len(all) != 1 {
+		t.Fatalf("got %d descriptors, want 1 (bad-hex entry should be skipped)", len(all))
+	}
+}
+
+func TestIoctlEncodings(t *testing.T) {
+	// USBDEVFS_DISCARDURB is _IO('U', 11) — direction NONE, size 0.
+	// _IOC encoding: (0<<30) | ('U'<<8) | 11 = 0x550B.
+	if got, want := usbdevfsDiscardURB, uintptr(0x550B); got != want {
+		t.Errorf("usbdevfsDiscardURB = 0x%X, want 0x%X", got, want)
+	}
+	// USBDEVFS_RESET is _IO('U', 20) = 0x5514.
+	if got, want := usbdevfsReset, uintptr(0x5514); got != want {
+		t.Errorf("usbdevfsReset = 0x%X, want 0x%X", got, want)
+	}
+	// USBDEVFS_CLAIMINTERFACE is _IOR('U', 15, unsigned int) = 0x8004550F.
+	if got, want := usbdevfsClaimInterface, uintptr(0x8004550F); got != want {
+		t.Errorf("usbdevfsClaimInterface = 0x%X, want 0x%X", got, want)
+	}
+	// USBDEVFS_RELEASEINTERFACE is _IOR('U', 16, unsigned int) = 0x80045510.
+	if got, want := usbdevfsReleaseInterface, uintptr(0x80045510); got != want {
+		t.Errorf("usbdevfsReleaseInterface = 0x%X, want 0x%X", got, want)
+	}
+}
+
+func TestIoctlEncodings_64Bit(t *testing.T) {
+	// On 64-bit arches the struct sizes match the kernel's published
+	// constants. On 32-bit they differ (pointers are 4 bytes), so the
+	// ioctl number changes accordingly — we only assert the 64-bit
+	// values here.
+	if unsafe.Sizeof(uintptr(0)) != 8 {
+		t.Skip("32-bit arch; skipping 64-bit ioctl constants")
+	}
+	// USBDEVFS_CONTROL is _IOWR('U', 0, 24) = 0xC0185500 on 64-bit.
+	if got, want := usbdevfsControl, uintptr(0xC0185500); got != want {
+		t.Errorf("usbdevfsControl = 0x%X, want 0x%X", got, want)
+	}
+	// USBDEVFS_SUBMITURB is _IOR('U', 10, 56) = 0x8038550A on 64-bit.
+	if got, want := usbdevfsSubmitURB, uintptr(0x8038550A); got != want {
+		t.Errorf("usbdevfsSubmitURB = 0x%X, want 0x%X", got, want)
+	}
+	// USBDEVFS_REAPURB is _IOW('U', 12, 8) = 0x4008550C on 64-bit.
+	if got, want := usbdevfsReapURB, uintptr(0x4008550C); got != want {
+		t.Errorf("usbdevfsReapURB = 0x%X, want 0x%X", got, want)
+	}
+}

--- a/internal/sdr/rtlsdr/usb/usb_mock.go
+++ b/internal/sdr/rtlsdr/usb/usb_mock.go
@@ -1,0 +1,285 @@
+package usb
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+// MockEnumerator returns a fixed set of [Descriptor] values and opens each
+// of them as a [MockTransport]. It is the test fixture used by every
+// higher layer (rtl2832u, tuners) so the RTL-SDR driver can be exercised
+// without a real dongle in CI.
+type MockEnumerator struct {
+	BackendName string         // override "mock" if set
+	Devices     []Descriptor   // returned by List, filtered by vid/pid
+	OpenFunc    func(Descriptor) (*MockTransport, error)
+}
+
+func (m *MockEnumerator) Name() string {
+	if m.BackendName != "" {
+		return m.BackendName
+	}
+	return "mock"
+}
+
+func (m *MockEnumerator) List(vid, pid uint16) ([]Descriptor, error) {
+	out := make([]Descriptor, 0, len(m.Devices))
+	for _, d := range m.Devices {
+		if vid != 0 && d.VID != vid {
+			continue
+		}
+		if pid != 0 && d.PID != pid {
+			continue
+		}
+		out = append(out, d)
+	}
+	return out, nil
+}
+
+func (m *MockEnumerator) Open(d Descriptor) (Transport, error) {
+	if m.OpenFunc != nil {
+		return m.OpenFunc(d)
+	}
+	return NewMockTransport(), nil
+}
+
+// CtrlExchange is one step in a [MockTransport.Script]. ControlIn matches
+// against (BRequest, WValue, WIndex) and returns Reply; ControlOut matches
+// the same triple plus the data payload and returns Err. Direction is
+// inferred from In: if In is true the SUT must call ControlIn, otherwise
+// ControlOut.
+type CtrlExchange struct {
+	In        bool
+	BRequest  uint8
+	WValue    uint16
+	WIndex    uint16
+	Data      []byte // expected for OUT, ignored for IN
+	Reply     []byte // returned for IN, ignored for OUT
+	Err       error  // returned instead of completing the transfer
+	N         int    // expected `n` for IN (0 = don't check)
+	TimeoutOK bool   // when true, ignore the SUT's timeout arg
+}
+
+// MockTransport replays a [Script] of [CtrlExchange] entries in order.
+// Mismatched calls fail with an error captured in [MockTransport.Err];
+// tests inspect Err after running the SUT. Bulk-IN is supported by
+// pushing pre-built byte slices into BulkPackets; the transport spaces
+// them by BulkInterval (default 0 = back-to-back).
+type MockTransport struct {
+	Script        []CtrlExchange
+	Step          int
+	Err           error
+	ClaimedIfaces map[int]bool
+	Closed        bool
+
+	BulkPackets  [][]byte
+	BulkInterval time.Duration
+
+	mu       sync.Mutex
+	bulkActv bool
+	bulkStop chan struct{}
+	bulkDone chan struct{}
+}
+
+// NewMockTransport returns an empty mock that fails every transfer until
+// Script is populated. Useful when a test only cares about lifecycle
+// (Open / ClaimInterface / Close).
+func NewMockTransport() *MockTransport {
+	return &MockTransport{ClaimedIfaces: map[int]bool{}}
+}
+
+func (m *MockTransport) recordErr(err error) {
+	if m.Err == nil {
+		m.Err = err
+	}
+}
+
+func (m *MockTransport) ControlIn(bRequest uint8, wValue, wIndex uint16, n int, timeoutMs int) ([]byte, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.Closed {
+		return nil, ErrClosed
+	}
+	if m.Step >= len(m.Script) {
+		err := fmt.Errorf("mock: unexpected ControlIn req=0x%02x val=0x%04x idx=0x%04x n=%d (script exhausted at step %d)", bRequest, wValue, wIndex, n, m.Step)
+		m.recordErr(err)
+		return nil, err
+	}
+	want := m.Script[m.Step]
+	m.Step++
+	if !want.In {
+		err := fmt.Errorf("mock step %d: expected ControlOut, got ControlIn(req=0x%02x,val=0x%04x,idx=0x%04x)", m.Step-1, bRequest, wValue, wIndex)
+		m.recordErr(err)
+		return nil, err
+	}
+	if want.BRequest != bRequest || want.WValue != wValue || want.WIndex != wIndex {
+		err := fmt.Errorf("mock step %d: ControlIn mismatch: got (req=0x%02x,val=0x%04x,idx=0x%04x), want (req=0x%02x,val=0x%04x,idx=0x%04x)", m.Step-1, bRequest, wValue, wIndex, want.BRequest, want.WValue, want.WIndex)
+		m.recordErr(err)
+		return nil, err
+	}
+	if want.N != 0 && want.N != n {
+		err := fmt.Errorf("mock step %d: ControlIn n mismatch: got %d, want %d", m.Step-1, n, want.N)
+		m.recordErr(err)
+		return nil, err
+	}
+	if want.Err != nil {
+		return nil, want.Err
+	}
+	out := make([]byte, len(want.Reply))
+	copy(out, want.Reply)
+	_ = timeoutMs
+	return out, nil
+}
+
+func (m *MockTransport) ControlOut(bRequest uint8, wValue, wIndex uint16, data []byte, timeoutMs int) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.Closed {
+		return ErrClosed
+	}
+	if m.Step >= len(m.Script) {
+		err := fmt.Errorf("mock: unexpected ControlOut req=0x%02x val=0x%04x idx=0x%04x len=%d (script exhausted at step %d)", bRequest, wValue, wIndex, len(data), m.Step)
+		m.recordErr(err)
+		return err
+	}
+	want := m.Script[m.Step]
+	m.Step++
+	if want.In {
+		err := fmt.Errorf("mock step %d: expected ControlIn, got ControlOut(req=0x%02x,val=0x%04x,idx=0x%04x,len=%d)", m.Step-1, bRequest, wValue, wIndex, len(data))
+		m.recordErr(err)
+		return err
+	}
+	if want.BRequest != bRequest || want.WValue != wValue || want.WIndex != wIndex {
+		err := fmt.Errorf("mock step %d: ControlOut mismatch: got (req=0x%02x,val=0x%04x,idx=0x%04x), want (req=0x%02x,val=0x%04x,idx=0x%04x)", m.Step-1, bRequest, wValue, wIndex, want.BRequest, want.WValue, want.WIndex)
+		m.recordErr(err)
+		return err
+	}
+	if !bytesEqual(want.Data, data) {
+		err := fmt.Errorf("mock step %d: ControlOut data mismatch: got %#x, want %#x", m.Step-1, data, want.Data)
+		m.recordErr(err)
+		return err
+	}
+	_ = timeoutMs
+	return want.Err
+}
+
+func (m *MockTransport) ClaimInterface(num int) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.Closed {
+		return ErrClosed
+	}
+	m.ClaimedIfaces[num] = true
+	return nil
+}
+
+func (m *MockTransport) ReleaseInterface(num int) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.ClaimedIfaces, num)
+	return nil
+}
+
+func (m *MockTransport) StartBulkIn(epAddr byte, ringBufs, bufLen int, onPacket func([]byte)) error {
+	m.mu.Lock()
+	if m.Closed {
+		m.mu.Unlock()
+		return ErrClosed
+	}
+	if m.bulkActv {
+		m.mu.Unlock()
+		return ErrBulkActive
+	}
+	m.bulkActv = true
+	m.bulkStop = make(chan struct{})
+	m.bulkDone = make(chan struct{})
+	packets := append([][]byte(nil), m.BulkPackets...)
+	interval := m.BulkInterval
+	m.mu.Unlock()
+
+	go func() {
+		defer close(m.bulkDone)
+		for _, pkt := range packets {
+			select {
+			case <-m.bulkStop:
+				return
+			default:
+			}
+			buf := make([]byte, len(pkt))
+			copy(buf, pkt)
+			onPacket(buf)
+			if interval > 0 {
+				select {
+				case <-m.bulkStop:
+					return
+				case <-time.After(interval):
+				}
+			}
+		}
+		<-m.bulkStop
+	}()
+	_ = epAddr
+	_ = ringBufs
+	_ = bufLen
+	return nil
+}
+
+func (m *MockTransport) StopBulkIn() error {
+	m.mu.Lock()
+	if !m.bulkActv {
+		m.mu.Unlock()
+		return ErrBulkInactive
+	}
+	m.bulkActv = false
+	stop := m.bulkStop
+	done := m.bulkDone
+	m.mu.Unlock()
+	close(stop)
+	<-done
+	return nil
+}
+
+func (m *MockTransport) Reset() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.Closed {
+		return ErrClosed
+	}
+	return nil
+}
+
+func (m *MockTransport) Close() error {
+	m.mu.Lock()
+	if m.Closed {
+		m.mu.Unlock()
+		return nil
+	}
+	m.Closed = true
+	active := m.bulkActv
+	stop := m.bulkStop
+	done := m.bulkDone
+	m.bulkActv = false
+	m.mu.Unlock()
+	if active {
+		close(stop)
+		<-done
+	}
+	return nil
+}
+
+// Remaining returns the number of unconsumed [CtrlExchange] entries in
+// the script. Tests typically assert it is zero after the SUT runs.
+func (m *MockTransport) Remaining() int { return len(m.Script) - m.Step }
+
+func bytesEqual(a, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/sdr/rtlsdr/usb/usb_other.go
+++ b/internal/sdr/rtlsdr/usb/usb_other.go
@@ -1,0 +1,20 @@
+//go:build !(linux && (amd64 || arm64 || 386 || arm || riscv64 || loong64))
+
+package usb
+
+// platformEnumerator returns a stub [Enumerator] whose every method
+// reports [ErrUnsupportedPlatform]. PR-02 (Windows / WinUSB) and PR-10
+// (macOS / IOKit via purego) replace this with real implementations.
+func platformEnumerator() Enumerator { return unsupportedEnumerator{} }
+
+type unsupportedEnumerator struct{}
+
+func (unsupportedEnumerator) Name() string { return "unsupported" }
+
+func (unsupportedEnumerator) List(vid, pid uint16) ([]Descriptor, error) {
+	return nil, ErrUnsupportedPlatform
+}
+
+func (unsupportedEnumerator) Open(Descriptor) (Transport, error) {
+	return nil, ErrUnsupportedPlatform
+}

--- a/internal/sdr/rtlsdr/usb/usb_test.go
+++ b/internal/sdr/rtlsdr/usb/usb_test.go
@@ -1,0 +1,268 @@
+package usb
+
+import (
+	"bytes"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestMockEnumerator_ListFiltersByVIDPID(t *testing.T) {
+	e := &MockEnumerator{Devices: []Descriptor{
+		{Bus: 1, Address: 4, VID: 0x0bda, PID: 0x2838, Serial: "00000001"},
+		{Bus: 1, Address: 5, VID: 0x0bda, PID: 0x2832, Serial: "00000002"},
+		{Bus: 1, Address: 6, VID: 0x1d50, PID: 0x6089, Serial: "hackrf"},
+	}}
+
+	all, err := e.List(0, 0)
+	if err != nil {
+		t.Fatalf("List(0,0): %v", err)
+	}
+	if got, want := len(all), 3; got != want {
+		t.Fatalf("List(0,0) len = %d, want %d", got, want)
+	}
+
+	rtl, err := e.List(0x0bda, 0)
+	if err != nil {
+		t.Fatalf("List vendor: %v", err)
+	}
+	if got, want := len(rtl), 2; got != want {
+		t.Fatalf("Realtek len = %d, want %d", got, want)
+	}
+
+	one, err := e.List(0x0bda, 0x2838)
+	if err != nil {
+		t.Fatalf("List exact: %v", err)
+	}
+	if got, want := len(one), 1; got != want {
+		t.Fatalf("exact match len = %d, want %d", got, want)
+	}
+	if one[0].Serial != "00000001" {
+		t.Errorf("matched device serial = %q, want 00000001", one[0].Serial)
+	}
+}
+
+func TestMockEnumerator_OpenReturnsTransport(t *testing.T) {
+	e := &MockEnumerator{Devices: []Descriptor{{VID: 1, PID: 2}}}
+	got, err := e.Open(e.Devices[0])
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if got == nil {
+		t.Fatal("Open returned nil transport")
+	}
+	_ = got.Close()
+}
+
+func TestMockTransport_ScriptedControlIn(t *testing.T) {
+	m := NewMockTransport()
+	m.Script = []CtrlExchange{
+		{In: true, BRequest: 0, WValue: 0x0010, WIndex: 0x0300, N: 2, Reply: []byte{0xab, 0xcd}},
+	}
+	got, err := m.ControlIn(0, 0x0010, 0x0300, 2, 1000)
+	if err != nil {
+		t.Fatalf("ControlIn: %v", err)
+	}
+	if !bytes.Equal(got, []byte{0xab, 0xcd}) {
+		t.Errorf("ControlIn data = %x, want abcd", got)
+	}
+	if m.Err != nil {
+		t.Errorf("m.Err = %v, want nil", m.Err)
+	}
+	if m.Remaining() != 0 {
+		t.Errorf("Remaining = %d, want 0", m.Remaining())
+	}
+}
+
+func TestMockTransport_ScriptedControlOut(t *testing.T) {
+	m := NewMockTransport()
+	m.Script = []CtrlExchange{
+		{In: false, BRequest: 1, WValue: 0x4444, WIndex: 0x0100, Data: []byte{0x10, 0x20}},
+	}
+	if err := m.ControlOut(1, 0x4444, 0x0100, []byte{0x10, 0x20}, 0); err != nil {
+		t.Fatalf("ControlOut: %v", err)
+	}
+	if m.Err != nil {
+		t.Errorf("m.Err = %v", m.Err)
+	}
+}
+
+func TestMockTransport_DirectionMismatch(t *testing.T) {
+	m := NewMockTransport()
+	m.Script = []CtrlExchange{{In: true, BRequest: 0, WValue: 0, WIndex: 0, Reply: []byte{0}}}
+	if err := m.ControlOut(0, 0, 0, nil, 0); err == nil {
+		t.Fatal("expected error for direction mismatch")
+	}
+	if m.Err == nil {
+		t.Error("m.Err not populated on mismatch")
+	}
+}
+
+func TestMockTransport_ParamMismatch(t *testing.T) {
+	m := NewMockTransport()
+	m.Script = []CtrlExchange{{In: true, BRequest: 5, WValue: 1, WIndex: 2, Reply: []byte{0}}}
+	if _, err := m.ControlIn(6, 1, 2, 1, 0); err == nil {
+		t.Fatal("expected error for bRequest mismatch")
+	}
+}
+
+func TestMockTransport_DataMismatch(t *testing.T) {
+	m := NewMockTransport()
+	m.Script = []CtrlExchange{{In: false, BRequest: 0, WValue: 0, WIndex: 0, Data: []byte{1, 2, 3}}}
+	if err := m.ControlOut(0, 0, 0, []byte{1, 2, 4}, 0); err == nil {
+		t.Fatal("expected error for data mismatch")
+	}
+}
+
+func TestMockTransport_ScriptExhausted(t *testing.T) {
+	m := NewMockTransport()
+	if _, err := m.ControlIn(0, 0, 0, 1, 0); err == nil {
+		t.Fatal("expected error from empty script")
+	}
+}
+
+func TestMockTransport_NParamCheck(t *testing.T) {
+	m := NewMockTransport()
+	m.Script = []CtrlExchange{{In: true, BRequest: 0, WValue: 0, WIndex: 0, N: 4, Reply: []byte{1, 2, 3, 4}}}
+	if _, err := m.ControlIn(0, 0, 0, 2, 0); err == nil {
+		t.Fatal("expected error for n mismatch")
+	}
+}
+
+func TestMockTransport_ErrFieldReturned(t *testing.T) {
+	want := errors.New("boom")
+	m := NewMockTransport()
+	m.Script = []CtrlExchange{{In: true, BRequest: 0, WValue: 0, WIndex: 0, Err: want}}
+	if _, err := m.ControlIn(0, 0, 0, 1, 0); !errors.Is(err, want) {
+		t.Fatalf("got %v, want %v", err, want)
+	}
+}
+
+func TestMockTransport_BulkInDispatch(t *testing.T) {
+	m := NewMockTransport()
+	m.BulkPackets = [][]byte{
+		{0x01, 0x02},
+		{0x03, 0x04, 0x05},
+	}
+
+	var mu sync.Mutex
+	var got [][]byte
+	if err := m.StartBulkIn(0x81, 4, 8, func(p []byte) {
+		mu.Lock()
+		c := make([]byte, len(p))
+		copy(c, p)
+		got = append(got, c)
+		mu.Unlock()
+	}); err != nil {
+		t.Fatalf("StartBulkIn: %v", err)
+	}
+	// Wait for the goroutine to dispatch both packets and park on bulkStop.
+	deadline := time.Now().Add(time.Second)
+	for {
+		mu.Lock()
+		n := len(got)
+		mu.Unlock()
+		if n >= 2 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("timed out waiting for bulk packets")
+		}
+		time.Sleep(time.Millisecond)
+	}
+	if err := m.StopBulkIn(); err != nil {
+		t.Fatalf("StopBulkIn: %v", err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if !bytes.Equal(got[0], []byte{0x01, 0x02}) || !bytes.Equal(got[1], []byte{0x03, 0x04, 0x05}) {
+		t.Errorf("got packets %x, want [[0102] [030405]]", got)
+	}
+}
+
+func TestMockTransport_DoubleStartFails(t *testing.T) {
+	m := NewMockTransport()
+	if err := m.StartBulkIn(0x81, 1, 8, func([]byte) {}); err != nil {
+		t.Fatalf("first StartBulkIn: %v", err)
+	}
+	if err := m.StartBulkIn(0x81, 1, 8, func([]byte) {}); !errors.Is(err, ErrBulkActive) {
+		t.Errorf("second StartBulkIn err = %v, want ErrBulkActive", err)
+	}
+	_ = m.StopBulkIn()
+}
+
+func TestMockTransport_StopWithoutStart(t *testing.T) {
+	m := NewMockTransport()
+	if err := m.StopBulkIn(); !errors.Is(err, ErrBulkInactive) {
+		t.Errorf("StopBulkIn without start = %v, want ErrBulkInactive", err)
+	}
+}
+
+func TestMockTransport_ClaimReleaseTrackIfaces(t *testing.T) {
+	m := NewMockTransport()
+	if err := m.ClaimInterface(0); err != nil {
+		t.Fatalf("Claim(0): %v", err)
+	}
+	if !m.ClaimedIfaces[0] {
+		t.Error("interface 0 not tracked after Claim")
+	}
+	if err := m.ReleaseInterface(0); err != nil {
+		t.Fatalf("Release(0): %v", err)
+	}
+	if m.ClaimedIfaces[0] {
+		t.Error("interface 0 still tracked after Release")
+	}
+}
+
+func TestMockTransport_CloseIdempotent(t *testing.T) {
+	m := NewMockTransport()
+	if err := m.Close(); err != nil {
+		t.Fatalf("first Close: %v", err)
+	}
+	if err := m.Close(); err != nil {
+		t.Fatalf("second Close: %v", err)
+	}
+	if _, err := m.ControlIn(0, 0, 0, 1, 0); !errors.Is(err, ErrClosed) {
+		t.Errorf("ControlIn after Close = %v, want ErrClosed", err)
+	}
+	if err := m.ControlOut(0, 0, 0, nil, 0); !errors.Is(err, ErrClosed) {
+		t.Errorf("ControlOut after Close = %v, want ErrClosed", err)
+	}
+}
+
+func TestMockTransport_CloseStopsBulk(t *testing.T) {
+	m := NewMockTransport()
+	if err := m.StartBulkIn(0x81, 1, 8, func([]byte) {}); err != nil {
+		t.Fatalf("StartBulkIn: %v", err)
+	}
+	done := make(chan struct{})
+	go func() {
+		_ = m.Close()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Close did not return")
+	}
+}
+
+func TestDefaultEnumeratorNotNil(t *testing.T) {
+	e := DefaultEnumerator()
+	if e == nil {
+		t.Fatal("DefaultEnumerator returned nil")
+	}
+	if e.Name() == "" {
+		t.Error("backend Name() empty")
+	}
+}
+
+func TestVendorConstants(t *testing.T) {
+	if VendorIn != 0xC0 {
+		t.Errorf("VendorIn = 0x%02x, want 0xC0", VendorIn)
+	}
+	if VendorOut != 0x40 {
+		t.Errorf("VendorOut = 0x%02x, want 0x40", VendorOut)
+	}
+}


### PR DESCRIPTION
PR-01 of the librtlsdr → pure-Go rewrite (see README roadmap). Lays the
foundation the RTL2832U register layer and tuner drivers will sit on,
with no functional change to the live driver — `rtlsdr_cgo.go` still
ships as the registered backend.

Adds `internal/sdr/rtlsdr/usb/`:

- usb.go: Transport + Enumerator interfaces, Descriptor, vendor
  request-type constants, sentinel errors, DefaultEnumerator
  dispatch.
- usb_mock.go: MockEnumerator + MockTransport with a record/replay
  script (CtrlExchange), bulk-IN packet injection, lifecycle
  tracking — the fixture every higher layer's unit tests will use.
- usb_linux.go: USBDEVFS backend. Encodes the ioctl numbers at init
  from unsafe.Sizeof on Go structs that match the kernel's
  asm-generic layout; supports amd64/arm64/386/arm/riscv64/loong64.
  Enumerates from /sys/bus/usb/devices with VID/PID filtering (no
  device claim required). Vendor-IN/OUT control transfers via
  USBDEVFS_CONTROL. Async bulk-IN ring of SUBMITURB-submitted
  URBs with a dedicated OS-thread-locked reaper goroutine reading
  REAPURB; cancel via DISCARDURB + drain-to-completion. Claim /
  release / reset / close lifecycle with idempotent Close.
- usb_other.go: ErrUnsupportedPlatform stub for everything else,
  so the package compiles on Windows / macOS today. PR-02 replaces
  it with the Windows WinUSB backend; PR-10 with macOS IOKit via
  purego.
- usb_test.go: mock-side unit tests (15 cases — script matching,
  direction/param/data mismatch detection, bulk dispatch, double-
  start / stop-without-start guards, idempotent Close).
- usb_linux_test.go: sysfs enumeration tests against a temp-dir
  fake root + ioctl-encoding goldens (USBDEVFS_CONTROL = 0xC0185500,
  USBDEVFS_SUBMITURB = 0x8038550A, USBDEVFS_REAPURB = 0x4008550C on
  64-bit arches).

go.mod: promotes golang.org/x/sys from indirect to direct.

README.md: adds the pure-Go RTL-SDR driver to the roadmap with the
full 10-PR sequence; updates the repo-layout listing.

Verified: `CGO_ENABLED=0 go test ./...` passes across the tree;
`CGO_ENABLED=0 go vet ./internal/sdr/rtlsdr/usb/...` clean;
`CGO_ENABLED=1 go test -race ./internal/sdr/rtlsdr/usb/...` clean.

https://claude.ai/code/session_01CQrwLLjvuoCgQYLkso4SuX