### PR TITLE
internal/radio/nxdn/receiver: IQ → C4FM dibit receiver for NXDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ frontend over gRPC, HTTP/SSE, or WebSocket.
 | P25 Phase 2       | Outbound + inbound 20-dibit sync, 360 ms / 12-subframe superframe + SlotType enum, MAC PDU parser + opcode enum, GroupVoiceChannelGrant accessor, control-channel state machine emitting `protocol = "p25-phase2"` grants |
 | DMR (Tier III)    | All 9 ETSI sync patterns, burst layout (132 dibits), Color Code + Data Type via (20,8,7) shortened-Hamming slot-type FEC (corrects up to 3 bit errors per slot type), CSBK with CRC, payload parsers for TalkGroup/Private Voice grants (LCN + timeslot) + Aloha + AdjacentSiteStatus + SystemInfoBroadcast, LCN → Hz band-plan resolver (linear + table forms), IQ → C4FM dibit receiver (`internal/radio/dmr/receiver`) composing FM demod + RRC matched filter + Mueller-Müller clock recovery + 4-level slicer to fan `dmr.DibitSink` out to a future `ControlChannel.Process` adapter, control-channel state machine emitting `protocol = "dmr-tier3"` grants and `decode.error` events with `no-bandplan` stage |
 | DMR (Tier II)     | Shares the burst / slot-type / BPTC(196,96) layers with Tier III; adds a 72-bit Full Link Control parser (FLCO enum: GroupVoiceChannelUser / UnitToUnitVoice / TalkerAlias / GPS / Terminator) with RS(12,9,4) parity verification (Voice LC Header seed) and a per-repeater conventional-mode state machine that decodes Voice LC Header bursts and emits `protocol = "dmr-tier2"` grants on the bus (deduped per call, cleared on Terminator-with-LC) and `decode.error` events with `voiceheader-bptc` / `voiceheader-rs` stages |
-| NXDN              | 192-dibit frame layout (4800 BFSK / 9600 4-FSK), LICH parse with parity + 16-bit doubled-wire decoder, FSW correlator, full SACCH channel decode (K=5 ½-rate convolutional Viterbi + 60-position sub-frame deinterleaver + 12-bit puncture undo + CRC-6 trailer), CAC parser with CRC, RCCH opcode enum + payload parsers, control-channel state machine |
+| NXDN              | 192-dibit frame layout (4800 BFSK / 9600 4-FSK), LICH parse with parity + 16-bit doubled-wire decoder, FSW correlator, full SACCH channel decode (K=5 ½-rate convolutional Viterbi + 60-position sub-frame deinterleaver + 12-bit puncture undo + CRC-6 trailer), CAC parser with CRC, RCCH opcode enum + payload parsers, IQ → C4FM dibit receiver (`internal/radio/nxdn/receiver`) for the 9600-baud 4-FSK variant composing FM demod + RRC matched filter + Mueller-Müller clock recovery + 4-level slicer to fan `nxdn.DibitSink` out to a future `ControlChannel.Process` adapter (BFSK variant — 2-level slicer — is a follow-up), control-channel state machine |
 | Motorola Type II  | OSW parser, opcode constants, LCN → Hz band-plan resolver (linear + table), control-channel state machine emitting `protocol = "motorola"` grants |
 | EDACS / GE-Marc   | 40-bit CCW parser, command enum (Idle / GroupVoiceGrant / ProVoiceGrant / IndividualCall / DataGrant / SystemID / AdjacentSite / Emergency / Affiliation / Encryption), per-command accessors with encrypted / emergency flags, LCN → Hz resolver, control-channel state machine emitting `protocol = "edacs"` grants |
 | LTR               | 41-bit per-repeater Status word parser, Channel → Hz resolver, optional area filter, per-repeater state machine emitting `protocol = "ltr"` grants when a status indicates an active call |
@@ -134,6 +134,15 @@ to its own package and lands independently.
 
 ### Recently shipped
 
