### PR TITLE
internal/radio/mpt1327/receiver: IQ → FFSK bit receiver for MPT 1327

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ frontend over gRPC, HTTP/SSE, or WebSocket.
 | Motorola Type II  | OSW parser, opcode constants, LCN → Hz band-plan resolver (linear + table), control-channel state machine emitting `protocol = "motorola"` grants |
 | EDACS / GE-Marc   | 40-bit CCW parser, command enum (Idle / GroupVoiceGrant / ProVoiceGrant / IndividualCall / DataGrant / SystemID / AdjacentSite / Emergency / Affiliation / Encryption), per-command accessors with encrypted / emergency flags, LCN → Hz resolver, IQ → GFSK bit receiver (`internal/radio/edacs/receiver`) composing FM demod + Gaussian matched filter (BT = 0.3) + Mueller-Müller clock recovery + 2-level slicer at 9600 baud to fan `edacs.BitSink` out to a future `ControlChannel.Process` adapter, control-channel state machine emitting `protocol = "edacs"` grants |
 | LTR               | 41-bit per-repeater Status word parser, Channel → Hz resolver, optional area filter, per-repeater state machine emitting `protocol = "ltr"` grants when a status indicates an active call |
-| MPT 1327          | 64-bit address-codeword parser (38 info + 26 BCH parity consumed upstream), CodewordKind enum (ALH / AHY / AHYC / GTC / ACK / Disconnect / Data / Emergency), accessors for GTC voice grants + AHYC system broadcast, channel resolver, control-channel state machine emitting `protocol = "mpt1327"` grants |
+| MPT 1327          | 64-bit address-codeword parser (38 info + 26 BCH parity consumed upstream), CodewordKind enum (ALH / AHY / AHYC / GTC / ACK / Disconnect / Data / Emergency), accessors for GTC voice grants + AHYC system broadcast, channel resolver, IQ → FFSK bit receiver (`internal/radio/mpt1327/receiver`) composing FM demod + FFSK tone discriminator (mark = 1200 Hz / space = 1800 Hz CCIR FFSK) + Mueller-Müller clock recovery at 1200 baud to fan `mpt1327.BitSink` out to a future `ControlChannel.Process` adapter, control-channel state machine emitting `protocol = "mpt1327"` grants |
 | dPMR (Mode 3)     | FS1 / FS2 / FS3 24-dibit sync, 80-bit CSBK parser, MessageType enum (RegistrationRequest / Response, VoiceServiceAllocation, IndividualVoiceAllocation, DataServiceAllocation, ServiceRequest, StandingServiceStatus, Release, Idle), AsVoiceGrant + AsSiteBroadcast accessors, PMR446 default band-plan, IQ → C4FM dibit receiver (`internal/radio/dpmr/receiver`) composing FM demod + RRC matched filter + Mueller-Müller clock recovery + 4-level slicer at the 2400-sym/s rate to fan `dpmr.DibitSink` out to a future `ControlChannel.Process` adapter, control-channel state machine emitting `protocol = "dpmr"` grants |
 | TETRA (TMO)       | Normal + extended training-sequence sync, generic Layer-3 PDU parser (4-bit Discriminator + type + payload), CMCE D-CONNECT / D-TX-GRANTED / D-RELEASE accessors, MLE-SYSINFO accessor (MCC / MNC / Location Area), TETRA-380 / 410 / 800 carrier resolver, control-channel state machine emitting `protocol = "tetra"` grants |
 | D-STAR            | Frame Sync + Slow Data sync, 41-byte PCH header parser (FLAG1 + RPT2 / RPT1 / UR / MY1 / MY2 + CRC-CCITT), IsGroupCall / IsEmergency / IsData accessors, repeater state machine emitting `protocol = "dstar"` grants on group transmissions |
@@ -134,6 +134,17 @@ to its own package and lands independently.
 
 ### Recently shipped
 
