### PR TITLE
internal/sdr/rtlsdr/rtl2832u: register + I2C + GPIO layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,8 +282,8 @@ to its own package and lands independently.
   R820T2, R828D, E4000, FC0012, FC0013, FC2580). The
   `sdr.Device` interface and IQ-format conversion at
   `internal/sdr/rtlsdr/rtlsdr_cgo.go:225-240` are preserved
-  bit-identically so the DSP chain is untouched. Status: PR-01 +
-  PR-02 + PR-03 landed — `internal/sdr/rtlsdr/usb/` exposes the
+  bit-identically so the DSP chain is untouched. Status: PR-01
+  through PR-04 landed. `internal/sdr/rtlsdr/usb/` exposes the
   `Transport` + `Enumerator` interfaces, a record/replay
   `MockTransport` for unit tests, and platform backends across
   Linux, Windows, and macOS. Linux uses USBDEVFS ioctls
@@ -301,12 +301,26 @@ to its own package and lands independently.
   follow-up — day-one macOS binaries build and start cleanly;
   only live dongle access is gated. CI compiles + vets + tests
   the package on `ubuntu-latest` + `windows-latest` +
-  `macos-latest` under `CGO_ENABLED=0`. PRs 04-10 land the
-  RTL2832U register/I2C layer, the R820T2 tuner, the wire-up
-  under the alternate driver name `rtlsdr-go`, the remaining
-  five tuners, the default flip, the deletion of
-  `rtlsdr_cgo.go` + every `librtlsdr` apt / MSYS2 / DLL-bundling
-  step in `Dockerfile`, `.github/workflows/*.yml`,
+  `macos-latest` under `CGO_ENABLED=0`.
+  `internal/sdr/rtlsdr/rtl2832u/` is the demodulator-chip layer
+  on top of the transport: `ReadBlockReg` / `WriteBlockReg`
+  (USB / SYS register space) and `ReadDemodReg` / `WriteDemodReg`
+  (page-addressed demod registers) match the librtlsdr wire
+  format byte-for-byte (including the load-bearing
+  page-0x0A/0x01 commit read after every demod write), plus
+  `InitBaseband` (the full 24-step + 20-byte-FIR power-on
+  sequence), `SetSampleRate` with the 28.4 fixed-point divisor
+  math (golden table covering 250 kS/s / 1.024 / 2.048 / 2.4 /
+  3.2 MS/s pins the realRatio sign-bit-extension corner case),
+  `SetIFFreq`, `SetSampleFreqCorrection` (PPM), `ResetBuffer`,
+  `SetFIR` / `SetFIRDefault`, the I2C bridge (`SetI2CRepeater`
+  caches the last value, `I2CReadReg` / `I2CWriteReg` /
+  `I2CRead` / `I2CWrite`), and GPIO + `SetBiasTee` plumbing.
+  PRs 05-10 land the R820T2 tuner, the wire-up under the
+  alternate driver name `rtlsdr-go`, the remaining five
+  tuners, the default flip, the deletion of `rtlsdr_cgo.go` +
+  every `librtlsdr` apt / MSYS2 / DLL-bundling step in
+  `Dockerfile`, `.github/workflows/*.yml`,
   `installer/gophertrunk.iss`, and the install docs, and the
   macOS IOKit transport itself.
 - **YSF Trellis decode + grant emission.** Sync, frame layout, and
@@ -404,7 +418,8 @@ tests.
 cmd/gophertrunk/        daemon entrypoint + sdr list CLI + read-only TUI
 internal/tui/           bubbletea TUI: 8 read-only panels over REST+SSE
 internal/sdr/           Driver interface, pool, CGO librtlsdr (→ pure-Go), mock
-internal/sdr/rtlsdr/usb/ Pure-Go USB transport: Linux USBDEVFS, Windows WinUSB, macOS stub, mock
+internal/sdr/rtlsdr/usb/      Pure-Go USB transport: Linux USBDEVFS, Windows WinUSB, macOS stub, mock
+internal/sdr/rtlsdr/rtl2832u/ RTL2832U register/I2C layer (sample-rate, IF, FIR, GPIO, I2C bridge)
 internal/dsp/           Channelizer, filters, demods, sync, FFT
 internal/radio/         framing/ + p25/phase1/ + dmr/ + nxdn/
 internal/trunking/      System, talkgroup DB, priority, engine, CC hunter