+- **NXDN IQ → C4FM dibit receiver** (`internal/radio/nxdn/receiver`)
+  composing FM demod + RRC matched filter + Mueller-Müller clock
+  recovery + 4-level slicer into one entry point that fans dibits
+  out via the new `nxdn.DibitSink` callback. Targets the 9600-baud
+  4-FSK variant (the same C4FM modulation P25 P1 / DMR / YSF use);
+  the 4800-baud BFSK variant — 2-level slicer rather than 4-level —
+  is a follow-up. The `ControlChannel.Process(dibits, baseIdx)`
+  adapter that does 8-dibit FSW detect + 192-dibit frame slice +
+  LICH / SACCH decode + `IngestFrame` is the next layer up.
 - **DMR IQ → C4FM dibit receiver** (`internal/radio/dmr/receiver`)
   composing FM demod + RRC matched filter + Mueller-Müller clock
   recovery + 4-level slicer into one entry point that fans dibits

--- a/internal/radio/nxdn/receiver/receiver.go
+++ b/internal/radio/nxdn/receiver/receiver.go
@@ -1,0 +1,162 @@
+// Package receiver wires the IQ → C4FM dibit chain that feeds the
+// NXDN control-channel state machine for the 9600-baud 4-FSK
+// variant (the most common deployment; the 4800-baud BFSK variant
+// uses a 2-level slicer and lives in a follow-up).
+//
+//	IQ samples
+//	  → FM discriminator (internal/dsp/demod.FM)
+//	  → RRC matched filter + 4-level slicer (internal/dsp/demod.C4FM)
+//	  → Mueller-Müller symbol clock recovery (internal/dsp/sync.MuellerMuller)
+//	  → 4-level symbol → 0..3 dibit (SymbolToDibit, local)
+//	  → nxdn.DibitSink
+//
+// NXDN's 9600-baud channel rate is 4800 sym/s 4-FSK with α = 0.20
+// RRC pulse shaping — the same modulation P25 Phase 1, DMR, and YSF
+// use, so the matched-filter parameters carry over unchanged. Only
+// the downstream framing (192-dibit / 80 ms frames, 8-dibit FSW,
+// LICH / SACCH / Info field layout) differs and lives in the parent
+// nxdn package.
+//
+// The receiver is stateful and not safe for concurrent Process
+// calls. Instantiate one per tuned frequency / per call chain.
+package receiver
+
+import (
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/demod"
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/sync"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/nxdn"
+)
+
+// NXDN on-air parameters (4-FSK 9600-baud variant).
+const (
+	// SymbolRate is the channel symbol rate. Each symbol carries one
+	// dibit (2 bits) on the wire for a total channel capacity of
+	// 9600 bps. The BFSK variant uses the same symbol rate but only
+	// 1 bit per symbol — a separate receiver path.
+	SymbolRate = 4800.0
+	// RolloffAlpha matches the standard NXDN / P25 Phase 1 / YSF /
+	// DMR receiver pulse shape.
+	RolloffAlpha = 0.20
+	// PulseSpanSymbols is the half-span of the RRC pulse on each
+	// side of the symbol time.
+	PulseSpanSymbols = 8
+)
+
+// Options configures a Receiver.
+type Options struct {
+	// SampleRateHz is the IQ sample rate after any upstream
+	// channelization. Required; must be ≥ 2 × SymbolRate.
+	SampleRateHz float64
+	// DibitSink receives the raw dibit stream the receiver decodes
+	// from IQ. Required.
+	DibitSink nxdn.DibitSink
+	// PulseSpanSymbols overrides the RRC half-span. <= 0 uses
+	// PulseSpanSymbols.
+	PulseSpanSymbols int
+	// Alpha overrides the RRC roll-off. <= 0 uses RolloffAlpha.
+	Alpha float64
+	// ClockGain is the Mueller-Müller loop gain. <= 0 uses 0.05.
+	ClockGain float64
+}
+
+// Receiver is the composed IQ → dibit pipeline.
+type Receiver struct {
+	fm        *demod.FM
+	mf        *demod.C4FM
+	clock     *sync.MuellerMuller
+	dibitSink nxdn.DibitSink
+	dibitBase int
+
+	disc    []float32
+	matched []float32
+	symbols []float32
+	sliced  []int8
+	dibits  []uint8
+}
+
+// New constructs a Receiver. Panics if SampleRateHz or DibitSink are
+// unset, or the resulting samples-per-symbol is below 2.
+func New(opts Options) *Receiver {
+	if opts.SampleRateHz <= 0 {
+		panic("receiver: SampleRateHz is required")
+	}
+	if opts.DibitSink == nil {
+		panic("receiver: DibitSink is required")
+	}
+	sps := opts.SampleRateHz / SymbolRate
+	if sps < 2 {
+		panic("receiver: SampleRateHz must be >= 2*SymbolRate (9600 Hz)")
+	}
+	span := opts.PulseSpanSymbols
+	if span <= 0 {
+		span = PulseSpanSymbols
+	}
+	alpha := opts.Alpha
+	if alpha <= 0 {
+		alpha = RolloffAlpha
+	}
+	gain := opts.ClockGain
+	if gain <= 0 {
+		gain = 0.05
+	}
+	const slicerScale = 1.0
+
+	return &Receiver{
+		fm:        demod.NewFM(),
+		mf:        demod.NewC4FM(int(sps+0.5), span, alpha, slicerScale),
+		clock:     sync.NewMuellerMuller(sps, gain),
+		dibitSink: opts.DibitSink,
+	}
+}
+
+// Process pushes one chunk of complex64 IQ samples through the chain.
+// Zero or more dibit batches may be emitted to DibitSink during the
+// call.
+func (r *Receiver) Process(iq []complex64) {
+	if len(iq) == 0 {
+		return
+	}
+	r.disc = r.fm.Process(r.disc, iq)
+	r.matched = r.mf.MatchedFilter(r.matched, r.disc)
+	r.symbols = r.clock.Process(r.symbols, r.matched)
+	if len(r.symbols) == 0 {
+		return
+	}
+	r.sliced = r.mf.SliceMany(r.sliced, r.symbols)
+	if cap(r.dibits) < len(r.sliced) {
+		r.dibits = make([]uint8, len(r.sliced))
+	} else {
+		r.dibits = r.dibits[:len(r.sliced)]
+	}
+	for i, sym := range r.sliced {
+		r.dibits[i] = SymbolToDibit(sym)
+	}
+	r.dibitSink(r.dibits, r.dibitBase)
+	r.dibitBase += len(r.dibits)
+}
+
+// Reset returns the receiver to its initial state.
+func (r *Receiver) Reset() {
+	r.dibitBase = 0
+}
+
+// SymbolToDibit maps a C4FM slicer output ({-3, -1, +1, +3}) to a
+// dibit value (0..3). Uses the same Gray-coded convention as the
+// P25 Phase 1 / DMR / YSF receivers: +3 → 01, +1 → 00, -1 → 10,
+// -3 → 11. NXDN's on-air symbol mapping in the Common Air Interface
+// specification matches this convention; the mapping is pinned by
+// unit test so a future spec re-read doesn't silently desync from
+// the FSW patterns in the parent nxdn package.
+func SymbolToDibit(sym int8) uint8 {
+	switch sym {
+	case 1:
+		return 0
+	case 3:
+		return 1
+	case -1:
+		return 2
+	case -3:
+		return 3
+	}
+	return 0
+}

