### PR TITLE
internal/sdr/rtlsdr: flip default — pure-Go is &quot;rtlsdr&quot;, CGO behind -tags rtlsdr_cgo

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ frontend over gRPC, HTTP/SSE, or WebSocket.
 
 | Area              | Component                                                  |
 | ----------------- | ---------------------------------------------------------- |
-| Hardware          | CGO `librtlsdr` binding, multi-device pool, role assignment, per-device gain (`auto` / tenths-of-dB) + PPM + bias-tee (5 V LNA power, e.g. NESDR Smart v5) applied at open time, DC blocker, IQ-imbalance correction, file-backed IQ replay (mock) |
+| Hardware          | Pure-Go RTL-SDR driver (USBDEVFS / WinUSB transport + RTL2832U register layer + R820T/R820T2/R828D/E4000/FC0012/FC0013/FC2580 tuner drivers; legacy CGO `librtlsdr` path still available via `-tags rtlsdr_cgo` for one release of safety-net coexistence), multi-device pool, role assignment, per-device gain (`auto` / tenths-of-dB) + PPM + bias-tee (5 V LNA power, e.g. NESDR Smart v5) applied at open time, DC blocker, IQ-imbalance correction, file-backed IQ replay (mock) |
 | DSP               | Polyphase channelizer, FIR + Kaiser LPF designer + RRC, CIC, halfband, IQ + audio AGC (attack/release envelope follower for voice), L/M polyphase resampler (complex IQ + real audio), FM / C4FM / H-DQPSK demods, single-pole IIR de-emphasis (75/50µs), Mueller-Müller clock recovery, frame-sync correlator |
 | FEC primitives    | CRC-CCITT/FALSE + CRC-CCITT/XMODEM (callable init), CRC-6 (NXDN SACCH), Hamming(15,11,3), Hamming(13,9,3), Hamming(20,8) (DMR slot-type, t=3), extended Golay(24,12,8) + non-extended Golay(23,12,7) (P25 IMBE), BCH(63,16,11), BPTC(196,96), Reed-Solomon(12,9,4) over GF(2^8) with DMR Voice LC Header / Terminator / Embedded LC seeds, 4-state ½-rate Viterbi, 16-state K=5 ½-rate Viterbi (shared by NXDN SACCH + planned YSF FICH) with depuncture-marker support |
 | P25 Phase 1       | 48-bit FSW + sync detector, NID parser (NAC + DUID) with BCH(63,16,11) error correction + even-parity check, full TSBK channel decode (TIA-102.BAAA Annex A 4-state ½-rate trellis + 98-dibit block deinterleaver) → CRC trailer validation, payload parsers for GroupVoiceChannelGrant / Update / NetworkStatus / RFSSStatus, IdentifierUpdate band-plan resolver, control-channel state machine emitting `protocol = "p25"` grants and `decode.error` events with `nid-bch` / `tsbk-trellis` / `tsbk-crc` / `no-bandplan` stages |
@@ -283,7 +283,8 @@ to its own package and lands independently.
   `sdr.Device` interface and IQ-format conversion at
   `internal/sdr/rtlsdr/rtlsdr_cgo.go:225-240` are preserved
   bit-identically so the DSP chain is untouched. Status: PR-01
-  through PR-07 landed. `internal/sdr/rtlsdr/usb/` exposes the
+  through PR-08 landed; the pure-Go driver is now the default
+  `rtlsdr` registrant. `internal/sdr/rtlsdr/usb/` exposes the
   `Transport` + `Enumerator` interfaces, a record/replay
   `MockTransport` for unit tests, and platform backends across
   Linux, Windows, and macOS. Linux uses USBDEVFS ioctls
@@ -355,18 +356,17 @@ to its own package and lands independently.
   `SetPPM` / `SetBiasTee` dispatch to the right layer with
   bit-identical math to `rtlsdr_cgo.go:225-240`; `StreamIQ`
   preserves the 32 × 16 KiB ring + 8-deep buffered channel +
