### PR TITLE
ccdecoder threads remaining per-protocol FEC opt-ins + TUI Settings panel surfaces them

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,34 @@ to its own package and lands independently.
 
 ### Recently shipped
 
+- **TUI Settings panel + README FEC opt-ins reference.** The
+  11th TUI panel (`Tab` past Scanner) renders each configured
+  system with a one-line summary of its FEC opt-in state across
+  every protocol that has a public-spec FEC chain — TETRA channel
+  coding, LTR FCS + Manchester, P25 Phase 2 trellis, NXDN
+  Viterbi, EDACS + MPT 1327 BCH. The panel reads the new opt-in
+  fields off `/api/v1/systems`' per-system DTO; the API
+  `SystemDTO` was extended to expose every opt-in flag as an
+  `omitempty` JSON value, and the client mirror picks them up
+  without further plumbing.
+
+  The panel is read-only; the bottom-line hint says "Edit
+  config.yaml + restart daemon to change", which matches the
+  existing wiring (opt-ins flow `SystemConfig` →
+  `trunking.System` → `ccdecoder.PipelineFactory` at construction
+  / on each `HuntProgress` retune). Runtime mutation is a future
+  follow-up that requires a PATCH endpoint + daemon-side
+  reconfig of active pipelines.
+
+  README gained an "FEC opt-ins" section with a table covering
+  every YAML key, its default behaviour, and what the on-path
+  unlocks. Each protocol's `ControlChannel` also picked up
+  matching getters (`tetra.ChannelCoding()` / `ExpectedChannel()`
+  / `ColourCode()`, `ltr.FCSMode()` / `ManchesterMode()`,
+  `p25phase2.TrellisMode()`, `nxdn.ViterbiMode()`,
+  `edacs.BCHMode()`, `mpt1327.BCHMode()`) — the TUI uses them
+  indirectly through the DTO; tests + observability code use
+  them directly.
 - **`ccdecoder` connector threads the remaining per-protocol
   FEC opt-ins from per-system config.** Closes out the
   connector-side FEC wiring for every protocol whose
