### PR TITLE
internal/radio/dpmr/receiver: IQ → C4FM dibit receiver for dPMR Mode 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ frontend over gRPC, HTTP/SSE, or WebSocket.
 | EDACS / GE-Marc   | 40-bit CCW parser, command enum (Idle / GroupVoiceGrant / ProVoiceGrant / IndividualCall / DataGrant / SystemID / AdjacentSite / Emergency / Affiliation / Encryption), per-command accessors with encrypted / emergency flags, LCN → Hz resolver, control-channel state machine emitting `protocol = "edacs"` grants |
 | LTR               | 41-bit per-repeater Status word parser, Channel → Hz resolver, optional area filter, per-repeater state machine emitting `protocol = "ltr"` grants when a status indicates an active call |
 | MPT 1327          | 64-bit address-codeword parser (38 info + 26 BCH parity consumed upstream), CodewordKind enum (ALH / AHY / AHYC / GTC / ACK / Disconnect / Data / Emergency), accessors for GTC voice grants + AHYC system broadcast, channel resolver, control-channel state machine emitting `protocol = "mpt1327"` grants |
-| dPMR (Mode 3)     | FS1 / FS2 / FS3 24-dibit sync, 80-bit CSBK parser, MessageType enum (RegistrationRequest / Response, VoiceServiceAllocation, IndividualVoiceAllocation, DataServiceAllocation, ServiceRequest, StandingServiceStatus, Release, Idle), AsVoiceGrant + AsSiteBroadcast accessors, PMR446 default band-plan, control-channel state machine emitting `protocol = "dpmr"` grants |
+| dPMR (Mode 3)     | FS1 / FS2 / FS3 24-dibit sync, 80-bit CSBK parser, MessageType enum (RegistrationRequest / Response, VoiceServiceAllocation, IndividualVoiceAllocation, DataServiceAllocation, ServiceRequest, StandingServiceStatus, Release, Idle), AsVoiceGrant + AsSiteBroadcast accessors, PMR446 default band-plan, IQ → C4FM dibit receiver (`internal/radio/dpmr/receiver`) composing FM demod + RRC matched filter + Mueller-Müller clock recovery + 4-level slicer at the 2400-sym/s rate to fan `dpmr.DibitSink` out to a future `ControlChannel.Process` adapter, control-channel state machine emitting `protocol = "dpmr"` grants |
 | TETRA (TMO)       | Normal + extended training-sequence sync, generic Layer-3 PDU parser (4-bit Discriminator + type + payload), CMCE D-CONNECT / D-TX-GRANTED / D-RELEASE accessors, MLE-SYSINFO accessor (MCC / MNC / Location Area), TETRA-380 / 410 / 800 carrier resolver, control-channel state machine emitting `protocol = "tetra"` grants |
 | D-STAR            | Frame Sync + Slow Data sync, 41-byte PCH header parser (FLAG1 + RPT2 / RPT1 / UR / MY1 / MY2 + CRC-CCITT), IsGroupCall / IsEmergency / IsData accessors, repeater state machine emitting `protocol = "dstar"` grants on group transmissions |
 | YSF (Yaesu System Fusion) | 4800-baud C4FM, 480-dibit / 100 ms frame layout (FSW / FICH / DCH offsets), 40-bit FSW correlator with mismatch tolerance, 32-bit Frame Information Channel parser (FrameType / CallType / Frame Number / Frame Total / DataType / VoIP / Squelch fields) with CRC-16 trailer, K=5 ½-rate Viterbi Trellis encoder + decoder over the 104-bit (48 info + 4 tail) FICH channel-bit region (`internal/radio/ysf/fich_trellis.go`, shared with NXDN SACCH), IQ → C4FM dibit receiver (`internal/radio/ysf/receiver`) composing FM demod + RRC matched filter + Mueller-Müller clock recovery + 4-level slicer to feed `ysf.DibitSink` into `ControlChannel.Process`, per-frequency state machine emitting `cc.locked` on sync detect and `protocol = "ysf"` grants (with the FICH SquelchCode as DG-ID talkgroup) on Header FICH for Group calls — Terminator FICH clears the dedup so the next transmission fires a fresh CallStart |
