### PR TITLE
.github/workflows/ci.yml: install libasound2-dev so build-test passes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,14 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: "1.24"
+      # internal/voice/player wraps github.com/ebitengine/oto/v3, which
+      # cgo-links against ALSA on Linux. The runtime dep (libasound2)
+      # ships on every desktop / server image; the build-time headers
+      # (libasound2-dev) are not on ubuntu-latest by default. Workstream F
+      # of the active plan replaces this with a purego dlopen of
+      # libasound2.so.2 and drops this apt step entirely.
+      - name: Install ALSA dev headers (oto/v3 cgo dep)
+        run: sudo apt-get update && sudo apt-get install -y libasound2-dev
       - run: go vet ./...
       - run: go build ./...
       - run: go test -race -count=1 ./...


### PR DESCRIPTION
## Summary

PR #159 merged with a failing `build-test` check because the runner doesn't have ALSA dev headers. `internal/voice/player` (added in #159) wraps `github.com/ebitengine/oto/v3`, which cgo-links against ALSA on Linux. The runtime `libasound2` ships on every standard image; the dev headers (`libasound2-dev`) are not on `ubuntu-latest` by default, so `go vet` / `go build` / `go test` fail with:

```
Package alsa was not found in the pkg-config search path.
```

This installs `libasound2-dev` before `go vet` runs.

This was originally pushed onto the #159 branch as commit `6ce6b4e`, but #159 was merged before that commit landed, so the fix is going in as a follow-up.

Workstream F of the active plan replaces oto with a purego dlopen of `libasound2.so.2` and drops this apt step entirely. The comment in the workflow points there.

## Test plan

- [x] Reproduces the failure locally without the apt step; passes with it
- [ ] Post-merge CI on main goes green

https://claude.ai/code/session_01FYBcR9CAiGws74GiqffTkd

---
_Generated by [Claude Code](https://claude.ai/code/session_01FYBcR9CAiGws74GiqffTkd)_