### PR TITLE
internal/radio/tetra: ControlChannel.Process adapter + ccdecoder factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,36 +53,27 @@ logged to SQLite, and the API + TUI surfaces all light up. Pure-Go
 IMBE / AMBE+2 produce intelligible audio. The CC Hunter supervisor and
 the conventional FM scanner are constructed by `cmd/gophertrunk` and
 expose their state through `/api/v1/scanner` and the TUI cockpit
-panel. The honest remaining gaps:
+panel. **Every trunked control modulation in the Features table now
+has an end-to-end IQ → CC chain shipping** — the `ccdecoder` connector
+constructed by `cmd/gophertrunk` covers all 10 protocols (P25 Phase 1,
+P25 Phase 2, DMR Tier III, NXDN, dPMR Mode 3, EDACS, Motorola Type II,
+LTR, MPT 1327, TETRA TMO) plus YSF on the amateur side.
 
-- **Per-protocol `ControlChannel.Process(stream, baseIdx)` adapters
-  for the 8 protocols beyond P25 Phase 1, YSF, and dPMR.** The
-  `internal/scanner/ccdecoder` package is wired into
-  `cmd/gophertrunk/daemon.go` — when a control SDR + trunked system
-  are configured, the daemon constructs a `ccdecoder.Decoder`
-  alongside the CC Hunter supervisor and spawns it as a goroutine
-  that owns the control SDR's `StreamIQ` loop. The connector
-  subscribes to `KindHuntProgress`, swaps the active per-protocol
-  pipeline on every supervisor retune, and pumps IQ chunks through
-  the active pipeline whose CC state machine publishes `cc.locked`
-  / `grant` events back on the bus — the trigger that lights up
-  every downstream surface (engine, recorder, call log, API, TUI).
-  Live trunked reception works today for P25 Phase 1, YSF, dPMR
-  Mode 3, NXDN (FSW + LICH only; CAC FEC pending), EDACS /
-  GE-Marc (24-bit sync + 40-bit CCW only; interleaved-RS FEC
-  pending), Motorola Type II / SmartZone (24-bit sync + 32-bit
-  OSW only; BCH(64,16,11) FEC pending), LTR (41-bit Status
-  alignment + state-machine dedup only; FCS verification +
-  Manchester decoding pending), MPT 1327 (38-bit codeword
-  alignment with auto-unlock; 64-bit on-air BCH(63,38) FEC
-  pending), DMR Tier III (multi-pattern 9-sync detect +
-  132-dibit burst slice + slot-type Hamming(20,8) + BPTC(196,96)
-  → CSBK end-to-end), and P25 Phase 2 (20-dibit outbound sync +
-  18-byte MAC PDU slice; Trellis FEC + slot-type extraction
-  across the full 180-dibit subframe pending). Only **TETRA**
-  remains: the IQ → symbol receiver ships but its CC state
-  machine still consumes pre-parsed PDUs; the
-  `Process(stream, baseIdx)` adapter is the last piece.
+The remaining gaps:
+
+- **Per-protocol on-air FEC layers.** The connector adapters that
+  shipped between PRs #113–#121 reach the CC state machines via
+  each protocol's `ControlChannel.Process(stream, baseIdx)` method.
+  Most adapters skip the on-air FEC and read information bits
+  straight from the wire — this works on test fixtures + clean
+  signals but typically fails on captured on-air traffic. Each
+  adapter PR documents the specific FEC layer pending; **DMR
+  Tier III** is the exception (full BPTC(196,96) + CSBK CRC chain
+  ships end-to-end via the existing tier3 package).
+- **Symbol-time clock recovery on complex IQ** for the π/4-DQPSK
+  family (P25 Phase 2, TETRA). The receivers currently do naive
+  decimation; Gardner-style timing recovery on complex IQ is the
+  follow-up that closes the gap for noisier captures.
 - **Digital-voice level calibration.** Pure-Go IMBE / AMBE+2 emit
   real audio end-to-end with shared AGC, frame-repeat on bad-frame
   indicator, phase-aware fade-in, and §6.2 spectral enhancement
