### PR TITLE
internal/scanner/ccdecoder: IQ → control-channel decoder connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,19 +55,22 @@ the conventional FM scanner are constructed by `cmd/gophertrunk` and
 expose their state through `/api/v1/scanner` and the TUI cockpit
 panel. The honest remaining gaps:
 
-- **IQ → control-channel decoder daemon wiring.** Every protocol
-  package ships a unit-tested control-channel state machine and the
-  P25 Phase 1 IQ → C4FM dibit receiver
-  (`internal/radio/p25/phase1/receiver`) now exposes both an LDU
-  sink (voice path) and a raw-dibit sink (control-channel path —
-  feeds `phase1.ControlChannel.Process` directly), but the connector
-  that takes the control SDR's live IQ stream, picks the right
-  protocol's receiver, and feeds its control-channel pipeline isn't
-  constructed by `cmd/gophertrunk` yet. Until that lands the CC
-  Hunter supervisor exhausts every candidate frequency without
-  seeing a `cc.locked` event, so each system enters `state=failed`
-  and backs off — the TUI Scanner panel surfaces this honestly
-  rather than faking a lock.
+- **Daemon-side connector wiring.** The
+  `internal/scanner/ccdecoder` package ships the IQ → CC connector
+  (subscribes to `KindHuntProgress`, owns the control SDR's
+  `StreamIQ` loop, swaps the active per-protocol pipeline on every
+  supervisor retune, pumps IQ chunks through the active pipeline
+  whose CC state machine publishes `cc.locked` / `grant` events).
+  The P25 Phase 1 and YSF pipeline factories are wired end-to-end;
+  DMR / NXDN / dPMR / EDACS / MPT 1327 / LTR / Motorola / P25 P2
+  / TETRA each have IQ → symbol receivers shipping but their
+  ControlChannel state machines still consume pre-parsed PDUs, so
+  their pipeline factories land alongside the `Process(stream,
+  baseIdx)` adapters in follow-up PRs. What's still missing for
+  live trunked reception is `cmd/gophertrunk` constructing a
+  `ccdecoder.Decoder` next to the existing supervisor and spawning
+  it as a daemon goroutine — that wiring + an end-to-end
+  integration test is the final piece.
 - **Digital-voice level calibration.** Pure-Go IMBE / AMBE+2 emit
   real audio end-to-end with shared AGC, frame-repeat on bad-frame
   indicator, phase-aware fade-in, and §6.2 spectral enhancement
@@ -134,6 +137,17 @@ to its own package and lands independently.
 
 ### Recently shipped
 
+- **IQ → control-channel decoder connector** (`internal/scanner/ccdecoder`)
+  — subscribes to `events.KindHuntProgress`, owns one
+  `StreamIQ(ctx)` loop on the control SDR, swaps the active
+  per-protocol pipeline (IQ → symbol-domain decoder → CC state
+  machine) on every supervisor retune, and pumps IQ chunks through
+  the active pipeline whose CC state machine publishes
+  `cc.locked` / `grant` events back on the bus. Closes the
+  load-bearing gap from "Status & known gaps". P25 Phase 1 and YSF
+  pipelines wire end-to-end today; other protocols register their
+  factories once the per-protocol `ControlChannel.Process(stream,
+  baseIdx)` adapters ship.
 - **TETRA TMO IQ → π/4-DQPSK dibit receiver** (`internal/radio/tetra/receiver`)
   composing the `demod.PiOver4DQPSK` helper (RRC matched filter at
   α = 0.35, π/4-rotated differential decode) with naive symbol-
@@ -363,7 +377,7 @@ internal/sdr/rtlsdr/purego/   sdr.Driver+sdr.Device wire-up; canonical "rtlsdr" 
 internal/dsp/           Channelizer, filters, demods, sync, FFT
 internal/radio/         framing/ + p25/phase1/ (+ phase1/receiver IQ→dibit) + dmr/ + nxdn/ + ysf/
 internal/trunking/      System, talkgroup DB (Scan flag), engine (ScanMode, HandleSyntheticCall), priority, CC hunter primitive, cc cache
-internal/scanner/       cchunt/ (multi-system CC supervisor) + conventional/ (analog FM scan list)
+internal/scanner/       cchunt/ (multi-system CC supervisor) + conventional/ (analog FM scan list) + ccdecoder/ (IQ→CC connector)
 internal/voice/         Recorder, vocoder plugin, demod composer
 internal/storage/       SQLite call log + retention sweeper
 internal/api/           HTTP REST + SSE + WebSocket + gRPC

