### PR TITLE
internal/radio/nxdn: SetViterbiMode K=5 ½-rate FEC opt-in for CAC region

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,12 +68,15 @@ The remaining gaps:
   straight from the wire — this works on test fixtures + clean
   signals but typically fails on captured on-air traffic.
   **DMR Tier III** ships full FEC end-to-end (BPTC(196,96) +
-  CSBK CRC). **NXDN** now enforces the CAC CRC-CCITT-16 strict-
-  mode at the adapter level (so noise gets dropped) but the
-  K=5 Viterbi + interleaver over the 288-wire-bit Info field is
-  still pending. **LTR** has a `SetManchesterMode` config for
-  deployments that bi-phase-encode the sub-audible status word;
-  FCS verification (12-bit trailer) is still pending.
+  CSBK CRC). **NXDN** now has `SetViterbiMode(ViterbiOn)` to
+  run K=5 ½-rate Viterbi over the 92 encoded CAC dibits in the
+  Info field (88 CAC info bits + 4 tail bits → 184 wire bits =
+  92 dibits — the bare-bones K=5 chain MMDVMHost / DSDcc / op25
+  share); the per-protocol interleaver + puncture inner layer
+  is the next follow-up. The CAC CRC-CCITT-16 strict-mode
+  remains enforced. **LTR** has a `SetManchesterMode` config
+  for deployments that bi-phase-encode the sub-audible status
+  word; FCS verification (12-bit trailer) is still pending.
   **Motorola Type II** has `SetBCHMode(BCHOn)` to run
   BCH(64,16,11) over each codeword pair. The remaining
   protocols (EDACS, MPT 1327, P25 Phase 2, TETRA) still have
@@ -149,6 +152,24 @@ to its own package and lands independently.
 
 ### Recently shipped
 
+- **NXDN K=5 ½-rate Viterbi FEC opt-in for the CAC region of the
+  Info field.** First heavy-FEC PR. `nxdn.SetViterbiMode(
+  ViterbiOn)` switches the `ControlChannel.Process` adapter
+  from "read 44 raw CAC dibits off the wire" to "collect 92
+  encoded CAC dibits + run them through the K=5 ½-rate Viterbi
+  primitive in `internal/radio/framing/viterbi_k5.go` to
+  recover 88 CAC info bits + 4 tail bits". The convolutional
+  primitive (constraint length 5, generator pair g1 = 0x19 /
+  g2 = 0x17 octal 31/27) is the same one MMDVMHost / DSDcc /
+  op25 use across NXDN SACCH and other K=5 open-spec systems;
+  this PR wires it into the CAC slot. Tests round-trip
+  CAC bytes → `EncodeK5` → 184 channel bits → 92 dibits →
+  Process → ParseCAC → cc.locked. The per-protocol interleave
+  + puncture inner layer NXDN applies inside the Info field
+  isn't reversed yet (the public references don't fully
+  document it); ViterbiOn is the bare-bones convolutional
+  decode, ViterbiOff (default) preserves the legacy raw-wire
+  behaviour for test fixtures and clean synthesized streams.
 - **Cross-protocol strict-validation FEC bundle: LTR + dPMR +
   TETRA + P25 Phase 2 `SetStrictValidation(bool)`.** Extends
   the soft-FEC noise filter from the previous PR across the

