### PR TITLE
internal/radio/mpt1327: ControlChannel.Process adapter + ccdecoder factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,9 +71,11 @@ panel. The honest remaining gaps:
   Mode 3, NXDN (FSW + LICH only; CAC FEC pending), EDACS /
   GE-Marc (24-bit sync + 40-bit CCW only; interleaved-RS FEC
   pending), Motorola Type II / SmartZone (24-bit sync + 32-bit
-  OSW only; BCH(64,16,11) FEC pending), and LTR (41-bit Status
+  OSW only; BCH(64,16,11) FEC pending), LTR (41-bit Status
   alignment + state-machine dedup only; FCS verification +
-  Manchester decoding pending). DMR / MPT 1327 / P25 P2 / TETRA
+  Manchester decoding pending), and MPT 1327 (38-bit codeword
+  alignment with auto-unlock on unrecognised-codeword runs;
+  64-bit on-air BCH(63,38) FEC pending). DMR / P25 P2 / TETRA
   each have IQ → symbol receivers shipping but their CC state
   machines still consume pre-parsed PDUs; adding the
   `Process(stream, baseIdx)` adapter on each (sync detect →
@@ -146,6 +148,20 @@ to its own package and lands independently.
 
 ### Recently shipped
 
+- **MPT 1327 `ControlChannel.Process(stream, baseIdx)` adapter +
+  ccdecoder factory.** Closes the IQ → CC alignment layer for
+  MPT 1327: the receiver's `BitSink` forwards FFSK bits into
+  `mpt1327.ControlChannel.Process`, which slides a 38-bit window
+  over the stream, commits to the first window that parses as a
+  recognised Address codeword (Aloha / AhoyChan / GoToChan /
+  Ack / Disconnect / Data / Emergency), follows the alignment
+  forward, and auto-unlocks + re-searches after 8 consecutive
+  frames whose codeword fails the recognised-codeword check.
+  `trunking.Protocol` gains `ProtocolMPT1327` (config string
+  `"mpt1327"`). The 64-bit on-air BCH(63,38) FEC + de-
+  interleaving are documented follow-ups; until they land the
+  adapter works on noise-free test fixtures but typically fails
+  to lock on captured MPT 1327 traffic.
 - **LTR `ControlChannel.Process(stream, baseIdx)` adapter +
   ccdecoder factory.** Closes the IQ → CC alignment layer for
   LTR: the receiver's `BitSink` forwards sub-audible bits into

--- a/internal/radio/mpt1327/control.go
+++ b/internal/radio/mpt1327/control.go
@@ -31,6 +31,11 @@ type ControlChannel struct {
 	resolver   Resolver
 	now        func() time.Time
 
+	// proc is the cross-call bit / alignment state the Process
+	// adapter uses (see process.go). Lazily constructed on the
+	// first Process call.
+	proc *processState
+
 	mu     sync.Mutex
 	locked bool
 	last   LockState

--- a/internal/radio/mpt1327/process.go
+++ b/internal/radio/mpt1327/process.go
@@ -1,0 +1,126 @@
+package mpt1327
+
+// processState is the cross-call bit buffering + frame-alignment
+// state the Process adapter holds. Lazily initialised.
+type processState struct {
+	buf       []byte
+	aligned   bool
+	off       int
+	consecBad int
+}
+
+// codewordInfoBits is the count of MPT 1327 address-codeword
+// information bits — 38. On-air codewords are 64 bits (38 info +
+// 26 BCH(63,38) parity); the BCH FEC is consumed upstream and
+// isn't implemented in this package yet (documented follow-up).
+const codewordInfoBits = 38
+
+// maxConsecBad is how many consecutive recognised-codeword-failed
+// frames the adapter tolerates while aligned before unlocking and
+// re-searching. Long quiet periods + the occasional bit error keep
+// the threshold modest.
+const maxConsecBad = 8
+
+// Process consumes a window of raw bits from the MPT 1327 receiver
+// (the IQ → FFSK bit chain in internal/radio/mpt1327/receiver/) and
+// drives the MPT 1327 state machine.
+//
+// MPT 1327 has no fixed inter-codeword sync pattern — codewords
+// flow back-to-back at 1200 bps. The adapter searches the buffered
+// stream for the first 38-bit window that parses as a recognised
+// Address codeword (Aloha / AhoyChan / GoToChan), commits to that
+// alignment, and follows it forward — unlocking + restarting the
+// search after maxConsecBad consecutive frames whose Type or Kind
+// fail the recognised-codeword check.
+//
+// baseIdx is the absolute bit index of bits[0] across the stream
+// lifetime; the adapter doesn't use it directly today.
+//
+// The 64-bit on-air codeword + BCH(63,38) FEC isn't reversed
+// here — the adapter reads 38 info bits straight from the wire.
+// Real on-air signals require the BCH layer (a documented
+// follow-up); until it ships the adapter sync-aligns on noise-
+// free test fixtures but typically fails to lock on captured
+// MPT 1327 traffic.
+func (c *ControlChannel) Process(bits []byte, baseIdx int) int {
+	if c.proc == nil {
+		c.proc = &processState{}
+	}
+	p := c.proc
+	p.buf = append(p.buf, bits...)
+
+	for {
+		if !p.aligned {
+			// Search forward for a recognised Address codeword.
+			found := false
+			for ; p.off+codewordInfoBits <= len(p.buf); p.off++ {
+				w, _ := CodewordFromBits(p.buf[p.off : p.off+codewordInfoBits])
+				if !isRecognisedAddressCodeword(w) {
+					continue
+				}
+				c.Ingest(w)
+				p.aligned = true
+				p.off += codewordInfoBits
+				p.consecBad = 0
+				found = true
+				break
+			}
+			if !found {
+				break
+			}
+			continue
+		}
+		// Aligned: pull next frame at fixed offset.
+		if p.off+codewordInfoBits > len(p.buf) {
+			break
+		}
+		w, _ := CodewordFromBits(p.buf[p.off : p.off+codewordInfoBits])
+		c.Ingest(w)
+		if isRecognisedAddressCodeword(w) {
+			p.consecBad = 0
+		} else {
+			p.consecBad++
+			if p.consecBad >= maxConsecBad {
+				p.aligned = false
+				p.consecBad = 0
+				// Re-search starts at the position AFTER the
+				// failed frame so we don't immediately re-lock to
+				// the same bad alignment.
+				p.off++
+				continue
+			}
+		}
+		p.off += codewordInfoBits
+	}
+
+	// Trim consumed bits from the front, keeping the unconsumed
+	// tail so a frame straddling a chunk boundary still parses on
+	// the next call.
+	if p.off > 0 {
+		drop := p.off
+		if drop > len(p.buf) {
+			drop = len(p.buf)
+		}
+		copy(p.buf, p.buf[drop:])
+		p.buf = p.buf[:len(p.buf)-drop]
+		p.off = 0
+	}
+	return baseIdx + len(bits)
+}
+
+// isRecognisedAddressCodeword reports whether a parsed Codeword is
+// an Address codeword (Type=0) whose Kind matches one of the
+// trunking-relevant opcodes the state machine acts on. Used as
+// the alignment discriminator since MPT 1327 has no fixed sync
+// pattern.
+func isRecognisedAddressCodeword(w Codeword) bool {
+	if w.Type != TypeAddress {
+		return false
+	}
+	switch w.Kind() {
+	case KindAloha, KindAhoy, KindAhoyChan, KindGoToChan,
+		KindAck, KindDisconnect, KindData, KindEmergency:
+		return true
+	}
+	return false
+}

--- a/internal/radio/mpt1327/process_test.go
+++ b/internal/radio/mpt1327/process_test.go
@@ -1,0 +1,130 @@
+package mpt1327
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+func gtcCodeword(prefix uint8, ident uint16, channel uint16) Codeword {
+	return Codeword{
+		Type:     TypeAddress,
+		Prefix:   prefix,
+		Ident:    ident,
+		Function: (uint32(KindGoToChan) << 13) | uint32(channel&0x1FFF),
+	}
+}
+
+func alohaCodeword(prefix uint8) Codeword {
+	return Codeword{
+		Type:     TypeAddress,
+		Prefix:   prefix,
+		Function: uint32(KindAloha) << 13,
+	}
+}
+
+// TestProcessLocksOnFirstAlohaAndDecodesGTC: build a back-to-back
+// stream of (Aloha, GoToChannel) codewords. The state machine must
+// lock on the Aloha and publish a Grant for the GoToChannel.
+func TestProcessLocksOnFirstAlohaAndDecodesGTC(t *testing.T) {
+	bus := events.NewBus(16)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{
+		Bus:         bus,
+		Log:         slog.Default(),
+		SystemName:  "Sys",
+		FrequencyHz: 169_212_500,
+	})
+
+	aloha := alohaCodeword(0x5)
+	gtc := gtcCodeword(0x5, 0x123, 7)
+
+	stream := append([]byte{}, CodewordBits(aloha)...)
+	stream = append(stream, CodewordBits(gtc)...)
+
+	cc.Process(stream, 0)
+
+	var sawLock, sawGrant bool
+	for {
+		select {
+		case ev := <-sub.C:
+			switch ev.Kind {
+			case events.KindCCLocked:
+				ls, _ := ev.Payload.(LockState)
+				if ls.Prefix != 0x5 {
+					t.Errorf("LockState.Prefix = %d, want 5", ls.Prefix)
+				}
+				sawLock = true
+			case events.KindGrant:
+				g, _ := ev.Payload.(trunking.Grant)
+				if g.Protocol != "mpt1327" {
+					t.Errorf("Grant.Protocol = %q, want mpt1327", g.Protocol)
+				}
+				if g.ChannelNum != 7 {
+					t.Errorf("Grant.ChannelNum = %d, want 7", g.ChannelNum)
+				}
+				sawGrant = true
+			}
+		default:
+			if !sawLock {
+				t.Errorf("Process did not publish a KindCCLocked")
+			}
+			if !sawGrant {
+				t.Errorf("Process did not publish a KindGrant for the GTC codeword")
+			}
+			return
+		}
+	}
+}
+
+// TestProcessHandlesCodewordSpanningCalls: an Aloha codeword split
+// across two Process calls still locks the channel.
+func TestProcessHandlesCodewordSpanningCalls(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, Log: slog.Default(), SystemName: "Sys"})
+
+	bits := CodewordBits(alohaCodeword(0x3))
+	cc.Process(bits[:20], 0)
+	cc.Process(bits[20:], 20)
+
+	var sawLock bool
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind == events.KindCCLocked {
+				sawLock = true
+			}
+		default:
+			if !sawLock {
+				t.Errorf("Process did not publish a KindCCLocked across the chunk boundary")
+			}
+			return
+		}
+	}
+}
+
+// TestIsRecognisedAddressCodeword: Data codewords and unknown
+// kinds are rejected; recognised Address codewords are accepted.
+func TestIsRecognisedAddressCodeword(t *testing.T) {
+	if isRecognisedAddressCodeword(Codeword{Type: TypeData}) {
+		t.Errorf("Data codeword should not be recognised")
+	}
+	if isRecognisedAddressCodeword(Codeword{Type: TypeAddress, Function: 0}) {
+		t.Errorf("Address codeword with KindUnknown should not be recognised")
+	}
+	if !isRecognisedAddressCodeword(alohaCodeword(0)) {
+		t.Errorf("Aloha codeword should be recognised")
+	}
+	if !isRecognisedAddressCodeword(gtcCodeword(0, 0, 0)) {
+		t.Errorf("GoToChannel codeword should be recognised")
+	}
+}

