### PR TITLE
internal/radio/ltr: SetFCSMode opt-in for the LTR Standard CRC-7 trailer check

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,13 +76,13 @@ The remaining gaps:
   is the next follow-up. The CAC CRC-CCITT-16 strict-mode
   remains enforced. **LTR** has a `SetManchesterMode` config
   for deployments that bi-phase-encode the sub-audible status
-  word, plus a `framing.CRC7LTR` primitive in
-  `internal/radio/framing/crc_ltr.go` (polynomial 0xFD, table
-  from DSheirer/sdrtrunk's CRCLTR.java) that future PRs can
-  wire into the adapter; the wiring is pending because
-  sdrtrunk's bit-layout reading (1-bit Area, 5-bit Channel)
-  disagrees with GopherTrunk's `Status` struct (5-bit Area,
-  4-bit Channel).
+  word, and `SetFCSMode(FCSOn)` to verify the 7-bit CRC trailer
+  per DSheirer/sdrtrunk's CRCLTR.java on the Ingest path. Under
+  FCSOn the CRC covers a 24-bit message vector (gophertrunk's
+  Group F-bit as sdrtrunk's "Area", plus Channel/Home/GroupID/
+  Free); the gophertrunk 5-bit `Status.Area` stays as opaque
+  metadata for the multi-system filter and only the low 7
+  bits of the 12-bit `Status.FCS` field are CRC-protected.
   **Motorola Type II** has `SetBCHMode(BCHOn)` to run
   BCH(64,16,11) over each codeword pair. **P25 Phase 2** now
   has `SetTrellisMode(TrellisOn)` to run the TIA-102 Annex A
@@ -182,6 +182,27 @@ to its own package and lands independently.
 
 ### Recently shipped
 
+- **LTR `SetFCSMode(FCSOn)` opt-in.** Wires the
+  `framing.CRC7LTR` primitive from PR #131 into the LTR
+  `ControlChannel.Ingest` path. Under FCSOn, Ingest computes
+  the CRC-7 over a 24-bit message vector derived from Status
+  fields (per DSheirer/sdrtrunk's CRCLTR.java layout: 1-bit
+  Group / F-bit as sdrtrunk's "Area", then Channel/Home/
+  GroupID/Free), compares it to the low 7 bits of
+  `Status.FCS`, and drops the frame on mismatch. `ComputeStatusFCS`
+  is exported so test fixtures + future encoders can populate
+  the trailer correctly. The 5-bit gophertrunk `Status.Area`
+  field stays as opaque metadata for the multi-system filter
+  (a different layer than the CRC-protected message); under
+  this wiring the gophertrunk Group F-bit is the canonical
+  sdrtrunk "Area" bit. Tests cover valid CRCs accepted,
+  corrupted CRCs dropped, corrupted message fields dropped,
+  FCSOff bypass preserved, default mode, and CRC-changes-with-
+  the-Group-bit sanity. Doesn't yet resolve the broader
+  layout disagreement between sdrtrunk's 7-bit CRC reading and
+  gophertrunk's 12-bit `Status.FCS` field (only the low 7 bits
+  are CRC-protected in this wiring) — that's a documented
+  follow-up.
 - **EDACS `SetBCHMode(BCHOn)` opt-in.** Wires the
   `BCHEncodeEDACS` / `BCHDecodeEDACS` framing primitive from
   PR #132 into the EDACS `ControlChannel.Process` adapter via