--- a/internal/scanner/ccdecoder/decoder.go
+++ b/internal/scanner/ccdecoder/decoder.go
@@ -1,0 +1,244 @@
+// Package ccdecoder is the connector that closes the IQ → control-
+// channel decoder gap listed in the README "Status & known gaps".
+//
+// What this package does:
+//
+//   - Owns the control SDR's IQ stream (one StreamIQ loop per
+//     Decoder lifetime).
+//   - Subscribes to events.KindHuntProgress so it learns which
+//     system / frequency the CC Hunter supervisor is currently
+//     attempting.
+//   - On every HuntProgress transition, swaps the active per-
+//     protocol pipeline (IQ → symbol-domain decoder → CC state
+//     machine) via the package-local factory map keyed on
+//     trunking.Protocol.
+//   - Pumps every IQ chunk arriving on the StreamIQ channel
+//     through the active pipeline's Process method. The pipeline's
+//     CC state machine publishes events.KindCCLocked /
+//     events.KindGrant on the same bus, which the supervisor +
+//     engine consume to drive the rest of the daemon.
+//
+// What this package does NOT do:
+//
+//   - It doesn't retune the SDR — that's the CC Hunter
+//     supervisor's job (`internal/scanner/cchunt`). The Decoder
+//     follows the supervisor's lead via HuntProgress events.
+//   - It doesn't open / close the SDR device — the daemon does
+//     that and hands a Tuner + IQSource through Options.
+//   - It doesn't decode every protocol from day one. Each
+//     pipeline is gated on having a control-channel state
+//     machine that accepts a raw dibit / bit stream. Protocols
+//     whose CC state machine still consumes pre-parsed PDUs
+//     (DMR / NXDN / dPMR / EDACS / MPT 1327 / LTR / Motorola /
+//     P25 P2 / TETRA) need a Process(...) adapter on their
+//     control package first — a documented follow-up per the
+//     per-protocol receiver PRs that already shipped.
+package ccdecoder
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// Tuner is the subset of sdr.Device the decoder uses for retuning.
+// Matches the same interface cchunt + conventional consume so the
+// daemon can hand the same Device to all three.
+type Tuner interface {
+	SetCenterFreq(hz uint32) error
+}
+
+// IQSource is the subset of sdr.Device the decoder consumes for IQ
+// samples. Matches conventional.IQSource so the same Device satisfies
+// both interfaces.
+type IQSource interface {
+	StreamIQ(ctx context.Context) (<-chan []complex64, error)
+}
+
+// Options configure a Decoder.
+type Options struct {
+	Bus     *events.Bus
+	Log     *slog.Logger
+	Tuner   Tuner    // currently unused but kept for API symmetry with cchunt
+	IQ      IQSource // control SDR providing the live IQ stream
+	Systems []trunking.System
+	// SampleRateHz is the IQ stream rate. Forwarded to the per-
+	// protocol receiver factories so they can size their matched
+	// filters correctly.
+	SampleRateHz float64
+}
+
+// Decoder is the long-lived component that converts the control
+// SDR's IQ stream into CC / grant events on the bus. Construct via
+// New, run via Run.
+type Decoder struct {
+	bus          *events.Bus
+	log          *slog.Logger
+	iq           IQSource
+	sampleRateHz float64
+	systems      map[string]trunking.System
+
+	mu       sync.Mutex
+	active   ProtocolPipeline
+	activeAt string // system name the active pipeline is bound to
+}
+
+// New constructs a Decoder. Returns an error when required Options
+// are missing.
+func New(opts Options) (*Decoder, error) {
+	if opts.Bus == nil {
+		return nil, errors.New("ccdecoder: events.Bus is required")
+	}
+	if opts.IQ == nil {
+		return nil, errors.New("ccdecoder: IQSource is required")
+	}
+	if opts.SampleRateHz <= 0 {
+		return nil, errors.New("ccdecoder: SampleRateHz must be > 0")
+	}
+	log := opts.Log
+	if log == nil {
+		log = slog.Default()
+	}
+	d := &Decoder{
+		bus:          opts.Bus,
+		log:          log,
+		iq:           opts.IQ,
+		sampleRateHz: opts.SampleRateHz,
+		systems:      make(map[string]trunking.System, len(opts.Systems)),
+	}
+	for _, s := range opts.Systems {
+		d.systems[s.Name] = s
+	}
+	return d, nil
+}
+
+// Run blocks until ctx cancels. It opens one StreamIQ loop on the
+// control SDR, subscribes to KindHuntProgress, swaps the active
+// per-protocol pipeline whenever the supervisor reports a new
+// (system, frequency) under attempt, and pumps every IQ chunk
+// through the active pipeline.
+//
+// Returns ctx.Err() on shutdown; any StreamIQ error from the SDR
+// surfaces as the return value.
+func (d *Decoder) Run(ctx context.Context) error {
+	stream, err := d.iq.StreamIQ(ctx)
+	if err != nil {
+		return err
+	}
+
+	sub := d.bus.Subscribe()
+	defer sub.Close()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case ev, ok := <-sub.C:
+			if !ok {
+				return nil
+			}
+			if ev.Kind != events.KindHuntProgress {
+				continue
+			}
+			p, ok := ev.Payload.(trunking.HuntProgress)
+			if !ok {
+				continue
+			}
+			d.handleProgress(p)
+		case iq, ok := <-stream:
+			if !ok {
+				return nil
+			}
+			d.pump(iq)
+		}
+	}
+}
+
+// handleProgress swaps the active pipeline to match the supervisor's
+// freshly-attempted system + frequency. Unknown systems / protocols
+// without a registered factory log + leave the active pipeline as-is
+// (so a stale pipeline doesn't decode noise into spurious events).
+func (d *Decoder) handleProgress(p trunking.HuntProgress) {
+	sys, ok := d.systems[p.System]
+	if !ok {
+		d.log.Debug("ccdecoder: HuntProgress for unknown system",
+			"system", p.System)
+		return
+	}
+	factory, ok := factories[sys.Protocol]
+	if !ok {
+		d.log.Debug("ccdecoder: no pipeline factory for protocol",
+			"system", p.System, "protocol", sys.Protocol)
+		d.clearActive()
+		return
+	}
+	d.mu.Lock()
+	// Close the previous pipeline before constructing a new one so
+	// resources don't accumulate on rapid retune storms.
+	if d.active != nil {
+		_ = d.active.Close()
+		d.active = nil
+		d.activeAt = ""
+	}
+	d.mu.Unlock()
+
+	p2, err := factory(PipelineOptions{
+		Bus:          d.bus,
+		Log:          d.log,
+		SystemName:   sys.Name,
+		FrequencyHz:  p.AttemptedFreqHz,
+		SampleRateHz: d.sampleRateHz,
+	})
+	if err != nil {
+		d.log.Warn("ccdecoder: pipeline factory failed",
+			"system", p.System, "protocol", sys.Protocol, "err", err)
+		return
+	}
+
+	d.mu.Lock()
+	d.active = p2
+	d.activeAt = sys.Name
+	d.mu.Unlock()
+}
+
+func (d *Decoder) clearActive() {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.active != nil {
+		_ = d.active.Close()
+		d.active = nil
+		d.activeAt = ""
+	}
+}
+
+// pump forwards an IQ chunk to the active pipeline. Holding the lock
+// for the whole Process call serialises against handleProgress's
+// pipeline swap so we never call Process on a half-constructed
+// pipeline.
+func (d *Decoder) pump(iq []complex64) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.active == nil {
+		return
+	}
+	d.active.Process(iq)
+}
+
+// Close releases the active pipeline. Safe to call from outside Run;
+// Run also runs Close on the active pipeline as part of normal swap
+// cleanup.
+func (d *Decoder) Close() error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.active != nil {
+		err := d.active.Close()
+		d.active = nil
+		d.activeAt = ""
+		return err
+	}
+	return nil
+}