-  drop-on-overrun semantics. Registration is gated by the
-  `-tags rtlsdr_purego` build flag so the new driver is opt-in
-  during the rewrite — the existing CGO driver keeps the
-  `rtlsdr` registration name in default builds. With the tag,
-  `rtlsdr-go` shows up in `gophertrunk sdr list` alongside any
-  CGO-backed `rtlsdr` entries (PR-08 swaps the names so
-  pure-Go becomes default; PR-09 deletes the CGO file and the
-  associated `librtlsdr` apt / MSYS2 / DLL-bundling steps).
-  PRs 08-10 land the default flip (pure-Go re-registers as
-  `rtlsdr`; CGO moves to `rtlsdr-cgo`), the deletion of
-  `rtlsdr_cgo.go` + every `librtlsdr` apt / MSYS2 / DLL-bundling
-  step in `Dockerfile`, `.github/workflows/*.yml`,
+  drop-on-overrun semantics. As of PR-08 the pure-Go driver
+  registers under the canonical name `rtlsdr` in every build
+  (the `rtlsdr_purego` opt-in flag from PR-06 is gone). The
+  legacy CGO librtlsdr backend is now opt-in via `-tags
+  rtlsdr_cgo` (requires `CGO_ENABLED=1` plus `librtlsdr-dev` on
+  the host) and registers as `rtlsdr-cgo` alongside the pure-Go
+  entry — one release of safety-net coexistence so operators
+  who hit a regression can fall back without rolling the
+  binary. PRs 09-10 land the deletion of `rtlsdr_cgo.go` +
+  every `librtlsdr` apt / MSYS2 / DLL-bundling step in
+  `Dockerfile`, `.github/workflows/*.yml`,
   `installer/gophertrunk.iss`, and the install docs, and the
   macOS IOKit transport itself.
 - **YSF Trellis decode + grant emission.** Sync, frame layout, and
@@ -383,7 +383,7 @@ to its own package and lands independently.
 ## Tech stack
 
 - **Language:** Go 1.24+
-- **Hardware:** `libusb-1.0` + `librtlsdr` via CGO (custom thin binding)
+- **Hardware:** Pure-Go RTL-SDR driver — USBDEVFS / WinUSB transport, RTL2832U register layer, and per-chip tuner drivers (R820T/R820T2/R828D/E4000/FC0012/FC0013/FC2580). The legacy CGO `librtlsdr` + `libusb-1.0` binding is still selectable for one release via `-tags rtlsdr_cgo`.
 - **DSP:** `gonum/dsp/fourier` for FFT, custom polyphase channelizer,
   filters, and demodulators
 - **Storage:** `modernc.org/sqlite` (pure Go)
@@ -467,7 +467,7 @@ internal/sdr/           Driver interface, pool, CGO librtlsdr (→ pure-Go), moc
 internal/sdr/rtlsdr/usb/      Pure-Go USB transport: Linux USBDEVFS, Windows WinUSB, macOS stub, mock
 internal/sdr/rtlsdr/rtl2832u/ RTL2832U register/I2C layer (sample-rate, IF, FIR, GPIO, I2C bridge)
 internal/sdr/rtlsdr/tuners/   R820T/R820T2/R828D + E4000 + FC0012 + FC0013 + FC2580 tuner drivers
-internal/sdr/rtlsdr/purego/   sdr.Driver+sdr.Device wire-up; -tags rtlsdr_purego registers as "rtlsdr-go"
+internal/sdr/rtlsdr/purego/   sdr.Driver+sdr.Device wire-up; default "rtlsdr" registrant (CGO fallback via -tags rtlsdr_cgo as "rtlsdr-cgo")
 internal/dsp/           Channelizer, filters, demods, sync, FFT
 internal/radio/         framing/ + p25/phase1/ + dmr/ + nxdn/
 internal/trunking/      System, talkgroup DB, priority, engine, CC hunter

