### PR TITLE
internal/radio/ltr: ControlChannel.Process adapter + ccdecoder factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,14 +70,16 @@ panel. The honest remaining gaps:
   Live trunked reception works today for P25 Phase 1, YSF, dPMR
   Mode 3, NXDN (FSW + LICH only; CAC FEC pending), EDACS /
   GE-Marc (24-bit sync + 40-bit CCW only; interleaved-RS FEC
-  pending), and Motorola Type II / SmartZone (24-bit sync +
-  32-bit OSW only; BCH(64,16,11) FEC pending). DMR / MPT 1327 /
-  LTR / P25 P2 / TETRA each have IQ → symbol receivers shipping
-  but their CC state machines still consume pre-parsed PDUs;
-  adding the `Process(stream, baseIdx)` adapter on each (sync
-  detect → frame slice → existing parser → Ingest) lights up
-  the rest. The adapter shape is ~30–50 lines per protocol and
-  documented per-receiver in the relevant PR descriptions.
+  pending), Motorola Type II / SmartZone (24-bit sync + 32-bit
+  OSW only; BCH(64,16,11) FEC pending), and LTR (41-bit Status
+  alignment + state-machine dedup only; FCS verification +
+  Manchester decoding pending). DMR / MPT 1327 / P25 P2 / TETRA
+  each have IQ → symbol receivers shipping but their CC state
+  machines still consume pre-parsed PDUs; adding the
+  `Process(stream, baseIdx)` adapter on each (sync detect →
+  frame slice → existing parser → Ingest) lights up the rest.
+  The adapter shape is ~30–50 lines per protocol and documented
+  per-receiver in the relevant PR descriptions.
 - **Digital-voice level calibration.** Pure-Go IMBE / AMBE+2 emit
   real audio end-to-end with shared AGC, frame-repeat on bad-frame
   indicator, phase-aware fade-in, and §6.2 spectral enhancement
@@ -144,6 +146,21 @@ to its own package and lands independently.
 
 ### Recently shipped
 
+- **LTR `ControlChannel.Process(stream, baseIdx)` adapter +
+  ccdecoder factory.** Closes the IQ → CC alignment layer for
+  LTR: the receiver's `BitSink` forwards sub-audible bits into
+  `ltr.ControlChannel.Process`, which buffers across calls,
+  slides a 41-bit window over the stream, commits to the first
+  position whose Sync bit is set, and follows the alignment
+  forward — unlocking + re-searching if a subsequent frame's
+  Sync bit drops to 0. Each successfully-aligned Status word is
+  dispatched into the existing `Ingest` path. `trunking.Protocol`
+  gains `ProtocolLTR` (config string `"ltr"`). FCS verification
+  over the 12-bit trailer + Manchester decoding of the on-air
+  bit stream are documented follow-ups; until they land the
+  adapter is honest about its noise floor (spurious alignments
+  drop through the state machine's Area / activeGroup dedup,
+  correctly-aligned frames drive cc.locked + grants).
 - **Motorola Type II `ControlChannel.Process(stream, baseIdx)`
   adapter + ccdecoder factory.** Closes the IQ → CC sync layer
   for Motorola: the receiver's `BitSink` forwards bits into

