### PR TITLE
internal/radio: Motorola BCH(64,16,11) FEC implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,10 +73,12 @@ The remaining gaps:
   K=5 Viterbi + interleaver over the 288-wire-bit Info field is
   still pending. **LTR** has a `SetManchesterMode` config for
   deployments that bi-phase-encode the sub-audible status word;
-  FCS verification (12-bit trailer) is still pending. The other
-  protocols (EDACS, Motorola, MPT 1327, P25 Phase 2, TETRA)
-  still have their per-protocol FEC layers pending — see each
-  adapter PR for the specific FEC parameters.
+  FCS verification (12-bit trailer) is still pending.
+  **Motorola Type II** has `SetBCHMode(BCHOn)` to run
+  BCH(64,16,11) over each codeword pair. The remaining
+  protocols (EDACS, MPT 1327, P25 Phase 2, TETRA) still have
+  their per-protocol FEC layers pending — see each adapter PR
+  for the specific FEC parameters.
 - **Symbol-time clock recovery on complex IQ** for the π/4-DQPSK
   family (P25 Phase 2, TETRA). The receivers currently do naive
   decimation; Gardner-style timing recovery on complex IQ is the
@@ -147,6 +149,19 @@ to its own package and lands independently.
 
 ### Recently shipped
 
+- **Motorola BCH(64,16,11) FEC.** `framing/bch.go` gains
+  `BCHEncode64_16` / `BCHDecode64_16` — the existing BCH(63,16,11)
+  primitive used by P25 Phase 1 NID, extended with an overall-
+  even-parity bit. The Motorola adapter gains `SetBCHMode(BCHOff
+  | BCHOn)`; when on, the adapter reads two 64-bit codewords
+  (128 channel bits) after each sync, decodes each via the
+  framing primitive, and concatenates the recovered 16-bit
+  halves into the 32-bit OSW. Uncorrectable codewords (> 11
+  errors) drop the frame silently. Tests cover the framing
+  primitive (round-trip, single-bit corrections, parity-flip
+  detection, > 11-bit rejection) plus an end-to-end Motorola
+  Process call decoding a BCH-encoded `OpGroupVoiceChannelGrant`
+  OSW.
 - **FEC bundle: framing `ManchesterEncode` / `ManchesterDecode` /
   `ManchesterDecodeMajority` helpers + LTR Manchester opt-in +
   NXDN CAC CRC strict-mode.** First FEC implementations PR.

