### PR TITLE
internal/radio/tetra: SetChannelCoding opt-in wires per-channel FEC decode into Process adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,18 +102,20 @@ The remaining gaps:
   correction; under BCHOn the effective CCW carries 28 info
   bits (Command + Status + Address + 4 high bits of LCN), the
   legacy struct's LCN bit 0 and Aux become BCH parity rather
-  than data. **TETRA** has both channel-coding families
-  shipped as primitives: the K=5 R=1/3 speech-traffic-channel
-  code in `framing/rcpc_tetra.go` (EN 300 395-2 §5.4.3) and
-  the K=5 R=1/4 signaling-channel code in
-  `framing/rcpc_tetra_sig.go` (EN 300 392-2 §8.2.3.1) covering
-  rates 2/3, 1/3, 292/432 and 148/432, plus the shortened
-  (30,14) Reed-Muller code in `framing/rm_30_14_tetra.go`
-  (§8.2.3.2) for AACH. Wiring all three into the TETRA
-  `ControlChannel.Process` adapter — slicing per the channel
-  type (AACH, SCH/HD, BNCH, STCH, SCH/F, BSCH), running
-  depuncture + Viterbi + CRC-16 (CCITT) verify + tail strip
-  per §8.3.1 — is the documented follow-up.
+  than data. **TETRA** ships the full §8.3.1 signaling-channel
+  chain — K=5 R=1/3 speech-traffic-channel code
+  (`framing/rcpc_tetra.go`, EN 300 395-2 §5.4.3), K=5 R=1/4
+  signaling-channel code (`framing/rcpc_tetra_sig.go`,
+  EN 300 392-2 §8.2.3.1) with rates 2/3, 1/3, 292/432 and
+  148/432, shortened (30,14) Reed-Muller code
+  (`framing/rm_30_14_tetra.go`, §8.2.3.2) for AACH, 32-tap
+  scrambler + (K,a) block interleaver from PR #138, and the
+  per-channel encode/decode helpers from PR #139 — composed
+  on the `tetra.ControlChannel.Process` adapter via the
+  `SetChannelCoding(ChannelCodingOn)` opt-in. The connector
+  surface (per-system colour code + expected-channel config
+  flowing from `trunking.System` into the live decoder)
+  is the remaining wiring task.
 - **Symbol-time clock recovery on complex IQ.** The Gardner
   timing-recovery primitive in `internal/dsp/sync/gardner.go`
   is now threaded into both the **P25 Phase 2** and **TETRA**
@@ -191,6 +193,39 @@ to its own package and lands independently.
 
 ### Recently shipped
 
+- **TETRA `SetChannelCoding(ChannelCodingOn)` opt-in wires
+  per-channel FEC decode into `Process`.** Lights up the
+  full ETSI EN 300 392-2 §8.3.1 type-5 → type-1 chain
+  (descramble + deinterleave + depuncture + Viterbi +
+  CRC-16 verify + tail strip) on the `tetra.ControlChannel`
+  Process adapter so live IQ captures — not just synthesized
+  type-1 fixtures — can drive `cc.locked` / Grant events.
+  New API mirrors the BCH wirings on MPT 1327 / EDACS /
+  Motorola:
+    - `SetChannelCoding(ChannelCodingOff | ChannelCodingOn)` —
+      default off (legacy 48-dibit raw path); on enables the
+      full FEC chain.
+    - `SetExpectedChannel(ChannelSCHHD | ChannelSCHF |
+      ChannelSCHHU | ChannelBSCH | ChannelAACH)` — picks
+      which logical channel lives in each burst window
+      under the on path. Default `ChannelSCHHD`.
+    - `SetColourCode(uint32)` — 30-bit extended colour code
+      seeding the scrambler (low 30 bits; masked to
+      `0x3FFFFFFF`). Ignored by BSCH per §8.2.5.2.
+  Under `ChannelCodingOn` the adapter slices the
+  channel-appropriate dibit window (108 for SCH/HD, 216
+  for SCH/F, 84 for SCH/HU, 60 for BSCH, 15 for AACH),
+  routes through the matching `DecodeSCHHD` / `DecodeSCHF`
+  / `DecodeSCHHU` / `DecodeBSCH` / `DecodeAACH` helper
+  shipped in PR #139, and silently drops frames whose
+  CRC fails. Tests round-trip a real `MLE SYSINFO` PDU
+  through SCH/HD → `KindCCLocked`, a `CMCE D-CONNECT` PDU
+  through SCH/F → `KindGrant`, plus heavy-corruption
+  rejection (30 adjacent bit flips) and wrong-colour-code
+  rejection. Wiring this into the `ccdecoder` connector
+  so per-system config (colour code, expected channel)
+  flows from `trunking.System` into the live decoder is
+  the next PR.
 - **TETRA per-channel encode/decode helpers in `tetra/`.**
   Composes the framing primitives shipped in PRs #137 and
   #138 (RCPC + (30,14) RM + (K,a) block interleaver +

