### PR TITLE
internal/voice/player: direct-ioctl ALSA backend (no libasound2 at runtime)

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,20 @@ to its own package and lands independently.
 
 ### Recently shipped
 
+- **Direct-ioctl ALSA backend (drops the runtime libasound2 dep).**
+  Setting `audio.device: ioctl` (or `ioctl:hw:C,D` for a specific
+  card / device) on Linux selects a direct-kernel backend that
+  opens `/dev/snd/pcmC{card}D{device}p` and drives the playback
+  state machine via `SNDRV_PCM_IOCTL_*` syscalls. No
+  `libasound2.so.2` at runtime, no `purego.Dlopen`, no cgo —
+  useful for distroless / Alpine / scratch container images that
+  don't ship the userspace library but do have the kernel sound
+  subsystem available. Defaults to card 0, device 0; format
+  pinned to S16_LE mono at `audio.sample_rate`, period sized
+  from `audio.buffer_ms`. The dlopen path stays the Linux
+  default because it auto-negotiates with the hardware; the
+  ioctl path uses fixed values so it only works when the
+  underlying device natively supports them.
 - **AMBE+2 DTMF dual-tone synthesis.** Tone frames with
   b₁ ∈ [128, 143] (the AMBE+2 DTMF range) now synthesise the
   correct summed sinewaves instead of routing through silence.

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -107,7 +107,11 @@ scanner:
 # to a silent player automatically so the daemon stays running.
 audio:
   enabled: false       # set true to play decoded calls live
-  device: ""           # empty = system default sink; "null" forces no-op
+  device: ""           # empty = system default sink; "null" forces no-op;
+                       # on Linux, "ioctl" or "ioctl:hw:C,D" bypasses
+                       # libasound2 entirely (direct kernel ioctl on
+                       # /dev/snd/pcmC*D*p — useful for distroless /
+                       # Alpine containers without libasound2.so.2)
   sample_rate: 8000    # must match recordings.sample_rate
   buffer_ms: 80        # playback queue depth; higher = more jitter-tolerant
   volume: 0.8          # 0..1 software gain

--- a/internal/voice/player/alsa_linux.go
+++ b/internal/voice/player/alsa_linux.go
@@ -25,6 +25,7 @@ package player
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"unsafe"
 