@@ -1152,7 +1180,7 @@ gophertrunk tui -no-color          # disable ANSI colour
 gophertrunk tui -insecure          # skip TLS verification
 ```
 
-Ten panels covering every read surface plus the operator scanner
+Eleven panels covering every read surface plus the operator scanner
 cockpit, vim-style navigation, live SSE event stream, periodic REST
 refresh, automatic reconnect on disconnect:
 
@@ -1179,6 +1207,52 @@ hold/resume/retune/dwell + scan_mode flip) start the daemon with
 `api.allow_mutations: true` and the TUI with `--write`. Both ends
 gate independently because the HTTP API has no authentication.
 See [`docs/tui.md`](docs/tui.md) for the full reference.
+
+## FEC opt-ins
+
+Every protocol that has a public-spec FEC chain ships the chain as
+an **opt-in**: the connector constructs each `ControlChannel` in
+its legacy raw-bit mode by default and only flips on the FEC layer
+when the operator sets a per-system key in `config.yaml`. Empty /
+absent keys preserve the legacy path so the synthesized-fixture
+tests stay green and operators with pre-stripped capture files
+(DSD-FME `-r` dumps, OP25 fixtures) don't see surprise CRC
+failures.
+
+Verify which opt-ins are active by opening the **Settings** panel
+in the TUI — it lists every configured system with a one-line
+summary of its FEC opt-in state (`channel coding: on (colour=…,
+sch/f)`, `viterbi: off`, `bch: on`, etc.). The panel is read-only;
+runtime mutation is a future PR. To change a mode, edit
+`config.yaml` and restart the daemon.
+
+| Protocol | YAML key(s) | Off (default) | On |
+| --- | --- | --- | --- |
+| TETRA | `tetra_colour_code` (uint32, low 30 bits), `tetra_channel` (`"sch/hd"` / `"sch/f"` / `"sch/hu"` / `"bsch"` / `"aach"`, default `sch/hd`) | Legacy 48-dibit raw-PDU path. CRC fails on live captures. | Full ETSI EN 300 392-2 §8.3.1 type-5 → type-1 chain (descramble + deinterleave + depuncture + Viterbi + CRC-16 verify + tail strip) per burst. Non-zero `tetra_colour_code` flips it on. |
+| LTR | `ltr_fcs_mode` (`""` / `"off"` / `"on"`), `ltr_manchester_mode` (`""` / `"off"` / `"nrz"` / `"strict"` / `"soft"`) | NRZ Status bits, no FCS verification. Matches synthesized-fixture path. | CRC-7 FCS check against sdrtrunk's CRCLTR.java layout (`on`) and/or Manchester decode of sub-audible signaling (`soft` = majority decode, `strict` = require mid-bit transition). Live sub-audible captures typically need `manchester: soft` + `fcs: on`. |
+| P25 Phase 2 | `p25_phase2_trellis_mode` (`""` / `"off"` / `"on"`) | Legacy 72-dibit raw-MAC-PDU path. | 4-state ½-rate trellis FEC over the MAC PDU window (146 channel dibits → 72 info dibits per TIA-102.AABF). |
+| NXDN | `nxdn_viterbi_mode` (`""` / `"off"` / `"on"`) | Legacy 44-dibit raw-CAC path. | K=5 ½-rate Viterbi over the CAC region (92 dibits → 88 info bits + 4 tail zeros per MMDVMHost's `NXDNConvolution`). NXDN CAC interleave / puncture remains a follow-up (not in the public spec). |
+| EDACS | `edacs_bch_mode` (`""` / `"off"` / `"on"`) | Legacy pre-stripped 40-bit CCW; payload struct's LCN bit 0 + Aux fields are data. | BCH(40, 28, 2) with single/double-bit correction over the 40-bit on-wire CCW; under `on` the effective CCW carries 28 info bits (Command + Status + Address + high LCN bits), the remaining bits become BCH parity. |
+| MPT 1327 | `mpt1327_bch_mode` (`""` / `"off"` / `"on"`) | Legacy 38-bit pre-stripped codeword. | BCH(63, 38) decode over the 64-bit on-wire codeword. |
+
+All string values are case-insensitive with whitespace tolerated;
+recognised on-values include `"on"` / `"true"` / `"1"`, off-values
+`""` / `"off"` / `"false"` / `"0"`. Unrecognised values fall back
+to off with a `warn`-level log line ("ccdecoder: unrecognised
+`<key>`; falling back to off") so a typo doesn't silently break
+the decoder.
+
+Each protocol's `ControlChannel` exposes matching getters
+(`tetra.ControlChannel.ChannelCoding()` / `ExpectedChannel()` /
+`ColourCode()`, `ltr.ControlChannel.FCSMode()` / `ManchesterMode()`,
+`p25phase2.ControlChannel.TrellisMode()`,
+`nxdn.ControlChannel.ViterbiMode()`,
+`edacs.ControlChannel.BCHMode()`,
+`mpt1327.ControlChannel.BCHMode()`) so tests + observability code
+can introspect the configured state without poking at unexported
+fields. The TUI Settings panel reads these via the
+`/api/v1/systems` endpoint's per-system DTO, which carries every
+opt-in field as a `omitempty` JSON value.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -199,6 +199,45 @@ to its own package and lands independently.
 
 ### Recently shipped
 
+- **`ccdecoder` connector threads the remaining per-protocol
+  FEC opt-ins from per-system config.** Closes out the
+  connector-side FEC wiring for every protocol whose
+  ControlChannel exposes a tunable on-air FEC layer. Same
+  pattern as PRs #141 (TETRA channel coding) and #142 (LTR
+  FCS + Manchester) — operators set one YAML key per
+  protocol and the matching pipeline factory turns the FEC
+  layer on automatically:
+    - `p25_phase2_trellis_mode: on` → `SetTrellisMode(TrellisOn)`
+      on the 4-state ½-rate trellis decoder over P25 Phase 2
+      MAC PDUs (146 channel dibits → 72 info dibits per
+      TIA-102.AABF).
+    - `nxdn_viterbi_mode: on` → `SetViterbiMode(ViterbiOn)`
+      on the K=5 ½-rate Viterbi decoder over the NXDN CAC
+      region (92 dibits → 88 info bits + 4 tail zeros per
+      MMDVMHost's NXDNConvolution).
+    - `edacs_bch_mode: on` → `SetBCHMode(BCHOn)` on the
+      BCH(40, 28, 2) decoder over the EDACS CCW (generator
+      0x1539, single/double-bit correction).
+    - `mpt1327_bch_mode: on` → `SetBCHMode(BCHOn)` on the
+      BCH(63, 38) decoder over the MPT 1327 codeword
+      (64-bit on-wire → 38 info bits + 26 parity).
+  Each protocol also gains a `ParseXxxMode` helper +
+  `XxxMode()` accessor mirroring the TETRA / LTR pattern
+  shipped in PR #141 / #142 so tests + observability code
+  can introspect configured state. Empty strings preserve
+  the legacy raw-bit path across all four protocols so
+  existing synthesized-fixture tests stay green. Unknown
+  values warn-log and fall back to the off default rather
+  than failing the retune.
+
+  With this PR, the only connector wiring that remains is
+  protocol-by-protocol on-air interleaver / puncture
+  layers for protocols whose public specs don't fully
+  document them (NXDN CAC interleave / puncture, EDACS
+  CCW interleaved RS-derived FEC layer above the BCH).
+  The plain "lights up live trunked reception" path is now
+  unblocked end-to-end across every protocol whose CC
+  state machine + FEC chain has a public reference.
 - **`ccdecoder` connector threads LTR FCS + Manchester modes
   from per-system config.** Same pattern as the TETRA wiring in
   PR #141 — operators set `ltr_fcs_mode` + `ltr_manchester_mode`

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -116,13 +116,17 @@ func NewDaemon(cfg config.Config, version string, log *slog.Logger) (*Daemon, er
 			return nil, fmt.Errorf("daemon: %w", err)
 		}
 		s := trunking.System{
-			Name:              sys.Name,
-			Protocol:          proto,
-			ControlChannels:   sys.ControlChannels,
-			TETRAColourCode:   sys.TETRAColourCode,
-			TETRAChannel:      sys.TETRAChannel,
-			LTRFCSMode:        sys.LTRFCSMode,
-			LTRManchesterMode: sys.LTRManchesterMode,
+			Name:                 sys.Name,
+			Protocol:             proto,
+			ControlChannels:      sys.ControlChannels,
+			TETRAColourCode:      sys.TETRAColourCode,
+			TETRAChannel:         sys.TETRAChannel,
+			LTRFCSMode:           sys.LTRFCSMode,
+			LTRManchesterMode:    sys.LTRManchesterMode,
+			P25Phase2TrellisMode: sys.P25Phase2TrellisMode,
+			NXDNViterbiMode:      sys.NXDNViterbiMode,
+			EDACSBCHMode:         sys.EDACSBCHMode,
+			MPT1327BCHMode:       sys.MPT1327BCHMode,
 		}
 		if err := s.Validate(); err != nil {
 			return nil, fmt.Errorf("daemon: system %q: %w", sys.Name, err)

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -25,17 +25,40 @@ type SystemDTO struct {
 	SystemID        uint16   `json:"system_id,omitempty"`
 	RFSS            uint8    `json:"rfss,omitempty"`
 	Site            uint8    `json:"site,omitempty"`
+
+	// Per-protocol FEC opt-in surface. Empty strings / zero
+	// TETRAColourCode indicate the legacy raw-bit path is active
+	// for that protocol. The TUI Settings panel renders these so
+	// operators can verify their config landed; runtime mutation
+	// is a follow-up (currently requires editing config.yaml +
+	// restarting the daemon).
+	TETRAColourCode      uint32 `json:"tetra_colour_code,omitempty"`
+	TETRAChannel         string `json:"tetra_channel,omitempty"`
+	LTRFCSMode           string `json:"ltr_fcs_mode,omitempty"`
+	LTRManchesterMode    string `json:"ltr_manchester_mode,omitempty"`
+	P25Phase2TrellisMode string `json:"p25_phase2_trellis_mode,omitempty"`
+	NXDNViterbiMode      string `json:"nxdn_viterbi_mode,omitempty"`
+	EDACSBCHMode         string `json:"edacs_bch_mode,omitempty"`
+	MPT1327BCHMode       string `json:"mpt1327_bch_mode,omitempty"`
 }
 
 func systemToDTO(s trunking.System) SystemDTO {
 	return SystemDTO{
-		Name:            s.Name,
-		Protocol:        s.Protocol.String(),
-		ControlChannels: append([]uint32(nil), s.ControlChannels...),
-		WACN:            s.WACN,
-		SystemID:        s.SystemID,
-		RFSS:            s.RFSS,
-		Site:            s.Site,
+		Name:                 s.Name,
+		Protocol:             s.Protocol.String(),
+		ControlChannels:      append([]uint32(nil), s.ControlChannels...),
+		WACN:                 s.WACN,
+		SystemID:             s.SystemID,
+		RFSS:                 s.RFSS,
+		Site:                 s.Site,
+		TETRAColourCode:      s.TETRAColourCode,
+		TETRAChannel:         s.TETRAChannel,
+		LTRFCSMode:           s.LTRFCSMode,
+		LTRManchesterMode:    s.LTRManchesterMode,
+		P25Phase2TrellisMode: s.P25Phase2TrellisMode,
+		NXDNViterbiMode:      s.NXDNViterbiMode,
+		EDACSBCHMode:         s.EDACSBCHMode,
+		MPT1327BCHMode:       s.MPT1327BCHMode,
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -135,6 +135,34 @@ type SystemConfig struct {
 	// tolerate noise bursts). Live captures of sub-audible LTR
 	// signaling should set "soft". Ignored for non-LTR protocols.
 	LTRManchesterMode string `yaml:"ltr_manchester_mode"`
+
+	// P25Phase2TrellisMode enables the 4-state ½-rate trellis FEC
+	// decoder on the P25 Phase 2 MAC PDU window. Recognised values:
+	// "" / "off" (default, legacy 72-dibit raw-MAC-PDU path) or
+	// "on" (146 channel dibits via the TIA-102.AABF trellis
+	// decoder). Live P25 Phase 2 captures need "on" to recover
+	// MAC PDUs through the FEC layer. Ignored for non-P25-Phase-2
+	// protocols.
+	P25Phase2TrellisMode string `yaml:"p25_phase2_trellis_mode"`
+	// NXDNViterbiMode enables the K=5 ½-rate Viterbi FEC decoder
+	// on the NXDN CAC region. Recognised values: "" / "off"
+	// (default, legacy raw-CAC path) or "on" (92 dibits via the
+	// K=5 Viterbi decoder). Live NXDN CAC captures need "on" to
+	// recover the CAC through its FEC. Ignored for non-NXDN
+	// protocols.
+	NXDNViterbiMode string `yaml:"nxdn_viterbi_mode"`
+	// EDACSBCHMode enables the BCH(40, 28, 2) FEC layer on the
+	// EDACS CCW. Recognised values: "" / "off" (default, legacy
+	// pre-stripped 40-bit CCW) or "on" (40-bit on-wire BCH decode
+	// with single/double-bit correction). Live EDACS CCW captures
+	// should set "on". Ignored for non-EDACS protocols.
+	EDACSBCHMode string `yaml:"edacs_bch_mode"`
+	// MPT1327BCHMode enables the BCH(63, 38) FEC layer on the MPT
+	// 1327 codeword. Recognised values: "" / "off" (default, legacy
+	// 38-bit pre-stripped codeword) or "on" (64-bit on-wire BCH
+	// decode). Live MPT 1327 captures should set "on". Ignored for
+	// non-MPT-1327 protocols.
+	MPT1327BCHMode string `yaml:"mpt1327_bch_mode"`
 }
 
 // APIConfig controls the HTTP REST + SSE + WebSocket and gRPC servers.

--- a/internal/radio/edacs/control.go
+++ b/internal/radio/edacs/control.go
@@ -2,6 +2,7 @@ package edacs
 
 import (
 	"log/slog"
+	"strings"
 	"sync"
 	"time"
 
@@ -85,6 +86,29 @@ func (c *ControlChannel) SetBCHMode(mode BCHMode) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.bchMode = mode
+}
+
+// BCHMode returns the configured BCHMode.
+func (c *ControlChannel) BCHMode() BCHMode {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.bchMode
+}
+
+// ParseBCHMode maps a config / user-facing string into a BCHMode.
+// Recognised values (case-insensitive): "" / "off" / "false" / "0"
+// → BCHOff (legacy pre-stripped 40-bit CCW path); "on" / "true" /
+// "1" → BCHOn (40-bit on-wire BCH(40, 28, 2) decode + 1/2-bit
+// correction). Unknown strings return BCHOff with `ok = false`.
+func ParseBCHMode(s string) (BCHMode, bool) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "", "off", "false", "0":
+		return BCHOff, true
+	case "on", "true", "1":
+		return BCHOn, true
+	default:
+		return BCHOff, false
+	}
 }
 
 // Options configure a ControlChannel.

--- a/internal/radio/edacs/process_bch_test.go
+++ b/internal/radio/edacs/process_bch_test.go
@@ -252,12 +252,47 @@ func TestSetBCHModeDefault(t *testing.T) {
 	if cc.bchMode != BCHOff {
 		t.Errorf("default bchMode = %v, want BCHOff", cc.bchMode)
 	}
+	if got := cc.BCHMode(); got != BCHOff {
+		t.Errorf("BCHMode() = %v, want BCHOff", got)
+	}
 	cc.SetBCHMode(BCHOn)
 	if cc.bchMode != BCHOn {
 		t.Errorf("SetBCHMode(BCHOn) did not take effect")
 	}
+	if got := cc.BCHMode(); got != BCHOn {
+		t.Errorf("BCHMode() = %v, want BCHOn", got)
+	}
 	cc.SetBCHMode(BCHOff)
 	if cc.bchMode != BCHOff {
 		t.Errorf("SetBCHMode(BCHOff) did not take effect")
+	}
+}
+
+// TestParseBCHMode covers the config-string → BCHMode mapping the
+// ccdecoder connector uses to translate the `edacs_bch_mode` YAML
+// field into a SetBCHMode call.
+func TestParseBCHMode(t *testing.T) {
+	cases := []struct {
+		in   string
+		want BCHMode
+		ok   bool
+	}{
+		{"", BCHOff, true},
+		{"off", BCHOff, true},
+		{"false", BCHOff, true},
+		{"0", BCHOff, true},
+		{"on", BCHOn, true},
+		{"ON", BCHOn, true},
+		{"true", BCHOn, true},
+		{"1", BCHOn, true},
+		{" on ", BCHOn, true},
+		{"nonsense", BCHOff, false},
+	}
+	for _, tc := range cases {
+		got, ok := ParseBCHMode(tc.in)
+		if got != tc.want || ok != tc.ok {
+			t.Errorf("ParseBCHMode(%q) = (%v, %v), want (%v, %v)",
+				tc.in, got, ok, tc.want, tc.ok)
+		}
 	}
 }

--- a/internal/radio/mpt1327/control.go
+++ b/internal/radio/mpt1327/control.go
@@ -2,6 +2,7 @@ package mpt1327
 
 import (
 	"log/slog"
+	"strings"
 	"sync"
 	"time"
 
@@ -96,6 +97,29 @@ func (c *ControlChannel) SetBCHMode(mode BCHMode) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.bchMode = mode
+}
+
+// BCHMode returns the configured BCHMode.
+func (c *ControlChannel) BCHMode() BCHMode {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.bchMode
+}
+
+// ParseBCHMode maps a config / user-facing string into a BCHMode.
+// Recognised values (case-insensitive): "" / "off" / "false" / "0"
+// → BCHOff (legacy 38-bit pre-stripped codeword path); "on" /
+// "true" / "1" → BCHOn (64-bit on-wire BCH(63, 38) decode). Unknown
+// strings return BCHOff with `ok = false`.
+func ParseBCHMode(s string) (BCHMode, bool) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "", "off", "false", "0":
+		return BCHOff, true
+	case "on", "true", "1":
+		return BCHOn, true
+	default:
+		return BCHOff, false
+	}
 }
 
 // Options configure a ControlChannel.

--- a/internal/radio/mpt1327/process_bch_test.go
+++ b/internal/radio/mpt1327/process_bch_test.go
@@ -198,13 +198,48 @@ func TestSetBCHModeDefault(t *testing.T) {
 	if cc.bchMode != BCHOff {
 		t.Errorf("default bchMode = %v, want BCHOff", cc.bchMode)
 	}
+	if got := cc.BCHMode(); got != BCHOff {
+		t.Errorf("BCHMode() = %v, want BCHOff", got)
+	}
 	cc.SetBCHMode(BCHOn)
 	if cc.bchMode != BCHOn {
 		t.Errorf("SetBCHMode(BCHOn) did not take effect")
 	}
+	if got := cc.BCHMode(); got != BCHOn {
+		t.Errorf("BCHMode() = %v, want BCHOn", got)
+	}
 	cc.SetBCHMode(BCHOff)
 	if cc.bchMode != BCHOff {
 		t.Errorf("SetBCHMode(BCHOff) did not take effect")
+	}
+}
+
+// TestParseBCHMode covers the config-string → BCHMode mapping the
+// ccdecoder connector uses to translate the `mpt1327_bch_mode`
+// YAML field into a SetBCHMode call.
+func TestParseBCHMode(t *testing.T) {
+	cases := []struct {
+		in   string
+		want BCHMode
+		ok   bool
+	}{
+		{"", BCHOff, true},
+		{"off", BCHOff, true},
+		{"false", BCHOff, true},
+		{"0", BCHOff, true},
+		{"on", BCHOn, true},
+		{"ON", BCHOn, true},
+		{"true", BCHOn, true},
+		{"1", BCHOn, true},
+		{" on ", BCHOn, true},
+		{"nonsense", BCHOff, false},
+	}
+	for _, tc := range cases {
+		got, ok := ParseBCHMode(tc.in)
+		if got != tc.want || ok != tc.ok {
+			t.Errorf("ParseBCHMode(%q) = (%v, %v), want (%v, %v)",
+				tc.in, got, ok, tc.want, tc.ok)
+		}
 	}
 }
 

--- a/internal/radio/nxdn/control.go
+++ b/internal/radio/nxdn/control.go
@@ -2,6 +2,7 @@ package nxdn
 
 import (
 	"log/slog"
+	"strings"
 
 	"github.com/MattCheramie/GopherTrunk/internal/events"
 )
@@ -77,6 +78,30 @@ const (
 // frames don't go through this adapter).
 func (c *ControlChannel) SetViterbiMode(mode ViterbiMode) {
 	c.viterbiMode = mode
+}
+
+// ViterbiMode returns the configured ViterbiMode. Mirrors the
+// Set* family so callers (and tests) can introspect the configured
+// mode without poking at unexported state.
+func (c *ControlChannel) ViterbiMode() ViterbiMode {
+	return c.viterbiMode
+}
+
+// ParseViterbiMode maps a config / user-facing string into a
+// ViterbiMode. Recognised values (case-insensitive): "" / "off" /
+// "false" / "0" → ViterbiOff (the legacy 44-dibit raw-CAC path);
+// "on" / "true" / "1" → ViterbiOn (92 dibits run through the K=5
+// ½-rate Viterbi decoder). Unknown strings return ViterbiOff
+// with `ok = false`.
+func ParseViterbiMode(s string) (ViterbiMode, bool) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "", "off", "false", "0":
+		return ViterbiOff, true
+	case "on", "true", "1":
+		return ViterbiOn, true
+	default:
+		return ViterbiOff, false
+	}
 }
 
 func NewControlChannel(bus *events.Bus, log *slog.Logger, freqHz uint32, rate BaudRate) *ControlChannel {

--- a/internal/radio/nxdn/process_viterbi_test.go
+++ b/internal/radio/nxdn/process_viterbi_test.go
@@ -153,12 +153,47 @@ func TestSetViterbiModeRetainsViterbiOffDefault(t *testing.T) {
 	if cc.viterbiMode != ViterbiOff {
 		t.Errorf("default viterbiMode = %v, want ViterbiOff", cc.viterbiMode)
 	}
+	if got := cc.ViterbiMode(); got != ViterbiOff {
+		t.Errorf("ViterbiMode() = %v, want ViterbiOff", got)
+	}
 	cc.SetViterbiMode(ViterbiOn)
 	if cc.viterbiMode != ViterbiOn {
 		t.Errorf("SetViterbiMode(ViterbiOn) did not take effect")
 	}
+	if got := cc.ViterbiMode(); got != ViterbiOn {
+		t.Errorf("ViterbiMode() = %v, want ViterbiOn", got)
+	}
 	cc.SetViterbiMode(ViterbiOff)
 	if cc.viterbiMode != ViterbiOff {
 		t.Errorf("SetViterbiMode(ViterbiOff) did not take effect")
+	}
+}
+
+// TestParseViterbiMode covers the config-string → ViterbiMode
+// mapping the ccdecoder connector uses to translate the
+// `nxdn_viterbi_mode` YAML field into a SetViterbiMode call.
+func TestParseViterbiMode(t *testing.T) {
+	cases := []struct {
+		in   string
+		want ViterbiMode
+		ok   bool
+	}{
+		{"", ViterbiOff, true},
+		{"off", ViterbiOff, true},
+		{"false", ViterbiOff, true},
+		{"0", ViterbiOff, true},
+		{"on", ViterbiOn, true},
+		{"ON", ViterbiOn, true},
+		{"true", ViterbiOn, true},
+		{"1", ViterbiOn, true},
+		{" on ", ViterbiOn, true},
+		{"nonsense", ViterbiOff, false},
+	}
+	for _, tc := range cases {
+		got, ok := ParseViterbiMode(tc.in)
+		if got != tc.want || ok != tc.ok {
+			t.Errorf("ParseViterbiMode(%q) = (%v, %v), want (%v, %v)",
+				tc.in, got, ok, tc.want, tc.ok)
+		}
 	}
 }

--- a/internal/radio/p25/phase2/control.go
+++ b/internal/radio/p25/phase2/control.go
@@ -2,6 +2,7 @@ package phase2
 
 import (
 	"log/slog"
+	"strings"
 	"sync"
 	"time"
 
@@ -77,6 +78,33 @@ func (c *ControlChannel) SetTrellisMode(mode TrellisMode) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.trellisMode = mode
+}
+
+// TrellisMode returns the current TrellisMode. Mirrors the Set*
+// family so callers (and tests) can introspect the configured
+// mode without poking at unexported state.
+func (c *ControlChannel) TrellisMode() TrellisMode {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.trellisMode
+}
+
+// ParseTrellisMode maps a config / user-facing string into a
+// TrellisMode. Recognised values (case-insensitive): "" / "off" /
+// "false" / "0" → TrellisOff (the legacy 72-dibit raw-MAC-PDU
+// path); "on" / "true" / "1" → TrellisOn (146 channel dibits run
+// through the 4-state ½-rate trellis decoder). Unknown strings
+// return TrellisOff with `ok = false` so callers can surface the
+// misconfiguration.
+func ParseTrellisMode(s string) (TrellisMode, bool) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "", "off", "false", "0":
+		return TrellisOff, true
+	case "on", "true", "1":
+		return TrellisOn, true
+	default:
+		return TrellisOff, false
+	}
 }
 
 // SetStrictValidation toggles the strict frame-validity filter on the

--- a/internal/radio/p25/phase2/process_trellis_test.go
+++ b/internal/radio/p25/phase2/process_trellis_test.go
@@ -170,12 +170,48 @@ func TestSetTrellisModeDefault(t *testing.T) {
 	if cc.trellisMode != TrellisOff {
 		t.Errorf("default trellisMode = %v, want TrellisOff", cc.trellisMode)
 	}
+	if got := cc.TrellisMode(); got != TrellisOff {
+		t.Errorf("TrellisMode() = %v, want TrellisOff", got)
+	}
 	cc.SetTrellisMode(TrellisOn)
 	if cc.trellisMode != TrellisOn {
 		t.Errorf("SetTrellisMode(TrellisOn) did not take effect")
 	}
+	if got := cc.TrellisMode(); got != TrellisOn {
+		t.Errorf("TrellisMode() = %v, want TrellisOn", got)
+	}
 	cc.SetTrellisMode(TrellisOff)
 	if cc.trellisMode != TrellisOff {
 		t.Errorf("SetTrellisMode(TrellisOff) did not take effect")
+	}
+}
+
+// TestParseTrellisMode covers the config-string → TrellisMode
+// mapping the ccdecoder connector uses to translate the
+// `p25_phase2_trellis_mode` YAML field into a SetTrellisMode call.
+func TestParseTrellisMode(t *testing.T) {
+	cases := []struct {
+		in   string
+		want TrellisMode
+		ok   bool
+	}{
+		{"", TrellisOff, true},
+		{"off", TrellisOff, true},
+		{"OFF", TrellisOff, true},
+		{"false", TrellisOff, true},
+		{"0", TrellisOff, true},
+		{"on", TrellisOn, true},
+		{"ON", TrellisOn, true},
+		{"true", TrellisOn, true},
+		{"1", TrellisOn, true},
+		{" on ", TrellisOn, true},
+		{"nonsense", TrellisOff, false},
+	}
+	for _, tc := range cases {
+		got, ok := ParseTrellisMode(tc.in)
+		if got != tc.want || ok != tc.ok {
+			t.Errorf("ParseTrellisMode(%q) = (%v, %v), want (%v, %v)",
+				tc.in, got, ok, tc.want, tc.ok)
+		}
 	}
 }

--- a/internal/scanner/ccdecoder/decoder_test.go
+++ b/internal/scanner/ccdecoder/decoder_test.go
@@ -7,7 +7,11 @@ import (
 	"time"
 
 	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/edacs"
 	"github.com/MattCheramie/GopherTrunk/internal/radio/ltr"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/mpt1327"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/nxdn"
+	p25phase2 "github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase2"
 	"github.com/MattCheramie/GopherTrunk/internal/radio/tetra"
 	"github.com/MattCheramie/GopherTrunk/internal/trunking"
 )
@@ -550,5 +554,120 @@ func TestYSFFactoryConstructs(t *testing.T) {
 	p.Reset()
 	if err := p.Close(); err != nil {
 		t.Errorf("Close: %v", err)
+	}
+}
+
+// TestP25Phase2FactoryAppliesTrellisFromSystem: a populated
+// trunking.System with P25Phase2TrellisMode = "on" must call
+// SetTrellisMode(TrellisOn) on the underlying ControlChannel.
+func TestP25Phase2FactoryAppliesTrellisFromSystem(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	p, err := newP25Phase2Pipeline(PipelineOptions{
+		Bus: bus, SystemName: "Test", FrequencyHz: 851_062_500,
+		SampleRateHz: 48_000,
+		System: trunking.System{
+			Name: "Test", Protocol: trunking.ProtocolP25Phase2,
+			ControlChannels:      []uint32{851_062_500},
+			P25Phase2TrellisMode: "on",
+		},
+	})
+	if err != nil {
+		t.Fatalf("newP25Phase2Pipeline: %v", err)
+	}
+	pp := p.(*p25Phase2Pipeline)
+	if got := pp.cc.TrellisMode(); got != p25phase2.TrellisOn {
+		t.Errorf("TrellisMode = %v, want TrellisOn", got)
+	}
+}
+
+// TestP25Phase2FactoryDefaultsKeepTrellisOff: empty config string
+// preserves the legacy 72-dibit raw-MAC-PDU path.
+func TestP25Phase2FactoryDefaultsKeepTrellisOff(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	p, err := newP25Phase2Pipeline(PipelineOptions{
+		Bus: bus, SystemName: "Test", FrequencyHz: 851_062_500,
+		SampleRateHz: 48_000,
+		System: trunking.System{
+			Name: "Test", Protocol: trunking.ProtocolP25Phase2,
+			ControlChannels: []uint32{851_062_500},
+		},
+	})
+	if err != nil {
+		t.Fatalf("newP25Phase2Pipeline: %v", err)
+	}
+	pp := p.(*p25Phase2Pipeline)
+	if got := pp.cc.TrellisMode(); got != p25phase2.TrellisOff {
+		t.Errorf("TrellisMode = %v, want TrellisOff", got)
+	}
+}
+
+// TestNXDNFactoryAppliesViterbiFromSystem: NXDNViterbiMode = "on"
+// flips the underlying ControlChannel's CAC region into ViterbiOn.
+func TestNXDNFactoryAppliesViterbiFromSystem(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	p, err := newNXDNPipeline(PipelineOptions{
+		Bus: bus, SystemName: "Test", FrequencyHz: 851_062_500,
+		SampleRateHz: 48_000,
+		System: trunking.System{
+			Name: "Test", Protocol: trunking.ProtocolNXDN,
+			ControlChannels: []uint32{851_062_500},
+			NXDNViterbiMode: "on",
+		},
+	})
+	if err != nil {
+		t.Fatalf("newNXDNPipeline: %v", err)
+	}
+	np := p.(*nxdnPipeline)
+	if got := np.cc.ViterbiMode(); got != nxdn.ViterbiOn {
+		t.Errorf("ViterbiMode = %v, want ViterbiOn", got)
+	}
+}
+
+// TestEDACSFactoryAppliesBCHFromSystem: EDACSBCHMode = "on" flips
+// the CCW decoder into BCHOn.
+func TestEDACSFactoryAppliesBCHFromSystem(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	p, err := newEDACSPipeline(PipelineOptions{
+		Bus: bus, SystemName: "Test", FrequencyHz: 866_000_000,
+		SampleRateHz: 96_000,
+		System: trunking.System{
+			Name: "Test", Protocol: trunking.ProtocolEDACS,
+			ControlChannels: []uint32{866_000_000},
+			EDACSBCHMode:    "on",
+		},
+	})
+	if err != nil {
+		t.Fatalf("newEDACSPipeline: %v", err)
+	}
+	ep := p.(*edacsPipeline)
+	if got := ep.cc.BCHMode(); got != edacs.BCHOn {
+		t.Errorf("BCHMode = %v, want BCHOn", got)
+	}
+}
+
+// TestMPT1327FactoryAppliesBCHFromSystem: MPT1327BCHMode = "on"
+// flips the codeword decoder into BCHOn.
+func TestMPT1327FactoryAppliesBCHFromSystem(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	p, err := newMPT1327Pipeline(PipelineOptions{
+		Bus: bus, SystemName: "Test", FrequencyHz: 169_212_500,
+		SampleRateHz: 48_000,
+		System: trunking.System{
+			Name: "Test", Protocol: trunking.ProtocolMPT1327,
+			ControlChannels: []uint32{169_212_500},
+			MPT1327BCHMode:  "on",
+		},
+	})
+	if err != nil {
+		t.Fatalf("newMPT1327Pipeline: %v", err)
+	}
+	mp := p.(*mpt1327Pipeline)
+	if got := mp.cc.BCHMode(); got != mpt1327.BCHOn {
+		t.Errorf("BCHMode = %v, want BCHOn", got)
 	}
 }

--- a/internal/scanner/ccdecoder/pipelines.go
+++ b/internal/scanner/ccdecoder/pipelines.go
@@ -150,6 +150,14 @@ func newP25Phase2Pipeline(opts PipelineOptions) (ProtocolPipeline, error) {
 		SystemName:  opts.SystemName,
 		FrequencyHz: opts.FrequencyHz,
 	})
+	if v := opts.System.P25Phase2TrellisMode; v != "" {
+		mode, ok := p25phase2.ParseTrellisMode(v)
+		if !ok {
+			opts.Log.Warn("ccdecoder: unrecognised p25_phase2_trellis_mode; falling back to off",
+				"system", opts.SystemName, "value", v)
+		}
+		cc.SetTrellisMode(mode)
+	}
 	rx := p25phase2rx.New(p25phase2rx.Options{
 		SampleRateHz: opts.SampleRateHz,
 		DibitSink: func(dibits []uint8, baseIdx int) {
@@ -332,6 +340,14 @@ func (p *dmrPipeline) Close() error            { return nil }
 // but typically fail the CAC CRC on real on-air signals.
 func newNXDNPipeline(opts PipelineOptions) (ProtocolPipeline, error) {
 	cc := nxdn.NewControlChannel(opts.Bus, opts.Log, opts.FrequencyHz, nxdn.Rate9600)
+	if v := opts.System.NXDNViterbiMode; v != "" {
+		mode, ok := nxdn.ParseViterbiMode(v)
+		if !ok {
+			opts.Log.Warn("ccdecoder: unrecognised nxdn_viterbi_mode; falling back to off",
+				"system", opts.SystemName, "value", v)
+		}
+		cc.SetViterbiMode(mode)
+	}
 	rx := nxdnrx.New(nxdnrx.Options{
 		SampleRateHz: opts.SampleRateHz,
 		DibitSink: func(dibits []uint8, baseIdx int) {
@@ -364,6 +380,14 @@ func newEDACSPipeline(opts PipelineOptions) (ProtocolPipeline, error) {
 		SystemName:  opts.SystemName,
 		FrequencyHz: opts.FrequencyHz,
 	})
+	if v := opts.System.EDACSBCHMode; v != "" {
+		mode, ok := edacs.ParseBCHMode(v)
+		if !ok {
+			opts.Log.Warn("ccdecoder: unrecognised edacs_bch_mode; falling back to off",
+				"system", opts.SystemName, "value", v)
+		}
+		cc.SetBCHMode(mode)
+	}
 	rx := edacsrx.New(edacsrx.Options{
 		SampleRateHz: opts.SampleRateHz,
 		BitSink: func(bits []byte, baseIdx int) {
@@ -487,6 +511,14 @@ func newMPT1327Pipeline(opts PipelineOptions) (ProtocolPipeline, error) {
 		SystemName:  opts.SystemName,
 		FrequencyHz: opts.FrequencyHz,
 	})
+	if v := opts.System.MPT1327BCHMode; v != "" {
+		mode, ok := mpt1327.ParseBCHMode(v)
+		if !ok {
+			opts.Log.Warn("ccdecoder: unrecognised mpt1327_bch_mode; falling back to off",
+				"system", opts.SystemName, "value", v)
+		}
+		cc.SetBCHMode(mode)
+	}
 	rx := mpt1327rx.New(mpt1327rx.Options{
 		SampleRateHz: opts.SampleRateHz,
 		BitSink: func(bits []byte, baseIdx int) {

--- a/internal/trunking/site.go
+++ b/internal/trunking/site.go
@@ -130,6 +130,37 @@ type System struct {
 	// Forwarded into ltr.ControlChannel.SetManchesterMode by the
 	// ccdecoder connector after parsing via ltr.ParseManchesterMode.
 	LTRManchesterMode string
+
+	// P25Phase2TrellisMode enables the 4-state ½-rate trellis FEC
+	// decoder on the P25 Phase 2 MAC PDU window. Recognised values
+	// (case-insensitive): "" / "off" → TrellisOff (legacy 72-dibit
+	// raw-MAC-PDU path); "on" → TrellisOn (146 channel dibits via
+	// the TIA-102.AABF trellis decoder). Forwarded into
+	// p25phase2.ControlChannel.SetTrellisMode by the ccdecoder
+	// connector after parsing via p25phase2.ParseTrellisMode.
+	P25Phase2TrellisMode string
+	// NXDNViterbiMode enables the K=5 ½-rate Viterbi FEC decoder
+	// on the NXDN CAC region. Recognised values (case-insensitive):
+	// "" / "off" → ViterbiOff (legacy 44-dibit raw-CAC path);
+	// "on" → ViterbiOn (92 dibits via the K=5 Viterbi decoder).
+	// Forwarded into nxdn.ControlChannel.SetViterbiMode by the
+	// ccdecoder connector after parsing via nxdn.ParseViterbiMode.
+	NXDNViterbiMode string
+	// EDACSBCHMode enables the BCH(40, 28, 2) FEC layer on the
+	// EDACS CCW. Recognised values (case-insensitive): "" / "off"
+	// → BCHOff (legacy pre-stripped 40-bit CCW path); "on" → BCHOn
+	// (40-bit on-wire BCH(40, 28, 2) decode + single/double-bit
+	// correction). Forwarded into edacs.ControlChannel.SetBCHMode
+	// by the ccdecoder connector after parsing via
+	// edacs.ParseBCHMode.
+	EDACSBCHMode string
+	// MPT1327BCHMode enables the BCH(63, 38) FEC layer on the MPT
+	// 1327 codeword. Recognised values (case-insensitive): "" /
+	// "off" → BCHOff (legacy 38-bit pre-stripped codeword path);
+	// "on" → BCHOn (64-bit on-wire BCH(63, 38) decode). Forwarded
+	// into mpt1327.ControlChannel.SetBCHMode by the ccdecoder
+	// connector after parsing via mpt1327.ParseBCHMode.
+	MPT1327BCHMode string
 }
 
 // Validate returns an error if the System lacks required fields.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -79,6 +79,7 @@ func New(cli *client.Client, opts Options) *Model {
 			panels.NewMetrics(),
 			panels.NewDevices(),
 			panels.NewScanner(),
+			panels.NewSettings(),
 		},
 	}
 	return m

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -82,10 +82,17 @@ func TestPanelSwitch_DigitAndTab(t *testing.T) {
 			t.Errorf("after %q active=%v, want %v", c.key, m.active, c.want)
 		}
 	}
-	// Tab cycles forward — Scanner is the last panel, so Tab wraps to Dashboard.
+	// Tab cycles forward — Scanner advances to Settings (the new
+	// last panel after PR #144).
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyTab})
 	m = updated.(*Model)
+	if m.active != state.PanelSettings {
+		t.Errorf("Tab from Scanner: active=%v, want Settings", m.active)
+	}
+	// Tab again wraps Settings → Dashboard.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	m = updated.(*Model)
 	if m.active != state.PanelDashboard {
-		t.Errorf("Tab from Scanner: active=%v, want Dashboard", m.active)
+		t.Errorf("Tab from Settings: active=%v, want Dashboard", m.active)
 	}
 }

--- a/internal/tui/client/types.go
+++ b/internal/tui/client/types.go
@@ -33,6 +33,17 @@ type SystemDTO struct {
 	SystemID        uint16   `json:"system_id,omitempty"`
 	RFSS            uint8    `json:"rfss,omitempty"`
 	Site            uint8    `json:"site,omitempty"`
+
+	// Per-protocol FEC opt-in surface (mirrors api.SystemDTO).
+	// The TUI Settings panel renders these.
+	TETRAColourCode      uint32 `json:"tetra_colour_code,omitempty"`
+	TETRAChannel         string `json:"tetra_channel,omitempty"`
+	LTRFCSMode           string `json:"ltr_fcs_mode,omitempty"`
+	LTRManchesterMode    string `json:"ltr_manchester_mode,omitempty"`
+	P25Phase2TrellisMode string `json:"p25_phase2_trellis_mode,omitempty"`
+	NXDNViterbiMode      string `json:"nxdn_viterbi_mode,omitempty"`
+	EDACSBCHMode         string `json:"edacs_bch_mode,omitempty"`
+	MPT1327BCHMode       string `json:"mpt1327_bch_mode,omitempty"`
 }
 
 // TalkgroupDTO mirrors api.TalkgroupDTO.

--- a/internal/tui/panels/settings.go
+++ b/internal/tui/panels/settings.go
@@ -1,0 +1,131 @@
+package panels
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/key"
+	"github.com/charmbracelet/bubbles/table"
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/MattCheramie/GopherTrunk/internal/tui/client"
+	"github.com/MattCheramie/GopherTrunk/internal/tui/state"
+)
+
+// SettingsPanel renders each configured trunking system with its
+// per-protocol FEC opt-in state — the source of truth for whether
+// the live decoder is running the spec's FEC chain or the legacy
+// raw-bit fixture path.
+//
+// The panel is read-only. Runtime mutation requires editing
+// config.yaml + restarting the daemon (the opt-ins flow from
+// SystemConfig → trunking.System → ccdecoder.PipelineFactory at
+// startup; the connector reads them once per HuntProgress retune).
+type SettingsPanel struct {
+	tbl   table.Model
+	count int
+}
+
+func NewSettings() *SettingsPanel {
+	t := table.New(
+		table.WithColumns(settingsColumns(80)),
+		table.WithFocused(true),
+	)
+	t.SetStyles(tableStyles())
+	return &SettingsPanel{tbl: t}
+}
+
+func (SettingsPanel) Title() string       { return "Settings" }
+func (SettingsPanel) Keys() []key.Binding { return nil }
+
+func (p *SettingsPanel) Update(msg tea.Msg, s *state.SharedState) (Panel, tea.Cmd) {
+	if len(s.Systems) != p.count {
+		p.refresh(s.Systems)
+	}
+	var cmd tea.Cmd
+	p.tbl, cmd = p.tbl.Update(msg)
+	return p, cmd
+}
+
+func (p *SettingsPanel) refresh(sys []client.SystemDTO) {
+	rows := make([]table.Row, 0, len(sys))
+	for _, s := range sys {
+		rows = append(rows, table.Row{
+			s.Name,
+			s.Protocol,
+			fecSummary(s),
+		})
+	}
+	p.tbl.SetRows(rows)
+	p.count = len(sys)
+}
+
+func (p *SettingsPanel) View(width, height int, focused bool, s *state.SharedState) string {
+	p.tbl.SetColumns(settingsColumns(width))
+	p.tbl.SetWidth(width)
+	if height > 4 {
+		p.tbl.SetHeight(height - 4)
+	}
+	body := p.tbl.View()
+	body += "\n\nEdit config.yaml + restart daemon to change; see the FEC opt-ins section in README.md."
+	return panelFrame("Settings", width, height, focused, body)
+}
+
+func settingsColumns(w int) []table.Column {
+	if w < 50 {
+		w = 50
+	}
+	nameW := w * 22 / 100
+	protoW := 11
+	fecW := w - nameW - protoW - 4
+	if fecW < 20 {
+		fecW = 20
+	}
+	return []table.Column{
+		{Title: "Name", Width: nameW},
+		{Title: "Protocol", Width: protoW},
+		{Title: "FEC opt-ins", Width: fecW},
+	}
+}
+
+// fecSummary returns a one-line, protocol-scoped summary of the
+// system's FEC opt-in state. Only the keys relevant to the system's
+// protocol are emitted so the column doesn't drown in N/A noise.
+func fecSummary(s client.SystemDTO) string {
+	var parts []string
+	switch strings.ToLower(s.Protocol) {
+	case "tetra":
+		if s.TETRAColourCode != 0 {
+			ch := s.TETRAChannel
+			if ch == "" {
+				ch = "sch/hd"
+			}
+			parts = append(parts, fmt.Sprintf("channel coding: on (colour=%#x, %s)", s.TETRAColourCode, ch))
+		} else {
+			parts = append(parts, "channel coding: off (set tetra_colour_code to enable)")
+		}
+	case "ltr":
+		parts = append(parts, "fcs: "+orOff(s.LTRFCSMode))
+		parts = append(parts, "manchester: "+orOff(s.LTRManchesterMode))
+	case "p25-phase2":
+		parts = append(parts, "trellis: "+orOff(s.P25Phase2TrellisMode))
+	case "nxdn":
+		parts = append(parts, "viterbi: "+orOff(s.NXDNViterbiMode))
+	case "edacs":
+		parts = append(parts, "bch: "+orOff(s.EDACSBCHMode))
+	case "mpt1327":
+		parts = append(parts, "bch: "+orOff(s.MPT1327BCHMode))
+	default:
+		parts = append(parts, "—")
+	}
+	return strings.Join(parts, "  ·  ")
+}
+
+// orOff returns the supplied mode string, or "off" when empty —
+// the canonical legacy / not-configured rendering across protocols.
+func orOff(s string) string {
+	if s == "" {
+		return "off"
+	}
+	return s
+}

--- a/internal/tui/panels/settings_test.go
+++ b/internal/tui/panels/settings_test.go
@@ -1,0 +1,75 @@
+package panels
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/MattCheramie/GopherTrunk/internal/tui/client"
+	"github.com/MattCheramie/GopherTrunk/internal/tui/state"
+)
+
+func TestSettingsPanel_RendersFECSummaryPerProtocol(t *testing.T) {
+	p := NewSettings()
+	s := &state.SharedState{
+		Systems: []client.SystemDTO{
+			{Name: "Metro", Protocol: "tetra", TETRAColourCode: 0x12345, TETRAChannel: "sch/f"},
+			{Name: "Suburb", Protocol: "tetra"},
+			{Name: "Country", Protocol: "ltr", LTRFCSMode: "on", LTRManchesterMode: "soft"},
+			{Name: "P2Sys", Protocol: "p25-phase2", P25Phase2TrellisMode: "on"},
+			{Name: "Mining", Protocol: "edacs", EDACSBCHMode: "on"},
+			{Name: "UK", Protocol: "mpt1327", MPT1327BCHMode: "on"},
+			{Name: "PSC", Protocol: "nxdn", NXDNViterbiMode: "on"},
+		},
+	}
+	_, _ = p.Update(tea.WindowSizeMsg{Width: 140, Height: 30}, s)
+	if p.count != 7 {
+		t.Fatalf("rows = %d, want 7", p.count)
+	}
+	view := p.View(140, 30, true, s)
+	wants := []string{
+		"Settings",
+		"Metro", "channel coding: on", "0x12345", "sch/f",
+		"Suburb", "channel coding: off",
+		"Country", "fcs: on", "manchester: soft",
+		"P2Sys", "trellis: on",
+		"Mining", "bch: on",
+		"UK", "bch: on",
+		"PSC", "viterbi: on",
+		"config.yaml",
+	}
+	for _, w := range wants {
+		if !strings.Contains(view, w) {
+			t.Errorf("view missing %q in:\n%s", w, view)
+		}
+	}
+}
+
+func TestSettingsPanel_UnknownProtocolFallsBackToDash(t *testing.T) {
+	p := NewSettings()
+	s := &state.SharedState{
+		Systems: []client.SystemDTO{
+			{Name: "Strange", Protocol: "smartzone"},
+		},
+	}
+	_, _ = p.Update(tea.WindowSizeMsg{Width: 100, Height: 20}, s)
+	if got := fecSummary(s.Systems[0]); got != "—" {
+		t.Errorf("fecSummary for unknown protocol = %q, want %q", got, "—")
+	}
+}
+
+func TestSettingsPanel_EmptyModeRendersOff(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"", "off"},
+		{"on", "on"},
+		{"soft", "soft"},
+	}
+	for _, c := range cases {
+		if got := orOff(c.in); got != c.want {
+			t.Errorf("orOff(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/internal/tui/state/state.go
+++ b/internal/tui/state/state.go
@@ -24,6 +24,7 @@ const (
 	PanelMetrics
 	PanelDevices
 	PanelScanner
+	PanelSettings
 	PanelCount
 )
 
@@ -49,6 +50,8 @@ func (p PanelKind) String() string {
 		return "Devices"
 	case PanelScanner:
 		return "Scanner"
+	case PanelSettings:
+		return "Settings"
 	}
 	return "?"
 }


### PR DESCRIPTION
## Summary

Bundles two related pieces of FEC opt-in work onto the same branch:

### 1. `ccdecoder` connector threads the remaining FEC opt-ins from `trunking.System`

Closes out the connector-side FEC wiring for every protocol whose `ControlChannel` exposes a tunable on-air FEC layer. Same pattern as PRs #141 (TETRA channel coding) and #142 (LTR FCS + Manchester) — one YAML key per protocol, parsed by a per-package `ParseXxxMode` helper, applied via the existing setter before any sample flows.

| YAML key | trunking.System field | Pipeline factory wires |
| --- | --- | --- |
| `p25_phase2_trellis_mode` | `P25Phase2TrellisMode` | `p25phase2.SetTrellisMode` (4-state ½-rate trellis over MAC PDU per TIA-102.AABF) |
| `nxdn_viterbi_mode` | `NXDNViterbiMode` | `nxdn.SetViterbiMode` (K=5 ½-rate Viterbi over CAC per MMDVMHost's `NXDNConvolution`) |
| `edacs_bch_mode` | `EDACSBCHMode` | `edacs.SetBCHMode` (BCH(40, 28, 2) over CCW) |
| `mpt1327_bch_mode` | `MPT1327BCHMode` | `mpt1327.SetBCHMode` (BCH(63, 38) over codeword) |

Each protocol gains a `ParseXxxMode` helper + `XxxMode()` getter. Recognised values (case-insensitive, whitespace tolerated): `""` / `off` / `false` / `0` → off (legacy raw-bit path); `on` / `true` / `1` → on (FEC layer applied). Unknown values warn-log and fall back to off.

### 2. TUI Settings panel surfaces every per-system opt-in

The eleventh TUI panel (`Tab` past Scanner) renders each configured system with a one-line summary of its FEC opt-in state across every protocol that has a public-spec FEC chain — TETRA channel coding, LTR FCS + Manchester, P25 Phase 2 Trellis, NXDN Viterbi, EDACS + MPT 1327 BCH.

- `api.SystemDTO` gains every opt-in field as `omitempty` JSON; `client.SystemDTO` mirrors them so the TUI reads them with no further plumbing
- `state.PanelSettings` + `state.PanelKind.String("Settings")` + `panels.NewSettings` registered as the last panel in `app.go`
- `panels/settings.go` renders each system's protocol-relevant opt-ins; non-trunked protocols fall back to `—`
- Panel is **read-only**; the hint at the bottom says "Edit `config.yaml` + restart daemon to change", matching the existing wiring (opt-ins flow `SystemConfig` → `trunking.System` → `ccdecoder.PipelineFactory` at construction / on each `HuntProgress` retune). Runtime mutation is a follow-up.

README also gains an **FEC opt-ins** section with a table covering every YAML key, default behaviour, and what the on-path unlocks.

## Test plan

- [x] `go test ./...` clean (all packages)
- [x] `go vet ./...` clean
- [x] Four new `ParseXxxMode` tests (P25 P2 Trellis / NXDN Viterbi / EDACS BCH / MPT 1327 BCH) covering off / on / true / false / numeric / whitespace / nonsense
- [x] Four extended `TestSetXxxModeDefault` tests covering the new `XxxMode()` getters
- [x] Four new `TestXxxFactoryAppliesYyyFromSystem` connector tests + one `TestP25Phase2FactoryDefaultsKeepTrellisOff` regression
- [x] `TestSettingsPanel_RendersFECSummaryPerProtocol` — every protocol's mode renders correctly across all 7 systems
- [x] `TestSettingsPanel_UnknownProtocolFallsBackToDash` + `TestSettingsPanel_EmptyModeRendersOff`
- [x] `TestPanelSwitch_DigitAndTab` updated for the new Tab cycle (Scanner → Settings → Dashboard)

## Followup

- Live toggling from the TUI (PATCH endpoint + daemon-side reconfig of active `ccdecoder` pipelines). Currently operators edit `config.yaml` + restart.
- Per-protocol on-air interleaver / puncture layers for NXDN CAC + EDACS CCW (blocked on reference data that isn't in the published specs).

https://claude.ai/code/session_019dtCCVEZJTKKr6YK3wy824