### PR TITLE
internal/radio/dmr/tier3: ControlChannel.Process adapter + ccdecoder factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,12 +73,14 @@ panel. The honest remaining gaps:
   pending), Motorola Type II / SmartZone (24-bit sync + 32-bit
   OSW only; BCH(64,16,11) FEC pending), LTR (41-bit Status
   alignment + state-machine dedup only; FCS verification +
-  Manchester decoding pending), and MPT 1327 (38-bit codeword
+  Manchester decoding pending), MPT 1327 (38-bit codeword
   alignment with auto-unlock on unrecognised-codeword runs;
-  64-bit on-air BCH(63,38) FEC pending). DMR / P25 P2 / TETRA
-  each have IQ → symbol receivers shipping but their CC state
-  machines still consume pre-parsed PDUs; adding the
-  `Process(stream, baseIdx)` adapter on each (sync detect →
+  64-bit on-air BCH(63,38) FEC pending), and DMR Tier III
+  (multi-pattern 9-sync detect + 132-dibit burst slice +
+  slot-type Hamming(20,8) + BPTC(196,96) → CSBK end-to-end).
+  P25 P2 / TETRA each have IQ → symbol receivers shipping but
+  their CC state machines still consume pre-parsed PDUs; adding
+  the `Process(stream, baseIdx)` adapter on each (sync detect →
   frame slice → existing parser → Ingest) lights up the rest.
   The adapter shape is ~30–50 lines per protocol and documented
   per-receiver in the relevant PR descriptions.
@@ -148,6 +150,20 @@ to its own package and lands independently.
 
 ### Recently shipped
 
+- **DMR Tier III `ControlChannel.Process(stream, baseIdx)` adapter +
+  ccdecoder factory.** Closes the IQ → CC chain for DMR — the
+  most layered protocol in the family. The receiver's `DibitSink`
+  forwards C4FM dibits into the adapter, which buffers across
+  calls + runs `dmr.SyncDetector` against all 9 ETSI sync words
+  in parallel + slices the 132-dibit burst around each match
+  (49-dibit first half + 5-dibit slot type before + 24-dibit
+  sync + 5-dibit slot type after + 49-dibit second half) +
+  parses the slot-type Hamming(20,8) codeword + hands the
+  `(Burst, SlotType)` pair to the existing `IngestBurst`. From
+  there the dmr/tier3 package's BPTC(196,96) + CSBK CRC chain
+  runs end-to-end — no FEC is bypassed for DMR. The adapter
+  retains a 163-dibit cross-call buffer so bursts that straddle
+  chunk boundaries decode correctly.
 - **MPT 1327 `ControlChannel.Process(stream, baseIdx)` adapter +
   ccdecoder factory.** Closes the IQ → CC alignment layer for
   MPT 1327: the receiver's `BitSink` forwards FFSK bits into

--- a/internal/radio/dmr/tier3/control.go
+++ b/internal/radio/dmr/tier3/control.go
@@ -48,6 +48,12 @@ type ControlChannel struct {
 	now        func() time.Time
 	locked     bool
 	last       LockState
+
+	// proc is the cross-call dibit / sync state the Process adapter
+	// uses (see process.go). Lazily constructed on the first
+	// Process call so tests that drive IngestBurst directly don't
+	// pay the construction cost.
+	proc *processState
 }
 
 // Options configure a ControlChannel.