+- **MPT 1327 IQ → FFSK bit receiver** (`internal/radio/mpt1327/receiver`)
+  composing FM demod + FFSK tone discriminator (CCIR FFSK:
+  mark = 1200 Hz / space = 1800 Hz) + Mueller-Müller clock
+  recovery at 1200 baud into one entry point that fans bits out
+  via the new `mpt1327.BitSink` callback. Sixth per-protocol
+  receiver in the family and the first audio-band-FSK one — leans
+  on the `demod.FFSK` helper shipped earlier in the roadmap. The
+  `ControlChannel.Process(bits, baseIdx)` adapter that does
+  cross-call bit buffering + 64-bit codeword slice + BCH(63,38)
+  parity verification + `ParseCodeword` + `Ingest` is the next
+  layer up.
 - **EDACS / GE-Marc IQ → GFSK bit receiver** (`internal/radio/edacs/receiver`)
   composing FM demod + Gaussian matched filter (BT = 0.3) +
   Mueller-Müller clock recovery + 2-level slicer at 9600 baud

--- a/internal/radio/mpt1327/codeword.go
+++ b/internal/radio/mpt1327/codeword.go
@@ -5,6 +5,18 @@ import (
 	"fmt"
 )
 
+// BitSink consumes the raw stream of bits an MPT 1327 receiver
+// decodes from IQ. baseIdx is the absolute bit index of bits[0]
+// across the stream lifetime — monotonically non-decreasing across
+// calls, and reset to 0 by Receiver.Reset so a retune produces a
+// fresh baseline. MPT 1327 is 2-level (1200 baud FFSK on top of
+// NBFM audio); the 4-level trunked protocols use a DibitSink
+// instead. Wire this into a future ControlChannel.Process adapter
+// (cross-call bit buffering → 64-bit codeword slice → upstream BCH
+// decode → ParseCodeword → Ingest) so the connector can drive the
+// MPT 1327 CC state machine on live IQ.
+type BitSink func(bits []byte, baseIdx int)
+
 // Codeword is one MPT 1327 address / data codeword — 38 information
 // bits packed into the upper 38 bits of a 64-bit transmission unit
 // (the lower 26 bits hold the BCH(63,38) parity, which the upstream

