### PR TITLE
cmd/gophertrunk: make integration-cc-p25p2 — P25 Phase 2 end-to-end lights-up check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ TAGS    ?=
 GO      ?= go
 PKGS    := ./...
 
-.PHONY: all build test integration integration-cc integration-cc-nxdn integration-cc-dmr integration-cc-dpmr integration-cc-edacs integration-cc-motorola integration-cc-tetra lint tidy vet clean run proto
+.PHONY: all build test integration integration-cc integration-cc-nxdn integration-cc-dmr integration-cc-dpmr integration-cc-edacs integration-cc-motorola integration-cc-tetra integration-cc-p25p2 lint tidy vet clean run proto
 
 all: build
 
@@ -78,6 +78,15 @@ integration-cc-motorola:
 # exercise the π/4-DQPSK modulator primitive shipped alongside this PR.
 integration-cc-tetra:
 	$(GO) test -tags "integration $(TAGS)" -race -count=1 -run TestDaemonCCDecodesTETRA ./cmd/gophertrunk/...
+
+# integration-cc-p25p2 boots the daemon with synthesized H-DQPSK IQ
+# (6000 sym/s, α = 0.20, π/8 rotation) carrying a 20-dibit outbound sync
+# + 146-dibit trellis-coded MAC PDU and asserts the production
+# newP25Phase2Pipeline + p25_phase2_trellis_mode + supervisor + API +
+# metrics chain recovers the lock. Reuses the π/4-DQPSK modulator from
+# PR #154.
+integration-cc-p25p2:
+	$(GO) test -tags "integration $(TAGS)" -race -count=1 -run TestDaemonCCDecodesP25Phase2 ./cmd/gophertrunk/...
 
 vet:
 	$(GO) vet -tags "$(TAGS)" $(PKGS)

--- a/README.md
+++ b/README.md
@@ -199,6 +199,34 @@ to its own package and lands independently.
 
 ### Recently shipped
 
+- **`make integration-cc-p25p2` — P25 Phase 2 end-to-end
+  lights-up check.** Second protocol to use the
+  π/4-DQPSK modulator shipped in PR #154; reuses the
+  primitive with `rotation = π/8` to synthesize H-DQPSK
+  (the π/8-shifted variant P25 Phase 2 specifies).
+  - 6000 sym/s, α = 0.20 RRC, sps = 8 at the test's 48 kHz
+    sample rate — different from TETRA's 18000 sym/s /
+    α = 0.35 / sps = 4 path, but the modulator's rotation
+    + sps + α parameters cover both cleanly.
+  - `p25phase2.LockState` now implements
+    `trunking.LockedPayload`. Sixth protocol with the same
+    latent-bug class fixed (NXDN / dPMR / EDACS / Motorola
+    / TETRA / P25 Phase 2). P25 Phase 2's MAC PDU header
+    doesn't carry a NAC equivalent — the NAC lives one
+    layer up in the Phase 2 superframe — so `LockedNAC`
+    returns 0; the supervisor uses it only as a cache key
+    on retune, so 0 is harmless.
+  - The P25 Phase 2 pipeline factory tunes its Gardner
+    `ClockGain` to 0.005 (same value as the TETRA factory
+    in PR #154; the 0.03 default over-corrects on clean
+    H-DQPSK signals and slips).
+  - Integration test synthesizes 80 back-to-back
+    `OpMACPTT` MAC PDUs (the canonical "lock me" non-idle
+    PDU) through the production trellis encoder
+    (`framing.EncodeP25Trellis`), wraps each in a 20-dibit
+    outbound sync, and asserts the daemon recovers the
+    lock via `p25_phase2_trellis_mode: on`. 30-run
+    flakiness check clean on first try.
 - **π/4-DQPSK modulator + `make integration-cc-tetra`.**
   First integration test to exercise a non-FSK modulation
   family, lighting up the full TETRA TMO control-channel