--- a/internal/radio/nxdn/control.go
+++ b/internal/radio/nxdn/control.go
@@ -35,6 +35,48 @@ type ControlChannel struct {
 	// adapter uses (see process.go). Lazily constructed on the
 	// first Process call.
 	proc *processState
+
+	// viterbiMode controls whether Process treats the CAC region
+	// of the Info field as raw on-wire bits (ViterbiOff, default)
+	// or runs the 144 dibits through the K=5 ½-rate Viterbi
+	// primitive before parsing (ViterbiOn). Set via
+	// SetViterbiMode.
+	viterbiMode ViterbiMode
+}
+
+// ViterbiMode selects how the Process adapter interprets the CAC
+// region inside the 144-dibit Info field.
+//
+//   - ViterbiOff (default): the adapter reads 44 dibits = 88 raw
+//     information bits straight off the wire. Works on test
+//     fixtures + clean synthesized streams whose CAC bits aren't
+//     channel-coded; it does NOT match the on-air NXDN encoding,
+//     so live-air CAC frames typically fail their CRC and the
+//     adapter silently drops them.
+//
+//   - ViterbiOn: the adapter collects the first 92 dibits of the
+//     Info field (= 184 wire bits), runs them through the K=5
+//     ½-rate Viterbi primitive in internal/radio/framing (the
+//     same code-polynomial pair used by MMDVMHost / DSDcc /
+//     op25), and parses the 88 leading info bits as a CAC. This
+//     matches the bare-bones NXDN CAC FEC layer (88 CAC bits +
+//     4 tail zeros → K=5 R=½). Inner per-protocol interleaver +
+//     puncture (spec-shape-dependent and not in the public
+//     references) are still deferred.
+type ViterbiMode uint8
+
+const (
+	ViterbiOff ViterbiMode = iota
+	ViterbiOn
+)
+
+// SetViterbiMode toggles the K=5 ½-rate Viterbi FEC layer on the
+// CAC region of the Info field. See ViterbiMode for the trade-
+// offs. The mode applies to every subsequent Process call; the
+// IngestFrame entry point is unaffected (callers that pre-parse
+// frames don't go through this adapter).
+func (c *ControlChannel) SetViterbiMode(mode ViterbiMode) {
+	c.viterbiMode = mode
 }
 
 func NewControlChannel(bus *events.Bus, log *slog.Logger, freqHz uint32, rate BaudRate) *ControlChannel {

--- a/internal/radio/nxdn/process.go
+++ b/internal/radio/nxdn/process.go
@@ -22,17 +22,29 @@ type processState struct {
 }
 
 // postSyncDibits is the count of dibits the adapter collects after
-// the 8-dibit FSW match: 8 LICH wire + 32 SACCH (skipped) + 44 CAC
-// info dibits = 84 dibits. The remaining 100 dibits of the 144-dibit
-// Info field carry the CAC FEC redundancy that a future package PR
-// decodes; this adapter only uses the first 44 dibits, which is
-// sufficient to drive cc.locked in test fixtures where the CAC
-// information bits are placed directly in the wire (no FEC encoding).
-// For real on-air NXDN traffic the CAC FEC layer is the next
-// follow-up; until that lands this adapter will sync on the FSW
-// but typically fail the CAC CRC and stay silent on production
-// signals.
+// the 8-dibit FSW match when SetViterbiMode is ViterbiOff: 8 LICH
+// wire + 32 SACCH (skipped) + 44 CAC info dibits = 84 dibits. The
+// remaining 100 dibits of the 144-dibit Info field carry FEC
+// redundancy or other content the no-FEC path doesn't read. This
+// mode drives cc.locked in test fixtures where the CAC bits are
+// placed directly on the wire; on real on-air signals the CAC CRC
+// almost always fails and the adapter silently drops the frame.
 const postSyncDibits = 84
+
+// postSyncDibitsViterbi is the count of dibits the adapter collects
+// after the 8-dibit FSW match when SetViterbiMode is ViterbiOn: 8
+// LICH + 32 SACCH (skipped) + 92 CAC-encoded dibits = 132 dibits.
+// The 92 CAC-encoded dibits = 184 wire bits = (88 CAC info + 4 tail
+// bits) × 2 — the K=5 ½-rate convolutional output. The remaining
+// 52 dibits of the 144-dibit Info field carry per-protocol
+// puncture / interleave content the public references don't fully
+// document; those layers are documented follow-ups.
+const postSyncDibitsViterbi = 8 + 32 + 92
+
+// cacViterbiInfoBits is the number of source bits the K=5 ½-rate
+// Viterbi decode recovers from the 92 encoded CAC dibits: 88 CAC
+// information bits + 4 zero tail bits to flush the encoder.
+const cacViterbiInfoBits = 92
 
 // Process consumes a window of raw dibits from the NXDN receiver
 // (the IQ → C4FM dibit chain in internal/radio/nxdn/receiver/),
@@ -52,10 +64,14 @@ func (c *ControlChannel) Process(dibits []uint8, baseIdx int) int {
 	if c.proc == nil {
 		c.proc = &processState{
 			det:   NewSyncDetector([][]uint8{FSWDibitsOutbound}, 1),
-			frame: make([]uint8, 0, postSyncDibits),
+			frame: make([]uint8, 0, postSyncDibitsViterbi),
 		}
 	}
 	p := c.proc
+	frameLen := postSyncDibits
+	if c.viterbiMode == ViterbiOn {
+		frameLen = postSyncDibitsViterbi
+	}
 
 	p.matchScratch, _ = p.det.Process(p.matchScratch[:0], dibits, baseIdx)
 	matchIdx := 0
@@ -82,7 +98,7 @@ func (c *ControlChannel) Process(dibits []uint8, baseIdx int) int {
 		// machine locks on.
 		for matchIdx < len(p.matchScratch) && p.matchScratch[matchIdx].Index == absPos {
 			if !p.matchScratch[matchIdx].Inbound {
-				p.remaining = postSyncDibits
+				p.remaining = frameLen
 				p.frame = p.frame[:0]
 			}
 			matchIdx++
@@ -96,38 +112,77 @@ func (c *ControlChannel) Process(dibits []uint8, baseIdx int) int {
 // Drops the frame silently on any parse / CRC error — the next
 // FSW match anchors the stream again.
 func (c *ControlChannel) tryIngestFrame(frame []uint8) {
-	if len(frame) != postSyncDibits {
+	// LICH: 8 wire dibits → 16 wire bits → DecodeLICHWire → info
+	// byte → ParseLICH. Layout is the same in both Viterbi modes.
+	if len(frame) < 8 {
 		return
 	}
-	// LICH: 8 wire dibits → 16 wire bits → DecodeLICHWire → info
-	// byte → ParseLICH.
 	lichBits := framing.DibitsToBits(frame[0:8])
 	lichByte, _ := DecodeLICHWire(lichBits)
 	lich := ParseLICH(lichByte)
 
-	// CAC: 44 dibits → 88 information bits → 11 bytes → ParseCAC.
-	// Frame offsets: 8..40 is the 32-dibit SACCH (skipped here;
-	// SACCH carries channel signalling decoded via the K=5
-	// Viterbi chain in sacch.go but isn't required for the
-	// cc.locked path). Offsets 40..84 are the first 44 dibits
-	// of the 144-dibit Info field.
-	cacBits := framing.DibitsToBits(frame[40:84])
-	cacBytes := framing.PackBitsMSB(cacBits)
-	if len(cacBytes) < 11 {
+	cacBytes, ok := c.extractCACBytes(frame)
+	if !ok {
 		return
 	}
-	cac, err := ParseCAC(cacBytes[:11])
+	cac, err := ParseCAC(cacBytes)
 	if err != nil {
-		// CRC-CCITT-16 mismatch — drop the frame. The Process
-		// adapter doesn't yet reverse the Viterbi + interleaver
-		// + puncture chain that the CAC FEC layer applies to
-		// the 288-wire-bit Info field, so on real on-air
-		// signals the CRC will almost always fail and this
-		// path silently skips. On test fixtures + clean
-		// fixtures the CRC validates and IngestFrame runs.
+		// CRC-CCITT-16 mismatch — drop the frame silently.
+		// ViterbiOff: the wire bits are read raw, so any noise
+		// on the CAC slot fails the CRC. ViterbiOn: the K=5
+		// decode recovers info bits but the per-protocol
+		// interleave / puncture isn't reversed, so on-air
+		// frames still typically fail; clean synthesized
+		// streams (or a future PR that adds the interleave
+		// reversal) pass.
 		return
 	}
 	c.IngestFrame(lich, &cac)
+}
+
+// extractCACBytes pulls the 11 CAC bytes (88 information bits +
+// CRC) out of the post-sync frame. The slice layout depends on
+// ViterbiMode:
+//
+//   - ViterbiOff: frame is 84 dibits total. Offsets 8..40 are the
+//     32-dibit SACCH (skipped). Offsets 40..84 are the first 44
+//     dibits of the Info field; their 88 wire bits ARE the CAC
+//     information bits (no FEC reversal).
+//
+//   - ViterbiOn: frame is 132 dibits total. Offsets 8..40 are
+//     SACCH (skipped). Offsets 40..132 are the first 92 dibits
+//     of the Info field = 184 wire bits = K=5 ½-rate-encoded
+//     output. ViterbiK5 recovers 92 source bits; the first 88
+//     are the CAC info bits.
+func (c *ControlChannel) extractCACBytes(frame []uint8) ([]byte, bool) {
+	switch c.viterbiMode {
+	case ViterbiOn:
+		if len(frame) != postSyncDibitsViterbi {
+			return nil, false
+		}
+		channelBits := framing.DibitsToBits(frame[40:postSyncDibitsViterbi])
+		if len(channelBits) != 2*cacViterbiInfoBits {
+			return nil, false
+		}
+		info, _ := framing.ViterbiK5(channelBits, cacViterbiInfoBits)
+		// Drop the 4 trailing tail bits; the first 88 source
+		// bits are the CAC information field.
+		cacBytes := framing.PackBitsMSB(info[:88])
+		if len(cacBytes) < 11 {
+			return nil, false
+		}
+		return cacBytes[:11], true
+	default:
+		if len(frame) != postSyncDibits {
+			return nil, false
+		}
+		cacBits := framing.DibitsToBits(frame[40:postSyncDibits])
+		cacBytes := framing.PackBitsMSB(cacBits)
+		if len(cacBytes) < 11 {
+			return nil, false
+		}
+		return cacBytes[:11], true
+	}
 }
 
 // Reset clears the Process adapter's sync-detection + partial-frame

--- a/internal/radio/nxdn/process_viterbi_test.go
+++ b/internal/radio/nxdn/process_viterbi_test.go
@@ -1,0 +1,164 @@
+package nxdn
+
+import (
+	"encoding/binary"
+	"log/slog"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+)
+
+// TestProcessViterbiOnDecodesEncodedCACFrame builds a dibit stream
+// that mimics on-air NXDN CAC framing with the K=5 ½-rate
+// convolutional encoder applied to the 88 CAC information bits +
+// 4 zero tail bits, and confirms Process with SetViterbiMode(
+// ViterbiOn) recovers the CAC and publishes cc.locked.
+//
+// Layout (post-sync):
+//
+//	dibits  0..8    LICH wire (RFCh = Control)
+//	dibits  8..40   SACCH (junk; skipped)
+//	dibits  40..132 CAC K=5 ½-rate-encoded (92 dibits = 184 wire bits)
+//
+// = 132 post-sync dibits, matching postSyncDibitsViterbi.
+func TestProcessViterbiOnDecodesEncodedCACFrame(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := NewControlChannel(bus, slog.Default(), 851_062_500, Rate9600)
+	cc.SetViterbiMode(ViterbiOn)
+
+	lichInfo := AssembleLICH(LICH{RFCh: RFChControl})
+	lichWire := EncodeLICHWire(lichInfo)
+	lichDibits := framing.BitsToDibits(lichWire)
+	if len(lichDibits) != 8 {
+		t.Fatalf("LICH wire dibits = %d, want 8", len(lichDibits))
+	}
+
+	var payload [8]byte
+	binary.BigEndian.PutUint16(payload[0:2], 0xAAAA)
+	binary.BigEndian.PutUint16(payload[2:4], 0x1234)
+	binary.BigEndian.PutUint16(payload[4:6], 0x5678)
+	cacBytes := AssembleCAC(CACMessage{
+		Type:    RCCHSITEINFO,
+		Payload: payload,
+	})
+	cacBits := framing.UnpackBitsMSB(cacBytes, 88)
+
+	// Append 4 zero tail bits to flush the encoder, then K=5
+	// ½-rate convolutional encode → 184 channel bits = 92 dibits.
+	source := make([]byte, 92)
+	copy(source, cacBits)
+	channelBits := framing.EncodeK5(source)
+	if len(channelBits) != 184 {
+		t.Fatalf("EncodeK5 produced %d bits, want 184", len(channelBits))
+	}
+	encodedCACDibits := framing.BitsToDibits(channelBits)
+	if len(encodedCACDibits) != 92 {
+		t.Fatalf("encoded CAC dibits = %d, want 92", len(encodedCACDibits))
+	}
+
+	stream := make([]uint8, 30)
+	stream = append(stream, FSWDibitsOutbound...)
+	stream = append(stream, lichDibits...)
+	stream = append(stream, make([]uint8, 32)...) // SACCH junk
+	stream = append(stream, encodedCACDibits...)
+
+	cc.Process(stream, 0)
+
+	var sawLock bool
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind == events.KindCCLocked {
+				ls, ok := ev.Payload.(LockState)
+				if !ok {
+					t.Fatalf("CCLocked payload type = %T, want LockState", ev.Payload)
+				}
+				if ls.SiteID != 0x1234 {
+					t.Errorf("LockState.SiteID = %#x, want 0x1234", ls.SiteID)
+				}
+				if ls.SystemID != 0x5678 {
+					t.Errorf("LockState.SystemID = %#x, want 0x5678", ls.SystemID)
+				}
+				sawLock = true
+			}
+		default:
+			if !sawLock {
+				t.Errorf("ViterbiOn Process did not publish a KindCCLocked for an encoded frame")
+			}
+			return
+		}
+	}
+}
+
+// TestProcessViterbiOnRejectsRawCACFrame confirms that a stream
+// formatted for ViterbiOff (raw CAC bits on the wire) does NOT
+// pass the CRC under ViterbiOn — because the K=5 decoder treats
+// the wire bits as convolution-encoded and produces garbage that
+// fails the CAC CRC-CCITT-16. The two modes are not interchangeable.
+func TestProcessViterbiOnRejectsRawCACFrame(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := NewControlChannel(bus, slog.Default(), 851_062_500, Rate9600)
+	cc.SetViterbiMode(ViterbiOn)
+
+	lichInfo := AssembleLICH(LICH{RFCh: RFChControl})
+	lichWire := EncodeLICHWire(lichInfo)
+	lichDibits := framing.BitsToDibits(lichWire)
+
+	var payload [8]byte
+	binary.BigEndian.PutUint16(payload[0:2], 0xAAAA)
+	binary.BigEndian.PutUint16(payload[2:4], 0x1234)
+	cacBytes := AssembleCAC(CACMessage{
+		Type:    RCCHSITEINFO,
+		Payload: payload,
+	})
+	cacBits := framing.UnpackBitsMSB(cacBytes, 88)
+
+	// Pack the raw CAC bits into 44 dibits + 48 junk dibits to fill
+	// the 92-dibit encoded-CAC window. ViterbiOn will run K=5 over
+	// these 184 wire bits and produce non-CAC output that fails CRC.
+	rawCACDibits := framing.BitsToDibits(cacBits)
+	encodedSlot := make([]uint8, 92)
+	copy(encodedSlot, rawCACDibits)
+
+	stream := make([]uint8, 30)
+	stream = append(stream, FSWDibitsOutbound...)
+	stream = append(stream, lichDibits...)
+	stream = append(stream, make([]uint8, 32)...)
+	stream = append(stream, encodedSlot...)
+
+	cc.Process(stream, 0)
+
+	select {
+	case ev := <-sub.C:
+		if ev.Kind == events.KindCCLocked {
+			t.Errorf("ViterbiOn Process accepted a raw (un-encoded) CAC frame as locked")
+		}
+	default:
+	}
+}
+
+// TestSetViterbiModeRetainsViterbiOffDefault confirms the zero-value
+// ControlChannel uses the legacy raw-CAC path.
+func TestSetViterbiModeRetainsViterbiOffDefault(t *testing.T) {
+	cc := NewControlChannel(nil, slog.Default(), 0, Rate9600)
+	if cc.viterbiMode != ViterbiOff {
+		t.Errorf("default viterbiMode = %v, want ViterbiOff", cc.viterbiMode)
+	}
+	cc.SetViterbiMode(ViterbiOn)
+	if cc.viterbiMode != ViterbiOn {
+		t.Errorf("SetViterbiMode(ViterbiOn) did not take effect")
+	}
+	cc.SetViterbiMode(ViterbiOff)
+	if cc.viterbiMode != ViterbiOff {
+		t.Errorf("SetViterbiMode(ViterbiOff) did not take effect")
+	}
+}


### PR DESCRIPTION
## Summary

First heavy-FEC PR. Adds `nxdn.SetViterbiMode(ViterbiOn)` which wires the existing `framing/viterbi_k5.go` K=5 ½-rate Viterbi primitive into the CAC region of the NXDN Info field.

**ViterbiOff (default, unchanged):** `Process` reads 44 raw CAC dibits = 88 raw information bits straight off the wire. Works on test fixtures + clean synthesized streams; matches the legacy adapter behaviour.

**ViterbiOn:** `Process` collects 92 encoded CAC dibits = 184 wire bits, runs them through `framing.ViterbiK5(channel, 92)` and parses the first 88 source bits as the CAC info field (the last 4 source bits are the encoder-flush tail zeros). The convolutional code (constraint length 5, generator pair g1 = 0x19 / g2 = 0x17 octal 31/27) is the same one MMDVMHost / DSDcc / op25 share across NXDN SACCH and other K=5 open-spec systems — the primitive already powers the existing SACCH FEC chain.

Post-sync frame layout under ViterbiOn (132 dibits total):

| dibits | content |
| --- | --- |
| 0..8 | LICH wire (unchanged) |
| 8..40 | SACCH (32 dibits, skipped) |
| 40..132 | CAC K=5 ½-rate-encoded (92 dibits = 184 wire bits) |

The per-protocol interleaver + puncture inner layer NXDN applies inside the Info field isn't reversed (public references don't fully document it). ViterbiOn is the bare-bones convolutional decode that handles synthesized encoded streams; the interleaver layer is a documented follow-up.

## Test plan

- [x] `go test ./internal/radio/nxdn/...` — three new tests:
  - Encoded CAC frame round-trips: `AssembleCAC` → 88 bits → `EncodeK5` → 184 channel bits → 92 dibits → `Process(ViterbiOn)` → `ParseCAC` → `KindCCLocked`
  - A raw-CAC stream (formatted for ViterbiOff) does NOT pass under ViterbiOn — the two modes are not interchangeable
  - Default mode is ViterbiOff
- [x] `go test ./...` (full suite)
- [x] `go vet ./...`
- [x] Legacy `TestProcessDecodesSiteInfoFrameAfterSync` still passes under default ViterbiOff

https://claude.ai/code/session_019dtCCVEZJTKKr6YK3wy824

---
_Generated by [Claude Code](https://claude.ai/code/session_019dtCCVEZJTKKr6YK3wy824)_