### PR TITLE
internal/radio/edacs: SetBCHMode opt-in (BCH(40,28,2) on-wire codeword check)

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,12 +95,14 @@ The remaining gaps:
   single-bit correction; the 10-bit Op field that the spec
   carries between Ident and Function isn't modelled by the
   Codeword struct yet (the wiring extracts the 38 info bits
-  the existing struct cares about and drops Op). **EDACS** has
-  a `framing.BCHEncodeEDACS` / `BCHDecodeEDACS` primitive in
-  `internal/radio/framing/bch_edacs.go` (BCH(40, 28, 2),
-  generator 0x1539, parameters from lwvmobile/edacs-fm's
-  bch3.h); wiring it into the EDACS adapter is the documented
-  follow-up. **TETRA** still has its RCPC + RM(1,5) channel
+  the existing struct cares about and drops Op). **EDACS** now
+  has `SetBCHMode(BCHOn)` to run BCH(40, 28, 2) (generator
+  0x1539, parameters from lwvmobile/edacs-fm's bch3.h) over
+  each 40-bit on-wire CCW with single + double-bit error
+  correction; under BCHOn the effective CCW carries 28 info
+  bits (Command + Status + Address + 4 high bits of LCN), the
+  legacy struct's LCN bit 0 and Aux become BCH parity rather
+  than data. **TETRA** still has its RCPC + RM(1,5) channel
   coding pending — needs ETSI EN 300 392-2 §8.2 to source the
   generator polynomials + puncturing patterns.
 - **Symbol-time clock recovery on complex IQ.** The Gardner
@@ -180,6 +182,26 @@ to its own package and lands independently.
 
 ### Recently shipped
 
+- **EDACS `SetBCHMode(BCHOn)` opt-in.** Wires the
+  `BCHEncodeEDACS` / `BCHDecodeEDACS` framing primitive from
+  PR #132 into the EDACS `ControlChannel.Process` adapter via
+  `SetBCHMode(BCHOff | BCHOn)`. Same opt-in shape as the
+  MPT 1327 wiring (PR #129) and Motorola's pre-existing
+  `SetBCHMode`. Under BCHOn the adapter slices 40-bit on-wire
+  codewords, runs the BCH(40, 28, 2) validation +
+  single/double-bit correction over each slice, then
+  re-encodes the corrected 28-bit info into a 40-bit wire
+  word that the existing `CCWFromBits` parser interprets.
+  Uncorrectable codewords (≥ 3 bit errors in unfavourable
+  positions) drop the frame. Under BCHOn the effective CCW
+  model carries Command (4) + Status (4) + Address (16) +
+  LCN (4 high bits, position 12..15) = 28 info bits; the
+  legacy struct's LCN bit 0 and Aux (11 bits) become BCH
+  parity, not data. Tests cover BCHOn round-trip (an
+  encoded GroupVoiceGrant publishes a Grant with the right
+  Address + LCN), single-bit error correction, double-bit
+  error correction (BCH(40, 28, 2)'s full t=2 capability),
+  triple-bit error rejection, and default-mode regression.
 - **EDACS BCH(40, 28, 2) primitive in framing/.** New shared
   `framing/bch_edacs.go` adds `BCHEncodeEDACS` /
   `BCHDecodeEDACS` for the EDACS Standard control-channel word

--- a/internal/radio/edacs/control.go
+++ b/internal/radio/edacs/control.go
@@ -38,6 +38,53 @@ type ControlChannel struct {
 	locked           bool
 	last             LockState
 	strictValidation bool
+	bchMode          BCHMode
+}
+
+// BCHMode selects how the Process adapter interprets the incoming
+// bit stream:
+//
+//   - BCHOff (default): the adapter slices 40-bit pre-stripped
+//     information windows and treats them as CCWs. Works on
+//     synthesized test fixtures whose codewords are not BCH-
+//     protected.
+//
+//   - BCHOn: the adapter slices 40-bit on-wire BCH(40,28,2)
+//     codewords (info at bits 12..39 high; 12-bit BCH parity at
+//     bits 0..11 low), runs the
+//     internal/radio/framing/bch_edacs.go primitive to
+//     validate + correct up to 2 bit errors per codeword, then
+//     re-encodes the corrected info into a 40-bit wire word
+//     that the existing CCWFromBits parser consumes.
+//
+// Under BCHOn the effective CCW model carries:
+//
+//	Command (4 bits, positions 36..39 of the codeword)
+//	Status  (4 bits, positions 32..35)
+//	Address (16 bits, positions 16..31)
+//	LCN     (4 bits, positions 12..15 — only the high 4 bits
+//	         of the existing 5-bit Codeword.LCN field;
+//	         the low bit is BCH parity)
+//
+// The existing `Aux` field at codeword bits 0..10 is BCH parity
+// under BCHOn — not data. Callers that depend on the legacy
+// 5-bit LCN range or the Aux payload should keep using BCHOff.
+type BCHMode uint8
+
+const (
+	BCHOff BCHMode = iota
+	BCHOn
+)
+
+// SetBCHMode toggles the BCH(40, 28, 2) FEC layer on the Process
+// adapter. See BCHMode for the trade-offs. The mode applies to
+// every subsequent Process call; the Ingest entry point is
+// unaffected (callers that pre-parse CCWs don't go through this
+// adapter).
+func (c *ControlChannel) SetBCHMode(mode BCHMode) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.bchMode = mode
 }
 
 // Options configure a ControlChannel.

--- a/internal/radio/edacs/process.go
+++ b/internal/radio/edacs/process.go
@@ -1,5 +1,9 @@
 package edacs
 
+import (
+	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+)
+
 // processState is the cross-call bit buffering + sync-detection
 // state the Process adapter holds. Lazily initialised on the first
 // Process call.
@@ -42,6 +46,9 @@ func (c *ControlChannel) Process(bits []byte, baseIdx int) int {
 		}
 	}
 	p := c.proc
+	c.mu.Lock()
+	mode := c.bchMode
+	c.mu.Unlock()
 
 	p.matchScratch, _ = p.det.Process(p.matchScratch[:0], bits, baseIdx)
 	matchIdx := 0
@@ -56,7 +63,7 @@ func (c *ControlChannel) Process(bits []byte, baseIdx int) int {
 			p.ccw = append(p.ccw, b&1)
 			p.remaining--
 			if p.remaining == 0 {
-				if ccw, err := CCWFromBits(p.ccw); err == nil {
+				if ccw, ok := c.parseCCW(p.ccw, mode); ok {
 					c.Ingest(ccw)
 				}
 				p.ccw = p.ccw[:0]
@@ -69,6 +76,58 @@ func (c *ControlChannel) Process(bits []byte, baseIdx int) int {
 		}
 	}
 	return baseIdx + len(bits)
+}
+
+// parseCCW turns a 40-bit wire window into a CCW. Under BCHOff
+// the window is treated as 40 bits of pre-stripped information;
+// under BCHOn the window is the on-wire BCH(40,28,2) codeword:
+// the adapter packs it into the framing primitive's uint64
+// convention, runs BCH validation + correction, then re-encodes
+// the corrected 28-bit info field into a fresh 40-bit wire word
+// (parity bits set to zero / cleared) so the existing
+// CCWFromBits parser can interpret it. Uncorrectable codewords
+// (errs == -1) are dropped by returning (zero, false).
+func (c *ControlChannel) parseCCW(wire []byte, mode BCHMode) (CCW, bool) {
+	if len(wire) != 40 {
+		return CCW{}, false
+	}
+	if mode != BCHOn {
+		w, err := CCWFromBits(wire)
+		if err != nil {
+			return CCW{}, false
+		}
+		return w, true
+	}
+	// Pack 40 wire bits into the framing primitive's uint64
+	// convention. wire[0] is the MSB of the on-wire CCW (Command
+	// bit 3), which maps to bit 39 of the codeword; wire[39] is
+	// the LSB (Aux bit 0), which maps to bit 0.
+	var cw uint64
+	for i := 0; i < 40; i++ {
+		if wire[i]&1 != 0 {
+			cw |= uint64(1) << uint(39-i)
+		}
+	}
+	info28, errs := framing.BCHDecodeEDACS(cw)
+	if errs == -1 {
+		return CCW{}, false
+	}
+	// Re-encode the corrected info field into a clean wire word.
+	// The parity bits in positions 0..11 become a valid checksum
+	// of the corrected info; CCWFromBits then reads the field
+	// values out of the canonical bit positions.
+	corrected := framing.BCHEncodeEDACS(info28)
+	out := make([]byte, 40)
+	for i := 0; i < 40; i++ {
+		if corrected&(uint64(1)<<uint(39-i)) != 0 {
+			out[i] = 1
+		}
+	}
+	w, err := CCWFromBits(out)
+	if err != nil {
+		return CCW{}, false
+	}
+	return w, true
 }
 
 // Reset clears the SyncDetector's history so a stale match doesn't

--- a/internal/radio/edacs/process_bch_test.go
+++ b/internal/radio/edacs/process_bch_test.go
@@ -1,0 +1,263 @@
+package edacs
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// ccwToWireBCH packs a CCW (Aux must be 0, LCN must fit in 4 bits)
+// through the BCH(40,28,2) primitive and returns 40 wire bits ready
+// for Process(BCHOn) to consume.
+//
+// Layout in the 40-bit codeword (matching framing.BCHEncodeEDACS):
+//
+//	bits 0..11  = 12-bit BCH parity (computed)
+//	bits 12..15 = high 4 bits of LCN
+//	bits 16..31 = Address
+//	bits 32..35 = Status
+//	bits 36..39 = Command
+//
+// The Aux field (low 11 bits of the legacy CCW layout) and bit 0
+// of LCN are overwritten by BCH parity and must be zero in the
+// input CCW for the round-trip to match.
+func ccwToWireBCH(c CCW) []byte {
+	// Build the 28 information bits from the CCW fields.
+	info := uint32(c.Command&0xF)<<24 |
+		uint32(c.Status&0xF)<<20 |
+		uint32(c.Address&0xFFFF)<<4 |
+		uint32((c.LCN>>1)&0xF)
+	cw := framing.BCHEncodeEDACS(info)
+	wire := make([]byte, 40)
+	for i := 0; i < 40; i++ {
+		if cw&(uint64(1)<<uint(39-i)) != 0 {
+			wire[i] = 1
+		}
+	}
+	return wire
+}
+
+// TestProcessBCHOnDecodesEncodedCCW: build a stream of 30 padding
+// bits + 24 sync bits + 40 BCH-encoded codeword bits and confirm
+// Process(BCHOn) recovers the original Command / Address / LCN.
+func TestProcessBCHOnDecodesEncodedCCW(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{
+		Bus:         bus,
+		Log:         slog.Default(),
+		SystemName:  "Sys",
+		FrequencyHz: 866_000_000,
+	})
+	cc.SetBCHMode(BCHOn)
+
+	ccw := CCW{
+		Command: CmdGroupVoiceGrant,
+		Status:  0,
+		Address: 0xCAFE,
+		// LCN stored in the 4 high bits of the legacy 5-bit field:
+		// LCN = 10 = 0b01010, of which the high 4 bits = 0b0101 = 5.
+		// Under BCHOn the recovered LCN is (high 4 bits << 1) = 10.
+		LCN: 10,
+		Aux: 0, // Aux is BCH parity under BCHOn — must be zero in input.
+	}
+	wire := ccwToWireBCH(ccw)
+
+	stream := make([]byte, 30)
+	stream = append(stream, OutboundSyncBits()...)
+	stream = append(stream, wire...)
+
+	cc.Process(stream, 0)
+
+	var sawGrant bool
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind == events.KindGrant {
+				g, _ := ev.Payload.(trunking.Grant)
+				if g.GroupID != uint32(ccw.Address) {
+					t.Errorf("Grant.GroupID = %#x, want %#x", g.GroupID, ccw.Address)
+				}
+				if g.ChannelNum != uint16(ccw.LCN&0x1E) {
+					// LCN's low bit is BCH parity under BCHOn; the
+					// recovered LCN has bit 0 = 0.
+					t.Errorf("Grant.ChannelNum = %d, want %d", g.ChannelNum, ccw.LCN&0x1E)
+				}
+				sawGrant = true
+			}
+		default:
+			if !sawGrant {
+				t.Errorf("BCHOn Process did not publish a Grant")
+			}
+			return
+		}
+	}
+}
+
+// TestProcessBCHOnCorrectsSingleBitError: flip one bit inside the
+// 40-bit BCH-encoded CCW; the decoder must still recover the
+// original GroupVoiceGrant and publish the Grant.
+func TestProcessBCHOnCorrectsSingleBitError(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{
+		Bus:         bus,
+		Log:         slog.Default(),
+		SystemName:  "Sys",
+		FrequencyHz: 866_000_000,
+	})
+	cc.SetBCHMode(BCHOn)
+
+	ccw := CCW{
+		Command: CmdGroupVoiceGrant,
+		Address: 0xBEEF,
+		LCN:     8,
+	}
+	wire := ccwToWireBCH(ccw)
+	// Flip one bit deep in the info portion (codeword position 20
+	// = wire index 19).
+	wire[19] ^= 1
+
+	stream := make([]byte, 30)
+	stream = append(stream, OutboundSyncBits()...)
+	stream = append(stream, wire...)
+
+	cc.Process(stream, 0)
+
+	var sawGrant bool
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind == events.KindGrant {
+				g, _ := ev.Payload.(trunking.Grant)
+				if g.GroupID != uint32(ccw.Address) {
+					t.Errorf("Grant.GroupID = %#x, want %#x", g.GroupID, ccw.Address)
+				}
+				sawGrant = true
+			}
+		default:
+			if !sawGrant {
+				t.Errorf("BCHOn Process did not publish a Grant after single-bit correction")
+			}
+			return
+		}
+	}
+}
+
+// TestProcessBCHOnCorrectsDoubleBitError: flip two bits in the
+// BCH-encoded codeword; BCH(40,28,2) corrects up to 2 errors so
+// the Grant must still land.
+func TestProcessBCHOnCorrectsDoubleBitError(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{
+		Bus:         bus,
+		Log:         slog.Default(),
+		SystemName:  "Sys",
+		FrequencyHz: 866_000_000,
+	})
+	cc.SetBCHMode(BCHOn)
+
+	ccw := CCW{
+		Command: CmdGroupVoiceGrant,
+		Address: 0x1234,
+		LCN:     4,
+	}
+	wire := ccwToWireBCH(ccw)
+	wire[5] ^= 1  // first error
+	wire[25] ^= 1 // second error
+
+	stream := make([]byte, 30)
+	stream = append(stream, OutboundSyncBits()...)
+	stream = append(stream, wire...)
+
+	cc.Process(stream, 0)
+
+	var sawGrant bool
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind == events.KindGrant {
+				g, _ := ev.Payload.(trunking.Grant)
+				if g.GroupID != uint32(ccw.Address) {
+					t.Errorf("Grant.GroupID = %#x, want %#x", g.GroupID, ccw.Address)
+				}
+				sawGrant = true
+			}
+		default:
+			if !sawGrant {
+				t.Errorf("BCHOn Process did not publish a Grant after double-bit correction")
+			}
+			return
+		}
+	}
+}
+
+// TestProcessBCHOnDropsUncorrectableCCW: corrupt the codeword with
+// three unfavourable bit flips; the BCH(40,28,2) decoder must
+// reject (errs == -1) and Process must not publish events.
+func TestProcessBCHOnDropsUncorrectableCCW(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{
+		Bus:        bus,
+		Log:        slog.Default(),
+		SystemName: "Sys",
+	})
+	cc.SetBCHMode(BCHOn)
+
+	ccw := CCW{Command: CmdGroupVoiceGrant, Address: 0xABCD, LCN: 6}
+	wire := ccwToWireBCH(ccw)
+	// Flip three info bits — beyond BCH(40,28,2)'s t=2 correction
+	// capability.
+	wire[1] ^= 1
+	wire[15] ^= 1
+	wire[30] ^= 1
+
+	stream := make([]byte, 30)
+	stream = append(stream, OutboundSyncBits()...)
+	stream = append(stream, wire...)
+
+	cc.Process(stream, 0)
+
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind == events.KindCCLocked || ev.Kind == events.KindGrant {
+				t.Errorf("BCHOn accepted an uncorrectable CCW: %v", ev.Kind)
+			}
+		default:
+			return
+		}
+	}
+}
+
+func TestSetBCHModeDefault(t *testing.T) {
+	cc := New(Options{Bus: events.NewBus(1)})
+	if cc.bchMode != BCHOff {
+		t.Errorf("default bchMode = %v, want BCHOff", cc.bchMode)
+	}
+	cc.SetBCHMode(BCHOn)
+	if cc.bchMode != BCHOn {
+		t.Errorf("SetBCHMode(BCHOn) did not take effect")
+	}
+	cc.SetBCHMode(BCHOff)
+	if cc.bchMode != BCHOff {
+		t.Errorf("SetBCHMode(BCHOff) did not take effect")
+	}
+}


