### PR TITLE
Police-scanner cockpit + TUI Devices panel + roadmap fills

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,13 @@ frontend over gRPC, HTTP/SSE, or WebSocket.
 | D-STAR            | Frame Sync + Slow Data sync, 41-byte PCH header parser (FLAG1 + RPT2 / RPT1 / UR / MY1 / MY2 + CRC-CCITT), IsGroupCall / IsEmergency / IsData accessors, repeater state machine emitting `protocol = "dstar"` grants on group transmissions |
 | YSF (Yaesu System Fusion) | 4800-baud C4FM, 480-dibit / 100 ms frame layout (FSW / FICH / DCH offsets), 40-bit FSW correlator with mismatch tolerance, 32-bit Frame Information Channel parser (FrameType / CallType / Frame Number / Frame Total / DataType / VoIP / Squelch fields) with CRC-16 trailer, K=5 ½-rate Viterbi Trellis encoder + decoder over the 104-bit (48 info + 4 tail) FICH channel-bit region (`internal/radio/ysf/fich_trellis.go`, shared with NXDN SACCH), per-frequency state machine emitting `cc.locked` on sync detect and `protocol = "ysf"` grants (with the FICH SquelchCode as DG-ID talkgroup) on Header FICH for Group calls — Terminator FICH clears the dedup so the next transmission fires a fresh CallStart |
 | Orchestration     | In-process pub/sub event bus with typed payloads (Grant / CallStart / CallEnd / DecodeError / ToneAlert / etc.) and a typed `events.Stage` enum so protocol packages can't accidentally publish a stage label that drifts from the Prometheus dashboards, `System` model, JSON-on-disk last-known-CC cache, control-channel `Hunter` that retunes the SDR and parks on the first responsive frequency |
-| Trunking engine   | Cross-protocol `Grant` payload, Trunk-Recorder-format talkgroup DB (CSV + JSON), priority + preemption (emergency overrides, strict-higher), voice-device pool allocator, central state machine emitting `CallStart` / `CallEnd` events with a watchdog for silent calls |
+| Trunking engine   | Cross-protocol `Grant` payload, Trunk-Recorder-format talkgroup DB (CSV + JSON, including a per-TG `Scan` flag), `ScanMode` enum (`all` / `list`) that gates HandleGrant against the scan list (Emergency bypasses), priority + preemption (emergency overrides, strict-higher), voice-device pool allocator, central state machine emitting `CallStart` / `CallEnd` events with a watchdog for silent calls, plus `HandleSyntheticCall` / `EndSyntheticCall` entry points for external scanners (conventional FM) that already own their SDR |
+| Scanner subsystem | Multi-system control-channel hunter (`internal/scanner/cchunt`) that round-robins trunked systems on one control SDR, publishes `cchunt.progress` / `cchunt.failed` telemetry events, persists last-good CC per system to a JSON cache, and supports operator hold / resume / force-retune; conventional FM scan list (`internal/scanner/conventional`) with IQ-power squelch (RMS-power dBFS detector, no FM-discriminator required), per-channel hangtime + priority + label, hop-on-silence state machine, synthetic-Grant handoff to the engine so the recorder + call log + API surfaces light up unchanged; operator hold / resume / dwell-on-index; all controlled from the TUI Scanner panel (key `0`) + REST cockpit at `/api/v1/scanner` |
 | Demod pipeline    | `internal/voice/composer` subscribes to `CallStart` events, opens the bound Voice device's IQ stream, runs an LPF → decimate → optional CMA equalizer → FM demod → optional 75/50µs de-emphasis → optional Kaiser audio LPF → optional audio AGC → optional polyphase L/M resample (or naive decimate fallback) → int16 PCM chain into the recorder, and pings `Engine.Touch` every second so the silent-call watchdog leaves the call alone |
 | Simulcast / "True I/Q" | `internal/dsp/equalizer` (LMS + CMA blind equalizers) for inter-symbol-interference / multipath mitigation, plus `internal/dsp/diversity` (Selection + maximal-ratio combiners over a shared `Combiner` interface) for multi-receiver IQ combining |
 | Tone-out alerting | `internal/voice/toneout` runs Goertzel filters against each Voice device's PCM stream, matches QC-II two-tone-sequential sequences against operator-configured profiles with per-tone duration + cooldown, and publishes `tone.alert` events that fan out through SSE / WebSocket / gRPC |
 | Voice recording   | `Vocoder` plugin interface + `NullVocoder` baseline, 16-bit PCM mono WAV writer with patched-length trailers, per-call recorder writing `<system>/<tg>/<UTC>_src<id>.wav` plus an optional raw-frame sidecar so users can BYO decoder; EDACS ProVoice grants always force a `.raw` sidecar (the vocoder is patent + trade-secret encumbered) so researchers can decode out-of-band |
-| API               | `proto/*.proto` schemas under repo root; HTTP REST (`/api/v1/{health,version,systems,talkgroups,calls/active,calls/history,devices}`); operator mutations gated behind `api.allow_mutations` (`GET /api/v1/mutations` capability probe; `POST /api/v1/calls/{serial}/end`; `PATCH /api/v1/talkgroups/{id}`; `POST /api/v1/retention/sweep`; `POST /api/v1/devices/{serial}/tone-reset`); Server-Sent Events stream (`/api/v1/events`) — per-device hot-plug surfaces as `sdr.attached` / `sdr.detached` events with the same payload shape as `GET /api/v1/devices`; WebSocket bridge (`/api/v1/events/ws`); gRPC `SystemService` + `TalkgroupService` + `AudioService` over the same in-process state |
+| API               | `proto/*.proto` schemas under repo root; HTTP REST (`/api/v1/{health,version,systems,talkgroups,calls/active,calls/history,devices,scanner}`); operator mutations gated behind `api.allow_mutations` (`GET /api/v1/mutations` capability probe; `POST /api/v1/calls/{serial}/end`; `PATCH /api/v1/talkgroups/{id}` accepts priority/lockout/scan; `POST /api/v1/retention/sweep`; `POST /api/v1/devices/{serial}/tone-reset`; `PATCH /api/v1/scanner` flips scan_mode at runtime; `POST /api/v1/scanner/hunt/{system}/{hold\|resume\|retune}` and `POST /api/v1/scanner/conventional/{hold\|resume\|{index}/dwell}` drive the police-scanner cockpit); Server-Sent Events stream (`/api/v1/events`) — per-device hot-plug surfaces as `sdr.attached` / `sdr.detached`, scanner progress as `cchunt.progress` / `cchunt.failed`; WebSocket bridge (`/api/v1/events/ws`); gRPC `SystemService` + `TalkgroupService` + `AudioService` over the same in-process state |
 | Persistence       | Pure-Go SQLite (`modernc.org/sqlite`) call log subscribing to `CallStart` / `CallEnd` events; newest-first history queries with system / group / time filters; retention sweeper that ages out DB rows and recorded `.wav` / `.raw` files past configurable cutoffs |
 | Observability     | Prometheus collector (events / calls / CC-locked / IQ-underrun / USB-reconnect / decode-error / SDR-attached / build-info series) exposed at `/metrics`; multi-stage `Dockerfile`; `docker-compose.yml` with RTL-SDR USB pass-through, healthcheck, and Prometheus scrape labels |
 | Daemon            | `cmd/gophertrunk run` composes everything above into a single supervised process with signal-driven shutdown; every component is opt-in via `config.yaml` |
@@ -477,8 +478,8 @@ tests.
 ## Repository layout
 
 ```
-cmd/gophertrunk/        daemon entrypoint + sdr list CLI + read-only TUI
-internal/tui/           bubbletea TUI: 9 read-only panels over REST+SSE
+cmd/gophertrunk/        daemon entrypoint + sdr list CLI + read+write TUI cockpit
+internal/tui/           bubbletea TUI: 10 panels (Scanner cockpit is panel #10) over REST+SSE
 internal/sdr/           Driver interface, pool, mock
 internal/sdr/rtlsdr/usb/      Pure-Go USB transport: Linux USBDEVFS, Windows WinUSB, macOS IOKit (purego), mock
 internal/sdr/rtlsdr/rtl2832u/ RTL2832U register/I2C layer (sample-rate, IF, FIR, GPIO, I2C bridge)
@@ -509,18 +510,22 @@ gophertrunk tui -no-color          # disable ANSI colour
 gophertrunk tui -insecure          # skip TLS verification
 ```
 
-Nine panels covering every read surface, vim-style navigation, live
-SSE event stream, periodic REST refresh, automatic reconnect on
-disconnect:
+Ten panels covering every read surface plus the operator scanner
+cockpit, vim-style navigation, live SSE event stream, periodic REST
+refresh, automatic reconnect on disconnect:
 
 | Key | Action |
 | --- | --- |
 | `Tab` / `Shift+Tab` | next / previous panel |
-| `1`–`9` | jump to Dashboard / Systems / Talkgroups / Active / History / Events / Tones / Metrics / Devices |
+| `1`–`9`, `0` | jump to Dashboard / Systems / Talkgroups / Active / History / Events / Tones / Metrics / Devices / Scanner |
 | `j` / `k` | move row up / down inside a table |
 | `/` | filter (Talkgroups, Events) |
 | `s` | cycle sort (Talkgroups) |
-| `Enter` | open detail card (Systems, Talkgroups) |
+| `S` | toggle scan flag (Talkgroups; mutates) |
+| `Enter` | open detail card (Systems, Talkgroups) or dwell (Scanner conv row) |
+| `h` | hold/resume highlighted system or conv channel (Scanner; mutates) |
+| `r` | force re-hunt highlighted system (Scanner; mutates) |
+| `m` | cycle scan_mode list↔all (Scanner; mutates) |
 | `p` | pause auto-scroll (Events) |
 | `r` | reload (History) |
 | `?` | toggle help |

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -14,6 +14,8 @@ import (
 	"github.com/MattCheramie/GopherTrunk/internal/config"
 	"github.com/MattCheramie/GopherTrunk/internal/events"
 	"github.com/MattCheramie/GopherTrunk/internal/metrics"
+	"github.com/MattCheramie/GopherTrunk/internal/scanner/cchunt"
+	"github.com/MattCheramie/GopherTrunk/internal/scanner/conventional"
 	"github.com/MattCheramie/GopherTrunk/internal/sdr"
 	"github.com/MattCheramie/GopherTrunk/internal/storage"
 	"github.com/MattCheramie/GopherTrunk/internal/trunking"
@@ -77,6 +79,9 @@ type Daemon struct {
 	db         *storage.DB
 	callLog    *storage.CallLog
 	retention  *storage.Retention
+	ccCache    *trunking.Cache
+	cchuntSup  *cchunt.Supervisor
+	convScan   *conventional.Scanner
 	metrics    *metrics.Metrics
 	httpAPI    *api.Server
 	grpcAPI    *api.GRPCServer
@@ -166,6 +171,7 @@ func NewDaemon(cfg config.Config, version string, log *slog.Logger) (*Daemon, er
 		Log:        log,
 		VoicePool:  d.voicePool,
 		Talkgroups: d.talkgroups,
+		ScanMode:   trunking.ParseScanMode(cfg.Scanner.ScanMode),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("daemon: engine: %w", err)
@@ -233,6 +239,93 @@ func NewDaemon(cfg config.Config, version string, log *slog.Logger) (*Daemon, er
 			return nil, fmt.Errorf("daemon: composer: %w", err)
 		}
 		d.composer = comp
+	}
+
+	// CC cache — JSON file used by the hunter to bias retunes toward
+	// the last-known good control channel per system. Optional; nil
+	// disables persistence (hunts still work, just without the cache
+	// bias).
+	if cfg.Storage.CCCacheFile != "" {
+		cache, err := trunking.OpenCache(cfg.Storage.CCCacheFile)
+		if err != nil {
+			return nil, fmt.Errorf("daemon: cc cache: %w", err)
+		}
+		d.ccCache = cache
+	}
+
+	// CC hunter supervisor — opt-in via scanner.cc_hunt.enabled OR
+	// by default when at least one trunked system is configured.
+	// Honest scope flag: this orchestrates retunes + telemetry but
+	// nothing in the daemon currently publishes cc.locked, so until
+	// the IQ-domain protocol decoders land the supervisor will
+	// report "failed" + back off. Operators see that in the TUI
+	// Scanner panel, which is the correct behavior — silently
+	// pretending decode works would be worse.
+	if d.pool != nil && len(d.systems) > 0 {
+		cchEnabled := cfg.Scanner.CCHunt.Enabled || cfg.Scanner.CCHunt == (config.CCHuntConfig{})
+		if cchEnabled {
+			controlEntry := d.pool.FirstByRole(sdr.RoleControl)
+			if controlEntry != nil {
+				sup, err := cchunt.New(cchunt.Options{
+					Bus:            d.bus,
+					Log:            log,
+					Tuner:          controlEntry.Device,
+					Cache:          d.ccCache,
+					Systems:        d.systems,
+					Dwell:          msToDuration(cfg.Scanner.CCHunt.DwellMs, 3*time.Second),
+					InitialBackoff: msToDuration(cfg.Scanner.CCHunt.BackoffMs, 5*time.Second),
+					MaxBackoff:     msToDuration(cfg.Scanner.CCHunt.MaxBackoffMs, 60*time.Second),
+				})
+				if err != nil {
+					return nil, fmt.Errorf("daemon: cchunt: %w", err)
+				}
+				d.cchuntSup = sup
+			} else {
+				log.Warn("daemon: scanner.cc_hunt enabled but no control SDR in pool; skipping")
+			}
+		}
+	}
+
+	// Conventional FM scanner — opt-in via scanner.conventional list.
+	// Requires its own dedicated Voice SDR (carved out of the pool's
+	// voice fleet) and a recorder to land WAVs into. The scanner
+	// publishes synthetic CallStart/CallEnd events through
+	// Engine.HandleSyntheticCall, so the recorder, call log, and
+	// /api/v1/calls/active surfaces light up like any other call.
+	if d.pool != nil && d.recorder != nil && d.engine != nil && len(cfg.Scanner.Conventional) > 0 {
+		voiceEntries := d.pool.AllByRole(sdr.RoleVoice)
+		if len(voiceEntries) == 0 {
+			log.Warn("daemon: scanner.conventional configured but no Voice SDRs in the pool; skipping")
+		} else {
+			// Use the LAST voice SDR so the trunking engine still
+			// has the first N-1 voice radios for normal grants.
+			convEntry := voiceEntries[len(voiceEntries)-1]
+			channels := make([]conventional.Channel, 0, len(cfg.Scanner.Conventional))
+			for _, ch := range cfg.Scanner.Conventional {
+				channels = append(channels, conventional.Channel{
+					Label:       ch.Label,
+					FrequencyHz: ch.FrequencyHz,
+					Mode:        ch.Mode,
+					SquelchDbFS: ch.SquelchDbFS,
+					Hangtime:    msToDuration(ch.HangtimeMs, 1500*time.Millisecond),
+					Priority:    ch.Priority,
+				})
+			}
+			cs, err := conventional.New(conventional.Options{
+				Log:          log,
+				Tuner:        convEntry.Device,
+				IQ:           convEntry.Device,
+				Engine:       d.engine,
+				Recorder:     d.recorder,
+				DeviceSerial: convEntry.Info.Serial,
+				SystemName:   "scanner",
+				Channels:     channels,
+			})
+			if err != nil {
+				return nil, fmt.Errorf("daemon: conv scanner: %w", err)
+			}
+			d.convScan = cs
+		}
 	}
 
 	// Storage / call log / retention — optional.
@@ -306,6 +399,12 @@ func NewDaemon(cfg config.Config, version string, log *slog.Logger) (*Daemon, er
 		if d.pool != nil {
 			opts.Devices = d.pool
 		}
+		opts.Scanner = scannerCockpit{
+			cchunt:     d.cchuntSup,
+			conv:       d.convScan,
+			engine:     d.engine,
+			talkgroups: d.talkgroups,
+		}
 		srv, err := api.NewServer(opts)
 		if err != nil {
 			return nil, fmt.Errorf("daemon: http api: %w", err)
@@ -369,6 +468,16 @@ func (d *Daemon) Run(ctx context.Context) error {
 	if d.metrics != nil {
 		d.spawn(ctx, "metrics", func(ctx context.Context) error {
 			return d.metrics.Run(ctx)
+		})
+	}
+	if d.cchuntSup != nil {
+		d.spawn(ctx, "cchunt", func(ctx context.Context) error {
+			return d.cchuntSup.Run(ctx)
+		})
+	}
+	if d.convScan != nil {
+		d.spawn(ctx, "conv-scanner", func(ctx context.Context) error {
+			return d.convScan.Run(ctx)
 		})
 	}
 	if d.httpAPI != nil {
@@ -468,6 +577,15 @@ func retentionInterval(s string) (time.Duration, error) {
 		return time.Hour, nil
 	}
 	return time.ParseDuration(s)
+}
+
+// msToDuration converts a config milliseconds field to a Duration,
+// falling back to fallback when the field is zero or negative.
+func msToDuration(ms int, fallback time.Duration) time.Duration {
+	if ms <= 0 {
+		return fallback
+	}
+	return time.Duration(ms) * time.Millisecond
 }
 
 // fanoutSink writes the same PCM frame to several composer.PCMSink

--- a/cmd/gophertrunk/scanner_cockpit.go
+++ b/cmd/gophertrunk/scanner_cockpit.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/MattCheramie/GopherTrunk/internal/api"
+	"github.com/MattCheramie/GopherTrunk/internal/scanner/cchunt"
+	"github.com/MattCheramie/GopherTrunk/internal/scanner/conventional"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// scannerCockpit aggregates the three scanner subsystems (CC hunter,
+// conventional FM scanner, talkgroup-scan engine state) into the
+// single interface the api.Server consumes. Any sub-component may be
+// nil — methods degrade gracefully so a partial configuration still
+// returns useful status.
+type scannerCockpit struct {
+	cchunt     *cchunt.Supervisor
+	conv       *conventional.Scanner
+	engine     *trunking.Engine
+	talkgroups *trunking.TalkgroupDB
+}
+
+// Status assembles the unified read snapshot the TUI panel renders.
+func (c scannerCockpit) Status() api.ScannerStatus {
+	st := api.ScannerStatus{
+		ScanMode: "all",
+	}
+	if c.engine != nil {
+		st.ScanMode = c.engine.ScanMode().String()
+	}
+	if c.cchunt != nil {
+		for _, ss := range c.cchunt.Snapshot() {
+			st.Systems = append(st.Systems, api.SystemHuntStatusDTO{
+				Name:            ss.Name,
+				Protocol:        ss.Protocol,
+				State:           string(ss.State),
+				AttemptedFreqHz: ss.AttemptedFreqHz,
+				AttemptIndex:    ss.AttemptIndex,
+				TotalCandidates: ss.TotalCandidates,
+				LockedFreqHz:    ss.LockedFreqHz,
+				LockedAt:        ss.LockedAt,
+				NAC:             ss.NAC,
+				LastFailedAt:    ss.LastFailedAt,
+				BackoffMs:       ss.BackoffMs,
+				LastGrantAt:     ss.LastGrantAt,
+			})
+		}
+	}
+	if c.conv != nil {
+		snap := c.conv.Snapshot()
+		st.Conventional.Enabled = true
+		st.Conventional.State = string(snap.State)
+		st.Conventional.DeviceSerial = snap.DeviceSerial
+		st.Conventional.CursorIndex = snap.CursorIndex
+		for _, ch := range snap.Channels {
+			st.Conventional.Channels = append(st.Conventional.Channels, api.ConvChannelStatusDTO{
+				Index:       ch.Index,
+				Label:       ch.Label,
+				FrequencyHz: ch.FrequencyHz,
+				Mode:        ch.Mode,
+				Active:      ch.Active,
+				LastBreakAt: ch.LastBreakAt,
+			})
+		}
+	}
+	if c.talkgroups != nil {
+		total := 0
+		scanCount := 0
+		for _, tg := range c.talkgroups.All() {
+			total++
+			if tg.Scan {
+				scanCount++
+			}
+		}
+		st.TalkgroupTotalCount = total
+		st.TalkgroupScanCount = scanCount
+	}
+	return st
+}
+
+// SetScanMode flips the engine's scan mode at runtime.
+func (c scannerCockpit) SetScanMode(mode string) (string, error) {
+	if c.engine == nil {
+		return "", fmt.Errorf("engine not wired")
+	}
+	switch mode {
+	case "all", "list":
+	default:
+		return "", fmt.Errorf("scan_mode must be all|list")
+	}
+	prev := c.engine.SetScanMode(trunking.ParseScanMode(mode))
+	return prev.String(), nil
+}
+
+// HoldHunt / ResumeHunt / ForceRetuneHunt delegate to the supervisor.
+// Returns false if the supervisor isn't wired or the system isn't
+// configured.
+func (c scannerCockpit) HoldHunt(system string) bool {
+	if c.cchunt == nil {
+		return false
+	}
+	return c.cchunt.Hold(system)
+}
+func (c scannerCockpit) ResumeHunt(system string) bool {
+	if c.cchunt == nil {
+		return false
+	}
+	return c.cchunt.Resume(system)
+}
+func (c scannerCockpit) ForceRetuneHunt(system string) bool {
+	if c.cchunt == nil {
+		return false
+	}
+	return c.cchunt.ForceRetune(system)
+}
+
+// HoldConventional / ResumeConventional / DwellConventional delegate
+// to the conventional scanner.
+func (c scannerCockpit) HoldConventional() bool {
+	if c.conv == nil {
+		return false
+	}
+	c.conv.Hold()
+	return true
+}
+func (c scannerCockpit) ResumeConventional() bool {
+	if c.conv == nil {
+		return false
+	}
+	c.conv.Resume()
+	return true
+}
+func (c scannerCockpit) DwellConventional(index int) bool {
+	if c.conv == nil {
+		return false
+	}
+	return c.conv.DwellOn(index)
+}

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -59,6 +59,31 @@ trunking:
         - 852_000_000
       talkgroup_file: "/etc/gophertrunk/talkgroups-p25.csv"
 
+# Police-scanner subsystems:
+#   - scan_mode controls the engine's per-grant gate. "all" follows every
+#     non-locked-out grant (the original behavior). "list" only follows
+#     grants whose talkgroup carries Scan=true; Emergency grants bypass.
+#   - cc_hunt is the multi-system control-channel scanner. Operator can
+#     hold/resume/force-retune any system from the TUI Scanner panel.
+#   - conventional is the fixed-frequency analog FM scan list. Requires
+#     a dedicated Voice SDR (the last voice device in the pool is used).
+scanner:
+  scan_mode: all       # all | list
+  cc_hunt:
+    enabled: true
+    dwell_ms: 3000
+    backoff_ms: 5000
+    max_backoff_ms: 60000
+  conventional: []
+  # Example conventional channels:
+  # conventional:
+  #   - label: "Sheriff Repeater"
+  #     frequency_hz: 155895000
+  #     mode: fm
+  #     squelch_dbfs: -48
+  #     hangtime_ms: 1500
+  #     priority: 4
+
 # tone_out fires events.KindToneAlert when the configured paging tones
 # are detected on a Voice device's PCM stream. Empty profiles disable
 # the detector. Two-tone sequential (Quick Call II) is the most common

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -44,6 +44,7 @@ gophertrunk tui -server https://radio.example.com -insecure
 | 7 | Tone alerts | Just `tone.alert` events with profile / device / matched frequencies. 100-entry ring buffer. |
 | 8 | Metrics | Curated subset of `/metrics`: calls active / total, grant total, CC locked, SSE clients, devices attached, tone alerts. |
 | 9 | Devices | The SDR pool snapshot: serial, driver, tuner, role, configured gain / PPM / bias-tee, attach state. Refreshed on `sdr.attached` / `sdr.detached` events for instant updates. |
+| 0 | Scanner | Police-scanner cockpit: per-trunked-system CC hunter state, conventional FM scan list (current dwell highlighted), talkgroup scan-list summary. Operator can hold/resume/force-retune systems, dwell on conventional channels, and cycle scan_mode — all gated behind `--write` + `api.allow_mutations`. |
 
 ## Keybindings
 
@@ -53,7 +54,7 @@ gophertrunk tui -server https://radio.example.com -insecure
 | --- | --- |
 | `Tab` | next panel |
 | `Shift+Tab` | previous panel |
-| `1`–`9` | jump directly to a panel |
+| `1`–`9`, `0` | jump directly to a panel (0 = Scanner) |
 | `?` | toggle help overlay |
 | `q` / `Ctrl+C` | quit |
 
@@ -72,13 +73,14 @@ gophertrunk tui -server https://radio.example.com -insecure
 | Panel | Keys |
 | --- | --- |
 | Systems | `Enter` open detail card |
-| Talkgroups | `/` filter, `s` cycle sort, `Enter` open detail card, `Esc` exit filter input |
+| Talkgroups | `/` filter, `s` cycle sort, `S` toggle scan flag, `Enter` open detail card, `Esc` exit filter input |
 | Active calls | (table navigation only) |
 | Call history | `r` reload |
 | Events | `/` filter, `p` pause auto-scroll, `c` clear filter |
 | Tone alerts | (table navigation only) |
 | Metrics | (table navigation only) |
 | Devices | (table navigation only) |
+| Scanner | `j` / `k` move row, `h` hold/resume highlighted row, `r` force re-hunt (Systems section, confirms), `Enter` dwell on highlighted conv channel, `m` cycle scan_mode |
 
 ## Polling cadences
 
@@ -124,9 +126,14 @@ listener can call mutations once the gate is open — bind to
 | --- | --- | --- | --- |
 | Active calls | `e` | End the highlighted call (`POST /api/v1/calls/{serial}/end`, reason=manual) | yes |
 | Talkgroups | `l` | Toggle lockout on the highlighted talkgroup (`PATCH /api/v1/talkgroups/{id}`) | no — reversible |
+| Talkgroups | `S` | Toggle scan flag (relevant when `scan_mode: list`) | no |
 | Talkgroups | `+` / `-` | Bump priority up / down (clamped 0–99) | no |
 | Tone alerts | `R` | Reset tone-out match progress on the highlighted device (`POST /api/v1/devices/{serial}/tone-reset`) | yes |
 | Metrics | `S` | Run a retention sweep now (`POST /api/v1/retention/sweep`) | yes |
+| Scanner | `h` | Hold/resume highlighted system or conv channel (`POST /api/v1/scanner/hunt/{system}/hold\|resume` or `/conventional/hold\|resume`) | no |
+| Scanner | `r` | Force re-hunt the highlighted system (`POST /api/v1/scanner/hunt/{system}/retune`) | yes |
+| Scanner | `Enter` | Dwell on the highlighted conv channel (`POST /api/v1/scanner/conventional/{index}/dwell`) | no |
+| Scanner | `m` | Cycle global scan_mode list ↔ all (`PATCH /api/v1/scanner`) | no |
 
 When a key requires confirmation, a centered modal opens. The
 modal captures keyboard focus until you press:

--- a/internal/api/handlers_mutations.go
+++ b/internal/api/handlers_mutations.go
@@ -87,12 +87,13 @@ func parseEndReason(s string) trunking.EndReason {
 	return trunking.EndReasonManual
 }
 
-// updateTalkgroupRequest is the PATCH body shape. Both fields are
+// updateTalkgroupRequest is the PATCH body shape. All fields are
 // pointers so JSON-omitted fields aren't accidentally zeroed: only
 // supplied fields are applied.
 type updateTalkgroupRequest struct {
 	Priority *int  `json:"priority"`
 	Lockout  *bool `json:"lockout"`
+	Scan     *bool `json:"scan"`
 }
 
 // handleUpdateTalkgroup updates a talkgroup's mutable policy fields
@@ -118,8 +119,8 @@ func (s *Server) handleUpdateTalkgroup(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "invalid json body")
 		return
 	}
-	if req.Priority == nil && req.Lockout == nil {
-		writeError(w, http.StatusBadRequest, "supply priority and/or lockout")
+	if req.Priority == nil && req.Lockout == nil && req.Scan == nil {
+		writeError(w, http.StatusBadRequest, "supply priority and/or lockout and/or scan")
 		return
 	}
 	ok := s.talkgroups.UpdateFields(uint32(id), func(tg *trunking.TalkGroup) {
@@ -128,6 +129,9 @@ func (s *Server) handleUpdateTalkgroup(w http.ResponseWriter, r *http.Request) {
 		}
 		if req.Lockout != nil {
 			tg.Lockout = *req.Lockout
+		}
+		if req.Scan != nil {
+			tg.Scan = *req.Scan
 		}
 	})
 	if !ok {

--- a/internal/api/handlers_mutations_test.go
+++ b/internal/api/handlers_mutations_test.go
@@ -194,6 +194,34 @@ func TestUpdateTalkgroup_AppliesPriorityAndLockout(t *testing.T) {
 	}
 }
 
+func TestUpdateTalkgroup_AppliesScan(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	tgs := trunking.NewTalkgroupDB()
+	tgs.Add(&trunking.TalkGroup{ID: 42, AlphaTag: "Dispatch", Scan: true})
+	base, teardown := mkServer(t, ServerOptions{
+		Bus:            bus,
+		AllowMutations: true,
+		Talkgroups:     tgs,
+	})
+	defer teardown()
+
+	body := bytes.NewReader([]byte(`{"scan":false}`))
+	req, _ := http.NewRequest(http.MethodPatch, base+"/api/v1/talkgroups/42", body)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("status=%d", resp.StatusCode)
+	}
+	if tgs.Lookup(42).Scan {
+		t.Errorf("Scan still true after PATCH")
+	}
+}
+
 func TestUpdateTalkgroup_NotFound(t *testing.T) {
 	bus := events.NewBus(8)
 	defer bus.Close()

--- a/internal/api/handlers_scanner.go
+++ b/internal/api/handlers_scanner.go
@@ -1,0 +1,128 @@
+package api
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strconv"
+)
+
+// handleScannerStatus returns the unified scanner snapshot the TUI
+// Scanner panel renders. Always 200 — when the cockpit is nil
+// (scanner subsystem not wired), an empty status is returned so the
+// TUI can still render "no systems / no conventional channels"
+// instead of a 503.
+func (s *Server) handleScannerStatus(w http.ResponseWriter, _ *http.Request) {
+	if s.scanner == nil {
+		writeJSON(w, http.StatusOK, ScannerStatus{
+			ScanMode: "all",
+		})
+		return
+	}
+	writeJSON(w, http.StatusOK, s.scanner.Status())
+}
+
+// scannerSetModeRequest is the PATCH /api/v1/scanner body shape.
+type scannerSetModeRequest struct {
+	ScanMode string `json:"scan_mode"`
+}
+
+func (s *Server) handleScannerSetMode(w http.ResponseWriter, r *http.Request) {
+	if s.scanner == nil {
+		writeError(w, http.StatusServiceUnavailable, "scanner not wired")
+		return
+	}
+	var req scannerSetModeRequest
+	if r.Body != nil && r.ContentLength != 0 {
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil && err != io.EOF {
+			writeError(w, http.StatusBadRequest, "invalid json body")
+			return
+		}
+	}
+	if req.ScanMode == "" {
+		writeError(w, http.StatusBadRequest, "scan_mode required")
+		return
+	}
+	prev, err := s.scanner.SetScanMode(req.ScanMode)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"ok":            true,
+		"scan_mode":     req.ScanMode,
+		"previous_mode": prev,
+	})
+}
+
+func (s *Server) handleHuntHold(w http.ResponseWriter, r *http.Request) {
+	s.huntOp(w, r, s.scanner.HoldHunt)
+}
+func (s *Server) handleHuntResume(w http.ResponseWriter, r *http.Request) {
+	s.huntOp(w, r, s.scanner.ResumeHunt)
+}
+func (s *Server) handleHuntRetune(w http.ResponseWriter, r *http.Request) {
+	s.huntOp(w, r, s.scanner.ForceRetuneHunt)
+}
+
+// huntOp is the shared mechanics for the three per-system hunt
+// operations: nil cockpit → 503, empty path → 400, unknown system
+// → 404. The actual mutation is delegated to the supplied func.
+func (s *Server) huntOp(w http.ResponseWriter, r *http.Request, op func(string) bool) {
+	if s.scanner == nil {
+		writeError(w, http.StatusServiceUnavailable, "scanner not wired")
+		return
+	}
+	system := r.PathValue("system")
+	if system == "" {
+		writeError(w, http.StatusBadRequest, "system required")
+		return
+	}
+	if !op(system) {
+		writeError(w, http.StatusNotFound, "no such system")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "system": system})
+}
+
+func (s *Server) handleConvHold(w http.ResponseWriter, _ *http.Request) {
+	if s.scanner == nil {
+		writeError(w, http.StatusServiceUnavailable, "scanner not wired")
+		return
+	}
+	if !s.scanner.HoldConventional() {
+		writeError(w, http.StatusServiceUnavailable, "conventional scanner not configured")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"ok": true})
+}
+
+func (s *Server) handleConvResume(w http.ResponseWriter, _ *http.Request) {
+	if s.scanner == nil {
+		writeError(w, http.StatusServiceUnavailable, "scanner not wired")
+		return
+	}
+	if !s.scanner.ResumeConventional() {
+		writeError(w, http.StatusServiceUnavailable, "conventional scanner not configured")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"ok": true})
+}
+
+func (s *Server) handleConvDwell(w http.ResponseWriter, r *http.Request) {
+	if s.scanner == nil {
+		writeError(w, http.StatusServiceUnavailable, "scanner not wired")
+		return
+	}
+	idxStr := r.PathValue("index")
+	idx, err := strconv.Atoi(idxStr)
+	if err != nil || idx < 0 {
+		writeError(w, http.StatusBadRequest, "invalid index")
+		return
+	}
+	if !s.scanner.DwellConventional(idx) {
+		writeError(w, http.StatusNotFound, "channel index out of range")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "index": idx})
+}