--- a/internal/radio/tetra/control.go
+++ b/internal/radio/tetra/control.go
@@ -41,6 +41,9 @@ type ControlChannel struct {
 	locked           bool
 	last             LockState
 	strictValidation bool
+	channelCoding    ChannelCodingMode
+	channelType      ChannelType
+	colourCode       uint32
 }
 
 // SetStrictValidation toggles the strict frame-validity filter on the
@@ -53,6 +56,88 @@ func (c *ControlChannel) SetStrictValidation(strict bool) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.strictValidation = strict
+}
+
+// ChannelCodingMode selects how the Process adapter interprets the
+// incoming dibit stream:
+//
+//   - ChannelCodingOff (default): the adapter slices a fixed 48-
+//     dibit window after each normal-training-sequence sync and
+//     parses the bits straight as a PDU. Works on synthesized
+//     test fixtures where the type-2 / type-5 layers aren't
+//     present; matches the legacy adapter behaviour.
+//
+//   - ChannelCodingOn: the adapter slices the channel-appropriate
+//     number of dibits per the configured ChannelType, runs the
+//     full type-5 → type-1 decode chain (descramble + deinterleave
+//     + depuncture + Viterbi + CRC-16 verify + tail strip) per
+//     ETSI EN 300 392-2 §8.3.1 using the per-channel helpers in
+//     channel_coding.go, then parses the recovered info bits as a
+//     PDU. Frames whose CRC fails are silently dropped.
+//
+// Use SetColourCode to seed the scrambler and SetExpectedChannel
+// to tell the adapter which logical channel lives in each burst.
+type ChannelCodingMode uint8
+
+const (
+	ChannelCodingOff ChannelCodingMode = iota
+	ChannelCodingOn
+)
+
+// ChannelType identifies which TETRA logical channel the Process
+// adapter is currently decoding under ChannelCodingOn. The
+// connector (or higher-layer caller) sets this per burst /
+// per-slot via SetExpectedChannel.
+type ChannelType uint8
+
+const (
+	// ChannelSCHHD covers SCH/HD, BNCH and STCH — they share the
+	// same coding chain per §8.3.1.4.1. 216 type-5 bits / 108
+	// dibits per burst, recovering 124 info bits.
+	ChannelSCHHD ChannelType = iota
+	// ChannelSCHF — full-slot signaling channel. 432 type-5 bits
+	// / 216 dibits, recovering 268 info bits.
+	ChannelSCHF
+	// ChannelSCHHU — half-slot signaling on the uplink. 168
+	// type-5 bits / 84 dibits, recovering 92 info bits.
+	ChannelSCHHU
+	// ChannelBSCH — broadcast synchronisation channel. 120 type-5
+	// bits / 60 dibits, recovering 60 info bits. Colour code
+	// is implicitly 0 for BSCH regardless of SetColourCode.
+	ChannelBSCH
+	// ChannelAACH — access-assignment channel (slot header).
+	// 30 type-5 bits / 15 dibits, recovering 14 info bits.
+	// AACH skips RCPC + interleaving, just RM + scramble.
+	ChannelAACH
+)
+
+// SetChannelCoding toggles the full EN 300 392-2 §8.3.1 channel
+// coding chain on the Process adapter. See ChannelCodingMode for
+// the trade-offs.
+func (c *ControlChannel) SetChannelCoding(mode ChannelCodingMode) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.channelCoding = mode
+}
+
+// SetExpectedChannel tells the Process adapter which TETRA logical
+// channel lives in each burst window. Only consulted when
+// ChannelCodingMode is ChannelCodingOn; ignored otherwise. The
+// default channel under ChannelCodingOn is ChannelSCHHD (the most
+// common signaling carrier for cc.locked / Grant events).
+func (c *ControlChannel) SetExpectedChannel(ch ChannelType) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.channelType = ch
+}
+
+// SetColourCode sets the 30-bit extended colour code the scrambler
+// uses under ChannelCodingOn (low 30 bits of colourCode hold
+// e(1)..e(30)). BSCH ignores this and uses 0 per §8.2.5.2.
+func (c *ControlChannel) SetColourCode(colourCode uint32) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.colourCode = colourCode & 0x3FFFFFFF
 }
 
 // Options configure a ControlChannel.

