### PR TITLE
cmd/gophertrunk: wire ccdecoder.Decoder into the daemon + integration test

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,22 +55,27 @@ the conventional FM scanner are constructed by `cmd/gophertrunk` and
 expose their state through `/api/v1/scanner` and the TUI cockpit
 panel. The honest remaining gaps:
 
-- **Daemon-side connector wiring.** The
-  `internal/scanner/ccdecoder` package ships the IQ → CC connector
-  (subscribes to `KindHuntProgress`, owns the control SDR's
-  `StreamIQ` loop, swaps the active per-protocol pipeline on every
-  supervisor retune, pumps IQ chunks through the active pipeline
-  whose CC state machine publishes `cc.locked` / `grant` events).
-  The P25 Phase 1 and YSF pipeline factories are wired end-to-end;
-  DMR / NXDN / dPMR / EDACS / MPT 1327 / LTR / Motorola / P25 P2
-  / TETRA each have IQ → symbol receivers shipping but their
-  ControlChannel state machines still consume pre-parsed PDUs, so
-  their pipeline factories land alongside the `Process(stream,
-  baseIdx)` adapters in follow-up PRs. What's still missing for
-  live trunked reception is `cmd/gophertrunk` constructing a
-  `ccdecoder.Decoder` next to the existing supervisor and spawning
-  it as a daemon goroutine — that wiring + an end-to-end
-  integration test is the final piece.
+- **Per-protocol `ControlChannel.Process(stream, baseIdx)` adapters
+  for everything beyond P25 Phase 1 and YSF.** The
+  `internal/scanner/ccdecoder` package is wired into
+  `cmd/gophertrunk/daemon.go` — when a control SDR + trunked system
+  are configured, the daemon constructs a `ccdecoder.Decoder`
+  alongside the CC Hunter supervisor and spawns it as a goroutine
+  that owns the control SDR's `StreamIQ` loop. The connector
+  subscribes to `KindHuntProgress`, swaps the active per-protocol
+  pipeline on every supervisor retune, and pumps IQ chunks through
+  the active pipeline whose CC state machine publishes `cc.locked`
+  / `grant` events back on the bus — the trigger that lights up
+  every downstream surface (engine, recorder, call log, API, TUI).
+  Live trunked reception works today for P25 Phase 1 and YSF
+  (both have IQ → symbol → CC state machine chains shipping
+  end-to-end). DMR / NXDN / dPMR / EDACS / MPT 1327 / LTR /
+  Motorola / P25 P2 / TETRA each have IQ → symbol receivers
+  shipping but their CC state machines still consume pre-parsed
+  PDUs; adding the `Process(stream, baseIdx)` adapter on each
+  (sync detect → frame slice → existing parser → Ingest) lights
+  up the rest. The adapter shape is ~30 lines per protocol and
+  documented per-receiver in the relevant PR descriptions.
 - **Digital-voice level calibration.** Pure-Go IMBE / AMBE+2 emit
   real audio end-to-end with shared AGC, frame-repeat on bad-frame
   indicator, phase-aware fade-in, and §6.2 spectral enhancement
@@ -137,6 +142,19 @@ to its own package and lands independently.
 
 ### Recently shipped
 
