### PR TITLE
internal/scanner/ccdecoder: thread TETRA colour code + expected channel from trunking.System

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,10 +112,16 @@ The remaining gaps:
   scrambler + (K,a) block interleaver from PR #138, and the
   per-channel encode/decode helpers from PR #139 — composed
   on the `tetra.ControlChannel.Process` adapter via the
-  `SetChannelCoding(ChannelCodingOn)` opt-in. The connector
-  surface (per-system colour code + expected-channel config
-  flowing from `trunking.System` into the live decoder)
-  is the remaining wiring task.
+  `SetChannelCoding(ChannelCodingOn)` opt-in and wired into
+  the live decoder by the `ccdecoder` connector reading
+  `tetra_colour_code` + `tetra_channel` off each
+  `trunking.System` per PR #141. The remaining TETRA work
+  on the "lights up live trunked reception" path is
+  validation against a captured TETRA TMO IQ exchange —
+  unit tests round-trip clean fixtures end-to-end, but
+  on-air recovery margins (Viterbi correction depth vs.
+  real co-channel + adjacent-channel interference) need a
+  live capture to characterise.
 - **Symbol-time clock recovery on complex IQ.** The Gardner
   timing-recovery primitive in `internal/dsp/sync/gardner.go`
   is now threaded into both the **P25 Phase 2** and **TETRA**
@@ -193,6 +199,47 @@ to its own package and lands independently.
 
 ### Recently shipped
 