@@ -107,6 +108,22 @@ type alsaBackend struct {
 }
 
 func newALSABackend(cfg Config) (Backend, error) {
+	// Direct-ioctl opt-in: an "ioctl" device name (with optional
+	// "hw:C,D" suffix after a colon) bypasses libasound2.so.2
+	// entirely. Useful for stripped-down container images that
+	// don't ship the userspace library but do have the kernel
+	// sound subsystem. The dlopen path stays the default because
+	// it negotiates format / rate / period with the hardware
+	// automatically; the ioctl path uses pinned values so it
+	// only works when the hardware natively supports them.
+	if cfg.Device == "ioctl" || strings.HasPrefix(cfg.Device, "ioctl:") {
+		spec := ""
+		if i := strings.IndexByte(cfg.Device, ':'); i >= 0 {
+			spec = cfg.Device[i+1:]
+		}
+		return newIoctlALSABackend(cfg, spec)
+	}
+
 	if err := loadALSA(); err != nil {
 		return nil, err
 	}

--- a/internal/voice/player/ioctl_linux.go
+++ b/internal/voice/player/ioctl_linux.go
@@ -1,0 +1,373 @@
+// Direct-ioctl ALSA backend — drives /dev/snd/pcmC{card}D{device}p
+// straight via SNDRV_PCM_IOCTL_* syscalls. No libasound2.so.2 at
+// runtime, no purego dlopen, no cgo. Useful for stripped-down
+// container images (distroless, scratch, minimal Alpine) that
+// don't ship the userspace ALSA library but do have the kernel
+// sound subsystem available.
+//
+// This is the no-runtime-dep alternative to alsa_linux.go's
+// purego dlopen path. Selected by setting audio.device to
+// "ioctl" (default card 0 device 0) or "ioctl:hw:C,D" (specific
+// card / device). The libasound2 dlopen path stays the default
+// because it negotiates format / rate / period sizes with the
+// hardware automatically; the ioctl path uses fixed values
+// (S16_LE mono at the configured sample rate) so it only works
+// when the underlying hardware supports them.
+//
+// References:
+//   - Kernel UAPI: include/uapi/sound/asound.h
+//   - ALSA library source (alsa-lib/src/pcm/pcm_hw.c) for the
+//     reference state-machine ordering: OPEN → HW_PARAMS →
+//     SW_PARAMS → PREPARE → WRITEI → DRAIN/DROP → CLOSE.
+//
+// Notes on the implementation:
+//   - The snd_pcm_hw_params struct is 604 bytes laid out as 3
+//     used + 5 reserved 256-bit masks, then 12 used + 9 reserved
+//     12-byte intervals, then a tail of bitmasks / info fields.
+//     Sizes are platform-independent because the kernel UAPI is
+//     defined in fixed-width types.
+//   - All ioctls use SYS_IOCTL via syscall.Syscall. We don't pull
+//     in golang.org/x/sys/unix as a direct dep — the project's
+//     other "purego" backends (RTL-SDR, ALSA-via-dlopen) follow
+//     the same convention.
+
+//go:build linux
+
+package player
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"unsafe"
+)
+
+// Linux UAPI constants from <sound/asound.h>. Stable since
+// libasound v1.0; these match every kernel that ships modern
+// ALSA support.
+const (
+	// Mask parameter indices into snd_pcm_hw_params.Masks.
+	hwParamAccess    = 0
+	hwParamFormat    = 1
+	hwParamSubformat = 2
+
+	// Interval parameter indices into snd_pcm_hw_params.Intervals.
+	hwParamSampleBits  = 0
+	hwParamFrameBits   = 1
+	hwParamChannels    = 2
+	hwParamRate        = 3
+	hwParamPeriodTime  = 4
+	hwParamPeriodSize  = 5
+	hwParamPeriodBytes = 6
+	hwParamPeriods     = 7
+	hwParamBufferTime  = 8
+	hwParamBufferSize  = 9
+	hwParamBufferBytes = 10
+
+	// Enum values for the mask params.
+	pcmAccessRWInterleaved = 3 // SNDRV_PCM_ACCESS_RW_INTERLEAVED
+	pcmFormatS16LE         = 2 // SNDRV_PCM_FORMAT_S16_LE
+	pcmSubformatStd        = 0 // SNDRV_PCM_SUBFORMAT_STD
+
+	// snd_pcm_sw_params SNDRV_PCM_HW_PARAMS_NO_PERIOD_WAKEUP is unused.
+	// We just set start_threshold + stop_threshold + avail_min and let
+	// every other sw_param default.
+
+	// Magic version the kernel checks at HW_PARAMS time. Pinned to
+	// SNDRV_PCM_VERSION as of the v6.x UAPI header set; backwards
+	// compatibility means older kernels accept newer versions.
+	pcmVersion = 0x00020000 + 13 // 2.0.13
+)
+
+// sndMask is the kernel's 256-bit mask, packed into 8 uint32s.
+type sndMask struct {
+	Bits [8]uint32
+}
+
+// sndInterval mirrors struct snd_interval. Min/Max are the bounds;
+// Flags encodes openmin/openmax/integer/empty (we only use INTEGER
+// and the implicit "min == max for a pinned value" case).
+type sndInterval struct {
+	Min, Max uint32
+	// Bit 0: openmin, bit 1: openmax, bit 2: integer, bit 3: empty.
+	Flags uint32
+}
+
+// sndPCMHwParams mirrors struct snd_pcm_hw_params. 604 bytes total.
+// Layout is fixed by the UAPI; do not reorder.
+type sndPCMHwParams struct {
+	Flags     uint32
+	Masks     [3]sndMask    // ACCESS, FORMAT, SUBFORMAT
+	Mres      [5]sndMask    // reserved masks
+	Intervals [12]sndInterval
+	Ires      [9]sndInterval // reserved intervals
+	Rmask     uint32         // requested mask (set by user, kernel may clear)
+	Cmask     uint32         // changed mask (kernel sets on REFINE)
+	Info      uint32
+	MSBits    uint32
+	RateNum   uint32
+	RateDen   uint32
+	FifoSize  uint64
+	Reserved  [64]byte
+}
+
+// sndPCMSwParams mirrors struct snd_pcm_sw_params. We only set
+// a handful of fields; the rest stay at the zero default which
+// matches what alsa-lib's defaults produce.
+type sndPCMSwParams struct {
+	TstampMode       uint32
+	PeriodStep       uint32
+	SleepMin         uint32
+	AvailMin         uint64
+	XferAlign        uint64 // obsolete; kept for layout
+	StartThreshold   uint64
+	StopThreshold    uint64
+	SilenceThreshold uint64
+	SilenceSize      uint64
+	Boundary         uint64
+	Proto            uint32
+	TstampType       uint32
+	Reserved         [56]byte
+}
+
+// sndXferi mirrors struct snd_xferi — the WRITEI / READI payload.
+type sndXferi struct {
+	Result int64
+	Buf    uintptr // pointer to the sample buffer
+	Frames uint64
+}
+
+// ioctl request numbers. Computed once and cached.
+var (
+	ioctlHwParams = ioctlRequest(_IOC_READ|_IOC_WRITE, 'A', 0x11, unsafe.Sizeof(sndPCMHwParams{}))
+	ioctlSwParams = ioctlRequest(_IOC_READ|_IOC_WRITE, 'A', 0x13, unsafe.Sizeof(sndPCMSwParams{}))
+	ioctlPrepare  = ioctlRequest(_IOC_NONE, 'A', 0x40, 0)
+	ioctlStart    = ioctlRequest(_IOC_NONE, 'A', 0x42, 0)
+	ioctlDrop     = ioctlRequest(_IOC_NONE, 'A', 0x43, 0)
+	ioctlDrain    = ioctlRequest(_IOC_NONE, 'A', 0x44, 0)
+	ioctlWriteI   = ioctlRequest(_IOC_WRITE, 'A', 0x50, unsafe.Sizeof(sndXferi{}))
+)
+
+const (
+	_IOC_NONE  = 0
+	_IOC_WRITE = 1
+	_IOC_READ  = 2
+
+	_IOC_NRSHIFT   = 0
+	_IOC_TYPESHIFT = 8
+	_IOC_SIZESHIFT = 16
+	_IOC_DIRSHIFT  = 30
+)
+
+func ioctlRequest(dir uintptr, typ uintptr, nr uintptr, size uintptr) uintptr {
+	return (dir << _IOC_DIRSHIFT) |
+		(typ << _IOC_TYPESHIFT) |
+		(nr << _IOC_NRSHIFT) |
+		(size << _IOC_SIZESHIFT)
+}
+
+// ioctlBackend implements Backend via direct kernel ALSA ioctls.
+type ioctlBackend struct {
+	f          *os.File
+	rate       uint32
+	periodSize uint32
+
+	closeOnce sync.Once
+	closeErr  error
+}
+
+// newIoctlALSABackend opens /dev/snd/pcmC{card}D{device}p and runs
+// the HW_PARAMS / SW_PARAMS / PREPARE handshake so the device is
+// ready to accept WRITEI calls. Device spec format: "hw:C,D" or
+// just "" (defaults to "hw:0,0").
+func newIoctlALSABackend(cfg Config, deviceSpec string) (Backend, error) {
+	card, device, err := parseIoctlDevice(deviceSpec)
+	if err != nil {
+		return nil, err
+	}
+	path := fmt.Sprintf("/dev/snd/pcmC%dD%dp", card, device)
+	f, err := os.OpenFile(path, os.O_RDWR, 0)
+	if err != nil {
+		return nil, fmt.Errorf("ioctl-alsa: open %s: %w", path, err)
+	}
+
+	rate := cfg.SampleRate
+	if rate == 0 {
+		rate = 8000
+	}
+	// Period size in frames — match the buffer-ms config but cap
+	// to keep things sane. 8 kHz × 80 ms = 640 frames; we round
+	// up to a power-of-two-ish value the kernel prefers.
+	bufMs := cfg.BufferMs
+	if bufMs <= 0 {
+		bufMs = 80
+	}
+	periodSize := uint32(int(rate) * bufMs / 1000)
+	if periodSize < 64 {
+		periodSize = 64
+	}
+	// Buffer holds 2 periods so the kernel can pipeline.
+	bufferSize := periodSize * 2
+
+	b := &ioctlBackend{f: f, rate: rate, periodSize: periodSize}
+
+	if err := b.setHWParams(rate, periodSize, bufferSize); err != nil {
+		f.Close()
+		return nil, err
+	}
+	if err := b.setSWParams(periodSize, bufferSize); err != nil {
+		f.Close()
+		return nil, err
+	}
+	if err := b.ioctl(ioctlPrepare, 0); err != nil {
+		f.Close()
+		return nil, fmt.Errorf("ioctl-alsa: PREPARE: %w", err)
+	}
+	return b, nil
+}
+
+// parseIoctlDevice accepts "" or "hw:C,D" forms. Returns the
+// numeric card / device. "ioctl" prefix is stripped by the caller
+// (newALSABackend) before reaching us.
+func parseIoctlDevice(spec string) (card, device uint32, err error) {
+	if spec == "" || spec == "default" || spec == "hw:0,0" {
+		return 0, 0, nil
+	}
+	if !strings.HasPrefix(spec, "hw:") {
+		return 0, 0, fmt.Errorf("ioctl-alsa: device %q must be empty or \"hw:C,D\"", spec)
+	}
+	parts := strings.Split(spec[3:], ",")
+	if len(parts) != 2 {
+		return 0, 0, fmt.Errorf("ioctl-alsa: device %q malformed", spec)
+	}
+	c, err := strconv.ParseUint(parts[0], 10, 32)
+	if err != nil {
+		return 0, 0, fmt.Errorf("ioctl-alsa: parse card %q: %w", parts[0], err)
+	}
+	d, err := strconv.ParseUint(parts[1], 10, 32)
+	if err != nil {
+		return 0, 0, fmt.Errorf("ioctl-alsa: parse device %q: %w", parts[1], err)
+	}
+	return uint32(c), uint32(d), nil
+}
+
+// setHWParams pins access mode, sample format, channel count, and
+// rate to fixed values (S16_LE / 1 ch / configured rate). The
+// kernel sets the rest based on hardware capability; we just
+// have to leave a valid wildcard for each.
+func (b *ioctlBackend) setHWParams(rate, periodSize, bufferSize uint32) error {
+	var p sndPCMHwParams
+	// Mask params — start with all bits set so the kernel can
+	// pick the one we narrow to.
+	for i := range p.Masks {
+		for j := range p.Masks[i].Bits {
+			p.Masks[i].Bits[j] = 0xFFFFFFFF
+		}
+	}
+	for i := range p.Intervals {
+		p.Intervals[i].Max = 0xFFFFFFFF
+	}
+	// Narrow ACCESS to RW_INTERLEAVED.
+	p.Masks[hwParamAccess].Bits = [8]uint32{}
+	p.Masks[hwParamAccess].Bits[pcmAccessRWInterleaved/32] = 1 << (pcmAccessRWInterleaved % 32)
+	// Narrow FORMAT to S16_LE.
+	p.Masks[hwParamFormat].Bits = [8]uint32{}
+	p.Masks[hwParamFormat].Bits[pcmFormatS16LE/32] = 1 << (pcmFormatS16LE % 32)
+	// Narrow SUBFORMAT to STD.
+	p.Masks[hwParamSubformat].Bits = [8]uint32{}
+	p.Masks[hwParamSubformat].Bits[pcmSubformatStd/32] = 1 << (pcmSubformatStd % 32)
+
+	pinInterval := func(idx, value uint32) {
+		p.Intervals[idx].Min = value
+		p.Intervals[idx].Max = value
+		p.Intervals[idx].Flags = 0
+	}
+	pinInterval(hwParamChannels, 1)
+	pinInterval(hwParamRate, rate)
+	pinInterval(hwParamPeriodSize, periodSize)
+	pinInterval(hwParamBufferSize, bufferSize)
+	// SAMPLE_BITS = 16, FRAME_BITS = 16 * channels = 16. The
+	// kernel derives these from FORMAT + CHANNELS but pinning
+	// them defensively avoids hardware-side surprises.
+	pinInterval(hwParamSampleBits, 16)
+	pinInterval(hwParamFrameBits, 16)
+
+	// Rmask = all params we set (the kernel checks which ones we
+	// actually constrained).
+	p.Rmask = 0xFFFFFFFF
+	if err := b.ioctl(ioctlHwParams, uintptr(unsafe.Pointer(&p))); err != nil {
+		return fmt.Errorf("ioctl-alsa: HW_PARAMS: %w", err)
+	}
+	return nil
+}
+
+// setSWParams configures the minimum start / stop threshold so
+// WRITEI starts playback automatically once we've buffered a
+// period and stops gracefully on underrun.
+func (b *ioctlBackend) setSWParams(periodSize, bufferSize uint32) error {
+	var p sndPCMSwParams
+	p.AvailMin = uint64(periodSize)
+	p.StartThreshold = uint64(periodSize) // start after the first full period
+	p.StopThreshold = uint64(bufferSize)  // stop when buffer drains entirely
+	p.Boundary = 1 << 30                  // arbitrary large wrap-around
+	if err := b.ioctl(ioctlSwParams, uintptr(unsafe.Pointer(&p))); err != nil {
+		return fmt.Errorf("ioctl-alsa: SW_PARAMS: %w", err)
+	}
+	return nil
+}
+
+// Write feeds int16 PCM via SNDRV_PCM_IOCTL_WRITEI_FRAMES. On
+// underrun (EPIPE) the kernel returns the device to XRUN state;
+// we recover by re-PREPARE'ing and re-issuing the write rather
+// than losing the chunk.
+func (b *ioctlBackend) Write(samples []int16) error {
+	if len(samples) == 0 {
+		return nil
+	}
+	frames := uint64(len(samples))
+	written := uint64(0)
+	for written < frames {
+		var xferi sndXferi
+		xferi.Buf = uintptr(unsafe.Pointer(&samples[written]))
+		xferi.Frames = frames - written
+		err := b.ioctl(ioctlWriteI, uintptr(unsafe.Pointer(&xferi)))
+		if err != nil {
+			if errors.Is(err, syscall.EPIPE) {
+				// Underrun. Re-arm the device and try the
+				// remaining frames again.
+				if perr := b.ioctl(ioctlPrepare, 0); perr != nil {
+					return fmt.Errorf("ioctl-alsa: PREPARE after underrun: %w", perr)
+				}
+				continue
+			}
+			return fmt.Errorf("ioctl-alsa: WRITEI: %w", err)
+		}
+		if xferi.Result < 0 {
+			return fmt.Errorf("ioctl-alsa: WRITEI result %d", xferi.Result)
+		}
+		written += uint64(xferi.Result)
+	}
+	return nil
+}
+
+// Close drains the buffer and releases the fd.
+func (b *ioctlBackend) Close() error {
+	b.closeOnce.Do(func() {
+		_ = b.ioctl(ioctlDrain, 0)
+		b.closeErr = b.f.Close()
+	})
+	return b.closeErr
+}
+
+// ioctl is a thin wrapper around syscall.Syscall(SYS_IOCTL, ...).
+func (b *ioctlBackend) ioctl(req uintptr, arg uintptr) error {
+	_, _, errno := syscall.Syscall(syscall.SYS_IOCTL, b.f.Fd(), req, arg)
+	if errno != 0 {
+		return errno
+	}
+	return nil
+}