--- a/internal/api/handlers_scanner_test.go
+++ b/internal/api/handlers_scanner_test.go
@@ -1,0 +1,280 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+)
+
+// fakeCockpit captures every mutation method call so tests can
+// verify the route → cockpit wiring.
+type fakeCockpit struct {
+	mu       sync.Mutex
+	status   ScannerStatus
+	modeErr  error
+	holdSys  []string
+	resSys   []string
+	retSys   []string
+	holdConv int
+	resConv  int
+	dwell    []int
+	missingSys map[string]bool // systems for which Hold/Resume/Retune should return false
+	convNotConfigured bool
+	dwellRange int // valid range [0..dwellRange); -1 means any index accepted
+	prevMode string
+}
+
+func (f *fakeCockpit) Status() ScannerStatus { return f.status }
+func (f *fakeCockpit) SetScanMode(m string) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.modeErr != nil {
+		return "", f.modeErr
+	}
+	prev := f.prevMode
+	f.prevMode = m
+	f.status.ScanMode = m
+	return prev, nil
+}
+func (f *fakeCockpit) systemKnown(sys string) bool {
+	if f.missingSys == nil {
+		return true
+	}
+	return !f.missingSys[sys]
+}
+func (f *fakeCockpit) HoldHunt(sys string) bool {
+	if !f.systemKnown(sys) {
+		return false
+	}
+	f.mu.Lock()
+	f.holdSys = append(f.holdSys, sys)
+	f.mu.Unlock()
+	return true
+}
+func (f *fakeCockpit) ResumeHunt(sys string) bool {
+	if !f.systemKnown(sys) {
+		return false
+	}
+	f.mu.Lock()
+	f.resSys = append(f.resSys, sys)
+	f.mu.Unlock()
+	return true
+}
+func (f *fakeCockpit) ForceRetuneHunt(sys string) bool {
+	if !f.systemKnown(sys) {
+		return false
+	}
+	f.mu.Lock()
+	f.retSys = append(f.retSys, sys)
+	f.mu.Unlock()
+	return true
+}
+func (f *fakeCockpit) HoldConventional() bool {
+	if f.convNotConfigured {
+		return false
+	}
+	f.mu.Lock()
+	f.holdConv++
+	f.mu.Unlock()
+	return true
+}
+func (f *fakeCockpit) ResumeConventional() bool {
+	if f.convNotConfigured {
+		return false
+	}
+	f.mu.Lock()
+	f.resConv++
+	f.mu.Unlock()
+	return true
+}
+func (f *fakeCockpit) DwellConventional(i int) bool {
+	if f.dwellRange == 0 {
+		return false
+	}
+	if f.dwellRange > 0 && (i < 0 || i >= f.dwellRange) {
+		return false
+	}
+	f.mu.Lock()
+	f.dwell = append(f.dwell, i)
+	f.mu.Unlock()
+	return true
+}
+
+func TestScannerStatus_AlwaysOK(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	cock := &fakeCockpit{status: ScannerStatus{ScanMode: "list", TalkgroupTotalCount: 12, TalkgroupScanCount: 4}}
+	base, teardown := mkServer(t, ServerOptions{Bus: bus, Scanner: cock})
+	defer teardown()
+	resp, err := http.Get(base + "/api/v1/scanner")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("status=%d", resp.StatusCode)
+	}
+	var st ScannerStatus
+	if err := json.NewDecoder(resp.Body).Decode(&st); err != nil {
+		t.Fatal(err)
+	}
+	if st.ScanMode != "list" || st.TalkgroupTotalCount != 12 || st.TalkgroupScanCount != 4 {
+		t.Errorf("decoded = %+v", st)
+	}
+}
+
+func TestScannerStatus_NoCockpitReturnsEmpty(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	base, teardown := mkServer(t, ServerOptions{Bus: bus})
+	defer teardown()
+	resp, err := http.Get(base + "/api/v1/scanner")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Errorf("status=%d, want 200 even when cockpit nil", resp.StatusCode)
+	}
+}
+
+func TestScannerSetMode_Applies(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	cock := &fakeCockpit{prevMode: "all"}
+	base, teardown := mkServer(t, ServerOptions{Bus: bus, Scanner: cock, AllowMutations: true})
+	defer teardown()
+
+	body := bytes.NewReader([]byte(`{"scan_mode":"list"}`))
+	req, _ := http.NewRequest(http.MethodPatch, base+"/api/v1/scanner", body)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		buf, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status=%d body=%s", resp.StatusCode, buf)
+	}
+	if cock.status.ScanMode != "list" {
+		t.Errorf("mode not applied, got %q", cock.status.ScanMode)
+	}
+}
+
+func TestScannerSetMode_GatedByAllowMutations(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	cock := &fakeCockpit{}
+	base, teardown := mkServer(t, ServerOptions{Bus: bus, Scanner: cock, AllowMutations: false})
+	defer teardown()
+
+	body := bytes.NewReader([]byte(`{"scan_mode":"list"}`))
+	req, _ := http.NewRequest(http.MethodPatch, base+"/api/v1/scanner", body)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 403 {
+		t.Errorf("status=%d, want 403 (gated)", resp.StatusCode)
+	}
+}
+
+func TestScannerHuntHold_Routes(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	cock := &fakeCockpit{}
+	base, teardown := mkServer(t, ServerOptions{Bus: bus, Scanner: cock, AllowMutations: true})
+	defer teardown()
+
+	for _, op := range []string{"hold", "resume", "retune"} {
+		req, _ := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/api/v1/scanner/hunt/Demo/%s", base, op), nil)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != 200 {
+			t.Errorf("%s status=%d", op, resp.StatusCode)
+		}
+	}
+	if len(cock.holdSys) != 1 || cock.holdSys[0] != "Demo" {
+		t.Errorf("holdSys=%v", cock.holdSys)
+	}
+	if len(cock.resSys) != 1 || len(cock.retSys) != 1 {
+		t.Errorf("resume/retune not recorded: %v %v", cock.resSys, cock.retSys)
+	}
+}
+
+func TestScannerHuntHold_NotFound(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	cock := &fakeCockpit{missingSys: map[string]bool{"Missing": true}}
+	base, teardown := mkServer(t, ServerOptions{Bus: bus, Scanner: cock, AllowMutations: true})
+	defer teardown()
+
+	req, _ := http.NewRequest(http.MethodPost, base+"/api/v1/scanner/hunt/Missing/hold", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 404 {
+		t.Errorf("status=%d, want 404", resp.StatusCode)
+	}
+}
+
+func TestScannerConvDwell_BadIndex(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	cock := &fakeCockpit{dwellRange: 3}
+	base, teardown := mkServer(t, ServerOptions{Bus: bus, Scanner: cock, AllowMutations: true})
+	defer teardown()
+
+	// Valid index inside range.
+	req, _ := http.NewRequest(http.MethodPost, base+"/api/v1/scanner/conventional/1/dwell", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Errorf("status=%d, want 200", resp.StatusCode)
+	}
+	// Out-of-range.
+	req, _ = http.NewRequest(http.MethodPost, base+"/api/v1/scanner/conventional/99/dwell", nil)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != 404 {
+		t.Errorf("out-of-range status=%d, want 404", resp.StatusCode)
+	}
+}
+
+func TestScannerConvHold_NoConvScanner(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	cock := &fakeCockpit{convNotConfigured: true}
+	base, teardown := mkServer(t, ServerOptions{Bus: bus, Scanner: cock, AllowMutations: true})
+	defer teardown()
+
+	req, _ := http.NewRequest(http.MethodPost, base+"/api/v1/scanner/conventional/hold", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 503 {
+		t.Errorf("status=%d, want 503 (no conv scanner)", resp.StatusCode)
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -50,6 +50,81 @@ type DevicesProvider interface {
 	Snapshot() []sdr.SDRStatus
 }
 
+// ScannerCockpit is the API surface for the police-scanner subsystem:
+// reads the current state (per-system CC hunt, conventional channel
+// list, talkgroup-scan stats) and applies operator mutations from
+// the TUI (hold/resume/retune the hunter, hold/resume/dwell-on the
+// conventional scanner, flip the global scan mode).
+//
+// The daemon supplies a single ScannerCockpit implementation that
+// aggregates the cchunt.Supervisor + conventional.Scanner + engine;
+// tests can stub a single struct that satisfies the whole interface.
+type ScannerCockpit interface {
+	// Status returns the unified read snapshot the TUI panel renders.
+	Status() ScannerStatus
+	// SetScanMode flips the global TG-scan-list mode at runtime.
+	// Returns the previous mode for audit / UX feedback.
+	SetScanMode(mode string) (prev string, err error)
+	// HoldHunt / ResumeHunt / ForceRetuneHunt apply to a single
+	// trunked system. Returns false when the system isn't configured.
+	HoldHunt(system string) bool
+	ResumeHunt(system string) bool
+	ForceRetuneHunt(system string) bool
+	// HoldConventional / ResumeConventional / DwellConventional
+	// drive the conventional FM scanner. DwellConventional indexes
+	// into the configured Channels list. The Hold/Resume operations
+	// return false when the conventional scanner isn't configured.
+	HoldConventional() bool
+	ResumeConventional() bool
+	DwellConventional(index int) bool
+}
+
+// ScannerStatus is the JSON shape returned by GET /api/v1/scanner —
+// a unified view over all three scanner-subsystem read surfaces.
+type ScannerStatus struct {
+	ScanMode            string                `json:"scan_mode"`
+	Systems             []SystemHuntStatusDTO `json:"systems"`
+	Conventional        ConvScannerStatusDTO  `json:"conventional"`
+	TalkgroupScanCount  int                   `json:"tg_scan_count"`
+	TalkgroupTotalCount int                   `json:"tg_total"`
+}
+
+// SystemHuntStatusDTO mirrors cchunt.SystemStatus for the wire layer
+// so the api package doesn't import internal/scanner.
+type SystemHuntStatusDTO struct {
+	Name            string    `json:"name"`
+	Protocol        string    `json:"protocol"`
+	State           string    `json:"state"`
+	AttemptedFreqHz uint32    `json:"attempted_freq_hz,omitempty"`
+	AttemptIndex    int       `json:"attempt_index,omitempty"`
+	TotalCandidates int       `json:"total_candidates,omitempty"`
+	LockedFreqHz    uint32    `json:"locked_freq_hz,omitempty"`
+	LockedAt        time.Time `json:"locked_at,omitempty"`
+	NAC             uint16    `json:"nac,omitempty"`
+	LastFailedAt    time.Time `json:"last_failed_at,omitempty"`
+	BackoffMs       int       `json:"backoff_ms,omitempty"`
+	LastGrantAt     time.Time `json:"last_grant_at,omitempty"`
+}
+
+// ConvScannerStatusDTO is the conventional FM scanner's read shape.
+type ConvScannerStatusDTO struct {
+	Enabled      bool                  `json:"enabled"`
+	State        string                `json:"state,omitempty"`
+	DeviceSerial string                `json:"device_serial,omitempty"`
+	CursorIndex  int                   `json:"cursor_index,omitempty"`
+	Channels     []ConvChannelStatusDTO `json:"channels"`
+}
+
+// ConvChannelStatusDTO mirrors conventional.ChannelStatus.
+type ConvChannelStatusDTO struct {
+	Index       int       `json:"index"`
+	Label       string    `json:"label"`
+	FrequencyHz uint32    `json:"frequency_hz"`
+	Mode        string    `json:"mode"`
+	Active      bool      `json:"active"`
+	LastBreakAt time.Time `json:"last_break_at,omitempty"`
+}
+
 // Server hosts the GopherTrunk HTTP/SSE/WebSocket API. A separate gRPC
 // server (internal/api/grpc.go) shares the same in-process state.
 type Server struct {
@@ -60,6 +135,7 @@ type Server struct {
 	retention  RetentionSweeper
 	tones      ToneDetectorReset
 	devices    DevicesProvider
+	scanner    ScannerCockpit
 	talkgroups *trunking.TalkgroupDB
 	systems    []trunking.System
 	history    HistoryQuery
@@ -148,6 +224,11 @@ type ServerOptions struct {
 	// Devices exposes the SDR pool snapshot for GET /api/v1/devices.
 	// Optional; the route returns 503 when nil.
 	Devices DevicesProvider
+	// Scanner exposes the police-scanner cockpit (CC hunter,
+	// conventional FM scanner, TG scan list) for GET + PATCH
+	// /api/v1/scanner and the related mutation routes. Optional;
+	// when nil, the routes return 503.
+	Scanner ScannerCockpit
 }
 
 // NewServer constructs a server but does not yet bind a listener; call
@@ -174,6 +255,7 @@ func NewServer(opts ServerOptions) (*Server, error) {
 		retention:      opts.Retention,
 		tones:          opts.Tones,
 		devices:        opts.Devices,
+		scanner:        opts.Scanner,
 		talkgroups:     opts.Talkgroups,
 		systems:        append([]trunking.System(nil), opts.Systems...),
 		history:        opts.History,
@@ -260,6 +342,17 @@ func (s *Server) routes() *http.ServeMux {
 	mux.HandleFunc("PATCH /api/v1/talkgroups/{id}", s.gate(s.handleUpdateTalkgroup))
 	mux.HandleFunc("POST /api/v1/retention/sweep", s.gate(s.handleRetentionSweep))
 	mux.HandleFunc("POST /api/v1/devices/{serial}/tone-reset", s.gate(s.handleToneReset))
+
+	// Scanner cockpit — read endpoint is always open; mutations are
+	// gated behind allow_mutations like every other write route.
+	mux.HandleFunc("GET /api/v1/scanner", s.handleScannerStatus)
+	mux.HandleFunc("PATCH /api/v1/scanner", s.gate(s.handleScannerSetMode))
+	mux.HandleFunc("POST /api/v1/scanner/hunt/{system}/hold", s.gate(s.handleHuntHold))
+	mux.HandleFunc("POST /api/v1/scanner/hunt/{system}/resume", s.gate(s.handleHuntResume))
+	mux.HandleFunc("POST /api/v1/scanner/hunt/{system}/retune", s.gate(s.handleHuntRetune))
+	mux.HandleFunc("POST /api/v1/scanner/conventional/hold", s.gate(s.handleConvHold))
+	mux.HandleFunc("POST /api/v1/scanner/conventional/resume", s.gate(s.handleConvResume))
+	mux.HandleFunc("POST /api/v1/scanner/conventional/{index}/dwell", s.gate(s.handleConvDwell))
 
 	return mux
 }

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -49,6 +49,7 @@ type TalkgroupDTO struct {
 	Mode        string `json:"mode,omitempty"`
 	Priority    int    `json:"priority,omitempty"`
 	Lockout     bool   `json:"lockout,omitempty"`
+	Scan        bool   `json:"scan"`
 }
 
 func talkgroupToDTO(tg *trunking.TalkGroup) *TalkgroupDTO {
@@ -64,6 +65,7 @@ func talkgroupToDTO(tg *trunking.TalkGroup) *TalkgroupDTO {
 		Mode:        tg.Mode,
 		Priority:    tg.Priority,
 		Lockout:     tg.Lockout,
+		Scan:        tg.Scan,
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,6 +19,48 @@ type Config struct {
 	Metrics    MetricsConfig    `yaml:"metrics"`
 	Retention  RetentionConfig  `yaml:"retention"`
 	ToneOut    ToneOutConfig    `yaml:"tone_out"`
+	Scanner    ScannerConfig    `yaml:"scanner"`
+}
+
+// ScannerConfig controls the police-scanner subsystems: the CC hunter,
+// the talkgroup scan-list mode, and the conventional FM scanner.
+// Empty == defaults; the daemon stays backwards compatible with
+// pre-scanner configs.
+type ScannerConfig struct {
+	// ScanMode is "all" (every non-locked-out grant is followed,
+	// the original behavior) or "list" (only TGs with Scan=true).
+	// Empty string defaults to "all". Operators can flip this at
+	// runtime from the TUI via PATCH /api/v1/scanner.
+	ScanMode string `yaml:"scan_mode"`
+	// CCHunt configures the multi-system control-channel hunter.
+	CCHunt CCHuntConfig `yaml:"cc_hunt"`
+	// Conventional is the fixed-frequency analog scan list.
+	Conventional []ConvChannelConfig `yaml:"conventional"`
+}
+
+// CCHuntConfig tunes the hunter's dwell + exponential backoff.
+type CCHuntConfig struct {
+	// Enabled defaults to true when any trunked system is configured.
+	// Set explicitly to false to ship without the hunter.
+	Enabled bool `yaml:"enabled"`
+	// DwellMs is the per-frequency wait window before declaring no
+	// lock. Defaults to 3000.
+	DwellMs int `yaml:"dwell_ms"`
+	// BackoffMs is the initial sleep after exhausting a system's CC
+	// list. Defaults to 5000. Doubles per failure up to MaxBackoffMs.
+	BackoffMs int `yaml:"backoff_ms"`
+	// MaxBackoffMs caps the exponential backoff. Defaults to 60000.
+	MaxBackoffMs int `yaml:"max_backoff_ms"`
+}
+
+// ConvChannelConfig is one entry in the conventional scan list.
+type ConvChannelConfig struct {
+	Label       string  `yaml:"label"`
+	FrequencyHz uint32  `yaml:"frequency_hz"`
+	Mode        string  `yaml:"mode"`        // "fm" | "nfm"
+	SquelchDbFS float64 `yaml:"squelch_dbfs"` // default -50
+	HangtimeMs  int     `yaml:"hangtime_ms"`  // default 1500
+	Priority    int     `yaml:"priority"`     // 1..10, 0 = unset
 }
 
 type LogConfig struct {
@@ -206,6 +248,21 @@ func (c Config) Validate() error {
 	if c.Retention.Interval != "" {
 		if _, err := parseDurationFlexible(c.Retention.Interval); err != nil {
 			return fmt.Errorf("retention.interval: %w", err)
+		}
+	}
+	switch c.Scanner.ScanMode {
+	case "", "all", "list":
+	default:
+		return fmt.Errorf("scanner.scan_mode must be \"all\" or \"list\"")
+	}
+	for i, ch := range c.Scanner.Conventional {
+		if ch.FrequencyHz == 0 {
+			return fmt.Errorf("scanner.conventional[%d]: frequency_hz required", i)
+		}
+		switch ch.Mode {
+		case "", "fm", "nfm":
+		default:
+			return fmt.Errorf("scanner.conventional[%d]: mode must be fm|nfm", i)
 		}
 	}
 	return nil

--- a/internal/events/bus.go
+++ b/internal/events/bus.go
@@ -12,16 +12,26 @@ import (
 type Kind string
 
 const (
-	KindSDRAttached Kind = "sdr.attached"
-	KindSDRDetached Kind = "sdr.detached"
-	KindCCLocked    Kind = "cc.locked"
-	KindCCLost      Kind = "cc.lost"
-	KindCallStart   Kind = "call.start"
-	KindCallEnd     Kind = "call.end"
-	KindGrant       Kind = "grant"
-	KindToneAlert   Kind = "tone.alert"
-	KindDecodeError Kind = "decode.error"
-	KindError       Kind = "error"
+	KindSDRAttached  Kind = "sdr.attached"
+	KindSDRDetached  Kind = "sdr.detached"
+	KindCCLocked     Kind = "cc.locked"
+	KindCCLost       Kind = "cc.lost"
+	KindCallStart    Kind = "call.start"
+	KindCallEnd      Kind = "call.end"
+	KindGrant        Kind = "grant"
+	KindToneAlert    Kind = "tone.alert"
+	KindDecodeError  Kind = "decode.error"
+	KindError        Kind = "error"
+	// Scanner subsystem (internal/scanner/cchunt):
+	//   KindHuntProgress fires once per CC candidate the hunter
+	//     tries — payload identifies which system + frequency +
+	//     position in the candidate list, so the TUI can render
+	//     "trying 851.012500 MHz (2/3)".
+	//   KindHuntFailed fires when a system exhausts its CC list
+	//     without locking; payload carries the next backoff window
+	//     so operators can see "retry in 5 s".
+	KindHuntProgress Kind = "cchunt.progress"
+	KindHuntFailed   Kind = "cchunt.failed"
 )
 
 // Stage names a particular FEC / parser checkpoint inside a protocol

--- a/internal/scanner/cchunt/supervisor.go
+++ b/internal/scanner/cchunt/supervisor.go
@@ -1,0 +1,557 @@
+package cchunt
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// Tuner is the subset of sdr.Device the supervisor needs. Decoupled
+// from sdr.Device so tests can substitute a fake without spinning up
+// a real driver.
+type Tuner interface {
+	SetCenterFreq(hz uint32) error
+}
+
+// Options configure a new Supervisor.
+type Options struct {
+	Bus     *events.Bus
+	Log     *slog.Logger
+	Tuner   Tuner
+	Cache   *trunking.Cache
+	Systems []trunking.System
+	// Dwell is forwarded to each Hunter.
+	Dwell time.Duration
+	// InitialBackoff is the sleep after the first hunt round that
+	// exhausts without a lock. Doubles per consecutive failure, up to
+	// MaxBackoff.
+	InitialBackoff time.Duration
+	MaxBackoff     time.Duration
+}
+
+// Supervisor multiplexes per-system trunking.Hunter runs over one
+// shared control SDR. Run blocks until ctx cancels and never returns
+// an error other than ctx.Err() — individual hunt failures are
+// reported on the bus and via Snapshot.
+type Supervisor struct {
+	bus     *events.Bus
+	log     *slog.Logger
+	tuner   Tuner
+	cache   *trunking.Cache
+	dwell   time.Duration
+	initBO  time.Duration
+	maxBO   time.Duration
+
+	mu     sync.RWMutex
+	states map[string]*systemRuntime
+	order  []string // stable iteration order for round-robin + Snapshot
+}
+
+// systemRuntime is the per-system mutable state the supervisor owns.
+// All access goes through Supervisor.mu.
+type systemRuntime struct {
+	sys      trunking.System
+	state    HuntState
+	heldByOp bool
+	// Last hunt progress (overwritten on every retune).
+	progress trunking.HuntProgress
+	// Last successful lock (carried forward across failures so the
+	// TUI can still show "was locked on X minutes ago").
+	lockedFreqHz uint32
+	lockedAt     time.Time
+	nac          uint16
+	// Failure state.
+	lastFailedAt   time.Time
+	backoffWindow  time.Duration
+	// Last grant observed (any grant whose system matches this one).
+	lastGrantAt time.Time
+	// retuneCh is non-nil while a hunt is in flight; closing it
+	// asks the in-flight Hunter to cancel its dwell and return
+	// early so the supervisor can re-hunt immediately. Only one
+	// retune may be in flight per system at a time.
+	retuneCh chan struct{}
+}
+
+// New constructs a Supervisor. Returns an error if opts.Bus or
+// opts.Tuner are missing. opts.Systems may be empty — the supervisor
+// then idles harmlessly.
+func New(opts Options) (*Supervisor, error) {
+	if opts.Bus == nil {
+		return nil, errors.New("cchunt: events.Bus is required")
+	}
+	if opts.Tuner == nil {
+		return nil, errors.New("cchunt: Tuner is required")
+	}
+	log := opts.Log
+	if log == nil {
+		log = slog.Default()
+	}
+	dwell := opts.Dwell
+	if dwell <= 0 {
+		dwell = 3 * time.Second
+	}
+	initBO := opts.InitialBackoff
+	if initBO <= 0 {
+		initBO = 5 * time.Second
+	}
+	maxBO := opts.MaxBackoff
+	if maxBO <= 0 {
+		maxBO = 60 * time.Second
+	}
+	if maxBO < initBO {
+		maxBO = initBO
+	}
+	s := &Supervisor{
+		bus:    opts.Bus,
+		log:    log,
+		tuner:  opts.Tuner,
+		cache:  opts.Cache,
+		dwell:  dwell,
+		initBO: initBO,
+		maxBO:  maxBO,
+		states: make(map[string]*systemRuntime, len(opts.Systems)),
+	}
+	for _, sys := range opts.Systems {
+		s.states[sys.Name] = &systemRuntime{
+			sys:           sys,
+			state:         StateIdle,
+			backoffWindow: initBO,
+		}
+		s.order = append(s.order, sys.Name)
+	}
+	// Stable round-robin order matches config-file order.
+	sort.SliceStable(s.order, func(i, j int) bool { return false })
+	return s, nil
+}
+
+// Run blocks until ctx cancels. It walks the configured systems in
+// round-robin order and hunts each one, sleeping per the per-system
+// backoff window on failure. Operator hold short-circuits the round
+// (the held system is skipped; the supervisor advances to the next).
+func (s *Supervisor) Run(ctx context.Context) error {
+	// Subscribe once for the whole supervisor lifetime so we can
+	// observe cc.locked / cc.lost / grant events across all systems.
+	sub := s.bus.Subscribe()
+	defer sub.Close()
+
+	// A separate goroutine drains the subscription into our state
+	// machine so the main hunt loop doesn't have to multiplex
+	// between hunting and listening on the same channel.
+	go s.listen(ctx, sub)
+
+	if len(s.order) == 0 {
+		<-ctx.Done()
+		return ctx.Err()
+	}
+
+	cursor := 0
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		name := s.order[cursor%len(s.order)]
+		cursor++
+
+		rt := s.runtime(name)
+		if rt == nil {
+			continue
+		}
+
+		// Skip held systems — they own their current state until the
+		// operator resumes them.
+		if s.isHeld(name) {
+			s.waitOrSleep(ctx, 500*time.Millisecond)
+			continue
+		}
+		// Skip systems still in backoff.
+		if remaining := s.backoffRemaining(name); remaining > 0 {
+			s.waitOrSleep(ctx, minDur(remaining, 500*time.Millisecond))
+			continue
+		}
+
+		s.startRound(name)
+		hunter, err := trunking.NewHunter(trunking.HunterOptions{
+			System: rt.sys,
+			Tuner:  s.tuner,
+			Bus:    s.bus,
+			Cache:  s.cache,
+			Log:    s.log,
+			Dwell:  s.dwell,
+		})
+		if err != nil {
+			s.log.Warn("cchunt: hunter construct failed", "system", name, "err", err)
+			s.markFailed(name)
+			continue
+		}
+
+		// Cancel the hunt if the operator forces a retune or holds
+		// us; the supervisor advances on either signal.
+		hctx, hcancel := context.WithCancel(ctx)
+		s.armRetune(name, hcancel)
+		_, herr := hunter.Hunt(hctx)
+		s.disarmRetune(name)
+		hcancel()
+
+		if herr == nil {
+			// Lock succeeded — the listen() goroutine will turn the
+			// matching cc.locked event into a StateLocked transition.
+			s.parkUntilUnlocked(ctx, name)
+			continue
+		}
+		if errors.Is(herr, context.Canceled) || errors.Is(herr, context.DeadlineExceeded) {
+			// Either the operator forced a retune (we want to loop
+			// immediately) or the daemon is shutting down.
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			continue
+		}
+		s.markFailed(name)
+	}
+}
+
+// listen drains events from the bus and updates per-system state.
+func (s *Supervisor) listen(ctx context.Context, sub *events.Subscription) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case ev, ok := <-sub.C:
+			if !ok {
+				return
+			}
+			switch ev.Kind {
+			case events.KindCCLocked:
+				lp, ok := ev.Payload.(trunking.LockedPayload)
+				if !ok {
+					continue
+				}
+				s.recordLock(lp.LockedFrequencyHz(), lp.LockedNAC())
+			case events.KindCCLost:
+				lp, _ := ev.Payload.(trunking.LockedPayload)
+				freq := uint32(0)
+				if lp != nil {
+					freq = lp.LockedFrequencyHz()
+				}
+				s.recordLost(freq)
+			case events.KindGrant:
+				g, ok := ev.Payload.(trunking.Grant)
+				if !ok {
+					continue
+				}
+				s.recordGrant(g.System, ev.Timestamp)
+			case events.KindHuntProgress:
+				p, ok := ev.Payload.(trunking.HuntProgress)
+				if !ok {
+					continue
+				}
+				s.recordProgress(p)
+			}
+		}
+	}
+}
+
+// --- runtime accessors (lock-guarded) ---
+
+func (s *Supervisor) runtime(name string) *systemRuntime {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.states[name]
+}
+
+func (s *Supervisor) startRound(name string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if rt := s.states[name]; rt != nil {
+		rt.state = StateHunting
+	}
+}
+
+func (s *Supervisor) markFailed(name string) {
+	s.mu.Lock()
+	rt := s.states[name]
+	if rt == nil {
+		s.mu.Unlock()
+		return
+	}
+	now := time.Now()
+	rt.state = StateFailed
+	rt.lastFailedAt = now
+	if rt.backoffWindow <= 0 {
+		rt.backoffWindow = s.initBO
+	}
+	wait := rt.backoffWindow
+	// Schedule next double.
+	rt.backoffWindow *= 2
+	if rt.backoffWindow > s.maxBO {
+		rt.backoffWindow = s.maxBO
+	}
+	s.mu.Unlock()
+
+	s.bus.Publish(events.Event{
+		Kind: events.KindHuntFailed,
+		Payload: trunking.HuntFailed{
+			System:    name,
+			At:        now,
+			BackoffMs: int(wait / time.Millisecond),
+		},
+	})
+}
+
+func (s *Supervisor) backoffRemaining(name string) time.Duration {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	rt := s.states[name]
+	if rt == nil || rt.state != StateFailed {
+		return 0
+	}
+	// Next attempt is allowed after lastFailedAt + the *previously*
+	// recorded wait, which we stashed in backoffWindow before
+	// doubling. To keep the math simple we don't track it
+	// separately; instead use the current window (already doubled)
+	// halved — works for round 2+; round 1 uses initBO.
+	wait := rt.backoffWindow / 2
+	if wait < s.initBO {
+		wait = s.initBO
+	}
+	elapsed := time.Since(rt.lastFailedAt)
+	if elapsed >= wait {
+		return 0
+	}
+	return wait - elapsed
+}
+
+func (s *Supervisor) recordLock(freqHz uint32, nac uint16) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, rt := range s.states {
+		for _, cc := range rt.sys.ControlChannels {
+			if cc == freqHz {
+				rt.state = StateLocked
+				rt.lockedFreqHz = freqHz
+				rt.lockedAt = time.Now()
+				rt.nac = nac
+				rt.backoffWindow = s.initBO // reset on success
+				return
+			}
+		}
+	}
+}
+
+func (s *Supervisor) recordLost(freqHz uint32) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, rt := range s.states {
+		if rt.lockedFreqHz == freqHz || (freqHz == 0 && rt.state == StateLocked) {
+			rt.state = StateHunting
+			rt.lockedFreqHz = 0
+		}
+	}
+}
+
+func (s *Supervisor) recordProgress(p trunking.HuntProgress) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if rt := s.states[p.System]; rt != nil {
+		rt.progress = p
+	}
+}
+
+func (s *Supervisor) recordGrant(system string, at time.Time) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if rt := s.states[system]; rt != nil {
+		rt.lastGrantAt = at
+	}
+}
+
+func (s *Supervisor) armRetune(name string, cancel context.CancelFunc) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if rt := s.states[name]; rt != nil {
+		ch := make(chan struct{})
+		rt.retuneCh = ch
+		go func() {
+			<-ch
+			cancel()
+		}()
+	}
+}
+
+func (s *Supervisor) disarmRetune(name string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if rt := s.states[name]; rt != nil && rt.retuneCh != nil {
+		// Closing here is benign if the consumer already fired the
+		// cancel; the goroutine guards against double-close because
+		// we replace retuneCh with nil after this.
+		select {
+		case <-rt.retuneCh:
+		default:
+			close(rt.retuneCh)
+		}
+		rt.retuneCh = nil
+	}
+}
+
+func (s *Supervisor) parkUntilUnlocked(ctx context.Context, name string) {
+	// Wait until the system transitions out of StateLocked (the
+	// listen() goroutine flips it on cc.lost) OR until ctx cancels.
+	t := time.NewTicker(250 * time.Millisecond)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			s.mu.RLock()
+			rt := s.states[name]
+			locked := rt != nil && rt.state == StateLocked && !rt.heldByOp
+			s.mu.RUnlock()
+			if !locked {
+				return
+			}
+		}
+	}
+}
+
+func (s *Supervisor) waitOrSleep(ctx context.Context, d time.Duration) {
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+	case <-t.C:
+	}
+}
+
+func (s *Supervisor) isHeld(name string) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	rt := s.states[name]
+	return rt != nil && rt.heldByOp
+}
+
+// --- operator mutation surface ---
+
+// Hold pins the supervisor on the named system's current state — no
+// further retunes happen until Resume. Returns false if the system
+// isn't configured.
+func (s *Supervisor) Hold(name string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	rt := s.states[name]
+	if rt == nil {
+		return false
+	}
+	rt.heldByOp = true
+	// Remember the held variant of whatever state we were in so the
+	// Snapshot still surfaces "locked + held" or "failed + held"
+	// rather than a generic "held" with no context.
+	rt.state = StateHeld
+	return true
+}
+
+// Resume undoes Hold. The next Run iteration picks the system back up
+// in the next round-robin slot.
+func (s *Supervisor) Resume(name string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	rt := s.states[name]
+	if rt == nil {
+		return false
+	}
+	rt.heldByOp = false
+	rt.state = StateIdle
+	rt.backoffWindow = s.initBO
+	return true
+}
+
+// ForceRetune asks the in-flight Hunter (if any) for the named system
+// to bail out so the next round picks it up immediately. If no hunt
+// is in flight (e.g. the system is in backoff) it clears the backoff
+// so the next round restarts the hunt.
+func (s *Supervisor) ForceRetune(name string) bool {
+	s.mu.Lock()
+	rt := s.states[name]
+	if rt == nil {
+		s.mu.Unlock()
+		return false
+	}
+	rt.lastFailedAt = time.Time{} // clear backoff
+	rt.backoffWindow = s.initBO
+	rt.state = StateIdle
+	ch := rt.retuneCh
+	rt.retuneCh = nil
+	s.mu.Unlock()
+	if ch != nil {
+		select {
+		case <-ch:
+		default:
+			close(ch)
+		}
+	}
+	return true
+}
+
+// Snapshot returns a copy of every system's current status. Safe to
+// call concurrently with Run.
+func (s *Supervisor) Snapshot() []SystemStatus {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]SystemStatus, 0, len(s.order))
+	for _, name := range s.order {
+		rt := s.states[name]
+		if rt == nil {
+			continue
+		}
+		st := SystemStatus{
+			Name:            rt.sys.Name,
+			Protocol:        rt.sys.Protocol.String(),
+			State:           rt.state,
+			AttemptedFreqHz: rt.progress.AttemptedFreqHz,
+			AttemptIndex:    rt.progress.AttemptIndex,
+			TotalCandidates: rt.progress.TotalCandidates,
+			LockedFreqHz:    rt.lockedFreqHz,
+			LockedAt:        rt.lockedAt,
+			NAC:             rt.nac,
+			LastFailedAt:    rt.lastFailedAt,
+			LastGrantAt:     rt.lastGrantAt,
+		}
+		if rt.state == StateFailed {
+			// Surface the wait window so the TUI can render
+			// "retry in 5 s".
+			rem := s.backoffRemainingLocked(rt)
+			st.BackoffMs = int(rem / time.Millisecond)
+		}
+		out = append(out, st)
+	}
+	return out
+}
+
+func (s *Supervisor) backoffRemainingLocked(rt *systemRuntime) time.Duration {
+	if rt.state != StateFailed {
+		return 0
+	}
+	wait := rt.backoffWindow / 2
+	if wait < s.initBO {
+		wait = s.initBO
+	}
+	elapsed := time.Since(rt.lastFailedAt)
+	if elapsed >= wait {
+		return 0
+	}
+	return wait - elapsed
+}
+
+func minDur(a, b time.Duration) time.Duration {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/internal/scanner/cchunt/supervisor_test.go
+++ b/internal/scanner/cchunt/supervisor_test.go
@@ -1,0 +1,220 @@
+package cchunt
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// fakeTuner records every SetCenterFreq call.
+type fakeTuner struct {
+	mu     sync.Mutex
+	calls  []uint32
+	err    error
+}
+
+func (f *fakeTuner) SetCenterFreq(hz uint32) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, hz)
+	return f.err
+}
+
+func (f *fakeTuner) tuned() []uint32 {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]uint32, len(f.calls))
+	copy(out, f.calls)
+	return out
+}
+
+// fakeLock is a payload satisfying trunking.LockedPayload so the
+// supervisor's listen() goroutine accepts our synthetic cc.locked.
+type fakeLock struct {
+	freq uint32
+	nac  uint16
+}
+
+func (f fakeLock) LockedFrequencyHz() uint32 { return f.freq }
+func (f fakeLock) LockedNAC() uint16          { return f.nac }
+
+func TestSupervisorFailsClosedWhenNothingLocks(t *testing.T) {
+	bus := events.NewBus(32)
+	defer bus.Close()
+	tuner := &fakeTuner{}
+	sys := trunking.System{
+		Name:            "Demo",
+		Protocol:        trunking.ProtocolP25,
+		ControlChannels: []uint32{851_000_000, 852_000_000},
+	}
+	sup, err := New(Options{
+		Bus:            bus,
+		Tuner:          tuner,
+		Systems:        []trunking.System{sys},
+		Dwell:          50 * time.Millisecond,
+		InitialBackoff: 50 * time.Millisecond,
+		MaxBackoff:     200 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Capture HuntFailed events.
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() { _ = sup.Run(ctx) }()
+
+	// Wait until we see KindHuntFailed for the Demo system.
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind == events.KindHuntFailed {
+				if f, ok := ev.Payload.(trunking.HuntFailed); ok && f.System == "Demo" {
+					cancel()
+					// Drain remaining events briefly so the goroutine exits.
+					done := make(chan struct{})
+					go func() { time.Sleep(100 * time.Millisecond); close(done) }()
+					<-done
+					if calls := tuner.tuned(); len(calls) < 2 {
+						t.Errorf("tuner saw %d retunes, want at least 2 (both CCs)", len(calls))
+					}
+					snap := sup.Snapshot()
+					if len(snap) != 1 || snap[0].Name != "Demo" {
+						t.Fatalf("snapshot = %+v", snap)
+					}
+					if snap[0].State != StateFailed {
+						t.Errorf("snapshot state = %q, want failed", snap[0].State)
+					}
+					return
+				}
+			}
+		case <-deadline:
+			cancel()
+			t.Fatal("never saw KindHuntFailed for Demo")
+		}
+	}
+}
+
+func TestSupervisorLocksAndParks(t *testing.T) {
+	bus := events.NewBus(32)
+	defer bus.Close()
+	tuner := &fakeTuner{}
+	sys := trunking.System{
+		Name:            "Locks",
+		Protocol:        trunking.ProtocolP25,
+		ControlChannels: []uint32{851_000_000, 852_000_000},
+	}
+	sup, err := New(Options{
+		Bus:            bus,
+		Tuner:          tuner,
+		Systems:        []trunking.System{sys},
+		Dwell:          200 * time.Millisecond,
+		InitialBackoff: 50 * time.Millisecond,
+		MaxBackoff:     100 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = sup.Run(ctx) }()
+
+	// Give the supervisor a moment to start hunting, then publish a
+	// cc.locked for the second candidate.
+	time.Sleep(80 * time.Millisecond)
+	bus.Publish(events.Event{
+		Kind:    events.KindCCLocked,
+		Payload: fakeLock{freq: 852_000_000, nac: 0xBEEF},
+	})
+
+	// Snapshot should report StateLocked within the dwell window.
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		snap := sup.Snapshot()
+		if len(snap) == 1 && snap[0].State == StateLocked && snap[0].LockedFreqHz == 852_000_000 {
+			if snap[0].NAC != 0xBEEF {
+				t.Errorf("NAC = %X, want BEEF", snap[0].NAC)
+			}
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("snapshot never reached StateLocked: %+v", sup.Snapshot())
+}
+
+func TestSupervisorHoldAndResume(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sup, err := New(Options{
+		Bus:     bus,
+		Tuner:   &fakeTuner{},
+		Systems: []trunking.System{{Name: "H", Protocol: trunking.ProtocolP25, ControlChannels: []uint32{1}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !sup.Hold("H") {
+		t.Fatal("Hold('H') = false")
+	}
+	if got := sup.Snapshot()[0].State; got != StateHeld {
+		t.Errorf("state after Hold = %q, want held", got)
+	}
+	if sup.Hold("missing") {
+		t.Errorf("Hold('missing') = true, want false")
+	}
+	if !sup.Resume("H") {
+		t.Fatal("Resume('H') = false")
+	}
+	if got := sup.Snapshot()[0].State; got != StateIdle {
+		t.Errorf("state after Resume = %q, want idle", got)
+	}
+}
+
+func TestSupervisorForceRetuneClearsBackoff(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sup, err := New(Options{
+		Bus:     bus,
+		Tuner:   &fakeTuner{},
+		Systems: []trunking.System{{Name: "R", Protocol: trunking.ProtocolP25, ControlChannels: []uint32{1}}},
+		InitialBackoff: time.Hour,
+		MaxBackoff:     time.Hour,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Mark as failed with a long backoff.
+	sup.markFailed("R")
+	if sup.backoffRemaining("R") <= 0 {
+		t.Fatal("expected non-zero backoff after markFailed")
+	}
+	if !sup.ForceRetune("R") {
+		t.Fatal("ForceRetune('R') = false")
+	}
+	if sup.backoffRemaining("R") > 0 {
+		t.Errorf("backoff not cleared after ForceRetune")
+	}
+}
+
+func TestSupervisorRunReturnsCtxErr(t *testing.T) {
+	bus := events.NewBus(4)
+	defer bus.Close()
+	sup, err := New(Options{Bus: bus, Tuner: &fakeTuner{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	got := sup.Run(ctx)
+	if got != context.DeadlineExceeded {
+		t.Errorf("Run() = %v, want context.DeadlineExceeded", got)
+	}
+}

--- a/internal/scanner/cchunt/types.go
+++ b/internal/scanner/cchunt/types.go
@@ -1,0 +1,63 @@
+// Package cchunt is the multi-system control-channel scanner.
+//
+// The supervisor owns one control SDR and multiplexes
+// `trunking.Hunter` runs across every configured trunked system. On
+// success a system parks until cc.lost; on failure the supervisor
+// exponentially backs off, publishes KindHuntFailed, and advances to
+// the next system. Operators can hold a system on its current lock,
+// resume the loop, or force a re-hunt — these mutation surfaces are
+// exposed through the API cockpit and the TUI Scanner panel.
+//
+// This package is the orchestration layer only. It does not produce
+// `cc.locked` events itself — those must come from the IQ-domain
+// protocol decoders (P25 / DMR / NXDN / YSF / ...). Without those
+// upstream feeders the supervisor will always exhaust the candidate
+// list and report failed; that's intentional, not a bug. See the
+// README "Roadmap" / "Known gaps" sections for the broader
+// IQ-domain decoder dependency.
+package cchunt
+
+import "time"
+
+// HuntState is the per-system status surfaced through the REST cockpit
+// + TUI. It maps onto a small set of user-facing words rather than
+// the raw supervisor internals.
+type HuntState string
+
+const (
+	// StateIdle means the supervisor hasn't run for this system yet
+	// (only seen briefly at startup before the first hunt round).
+	StateIdle HuntState = "idle"
+	// StateHunting means the supervisor is actively walking the
+	// system's candidate CCs.
+	StateHunting HuntState = "hunting"
+	// StateLocked means a hunt succeeded — a cc.locked event was
+	// observed within the dwell window and persisted to the cache.
+	StateLocked HuntState = "locked"
+	// StateFailed means the last hunt round exhausted without a
+	// lock; the supervisor is in backoff before retrying.
+	StateFailed HuntState = "failed"
+	// StateHeld means the operator pinned the supervisor on its
+	// current lock (or on its current failed state) — retunes are
+	// suppressed until Resume.
+	StateHeld HuntState = "held"
+)
+
+// SystemStatus is the per-system snapshot the supervisor exposes to
+// the REST handler (and indirectly to the TUI cockpit panel).
+// Time-valued fields are zero when not applicable (e.g. LockedAt is
+// zero before the first successful hunt).
+type SystemStatus struct {
+	Name            string    `json:"name"`
+	Protocol        string    `json:"protocol"`
+	State           HuntState `json:"state"`
+	AttemptedFreqHz uint32    `json:"attempted_freq_hz,omitempty"`
+	AttemptIndex    int       `json:"attempt_index,omitempty"`
+	TotalCandidates int       `json:"total_candidates,omitempty"`
+	LockedFreqHz    uint32    `json:"locked_freq_hz,omitempty"`
+	LockedAt        time.Time `json:"locked_at,omitempty"`
+	NAC             uint16    `json:"nac,omitempty"`
+	LastFailedAt    time.Time `json:"last_failed_at,omitempty"`
+	BackoffMs       int       `json:"backoff_ms,omitempty"`
+	LastGrantAt     time.Time `json:"last_grant_at,omitempty"`
+}

--- a/internal/scanner/conventional/scanner.go
+++ b/internal/scanner/conventional/scanner.go
@@ -1,0 +1,416 @@
+package conventional
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// Channel is one entry in the conventional scan list.
+type Channel struct {
+	Label       string
+	FrequencyHz uint32
+	// Mode is "fm" or "nfm" — the latter narrows the post-demod
+	// audio LPF; both share the IQ-power squelch.
+	Mode string
+	// SquelchDbFS is the threshold above which the scanner declares
+	// "carrier present". A typical value for an RTL-SDR-class
+	// receiver is around -50 dBFS; tune per channel as needed.
+	SquelchDbFS float64
+	// Hangtime is how long below threshold must elapse before the
+	// scanner declares the call over and resumes hopping. Default
+	// 1500 ms keeps the scanner from clipping the tail of normal
+	// FM transmissions.
+	Hangtime time.Duration
+	// Priority is forwarded to the synthetic talkgroup so the
+	// engine's preemption logic respects it relative to other
+	// conv-scanner channels.
+	Priority int
+}
+
+// Tuner is the subset of sdr.Device the scanner needs.
+type Tuner interface {
+	SetCenterFreq(hz uint32) error
+}
+
+// IQSource provides the IQ stream the scanner consumes for both
+// squelch detection and (downstream) recorder integration. The
+// scanner cancels and re-opens the stream every tune to drop any
+// in-flight samples from the previous channel.
+type IQSource interface {
+	StreamIQ(ctx context.Context) (<-chan []complex64, error)
+}
+
+// Engine is the subset of trunking.Engine the scanner needs. Only
+// the synthetic-call entry points; this keeps tests trivial without
+// constructing a full Engine.
+type Engine interface {
+	HandleSyntheticCall(g trunking.Grant, deviceSerial string)
+	EndSyntheticCall(deviceSerial string, reason trunking.EndReason) bool
+	Touch(deviceSerial string)
+}
+
+// Recorder is the subset of voice.Recorder the scanner feeds. The
+// real recorder accepts WritePCM by device serial; tests can stub
+// with a noop.
+type Recorder interface {
+	WritePCM(deviceSerial string, samples []int16) error
+}
+
+// Options configure the conventional scanner.
+type Options struct {
+	Log          *slog.Logger
+	Tuner        Tuner
+	IQ           IQSource
+	Engine       Engine
+	Recorder     Recorder
+	DeviceSerial string
+	SystemName   string // surfaces on the synthetic Grant.System
+	Channels     []Channel
+	// DwellChunkLen is the IQ-power measurement window in samples
+	// during SCANNING. Default 4096 (≈ 1.7 ms at 2.4 MS/s).
+	DwellChunkLen int
+	// MinDwellPerChannel is the minimum time on each channel during
+	// SCANNING before advancing — even if squelch never opens. Default
+	// 100 ms; let signals settle after retune.
+	MinDwellPerChannel time.Duration
+	// Now is injectable for tests; defaults to time.Now.
+	Now func() time.Time
+}
+
+// State is the high-level scanner state surfaced through Snapshot.
+type State string
+
+const (
+	StateScanning State = "scanning"
+	StateDwell    State = "dwell"
+	StateHeld     State = "held"
+)
+
+// ChannelStatus is one row in the Snapshot.
+type ChannelStatus struct {
+	Index       int       `json:"index"`
+	Label       string    `json:"label"`
+	FrequencyHz uint32    `json:"frequency_hz"`
+	Mode        string    `json:"mode"`
+	Active      bool      `json:"active"`
+	LastBreakAt time.Time `json:"last_break_at,omitempty"`
+}
+
+// Status is the scanner-wide snapshot.
+type Status struct {
+	State       State           `json:"state"`
+	Channels    []ChannelStatus `json:"channels"`
+	CursorIndex int             `json:"cursor_index"`
+	DeviceSerial string         `json:"device_serial,omitempty"`
+}
+
+// Scanner is the state machine. Construct via New, Run with a ctx.
+type Scanner struct {
+	opts Options
+	log  *slog.Logger
+
+	mu          sync.RWMutex
+	cursor      int
+	state       State
+	held        bool
+	lastBreakAt []time.Time
+	// dwellIndex is the channel index currently dwelling (when
+	// state == StateDwell); -1 otherwise. Operator hold and
+	// "dwell on N" mutations write through this field.
+	dwellIndex int
+	// forcedDwellIndex is set by DwellOn — the next round picks this
+	// channel up directly, bypassing the scan cursor.
+	forcedDwellIndex int
+}
+
+// New constructs a Scanner. Channels must be non-empty.
+func New(opts Options) (*Scanner, error) {
+	if opts.Engine == nil {
+		return nil, errors.New("conventional: Engine is required")
+	}
+	if opts.Tuner == nil {
+		return nil, errors.New("conventional: Tuner is required")
+	}
+	if opts.IQ == nil {
+		return nil, errors.New("conventional: IQSource is required")
+	}
+	if opts.Recorder == nil {
+		return nil, errors.New("conventional: Recorder is required")
+	}
+	if len(opts.Channels) == 0 {
+		return nil, errors.New("conventional: at least one channel is required")
+	}
+	if opts.DeviceSerial == "" {
+		return nil, errors.New("conventional: DeviceSerial is required")
+	}
+	if opts.DwellChunkLen <= 0 {
+		opts.DwellChunkLen = 4096
+	}
+	if opts.MinDwellPerChannel <= 0 {
+		opts.MinDwellPerChannel = 100 * time.Millisecond
+	}
+	if opts.Now == nil {
+		opts.Now = time.Now
+	}
+	if opts.Log == nil {
+		opts.Log = slog.Default()
+	}
+	// Apply per-channel defaults.
+	for i := range opts.Channels {
+		ch := &opts.Channels[i]
+		if ch.SquelchDbFS == 0 {
+			ch.SquelchDbFS = -50
+		}
+		if ch.Hangtime <= 0 {
+			ch.Hangtime = 1500 * time.Millisecond
+		}
+		if ch.Mode == "" {
+			ch.Mode = "fm"
+		}
+	}
+	return &Scanner{
+		opts:             opts,
+		log:              opts.Log,
+		state:            StateScanning,
+		dwellIndex:       -1,
+		forcedDwellIndex: -1,
+		lastBreakAt:      make([]time.Time, len(opts.Channels)),
+	}, nil
+}
+
+// Run blocks until ctx cancels. Tunes, measures squelch, hands off
+// to the engine on break, and resumes scanning after hangtime.
+// Returns ctx.Err() on shutdown.
+func (s *Scanner) Run(ctx context.Context) error {
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if s.IsHeld() {
+			s.sleep(ctx, 100*time.Millisecond)
+			continue
+		}
+		idx := s.nextChannel()
+		ch := s.opts.Channels[idx]
+
+		if err := s.opts.Tuner.SetCenterFreq(ch.FrequencyHz); err != nil {
+			s.log.Warn("conv: tune failed", "freq_hz", ch.FrequencyHz, "err", err)
+			s.sleep(ctx, 100*time.Millisecond)
+			continue
+		}
+
+		// Open the IQ stream for this dwell. We close it on advance.
+		streamCtx, cancel := context.WithCancel(ctx)
+		stream, err := s.opts.IQ.StreamIQ(streamCtx)
+		if err != nil {
+			cancel()
+			s.log.Warn("conv: StreamIQ failed", "err", err)
+			s.sleep(ctx, 200*time.Millisecond)
+			continue
+		}
+
+		// Wait for either squelch to break, the min-dwell timer to
+		// expire (advance), or ctx cancel.
+		broken := s.scanWindow(ctx, idx, ch, stream)
+		if !broken {
+			cancel()
+			continue
+		}
+
+		// Squelch is open — hand off to the engine and stay on this
+		// channel feeding PCM through the recorder until hangtime.
+		s.beginDwell(idx, ch, stream, streamCtx, cancel)
+	}
+}
+
+// scanWindow returns true when squelch opens within MinDwellPerChannel,
+// false when the timer expires (advance to next channel).
+func (s *Scanner) scanWindow(ctx context.Context, idx int, ch Channel, stream <-chan []complex64) bool {
+	deadline := time.NewTimer(s.opts.MinDwellPerChannel)
+	defer deadline.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return false
+		case <-deadline.C:
+			return false
+		case iq, ok := <-stream:
+			if !ok {
+				return false
+			}
+			if PowerDbFS(iq) >= ch.SquelchDbFS {
+				return true
+			}
+		}
+	}
+}
+
+// beginDwell takes the open IQ stream, announces a synthetic call
+// via the engine, and stays on the channel feeding PCM to the
+// recorder until hangtime silence is observed. Returns after
+// publishing CallEnd.
+func (s *Scanner) beginDwell(idx int, ch Channel, stream <-chan []complex64, streamCtx context.Context, cancel context.CancelFunc) {
+	defer cancel()
+
+	now := s.opts.Now()
+	s.mu.Lock()
+	s.state = StateDwell
+	s.dwellIndex = idx
+	s.lastBreakAt[idx] = now
+	s.mu.Unlock()
+
+	// Synthesize a Grant. GroupID is derived from the channel index
+	// so each conv channel surfaces as a distinct talkgroup in the
+	// API + call log; bit 31 set so it can't collide with a real
+	// trunked GroupID (which are 24/28-bit fields in practice).
+	gid := uint32(0x80000000) | uint32(idx)
+	g := trunking.Grant{
+		System:      s.opts.SystemName,
+		Protocol:    "fm-conv",
+		GroupID:     gid,
+		SourceID:    0,
+		FrequencyHz: ch.FrequencyHz,
+		At:          now,
+	}
+	s.opts.Engine.HandleSyntheticCall(g, s.opts.DeviceSerial)
+
+	// Carrier-drop detection: keep reading IQ; track time below
+	// threshold. Touch the engine watchdog on each chunk so it
+	// doesn't time the call out prematurely. We DON'T run a real
+	// FM-demod chain here — that's a follow-up. For now the
+	// recorder gets a silent WAV that documents the carrier-active
+	// window, which is enough to validate the integration.
+	belowSince := time.Time{}
+	ticker := time.NewTicker(250 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-streamCtx.Done():
+			s.endDwell(idx, trunking.EndReasonError)
+			return
+		case <-ticker.C:
+			s.opts.Engine.Touch(s.opts.DeviceSerial)
+		case iq, ok := <-stream:
+			if !ok {
+				s.endDwell(idx, trunking.EndReasonError)
+				return
+			}
+			power := PowerDbFS(iq)
+			if power >= ch.SquelchDbFS {
+				belowSince = time.Time{}
+			} else if belowSince.IsZero() {
+				belowSince = s.opts.Now()
+			} else if s.opts.Now().Sub(belowSince) >= ch.Hangtime {
+				s.endDwell(idx, trunking.EndReasonNormal)
+				return
+			}
+		}
+	}
+}
+
+func (s *Scanner) endDwell(idx int, reason trunking.EndReason) {
+	s.opts.Engine.EndSyntheticCall(s.opts.DeviceSerial, reason)
+	s.mu.Lock()
+	if s.dwellIndex == idx {
+		s.state = StateScanning
+		s.dwellIndex = -1
+	}
+	s.mu.Unlock()
+}
+
+// nextChannel returns the index of the next channel to tune,
+// respecting any forced-dwell override from DwellOn.
+func (s *Scanner) nextChannel() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.forcedDwellIndex >= 0 && s.forcedDwellIndex < len(s.opts.Channels) {
+		idx := s.forcedDwellIndex
+		s.forcedDwellIndex = -1
+		s.cursor = (idx + 1) % len(s.opts.Channels)
+		return idx
+	}
+	idx := s.cursor
+	s.cursor = (s.cursor + 1) % len(s.opts.Channels)
+	return idx
+}
+
+func (s *Scanner) sleep(ctx context.Context, d time.Duration) {
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+	case <-t.C:
+	}
+}
+
+// --- operator mutation surface ---
+
+// Hold pins the scanner on its current channel (in StateDwell) or
+// pauses scanning (in StateScanning). The held state persists until
+// Resume.
+func (s *Scanner) Hold() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.held = true
+	s.state = StateHeld
+}
+
+// Resume undoes Hold. The next Run iteration picks scanning back up.
+func (s *Scanner) Resume() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.held = false
+	if s.dwellIndex >= 0 {
+		s.state = StateDwell
+	} else {
+		s.state = StateScanning
+	}
+}
+
+// IsHeld reports whether the scanner is currently held.
+func (s *Scanner) IsHeld() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.held
+}
+
+// DwellOn asks the scanner to advance to the named channel on the
+// next round. Returns false if idx is out of range.
+func (s *Scanner) DwellOn(idx int) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if idx < 0 || idx >= len(s.opts.Channels) {
+		return false
+	}
+	s.forcedDwellIndex = idx
+	return true
+}
+
+// Snapshot returns a copy of the current scanner state for the
+// REST cockpit / TUI panel.
+func (s *Scanner) Snapshot() Status {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	channels := make([]ChannelStatus, len(s.opts.Channels))
+	for i, ch := range s.opts.Channels {
+		channels[i] = ChannelStatus{
+			Index:       i,
+			Label:       ch.Label,
+			FrequencyHz: ch.FrequencyHz,
+			Mode:        ch.Mode,
+			Active:      i == s.dwellIndex,
+			LastBreakAt: s.lastBreakAt[i],
+		}
+	}
+	return Status{
+		State:        s.state,
+		Channels:     channels,
+		CursorIndex:  s.cursor,
+		DeviceSerial: s.opts.DeviceSerial,
+	}
+}

--- a/internal/scanner/conventional/scanner_test.go
+++ b/internal/scanner/conventional/scanner_test.go
@@ -1,0 +1,278 @@
+package conventional
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+type fakeTuner struct {
+	mu    sync.Mutex
+	calls []uint32
+}
+
+func (f *fakeTuner) SetCenterFreq(hz uint32) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, hz)
+	return nil
+}
+
+func (f *fakeTuner) tuned() []uint32 {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]uint32, len(f.calls))
+	copy(out, f.calls)
+	return out
+}
+
+// fakeIQ emits the supplied chunks per-channel keyed by frequency.
+// When a frequency runs out of chunks it sends silence (zero IQ).
+type fakeIQ struct {
+	mu     sync.Mutex
+	chunks map[uint32][][]complex64
+	last   uint32
+	tuner  *fakeTuner
+}
+
+func (f *fakeIQ) StreamIQ(ctx context.Context) (<-chan []complex64, error) {
+	out := make(chan []complex64, 8)
+	go func() {
+		defer close(out)
+		// Look up the most recent SetCenterFreq call to know which
+		// frequency to source samples from.
+		ticker := time.NewTicker(2 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				f.mu.Lock()
+				if f.tuner != nil {
+					f.tuner.mu.Lock()
+					if len(f.tuner.calls) > 0 {
+						f.last = f.tuner.calls[len(f.tuner.calls)-1]
+					}
+					f.tuner.mu.Unlock()
+				}
+				queue := f.chunks[f.last]
+				var chunk []complex64
+				if len(queue) > 0 {
+					chunk = queue[0]
+					f.chunks[f.last] = queue[1:]
+				} else {
+					// Silence.
+					chunk = make([]complex64, 256)
+				}
+				f.mu.Unlock()
+				select {
+				case <-ctx.Done():
+					return
+				case out <- chunk:
+				}
+			}
+		}
+	}()
+	return out, nil
+}
+
+type fakeEngine struct {
+	mu       sync.Mutex
+	starts   []trunking.Grant
+	ends     []string
+	touches  int
+}
+
+func (e *fakeEngine) HandleSyntheticCall(g trunking.Grant, deviceSerial string) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.starts = append(e.starts, g)
+}
+func (e *fakeEngine) EndSyntheticCall(deviceSerial string, reason trunking.EndReason) bool {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.ends = append(e.ends, deviceSerial)
+	return true
+}
+func (e *fakeEngine) Touch(deviceSerial string) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.touches++
+}
+func (e *fakeEngine) startCount() int {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return len(e.starts)
+}
+func (e *fakeEngine) endCount() int {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return len(e.ends)
+}
+
+type fakeRecorder struct{}
+
+func (fakeRecorder) WritePCM(_ string, _ []int16) error { return nil }
+
+func loudChunk(n int) []complex64 {
+	out := make([]complex64, n)
+	for i := range out {
+		out[i] = complex(0.7, 0.7)
+	}
+	return out
+}
+
+func TestConvScannerHopsThroughEmptyChannels(t *testing.T) {
+	tuner := &fakeTuner{}
+	iq := &fakeIQ{chunks: map[uint32][][]complex64{}, tuner: tuner}
+	eng := &fakeEngine{}
+	s, err := New(Options{
+		Tuner: tuner, IQ: iq, Engine: eng, Recorder: fakeRecorder{},
+		DeviceSerial: "CONV-1",
+		SystemName:   "test",
+		Channels: []Channel{
+			{Label: "A", FrequencyHz: 100_000_000, SquelchDbFS: -10},
+			{Label: "B", FrequencyHz: 200_000_000, SquelchDbFS: -10},
+			{Label: "C", FrequencyHz: 300_000_000, SquelchDbFS: -10},
+		},
+		MinDwellPerChannel: 30 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	_ = s.Run(ctx)
+
+	calls := tuner.tuned()
+	if len(calls) < 3 {
+		t.Fatalf("expected at least 3 tune calls in 500ms, got %d", len(calls))
+	}
+	// All three frequencies should appear in the hop sequence.
+	seen := map[uint32]bool{}
+	for _, hz := range calls {
+		seen[hz] = true
+	}
+	if !seen[100_000_000] || !seen[200_000_000] || !seen[300_000_000] {
+		t.Errorf("hop sequence missing channels: %v", calls)
+	}
+	if eng.startCount() != 0 {
+		t.Errorf("no squelch break should fire on silence; saw %d starts", eng.startCount())
+	}
+}
+
+func TestConvScannerBreaksSquelchAndEndsOnHangtime(t *testing.T) {
+	tuner := &fakeTuner{}
+	// Channel B (200 MHz) emits N loud chunks then silence; A and C
+	// stay silent. Hangtime is short for test speed.
+	iq := &fakeIQ{
+		tuner: tuner,
+		chunks: map[uint32][][]complex64{
+			200_000_000: {
+				loudChunk(256), loudChunk(256), loudChunk(256),
+			},
+		},
+	}
+	eng := &fakeEngine{}
+	s, err := New(Options{
+		Tuner: tuner, IQ: iq, Engine: eng, Recorder: fakeRecorder{},
+		DeviceSerial: "CONV-1",
+		SystemName:   "test",
+		Channels: []Channel{
+			{Label: "A", FrequencyHz: 100_000_000, SquelchDbFS: -10},
+			{Label: "B", FrequencyHz: 200_000_000, SquelchDbFS: -10, Hangtime: 50 * time.Millisecond},
+			{Label: "C", FrequencyHz: 300_000_000, SquelchDbFS: -10},
+		},
+		MinDwellPerChannel: 30 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	_ = s.Run(ctx)
+
+	if eng.startCount() == 0 {
+		t.Fatal("squelch never fired (no HandleSyntheticCall)")
+	}
+	if eng.endCount() == 0 {
+		t.Fatal("hangtime never expired (no EndSyntheticCall)")
+	}
+	// First start's frequency must match channel B.
+	if eng.starts[0].FrequencyHz != 200_000_000 {
+		t.Errorf("first start freq = %d, want 200_000_000", eng.starts[0].FrequencyHz)
+	}
+	if eng.starts[0].Protocol != "fm-conv" {
+		t.Errorf("protocol = %q, want fm-conv", eng.starts[0].Protocol)
+	}
+}
+
+func TestConvScannerHoldAndResume(t *testing.T) {
+	s, err := New(Options{
+		Tuner: &fakeTuner{}, IQ: &fakeIQ{tuner: &fakeTuner{}}, Engine: &fakeEngine{}, Recorder: fakeRecorder{},
+		DeviceSerial: "CONV-1",
+		Channels:     []Channel{{Label: "A", FrequencyHz: 1, SquelchDbFS: -10}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.Hold()
+	if !s.IsHeld() {
+		t.Error("IsHeld() = false after Hold()")
+	}
+	if got := s.Snapshot().State; got != StateHeld {
+		t.Errorf("state = %q, want held", got)
+	}
+	s.Resume()
+	if s.IsHeld() {
+		t.Error("IsHeld() = true after Resume()")
+	}
+}
+
+func TestConvScannerDwellOn(t *testing.T) {
+	s, err := New(Options{
+		Tuner: &fakeTuner{}, IQ: &fakeIQ{tuner: &fakeTuner{}}, Engine: &fakeEngine{}, Recorder: fakeRecorder{},
+		DeviceSerial: "CONV-1",
+		Channels: []Channel{
+			{Label: "A", FrequencyHz: 1, SquelchDbFS: -10},
+			{Label: "B", FrequencyHz: 2, SquelchDbFS: -10},
+			{Label: "C", FrequencyHz: 3, SquelchDbFS: -10},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !s.DwellOn(2) {
+		t.Fatal("DwellOn(2) = false")
+	}
+	if s.DwellOn(99) {
+		t.Errorf("DwellOn(99) should fail")
+	}
+	// Next call to nextChannel must return 2.
+	if idx := s.nextChannel(); idx != 2 {
+		t.Errorf("nextChannel after DwellOn(2) = %d, want 2", idx)
+	}
+}
+
+func TestConvScannerRejectsBadConfig(t *testing.T) {
+	cases := []struct {
+		name string
+		opts Options
+	}{
+		{"no engine", Options{Tuner: &fakeTuner{}, IQ: &fakeIQ{}, Recorder: fakeRecorder{}, DeviceSerial: "x", Channels: []Channel{{FrequencyHz: 1}}}},
+		{"no tuner", Options{Engine: &fakeEngine{}, IQ: &fakeIQ{}, Recorder: fakeRecorder{}, DeviceSerial: "x", Channels: []Channel{{FrequencyHz: 1}}}},
+		{"no channels", Options{Engine: &fakeEngine{}, Tuner: &fakeTuner{}, IQ: &fakeIQ{}, Recorder: fakeRecorder{}, DeviceSerial: "x"}},
+		{"no device serial", Options{Engine: &fakeEngine{}, Tuner: &fakeTuner{}, IQ: &fakeIQ{}, Recorder: fakeRecorder{}, Channels: []Channel{{FrequencyHz: 1}}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := New(tc.opts); err == nil {
+				t.Errorf("expected error for %s", tc.name)
+			}
+		})
+	}
+}

--- a/internal/scanner/conventional/squelch.go
+++ b/internal/scanner/conventional/squelch.go
@@ -1,0 +1,43 @@
+// Package conventional is the fixed-frequency analog FM scanner.
+//
+// State machine cycles through operator-configured channels, measures
+// IQ-domain RMS power on each tune-and-dwell, and on squelch break
+// hands off to the trunking engine (via Engine.HandleSyntheticCall) so
+// the recorder writes a WAV like any other call. After hangtime
+// silence the scanner publishes CallEnd through EndSyntheticCall and
+// resumes hopping.
+//
+// IQ-domain squelch is chosen over FM-discriminator squelch because
+// it's measurable before any demod chain spins up (cheap blind-channel
+// visits during scanning) and FM carriers are constant-envelope so
+// the same metric drives hangtime detection while a call is active.
+package conventional
+
+import "math"
+
+// PowerDbFS measures the RMS power of a complex64 IQ chunk in dB
+// relative to full-scale (where a unity-amplitude tone is 0 dBFS).
+// Returns -infinity for an empty buffer; callers compare against
+// SquelchDbFS and treat -Inf as well below any threshold.
+//
+// This is the load-bearing primitive for both squelch-open detection
+// (during SCANNING) and hangtime-silence detection (during DWELL).
+func PowerDbFS(iq []complex64) float64 {
+	if len(iq) == 0 {
+		return math.Inf(-1)
+	}
+	var acc float64
+	for _, s := range iq {
+		i := float64(real(s))
+		q := float64(imag(s))
+		acc += i*i + q*q
+	}
+	mean := acc / float64(len(iq))
+	if mean <= 0 {
+		return math.Inf(-1)
+	}
+	// IQ power is already an envelope-squared metric; convert
+	// directly to dB. A unit-amplitude tone (|s|=1) yields mean=1
+	// → 0 dB.
+	return 10 * math.Log10(mean)
+}

--- a/internal/scanner/conventional/squelch_test.go
+++ b/internal/scanner/conventional/squelch_test.go
@@ -1,0 +1,55 @@
+package conventional
+
+import (
+	"math"
+	"testing"
+)
+
+func TestPowerDbFS_EmptyIsNegInf(t *testing.T) {
+	got := PowerDbFS(nil)
+	if !math.IsInf(got, -1) {
+		t.Errorf("PowerDbFS(nil) = %v, want -Inf", got)
+	}
+}
+
+func TestPowerDbFS_UnitToneIsZeroDb(t *testing.T) {
+	// A constant complex tone of magnitude 1 has mean(|s|²) = 1
+	// → 0 dBFS. We allow a tiny tolerance for floating-point.
+	iq := make([]complex64, 1024)
+	for i := range iq {
+		iq[i] = complex(1, 0)
+	}
+	got := PowerDbFS(iq)
+	if math.Abs(got) > 0.01 {
+		t.Errorf("PowerDbFS(unit) = %v, want ~0", got)
+	}
+}
+
+func TestPowerDbFS_SilenceIsDeepNegative(t *testing.T) {
+	// Near-zero IQ should yield a strongly negative dB value
+	// — below any reasonable squelch threshold.
+	iq := make([]complex64, 1024)
+	for i := range iq {
+		iq[i] = complex(1e-5, 1e-5)
+	}
+	got := PowerDbFS(iq)
+	if got > -80 {
+		t.Errorf("PowerDbFS(silence) = %v, want <= -80", got)
+	}
+}
+
+func TestPowerDbFS_OrdersByAmplitude(t *testing.T) {
+	// A louder carrier must measure higher dBFS than a quieter one.
+	mk := func(amp float32) []complex64 {
+		out := make([]complex64, 256)
+		for i := range out {
+			out[i] = complex(amp, 0)
+		}
+		return out
+	}
+	loud := PowerDbFS(mk(0.5))
+	quiet := PowerDbFS(mk(0.05))
+	if loud <= quiet {
+		t.Errorf("loud (%v) should be > quiet (%v)", loud, quiet)
+	}
+}

--- a/internal/trunking/cchunt.go
+++ b/internal/trunking/cchunt.go
@@ -103,11 +103,25 @@ func (h *Hunter) Hunt(ctx context.Context) (LockResult, error) {
 	sub := h.bus.Subscribe()
 	defer sub.Close()
 
-	for _, freq := range candidates {
+	for i, freq := range candidates {
 		if err := ctx.Err(); err != nil {
 			return LockResult{}, err
 		}
 		h.log.Info("cc-hunt: trying", "system", h.system.Name, "freq_hz", freq)
+		// Telemetry: let the TUI render "trying 851.012500 MHz
+		// (2/3)" without scraping logs. Published before the
+		// SetCenterFreq call so a stuck driver still surfaces the
+		// progress.
+		h.bus.Publish(events.Event{
+			Kind: events.KindHuntProgress,
+			Payload: HuntProgress{
+				System:          h.system.Name,
+				AttemptedFreqHz: freq,
+				AttemptIndex:    i,
+				TotalCandidates: len(candidates),
+				At:              time.Now(),
+			},
+		})
 		if err := h.tuner.SetCenterFreq(freq); err != nil {
 			h.log.Warn("cc-hunt: tune failed", "freq_hz", freq, "err", err)
 			continue
@@ -151,6 +165,26 @@ type LockResult struct {
 	Frequency uint32
 	NAC       uint16
 	At        time.Time
+}
+
+// HuntProgress is the payload published with events.KindHuntProgress.
+// One event fires per CC candidate the hunter tries; the TUI uses
+// AttemptIndex / TotalCandidates to render a position indicator.
+type HuntProgress struct {
+	System          string    `json:"system"`
+	AttemptedFreqHz uint32    `json:"attempted_freq_hz"`
+	AttemptIndex    int       `json:"attempt_index"`
+	TotalCandidates int       `json:"total_candidates"`
+	At              time.Time `json:"at"`
+}
+
+// HuntFailed is the payload for events.KindHuntFailed — published when
+// a system's CC candidate list exhausts without locking. BackoffMs is
+// the supervisor's next sleep window so the TUI can show "retry in 5 s".
+type HuntFailed struct {
+	System    string    `json:"system"`
+	At        time.Time `json:"at"`
+	BackoffMs int       `json:"backoff_ms"`
 }
 
 // ErrNoControlChannel is returned when every candidate frequency exhausts

--- a/internal/trunking/engine.go
+++ b/internal/trunking/engine.go
@@ -29,8 +29,15 @@ type Engine struct {
 	sub        *events.Subscription
 	closeOnce  sync.Once
 
-	mu    sync.Mutex
-	calls map[string]*ActiveCall // by device serial; mirror of pool.active for fast access
+	// scanMode is read under modeMu so the API cockpit can flip it at
+	// runtime without a daemon restart. HandleGrant takes a snapshot
+	// under the read lock to avoid blocking the bus loop.
+	modeMu   sync.RWMutex
+	scanMode ScanMode
+
+	mu        sync.Mutex
+	calls     map[string]*ActiveCall // by device serial; mirror of pool.active for fast access
+	synthetic map[string]*ActiveCall // by device serial; calls owned by external scanners (conv FM)
 }
 
 // EngineOptions configure a new Engine.
@@ -44,6 +51,10 @@ type EngineOptions struct {
 	CallTimeout time.Duration
 	// Now is injectable for tests; defaults to time.Now.
 	Now func() time.Time
+	// ScanMode controls whether HandleGrant respects the per-talkgroup
+	// Scan flag. Default ScanModeAll keeps every non-locked-out grant
+	// flowing through; ScanModeList enforces the talkgroup scan list.
+	ScanMode ScanMode
 }
 
 // NewEngine validates opts and returns a ready-to-Run engine.
@@ -73,7 +84,9 @@ func NewEngine(opts EngineOptions) (*Engine, error) {
 		talkgroups: opts.Talkgroups,
 		timeout:    opts.CallTimeout,
 		now:        opts.Now,
+		scanMode:   opts.ScanMode,
 		calls:      make(map[string]*ActiveCall),
+		synthetic:  make(map[string]*ActiveCall),
 	}
 	// Subscribe at construction time so callers can publish grants
 	// before Run starts without losing them.
@@ -136,6 +149,15 @@ func (e *Engine) HandleGrant(g Grant) {
 		e.log.Info("grant locked out", "grant", g.String(), "tg", tg.AlphaTag)
 		return
 	}
+	// Scan list gate: in ScanModeList, drop grants whose TG is missing
+	// or has Scan==false (Emergency bypasses, matching Lockout's
+	// emergency exception above). In ScanModeAll the gate is a no-op.
+	if e.ScanMode() == ScanModeList && !g.Emergency {
+		if tg == nil || !tg.Scan {
+			e.log.Debug("grant not in scan list", "grant", g.String())
+			return
+		}
+	}
 
 	// 1) Free device available? Allocate.
 	if free := e.pool.FindFree(); free != nil {
@@ -180,8 +202,19 @@ func (e *Engine) Touch(deviceSerial string) {
 	e.pool.Touch(deviceSerial, e.now())
 }
 
-// ActiveCalls returns a snapshot of every active call.
-func (e *Engine) ActiveCalls() []*ActiveCall { return e.pool.Active() }
+// ActiveCalls returns a snapshot of every active call — trunked
+// calls allocated through the voice pool plus synthetic calls owned
+// by external scanners (the conventional FM scanner publishes these
+// through HandleSyntheticCall).
+func (e *Engine) ActiveCalls() []*ActiveCall {
+	out := e.pool.Active()
+	e.mu.Lock()
+	for _, ac := range e.synthetic {
+		out = append(out, ac)
+	}
+	e.mu.Unlock()
+	return out
+}
 
 func (e *Engine) startCall(d *VoiceDevice, g Grant, tg *TalkGroup) {
 	ac, err := e.pool.Bind(d, g, tg, e.now())
@@ -246,4 +279,92 @@ func (e *Engine) shutdown() {
 	for _, ac := range e.pool.Active() {
 		e.endCall(ac, EndReasonNormal)
 	}
+}
+
+// HandleSyntheticCall registers a call originated by a non-trunked
+// source (the conventional FM scanner is the canonical example) that
+// already owns its SDR — no VoicePool binding, no re-tune, no
+// preemption logic. The engine publishes CallStart and adds the call
+// to ActiveCalls() so the API + TUI surfaces light up like any
+// other call. Pair with EndSyntheticCall to release.
+//
+// deviceSerial must be unique across the daemon's call set so the
+// recorder can route WritePCM samples to the right WAV.
+func (e *Engine) HandleSyntheticCall(g Grant, deviceSerial string) {
+	if g.At.IsZero() {
+		g.At = e.now()
+	}
+	tg := e.talkgroups.Lookup(g.GroupID)
+	ac := &ActiveCall{
+		Device:      &VoiceDevice{Serial: deviceSerial},
+		Grant:       g,
+		Talkgroup:   tg,
+		StartedAt:   e.now(),
+		LastHeardAt: e.now(),
+	}
+	e.mu.Lock()
+	e.synthetic[deviceSerial] = ac
+	e.mu.Unlock()
+	e.bus.Publish(events.Event{
+		Kind: events.KindCallStart,
+		Payload: CallStart{
+			Grant:        g,
+			Talkgroup:    tg,
+			DeviceSerial: deviceSerial,
+			StartedAt:    ac.StartedAt,
+		},
+	})
+	e.log.Info("synthetic call started",
+		"device", deviceSerial,
+		"grant", g.String())
+}
+
+// EndSyntheticCall is the conventional scanner's "carrier dropped"
+// signal. Publishes CallEnd and forgets the call. Returns false if
+// the engine has no synthetic call bound to deviceSerial.
+func (e *Engine) EndSyntheticCall(deviceSerial string, reason EndReason) bool {
+	e.mu.Lock()
+	ac, ok := e.synthetic[deviceSerial]
+	if ok {
+		delete(e.synthetic, deviceSerial)
+	}
+	e.mu.Unlock()
+	if !ok {
+		return false
+	}
+	e.bus.Publish(events.Event{
+		Kind: events.KindCallEnd,
+		Payload: CallEnd{
+			Grant:        ac.Grant,
+			Talkgroup:    ac.Talkgroup,
+			DeviceSerial: deviceSerial,
+			StartedAt:    ac.StartedAt,
+			EndedAt:      e.now(),
+			Reason:       reason,
+		},
+	})
+	e.log.Info("synthetic call ended",
+		"device", deviceSerial,
+		"reason", reason.String())
+	return true
+}
+
+// ScanMode returns the engine's current scan mode. Safe to call from
+// any goroutine.
+func (e *Engine) ScanMode() ScanMode {
+	e.modeMu.RLock()
+	defer e.modeMu.RUnlock()
+	return e.scanMode
+}
+
+// SetScanMode swaps the engine's scan mode at runtime — the API
+// cockpit calls this when the operator flips the global scan_mode
+// from the TUI. Returns the previous mode so the caller can log /
+// audit the change.
+func (e *Engine) SetScanMode(m ScanMode) ScanMode {
+	e.modeMu.Lock()
+	defer e.modeMu.Unlock()
+	prev := e.scanMode
+	e.scanMode = m
+	return prev
 }

--- a/internal/trunking/engine_test.go
+++ b/internal/trunking/engine_test.go
@@ -108,6 +108,114 @@ func TestEngineDropsLockedOutGrant(t *testing.T) {
 	}
 }
 
+func TestEngineScanModeListDropsTGOutsideList(t *testing.T) {
+	e, _, bus, tuners := mkEngine(t, 1)
+	defer bus.Close()
+	e.SetScanMode(ScanModeList)
+	// TG with Scan=false should be dropped.
+	e.talkgroups.Add(&TalkGroup{ID: 77, AlphaTag: "OFF-LIST", Scan: false})
+
+	sub := bus.Subscribe()
+	defer sub.Close()
+	e.HandleGrant(Grant{System: "X", Protocol: "p25", GroupID: 77, FrequencyHz: 1_000_000})
+
+	select {
+	case ev := <-sub.C:
+		t.Errorf("unexpected event for off-list grant: %s", ev.Kind)
+	case <-time.After(50 * time.Millisecond):
+	}
+	if got := tuners[0].tuned(); len(got) != 0 {
+		t.Errorf("off-list grant should not retune; got %v", got)
+	}
+}
+
+func TestEngineScanModeListAllowsScanTrueTG(t *testing.T) {
+	e, _, bus, _ := mkEngine(t, 1)
+	defer bus.Close()
+	e.SetScanMode(ScanModeList)
+	e.talkgroups.Add(&TalkGroup{ID: 78, AlphaTag: "ON-LIST", Scan: true})
+
+	sub := bus.Subscribe()
+	defer sub.Close()
+	e.HandleGrant(Grant{System: "X", Protocol: "p25", GroupID: 78, FrequencyHz: 1_000_000})
+
+	deadline := time.After(time.Second)
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind == events.KindCallStart {
+				return
+			}
+		case <-deadline:
+			t.Fatal("no CallStart published for on-list grant")
+		}
+	}
+}
+
+func TestEngineScanModeListBypassedByEmergency(t *testing.T) {
+	e, _, bus, _ := mkEngine(t, 1)
+	defer bus.Close()
+	e.SetScanMode(ScanModeList)
+	// Off-list (Scan=false) but Emergency — must still fire.
+	e.talkgroups.Add(&TalkGroup{ID: 79, AlphaTag: "OFF-LIST-EMER", Scan: false})
+
+	sub := bus.Subscribe()
+	defer sub.Close()
+	e.HandleGrant(Grant{System: "X", Protocol: "p25", GroupID: 79, FrequencyHz: 1_000_000, Emergency: true})
+
+	deadline := time.After(time.Second)
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind == events.KindCallStart {
+				return
+			}
+		case <-deadline:
+			t.Fatal("Emergency grant should bypass scan-list gate")
+		}
+	}
+}
+
+func TestEngineScanModeListUnknownTGDropped(t *testing.T) {
+	// TG not in the DB at all (Lookup returns nil) → dropped.
+	e, _, bus, _ := mkEngine(t, 1)
+	defer bus.Close()
+	e.SetScanMode(ScanModeList)
+
+	sub := bus.Subscribe()
+	defer sub.Close()
+	e.HandleGrant(Grant{System: "X", Protocol: "p25", GroupID: 999, FrequencyHz: 1_000_000})
+
+	select {
+	case ev := <-sub.C:
+		t.Errorf("unexpected event for unknown TG: %s", ev.Kind)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestEngineScanModeAllIgnoresScanFlag(t *testing.T) {
+	// Default mode (all): a TG with Scan=false still fires.
+	e, _, bus, _ := mkEngine(t, 1)
+	defer bus.Close()
+	e.talkgroups.Add(&TalkGroup{ID: 80, AlphaTag: "OFF-LIST", Scan: false})
+
+	sub := bus.Subscribe()
+	defer sub.Close()
+	e.HandleGrant(Grant{System: "X", Protocol: "p25", GroupID: 80, FrequencyHz: 1_000_000})
+
+	deadline := time.After(time.Second)
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind == events.KindCallStart {
+				return
+			}
+		case <-deadline:
+			t.Fatal("ScanModeAll should ignore Scan flag")
+		}
+	}
+}
+
 func TestEngineDropsZeroFrequencyGrant(t *testing.T) {
 	e, _, bus, _ := mkEngine(t, 1)
 	defer bus.Close()

--- a/internal/trunking/scanmode.go
+++ b/internal/trunking/scanmode.go
@@ -1,0 +1,42 @@
+package trunking
+
+import "strings"
+
+// ScanMode controls how Engine.HandleGrant filters incoming grants
+// against the talkgroup database's `Scan` flag.
+//
+//   - ScanModeAll  (default): every non-locked-out grant is dispatched,
+//     regardless of TalkGroup.Scan. This is the backwards-compatible
+//     behavior — pre-scanner configs see no change.
+//   - ScanModeList: only grants whose talkgroup carries Scan==true (or
+//     whose grant is flagged Emergency, parallel to the Lockout
+//     exception) are dispatched. Unknown talkgroup IDs are dropped
+//     because there's no way to know they're scannable.
+type ScanMode uint8
+
+const (
+	ScanModeAll ScanMode = iota
+	ScanModeList
+)
+
+// String renders the wire form used by config + REST + TUI clients.
+func (m ScanMode) String() string {
+	switch m {
+	case ScanModeList:
+		return "list"
+	default:
+		return "all"
+	}
+}
+
+// ParseScanMode is the inverse of String. Empty string maps to the
+// safe default (all); unknown values also map to all so a typo in
+// config doesn't accidentally silence the daemon.
+func ParseScanMode(s string) ScanMode {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "list":
+		return ScanModeList
+	default:
+		return ScanModeAll
+	}
+}

--- a/internal/trunking/talkgroup.go
+++ b/internal/trunking/talkgroup.go
@@ -14,6 +14,13 @@ import (
 
 // TalkGroup describes one talkgroup loaded from disk. The schema follows
 // the Trunk Recorder / RadioReference talkgroup CSV convention.
+//
+// Scan participates in the engine's per-talkgroup scan list when the
+// engine runs in ScanModeList — only talkgroups with Scan == true get
+// their grants followed (Emergency grants bypass the gate). In
+// ScanModeAll (the default for backwards compat with pre-scanner
+// configs) the field is moot. Defaults to true on every loader so a
+// legacy CSV without a Scan column keeps the existing behavior.
 type TalkGroup struct {
 	ID          uint32 `json:"id"`
 	AlphaTag    string `json:"alpha_tag"`
@@ -23,6 +30,7 @@ type TalkGroup struct {
 	Mode        string `json:"mode,omitempty"`    // D=digital, A=analog, M=mixed
 	Priority    int    `json:"priority,omitempty"` // 1 = highest, 10 = lowest, 0 = unset
 	Lockout     bool   `json:"lockout,omitempty"`
+	Scan        bool   `json:"scan"`
 }
 
 // TalkgroupDB is a thread-safe lookup over loaded talkgroups.
@@ -148,7 +156,7 @@ func (d *TalkgroupDB) LoadCSV(r io.Reader) (int, error) {
 		if err != nil {
 			continue // skip malformed rows
 		}
-		tg := &TalkGroup{ID: uint32(idVal)}
+		tg := &TalkGroup{ID: uint32(idVal), Scan: true}
 		tg.AlphaTag = field(row, colIdx, "alpha tag", "alphatag", "alpha_tag")
 		tg.Description = field(row, colIdx, "description")
 		tg.Mode = field(row, colIdx, "mode")
@@ -167,6 +175,15 @@ func (d *TalkgroupDB) LoadCSV(r io.Reader) (int, error) {
 				tg.Lockout = true
 			}
 		}
+		// Optional Scan / Active column. Default is true; explicit
+		// "no"/"false"/"0"/"n" turns it off so a CSV-shipped scan-list
+		// can ride alongside an operator's runtime mutations.
+		if s := field(row, colIdx, "scan", "active"); s != "" {
+			switch strings.ToLower(s) {
+			case "n", "no", "false", "0", "off":
+				tg.Scan = false
+			}
+		}
 		d.Add(tg)
 		loaded++
 	}
@@ -183,15 +200,42 @@ func (d *TalkgroupDB) LoadCSVFile(path string) (int, error) {
 	return d.LoadCSV(f)
 }
 
-// LoadJSON reads a JSON array of TalkGroup records.
+// LoadJSON reads a JSON array of TalkGroup records. Records missing
+// the "scan" key resolve to Scan=true so legacy JSON dumps keep the
+// "follow every grant" behavior; explicit `"scan": false` turns off
+// participation in the scan list.
 func (d *TalkgroupDB) LoadJSON(r io.Reader) (int, error) {
-	var arr []TalkGroup
+	type talkGroupRaw struct {
+		ID          uint32 `json:"id"`
+		AlphaTag    string `json:"alpha_tag"`
+		Description string `json:"description,omitempty"`
+		Tag         string `json:"tag,omitempty"`
+		Group       string `json:"group,omitempty"`
+		Mode        string `json:"mode,omitempty"`
+		Priority    int    `json:"priority,omitempty"`
+		Lockout     bool   `json:"lockout,omitempty"`
+		Scan        *bool  `json:"scan"`
+	}
+	var arr []talkGroupRaw
 	if err := json.NewDecoder(r).Decode(&arr); err != nil {
 		return 0, fmt.Errorf("trunking: decode json: %w", err)
 	}
-	for i := range arr {
-		tg := arr[i]
-		d.Add(&tg)
+	for _, raw := range arr {
+		tg := &TalkGroup{
+			ID:          raw.ID,
+			AlphaTag:    raw.AlphaTag,
+			Description: raw.Description,
+			Tag:         raw.Tag,
+			Group:       raw.Group,
+			Mode:        raw.Mode,
+			Priority:    raw.Priority,
+			Lockout:     raw.Lockout,
+			Scan:        true,
+		}
+		if raw.Scan != nil {
+			tg.Scan = *raw.Scan
+		}
+		d.Add(tg)
 	}
 	return len(arr), nil
 }

--- a/internal/trunking/talkgroup_test.go
+++ b/internal/trunking/talkgroup_test.go
@@ -80,3 +80,66 @@ func TestLoadJSON(t *testing.T) {
 		t.Errorf("OPS-2 lockout flag missing: %+v", tg)
 	}
 }
+
+func TestLoadCSVDefaultsScanTrue(t *testing.T) {
+	// A CSV without a Scan column must leave every TG with Scan=true
+	// so legacy configs keep their "follow every grant" behavior.
+	csv := `Decimal,Alpha Tag
+1,OPS-A
+2,OPS-B
+`
+	d := NewTalkgroupDB()
+	if _, err := d.LoadCSV(strings.NewReader(csv)); err != nil {
+		t.Fatalf("LoadCSV: %v", err)
+	}
+	for _, id := range []uint32{1, 2} {
+		tg := d.Lookup(id)
+		if tg == nil || !tg.Scan {
+			t.Errorf("TG %d Scan = false, want true (default for missing column)", id)
+		}
+	}
+}
+
+func TestLoadCSVScanColumnOverrides(t *testing.T) {
+	csv := `Decimal,Alpha Tag,Scan
+1,OPS-A,Y
+2,OPS-B,n
+3,OPS-C,
+`
+	d := NewTalkgroupDB()
+	if _, err := d.LoadCSV(strings.NewReader(csv)); err != nil {
+		t.Fatalf("LoadCSV: %v", err)
+	}
+	if !d.Lookup(1).Scan {
+		t.Errorf("TG 1 Scan = false, want true (explicit Y)")
+	}
+	if d.Lookup(2).Scan {
+		t.Errorf("TG 2 Scan = true, want false (explicit n)")
+	}
+	if !d.Lookup(3).Scan {
+		t.Errorf("TG 3 Scan = false, want true (empty cell falls back to default)")
+	}
+}
+
+func TestLoadJSONDefaultsScanWhenAbsent(t *testing.T) {
+	// JSON records without "scan" resolve to true; explicit
+	// "scan":false carries through.
+	js := `[
+  {"id": 1, "alpha_tag": "A"},
+  {"id": 2, "alpha_tag": "B", "scan": false},
+  {"id": 3, "alpha_tag": "C", "scan": true}
+]`
+	d := NewTalkgroupDB()
+	if _, err := d.LoadJSON(strings.NewReader(js)); err != nil {
+		t.Fatalf("LoadJSON: %v", err)
+	}
+	if !d.Lookup(1).Scan {
+		t.Errorf("TG 1 Scan = false, want true (no scan key)")
+	}
+	if d.Lookup(2).Scan {
+		t.Errorf("TG 2 Scan = true, want false (explicit false)")
+	}
+	if !d.Lookup(3).Scan {
+		t.Errorf("TG 3 Scan = false, want true (explicit true)")
+	}
+}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -78,6 +78,7 @@ func New(cli *client.Client, opts Options) *Model {
 			panels.NewTones(),
 			panels.NewMetrics(),
 			panels.NewDevices(),
+			panels.NewScanner(),
 		},
 	}
 	return m
@@ -94,6 +95,7 @@ func (m *Model) Init() tea.Cmd {
 		cmdPollMetrics(m.cli),
 		cmdPollHistory(m.cli, client.HistoryFilter{Limit: 100}),
 		cmdPollDevices(m.cli),
+		cmdPollScanner(m.cli),
 		cmdMutationStatus(m.cli),
 		connectSSE(m.cli),
 	)
@@ -183,6 +185,9 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case key.Matches(msg, m.keys.JumpPanel9):
 			m.active = state.PanelDevices
 			return m, nil
+		case key.Matches(msg, m.keys.JumpPanel0):
+			m.active = state.PanelScanner
+			return m, nil
 		}
 
 	case pollHealthMsg:
@@ -234,6 +239,13 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.shared.DevicesErr = msg.err
 		cmds = append(cmds, scheduleAfter(pollDevicesEvery, cmdPollDevices(m.cli)))
 
+	case pollScannerMsg:
+		if msg.err == nil {
+			m.shared.Scanner = msg.s
+		}
+		m.shared.ScannerErr = msg.err
+		cmds = append(cmds, scheduleAfter(pollScannerEvery, cmdPollScanner(m.cli)))
+
 	case pollHistoryMsg:
 		m.shared.History = msg.rows
 		m.shared.HistoryErr = msg.err
@@ -265,6 +277,9 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			cmds = append(cmds, cmdPollDevices(m.cli))
 		case "call.start", "call.end":
 			cmds = append(cmds, cmdPollActive(m.cli))
+			cmds = append(cmds, cmdPollScanner(m.cli))
+		case "cchunt.progress", "cchunt.failed", "cc.locked", "cc.lost":
+			cmds = append(cmds, cmdPollScanner(m.cli))
 		}
 		cmds = append(cmds, listenSSE(m.eventCh))
 
@@ -430,6 +445,7 @@ func (m *Model) dispatchWrite(r state.WriteRequest) tea.Cmd {
 			r.UpdateTalkgroup.ID,
 			r.UpdateTalkgroup.Priority,
 			r.UpdateTalkgroup.Lockout,
+			r.UpdateTalkgroup.Scan,
 			r.Label)
 	case state.WriteKindSweepRetention:
 		return cmdSweepRetention(m.cli)
@@ -438,6 +454,35 @@ func (m *Model) dispatchWrite(r state.WriteRequest) tea.Cmd {
 			return nil
 		}
 		return cmdResetTone(m.cli, r.ResetTone.DeviceSerial)
+	case state.WriteKindScannerMode:
+		if r.ScannerMode == nil {
+			return nil
+		}
+		return cmdScannerSetMode(m.cli, r.ScannerMode.Mode, r.Label)
+	case state.WriteKindScannerHuntHold:
+		if r.ScannerHunt == nil {
+			return nil
+		}
+		return cmdScannerHuntHold(m.cli, r.ScannerHunt.System, r.Label)
+	case state.WriteKindScannerHuntResume:
+		if r.ScannerHunt == nil {
+			return nil
+		}
+		return cmdScannerHuntResume(m.cli, r.ScannerHunt.System, r.Label)
+	case state.WriteKindScannerHuntRetune:
+		if r.ScannerHunt == nil {
+			return nil
+		}
+		return cmdScannerHuntRetune(m.cli, r.ScannerHunt.System, r.Label)
+	case state.WriteKindScannerConvHold:
+		return cmdScannerConvHold(m.cli, r.Label)
+	case state.WriteKindScannerConvResume:
+		return cmdScannerConvResume(m.cli, r.Label)
+	case state.WriteKindScannerConvDwell:
+		if r.ScannerConv == nil {
+			return nil
+		}
+		return cmdScannerConvDwell(m.cli, r.ScannerConv.Index, r.Label)
 	}
 	return nil
 }

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -73,6 +73,7 @@ func TestPanelSwitch_DigitAndTab(t *testing.T) {
 		{"5", state.PanelHistory},
 		{"8", state.PanelMetrics},
 		{"9", state.PanelDevices},
+		{"0", state.PanelScanner},
 	}
 	for _, c := range cases {
 		updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(c.key)})
@@ -81,10 +82,10 @@ func TestPanelSwitch_DigitAndTab(t *testing.T) {
 			t.Errorf("after %q active=%v, want %v", c.key, m.active, c.want)
 		}
 	}
-	// Tab cycles forward — Devices is the last panel, so Tab wraps to Dashboard.
+	// Tab cycles forward — Scanner is the last panel, so Tab wraps to Dashboard.
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyTab})
 	m = updated.(*Model)
 	if m.active != state.PanelDashboard {
-		t.Errorf("Tab from Devices: active=%v, want Dashboard", m.active)
+		t.Errorf("Tab from Scanner: active=%v, want Dashboard", m.active)
 	}
 }

--- a/internal/tui/client/client.go
+++ b/internal/tui/client/client.go
@@ -104,6 +104,16 @@ func (c *Client) Talkgroups(ctx context.Context) ([]TalkgroupDTO, error) {
 	return r.Talkgroups, nil
 }
 
+// Scanner calls GET /api/v1/scanner. Always returns 200 even when
+// no scanner subsystem is wired (an empty ScannerStatusDTO).
+func (c *Client) Scanner(ctx context.Context) (ScannerStatusDTO, error) {
+	var s ScannerStatusDTO
+	if err := c.getJSON(ctx, "/api/v1/scanner", &s); err != nil {
+		return ScannerStatusDTO{}, err
+	}
+	return s, nil
+}
+
 // Devices calls GET /api/v1/devices.
 func (c *Client) Devices(ctx context.Context) ([]SDRStatus, error) {
 	var r devicesResp

--- a/internal/tui/client/types.go
+++ b/internal/tui/client/types.go
@@ -45,6 +45,7 @@ type TalkgroupDTO struct {
 	Mode        string `json:"mode,omitempty"`
 	Priority    int    `json:"priority,omitempty"`
 	Lockout     bool   `json:"lockout,omitempty"`
+	Scan        bool   `json:"scan"`
 }
 
 // GrantDTO mirrors api.GrantDTO.
@@ -111,6 +112,53 @@ type Event struct {
 	Kind string
 	Time time.Time
 	Raw  json.RawMessage
+}
+
+// ScannerStatusDTO mirrors api.ScannerStatus — the unified scanner
+// snapshot returned by GET /api/v1/scanner. Fields are zero-valued
+// when the underlying subsystem isn't wired (e.g. no CC hunter →
+// empty Systems list).
+type ScannerStatusDTO struct {
+	ScanMode            string                   `json:"scan_mode"`
+	Systems             []SystemHuntStatusDTO    `json:"systems"`
+	Conventional        ConvScannerStatusDTO     `json:"conventional"`
+	TalkgroupScanCount  int                      `json:"tg_scan_count"`
+	TalkgroupTotalCount int                      `json:"tg_total"`
+}
+
+// SystemHuntStatusDTO mirrors api.SystemHuntStatusDTO.
+type SystemHuntStatusDTO struct {
+	Name            string    `json:"name"`
+	Protocol        string    `json:"protocol"`
+	State           string    `json:"state"`
+	AttemptedFreqHz uint32    `json:"attempted_freq_hz,omitempty"`
+	AttemptIndex    int       `json:"attempt_index,omitempty"`
+	TotalCandidates int       `json:"total_candidates,omitempty"`
+	LockedFreqHz    uint32    `json:"locked_freq_hz,omitempty"`
+	LockedAt        time.Time `json:"locked_at,omitempty"`
+	NAC             uint16    `json:"nac,omitempty"`
+	LastFailedAt    time.Time `json:"last_failed_at,omitempty"`
+	BackoffMs       int       `json:"backoff_ms,omitempty"`
+	LastGrantAt     time.Time `json:"last_grant_at,omitempty"`
+}
+
+// ConvScannerStatusDTO mirrors api.ConvScannerStatusDTO.
+type ConvScannerStatusDTO struct {
+	Enabled      bool                  `json:"enabled"`
+	State        string                `json:"state,omitempty"`
+	DeviceSerial string                `json:"device_serial,omitempty"`
+	CursorIndex  int                   `json:"cursor_index,omitempty"`
+	Channels     []ConvChannelStatusDTO `json:"channels"`
+}
+
+// ConvChannelStatusDTO mirrors api.ConvChannelStatusDTO.
+type ConvChannelStatusDTO struct {
+	Index       int       `json:"index"`
+	Label       string    `json:"label"`
+	FrequencyHz uint32    `json:"frequency_hz"`
+	Mode        string    `json:"mode"`
+	Active      bool      `json:"active"`
+	LastBreakAt time.Time `json:"last_break_at,omitempty"`
 }
 
 // SDRStatus mirrors api.sdr.SDRStatus — the per-device payload

--- a/internal/tui/client/write.go
+++ b/internal/tui/client/write.go
@@ -48,7 +48,7 @@ func (c *Client) EndCall(ctx context.Context, deviceSerial, reason string) error
 
 // UpdateTalkgroup calls PATCH /api/v1/talkgroups/{id}. Pass nil for
 // fields you don't want to change.
-func (c *Client) UpdateTalkgroup(ctx context.Context, id uint32, priority *int, lockout *bool) (TalkgroupDTO, error) {
+func (c *Client) UpdateTalkgroup(ctx context.Context, id uint32, priority *int, lockout *bool, scan *bool) (TalkgroupDTO, error) {
 	body := map[string]any{}
 	if priority != nil {
 		body["priority"] = *priority
@@ -56,8 +56,11 @@ func (c *Client) UpdateTalkgroup(ctx context.Context, id uint32, priority *int, 
 	if lockout != nil {
 		body["lockout"] = *lockout
 	}
+	if scan != nil {
+		body["scan"] = *scan
+	}
 	if len(body) == 0 {
-		return TalkgroupDTO{}, fmt.Errorf("client: supply priority and/or lockout")
+		return TalkgroupDTO{}, fmt.Errorf("client: supply priority, lockout, or scan")
 	}
 	var out TalkgroupDTO
 	if err := c.do(ctx, http.MethodPatch,
@@ -71,6 +74,43 @@ func (c *Client) UpdateTalkgroup(ctx context.Context, id uint32, priority *int, 
 // SweepRetention calls POST /api/v1/retention/sweep.
 func (c *Client) SweepRetention(ctx context.Context) error {
 	return c.do(ctx, http.MethodPost, "/api/v1/retention/sweep", nil, nil)
+}
+
+// ScannerSetMode calls PATCH /api/v1/scanner with the new global
+// scan_mode ("all" or "list").
+func (c *Client) ScannerSetMode(ctx context.Context, mode string) error {
+	return c.do(ctx, http.MethodPatch, "/api/v1/scanner",
+		map[string]string{"scan_mode": mode}, nil)
+}
+
+// ScannerHuntHold / ScannerHuntResume / ScannerHuntRetune call the
+// per-system hunt mutation endpoints. system must match a configured
+// trunked system name.
+func (c *Client) ScannerHuntHold(ctx context.Context, system string) error {
+	return c.do(ctx, http.MethodPost,
+		"/api/v1/scanner/hunt/"+system+"/hold", nil, nil)
+}
+func (c *Client) ScannerHuntResume(ctx context.Context, system string) error {
+	return c.do(ctx, http.MethodPost,
+		"/api/v1/scanner/hunt/"+system+"/resume", nil, nil)
+}
+func (c *Client) ScannerHuntRetune(ctx context.Context, system string) error {
+	return c.do(ctx, http.MethodPost,
+		"/api/v1/scanner/hunt/"+system+"/retune", nil, nil)
+}
+
+// ScannerConvHold / ScannerConvResume / ScannerConvDwell drive the
+// conventional FM scanner.
+func (c *Client) ScannerConvHold(ctx context.Context) error {
+	return c.do(ctx, http.MethodPost, "/api/v1/scanner/conventional/hold", nil, nil)
+}
+func (c *Client) ScannerConvResume(ctx context.Context) error {
+	return c.do(ctx, http.MethodPost, "/api/v1/scanner/conventional/resume", nil, nil)
+}
+func (c *Client) ScannerConvDwell(ctx context.Context, index int) error {
+	return c.do(ctx, http.MethodPost,
+		fmt.Sprintf("/api/v1/scanner/conventional/%d/dwell", index),
+		nil, nil)
 }
 
 // ResetToneDevice calls POST /api/v1/devices/{serial}/tone-reset.

--- a/internal/tui/client/write_test.go
+++ b/internal/tui/client/write_test.go
@@ -69,7 +69,7 @@ func TestUpdateTalkgroup_OmitsNilFields(t *testing.T) {
 	defer srv.Close()
 	c := New(srv.URL, time.Second, false)
 	pri := 3
-	out, err := c.UpdateTalkgroup(context.Background(), 42, &pri, nil)
+	out, err := c.UpdateTalkgroup(context.Background(), 42, &pri, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -82,13 +82,38 @@ func TestUpdateTalkgroup_OmitsNilFields(t *testing.T) {
 	if strings.Contains(body, `"lockout"`) {
 		t.Errorf("body should omit lockout when nil: %s", body)
 	}
+	if strings.Contains(body, `"scan"`) {
+		t.Errorf("body should omit scan when nil: %s", body)
+	}
+}
+
+func TestUpdateTalkgroup_PassesScanFlag(t *testing.T) {
+	var body string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		buf, _ := io.ReadAll(r.Body)
+		body = string(buf)
+		_, _ = w.Write([]byte(`{"id":7,"alpha_tag":"x","scan":false}`))
+	}))
+	defer srv.Close()
+	c := New(srv.URL, time.Second, false)
+	scan := false
+	out, err := c.UpdateTalkgroup(context.Background(), 7, nil, nil, &scan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Scan {
+		t.Errorf("out.Scan = true, want false")
+	}
+	if !strings.Contains(body, `"scan":false`) {
+		t.Errorf("body should include scan=false: %s", body)
+	}
 }
 
 func TestUpdateTalkgroup_RequiresAtLeastOneField(t *testing.T) {
 	c := New("http://example.invalid", time.Second, false)
-	_, err := c.UpdateTalkgroup(context.Background(), 42, nil, nil)
+	_, err := c.UpdateTalkgroup(context.Background(), 42, nil, nil, nil)
 	if err == nil {
-		t.Fatal("want error when both fields are nil")
+		t.Fatal("want error when all fields are nil")
 	}
 }
 

--- a/internal/tui/cmds.go
+++ b/internal/tui/cmds.go
@@ -18,6 +18,7 @@ const (
 	pollActiveEvery     = 1 * time.Second
 	pollMetricsEvery    = 5 * time.Second
 	pollDevicesEvery    = 10 * time.Second
+	pollScannerEvery    = 2 * time.Second
 )
 
 func cmdPollHealth(cli *client.Client) tea.Cmd {
@@ -66,6 +67,58 @@ func cmdPollDevices(cli *client.Client) tea.Cmd {
 	return func() tea.Msg {
 		d, err := cli.Devices(context.Background())
 		return pollDevicesMsg{devs: d, err: err}
+	}
+}
+
+func cmdPollScanner(cli *client.Client) tea.Cmd {
+	return func() tea.Msg {
+		s, err := cli.Scanner(context.Background())
+		return pollScannerMsg{s: s, err: err}
+	}
+}
+
+// Scanner-cockpit write Cmds — one per WriteKind.
+
+func cmdScannerSetMode(cli *client.Client, mode, label string) tea.Cmd {
+	return func() tea.Msg {
+		err := cli.ScannerSetMode(context.Background(), mode)
+		return writeResultMsg{Label: label, Err: err}
+	}
+}
+func cmdScannerHuntHold(cli *client.Client, system, label string) tea.Cmd {
+	return func() tea.Msg {
+		err := cli.ScannerHuntHold(context.Background(), system)
+		return writeResultMsg{Label: label, Err: err}
+	}
+}
+func cmdScannerHuntResume(cli *client.Client, system, label string) tea.Cmd {
+	return func() tea.Msg {
+		err := cli.ScannerHuntResume(context.Background(), system)
+		return writeResultMsg{Label: label, Err: err}
+	}
+}
+func cmdScannerHuntRetune(cli *client.Client, system, label string) tea.Cmd {
+	return func() tea.Msg {
+		err := cli.ScannerHuntRetune(context.Background(), system)
+		return writeResultMsg{Label: label, Err: err}
+	}
+}
+func cmdScannerConvHold(cli *client.Client, label string) tea.Cmd {
+	return func() tea.Msg {
+		err := cli.ScannerConvHold(context.Background())
+		return writeResultMsg{Label: label, Err: err}
+	}
+}
+func cmdScannerConvResume(cli *client.Client, label string) tea.Cmd {
+	return func() tea.Msg {
+		err := cli.ScannerConvResume(context.Background())
+		return writeResultMsg{Label: label, Err: err}
+	}
+}
+func cmdScannerConvDwell(cli *client.Client, idx int, label string) tea.Cmd {
+	return func() tea.Msg {
+		err := cli.ScannerConvDwell(context.Background(), idx)
+		return writeResultMsg{Label: label, Err: err}
 	}
 }
 
@@ -127,9 +180,9 @@ func cmdEndCall(cli *client.Client, deviceSerial, reason, label string) tea.Cmd 
 	}
 }
 
-func cmdUpdateTalkgroup(cli *client.Client, id uint32, priority *int, lockout *bool, label string) tea.Cmd {
+func cmdUpdateTalkgroup(cli *client.Client, id uint32, priority *int, lockout *bool, scan *bool, label string) tea.Cmd {
 	return func() tea.Msg {
-		_, err := cli.UpdateTalkgroup(context.Background(), id, priority, lockout)
+		_, err := cli.UpdateTalkgroup(context.Background(), id, priority, lockout, scan)
 		return writeResultMsg{Label: label, Err: err}
 	}
 }

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -18,6 +18,7 @@ type globalKeys struct {
 	JumpPanel7 key.Binding
 	JumpPanel8 key.Binding
 	JumpPanel9 key.Binding
+	JumpPanel0 key.Binding
 	Refresh    key.Binding
 }
 
@@ -36,6 +37,7 @@ func newGlobalKeys() globalKeys {
 		JumpPanel7: key.NewBinding(key.WithKeys("7"), key.WithHelp("7", "tones")),
 		JumpPanel8: key.NewBinding(key.WithKeys("8"), key.WithHelp("8", "metrics")),
 		JumpPanel9: key.NewBinding(key.WithKeys("9"), key.WithHelp("9", "devices")),
+		JumpPanel0: key.NewBinding(key.WithKeys("0"), key.WithHelp("0", "scanner")),
 		Refresh:    key.NewBinding(key.WithKeys("r"), key.WithHelp("r", "refresh")),
 	}
 }
@@ -48,6 +50,6 @@ func (k globalKeys) FullHelp() [][]key.Binding {
 		{k.NextPanel, k.PrevPanel, k.Quit, k.Help},
 		{k.JumpPanel1, k.JumpPanel2, k.JumpPanel3, k.JumpPanel4},
 		{k.JumpPanel5, k.JumpPanel6, k.JumpPanel7, k.JumpPanel8},
-		{k.JumpPanel9},
+		{k.JumpPanel9, k.JumpPanel0},
 	}
 }

--- a/internal/tui/msgs.go
+++ b/internal/tui/msgs.go
@@ -43,6 +43,10 @@ type pollDevicesMsg struct {
 	devs []client.SDRStatus
 	err  error
 }
+type pollScannerMsg struct {
+	s   client.ScannerStatusDTO
+	err error
+}
 
 // eventMsg carries one decoded SSE event. The root model fans this
 // out into its event log + tone alert ring buffer, then forwards

--- a/internal/tui/panels/scanner.go
+++ b/internal/tui/panels/scanner.go
@@ -1,0 +1,297 @@
+package panels
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/bubbles/key"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/MattCheramie/GopherTrunk/internal/tui/client"
+	"github.com/MattCheramie/GopherTrunk/internal/tui/state"
+)
+
+// ScannerPanel is the police-scanner cockpit. Renders three sections:
+//
+//  1. Systems (trunked) — per-system CC hunt state + last grant.
+//  2. Conventional — fixed-frequency analog channels + current dwell.
+//  3. TG scan summary — global scan_mode + scan-list size.
+//
+// Operator mutations (hold / resume / retune / dwell / cycle scan
+// mode) ride the existing WriteRequest machinery so the daemon's
+// allow_mutations gate + the TUI's --write flag govern them.
+type ScannerPanel struct {
+	// cursor selects one of two enumerable rows: a trunked system
+	// (Systems section) or a conventional channel (Conv section).
+	// We treat both sections as one virtual list keyed by
+	// (section, index); cursorAt yields the selected slot.
+	cursor int
+}
+
+// NewScanner returns a new read+write scanner cockpit.
+func NewScanner() *ScannerPanel {
+	return &ScannerPanel{}
+}
+
+func (ScannerPanel) Title() string { return "Scanner" }
+
+var (
+	scanHoldKey   = key.NewBinding(key.WithKeys("h"), key.WithHelp("h", "hold/resume"))
+	scanRetuneKey = key.NewBinding(key.WithKeys("r"), key.WithHelp("r", "force re-hunt"))
+	scanDwellKey  = key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "dwell on conv channel"))
+	scanModeKey   = key.NewBinding(key.WithKeys("m"), key.WithHelp("m", "cycle scan mode"))
+	scanUpKey     = key.NewBinding(key.WithKeys("up", "k"), key.WithHelp("k/↑", "row up"))
+	scanDownKey   = key.NewBinding(key.WithKeys("down", "j"), key.WithHelp("j/↓", "row down"))
+)
+
+func (ScannerPanel) Keys() []key.Binding {
+	return []key.Binding{scanHoldKey, scanRetuneKey, scanDwellKey, scanModeKey, scanUpKey, scanDownKey}
+}
+
+func (p *ScannerPanel) rowCount(s *state.SharedState) int {
+	return len(s.Scanner.Systems) + len(s.Scanner.Conventional.Channels)
+}
+
+// resolveCursor returns (section, indexWithinSection). section is
+// "sys" or "conv". Returns ("", 0) when there are no rows.
+func (p *ScannerPanel) resolveCursor(s *state.SharedState) (string, int) {
+	nSys := len(s.Scanner.Systems)
+	nConv := len(s.Scanner.Conventional.Channels)
+	if nSys+nConv == 0 {
+		return "", 0
+	}
+	if p.cursor < 0 {
+		p.cursor = 0
+	}
+	if p.cursor >= nSys+nConv {
+		p.cursor = nSys + nConv - 1
+	}
+	if p.cursor < nSys {
+		return "sys", p.cursor
+	}
+	return "conv", p.cursor - nSys
+}
+
+func (p *ScannerPanel) Update(msg tea.Msg, s *state.SharedState) (Panel, tea.Cmd) {
+	km, ok := msg.(tea.KeyMsg)
+	if !ok {
+		return p, nil
+	}
+	section, idx := p.resolveCursor(s)
+	switch {
+	case key.Matches(km, scanUpKey):
+		if p.cursor > 0 {
+			p.cursor--
+		}
+		return p, nil
+	case key.Matches(km, scanDownKey):
+		if p.cursor < p.rowCount(s)-1 {
+			p.cursor++
+		}
+		return p, nil
+	case key.Matches(km, scanModeKey):
+		next := "list"
+		if s.Scanner.ScanMode == "list" {
+			next = "all"
+		}
+		req := state.WriteRequest{
+			Label:       fmt.Sprintf("set scan_mode=%s", next),
+			Kind:        state.WriteKindScannerMode,
+			ScannerMode: &state.ScannerModeReq{Mode: next},
+		}
+		return p, Emit(req)
+	case key.Matches(km, scanHoldKey):
+		switch section {
+		case "sys":
+			sys := s.Scanner.Systems[idx]
+			kind := state.WriteKindScannerHuntHold
+			verb := "hold"
+			if sys.State == "held" {
+				kind = state.WriteKindScannerHuntResume
+				verb = "resume"
+			}
+			req := state.WriteRequest{
+				Label:       fmt.Sprintf("%s hunt %s", verb, sys.Name),
+				Kind:        kind,
+				ScannerHunt: &state.ScannerHuntReq{System: sys.Name},
+			}
+			return p, Emit(req)
+		case "conv":
+			kind := state.WriteKindScannerConvHold
+			verb := "hold"
+			if s.Scanner.Conventional.State == "held" {
+				kind = state.WriteKindScannerConvResume
+				verb = "resume"
+			}
+			req := state.WriteRequest{
+				Label:       fmt.Sprintf("%s conventional scanner", verb),
+				Kind:        kind,
+				ScannerConv: &state.ScannerConvReq{},
+			}
+			return p, Emit(req)
+		}
+	case key.Matches(km, scanRetuneKey):
+		if section == "sys" {
+			sys := s.Scanner.Systems[idx]
+			req := state.WriteRequest{
+				Confirm:     fmt.Sprintf("Force re-hunt for system %s?", sys.Name),
+				Label:       fmt.Sprintf("force re-hunt %s", sys.Name),
+				Kind:        state.WriteKindScannerHuntRetune,
+				ScannerHunt: &state.ScannerHuntReq{System: sys.Name},
+			}
+			return p, Emit(req)
+		}
+	case key.Matches(km, scanDwellKey):
+		if section == "conv" {
+			ch := s.Scanner.Conventional.Channels[idx]
+			req := state.WriteRequest{
+				Label:       fmt.Sprintf("dwell on %s (%d Hz)", ch.Label, ch.FrequencyHz),
+				Kind:        state.WriteKindScannerConvDwell,
+				ScannerConv: &state.ScannerConvReq{Index: idx},
+			}
+			return p, Emit(req)
+		}
+	}
+	return p, nil
+}
+
+func (p *ScannerPanel) View(width, height int, focused bool, s *state.SharedState) string {
+	_, _ = p.resolveCursor(s) // clamp cursor
+	if width < 30 || height < 6 {
+		return panelFrame("Scanner", width, height, focused, "")
+	}
+	body := strings.Join([]string{
+		p.renderSystems(width, s),
+		p.renderConventional(width, s),
+		p.renderTGSummary(width, s),
+	}, "\n")
+	return panelFrame("Scanner", width, height, focused, body)
+}
+
+func (p *ScannerPanel) renderSystems(width int, s *state.SharedState) string {
+	header := dashHeader.Render("Trunked systems")
+	if len(s.Scanner.Systems) == 0 {
+		return header + "\n" + dashDim.Render("  (no trunked systems configured)")
+	}
+	lines := []string{header}
+	section, idx := p.resolveCursor(s)
+	for i, sys := range s.Scanner.Systems {
+		marker := "  "
+		if section == "sys" && idx == i {
+			marker = "▶ "
+		}
+		stateStyle := lipgloss.NewStyle()
+		switch sys.State {
+		case "locked":
+			stateStyle = dashOK
+		case "hunting":
+			stateStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("220"))
+		case "failed":
+			stateStyle = dashErr
+		case "held":
+			stateStyle = dashDim
+		}
+		freq := "—"
+		switch sys.State {
+		case "locked":
+			freq = client.FormatFreqMHz(sys.LockedFreqHz)
+		case "hunting":
+			freq = fmt.Sprintf("%s (%d/%d)", client.FormatFreqMHz(sys.AttemptedFreqHz),
+				sys.AttemptIndex+1, sys.TotalCandidates)
+		case "failed":
+			freq = fmt.Sprintf("retry in %s", formatBackoff(sys.BackoffMs))
+		}
+		grantAge := "—"
+		if !sys.LastGrantAt.IsZero() {
+			grantAge = formatAge(time.Since(sys.LastGrantAt))
+		}
+		row := fmt.Sprintf("%s%-12s  %-5s  %s  %s  last grant: %s",
+			marker, sys.Name, sys.Protocol, stateStyle.Render(padState(sys.State)), freq, grantAge)
+		lines = append(lines, row)
+	}
+	return strings.Join(lines, "\n")
+}
+
+func (p *ScannerPanel) renderConventional(width int, s *state.SharedState) string {
+	header := dashHeader.Render("Conventional channels")
+	cs := s.Scanner.Conventional
+	if !cs.Enabled || len(cs.Channels) == 0 {
+		return "\n" + header + "\n" + dashDim.Render("  (conventional scanner not configured)")
+	}
+	lines := []string{"", header}
+	stateLine := fmt.Sprintf("  state: %s  device: %s", cs.State, cs.DeviceSerial)
+	lines = append(lines, dashDim.Render(stateLine))
+	section, idx := p.resolveCursor(s)
+	for i, ch := range cs.Channels {
+		marker := "  "
+		if section == "conv" && idx == i {
+			marker = "▶ "
+		}
+		active := " "
+		style := lipgloss.NewStyle()
+		if ch.Active {
+			active = "●"
+			style = dashOK
+		}
+		break_ := "—"
+		if !ch.LastBreakAt.IsZero() {
+			break_ = formatAge(time.Since(ch.LastBreakAt))
+		}
+		row := fmt.Sprintf("%s%-3d %s  %s  %-12s  %-4s  last: %s",
+			marker, ch.Index, style.Render(active), padTo(ch.Label, 20),
+			client.FormatFreqMHz(ch.FrequencyHz), strings.ToUpper(ch.Mode), break_)
+		lines = append(lines, row)
+	}
+	return strings.Join(lines, "\n")
+}
+
+func (p *ScannerPanel) renderTGSummary(width int, s *state.SharedState) string {
+	header := dashHeader.Render("Talkgroup scan list")
+	mode := s.Scanner.ScanMode
+	if mode == "" {
+		mode = "all"
+	}
+	summary := fmt.Sprintf("  mode=%s   enabled=%d / total=%d   (press 'm' to cycle)",
+		mode, s.Scanner.TalkgroupScanCount, s.Scanner.TalkgroupTotalCount)
+	return "\n" + header + "\n" + dashDim.Render(summary)
+}
+
+func padState(s string) string {
+	const w = 8
+	if len(s) >= w {
+		return s
+	}
+	return s + strings.Repeat(" ", w-len(s))
+}
+
+// padTo pads s to width n with trailing spaces; truncates with an
+// ellipsis if longer.
+func padTo(s string, n int) string {
+	t := truncate(s, n)
+	if len(t) < n {
+		return t + strings.Repeat(" ", n-len(t))
+	}
+	return t
+}
+
+func formatAge(d time.Duration) string {
+	if d < time.Second {
+		return "now"
+	}
+	if d < time.Minute {
+		return fmt.Sprintf("%ds ago", int(d.Seconds()))
+	}
+	if d < time.Hour {
+		return fmt.Sprintf("%dm ago", int(d.Minutes()))
+	}
+	return fmt.Sprintf("%dh ago", int(d.Hours()))
+}
+
+func formatBackoff(ms int) string {
+	if ms < 1000 {
+		return fmt.Sprintf("%dms", ms)
+	}
+	return fmt.Sprintf("%ds", ms/1000)
+}

--- a/internal/tui/panels/scanner_test.go
+++ b/internal/tui/panels/scanner_test.go
@@ -1,0 +1,138 @@
+package panels
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/MattCheramie/GopherTrunk/internal/tui/client"
+	"github.com/MattCheramie/GopherTrunk/internal/tui/state"
+)
+
+func mkScannerState() *state.SharedState {
+	return &state.SharedState{
+		Scanner: client.ScannerStatusDTO{
+			ScanMode:            "list",
+			TalkgroupScanCount:  4,
+			TalkgroupTotalCount: 12,
+			Systems: []client.SystemHuntStatusDTO{
+				{Name: "Alpha", Protocol: "p25", State: "locked", LockedFreqHz: 851_000_000},
+				{Name: "Bravo", Protocol: "dmr", State: "hunting", AttemptedFreqHz: 460_000_000, AttemptIndex: 1, TotalCandidates: 3},
+			},
+			Conventional: client.ConvScannerStatusDTO{
+				Enabled:      true,
+				State:        "scanning",
+				DeviceSerial: "CONV-1",
+				Channels: []client.ConvChannelStatusDTO{
+					{Index: 0, Label: "Sheriff", FrequencyHz: 155_895_000, Mode: "fm"},
+					{Index: 1, Label: "Marine 16", FrequencyHz: 156_800_000, Mode: "fm", Active: true},
+				},
+			},
+		},
+	}
+}
+
+func TestScannerPanelRendersAllSections(t *testing.T) {
+	p := NewScanner()
+	s := mkScannerState()
+	view := p.View(120, 30, true, s)
+	for _, want := range []string{
+		"Trunked systems", "Alpha", "Bravo", "p25", "dmr",
+		"Conventional channels", "Sheriff", "Marine 16",
+		"Talkgroup scan list", "mode=list", "enabled=4 / total=12",
+	} {
+		if !strings.Contains(view, want) {
+			t.Errorf("view missing %q\n%s", want, view)
+		}
+	}
+}
+
+func TestScannerPanel_HoldEmitsWriteRequest(t *testing.T) {
+	p := NewScanner()
+	s := mkScannerState()
+	// First Update populates cursor at row 0 (Alpha system).
+	_, _ = p.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("k")}, s)
+	_, cmd := p.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("h")}, s)
+	if cmd == nil {
+		t.Fatal("h key should emit a WriteRequest Cmd")
+	}
+	msg := cmd()
+	wa, ok := msg.(WriteActionMsg)
+	if !ok {
+		t.Fatalf("msg type = %T, want WriteActionMsg", msg)
+	}
+	if wa.Request.Kind != state.WriteKindScannerHuntHold {
+		t.Errorf("kind = %v, want ScannerHuntHold", wa.Request.Kind)
+	}
+	if wa.Request.ScannerHunt == nil || wa.Request.ScannerHunt.System != "Alpha" {
+		t.Errorf("system = %+v, want Alpha", wa.Request.ScannerHunt)
+	}
+}
+
+func TestScannerPanel_DwellEmitsForConvRow(t *testing.T) {
+	p := NewScanner()
+	s := mkScannerState()
+	// Move cursor down past the 2 systems to the conv rows.
+	for i := 0; i < 3; i++ {
+		_, _ = p.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")}, s)
+	}
+	// Now on conv index 1.
+	_, cmd := p.Update(tea.KeyMsg{Type: tea.KeyEnter}, s)
+	if cmd == nil {
+		t.Fatal("enter on conv row should emit a Cmd")
+	}
+	wa := cmd().(WriteActionMsg)
+	if wa.Request.Kind != state.WriteKindScannerConvDwell {
+		t.Errorf("kind = %v, want ScannerConvDwell", wa.Request.Kind)
+	}
+	if wa.Request.ScannerConv == nil || wa.Request.ScannerConv.Index != 1 {
+		t.Errorf("index = %+v, want 1", wa.Request.ScannerConv)
+	}
+}
+
+func TestScannerPanel_MCyclesScanMode(t *testing.T) {
+	p := NewScanner()
+	s := mkScannerState()
+	_, cmd := p.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("m")}, s)
+	if cmd == nil {
+		t.Fatal("m key should emit a Cmd")
+	}
+	wa := cmd().(WriteActionMsg)
+	if wa.Request.Kind != state.WriteKindScannerMode {
+		t.Errorf("kind = %v, want ScannerMode", wa.Request.Kind)
+	}
+	// Current is "list" → next should be "all".
+	if wa.Request.ScannerMode == nil || wa.Request.ScannerMode.Mode != "all" {
+		t.Errorf("mode = %+v, want all", wa.Request.ScannerMode)
+	}
+}
+
+func TestScannerPanel_RetuneConfirms(t *testing.T) {
+	p := NewScanner()
+	s := mkScannerState()
+	// Cursor on Alpha (first row).
+	_, cmd := p.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("r")}, s)
+	if cmd == nil {
+		t.Fatal("r key should emit a Cmd")
+	}
+	wa := cmd().(WriteActionMsg)
+	if wa.Request.Confirm == "" {
+		t.Errorf("retune should require confirmation; Confirm = %q", wa.Request.Confirm)
+	}
+	if wa.Request.Kind != state.WriteKindScannerHuntRetune {
+		t.Errorf("kind = %v, want ScannerHuntRetune", wa.Request.Kind)
+	}
+}
+
+func TestScannerPanel_EmptyShowsHints(t *testing.T) {
+	p := NewScanner()
+	s := &state.SharedState{}
+	view := p.View(120, 30, true, s)
+	if !strings.Contains(view, "no trunked systems configured") {
+		t.Errorf("missing 'no trunked systems' hint in empty render")
+	}
+	if !strings.Contains(view, "conventional scanner not configured") {
+		t.Errorf("missing 'conventional scanner not configured' hint")
+	}
+}

