### PR TITLE
internal/scanner/ccdecoder: thread Motorola BCH from trunking.System

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,31 @@ to its own package and lands independently.
 
 ### Recently shipped
 
+- **Motorola Type II BCH(64, 16, 11) wired through the
+  connector.** Closes the last unfinished FEC opt-in in the
+  TETRA / LTR / P25 P2 / NXDN / EDACS / MPT 1327 / Motorola
+  family. The BCH layer existed on `motorola.ControlChannel`
+  for a while (`SetBCHMode(BCHOn)` reads two 64-bit codewords
+  after sync, decodes each via `framing.BCHDecode64_16`, and
+  reassembles the 32-bit OSW from the two recovered 16-bit
+  halves with single- through 11-bit-error correction per
+  codeword); this PR threads it through the same per-system
+  YAML pipeline every other protocol uses:
+    - `trunking.System` gains `MotorolaBCHMode string`;
+      `config.SystemConfig` exposes it as `motorola_bch_mode`
+      (`""` / `"off"` / `"on"`).
+    - `motorola.ParseBCHMode` + `motorola.ControlChannel.BCHMode()`
+      mirror the accessors on every other FEC-opt-in protocol.
+    - `newMotorolaPipeline` calls `SetBCHMode` before any
+      sample flows; empty string preserves the legacy 32-bit
+      raw-OSW path for synthesized-fixture tests.
+    - `api.SystemDTO` + `client.SystemDTO` carry the field as
+      `omitempty` JSON; the TUI **Settings** panel renders a
+      `bch: on` / `bch: off` row for Motorola systems.
+    - README's FEC opt-ins table gains a Motorola row.
+  With this PR, every protocol whose ControlChannel exposes a
+  tunable on-air FEC layer is now connector-configurable from
+  per-system YAML.
 - **Reference spec PDFs consolidated under `docs/specs/`.** The
   NXDN-TS-1-A and ETSI EN 300 392-2 PDFs that drive the
   on-air FEC implementations were previously sitting at the
@@ -1319,6 +1344,7 @@ runtime mutation is a future PR. To change a mode, edit
 | NXDN | `nxdn_viterbi_mode` (`""` / `"off"` / `"on"` / `"spec"`) | Legacy 44-dibit raw-CAC path. | `on`: simplified K=5 ½-rate Viterbi over the CAC region (92 dibits → 88 info bits + 4 tail zeros — matches the older MMDVMHost / DSDcc fixtures). `spec`: full NXDN-TS-1-A rev 1.3 §4.5.1.1 outbound chain (150 dibits = 300 channel bits → deinterleave 25×12 → depuncture 50/350 → K=5 Viterbi → 16-bit CRC verify → 155 info bits = 8 SR + 144 L3 + 3 Null). Use `spec` for live captures; `on` for back-compat with the older synthesized fixtures. |
 | EDACS | `edacs_bch_mode` (`""` / `"off"` / `"on"`) | Legacy pre-stripped 40-bit CCW; payload struct's LCN bit 0 + Aux fields are data. | BCH(40, 28, 2) with single/double-bit correction over the 40-bit on-wire CCW; under `on` the effective CCW carries 28 info bits (Command + Status + Address + high LCN bits), the remaining bits become BCH parity. |
 | MPT 1327 | `mpt1327_bch_mode` (`""` / `"off"` / `"on"`) | Legacy 38-bit pre-stripped codeword. | BCH(63, 38) decode over the 64-bit on-wire codeword. |
