### PR TITLE
internal/radio/framing: TETRA signaling-channel RCPC + (30,14) RM primitives per EN 300 392-2 §8.2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,13 +102,18 @@ The remaining gaps:
   correction; under BCHOn the effective CCW carries 28 info
   bits (Command + Status + Address + 4 high bits of LCN), the
   legacy struct's LCN bit 0 and Aux become BCH parity rather
-  than data. **TETRA** has a `framing.EncodeRCPCTetraMother`
-  / `DecodeRCPCTetraMother` primitive in
-  `internal/radio/framing/rcpc_tetra.go` plus puncturing
-  tables for the rate-2/3, 8/18, and 8/17 schemes per ETSI
-  EN 300 395-2 §5.4.3; wiring it into the TETRA adapter is
-  the documented follow-up. RM(1,5) for the broadcast block
-  header is still pending.
+  than data. **TETRA** has both channel-coding families
+  shipped as primitives: the K=5 R=1/3 speech-traffic-channel
+  code in `framing/rcpc_tetra.go` (EN 300 395-2 §5.4.3) and
+  the K=5 R=1/4 signaling-channel code in
+  `framing/rcpc_tetra_sig.go` (EN 300 392-2 §8.2.3.1) covering
+  rates 2/3, 1/3, 292/432 and 148/432, plus the shortened
+  (30,14) Reed-Muller code in `framing/rm_30_14_tetra.go`
+  (§8.2.3.2) for AACH. Wiring all three into the TETRA
+  `ControlChannel.Process` adapter — slicing per the channel
+  type (AACH, SCH/HD, BNCH, STCH, SCH/F, BSCH), running
+  depuncture + Viterbi + CRC-16 (CCITT) verify + tail strip
+  per §8.3.1 — is the documented follow-up.
 - **Symbol-time clock recovery on complex IQ.** The Gardner
   timing-recovery primitive in `internal/dsp/sync/gardner.go`
   is now threaded into both the **P25 Phase 2** and **TETRA**
@@ -186,6 +191,33 @@ to its own package and lands independently.
 
 ### Recently shipped
 
+- **TETRA signaling-channel RCPC + (30,14) RM primitives in
+  framing/.** Adds the K=5 R=1/4 16-state convolutional mother
+  code and the four puncturing schemes TETRA uses on every
+  π/4-DQPSK signaling channel (BSCH, SCH/HD, BNCH, STCH,
+  SCH/HU, SCH/F), plus the shortened (30,14) Reed-Muller block
+  code used by AACH. Per ETSI EN 300 392-2 §8.2.3.1 / .2 —
+  distinct from the K=5 R=1/3 speech-traffic-channel code in
+  PR #135 (EN 300 395-2 §5.4.3): same 16-state structure but
+  four generator polynomials and a different puncturing
+  table family. Generator polynomials: `G₁(D) = 1+D+D⁴`,
+  `G₂(D) = 1+D²+D³+D⁴`, `G₃(D) = 1+D+D²+D⁴`, `G₄(D) =
+  1+D+D³+D⁴`. Puncturing schemes shipped: rate-2/3 (P=(1,2,5),
+  used by all standard signaling channels), rate-1/3
+  (stronger protection, P=(1,2,3,5,6,7)), plus rate-292/432
+  and rate-148/432 (special long-block patterns with index-
+  shift helpers). The (30,14) RM code uses the spec's
+  14×16 parity matrix from §8.2.3.2 and is systematic in
+  the first 14 bits. Tests cover round-trip on clean
+  channels for both rates 2/3 and 1/3, single-bit error
+  correction at the mother-code and punctured layers,
+  encoder impulse-response sanity against the four
+  generator polynomials, all 30 single-bit error positions
+  on the RM code, parity-matrix-row consistency, and
+  index-shift monotonicity for the special rates. The
+  TETRA `ControlChannel` adapter wiring (depuncture +
+  Viterbi + CRC-16 strip → ParsePDU per channel type) is
+  the follow-up PR.
 - **MPT 1327 Op field extension.** Adds the spec's 10-bit Op
   field (between Ident and Function) to `mpt1327.Codeword`,
   closing the documented follow-up from PR #129. New 48-bit

