### PR TITLE
internal/radio: cross-protocol SetStrictValidation for LTR + dPMR + TETRA + P25 Phase 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,26 @@ to its own package and lands independently.
 
 ### Recently shipped
 
+- **Cross-protocol strict-validation FEC bundle: LTR + dPMR +
+  TETRA + P25 Phase 2 `SetStrictValidation(bool)`.** Extends
+  the soft-FEC noise filter from the previous PR across the
+  remaining four protocols, completing the family of seven.
+  Same pattern as the EDACS / Motorola / MPT 1327 bundle: each
+  Ingest path now drops frames whose opcode / type / range
+  fields fall outside the documented set before the state
+  machine acts on them. dPMR rejects CSBKs whose 5-bit
+  MessageType is unallocated (per ETSI TS 102 658 §6.5.2);
+  TETRA rejects PDUs whose (Discriminator, Type) pair isn't in
+  the documented CMCE / MLE set (also drops MM and SDS sub-
+  protocols, which the state machine doesn't surface for
+  trunking); P25 Phase 2 rejects MAC PDUs whose 8-bit Opcode
+  is outside the TIA-102.AABF / BBAB table; LTR rejects Status
+  words whose Channel or Home field falls outside the
+  documented 1..20 range. Each protocol also gains an
+  `IsKnown()` / `IsWellFormed()` method on its enum / status
+  type for callers that want to apply the same allow-list
+  themselves. Strict validation is now available on every
+  protocol with an enumerable opcode space.
 - **Cross-protocol strict-validation FEC bundle: EDACS +
   Motorola + MPT 1327 `SetStrictValidation(bool)`.** Each
   adapter gains a soft-FEC noise-reduction mode that rejects

--- a/internal/radio/dpmr/control.go
+++ b/internal/radio/dpmr/control.go
@@ -36,9 +36,22 @@ type ControlChannel struct {
 	// don't pay the construction cost.
 	proc *processState
 
-	mu     sync.Mutex
-	locked bool
-	last   LockState
+	mu               sync.Mutex
+	locked           bool
+	last             LockState
+	strictValidation bool
+}
+
+// SetStrictValidation toggles the strict frame-validity filter on the
+// Ingest path. When enabled, CSBKs whose 5-bit MessageType is not in
+// the documented ETSI TS 102 658 §6.5.2 set are silently dropped at
+// Ingest time. The Process adapter already filters at the framing
+// layer; strict-mode tightens it further so PDUs from a
+// misaligned-but-passing window still drop out.
+func (c *ControlChannel) SetStrictValidation(strict bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.strictValidation = strict
 }
 
 // Options configure a ControlChannel.
