### PR TITLE
internal/radio/edacs/receiver: IQ → GFSK bit receiver for EDACS / GE-Marc

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ frontend over gRPC, HTTP/SSE, or WebSocket.
 | DMR (Tier II)     | Shares the burst / slot-type / BPTC(196,96) layers with Tier III; adds a 72-bit Full Link Control parser (FLCO enum: GroupVoiceChannelUser / UnitToUnitVoice / TalkerAlias / GPS / Terminator) with RS(12,9,4) parity verification (Voice LC Header seed) and a per-repeater conventional-mode state machine that decodes Voice LC Header bursts and emits `protocol = "dmr-tier2"` grants on the bus (deduped per call, cleared on Terminator-with-LC) and `decode.error` events with `voiceheader-bptc` / `voiceheader-rs` stages |
 | NXDN              | 192-dibit frame layout (4800 BFSK / 9600 4-FSK), LICH parse with parity + 16-bit doubled-wire decoder, FSW correlator, full SACCH channel decode (K=5 ½-rate convolutional Viterbi + 60-position sub-frame deinterleaver + 12-bit puncture undo + CRC-6 trailer), CAC parser with CRC, RCCH opcode enum + payload parsers, IQ → C4FM dibit receiver (`internal/radio/nxdn/receiver`) for the 9600-baud 4-FSK variant composing FM demod + RRC matched filter + Mueller-Müller clock recovery + 4-level slicer to fan `nxdn.DibitSink` out to a future `ControlChannel.Process` adapter (BFSK variant — 2-level slicer — is a follow-up), control-channel state machine |
 | Motorola Type II  | OSW parser, opcode constants, LCN → Hz band-plan resolver (linear + table), control-channel state machine emitting `protocol = "motorola"` grants |
-| EDACS / GE-Marc   | 40-bit CCW parser, command enum (Idle / GroupVoiceGrant / ProVoiceGrant / IndividualCall / DataGrant / SystemID / AdjacentSite / Emergency / Affiliation / Encryption), per-command accessors with encrypted / emergency flags, LCN → Hz resolver, control-channel state machine emitting `protocol = "edacs"` grants |
+| EDACS / GE-Marc   | 40-bit CCW parser, command enum (Idle / GroupVoiceGrant / ProVoiceGrant / IndividualCall / DataGrant / SystemID / AdjacentSite / Emergency / Affiliation / Encryption), per-command accessors with encrypted / emergency flags, LCN → Hz resolver, IQ → GFSK bit receiver (`internal/radio/edacs/receiver`) composing FM demod + Gaussian matched filter (BT = 0.3) + Mueller-Müller clock recovery + 2-level slicer at 9600 baud to fan `edacs.BitSink` out to a future `ControlChannel.Process` adapter, control-channel state machine emitting `protocol = "edacs"` grants |
 | LTR               | 41-bit per-repeater Status word parser, Channel → Hz resolver, optional area filter, per-repeater state machine emitting `protocol = "ltr"` grants when a status indicates an active call |
 | MPT 1327          | 64-bit address-codeword parser (38 info + 26 BCH parity consumed upstream), CodewordKind enum (ALH / AHY / AHYC / GTC / ACK / Disconnect / Data / Emergency), accessors for GTC voice grants + AHYC system broadcast, channel resolver, control-channel state machine emitting `protocol = "mpt1327"` grants |
 | dPMR (Mode 3)     | FS1 / FS2 / FS3 24-dibit sync, 80-bit CSBK parser, MessageType enum (RegistrationRequest / Response, VoiceServiceAllocation, IndividualVoiceAllocation, DataServiceAllocation, ServiceRequest, StandingServiceStatus, Release, Idle), AsVoiceGrant + AsSiteBroadcast accessors, PMR446 default band-plan, IQ → C4FM dibit receiver (`internal/radio/dpmr/receiver`) composing FM demod + RRC matched filter + Mueller-Müller clock recovery + 4-level slicer at the 2400-sym/s rate to fan `dpmr.DibitSink` out to a future `ControlChannel.Process` adapter, control-channel state machine emitting `protocol = "dpmr"` grants |
@@ -134,6 +134,15 @@ to its own package and lands independently.
 
 ### Recently shipped
 
