### PR TITLE
internal/radio/nxdn: ControlChannel.Process adapter + ccdecoder factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,16 +67,17 @@ panel. The honest remaining gaps:
   the active pipeline whose CC state machine publishes `cc.locked`
   / `grant` events back on the bus — the trigger that lights up
   every downstream surface (engine, recorder, call log, API, TUI).
-  Live trunked reception works today for P25 Phase 1, YSF, and
-  dPMR Mode 3 (all three have IQ → symbol → CC state machine
-  chains shipping end-to-end). DMR / NXDN / EDACS / MPT 1327 /
-  LTR / Motorola / P25 P2 / TETRA each have IQ → symbol
-  receivers shipping but their CC state machines still consume
-  pre-parsed PDUs; adding the `Process(stream, baseIdx)` adapter
-  on each (sync detect → frame slice → existing parser → Ingest)
-  lights up the rest. The adapter shape is ~30–50 lines per
-  protocol and documented per-receiver in the relevant PR
-  descriptions.
+  Live trunked reception works today for P25 Phase 1, YSF, dPMR
+  Mode 3, and NXDN (FSW sync + LICH parse only — full CAC FEC
+  decoding is the next NXDN follow-up; until then the adapter
+  sync-locks but typically fails the CAC CRC on real on-air
+  signals). DMR / EDACS / MPT 1327 / LTR / Motorola / P25 P2 /
+  TETRA each have IQ → symbol receivers shipping but their CC
+  state machines still consume pre-parsed PDUs; adding the
+  `Process(stream, baseIdx)` adapter on each (sync detect → frame
+  slice → existing parser → Ingest) lights up the rest. The
+  adapter shape is ~30–50 lines per protocol and documented
+  per-receiver in the relevant PR descriptions.
 - **Digital-voice level calibration.** Pure-Go IMBE / AMBE+2 emit
   real audio end-to-end with shared AGC, frame-repeat on bad-frame
   indicator, phase-aware fade-in, and §6.2 spectral enhancement
@@ -143,6 +144,21 @@ to its own package and lands independently.
 
 ### Recently shipped
 
+- **NXDN `ControlChannel.Process(stream, baseIdx)` adapter +
+  ccdecoder factory.** Closes the IQ → CC sync layer for NXDN:
+  the receiver's `DibitSink` forwards into
+  `nxdn.ControlChannel.Process`, which buffers across calls +
+  detects the 8-dibit outbound FSW + parses the LICH from the
+  next 16 wire bits (doubled-bit majority decode via
+  `DecodeLICHWire` → `ParseLICH`) + pulls the first 44 dibits of
+  the 144-dibit Info field as raw CAC bits → `ParseCAC` →
+  `IngestFrame`. The CAC FEC layer (K=5 ½-rate Viterbi +
+  interleaver + puncture across the full 288-wire-bit Info field)
+  is the next NXDN follow-up; until it ships the adapter
+  sync-locks but typically fails the CAC CRC on real on-air
+  signals. Inbound (MS → BS) FSW matches are silently ignored
+  since they don't carry the CC announcement payloads the state
+  machine locks on.
 - **dPMR Mode 3 `ControlChannel.Process(stream, baseIdx)` adapter +
   ccdecoder factory.** Closes the IQ → CC loop for dPMR: the
   receiver's `DibitSink` forwards into `dpmr.ControlChannel.Process`,