+- **`ccdecoder` connector threads TETRA channel coding from
+  per-system config.** Closes the last gap between the
+  daemon's YAML and the §8.3.1 type-5 → type-1 decoder
+  shipped in PR #140 — operators set the cell's extended
+  colour code + signaling channel once in `config.yaml` and
+  the `newTETRAPipeline` factory flips
+  `tetra.ControlChannel.SetChannelCoding(ChannelCodingOn)`
+  automatically on every retune.
+  - `trunking.System` gains `TETRAColourCode uint32` (low
+    30 bits of the §8.2.5 extended colour code, bits 30..31
+    silently ignored) and `TETRAChannel string` (the
+    config-side name for the logical channel that lives in
+    each burst window).
+  - `config.SystemConfig` exposes those as `tetra_colour_code`
+    + `tetra_channel` YAML keys; `cmd/gophertrunk/daemon.go`
+    forwards them into `trunking.System` on construction.
+  - `ccdecoder.PipelineOptions` carries the full
+    `trunking.System` so per-protocol factories can read
+    protocol-specific config without a new field per protocol.
+  - `tetra.ParseChannelType` maps the YAML string
+    (`"sch/hd" | "sch/f" | "sch/hu" | "bsch" | "aach"`,
+    case-insensitive, `"/"` and `"_"` both accepted, empty
+    defaults to `sch/hd`) into a `tetra.ChannelType`;
+    unknown values fall back to SCH/HD with a warn-level
+    log entry.
+  - `tetra.ControlChannel.ChannelCoding` / `ExpectedChannel`
+    / `ColourCode` accessors let tests + observability code
+    introspect the configured state without poking at
+    unexported fields.
+  - Zero `TETRAColourCode` preserves the legacy
+    `ChannelCodingOff` raw-dibit path so existing
+    synthesized-fixture tests stay green.
+  Tests cover the config-string → ChannelType parser across
+  every recognised value (plus a misconfigured-input
+  warning case), the factory turning channel coding on
+  with the right colour code + channel under a populated
+  System, and the factory leaving channel coding off when
+  the colour code is left at the zero default. The remaining
+  work toward "lights up live trunked reception" is now
+  protocol-by-protocol FEC wiring across the other 9
+  protocols, not connector plumbing.
 - **TETRA `SetChannelCoding(ChannelCodingOn)` opt-in wires
   per-channel FEC decode into `Process`.** Lights up the
   full ETSI EN 300 392-2 §8.3.1 type-5 → type-1 chain

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -119,6 +119,8 @@ func NewDaemon(cfg config.Config, version string, log *slog.Logger) (*Daemon, er
 			Name:            sys.Name,
 			Protocol:        proto,
 			ControlChannels: sys.ControlChannels,
+			TETRAColourCode: sys.TETRAColourCode,
+			TETRAChannel:    sys.TETRAChannel,
 		}
 		if err := s.Validate(); err != nil {
 			return nil, fmt.Errorf("daemon: system %q: %w", sys.Name, err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -97,10 +97,27 @@ type TrunkingConfig struct {
 }
 
 type SystemConfig struct {
-	Name             string   `yaml:"name"`
-	Protocol         string   `yaml:"protocol"`
-	ControlChannels  []uint32 `yaml:"control_channels"`
-	TalkgroupFile    string   `yaml:"talkgroup_file"`
+	Name            string   `yaml:"name"`
+	Protocol        string   `yaml:"protocol"`
+	ControlChannels []uint32 `yaml:"control_channels"`
+	TalkgroupFile   string   `yaml:"talkgroup_file"`
+
+	// TETRAColourCode is the 30-bit extended colour code the TETRA
+	// scrambler uses to seed its LFSR (ETSI EN 300 392-2 §8.2.5).
+	// Set this to the per-cell colour code of the TETRA TMO system
+	// being decoded so the ccdecoder connector turns on the full
+	// §8.3.1 type-5 → type-1 decode chain (descramble + deinterleave
+	// + depuncture + Viterbi + CRC-16). Bits 30..31 are silently
+	// ignored. Zero (the default) keeps the legacy raw-dibit path,
+	// which only works on FEC-free synthesized fixtures. Ignored
+	// for non-TETRA protocols.
+	TETRAColourCode uint32 `yaml:"tetra_colour_code"`
+	// TETRAChannel selects which TETRA logical channel lives in
+	// each burst window under ChannelCodingOn. Recognised values:
+	// "sch/hd" | "sch/f" | "sch/hu" | "bsch" | "aach". Empty
+	// defaults to "sch/hd" — the standard signaling channel for
+	// cc.locked / Grant events. Ignored for non-TETRA protocols.
+	TETRAChannel string `yaml:"tetra_channel"`
 }
 
 // APIConfig controls the HTTP REST + SSE + WebSocket and gRPC servers.

--- a/internal/radio/tetra/control.go
+++ b/internal/radio/tetra/control.go
@@ -2,6 +2,7 @@ package tetra
 
 import (
 	"log/slog"
+	"strings"
 	"sync"
 	"time"
 
@@ -111,6 +112,33 @@ const (
 	ChannelAACH
 )
 
+// ParseChannelType maps a config / user-facing string into a
+// ChannelType. Recognised values (case-insensitive, "/" optional):
+// "sch/hd" | "schhd" | "sch_hd", "sch/f" | "schf", "sch/hu" |
+// "schhu", "bsch", "aach". An empty string returns ChannelSCHHD —
+// the default ChannelCodingOn channel — and `ok = true` so config
+// callers can leave the field blank. Unknown strings return
+// ChannelSCHHD with `ok = false` so callers can surface the
+// misconfiguration.
+func ParseChannelType(s string) (ChannelType, bool) {
+	switch strings.ToLower(strings.ReplaceAll(strings.ReplaceAll(s, "/", ""), "_", "")) {
+	case "":
+		return ChannelSCHHD, true
+	case "schhd", "bnch", "stch":
+		return ChannelSCHHD, true
+	case "schf":
+		return ChannelSCHF, true
+	case "schhu":
+		return ChannelSCHHU, true
+	case "bsch":
+		return ChannelBSCH, true
+	case "aach":
+		return ChannelAACH, true
+	default:
+		return ChannelSCHHD, false
+	}
+}
+
 // SetChannelCoding toggles the full EN 300 392-2 §8.3.1 channel
 // coding chain on the Process adapter. See ChannelCodingMode for
 // the trade-offs.
@@ -138,6 +166,30 @@ func (c *ControlChannel) SetColourCode(colourCode uint32) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.colourCode = colourCode & 0x3FFFFFFF
+}
+
+// ChannelCoding returns the current ChannelCodingMode. Mirrors the
+// Set* family so callers (and tests) can introspect the configured
+// mode without poking at unexported state.
+func (c *ControlChannel) ChannelCoding() ChannelCodingMode {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.channelCoding
+}
+
+// ExpectedChannel returns the ChannelType the Process adapter
+// currently expects under ChannelCodingOn.
+func (c *ControlChannel) ExpectedChannel() ChannelType {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.channelType
+}
+
+// ColourCode returns the configured 30-bit extended colour code.
+func (c *ControlChannel) ColourCode() uint32 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.colourCode
 }
 
 // Options configure a ControlChannel.

--- a/internal/radio/tetra/process_channel_coding_test.go
+++ b/internal/radio/tetra/process_channel_coding_test.go
@@ -275,6 +275,42 @@ func TestSetChannelCodingDefault(t *testing.T) {
 	}
 }
 
