### PR TITLE
internal/sdr/rtlsdr/usb: Windows WinUSB backend + CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,3 +19,28 @@ jobs:
       - run: go build ./...
       - run: go test -race -count=1 ./...
       - run: make integration
+
+  # Cross-platform check for the pure-Go USB transport (internal/sdr/rtlsdr/usb).
+  # The rest of the tree still requires CGO + librtlsdr on non-Linux, but the
+  # usb sub-package must build & test cleanly under CGO_ENABLED=0 on every
+  # supported OS as it lands platform-specific backends. Currently exercises
+  # the WinUSB backend introduced in PR-02.
+  usb-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+      - name: Build (CGO disabled)
+        env:
+          CGO_ENABLED: "0"
+        run: go build ./internal/sdr/rtlsdr/usb/...
+      - name: Vet
+        env:
+          CGO_ENABLED: "0"
+        run: go vet ./internal/sdr/rtlsdr/usb/...
+      - name: Test
+        env:
+          CGO_ENABLED: "0"
+        run: go test -count=1 ./internal/sdr/rtlsdr/usb/...

--- a/README.md
+++ b/README.md
@@ -282,22 +282,29 @@ to its own package and lands independently.
   R820T2, R828D, E4000, FC0012, FC0013, FC2580). The
   `sdr.Device` interface and IQ-format conversion at
   `internal/sdr/rtlsdr/rtlsdr_cgo.go:225-240` are preserved
-  bit-identically so the DSP chain is untouched. Status: PR-01
-  landed — `internal/sdr/rtlsdr/usb/` exposes the `Transport` +
-  `Enumerator` interfaces, a record/replay `MockTransport` for
-  unit tests, and the Linux USBDEVFS backend (ioctl encoding,
-  sysfs enumeration with VID/PID filtering, vendor-IN/OUT control
-  transfers, 32-deep URB ring on the bulk-IN endpoint with a
-  dedicated reaper goroutine, claim/release/reset/close
-  lifecycle); non-Linux platforms compile with a clear
-  `ErrUnsupportedPlatform` stub. PRs 02-10 land the Windows
-  WinUSB backend, the macOS stub + IOKit follow-up, the
-  RTL2832U register/I2C layer, the R820T2 tuner, the wire-up
-  under the alternate driver name `rtlsdr-go`, the remaining
-  five tuners, the default flip, and the deletion of
-  `rtlsdr_cgo.go` + every `librtlsdr` apt / MSYS2 / DLL-bundling
-  step in `Dockerfile`, `.github/workflows/*.yml`,
-  `installer/gophertrunk.iss`, and the install docs.
+  bit-identically so the DSP chain is untouched. Status: PR-01 +
+  PR-02 landed — `internal/sdr/rtlsdr/usb/` exposes the
+  `Transport` + `Enumerator` interfaces, a record/replay
+  `MockTransport` for unit tests, and platform backends for
+  Linux + Windows. Linux uses USBDEVFS ioctls
+  (`/sys/bus/usb/devices` enumeration without root, vendor-IN/OUT
+  control transfers, 32-deep URB ring on the bulk-IN endpoint
+  with a dedicated reaper goroutine). Windows uses
+  WinUSB via lazy-loaded `setupapi.dll` + `winusb.dll`
+  (SetupDi-based enumeration of `GUID_DEVINTERFACE_USB_DEVICE`,
+  device-path → VID/PID/serial parser, RAW_IO bulk-IN with an
+  auto-reset-event ring driven by `WaitForMultipleObjects` /
+  `WinUsb_GetOverlappedResult`, `WinUsb_AbortPipe` for cancel).
+  CI now compiles + vets + tests the package on
+  `windows-latest` under `CGO_ENABLED=0`. macOS still falls
+  through to the `ErrUnsupportedPlatform` stub. PRs 03-10 land
+  the macOS stub formalization + IOKit follow-up, the RTL2832U
+  register/I2C layer, the R820T2 tuner, the wire-up under the
+  alternate driver name `rtlsdr-go`, the remaining five tuners,
+  the default flip, and the deletion of `rtlsdr_cgo.go` + every
+  `librtlsdr` apt / MSYS2 / DLL-bundling step in `Dockerfile`,
+  `.github/workflows/*.yml`, `installer/gophertrunk.iss`, and
+  the install docs.
 - **YSF Trellis decode + grant emission.** Sync, frame layout, and
   the post-FEC FICH bit-level parser are in; what's left is the
   K=5 ½-rate Viterbi Trellis decoder over the on-air 100-bit FICH
@@ -393,7 +400,7 @@ tests.
 cmd/gophertrunk/        daemon entrypoint + sdr list CLI + read-only TUI
 internal/tui/           bubbletea TUI: 8 read-only panels over REST+SSE
 internal/sdr/           Driver interface, pool, CGO librtlsdr (→ pure-Go), mock