--- a/internal/radio/framing/rcpc_tetra_sig.go
+++ b/internal/radio/framing/rcpc_tetra_sig.go
@@ -1,0 +1,218 @@
+package framing
+
+// TETRA signaling-channel RCPC primitive per ETSI EN 300 392-2 §8.2.3.1.
+//
+// This is the K=5 R=1/4 16-state convolutional mother code used by
+// every TETRA π/4-DQPSK signaling channel (BSCH, SCH/HD, BNCH,
+// STCH, SCH/HU, SCH/F) — distinct from the K=5 R=1/3 speech-traffic-
+// channel code in `rcpc_tetra.go` (which is from EN 300 395-2 §5.4.3).
+// Same 16-state structure, but with four generator polynomials and a
+// different puncturing table family.
+//
+// Mother code generator polynomials:
+//
+//	G_1(D) = 1 + D + D^4              (0x13)
+//	G_2(D) = 1 + D^2 + D^3 + D^4      (0x1D)
+//	G_3(D) = 1 + D + D^2 + D^4        (0x17)
+//	G_4(D) = 1 + D + D^3 + D^4        (0x1B)
+//
+// Encoder convention: state bits stored as (d1<<3)|(d2<<2)|(d3<<1)|d4
+// where d1 is the most-recent bit shifted in before the current
+// input, d4 is the oldest. For a register of [input, d1, d2, d3, d4]
+// the polynomials evaluate to:
+//
+//	g1 = input ^ d1 ^ d4
+//	g2 = input ^ d2 ^ d3 ^ d4
+//	g3 = input ^ d1 ^ d2 ^ d4
+//	g4 = input ^ d1 ^ d3 ^ d4
+//
+// Callers flush the encoder with K-1 = 4 zero tail bits at the end
+// of each block so the Viterbi decoder can pick the surviving path
+// ending in state 0.
+
+// EncodeRCPCTetraSigMother encodes len(input) information bits into
+// 4 * len(input) channel bits via the TETRA K=5 1/4-rate signaling-
+// channel mother code. Caller is responsible for appending the K-1
+// = 4 tail bits (zeros) to the input before calling.
+func EncodeRCPCTetraSigMother(input []byte) []byte {
+	out := make([]byte, 4*len(input))
+	var d1, d2, d3, d4 byte
+	for i, in := range input {
+		bit := in & 1
+		out[4*i] = bit ^ d1 ^ d4
+		out[4*i+1] = bit ^ d2 ^ d3 ^ d4
+		out[4*i+2] = bit ^ d1 ^ d2 ^ d4
+		out[4*i+3] = bit ^ d1 ^ d3 ^ d4
+		d4 = d3
+		d3 = d2
+		d2 = d1
+		d1 = bit
+	}
+	return out
+}
+
+// DecodeRCPCTetraSigMother runs hard-decision 16-state Viterbi over
+// the K=5 1/4-rate mother code. channel holds 4*stages bits arranged
+// as (g1, g2, g3, g4) tuples per encoder stage; output is the
+// recovered stages-bit input sequence plus the path metric of the
+// surviving path (0 = clean channel).
+//
+// Bits at depunctured positions should be set to DepunctureMark so
+// the cost accumulator skips them — same convention as the other
+// K=5 primitives in this package.
+//
+// The Viterbi survivor is forced to the state-0 terminal constraint
+// (the tail bits flush the encoder there).
+func DecodeRCPCTetraSigMother(channel []byte, stages int) ([]byte, int) {
+	const numStates = 16
+	const inf = 1 << 30
+	pm := make([]int, numStates)
+	for i := range pm {
+		pm[i] = inf
+	}
+	pm[0] = 0
+	trace := make([][numStates]uint8, stages)
+
+	for s := 0; s < stages; s++ {
+		var npm [numStates]int
+		for i := range npm {
+			npm[i] = inf
+		}
+		rxG1 := channel[4*s]
+		rxG2 := channel[4*s+1]
+		rxG3 := channel[4*s+2]
+		rxG4 := channel[4*s+3]
+		for cur := 0; cur < numStates; cur++ {
+			if pm[cur] >= inf {
+				continue
+			}
+			d1 := (cur >> 3) & 1
+			d2 := (cur >> 2) & 1
+			d3 := (cur >> 1) & 1
+			d4 := cur & 1
+			for input := 0; input < 2; input++ {
+				g1 := byte(input^d1^d4) & 1
+				g2 := byte(input^d2^d3^d4) & 1
+				g3 := byte(input^d1^d2^d4) & 1
+				g4 := byte(input^d1^d3^d4) & 1
+				cost := pm[cur]
+				if rxG1 != DepunctureMark && g1 != rxG1 {
+					cost++
+				}
+				if rxG2 != DepunctureMark && g2 != rxG2 {
+					cost++
+				}
+				if rxG3 != DepunctureMark && g3 != rxG3 {
+					cost++
+				}
+				if rxG4 != DepunctureMark && g4 != rxG4 {
+					cost++
+				}
+				next := (input << 3) | (d1 << 2) | (d2 << 1) | d3
+				if cost < npm[next] {
+					npm[next] = cost
+					trace[s][next] = uint8((cur << 1) | input)
+				}
+			}
+		}
+		copy(pm, npm[:])
+	}
+
+	final := 0
+	metric := pm[final]
+	out := make([]byte, stages)
+	state := final
+	for s := stages - 1; s >= 0; s-- {
+		entry := trace[s][state]
+		out[s] = entry & 1
+		state = int(entry >> 1)
+	}
+	return out, metric
+}
+
+// PunctureRCPCTetraSig selects k3 bits from the mother-code output
+// per the TETRA signaling-channel puncturing scheme — §8.2.3.1.2
+// formula:
+//
+//	k = 8 * ((i-1) div t) + P[((i-1) mod t)]    (1-indexed)
+//	b_3(j) = V(k)                                j = 1..k3
+//
+// where i = j for the simple rates (2/3, 1/3) and i = j +
+// (j-1) div 65 / 35 for the 292/432 and 148/432 special rates.
+// Callers pass the indexShift slice that maps 1-indexed j to the
+// 1-indexed mother-code "i" — pass nil for the identity case
+// (i = j). Period is fixed at 8 for all four schemes.
+func PunctureRCPCTetraSig(mother []byte, puncture []int, k3 int, indexShift func(j int) int) []byte {
+	const period = 8
+	t := len(puncture)
+	if indexShift == nil {
+		indexShift = func(j int) int { return j }
+	}
+	out := make([]byte, k3)
+	for j := 1; j <= k3; j++ {
+		i := indexShift(j)
+		blockIdx := (i - 1) / t
+		offset := i - t*blockIdx // 1..t
+		k := period*blockIdx + puncture[offset-1]
+		out[j-1] = mother[k-1]
+	}
+	return out
+}
+
+// DepunctureRCPCTetraSig is the inverse of PunctureRCPCTetraSig:
+// allocates a motherLen-sized buffer, fills it with DepunctureMark,
+// and copies received bits at the puncture-map positions.
+func DepunctureRCPCTetraSig(punctured []byte, puncture []int, motherLen int, indexShift func(j int) int) []byte {
+	const period = 8
+	t := len(puncture)
+	if indexShift == nil {
+		indexShift = func(j int) int { return j }
+	}
+	out := make([]byte, motherLen)
+	for i := range out {
+		out[i] = DepunctureMark
+	}
+	for j := 1; j <= len(punctured); j++ {
+		i := indexShift(j)
+		blockIdx := (i - 1) / t
+		offset := i - t*blockIdx
+		k := period*blockIdx + puncture[offset-1]
+		if k-1 < motherLen {
+			out[k-1] = punctured[j-1]
+		}
+	}
+	return out
+}
+
+// TETRA signaling-channel RCPC puncturing schemes per ETSI
+// EN 300 392-2 §8.2.3.1.3 / .4 / .5 / .6. Each pattern is 1-indexed
+// exactly as the spec lists it. Period is fixed at 8.
+//
+// RCPCTetraSigPuncture23 is the rate-2/3 scheme (§8.2.3.1.3) used
+// by every standard signaling channel (BSCH, SCH/HD, BNCH, STCH,
+// SCH/HU, SCH/F).
+//
+// RCPCTetraSigPuncture13 is the rate-1/3 scheme (§8.2.3.1.4) used
+// by data channels that need stronger protection.
+//
+// RCPCTetraSigPuncture292_432 / RCPCTetraSigPuncture148_432 are
+// the special rate-292/432 and rate-148/432 schemes (§8.2.3.1.5 /
+// .6) that pair with the index-shift helpers below.
+var (
+	RCPCTetraSigPuncture23      = []int{1, 2, 5}
+	RCPCTetraSigPuncture13      = []int{1, 2, 3, 5, 6, 7}
+	RCPCTetraSigPuncture292_432 = []int{1, 2, 5}
+	RCPCTetraSigPuncture148_432 = []int{1, 2, 3, 5, 6, 7}
+)
+
+// RCPCTetraSigIndexShift292_432 implements i = j + (j-1) div 65
+// for the rate-292/432 scheme per §8.2.3.1.5.
+func RCPCTetraSigIndexShift292_432(j int) int {
+	return j + (j-1)/65
+}
+
+// RCPCTetraSigIndexShift148_432 implements i = j + (j-1) div 35
+// for the rate-148/432 scheme per §8.2.3.1.6.
+func RCPCTetraSigIndexShift148_432(j int) int {
+	return j + (j-1)/35
+}

