### PR TITLE
internal/scanner/conventional: runtime channel lockout

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,18 @@ to its own package and lands independently.
 
 ### Recently shipped
 
+- **Conventional channel runtime lockout.** Press `L` on the TUI's
+  Scanner panel (or `POST /api/v1/scanner/conventional/{idx}/lockout`)
+  to skip a conventional FM channel during scan, matching the
+  muscle memory of a Uniden / Whistler lockout button. Skipped
+  channels show a `✗` marker in the channel list and are omitted
+  from `pickNextChannel` rotation; pressing `L` again (or POSTing
+  `unlockout`) restores them. If the locked-out channel is
+  currently dwelling, the synthetic call ends immediately
+  (`EndReasonLockout`) so the operator's intent takes effect
+  within one IQ chunk. Lockouts are runtime-only — they don't
+  persist across daemon restarts, since config is the right
+  place to permanently exclude a channel.
 - **macOS RTL-SDR serial / manufacturer / product strings.** The
   pure-Go USB enumerator's Darwin backend
   (`internal/sdr/rtlsdr/usb/usb_darwin.go`) now reads the IORegistry

--- a/cmd/gophertrunk/scanner_cockpit.go
+++ b/cmd/gophertrunk/scanner_cockpit.go
@@ -61,6 +61,7 @@ func (c scannerCockpit) Status() api.ScannerStatus {
 				FrequencyHz: ch.FrequencyHz,
 				Mode:        ch.Mode,
 				Active:      ch.Active,
+				LockedOut:   ch.LockedOut,
 				LastBreakAt: ch.LastBreakAt,
 			})
 		}
@@ -137,6 +138,18 @@ func (c scannerCockpit) DwellConventional(index int) bool {
 		return false
 	}
 	return c.conv.DwellOn(index)
+}
+func (c scannerCockpit) LockoutConventional(index int) bool {
+	if c.conv == nil {
+		return false
+	}
+	return c.conv.LockoutChannel(index)
+}
+func (c scannerCockpit) UnlockoutConventional(index int) bool {
+	if c.conv == nil {
+		return false
+	}
+	return c.conv.UnlockoutChannel(index)
 }
 
 // ManualTune adds a VFO-style temporary channel and forces dwell on

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -80,7 +80,7 @@ gophertrunk tui -server https://radio.example.com -insecure
 | Tone alerts | (table navigation only) |
 | Metrics | (table navigation only) |
 | Devices | (table navigation only) |
-| Scanner | `j` / `k` move row, `h` hold/resume highlighted row, `r` force re-hunt (Systems section, confirms), `Enter` dwell on highlighted conv channel, `m` cycle scan_mode, `+` / `-` volume up/down (5% step), `M` mute toggle, `R` recording toggle, `f` manual tune (type frequency in MHz, Enter to listen, Esc to cancel) |
+| Scanner | `j` / `k` move row, `h` hold/resume highlighted row, `r` force re-hunt (Systems section, confirms), `Enter` dwell on highlighted conv channel, `L` lockout / unlockout highlighted conv channel (skipped from scan rotation, runtime-only), `m` cycle scan_mode, `+` / `-` volume up/down (5% step), `M` mute toggle, `R` recording toggle, `f` manual tune (type frequency in MHz, Enter to listen, Esc to cancel) |
 
 ## Polling cadences
 

--- a/internal/api/handlers_scanner.go
+++ b/internal/api/handlers_scanner.go
@@ -127,6 +127,54 @@ func (s *Server) handleConvDwell(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "index": idx})
 }
 
