### PR TITLE
internal/voice/player + internal/api: live audio playback + TUI/API audio cockpit

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,20 @@ The remaining gaps:
   unit tests; calibration against a captured YSF transmission's
   exact interleaver / puncture schedule lands once a real-air capture
   is available.
+- **Live audio playback to speakers.** The daemon now ships a
+  `voice.Player` sink (`internal/voice/player`) wrapping
+  github.com/ebitengine/oto/v3 (ALSA on Linux, CoreAudio on macOS,
+  WASAPI on Windows; libasound2-dev required at build time on Linux).
+  When `audio.enabled: true` is set in config the per-call composer
+  and the conventional FM scanner fan PCM into the player alongside
+  the existing WAV recorder, so calls play out the host's default
+  output device in real time. Software gain stage in front of the
+  backend makes volume and mute changes instant. Disabled by default;
+  headless servers stay silent and continue to record WAVs identically
+  to before. TUI volume / mute / record-toggle keybindings + REST
+  mutation endpoints (`/api/v1/audio/*`) are the next follow-up — for
+  now operators tune via the `audio.volume` and `audio.muted` config
+  fields. New CLI: `gophertrunk audio list` mirrors `sdr list`.
 
 The Go interfaces and event payloads carry every protocol already;
 the remaining decoder wiring is the load-bearing follow-up.

--- a/README.md
+++ b/README.md
@@ -156,20 +156,24 @@ The remaining gaps:
   unit tests; calibration against a captured YSF transmission's
   exact interleaver / puncture schedule lands once a real-air capture
   is available.
-- **Live audio playback to speakers.** The daemon now ships a
-  `voice.Player` sink (`internal/voice/player`) wrapping
+- **Live audio playback to speakers + TUI / API audio cockpit.** The
+  daemon ships a `voice.Player` sink (`internal/voice/player`) wrapping
   github.com/ebitengine/oto/v3 (ALSA on Linux, CoreAudio on macOS,
   WASAPI on Windows; libasound2-dev required at build time on Linux).
   When `audio.enabled: true` is set in config the per-call composer
   and the conventional FM scanner fan PCM into the player alongside
   the existing WAV recorder, so calls play out the host's default
-  output device in real time. Software gain stage in front of the
-  backend makes volume and mute changes instant. Disabled by default;
-  headless servers stay silent and continue to record WAVs identically
-  to before. TUI volume / mute / record-toggle keybindings + REST
-  mutation endpoints (`/api/v1/audio/*`) are the next follow-up — for
-  now operators tune via the `audio.volume` and `audio.muted` config
-  fields. New CLI: `gophertrunk audio list` mirrors `sdr list`.
+  output device in real time. Volume / mute / recording can be
+  toggled live: the TUI's Scanner panel binds `+` / `-` for volume
+  (5% step), `M` for mute, and `R` for record on/off; the same knobs
+  are exposed as `GET` / `PATCH /api/v1/audio` for remote clients
+  (PATCH gated by `api.allow_mutations` like every other write
+  endpoint). The recorder gate stops new WAVs from landing without
+  truncating in-flight sessions, matching scanner muscle memory.
+  Disabled by default; headless servers stay silent and continue to
+  record WAVs identically to before. New CLI: `gophertrunk audio
+  list` mirrors `sdr list`. Drop-the-libasound2-dev-build-dep
+  follow-up tracked under Workstream F of the active plan.
 
 The Go interfaces and event payloads carry every protocol already;
 the remaining decoder wiring is the load-bearing follow-up.

--- a/cmd/gophertrunk/audio.go
+++ b/cmd/gophertrunk/audio.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/MattCheramie/GopherTrunk/internal/voice/player"
+)
+
+// runAudio dispatches the `gophertrunk audio …` subcommands. v1
+// exposes only `list`, which prints the audio outputs the player
+// backend can route to. oto/v3 does not expose a device picker —
+// it always routes to the OS default sink — so the listing is
+// short by design. Kept as a subcommand so future backends can
+// add real enumeration without breaking the CLI shape.
+func runAudio(args []string) {
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "usage: gophertrunk audio list")
+		os.Exit(2)
+	}
+	switch args[0] {
+	case "list":
+		listAudio()
+	default:
+		fmt.Fprintf(os.Stderr, "unknown audio subcommand: %s\n", args[0])
+		os.Exit(2)
+	}
+}
+
+func listAudio() {
+	devs := player.ListDevices()
+	if len(devs) == 0 {
+		fmt.Println("no audio output devices available")
+		return
+	}
+	fmt.Printf("%-4s  %s\n", "IDX", "DEVICE")
+	for i, d := range devs {
+		fmt.Printf("%-4d  %s\n", i, d)
+	}
+}

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -475,6 +475,9 @@ func NewDaemon(cfg config.Config, version string, log *slog.Logger) (*Daemon, er
 			engine:     d.engine,
 			talkgroups: d.talkgroups,
 		}
+		if d.player != nil || d.recorder != nil {
+			opts.Audio = audioCockpit{player: d.player, recorder: d.recorder}
+		}
 		srv, err := api.NewServer(opts)
 		if err != nil {
 			return nil, fmt.Errorf("daemon: http api: %w", err)
@@ -756,6 +759,79 @@ func (f convFanoutRecorder) WritePCM(serial string, samples []int16) error {
 		_ = r.WritePCM(serial, samples)
 	}
 	return nil
+}
+
+// audioCockpit aggregates the live-audio Player and the WAV
+// Recorder into the api.AudioController interface so GET / PATCH
+// /api/v1/audio can drive volume, mute, and recording from one
+// place. A nil Player (audio.enabled=false in config) collapses
+// the playback side to no-ops while the recorder gate still works.
+type audioCockpit struct {
+	player   *player.Player
+	recorder *voice.Recorder
+}
+
+func (a audioCockpit) Volume() float32 {
+	if a.player == nil {
+		return 0
+	}
+	return a.player.Volume()
+}
+
+func (a audioCockpit) SetVolume(v float32) {
+	if a.player == nil {
+		return
+	}
+	a.player.SetVolume(v)
+}
+
+func (a audioCockpit) Muted() bool {
+	if a.player == nil {
+		return true
+	}
+	return a.player.Muted()
+}
+
+func (a audioCockpit) SetMuted(m bool) {
+	if a.player == nil {
+		return
+	}
+	a.player.SetMuted(m)
+}
+
+func (a audioCockpit) RecordingEnabled() bool {
+	if a.recorder == nil {
+		return false
+	}
+	return a.recorder.RecordingEnabled()
+}
+
+func (a audioCockpit) SetRecordingEnabled(enabled bool) {
+	if a.recorder == nil {
+		return
+	}
+	a.recorder.SetRecordingEnabled(enabled)
+}
+
+func (a audioCockpit) DropsTotal() uint64 {
+	if a.player == nil {
+		return 0
+	}
+	return a.player.Stats().DropsTotal
+}
+
+func (a audioCockpit) SampleRate() uint32 {
+	if a.player == nil {
+		return 0
+	}
+	return a.player.Stats().SampleRate
+}
+
+func (a audioCockpit) BackendEnabled() bool {
+	if a.player == nil {
+		return false
+	}
+	return a.player.Stats().Enabled
 }
 
 // poolDevices adapts *sdr.Pool to composer.Devices. The composer only

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -22,6 +22,7 @@ import (
 	"github.com/MattCheramie/GopherTrunk/internal/trunking"
 	"github.com/MattCheramie/GopherTrunk/internal/voice"
 	"github.com/MattCheramie/GopherTrunk/internal/voice/composer"
+	"github.com/MattCheramie/GopherTrunk/internal/voice/player"
 	"github.com/MattCheramie/GopherTrunk/internal/voice/toneout"
 )
 