--- a/internal/radio/mpt1327/receiver/receiver.go
+++ b/internal/radio/mpt1327/receiver/receiver.go
@@ -1,0 +1,126 @@
+// Package receiver wires the IQ → FFSK bit chain that feeds the
+// MPT 1327 control-channel state machine. MPT 1327 carries 1200-baud
+// CCIR FFSK signalling on top of a narrowband-FM audio channel —
+// mark = 1200 Hz = binary 1, space = 1800 Hz = binary 0.
+//
+//	IQ samples
+//	  → FM discriminator (internal/dsp/demod.FM)
+//	  → real audio
+//	  → FFSK tone discriminator (internal/dsp/demod.FFSK)
+//	  → Mueller-Müller symbol clock recovery (internal/dsp/sync.MuellerMuller)
+//	  → mpt1327.BitSink
+//
+// The receiver is 2-level so it emits raw bits (each byte is 0 or 1)
+// via mpt1327.BitSink. The downstream framing (24-bit preamble +
+// 64-bit codeword units, BCH(63,38) parity) lives in the parent
+// mpt1327 package + upstream FEC.
+//
+// The receiver is stateful and not safe for concurrent Process
+// calls. Instantiate one per tuned frequency / per call chain.
+package receiver
+
+import (
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/demod"
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/sync"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/mpt1327"
+)
+
+// MPT 1327 on-air parameters (CCIR FFSK).
+const (
+	// SymbolRate is the bit rate on the FFSK signalling layer.
+	SymbolRate = 1200.0
+	// MarkHz / SpaceHz are the CCIR FFSK tone frequencies inside
+	// the FM audio. Mark conventionally encodes binary 1.
+	MarkHz  = 1200.0
+	SpaceHz = 1800.0
+)
+
+// Options configures a Receiver.
+type Options struct {
+	// SampleRateHz is the IQ sample rate after any upstream
+	// channelization. Required; must be ≥ 2 × SpaceHz so the FFSK
+	// helper's complex mixer can reach the upper tone.
+	SampleRateHz float64
+	// BitSink receives the raw bit stream the receiver decodes
+	// from IQ. Required.
+	BitSink mpt1327.BitSink
+	// ClockGain is the Mueller-Müller loop gain. <= 0 uses 0.05.
+	ClockGain float64
+}
+
+// Receiver is the composed IQ → bit pipeline.
+type Receiver struct {
+	fm      *demod.FM
+	ffsk    *demod.FFSK
+	clock   *sync.MuellerMuller
+	bitSink mpt1327.BitSink
+	bitBase int
+
+	disc    []float32
+	tone    []float32
+	symbols []float32
+	bits    []byte
+}
+
+// New constructs a Receiver. Panics if SampleRateHz or BitSink are
+// unset, or the resulting samples-per-symbol is below 2.
+func New(opts Options) *Receiver {
+	if opts.SampleRateHz <= 0 {
+		panic("receiver: SampleRateHz is required")
+	}
+	if opts.BitSink == nil {
+		panic("receiver: BitSink is required")
+	}
+	if opts.SampleRateHz < 2*SpaceHz {
+		panic("receiver: SampleRateHz must be >= 2*SpaceHz (3600 Hz)")
+	}
+	sps := opts.SampleRateHz / SymbolRate
+	if sps < 2 {
+		panic("receiver: SampleRateHz must be >= 2*SymbolRate (2400 Hz)")
+	}
+	gain := opts.ClockGain
+	if gain <= 0 {
+		gain = 0.05
+	}
+
+	return &Receiver{
+		fm:      demod.NewFM(),
+		ffsk:    demod.NewFFSK(opts.SampleRateHz, MarkHz, SpaceHz),
+		clock:   sync.NewMuellerMuller(sps, gain),
+		bitSink: opts.BitSink,
+	}
+}
+
+// Process pushes one chunk of complex64 IQ samples through the
+// chain. Zero or more bit batches may be emitted to BitSink during
+// the call.
+func (r *Receiver) Process(iq []complex64) {
+	if len(iq) == 0 {
+		return
+	}
+	r.disc = r.fm.Process(r.disc, iq)
+	r.tone = r.ffsk.Discriminate(r.tone, r.disc)
+	r.symbols = r.clock.Process(r.symbols, r.tone)
+	if len(r.symbols) == 0 {
+		return
+	}
+	if cap(r.bits) < len(r.symbols) {
+		r.bits = make([]byte, len(r.symbols))
+	} else {
+		r.bits = r.bits[:len(r.symbols)]
+	}
+	for i, s := range r.symbols {
+		r.bits[i] = byte(r.ffsk.Slice(s))
+	}
+	r.bitSink(r.bits, r.bitBase)
+	r.bitBase += len(r.bits)
+}
+
+// Reset returns the receiver to its initial state. Call on stream
+// re-sync (control-channel hunt success, IQ underrun recovery) so
+// the BitSink baseIdx restarts at 0 and the FFSK chain sheds its
+// mixer phase + LPF history.
+func (r *Receiver) Reset() {
+	r.bitBase = 0
+	r.ffsk.Reset()
+}

