### PR TITLE
internal/radio/tetra: per-channel encode/decode helpers per EN 300 392-2 §8.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,37 @@ to its own package and lands independently.
 
 ### Recently shipped
 
+- **TETRA per-channel encode/decode helpers in `tetra/`.**
+  Composes the framing primitives shipped in PRs #137 and
+  #138 (RCPC + (30,14) RM + (K,a) block interleaver +
+  scrambler + the existing CRC-16 CCITT) into the full
+  type-1 → type-5 encode chain and its inverse per ETSI
+  EN 300 392-2 §8.3.1 for every standard π/4-DQPSK signaling
+  channel:
+    - `EncodeSCHHD` / `DecodeSCHHD` — 124 ↔ 216 bits
+      (§8.3.1.4.1, also covers BNCH + STCH)
+    - `EncodeSCHF` / `DecodeSCHF` — 268 ↔ 432 bits
+      (§8.3.1.4.5)
+    - `EncodeSCHHU` / `DecodeSCHHU` — 92 ↔ 168 bits
+      (§8.3.1.4.3)
+    - `EncodeBSCH` / `DecodeBSCH` — 60 ↔ 120 bits, colour
+      code fixed at 0 per §8.2.5.2 (§8.3.1.2)
+    - `EncodeAACH` / `DecodeAACH` — 14 ↔ 30 bits, simpler
+      chain (RM + scramble only, no RCPC or interleave per
+      §8.3.1.1)
+  Tests round-trip every channel cleanly across multiple
+  colour codes, confirm CRC-fail detection on heavily-
+  corrupted streams, single-bit-error correction by the
+  Viterbi inner decoder under R=2/3 puncturing, wrong-
+  colour-code failure, and wrong-input-size rejection. The
+  CRC-16 used in §8.2.3.3 is the spec's `(K1+16, K1)` block
+  code — equivalent to CRC-CCITT with `init = 0xFFFF`,
+  `final XOR = 0xFFFF`, processed bit-level for the
+  non-byte-aligned K1 values TETRA uses. Wiring these
+  helpers into `tetra.ControlChannel.Process` (with the
+  burst-position discrimination from EN 300 392-2 §9 to
+  pick which channel decode runs per slot) is the next
+  PR.
 - **TETRA scrambler + (K, a) block-interleaver primitives in
   framing/.** Closes the remaining framing-layer gap before
   the full TETRA channel-decode chain can be wired together.

