### PR TITLE
internal/sdr/rtlsdr/purego: pure-Go sdr.Driver wired up behind -tags rtlsdr_purego

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ to its own package and lands independently.
   `sdr.Device` interface and IQ-format conversion at
   `internal/sdr/rtlsdr/rtlsdr_cgo.go:225-240` are preserved
   bit-identically so the DSP chain is untouched. Status: PR-01
-  through PR-05 landed. `internal/sdr/rtlsdr/usb/` exposes the
+  through PR-06 landed. `internal/sdr/rtlsdr/usb/` exposes the
   `Transport` + `Enumerator` interfaces, a record/replay
   `MockTransport` for unit tests, and platform backends across
   Linux, Windows, and macOS. Linux uses USBDEVFS ioctls
@@ -331,13 +331,30 @@ to its own package and lands independently.
   (LNA + mixer + VGA stages), AGC ↔ manual mode toggle, and a
   Standby low-power sequence. Detection probes I2C addresses
   0x34 and 0x74, accepts chip ID 0x69 (or the bit-reversed
-  0x96 clone variant). PRs 06-10 land the wire-up under the
-  alternate driver name `rtlsdr-go`, the remaining four tuners
-  (E4000, FC0012, FC0013, FC2580), the default flip, the
-  deletion of `rtlsdr_cgo.go` + every `librtlsdr` apt / MSYS2 /
-  DLL-bundling step in `Dockerfile`, `.github/workflows/*.yml`,
-  `installer/gophertrunk.iss`, and the install docs, and the
-  macOS IOKit transport itself.
+  0x96 clone variant).
+  `internal/sdr/rtlsdr/purego/` is the consumer-facing driver
+  that composes the three layers above into the
+  `sdr.Driver` + `sdr.Device` contracts. `Driver.Enumerate`
+  filters discovered USB devices against a 41-entry known-VID/PID
+  table mirroring `librtlsdr`'s `known_devices`. `Driver.Open`
+  claims interface 0, runs `Demod.InitBaseband`, probes for an
+  R820T-family tuner, runs `Tuner.Init`, and programs the
+  3.57 MHz IF on the demod. `Device.SetCenterFreq` /
+  `SetSampleRate` / `SetGain` (manual ladder + AGC) /
+  `SetPPM` / `SetBiasTee` dispatch to the right layer with
+  bit-identical math to `rtlsdr_cgo.go:225-240`; `StreamIQ`
+  preserves the 32 × 16 KiB ring + 8-deep buffered channel +
+  drop-on-overrun semantics. Registration is gated by the
+  `-tags rtlsdr_purego` build flag so the new driver is opt-in
+  during the rewrite — the existing CGO driver keeps the
+  `rtlsdr` registration name in default builds. With the tag,
+  `rtlsdr-go` shows up in `gophertrunk sdr list` alongside any
+  CGO-backed `rtlsdr` entries (PR-08 swaps the names so
+  pure-Go becomes default; PR-09 deletes the CGO file and the
+  associated `librtlsdr` apt / MSYS2 / DLL-bundling steps).
+  PRs 07-10 land the remaining four tuners (E4000, FC0012,
+  FC0013, FC2580), the default flip, the deletion of
+  `rtlsdr_cgo.go`, and the macOS IOKit transport itself.
 - **YSF Trellis decode + grant emission.** Sync, frame layout, and
   the post-FEC FICH bit-level parser are in; what's left is the
   K=5 ½-rate Viterbi Trellis decoder over the on-air 100-bit FICH
@@ -436,6 +453,7 @@ internal/sdr/           Driver interface, pool, CGO librtlsdr (→ pure-Go), moc
 internal/sdr/rtlsdr/usb/      Pure-Go USB transport: Linux USBDEVFS, Windows WinUSB, macOS stub, mock
 internal/sdr/rtlsdr/rtl2832u/ RTL2832U register/I2C layer (sample-rate, IF, FIR, GPIO, I2C bridge)
 internal/sdr/rtlsdr/tuners/   R820T/R820T2/R828D tuner driver (PLL + mux + gain + bandwidth)
+internal/sdr/rtlsdr/purego/   sdr.Driver+sdr.Device wire-up; -tags rtlsdr_purego registers as "rtlsdr-go"
 internal/dsp/           Channelizer, filters, demods, sync, FFT
 internal/radio/         framing/ + p25/phase1/ + dmr/ + nxdn/
 internal/trunking/      System, talkgroup DB, priority, engine, CC hunter