--- a/internal/sdr/rtlsdr/rtl2832u/demod.go
+++ b/internal/sdr/rtlsdr/rtl2832u/demod.go
@@ -1,0 +1,266 @@
+package rtl2832u
+
+import "fmt"
+
+// firDefault are the 20-tap FIR coefficients librtlsdr ships for DAB/FM
+// reception (the DVB-T variant is unused for SDR). First 8 entries are
+// 8-bit signed; entries 8..15 are 12-bit signed and pack into 12 bytes
+// on the wire (see SetFIR for the packing math).
+var firDefault = [20]int16{
+	-54, -36, -41, -40, -32, -14, 14, 53, // 8-bit signed taps
+	101, 156, 220, 298, 401, 532, 686, 689, // 12-bit signed taps (12-bit limit)
+	// the last 4 entries are unused (kept for table symmetry with the C library)
+	0, 0, 0, 0,
+}
+
+// initBasebandStep is one transfer in the InitBaseband golden sequence.
+// Captured verbatim from librtlsdr's rtlsdr_init_baseband — the
+// constants live here so the unit tests can replay the exact same
+// sequence against the mock transport.
+type initBasebandStep struct {
+	demod bool   // true → ReadDemodReg/WriteDemodReg, false → ReadBlockReg/WriteBlockReg
+	block uint8  // when !demod
+	page  uint8  // when demod
+	addr  uint16 // demod uses 1-byte addresses (cast from uint8 in the C source)
+	val   uint16
+	n     int
+}
+
+// initBasebandSteps is the fixed sequence rtlsdr_init_baseband sends
+// to the chip after open. Order is load-bearing: the FIR upload sits
+// between the demod soft-reset and the SDR-mode enable.
+var initBasebandSteps = []initBasebandStep{
+	// USB init
+	{block: BlockUSB, addr: USBSysctl, val: 0x09, n: 1},
+	{block: BlockUSB, addr: USBEpaMaxpkt, val: 0x0002, n: 2},
+	{block: BlockUSB, addr: USBEpaCtl, val: 0x1002, n: 2},
+	// Power on demod
+	{block: BlockSys, addr: SysDemodCtl1, val: 0x22, n: 1},
+	{block: BlockSys, addr: SysDemodCtl, val: 0xE8, n: 1},
+	// Demod soft-reset (bit 3) + release
+	{demod: true, page: 1, addr: 0x01, val: 0x14, n: 1},
+	{demod: true, page: 1, addr: 0x01, val: 0x10, n: 1},
+	// Disable spectrum inversion / adjacent-channel rejection
+	{demod: true, page: 1, addr: 0x15, val: 0x00, n: 1},
+	{demod: true, page: 1, addr: 0x16, val: 0x0000, n: 2},
+	// Clear DDC shift + IF frequency registers
+	{demod: true, page: 1, addr: 0x16, val: 0x00, n: 1},
+	{demod: true, page: 1, addr: 0x17, val: 0x00, n: 1},
+	{demod: true, page: 1, addr: 0x18, val: 0x00, n: 1},
+	{demod: true, page: 1, addr: 0x19, val: 0x00, n: 1},
+	{demod: true, page: 1, addr: 0x1A, val: 0x00, n: 1},
+	{demod: true, page: 1, addr: 0x1B, val: 0x00, n: 1},
+	// FIR coefficients land at page 1, addr 0x1C..0x2F (20 single-byte writes).
+	// SetFIRDefault expands the firDefault table into the corresponding writes
+	// — they're not enumerated here so the test stays robust to FIR table
+	// changes; SetFIR's own test pins the byte-packing math.
+	// SDR mode, DAGC off (bit 5)
+	{demod: true, page: 0, addr: 0x19, val: 0x05, n: 1},
+	// FSM state-holding registers
+	{demod: true, page: 1, addr: 0x93, val: 0xF0, n: 1},
+	{demod: true, page: 1, addr: 0x94, val: 0x0F, n: 1},
+	// Disable demod AGC (en_dagc bit 0)
+	{demod: true, page: 1, addr: 0x11, val: 0x00, n: 1},
+	// Disable RF + IF AGC loop
+	{demod: true, page: 1, addr: 0x04, val: 0x00, n: 1},
+	// Disable PID filter
+	{demod: true, page: 0, addr: 0x61, val: 0x60, n: 1},
+	// Default ADC I/Q datapath (opt_adc_iq = 0)
+	{demod: true, page: 0, addr: 0x06, val: 0x80, n: 1},
+	// Zero-IF mode + DC cancellation + IQ estimation/compensation
+	{demod: true, page: 1, addr: 0xB1, val: 0x1B, n: 1},
+	// Disable 4.096 MHz clock output on TP_CK0
+	{demod: true, page: 0, addr: 0x0D, val: 0x83, n: 1},
+}
+
+// InitBaseband walks the librtlsdr initialization sequence: power on
+// the demod, soft-reset, load FIR coefficients, enable SDR mode, and
+// configure zero-IF + IQ compensation. Idempotent on re-open.
+func (d *Demod) InitBaseband() error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	// Steps before the FIR upload.
+	for i := 0; i < 15; i++ {
+		if err := d.runInitStep(initBasebandSteps[i]); err != nil {
+			return fmt.Errorf("init baseband step %d: %w", i, err)
+		}
+	}
+	// Default FIR (20 single-byte writes at page 1, addr 0x1C..0x2F).
+	if err := d.setFIRLocked(firDefault); err != nil {
+		return fmt.Errorf("init baseband: FIR upload: %w", err)
+	}
+	for i := 15; i < len(initBasebandSteps); i++ {
+		if err := d.runInitStep(initBasebandSteps[i]); err != nil {
+			return fmt.Errorf("init baseband step %d: %w", i, err)
+		}
+	}
+	return nil
+}
+
+func (d *Demod) runInitStep(s initBasebandStep) error {
+	if s.demod {
+		return d.writeDemodRegLocked(s.page, s.addr, s.val, s.n)
+	}
+	return d.writeBlockRegLocked(s.block, s.addr, s.val, s.n)
+}
+
+// DeinitBaseband is the inverse of InitBaseband — power down the demod
+// so the next consumer of the USB device sees a clean state. Today
+// this is just clearing DEMOD_CTL; librtlsdr's rtlsdr_deinit_baseband
+// is similarly minimal.
+func (d *Demod) DeinitBaseband() error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.writeBlockRegLocked(BlockSys, SysDemodCtl, 0x20, 1)
+}
+
+// SetFIR uploads custom FIR filter coefficients. Layout matches
+// rtlsdr_set_fir: first 8 entries are 8-bit signed (one byte each),
+// entries 8..15 are 12-bit signed and pack three nibbles per pair —
+// 24 bits per pair → 12 bytes total. Total wire footprint is 20
+// single-byte demod writes at page 1, addr 0x1C..0x2F.
+func (d *Demod) SetFIR(coeffs [20]int16) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.setFIRLocked(coeffs)
+}
+
+// SetFIRDefault reloads the librtlsdr default FIR (DAB/FM tuned).
+func (d *Demod) SetFIRDefault() error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.setFIRLocked(firDefault)
+}
+
+func (d *Demod) setFIRLocked(coeffs [20]int16) error {
+	for i := 0; i < 8; i++ {
+		if coeffs[i] < -128 || coeffs[i] > 127 {
+			return fmt.Errorf("rtl2832u: FIR coeff[%d]=%d out of 8-bit range", i, coeffs[i])
+		}
+	}
+	// Pack 8 × int16 into 8 wire bytes (8-bit signed).
+	var fir [20]byte
+	for i := 0; i < 8; i++ {
+		fir[i] = byte(coeffs[i])
+	}
+	// Pack 4 pairs of 12-bit signed coeffs into 12 bytes (3 bytes per pair).
+	for i := 0; i < 4; i++ {
+		v0 := coeffs[8+i*2]
+		v1 := coeffs[8+i*2+1]
+		if v0 < -2048 || v0 > 2047 || v1 < -2048 || v1 > 2047 {
+			return fmt.Errorf("rtl2832u: FIR coeff[%d..%d]=(%d,%d) out of 12-bit range", 8+i*2, 8+i*2+1, v0, v1)
+		}
+		fir[8+i*3] = byte(v0 >> 4)
+		fir[8+i*3+1] = byte((v0 << 4) | ((v1 >> 8) & 0x0F))
+		fir[8+i*3+2] = byte(v1)
+	}
+	for i := 0; i < 20; i++ {
+		if err := d.writeDemodRegLocked(1, 0x1C+uint16(i), uint16(fir[i]), 1); err != nil {
+			return fmt.Errorf("rtl2832u: FIR write %d: %w", i, err)
+		}
+	}
+	return nil
+}
+
+// SetSampleRate programs the resampler divider for the requested rate.
+// The chip can only land on rates that map exactly to its 28.4
+// fixed-point divisor; the returned actualHz is the rate the resampler
+// is actually running at (typically within 1 Hz of requested for the
+// useful range, but the API exposes the truth so callers don't lie to
+// their downstream DSP).
+func (d *Demod) SetSampleRate(hz uint32) (actualHz uint32, err error) {
+	if !IsValidSampleRate(hz) {
+		return 0, fmt.Errorf("rtl2832u: sample rate %d Hz outside [%d, %d] (or in the [%d, %d] forbidden gap)", hz, MinSampleRateHz, MaxSampleRateHz, GapLowHz, GapHighHz)
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.setSampleRateLocked(hz)
+}
+
+func (d *Demod) setSampleRateLocked(hz uint32) (uint32, error) {
+	rsampRatio, realHz := computeResamplerDivisor(d.xtal, hz)
+	// Top 16 bits of the divisor → page 1, addr 0x9F (2 bytes).
+	if err := d.writeDemodRegLocked(1, 0x9F, uint16(rsampRatio>>16), 2); err != nil {
+		return 0, err
+	}
+	// Bottom 16 bits → page 1, addr 0xA1 (2 bytes).
+	if err := d.writeDemodRegLocked(1, 0xA1, uint16(rsampRatio&0xFFFF), 2); err != nil {
+		return 0, err
+	}
+	d.rate = realHz
+	// Apply the current PPM correction against the new rate.
+	if err := d.setSampleFreqCorrectionLocked(d.ppm); err != nil {
+		return 0, err
+	}
+	// Soft-reset the demod so the new divisor takes effect immediately.
+	if err := d.writeDemodRegLocked(1, 0x01, 0x14, 1); err != nil {
+		return 0, err
+	}
+	if err := d.writeDemodRegLocked(1, 0x01, 0x10, 1); err != nil {
+		return 0, err
+	}
+	return realHz, nil
+}
+
+// computeResamplerDivisor is the 28.4 fixed-point math librtlsdr uses
+// to translate a target sample rate into the chip's divisor register.
+// Exposed for the golden-table test in this package; production code
+// goes through SetSampleRate which calls this and writes the result.
+func computeResamplerDivisor(xtalHz, sampHz uint32) (divisor, realHz uint32) {
+	ratio := uint64(xtalHz) * twoPow22 / uint64(sampHz)
+	ratio &= 0x0FFF_FFFC
+	realRatio := ratio | ((ratio & 0x0800_0000) << 1)
+	realHz = uint32(uint64(xtalHz) * twoPow22 / realRatio)
+	return uint32(ratio), realHz
+}
+
+// SetSampleFreqCorrection applies a parts-per-million bias against the
+// reference crystal. Negative ppm makes the chip run slow; positive
+// makes it run fast. Math matches rtlsdr_set_sample_freq_correction.
+func (d *Demod) SetSampleFreqCorrection(ppm int) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.setSampleFreqCorrectionLocked(ppm)
+}
+
+func (d *Demod) setSampleFreqCorrectionLocked(ppm int) error {
+	d.ppm = ppm
+	offs := int16(int64(ppm) * -1 * (1 << 24) / 1_000_000)
+	if err := d.writeDemodRegLocked(1, 0x3F, uint16(offs&0xFF), 1); err != nil {
+		return err
+	}
+	return d.writeDemodRegLocked(1, 0x3E, uint16((offs>>8)&0x3F), 1)
+}
+
+// SetIFFreq programs the intermediate-frequency offset (Hz). The
+// effective value is `-freq * 2^22 / xtal`, split into 22 bits across
+// three demod registers (page 1, addr 0x19..0x1B).
+func (d *Demod) SetIFFreq(freqHz uint32) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.setIFFreqLocked(freqHz)
+}
+
+func (d *Demod) setIFFreqLocked(freqHz uint32) error {
+	ifFreq := -int32(uint64(freqHz) * twoPow22 / uint64(d.xtal))
+	d.ifHz = ifFreq
+	if err := d.writeDemodRegLocked(1, 0x19, uint16((ifFreq>>16)&0x3F), 1); err != nil {
+		return err
+	}
+	if err := d.writeDemodRegLocked(1, 0x1A, uint16((ifFreq>>8)&0xFF), 1); err != nil {
+		return err
+	}
+	return d.writeDemodRegLocked(1, 0x1B, uint16(ifFreq&0xFF), 1)
+}
+
+// ResetBuffer clears the USB FIFO so the next bulk-IN stream starts at
+// a fresh buffer boundary. Always called immediately before
+// StartBulkIn — matches rtlsdr_reset_buffer's two-write sequence.
+func (d *Demod) ResetBuffer() error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if err := d.writeBlockRegLocked(BlockUSB, USBEpaCtl, 0x1002, 2); err != nil {
+		return err
+	}
+	return d.writeBlockRegLocked(BlockUSB, USBEpaCtl, 0x0000, 2)
+}