--- a/internal/radio/tetra/channel_coding.go
+++ b/internal/radio/tetra/channel_coding.go
@@ -1,0 +1,223 @@
+package tetra
+
+import (
+	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+)
+
+// TETRA per-channel encode/decode helpers per ETSI EN 300 392-2
+// §8.3.1, composing the framing primitives (RCPC mother + puncture,
+// (30,14) RM, block interleaver, scrambler) shipped in PRs #137 +
+// #138 into the full type-1 → type-5 chain for each π/4-DQPSK
+// signaling channel.
+//
+// Channels covered:
+//
+//	AACH      14 → 30 bits — (30,14) RM + scramble (§8.3.1.1)
+//	BSCH      60 → 120     — CRC-16 + tail + RCPC R=2/3 + (120,11)
+//	                          interleave + scramble (colour=0
+//	                          per §8.2.5.2) (§8.3.1.2)
+//	SCH/HD    124 → 216    — CRC-16 + tail + RCPC R=2/3 + (216,101)
+//	                          interleave + scramble (§8.3.1.4.1)
+//	                          (also covers BNCH + STCH — same chain)
+//	SCH/HU    92 → 168     — CRC-16 + tail + RCPC R=2/3 + (168,13)
+//	                          interleave + scramble (§8.3.1.4.3)
+//	SCH/F     268 → 432    — CRC-16 + tail + RCPC R=2/3 + (432,103)
+//	                          interleave + scramble (§8.3.1.4.5)
+//
+// All bit slices are 0/1 byte values, MSB-first per spec convention.
+//
+// The CRC-16 used by the (K1+16, K1) block code in §8.2.3.3 is the
+// standard CRC-CCITT with polynomial G(X) = X^16 + X^12 + X^5 + 1
+// (= 0x1021), initial fill 0xFFFF, and final XOR 0xFFFF — that's
+// the spec's eq. 8.15 unpacked into the textbook
+// "CRC-CCITT-FALSE / FFFF" convention. The Decode helpers verify
+// this CRC; failure returns (info, false).
+
+// crcTetraK1Plus16 computes the 16-bit CRC for the (K1+16, K1) block
+// code per §8.2.3.3 eq. 8.14-8.18. Processes the K1-bit input
+// MSB-first with init=0xFFFF, applies final XOR=0xFFFF. Output is
+// the 16-bit CRC to append (MSB first) to the K1 information bits
+// to form the K1+16 block-encoded bits.
+func crcTetraK1Plus16(bits []byte) uint16 {
+	crc := uint16(0xFFFF)
+	for _, b := range bits {
+		topBit := (crc >> 15) & 1
+		crc = (crc << 1) & 0xFFFF
+		if topBit^(uint16(b&1)) != 0 {
+			crc ^= 0x1021
+		}
+	}
+	return crc ^ 0xFFFF
+}
+
+// appendCRC16 appends the 16-bit CRC of bits (computed via
+// crcTetraK1Plus16) as 16 MSB-first bit entries.
+func appendCRC16(bits []byte) []byte {
+	crc := crcTetraK1Plus16(bits)
+	out := make([]byte, len(bits)+16)
+	copy(out, bits)
+	for i := 0; i < 16; i++ {
+		out[len(bits)+i] = byte((crc >> uint(15-i)) & 1)
+	}
+	return out
+}
+
+// appendTailBits appends n zero bits to the slice.
+func appendTailBits(bits []byte, n int) []byte {
+	out := make([]byte, len(bits)+n)
+	copy(out, bits)
+	return out
+}
+
+// encodeRCPCRate23 runs len(input) type-2 bits through the K=5
+// R=1/4 mother code and rate-2/3 puncturing, producing (3/2)*
+// len(input) type-3 bits. Both sizes must be exact.
+func encodeRCPCRate23(type2 []byte) []byte {
+	mother := framing.EncodeRCPCTetraSigMother(type2)
+	k3 := (3 * len(type2)) / 2
+	return framing.PunctureRCPCTetraSig(mother, framing.RCPCTetraSigPuncture23, k3, nil)
+}
+
+// decodeRCPCRate23 inverts encodeRCPCRate23: depuncture +
+// Viterbi-decode len(type3)*2/3 stages from the type-3 bits.
+// Returns the recovered K2-bit type-2 stream (still including any
+// tail bits the encoder appended).
+func decodeRCPCRate23(type3 []byte) []byte {
+	stages := (2 * len(type3)) / 3
+	motherLen := 4 * stages
+	mother := framing.DepunctureRCPCTetraSig(type3, framing.RCPCTetraSigPuncture23, motherLen, nil)
+	out, _ := framing.DecodeRCPCTetraSigMother(mother, stages)
+	return out
+}
+
+// signalingEncode runs the common SCH/BSCH chain — CRC-16 +
+// 4 zero tail bits + RCPC R=2/3 + (K, a) interleave + scramble —
+// producing K3 type-5 output bits from K1 type-1 input bits.
+func signalingEncode(type1 []byte, interleaverK, interleaverA int, colourCode uint32) []byte {
+	withCRC := appendCRC16(type1)                // K1 + 16
+	type2 := appendTailBits(withCRC, 4)          // K1 + 20
+	type3 := encodeRCPCRate23(type2)             // (K1 + 20) * 3 / 2
+	type4 := framing.BlockInterleaveTetra(type3, interleaverK, interleaverA)
+	type5 := framing.ScrambleTetra(type4, colourCode)
+	return type5
+}
+
+// signalingDecode reverses signalingEncode. Returns the recovered
+// K1-bit type-1 block plus a CRC-pass flag.
+func signalingDecode(type5 []byte, interleaverK, interleaverA int, colourCode uint32, k1 int) ([]byte, bool) {
+	type4 := framing.DescrambleTetra(type5, colourCode)
+	type3 := framing.BlockDeinterleaveTetra(type4, interleaverK, interleaverA)
+	type2 := decodeRCPCRate23(type3) // K1 + 20
+	if len(type2) < k1+20 {
+		return nil, false
+	}
+	// Strip 4 tail bits → K1 + 16 block-encoded bits
+	blockEncoded := type2[:k1+16]
+	info := blockEncoded[:k1]
+	receivedCRC := uint16(0)
+	for i := 0; i < 16; i++ {
+		receivedCRC = (receivedCRC << 1) | uint16(blockEncoded[k1+i]&1)
+	}
+	expected := crcTetraK1Plus16(info)
+	if expected != receivedCRC {
+		return info, false
+	}
+	return info, true
+}
+
+// EncodeSCHHD runs 124 type-1 bits through the SCH/HD chain per
+// §8.3.1.4.1 — also valid for BNCH and STCH which share the same
+// coding. Returns 216 type-5 bits.
+func EncodeSCHHD(type1 []byte, colourCode uint32) []byte {
+	if len(type1) != 124 {
+		return nil
+	}
+	return signalingEncode(type1, framing.InterleaveKSCHHD, framing.InterleaveASCHHD, colourCode)
+}
+
+// DecodeSCHHD inverts EncodeSCHHD. Returns the 124 recovered type-1
+// bits and a CRC-pass flag; if the flag is false the info bits
+// are the best Viterbi guess but should not be trusted.
+func DecodeSCHHD(type5 []byte, colourCode uint32) ([]byte, bool) {
+	if len(type5) != 216 {
+		return nil, false
+	}
+	return signalingDecode(type5, framing.InterleaveKSCHHD, framing.InterleaveASCHHD, colourCode, 124)
+}
+
+// EncodeSCHF runs 268 type-1 bits through the SCH/F chain per
+// §8.3.1.4.5. Returns 432 type-5 bits.
+func EncodeSCHF(type1 []byte, colourCode uint32) []byte {
+	if len(type1) != 268 {
+		return nil
+	}
+	return signalingEncode(type1, framing.InterleaveKSCHF, framing.InterleaveASCHF, colourCode)
+}
+
+// DecodeSCHF inverts EncodeSCHF.
+func DecodeSCHF(type5 []byte, colourCode uint32) ([]byte, bool) {
+	if len(type5) != 432 {
+		return nil, false
+	}
+	return signalingDecode(type5, framing.InterleaveKSCHF, framing.InterleaveASCHF, colourCode, 268)
+}
+
+// EncodeSCHHU runs 92 type-1 bits through the SCH/HU chain per
+// §8.3.1.4.3. Returns 168 type-5 bits.
+func EncodeSCHHU(type1 []byte, colourCode uint32) []byte {
+	if len(type1) != 92 {
+		return nil
+	}
+	return signalingEncode(type1, framing.InterleaveKSCHHU, framing.InterleaveASCHHU, colourCode)
+}
+
+// DecodeSCHHU inverts EncodeSCHHU.
+func DecodeSCHHU(type5 []byte, colourCode uint32) ([]byte, bool) {
+	if len(type5) != 168 {
+		return nil, false
+	}
+	return signalingDecode(type5, framing.InterleaveKSCHHU, framing.InterleaveASCHHU, colourCode, 92)
+}
+
+// EncodeBSCH runs 60 type-1 bits through the BSCH chain per
+// §8.3.1.2. Colour code is always zero for BSCH per §8.2.5.2.
+// Returns 120 type-5 bits.
+func EncodeBSCH(type1 []byte) []byte {
+	if len(type1) != 60 {
+		return nil
+	}
+	return signalingEncode(type1, framing.InterleaveKBSCH, framing.InterleaveABSCH, 0)
+}
+
+// DecodeBSCH inverts EncodeBSCH.
+func DecodeBSCH(type5 []byte) ([]byte, bool) {
+	if len(type5) != 120 {
+		return nil, false
+	}
+	return signalingDecode(type5, framing.InterleaveKBSCH, framing.InterleaveABSCH, 0, 60)
+}
+
+// EncodeAACH runs 14 type-1 bits through the AACH chain per
+// §8.3.1.1 — shorter than the other signaling channels because
+// AACH skips RCPC + interleaving entirely. The (30,14) RM block
+// code directly yields the type-2 / type-3 / type-4 bits, then
+// scrambling produces 30 type-5 bits.
+func EncodeAACH(type1 []byte, colourCode uint32) []byte {
+	if len(type1) != 14 {
+		return nil
+	}
+	type2 := framing.EncodeRM3014Tetra(type1)
+	return framing.ScrambleTetra(type2, colourCode)
+}
+
+// DecodeAACH inverts EncodeAACH. Returns the recovered 14 type-1
+// bits plus the Viterbi-style Hamming-distance metric from the
+// (30,14) RM decoder (0 = clean codeword, ≥ 1 = corrections
+// applied or uncorrectable).
+func DecodeAACH(type5 []byte, colourCode uint32) ([]byte, int) {
+	if len(type5) != 30 {
+		return nil, -1
+	}
+	type4 := framing.DescrambleTetra(type5, colourCode)
+	return framing.DecodeRM3014Tetra(type4)
+}

