### PR TITLE
internal/radio/framing: EDACS BCH(40,28,2) primitive (generator 0x1539, t=2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,10 +95,14 @@ The remaining gaps:
   single-bit correction; the 10-bit Op field that the spec
   carries between Ident and Function isn't modelled by the
   Codeword struct yet (the wiring extracts the 38 info bits
-  the existing struct cares about and drops Op). The remaining
-  protocols (EDACS, TETRA, LTR FCS) still have their
-  per-protocol FEC layers pending — see each adapter PR for
-  the specific FEC parameters.
+  the existing struct cares about and drops Op). **EDACS** has
+  a `framing.BCHEncodeEDACS` / `BCHDecodeEDACS` primitive in
+  `internal/radio/framing/bch_edacs.go` (BCH(40, 28, 2),
+  generator 0x1539, parameters from lwvmobile/edacs-fm's
+  bch3.h); wiring it into the EDACS adapter is the documented
+  follow-up. **TETRA** still has its RCPC + RM(1,5) channel
+  coding pending — needs ETSI EN 300 392-2 §8.2 to source the
+  generator polynomials + puncturing patterns.
 - **Symbol-time clock recovery on complex IQ.** The Gardner
   timing-recovery primitive in `internal/dsp/sync/gardner.go`
   is now threaded into both the **P25 Phase 2** and **TETRA**
@@ -176,6 +180,29 @@ to its own package and lands independently.
 
 ### Recently shipped
 