--- a/internal/radio/dmr/tier3/process.go
+++ b/internal/radio/dmr/tier3/process.go
@@ -1,0 +1,121 @@
+package tier3
+
+import (
+	"github.com/MattCheramie/GopherTrunk/internal/radio/dmr"
+)
+
+// burstLookback is the number of dibits the burst extends BEFORE
+// the FSW sync match position. The DMR burst layout puts the
+// 24-dibit sync at offsets 54..77 within the 132-dibit burst; the
+// match index is the position of the LAST sync dibit, so the burst
+// starts 77 dibits behind the match.
+const burstLookback = dmr.HalfPayloadDibits + dmr.SlotTypeDibits + dmr.SyncDibits - 1 // 77
+
+// burstLookahead is the number of dibits the burst extends AFTER
+// the FSW sync match position (5 slot-type + 49 second-half = 54).
+const burstLookahead = dmr.SlotTypeDibits + dmr.HalfPayloadDibits // 54
+
+// bufKeep is the minimum dibit retention so any incoming sync match
+// can look back the full 77 dibits + a small safety margin.
+const bufKeep = burstLookback + burstLookahead + 32 // 163
+
+// processState is the cross-call dibit buffering + sync-detection
+// state the Process adapter holds. Lazily initialised on first use.
+type processState struct {
+	det      *dmr.SyncDetector
+	buf      []uint8
+	bufStart int // absolute dibit index of buf[0]
+	// pending matches whose trailing 54 dibits haven't arrived yet.
+	pending []dmr.Match
+}
+
+// Process consumes a window of raw dibits from the DMR receiver
+// (the IQ → C4FM dibit chain in internal/radio/dmr/receiver/) and
+// drives the Tier III control-channel state machine.
+//
+// On every Process call the adapter:
+//
+//   - Appends the new dibits to its cross-call buffer.
+//   - Runs the multi-pattern SyncDetector against all 9 ETSI
+//     sync words so any burst type (BS / MS / DM, voice / data /
+//     embedded) can be matched.
+//   - Queues each sync hit; processes hits whose trailing 54
+//     dibits are now in the buffer by extracting the 132-dibit
+//     burst, parsing the 20-bit slot-type Hamming(20,8) codeword,
+//     and forwarding (Burst, SlotType) to IngestBurst.
+//   - Trims the buffer to bufKeep dibits so any future sync match
+//     has the full 77-dibit lookback available.
+//
+// baseIdx is the absolute dibit index of dibits[0]. The adapter
+// tracks the buffer's absolute position so cross-call sync matches
+// align correctly across chunk boundaries.
+//
+// Returns baseIdx + len(dibits) to match the YSF / P25 P1 / dPMR /
+// NXDN / EDACS / Motorola / LTR / MPT 1327 Process contracts.
+//
+// On-air voice / data burst payload decoding (the BPTC(196,96) +
+// CSBK CRC chain) lives inside IngestBurst; this adapter just gets
+// 132 dibits into IngestBurst's hands. The slot-type Hamming(20,8)
+// decoder filters out bursts whose slot type doesn't match
+// DTCSBK before any BPTC work, so most noise drops here.
+func (c *ControlChannel) Process(dibits []uint8, baseIdx int) int {
+	if c.proc == nil {
+		c.proc = &processState{
+			det: dmr.NewSyncDetector(nil, 2),
+		}
+	}
+	p := c.proc
+
+	// Track the buffer's absolute start the first time we receive
+	// dibits. After trimming, bufStart advances as we drop older
+	// dibits.
+	if len(p.buf) == 0 {
+		p.bufStart = baseIdx
+	}
+	p.buf = append(p.buf, dibits...)
+
+	// Run sync detection on the freshly-appended dibits.
+	matches, _ := p.det.Process(nil, dibits, baseIdx)
+	p.pending = append(p.pending, matches...)
+
+	// Process pending hits whose full burst is now in the buffer.
+	bufEnd := p.bufStart + len(p.buf)
+	keep := p.pending[:0]
+	for _, m := range p.pending {
+		burstStart := m.Index - burstLookback
+		burstEnd := m.Index + burstLookahead + 1 // exclusive
+		if burstEnd > bufEnd {
+			// Need more trailing dibits.
+			keep = append(keep, m)
+			continue
+		}
+		if burstStart < p.bufStart {
+			// Lookback already trimmed; drop this match.
+			continue
+		}
+		offset := burstStart - p.bufStart
+		var b dmr.Burst
+		copy(b.Dibits[:], p.buf[offset:offset+dmr.BurstDibits])
+
+		// Decode slot type (Hamming(20,8) over the 20 bits of the
+		// slot-type field surrounding the sync). ParseSlotType
+		// returns the slot type + error count; we accept partially-
+		// corrected slot types (positive errs) but drop hard
+		// failures (slot.DataType won't match DTCSBK anyway).
+		slot, _, err := dmr.ParseSlotType(b.SlotTypeBitsAll())
+		if err != nil {
+			continue
+		}
+		c.IngestBurst(&b, slot)
+	}
+	p.pending = keep
+
+	// Trim the buffer: keep the last bufKeep dibits.
+	if len(p.buf) > bufKeep {
+		drop := len(p.buf) - bufKeep
+		copy(p.buf, p.buf[drop:])
+		p.buf = p.buf[:bufKeep]
+		p.bufStart += drop
+	}
+	return baseIdx + len(dibits)
+}