--- a/internal/scanner/ccdecoder/decoder_test.go
+++ b/internal/scanner/ccdecoder/decoder_test.go
@@ -269,6 +269,23 @@ func TestP25Phase1FactoryConstructs(t *testing.T) {
 	}
 }
 
+func TestMPT1327FactoryConstructs(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	p, err := newMPT1327Pipeline(PipelineOptions{
+		Bus: bus, SystemName: "Smoke",
+		FrequencyHz: 169_212_500, SampleRateHz: 48_000,
+	})
+	if err != nil {
+		t.Fatalf("newMPT1327Pipeline: %v", err)
+	}
+	p.Process(make([]complex64, 4800))
+	p.Reset()
+	if err := p.Close(); err != nil {
+		t.Errorf("Close: %v", err)
+	}
+}
+
 func TestLTRFactoryConstructs(t *testing.T) {
 	bus := events.NewBus(8)
 	defer bus.Close()

--- a/internal/scanner/ccdecoder/pipelines.go
+++ b/internal/scanner/ccdecoder/pipelines.go
@@ -12,6 +12,8 @@ import (
 	ltrrx "github.com/MattCheramie/GopherTrunk/internal/radio/ltr/receiver"
 	"github.com/MattCheramie/GopherTrunk/internal/radio/motorola"
 	motorolarx "github.com/MattCheramie/GopherTrunk/internal/radio/motorola/receiver"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/mpt1327"
+	mpt1327rx "github.com/MattCheramie/GopherTrunk/internal/radio/mpt1327/receiver"
 	"github.com/MattCheramie/GopherTrunk/internal/radio/nxdn"
 	nxdnrx "github.com/MattCheramie/GopherTrunk/internal/radio/nxdn/receiver"
 	p25phase1 "github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase1"
@@ -74,6 +76,7 @@ var factories = map[trunking.Protocol]PipelineFactory{
 	trunking.ProtocolEDACS:    newEDACSPipeline,
 	trunking.ProtocolMotorola: newMotorolaPipeline,
 	trunking.ProtocolLTR:      newLTRPipeline,
+	trunking.ProtocolMPT1327:  newMPT1327Pipeline,
 }
 
 // newP25Phase1Pipeline wires the existing
@@ -292,3 +295,37 @@ type ltrPipeline struct {
 func (p *ltrPipeline) Process(iq []complex64) { p.rx.Process(iq) }
 func (p *ltrPipeline) Reset()                  { p.rx.Reset() }
 func (p *ltrPipeline) Close() error            { return nil }
+
+// newMPT1327Pipeline wires internal/radio/mpt1327/receiver into
+// mpt1327.ControlChannel.Process. The receiver's BitSink forwards
+// FFSK bits into the state machine, which slides a 38-bit window
+// over the stream + commits to the first window that parses as a
+// recognised Address codeword + follows the alignment with an
+// auto-unlock on extended runs of unrecognised codewords. The
+// 64-bit on-air codeword's BCH(63,38) FEC + de-interleaving are
+// follow-ups; without them the adapter works on noise-free test
+// fixtures but typically fails on captured MPT 1327 traffic.
+func newMPT1327Pipeline(opts PipelineOptions) (ProtocolPipeline, error) {
+	cc := mpt1327.New(mpt1327.Options{
+		Bus:         opts.Bus,
+		Log:         opts.Log,
+		SystemName:  opts.SystemName,
+		FrequencyHz: opts.FrequencyHz,
+	})
+	rx := mpt1327rx.New(mpt1327rx.Options{
+		SampleRateHz: opts.SampleRateHz,
+		BitSink: func(bits []byte, baseIdx int) {
+			cc.Process(bits, baseIdx)
+		},
+	})
+	return &mpt1327Pipeline{rx: rx, cc: cc}, nil
+}
+
+type mpt1327Pipeline struct {
+	rx *mpt1327rx.Receiver
+	cc *mpt1327.ControlChannel
+}
+
+func (p *mpt1327Pipeline) Process(iq []complex64) { p.rx.Process(iq) }
+func (p *mpt1327Pipeline) Reset()                  { p.rx.Reset() }
+func (p *mpt1327Pipeline) Close() error            { return nil }

--- a/internal/trunking/site.go
+++ b/internal/trunking/site.go
@@ -21,6 +21,7 @@ const (
 	ProtocolEDACS             // EDACS / GE-Marc
 	ProtocolMotorola          // Motorola Type II / SmartZone
 	ProtocolLTR               // Logic Trunked Radio (LTR / LTR-Net)
+	ProtocolMPT1327           // MPT 1327 (UK / Commonwealth utility trunking)
 )
 
 func (p Protocol) String() string {
@@ -39,13 +40,15 @@ func (p Protocol) String() string {
 		return "motorola"
 	case ProtocolLTR:
 		return "ltr"
+	case ProtocolMPT1327:
+		return "mpt1327"
 	default:
 		return "unknown"
 	}
 }
 
 // ParseProtocol maps a string ("p25", "dmr", "nxdn", "dpmr",
-// "edacs", "motorola", "ltr") to a Protocol value.
+// "edacs", "motorola", "ltr", "mpt1327") to a Protocol value.
 func ParseProtocol(s string) (Protocol, error) {
 	switch strings.ToLower(s) {
 	case "p25":
@@ -62,6 +65,8 @@ func ParseProtocol(s string) (Protocol, error) {
 		return ProtocolMotorola, nil
 	case "ltr":
 		return ProtocolLTR, nil
+	case "mpt1327":
+		return ProtocolMPT1327, nil
 	default:
 		return ProtocolUnknown, fmt.Errorf("trunking: unknown protocol %q", s)
 	}
@@ -84,7 +89,7 @@ func (s System) Validate() error {
 		return errors.New("trunking: system name is required")
 	}
 	if s.Protocol == ProtocolUnknown {
-		return errors.New("trunking: protocol must be p25|dmr|nxdn|dpmr|edacs|motorola|ltr")
+		return errors.New("trunking: protocol must be p25|dmr|nxdn|dpmr|edacs|motorola|ltr|mpt1327")
 	}
 	if len(s.ControlChannels) == 0 {
 		return errors.New("trunking: at least one control_channel frequency is required")


### PR DESCRIPTION
## Summary

Sixth of the per-protocol `ControlChannel.Process(stream, baseIdx)`
adapter follow-ups.

Closes the IQ → CC alignment layer for **MPT 1327**. Like LTR,
MPT 1327 has no fixed inter-codeword sync pattern: codewords flow
back-to-back at 1200 bps. The adapter slides a 38-bit window over
the stream and commits to the first window that parses as a
recognised Address codeword.

The adapter:

- Buffers cross-call bits.
- While unaligned, walks forward looking for any 38-bit window
  whose `Codeword` has `Type=Address` AND a recognised `Kind`
  (Aloha / AhoyChan / GoToChan / Ack / Disconnect / Data /
  Emergency).
- On match, `Ingest`s the codeword + commits to that alignment.
- Follows the alignment at fixed 38-bit offsets, calling
  `Ingest` on every codeword.
- Tracks consecutive unrecognised codewords; after 8 in a row
  unlocks alignment + restarts the search.

## Daemon-level changes

- **`trunking.Protocol`** gains `ProtocolMPT1327` (config string
  `"mpt1327"`). `ParseProtocol` + `String` + `Validate` recognise
  the new value.
- **`ccdecoder/pipelines.go`** gains `newMPT1327Pipeline` +
  `mpt1327Pipeline` wrapper, plus a row in the `factories` map.

## Deferred to a follow-up

The on-air codeword is 64 bits — 38 info + 26 BCH(63,38) parity
+ optional de-interleaving — which this adapter doesn't reverse.
The adapter reads 38 info bits straight from the wire, which works
on test fixtures but typically fails on captured MPT 1327 traffic
where bit errors and the BCH-encoded layout combine.

## Test plan

- [x] `go test ./internal/radio/mpt1327/... -race -v`
- [x] `go test ./internal/scanner/ccdecoder/... ./internal/trunking/... -race`
- [x] `go build ./...`
- [x] `go vet ./...`

New tests cover:
- An `(Aloha, GoToChannel)` codeword pair drives `cc.locked` +
  grant publication with the right Prefix / Protocol /
  ChannelNum.
- A codeword that straddles a chunk boundary still drives
  `cc.locked` after the trailing bits arrive in the next call.
- `isRecognisedAddressCodeword` rejects Data codewords and
  `KindUnknown`; accepts Aloha + GoToChan.
- ccdecoder smoke construction of the new MPT 1327 factory.

## README

- "Status & known gaps" updated — MPT 1327 moves to "works today
  (codeword alignment with auto-unlock)"; BCH(63,38) FEC + de-
  interleaving flagged as follow-ups. 3 protocols still pending
  adapters.
- "Recently shipped" gains a bullet for the MPT 1327 adapter +
  factory wiring + deferral list.


---
_Generated by [Claude Code](https://claude.ai/code/session_019dtCCVEZJTKKr6YK3wy824)_