--- a/internal/radio/nxdn/control.go
+++ b/internal/radio/nxdn/control.go
@@ -30,6 +30,11 @@ type ControlChannel struct {
 	rate   BaudRate
 	locked bool
 	last   LockState
+
+	// proc is the cross-call dibit / sync state the Process
+	// adapter uses (see process.go). Lazily constructed on the
+	// first Process call.
+	proc *processState
 }
 
 func NewControlChannel(bus *events.Bus, log *slog.Logger, freqHz uint32, rate BaudRate) *ControlChannel {

--- a/internal/radio/nxdn/process.go
+++ b/internal/radio/nxdn/process.go
@@ -1,0 +1,137 @@
+package nxdn
+
+import (
+	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+)
+
+// processState is the cross-call dibit buffering + sync-detection
+// state the Process adapter holds. Lazily initialised on the first
+// Process call so the existing IngestFrame path stays callable
+// from tests that hand in pre-parsed LICH + CAC structures.
+type processState struct {
+	det *SyncDetector
+	// remaining > 0: collecting frame dibits after the FSW match;
+	// counts down to 0 as Process feeds dibits forward.
+	remaining int
+	// frame accumulates the post-FSW frame dibits the adapter
+	// slices into LICH wire bits + (skipped) SACCH + CAC info bits.
+	frame []uint8
+	// matchScratch is reused across calls so SyncDetector.Process
+	// doesn't allocate fresh slices.
+	matchScratch []Match
+}
+
+// postSyncDibits is the count of dibits the adapter collects after
+// the 8-dibit FSW match: 8 LICH wire + 32 SACCH (skipped) + 44 CAC
+// info dibits = 84 dibits. The remaining 100 dibits of the 144-dibit
+// Info field carry the CAC FEC redundancy that a future package PR
+// decodes; this adapter only uses the first 44 dibits, which is
+// sufficient to drive cc.locked in test fixtures where the CAC
+// information bits are placed directly in the wire (no FEC encoding).
+// For real on-air NXDN traffic the CAC FEC layer is the next
+// follow-up; until that lands this adapter will sync on the FSW
+// but typically fail the CAC CRC and stay silent on production
+// signals.
+const postSyncDibits = 84
+
+// Process consumes a window of raw dibits from the NXDN receiver
+// (the IQ → C4FM dibit chain in internal/radio/nxdn/receiver/),
+// runs the outbound-FSW detector, parses the LICH from the next 8
+// wire dibits, and tries ParseCAC on the next 44 dibits' worth of
+// information bits before handing the (lich, cac) pair to
+// IngestFrame.
+//
+// baseIdx is the absolute dibit index of dibits[0] across the
+// stream lifetime. The adapter's internal countdown survives
+// across Process calls so a sync match in one chunk and the
+// payload in the next still decode cleanly.
+//
+// Returns baseIdx + len(dibits) to match the YSF / P25 Phase 1 /
+// dPMR ControlChannel.Process contracts.
+func (c *ControlChannel) Process(dibits []uint8, baseIdx int) int {
+	if c.proc == nil {
+		c.proc = &processState{
+			det:   NewSyncDetector([][]uint8{FSWDibitsOutbound}, 1),
+			frame: make([]uint8, 0, postSyncDibits),
+		}
+	}
+	p := c.proc
+
+	p.matchScratch, _ = p.det.Process(p.matchScratch[:0], dibits, baseIdx)
+	matchIdx := 0
+
+	for i, d := range dibits {
+		absPos := baseIdx + i
+		// Collect first (this dibit completes the post-sync window
+		// if remaining counts down to 0). Doing this BEFORE the
+		// sync-match check is important: the sync match's absolute
+		// index is the LAST dibit of the 8-dibit FSW, so the next
+		// frame data starts at the NEXT iteration.
+		if p.remaining > 0 {
+			p.frame = append(p.frame, d)
+			p.remaining--
+			if p.remaining == 0 {
+				c.tryIngestFrame(p.frame)
+				p.frame = p.frame[:0]
+			}
+		}
+		// Check if a sync ended at this position. If yes, start
+		// collecting post-sync dibits from the NEXT iteration.
+		// Only honour outbound matches — inbound (MS → BS) bursts
+		// don't carry the CC announcement payloads the state
+		// machine locks on.
+		for matchIdx < len(p.matchScratch) && p.matchScratch[matchIdx].Index == absPos {
+			if !p.matchScratch[matchIdx].Inbound {
+				p.remaining = postSyncDibits
+				p.frame = p.frame[:0]
+			}
+			matchIdx++
+		}
+	}
+	return baseIdx + len(dibits)
+}
+
+// tryIngestFrame slices the collected post-sync dibits into LICH +
+// CAC bits, parses each, and forwards the result to IngestFrame.
+// Drops the frame silently on any parse / CRC error — the next
+// FSW match anchors the stream again.
+func (c *ControlChannel) tryIngestFrame(frame []uint8) {
+	if len(frame) != postSyncDibits {
+		return
+	}
+	// LICH: 8 wire dibits → 16 wire bits → DecodeLICHWire → info
+	// byte → ParseLICH.
+	lichBits := framing.DibitsToBits(frame[0:8])
+	lichByte, _ := DecodeLICHWire(lichBits)
+	lich := ParseLICH(lichByte)
+
+	// CAC: 44 dibits → 88 information bits → 11 bytes → ParseCAC.
+	// Frame offsets: 8..40 is the 32-dibit SACCH (skipped here;
+	// SACCH carries channel signalling decoded via the K=5
+	// Viterbi chain in sacch.go but isn't required for the
+	// cc.locked path). Offsets 40..84 are the first 44 dibits
+	// of the 144-dibit Info field.
+	cacBits := framing.DibitsToBits(frame[40:84])
+	cacBytes := framing.PackBitsMSB(cacBits)
+	if len(cacBytes) < 11 {
+		return
+	}
+	cac, _ := ParseCAC(cacBytes[:11])
+	// CRC mismatch is non-fatal — IngestFrame will simply not
+	// publish cc.locked unless the message type is one it
+	// recognises (RCCHSITEINFO / RCCHCCH). For real-air signals
+	// the CAC FEC layer (a documented follow-up) is required to
+	// pull valid info bits out of the 288-wire-bit Info field.
+	c.IngestFrame(lich, &cac)
+}
+
+// Reset clears the Process adapter's sync-detection + partial-frame
+// state. The receiver-side Reset rewinds the absolute dibit index;
+// callers that need to clear stream state on retune call this.
+func (s *SyncDetector) Reset() {
+	for i := range s.hist {
+		s.hist[i] = 0
+	}
+	s.primed = 0
+	s.pos = 0
+}

--- a/internal/radio/nxdn/process_test.go
+++ b/internal/radio/nxdn/process_test.go
@@ -1,0 +1,141 @@
+package nxdn
+
+import (
+	"encoding/binary"
+	"log/slog"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+)
+
+// TestProcessDecodesSiteInfoFrameAfterSync builds a dibit stream
+// that contains:
+//
+//   - 30 padding dibits (so SyncDetector primes before FSW starts)
+//   - 8 outbound FSW dibits
+//   - 8 LICH wire dibits (encoding RFCh = Control, parity OK)
+//   - 32 SACCH dibits (junk; SACCH not consumed by adapter)
+//   - 44 dibits whose raw bits decode to a valid RCCHSITEINFO
+//     CACMessage (no FEC encoding — this exercises the adapter
+//     wiring rather than the FEC path)
+//
+// Runs the stream through Process and confirms a KindCCLocked
+// event lands on the bus.
+//
+// Production NXDN traffic carries the 88 CAC information bits
+// across the 288-wire-bit Info field via a K=5 ½-rate Viterbi +
+// interleaver + puncture chain that this adapter doesn't yet
+// reverse. Until that FEC layer ships, the adapter sync-locks
+// on the FSW but typically fails the CAC CRC on real signals.
+func TestProcessDecodesSiteInfoFrameAfterSync(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := NewControlChannel(bus, slog.Default(), 851_062_500, Rate9600)
+
+	// LICH: RFCh = Control, FCT / Option / Direction zero, parity
+	// computed by AssembleLICH. Wire-encode it (each info bit
+	// doubled) into 16 bits = 8 dibits.
+	lichInfo := AssembleLICH(LICH{RFCh: RFChControl})
+	lichWire := EncodeLICHWire(lichInfo)
+	lichDibits := framing.BitsToDibits(lichWire)
+	if len(lichDibits) != 8 {
+		t.Fatalf("LICH wire dibits = %d, want 8", len(lichDibits))
+	}
+
+	// CAC: SITEINFO with non-trivial site / system IDs so the
+	// state machine has something to publish + assert on.
+	var payload [8]byte
+	binary.BigEndian.PutUint16(payload[0:2], 0xAAAA) // LocationID
+	binary.BigEndian.PutUint16(payload[2:4], 0x1234) // SiteID
+	binary.BigEndian.PutUint16(payload[4:6], 0x5678) // SystemID
+	cacBytes := AssembleCAC(CACMessage{
+		Type:    RCCHSITEINFO,
+		Payload: payload,
+	})
+	// AssembleCAC produces 11 bytes (88 bits + CRC). Unpack MSB-
+	// first into 88 bits, then to 44 dibits.
+	cacBits := framing.UnpackBitsMSB(cacBytes, 88)
+	cacDibits := framing.BitsToDibits(cacBits)
+	if len(cacDibits) != 44 {
+		t.Fatalf("CAC dibits = %d, want 44", len(cacDibits))
+	}
+
+	// Assemble the dibit stream: padding + FSW + LICH + SACCH
+	// (junk) + CAC (raw).
+	stream := make([]uint8, 30)
+	stream = append(stream, FSWDibitsOutbound...)
+	stream = append(stream, lichDibits...)
+	stream = append(stream, make([]uint8, 32)...) // SACCH junk
+	stream = append(stream, cacDibits...)
+
+	cc.Process(stream, 0)
+
+	var sawLock bool
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind == events.KindCCLocked {
+				ls, ok := ev.Payload.(LockState)
+				if !ok {
+					t.Fatalf("CCLocked payload type = %T, want LockState", ev.Payload)
+				}
+				if ls.FrequencyHz != 851_062_500 {
+					t.Errorf("LockState.FrequencyHz = %d, want 851062500", ls.FrequencyHz)
+				}
+				if ls.SiteID != 0x1234 {
+					t.Errorf("LockState.SiteID = %#x, want 0x1234", ls.SiteID)
+				}
+				if ls.SystemID != 0x5678 {
+					t.Errorf("LockState.SystemID = %#x, want 0x5678", ls.SystemID)
+				}
+				sawLock = true
+			}
+		default:
+			if !sawLock {
+				t.Errorf("Process did not publish a KindCCLocked for a valid frame")
+			}
+			return
+		}
+	}
+}
+
+// TestProcessIgnoresGarbageWithoutSync confirms a dibit stream
+// that never contains the outbound FSW produces no events.
+func TestProcessIgnoresGarbageWithoutSync(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := NewControlChannel(bus, slog.Default(), 0, Rate9600)
+
+	garbage := make([]uint8, 1000)
+	for i := range garbage {
+		garbage[i] = uint8(i % 4)
+	}
+	cc.Process(garbage, 0)
+
+	select {
+	case ev := <-sub.C:
+		t.Errorf("unexpected event from garbage stream: %v", ev.Kind)
+	default:
+	}
+}
+
+// TestSyncDetectorReset confirms the helper Reset clears history.
+func TestSyncDetectorReset(t *testing.T) {
+	det := NewSyncDetector([][]uint8{FSWDibitsOutbound}, 0)
+	junk := make([]uint8, 100)
+	det.Process(nil, junk, 0)
+	det.Reset()
+	if det.primed != 0 {
+		t.Errorf("post-Reset primed = %d, want 0", det.primed)
+	}
+	if det.pos != 0 {
+		t.Errorf("post-Reset pos = %d, want 0", det.pos)
+	}
+}

