### PR TITLE
internal/radio/ltr/receiver: IQ → sub-audible bit receiver for LTR

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ frontend over gRPC, HTTP/SSE, or WebSocket.
 | NXDN              | 192-dibit frame layout (4800 BFSK / 9600 4-FSK), LICH parse with parity + 16-bit doubled-wire decoder, FSW correlator, full SACCH channel decode (K=5 ½-rate convolutional Viterbi + 60-position sub-frame deinterleaver + 12-bit puncture undo + CRC-6 trailer), CAC parser with CRC, RCCH opcode enum + payload parsers, IQ → C4FM dibit receiver (`internal/radio/nxdn/receiver`) for the 9600-baud 4-FSK variant composing FM demod + RRC matched filter + Mueller-Müller clock recovery + 4-level slicer to fan `nxdn.DibitSink` out to a future `ControlChannel.Process` adapter (BFSK variant — 2-level slicer — is a follow-up), control-channel state machine |
 | Motorola Type II  | OSW parser, opcode constants, LCN → Hz band-plan resolver (linear + table), control-channel state machine emitting `protocol = "motorola"` grants |
 | EDACS / GE-Marc   | 40-bit CCW parser, command enum (Idle / GroupVoiceGrant / ProVoiceGrant / IndividualCall / DataGrant / SystemID / AdjacentSite / Emergency / Affiliation / Encryption), per-command accessors with encrypted / emergency flags, LCN → Hz resolver, IQ → GFSK bit receiver (`internal/radio/edacs/receiver`) composing FM demod + Gaussian matched filter (BT = 0.3) + Mueller-Müller clock recovery + 2-level slicer at 9600 baud to fan `edacs.BitSink` out to a future `ControlChannel.Process` adapter, control-channel state machine emitting `protocol = "edacs"` grants |
-| LTR               | 41-bit per-repeater Status word parser, Channel → Hz resolver, optional area filter, per-repeater state machine emitting `protocol = "ltr"` grants when a status indicates an active call |
+| LTR               | 41-bit per-repeater Status word parser, Channel → Hz resolver, optional area filter, IQ → sub-audible bit receiver (`internal/radio/ltr/receiver`) composing FM demod + narrow sub-audible LPF (~300 Hz Kaiser-windowed FIR) + Mueller-Müller clock recovery at 300 baud + 2-level slicer to fan `ltr.BitSink` out to a future `ControlChannel.Process` adapter (Manchester decode + 41-bit framing live there), per-repeater state machine emitting `protocol = "ltr"` grants when a status indicates an active call |
 | MPT 1327          | 64-bit address-codeword parser (38 info + 26 BCH parity consumed upstream), CodewordKind enum (ALH / AHY / AHYC / GTC / ACK / Disconnect / Data / Emergency), accessors for GTC voice grants + AHYC system broadcast, channel resolver, IQ → FFSK bit receiver (`internal/radio/mpt1327/receiver`) composing FM demod + FFSK tone discriminator (mark = 1200 Hz / space = 1800 Hz CCIR FFSK) + Mueller-Müller clock recovery at 1200 baud to fan `mpt1327.BitSink` out to a future `ControlChannel.Process` adapter, control-channel state machine emitting `protocol = "mpt1327"` grants |
 | dPMR (Mode 3)     | FS1 / FS2 / FS3 24-dibit sync, 80-bit CSBK parser, MessageType enum (RegistrationRequest / Response, VoiceServiceAllocation, IndividualVoiceAllocation, DataServiceAllocation, ServiceRequest, StandingServiceStatus, Release, Idle), AsVoiceGrant + AsSiteBroadcast accessors, PMR446 default band-plan, IQ → C4FM dibit receiver (`internal/radio/dpmr/receiver`) composing FM demod + RRC matched filter + Mueller-Müller clock recovery + 4-level slicer at the 2400-sym/s rate to fan `dpmr.DibitSink` out to a future `ControlChannel.Process` adapter, control-channel state machine emitting `protocol = "dpmr"` grants |
 | TETRA (TMO)       | Normal + extended training-sequence sync, generic Layer-3 PDU parser (4-bit Discriminator + type + payload), CMCE D-CONNECT / D-TX-GRANTED / D-RELEASE accessors, MLE-SYSINFO accessor (MCC / MNC / Location Area), TETRA-380 / 410 / 800 carrier resolver, control-channel state machine emitting `protocol = "tetra"` grants |