--- a/internal/sdr/rtlsdr/rtl2832u/demod_test.go
+++ b/internal/sdr/rtlsdr/rtl2832u/demod_test.go
@@ -1,0 +1,326 @@
+package rtl2832u
+
+import (
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/sdr/rtlsdr/usb"
+)
+
+// expectDemodWrite builds the (write, commit-read) script entries for one
+// demod register write. Keeps the InitBaseband golden table readable.
+func expectDemodWrite(page uint8, addr, val uint16, n int) []usb.CtrlExchange {
+	wValue := (addr << 8) | 0x20
+	wIndex := uint16(0x10) | uint16(page)
+	return []usb.CtrlExchange{
+		{In: false, BRequest: 0, WValue: wValue, WIndex: wIndex, Data: encodeWriteVal(val, n)},
+		commit,
+	}
+}
+
+func expectBlockWrite(block uint8, addr, val uint16, n int) usb.CtrlExchange {
+	return usb.CtrlExchange{
+		In:       false,
+		BRequest: 0,
+		WValue:   addr,
+		WIndex:   uint16(block)<<8 | 0x10,
+		Data:     encodeWriteVal(val, n),
+	}
+}
+
+func TestComputeResamplerDivisor_GoldenTable(t *testing.T) {
+	// Each row was computed against the published librtlsdr formula
+	// with the default 28.8 MHz reference crystal:
+	//
+	//   rsamp_ratio = (xtal * 2^22) / samp_rate
+	//   rsamp_ratio &= 0x0FFFFFFC
+	//   real_rsamp_ratio = rsamp_ratio | ((rsamp_ratio & 0x08000000) << 1)
+	//   real_rate = (xtal * 2^22) / real_rsamp_ratio
+	//
+	// The values pin both the divisor written to demod pages 0x9F/0xA1
+	// and the post-quantization "real" rate that downstream DSP will
+	// see.
+	cases := []struct {
+		samp        uint32
+		wantDiv     uint32
+		wantRealHz  uint32
+	}{
+		// 2.4 MS/s — the project's default working rate.
+		// xtal*2^22 / 2_400_000 = 50_331_648 = 0x03000000.
+		{samp: 2_400_000, wantDiv: 0x03000000, wantRealHz: 2_400_000},
+		// 1.024 MS/s. xtal*2^22 / 1_024_000 = 117_964_800 = 0x07080000.
+		{samp: 1_024_000, wantDiv: 0x07080000, wantRealHz: 1_024_000},
+		// 2.048 MS/s. xtal*2^22 / 2_048_000 = 58_982_400 = 0x03840000.
+		{samp: 2_048_000, wantDiv: 0x03840000, wantRealHz: 2_048_000},
+		// 3.2 MS/s — the upper limit librtlsdr admits.
+		// xtal*2^22 / 3_200_000 = 37_748_736 = 0x02400000.
+		{samp: 3_200_000, wantDiv: 0x02400000, wantRealHz: 3_200_000},
+		// 250 kS/s — below the 300 kHz forbidden floor; hits the
+		// sign-bit expansion path. Pre-mask ratio is 0x1CCCCCCC;
+		// the mask clears bits 28+, leaving 0x0CCCCCCC. The
+		// sign-extend OR then puts bit 27 back into the realRatio
+		// used for the realHz computation, but the divisor written
+		// to demod 0x9F/0xA1 stays 0x0CCCCCCC.
+		{samp: 250_000, wantDiv: 0x0CCCCCCC, wantRealHz: 250_000},
+	}
+	for _, tc := range cases {
+		div, realHz := computeResamplerDivisor(DefaultXtalHz, tc.samp)
+		if div != tc.wantDiv {
+			t.Errorf("computeResamplerDivisor(%d) divisor = 0x%08X, want 0x%08X", tc.samp, div, tc.wantDiv)
+		}
+		// Real-rate quantization: assert we're within 1 Hz of the
+		// requested rate (the divisor has 28-bit resolution so the
+		// quantization step at 2.4 MS/s is ~0.05 Hz).
+		diff := int64(realHz) - int64(tc.wantRealHz)
+		if diff < -1 || diff > 1 {
+			t.Errorf("computeResamplerDivisor(%d) realHz = %d, want %d (±1)", tc.samp, realHz, tc.wantRealHz)
+		}
+	}
+}
+
+func TestIsValidSampleRate(t *testing.T) {
+	cases := []struct {
+		hz   uint32
+		want bool
+	}{
+		{hz: 225_000, want: false},   // C source rejects samp_rate <= 225_000
+		{hz: 225_001, want: true},    // first allowed value just above floor
+		{hz: 250_000, want: true},    // common sub-rate
+		{hz: 300_000, want: true},    // boundary: 300_000 is OK (gap starts at >300_000)
+		{hz: 300_001, want: false},   // inside forbidden gap
+		{hz: 600_000, want: false},   // middle of gap
+		{hz: 900_000, want: false},   // upper edge of gap (still forbidden — <= 900_000)
+		{hz: 900_001, want: true},    // just above gap
+		{hz: 2_400_000, want: true},  // default rate
+		{hz: 3_200_000, want: true},  // upper limit
+		{hz: 3_200_001, want: false}, // above ceiling
+	}
+	for _, tc := range cases {
+		got := IsValidSampleRate(tc.hz)
+		if got != tc.want {
+			t.Errorf("IsValidSampleRate(%d) = %v, want %v", tc.hz, got, tc.want)
+		}
+	}
+}
+
+func TestSetSampleRate_RejectsOutOfRange(t *testing.T) {
+	d := New(usb.NewMockTransport())
+	for _, hz := range []uint32{0, 100_000, 225_000, 300_001, 900_000, 5_000_000} {
+		_, err := d.SetSampleRate(hz)
+		if err == nil {
+			t.Errorf("SetSampleRate(%d) = nil, want error", hz)
+		}
+	}
+}
+
+func TestSetSampleRate_WritesDivisorAndResets(t *testing.T) {
+	// Full transcript for 2.4 MS/s:
+	// - demod write page=1 addr=0x9F val=0x0300 n=2  (divisor high half)
+	// - demod write page=1 addr=0xA1 val=0x0000 n=2  (divisor low half)
+	// - sample-freq correction at ppm=0 (two demod writes at 0x3F, 0x3E)
+	// - soft-reset demod (writes 0x14 then 0x10 to page=1 addr=0x01)
+	m := usb.NewMockTransport()
+	var script []usb.CtrlExchange
+	script = append(script, expectDemodWrite(1, 0x9F, 0x0300, 2)...)
+	script = append(script, expectDemodWrite(1, 0xA1, 0x0000, 2)...)
+	script = append(script, expectDemodWrite(1, 0x3F, 0x00, 1)...)
+	script = append(script, expectDemodWrite(1, 0x3E, 0x00, 1)...)
+	script = append(script, expectDemodWrite(1, 0x01, 0x14, 1)...)
+	script = append(script, expectDemodWrite(1, 0x01, 0x10, 1)...)
+	m.Script = script
+
+	d := New(m)
+	got, err := d.SetSampleRate(2_400_000)
+	if err != nil {
+		t.Fatalf("SetSampleRate: %v", err)
+	}
+	if got != 2_400_000 {
+		t.Errorf("actual rate = %d, want 2_400_000", got)
+	}
+	if m.Err != nil {
+		t.Errorf("mock err = %v", m.Err)
+	}
+	if m.Remaining() != 0 {
+		t.Errorf("remaining script entries = %d, want 0", m.Remaining())
+	}
+	if d.GetSampleRate() != 2_400_000 {
+		t.Errorf("GetSampleRate = %d, want 2_400_000", d.GetSampleRate())
+	}
+}
+
+func TestSetIFFreq_MathMatchesLibrtlsdr(t *testing.T) {
+	// For freq=0 Hz the IF-freq divisor is 0; all three demod registers
+	// receive 0x00. The 22-bit value is the negative of the freq.
+	m := usb.NewMockTransport()
+	script := []usb.CtrlExchange{}
+	script = append(script, expectDemodWrite(1, 0x19, 0x00, 1)...)
+	script = append(script, expectDemodWrite(1, 0x1A, 0x00, 1)...)
+	script = append(script, expectDemodWrite(1, 0x1B, 0x00, 1)...)
+	m.Script = script
+
+	d := New(m)
+	if err := d.SetIFFreq(0); err != nil {
+		t.Fatalf("SetIFFreq(0): %v", err)
+	}
+	if m.Remaining() != 0 {
+		t.Errorf("remaining=%d, want 0", m.Remaining())
+	}
+}
+
+func TestSetSampleFreqCorrection_Zero(t *testing.T) {
+	// ppm=0 → offs=0 → both writes land 0x00.
+	m := usb.NewMockTransport()
+	script := []usb.CtrlExchange{}
+	script = append(script, expectDemodWrite(1, 0x3F, 0x00, 1)...)
+	script = append(script, expectDemodWrite(1, 0x3E, 0x00, 1)...)
+	m.Script = script
+
+	d := New(m)
+	if err := d.SetSampleFreqCorrection(0); err != nil {
+		t.Fatalf("SetSampleFreqCorrection(0): %v", err)
+	}
+}
+
+func TestSetSampleFreqCorrection_Nonzero(t *testing.T) {
+	// ppm=50 → offs = -50 * 2^24 / 1_000_000 = -838
+	// Truncating to int16: -838 = 0xFCBA (two's complement).
+	// Low byte 0xBA → write to 0x3F.
+	// High byte sign-extended: 0xFC, masked to 6 bits: 0x3C → write to 0x3E.
+	m := usb.NewMockTransport()
+	script := []usb.CtrlExchange{}
+	script = append(script, expectDemodWrite(1, 0x3F, 0xBA, 1)...)
+	script = append(script, expectDemodWrite(1, 0x3E, 0x3C, 1)...)
+	m.Script = script
+
+	d := New(m)
+	if err := d.SetSampleFreqCorrection(50); err != nil {
+		t.Fatalf("SetSampleFreqCorrection(50): %v", err)
+	}
+	if m.Err != nil {
+		t.Errorf("mock err: %v", m.Err)
+	}
+}
+
+func TestResetBuffer_SequenceMatchesLibrtlsdr(t *testing.T) {
+	m := usb.NewMockTransport()
+	m.Script = []usb.CtrlExchange{
+		expectBlockWrite(BlockUSB, USBEpaCtl, 0x1002, 2),
+		expectBlockWrite(BlockUSB, USBEpaCtl, 0x0000, 2),
+	}
+	d := New(m)
+	if err := d.ResetBuffer(); err != nil {
+		t.Fatalf("ResetBuffer: %v", err)
+	}
+	if m.Err != nil || m.Remaining() != 0 {
+		t.Errorf("mock state: err=%v remaining=%d", m.Err, m.Remaining())
+	}
+}
+
+func TestSetFIRDefault_TwentyDemodWrites(t *testing.T) {
+	// Pre-compute the expected byte sequence the FIR packing math
+	// produces against firDefault.
+	expected := buildFIRWireBytes(t, firDefault)
+	m := usb.NewMockTransport()
+	for i, b := range expected {
+		m.Script = append(m.Script, expectDemodWrite(1, 0x1C+uint16(i), uint16(b), 1)...)
+	}
+
+	d := New(m)
+	if err := d.SetFIRDefault(); err != nil {
+		t.Fatalf("SetFIRDefault: %v", err)
+	}
+	if m.Err != nil {
+		t.Errorf("mock err: %v", m.Err)
+	}
+	if m.Remaining() != 0 {
+		t.Errorf("remaining=%d, want 0", m.Remaining())
+	}
+}
+
+func TestSetFIR_OutOfRange8BitTap(t *testing.T) {
+	var bad [20]int16 = firDefault
+	bad[2] = 200 // outside 8-bit signed range
+	if err := New(usb.NewMockTransport()).SetFIR(bad); err == nil {
+		t.Fatal("expected error for out-of-range 8-bit tap")
+	}
+}
+
+func TestSetFIR_OutOfRange12BitTap(t *testing.T) {
+	var bad [20]int16 = firDefault
+	bad[10] = 3000 // outside 12-bit signed range (±2048)
+	if err := New(usb.NewMockTransport()).SetFIR(bad); err == nil {
+		t.Fatal("expected error for out-of-range 12-bit tap")
+	}
+}
+
+// buildFIRWireBytes recomputes the FIR packing in the test (independent of
+// production code) so a packing-math bug shows up as a script mismatch
+// rather than silently passing through identical logic.
+func buildFIRWireBytes(t *testing.T, coeffs [20]int16) []byte {
+	t.Helper()
+	var out [20]byte
+	for i := 0; i < 8; i++ {
+		out[i] = byte(coeffs[i])
+	}
+	for i := 0; i < 4; i++ {
+		v0 := coeffs[8+i*2]
+		v1 := coeffs[8+i*2+1]
+		out[8+i*3] = byte(v0 >> 4)
+		out[8+i*3+1] = byte((v0 << 4) | ((v1 >> 8) & 0x0F))
+		out[8+i*3+2] = byte(v1)
+	}
+	return out[:]
+}
+
+func TestInitBaseband_FullSequence(t *testing.T) {
+	// Builds the entire init transcript and asserts InitBaseband walks
+	// it in order. If anyone reorders rtlsdr_init_baseband upstream
+	// without porting the change, this test fails noisily.
+	m := usb.NewMockTransport()
+	var script []usb.CtrlExchange
+
+	// Steps 0..14 (before FIR upload).
+	for i := 0; i < 15; i++ {
+		s := initBasebandSteps[i]
+		if s.demod {
+			script = append(script, expectDemodWrite(s.page, s.addr, s.val, s.n)...)
+		} else {
+			script = append(script, expectBlockWrite(s.block, s.addr, s.val, s.n))
+		}
+	}
+	// FIR upload — same expected wire bytes as TestSetFIRDefault.
+	firBytes := buildFIRWireBytes(t, firDefault)
+	for i, b := range firBytes {
+		script = append(script, expectDemodWrite(1, 0x1C+uint16(i), uint16(b), 1)...)
+	}
+	// Steps 15..end (after FIR upload).
+	for i := 15; i < len(initBasebandSteps); i++ {
+		s := initBasebandSteps[i]
+		script = append(script, expectDemodWrite(s.page, s.addr, s.val, s.n)...)
+	}
+	m.Script = script
+
+	d := New(m)
+	if err := d.InitBaseband(); err != nil {
+		t.Fatalf("InitBaseband: %v", err)
+	}
+	if m.Err != nil {
+		t.Errorf("mock err: %v", m.Err)
+	}
+	if m.Remaining() != 0 {
+		t.Errorf("remaining=%d, want 0", m.Remaining())
+	}
+}
+
+func TestDeinitBaseband_ClearsDemodCtl(t *testing.T) {
+	m := usb.NewMockTransport()
+	m.Script = []usb.CtrlExchange{
+		expectBlockWrite(BlockSys, SysDemodCtl, 0x20, 1),
+	}
+	d := New(m)
+	if err := d.DeinitBaseband(); err != nil {
+		t.Fatalf("DeinitBaseband: %v", err)
+	}
+	if m.Remaining() != 0 {
+		t.Errorf("remaining=%d, want 0", m.Remaining())
+	}
+}