@@ -149,6 +140,21 @@ to its own package and lands independently.
 
 ### Recently shipped
 
+- **TETRA TMO `ControlChannel.Process(stream, baseIdx)` adapter +
+  ccdecoder factory.** Closes the IQ → CC sync layer for TETRA —
+  the last per-protocol adapter from the connector roadmap. The
+  receiver's `DibitSink` forwards π/4-DQPSK dibits into
+  `tetra.ControlChannel.Process`, which buffers across calls +
+  detects the 38-dibit normal training-sequence sync + slices a
+  48-dibit PDU (1 header byte + 11 payload bytes = 96 bits) +
+  parses it via `ParsePDU` + dispatches through the existing
+  `Ingest`. `trunking.Protocol` gains `ProtocolTETRA` (config
+  string `"tetra"`). RCPC / RM FEC + interleaving across the
+  full TDMA slot are documented follow-ups; until they land the
+  adapter works on test fixtures but typically fails to lock on
+  captured TETRA traffic. **With this PR every trunked control
+  modulation listed in the Features table has an end-to-end
+  IQ → CC chain shipping.**
 - **P25 Phase 2 `ControlChannel.Process(stream, baseIdx)` adapter +
   ccdecoder factory.** Closes the IQ → CC sync layer for P25
   Phase 2: the receiver's `DibitSink` forwards H-DQPSK dibits

