### PR TITLE
cmd/gophertrunk: make integration-cc-dpmr — dPMR Mode 3 end-to-end lights-up check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ TAGS    ?=
 GO      ?= go
 PKGS    := ./...
 
-.PHONY: all build test integration integration-cc integration-cc-nxdn integration-cc-dmr lint tidy vet clean run proto
+.PHONY: all build test integration integration-cc integration-cc-nxdn integration-cc-dmr integration-cc-dpmr lint tidy vet clean run proto
 
 all: build
 
@@ -46,6 +46,13 @@ integration-cc-nxdn:
 # the lock.
 integration-cc-dmr:
 	$(GO) test -tags "integration $(TAGS)" -race -count=1 -run TestDaemonCCDecodesDMRTier3 ./cmd/gophertrunk/...
+
+# integration-cc-dpmr boots the daemon with synthesized 2400-baud 4-FSK IQ
+# carrying a 24-dibit FS3 sync + 40-dibit StandingServiceStatus CSBK and
+# asserts the production newDPMRPipeline + supervisor + API + metrics
+# chain recovers the lock.
+integration-cc-dpmr:
+	$(GO) test -tags "integration $(TAGS)" -race -count=1 -run TestDaemonCCDecodesDPMR ./cmd/gophertrunk/...
 
 vet:
 	$(GO) vet -tags "$(TAGS)" $(PKGS)

--- a/README.md
+++ b/README.md
@@ -199,6 +199,36 @@ to its own package and lands independently.
 
 ### Recently shipped
 