+// handleConvLockout flips the per-channel lockout flag on. Locked-
+// out channels are skipped by the scanner's pickNextChannel until
+// the operator unlocks them via handleConvUnlockout.
+//
+//	POST /api/v1/scanner/conventional/{index}/lockout
+//
+// Responses:
+//
+//	200 {"ok":true,"index":N,"locked_out":true}
+//	404 if the channel index is out of range
+//	503 if the scanner cockpit isn't wired
+func (s *Server) handleConvLockout(w http.ResponseWriter, r *http.Request) {
+	s.convLockoutOp(w, r, s.scanner.LockoutConventional, true)
+}
+
+// handleConvUnlockout flips the per-channel lockout flag off. Same
+// shape as handleConvLockout.
+//
+//	POST /api/v1/scanner/conventional/{index}/unlockout
+func (s *Server) handleConvUnlockout(w http.ResponseWriter, r *http.Request) {
+	s.convLockoutOp(w, r, s.scanner.UnlockoutConventional, false)
+}
+
+// convLockoutOp is the shared mechanics for both lockout sides.
+// Factors out the index parsing + 404/503 logic so the two
+// handlers stay one-liners.
+func (s *Server) convLockoutOp(w http.ResponseWriter, r *http.Request, op func(int) bool, newState bool) {
+	if s.scanner == nil {
+		writeError(w, http.StatusServiceUnavailable, "scanner not wired")
+		return
+	}
+	idxStr := r.PathValue("index")
+	idx, err := strconv.Atoi(idxStr)
+	if err != nil || idx < 0 {
+		writeError(w, http.StatusBadRequest, "invalid index")
+		return
+	}
+	if !op(idx) {
+		writeError(w, http.StatusNotFound, "channel index out of range")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"ok":         true,
+		"index":      idx,
+		"locked_out": newState,
+	})
+}
+
 // handleScannerManualTune adds a VFO-style temporary channel to the
 // conventional scanner and forces dwell on it. Mirrors the muscle
 // memory of a traditional scanner's "FREQ" / "MAN" / "TUNE" key.

--- a/internal/api/handlers_scanner_test.go
+++ b/internal/api/handlers_scanner_test.go
@@ -109,6 +109,24 @@ func (f *fakeCockpit) DwellConventional(i int) bool {
 	f.mu.Unlock()
 	return true
 }
