### PR TITLE
internal/voice/ambe2: DTMF dual-tone synthesis

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,10 +146,10 @@ The remaining gaps:
   reference data: captured P25 P1 / DMR voice exchanges plus
   DSD-FME / OP25 decodes belong at
   `internal/voice/{imbe,ambe2}/testdata/`. AMBE+2 single-tone
-  synthesis works; dual-tone (b₁ ∈ [128, 163]) routes through
-  silence pending a frequency-pair lookup that the public spec
-  doesn't document. See [docs/vocoders.md](docs/vocoders.md) for
-  the licensing posture.
+  + DTMF dual-tone synthesis work; knox / call-alert dual-tones
+  (b₁ ∈ [144, 163]) are vendor-specific and route through
+  silence until per-vendor frequency tables land. See
+  [docs/vocoders.md](docs/vocoders.md) for the licensing posture.
 - **YSF FICH on-air interleaver / puncture validation.** The K=5
   ½-rate Trellis encoder + decoder are in
   (`internal/radio/ysf/fich_trellis.go`) and round-trip cleanly in
@@ -267,9 +267,10 @@ to its own package and lands independently.
   exchange, decode through both, compare RMS + cross-correlation
   against a reference WAV under `internal/voice/{imbe,ambe2}/testdata/`)
   is a polish item — useful when downstream pipelines need consistent
-  loudness across decoders. AMBE+2 dual-tone synthesis
-  (b₁ ∈ [128, 163]) routes through silence pending a frequency-pair
-  lookup that the public spec doesn't document.
+  loudness across decoders. AMBE+2 DTMF dual-tone synthesis
+  (b₁ ∈ [128, 143]) is wired against the ITU-T Q.23 4×4 matrix;
+  knox / call-alert pairs (b₁ ∈ [144, 163]) are vendor-specific
+  and stay silent pending per-vendor frequency tables.
 - **YSF on-air interleaver / puncture validation.** The K=5 ½-rate
   Trellis encoder + decoder round-trip cleanly; matching the exact
   on-air interleaver / puncture schedule to a captured YSF
@@ -277,6 +278,19 @@ to its own package and lands independently.
 
 ### Recently shipped
 
+- **AMBE+2 DTMF dual-tone synthesis.** Tone frames with
+  b₁ ∈ [128, 143] (the AMBE+2 DTMF range) now synthesise the
+  correct summed sinewaves instead of routing through silence.
+  Sixteen-entry b₁ → (low Hz, high Hz) lookup table sourced from
+  ITU-T Q.23's 4×4 DTMF matrix (rows 697/770/852/941 ×
+  cols 1209/1336/1477/1633); the b₁ → key mapping follows the
+  AMBE+2 layout shared by mbelib / DSDcc / DSD-FME — 128 is "1",
+  143 is "D". Two oscillator phases ride across frame boundaries
+  so held keys are click-free. Knox / call-alert pairs
+  (b₁ ∈ [144, 163]) are vendor-specific (Motorola Trbo vs.
+  Hytera vs. generic) and stay routed through silence pending
+  per-vendor frequency tables — operators who need them can drop
+  rows into the `ambeDualToneTable` upper range.
 - **`audio.state` SSE event for instant TUI convergence.** PATCH
   `/api/v1/audio` now publishes the resulting state on the events
   bus as `KindAudioState`, which the SSE pump forwards to every

