### PR TITLE
internal/radio/p25/phase2: ControlChannel.Process adapter + ccdecoder factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,16 +74,15 @@ panel. The honest remaining gaps:
   OSW only; BCH(64,16,11) FEC pending), LTR (41-bit Status
   alignment + state-machine dedup only; FCS verification +
   Manchester decoding pending), MPT 1327 (38-bit codeword
-  alignment with auto-unlock on unrecognised-codeword runs;
-  64-bit on-air BCH(63,38) FEC pending), and DMR Tier III
-  (multi-pattern 9-sync detect + 132-dibit burst slice +
-  slot-type Hamming(20,8) + BPTC(196,96) → CSBK end-to-end).
-  P25 P2 / TETRA each have IQ → symbol receivers shipping but
-  their CC state machines still consume pre-parsed PDUs; adding
-  the `Process(stream, baseIdx)` adapter on each (sync detect →
-  frame slice → existing parser → Ingest) lights up the rest.
-  The adapter shape is ~30–50 lines per protocol and documented
-  per-receiver in the relevant PR descriptions.
+  alignment with auto-unlock; 64-bit on-air BCH(63,38) FEC
+  pending), DMR Tier III (multi-pattern 9-sync detect +
+  132-dibit burst slice + slot-type Hamming(20,8) + BPTC(196,96)
+  → CSBK end-to-end), and P25 Phase 2 (20-dibit outbound sync +
+  18-byte MAC PDU slice; Trellis FEC + slot-type extraction
+  across the full 180-dibit subframe pending). Only **TETRA**
+  remains: the IQ → symbol receiver ships but its CC state
+  machine still consumes pre-parsed PDUs; the
+  `Process(stream, baseIdx)` adapter is the last piece.
 - **Digital-voice level calibration.** Pure-Go IMBE / AMBE+2 emit
   real audio end-to-end with shared AGC, frame-repeat on bad-frame
   indicator, phase-aware fade-in, and §6.2 spectral enhancement
@@ -150,6 +149,18 @@ to its own package and lands independently.
 
 ### Recently shipped
 
+- **P25 Phase 2 `ControlChannel.Process(stream, baseIdx)` adapter +
+  ccdecoder factory.** Closes the IQ → CC sync layer for P25
+  Phase 2: the receiver's `DibitSink` forwards H-DQPSK dibits
+  into `phase2.ControlChannel.Process`, which buffers across
+  calls + detects the 20-dibit outbound sync + slices a 72-dibit
+  MAC PDU (1 opcode + 17 payload bytes = 144 bits) + parses it
+  via `ParseMACPDU` + dispatches through the existing `Ingest`.
+  `trunking.Protocol` gains `ProtocolP25Phase2` (config string
+  `"p25-phase2"`). Trellis FEC + slot-type extraction across the
+  full 180-dibit subframe are documented follow-ups; until they
+  land the adapter works on test fixtures but typically fails to
+  lock on captured Phase 2 traffic.
 - **DMR Tier III `ControlChannel.Process(stream, baseIdx)` adapter +
   ccdecoder factory.** Closes the IQ → CC chain for DMR — the
   most layered protocol in the family. The receiver's `DibitSink`

--- a/internal/radio/p25/phase2/control.go
+++ b/internal/radio/p25/phase2/control.go
@@ -27,6 +27,11 @@ type ControlChannel struct {
 	freqHz     uint32
 	now        func() time.Time
 
+	// proc is the cross-call dibit / sync state the Process
+	// adapter uses (see process.go). Lazily constructed on the
+	// first Process call.
+	proc *processState
+
 	mu     sync.Mutex
 	locked bool
 }