--- a/cmd/gophertrunk/main.go
+++ b/cmd/gophertrunk/main.go
@@ -12,6 +12,12 @@ import (
 	gtlog "github.com/MattCheramie/GopherTrunk/internal/log"
 	"github.com/MattCheramie/GopherTrunk/internal/sdr"
 	_ "github.com/MattCheramie/GopherTrunk/internal/sdr/rtlsdr"
+	// Pure-Go RTL-SDR driver (PR-06). Only its init() fires under
+	// -tags rtlsdr_purego; default builds get a no-op import so the
+	// CGO driver in internal/sdr/rtlsdr/rtlsdr_cgo.go stays the
+	// sole "rtlsdr" registrant. PR-08 will swap which side is
+	// default; PR-09 will delete the CGO file.
+	_ "github.com/MattCheramie/GopherTrunk/internal/sdr/rtlsdr/purego"
 	"github.com/MattCheramie/GopherTrunk/internal/version"
 
 	// Blank import: pulls in the pure-Go IMBE decoder so the daemon

--- a/internal/sdr/rtlsdr/purego/device.go
+++ b/internal/sdr/rtlsdr/purego/device.go
@@ -1,0 +1,182 @@
+package purego
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+
+	"github.com/MattCheramie/GopherTrunk/internal/sdr"
+	"github.com/MattCheramie/GopherTrunk/internal/sdr/rtlsdr/rtl2832u"
+	"github.com/MattCheramie/GopherTrunk/internal/sdr/rtlsdr/tuners"
+	"github.com/MattCheramie/GopherTrunk/internal/sdr/rtlsdr/usb"
+)
+
+// biasTeeGPIO is the GPIO pin that drives the 5 V LNA-power output on
+// the dominant RTL-SDR designs (RTL-SDR.com v3+, NESDR Smart v5).
+// Other clones map bias-tee to different pins; future work can table
+// this per (VID, PID) — see the per-product mapping comment in
+// rtl2832u.SetBiasTee.
+const biasTeeGPIO uint8 = 0
+
+// ErrClosed is returned by [Device] methods invoked after [Device.Close].
+var ErrClosed = errors.New("rtlsdr-go: device closed")
+
+// Device implements [sdr.Device] for the pure-Go backend. It composes
+// the platform USB transport, the RTL2832U register layer, and the
+// per-chip tuner driver. Methods are goroutine-safe by virtue of the
+// underlying components being safe under their own mutexes; Device
+// adds light coordination for the streaming-state machine and the
+// closed flag.
+type Device struct {
+	transport usb.Transport
+	demod     *rtl2832u.Demod
+	tuner     tuners.Tuner
+	info      sdr.Info
+
+	streamMu sync.Mutex
+	out      chan []complex64
+	stopOnce sync.Once
+
+	closed atomic.Bool
+}
+
+// Info returns the descriptor populated by [Driver.Open] — driver
+// name, USB index, serial / manufacturer / product strings, tuner
+// chip name, and the tuner's gain ladder.
+func (d *Device) Info() sdr.Info { return d.info }
+
+// SetCenterFreq tunes the LO. Delegates to the tuner; settles
+// briefly afterwards so the PLL has time to lock.
+func (d *Device) SetCenterFreq(hz uint32) error {
+	if d.closed.Load() {
+		return ErrClosed
+	}
+	if err := d.tuner.SetFreq(hz); err != nil {
+		return fmt.Errorf("rtlsdr-go: SetCenterFreq(%d): %w", hz, err)
+	}
+	if r, ok := d.tuner.(interface{ SettleAfterRetune() }); ok {
+		r.SettleAfterRetune()
+	}
+	return nil
+}
+
+// SetSampleRate programs the demod resampler and the tuner's IF
+// filter to match. Returns the actual rate the chip can produce
+// (the demod quantizes to its 28.4 fixed-point divisor); callers
+// that need the exact value can read it back via [Demod.GetSampleRate]
+// — but the [sdr.Device] contract returns just the error.
+func (d *Device) SetSampleRate(hz uint32) error {
+	if d.closed.Load() {
+		return ErrClosed
+	}
+	actual, err := d.demod.SetSampleRate(hz)
+	if err != nil {
+		return fmt.Errorf("rtlsdr-go: SetSampleRate(%d): %w", hz, err)
+	}
+	if err := d.tuner.SetBandwidth(actual); err != nil {
+		return fmt.Errorf("rtlsdr-go: tuner bandwidth: %w", err)
+	}
+	return nil
+}
+
+// SetGain takes the [sdr.Device] convention: tenthDB < 0 selects AGC,
+// tenthDB ≥ 0 switches to manual mode and applies the closest
+// quantized gain on the chip's ladder. Mirrors librtlsdr's
+// rtlsdr_set_tuner_gain_mode + rtlsdr_set_tuner_gain pair.
+func (d *Device) SetGain(tenthDB int) error {
+	if d.closed.Load() {
+		return ErrClosed
+	}
+	if tenthDB < 0 {
+		if err := d.tuner.SetGainMode(false); err != nil {
+			return fmt.Errorf("rtlsdr-go: SetGain auto: %w", err)
+		}
+		return nil
+	}
+	if err := d.tuner.SetGainMode(true); err != nil {
+		return fmt.Errorf("rtlsdr-go: SetGain manual mode: %w", err)
+	}
+	if err := d.tuner.SetGain(tenthDB); err != nil {
+		return fmt.Errorf("rtlsdr-go: SetGain(%d tenthDB): %w", tenthDB, err)
+	}
+	return nil
+}
+
+// SetPPM applies a parts-per-million correction to the resampler.
+// Negative slows the chip; positive speeds it up.
+func (d *Device) SetPPM(ppm int) error {
+	if d.closed.Load() {
+		return ErrClosed
+	}
+	if err := d.demod.SetSampleFreqCorrection(ppm); err != nil {
+		return fmt.Errorf("rtlsdr-go: SetPPM(%d): %w", ppm, err)
+	}
+	return nil
+}
+
+// SetBiasTee toggles the dongle's 5 V LNA-power output. The GPIO pin
+// is hard-coded to 0 — the standard for RTL-SDR.com v3+ and NESDR
+// Smart v5 dongles. Boards that wire bias-tee to a different pin
+// will silently no-op; per-product pin mapping is a future
+// enhancement (see the comment in rtl2832u.SetBiasTee).
+func (d *Device) SetBiasTee(enable bool) error {
+	if d.closed.Load() {
+		return ErrClosed
+	}
+	if err := d.demod.SetBiasTee(biasTeeGPIO, enable); err != nil {
+		return fmt.Errorf("rtlsdr-go: SetBiasTee(%v): %w", enable, err)
+	}
+	return nil
+}
+
+// Close releases the tuner, powers off the demod, and closes the USB
+// transport. Idempotent; safe to call from any goroutine.
+func (d *Device) Close() error {
+	if !d.closed.CompareAndSwap(false, true) {
+		return nil
+	}
+	d.cancelStream()
+	var firstErr error
+	if d.tuner != nil {
+		if err := d.tuner.Standby(); err != nil && firstErr == nil {
+			firstErr = fmt.Errorf("rtlsdr-go: tuner standby: %w", err)
+		}
+	}
+	if d.demod != nil {
+		if err := d.demod.DeinitBaseband(); err != nil && firstErr == nil {
+			firstErr = fmt.Errorf("rtlsdr-go: demod deinit: %w", err)
+		}
+	}
+	if err := d.transport.Close(); err != nil && firstErr == nil {
+		firstErr = fmt.Errorf("rtlsdr-go: transport close: %w", err)
+	}
+	return firstErr
+}
+
+// cancelStream is the path closed-channel-on-error and ctx-cancel both
+// take. Idempotent via stopOnce — stops the bulk-IN ring and closes
+// the consumer channel.
+func (d *Device) cancelStream() {
+	d.stopOnce.Do(func() {
+		_ = d.transport.StopBulkIn()
+		d.streamMu.Lock()
+		if d.out != nil {
+			close(d.out)
+			d.out = nil
+		}
+		d.streamMu.Unlock()
+	})
+}
+
+// StreamIQ is implemented in stream.go (kept separate so the IQ
+// conversion math sits next to its unit test).
+//
+// Compile-time assertion that Device satisfies sdr.Device.
+var _ sdr.Device = (*Device)(nil)
+
+// ensure the unused-import warning stays away when the build skips
+// the streaming code path (it doesn't today; this is a guard for the
+// future).
+var _ = context.TODO