--- a/internal/radio/ltr/control.go
+++ b/internal/radio/ltr/control.go
@@ -40,6 +40,10 @@ type ControlChannel struct {
 	expectedArea uint8
 	areaSet      bool
 
+	// proc is the cross-call bit buffer the Process adapter uses
+	// (see process.go). Lazily constructed on the first Process call.
+	proc *processState
+
 	mu     sync.Mutex
 	locked bool
 	last   LockState

--- a/internal/radio/ltr/process.go
+++ b/internal/radio/ltr/process.go
@@ -1,0 +1,98 @@
+package ltr
+
+// processState is the cross-call bit buffering + frame-alignment
+// state the Process adapter holds. Lazily initialised.
+type processState struct {
+	buf []byte
+	// aligned is true once we've committed to a 41-bit frame
+	// boundary. Locked alignment processes frames at fixed
+	// statusBits offsets; an unexpected Sync=0 at the boundary
+	// unlocks and triggers a fresh search.
+	aligned bool
+	// off is the cursor into buf. While unaligned it's the next
+	// bit to test for Sync=1; while aligned it's the next frame
+	// start. Buffer trimming happens after each Process call so
+	// off resets to 0.
+	off int
+}
+
+// statusBits is the on-air length of one LTR Status word (41 bits)
+// transmitted continuously at 300 bps under the in-band voice. The
+// MSB of every word is the Sync bit (always 1) — there is no
+// separate sync pattern preceding each word.
+const statusBits = 41
+
+// Process consumes a window of raw bits from the LTR receiver (the
+// IQ → sub-audible bit chain in internal/radio/ltr/receiver/) and
+// drives the LTR state machine.
+//
+// LTR has no fixed sync pattern that frames Status words on the
+// wire — instead every word starts with a Sync bit (always 1)
+// and frames run back-to-back. The adapter searches the buffered
+// stream for the first Sync=1 position, commits to that 41-bit
+// alignment, and follows it forward. If a subsequent frame's
+// Sync bit is 0 the alignment unlocks and the search restarts.
+// Per-Status fields (Area, Group, GroupID, …) are validated by
+// the state machine's Ingest method via its Sync + Area filters
+// and the activeGroup dedup.
+//
+// baseIdx is the absolute bit index of bits[0] across the stream
+// lifetime; the adapter doesn't use it directly today.
+//
+// FCS (12-bit trailer) verification and Manchester de-encoding of
+// the on-air bit stream are documented follow-ups; until they
+// ship the adapter is honest about its noise floor — false
+// alignment leads to spurious Ingest calls that the state
+// machine silently drops, and a small fraction of correctly-
+// aligned frames drive cc.locked + grant publication.
+func (c *ControlChannel) Process(bits []byte, baseIdx int) int {
+	if c.proc == nil {
+		c.proc = &processState{}
+	}
+	p := c.proc
+	p.buf = append(p.buf, bits...)
+
+	for {
+		if !p.aligned {
+			// Slide forward until we find a Sync=1 with room
+			// for the rest of the 41-bit window.
+			for p.off+statusBits <= len(p.buf) && p.buf[p.off] != 1 {
+				p.off++
+			}
+			if p.off+statusBits > len(p.buf) {
+				break
+			}
+			st, _ := StatusFromBits(p.buf[p.off : p.off+statusBits])
+			c.Ingest(st)
+			p.aligned = true
+			p.off += statusBits
+			continue
+		}
+		// Aligned: pull the next frame at the fixed offset.
+		if p.off+statusBits > len(p.buf) {
+			break
+		}
+		window := p.buf[p.off : p.off+statusBits]
+		if window[0] != 1 {
+			// Sync invariant broken — unlock and re-search.
+			p.aligned = false
+			continue
+		}
+		st, _ := StatusFromBits(window)
+		c.Ingest(st)
+		p.off += statusBits
+	}
+
+	// Trim consumed bits from the front. Keeps any partial frame
+	// (or unconsumed search prefix) for the next call.
+	if p.off > 0 {
+		drop := p.off
+		if drop > len(p.buf) {
+			drop = len(p.buf)
+		}
+		copy(p.buf, p.buf[drop:])
+		p.buf = p.buf[:len(p.buf)-drop]
+		p.off = 0
+	}
+	return baseIdx + len(bits)
+}

--- a/internal/radio/ltr/process_test.go
+++ b/internal/radio/ltr/process_test.go
@@ -1,0 +1,151 @@
+package ltr
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// TestProcessLocksOnFirstStatusWord: build a bit stream of three
+// back-to-back LTR Status words, run Process, and assert the
+// state machine publishes a KindCCLocked carrying the first
+// word's Area + Home.
+func TestProcessLocksOnFirstStatusWord(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{
+		Bus:         bus,
+		Log:         slog.Default(),
+		SystemName:  "Sys",
+		FrequencyHz: 935_012_500,
+	})
+
+	// Three idle frames in a row (Group=false, GroupID=0).
+	idle := Status{Sync: true, Area: 7, Channel: 3, Home: 4, Free: 5}
+	stream := append([]byte{}, StatusBits(idle)...)
+	stream = append(stream, StatusBits(idle)...)
+	stream = append(stream, StatusBits(idle)...)
+
+	cc.Process(stream, 0)
+
+	var lockState LockState
+	var sawLock bool
+	for !sawLock {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind == events.KindCCLocked {
+				lockState, _ = ev.Payload.(LockState)
+				sawLock = true
+			}
+		default:
+			t.Fatalf("Process did not publish a KindCCLocked")
+		}
+	}
+	if lockState.FrequencyHz != 935_012_500 {
+		t.Errorf("LockState.FrequencyHz = %d, want 935012500", lockState.FrequencyHz)
+	}
+	if lockState.Area != 7 {
+		t.Errorf("LockState.Area = %d, want 7", lockState.Area)
+	}
+	if lockState.Repeater != 4 {
+		t.Errorf("LockState.Repeater = %d, want 4", lockState.Repeater)
+	}
+}
+
+// TestProcessPublishesGrantOnActiveStatus: an active Status word
+// (Group=true, GroupID != 0) must trigger a KindGrant on the bus.
+func TestProcessPublishesGrantOnActiveStatus(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{
+		Bus:         bus,
+		Log:         slog.Default(),
+		SystemName:  "Sys",
+		FrequencyHz: 935_012_500,
+	})
+
+	active := Status{
+		Sync:    true,
+		Area:    7,
+		Group:   true,
+		Channel: 3,
+		Home:    4,
+		GroupID: 0x42,
+	}
+	stream := append([]byte{}, StatusBits(active)...)
+	stream = append(stream, StatusBits(active)...) // dedup test
+	cc.Process(stream, 0)
+
+	grants := 0
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind == events.KindGrant {
+				g, ok := ev.Payload.(trunking.Grant)
+				if !ok {
+					t.Fatalf("Grant payload type = %T", ev.Payload)
+				}
+				if g.System != "Sys" {
+					t.Errorf("Grant.System = %q", g.System)
+				}
+				if g.Protocol != "ltr" {
+					t.Errorf("Grant.Protocol = %q, want ltr", g.Protocol)
+				}
+				if g.GroupID != 0x42 {
+					t.Errorf("Grant.GroupID = %#x", g.GroupID)
+				}
+				grants++
+			}
+		default:
+			if grants == 0 {
+				t.Errorf("Process did not publish a KindGrant for an active Status")
+			}
+			if grants > 1 {
+				t.Errorf("Process published %d Grants for one call; activeGroup dedup broke", grants)
+			}
+			return
+		}
+	}
+}
+
+// TestProcessHandlesFrameSpanningCalls: a Status word that
+// straddles a chunk boundary still drives Ingest after the second
+// Process call delivers the trailing bits.
+func TestProcessHandlesFrameSpanningCalls(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, Log: slog.Default(), SystemName: "Sys"})
+
+	idle := Status{Sync: true, Area: 1, Channel: 2, Home: 3}
+	bits := StatusBits(idle)
+
+	// Split the 41-bit frame at offset 20.
+	cc.Process(bits[:20], 0)
+	cc.Process(bits[20:], 20)
+
+	var sawLock bool
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind == events.KindCCLocked {
+				sawLock = true
+			}
+		default:
+			if !sawLock {
+				t.Errorf("Process did not publish a KindCCLocked across the chunk boundary")
+			}
+			return
+		}
+	}
+}