@@ -75,6 +88,12 @@ func New(opts Options) *ControlChannel {
 // captures arrive via an upstream 4FSK demod + FEC; tests publish
 // CSBKs directly.
 func (c *ControlChannel) Ingest(b CSBK) {
+	c.mu.Lock()
+	strict := c.strictValidation
+	c.mu.Unlock()
+	if strict && !b.Type.IsKnown() {
+		return
+	}
 	if b.IsIdle() {
 		return
 	}

--- a/internal/radio/dpmr/opcodes.go
+++ b/internal/radio/dpmr/opcodes.go
@@ -105,3 +105,18 @@ func (c CSBK) IsIdle() bool {
 	}
 	return false
 }
+
+// IsKnown reports whether the MessageType is one of the documented
+// ETSI TS 102 658 §6.5.2 values the state machine recognises. Used
+// by SetStrictValidation to drop CSBKs whose 5-bit Message Type field
+// falls in the unallocated range.
+func (m MessageType) IsKnown() bool {
+	switch m {
+	case MsgRegistrationRequest, MsgRegistrationResponse,
+		MsgVoiceServiceAllocation, MsgIndividualVoiceAllocation,
+		MsgDataServiceAllocation, MsgServiceRequest,
+		MsgStandingServiceStatus, MsgRelease, MsgIdle:
+		return true
+	}
+	return false
+}

--- a/internal/radio/dpmr/strict_test.go
+++ b/internal/radio/dpmr/strict_test.go
@@ -1,0 +1,85 @@
+package dpmr
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+)
+
+// TestStrictValidationDropsUnknownMessageType: a CSBK whose 5-bit
+// MessageType field is not in the documented ETSI TS 102 658 §6.5.2
+// set must be dropped by Ingest under SetStrictValidation(true).
+func TestStrictValidationDropsUnknownMessageType(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, Log: slog.Default(), SystemName: "Sys"})
+	cc.SetStrictValidation(true)
+
+	// MessageType 0x10 is in the unallocated range.
+	cc.Ingest(CSBK{Type: MessageType(0x10), SourceID: 0x111111, DestID: 0x222222})
+
+	select {
+	case ev := <-sub.C:
+		t.Errorf("strict-mode CSBK with unknown MessageType published %v", ev.Kind)
+	default:
+	}
+}
+
+// TestStrictValidationKeepsKnownMessageType: a CSBK with a recognised
+// MessageType must still publish its event under strict mode.
+func TestStrictValidationKeepsKnownMessageType(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, Log: slog.Default(), SystemName: "Sys"})
+	cc.SetStrictValidation(true)
+
+	cc.Ingest(CSBK{
+		Type:     MsgVoiceServiceAllocation,
+		Flags:    FlagGroupCall,
+		SourceID: 0xAAAAAA,
+		DestID:   0xBBBBBB,
+		Extra:    7,
+	})
+
+	got := 0
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind == events.KindGrant {
+				got++
+			}
+		default:
+			if got == 0 {
+				t.Errorf("strict-mode CSBK with known MessageType did not publish a Grant")
+			}
+			return
+		}
+	}
+}
+
+func TestMessageTypeIsKnownCoversDocumentedConstants(t *testing.T) {
+	known := []MessageType{
+		MsgRegistrationRequest, MsgRegistrationResponse,
+		MsgVoiceServiceAllocation, MsgIndividualVoiceAllocation,
+		MsgDataServiceAllocation, MsgServiceRequest,
+		MsgStandingServiceStatus, MsgRelease, MsgIdle,
+	}
+	for _, m := range known {
+		if !m.IsKnown() {
+			t.Errorf("MessageType %#x should be known", uint8(m))
+		}
+	}
+	if MsgUnknown.IsKnown() {
+		t.Errorf("MsgUnknown should NOT be known")
+	}
+	if MessageType(0x10).IsKnown() {
+		t.Errorf("MessageType 0x10 should NOT be known")
+	}
+}

--- a/internal/radio/ltr/control.go
+++ b/internal/radio/ltr/control.go
@@ -55,7 +55,20 @@ type ControlChannel struct {
 	// activeGroup tracks the group currently announced as active so
 	// repeated grant frames during one call don't republish a new
 	// grant on every status word.
-	activeGroup uint16
+	activeGroup      uint16
+	strictValidation bool
+}
+
+// SetStrictValidation toggles the strict frame-validity filter on the
+// Ingest path. When enabled, Status words whose fixed-range fields
+// (Channel 1..20, Home 1..20) fall outside the documented set are
+// silently dropped at Ingest time. The Process adapter already
+// filters at the framing layer; strict-mode tightens it further so
+// frames from a misaligned-but-passing sync window still drop out.
+func (c *ControlChannel) SetStrictValidation(strict bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.strictValidation = strict
 }
 
 // Options configure a ControlChannel.