--- a/internal/sdr/rtlsdr/purego/devices.go
+++ b/internal/sdr/rtlsdr/purego/devices.go
@@ -1,0 +1,91 @@
+// Package purego is the pure-Go RTL-SDR driver — the [sdr.Device] /
+// [sdr.Driver] implementation that composes the platform USB transport
+// (internal/sdr/rtlsdr/usb), the RTL2832U register layer
+// (internal/sdr/rtlsdr/rtl2832u), and the per-chip tuner drivers
+// (internal/sdr/rtlsdr/tuners). It is the consumer-facing layer of
+// the librtlsdr → pure-Go rewrite.
+//
+// Registration is gated by the rtlsdr_purego build tag so the driver
+// coexists with the existing CGO librtlsdr backend during the
+// transition. Default builds (no tag) exclude the [init] in
+// register.go, so importing this package is a compile-time no-op
+// for SDR registration. With -tags rtlsdr_purego the driver
+// registers under the name "rtlsdr-go" and the existing CGO driver
+// stays under "rtlsdr"; PR-08 will flip the default and PR-09 will
+// delete the CGO file entirely.
+//
+// All exported types are always defined regardless of build tag so
+// tests and explicit-construction callers (no auto-registration via
+// init) work identically across configurations.
+package purego
+
+// knownDevice is one row of the VID/PID table librtlsdr maintains in
+// src/librtlsdr.c known_devices. We claim a USB device only if it
+// matches a row in this table — this keeps random USB devices the
+// kernel would let us open from being mistaken for SDR dongles.
+type knownDevice struct {
+	VID, PID uint16
+	Name     string // friendly product name for sdr.Info.Product
+}
+
+// knownDevices mirrors librtlsdr's known_devices verbatim; ordering
+// is preserved for cross-referencing against the C source. The entries
+// cover OEM rebrands of the Realtek RTL2832U reference board (Terratec,
+// Compro, NooElec, etc.) — modern dongles from RTL-SDR.com / NooElec
+// use 0x0bda:0x2832 or 0x0bda:0x2838.
+var knownDevices = []knownDevice{
+	{VID: 0x0bda, PID: 0x2832, Name: "Generic RTL2832U"},
+	{VID: 0x0bda, PID: 0x2838, Name: "Generic RTL2832U OEM"},
+	{VID: 0x0413, PID: 0x6680, Name: "DigitalNow Quad DVB-T PCI-E"},
+	{VID: 0x0413, PID: 0x6f0f, Name: "Leadtek WinFast DTV Dongle Mini D"},
+	{VID: 0x0458, PID: 0x707f, Name: "Genius TVGo DVB-T03 USB"},
+	{VID: 0x0ccd, PID: 0x00a9, Name: "Terratec Cinergy T Stick Black"},
+	{VID: 0x0ccd, PID: 0x00b3, Name: "Terratec NOXON DAB/DAB+ USB v1"},
+	{VID: 0x0ccd, PID: 0x00b4, Name: "Terratec Deutschlandradio DAB Stick"},
+	{VID: 0x0ccd, PID: 0x00b5, Name: "Terratec NOXON DAB Stick - Radio Energy"},
+	{VID: 0x0ccd, PID: 0x00b7, Name: "Terratec Media Broadcast DAB Stick"},
+	{VID: 0x0ccd, PID: 0x00b8, Name: "Terratec BR DAB Stick"},
+	{VID: 0x0ccd, PID: 0x00b9, Name: "Terratec WDR DAB Stick"},
+	{VID: 0x0ccd, PID: 0x00c0, Name: "Terratec MuellerVerlag DAB Stick"},
+	{VID: 0x0ccd, PID: 0x00c6, Name: "Terratec Fraunhofer DAB Stick"},
+	{VID: 0x0ccd, PID: 0x00d3, Name: "Terratec Cinergy T Stick RC (Rev. 3)"},
+	{VID: 0x0ccd, PID: 0x00d7, Name: "Terratec T Stick PLUS"},
+	{VID: 0x0ccd, PID: 0x00e0, Name: "Terratec NOXON DAB/DAB+ USB v2"},
+	{VID: 0x1554, PID: 0x5020, Name: "PixelView PV-DT235U(RN)"},
+	{VID: 0x15f4, PID: 0x0131, Name: "Astrometa DVB-T/DVB-T2"},
+	{VID: 0x15f4, PID: 0x0133, Name: "HanfTek DAB+FM+DVB-T"},
+	{VID: 0x185b, PID: 0x0620, Name: "Compro Videomate U620F"},
+	{VID: 0x185b, PID: 0x0650, Name: "Compro Videomate U650F"},
+	{VID: 0x185b, PID: 0x0680, Name: "Compro Videomate U680F"},
+	{VID: 0x1b80, PID: 0xd393, Name: "GIGABYTE GT-U7300"},
+	{VID: 0x1b80, PID: 0xd394, Name: "DIKOM USB-DVBT HD"},
+	{VID: 0x1b80, PID: 0xd395, Name: "Peak 102569AGPK"},
+	{VID: 0x1b80, PID: 0xd397, Name: "KWorld KW-UB450-T USB DVB-T Pico TV"},
+	{VID: 0x1b80, PID: 0xd398, Name: "Zaapa ZT-MINDVBZP"},
+	{VID: 0x1b80, PID: 0xd39d, Name: "SVEON STV20 DVB-T USB & FM"},
+	{VID: 0x1b80, PID: 0xd3a4, Name: "Twintech UT-40"},
+	{VID: 0x1b80, PID: 0xd3a8, Name: "ASUS U3100MINI_PLUS_V2"},
+	{VID: 0x1b80, PID: 0xd3af, Name: "SVEON STV27 DVB-T USB & FM"},
+	{VID: 0x1b80, PID: 0xd3b0, Name: "SVEON STV21 DVB-T USB & FM"},
+	{VID: 0x1d19, PID: 0x1101, Name: "Dexatek DK DVB-T Dongle (Logilink VG0002A)"},
+	{VID: 0x1d19, PID: 0x1102, Name: "Dexatek DK DVB-T Dongle (MSI DigiVox mini II V3.0)"},
+	{VID: 0x1d19, PID: 0x1103, Name: "Dexatek Technology Ltd. DK 5217 DVB-T Dongle"},
+	{VID: 0x1d19, PID: 0x1104, Name: "MSI DigiVox Micro HD"},
+	{VID: 0x1f4d, PID: 0xa803, Name: "Sweex DVB-T USB"},
+	{VID: 0x1f4d, PID: 0xb803, Name: "GTek T803"},
+	{VID: 0x1f4d, PID: 0xc803, Name: "Lifeview LV5TDeluxe"},
+	{VID: 0x1f4d, PID: 0xd286, Name: "MyGica TD312"},
+	{VID: 0x1f4d, PID: 0xd803, Name: "PROlectrix DV107669"},
+}
+
+// lookupKnown returns the friendly device name for a (vid, pid)
+// pair, or nil when the device isn't on the supported list. nil is
+// the signal to [Driver.Enumerate] to skip the descriptor.
+func lookupKnown(vid, pid uint16) *knownDevice {
+	for i := range knownDevices {
+		if knownDevices[i].VID == vid && knownDevices[i].PID == pid {
+			return &knownDevices[i]
+		}
+	}
+	return nil
+}

