### PR TITLE
internal/radio/dmr/receiver: IQ → C4FM dibit receiver for DMR

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ frontend over gRPC, HTTP/SSE, or WebSocket.
 | FEC primitives    | CRC-CCITT/FALSE + CRC-CCITT/XMODEM (callable init), CRC-6 (NXDN SACCH), Hamming(15,11,3), Hamming(13,9,3), Hamming(20,8) (DMR slot-type, t=3), extended Golay(24,12,8) + non-extended Golay(23,12,7) (P25 IMBE), BCH(63,16,11), BPTC(196,96), Reed-Solomon(12,9,4) over GF(2^8) with DMR Voice LC Header / Terminator / Embedded LC seeds, 4-state ½-rate Viterbi, 16-state K=5 ½-rate Viterbi (shared by NXDN SACCH and YSF FICH) with depuncture-marker support |
 | P25 Phase 1       | 48-bit FSW + sync detector, NID parser (NAC + DUID) with BCH(63,16,11) error correction + even-parity check, full TSBK channel decode (TIA-102.BAAA Annex A 4-state ½-rate trellis + 98-dibit block deinterleaver) → CRC trailer validation, payload parsers for GroupVoiceChannelGrant / Update / NetworkStatus / RFSSStatus, IdentifierUpdate band-plan resolver, control-channel state machine emitting `protocol = "p25"` grants and `decode.error` events with `nid-bch` / `tsbk-trellis` / `tsbk-crc` / `no-bandplan` stages |
 | P25 Phase 2       | Outbound + inbound 20-dibit sync, 360 ms / 12-subframe superframe + SlotType enum, MAC PDU parser + opcode enum, GroupVoiceChannelGrant accessor, control-channel state machine emitting `protocol = "p25-phase2"` grants |
-| DMR (Tier III)    | All 9 ETSI sync patterns, burst layout (132 dibits), Color Code + Data Type via (20,8,7) shortened-Hamming slot-type FEC (corrects up to 3 bit errors per slot type), CSBK with CRC, payload parsers for TalkGroup/Private Voice grants (LCN + timeslot) + Aloha + AdjacentSiteStatus + SystemInfoBroadcast, LCN → Hz band-plan resolver (linear + table forms), control-channel state machine emitting `protocol = "dmr-tier3"` grants and `decode.error` events with `no-bandplan` stage |
+| DMR (Tier III)    | All 9 ETSI sync patterns, burst layout (132 dibits), Color Code + Data Type via (20,8,7) shortened-Hamming slot-type FEC (corrects up to 3 bit errors per slot type), CSBK with CRC, payload parsers for TalkGroup/Private Voice grants (LCN + timeslot) + Aloha + AdjacentSiteStatus + SystemInfoBroadcast, LCN → Hz band-plan resolver (linear + table forms), IQ → C4FM dibit receiver (`internal/radio/dmr/receiver`) composing FM demod + RRC matched filter + Mueller-Müller clock recovery + 4-level slicer to fan `dmr.DibitSink` out to a future `ControlChannel.Process` adapter, control-channel state machine emitting `protocol = "dmr-tier3"` grants and `decode.error` events with `no-bandplan` stage |
 | DMR (Tier II)     | Shares the burst / slot-type / BPTC(196,96) layers with Tier III; adds a 72-bit Full Link Control parser (FLCO enum: GroupVoiceChannelUser / UnitToUnitVoice / TalkerAlias / GPS / Terminator) with RS(12,9,4) parity verification (Voice LC Header seed) and a per-repeater conventional-mode state machine that decodes Voice LC Header bursts and emits `protocol = "dmr-tier2"` grants on the bus (deduped per call, cleared on Terminator-with-LC) and `decode.error` events with `voiceheader-bptc` / `voiceheader-rs` stages |
 | NXDN              | 192-dibit frame layout (4800 BFSK / 9600 4-FSK), LICH parse with parity + 16-bit doubled-wire decoder, FSW correlator, full SACCH channel decode (K=5 ½-rate convolutional Viterbi + 60-position sub-frame deinterleaver + 12-bit puncture undo + CRC-6 trailer), CAC parser with CRC, RCCH opcode enum + payload parsers, control-channel state machine |
 | Motorola Type II  | OSW parser, opcode constants, LCN → Hz band-plan resolver (linear + table), control-channel state machine emitting `protocol = "motorola"` grants |
