### PR TITLE
cmd/gophertrunk: make integration-cc-nxdn — NXDN end-to-end lights-up check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 /bin/
 /dist/
+# `go build ./...` without -o drops a `gophertrunk` binary at the
+# repo root; the canonical build location is bin/gophertrunk via
+# `make build`. Don't track the stray.
+/gophertrunk
 *.test
 *.out
 *.prof

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ TAGS    ?=
 GO      ?= go
 PKGS    := ./...
 
-.PHONY: all build test integration integration-cc lint tidy vet clean run proto
+.PHONY: all build test integration integration-cc integration-cc-nxdn lint tidy vet clean run proto
 
 all: build
 
@@ -30,6 +30,14 @@ integration:
 # this one isolates the CC-decoder critical path.
 integration-cc:
 	$(GO) test -tags "integration $(TAGS)" -race -count=1 -run TestDaemonCCDecodesP25Phase1 ./cmd/gophertrunk/...
+
+# integration-cc-nxdn is the NXDN-specific sibling of integration-cc. Boots
+# the daemon with synthesized C4FM IQ replaying a SITE_INFO RCCH message
+# through the NXDN-TS-1-A §4.5.1.1 spec FEC chain (`nxdn_viterbi_mode: spec`)
+# and asserts the production newNXDNPipeline + the supervisor + API + metrics
+# all recover the lock.
+integration-cc-nxdn:
+	$(GO) test -tags "integration $(TAGS)" -race -count=1 -run TestDaemonCCDecodesNXDN ./cmd/gophertrunk/...
 
 vet:
 	$(GO) vet -tags "$(TAGS)" $(PKGS)

--- a/README.md
+++ b/README.md
@@ -199,6 +199,37 @@ to its own package and lands independently.
 
 ### Recently shipped
 
