### PR TITLE
internal/radio/edacs: ControlChannel.Process adapter + ccdecoder factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,16 +68,15 @@ panel. The honest remaining gaps:
   / `grant` events back on the bus — the trigger that lights up
   every downstream surface (engine, recorder, call log, API, TUI).
   Live trunked reception works today for P25 Phase 1, YSF, dPMR
-  Mode 3, and NXDN (FSW sync + LICH parse only — full CAC FEC
-  decoding is the next NXDN follow-up; until then the adapter
-  sync-locks but typically fails the CAC CRC on real on-air
-  signals). DMR / EDACS / MPT 1327 / LTR / Motorola / P25 P2 /
-  TETRA each have IQ → symbol receivers shipping but their CC
-  state machines still consume pre-parsed PDUs; adding the
-  `Process(stream, baseIdx)` adapter on each (sync detect → frame
-  slice → existing parser → Ingest) lights up the rest. The
-  adapter shape is ~30–50 lines per protocol and documented
-  per-receiver in the relevant PR descriptions.
+  Mode 3, NXDN (FSW + LICH only; CAC FEC pending), and EDACS /
+  GE-Marc (24-bit sync + 40-bit CCW only; interleaved-RS FEC
+  pending). DMR / MPT 1327 / LTR / Motorola / P25 P2 / TETRA each
+  have IQ → symbol receivers shipping but their CC state machines
+  still consume pre-parsed PDUs; adding the `Process(stream,
+  baseIdx)` adapter on each (sync detect → frame slice → existing
+  parser → Ingest) lights up the rest. The adapter shape is
+  ~30–50 lines per protocol and documented per-receiver in the
+  relevant PR descriptions.
 - **Digital-voice level calibration.** Pure-Go IMBE / AMBE+2 emit
   real audio end-to-end with shared AGC, frame-repeat on bad-frame
   indicator, phase-aware fade-in, and §6.2 spectral enhancement
@@ -144,6 +143,17 @@ to its own package and lands independently.
 
 ### Recently shipped
 
+- **EDACS / GE-Marc `ControlChannel.Process(stream, baseIdx)`
+  adapter + ccdecoder factory.** Closes the IQ → CC loop for
+  EDACS: the receiver's `BitSink` forwards bits into
+  `edacs.ControlChannel.Process`, which buffers across calls +
+  detects the 24-bit outbound sync + slices the 40-bit CCW +
+  parses it via `CCWFromBits` + dispatches via the existing
+  `Ingest`. `trunking.Protocol` gains `ProtocolEDACS` (config
+  string `"edacs"`). The interleaved Reed-Solomon-derived FEC
+  over the CCW is a follow-up; until it lands the adapter
+  sync-locks but typically fails CCW parsing on noisy on-air
+  signals.
 - **NXDN `ControlChannel.Process(stream, baseIdx)` adapter +
   ccdecoder factory.** Closes the IQ → CC sync layer for NXDN:
   the receiver's `DibitSink` forwards into

