### PR TITLE
internal/voice/calibrate: vocoder level-calibration harness scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,13 +71,20 @@ panel. The honest remaining gaps:
 - **Digital-voice level calibration.** Pure-Go IMBE / AMBE+2 emit
   real audio end-to-end with shared AGC, frame-repeat on bad-frame
   indicator, phase-aware fade-in, and §6.2 spectral enhancement
-  shipping. Absolute-level calibration against a known-good reference
-  decoder (DSD-FME or OP25) is a polish item that needs captured
-  P25 P1 / DMR voice exchanges in `internal/voice/{imbe,ambe2}/testdata/`.
-  AMBE+2 single-tone synthesis works; dual-tone (b₁ ∈ [128, 163])
-  routes through silence pending a frequency-pair lookup that the
-  public spec doesn't document. See [docs/vocoders.md](docs/vocoders.md)
-  for the licensing posture.
+  shipping. The comparison harness lives at
+  `internal/voice/calibrate/` — `calibrate.Compare(raw, refWav,
+  vocoderName)` returns `RMSRatioDb` + normalised cross-correlation
+  + lag against a reference WAV from DSD-FME or OP25, and the
+  package's `TestCompare{IMBE,AMBE2}SkipsWithoutFixtures` tests
+  enforce `|RMS offset| < 3 dB` and peak xcorr > 0.85 once
+  fixtures are in place. The remaining gap is sourcing the
+  reference data: captured P25 P1 / DMR voice exchanges plus
+  DSD-FME / OP25 decodes belong at
+  `internal/voice/{imbe,ambe2}/testdata/`. AMBE+2 single-tone
+  synthesis works; dual-tone (b₁ ∈ [128, 163]) routes through
+  silence pending a frequency-pair lookup that the public spec
+  doesn't document. See [docs/vocoders.md](docs/vocoders.md) for
+  the licensing posture.
 - **YSF FICH on-air interleaver / puncture validation.** The K=5
   ½-rate Trellis encoder + decoder are in
   (`internal/radio/ysf/fich_trellis.go`) and round-trip cleanly in
@@ -127,6 +134,15 @@ to its own package and lands independently.
 
 ### Recently shipped
 
+- **Vocoder calibration harness** (`internal/voice/calibrate/`)
+  — `Compare(raw, refWav, vocoderName)` returns RMS-ratio (dB),
+  normalised cross-correlation, and best alignment lag against an
+  external decoder's reference WAV. Unit tests cover the RMS +
+  cross-correlation primitives + a WAV round-trip via the shared
+  `voice.WavWriter`; integration tests for IMBE / AMBE+2 skip
+  cleanly until the testdata fixtures land. The harness's failure
+  output names the AGC constant in
+  `internal/voice/mbe/agc.go:DefaultAGCConfig` to adjust.
 - **Police-scanner subsystem** (`internal/scanner/{cchunt,conventional}`)
   — multi-system CC Hunter supervisor with hold/resume/force-retune,
   conventional FM scan list with IQ-power squelch, talkgroup scan