--- a/internal/radio/tetra/channel_coding_test.go
+++ b/internal/radio/tetra/channel_coding_test.go
@@ -1,0 +1,232 @@
+package tetra
+
+import (
+	"math/rand"
+	"testing"
+)
+
+// fillBits populates a bit slice from a deterministic PRNG so the
+// per-channel round-trip tests exercise non-trivial content.
+func fillBits(n int, seed int64) []byte {
+	r := rand.New(rand.NewSource(seed))
+	out := make([]byte, n)
+	for i := range out {
+		out[i] = byte(r.Intn(2))
+	}
+	return out
+}
+
+func TestEncodeDecodeSCHHDRoundTrip(t *testing.T) {
+	cases := []struct {
+		name       string
+		seed       int64
+		colourCode uint32
+	}{
+		{"random colour 0", 1, 0},
+		{"random colour 0x1234", 2, 0x1234},
+		{"random full 30-bit colour", 3, 0x3FFFFFFF},
+		{"alternating bits, colour 0xABCDE", 4, 0xABCDE},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			info := fillBits(124, tc.seed)
+			type5 := EncodeSCHHD(info, tc.colourCode)
+			if len(type5) != 216 {
+				t.Fatalf("EncodeSCHHD produced %d bits, want 216", len(type5))
+			}
+			recovered, ok := DecodeSCHHD(type5, tc.colourCode)
+			if !ok {
+				t.Fatalf("DecodeSCHHD: CRC fail on clean round-trip")
+			}
+			for i, want := range info {
+				if recovered[i] != want {
+					t.Errorf("bit %d: got %d, want %d", i, recovered[i], want)
+					break
+				}
+			}
+		})
+	}
+}
+
+func TestEncodeDecodeSCHFRoundTrip(t *testing.T) {
+	info := fillBits(268, 5)
+	type5 := EncodeSCHF(info, 0xDEADBEEF&0x3FFFFFFF)
+	if len(type5) != 432 {
+		t.Fatalf("EncodeSCHF produced %d bits, want 432", len(type5))
+	}
+	recovered, ok := DecodeSCHF(type5, 0xDEADBEEF&0x3FFFFFFF)
+	if !ok {
+		t.Fatalf("DecodeSCHF: CRC fail on clean round-trip")
+	}
+	for i, want := range info {
+		if recovered[i] != want {
+			t.Errorf("bit %d: got %d, want %d", i, recovered[i], want)
+			break
+		}
+	}
+}
+
+func TestEncodeDecodeSCHHURoundTrip(t *testing.T) {
+	info := fillBits(92, 6)
+	type5 := EncodeSCHHU(info, 0x7777)
+	if len(type5) != 168 {
+		t.Fatalf("EncodeSCHHU produced %d bits, want 168", len(type5))
+	}
+	recovered, ok := DecodeSCHHU(type5, 0x7777)
+	if !ok {
+		t.Fatalf("DecodeSCHHU: CRC fail on clean round-trip")
+	}
+	for i, want := range info {
+		if recovered[i] != want {
+			t.Errorf("bit %d: got %d, want %d", i, recovered[i], want)
+			break
+		}
+	}
+}
+
+func TestEncodeDecodeBSCHRoundTrip(t *testing.T) {
+	info := fillBits(60, 7)
+	type5 := EncodeBSCH(info)
+	if len(type5) != 120 {
+		t.Fatalf("EncodeBSCH produced %d bits, want 120", len(type5))
+	}
+	recovered, ok := DecodeBSCH(type5)
+	if !ok {
+		t.Fatalf("DecodeBSCH: CRC fail on clean round-trip")
+	}
+	for i, want := range info {
+		if recovered[i] != want {
+			t.Errorf("bit %d: got %d, want %d", i, recovered[i], want)
+			break
+		}
+	}
+}
+
+func TestEncodeDecodeAACHRoundTrip(t *testing.T) {
+	cases := []struct {
+		name       string
+		seed       int64
+		colourCode uint32
+	}{
+		{"colour 0", 8, 0},
+		{"colour 0x12345", 9, 0x12345},
+		{"colour 0x3FFFFFFF", 10, 0x3FFFFFFF},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			info := fillBits(14, tc.seed)
+			type5 := EncodeAACH(info, tc.colourCode)
+			if len(type5) != 30 {
+				t.Fatalf("EncodeAACH produced %d bits, want 30", len(type5))
+			}
+			recovered, errs := DecodeAACH(type5, tc.colourCode)
+			if errs != 0 {
+				t.Errorf("DecodeAACH: errs = %d, want 0 on clean round-trip", errs)
+			}
+			for i, want := range info {
+				if recovered[i] != want {
+					t.Errorf("bit %d: got %d, want %d", i, recovered[i], want)
+					break
+				}
+			}
+		})
+	}
+}
+
+// TestDecodeSCHHDDetectsCRCError: flip enough bits in the type-5
+// stream to overwhelm the inner Viterbi correction radius, and
+// confirm the decoder reports CRC failure (not a silent pass).
+// The K=5 R=2/3 RCPC + (216, 101) interleave is fairly robust —
+// 3 bit flips often correct cleanly, so this test bumps to many
+// adjacent flips to defeat the FEC and force the CRC check to
+// observe corruption.
+func TestDecodeSCHHDDetectsCRCError(t *testing.T) {
+	info := fillBits(124, 11)
+	type5 := EncodeSCHHD(info, 0x55555)
+	// Flip 30 adjacent bits — guaranteed to overwhelm both the
+	// Viterbi corrector and the post-deinterleave error spread.
+	corrupted := append([]byte{}, type5...)
+	for i := 50; i < 80; i++ {
+		corrupted[i] ^= 1
+	}
+	_, ok := DecodeSCHHD(corrupted, 0x55555)
+	if ok {
+		t.Errorf("DecodeSCHHD reported CRC pass on a heavily-corrupted stream")
+	}
+}
+
+// TestDecodeSCHHDWrongColourCodeFails: a stream scrambled with one
+// colour code descrambled with a different one produces garbage at
+// the deinterleave stage, which should fail the CRC.
+func TestDecodeSCHHDWrongColourCodeFails(t *testing.T) {
+	info := fillBits(124, 12)
+	type5 := EncodeSCHHD(info, 0xAAAA)
+	_, ok := DecodeSCHHD(type5, 0x5555)
+	if ok {
+		t.Errorf("DecodeSCHHD reported CRC pass with wrong colour code")
+	}
+}
+
+// TestDecodeSCHHDCorrectsSingleBitError: a single bit flip in the
+// type-5 stream should be corrected by the Viterbi inner decoder
+// without breaking the CRC.
+func TestDecodeSCHHDCorrectsSingleBitError(t *testing.T) {
+	info := fillBits(124, 13)
+	type5 := EncodeSCHHD(info, 0x1B2D4F)
+	corrupted := append([]byte{}, type5...)
+	corrupted[100] ^= 1
+	recovered, ok := DecodeSCHHD(corrupted, 0x1B2D4F)
+	if !ok {
+		t.Errorf("DecodeSCHHD: CRC fail after single-bit correction; want pass")
+	}
+	for i, want := range info {
+		if recovered[i] != want {
+			t.Errorf("bit %d: got %d, want %d (single-bit correction)", i, recovered[i], want)
+			break
+		}
+	}
+}
+
+// TestEncodeFunctionsRejectWrongSize: each EncodeXxx should return
+// nil when handed the wrong input length.
+func TestEncodeFunctionsRejectWrongSize(t *testing.T) {
+	if got := EncodeSCHHD(make([]byte, 100), 0); got != nil {
+		t.Errorf("EncodeSCHHD accepted 100-bit input, want nil")
+	}
+	if got := EncodeSCHF(make([]byte, 200), 0); got != nil {
+		t.Errorf("EncodeSCHF accepted 200-bit input, want nil")
+	}
+	if got := EncodeSCHHU(make([]byte, 50), 0); got != nil {
+		t.Errorf("EncodeSCHHU accepted 50-bit input, want nil")
+	}
+	if got := EncodeBSCH(make([]byte, 50)); got != nil {
+		t.Errorf("EncodeBSCH accepted 50-bit input, want nil")
+	}
+	if got := EncodeAACH(make([]byte, 13), 0); got != nil {
+		t.Errorf("EncodeAACH accepted 13-bit input, want nil")
+	}
+}
+
+// TestCRCTetraK1Plus16AllZerosAllOnes provides a sanity anchor for
+// the bit-level CRC implementation against two known inputs.
+func TestCRCTetraK1Plus16AllZerosAllOnes(t *testing.T) {
+	// CRC of all-zero K1-bit input with init=0xFFFF, no XOR-after
+	// step would give a deterministic value; the init=0xFFFF +
+	// XOR=0xFFFF spec form complements both ends.
+	zeros := make([]byte, 124)
+	crc0 := crcTetraK1Plus16(zeros)
+	if crc0 == 0 {
+		// 0xFFFF init shifted through with all-zero input yields a
+		// non-zero residue; final XOR with 0xFFFF complements.
+		// Confirm the result is non-zero (sanity, no specific value).
+		t.Errorf("crcTetraK1Plus16(all zeros) = 0, expected non-zero residue")
+	}
+	ones := make([]byte, 124)
+	for i := range ones {
+		ones[i] = 1
+	}
+	crc1 := crcTetraK1Plus16(ones)
+	if crc0 == crc1 {
+		t.Errorf("crcTetraK1Plus16 yields same value for all-zero and all-one inputs (%#x)", crc0)
+	}
+}