--- a/internal/radio/ltr/control.go
+++ b/internal/radio/ltr/control.go
@@ -57,6 +57,46 @@ type ControlChannel struct {
 	// grant on every status word.
 	activeGroup      uint16
 	strictValidation bool
+	fcsMode          FCSMode
+}
+
+// FCSMode selects whether the Ingest path verifies the LTR
+// CRC-7 trailer per DSheirer/sdrtrunk's CRCLTR.java.
+//
+//   - FCSOff (default): the Ingest path doesn't run any
+//     checksum verification. The Status.FCS field is treated as
+//     opaque metadata. Existing behaviour pre-PR #40.
+//
+//   - FCSOn: the Ingest path computes the CRC-7 over a 24-bit
+//     message built from the Status fields per sdrtrunk's layout
+//     and compares it to the low 7 bits of Status.FCS. Frames
+//     whose CRC doesn't match are silently dropped. Useful when
+//     the upstream framing layer has populated Status.FCS from
+//     the on-air bits and the caller wants to filter out
+//     corrupted frames.
+//
+// Per sdrtrunk's layout the 24 message bits cover the four LTR
+// fields the CRC protects: Area (1 bit, mapped from gophertrunk's
+// 1-bit Group / F-bit), Channel (5 bits), Home (5 bits), Group
+// (8 bits, mapped from gophertrunk's GroupID), and Free (5 bits).
+// Note that sdrtrunk's "Area" field is 1 bit, not the 5-bit
+// gophertrunk `Status.Area` — the gophertrunk Group F-bit is what
+// matches sdrtrunk's Area at this layer. Status.Area continues to
+// drive the multi-system filter; the FCS check is independent of
+// it.
+type FCSMode uint8
+
+const (
+	FCSOff FCSMode = iota
+	FCSOn
+)
+
+// SetFCSMode toggles the CRC-7 FCS verification on the Ingest
+// path. See FCSMode for the trade-offs.
+func (c *ControlChannel) SetFCSMode(mode FCSMode) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.fcsMode = mode
 }
 
 // SetStrictValidation toggles the strict frame-validity filter on the