--- a/internal/scanner/ccdecoder/decoder_test.go
+++ b/internal/scanner/ccdecoder/decoder_test.go
@@ -269,6 +269,23 @@ func TestP25Phase1FactoryConstructs(t *testing.T) {
 	}
 }
 
+func TestLTRFactoryConstructs(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	p, err := newLTRPipeline(PipelineOptions{
+		Bus: bus, SystemName: "Smoke",
+		FrequencyHz: 935_012_500, SampleRateHz: 48_000,
+	})
+	if err != nil {
+		t.Fatalf("newLTRPipeline: %v", err)
+	}
+	p.Process(make([]complex64, 4800))
+	p.Reset()
+	if err := p.Close(); err != nil {
+		t.Errorf("Close: %v", err)
+	}
+}
+
 func TestMotorolaFactoryConstructs(t *testing.T) {
 	bus := events.NewBus(8)
 	defer bus.Close()

--- a/internal/scanner/ccdecoder/pipelines.go
+++ b/internal/scanner/ccdecoder/pipelines.go
@@ -8,6 +8,8 @@ import (
 	dpmrrx "github.com/MattCheramie/GopherTrunk/internal/radio/dpmr/receiver"
 	"github.com/MattCheramie/GopherTrunk/internal/radio/edacs"
 	edacsrx "github.com/MattCheramie/GopherTrunk/internal/radio/edacs/receiver"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/ltr"
+	ltrrx "github.com/MattCheramie/GopherTrunk/internal/radio/ltr/receiver"
 	"github.com/MattCheramie/GopherTrunk/internal/radio/motorola"
 	motorolarx "github.com/MattCheramie/GopherTrunk/internal/radio/motorola/receiver"
 	"github.com/MattCheramie/GopherTrunk/internal/radio/nxdn"
@@ -71,6 +73,7 @@ var factories = map[trunking.Protocol]PipelineFactory{
 	trunking.ProtocolNXDN:     newNXDNPipeline,
 	trunking.ProtocolEDACS:    newEDACSPipeline,
 	trunking.ProtocolMotorola: newMotorolaPipeline,
+	trunking.ProtocolLTR:      newLTRPipeline,
 }
 
 // newP25Phase1Pipeline wires the existing
@@ -257,3 +260,35 @@ type motorolaPipeline struct {
 func (p *motorolaPipeline) Process(iq []complex64) { p.rx.Process(iq) }
 func (p *motorolaPipeline) Reset()                  { p.rx.Reset() }
 func (p *motorolaPipeline) Close() error            { return nil }
+
+// newLTRPipeline wires internal/radio/ltr/receiver into
+// ltr.ControlChannel.Process. The receiver's BitSink forwards
+// sub-audible bits into the state machine, which slides a 41-bit
+// window across the stream, commits to the first Sync=1 alignment
+// it finds, and dispatches each Status word into the existing
+// Ingest path. FCS validation + Manchester decoding are
+// follow-ups.
+func newLTRPipeline(opts PipelineOptions) (ProtocolPipeline, error) {
+	cc := ltr.New(ltr.Options{
+		Bus:         opts.Bus,
+		Log:         opts.Log,
+		SystemName:  opts.SystemName,
+		FrequencyHz: opts.FrequencyHz,
+	})
+	rx := ltrrx.New(ltrrx.Options{
+		SampleRateHz: opts.SampleRateHz,
+		BitSink: func(bits []byte, baseIdx int) {
+			cc.Process(bits, baseIdx)
+		},
+	})
+	return &ltrPipeline{rx: rx, cc: cc}, nil
+}
+
+type ltrPipeline struct {
+	rx *ltrrx.Receiver
+	cc *ltr.ControlChannel
+}
+
+func (p *ltrPipeline) Process(iq []complex64) { p.rx.Process(iq) }
+func (p *ltrPipeline) Reset()                  { p.rx.Reset() }
+func (p *ltrPipeline) Close() error            { return nil }

--- a/internal/trunking/site.go
+++ b/internal/trunking/site.go
@@ -20,6 +20,7 @@ const (
 	ProtocolDPMR              // dPMR Mode 3 (digital PMR446 trunking)
 	ProtocolEDACS             // EDACS / GE-Marc
 	ProtocolMotorola          // Motorola Type II / SmartZone
+	ProtocolLTR               // Logic Trunked Radio (LTR / LTR-Net)
 )
 
 func (p Protocol) String() string {
@@ -36,13 +37,15 @@ func (p Protocol) String() string {
 		return "edacs"
 	case ProtocolMotorola:
 		return "motorola"
+	case ProtocolLTR:
+		return "ltr"
 	default:
 		return "unknown"
 	}
 }
 
 // ParseProtocol maps a string ("p25", "dmr", "nxdn", "dpmr",
-// "edacs", "motorola") to a Protocol value.
+// "edacs", "motorola", "ltr") to a Protocol value.
 func ParseProtocol(s string) (Protocol, error) {
 	switch strings.ToLower(s) {
 	case "p25":
@@ -57,6 +60,8 @@ func ParseProtocol(s string) (Protocol, error) {
 		return ProtocolEDACS, nil
 	case "motorola":
 		return ProtocolMotorola, nil
+	case "ltr":
+		return ProtocolLTR, nil
 	default:
 		return ProtocolUnknown, fmt.Errorf("trunking: unknown protocol %q", s)
 	}
@@ -79,7 +84,7 @@ func (s System) Validate() error {
 		return errors.New("trunking: system name is required")
 	}
 	if s.Protocol == ProtocolUnknown {
-		return errors.New("trunking: protocol must be p25|dmr|nxdn|dpmr|edacs|motorola")
+		return errors.New("trunking: protocol must be p25|dmr|nxdn|dpmr|edacs|motorola|ltr")
 	}
 	if len(s.ControlChannels) == 0 {
 		return errors.New("trunking: at least one control_channel frequency is required")


### PR DESCRIPTION
## Summary

Fifth of the per-protocol `ControlChannel.Process(stream, baseIdx)`
adapter follow-ups.

Closes the IQ → CC alignment layer for **LTR**. LTR is unique
among the trunked protocols: there is **no fixed sync pattern**,
just a Sync bit at the MSB of every 41-bit Status word
transmitted continuously at 300 bps under the in-band voice.

The adapter:

- Buffers cross-call bits.
- While unaligned, slides forward looking for any position whose
  first bit (Status word's Sync field) is 1.
- Commits to that 41-bit alignment, parses + `Ingest`s the
  Status, follows the alignment at fixed offsets.
- Unlocks + restarts the search if a subsequent frame's Sync bit
  drops to 0.

Per-frame validity is enforced by the state machine: `Sync = 1`
check, optional `Area` filter, `activeGroup` dedup so repeated
status words during one call don't republish a Grant on every
frame.

## Daemon-level changes

- **`trunking.Protocol`** gains `ProtocolLTR` (config string
  `"ltr"`). `ParseProtocol` + `String` + `Validate` recognise
  the new value.
- **`ccdecoder/pipelines.go`** gains `newLTRPipeline` +
  `ltrPipeline` wrapper, plus a row in the `factories` map.

## Deferred to follow-ups

- **FCS verification** over the 12-bit trailer (the Status word
  parser doesn't validate it today).
- **Manchester decoding** of the on-air bit stream (some LTR
  variants encode the sub-audible bits bi-phase).

Until those land the adapter is honest about its noise floor:
spurious alignments drop through the state machine's filters,
correctly-aligned frames drive `cc.locked` + grants.

## Test plan

- [x] `go test ./internal/radio/ltr/... -race -v`
- [x] `go test ./internal/scanner/ccdecoder/... ./internal/trunking/... -race`
- [x] `go build ./...`
- [x] `go vet ./...`

New tests cover:
- Three back-to-back idle Status words drive a single
  `KindCCLocked` with the right `FrequencyHz` / `Area` /
  `Repeater`.
- An active Status (`Group=true`, `GroupID != 0`) publishes a
  `KindGrant`; a duplicate active Status is deduped.
- A Status word that straddles a chunk boundary still drives
  `KindCCLocked` after the trailing bits arrive in the next
  `Process` call.
- ccdecoder smoke construction of the new LTR factory.

## README

- "Status & known gaps" updated — LTR moves to "works today
  (sync alignment + state-machine dedup only)"; FCS + Manchester
  flagged as follow-ups. 4 protocols still pending adapters.
- "Recently shipped" gains a bullet for the LTR adapter +
  factory wiring + deferral list.


---
_Generated by [Claude Code](https://claude.ai/code/session_019dtCCVEZJTKKr6YK3wy824)_