@@ -76,6 +77,7 @@ type Daemon struct {
 	voicePool  *trunking.VoicePool
 	recorder   *voice.Recorder
 	composer   *composer.Composer
+	player     *player.Player
 	toneout    *toneout.Detector
 	db         *storage.DB
 	callLog    *storage.CallLog
@@ -223,14 +225,41 @@ func NewDaemon(cfg config.Config, version string, log *slog.Logger) (*Daemon, er
 		d.toneout = det
 	}
 
+	// Live audio player — optional. Independent of the composer; if
+	// enabled, we feed it as one fan-out arm alongside the recorder.
+	// Defaults to disabled so headless servers stay quiet.
+	playerSampleRate := cfg.Audio.SampleRate
+	if playerSampleRate == 0 {
+		playerSampleRate = cfg.Recordings.SampleRate
+	}
+	pl, err := player.New(player.Config{
+		Enabled:    cfg.Audio.Enabled,
+		Device:     cfg.Audio.Device,
+		SampleRate: playerSampleRate,
+		BufferMs:   cfg.Audio.BufferMs,
+		Volume:     cfg.Audio.Volume,
+		Muted:      cfg.Audio.Muted,
+	}, log)
+	if err != nil {
+		return nil, fmt.Errorf("daemon: player: %w", err)
+	}
+	d.player = pl
+
 	// Composer is wired when we have a Voice device pool to source IQ
 	// from + a recorder to feed PCM into. Without an SDR pool there's
 	// nothing to demod, and without a recorder PCM has no destination.
 	if d.pool != nil && d.recorder != nil {
-		// Fan PCM to recorder + tone-out (if configured).
-		var sink composer.PCMSink = d.recorder
+		// Fan PCM to recorder + tone-out (if configured) + live player.
+		sinks := []composer.PCMSink{d.recorder}
 		if d.toneout != nil {
-			sink = fanoutSink{d.recorder, d.toneout}
+			sinks = append(sinks, d.toneout)
+		}
+		if d.player != nil {
+			sinks = append(sinks, playerSink{d.player})
+		}
+		var sink composer.PCMSink = d.recorder
+		if len(sinks) > 1 {
+			sink = fanoutSink(sinks)
 		}
 		comp, err := composer.New(composer.Options{
 			Bus:           d.bus,
@@ -348,12 +377,16 @@ func NewDaemon(cfg config.Config, version string, log *slog.Logger) (*Daemon, er
 					Priority:    ch.Priority,
 				})
 			}
+			var convRec conventional.Recorder = d.recorder
+			if d.player != nil {
+				convRec = convFanoutRecorder{d.recorder, playerSink{d.player}}
+			}
 			cs, err := conventional.New(conventional.Options{
 				Log:          log,
 				Tuner:        convEntry.Device,
 				IQ:           convEntry.Device,
 				Engine:       d.engine,
-				Recorder:     d.recorder,
+				Recorder:     convRec,
 				DeviceSerial: convEntry.Info.Serial,
 				SystemName:   "scanner",
 				Channels:     channels,
@@ -557,6 +590,9 @@ func (d *Daemon) Close() {
 		if d.composer != nil {
 			_ = d.composer.Close()
 		}
+		if d.player != nil {
+			_ = d.player.Close()
+		}
 		if d.recorder != nil {
 			_ = d.recorder.Close()
 		}
@@ -697,6 +733,29 @@ func toneProfilesFromConfig(in []config.ToneProfileConfig) ([]toneout.Profile, e
 		})
 	}
 	return out, nil
+}
+
+// playerSink adapts *player.Player to composer.PCMSink. The Player's
+// WritePCM signature is identical so the adapter is a zero-cost shim
+// that exists only to satisfy Go's nominal-typing for the fan-out
+// slice element type.
+type playerSink struct{ p *player.Player }
+
+func (s playerSink) WritePCM(serial string, samples []int16) error {
+	return s.p.WritePCM(serial, samples)
+}
+
+// convFanoutRecorder lets the conventional scanner drive both the
+// WAV recorder and the live player. The conventional.Recorder
+// interface only requires WritePCM, matching what both downstreams
+// implement.
+type convFanoutRecorder []conventional.Recorder
+
+func (f convFanoutRecorder) WritePCM(serial string, samples []int16) error {
+	for _, r := range f {
+		_ = r.WritePCM(serial, samples)
+	}
+	return nil
 }
 
 // poolDevices adapts *sdr.Pool to composer.Devices. The composer only

--- a/cmd/gophertrunk/main.go
+++ b/cmd/gophertrunk/main.go
@@ -41,6 +41,8 @@ func main() {
 		fmt.Println(version.Version)
 	case "sdr":
 		runSDR(os.Args[2:])
+	case "audio":
+		runAudio(os.Args[2:])
 	case "tui":
 		runTUI(os.Args[2:])
 	case "decode":
@@ -60,6 +62,7 @@ func printUsage() {
 USAGE:
   gophertrunk [run] [-config path]    run the daemon (default)
   gophertrunk sdr list                list discovered SDR devices
+  gophertrunk audio list              list audio output devices
   gophertrunk tui [-server URL]       open the read-only operator TUI
   gophertrunk decode [flags]          decode a captured .raw frame stream into a WAV
   gophertrunk version                 print build version

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -84,6 +84,18 @@ scanner:
   #     hangtime_ms: 1500
   #     priority: 4
 
+# audio routes decoded PCM to the host's speakers. Disabled by default;
+# WAV recording is unaffected and continues whether audio is on or off.
+# Backend init failure (no audio device, no PulseAudio/ALSA) falls back
+# to a silent player automatically so the daemon stays running.
+audio:
+  enabled: false       # set true to play decoded calls live
+  device: ""           # empty = system default sink; "null" forces no-op
+  sample_rate: 8000    # must match recordings.sample_rate
+  buffer_ms: 80        # playback queue depth; higher = more jitter-tolerant
+  volume: 0.8          # 0..1 software gain
+  muted: false
+
 # tone_out fires events.KindToneAlert when the configured paging tones
 # are detected on a Voice device's PCM stream. Empty profiles disable
 # the detector. Two-tone sequential (Quick Call II) is the most common

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -80,7 +80,7 @@ gophertrunk tui -server https://radio.example.com -insecure
 | Tone alerts | (table navigation only) |
 | Metrics | (table navigation only) |
 | Devices | (table navigation only) |
-| Scanner | `j` / `k` move row, `h` hold/resume highlighted row, `r` force re-hunt (Systems section, confirms), `Enter` dwell on highlighted conv channel, `m` cycle scan_mode |
+| Scanner | `j` / `k` move row, `h` hold/resume highlighted row, `r` force re-hunt (Systems section, confirms), `Enter` dwell on highlighted conv channel, `m` cycle scan_mode, `+` / `-` volume up/down (5% step), `M` mute toggle, `R` recording toggle |
 
 ## Polling cadences
 

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/clipperhouse/stringish v0.1.1 // indirect
 	github.com/clipperhouse/uax29/v2 v2.5.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
+	github.com/ebitengine/oto/v3 v3.3.3 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/kr/text v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -35,6 +35,10 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
+github.com/ebitengine/oto/v3 v3.3.3 h1:m6RV69OqoXYSWCDsHXN9rc07aDuDstGHtait7HXSM7g=
+github.com/ebitengine/oto/v3 v3.3.3/go.mod h1:MZeb/lwoC4DCOdiTIxYezrURTw7EvK/yF863+tmBI+U=
+github.com/ebitengine/oto/v3 v3.4.0 h1:br0PgASsEWaoWn38b2Goe7m1GKFYfNgnsjSd5Gg+/bQ=
+github.com/ebitengine/oto/v3 v3.4.0/go.mod h1:IOleLVD0m+CMak3mRVwsYY8vTctQgOM0iiL6S7Ar7eI=
 github.com/ebitengine/purego v0.10.0 h1:QIw4xfpWT6GWTzaW5XEKy3HXoqrJGx1ijYHzTF0/ISU=
 github.com/ebitengine/purego v0.10.0/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6baUTXGLOoWe4PQhGxaX0KpnayAqC48p4=

--- a/internal/api/handlers_audio.go
+++ b/internal/api/handlers_audio.go
@@ -1,0 +1,111 @@
+package api
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+)
+
+// AudioStatusDTO is the JSON shape returned by GET /api/v1/audio. Mirrors
+// the AudioController interface so the TUI doesn't need to know how
+// the daemon plumbed the player + recorder together.
+type AudioStatusDTO struct {
+	// BackendEnabled is true when a real audio sink is attached.
+	// False = audio.enabled was off in config or the backend
+	// failed to init; PATCH still works but takes effect only on
+	// the recorder gate.
+	BackendEnabled bool `json:"backend_enabled"`
+	// SampleRate is the host playback rate in Hz.
+	SampleRate uint32 `json:"sample_rate"`
+	// Volume is the software gain (0..1).
+	Volume float32 `json:"volume"`
+	// Muted reports the mute state.
+	Muted bool `json:"muted"`
+	// RecordingEnabled is the recorder's "create new sessions"
+	// gate. In-flight sessions are unaffected.
+	RecordingEnabled bool `json:"recording_enabled"`
+	// DropsTotal is a monotonically increasing counter of PCM
+	// samples lost because the playback queue was full.
+	DropsTotal uint64 `json:"drops_total"`
+}
+
+// audioPatchRequest is the body of PATCH /api/v1/audio. Every field
+// is a pointer so JSON-omitted fields are not zeroed: only supplied
+// fields are applied. Matches the talkgroup-patch convention.
+type audioPatchRequest struct {
+	Volume    *float32 `json:"volume"`
+	Muted     *bool    `json:"muted"`
+	Recording *bool    `json:"recording_enabled"`
+}
+
+// handleAudioStatus reports the live-audio cockpit's current state.
+//
+//   GET /api/v1/audio
+//
+// Responses:
+//
+//	200 with an AudioStatusDTO
+//	503 if the daemon doesn't have an AudioController wired
+func (s *Server) handleAudioStatus(w http.ResponseWriter, _ *http.Request) {
+	if s.audio == nil {
+		writeError(w, http.StatusServiceUnavailable, "audio not wired")
+		return
+	}
+	writeJSON(w, http.StatusOK, audioStatusDTO(s.audio))
+}
+
+// handleAudioPatch applies one or more cockpit mutations and returns
+// the updated state. Each field is optional; omit a field to leave
+// that knob alone.
+//
+//   PATCH /api/v1/audio
+//   Content-Type: application/json
+//   {"volume":0.5,"muted":false,"recording_enabled":true}
+//
+// Responses:
+//
+//	200 with the updated AudioStatusDTO
+//	400 if the body is malformed or out of range
+//	503 if the daemon doesn't have an AudioController wired
+func (s *Server) handleAudioPatch(w http.ResponseWriter, r *http.Request) {
+	if s.audio == nil {
+		writeError(w, http.StatusServiceUnavailable, "audio not wired")
+		return
+	}
+	var req audioPatchRequest
+	if r.Body != nil && r.ContentLength != 0 {
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil && err != io.EOF {
+			writeError(w, http.StatusBadRequest, "invalid json body")
+			return
+		}
+	}
+	if req.Volume == nil && req.Muted == nil && req.Recording == nil {
+		writeError(w, http.StatusBadRequest, "supply volume, muted, and/or recording_enabled")
+		return
+	}
+	if req.Volume != nil {
+		if *req.Volume < 0 || *req.Volume > 1 {
+			writeError(w, http.StatusBadRequest, "volume must be between 0.0 and 1.0")
+			return
+		}
+		s.audio.SetVolume(*req.Volume)
+	}
+	if req.Muted != nil {
+		s.audio.SetMuted(*req.Muted)
+	}
+	if req.Recording != nil {
+		s.audio.SetRecordingEnabled(*req.Recording)
+	}
+	writeJSON(w, http.StatusOK, audioStatusDTO(s.audio))
+}
+
+func audioStatusDTO(a AudioController) AudioStatusDTO {
+	return AudioStatusDTO{
+		BackendEnabled:   a.BackendEnabled(),
+		SampleRate:       a.SampleRate(),
+		Volume:           a.Volume(),
+		Muted:            a.Muted(),
+		RecordingEnabled: a.RecordingEnabled(),
+		DropsTotal:       a.DropsTotal(),
+	}
+}

--- a/internal/api/handlers_audio_test.go
+++ b/internal/api/handlers_audio_test.go
@@ -1,0 +1,225 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"math"
+	"net/http"
+	"sync/atomic"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+)
+
+// fakeAudio implements AudioController for tests. Records SetVolume /
+// SetMuted / SetRecordingEnabled calls so assertions can confirm
+// the PATCH handler routed each knob correctly.
+type fakeAudio struct {
+	volume   atomic.Uint32 // float32 bits
+	muted    atomic.Bool
+	rec      atomic.Bool
+	drops    uint64
+	rate     uint32
+	backend  bool
+	setVolN  atomic.Int32
+	setMuteN atomic.Int32
+	setRecN  atomic.Int32
+}
+
+func newFakeAudio() *fakeAudio {
+	f := &fakeAudio{rate: 8000, backend: true}
+	f.volume.Store(0x3F400000) // 0.75 in float32 bits
+	f.rec.Store(true)
+	return f
+}
+
+func (f *fakeAudio) Volume() float32 {
+	return float32frombits32(f.volume.Load())
+}
+
+func (f *fakeAudio) SetVolume(v float32) {
+	f.volume.Store(float32bits32(v))
+	f.setVolN.Add(1)
+}
+
+func (f *fakeAudio) Muted() bool { return f.muted.Load() }
+
+func (f *fakeAudio) SetMuted(m bool) {
+	f.muted.Store(m)
+	f.setMuteN.Add(1)
+}
+
+func (f *fakeAudio) RecordingEnabled() bool { return f.rec.Load() }
+
+func (f *fakeAudio) SetRecordingEnabled(enabled bool) {
+	f.rec.Store(enabled)
+	f.setRecN.Add(1)
+}
+
+func (f *fakeAudio) DropsTotal() uint64    { return f.drops }
+func (f *fakeAudio) SampleRate() uint32    { return f.rate }
+func (f *fakeAudio) BackendEnabled() bool  { return f.backend }
+
+func float32bits32(f float32) uint32     { return math.Float32bits(f) }
+func float32frombits32(u uint32) float32 { return math.Float32frombits(u) }
+
+func TestAudioStatus_OK(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	fa := newFakeAudio()
+	base, teardown := mkServer(t, ServerOptions{Bus: bus, Audio: fa})
+	defer teardown()
+
+	resp, err := http.Get(base + "/api/v1/audio")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("status=%d", resp.StatusCode)
+	}
+	var body AudioStatusDTO
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !body.BackendEnabled {
+		t.Errorf("backend_enabled = false")
+	}
+	if body.SampleRate != 8000 {
+		t.Errorf("sample_rate=%d", body.SampleRate)
+	}
+	if body.Volume < 0.74 || body.Volume > 0.76 {
+		t.Errorf("volume=%f, want ~0.75", body.Volume)
+	}
+	if !body.RecordingEnabled {
+		t.Errorf("recording_enabled = false")
+	}
+}
+
+func TestAudioStatus_NotWired(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	base, teardown := mkServer(t, ServerOptions{Bus: bus})
+	defer teardown()
+
+	resp, err := http.Get(base + "/api/v1/audio")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 503 {
+		t.Errorf("status=%d, want 503", resp.StatusCode)
+	}
+}
+
+func TestAudioPatch_AppliesAllFields(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	fa := newFakeAudio()
+	base, teardown := mkServer(t, ServerOptions{
+		Bus:            bus,
+		AllowMutations: true,
+		Audio:          fa,
+	})
+	defer teardown()
+
+	body := `{"volume":0.5,"muted":true,"recording_enabled":false}`
+	req, _ := http.NewRequest(http.MethodPatch, base+"/api/v1/audio", bytes.NewReader([]byte(body)))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("status=%d", resp.StatusCode)
+	}
+	if fa.setVolN.Load() != 1 || fa.setMuteN.Load() != 1 || fa.setRecN.Load() != 1 {
+		t.Errorf("expected one SetVolume / SetMuted / SetRecordingEnabled call each, got %d/%d/%d",
+			fa.setVolN.Load(), fa.setMuteN.Load(), fa.setRecN.Load())
+	}
+	if !fa.Muted() {
+		t.Errorf("muted not applied")
+	}
+	if fa.RecordingEnabled() {
+		t.Errorf("recording not disabled")
+	}
+}
+
+func TestAudioPatch_RejectsOutOfRangeVolume(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	fa := newFakeAudio()
+	base, teardown := mkServer(t, ServerOptions{
+		Bus:            bus,
+		AllowMutations: true,
+		Audio:          fa,
+	})
+	defer teardown()
+
+	body := `{"volume":2.0}`
+	req, _ := http.NewRequest(http.MethodPatch, base+"/api/v1/audio", bytes.NewReader([]byte(body)))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 400 {
+		t.Errorf("status=%d, want 400", resp.StatusCode)
+	}
+	if fa.setVolN.Load() != 0 {
+		t.Errorf("SetVolume should not be called on rejected request")
+	}
+}
+
+func TestAudioPatch_RejectsEmptyBody(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	fa := newFakeAudio()
+	base, teardown := mkServer(t, ServerOptions{
+		Bus:            bus,
+		AllowMutations: true,
+		Audio:          fa,
+	})
+	defer teardown()
+
+	body := `{}`
+	req, _ := http.NewRequest(http.MethodPatch, base+"/api/v1/audio", bytes.NewReader([]byte(body)))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 400 {
+		t.Errorf("status=%d, want 400", resp.StatusCode)
+	}
+}
+
+func TestAudioPatch_GatedByAllowMutations(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	fa := newFakeAudio()
+	base, teardown := mkServer(t, ServerOptions{
+		Bus:   bus,
+		Audio: fa,
+		// AllowMutations: false (default)
+	})
+	defer teardown()
+
+	body := `{"muted":true}`
+	req, _ := http.NewRequest(http.MethodPatch, base+"/api/v1/audio", bytes.NewReader([]byte(body)))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 403 {
+		t.Errorf("status=%d, want 403", resp.StatusCode)
+	}
+	if fa.setMuteN.Load() != 0 {
+		t.Errorf("SetMuted called despite gate")
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -50,6 +50,43 @@ type DevicesProvider interface {
 	Snapshot() []sdr.SDRStatus
 }
 
+// AudioController is the API surface for the live-audio subsystem
+// (the voice.Player sink + the WAV recorder gate). All four methods
+// are safe to call from any goroutine; the daemon supplies a single
+// adapter that fans into player.Player + voice.Recorder, tests use a
+// fake.
+type AudioController interface {
+	// Volume returns the current software gain (0..1).
+	Volume() float32
+	// SetVolume clamps to 0..1 and applies immediately.
+	SetVolume(v float32)
+	// Muted reports the mute state.
+	Muted() bool
+	// SetMuted toggles mute. Mute is a software-gain bypass, not a
+	// device-level operation — toggling is instant.
+	SetMuted(m bool)
+	// RecordingEnabled reports whether the recorder's "create new
+	// sessions" gate is open. In-flight sessions are not affected
+	// by this gate.
+	RecordingEnabled() bool
+	// SetRecordingEnabled flips the recorder gate. False stops new
+	// WAVs from landing on disk; in-flight sessions complete.
+	SetRecordingEnabled(enabled bool)
+	// DropsTotal is a monotonically increasing counter of PCM
+	// samples lost because the playback queue was full. Surfaced
+	// so operators can spot scheduling-jitter problems from the
+	// TUI without reaching for /metrics.
+	DropsTotal() uint64
+	// SampleRate is the host playback rate the player was opened
+	// at, in Hz. Read-only; reopening the device with a different
+	// rate requires a daemon restart.
+	SampleRate() uint32
+	// BackendEnabled reports whether a real audio backend is
+	// attached. False means audio.enabled was off in config or the
+	// backend failed to init, and writes are silently dropped.
+	BackendEnabled() bool
+}
+
 // ScannerCockpit is the API surface for the police-scanner subsystem:
 // reads the current state (per-system CC hunt, conventional channel
 // list, talkgroup-scan stats) and applies operator mutations from
@@ -136,6 +173,7 @@ type Server struct {
 	tones      ToneDetectorReset
 	devices    DevicesProvider
 	scanner    ScannerCockpit
+	audio      AudioController
 	talkgroups *trunking.TalkgroupDB
 	systems    []trunking.System
 	history    HistoryQuery
@@ -229,6 +267,10 @@ type ServerOptions struct {
 	// /api/v1/scanner and the related mutation routes. Optional;
 	// when nil, the routes return 503.
 	Scanner ScannerCockpit
+	// Audio exposes the live-audio player + recorder gate for
+	// GET + PATCH /api/v1/audio. Optional; when nil, the routes
+	// return 503.
+	Audio AudioController
 }
 
 // NewServer constructs a server but does not yet bind a listener; call
@@ -256,6 +298,7 @@ func NewServer(opts ServerOptions) (*Server, error) {
 		tones:          opts.Tones,
 		devices:        opts.Devices,
 		scanner:        opts.Scanner,
+		audio:          opts.Audio,
 		talkgroups:     opts.Talkgroups,
 		systems:        append([]trunking.System(nil), opts.Systems...),
 		history:        opts.History,
@@ -353,6 +396,11 @@ func (s *Server) routes() *http.ServeMux {
 	mux.HandleFunc("POST /api/v1/scanner/conventional/hold", s.gate(s.handleConvHold))
 	mux.HandleFunc("POST /api/v1/scanner/conventional/resume", s.gate(s.handleConvResume))
 	mux.HandleFunc("POST /api/v1/scanner/conventional/{index}/dwell", s.gate(s.handleConvDwell))
+
+	// Audio cockpit — read endpoint is always open; the PATCH is
+	// gated behind allow_mutations like every other write route.
+	mux.HandleFunc("GET /api/v1/audio", s.handleAudioStatus)
+	mux.HandleFunc("PATCH /api/v1/audio", s.gate(s.handleAudioPatch))
 
 	return mux
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,6 +20,37 @@ type Config struct {
 	Retention  RetentionConfig  `yaml:"retention"`
 	ToneOut    ToneOutConfig    `yaml:"tone_out"`
 	Scanner    ScannerConfig    `yaml:"scanner"`
+	Audio      AudioConfig      `yaml:"audio"`
+}
+
+// AudioConfig controls live audio playback to the host's speakers.
+// The daemon mixes decoded PCM from the per-call composer and the
+// conventional scanner into a single output stream, applied with
+// software gain so volume / mute changes are instant.
+//
+// Disabled by default — headless servers stay silent unless
+// audio.enabled is set true. Backend init failure (e.g. no audio
+// device, no PulseAudio / ALSA on the host) falls back to the null
+// player automatically.
+type AudioConfig struct {
+	// Enabled gates live playback. Default false. The recorder
+	// path is unaffected: WAVs land on disk whether audio is on
+	// or off.
+	Enabled bool `yaml:"enabled"`
+	// Device is the backend-specific output device name. Empty
+	// (or "default") routes to the system default sink. "null"
+	// forces the no-op backend even when Enabled=true.
+	Device string `yaml:"device"`
+	// SampleRate is the host playback rate in Hz. Default 8000;
+	// must match recordings.sample_rate so the composer's PCM
+	// frames don't need a resample stage.
+	SampleRate uint32 `yaml:"sample_rate"`
+	// BufferMs is the depth of the playback queue. Default 80.
+	BufferMs int `yaml:"buffer_ms"`
+	// Volume is the initial software gain (0..1). Default 0.8.
+	Volume float32 `yaml:"volume"`
+	// Muted is the initial mute state. Default false.
+	Muted bool `yaml:"muted"`
 }
 
 // ScannerConfig controls the police-scanner subsystems: the CC hunter,
@@ -323,6 +354,12 @@ func (c Config) Validate() error {
 	case "", "all", "list":
 	default:
 		return fmt.Errorf("scanner.scan_mode must be \"all\" or \"list\"")
+	}
+	if c.Audio.SampleRate != 0 && (c.Audio.SampleRate < 4000 || c.Audio.SampleRate > 48_000) {
+		return fmt.Errorf("audio.sample_rate %d outside 4000..48000", c.Audio.SampleRate)
+	}
+	if c.Audio.Volume != 0 && (c.Audio.Volume < 0 || c.Audio.Volume > 1) {
+		return fmt.Errorf("audio.volume %f outside 0..1", c.Audio.Volume)
 	}
 	for i, ch := range c.Scanner.Conventional {
 		if ch.FrequencyHz == 0 {

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -97,6 +97,7 @@ func (m *Model) Init() tea.Cmd {
 		cmdPollHistory(m.cli, client.HistoryFilter{Limit: 100}),
 		cmdPollDevices(m.cli),
 		cmdPollScanner(m.cli),
+		cmdPollAudio(m.cli),
 		cmdMutationStatus(m.cli),
 		connectSSE(m.cli),
 	)
@@ -246,6 +247,13 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.shared.ScannerErr = msg.err
 		cmds = append(cmds, scheduleAfter(pollScannerEvery, cmdPollScanner(m.cli)))
+
+	case pollAudioMsg:
+		if msg.err == nil {
+			m.shared.Audio = msg.a
+		}
+		m.shared.AudioErr = msg.err
+		cmds = append(cmds, scheduleAfter(pollAudioEvery, cmdPollAudio(m.cli)))
 
 	case pollHistoryMsg:
 		m.shared.History = msg.rows
@@ -484,6 +492,14 @@ func (m *Model) dispatchWrite(r state.WriteRequest) tea.Cmd {
 			return nil
 		}
 		return cmdScannerConvDwell(m.cli, r.ScannerConv.Index, r.Label)
+	case state.WriteKindAudio:
+		if r.Audio == nil {
+			return nil
+		}
+		return tea.Batch(
+			cmdSetAudio(m.cli, r.Audio.Volume, r.Audio.Muted, r.Audio.Recording, r.Label),
+			cmdPollAudio(m.cli),
+		)
 	}
 	return nil
 }

--- a/internal/tui/client/write.go
+++ b/internal/tui/client/write.go
@@ -113,6 +113,55 @@ func (c *Client) ScannerConvDwell(ctx context.Context, index int) error {
 		nil, nil)
 }
 
+// AudioStatusDTO mirrors api.AudioStatusDTO for the wire layer.
+type AudioStatusDTO struct {
+	BackendEnabled   bool    `json:"backend_enabled"`
+	SampleRate       uint32  `json:"sample_rate"`
+	Volume           float32 `json:"volume"`
+	Muted            bool    `json:"muted"`
+	RecordingEnabled bool    `json:"recording_enabled"`
+	DropsTotal       uint64  `json:"drops_total"`
+}
+
+// AudioStatus calls GET /api/v1/audio. Returns a zero value (no
+// error) when the daemon doesn't have the audio cockpit wired so
+// older daemons don't break the TUI.
+func (c *Client) AudioStatus(ctx context.Context) (AudioStatusDTO, error) {
+	var s AudioStatusDTO
+	err := c.getJSON(ctx, "/api/v1/audio", &s)
+	if err != nil {
+		var herr *HTTPError
+		if asHTTPErr(err, &herr) && (herr.Status == http.StatusNotFound || herr.Status == http.StatusServiceUnavailable) {
+			return AudioStatusDTO{}, nil
+		}
+		return AudioStatusDTO{}, err
+	}
+	return s, nil
+}
+
+// SetAudio calls PATCH /api/v1/audio with whichever knobs are non-nil.
+// Pass nil to leave a field unchanged.
+func (c *Client) SetAudio(ctx context.Context, volume *float32, muted *bool, recording *bool) (AudioStatusDTO, error) {
+	body := map[string]any{}
+	if volume != nil {
+		body["volume"] = *volume
+	}
+	if muted != nil {
+		body["muted"] = *muted
+	}
+	if recording != nil {
+		body["recording_enabled"] = *recording
+	}
+	if len(body) == 0 {
+		return AudioStatusDTO{}, fmt.Errorf("client: supply volume, muted, or recording_enabled")
+	}
+	var out AudioStatusDTO
+	if err := c.do(ctx, http.MethodPatch, "/api/v1/audio", body, &out); err != nil {
+		return AudioStatusDTO{}, err
+	}
+	return out, nil
+}
+
 // ResetToneDevice calls POST /api/v1/devices/{serial}/tone-reset.
 func (c *Client) ResetToneDevice(ctx context.Context, serial string) error {
 	if serial == "" {

--- a/internal/tui/cmds.go
+++ b/internal/tui/cmds.go
@@ -19,6 +19,7 @@ const (
 	pollMetricsEvery    = 5 * time.Second
 	pollDevicesEvery    = 10 * time.Second
 	pollScannerEvery    = 2 * time.Second
+	pollAudioEvery      = 3 * time.Second
 )
 
 func cmdPollHealth(cli *client.Client) tea.Cmd {
@@ -118,6 +119,27 @@ func cmdScannerConvResume(cli *client.Client, label string) tea.Cmd {
 func cmdScannerConvDwell(cli *client.Client, idx int, label string) tea.Cmd {
 	return func() tea.Msg {
 		err := cli.ScannerConvDwell(context.Background(), idx)
+		return writeResultMsg{Label: label, Err: err}
+	}
+}
+
+// cmdPollAudio fetches the audio cockpit's current state. Used to
+// keep the dashboard volume / mute / record indicator in sync with
+// any out-of-band mutations (another TUI instance, a curl command,
+// etc.).
+func cmdPollAudio(cli *client.Client) tea.Cmd {
+	return func() tea.Msg {
+		a, err := cli.AudioStatus(context.Background())
+		return pollAudioMsg{a: a, err: err}
+	}
+}
+
+// cmdSetAudio dispatches a PATCH /api/v1/audio with whichever knobs
+// are non-nil. Returns a writeResultMsg with the supplied label so
+// the toast surface stays consistent with the other writes.
+func cmdSetAudio(cli *client.Client, volume *float32, muted *bool, recording *bool, label string) tea.Cmd {
+	return func() tea.Msg {
+		_, err := cli.SetAudio(context.Background(), volume, muted, recording)
 		return writeResultMsg{Label: label, Err: err}
 	}
 }

--- a/internal/tui/msgs.go
+++ b/internal/tui/msgs.go
@@ -47,6 +47,10 @@ type pollScannerMsg struct {
 	s   client.ScannerStatusDTO
 	err error
 }
+type pollAudioMsg struct {
+	a   client.AudioStatusDTO
+	err error
+}
 
 // eventMsg carries one decoded SSE event. The root model fans this
 // out into its event log + tone alert ring buffer, then forwards

--- a/internal/tui/panels/scanner.go
+++ b/internal/tui/panels/scanner.go
@@ -44,11 +44,24 @@ var (
 	scanModeKey   = key.NewBinding(key.WithKeys("m"), key.WithHelp("m", "cycle scan mode"))
 	scanUpKey     = key.NewBinding(key.WithKeys("up", "k"), key.WithHelp("k/↑", "row up"))
 	scanDownKey   = key.NewBinding(key.WithKeys("down", "j"), key.WithHelp("j/↓", "row down"))
+	scanVolUpKey  = key.NewBinding(key.WithKeys("+", "="), key.WithHelp("+", "volume up"))
+	scanVolDnKey  = key.NewBinding(key.WithKeys("-", "_"), key.WithHelp("-", "volume down"))
+	scanMuteKey   = key.NewBinding(key.WithKeys("M"), key.WithHelp("M", "mute toggle"))
+	scanRecKey    = key.NewBinding(key.WithKeys("R"), key.WithHelp("R", "record toggle"))
 )
 
 func (ScannerPanel) Keys() []key.Binding {
-	return []key.Binding{scanHoldKey, scanRetuneKey, scanDwellKey, scanModeKey, scanUpKey, scanDownKey}
+	return []key.Binding{
+		scanHoldKey, scanRetuneKey, scanDwellKey, scanModeKey,
+		scanUpKey, scanDownKey,
+		scanVolUpKey, scanVolDnKey, scanMuteKey, scanRecKey,
+	}
 }
+
+// volumeStep is the increment per +/− press. 0.05 maps to 20 presses
+// edge-to-edge — matches the analog volume-knob muscle memory of a
+// handheld scanner without overshooting on a keyboard.
+const volumeStep = 0.05
 
 func (p *ScannerPanel) rowCount(s *state.SharedState) int {
 	return len(s.Scanner.Systems) + len(s.Scanner.Conventional.Channels)
@@ -153,8 +166,59 @@ func (p *ScannerPanel) Update(msg tea.Msg, s *state.SharedState) (Panel, tea.Cmd
 			}
 			return p, Emit(req)
 		}
+	case key.Matches(km, scanVolUpKey):
+		v := clampVolume(s.Audio.Volume + volumeStep)
+		req := state.WriteRequest{
+			Label: fmt.Sprintf("volume %d%%", int(v*100+0.5)),
+			Kind:  state.WriteKindAudio,
+			Audio: &state.AudioReq{Volume: &v},
+		}
+		return p, Emit(req)
+	case key.Matches(km, scanVolDnKey):
+		v := clampVolume(s.Audio.Volume - volumeStep)
+		req := state.WriteRequest{
+			Label: fmt.Sprintf("volume %d%%", int(v*100+0.5)),
+			Kind:  state.WriteKindAudio,
+			Audio: &state.AudioReq{Volume: &v},
+		}
+		return p, Emit(req)
+	case key.Matches(km, scanMuteKey):
+		next := !s.Audio.Muted
+		label := "unmute"
+		if next {
+			label = "mute"
+		}
+		req := state.WriteRequest{
+			Label: label,
+			Kind:  state.WriteKindAudio,
+			Audio: &state.AudioReq{Muted: &next},
+		}
+		return p, Emit(req)
+	case key.Matches(km, scanRecKey):
+		next := !s.Audio.RecordingEnabled
+		label := "recording off"
+		if next {
+			label = "recording on"
+		}
+		req := state.WriteRequest{
+			Label: label,
+			Kind:  state.WriteKindAudio,
+			Audio: &state.AudioReq{Recording: &next},
+		}
+		return p, Emit(req)
 	}
 	return p, nil
+}
+
+// clampVolume keeps the +/− stepping inside the legal 0..1 range.
+func clampVolume(v float32) float32 {
+	if v < 0 {
+		return 0
+	}
+	if v > 1 {
+		return 1
+	}
+	return v
 }
 
 func (p *ScannerPanel) View(width, height int, focused bool, s *state.SharedState) string {
@@ -166,8 +230,34 @@ func (p *ScannerPanel) View(width, height int, focused bool, s *state.SharedStat
 		p.renderSystems(width, s),
 		p.renderConventional(width, s),
 		p.renderTGSummary(width, s),
+		p.renderAudio(width, s),
 	}, "\n")
 	return panelFrame("Scanner", width, height, focused, body)
+}
+
+func (p *ScannerPanel) renderAudio(width int, s *state.SharedState) string {
+	header := dashHeader.Render("Audio")
+	a := s.Audio
+	state := "off"
+	style := dashDim
+	if a.BackendEnabled {
+		state = "on"
+		style = dashOK
+		if a.Muted {
+			state = "muted"
+			style = dashErr
+		}
+	}
+	rec := "off"
+	if a.RecordingEnabled {
+		rec = "on"
+	}
+	line := fmt.Sprintf("  output=%s  vol=%d%%  rec=%s   (+/- volume, M mute, R record)",
+		style.Render(state),
+		int(a.Volume*100+0.5),
+		rec,
+	)
+	return "\n" + header + "\n" + dashDim.Render(line)
 }
 
 func (p *ScannerPanel) renderSystems(width int, s *state.SharedState) string {

--- a/internal/tui/state/state.go
+++ b/internal/tui/state/state.go
@@ -81,6 +81,8 @@ type SharedState struct {
 	DevicesErr  error
 	Scanner     client.ScannerStatusDTO
 	ScannerErr  error
+	Audio       client.AudioStatusDTO
+	AudioErr    error
 
 	EventLog   RingReader[client.Event]
 	ToneAlerts RingReader[client.Event]
@@ -121,6 +123,7 @@ type WriteRequest struct {
 	ScannerMode     *ScannerModeReq
 	ScannerHunt     *ScannerHuntReq
 	ScannerConv     *ScannerConvReq
+	Audio           *AudioReq
 }
 
 // WriteKind discriminates a WriteRequest's payload.
@@ -139,7 +142,16 @@ const (
 	WriteKindScannerConvHold
 	WriteKindScannerConvResume
 	WriteKindScannerConvDwell
+	WriteKindAudio
 )
+
+// AudioReq sets one or more knobs on the audio cockpit. Nil fields
+// are left unchanged.
+type AudioReq struct {
+	Volume    *float32
+	Muted     *bool
+	Recording *bool
+}
 
 // ScannerModeReq sets the engine's global scan_mode at runtime.
 type ScannerModeReq struct{ Mode string }

--- a/internal/voice/player/oto.go
+++ b/internal/voice/player/oto.go
@@ -1,0 +1,228 @@
+package player
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"sync"
+	"time"
+
+	"github.com/ebitengine/oto/v3"
+)
+
+// otoCtx is the process-global oto context. oto.NewContext can only
+// be called once per process, so we cache the first context and
+// re-use it across daemon restarts (e.g. inside tests that boot the
+// daemon repeatedly).
+var (
+	otoOnce  sync.Once
+	otoCtx   *oto.Context
+	otoErr   error
+	otoRateA uint32 // the sample rate the cached context was opened at
+)
+
+func init() {
+	defaultBackendFactory = func(cfg Config) (Backend, error) {
+		ctx, err := acquireOtoContext(cfg.SampleRate)
+		if err != nil {
+			return nil, err
+		}
+		// Reader feeds the oto.Player on demand. We hand it the
+		// channel side so the audio goroutine in player.go can
+		// push samples without blocking.
+		r := newPCMReader()
+		p := ctx.NewPlayer(r)
+		p.SetBufferSize(otoBufferBytes(cfg))
+		p.Play()
+		return &otoBackend{
+			ctx:    ctx,
+			player: p,
+			reader: r,
+		}, nil
+	}
+}
+
+// acquireOtoContext returns the cached oto context, creating it on
+// the first call. If a context already exists with a different
+// sample rate the new request is rejected — oto only supports one
+// rate per process.
+func acquireOtoContext(rate uint32) (*oto.Context, error) {
+	otoOnce.Do(func() {
+		opts := &oto.NewContextOptions{
+			SampleRate:   int(rate),
+			ChannelCount: 1,
+			Format:       oto.FormatSignedInt16LE,
+		}
+		ctx, ready, err := oto.NewContext(opts)
+		if err != nil {
+			otoErr = err
+			return
+		}
+		<-ready
+		otoCtx = ctx
+		otoRateA = rate
+	})
+	if otoErr != nil {
+		return nil, fmt.Errorf("oto: %w", otoErr)
+	}
+	if otoCtx == nil {
+		return nil, errors.New("oto: context not initialised")
+	}
+	if otoRateA != rate {
+		return nil, fmt.Errorf("oto: context already opened at %d Hz; %d Hz requested", otoRateA, rate)
+	}
+	return otoCtx, nil
+}
+
+func otoBufferBytes(cfg Config) int {
+	ms := cfg.BufferMs
+	if ms <= 0 {
+		ms = 80
+	}
+	rate := int(cfg.SampleRate)
+	if rate <= 0 {
+		rate = 8000
+	}
+	// 2 bytes per int16, mono.
+	return rate * ms / 1000 * 2
+}
+
+// otoBackend implements Backend on top of oto.Player.
+type otoBackend struct {
+	ctx    *oto.Context
+	player *oto.Player
+	reader *pcmReader
+
+	closeOnce sync.Once
+	closeErr  error
+}
+
+func (b *otoBackend) Write(samples []int16) error {
+	return b.reader.write(samples)
+}
+
+func (b *otoBackend) Close() error {
+	b.closeOnce.Do(func() {
+		b.reader.close()
+		b.closeErr = b.player.Close()
+	})
+	return b.closeErr
+}
+
+// pcmReader is the io.Reader oto pulls from. PCM is queued from the
+// caller via write() and dequeued from the audio thread via Read().
+// A bounded ring drops the oldest samples when the producer
+// outpaces the consumer — this only happens in pathological cases
+// because the producer is itself queue-bounded in player.go.
+type pcmReader struct {
+	mu     sync.Mutex
+	cond   *sync.Cond
+	buf    []byte
+	closed bool
+	// maxBytes caps the ring at ~1s of audio at 8kHz/mono/int16.
+	// Big enough to absorb a stalled output device for a moment,
+	// small enough to bound memory.
+	maxBytes int
+}
+
+func newPCMReader() *pcmReader {
+	r := &pcmReader{maxBytes: 16000 * 2}
+	r.cond = sync.NewCond(&r.mu)
+	return r
+}
+
+func (r *pcmReader) write(samples []int16) error {
+	if len(samples) == 0 {
+		return nil
+	}
+	bs := make([]byte, len(samples)*2)
+	for i, s := range samples {
+		binary.LittleEndian.PutUint16(bs[i*2:], uint16(s))
+	}
+	r.mu.Lock()
+	if r.closed {
+		r.mu.Unlock()
+		return io.ErrClosedPipe
+	}
+	r.buf = append(r.buf, bs...)
+	if over := len(r.buf) - r.maxBytes; over > 0 {
+		// drop oldest
+		r.buf = r.buf[over:]
+	}
+	r.cond.Signal()
+	r.mu.Unlock()
+	return nil
+}
+
+func (r *pcmReader) close() {
+	r.mu.Lock()
+	r.closed = true
+	r.cond.Broadcast()
+	r.mu.Unlock()
+}
+
+// Read drains queued samples. If the queue is empty it waits briefly
+// for samples to arrive (so oto isn't spun in a tight loop), and
+// returns silence when the wait elapses. Returning silence rather
+// than blocking forever keeps the underlying audio device happy
+// during inter-call gaps.
+func (r *pcmReader) Read(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	r.mu.Lock()
+	if !r.closed && len(r.buf) == 0 {
+		waitUntil := time.Now().Add(20 * time.Millisecond)
+		for !r.closed && len(r.buf) == 0 {
+			waitDur := time.Until(waitUntil)
+			if waitDur <= 0 {
+				break
+			}
+			waitWithTimeout(r.cond, waitDur)
+		}
+	}
+	if r.closed && len(r.buf) == 0 {
+		r.mu.Unlock()
+		return 0, io.EOF
+	}
+	if len(r.buf) == 0 {
+		r.mu.Unlock()
+		// silence: zero-fill p so oto outputs silence between calls.
+		for i := range p {
+			p[i] = 0
+		}
+		return len(p), nil
+	}
+	n := copy(p, r.buf)
+	r.buf = r.buf[n:]
+	r.mu.Unlock()
+	return n, nil
+}
+
+// waitWithTimeout is a cond.Wait with a timeout. The std-lib
+// sync.Cond has no native timeout so we spawn a one-shot goroutine
+// that wakes the cond if the duration elapses first. Cheap because
+// audio gaps between calls are seconds, not milliseconds.
+func waitWithTimeout(c *sync.Cond, d time.Duration) {
+	stop := make(chan struct{})
+	defer close(stop)
+	go func() {
+		select {
+		case <-time.After(d):
+			c.L.Lock()
+			c.Broadcast()
+			c.L.Unlock()
+		case <-stop:
+		}
+	}()
+	c.Wait()
+}
+
+// ListDevices is a placeholder enumeration. oto/v3 does not expose
+// a device picker — it routes to whatever the OS audio service
+// considers the default sink. We surface that as a single entry
+// so `gophertrunk audio list` still produces something useful.
+func ListDevices() []string {
+	return []string{"default (system output)"}
+}

--- a/internal/voice/player/player.go
+++ b/internal/voice/player/player.go
@@ -1,0 +1,303 @@
+// Package player is the live-audio sink that turns int16 PCM coming
+// out of the per-call composer / conventional scanner into sound out
+// of the host's speakers. It plugs into the same composer.PCMSink /
+// conventional.Recorder fan-out point the per-call WAV recorder uses,
+// so wiring is a one-line change in cmd/gophertrunk/daemon.go.
+//
+// The default backend is github.com/ebitengine/oto/v3 — routes to
+// ALSA on Linux (cgo + libasound2-dev at build time, libasound2 at
+// runtime), CoreAudio on macOS, WASAPI on Windows. When audio.enabled
+// is false in config, when the backend fails to initialise on a
+// headless box, or when audio.device is "null", the daemon silently
+// uses a no-op player and the rest of the system runs identically.
+//
+// Volume and mute are applied at WritePCM time as a software gain
+// stage so changes are instant and don't require reopening the
+// device.
+package player
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"math"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// Config controls how the live-audio player initialises.
+type Config struct {
+	// Enabled gates the real backend. False (or any backend
+	// failure) leaves the player as a no-op so headless servers
+	// keep working.
+	Enabled bool
+	// Device is the backend-specific output device name; empty
+	// (or "default") = system default. "null" forces the no-op
+	// backend even when Enabled=true (useful for tests).
+	Device string
+	// SampleRate is the host playback rate in Hz. Must match the
+	// rate the composer feeds the recorder (typically 8000).
+	SampleRate uint32
+	// BufferMs is the depth of the playback queue. Larger =
+	// more resilient to scheduling jitter, smaller = lower
+	// latency. Default 80 ms.
+	BufferMs int
+	// Volume is the initial software gain (0..1). Default 0.8.
+	Volume float32
+	// Muted is the initial mute state.
+	Muted bool
+}
+
+// Backend is the per-OS audio sink the Player drives. Production
+// uses an oto-backed implementation; tests use a loopback that
+// captures whatever the player writes.
+type Backend interface {
+	// Write blocks until the supplied PCM has been queued to the
+	// device. samples are 16-bit LE PCM at the configured rate.
+	Write(samples []int16) error
+	Close() error
+}
+
+// Player mixes PCM from one-or-more call serials into a single
+// output stream. WritePCM matches composer.PCMSink so the daemon
+// can drop the Player into the existing fan-out alongside the
+// Recorder.
+type Player struct {
+	log *slog.Logger
+
+	backend    Backend
+	sampleRate uint32
+
+	// Software gain stage. Stored as the float32 bit pattern in a
+	// uint32 atomic so SetVolume is lock-free.
+	volume atomic.Uint32 // math.Float32bits
+	muted  atomic.Bool
+
+	// Single bounded PCM queue. WritePCM does a non-blocking
+	// send and drops on full so the composer goroutine never
+	// blocks on a slow audio device.
+	queue chan []int16
+
+	// drops counts samples lost to a full queue. Surfaced via
+	// Stats for the API / TUI.
+	drops atomic.Uint64
+
+	stopOnce sync.Once
+	stop     chan struct{}
+	done     chan struct{}
+}
+
+// defaultBackendFactory is the production backend constructor. Set
+// by the oto-backed init in player_oto.go. Left nil in builds where
+// no backend has been linked in.
+var defaultBackendFactory func(cfg Config) (Backend, error)
+
+// New constructs a Player. When cfg.Enabled is false, the device
+// is "null", or the backend factory fails, the returned Player is
+// a no-op (writes are accepted and dropped) so the daemon keeps
+// running on headless boxes.
+func New(cfg Config, log *slog.Logger) (*Player, error) {
+	if log == nil {
+		return nil, errors.New("player: logger is required")
+	}
+	if cfg.SampleRate == 0 {
+		cfg.SampleRate = 8000
+	}
+	if cfg.BufferMs <= 0 {
+		cfg.BufferMs = 80
+	}
+	if cfg.Volume <= 0 {
+		cfg.Volume = 0.8
+	}
+	if cfg.Volume > 1 {
+		cfg.Volume = 1
+	}
+
+	p := &Player{
+		log:        log,
+		sampleRate: cfg.SampleRate,
+		queue:      make(chan []int16, 32),
+		stop:       make(chan struct{}),
+		done:       make(chan struct{}),
+	}
+	p.setVolume(cfg.Volume)
+	p.muted.Store(cfg.Muted)
+
+	if !cfg.Enabled || cfg.Device == "null" || defaultBackendFactory == nil {
+		log.Info("player: live audio disabled", "enabled", cfg.Enabled, "device", cfg.Device)
+		close(p.done)
+		return p, nil
+	}
+
+	be, err := defaultBackendFactory(cfg)
+	if err != nil {
+		log.Warn("player: backend init failed; running headless", "err", err)
+		close(p.done)
+		return p, nil
+	}
+	p.backend = be
+	go p.run()
+	return p, nil
+}
+
+// NewWithBackend constructs a Player wrapping an explicit backend.
+// Used by tests with a loopback backend.
+func NewWithBackend(be Backend, cfg Config, log *slog.Logger) (*Player, error) {
+	if log == nil {
+		return nil, errors.New("player: logger is required")
+	}
+	if cfg.SampleRate == 0 {
+		cfg.SampleRate = 8000
+	}
+	if cfg.Volume <= 0 {
+		cfg.Volume = 0.8
+	}
+	if cfg.Volume > 1 {
+		cfg.Volume = 1
+	}
+	p := &Player{
+		log:        log,
+		sampleRate: cfg.SampleRate,
+		queue:      make(chan []int16, 32),
+		stop:       make(chan struct{}),
+		done:       make(chan struct{}),
+		backend:    be,
+	}
+	p.setVolume(cfg.Volume)
+	p.muted.Store(cfg.Muted)
+	go p.run()
+	return p, nil
+}
+
+// WritePCM is the composer / conventional-scanner side of the fan-out.
+// Matches the composer.PCMSink and conventional.Recorder interfaces
+// so the daemon can drop the player straight into the existing
+// fanoutSink without any code changes downstream.
+//
+// The deviceSerial argument is the same routing key the recorder uses
+// (one in-flight call per voice SDR); the player doesn't tee per
+// device because the host has one output stream, but it's kept on
+// the signature so the interface stays compatible.
+func (p *Player) WritePCM(deviceSerial string, samples []int16) error {
+	if p == nil || p.backend == nil || len(samples) == 0 {
+		return nil
+	}
+	if p.muted.Load() {
+		return nil
+	}
+	buf := make([]int16, len(samples))
+	gain := p.getVolume()
+	if gain != 1.0 {
+		for i, s := range samples {
+			v := float32(s) * gain
+			if v > 32767 {
+				v = 32767
+			} else if v < -32768 {
+				v = -32768
+			}
+			buf[i] = int16(v)
+		}
+	} else {
+		copy(buf, samples)
+	}
+
+	select {
+	case p.queue <- buf:
+	default:
+		p.drops.Add(uint64(len(buf)))
+	}
+	return nil
+}
+
+// SetVolume sets the software gain in 0..1.
+func (p *Player) SetVolume(v float32) {
+	if v < 0 {
+		v = 0
+	} else if v > 1 {
+		v = 1
+	}
+	p.setVolume(v)
+}
+
+// Volume returns the current software gain.
+func (p *Player) Volume() float32 { return p.getVolume() }
+
+// SetMuted toggles the mute state.
+func (p *Player) SetMuted(m bool) { p.muted.Store(m) }
+
+// Muted returns true if currently muted.
+func (p *Player) Muted() bool { return p.muted.Load() }
+
+// Stats reports a snapshot of player counters for the API.
+type Stats struct {
+	Enabled    bool
+	SampleRate uint32
+	Volume     float32
+	Muted      bool
+	DropsTotal uint64
+}
+
+func (p *Player) Stats() Stats {
+	return Stats{
+		Enabled:    p.backend != nil,
+		SampleRate: p.sampleRate,
+		Volume:     p.getVolume(),
+		Muted:      p.muted.Load(),
+		DropsTotal: p.drops.Load(),
+	}
+}
+
+// Close stops the player and releases the backend.
+func (p *Player) Close() error {
+	if p == nil {
+		return nil
+	}
+	var closeErr error
+	p.stopOnce.Do(func() {
+		close(p.stop)
+		<-p.done
+		if p.backend != nil {
+			closeErr = p.backend.Close()
+		}
+	})
+	return closeErr
+}
+
+func (p *Player) setVolume(v float32) {
+	p.volume.Store(math.Float32bits(v))
+}
+
+func (p *Player) getVolume() float32 {
+	return math.Float32frombits(p.volume.Load())
+}
+
+func (p *Player) run() {
+	defer close(p.done)
+	idle := time.NewTicker(20 * time.Millisecond)
+	defer idle.Stop()
+	for {
+		select {
+		case <-p.stop:
+			return
+		case buf := <-p.queue:
+			if err := p.backend.Write(buf); err != nil {
+				p.log.Warn("player: backend write failed", "err", err)
+				return
+			}
+		case <-idle.C:
+			// no-op; keeps the goroutine responsive to stop even if
+			// the queue stays empty for long stretches between calls.
+		}
+	}
+}
+
+// String returns a human-readable description of the player state,
+// suitable for logging and the TUI status strip.
+func (p *Player) String() string {
+	if p == nil {
+		return "player(nil)"
+	}
+	return fmt.Sprintf("player(enabled=%t volume=%.2f muted=%t)",
+		p.backend != nil, p.getVolume(), p.muted.Load())
+}

--- a/internal/voice/player/player_test.go
+++ b/internal/voice/player/player_test.go
@@ -1,0 +1,157 @@
+package player
+
+import (
+	"io"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+)
+
+// loopback is a Backend that captures every Write into a slice so
+// tests can assert what the Player produced.
+type loopback struct {
+	mu      sync.Mutex
+	samples []int16
+	closed  bool
+}
+
+func (l *loopback) Write(samples []int16) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.closed {
+		return io.ErrClosedPipe
+	}
+	l.samples = append(l.samples, samples...)
+	return nil
+}
+
+func (l *loopback) Close() error {
+	l.mu.Lock()
+	l.closed = true
+	l.mu.Unlock()
+	return nil
+}
+
+func (l *loopback) snapshot() []int16 {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	out := make([]int16, len(l.samples))
+	copy(out, l.samples)
+	return out
+}
+
+func newTestPlayer(t *testing.T, cfg Config) (*Player, *loopback) {
+	t.Helper()
+	lb := &loopback{}
+	cfg.SampleRate = 8000
+	cfg.Volume = 1.0
+	p, err := NewWithBackend(lb, cfg, slog.Default())
+	if err != nil {
+		t.Fatalf("NewWithBackend: %v", err)
+	}
+	t.Cleanup(func() { _ = p.Close() })
+	return p, lb
+}
+
+func TestPlayerWritePCMPassThrough(t *testing.T) {
+	p, lb := newTestPlayer(t, Config{})
+	in := []int16{100, 200, -300, 400}
+	if err := p.WritePCM("dev", in); err != nil {
+		t.Fatalf("WritePCM: %v", err)
+	}
+	// give the run goroutine a tick to drain
+	waitFor(t, 200*time.Millisecond, func() bool {
+		return len(lb.snapshot()) == len(in)
+	})
+	got := lb.snapshot()
+	if len(got) != len(in) {
+		t.Fatalf("loopback length: got %d, want %d", len(got), len(in))
+	}
+	for i := range in {
+		if got[i] != in[i] {
+			t.Errorf("sample %d: got %d, want %d", i, got[i], in[i])
+		}
+	}
+}
+
+func TestPlayerMuted(t *testing.T) {
+	p, lb := newTestPlayer(t, Config{Muted: true})
+	if err := p.WritePCM("dev", []int16{1, 2, 3}); err != nil {
+		t.Fatalf("WritePCM: %v", err)
+	}
+	time.Sleep(50 * time.Millisecond)
+	if got := lb.snapshot(); len(got) != 0 {
+		t.Fatalf("muted player wrote %d samples", len(got))
+	}
+
+	// Unmute and confirm samples flow.
+	p.SetMuted(false)
+	if err := p.WritePCM("dev", []int16{10, 20}); err != nil {
+		t.Fatalf("WritePCM: %v", err)
+	}
+	waitFor(t, 200*time.Millisecond, func() bool {
+		return len(lb.snapshot()) == 2
+	})
+	got := lb.snapshot()
+	if len(got) != 2 || got[0] != 10 || got[1] != 20 {
+		t.Fatalf("unexpected samples after unmute: %v", got)
+	}
+}
+
+func TestPlayerVolumeHalves(t *testing.T) {
+	p, lb := newTestPlayer(t, Config{})
+	p.SetVolume(0.5)
+	if err := p.WritePCM("dev", []int16{1000, -2000, 4000}); err != nil {
+		t.Fatalf("WritePCM: %v", err)
+	}
+	waitFor(t, 200*time.Millisecond, func() bool {
+		return len(lb.snapshot()) == 3
+	})
+	got := lb.snapshot()
+	want := []int16{500, -1000, 2000}
+	for i, w := range want {
+		if got[i] != w {
+			t.Errorf("sample %d: got %d, want %d", i, got[i], w)
+		}
+	}
+}
+
+func TestPlayerNullBackend(t *testing.T) {
+	// Enabled=false should produce a Player whose WritePCM is a
+	// silent no-op, with backend == nil and Enabled stat false.
+	p, err := New(Config{Enabled: false}, slog.Default())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer p.Close()
+	if err := p.WritePCM("dev", []int16{1, 2, 3}); err != nil {
+		t.Fatalf("WritePCM: %v", err)
+	}
+	if st := p.Stats(); st.Enabled {
+		t.Fatalf("expected Enabled=false on null player")
+	}
+}
+
+func TestPlayerClosed(t *testing.T) {
+	p, _ := newTestPlayer(t, Config{})
+	if err := p.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	// Second Close is a no-op.
+	if err := p.Close(); err != nil {
+		t.Fatalf("second Close: %v", err)
+	}
+}
+
+func waitFor(t *testing.T, d time.Duration, fn func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(d)
+	for time.Now().Before(deadline) {
+		if fn() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("condition not met within %s", d)
+}

--- a/internal/voice/recorder.go
+++ b/internal/voice/recorder.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/MattCheramie/GopherTrunk/internal/events"
@@ -58,6 +59,14 @@ type Recorder struct {
 	sub       *events.Subscription
 	runDone   chan struct{}
 	closeOnce sync.Once
+
+	// recordDisabled gates new sessions at runtime. Toggled from
+	// the API by operators who want to stop laying down WAVs
+	// without restarting the daemon. In-flight sessions are NOT
+	// truncated on disable — they finish naturally on CallEnd so
+	// the head of a call isn't lost when the operator flips the
+	// switch mid-conversation.
+	recordDisabled atomic.Bool
 }
 
 // RecorderOptions configure a new Recorder.
@@ -139,6 +148,20 @@ func NewRecorder(opts RecorderOptions) (*Recorder, error) {
 	}
 	r.sub = opts.Bus.Subscribe()
 	return r, nil
+}
+
+// SetRecordingEnabled toggles the recorder's runtime "create new
+// sessions" gate. When enabled is false, subsequent CallStart events
+// do NOT open .wav / .raw files; in-flight sessions are left alone
+// so the head of a mid-call disable isn't lost on disk. Default
+// (after NewRecorder) is enabled = true.
+func (r *Recorder) SetRecordingEnabled(enabled bool) {
+	r.recordDisabled.Store(!enabled)
+}
+
+// RecordingEnabled reports the current gate state.
+func (r *Recorder) RecordingEnabled() bool {
+	return !r.recordDisabled.Load()
 }
 
 // SessionCount returns the number of currently-open recording sessions.
@@ -262,6 +285,13 @@ func (r *Recorder) WriteRawFrame(deviceSerial string, frame []byte) error {
 }
 
 func (r *Recorder) handleStart(cs trunking.CallStart) {
+	if r.recordDisabled.Load() {
+		// Operator has flipped off recording at runtime. Drop the
+		// CallStart silently so no files land on disk for this call.
+		// In-flight sessions started before the disable continue to
+		// completion via handleEnd.
+		return
+	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if _, busy := r.sessions[cs.DeviceSerial]; busy {

--- a/internal/voice/recorder_test.go
+++ b/internal/voice/recorder_test.go
@@ -91,6 +91,61 @@ func TestRecorderWritesPerCallWav(t *testing.T) {
 	}
 }
 
+// TestRecorderGateBlocksNewSessions confirms the runtime
+// SetRecordingEnabled(false) gate stops handleStart from opening
+// new .wav files while leaving in-flight sessions alone. Matches the
+// TUI / API "press R to toggle recording" semantics.
+func TestRecorderGateBlocksNewSessions(t *testing.T) {
+	r, bus, dir := mkRecorder(t, false)
+	defer r.Close()
+	defer bus.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go r.Run(ctx)
+
+	r.SetRecordingEnabled(false)
+	if r.RecordingEnabled() {
+		t.Fatal("RecordingEnabled should report false after SetRecordingEnabled(false)")
+	}
+
+	cs := trunking.CallStart{
+		Grant: trunking.Grant{
+			System:   "Sys",
+			Protocol: "p25",
+			GroupID:  7,
+			SourceID: 8,
+		},
+		Talkgroup:    &trunking.TalkGroup{ID: 7, AlphaTag: "GATE"},
+		DeviceSerial: "VOICE-G",
+		StartedAt:    time.Date(2026, 5, 5, 12, 0, 0, 0, time.UTC),
+	}
+	bus.Publish(events.Event{Kind: events.KindCallStart, Payload: cs})
+	time.Sleep(50 * time.Millisecond)
+	if r.HasSession("VOICE-G") {
+		t.Fatal("recorder opened a session despite gate")
+	}
+
+	// Re-enable and confirm the next CallStart opens a session.
+	r.SetRecordingEnabled(true)
+	cs2 := cs
+	cs2.DeviceSerial = "VOICE-G2"
+	bus.Publish(events.Event{Kind: events.KindCallStart, Payload: cs2})
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if r.HasSession("VOICE-G2") {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if !r.HasSession("VOICE-G2") {
+		t.Fatal("session not opened after gate re-enabled")
+	}
+	// dir is unused here but the helper drops a tempdir we should
+	// not crash on.
+	_ = dir
+}
+
 func TestRecorderWritePCMDropsWithoutSession(t *testing.T) {
 	r, bus, _ := mkRecorder(t, false)
 	defer r.Close()


### PR DESCRIPTION
Two-commit PR that turns GopherTrunk into a scanner you can run from one keyboard: decoded calls play out the host speakers, and volume / mute / recording are toggleable live from the TUI and over the REST API.

Workstreams A + B of the multi-PR plan. C (manual VFO tune), D (CTCSS / squelch tail), F (drop the libasound2-dev build dep) follow.

## Commit 1 — `internal/voice/player`: live audio playback to host speakers

Adds a `voice.Player` sink that wraps `github.com/ebitengine/oto/v3` (ALSA / CoreAudio / WASAPI). The daemon fans PCM from the per-call composer and the conventional FM scanner into the player alongside the existing WAV recorder, so when `audio.enabled: true` is set in config, decoded calls play out the host's default output device in real time. Software gain stage in front of the backend keeps volume and mute changes instant. Disabled by default — headless servers stay silent and continue to record WAVs identically to before.

Also:
- `audio:` config block (`enabled`, `device`, `sample_rate`, `buffer_ms`, `volume`, `muted`) + validation
- `gophertrunk audio list` subcommand mirroring `sdr list`
- `playerSink` + `convFanoutRecorder` adapters in the daemon that slot the Player into the existing `fanoutSink` and the conventional scanner's `Recorder` interface without changing either downstream

Linux builds require `libasound2-dev` at build time (`libasound2` at runtime); macOS / Windows builds work as-is. The build-time-dep removal is tracked under Workstream F of the active plan.

## Commit 2 — `internal/api`: audio cockpit + TUI volume / mute / record controls

Adds the TUI / API control surface over the v1 audio sink. Operators can now hold / resume / retune the hunter **and** adjust volume, mute, and recording, all from the Scanner panel.

### API

- `GET /api/v1/audio` — reports `BackendEnabled`, `SampleRate`, `Volume`, `Muted`, `RecordingEnabled`, `DropsTotal`. Open like `GET /api/v1/scanner`.
- `PATCH /api/v1/audio` — applies any subset of `{volume, muted, recording_enabled}` with the same pointer-field "leave unchanged when omitted" convention as the talkgroup patch. Gated by `api.allow_mutations`.
- New `AudioController` interface on `api.ServerOptions`; the daemon supplies an `audioCockpit` adapter (`cmd/gophertrunk/daemon.go`) that fans into `*player.Player` and `*voice.Recorder`.

### Recorder gate

`voice.Recorder` now exposes `SetRecordingEnabled` / `RecordingEnabled`. When disabled, `CallStart` events do **not** open new `.wav` / `.raw` files; in-flight sessions complete naturally on `CallEnd` so the head of a mid-call disable isn't lost on disk.

### TUI

- New keybindings on the Scanner panel: `+` / `-` adjust volume by 5%, `M` toggles mute, `R` toggles recording.
- Status footer in the Scanner panel shows `output / vol / rec` state live.
- `SharedState.Audio` populated from a 3-second poll of `/api/v1/audio`.
- `WriteKindAudio` dispatches to `PATCH /api/v1/audio` through the existing toast / refresh machinery.

### Tests

- Player unit tests (loopback backend, no host audio required).
- 6 new API handler tests: GET (OK + 503 when not wired), PATCH happy path, out-of-range volume rejection, empty-body rejection, `allow_mutations` gate.
- 1 new recorder gate test: confirms the disable blocks new sessions and re-enable lets the next CallStart through.
- All pre-existing tests still pass. `go vet ./...` clean.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -short ./...` all green (incl. new player / handler / recorder tests)
- [ ] Manual smoke: `gophertrunk run` + `gophertrunk tui --write` on a host with an SDR, confirm:
  - hopping CC, grant, voice plays through speakers, WAV appears under `recordings/`
  - `+` / `-` audibly adjusts volume, `M` mutes, `R` toggles new-WAV creation while in-flight WAVs continue to flush
- [ ] Manual remote: `curl -X PATCH http://127.0.0.1:8080/api/v1/audio -d '{"muted":true}'` updates the TUI status footer on the next 3s poll
- [ ] Headless safety: `audio.enabled: false` keeps daemon recording WAVs identically to today

https://claude.ai/code/session_01FYBcR9CAiGws74GiqffTkd