--- a/internal/radio/p25/phase2/process.go
+++ b/internal/radio/p25/phase2/process.go
@@ -1,0 +1,85 @@
+package phase2
+
+import (
+	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+)
+
+// processState is the cross-call dibit buffering + sync-detection
+// state the Process adapter holds. Lazily initialised.
+type processState struct {
+	det          *SyncDetector
+	remaining    int
+	macDibits    []uint8
+	matchScratch []int
+}
+
+// macPDUDibits is the count of dibits the adapter collects after
+// each 20-dibit outbound sync match. A MAC PDU after FEC removal
+// is 18 bytes = 144 bits = 72 dibits (1 opcode + up to 17 payload
+// bytes). The Trellis + interleaver layer that spans the full
+// 180-dibit subframe isn't reversed here — the adapter reads the
+// 72 information dibits straight from the wire, which works for
+// test fixtures + clean signals but typically fails on noisy
+// on-air captures. Trellis decoding is the documented follow-up.
+const macPDUDibits = 72
+
+// Process consumes a window of raw dibits from the Phase 2
+// receiver (the IQ → H-DQPSK dibit chain in
+// internal/radio/p25/phase2/receiver/), runs the 20-dibit
+// outbound sync detector, slices the following 72-dibit MAC PDU
+// out of the stream, parses it via ParseMACPDU, and forwards the
+// result to Ingest.
+//
+// baseIdx is the absolute dibit index of dibits[0]. The adapter's
+// internal countdown survives across Process calls so a sync
+// match in one chunk and the MAC PDU payload in the next still
+// decode cleanly.
+//
+// Returns baseIdx + len(dibits) to match the ControlChannel.Process
+// contracts shared across protocols.
+func (c *ControlChannel) Process(dibits []uint8, baseIdx int) int {
+	if c.proc == nil {
+		c.proc = &processState{
+			det:       NewSyncDetector(OutboundSyncDibits(), 2),
+			macDibits: make([]uint8, 0, macPDUDibits),
+		}
+	}
+	p := c.proc
+
+	p.matchScratch, _ = p.det.Process(p.matchScratch[:0], dibits, baseIdx)
+	matchIdx := 0
+
+	for i, d := range dibits {
+		absPos := baseIdx + i
+		if p.remaining > 0 {
+			p.macDibits = append(p.macDibits, d)
+			p.remaining--
+			if p.remaining == 0 {
+				bits := framing.DibitsToBits(p.macDibits)
+				info := framing.PackBitsMSB(bits)
+				if len(info) >= 18 {
+					if pdu, err := ParseMACPDU(info[:18]); err == nil {
+						c.Ingest(pdu)
+					}
+				}
+				p.macDibits = p.macDibits[:0]
+			}
+		}
+		for matchIdx < len(p.matchScratch) && p.matchScratch[matchIdx] == absPos {
+			p.remaining = macPDUDibits
+			p.macDibits = p.macDibits[:0]
+			matchIdx++
+		}
+	}
+	return baseIdx + len(dibits)
+}
+
+// Reset clears the SyncDetector's history so a stale match doesn't
+// fire after a stream re-sync.
+func (s *SyncDetector) Reset() {
+	for i := range s.hist {
+		s.hist[i] = 0
+	}
+	s.primed = 0
+	s.pos = 0
+}

--- a/internal/radio/p25/phase2/process_test.go
+++ b/internal/radio/p25/phase2/process_test.go
@@ -1,0 +1,133 @@
+package phase2
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+)
+
+// TestProcessLocksOnFirstMACPDUAfterSync: build a dibit stream of
+// 30 padding dibits + 20 outbound sync dibits + 72 dibits whose
+// raw bits form a MAC PDU (opcode = OpMACPTT, no payload). The
+// state machine should publish a KindCCLocked since
+// OpMACPTT.IsIdle() returns false.
+func TestProcessLocksOnFirstMACPDUAfterSync(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{
+		Bus:         bus,
+		Log:         slog.Default(),
+		SystemName:  "Sys",
+		FrequencyHz: 851_062_500,
+	})
+
+	pdu := MACPDU{Opcode: OpMACPTT, Payload: make([]byte, 17)}
+	pduBytes := AssembleMACPDU(pdu)
+	if len(pduBytes) != 18 {
+		t.Fatalf("AssembleMACPDU = %d bytes, want 18", len(pduBytes))
+	}
+	pduBits := framing.UnpackBitsMSB(pduBytes, 144)
+	pduDibits := framing.BitsToDibits(pduBits)
+	if len(pduDibits) != 72 {
+		t.Fatalf("MAC PDU dibits = %d, want 72", len(pduDibits))
+	}
+
+	stream := make([]uint8, 30)
+	stream = append(stream, OutboundSyncDibits()...)
+	stream = append(stream, pduDibits...)
+
+	cc.Process(stream, 0)
+
+	var sawLock bool
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind == events.KindCCLocked {
+				ls, _ := ev.Payload.(LockState)
+				if ls.FrequencyHz != 851_062_500 {
+					t.Errorf("LockState.FrequencyHz = %d", ls.FrequencyHz)
+				}
+				sawLock = true
+			}
+		default:
+			if !sawLock {
+				t.Errorf("Process did not publish a KindCCLocked")
+			}
+			return
+		}
+	}
+}
+
+// TestProcessHandlesMACPDUSpanningCalls confirms that a sync +
+// MAC PDU split across two Process calls still drives Ingest.
+func TestProcessHandlesMACPDUSpanningCalls(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, Log: slog.Default(), SystemName: "Sys"})
+
+	pdu := MACPDU{Opcode: OpMACPTT, Payload: make([]byte, 17)}
+	pduBits := framing.UnpackBitsMSB(AssembleMACPDU(pdu), 144)
+	pduDibits := framing.BitsToDibits(pduBits)
+
+	chunk1 := make([]uint8, 30)
+	chunk1 = append(chunk1, OutboundSyncDibits()...)
+	cc.Process(chunk1, 0)
+	cc.Process(pduDibits, len(chunk1))
+
+	var sawLock bool
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind == events.KindCCLocked {
+				sawLock = true
+			}
+		default:
+			if !sawLock {
+				t.Errorf("Process did not publish a KindCCLocked across the chunk boundary")
+			}
+			return
+		}
+	}
+}
+
+func TestProcessIgnoresGarbageWithoutSync(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, Log: slog.Default(), SystemName: "Sys"})
+
+	garbage := make([]uint8, 2000)
+	for i := range garbage {
+		garbage[i] = uint8(i % 4)
+	}
+	cc.Process(garbage, 0)
+
+	select {
+	case ev := <-sub.C:
+		t.Errorf("unexpected event from garbage stream: %v", ev.Kind)
+	default:
+	}
+}
+
+func TestSyncDetectorReset(t *testing.T) {
+	det := NewSyncDetector(OutboundSyncDibits(), 0)
+	junk := make([]uint8, 100)
+	det.Process(nil, junk, 0)
+	det.Reset()
+	if det.primed != 0 {
+		t.Errorf("post-Reset primed = %d, want 0", det.primed)
+	}
+	if det.pos != 0 {
+		t.Errorf("post-Reset pos = %d, want 0", det.pos)
+	}
+}