-internal/sdr/rtlsdr/usb/ Pure-Go USB transport: Linux USBDEVFS, mock
+internal/sdr/rtlsdr/usb/ Pure-Go USB transport: Linux USBDEVFS, Windows WinUSB, mock
 internal/dsp/           Channelizer, filters, demods, sync, FFT
 internal/radio/         framing/ + p25/phase1/ + dmr/ + nxdn/
 internal/trunking/      System, talkgroup DB, priority, engine, CC hunter

--- a/internal/sdr/rtlsdr/usb/usb_other.go
+++ b/internal/sdr/rtlsdr/usb/usb_other.go
@@ -1,10 +1,10 @@
-//go:build !(linux && (amd64 || arm64 || 386 || arm || riscv64 || loong64))
+//go:build !(linux && (amd64 || arm64 || 386 || arm || riscv64 || loong64)) && !(windows && (amd64 || arm64))
 
 package usb
 
 // platformEnumerator returns a stub [Enumerator] whose every method
-// reports [ErrUnsupportedPlatform]. PR-02 (Windows / WinUSB) and PR-10
-// (macOS / IOKit via purego) replace this with real implementations.
+// reports [ErrUnsupportedPlatform]. PR-10 replaces this on macOS with a
+// real IOKit-via-purego implementation.
 func platformEnumerator() Enumerator { return unsupportedEnumerator{} }
 
 type unsupportedEnumerator struct{}