--- a/internal/sdr/rtlsdr/purego/driver.go
+++ b/internal/sdr/rtlsdr/purego/driver.go
@@ -1,0 +1,172 @@
+package purego
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/MattCheramie/GopherTrunk/internal/sdr"
+	"github.com/MattCheramie/GopherTrunk/internal/sdr/rtlsdr/rtl2832u"
+	"github.com/MattCheramie/GopherTrunk/internal/sdr/rtlsdr/tuners"
+	"github.com/MattCheramie/GopherTrunk/internal/sdr/rtlsdr/usb"
+)
+
+// DriverName is the [sdr.Driver.Name] this backend registers under.
+// Distinct from "rtlsdr" so the pure-Go and CGO drivers can coexist
+// during the transition (PR-08 will swap names).
+const DriverName = "rtlsdr-go"
+
+// Driver implements [sdr.Driver]. The optional Enumerator field lets
+// tests inject a [usb.MockEnumerator]; production code leaves it nil
+// and falls through to [usb.DefaultEnumerator].
+type Driver struct {
+	Enumerator usb.Enumerator
+
+	// detectCache stores the descriptors returned by the most recent
+	// Enumerate so Open(idx) can map index → descriptor without
+	// re-scanning sysfs.
+	mu          sync.Mutex
+	detectCache []usb.Descriptor
+}
+
+// New returns a Driver bound to the given enumerator. Pass nil to use
+// the default (platform) enumerator.
+func New(e usb.Enumerator) *Driver {
+	return &Driver{Enumerator: e}
+}
+
+// Name returns "rtlsdr-go".
+func (d *Driver) Name() string { return DriverName }
+
+func (d *Driver) enumerator() usb.Enumerator {
+	if d.Enumerator != nil {
+		return d.Enumerator
+	}
+	return usb.DefaultEnumerator()
+}
+
+// Enumerate scans the platform for known RTL-SDR dongles and returns
+// one [sdr.Info] per matching descriptor. Per the [sdr.Driver]
+// contract, the returned slice is stable across calls — Open uses
+// the index into it to find the descriptor to claim.
+//
+// Devices not in [knownDevices] are silently filtered out so we don't
+// claim arbitrary USB devices (e.g. mice, keyboards) sharing a vendor
+// ID with a supported chipset. New devices show up by adding rows to
+// devices.go.
+func (d *Driver) Enumerate() ([]sdr.Info, error) {
+	all, err := d.enumerator().List(0, 0)
+	if err != nil {
+		return nil, fmt.Errorf("rtlsdr-go: enumerate: %w", err)
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.detectCache = d.detectCache[:0]
+	out := make([]sdr.Info, 0, len(all))
+	for _, desc := range all {
+		kd := lookupKnown(desc.VID, desc.PID)
+		if kd == nil {
+			continue
+		}
+		// Prefer the device-reported product string over our own
+		// friendly name when available; falls back to our table for
+		// dongles that don't populate iProduct.
+		product := desc.Product
+		if product == "" {
+			product = kd.Name
+		}
+		out = append(out, sdr.Info{
+			Driver:       DriverName,
+			Index:        len(d.detectCache),
+			Serial:       desc.Serial,
+			Manufacturer: desc.Manufacturer,
+			Product:      product,
+		})
+		d.detectCache = append(d.detectCache, desc)
+	}
+	return out, nil
+}
+
+// Open claims the device at the given index (an offset into the
+// most-recent [Driver.Enumerate] result), brings up the demod and
+// tuner, and returns an [sdr.Device] handle.
+//
+// Steps:
+//  1. Open the USB transport via the enumerator.
+//  2. Claim USB interface 0 (RTL-SDR's only interface).
+//  3. Wrap the transport in [rtl2832u.Demod] and run the baseband
+//     init flood.
+//  4. Probe for an R820T-family tuner; set up the [tuners.Tuner]
+//     and run its init.
+//  5. Program the tuner's IF frequency on the demod.
+//  6. Populate [sdr.Info] with the tuner's name and gain ladder.
+//
+// Failure at any step closes the transport and returns the error.
+func (d *Driver) Open(idx int) (sdr.Device, error) {
+	d.mu.Lock()
+	if idx < 0 || idx >= len(d.detectCache) {
+		d.mu.Unlock()
+		return nil, fmt.Errorf("rtlsdr-go: index %d out of range (cache size %d; call Enumerate first)", idx, len(d.detectCache))
+	}
+	desc := d.detectCache[idx]
+	d.mu.Unlock()
+
+	transport, err := d.enumerator().Open(desc)
+	if err != nil {
+		return nil, fmt.Errorf("rtlsdr-go: open USB %s: %w", desc.Path, err)
+	}
+
+	dev, err := openDevice(transport, desc, idx)
+	if err != nil {
+		_ = transport.Close()
+		return nil, err
+	}
+	return dev, nil
+}
+
+// openDevice runs the full bring-up sequence: claim interface, init
+// demod, detect + init tuner, set IF freq. Factored out of Open so
+// tests can drive it directly with a mock transport without going
+// through the enumerator.
+func openDevice(transport usb.Transport, desc usb.Descriptor, idx int) (*Device, error) {
+	if err := transport.ClaimInterface(0); err != nil {
+		return nil, fmt.Errorf("rtlsdr-go: claim interface 0: %w", err)
+	}
+
+	demod := rtl2832u.New(transport)
+	if err := demod.InitBaseband(); err != nil {
+		return nil, fmt.Errorf("rtlsdr-go: init baseband: %w", err)
+	}
+
+	i2cAddr, chipType, err := tuners.Detect(demod)
+	if err != nil {
+		return nil, fmt.Errorf("rtlsdr-go: tuner detect: %w", err)
+	}
+	tuner := tuners.NewR82xx(demod, i2cAddr, chipType)
+	if err := tuner.Init(); err != nil {
+		return nil, fmt.Errorf("rtlsdr-go: tuner init: %w", err)
+	}
+	if err := demod.SetIFFreq(tuner.IFFreqHz()); err != nil {
+		return nil, fmt.Errorf("rtlsdr-go: set IF freq: %w", err)
+	}
+
+	kd := lookupKnown(desc.VID, desc.PID)
+	product := desc.Product
+	if product == "" && kd != nil {
+		product = kd.Name
+	}
+	info := sdr.Info{
+		Driver:       DriverName,
+		Index:        idx,
+		Serial:       desc.Serial,
+		Manufacturer: desc.Manufacturer,
+		Product:      product,
+		TunerName:    chipType.String(),
+		Gains:        tuner.Gains(),
+	}
+	return &Device{
+		transport: transport,
+		demod:     demod,
+		tuner:     tuner,
+		info:      info,
+	}, nil
+}

--- a/internal/sdr/rtlsdr/purego/driver_test.go
+++ b/internal/sdr/rtlsdr/purego/driver_test.go
@@ -1,0 +1,133 @@
+package purego
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/sdr/rtlsdr/usb"
+)
+
+func TestDriverNameIsRtlsdrGo(t *testing.T) {
+	d := New(nil)
+	if got, want := d.Name(), "rtlsdr-go"; got != want {
+		t.Errorf("Name() = %q, want %q", got, want)
+	}
+	if DriverName != "rtlsdr-go" {
+		t.Errorf("DriverName const = %q, want rtlsdr-go", DriverName)
+	}
+}
+
+func TestLookupKnown_HitsRealtekDefaults(t *testing.T) {
+	// 0x0bda:0x2832 and 0x0bda:0x2838 are the dominant generic
+	// RTL2832U IDs — must always match.
+	for _, c := range []struct {
+		vid, pid uint16
+		wantSub  string
+	}{
+		{0x0bda, 0x2832, "Generic RTL2832U"},
+		{0x0bda, 0x2838, "Generic RTL2832U OEM"},
+	} {
+		k := lookupKnown(c.vid, c.pid)
+		if k == nil {
+			t.Errorf("lookupKnown(0x%04x, 0x%04x) = nil, want match", c.vid, c.pid)
+			continue
+		}
+		if !strings.Contains(k.Name, c.wantSub) {
+			t.Errorf("lookupKnown(0x%04x, 0x%04x).Name = %q, want substring %q", c.vid, c.pid, k.Name, c.wantSub)
+		}
+	}
+}
+
+func TestLookupKnown_MissReturnsNil(t *testing.T) {
+	if k := lookupKnown(0x1d50, 0x6089); k != nil { // HackRF VID/PID
+		t.Errorf("lookupKnown(HackRF) = %+v, want nil (not an RTL-SDR)", k)
+	}
+}
+
+func TestEnumerate_FiltersToKnownDevices(t *testing.T) {
+	mock := &usb.MockEnumerator{
+		Devices: []usb.Descriptor{
+			// Two RTL-SDRs (one populated product string, one bare).
+			{Bus: 1, Address: 4, VID: 0x0bda, PID: 0x2838, Serial: "00000001", Manufacturer: "Realtek", Product: "RTL2838UHIDIR"},
+			{Bus: 1, Address: 5, VID: 0x0bda, PID: 0x2832, Serial: "00000002", Manufacturer: "Realtek"},
+			// Not an RTL-SDR — must be skipped.
+			{Bus: 1, Address: 6, VID: 0x1d50, PID: 0x6089, Serial: "hackrf"},
+		},
+	}
+	d := New(mock)
+	got, err := d.Enumerate()
+	if err != nil {
+		t.Fatalf("Enumerate: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("Enumerate returned %d entries, want 2 (HackRF must be filtered)", len(got))
+	}
+	if got[0].Driver != "rtlsdr-go" {
+		t.Errorf("Info.Driver = %q, want rtlsdr-go", got[0].Driver)
+	}
+	if got[0].Index != 0 || got[1].Index != 1 {
+		t.Errorf("indices = (%d, %d), want (0, 1)", got[0].Index, got[1].Index)
+	}
+	// First device populated iProduct → use it verbatim.
+	if got[0].Product != "RTL2838UHIDIR" {
+		t.Errorf("Info.Product[0] = %q, want RTL2838UHIDIR (device-reported)", got[0].Product)
+	}
+	// Second device has empty iProduct → fall back to the friendly name.
+	if !strings.Contains(got[1].Product, "RTL2832U") {
+		t.Errorf("Info.Product[1] = %q, want fallback friendly name", got[1].Product)
+	}
+}
+
+func TestEnumerate_PopulatesDetectCacheForOpen(t *testing.T) {
+	mock := &usb.MockEnumerator{
+		Devices: []usb.Descriptor{
+			{VID: 0x0bda, PID: 0x2838, Serial: "00000001"},
+		},
+	}
+	d := New(mock)
+	if _, err := d.Enumerate(); err != nil {
+		t.Fatalf("Enumerate: %v", err)
+	}
+	if got := len(d.detectCache); got != 1 {
+		t.Errorf("detectCache size = %d, want 1", got)
+	}
+	if d.detectCache[0].Serial != "00000001" {
+		t.Errorf("cached serial = %q, want 00000001", d.detectCache[0].Serial)
+	}
+}
+
+func TestOpen_BadIndexReturnsError(t *testing.T) {
+	d := New(&usb.MockEnumerator{})
+	if _, err := d.Open(0); err == nil {
+		t.Error("Open(0) on empty cache returned nil, want error")
+	}
+	if _, err := d.Open(-1); err == nil {
+		t.Error("Open(-1) returned nil, want error")
+	}
+}
+
+func TestEnumerator_DefaultFallback(t *testing.T) {
+	// New(nil) should return a Driver that uses DefaultEnumerator.
+	d := New(nil)
+	enum := d.enumerator()
+	if enum == nil {
+		t.Fatal("default enumerator is nil")
+	}
+	// The platform's default enumerator name is OS-dependent
+	// ("usbdevfs" on Linux, "winusb" on Windows, "macos-stub" on
+	// macOS); we just assert it's non-empty.
+	if enum.Name() == "" {
+		t.Error("default enumerator Name() is empty")
+	}
+}
+
+func TestKnownDevicesNoDuplicates(t *testing.T) {
+	seen := map[uint32]string{}
+	for _, k := range knownDevices {
+		key := uint32(k.VID)<<16 | uint32(k.PID)
+		if existing, ok := seen[key]; ok {
+			t.Errorf("duplicate VID/PID 0x%04x:0x%04x: %q vs %q", k.VID, k.PID, existing, k.Name)
+		}
+		seen[key] = k.Name
+	}
+}

--- a/internal/sdr/rtlsdr/purego/register.go
+++ b/internal/sdr/rtlsdr/purego/register.go
@@ -1,0 +1,17 @@
+//go:build rtlsdr_purego
+
+package purego
+
+import "github.com/MattCheramie/GopherTrunk/internal/sdr"
+
+// init registers the pure-Go RTL-SDR driver with the global SDR
+// registry. Gated by the rtlsdr_purego build tag so the CGO and
+// pure-Go drivers can coexist during the rewrite (PR-08 will swap
+// names; PR-09 will remove the CGO wrapper entirely).
+//
+// Default builds (no -tags rtlsdr_purego) skip this file, leaving
+// the package importable but inert — the blank import in
+// cmd/gophertrunk/main.go is then a compile-time no-op for SDR
+// registration. Existing CGO builds keep registering as "rtlsdr"
+// from internal/sdr/rtlsdr/rtlsdr_cgo.go.
+func init() { sdr.Register(&Driver{}) }

--- a/internal/sdr/rtlsdr/purego/stream.go
+++ b/internal/sdr/rtlsdr/purego/stream.go
@@ -1,0 +1,114 @@
+package purego
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+)
+
+// Async-bulk geometry copied verbatim from the CGO driver
+// (internal/sdr/rtlsdr/rtlsdr_cgo.go:42-45). 32 buffers × 16 KiB ≈
+// 6 ms of headroom at 2.4 MS/s. Changing these requires a
+// matching update on the C side until PR-09 deletes that file.
+const (
+	asyncBufCount = 32
+	asyncBufLen   = 16 * 1024
+
+	// streamChanDepth matches rtlsdr_cgo.go:190 — `make(chan
+	// []complex64, 8)`. Drop-on-overrun semantics in [Device.deliver]
+	// rely on this being non-zero.
+	streamChanDepth = 8
+
+	// bulkInEndpoint is the RTL-SDR bulk-IN endpoint address. Hardware
+	// invariant — every RTL2832U exposes the IQ stream here.
+	bulkInEndpoint = 0x81
+)
+
+// StreamIQ resets the USB FIFO, kicks off a bulk-IN ring on the
+// transport, and returns a buffered channel of complex64 samples.
+// The channel closes when ctx cancels or [Device.Close] is called.
+//
+// Behaviour invariants — kept identical to rtlsdr_cgo.go:181-217 so
+// the new driver is a drop-in replacement:
+//
+//   - Returns an error if a stream is already active on this Device.
+//   - 8-deep buffered channel; senders use non-blocking select with
+//     a default branch so slow consumers result in dropped buffers
+//     rather than back-pressure on the kernel.
+//   - The reaper goroutine inside [usb.Transport.StartBulkIn]
+//     dispatches one onPacket call per completed URB.
+//   - On ctx cancellation, [Device.cancelStream] runs StopBulkIn and
+//     closes the channel.
+func (d *Device) StreamIQ(ctx context.Context) (<-chan []complex64, error) {
+	d.streamMu.Lock()
+	defer d.streamMu.Unlock()
+	if d.closed.Load() {
+		return nil, ErrClosed
+	}
+	if d.out != nil {
+		return nil, errors.New("rtlsdr-go: stream already active")
+	}
+	if err := d.demod.ResetBuffer(); err != nil {
+		return nil, fmt.Errorf("rtlsdr-go: reset buffer: %w", err)
+	}
+	out := make(chan []complex64, streamChanDepth)
+	d.out = out
+	d.stopOnce = sync.Once{}
+
+	if err := d.transport.StartBulkIn(bulkInEndpoint, asyncBufCount, asyncBufLen, d.deliver); err != nil {
+		d.out = nil
+		return nil, fmt.Errorf("rtlsdr-go: StartBulkIn: %w", err)
+	}
+
+	// Cancel goroutine: when ctx fires, tear the stream down. Mirrors
+	// rtlsdr_cgo.go:211-214.
+	go func() {
+		<-ctx.Done()
+		d.cancelStream()
+	}()
+
+	return out, nil
+}
+
+// deliver receives one bulk-IN buffer from the transport reaper,
+// converts the u8 IQ pairs into complex64, and pushes the result
+// onto the consumer channel. Drop-on-overrun if the consumer is
+// behind. Bit-identical conversion math to rtlsdr_cgo.go:225-240
+// so downstream DSP sees the same bit pattern from either backend.
+func (d *Device) deliver(buf []byte) {
+	samples := convertU8IQ(buf)
+	d.streamMu.Lock()
+	out := d.out
+	d.streamMu.Unlock()
+	if out == nil {
+		return
+	}
+	select {
+	case out <- samples:
+	default:
+		// Consumer can't keep up. Drop. The application's
+		// `iq-underrun` Prometheus counter is the operator-facing
+		// telemetry for this — see internal/metrics.
+	}
+}
+
+// convertU8IQ translates a slice of unsigned-8-bit IQ pairs into
+// normalized complex64 samples. The conversion is the bit-identical
+// port of rtlsdr_cgo.go:225-240:
+//
+//   - DC bias of 127.5 (mid-range of u8) is subtracted.
+//   - Result is divided by 127.5 to scale to [-1, +1).
+//
+// Pinned by [TestConvertU8IQ_BitIdenticalWithCGO] so any drift from
+// the CGO driver shows up immediately.
+func convertU8IQ(buf []byte) []complex64 {
+	n := len(buf) / 2
+	out := make([]complex64, n)
+	for i := 0; i < n; i++ {
+		i8 := float32(buf[2*i]) - 127.5
+		q8 := float32(buf[2*i+1]) - 127.5
+		out[i] = complex(i8/127.5, q8/127.5)
+	}
+	return out
+}