+| Motorola Type II | `motorola_bch_mode` (`""` / `"off"` / `"on"`) | Legacy 32-bit raw-OSW path. | Two 64-bit BCH(64, 16, 11) codewords reassembled into the 32-bit OSW with single- through 11-bit-error correction per codeword. Live captures should set `on`. |
 
 All string values are case-insensitive with whitespace tolerated;
 recognised on-values include `"on"` / `"true"` / `"1"`, off-values

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -127,6 +127,7 @@ func NewDaemon(cfg config.Config, version string, log *slog.Logger) (*Daemon, er
 			NXDNViterbiMode:      sys.NXDNViterbiMode,
 			EDACSBCHMode:         sys.EDACSBCHMode,
 			MPT1327BCHMode:       sys.MPT1327BCHMode,
+			MotorolaBCHMode:      sys.MotorolaBCHMode,
 		}
 		if err := s.Validate(); err != nil {
 			return nil, fmt.Errorf("daemon: system %q: %w", sys.Name, err)

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -40,6 +40,7 @@ type SystemDTO struct {
 	NXDNViterbiMode      string `json:"nxdn_viterbi_mode,omitempty"`
 	EDACSBCHMode         string `json:"edacs_bch_mode,omitempty"`
 	MPT1327BCHMode       string `json:"mpt1327_bch_mode,omitempty"`
+	MotorolaBCHMode      string `json:"motorola_bch_mode,omitempty"`
 }
 
 func systemToDTO(s trunking.System) SystemDTO {
@@ -59,6 +60,7 @@ func systemToDTO(s trunking.System) SystemDTO {
 		NXDNViterbiMode:      s.NXDNViterbiMode,
 		EDACSBCHMode:         s.EDACSBCHMode,
 		MPT1327BCHMode:       s.MPT1327BCHMode,
+		MotorolaBCHMode:      s.MotorolaBCHMode,
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -163,6 +163,13 @@ type SystemConfig struct {
 	// decode). Live MPT 1327 captures should set "on". Ignored for
 	// non-MPT-1327 protocols.
 	MPT1327BCHMode string `yaml:"mpt1327_bch_mode"`
+	// MotorolaBCHMode enables the BCH(64, 16, 11) FEC layer on the
+	// Motorola Type II OSW. Recognised values: "" / "off" (default,
+	// legacy 32-bit raw-OSW path) or "on" (two 64-bit BCH(64, 16, 11)
+	// codewords reassembled into the 32-bit OSW with single- through
+	// 11-bit-error correction). Live Motorola Type II captures
+	// should set "on". Ignored for non-Motorola protocols.
+	MotorolaBCHMode string `yaml:"motorola_bch_mode"`
 }
 
 // APIConfig controls the HTTP REST + SSE + WebSocket and gRPC servers.

--- a/internal/radio/motorola/process.go
+++ b/internal/radio/motorola/process.go
@@ -1,6 +1,10 @@
 package motorola
 
-import "github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+import (
+	"strings"
+
+	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+)
 
 // processState is the cross-call bit buffering + sync-detection
 // state the Process adapter holds. Lazily initialised on the first
@@ -41,6 +45,32 @@ func (c *ControlChannel) SetBCHMode(m BCHMode) {
 	if c.proc != nil {
 		c.proc.remaining = 0
 		c.proc.osw = c.proc.osw[:0]
+	}
+}
+
+// BCHMode returns the configured BCHMode. Mirrors the Set* family
+// so callers (and tests) can introspect the configured mode
+// without poking at unexported state.
+func (c *ControlChannel) BCHMode() BCHMode {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.bchMode
+}
+
+// ParseBCHMode maps a config / user-facing string into a BCHMode.
+// Recognised values (case-insensitive): "" / "off" / "false" /
+// "0" → BCHOff (legacy 32-bit raw-OSW path); "on" / "true" /
+// "1" → BCHOn (two 64-bit BCH(64, 16, 11) codewords reassembled
+// into the 32-bit OSW). Unknown strings return BCHOff with
+// `ok = false` so callers can surface the misconfiguration.
+func ParseBCHMode(s string) (BCHMode, bool) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "", "off", "false", "0":
+		return BCHOff, true
+	case "on", "true", "1":
+		return BCHOn, true
+	default:
+		return BCHOff, false
 	}
 }
 

--- a/internal/radio/motorola/process_test.go
+++ b/internal/radio/motorola/process_test.go
@@ -214,3 +214,56 @@ func TestSyncDetectorReset(t *testing.T) {
 		t.Errorf("post-Reset pos = %d, want 0", det.pos)
 	}
 }