--- a/internal/radio/framing/bch.go
+++ b/internal/radio/framing/bch.go
@@ -64,3 +64,54 @@ func BCHDecode63_16(cw uint64) (uint16, int) {
 func BCH6316ParityBit(cw uint64) byte {
 	return byte(PopCount64(cw&((uint64(1)<<63)-1)) & 1)
 }
+
+// BCHEncode64_16 encodes 16 information bits into a 64-bit BCH
+// codeword: the 63-bit BCH(63,16,11) codeword from BCHEncode63_16
+// plus a trailing overall-even-parity bit. This is the FEC layer
+// used by Motorola Type II / SmartZone control-channel OSWs (each
+// OSW frame carries two BCH(64,16,11) codewords concatenated; two
+// codewords' 16 info bits each combine into the OSW's 32-bit
+// {Address, Command} field).
+//
+// Bit 0 of the returned uint64 is the parity bit; bits 1..63 are
+// the 63-bit BCH codeword (info in the high 16 bits of that
+// range, parity in the low 47). Encoders that want the canonical
+// MSB-first 64-bit wire representation should pack [parity, bch63
+// high → low].
+func BCHEncode64_16(data uint16) uint64 {
+	cw63 := BCHEncode63_16(data)
+	parity := uint64(BCH6316ParityBit(cw63))
+	return (cw63 << 1) | parity
+}
+
+// BCHDecode64_16 decodes a 64-bit BCH codeword by extracting the
+// 63-bit BCH(63,16,11) codeword (top 63 bits) and the trailing
+// parity bit, running BCHDecode63_16 on the 63-bit codeword, and
+// reporting the corrected info + total error count.
+//
+// Returns (data, errors) where errors is the bit-error count
+// corrected. errors = -1 means uncorrectable (the inner BCH
+// decoder reported > 11 errors); the returned data is the closest
+// codeword's info but should not be trusted.
+//
+// The trailing parity bit is included in the error count: if the
+// 63-bit decode reports E errors AND the recomputed parity over
+// the corrected 63-bit codeword doesn't match the received
+// parity, the total is E + 1 (still uncorrectable if E > 10).
+func BCHDecode64_16(cw uint64) (uint16, int) {
+	parity := byte(cw & 1)
+	cw63 := (cw >> 1) & ((uint64(1) << 63) - 1)
+	data, errs := BCHDecode63_16(cw63)
+	if errs < 0 {
+		return data, -1
+	}
+	// Recompute parity over the corrected 63-bit codeword.
+	gotParity := BCH6316ParityBit(BCHEncode63_16(data))
+	if gotParity != parity {
+		errs++
+		if errs > 11 {
+			return data, -1
+		}
+	}
+	return data, errs
+}

--- a/internal/radio/framing/bch_test.go
+++ b/internal/radio/framing/bch_test.go
@@ -2,6 +2,72 @@ package framing
 
 import "testing"
 
+// TestBCH6416RoundTrip: every clean BCH(64,16,11) codeword
+// decodes back to its source info with zero errors.
+func TestBCH6416RoundTrip(t *testing.T) {
+	for d := uint32(0); d < 1<<16; d += 257 {
+		cw := BCHEncode64_16(uint16(d))
+		got, errs := BCHDecode64_16(cw)
+		if errs != 0 {
+			t.Errorf("d=%04x: clean decode reported %d errors", d, errs)
+		}
+		if uint32(got) != d {
+			t.Errorf("d=%04x: decode round-trip = %04x", d, got)
+		}
+	}
+}
+
+// TestBCH6416CorrectsSingleBitErrors: flip any single bit in a
+// 64-bit codeword and confirm the decoder still recovers the
+// original info with errors == 1.
+func TestBCH6416CorrectsSingleBitErrors(t *testing.T) {
+	data := uint16(0xABCD)
+	cw := BCHEncode64_16(data)
+	for bit := 0; bit < 64; bit++ {
+		corrupted := cw ^ (uint64(1) << uint(bit))
+		got, errs := BCHDecode64_16(corrupted)
+		if errs != 1 {
+			t.Errorf("bit=%d: errs = %d, want 1", bit, errs)
+		}
+		if got != data {
+			t.Errorf("bit=%d: data = %04x, want %04x", bit, got, data)
+		}
+	}
+}
+
+// TestBCH6416DetectsParityFlip: flipping the trailing parity bit
+// alone is uncorrectable by the 63-bit BCH but the decoder must
+// still report errs >= 1 (not a clean decode).
+func TestBCH6416DetectsParityFlip(t *testing.T) {
+	data := uint16(0x5A5A)
+	cw := BCHEncode64_16(data)
+	corrupted := cw ^ 1 // flip the parity bit
+	got, errs := BCHDecode64_16(corrupted)
+	if errs < 1 {
+		t.Errorf("errs = %d, want >= 1", errs)
+	}
+	if got != data {
+		t.Errorf("data = %04x, want %04x (parity flip should still recover info)",
+			got, data)
+	}
+}
+
+// TestBCH6416RejectsManyErrors: corrupt 12 bits in a 64-bit
+// codeword (one past the 11-bit correction limit) and confirm
+// the decoder reports errs == -1.
+func TestBCH6416RejectsManyErrors(t *testing.T) {
+	data := uint16(0xDEAD)
+	cw := BCHEncode64_16(data)
+	// Flip bits 0..11 — 12 bit flips.
+	for bit := 0; bit < 12; bit++ {
+		cw ^= uint64(1) << uint(bit)
+	}
+	_, errs := BCHDecode64_16(cw)
+	if errs != -1 {
+		t.Errorf("errs = %d, want -1 (uncorrectable)", errs)
+	}
+}
+
 func TestBCH6316RoundTrip(t *testing.T) {
 	// Sparse sweep across the 65536-entry info space; brute-force decode
 	// is ~1 ms per call so an exhaustive sweep would dominate the test

--- a/internal/radio/motorola/control.go
+++ b/internal/radio/motorola/control.go
@@ -39,6 +39,13 @@ type ControlChannel struct {
 	// Process call.
 	proc *processState
 
+	// bchMode controls whether the Process adapter runs the
+	// BCH(64,16,11) FEC over each on-air codeword. Set via
+	// SetBCHMode; default BCHOff treats the 32 bits after sync
+	// as raw OSW info (works for test fixtures + clean signals
+	// but not for noisy on-air traffic).
+	bchMode BCHMode
+
 	mu     sync.Mutex
 	locked bool
 	last   LockState

--- a/internal/radio/motorola/process.go
+++ b/internal/radio/motorola/process.go
@@ -1,5 +1,7 @@
 package motorola
 
+import "github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+
 // processState is the cross-call bit buffering + sync-detection
 // state the Process adapter holds. Lazily initialised on the first
 // Process call.
@@ -10,20 +12,54 @@ type processState struct {
 	matchScratch []int
 }
 
+// BCHMode controls whether the Process adapter runs the
+// BCH(64,16,11) FEC over each on-air codeword pair before
+// reassembling the 32-bit OSW. Configurable via SetBCHMode.
+type BCHMode uint8
+
+const (
+	// BCHOff treats the 32 bits after sync as raw OSW info bits.
+	// Works for test fixtures + clean signals; on-air traffic
+	// usually fails OSW parsing.
+	BCHOff BCHMode = iota
+	// BCHOn reads two 64-bit BCH(64,16,11) codewords (128 wire
+	// bits) after sync, decodes each via the framing primitive,
+	// and concatenates the recovered 16-bit halves into the
+	// 32-bit OSW. Uncorrectable codewords (> 11 errors) drop the
+	// frame.
+	BCHOn
+)
+
+// SetBCHMode configures whether the Process adapter runs
+// BCH(64,16,11) FEC over each codeword pair. Call before the
+// first Process call; switching mode mid-stream resets the
+// adapter's buffer.
+func (c *ControlChannel) SetBCHMode(m BCHMode) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.bchMode = m
+	if c.proc != nil {
+		c.proc.remaining = 0
+		c.proc.osw = c.proc.osw[:0]
+	}
+}
+
 // oswInfoBits is the count of bits the adapter collects after each
-// 24-bit sync match: 32 information bits = one OSW. The on-air
-// 84-bit OSW frame (with BCH(64,16,11) FEC over the upper 64 bits)
-// isn't reversed here — the adapter reads the 32 information bits
-// straight from the wire, which works for test fixtures + clean
-// signals but typically fails on noisy on-air captures. Adding the
-// BCH layer is a documented follow-up.
+// 24-bit sync match in BCHOff mode: 32 information bits = one OSW.
 const oswInfoBits = 32
+
+// oswBCHBits is the count of bits the adapter collects after each
+// sync match in BCHOn mode: two 64-bit BCH(64,16,11) codewords =
+// 128 channel bits, decoding to 32 information bits.
+const oswBCHBits = 128
 
 // Process consumes a window of raw bits from the Motorola receiver
 // (the IQ → MSK bit chain in internal/radio/motorola/receiver/),
 // runs the 24-bit outbound sync detector, slices the following
-// 32-bit OSW out of the stream, parses it via OSWFromBits, and
-// forwards the result to Ingest.
+// codeword window (32 raw bits in BCHOff mode, 128 channel bits
+// across two BCH(64,16,11) codewords in BCHOn mode) out of the
+// stream, parses it via OSWFromBits, and forwards the result to
+// Ingest.
 //
 // baseIdx is the absolute bit index of bits[0] across the stream
 // lifetime. The adapter's internal countdown survives across
@@ -36,7 +72,7 @@ func (c *ControlChannel) Process(bits []byte, baseIdx int) int {
 	if c.proc == nil {
 		c.proc = &processState{
 			det: NewSyncDetector(OutboundSyncBits(), 1),
-			osw: make([]byte, 0, oswInfoBits),
+			osw: make([]byte, 0, oswBCHBits),
 		}
 	}
 	p := c.proc
@@ -44,25 +80,94 @@ func (c *ControlChannel) Process(bits []byte, baseIdx int) int {
 	p.matchScratch, _ = p.det.Process(p.matchScratch[:0], bits, baseIdx)
 	matchIdx := 0
 
+	postSyncBits := c.codewordBitsForMode()
+
 	for i, b := range bits {
 		absPos := baseIdx + i
 		if p.remaining > 0 {
 			p.osw = append(p.osw, b&1)
 			p.remaining--
 			if p.remaining == 0 {
-				if osw, err := OSWFromBits(p.osw); err == nil {
-					c.Ingest(osw)
-				}
+				c.tryIngestOSW(p.osw)
 				p.osw = p.osw[:0]
 			}
 		}
 		for matchIdx < len(p.matchScratch) && p.matchScratch[matchIdx] == absPos {
-			p.remaining = oswInfoBits
+			p.remaining = postSyncBits
 			p.osw = p.osw[:0]
 			matchIdx++
 		}
 	}
 	return baseIdx + len(bits)
+}
+
+// codewordBitsForMode returns how many bits Process collects
+// after each sync, based on the current BCH mode.
+func (c *ControlChannel) codewordBitsForMode() int {
+	c.mu.Lock()
+	m := c.bchMode
+	c.mu.Unlock()
+	if m == BCHOn {
+		return oswBCHBits
+	}
+	return oswInfoBits
+}
+
+// tryIngestOSW reconstructs an OSW from the post-sync bits and
+// hands it to Ingest. In BCHOff mode the bits are used directly;
+// in BCHOn mode each 64-bit codeword runs through BCHDecode64_16
+// and the two recovered 16-bit halves are concatenated.
+func (c *ControlChannel) tryIngestOSW(post []byte) {
+	c.mu.Lock()
+	m := c.bchMode
+	c.mu.Unlock()
+	switch m {
+	case BCHOn:
+		if len(post) != oswBCHBits {
+			return
+		}
+		half1, errs1 := framing.BCHDecode64_16(bitsToUint64(post[0:64]))
+		if errs1 < 0 {
+			return
+		}
+		half2, errs2 := framing.BCHDecode64_16(bitsToUint64(post[64:128]))
+		if errs2 < 0 {
+			return
+		}
+		var bits [32]byte
+		for i := 0; i < 16; i++ {
+			bits[i] = byte((half1 >> uint(15-i)) & 1)
+		}
+		for i := 0; i < 16; i++ {
+			bits[16+i] = byte((half2 >> uint(15-i)) & 1)
+		}
+		if osw, err := OSWFromBits(bits[:]); err == nil {
+			c.Ingest(osw)
+		}
+	default:
+		if len(post) != oswInfoBits {
+			return
+		}
+		if osw, err := OSWFromBits(post); err == nil {
+			c.Ingest(osw)
+		}
+	}
+}
+
+// bitsToUint64 packs up to 64 MSB-first bits into a uint64. Bit
+// 63 of the result is bits[0] (the wire-order leading bit).
+func bitsToUint64(bits []byte) uint64 {
+	var v uint64
+	n := len(bits)
+	if n > 64 {
+		n = 64
+	}
+	for i := 0; i < n; i++ {
+		if bits[i]&1 != 0 {
+			v |= uint64(1) << uint(63-i)
+		}
+	}
+	return v
 }
 
 // Reset clears the SyncDetector's history so a stale match doesn't

--- a/internal/radio/motorola/process_test.go
+++ b/internal/radio/motorola/process_test.go
@@ -120,6 +120,88 @@ func TestProcessHandlesSyncSpanningCalls(t *testing.T) {
 	}
 }
 
+// TestProcessBCHModeDecodesEncodedOSW: in BCHOn mode the adapter
+// must read two 64-bit BCH(64,16,11) codewords after sync and
+// recover the underlying 32-bit OSW.
+func TestProcessBCHModeDecodesEncodedOSW(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{
+		Bus: bus, Log: slog.Default(), SystemName: "Sys",
+		FrequencyHz: 851_012_500,
+	})
+	cc.SetBCHMode(BCHOn)
+
+	cmd := (uint16(OpGroupVoiceChannelGrant) << 4) | 0x4
+	osw := OSW{Address: 0xC0DE, Command: cmd}
+
+	// Encode the OSW's two 16-bit halves through BCH(64,16,11)
+	// and pack into a 128-bit channel stream.
+	cw1 := framingBCHEncode64_16(osw.Address)
+	cw2 := framingBCHEncode64_16(osw.Command)
+	encoded := make([]byte, 128)
+	for i := 0; i < 64; i++ {
+		if cw1&(uint64(1)<<uint(63-i)) != 0 {
+			encoded[i] = 1
+		}
+	}
+	for i := 0; i < 64; i++ {
+		if cw2&(uint64(1)<<uint(63-i)) != 0 {
+			encoded[64+i] = 1
+		}
+	}
+
+	stream := make([]byte, 30)
+	stream = append(stream, OutboundSyncBits()...)
+	stream = append(stream, encoded...)
+
+	cc.Process(stream, 0)
+
+	var sawGrant bool
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind == events.KindGrant {
+				g, _ := ev.Payload.(trunking.Grant)
+				if g.GroupID == 0xC0DE {
+					sawGrant = true
+				}
+			}
+		default:
+			if !sawGrant {
+				t.Errorf("BCHOn mode did not publish a KindGrant for the encoded OSW")
+			}
+			return
+		}
+	}
+}
+
+// framingBCHEncode64_16 is a tiny shim so this test file doesn't
+// import framing directly (which would require widening the
+// existing test file's import set).
+func framingBCHEncode64_16(data uint16) uint64 {
+	// Reproduce framing.BCHEncode64_16 inline. Keeping this local
+	// avoids a wider import for one test.
+	const generator uint64 = 0xF391E2F34B99
+	info := uint64(data) & 0xFFFF
+	rem := info << 47
+	for i := 62; i >= 47; i-- {
+		if rem&(uint64(1)<<uint(i)) != 0 {
+			rem ^= generator << uint(i-47)
+		}
+	}
+	cw63 := (info << 47) | (rem & ((uint64(1) << 47) - 1))
+	// Append overall-even parity bit at bit 0.
+	parity := uint64(0)
+	for b := 0; b < 63; b++ {
+		parity ^= (cw63 >> uint(b)) & 1
+	}
+	return (cw63 << 1) | parity
+}
+
 func TestSyncDetectorReset(t *testing.T) {
 	det := NewSyncDetector(OutboundSyncBits(), 0)
 	junk := make([]byte, 100)


### PR DESCRIPTION
## Summary

Second FEC PR. Implements the **BCH(64,16,11)** error-correcting
code used by Motorola Type II / SmartZone control-channel OSWs.

### `framing/bch.go` — new primitives

- `BCHEncode64_16(data uint16) uint64` — wraps the existing
  `BCHEncode63_16` and appends an overall-even-parity bit at
  bit 0 of the returned uint64.
- `BCHDecode64_16(cw uint64) (data, errors int)` — strips
  parity, runs `BCHDecode63_16`, then recomputes parity over the
  corrected 63-bit codeword and folds the parity-mismatch into
  the total error count. Returns `errors = -1` when
  uncorrectable.

### Motorola adapter

- New `SetBCHMode(BCHOff | BCHOn)`.
  - `BCHOff` (default) keeps existing behaviour: 32 bits after
    sync = raw OSW.
  - `BCHOn` reads 128 channel bits after each sync (two
    BCH(64,16,11) codewords), decodes each via the framing
    primitive, and concatenates the recovered 16-bit halves into
    the 32-bit `{Address, Command}` OSW.
- Uncorrectable codewords (> 11 errors) silently drop the frame.
- Mode-switch mid-stream resets the pending OSW buffer so stale
  half-codewords don't bleed across the switch.

## Test plan

- [x] `go test ./internal/radio/framing/... ./internal/radio/motorola/... -race`
- [x] `go build ./...`
- [x] `go vet ./internal/radio/motorola/...`

New tests cover:
- BCH(64,16,11) clean round-trip across a sparse sweep of the
  65536-entry info space.
- Single-bit error correction at every position 0..63.
- Parity-flip-only detection (`errs >= 1`, info still
  recovered).
- > 11-bit rejection (`errs = -1`).
- End-to-end Motorola `Process` call decoding a BCH-encoded
  `OpGroupVoiceChannelGrant` OSW (synthesised via
  `BCHEncode64_16` of the Address + Command halves) into a
  `KindGrant` with the right `GroupID`.

## README

- "Status & known gaps" updated — Motorola moves to "FEC
  shipping (BCH(64,16,11))"; remaining protocols (EDACS, MPT
  1327, P25 P2, TETRA) still pending.
- "Recently shipped" gains a bullet for the BCH primitive +
  Motorola wiring.

## Next FEC bundles

- MPT 1327 BCH(63,38) syndrome-check FEC
- EDACS interleaved Reed-Solomon + P25 Phase 2 Trellis FEC
- TETRA RCPC + RM FEC + complex-IQ clock recovery


---
_Generated by [Claude Code](https://claude.ai/code/session_019dtCCVEZJTKKr6YK3wy824)_