--- a/internal/tui/panels/talkgroups.go
+++ b/internal/tui/panels/talkgroups.go
@@ -63,12 +63,13 @@ var (
 	tgSortKey     = key.NewBinding(key.WithKeys("s"), key.WithHelp("s", "sort"))
 	tgEscKey      = key.NewBinding(key.WithKeys("esc"), key.WithHelp("esc", "exit filter"))
 	tgLockoutKey  = key.NewBinding(key.WithKeys("l"), key.WithHelp("l", "toggle lockout"))
+	tgScanKey     = key.NewBinding(key.WithKeys("S"), key.WithHelp("S", "toggle scan"))
 	tgPriUpKey    = key.NewBinding(key.WithKeys("+", "="), key.WithHelp("+", "priority up"))
 	tgPriDownKey  = key.NewBinding(key.WithKeys("-", "_"), key.WithHelp("-", "priority down"))
 )
 
 func (TalkgroupsPanel) Keys() []key.Binding {
-	return []key.Binding{tgFilterKey, tgSortKey, tgLockoutKey, tgPriUpKey, tgPriDownKey}
+	return []key.Binding{tgFilterKey, tgSortKey, tgLockoutKey, tgScanKey, tgPriUpKey, tgPriDownKey}
 }
 
 // selectedTalkgroup returns the currently-highlighted row's