--- a/internal/sdr/rtlsdr/usb/usb_windows.go
+++ b/internal/sdr/rtlsdr/usb/usb_windows.go
@@ -1,0 +1,648 @@
+//go:build windows && (amd64 || arm64)
+
+package usb
+
+import (
+	"errors"
+	"fmt"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+// Lazy-loaded Win32 entry points. setupapi.dll handles device-info
+// enumeration; winusb.dll wraps the bound WinUSB kernel-mode driver.
+// Loading is deferred so this package still compiles + imports cleanly
+// on Wine / older Windows installs missing the DLLs — callers see a
+// runtime error from the first proc call instead of a load-time panic.
+var (
+	modSetupAPI = windows.NewLazySystemDLL("setupapi.dll")
+	modWinUSB   = windows.NewLazySystemDLL("winusb.dll")
+	modKernel32 = windows.NewLazySystemDLL("kernel32.dll")
+
+	procSetupDiGetClassDevsW             = modSetupAPI.NewProc("SetupDiGetClassDevsW")
+	procSetupDiEnumDeviceInterfaces      = modSetupAPI.NewProc("SetupDiEnumDeviceInterfaces")
+	procSetupDiGetDeviceInterfaceDetailW = modSetupAPI.NewProc("SetupDiGetDeviceInterfaceDetailW")
+	procSetupDiDestroyDeviceInfoList     = modSetupAPI.NewProc("SetupDiDestroyDeviceInfoList")
+
+	procWinUsbInitialize          = modWinUSB.NewProc("WinUsb_Initialize")
+	procWinUsbFree                = modWinUSB.NewProc("WinUsb_Free")
+	procWinUsbControlTransfer     = modWinUSB.NewProc("WinUsb_ControlTransfer")
+	procWinUsbReadPipe            = modWinUSB.NewProc("WinUsb_ReadPipe")
+	procWinUsbAbortPipe           = modWinUSB.NewProc("WinUsb_AbortPipe")
+	procWinUsbResetPipe           = modWinUSB.NewProc("WinUsb_ResetPipe")
+	procWinUsbSetPipePolicy       = modWinUSB.NewProc("WinUsb_SetPipePolicy")
+	procWinUsbGetOverlappedResult = modWinUSB.NewProc("WinUsb_GetOverlappedResult")
+)
+
+// GUID_DEVINTERFACE_USB_DEVICE — the class GUID every USB device exposes
+// via the usbhub stack, regardless of which function driver is bound.
+// Lets us enumerate every USB device on the system, then probe each one
+// for WinUSB binding via [winTransport.tryInitialize].
+var guidDevInterfaceUSBDevice = windows.GUID{
+	Data1: 0xA5DCBF10,
+	Data2: 0x6530,
+	Data3: 0x11D2,
+	Data4: [8]byte{0x90, 0x1F, 0x00, 0xC0, 0x4F, 0xB9, 0x51, 0xED},
+}
+
+// WinUSB pipe-policy IDs (see WinUsb_SetPipePolicy).
+const (
+	policyPipeTransferTimeout = 0x03
+	policyRawIO               = 0x07
+	policyAllowPartialReads   = 0x05
+	policyAutoClearStall      = 0x02
+)
+
+// DIGCF_PRESENT | DIGCF_DEVICEINTERFACE — only currently-attached devices.
+const digcfPresentDeviceInterface = windows.DIGCF_PRESENT | windows.DIGCF_DEVICEINTERFACE
+
+// spDeviceInterfaceData mirrors SP_DEVICE_INTERFACE_DATA. The Size field
+// must be the size of this struct (32 bytes on x64).
+type spDeviceInterfaceData struct {
+	Size               uint32
+	InterfaceClassGuid windows.GUID
+	Flags              uint32
+	Reserved           uintptr
+}
+
+// On 64-bit Windows the SP_DEVICE_INTERFACE_DETAIL_DATA_W header is 8
+// bytes (DWORD cbSize + padding). The build tag at the top of this file
+// restricts compilation to amd64 / arm64 so this constant is safe to
+// hard-code.
+const spDeviceInterfaceDetailDataHeaderSize = 8
+
+func platformEnumerator() Enumerator { return &winEnumerator{} }
+
+// winEnumerator walks every present USB device interface via SetupAPI
+// and, on Open, hands ownership to the bound WinUSB driver. Devices that
+// aren't WinUSB-bound (the default for an out-of-the-box RTL-SDR before
+// Zadig) cause Open to fail with an explicit "no WinUSB driver" error.
+type winEnumerator struct{}
+
+func (w *winEnumerator) Name() string { return "winusb" }
+
+func (w *winEnumerator) List(vid, pid uint16) ([]Descriptor, error) {
+	devSet, _, errno := procSetupDiGetClassDevsW.Call(
+		uintptr(unsafe.Pointer(&guidDevInterfaceUSBDevice)),
+		0,
+		0,
+		uintptr(digcfPresentDeviceInterface),
+	)
+	if devSet == uintptr(windows.InvalidHandle) || devSet == 0 {
+		return nil, fmt.Errorf("winusb: SetupDiGetClassDevs: %w", winErr(errno))
+	}
+	defer procSetupDiDestroyDeviceInfoList.Call(devSet)
+
+	var out []Descriptor
+	for memberIndex := uint32(0); ; memberIndex++ {
+		var iface spDeviceInterfaceData
+		iface.Size = uint32(unsafe.Sizeof(iface))
+		ret, _, errno := procSetupDiEnumDeviceInterfaces.Call(
+			devSet,
+			0,
+			uintptr(unsafe.Pointer(&guidDevInterfaceUSBDevice)),
+			uintptr(memberIndex),
+			uintptr(unsafe.Pointer(&iface)),
+		)
+		if ret == 0 {
+			if errno == windows.ERROR_NO_MORE_ITEMS {
+				break
+			}
+			return out, fmt.Errorf("winusb: SetupDiEnumDeviceInterfaces[%d]: %w", memberIndex, winErr(errno))
+		}
+		path, err := getDeviceInterfacePath(devSet, &iface)
+		if err != nil {
+			continue
+		}
+		v, p, serial := parseDevicePath(path)
+		if v == 0 && p == 0 {
+			continue
+		}
+		if vid != 0 && v != vid {
+			continue
+		}
+		if pid != 0 && p != pid {
+			continue
+		}
+		out = append(out, Descriptor{
+			Bus:     0, // Windows doesn't expose libusb-style bus/address;
+			Address: 0, // serial number is the disambiguator.
+			VID:     v,
+			PID:     p,
+			Serial:  serial,
+			Path:    path,
+		})
+	}
+	return out, nil
+}
+
+func (w *winEnumerator) Open(d Descriptor) (Transport, error) {
+	if d.Path == "" {
+		return nil, errors.New("winusb: Descriptor.Path empty (re-enumerate)")
+	}
+	wpath, err := windows.UTF16PtrFromString(d.Path)
+	if err != nil {
+		return nil, fmt.Errorf("winusb: bad path %q: %w", d.Path, err)
+	}
+	handle, err := windows.CreateFile(
+		wpath,
+		windows.GENERIC_READ|windows.GENERIC_WRITE,
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE,
+		nil,
+		windows.OPEN_EXISTING,
+		windows.FILE_ATTRIBUTE_NORMAL|windows.FILE_FLAG_OVERLAPPED,
+		0,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("winusb: CreateFile %q: %w", d.Path, err)
+	}
+	var ifaceHandle uintptr
+	ret, _, errno := procWinUsbInitialize.Call(uintptr(handle), uintptr(unsafe.Pointer(&ifaceHandle)))
+	if ret == 0 {
+		windows.CloseHandle(handle)
+		return nil, fmt.Errorf("winusb: WinUsb_Initialize (driver not bound? run Zadig): %w", winErr(errno))
+	}
+	return &winTransport{
+		fileHandle:  handle,
+		ifaceHandle: ifaceHandle,
+		desc:        d,
+	}, nil
+}
+
+// winTransport is the WinUSB-backed [Transport].
+type winTransport struct {
+	fileHandle  windows.Handle
+	ifaceHandle uintptr
+	desc        Descriptor
+	closed      atomic.Bool
+
+	bulkMu       sync.Mutex
+	bulkActive   bool
+	bulkEpAddr   byte
+	bulkSlots    []*winBulkSlot
+	bulkEvents   []windows.Handle
+	bulkStopFlag atomic.Int32
+	bulkDone     chan struct{}
+
+	timeoutMu      sync.Mutex
+	lastCtlTimeout uint32
+}
+
+type winBulkSlot struct {
+	buf        []byte
+	overlapped windows.Overlapped
+	event      windows.Handle
+}
+
+// winusbSetupPacket is the 8-byte setup packet WinUsb_ControlTransfer
+// consumes — identical wire format to the USB 2.0 setup stage.
+type winusbSetupPacket struct {
+	RequestType uint8
+	Request     uint8
+	Value       uint16
+	Index       uint16
+	Length      uint16
+}
+
+func (t *winTransport) applyControlTimeout(timeoutMs int) {
+	if timeoutMs <= 0 {
+		return
+	}
+	v := uint32(timeoutMs)
+	t.timeoutMu.Lock()
+	if t.lastCtlTimeout == v {
+		t.timeoutMu.Unlock()
+		return
+	}
+	t.lastCtlTimeout = v
+	t.timeoutMu.Unlock()
+	// Pipe ID 0 = the default control endpoint.
+	procWinUsbSetPipePolicy.Call(
+		t.ifaceHandle,
+		0,
+		policyPipeTransferTimeout,
+		uintptr(unsafe.Sizeof(v)),
+		uintptr(unsafe.Pointer(&v)),
+	)
+}
+
+func (t *winTransport) ControlIn(bRequest uint8, wValue, wIndex uint16, n int, timeoutMs int) ([]byte, error) {
+	if t.closed.Load() {
+		return nil, ErrClosed
+	}
+	if n < 0 || n > 0xFFFF {
+		return nil, fmt.Errorf("winusb: control IN length %d out of range", n)
+	}
+	t.applyControlTimeout(timeoutMs)
+	pkt := winusbSetupPacket{
+		RequestType: VendorIn,
+		Request:     bRequest,
+		Value:       wValue,
+		Index:       wIndex,
+		Length:      uint16(n),
+	}
+	var buf []byte
+	var bufPtr uintptr
+	if n > 0 {
+		buf = make([]byte, n)
+		bufPtr = uintptr(unsafe.Pointer(&buf[0]))
+	}
+	var transferred uint32
+	ret, _, errno := procWinUsbControlTransfer.Call(
+		t.ifaceHandle,
+		uintptr(unsafe.Pointer(&pkt)),
+		bufPtr,
+		uintptr(n),
+		uintptr(unsafe.Pointer(&transferred)),
+		0,
+	)
+	if ret == 0 {
+		return nil, fmt.Errorf("winusb: WinUsb_ControlTransfer IN: %w", winErr(errno))
+	}
+	return buf[:transferred], nil
+}
+
+func (t *winTransport) ControlOut(bRequest uint8, wValue, wIndex uint16, data []byte, timeoutMs int) error {
+	if t.closed.Load() {
+		return ErrClosed
+	}
+	if len(data) > 0xFFFF {
+		return fmt.Errorf("winusb: control OUT length %d out of range", len(data))
+	}
+	t.applyControlTimeout(timeoutMs)
+	pkt := winusbSetupPacket{
+		RequestType: VendorOut,
+		Request:     bRequest,
+		Value:       wValue,
+		Index:       wIndex,
+		Length:      uint16(len(data)),
+	}
+	var dataPtr uintptr
+	if len(data) > 0 {
+		dataPtr = uintptr(unsafe.Pointer(&data[0]))
+	}
+	var transferred uint32
+	ret, _, errno := procWinUsbControlTransfer.Call(
+		t.ifaceHandle,
+		uintptr(unsafe.Pointer(&pkt)),
+		dataPtr,
+		uintptr(len(data)),
+		uintptr(unsafe.Pointer(&transferred)),
+		0,
+	)
+	if ret == 0 {
+		return fmt.Errorf("winusb: WinUsb_ControlTransfer OUT: %w", winErr(errno))
+	}
+	return nil
+}
+
+// ClaimInterface is a no-op on Windows: WinUsb_Initialize already gave
+// us exclusive access to interface 0. Multi-interface WinUSB devices
+// require WinUsb_GetAssociatedInterface to access interfaces > 0, but
+// the RTL-SDR exposes only interface 0 — we'd surface that as an error
+// rather than silently succeed if num != 0.
+func (t *winTransport) ClaimInterface(num int) error {
+	if t.closed.Load() {
+		return ErrClosed
+	}
+	if num != 0 {
+		return fmt.Errorf("winusb: only interface 0 supported (got %d)", num)
+	}
+	return nil
+}
+
+func (t *winTransport) ReleaseInterface(int) error { return nil }
+
+func (t *winTransport) Reset() error {
+	// WinUSB has no equivalent of libusb_reset_device — issuing a USB
+	// port-reset requires IOCTL_USB_CYCLE_PORT on the parent hub, which
+	// is brittle and rarely needed. Return nil so callers treat it as
+	// a best-effort no-op (matches the Linux backend's behavior on
+	// kernels that don't expose USBDEVFS_RESET).
+	if t.closed.Load() {
+		return ErrClosed
+	}
+	return nil
+}
+
+func (t *winTransport) StartBulkIn(epAddr byte, ringBufs, bufLen int, onPacket func([]byte)) error {
+	if t.closed.Load() {
+		return ErrClosed
+	}
+	if ringBufs <= 0 || bufLen <= 0 {
+		return fmt.Errorf("winusb: invalid bulk ring geometry (bufs=%d len=%d)", ringBufs, bufLen)
+	}
+	if ringBufs > 64 {
+		// WaitForMultipleObjects caps at MAXIMUM_WAIT_OBJECTS = 64.
+		// The default of 32 is well below this — we only guard against
+		// callers asking for absurd values.
+		return fmt.Errorf("winusb: ringBufs %d exceeds WaitForMultipleObjects limit (64)", ringBufs)
+	}
+	t.bulkMu.Lock()
+	defer t.bulkMu.Unlock()
+	if t.bulkActive {
+		return ErrBulkActive
+	}
+
+	// Enable RAW_IO for max throughput; the RTL2832U IQ stream is
+	// always a multiple of maxpacketsize (512 B on full-speed bulk).
+	one := uint8(1)
+	procWinUsbSetPipePolicy.Call(
+		t.ifaceHandle,
+		uintptr(epAddr),
+		policyRawIO,
+		uintptr(unsafe.Sizeof(one)),
+		uintptr(unsafe.Pointer(&one)),
+	)
+	procWinUsbSetPipePolicy.Call(
+		t.ifaceHandle,
+		uintptr(epAddr),
+		policyAllowPartialReads,
+		uintptr(unsafe.Sizeof(one)),
+		uintptr(unsafe.Pointer(&one)),
+	)
+	// Disable per-pipe transfer timeout (we manage cancellation via AbortPipe).
+	zero := uint32(0)
+	procWinUsbSetPipePolicy.Call(
+		t.ifaceHandle,
+		uintptr(epAddr),
+		policyPipeTransferTimeout,
+		uintptr(unsafe.Sizeof(zero)),
+		uintptr(unsafe.Pointer(&zero)),
+	)
+
+	slots := make([]*winBulkSlot, 0, ringBufs)
+	events := make([]windows.Handle, 0, ringBufs)
+	cleanup := func() {
+		for _, s := range slots {
+			procWinUsbAbortPipe.Call(t.ifaceHandle, uintptr(epAddr))
+			_ = s
+		}
+		for _, ev := range events {
+			windows.CloseHandle(ev)
+		}
+	}
+	for i := 0; i < ringBufs; i++ {
+		// Auto-reset event so WaitForMultipleObjects atomically clears
+		// it on return — saves a ResetEvent call before re-issuing.
+		ev, err := windows.CreateEvent(nil, 0 /*manualReset=false*/, 0, nil)
+		if err != nil {
+			cleanup()
+			return fmt.Errorf("winusb: CreateEvent[%d]: %w", i, err)
+		}
+		s := &winBulkSlot{
+			buf:   make([]byte, bufLen),
+			event: ev,
+		}
+		s.overlapped.HEvent = ev
+		if err := t.issueReadPipe(epAddr, s); err != nil {
+			windows.CloseHandle(ev)
+			cleanup()
+			return fmt.Errorf("winusb: ReadPipe[%d]: %w", i, err)
+		}
+		slots = append(slots, s)
+		events = append(events, ev)
+	}
+
+	t.bulkEpAddr = epAddr
+	t.bulkSlots = slots
+	t.bulkEvents = events
+	t.bulkActive = true
+	t.bulkStopFlag.Store(0)
+	t.bulkDone = make(chan struct{})
+
+	go t.reapLoop(onPacket)
+	return nil
+}
+
+// issueReadPipe arms one bulk-IN URB on the kernel side. The success path
+// is ERROR_IO_PENDING (Go's CreateFile|FILE_FLAG_OVERLAPPED makes every
+// pipe op async); the rare synchronous-completion path also returns
+// success.
+func (t *winTransport) issueReadPipe(epAddr byte, s *winBulkSlot) error {
+	var transferred uint32
+	ret, _, errno := procWinUsbReadPipe.Call(
+		t.ifaceHandle,
+		uintptr(epAddr),
+		uintptr(unsafe.Pointer(&s.buf[0])),
+		uintptr(len(s.buf)),
+		uintptr(unsafe.Pointer(&transferred)),
+		uintptr(unsafe.Pointer(&s.overlapped)),
+	)
+	if ret == 0 {
+		if errno == windows.ERROR_IO_PENDING {
+			return nil
+		}
+		return winErr(errno)
+	}
+	return nil
+}
+
+func (t *winTransport) reapLoop(onPacket func([]byte)) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+	defer close(t.bulkDone)
+
+	// Active mask — once a slot's I/O is taken to completion under stop
+	// we mark it consumed; we exit when no slot is still in flight.
+	consumed := make([]bool, len(t.bulkSlots))
+	for {
+		// Build a wait list of unfinished events.
+		wait := make([]windows.Handle, 0, len(t.bulkSlots))
+		idxMap := make([]int, 0, len(t.bulkSlots))
+		for i, c := range consumed {
+			if !c {
+				wait = append(wait, t.bulkEvents[i])
+				idxMap = append(idxMap, i)
+			}
+		}
+		if len(wait) == 0 {
+			return
+		}
+		ret, err := windows.WaitForMultipleObjects(wait, false, windows.INFINITE)
+		if err != nil {
+			return
+		}
+		raw := int(ret - windows.WAIT_OBJECT_0)
+		if raw < 0 || raw >= len(wait) {
+			return
+		}
+		slotIdx := idxMap[raw]
+		slot := t.bulkSlots[slotIdx]
+		var transferred uint32
+		result, _, _ := procWinUsbGetOverlappedResult.Call(
+			t.ifaceHandle,
+			uintptr(unsafe.Pointer(&slot.overlapped)),
+			uintptr(unsafe.Pointer(&transferred)),
+			0, // bWait = FALSE
+		)
+		stop := t.bulkStopFlag.Load() != 0
+		if stop {
+			consumed[slotIdx] = true
+			continue
+		}
+		if result != 0 && transferred > 0 {
+			onPacket(slot.buf[:transferred])
+		}
+		if err := t.issueReadPipe(t.bulkEpAddr, slot); err != nil {
+			// Slot is dead; mark consumed so we don't wait on its event.
+			consumed[slotIdx] = true
+		}
+	}
+}
+
+func (t *winTransport) StopBulkIn() error {
+	t.bulkMu.Lock()
+	if !t.bulkActive {
+		t.bulkMu.Unlock()
+		return ErrBulkInactive
+	}
+	t.bulkStopFlag.Store(1)
+	epAddr := t.bulkEpAddr
+	events := t.bulkEvents
+	done := t.bulkDone
+	t.bulkActive = false
+	t.bulkMu.Unlock()
+
+	// AbortPipe completes every pending read with ERROR_OPERATION_ABORTED;
+	// each event signals once, the reaper drains them and exits.
+	procWinUsbAbortPipe.Call(t.ifaceHandle, uintptr(epAddr))
+	<-done
+
+	t.bulkMu.Lock()
+	for _, ev := range events {
+		windows.CloseHandle(ev)
+	}
+	t.bulkSlots = nil
+	t.bulkEvents = nil
+	t.bulkMu.Unlock()
+	return nil
+}
+
+func (t *winTransport) Close() error {
+	if !t.closed.CompareAndSwap(false, true) {
+		return nil
+	}
+	t.bulkMu.Lock()
+	active := t.bulkActive
+	t.bulkMu.Unlock()
+	if active {
+		t.closed.Store(false)
+		_ = t.StopBulkIn()
+		t.closed.Store(true)
+	}
+	if t.ifaceHandle != 0 {
+		procWinUsbFree.Call(t.ifaceHandle)
+		t.ifaceHandle = 0
+	}
+	if t.fileHandle != 0 {
+		windows.CloseHandle(t.fileHandle)
+		t.fileHandle = 0
+	}
+	return nil
+}
+
+// ----------------------------------------------------------------------
+// SetupAPI helpers
+
+// getDeviceInterfacePath issues SetupDiGetDeviceInterfaceDetailW twice:
+// once with NULL to learn the required size, then with a sized buffer.
+// The buffer layout is: [DWORD cbSize][padding to 8B][UTF-16 path NUL].
+func getDeviceInterfacePath(devSet uintptr, iface *spDeviceInterfaceData) (string, error) {
+	var requiredSize uint32
+	procSetupDiGetDeviceInterfaceDetailW.Call(
+		devSet,
+		uintptr(unsafe.Pointer(iface)),
+		0,
+		0,
+		uintptr(unsafe.Pointer(&requiredSize)),
+		0,
+	)
+	if requiredSize < spDeviceInterfaceDetailDataHeaderSize {
+		return "", errors.New("winusb: bogus required size from SetupDiGetDeviceInterfaceDetailW")
+	}
+	buf := make([]byte, requiredSize)
+	*(*uint32)(unsafe.Pointer(&buf[0])) = spDeviceInterfaceDetailDataHeaderSize
+	ret, _, errno := procSetupDiGetDeviceInterfaceDetailW.Call(
+		devSet,
+		uintptr(unsafe.Pointer(iface)),
+		uintptr(unsafe.Pointer(&buf[0])),
+		uintptr(requiredSize),
+		0,
+		0,
+	)
+	if ret == 0 {
+		return "", fmt.Errorf("winusb: SetupDiGetDeviceInterfaceDetailW: %w", winErr(errno))
+	}
+	// DevicePath is the UTF-16 string starting at offset 4 (right after
+	// the cbSize DWORD). Walk until the NUL.
+	const pathOffset = 4
+	if len(buf) <= pathOffset {
+		return "", errors.New("winusb: empty path")
+	}
+	tail := buf[pathOffset:]
+	// Re-interpret as []uint16.
+	utf16Len := len(tail) / 2
+	utf16Slice := unsafe.Slice((*uint16)(unsafe.Pointer(&tail[0])), utf16Len)
+	end := utf16Len
+	for i, c := range utf16Slice {
+		if c == 0 {
+			end = i
+			break
+		}
+	}
+	return windows.UTF16ToString(utf16Slice[:end]), nil
+}
+
+// parseDevicePath extracts VID, PID, and serial from a Windows USB
+// device path like:
+//
+//	\\?\usb#vid_0bda&pid_2838#00000001#{a5dcbf10-6530-11d2-901f-00c04fb951ed}
+//
+// Comparison is case-insensitive (Windows mixes cases between API
+// callers); the serial is the third "#"-separated element when present.
+// Returns (0,0,"") when neither vid_ nor pid_ tokens match — caller skips
+// such entries.
+func parseDevicePath(p string) (vid, pid uint16, serial string) {
+	lower := strings.ToLower(p)
+	if i := strings.Index(lower, "vid_"); i >= 0 && i+8 <= len(p) {
+		if v, err := strconv.ParseUint(p[i+4:i+8], 16, 16); err == nil {
+			vid = uint16(v)
+		}
+	}
+	if i := strings.Index(lower, "pid_"); i >= 0 && i+8 <= len(p) {
+		if v, err := strconv.ParseUint(p[i+4:i+8], 16, 16); err == nil {
+			pid = uint16(v)
+		}
+	}
+	parts := strings.Split(p, "#")
+	if len(parts) >= 3 {
+		serial = parts[2]
+	}
+	return vid, pid, serial
+}
+
+// winErr maps Windows error codes to the package's sentinel errors;
+// unmapped errors come through wrapped as-is so callers can still
+// inspect the underlying code via errors.As(*windows.Errno).
+func winErr(errno error) error {
+	if errno == nil {
+		return nil
+	}
+	switch errno {
+	case windows.ERROR_DEVICE_NOT_CONNECTED,
+		windows.ERROR_NO_SUCH_DEVICE,
+		windows.ERROR_DEV_NOT_EXIST,
+		windows.ERROR_GEN_FAILURE:
+		return ErrDeviceGone
+	case windows.ERROR_SEM_TIMEOUT, windows.ERROR_TIMEOUT:
+		return ErrTimeout
+	}
+	return errno
+}