@@ -134,6 +134,14 @@ to its own package and lands independently.
 
 ### Recently shipped
 
+- **dPMR Mode 3 IQ → C4FM dibit receiver** (`internal/radio/dpmr/receiver`)
+  composing FM demod + RRC matched filter + Mueller-Müller clock
+  recovery + 4-level slicer at the 2400-sym/s rate (half the P25 P1
+  / DMR / NXDN / YSF rate, matching dPMR's 6.25 kHz channel
+  spacing) into one entry point that fans dibits out via the new
+  `dpmr.DibitSink` callback. The `ControlChannel.Process(dibits,
+  baseIdx)` adapter that does FS3 sync detect + 80-bit CSBK slice +
+  `CSBKFromBits` + `Ingest` is the next layer up.
 - **NXDN IQ → C4FM dibit receiver** (`internal/radio/nxdn/receiver`)
   composing FM demod + RRC matched filter + Mueller-Müller clock
   recovery + 4-level slicer into one entry point that fans dibits

--- a/internal/radio/dpmr/receiver/receiver.go
+++ b/internal/radio/dpmr/receiver/receiver.go
@@ -1,0 +1,155 @@
+// Package receiver wires the IQ → C4FM dibit chain that feeds the
+// dPMR Mode 3 control-channel state machine.
+//
+//	IQ samples
+//	  → FM discriminator (internal/dsp/demod.FM)
+//	  → RRC matched filter + 4-level slicer (internal/dsp/demod.C4FM)
+//	  → Mueller-Müller symbol clock recovery (internal/dsp/sync.MuellerMuller)
+//	  → 4-level symbol → 0..3 dibit (SymbolToDibit, local)
+//	  → dpmr.DibitSink
+//
+// dPMR Mode 3 runs 4-level C4FM at 2400 sym/s — half the symbol
+// rate of P25 Phase 1 / DMR / YSF — with α = 0.20 RRC pulse
+// shaping. The downstream framing (FS1 / FS2 / FS3 24-dibit sync,
+// 80-bit CSBK signalling) lives in the parent dpmr package.
+//
+// The receiver is stateful and not safe for concurrent Process
+// calls. Instantiate one per tuned frequency / per call chain.
+package receiver
+
+import (
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/demod"
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/sync"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/dpmr"
+)
+
+// dPMR Mode 3 on-air parameters (per ETSI TS 102 658).
+const (
+	// SymbolRate is the channel symbol rate. Each symbol carries
+	// one dibit (2 bits) for a total channel capacity of 4800 bps.
+	// Half the P25 P1 / DMR / YSF rate, matching the 6.25 kHz
+	// channel spacing dPMR targets.
+	SymbolRate = 2400.0
+	// RolloffAlpha matches the standard dPMR receiver pulse shape.
+	RolloffAlpha = 0.20
+	// PulseSpanSymbols is the half-span of the RRC pulse on each
+	// side of the symbol time.
+	PulseSpanSymbols = 8
+)
+
+// Options configures a Receiver.
+type Options struct {
+	// SampleRateHz is the IQ sample rate after any upstream
+	// channelization. Required; must be ≥ 2 × SymbolRate.
+	SampleRateHz float64
+	// DibitSink receives the raw dibit stream the receiver decodes
+	// from IQ. Required.
+	DibitSink dpmr.DibitSink
+	// PulseSpanSymbols overrides the RRC half-span. <= 0 uses
+	// PulseSpanSymbols.
+	PulseSpanSymbols int
+	// Alpha overrides the RRC roll-off. <= 0 uses RolloffAlpha.
+	Alpha float64
+	// ClockGain is the Mueller-Müller loop gain. <= 0 uses 0.05.
+	ClockGain float64
+}
+
+// Receiver is the composed IQ → dibit pipeline.
+type Receiver struct {
+	fm        *demod.FM
+	mf        *demod.C4FM
+	clock     *sync.MuellerMuller
+	dibitSink dpmr.DibitSink
+	dibitBase int
+
+	disc    []float32
+	matched []float32
+	symbols []float32
+	sliced  []int8
+	dibits  []uint8
+}
+
+// New constructs a Receiver. Panics if SampleRateHz or DibitSink are
+// unset, or the resulting samples-per-symbol is below 2.
+func New(opts Options) *Receiver {
+	if opts.SampleRateHz <= 0 {
+		panic("receiver: SampleRateHz is required")
+	}
+	if opts.DibitSink == nil {
+		panic("receiver: DibitSink is required")
+	}
+	sps := opts.SampleRateHz / SymbolRate
+	if sps < 2 {
+		panic("receiver: SampleRateHz must be >= 2*SymbolRate (4800 Hz)")
+	}
+	span := opts.PulseSpanSymbols
+	if span <= 0 {
+		span = PulseSpanSymbols
+	}
+	alpha := opts.Alpha
+	if alpha <= 0 {
+		alpha = RolloffAlpha
+	}
+	gain := opts.ClockGain
+	if gain <= 0 {
+		gain = 0.05
+	}
+	const slicerScale = 1.0
+
+	return &Receiver{
+		fm:        demod.NewFM(),
+		mf:        demod.NewC4FM(int(sps+0.5), span, alpha, slicerScale),
+		clock:     sync.NewMuellerMuller(sps, gain),
+		dibitSink: opts.DibitSink,
+	}
+}
+
+// Process pushes one chunk of complex64 IQ samples through the chain.
+func (r *Receiver) Process(iq []complex64) {
+	if len(iq) == 0 {
+		return
+	}
+	r.disc = r.fm.Process(r.disc, iq)
+	r.matched = r.mf.MatchedFilter(r.matched, r.disc)
+	r.symbols = r.clock.Process(r.symbols, r.matched)
+	if len(r.symbols) == 0 {
+		return
+	}
+	r.sliced = r.mf.SliceMany(r.sliced, r.symbols)
+	if cap(r.dibits) < len(r.sliced) {
+		r.dibits = make([]uint8, len(r.sliced))
+	} else {
+		r.dibits = r.dibits[:len(r.sliced)]
+	}
+	for i, sym := range r.sliced {
+		r.dibits[i] = SymbolToDibit(sym)
+	}
+	r.dibitSink(r.dibits, r.dibitBase)
+	r.dibitBase += len(r.dibits)
+}
+
+// Reset returns the receiver to its initial state.
+func (r *Receiver) Reset() {
+	r.dibitBase = 0
+}
+
+// SymbolToDibit maps a C4FM slicer output ({-3, -1, +1, +3}) to a
+// dibit value (0..3). Uses the same Gray-coded convention as the
+// P25 Phase 1 / DMR / NXDN / YSF receivers: +3 → 01, +1 → 00,
+// -1 → 10, -3 → 11. The dPMR symbol-to-dibit mapping in ETSI
+// TS 102 658 matches this convention; the mapping is pinned by
+// unit test so a future spec re-read doesn't silently desync from
+// the FS1 / FS2 / FS3 patterns in the parent dpmr package.
+func SymbolToDibit(sym int8) uint8 {
+	switch sym {
+	case 1:
+		return 0
+	case 3:
+		return 1
+	case -1:
+		return 2
+	case -3:
+		return 3
+	}
+	return 0
+}