@@ -134,6 +134,13 @@ to its own package and lands independently.
 
 ### Recently shipped
 
+- **LTR IQ → sub-audible bit receiver** (`internal/radio/ltr/receiver`)
+  composing FM demod + a narrow sub-audible LPF (Kaiser-windowed
+  FIR, ~300 Hz cutoff) + Mueller-Müller clock recovery at 300 baud
+  + 2-level slicer into one entry point that fans bits out via the
+  new `ltr.BitSink` callback. Seventh per-protocol receiver in the
+  family. Manchester decoding + 41-bit Status framing live in the
+  follow-up `ControlChannel.Process(bits, baseIdx)` adapter.
 - **MPT 1327 IQ → FFSK bit receiver** (`internal/radio/mpt1327/receiver`)
   composing FM demod + FFSK tone discriminator (CCIR FFSK:
   mark = 1200 Hz / space = 1800 Hz) + Mueller-Müller clock

--- a/internal/radio/ltr/receiver/receiver.go
+++ b/internal/radio/ltr/receiver/receiver.go
@@ -1,0 +1,157 @@
+// Package receiver wires the IQ → sub-audible bit chain that feeds
+// the LTR per-repeater state machine. LTR transmits a 41-bit Status
+// word at 300 baud underneath the in-band voice — sub-audible (the
+// bulk of the signal energy sits below 300 Hz), so the receiver
+// extracts it via FM demod + a narrow low-pass filter, then runs
+// symbol-rate clock recovery + 2-level slicing.
+//
+//	IQ samples
+//	  → FM discriminator (internal/dsp/demod.FM)
+//	  → real audio
+//	  → narrow lowpass (sub-audible band, ~300 Hz cutoff)
+//	  → Mueller-Müller symbol clock recovery at 300 baud
+//	  → 2-level slicer at zero
+//	  → ltr.BitSink
+//
+// The receiver emits raw bits (each byte is 0 or 1) via
+// ltr.BitSink. Manchester decoding (if the system uses it) plus the
+// 41-bit Status-word framing live in a future
+// ControlChannel.Process adapter and aren't wired by this package.
+//
+// The receiver is stateful and not safe for concurrent Process
+// calls. Instantiate one per tuned frequency / per call chain.
+package receiver
+
+import (
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/demod"
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/filter"
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/sync"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/ltr"
+)
+
+// LTR on-air parameters.
+const (
+	// SymbolRate is the on-air bit rate of the LTR Status-word
+	// channel. Manchester-encoded systems double the transition
+	// rate but the symbol clock here is the underlying bit clock.
+	SymbolRate = 300.0
+	// LPFCutoffHz is the default sub-audible cutoff. The Status
+	// word's energy sits below 300 Hz; everything above belongs to
+	// the voice and should be rejected.
+	LPFCutoffHz = 300.0
+	// LPFLen is the default Kaiser FIR length for the sub-audible
+	// LPF. 101 taps at 48 kHz gives a transition width of ~430 Hz
+	// (β = 8.6, ~85 dB stopband) so the voice spectrum above the
+	// cutoff is heavily attenuated.
+	LPFLen = 101
+	// LPFBeta is the Kaiser β for the LPF.
+	LPFBeta = 8.6
+)
+
+// Options configures a Receiver.
+type Options struct {
+	// SampleRateHz is the IQ sample rate after any upstream
+	// channelization. Required; must be ≥ 2 × SymbolRate.
+	SampleRateHz float64
+	// BitSink receives the raw bit stream the receiver decodes
+	// from IQ. Required.
+	BitSink ltr.BitSink
+	// LPFCutoffHz overrides the sub-audible cutoff. <= 0 uses
+	// LPFCutoffHz.
+	LPFCutoffHz float64
+	// LPFLen overrides the LPF length. <= 0 uses LPFLen.
+	LPFLen int
+	// ClockGain is the Mueller-Müller loop gain. <= 0 uses 0.05.
+	ClockGain float64
+}
+
+// Receiver is the composed IQ → bit pipeline.
+type Receiver struct {
+	fm      *demod.FM
+	lpf     *filter.RealFIR
+	clock   *sync.MuellerMuller
+	bitSink ltr.BitSink
+	bitBase int
+
+	disc    []float32
+	low     []float32
+	symbols []float32
+	bits    []byte
+}
+
+// New constructs a Receiver. Panics if SampleRateHz or BitSink are
+// unset, or the resulting samples-per-symbol is below 2.
+func New(opts Options) *Receiver {
+	if opts.SampleRateHz <= 0 {
+		panic("receiver: SampleRateHz is required")
+	}
+	if opts.BitSink == nil {
+		panic("receiver: BitSink is required")
+	}
+	sps := opts.SampleRateHz / SymbolRate
+	if sps < 2 {
+		panic("receiver: SampleRateHz must be >= 2*SymbolRate (600 Hz)")
+	}
+
+	cutoff := opts.LPFCutoffHz
+	if cutoff <= 0 {
+		cutoff = LPFCutoffHz
+	}
+	n := opts.LPFLen
+	if n <= 0 {
+		n = LPFLen
+	}
+	if n%2 == 0 {
+		n++
+	}
+	gain := opts.ClockGain
+	if gain <= 0 {
+		gain = 0.05
+	}
+
+	lpfTaps := filter.LowpassKaiser(n, cutoff/opts.SampleRateHz, LPFBeta)
+
+	return &Receiver{
+		fm:      demod.NewFM(),
+		lpf:     filter.NewRealFIR(lpfTaps),
+		clock:   sync.NewMuellerMuller(sps, gain),
+		bitSink: opts.BitSink,
+	}
+}
+
+// Process pushes one chunk of complex64 IQ samples through the
+// chain. Zero or more bit batches may be emitted to BitSink during
+// the call.
+func (r *Receiver) Process(iq []complex64) {
+	if len(iq) == 0 {
+		return
+	}
+	r.disc = r.fm.Process(r.disc, iq)
+	r.low = r.lpf.Process(r.low, r.disc)
+	r.symbols = r.clock.Process(r.symbols, r.low)
+	if len(r.symbols) == 0 {
+		return
+	}
+	if cap(r.bits) < len(r.symbols) {
+		r.bits = make([]byte, len(r.symbols))
+	} else {
+		r.bits = r.bits[:len(r.symbols)]
+	}
+	for i, s := range r.symbols {
+		if s > 0 {
+			r.bits[i] = 1
+		} else {
+			r.bits[i] = 0
+		}
+	}
+	r.bitSink(r.bits, r.bitBase)
+	r.bitBase += len(r.bits)
+}
+
+// Reset returns the receiver to its initial state. Call on stream
+// re-sync (control-channel hunt success, IQ underrun recovery) so
+// the BitSink baseIdx restarts at 0 and the LPF sheds its history.
+func (r *Receiver) Reset() {
+	r.bitBase = 0
+	r.lpf.Reset()
+}