--- a/internal/scanner/ccdecoder/decoder_test.go
+++ b/internal/scanner/ccdecoder/decoder_test.go
@@ -1,0 +1,287 @@
+package ccdecoder
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// fakeIQSource feeds a pre-supplied IQ stream onto the channel
+// StreamIQ returns. When `repeat` is true the source cycles
+// through `chunks` until ctx cancels, so the Run loop has IQ to
+// pump after a mid-test pipeline swap.
+type fakeIQSource struct {
+	chunks [][]complex64
+	repeat bool
+}
+
+func (f *fakeIQSource) StreamIQ(ctx context.Context) (<-chan []complex64, error) {
+	ch := make(chan []complex64)
+	go func() {
+		defer close(ch)
+		for {
+			for _, c := range f.chunks {
+				select {
+				case <-ctx.Done():
+					return
+				case ch <- c:
+				}
+			}
+			if !f.repeat {
+				<-ctx.Done()
+				return
+			}
+		}
+	}()
+	return ch, nil
+}
+
+type fakeTuner struct{}
+
+func (fakeTuner) SetCenterFreq(uint32) error { return nil }
+
+type erroringIQSource struct{ err error }
+
+func (e erroringIQSource) StreamIQ(ctx context.Context) (<-chan []complex64, error) {
+	return nil, e.err
+}
+
+// recordingPipeline implements ProtocolPipeline and records every
+// Process / Reset / Close call so tests can assert on the
+// connector's invocation pattern.
+type recordingPipeline struct {
+	processChunks [][]complex64
+	resets        int
+	closes        int
+}
+
+func (r *recordingPipeline) Process(iq []complex64) {
+	cp := make([]complex64, len(iq))
+	copy(cp, iq)
+	r.processChunks = append(r.processChunks, cp)
+}
+func (r *recordingPipeline) Reset()       { r.resets++ }
+func (r *recordingPipeline) Close() error { r.closes++; return nil }
+
+// withRecordingFactory swaps the package factory map for one that
+// builds *recordingPipelines, returns the built pipeline so the
+// test can inspect it, and restores the original map on cleanup.
+func withRecordingFactory(t *testing.T, proto trunking.Protocol) *recordingPipeline {
+	t.Helper()
+	saved := factories
+	rec := &recordingPipeline{}
+	factories = map[trunking.Protocol]PipelineFactory{
+		proto: func(PipelineOptions) (ProtocolPipeline, error) {
+			return rec, nil
+		},
+	}
+	t.Cleanup(func() { factories = saved })
+	return rec
+}
+
+func TestNewRequiresBus(t *testing.T) {
+	_, err := New(Options{IQ: &fakeIQSource{}, SampleRateHz: 48000})
+	if err == nil {
+		t.Fatalf("expected error for missing Bus")
+	}
+}
+
+func TestNewRequiresIQSource(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	_, err := New(Options{Bus: bus, SampleRateHz: 48000})
+	if err == nil {
+		t.Fatalf("expected error for missing IQ source")
+	}
+}
+
+func TestNewRequiresSampleRate(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	_, err := New(Options{Bus: bus, IQ: &fakeIQSource{}})
+	if err == nil {
+		t.Fatalf("expected error for missing SampleRateHz")
+	}
+}
+
+func TestRunPropagatesStreamIQError(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	wantErr := errors.New("usb gone")
+	d, err := New(Options{
+		Bus: bus, IQ: erroringIQSource{err: wantErr}, SampleRateHz: 48000,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if got := d.Run(context.Background()); !errors.Is(got, wantErr) {
+		t.Errorf("Run = %v, want %v", got, wantErr)
+	}
+}
+
+// TestRunSwapsPipelineOnHuntProgress: publish a HuntProgress event
+// before the StreamIQ stream is exhausted, then confirm the
+// recording pipeline's factory ran (so an IQ chunk flowing after
+// the event makes it through Process).
+func TestRunSwapsPipelineOnHuntProgress(t *testing.T) {
+	rec := withRecordingFactory(t, trunking.ProtocolP25)
+
+	bus := events.NewBus(16)
+	defer bus.Close()
+
+	iq := &fakeIQSource{
+		chunks: [][]complex64{make([]complex64, 64), make([]complex64, 64)},
+		repeat: true,
+	}
+	systems := []trunking.System{{
+		Name: "TestSys", Protocol: trunking.ProtocolP25,
+		ControlChannels: []uint32{851_012_500},
+	}}
+	d, err := New(Options{
+		Bus: bus, IQ: iq, Tuner: fakeTuner{},
+		Systems: systems, SampleRateHz: 48000,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Publish the HuntProgress before Run starts so the subscription
+	// catches it. Bus.Publish is fan-out; the events.NewBus buffer
+	// holds it until Run subscribes.
+	go func() {
+		// Wait long enough that Run subscribes and starts consuming.
+		time.Sleep(50 * time.Millisecond)
+		bus.Publish(events.Event{
+			Kind: events.KindHuntProgress,
+			Payload: trunking.HuntProgress{
+				System:          "TestSys",
+				AttemptedFreqHz: 851_012_500,
+				AttemptIndex:    1,
+				TotalCandidates: 1,
+				At:              time.Now(),
+			},
+		})
+		// Let the swap + a couple of pump iterations land.
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	_ = d.Run(ctx)
+
+	// At least one Process call should have hit the recording
+	// pipeline (the swap happened, then the next IQ chunk was
+	// pumped through it).
+	// Note: subscription delivery + StreamIQ pre-loaded buffer
+	// timing isn't strictly ordered, so we tolerate the swap
+	// happening after one chunk has already been dropped.
+	if len(rec.processChunks) == 0 && rec.closes == 0 {
+		t.Errorf("expected the recording pipeline to be either Process'd or Close'd, got neither")
+	}
+}
+
+// TestHandleProgressUnknownSystemIsIgnored: HuntProgress for a
+// system we don't know about must NOT construct a pipeline (no
+// recordingPipeline.Process calls), but must also not crash.
+func TestHandleProgressUnknownSystemIsIgnored(t *testing.T) {
+	rec := withRecordingFactory(t, trunking.ProtocolP25)
+
+	bus := events.NewBus(8)
+	defer bus.Close()
+	d, err := New(Options{
+		Bus: bus, IQ: &fakeIQSource{}, SampleRateHz: 48000,
+		Systems: []trunking.System{{
+			Name: "Known", Protocol: trunking.ProtocolP25,
+			ControlChannels: []uint32{851_012_500},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	d.handleProgress(trunking.HuntProgress{
+		System: "Unknown", AttemptedFreqHz: 851_012_500,
+	})
+	if len(rec.processChunks) != 0 {
+		t.Errorf("recording pipeline should not have been built for an unknown system")
+	}
+}
+
+// TestHandleProgressUnknownProtocolClearsActive: HuntProgress for
+// a known system whose protocol has no factory must clear any
+// active pipeline (otherwise stale state bleeds into new tunes).
+func TestHandleProgressUnknownProtocolClearsActive(t *testing.T) {
+	// Empty factory map for this test — every protocol is "unknown".
+	saved := factories
+	factories = map[trunking.Protocol]PipelineFactory{}
+	defer func() { factories = saved }()
+
+	bus := events.NewBus(8)
+	defer bus.Close()
+	d, err := New(Options{
+		Bus: bus, IQ: &fakeIQSource{}, SampleRateHz: 48000,
+		Systems: []trunking.System{{
+			Name: "Sys", Protocol: trunking.ProtocolDMR,
+			ControlChannels: []uint32{460_000_000},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	// Seed an active pipeline.
+	rec := &recordingPipeline{}
+	d.active = rec
+	d.activeAt = "Sys"
+
+	d.handleProgress(trunking.HuntProgress{
+		System: "Sys", AttemptedFreqHz: 460_000_000,
+	})
+	if d.active != nil {
+		t.Errorf("active pipeline should be cleared when protocol has no factory")
+	}
+	if rec.closes != 1 {
+		t.Errorf("recording pipeline Close calls = %d, want 1", rec.closes)
+	}
+}
+
+// TestP25Phase1FactoryConstructs: smoke test that the wired
+// P25 P1 factory builds without error and returns a pipeline whose
+// Process / Reset / Close run cleanly on a small IQ chunk.
+func TestP25Phase1FactoryConstructs(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	p, err := newP25Phase1Pipeline(PipelineOptions{
+		Bus: bus, SystemName: "Smoke",
+		FrequencyHz: 851_012_500, SampleRateHz: 48_000,
+	})
+	if err != nil {
+		t.Fatalf("newP25Phase1Pipeline: %v", err)
+	}
+	p.Process(make([]complex64, 4800))
+	p.Reset()
+	if err := p.Close(); err != nil {
+		t.Errorf("Close: %v", err)
+	}
+}
+
+func TestYSFFactoryConstructs(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	p, err := newYSFPipeline(PipelineOptions{
+		Bus: bus, SystemName: "Smoke",
+		FrequencyHz: 446_000_000, SampleRateHz: 48_000,
+	})
+	if err != nil {
+		t.Fatalf("newYSFPipeline: %v", err)
+	}
+	p.Process(make([]complex64, 4800))
+	p.Reset()
+	if err := p.Close(); err != nil {
+		t.Errorf("Close: %v", err)
+	}
+}

--- a/internal/scanner/ccdecoder/pipelines.go
+++ b/internal/scanner/ccdecoder/pipelines.go
@@ -1,0 +1,125 @@
+package ccdecoder
+
+import (
+	"log/slog"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	p25phase1 "github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase1"
+	p25phase1rx "github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase1/receiver"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/ysf"
+	ysfrx "github.com/MattCheramie/GopherTrunk/internal/radio/ysf/receiver"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// ProtocolPipeline is the contract every per-protocol receiver
+// pipeline satisfies. Process consumes one chunk of complex IQ;
+// Reset clears symbol-domain state on stream re-sync; Close
+// releases any held resources (it's idempotent and may return nil).
+type ProtocolPipeline interface {
+	Process(iq []complex64)
+	Reset()
+	Close() error
+}
+
+// PipelineOptions is the per-pipeline construction shape — the
+// connector hands the bus + log down, plus the (system, frequency)
+// the supervisor is currently attempting and the IQ sample rate
+// the receiver needs to size its matched filter.
+type PipelineOptions struct {
+	Bus          *events.Bus
+	Log          *slog.Logger
+	SystemName   string
+	FrequencyHz  uint32
+	SampleRateHz float64
+}
+
+// PipelineFactory constructs a fresh ProtocolPipeline for one tuned
+// system. The factory returns an error when the protocol's
+// per-receiver / per-state-machine wiring isn't complete enough to
+// drive a live CC pipeline end-to-end yet — the connector skips the
+// retune in that case and the system stays in `state=hunting`.
+type PipelineFactory func(PipelineOptions) (ProtocolPipeline, error)
+
+// factories maps a trunking.Protocol to its pipeline factory. Only
+// protocols whose ControlChannel state machine already accepts a
+// raw dibit / bit stream are wired here. Others land in follow-up
+// PRs as the per-protocol Process(...) adapters ship.
+//
+// The Protocol enum currently lumps P25 Phase 1 and Phase 2
+// together; this factory targets Phase 1 (the more common
+// deployment + the protocol with a complete IQ → dibits → CC →
+// bus chain shipping today). A future PR splits Phase 1 / Phase 2
+// once the daemon's config grows a per-system phase selector.
+//
+// DMR / NXDN / dPMR / EDACS / MPT 1327 / LTR / Motorola Type II /
+// TETRA all have IQ → symbol receivers shipping but their
+// ControlChannel state machines still consume pre-parsed PDUs.
+// Adding `Process(stream, baseIdx)` adapters that buffer +
+// detect sync + frame + dispatch into the existing parsers is a
+// follow-up.
+var factories = map[trunking.Protocol]PipelineFactory{
+	trunking.ProtocolP25: newP25Phase1Pipeline,
+}
+
+// newP25Phase1Pipeline wires the existing
+// internal/radio/p25/phase1/receiver into
+// phase1.ControlChannel.Process. The receiver's DibitSink
+// forwards dibits + baseIdx straight into the state machine,
+// which publishes events.KindCCLocked + events.KindGrant on the
+// bus when the supervisor's tuned frequency carries valid P25
+// traffic.
+func newP25Phase1Pipeline(opts PipelineOptions) (ProtocolPipeline, error) {
+	cc := p25phase1.New(p25phase1.Options{
+		Bus:         opts.Bus,
+		Log:         opts.Log,
+		SystemName:  opts.SystemName,
+		FrequencyHz: opts.FrequencyHz,
+	})
+	rx := p25phase1rx.New(p25phase1rx.Options{
+		SampleRateHz: opts.SampleRateHz,
+		DibitSink: func(dibits []uint8, baseIdx int) {
+			cc.Process(dibits, baseIdx)
+		},
+	})
+	return &p25Phase1Pipeline{rx: rx, cc: cc}, nil
+}
+
+type p25Phase1Pipeline struct {
+	rx *p25phase1rx.Receiver
+	cc *p25phase1.ControlChannel
+}
+
+func (p *p25Phase1Pipeline) Process(iq []complex64) { p.rx.Process(iq) }
+func (p *p25Phase1Pipeline) Reset()                  { p.rx.Reset() }
+func (p *p25Phase1Pipeline) Close() error            { return nil }
+
+// newYSFPipeline wires the existing internal/radio/ysf/receiver
+// into ysf.ControlChannel.Process. YSF lacks a published
+// trunking.Protocol enum value today (the config layer expects
+// "p25" / "dmr" / "nxdn"); the factory is exposed for direct use
+// by the daemon + tests rather than via the factory map. Once the
+// Protocol enum gains a YSF entry the factory map gains a row.
+func newYSFPipeline(opts PipelineOptions) (ProtocolPipeline, error) {
+	cc := ysf.New(ysf.Options{
+		Bus:         opts.Bus,
+		Log:         opts.Log,
+		SystemName:  opts.SystemName,
+		FrequencyHz: opts.FrequencyHz,
+	})
+	rx := ysfrx.New(ysfrx.Options{
+		SampleRateHz: opts.SampleRateHz,
+		DibitSink: func(dibits []uint8, baseIdx int) {
+			cc.Process(dibits, baseIdx)
+		},
+	})
+	return &ysfPipeline{rx: rx, cc: cc}, nil
+}
+
+type ysfPipeline struct {
+	rx *ysfrx.Receiver
+	cc *ysf.ControlChannel
+}
+
+func (p *ysfPipeline) Process(iq []complex64) { p.rx.Process(iq) }
+func (p *ysfPipeline) Reset()                  { p.rx.Reset() }
+func (p *ysfPipeline) Close() error            { return nil }


### PR DESCRIPTION
## Summary

PR #16 of the roadmap — the load-bearing connector that closes
the IQ → control-channel gap.

`internal/scanner/ccdecoder.Decoder`:
- Owns one `StreamIQ(ctx)` loop on the control SDR.
- Subscribes to `events.KindHuntProgress` so it learns which
  system / frequency the CC Hunter supervisor is currently
  attempting.
- On every `HuntProgress` transition, **swaps the active per-
  protocol pipeline** (IQ → symbol-domain decoder → CC state
  machine) via a factory map keyed on `trunking.Protocol`.
- Pumps every IQ chunk arriving on the `StreamIQ` channel
  through the active pipeline. The pipeline's CC state machine
  publishes `events.KindCCLocked` + `events.KindGrant` on the
  same bus, which the supervisor + engine consume.

`ProtocolPipeline` is the contract every per-protocol pipeline
satisfies: `Process(iq)` / `Reset()` / `Close()`.

### Wired pipelines today

- **P25 Phase 1** (registered in the factory map under
  `trunking.ProtocolP25`) — receiver + ControlChannel.Process
  end-to-end.
- **YSF** (exposed as a direct factory `newYSFPipeline` pending
  a YSF entry in `trunking.Protocol`) — same shape.

### Deferred to follow-ups

DMR / NXDN / dPMR / EDACS / MPT 1327 / LTR / Motorola / P25 P2 /
TETRA all have IQ → symbol receivers shipping but their
ControlChannel state machines still consume pre-parsed PDUs.
Adding the `Process(stream, baseIdx)` adapters that buffer +
detect sync + frame + dispatch is the documented per-protocol
follow-up flagged in each receiver PR; the factories register
themselves once those adapters land.

`cmd/gophertrunk` doesn't yet construct a `ccdecoder.Decoder`
next to the existing supervisor — that integration + an
end-to-end test ship in the next (final) PR.

## Test plan

- [x] `go test ./internal/scanner/ccdecoder/... -race`
- [x] `go build ./...`
- [x] `go vet ./internal/scanner/...`

New tests cover:
- `Options` validation: missing `Bus` / `IQ` / `SampleRateHz` all error.
- `Run` propagates `StreamIQ` errors from the SDR.
- **Pipeline swap on `KindHuntProgress`**: integration test with a
  repeating fake IQ source, asserts the recording pipeline is
  invoked after the supervisor's published HuntProgress event.
- Unknown-system `HuntProgress` is silently ignored (no spurious
  pipeline build).
- Unknown-protocol `HuntProgress` clears the active pipeline
  (so stale state doesn't bleed into new tunes).
- Smoke construction of both wired pipeline factories
  (P25 Phase 1 + YSF) processing a small IQ buffer without
  crashing.

## README

- "Status & known gaps" updated: the connector ships, the
  remaining work is daemon-side wiring + end-to-end integration test.
- "Recently shipped" gains a bullet for the connector.
- Repository layout listing now includes `ccdecoder/`.


---
_Generated by [Claude Code](https://claude.ai/code/session_019dtCCVEZJTKKr6YK3wy824)_