+- **EDACS / GE-Marc IQ → GFSK bit receiver** (`internal/radio/edacs/receiver`)
+  composing FM demod + Gaussian matched filter (BT = 0.3) +
+  Mueller-Müller clock recovery + 2-level slicer at 9600 baud
+  into one entry point that fans bits out via the new
+  `edacs.BitSink` callback. First non-C4FM per-protocol receiver
+  in the family — leans on the `demod.GFSK` helper shipped earlier
+  in the roadmap. The `ControlChannel.Process(bits, baseIdx)`
+  adapter that does 24-bit sync detect + 40-bit CCW slice +
+  `CCWFromBits` + `Ingest` is the next layer up.
 - **dPMR Mode 3 IQ → C4FM dibit receiver** (`internal/radio/dpmr/receiver`)
   composing FM demod + RRC matched filter + Mueller-Müller clock
   recovery + 4-level slicer at the 2400-sym/s rate (half the P25 P1

--- a/internal/radio/edacs/receiver/receiver.go
+++ b/internal/radio/edacs/receiver/receiver.go
@@ -1,0 +1,138 @@
+// Package receiver wires the IQ → GFSK bit chain that feeds the
+// EDACS / GE-Marc control-channel state machine.
+//
+//	IQ samples
+//	  → FM discriminator (internal/dsp/demod.FM)
+//	  → Gaussian matched filter + 2-level slicer (internal/dsp/demod.GFSK)
+//	  → Mueller-Müller symbol clock recovery (internal/dsp/sync.MuellerMuller)
+//	  → edacs.BitSink
+//
+// EDACS runs a continuous 9600-baud GFSK control channel with the
+// standard BT = 0.3 Gaussian premod filter. Unlike the 4FSK family
+// (C4FM at 4800 sym/s), EDACS is 2-level so the receiver emits raw
+// bits (each byte is 0 or 1), not dibits. The downstream framing
+// (24-bit sync, 40-bit Control Channel Words) lives in the parent
+// edacs package.
+//
+// The receiver is stateful and not safe for concurrent Process
+// calls. Instantiate one per tuned frequency / per call chain.
+package receiver
+
+import (
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/demod"
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/sync"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/edacs"
+)
+
+// EDACS / GE-Marc on-air parameters.
+const (
+	// SymbolRate is the channel symbol rate. Each symbol carries
+	// one bit on the wire — total channel capacity 9600 bps.
+	SymbolRate = 9600.0
+	// BT is the Gaussian premod product matching standard EDACS /
+	// GE-Marc deployments.
+	BT = 0.3
+	// PulseSpanSymbols is the half-span of the Gaussian pulse on
+	// each side of the symbol time. 4 symbols is the typical
+	// receiver-side compromise; the Gaussian shape is sharp enough
+	// that longer spans add little selectivity.
+	PulseSpanSymbols = 4
+)
+
+// Options configures a Receiver.
+type Options struct {
+	// SampleRateHz is the IQ sample rate after any upstream
+	// channelization. Required; must be ≥ 2 × SymbolRate (19200 Hz).
+	SampleRateHz float64
+	// BitSink receives the raw bit stream the receiver decodes
+	// from IQ. Required.
+	BitSink edacs.BitSink
+	// PulseSpanSymbols overrides the Gaussian half-span. <= 0
+	// uses PulseSpanSymbols.
+	PulseSpanSymbols int
+	// BTProduct overrides the Gaussian BT product. <= 0 uses BT.
+	BTProduct float64
+	// ClockGain is the Mueller-Müller loop gain. <= 0 uses 0.05.
+	ClockGain float64
+}
+
+// Receiver is the composed IQ → bit pipeline.
+type Receiver struct {
+	fm       *demod.FM
+	gfsk     *demod.GFSK
+	clock    *sync.MuellerMuller
+	bitSink  edacs.BitSink
+	bitBase  int
+
+	disc    []float32
+	matched []float32
+	symbols []float32
+	bits    []byte
+}
+
+// New constructs a Receiver. Panics if SampleRateHz or BitSink are
+// unset, or the resulting samples-per-symbol is below 2.
+func New(opts Options) *Receiver {
+	if opts.SampleRateHz <= 0 {
+		panic("receiver: SampleRateHz is required")
+	}
+	if opts.BitSink == nil {
+		panic("receiver: BitSink is required")
+	}
+	sps := opts.SampleRateHz / SymbolRate
+	if sps < 2 {
+		panic("receiver: SampleRateHz must be >= 2*SymbolRate (19200 Hz)")
+	}
+	span := opts.PulseSpanSymbols
+	if span <= 0 {
+		span = PulseSpanSymbols
+	}
+	bt := opts.BTProduct
+	if bt <= 0 {
+		bt = BT
+	}
+	gain := opts.ClockGain
+	if gain <= 0 {
+		gain = 0.05
+	}
+
+	return &Receiver{
+		fm:      demod.NewFM(),
+		gfsk:    demod.NewGFSK(int(sps+0.5), span, bt),
+		clock:   sync.NewMuellerMuller(sps, gain),
+		bitSink: opts.BitSink,
+	}
+}
+
+// Process pushes one chunk of complex64 IQ samples through the chain.
+// Zero or more bit batches may be emitted to BitSink during the call.
+func (r *Receiver) Process(iq []complex64) {
+	if len(iq) == 0 {
+		return
+	}
+	r.disc = r.fm.Process(r.disc, iq)
+	r.matched = r.gfsk.MatchedFilter(r.matched, r.disc)
+	r.symbols = r.clock.Process(r.symbols, r.matched)
+	if len(r.symbols) == 0 {
+		return
+	}
+	if cap(r.bits) < len(r.symbols) {
+		r.bits = make([]byte, len(r.symbols))
+	} else {
+		r.bits = r.bits[:len(r.symbols)]
+	}
+	for i, s := range r.symbols {
+		r.bits[i] = byte(r.gfsk.Slice(s))
+	}
+	r.bitSink(r.bits, r.bitBase)
+	r.bitBase += len(r.bits)
+}
+
+// Reset returns the receiver to its initial state. Call on stream
+// re-sync (control-channel hunt success, IQ underrun recovery) so
+// the BitSink baseIdx restarts at 0 and the matched filter / clock
+// recovery shed their stale history.
+func (r *Receiver) Reset() {
+	r.bitBase = 0
+	r.gfsk.Reset()
+}

--- a/internal/radio/edacs/receiver/receiver_test.go
+++ b/internal/radio/edacs/receiver/receiver_test.go
@@ -1,0 +1,151 @@
+package receiver
+
+import (
+	"math"
+	"testing"
+)
+
+func TestReceiverConstructsAndProcessesSilence(t *testing.T) {
+	r := New(Options{
+		SampleRateHz: 48_000,
+		BitSink:      func(bits []byte, baseIdx int) {},
+	})
+	silence := make([]complex64, 9600)
+	for range 4 {
+		r.Process(silence)
+	}
+}
+
+func TestReceiverConstructorPanicsOnBadParams(t *testing.T) {
+	cases := []struct {
+		name string
+		opts Options
+	}{
+		{"missing sample rate", Options{BitSink: func([]byte, int) {}}},
+		{"missing sink", Options{SampleRateHz: 48_000}},
+		{"sample rate below 2x symbol rate", Options{SampleRateHz: 16_000, BitSink: func([]byte, int) {}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r == nil {
+					t.Errorf("expected panic, got nil")
+				}
+			}()
+			_ = New(tc.opts)
+		})
+	}
+}
+
+// makeNRZIQ at 96 kHz / 10 sps cycles through alternating ±NRZ
+// symbols modulated as FM tones around ±deviation. Mirrors the
+// GFSK helper's own round-trip test fixture — the dPMR / NXDN
+// versions don't apply here because EDACS is 2-level.
+func makeNRZIQ(nBits int) []complex64 {
+	const sampleRate = 96_000.0
+	const sps = 10 // 96000 / 9600
+	const deviation = 2400.0
+	radPerSample := func(bit int) float64 {
+		v := -1.0
+		if bit == 1 {
+			v = +1.0
+		}
+		return 2 * math.Pi * v * deviation / sampleRate
+	}
+	iq := make([]complex64, nBits*sps)
+	phase := 0.0
+	for b := 0; b < nBits; b++ {
+		dphi := radPerSample(b % 2)
+		base := b * sps
+		for k := 0; k < sps; k++ {
+			iq[base+k] = complex(float32(math.Cos(phase)), float32(math.Sin(phase)))
+			phase += dphi
+		}
+	}
+	return iq
+}
+
+func TestReceiverEmitsBitsFromNRZ(t *testing.T) {
+	var batches int
+	r := New(Options{
+		SampleRateHz: 96_000,
+		BitSink:      func(bits []byte, baseIdx int) { batches++ },
+	})
+	iq := makeNRZIQ(1024)
+	chunk := 4096
+	for i := 0; i < len(iq); i += chunk {
+		end := i + chunk
+		if end > len(iq) {
+			end = len(iq)
+		}
+		r.Process(iq[i:end])
+	}
+	if batches == 0 {
+		t.Errorf("BitSink received zero batches; Mueller-Müller loop produced no symbols")
+	}
+}
+
+func TestReceiverBitSinkBaseIdxMonotonic(t *testing.T) {
+	var baseIdxs []int
+	var batchLens []int
+	r := New(Options{
+		SampleRateHz: 96_000,
+		BitSink: func(bits []byte, baseIdx int) {
+			baseIdxs = append(baseIdxs, baseIdx)
+			batchLens = append(batchLens, len(bits))
+		},
+	})
+
+	iq := makeNRZIQ(1024)
+	chunk := 4096
+	for i := 0; i < len(iq); i += chunk {
+		end := i + chunk
+		if end > len(iq) {
+			end = len(iq)
+		}
+		r.Process(iq[i:end])
+	}
+
+	if len(baseIdxs) == 0 {
+		t.Fatalf("expected BitSink to receive at least one batch")
+	}
+	if baseIdxs[0] != 0 {
+		t.Errorf("first baseIdx = %d, want 0", baseIdxs[0])
+	}
+	cumulative := 0
+	for i := range baseIdxs {
+		if baseIdxs[i] != cumulative {
+			t.Errorf("baseIdx[%d]=%d, want %d", i, baseIdxs[i], cumulative)
+		}
+		cumulative += batchLens[i]
+	}
+
+	r.Reset()
+	baseIdxs = baseIdxs[:0]
+	batchLens = batchLens[:0]
+	r.Process(iq)
+	if len(baseIdxs) == 0 {
+		t.Fatalf("post-Reset: expected BitSink to receive at least one batch")
+	}
+	if baseIdxs[0] != 0 {
+		t.Errorf("post-Reset: first baseIdx = %d, want 0", baseIdxs[0])
+	}
+}
+
+func TestReceiverEmittedBitsAreBinary(t *testing.T) {
+	var bad int
+	r := New(Options{
+		SampleRateHz: 96_000,
+		BitSink: func(bits []byte, baseIdx int) {
+			for _, b := range bits {
+				if b > 1 {
+					bad++
+				}
+			}
+		},
+	})
+	r.Process(makeNRZIQ(1024))
+	if bad > 0 {
+		t.Errorf("%d bit(s) outside 0..1 range", bad)
+	}
+}