@@ -134,6 +134,14 @@ to its own package and lands independently.
 
 ### Recently shipped
 
+- **DMR IQ → C4FM dibit receiver** (`internal/radio/dmr/receiver`)
+  composing FM demod + RRC matched filter + Mueller-Müller clock
+  recovery + 4-level slicer into one entry point that fans dibits
+  out via the new `dmr.DibitSink` callback. Same shape as the
+  YSF / P25 P1 receivers (4800-baud C4FM is shared across the
+  4FSK family); the cross-call buffering + sync-detect + 132-dibit
+  burst assembly + `Process(dibits, baseIdx)` adapter on
+  `tier3.ControlChannel` is the next layer up.
 - **YSF IQ → C4FM dibit receiver** (`internal/radio/ysf/receiver`)
   composing FM demod + RRC matched filter + Mueller-Müller clock
   recovery + 4-level slicer into one entry point that fans dibits

--- a/internal/radio/dmr/receiver/receiver.go
+++ b/internal/radio/dmr/receiver/receiver.go
@@ -1,0 +1,173 @@
+// Package receiver wires the IQ → C4FM dibit chain that feeds the
+// DMR control-channel state machines (Tier II conventional + Tier III
+// trunked). It composes primitives that already live in internal/dsp
+// + internal/radio/dmr:
+//
+//	IQ samples
+//	  → FM discriminator (internal/dsp/demod.FM)
+//	  → RRC matched filter + 4-level slicer (internal/dsp/demod.C4FM)
+//	  → Mueller-Müller symbol clock recovery (internal/dsp/sync.MuellerMuller)
+//	  → 4-level symbol → 0..3 dibit (SymbolToDibit, local)
+//	  → dmr.DibitSink (cross-call indexed by absolute dibit position)
+//
+// DMR runs the same 4800-baud 4-level C4FM modulation as P25 Phase 1
+// and YSF, so the matched-filter parameters (RRC α = 0.20, 4800
+// sym/s) are identical. The downstream framing — 132-dibit TDMA
+// bursts with a 24-dibit sync field bracketed by 2 × 10-bit slot-
+// type fields — lives in the parent dmr package and the tier2 /
+// tier3 control-channel state machines.
+//
+// The receiver is stateful and not safe for concurrent Process calls.
+// Instantiate one per tuned frequency / per call chain. All
+// primitives it composes own their own internal history so chunk
+// boundaries do not corrupt the stream.
+package receiver
+
+import (
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/demod"
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/sync"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/dmr"
+)
+
+// DMR on-air parameters (per ETSI TS 102 361-1).
+const (
+	// SymbolRate is the channel symbol rate. Each symbol carries one
+	// dibit (2 bits) on the wire; with 2 TDMA slots the total channel
+	// capacity is 9600 bps.
+	SymbolRate = 4800.0
+	// RolloffAlpha is the RRC roll-off the matched filter is designed
+	// around. 0.20 matches the standard DMR / P25 Phase 1 / YSF
+	// receiver pulse shape.
+	RolloffAlpha = 0.20
+	// PulseSpanSymbols is the half-span of the RRC pulse on each side
+	// of the symbol time. 8 symbols (16 total) is the standard
+	// receiver-side compromise between truncation noise and CPU cost.
+	PulseSpanSymbols = 8
+)
+
+// Options configures a Receiver. Zero-valued fields fall back to the
+// DMR defaults above.
+type Options struct {
+	// SampleRateHz is the IQ sample rate after any upstream
+	// channelization. Required; must be ≥ 2 × SymbolRate.
+	SampleRateHz float64
+	// DibitSink receives the raw dibit stream the receiver decodes
+	// from IQ. The connector wraps a DMR ControlChannel adapter
+	// here once that lands; this PR ships the symbol-domain glue
+	// in isolation so the connector + adapter can land together.
+	// Required.
+	DibitSink dmr.DibitSink
+	// PulseSpanSymbols overrides the RRC half-span. <= 0 uses
+	// PulseSpanSymbols.
+	PulseSpanSymbols int
+	// Alpha overrides the RRC roll-off. <= 0 uses RolloffAlpha.
+	Alpha float64
+	// ClockGain is the Mueller-Müller loop gain. <= 0 uses 0.05.
+	ClockGain float64
+}
+
+// Receiver is the composed IQ → dibit pipeline. Process is the only
+// hot path; instantiate once per call chain and reuse.
+type Receiver struct {
+	fm        *demod.FM
+	mf        *demod.C4FM
+	clock     *sync.MuellerMuller
+	dibitSink dmr.DibitSink
+	dibitBase int
+
+	disc    []float32
+	matched []float32
+	symbols []float32
+	sliced  []int8
+	dibits  []uint8
+}
+
+// New constructs a Receiver from opts. Panics if SampleRateHz or
+// DibitSink are unset, or the resulting samples-per-symbol is below 2
+// (the Mueller-Müller loop's minimum).
+func New(opts Options) *Receiver {
+	if opts.SampleRateHz <= 0 {
+		panic("receiver: SampleRateHz is required")
+	}
+	if opts.DibitSink == nil {
+		panic("receiver: DibitSink is required")
+	}
+	sps := opts.SampleRateHz / SymbolRate
+	if sps < 2 {
+		panic("receiver: SampleRateHz must be >= 2*SymbolRate (9600 Hz)")
+	}
+	span := opts.PulseSpanSymbols
+	if span <= 0 {
+		span = PulseSpanSymbols
+	}
+	alpha := opts.Alpha
+	if alpha <= 0 {
+		alpha = RolloffAlpha
+	}
+	gain := opts.ClockGain
+	if gain <= 0 {
+		gain = 0.05
+	}
+	const slicerScale = 1.0
+
+	return &Receiver{
+		fm:        demod.NewFM(),
+		mf:        demod.NewC4FM(int(sps+0.5), span, alpha, slicerScale),
+		clock:     sync.NewMuellerMuller(sps, gain),
+		dibitSink: opts.DibitSink,
+	}
+}
+
+// Process pushes one chunk of complex64 IQ samples through the chain.
+// Zero or more dibit batches may be emitted to DibitSink during the
+// call.
+func (r *Receiver) Process(iq []complex64) {
+	if len(iq) == 0 {
+		return
+	}
+	r.disc = r.fm.Process(r.disc, iq)
+	r.matched = r.mf.MatchedFilter(r.matched, r.disc)
+	r.symbols = r.clock.Process(r.symbols, r.matched)
+	if len(r.symbols) == 0 {
+		return
+	}
+	r.sliced = r.mf.SliceMany(r.sliced, r.symbols)
+	if cap(r.dibits) < len(r.sliced) {
+		r.dibits = make([]uint8, len(r.sliced))
+	} else {
+		r.dibits = r.dibits[:len(r.sliced)]
+	}
+	for i, sym := range r.sliced {
+		r.dibits[i] = SymbolToDibit(sym)
+	}
+	r.dibitSink(r.dibits, r.dibitBase)
+	r.dibitBase += len(r.dibits)
+}
+
+// Reset returns the receiver to its initial state. Call on stream
+// re-sync (control-channel hunt success, IQ underrun recovery) so
+// the DibitSink baseIdx restarts at 0.
+func (r *Receiver) Reset() {
+	r.dibitBase = 0
+}
+
+// SymbolToDibit maps a C4FM slicer output ({-3, -1, +1, +3}) to a
+// dibit value (0..3). Uses the same Gray-coded convention as
+// P25 Phase 1 (TIA-102.BAAA) and YSF: +3 → 01, +1 → 00, -1 → 10,
+// -3 → 11. DMR's on-air symbol-to-dibit mapping in ETSI TS 102 361-1
+// matches this; the receiver's mapping is pinned by unit test so a
+// future spec re-read doesn't silently desync from the published
+// sync patterns in the parent dmr package.
+func SymbolToDibit(sym int8) uint8 {
+	switch sym {
+	case 1:
+		return 0
+	case 3:
+		return 1
+	case -1:
+		return 2
+	case -3:
+		return 3
+	}
+	return 0
+}