@@ -112,8 +152,14 @@ func New(opts Options) *ControlChannel {
 func (c *ControlChannel) Ingest(s Status) {
 	c.mu.Lock()
 	strict := c.strictValidation
+	fcsMode := c.fcsMode
 	c.mu.Unlock()
 	if strict && !s.IsWellFormed() {
+		return
+	}
+	if fcsMode == FCSOn && !verifyStatusFCS(s) {
+		// CRC-7 mismatch — drop. Almost certainly a frame with
+		// bit errors or a misaligned codeword.
 		return
 	}
 	if !s.Sync {

--- a/internal/radio/ltr/fcs.go
+++ b/internal/radio/ltr/fcs.go
@@ -1,0 +1,61 @@
+package ltr
+
+import (
+	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+)
+
+// statusFCSMessageBits builds the 24-bit message vector that the
+// CRC-7 covers, per sdrtrunk's CRCLTR.java layout:
+//
+//	index 0      sdrtrunk Area    — 1 bit  — mapped from
+//	                                Status.Group (the F-bit)
+//	indices 1..5 sdrtrunk Channel — 5 bits — Status.Channel
+//	                                MSB-first
+//	indices 6..10 sdrtrunk Home    — 5 bits — Status.Home
+//	                                MSB-first
+//	indices 11..18 sdrtrunk Group  — 8 bits — Status.GroupID
+//	                                MSB-first
+//	indices 19..23 sdrtrunk Free   — 5 bits — Status.Free
+//	                                MSB-first
+//
+// The gophertrunk Status struct's 5-bit Area field doesn't map
+// into the 24-bit FCS-protected message — it's used elsewhere in
+// the package (multi-system filter) and isn't part of the CRC.
+func statusFCSMessageBits(s Status) []byte {
+	msg := make([]byte, 24)
+	if s.Group {
+		msg[0] = 1
+	}
+	// Channel: 5 bits MSB-first.
+	for i := 0; i < 5; i++ {
+		msg[1+i] = (s.Channel >> uint(4-i)) & 1
+	}
+	// Home: 5 bits MSB-first.
+	for i := 0; i < 5; i++ {
+		msg[6+i] = (s.Home >> uint(4-i)) & 1
+	}
+	// GroupID: 8 bits MSB-first.
+	for i := 0; i < 8; i++ {
+		msg[11+i] = byte((s.GroupID >> uint(7-i)) & 1)
+	}
+	// Free: 5 bits MSB-first.
+	for i := 0; i < 5; i++ {
+		msg[19+i] = (s.Free >> uint(4-i)) & 1
+	}
+	return msg
+}
+
+// ComputeStatusFCS returns the 7-bit LTR Standard CRC computed
+// over the message bits derived from Status. Use this to populate
+// the Status.FCS field of a synthesized frame so the
+// FCSOn-equipped Ingest path accepts it.
+func ComputeStatusFCS(s Status) uint8 {
+	return framing.CRC7LTR(statusFCSMessageBits(s))
+}
+
+// verifyStatusFCS reports whether the low 7 bits of Status.FCS
+// match the CRC-7 of the message bits derived from Status.
+func verifyStatusFCS(s Status) bool {
+	want := framing.CRC7LTR(statusFCSMessageBits(s))
+	return uint8(s.FCS&0x7F) == want
+}

--- a/internal/radio/ltr/fcs_test.go
+++ b/internal/radio/ltr/fcs_test.go
@@ -1,0 +1,159 @@
+package ltr
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+)
+
+// makeStatusWithValidFCS builds a Status with the trunking-relevant
+// fields populated and Status.FCS set to the CRC-7 of the
+// resulting 24-bit message vector. Used by FCSOn tests.
+func makeStatusWithValidFCS() Status {
+	s := Status{
+		Sync:    true,
+		Area:    1,
+		Group:   true,
+		Channel: 5,
+		Home:    7,
+		GroupID: 42,
+		Free:    3,
+	}
+	s.FCS = uint16(ComputeStatusFCS(s))
+	return s
+}
+
+// TestFCSOnAcceptsValidChecksum: a Status whose FCS field carries
+// the correctly-computed CRC-7 must pass the Ingest check under
+// SetFCSMode(FCSOn) and reach the lock / grant path.
+func TestFCSOnAcceptsValidChecksum(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, Log: slog.Default(), SystemName: "Sys"})
+	cc.SetFCSMode(FCSOn)
+
+	cc.Ingest(makeStatusWithValidFCS())
+
+	var sawLock bool
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind == events.KindCCLocked {
+				sawLock = true
+			}
+		default:
+			if !sawLock {
+				t.Errorf("FCSOn dropped a Status with a valid CRC")
+			}
+			return
+		}
+	}
+}
+
+// TestFCSOnDropsCorruptedChecksum: flipping a bit in the FCS
+// trailer must cause FCSOn to drop the frame.
+func TestFCSOnDropsCorruptedChecksum(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, Log: slog.Default(), SystemName: "Sys"})
+	cc.SetFCSMode(FCSOn)
+
+	s := makeStatusWithValidFCS()
+	s.FCS ^= 1 // corrupt the LSB
+	cc.Ingest(s)
+
+	select {
+	case ev := <-sub.C:
+		t.Errorf("FCSOn accepted a Status with a bad CRC: %v", ev.Kind)
+	default:
+	}
+}
+
+// TestFCSOnDropsCorruptedMessage: flipping a bit in one of the
+// FCS-protected fields (Channel, Home, GroupID, Free) must also
+// cause FCSOn to drop the frame (the precomputed FCS no longer
+// matches the recomputed CRC).
+func TestFCSOnDropsCorruptedMessage(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, Log: slog.Default(), SystemName: "Sys"})
+	cc.SetFCSMode(FCSOn)
+
+	s := makeStatusWithValidFCS()
+	s.Channel ^= 1 // flip a single Channel bit
+	cc.Ingest(s)
+
+	select {
+	case ev := <-sub.C:
+		t.Errorf("FCSOn accepted a Status with a corrupted message field: %v", ev.Kind)
+	default:
+	}
+}
+
+// TestFCSOffIgnoresChecksum: FCSOff (the default) must NOT verify
+// the CRC — a Status with a bogus FCS field still drives the
+// state machine.
+func TestFCSOffIgnoresChecksum(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, Log: slog.Default(), SystemName: "Sys"})
+	// Default mode is FCSOff; don't call SetFCSMode.
+
+	s := makeStatusWithValidFCS()
+	s.FCS = 0x7F // bogus checksum
+	cc.Ingest(s)
+
+	var sawLock bool
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind == events.KindCCLocked {
+				sawLock = true
+			}
+		default:
+			if !sawLock {
+				t.Errorf("FCSOff dropped a frame despite bypassing the FCS check")
+			}
+			return
+		}
+	}
+}
+
+func TestSetFCSModeDefault(t *testing.T) {
+	cc := New(Options{Bus: events.NewBus(1)})
+	if cc.fcsMode != FCSOff {
+		t.Errorf("default fcsMode = %v, want FCSOff", cc.fcsMode)
+	}
+	cc.SetFCSMode(FCSOn)
+	if cc.fcsMode != FCSOn {
+		t.Errorf("SetFCSMode(FCSOn) did not take effect")
+	}
+	cc.SetFCSMode(FCSOff)
+	if cc.fcsMode != FCSOff {
+		t.Errorf("SetFCSMode(FCSOff) did not take effect")
+	}
+}
+
+func TestComputeStatusFCSMatchesPrimitive(t *testing.T) {
+	// Two distinct Status configurations should produce distinct
+	// CRC values (sanity check that the message-bit mapping
+	// actually varies across fields).
+	s1 := Status{Group: true, Channel: 1, Home: 1, GroupID: 1, Free: 1}
+	s2 := Status{Group: false, Channel: 1, Home: 1, GroupID: 1, Free: 1}
+	if ComputeStatusFCS(s1) == ComputeStatusFCS(s2) {
+		t.Errorf("CRC didn't change when the Group bit flipped: both = %#x", ComputeStatusFCS(s1))
+	}
+}