@@ -1512,6 +1540,7 @@ make integration-cc-dpmr      # dPMR Mode 3 "lights up" — FS3 sync + 80-bit CS
 make integration-cc-edacs     # EDACS "lights up" — GFSK + BCH(40, 28, 2) CCW
 make integration-cc-motorola  # Motorola Type II "lights up" — GFSK + BCH(64, 16, 11) OSW
 make integration-cc-tetra     # TETRA TMO "lights up" — π/4-DQPSK + full §8.3.1 chain
+make integration-cc-p25p2     # P25 Phase 2 "lights up" — H-DQPSK + trellis MAC PDU
 
 ./bin/gophertrunk version
 ./bin/gophertrunk sdr list                # enumerates attached dongles

--- a/cmd/gophertrunk/integration_cc_p25p2_test.go
+++ b/cmd/gophertrunk/integration_cc_p25p2_test.go
@@ -1,0 +1,178 @@
+//go:build integration
+
+package main
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"math"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/config"
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/demod"
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	p25phase2 "github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase2"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+	"github.com/MattCheramie/GopherTrunk/internal/sdr"
+)
+
+// TestDaemonCCDecodesP25Phase2 is the per-protocol sibling of
+// integration-cc-tetra (PR #154). Boots the daemon with a mock SDR
+// replaying synthesized P25 Phase 2 H-DQPSK IQ (20-dibit outbound
+// sync + 146-dibit trellis-coded MAC PDU) and asserts the
+// production newP25Phase2Pipeline + p25_phase2_trellis_mode + Gardner
+// clock recovery + supervisor + API + metrics chain recovers the
+// lock.
+//
+// H-DQPSK is π/8-shifted differential QPSK at 6000 sym/s with
+// α = 0.20 RRC. The π/4-DQPSK modulator from PR #154 handles it
+// directly via the rotation argument (π/8 instead of π/4 for
+// TETRA's true π/4-DQPSK). Per-protocol differences are:
+//
+//   - rotation = π/8 vs π/4
+//   - symbol rate (6000 vs 18000)
+//   - α (0.20 vs 0.35)
+//   - framing (20-dibit outbound sync + 146 trellis-coded dibits
+//     vs TETRA's 38-dibit normal training sequence + 108 channel
+//     dibits)
+//   - FEC chain (4-state ½-rate trellis vs TETRA's K=5 R=1/4 RCPC)
+func TestDaemonCCDecodesP25Phase2(t *testing.T) {
+	const (
+		controlFreqHz = 851_062_500
+		// 6000 × 8 = 48 kHz IQ rate; sps = 8 (exact integer).
+		sampleRate = 48_000.0
+		sps        = 8
+		span       = 8
+		alpha      = 0.20
+		pduRepeats = 80
+	)
+
+	dibits := buildP25Phase2MACPTTStream(pduRepeats)
+	iq := demod.ModulatePiOver4DQPSK(dibits, sps, span, alpha, math.Pi/8)
+
+	dir := t.TempDir()
+	iqPath := filepath.Join(dir, "p25p2-cc.cfile")
+	if err := writeIQToU8File(iqPath, iq); err != nil {
+		t.Fatalf("write IQ: %v", err)
+	}
+	sdr.Register(&sdr.MockDriver{Files: []string{iqPath}})
+
+	cfg := config.Default()
+	cfg.SDR.SampleRate = uint32(sampleRate)
+	cfg.SDR.Devices = []config.DeviceConfig{
+		{Serial: "mock-00", Role: "control"},
+	}
+	cfg.Trunking.Systems = []config.SystemConfig{
+		{
+			Name:                 "P25P2Site",
+			Protocol:             "p25-phase2",
+			ControlChannels:      []uint32{controlFreqHz},
+			P25Phase2TrellisMode: "on",
+		},
+	}
+	cfg.API.HTTPAddr = freeAddr(t)
+	cfg.Metrics.Enabled = true
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	d, err := NewDaemon(cfg, "integration-cc-p25p2", logger)
+	if err != nil {
+		t.Fatalf("NewDaemon: %v", err)
+	}
+	if d.ccDecoder == nil {
+		t.Fatalf("ccDecoder is nil; daemon should have constructed one")
+	}
+
+	sub := d.Bus().Subscribe()
+	defer sub.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	runErrCh := make(chan error, 1)
+	go func() { runErrCh <- d.Run(ctx) }()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case <-runErrCh:
+		case <-time.After(3 * time.Second):
+		}
+	})
+
+	base := "http://" + cfg.API.HTTPAddr
+	waitReachable(t, base+"/api/v1/health", 3*time.Second)
+
+	deadline := time.After(5 * time.Second)
+	var locked bool
+WaitLoop:
+	for !locked {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind != events.KindCCLocked {
+				continue
+			}
+			ls, ok := ev.Payload.(p25phase2.LockState)
+			if !ok {
+				t.Errorf("CCLocked payload type = %T, want p25phase2.LockState", ev.Payload)
+				continue
+			}
+			if ls.FrequencyHz != controlFreqHz {
+				t.Errorf("LockState.FrequencyHz = %d, want %d", ls.FrequencyHz, controlFreqHz)
+			}
+			locked = true
+			break WaitLoop
+		case <-deadline:
+			t.Fatalf("no cc.locked event arrived within 5s")
+		}
+	}
+
+	waitForScannerLock(t, base, "P25P2Site", 2*time.Second)
+
+	body := scrape(t, base+"/metrics")
+	if !strings.Contains(body, "gophertrunk_control_channel_locked{") {
+		t.Errorf("/metrics missing gophertrunk_control_channel_locked gauge family:\n%s", body)
+	}
+	if !strings.Contains(body, `gophertrunk_events_total{kind="cc.locked"} 1`) {
+		t.Errorf("/metrics did not count one cc.locked event:\n%s", body)
+	}
+}
+
+// buildP25Phase2MACPTTStream assembles a P25 Phase 2 dibit stream
+// for the H-DQPSK modulator + receiver chain:
+//
+//   - 400-dibit warmup cycling 0..3 so the matched filter +
+//     differential decoder converge on the constellation centre
+//   - `repeats` × (20-dibit outbound sync + 146-dibit
+//     trellis-coded MAC PDU + 30 idle dibits)
+//   - 100-dibit trailer for clean flush
+//
+// Each PDU is an OpMACPTT (PTT-on, the canonical "lock me"
+// non-idle MAC PDU). The 72 info dibits run through the
+// TIA-102 Annex A 4-state ½-rate trellis encoder via
+// framing.EncodeP25Trellis.
+func buildP25Phase2MACPTTStream(repeats int) []uint8 {
+	pdu := p25phase2.MACPDU{Opcode: p25phase2.OpMACPTT, Payload: make([]byte, 17)}
+	pduBits := framing.UnpackBitsMSB(p25phase2.AssembleMACPDU(pdu), 144)
+	infoDibits := framing.BitsToDibits(pduBits)
+	channelDibits := framing.EncodeP25Trellis(infoDibits)
+
+	frame := make([]uint8, 0, 20+len(channelDibits))
+	frame = append(frame, p25phase2.OutboundSyncDibits()...)
+	frame = append(frame, channelDibits...)
+
+	out := make([]uint8, 0, 400+repeats*(len(frame)+30)+100)
+	for i := 0; i < 400; i++ {
+		out = append(out, uint8(i&3))
+	}
+	for r := 0; r < repeats; r++ {
+		out = append(out, frame...)
+		for i := 0; i < 30; i++ {
+			out = append(out, uint8(i&3))
+		}
+	}
+	for i := 0; i < 100; i++ {
+		out = append(out, uint8(i&3))
+	}
+	return out
+}