--- a/internal/radio/ltr/receiver/receiver_test.go
+++ b/internal/radio/ltr/receiver/receiver_test.go
@@ -1,0 +1,157 @@
+package receiver
+
+import (
+	"math"
+	"testing"
+)
+
+func TestReceiverConstructsAndProcessesSilence(t *testing.T) {
+	r := New(Options{
+		SampleRateHz: 48_000,
+		BitSink:      func(bits []byte, baseIdx int) {},
+	})
+	silence := make([]complex64, 4800)
+	for range 4 {
+		r.Process(silence)
+	}
+}
+
+func TestReceiverConstructorPanicsOnBadParams(t *testing.T) {
+	cases := []struct {
+		name string
+		opts Options
+	}{
+		{"missing sample rate", Options{BitSink: func([]byte, int) {}}},
+		{"missing sink", Options{SampleRateHz: 48_000}},
+		{"sample rate below 2x symbol rate", Options{SampleRateHz: 500, BitSink: func([]byte, int) {}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r == nil {
+					t.Errorf("expected panic, got nil")
+				}
+			}()
+			_ = New(tc.opts)
+		})
+	}
+}
+
+// makeLTRFMIQ synthesises an IQ stream whose FM-demodulator output
+// is a sub-audible NRZ waveform at 300 baud — the underlying signal
+// shape an LTR Status word rides on (Manchester encoding aside).
+// Each bit period holds the audio constant at ±1; the receiver's
+// LPF + clock recovery should pull the same alternation back out.
+func makeLTRFMIQ(bits []int) []complex64 {
+	const sampleRate = 48_000.0
+	const bitRate = 300.0
+	const sps = int(sampleRate / bitRate) // 160
+	const fmDeviation = 2_000.0           // peak FM deviation in Hz
+
+	audio := make([]float32, len(bits)*sps)
+	for b, bit := range bits {
+		v := float32(-1)
+		if bit == 1 {
+			v = +1
+		}
+		for k := 0; k < sps; k++ {
+			audio[b*sps+k] = v
+		}
+	}
+
+	iq := make([]complex64, len(audio))
+	phase := 0.0
+	for i, a := range audio {
+		phase += 2 * math.Pi * float64(a) * fmDeviation / sampleRate
+		iq[i] = complex(float32(math.Cos(phase)), float32(math.Sin(phase)))
+	}
+	return iq
+}
+
+func TestReceiverEmitsBitsFromSubAudibleNRZ(t *testing.T) {
+	bits := []int{1, 0, 1, 0, 1, 1, 0, 0, 1, 0, 1, 1, 1, 0, 0, 1, 0, 1, 1, 0,
+		1, 1, 0, 0, 1, 0, 1, 0, 0, 1, 1, 1, 0, 0, 1, 0}
+	var batches int
+	r := New(Options{
+		SampleRateHz: 48_000,
+		BitSink:      func(b []byte, baseIdx int) { batches++ },
+	})
+	iq := makeLTRFMIQ(bits)
+	chunk := 4096
+	for i := 0; i < len(iq); i += chunk {
+		end := i + chunk
+		if end > len(iq) {
+			end = len(iq)
+		}
+		r.Process(iq[i:end])
+	}
+	if batches == 0 {
+		t.Errorf("BitSink received zero batches; the chain produced no symbols")
+	}
+}
+
+func TestReceiverBitSinkBaseIdxMonotonic(t *testing.T) {
+	var baseIdxs []int
+	var batchLens []int
+	r := New(Options{
+		SampleRateHz: 48_000,
+		BitSink: func(b []byte, baseIdx int) {
+			baseIdxs = append(baseIdxs, baseIdx)
+			batchLens = append(batchLens, len(b))
+		},
+	})
+
+	bits := []int{1, 0, 1, 1, 0, 0, 1, 0, 1, 1, 1, 0, 0, 1, 0, 1}
+	iq := makeLTRFMIQ(bits)
+	chunk := 4096
+	for i := 0; i < len(iq); i += chunk {
+		end := i + chunk
+		if end > len(iq) {
+			end = len(iq)
+		}
+		r.Process(iq[i:end])
+	}
+
+	if len(baseIdxs) == 0 {
+		t.Fatalf("expected BitSink to receive at least one batch")
+	}
+	if baseIdxs[0] != 0 {
+		t.Errorf("first baseIdx = %d, want 0", baseIdxs[0])
+	}
+	cumulative := 0
+	for i := range baseIdxs {
+		if baseIdxs[i] != cumulative {
+			t.Errorf("baseIdx[%d]=%d, want %d", i, baseIdxs[i], cumulative)
+		}
+		cumulative += batchLens[i]
+	}
+
+	r.Reset()
+	baseIdxs = baseIdxs[:0]
+	batchLens = batchLens[:0]
+	r.Process(iq)
+	if len(baseIdxs) == 0 {
+		t.Fatalf("post-Reset: expected BitSink to receive at least one batch")
+	}
+	if baseIdxs[0] != 0 {
+		t.Errorf("post-Reset: first baseIdx = %d, want 0", baseIdxs[0])
+	}
+}
+
+func TestReceiverEmittedBitsAreBinary(t *testing.T) {
+	var bad int
+	r := New(Options{
+		SampleRateHz: 48_000,
+		BitSink: func(b []byte, baseIdx int) {
+			for _, v := range b {
+				if v > 1 {
+					bad++
+				}
+			}
+		},
+	})
+	r.Process(makeLTRFMIQ([]int{1, 0, 1, 0, 1, 1, 0, 0}))
+	if bad > 0 {
+		t.Errorf("%d bit(s) outside 0..1 range", bad)
+	}
+}