@@ -97,6 +110,12 @@ func New(opts Options) *ControlChannel {
 // arrive from an upstream sub-audible 300-baud demod; tests publish
 // status words directly.
 func (c *ControlChannel) Ingest(s Status) {
+	c.mu.Lock()
+	strict := c.strictValidation
+	c.mu.Unlock()
+	if strict && !s.IsWellFormed() {
+		return
+	}
 	if !s.Sync {
 		// Malformed frame; drop.
 		return

--- a/internal/radio/ltr/status.go
+++ b/internal/radio/ltr/status.go
@@ -125,3 +125,21 @@ func StatusBits(s Status) []byte {
 // on this repeater. By convention LTR sets the Group ("F") bit to 1
 // while a group is transmitting and the GroupID is non-zero.
 func (s Status) IsActive() bool { return s.Group && s.GroupID != 0 }
+
+// IsWellFormed reports whether the status word's fixed-range fields
+// look like a legitimate LTR frame rather than noise that happened to
+// pass the sync test. LTR channels are numbered 1..20 and the home
+// repeater identifier is 1..20; either field being zero means the
+// frame was almost certainly bit-garbage.
+func (s Status) IsWellFormed() bool {
+	if !s.Sync {
+		return false
+	}
+	if s.Channel == 0 || s.Channel > 20 {
+		return false
+	}
+	if s.Home == 0 || s.Home > 20 {
+		return false
+	}
+	return true
+}

--- a/internal/radio/ltr/strict_test.go
+++ b/internal/radio/ltr/strict_test.go
@@ -1,0 +1,111 @@
+package ltr
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+)
+
+// TestStrictValidationDropsMalformedStatus: a Status word with
+// Channel == 0 (outside the documented 1..20 range) must be dropped
+// by Ingest under SetStrictValidation(true). Without strict mode the
+// same status would still pass through Ingest because Sync is set.
+func TestStrictValidationDropsMalformedStatus(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, Log: slog.Default(), SystemName: "Sys"})
+	cc.SetStrictValidation(true)
+
+	cc.Ingest(Status{Sync: true, Area: 1, Channel: 0, Home: 5})
+
+	select {
+	case ev := <-sub.C:
+		t.Errorf("strict-mode malformed Status published %v", ev.Kind)
+	default:
+	}
+}
+
+// TestStrictValidationDropsOutOfRangeHome: a Status word with Home
+// outside 1..20 must be dropped under strict mode.
+func TestStrictValidationDropsOutOfRangeHome(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, Log: slog.Default(), SystemName: "Sys"})
+	cc.SetStrictValidation(true)
+
+	cc.Ingest(Status{Sync: true, Area: 1, Channel: 3, Home: 25})
+
+	select {
+	case ev := <-sub.C:
+		t.Errorf("strict-mode Status with Home=25 published %v", ev.Kind)
+	default:
+	}
+}
+
+// TestStrictValidationKeepsWellFormedStatus: a Status word with all
+// fixed-range fields in the documented spans must still publish a
+// cc.locked under strict mode.
+func TestStrictValidationKeepsWellFormedStatus(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, Log: slog.Default(), SystemName: "Sys"})
+	cc.SetStrictValidation(true)
+
+	cc.Ingest(Status{
+		Sync:    true,
+		Area:    1,
+		Channel: 3,
+		Home:    5,
+		GroupID: 42,
+		Group:   true,
+	})
+
+	got := 0
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind == events.KindCCLocked {
+				got++
+			}
+		default:
+			if got == 0 {
+				t.Errorf("strict-mode well-formed Status did not publish a CCLocked")
+			}
+			return
+		}
+	}
+}
+
+func TestIsWellFormedCoversValidAndInvalidRanges(t *testing.T) {
+	for ch := uint8(1); ch <= 20; ch++ {
+		s := Status{Sync: true, Channel: ch, Home: 10}
+		if !s.IsWellFormed() {
+			t.Errorf("Channel %d should be well-formed", ch)
+		}
+	}
+	for _, ch := range []uint8{0, 21, 22, 31} {
+		s := Status{Sync: true, Channel: ch, Home: 10}
+		if s.IsWellFormed() {
+			t.Errorf("Channel %d should NOT be well-formed", ch)
+		}
+	}
+	for _, h := range []uint8{0, 21, 25, 31} {
+		s := Status{Sync: true, Channel: 1, Home: h}
+		if s.IsWellFormed() {
+			t.Errorf("Home %d should NOT be well-formed", h)
+		}
+	}
+	if (Status{Sync: false, Channel: 1, Home: 1}).IsWellFormed() {
+		t.Errorf("status without Sync should NOT be well-formed")
+	}
+}

--- a/internal/radio/p25/phase2/control.go
+++ b/internal/radio/p25/phase2/control.go
@@ -32,8 +32,21 @@ type ControlChannel struct {
 	// first Process call.
 	proc *processState
 
-	mu     sync.Mutex
-	locked bool
+	mu               sync.Mutex
+	locked           bool
+	strictValidation bool
+}
+
+// SetStrictValidation toggles the strict frame-validity filter on the
+// Ingest path. When enabled, MAC PDUs whose 8-bit Opcode is not in
+// the documented TIA-102.AABF / BBAB set are silently dropped at
+// Ingest time. The Process adapter already filters at the framing
+// layer; strict-mode tightens it further so PDUs from a
+// misaligned-but-passing window still drop out.
+func (c *ControlChannel) SetStrictValidation(strict bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.strictValidation = strict
 }
 
 // Options configure a ControlChannel.