--- a/internal/radio/dmr/tier3/process_test.go
+++ b/internal/radio/dmr/tier3/process_test.go
@@ -1,0 +1,166 @@
+package tier3
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/dmr"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+)
+
+// buildAlohaBurst builds a 132-dibit DMR burst carrying an Aloha
+// CSBK at the requested ColorCode + SystemID. The payload goes
+// through full BPTC(196,96) encoding so DecodeBPTC + ParseCSBK
+// (inside IngestBurst) recover the original.
+func buildAlohaBurst(t *testing.T, cc uint8, systemID uint16) []uint8 {
+	t.Helper()
+	csbk := CSBK{Opcode: OpAloha, LB: true}
+	// Aloha payload layout (see payloads.go ParseAloha):
+	//   bytes [0]=ServiceOptions, [1]=AlohaService,
+	//   bytes [2..3]=SystemID, ...
+	csbk.Payload[2] = byte(systemID >> 8)
+	csbk.Payload[3] = byte(systemID & 0xFF)
+	csbkBytes := AssembleCSBK(csbk)
+
+	infoBits := framing.UnpackBitsMSB(csbkBytes, 96)
+	channelBits := framing.EncodeBPTC196_96(infoBits)
+
+	// Pack the 196 channel bits into 98 dibits.
+	dibits := framing.BitsToDibits(channelBits)
+	if len(dibits) != 98 {
+		t.Fatalf("BPTC produced %d dibits, want 98", len(dibits))
+	}
+	// Burst layout: payload first half (49 dibits) + slot type
+	// before (5 dibits) + sync (24 dibits) + slot type after
+	// (5 dibits) + payload second half (49 dibits) = 132 dibits.
+	slotBits := dmr.AssembleSlotType(dmr.SlotType{
+		ColorCode: cc,
+		DataType:  dmr.DTCSBK,
+	})
+	slotDibits := framing.BitsToDibits(slotBits)
+	if len(slotDibits) != 10 {
+		t.Fatalf("slot-type dibits = %d, want 10", len(slotDibits))
+	}
+
+	out := make([]uint8, 0, dmr.BurstDibits)
+	out = append(out, dibits[:dmr.HalfPayloadDibits]...)
+	out = append(out, slotDibits[:dmr.SlotTypeDibits]...)
+	out = append(out, dmr.BSData.Dibits[:]...)
+	out = append(out, slotDibits[dmr.SlotTypeDibits:]...)
+	out = append(out, dibits[dmr.HalfPayloadDibits:]...)
+	if len(out) != dmr.BurstDibits {
+		t.Fatalf("built burst length = %d, want %d", len(out), dmr.BurstDibits)
+	}
+	return out
+}
+
+// TestProcessLocksOnAlohaBurst: feed Process a stream of (padding,
+// Aloha CSBK burst, trailing padding), confirm a KindCCLocked
+// event lands on the bus with the ColorCode + SystemID we encoded.
+func TestProcessLocksOnAlohaBurst(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{
+		Bus:         bus,
+		Log:         slog.Default(),
+		SystemName:  "Sys",
+		FrequencyHz: 460_000_000,
+	})
+
+	burst := buildAlohaBurst(t, 0xA, 0x1234)
+
+	// 200 dibits of padding for sync-detector priming + adapter
+	// lookback + Aloha burst + 64 trailing dibits.
+	stream := make([]uint8, 200)
+	stream = append(stream, burst...)
+	stream = append(stream, make([]uint8, 64)...)
+
+	cc.Process(stream, 0)
+
+	var sawLock bool
+	var ls LockState
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind == events.KindCCLocked {
+				ls, _ = ev.Payload.(LockState)
+				sawLock = true
+			}
+		default:
+			if !sawLock {
+				t.Errorf("Process did not publish a KindCCLocked")
+				return
+			}
+			if ls.ColorCode != 0xA {
+				t.Errorf("LockState.ColorCode = %d, want 10", ls.ColorCode)
+			}
+			if ls.SystemID != 0x1234 {
+				t.Errorf("LockState.SystemID = %#x, want 0x1234", ls.SystemID)
+			}
+			return
+		}
+	}
+}
+
+// TestProcessHandlesBurstSpanningCalls: a burst whose dibits
+// arrive across two Process calls still drives IngestBurst.
+func TestProcessHandlesBurstSpanningCalls(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, Log: slog.Default(), SystemName: "Sys"})
+
+	burst := buildAlohaBurst(t, 0x5, 0xCAFE)
+	stream := make([]uint8, 200)
+	stream = append(stream, burst...)
+	stream = append(stream, make([]uint8, 64)...)
+
+	// Split right in the middle of the burst.
+	mid := len(stream) / 2
+	cc.Process(stream[:mid], 0)
+	cc.Process(stream[mid:], mid)
+
+	var sawLock bool
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind == events.KindCCLocked {
+				sawLock = true
+			}
+		default:
+			if !sawLock {
+				t.Errorf("Process did not publish a KindCCLocked across the chunk boundary")
+			}
+			return
+		}
+	}
+}
+
+// TestProcessIgnoresGarbage confirms a dibit stream without any
+// DMR sync pattern produces no events.
+func TestProcessIgnoresGarbage(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, Log: slog.Default(), SystemName: "Sys"})
+
+	garbage := make([]uint8, 2000)
+	for i := range garbage {
+		garbage[i] = uint8(i % 4)
+	}
+	cc.Process(garbage, 0)
+
+	select {
+	case ev := <-sub.C:
+		t.Errorf("unexpected event from garbage stream: %v", ev.Kind)
+	default:
+	}
+}