+// TestParseChannelType covers the config-string → ChannelType
+// mapping the ccdecoder connector uses to translate the
+// `tetra_channel` YAML field into a SetExpectedChannel call.
+func TestParseChannelType(t *testing.T) {
+	cases := []struct {
+		in   string
+		want ChannelType
+		ok   bool
+	}{
+		{"", ChannelSCHHD, true},
+		{"sch/hd", ChannelSCHHD, true},
+		{"SCH/HD", ChannelSCHHD, true},
+		{"sch_hd", ChannelSCHHD, true},
+		{"schhd", ChannelSCHHD, true},
+		{"bnch", ChannelSCHHD, true}, // BNCH shares the SCH/HD coding chain.
+		{"stch", ChannelSCHHD, true}, // STCH too.
+		{"sch/f", ChannelSCHF, true},
+		{"schf", ChannelSCHF, true},
+		{"sch/hu", ChannelSCHHU, true},
+		{"schhu", ChannelSCHHU, true},
+		{"bsch", ChannelBSCH, true},
+		{"BSCH", ChannelBSCH, true},
+		{"aach", ChannelAACH, true},
+		{"AACH", ChannelAACH, true},
+		{"nonsense", ChannelSCHHD, false},
+		{"sch/q", ChannelSCHHD, false},
+	}
+	for _, tc := range cases {
+		got, ok := ParseChannelType(tc.in)
+		if got != tc.want || ok != tc.ok {
+			t.Errorf("ParseChannelType(%q) = (%v, %v), want (%v, %v)",
+				tc.in, got, ok, tc.want, tc.ok)
+		}
+	}
+}
+
 // TestChannelDibitCount sanity check that each channel maps to
 // its spec-correct type-5-bit / dibit count.
 func TestChannelDibitCount(t *testing.T) {

--- a/internal/scanner/ccdecoder/decoder.go
+++ b/internal/scanner/ccdecoder/decoder.go
@@ -192,6 +192,7 @@ func (d *Decoder) handleProgress(p trunking.HuntProgress) {
 		SystemName:   sys.Name,
 		FrequencyHz:  p.AttemptedFreqHz,
 		SampleRateHz: d.sampleRateHz,
+		System:       sys,
 	})
 	if err != nil {
 		d.log.Warn("ccdecoder: pipeline factory failed",

--- a/internal/scanner/ccdecoder/decoder_test.go
+++ b/internal/scanner/ccdecoder/decoder_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/tetra"
 	"github.com/MattCheramie/GopherTrunk/internal/trunking"
 )
 
@@ -283,6 +284,62 @@ func TestTETRAFactoryConstructs(t *testing.T) {
 	p.Reset()
 	if err := p.Close(); err != nil {
 		t.Errorf("Close: %v", err)
+	}
+}
+
+// TestTETRAFactoryEnablesChannelCodingFromSystem: when the
+// trunking.System carries a non-zero TETRAColourCode, the factory
+// must flip the underlying ControlChannel into ChannelCodingOn and
+// apply the colour code + expected channel from config.
+func TestTETRAFactoryEnablesChannelCodingFromSystem(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	p, err := newTETRAPipeline(PipelineOptions{
+		Bus: bus, SystemName: "Test", FrequencyHz: 412_062_500,
+		SampleRateHz: 144_000,
+		System: trunking.System{
+			Name: "Test", Protocol: trunking.ProtocolTETRA,
+			ControlChannels: []uint32{412_062_500},
+			TETRAColourCode: 0x12345,
+			TETRAChannel:    "sch/f",
+		},
+	})
+	if err != nil {
+		t.Fatalf("newTETRAPipeline: %v", err)
+	}
+	tp := p.(*tetraPipeline)
+	if got := tp.cc.ChannelCoding(); got != tetra.ChannelCodingOn {
+		t.Errorf("ChannelCoding = %v, want ChannelCodingOn", got)
+	}
+	if got := tp.cc.ExpectedChannel(); got != tetra.ChannelSCHF {
+		t.Errorf("ExpectedChannel = %v, want ChannelSCHF", got)
+	}
+	if got := tp.cc.ColourCode(); got != 0x12345 {
+		t.Errorf("ColourCode = %#x, want 0x12345", got)
+	}
+}
+
+// TestTETRAFactoryDefaultColourCodeKeepsCodingOff: zero
+// TETRAColourCode preserves the legacy raw-dibit path so existing
+// synthesized-fixture tests stay green.
+func TestTETRAFactoryDefaultColourCodeKeepsCodingOff(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	p, err := newTETRAPipeline(PipelineOptions{
+		Bus: bus, SystemName: "Test", FrequencyHz: 412_062_500,
+		SampleRateHz: 144_000,
+		System: trunking.System{
+			Name: "Test", Protocol: trunking.ProtocolTETRA,
+			ControlChannels: []uint32{412_062_500},
+			// TETRAColourCode left at zero.
+		},
+	})
+	if err != nil {
+		t.Fatalf("newTETRAPipeline: %v", err)
+	}
+	tp := p.(*tetraPipeline)
+	if got := tp.cc.ChannelCoding(); got != tetra.ChannelCodingOff {
+		t.Errorf("ChannelCoding = %v, want ChannelCodingOff", got)
 	}
 }
 

--- a/internal/scanner/ccdecoder/pipelines.go
+++ b/internal/scanner/ccdecoder/pipelines.go
@@ -44,12 +44,20 @@ type ProtocolPipeline interface {
 // connector hands the bus + log down, plus the (system, frequency)
 // the supervisor is currently attempting and the IQ sample rate
 // the receiver needs to size its matched filter.
+//
+// System carries the full trunking.System the supervisor is hunting,
+// so per-protocol factories can read protocol-specific config off it
+// (TETRA colour code + expected channel, P25 WACN, etc.) without
+// needing a new field on PipelineOptions per protocol. SystemName +
+// FrequencyHz remain at the top level because they're consumed by
+// every factory.
 type PipelineOptions struct {
 	Bus          *events.Bus
 	Log          *slog.Logger
 	SystemName   string
 	FrequencyHz  uint32
 	SampleRateHz float64
+	System       trunking.System
 }
 
 // PipelineFactory constructs a fresh ProtocolPipeline for one tuned
@@ -163,10 +171,18 @@ func (p *p25Phase2Pipeline) Close() error            { return nil }
 
 // newTETRAPipeline wires internal/radio/tetra/receiver into
 // tetra.ControlChannel.Process. The receiver's DibitSink forwards
-// π/4-DQPSK dibits into the state machine (38-dibit normal
-// training-sequence detect → 48-dibit PDU slice → ParsePDU →
-// Ingest). The RCPC + RM FEC + interleaving across the full TDMA
-// slot are follow-ups.
+// π/4-DQPSK dibits into the state machine.
+//
+// When the supplied trunking.System carries a non-zero TETRAColourCode,
+// the factory flips the CC into ChannelCodingOn — slicing per the
+// configured TETRAChannel (default ChannelSCHHD) and running the full
+// ETSI EN 300 392-2 §8.3.1 type-5 → type-1 decode chain (descramble +
+// deinterleave + depuncture + Viterbi + CRC-16 verify + tail strip)
+// per burst. Leaving TETRAColourCode at zero keeps the legacy
+// ChannelCodingOff raw-dibit path (38-dibit normal training-sequence
+// detect → 48-dibit PDU slice → ParsePDU → Ingest), which still
+// works on synthesized fixtures but won't lock on live FEC-encoded
+// captures.
 //
 // The connector wires the receiver with `ClockMode: ClockGardner`
 // — Gardner timing recovery on complex IQ replaces the receiver's
@@ -180,6 +196,16 @@ func newTETRAPipeline(opts PipelineOptions) (ProtocolPipeline, error) {
 		SystemName:  opts.SystemName,
 		FrequencyHz: opts.FrequencyHz,
 	})
+	if opts.System.TETRAColourCode != 0 {
+		ch, ok := tetra.ParseChannelType(opts.System.TETRAChannel)
+		if !ok {
+			opts.Log.Warn("ccdecoder: unrecognised tetra_channel; falling back to SCH/HD",
+				"system", opts.SystemName, "value", opts.System.TETRAChannel)
+		}
+		cc.SetChannelCoding(tetra.ChannelCodingOn)
+		cc.SetExpectedChannel(ch)
+		cc.SetColourCode(opts.System.TETRAColourCode)
+	}
 	rx := tetrarx.New(tetrarx.Options{
 		SampleRateHz: opts.SampleRateHz,
 		DibitSink: func(dibits []uint8, baseIdx int) {

--- a/internal/trunking/site.go
+++ b/internal/trunking/site.go
@@ -92,6 +92,24 @@ type System struct {
 	SystemID        uint16   // 12-bit system identifier (P25 SYSID)
 	RFSS            uint8    // RF SubSystem ID (P25)
 	Site            uint8    // Site ID
+
+	// TETRAColourCode is the low 30 bits of the extended colour code
+	// the TETRA scrambler uses to seed its LFSR per ETSI EN 300 392-2
+	// §8.2.5 ("ec" in the spec). The ccdecoder connector forwards this
+	// into tetra.ControlChannel.SetColourCode under ChannelCodingOn.
+	// Zero is valid (BSCH always uses 0 per §8.2.5.2) but disables
+	// channel coding because the colour code is the per-cell secret
+	// the descrambler needs to recover the type-3 stream. Bits 30..31
+	// are silently ignored downstream.
+	TETRAColourCode uint32
+	// TETRAChannel selects which TETRA logical channel lives in each
+	// burst window under ChannelCodingOn. Recognised values:
+	// "sch/hd" | "sch/f" | "sch/hu" | "bsch" | "aach" (case-insensitive,
+	// "/" optional). Empty defaults to "sch/hd" — the most common
+	// signaling carrier for cc.locked / Grant events. Forwarded into
+	// tetra.ControlChannel.SetExpectedChannel by the ccdecoder
+	// connector after parsing via tetra.ParseChannelType.
+	TETRAChannel string
 }
 
 // Validate returns an error if the System lacks required fields.


### PR DESCRIPTION
## Summary

- Adds `TETRAColourCode uint32` + `TETRAChannel string` to `trunking.System`, plus matching `tetra_colour_code` + `tetra_channel` YAML keys on `config.SystemConfig`, forwarded through `cmd/gophertrunk/daemon.go`
- `ccdecoder.PipelineOptions` now carries the full `trunking.System` so per-protocol factories can read protocol-specific config off it without a new field per protocol
- `newTETRAPipeline` flips `tetra.ControlChannel.SetChannelCoding(ChannelCodingOn)` automatically when `TETRAColourCode` is non-zero, applies the colour code, and routes burst windows through the channel selected by `TETRAChannel` (parsed via the new `tetra.ParseChannelType` helper; empty defaults to `sch/hd`, unknown values warn-log and fall back)
- Adds `ChannelCoding()` / `ExpectedChannel()` / `ColourCode()` getters on `tetra.ControlChannel` for tests + observability

Closes the last gap between the daemon's YAML and the §8.3.1 type-5 → type-1 TETRA decoder shipped in PR #140 — operators set the cell's extended colour code + signaling channel once in `config.yaml` and the connector turns channel coding on automatically on every retune.

## Test plan

- [x] `go test ./...` clean (61 packages)
- [x] `go vet ./...` clean
- [x] New `TestParseChannelType` covers every recognised string (case-insensitive, "/" + "_" both accepted, empty = SCH/HD, unknown returns `(SCHHD, false)`)
- [x] New `TestTETRAFactoryEnablesChannelCodingFromSystem` — populated `trunking.System` → `ChannelCoding=On`, `ExpectedChannel=SCH/F`, `ColourCode=0x12345`
- [x] New `TestTETRAFactoryDefaultColourCodeKeepsCodingOff` — zero colour code preserves legacy raw-dibit path

https://claude.ai/code/session_019dtCCVEZJTKKr6YK3wy824

---
_Generated by [Claude Code](https://claude.ai/code/session_019dtCCVEZJTKKr6YK3wy824)_