+- **EDACS BCH(40, 28, 2) primitive in framing/.** New shared
+  `framing/bch_edacs.go` adds `BCHEncodeEDACS` /
+  `BCHDecodeEDACS` for the EDACS Standard control-channel word
+  check. Parameters confirmed from lwvmobile/edacs-fm's
+  `bch3.h` (the most-cited public reference for EDACS channel
+  coding): shortened BCH(40, 28, 2) derived from BCH(63, 51, 2)
+  over GF(2^6) with primitive polynomial x^6 + x + 1.
+  Generator polynomial `g(x) = m₁(x) · m₃(x) = x^12 + x^10 +
+  x^8 + x^5 + x^4 + x^3 + 1 = 0x1539`, designed minimum
+  distance d = 5, corrects up to t = 2 bit errors per
+  codeword. The decoder precomputes a 40-entry single-bit-
+  error syndrome table at package init, then handles
+  single-bit corrections via direct lookup and double-bit
+  corrections by iterating the 780 ordered pairs. Tests cover
+  round-trip cleanly across constants + 1024 random info
+  values, single-bit correction across all 40 positions,
+  double-bit correction across all (40 choose 2) = 780 pairs,
+  triple-bit error rejection (> 95% detected / mis-corrected),
+  syndrome-table uniqueness + bit-width sanity, and
+  encoded-codeword self-syndrome zero check. Not yet wired
+  into the EDACS `ControlChannel` adapter; the existing 40-bit
+  CCW struct needs cross-checking against this layout —
+  documented follow-up.
 - **LTR Standard CRC-7 primitive in framing/.** New shared
   `framing/crc_ltr.go` adds `CRC7LTR` / `VerifyCRC7LTR` for
   the LTR Standard message check (polynomial 0xFD, initial

--- a/internal/radio/framing/bch_edacs.go
+++ b/internal/radio/framing/bch_edacs.go
@@ -1,0 +1,127 @@
+package framing
+
+// EDACS BCH(40, 28, 2) codeword check.
+//
+// EDACS Standard control-channel words (CCWs) are protected by a
+// shortened BCH(40, 28, 2) code per lwvmobile/edacs-fm's bch3.h —
+// the most-cited public reference for the EDACS channel coding.
+// The shortened code derives from the BCH(63, 51, 2) mother code
+// over GF(2^6) with primitive polynomial x^6 + x + 1; the
+// generator polynomial is the product of the minimal polynomials
+// of α and α^3:
+//
+//	m₁(x) = x^6 + x + 1
+//	m₃(x) = x^6 + x^4 + x^2 + x + 1
+//	g(x)  = m₁(x) · m₃(x)
+//	      = x^12 + x^10 + x^8 + x^5 + x^4 + x^3 + 1
+//	      = 0x1539  (= 0x0539 without the implicit x^12)
+//
+// The code corrects up to t = 2 bit errors per 40-bit codeword,
+// with designed minimum distance d = 5.
+//
+// Codeword layout (systematic):
+//
+//	bits 0..11   12-bit BCH parity (low bits)
+//	bits 12..39  28-bit information field (high bits)
+
+const (
+	bchEDACSCodewordBits = 40
+	bchEDACSInfoBits     = 28
+	bchEDACSParityBits   = 12
+	bchEDACSInfoMask     = uint32(1)<<bchEDACSInfoBits - 1
+	bchEDACSParityMask   = uint16(1)<<bchEDACSParityBits - 1
+
+	// bchEDACSGenerator is the degree-12 generator polynomial
+	// g(x) = x^12 + x^10 + x^8 + x^5 + x^4 + x^3 + 1, packed
+	// into a 13-bit uint16 (bit 12 = x^12, bit 0 = 1).
+	bchEDACSGenerator uint16 = 0x1539
+)
+
+// bchEDACSSyndromes[i] is the 12-bit syndrome of a single-bit
+// error at codeword position i (i.e. x^i mod g(x)), computed at
+// package init time. The decoder uses this table for both
+// single-bit and double-bit error correction (a double-bit error
+// at positions (i, j) has syndrome syndromes[i] ^ syndromes[j]).
+var bchEDACSSyndromes [bchEDACSCodewordBits]uint16
+
+func init() {
+	// Compute x^i mod g(x) for i in 0..39 via repeated shift +
+	// reduction.
+	v := uint16(1)
+	for i := 0; i < bchEDACSCodewordBits; i++ {
+		bchEDACSSyndromes[i] = v
+		// Multiply by x: shift left and reduce if the new top bit
+		// is set.
+		v <<= 1
+		if v&(1<<bchEDACSParityBits) != 0 {
+			v ^= bchEDACSGenerator
+		}
+		v &= bchEDACSParityMask
+	}
+}
+
+// computeBCHEDACSSyndrome returns the 12-bit BCH syndrome of a
+// 40-bit codeword: cw(x) mod g(x).
+func computeBCHEDACSSyndrome(cw uint64) uint16 {
+	var s uint16
+	for i := 0; i < bchEDACSCodewordBits; i++ {
+		if cw&(uint64(1)<<uint(i)) != 0 {
+			s ^= bchEDACSSyndromes[i]
+		}
+	}
+	return s
+}
+
+// BCHEncodeEDACS builds a 40-bit EDACS codeword from 28 bits of
+// information. Only the low 28 bits of info are used. The
+// codeword is systematic: info bits occupy positions 12..39
+// (high), the 12-bit BCH parity occupies positions 0..11 (low).
+func BCHEncodeEDACS(info uint32) uint64 {
+	info &= bchEDACSInfoMask
+	// Place info at bits 12..39, then derive parity such that the
+	// total codeword is divisible by g(x). The systematic parity
+	// is the syndrome of (info << 12).
+	cw := uint64(info) << bchEDACSParityBits
+	parity := computeBCHEDACSSyndrome(cw)
+	return cw | uint64(parity)
+}
+
+// BCHDecodeEDACS validates and (where possible) corrects a 40-bit
+// EDACS codeword. Returns (info, errs) where:
+//
+//   - errs = 0: codeword passed cleanly; info is the recovered
+//     28-bit information field.
+//   - errs = 1 or 2: a 1- or 2-bit error was detected and
+//     corrected; info reflects the corrected information field.
+//   - errs = -1: the codeword carries more than 2 bit errors (or
+//     a pattern this BCH(40, 28, 2) can't isolate); info is the
+//     received information field but should not be trusted.
+//
+// Single-bit corrections are looked up directly in the per-
+// position syndrome table; double-bit corrections iterate the
+// 780 ordered pairs of bit positions and match against the
+// observed syndrome.
+func BCHDecodeEDACS(cw uint64) (uint32, int) {
+	cw &= (uint64(1) << bchEDACSCodewordBits) - 1
+	syndrome := computeBCHEDACSSyndrome(cw)
+	if syndrome == 0 {
+		return uint32(cw>>bchEDACSParityBits) & bchEDACSInfoMask, 0
+	}
+	// Single-bit correction.
+	for pos := 0; pos < bchEDACSCodewordBits; pos++ {
+		if bchEDACSSyndromes[pos] == syndrome {
+			corrected := cw ^ (uint64(1) << uint(pos))
+			return uint32(corrected>>bchEDACSParityBits) & bchEDACSInfoMask, 1
+		}
+	}
+	// Double-bit correction.
+	for i := 0; i < bchEDACSCodewordBits-1; i++ {
+		for j := i + 1; j < bchEDACSCodewordBits; j++ {
+			if bchEDACSSyndromes[i]^bchEDACSSyndromes[j] == syndrome {
+				corrected := cw ^ (uint64(1) << uint(i)) ^ (uint64(1) << uint(j))
+				return uint32(corrected>>bchEDACSParityBits) & bchEDACSInfoMask, 2
+			}
+		}
+	}
+	return uint32(cw>>bchEDACSParityBits) & bchEDACSInfoMask, -1
+}

--- a/internal/radio/framing/bch_edacs_test.go
+++ b/internal/radio/framing/bch_edacs_test.go
@@ -1,0 +1,155 @@
+package framing
+
+import (
+	"math/rand"
+	"testing"
+)
+
+func TestBCHEDACSRoundTripCleanCodeword(t *testing.T) {
+	infos := []uint32{
+		0,
+		1,
+		0x0123456,
+		0x0FFFFFF,
+		0x0AAAAAA,
+		0x0555555,
+		0x0DEADBE, // 28-bit truncated
+	}
+	for _, info := range infos {
+		want := info & bchEDACSInfoMask
+		cw := BCHEncodeEDACS(info)
+		got, errs := BCHDecodeEDACS(cw)
+		if errs != 0 {
+			t.Errorf("info=%#x: errs=%d, want 0", info, errs)
+		}
+		if got != want {
+			t.Errorf("info=%#x: decoded=%#x, want=%#x", info, got, want)
+		}
+	}
+}
+
+func TestBCHEDACSCorrectsAnySingleBitError(t *testing.T) {
+	const info = uint32(0x0CAFEBA)
+	want := info & bchEDACSInfoMask
+	cw := BCHEncodeEDACS(info)
+	for pos := 0; pos < bchEDACSCodewordBits; pos++ {
+		corrupted := cw ^ (uint64(1) << uint(pos))
+		got, errs := BCHDecodeEDACS(corrupted)
+		if errs != 1 {
+			t.Errorf("pos=%d: errs=%d, want 1", pos, errs)
+			continue
+		}
+		if got != want {
+			t.Errorf("pos=%d: decoded info=%#x, want %#x", pos, got, want)
+		}
+	}
+}
+
+func TestBCHEDACSCorrectsAnyDoubleBitError(t *testing.T) {
+	const info = uint32(0x0123456)
+	want := info & bchEDACSInfoMask
+	cw := BCHEncodeEDACS(info)
+	for i := 0; i < bchEDACSCodewordBits-1; i++ {
+		for j := i + 1; j < bchEDACSCodewordBits; j++ {
+			corrupted := cw ^ (uint64(1) << uint(i)) ^ (uint64(1) << uint(j))
+			got, errs := BCHDecodeEDACS(corrupted)
+			if errs != 2 {
+				t.Errorf("pos=(%d,%d): errs=%d, want 2", i, j, errs)
+				continue
+			}
+			if got != want {
+				t.Errorf("pos=(%d,%d): decoded info=%#x, want %#x", i, j, got, want)
+			}
+		}
+	}
+}
+
+func TestBCHEDACSRejectsTripleBitErrors(t *testing.T) {
+	const info = uint32(0x0ABCDEF)
+	want := info & bchEDACSInfoMask
+	cw := BCHEncodeEDACS(info)
+	// BCH(40,28,2) corrects t=2 errors; triple-bit patterns
+	// should mostly be rejected (errs == -1) or mis-corrected
+	// to a wrong info — never silently accepted as clean.
+	wrongCount := 0
+	total := 0
+	for i := 0; i < bchEDACSCodewordBits-2; i++ {
+		for j := i + 1; j < bchEDACSCodewordBits-1; j++ {
+			for k := j + 1; k < bchEDACSCodewordBits; k++ {
+				corrupted := cw ^ (uint64(1) << uint(i)) ^ (uint64(1) << uint(j)) ^ (uint64(1) << uint(k))
+				got, errs := BCHDecodeEDACS(corrupted)
+				total++
+				if errs == 0 && got == want {
+					t.Errorf("triple-error (%d, %d, %d) silently passed", i, j, k)
+				}
+				if errs == -1 || got != want {
+					wrongCount++
+				}
+			}
+		}
+	}
+	// Almost all triple-bit errors should be detected or
+	// mis-corrected to a wrong info. A small fraction map to
+	// syndromically-equivalent ≤2-bit patterns; that's a known
+	// property of BCH(40, 28, 2).
+	if float64(wrongCount)/float64(total) < 0.95 {
+		t.Errorf("only %d/%d triple errors detected/mis-corrected (< 95%%)", wrongCount, total)
+	}
+}
+
+func TestBCHEDACSRandomRoundTrip(t *testing.T) {
+	r := rand.New(rand.NewSource(0xED4C5))
+	for trial := 0; trial < 1024; trial++ {
+		info := r.Uint32() & bchEDACSInfoMask
+		cw := BCHEncodeEDACS(info)
+		got, errs := BCHDecodeEDACS(cw)
+		if errs != 0 || got != info {
+			t.Errorf("trial %d: info=%#x decoded=(%#x, %d)", trial, info, got, errs)
+		}
+	}
+}
+
+func TestBCHEDACSSyndromeTableSanity(t *testing.T) {
+	// syndromes[0] = x^0 mod g = 1.
+	if bchEDACSSyndromes[0] != 1 {
+		t.Errorf("syndromes[0] = %#x, want 1", bchEDACSSyndromes[0])
+	}
+	// syndromes[i] = 1 << i for i < 12 (since x^i has degree < 12).
+	for i := 0; i < bchEDACSParityBits; i++ {
+		want := uint16(1) << uint(i)
+		if bchEDACSSyndromes[i] != want {
+			t.Errorf("syndromes[%d] = %#x, want %#x", i, bchEDACSSyndromes[i], want)
+		}
+	}
+	// syndromes[12] = x^12 mod g = g(x) - x^12 = low 12 bits of generator.
+	want12 := bchEDACSGenerator & bchEDACSParityMask
+	if bchEDACSSyndromes[12] != want12 {
+		t.Errorf("syndromes[12] = %#x, want %#x", bchEDACSSyndromes[12], want12)
+	}
+	// All 40 entries must be unique within the table (a
+	// requirement for single-bit-error correction).
+	seen := map[uint16]int{}
+	for i, s := range bchEDACSSyndromes {
+		if prev, dup := seen[s]; dup {
+			t.Errorf("duplicate syndrome %#x at positions %d and %d", s, prev, i)
+		}
+		seen[s] = i
+	}
+	// All entries must fit in 12 bits.
+	for i, s := range bchEDACSSyndromes {
+		if s>>bchEDACSParityBits != 0 {
+			t.Errorf("syndrome[%d] = %#x exceeds 12 bits", i, s)
+		}
+	}
+}
+
+func TestBCHEDACSEncodedCodewordPassesItsOwnSyndrome(t *testing.T) {
+	r := rand.New(rand.NewSource(0xC0DE))
+	for trial := 0; trial < 64; trial++ {
+		info := r.Uint32() & bchEDACSInfoMask
+		cw := BCHEncodeEDACS(info)
+		if s := computeBCHEDACSSyndrome(cw); s != 0 {
+			t.Errorf("trial %d: encoded codeword %#x has nonzero syndrome %#x", trial, cw, s)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds `BCHEncodeEDACS` / `BCHDecodeEDACS` in a new `internal/radio/framing/bch_edacs.go` for the EDACS Standard control-channel word check. Parameters confirmed from lwvmobile/edacs-fm's `bch3.h` (the most-cited public reference for EDACS channel coding).

| Parameter | Value |
| --- | --- |
| GF size | GF(2^6) — 64 elements |
| Primitive polynomial | x^6 + x + 1 |
| Mother code | BCH(63, 51, 2) |
| Shortened length | 40 bits |
| Information bits (k) | 28 |
| Parity bits | 12 |
| Error correction (t) | 2 (corrects up to 2 bit errors) |
| Designed min. distance (d) | 5 |
| Generator polynomial | g(x) = m₁(x) · m₃(x) = x^12 + x^10 + x^8 + x^5 + x^4 + x^3 + 1 = **0x1539** |

Codeword layout (systematic): info bits at positions 12..39 (high 28 bits), 12-bit BCH parity at positions 0..11 (low bits).

Decoder precomputes a 40-entry single-bit-error syndrome table at package init (`x^i mod g(x)` for i in 0..39). Decoding flow:

1. Compute syndrome = `cw(x) mod g(x)`.
2. Zero syndrome → clean codeword.
3. Match syndrome against the 40-entry table → single-bit correction.
4. Iterate the 780 ordered pairs (i, j) → double-bit correction where `syndromes[i] ^ syndromes[j] == syndrome`.
5. Otherwise uncorrectable → `errs = -1`.

## Test plan

- [x] `go test ./internal/radio/framing/ -run BCHEDACS` — seven new tests:
  - Round-trip across constants + 1024 random info values
  - Single-bit error correction at every one of the 40 positions (exact info recovery)
  - Double-bit error correction across **all** C(40, 2) = 780 ordered pairs (exact info recovery)
  - Triple-bit rejection: > 95% of all C(40, 3) = 9 880 triples flagged
  - Syndrome table sanity: low 12 entries are powers of two, position 12 matches `g(x) - x^12`, uniqueness across all 40 entries, all entries 12-bit-bounded
  - Encoded codewords have zero self-syndrome
- [x] `go test ./...` (full suite)
- [x] `go vet ./...`

## Follow-up

Not yet wired into the EDACS `ControlChannel` adapter — the existing 40-bit CCW struct in `internal/radio/edacs/` needs cross-checking against this layout (the wiring PR will mirror the MPT 1327 BCH wiring pattern from #129).

## Reference

[`lwvmobile/edacs-fm/bch3.h`](https://github.com/lwvmobile/edacs-fm/blob/master/bch3.h) — Robert Morelos-Zaragoza's generic BCH3 implementation from www.eccpage.com, configured for m=6, length=40, t=2.

https://claude.ai/code/session_019dtCCVEZJTKKr6YK3wy824

---
_Generated by [Claude Code](https://claude.ai/code/session_019dtCCVEZJTKKr6YK3wy824)_