--- a/internal/sdr/rtlsdr/rtl2832u/gpio.go
+++ b/internal/sdr/rtlsdr/rtl2832u/gpio.go
@@ -1,0 +1,68 @@
+package rtl2832u
+
+import "fmt"
+
+// SetGPIOOutput configures the given GPIO pin (0..7 on the chip's
+// system block) as an output. Bias-tee on RTL-SDR.com v3+ dongles
+// lives on GPIO 0; clones map it elsewhere.
+func (d *Demod) SetGPIOOutput(gpio uint8) error {
+	if gpio > 7 {
+		return fmt.Errorf("rtl2832u: GPIO pin %d out of range", gpio)
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.setGPIOOutputLocked(gpio)
+}
+
+func (d *Demod) setGPIOOutputLocked(gpio uint8) error {
+	// Read-modify-write on GPD (direction) and GPOE (output enable).
+	gpd, err := d.readBlockRegLocked(BlockSys, SysGPD, 1)
+	if err != nil {
+		return err
+	}
+	if err := d.writeBlockRegLocked(BlockSys, SysGPD, uint16(gpd[0]&^(1<<gpio)), 1); err != nil {
+		return err
+	}
+	gpoe, err := d.readBlockRegLocked(BlockSys, SysGPOE, 1)
+	if err != nil {
+		return err
+	}
+	return d.writeBlockRegLocked(BlockSys, SysGPOE, uint16(gpoe[0]|(1<<gpio)), 1)
+}
+
+// SetGPIOBit drives the given GPIO pin high or low. The pin must
+// already be configured as an output via SetGPIOOutput.
+func (d *Demod) SetGPIOBit(gpio uint8, high bool) error {
+	if gpio > 7 {
+		return fmt.Errorf("rtl2832u: GPIO pin %d out of range", gpio)
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.setGPIOBitLocked(gpio, high)
+}
+
+func (d *Demod) setGPIOBitLocked(gpio uint8, high bool) error {
+	gpo, err := d.readBlockRegLocked(BlockSys, SysGPO, 1)
+	if err != nil {
+		return err
+	}
+	v := gpo[0]
+	if high {
+		v |= 1 << gpio
+	} else {
+		v &^= 1 << gpio
+	}
+	return d.writeBlockRegLocked(BlockSys, SysGPO, uint16(v), 1)
+}
+
+// SetBiasTee turns the 5 V LNA-power output on or off. The actual GPIO
+// pin varies per dongle (the RTL-SDR.com v3+ uses pin 0; NESDR uses
+// pin 4 on some revisions); the driver layer (PR-06) plumbs the right
+// pin in based on Info.Product. Provided as a convenience here so the
+// tuner code can flip it without rederiving the read-modify-write.
+func (d *Demod) SetBiasTee(gpio uint8, on bool) error {
+	if err := d.SetGPIOOutput(gpio); err != nil {
+		return fmt.Errorf("rtl2832u: SetBiasTee: configure output: %w", err)
+	}
+	return d.SetGPIOBit(gpio, on)
+}

--- a/internal/sdr/rtlsdr/rtl2832u/gpio_test.go
+++ b/internal/sdr/rtlsdr/rtl2832u/gpio_test.go
@@ -1,0 +1,78 @@
+package rtl2832u
+
+import (
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/sdr/rtlsdr/usb"
+)
+
+func TestSetGPIOOutput_RMW(t *testing.T) {
+	// SetGPIOOutput does a read-modify-write on both GPD and GPOE,
+	// touching only the bit for the requested pin.
+	m := usb.NewMockTransport()
+	// Existing GPD = 0xFF (all inputs); we clear bit 0.
+	m.Script = []usb.CtrlExchange{
+		{In: true, BRequest: 0, WValue: SysGPD, WIndex: uint16(BlockSys) << 8, N: 1, Reply: []byte{0xFF}},
+		expectBlockWrite(BlockSys, SysGPD, 0xFE, 1),
+		{In: true, BRequest: 0, WValue: SysGPOE, WIndex: uint16(BlockSys) << 8, N: 1, Reply: []byte{0x00}},
+		expectBlockWrite(BlockSys, SysGPOE, 0x01, 1),
+	}
+	d := New(m)
+	if err := d.SetGPIOOutput(0); err != nil {
+		t.Fatalf("SetGPIOOutput(0): %v", err)
+	}
+	if m.Err != nil || m.Remaining() != 0 {
+		t.Errorf("mock state: err=%v remaining=%d", m.Err, m.Remaining())
+	}
+}
+
+func TestSetGPIOBit_HighThenLow(t *testing.T) {
+	m := usb.NewMockTransport()
+	m.Script = []usb.CtrlExchange{
+		// High: read GPO=0x00, write 0x01 (bit 0 set).
+		{In: true, BRequest: 0, WValue: SysGPO, WIndex: uint16(BlockSys) << 8, N: 1, Reply: []byte{0x00}},
+		expectBlockWrite(BlockSys, SysGPO, 0x01, 1),
+		// Low: read GPO=0x01 (the previous write), write 0x00.
+		{In: true, BRequest: 0, WValue: SysGPO, WIndex: uint16(BlockSys) << 8, N: 1, Reply: []byte{0x01}},
+		expectBlockWrite(BlockSys, SysGPO, 0x00, 1),
+	}
+	d := New(m)
+	if err := d.SetGPIOBit(0, true); err != nil {
+		t.Fatalf("SetGPIOBit(0,true): %v", err)
+	}
+	if err := d.SetGPIOBit(0, false); err != nil {
+		t.Fatalf("SetGPIOBit(0,false): %v", err)
+	}
+}
+
+func TestSetGPIO_PinOutOfRange(t *testing.T) {
+	d := New(usb.NewMockTransport())
+	if err := d.SetGPIOOutput(8); err == nil {
+		t.Error("SetGPIOOutput(8) should fail")
+	}
+	if err := d.SetGPIOBit(255, true); err == nil {
+		t.Error("SetGPIOBit(255) should fail")
+	}
+}
+
+func TestSetBiasTee_FullSequence(t *testing.T) {
+	// Combines SetGPIOOutput + SetGPIOBit. Pin 0, on.
+	m := usb.NewMockTransport()
+	m.Script = []usb.CtrlExchange{
+		// SetGPIOOutput(0) — GPD r/m/w then GPOE r/m/w.
+		{In: true, BRequest: 0, WValue: SysGPD, WIndex: uint16(BlockSys) << 8, N: 1, Reply: []byte{0xFF}},
+		expectBlockWrite(BlockSys, SysGPD, 0xFE, 1),
+		{In: true, BRequest: 0, WValue: SysGPOE, WIndex: uint16(BlockSys) << 8, N: 1, Reply: []byte{0x00}},
+		expectBlockWrite(BlockSys, SysGPOE, 0x01, 1),
+		// SetGPIOBit(0, true) — GPO r/m/w.
+		{In: true, BRequest: 0, WValue: SysGPO, WIndex: uint16(BlockSys) << 8, N: 1, Reply: []byte{0x00}},
+		expectBlockWrite(BlockSys, SysGPO, 0x01, 1),
+	}
+	d := New(m)
+	if err := d.SetBiasTee(0, true); err != nil {
+		t.Fatalf("SetBiasTee: %v", err)
+	}
+	if m.Err != nil || m.Remaining() != 0 {
+		t.Errorf("mock state: err=%v remaining=%d", m.Err, m.Remaining())
+	}
+}

--- a/internal/sdr/rtlsdr/rtl2832u/i2c.go
+++ b/internal/sdr/rtlsdr/rtl2832u/i2c.go
@@ -1,0 +1,102 @@
+package rtl2832u
+
+import "fmt"
+
+// SetI2CRepeater enables/disables the demod's I2C bridge so the
+// tuner-driver layer (R820T/R820T2/E4000/...) can talk to its chip
+// through the same USB control endpoint. librtlsdr toggles this
+// around every tuner I2C burst — pulling the chain low between
+// bursts so the demod doesn't compete with the tuner for the bus.
+//
+// Caches the last-pushed value; calling repeatedly with the same
+// argument is free.
+func (d *Demod) SetI2CRepeater(on bool) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.repON == on {
+		return nil
+	}
+	val := uint16(0x10)
+	if on {
+		val = 0x18
+	}
+	if err := d.writeDemodRegLocked(1, 0x01, val, 1); err != nil {
+		return fmt.Errorf("rtl2832u: SetI2CRepeater(%v): %w", on, err)
+	}
+	d.repON = on
+	return nil
+}
+
+// I2CWrite issues a bulk write to the tuner over the I2C bridge.
+// Matches rtlsdr_i2c_write — addr is the 7-bit tuner I2C address; the
+// 8th bit is the read/write flag the chip injects automatically.
+func (d *Demod) I2CWrite(i2cAddr uint8, data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
+	if len(data) > 0xFFFF {
+		return fmt.Errorf("rtl2832u: I2CWrite length %d out of range", len(data))
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.i2cWriteLocked(i2cAddr, data)
+}
+
+func (d *Demod) i2cWriteLocked(i2cAddr uint8, data []byte) error {
+	index := uint16(BlockIIC)<<8 | 0x10
+	if err := d.t.ControlOut(0, uint16(i2cAddr), index, data, CtrlTimeoutMs); err != nil {
+		return fmt.Errorf("rtl2832u: I2CWrite addr=0x%02x: %w", i2cAddr, err)
+	}
+	return nil
+}
+
+// I2CRead bulk-reads n bytes from the tuner. The caller is expected to
+// have already issued an I2CWrite with the register pointer if the
+// tuner uses register-addressed access (R820T-family does; FC0012
+// uses bare reads).
+func (d *Demod) I2CRead(i2cAddr uint8, n int) ([]byte, error) {
+	if n <= 0 {
+		return nil, nil
+	}
+	if n > 0xFFFF {
+		return nil, fmt.Errorf("rtl2832u: I2CRead length %d out of range", n)
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.i2cReadLocked(i2cAddr, n)
+}
+
+func (d *Demod) i2cReadLocked(i2cAddr uint8, n int) ([]byte, error) {
+	index := uint16(BlockIIC) << 8
+	out, err := d.t.ControlIn(0, uint16(i2cAddr), index, n, CtrlTimeoutMs)
+	if err != nil {
+		return nil, fmt.Errorf("rtl2832u: I2CRead addr=0x%02x: %w", i2cAddr, err)
+	}
+	return out, nil
+}
+
+// I2CWriteReg writes a single byte to a tuner register over the bridge.
+// Matches rtlsdr_i2c_write_reg: emits a 2-byte payload (reg, val).
+func (d *Demod) I2CWriteReg(i2cAddr, reg, val uint8) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.i2cWriteLocked(i2cAddr, []byte{reg, val})
+}
+
+// I2CReadReg reads a single byte from a tuner register: write the
+// register pointer, then read 1 byte. Matches rtlsdr_i2c_read_reg.
+func (d *Demod) I2CReadReg(i2cAddr, reg uint8) (uint8, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if err := d.i2cWriteLocked(i2cAddr, []byte{reg}); err != nil {
+		return 0, err
+	}
+	out, err := d.i2cReadLocked(i2cAddr, 1)
+	if err != nil {
+		return 0, err
+	}
+	if len(out) == 0 {
+		return 0, fmt.Errorf("rtl2832u: I2CReadReg(0x%02x, 0x%02x): short read", i2cAddr, reg)
+	}
+	return out[0], nil
+}

--- a/internal/sdr/rtlsdr/rtl2832u/i2c_test.go
+++ b/internal/sdr/rtlsdr/rtl2832u/i2c_test.go
@@ -1,0 +1,130 @@
+package rtl2832u
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/sdr/rtlsdr/usb"
+)
+
+func TestSetI2CRepeater_On(t *testing.T) {
+	// page=1 addr=0x01 val=0x18 (bit 3 + bit 4 = enable repeater).
+	m := usb.NewMockTransport()
+	m.Script = expectDemodWrite(1, 0x01, 0x18, 1)
+	d := New(m)
+	if err := d.SetI2CRepeater(true); err != nil {
+		t.Fatalf("SetI2CRepeater(true): %v", err)
+	}
+	if m.Remaining() != 0 {
+		t.Errorf("remaining=%d, want 0", m.Remaining())
+	}
+}
+
+func TestSetI2CRepeater_Off(t *testing.T) {
+	// Default cached value is false; calling Off again is a no-op so we
+	// need to flip on first, then back off.
+	m := usb.NewMockTransport()
+	script := []usb.CtrlExchange{}
+	script = append(script, expectDemodWrite(1, 0x01, 0x18, 1)...)
+	script = append(script, expectDemodWrite(1, 0x01, 0x10, 1)...)
+	m.Script = script
+	d := New(m)
+	if err := d.SetI2CRepeater(true); err != nil {
+		t.Fatalf("on: %v", err)
+	}
+	if err := d.SetI2CRepeater(false); err != nil {
+		t.Fatalf("off: %v", err)
+	}
+	if m.Remaining() != 0 {
+		t.Errorf("remaining=%d, want 0", m.Remaining())
+	}
+}
+
+func TestSetI2CRepeater_CachesSameValue(t *testing.T) {
+	// Second call with the same arg must not emit any transfer.
+	m := usb.NewMockTransport()
+	m.Script = expectDemodWrite(1, 0x01, 0x18, 1)
+	d := New(m)
+	if err := d.SetI2CRepeater(true); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	if err := d.SetI2CRepeater(true); err != nil {
+		t.Fatalf("redundant call: %v", err)
+	}
+	if m.Remaining() != 0 {
+		t.Errorf("redundant call emitted a transfer (remaining=%d after first consumed)", m.Remaining())
+	}
+}
+
+func TestI2CWriteReg_TwoBytePayload(t *testing.T) {
+	// i2c_addr=0x34 (R820T2), reg=0x07, val=0x80.
+	// On the wire: block=BlockIIC=6, wValue=0x0034, wIndex=0x0610,
+	// data=[0x07, 0x80].
+	m := usb.NewMockTransport()
+	m.Script = []usb.CtrlExchange{
+		{In: false, BRequest: 0, WValue: 0x0034, WIndex: uint16(BlockIIC)<<8 | 0x10, Data: []byte{0x07, 0x80}},
+	}
+	d := New(m)
+	if err := d.I2CWriteReg(0x34, 0x07, 0x80); err != nil {
+		t.Fatalf("I2CWriteReg: %v", err)
+	}
+	if m.Err != nil || m.Remaining() != 0 {
+		t.Errorf("mock state: err=%v remaining=%d", m.Err, m.Remaining())
+	}
+}
+
+func TestI2CReadReg_WriteThenRead(t *testing.T) {
+	// write the register pointer, then read 1 byte.
+	m := usb.NewMockTransport()
+	m.Script = []usb.CtrlExchange{
+		{In: false, BRequest: 0, WValue: 0x0034, WIndex: uint16(BlockIIC)<<8 | 0x10, Data: []byte{0x09}},
+		{In: true, BRequest: 0, WValue: 0x0034, WIndex: uint16(BlockIIC) << 8, N: 1, Reply: []byte{0xC9}},
+	}
+	d := New(m)
+	got, err := d.I2CReadReg(0x34, 0x09)
+	if err != nil {
+		t.Fatalf("I2CReadReg: %v", err)
+	}
+	if got != 0xC9 {
+		t.Errorf("got 0x%02x, want 0xC9", got)
+	}
+}
+
+func TestI2CWrite_BulkPayload(t *testing.T) {
+	// Tuner driver might burst-write a whole register block.
+	payload := []byte{0x05, 0x90, 0x00, 0x01}
+	m := usb.NewMockTransport()
+	m.Script = []usb.CtrlExchange{
+		{In: false, BRequest: 0, WValue: 0x0034, WIndex: uint16(BlockIIC)<<8 | 0x10, Data: payload},
+	}
+	d := New(m)
+	if err := d.I2CWrite(0x34, payload); err != nil {
+		t.Fatalf("I2CWrite: %v", err)
+	}
+}
+
+func TestI2CRead_BulkPayload(t *testing.T) {
+	m := usb.NewMockTransport()
+	m.Script = []usb.CtrlExchange{
+		{In: true, BRequest: 0, WValue: 0x0034, WIndex: uint16(BlockIIC) << 8, N: 4, Reply: []byte{0xDE, 0xAD, 0xBE, 0xEF}},
+	}
+	d := New(m)
+	got, err := d.I2CRead(0x34, 4)
+	if err != nil {
+		t.Fatalf("I2CRead: %v", err)
+	}
+	if !bytes.Equal(got, []byte{0xDE, 0xAD, 0xBE, 0xEF}) {
+		t.Errorf("got %x, want DEADBEEF", got)
+	}
+}
+
+func TestI2CRead_ZeroN(t *testing.T) {
+	d := New(usb.NewMockTransport())
+	got, err := d.I2CRead(0x34, 0)
+	if err != nil {
+		t.Fatalf("I2CRead(0): %v", err)
+	}
+	if got != nil {
+		t.Errorf("got %v, want nil for n=0", got)
+	}
+}

--- a/internal/sdr/rtlsdr/rtl2832u/regs.go
+++ b/internal/sdr/rtlsdr/rtl2832u/regs.go
@@ -1,0 +1,92 @@
+// Package rtl2832u is the pure-Go register / I2C-bridge layer that sits
+// between the platform USB transport (internal/sdr/rtlsdr/usb) and the
+// per-tuner drivers. It mirrors osmocom librtlsdr's src/librtlsdr.c
+// register and demodulator access primitives, with no behavior change
+// on the wire — every control transfer that leaves a [Demod] matches
+// what the C library would have sent under the same call.
+//
+// The package is consumed by:
+//
+//   - internal/sdr/rtlsdr/tuners (R820T/R820T2/R828D, E4000, FC0012,
+//     FC0013, FC2580) — for I2C reads and writes against the tuner
+//     IC behind the RTL2832U's I2C bridge.
+//   - internal/sdr/rtlsdr/driver.go (PR-06) — for baseband init,
+//     sample-rate / IF-frequency / PPM programming, FIR coefficients,
+//     bias-tee GPIO, and reset-buffer bookkeeping.
+//
+// No production code outside the rtlsdr driver tree should depend on
+// this package.
+package rtl2832u
+
+// USB-block IDs used by [Demod.ReadBlockReg] / [Demod.WriteBlockReg].
+// The chip exposes seven memory-mapped "blocks"; we send the block
+// number in the high byte of wIndex (low byte carries the read/write
+// direction flag).
+const (
+	BlockDemod uint8 = 0 // page-addressed demod registers (use ReadDemodReg/WriteDemodReg)
+	BlockUSB   uint8 = 1 // USB controller registers (FIFO, EP config)
+	BlockSys   uint8 = 2 // system registers (DEMOD_CTL, GPO, GPI, GPOE, GPD)
+	BlockTuner uint8 = 3 // tuner-direct access (legacy; we use the I2C bridge instead)
+	BlockROM   uint8 = 4 // boot ROM
+	BlockIR    uint8 = 5 // IR receiver block (unused for SDR)
+	BlockIIC   uint8 = 6 // I2C bridge to the tuner IC
+)
+
+// USB-block register addresses.
+const (
+	USBSysctl    uint16 = 0x2000
+	USBCtrl      uint16 = 0x2010
+	USBStat      uint16 = 0x2014
+	USBEpaCfg    uint16 = 0x2144
+	USBEpaCtl    uint16 = 0x2148
+	USBEpaMaxpkt uint16 = 0x2158
+)
+
+// System-block register addresses.
+const (
+	SysDemodCtl  uint16 = 0x3000
+	SysGPO       uint16 = 0x3001
+	SysGPI       uint16 = 0x3002
+	SysGPOE      uint16 = 0x3003 // GPIO output enable
+	SysGPD       uint16 = 0x3004 // GPIO direction
+	SysDemodCtl1 uint16 = 0x300B
+)
+
+// DefaultXtalHz is the RTL2832U's default reference-crystal frequency
+// (28.8 MHz). Some clones use 28.7715 MHz or other values; user-level
+// PPM correction handles small offsets.
+const DefaultXtalHz uint32 = 28_800_000
+
+// CtrlTimeoutMs is the default per-transfer timeout for register
+// reads/writes. Matches osmocom librtlsdr's CTRL_TIMEOUT.
+const CtrlTimeoutMs = 300
+
+// twoPow22 = 2^22; the RTL2832U's IF-frequency and sample-rate
+// dividers use 28.4 fixed-point math seeded against this constant.
+const twoPow22 = 1 << 22
+
+// MinSampleRateHz / MaxSampleRateHz bound the range librtlsdr accepts.
+// The hardware can theoretically run lower/higher but the resampler
+// produces garbage outside these limits.
+const (
+	MinSampleRateHz uint32 = 225_001
+	MaxSampleRateHz uint32 = 3_200_000
+
+	// The RTL2832U has a forbidden sample-rate gap between 300 kS/s
+	// and 900 kS/s where the resampler exhibits known artefacts;
+	// librtlsdr rejects these values, so we do too.
+	GapLowHz  uint32 = 300_000
+	GapHighHz uint32 = 900_000
+)
+
+// IsValidSampleRate is the same predicate librtlsdr uses to gate
+// rtlsdr_set_sample_rate inputs.
+func IsValidSampleRate(hz uint32) bool {
+	if hz <= MinSampleRateHz-1 || hz > MaxSampleRateHz {
+		return false
+	}
+	if hz > GapLowHz && hz <= GapHighHz {
+		return false
+	}
+	return true
+}

--- a/internal/sdr/rtlsdr/rtl2832u/transport.go
+++ b/internal/sdr/rtlsdr/rtl2832u/transport.go
@@ -1,0 +1,162 @@
+package rtl2832u
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/MattCheramie/GopherTrunk/internal/sdr/rtlsdr/usb"
+)
+
+// Demod is the per-device register interface. One [Demod] wraps one
+// claimed [usb.Transport] and is owned by the higher-level driver
+// (PR-06). It serializes control transfers behind a mutex so concurrent
+// register accesses from multiple goroutines (e.g. tuner code racing
+// with bias-tee toggling) interleave cleanly on the USB wire.
+//
+// All ReadBlockReg / WriteBlockReg / ReadDemodReg / WriteDemodReg
+// methods produce control transfers byte-identical to what librtlsdr
+// sends — confirmed by the golden tests in this package.
+type Demod struct {
+	t     usb.Transport
+	mu    sync.Mutex
+	xtal  uint32
+	rate  uint32
+	ifHz  int32
+	ppm   int
+	repON bool // last value pushed to SetI2CRepeater
+}
+
+// New wraps the given transport. The caller is responsible for opening
+// and claiming the device first; this layer doesn't manage the USB
+// handle, only the protocol on top of it.
+func New(t usb.Transport) *Demod {
+	return &Demod{t: t, xtal: DefaultXtalHz}
+}
+
+// SetXtal overrides the default 28.8 MHz reference frequency for boards
+// that ship with a non-standard crystal. Sample-rate and IF math both
+// scale against this value.
+func (d *Demod) SetXtal(hz uint32) {
+	d.mu.Lock()
+	d.xtal = hz
+	d.mu.Unlock()
+}
+
+// XtalHz returns the current reference-crystal value in Hz.
+func (d *Demod) XtalHz() uint32 {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.xtal
+}
+
+// GetSampleRate returns the most-recently-programmed sample rate in Hz,
+// adjusted for the chip's actual resampler resolution (not the value
+// the caller requested).
+func (d *Demod) GetSampleRate() uint32 {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.rate
+}
+
+// ReadBlockReg issues a vendor-IN control transfer against the given
+// block at the given address, returning n bytes. Matches librtlsdr's
+// rtlsdr_read_reg: wValue=addr, wIndex=block<<8, bmRequestType=0xC0.
+//
+// On the wire, the chip returns bytes in little-endian for n=2 reads.
+// Callers wanting a uint16 should mask/shift accordingly (or use the
+// ReadBlockRegU16 convenience).
+func (d *Demod) ReadBlockReg(block uint8, addr uint16, n int) ([]byte, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.readBlockRegLocked(block, addr, n)
+}
+
+func (d *Demod) readBlockRegLocked(block uint8, addr uint16, n int) ([]byte, error) {
+	index := uint16(block) << 8
+	out, err := d.t.ControlIn(0, addr, index, n, CtrlTimeoutMs)
+	if err != nil {
+		return nil, fmt.Errorf("rtl2832u: read block=%d addr=0x%04x: %w", block, addr, err)
+	}
+	return out, nil
+}
+
+// WriteBlockReg writes a register in the given block. Encoding matches
+// rtlsdr_write_reg: wValue=addr, wIndex=block<<8|0x10. For n=1 the low
+// byte of val is sent; for n=2 val is sent big-endian (data[0]=high,
+// data[1]=low).
+func (d *Demod) WriteBlockReg(block uint8, addr, val uint16, n int) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.writeBlockRegLocked(block, addr, val, n)
+}
+
+func (d *Demod) writeBlockRegLocked(block uint8, addr, val uint16, n int) error {
+	index := uint16(block)<<8 | 0x10
+	data := encodeWriteVal(val, n)
+	if err := d.t.ControlOut(0, addr, index, data, CtrlTimeoutMs); err != nil {
+		return fmt.Errorf("rtl2832u: write block=%d addr=0x%04x val=0x%04x: %w", block, addr, val, err)
+	}
+	return nil
+}
+
+// ReadDemodReg reads from the page-addressed demod register space.
+// Matches rtlsdr_demod_read_reg: wValue=(addr<<8)|0x20, wIndex=page,
+// bmRequestType=0xC0.
+//
+// Callers usually want one byte; on n=2 the chip emits little-endian.
+func (d *Demod) ReadDemodReg(page uint8, addr uint16, n int) ([]byte, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.readDemodRegLocked(page, addr, n)
+}
+
+func (d *Demod) readDemodRegLocked(page uint8, addr uint16, n int) ([]byte, error) {
+	wValue := (addr << 8) | 0x20
+	wIndex := uint16(page)
+	out, err := d.t.ControlIn(0, wValue, wIndex, n, CtrlTimeoutMs)
+	if err != nil {
+		return nil, fmt.Errorf("rtl2832u: read demod page=%d addr=0x%02x: %w", page, addr, err)
+	}
+	return out, nil
+}
+
+// WriteDemodReg writes to the page-addressed demod register space.
+// Matches rtlsdr_demod_write_reg: wValue=(addr<<8)|0x20,
+// wIndex=0x10|page, bmRequestType=0x40. Each write is followed by a
+// "commit" read of page 0x0A register 0x01 — without this dummy read
+// the chip does not latch the previous write. Match the C library bit
+// for bit; the commit read is load-bearing on real hardware.
+func (d *Demod) WriteDemodReg(page uint8, addr, val uint16, n int) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.writeDemodRegLocked(page, addr, val, n)
+}
+
+func (d *Demod) writeDemodRegLocked(page uint8, addr, val uint16, n int) error {
+	wValue := (addr << 8) | 0x20
+	wIndex := uint16(0x10) | uint16(page)
+	data := encodeWriteVal(val, n)
+	if err := d.t.ControlOut(0, wValue, wIndex, data, CtrlTimeoutMs); err != nil {
+		return fmt.Errorf("rtl2832u: write demod page=%d addr=0x%02x val=0x%04x: %w", page, addr, val, err)
+	}
+	// Commit. Required by the RTL2832U register interface — without it
+	// the demod write doesn't take effect. Errors here are non-fatal
+	// (the underlying write already happened), so we swallow them.
+	_, _ = d.readDemodRegLocked(0x0A, 0x01, 1)
+	return nil
+}
+
+// encodeWriteVal mirrors the C library's data layout: 1-byte writes
+// send val & 0xff; 2-byte writes send big-endian (high byte first).
+// Anything else is a programmer error and we panic — the package
+// never has cause to issue an n=0 or n>2 write.
+func encodeWriteVal(val uint16, n int) []byte {
+	switch n {
+	case 1:
+		return []byte{byte(val & 0xff)}
+	case 2:
+		return []byte{byte(val >> 8), byte(val & 0xff)}
+	default:
+		panic(fmt.Sprintf("rtl2832u: encodeWriteVal n=%d not in {1,2}", n))
+	}
+}