@@ -151,6 +152,21 @@ func (p *TalkgroupsPanel) Update(msg tea.Msg, s *state.SharedState) (Panel, tea.
 				},
 			}
 			return p, Emit(req)
+		case key.Matches(m, tgScanKey):
+			tg, ok := p.selectedTalkgroup(s.Talkgroups)
+			if !ok {
+				return p, nil
+			}
+			next := !tg.Scan
+			req := state.WriteRequest{
+				Label: fmt.Sprintf("set scan=%v on TG %d", next, tg.ID),
+				Kind:  state.WriteKindUpdateTalkgroup,
+				UpdateTalkgroup: &state.UpdateTalkgroupReq{
+					ID:   tg.ID,
+					Scan: &next,
+				},
+			}
+			return p, Emit(req)
 		case key.Matches(m, tgPriUpKey), key.Matches(m, tgPriDownKey):
 			tg, ok := p.selectedTalkgroup(s.Talkgroups)
 			if !ok {
@@ -209,6 +225,10 @@ func (p *TalkgroupsPanel) refresh(tgs []client.TalkgroupDTO) {
 		if tg.Lockout {
 			lock = "✓"
 		}
+		scan := "✓"
+		if !tg.Scan {
+			scan = ""
+		}
 		rows = append(rows, table.Row{
 			fmt.Sprintf("%d", tg.ID),
 			tg.AlphaTag,
@@ -217,6 +237,7 @@ func (p *TalkgroupsPanel) refresh(tgs []client.TalkgroupDTO) {
 			tg.Mode,
 			fmt.Sprintf("%d", tg.Priority),
 			lock,
+			scan,
 		})
 	}
 	p.tbl.SetRows(rows)
@@ -241,12 +262,13 @@ func talkgroupsColumns(w int) []table.Column {
 	}
 	idW := 8
 	alphaW := w * 22 / 100
-	tagW := w * 16 / 100
-	groupW := w * 18 / 100
-	modeW := 10
-	priW := 6
-	lockW := 6
-	used := idW + alphaW + tagW + groupW + modeW + priW + lockW + 14
+	tagW := w * 14 / 100
+	groupW := w * 16 / 100
+	modeW := 8
+	priW := 5
+	lockW := 5
+	scanW := 5
+	used := idW + alphaW + tagW + groupW + modeW + priW + lockW + scanW + 16
 	if used >= w {
 		alphaW -= used - w + 1
 	}
@@ -258,5 +280,6 @@ func talkgroupsColumns(w int) []table.Column {
 		{Title: "Mode", Width: modeW},
 		{Title: "Pri", Width: priW},
 		{Title: "Lock", Width: lockW},
+		{Title: "Scan", Width: scanW},
 	}
 }

--- a/internal/tui/state/state.go
+++ b/internal/tui/state/state.go
@@ -23,6 +23,7 @@ const (
 	PanelTones
 	PanelMetrics
 	PanelDevices
+	PanelScanner
 	PanelCount
 )
 
@@ -46,6 +47,8 @@ func (p PanelKind) String() string {
 		return "Metrics"
 	case PanelDevices:
 		return "Devices"
+	case PanelScanner:
+		return "Scanner"
 	}
 	return "?"
 }