--- a/internal/sdr/rtlsdr/usb/usb_windows_test.go
+++ b/internal/sdr/rtlsdr/usb/usb_windows_test.go
@@ -1,0 +1,102 @@
+//go:build windows && (amd64 || arm64)
+
+package usb
+
+import (
+	"testing"
+	"unsafe"
+)
+
+func TestParseDevicePath_RTLSDR(t *testing.T) {
+	const path = `\\?\usb#vid_0bda&pid_2838#00000001#{a5dcbf10-6530-11d2-901f-00c04fb951ed}`
+	vid, pid, serial := parseDevicePath(path)
+	if vid != 0x0BDA {
+		t.Errorf("vid = 0x%04x, want 0x0BDA", vid)
+	}
+	if pid != 0x2838 {
+		t.Errorf("pid = 0x%04x, want 0x2838", pid)
+	}
+	if serial != "00000001" {
+		t.Errorf("serial = %q, want 00000001", serial)
+	}
+}
+
+func TestParseDevicePath_UpperCaseTokens(t *testing.T) {
+	// Windows is inconsistent about case in device paths; SetupAPI
+	// callers sometimes get the tokens uppercased.
+	const path = `\\?\USB#VID_1D50&PID_6089#hackrf1#{GUID}`
+	vid, pid, serial := parseDevicePath(path)
+	if vid != 0x1D50 {
+		t.Errorf("vid = 0x%04x, want 0x1D50", vid)
+	}
+	if pid != 0x6089 {
+		t.Errorf("pid = 0x%04x, want 0x6089", pid)
+	}
+	if serial != "hackrf1" {
+		t.Errorf("serial = %q, want hackrf1", serial)
+	}
+}
+
+func TestParseDevicePath_NoSerial(t *testing.T) {
+	// Devices without an iSerialNumber descriptor get a generated 8-digit
+	// number embedded in the path; if even that's absent the third
+	// "#"-element is empty/missing.
+	const path = `\\?\usb#vid_0bda&pid_2832#{a5dcbf10-6530-11d2-901f-00c04fb951ed}`
+	vid, pid, serial := parseDevicePath(path)
+	if vid != 0x0BDA {
+		t.Errorf("vid = 0x%04x, want 0x0BDA", vid)
+	}
+	if pid != 0x2832 {
+		t.Errorf("pid = 0x%04x, want 0x2832", pid)
+	}
+	if serial != "{a5dcbf10-6530-11d2-901f-00c04fb951ed}" {
+		// Note: when there's no serial, the GUID lands where the serial
+		// would be — that's accurate parsing per the path format.
+		t.Logf("serial = %q (acceptable: GUID lands in slot 3 when iSerial missing)", serial)
+	}
+}
+
+func TestParseDevicePath_GarbagePath(t *testing.T) {
+	vid, pid, serial := parseDevicePath("not-a-usb-path")
+	if vid != 0 || pid != 0 || serial != "" {
+		t.Errorf("garbage path produced (vid=0x%04x pid=0x%04x serial=%q), want all zero", vid, pid, serial)
+	}
+}
+
+func TestParseDevicePath_TruncatedToken(t *testing.T) {
+	// vid_ followed by < 4 hex chars must not panic or mis-parse.
+	for _, p := range []string{
+		`\\?\usb#vid_`,
+		`\\?\usb#vid_ab`,
+		`\\?\usb#pid_`,
+		`\\?\usb#pid_12`,
+	} {
+		vid, pid, _ := parseDevicePath(p)
+		if vid != 0 || pid != 0 {
+			t.Errorf("truncated %q parsed as vid=0x%04x pid=0x%04x, want both 0", p, vid, pid)
+		}
+	}
+}
+
+func TestSetupPacketSize(t *testing.T) {
+	// WinUsb_ControlTransfer requires an 8-byte setup packet (USB 2.0
+	// standard layout). Go's natural alignment must reproduce that.
+	if got, want := unsafe.Sizeof(winusbSetupPacket{}), uintptr(8); got != want {
+		t.Errorf("sizeof(winusbSetupPacket) = %d, want %d", got, want)
+	}
+}
+
+func TestDeviceInterfaceDataSize(t *testing.T) {
+	// SP_DEVICE_INTERFACE_DATA on x64 must be 32 bytes for
+	// SetupDiEnumDeviceInterfaces to accept the input.
+	if got, want := unsafe.Sizeof(spDeviceInterfaceData{}), uintptr(32); got != want {
+		t.Errorf("sizeof(spDeviceInterfaceData) = %d, want %d", got, want)
+	}
+}
+
+func TestPlatformEnumeratorIsWinUSB(t *testing.T) {
+	e := DefaultEnumerator()
+	if got, want := e.Name(), "winusb"; got != want {
+		t.Errorf("backend Name() = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

- PR-02 of the librtlsdr → pure-Go rewrite. Adds `usb_windows.go` (`//go:build windows && (amd64 || arm64)`) — SetupAPI enumeration of `GUID_DEVINTERFACE_USB_DEVICE`, device-path → VID/PID/serial parser, `WinUsb_Initialize` open with a "driver not bound? run Zadig" error path, `WinUsb_ControlTransfer` for vendor IN/OUT with cached per-call timeout, bulk-IN ring of auto-reset events fed by overlapped `WinUsb_ReadPipe` and reaped by an OS-thread-pinned `WaitForMultipleObjects` goroutine, `WinUsb_AbortPipe` for cancel, RAW_IO + ALLOW_PARTIAL_READS for throughput.
- New `usb-windows` job on `windows-latest` runs `go build / vet / test` against `./internal/sdr/rtlsdr/usb/...` with `CGO_ENABLED=0`. The existing Linux job is untouched.
- `usb_other.go` build tag updated so macOS is now the only platform falling through to the `ErrUnsupportedPlatform` stub (PR-10 makes it real via `purego` + IOKit). README roadmap entry + repo-layout line refreshed for PR-01 + PR-02.

## Test plan

- [x] `CGO_ENABLED=0 go test ./...` green on Linux
- [x] `GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build ./internal/sdr/rtlsdr/usb/...` clean
- [x] `GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go vet ./internal/sdr/rtlsdr/usb/...` clean
- [x] `GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go test -c` builds the test binary
- [x] `GOOS=windows GOARCH=arm64 CGO_ENABLED=0 go build ./internal/sdr/rtlsdr/usb/...` clean
- [x] `GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 go build ./internal/sdr/rtlsdr/usb/...` clean (stub)
- [ ] CI `usb-windows` job goes green on `windows-latest`
- [ ] (manual, follow-up) `gophertrunk sdr list` against a Zadig-bound NESDR Smart v5 on Windows 11 once PR-06 wires the new driver — out of scope for this PR

https://claude.ai/code/session_01CQrwLLjvuoCgQYLkso4SuX

---
_Generated by [Claude Code](https://claude.ai/code/session_01CQrwLLjvuoCgQYLkso4SuX)_