--- a/internal/sdr/rtlsdr/rtl2832u/transport_test.go
+++ b/internal/sdr/rtlsdr/rtl2832u/transport_test.go
@@ -1,0 +1,150 @@
+package rtl2832u
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/sdr/rtlsdr/usb"
+)
+
+// commit is the dummy demod read every demod write triggers (page 0x0A,
+// addr 0x01, 1 byte) — defined once so the test scripts read cleanly.
+var commit = usb.CtrlExchange{In: true, BRequest: 0, WValue: (0x01 << 8) | 0x20, WIndex: 0x0A, N: 1, Reply: []byte{0x00}}
+
+func TestReadBlockReg_EncodesUSBControlTransfer(t *testing.T) {
+	m := usb.NewMockTransport()
+	m.Script = []usb.CtrlExchange{
+		{In: true, BRequest: 0, WValue: USBSysctl, WIndex: uint16(BlockUSB) << 8, N: 1, Reply: []byte{0xAB}},
+	}
+	d := New(m)
+	got, err := d.ReadBlockReg(BlockUSB, USBSysctl, 1)
+	if err != nil {
+		t.Fatalf("ReadBlockReg: %v", err)
+	}
+	if !bytes.Equal(got, []byte{0xAB}) {
+		t.Errorf("got %x, want AB", got)
+	}
+	if m.Err != nil || m.Remaining() != 0 {
+		t.Errorf("mock state: err=%v remaining=%d", m.Err, m.Remaining())
+	}
+}
+
+func TestWriteBlockReg_OneByte(t *testing.T) {
+	m := usb.NewMockTransport()
+	m.Script = []usb.CtrlExchange{
+		{In: false, BRequest: 0, WValue: USBSysctl, WIndex: uint16(BlockUSB)<<8 | 0x10, Data: []byte{0x09}},
+	}
+	d := New(m)
+	if err := d.WriteBlockReg(BlockUSB, USBSysctl, 0x09, 1); err != nil {
+		t.Fatalf("WriteBlockReg: %v", err)
+	}
+	if m.Err != nil || m.Remaining() != 0 {
+		t.Errorf("mock state: err=%v remaining=%d", m.Err, m.Remaining())
+	}
+}
+
+func TestWriteBlockReg_TwoBytesBigEndian(t *testing.T) {
+	// librtlsdr emits 2-byte writes big-endian: data[0]=high, data[1]=low.
+	m := usb.NewMockTransport()
+	m.Script = []usb.CtrlExchange{
+		{In: false, BRequest: 0, WValue: USBEpaCtl, WIndex: uint16(BlockUSB)<<8 | 0x10, Data: []byte{0x10, 0x02}},
+	}
+	d := New(m)
+	if err := d.WriteBlockReg(BlockUSB, USBEpaCtl, 0x1002, 2); err != nil {
+		t.Fatalf("WriteBlockReg: %v", err)
+	}
+	if m.Err != nil || m.Remaining() != 0 {
+		t.Errorf("mock state: err=%v remaining=%d", m.Err, m.Remaining())
+	}
+}
+
+func TestReadDemodReg_EncodesPageInIndex(t *testing.T) {
+	m := usb.NewMockTransport()
+	// page=1, addr=0x01 → wValue=(0x01<<8)|0x20=0x0120, wIndex=page=1
+	m.Script = []usb.CtrlExchange{
+		{In: true, BRequest: 0, WValue: 0x0120, WIndex: 1, N: 1, Reply: []byte{0xCD}},
+	}
+	d := New(m)
+	got, err := d.ReadDemodReg(1, 0x01, 1)
+	if err != nil {
+		t.Fatalf("ReadDemodReg: %v", err)
+	}
+	if !bytes.Equal(got, []byte{0xCD}) {
+		t.Errorf("got %x, want CD", got)
+	}
+}
+
+func TestWriteDemodReg_IncludesCommitRead(t *testing.T) {
+	// Each demod write must be followed by a 1-byte read of page 0x0A,
+	// addr 0x01 — without it the chip doesn't latch the write.
+	m := usb.NewMockTransport()
+	m.Script = []usb.CtrlExchange{
+		// The write itself: page=1, addr=0x01, val=0x14, wValue=(0x01<<8)|0x20=0x0120,
+		// wIndex=0x10|1=0x11, data=[0x14] (low byte for n=1).
+		{In: false, BRequest: 0, WValue: 0x0120, WIndex: 0x11, Data: []byte{0x14}},
+		// The commit read: page=0x0A, addr=0x01, wValue=0x0120, wIndex=0x0A, n=1.
+		commit,
+	}
+	d := New(m)
+	if err := d.WriteDemodReg(1, 0x01, 0x14, 1); err != nil {
+		t.Fatalf("WriteDemodReg: %v", err)
+	}
+	if m.Err != nil || m.Remaining() != 0 {
+		t.Errorf("mock state: err=%v remaining=%d", m.Err, m.Remaining())
+	}
+}
+
+func TestEncodeWriteVal(t *testing.T) {
+	cases := []struct {
+		val  uint16
+		n    int
+		want []byte
+	}{
+		{val: 0x09, n: 1, want: []byte{0x09}},
+		{val: 0x42, n: 1, want: []byte{0x42}},
+		{val: 0xABCD, n: 1, want: []byte{0xCD}}, // n=1 truncates to low byte
+		{val: 0x0000, n: 2, want: []byte{0x00, 0x00}},
+		{val: 0x1002, n: 2, want: []byte{0x10, 0x02}}, // big-endian
+		{val: 0xABCD, n: 2, want: []byte{0xAB, 0xCD}}, // big-endian
+	}
+	for _, tc := range cases {
+		got := encodeWriteVal(tc.val, tc.n)
+		if !bytes.Equal(got, tc.want) {
+			t.Errorf("encodeWriteVal(0x%04x, %d) = %x, want %x", tc.val, tc.n, got, tc.want)
+		}
+	}
+}
+
+func TestEncodeWriteVal_BadN(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Error("encodeWriteVal with n=3 should panic")
+		}
+	}()
+	encodeWriteVal(0, 3)
+}
+
+func TestWriteBlockReg_PropagatesTransportError(t *testing.T) {
+	wantErr := errors.New("boom")
+	m := usb.NewMockTransport()
+	m.Script = []usb.CtrlExchange{
+		{In: false, BRequest: 0, WValue: USBSysctl, WIndex: uint16(BlockUSB)<<8 | 0x10, Data: []byte{0x09}, Err: wantErr},
+	}
+	d := New(m)
+	err := d.WriteBlockReg(BlockUSB, USBSysctl, 0x09, 1)
+	if !errors.Is(err, wantErr) {
+		t.Errorf("err = %v, want chain containing %v", err, wantErr)
+	}
+}
+
+func TestXtalDefaultAndOverride(t *testing.T) {
+	d := New(usb.NewMockTransport())
+	if d.XtalHz() != DefaultXtalHz {
+		t.Errorf("default xtal = %d, want %d", d.XtalHz(), DefaultXtalHz)
+	}
+	d.SetXtal(28_700_000)
+	if d.XtalHz() != 28_700_000 {
+		t.Errorf("overridden xtal = %d, want 28_700_000", d.XtalHz())
+	}
+}


