### PR TITLE
internal/radio/framing: LTR Standard CRC-7 primitive (polynomial 0xFD, 24-bit message)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,13 @@ The remaining gaps:
   is the next follow-up. The CAC CRC-CCITT-16 strict-mode
   remains enforced. **LTR** has a `SetManchesterMode` config
   for deployments that bi-phase-encode the sub-audible status
-  word; FCS verification (12-bit trailer) is still pending.
+  word, plus a `framing.CRC7LTR` primitive in
+  `internal/radio/framing/crc_ltr.go` (polynomial 0xFD, table
+  from DSheirer/sdrtrunk's CRCLTR.java) that future PRs can
+  wire into the adapter; the wiring is pending because
+  sdrtrunk's bit-layout reading (1-bit Area, 5-bit Channel)
+  disagrees with GopherTrunk's `Status` struct (5-bit Area,
+  4-bit Channel).
   **Motorola Type II** has `SetBCHMode(BCHOn)` to run
   BCH(64,16,11) over each codeword pair. **P25 Phase 2** now
   has `SetTrellisMode(TrellisOn)` to run the TIA-102 Annex A
@@ -170,6 +176,24 @@ to its own package and lands independently.
 
 ### Recently shipped
 
+- **LTR Standard CRC-7 primitive in framing/.** New shared
+  `framing/crc_ltr.go` adds `CRC7LTR` / `VerifyCRC7LTR` for
+  the LTR Standard message check (polynomial 0xFD, initial
+  fill 0x00) per DSheirer/sdrtrunk's `edac/CRCLTR.java`. The
+  24-entry syndrome lookup table covers the four fields LTR
+  protects (Area, Channel, Home, Group, Free — 24 bits total),
+  with direction-aware verification: OSW (outbound) frames
+  must match the calculated checksum as-is; ISW (inbound)
+  frames carry the bit-inverted checksum. The primitive isn't
+  yet wired into the LTR `ControlChannel` adapter because the
+  bit layout sdrtrunk documents (1-bit Area, 5-bit Channel)
+  disagrees with the GopherTrunk `Status` struct (5-bit Area,
+  4-bit Channel) — reconciling the two LTR Standard
+  interpretations is the documented follow-up. Tests cover
+  zero-message zero-checksum, single-bit syndrome matches,
+  256 random-message round-trips, single-bit-error detection
+  across all 24 positions, ISW checksum inversion, and
+  table-uniqueness / 7-bit-bound sanity.
 - **Gardner clock recovery threaded into the P25 Phase 2 +
   TETRA receivers.** Each π/4-DQPSK receiver gains an
   `Options.ClockMode` (`ClockNaive` default, `ClockGardner`

--- a/internal/radio/framing/crc_ltr.go
+++ b/internal/radio/framing/crc_ltr.go
@@ -1,0 +1,95 @@
+package framing
+
+// LTR Standard message check (CRC-7).
+//
+// Per the most-cited public reference (DSheirer/sdrtrunk's
+// CRCLTR.java), LTR Standard protects a 24-bit message field with
+// a CRC-7 computed by XORing precomputed syndrome contributions
+// from a 24-entry lookup table:
+//
+//	polynomial: 0xFD  (= x^7 + x^6 + x^5 + x^4 + x^3 + x^2 + 1
+//	                     with the explicit x^7 leading term)
+//	initial fill: 0x00
+//
+// The 24 message bits cover the four LTR fields the CRC protects:
+//
+//	Area     (1 bit)   — sdrtrunk's table[0]
+//	Channel  (5 bits)  — table[1..5]   (MSB-first: Channel 4..0)
+//	Home     (5 bits)  — table[6..10]  (MSB-first: Home 4..0)
+//	Group    (8 bits)  — table[11..18] (MSB-first: Group 7..0)
+//	Free     (5 bits)  — table[19..23] (MSB-first: Free 4..0)
+//	= 24 message bits
+//
+// Note: sdrtrunk's "Area (1 bit)" reading is one of several LTR
+// Standard interpretations in circulation. GopherTrunk's existing
+// 41-bit Status struct models Area as 5 bits and Channel as 4 bits
+// (different convention); reconciling those layouts before wiring
+// this primitive into the LTR adapter is the documented follow-up.
+
+// crc7LTRChecksums is the 24-entry syndrome lookup table copied
+// from sdrtrunk's CRCLTR.java. Each entry is the 7-bit CRC
+// contribution of one message bit set.
+var crc7LTRChecksums = [24]byte{
+	0x38, // Area
+	0x1C, // Channel 4 (MSB)
+	0x0E, // Channel 3
+	0x46, // Channel 2
+	0x23, // Channel 1
+	0x51, // Channel 0 (LSB)
+	0x68, // Home 4 (MSB)
+	0x75, // Home 3
+	0x7A, // Home 2
+	0x3D, // Home 1
+	0x1F, // Home 0 (LSB)
+	0x4F, // Group 7 (MSB)
+	0x26, // Group 6
+	0x52, // Group 5
+	0x29, // Group 4
+	0x15, // Group 3
+	0x0B, // Group 2
+	0x45, // Group 1
+	0x62, // Group 0 (LSB)
+	0x31, // Free 4 (MSB)
+	0x19, // Free 3
+	0x0D, // Free 2
+	0x07, // Free 1
+	0x43, // Free 0 (LSB)
+}
+
+// CRC7LTR computes the 7-bit LTR Standard message CRC over a
+// 24-bit message field. Each entry of msgBits is the value 0 or 1;
+// msgBits[0] is the Area bit, msgBits[1..5] are the 5 Channel bits
+// MSB-first, and so on per the field layout documented above.
+//
+// The returned checksum occupies the low 7 bits of a byte (the
+// high bit is always zero). Pass the same value the LTR
+// transmitter computed at encode time; verify that
+// CRC7LTR(receivedMsg) == receivedChecksum.
+func CRC7LTR(msgBits []byte) byte {
+	var crc byte
+	n := len(msgBits)
+	if n > len(crc7LTRChecksums) {
+		n = len(crc7LTRChecksums)
+	}
+	for i := 0; i < n; i++ {
+		if msgBits[i]&1 != 0 {
+			crc ^= crc7LTRChecksums[i]
+		}
+	}
+	return crc & 0x7F
+}
+
+// VerifyCRC7LTR reports whether the 7-bit checksum for the
+// supplied 24-bit message matches the expected value. The OSW
+// (outbound from base) variant requires `calculated ==
+// transmitted`; the ISW (inbound from subscriber) variant
+// requires `calculated ^ 0x7F == transmitted` (per sdrtrunk's
+// CRCLTR.check direction-aware logic). Most decoders consume
+// only OSW frames; pass false for inbound otherwise.
+func VerifyCRC7LTR(msgBits []byte, transmitted byte, inbound bool) bool {
+	calculated := CRC7LTR(msgBits)
+	if inbound {
+		return (calculated^0x7F)&0x7F == transmitted&0x7F
+	}
+	return calculated == transmitted&0x7F
+}

--- a/internal/radio/framing/crc_ltr_test.go
+++ b/internal/radio/framing/crc_ltr_test.go
@@ -1,0 +1,106 @@
+package framing
+
+import (
+	"math/rand"
+	"testing"
+)
+
+func TestCRC7LTRZeroMessage(t *testing.T) {
+	msg := make([]byte, 24)
+	if got := CRC7LTR(msg); got != 0 {
+		t.Errorf("CRC of all-zero message = %#x, want 0x00", got)
+	}
+}
+
+func TestCRC7LTRSingleBitMatchesTable(t *testing.T) {
+	for i := 0; i < 24; i++ {
+		msg := make([]byte, 24)
+		msg[i] = 1
+		got := CRC7LTR(msg)
+		want := crc7LTRChecksums[i] & 0x7F
+		if got != want {
+			t.Errorf("CRC of bit %d set = %#x, want %#x", i, got, want)
+		}
+	}
+}
+
+func TestCRC7LTRMultiBitXORsTable(t *testing.T) {
+	msg := make([]byte, 24)
+	msg[0], msg[1], msg[11] = 1, 1, 1
+	want := (crc7LTRChecksums[0] ^ crc7LTRChecksums[1] ^ crc7LTRChecksums[11]) & 0x7F
+	if got := CRC7LTR(msg); got != want {
+		t.Errorf("CRC = %#x, want %#x", got, want)
+	}
+}
+
+func TestCRC7LTRRoundTripOSW(t *testing.T) {
+	r := rand.New(rand.NewSource(0xC0DE))
+	for trial := 0; trial < 256; trial++ {
+		msg := make([]byte, 24)
+		for i := range msg {
+			msg[i] = byte(r.Intn(2))
+		}
+		crc := CRC7LTR(msg)
+		if !VerifyCRC7LTR(msg, crc, false) {
+			t.Errorf("trial %d: OSW round-trip failed: msg=%v crc=%#x", trial, msg, crc)
+		}
+	}
+}
+
+func TestCRC7LTRDetectsSingleBitErrorInMessage(t *testing.T) {
+	msg := make([]byte, 24)
+	for i := 0; i < 24; i += 2 {
+		msg[i] = 1
+	}
+	crc := CRC7LTR(msg)
+	for pos := 0; pos < 24; pos++ {
+		corrupted := append([]byte{}, msg...)
+		corrupted[pos] ^= 1
+		if VerifyCRC7LTR(corrupted, crc, false) {
+			t.Errorf("bit %d flip went undetected", pos)
+		}
+	}
+}
+
+func TestVerifyCRC7LTRInboundInvertsChecksum(t *testing.T) {
+	msg := make([]byte, 24)
+	for i := 0; i < 24; i += 3 {
+		msg[i] = 1
+	}
+	crc := CRC7LTR(msg)
+	inv := crc ^ 0x7F
+	// OSW path: matches the as-is checksum.
+	if !VerifyCRC7LTR(msg, crc, false) {
+		t.Errorf("OSW: VerifyCRC7LTR(_, crc, false) = false, want true")
+	}
+	if VerifyCRC7LTR(msg, inv, false) {
+		t.Errorf("OSW: VerifyCRC7LTR(_, ~crc, false) = true, want false")
+	}
+	// ISW path: matches the bit-inverted checksum.
+	if !VerifyCRC7LTR(msg, inv, true) {
+		t.Errorf("ISW: VerifyCRC7LTR(_, ~crc, true) = false, want true")
+	}
+	if VerifyCRC7LTR(msg, crc, true) {
+		t.Errorf("ISW: VerifyCRC7LTR(_, crc, true) = true, want false")
+	}
+}
+
+func TestCRC7LTRChecksumsAreUnique(t *testing.T) {
+	// Each table entry must be distinct (single-bit-error
+	// detection requires unique syndromes per bit position).
+	seen := map[byte]int{}
+	for i, c := range crc7LTRChecksums {
+		if prev, dup := seen[c]; dup {
+			t.Errorf("duplicate checksum %#x at positions %d and %d", c, prev, i)
+		}
+		seen[c] = i
+	}
+}
+
+func TestCRC7LTRChecksumsAreSevenBit(t *testing.T) {
+	for i, c := range crc7LTRChecksums {
+		if c&0x80 != 0 {
+			t.Errorf("checksum at index %d = %#x has high bit set", i, c)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds `CRC7LTR` / `VerifyCRC7LTR` in a new `internal/radio/framing/crc_ltr.go` for the LTR Standard message check. Parameters and lookup table copied verbatim from DSheirer/sdrtrunk's `edac/CRCLTR.java`:

- **Polynomial:** `0xFD` (= x^7 + x^6 + x^5 + x^4 + x^3 + x^2 + 1, with explicit x^7 leading term)
- **Initial fill:** `0x00`

The 24-entry syndrome lookup table covers the four LTR fields the CRC protects (per sdrtrunk's layout interpretation):

| Field | Bits | Table index |
| --- | --- | --- |
| Area | 1 | 0 |
| Channel | 5 | 1..5 |
| Home | 5 | 6..10 |
| Group | 8 | 11..18 |
| Free | 5 | 19..23 |

`VerifyCRC7LTR` is direction-aware: OSW (outbound from base) frames must match the calculated checksum as-is; ISW (inbound from subscriber) frames carry the bit-inverted checksum.

## Not yet wired

The primitive isn't yet wired into the LTR `ControlChannel` adapter because sdrtrunk's bit-layout reading (1-bit Area, 5-bit Channel) disagrees with GopherTrunk's existing `Status` struct (5-bit Area, 4-bit Channel — a different LTR Standard interpretation). Reconciling the two readings + extending `Status` (or defining a sdrtrunk-compatible shim) is the documented follow-up PR.

## Test plan

- [x] `go test ./internal/radio/framing/ -run CRC7LTR` — eight new tests:
  - All-zero message → zero checksum
  - Single-bit set → checksum equals the table entry (24 positions)
  - Multi-bit XOR property
  - 256 random-message OSW round-trips
  - Single-bit-error detection at every position
  - ISW inversion semantics
  - Table uniqueness (single-bit-error detection requires unique syndromes)
  - All entries are 7-bit-bounded (no high-bit leak)
- [x] `go test ./...` (full suite)
- [x] `go vet ./...`

## Reference

DSheirer/sdrtrunk: `src/main/java/io/github/dsheirer/edac/CRCLTR.java`

https://claude.ai/code/session_019dtCCVEZJTKKr6YK3wy824

---
_Generated by [Claude Code](https://claude.ai/code/session_019dtCCVEZJTKKr6YK3wy824)_