### PR TITLE
internal/radio/framing: TETRA RCPC primitive (K=5 R=1/3 mother + 2/3, 8/18, 8/17 puncturing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,9 +102,13 @@ The remaining gaps:
   correction; under BCHOn the effective CCW carries 28 info
   bits (Command + Status + Address + 4 high bits of LCN), the
   legacy struct's LCN bit 0 and Aux become BCH parity rather
-  than data. **TETRA** still has its RCPC + RM(1,5) channel
-  coding pending — needs ETSI EN 300 392-2 §8.2 to source the
-  generator polynomials + puncturing patterns.
+  than data. **TETRA** has a `framing.EncodeRCPCTetraMother`
+  / `DecodeRCPCTetraMother` primitive in
+  `internal/radio/framing/rcpc_tetra.go` plus puncturing
+  tables for the rate-2/3, 8/18, and 8/17 schemes per ETSI
+  EN 300 395-2 §5.4.3; wiring it into the TETRA adapter is
+  the documented follow-up. RM(1,5) for the broadcast block
+  header is still pending.
 - **Symbol-time clock recovery on complex IQ.** The Gardner
   timing-recovery primitive in `internal/dsp/sync/gardner.go`
   is now threaded into both the **P25 Phase 2** and **TETRA**
@@ -182,6 +186,36 @@ to its own package and lands independently.
 
 ### Recently shipped
 
+- **TETRA RCPC primitive in framing/.** New shared
+  `framing/rcpc_tetra.go` adds the K=5 ½-rate→1/3-rate
+  16-state convolutional mother code plus puncturing /
+  depuncturing helpers per ETSI EN 300 395-2 §5.4.3. Generator
+  polynomials `G₁(D) = 1 + D + D² + D³ + D⁴` (= 0x1F),
+  `G₂(D) = 1 + D + D³ + D⁴` (= 0x1B), `G₃(D) = 1 + D² + D⁴`
+  (= 0x15) — distinct from the K=5 R=½ code in
+  `viterbi_k5.go` (NXDN / YSF), so this is a separate
+  primitive with the same 16-state structure but three
+  outputs per input. Includes spec-verbatim puncturing tables
+  for the three rates TETRA's normal + stealing-mode speech
+  traffic channels use: rate-8/12 (= 2/3) for class-1 bits
+  (P = (1, 2, 4), Period = 6, §5.5.2.1), rate-8/18 for
+  class-2 bits in normal traffic (P = (1..5, 7, 8, 10, 11),
+  Period = 12, §5.5.2.2), and rate-8/17 for class-2 bits
+  under frame-stealing (17-element P, Period = 24,
+  §5.6.2.1). The mother-code `DecodeRCPCTetraMother` is a
+  16-state hard-decision Viterbi; depunctured positions use
+  the same `DepunctureMark` sentinel as the K=5 R=½ code so
+  callers can mix the two via a single decoder pattern.
+  Tests cover mother-code round-trip + single-bit
+  correction, encoder impulse-response sanity against the
+  three generator polynomials, round-trips for all three
+  puncturing schemes, single-bit-error correction over a
+  punctured rate-2/3 channel, and a schedule-sanity check
+  asserting the puncturing tables are strictly increasing
+  and bounded by their Period. Wiring this primitive into
+  the TETRA `ControlChannel.Process` adapter (sliced 432-bit
+  type-3 → type-2 stream per §5.5 / §5.6) is the
+  documented follow-up.
 - **LTR `SetFCSMode(FCSOn)` opt-in.** Wires the
   `framing.CRC7LTR` primitive from PR #131 into the LTR
   `ControlChannel.Ingest` path. Under FCSOn, Ingest computes

--- a/internal/radio/framing/rcpc_tetra.go
+++ b/internal/radio/framing/rcpc_tetra.go
@@ -1,0 +1,201 @@
+package framing
+
+// TETRA channel-coding RCPC primitive per ETSI EN 300 395-2 §5.4.3.
+//
+// Mother code: 16-state, constraint length K=5, rate 1/3
+// convolutional code with generator polynomials:
+//
+//	G_1(D) = 1 + D + D^2 + D^3 + D^4    (0x1F)
+//	G_2(D) = 1 + D + D^3 + D^4          (0x1B)
+//	G_3(D) = 1 + D^2 + D^4              (0x15)
+//
+// Different polynomials and rate from the K=5 1/2-rate code in
+// viterbi_k5.go (which serves NXDN SACCH / YSF FICH), so this is a
+// separate primitive — same 16-state structure, three outputs per
+// input instead of two.
+//
+// Encoder convention: state bits stored as (d1<<3)|(d2<<2)|(d3<<1)|d4
+// where d1 is the most-recent bit shifted in before the current
+// input, and d4 is the oldest (4 input cycles back). For a register
+// of [input, d1, d2, d3, d4], the polynomials evaluate to:
+//
+//	g1 = input ^ d1 ^ d2 ^ d3 ^ d4
+//	g2 = input ^ d1 ^ d3 ^ d4
+//	g3 = input ^ d2 ^ d4
+//
+// Caller flushes the encoder with K-1 = 4 tail bits (zeros) at the
+// end of each block so the Viterbi decoder can pick the surviving
+// path ending in state 0.
+//
+// Puncturing patterns and periods for the rates TETRA uses are
+// supplied as exported tables; callers pick the matching
+// (period, puncture) pair for their channel type.
+
+// EncodeRCPCTetraMother encodes len(input) information bits into
+// 3 * len(input) channel bits via the TETRA K=5 1/3-rate mother
+// code. Caller is responsible for appending the K-1 = 4 tail bits
+// (zeros) to the input before calling so the encoder flushes back
+// to state 0.
+func EncodeRCPCTetraMother(input []byte) []byte {
+	out := make([]byte, 3*len(input))
+	var d1, d2, d3, d4 byte
+	for i, in := range input {
+		bit := in & 1
+		out[3*i] = bit ^ d1 ^ d2 ^ d3 ^ d4
+		out[3*i+1] = bit ^ d1 ^ d3 ^ d4
+		out[3*i+2] = bit ^ d2 ^ d4
+		d4 = d3
+		d3 = d2
+		d2 = d1
+		d1 = bit
+	}
+	return out
+}
+
+// DecodeRCPCTetraMother runs hard-decision 16-state Viterbi over
+// the K=5 1/3-rate mother code. channel holds 3*stages bits arranged
+// as (g1, g2, g3) triples per encoder stage; output is the recovered
+// stages-bit input sequence plus the path metric of the surviving
+// path (0 = clean channel, positive = corrected bit errors).
+//
+// Bits at depunctured positions should be set to DepunctureMark so
+// the cost accumulator skips them — matches the same convention the
+// K=5 1/2-rate primitive in viterbi_k5.go uses.
+//
+// The Viterbi survivor is forced to the state-0 terminal constraint
+// because TETRA appends K-1 = 4 zero tail bits at every encoder
+// flush.
+func DecodeRCPCTetraMother(channel []byte, stages int) ([]byte, int) {
+	const numStates = 16
+	const inf = 1 << 30
+	pm := make([]int, numStates)
+	for i := range pm {
+		pm[i] = inf
+	}
+	pm[0] = 0
+	trace := make([][numStates]uint8, stages)
+
+	for s := 0; s < stages; s++ {
+		var npm [numStates]int
+		for i := range npm {
+			npm[i] = inf
+		}
+		rxG1 := channel[3*s]
+		rxG2 := channel[3*s+1]
+		rxG3 := channel[3*s+2]
+		for cur := 0; cur < numStates; cur++ {
+			if pm[cur] >= inf {
+				continue
+			}
+			d1 := (cur >> 3) & 1
+			d2 := (cur >> 2) & 1
+			d3 := (cur >> 1) & 1
+			d4 := cur & 1
+			for input := 0; input < 2; input++ {
+				g1 := byte(input^d1^d2^d3^d4) & 1
+				g2 := byte(input^d1^d3^d4) & 1
+				g3 := byte(input^d2^d4) & 1
+				cost := pm[cur]
+				if rxG1 != DepunctureMark && g1 != rxG1 {
+					cost++
+				}
+				if rxG2 != DepunctureMark && g2 != rxG2 {
+					cost++
+				}
+				if rxG3 != DepunctureMark && g3 != rxG3 {
+					cost++
+				}
+				next := (input << 3) | (d1 << 2) | (d2 << 1) | d3
+				if cost < npm[next] {
+					npm[next] = cost
+					trace[s][next] = uint8((cur << 1) | input)
+				}
+			}
+		}
+		copy(pm, npm[:])
+	}
+
+	// Encoder is flushed back to state 0 by the tail bits — pick
+	// state 0 unconditionally so the survivor honours the
+	// terminal-state constraint.
+	final := 0
+	metric := pm[final]
+
+	out := make([]byte, stages)
+	state := final
+	for s := stages - 1; s >= 0; s-- {
+		entry := trace[s][state]
+		out[s] = entry & 1
+		state = int(entry >> 1)
+	}
+	return out, metric
+}
+
+// PunctureRCPCTetra selects k3 bits from the mother-code output per
+// the TETRA puncturing scheme. puncture[i] holds the 1-indexed
+// position within each period window to keep — values in 1..period.
+// puncture and period are passed verbatim from the spec (§5.5.2 /
+// §5.6.2). The implementation follows the §5.4.3.2 formula:
+//
+//	k = period * ((j-1) div t) + puncture[((j-1) mod t)]   1-indexed
+//	C_3(j) = V(k)                                          j = 1..k3
+//
+// where t = len(puncture).
+func PunctureRCPCTetra(mother []byte, period int, puncture []int, k3 int) []byte {
+	t := len(puncture)
+	out := make([]byte, k3)
+	for j := 1; j <= k3; j++ {
+		blockIdx := (j - 1) / t
+		offset := j - t*blockIdx // 1..t
+		k := period*blockIdx + puncture[offset-1]
+		out[j-1] = mother[k-1]
+	}
+	return out
+}
+
+// DepunctureRCPCTetra is the inverse of PunctureRCPCTetra: it
+// allocates a motherLen-sized buffer, fills it with DepunctureMark,
+// and copies received bits at the puncture-map positions. Pass the
+// result straight to DecodeRCPCTetraMother.
+func DepunctureRCPCTetra(punctured []byte, period int, puncture []int, motherLen int) []byte {
+	t := len(puncture)
+	out := make([]byte, motherLen)
+	for i := range out {
+		out[i] = DepunctureMark
+	}
+	for j := 1; j <= len(punctured); j++ {
+		blockIdx := (j - 1) / t
+		offset := j - t*blockIdx
+		k := period*blockIdx + puncture[offset-1]
+		if k-1 < motherLen {
+			out[k-1] = punctured[j-1]
+		}
+	}
+	return out
+}
+
+// TETRA RCPC puncturing schemes per ETSI EN 300 395-2.
+//
+// RCPCTetraPuncture23 is the rate-8/12 (= 2/3) scheme for class-1
+// bits in the normal speech traffic channel (§5.5.2.1).
+//
+// RCPCTetraPuncture818 is the rate-8/18 scheme for class-2 bits in
+// the normal speech traffic channel (§5.5.2.2).
+//
+// RCPCTetraPuncture817 is the rate-8/17 scheme for class-2 bits
+// under frame-stealing mode (§5.6.2.1).
+//
+// Each pattern is 1-indexed exactly as the spec lists it; pair each
+// with the matching Period* constant when calling
+// PunctureRCPCTetra / DepunctureRCPCTetra.
+var (
+	RCPCTetraPuncture23  = []int{1, 2, 4}
+	RCPCTetraPuncture818 = []int{1, 2, 3, 4, 5, 7, 8, 10, 11}
+	RCPCTetraPuncture817 = []int{1, 2, 3, 4, 5, 7, 8, 10, 11, 13, 14, 16, 17, 19, 20, 22, 23}
+)
+
+const (
+	RCPCTetraPeriod23  = 6
+	RCPCTetraPeriod818 = 12
+	RCPCTetraPeriod817 = 24
+)

--- a/internal/radio/framing/rcpc_tetra_test.go
+++ b/internal/radio/framing/rcpc_tetra_test.go
@@ -1,0 +1,206 @@
+package framing
+
+import "testing"
+
+// TestRCPCTetraMotherRoundTripCleanChannel: encode a random-ish
+// information bit sequence + 4 tail zeros, decode the mother-code
+// output, recover the original bits exactly with metric 0.
+func TestRCPCTetraMotherRoundTripCleanChannel(t *testing.T) {
+	info := []byte{
+		1, 0, 1, 1, 0, 1, 0, 0, 1, 1, 1, 0, 0, 0, 1, 1,
+		1, 1, 0, 0, 1, 0, 1, 1, 0, 1, 0, 1, 0, 0, 1, 1,
+	}
+	stages := len(info) + 4 // K-1 = 4 tail bits
+	in := make([]byte, stages)
+	copy(in, info)
+	channel := EncodeRCPCTetraMother(in)
+	if len(channel) != 3*stages {
+		t.Fatalf("encoded length = %d, want %d", len(channel), 3*stages)
+	}
+	out, metric := DecodeRCPCTetraMother(channel, stages)
+	if metric != 0 {
+		t.Errorf("clean-channel metric = %d, want 0", metric)
+	}
+	for i, want := range in {
+		if out[i] != want {
+			t.Errorf("bit %d: got %d, want %d", i, out[i], want)
+		}
+	}
+}
+
+// TestRCPCTetraMotherCorrectsSingleBitError: flip a single channel
+// bit in a clean encoding; the Viterbi survivor must still recover
+// the original info exactly. K=5 1/3-rate has free distance 12 so
+// it corrects many single-bit errors easily.
+func TestRCPCTetraMotherCorrectsSingleBitError(t *testing.T) {
+	info := []byte{1, 0, 1, 1, 0, 0, 1, 0, 1, 1, 0, 1, 1, 0, 0, 1}
+	stages := len(info) + 4
+	in := make([]byte, stages)
+	copy(in, info)
+	channel := EncodeRCPCTetraMother(in)
+	channel[11] ^= 1 // flip one channel bit
+	out, metric := DecodeRCPCTetraMother(channel, stages)
+	if metric == 0 {
+		t.Error("expected non-zero metric on a corrupted channel")
+	}
+	for i, want := range in {
+		if out[i] != want {
+			t.Errorf("bit %d: got %d, want %d", i, out[i], want)
+		}
+	}
+}
+
+// TestRCPCTetraEncoderInitialStateZero: with all-zero state and a
+// single 1 followed by zeros, the first triple is (1, 1, 1) — the
+// impulse response of the three generators at lag 0.
+func TestRCPCTetraEncoderInitialStateZero(t *testing.T) {
+	in := []byte{1, 0, 0, 0, 0, 0, 0, 0, 0}
+	out := EncodeRCPCTetraMother(in)
+	if out[0] != 1 || out[1] != 1 || out[2] != 1 {
+		t.Errorf("first triple = (%d, %d, %d), want (1, 1, 1)", out[0], out[1], out[2])
+	}
+}
+
+// TestRCPCTetraEncoderMatchesGeneratorPolys: the second triple (lag
+// 1, i.e. input = 0, d1 = 1, others zero) must equal the polynomial
+// pattern at index 1:
+//   g1 = 0 ^ 1 ^ 0 ^ 0 ^ 0 = 1
+//   g2 = 0 ^ 1 ^ 0 ^ 0 = 1
+//   g3 = 0 ^ 0 ^ 0 = 0
+func TestRCPCTetraEncoderMatchesGeneratorPolys(t *testing.T) {
+	in := []byte{1, 0, 0, 0, 0, 0, 0, 0, 0}
+	out := EncodeRCPCTetraMother(in)
+	if out[3] != 1 || out[4] != 1 || out[5] != 0 {
+		t.Errorf("second triple = (%d, %d, %d), want (1, 1, 0)", out[3], out[4], out[5])
+	}
+}
+
+// TestRCPCTetraPunctureRate23RoundTrip: rate-8/12 (= 2/3)
+// puncturing scheme used for class-1 bits in the normal speech
+// channel. Encode 8 info bits + 4 tail bits, mother-code produces
+// 36 bits; puncture to 12 bits (since 8 input bits at rate 2/3
+// give 12 output bits, here we test 12 mother bits → 8 punctured
+// bits scaled by the 2 input bits per period). Round-trip back
+// through depuncture + Viterbi must recover the original info.
+func TestRCPCTetraPunctureRate23RoundTrip(t *testing.T) {
+	// 8 information bits + 4 tail bits = 12 stages.
+	info := []byte{1, 0, 1, 1, 0, 1, 0, 0}
+	stages := len(info) + 4
+	in := make([]byte, stages)
+	copy(in, info)
+	mother := EncodeRCPCTetraMother(in)
+	if len(mother) != 36 {
+		t.Fatalf("mother length = %d, want 36", len(mother))
+	}
+	// Rate 2/3: 12 input → 18 output. (We round to whole periods.)
+	// k3 must be a multiple of t=3 for clean tiling, and the
+	// punctured length must not exceed the mother length scaled by
+	// the rate. For 12 stages and rate 2/3 we get 18 output bits.
+	const k3 = 18
+	punctured := PunctureRCPCTetra(mother, RCPCTetraPeriod23, RCPCTetraPuncture23, k3)
+	if len(punctured) != k3 {
+		t.Fatalf("punctured length = %d, want %d", len(punctured), k3)
+	}
+	depunctured := DepunctureRCPCTetra(punctured, RCPCTetraPeriod23, RCPCTetraPuncture23, len(mother))
+	out, _ := DecodeRCPCTetraMother(depunctured, stages)
+	for i, want := range in {
+		if out[i] != want {
+			t.Errorf("bit %d: got %d, want %d (rate 2/3 round-trip)", i, out[i], want)
+		}
+	}
+}
+
+// TestRCPCTetraPunctureRate818RoundTrip: rate-8/18 scheme for
+// class-2 bits in normal speech. 8 input bits → 24 mother bits →
+// 18 punctured bits.
+func TestRCPCTetraPunctureRate818RoundTrip(t *testing.T) {
+	info := []byte{1, 0, 1, 0, 1, 1, 0, 1}
+	stages := len(info) + 4
+	in := make([]byte, stages)
+	copy(in, info)
+	mother := EncodeRCPCTetraMother(in)
+	if len(mother) != 36 {
+		t.Fatalf("mother length = %d, want 36", len(mother))
+	}
+	const k3 = 27 // 12 stages * 9/(12/3) hmm; just take a multiple of t=9 that fits
+	punctured := PunctureRCPCTetra(mother, RCPCTetraPeriod818, RCPCTetraPuncture818, k3)
+	depunctured := DepunctureRCPCTetra(punctured, RCPCTetraPeriod818, RCPCTetraPuncture818, len(mother))
+	out, _ := DecodeRCPCTetraMother(depunctured, stages)
+	for i, want := range in {
+		if out[i] != want {
+			t.Errorf("bit %d: got %d, want %d (rate 8/18 round-trip)", i, out[i], want)
+		}
+	}
+}
+
+// TestRCPCTetraPunctureRate817RoundTrip: rate-8/17 scheme used in
+// frame-stealing mode.
+func TestRCPCTetraPunctureRate817RoundTrip(t *testing.T) {
+	info := []byte{1, 1, 0, 0, 1, 0, 1, 1, 0, 1, 0, 1}
+	stages := len(info) + 4
+	in := make([]byte, stages)
+	copy(in, info)
+	mother := EncodeRCPCTetraMother(in)
+	// Use k3 = 34 (2 full periods of 17 each, well within the
+	// 48-bit mother for 16-stage input).
+	const k3 = 34
+	punctured := PunctureRCPCTetra(mother, RCPCTetraPeriod817, RCPCTetraPuncture817, k3)
+	depunctured := DepunctureRCPCTetra(punctured, RCPCTetraPeriod817, RCPCTetraPuncture817, len(mother))
+	out, _ := DecodeRCPCTetraMother(depunctured, stages)
+	for i, want := range in {
+		if out[i] != want {
+			t.Errorf("bit %d: got %d, want %d (rate 8/17 round-trip)", i, out[i], want)
+		}
+	}
+}
+
+// TestRCPCTetraPunctureCorrectsSingleErrorOnRate23: with the
+// rate-2/3 puncture in place, flipping one received bit still
+// recovers the original info (K=5 1/3-rate has plenty of free
+// distance to correct single errors).
+func TestRCPCTetraPunctureCorrectsSingleErrorOnRate23(t *testing.T) {
+	info := []byte{1, 0, 1, 1, 0, 1, 0, 0}
+	stages := len(info) + 4
+	in := make([]byte, stages)
+	copy(in, info)
+	mother := EncodeRCPCTetraMother(in)
+	const k3 = 18
+	punctured := PunctureRCPCTetra(mother, RCPCTetraPeriod23, RCPCTetraPuncture23, k3)
+	// Flip one bit in the punctured stream.
+	punctured[5] ^= 1
+	depunctured := DepunctureRCPCTetra(punctured, RCPCTetraPeriod23, RCPCTetraPuncture23, len(mother))
+	out, metric := DecodeRCPCTetraMother(depunctured, stages)
+	if metric == 0 {
+		t.Error("expected non-zero metric on a corrupted punctured channel")
+	}
+	for i, want := range in {
+		if out[i] != want {
+			t.Errorf("bit %d: got %d, want %d (rate 2/3 + 1 error)", i, out[i], want)
+		}
+	}
+}
+
+// TestRCPCTetraPunctureScheduleSanity: the puncture maps must list
+// strictly-increasing 1-indexed positions all <= period.
+func TestRCPCTetraPunctureScheduleSanity(t *testing.T) {
+	cases := []struct {
+		name    string
+		pattern []int
+		period  int
+	}{
+		{"rate 2/3", RCPCTetraPuncture23, RCPCTetraPeriod23},
+		{"rate 8/18", RCPCTetraPuncture818, RCPCTetraPeriod818},
+		{"rate 8/17", RCPCTetraPuncture817, RCPCTetraPeriod817},
+	}
+	for _, tc := range cases {
+		for i, p := range tc.pattern {
+			if p < 1 || p > tc.period {
+				t.Errorf("%s: pattern[%d] = %d is outside 1..%d", tc.name, i, p, tc.period)
+			}
+			if i > 0 && p <= tc.pattern[i-1] {
+				t.Errorf("%s: pattern[%d] = %d is not strictly greater than pattern[%d] = %d",
+					tc.name, i, p, i-1, tc.pattern[i-1])
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds the TETRA channel-coding RCPC primitive in a new `internal/radio/framing/rcpc_tetra.go` per **ETSI EN 300 395-2 §5.4.3** (the spec you supplied).

**Mother code:** 16-state, K=5, R=1/3 convolutional with generator polynomials

| Generator | Polynomial | Hex |
| --- | --- | --- |
| G₁(D) | 1 + D + D² + D³ + D⁴ | 0x1F |
| G₂(D) | 1 + D + D³ + D⁴ | 0x1B |
| G₃(D) | 1 + D² + D⁴ | 0x15 |

Different polynomials and rate from the K=5 R=1/2 code in `viterbi_k5.go` (NXDN SACCH / YSF FICH), so this is a new primitive — same 16-state structure but three outputs per input. `DecodeRCPCTetraMother` is a hard-decision 16-state Viterbi that picks the survivor ending in state 0 (per the K−1 = 4 zero tail bits the encoder appends to flush). The `DepunctureMark` sentinel matches `viterbi_k5.go`'s so callers can mix the two via a single decoder pattern.

**Puncturing tables** shipped verbatim from the spec:

| Constant | Rate | P (1-indexed) | Period | Spec |
| --- | --- | --- | --- | --- |
| `RCPCTetraPuncture23` | 2/3 (class 1, normal) | (1, 2, 4) | 6 | §5.5.2.1 |
| `RCPCTetraPuncture818` | 8/18 (class 2, normal) | (1, 2, 3, 4, 5, 7, 8, 10, 11) | 12 | §5.5.2.2 |
| `RCPCTetraPuncture817` | 8/17 (class 2, stealing) | 17-element | 24 | §5.6.2.1 |

Puncturing formula follows §5.4.3.2 exactly: `k = period * ((j-1) div t) + P[((j-1) mod t)]`.

## Test plan

- [x] `go test ./internal/radio/framing/ -run RCPCTetra` — nine new tests:
  - Mother-code round-trip on a clean channel (metric 0, exact info recovery)
  - Mother-code single-bit error correction
  - Encoder impulse-response sanity: first triple `(1, 1, 1)`, second triple `(1, 1, 0)` — matches the three generator polynomial taps
  - Rate-2/3 puncture + depuncture + decode round-trip
  - Rate-8/18 puncture + depuncture + decode round-trip
  - Rate-8/17 puncture + depuncture + decode round-trip
  - Rate-2/3 + single-bit error in the punctured channel still recovers info
  - Puncturing schedules are strictly-increasing 1-indexed positions bounded by Period
- [x] `go test ./...` (full suite)
- [x] `go vet ./...`

## Follow-up

Wiring this primitive into the TETRA `ControlChannel.Process` adapter (slicing 432-bit type-3 blocks per §5.5, running depuncture + Viterbi + CRC verify per the sensitivity-class structure of §5.4.1) is the documented follow-up — same pattern as the EDACS / MPT 1327 wirings (PRs #129, #133). The RM(1,5) primitive for the TETRA broadcast block header is still pending — that's outside §5.4.3 and will need EN 300 392-2 (or equivalent) for the generator matrix.

## Reference

ETSI EN 300 395-2 V1.3.0 §5.4.3 — *TETRA Speech codec for full-rate traffic channel; Part 2: TETRA codec*.

https://claude.ai/code/session_019dtCCVEZJTKKr6YK3wy824

---
_Generated by [Claude Code](https://claude.ai/code/session_019dtCCVEZJTKKr6YK3wy824)_