--- a/internal/radio/dmr/receiver/receiver_test.go
+++ b/internal/radio/dmr/receiver/receiver_test.go
@@ -1,0 +1,167 @@
+package receiver
+
+import (
+	"math"
+	"testing"
+)
+
+func TestReceiverConstructsAndProcessesSilence(t *testing.T) {
+	r := New(Options{
+		SampleRateHz: 48_000,
+		DibitSink:    func(dibits []uint8, baseIdx int) {},
+	})
+	silence := make([]complex64, 4800)
+	for range 4 {
+		r.Process(silence)
+	}
+}
+
+func TestReceiverConstructorPanicsOnBadParams(t *testing.T) {
+	cases := []struct {
+		name string
+		opts Options
+	}{
+		{"missing sample rate", Options{DibitSink: func([]uint8, int) {}}},
+		{"missing sink", Options{SampleRateHz: 48_000}},
+		{"sample rate below 2x symbol rate", Options{SampleRateHz: 8_000, DibitSink: func([]uint8, int) {}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r == nil {
+					t.Errorf("expected panic, got nil")
+				}
+			}()
+			_ = New(tc.opts)
+		})
+	}
+}
+
+// makePhaseRampIQ synthesises a 48 kHz / 10 sps IQ buffer whose
+// instantaneous frequency cycles through the four C4FM symbols.
+// Same fixture shape as the YSF / P25 P1 receiver tests; DMR shares
+// the modulation so the signal works without modification.
+func makePhaseRampIQ(symbols int) []complex64 {
+	const sampleRate = 48_000.0
+	const sps = 10
+	const deviation = 1944.0 // DMR nominal outer-deviation (per ETSI)
+	radPerSample := func(symbolValue int) float64 {
+		return 2 * math.Pi * float64(symbolValue) * deviation / 3.0 / sampleRate
+	}
+	iq := make([]complex64, symbols*sps)
+	phase := 0.0
+	for s := 0; s < symbols; s++ {
+		val := []int{-3, -1, +1, +3}[s%4]
+		dphi := radPerSample(val)
+		base := s * sps
+		for k := 0; k < sps; k++ {
+			iq[base+k] = complex(float32(math.Cos(phase)), float32(math.Sin(phase)))
+			phase += dphi
+		}
+	}
+	return iq
+}
+
+func TestReceiverEmitsDibitsFromPhaseRamp(t *testing.T) {
+	var batches int
+	r := New(Options{
+		SampleRateHz: 48_000,
+		DibitSink:    func(dibits []uint8, baseIdx int) { batches++ },
+	})
+	iq := makePhaseRampIQ(1024)
+	chunk := 4096
+	for i := 0; i < len(iq); i += chunk {
+		end := i + chunk
+		if end > len(iq) {
+			end = len(iq)
+		}
+		r.Process(iq[i:end])
+	}
+	if batches == 0 {
+		t.Errorf("DibitSink received zero batches; Mueller-Müller loop produced no symbols")
+	}
+}
+
+func TestReceiverDibitSinkBaseIdxMonotonic(t *testing.T) {
+	var baseIdxs []int
+	var batchLens []int
+	r := New(Options{
+		SampleRateHz: 48_000,
+		DibitSink: func(dibits []uint8, baseIdx int) {
+			baseIdxs = append(baseIdxs, baseIdx)
+			batchLens = append(batchLens, len(dibits))
+		},
+	})
+
+	iq := makePhaseRampIQ(1024)
+	chunk := 4096
+	for i := 0; i < len(iq); i += chunk {
+		end := i + chunk
+		if end > len(iq) {
+			end = len(iq)
+		}
+		r.Process(iq[i:end])
+	}
+
+	if len(baseIdxs) == 0 {
+		t.Fatalf("expected DibitSink to receive at least one batch")
+	}
+	if baseIdxs[0] != 0 {
+		t.Errorf("first baseIdx = %d, want 0", baseIdxs[0])
+	}
+	cumulative := 0
+	for i := range baseIdxs {
+		if baseIdxs[i] != cumulative {
+			t.Errorf("baseIdx[%d]=%d, want %d", i, baseIdxs[i], cumulative)
+		}
+		cumulative += batchLens[i]
+	}
+
+	r.Reset()
+	baseIdxs = baseIdxs[:0]
+	batchLens = batchLens[:0]
+	r.Process(iq)
+	if len(baseIdxs) == 0 {
+		t.Fatalf("post-Reset: expected DibitSink to receive at least one batch")
+	}
+	if baseIdxs[0] != 0 {
+		t.Errorf("post-Reset: first baseIdx = %d, want 0", baseIdxs[0])
+	}
+}
+
+func TestReceiverEmittedDibitsAreValid(t *testing.T) {
+	var bad int
+	r := New(Options{
+		SampleRateHz: 48_000,
+		DibitSink: func(dibits []uint8, baseIdx int) {
+			for _, d := range dibits {
+				if d > 3 {
+					bad++
+				}
+			}
+		},
+	})
+	r.Process(makePhaseRampIQ(1024))
+	if bad > 0 {
+		t.Errorf("%d dibit(s) out of 0..3 range", bad)
+	}
+}
+
+// TestSymbolToDibitMatchesP25Phase1Convention pins the slicer-to-
+// dibit mapping so a future change here doesn't silently desync
+// from the AllSyncs / SyncDetector patterns in the parent dmr
+// package. ETSI TS 102 361-1's symbol-to-dibit table matches
+// the Gray-coded P25 Phase 1 convention; DSDcc + OP25 confirm.
+func TestSymbolToDibitMatchesP25Phase1Convention(t *testing.T) {
+	cases := []struct {
+		sym  int8
+		want uint8
+	}{
+		{1, 0}, {3, 1}, {-1, 2}, {-3, 3},
+	}
+	for _, tc := range cases {
+		if got := SymbolToDibit(tc.sym); got != tc.want {
+			t.Errorf("SymbolToDibit(%d) = %d, want %d", tc.sym, got, tc.want)
+		}
+	}
+}