### PR DESCRIPTION
## Summary

- PR-04 of the librtlsdr → pure-Go rewrite. Adds the demodulator-chip layer (`internal/sdr/rtlsdr/rtl2832u/`) that sits between the platform USB transport (PR-01..03) and the per-tuner drivers landing in PR-05+. No behavior change on the live `rtlsdr` driver — the new package is not wired up yet; PR-06 makes it reachable behind the alternate driver name `rtlsdr-go`.
- Layered API: `ReadBlockReg` / `WriteBlockReg` for USB+SYS block registers, `ReadDemodReg` / `WriteDemodReg` for the page-addressed demod space (with the load-bearing page-0x0A/0x01 commit read after every write), plus high-level helpers `InitBaseband` (full 24-step + 20-byte-FIR power-on sequence), `SetSampleRate` (28.4 fixed-point divisor math with the sign-bit-extension trick from librtlsdr), `SetIFFreq`, `SetSampleFreqCorrection` (PPM), `ResetBuffer`, `SetFIR` / `SetFIRDefault`, the I2C bridge (`SetI2CRepeater` caches the last value), and GPIO + `SetBiasTee`.
- Wire-format pins: byte-identical with librtlsdr (`rtlsdr_read_reg` / `rtlsdr_write_reg` / `rtlsdr_demod_read_reg` / `rtlsdr_demod_write_reg`) including the big-endian 2-byte write quirk and the page-0x0A commit read. Golden divisor table covers 250 kS/s (sign-bit-extension corner) / 1.024 / 2.048 / 2.4 / 3.2 MS/s. `InitBaseband` full-sequence golden pins the exact init order so any upstream reordering fails noisily.

## Test plan

- [x] `CGO_ENABLED=0 go test ./internal/sdr/rtlsdr/rtl2832u/...` green (transport, demod, i2c, gpio)
- [x] `CGO_ENABLED=0 go test ./...` green tree-wide
- [x] `GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go vet ./internal/sdr/rtlsdr/...` clean
- [x] `GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 go vet ./internal/sdr/rtlsdr/...` clean
- [x] Test binaries compile on `windows/amd64` and `darwin/arm64`
- [ ] CI `usb-windows` and `usb-macos` jobs go green
- [ ] (manual, follow-up) Once PR-06 wires the new driver, replay-test `InitBaseband` against a real R820T2 dongle: pcap the USB control transfers via Wireshark + usbmon and diff against the librtlsdr-CGO baseline — must be byte-identical

https://claude.ai/code/session_01CQrwLLjvuoCgQYLkso4SuX

---
_Generated by [Claude Code](https://claude.ai/code/session_01CQrwLLjvuoCgQYLkso4SuX)_