### PR TITLE
internal/radio: thread Gardner clock recovery into the P25 Phase 2 + TETRA receivers

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,14 +93,17 @@ The remaining gaps:
   protocols (EDACS, TETRA, LTR FCS) still have their
   per-protocol FEC layers pending — see each adapter PR for
   the specific FEC parameters.
-- **Symbol-time clock recovery on complex IQ** for the π/4-DQPSK
-  family (P25 Phase 2, TETRA). The Gardner timing-recovery
-  primitive now ships in `internal/dsp/sync/gardner.go` —
-  non-data-aided, complex-valued, with cross-call state for
-  chunked streams. It isn't yet wired into the π/4-DQPSK
-  receivers (which still use naive decimation); the follow-up
-  PR threads it into the `MatchedFilter → clock recovery →
-  Decode` pipeline so noisier on-air captures lock.
+- **Symbol-time clock recovery on complex IQ.** The Gardner
+  timing-recovery primitive in `internal/dsp/sync/gardner.go`
+  is now threaded into both the **P25 Phase 2** and **TETRA**
+  receivers via a per-receiver `ClockMode` opt-in
+  (`ClockNaive` default preserves the pre-Gardner behaviour for
+  existing tests; `ClockGardner` routes the matched-filter
+  output through the Gardner loop). Noisier on-air captures
+  whose symbol clock isn't aligned with the SDR sample clock
+  should lock cleanly under `ClockGardner`. The connector
+  configuration for picking the mode at runtime is the
+  follow-up.
 - **Digital-voice level calibration.** Pure-Go IMBE / AMBE+2 emit
   real audio end-to-end with shared AGC, frame-repeat on bad-frame
   indicator, phase-aware fade-in, and §6.2 spectral enhancement
@@ -167,6 +170,21 @@ to its own package and lands independently.
 
 ### Recently shipped
 
+- **Gardner clock recovery threaded into the P25 Phase 2 +
+  TETRA receivers.** Each π/4-DQPSK receiver gains an
+  `Options.ClockMode` (`ClockNaive` default, `ClockGardner`
+  opt-in) that swaps the naive every-sps-th-sample decimation
+  for the `sync.Gardner` timing-recovery loop landed in PR
+  #128. The Gardner loop manages its own cross-call tail
+  state, so chunked streams converge once rather than per
+  chunk; `Reset()` clears the loop state alongside the rest
+  of the receiver. The existing test fixtures (which assume
+  fixed sample alignment) keep passing under the default
+  `ClockNaive`. New tests confirm the Gardner path produces
+  valid in-range dibits, the loop is constructed only when
+  requested, and `Reset()` restarts the dibit-base counter.
+  The connector configuration plumbing for picking the mode
+  at runtime is the documented follow-up.
 - **MPT 1327 `SetBCHMode(BCHOn)` opt-in.** Wires the
   `BCHEncodeMPT1327` / `BCHDecodeMPT1327` framing primitive
   into the MPT 1327 `ControlChannel.Process` adapter. When on,

--- a/internal/radio/p25/phase2/receiver/receiver.go
+++ b/internal/radio/p25/phase2/receiver/receiver.go
@@ -29,6 +29,7 @@ import (
 	"math"
 
 	"github.com/MattCheramie/GopherTrunk/internal/dsp/demod"
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/sync"
 	"github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase2"
 )
 
@@ -63,7 +64,43 @@ type Options struct {
 	PulseSpanSymbols int
 	// Alpha overrides the RRC roll-off. <= 0 uses RolloffAlpha.
 	Alpha float64
+	// ClockMode selects the symbol-time recovery strategy. See
+	// the ClockMode type doc for the trade-offs. Zero value is
+	// ClockNaive (matches the receiver's pre-Gardner behaviour).
+	ClockMode ClockMode
+	// GardnerGain overrides the Gardner loop step (default 0.03,
+	// applied only when ClockMode is ClockGardner).
+	GardnerGain float64
 }