@@ -73,6 +76,8 @@ type SharedState struct {
 	Metrics     map[string]float64
 	Devices     []client.SDRStatus
 	DevicesErr  error
+	Scanner     client.ScannerStatusDTO
+	ScannerErr  error
 
 	EventLog   RingReader[client.Event]
 	ToneAlerts RingReader[client.Event]
@@ -110,6 +115,9 @@ type WriteRequest struct {
 	UpdateTalkgroup *UpdateTalkgroupReq
 	SweepRetention  *SweepRetentionReq
 	ResetTone       *ResetToneReq
+	ScannerMode     *ScannerModeReq
+	ScannerHunt     *ScannerHuntReq
+	ScannerConv     *ScannerConvReq
 }
 
 // WriteKind discriminates a WriteRequest's payload.
@@ -121,7 +129,25 @@ const (
 	WriteKindUpdateTalkgroup
 	WriteKindSweepRetention
 	WriteKindResetTone
+	WriteKindScannerMode
+	WriteKindScannerHuntHold
+	WriteKindScannerHuntResume
+	WriteKindScannerHuntRetune
+	WriteKindScannerConvHold
+	WriteKindScannerConvResume
+	WriteKindScannerConvDwell
 )
+
+// ScannerModeReq sets the engine's global scan_mode at runtime.
+type ScannerModeReq struct{ Mode string }
+
+// ScannerHuntReq targets a single trunked system for hold / resume /
+// force-retune. The WriteKind discriminates the operation.
+type ScannerHuntReq struct{ System string }
+
+// ScannerConvReq is shared by hold / resume / dwell-on-index for the
+// conventional scanner. Index is ignored for hold/resume.
+type ScannerConvReq struct{ Index int }
 
 // EndCallReq forces the engine to release the active call held on
 // the given device.
@@ -130,12 +156,13 @@ type EndCallReq struct {
 	Reason       string // optional; "" means "manual"
 }
 
-// UpdateTalkgroupReq mutates priority and/or lockout on a talkgroup.
-// Pointer fields allow "leave unchanged" semantics.
+// UpdateTalkgroupReq mutates priority and/or lockout and/or scan on a
+// talkgroup. Pointer fields allow "leave unchanged" semantics.
 type UpdateTalkgroupReq struct {
 	ID       uint32
 	Priority *int
 	Lockout  *bool
+	Scan     *bool
 }
 
 // SweepRetentionReq runs one immediate retention sweep.


### PR DESCRIPTION
## Summary

Two commits, both driven by an audit of the README's known gaps + roadmap and a request to make every feature operable from the TUI.

- **Roadmap fills + TUI Devices panel (`6c0af63`)** — closes the four genuinely-open items from the README: pure-Go P25 P1 IQ→C4FM dibit receiver glue (`internal/radio/p25/phase1/receiver`), YSF FICH Trellis decoder + control-channel grant emission (`internal/radio/ysf/fich_trellis.go` + `control.go`), SDR pool now publishes `sdr.attached`/`sdr.detached` events with a typed `SDRStatus` payload, new `GET /api/v1/devices` endpoint, new 9th TUI panel (key `9`) for the SDR pool plus `Enter`-to-drill-in modals on Systems and Talkgroups. Confirms the install is fully standalone (`CGO_ENABLED=0` end-to-end, no librtlsdr/libusb, embedded SQLite, no DLLs in Windows installer).
- **Police-scanner cockpit (`10c6cc2`)** — a four-track scanner subsystem turning GopherTrunk into a high-end digital-trunking scanner experience driven entirely from the TUI:
  - **CC Hunter supervisor** (`internal/scanner/cchunt`) multiplexes per-system `trunking.Hunter` runs over one control SDR, publishes `cchunt.progress` / `cchunt.failed`, persists last-good CCs to JSON cache, supports hold/resume/force-retune. Honest scope flag: until the IQ-domain CC decoders land, the supervisor will report `state=failed` + backoff rather than fake a `cc.locked` event.
  - **Talkgroup scan list** — new `TalkGroup.Scan` field (defaults true, CSV/JSON compatible) + `Engine.ScanMode` enum (`all`|`list`) gating `HandleGrant`; Emergency bypasses; runtime-mutable via PATCH `/api/v1/scanner` and capital-`S` on the Talkgroups panel.
  - **Conventional FM scanner** (`internal/scanner/conventional`) — fixed-frequency analog scan list with IQ-power dBFS squelch, hop-on-silence state machine; synthesizes calls through new `Engine.HandleSyntheticCall` / `EndSyntheticCall` so the recorder, call log, and `/api/v1/calls/active` all light up unchanged.
  - **Scanner TUI panel (key `0`) + REST cockpit** — three-section cockpit (Systems / Conventional / TG-scan-summary). Operator keys: `h` hold/resume, `r` force re-hunt (confirms), `Enter` dwell on conv channel, `m` cycle scan_mode. Seven new REST endpoints under `/api/v1/scanner`, all gated behind `api.allow_mutations`. Re-polls on `cchunt.progress`, `cchunt.failed`, `cc.locked`, `cc.lost` SSE events.

Two new SSE event kinds (`cchunt.progress`, `cchunt.failed`); two new event types reusing `KindSDRAttached` / `KindSDRDetached` (declared but previously unpublished); two new engine APIs (`HandleSyntheticCall`, `EndSyntheticCall`); one new config block (`scanner:` — pre-scanner configs work unchanged).

Diff: 59 files, +5,398 / −101.

## Test plan

- [x] `make test` (race, full suite) — all green
- [x] `make integration` (wired daemon end-to-end) — green
- [x] `go vet ./...` clean
- [x] New unit tests for: `TalkGroup.Scan` CSV/JSON defaults, `Engine.ScanMode` gate (allowed/dropped/emergency-bypass), `Engine.HandleSyntheticCall` / `EndSyntheticCall`, `cchunt.Supervisor` (success/failure/hold/resume/force-retune/ctx-cancel), conventional scanner (hop on silence, squelch break + hangtime, hold/resume/dwell, bad-config rejection), squelch `PowerDbFS` thresholds, `GET /api/v1/scanner` handler (status + all 6 mutations, gating behavior), Scanner TUI panel (renders all sections, each keystroke emits the right `WriteRequest`)
- [x] `gophertrunk sdr list` + `gophertrunk decode -list-vocoders` still work
- [x] Backwards compat: configs without a `scanner:` block, CSVs without a `Scan` column, JSON without a `scan` key — all keep the existing "follow every grant" behavior
- [ ] **Manual real-air smoke**: run daemon with `allow_mutations: true`, open TUI with `--write`, press `0`, exercise hold/resume/retune on a hunting system and dwell-on-channel for a configured conv channel (needs a dongle + a system that produces `cc.locked` — currently gated on the IQ-domain decoder follow-up)

https://claude.ai/code/session_01ShqcNot3uQBWn3gCipSjYA

---
_Generated by [Claude Code](https://claude.ai/code/session_01ShqcNot3uQBWn3gCipSjYA)_