### PR TITLE
internal/api: audio.state SSE event for instant TUI convergence

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,15 @@ to its own package and lands independently.
 
 ### Recently shipped
 
+- **`audio.state` SSE event for instant TUI convergence.** PATCH
+  `/api/v1/audio` now publishes the resulting state on the events
+  bus as `KindAudioState`, which the SSE pump forwards to every
+  subscriber. The TUI listens and re-fetches the audio snapshot on
+  receipt, so two TUIs / a TUI plus a `curl` PATCH converge inside
+  one SSE round-trip instead of waiting up to 3 s for the next
+  poll tick. The payload is the same `AudioStatusDTO` the HTTP
+  response carries — clients can use it directly or just treat the
+  event as a poll trigger.
 - **Conventional channel runtime lockout.** Press `L` on the TUI's
   Scanner panel (or `POST /api/v1/scanner/conventional/{idx}/lockout`)
   to skip a conventional FM channel during scan, matching the

--- a/internal/api/handlers_audio.go
+++ b/internal/api/handlers_audio.go
@@ -4,6 +4,9 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
 )
 
 // AudioStatusDTO is the JSON shape returned by GET /api/v1/audio. Mirrors
@@ -96,7 +99,19 @@ func (s *Server) handleAudioPatch(w http.ResponseWriter, r *http.Request) {
 	if req.Recording != nil {
 		s.audio.SetRecordingEnabled(*req.Recording)
 	}
-	writeJSON(w, http.StatusOK, audioStatusDTO(s.audio))
+	state := audioStatusDTO(s.audio)
+	// Push the new state to SSE subscribers so other TUIs / web
+	// clients converge instantly instead of waiting for the next
+	// 3 s poll tick. The events.Bus passes the DTO through to the
+	// SSE pump's default payload case unchanged.
+	if s.bus != nil {
+		s.bus.Publish(events.Event{
+			Kind:      events.KindAudioState,
+			Timestamp: time.Now().UTC(),
+			Payload:   state,
+		})
+	}
+	writeJSON(w, http.StatusOK, state)
 }
 
 func audioStatusDTO(a AudioController) AudioStatusDTO {

--- a/internal/api/handlers_audio_test.go
+++ b/internal/api/handlers_audio_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/MattCheramie/GopherTrunk/internal/events"
 )
@@ -143,6 +144,54 @@ func TestAudioPatch_AppliesAllFields(t *testing.T) {
 	}
 	if fa.RecordingEnabled() {
 		t.Errorf("recording not disabled")
+	}
+}
+
+// TestAudioPatch_PublishesSSEEvent verifies the PATCH handler emits
+// an events.KindAudioState event on the bus so SSE subscribers
+// converge instantly instead of waiting for the next poll. The
+// emitted payload is the new state (same shape as the HTTP
+// response).
+func TestAudioPatch_PublishesSSEEvent(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	fa := newFakeAudio()
+	base, teardown := mkServer(t, ServerOptions{
+		Bus:            bus,
+		AllowMutations: true,
+		Audio:          fa,
+	})
+	defer teardown()
+
+	body := `{"muted":true}`
+	req, _ := http.NewRequest(http.MethodPatch, base+"/api/v1/audio", bytes.NewReader([]byte(body)))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("status=%d", resp.StatusCode)
+	}
+
+	select {
+	case ev := <-sub.C:
+		if ev.Kind != events.KindAudioState {
+			t.Errorf("event kind = %q, want audio.state", ev.Kind)
+		}
+		state, ok := ev.Payload.(AudioStatusDTO)
+		if !ok {
+			t.Fatalf("payload type = %T, want AudioStatusDTO", ev.Payload)
+		}
+		if !state.Muted {
+			t.Errorf("event payload muted = false, want true")
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("no audio.state event published within 500 ms")
 	}
 }
 

--- a/internal/events/bus.go
+++ b/internal/events/bus.go
@@ -32,6 +32,13 @@ const (
 	//     so operators can see "retry in 5 s".
 	KindHuntProgress Kind = "cchunt.progress"
 	KindHuntFailed   Kind = "cchunt.failed"
+	// KindAudioState fires when an operator changes the live-audio
+	// cockpit — volume, mute, or recording-gate. The payload is the
+	// new state (the same shape as GET /api/v1/audio). Subscribers
+	// can re-render volume sliders / mute indicators instantly
+	// instead of waiting for the next 3 s poll tick. Emitted by
+	// the HTTP API's PATCH /api/v1/audio handler.
+	KindAudioState Kind = "audio.state"
 )
 
 // Stage names a particular FEC / parser checkpoint inside a protocol

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -289,6 +289,12 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			cmds = append(cmds, cmdPollScanner(m.cli))
 		case "cchunt.progress", "cchunt.failed", "cc.locked", "cc.lost":
 			cmds = append(cmds, cmdPollScanner(m.cli))
+		case "audio.state":
+			// Refresh the audio snapshot now rather than waiting
+			// for the next 3 s poll. Multiple TUIs / clients
+			// converge on volume / mute / record state inside one
+			// SSE round-trip instead of one full poll period.
+			cmds = append(cmds, cmdPollAudio(m.cli))
 		}
 		cmds = append(cmds, listenSSE(m.eventCh))
 


### PR DESCRIPTION
## Summary

Closes a follow-up flagged in the Workstream B plan ("emit an `audio.state` event whenever volume/mute/device changes so other TUIs converge"). Without it, a TUI mutating volume / mute / record via `PATCH /api/v1/audio` waits up to one full poll period (3 s) for the change to show up in another TUI watching the same daemon.

## Wire

- `events.KindAudioState` (`"audio.state"`) added to the `events.Kind` constant set.
- `handlers_audio.go`'s PATCH handler builds the post-mutation `AudioStatusDTO` once, publishes it on the bus with the new kind + a UTC timestamp, and returns it to the HTTP caller. The SSE pump's default payload case passes the DTO through unchanged so the JSON envelope on the wire matches `GET /api/v1/audio` exactly.
- TUI `app.go`'s `eventMsg` dispatch grows an `"audio.state"` branch that triggers `cmdPollAudio`. The TUI doesn't try to decode the payload from the event directly — it just uses the event as a poll trigger, keeping the wire format the single source of truth.

## Tests

- **New** `TestAudioPatch_PublishesSSEEvent` subscribes to the bus before the PATCH, asserts the resulting event's kind + payload type + the `Muted` bit it set.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -short ./...` all green
- [ ] Manual smoke: open two `gophertrunk tui --write` instances against the same daemon, change volume / mute / record in one and watch the other converge before the 3 s poll fires.
- [ ] `curl -N http://127.0.0.1:8080/api/v1/events` shows an `event: audio.state` line immediately after a PATCH from another client.

https://claude.ai/code/session_01FYBcR9CAiGws74GiqffTkd

---
_Generated by [Claude Code](https://claude.ai/code/session_01FYBcR9CAiGws74GiqffTkd)_