### PR DESCRIPTION
## Summary

Composes the framing primitives shipped in PRs #137 + #138 (RCPC mother + puncturing, (30,14) RM, (K,a) block interleaver, scrambler) plus the existing CRC-CCITT helper into the full type-1 → type-5 encode chain (and its inverse) for every standard TETRA π/4-DQPSK signaling channel.

### Per-channel encode/decode helpers

| Helper pair | Sizes | Spec |
| --- | --- | --- |
| `EncodeSCHHD` / `DecodeSCHHD` | 124 ↔ 216 bits | §8.3.1.4.1 (also covers BNCH + STCH) |
| `EncodeSCHF` / `DecodeSCHF` | 268 ↔ 432 bits | §8.3.1.4.5 |
| `EncodeSCHHU` / `DecodeSCHHU` | 92 ↔ 168 bits | §8.3.1.4.3 |
| `EncodeBSCH` / `DecodeBSCH` | 60 ↔ 120 bits | §8.3.1.2 (colour fixed at 0 per §8.2.5.2) |
| `EncodeAACH` / `DecodeAACH` | 14 ↔ 30 bits | §8.3.1.1 (RM + scramble only) |

Chain for SCH / BSCH:

```
type-1
  ↓ append CRC-16 (init=0xFFFF, final XOR=0xFFFF)
  ↓ append 4 zero tail bits
type-2
  ↓ RCPC K=5 R=1/4 mother + rate-2/3 puncture
type-3
  ↓ (K, a) block interleave
type-4
  ↓ scramble (XOR with 32-tap LFSR seeded by colour)
type-5
```