### PR DESCRIPTION
## Summary

Wires the `BCHEncodeEDACS` / `BCHDecodeEDACS` framing primitive from PR #132 into the EDACS `ControlChannel.Process` adapter via `SetBCHMode(BCHOff | BCHOn)`. Same opt-in shape as Motorola's `SetBCHMode` and the MPT 1327 wiring (PR #129).

**BCHOff (default, unchanged):** `Process` reads 40-bit pre-stripped information windows and treats them as CCWs. Matches the legacy adapter behaviour; all existing 40-bit-info tests still pass.

**BCHOn:** `Process` reads 40-bit on-wire codewords, packs into the framing primitive's uint64 convention, runs `BCHDecodeEDACS` for validation + single/double-bit correction (full t=2 capability), then re-encodes the corrected 28-bit info into a fresh 40-bit wire word that `CCWFromBits` parses.

## Field mapping under BCHOn

The 28 BCH information bits cover the high 28 bits of the existing 40-bit CCW layout:

| Bits | Field | Notes |
| --- | --- | --- |
| 36..39 | Command (4) | unchanged |
| 32..35 | Status (4) | unchanged |
| 16..31 | Address (16) | unchanged |
| 12..15 | LCN (4 high bits) | the legacy 5-bit `Codeword.LCN` field's low bit becomes BCH parity |
| 0..11 | BCH parity (12) | overlaps the legacy `Aux` (11) field + LCN bit 0 |