--- a/cmd/gophertrunk/main.go
+++ b/cmd/gophertrunk/main.go
@@ -11,13 +11,17 @@ import (
 	"github.com/MattCheramie/GopherTrunk/internal/config"
 	gtlog "github.com/MattCheramie/GopherTrunk/internal/log"
 	"github.com/MattCheramie/GopherTrunk/internal/sdr"
-	_ "github.com/MattCheramie/GopherTrunk/internal/sdr/rtlsdr"
-	// Pure-Go RTL-SDR driver (PR-06). Only its init() fires under
-	// -tags rtlsdr_purego; default builds get a no-op import so the
-	// CGO driver in internal/sdr/rtlsdr/rtlsdr_cgo.go stays the
-	// sole "rtlsdr" registrant. PR-08 will swap which side is
-	// default; PR-09 will delete the CGO file.
+	// Pure-Go RTL-SDR driver. Registers under the canonical name
+	// "rtlsdr" in every build (PR-08 made this the default; PR-06
+	// shipped it behind -tags rtlsdr_purego).
 	_ "github.com/MattCheramie/GopherTrunk/internal/sdr/rtlsdr/purego"
+	// Legacy CGO librtlsdr backend. Only compiled with -tags
+	// rtlsdr_cgo (and CGO_ENABLED=1 + librtlsdr-dev on the host);
+	// when present it registers as "rtlsdr-cgo" alongside the
+	// pure-Go entry. PR-09 deletes this path entirely along with
+	// every librtlsdr apt / MSYS2 / DLL-bundling step in the build
+	// system.
+	_ "github.com/MattCheramie/GopherTrunk/internal/sdr/rtlsdr"
 	"github.com/MattCheramie/GopherTrunk/internal/version"
 
 	// Blank import: pulls in the pure-Go IMBE decoder so the daemon

--- a/internal/sdr/rtlsdr/purego/device.go
+++ b/internal/sdr/rtlsdr/purego/device.go
@@ -21,7 +21,7 @@ import (
 const biasTeeGPIO uint8 = 0
 
 // ErrClosed is returned by [Device] methods invoked after [Device.Close].
-var ErrClosed = errors.New("rtlsdr-go: device closed")
+var ErrClosed = errors.New("rtlsdr: device closed")
 
 // Device implements [sdr.Device] for the pure-Go backend. It composes
 // the platform USB transport, the RTL2832U register layer, and the
@@ -54,7 +54,7 @@ func (d *Device) SetCenterFreq(hz uint32) error {
 		return ErrClosed
 	}
 	if err := d.tuner.SetFreq(hz); err != nil {
-		return fmt.Errorf("rtlsdr-go: SetCenterFreq(%d): %w", hz, err)
+		return fmt.Errorf("rtlsdr: SetCenterFreq(%d): %w", hz, err)
 	}
 	if r, ok := d.tuner.(interface{ SettleAfterRetune() }); ok {
 		r.SettleAfterRetune()
@@ -73,10 +73,10 @@ func (d *Device) SetSampleRate(hz uint32) error {
 	}
 	actual, err := d.demod.SetSampleRate(hz)
 	if err != nil {
-		return fmt.Errorf("rtlsdr-go: SetSampleRate(%d): %w", hz, err)
+		return fmt.Errorf("rtlsdr: SetSampleRate(%d): %w", hz, err)
 	}
 	if err := d.tuner.SetBandwidth(actual); err != nil {
-		return fmt.Errorf("rtlsdr-go: tuner bandwidth: %w", err)
+		return fmt.Errorf("rtlsdr: tuner bandwidth: %w", err)
 	}
 	return nil
 }
@@ -91,15 +91,15 @@ func (d *Device) SetGain(tenthDB int) error {
 	}
 	if tenthDB < 0 {
 		if err := d.tuner.SetGainMode(false); err != nil {
-			return fmt.Errorf("rtlsdr-go: SetGain auto: %w", err)
+			return fmt.Errorf("rtlsdr: SetGain auto: %w", err)
 		}
 		return nil
 	}
 	if err := d.tuner.SetGainMode(true); err != nil {
-		return fmt.Errorf("rtlsdr-go: SetGain manual mode: %w", err)
+		return fmt.Errorf("rtlsdr: SetGain manual mode: %w", err)
 	}
 	if err := d.tuner.SetGain(tenthDB); err != nil {
-		return fmt.Errorf("rtlsdr-go: SetGain(%d tenthDB): %w", tenthDB, err)
+		return fmt.Errorf("rtlsdr: SetGain(%d tenthDB): %w", tenthDB, err)
 	}
 	return nil
 }
@@ -111,7 +111,7 @@ func (d *Device) SetPPM(ppm int) error {
 		return ErrClosed
 	}
 	if err := d.demod.SetSampleFreqCorrection(ppm); err != nil {
-		return fmt.Errorf("rtlsdr-go: SetPPM(%d): %w", ppm, err)
+		return fmt.Errorf("rtlsdr: SetPPM(%d): %w", ppm, err)
 	}
 	return nil
 }