+- **`make integration-cc-dpmr` — dPMR Mode 3 end-to-end
+  lights-up check.** Fourth per-protocol sibling of
+  `integration-cc`. Boots the daemon with a mock SDR
+  replaying synthesized dPMR Mode 3 IQ (24-dibit FS3 sync
+  + 40-dibit / 80-bit `StandingServiceStatus` CSBK), and
+  asserts the production `newDPMRPipeline` + supervisor +
+  API + metrics chain recovers the lock.
+  - `internal/radio/dpmr/receiver` picks up the same
+    `Options.DeviationHz` slicer-calibration knob as the
+    P25 P1 / NXDN / DMR receivers (PRs #148 / #149 / #150).
+    The ccdecoder's `newDPMRPipeline` passes **900 Hz** —
+    half the P25 / DMR / YSF deviation, matching the
+    6.25 kHz channel spacing dPMR targets.
+  - `dpmr.LockState` now implements
+    `trunking.LockedPayload` (`LockedFrequencyHz` +
+    `LockedNAC`). dPMR doesn't have a P25-style NAC; the
+    low 16 bits of SystemID are the closest per-cell
+    identifier and get plumbed into the NAC slot. Same
+    latent-bug class as the NXDN fix in PR #149 — without
+    these methods, the supervisor's type-assertion on
+    cc.locked silently drops the event and
+    `/api/v1/scanner` never surfaces `state=locked`.
+  - The C4FM modulator from PR #148 handles dPMR's
+    half-rate 2400 sym/s modulation directly via the `sps`
+    parameter (20 instead of P25/DMR/NXDN's 10 at the same
+    sample rate). No DSP changes needed.
+  - 30-run flakiness check clean on first try — the lower
+    symbol rate + lower deviation gives the MM clock loop
+    a comfortable margin without needing the ClockGain
+    tweak DMR needed in PR #150.
 - **`make integration-cc-dmr` — DMR Tier III end-to-end
   lights-up check.** Third per-protocol sibling of
   `integration-cc`. Boots the daemon with a mock SDR
@@ -1378,6 +1408,7 @@ make integration           # boots the wired daemon end-to-end (no SDR needed)
 make integration-cc        # P25 Phase 1 "lights up live trunked reception"
 make integration-cc-nxdn   # NXDN "lights up" — synthesizes spec FEC chain
 make integration-cc-dmr    # DMR Tier III "lights up" — Aloha CSBK via BPTC
+make integration-cc-dpmr   # dPMR Mode 3 "lights up" — FS3 sync + 80-bit CSBK
 
 ./bin/gophertrunk version
 ./bin/gophertrunk sdr list                # enumerates attached dongles

--- a/cmd/gophertrunk/integration_cc_dpmr_test.go
+++ b/cmd/gophertrunk/integration_cc_dpmr_test.go
@@ -1,0 +1,173 @@
+//go:build integration
+
+package main
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/config"
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/demod"
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/dpmr"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+	"github.com/MattCheramie/GopherTrunk/internal/sdr"
+)
+
+// TestDaemonCCDecodesDPMR is the per-protocol sibling of the
+// P25 P1 / NXDN / DMR Tier III integration-cc tests. Boots the
+// daemon with a mock SDR replaying a fully-synthesized dPMR
+// Mode 3 control-channel stream (24-dibit FS3 sync + 40-dibit /
+// 80-bit StandingServiceStatus CSBK), and asserts the production
+// newDPMRPipeline + supervisor + API + metrics chain recovers
+// the lock.
+//
+// dPMR Mode 3 runs 4-level C4FM at 2400 sym/s — half the symbol
+// rate of P25 P1 / DMR — with 900 Hz peak deviation and α = 0.20
+// RRC. The C4FM modulator from PR #148 handles it; per-protocol
+// differences from the P25 P1 test are the symbol rate (2400
+// instead of 4800), the deviation (900 instead of 1800), and the
+// framing (FS3 sync + 80-bit CSBK vs FSW + NID + TSBK).
+func TestDaemonCCDecodesDPMR(t *testing.T) {
+	const (
+		controlFreqHz = 446_018_750
+		sampleRateHz  = 48_000
+		// At 2400 sym/s with 48 kHz sample rate, sps = 20 — twice
+		// the P25 P1 / DMR / NXDN value because dPMR is half-rate.
+		sps         = 20
+		span        = 8
+		alpha       = 0.20
+		deviationHz = 900.0
+		systemID    = uint32(0x123456)
+		csbkRepeats = 30
+	)
+
+	dibits := buildDPMRSiteBroadcastDibits(csbkRepeats, systemID)
+	iq := demod.ModulateC4FM(dibits, sps, span, alpha, sampleRateHz, deviationHz)
+
+	dir := t.TempDir()
+	iqPath := filepath.Join(dir, "dpmr-cc.cfile")
+	if err := writeIQToU8File(iqPath, iq); err != nil {
+		t.Fatalf("write IQ: %v", err)
+	}
+	sdr.Register(&sdr.MockDriver{Files: []string{iqPath}})
+
+	cfg := config.Default()
+	cfg.SDR.SampleRate = sampleRateHz
+	cfg.SDR.Devices = []config.DeviceConfig{
+		{Serial: "mock-00", Role: "control"},
+	}
+	cfg.Trunking.Systems = []config.SystemConfig{
+		{Name: "DPMRSite", Protocol: "dpmr", ControlChannels: []uint32{controlFreqHz}},
+	}
+	cfg.API.HTTPAddr = freeAddr(t)
+	cfg.Metrics.Enabled = true
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	d, err := NewDaemon(cfg, "integration-cc-dpmr", logger)
+	if err != nil {
+		t.Fatalf("NewDaemon: %v", err)
+	}
+	if d.ccDecoder == nil {
+		t.Fatalf("ccDecoder is nil; daemon should have constructed one")
+	}
+
+	sub := d.Bus().Subscribe()
+	defer sub.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	runErrCh := make(chan error, 1)
+	go func() { runErrCh <- d.Run(ctx) }()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case <-runErrCh:
+		case <-time.After(3 * time.Second):
+		}
+	})
+
+	base := "http://" + cfg.API.HTTPAddr
+	waitReachable(t, base+"/api/v1/health", 3*time.Second)
+
+	deadline := time.After(5 * time.Second)
+	var locked bool
+WaitLoop:
+	for !locked {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind != events.KindCCLocked {
+				continue
+			}
+			ls, ok := ev.Payload.(dpmr.LockState)
+			if !ok {
+				t.Errorf("CCLocked payload type = %T, want dpmr.LockState", ev.Payload)
+				continue
+			}
+			if ls.SystemID != systemID {
+				t.Errorf("LockState.SystemID = %#x, want %#x", ls.SystemID, systemID)
+			}
+			if ls.FrequencyHz != controlFreqHz {
+				t.Errorf("LockState.FrequencyHz = %d, want %d", ls.FrequencyHz, controlFreqHz)
+			}
+			locked = true
+			break WaitLoop
+		case <-deadline:
+			t.Fatalf("no cc.locked event arrived within 5s")
+		}
+	}
+
+	waitForScannerLock(t, base, "DPMRSite", 2*time.Second)
+
+	body := scrape(t, base+"/metrics")
+	if !strings.Contains(body, "gophertrunk_control_channel_locked{") {
+		t.Errorf("/metrics missing gophertrunk_control_channel_locked gauge family:\n%s", body)
+	}
+	if !strings.Contains(body, `gophertrunk_events_total{kind="cc.locked"} 1`) {
+		t.Errorf("/metrics did not count one cc.locked event:\n%s", body)
+	}
+}
+
+// buildDPMRSiteBroadcastDibits assembles a dPMR Mode 3 dibit
+// stream for the C4FM modulator + receiver chain:
+//
+//   - 400-dibit warmup cycling 0..3 so the Mueller-Müller clock
+//     recovery sees every symbol level (dPMR's half-rate
+//     symbol stream means each warmup dibit covers twice the
+//     wall-time of a P25 P1 / DMR dibit; the longer count
+//     keeps the convergence time comparable in absolute terms)
+//   - `repeats` × (24-dibit FS3 sync + 40-dibit CSBK + 16 idle
+//     dibits)
+//   - 100-dibit trailer for clean flush
+//
+// Each frame's CSBK is a StandingServiceStatus carrying the
+// requested SystemID — the dPMR control state machine's
+// canonical "lock me" message.
+func buildDPMRSiteBroadcastDibits(repeats int, systemID uint32) []uint8 {
+	csbk := dpmr.CSBK{Type: dpmr.MsgStandingServiceStatus, DestID: systemID, Extra: 0x42}
+	csbkBits := dpmr.CSBKBits(csbk)
+	csbkDibits := framing.BitsToDibits(csbkBits)
+
+	frame := make([]uint8, 0, 24+len(csbkDibits))
+	frame = append(frame, dpmr.FS3Dibits()...)
+	frame = append(frame, csbkDibits...)
+
+	out := make([]uint8, 0, 400+repeats*(len(frame)+16)+100)
+	for i := 0; i < 400; i++ {
+		out = append(out, uint8(i&3))
+	}
+	for r := 0; r < repeats; r++ {
+		out = append(out, frame...)
+		for i := 0; i < 16; i++ {
+			out = append(out, uint8(i&3))
+		}
+	}
+	for i := 0; i < 100; i++ {
+		out = append(out, uint8(i&3))
+	}
+	return out
+}