+
+// ClockMode selects how the receiver decimates the matched-filter
+// output to one sample per symbol.
+//
+//   - ClockNaive (default): picks every sps-th sample starting at
+//     an offset advanced by sps each emission. Works on
+//     synthesized signals whose symbol-time peaks fall at fixed
+//     sample positions; matches the receiver's pre-Gardner
+//     behaviour exactly.
+//
+//   - ClockGardner: routes the matched-filter output through the
+//     Gardner symbol-timing-recovery loop in internal/dsp/sync —
+//     non-data-aided, complex-valued, with cross-call state for
+//     chunked streams. Useful for noisier on-air captures where
+//     the symbol clock isn't perfectly aligned with the SDR
+//     sample clock.
+//
+// Wiring Gardner into the pipeline is the follow-up the Gardner
+// primitive PR (#128) called out; the choice is per-receiver and
+// runtime-configurable so the existing test fixtures (which
+// depend on fixed sample alignment) keep passing under
+// ClockNaive while ClockGardner becomes the recommended default
+// for live SDR captures.
+type ClockMode uint8
+
+const (
+	ClockNaive ClockMode = iota
+	ClockGardner
+)
 
 // Receiver is the composed IQ → dibit pipeline.
 type Receiver struct {
@@ -77,12 +114,17 @@ type Receiver struct {
 	// pending matched-filter buffer is consumed.
 	rxOffset int
 
+	clockMode ClockMode
+	gardner   *sync.Gardner
+
 	// Scratch buffers reused across calls.
 	matched []complex64
 	dibits  []uint8
+	symbols []complex64
 	// pending holds matched-filter samples from prior Process calls
 	// that didn't align with a symbol centre and are needed for the
-	// next decimation step.
+	// next decimation step (ClockNaive). Under ClockGardner the
+	// Gardner loop manages its own cross-call tail internally.
 	pending []complex64
 }
 
@@ -107,11 +149,20 @@ func New(opts Options) *Receiver {
 	if alpha <= 0 {
 		alpha = RolloffAlpha
 	}
-	return &Receiver{
+	r := &Receiver{
 		dq:        demod.NewPiOver4DQPSK(int(sps+0.5), span, alpha, Rotation),
 		sps:       int(sps + 0.5),
 		dibitSink: opts.DibitSink,
+		clockMode: opts.ClockMode,
 	}
+	if r.clockMode == ClockGardner {
+		gain := opts.GardnerGain
+		if gain <= 0 {
+			gain = 0.03
+		}
+		r.gardner = sync.NewGardner(float64(r.sps), gain)
+	}
+	return r
 }
 
 // Process pushes one chunk of complex64 IQ samples through the
@@ -122,41 +173,43 @@ func (r *Receiver) Process(iq []complex64) {
 		return
 	}
 	r.matched = r.dq.MatchedFilter(r.matched, iq)
-	r.pending = append(r.pending, r.matched...)
-
-	// Decimate the pending buffer: pick one sample per sps
-	// starting at rxOffset.
 	r.dibits = r.dibits[:0]
-	var symbols []complex64
-	for r.rxOffset < len(r.pending) {
-		symbols = append(symbols, r.pending[r.rxOffset])
-		r.rxOffset += r.sps
-	}
-	if len(symbols) == 0 {
-		return
-	}
-	r.dibits = r.dq.Decode(r.dibits, symbols)
-	r.dibitSink(r.dibits, r.dibitBase)
-	r.dibitBase += len(r.dibits)
+	r.symbols = r.symbols[:0]
 
-	// Trim the pending buffer: keep only the samples we haven't
-	// consumed yet. rxOffset becomes the offset into the trimmed
-	// buffer.
-	drop := r.rxOffset - r.sps
-	if drop < 0 {
-		drop = 0
-	}
-	if drop > len(r.pending) {
-		drop = len(r.pending)
-	}
-	if drop > 0 {
-		copy(r.pending, r.pending[drop:])
-		r.pending = r.pending[:len(r.pending)-drop]
-		r.rxOffset -= drop
-		if r.rxOffset < 0 {
-			r.rxOffset = 0
+	if r.clockMode == ClockGardner {
+		// Gardner manages its own cross-call tail state, so the
+		// receiver hands each matched-filter chunk straight in.
+		r.symbols = r.gardner.Process(r.symbols, r.matched)
+	} else {
+		// Naive decimation: pick every sps-th sample starting at
+		// rxOffset, preserving cross-call state in r.pending.
+		r.pending = append(r.pending, r.matched...)
+		for r.rxOffset < len(r.pending) {
+			r.symbols = append(r.symbols, r.pending[r.rxOffset])
+			r.rxOffset += r.sps
+		}
+		drop := r.rxOffset - r.sps
+		if drop < 0 {
+			drop = 0
+		}
+		if drop > len(r.pending) {
+			drop = len(r.pending)
+		}
+		if drop > 0 {
+			copy(r.pending, r.pending[drop:])
+			r.pending = r.pending[:len(r.pending)-drop]
+			r.rxOffset -= drop
+			if r.rxOffset < 0 {
+				r.rxOffset = 0
+			}
 		}
 	}
+	if len(r.symbols) == 0 {
+		return
+	}
+	r.dibits = r.dq.Decode(r.dibits, r.symbols)
+	r.dibitSink(r.dibits, r.dibitBase)
+	r.dibitBase += len(r.dibits)
 }
 
 // Reset returns the receiver to its initial state. Call on stream
@@ -168,4 +221,7 @@ func (r *Receiver) Reset() {
 	r.dq.Reset()
 	r.pending = r.pending[:0]
 	r.rxOffset = 0
+	if r.gardner != nil {
+		r.gardner.Reset()
+	}
 }

--- a/internal/radio/p25/phase2/receiver/receiver_gardner_test.go
+++ b/internal/radio/p25/phase2/receiver/receiver_gardner_test.go
@@ -1,0 +1,115 @@
+package receiver
+
+import "testing"
+
+// TestReceiverGardnerProcessesIQEndToEnd: configure the receiver
+// with ClockGardner and confirm the Gardner-driven decimation path
+// produces a non-zero number of dibits on a clean P25 Phase 2
+// H-DQPSK stream. We don't assert symbol-for-symbol equality
+// (Gardner's timing-recovery loop picks slightly different
+// sampling points than naive decimation during convergence); the
+// invariants checked are:
+//
+//   - DibitSink fires at least once
+//   - Every emitted dibit is in 0..3
+//   - baseIdx is monotonically non-decreasing
+func TestReceiverGardnerProcessesIQEndToEnd(t *testing.T) {
+	var batches int
+	var bad int
+	var lastBase int
+	r := New(Options{
+		SampleRateHz: 48_000,
+		DibitSink: func(d []uint8, baseIdx int) {
+			batches++
+			if baseIdx < lastBase {
+				t.Errorf("baseIdx regressed: %d < %d", baseIdx, lastBase)
+			}
+			lastBase = baseIdx + len(d)
+			for _, v := range d {
+				if v > 3 {
+					bad++
+				}
+			}
+		},
+		ClockMode: ClockGardner,
+	})
+
+	dibits := []uint8{
+		0b00, 0b01, 0b10, 0b11, 0b00, 0b01, 0b10, 0b11,
+		0b11, 0b10, 0b01, 0b00, 0b11, 0b10, 0b01, 0b00,
+		0b00, 0b01, 0b10, 0b11, 0b00, 0b01, 0b10, 0b11,
+		0b11, 0b10, 0b01, 0b00, 0b11, 0b10, 0b01, 0b00,
+	}
+	iq, _ := makeP2HDQPSKIQ(dibits)
+	chunk := 4096
+	for i := 0; i < len(iq); i += chunk {
+		end := i + chunk
+		if end > len(iq) {
+			end = len(iq)
+		}
+		r.Process(iq[i:end])
+	}
+	if batches == 0 {
+		t.Errorf("ClockGardner DibitSink received zero batches")
+	}
+	if bad > 0 {
+		t.Errorf("%d dibit(s) outside 0..3 range under ClockGardner", bad)
+	}
+}
+
+func TestReceiverGardnerDefaultGain(t *testing.T) {
+	r := New(Options{
+		SampleRateHz: 48_000,
+		DibitSink:    func([]uint8, int) {},
+		ClockMode:    ClockGardner,
+	})
+	if r.gardner == nil {
+		t.Fatalf("ClockGardner did not construct a Gardner loop")
+	}
+}
+
+func TestReceiverGardnerExplicitGain(t *testing.T) {
+	r := New(Options{
+		SampleRateHz: 48_000,
+		DibitSink:    func([]uint8, int) {},
+		ClockMode:    ClockGardner,
+		GardnerGain:  0.05,
+	})
+	if r.gardner == nil {
+		t.Fatalf("ClockGardner did not construct a Gardner loop")
+	}
+}
+
+func TestReceiverClockNaiveSkipsGardnerConstruction(t *testing.T) {
+	r := New(Options{
+		SampleRateHz: 48_000,
+		DibitSink:    func([]uint8, int) {},
+	})
+	if r.gardner != nil {
+		t.Errorf("ClockNaive (default) constructed a Gardner loop")
+	}
+}
+
+func TestReceiverGardnerResetClearsState(t *testing.T) {
+	r := New(Options{
+		SampleRateHz: 48_000,
+		DibitSink:    func([]uint8, int) {},
+		ClockMode:    ClockGardner,
+	})
+	dibits := []uint8{0b00, 0b01, 0b10, 0b11, 0b00, 0b01, 0b10, 0b11}
+	iq, _ := makeP2HDQPSKIQ(dibits)
+	r.Process(iq)
+	r.Reset()
+	// After Reset, the dibitBase counter must start back at zero
+	// on the next emission.
+	var firstBase int = -1
+	r.dibitSink = func(d []uint8, baseIdx int) {
+		if firstBase < 0 {
+			firstBase = baseIdx
+		}
+	}
+	r.Process(iq)
+	if firstBase != 0 {
+		t.Errorf("post-Reset first baseIdx = %d, want 0", firstBase)
+	}
+}

--- a/internal/radio/tetra/receiver/receiver.go
+++ b/internal/radio/tetra/receiver/receiver.go
@@ -23,6 +23,7 @@ import (
 	"math"
 
 	"github.com/MattCheramie/GopherTrunk/internal/dsp/demod"
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/sync"
 	"github.com/MattCheramie/GopherTrunk/internal/radio/tetra"
 )
 
@@ -58,7 +59,30 @@ type Options struct {
 	PulseSpanSymbols int
 	// Alpha overrides the RRC roll-off. <= 0 uses RolloffAlpha.
 	Alpha float64
+	// ClockMode selects the symbol-time recovery strategy. See
+	// the ClockMode type doc for the trade-offs. Zero value is
+	// ClockNaive (matches the receiver's pre-Gardner behaviour).
+	ClockMode ClockMode
+	// GardnerGain overrides the Gardner loop step (default 0.03,
+	// applied only when ClockMode is ClockGardner).
+	GardnerGain float64
 }
+
+// ClockMode selects how the receiver decimates the matched-filter
+// output to one sample per symbol. Same enum / semantics as the
+// P25 Phase 2 receiver's ClockMode:
+//
+//   - ClockNaive (default): every sps-th sample. Matches the
+//     receiver's pre-Gardner behaviour exactly.
+//   - ClockGardner: routes through the Gardner symbol-timing-
+//     recovery loop in internal/dsp/sync. Recommended for noisier
+//     on-air captures.
+type ClockMode uint8
+
+const (
+	ClockNaive ClockMode = iota
+	ClockGardner
+)
 
 // Receiver is the composed IQ → dibit pipeline.
 type Receiver struct {
@@ -68,8 +92,12 @@ type Receiver struct {
 	dibitBase int
 	rxOffset  int
 
+	clockMode ClockMode
+	gardner   *sync.Gardner
+
 	matched []complex64
 	dibits  []uint8
+	symbols []complex64
 	pending []complex64
 }
 
@@ -94,11 +122,20 @@ func New(opts Options) *Receiver {
 	if alpha <= 0 {
 		alpha = RolloffAlpha
 	}
-	return &Receiver{
+	r := &Receiver{
 		dq:        demod.NewPiOver4DQPSK(int(sps+0.5), span, alpha, Rotation),
 		sps:       int(sps + 0.5),
 		dibitSink: opts.DibitSink,
+		clockMode: opts.ClockMode,
 	}
+	if r.clockMode == ClockGardner {
+		gain := opts.GardnerGain
+		if gain <= 0 {
+			gain = 0.03
+		}
+		r.gardner = sync.NewGardner(float64(r.sps), gain)
+	}
+	return r
 }
 
 // Process pushes one chunk of complex64 IQ samples through the
@@ -109,36 +146,39 @@ func (r *Receiver) Process(iq []complex64) {
 		return
 	}
 	r.matched = r.dq.MatchedFilter(r.matched, iq)
-	r.pending = append(r.pending, r.matched...)
-
 	r.dibits = r.dibits[:0]
-	var symbols []complex64
-	for r.rxOffset < len(r.pending) {
-		symbols = append(symbols, r.pending[r.rxOffset])
-		r.rxOffset += r.sps
-	}
-	if len(symbols) == 0 {
-		return
-	}
-	r.dibits = r.dq.Decode(r.dibits, symbols)
-	r.dibitSink(r.dibits, r.dibitBase)
-	r.dibitBase += len(r.dibits)
+	r.symbols = r.symbols[:0]
 
-	drop := r.rxOffset - r.sps
-	if drop < 0 {
-		drop = 0
-	}
-	if drop > len(r.pending) {
-		drop = len(r.pending)
-	}
-	if drop > 0 {
-		copy(r.pending, r.pending[drop:])
-		r.pending = r.pending[:len(r.pending)-drop]
-		r.rxOffset -= drop
-		if r.rxOffset < 0 {
-			r.rxOffset = 0
+	if r.clockMode == ClockGardner {
+		r.symbols = r.gardner.Process(r.symbols, r.matched)
+	} else {
+		r.pending = append(r.pending, r.matched...)
+		for r.rxOffset < len(r.pending) {
+			r.symbols = append(r.symbols, r.pending[r.rxOffset])
+			r.rxOffset += r.sps
+		}
+		drop := r.rxOffset - r.sps
+		if drop < 0 {
+			drop = 0
+		}
+		if drop > len(r.pending) {
+			drop = len(r.pending)
+		}
+		if drop > 0 {
+			copy(r.pending, r.pending[drop:])
+			r.pending = r.pending[:len(r.pending)-drop]
+			r.rxOffset -= drop
+			if r.rxOffset < 0 {
+				r.rxOffset = 0
+			}
 		}
 	}
+	if len(r.symbols) == 0 {
+		return
+	}
+	r.dibits = r.dq.Decode(r.dibits, r.symbols)
+	r.dibitSink(r.dibits, r.dibitBase)
+	r.dibitBase += len(r.dibits)
 }
 
 // Reset returns the receiver to its initial state. Call on stream
@@ -150,4 +190,7 @@ func (r *Receiver) Reset() {
 	r.dq.Reset()
 	r.pending = r.pending[:0]
 	r.rxOffset = 0
+	if r.gardner != nil {
+		r.gardner.Reset()
+	}
 }

--- a/internal/radio/tetra/receiver/receiver_gardner_test.go
+++ b/internal/radio/tetra/receiver/receiver_gardner_test.go
@@ -1,0 +1,106 @@
+package receiver
+
+import "testing"
+
+// TestReceiverGardnerProcessesIQEndToEnd: configure the TETRA
+// receiver with ClockGardner and confirm the Gardner-driven
+// decimation path produces a non-zero number of dibits on a
+// clean π/4-DQPSK stream. Mirrors the P25 Phase 2 receiver test.
+func TestReceiverGardnerProcessesIQEndToEnd(t *testing.T) {
+	var batches int
+	var bad int
+	var lastBase int
+	r := New(Options{
+		SampleRateHz: 144_000,
+		DibitSink: func(d []uint8, baseIdx int) {
+			batches++
+			if baseIdx < lastBase {
+				t.Errorf("baseIdx regressed: %d < %d", baseIdx, lastBase)
+			}
+			lastBase = baseIdx + len(d)
+			for _, v := range d {
+				if v > 3 {
+					bad++
+				}
+			}
+		},
+		ClockMode: ClockGardner,
+	})
+
+	dibits := []uint8{
+		0b00, 0b01, 0b10, 0b11, 0b00, 0b01, 0b10, 0b11,
+		0b11, 0b10, 0b01, 0b00, 0b11, 0b10, 0b01, 0b00,
+		0b00, 0b01, 0b10, 0b11, 0b00, 0b01, 0b10, 0b11,
+		0b11, 0b10, 0b01, 0b00, 0b11, 0b10, 0b01, 0b00,
+	}
+	iq := makeTetraDQPSKIQ(dibits)
+	chunk := 4096
+	for i := 0; i < len(iq); i += chunk {
+		end := i + chunk
+		if end > len(iq) {
+			end = len(iq)
+		}
+		r.Process(iq[i:end])
+	}
+	if batches == 0 {
+		t.Errorf("ClockGardner DibitSink received zero batches")
+	}
+	if bad > 0 {
+		t.Errorf("%d dibit(s) outside 0..3 range under ClockGardner", bad)
+	}
+}
+
+func TestReceiverGardnerDefaultGain(t *testing.T) {
+	r := New(Options{
+		SampleRateHz: 144_000,
+		DibitSink:    func([]uint8, int) {},
+		ClockMode:    ClockGardner,
+	})
+	if r.gardner == nil {
+		t.Fatalf("ClockGardner did not construct a Gardner loop")
+	}
+}
+
+func TestReceiverGardnerExplicitGain(t *testing.T) {
+	r := New(Options{
+		SampleRateHz: 144_000,
+		DibitSink:    func([]uint8, int) {},
+		ClockMode:    ClockGardner,
+		GardnerGain:  0.05,
+	})
+	if r.gardner == nil {
+		t.Fatalf("ClockGardner did not construct a Gardner loop")
+	}
+}
+
+func TestReceiverClockNaiveSkipsGardnerConstruction(t *testing.T) {
+	r := New(Options{
+		SampleRateHz: 144_000,
+		DibitSink:    func([]uint8, int) {},
+	})
+	if r.gardner != nil {
+		t.Errorf("ClockNaive (default) constructed a Gardner loop")
+	}
+}
+
+func TestReceiverGardnerResetClearsState(t *testing.T) {
+	r := New(Options{
+		SampleRateHz: 144_000,
+		DibitSink:    func([]uint8, int) {},
+		ClockMode:    ClockGardner,
+	})
+	dibits := []uint8{0b00, 0b01, 0b10, 0b11, 0b00, 0b01, 0b10, 0b11}
+	iq := makeTetraDQPSKIQ(dibits)
+	r.Process(iq)
+	r.Reset()
+	var firstBase int = -1
+	r.dibitSink = func(d []uint8, baseIdx int) {
+		if firstBase < 0 {
+			firstBase = baseIdx
+		}
+	}
+	r.Process(iq)
+	if firstBase != 0 {
+		t.Errorf("post-Reset first baseIdx = %d, want 0", firstBase)
+	}
+}


### PR DESCRIPTION
## Summary

Both π/4-DQPSK receivers (P25 Phase 2 and TETRA TMO) gain an `Options.ClockMode` opt-in that swaps the naive every-sps-th-sample decimation for the `sync.Gardner` timing-recovery loop landed in PR #128.

**ClockNaive (default, unchanged):** picks every sps-th sample. Preserves the receiver's pre-Gardner behaviour exactly — the existing test fixtures (which depend on fixed sample alignment) keep passing.

**ClockGardner:** routes the matched-filter output through `sync.Gardner` — non-data-aided, complex-valued, with cross-call tail state managed inside the Gardner loop, so chunked streams converge once rather than per chunk.

Internal `Receiver` state grows a `clockMode` field + a Gardner loop pointer constructed only when `ClockGardner` is selected. `Reset()` now also resets the Gardner loop so retunes don't carry a stale timing estimate. `GardnerGain` lets callers override the loop step (default 0.03, the recommended starting point for noisier on-air captures).

Both packages use the same opt-in shape — `ClockMode` enum with `ClockNaive` / `ClockGardner`, `GardnerGain` override field. The connector configuration plumbing for picking the mode at runtime is the documented follow-up; operators can wire `ClockGardner` manually in their `Options` for now.

## Test plan

Per receiver (P25 P2 + TETRA):

- [x] End-to-end IQ → dibit decode under ClockGardner produces a non-zero number of in-range dibits with monotonic baseIdx
- [x] Gardner loop is constructed only when ClockGardner is set
- [x] Explicit `GardnerGain` is accepted
- [x] ClockNaive (default) does not allocate a Gardner loop
- [x] `Reset()` restarts the dibit-base counter to 0

Plus:

- [x] `go test ./...` (full suite) — every existing receiver test still passes under default ClockNaive
- [x] `go vet ./...`

## Reference

PR #128 — Gardner primitive landed in `internal/dsp/sync/gardner.go`.

https://claude.ai/code/session_019dtCCVEZJTKKr6YK3wy824

---
_Generated by [Claude Code](https://claude.ai/code/session_019dtCCVEZJTKKr6YK3wy824)_