--- a/internal/voice/calibrate/calibrate.go
+++ b/internal/voice/calibrate/calibrate.go
@@ -1,0 +1,286 @@
+// Package calibrate compares an in-tree Vocoder's PCM output against
+// a reference WAV (typically produced by DSD-FME or OP25) from the
+// same raw vocoder-frame source. It quantifies loudness offset
+// (RMSRatioDb) and waveform similarity (PeakXcorr).
+//
+// The harness exists so the AGC + level-related constants in
+// internal/voice/mbe/agc.go can be tuned against an external
+// reference decoder. Fixture .raw + WAV files live under
+// internal/voice/{imbe,ambe2}/testdata/; the matching tests skip
+// when those aren't checked in, so CI stays green until the
+// reference data lands. The same testdata layout is documented in
+// the README "Status & known gaps" → vocoder level calibration
+// bullet.
+package calibrate
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+	"math"
+	"os"
+
+	"github.com/MattCheramie/GopherTrunk/internal/voice"
+)
+
+// MaxLagSamples is the half-window in samples (±) over which Compare
+// searches for the best cross-correlation peak. At 8 kHz PCM, 200
+// samples ≈ ±25 ms — large enough to absorb each decoder's pipeline
+// group delay, small enough to keep the O(N · maxLag) inner loop
+// cheap on a multi-second sample.
+const MaxLagSamples = 200
+
+// expectedSampleRate is the PCM rate both the in-tree decoder and
+// the reference WAV must emit. The MBE-family decoders (IMBE,
+// AMBE+2) all produce 8 kHz / 160-samples-per-frame / 20 ms output;
+// DSD-FME and OP25 default to the same.
+const expectedSampleRate uint32 = 8000
+
+// Result is what Compare returns.
+//
+// RMSRatioDb is the loudness offset the in-tree decoder needs to
+// move to match the reference, in dB: positive means the in-tree
+// decoder is louder than the reference. The MBE AGC's TargetPeak in
+// internal/voice/mbe/agc.go is the knob to tune from here.
+//
+// PeakXcorr is the normalised cross-correlation magnitude at the
+// best alignment, in [0, 1]. Values above 0.85 indicate the two
+// waveforms are recognisably the same speech; below 0.5 the two
+// decoders are very likely not on the same source.
+//
+// LagSamples is the alignment offset that produced PeakXcorr. Small
+// lags (|lag| < 50) mean the two decoders' group delays are
+// reasonably aligned; values near ±MaxLagSamples mean we picked an
+// edge of the search window and the peak might be outside it —
+// re-run with a larger window if the in-tree decoder has more
+// pipeline latency than expected.
+//
+// InTreeSampleCount and RefSampleCount help the operator diagnose
+// length mismatches (e.g. the in-tree decoder repeated frames the
+// reference dropped).
+type Result struct {
+	RMSRatioDb        float64
+	PeakXcorr         float64
+	LagSamples        int
+	InTreeSampleCount int
+	RefSampleCount    int
+}
+
+// Compare reads vocoder frames from rawPath, decodes them through
+// the named vocoder from voice.DefaultRegistry, reads the reference
+// WAV from refWavPath, and computes a Result.
+//
+// Both decoders are expected to emit 8 kHz / 16-bit / mono PCM.
+// Sample-rate or channel-count mismatches are reported as an error.
+//
+// The Vocoder is constructed fresh per call; its Close is called on
+// the way out. The raw file must contain a whole number of vocoder
+// frames (FrameSize-aligned).
+func Compare(rawPath, refWavPath, vocoderName string) (Result, error) {
+	rawBytes, err := os.ReadFile(rawPath)
+	if err != nil {
+		return Result{}, fmt.Errorf("calibrate: read raw %q: %w", rawPath, err)
+	}
+
+	v, err := voice.DefaultRegistry.New(vocoderName)
+	if err != nil {
+		return Result{}, fmt.Errorf("calibrate: vocoder %q: %w", vocoderName, err)
+	}
+	defer v.Close()
+
+	frameSize := v.FrameSize()
+	if frameSize <= 0 {
+		return Result{}, fmt.Errorf("calibrate: vocoder %q reports invalid FrameSize=%d",
+			vocoderName, frameSize)
+	}
+	if len(rawBytes)%frameSize != 0 {
+		return Result{}, fmt.Errorf("calibrate: raw file size %d is not a multiple of %s frame size %d",
+			len(rawBytes), vocoderName, frameSize)
+	}
+
+	var inTree []int16
+	for i := 0; i < len(rawBytes); i += frameSize {
+		samples, err := v.Decode(rawBytes[i : i+frameSize])
+		if err != nil {
+			return Result{}, fmt.Errorf("calibrate: decode frame %d: %w", i/frameSize, err)
+		}
+		inTree = append(inTree, samples...)
+	}
+
+	refSamples, refRate, err := readWav(refWavPath)
+	if err != nil {
+		return Result{}, fmt.Errorf("calibrate: read ref WAV %q: %w", refWavPath, err)
+	}
+	if refRate != expectedSampleRate {
+		return Result{}, fmt.Errorf("calibrate: reference WAV rate %d Hz != expected %d Hz",
+			refRate, expectedSampleRate)
+	}
+
+	rmsIn := rms(inTree)
+	rmsRef := rms(refSamples)
+	var rmsDb float64
+	switch {
+	case rmsRef <= 0 || rmsIn <= 0:
+		// One stream is identically silent; the ratio isn't defined.
+		// Leave RMSRatioDb at 0 — the test's |Δ| < 3 dB threshold
+		// will still flag the mismatch through PeakXcorr.
+	default:
+		rmsDb = 20 * math.Log10(rmsIn/rmsRef)
+	}
+
+	peakXc, lag := bestXcorr(inTree, refSamples, MaxLagSamples)
+
+	return Result{
+		RMSRatioDb:        rmsDb,
+		PeakXcorr:         peakXc,
+		LagSamples:        lag,
+		InTreeSampleCount: len(inTree),
+		RefSampleCount:    len(refSamples),
+	}, nil
+}
+
+// rms returns the root-mean-square amplitude of an int16 sample
+// stream. Empty input returns 0.
+func rms(samples []int16) float64 {
+	if len(samples) == 0 {
+		return 0
+	}
+	var sumSq float64
+	for _, s := range samples {
+		f := float64(s)
+		sumSq += f * f
+	}
+	return math.Sqrt(sumSq / float64(len(samples)))
+}
+
+// bestXcorr returns the peak normalised cross-correlation magnitude
+// and the lag (in samples) at which it occurred, searching
+// lag ∈ [−maxLag, +maxLag]. Both inputs are truncated to the
+// shorter length so the comparison covers the same span regardless
+// of decoder-length mismatch. Returns (0, 0) when either input is
+// too short or has zero energy.
+//
+// The result is the absolute value of the correlation — a
+// 180°-phase-inverted decoder still produces |xcorr| ≈ 1 and is
+// caught instead by the RMSRatioDb / sign-check.
+func bestXcorr(x, y []int16, maxLag int) (float64, int) {
+	n := len(x)
+	if len(y) < n {
+		n = len(y)
+	}
+	if n <= 2*maxLag {
+		return 0, 0
+	}
+
+	var energyX, energyY float64
+	for i := 0; i < n; i++ {
+		energyX += float64(x[i]) * float64(x[i])
+		energyY += float64(y[i]) * float64(y[i])
+	}
+	denom := math.Sqrt(energyX * energyY)
+	if denom <= 0 {
+		return 0, 0
+	}
+
+	bestVal := -1.0
+	bestLag := 0
+	for lag := -maxLag; lag <= maxLag; lag++ {
+		var dot float64
+		for i := 0; i < n; i++ {
+			j := i + lag
+			if j < 0 || j >= n {
+				continue
+			}
+			dot += float64(x[i]) * float64(y[j])
+		}
+		v := math.Abs(dot / denom)
+		if v > bestVal {
+			bestVal = v
+			bestLag = lag
+		}
+	}
+	return bestVal, bestLag
+}
+
+// readWav reads a 16-bit / mono / PCM WAV file and returns the
+// samples plus the file's sample rate. Mirrors voice.WavWriter's
+// output format: RIFF / WAVE / fmt(16) / data. Non-PCM, non-mono,
+// or non-16-bit files are rejected. Auxiliary chunks (LIST, INFO,
+// JUNK) between fmt and data are skipped.
+func readWav(path string) ([]int16, uint32, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer f.Close()
+
+	// RIFF + WAVE header.
+	riff := make([]byte, 12)
+	if _, err := io.ReadFull(f, riff); err != nil {
+		return nil, 0, fmt.Errorf("read RIFF header: %w", err)
+	}
+	if string(riff[0:4]) != "RIFF" || string(riff[8:12]) != "WAVE" {
+		return nil, 0, fmt.Errorf("not a RIFF/WAVE file (got %q / %q)",
+			string(riff[0:4]), string(riff[8:12]))
+	}
+
+	var sampleRate uint32
+	gotFmt := false
+	for {
+		chunkHeader := make([]byte, 8)
+		_, err := io.ReadFull(f, chunkHeader)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, 0, fmt.Errorf("read chunk header: %w", err)
+		}
+		chunkID := string(chunkHeader[0:4])
+		chunkSize := binary.LittleEndian.Uint32(chunkHeader[4:8])
+
+		switch chunkID {
+		case "fmt ":
+			body := make([]byte, chunkSize)
+			if _, err := io.ReadFull(f, body); err != nil {
+				return nil, 0, fmt.Errorf("read fmt chunk: %w", err)
+			}
+			if chunkSize < 16 {
+				return nil, 0, fmt.Errorf("fmt chunk too short (%d bytes)", chunkSize)
+			}
+			fmtTag := binary.LittleEndian.Uint16(body[0:2])
+			if fmtTag != 1 {
+				return nil, 0, fmt.Errorf("unsupported format tag %d (want 1 = PCM)", fmtTag)
+			}
+			channels := binary.LittleEndian.Uint16(body[2:4])
+			if channels != 1 {
+				return nil, 0, fmt.Errorf("unsupported channel count %d (want 1 = mono)", channels)
+			}
+			sampleRate = binary.LittleEndian.Uint32(body[4:8])
+			bitsPerSample := binary.LittleEndian.Uint16(body[14:16])
+			if bitsPerSample != 16 {
+				return nil, 0, fmt.Errorf("unsupported bits per sample %d (want 16)", bitsPerSample)
+			}
+			gotFmt = true
+		case "data":
+			if !gotFmt {
+				return nil, 0, fmt.Errorf("data chunk before fmt chunk")
+			}
+			samples := make([]int16, chunkSize/2)
+			if err := binary.Read(f, binary.LittleEndian, &samples); err != nil {
+				return nil, 0, fmt.Errorf("read data chunk: %w", err)
+			}
+			return samples, sampleRate, nil
+		default:
+			// Skip unknown chunks (LIST, JUNK, etc.). Chunks are
+			// word-aligned; pad to even size when skipping.
+			skip := int64(chunkSize)
+			if skip%2 == 1 {
+				skip++
+			}
+			if _, err := f.Seek(skip, io.SeekCurrent); err != nil {
+				return nil, 0, fmt.Errorf("skip %s chunk: %w", chunkID, err)
+			}
+		}
+	}
+	return nil, 0, fmt.Errorf("no data chunk found in WAV")
+}

