### PR TITLE
internal/scanner/ccdecoder: thread LTR FCS + Manchester modes from trunking.System

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,45 @@ to its own package and lands independently.
 
 ### Recently shipped
 
+- **`ccdecoder` connector threads LTR FCS + Manchester modes
+  from per-system config.** Same pattern as the TETRA wiring in
+  PR #141 — operators set `ltr_fcs_mode` + `ltr_manchester_mode`
+  once in `config.yaml` and the `newLTRPipeline` factory calls
+  `ltr.ControlChannel.SetFCSMode` / `SetManchesterMode` before
+  any sample flows. Both `ltr.ControlChannel` primitives have
+  shipped for a while (CRC-7 FCS check against sdrtrunk's
+  CRCLTR.java layout, Manchester decode with strict / soft
+  variants); this PR flips them on under config control.
+  - `trunking.System` gains `LTRFCSMode string` + `LTRManchesterMode
+    string`; `config.SystemConfig` exposes them as
+    `ltr_fcs_mode` (recognises `"off"` / `"on"`) +
+    `ltr_manchester_mode` (recognises `"off"` / `"nrz"` /
+    `"strict"` / `"soft"`, all case-insensitive with whitespace
+    tolerated).
+  - `ltr.ParseFCSMode` + `ltr.ParseManchesterMode` map the
+    YAML string into the typed mode; unknown values warn-log
+    and fall back to the legacy off / NRZ default rather than
+    failing the retune.
+  - `ltr.ControlChannel.FCSMode` + `ManchesterMode` accessors
+    mirror the TETRA pattern so tests + observability code can
+    introspect configured state without poking at unexported
+    fields.
+  - Empty strings preserve the legacy `FCSOff` + `ManchesterOff`
+    raw-NRZ path so existing synthesized-fixture tests stay
+    green. Live captures of sub-audible LTR signaling typically
+    need `ltr_manchester_mode: soft` + `ltr_fcs_mode: on` to
+    pass the CRC.
+  Tests cover the config-string parsers across every recognised
+  value (plus a misconfigured-input case), the factory applying
+  both modes when the System carries non-empty strings, and the
+  factory preserving the legacy modes when both strings are
+  empty. The connector now configures every protocol whose
+  control-channel state machine has a tunable on-air FEC layer
+  (TETRA channel coding, LTR FCS + Manchester); per-protocol
+  FEC wiring for NXDN CAC / EDACS CCW / P25 Phase 2 trellis
+  remains the next code work, gated on the public-references
+  question (NXDN CAC interleave / puncture isn't documented
+  in the public spec).
 - **`ccdecoder` connector threads TETRA channel coding from
   per-system config.** Closes the last gap between the
   daemon's YAML and the §8.3.1 type-5 → type-1 decoder

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -116,11 +116,13 @@ func NewDaemon(cfg config.Config, version string, log *slog.Logger) (*Daemon, er
 			return nil, fmt.Errorf("daemon: %w", err)
 		}
 		s := trunking.System{
-			Name:            sys.Name,
-			Protocol:        proto,
-			ControlChannels: sys.ControlChannels,
-			TETRAColourCode: sys.TETRAColourCode,
-			TETRAChannel:    sys.TETRAChannel,
+			Name:              sys.Name,
+			Protocol:          proto,
+			ControlChannels:   sys.ControlChannels,
+			TETRAColourCode:   sys.TETRAColourCode,
+			TETRAChannel:      sys.TETRAChannel,
+			LTRFCSMode:        sys.LTRFCSMode,
+			LTRManchesterMode: sys.LTRManchesterMode,
 		}
 		if err := s.Validate(); err != nil {
 			return nil, fmt.Errorf("daemon: system %q: %w", sys.Name, err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -118,6 +118,23 @@ type SystemConfig struct {
 	// defaults to "sch/hd" — the standard signaling channel for
 	// cc.locked / Grant events. Ignored for non-TETRA protocols.
 	TETRAChannel string `yaml:"tetra_channel"`
+
+	// LTRFCSMode enables the CRC-7 FCS check on the LTR Status
+	// Ingest path. Recognised values: "" / "off" (default,
+	// no verification — matches pre-PR #40 behaviour) or
+	// "on" / "true" (drop Status words whose FCS trailer doesn't
+	// match). Useful when the upstream framing layer has populated
+	// Status.FCS from the on-air bits and the operator wants to
+	// filter out corrupted frames. Ignored for non-LTR protocols.
+	LTRFCSMode string `yaml:"ltr_fcs_mode"`
+	// LTRManchesterMode controls Manchester decoding of the
+	// sub-audible LTR bit stream. Recognised values: "" / "off" /
+	// "nrz" (raw NRZ, default — matches the synthesized-fixture
+	// path), "strict" (require a mid-bit transition per pair,
+	// drop transition-less pairs), "soft" / "on" (majority-decode,
+	// tolerate noise bursts). Live captures of sub-audible LTR
+	// signaling should set "soft". Ignored for non-LTR protocols.
+	LTRManchesterMode string `yaml:"ltr_manchester_mode"`
 }
 
 // APIConfig controls the HTTP REST + SSE + WebSocket and gRPC servers.

--- a/internal/radio/ltr/control.go
+++ b/internal/radio/ltr/control.go
@@ -2,6 +2,7 @@ package ltr
 
 import (
 	"log/slog"
+	"strings"
 	"sync"
 	"time"
 
@@ -97,6 +98,57 @@ func (c *ControlChannel) SetFCSMode(mode FCSMode) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.fcsMode = mode
+}
+
+// FCSMode returns the current FCSMode. Mirrors the Set* family so
+// callers (and tests) can introspect the configured mode without
+// poking at unexported state.
+func (c *ControlChannel) FCSMode() FCSMode {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.fcsMode
+}
+
+// ManchesterMode returns the configured Manchester decode mode.
+func (c *ControlChannel) ManchesterMode() ManchesterDecodeMode {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.manchesterMode
+}
+
+// ParseFCSMode maps a config / user-facing string into an FCSMode.
+// Recognised values (case-insensitive): "" / "off" → FCSOff (the
+// pre-PR #40 behaviour, no CRC check), "on" / "true" → FCSOn.
+// Unknown strings return FCSOff with `ok = false` so callers can
+// surface the misconfiguration.
+func ParseFCSMode(s string) (FCSMode, bool) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "", "off", "false", "0":
+		return FCSOff, true
+	case "on", "true", "1":
+		return FCSOn, true
+	default:
+		return FCSOff, false
+	}
+}
+
+// ParseManchesterMode maps a config / user-facing string into a
+// ManchesterDecodeMode. Recognised values (case-insensitive):
+// "" / "off" / "nrz" → ManchesterOff (raw NRZ), "strict" →
+// ManchesterStrict (drop transition-less pairs), "soft" / "on" →
+// ManchesterSoft (majority-decode + tolerate noise bursts).
+// Unknown strings return ManchesterOff with `ok = false`.
+func ParseManchesterMode(s string) (ManchesterDecodeMode, bool) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "", "off", "nrz":
+		return ManchesterOff, true
+	case "strict":
+		return ManchesterStrict, true
+	case "soft", "on":
+		return ManchesterSoft, true
+	default:
+		return ManchesterOff, false
+	}
 }
 
 // SetStrictValidation toggles the strict frame-validity filter on the