--- a/internal/radio/tetra/process.go
+++ b/internal/radio/tetra/process.go
@@ -14,14 +14,34 @@ type processState struct {
 }
 
 // pduDibitCount is the count of dibits the adapter collects after
-// each 38-dibit training-sequence match. A TETRA VoiceGrant (CMCE
-// D-CONNECT) needs 1 header byte + 11 payload bytes = 12 bytes =
-// 96 bits = 48 dibits — large enough to cover SystemBroadcast +
-// VoiceGrant + Release. The RCPC / RM FEC + interleaving across
-// the full slot aren't reversed here; the adapter reads the
-// information bits straight from the wire, which works on test
-// fixtures but typically fails on captured TETRA traffic.
+// each 38-dibit training-sequence match under ChannelCodingOff —
+// 48 dibits = 96 bits, large enough to cover SystemBroadcast /
+// VoiceGrant / Release PDUs read raw from a synthesized fixture.
+// Under ChannelCodingOn the slice size is channel-specific (see
+// channelDibitCount).
 const pduDibitCount = 48
+
+// channelDibitCount returns the number of dibits the Process
+// adapter collects after sync detection for each ChannelType
+// under ChannelCodingOn. Each value is the type-5 bit count of
+// the channel (per EN 300 392-2 §8.3.1) divided by 2 (one dibit
+// = 2 bits).
+func channelDibitCount(ch ChannelType) int {
+	switch ch {
+	case ChannelAACH:
+		return 15 // 30 type-5 bits / 2
+	case ChannelBSCH:
+		return 60 // 120 / 2
+	case ChannelSCHHD:
+		return 108 // 216 / 2
+	case ChannelSCHHU:
+		return 84 // 168 / 2
+	case ChannelSCHF:
+		return 216 // 432 / 2
+	default:
+		return 108 // SCH/HD default
+	}
+}
 
 // Process consumes a window of raw dibits from the TETRA receiver
 // (the IQ → π/4-DQPSK dibit chain in internal/radio/tetra/receiver/),