### PR DESCRIPTION
## Summary

Wires the `framing.CRC7LTR` primitive from PR #131 into the LTR `ControlChannel.Ingest` path via `SetFCSMode(FCSOff | FCSOn)`. Same opt-in shape as the BCH wirings on other protocols (PR #129 MPT 1327, PR #133 EDACS).

**FCSOff (default, unchanged):** the Ingest path doesn't verify any checksum. `Status.FCS` is treated as opaque metadata.

**FCSOn:** the Ingest path builds a 24-bit message vector from Status fields per sdrtrunk's `CRCLTR.java` layout, runs `framing.CRC7LTR`, and compares the result to the low 7 bits of `Status.FCS`. Drops the frame on mismatch.

## Message vector under FCSOn

| Index | Field | Source |
| --- | --- | --- |
| 0 | sdrtrunk Area (1 bit) | gophertrunk `Status.Group` (F-bit) |
| 1..5 | sdrtrunk Channel (5 bits, MSB-first) | `Status.Channel` |
| 6..10 | sdrtrunk Home (5 bits, MSB-first) | `Status.Home` |
| 11..18 | sdrtrunk Group (8 bits, MSB-first) | `Status.GroupID` |
| 19..23 | sdrtrunk Free (5 bits, MSB-first) | `Status.Free` |

The gophertrunk 5-bit `Status.Area` field is NOT part of the CRC message vector — it stays as opaque metadata for the multi-system filter (a different layer than the CRC-protected message). Under this wiring the gophertrunk Group F-bit is the canonical sdrtrunk "Area" bit. Only the low 7 bits of the 12-bit `Status.FCS` field are CRC-protected.

`ComputeStatusFCS` is exported so test fixtures + future encoders can populate the trailer correctly.

## Test plan

- [x] `go test ./internal/radio/ltr/ -run FCS` — six new tests:
  - Valid CRC accepted under FCSOn (Status drives `KindCCLocked`)
  - Corrupted FCS trailer dropped (one-bit flip in `Status.FCS`)
  - Corrupted message field dropped (one-bit flip in `Status.Channel` — recomputed CRC no longer matches stored)
  - FCSOff (default) bypasses the check entirely
  - Default mode is FCSOff
  - CRC changes when the Group bit flips (mapping sanity)
- [x] `go test ./...` (full suite) — existing tests still pass under default FCSOff
- [x] `go vet ./...`

## Follow-up

Doesn't resolve the broader **7-bit-vs-12-bit FCS** layout disagreement between sdrtrunk and gophertrunk (sdrtrunk reads CRC-7, gophertrunk's `Status.FCS` is 12 bits — the upper 5 bits remain opaque under this wiring). Needs a captured + decoded LTR Standard status word with known-good field values to disambiguate.

## Reference

[DSheirer/sdrtrunk: `edac/CRCLTR.java`](https://github.com/DSheirer/sdrtrunk/blob/master/src/main/java/io/github/dsheirer/edac/CRCLTR.java)

https://claude.ai/code/session_019dtCCVEZJTKKr6YK3wy824

---
_Generated by [Claude Code](https://claude.ai/code/session_019dtCCVEZJTKKr6YK3wy824)_