--- a/internal/radio/p25/phase2/control.go
+++ b/internal/radio/p25/phase2/control.go
@@ -186,6 +186,19 @@ type LockState struct {
 	FrequencyHz uint32
 }
 
+// LockedFrequencyHz / LockedNAC make LockState satisfy
+// trunking.LockedPayload so the cchunt supervisor's state machine
+// recognises P25 Phase 2 lock events alongside the protocol-neutral
+// P25 Phase 1 / DMR / NXDN / TETRA payloads. Phase 2's MAC PDU
+// header doesn't carry a NAC equivalent (the NAC lives one layer
+// up in the Phase 2 superframe), so LockedNAC returns 0; the
+// supervisor uses it only as a cache key on retune, so 0 is
+// harmless. Without these methods, the supervisor's type-assertion
+// on cc.locked silently drops the event and /api/v1/scanner never
+// surfaces state=locked.
+func (s LockState) LockedFrequencyHz() uint32 { return s.FrequencyHz }
+func (s LockState) LockedNAC() uint16         { return 0 }
+
 func (c *ControlChannel) publishGrant(g GroupVoiceChannelGrant, op Opcode) {
 	if c.bus == nil {
 		return

--- a/internal/scanner/ccdecoder/pipelines.go
+++ b/internal/scanner/ccdecoder/pipelines.go
@@ -197,6 +197,12 @@ func newP25Phase2Pipeline(opts PipelineOptions) (ProtocolPipeline, error) {
 			cc.Process(dibits, baseIdx)
 		},
 		ClockMode: p25phase2rx.ClockGardner,
+		// Tuned smaller than the 0.03 default — H-DQPSK at
+		// 6000 sym/s has the same slip behaviour as TETRA's
+		// π/4-DQPSK at the default gain (see PR #154). 0.005
+		// tracks both clean synthesized IQ and noisier on-air
+		// captures within the loop's lock-acquisition margin.
+		GardnerGain: 0.005,
 	})
 	return &p25Phase2Pipeline{rx: rx, cc: cc}, nil
 }


