### PR TITLE
internal/radio/motorola: ControlChannel.Process adapter + ccdecoder factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,15 +68,16 @@ panel. The honest remaining gaps:
   / `grant` events back on the bus — the trigger that lights up
   every downstream surface (engine, recorder, call log, API, TUI).
   Live trunked reception works today for P25 Phase 1, YSF, dPMR
-  Mode 3, NXDN (FSW + LICH only; CAC FEC pending), and EDACS /
+  Mode 3, NXDN (FSW + LICH only; CAC FEC pending), EDACS /
   GE-Marc (24-bit sync + 40-bit CCW only; interleaved-RS FEC
-  pending). DMR / MPT 1327 / LTR / Motorola / P25 P2 / TETRA each
-  have IQ → symbol receivers shipping but their CC state machines
-  still consume pre-parsed PDUs; adding the `Process(stream,
-  baseIdx)` adapter on each (sync detect → frame slice → existing
-  parser → Ingest) lights up the rest. The adapter shape is
-  ~30–50 lines per protocol and documented per-receiver in the
-  relevant PR descriptions.
+  pending), and Motorola Type II / SmartZone (24-bit sync +
+  32-bit OSW only; BCH(64,16,11) FEC pending). DMR / MPT 1327 /
+  LTR / P25 P2 / TETRA each have IQ → symbol receivers shipping
+  but their CC state machines still consume pre-parsed PDUs;
+  adding the `Process(stream, baseIdx)` adapter on each (sync
+  detect → frame slice → existing parser → Ingest) lights up
+  the rest. The adapter shape is ~30–50 lines per protocol and
+  documented per-receiver in the relevant PR descriptions.
 - **Digital-voice level calibration.** Pure-Go IMBE / AMBE+2 emit
   real audio end-to-end with shared AGC, frame-repeat on bad-frame
   indicator, phase-aware fade-in, and §6.2 spectral enhancement
@@ -143,6 +144,17 @@ to its own package and lands independently.
 
 ### Recently shipped
 
+- **Motorola Type II `ControlChannel.Process(stream, baseIdx)`
+  adapter + ccdecoder factory.** Closes the IQ → CC sync layer
+  for Motorola: the receiver's `BitSink` forwards bits into
+  `motorola.ControlChannel.Process`, which buffers across calls
+  + detects the 24-bit outbound sync + slices a 32-bit OSW out
+  of the wire + parses it via `OSWFromBits` + dispatches via the
+  existing `Ingest`. `trunking.Protocol` gains `ProtocolMotorola`
+  (config string `"motorola"`). The BCH(64,16,11) FEC + de-
+  interleaving over the OSW are follow-ups; until they ship the
+  adapter sync-locks but typically fails OSW parsing on noisy
+  on-air signals.
 - **EDACS / GE-Marc `ControlChannel.Process(stream, baseIdx)`
   adapter + ccdecoder factory.** Closes the IQ → CC loop for
   EDACS: the receiver's `BitSink` forwards bits into