--- a/internal/scanner/ccdecoder/decoder_test.go
+++ b/internal/scanner/ccdecoder/decoder_test.go
@@ -269,6 +269,23 @@ func TestP25Phase1FactoryConstructs(t *testing.T) {
 	}
 }
 
+func TestDMRTier3FactoryConstructs(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	p, err := newDMRTier3Pipeline(PipelineOptions{
+		Bus: bus, SystemName: "Smoke",
+		FrequencyHz: 460_000_000, SampleRateHz: 48_000,
+	})
+	if err != nil {
+		t.Fatalf("newDMRTier3Pipeline: %v", err)
+	}
+	p.Process(make([]complex64, 4800))
+	p.Reset()
+	if err := p.Close(); err != nil {
+		t.Errorf("Close: %v", err)
+	}
+}
+
 func TestMPT1327FactoryConstructs(t *testing.T) {
 	bus := events.NewBus(8)
 	defer bus.Close()

--- a/internal/scanner/ccdecoder/pipelines.go
+++ b/internal/scanner/ccdecoder/pipelines.go
@@ -4,6 +4,9 @@ import (
 	"log/slog"
 
 	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/dmr"
+	dmrrx "github.com/MattCheramie/GopherTrunk/internal/radio/dmr/receiver"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/dmr/tier3"
 	"github.com/MattCheramie/GopherTrunk/internal/radio/dpmr"
 	dpmrrx "github.com/MattCheramie/GopherTrunk/internal/radio/dpmr/receiver"
 	"github.com/MattCheramie/GopherTrunk/internal/radio/edacs"
@@ -71,6 +74,7 @@ type PipelineFactory func(PipelineOptions) (ProtocolPipeline, error)
 // follow-up.
 var factories = map[trunking.Protocol]PipelineFactory{
 	trunking.ProtocolP25:      newP25Phase1Pipeline,
+	trunking.ProtocolDMR:      newDMRTier3Pipeline,
 	trunking.ProtocolDPMR:     newDPMRPipeline,
 	trunking.ProtocolNXDN:     newNXDNPipeline,
 	trunking.ProtocolEDACS:    newEDACSPipeline,
@@ -172,6 +176,41 @@ type dpmrPipeline struct {
 func (p *dpmrPipeline) Process(iq []complex64) { p.rx.Process(iq) }
 func (p *dpmrPipeline) Reset()                  { p.rx.Reset() }
 func (p *dpmrPipeline) Close() error            { return nil }
+
+// newDMRTier3Pipeline wires internal/radio/dmr/receiver into
+// dmr/tier3.ControlChannel.Process. The receiver's DibitSink
+// forwards dibits into the adapter (multi-pattern sync detect
+// across all 9 ETSI sync words → 132-dibit burst slice →
+// slot-type Hamming(20,8) decode → IngestBurst → BPTC(196,96) →
+// CSBK CRC → cc.locked / grant publication).
+func newDMRTier3Pipeline(opts PipelineOptions) (ProtocolPipeline, error) {
+	cc := tier3.New(tier3.Options{
+		Bus:         opts.Bus,
+		Log:         opts.Log,
+		SystemName:  opts.SystemName,
+		FrequencyHz: opts.FrequencyHz,
+	})
+	rx := dmrrx.New(dmrrx.Options{
+		SampleRateHz: opts.SampleRateHz,
+		DibitSink: func(dibits []uint8, baseIdx int) {
+			cc.Process(dibits, baseIdx)
+		},
+	})
+	return &dmrPipeline{rx: rx, cc: cc}, nil
+}
+
+type dmrPipeline struct {
+	rx *dmrrx.Receiver
+	cc *tier3.ControlChannel
+}
+
+// dmrPipeline holds dmr import alive for the package-level
+// import-grouping rule; the underlying Receiver type is in dmrrx.
+var _ = dmr.BurstDibits
+
+func (p *dmrPipeline) Process(iq []complex64) { p.rx.Process(iq) }
+func (p *dmrPipeline) Reset()                  { p.rx.Reset() }
+func (p *dmrPipeline) Close() error            { return nil }
 
 // newNXDNPipeline wires internal/radio/nxdn/receiver into
 // nxdn.ControlChannel.Process. The receiver's DibitSink forwards


### PR DESCRIPTION
## Summary

Seventh and most layered of the per-protocol adapter follow-ups.

Closes the IQ → CC chain for **DMR Tier III**. Unlike most of the
other adapters which defer FEC to a follow-up, DMR has full on-air
decoding shipping today: `dmr.SlotType` decodes Hamming(20,8) and
`framing.BPTC196_96` decodes the payload, both already used by
`IngestBurst`. The adapter just gets 132 dibits into
`IngestBurst`'s hands at the right alignment.

The adapter:

- Buffers cross-call dibits with absolute-position tracking so
  sync matches straddling chunk boundaries align correctly.
- Runs `dmr.SyncDetector` against all 9 ETSI sync words in
  parallel (BS / MS / DM voice / data / RC variants).
- For each sync hit at absolute index M, the 132-dibit burst
  spans positions [M-77, M+54]. The adapter queues hits and
  processes each once enough trailing dibits arrive.
- Builds a `dmr.Burst`, parses the 20-bit slot-type Hamming
  codeword (5 dibits before + 5 dibits after the sync), and
  calls `IngestBurst(burst, slot)`. From there BPTC(196,96) +
  CSBK CRC run inside the existing tier3 path.
- Retains the last 163 dibits (77 lookback + 54 lookahead +
  32 safety) so any future sync match has the full lookback
  available.

## Daemon-level changes

- **`ccdecoder/pipelines.go`** gains `newDMRTier3Pipeline` +
  `dmrPipeline` wrapper, plus a row in the `factories` map
  under the existing `trunking.ProtocolDMR` (no new enum entry
  needed).

## Test plan

- [x] `go test ./internal/radio/dmr/tier3/... -race -v`
- [x] `go test ./internal/radio/dmr/... ./internal/scanner/ccdecoder/... -race`
- [x] `go build ./...`
- [x] `go vet ./...`

New tests cover:
- A full Aloha CSBK burst (encoded via `AssembleCSBK` +
  `EncodeBPTC196_96` + `AssembleSlotType` + `dmr.BSData` sync)
  drives `cc.locked` with the right ColorCode + SystemID.
- A burst that straddles a chunk boundary still drives
  `cc.locked` (cross-call alignment works).
- Garbage without any DMR sync produces no events.
- ccdecoder smoke construction of the new DMR factory.

## README

- "Status & known gaps" updated — DMR Tier III moves to "works
  today (full BPTC + CSBK chain)". Only **P25 P2 and TETRA**
  remain.
- "Recently shipped" gains a bullet describing the adapter +
  factory wiring.


---
_Generated by [Claude Code](https://claude.ai/code/session_019dtCCVEZJTKKr6YK3wy824)_