### PR DESCRIPTION
## Summary

Second protocol to use the **π/4-DQPSK modulator** shipped in PR #154 — this time with `rotation = π/8` to synthesize H-DQPSK (the π/8-shifted variant P25 Phase 2 specifies). Pattern matches the GFSK reuse for EDACS + Motorola in PRs #152 / #153.

## Plumbing

- **`p25phase2.LockState` now implements `trunking.LockedPayload`**. **Sixth protocol with the same latent-bug class fixed** (NXDN / dPMR / EDACS / Motorola / TETRA / P25 Phase 2). P25 Phase 2's MAC PDU header doesn't carry a NAC equivalent — the NAC lives one layer up in the Phase 2 superframe — so `LockedNAC` returns 0; the supervisor uses it only as a cache key on retune, so 0 is harmless.
- **The P25 Phase 2 pipeline factory tunes its Gardner `ClockGain` to 0.005** (same value as the TETRA factory in PR #154). The 0.03 default over-corrects on clean H-DQPSK signals and slips.
- **Integration test** synthesizes 80 back-to-back `OpMACPTT` MAC PDUs (the canonical "lock me" non-idle PDU) through the production trellis encoder (`framing.EncodeP25Trellis`), wraps each in a 20-dibit outbound sync, and asserts the daemon recovers the lock via `p25_phase2_trellis_mode: on`.

## Test plan

- [x] `go test ./...` clean
- [x] `go vet ./...` clean
- [x] `make integration` clean
- [x] `make integration-cc-p25p2` clean
- [x] 30-iteration flakiness check on `TestDaemonCCDecodesP25Phase2` — all pass on first try

## Followup (per "next sibling integration-cc" punch list)

1. ~~NXDN integration-cc~~ ✅
2. ~~DMR Tier III integration-cc~~ ✅
3. ~~dPMR Mode 3 integration-cc~~ ✅
4. ~~GFSK modulator + EDACS integration-cc~~ ✅
5. ~~Motorola Type II integration-cc~~ ✅
6. ~~π/4-DQPSK modulator + TETRA integration-cc~~ ✅
7. ~~P25 Phase 2 integration-cc~~ ✅ (this PR — reused π/4-DQPSK)
8. **FFSK modulator** (unlocks MPT 1327)
9. **Sub-audible Manchester** (unlocks LTR)

7/9 done. Remaining two each need a dedicated modulator (FFSK at 1200 baud audio-band, Manchester at 150 baud sub-audible).

https://claude.ai/code/session_019dtCCVEZJTKKr6YK3wy824

---
_Generated by [Claude Code](https://claude.ai/code/session_019dtCCVEZJTKKr6YK3wy824)_