### PR TITLE
internal/scanner/conventional: manual VFO tune from the TUI / API

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,19 @@ The remaining gaps:
   unit tests; calibration against a captured YSF transmission's
   exact interleaver / puncture schedule lands once a real-air capture
   is available.
+- **Manual VFO tune from the TUI / API.** The Scanner panel now binds
+  `f` to a bubbles/textinput overlay: type a frequency in MHz, Enter,
+  and the conventional FM scanner appends a runtime "manual" channel
+  and forces dwell on it. Same flow available over REST as `POST
+  /api/v1/scanner/manual_tune` (and `DELETE /api/v1/scanner/manual_tune/{idx}`
+  to revoke), gated behind `api.allow_mutations`. To run manual tune
+  without any static `scanner.conventional` entries, set
+  `scanner.manual_tune_enabled: true` in config — the daemon then
+  constructs the conventional scanner against the last Voice SDR
+  regardless of the static channel count. `internal/scanner/conventional`
+  now accepts an empty seed channel list and exposes
+  `AddTemporaryChannel` / `RemoveTemporaryChannel` so the same VFO
+  surface is callable from any embedder.
 - **Live audio playback to speakers + TUI / API audio cockpit.** The
   daemon ships a `voice.Player` sink (`internal/voice/player`) wrapping
   github.com/ebitengine/oto/v3 (ALSA on Linux, CoreAudio on macOS,

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -358,10 +358,11 @@ func NewDaemon(cfg config.Config, version string, log *slog.Logger) (*Daemon, er
 	// publishes synthetic CallStart/CallEnd events through
 	// Engine.HandleSyntheticCall, so the recorder, call log, and
 	// /api/v1/calls/active surfaces light up like any other call.
-	if d.pool != nil && d.recorder != nil && d.engine != nil && len(cfg.Scanner.Conventional) > 0 {
+	convWanted := len(cfg.Scanner.Conventional) > 0 || cfg.Scanner.ManualTuneEnabled
+	if d.pool != nil && d.recorder != nil && d.engine != nil && convWanted {
 		voiceEntries := d.pool.AllByRole(sdr.RoleVoice)
 		if len(voiceEntries) == 0 {
-			log.Warn("daemon: scanner.conventional configured but no Voice SDRs in the pool; skipping")
+			log.Warn("daemon: scanner.conventional / manual_tune_enabled configured but no Voice SDRs in the pool; skipping")
 		} else {
 			// Use the LAST voice SDR so the trunking engine still
 			// has the first N-1 voice radios for normal grants.

--- a/cmd/gophertrunk/scanner_cockpit.go
+++ b/cmd/gophertrunk/scanner_cockpit.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/MattCheramie/GopherTrunk/internal/api"
 	"github.com/MattCheramie/GopherTrunk/internal/scanner/cchunt"
@@ -136,4 +137,36 @@ func (c scannerCockpit) DwellConventional(index int) bool {
 		return false
 	}
 	return c.conv.DwellOn(index)
+}
+
+// ManualTune adds a VFO-style temporary channel and forces dwell on
+// it. Falls back to scanner defaults (SquelchDbFS=-50, Hangtime=
+// 1500ms, Mode=fm) so the API caller only has to supply
+// FrequencyHz to "listen now".
+func (c scannerCockpit) ManualTune(req api.ManualTuneRequest) (int, bool) {
+	if c.conv == nil {
+		return 0, false
+	}
+	ch := conventional.Channel{
+		Label:       req.Label,
+		FrequencyHz: req.FrequencyHz,
+		Mode:        req.Mode,
+		SquelchDbFS: req.SquelchDbFS,
+	}
+	if req.HangtimeMs > 0 {
+		ch.Hangtime = time.Duration(req.HangtimeMs) * time.Millisecond
+	}
+	if ch.Label == "" {
+		ch.Label = "manual"
+	}
+	idx := c.conv.AddTemporaryChannel(ch)
+	return idx, true
+}
+
+// ClearManualTune removes a previously-added temp channel.
+func (c scannerCockpit) ClearManualTune(index int) bool {
+	if c.conv == nil {
+		return false
+	}
+	return c.conv.RemoveTemporaryChannel(index)
 }

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -74,6 +74,14 @@ scanner:
     dwell_ms: 3000
     backoff_ms: 5000
     max_backoff_ms: 60000
+  # manual_tune_enabled opts in to constructing the conventional
+  # scanner even when no static channels are configured, so the
+  # TUI's `f` key (or POST /api/v1/scanner/manual_tune) can
+  # VFO-tune at runtime. The scanner steals one Voice SDR from
+  # the trunking pool, so only enable if you have a spare Voice
+  # SDR or are willing to trade trunked grant-following for
+  # manual tune.
+  manual_tune_enabled: false
   conventional: []
   # Example conventional channels:
   # conventional:

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -80,7 +80,7 @@ gophertrunk tui -server https://radio.example.com -insecure
 | Tone alerts | (table navigation only) |
 | Metrics | (table navigation only) |
 | Devices | (table navigation only) |
-| Scanner | `j` / `k` move row, `h` hold/resume highlighted row, `r` force re-hunt (Systems section, confirms), `Enter` dwell on highlighted conv channel, `m` cycle scan_mode, `+` / `-` volume up/down (5% step), `M` mute toggle, `R` recording toggle |
+| Scanner | `j` / `k` move row, `h` hold/resume highlighted row, `r` force re-hunt (Systems section, confirms), `Enter` dwell on highlighted conv channel, `m` cycle scan_mode, `+` / `-` volume up/down (5% step), `M` mute toggle, `R` recording toggle, `f` manual tune (type frequency in MHz, Enter to listen, Esc to cancel) |
 
 ## Polling cadences
 

--- a/internal/api/handlers_scanner.go
+++ b/internal/api/handlers_scanner.go
@@ -126,3 +126,88 @@ func (s *Server) handleConvDwell(w http.ResponseWriter, r *http.Request) {
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "index": idx})
 }
+
+// handleScannerManualTune adds a VFO-style temporary channel to the
+// conventional scanner and forces dwell on it. Mirrors the muscle
+// memory of a traditional scanner's "FREQ" / "MAN" / "TUNE" key.
+//
+//   POST /api/v1/scanner/manual_tune
+//   Content-Type: application/json
+//   {"frequency_hz":155895000,"label":"sheriff","mode":"fm"}
+//
+// Responses:
+//
+//	200 {"ok":true,"index":N,"frequency_hz":...}
+//	400 if frequency_hz is missing or out of range
+//	503 if the conventional scanner isn't wired (no Voice SDR
+//	    carved out for it)
+func (s *Server) handleScannerManualTune(w http.ResponseWriter, r *http.Request) {
+	if s.scanner == nil {
+		writeError(w, http.StatusServiceUnavailable, "scanner not wired")
+		return
+	}
+	var req ManualTuneRequest
+	if r.Body == nil || r.ContentLength == 0 {
+		writeError(w, http.StatusBadRequest, "body required")
+		return
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid json body")
+		return
+	}
+	if req.FrequencyHz == 0 {
+		writeError(w, http.StatusBadRequest, "frequency_hz required")
+		return
+	}
+	// Sanity check: 25 MHz – 1.3 GHz is the practical RTL-SDR tuning
+	// range. Looser is fine but a zero or absurd value almost
+	// certainly means the operator mis-typed.
+	if req.FrequencyHz < 25_000_000 || req.FrequencyHz > 1_300_000_000 {
+		writeError(w, http.StatusBadRequest, "frequency_hz outside 25 MHz – 1.3 GHz tuning range")
+		return
+	}
+	if req.Mode != "" && req.Mode != "fm" && req.Mode != "nfm" {
+		writeError(w, http.StatusBadRequest, "mode must be fm or nfm")
+		return
+	}
+	idx, ok := s.scanner.ManualTune(req)
+	if !ok {
+		writeError(w, http.StatusServiceUnavailable, "conventional scanner not configured")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"ok":           true,
+		"index":        idx,
+		"frequency_hz": req.FrequencyHz,
+	})
+}
+
+// handleScannerClearManualTune removes a temporary channel
+// previously added via manual tune. Static (config-seeded)
+// channels can't be removed at runtime — those return 404.
+//
+//   DELETE /api/v1/scanner/manual_tune/{index}
+//
+// Responses:
+//
+//	200 {"ok":true,"index":N}
+//	400 if the index can't be parsed
+//	404 if the index isn't a temp channel
+//	503 if the scanner isn't wired
+func (s *Server) handleScannerClearManualTune(w http.ResponseWriter, r *http.Request) {
+	if s.scanner == nil {
+		writeError(w, http.StatusServiceUnavailable, "scanner not wired")
+		return
+	}
+	idxStr := r.PathValue("index")
+	idx, err := strconv.Atoi(idxStr)
+	if err != nil || idx < 0 {
+		writeError(w, http.StatusBadRequest, "invalid index")
+		return
+	}
+	if !s.scanner.ClearManualTune(idx) {
+		writeError(w, http.StatusNotFound, "no such temporary channel")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "index": idx})
+}