+
+// TestSetBCHModeDefault confirms the zero-value ControlChannel
+// uses BCHOff, the accessor mirrors the setter, and the
+// SetBCHMode toggle round-trips both ways.
+func TestSetBCHModeDefault(t *testing.T) {
+	cc := New(Options{})
+	if cc.bchMode != BCHOff {
+		t.Errorf("default bchMode = %v, want BCHOff", cc.bchMode)
+	}
+	if got := cc.BCHMode(); got != BCHOff {
+		t.Errorf("BCHMode() = %v, want BCHOff", got)
+	}
+	cc.SetBCHMode(BCHOn)
+	if cc.bchMode != BCHOn {
+		t.Errorf("SetBCHMode(BCHOn) did not take effect")
+	}
+	if got := cc.BCHMode(); got != BCHOn {
+		t.Errorf("BCHMode() = %v, want BCHOn", got)
+	}
+	cc.SetBCHMode(BCHOff)
+	if cc.bchMode != BCHOff {
+		t.Errorf("SetBCHMode(BCHOff) did not take effect")
+	}
+}
+
+// TestParseBCHMode covers the config-string → BCHMode mapping the
+// ccdecoder connector uses to translate the `motorola_bch_mode`
+// YAML field into a SetBCHMode call.
+func TestParseBCHMode(t *testing.T) {
+	cases := []struct {
+		in   string
+		want BCHMode
+		ok   bool
+	}{
+		{"", BCHOff, true},
+		{"off", BCHOff, true},
+		{"false", BCHOff, true},
+		{"0", BCHOff, true},
+		{"on", BCHOn, true},
+		{"ON", BCHOn, true},
+		{"true", BCHOn, true},
+		{"1", BCHOn, true},
+		{" on ", BCHOn, true},
+		{"nonsense", BCHOff, false},
+	}
+	for _, tc := range cases {
+		got, ok := ParseBCHMode(tc.in)
+		if got != tc.want || ok != tc.ok {
+			t.Errorf("ParseBCHMode(%q) = (%v, %v), want (%v, %v)",
+				tc.in, got, ok, tc.want, tc.ok)
+		}
+	}
+}

--- a/internal/scanner/ccdecoder/decoder_test.go
+++ b/internal/scanner/ccdecoder/decoder_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/MattCheramie/GopherTrunk/internal/events"
 	"github.com/MattCheramie/GopherTrunk/internal/radio/edacs"
 	"github.com/MattCheramie/GopherTrunk/internal/radio/ltr"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/motorola"
 	"github.com/MattCheramie/GopherTrunk/internal/radio/mpt1327"
 	"github.com/MattCheramie/GopherTrunk/internal/radio/nxdn"
 	p25phase2 "github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase2"
@@ -486,6 +487,51 @@ func TestMotorolaFactoryConstructs(t *testing.T) {
 	p.Reset()
 	if err := p.Close(); err != nil {
 		t.Errorf("Close: %v", err)
+	}
+}
+
+// TestMotorolaFactoryAppliesBCHFromSystem: MotorolaBCHMode = "on"
+// flips the OSW decoder into BCHOn.
+func TestMotorolaFactoryAppliesBCHFromSystem(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	p, err := newMotorolaPipeline(PipelineOptions{
+		Bus: bus, SystemName: "Test", FrequencyHz: 851_012_500,
+		SampleRateHz: 48_000,
+		System: trunking.System{
+			Name: "Test", Protocol: trunking.ProtocolMotorola,
+			ControlChannels: []uint32{851_012_500},
+			MotorolaBCHMode: "on",
+		},
+	})
+	if err != nil {
+		t.Fatalf("newMotorolaPipeline: %v", err)
+	}
+	mp := p.(*motorolaPipeline)
+	if got := mp.cc.BCHMode(); got != motorola.BCHOn {
+		t.Errorf("BCHMode = %v, want BCHOn", got)
+	}
+}
+
+// TestMotorolaFactoryDefaultsKeepBCHOff: empty MotorolaBCHMode
+// preserves the legacy 32-bit raw-OSW path.
+func TestMotorolaFactoryDefaultsKeepBCHOff(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	p, err := newMotorolaPipeline(PipelineOptions{
+		Bus: bus, SystemName: "Test", FrequencyHz: 851_012_500,
+		SampleRateHz: 48_000,
+		System: trunking.System{
+			Name: "Test", Protocol: trunking.ProtocolMotorola,
+			ControlChannels: []uint32{851_012_500},
+		},
+	})
+	if err != nil {
+		t.Fatalf("newMotorolaPipeline: %v", err)
+	}
+	mp := p.(*motorolaPipeline)
+	if got := mp.cc.BCHMode(); got != motorola.BCHOff {
+		t.Errorf("BCHMode = %v, want BCHOff", got)
 	}
 }
 