--- a/internal/radio/tetra/control.go
+++ b/internal/radio/tetra/control.go
@@ -32,6 +32,11 @@ type ControlChannel struct {
 	resolver   Resolver
 	now        func() time.Time
 
+	// proc is the cross-call dibit / sync state the Process
+	// adapter uses (see process.go). Lazily constructed on the
+	// first Process call.
+	proc *processState
+
 	mu     sync.Mutex
 	locked bool
 	last   LockState

--- a/internal/radio/tetra/process.go
+++ b/internal/radio/tetra/process.go
@@ -1,0 +1,83 @@
+package tetra
+
+import (
+	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+)
+
+// processState is the cross-call dibit buffering + sync-detection
+// state the Process adapter holds. Lazily initialised.
+type processState struct {
+	det          *SyncDetector
+	remaining    int
+	pduDibits    []uint8
+	matchScratch []int
+}
+
+// pduDibitCount is the count of dibits the adapter collects after
+// each 38-dibit training-sequence match. A TETRA VoiceGrant (CMCE
+// D-CONNECT) needs 1 header byte + 11 payload bytes = 12 bytes =
+// 96 bits = 48 dibits — large enough to cover SystemBroadcast +
+// VoiceGrant + Release. The RCPC / RM FEC + interleaving across
+// the full slot aren't reversed here; the adapter reads the
+// information bits straight from the wire, which works on test
+// fixtures but typically fails on captured TETRA traffic.
+const pduDibitCount = 48
+
+// Process consumes a window of raw dibits from the TETRA receiver
+// (the IQ → π/4-DQPSK dibit chain in internal/radio/tetra/receiver/),
+// runs the 38-dibit normal training-sequence detector, slices the
+// following 48-dibit PDU out of the stream, parses it via ParsePDU,
+// and forwards the result to Ingest.
+//
+// baseIdx is the absolute dibit index of dibits[0]. The adapter's
+// internal countdown survives across Process calls so a sync match
+// in one chunk and the PDU payload in the next still decode cleanly.
+//
+// Returns baseIdx + len(dibits) to match the ControlChannel.Process
+// contracts shared across protocols.
+func (c *ControlChannel) Process(dibits []uint8, baseIdx int) int {
+	if c.proc == nil {
+		c.proc = &processState{
+			det:       NewSyncDetector(NormalSyncDibits(), 3),
+			pduDibits: make([]uint8, 0, pduDibitCount),
+		}
+	}
+	p := c.proc
+
+	p.matchScratch, _ = p.det.Process(p.matchScratch[:0], dibits, baseIdx)
+	matchIdx := 0
+
+	for i, d := range dibits {
+		absPos := baseIdx + i
+		if p.remaining > 0 {
+			p.pduDibits = append(p.pduDibits, d)
+			p.remaining--
+			if p.remaining == 0 {
+				bits := framing.DibitsToBits(p.pduDibits)
+				info := framing.PackBitsMSB(bits)
+				if len(info) >= 1 {
+					if pdu, err := ParsePDU(info); err == nil {
+						c.Ingest(pdu)
+					}
+				}
+				p.pduDibits = p.pduDibits[:0]
+			}
+		}
+		for matchIdx < len(p.matchScratch) && p.matchScratch[matchIdx] == absPos {
+			p.remaining = pduDibitCount
+			p.pduDibits = p.pduDibits[:0]
+			matchIdx++
+		}
+	}
+	return baseIdx + len(dibits)
+}
+
+// Reset clears the SyncDetector's history so a stale match doesn't
+// fire after a stream re-sync.
+func (s *SyncDetector) Reset() {
+	for i := range s.hist {
+		s.hist[i] = 0
+	}
+	s.primed = 0
+	s.pos = 0
+}

--- a/internal/radio/tetra/process_test.go
+++ b/internal/radio/tetra/process_test.go
@@ -1,0 +1,159 @@
+package tetra
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+)
+
+// TestProcessLocksOnSystemBroadcastAfterSync builds a dibit stream
+// of 50 padding dibits + 38 normal training-sequence dibits + 48
+// dibits whose raw bits decode to an MLE-SYSINFO PDU with known
+// MCC / MNC / LocationArea, and confirms a KindCCLocked event
+// lands on the bus.
+func TestProcessLocksOnSystemBroadcastAfterSync(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{
+		Bus:         bus,
+		Log:         slog.Default(),
+		SystemName:  "Sys",
+		FrequencyHz: 412_062_500,
+	})
+
+	// SystemBroadcast layout: 10-bit MCC + 14-bit MNC + 14-bit LA
+	// packed MSB-first into 5 bytes (38 bits + 2 trailing pad bits).
+	const (
+		mcc uint16 = 0x123 // 10-bit
+		mnc uint16 = 0x1FF // 14-bit
+		la  uint16 = 0x0AB // 14-bit
+	)
+	payload := make([]byte, 11) // pad to 11 so VoiceGrant-sized PDUs also fit
+	payload[0] = byte(mcc >> 2)
+	payload[1] = byte((mcc&0x3)<<6) | byte((mnc>>8)&0x3F)
+	payload[2] = byte(mnc & 0xFF)
+	payload[3] = byte(la >> 6)
+	payload[4] = byte((la & 0x3F) << 2)
+
+	pdu := PDU{
+		Disc:    DiscMLE,
+		Type:    uint8(MLESystemInfo),
+		Payload: payload,
+	}
+	pduBytes := AssemblePDU(pdu)
+	pduBits := framing.UnpackBitsMSB(pduBytes, 96)
+	pduDibits := framing.BitsToDibits(pduBits)
+	if len(pduDibits) != 48 {
+		t.Fatalf("PDU dibits = %d, want 48", len(pduDibits))
+	}
+
+	stream := make([]uint8, 50)
+	stream = append(stream, NormalSyncDibits()...)
+	stream = append(stream, pduDibits...)
+
+	cc.Process(stream, 0)
+
+	var sawLock bool
+	var ls LockState
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind == events.KindCCLocked {
+				ls, _ = ev.Payload.(LockState)
+				sawLock = true
+			}
+		default:
+			if !sawLock {
+				t.Errorf("Process did not publish a KindCCLocked")
+				return
+			}
+			if ls.FrequencyHz != 412_062_500 {
+				t.Errorf("LockState.FrequencyHz = %d", ls.FrequencyHz)
+			}
+			if ls.MCC != mcc {
+				t.Errorf("LockState.MCC = %#x, want %#x", ls.MCC, mcc)
+			}
+			if ls.MNC != mnc {
+				t.Errorf("LockState.MNC = %#x, want %#x", ls.MNC, mnc)
+			}
+			if ls.LocationArea != la {
+				t.Errorf("LockState.LocationArea = %#x, want %#x", ls.LocationArea, la)
+			}
+			return
+		}
+	}
+}
+
+func TestProcessHandlesPDUSpanningCalls(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, Log: slog.Default(), SystemName: "Sys"})
+
+	payload := make([]byte, 11)
+	payload[0] = 0x40 // MCC bits — anything non-zero so SystemBroadcast parses
+	pdu := PDU{Disc: DiscMLE, Type: uint8(MLESystemInfo), Payload: payload}
+	pduBits := framing.UnpackBitsMSB(AssemblePDU(pdu), 96)
+	pduDibits := framing.BitsToDibits(pduBits)
+
+	chunk1 := make([]uint8, 50)
+	chunk1 = append(chunk1, NormalSyncDibits()...)
+	cc.Process(chunk1, 0)
+	cc.Process(pduDibits, len(chunk1))
+
+	var sawLock bool
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind == events.KindCCLocked {
+				sawLock = true
+			}
+		default:
+			if !sawLock {
+				t.Errorf("Process did not publish a KindCCLocked across the chunk boundary")
+			}
+			return
+		}
+	}
+}
+
+func TestProcessIgnoresGarbageWithoutSync(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, Log: slog.Default(), SystemName: "Sys"})
+
+	garbage := make([]uint8, 2000)
+	for i := range garbage {
+		garbage[i] = uint8(i % 4)
+	}
+	cc.Process(garbage, 0)
+
+	select {
+	case ev := <-sub.C:
+		t.Errorf("unexpected event from garbage stream: %v", ev.Kind)
+	default:
+	}
+}
+
+func TestSyncDetectorReset(t *testing.T) {
+	det := NewSyncDetector(NormalSyncDibits(), 0)
+	junk := make([]uint8, 100)
+	det.Process(nil, junk, 0)
+	det.Reset()
+	if det.primed != 0 {
+		t.Errorf("post-Reset primed = %d, want 0", det.primed)
+	}
+	if det.pos != 0 {
+		t.Errorf("post-Reset pos = %d, want 0", det.pos)
+	}
+}