--- a/internal/scanner/ccdecoder/decoder_test.go
+++ b/internal/scanner/ccdecoder/decoder_test.go
@@ -269,6 +269,23 @@ func TestP25Phase1FactoryConstructs(t *testing.T) {
 	}
 }
 
+func TestNXDNFactoryConstructs(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	p, err := newNXDNPipeline(PipelineOptions{
+		Bus: bus, SystemName: "Smoke",
+		FrequencyHz: 851_062_500, SampleRateHz: 48_000,
+	})
+	if err != nil {
+		t.Fatalf("newNXDNPipeline: %v", err)
+	}
+	p.Process(make([]complex64, 4800))
+	p.Reset()
+	if err := p.Close(); err != nil {
+		t.Errorf("Close: %v", err)
+	}
+}
+
 func TestDPMRFactoryConstructs(t *testing.T) {
 	bus := events.NewBus(8)
 	defer bus.Close()

--- a/internal/scanner/ccdecoder/pipelines.go
+++ b/internal/scanner/ccdecoder/pipelines.go
@@ -6,6 +6,8 @@ import (
 	"github.com/MattCheramie/GopherTrunk/internal/events"
 	"github.com/MattCheramie/GopherTrunk/internal/radio/dpmr"
 	dpmrrx "github.com/MattCheramie/GopherTrunk/internal/radio/dpmr/receiver"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/nxdn"
+	nxdnrx "github.com/MattCheramie/GopherTrunk/internal/radio/nxdn/receiver"
 	p25phase1 "github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase1"
 	p25phase1rx "github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase1/receiver"
 	"github.com/MattCheramie/GopherTrunk/internal/radio/ysf"
@@ -62,6 +64,7 @@ type PipelineFactory func(PipelineOptions) (ProtocolPipeline, error)
 var factories = map[trunking.Protocol]PipelineFactory{
 	trunking.ProtocolP25:  newP25Phase1Pipeline,
 	trunking.ProtocolDPMR: newDPMRPipeline,
+	trunking.ProtocolNXDN: newNXDNPipeline,
 }
 
 // newP25Phase1Pipeline wires the existing
@@ -157,3 +160,31 @@ type dpmrPipeline struct {
 func (p *dpmrPipeline) Process(iq []complex64) { p.rx.Process(iq) }
 func (p *dpmrPipeline) Reset()                  { p.rx.Reset() }
 func (p *dpmrPipeline) Close() error            { return nil }
+
+// newNXDNPipeline wires internal/radio/nxdn/receiver into
+// nxdn.ControlChannel.Process. The receiver's DibitSink forwards
+// dibits into the state machine, which detects the outbound 8-dibit
+// FSW, parses the LICH from the next 16 wire bits, and pulls the
+// first 44 dibits of the Info field as raw CAC bits. The CAC FEC
+// layer (K=5 ½-rate Viterbi + interleaver + puncture) is a
+// follow-up; until it ships the adapter will sync on FSW + LICH
+// but typically fail the CAC CRC on real on-air signals.
+func newNXDNPipeline(opts PipelineOptions) (ProtocolPipeline, error) {
+	cc := nxdn.NewControlChannel(opts.Bus, opts.Log, opts.FrequencyHz, nxdn.Rate9600)
+	rx := nxdnrx.New(nxdnrx.Options{
+		SampleRateHz: opts.SampleRateHz,
+		DibitSink: func(dibits []uint8, baseIdx int) {
+			cc.Process(dibits, baseIdx)
+		},
+	})
+	return &nxdnPipeline{rx: rx, cc: cc}, nil
+}
+
+type nxdnPipeline struct {
+	rx *nxdnrx.Receiver
+	cc *nxdn.ControlChannel
+}
+
+func (p *nxdnPipeline) Process(iq []complex64) { p.rx.Process(iq) }
+func (p *nxdnPipeline) Reset()                  { p.rx.Reset() }
+func (p *nxdnPipeline) Close() error            { return nil }


### PR DESCRIPTION
## Summary

Second of the per-protocol `ControlChannel.Process(stream, baseIdx)`
adapter follow-ups from the ccdecoder connector PR (#111).

Closes the IQ → CC sync layer for **NXDN**. The receiver's
`DibitSink` forwards dibits into `nxdn.ControlChannel.Process`,
which:

- Buffers cross-call state via an internal countdown + partial
  frame slice.
- Runs the outbound FSW `SyncDetector` across each incoming chunk;
  silently ignores inbound (MS → BS) matches since they don't
  carry the CC announcement payloads the state machine locks on.
- On each outbound FSW match collects **84 dibits** = 8 LICH wire
  + 32 SACCH (skipped) + 44 CAC info dibits.
- Decodes the LICH via `DecodeLICHWire` (doubled-bit majority
  decode) → `ParseLICH`.
- Pulls 44 dibits worth of info bits, packs to 11 bytes, runs
  `ParseCAC`, hands the `(lich, cac)` pair to `IngestFrame`,
  which publishes `events.KindCCLocked` for `RCCHSITEINFO` /
  `RCCHCCH` messages.

## Deferred to a follow-up

The CAC FEC layer — K=5 ½-rate Viterbi + interleaver + puncture
across the full 288-wire-bit Info field — isn't decoded by this
adapter. The adapter reads the first 44 dibits of the Info field
as raw information bits, which works for test fixtures (where
CAC bits are placed directly in the wire) but typically fails the
CAC CRC on real on-air NXDN signals. Until the FEC layer ships,
NXDN sync-locks on FSW + LICH but rarely publishes
`cc.locked` from a live capture.

## ccdecoder

- `newNXDNPipeline` factory + `nxdnPipeline` wrapper.
- Row in the `factories` map under `trunking.ProtocolNXDN`.

## Helper change

- `nxdn.SyncDetector.Reset()` is added (small helper, mirrors
  the dPMR sibling).

## Test plan

- [x] `go test ./internal/radio/nxdn/... -race -v`
- [x] `go test ./internal/scanner/ccdecoder/... -race`
- [x] `go build ./...`
- [x] `go vet ./...`

New tests cover:
- A 30-dibit-padded outbound FSW + valid LICH (`RFCh=Control`) +
  raw `RCCHSITEINFO` CAC triggers a `KindCCLocked` with the right
  `FrequencyHz`, `SiteID`, `SystemID`.
- Garbage without an FSW produces no events.
- `SyncDetector.Reset` clears `primed` + `pos`.
- ccdecoder smoke construction of the new NXDN factory.

## README

- "Status & known gaps" updated — NXDN moves to "works today
  (FSW + LICH only)"; CAC FEC flagged as the next NXDN follow-up.
  7 protocols still pending adapters.
- "Recently shipped" gains a bullet for the NXDN adapter +
  factory wiring + FEC deferral.


---
_Generated by [Claude Code](https://claude.ai/code/session_019dtCCVEZJTKKr6YK3wy824)_