--- a/internal/radio/dmr/sync.go
+++ b/internal/radio/dmr/sync.go
@@ -4,6 +4,15 @@
 // timeslot, framed by a 48-bit sync pattern.
 package dmr
 
+// DibitSink consumes the raw stream of dibits a DMR receiver decodes
+// from IQ. baseIdx is the absolute dibit index of dibits[0] across
+// the stream lifetime — monotonically non-decreasing across calls,
+// and reset to 0 by Receiver.Reset so a retune produces a fresh
+// baseline. Wire this into a future ControlChannel.Process adapter
+// (sync detect → 132-dibit burst assembly → IngestBurst) so the
+// connector can drive the DMR CC state machine on live IQ.
+type DibitSink func(dibits []uint8, baseIdx int)
+
 // SyncPattern enumerates the 48-bit sync words defined in ETSI
 // TS 102 361-1 §9.1.1, encoded as 24 dibits MSB-first.
 type SyncPattern struct {


### PR DESCRIPTION
## Summary

PR #7 of the roadmap — second per-protocol IQ → dibit receiver.

DMR runs the same 4800-baud 4-level C4FM modulation as P25 Phase 1
and YSF (α = 0.20 RRC pulse shaping), so the receiver mirrors the
P25 P1 / YSF subpackages structurally. Only the downstream framing
differs — DMR is 2-slot TDMA with a 132-dibit burst layout (49 +
5 + 24 + 5 + 49) and that lives in the parent `dmr` package + the
`tier2` / `tier3` control-channel state machines.

Pipeline:
```
IQ samples
  → demod.FM
  → demod.C4FM RRC matched filter + 4-level slicer
  → sync.MuellerMuller clock recovery
  → SymbolToDibit (TIA-102.BAAA / DSDcc convention)
  → dmr.DibitSink
```

Adds `dmr.DibitSink` in the parent package (mirrors
`ysf.DibitSink` / `phase1.DibitSink`).

### Deferred to a follow-up

Unlike YSF, DMR's `tier3.ControlChannel.IngestBurst(b, slot)`
consumes already-parsed bursts, so the connector that lands later
can't just forward dibits straight in. A `Process(dibits, baseIdx)`
adapter on `tier3.ControlChannel` (cross-call dibit buffering →
24-dibit sync detect → 132-dibit burst slice → Hamming(20,8) slot-
type decode → IngestBurst) is the next layer up and ships in its
own PR alongside the connector work.

## Test plan

- [x] `go test ./internal/radio/dmr/... -race`
- [x] `go build ./...`
- [x] `go vet ./internal/radio/dmr/...`

New tests cover:
- Constructor preconditions (missing sample rate / sink / sub-Nyquist rate panic)
- Silence smoke test (no crash)
- Phase-ramp dibit emission (chain produces dibits on a clean 4-level FSK signal)
- `baseIdx` monotonicity + `Reset` rewinds to 0
- Every emitted dibit is in 0..3
- `SymbolToDibit` pinned to the P25 / DSDcc Gray-coded convention

## README

- DMR (Tier III) feature row now mentions the IQ → C4FM dibit
  receiver path.
- "Recently shipped" gains a bullet for the new receiver
  subpackage describing the composition + the deferred
  `ControlChannel.Process` adapter work.


---
_Generated by [Claude Code](https://claude.ai/code/session_019dtCCVEZJTKKr6YK3wy824)_