AACH skips the RCPC + interleave layers entirely (just RM + scramble).

**CRC**: bit-level since TETRA K1 values aren't byte-aligned (e.g. 124 bits for SCH/HD). The existing `framing/crc.go` has byte-level helpers; this PR adds a tetra-package-private bit-level CRC matching the spec's `(K1+16, K1)` block code (init=0xFFFF, final XOR=0xFFFF) from eq. 8.14-8.18.

Decode helpers return `(info, ok)` where `ok` signals CRC pass. Failed CRC means the recovered info bits are the best Viterbi guess but shouldn't be trusted.

## Test plan

- [x] `go test ./internal/radio/tetra/ -run 'EncodeDecode|DecodeSCHHD|EncodeFunctions|CRCTetra'` — 16 new tests:
  - SCH/HD round-trip × 4 colour codes (random + alternating)
  - SCH/F round-trip
  - SCH/HU round-trip
  - BSCH round-trip
  - AACH round-trip × 3 colour codes
  - SCH/HD CRC-fail detection on a heavily-corrupted (30-adjacent-bit-flip) stream
  - SCH/HD CRC-fail on wrong colour code (descrambles to noise)
  - SCH/HD single-bit error correction by inner Viterbi
  - All `Encode*` reject wrong-size inputs
  - CRC sanity: all-zero vs all-ones produce different non-zero residues
- [x] `go test ./...` (full suite)
- [x] `go vet ./...`

## Follow-up

Wiring these helpers into `tetra.ControlChannel.Process` — slot-position discrimination per EN 300 392-2 §9 to pick which channel decode runs per burst, plus a `SetChannelCoding` + `SetColourCode` opt-in mirroring the BCH wiring on other protocols — is the next PR.

## Reference

ETSI EN 300 392-2 V3.8.1 §8.3.1 (per-channel error control schemes) + §8.2.3.3 ((K1+16, K1) block code) + §8.2.5.2 (scrambling init). PDF at `./en_30039202v030801p.pdf`.

https://claude.ai/code/session_019dtCCVEZJTKKr6YK3wy824

---
_Generated by [Claude Code](https://claude.ai/code/session_019dtCCVEZJTKKr6YK3wy824)_