--- a/internal/radio/framing/rcpc_tetra_sig_test.go
+++ b/internal/radio/framing/rcpc_tetra_sig_test.go
@@ -1,0 +1,175 @@
+package framing
+
+import "testing"
+
+func TestRCPCTetraSigMotherRoundTripCleanChannel(t *testing.T) {
+	info := []byte{
+		1, 0, 1, 1, 0, 1, 0, 0, 1, 1, 1, 0, 0, 0, 1, 1,
+		1, 1, 0, 0, 1, 0, 1, 1, 0, 1, 0, 1, 0, 0, 1, 1,
+	}
+	stages := len(info) + 4
+	in := make([]byte, stages)
+	copy(in, info)
+	channel := EncodeRCPCTetraSigMother(in)
+	if len(channel) != 4*stages {
+		t.Fatalf("encoded length = %d, want %d", len(channel), 4*stages)
+	}
+	out, metric := DecodeRCPCTetraSigMother(channel, stages)
+	if metric != 0 {
+		t.Errorf("clean-channel metric = %d, want 0", metric)
+	}
+	for i, want := range in {
+		if out[i] != want {
+			t.Errorf("bit %d: got %d, want %d", i, out[i], want)
+		}
+	}
+}
+
+func TestRCPCTetraSigMotherCorrectsSingleBitError(t *testing.T) {
+	info := []byte{1, 0, 1, 1, 0, 0, 1, 0, 1, 1, 0, 1, 1, 0, 0, 1}
+	stages := len(info) + 4
+	in := make([]byte, stages)
+	copy(in, info)
+	channel := EncodeRCPCTetraSigMother(in)
+	channel[15] ^= 1
+	out, metric := DecodeRCPCTetraSigMother(channel, stages)
+	if metric == 0 {
+		t.Error("expected non-zero metric on a corrupted channel")
+	}
+	for i, want := range in {
+		if out[i] != want {
+			t.Errorf("bit %d: got %d, want %d", i, out[i], want)
+		}
+	}
+}
+
+func TestRCPCTetraSigEncoderInitialStateZero(t *testing.T) {
+	in := []byte{1, 0, 0, 0, 0, 0, 0, 0, 0}
+	out := EncodeRCPCTetraSigMother(in)
+	// First tuple: input=1, all state bits 0 → g1=1, g2=1, g3=1, g4=1
+	if out[0] != 1 || out[1] != 1 || out[2] != 1 || out[3] != 1 {
+		t.Errorf("first tuple = (%d, %d, %d, %d), want (1, 1, 1, 1)", out[0], out[1], out[2], out[3])
+	}
+}
+
+func TestRCPCTetraSigEncoderMatchesGeneratorPolys(t *testing.T) {
+	// Second tuple: input=0, d1=1, others 0.
+	//   g1 = 0 ^ 1 ^ 0 = 1
+	//   g2 = 0 ^ 0 ^ 0 ^ 0 = 0
+	//   g3 = 0 ^ 1 ^ 0 ^ 0 = 1
+	//   g4 = 0 ^ 1 ^ 0 ^ 0 = 1
+	in := []byte{1, 0, 0, 0, 0, 0, 0, 0, 0}
+	out := EncodeRCPCTetraSigMother(in)
+	if out[4] != 1 || out[5] != 0 || out[6] != 1 || out[7] != 1 {
+		t.Errorf("second tuple = (%d, %d, %d, %d), want (1, 0, 1, 1)", out[4], out[5], out[6], out[7])
+	}
+}
+
+// TestRCPCTetraSigRate23RoundTrip exercises the SCH/HD / BSCH /
+// SCH/F path: 8 input bits + 4 tail → 12 stages → 48 mother bits →
+// puncture to 18 channel bits (rate 2/3).
+func TestRCPCTetraSigRate23RoundTrip(t *testing.T) {
+	info := []byte{1, 0, 1, 1, 0, 1, 0, 0}
+	stages := len(info) + 4
+	in := make([]byte, stages)
+	copy(in, info)
+	mother := EncodeRCPCTetraSigMother(in)
+	if len(mother) != 48 {
+		t.Fatalf("mother length = %d, want 48", len(mother))
+	}
+	const k3 = 18
+	punctured := PunctureRCPCTetraSig(mother, RCPCTetraSigPuncture23, k3, nil)
+	depunctured := DepunctureRCPCTetraSig(punctured, RCPCTetraSigPuncture23, len(mother), nil)
+	out, _ := DecodeRCPCTetraSigMother(depunctured, stages)
+	for i, want := range in {
+		if out[i] != want {
+			t.Errorf("bit %d: got %d, want %d (rate 2/3 round-trip)", i, out[i], want)
+		}
+	}
+}
+
+// TestRCPCTetraSigRate13RoundTrip exercises the rate-1/3 stronger-
+// protection path: 8 input bits + 4 tail → 12 stages → 48 mother
+// bits → puncture to 36 channel bits.
+func TestRCPCTetraSigRate13RoundTrip(t *testing.T) {
+	info := []byte{1, 1, 0, 0, 1, 0, 1, 1}
+	stages := len(info) + 4
+	in := make([]byte, stages)
+	copy(in, info)
+	mother := EncodeRCPCTetraSigMother(in)
+	const k3 = 36
+	punctured := PunctureRCPCTetraSig(mother, RCPCTetraSigPuncture13, k3, nil)
+	depunctured := DepunctureRCPCTetraSig(punctured, RCPCTetraSigPuncture13, len(mother), nil)
+	out, _ := DecodeRCPCTetraSigMother(depunctured, stages)
+	for i, want := range in {
+		if out[i] != want {
+			t.Errorf("bit %d: got %d, want %d (rate 1/3 round-trip)", i, out[i], want)
+		}
+	}
+}
+
+func TestRCPCTetraSigRate23CorrectsSingleError(t *testing.T) {
+	info := []byte{1, 0, 1, 1, 0, 1, 0, 0}
+	stages := len(info) + 4
+	in := make([]byte, stages)
+	copy(in, info)
+	mother := EncodeRCPCTetraSigMother(in)
+	const k3 = 18
+	punctured := PunctureRCPCTetraSig(mother, RCPCTetraSigPuncture23, k3, nil)
+	punctured[7] ^= 1
+	depunctured := DepunctureRCPCTetraSig(punctured, RCPCTetraSigPuncture23, len(mother), nil)
+	out, metric := DecodeRCPCTetraSigMother(depunctured, stages)
+	if metric == 0 {
+		t.Error("expected non-zero metric on a corrupted punctured channel")
+	}
+	for i, want := range in {
+		if out[i] != want {
+			t.Errorf("bit %d: got %d, want %d (rate 2/3 + 1 error)", i, out[i], want)
+		}
+	}
+}
+
+// TestRCPCTetraSigIndexShifts: sanity check the spec's special-rate
+// index shifts produce monotone-increasing i values within their
+// declared output ranges.
+func TestRCPCTetraSigIndexShifts(t *testing.T) {
+	// Rate 292/432: j = 1..432, i = j + (j-1) div 65
+	last := 0
+	for j := 1; j <= 432; j++ {
+		i := RCPCTetraSigIndexShift292_432(j)
+		if i <= last {
+			t.Errorf("292/432: i(%d) = %d is not strictly greater than i(%d) = %d", j, i, j-1, last)
+		}
+		last = i
+	}
+	// Rate 148/432
+	last = 0
+	for j := 1; j <= 432; j++ {
+		i := RCPCTetraSigIndexShift148_432(j)
+		if i <= last {
+			t.Errorf("148/432: i(%d) = %d is not strictly greater than i(%d) = %d", j, i, j-1, last)
+		}
+		last = i
+	}
+}
+
+func TestRCPCTetraSigPunctureScheduleSanity(t *testing.T) {
+	cases := []struct {
+		name    string
+		pattern []int
+	}{
+		{"rate 2/3", RCPCTetraSigPuncture23},
+		{"rate 1/3", RCPCTetraSigPuncture13},
+	}
+	for _, tc := range cases {
+		for i, p := range tc.pattern {
+			if p < 1 || p > 8 {
+				t.Errorf("%s: pattern[%d] = %d is outside 1..8 (Period)", tc.name, i, p)
+			}
+			if i > 0 && p <= tc.pattern[i-1] {
+				t.Errorf("%s: pattern[%d] = %d is not strictly greater than pattern[%d] = %d",
+					tc.name, i, p, i-1, tc.pattern[i-1])
+			}
+		}
+	}
+}