--- a/internal/radio/dpmr/receiver/receiver_test.go
+++ b/internal/radio/dpmr/receiver/receiver_test.go
@@ -1,0 +1,162 @@
+package receiver
+
+import (
+	"math"
+	"testing"
+)
+
+func TestReceiverConstructsAndProcessesSilence(t *testing.T) {
+	r := New(Options{
+		SampleRateHz: 48_000,
+		DibitSink:    func(dibits []uint8, baseIdx int) {},
+	})
+	silence := make([]complex64, 4800)
+	for range 4 {
+		r.Process(silence)
+	}
+}
+
+func TestReceiverConstructorPanicsOnBadParams(t *testing.T) {
+	cases := []struct {
+		name string
+		opts Options
+	}{
+		{"missing sample rate", Options{DibitSink: func([]uint8, int) {}}},
+		{"missing sink", Options{SampleRateHz: 48_000}},
+		{"sample rate below 2x symbol rate", Options{SampleRateHz: 4_000, DibitSink: func([]uint8, int) {}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r == nil {
+					t.Errorf("expected panic, got nil")
+				}
+			}()
+			_ = New(tc.opts)
+		})
+	}
+}
+
+// makePhaseRampIQ at 48 kHz / 20 sps (sps = SampleRate / SymbolRate
+// = 48000 / 2400) cycles through the four C4FM symbols, mirroring
+// the YSF / DMR / NXDN test fixtures but at dPMR's slower symbol
+// rate.
+func makePhaseRampIQ(symbols int) []complex64 {
+	const sampleRate = 48_000.0
+	const sps = 20
+	const deviation = 900.0 // half the P25 P1 / DMR / YSF deviation; dPMR uses tighter spacing
+	radPerSample := func(symbolValue int) float64 {
+		return 2 * math.Pi * float64(symbolValue) * deviation / 3.0 / sampleRate
+	}
+	iq := make([]complex64, symbols*sps)
+	phase := 0.0
+	for s := 0; s < symbols; s++ {
+		val := []int{-3, -1, +1, +3}[s%4]
+		dphi := radPerSample(val)
+		base := s * sps
+		for k := 0; k < sps; k++ {
+			iq[base+k] = complex(float32(math.Cos(phase)), float32(math.Sin(phase)))
+			phase += dphi
+		}
+	}
+	return iq
+}
+
+func TestReceiverEmitsDibitsFromPhaseRamp(t *testing.T) {
+	var batches int
+	r := New(Options{
+		SampleRateHz: 48_000,
+		DibitSink:    func(dibits []uint8, baseIdx int) { batches++ },
+	})
+	iq := makePhaseRampIQ(1024)
+	chunk := 4096
+	for i := 0; i < len(iq); i += chunk {
+		end := i + chunk
+		if end > len(iq) {
+			end = len(iq)
+		}
+		r.Process(iq[i:end])
+	}
+	if batches == 0 {
+		t.Errorf("DibitSink received zero batches; Mueller-Müller loop produced no symbols")
+	}
+}
+
+func TestReceiverDibitSinkBaseIdxMonotonic(t *testing.T) {
+	var baseIdxs []int
+	var batchLens []int
+	r := New(Options{
+		SampleRateHz: 48_000,
+		DibitSink: func(dibits []uint8, baseIdx int) {
+			baseIdxs = append(baseIdxs, baseIdx)
+			batchLens = append(batchLens, len(dibits))
+		},
+	})
+
+	iq := makePhaseRampIQ(1024)
+	chunk := 4096
+	for i := 0; i < len(iq); i += chunk {
+		end := i + chunk
+		if end > len(iq) {
+			end = len(iq)
+		}
+		r.Process(iq[i:end])
+	}
+
+	if len(baseIdxs) == 0 {
+		t.Fatalf("expected DibitSink to receive at least one batch")
+	}
+	if baseIdxs[0] != 0 {
+		t.Errorf("first baseIdx = %d, want 0", baseIdxs[0])
+	}
+	cumulative := 0
+	for i := range baseIdxs {
+		if baseIdxs[i] != cumulative {
+			t.Errorf("baseIdx[%d]=%d, want %d", i, baseIdxs[i], cumulative)
+		}
+		cumulative += batchLens[i]
+	}
+
+	r.Reset()
+	baseIdxs = baseIdxs[:0]
+	batchLens = batchLens[:0]
+	r.Process(iq)
+	if len(baseIdxs) == 0 {
+		t.Fatalf("post-Reset: expected DibitSink to receive at least one batch")
+	}
+	if baseIdxs[0] != 0 {
+		t.Errorf("post-Reset: first baseIdx = %d, want 0", baseIdxs[0])
+	}
+}
+
+func TestReceiverEmittedDibitsAreValid(t *testing.T) {
+	var bad int
+	r := New(Options{
+		SampleRateHz: 48_000,
+		DibitSink: func(dibits []uint8, baseIdx int) {
+			for _, d := range dibits {
+				if d > 3 {
+					bad++
+				}
+			}
+		},
+	})
+	r.Process(makePhaseRampIQ(1024))
+	if bad > 0 {
+		t.Errorf("%d dibit(s) out of 0..3 range", bad)
+	}
+}
+
+func TestSymbolToDibitMatchesP25Phase1Convention(t *testing.T) {
+	cases := []struct {
+		sym  int8
+		want uint8
+	}{
+		{1, 0}, {3, 1}, {-1, 2}, {-3, 3},
+	}
+	for _, tc := range cases {
+		if got := SymbolToDibit(tc.sym); got != tc.want {
+			t.Errorf("SymbolToDibit(%d) = %d, want %d", tc.sym, got, tc.want)
+		}
+	}
+}