--- a/internal/radio/edacs/sync.go
+++ b/internal/radio/edacs/sync.go
@@ -1,5 +1,16 @@
 package edacs
 
+// BitSink consumes the raw stream of bits an EDACS receiver decodes
+// from IQ. baseIdx is the absolute bit index of bits[0] across the
+// stream lifetime — monotonically non-decreasing across calls, and
+// reset to 0 by Receiver.Reset so a retune produces a fresh
+// baseline. EDACS is bit-oriented (2-level GFSK at 9600 baud); the
+// other 4-level trunked protocols use a DibitSink instead. Wire
+// this into a future ControlChannel.Process adapter (sync detect
+// → 40-bit CCW slice → CCWFromBits → Ingest) so the connector can
+// drive the EDACS CC state machine on live IQ.
+type BitSink func(bits []byte, baseIdx int)
+
 // SyncWord is the 24-bit sync sequence prefacing each EDACS Control
 // Channel Word. Stored as MSB-first bits to mesh with the rest of the
 // radio stack's framing layer.


### PR DESCRIPTION
## Summary

PR #10 of the roadmap — fifth per-protocol IQ → bit receiver, and
the first non-C4FM one. EDACS / GE-Marc runs a continuous 9600-baud
GFSK control channel with the standard BT = 0.3 Gaussian premod
filter; the receiver leans on the `demod.GFSK` helper shipped
earlier in the roadmap.