@@ -68,6 +81,12 @@ func New(opts Options) *ControlChannel {
 // captures arrive from an upstream H-DQPSK demod + TDMA superframe
 // sync + Trellis FEC; tests publish PDUs directly.
 func (c *ControlChannel) Ingest(p MACPDU) {
+	c.mu.Lock()
+	strict := c.strictValidation
+	c.mu.Unlock()
+	if strict && !p.Opcode.IsKnown() {
+		return
+	}
 	if p.IsIdle() {
 		return
 	}

--- a/internal/radio/p25/phase2/mac.go
+++ b/internal/radio/p25/phase2/mac.go
@@ -140,3 +140,18 @@ func (p MACPDU) IsIdle() bool {
 	}
 	return false
 }
+
+// IsKnown reports whether the Opcode is one of the documented
+// TIA-102.AABF / BBAB MAC PDU opcodes the state machine recognises.
+// Used by SetStrictValidation to drop PDUs whose 8-bit opcode field
+// falls outside the recognised set.
+func (o Opcode) IsKnown() bool {
+	switch o {
+	case OpMACPTT, OpMACEnd, OpMACIdle, OpMACHangtime, OpMACActive,
+		OpGroupVoiceChannelGrant, OpGroupVoiceChannelGrantUpdate,
+		OpGroupVoiceChannelUserExt, OpUnitToUnitVoiceChannelGrant,
+		OpNetworkStatusBroadcastUpdate, OpRFSSStatusBroadcastUpdate:
+		return true
+	}
+	return false
+}

--- a/internal/radio/p25/phase2/strict_test.go
+++ b/internal/radio/p25/phase2/strict_test.go
@@ -1,0 +1,90 @@
+package phase2
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+)
+
+// TestStrictValidationDropsUnknownOpcode: a MAC PDU whose 8-bit
+// Opcode field is not in the documented TIA-102.AABF / BBAB set must
+// be dropped by Ingest under SetStrictValidation(true).
+func TestStrictValidationDropsUnknownOpcode(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, Log: slog.Default(), SystemName: "Sys"})
+	cc.SetStrictValidation(true)
+
+	// Opcode 0x7E is not in the documented list.
+	cc.Ingest(MACPDU{Opcode: Opcode(0x7E), Payload: make([]byte, 8)})
+
+	select {
+	case ev := <-sub.C:
+		t.Errorf("strict-mode MAC PDU with unknown Opcode published %v", ev.Kind)
+	default:
+	}
+}
+
+// TestStrictValidationKeepsKnownOpcode: a MAC PDU with a recognised
+// Opcode must still publish its event under strict mode.
+func TestStrictValidationKeepsKnownOpcode(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, Log: slog.Default(), SystemName: "Sys"})
+	cc.SetStrictValidation(true)
+
+	// GroupVoiceChannelGrant payload: service options, channel ID+num,
+	// group address, source ID. Channel ID 1, channel 7, talkgroup
+	// 0xCAFE, source 0x123456.
+	payload := []byte{
+		0x00,             // service options
+		0x10, 0x07,       // channel ID 1 (upper 4 bits) + channel 7
+		0xCA, 0xFE,       // group address
+		0x12, 0x34, 0x56, // source ID
+	}
+	cc.Ingest(MACPDU{Opcode: OpGroupVoiceChannelGrant, Payload: payload})
+
+	got := 0
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind == events.KindGrant {
+				got++
+			}
+		default:
+			if got == 0 {
+				t.Errorf("strict-mode MAC PDU with known Opcode did not publish a Grant")
+			}
+			return
+		}
+	}
+}
+
+func TestOpcodeIsKnownCoversDocumentedConstants(t *testing.T) {
+	known := []Opcode{
+		OpMACPTT, OpMACEnd, OpMACIdle, OpMACHangtime, OpMACActive,
+		OpGroupVoiceChannelGrant, OpGroupVoiceChannelGrantUpdate,
+		OpGroupVoiceChannelUserExt, OpUnitToUnitVoiceChannelGrant,
+		OpNetworkStatusBroadcastUpdate, OpRFSSStatusBroadcastUpdate,
+	}
+	for _, o := range known {
+		if !o.IsKnown() {
+			t.Errorf("Opcode %#x should be known", uint8(o))
+		}
+	}
+	if OpUnknown.IsKnown() {
+		t.Errorf("OpUnknown should NOT be known")
+	}
+	for _, o := range []Opcode{0x10, 0x7E, 0x80, 0xC0} {
+		if o.IsKnown() {
+			t.Errorf("Opcode %#x should NOT be known", uint8(o))
+		}
+	}
+}

--- a/internal/radio/tetra/cmce.go
+++ b/internal/radio/tetra/cmce.go
@@ -176,3 +176,30 @@ func (p PDU) IsIdle() bool {
 	}
 	return false
 }