--- a/internal/radio/framing/rm_30_14_tetra.go
+++ b/internal/radio/framing/rm_30_14_tetra.go
@@ -1,0 +1,119 @@
+package framing
+
+// Shortened (30,14) Reed-Muller block code per ETSI EN 300 392-2
+// §8.2.3.2. Used by the TETRA AACH (Access Assignment Channel) to
+// encode 14 type-1 information bits into 30 type-2 channel bits with
+// no further convolutional coding or interleaving — AACH's
+// type-4 block equals its type-2 block.
+//
+// Generator matrix G is [I_14 | P] where I_14 is the 14×14 identity
+// (so the code is systematic — the first 14 type-2 bits equal the
+// 14 type-1 bits) and P is the 14×16 parity matrix from
+// equation (8.13):
+//
+//	row 1:  1 0 0 1 1 0 1 1 0 1 1 0 0 0 0 0
+//	row 2:  0 0 1 0 1 1 0 1 1 1 1 0 0 0 0 0
+//	row 3:  1 1 1 1 1 1 0 0 0 0 1 0 0 0 0 0
+//	row 4:  1 1 1 0 0 0 0 0 0 0 1 1 1 1 0 0
+//	row 5:  1 0 0 1 1 0 0 0 0 0 1 1 1 0 1 0
+//	row 6:  0 1 0 1 0 1 0 0 0 0 1 1 0 1 1 0
+//	row 7:  0 0 1 0 1 1 0 0 0 0 1 0 1 1 1 0
+//	row 8:  1 1 1 1 1 1 1 1 1 1 0 1 1 1 1 1
+//	row 9:  1 0 0 0 0 0 1 1 0 0 1 1 1 0 0 1
+//	row 10: 0 1 0 0 0 0 1 0 1 0 1 1 0 1 0 1
+//	row 11: 0 0 1 0 0 0 0 1 1 0 1 0 1 1 0 1
+//	row 12: 0 0 0 1 0 0 1 0 0 1 1 1 0 0 1 1
+//	row 13: 0 0 0 0 1 0 0 1 0 1 1 0 1 0 1 1
+//	row 14: 0 0 0 0 0 1 0 0 1 1 1 0 0 1 1 1
+//
+// Encoding rule: b_2 = b_1 * G over GF(2).
+
+// rm3014ParityMatrix is the 14×16 parity portion P of the (30,14)
+// generator matrix. rm3014ParityMatrix[r][c] is row r, column c.
+var rm3014ParityMatrix = [14][16]byte{
+	{1, 0, 0, 1, 1, 0, 1, 1, 0, 1, 1, 0, 0, 0, 0, 0},
+	{0, 0, 1, 0, 1, 1, 0, 1, 1, 1, 1, 0, 0, 0, 0, 0},
+	{1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0},
+	{1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 0, 0},
+	{1, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 1, 1, 0, 1, 0},
+	{0, 1, 0, 1, 0, 1, 0, 0, 0, 0, 1, 1, 0, 1, 1, 0},
+	{0, 0, 1, 0, 1, 1, 0, 0, 0, 0, 1, 0, 1, 1, 1, 0},
+	{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1},
+	{1, 0, 0, 0, 0, 0, 1, 1, 0, 0, 1, 1, 1, 0, 0, 1},
+	{0, 1, 0, 0, 0, 0, 1, 0, 1, 0, 1, 1, 0, 1, 0, 1},
+	{0, 0, 1, 0, 0, 0, 0, 1, 1, 0, 1, 0, 1, 1, 0, 1},
+	{0, 0, 0, 1, 0, 0, 1, 0, 0, 1, 1, 1, 0, 0, 1, 1},
+	{0, 0, 0, 0, 1, 0, 0, 1, 0, 1, 1, 0, 1, 0, 1, 1},
+	{0, 0, 0, 0, 0, 1, 0, 0, 1, 1, 1, 0, 0, 1, 1, 1},
+}
+
+// EncodeRM3014Tetra encodes 14 type-1 information bits (each entry
+// 0/1, MSB-first per the spec convention) into 30 type-2 channel
+// bits via the shortened (30,14) Reed-Muller code from
+// EN 300 392-2 §8.2.3.2. The first 14 output bits equal the input
+// (systematic encoding); the trailing 16 bits are the parity sum
+// of the input vector dotted into each column of the parity matrix.
+func EncodeRM3014Tetra(info []byte) []byte {
+	if len(info) != 14 {
+		return nil
+	}
+	out := make([]byte, 30)
+	// Systematic: first 14 output bits equal the input bits.
+	for i := 0; i < 14; i++ {
+		out[i] = info[i] & 1
+	}
+	// Parity: for each of the 16 parity columns, XOR the input
+	// bits whose row has a 1 in that column.
+	for c := 0; c < 16; c++ {
+		var p byte
+		for r := 0; r < 14; r++ {
+			if info[r]&1 != 0 && rm3014ParityMatrix[r][c] != 0 {
+				p ^= 1
+			}
+		}
+		out[14+c] = p
+	}
+	return out
+}
+
+// DecodeRM3014Tetra decodes 30 received bits via minimum-Hamming-
+// distance search across all 2^14 = 16 384 valid codewords. Returns
+// (info, errs) where info is the 14-bit information vector closest
+// to the received word and errs is the Hamming distance to that
+// codeword. errs = 0 means the received word is a valid codeword.
+//
+// For a clean channel this recovers the original info exactly; for
+// noisier captures the (30,14) RM code has minimum distance ≥ 4
+// (giving guaranteed single-bit correction across the 30-bit
+// codeword) and detect-up-to-3 capability — beyond that the
+// closest-codeword decoder may mis-correct.
+func DecodeRM3014Tetra(received []byte) ([]byte, int) {
+	if len(received) != 30 {
+		return nil, -1
+	}
+	bestDist := 31
+	var bestInfo [14]byte
+	for v := 0; v < (1 << 14); v++ {
+		var info [14]byte
+		for i := 0; i < 14; i++ {
+			info[i] = byte((v >> uint(13-i)) & 1)
+		}
+		cw := EncodeRM3014Tetra(info[:])
+		dist := 0
+		for i := 0; i < 30; i++ {
+			if cw[i] != received[i]&1 {
+				dist++
+			}
+		}
+		if dist < bestDist {
+			bestDist = dist
+			bestInfo = info
+			if dist == 0 {
+				break
+			}
+		}
+	}
+	out := make([]byte, 14)
+	copy(out, bestInfo[:])
+	return out, bestDist
+}