--- a/internal/voice/player/ioctl_linux_test.go
+++ b/internal/voice/player/ioctl_linux_test.go
@@ -1,0 +1,115 @@
+//go:build linux
+
+package player
+
+import (
+	"testing"
+	"unsafe"
+)
+
+func TestParseIoctlDevice(t *testing.T) {
+	cases := []struct {
+		name       string
+		in         string
+		wantCard   uint32
+		wantDevice uint32
+		wantErr    bool
+	}{
+		{"empty defaults to 0,0", "", 0, 0, false},
+		{"\"default\" defaults to 0,0", "default", 0, 0, false},
+		{"hw:0,0 explicit", "hw:0,0", 0, 0, false},
+		{"hw:1,0 second card", "hw:1,0", 1, 0, false},
+		{"hw:0,2 second device on card 0", "hw:0,2", 0, 2, false},
+		{"hw:2,3 card 2 device 3", "hw:2,3", 2, 3, false},
+		{"missing hw prefix fails", "0,0", 0, 0, true},
+		{"missing comma fails", "hw:0", 0, 0, true},
+		{"non-numeric card fails", "hw:a,0", 0, 0, true},
+		{"non-numeric device fails", "hw:0,a", 0, 0, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			card, device, err := parseIoctlDevice(tc.in)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("err = %v, want err? %v", err, tc.wantErr)
+			}
+			if !tc.wantErr {
+				if card != tc.wantCard || device != tc.wantDevice {
+					t.Errorf("got card=%d device=%d, want %d,%d",
+						card, device, tc.wantCard, tc.wantDevice)
+				}
+			}
+		})
+	}
+}
+
+// TestIoctlRequestEncoding pins the ioctl-number encoding against
+// the well-known kernel-published values for SNDRV_PCM_IOCTL_*.
+// The reference numbers come from the v6.x include/uapi/sound/asound.h
+// header; they're stable since libasound 1.0 and any drift here
+// would silently break audio on every Linux box.
+func TestIoctlRequestEncoding(t *testing.T) {
+	// _IO('A', 0x40) for PREPARE — no payload, so size = 0.
+	gotPrepare := ioctlRequest(_IOC_NONE, 'A', 0x40, 0)
+	const wantPrepare uintptr = 0x4140
+	if gotPrepare != wantPrepare {
+		t.Errorf("ioctlPrepare = 0x%x, want 0x%x", gotPrepare, wantPrepare)
+	}
+	// _IO('A', 0x42) for START.
+	gotStart := ioctlRequest(_IOC_NONE, 'A', 0x42, 0)
+	const wantStart uintptr = 0x4142
+	if gotStart != wantStart {
+		t.Errorf("ioctlStart = 0x%x, want 0x%x", gotStart, wantStart)
+	}
+	// _IO('A', 0x44) for DRAIN.
+	gotDrain := ioctlRequest(_IOC_NONE, 'A', 0x44, 0)
+	const wantDrain uintptr = 0x4144
+	if gotDrain != wantDrain {
+		t.Errorf("ioctlDrain = 0x%x, want 0x%x", gotDrain, wantDrain)
+	}
+}
+
+// TestSndPCMHwParamsSize pins the struct size against the kernel
+// UAPI layout. On 64-bit Linux the struct is 608 bytes — the
+// trailing fifo_size is unsigned long (8 bytes) requiring 8-byte
+// alignment, which inserts 4 bytes of padding after the prior
+// uint32 fields. On 32-bit Linux it would be 604 bytes (no
+// padding); we'd need a separate constant + build tag for that.
+//
+// The ioctl number encoding embeds this size — if our Go struct
+// drifts vs. the kernel's, HW_PARAMS calls return -ENOTTY
+// because the kernel checks the embedded size.
+func TestSndPCMHwParamsSize(t *testing.T) {
+	const wantSize64 = 608
+	got := unsafe.Sizeof(sndPCMHwParams{})
+	if got != wantSize64 {
+		t.Errorf("sizeof(sndPCMHwParams) = %d, want %d (64-bit Linux UAPI)", got, wantSize64)
+	}
+}
+
+// TestSndMaskSize: 256-bit mask packed into 8 uint32s = 32 bytes.
+func TestSndMaskSize(t *testing.T) {
+	if got, want := unsafe.Sizeof(sndMask{}), uintptr(32); got != want {
+		t.Errorf("sizeof(sndMask) = %d, want %d", got, want)
+	}
+}
+
+// TestSndIntervalSize: 3 uint32 fields = 12 bytes.
+func TestSndIntervalSize(t *testing.T) {
+	if got, want := unsafe.Sizeof(sndInterval{}), uintptr(12); got != want {
+		t.Errorf("sizeof(sndInterval) = %d, want %d", got, want)
+	}
+}
+
+// TestNewIoctlALSABackend_NoDevice confirms the constructor returns
+// an error (rather than panicking) when /dev/snd/pcmC*D*p is
+// missing. On a CI runner without a sound card the kernel sound
+// subsystem isn't loaded and the path doesn't exist; the daemon's
+// Player.New wraps this in a degraded "null player" fallback.
+func TestNewIoctlALSABackend_NoDevice(t *testing.T) {
+	// Pick a card / device combination that's basically guaranteed
+	// not to exist on a CI runner. 99 ought to do it.
+	_, err := newIoctlALSABackend(Config{SampleRate: 8000}, "hw:99,99")
+	if err == nil {
+		t.Skip("hw:99,99 unexpectedly exists; can't test the no-device path here")
+	}
+}


