### PR TITLE
cmd/gophertrunk: make integration-cc-motorola — Motorola Type II end-to-end lights-up check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ TAGS    ?=
 GO      ?= go
 PKGS    := ./...
 
-.PHONY: all build test integration integration-cc integration-cc-nxdn integration-cc-dmr integration-cc-dpmr integration-cc-edacs lint tidy vet clean run proto
+.PHONY: all build test integration integration-cc integration-cc-nxdn integration-cc-dmr integration-cc-dpmr integration-cc-edacs integration-cc-motorola lint tidy vet clean run proto
 
 all: build
 
@@ -62,6 +62,14 @@ integration-cc-dpmr:
 # test; exercises the new GFSKModulator primitive in internal/dsp/demod.
 integration-cc-edacs:
 	$(GO) test -tags "integration $(TAGS)" -race -count=1 -run TestDaemonCCDecodesEDACS ./cmd/gophertrunk/...
+
+# integration-cc-motorola boots the daemon with synthesized 3600-baud 2-FSK
+# GFSK IQ (BT = 0.5) carrying a 24-bit outbound sync + 128-bit BCH(64, 16, 11)
+# OSW pair encoding an OpSystemIDExtended announcement. Reuses the GFSKModulator
+# from the EDACS PR; differences are framing + per-codeword BCH instead of
+# whole-CCW BCH.
+integration-cc-motorola:
+	$(GO) test -tags "integration $(TAGS)" -race -count=1 -run TestDaemonCCDecodesMotorola ./cmd/gophertrunk/...
 
 vet:
 	$(GO) vet -tags "$(TAGS)" $(PKGS)

--- a/README.md
+++ b/README.md
@@ -199,6 +199,31 @@ to its own package and lands independently.
 
 ### Recently shipped
 
+- **`make integration-cc-motorola` — Motorola Type II
+  end-to-end lights-up check.** Second non-C4FM protocol
+  to light up through the daemon; reuses the GFSK
+  modulator shipped in PR #152 with different per-protocol
+  framing (Motorola Type II OSW vs EDACS CCW) and a
+  different FEC chain (per-codeword BCH(64, 16, 11)
+  wrapping each 16-bit OSW half vs EDACS' single
+  BCH(40, 28, 2) over the whole CCW).
+  - 3600-baud 2-FSK with BT = 0.5 — the SmartZone
+    standard's tighter-bandwidth profile vs EDACS' 0.3.
+    Sample rate picked at 97.2 kHz so an integer sps = 27
+    matches the receiver's float computation with no
+    rounding drift.
+  - `motorola.LockState` now implements
+    `trunking.LockedPayload` (`LockedFrequencyHz` +
+    `LockedNAC`). Same latent-bug class fixed on NXDN /
+    dPMR / EDACS in PRs #149 / #151 / #152 — fourth
+    protocol with the same shape.
+  - The test synthesizes an `OpSystemIDExtended` OSW
+    (carrying a SystemID announcement) through
+    `framing.BCHEncode64_16` × 2 for the two halves,
+    sandwiches it between the 24-bit outbound sync and
+    idle padding, and asserts the daemon recovers the
+    lock via the `motorola_bch_mode: on` opt-in.
+  - 30-run flakiness check clean.
 - **GFSK modulator + `make integration-cc-edacs`.** First
   non-C4FM protocol to light up end-to-end through the
   daemon's mock-SDR + production-receiver chain.