@@ -126,7 +126,7 @@ func (d *Device) SetBiasTee(enable bool) error {
 		return ErrClosed
 	}
 	if err := d.demod.SetBiasTee(biasTeeGPIO, enable); err != nil {
-		return fmt.Errorf("rtlsdr-go: SetBiasTee(%v): %w", enable, err)
+		return fmt.Errorf("rtlsdr: SetBiasTee(%v): %w", enable, err)
 	}
 	return nil
 }
@@ -141,16 +141,16 @@ func (d *Device) Close() error {
 	var firstErr error
 	if d.tuner != nil {
 		if err := d.tuner.Standby(); err != nil && firstErr == nil {
-			firstErr = fmt.Errorf("rtlsdr-go: tuner standby: %w", err)
+			firstErr = fmt.Errorf("rtlsdr: tuner standby: %w", err)
 		}
 	}
 	if d.demod != nil {
 		if err := d.demod.DeinitBaseband(); err != nil && firstErr == nil {
-			firstErr = fmt.Errorf("rtlsdr-go: demod deinit: %w", err)
+			firstErr = fmt.Errorf("rtlsdr: demod deinit: %w", err)
 		}
 	}
 	if err := d.transport.Close(); err != nil && firstErr == nil {
-		firstErr = fmt.Errorf("rtlsdr-go: transport close: %w", err)
+		firstErr = fmt.Errorf("rtlsdr: transport close: %w", err)
 	}
 	return firstErr
 }

--- a/internal/sdr/rtlsdr/purego/devices.go
+++ b/internal/sdr/rtlsdr/purego/devices.go
@@ -5,18 +5,12 @@
 // (internal/sdr/rtlsdr/tuners). It is the consumer-facing layer of
 // the librtlsdr → pure-Go rewrite.
 //
-// Registration is gated by the rtlsdr_purego build tag so the driver
-// coexists with the existing CGO librtlsdr backend during the
-// transition. Default builds (no tag) exclude the [init] in
-// register.go, so importing this package is a compile-time no-op
-// for SDR registration. With -tags rtlsdr_purego the driver
-// registers under the name "rtlsdr-go" and the existing CGO driver
-// stays under "rtlsdr"; PR-08 will flip the default and PR-09 will
-// delete the CGO file entirely.
-//
-// All exported types are always defined regardless of build tag so
-// tests and explicit-construction callers (no auto-registration via
-// init) work identically across configurations.
+// As of PR-08 this driver registers under the canonical name
+// "rtlsdr" in every build. The legacy CGO librtlsdr backend
+// (internal/sdr/rtlsdr/rtlsdr_cgo.go) is gated behind the
+// rtlsdr_cgo build tag and, when explicitly enabled, registers as
+// "rtlsdr-cgo" so operators have one release of safety-net
+// coexistence to fall back to before PR-09 deletes the CGO path.
 package purego
 
 // knownDevice is one row of the VID/PID table librtlsdr maintains in

--- a/internal/sdr/rtlsdr/purego/driver.go
+++ b/internal/sdr/rtlsdr/purego/driver.go
@@ -11,9 +11,12 @@ import (
 )
 
 // DriverName is the [sdr.Driver.Name] this backend registers under.
-// Distinct from "rtlsdr" so the pure-Go and CGO drivers can coexist
-// during the transition (PR-08 will swap names).
-const DriverName = "rtlsdr-go"
+// PR-08 flipped this from "rtlsdr-go" to "rtlsdr" so the pure-Go
+// path is the default for downstream consumers (config files,
+// `gophertrunk sdr list` output, Prometheus labels). The CGO driver
+// — when explicitly enabled via -tags rtlsdr_cgo — now registers as
+// "rtlsdr-cgo" instead. PR-09 deletes the CGO file entirely.
+const DriverName = "rtlsdr"
 
 // Driver implements [sdr.Driver]. The optional Enumerator field lets
 // tests inject a [usb.MockEnumerator]; production code leaves it nil