+- **`make integration-cc-nxdn` — NXDN end-to-end lights-up
+  check.** First sibling target of `integration-cc` covering
+  a second protocol end-to-end. Boots the daemon with a mock
+  SDR replaying a fully-synthesized NXDN-TS-1-A §4.6 RCCH
+  outbound frame (FSW + LICH + 150-dibit CAC carrying a
+  SITE_INFO message through the §4.5.1.1 spec FEC chain
+  shipped in PR #144), and asserts the production
+  `newNXDNPipeline` + `nxdn_viterbi_mode: spec` recover the
+  lock and surface it through the bus + supervisor + API +
+  metrics.
+  - `internal/radio/nxdn/receiver` gains the same
+    `Options.DeviationHz` calibration knob the P25 Phase 1
+    receiver picked up in PR #148. The ccdecoder's
+    `newNXDNPipeline` factory passes the spec 1800 Hz value
+    so live captures slice correctly out of the box.
+  - `nxdn.LockState` now implements `trunking.LockedPayload`
+    (`LockedFrequencyHz` + `LockedNAC` methods). NXDN
+    doesn't have a P25-style NAC; the SiteID is the closest
+    per-cell identifier and is plumbed into the NAC slot.
+    Without this, cc.locked events fired correctly but the
+    cchunt supervisor's state machine silently dropped them
+    on the type-assertion check and `/api/v1/scanner` never
+    surfaced `state=locked` for NXDN systems.
+  - The C4FM modulator from PR #148 carries straight over —
+    NXDN's 9600-baud 4-FSK / α = 0.20 / 1800 Hz deviation
+    matches P25 Phase 1's modulation params exactly. The
+    only differences are framing (192-dibit / 80 ms frames,
+    8-dibit FSW vs P25's 24-dibit FSW, LICH + CAC vs NID +
+    TSBK) and the channel-coding chain above the demod —
+    both of which were already wired up by earlier PRs.
+  20-run flakiness check clean.
 - **C4FM modulator + RRC pulse shaping + receiver-side
   slicer calibration.** Closes the last stub in the
   `make integration-cc` chain. The IQ → dibit demodulation
@@ -1305,10 +1336,11 @@ and DVB-driver blacklisting on Linux.
 ### Build, test, run
 
 ```sh
-make build           # produces ./bin/gophertrunk
-make test            # go test -race ./...
-make integration     # boots the wired daemon end-to-end (no SDR needed)
-make integration-cc  # focused "lights up live trunked reception" check
+make build                 # produces ./bin/gophertrunk
+make test                  # go test -race ./...
+make integration           # boots the wired daemon end-to-end (no SDR needed)
+make integration-cc        # P25 Phase 1 "lights up live trunked reception"
+make integration-cc-nxdn   # NXDN "lights up" — synthesizes spec FEC chain
 
 ./bin/gophertrunk version
 ./bin/gophertrunk sdr list                # enumerates attached dongles

--- a/cmd/gophertrunk/integration_cc_nxdn_test.go
+++ b/cmd/gophertrunk/integration_cc_nxdn_test.go
@@ -1,0 +1,204 @@
+//go:build integration
+
+package main
+
+import (
+	"context"
+	"encoding/binary"
+	"io"
+	"log/slog"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/config"
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/demod"
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/nxdn"
+	"github.com/MattCheramie/GopherTrunk/internal/sdr"
+)
+
+// TestDaemonCCDecodesNXDN is the per-protocol sibling of
+// TestDaemonCCDecodesP25Phase1: boot the daemon with a mock SDR
+// replaying a fully-synthesized NXDN-TS-1-A §4.6 RCCH outbound
+// frame (FSW + LICH + 150-dibit CAC carrying a SITE_INFO RCCH
+// message through the §4.5.1.1 spec-correct FEC chain), assert
+// the production newNXDNPipeline + `nxdn_viterbi_mode: spec`
+// recovers the lock and surfaces it through the bus + API +
+// metrics.
+//
+// The synthesized IQ is the same 9600-baud / 4-FSK / α = 0.20 /
+// 1800 Hz peak deviation modulation used by P25 Phase 1 — NXDN
+// shares the modulation params, just differs in the framing and
+// channel-coding layers above the demod. The newly-shipped C4FM
+// modulator (PR #148) carries straight over; the receiver-side
+// slicer calibration via Options.DeviationHz is the only other
+// piece the test needs to round-trip cleanly.
+func TestDaemonCCDecodesNXDN(t *testing.T) {
+	const (
+		controlFreqHz = 851_062_500
+		sampleRateHz  = 48_000
+		sps           = 10
+		span          = 8
+		alpha         = 0.20
+		deviationHz   = 1800.0
+		frameRepeats  = 20
+		siteID        = 0xBEEF
+		systemID      = 0x0042
+	)
+
+	dibits := buildNXDNSpecEncodedDibits(frameRepeats, siteID, systemID)
+	iq := demod.ModulateC4FM(dibits, sps, span, alpha, sampleRateHz, deviationHz)
+
+	dir := t.TempDir()
+	iqPath := filepath.Join(dir, "nxdn-cc.cfile")
+	if err := writeIQToU8File(iqPath, iq); err != nil {
+		t.Fatalf("write IQ: %v", err)
+	}
+	sdr.Register(&sdr.MockDriver{Files: []string{iqPath}})
+
+	cfg := config.Default()
+	cfg.SDR.SampleRate = sampleRateHz
+	cfg.SDR.Devices = []config.DeviceConfig{
+		{Serial: "mock-00", Role: "control"},
+	}
+	cfg.Trunking.Systems = []config.SystemConfig{
+		{
+			Name:            "NXDNSite",
+			Protocol:        "nxdn",
+			ControlChannels: []uint32{controlFreqHz},
+			NXDNViterbiMode: "spec",
+		},
+	}
+	cfg.API.HTTPAddr = freeAddr(t)
+	cfg.Metrics.Enabled = true
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	d, err := NewDaemon(cfg, "integration-cc-nxdn", logger)
+	if err != nil {
+		t.Fatalf("NewDaemon: %v", err)
+	}
+	if d.ccDecoder == nil {
+		t.Fatalf("ccDecoder is nil; daemon should have constructed one")
+	}
+
+	sub := d.Bus().Subscribe()
+	defer sub.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	runErrCh := make(chan error, 1)
+	go func() { runErrCh <- d.Run(ctx) }()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case <-runErrCh:
+		case <-time.After(3 * time.Second):
+		}
+	})
+
+	base := "http://" + cfg.API.HTTPAddr
+	waitReachable(t, base+"/api/v1/health", 3*time.Second)
+
+	deadline := time.After(5 * time.Second)
+	var locked bool
+WaitLoop:
+	for !locked {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind != events.KindCCLocked {
+				continue
+			}
+			ls, ok := ev.Payload.(nxdn.LockState)
+			if !ok {
+				t.Errorf("CCLocked payload type = %T, want nxdn.LockState", ev.Payload)
+				continue
+			}
+			if ls.SiteID != siteID {
+				t.Errorf("LockState.SiteID = %#x, want %#x", ls.SiteID, siteID)
+			}
+			if ls.SystemID != systemID {
+				t.Errorf("LockState.SystemID = %#x, want %#x", ls.SystemID, systemID)
+			}
+			if ls.FrequencyHz != controlFreqHz {
+				t.Errorf("LockState.FrequencyHz = %d, want %d", ls.FrequencyHz, controlFreqHz)
+			}
+			locked = true
+			break WaitLoop
+		case <-deadline:
+			t.Fatalf("no cc.locked event arrived within 5s")
+		}
+	}
+
+	waitForScannerLock(t, base, "NXDNSite", 2*time.Second)
+
+	body := scrape(t, base+"/metrics")
+	if !strings.Contains(body, "gophertrunk_control_channel_locked{") {
+		t.Errorf("/metrics missing gophertrunk_control_channel_locked gauge family:\n%s", body)
+	}
+	if !strings.Contains(body, `gophertrunk_events_total{kind="cc.locked"} 1`) {
+		t.Errorf("/metrics did not count one cc.locked event:\n%s", body)
+	}
+}
+
+// buildNXDNSpecEncodedDibits assembles a long NXDN dibit stream
+// for the C4FM modulator + receiver chain:
+//
+//   - 300-dibit warmup cycling 0..3 so the Mueller-Müller clock
+//     recovery sees every symbol level
+//   - `repeats` × (FSWDibitsOutbound + LICH wire dibits + 150
+//     spec-encoded CAC dibits + 50 idle dibits)
+//   - 100-dibit trailer for clean flush
+//
+// Each frame layout matches the production process.go
+// ViterbiSpec post-sync window (8 LICH + 150 CAC = 158 dibits)
+// per §4.6 RCCH outbound. The CAC carries a SITE_INFO RCCH
+// message via the §4.5.1.1 spec FEC chain (EncodeCACChannel):
+// 155 info bits (8 SR + 144 L3 + 3 Null) → CRC-16 → 4 tail →
+// K=5 R=1/2 → puncture(50/350) → 25×12 interleave → 300 channel
+// bits = 150 dibits.
+func buildNXDNSpecEncodedDibits(repeats int, siteID, systemID uint16) []uint8 {
+	// LICH for RCCH outbound control channel.
+	lichInfo := nxdn.AssembleLICH(nxdn.LICH{RFCh: nxdn.RFChControl})
+	lichWire := nxdn.EncodeLICHWire(lichInfo)
+	lichDibits := framing.BitsToDibits(lichWire)
+
+	// SITE_INFO L3 prefix: 1 byte RCCH type + 8 bytes payload.
+	var payload [8]byte
+	binary.BigEndian.PutUint16(payload[0:2], 0xAAAA)
+	binary.BigEndian.PutUint16(payload[2:4], siteID)
+	binary.BigEndian.PutUint16(payload[4:6], systemID)
+	l3 := make([]byte, 9)
+	l3[0] = byte(nxdn.RCCHSITEINFO)
+	copy(l3[1:9], payload[:])
+
+	// Build the 155-bit spec info block: SR zero + L3 prefix +
+	// trailing zeros + 3 Null bits.
+	info := make([]byte, nxdn.CACInfoBits)
+	l3Bits := framing.UnpackBitsMSB(l3, 72)
+	copy(info[8:8+72], l3Bits)
+
+	channel := nxdn.EncodeCACChannel(info)
+	cacDibits := framing.BitsToDibits(channel)
+
+	frame := make([]uint8, 0, 8+len(lichDibits)+len(cacDibits))
+	frame = append(frame, nxdn.FSWDibitsOutbound...)
+	frame = append(frame, lichDibits...)
+	frame = append(frame, cacDibits...)
+
+	out := make([]uint8, 0, 300+repeats*(len(frame)+50)+100)
+	for i := 0; i < 300; i++ {
+		out = append(out, uint8(i&3))
+	}
+	for r := 0; r < repeats; r++ {
+		out = append(out, frame...)
+		for i := 0; i < 50; i++ {
+			out = append(out, uint8(i&3))
+		}
+	}
+	for i := 0; i < 100; i++ {
+		out = append(out, uint8(i&3))
+	}
+	return out
+}

--- a/internal/radio/nxdn/control.go
+++ b/internal/radio/nxdn/control.go
@@ -16,6 +16,19 @@ type LockState struct {
 	SystemID    uint16
 }
 
+// LockedFrequencyHz / LockedNAC make LockState satisfy
+// trunking.LockedPayload so the cchunt supervisor's state
+// machine recognises NXDN lock events alongside the protocol-
+// neutral P25 / DMR / TETRA payloads it already handles.
+//
+// NXDN doesn't have a P25-style NAC; the SiteID is the closest
+// per-cell identifier (it scopes the lock to a specific repeater
+// + site combination), so it's plumbed into the "NAC" slot.
+// Downstream consumers that key off LockedNAC see a stable
+// per-site value across re-locks.
+func (s LockState) LockedFrequencyHz() uint32 { return s.FrequencyHz }
+func (s LockState) LockedNAC() uint16         { return s.SiteID }
+
 // ControlChannel ingests parsed NXDN frames whose LICH indicates RCCH
 // (control channel), reads the CAC payload, and emits cc.locked when it
 // observes a SITE_INFO or CCH announcement message that confirms the

--- a/internal/radio/nxdn/receiver/receiver.go
+++ b/internal/radio/nxdn/receiver/receiver.go
@@ -22,6 +22,8 @@
 package receiver
 
 import (
+	"math"
+
 	"github.com/MattCheramie/GopherTrunk/internal/dsp/demod"
 	"github.com/MattCheramie/GopherTrunk/internal/dsp/sync"
 	"github.com/MattCheramie/GopherTrunk/internal/radio/nxdn"
@@ -57,6 +59,15 @@ type Options struct {
 	Alpha float64
 	// ClockGain is the Mueller-Müller loop gain. <= 0 uses 0.05.
 	ClockGain float64
+	// DeviationHz is the peak frequency deviation of the C4FM
+	// signal at symbol ±3 (1800 Hz on NXDN per the Common Air
+	// Interface spec — same value P25 Phase 1 uses). Used to
+	// calibrate the slicer thresholds against the
+	// FM-discriminator output level (slicer scale =
+	// 2π · DeviationHz / SampleRateHz). <= 0 falls back to the
+	// legacy slicerScale = 1.0 — back-compat with fixtures that
+	// pre-scale their FM levels.
+	DeviationHz float64
 }
 
 // Receiver is the composed IQ → dibit pipeline.
@@ -99,7 +110,15 @@ func New(opts Options) *Receiver {
 	if gain <= 0 {
 		gain = 0.05
 	}
-	const slicerScale = 1.0
+	// Slicer thresholds: when DeviationHz is set, calibrate
+	// against the physical FM-discriminator level so a real
+	// captured / synthesized signal slices correctly. Without it,
+	// fall back to the legacy "FM-output-already-normalised-to-±1"
+	// thresholds (matches existing fixture tests that pre-scale).
+	slicerScale := 1.0
+	if opts.DeviationHz > 0 {
+		slicerScale = 2.0 * math.Pi * opts.DeviationHz / opts.SampleRateHz
+	}
 
 	return &Receiver{
 		fm:        demod.NewFM(),

--- a/internal/scanner/ccdecoder/pipelines.go
+++ b/internal/scanner/ccdecoder/pipelines.go
@@ -383,6 +383,11 @@ func newNXDNPipeline(opts PipelineOptions) (ProtocolPipeline, error) {
 	}
 	rx := nxdnrx.New(nxdnrx.Options{
 		SampleRateHz: opts.SampleRateHz,
+		// NXDN spec peak deviation per the Common Air Interface
+		// (same value P25 Phase 1 uses). Calibrates the slicer
+		// thresholds against the FM-discriminator output level so
+		// live captures slice correctly out of the box.
+		DeviationHz: 1800.0,
 		DibitSink: func(dibits []uint8, baseIdx int) {
 			cc.Process(dibits, baseIdx)
 		},


### PR DESCRIPTION
## Summary

First sibling of `integration-cc` covering a second protocol end-to-end. Boots the daemon with a mock SDR replaying a fully-synthesized **NXDN-TS-1-A §4.6 RCCH outbound frame** (FSW + LICH + 150-dibit CAC carrying a SITE_INFO RCCH message through the §4.5.1.1 spec FEC chain shipped in PR #144), and asserts the production `newNXDNPipeline` + `nxdn_viterbi_mode: spec` recover the lock and surface it through the bus + supervisor + API + metrics.

The C4FM modulator + RRC shaping primitive from PR #148 carries straight over — NXDN's 9600-baud 4-FSK / α = 0.20 / 1800 Hz deviation matches P25 Phase 1's modulation exactly. The differences are framing (192-dibit / 80 ms frames, 8-dibit FSW, LICH + CAC vs P25's NID + TSBK) and channel coding above the demod, both wired by earlier PRs.

## Plumbing

- **`nxdn/receiver` gains `Options.DeviationHz`** with the same slicer-calibration semantics as the P25 Phase 1 receiver from PR #148. The ccdecoder's `newNXDNPipeline` factory passes the spec 1800 Hz value so live captures slice correctly out of the box.

- **`nxdn.LockState` now implements `trunking.LockedPayload`** (`LockedFrequencyHz` + `LockedNAC` methods). NXDN doesn't have a P25-style NAC; the SiteID is the closest per-cell identifier and is plumbed into the NAC slot. **Without this, cc.locked events fired correctly but the cchunt supervisor's state machine silently dropped them on the type-assertion check and `/api/v1/scanner` never surfaced `state=locked` for NXDN systems.** Latent pre-existing bug surfaced by adding the integration test — P25 P1's `phase1.LockState` already implements `LockedPayload`, so the P25 path didn't hit it.

- **New `make integration-cc-nxdn` Makefile target** runs only the new test. Both `make integration-cc` and `make integration-cc-nxdn` also fire under `make integration`.

## Test plan

- [x] `go test ./...` clean
- [x] `go vet ./...` clean
- [x] `make integration` clean
- [x] `make integration-cc-nxdn` clean
- [x] 20-iteration flakiness check on `TestDaemonCCDecodesNXDN` — all pass

## Followup (per "next sibling integration-cc" punch list)

1. ~~NXDN integration-cc~~ ✅
2. DMR Tier III integration-cc
3. dPMR Mode 3 integration-cc
4. GFSK modulator (unlocks EDACS + Motorola Type II)
5. π/4-DQPSK modulator (unlocks TETRA + P25 P2)
6. FFSK modulator (unlocks MPT 1327)
7. Sub-audible Manchester (unlocks LTR)

https://claude.ai/code/session_019dtCCVEZJTKKr6YK3wy824

---
_Generated by [Claude Code](https://claude.ai/code/session_019dtCCVEZJTKKr6YK3wy824)_