--- a/internal/radio/nxdn/receiver/receiver_test.go
+++ b/internal/radio/nxdn/receiver/receiver_test.go
@@ -1,0 +1,158 @@
+package receiver
+
+import (
+	"math"
+	"testing"
+)
+
+func TestReceiverConstructsAndProcessesSilence(t *testing.T) {
+	r := New(Options{
+		SampleRateHz: 48_000,
+		DibitSink:    func(dibits []uint8, baseIdx int) {},
+	})
+	silence := make([]complex64, 4800)
+	for range 4 {
+		r.Process(silence)
+	}
+}
+
+func TestReceiverConstructorPanicsOnBadParams(t *testing.T) {
+	cases := []struct {
+		name string
+		opts Options
+	}{
+		{"missing sample rate", Options{DibitSink: func([]uint8, int) {}}},
+		{"missing sink", Options{SampleRateHz: 48_000}},
+		{"sample rate below 2x symbol rate", Options{SampleRateHz: 8_000, DibitSink: func([]uint8, int) {}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r == nil {
+					t.Errorf("expected panic, got nil")
+				}
+			}()
+			_ = New(tc.opts)
+		})
+	}
+}
+
+func makePhaseRampIQ(symbols int) []complex64 {
+	const sampleRate = 48_000.0
+	const sps = 10
+	const deviation = 1800.0
+	radPerSample := func(symbolValue int) float64 {
+		return 2 * math.Pi * float64(symbolValue) * deviation / 3.0 / sampleRate
+	}
+	iq := make([]complex64, symbols*sps)
+	phase := 0.0
+	for s := 0; s < symbols; s++ {
+		val := []int{-3, -1, +1, +3}[s%4]
+		dphi := radPerSample(val)
+		base := s * sps
+		for k := 0; k < sps; k++ {
+			iq[base+k] = complex(float32(math.Cos(phase)), float32(math.Sin(phase)))
+			phase += dphi
+		}
+	}
+	return iq
+}
+
+func TestReceiverEmitsDibitsFromPhaseRamp(t *testing.T) {
+	var batches int
+	r := New(Options{
+		SampleRateHz: 48_000,
+		DibitSink:    func(dibits []uint8, baseIdx int) { batches++ },
+	})
+	iq := makePhaseRampIQ(1024)
+	chunk := 4096
+	for i := 0; i < len(iq); i += chunk {
+		end := i + chunk
+		if end > len(iq) {
+			end = len(iq)
+		}
+		r.Process(iq[i:end])
+	}
+	if batches == 0 {
+		t.Errorf("DibitSink received zero batches; Mueller-Müller loop produced no symbols")
+	}
+}
+
+func TestReceiverDibitSinkBaseIdxMonotonic(t *testing.T) {
+	var baseIdxs []int
+	var batchLens []int
+	r := New(Options{
+		SampleRateHz: 48_000,
+		DibitSink: func(dibits []uint8, baseIdx int) {
+			baseIdxs = append(baseIdxs, baseIdx)
+			batchLens = append(batchLens, len(dibits))
+		},
+	})
+
+	iq := makePhaseRampIQ(1024)
+	chunk := 4096
+	for i := 0; i < len(iq); i += chunk {
+		end := i + chunk
+		if end > len(iq) {
+			end = len(iq)
+		}
+		r.Process(iq[i:end])
+	}
+
+	if len(baseIdxs) == 0 {
+		t.Fatalf("expected DibitSink to receive at least one batch")
+	}
+	if baseIdxs[0] != 0 {
+		t.Errorf("first baseIdx = %d, want 0", baseIdxs[0])
+	}
+	cumulative := 0
+	for i := range baseIdxs {
+		if baseIdxs[i] != cumulative {
+			t.Errorf("baseIdx[%d]=%d, want %d", i, baseIdxs[i], cumulative)
+		}
+		cumulative += batchLens[i]
+	}
+
+	r.Reset()
+	baseIdxs = baseIdxs[:0]
+	batchLens = batchLens[:0]
+	r.Process(iq)
+	if len(baseIdxs) == 0 {
+		t.Fatalf("post-Reset: expected DibitSink to receive at least one batch")
+	}
+	if baseIdxs[0] != 0 {
+		t.Errorf("post-Reset: first baseIdx = %d, want 0", baseIdxs[0])
+	}
+}
+
+func TestReceiverEmittedDibitsAreValid(t *testing.T) {
+	var bad int
+	r := New(Options{
+		SampleRateHz: 48_000,
+		DibitSink: func(dibits []uint8, baseIdx int) {
+			for _, d := range dibits {
+				if d > 3 {
+					bad++
+				}
+			}
+		},
+	})
+	r.Process(makePhaseRampIQ(1024))
+	if bad > 0 {
+		t.Errorf("%d dibit(s) out of 0..3 range", bad)
+	}
+}
+
+func TestSymbolToDibitMatchesP25Phase1Convention(t *testing.T) {
+	cases := []struct {
+		sym  int8
+		want uint8
+	}{
+		{1, 0}, {3, 1}, {-1, 2}, {-3, 3},
+	}
+	for _, tc := range cases {
+		if got := SymbolToDibit(tc.sym); got != tc.want {
+			t.Errorf("SymbolToDibit(%d) = %d, want %d", tc.sym, got, tc.want)
+		}
+	}
+}