Unlike the 4FSK family (C4FM at 4800 sym/s, dibits), EDACS is
**2-level** so the receiver emits raw bits (each byte is 0 or 1) via
a new `edacs.BitSink` callback type.

Pipeline:
```
IQ samples
  → demod.FM
  → demod.GFSK matched filter (Gaussian, BT = 0.3)
  → sync.MuellerMuller clock recovery
  → demod.GFSK.Slice (2-level slicer at zero)
  → edacs.BitSink
```

The `ControlChannel.Process(bits, baseIdx)` adapter (cross-call
bit buffering + 24-bit sync detect + 40-bit CCW slice +
`CCWFromBits` + `Ingest`) ships in its own follow-up alongside
the connector work.

## Test plan

- [x] `go test ./internal/radio/edacs/... -race`
- [x] `go build ./...`
- [x] `go vet ./internal/radio/edacs/...`

New tests cover:
- Constructor preconditions (with sub-Nyquist threshold for 9600 baud)
- Silence smoke test
- NRZ bit emission from a synthesised ±deviation FM signal
- `baseIdx` monotonicity + `Reset` rewinds to 0
- Every emitted bit is in 0..1

## README

- EDACS feature row now mentions the IQ → GFSK bit receiver path.
- "Recently shipped" gains a bullet for the new receiver
  subpackage, calling out that this is the first non-C4FM
  per-protocol receiver.


---
_Generated by [Claude Code](https://claude.ai/code/session_019dtCCVEZJTKKr6YK3wy824)_