So under BCHOn, callers must treat the recovered LCN as a 4-bit value (effectively `LCN & 0x1E`) and ignore the `Aux` payload. Callers that depend on the legacy 5-bit LCN range or the Aux payload should keep using BCHOff.

## Test plan

- [x] `go test ./internal/radio/edacs/` — five new BCH tests:
  - BCHOn round-trip on a clean `GroupVoiceGrant`: Grant publishes right Address + LCN
  - Single-bit error correction: one flipped bit per codeword still drives Grant
  - Double-bit error correction: two flipped bits still drive Grant (full t=2)
  - Uncorrectable rejection: three unfavourable flips drop the frame
  - Default mode is BCHOff
- [x] `go test ./...` (full suite) — existing 40-bit-info tests still pass under default BCHOff
- [x] `go vet ./...`

## Follow-up

Wiring the spec's 10-bit Op field into the CCW struct (so the BCH layer can surface a richer information field) is the documented follow-up. Strict-validation mode (PR #29) still applies on the Ingest path under both modes.

## Reference

[`lwvmobile/edacs-fm/bch3.h`](https://github.com/lwvmobile/edacs-fm/blob/master/bch3.h) — confirms BCH(40, 28, 2) parameters and the bit layout (info at positions 12..39, parity at 0..11).

https://claude.ai/code/session_019dtCCVEZJTKKr6YK3wy824

---
_Generated by [Claude Code](https://claude.ai/code/session_019dtCCVEZJTKKr6YK3wy824)_