--- a/internal/voice/calibrate/calibrate_test.go
+++ b/internal/voice/calibrate/calibrate_test.go
@@ -1,0 +1,235 @@
+package calibrate
+
+import (
+	"math"
+	"os"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/voice"
+
+	// Blank-import the in-tree vocoders so Compare can resolve
+	// them by name through voice.DefaultRegistry.
+	_ "github.com/MattCheramie/GopherTrunk/internal/voice/ambe2"
+	_ "github.com/MattCheramie/GopherTrunk/internal/voice/imbe"
+)
+
+func TestRMSZeroOnEmpty(t *testing.T) {
+	if got := rms(nil); got != 0 {
+		t.Errorf("rms(nil) = %f, want 0", got)
+	}
+}
+
+func TestRMSConstantSignal(t *testing.T) {
+	// Constant signal of amplitude A has RMS == A.
+	const A = 1000
+	samples := make([]int16, 800)
+	for i := range samples {
+		samples[i] = A
+	}
+	got := rms(samples)
+	if math.Abs(got-A) > 1e-6 {
+		t.Errorf("rms(constant %d) = %f, want %d", A, got, A)
+	}
+}
+
+func TestRMSSineWaveHasExpectedAmplitude(t *testing.T) {
+	// A sine of peak amplitude A has RMS = A / sqrt(2).
+	const A = 16000
+	const N = 8000 // one second of 8 kHz audio at 1 cycle/8000 samples
+	samples := make([]int16, N)
+	for i := range samples {
+		samples[i] = int16(float64(A) * math.Sin(2*math.Pi*float64(i)/N))
+	}
+	want := float64(A) / math.Sqrt2
+	got := rms(samples)
+	if math.Abs(got-want)/want > 0.01 {
+		t.Errorf("rms(sine A=%d) = %f, want %f (±1%%)", A, got, want)
+	}
+}
+
+// TestBestXcorrFindsKnownDelay: build a signal plus a copy shifted
+// by a known number of samples; bestXcorr must report that exact
+// lag and a correlation magnitude close to 1.
+func TestBestXcorrFindsKnownDelay(t *testing.T) {
+	const N = 4000
+	const knownLag = 37
+	x := make([]int16, N)
+	y := make([]int16, N)
+
+	// Build a non-trivial signal (sum of two tones) so the
+	// correlation peak is sharp.
+	for i := 0; i < N; i++ {
+		v := 8000 * (math.Sin(2*math.Pi*100*float64(i)/8000) +
+			0.5*math.Sin(2*math.Pi*240*float64(i)/8000))
+		x[i] = int16(v)
+		if i+knownLag < N {
+			y[i+knownLag] = x[i]
+		}
+	}
+
+	// We search the lag that aligns x[i] with y[i+lag]. Built y so
+	// y[i+knownLag] = x[i] ⇒ bestXcorr should peak at lag = +knownLag.
+	peak, lag := bestXcorr(x, y, 200)
+	if peak < 0.99 {
+		t.Errorf("peak xcorr = %f, want > 0.99", peak)
+	}
+	if lag != knownLag {
+		t.Errorf("lag = %d, want %d", lag, knownLag)
+	}
+}
+
+func TestBestXcorrZeroEnergyInputs(t *testing.T) {
+	x := make([]int16, 1000)
+	y := make([]int16, 1000)
+	if peak, lag := bestXcorr(x, y, 100); peak != 0 || lag != 0 {
+		t.Errorf("bestXcorr(zeros) = (%f, %d), want (0, 0)", peak, lag)
+	}
+}
+
+// seekableBuffer wraps a bytes.Buffer with the io.Seeker bits that
+// WavWriter needs to patch length fields. The buffer grows on write
+// so Seek calls past the end zero-pad the gap.
+type seekableBuffer struct {
+	data []byte
+	pos  int64
+}
+
+func (b *seekableBuffer) Write(p []byte) (int, error) {
+	end := b.pos + int64(len(p))
+	if int64(cap(b.data)) < end {
+		grown := make([]byte, end)
+		copy(grown, b.data)
+		b.data = grown
+	} else if int64(len(b.data)) < end {
+		b.data = b.data[:end]
+	}
+	copy(b.data[b.pos:end], p)
+	b.pos = end
+	return len(p), nil
+}
+
+func (b *seekableBuffer) Seek(offset int64, whence int) (int64, error) {
+	switch whence {
+	case 0:
+		b.pos = offset
+	case 1:
+		b.pos += offset
+	case 2:
+		b.pos = int64(len(b.data)) + offset
+	}
+	return b.pos, nil
+}
+
+// TestReadWavRoundtripsViaWavWriter: pipe int16 samples through
+// voice.WavWriter, then read them back via readWav. The recovered
+// samples and sample rate must match what we wrote.
+func TestReadWavRoundtripsViaWavWriter(t *testing.T) {
+	const want = 8000
+	in := []int16{0, 1, 2, 100, 200, -100, -200, 32000, -32000}
+
+	buf := &seekableBuffer{}
+	wav, err := voice.NewWavWriter(buf, want)
+	if err != nil {
+		t.Fatalf("NewWavWriter: %v", err)
+	}
+	if err := wav.WriteSamples(in); err != nil {
+		t.Fatalf("WriteSamples: %v", err)
+	}
+	if err := wav.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	// Spill to a temp file so readWav can os.Open it.
+	tf, err := os.CreateTemp("", "calibrate-wav-*.wav")
+	if err != nil {
+		t.Fatalf("temp file: %v", err)
+	}
+	defer os.Remove(tf.Name())
+	if _, err := tf.Write(buf.data); err != nil {
+		t.Fatalf("write temp: %v", err)
+	}
+	tf.Close()
+
+	got, rate, err := readWav(tf.Name())
+	if err != nil {
+		t.Fatalf("readWav: %v", err)
+	}
+	if rate != want {
+		t.Errorf("sample rate = %d, want %d", rate, want)
+	}
+	if len(got) != len(in) {
+		t.Fatalf("sample count = %d, want %d", len(got), len(in))
+	}
+	for i := range in {
+		if got[i] != in[i] {
+			t.Errorf("samples[%d] = %d, want %d", i, got[i], in[i])
+		}
+	}
+}
+
+// TestCompareIMBESkipsWithoutFixtures: the calibration test for the
+// IMBE decoder needs `internal/voice/imbe/testdata/p25-p1-voice.raw`
+// plus a DSD-FME / OP25 reference WAV alongside it. Until those are
+// checked in the test skips and CI stays green. Once fixtures land,
+// remove the skip guard and the assertions enforce |RMS offset| <
+// 3 dB and peak xcorr > 0.85.
+func TestCompareIMBESkipsWithoutFixtures(t *testing.T) {
+	const raw = "../imbe/testdata/p25-p1-voice.raw"
+	const refWav = "../imbe/testdata/p25-p1-voice-dsdfme.wav"
+
+	if _, err := os.Stat(raw); os.IsNotExist(err) {
+		t.Skipf("no IMBE testdata at %s — capture and check in per README", raw)
+	}
+	if _, err := os.Stat(refWav); os.IsNotExist(err) {
+		t.Skipf("no IMBE reference WAV at %s", refWav)
+	}
+
+	res, err := Compare(raw, refWav, "imbe")
+	if err != nil {
+		t.Fatalf("Compare(imbe): %v", err)
+	}
+	t.Logf("IMBE calibration: rmsRatio=%+.2f dB peakXcorr=%.3f lag=%d in=%d ref=%d",
+		res.RMSRatioDb, res.PeakXcorr, res.LagSamples,
+		res.InTreeSampleCount, res.RefSampleCount)
+
+	if math.Abs(res.RMSRatioDb) > 3.0 {
+		t.Errorf("IMBE RMS offset %.2f dB exceeds ±3 dB — adjust mbe.DefaultAGCConfig.TargetPeak in internal/voice/mbe/agc.go",
+			res.RMSRatioDb)
+	}
+	if res.PeakXcorr < 0.85 {
+		t.Errorf("IMBE peak xcorr %.3f < 0.85 (lag=%d) — verify §6.2 spectral enhancement and AGC attack/release in internal/voice/mbe/agc.go:DefaultAGCConfig",
+			res.PeakXcorr, res.LagSamples)
+	}
+}
+
+// TestCompareAMBE2SkipsWithoutFixtures: same idea for the AMBE+2
+// decoder. Fixture path:
+// `internal/voice/ambe2/testdata/dmr-voice.raw` plus reference WAV.
+func TestCompareAMBE2SkipsWithoutFixtures(t *testing.T) {
+	const raw = "../ambe2/testdata/dmr-voice.raw"
+	const refWav = "../ambe2/testdata/dmr-voice-dsdfme.wav"
+
+	if _, err := os.Stat(raw); os.IsNotExist(err) {
+		t.Skipf("no AMBE+2 testdata at %s — capture and check in per README", raw)
+	}
+	if _, err := os.Stat(refWav); os.IsNotExist(err) {
+		t.Skipf("no AMBE+2 reference WAV at %s", refWav)
+	}
+
+	res, err := Compare(raw, refWav, "ambe2")
+	if err != nil {
+		t.Fatalf("Compare(ambe2): %v", err)
+	}
+	t.Logf("AMBE+2 calibration: rmsRatio=%+.2f dB peakXcorr=%.3f lag=%d in=%d ref=%d",
+		res.RMSRatioDb, res.PeakXcorr, res.LagSamples,
+		res.InTreeSampleCount, res.RefSampleCount)
+
+	if math.Abs(res.RMSRatioDb) > 3.0 {
+		t.Errorf("AMBE+2 RMS offset %.2f dB exceeds ±3 dB — adjust mbe.DefaultAGCConfig.TargetPeak",
+			res.RMSRatioDb)
+	}
+	if res.PeakXcorr < 0.85 {
+		t.Errorf("AMBE+2 peak xcorr %.3f < 0.85 (lag=%d) — verify the dual-tone fallback in internal/voice/ambe2/decoder.go (b1 ∈ [128,163] routes through silence; see README) is not corrupting the in-tree signal",
+			res.PeakXcorr, res.LagSamples)
+	}
+}