--- a/internal/radio/nxdn/sync.go
+++ b/internal/radio/nxdn/sync.go
@@ -1,5 +1,15 @@
 package nxdn
 
+// DibitSink consumes the raw stream of dibits an NXDN receiver
+// decodes from IQ. baseIdx is the absolute dibit index of dibits[0]
+// across the stream lifetime — monotonically non-decreasing across
+// calls, and reset to 0 by Receiver.Reset so a retune produces a
+// fresh baseline. Wire this into a future ControlChannel.Process
+// adapter (sync detect → 192-dibit frame slice → LICH/SACCH decode
+// → IngestFrame) so the connector can drive the NXDN CC state
+// machine on live IQ.
+type DibitSink func(dibits []uint8, baseIdx int)
+
 // FSW patterns (16 bits = 8 dibits). These constants follow the NXDN
 // Common Air Interface specification §6.2.1; the exact bit pattern
 // should be cross-checked against the published technical document


### PR DESCRIPTION
## Summary

PR #8 of the roadmap — third per-protocol IQ → dibit receiver.

NXDN's 9600-baud channel rate is 4-FSK at 4800 sym/s with α = 0.20
RRC pulse shaping — identical modulation to P25 Phase 1 / DMR / YSF
— so this receiver mirrors those subpackages exactly. Only the
downstream framing (192-dibit / 80 ms frames, 8-dibit FSW, LICH /
SACCH / Info field layout) differs and lives in the parent `nxdn`
package.