@@ -34,7 +37,8 @@ func New(e usb.Enumerator) *Driver {
 	return &Driver{Enumerator: e}
 }
 
-// Name returns "rtlsdr-go".
+// Name returns "rtlsdr" — the canonical name the SDR registry
+// exposes this driver under as of PR-08.
 func (d *Driver) Name() string { return DriverName }
 
 func (d *Driver) enumerator() usb.Enumerator {
@@ -56,7 +60,7 @@ func (d *Driver) enumerator() usb.Enumerator {
 func (d *Driver) Enumerate() ([]sdr.Info, error) {
 	all, err := d.enumerator().List(0, 0)
 	if err != nil {
-		return nil, fmt.Errorf("rtlsdr-go: enumerate: %w", err)
+		return nil, fmt.Errorf("rtlsdr: enumerate: %w", err)
 	}
 	d.mu.Lock()
 	defer d.mu.Unlock()
@@ -105,14 +109,14 @@ func (d *Driver) Open(idx int) (sdr.Device, error) {
 	d.mu.Lock()
 	if idx < 0 || idx >= len(d.detectCache) {
 		d.mu.Unlock()
-		return nil, fmt.Errorf("rtlsdr-go: index %d out of range (cache size %d; call Enumerate first)", idx, len(d.detectCache))
+		return nil, fmt.Errorf("rtlsdr: index %d out of range (cache size %d; call Enumerate first)", idx, len(d.detectCache))
 	}
 	desc := d.detectCache[idx]
 	d.mu.Unlock()
 
 	transport, err := d.enumerator().Open(desc)
 	if err != nil {
-		return nil, fmt.Errorf("rtlsdr-go: open USB %s: %w", desc.Path, err)
+		return nil, fmt.Errorf("rtlsdr: open USB %s: %w", desc.Path, err)
 	}
 
 	dev, err := openDevice(transport, desc, idx)
@@ -129,23 +133,23 @@ func (d *Driver) Open(idx int) (sdr.Device, error) {
 // through the enumerator.
 func openDevice(transport usb.Transport, desc usb.Descriptor, idx int) (*Device, error) {
 	if err := transport.ClaimInterface(0); err != nil {
-		return nil, fmt.Errorf("rtlsdr-go: claim interface 0: %w", err)
+		return nil, fmt.Errorf("rtlsdr: claim interface 0: %w", err)
 	}
 
 	demod := rtl2832u.New(transport)
 	if err := demod.InitBaseband(); err != nil {
-		return nil, fmt.Errorf("rtlsdr-go: init baseband: %w", err)
+		return nil, fmt.Errorf("rtlsdr: init baseband: %w", err)
 	}
 
 	tuner, err := tuners.Detect(demod)
 	if err != nil {
-		return nil, fmt.Errorf("rtlsdr-go: tuner detect: %w", err)
+		return nil, fmt.Errorf("rtlsdr: tuner detect: %w", err)
 	}
 	if err := tuner.Init(); err != nil {
-		return nil, fmt.Errorf("rtlsdr-go: tuner init: %w", err)
+		return nil, fmt.Errorf("rtlsdr: tuner init: %w", err)
 	}
 	if err := demod.SetIFFreq(tuner.IFFreqHz()); err != nil {
-		return nil, fmt.Errorf("rtlsdr-go: set IF freq: %w", err)
+		return nil, fmt.Errorf("rtlsdr: set IF freq: %w", err)
 	}
 
 	kd := lookupKnown(desc.VID, desc.PID)

--- a/internal/sdr/rtlsdr/purego/driver_test.go
+++ b/internal/sdr/rtlsdr/purego/driver_test.go
@@ -7,13 +7,16 @@ import (
 	"github.com/MattCheramie/GopherTrunk/internal/sdr/rtlsdr/usb"
 )
 
-func TestDriverNameIsRtlsdrGo(t *testing.T) {
+func TestDriverNameIsRtlsdr(t *testing.T) {
+	// PR-08 flipped the default from "rtlsdr-go" to "rtlsdr"; the
+	// CGO backend now registers as "rtlsdr-cgo" when explicitly
+	// enabled via -tags rtlsdr_cgo.
 	d := New(nil)
-	if got, want := d.Name(), "rtlsdr-go"; got != want {
+	if got, want := d.Name(), "rtlsdr"; got != want {
 		t.Errorf("Name() = %q, want %q", got, want)
 	}
-	if DriverName != "rtlsdr-go" {
-		t.Errorf("DriverName const = %q, want rtlsdr-go", DriverName)
+	if DriverName != "rtlsdr" {
+		t.Errorf("DriverName const = %q, want rtlsdr", DriverName)
 	}
 }
 
@@ -62,8 +65,8 @@ func TestEnumerate_FiltersToKnownDevices(t *testing.T) {
 	if len(got) != 2 {
 		t.Fatalf("Enumerate returned %d entries, want 2 (HackRF must be filtered)", len(got))
 	}
-	if got[0].Driver != "rtlsdr-go" {
-		t.Errorf("Info.Driver = %q, want rtlsdr-go", got[0].Driver)
+	if got[0].Driver != "rtlsdr" {
+		t.Errorf("Info.Driver = %q, want rtlsdr", got[0].Driver)
 	}
 	if got[0].Index != 0 || got[1].Index != 1 {
 		t.Errorf("indices = (%d, %d), want (0, 1)", got[0].Index, got[1].Index)

--- a/internal/sdr/rtlsdr/purego/register.go
+++ b/internal/sdr/rtlsdr/purego/register.go
@@ -1,17 +1,16 @@
-//go:build rtlsdr_purego
-
 package purego
 
 import "github.com/MattCheramie/GopherTrunk/internal/sdr"
 
 // init registers the pure-Go RTL-SDR driver with the global SDR
-// registry. Gated by the rtlsdr_purego build tag so the CGO and
-// pure-Go drivers can coexist during the rewrite (PR-08 will swap
-// names; PR-09 will remove the CGO wrapper entirely).
+// registry under the canonical name "rtlsdr". PR-08 made this the
+// default (dropped the rtlsdr_purego build tag introduced in PR-06).
 //
-// Default builds (no -tags rtlsdr_purego) skip this file, leaving
-// the package importable but inert — the blank import in
-// cmd/gophertrunk/main.go is then a compile-time no-op for SDR
-// registration. Existing CGO builds keep registering as "rtlsdr"
-// from internal/sdr/rtlsdr/rtlsdr_cgo.go.
+// The existing CGO librtlsdr backend continues to compile during one
+// release of safety-net coexistence — with -tags rtlsdr_cgo it
+// registers under "rtlsdr-cgo" alongside the pure-Go entry, so
+// operators who hit a regression can fall back to the C library
+// without rolling back the binary. PR-09 deletes that path
+// entirely along with every `librtlsdr` apt / MSYS2 / DLL-bundling
+// step in the build system.
 func init() { sdr.Register(&Driver{}) }

--- a/internal/sdr/rtlsdr/purego/stream.go
+++ b/internal/sdr/rtlsdr/purego/stream.go
@@ -47,10 +47,10 @@ func (d *Device) StreamIQ(ctx context.Context) (<-chan []complex64, error) {
 		return nil, ErrClosed
 	}
 	if d.out != nil {
-		return nil, errors.New("rtlsdr-go: stream already active")
+		return nil, errors.New("rtlsdr: stream already active")
 	}
 	if err := d.demod.ResetBuffer(); err != nil {
-		return nil, fmt.Errorf("rtlsdr-go: reset buffer: %w", err)
+		return nil, fmt.Errorf("rtlsdr: reset buffer: %w", err)
 	}
 	out := make(chan []complex64, streamChanDepth)
 	d.out = out
@@ -58,7 +58,7 @@ func (d *Device) StreamIQ(ctx context.Context) (<-chan []complex64, error) {
 
 	if err := d.transport.StartBulkIn(bulkInEndpoint, asyncBufCount, asyncBufLen, d.deliver); err != nil {
 		d.out = nil
-		return nil, fmt.Errorf("rtlsdr-go: StartBulkIn: %w", err)
+		return nil, fmt.Errorf("rtlsdr: StartBulkIn: %w", err)
 	}
 
 	// Cancel goroutine: when ctx fires, tear the stream down. Mirrors

--- a/internal/sdr/rtlsdr/rtlsdr_cgo.go
+++ b/internal/sdr/rtlsdr/rtlsdr_cgo.go
@@ -1,6 +1,17 @@
+//go:build rtlsdr_cgo
+
 // Package rtlsdr is a thin CGO binding to librtlsdr. It exposes the subset
 // of the C API required by GopherTrunk: enumeration, tuning, sample rate,
 // gain, PPM, and an async read loop bridged to a Go channel of complex64.
+//
+// PR-08 of the librtlsdr → pure-Go rewrite gated this file behind the
+// `rtlsdr_cgo` build tag and renamed its registration name to
+// "rtlsdr-cgo". The pure-Go driver in internal/sdr/rtlsdr/purego now
+// claims the default "rtlsdr" name. Operators who hit a regression in
+// the pure-Go path can rebuild with `-tags rtlsdr_cgo` (and
+// CGO_ENABLED=1 + librtlsdr-dev installed) to expose the C-backed
+// driver alongside, then select it via config or by serial. PR-09
+// deletes this file entirely.
 //
 // The build links against -lrtlsdr and requires librtlsdr-dev headers on
 // the build host. Runtime needs udev rules granting USB access (see
@@ -36,7 +47,7 @@ import (
 	"github.com/MattCheramie/GopherTrunk/internal/sdr"
 )
 
-const driverName = "rtlsdr"
+const driverName = "rtlsdr-cgo"
 
 // Default async-buffer geometry. 32 buffers × 16 KiB → ~6 ms at 2.4 MS/s.
 const (


### PR DESCRIPTION
## Summary

- PR-08 of the librtlsdr → pure-Go rewrite. Promotes the pure-Go driver from `rtlsdr-go` to the canonical `rtlsdr` registration name; gates the legacy CGO backend behind `-tags rtlsdr_cgo` and renames it `rtlsdr-cgo`. Default builds no longer compile the C-bound file at all — `librtlsdr-dev` becomes a CI-only dependency until PR-09 deletes it.
- `internal/sdr/rtlsdr/purego/`: `DriverName = "rtlsdr"`, `register.go`'s `init()` drops its `rtlsdr_purego` tag (was opt-in in PR-06, now default), error-prefix strings renamed from `"rtlsdr-go:"` to `"rtlsdr:"` so what users see in error messages matches `gophertrunk sdr list`. Doc comments + package commentary refreshed.
- `internal/sdr/rtlsdr/rtlsdr_cgo.go`: new `//go:build rtlsdr_cgo` constraint; `driverName` const renamed to `"rtlsdr-cgo"`. When the tag is on (CGO_ENABLED=1 + librtlsdr-dev on host) the C entry appears alongside the pure-Go one so operators have one release of safety-net coexistence to fall back without rolling the binary.
- `cmd/gophertrunk/main.go`: reordered + re-annotated the two blank imports. Pure-Go is now the always-on canonical registrant; CGO is conditionally compiled. README's top-of-file Features / Stack / roadmap blocks updated to describe the pure-Go driver as the default.

## Test plan

- [x] `CGO_ENABLED=0 go test ./...` green tree-wide (no behavior change in any package outside `internal/sdr/rtlsdr/purego` + `internal/sdr/rtlsdr`)
- [x] `CGO_ENABLED=0 go build ./cmd/gophertrunk/...` clean
- [x] `GOOS=windows GOARCH=amd64 / GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 go vet ./...` clean
- [x] Dev-container CGO build fails as expected (no `librtlsdr-dev` installed); CI's `build-test` job has it and will exercise the path
- [x] `purego` test assertions on `Driver.Name()` / `DriverName` / `sdr.Info.Driver` updated to expect `"rtlsdr"`
- [ ] CI `build-test` (Linux + librtlsdr-dev) and `usb-windows` / `usb-macos` jobs go green
- [ ] (manual, follow-up) Existing operator configs that say `driver: rtlsdr` continue to work transparently (the pure-Go entry now owns that name); operators who want to A/B against the C path rebuild with `-tags rtlsdr_cgo` and select via serial or by reordering pool hints

https://claude.ai/code/session_01CQrwLLjvuoCgQYLkso4SuX

---
_Generated by [Claude Code](https://claude.ai/code/session_01CQrwLLjvuoCgQYLkso4SuX)_