--- a/internal/radio/dpmr/sync.go
+++ b/internal/radio/dpmr/sync.go
@@ -1,5 +1,15 @@
 package dpmr
 
+// DibitSink consumes the raw stream of dibits a dPMR receiver
+// decodes from IQ. baseIdx is the absolute dibit index of
+// dibits[0] across the stream lifetime — monotonically non-
+// decreasing across calls, and reset to 0 by Receiver.Reset so a
+// retune produces a fresh baseline. Wire this into a future
+// ControlChannel.Process adapter (FS3 sync detect → 80-bit CSBK
+// slice → CSBKFromBits → Ingest) so the connector can drive the
+// dPMR CC state machine on live IQ.
+type DibitSink func(dibits []uint8, baseIdx int)
+
 // dPMR sync words per ETSI TS 102 658 §4.4. Three distinct 48-bit
 // (24-dibit) patterns mark the three burst types Mode 3 uses:
 //


### PR DESCRIPTION
## Summary

PR #9 of the roadmap — fourth per-protocol IQ → dibit receiver.

dPMR Mode 3 is 4-level C4FM at **2400 sym/s** — half the symbol
rate of P25 P1 / DMR / NXDN / YSF, matching the 6.25 kHz channel
spacing dPMR targets — with α = 0.20 RRC pulse shaping. The slower
symbol rate is the only DSP-level difference from the other 4FSK
receivers; the downstream framing (FS1 / FS2 / FS3 24-dibit sync,
80-bit CSBK signalling) lives in the parent `dpmr` package.