--- a/internal/api/handlers_scanner_test.go
+++ b/internal/api/handlers_scanner_test.go
@@ -28,6 +28,10 @@ type fakeCockpit struct {
 	convNotConfigured bool
 	dwellRange int // valid range [0..dwellRange); -1 means any index accepted
 	prevMode string
+	manualReqs []ManualTuneRequest
+	manualNextIdx int
+	clearedManual []int
+	clearOK bool
 }
 
 func (f *fakeCockpit) Status() ScannerStatus { return f.status }
@@ -103,6 +107,26 @@ func (f *fakeCockpit) DwellConventional(i int) bool {
 	f.mu.Lock()
 	f.dwell = append(f.dwell, i)
 	f.mu.Unlock()
+	return true
+}
+func (f *fakeCockpit) ManualTune(req ManualTuneRequest) (int, bool) {
+	if f.convNotConfigured {
+		return 0, false
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	idx := f.manualNextIdx
+	f.manualNextIdx++
+	f.manualReqs = append(f.manualReqs, req)
+	return idx, true
+}
+func (f *fakeCockpit) ClearManualTune(i int) bool {
+	if !f.clearOK {
+		return false
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.clearedManual = append(f.clearedManual, i)
 	return true
 }
 
@@ -278,3 +302,139 @@ func TestScannerConvHold_NoConvScanner(t *testing.T) {
 		t.Errorf("status=%d, want 503 (no conv scanner)", resp.StatusCode)
 	}
 }
+
+func TestScannerManualTune_OK(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	cock := &fakeCockpit{}
+	base, teardown := mkServer(t, ServerOptions{Bus: bus, Scanner: cock, AllowMutations: true})
+	defer teardown()
+
+	body := bytes.NewReader([]byte(`{"frequency_hz":155895000,"label":"sheriff","mode":"fm"}`))
+	resp, err := http.Post(base+"/api/v1/scanner/manual_tune", "application/json", body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("status=%d", resp.StatusCode)
+	}
+	if len(cock.manualReqs) != 1 || cock.manualReqs[0].FrequencyHz != 155895000 || cock.manualReqs[0].Label != "sheriff" {
+		t.Errorf("ManualTune not routed: %+v", cock.manualReqs)
+	}
+}
+
+func TestScannerManualTune_RejectsMissingFreq(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	cock := &fakeCockpit{}
+	base, teardown := mkServer(t, ServerOptions{Bus: bus, Scanner: cock, AllowMutations: true})
+	defer teardown()
+
+	body := bytes.NewReader([]byte(`{"label":"x"}`))
+	resp, err := http.Post(base+"/api/v1/scanner/manual_tune", "application/json", body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 400 {
+		t.Errorf("status=%d, want 400", resp.StatusCode)
+	}
+	if len(cock.manualReqs) != 0 {
+		t.Errorf("ManualTune should not be called on rejected request")
+	}
+}
+
+func TestScannerManualTune_RejectsOutOfRangeFreq(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	cock := &fakeCockpit{}
+	base, teardown := mkServer(t, ServerOptions{Bus: bus, Scanner: cock, AllowMutations: true})
+	defer teardown()
+
+	body := bytes.NewReader([]byte(`{"frequency_hz":5000000000}`))
+	resp, err := http.Post(base+"/api/v1/scanner/manual_tune", "application/json", body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 400 {
+		t.Errorf("status=%d, want 400", resp.StatusCode)
+	}
+}
+
+func TestScannerManualTune_503WhenNoConvScanner(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	cock := &fakeCockpit{convNotConfigured: true}
+	base, teardown := mkServer(t, ServerOptions{Bus: bus, Scanner: cock, AllowMutations: true})
+	defer teardown()
+
+	body := bytes.NewReader([]byte(`{"frequency_hz":155895000}`))
+	resp, err := http.Post(base+"/api/v1/scanner/manual_tune", "application/json", body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 503 {
+		t.Errorf("status=%d, want 503", resp.StatusCode)
+	}
+}
+
+func TestScannerClearManualTune(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	cock := &fakeCockpit{clearOK: true}
+	base, teardown := mkServer(t, ServerOptions{Bus: bus, Scanner: cock, AllowMutations: true})
+	defer teardown()
+
+	req, _ := http.NewRequest(http.MethodDelete, base+"/api/v1/scanner/manual_tune/3", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Errorf("status=%d, want 200", resp.StatusCode)
+	}
+	if len(cock.clearedManual) != 1 || cock.clearedManual[0] != 3 {
+		t.Errorf("ClearManualTune not routed: %v", cock.clearedManual)
+	}
+
+	// Same call with clearOK=false → 404.
+	cock.clearOK = false
+	req, _ = http.NewRequest(http.MethodDelete, base+"/api/v1/scanner/manual_tune/3", nil)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != 404 {
+		t.Errorf("clearOK=false status=%d, want 404", resp.StatusCode)
+	}
+}
+
+func TestScannerManualTune_Gated(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	cock := &fakeCockpit{}
+	base, teardown := mkServer(t, ServerOptions{Bus: bus, Scanner: cock /* AllowMutations:false */})
+	defer teardown()
+
+	body := bytes.NewReader([]byte(`{"frequency_hz":155895000}`))
+	resp, err := http.Post(base+"/api/v1/scanner/manual_tune", "application/json", body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 403 {
+		t.Errorf("status=%d, want 403", resp.StatusCode)
+	}
+	if len(cock.manualReqs) != 0 {
+		t.Errorf("ManualTune called despite gate")
+	}
+}
+
+// suppress "unused import" issues; using io / fmt may be needed via bytes.
+var _ = io.Discard
+var _ = fmt.Sprintf

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -114,6 +114,26 @@ type ScannerCockpit interface {
 	HoldConventional() bool
 	ResumeConventional() bool
 	DwellConventional(index int) bool
+	// ManualTune appends a VFO-style temporary channel to the
+	// conventional scanner and forces dwell on it. Returns the new
+	// index + ok=true on success; ok=false when the conventional
+	// scanner isn't configured (no Voice SDR carved out for it).
+	ManualTune(req ManualTuneRequest) (index int, ok bool)
+	// ClearManualTune removes a previously-added temp channel by
+	// index. Returns false if the index isn't a temp channel or
+	// the scanner isn't configured.
+	ClearManualTune(index int) bool
+}
+
+// ManualTuneRequest is the shape of POST /api/v1/scanner/manual_tune.
+// FrequencyHz is required; everything else falls back to scanner
+// defaults (Mode=fm, SquelchDbFS=-50, Hangtime=1500ms).
+type ManualTuneRequest struct {
+	FrequencyHz uint32  `json:"frequency_hz"`
+	Label       string  `json:"label"`
+	Mode        string  `json:"mode"`
+	SquelchDbFS float64 `json:"squelch_dbfs"`
+	HangtimeMs  int     `json:"hangtime_ms"`
 }
 
 // ScannerStatus is the JSON shape returned by GET /api/v1/scanner —
@@ -396,6 +416,8 @@ func (s *Server) routes() *http.ServeMux {
 	mux.HandleFunc("POST /api/v1/scanner/conventional/hold", s.gate(s.handleConvHold))
 	mux.HandleFunc("POST /api/v1/scanner/conventional/resume", s.gate(s.handleConvResume))
 	mux.HandleFunc("POST /api/v1/scanner/conventional/{index}/dwell", s.gate(s.handleConvDwell))
+	mux.HandleFunc("POST /api/v1/scanner/manual_tune", s.gate(s.handleScannerManualTune))
+	mux.HandleFunc("DELETE /api/v1/scanner/manual_tune/{index}", s.gate(s.handleScannerClearManualTune))
 
 	// Audio cockpit — read endpoint is always open; the PATCH is
 	// gated behind allow_mutations like every other write route.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -67,6 +67,14 @@ type ScannerConfig struct {
 	CCHunt CCHuntConfig `yaml:"cc_hunt"`
 	// Conventional is the fixed-frequency analog scan list.
 	Conventional []ConvChannelConfig `yaml:"conventional"`
+	// ManualTuneEnabled opts in to constructing the conventional
+	// scanner even when no static channels are configured, so the
+	// TUI's `f` key (or POST /api/v1/scanner/manual_tune) can
+	// VFO-tune at runtime. Off by default — the scanner steals a
+	// Voice SDR from the trunking pool, so operators with only
+	// one Voice SDR need to know they're trading trunked grant-
+	// following for manual tune.
+	ManualTuneEnabled bool `yaml:"manual_tune_enabled"`
 }
 
 // CCHuntConfig tunes the hunter's dwell + exponential backoff.

--- a/internal/scanner/conventional/scanner.go
+++ b/internal/scanner/conventional/scanner.go
@@ -115,6 +115,7 @@ type Scanner struct {
 	log  *slog.Logger
 
 	mu          sync.RWMutex
+	channels    []Channel // mutable; opts.Channels is the seed, AddTemporaryChannel grows it
 	cursor      int
 	state       State
 	held        bool
@@ -126,9 +127,16 @@ type Scanner struct {
 	// forcedDwellIndex is set by DwellOn — the next round picks this
 	// channel up directly, bypassing the scan cursor.
 	forcedDwellIndex int
+	// tempChannels tracks indices added by AddTemporaryChannel so
+	// RemoveTemporaryChannel can validate the index belongs to a
+	// VFO-style entry rather than a config-seeded one. Bool value
+	// is irrelevant — set membership only.
+	tempChannels map[int]bool
 }
 
-// New constructs a Scanner. Channels must be non-empty.
+// New constructs a Scanner. Channels may be empty when the operator
+// only intends to drive the scanner via AddTemporaryChannel (manual
+// VFO tune from the TUI / API).
 func New(opts Options) (*Scanner, error) {
 	if opts.Engine == nil {
 		return nil, errors.New("conventional: Engine is required")
@@ -141,9 +149,6 @@ func New(opts Options) (*Scanner, error) {
 	}
 	if opts.Recorder == nil {
 		return nil, errors.New("conventional: Recorder is required")
-	}
-	if len(opts.Channels) == 0 {
-		return nil, errors.New("conventional: at least one channel is required")
 	}
 	if opts.DeviceSerial == "" {
 		return nil, errors.New("conventional: DeviceSerial is required")
@@ -160,9 +165,12 @@ func New(opts Options) (*Scanner, error) {
 	if opts.Log == nil {
 		opts.Log = slog.Default()
 	}
-	// Apply per-channel defaults.
-	for i := range opts.Channels {
-		ch := &opts.Channels[i]
+	// Copy + apply per-channel defaults so the caller's slice
+	// stays untouched.
+	channels := make([]Channel, len(opts.Channels))
+	copy(channels, opts.Channels)
+	for i := range channels {
+		ch := &channels[i]
 		if ch.SquelchDbFS == 0 {
 			ch.SquelchDbFS = -50
 		}
@@ -176,10 +184,12 @@ func New(opts Options) (*Scanner, error) {
 	return &Scanner{
 		opts:             opts,
 		log:              opts.Log,
+		channels:         channels,
 		state:            StateScanning,
 		dwellIndex:       -1,
 		forcedDwellIndex: -1,
-		lastBreakAt:      make([]time.Time, len(opts.Channels)),
+		lastBreakAt:      make([]time.Time, len(channels)),
+		tempChannels:     make(map[int]bool),
 	}, nil
 }
 
@@ -195,8 +205,15 @@ func (s *Scanner) Run(ctx context.Context) error {
 			s.sleep(ctx, 100*time.Millisecond)
 			continue
 		}
-		idx := s.nextChannel()
-		ch := s.opts.Channels[idx]
+		idx, ch, ok := s.pickNextChannel()
+		if !ok {
+			// Empty channel list — operator has neither configured
+			// any static channels nor added a temporary one. Idle
+			// in 100 ms ticks so AddTemporaryChannel picks up on
+			// the next round.
+			s.sleep(ctx, 100*time.Millisecond)
+			continue
+		}
 
 		if err := s.opts.Tuner.SetCenterFreq(ch.FrequencyHz); err != nil {
 			s.log.Warn("conv: tune failed", "freq_hz", ch.FrequencyHz, "err", err)
@@ -323,20 +340,29 @@ func (s *Scanner) endDwell(idx int, reason trunking.EndReason) {
 	s.mu.Unlock()
 }
 
-// nextChannel returns the index of the next channel to tune,
-// respecting any forced-dwell override from DwellOn.
-func (s *Scanner) nextChannel() int {
+// pickNextChannel returns the index + a copy of the next channel to
+// tune, respecting any forced-dwell override from DwellOn. The
+// returned ok=false signals an empty channel list — the Run loop
+// idles until AddTemporaryChannel populates one.
+func (s *Scanner) pickNextChannel() (int, Channel, bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if s.forcedDwellIndex >= 0 && s.forcedDwellIndex < len(s.opts.Channels) {
+	n := len(s.channels)
+	if n == 0 {
+		return 0, Channel{}, false
+	}
+	if s.forcedDwellIndex >= 0 && s.forcedDwellIndex < n {
 		idx := s.forcedDwellIndex
 		s.forcedDwellIndex = -1
-		s.cursor = (idx + 1) % len(s.opts.Channels)
-		return idx
+		s.cursor = (idx + 1) % n
+		return idx, s.channels[idx], true
+	}
+	if s.cursor >= n {
+		s.cursor = 0
 	}
 	idx := s.cursor
-	s.cursor = (s.cursor + 1) % len(s.opts.Channels)
-	return idx
+	s.cursor = (s.cursor + 1) % n
+	return idx, s.channels[idx], true
 }
 
 func (s *Scanner) sleep(ctx context.Context, d time.Duration) {
@@ -384,10 +410,104 @@ func (s *Scanner) IsHeld() bool {
 func (s *Scanner) DwellOn(idx int) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if idx < 0 || idx >= len(s.opts.Channels) {
+	if idx < 0 || idx >= len(s.channels) {
 		return false
 	}
 	s.forcedDwellIndex = idx
+	return true
+}
+
+// AddTemporaryChannel appends a runtime "VFO" channel and forces
+// the scanner to dwell on it next round. Returns the new index.
+// Defaults are applied identically to the config-seeded path
+// (SquelchDbFS=-50, Hangtime=1500ms, Mode=fm). Safe to call from
+// any goroutine.
+func (s *Scanner) AddTemporaryChannel(ch Channel) int {
+	if ch.SquelchDbFS == 0 {
+		ch.SquelchDbFS = -50
+	}
+	if ch.Hangtime <= 0 {
+		ch.Hangtime = 1500 * time.Millisecond
+	}
+	if ch.Mode == "" {
+		ch.Mode = "fm"
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	idx := len(s.channels)
+	s.channels = append(s.channels, ch)
+	s.lastBreakAt = append(s.lastBreakAt, time.Time{})
+	s.tempChannels[idx] = true
+	s.forcedDwellIndex = idx
+	// Make sure we're not held — a manual tune is an explicit
+	// "listen now" intent.
+	s.held = false
+	s.state = StateScanning
+	return idx
+}
+
+// RemoveTemporaryChannel deletes a channel previously added via
+// AddTemporaryChannel. Static (config-seeded) channels can't be
+// removed at runtime; this returns false for those. If the
+// channel is currently dwelling, the scanner ends the synthetic
+// call before removing it.
+//
+// Note: removing a temporary channel re-indexes everything after
+// it. This is fine for the v1 manual-tune flow (which adds one
+// VFO at a time and revokes it on a new tune) but callers must
+// not assume indices are stable across a remove.
+func (s *Scanner) RemoveTemporaryChannel(idx int) bool {
+	s.mu.Lock()
+	if !s.tempChannels[idx] {
+		s.mu.Unlock()
+		return false
+	}
+	// If we're currently dwelling on the channel being removed,
+	// end the synthetic call first so the engine cleans up.
+	dwelling := s.dwellIndex == idx
+	s.mu.Unlock()
+	if dwelling {
+		s.opts.Engine.EndSyntheticCall(s.opts.DeviceSerial, trunking.EndReasonManual)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	// Re-validate under the lock (a concurrent remove could have
+	// snuck in).
+	if !s.tempChannels[idx] || idx >= len(s.channels) {
+		return false
+	}
+	s.channels = append(s.channels[:idx], s.channels[idx+1:]...)
+	s.lastBreakAt = append(s.lastBreakAt[:idx], s.lastBreakAt[idx+1:]...)
+	// Rebuild the tempChannels set with shifted indices.
+	rebuilt := make(map[int]bool, len(s.tempChannels))
+	for i := range s.tempChannels {
+		switch {
+		case i == idx:
+			// dropped
+		case i > idx:
+			rebuilt[i-1] = true
+		default:
+			rebuilt[i] = true
+		}
+	}
+	s.tempChannels = rebuilt
+	if s.cursor > idx {
+		s.cursor--
+	}
+	if s.cursor >= len(s.channels) {
+		s.cursor = 0
+	}
+	if s.dwellIndex == idx {
+		s.dwellIndex = -1
+		s.state = StateScanning
+	} else if s.dwellIndex > idx {
+		s.dwellIndex--
+	}
+	if s.forcedDwellIndex == idx {
+		s.forcedDwellIndex = -1
+	} else if s.forcedDwellIndex > idx {
+		s.forcedDwellIndex--
+	}
 	return true
 }
 
@@ -396,8 +516,8 @@ func (s *Scanner) DwellOn(idx int) bool {
 func (s *Scanner) Snapshot() Status {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	channels := make([]ChannelStatus, len(s.opts.Channels))
-	for i, ch := range s.opts.Channels {
+	channels := make([]ChannelStatus, len(s.channels))
+	for i, ch := range s.channels {
 		channels[i] = ChannelStatus{
 			Index:       i,
 			Label:       ch.Label,

--- a/internal/scanner/conventional/scanner_test.go
+++ b/internal/scanner/conventional/scanner_test.go
@@ -252,9 +252,127 @@ func TestConvScannerDwellOn(t *testing.T) {
 	if s.DwellOn(99) {
 		t.Errorf("DwellOn(99) should fail")
 	}
-	// Next call to nextChannel must return 2.
-	if idx := s.nextChannel(); idx != 2 {
-		t.Errorf("nextChannel after DwellOn(2) = %d, want 2", idx)
+	// Next call to pickNextChannel must return 2.
+	idx, _, ok := s.pickNextChannel()
+	if !ok {
+		t.Fatal("pickNextChannel returned no channel")
+	}
+	if idx != 2 {
+		t.Errorf("pickNextChannel after DwellOn(2) = %d, want 2", idx)
+	}
+}
+
+func TestAddTemporaryChannelGrowsAndForcesDwell(t *testing.T) {
+	s, err := New(Options{
+		Engine: &fakeEngine{}, Tuner: &fakeTuner{}, IQ: &fakeIQ{},
+		Recorder: fakeRecorder{}, DeviceSerial: "x",
+		Channels: []Channel{{Label: "static", FrequencyHz: 100}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	idx := s.AddTemporaryChannel(Channel{Label: "VFO", FrequencyHz: 155895000})
+	if idx != 1 {
+		t.Errorf("new idx = %d, want 1", idx)
+	}
+	snap := s.Snapshot()
+	if len(snap.Channels) != 2 {
+		t.Fatalf("Snapshot channels = %d, want 2", len(snap.Channels))
+	}
+	if snap.Channels[1].FrequencyHz != 155895000 {
+		t.Errorf("VFO freq = %d, want 155895000", snap.Channels[1].FrequencyHz)
+	}
+	// AddTemporaryChannel must force the next pick to land on the new
+	// channel (manual tune = "listen now" intent).
+	got, _, ok := s.pickNextChannel()
+	if !ok || got != 1 {
+		t.Errorf("first pick after AddTemporaryChannel = %d ok=%t, want 1 ok=true", got, ok)
+	}
+}
+
+func TestAddTemporaryChannelDefaultsAppliedOncePerChannel(t *testing.T) {
+	s, err := New(Options{
+		Engine: &fakeEngine{}, Tuner: &fakeTuner{}, IQ: &fakeIQ{},
+		Recorder: fakeRecorder{}, DeviceSerial: "x",
+		Channels: []Channel{{Label: "static", FrequencyHz: 100}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Zero-valued knobs should default the same way config-seeded
+	// channels do.
+	s.AddTemporaryChannel(Channel{Label: "vfo", FrequencyHz: 1})
+	snap := s.Snapshot()
+	got := snap.Channels[1]
+	if got.Mode != "fm" {
+		t.Errorf("default mode = %q, want fm", got.Mode)
+	}
+}
+
+func TestRemoveTemporaryChannelRevokesAndReindexes(t *testing.T) {
+	s, err := New(Options{
+		Engine: &fakeEngine{}, Tuner: &fakeTuner{}, IQ: &fakeIQ{},
+		Recorder: fakeRecorder{}, DeviceSerial: "x",
+		Channels: []Channel{{Label: "static", FrequencyHz: 100}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	idx := s.AddTemporaryChannel(Channel{Label: "VFO", FrequencyHz: 1})
+	if !s.RemoveTemporaryChannel(idx) {
+		t.Fatal("RemoveTemporaryChannel(1) returned false")
+	}
+	snap := s.Snapshot()
+	if len(snap.Channels) != 1 {
+		t.Errorf("after remove channels = %d, want 1", len(snap.Channels))
+	}
+	// Removing again returns false (not a temp channel anymore).
+	if s.RemoveTemporaryChannel(idx) {
+		t.Error("second remove should return false")
+	}
+	// Removing a static (config-seeded) channel returns false.
+	if s.RemoveTemporaryChannel(0) {
+		t.Error("removing static channel should return false")
+	}
+}
+
+func TestRunWithEmptyChannelsIdlesUntilAdd(t *testing.T) {
+	tnr := &fakeTuner{}
+	s, err := New(Options{
+		Engine: &fakeEngine{}, Tuner: tnr, IQ: &fakeIQ{tuner: tnr},
+		Recorder: fakeRecorder{}, DeviceSerial: "x",
+		// No Channels — operator only ever drives this via
+		// AddTemporaryChannel from the TUI / API.
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go func() {
+		_ = s.Run(ctx)
+		close(done)
+	}()
+	// Idle for a tick; no tune should happen with zero channels.
+	time.Sleep(60 * time.Millisecond)
+	if len(tnr.tuned()) != 0 {
+		t.Errorf("empty-channels scanner tuned anyway: %v", tnr.tuned())
+	}
+	cancel()
+	<-done
+}
+
+func TestConvScannerAcceptsEmptyChannels(t *testing.T) {
+	// Distinct from TestConvScannerRejectsBadConfig — empty Channels
+	// used to fail validation but now must succeed to support manual
+	// VFO tune via AddTemporaryChannel.
+	_, err := New(Options{
+		Engine: &fakeEngine{}, Tuner: &fakeTuner{}, IQ: &fakeIQ{},
+		Recorder: fakeRecorder{}, DeviceSerial: "x",
+	})
+	if err != nil {
+		t.Fatalf("New with empty channels: %v", err)
 	}
 }
 
@@ -265,7 +383,6 @@ func TestConvScannerRejectsBadConfig(t *testing.T) {
 	}{
 		{"no engine", Options{Tuner: &fakeTuner{}, IQ: &fakeIQ{}, Recorder: fakeRecorder{}, DeviceSerial: "x", Channels: []Channel{{FrequencyHz: 1}}}},
 		{"no tuner", Options{Engine: &fakeEngine{}, IQ: &fakeIQ{}, Recorder: fakeRecorder{}, DeviceSerial: "x", Channels: []Channel{{FrequencyHz: 1}}}},
-		{"no channels", Options{Engine: &fakeEngine{}, Tuner: &fakeTuner{}, IQ: &fakeIQ{}, Recorder: fakeRecorder{}, DeviceSerial: "x"}},
 		{"no device serial", Options{Engine: &fakeEngine{}, Tuner: &fakeTuner{}, IQ: &fakeIQ{}, Recorder: fakeRecorder{}, Channels: []Channel{{FrequencyHz: 1}}}},
 	}
 	for _, tc := range cases {

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -500,6 +500,18 @@ func (m *Model) dispatchWrite(r state.WriteRequest) tea.Cmd {
 			cmdSetAudio(m.cli, r.Audio.Volume, r.Audio.Muted, r.Audio.Recording, r.Label),
 			cmdPollAudio(m.cli),
 		)
+	case state.WriteKindScannerManualTune:
+		if r.ScannerManualTune == nil {
+			return nil
+		}
+		return tea.Batch(
+			cmdScannerManualTune(m.cli,
+				r.ScannerManualTune.FrequencyHz,
+				r.ScannerManualTune.Label,
+				r.ScannerManualTune.Mode,
+				r.Label),
+			cmdPollScanner(m.cli),
+		)
 	}
 	return nil
 }

--- a/internal/tui/client/write.go
+++ b/internal/tui/client/write.go
@@ -162,6 +162,32 @@ func (c *Client) SetAudio(ctx context.Context, volume *float32, muted *bool, rec
 	return out, nil
 }
 
+// ScannerManualTune calls POST /api/v1/scanner/manual_tune. The
+// optional label / mode / squelch_dbfs default on the server side
+// when empty; only frequency_hz is required.
+func (c *Client) ScannerManualTune(ctx context.Context, freqHz uint32, label, mode string) (int, error) {
+	body := map[string]any{"frequency_hz": freqHz}
+	if label != "" {
+		body["label"] = label
+	}
+	if mode != "" {
+		body["mode"] = mode
+	}
+	var out struct {
+		OK    bool `json:"ok"`
+		Index int  `json:"index"`
+	}
+	if err := c.do(ctx, http.MethodPost, "/api/v1/scanner/manual_tune", body, &out); err != nil {
+		return 0, err
+	}
+	return out.Index, nil
+}
+
+// ScannerClearManualTune calls DELETE /api/v1/scanner/manual_tune/{index}.
+func (c *Client) ScannerClearManualTune(ctx context.Context, index int) error {
+	return c.do(ctx, http.MethodDelete, fmt.Sprintf("/api/v1/scanner/manual_tune/%d", index), nil, nil)
+}
+
 // ResetToneDevice calls POST /api/v1/devices/{serial}/tone-reset.
 func (c *Client) ResetToneDevice(ctx context.Context, serial string) error {
 	if serial == "" {

--- a/internal/tui/cmds.go
+++ b/internal/tui/cmds.go
@@ -144,6 +144,14 @@ func cmdSetAudio(cli *client.Client, volume *float32, muted *bool, recording *bo
 	}
 }
 
+// cmdScannerManualTune adds a runtime VFO channel and forces dwell.
+func cmdScannerManualTune(cli *client.Client, freqHz uint32, label, mode, toastLabel string) tea.Cmd {
+	return func() tea.Msg {
+		_, err := cli.ScannerManualTune(context.Background(), freqHz, label, mode)
+		return writeResultMsg{Label: toastLabel, Err: err}
+	}
+}
+
 func cmdPollHistory(cli *client.Client, f client.HistoryFilter) tea.Cmd {
 	return func() tea.Msg {
 		rows, err := cli.History(context.Background(), f)

--- a/internal/tui/panels/scanner.go
+++ b/internal/tui/panels/scanner.go
@@ -2,10 +2,12 @@ package panels
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/charmbracelet/bubbles/key"
+	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
@@ -28,11 +30,24 @@ type ScannerPanel struct {
 	// We treat both sections as one virtual list keyed by
 	// (section, index); cursorAt yields the selected slot.
 	cursor int
+
+	// manualInput is the textinput overlay for the 'f' (frequency)
+	// keybind: operator types a frequency in MHz and Enter dispatches
+	// a manual_tune mutation. Esc aborts. inputErr surfaces a parse
+	// error inline so the operator can correct without dispatching.
+	manualInput  textinput.Model
+	editingFreq  bool
+	inputErr     string
 }
 
 // NewScanner returns a new read+write scanner cockpit.
 func NewScanner() *ScannerPanel {
-	return &ScannerPanel{}
+	in := textinput.New()
+	in.Placeholder = "freq MHz (e.g. 155.895)"
+	in.CharLimit = 16
+	in.Width = 24
+	in.Prompt = "freq> "
+	return &ScannerPanel{manualInput: in}
 }
 
 func (ScannerPanel) Title() string { return "Scanner" }
@@ -48,6 +63,8 @@ var (
 	scanVolDnKey  = key.NewBinding(key.WithKeys("-", "_"), key.WithHelp("-", "volume down"))
 	scanMuteKey   = key.NewBinding(key.WithKeys("M"), key.WithHelp("M", "mute toggle"))
 	scanRecKey    = key.NewBinding(key.WithKeys("R"), key.WithHelp("R", "record toggle"))
+	scanManualKey = key.NewBinding(key.WithKeys("f"), key.WithHelp("f", "manual tune"))
+	scanEscKey    = key.NewBinding(key.WithKeys("esc"), key.WithHelp("esc", "cancel"))
 )
 
 func (ScannerPanel) Keys() []key.Binding {
@@ -55,6 +72,7 @@ func (ScannerPanel) Keys() []key.Binding {
 		scanHoldKey, scanRetuneKey, scanDwellKey, scanModeKey,
 		scanUpKey, scanDownKey,
 		scanVolUpKey, scanVolDnKey, scanMuteKey, scanRecKey,
+		scanManualKey,
 	}
 }
 
@@ -92,8 +110,49 @@ func (p *ScannerPanel) Update(msg tea.Msg, s *state.SharedState) (Panel, tea.Cmd
 	if !ok {
 		return p, nil
 	}
+	// While the manual-tune textinput is open, all keys go to the
+	// input field. Enter commits, Esc aborts, everything else is a
+	// character.
+	if p.editingFreq {
+		switch {
+		case key.Matches(km, scanEscKey):
+			p.editingFreq = false
+			p.inputErr = ""
+			p.manualInput.SetValue("")
+			p.manualInput.Blur()
+			return p, nil
+		case km.String() == "enter":
+			hz, err := parseFreqMHz(p.manualInput.Value())
+			if err != nil {
+				p.inputErr = err.Error()
+				return p, nil
+			}
+			p.editingFreq = false
+			p.inputErr = ""
+			p.manualInput.SetValue("")
+			p.manualInput.Blur()
+			req := state.WriteRequest{
+				Label: fmt.Sprintf("manual tune %.4f MHz", float64(hz)/1e6),
+				Kind:  state.WriteKindScannerManualTune,
+				ScannerManualTune: &state.ScannerManualTuneReq{
+					FrequencyHz: hz,
+					Mode:        "fm",
+				},
+			}
+			return p, Emit(req)
+		}
+		var cmd tea.Cmd
+		p.manualInput, cmd = p.manualInput.Update(msg)
+		return p, cmd
+	}
 	section, idx := p.resolveCursor(s)
 	switch {
+	case key.Matches(km, scanManualKey):
+		p.editingFreq = true
+		p.inputErr = ""
+		p.manualInput.SetValue("")
+		p.manualInput.Focus()
+		return p, textinput.Blink
 	case key.Matches(km, scanUpKey):
 		if p.cursor > 0 {
 			p.cursor--
@@ -226,13 +285,50 @@ func (p *ScannerPanel) View(width, height int, focused bool, s *state.SharedStat
 	if width < 30 || height < 6 {
 		return panelFrame("Scanner", width, height, focused, "")
 	}
-	body := strings.Join([]string{
+	parts := []string{
 		p.renderSystems(width, s),
 		p.renderConventional(width, s),
 		p.renderTGSummary(width, s),
 		p.renderAudio(width, s),
-	}, "\n")
+	}
+	if mt := p.renderManualTune(width); mt != "" {
+		parts = append(parts, mt)
+	}
+	body := strings.Join(parts, "\n")
 	return panelFrame("Scanner", width, height, focused, body)
+}
+
+// parseFreqMHz accepts a frequency in MHz (e.g. "155.895" or
+// "851.5") and returns the Hz value. Empty / un-parseable / out
+// of the practical RTL-SDR tuning range surface as an error the
+// caller renders inline next to the textinput.
+func parseFreqMHz(s string) (uint32, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, fmt.Errorf("enter a frequency")
+	}
+	mhz, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return 0, fmt.Errorf("not a number")
+	}
+	if mhz < 25 || mhz > 1300 {
+		return 0, fmt.Errorf("outside 25 – 1300 MHz")
+	}
+	return uint32(mhz*1e6 + 0.5), nil
+}
+
+func (p *ScannerPanel) renderManualTune(width int) string {
+	if !p.editingFreq && p.inputErr == "" {
+		return ""
+	}
+	header := dashHeader.Render("Manual tune")
+	line := "  " + p.manualInput.View()
+	if p.inputErr != "" {
+		line += "  " + dashErr.Render("("+p.inputErr+")")
+	} else {
+		line += "  " + dashDim.Render("(Enter to tune, Esc to cancel)")
+	}
+	return "\n" + header + "\n" + line
 }
 
 func (p *ScannerPanel) renderAudio(width int, s *state.SharedState) string {

--- a/internal/tui/state/state.go
+++ b/internal/tui/state/state.go
@@ -120,10 +120,11 @@ type WriteRequest struct {
 	UpdateTalkgroup *UpdateTalkgroupReq
 	SweepRetention  *SweepRetentionReq
 	ResetTone       *ResetToneReq
-	ScannerMode     *ScannerModeReq
-	ScannerHunt     *ScannerHuntReq
-	ScannerConv     *ScannerConvReq
-	Audio           *AudioReq
+	ScannerMode       *ScannerModeReq
+	ScannerHunt       *ScannerHuntReq
+	ScannerConv       *ScannerConvReq
+	ScannerManualTune *ScannerManualTuneReq
+	Audio             *AudioReq
 }
 
 // WriteKind discriminates a WriteRequest's payload.
@@ -143,7 +144,15 @@ const (
 	WriteKindScannerConvResume
 	WriteKindScannerConvDwell
 	WriteKindAudio
+	WriteKindScannerManualTune
 )
+
+// ScannerManualTuneReq adds a temp VFO channel and forces dwell.
+type ScannerManualTuneReq struct {
+	FrequencyHz uint32
+	Label       string
+	Mode        string
+}
 
 // AudioReq sets one or more knobs on the audio cockpit. Nil fields
 // are left unchanged.


### PR DESCRIPTION
## Summary

Adds the "punch in a frequency and listen now" flow that traditional police scanners expose on a FREQ / MAN / TUNE key. Workstream C of the audio plan. Builds on PR #159 (live audio playback) and PR #160 (CI fix).

**Note:** depends on the CI fix in PR #160. The branch is currently based off `claude/ci-libasound2-dev` so CI passes on its own; rebase onto `main` once #160 merges and the `.github/workflows/ci.yml` change drops cleanly into history.

## What lands

### `internal/scanner/conventional` — core

- `conventional.Scanner` now accepts an **empty channel list** at `New()`. `Run()` idles in 100ms ticks until `AddTemporaryChannel` populates one, so a daemon configured purely for manual tune keeps the Voice SDR allocated without burning CPU.
- New `AddTemporaryChannel(ch Channel) int` and `RemoveTemporaryChannel(idx int) bool`:
  - Add forces dwell on the new index (manual tune == "listen now"), un-holds the scanner if held, and applies the same per-channel defaults as the config-seeded path.
  - Remove tracks temp-vs-static via an internal set so static channels can't be removed at runtime; re-indexes `cursor` / `dwellIndex` / `forcedDwellIndex` / `tempChannels` correctly on removal.

### `internal/api` — REST surface

- `POST /api/v1/scanner/manual_tune` with body `{frequency_hz, label?, mode?, squelch_dbfs?, hangtime_ms?}`. Validates the frequency is inside the 25 MHz – 1.3 GHz practical RTL-SDR tuning range, dispatches to `ManualTune` on the cockpit, returns the new index.
- `DELETE /api/v1/scanner/manual_tune/{index}` revokes a temp channel; 404 if the index isn't a temp.
- Both routes are mutation-gated like every other write.

### `internal/tui` — Scanner panel

- New `f` keybind opens a `bubbles/textinput` overlay (same component used by the Talkgroups filter and Events filter). Operator types a frequency in MHz, Enter dispatches `WriteKindScannerManualTune`, Esc cancels. Parse / range errors render inline next to the input.

### Daemon

- New `scanner.manual_tune_enabled: false` config flag opts in to constructing the conventional scanner even with no static channels. The scanner steals one Voice SDR from the trunking pool, so operators with only one Voice SDR need to opt in explicitly (the comment in `config.example.yaml` calls this out).
- `scannerCockpit.ManualTune` / `ClearManualTune` adapt `api.ManualTuneRequest` into the `conventional.Channel` shape and delegate to the new Scanner methods.

## Tests

- 4 new conv-scanner tests: `AddTemporaryChannel` grows + forces dwell, defaults applied per channel, `RemoveTemporaryChannel` revokes + re-indexes + rejects static channels, `Run` with empty channels idles instead of tuning.
- 5 new API handler tests: manual_tune OK / missing freq / out-of-range / 503 when conv not configured / 403 when mutations disabled, plus DELETE happy path + 404.
- All pre-existing tests still pass. `go vet ./...` clean.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -short ./...` all green
- [ ] Manual smoke: with `scanner.manual_tune_enabled: true` + one spare Voice SDR, launch `gophertrunk run` + `gophertrunk tui --write`, hit `f` on the Scanner panel, type `155.895`, Enter → SDR retunes, audio plays through host speakers (Workstream A) when squelch breaks
- [ ] Manual REST: `curl -X POST http://127.0.0.1:8080/api/v1/scanner/manual_tune -d '{"frequency_hz":155895000}'` returns `{"ok":true,"index":...}` and the next `GET /api/v1/scanner` shows the new entry
- [ ] DELETE: `curl -X DELETE http://127.0.0.1:8080/api/v1/scanner/manual_tune/0` revokes the temp entry; the conventional scanner returns to scanning the static channel list

https://claude.ai/code/session_01FYBcR9CAiGws74GiqffTkd

---
_Generated by [Claude Code](https://claude.ai/code/session_01FYBcR9CAiGws74GiqffTkd)_