--- a/internal/scanner/ccdecoder/decoder_test.go
+++ b/internal/scanner/ccdecoder/decoder_test.go
@@ -269,6 +269,23 @@ func TestP25Phase1FactoryConstructs(t *testing.T) {
 	}
 }
 
+func TestP25Phase2FactoryConstructs(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	p, err := newP25Phase2Pipeline(PipelineOptions{
+		Bus: bus, SystemName: "Smoke",
+		FrequencyHz: 851_062_500, SampleRateHz: 48_000,
+	})
+	if err != nil {
+		t.Fatalf("newP25Phase2Pipeline: %v", err)
+	}
+	p.Process(make([]complex64, 4800))
+	p.Reset()
+	if err := p.Close(); err != nil {
+		t.Errorf("Close: %v", err)
+	}
+}
+
 func TestDMRTier3FactoryConstructs(t *testing.T) {
 	bus := events.NewBus(8)
 	defer bus.Close()

--- a/internal/scanner/ccdecoder/pipelines.go
+++ b/internal/scanner/ccdecoder/pipelines.go
@@ -21,6 +21,8 @@ import (
 	nxdnrx "github.com/MattCheramie/GopherTrunk/internal/radio/nxdn/receiver"
 	p25phase1 "github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase1"
 	p25phase1rx "github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase1/receiver"
+	p25phase2 "github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase2"
+	p25phase2rx "github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase2/receiver"
 	"github.com/MattCheramie/GopherTrunk/internal/radio/ysf"
 	ysfrx "github.com/MattCheramie/GopherTrunk/internal/radio/ysf/receiver"
 	"github.com/MattCheramie/GopherTrunk/internal/trunking"
@@ -73,14 +75,15 @@ type PipelineFactory func(PipelineOptions) (ProtocolPipeline, error)
 // detect sync + frame + dispatch into the existing parsers is a
 // follow-up.
 var factories = map[trunking.Protocol]PipelineFactory{
-	trunking.ProtocolP25:      newP25Phase1Pipeline,
-	trunking.ProtocolDMR:      newDMRTier3Pipeline,
-	trunking.ProtocolDPMR:     newDPMRPipeline,
-	trunking.ProtocolNXDN:     newNXDNPipeline,
-	trunking.ProtocolEDACS:    newEDACSPipeline,
-	trunking.ProtocolMotorola: newMotorolaPipeline,
-	trunking.ProtocolLTR:      newLTRPipeline,
-	trunking.ProtocolMPT1327:  newMPT1327Pipeline,
+	trunking.ProtocolP25:       newP25Phase1Pipeline,
+	trunking.ProtocolP25Phase2: newP25Phase2Pipeline,
+	trunking.ProtocolDMR:       newDMRTier3Pipeline,
+	trunking.ProtocolDPMR:      newDPMRPipeline,
+	trunking.ProtocolNXDN:      newNXDNPipeline,
+	trunking.ProtocolEDACS:     newEDACSPipeline,
+	trunking.ProtocolMotorola:  newMotorolaPipeline,
+	trunking.ProtocolLTR:       newLTRPipeline,
+	trunking.ProtocolMPT1327:   newMPT1327Pipeline,
 }
 
 // newP25Phase1Pipeline wires the existing
@@ -114,6 +117,40 @@ type p25Phase1Pipeline struct {
 func (p *p25Phase1Pipeline) Process(iq []complex64) { p.rx.Process(iq) }
 func (p *p25Phase1Pipeline) Reset()                  { p.rx.Reset() }
 func (p *p25Phase1Pipeline) Close() error            { return nil }
+
+// newP25Phase2Pipeline wires internal/radio/p25/phase2/receiver into
+// p25phase2.ControlChannel.Process. The receiver's DibitSink forwards
+// H-DQPSK dibits into the state machine (20-dibit outbound sync
+// detect → 72-dibit MAC PDU slice → ParseMACPDU → Ingest), which
+// publishes cc.locked on the first non-idle MAC PDU and grants on
+// GroupVoiceChannelGrant variants. Trellis FEC + slot-type
+// extraction across the full 180-dibit subframe are follow-ups;
+// without them the adapter works on test fixtures but typically
+// fails to lock on captured Phase 2 traffic.
+func newP25Phase2Pipeline(opts PipelineOptions) (ProtocolPipeline, error) {
+	cc := p25phase2.New(p25phase2.Options{
+		Bus:         opts.Bus,
+		Log:         opts.Log,
+		SystemName:  opts.SystemName,
+		FrequencyHz: opts.FrequencyHz,
+	})
+	rx := p25phase2rx.New(p25phase2rx.Options{
+		SampleRateHz: opts.SampleRateHz,
+		DibitSink: func(dibits []uint8, baseIdx int) {
+			cc.Process(dibits, baseIdx)
+		},
+	})
+	return &p25Phase2Pipeline{rx: rx, cc: cc}, nil
+}
+
+type p25Phase2Pipeline struct {
+	rx *p25phase2rx.Receiver
+	cc *p25phase2.ControlChannel
+}
+
+func (p *p25Phase2Pipeline) Process(iq []complex64) { p.rx.Process(iq) }
+func (p *p25Phase2Pipeline) Reset()                  { p.rx.Reset() }
+func (p *p25Phase2Pipeline) Close() error            { return nil }
 
 // newYSFPipeline wires the existing internal/radio/ysf/receiver
 // into ysf.ControlChannel.Process. YSF lacks a published

--- a/internal/trunking/site.go
+++ b/internal/trunking/site.go
@@ -13,15 +13,16 @@ import (
 type Protocol uint8
 
 const (
-	ProtocolUnknown  Protocol = iota
-	ProtocolP25               // P25 Phase 1 / Phase 2
-	ProtocolDMR               // DMR Tier II / III
-	ProtocolNXDN              // NXDN
-	ProtocolDPMR              // dPMR Mode 3 (digital PMR446 trunking)
-	ProtocolEDACS             // EDACS / GE-Marc
-	ProtocolMotorola          // Motorola Type II / SmartZone
-	ProtocolLTR               // Logic Trunked Radio (LTR / LTR-Net)
-	ProtocolMPT1327           // MPT 1327 (UK / Commonwealth utility trunking)
+	ProtocolUnknown   Protocol = iota
+	ProtocolP25                // P25 Phase 1 (config "p25" — Phase 2 uses ProtocolP25Phase2)
+	ProtocolDMR                // DMR Tier II / III
+	ProtocolNXDN               // NXDN
+	ProtocolDPMR               // dPMR Mode 3 (digital PMR446 trunking)
+	ProtocolEDACS              // EDACS / GE-Marc
+	ProtocolMotorola           // Motorola Type II / SmartZone
+	ProtocolLTR                // Logic Trunked Radio (LTR / LTR-Net)
+	ProtocolMPT1327            // MPT 1327 (UK / Commonwealth utility trunking)
+	ProtocolP25Phase2          // P25 Phase 2 (H-DQPSK TDMA, config "p25-phase2")
 )
 
 func (p Protocol) String() string {
@@ -42,13 +43,16 @@ func (p Protocol) String() string {
 		return "ltr"
 	case ProtocolMPT1327:
 		return "mpt1327"
+	case ProtocolP25Phase2:
+		return "p25-phase2"
 	default:
 		return "unknown"
 	}
 }
 
 // ParseProtocol maps a string ("p25", "dmr", "nxdn", "dpmr",
-// "edacs", "motorola", "ltr", "mpt1327") to a Protocol value.
+// "edacs", "motorola", "ltr", "mpt1327", "p25-phase2") to a
+// Protocol value.
 func ParseProtocol(s string) (Protocol, error) {
 	switch strings.ToLower(s) {
 	case "p25":
@@ -67,6 +71,8 @@ func ParseProtocol(s string) (Protocol, error) {
 		return ProtocolLTR, nil
 	case "mpt1327":
 		return ProtocolMPT1327, nil
+	case "p25-phase2", "p25_phase2", "p25p2":
+		return ProtocolP25Phase2, nil
 	default:
 		return ProtocolUnknown, fmt.Errorf("trunking: unknown protocol %q", s)
 	}
@@ -89,7 +95,7 @@ func (s System) Validate() error {
 		return errors.New("trunking: system name is required")
 	}
 	if s.Protocol == ProtocolUnknown {
-		return errors.New("trunking: protocol must be p25|dmr|nxdn|dpmr|edacs|motorola|ltr|mpt1327")
+		return errors.New("trunking: protocol must be p25|p25-phase2|dmr|nxdn|dpmr|edacs|motorola|ltr|mpt1327")
 	}
 	if len(s.ControlChannels) == 0 {
 		return errors.New("trunking: at least one control_channel frequency is required")


### PR DESCRIPTION
## Summary

Eighth of the per-protocol `ControlChannel.Process(stream, baseIdx)`
adapter follow-ups.

Closes the IQ → CC sync layer for **P25 Phase 2**. The receiver's
`DibitSink` forwards H-DQPSK dibits into
`phase2.ControlChannel.Process`, which:

- Buffers cross-call state via an internal countdown + partial
  MAC PDU slice.
- Runs the 20-dibit outbound `SyncDetector` across each incoming
  chunk.
- On each sync match collects 72 dibits = 144 bits = 18 bytes.
- Hands the 18 bytes to `ParseMACPDU` + the parsed PDU to the
  existing `Ingest` path, which publishes `KindCCLocked` on any
  non-idle PDU and `KindGrant` on `GroupVoiceChannelGrant`
  variants.

## Daemon-level changes

- **`trunking.Protocol`** gains `ProtocolP25Phase2` (config
  strings `"p25-phase2"` / `"p25_phase2"` / `"p25p2"`). The
  existing `ProtocolP25` continues to mean **Phase 1**; Phase 2
  systems must explicitly opt in with the new config string.
- **`ccdecoder/pipelines.go`** gains `newP25Phase2Pipeline` +
  `p25Phase2Pipeline` wrapper, plus a row in the `factories`
  map.

## Deferred to a follow-up

Phase 2's 180-dibit subframe is protected by Trellis FEC +
slot-type identification + the SLOT alternation between voice and
MAC. This adapter reads 72 information dibits straight from the
wire after the sync, which works on test fixtures (no FEC) but
typically fails on captured Phase 2 traffic where the MAC PDU
bits are spread across the full subframe via the FEC + 4-state
trellis. Decoding the full subframe is the documented next-step
follow-up.

## Test plan

- [x] `go test ./internal/radio/p25/phase2/... -race -v`
- [x] `go test ./internal/scanner/ccdecoder/... ./internal/trunking/... -race`
- [x] `go build ./...`
- [x] `go vet ./...`

New tests cover:
- A 30-dibit-padded sync + valid MAC PDU (OpMACPTT, 17-byte
  payload) triggers `KindCCLocked` with the right `FrequencyHz`.
- A MAC PDU split across two Process calls still locks the
  channel.
- Garbage without a sync produces no events.
- `SyncDetector.Reset` clears `primed` + `pos`.
- ccdecoder smoke construction of the new Phase 2 factory.

## README

- "Status & known gaps" updated — P25 Phase 2 moves to "works
  today (sync + MAC PDU only)"; Trellis FEC + slot-type
  extraction flagged as follow-ups. **Only TETRA remains.**
- "Recently shipped" gains a bullet for the Phase 2 adapter +
  factory wiring + FEC deferral.


---
_Generated by [Claude Code](https://claude.ai/code/session_019dtCCVEZJTKKr6YK3wy824)_