--- a/internal/radio/ltr/fcs_test.go
+++ b/internal/radio/ltr/fcs_test.go
@@ -137,13 +137,91 @@ func TestSetFCSModeDefault(t *testing.T) {
 	if cc.fcsMode != FCSOff {
 		t.Errorf("default fcsMode = %v, want FCSOff", cc.fcsMode)
 	}
+	if got := cc.FCSMode(); got != FCSOff {
+		t.Errorf("FCSMode() = %v, want FCSOff", got)
+	}
 	cc.SetFCSMode(FCSOn)
 	if cc.fcsMode != FCSOn {
 		t.Errorf("SetFCSMode(FCSOn) did not take effect")
 	}
+	if got := cc.FCSMode(); got != FCSOn {
+		t.Errorf("FCSMode() = %v, want FCSOn", got)
+	}
 	cc.SetFCSMode(FCSOff)
 	if cc.fcsMode != FCSOff {
 		t.Errorf("SetFCSMode(FCSOff) did not take effect")
+	}
+}
+
+// TestParseFCSMode covers the config-string → FCSMode mapping the
+// ccdecoder connector uses to translate the `ltr_fcs_mode` YAML
+// field into a SetFCSMode call.
+func TestParseFCSMode(t *testing.T) {
+	cases := []struct {
+		in   string
+		want FCSMode
+		ok   bool
+	}{
+		{"", FCSOff, true},
+		{"off", FCSOff, true},
+		{"OFF", FCSOff, true},
+		{"false", FCSOff, true},
+		{"0", FCSOff, true},
+		{"on", FCSOn, true},
+		{"ON", FCSOn, true},
+		{"true", FCSOn, true},
+		{"1", FCSOn, true},
+		{" on ", FCSOn, true}, // whitespace tolerated
+		{"nonsense", FCSOff, false},
+	}
+	for _, tc := range cases {
+		got, ok := ParseFCSMode(tc.in)
+		if got != tc.want || ok != tc.ok {
+			t.Errorf("ParseFCSMode(%q) = (%v, %v), want (%v, %v)",
+				tc.in, got, ok, tc.want, tc.ok)
+		}
+	}
+}
+
+// TestParseManchesterMode covers the config-string →
+// ManchesterDecodeMode mapping for `ltr_manchester_mode`.
+func TestParseManchesterMode(t *testing.T) {
+	cases := []struct {
+		in   string
+		want ManchesterDecodeMode
+		ok   bool
+	}{
+		{"", ManchesterOff, true},
+		{"off", ManchesterOff, true},
+		{"nrz", ManchesterOff, true},
+		{"NRZ", ManchesterOff, true},
+		{"strict", ManchesterStrict, true},
+		{"Strict", ManchesterStrict, true},
+		{"soft", ManchesterSoft, true},
+		{"on", ManchesterSoft, true},
+		{"Soft", ManchesterSoft, true},
+		{" strict ", ManchesterStrict, true},
+		{"nonsense", ManchesterOff, false},
+	}
+	for _, tc := range cases {
+		got, ok := ParseManchesterMode(tc.in)
+		if got != tc.want || ok != tc.ok {
+			t.Errorf("ParseManchesterMode(%q) = (%v, %v), want (%v, %v)",
+				tc.in, got, ok, tc.want, tc.ok)
+		}
+	}
+}
+
+// TestManchesterModeAccessor mirrors TestSetFCSModeDefault for the
+// Manchester mode getter.
+func TestManchesterModeAccessor(t *testing.T) {
+	cc := New(Options{Bus: events.NewBus(1)})
+	if got := cc.ManchesterMode(); got != ManchesterOff {
+		t.Errorf("default ManchesterMode() = %v, want ManchesterOff", got)
+	}
+	cc.SetManchesterMode(ManchesterSoft)
+	if got := cc.ManchesterMode(); got != ManchesterSoft {
+		t.Errorf("ManchesterMode() = %v, want ManchesterSoft", got)
 	}
 }
 