--- a/internal/scanner/ccdecoder/pipelines.go
+++ b/internal/scanner/ccdecoder/pipelines.go
@@ -409,9 +409,16 @@ func (p *edacsPipeline) Close() error            { return nil }
 // newMotorolaPipeline wires internal/radio/motorola/receiver into
 // motorola.ControlChannel.Process. The receiver's BitSink forwards
 // bits + baseIdx into the state machine (24-bit sync detect →
-// 32-bit OSW slice → OSWFromBits → Ingest). The BCH(64,16,11)
-// FEC over the OSW is a follow-up; until it lands the adapter
-// sync-locks but typically fails OSW parsing on noisy signals.
+// 32-bit OSW slice → OSWFromBits → Ingest).
+//
+// The BCH(64, 16, 11) FEC layer is gated on per-system config:
+// trunking.System.MotorolaBCHMode (the `motorola_bch_mode` YAML
+// key) flips SetBCHMode on the ControlChannel before any sample
+// flows. Empty string preserves the legacy 32-bit raw-OSW path so
+// existing synthesized-fixture tests stay green; live Motorola
+// Type II captures typically need `motorola_bch_mode: on` to pass
+// the FEC layer. Unknown values warn-log and fall back to off
+// rather than failing the retune.
 func newMotorolaPipeline(opts PipelineOptions) (ProtocolPipeline, error) {
 	cc := motorola.New(motorola.Options{
 		Bus:         opts.Bus,
@@ -419,6 +426,14 @@ func newMotorolaPipeline(opts PipelineOptions) (ProtocolPipeline, error) {
 		SystemName:  opts.SystemName,
 		FrequencyHz: opts.FrequencyHz,
 	})
+	if v := opts.System.MotorolaBCHMode; v != "" {
+		mode, ok := motorola.ParseBCHMode(v)
+		if !ok {
+			opts.Log.Warn("ccdecoder: unrecognised motorola_bch_mode; falling back to off",
+				"system", opts.SystemName, "value", v)
+		}
+		cc.SetBCHMode(mode)
+	}
 	rx := motorolarx.New(motorolarx.Options{
 		SampleRateHz: opts.SampleRateHz,
 		BitSink: func(bits []byte, baseIdx int) {

--- a/internal/trunking/site.go
+++ b/internal/trunking/site.go
@@ -161,6 +161,15 @@ type System struct {
 	// into mpt1327.ControlChannel.SetBCHMode by the ccdecoder
 	// connector after parsing via mpt1327.ParseBCHMode.
 	MPT1327BCHMode string
+	// MotorolaBCHMode enables the BCH(64, 16, 11) FEC layer on the
+	// Motorola Type II OSW. Recognised values (case-insensitive):
+	// "" / "off" → BCHOff (legacy 32-bit raw-OSW path); "on" →
+	// BCHOn (two 64-bit BCH(64, 16, 11) codewords reassembled into
+	// the 32-bit OSW, with up to 11 bit errors corrected per
+	// codeword). Forwarded into
+	// motorola.ControlChannel.SetBCHMode by the ccdecoder
+	// connector after parsing via motorola.ParseBCHMode.
+	MotorolaBCHMode string
 }
 
 // Validate returns an error if the System lacks required fields.

--- a/internal/tui/client/types.go
+++ b/internal/tui/client/types.go
@@ -44,6 +44,7 @@ type SystemDTO struct {
 	NXDNViterbiMode      string `json:"nxdn_viterbi_mode,omitempty"`
 	EDACSBCHMode         string `json:"edacs_bch_mode,omitempty"`
 	MPT1327BCHMode       string `json:"mpt1327_bch_mode,omitempty"`
+	MotorolaBCHMode      string `json:"motorola_bch_mode,omitempty"`
 }
 
 // TalkgroupDTO mirrors api.TalkgroupDTO.

--- a/internal/tui/panels/settings.go
+++ b/internal/tui/panels/settings.go
@@ -115,6 +115,8 @@ func fecSummary(s client.SystemDTO) string {
 		parts = append(parts, "bch: "+orOff(s.EDACSBCHMode))
 	case "mpt1327":
 		parts = append(parts, "bch: "+orOff(s.MPT1327BCHMode))
+	case "motorola":
+		parts = append(parts, "bch: "+orOff(s.MotorolaBCHMode))
 	default:
 		parts = append(parts, "—")
 	}

--- a/internal/tui/panels/settings_test.go
+++ b/internal/tui/panels/settings_test.go
@@ -21,11 +21,12 @@ func TestSettingsPanel_RendersFECSummaryPerProtocol(t *testing.T) {
 			{Name: "Mining", Protocol: "edacs", EDACSBCHMode: "on"},
 			{Name: "UK", Protocol: "mpt1327", MPT1327BCHMode: "on"},
 			{Name: "PSC", Protocol: "nxdn", NXDNViterbiMode: "on"},
+			{Name: "Moto", Protocol: "motorola", MotorolaBCHMode: "on"},
 		},
 	}
 	_, _ = p.Update(tea.WindowSizeMsg{Width: 140, Height: 30}, s)
-	if p.count != 7 {
-		t.Fatalf("rows = %d, want 7", p.count)
+	if p.count != 8 {
+		t.Fatalf("rows = %d, want 8", p.count)
 	}
 	view := p.View(140, 30, true, s)
 	wants := []string{
@@ -37,6 +38,7 @@ func TestSettingsPanel_RendersFECSummaryPerProtocol(t *testing.T) {
 		"Mining", "bch: on",
 		"UK", "bch: on",
 		"PSC", "viterbi: on",
+		"Moto", "bch: on",
 		"config.yaml",
 	}
 	for _, w := range wants {


### PR DESCRIPTION
## Summary

Closes the last unfinished FEC opt-in in the TETRA / LTR / P25 P2 / NXDN / EDACS / MPT 1327 / Motorola family. With this PR, **every protocol whose `ControlChannel` exposes a tunable on-air FEC layer is connector-configurable from per-system YAML**.

The Motorola BCH(64, 16, 11) layer has existed on `motorola.ControlChannel` for a while — `SetBCHMode(BCHOn)` reads two 64-bit codewords after sync, decodes each via the existing `framing.BCHDecode64_16` primitive, and reassembles the 32-bit OSW from the two recovered 16-bit halves with single- through 11-bit error correction per codeword. It just wasn't wired through the config pipeline like every other FEC opt-in. Same shape as PRs #141 (TETRA), #142 (LTR), #143 (P25 P2 / NXDN / EDACS / MPT 1327).

## Plumbing

- `trunking.System` gains `MotorolaBCHMode string`; `config.SystemConfig` exposes it as `motorola_bch_mode` (recognises `""` / `"off"` / `"false"` / `"0"` / `"on"` / `"true"` / `"1"`, case-insensitive, whitespace tolerated)
- `motorola.ParseBCHMode` + `motorola.ControlChannel.BCHMode()` mirror the accessors on the other FEC-opt-in protocols
- `newMotorolaPipeline` calls `SetBCHMode` before any sample flows; empty string preserves the legacy 32-bit raw-OSW path for synthesized-fixture tests
- `api.SystemDTO` + `client.SystemDTO` carry the field as `omitempty` JSON; the TUI **Settings** panel renders a `bch: on` / `bch: off` row for Motorola systems
- README's FEC opt-ins table gains a Motorola row + new Recently shipped entry

## Test plan

- [x] `go test ./...` clean
- [x] `go vet ./...` clean
- [x] `TestSetBCHModeDefault` exercises the new `BCHMode()` getter + `SetBCHMode` round-trip
- [x] `TestParseBCHMode` covers `""` / `off` / `on` / `true` / `false` / numeric / whitespace / nonsense
- [x] `TestMotorolaFactoryAppliesBCHFromSystem` + `TestMotorolaFactoryDefaultsKeepBCHOff` cover the connector wiring
- [x] `TestSettingsPanel_RendersFECSummaryPerProtocol` expanded to render the Motorola row

## Followup

Per the punch list:
- `make integration-cc` end-to-end target — boots the daemon with a mock SDR replaying synthesized P25 P1 CC IQ, asserts the supervisor reaches `locked`, `cc.locked` + `grant` events fire, and `gophertrunk_cc_locked_total` increments. The "lights up live trunked reception" milestone from the original plan.
- Live-capture FEC validation across every protocol (operator-supplied IQ).
- Vocoder calibration fixtures (operator-supplied P25 P1 IMBE + DMR AMBE+2 raw + reference WAVs).

https://claude.ai/code/session_019dtCCVEZJTKKr6YK3wy824

---
_Generated by [Claude Code](https://claude.ai/code/session_019dtCCVEZJTKKr6YK3wy824)_