Pipeline:
```
IQ samples
  → demod.FM
  → demod.C4FM RRC matched filter + 4-level slicer
  → sync.MuellerMuller clock recovery
  → SymbolToDibit (TIA-102.BAAA / DSDcc convention)
  → dpmr.DibitSink
```

Adds `dpmr.DibitSink` in the parent package (mirrors `nxdn` /
`dmr` / `ysf` / `phase1` siblings).

The `ControlChannel.Process(dibits, baseIdx)` adapter (cross-call
dibit buffering + FS3 sync detect + 80-bit CSBK slice +
`CSBKFromBits` + `Ingest`) ships in its own follow-up alongside
the connector work.

## Test plan

- [x] `go test ./internal/radio/dpmr/... -race`
- [x] `go build ./...`
- [x] `go vet ./internal/radio/dpmr/...`

New tests cover:
- Constructor preconditions (with the correct sub-Nyquist threshold for 2400 sym/s)
- Silence smoke test
- Phase-ramp dibit emission
- `baseIdx` monotonicity + `Reset` rewinds to 0
- Every emitted dibit is in 0..3
- `SymbolToDibit` pinned to the P25 / DSDcc Gray-coded convention

## README

- dPMR (Mode 3) feature row now mentions the IQ → C4FM dibit
  receiver path.
- "Recently shipped" gains a bullet for the new receiver
  subpackage describing the composition + deferred adapter work.


---
_Generated by [Claude Code](https://claude.ai/code/session_019dtCCVEZJTKKr6YK3wy824)_