--- a/internal/radio/motorola/control.go
+++ b/internal/radio/motorola/control.go
@@ -34,6 +34,11 @@ type ControlChannel struct {
 	resolver   Resolver
 	now        func() time.Time
 
+	// proc is the cross-call bit / sync state the Process adapter
+	// uses (see process.go). Lazily constructed on the first
+	// Process call.
+	proc *processState
+
 	mu     sync.Mutex
 	locked bool
 	last   LockState

--- a/internal/radio/motorola/process.go
+++ b/internal/radio/motorola/process.go
@@ -1,0 +1,76 @@
+package motorola
+
+// processState is the cross-call bit buffering + sync-detection
+// state the Process adapter holds. Lazily initialised on the first
+// Process call.
+type processState struct {
+	det          *SyncDetector
+	remaining    int
+	osw          []byte
+	matchScratch []int
+}
+
+// oswInfoBits is the count of bits the adapter collects after each
+// 24-bit sync match: 32 information bits = one OSW. The on-air
+// 84-bit OSW frame (with BCH(64,16,11) FEC over the upper 64 bits)
+// isn't reversed here — the adapter reads the 32 information bits
+// straight from the wire, which works for test fixtures + clean
+// signals but typically fails on noisy on-air captures. Adding the
+// BCH layer is a documented follow-up.
+const oswInfoBits = 32
+
+// Process consumes a window of raw bits from the Motorola receiver
+// (the IQ → MSK bit chain in internal/radio/motorola/receiver/),
+// runs the 24-bit outbound sync detector, slices the following
+// 32-bit OSW out of the stream, parses it via OSWFromBits, and
+// forwards the result to Ingest.
+//
+// baseIdx is the absolute bit index of bits[0] across the stream
+// lifetime. The adapter's internal countdown survives across
+// Process calls so a sync match in one chunk and the payload in
+// the next still decode cleanly.
+//
+// Returns baseIdx + len(bits) to match the YSF / P25 Phase 1 /
+// dPMR / NXDN / EDACS ControlChannel.Process contracts.
+func (c *ControlChannel) Process(bits []byte, baseIdx int) int {
+	if c.proc == nil {
+		c.proc = &processState{
+			det: NewSyncDetector(OutboundSyncBits(), 1),
+			osw: make([]byte, 0, oswInfoBits),
+		}
+	}
+	p := c.proc
+
+	p.matchScratch, _ = p.det.Process(p.matchScratch[:0], bits, baseIdx)
+	matchIdx := 0
+
+	for i, b := range bits {
+		absPos := baseIdx + i
+		if p.remaining > 0 {
+			p.osw = append(p.osw, b&1)
+			p.remaining--
+			if p.remaining == 0 {
+				if osw, err := OSWFromBits(p.osw); err == nil {
+					c.Ingest(osw)
+				}
+				p.osw = p.osw[:0]
+			}
+		}
+		for matchIdx < len(p.matchScratch) && p.matchScratch[matchIdx] == absPos {
+			p.remaining = oswInfoBits
+			p.osw = p.osw[:0]
+			matchIdx++
+		}
+	}
+	return baseIdx + len(bits)
+}
+
+// Reset clears the SyncDetector's history so a stale match doesn't
+// fire after a stream re-sync.
+func (s *SyncDetector) Reset() {
+	for i := range s.hist {
+		s.hist[i] = 0
+	}
+	s.primed = 0
+	s.pos = 0
+}

--- a/internal/radio/motorola/process_test.go
+++ b/internal/radio/motorola/process_test.go
@@ -1,0 +1,134 @@
+package motorola
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// TestProcessDecodesGroupVoiceGrantAfterSync builds a bit stream
+// containing 30 bits of padding (so the SyncDetector primes), the
+// 24-bit outbound sync, and a 32-bit OSW carrying a Group Voice
+// Channel Grant. Process must publish a KindGrant on the bus.
+func TestProcessDecodesGroupVoiceGrantAfterSync(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{
+		Bus:         bus,
+		Log:         slog.Default(),
+		SystemName:  "Sys",
+		FrequencyHz: 851_012_500,
+	})
+
+	// Command = (opcode << 4) | LCN. Group Voice Channel Grant on
+	// LCN 5.
+	cmd := (uint16(OpGroupVoiceChannelGrant) << 4) | 0x5
+	osw := OSW{Address: 0xCAFE, Command: cmd}
+	oswBits := OSWBits(osw)
+
+	stream := make([]byte, 30)
+	stream = append(stream, OutboundSyncBits()...)
+	stream = append(stream, oswBits...)
+
+	cc.Process(stream, 0)
+
+	var sawGrant bool
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind == events.KindGrant {
+				g, ok := ev.Payload.(trunking.Grant)
+				if !ok {
+					t.Fatalf("Grant payload type = %T, want trunking.Grant", ev.Payload)
+				}
+				if g.System != "Sys" {
+					t.Errorf("Grant.System = %q, want Sys", g.System)
+				}
+				if g.Protocol != "motorola" {
+					t.Errorf("Grant.Protocol = %q, want motorola", g.Protocol)
+				}
+				if g.GroupID != 0xCAFE {
+					t.Errorf("Grant.GroupID = %#x, want 0xCAFE", g.GroupID)
+				}
+				sawGrant = true
+			}
+		default:
+			if !sawGrant {
+				t.Errorf("Process did not publish a KindGrant for a valid OSW")
+			}
+			return
+		}
+	}
+}
+
+func TestProcessIgnoresGarbageWithoutSync(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, Log: slog.Default(), SystemName: "Sys"})
+
+	garbage := make([]byte, 1000)
+	for i := range garbage {
+		garbage[i] = byte(i & 1)
+	}
+	cc.Process(garbage, 0)
+
+	select {
+	case ev := <-sub.C:
+		t.Errorf("unexpected event from garbage stream: %v", ev.Kind)
+	default:
+	}
+}
+
+func TestProcessHandlesSyncSpanningCalls(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, Log: slog.Default(), SystemName: "Sys"})
+
+	cmd := (uint16(OpGroupVoiceChannelGrant) << 4) | 0x3
+	osw := OSW{Address: 0xBEEF, Command: cmd}
+	oswBits := OSWBits(osw)
+
+	chunk1 := make([]byte, 30)
+	chunk1 = append(chunk1, OutboundSyncBits()...)
+	cc.Process(chunk1, 0)
+	cc.Process(oswBits, len(chunk1))
+
+	var sawGrant bool
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind == events.KindGrant {
+				sawGrant = true
+			}
+		default:
+			if !sawGrant {
+				t.Errorf("Process did not publish a KindGrant across the chunk boundary")
+			}
+			return
+		}
+	}
+}
+
+func TestSyncDetectorReset(t *testing.T) {
+	det := NewSyncDetector(OutboundSyncBits(), 0)
+	junk := make([]byte, 100)
+	det.Process(nil, junk, 0)
+	det.Reset()
+	if det.primed != 0 {
+		t.Errorf("post-Reset primed = %d, want 0", det.primed)
+	}
+	if det.pos != 0 {
+		t.Errorf("post-Reset pos = %d, want 0", det.pos)
+	}
+}