--- a/internal/radio/ltr/sink.go
+++ b/internal/radio/ltr/sink.go
@@ -1,0 +1,13 @@
+package ltr
+
+// BitSink consumes the raw stream of bits an LTR receiver decodes
+// from the sub-audible signalling layer. baseIdx is the absolute
+// bit index of bits[0] across the stream lifetime — monotonically
+// non-decreasing across calls, and reset to 0 by Receiver.Reset so
+// a retune produces a fresh baseline. LTR is 2-level; the 4-level
+// trunked protocols use a DibitSink instead. Wire this into a
+// future ControlChannel.Process adapter (optional Manchester
+// decode + 41-bit Status framing + StatusFromBits + Ingest) so the
+// connector can drive the LTR per-repeater state machine on live
+// IQ.
+type BitSink func(bits []byte, baseIdx int)


### PR DESCRIPTION
## Summary

PR #12 of the roadmap — seventh per-protocol receiver. LTR transmits
a 41-bit Status word at 300 baud underneath the in-band voice; the
bulk of the signal energy sits below ~300 Hz, so the receiver
extracts it via FM demod + a narrow sub-audible Kaiser LPF, then
runs symbol-rate clock recovery + 2-level slicing.

Pipeline:
```
IQ samples
  → demod.FM
  → real audio
  → filter.RealFIR (Kaiser LPF, ~300 Hz cutoff, ~85 dB stopband)
  → sync.MuellerMuller clock recovery at 300 baud
  → 2-level slicer at zero
  → ltr.BitSink
```