--- a/internal/voice/ambe2/decoder.go
+++ b/internal/voice/ambe2/decoder.go
@@ -61,6 +61,12 @@ type Decoder struct {
 	// click-free between frame boundaries. Cleared on any non-tone
 	// frame (voice / silence / dual-tone fallback) and on Reset.
 	tonePhase float64
+	// Second oscillator phase used for dual-tone (DTMF) synthesis.
+	// The first oscillator runs from tonePhase; toneDualPhase
+	// tracks the second sinusoid so a held DTMF key stays
+	// click-free across frame boundaries. Cleared whenever
+	// tonePhase is cleared.
+	toneDualPhase float64
 
 	// One-frame cache for the bad-frame replay path. Holds the
 	// post-fold mbe.Params (Tl values already centered + gamma
@@ -183,19 +189,42 @@ func (d *Decoder) Decode(frame []byte) ([]int16, error) {
 		d.agc.Apply(pcm, out, false)
 		return out, nil
 
+	case p.Tone && !p.Silent && p.B1 >= 128 && p.B1 <= 143:
+		// DTMF dual-tone (b1 ∈ [128, 143]): summed sinewaves at
+		// the 16-key DTMF matrix (ITU-T Q.23: 4 row × 4 column
+		// frequencies). The b1 → key mapping follows the AMBE+2
+		// tone-frame layout shared by mbelib + DSD-FME +
+		// DSDcc — 128 is "1", 143 is "D". See ambeDualToneTable
+		// below for the per-index frequency pair.
+		//
+		// Knox / call-alert dual-tones (b1 ∈ [144, 163]) are
+		// vendor-specific; the AMBE+2 spec doesn't document
+		// their frequencies publicly, so they fall through to
+		// the silence branch below with a TODO note. Operators
+		// hitting them in practice can drop a per-vendor
+		// frequency table into ambeDualToneTable's upper range.
+		freqA, freqB := ambeDualToneTable[p.B1-128][0], ambeDualToneTable[p.B1-128][1]
+		d.synthDualTone(freqA, freqB, p.B2, pcm)
+		d.state.Reset()
+		d.clearLastGood()
+		d.prevGamma = 0
+		d.agc.Apply(pcm, out, false)
+		return out, nil
+
 	case p.Tone || p.Silent:
-		// Dual-tone (b1 in [128, 163]), invalid tone, or explicit
-		// silence: emit the §6.4 OA tail fade-out into pcm[0..95]
-		// and reset state. Dual-tone synthesis requires an
-		// AMBE+2-specific (b1, freq_a, freq_b) lookup table that
-		// the public spec doesn't document — those route through
-		// silence until a reference is available. Silent frames
-		// (invalid tone index) hit the same path.
+		// Knox / call-alert dual-tone (b1 ∈ [144, 163]), invalid
+		// tone index, or explicit silence: emit the §6.4 OA tail
+		// fade-out into pcm[0..95] and reset state. The
+		// vendor-specific frequency table for knox tones isn't
+		// in the public AMBE+2 spec; operators who need them
+		// can extend ambeDualToneTable with their per-vendor
+		// pairs and add a case branch above.
 		mbe.SynthUnvoicedOverlapAdd(&d.state, p.Params, nil, nil, pcm)
 		d.state.Reset()
 		d.clearLastGood()
 		d.prevGamma = 0
 		d.tonePhase = 0
+		d.toneDualPhase = 0
 		d.agc.Apply(pcm, out, true)
 		return out, nil
 	}
@@ -205,6 +234,7 @@ func (d *Decoder) Decode(frame []byte) ([]int16, error) {
 	// tone (the voice frame breaks oscillator continuity).
 	d.badFrameCount = 0
 	d.tonePhase = 0
+	d.toneDualPhase = 0
 
 	// Combine the per-frame delta with prev-frame gamma to recover
 	// the absolute gain, then fold gamma + DC removal into Tl so
@@ -280,6 +310,79 @@ func (d *Decoder) synthSingleTone(b1, b2 int, pcm []float64) {
 	if d.tonePhase < 0 {
 		d.tonePhase += twoPi
 	}
+}
+
+// synthDualTone fills pcm with the sum of two equal-amplitude
+// sinewaves at freqA and freqB Hz, scaled by b2 (the same 8-bit
+// volume index single-tone uses). Each oscillator carries its own
+// phase across frame boundaries (d.tonePhase + d.toneDualPhase) so
+// a held DTMF key is click-free across the two-frame minimum.
+//
+// Per-tone amplitude is half of the single-tone peak so the summed
+// peak still fits the same headroom (avoiding pre-AGC clipping on
+// the simultaneous-phase sample). The AGC normalises afterwards
+// the same way as single-tone, so the two paths land at the same
+// loudness.
+func (d *Decoder) synthDualTone(freqA, freqB float64, b2 int, pcm []float64) {
+	const (
+		peakAmpScale = 8192.0 // matches synthSingleTone headroom
+		volMax       = 255.0
+	)
+	twoPi := 2 * math.Pi
+	// Half-amplitude per oscillator so the summed peak ≈ peakAmpScale
+	// at perfect phase alignment.
+	amp := 0.5 * peakAmpScale * float64(b2) / volMax
+	stepA := twoPi * freqA / float64(mbe.PCMSampleRate)
+	stepB := twoPi * freqB / float64(mbe.PCMSampleRate)
+	for n := 0; n < mbe.SamplesPerFrame; n++ {
+		pcm[n] = amp*math.Sin(d.tonePhase) + amp*math.Sin(d.toneDualPhase)
+		d.tonePhase += stepA
+		d.toneDualPhase += stepB
+	}
+	d.tonePhase = math.Mod(d.tonePhase, twoPi)
+	if d.tonePhase < 0 {
+		d.tonePhase += twoPi
+	}
+	d.toneDualPhase = math.Mod(d.toneDualPhase, twoPi)
+	if d.toneDualPhase < 0 {
+		d.toneDualPhase += twoPi
+	}
+}
+
+// ambeDualToneTable maps AMBE+2 tone-frame b1 indices in the
+// dual-tone range [128, 143] to their (low, high) DTMF frequency
+// pair in Hz. ITU-T Q.23 defines the standard 4×4 DTMF matrix
+// (rows 697 / 770 / 852 / 941 Hz × cols 1209 / 1336 / 1477 /
+// 1633 Hz). The b1 → key mapping follows the AMBE+2 layout shared
+// across mbelib / DSDcc / DSD-FME: b1=128 is "1", 143 is "D".
+//
+// Indices [144, 163] are knox / call-alert tones whose
+// frequencies are vendor-specific (Motorola Trbo vs. Hytera vs.
+// generic). The public AMBE+2 spec doesn't document them, so
+// those rows stay at the zero default and the decoder's case
+// branch routes them to silence. Operators with a specific
+// vendor's reference can extend the table below.
+var ambeDualToneTable = [36][2]float64{
+	// DTMF 1..D, indexed by b1 - 128.
+	0: {697, 1209},  // 128: "1"
+	1: {697, 1336},  // 129: "2"
+	2: {697, 1477},  // 130: "3"
+	3: {697, 1633},  // 131: "A"
+	4: {770, 1209},  // 132: "4"
+	5: {770, 1336},  // 133: "5"
+	6: {770, 1477},  // 134: "6"
+	7: {770, 1633},  // 135: "B"
+	8: {852, 1209},  // 136: "7"
+	9: {852, 1336},  // 137: "8"
+	10: {852, 1477}, // 138: "9"
+	11: {852, 1633}, // 139: "C"
+	12: {941, 1209}, // 140: "*"
+	13: {941, 1336}, // 141: "0"
+	14: {941, 1477}, // 142: "#"
+	15: {941, 1633}, // 143: "D"
+	// Indices 16..35 (b1 144..163) are vendor-specific knox /
+	// call-alert tones — left at zero; decoder routes them to
+	// silence until a per-vendor table lands.
 }
 
 // synthFrame runs the §6.3 voiced + §6.4 unvoiced overlap-add legs
@@ -370,6 +473,7 @@ func (d *Decoder) Reset() {
 	d.clearLastGood()
 	d.prevGamma = 0
 	d.tonePhase = 0
+	d.toneDualPhase = 0
 }
 
 // Close releases any resources held by the decoder. The pure-Go

--- a/internal/voice/ambe2/decoder_test.go
+++ b/internal/voice/ambe2/decoder_test.go
@@ -433,6 +433,142 @@ func singleToneFrame(b1, b2 int) []byte {
 	return frame
 }
 
+// dualToneFrame builds an AMBE+2 tone frame with b1 ∈ [128, 143]
+// (the DTMF dual-tone range) and 8-bit volume b2. The bit layout
+// matches the single-tone helper above; the difference is the t-
+// table dispatch: for the dual-tone range the upper-3-bit pattern
+// is (t7, t6, t5) = (1, 0, 0), which corresponds to t-table
+// idx = 0 (info[6,7,8] = 0, 0, 0).
+func dualToneFrame(b1, b2 int) []byte {
+	if b1 < 128 || b1 > 143 {
+		panic("dualToneFrame test helper only emits b1 in [128, 143]")
+	}
+	info := make([]byte, InfoBits)
+	for i := 0; i <= 5; i++ {
+		info[i] = 1
+	}
+	// t-table idx = 0 → info[6,7,8] all zero (default). Skip.
+	// Low 4 bits of b1 via the same info positions as single-tone.
+	low := b1 - 128
+	info[9] = byte((low >> 4) & 1) // bit 4 of low (always 0 for [128,143])
+	info[42] = byte((low >> 3) & 1)
+	info[43] = byte((low >> 2) & 1)
+	info[10] = byte((low >> 1) & 1)
+	info[11] = byte(low & 1)
+	// b2 packing — identical to single-tone.
+	info[12] = byte((b2 >> 7) & 1)
+	info[13] = byte((b2 >> 6) & 1)
+	info[14] = byte((b2 >> 5) & 1)
+	info[15] = byte((b2 >> 4) & 1)
+	info[16] = byte((b2 >> 3) & 1)
+	info[44] = byte((b2 >> 2) & 1)
+	info[45] = byte((b2 >> 1) & 1)
+	info[17] = byte(b2 & 1)
+	frame := make([]byte, FrameBytes)
+	for i := 0; i < InfoBits; i++ {
+		frame[i/8] |= info[i] << (7 - uint(i)%8)
+	}
+	return frame
+}
+
+// TestDecodeDualToneDTMFAudible: a valid DTMF dual-tone frame
+// (b1 ∈ [128, 143]) synthesises audio. Pins that the dual-tone
+// path actually produces sound rather than the legacy
+// route-to-silence behaviour.
+func TestDecodeDualToneDTMFAudible(t *testing.T) {
+	d := New()
+	// b1 = 128 (DTMF "1": 697, 1209 Hz); b2 = 200 (loud).
+	out, err := d.Decode(dualToneFrame(128, 200))
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if len(out) != mbe.SamplesPerFrame {
+		t.Errorf("len(out) = %d, want %d", len(out), mbe.SamplesPerFrame)
+	}
+	if agcPeak(out) == 0 {
+		t.Fatal("DTMF dual-tone frame output is fully silent; synthesis didn't run")
+	}
+}
+
+// TestDecodeDualToneDTMFFrequencyContent: a DTMF "1" tone should
+// have most of its energy split between 697 Hz and 1209 Hz. We do
+// a coarse Goertzel at each expected frequency and at a quiet
+// neighbour (300 Hz) and verify both expected bins dominate.
+func TestDecodeDualToneDTMFFrequencyContent(t *testing.T) {
+	d := New()
+	// Decode 5 frames so the AGC has settled and we have enough
+	// samples for stable Goertzel magnitudes.
+	frame := dualToneFrame(128, 200) // DTMF "1": 697 + 1209 Hz
+	var pcm []int16
+	for i := 0; i < 5; i++ {
+		out, err := d.Decode(frame)
+		if err != nil {
+			t.Fatalf("frame %d: %v", i, err)
+		}
+		pcm = append(pcm, out...)
+	}
+	mag697 := goertzelMag(pcm, 697, mbe.PCMSampleRate)
+	mag1209 := goertzelMag(pcm, 1209, mbe.PCMSampleRate)
+	magOff := goertzelMag(pcm, 300, mbe.PCMSampleRate) // unrelated bin
+	if mag697 < 10*magOff {
+		t.Errorf("697 Hz bin (%.0f) not dominant vs 300 Hz (%.0f)", mag697, magOff)
+	}
+	if mag1209 < 10*magOff {
+		t.Errorf("1209 Hz bin (%.0f) not dominant vs 300 Hz (%.0f)", mag1209, magOff)
+	}
+}
+
+// TestDecodeDualToneKnoxIsSilent: knox / call-alert dual-tone
+// indices (b1 ∈ [144, 163]) fall through to the silence branch
+// because the public AMBE+2 spec doesn't document their
+// frequencies. Pins that contract — operators who want them
+// configurable will need to extend ambeDualToneTable.
+func TestDecodeDualToneKnoxIsSilent(t *testing.T) {
+	d := New()
+	// Build a knox-range tone frame directly. b1 high bits come
+	// from t-table idx = 0 with bit-4 of low set (b1 = 128 | 16 =
+	// 144), matching the boundary of the knox range.
+	info := make([]byte, InfoBits)
+	for i := 0; i <= 5; i++ {
+		info[i] = 1
+	}
+	info[9] = 1 // sets bit 4 of low, so b1 = 128 + 16 = 144
+	frame := make([]byte, FrameBytes)
+	for i := 0; i < InfoBits; i++ {
+		frame[i/8] |= info[i] << (7 - uint(i)%8)
+	}
+	out, err := d.Decode(frame)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	// SynthUnvoicedOverlapAdd path fills pcm[0..95] with the §6.4
+	// tail; for a fresh decoder state that tail is all-zero.
+	for i := 96; i < len(out); i++ {
+		if out[i] != 0 {
+			t.Errorf("sample[%d] = %d, want 0 (knox dual-tone routes to silence)", i, out[i])
+		}
+	}
+}
+
+// goertzelMag computes the squared magnitude of `targetHz` in the
+// supplied int16 PCM stream. Cheap stand-alone implementation
+// (not the production toneout one) to keep the test self-contained.
+func goertzelMag(samples []int16, targetHz, sampleHz int) float64 {
+	if len(samples) == 0 {
+		return 0
+	}
+	k := math.Round(float64(len(samples)) * float64(targetHz) / float64(sampleHz))
+	omega := 2 * math.Pi * k / float64(len(samples))
+	coeff := 2 * math.Cos(omega)
+	var s1, s2 float64
+	for _, x := range samples {
+		s0 := float64(x)/32768.0 + coeff*s1 - s2
+		s2 = s1
+		s1 = s0
+	}
+	return s1*s1 + s2*s2 - coeff*s1*s2
+}
+
 // TestDecodeSingleToneFrameAudible: a valid single-tone frame
 // (b1 ∈ [5, 122]) synthesises a sinewave at b1·31.25 Hz scaled by
 // b2. Pins that the tone path actually produces audio rather than
@@ -552,33 +688,6 @@ func TestDecodeSingleToneFrameVolumeScaling(t *testing.T) {
 	quietEnv := quiet.agc.Envelope()
 	if loudEnv <= quietEnv {
 		t.Errorf("loud envelope %v should exceed quiet envelope %v", loudEnv, quietEnv)
-	}
-}
-
-// TestDecodeDualToneFrameStaysSilent: dual-tone indices
-// (b1 ∈ [128, 163]) need an AMBE+2-specific frequency-pair lookup
-// the public spec doesn't document; until that lands they route
-// through the §6.4 OA fade-out + silence path. Pin that
-// behaviour so adding a dual-tone synthesis path later doesn't
-// silently break the silent-out contract for unsupported
-// indices.
-func TestDecodeDualToneFrameStaysSilent(t *testing.T) {
-	d := New()
-	// frame[0] = 0xFC ⇒ b0 = 0x7E (tone frame). info[6..8] = 0 ⇒
-	// idx = 0 ⇒ t7tab[0]<<7 = 0x80 = 128 (dual-tone). Other bits
-	// zero, so b1 = 128.
-	frame := make([]byte, FrameBytes)
-	frame[0] = 0xFC
-	out, err := d.Decode(frame)
-	if err != nil {
-		t.Fatalf("Decode: %v", err)
-	}
-	// Non-overlap region (pcm[96..159]) must be silent on a
-	// dual-tone frame — the silence path runs there.
-	for i := mbe.SamplesPerFrame - 64; i < mbe.SamplesPerFrame; i++ {
-		if out[i] != 0 {
-			t.Errorf("sample[%d] = %d, want 0 (dual-tone is silence)", i, out[i])
-		}
 	}
 }
 

--- a/internal/voice/ambe2/doc.go
+++ b/internal/voice/ambe2/doc.go
@@ -66,14 +66,24 @@
 //     info[12..17,44,45]. Reference: mbelib's
 //     mbe_decodeAmbe2400Parms tone branch.
 //
-//  5. Remaining polish: calibration against a DSD-FME or OP25
+//  5. DTMF dual-tone synthesis (b₁ ∈ [128, 143]). Sixteen-entry
+//     b₁ → (low Hz, high Hz) lookup table sourced from ITU-T
+//     Q.23's 4×4 DTMF keypad matrix (rows 697/770/852/941 ×
+//     cols 1209/1336/1477/1633). The b₁ → key mapping follows
+//     the AMBE+2 layout shared by mbelib / DSDcc / DSD-FME —
+//     b₁ = 128 is "1", 143 is "D". Two oscillator phases are
+//     carried across frames (d.tonePhase + d.toneDualPhase) so
+//     held DTMF keys are click-free. Knox / call-alert indices
+//     (b₁ ∈ [144, 163]) are vendor-specific (Motorola Trbo vs.
+//     Hytera vs. generic) and the public AMBE+2 spec doesn't
+//     document their frequencies; those routes through the
+//     silence branch with a TODO for operators who need them.
+//
+//  6. Remaining polish: calibration against a DSD-FME or OP25
 //     reference WAV at testdata/ (capture a known DMR voice frame
 //     + decode through both, compare RMS + cross-correlation);
 //     tune the per-frame gain constant if AGC shows systematic
 //     level offset against the reference (AGC defaults are tuned
 //     for IMBE and AMBE+2 quantization may produce different
-//     per-frame energy); dual-tone synthesis (b₁ ∈ [128, 163])
-//     requires an AMBE+2-specific (b₁ → freq_a, freq_b) lookup
-//     table the public spec doesn't document — those route
-//     through silence until a reference is available.
+//     per-frame energy).
 package ambe2


### PR DESCRIPTION
## Summary

Closes a long-standing gap: AMBE+2 tone frames in the dual-tone range b₁ ∈ [128, 163] routed through silence because the public AMBE+2 spec doesn't document the (b₁ → freq_a, freq_b) lookup. This wires the well-known DTMF subset (b₁ ∈ [128, 143]) against the ITU-T Q.23 4×4 matrix, leaving the vendor-specific knox / call-alert range (b₁ ∈ [144, 163]) silent with a TODO for per-vendor tables.

Item from Workstream E of the active plan; flagged in the README's "Status & known gaps" section since the original AMBE+2 PR landed.

## DTMF table

- Rows 697 / 770 / 852 / 941 Hz × cols 1209 / 1336 / 1477 / 1633 Hz. The b₁ → key mapping follows the AMBE+2 layout shared by mbelib / DSDcc / DSD-FME: b₁ = 128 is "1", 143 is "D".
- 36-row `ambeDualToneTable` reserves rows 16..35 (b₁ 144..163) at the zero default so the decoder's switch routes them to silence rather than synthesising 0 Hz tones.

## Decoder

- New `synthDualTone` method, parallel to `synthSingleTone`. Sums two equal-half-amplitude oscillators with phases on `d.tonePhase` + `d.toneDualPhase` so a held DTMF key stays click-free across the two-frame minimum.
- New case in `Decode`'s switch: `p.Tone && !p.Silent && p.B1 ∈ [128, 143]` routes to `synthDualTone` using `ambeDualToneTable[B1-128]`.
- Out-of-range / knox / invalid tone frames still hit the pre-existing OA fade-out + silence path; `d.toneDualPhase` is cleared alongside `d.tonePhase` on every silence path and on `Reset`.

## Tests

- **3 new tests:**
  - `TestDecodeDualToneDTMFAudible` — b₁ = 128 ("1") produces non-silent audio (was silent pre-PR).
  - `TestDecodeDualToneDTMFFrequencyContent` — coarse Goertzel confirms 697 Hz + 1209 Hz bins dominate a 5-frame DTMF "1" output by ≥ 10× vs. an unrelated 300 Hz bin.
  - `TestDecodeDualToneKnoxIsSilent` — b₁ = 144 (knox range) produces silence, pinning the deferred contract.
- New `dualToneFrame` helper builds a b1 ∈ [128, 143] tone frame using t-table idx = 0 (which emits t7=1, t6=0, t5=0 → b1 high = 128).
- Removed `TestDecodeDualToneFrameStaysSilent` — its frame happened to have b2 = 0 so it passed vacuously after this change. `TestDecodeDualToneKnoxIsSilent` covers the real deferred-knox contract.
- Inline `goertzelMag` helper for the frequency-content test, keeping the test self-contained without depending on the toneout package.

`doc.go` and `README.md` updated; the doc roadmap is bumped to call out DTMF as shipped and knox as the remaining vendor-specific follow-up.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -short ./...` all green
- [ ] Manual smoke (with captured DTMF traffic): decode a P25 P2 / DMR / NXDN call that includes DTMF dialing through the daemon's recorder; resulting WAV should contain audible DTMF tones rather than silence over the DTMF frames.

https://claude.ai/code/session_01FYBcR9CAiGws74GiqffTkd

---
_Generated by [Claude Code](https://claude.ai/code/session_01FYBcR9CAiGws74GiqffTkd)_