--- a/internal/scanner/ccdecoder/decoder_test.go
+++ b/internal/scanner/ccdecoder/decoder_test.go
@@ -269,6 +269,23 @@ func TestP25Phase1FactoryConstructs(t *testing.T) {
 	}
 }
 
+func TestTETRAFactoryConstructs(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	p, err := newTETRAPipeline(PipelineOptions{
+		Bus: bus, SystemName: "Smoke",
+		FrequencyHz: 412_062_500, SampleRateHz: 144_000,
+	})
+	if err != nil {
+		t.Fatalf("newTETRAPipeline: %v", err)
+	}
+	p.Process(make([]complex64, 14400))
+	p.Reset()
+	if err := p.Close(); err != nil {
+		t.Errorf("Close: %v", err)
+	}
+}
+
 func TestP25Phase2FactoryConstructs(t *testing.T) {
 	bus := events.NewBus(8)
 	defer bus.Close()

--- a/internal/scanner/ccdecoder/pipelines.go
+++ b/internal/scanner/ccdecoder/pipelines.go
@@ -23,6 +23,8 @@ import (
 	p25phase1rx "github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase1/receiver"
 	p25phase2 "github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase2"
 	p25phase2rx "github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase2/receiver"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/tetra"
+	tetrarx "github.com/MattCheramie/GopherTrunk/internal/radio/tetra/receiver"
 	"github.com/MattCheramie/GopherTrunk/internal/radio/ysf"
 	ysfrx "github.com/MattCheramie/GopherTrunk/internal/radio/ysf/receiver"
 	"github.com/MattCheramie/GopherTrunk/internal/trunking"
@@ -84,6 +86,7 @@ var factories = map[trunking.Protocol]PipelineFactory{
 	trunking.ProtocolMotorola:  newMotorolaPipeline,
 	trunking.ProtocolLTR:       newLTRPipeline,
 	trunking.ProtocolMPT1327:   newMPT1327Pipeline,
+	trunking.ProtocolTETRA:     newTETRAPipeline,
 }
 
 // newP25Phase1Pipeline wires the existing
@@ -151,6 +154,38 @@ type p25Phase2Pipeline struct {
 func (p *p25Phase2Pipeline) Process(iq []complex64) { p.rx.Process(iq) }
 func (p *p25Phase2Pipeline) Reset()                  { p.rx.Reset() }
 func (p *p25Phase2Pipeline) Close() error            { return nil }
+
+// newTETRAPipeline wires internal/radio/tetra/receiver into
+// tetra.ControlChannel.Process. The receiver's DibitSink forwards
+// π/4-DQPSK dibits into the state machine (38-dibit normal
+// training-sequence detect → 48-dibit PDU slice → ParsePDU →
+// Ingest). The RCPC + RM FEC + interleaving across the full TDMA
+// slot are follow-ups; without them the adapter works on test
+// fixtures but typically fails to lock on captured TETRA traffic.
+func newTETRAPipeline(opts PipelineOptions) (ProtocolPipeline, error) {
+	cc := tetra.New(tetra.Options{
+		Bus:         opts.Bus,
+		Log:         opts.Log,
+		SystemName:  opts.SystemName,
+		FrequencyHz: opts.FrequencyHz,
+	})
+	rx := tetrarx.New(tetrarx.Options{
+		SampleRateHz: opts.SampleRateHz,
+		DibitSink: func(dibits []uint8, baseIdx int) {
+			cc.Process(dibits, baseIdx)
+		},
+	})
+	return &tetraPipeline{rx: rx, cc: cc}, nil
+}
+
+type tetraPipeline struct {
+	rx *tetrarx.Receiver
+	cc *tetra.ControlChannel
+}
+
+func (p *tetraPipeline) Process(iq []complex64) { p.rx.Process(iq) }
+func (p *tetraPipeline) Reset()                  { p.rx.Reset() }
+func (p *tetraPipeline) Close() error            { return nil }
 
 // newYSFPipeline wires the existing internal/radio/ysf/receiver
 // into ysf.ControlChannel.Process. YSF lacks a published

--- a/internal/trunking/site.go
+++ b/internal/trunking/site.go
@@ -23,6 +23,7 @@ const (
 	ProtocolLTR                // Logic Trunked Radio (LTR / LTR-Net)
 	ProtocolMPT1327            // MPT 1327 (UK / Commonwealth utility trunking)
 	ProtocolP25Phase2          // P25 Phase 2 (H-DQPSK TDMA, config "p25-phase2")
+	ProtocolTETRA              // TETRA TMO (π/4-DQPSK, ETSI EN 300 392-2)
 )
 
 func (p Protocol) String() string {
@@ -45,14 +46,16 @@ func (p Protocol) String() string {
 		return "mpt1327"
 	case ProtocolP25Phase2:
 		return "p25-phase2"
+	case ProtocolTETRA:
+		return "tetra"
 	default:
 		return "unknown"
 	}
 }
 
 // ParseProtocol maps a string ("p25", "dmr", "nxdn", "dpmr",
-// "edacs", "motorola", "ltr", "mpt1327", "p25-phase2") to a
-// Protocol value.
+// "edacs", "motorola", "ltr", "mpt1327", "p25-phase2", "tetra") to
+// a Protocol value.
 func ParseProtocol(s string) (Protocol, error) {
 	switch strings.ToLower(s) {
 	case "p25":
@@ -73,6 +76,8 @@ func ParseProtocol(s string) (Protocol, error) {
 		return ProtocolMPT1327, nil
 	case "p25-phase2", "p25_phase2", "p25p2":
 		return ProtocolP25Phase2, nil
+	case "tetra":
+		return ProtocolTETRA, nil
 	default:
 		return ProtocolUnknown, fmt.Errorf("trunking: unknown protocol %q", s)
 	}
@@ -95,7 +100,7 @@ func (s System) Validate() error {
 		return errors.New("trunking: system name is required")
 	}
 	if s.Protocol == ProtocolUnknown {
-		return errors.New("trunking: protocol must be p25|p25-phase2|dmr|nxdn|dpmr|edacs|motorola|ltr|mpt1327")
+		return errors.New("trunking: protocol must be p25|p25-phase2|dmr|nxdn|dpmr|edacs|motorola|ltr|mpt1327|tetra")
 	}
 	if len(s.ControlChannels) == 0 {
 		return errors.New("trunking: at least one control_channel frequency is required")


### PR DESCRIPTION
## Summary

**Last per-protocol `ControlChannel.Process(stream, baseIdx)`
adapter from the connector roadmap.** With this PR every trunked
control modulation listed in the Features table has an end-to-end
IQ → CC chain shipping.

Closes the IQ → CC sync layer for **TETRA TMO**. The receiver's
`DibitSink` forwards π/4-DQPSK dibits into
`tetra.ControlChannel.Process`, which:

- Buffers cross-call state via an internal countdown + partial
  PDU slice.
- Runs the 38-dibit normal training-sequence `SyncDetector`
  across each incoming chunk (tolerance 3 since π/4-DQPSK is
  noisier than 4-FSK).
- On each sync match collects 48 dibits = 96 bits = 12 bytes
  (1 header + 11 payload — large enough for `SystemBroadcast`,
  `VoiceGrant`, and `Release` PDUs).
- Hands the bytes to `ParsePDU` + the parsed PDU to the existing
  `Ingest` path, which publishes `KindCCLocked` on `MLE-SYSINFO`
  or any non-idle CMCE PDU and `KindGrant` on `D-CONNECT` /
  `D-TX-GRANTED` variants.

## Daemon-level changes

- **`trunking.Protocol`** gains `ProtocolTETRA` (config string
  `"tetra"`). `ParseProtocol` + `String` + `Validate` recognise
  the new value.
- **`ccdecoder/pipelines.go`** gains `newTETRAPipeline` +
  `tetraPipeline` wrapper, plus a row in the `factories` map.

## Deferred to a follow-up

RCPC + RM FEC + interleaving across the full TDMA slot aren't
reversed here. The adapter reads PDU information bits straight
from the wire, which works on test fixtures (no FEC) but typically
fails on captured TETRA traffic.

## Test plan

- [x] `go test ./internal/radio/tetra/... -race -v`
- [x] `go test ./internal/scanner/ccdecoder/... ./internal/trunking/... -race`
- [x] `go test -tags integration -race -count=1 ./cmd/gophertrunk/...`
- [x] `go build ./...`
- [x] `go vet ./...`

New tests cover:
- A 50-dibit-padded sync + valid `MLE-SYSINFO` PDU with known
  MCC / MNC / LocationArea triggers `KindCCLocked` with the right
  identifier fields.
- A PDU split across two Process calls still locks the channel.
- Garbage without a sync produces no events.
- `SyncDetector.Reset` clears `primed` + `pos`.
- ccdecoder smoke construction of the new TETRA factory.

## README

- "Status & known gaps" **rewritten** — the section now opens
  with "Every trunked control modulation has an end-to-end IQ →
  CC chain shipping" and lists the remaining gaps as
  cross-cutting follow-ups (per-protocol on-air FEC layers,
  complex-IQ clock recovery for π/4-DQPSK, digital-voice level
  calibration) rather than per-protocol adapter work.
- "Recently shipped" gains a bullet for the TETRA adapter
  + factory wiring + FEC deferral.

## Milestone

This completes the per-protocol adapter sweep. **9 out of 10
trunked protocols** (P25 P1, P25 P2, DMR Tier III, NXDN, dPMR,
EDACS, Motorola, LTR, MPT 1327, TETRA) now have an end-to-end
sync-layer IQ → CC chain wired through the `ccdecoder` connector
the daemon spawns. **DMR Tier III** is the only one with full FEC
shipping today (BPTC(196,96) + CSBK CRC); the others have their
FEC layers documented as follow-ups.


---
_Generated by [Claude Code](https://claude.ai/code/session_019dtCCVEZJTKKr6YK3wy824)_