Pipeline:
```
IQ samples
  → demod.FM
  → demod.C4FM RRC matched filter + 4-level slicer
  → sync.MuellerMuller clock recovery
  → SymbolToDibit (TIA-102.BAAA / DSDcc convention)
  → nxdn.DibitSink
```

Adds `nxdn.DibitSink` in the parent package (mirrors `dmr.DibitSink`
/ `ysf.DibitSink` / `phase1.DibitSink`).

### Deferred to follow-ups

- **NXDN 4800-baud BFSK variant** — same channel rate but 1 bit per
  symbol, 2-level slicer. Will land as a sibling receiver path or
  via an `Options.BaudRate` switch once a real-air BFSK capture is
  available to pin the slicer threshold.
- **`ControlChannel.Process(dibits, baseIdx)` adapter** —
  cross-call dibit buffering + 8-dibit FSW detect + 192-dibit
  frame slice + LICH / SACCH decode + `IngestFrame`. Ships
  alongside the connector PR.

## Test plan

- [x] `go test ./internal/radio/nxdn/... -race`
- [x] `go build ./...`
- [x] `go vet ./internal/radio/nxdn/...`

New tests cover:
- Constructor preconditions (missing sample rate / sink / sub-Nyquist rate panic)
- Silence smoke test (no crash)
- Phase-ramp dibit emission
- `baseIdx` monotonicity + `Reset` rewinds to 0
- Every emitted dibit is in 0..3
- `SymbolToDibit` pinned to the P25 / DSDcc Gray-coded convention

## README

- NXDN feature row now mentions the IQ → C4FM dibit receiver path
  + flags the deferred BFSK variant.
- "Recently shipped" gains a bullet for the new receiver
  subpackage describing the composition + deferred adapter work.


---
_Generated by [Claude Code](https://claude.ai/code/session_019dtCCVEZJTKKr6YK3wy824)_