### PR DESCRIPTION
## Summary

Adds a no-runtime-dep ALSA backend selected by `audio.device: "ioctl"` (or `"ioctl:hw:C,D"` for a specific card / device). The backend opens `/dev/snd/pcmC{card}D{device}p` and drives the playback state machine via `SNDRV_PCM_IOCTL_*` syscalls — no `libasound2.so.2`, no `purego.Dlopen`, no cgo.

Useful for distroless / Alpine / scratch container images that don't ship the userspace library but do have the kernel sound subsystem. Closes the Workstream F follow-up flagged in the plan ("Direct-ioctl alternative to drop the runtime libasound2 dep entirely").

The dlopen path stays the Linux default because it auto-negotiates format / rate / period with the hardware; the ioctl path uses pinned values (S16_LE mono at `audio.sample_rate`, period from `audio.buffer_ms`) so it only works when the underlying device natively supports them. Operators opt in by setting `audio.device`.

## Struct layout (pinned by tests)

- `sndPCMHwParams`: 608 bytes (8-byte `fifo_size` requires 8-byte alignment, adding 4 bytes of padding on 64-bit Linux).
- `sndMask`: 256-bit mask packed into 8 uint32 = 32 bytes.
- `sndInterval`: 3 uint32 = 12 bytes.

## State machine