+func (f *fakeCockpit) LockoutConventional(i int) bool {
+	if f.dwellRange == 0 {
+		return false
+	}
+	if f.dwellRange > 0 && (i < 0 || i >= f.dwellRange) {
+		return false
+	}
+	return true
+}
+func (f *fakeCockpit) UnlockoutConventional(i int) bool {
+	if f.dwellRange == 0 {
+		return false
+	}
+	if f.dwellRange > 0 && (i < 0 || i >= f.dwellRange) {
+		return false
+	}
+	return true
+}
 func (f *fakeCockpit) ManualTune(req ManualTuneRequest) (int, bool) {
 	if f.convNotConfigured {
 		return 0, false

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -114,6 +114,13 @@ type ScannerCockpit interface {
 	HoldConventional() bool
 	ResumeConventional() bool
 	DwellConventional(index int) bool
+	// LockoutConventional / UnlockoutConventional toggle the per-
+	// channel lockout flag the scan loop respects. Locked-out
+	// channels are skipped by pickNextChannel. Returns false when
+	// the conventional scanner isn't configured or the index is
+	// out of range.
+	LockoutConventional(index int) bool
+	UnlockoutConventional(index int) bool
 	// ManualTune appends a VFO-style temporary channel to the
 	// conventional scanner and forces dwell on it. Returns the new
 	// index + ok=true on success; ok=false when the conventional
@@ -179,6 +186,7 @@ type ConvChannelStatusDTO struct {
 	FrequencyHz uint32    `json:"frequency_hz"`
 	Mode        string    `json:"mode"`
 	Active      bool      `json:"active"`
+	LockedOut   bool      `json:"locked_out,omitempty"`
 	LastBreakAt time.Time `json:"last_break_at,omitempty"`
 }
 
@@ -416,6 +424,8 @@ func (s *Server) routes() *http.ServeMux {
 	mux.HandleFunc("POST /api/v1/scanner/conventional/hold", s.gate(s.handleConvHold))
 	mux.HandleFunc("POST /api/v1/scanner/conventional/resume", s.gate(s.handleConvResume))
 	mux.HandleFunc("POST /api/v1/scanner/conventional/{index}/dwell", s.gate(s.handleConvDwell))
+	mux.HandleFunc("POST /api/v1/scanner/conventional/{index}/lockout", s.gate(s.handleConvLockout))
+	mux.HandleFunc("POST /api/v1/scanner/conventional/{index}/unlockout", s.gate(s.handleConvUnlockout))
 	mux.HandleFunc("POST /api/v1/scanner/manual_tune", s.gate(s.handleScannerManualTune))
 	mux.HandleFunc("DELETE /api/v1/scanner/manual_tune/{index}", s.gate(s.handleScannerClearManualTune))
 

--- a/internal/scanner/conventional/scanner.go
+++ b/internal/scanner/conventional/scanner.go
@@ -130,6 +130,10 @@ type ChannelStatus struct {
 	FrequencyHz uint32    `json:"frequency_hz"`
 	Mode        string    `json:"mode"`
 	Active      bool      `json:"active"`
+	// LockedOut reports whether the channel is excluded from the
+	// scan cycle by operator action. Runtime-only — the field is
+	// not persisted across daemon restarts.
+	LockedOut   bool      `json:"locked_out,omitempty"`
 	LastBreakAt time.Time `json:"last_break_at,omitempty"`
 }
 
@@ -168,6 +172,12 @@ type Scanner struct {
 	// VFO-style entry rather than a config-seeded one. Bool value
 	// is irrelevant — set membership only.
 	tempChannels map[int]bool
+	// lockedOut tracks indices the operator has skipped at
+	// runtime. The scan loop omits these from pickNextChannel
+	// rotation. Cleared by UnlockoutChannel; persists across
+	// scanner state changes (hold / resume) but not across daemon
+	// restarts.
+	lockedOut map[int]bool
 }
 
 // New constructs a Scanner. Channels may be empty when the operator
@@ -244,6 +254,7 @@ func New(opts Options) (*Scanner, error) {
 		forcedDwellIndex: -1,
 		lastBreakAt:      make([]time.Time, len(channels)),
 		tempChannels:     make(map[int]bool),
+		lockedOut:        make(map[int]bool),
 	}, nil
 }
 
@@ -502,9 +513,16 @@ func (s *Scanner) endDwell(idx int, reason trunking.EndReason) {
 }
 
 // pickNextChannel returns the index + a copy of the next channel to
-// tune, respecting any forced-dwell override from DwellOn. The
-// returned ok=false signals an empty channel list — the Run loop
-// idles until AddTemporaryChannel populates one.
+// tune, respecting any forced-dwell override from DwellOn and
+// skipping locked-out channels. The returned ok=false signals
+// either an empty channel list OR every channel locked out — the
+// Run loop idles in both cases until AddTemporaryChannel populates
+// one or the operator unlocks a row.
+//
+// Forced-dwell beats lockout: pressing the conv-dwell key on a
+// locked-out row deliberately overrides the lockout for one cycle.
+// The operator's explicit intent wins; the lockout flag stays
+// set so the scanner skips it again on the next pass.
 func (s *Scanner) pickNextChannel() (int, Channel, bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -521,9 +539,18 @@ func (s *Scanner) pickNextChannel() (int, Channel, bool) {
 	if s.cursor >= n {
 		s.cursor = 0
 	}
-	idx := s.cursor
-	s.cursor = (s.cursor + 1) % n
-	return idx, s.channels[idx], true
+	// Walk at most n steps looking for a non-locked-out channel.
+	// One full lap with no candidates means every channel is
+	// locked out — return ok=false so the Run loop idles.
+	for attempts := 0; attempts < n; attempts++ {
+		idx := s.cursor
+		s.cursor = (s.cursor + 1) % n
+		if s.lockedOut[idx] {
+			continue
+		}
+		return idx, s.channels[idx], true
+	}
+	return 0, Channel{}, false
 }
 
 // detectorFor returns the CTCSS detector for the given channel
@@ -588,6 +615,45 @@ func (s *Scanner) DwellOn(idx int) bool {
 		return false
 	}
 	s.forcedDwellIndex = idx
+	return true
+}
+
+// LockoutChannel marks the channel index as skipped during scan.
+// The scan loop's pickNextChannel respects this — a locked-out
+// channel is omitted from rotation. If the locked-out channel is
+// currently dwelling, the synthetic call ends immediately so the
+// operator's intent ("don't listen to this") takes effect within
+// one IQ chunk rather than waiting for hangtime.
+//
+// Returns false when idx is out of range. Locking out an already-
+// locked channel is a no-op (still true).
+func (s *Scanner) LockoutChannel(idx int) bool {
+	s.mu.Lock()
+	if idx < 0 || idx >= len(s.channels) {
+		s.mu.Unlock()
+		return false
+	}
+	s.lockedOut[idx] = true
+	dwelling := s.dwellIndex == idx
+	s.mu.Unlock()
+	if dwelling {
+		s.opts.Engine.EndSyntheticCall(s.opts.DeviceSerial, trunking.EndReasonLockout)
+	}
+	return true
+}
+
+// UnlockoutChannel undoes LockoutChannel. The scanner picks the
+// channel back up on the next pass.
+//
+// Returns false when idx is out of range. Unlocking an already-
+// unlocked channel is a no-op (still true).
+func (s *Scanner) UnlockoutChannel(idx int) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if idx < 0 || idx >= len(s.channels) {
+		return false
+	}
+	delete(s.lockedOut, idx)
 	return true
 }
 
@@ -664,19 +730,11 @@ func (s *Scanner) RemoveTemporaryChannel(idx int) bool {
 	s.channels = append(s.channels[:idx], s.channels[idx+1:]...)
 	s.detectors = append(s.detectors[:idx], s.detectors[idx+1:]...)
 	s.lastBreakAt = append(s.lastBreakAt[:idx], s.lastBreakAt[idx+1:]...)
-	// Rebuild the tempChannels set with shifted indices.
-	rebuilt := make(map[int]bool, len(s.tempChannels))
-	for i := range s.tempChannels {
-		switch {
-		case i == idx:
-			// dropped
-		case i > idx:
-			rebuilt[i-1] = true
-		default:
-			rebuilt[i] = true
-		}
-	}
-	s.tempChannels = rebuilt
+	// Rebuild the tempChannels + lockedOut sets with shifted indices.
+	// Both maps share the same shift rule: drop the removed entry,
+	// decrement anything above it.
+	s.tempChannels = shiftIndexSet(s.tempChannels, idx)
+	s.lockedOut = shiftIndexSet(s.lockedOut, idx)
 	if s.cursor > idx {
 		s.cursor--
 	}
@@ -710,6 +768,7 @@ func (s *Scanner) Snapshot() Status {
 			FrequencyHz: ch.FrequencyHz,
 			Mode:        ch.Mode,
 			Active:      i == s.dwellIndex,
+			LockedOut:   s.lockedOut[i],
 			LastBreakAt: s.lastBreakAt[i],
 		}
 	}
@@ -719,4 +778,23 @@ func (s *Scanner) Snapshot() Status {
 		CursorIndex:  s.cursor,
 		DeviceSerial: s.opts.DeviceSerial,
 	}
+}
+
+// shiftIndexSet rebuilds a set keyed by channel index after the
+// removal of dropIdx. Entries above dropIdx shift down by one;
+// the entry at dropIdx is dropped. Used to keep tempChannels and
+// lockedOut consistent with the post-removal channels slice.
+func shiftIndexSet(in map[int]bool, dropIdx int) map[int]bool {
+	out := make(map[int]bool, len(in))
+	for i := range in {
+		switch {
+		case i == dropIdx:
+			// dropped
+		case i > dropIdx:
+			out[i-1] = true
+		default:
+			out[i] = true
+		}
+	}
+	return out
 }

--- a/internal/scanner/conventional/scanner_test.go
+++ b/internal/scanner/conventional/scanner_test.go
@@ -126,6 +126,129 @@ func loudChunk(n int) []complex64 {
 	return out
 }
 
+// TestConvScannerLockoutSkipsChannel confirms LockoutChannel(idx)
+// removes the channel from the scan rotation and Snapshot reports
+// LockedOut=true. The scanner should tune only the two non-locked
+// channels during the test window.
+func TestConvScannerLockoutSkipsChannel(t *testing.T) {
+	tuner := &fakeTuner{}
+	iq := &fakeIQ{chunks: map[uint32][][]complex64{}, tuner: tuner}
+	eng := &fakeEngine{}
+	s, err := New(Options{
+		Tuner: tuner, IQ: iq, Engine: eng, Recorder: fakeRecorder{},
+		DeviceSerial: "CONV-LO",
+		SystemName:   "test",
+		Channels: []Channel{
+			{Label: "A", FrequencyHz: 100_000_000, SquelchDbFS: -10},
+			{Label: "B-LOCKED", FrequencyHz: 200_000_000, SquelchDbFS: -10},
+			{Label: "C", FrequencyHz: 300_000_000, SquelchDbFS: -10},
+		},
+		MinDwellPerChannel: 30 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !s.LockoutChannel(1) {
+		t.Fatal("LockoutChannel returned false on a valid index")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	_ = s.Run(ctx)
+
+	// Snapshot should reflect the lockout.
+	snap := s.Snapshot()
+	if !snap.Channels[1].LockedOut {
+		t.Errorf("Snapshot.Channels[1].LockedOut = false, want true")
+	}
+	if snap.Channels[0].LockedOut || snap.Channels[2].LockedOut {
+		t.Errorf("non-locked channels reported LockedOut=true")
+	}
+
+	// The locked channel's frequency must not appear in the tune list.
+	for _, hz := range tuner.tuned() {
+		if hz == 200_000_000 {
+			t.Errorf("scanner tuned the locked-out channel (200 MHz)")
+		}
+	}
+
+	// Unlock and confirm the flag clears.
+	if !s.UnlockoutChannel(1) {
+		t.Fatal("UnlockoutChannel returned false on a valid index")
+	}
+	if s.Snapshot().Channels[1].LockedOut {
+		t.Error("Snapshot.Channels[1].LockedOut still true after UnlockoutChannel")
+	}
+}
+
+// TestConvScannerLockoutAllIdles confirms the Run loop idles when
+// every channel is locked out (rather than spinning or panicking).
+// pickNextChannel should report ok=false; the loop sleeps for a
+// short tick and re-checks.
+func TestConvScannerLockoutAllIdles(t *testing.T) {
+	tuner := &fakeTuner{}
+	iq := &fakeIQ{chunks: map[uint32][][]complex64{}, tuner: tuner}
+	eng := &fakeEngine{}
+	s, err := New(Options{
+		Tuner: tuner, IQ: iq, Engine: eng, Recorder: fakeRecorder{},
+		DeviceSerial: "CONV-ALL-LO",
+		SystemName:   "test",
+		Channels: []Channel{
+			{Label: "A", FrequencyHz: 100_000_000, SquelchDbFS: -10},
+			{Label: "B", FrequencyHz: 200_000_000, SquelchDbFS: -10},
+		},
+		MinDwellPerChannel: 30 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.LockoutChannel(0)
+	s.LockoutChannel(1)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	_ = s.Run(ctx)
+
+	// With every channel locked out the scanner shouldn't have
+	// tuned anything.
+	if len(tuner.tuned()) != 0 {
+		t.Errorf("scanner tuned despite every channel locked out: %v", tuner.tuned())
+	}
+}
+
+// TestConvScannerLockoutOutOfRangeReturnsFalse pins the
+// out-of-range return contract — the caller (HTTP handler, TUI
+// keybind) uses false to surface a 404 / toast.
+func TestConvScannerLockoutOutOfRangeReturnsFalse(t *testing.T) {
+	tuner := &fakeTuner{}
+	iq := &fakeIQ{chunks: map[uint32][][]complex64{}, tuner: tuner}
+	eng := &fakeEngine{}
+	s, err := New(Options{
+		Tuner: tuner, IQ: iq, Engine: eng, Recorder: fakeRecorder{},
+		DeviceSerial: "CONV-OOR",
+		SystemName:   "test",
+		Channels: []Channel{
+			{Label: "A", FrequencyHz: 100_000_000, SquelchDbFS: -10},
+		},
+		MinDwellPerChannel: 10 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.LockoutChannel(-1) {
+		t.Error("LockoutChannel(-1) should return false")
+	}
+	if s.LockoutChannel(99) {
+		t.Error("LockoutChannel(99) should return false")
+	}
+	if s.UnlockoutChannel(-1) {
+		t.Error("UnlockoutChannel(-1) should return false")
+	}
+	if s.UnlockoutChannel(99) {
+		t.Error("UnlockoutChannel(99) should return false")
+	}
+}
+
 func TestConvScannerHopsThroughEmptyChannels(t *testing.T) {
 	tuner := &fakeTuner{}
 	iq := &fakeIQ{chunks: map[uint32][][]complex64{}, tuner: tuner}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -492,6 +492,16 @@ func (m *Model) dispatchWrite(r state.WriteRequest) tea.Cmd {
 			return nil
 		}
 		return cmdScannerConvDwell(m.cli, r.ScannerConv.Index, r.Label)
+	case state.WriteKindScannerConvLockout:
+		if r.ScannerConv == nil {
+			return nil
+		}
+		return cmdScannerConvLockout(m.cli, r.ScannerConv.Index, r.Label)
+	case state.WriteKindScannerConvUnlockout:
+		if r.ScannerConv == nil {
+			return nil
+		}
+		return cmdScannerConvUnlockout(m.cli, r.ScannerConv.Index, r.Label)
 	case state.WriteKindAudio:
 		if r.Audio == nil {
 			return nil

--- a/internal/tui/client/types.go
+++ b/internal/tui/client/types.go
@@ -170,6 +170,7 @@ type ConvChannelStatusDTO struct {
 	FrequencyHz uint32    `json:"frequency_hz"`
 	Mode        string    `json:"mode"`
 	Active      bool      `json:"active"`
+	LockedOut   bool      `json:"locked_out,omitempty"`
 	LastBreakAt time.Time `json:"last_break_at,omitempty"`
 }
 

--- a/internal/tui/client/write.go
+++ b/internal/tui/client/write.go
@@ -113,6 +113,21 @@ func (c *Client) ScannerConvDwell(ctx context.Context, index int) error {
 		nil, nil)
 }
 
+// ScannerConvLockout / ScannerConvUnlockout toggle the per-channel
+// lockout the scanner respects when picking the next channel to
+// dwell on. The flag is runtime-only; it doesn't persist across
+// daemon restarts.
+func (c *Client) ScannerConvLockout(ctx context.Context, index int) error {
+	return c.do(ctx, http.MethodPost,
+		fmt.Sprintf("/api/v1/scanner/conventional/%d/lockout", index),
+		nil, nil)
+}
+func (c *Client) ScannerConvUnlockout(ctx context.Context, index int) error {
+	return c.do(ctx, http.MethodPost,
+		fmt.Sprintf("/api/v1/scanner/conventional/%d/unlockout", index),
+		nil, nil)
+}
+
 // AudioStatusDTO mirrors api.AudioStatusDTO for the wire layer.
 type AudioStatusDTO struct {
 	BackendEnabled   bool    `json:"backend_enabled"`

--- a/internal/tui/cmds.go
+++ b/internal/tui/cmds.go
@@ -122,6 +122,18 @@ func cmdScannerConvDwell(cli *client.Client, idx int, label string) tea.Cmd {
 		return writeResultMsg{Label: label, Err: err}
 	}
 }
+func cmdScannerConvLockout(cli *client.Client, idx int, label string) tea.Cmd {
+	return func() tea.Msg {
+		err := cli.ScannerConvLockout(context.Background(), idx)
+		return writeResultMsg{Label: label, Err: err}
+	}
+}
+func cmdScannerConvUnlockout(cli *client.Client, idx int, label string) tea.Cmd {
+	return func() tea.Msg {
+		err := cli.ScannerConvUnlockout(context.Background(), idx)
+		return writeResultMsg{Label: label, Err: err}
+	}
+}
 
 // cmdPollAudio fetches the audio cockpit's current state. Used to
 // keep the dashboard volume / mute / record indicator in sync with

--- a/internal/tui/panels/scanner.go
+++ b/internal/tui/panels/scanner.go
@@ -63,8 +63,9 @@ var (
 	scanVolDnKey  = key.NewBinding(key.WithKeys("-", "_"), key.WithHelp("-", "volume down"))
 	scanMuteKey   = key.NewBinding(key.WithKeys("M"), key.WithHelp("M", "mute toggle"))
 	scanRecKey    = key.NewBinding(key.WithKeys("R"), key.WithHelp("R", "record toggle"))
-	scanManualKey = key.NewBinding(key.WithKeys("f"), key.WithHelp("f", "manual tune"))
-	scanEscKey    = key.NewBinding(key.WithKeys("esc"), key.WithHelp("esc", "cancel"))
+	scanManualKey  = key.NewBinding(key.WithKeys("f"), key.WithHelp("f", "manual tune"))
+	scanLockoutKey = key.NewBinding(key.WithKeys("L"), key.WithHelp("L", "lockout/unlockout"))
+	scanEscKey     = key.NewBinding(key.WithKeys("esc"), key.WithHelp("esc", "cancel"))
 )
 
 func (ScannerPanel) Keys() []key.Binding {
@@ -72,7 +73,7 @@ func (ScannerPanel) Keys() []key.Binding {
 		scanHoldKey, scanRetuneKey, scanDwellKey, scanModeKey,
 		scanUpKey, scanDownKey,
 		scanVolUpKey, scanVolDnKey, scanMuteKey, scanRecKey,
-		scanManualKey,
+		scanManualKey, scanLockoutKey,
 	}
 }
 
@@ -221,6 +222,22 @@ func (p *ScannerPanel) Update(msg tea.Msg, s *state.SharedState) (Panel, tea.Cmd
 			req := state.WriteRequest{
 				Label:       fmt.Sprintf("dwell on %s (%d Hz)", ch.Label, ch.FrequencyHz),
 				Kind:        state.WriteKindScannerConvDwell,
+				ScannerConv: &state.ScannerConvReq{Index: idx},
+			}
+			return p, Emit(req)
+		}
+	case key.Matches(km, scanLockoutKey):
+		if section == "conv" {
+			ch := s.Scanner.Conventional.Channels[idx]
+			kind := state.WriteKindScannerConvLockout
+			verb := "lockout"
+			if ch.LockedOut {
+				kind = state.WriteKindScannerConvUnlockout
+				verb = "unlockout"
+			}
+			req := state.WriteRequest{
+				Label:       fmt.Sprintf("%s %s", verb, ch.Label),
+				Kind:        kind,
 				ScannerConv: &state.ScannerConvReq{Index: idx},
 			}
 			return p, Emit(req)
@@ -420,6 +437,12 @@ func (p *ScannerPanel) renderConventional(width int, s *state.SharedState) strin
 		if ch.Active {
 			active = "●"
 			style = dashOK
+		}
+		if ch.LockedOut {
+			// Lockout overrides the active indicator visually so
+			// the operator can spot a skipped channel at a glance.
+			active = "✗"
+			style = dashDim
 		}
 		break_ := "—"
 		if !ch.LastBreakAt.IsZero() {

--- a/internal/tui/state/state.go
+++ b/internal/tui/state/state.go
@@ -143,6 +143,8 @@ const (
 	WriteKindScannerConvHold
 	WriteKindScannerConvResume
 	WriteKindScannerConvDwell
+	WriteKindScannerConvLockout
+	WriteKindScannerConvUnlockout
 	WriteKindAudio
 	WriteKindScannerManualTune
 )


### PR DESCRIPTION
## Summary

Adds the "press L to skip this channel" muscle memory from physical police scanners. Closes a gap in the conventional scanner cockpit: trunked talkgroups have had lockout for a while, but conv FM channels could only be permanently excluded via config — there was no runtime escape hatch for "I don't want to hear this one right now".

## Scanner core

- `Channel.lockedOut` map (set membership keyed by channel index). `pickNextChannel` walks at most `n` entries looking for a non-locked-out channel; one full lap with no candidates means every channel is locked out and the Run loop idles.
- `LockoutChannel(idx)` / `UnlockoutChannel(idx)` flip the map. If the locked channel is currently dwelling, the synthetic call is ended with `EndReasonLockout` so the operator's intent takes effect within one IQ chunk rather than waiting for hangtime.
- `DwellOn()` bypasses the lockout for one cycle but doesn't clear the flag — explicit intent wins, lockout still skips the channel next pass.
- `RemoveTemporaryChannel` re-indexes the `lockedOut` map (parallel to `tempChannels`) via a new `shiftIndexSet` helper so VFO add/remove doesn't desync the lockout state.
- `ChannelStatus.LockedOut` surfaced through `Snapshot()`.

## API

- `POST /api/v1/scanner/conventional/{idx}/lockout` and `.../unlockout` via the existing `convLockoutOp` helper. Same 503/400/404 envelope as `DwellConventional`. `ScannerCockpit` interface grows `LockoutConventional` / `UnlockoutConventional` methods.
- `ConvChannelStatusDTO.LockedOut` field threads through to JSON so remote clients see the same state as the TUI.

## TUI

- `scanLockoutKey "L"` on the Scanner panel. Inspects the highlighted conv row's `LockedOut` to pick the lockout vs. unlockout `WriteKind`, emits via the existing toast machinery.
- Conv channel renderer shows a `✗` marker (dim style) for locked-out rows, overriding the `●` active indicator so an operator can spot a skipped channel at a glance.

## Tests

- **3 new scanner-level tests**:
  - `TestConvScannerLockoutSkipsChannel` — lockout removes the channel from the tune list and Snapshot reflects it.
  - `TestConvScannerLockoutAllIdles` — every channel locked out leaves the tuner untouched (no spin, no panic).
  - `TestConvScannerLockoutOutOfRangeReturnsFalse` — pins the false-on-bad-index contract.
- `fakeCockpit` grows `LockoutConventional` / `UnlockoutConventional` to keep `handlers_scanner_test.go` compiling against the extended `ScannerCockpit` interface.

`docs/tui.md` and `README.md` updated.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -short ./...` all green
- [ ] Manual smoke: with an SDR + conventional scan list configured, press `L` on a noisy channel in the TUI Scanner panel; the channel marker changes to `✗`, the scanner skips it on the next pass, and pressing `L` again restores it.
- [ ] Manual remote: `curl -X POST -H "X-Allow-Mutations: 1" 127.0.0.1:8080/api/v1/scanner/conventional/0/lockout` reflects in the TUI on the next 2 s scanner poll.

https://claude.ai/code/session_01FYBcR9CAiGws74GiqffTkd

---
_Generated by [Claude Code](https://claude.ai/code/session_01FYBcR9CAiGws74GiqffTkd)_