--- a/internal/radio/mpt1327/receiver/receiver_test.go
+++ b/internal/radio/mpt1327/receiver/receiver_test.go
@@ -1,0 +1,164 @@
+package receiver
+
+import (
+	"math"
+	"testing"
+)
+
+func TestReceiverConstructsAndProcessesSilence(t *testing.T) {
+	r := New(Options{
+		SampleRateHz: 48_000,
+		BitSink:      func(bits []byte, baseIdx int) {},
+	})
+	silence := make([]complex64, 4800)
+	for range 4 {
+		r.Process(silence)
+	}
+}
+
+func TestReceiverConstructorPanicsOnBadParams(t *testing.T) {
+	cases := []struct {
+		name string
+		opts Options
+	}{
+		{"missing sample rate", Options{BitSink: func([]byte, int) {}}},
+		{"missing sink", Options{SampleRateHz: 48_000}},
+		{"sample rate below 2x space tone", Options{SampleRateHz: 3000, BitSink: func([]byte, int) {}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r == nil {
+					t.Errorf("expected panic, got nil")
+				}
+			}()
+			_ = New(tc.opts)
+		})
+	}
+}
+
+// makeFMFFSKIQ synthesises an MPT-1327-style IQ stream:
+//
+//  1. Build an audio waveform whose instantaneous frequency steps
+//     between MarkHz / SpaceHz at the 1200 baud bit rate (continuous
+//     phase so the FFSK discriminator sees a clean signal).
+//  2. FM-modulate that audio onto an IQ carrier at the requested
+//     deviation. The receiver's FM discriminator inverts step 2
+//     and hands the original audio waveform to the FFSK helper.
+func makeFMFFSKIQ(bits []int) []complex64 {
+	const sampleRate = 48_000.0
+	const bitRate = 1200.0
+	const sps = int(sampleRate / bitRate) // 40
+	const fmDeviation = 4_000.0           // peak FM deviation in Hz
+
+	audio := make([]float32, len(bits)*sps)
+	audioPhase := 0.0
+	for b, bit := range bits {
+		toneHz := SpaceHz
+		if bit == 1 {
+			toneHz = MarkHz
+		}
+		dphi := 2 * math.Pi * toneHz / sampleRate
+		for k := 0; k < sps; k++ {
+			audio[b*sps+k] = float32(math.Sin(audioPhase))
+			audioPhase += dphi
+		}
+	}
+
+	iq := make([]complex64, len(audio))
+	rfPhase := 0.0
+	for i, a := range audio {
+		rfPhase += 2 * math.Pi * float64(a) * fmDeviation / sampleRate
+		iq[i] = complex(float32(math.Cos(rfPhase)), float32(math.Sin(rfPhase)))
+	}
+	return iq
+}
+
+func TestReceiverEmitsBitsFromFMFFSK(t *testing.T) {
+	bits := []int{1, 0, 1, 0, 1, 1, 0, 0, 1, 0, 1, 1, 1, 0, 0, 1, 0, 1, 1, 0,
+		1, 1, 0, 0, 1, 0, 1, 0, 0, 1, 1, 1, 0, 0, 1, 0}
+	var batches int
+	r := New(Options{
+		SampleRateHz: 48_000,
+		BitSink:      func(b []byte, baseIdx int) { batches++ },
+	})
+	iq := makeFMFFSKIQ(bits)
+	chunk := 4096
+	for i := 0; i < len(iq); i += chunk {
+		end := i + chunk
+		if end > len(iq) {
+			end = len(iq)
+		}
+		r.Process(iq[i:end])
+	}
+	if batches == 0 {
+		t.Errorf("BitSink received zero batches; the chain produced no symbols")
+	}
+}
+
+func TestReceiverBitSinkBaseIdxMonotonic(t *testing.T) {
+	var baseIdxs []int
+	var batchLens []int
+	r := New(Options{
+		SampleRateHz: 48_000,
+		BitSink: func(b []byte, baseIdx int) {
+			baseIdxs = append(baseIdxs, baseIdx)
+			batchLens = append(batchLens, len(b))
+		},
+	})
+
+	bits := []int{1, 0, 1, 1, 0, 0, 1, 0, 1, 1, 1, 0, 0, 1, 0, 1}
+	iq := makeFMFFSKIQ(bits)
+	chunk := 4096
+	for i := 0; i < len(iq); i += chunk {
+		end := i + chunk
+		if end > len(iq) {
+			end = len(iq)
+		}
+		r.Process(iq[i:end])
+	}
+
+	if len(baseIdxs) == 0 {
+		t.Fatalf("expected BitSink to receive at least one batch")
+	}
+	if baseIdxs[0] != 0 {
+		t.Errorf("first baseIdx = %d, want 0", baseIdxs[0])
+	}
+	cumulative := 0
+	for i := range baseIdxs {
+		if baseIdxs[i] != cumulative {
+			t.Errorf("baseIdx[%d]=%d, want %d", i, baseIdxs[i], cumulative)
+		}
+		cumulative += batchLens[i]
+	}
+
+	r.Reset()
+	baseIdxs = baseIdxs[:0]
+	batchLens = batchLens[:0]
+	r.Process(iq)
+	if len(baseIdxs) == 0 {
+		t.Fatalf("post-Reset: expected BitSink to receive at least one batch")
+	}
+	if baseIdxs[0] != 0 {
+		t.Errorf("post-Reset: first baseIdx = %d, want 0", baseIdxs[0])
+	}
+}
+
+func TestReceiverEmittedBitsAreBinary(t *testing.T) {
+	var bad int
+	r := New(Options{
+		SampleRateHz: 48_000,
+		BitSink: func(b []byte, baseIdx int) {
+			for _, v := range b {
+				if v > 1 {
+					bad++
+				}
+			}
+		},
+	})
+	bits := []int{1, 0, 1, 0, 1, 1, 0, 0}
+	r.Process(makeFMFFSKIQ(bits))
+	if bad > 0 {
+		t.Errorf("%d bit(s) outside 0..1 range", bad)
+	}
+}