@@ -1435,14 +1460,15 @@ and DVB-driver blacklisting on Linux.
 ### Build, test, run
 
 ```sh
-make build                 # produces ./bin/gophertrunk
-make test                  # go test -race ./...
-make integration           # boots the wired daemon end-to-end (no SDR needed)
-make integration-cc        # P25 Phase 1 "lights up live trunked reception"
-make integration-cc-nxdn   # NXDN "lights up" — synthesizes spec FEC chain
-make integration-cc-dmr    # DMR Tier III "lights up" — Aloha CSBK via BPTC
-make integration-cc-dpmr   # dPMR Mode 3 "lights up" — FS3 sync + 80-bit CSBK
-make integration-cc-edacs  # EDACS "lights up" — GFSK + BCH(40, 28, 2) CCW
+make build                    # produces ./bin/gophertrunk
+make test                     # go test -race ./...
+make integration              # boots the wired daemon end-to-end (no SDR needed)
+make integration-cc           # P25 Phase 1 "lights up live trunked reception"
+make integration-cc-nxdn      # NXDN "lights up" — synthesizes spec FEC chain
+make integration-cc-dmr       # DMR Tier III "lights up" — Aloha CSBK via BPTC
+make integration-cc-dpmr      # dPMR Mode 3 "lights up" — FS3 sync + 80-bit CSBK
+make integration-cc-edacs     # EDACS "lights up" — GFSK + BCH(40, 28, 2) CCW
+make integration-cc-motorola  # Motorola Type II "lights up" — GFSK + BCH(64, 16, 11) OSW
 
 ./bin/gophertrunk version
 ./bin/gophertrunk sdr list                # enumerates attached dongles

--- a/cmd/gophertrunk/integration_cc_motorola_test.go
+++ b/cmd/gophertrunk/integration_cc_motorola_test.go
@@ -1,0 +1,197 @@
+//go:build integration
+
+package main
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/config"
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/demod"
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/motorola"
+	"github.com/MattCheramie/GopherTrunk/internal/sdr"
+)
+
+// TestDaemonCCDecodesMotorola is the per-protocol sibling of the
+// EDACS integration test (PR #152). Reuses the same GFSK
+// modulator; the differences are framing layer + per-codeword
+// BCH(64, 16, 11) instead of the BCH(40, 28, 2) EDACS uses.
+//
+// Motorola Type II runs 3600-baud 2-FSK with BT = 0.5 (the
+// SmartZone standard's tighter-bandwidth profile vs EDACS' 0.3).
+// Each OSW is 32 bits (16-bit Address + 16-bit Command); under
+// `motorola_bch_mode: on` each half is wrapped in a 64-bit BCH
+// codeword (16 info + 48 parity) for ±11 bit-error correction
+// per half, so the on-air OSW occupies 128 bits = ~36 ms of
+// channel time.
+//
+// The test asserts the production newMotorolaPipeline + BCH-on
+// opt-in + supervisor + API + metrics chain recovers a
+// CmdSystemID-Extended OSW and publishes cc.locked with the
+// encoded SystemID.
+func TestDaemonCCDecodesMotorola(t *testing.T) {
+	const (
+		controlFreqHz = 851_012_500
+		// 27 sps × 3600 symbol rate = 97_200 Hz IQ rate. Picked so
+		// the integer sps matches the receiver's float computation
+		// exactly with no rounding drift.
+		sampleRate  = 97_200.0
+		sps         = 27
+		span        = 4
+		bt          = 0.5
+		deviationHz = 1500.0
+		systemID    = uint16(0x4567)
+		oswRepeats  = 30
+	)
+
+	bits := buildMotorolaSystemIDStream(oswRepeats, systemID)
+	iq := demod.ModulateGFSK(bits, sps, span, bt, sampleRate, deviationHz)
+
+	dir := t.TempDir()
+	iqPath := filepath.Join(dir, "motorola-cc.cfile")
+	if err := writeIQToU8File(iqPath, iq); err != nil {
+		t.Fatalf("write IQ: %v", err)
+	}
+	sdr.Register(&sdr.MockDriver{Files: []string{iqPath}})
+
+	cfg := config.Default()
+	cfg.SDR.SampleRate = uint32(sampleRate)
+	cfg.SDR.Devices = []config.DeviceConfig{
+		{Serial: "mock-00", Role: "control"},
+	}
+	cfg.Trunking.Systems = []config.SystemConfig{
+		{
+			Name:            "MotoSite",
+			Protocol:        "motorola",
+			ControlChannels: []uint32{controlFreqHz},
+			MotorolaBCHMode: "on",
+		},
+	}
+	cfg.API.HTTPAddr = freeAddr(t)
+	cfg.Metrics.Enabled = true
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	d, err := NewDaemon(cfg, "integration-cc-motorola", logger)
+	if err != nil {
+		t.Fatalf("NewDaemon: %v", err)
+	}
+	if d.ccDecoder == nil {
+		t.Fatalf("ccDecoder is nil; daemon should have constructed one")
+	}
+
+	sub := d.Bus().Subscribe()
+	defer sub.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	runErrCh := make(chan error, 1)
+	go func() { runErrCh <- d.Run(ctx) }()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case <-runErrCh:
+		case <-time.After(3 * time.Second):
+		}
+	})
+
+	base := "http://" + cfg.API.HTTPAddr
+	waitReachable(t, base+"/api/v1/health", 3*time.Second)
+
+	deadline := time.After(5 * time.Second)
+	var locked bool
+WaitLoop:
+	for !locked {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind != events.KindCCLocked {
+				continue
+			}
+			ls, ok := ev.Payload.(motorola.LockState)
+			if !ok {
+				t.Errorf("CCLocked payload type = %T, want motorola.LockState", ev.Payload)
+				continue
+			}
+			if ls.SystemID != systemID {
+				t.Errorf("LockState.SystemID = %#x, want %#x", ls.SystemID, systemID)
+			}
+			if ls.FrequencyHz != controlFreqHz {
+				t.Errorf("LockState.FrequencyHz = %d, want %d", ls.FrequencyHz, controlFreqHz)
+			}
+			locked = true
+			break WaitLoop
+		case <-deadline:
+			t.Fatalf("no cc.locked event arrived within 5s")
+		}
+	}
+
+	waitForScannerLock(t, base, "MotoSite", 2*time.Second)
+
+	body := scrape(t, base+"/metrics")
+	if !strings.Contains(body, "gophertrunk_control_channel_locked{") {
+		t.Errorf("/metrics missing gophertrunk_control_channel_locked gauge family:\n%s", body)
+	}
+	if !strings.Contains(body, `gophertrunk_events_total{kind="cc.locked"} 1`) {
+		t.Errorf("/metrics did not count one cc.locked event:\n%s", body)
+	}
+}
+
+// buildMotorolaSystemIDStream assembles a Motorola Type II bit
+// stream for the GFSK modulator + receiver chain:
+//
+//   - 200-bit warmup alternating 0/1 so the Mueller-Müller clock
+//     recovery sees a transition every symbol
+//   - `repeats` × (24-bit outbound sync + 128-bit BCH-encoded
+//     OSW + 16 idle bits)
+//   - 100-bit trailer for clean flush
+//
+// Each OSW carries OpSystemIDExtended with Address = systemID,
+// encoded through framing.BCHEncode64_16 (two 64-bit codewords
+// for the two 16-bit halves) so the production receiver's
+// `motorola_bch_mode: on` BCH layer is exercised on the
+// recovered bits.
+func buildMotorolaSystemIDStream(repeats int, systemID uint16) []byte {
+	// Command = (opcode << 4) | LCN_or_class. For OpSystemIDExtended
+	// (0x080), the low nibble is a per-system class — pick 0 since
+	// the test only asserts on SystemID.
+	command := uint16(motorola.OpSystemIDExtended) << 4
+
+	// BCH-encode each 16-bit half into a 64-bit codeword.
+	cw1 := framing.BCHEncode64_16(systemID)
+	cw2 := framing.BCHEncode64_16(command)
+	encoded := make([]byte, 128)
+	for i := 0; i < 64; i++ {
+		if cw1&(uint64(1)<<uint(63-i)) != 0 {
+			encoded[i] = 1
+		}
+	}
+	for i := 0; i < 64; i++ {
+		if cw2&(uint64(1)<<uint(63-i)) != 0 {
+			encoded[64+i] = 1
+		}
+	}
+
+	frame := make([]byte, 0, 24+128)
+	frame = append(frame, motorola.OutboundSyncBits()...)
+	frame = append(frame, encoded...)
+
+	out := make([]byte, 0, 200+repeats*(len(frame)+16)+100)
+	for i := 0; i < 200; i++ {
+		out = append(out, byte(i&1))
+	}
+	for r := 0; r < repeats; r++ {
+		out = append(out, frame...)
+		for i := 0; i < 16; i++ {
+			out = append(out, byte(i&1))
+		}
+	}
+	for i := 0; i < 100; i++ {
+		out = append(out, byte(i&1))
+	}
+	return out
+}

--- a/internal/radio/motorola/control.go
+++ b/internal/radio/motorola/control.go
@@ -16,6 +16,17 @@ type LockState struct {
 	SystemID    uint16
 }
 
+// LockedFrequencyHz / LockedNAC make LockState satisfy
+// trunking.LockedPayload so the cchunt supervisor's state machine
+// recognises Motorola lock events alongside the protocol-neutral P25 /
+// DMR / NXDN / TETRA payloads. Motorola doesn't have a P25-style NAC;
+// SystemID is the closest per-site identifier and gets plumbed into
+// the NAC slot. Without these methods, the supervisor's type-assertion
+// on cc.locked silently drops the event and /api/v1/scanner never
+// surfaces state=locked.
+func (s LockState) LockedFrequencyHz() uint32 { return s.FrequencyHz }
+func (s LockState) LockedNAC() uint16         { return s.SystemID }
+
 // ControlChannel ingests OSWs from a single SmartZone control channel,
 // emits cc.locked the first time it sees a System-ID announcement on
 // a freshly-tuned device, and republishes voice grants as


### PR DESCRIPTION
## Summary

Second non-C4FM protocol to light up through the daemon. Reuses the **GFSK modulator** shipped in PR #152 with different per-protocol framing (Motorola Type II OSW vs EDACS CCW) and a different FEC chain (per-codeword BCH(64, 16, 11) wrapping each 16-bit OSW half vs EDACS' single BCH(40, 28, 2) over the whole CCW).

## Plumbing

- **`motorola.LockState` now implements `trunking.LockedPayload`** (`LockedFrequencyHz` + `LockedNAC`). Fourth protocol with the same latent-bug pattern fixed on NXDN / dPMR / EDACS in PRs #149 / #151 / #152.
- **No new DSP primitive needed** — the GFSK modulator from PR #152 handles Motorola's 3600-baud 2-FSK / BT = 0.5 directly. Per-protocol differences are the bit rate (3600 vs 9600), the BT product (0.5 vs 0.3), and the BCH layout.
- **Sample rate picked at 97.2 kHz** so an integer sps = 27 matches the receiver's float computation (97200 / 3600) with no rounding drift.

## Test plan

- [x] `go test ./...` clean
- [x] `go vet ./...` clean
- [x] `make integration` clean
- [x] `make integration-cc-motorola` clean
- [x] 30-iteration flakiness check on `TestDaemonCCDecodesMotorola` — all pass

## Followup (per "next sibling integration-cc" punch list)

1. ~~NXDN integration-cc~~ ✅
2. ~~DMR Tier III integration-cc~~ ✅
3. ~~dPMR Mode 3 integration-cc~~ ✅
4. ~~GFSK modulator + EDACS integration-cc~~ ✅
5. ~~Motorola Type II integration-cc~~ ✅ (this PR — reused GFSK modulator)
6. **π/4-DQPSK modulator** (unlocks TETRA + P25 P2)
7. **FFSK modulator** (unlocks MPT 1327)
8. **Sub-audible Manchester** (unlocks LTR)

5/8 done; remaining three each need a different modulation family (DQPSK, FFSK, sub-audible NRZ + Manchester).

https://claude.ai/code/session_019dtCCVEZJTKKr6YK3wy824

---
_Generated by [Claude Code](https://claude.ai/code/session_019dtCCVEZJTKKr6YK3wy824)_