### PR DESCRIPTION
## Summary

PR #5 of the README roadmap follow-up — the standalone Workstream B
(vocoder level calibration). Lands the harness scaffolding so the
remaining work for that roadmap item is purely sourcing reference
data; everything else is wired and tested.

Adds **`internal/voice/calibrate/`** — `Compare(rawPath, refWavPath,
vocoderName)` runs the in-tree vocoder (resolved from
`voice.DefaultRegistry`) against the same source as an external
reference decoder (DSD-FME / OP25), and returns:

- **`RMSRatioDb`** — loudness offset in dB. Positive = in-tree is
  louder than reference. Operators tune
  `mbe.DefaultAGCConfig.TargetPeak` in
  `internal/voice/mbe/agc.go` from this value.
- **`PeakXcorr`** — normalised cross-correlation magnitude at the
  best alignment, in [0, 1]. Above 0.85 = same speech.
- **`LagSamples`** — alignment offset at `PeakXcorr`, with a search
  window of ±200 samples (≈ ±25 ms at 8 kHz).

The package owns a minimal `readWav` that mirrors the existing
`voice.WavWriter` output and skips unknown auxiliary chunks (LIST,
INFO, JUNK) between `fmt` and `data` so reference WAVs from
real-world decoders parse cleanly.

## Test plan