--- a/internal/radio/dpmr/control.go
+++ b/internal/radio/dpmr/control.go
@@ -16,6 +16,17 @@ type LockState struct {
 	SystemID    uint32 // first StandingServiceStatus' DestID, when seen
 }
 
+// LockedFrequencyHz / LockedNAC make LockState satisfy
+// trunking.LockedPayload so the cchunt supervisor's state machine
+// recognises dPMR lock events alongside the protocol-neutral P25 /
+// DMR / NXDN / TETRA payloads. dPMR doesn't have a P25-style NAC;
+// the low 16 bits of SystemID are the closest per-cell identifier
+// and get plumbed into the NAC slot. Without these methods, the
+// supervisor's type-assertion on cc.locked silently drops the event
+// and /api/v1/scanner never surfaces state=locked.
+func (s LockState) LockedFrequencyHz() uint32 { return s.FrequencyHz }
+func (s LockState) LockedNAC() uint16         { return uint16(s.SystemID) }
+
 // ControlChannel ingests CSBKs from a single dPMR Mode 3 control
 // channel, emits cc.locked the first time a valid StandingServiceStatus
 // (or any non-idle CSBK) arrives on a freshly-tuned device, and

--- a/internal/radio/dpmr/receiver/receiver.go
+++ b/internal/radio/dpmr/receiver/receiver.go
@@ -18,6 +18,8 @@
 package receiver
 
 import (
+	"math"
+
 	"github.com/MattCheramie/GopherTrunk/internal/dsp/demod"
 	"github.com/MattCheramie/GopherTrunk/internal/dsp/sync"
 	"github.com/MattCheramie/GopherTrunk/internal/radio/dpmr"
@@ -52,6 +54,14 @@ type Options struct {
 	Alpha float64
 	// ClockGain is the Mueller-Müller loop gain. <= 0 uses 0.05.
 	ClockGain float64
+	// DeviationHz is the peak frequency deviation of the C4FM
+	// signal at symbol ±3 (900 Hz on dPMR Mode 3 — half of P25 /
+	// DMR / YSF, matching the 6.25 kHz channel spacing). Used to
+	// calibrate the slicer thresholds against the FM-discriminator
+	// output level (slicer scale = 2π · DeviationHz / SampleRateHz).
+	// <= 0 falls back to the legacy slicerScale = 1.0 for fixtures
+	// that pre-scale their FM levels.
+	DeviationHz float64
 }
 
 // Receiver is the composed IQ → dibit pipeline.
@@ -94,7 +104,14 @@ func New(opts Options) *Receiver {
 	if gain <= 0 {
 		gain = 0.05
 	}
-	const slicerScale = 1.0
+	// Slicer thresholds: calibrate against physical FM level when
+	// DeviationHz is set (same fix as the P25 P1 / NXDN / DMR
+	// receivers). Legacy "FM-output-normalised-to-±1" fixtures
+	// stay green via the fallback.
+	slicerScale := 1.0
+	if opts.DeviationHz > 0 {
+		slicerScale = 2.0 * math.Pi * opts.DeviationHz / opts.SampleRateHz
+	}
 
 	return &Receiver{
 		fm:        demod.NewFM(),

--- a/internal/scanner/ccdecoder/pipelines.go
+++ b/internal/scanner/ccdecoder/pipelines.go
@@ -312,6 +312,11 @@ func newDPMRPipeline(opts PipelineOptions) (ProtocolPipeline, error) {
 	})
 	rx := dpmrrx.New(dpmrrx.Options{
 		SampleRateHz: opts.SampleRateHz,
+		// dPMR Mode 3 peak deviation — half of P25 / DMR / YSF,
+		// matching the 6.25 kHz channel spacing. Calibrates
+		// slicer thresholds against the FM-discriminator output
+		// level so live captures slice correctly.
+		DeviationHz: 900.0,
 		DibitSink: func(dibits []uint8, baseIdx int) {
 			cc.Process(dibits, baseIdx)
 		},


### PR DESCRIPTION
## Summary

Fourth per-protocol sibling of `integration-cc`. Boots the daemon with a mock SDR replaying synthesized **dPMR Mode 3** IQ (24-dibit FS3 sync + 40-dibit / 80-bit `StandingServiceStatus` CSBK), and asserts the production `newDPMRPipeline` + supervisor + API + metrics chain recovers the lock.

## Plumbing

- **`internal/radio/dpmr/receiver` gains `Options.DeviationHz`** with the same slicer-calibration semantics as the P25 P1 / NXDN / DMR receivers (PRs #148 / #149 / #150). The ccdecoder's `newDPMRPipeline` passes **900 Hz** — half the P25 / DMR / YSF deviation, matching the 6.25 kHz channel spacing dPMR targets.
- **`dpmr.LockState` now implements `trunking.LockedPayload`** (`LockedFrequencyHz` + `LockedNAC`). dPMR doesn't have a P25-style NAC; the low 16 bits of SystemID are the closest per-cell identifier and get plumbed into the NAC slot. **Same latent-bug class as the NXDN fix in PR #149** — without these methods, the supervisor's type-assertion on cc.locked silently drops the event and `/api/v1/scanner` never surfaces `state=locked`.
- **The C4FM modulator from PR #148 handles dPMR's half-rate 2400 sym/s modulation directly** via the `sps` parameter (20 instead of P25/DMR/NXDN's 10 at the same sample rate). No DSP changes needed.

## Test plan

- [x] `go test ./...` clean
- [x] `go vet ./...` clean
- [x] `make integration` clean
- [x] `make integration-cc-dpmr` clean
- [x] 30-iteration flakiness check on `TestDaemonCCDecodesDPMR` — all pass on first try. Lower symbol rate + lower deviation gives the MM clock loop a comfortable margin without needing the `ClockGain` tweak DMR needed in PR #150.

## Followup (per "next sibling integration-cc" punch list)

1. ~~NXDN integration-cc~~ ✅
2. ~~DMR Tier III integration-cc~~ ✅
3. ~~dPMR Mode 3 integration-cc~~ ✅
4. **GFSK modulator (unlocks EDACS + Motorola Type II)** ← next
5. π/4-DQPSK modulator (unlocks TETRA + P25 P2)
6. FFSK modulator (unlocks MPT 1327)
7. Sub-audible Manchester (unlocks LTR)

Half done on the punch list. The remaining four protocols use modulations the C4FM modulator can't synthesize directly — each needs its own DSP primitive.

https://claude.ai/code/session_019dtCCVEZJTKKr6YK3wy824

---
_Generated by [Claude Code](https://claude.ai/code/session_019dtCCVEZJTKKr6YK3wy824)_