--- a/internal/radio/edacs/control.go
+++ b/internal/radio/edacs/control.go
@@ -29,6 +29,11 @@ type ControlChannel struct {
 	resolver   Resolver
 	now        func() time.Time
 
+	// proc is the cross-call bit / sync state the Process adapter
+	// uses (see process.go). Lazily constructed on the first
+	// Process call.
+	proc *processState
+
 	mu     sync.Mutex
 	locked bool
 	last   LockState

--- a/internal/radio/edacs/process.go
+++ b/internal/radio/edacs/process.go
@@ -1,0 +1,82 @@
+package edacs
+
+// processState is the cross-call bit buffering + sync-detection
+// state the Process adapter holds. Lazily initialised on the first
+// Process call.
+type processState struct {
+	det *SyncDetector
+	// remaining > 0: collecting CCW bits after a sync match;
+	// counts down to 0 as Process feeds bits forward.
+	remaining int
+	// ccw accumulates the 40 bits that make up one CCW info block.
+	ccw []byte
+	// matchScratch is reused across calls so SyncDetector.Process
+	// doesn't allocate fresh slices.
+	matchScratch []int
+}
+
+// Process consumes a window of raw bits from the EDACS receiver
+// (the IQ → GFSK bit chain in internal/radio/edacs/receiver/), runs
+// the 24-bit outbound sync detector, slices the following 40-bit
+// CCW out of the stream, parses it via CCWFromBits, and forwards
+// the result to Ingest.
+//
+// baseIdx is the absolute bit index of bits[0] across the stream
+// lifetime. The adapter's internal countdown survives across
+// Process calls so a sync match in one chunk and the payload in
+// the next still decode cleanly.
+//
+// The interleaved Reed-Solomon-derived FEC over the CCW is NOT
+// reversed here — the package's CCW parser assumes the upstream
+// caller delivered the 40 information bits already, which is the
+// case for test fixtures + clean signals but not for noisy on-air
+// captures. Adding the RS FEC layer is a documented follow-up.
+//
+// Returns baseIdx + len(bits) to match the YSF / P25 Phase 1 /
+// dPMR / NXDN ControlChannel.Process contracts.
+func (c *ControlChannel) Process(bits []byte, baseIdx int) int {
+	if c.proc == nil {
+		c.proc = &processState{
+			det: NewSyncDetector(OutboundSyncBits(), 1),
+			ccw: make([]byte, 0, 40),
+		}
+	}
+	p := c.proc
+
+	p.matchScratch, _ = p.det.Process(p.matchScratch[:0], bits, baseIdx)
+	matchIdx := 0
+
+	for i, b := range bits {
+		absPos := baseIdx + i
+		// Collect first (this bit completes the 40-bit CCW if
+		// remaining counts down to 0). Order matters: the sync
+		// match's absolute index is the LAST bit of the 24-bit
+		// sync, so the CCW starts at the NEXT iteration.
+		if p.remaining > 0 {
+			p.ccw = append(p.ccw, b&1)
+			p.remaining--
+			if p.remaining == 0 {
+				if ccw, err := CCWFromBits(p.ccw); err == nil {
+					c.Ingest(ccw)
+				}
+				p.ccw = p.ccw[:0]
+			}
+		}
+		for matchIdx < len(p.matchScratch) && p.matchScratch[matchIdx] == absPos {
+			p.remaining = 40
+			p.ccw = p.ccw[:0]
+			matchIdx++
+		}
+	}
+	return baseIdx + len(bits)
+}
+
+// Reset clears the SyncDetector's history so a stale match doesn't
+// fire after a stream re-sync.
+func (s *SyncDetector) Reset() {
+	for i := range s.hist {
+		s.hist[i] = 0
+	}
+	s.primed = 0
+	s.pos = 0
+}

--- a/internal/radio/edacs/process_test.go
+++ b/internal/radio/edacs/process_test.go
@@ -1,0 +1,147 @@
+package edacs
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// TestProcessDecodesGroupVoiceGrantAfterSync builds a bit stream
+// containing 30 bits of padding (so the SyncDetector primes before
+// the sync starts), the 24-bit outbound sync, and a 40-bit
+// GroupVoiceGrant CCW. Process must publish a KindGrant on the
+// bus with the expected payload fields.
+func TestProcessDecodesGroupVoiceGrantAfterSync(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{
+		Bus:         bus,
+		Log:         slog.Default(),
+		SystemName:  "Sys",
+		FrequencyHz: 866_000_000,
+	})
+
+	ccw := CCW{
+		Command: CmdGroupVoiceGrant,
+		Status:  0,
+		Address: 0xCAFE,
+		LCN:     5,
+		Aux:     0x123,
+	}
+	ccwBits := CCWBits(ccw)
+
+	// 30 padding bits + 24 sync bits + 40 CCW bits.
+	stream := make([]byte, 30)
+	stream = append(stream, OutboundSyncBits()...)
+	stream = append(stream, ccwBits...)
+
+	cc.Process(stream, 0)
+
+	var sawGrant bool
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind == events.KindGrant {
+				g, ok := ev.Payload.(trunking.Grant)
+				if !ok {
+					t.Fatalf("Grant payload type = %T, want trunking.Grant", ev.Payload)
+				}
+				if g.System != "Sys" {
+					t.Errorf("Grant.System = %q, want Sys", g.System)
+				}
+				if g.Protocol != "edacs" {
+					t.Errorf("Grant.Protocol = %q, want edacs", g.Protocol)
+				}
+				if g.GroupID != 0xCAFE {
+					t.Errorf("Grant.GroupID = %#x, want 0xCAFE", g.GroupID)
+				}
+				sawGrant = true
+			}
+		default:
+			if !sawGrant {
+				t.Errorf("Process did not publish a KindGrant for a valid CCW")
+			}
+			return
+		}
+	}
+}
+
+// TestProcessIgnoresGarbageWithoutSync confirms a stream that
+// never contains the 24-bit sync produces no events.
+func TestProcessIgnoresGarbageWithoutSync(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, Log: slog.Default(), SystemName: "Sys"})
+
+	garbage := make([]byte, 1000)
+	for i := range garbage {
+		garbage[i] = byte(i & 1)
+	}
+	cc.Process(garbage, 0)
+
+	select {
+	case ev := <-sub.C:
+		t.Errorf("unexpected event from garbage stream: %v", ev.Kind)
+	default:
+	}
+}
+
+// TestProcessHandlesSyncSpanningCalls confirms a CCW whose sync
+// arrives in one Process call and whose payload arrives in the
+// next still decodes correctly.
+func TestProcessHandlesSyncSpanningCalls(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, Log: slog.Default(), SystemName: "Sys"})
+
+	ccw := CCW{
+		Command: CmdGroupVoiceGrant,
+		Address: 0xBEEF,
+		LCN:     3,
+	}
+	ccwBits := CCWBits(ccw)
+
+	chunk1 := make([]byte, 30)
+	chunk1 = append(chunk1, OutboundSyncBits()...)
+	cc.Process(chunk1, 0)
+	cc.Process(ccwBits, len(chunk1))
+
+	var sawGrant bool
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind == events.KindGrant {
+				sawGrant = true
+			}
+		default:
+			if !sawGrant {
+				t.Errorf("Process did not publish a KindGrant across the chunk boundary")
+			}
+			return
+		}
+	}
+}
+
+func TestSyncDetectorReset(t *testing.T) {
+	det := NewSyncDetector(OutboundSyncBits(), 0)
+	junk := make([]byte, 100)
+	det.Process(nil, junk, 0)
+	det.Reset()
+	if det.primed != 0 {
+		t.Errorf("post-Reset primed = %d, want 0", det.primed)
+	}
+	if det.pos != 0 {
+		t.Errorf("post-Reset pos = %d, want 0", det.pos)
+	}
+}