--- a/internal/scanner/ccdecoder/decoder_test.go
+++ b/internal/scanner/ccdecoder/decoder_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/ltr"
 	"github.com/MattCheramie/GopherTrunk/internal/radio/tetra"
 	"github.com/MattCheramie/GopherTrunk/internal/trunking"
 )
@@ -408,6 +409,62 @@ func TestLTRFactoryConstructs(t *testing.T) {
 	p.Reset()
 	if err := p.Close(); err != nil {
 		t.Errorf("Close: %v", err)
+	}
+}
+
+// TestLTRFactoryAppliesFCSAndManchesterFromSystem: when the
+// trunking.System carries LTRFCSMode + LTRManchesterMode strings,
+// the factory must parse them and apply them to the underlying
+// ControlChannel.
+func TestLTRFactoryAppliesFCSAndManchesterFromSystem(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	p, err := newLTRPipeline(PipelineOptions{
+		Bus: bus, SystemName: "Test", FrequencyHz: 935_012_500,
+		SampleRateHz: 48_000,
+		System: trunking.System{
+			Name: "Test", Protocol: trunking.ProtocolLTR,
+			ControlChannels:   []uint32{935_012_500},
+			LTRFCSMode:        "on",
+			LTRManchesterMode: "soft",
+		},
+	})
+	if err != nil {
+		t.Fatalf("newLTRPipeline: %v", err)
+	}
+	lp := p.(*ltrPipeline)
+	if got := lp.cc.FCSMode(); got != ltr.FCSOn {
+		t.Errorf("FCSMode = %v, want FCSOn", got)
+	}
+	if got := lp.cc.ManchesterMode(); got != ltr.ManchesterSoft {
+		t.Errorf("ManchesterMode = %v, want ManchesterSoft", got)
+	}
+}
+
+// TestLTRFactoryDefaultsKeepLegacyModes: empty LTRFCSMode +
+// LTRManchesterMode preserve the legacy FCSOff + ManchesterOff
+// path so existing synthesized-fixture tests stay green.
+func TestLTRFactoryDefaultsKeepLegacyModes(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	p, err := newLTRPipeline(PipelineOptions{
+		Bus: bus, SystemName: "Test", FrequencyHz: 935_012_500,
+		SampleRateHz: 48_000,
+		System: trunking.System{
+			Name: "Test", Protocol: trunking.ProtocolLTR,
+			ControlChannels: []uint32{935_012_500},
+			// LTRFCSMode + LTRManchesterMode left empty.
+		},
+	})
+	if err != nil {
+		t.Fatalf("newLTRPipeline: %v", err)
+	}
+	lp := p.(*ltrPipeline)
+	if got := lp.cc.FCSMode(); got != ltr.FCSOff {
+		t.Errorf("FCSMode = %v, want FCSOff", got)
+	}
+	if got := lp.cc.ManchesterMode(); got != ltr.ManchesterOff {
+		t.Errorf("ManchesterMode = %v, want ManchesterOff", got)
 	}
 }
 