- `HW_PARAMS` pins access = `RW_INTERLEAVED`, format = `S16_LE`, subformat = `STD`, channels = 1, rate = `audio.sample_rate`, `period_size` = `rate * buffer_ms / 1000` (min 64), `buffer_size` = `2 * period_size`.
- `SW_PARAMS` sets `start_threshold` = period_size, `stop_threshold` = buffer_size, `boundary` = `1<<30`.
- `PREPARE` on open + `EPIPE` recovery in `Write`.
- `WRITEI` loop until all frames consumed; partial writes are re-attempted.
- `DRAIN` on `Close`.

## Tests

**4 new tests:**
- `TestParseIoctlDevice` — covers `""`, `"default"`, `"hw:0,0"`, `"hw:1,0"`, `"hw:0,2"`, `"hw:2,3"`, and 4 malformed cases.
- `TestIoctlRequestEncoding` — pins the bit layout of three no-payload ioctl numbers (`PREPARE=0x4140`, `START=0x4142`, `DRAIN=0x4144`) against the kernel UAPI.
- `TestSndPCMHwParamsSize` / `TestSndMaskSize` / `TestSndIntervalSize` — pin struct sizes.
- `TestNewIoctlALSABackend_NoDevice` — confirms the constructor returns an error (not a panic) when `/dev/snd/pcmC99D99p` doesn't exist.

`config.example.yaml` documents the new device-name option.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -short ./...` all green (the new tests + all existing player tests)
- [ ] Manual smoke (Linux desktop): set `audio.enabled: true` + `audio.device: ioctl` and confirm decoded calls play out the default sound card.
- [ ] Manual headless: `audio.device: ioctl` with no sound card present returns an error from the backend factory; `Player.New` falls back to the null player and the daemon keeps running.
- [ ] Container smoke: build an Alpine image with NO `alpine-baselayout` / `alsa-lib` package and confirm `gophertrunk run` with `audio.device: ioctl` plays audio through the kernel sound subsystem alone.

https://claude.ai/code/session_01FYBcR9CAiGws74GiqffTkd

---
_Generated by [Claude Code](https://claude.ai/code/session_01FYBcR9CAiGws74GiqffTkd)_