--- a/internal/scanner/ccdecoder/decoder_test.go
+++ b/internal/scanner/ccdecoder/decoder_test.go
@@ -269,6 +269,23 @@ func TestP25Phase1FactoryConstructs(t *testing.T) {
 	}
 }
 
+func TestEDACSFactoryConstructs(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	p, err := newEDACSPipeline(PipelineOptions{
+		Bus: bus, SystemName: "Smoke",
+		FrequencyHz: 866_000_000, SampleRateHz: 96_000,
+	})
+	if err != nil {
+		t.Fatalf("newEDACSPipeline: %v", err)
+	}
+	p.Process(make([]complex64, 9600))
+	p.Reset()
+	if err := p.Close(); err != nil {
+		t.Errorf("Close: %v", err)
+	}
+}
+
 func TestNXDNFactoryConstructs(t *testing.T) {
 	bus := events.NewBus(8)
 	defer bus.Close()

--- a/internal/scanner/ccdecoder/pipelines.go
+++ b/internal/scanner/ccdecoder/pipelines.go
@@ -6,6 +6,8 @@ import (
 	"github.com/MattCheramie/GopherTrunk/internal/events"
 	"github.com/MattCheramie/GopherTrunk/internal/radio/dpmr"
 	dpmrrx "github.com/MattCheramie/GopherTrunk/internal/radio/dpmr/receiver"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/edacs"
+	edacsrx "github.com/MattCheramie/GopherTrunk/internal/radio/edacs/receiver"
 	"github.com/MattCheramie/GopherTrunk/internal/radio/nxdn"
 	nxdnrx "github.com/MattCheramie/GopherTrunk/internal/radio/nxdn/receiver"
 	p25phase1 "github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase1"
@@ -62,9 +64,10 @@ type PipelineFactory func(PipelineOptions) (ProtocolPipeline, error)
 // detect sync + frame + dispatch into the existing parsers is a
 // follow-up.
 var factories = map[trunking.Protocol]PipelineFactory{
-	trunking.ProtocolP25:  newP25Phase1Pipeline,
-	trunking.ProtocolDPMR: newDPMRPipeline,
-	trunking.ProtocolNXDN: newNXDNPipeline,
+	trunking.ProtocolP25:   newP25Phase1Pipeline,
+	trunking.ProtocolDPMR:  newDPMRPipeline,
+	trunking.ProtocolNXDN:  newNXDNPipeline,
+	trunking.ProtocolEDACS: newEDACSPipeline,
 }
 
 // newP25Phase1Pipeline wires the existing
@@ -188,3 +191,35 @@ type nxdnPipeline struct {
 func (p *nxdnPipeline) Process(iq []complex64) { p.rx.Process(iq) }
 func (p *nxdnPipeline) Reset()                  { p.rx.Reset() }
 func (p *nxdnPipeline) Close() error            { return nil }
+
+// newEDACSPipeline wires internal/radio/edacs/receiver into
+// edacs.ControlChannel.Process. The receiver's BitSink forwards
+// bits + baseIdx into the state machine (24-bit sync detect →
+// 40-bit CCW slice → CCWFromBits → Ingest). The interleaved
+// Reed-Solomon-derived FEC over the CCW is a follow-up; until
+// it lands the adapter sync-locks but typically fails CCW
+// parsing on noisy on-air signals.
+func newEDACSPipeline(opts PipelineOptions) (ProtocolPipeline, error) {
+	cc := edacs.New(edacs.Options{
+		Bus:         opts.Bus,
+		Log:         opts.Log,
+		SystemName:  opts.SystemName,
+		FrequencyHz: opts.FrequencyHz,
+	})
+	rx := edacsrx.New(edacsrx.Options{
+		SampleRateHz: opts.SampleRateHz,
+		BitSink: func(bits []byte, baseIdx int) {
+			cc.Process(bits, baseIdx)
+		},
+	})
+	return &edacsPipeline{rx: rx, cc: cc}, nil
+}
+
+type edacsPipeline struct {
+	rx *edacsrx.Receiver
+	cc *edacs.ControlChannel
+}
+
+func (p *edacsPipeline) Process(iq []complex64) { p.rx.Process(iq) }
+func (p *edacsPipeline) Reset()                  { p.rx.Reset() }
+func (p *edacsPipeline) Close() error            { return nil }

--- a/internal/trunking/site.go
+++ b/internal/trunking/site.go
@@ -18,6 +18,7 @@ const (
 	ProtocolDMR              // DMR Tier II / III
 	ProtocolNXDN             // NXDN
 	ProtocolDPMR             // dPMR Mode 3 (digital PMR446 trunking)
+	ProtocolEDACS            // EDACS / GE-Marc
 )
 
 func (p Protocol) String() string {
@@ -30,13 +31,15 @@ func (p Protocol) String() string {
 		return "nxdn"
 	case ProtocolDPMR:
 		return "dpmr"
+	case ProtocolEDACS:
+		return "edacs"
 	default:
 		return "unknown"
 	}
 }
 
-// ParseProtocol maps a string ("p25", "dmr", "nxdn", "dpmr") to a
-// Protocol value.
+// ParseProtocol maps a string ("p25", "dmr", "nxdn", "dpmr",
+// "edacs") to a Protocol value.
 func ParseProtocol(s string) (Protocol, error) {
 	switch strings.ToLower(s) {
 	case "p25":
@@ -47,6 +50,8 @@ func ParseProtocol(s string) (Protocol, error) {
 		return ProtocolNXDN, nil
 	case "dpmr":
 		return ProtocolDPMR, nil
+	case "edacs":
+		return ProtocolEDACS, nil
 	default:
 		return ProtocolUnknown, fmt.Errorf("trunking: unknown protocol %q", s)
 	}
@@ -69,7 +74,7 @@ func (s System) Validate() error {
 		return errors.New("trunking: system name is required")
 	}
 	if s.Protocol == ProtocolUnknown {
-		return errors.New("trunking: protocol must be p25|dmr|nxdn|dpmr")
+		return errors.New("trunking: protocol must be p25|dmr|nxdn|dpmr|edacs")
 	}
 	if len(s.ControlChannels) == 0 {
 		return errors.New("trunking: at least one control_channel frequency is required")


### PR DESCRIPTION
## Summary

Third of the per-protocol `ControlChannel.Process(stream, baseIdx)`
adapter follow-ups.

Closes the IQ → CC sync layer for **EDACS / GE-Marc**. The
receiver's `BitSink` forwards bits into
`edacs.ControlChannel.Process`, which:

- Buffers cross-call state via an internal countdown + partial
  CCW slice.
- Runs the 24-bit outbound `SyncDetector` across each incoming
  chunk.
- On each sync match collects 40 bits.
- Hands the 40 bits to `CCWFromBits` + the parsed CCW to the
  existing `Ingest` path, which publishes
  `events.KindCCLocked` / `events.KindGrant` on the bus.

## Daemon-level changes

- **`trunking.Protocol`** gains `ProtocolEDACS` (config string
  `"edacs"`). `ParseProtocol` + `String` + `Validate` recognise
  the new value.
- **`ccdecoder/pipelines.go`** gains `newEDACSPipeline` +
  `edacsPipeline` wrapper, plus a row in the `factories` map.

## Deferred to a follow-up

The interleaved Reed-Solomon-derived FEC over the CCW isn't
reversed here. The adapter reads the 40 information bits straight
out of the wire, which works for test fixtures + clean signals
but typically fails on noisy on-air captures.

## Test plan

- [x] `go test ./internal/radio/edacs/... -race -v`
- [x] `go test ./internal/scanner/ccdecoder/... ./internal/trunking/... -race`
- [x] `go build ./...`
- [x] `go vet ./...`

New tests cover:
- A 30-bit-padded sync + valid `CmdGroupVoiceGrant` CCW triggers
  a `KindGrant` with the right System / Protocol / GroupID.
- Garbage without a sync produces no events.
- A sync that arrives in chunk N + CCW payload in chunk N+1
  still decodes cleanly.
- `SyncDetector.Reset` clears `primed` + `pos`.
- ccdecoder smoke construction of the new EDACS factory.

## README

- "Status & known gaps" updated — EDACS moves to "works today
  (sync + CCW only)"; RS-derived FEC flagged as the follow-up.
  6 protocols still pending adapters.
- "Recently shipped" gains a bullet for the EDACS adapter +
  factory wiring + FEC deferral.


---
_Generated by [Claude Code](https://claude.ai/code/session_019dtCCVEZJTKKr6YK3wy824)_