--- a/internal/sdr/rtlsdr/purego/stream_test.go
+++ b/internal/sdr/rtlsdr/purego/stream_test.go
@@ -1,0 +1,304 @@
+package purego
+
+import (
+	"context"
+	"errors"
+	"math"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/sdr"
+	"github.com/MattCheramie/GopherTrunk/internal/sdr/rtlsdr/rtl2832u"
+	"github.com/MattCheramie/GopherTrunk/internal/sdr/rtlsdr/tuners"
+	"github.com/MattCheramie/GopherTrunk/internal/sdr/rtlsdr/usb"
+)
+
+func TestConvertU8IQ_BitIdenticalWithCGO(t *testing.T) {
+	// The conversion math is the bit-identical port of
+	// rtlsdr_cgo.go:225-240. Reproduce it inline as the oracle so
+	// any drift in the production code (e.g. someone "optimizing"
+	// /127.5 to *0.0078431) shows up as a failed assertion.
+	cases := []struct {
+		buf []byte
+	}{
+		{buf: []byte{}},
+		{buf: []byte{127, 128}},                       // ~zero IQ
+		{buf: []byte{0, 0}},                            // negative max
+		{buf: []byte{255, 255}},                        // positive max
+		{buf: []byte{127, 128, 0, 0, 255, 255, 64, 192}},
+	}
+	for _, c := range cases {
+		got := convertU8IQ(c.buf)
+		want := referenceConvertU8IQ(c.buf)
+		if len(got) != len(want) {
+			t.Errorf("len mismatch on %v: got %d, want %d", c.buf, len(got), len(want))
+			continue
+		}
+		for i := range got {
+			if got[i] != want[i] {
+				t.Errorf("convertU8IQ(%v)[%d] = %v, want %v", c.buf, i, got[i], want[i])
+			}
+		}
+	}
+}
+
+// referenceConvertU8IQ is the C-side math written out longhand.
+// MUST stay byte-identical with rtlsdr_cgo.go:225-240.
+func referenceConvertU8IQ(buf []byte) []complex64 {
+	n := len(buf) / 2
+	out := make([]complex64, n)
+	for i := 0; i < n; i++ {
+		i8 := float32(buf[2*i]) - 127.5
+		q8 := float32(buf[2*i+1]) - 127.5
+		out[i] = complex(i8/127.5, q8/127.5)
+	}
+	return out
+}
+
+func TestConvertU8IQ_ZeroBufferYieldsNoSamples(t *testing.T) {
+	if got := convertU8IQ(nil); len(got) != 0 {
+		t.Errorf("convertU8IQ(nil) returned %d samples, want 0", len(got))
+	}
+	if got := convertU8IQ([]byte{1}); len(got) != 0 {
+		t.Errorf("convertU8IQ(odd length) returned %d samples, want 0 (truncated by /2)", len(got))
+	}
+}
+
+func TestConvertU8IQ_DCBiasMidScaleIsNearZero(t *testing.T) {
+	// 127, 128 brackets the chip's DC bias of 127.5; the resulting
+	// complex value should have |real|, |imag| ≤ 1/127.5 ≈ 0.00785.
+	const tol = 0.01
+	got := convertU8IQ([]byte{127, 128})
+	if len(got) != 1 {
+		t.Fatalf("len = %d, want 1", len(got))
+	}
+	if math.Abs(float64(real(got[0]))) > tol || math.Abs(float64(imag(got[0]))) > tol {
+		t.Errorf("expected near-zero, got %v", got[0])
+	}
+}
+
+func TestConvertU8IQ_ExtremesScaleToUnit(t *testing.T) {
+	// 0 and 255 map to (0-127.5)/127.5 = -1 and (255-127.5)/127.5 ≈ 1.0.
+	const tol = 0.005
+	gotMin := convertU8IQ([]byte{0, 0})
+	if math.Abs(float64(real(gotMin[0]))-(-1.0)) > tol {
+		t.Errorf("min real = %v, want ~-1", real(gotMin[0]))
+	}
+	gotMax := convertU8IQ([]byte{255, 255})
+	if math.Abs(float64(real(gotMax[0]))-1.0) > tol {
+		t.Errorf("max real = %v, want ~1", real(gotMax[0]))
+	}
+}
+
+// fakeTuner is an in-memory [tuners.Tuner] that records dispatch
+// calls. Used by Device-level tests that care about the interaction
+// between Device methods and the tuner without needing the full
+// R820T register-script setup.
+type fakeTuner struct {
+	mu                sync.Mutex
+	freqCalls         []uint32
+	bwCalls           []uint32
+	gainCalls         []int
+	gainModeCalls     []bool
+	standbyCalls      int
+	freqErr, bwErr    error
+	gainErr, modeErr  error
+}
+
+func (f *fakeTuner) Type() tuners.Type     { return tuners.TypeR820T2 }
+func (f *fakeTuner) IFFreqHz() uint32      { return 3_570_000 }
+func (f *fakeTuner) Init() error           { return nil }
+func (f *fakeTuner) Standby() error        { f.standbyCalls++; return nil }
+func (f *fakeTuner) Close() error          { return f.Standby() }
+func (f *fakeTuner) Gains() []int          { return []int{0, 100, 200} }
+func (f *fakeTuner) SetFreq(hz uint32) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.freqCalls = append(f.freqCalls, hz)
+	return f.freqErr
+}
+func (f *fakeTuner) SetBandwidth(hz uint32) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.bwCalls = append(f.bwCalls, hz)
+	return f.bwErr
+}
+func (f *fakeTuner) SetGain(t int) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.gainCalls = append(f.gainCalls, t)
+	return f.gainErr
+}
+func (f *fakeTuner) SetGainMode(m bool) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.gainModeCalls = append(f.gainModeCalls, m)
+	return f.modeErr
+}
+
+func newDeviceWithFakeTuner(transport usb.Transport, fake *fakeTuner) *Device {
+	demod := rtl2832u.New(transport)
+	return &Device{
+		transport: transport,
+		demod:     demod,
+		tuner:     fake,
+		info:      sdr.Info{Driver: DriverName, Index: 0},
+	}
+}
+
+func TestDevice_SetCenterFreqDispatchesToTuner(t *testing.T) {
+	mock := usb.NewMockTransport()
+	fake := &fakeTuner{}
+	d := newDeviceWithFakeTuner(mock, fake)
+	if err := d.SetCenterFreq(100_000_000); err != nil {
+		t.Fatalf("SetCenterFreq: %v", err)
+	}
+	if len(fake.freqCalls) != 1 || fake.freqCalls[0] != 100_000_000 {
+		t.Errorf("freqCalls = %v, want [100_000_000]", fake.freqCalls)
+	}
+}
+
+func TestDevice_SetCenterFreqAfterCloseFails(t *testing.T) {
+	mock := usb.NewMockTransport()
+	d := newDeviceWithFakeTuner(mock, &fakeTuner{})
+	d.closed.Store(true)
+	if err := d.SetCenterFreq(100_000_000); !errors.Is(err, ErrClosed) {
+		t.Errorf("got %v, want ErrClosed", err)
+	}
+}
+
+func TestDevice_SetGainAutoFlipsModeOff(t *testing.T) {
+	fake := &fakeTuner{}
+	d := newDeviceWithFakeTuner(usb.NewMockTransport(), fake)
+	if err := d.SetGain(-1); err != nil {
+		t.Fatalf("SetGain(-1): %v", err)
+	}
+	if len(fake.gainModeCalls) != 1 || fake.gainModeCalls[0] != false {
+		t.Errorf("gainModeCalls = %v, want [false]", fake.gainModeCalls)
+	}
+	if len(fake.gainCalls) != 0 {
+		t.Errorf("gainCalls = %v, want empty (AGC mode)", fake.gainCalls)
+	}
+}
+
+func TestDevice_SetGainManualSetsModeAndValue(t *testing.T) {
+	fake := &fakeTuner{}
+	d := newDeviceWithFakeTuner(usb.NewMockTransport(), fake)
+	if err := d.SetGain(250); err != nil {
+		t.Fatalf("SetGain(250): %v", err)
+	}
+	if len(fake.gainModeCalls) != 1 || fake.gainModeCalls[0] != true {
+		t.Errorf("gainModeCalls = %v, want [true]", fake.gainModeCalls)
+	}
+	if len(fake.gainCalls) != 1 || fake.gainCalls[0] != 250 {
+		t.Errorf("gainCalls = %v, want [250]", fake.gainCalls)
+	}
+}
+
+func TestStreamIQ_ChannelClosesOnContextCancel(t *testing.T) {
+	mock := usb.NewMockTransport()
+	// Script: ResetBuffer = 2 block writes (0x1002, 0x0000) at
+	// USBEpaCtl. Then bulk packets dispatched by mock.
+	mock.Script = []usb.CtrlExchange{
+		{In: false, BRequest: 0, WValue: rtl2832u.USBEpaCtl, WIndex: uint16(rtl2832u.BlockUSB)<<8 | 0x10, Data: []byte{0x10, 0x02}},
+		{In: false, BRequest: 0, WValue: rtl2832u.USBEpaCtl, WIndex: uint16(rtl2832u.BlockUSB)<<8 | 0x10, Data: []byte{0x00, 0x00}},
+	}
+	mock.BulkPackets = [][]byte{
+		{127, 128, 127, 128}, // 2 IQ samples near zero
+	}
+	d := newDeviceWithFakeTuner(mock, &fakeTuner{})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ch, err := d.StreamIQ(ctx)
+	if err != nil {
+		t.Fatalf("StreamIQ: %v", err)
+	}
+
+	// Drain at least one sample (the mock dispatches the packet
+	// immediately after StartBulkIn).
+	select {
+	case <-ch:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for first packet")
+	}
+
+	cancel()
+	// Channel must close after cancel.
+	deadline := time.NewTimer(time.Second)
+	defer deadline.Stop()
+loop:
+	for {
+		select {
+		case _, ok := <-ch:
+			if !ok {
+				break loop
+			}
+		case <-deadline.C:
+			t.Fatal("channel did not close after ctx cancel")
+		}
+	}
+}
+
+func TestStreamIQ_DoubleStartFails(t *testing.T) {
+	mock := usb.NewMockTransport()
+	mock.Script = []usb.CtrlExchange{
+		{In: false, BRequest: 0, WValue: rtl2832u.USBEpaCtl, WIndex: uint16(rtl2832u.BlockUSB)<<8 | 0x10, Data: []byte{0x10, 0x02}},
+		{In: false, BRequest: 0, WValue: rtl2832u.USBEpaCtl, WIndex: uint16(rtl2832u.BlockUSB)<<8 | 0x10, Data: []byte{0x00, 0x00}},
+	}
+	d := newDeviceWithFakeTuner(mock, &fakeTuner{})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if _, err := d.StreamIQ(ctx); err != nil {
+		t.Fatalf("first StreamIQ: %v", err)
+	}
+	if _, err := d.StreamIQ(ctx); err == nil {
+		t.Error("second StreamIQ returned nil, want error")
+	}
+}
+
+func TestStreamIQ_AfterCloseFails(t *testing.T) {
+	d := newDeviceWithFakeTuner(usb.NewMockTransport(), &fakeTuner{})
+	d.closed.Store(true)
+	if _, err := d.StreamIQ(context.Background()); !errors.Is(err, ErrClosed) {
+		t.Errorf("StreamIQ after close = %v, want ErrClosed", err)
+	}
+}
+
+func TestDevice_CloseIdempotent(t *testing.T) {
+	d := newDeviceWithFakeTuner(usb.NewMockTransport(), &fakeTuner{})
+	// First Close — DeinitBaseband writes 1 block reg, transport.Close
+	// is a no-op on the mock. Tuner standby increments the counter.
+	mock := d.transport.(*usb.MockTransport)
+	mock.Script = []usb.CtrlExchange{
+		{In: false, BRequest: 0, WValue: rtl2832u.SysDemodCtl, WIndex: uint16(rtl2832u.BlockSys)<<8 | 0x10, Data: []byte{0x20}},
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("first Close: %v", err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("second Close: %v", err)
+	}
+	fake := d.tuner.(*fakeTuner)
+	if fake.standbyCalls != 1 {
+		t.Errorf("standby called %d times across two Close() calls, want exactly 1", fake.standbyCalls)
+	}
+}
+
+func TestStreamConstants_MatchCGOGeometry(t *testing.T) {
+	// Pin the buffer geometry so any drift from the CGO driver
+	// (which still ships in rtlsdr_cgo.go until PR-09) shows up
+	// as a test failure.
+	if asyncBufCount != 32 {
+		t.Errorf("asyncBufCount = %d, want 32 (matches rtlsdr_cgo.go:43)", asyncBufCount)
+	}
+	if asyncBufLen != 16*1024 {
+		t.Errorf("asyncBufLen = %d, want 16384 (matches rtlsdr_cgo.go:44)", asyncBufLen)
+	}
+	if streamChanDepth != 8 {
+		t.Errorf("streamChanDepth = %d, want 8 (matches rtlsdr_cgo.go:190)", streamChanDepth)
+	}
+	if bulkInEndpoint != 0x81 {
+		t.Errorf("bulkInEndpoint = 0x%02x, want 0x81", bulkInEndpoint)
+	}
+}


### PR DESCRIPTION
## Summary

- PR-06 of the librtlsdr → pure-Go rewrite. Composes the three layers from PRs 01-05 (USB transport, RTL2832U register layer, R820T2 tuner) into a complete `sdr.Driver` / `sdr.Device` implementation in `internal/sdr/rtlsdr/purego/`. Driver registration is gated by the `rtlsdr_purego` build tag so it coexists with the existing CGO librtlsdr backend during the transition; PR-08 will swap which side is default, PR-09 will delete the CGO file.
- New driver name: `rtlsdr-go`. `Driver.Enumerate` filters discovered USB devices against a 41-entry known-VID/PID table mirroring librtlsdr's `known_devices` verbatim. `Driver.Open` claims interface 0, runs `Demod.InitBaseband`, probes for an R820T family tuner, runs `Tuner.Init`, and programs the 3.57 MHz IF on the demod. Per-method dispatch on `Device` is bit-identical with `rtlsdr_cgo.go`: `SetCenterFreq` → `Tuner.SetFreq` + settle, `SetSampleRate` → `Demod.SetSampleRate(actual)` → `Tuner.SetBandwidth(actual)`, `SetGain` follows the librtlsdr semantics (negative tenthDB → AGC, ≥0 → manual mode + value), `SetPPM` → `Demod.SetSampleFreqCorrection`, `SetBiasTee` → `Demod.SetBiasTee` on hard-coded GPIO 0 (RTL-SDR.com v3 / NESDR Smart v5 convention).
- `StreamIQ` and `convertU8IQ` are byte-identical with `rtlsdr_cgo.go:181-240` so downstream DSP sees the same bit pattern from either backend. Buffer geometry constants (32 × 16 KiB ring, 8-deep buffered channel, drop-on-overrun, bulk-IN endpoint 0x81) are pinned by `TestStreamConstants_MatchCGOGeometry`. The IQ conversion is pinned by `TestConvertU8IQ_BitIdenticalWithCGO` against an inline reference port of the C math.
- `cmd/gophertrunk/main.go`: blank import of the new package. Compiles in both default and tagged builds; only registers under `-tags rtlsdr_purego`.

## Test plan

- [x] `CGO_ENABLED=0 go test ./internal/sdr/rtlsdr/purego/...` green (default and `-tags rtlsdr_purego`)
- [x] `CGO_ENABLED=0 go test ./...` green tree-wide
- [x] `CGO_ENABLED=0 go build ./cmd/gophertrunk/...` clean (default and tagged)
- [x] `GOOS=windows GOARCH=amd64 / GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 go vet -tags rtlsdr_purego ./internal/sdr/...` clean for both
- [x] Test binaries compile on `windows/amd64` and `darwin/arm64` (default and tagged)
- [ ] CI `usb-windows` and `usb-macos` jobs go green
- [ ] (manual, follow-up — needs hardware) `gophertrunk -tags rtlsdr_purego sdr list` shows the dongle as a `rtlsdr-go` entry; `gophertrunk decode` against an FM broadcaster produces audio bit-identical with the CGO baseline; `iq-underrun` / `usb-reconnect` Prometheus counters stay flat for a 10-min run on a P25 trunked-system control channel

https://claude.ai/code/session_01CQrwLLjvuoCgQYLkso4SuX

---
_Generated by [Claude Code](https://claude.ai/code/session_01CQrwLLjvuoCgQYLkso4SuX)_