--- a/internal/scanner/ccdecoder/decoder_test.go
+++ b/internal/scanner/ccdecoder/decoder_test.go
@@ -269,6 +269,23 @@ func TestP25Phase1FactoryConstructs(t *testing.T) {
 	}
 }
 
+func TestMotorolaFactoryConstructs(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	p, err := newMotorolaPipeline(PipelineOptions{
+		Bus: bus, SystemName: "Smoke",
+		FrequencyHz: 851_012_500, SampleRateHz: 48_000,
+	})
+	if err != nil {
+		t.Fatalf("newMotorolaPipeline: %v", err)
+	}
+	p.Process(make([]complex64, 4800))
+	p.Reset()
+	if err := p.Close(); err != nil {
+		t.Errorf("Close: %v", err)
+	}
+}
+
 func TestEDACSFactoryConstructs(t *testing.T) {
 	bus := events.NewBus(8)
 	defer bus.Close()

--- a/internal/scanner/ccdecoder/pipelines.go
+++ b/internal/scanner/ccdecoder/pipelines.go
@@ -8,6 +8,8 @@ import (
 	dpmrrx "github.com/MattCheramie/GopherTrunk/internal/radio/dpmr/receiver"
 	"github.com/MattCheramie/GopherTrunk/internal/radio/edacs"
 	edacsrx "github.com/MattCheramie/GopherTrunk/internal/radio/edacs/receiver"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/motorola"
+	motorolarx "github.com/MattCheramie/GopherTrunk/internal/radio/motorola/receiver"
 	"github.com/MattCheramie/GopherTrunk/internal/radio/nxdn"
 	nxdnrx "github.com/MattCheramie/GopherTrunk/internal/radio/nxdn/receiver"
 	p25phase1 "github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase1"
@@ -64,10 +66,11 @@ type PipelineFactory func(PipelineOptions) (ProtocolPipeline, error)
 // detect sync + frame + dispatch into the existing parsers is a
 // follow-up.
 var factories = map[trunking.Protocol]PipelineFactory{
-	trunking.ProtocolP25:   newP25Phase1Pipeline,
-	trunking.ProtocolDPMR:  newDPMRPipeline,
-	trunking.ProtocolNXDN:  newNXDNPipeline,
-	trunking.ProtocolEDACS: newEDACSPipeline,
+	trunking.ProtocolP25:      newP25Phase1Pipeline,
+	trunking.ProtocolDPMR:     newDPMRPipeline,
+	trunking.ProtocolNXDN:     newNXDNPipeline,
+	trunking.ProtocolEDACS:    newEDACSPipeline,
+	trunking.ProtocolMotorola: newMotorolaPipeline,
 }
 
 // newP25Phase1Pipeline wires the existing
@@ -223,3 +226,34 @@ type edacsPipeline struct {
 func (p *edacsPipeline) Process(iq []complex64) { p.rx.Process(iq) }
 func (p *edacsPipeline) Reset()                  { p.rx.Reset() }
 func (p *edacsPipeline) Close() error            { return nil }
+
+// newMotorolaPipeline wires internal/radio/motorola/receiver into
+// motorola.ControlChannel.Process. The receiver's BitSink forwards
+// bits + baseIdx into the state machine (24-bit sync detect →
+// 32-bit OSW slice → OSWFromBits → Ingest). The BCH(64,16,11)
+// FEC over the OSW is a follow-up; until it lands the adapter
+// sync-locks but typically fails OSW parsing on noisy signals.
+func newMotorolaPipeline(opts PipelineOptions) (ProtocolPipeline, error) {
+	cc := motorola.New(motorola.Options{
+		Bus:         opts.Bus,
+		Log:         opts.Log,
+		SystemName:  opts.SystemName,
+		FrequencyHz: opts.FrequencyHz,
+	})
+	rx := motorolarx.New(motorolarx.Options{
+		SampleRateHz: opts.SampleRateHz,
+		BitSink: func(bits []byte, baseIdx int) {
+			cc.Process(bits, baseIdx)
+		},
+	})
+	return &motorolaPipeline{rx: rx, cc: cc}, nil
+}
+
+type motorolaPipeline struct {
+	rx *motorolarx.Receiver
+	cc *motorola.ControlChannel
+}
+
+func (p *motorolaPipeline) Process(iq []complex64) { p.rx.Process(iq) }
+func (p *motorolaPipeline) Reset()                  { p.rx.Reset() }
+func (p *motorolaPipeline) Close() error            { return nil }

--- a/internal/trunking/site.go
+++ b/internal/trunking/site.go
@@ -13,12 +13,13 @@ import (
 type Protocol uint8
 
 const (
-	ProtocolUnknown Protocol = iota
-	ProtocolP25              // P25 Phase 1 / Phase 2
-	ProtocolDMR              // DMR Tier II / III
-	ProtocolNXDN             // NXDN
-	ProtocolDPMR             // dPMR Mode 3 (digital PMR446 trunking)
-	ProtocolEDACS            // EDACS / GE-Marc
+	ProtocolUnknown  Protocol = iota
+	ProtocolP25               // P25 Phase 1 / Phase 2
+	ProtocolDMR               // DMR Tier II / III
+	ProtocolNXDN              // NXDN
+	ProtocolDPMR              // dPMR Mode 3 (digital PMR446 trunking)
+	ProtocolEDACS             // EDACS / GE-Marc
+	ProtocolMotorola          // Motorola Type II / SmartZone
 )
 
 func (p Protocol) String() string {
@@ -33,13 +34,15 @@ func (p Protocol) String() string {
 		return "dpmr"
 	case ProtocolEDACS:
 		return "edacs"
+	case ProtocolMotorola:
+		return "motorola"
 	default:
 		return "unknown"
 	}
 }
 
 // ParseProtocol maps a string ("p25", "dmr", "nxdn", "dpmr",
-// "edacs") to a Protocol value.
+// "edacs", "motorola") to a Protocol value.
 func ParseProtocol(s string) (Protocol, error) {
 	switch strings.ToLower(s) {
 	case "p25":
@@ -52,6 +55,8 @@ func ParseProtocol(s string) (Protocol, error) {
 		return ProtocolDPMR, nil
 	case "edacs":
 		return ProtocolEDACS, nil
+	case "motorola":
+		return ProtocolMotorola, nil
 	default:
 		return ProtocolUnknown, fmt.Errorf("trunking: unknown protocol %q", s)
 	}
@@ -74,7 +79,7 @@ func (s System) Validate() error {
 		return errors.New("trunking: system name is required")
 	}
 	if s.Protocol == ProtocolUnknown {
-		return errors.New("trunking: protocol must be p25|dmr|nxdn|dpmr|edacs")
+		return errors.New("trunking: protocol must be p25|dmr|nxdn|dpmr|edacs|motorola")
 	}
 	if len(s.ControlChannels) == 0 {
 		return errors.New("trunking: at least one control_channel frequency is required")


### PR DESCRIPTION
## Summary

Fourth of the per-protocol `ControlChannel.Process(stream, baseIdx)`
adapter follow-ups.

Closes the IQ → CC sync layer for **Motorola Type II / SmartZone**.
The receiver's `BitSink` forwards bits into
`motorola.ControlChannel.Process`, which:

- Buffers cross-call state via an internal countdown + partial
  OSW slice.
- Runs the 24-bit outbound `SyncDetector` across each incoming
  chunk.
- On each sync match collects 32 bits.
- Hands the 32 bits to `OSWFromBits` + the parsed OSW to the
  existing `Ingest` path, which publishes
  `events.KindCCLocked` on a System ID announcement and
  `events.KindGrant` on voice-grant opcodes.

## Daemon-level changes

- **`trunking.Protocol`** gains `ProtocolMotorola` (config string
  `"motorola"`). `ParseProtocol` + `String` + `Validate` recognise
  the new value.
- **`ccdecoder/pipelines.go`** gains `newMotorolaPipeline` +
  `motorolaPipeline` wrapper, plus a row in the `factories` map.

## Deferred to a follow-up

The on-air OSW is protected by BCH(64,16,11) FEC + a de-
interleaving stage that this adapter doesn't reverse. The adapter
reads 32 information bits straight out of the wire, which works
for test fixtures + clean signals but typically fails on noisy
on-air captures.

## Test plan

- [x] `go test ./internal/radio/motorola/... -race -v`
- [x] `go test ./internal/scanner/ccdecoder/... ./internal/trunking/... -race`
- [x] `go build ./...`
- [x] `go vet ./...`

New tests cover:
- A 30-bit-padded sync + valid `OpGroupVoiceChannelGrant` OSW
  triggers a `KindGrant` with the right System / Protocol /
  GroupID.
- Garbage without a sync produces no events.
- Sync arriving in chunk N + payload in chunk N+1 still decodes
  cleanly.
- `SyncDetector.Reset` clears `primed` + `pos`.
- ccdecoder smoke construction of the new Motorola factory.

## README

- "Status & known gaps" updated — Motorola moves to "works today
  (sync + OSW only)"; BCH FEC + de-interleaving flagged as the
  follow-up. 5 protocols still pending adapters.
- "Recently shipped" gains a bullet for the Motorola adapter +
  factory wiring + FEC deferral.


---
_Generated by [Claude Code](https://claude.ai/code/session_019dtCCVEZJTKKr6YK3wy824)_