+- **Daemon wiring for the IQ → CC decoder connector**
+  (`cmd/gophertrunk/daemon.go`). When the daemon's pool has a
+  control-role SDR + at least one trunked system configured, it
+  constructs a `ccdecoder.Decoder` next to the existing
+  `cchunt.Supervisor` and spawns it as a daemon goroutine. The
+  connector owns the control SDR's `StreamIQ` loop, swaps the
+  active per-protocol pipeline on every `KindHuntProgress` retune,
+  and pumps IQ chunks through the active pipeline whose CC state
+  machine publishes `cc.locked` / `grant` events back on the bus
+  — the trigger that lights up every downstream surface (engine,
+  recorder, call log, API, TUI). `make integration` now boots the
+  full chain with a mock SDR and asserts the connector is
+  constructed + runs without crashing.
 - **IQ → control-channel decoder connector** (`internal/scanner/ccdecoder`)
   — subscribes to `events.KindHuntProgress`, owns one
   `StreamIQ(ctx)` loop on the control SDR, swaps the active

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -14,6 +14,7 @@ import (
 	"github.com/MattCheramie/GopherTrunk/internal/config"
 	"github.com/MattCheramie/GopherTrunk/internal/events"
 	"github.com/MattCheramie/GopherTrunk/internal/metrics"
+	"github.com/MattCheramie/GopherTrunk/internal/scanner/ccdecoder"
 	"github.com/MattCheramie/GopherTrunk/internal/scanner/cchunt"
 	"github.com/MattCheramie/GopherTrunk/internal/scanner/conventional"
 	"github.com/MattCheramie/GopherTrunk/internal/sdr"
@@ -81,6 +82,7 @@ type Daemon struct {
 	retention  *storage.Retention
 	ccCache    *trunking.Cache
 	cchuntSup  *cchunt.Supervisor
+	ccDecoder  *ccdecoder.Decoder
 	convScan   *conventional.Scanner
 	metrics    *metrics.Metrics
 	httpAPI    *api.Server
@@ -255,12 +257,12 @@ func NewDaemon(cfg config.Config, version string, log *slog.Logger) (*Daemon, er
 
 	// CC hunter supervisor — opt-in via scanner.cc_hunt.enabled OR
 	// by default when at least one trunked system is configured.
-	// Honest scope flag: this orchestrates retunes + telemetry but
-	// nothing in the daemon currently publishes cc.locked, so until
-	// the IQ-domain protocol decoders land the supervisor will
-	// report "failed" + back off. Operators see that in the TUI
-	// Scanner panel, which is the correct behavior — silently
-	// pretending decode works would be worse.
+	// Constructs an IQ → CC decoder connector alongside (below) so
+	// the supervisor's retunes drive a live demod pipeline. P25
+	// Phase 1 and YSF have wired pipelines today; other protocols
+	// stay in `state=hunting` until their per-protocol
+	// ControlChannel.Process(stream, baseIdx) adapters ship — see
+	// internal/scanner/ccdecoder/pipelines.go for the factory map.
 	if d.pool != nil && len(d.systems) > 0 {
 		cchEnabled := cfg.Scanner.CCHunt.Enabled || cfg.Scanner.CCHunt == (config.CCHuntConfig{})
 		if cchEnabled {
@@ -280,6 +282,32 @@ func NewDaemon(cfg config.Config, version string, log *slog.Logger) (*Daemon, er
 					return nil, fmt.Errorf("daemon: cchunt: %w", err)
 				}
 				d.cchuntSup = sup
+
+				// IQ → CC decoder connector. Owns one StreamIQ
+				// loop on the control SDR, subscribes to
+				// KindHuntProgress so it learns which system /
+				// frequency the supervisor is currently attempting,
+				// and pumps IQ through the matching per-protocol
+				// pipeline so the CC state machine publishes
+				// cc.locked / grant events on the bus. Only P25
+				// Phase 1 and YSF have wired pipelines today —
+				// other protocols log a "no factory" debug message
+				// when their HuntProgress lands and the supervisor
+				// stays in `state=hunting`. See README for the
+				// per-protocol Process(stream, baseIdx) adapter
+				// follow-ups.
+				dec, err := ccdecoder.New(ccdecoder.Options{
+					Bus:          d.bus,
+					Log:          log,
+					Tuner:        controlEntry.Device,
+					IQ:           controlEntry.Device,
+					Systems:      d.systems,
+					SampleRateHz: float64(cfg.SDR.SampleRate),
+				})
+				if err != nil {
+					return nil, fmt.Errorf("daemon: ccdecoder: %w", err)
+				}
+				d.ccDecoder = dec
 			} else {
 				log.Warn("daemon: scanner.cc_hunt enabled but no control SDR in pool; skipping")
 			}
@@ -475,6 +503,11 @@ func (d *Daemon) Run(ctx context.Context) error {
 			return d.cchuntSup.Run(ctx)
 		})
 	}
+	if d.ccDecoder != nil {
+		d.spawn(ctx, "ccdecoder", func(ctx context.Context) error {
+			return d.ccDecoder.Run(ctx)
+		})
+	}
 	if d.convScan != nil {
 		d.spawn(ctx, "conv-scanner", func(ctx context.Context) error {
 			return d.convScan.Run(ctx)
@@ -508,6 +541,9 @@ func (d *Daemon) Close() {
 		}
 		if d.grpcAPI != nil {
 			d.grpcAPI.Stop()
+		}
+		if d.ccDecoder != nil {
+			_ = d.ccDecoder.Close()
 		}
 		if d.composer != nil {
 			_ = d.composer.Close()

--- a/cmd/gophertrunk/integration_test.go
+++ b/cmd/gophertrunk/integration_test.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -17,6 +18,7 @@ import (
 
 	"github.com/MattCheramie/GopherTrunk/internal/config"
 	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/sdr"
 	"github.com/MattCheramie/GopherTrunk/internal/trunking"
 )
 
@@ -228,3 +230,84 @@ func TestDaemonStartsWithMinimalConfig(t *testing.T) {
 // fmt.Stringer (smoke check that the helper symbols exist in this
 // build tag).
 var _ = fmt.Stringer(nil)
+
+// TestDaemonWiresCCDecoder boots the daemon with a mock SDR + one
+// trunked system and asserts the new IQ → CC decoder connector is
+// constructed alongside the CC Hunter supervisor. The connector
+// runs as a daemon goroutine that owns the control SDR's StreamIQ
+// loop and pumps IQ through the active per-protocol pipeline
+// whenever the supervisor reports a HuntProgress event; this test
+// validates the wiring only, not the symbol-domain decode path
+// (that's covered by the per-protocol receiver and ccdecoder unit
+// tests).
+//
+// A small empty mock IQ file backs a sdr.MockDriver registered in
+// the test's setup; the daemon's pool picks the device up by
+// serial and assigns it RoleControl, which is the trigger for
+// constructing the connector.
+func TestDaemonWiresCCDecoder(t *testing.T) {
+	dir := t.TempDir()
+	iqPath := filepath.Join(dir, "ctrl.cfile")
+	if err := os.WriteFile(iqPath, make([]byte, 4096), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	sdr.Register(&sdr.MockDriver{Files: []string{iqPath}})
+
+	cfg := config.Default()
+	cfg.SDR.Devices = []config.DeviceConfig{
+		{Serial: "mock-00", Role: "control"},
+	}
+	cfg.Trunking.Systems = []config.SystemConfig{
+		{Name: "Alpha", Protocol: "p25", ControlChannels: []uint32{851_000_000}},
+	}
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	d, err := NewDaemon(cfg, "ccdecoder-wire", logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d.ccDecoder == nil {
+		t.Fatalf("ccDecoder is nil; daemon should have constructed one when a control SDR + trunked system are present")
+	}
+	if d.cchuntSup == nil {
+		t.Fatalf("cchuntSup is nil; daemon should have constructed the supervisor alongside the connector")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	runErrCh := make(chan error, 1)
+	go func() { runErrCh <- d.Run(ctx) }()
+
+	// Publish a HuntProgress event to confirm the connector
+	// subscription is alive — the connector will look up the
+	// matching system + protocol factory and either construct a
+	// pipeline (P25 → wires; we don't synthesize valid P25 IQ
+	// here so the pipeline just runs silently) or log a "no
+	// factory" debug message. Either way the daemon must not
+	// crash and shutdown must remain clean.
+	d.Bus().Publish(events.Event{
+		Kind: events.KindHuntProgress,
+		Payload: trunking.HuntProgress{
+			System:          "Alpha",
+			AttemptedFreqHz: 851_000_000,
+			AttemptIndex:    1,
+			TotalCandidates: 1,
+			At:              time.Now(),
+		},
+	})
+
+	// Let the daemon spin for a bit so the goroutine pumps a
+	// few IQ chunks from the mock file (the mock returns EOF
+	// quickly with our 4 KiB seed; that's fine — the test only
+	// asserts the wiring is in place + nothing crashes).
+	time.Sleep(200 * time.Millisecond)
+
+	cancel()
+	select {
+	case err := <-runErrCh:
+		if err != nil && err != context.Canceled {
+			t.Errorf("Run returned unexpected error: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Errorf("daemon did not exit within 3s after cancel")
+	}
+}


### PR DESCRIPTION
## Summary

**Final PR of the roadmap.** Wires the
`internal/scanner/ccdecoder.Decoder` into `cmd/gophertrunk/daemon.go`
and adds the integration test that asserts the wiring is in place.

When the daemon's pool has a control-role SDR + at least one
trunked system configured, `NewDaemon` now constructs a
`ccdecoder.Decoder` next to the existing `cchunt.Supervisor` and
spawns it as a daemon goroutine. The connector owns the control
SDR's `StreamIQ` loop, subscribes to `events.KindHuntProgress`,
swaps the active per-protocol pipeline on every retune, and pumps
IQ chunks through the active pipeline whose CC state machine
publishes `events.KindCCLocked` + `events.KindGrant` on the bus.

Live trunked reception flows end-to-end today for the protocols
whose CC state machine accepts a raw dibit / bit stream:

- **P25 Phase 1** — IQ → C4FM dibit receiver →
  `phase1.ControlChannel.Process`
- **YSF** — IQ → C4FM dibit receiver →
  `ysf.ControlChannel.Process`

### Remaining gap

DMR / NXDN / dPMR / EDACS / MPT 1327 / LTR / Motorola / P25 P2 /
TETRA each have IQ → symbol receivers shipping but their
ControlChannel state machines still consume pre-parsed PDUs.
Adding a `Process(stream, baseIdx)` adapter on each (~30 lines:
cross-call buffer + sync detect + frame slice + existing parser
+ Ingest) lights up the rest. The factories in
`internal/scanner/ccdecoder/pipelines.go` register themselves as
those land. Each receiver PR already documents this follow-up.

## Daemon plumbing

- New `ccDecoder *ccdecoder.Decoder` field on the `Daemon` struct.
- `NewDaemon` constructs it inside the same control-SDR /
  trunked-system guard the supervisor uses.
- `Run` spawns a `"ccdecoder"` goroutine after `"cchunt"`.
- `Close` releases the connector before the composer + recorder.
- The supervisor's old "nothing publishes cc.locked" comment is
  rewritten to describe the new wiring.

## Test plan

- [x] `go test -tags integration -race -count=1 ./cmd/gophertrunk/...`
- [x] `go test -race -count=1 ./...` — all 61 packages pass
- [x] `go build ./...`
- [x] `go vet ./cmd/...`

New integration test:
- **`TestDaemonWiresCCDecoder`** — registers an `sdr.MockDriver`
  pointing at a tiny test IQ file, configures the daemon with
  that mock device claimed as control + one P25 system,
  constructs the daemon, asserts both `d.cchuntSup` and
  `d.ccDecoder` are non-nil (wiring landed), runs the daemon for
  200 ms, publishes a `HuntProgress` event to confirm the
  subscription is alive, and asserts a clean shutdown within 3 s
  of cancel.

## README

- "Status & known gaps" rewritten — the daemon-wiring gap is
  gone; the remaining gap is per-protocol `Process` adapters for
  the 9 protocols beyond P25 P1 + YSF.
- "Recently shipped" gains a bullet for the daemon wiring.


---
_Generated by [Claude Code](https://claude.ai/code/session_019dtCCVEZJTKKr6YK3wy824)_