@@ -36,10 +56,16 @@ const pduDibitCount = 48
 // Returns baseIdx + len(dibits) to match the ControlChannel.Process
 // contracts shared across protocols.
 func (c *ControlChannel) Process(dibits []uint8, baseIdx int) int {
+	c.mu.Lock()
+	mode := c.channelCoding
+	channel := c.channelType
+	colour := c.colourCode
+	c.mu.Unlock()
+
 	if c.proc == nil {
 		c.proc = &processState{
 			det:       NewSyncDetector(NormalSyncDibits(), 3),
-			pduDibits: make([]uint8, 0, pduDibitCount),
+			pduDibits: make([]uint8, 0, channelDibitCount(ChannelSCHF)),
 		}
 	}
 	p := c.proc
@@ -47,29 +73,77 @@ func (c *ControlChannel) Process(dibits []uint8, baseIdx int) int {
 	p.matchScratch, _ = p.det.Process(p.matchScratch[:0], dibits, baseIdx)
 	matchIdx := 0
 
+	sliceCount := pduDibitCount
+	if mode == ChannelCodingOn {
+		sliceCount = channelDibitCount(channel)
+	}
+
 	for i, d := range dibits {
 		absPos := baseIdx + i
 		if p.remaining > 0 {
 			p.pduDibits = append(p.pduDibits, d)
 			p.remaining--
 			if p.remaining == 0 {
-				bits := framing.DibitsToBits(p.pduDibits)
-				info := framing.PackBitsMSB(bits)
-				if len(info) >= 1 {
-					if pdu, err := ParsePDU(info); err == nil {
-						c.Ingest(pdu)
-					}
-				}
+				c.dispatchSlice(p.pduDibits, mode, channel, colour)
 				p.pduDibits = p.pduDibits[:0]
 			}
 		}
 		for matchIdx < len(p.matchScratch) && p.matchScratch[matchIdx] == absPos {
-			p.remaining = pduDibitCount
+			p.remaining = sliceCount
 			p.pduDibits = p.pduDibits[:0]
 			matchIdx++
 		}
 	}
 	return baseIdx + len(dibits)
+}
+
+// dispatchSlice turns the collected post-sync dibit slice into a
+// PDU and forwards it to Ingest. Under ChannelCodingOff the
+// slice is interpreted as raw type-1 bits; under ChannelCodingOn
+// the configured ChannelType drives a full type-5 → type-1 decode
+// chain via the per-channel helpers in channel_coding.go.
+func (c *ControlChannel) dispatchSlice(slice []uint8, mode ChannelCodingMode, channel ChannelType, colour uint32) {
+	bits := framing.DibitsToBits(slice)
+	var info []byte
+	switch {
+	case mode != ChannelCodingOn:
+		info = framing.PackBitsMSB(bits)
+	case channel == ChannelAACH:
+		recovered, errs := DecodeAACH(bits, colour)
+		if errs < 0 {
+			return
+		}
+		info = framing.PackBitsMSB(recovered)
+	case channel == ChannelBSCH:
+		recovered, ok := DecodeBSCH(bits)
+		if !ok {
+			return
+		}
+		info = framing.PackBitsMSB(recovered)
+	case channel == ChannelSCHHU:
+		recovered, ok := DecodeSCHHU(bits, colour)
+		if !ok {
+			return
+		}
+		info = framing.PackBitsMSB(recovered)
+	case channel == ChannelSCHF:
+		recovered, ok := DecodeSCHF(bits, colour)
+		if !ok {
+			return
+		}
+		info = framing.PackBitsMSB(recovered)
+	default: // ChannelSCHHD
+		recovered, ok := DecodeSCHHD(bits, colour)
+		if !ok {
+			return
+		}
+		info = framing.PackBitsMSB(recovered)
+	}
+	if len(info) >= 1 {
+		if pdu, err := ParsePDU(info); err == nil {
+			c.Ingest(pdu)
+		}
+	}
 }
 
 // Reset clears the SyncDetector's history so a stale match doesn't

--- a/internal/radio/tetra/process_channel_coding_test.go
+++ b/internal/radio/tetra/process_channel_coding_test.go
@@ -1,0 +1,297 @@
+package tetra
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+)
+
+// pduToType1Bits converts a PDU (header byte + payload bytes)
+// into a bit slice of exactly k1 bits, MSB-first per byte,
+// zero-padded if the PDU is shorter than k1. Returns nil if
+// the PDU is too long to fit in k1 bits.
+func pduToType1Bits(pdu PDU, k1 int) []byte {
+	bytes := AssemblePDU(pdu)
+	if len(bytes)*8 > k1 {
+		return nil
+	}
+	out := make([]byte, k1)
+	for i, b := range bytes {
+		for j := 0; j < 8; j++ {
+			out[i*8+j] = (b >> uint(7-j)) & 1
+		}
+	}
+	return out
+}
+
+// TestProcessChannelCodingOnSCHHDRoundTrip: encode a known PDU
+// through EncodeSCHHD, build a wire-bit stream (padding + sync +
+// 108 dibits of channel-coded SCH/HD), push it through
+// Process(ChannelCodingOn / SCHHD), confirm the state machine
+// publishes the expected event.
+func TestProcessChannelCodingOnSCHHDRoundTrip(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{
+		Bus:         bus,
+		Log:         slog.Default(),
+		SystemName:  "Sys",
+		FrequencyHz: 412_062_500,
+	})
+	cc.SetChannelCoding(ChannelCodingOn)
+	cc.SetExpectedChannel(ChannelSCHHD)
+	cc.SetColourCode(0x12345)
+
+	// MLE SYSINFO — drives a cc.locked event.
+	pdu := PDU{
+		Disc: DiscMLE,
+		Type: uint8(MLESystemInfo),
+		Payload: []byte{
+			// MCC=10 bits, MNC=14 bits, LA=14 bits — 38 bits across 5 bytes
+			// (rest zero — minimum valid).
+			0x00, 0x40, 0x00, 0x00, 0x00,
+		},
+	}
+	info := pduToType1Bits(pdu, 124)
+	if info == nil {
+		t.Fatalf("PDU too large for SCH/HD 124 type-1 bits")
+	}
+	type5 := EncodeSCHHD(info, 0x12345)
+	if len(type5) != 216 {
+		t.Fatalf("EncodeSCHHD produced %d bits, want 216", len(type5))
+	}
+	dibits := framing.BitsToDibits(type5)
+	if len(dibits) != 108 {
+		t.Fatalf("type-5 → dibits = %d, want 108", len(dibits))
+	}
+
+	// Stream: 30 padding dibits + 38-dibit normal training sequence
+	// + 108 channel-coded SCH/HD dibits.
+	stream := make([]uint8, 30)
+	stream = append(stream, NormalSyncDibits()...)
+	stream = append(stream, dibits...)
+
+	cc.Process(stream, 0)
+
+	var sawLock bool
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind == events.KindCCLocked {
+				sawLock = true
+			}
+		default:
+			if !sawLock {
+				t.Errorf("ChannelCodingOn Process did not publish KindCCLocked for a MLE SYSINFO encoded via SCH/HD")
+			}
+			return
+		}
+	}
+}
+
+// TestProcessChannelCodingOnSCHFRoundTrip: same idea but with a
+// full-slot signaling channel (432 type-5 bits / 216 dibits) and
+// a CMCE D-CONNECT (voice grant) PDU.
+func TestProcessChannelCodingOnSCHFRoundTrip(t *testing.T) {
+	bus := events.NewBus(16)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{
+		Bus:         bus,
+		Log:         slog.Default(),
+		SystemName:  "Sys",
+		FrequencyHz: 412_062_500,
+	})
+	cc.SetChannelCoding(ChannelCodingOn)
+	cc.SetExpectedChannel(ChannelSCHF)
+	cc.SetColourCode(0xAAAA)
+
+	// CMCE D-CONNECT carrying a VoiceGrant for talkgroup 0xCAFE,
+	// source 0xAAAAAA, dest 0xBBBBBB, carrier 7, group flag set.
+	payload := make([]byte, 11)
+	payload[0], payload[1] = 0x00, 0x04 // CID = 1
+	payload[2], payload[3], payload[4] = 0xAA, 0xAA, 0xAA
+	payload[5], payload[6], payload[7] = 0xBB, 0xBB, 0xBB
+	payload[8] = 0x80                  // group flag
+	payload[9], payload[10] = 0x00, 0x70 // carrier 7
+	pdu := PDU{Disc: DiscCMCE, Type: uint8(CMCEDConnect), Payload: payload}
+	info := pduToType1Bits(pdu, 268)
+	if info == nil {
+		t.Fatalf("PDU too large for SCH/F 268 type-1 bits")
+	}
+	type5 := EncodeSCHF(info, 0xAAAA)
+	dibits := framing.BitsToDibits(type5)
+	if len(dibits) != 216 {
+		t.Fatalf("type-5 → dibits = %d, want 216", len(dibits))
+	}
+
+	stream := make([]uint8, 30)
+	stream = append(stream, NormalSyncDibits()...)
+	stream = append(stream, dibits...)
+
+	cc.Process(stream, 0)
+
+	var sawGrant bool
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind == events.KindGrant {
+				sawGrant = true
+			}
+		default:
+			if !sawGrant {
+				t.Errorf("ChannelCodingOn Process did not publish KindGrant for a CMCE D-CONNECT encoded via SCH/F")
+			}
+			return
+		}
+	}
+}
+
+// TestProcessChannelCodingOnRejectsCRCFailure: corrupt the
+// channel-coded dibits enough to overwhelm the inner Viterbi
+// (30 adjacent bit flips), confirm Process drops the frame
+// (no Grant / cc.locked).
+func TestProcessChannelCodingOnRejectsCRCFailure(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{
+		Bus:        bus,
+		Log:        slog.Default(),
+		SystemName: "Sys",
+	})
+	cc.SetChannelCoding(ChannelCodingOn)
+	cc.SetExpectedChannel(ChannelSCHHD)
+	cc.SetColourCode(0x12345)
+
+	pdu := PDU{
+		Disc:    DiscMLE,
+		Type:    uint8(MLESystemInfo),
+		Payload: []byte{0x00, 0x40, 0x00, 0x00, 0x00},
+	}
+	info := pduToType1Bits(pdu, 124)
+	type5 := EncodeSCHHD(info, 0x12345)
+	// Heavy corruption: 30 adjacent bit flips
+	for i := 50; i < 80; i++ {
+		type5[i] ^= 1
+	}
+	dibits := framing.BitsToDibits(type5)
+
+	stream := make([]uint8, 30)
+	stream = append(stream, NormalSyncDibits()...)
+	stream = append(stream, dibits...)
+
+	cc.Process(stream, 0)
+
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind == events.KindCCLocked || ev.Kind == events.KindGrant {
+				t.Errorf("ChannelCodingOn accepted a heavily-corrupted frame: %v", ev.Kind)
+			}
+		default:
+			return
+		}
+	}
+}
+
+// TestProcessChannelCodingOnRejectsWrongColourCode: encode with
+// colour code A, configure decoder for colour code B — descramble
+// produces garbage, CRC fails, no event.
+func TestProcessChannelCodingOnRejectsWrongColourCode(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{
+		Bus:        bus,
+		Log:        slog.Default(),
+		SystemName: "Sys",
+	})
+	cc.SetChannelCoding(ChannelCodingOn)
+	cc.SetExpectedChannel(ChannelSCHHD)
+	cc.SetColourCode(0xBBBB) // decoder configured with wrong colour
+
+	pdu := PDU{
+		Disc:    DiscMLE,
+		Type:    uint8(MLESystemInfo),
+		Payload: []byte{0x00, 0x40, 0x00, 0x00, 0x00},
+	}
+	info := pduToType1Bits(pdu, 124)
+	type5 := EncodeSCHHD(info, 0xAAAA) // encoded with different colour
+	dibits := framing.BitsToDibits(type5)
+
+	stream := make([]uint8, 30)
+	stream = append(stream, NormalSyncDibits()...)
+	stream = append(stream, dibits...)
+
+	cc.Process(stream, 0)
+
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind == events.KindCCLocked || ev.Kind == events.KindGrant {
+				t.Errorf("ChannelCodingOn accepted a frame with wrong colour code: %v", ev.Kind)
+			}
+		default:
+			return
+		}
+	}
+}
+
+// TestSetChannelCodingDefault: the zero-value ControlChannel uses
+// ChannelCodingOff (the legacy 48-dibit raw path).
+func TestSetChannelCodingDefault(t *testing.T) {
+	cc := New(Options{Bus: events.NewBus(1)})
+	if cc.channelCoding != ChannelCodingOff {
+		t.Errorf("default channelCoding = %v, want ChannelCodingOff", cc.channelCoding)
+	}
+	cc.SetChannelCoding(ChannelCodingOn)
+	if cc.channelCoding != ChannelCodingOn {
+		t.Errorf("SetChannelCoding(ChannelCodingOn) did not take effect")
+	}
+	cc.SetExpectedChannel(ChannelSCHF)
+	if cc.channelType != ChannelSCHF {
+		t.Errorf("SetExpectedChannel(ChannelSCHF) did not take effect")
+	}
+	cc.SetColourCode(0x12345)
+	if cc.colourCode != 0x12345 {
+		t.Errorf("SetColourCode(0x12345) did not take effect")
+	}
+	// Colour code mask should clip to low 30 bits.
+	cc.SetColourCode(0xFFFFFFFF)
+	if cc.colourCode != 0x3FFFFFFF {
+		t.Errorf("SetColourCode(0xFFFFFFFF) was not masked to 30 bits: got %#x", cc.colourCode)
+	}
+}
+
+// TestChannelDibitCount sanity check that each channel maps to
+// its spec-correct type-5-bit / dibit count.
+func TestChannelDibitCount(t *testing.T) {
+	cases := []struct {
+		ch        ChannelType
+		wantDibit int
+	}{
+		{ChannelAACH, 15},
+		{ChannelBSCH, 60},
+		{ChannelSCHHD, 108},
+		{ChannelSCHHU, 84},
+		{ChannelSCHF, 216},
+	}
+	for _, tc := range cases {
+		got := channelDibitCount(tc.ch)
+		if got != tc.wantDibit {
+			t.Errorf("channelDibitCount(%d) = %d, want %d", tc.ch, got, tc.wantDibit)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `SetChannelCoding(ChannelCodingOn)` / `SetExpectedChannel(...)` / `SetColourCode(...)` to `tetra.ControlChannel`, mirroring the BCH opt-ins on MPT 1327 / EDACS / Motorola
- Under `ChannelCodingOn`, `Process` slices the channel-appropriate dibit window (108 SCH/HD, 216 SCH/F, 84 SCH/HU, 60 BSCH, 15 AACH) and runs the full ETSI EN 300 392-2 §8.3.1 type-5 → type-1 chain (descramble + deinterleave + depuncture + Viterbi + CRC-16 verify + tail strip) via the per-channel helpers shipped in PR #139
- Frames whose CRC fails are silently dropped; default `ChannelCodingOff` preserves the legacy 48-dibit raw path used by existing synthesized-fixture tests

This lets live IQ captures — not just type-1 fixtures — drive `cc.locked` / `Grant` events end-to-end. Threading colour-code + expected-channel from `trunking.System` into the live `ccdecoder` connector is the follow-up PR.

## Test plan

- [x] `go test ./internal/radio/tetra/...` — 6 new wiring tests + all existing tetra tests pass
  - `TestProcessChannelCodingOnSCHHDRoundTrip` — MLE SYSINFO → SCH/HD → `KindCCLocked`
  - `TestProcessChannelCodingOnSCHFRoundTrip` — CMCE D-CONNECT → SCH/F → `KindGrant`
  - `TestProcessChannelCodingOnRejectsCRCFailure` — 30 adjacent bit flips → no event
  - `TestProcessChannelCodingOnRejectsWrongColourCode` — encoder/decoder colour mismatch → no event
  - `TestSetChannelCodingDefault` — zero value is `ChannelCodingOff`; setters round-trip; colour-code masks to 30 bits
  - `TestChannelDibitCount` — channel → dibit-count mapping matches §8.3.1
- [x] `go test ./...` clean
- [x] `go vet ./...` clean

https://claude.ai/code/session_019dtCCVEZJTKKr6YK3wy824

---
_Generated by [Claude Code](https://claude.ai/code/session_019dtCCVEZJTKKr6YK3wy824)_