Adds `ltr.BitSink` in a new `internal/radio/ltr/sink.go` (mirrors
`mpt1327.BitSink` / `edacs.BitSink`; 2-level protocols use
`BitSink`, the 4-level trunked protocols use `DibitSink`).

### Deferred to a follow-up

The receiver hands raw bits to the sink — Manchester decoding (if
the LTR variant uses bi-phase encoding) and 41-bit Status-word
framing both live in the future `ControlChannel.Process(bits,
baseIdx)` adapter that ships alongside the connector work.

## Test plan

- [x] `go test ./internal/radio/ltr/... -race`
- [x] `go build ./...`
- [x] `go vet ./internal/radio/ltr/...`

New tests cover:
- Constructor preconditions (sub-Nyquist threshold at 600 Hz for 300 baud)
- Silence smoke test
- **End-to-end round-trip**: synthesises an FM IQ signal whose
  discriminator output is a sub-audible NRZ waveform at 300 baud
  and confirms the receiver chain produces non-zero bit batches
- `baseIdx` monotonicity + `Reset` rewinds to 0
- Every emitted bit is in 0..1

## README

- LTR feature row now mentions the IQ → sub-audible bit receiver path
  + flags Manchester decode + framing as a follow-up.
- "Recently shipped" gains a bullet for the new receiver subpackage.


---
_Generated by [Claude Code](https://claude.ai/code/session_019dtCCVEZJTKKr6YK3wy824)_