### PR DESCRIPTION
## Summary

PR #11 of the roadmap — sixth per-protocol receiver and the first
audio-band-FSK one. MPT 1327 carries 1200-baud CCIR FFSK
signalling on top of a narrowband-FM audio channel:

- **mark** = 1200 Hz = binary 1
- **space** = 1800 Hz = binary 0

The receiver leans on the `demod.FFSK` helper shipped earlier in
the roadmap, which already handles the complex mixer + Kaiser LPF
+ FM-discriminator stage that pulls the tone-difference signal
out of the FM audio.

Pipeline:
```
IQ samples
  → demod.FM
  → real audio
  → demod.FFSK.Discriminate (CCIR FFSK tones)
  → sync.MuellerMuller clock recovery at 1200 baud
  → demod.FFSK.Slice (1 for mark, 0 for space)
  → mpt1327.BitSink
```

Adds an `mpt1327.BitSink` function type in the parent package
(mirrors `edacs.BitSink`; 2-level protocols use `BitSink`, the
4-level trunked protocols use `DibitSink`).

The `ControlChannel.Process(bits, baseIdx)` adapter (cross-call
bit buffering + 64-bit codeword slice + BCH(63,38) parity
verification + `ParseCodeword` + `Ingest`) ships in its own
follow-up alongside the connector work.

## Test plan

- [x] `go test ./internal/radio/mpt1327/... -race`
- [x] `go build ./...`
- [x] `go vet ./internal/radio/mpt1327/...`

New tests cover:
- Constructor preconditions (with sub-Nyquist threshold for the 1800 Hz space tone)
- Silence smoke test
- **End-to-end round-trip**: synthesises a CCIR-FFSK-modulated
  FM IQ signal from a known bit pattern (build audio tones at
  mark/space → integrate to phase → emit IQ) and confirms the
  receiver chain produces non-zero bit batches
- `baseIdx` monotonicity + `Reset` rewinds to 0
- Every emitted bit is in 0..1

## README

- MPT 1327 feature row now mentions the IQ → FFSK bit receiver path.
- "Recently shipped" gains a bullet for the new receiver, calling
  out that this is the first audio-band-FSK per-protocol receiver.


---
_Generated by [Claude Code](https://claude.ai/code/session_019dtCCVEZJTKKr6YK3wy824)_