+
+// IsKnown reports whether the PDU's (Discriminator, Type) pair is
+// one of the documented ETSI EN 300 392-2 values the state machine
+// recognises. Used by SetStrictValidation to drop PDUs whose 4-bit
+// type field falls in the unallocated range for the sub-protocol
+// the Discriminator selects.
+func (p PDU) IsKnown() bool {
+	t := PDUType(p.Type)
+	if p.IsCMCE() {
+		switch t {
+		case CMCEDSetup, CMCEDConnect, CMCEDRelease, CMCEDTxCeased,
+			CMCEDTxGranted, CMCEDInfo, CMCEDCallProceeding:
+			return true
+		}
+		return false
+	}
+	if p.IsMLE() {
+		switch t {
+		case MLESystemInfo:
+			return true
+		}
+		return false
+	}
+	// MM and SDS sub-protocols don't carry trunking-relevant grants;
+	// strict mode drops them entirely.
+	return false
+}

--- a/internal/radio/tetra/control.go
+++ b/internal/radio/tetra/control.go
@@ -37,9 +37,22 @@ type ControlChannel struct {
 	// first Process call.
 	proc *processState
 
-	mu     sync.Mutex
-	locked bool
-	last   LockState
+	mu               sync.Mutex
+	locked           bool
+	last             LockState
+	strictValidation bool
+}
+
+// SetStrictValidation toggles the strict frame-validity filter on the
+// Ingest path. When enabled, PDUs whose (Discriminator, Type) pair is
+// not in the documented ETSI EN 300 392-2 set are silently dropped at
+// Ingest time. The Process adapter already filters at the framing
+// layer; strict-mode tightens it further so PDUs from a
+// misaligned-but-passing window still drop out.
+func (c *ControlChannel) SetStrictValidation(strict bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.strictValidation = strict
 }
 
 // Options configure a ControlChannel.
@@ -76,6 +89,12 @@ func New(opts Options) *ControlChannel {
 // captures arrive via an upstream π/4-DQPSK demod + RCPC/RM FEC;
 // tests publish PDUs directly.
 func (c *ControlChannel) Ingest(p PDU) {
+	c.mu.Lock()
+	strict := c.strictValidation
+	c.mu.Unlock()
+	if strict && !p.IsKnown() {
+		return
+	}
 	if p.IsIdle() {
 		return
 	}

--- a/internal/radio/tetra/strict_test.go
+++ b/internal/radio/tetra/strict_test.go
@@ -1,0 +1,115 @@
+package tetra
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+)
+
+// TestStrictValidationDropsUnknownPDU: a PDU whose (Discriminator,
+// Type) pair is not in the documented ETSI EN 300 392-2 set must be
+// dropped by Ingest under SetStrictValidation(true).
+func TestStrictValidationDropsUnknownPDU(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, Log: slog.Default(), SystemName: "Sys"})
+	cc.SetStrictValidation(true)
+
+	// CMCE Type 0xF is unallocated in the trunking sub-protocol.
+	cc.Ingest(PDU{Disc: DiscCMCE, Type: 0xF, Payload: make([]byte, 11)})
+
+	select {
+	case ev := <-sub.C:
+		t.Errorf("strict-mode unknown CMCE Type published %v", ev.Kind)
+	default:
+	}
+}
+
+// TestStrictValidationDropsUnknownDiscriminator: a PDU whose
+// Discriminator selects a sub-protocol the state machine doesn't
+// surface (MM, SDS) must be dropped under strict mode regardless of
+// the Type field.
+func TestStrictValidationDropsUnknownDiscriminator(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, Log: slog.Default(), SystemName: "Sys"})
+	cc.SetStrictValidation(true)
+
+	cc.Ingest(PDU{Disc: DiscSDS, Type: 0x1, Payload: []byte{0x00}})
+
+	select {
+	case ev := <-sub.C:
+		t.Errorf("strict-mode SDS PDU published %v", ev.Kind)
+	default:
+	}
+}
+
+// TestStrictValidationKeepsKnownPDU: a PDU with a recognised
+// (Discriminator, Type) pair must still publish its event under
+// strict mode. Uses a D-CONNECT carrying a voice grant.
+func TestStrictValidationKeepsKnownPDU(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, Log: slog.Default(), SystemName: "Sys"})
+	cc.SetStrictValidation(true)
+
+	// Build a minimal D-CONNECT payload: 14-bit CID + flags, source SSI,
+	// dest SSI, flags byte, carrier+slot. Channel 7, slot 0, group call.
+	payload := make([]byte, 11)
+	payload[0], payload[1] = 0x00, 0x04 // CID = 1 in upper 14 bits
+	payload[2], payload[3], payload[4] = 0xAA, 0xAA, 0xAA
+	payload[5], payload[6], payload[7] = 0xBB, 0xBB, 0xBB
+	payload[8] = 0x80                  // group flag set
+	payload[9], payload[10] = 0x00, 0x70 // carrier 7 in upper 12 bits, slot 0
+	cc.Ingest(PDU{Disc: DiscCMCE, Type: uint8(CMCEDConnect), Payload: payload})
+
+	got := 0
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind == events.KindGrant {
+				got++
+			}
+		default:
+			if got == 0 {
+				t.Errorf("strict-mode D-CONNECT did not publish a Grant")
+			}
+			return
+		}
+	}
+}
+
+func TestPDUIsKnownCoversDocumentedConstants(t *testing.T) {
+	knownCMCE := []PDUType{
+		CMCEDSetup, CMCEDConnect, CMCEDRelease, CMCEDTxCeased,
+		CMCEDTxGranted, CMCEDInfo, CMCEDCallProceeding,
+	}
+	for _, ty := range knownCMCE {
+		p := PDU{Disc: DiscCMCE, Type: uint8(ty)}
+		if !p.IsKnown() {
+			t.Errorf("CMCE Type %#x should be known", uint8(ty))
+		}
+	}
+	if !(PDU{Disc: DiscMLE, Type: uint8(MLESystemInfo)}.IsKnown()) {
+		t.Errorf("MLE SYSINFO should be known")
+	}
+	for _, ty := range []uint8{0x0, 0x3, 0x8, 0xB, 0xC, 0xD, 0xE, 0xF} {
+		p := PDU{Disc: DiscCMCE, Type: ty}
+		if p.IsKnown() {
+			t.Errorf("CMCE Type %#x should NOT be known", ty)
+		}
+	}
+	if (PDU{Disc: DiscMM, Type: 0x1}).IsKnown() {
+		t.Errorf("MM PDUs should NOT be known")
+	}
+}