--- a/internal/scanner/ccdecoder/pipelines.go
+++ b/internal/scanner/ccdecoder/pipelines.go
@@ -418,8 +418,18 @@ func (p *motorolaPipeline) Close() error            { return nil }
 // sub-audible bits into the state machine, which slides a 41-bit
 // window across the stream, commits to the first Sync=1 alignment
 // it finds, and dispatches each Status word into the existing
-// Ingest path. FCS validation + Manchester decoding are
-// follow-ups.
+// Ingest path.
+//
+// FCS verification + Manchester decoding are gated on per-system
+// config: trunking.System.LTRFCSMode and LTRManchesterMode (the
+// `ltr_fcs_mode` + `ltr_manchester_mode` YAML keys) flip the
+// corresponding modes on the ControlChannel before any sample
+// flows. Empty strings preserve the legacy raw-NRZ + no-CRC path
+// so existing synthesized-fixture tests stay green; live captures
+// of sub-audible LTR signaling typically need
+// `ltr_manchester_mode: soft` + `ltr_fcs_mode: on`. Unknown values
+// warn-log and fall back to the off / NRZ default rather than
+// failing the retune.
 func newLTRPipeline(opts PipelineOptions) (ProtocolPipeline, error) {
 	cc := ltr.New(ltr.Options{
 		Bus:         opts.Bus,
@@ -427,6 +437,22 @@ func newLTRPipeline(opts PipelineOptions) (ProtocolPipeline, error) {
 		SystemName:  opts.SystemName,
 		FrequencyHz: opts.FrequencyHz,
 	})
+	if v := opts.System.LTRFCSMode; v != "" {
+		mode, ok := ltr.ParseFCSMode(v)
+		if !ok {
+			opts.Log.Warn("ccdecoder: unrecognised ltr_fcs_mode; falling back to off",
+				"system", opts.SystemName, "value", v)
+		}
+		cc.SetFCSMode(mode)
+	}
+	if v := opts.System.LTRManchesterMode; v != "" {
+		mode, ok := ltr.ParseManchesterMode(v)
+		if !ok {
+			opts.Log.Warn("ccdecoder: unrecognised ltr_manchester_mode; falling back to off",
+				"system", opts.SystemName, "value", v)
+		}
+		cc.SetManchesterMode(mode)
+	}
 	rx := ltrrx.New(ltrrx.Options{
 		SampleRateHz: opts.SampleRateHz,
 		BitSink: func(bits []byte, baseIdx int) {

--- a/internal/trunking/site.go
+++ b/internal/trunking/site.go
@@ -110,6 +110,26 @@ type System struct {
 	// tetra.ControlChannel.SetExpectedChannel by the ccdecoder
 	// connector after parsing via tetra.ParseChannelType.
 	TETRAChannel string
+
+	// LTRFCSMode enables CRC-7 FCS verification on the LTR Status
+	// Ingest path (per DSheirer/sdrtrunk's CRCLTR.java layout).
+	// Recognised values (case-insensitive): "" / "off" — no
+	// verification (default, pre-PR #40 behaviour); "on" / "true" —
+	// drop Status words whose 7-bit FCS trailer doesn't match the
+	// CRC over the 24-bit message vector. Forwarded into
+	// ltr.ControlChannel.SetFCSMode by the ccdecoder connector
+	// after parsing via ltr.ParseFCSMode.
+	LTRFCSMode string
+	// LTRManchesterMode controls Manchester decoding of the LTR
+	// sub-audible bit stream. Recognised values (case-insensitive):
+	// "" / "off" / "nrz" — raw NRZ (default, in-package tests);
+	// "strict" — require a mid-bit transition per pair, drop
+	// transition-less pairs; "soft" / "on" — majority-decode each
+	// pair and tolerate noise bursts. Live captures of sub-audible
+	// LTR signaling should use "soft" (the dominant on-air encoding).
+	// Forwarded into ltr.ControlChannel.SetManchesterMode by the
+	// ccdecoder connector after parsing via ltr.ParseManchesterMode.
+	LTRManchesterMode string
 }
 
 // Validate returns an error if the System lacks required fields.


### PR DESCRIPTION
## Summary

- Adds `LTRFCSMode string` + `LTRManchesterMode string` to `trunking.System`, plus matching `ltr_fcs_mode` + `ltr_manchester_mode` YAML keys on `config.SystemConfig`, forwarded through `cmd/gophertrunk/daemon.go`
- `newLTRPipeline` parses both strings via the new `ltr.ParseFCSMode` / `ltr.ParseManchesterMode` helpers and calls `ltr.ControlChannel.SetFCSMode` / `SetManchesterMode` before any sample flows
- Adds `FCSMode()` / `ManchesterMode()` getters on `ltr.ControlChannel` for tests + observability (mirrors the TETRA accessors shipped in PR #141)

Both LTR primitives — the CRC-7 FCS check against sdrtrunk's CRCLTR.java layout and the strict / soft Manchester decoders — have shipped for a while. This PR flips them on under per-system config control. Live captures of sub-audible LTR signaling typically need `ltr_manchester_mode: soft` + `ltr_fcs_mode: on` to pass the CRC; empty strings preserve the legacy `FCSOff` + `ManchesterOff` raw-NRZ path so existing synthesized-fixture tests stay green.

## Test plan

- [x] `go test ./...` clean (all packages)
- [x] `go vet ./...` clean
- [x] `TestParseFCSMode` — covers `""` / `off` / `on` / `true` / `1` / whitespace / nonsense
- [x] `TestParseManchesterMode` — covers `""` / `off` / `nrz` / `strict` / `soft` / `on` / whitespace / nonsense
- [x] `TestManchesterModeAccessor` — getter mirrors `SetManchesterMode`
- [x] `TestSetFCSModeDefault` extended to exercise the new `FCSMode()` getter
- [x] `TestLTRFactoryAppliesFCSAndManchesterFromSystem` — populated `trunking.System` → `FCSOn` + `ManchesterSoft`
- [x] `TestLTRFactoryDefaultsKeepLegacyModes` — empty strings preserve `FCSOff` + `ManchesterOff`

## Followup

Per-protocol FEC wiring for NXDN CAC / EDACS CCW / P25 Phase 2 trellis remains the next code work. NXDN CAC interleave + puncture is blocked on data that isn't in the published NXDN spec; need a captured frame or a reference implementation's tables.

https://claude.ai/code/session_019dtCCVEZJTKKr6YK3wy824

---
_Generated by [Claude Code](https://claude.ai/code/session_019dtCCVEZJTKKr6YK3wy824)_