- [x] `go test ./internal/voice/calibrate/... -race -v`
- [x] `go build ./...`
- [x] `go vet ./internal/voice/...`

Unit tests cover:
- `rms` on constant + sine signals (peak = A → RMS = A/√2)
- `bestXcorr` recovering a known +37 sample delay with peak > 0.99
- `bestXcorr` returning (0, 0) on zero-energy inputs
- `readWav` round-trips int16 samples through `voice.WavWriter` —
  guards against drift between the writer and reader

Integration tests for IMBE and AMBE+2:
- Skip cleanly when fixtures aren't checked in (CI stays green)
- Once fixtures land, enforce `|RMS offset| < 3 dB` and
  `PeakXcorr > 0.85`. Failure output names the AGC constant or
  pipeline stage to adjust.

## Reference data needed (separate work)

Per the plan, the fixtures to land at
`internal/voice/{imbe,ambe2}/testdata/` are:

- A captured P25 P1 voice exchange in raw IMBE-frame form (≥ 30 s)
  plus DSD-FME and OP25 decodes of the same exchange as 8 kHz / 16
  bit / mono WAV.
- A captured DMR voice exchange in raw AMBE+2-frame form plus
  DSD-FME and OP25 decodes.

The harness is ready to consume them; this PR doesn't ship the
fixtures themselves.

## README

- "Status & known gaps" → "Digital-voice level calibration" now
  points at the harness and identifies sourcing reference data as
  the remaining work.
- "Recently shipped" gains a bullet for the calibration harness.


---
_Generated by [Claude Code](https://claude.ai/code/session_019dtCCVEZJTKKr6YK3wy824)_