### PR DESCRIPTION
## Summary

Extends the soft-FEC noise filter from PR #124 across the remaining four protocols with an enumerable opcode space, completing the family of seven. Same pattern as the EDACS / Motorola / MPT 1327 bundle: each Ingest path now drops frames whose opcode / type / range fields fall outside the documented set before the state machine acts on them.

- **dPMR**: new `MessageType.IsKnown()` covers ETSI TS 102 658 §6.5.2 values; Ingest drops CSBKs whose 5-bit MessageType is unallocated.
- **TETRA**: new `PDU.IsKnown()` covers documented CMCE + MLE (Discriminator, Type) pairs; Ingest drops unrecognised pairs and also drops MM / SDS sub-protocols (the state machine doesn't surface them for trunking).
- **P25 Phase 2**: new `Opcode.IsKnown()` covers TIA-102.AABF / BBAB MAC PDU opcodes; Ingest drops MAC PDUs whose 8-bit Opcode is outside the documented set.
- **LTR**: new `Status.IsWellFormed()` covers Sync + Channel in 1..20 + Home in 1..20 (documented ranges); Ingest drops Status words outside those ranges.

Each control channel gets a `SetStrictValidation(bool)` method guarded by the existing `mu` mutex. The Ingest path checks the flag before any existing `IsIdle` / opcode dispatch, so noise frames get rejected before the state machine notices.

Strict validation is now available on every protocol with an enumerable opcode space. The remaining FEC work is heavy forward-error-correction (NXDN Viterbi, MPT 1327 BCH correction, EDACS RS, P25 P2 Trellis, TETRA RCPC, LTR FCS) and lives in follow-up PRs.

## Test plan

- [x] `go test ./internal/radio/dpmr/... ./internal/radio/tetra/... ./internal/radio/p25/phase2/... ./internal/radio/ltr/...`
- [x] `go test ./...` (full suite)
- [x] `go vet ./...`
- [x] Each new strict_test.go covers: dropping an unknown opcode under strict mode, preserving a known opcode, and an `IsKnown()` / `IsWellFormed()` constants/ranges sanity check
- [x] TETRA: dedicated test that strict mode also drops MM / SDS PDUs regardless of Type

https://claude.ai/code/session_019dtCCVEZJTKKr6YK3wy824

---
_Generated by [Claude Code](https://claude.ai/code/session_019dtCCVEZJTKKr6YK3wy824)_