--- a/internal/radio/framing/rm_30_14_tetra_test.go
+++ b/internal/radio/framing/rm_30_14_tetra_test.go
@@ -1,0 +1,118 @@
+package framing
+
+import (
+	"math/rand"
+	"testing"
+)
+
+func TestRM3014TetraRoundTripCleanCodeword(t *testing.T) {
+	cases := [][]byte{
+		make([]byte, 14),                                              // all zeros
+		{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1},                    // all ones
+		{1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0},                    // alternating
+		{0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1},                    // alternating opposite
+		{1, 0, 0, 1, 1, 0, 1, 1, 0, 1, 0, 0, 1, 1},                    // pattern
+	}
+	for _, info := range cases {
+		cw := EncodeRM3014Tetra(info)
+		if len(cw) != 30 {
+			t.Fatalf("EncodeRM3014Tetra produced %d bits, want 30", len(cw))
+		}
+		got, errs := DecodeRM3014Tetra(cw)
+		if errs != 0 {
+			t.Errorf("clean codeword: errs = %d, want 0 (info=%v)", errs, info)
+		}
+		for i, want := range info {
+			if got[i] != want {
+				t.Errorf("info[%d]: got %d, want %d (input=%v)", i, got[i], want, info)
+			}
+		}
+	}
+}
+
+func TestRM3014TetraEncoderIsSystematic(t *testing.T) {
+	info := []byte{1, 0, 1, 1, 0, 0, 1, 0, 1, 1, 0, 1, 1, 0}
+	cw := EncodeRM3014Tetra(info)
+	// First 14 bits of the codeword must equal the 14 info bits.
+	for i := 0; i < 14; i++ {
+		if cw[i] != info[i] {
+			t.Errorf("systematic prefix[%d] = %d, want %d", i, cw[i], info[i])
+		}
+	}
+}
+
+func TestRM3014TetraCorrectsSingleBitError(t *testing.T) {
+	info := []byte{1, 0, 1, 1, 0, 0, 1, 0, 1, 1, 0, 1, 1, 0}
+	cw := EncodeRM3014Tetra(info)
+	for pos := 0; pos < 30; pos++ {
+		corrupted := append([]byte{}, cw...)
+		corrupted[pos] ^= 1
+		got, errs := DecodeRM3014Tetra(corrupted)
+		if errs != 1 {
+			t.Errorf("pos=%d: errs=%d, want 1", pos, errs)
+			continue
+		}
+		for i, want := range info {
+			if got[i] != want {
+				t.Errorf("pos=%d info[%d]: got %d, want %d", pos, i, got[i], want)
+			}
+		}
+	}
+}
+
+func TestRM3014TetraRejectsWrongLength(t *testing.T) {
+	if cw := EncodeRM3014Tetra(make([]byte, 13)); cw != nil {
+		t.Errorf("EncodeRM3014Tetra accepted 13-bit input, want nil")
+	}
+	if cw := EncodeRM3014Tetra(make([]byte, 15)); cw != nil {
+		t.Errorf("EncodeRM3014Tetra accepted 15-bit input, want nil")
+	}
+	if info, errs := DecodeRM3014Tetra(make([]byte, 29)); info != nil || errs != -1 {
+		t.Errorf("DecodeRM3014Tetra accepted 29-bit input, got (%v, %d)", info, errs)
+	}
+}
+
+func TestRM3014TetraRandomRoundTrip(t *testing.T) {
+	r := rand.New(rand.NewSource(0xAACC))
+	for trial := 0; trial < 64; trial++ {
+		info := make([]byte, 14)
+		for i := range info {
+			info[i] = byte(r.Intn(2))
+		}
+		cw := EncodeRM3014Tetra(info)
+		got, errs := DecodeRM3014Tetra(cw)
+		if errs != 0 {
+			t.Errorf("trial %d clean decode: errs = %d, want 0", trial, errs)
+			continue
+		}
+		for i, want := range info {
+			if got[i] != want {
+				t.Errorf("trial %d info[%d]: got %d, want %d", trial, i, got[i], want)
+			}
+		}
+	}
+}
+
+// TestRM3014TetraParityMatrixSanity asserts the generator matrix
+// columns produce non-trivial parity for every input bit — protects
+// against accidental drift in the matrix transcription. With a
+// single-bit input vector, the resulting codeword should have its
+// systematic position set plus whatever parity columns the matrix
+// row populates.
+func TestRM3014TetraParityMatrixSanity(t *testing.T) {
+	for row := 0; row < 14; row++ {
+		info := make([]byte, 14)
+		info[row] = 1
+		cw := EncodeRM3014Tetra(info)
+		// Systematic position
+		if cw[row] != 1 {
+			t.Errorf("row %d: systematic bit not set", row)
+		}
+		// Parity bits must equal the parity matrix row
+		for c := 0; c < 16; c++ {
+			if cw[14+c] != rm3014ParityMatrix[row][c] {
+				t.Errorf("row %d parity column %d: got %d, want %d", row, c, cw[14+c], rm3014ParityMatrix[row][c])
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds two TETRA channel-coding primitives the existing speech-codec RCPC primitive (PR #135) didn't cover. The speech path in EN 300 395-2 §5.4.3 uses a K=5 R=1/3 code; the **signaling channels** in EN 300 392-2 §8.2.3 use a **different K=5 R=1/4** mother code with its own puncturing table family, plus a shortened **(30,14) Reed-Muller** block code for AACH.

### TETRA signaling-channel RCPC (`framing/rcpc_tetra_sig.go`)

K=5, R=1/4, 16-state mother code with four generator polynomials per §8.2.3.1.1:

| Generator | Polynomial | Hex |
| --- | --- | --- |
| G₁(D) | 1 + D + D⁴ | 0x13 |
| G₂(D) | 1 + D² + D³ + D⁴ | 0x1D |
| G₃(D) | 1 + D + D² + D⁴ | 0x17 |
| G₄(D) | 1 + D + D³ + D⁴ | 0x1B |

Four puncturing schemes shipped verbatim (Period = 8 for all):

| Constant | Rate | P (1-indexed) | Spec |
| --- | --- | --- | --- |
| `RCPCTetraSigPuncture23` | 2/3 | (1, 2, 5) | §8.2.3.1.3 |
| `RCPCTetraSigPuncture13` | 1/3 | (1, 2, 3, 5, 6, 7) | §8.2.3.1.4 |
| `RCPCTetraSigPuncture292_432` | 292/432 | (1, 2, 5) + index-shift | §8.2.3.1.5 |
| `RCPCTetraSigPuncture148_432` | 148/432 | (1, 2, 3, 5, 6, 7) + index-shift | §8.2.3.1.6 |

Rate 2/3 covers every standard signaling channel (BSCH, SCH/HD, BNCH, STCH, SCH/HU, SCH/F). Index-shift helpers `RCPCTetraSigIndexShift292_432` (`i = j + (j-1) div 65`) and `RCPCTetraSigIndexShift148_432` (`i = j + (j-1) div 35`) implement the special-rate j → mother-code i mapping.

### Shortened (30,14) Reed-Muller (`framing/rm_30_14_tetra.go`)

Encodes 14 type-1 bits into 30 type-2 bits via the spec's 14×16 parity matrix (eq. 8.13). Systematic in the first 14 output bits. Decoding is minimum-Hamming-distance search over all 2^14 codewords — fast enough at TETRA frame rates.

## Test plan

- [x] `go test ./internal/radio/framing/ -run 'RCPCTetraSig|RM3014Tetra'` — 14 new tests:
  - RCPC: mother-code clean round-trip + single-error correction + encoder impulse-response sanity vs each polynomial + rate-2/3 round-trip + rate-1/3 round-trip + rate-2/3 + 1-bit error correction + 292/432 + 148/432 index-shift monotonicity over `j ∈ [1, 432]` + schedule sanity
  - RM: round-trip across 5 info vectors + systematic-prefix check + all 30 single-bit error positions corrected + wrong-length rejection + 64 random round-trips + parity-matrix-row consistency
- [x] `go test ./...` (full suite)
- [x] `go vet ./...`

## Follow-up

Wiring all three primitives into `tetra.ControlChannel.Process` adapter — slicing per channel type (AACH 30 / BSCH 120 / SCH/HD 216 / SCH/F 432 dibits), running depuncture + Viterbi + CRC-16 (CCITT, already in `framing/crc.go`) + tail strip per §8.3.1 — is the next PR.

## Reference

ETSI EN 300 392-2 V3.8.1 §8.2.3.1 (RCPC mother code + puncturing) and §8.2.3.2 (shortened (30,14) RM code). PDF in the repo at `./en_30039202v030801p.pdf`.

https://claude.ai/code/session_019dtCCVEZJTKKr6YK3wy824

---
_Generated by [Claude Code](https://claude.ai/code/session_019dtCCVEZJTKKr6YK3wy824)_