### PR TITLE
tui: first-class operator console with full feature touch-points

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ TAGS    ?=
 GO      ?= go
 PKGS    := ./...
 
-.PHONY: all build test integration integration-cc integration-cc-grant integration-cc-nxdn integration-cc-dmr integration-cc-dpmr integration-cc-edacs integration-cc-motorola integration-cc-tetra integration-cc-p25p2 integration-cc-mpt1327 integration-cc-ltr integration-cc-ysf lint tidy vet clean run proto
+.PHONY: all build test integration integration-cc integration-cc-grant integration-cc-nxdn integration-cc-dmr integration-cc-dpmr integration-cc-edacs integration-cc-motorola integration-cc-tetra integration-cc-p25p2 integration-cc-mpt1327 integration-cc-ltr integration-cc-ysf lint tidy vet clean run proto cross-build release-archives
 
 all: build
 
@@ -136,6 +136,40 @@ lint: vet
 
 tidy:
 	$(GO) mod tidy
+
+# cross-build produces a static, dependency-free binary for every
+# common (OS, arch) pair the daemon supports. CGO_ENABLED=0 is safe:
+# the project uses purego for every system FFI (ALSA / WASAPI /
+# CoreAudio / IOKit / WinUSB) and modernc.org/sqlite for the call
+# log, so no cgo is required. Each output lands under dist/.
+GOOSES   ?= linux darwin windows
+GOARCHES ?= amd64 arm64
+
+cross-build:
+	@mkdir -p dist
+	@for os in $(GOOSES); do \
+	    for arch in $(GOARCHES); do \
+	        ext=""; [ "$$os" = "windows" ] && ext=".exe"; \
+	        echo "  → CGO_ENABLED=0 GOOS=$$os GOARCH=$$arch"; \
+	        CGO_ENABLED=0 GOOS=$$os GOARCH=$$arch \
+	            $(GO) build -tags "$(TAGS)" -ldflags "$(LDFLAGS)" \
+	            -o dist/gophertrunk-$$os-$$arch$$ext ./cmd/gophertrunk || exit 1; \
+	    done; \
+	done
+	@ls -lh dist/
+
+# release-archives wraps the cross-build outputs in per-target
+# tarballs (linux/darwin) and zips (windows). Run `make cross-build`
+# first, or chain: `make cross-build release-archives`.
+release-archives:
+	@command -v zip >/dev/null || { echo "zip not installed"; exit 1; }
+	@cd dist && for f in gophertrunk-*; do \
+	    case "$$f" in \
+	        *windows*) zip -q $${f%.exe}.zip $$f ;; \
+	        *) tar czf $$f.tar.gz $$f ;; \
+	    esac; \
+	done
+	@ls -lh dist/
 
 clean:
 	rm -rf bin/ dist/

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -498,6 +498,12 @@ func NewDaemon(cfg config.Config, version string, log *slog.Logger) (*Daemon, er
 		if d.player != nil || d.recorder != nil {
 			opts.Audio = audioCockpit{player: d.player, recorder: d.recorder}
 		}
+		cfgCopy := cfg
+		opts.Runtime = &runtimeSnapshot{
+			cfg:     &cfgCopy,
+			version: version,
+			metrics: cfg.Metrics.Enabled,
+		}
 		srv, err := api.NewServer(opts)
 		if err != nil {
 			return nil, fmt.Errorf("daemon: http api: %w", err)

--- a/cmd/gophertrunk/runtime.go
+++ b/cmd/gophertrunk/runtime.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/api"
+	"github.com/MattCheramie/GopherTrunk/internal/config"
+	"github.com/MattCheramie/GopherTrunk/internal/sdr"
+	"github.com/MattCheramie/GopherTrunk/internal/voice/player"
+)
+
+// runtimeSnapshot wraps the daemon config + a few process-global
+// registries into the api.RuntimeProvider shape. The DTO is rebuilt
+// on every /api/v1/runtime call since the daemon config is immutable
+// at runtime; cost is a handful of slice allocs.
+type runtimeSnapshot struct {
+	cfg     *config.Config
+	version string
+	metrics bool
+}
+
+// vocoderProtocolMap is the canonical mapping the daemon hands to
+// each protocol's voice decoder at construction time. Surfaced here
+// so the TUI's Vocoders tab matches what the engine actually loads.
+// Keep in sync with the per-protocol pipeline factories in
+// internal/radio/*/pipeline.go.
+var vocoderProtocolMap = map[string]string{
+	"p25":         "imbe",
+	"p25-phase2":  "ambe2",
+	"dmr":         "ambe2",
+	"nxdn":        "ambe2",
+	"dpmr":        "ambe2",
+	"tetra":       "ambe2",
+	"ysf":         "ambe2",
+	"edacs":       "ambe2",
+	"motorola":    "—",
+	"ltr":         "—",
+	"mpt1327":     "—",
+}
+
+func (r *runtimeSnapshot) Runtime() api.RuntimeDTO {
+	cfg := r.cfg
+	dto := api.RuntimeDTO{
+		HTTPAddr:       cfg.API.HTTPAddr,
+		GRPCAddr:       cfg.API.GRPCAddr,
+		AllowMutations: cfg.API.AllowMutations,
+		LogLevel:       cfg.Log.Level,
+		LogFormat:      cfg.Log.Format,
+		Version:        r.version,
+
+		StorageDBPath:  cfg.Storage.Path,
+		StorageCCCache: cfg.Storage.CCCacheFile,
+
+		RetentionCallLogDays: cfg.Retention.CallLogDays,
+		RetentionFilesDays:   cfg.Retention.FilesDays,
+
+		RecordingDir:        cfg.Recordings.Dir,
+		RecordingSampleRate: int(cfg.Recordings.SampleRate),
+		RecordingWriteRaw:   cfg.Recordings.WriteRaw,
+		RecordingEQEnabled:  cfg.Recordings.Equalizer.Enabled,
+		RecordingEQTaps:     cfg.Recordings.Equalizer.Taps,
+
+		AudioEnabled:    cfg.Audio.Enabled,
+		AudioDevice:     cfg.Audio.Device,
+		AudioSampleRate: int(cfg.Audio.SampleRate),
+		AudioBufferMs:   cfg.Audio.BufferMs,
+		AudioBackends:   player.ListDevices(),
+
+		SDRSampleRate: int(cfg.SDR.SampleRate),
+		SDRBackends:   sdrBackendNames(),
+
+		ScannerScanMode:          cfg.Scanner.ScanMode,
+		ScannerCCHuntEnabled:     cfg.Scanner.CCHunt.Enabled,
+		ScannerCCHuntDwellMs:     cfg.Scanner.CCHunt.DwellMs,
+		ScannerCCHuntBackoffMs:   cfg.Scanner.CCHunt.BackoffMs,
+		ScannerCCMaxBackoffMs:    cfg.Scanner.CCHunt.MaxBackoffMs,
+		ScannerManualTuneEnabled: cfg.Scanner.ManualTuneEnabled,
+
+		MetricsEnabled: r.metrics,
+		VocoderMap:     vocoderProtocolMap,
+	}
+	if cfg.Recordings.Equalizer.StepSize != 0 {
+		dto.RecordingEQStepSize = formatFloat(float64(cfg.Recordings.Equalizer.StepSize))
+	}
+	if d, err := time.ParseDuration(cfg.Retention.Interval); err == nil {
+		dto.RetentionInterval = d
+	}
+	for _, prof := range cfg.ToneOut.Profiles {
+		cooldown, _ := time.ParseDuration(prof.Cooldown)
+		dto.ToneProfiles = append(dto.ToneProfiles, api.ToneProfileDTO{
+			Name:      prof.Name,
+			AlphaTag:  prof.AlphaTag,
+			Cooldown:  cooldown,
+			ToneCount: len(prof.Tones),
+		})
+	}
+	return dto
+}
+
+func sdrBackendNames() []string {
+	drivers := sdr.Drivers()
+	out := make([]string, 0, len(drivers))
+	for _, d := range drivers {
+		out = append(out, d.Name())
+	}
+	return out
+}
+
+// formatFloat is a tiny helper to avoid pulling strconv into the API
+// DTO encoding path. 6 significant digits is enough for step_size
+// constants like 1e-4.
+func formatFloat(v float64) string {
+	// We deliberately go via fmt — strconv has no shorthand for "drop
+	// trailing zeroes" without going through ParseFloat round-trips.
+	const eps = 1e-12
+	s := ""
+	switch {
+	case v == 0:
+		return "0"
+	case v < eps:
+		s = fmt.Sprintf("%g", v)
+	default:
+		s = fmt.Sprintf("%g", v)
+	}
+	return s
+}

--- a/internal/api/handlers_runtime.go
+++ b/internal/api/handlers_runtime.go
@@ -1,0 +1,100 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+)
+
+// RuntimeDTO is the sanitised, JSON-friendly snapshot of every config
+// knob + runtime fact the TUI's tabbed Settings inspector renders.
+// Keep this strictly read-only — no secrets, no credentials, no
+// auth tokens. Operators expect /api/v1/runtime to be safe to scrape.
+type RuntimeDTO struct {
+	// API listener addresses (empty when disabled).
+	HTTPAddr       string `json:"http_addr,omitempty"`
+	GRPCAddr       string `json:"grpc_addr,omitempty"`
+	WSPath         string `json:"ws_path,omitempty"`
+	SSEPath        string `json:"sse_path,omitempty"`
+	MetricsPath    string `json:"metrics_path,omitempty"`
+	AllowMutations bool   `json:"allow_mutations"`
+
+	// Daemon log + version.
+	LogLevel  string `json:"log_level"`
+	LogFormat string `json:"log_format"`
+	Version   string `json:"version,omitempty"`
+
+	// Storage paths (sanitised — paths only, never contents).
+	StorageDBPath  string `json:"storage_db_path,omitempty"`
+	StorageCCCache string `json:"storage_cc_cache,omitempty"`
+
+	// Retention windows.
+	RetentionCallLogDays int           `json:"retention_call_log_days"`
+	RetentionFilesDays   int           `json:"retention_files_days"`
+	RetentionInterval    time.Duration `json:"retention_interval_ns"`
+
+	// Recording config.
+	RecordingDir        string `json:"recording_dir,omitempty"`
+	RecordingSampleRate int    `json:"recording_sample_rate"`
+	RecordingWriteRaw   bool   `json:"recording_write_raw"`
+	RecordingEQEnabled  bool   `json:"recording_eq_enabled"`
+	RecordingEQTaps     int    `json:"recording_eq_taps,omitempty"`
+	RecordingEQStepSize string `json:"recording_eq_step_size,omitempty"`
+
+	// Audio runtime (mirrors AudioStatus but adds device list +
+	// backend identity so operators can confirm whether the Linux
+	// fallback path took effect).
+	AudioEnabled        bool     `json:"audio_enabled"`
+	AudioDevice         string   `json:"audio_device,omitempty"`
+	AudioSampleRate     int      `json:"audio_sample_rate"`
+	AudioBufferMs       int      `json:"audio_buffer_ms"`
+	AudioBackends       []string `json:"audio_backends"`
+	AudioDisableFallbk  bool     `json:"audio_disable_fallback"`
+
+	// SDR pool config (the live status is on /api/v1/devices).
+	SDRSampleRate int      `json:"sdr_sample_rate"`
+	SDRBackends   []string `json:"sdr_backends"`
+
+	// Scanner config (the live state is on /api/v1/scanner).
+	ScannerScanMode          string `json:"scanner_scan_mode"`
+	ScannerCCHuntEnabled     bool   `json:"scanner_cc_hunt_enabled"`
+	ScannerCCHuntDwellMs     int    `json:"scanner_cc_hunt_dwell_ms"`
+	ScannerCCHuntBackoffMs   int    `json:"scanner_cc_hunt_backoff_ms"`
+	ScannerCCMaxBackoffMs    int    `json:"scanner_cc_max_backoff_ms"`
+	ScannerManualTuneEnabled bool   `json:"scanner_manual_tune_enabled"`
+
+	// Tone-out profiles (names only, plus tone counts + cooldown).
+	ToneProfiles []ToneProfileDTO `json:"tone_profiles,omitempty"`
+
+	// Vocoder map by protocol — operator-facing names like
+	// "p25-phase2" → "ambe2".
+	VocoderMap map[string]string `json:"vocoder_map"`
+
+	// MetricsEnabled mirrors metrics.enabled config.
+	MetricsEnabled bool `json:"metrics_enabled"`
+}
+
+// ToneProfileDTO is the minimal projection of a tone-out profile —
+// no internal detector state, just the operator-relevant fields.
+type ToneProfileDTO struct {
+	Name      string        `json:"name"`
+	AlphaTag  string        `json:"alpha_tag,omitempty"`
+	Cooldown  time.Duration `json:"cooldown_ns"`
+	ToneCount int           `json:"tone_count"`
+}
+
+// RuntimeProvider returns the runtime snapshot. The daemon supplies
+// the production impl; tests supply a fake. Optional on ServerOptions —
+// when nil, GET /api/v1/runtime returns 503.
+type RuntimeProvider interface {
+	Runtime() RuntimeDTO
+}
+
+func (s *Server) handleRuntime(w http.ResponseWriter, _ *http.Request) {
+	if s.runtime == nil {
+		http.Error(w, "runtime snapshot unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(s.runtime.Runtime())
+}

--- a/internal/api/handlers_runtime_test.go
+++ b/internal/api/handlers_runtime_test.go
@@ -1,0 +1,74 @@
+package api
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+)
+
+type fakeRuntime struct{ dto RuntimeDTO }
+
+func (f fakeRuntime) Runtime() RuntimeDTO { return f.dto }
+
+func TestHandleRuntime_503WhenNotConfigured(t *testing.T) {
+	bus := events.NewBus(8)
+	s, err := NewServer(ServerOptions{
+		Addr: ":0",
+		Bus:  bus,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/runtime", nil)
+	s.handleRuntime(rr, req)
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Errorf("got %d, want 503", rr.Code)
+	}
+}
+
+func TestHandleRuntime_ServesDTO(t *testing.T) {
+	bus := events.NewBus(8)
+	fake := fakeRuntime{dto: RuntimeDTO{
+		HTTPAddr:          "127.0.0.1:8080",
+		AllowMutations:    true,
+		LogLevel:          "info",
+		LogFormat:         "text",
+		Version:           "v0.0-test",
+		AudioEnabled:      true,
+		AudioDevice:       "default",
+		AudioSampleRate:   8000,
+		AudioBackends:     []string{"default", "null"},
+		RetentionInterval: 1 * time.Hour,
+		VocoderMap:        map[string]string{"p25": "imbe"},
+	}}
+	s, err := NewServer(ServerOptions{Addr: ":0", Bus: bus, Runtime: fake})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/runtime", nil)
+	s.handleRuntime(rr, req)
+	if rr.Code != http.StatusOK {
+		body, _ := io.ReadAll(rr.Body)
+		t.Fatalf("got %d, want 200: %s", rr.Code, body)
+	}
+	var out RuntimeDTO
+	if err := json.NewDecoder(rr.Body).Decode(&out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if out.HTTPAddr != fake.dto.HTTPAddr {
+		t.Errorf("HTTPAddr = %q, want %q", out.HTTPAddr, fake.dto.HTTPAddr)
+	}
+	if out.VocoderMap["p25"] != "imbe" {
+		t.Errorf("vocoder map round-trip lost data: %v", out.VocoderMap)
+	}
+	if out.RetentionInterval != fake.dto.RetentionInterval {
+		t.Errorf("retention interval lost: got %v want %v", out.RetentionInterval, fake.dto.RetentionInterval)
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -202,6 +202,7 @@ type Server struct {
 	devices    DevicesProvider
 	scanner    ScannerCockpit
 	audio      AudioController
+	runtime    RuntimeProvider
 	talkgroups *trunking.TalkgroupDB
 	systems    []trunking.System
 	history    HistoryQuery
@@ -299,6 +300,11 @@ type ServerOptions struct {
 	// GET + PATCH /api/v1/audio. Optional; when nil, the routes
 	// return 503.
 	Audio AudioController
+	// Runtime exposes the read-only daemon config snapshot served at
+	// GET /api/v1/runtime. The TUI's tabbed Settings inspector uses
+	// it to surface every config knob. Optional; when nil, the
+	// route returns 503.
+	Runtime RuntimeProvider
 }
 
 // NewServer constructs a server but does not yet bind a listener; call
@@ -327,6 +333,7 @@ func NewServer(opts ServerOptions) (*Server, error) {
 		devices:        opts.Devices,
 		scanner:        opts.Scanner,
 		audio:          opts.Audio,
+		runtime:        opts.Runtime,
 		talkgroups:     opts.Talkgroups,
 		systems:        append([]trunking.System(nil), opts.Systems...),
 		history:        opts.History,
@@ -390,6 +397,7 @@ func (s *Server) shutdown(ctx context.Context) error {
 func (s *Server) routes() *http.ServeMux {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /api/v1/health", s.handleHealth)
+	mux.HandleFunc("GET /api/v1/runtime", s.handleRuntime)
 	mux.HandleFunc("GET /api/v1/version", s.handleVersion)
 	mux.HandleFunc("GET /api/v1/systems", s.handleListSystems)
 	mux.HandleFunc("GET /api/v1/systems/{name}", s.handleGetSystem)

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -47,6 +47,12 @@ type Model struct {
 
 	confirm *confirmModal
 	detail  *detailModal
+	palette *paletteModel
+
+	// tabRects caches the bounding boxes of each tab in the most
+	// recently rendered tab strip. Mouse hit-testing reads it to map
+	// a click to a panel.
+	tabRects []tabRect
 
 	historyLoaded bool
 	toastUntil    time.Time
@@ -62,12 +68,13 @@ func New(cli *client.Client, opts Options) *Model {
 		Metrics:    map[string]float64{},
 	}
 	m := &Model{
-		cli:    cli,
-		opts:   opts,
-		styles: st,
-		keys:   newGlobalKeys(),
-		help:   help.New(),
-		shared: shared,
+		cli:     cli,
+		opts:    opts,
+		styles:  st,
+		keys:    newGlobalKeys(),
+		help:    help.New(),
+		shared:  shared,
+		palette: newPalette(),
 		panels: []panels.Panel{
 			panels.NewDashboard(),
 			panels.NewSystems(),
@@ -98,6 +105,7 @@ func (m *Model) Init() tea.Cmd {
 		cmdPollDevices(m.cli),
 		cmdPollScanner(m.cli),
 		cmdPollAudio(m.cli),
+		cmdPollRuntime(m.cli),
 		cmdMutationStatus(m.cli),
 		connectSSE(m.cli),
 	)
@@ -118,7 +126,28 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
 		m.height = msg.Height
+	case tea.MouseMsg:
+		if cmd, consumed := m.handleMouseMsg(msg); consumed {
+			return m, cmd
+		}
 	case tea.KeyMsg:
+		// Palette captures keys when open. Always evaluated first so
+		// the operator can dismiss/run actions even from inside a
+		// modal-less state.
+		if m.palette != nil && m.palette.open {
+			if cmd := m.handlePaletteKey(msg); cmd != nil {
+				return m, cmd
+			}
+			return m, nil
+		}
+		// Help overlay captures keys when open. ? or esc closes.
+		if m.help.ShowAll {
+			switch msg.String() {
+			case "?", "esc", "q":
+				m.help.ShowAll = false
+			}
+			return m, nil
+		}
 		// Modal capture: when a confirmation is pending, every key
 		// goes to the modal — global nav and panels are frozen.
 		if m.confirm != nil {
@@ -153,6 +182,9 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Quit
 		case key.Matches(msg, m.keys.Help):
 			m.help.ShowAll = !m.help.ShowAll
+			return m, nil
+		case key.Matches(msg, m.keys.Palette):
+			m.openPalette()
 			return m, nil
 		case key.Matches(msg, m.keys.NextPanel):
 			m.active = (m.active + 1) % state.PanelCount
@@ -254,6 +286,13 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.shared.AudioErr = msg.err
 		cmds = append(cmds, scheduleAfter(pollAudioEvery, cmdPollAudio(m.cli)))
+
+	case pollRuntimeMsg:
+		if msg.err == nil {
+			m.shared.Runtime = msg.r
+		}
+		m.shared.RuntimeErr = msg.err
+		cmds = append(cmds, scheduleAfter(pollRuntimeEvery, cmdPollRuntime(m.cli)))
 
 	case pollHistoryMsg:
 		m.shared.History = msg.rows
@@ -400,15 +439,64 @@ func (m *Model) View() string {
 }
 
 func (m *Model) renderTabs() string {
-	parts := make([]string, 0, state.PanelCount)
+	// Build the full label set first so we can decide if we need to
+	// collapse for narrow terminals.
+	labels := make([]string, state.PanelCount)
 	for i := state.PanelKind(0); i < state.PanelCount; i++ {
-		label := fmt.Sprintf("%d %s", int(i)+1, m.panels[i].Title())
-		if i == m.active {
-			parts = append(parts, m.styles.activeTab.Render(label))
-		} else {
-			parts = append(parts, m.styles.tab.Render(label))
-		}
+		labels[i] = fmt.Sprintf("%d %s", int(i)+1, m.panels[i].Title())
 	}
+	// Estimate width: each tab gets 2 padding cells + label runes + 1 separator.
+	full := 0
+	for _, l := range labels {
+		full += lipgloss.Width(l) + 3
+	}
+	// Below the natural width, switch to compact mode: render the
+	// active tab fully + the panel index sequence "1·2·3·…" with the
+	// active index inverted, plus a "more" pill that opens the
+	// palette filtered to panel jumps.
+	if m.width > 0 && full > m.width {
+		return m.renderCompactTabs(labels)
+	}
+	parts := make([]string, 0, state.PanelCount)
+	rects := make([]tabRect, 0, state.PanelCount)
+	x := 0
+	for i := state.PanelKind(0); i < state.PanelCount; i++ {
+		var rendered string
+		if i == m.active {
+			rendered = m.styles.activeTab.Render(labels[i])
+		} else {
+			rendered = m.styles.tab.Render(labels[i])
+		}
+		parts = append(parts, rendered)
+		w := lipgloss.Width(rendered)
+		rects = append(rects, tabRect{kind: i, xStart: x, xEnd: x + w})
+		x += w + 1 // +1 for the separator space
+	}
+	m.tabRects = rects
+	return strings.Join(parts, " ")
+}
+
+// renderCompactTabs is the narrow-terminal fallback: a strip of
+// numeric indices ("1 2 3 …") with the active one labelled fully, and
+// a trailing "more" pill that points the operator at ctrl+p.
+func (m *Model) renderCompactTabs(labels []string) string {
+	parts := make([]string, 0, state.PanelCount+1)
+	rects := make([]tabRect, 0, state.PanelCount)
+	x := 0
+	for i := state.PanelKind(0); i < state.PanelCount; i++ {
+		var rendered string
+		if i == m.active {
+			rendered = m.styles.activeTab.Render(labels[i])
+		} else {
+			rendered = m.styles.tab.Render(fmt.Sprintf("%d", int(i)+1))
+		}
+		parts = append(parts, rendered)
+		w := lipgloss.Width(rendered)
+		rects = append(rects, tabRect{kind: i, xStart: x, xEnd: x + w})
+		x += w + 1
+	}
+	m.tabRects = rects
+	parts = append(parts, m.styles.help.Render("⌃P more"))
 	return strings.Join(parts, " ")
 }
 
@@ -423,7 +511,7 @@ func (m *Model) renderStatusBar() string {
 		len(m.shared.ActiveCalls),
 		m.shared.EventLog.Len(),
 		m.shared.ToneAlerts.Len())
-	help := m.styles.help.Render("tab:next  ?:help  q:quit")
+	help := m.styles.help.Render("tab:next  ⌃P:cmd  ?:help  q:quit")
 	toast := ""
 	if m.shared.Toast != "" && time.Now().Before(m.toastUntil) {
 		toast = m.styles.toast.Render(m.shared.Toast)

--- a/internal/tui/client/client.go
+++ b/internal/tui/client/client.go
@@ -61,6 +61,13 @@ func (c *Client) Health(ctx context.Context) (Health, error) {
 	return h, c.getJSON(ctx, "/api/v1/health", &h)
 }
 
+// Runtime calls GET /api/v1/runtime — the read-only daemon config
+// snapshot consumed by the TUI's tabbed Settings inspector.
+func (c *Client) Runtime(ctx context.Context) (RuntimeDTO, error) {
+	var r RuntimeDTO
+	return r, c.getJSON(ctx, "/api/v1/runtime", &r)
+}
+
 // Version calls GET /api/v1/version.
 func (c *Client) Version(ctx context.Context) (string, error) {
 	var v Version

--- a/internal/tui/client/types.go
+++ b/internal/tui/client/types.go
@@ -218,6 +218,67 @@ type LockState struct {
 // HTTPError is returned by the REST methods on a non-2xx response.
 // Status carries the HTTP code; Body carries up to a few hundred
 // bytes of the response for the toast UI to show.
+// RuntimeDTO mirrors api.RuntimeDTO. Consumed by the TUI's tabbed
+// Settings inspector to render every configured feature, output,
+// protocol surface, etc. — the touch-point inventory the operator
+// expects to see in one place.
+type RuntimeDTO struct {
+	HTTPAddr       string `json:"http_addr,omitempty"`
+	GRPCAddr       string `json:"grpc_addr,omitempty"`
+	WSPath         string `json:"ws_path,omitempty"`
+	SSEPath        string `json:"sse_path,omitempty"`
+	MetricsPath    string `json:"metrics_path,omitempty"`
+	AllowMutations bool   `json:"allow_mutations"`
+
+	LogLevel  string `json:"log_level"`
+	LogFormat string `json:"log_format"`
+	Version   string `json:"version,omitempty"`
+
+	StorageDBPath  string `json:"storage_db_path,omitempty"`
+	StorageCCCache string `json:"storage_cc_cache,omitempty"`
+
+	RetentionCallLogDays int           `json:"retention_call_log_days"`
+	RetentionFilesDays   int           `json:"retention_files_days"`
+	RetentionInterval    time.Duration `json:"retention_interval_ns"`
+
+	RecordingDir        string `json:"recording_dir,omitempty"`
+	RecordingSampleRate int    `json:"recording_sample_rate"`
+	RecordingWriteRaw   bool   `json:"recording_write_raw"`
+	RecordingEQEnabled  bool   `json:"recording_eq_enabled"`
+	RecordingEQTaps     int    `json:"recording_eq_taps,omitempty"`
+	RecordingEQStepSize string `json:"recording_eq_step_size,omitempty"`
+
+	AudioEnabled       bool     `json:"audio_enabled"`
+	AudioDevice        string   `json:"audio_device,omitempty"`
+	AudioSampleRate    int      `json:"audio_sample_rate"`
+	AudioBufferMs      int      `json:"audio_buffer_ms"`
+	AudioBackends      []string `json:"audio_backends"`
+	AudioDisableFallbk bool     `json:"audio_disable_fallback"`
+
+	SDRSampleRate int      `json:"sdr_sample_rate"`
+	SDRBackends   []string `json:"sdr_backends"`
+
+	ScannerScanMode          string `json:"scanner_scan_mode"`
+	ScannerCCHuntEnabled     bool   `json:"scanner_cc_hunt_enabled"`
+	ScannerCCHuntDwellMs     int    `json:"scanner_cc_hunt_dwell_ms"`
+	ScannerCCHuntBackoffMs   int    `json:"scanner_cc_hunt_backoff_ms"`
+	ScannerCCMaxBackoffMs    int    `json:"scanner_cc_max_backoff_ms"`
+	ScannerManualTuneEnabled bool   `json:"scanner_manual_tune_enabled"`
+
+	ToneProfiles []ToneProfileDTO `json:"tone_profiles,omitempty"`
+
+	VocoderMap     map[string]string `json:"vocoder_map"`
+	MetricsEnabled bool              `json:"metrics_enabled"`
+}
+
+// ToneProfileDTO mirrors api.ToneProfileDTO.
+type ToneProfileDTO struct {
+	Name      string        `json:"name"`
+	AlphaTag  string        `json:"alpha_tag,omitempty"`
+	Cooldown  time.Duration `json:"cooldown_ns"`
+	ToneCount int           `json:"tone_count"`
+}
+
 type HTTPError struct {
 	Status int
 	Method string

--- a/internal/tui/cmds.go
+++ b/internal/tui/cmds.go
@@ -20,6 +20,7 @@ const (
 	pollDevicesEvery    = 10 * time.Second
 	pollScannerEvery    = 2 * time.Second
 	pollAudioEvery      = 3 * time.Second
+	pollRuntimeEvery    = 30 * time.Second
 )
 
 func cmdPollHealth(cli *client.Client) tea.Cmd {
@@ -132,6 +133,17 @@ func cmdScannerConvUnlockout(cli *client.Client, idx int, label string) tea.Cmd 
 	return func() tea.Msg {
 		err := cli.ScannerConvUnlockout(context.Background(), idx)
 		return writeResultMsg{Label: label, Err: err}
+	}
+}
+
+// cmdPollRuntime fetches the daemon's read-only runtime snapshot
+// — config knobs, output paths, audio device list, etc. Polled
+// every 30s since none of these mutate at runtime; rebuilding the
+// Settings panel cells more often would just burn CPU.
+func cmdPollRuntime(cli *client.Client) tea.Cmd {
+	return func() tea.Msg {
+		r, err := cli.Runtime(context.Background())
+		return pollRuntimeMsg{r: r, err: err}
 	}
 }
 

--- a/internal/tui/help.go
+++ b/internal/tui/help.go
@@ -1,0 +1,90 @@
+package tui
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/bubbles/key"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/MattCheramie/GopherTrunk/internal/tui/state"
+	"github.com/MattCheramie/GopherTrunk/internal/tui/theme"
+)
+
+// renderHelpOverlay draws the full keybinding card the operator
+// sees on `?`. Two columns: "Global" from the root model's
+// globalKeys, "Panel" from the active panel's Keys(). Bottom strip
+// repeats the universal escape hatch ("? to close").
+func (m *Model) renderHelpOverlay(width, height int, behind string) string {
+	p := theme.Theme()
+	header := p.Title().Render("Keyboard reference")
+
+	globalCol := renderHelpColumn("Global", m.keys.helpEntries())
+	panelKeys := m.panels[m.active].Keys()
+	panelCol := renderHelpColumn(m.panels[m.active].Title(), keyEntriesFromBindings(panelKeys))
+
+	cols := lipgloss.JoinHorizontal(lipgloss.Top, globalCol, "    ", panelCol)
+	footer := p.Hint().Render("? to close")
+
+	box := p.ModalBox("info").Render(header + "\n\n" + cols + "\n\n" + footer)
+	return lipgloss.Place(width, height,
+		lipgloss.Center, lipgloss.Center,
+		box,
+		lipgloss.WithWhitespaceChars(" "),
+		lipgloss.WithWhitespaceForeground(p.BgAlt),
+	)
+}
+
+type helpEntry struct{ key, desc string }
+
+func renderHelpColumn(title string, entries []helpEntry) string {
+	p := theme.Theme()
+	if len(entries) == 0 {
+		return p.Header().Render(title) + "\n" + p.Hint().Render("  (no keys)")
+	}
+	maxK := 0
+	for _, e := range entries {
+		if l := len([]rune(e.key)); l > maxK {
+			maxK = l
+		}
+	}
+	var b strings.Builder
+	b.WriteString(p.Header().Render(title) + "\n")
+	for _, e := range entries {
+		k := e.key + strings.Repeat(" ", maxK-len([]rune(e.key)))
+		b.WriteString("  " + p.Accented().Render(k) + "  " + e.desc + "\n")
+	}
+	return b.String()
+}
+
+func keyEntriesFromBindings(bs []key.Binding) []helpEntry {
+	out := make([]helpEntry, 0, len(bs))
+	for _, b := range bs {
+		h := b.Help()
+		out = append(out, helpEntry{key: h.Key, desc: h.Desc})
+	}
+	return out
+}
+
+// helpEntries lists every global binding the operator can fire from
+// the root model. Order matches the natural keyboard scan: nav first,
+// then jumps, then commands.
+func (k globalKeys) helpEntries() []helpEntry {
+	return []helpEntry{
+		{"tab", "next panel"},
+		{"shift+tab", "prev panel"},
+		{"1-9, 0", "jump to panel by index"},
+		{"ctrl+p", "command palette"},
+		{"?", "toggle help"},
+		{"r", "refresh"},
+		{"q / ctrl+c", "quit"},
+	}
+}
+
+// activeHelp is true when the help overlay is currently up. Used by
+// activeModal() so the help overlay takes input precedence.
+func (m *Model) helpVisible() bool { return m.help.ShowAll }
+
+// helpKindMatches catches whether a key event is what activates the
+// help overlay. Exposed so the centralized Update routing can flip
+// state.
+func (m *Model) helpKindMatches(_ state.PanelKind) bool { return false }

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -20,6 +20,7 @@ type globalKeys struct {
 	JumpPanel9 key.Binding
 	JumpPanel0 key.Binding
 	Refresh    key.Binding
+	Palette    key.Binding
 }
 
 func newGlobalKeys() globalKeys {
@@ -39,6 +40,7 @@ func newGlobalKeys() globalKeys {
 		JumpPanel9: key.NewBinding(key.WithKeys("9"), key.WithHelp("9", "devices")),
 		JumpPanel0: key.NewBinding(key.WithKeys("0"), key.WithHelp("0", "scanner")),
 		Refresh:    key.NewBinding(key.WithKeys("r"), key.WithHelp("r", "refresh")),
+		Palette:    key.NewBinding(key.WithKeys("ctrl+p"), key.WithHelp("ctrl+p", "command palette")),
 	}
 }
 

--- a/internal/tui/modal.go
+++ b/internal/tui/modal.go
@@ -7,6 +7,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 
 	"github.com/MattCheramie/GopherTrunk/internal/tui/state"
+	"github.com/MattCheramie/GopherTrunk/internal/tui/theme"
 )
 
 // confirmModal is the modal overlay shown when a panel issues a
@@ -26,8 +27,12 @@ type detailModal struct {
 	body  string
 }
 
-// activeModal returns true when any modal (confirm or detail) is up.
-func (m *Model) activeModal() bool { return m.confirm != nil || m.detail != nil }
+// activeModal returns true when any modal (confirm / detail /
+// palette / help) is up.
+func (m *Model) activeModal() bool {
+	return m.confirm != nil || m.detail != nil ||
+		(m.palette != nil && m.palette.open) || m.help.ShowAll
+}
 
 // requestConfirm stores the request and triggers the modal overlay,
 // or runs the request immediately when Confirm is empty.
@@ -56,48 +61,42 @@ func (m *Model) renderModal(width, height int, behind string) string {
 	if m.detail != nil {
 		return m.renderDetailModal(width, height, behind)
 	}
+	if m.palette != nil && m.palette.open {
+		return m.renderPalette(width, height, behind)
+	}
+	if m.help.ShowAll {
+		return m.renderHelpOverlay(width, height, behind)
+	}
 	return behind
 }
 
 func (m *Model) renderConfirmModal(width, height int, _ string) string {
-	box := lipgloss.NewStyle().
-		Border(lipgloss.RoundedBorder()).
-		BorderForeground(lipgloss.Color("196")).
-		Padding(1, 2).
-		Background(lipgloss.Color("236")).
-		Foreground(lipgloss.Color("231"))
-
-	header := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("196")).Render("Confirm action")
+	p := theme.Theme()
+	box := p.ModalBox("danger")
+	header := lipgloss.NewStyle().Bold(true).Foreground(p.Danger).Render("Confirm action")
 	body := m.confirm.prompt
-	footer := lipgloss.NewStyle().Foreground(lipgloss.Color("245")).Render("y/enter: confirm   n/esc: cancel")
+	footer := p.Hint().Render("y/enter: confirm   n/esc: cancel")
 	contents := strings.Join([]string{header, "", body, "", footer}, "\n")
 	rendered := box.Render(contents)
-
 	return lipgloss.Place(width, height,
 		lipgloss.Center, lipgloss.Center,
 		rendered,
 		lipgloss.WithWhitespaceChars(" "),
-		lipgloss.WithWhitespaceForeground(lipgloss.Color("236")),
+		lipgloss.WithWhitespaceForeground(p.BgAlt),
 	)
 }
 
 func (m *Model) renderDetailModal(width, height int, _ string) string {
-	box := lipgloss.NewStyle().
-		Border(lipgloss.RoundedBorder()).
-		BorderForeground(lipgloss.Color("39")).
-		Padding(1, 2).
-		Background(lipgloss.Color("236")).
-		Foreground(lipgloss.Color("231"))
-
-	header := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("39")).Render(m.detail.title)
-	footer := lipgloss.NewStyle().Foreground(lipgloss.Color("245")).Render("esc/q/enter: close")
+	p := theme.Theme()
+	box := p.ModalBox("info")
+	header := lipgloss.NewStyle().Bold(true).Foreground(p.Accent).Render(m.detail.title)
+	footer := p.Hint().Render("esc/q/enter: close")
 	contents := strings.Join([]string{header, "", m.detail.body, "", footer}, "\n")
 	rendered := box.Render(contents)
-
 	return lipgloss.Place(width, height,
 		lipgloss.Center, lipgloss.Center,
 		rendered,
 		lipgloss.WithWhitespaceChars(" "),
-		lipgloss.WithWhitespaceForeground(lipgloss.Color("236")),
+		lipgloss.WithWhitespaceForeground(p.BgAlt),
 	)
 }

--- a/internal/tui/mouse.go
+++ b/internal/tui/mouse.go
@@ -1,0 +1,38 @@
+package tui
+
+import (
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/MattCheramie/GopherTrunk/internal/tui/state"
+)
+
+// tabRect is the bounding box of one tab in the rendered tab strip,
+// cached every renderTabs() call so hitTestTab can map a mouse click
+// back to a state.PanelKind without re-measuring the strip.
+type tabRect struct {
+	kind        state.PanelKind
+	xStart, xEnd int
+}
+
+// handleMouseMsg routes a tea.MouseMsg to the right tabbable
+// surface. Currently only the tab strip (top row) and the "more"
+// pill (also top row) are wired. Returns true when the click was
+// consumed.
+func (m *Model) handleMouseMsg(msg tea.MouseMsg) (tea.Cmd, bool) {
+	if msg.Button != tea.MouseButtonLeft || msg.Action != tea.MouseActionPress {
+		return nil, false
+	}
+	// Tab strip is always row 0. If the click is below the strip
+	// pass it through to the active panel (delegated below in
+	// Update once panel-side mouse hooks land).
+	if msg.Y != 0 {
+		return nil, false
+	}
+	for _, r := range m.tabRects {
+		if msg.X >= r.xStart && msg.X < r.xEnd {
+			m.active = r.kind
+			return nil, true
+		}
+	}
+	return nil, false
+}

--- a/internal/tui/mouse_test.go
+++ b/internal/tui/mouse_test.go
@@ -1,0 +1,55 @@
+package tui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/MattCheramie/GopherTrunk/internal/tui/state"
+)
+
+func TestHitTestTab_SelectsClickedTab(t *testing.T) {
+	m := newTestModel(t)
+	m.width = 200 // wide enough for the full strip
+	m.height = 24
+	_ = m.renderTabs() // populate m.tabRects
+
+	if len(m.tabRects) == 0 {
+		t.Fatal("renderTabs populated no rects")
+	}
+	// Click the Talkgroups tab (index 2 / PanelTalkgroups).
+	target := m.tabRects[state.PanelTalkgroups]
+	msg := tea.MouseMsg{
+		X:      target.xStart + 1,
+		Y:      0,
+		Button: tea.MouseButtonLeft,
+		Action: tea.MouseActionPress,
+	}
+	_, consumed := m.handleMouseMsg(msg)
+	if !consumed {
+		t.Fatal("click on tab strip was not consumed")
+	}
+	if m.active != state.PanelTalkgroups {
+		t.Errorf("active = %v, want %v", m.active, state.PanelTalkgroups)
+	}
+}
+
+func TestHitTestTab_IgnoresBodyClicks(t *testing.T) {
+	m := newTestModel(t)
+	m.width = 200
+	m.height = 24
+	_ = m.renderTabs()
+	original := m.active
+	msg := tea.MouseMsg{
+		X: 5, Y: 8, // below the tab strip
+		Button: tea.MouseButtonLeft,
+		Action: tea.MouseActionPress,
+	}
+	_, consumed := m.handleMouseMsg(msg)
+	if consumed {
+		t.Fatal("body click should not be consumed by tab hit-test")
+	}
+	if m.active != original {
+		t.Errorf("active changed unexpectedly: %v → %v", original, m.active)
+	}
+}

--- a/internal/tui/msgs.go
+++ b/internal/tui/msgs.go
@@ -51,6 +51,10 @@ type pollAudioMsg struct {
 	a   client.AudioStatusDTO
 	err error
 }
+type pollRuntimeMsg struct {
+	r   client.RuntimeDTO
+	err error
+}
 
 // eventMsg carries one decoded SSE event. The root model fans this
 // out into its event log + tone alert ring buffer, then forwards

--- a/internal/tui/palette.go
+++ b/internal/tui/palette.go
@@ -1,0 +1,463 @@
+package tui
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"unicode"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/MattCheramie/GopherTrunk/internal/tui/client"
+	"github.com/MattCheramie/GopherTrunk/internal/tui/panels"
+	"github.com/MattCheramie/GopherTrunk/internal/tui/state"
+	"github.com/MattCheramie/GopherTrunk/internal/tui/theme"
+)
+
+// paletteAction is one entry in the command palette. Label is what
+// the operator sees + fuzzy-matches against; Run is the side effect
+// fired on Enter. The Kind field is a coarse category used only for
+// inline tagging in the palette list ("nav" / "audio" / "scanner" /
+// "talkgroup" / "system" / "device" / "help").
+type paletteAction struct {
+	ID    string
+	Label string
+	Kind  string
+	Hint  string
+	Run   func(*Model) tea.Cmd
+}
+
+// paletteModel is the textinput + ranked list overlay opened with
+// Ctrl+P. It rebuilds its action list each time it opens so newly-
+// arrived systems / talkgroups / devices appear without a re-launch.
+type paletteModel struct {
+	open     bool
+	cursor   int
+	input    textinput.Model
+	all      []paletteAction
+	filtered []paletteAction
+}
+
+func newPalette() *paletteModel {
+	in := textinput.New()
+	in.Placeholder = "search panels, mutations, systems, talkgroups…"
+	in.Prompt = " "
+	in.CharLimit = 80
+	in.Width = 48
+	return &paletteModel{input: in}
+}
+
+// openPalette rebuilds the action list against the current shared
+// state and focuses the input.
+func (m *Model) openPalette() {
+	if m.palette == nil {
+		m.palette = newPalette()
+	}
+	m.palette.all = m.discoverActions()
+	m.palette.input.SetValue("")
+	m.palette.input.Focus()
+	m.palette.cursor = 0
+	m.palette.open = true
+	m.palette.refilter()
+}
+
+// closePalette hides the overlay and unfocuses the input.
+func (m *Model) closePalette() {
+	if m.palette == nil {
+		return
+	}
+	m.palette.open = false
+	m.palette.input.Blur()
+}
+
+// refilter recomputes filtered using the current query.
+func (pm *paletteModel) refilter() {
+	q := strings.ToLower(strings.TrimSpace(pm.input.Value()))
+	if q == "" {
+		pm.filtered = append(pm.filtered[:0], pm.all...)
+		if pm.cursor >= len(pm.filtered) {
+			pm.cursor = 0
+		}
+		return
+	}
+	type scored struct {
+		a paletteAction
+		s int
+	}
+	out := make([]scored, 0, len(pm.all))
+	for _, a := range pm.all {
+		if s := fuzzyScore(strings.ToLower(a.Label), q); s > 0 {
+			out = append(out, scored{a: a, s: s})
+		}
+	}
+	sort.SliceStable(out, func(i, j int) bool { return out[i].s > out[j].s })
+	pm.filtered = pm.filtered[:0]
+	for _, s := range out {
+		pm.filtered = append(pm.filtered, s.a)
+	}
+	if pm.cursor >= len(pm.filtered) {
+		pm.cursor = 0
+	}
+}
+
+// fuzzyScore returns a small positive integer when query's characters
+// appear in order inside label, 0 otherwise. Prefix matches + word-
+// start matches earn bonus points so "act" ranks "Active" above
+// "Scanner activities".
+func fuzzyScore(label, query string) int {
+	if query == "" {
+		return 1
+	}
+	if strings.HasPrefix(label, query) {
+		return 1000 + len(query)
+	}
+	score := 0
+	li := 0
+	prevSep := true
+	for _, qc := range query {
+		found := false
+		for li < len(label) {
+			lc := rune(label[li])
+			if lc == qc {
+				score += 10
+				if prevSep {
+					score += 20 // word-start bonus
+				}
+				li++
+				prevSep = false
+				found = true
+				break
+			}
+			if unicode.IsSpace(lc) || lc == '_' || lc == '-' || lc == ':' {
+				prevSep = true
+			} else {
+				prevSep = false
+			}
+			li++
+		}
+		if !found {
+			return 0
+		}
+	}
+	return score
+}
+
+// handlePaletteKey routes a key event while the palette is open. The
+// caller has already established m.palette.open == true.
+func (m *Model) handlePaletteKey(km tea.KeyMsg) tea.Cmd {
+	switch km.String() {
+	case "esc", "ctrl+p":
+		m.closePalette()
+		return nil
+	case "enter":
+		if a, ok := m.paletteSelected(); ok {
+			m.closePalette()
+			if a.Run != nil {
+				return a.Run(m)
+			}
+		}
+		return nil
+	case "up", "ctrl+k":
+		if m.palette.cursor > 0 {
+			m.palette.cursor--
+		}
+		return nil
+	case "down", "ctrl+j":
+		if m.palette.cursor < len(m.palette.filtered)-1 {
+			m.palette.cursor++
+		}
+		return nil
+	}
+	var cmd tea.Cmd
+	m.palette.input, cmd = m.palette.input.Update(km)
+	m.palette.refilter()
+	return cmd
+}
+
+func (m *Model) paletteSelected() (paletteAction, bool) {
+	if m.palette == nil || !m.palette.open || len(m.palette.filtered) == 0 {
+		return paletteAction{}, false
+	}
+	i := m.palette.cursor
+	if i < 0 || i >= len(m.palette.filtered) {
+		return paletteAction{}, false
+	}
+	return m.palette.filtered[i], true
+}
+
+// discoverActions builds the action list against the current shared
+// state. Each call re-enumerates so post-startup arrivals (new
+// talkgroup file load, new SDR hotplug) are reachable without
+// closing/reopening the palette twice.
+func (m *Model) discoverActions() []paletteAction {
+	out := make([]paletteAction, 0, 64)
+
+	// 1) Panel jumps.
+	for i := state.PanelKind(0); i < state.PanelCount; i++ {
+		i := i
+		out = append(out, paletteAction{
+			ID:    fmt.Sprintf("jump:%d", i),
+			Label: fmt.Sprintf("Jump to %s", m.panels[i].Title()),
+			Kind:  "nav",
+			Hint:  fmt.Sprintf("%d", int(i)+1),
+			Run: func(mm *Model) tea.Cmd {
+				mm.active = i
+				return nil
+			},
+		})
+	}
+
+	// 2) Help / quit.
+	out = append(out, paletteAction{
+		ID:    "help",
+		Label: "Show keyboard reference",
+		Kind:  "help",
+		Hint:  "?",
+		Run: func(mm *Model) tea.Cmd {
+			mm.help.ShowAll = true
+			return nil
+		},
+	})
+	out = append(out, paletteAction{
+		ID:    "quit",
+		Label: "Quit GopherTrunk TUI",
+		Kind:  "help",
+		Hint:  "q",
+		Run: func(mm *Model) tea.Cmd {
+			if mm.sseCancel != nil {
+				mm.sseCancel()
+			}
+			return tea.Quit
+		},
+	})
+
+	// 3) Audio mutations (only useful when --write is enabled, but
+	// listing them unconditionally keeps the palette consistent;
+	// the actions short-circuit on m.shared.WriteEnabled).
+	addAudio := func(label, hint string, run func(*Model) tea.Cmd) {
+		out = append(out, paletteAction{
+			ID: "audio:" + label, Label: "Audio: " + label, Kind: "audio", Hint: hint, Run: run,
+		})
+	}
+	addAudio("volume up 5%", "+", paletteAudioVol(+0.05))
+	addAudio("volume down 5%", "-", paletteAudioVol(-0.05))
+	addAudio("toggle mute", "M", paletteAudioMute())
+	addAudio("toggle recording", "R", paletteAudioRecord())
+
+	// 4) Retention sweep.
+	out = append(out, paletteAction{
+		ID:    "retention:sweep",
+		Label: "Retention: run sweep now",
+		Kind:  "retention",
+		Run: func(mm *Model) tea.Cmd {
+			req := state.WriteRequest{
+				Confirm:        "Run a retention sweep now?",
+				Label:          "retention sweep",
+				Kind:           state.WriteKindSweepRetention,
+				SweepRetention: &state.SweepRetentionReq{},
+			}
+			return func() tea.Msg { return panels.WriteActionMsg{Request: req} }
+		},
+	})
+
+	// 5) Scanner mutations — scan-mode toggle + per-system holds.
+	out = append(out, paletteAction{
+		ID:    "scanner:toggle-mode",
+		Label: "Scanner: toggle scan mode (all/list)",
+		Kind:  "scanner",
+		Run: func(mm *Model) tea.Cmd {
+			next := "list"
+			if mm.shared.Scanner.ScanMode == "list" {
+				next = "all"
+			}
+			req := state.WriteRequest{
+				Label:       fmt.Sprintf("set scan_mode=%s", next),
+				Kind:        state.WriteKindScannerMode,
+				ScannerMode: &state.ScannerModeReq{Mode: next},
+			}
+			return func() tea.Msg { return panels.WriteActionMsg{Request: req} }
+		},
+	})
+	for _, sys := range m.shared.Scanner.Systems {
+		sys := sys
+		out = append(out, paletteAction{
+			ID:    "scanner:hold:" + sys.Name,
+			Label: "Scanner: hold/resume hunt — " + sys.Name,
+			Kind:  "scanner",
+			Run: func(mm *Model) tea.Cmd {
+				kind := state.WriteKindScannerHuntHold
+				verb := "hold"
+				if sys.State == "held" {
+					kind = state.WriteKindScannerHuntResume
+					verb = "resume"
+				}
+				req := state.WriteRequest{
+					Label:       fmt.Sprintf("%s hunt %s", verb, sys.Name),
+					Kind:        kind,
+					ScannerHunt: &state.ScannerHuntReq{System: sys.Name},
+				}
+				return func() tea.Msg { return panels.WriteActionMsg{Request: req} }
+			},
+		})
+	}
+
+	// 6) System / talkgroup / device drill-ins — handy nav.
+	for _, sys := range m.shared.Systems {
+		sys := sys
+		out = append(out, paletteAction{
+			ID:    "system:" + sys.Name,
+			Label: "Open system: " + sys.Name + " (" + sys.Protocol + ")",
+			Kind:  "system",
+			Run: func(mm *Model) tea.Cmd {
+				return func() tea.Msg { return panels.SystemDetailMsg{Name: sys.Name} }
+			},
+		})
+	}
+	// Cap talkgroup actions to the first 200 — bigger lists drown
+	// out the palette.
+	tgLimit := len(m.shared.Talkgroups)
+	if tgLimit > 200 {
+		tgLimit = 200
+	}
+	for _, tg := range m.shared.Talkgroups[:tgLimit] {
+		tg := tg
+		alpha := tg.AlphaTag
+		if alpha == "" {
+			alpha = "—"
+		}
+		out = append(out, paletteAction{
+			ID:    fmt.Sprintf("tg:%d", tg.ID),
+			Label: fmt.Sprintf("Open TG %d  %s", tg.ID, alpha),
+			Kind:  "talkgroup",
+			Run: func(mm *Model) tea.Cmd {
+				return func() tea.Msg { return panels.TalkgroupDetailMsg{ID: tg.ID} }
+			},
+		})
+	}
+	for _, dev := range m.shared.Devices {
+		dev := dev
+		out = append(out, paletteAction{
+			ID:    "device:" + dev.Serial,
+			Label: fmt.Sprintf("SDR: %s  %s  %s", dev.Serial, dev.Driver, dev.TunerName),
+			Kind:  "device",
+			Run: func(mm *Model) tea.Cmd {
+				mm.active = state.PanelDevices
+				return nil
+			},
+		})
+	}
+
+	return out
+}
+
+func paletteAudioVol(delta float32) func(*Model) tea.Cmd {
+	return func(mm *Model) tea.Cmd {
+		v := mm.shared.Audio.Volume + delta
+		if v < 0 {
+			v = 0
+		}
+		if v > 1 {
+			v = 1
+		}
+		req := state.WriteRequest{
+			Label: fmt.Sprintf("volume %d%%", int(v*100+0.5)),
+			Kind:  state.WriteKindAudio,
+			Audio: &state.AudioReq{Volume: &v},
+		}
+		return func() tea.Msg { return panels.WriteActionMsg{Request: req} }
+	}
+}
+
+func paletteAudioMute() func(*Model) tea.Cmd {
+	return func(mm *Model) tea.Cmd {
+		next := !mm.shared.Audio.Muted
+		req := state.WriteRequest{
+			Label: ifElse(next, "mute", "unmute"),
+			Kind:  state.WriteKindAudio,
+			Audio: &state.AudioReq{Muted: &next},
+		}
+		return func() tea.Msg { return panels.WriteActionMsg{Request: req} }
+	}
+}
+
+func paletteAudioRecord() func(*Model) tea.Cmd {
+	return func(mm *Model) tea.Cmd {
+		next := !mm.shared.Audio.RecordingEnabled
+		req := state.WriteRequest{
+			Label: ifElse(next, "recording on", "recording off"),
+			Kind:  state.WriteKindAudio,
+			Audio: &state.AudioReq{Recording: &next},
+		}
+		return func() tea.Msg { return panels.WriteActionMsg{Request: req} }
+	}
+}
+
+func ifElse(cond bool, a, b string) string {
+	if cond {
+		return a
+	}
+	return b
+}
+
+// renderPalette draws the overlay. Width is clamped so the overlay
+// stays readable on terminals as narrow as 40 cols. Up to 12 rows
+// shown.
+func (m *Model) renderPalette(width, height int, _ string) string {
+	pm := m.palette
+	p := theme.Theme()
+	w := width * 3 / 4
+	if w < 50 {
+		w = 50
+	}
+	if w > 100 {
+		w = 100
+	}
+	header := p.Title().Render("Command palette")
+	hint := p.Hint().Render("type to filter • ↑/↓ to move • Enter to run • Esc to close")
+	box := p.ModalBox("info").Width(w)
+
+	var rows []string
+	rows = append(rows, header, "", pm.input.View(), hint, "")
+	// Render up to 12 hits.
+	const maxRows = 12
+	end := len(pm.filtered)
+	if end > maxRows {
+		end = maxRows
+	}
+	for i := 0; i < end; i++ {
+		a := pm.filtered[i]
+		line := a.Label
+		if a.Hint != "" {
+			line += "  " + p.Hint().Render("("+a.Hint+")")
+		}
+		if a.Kind != "" {
+			line = p.Hint().Render(fmt.Sprintf("[%-9s]", a.Kind)) + " " + line
+		}
+		if i == pm.cursor {
+			line = p.Selected().Render(" ▶ " + line)
+		} else {
+			line = "   " + line
+		}
+		rows = append(rows, line)
+	}
+	if end == 0 {
+		rows = append(rows, p.Hint().Render("  (no matches)"))
+	} else if len(pm.filtered) > end {
+		rows = append(rows, p.Hint().Render(fmt.Sprintf("  +%d more — refine your search", len(pm.filtered)-end)))
+	}
+	body := strings.Join(rows, "\n")
+	rendered := box.Render(body)
+	return lipgloss.Place(width, height,
+		lipgloss.Center, lipgloss.Center,
+		rendered,
+		lipgloss.WithWhitespaceChars(" "),
+		lipgloss.WithWhitespaceForeground(p.BgAlt),
+	)
+}
+
+// ifElseClient and clientShortRef keep the imports honest — the
+// palette references client types via the shared state but Go's
+// import-pruner will complain otherwise. (No-op at runtime.)
+var _ = client.Event{}

--- a/internal/tui/palette_test.go
+++ b/internal/tui/palette_test.go
@@ -1,0 +1,84 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/MattCheramie/GopherTrunk/internal/tui/state"
+)
+
+func TestFuzzyScore_ExactPrefixWins(t *testing.T) {
+	if fuzzyScore("settings", "set") <= fuzzyScore("scanner settings", "set") {
+		t.Fatalf("prefix match did not outrank middle-of-string match")
+	}
+}
+
+func TestFuzzyScore_NoMatch(t *testing.T) {
+	if fuzzyScore("scanner", "xyz") != 0 {
+		t.Fatalf("expected 0 on miss, got >0")
+	}
+}
+
+func TestPalette_OpensAndDiscoversPanelJumps(t *testing.T) {
+	m := newTestModel(t)
+	m.openPalette()
+	if !m.palette.open {
+		t.Fatal("palette did not open")
+	}
+	// Every panel title must show up as a jump action.
+	for i := state.PanelKind(0); i < state.PanelCount; i++ {
+		want := "Jump to " + m.panels[i].Title()
+		var found bool
+		for _, a := range m.palette.all {
+			if a.Label == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("missing palette action %q", want)
+		}
+	}
+}
+
+func TestPalette_FilterMatchesSubstring(t *testing.T) {
+	m := newTestModel(t)
+	m.openPalette()
+	// Type "scan" — should match Scanner-related entries.
+	m.palette.input.SetValue("scan")
+	m.palette.refilter()
+	if len(m.palette.filtered) == 0 {
+		t.Fatalf("scan filter yielded no matches")
+	}
+	if !strings.Contains(strings.ToLower(m.palette.filtered[0].Label), "scan") {
+		t.Errorf("top match doesn't contain 'scan': %q", m.palette.filtered[0].Label)
+	}
+}
+
+func TestPalette_EnterRunsAction(t *testing.T) {
+	m := newTestModel(t)
+	m.openPalette()
+	// Move to first action and Enter — should close the palette.
+	cmd := m.handlePaletteKey(tea.KeyMsg{Type: tea.KeyEnter})
+	if m.palette.open {
+		t.Fatal("Enter did not close the palette")
+	}
+	// Panel jumps return nil cmd; that's fine. Just assert no panic.
+	_ = cmd
+}
+
+func TestPalette_EscClosesWithoutAction(t *testing.T) {
+	m := newTestModel(t)
+	m.openPalette()
+	originalActive := m.active
+	m.handlePaletteKey(tea.KeyMsg{Type: tea.KeyEsc})
+	if m.palette.open {
+		t.Fatal("Esc did not close the palette")
+	}
+	if m.active != originalActive {
+		t.Errorf("Esc fired an action — active changed from %v to %v", originalActive, m.active)
+	}
+}
+

--- a/internal/tui/panels/active.go
+++ b/internal/tui/panels/active.go
@@ -13,8 +13,8 @@ import (
 
 // ActivePanel renders calls currently being followed.
 type ActivePanel struct {
-	tbl       table.Model
-	lastCount int
+	tbl      table.Model
+	lastHash uint64
 }
 
 func NewActive() *ActivePanel {
@@ -53,9 +53,19 @@ func (p *ActivePanel) Update(msg tea.Msg, s *state.SharedState) (Panel, tea.Cmd)
 			return p, Emit(req)
 		}
 	}
-	// Refresh on every update — the polling cadence is 1 s and the
-	// table is small.
-	p.refresh(s.ActiveCalls)
+	// Refresh on every update — the polling cadence is 1 s. The hash
+	// gate keeps us from rebuilding the bubbles/table on every Update
+	// call when nothing has changed.
+	h := hashRows(s.ActiveCalls, func(ac client.ActiveCallDTO) string {
+		return fmt.Sprintf("%s|%d|%d|%s|%d|%v|%v",
+			ac.DeviceSerial, ac.Grant.GroupID, ac.Grant.SourceID,
+			ac.Grant.System, ac.Grant.FrequencyHz,
+			ac.Grant.Encrypted, ac.Grant.Emergency)
+	})
+	if h != p.lastHash {
+		p.refresh(s.ActiveCalls)
+		p.lastHash = h
+	}
 	var cmd tea.Cmd
 	p.tbl, cmd = p.tbl.Update(msg)
 	return p, cmd
@@ -87,7 +97,6 @@ func (p *ActivePanel) refresh(calls []client.ActiveCallDTO) {
 		})
 	}
 	p.tbl.SetRows(rows)
-	p.lastCount = len(calls)
 }
 
 func (p *ActivePanel) View(width, height int, focused bool, s *state.SharedState) string {

--- a/internal/tui/panels/dashboard.go
+++ b/internal/tui/panels/dashboard.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/MattCheramie/GopherTrunk/internal/tui/client"
 	"github.com/MattCheramie/GopherTrunk/internal/tui/state"
+	"github.com/MattCheramie/GopherTrunk/internal/tui/theme"
 )
 
 // DashboardPanel is the at-a-glance landing screen. It is a pure
@@ -27,17 +28,24 @@ func (p *DashboardPanel) Update(_ tea.Msg, _ *state.SharedState) (Panel, tea.Cmd
 	return p, nil
 }
 
-var (
-	dashHeader = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("39"))
-	dashOK     = lipgloss.NewStyle().Foreground(lipgloss.Color("42"))
-	dashErr    = lipgloss.NewStyle().Foreground(lipgloss.Color("196"))
-	dashDim    = lipgloss.NewStyle().Foreground(lipgloss.Color("245"))
-	dashAlert  = lipgloss.NewStyle().Foreground(lipgloss.Color("196")).Bold(true)
-)
-
 func (p *DashboardPanel) View(width, height int, _ bool, s *state.SharedState) string {
 	if width < 4 || height < 4 {
 		return ""
+	}
+	// Below 80 cols the 2×2 grid is unreadable; stack vertically and
+	// trim the bottom row to whatever space is left.
+	if width < 80 {
+		rowH := (height - 1) / 4
+		if rowH < 3 {
+			rowH = 3
+		}
+		parts := []string{
+			dashboardCard("Health", width, rowH, p.healthBody(s)),
+			dashboardCard("Active calls", width, rowH, p.activeBody(s)),
+			dashboardCard("Recent events", width, rowH, p.eventsBody(s)),
+			dashboardCard("Tone alerts", width, rowH, p.tonesBody(s)),
+		}
+		return lipgloss.JoinVertical(lipgloss.Left, parts...)
 	}
 	colW := (width - 2) / 2
 	if colW < 20 {
@@ -59,10 +67,7 @@ func (p *DashboardPanel) View(width, height int, _ bool, s *state.SharedState) s
 }
 
 func dashboardCard(title string, w, h int, body string) string {
-	style := lipgloss.NewStyle().
-		Border(lipgloss.RoundedBorder()).
-		BorderForeground(lipgloss.Color("240")).
-		Padding(0, 1).
+	style := theme.Theme().Frame(false).
 		Width(w - 2).
 		Height(h - 2)
 	header := dashHeader.Render(title)

--- a/internal/tui/panels/devices.go
+++ b/internal/tui/panels/devices.go
@@ -16,8 +16,8 @@ import (
 // daemon has opened, with role / tuner / configured gain / PPM /
 // bias-tee state.
 type DevicesPanel struct {
-	tbl   table.Model
-	count int
+	tbl      table.Model
+	lastHash uint64
 }
 
 func NewDevices() *DevicesPanel {
@@ -33,8 +33,14 @@ func (DevicesPanel) Title() string       { return "Devices" }
 func (DevicesPanel) Keys() []key.Binding { return nil }
 
 func (p *DevicesPanel) Update(msg tea.Msg, s *state.SharedState) (Panel, tea.Cmd) {
-	if len(s.Devices) != p.count {
+	h := hashRows(s.Devices, func(d client.SDRStatus) string {
+		return fmt.Sprintf("%s|%s|%s|%s|%v|%d|%d|%v|%v",
+			d.Serial, d.Driver, d.TunerName, d.Role,
+			d.GainAuto, d.GainTenthDB, d.PPM, d.BiasTee, d.Attached)
+	})
+	if h != p.lastHash {
 		p.refresh(s.Devices)
+		p.lastHash = h
 	}
 	var cmd tea.Cmd
 	p.tbl, cmd = p.tbl.Update(msg)
@@ -69,7 +75,6 @@ func (p *DevicesPanel) refresh(devs []client.SDRStatus) {
 		})
 	}
 	p.tbl.SetRows(rows)
-	p.count = len(devs)
 }
 
 func (p *DevicesPanel) View(width, height int, focused bool, s *state.SharedState) string {

--- a/internal/tui/panels/devices_test.go
+++ b/internal/tui/panels/devices_test.go
@@ -22,8 +22,8 @@ func TestDevicesPanel_RendersSnapshot(t *testing.T) {
 	}
 	// First Update populates the table.
 	_, _ = p.Update(tea.WindowSizeMsg{Width: 120, Height: 30}, s)
-	if p.count != 2 {
-		t.Fatalf("rows = %d, want 2", p.count)
+	if got := len(p.tbl.Rows()); got != 2 {
+		t.Fatalf("rows = %d, want 2", got)
 	}
 	view := p.View(120, 30, true, s)
 	for _, want := range []string{"AAA", "BBB", "control", "voice", "auto", "49.6 dB"} {

--- a/internal/tui/panels/diff_test.go
+++ b/internal/tui/panels/diff_test.go
@@ -1,0 +1,50 @@
+package panels
+
+import (
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/tui/client"
+)
+
+func TestHashRows_StableForIdenticalRows(t *testing.T) {
+	rows := []client.SDRStatus{
+		{Serial: "AAA", Driver: "rtlsdr", Role: "control"},
+		{Serial: "BBB", Driver: "rtlsdr", Role: "voice"},
+	}
+	keyFn := func(d client.SDRStatus) string { return d.Serial + "|" + d.Role }
+	h1 := hashRows(rows, keyFn)
+	h2 := hashRows(rows, keyFn)
+	if h1 != h2 {
+		t.Fatalf("hashRows non-deterministic: %x vs %x", h1, h2)
+	}
+}
+
+func TestHashRows_ChangesOnContentChange(t *testing.T) {
+	a := []client.SDRStatus{{Serial: "AAA", Driver: "rtlsdr"}}
+	b := []client.SDRStatus{{Serial: "BBB", Driver: "rtlsdr"}}
+	keyFn := func(d client.SDRStatus) string { return d.Serial + "|" + d.Driver }
+	if hashRows(a, keyFn) == hashRows(b, keyFn) {
+		t.Fatal("hashRows collided across distinct content")
+	}
+}
+
+func TestHashRows_ChangesOnOrderChange(t *testing.T) {
+	a := []client.SDRStatus{
+		{Serial: "AAA"}, {Serial: "BBB"},
+	}
+	b := []client.SDRStatus{
+		{Serial: "BBB"}, {Serial: "AAA"},
+	}
+	keyFn := func(d client.SDRStatus) string { return d.Serial }
+	if hashRows(a, keyFn) == hashRows(b, keyFn) {
+		t.Fatal("hashRows did not detect reordering")
+	}
+}
+
+func TestHashStringMap_StableWithMapOrder(t *testing.T) {
+	m1 := map[string]float64{"a": 1, "b": 2, "c": 3}
+	m2 := map[string]float64{"c": 3, "a": 1, "b": 2}
+	if hashStringMap(m1) != hashStringMap(m2) {
+		t.Fatal("hashStringMap is sensitive to insertion order — sort failed")
+	}
+}

--- a/internal/tui/panels/frame.go
+++ b/internal/tui/panels/frame.go
@@ -1,0 +1,46 @@
+package panels
+
+import (
+	"github.com/charmbracelet/bubbles/table"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/MattCheramie/GopherTrunk/internal/tui/theme"
+)
+
+// panelFrame draws the canonical bordered card used by every table
+// panel. focused flips the border colour to the accent so the active
+// panel is unambiguous regardless of where the operator's eye lands.
+func panelFrame(title string, w, h int, focused bool, body string) string {
+	p := theme.Theme()
+	border := p.Frame(focused)
+	if w > 4 {
+		border = border.Width(w - 2)
+	}
+	if h > 4 {
+		border = border.Height(h - 2)
+	}
+	titleStyle := p.Title()
+	if focused {
+		// Invert the title bar on the focused panel so the eye lands
+		// on it immediately even when many panels share a screen.
+		titleStyle = titleStyle.Background(p.Accent).Foreground(p.Fg)
+	}
+	return border.Render(titleStyle.Render(" "+title+" ") + "\n" + body)
+}
+
+// tableStyles is the shared bubbles/table theme — bold accent
+// header with a muted bottom border, accent-tinted selected row.
+func tableStyles() table.Styles {
+	p := theme.Theme()
+	s := table.DefaultStyles()
+	s.Header = s.Header.
+		BorderStyle(lipgloss.NormalBorder()).
+		BorderForeground(p.Border).
+		BorderBottom(true).
+		Bold(true).
+		Foreground(p.Accent)
+	s.Selected = s.Selected.
+		Foreground(p.Fg).
+		Background(p.SelectBg)
+	return s
+}

--- a/internal/tui/panels/history.go
+++ b/internal/tui/panels/history.go
@@ -19,9 +19,9 @@ import (
 // `r`. The panel does not poll continuously — history is a stable
 // list and the daemon already paginates it.
 type HistoryPanel struct {
-	tbl       table.Model
-	lastCount int
-	reloadAt  time.Time
+	tbl      table.Model
+	lastHash uint64
+	reloadAt time.Time
 }
 
 // NewHistory constructs the panel.
@@ -56,8 +56,16 @@ func (p *HistoryPanel) Update(msg tea.Msg, s *state.SharedState) (Panel, tea.Cmd
 			return p, nil
 		}
 	}
-	if len(s.History) != p.lastCount {
+	h := hashRows(s.History, func(r client.CallRow) string {
+		return fmt.Sprintf("%s|%s|%d|%s|%d|%s|%s",
+			r.StartedAt.Format(time.RFC3339Nano),
+			r.EndedAt.Format(time.RFC3339Nano),
+			r.GroupID, r.TalkgroupAlpha, r.SourceID,
+			r.System, r.EndReason)
+	})
+	if h != p.lastHash {
 		p.refresh(s.History)
+		p.lastHash = h
 	}
 	var cmd tea.Cmd
 	p.tbl, cmd = p.tbl.Update(msg)
@@ -86,7 +94,6 @@ func (p *HistoryPanel) refresh(rows []client.CallRow) {
 		})
 	}
 	p.tbl.SetRows(out)
-	p.lastCount = len(rows)
 }
 
 func (p *HistoryPanel) View(width, height int, focused bool, s *state.SharedState) string {

--- a/internal/tui/panels/metrics.go
+++ b/internal/tui/panels/metrics.go
@@ -17,7 +17,8 @@ import (
 // whitelist captures the headline counters operators usually care
 // about.
 type MetricsPanel struct {
-	tbl table.Model
+	tbl      table.Model
+	lastHash uint64
 }
 
 // curatedMetrics is the order metrics are displayed in. Names that
@@ -57,7 +58,11 @@ func (p *MetricsPanel) Update(msg tea.Msg, s *state.SharedState) (Panel, tea.Cmd
 		}
 		return p, Emit(req)
 	}
-	p.refresh(s.Metrics)
+	h := hashStringMap(s.Metrics)
+	if h != p.lastHash {
+		p.refresh(s.Metrics)
+		p.lastHash = h
+	}
 	var cmd tea.Cmd
 	p.tbl, cmd = p.tbl.Update(msg)
 	return p, cmd

--- a/internal/tui/panels/scanner.go
+++ b/internal/tui/panels/scanner.go
@@ -390,7 +390,7 @@ func (p *ScannerPanel) renderSystems(width int, s *state.SharedState) string {
 		case "locked":
 			stateStyle = dashOK
 		case "hunting":
-			stateStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("220"))
+			stateStyle = dashWarn
 		case "failed":
 			stateStyle = dashErr
 		case "held":

--- a/internal/tui/panels/settings.go
+++ b/internal/tui/panels/settings.go
@@ -12,18 +12,60 @@ import (
 	"github.com/MattCheramie/GopherTrunk/internal/tui/state"
 )
 
-// SettingsPanel renders each configured trunking system with its
-// per-protocol FEC opt-in state — the source of truth for whether
-// the live decoder is running the spec's FEC chain or the legacy
-// raw-bit fixture path.
-//
-// The panel is read-only. Runtime mutation requires editing
-// config.yaml + restarting the daemon (the opt-ins flow from
-// SystemConfig → trunking.System → ccdecoder.PipelineFactory at
-// startup; the connector reads them once per HuntProgress retune).
+// settingsTab enumerates the inspector's sub-views. Each tab pulls
+// exclusively from SharedState.Runtime (the /api/v1/runtime snapshot)
+// or SharedState.Systems (already polled) — so the tab switch is a
+// pure render, no extra fetches.
+type settingsTab int
+
+const (
+	tabDaemon settingsTab = iota
+	tabStorage
+	tabAudio
+	tabRecording
+	tabTones
+	tabAPI
+	tabVocoders
+	tabSDR
+	tabFEC
+	tabCount
+)
+
+func (t settingsTab) String() string {
+	switch t {
+	case tabDaemon:
+		return "Daemon"
+	case tabStorage:
+		return "Storage"
+	case tabAudio:
+		return "Audio"
+	case tabRecording:
+		return "Recording"
+	case tabTones:
+		return "Tones"
+	case tabAPI:
+		return "API"
+	case tabVocoders:
+		return "Vocoders"
+	case tabSDR:
+		return "SDR"
+	case tabFEC:
+		return "FEC opt-ins"
+	}
+	return "?"
+}
+
+// SettingsPanel is the tabbed inspector that surfaces every config
+// knob, output, protocol surface, and runtime fact. Driven by
+// SharedState.Runtime; one /api/v1/runtime poll feeds every tab so
+// the operator sees a coherent snapshot.
 type SettingsPanel struct {
-	tbl   table.Model
-	count int
+	tab settingsTab
+
+	// FEC opt-ins tab retains the existing table view; the other
+	// tabs render plain text.
+	tbl      table.Model
+	lastHash uint64
 }
 
 func NewSettings() *SettingsPanel {
@@ -32,19 +74,49 @@ func NewSettings() *SettingsPanel {
 		table.WithFocused(true),
 	)
 	t.SetStyles(tableStyles())
-	return &SettingsPanel{tbl: t}
+	return &SettingsPanel{tab: tabDaemon, tbl: t}
 }
 
-func (SettingsPanel) Title() string       { return "Settings" }
-func (SettingsPanel) Keys() []key.Binding { return nil }
+func (SettingsPanel) Title() string { return "Settings" }
+
+var (
+	settingsNextTab = key.NewBinding(key.WithKeys("]", "l", "right"), key.WithHelp("]/l/→", "next tab"))
+	settingsPrevTab = key.NewBinding(key.WithKeys("[", "h", "left"), key.WithHelp("[/h/←", "prev tab"))
+)
+
+func (SettingsPanel) Keys() []key.Binding {
+	return []key.Binding{settingsNextTab, settingsPrevTab}
+}
 
 func (p *SettingsPanel) Update(msg tea.Msg, s *state.SharedState) (Panel, tea.Cmd) {
-	if len(s.Systems) != p.count {
-		p.refresh(s.Systems)
+	if km, ok := msg.(tea.KeyMsg); ok {
+		switch {
+		case key.Matches(km, settingsNextTab):
+			p.tab = (p.tab + 1) % tabCount
+		case key.Matches(km, settingsPrevTab):
+			p.tab = (p.tab + tabCount - 1) % tabCount
+		}
 	}
-	var cmd tea.Cmd
-	p.tbl, cmd = p.tbl.Update(msg)
-	return p, cmd
+	// Refresh the FEC table whenever we're on (or have just switched
+	// to) the FEC tab — the hash gate keeps the cost negligible.
+	if p.tab == tabFEC {
+		h := hashRows(s.Systems, func(sys client.SystemDTO) string {
+			return fmt.Sprintf("%s|%s|%d|%s|%s|%s|%s|%s|%s",
+				sys.Name, sys.Protocol,
+				sys.TETRAColourCode, sys.TETRAChannel,
+				sys.LTRFCSMode, sys.LTRManchesterMode,
+				sys.P25Phase2TrellisMode, sys.NXDNViterbiMode,
+				sys.EDACSBCHMode)
+		})
+		if h != p.lastHash {
+			p.refresh(s.Systems)
+			p.lastHash = h
+		}
+		var cmd tea.Cmd
+		p.tbl, cmd = p.tbl.Update(msg)
+		return p, cmd
+	}
+	return p, nil
 }
 
 func (p *SettingsPanel) refresh(sys []client.SystemDTO) {
@@ -57,18 +129,131 @@ func (p *SettingsPanel) refresh(sys []client.SystemDTO) {
 		})
 	}
 	p.tbl.SetRows(rows)
-	p.count = len(sys)
 }
 
 func (p *SettingsPanel) View(width, height int, focused bool, s *state.SharedState) string {
-	p.tbl.SetColumns(settingsColumns(width))
-	p.tbl.SetWidth(width)
-	if height > 4 {
-		p.tbl.SetHeight(height - 4)
+	header := p.renderTabBar(width)
+	var body string
+	if p.tab == tabFEC {
+		p.tbl.SetColumns(settingsColumns(width))
+		p.tbl.SetWidth(width)
+		if height > 6 {
+			p.tbl.SetHeight(height - 6)
+		}
+		body = p.tbl.View() + "\n\n" + dashDim.Render("Edit config.yaml + restart daemon to change; see the FEC opt-ins section in README.md.")
+	} else {
+		body = p.renderTab(width, s)
 	}
-	body := p.tbl.View()
-	body += "\n\nEdit config.yaml + restart daemon to change; see the FEC opt-ins section in README.md."
-	return panelFrame("Settings", width, height, focused, body)
+	return panelFrame("Settings", width, height, focused, header+"\n"+body)
+}
+
+func (p *SettingsPanel) renderTabBar(width int) string {
+	parts := make([]string, 0, tabCount)
+	for i := settingsTab(0); i < tabCount; i++ {
+		label := fmt.Sprintf(" %s ", i.String())
+		if i == p.tab {
+			parts = append(parts, dashAccent.Render(">"+label+"<"))
+		} else {
+			parts = append(parts, dashDim.Render(label))
+		}
+	}
+	bar := strings.Join(parts, " ")
+	hint := dashDim.Render("  [/]  to switch  •  config.yaml owns these values")
+	return bar + hint
+}
+
+func (p *SettingsPanel) renderTab(width int, s *state.SharedState) string {
+	r := s.Runtime
+	switch p.tab {
+	case tabDaemon:
+		return rows([][2]string{
+			{"Version", or(r.Version, "—")},
+			{"Log level", or(r.LogLevel, "info")},
+			{"Log format", or(r.LogFormat, "text")},
+			{"Metrics enabled", boolText(r.MetricsEnabled)},
+		})
+	case tabStorage:
+		return rows([][2]string{
+			{"Call log path", or(r.StorageDBPath, "—  (call log disabled)")},
+			{"CC cache file", or(r.StorageCCCache, "—  (cache disabled)")},
+			{"Retention (call log)", fmt.Sprintf("%d days", r.RetentionCallLogDays)},
+			{"Retention (files)", fmt.Sprintf("%d days", r.RetentionFilesDays)},
+			{"Retention interval", durText(r.RetentionInterval)},
+		})
+	case tabAudio:
+		out := rows([][2]string{
+			{"Enabled", boolText(r.AudioEnabled)},
+			{"Device", or(r.AudioDevice, "default (system sink)")},
+			{"Sample rate", fmt.Sprintf("%d Hz", r.AudioSampleRate)},
+			{"Buffer", fmt.Sprintf("%d ms", r.AudioBufferMs)},
+			{"Disable auto-fallback (Linux)", boolText(r.AudioDisableFallbk)},
+		})
+		if len(r.AudioBackends) > 0 {
+			out += "\n\n" + dashHeader.Render("Available outputs") + "\n  " + strings.Join(r.AudioBackends, "\n  ")
+		}
+		return out
+	case tabRecording:
+		return rows([][2]string{
+			{"Output directory", or(r.RecordingDir, "—  (recording disabled)")},
+			{"Sample rate", fmt.Sprintf("%d Hz", r.RecordingSampleRate)},
+			{"Write raw vocoder frames", boolText(r.RecordingWriteRaw)},
+			{"CMA equalizer", boolText(r.RecordingEQEnabled)},
+			{"  EQ taps", intText(r.RecordingEQTaps)},
+			{"  EQ step size", or(r.RecordingEQStepSize, "—")},
+		})
+	case tabTones:
+		if len(r.ToneProfiles) == 0 {
+			return dashDim.Render("  no tone-out profiles configured")
+		}
+		var b strings.Builder
+		for _, t := range r.ToneProfiles {
+			fmt.Fprintf(&b, "  %s\n", dashAccent.Render(t.Name))
+			if t.AlphaTag != "" {
+				fmt.Fprintf(&b, "    alpha    %s\n", t.AlphaTag)
+			}
+			fmt.Fprintf(&b, "    tones    %d\n", t.ToneCount)
+			fmt.Fprintf(&b, "    cooldown %s\n", durText(t.Cooldown))
+		}
+		return b.String()
+	case tabAPI:
+		return rows([][2]string{
+			{"HTTP REST + SSE + WS", or(r.HTTPAddr, "—  (HTTP API disabled)")},
+			{"  SSE path", "/api/v1/events"},
+			{"  WS path", "/api/v1/events/ws"},
+			{"  Metrics path", "/metrics  (if metrics.enabled)"},
+			{"gRPC", or(r.GRPCAddr, "—  (gRPC disabled)")},
+			{"Allow mutations", boolText(r.AllowMutations)},
+		})
+	case tabVocoders:
+		if len(r.VocoderMap) == 0 {
+			return dashDim.Render("  vocoder map unavailable")
+		}
+		// Render the map sorted for deterministic output.
+		keys := make([]string, 0, len(r.VocoderMap))
+		for k := range r.VocoderMap {
+			keys = append(keys, k)
+		}
+		// inline insertion sort over short slices
+		for i := 1; i < len(keys); i++ {
+			for j := i; j > 0 && keys[j-1] > keys[j]; j-- {
+				keys[j-1], keys[j] = keys[j], keys[j-1]
+			}
+		}
+		out := make([][2]string, 0, len(keys))
+		for _, k := range keys {
+			out = append(out, [2]string{k, r.VocoderMap[k]})
+		}
+		return rows(out)
+	case tabSDR:
+		out := rows([][2]string{
+			{"Sample rate", fmt.Sprintf("%d Hz", r.SDRSampleRate)},
+		})
+		if len(r.SDRBackends) > 0 {
+			out += "\n\n" + dashHeader.Render("Linked backends") + "\n  " + strings.Join(r.SDRBackends, ", ")
+		}
+		return out
+	}
+	return ""
 }
 
 func settingsColumns(w int) []table.Column {
@@ -86,6 +271,52 @@ func settingsColumns(w int) []table.Column {
 		{Title: "Protocol", Width: protoW},
 		{Title: "FEC opt-ins", Width: fecW},
 	}
+}
+
+// rows renders a two-column key/value list. Keys right-padded to the
+// widest key in the slice so the values align without lipgloss table
+// machinery — keeps the inspector lightweight.
+func rows(pairs [][2]string) string {
+	maxK := 0
+	for _, p := range pairs {
+		if l := len([]rune(p[0])); l > maxK {
+			maxK = l
+		}
+	}
+	var b strings.Builder
+	for _, p := range pairs {
+		k := p[0] + strings.Repeat(" ", maxK-len([]rune(p[0])))
+		fmt.Fprintf(&b, "  %s   %s\n", dashDim.Render(k), p[1])
+	}
+	return b.String()
+}
+
+func or(s, fallback string) string {
+	if s == "" {
+		return fallback
+	}
+	return s
+}
+
+func boolText(b bool) string {
+	if b {
+		return dashOK.Render("on")
+	}
+	return dashDim.Render("off")
+}
+
+func intText(n int) string {
+	if n == 0 {
+		return "—"
+	}
+	return fmt.Sprintf("%d", n)
+}
+
+func durText(d interface{ Nanoseconds() int64 }) string {
+	if d.Nanoseconds() == 0 {
+		return "—"
+	}
+	return fmt.Sprintf("%v", d)
 }
 
 // fecSummary returns a one-line, protocol-scoped summary of the

--- a/internal/tui/panels/settings_test.go
+++ b/internal/tui/panels/settings_test.go
@@ -25,8 +25,14 @@ func TestSettingsPanel_RendersFECSummaryPerProtocol(t *testing.T) {
 		},
 	}
 	_, _ = p.Update(tea.WindowSizeMsg{Width: 140, Height: 30}, s)
-	if p.count != 8 {
-		t.Fatalf("rows = %d, want 8", p.count)
+	// Switch to the FEC opt-ins tab — the inspector defaults to the
+	// Daemon tab and only the FEC tab renders the per-system FEC
+	// summary table this test asserts on.
+	for p.tab != tabFEC {
+		_, _ = p.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("]")}, s)
+	}
+	if got := len(p.tbl.Rows()); got != 8 {
+		t.Fatalf("rows = %d, want 8", got)
 	}
 	view := p.View(140, 30, true, s)
 	wants := []string{

--- a/internal/tui/panels/systems.go
+++ b/internal/tui/panels/systems.go
@@ -7,7 +7,6 @@ import (
 	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/table"
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/charmbracelet/lipgloss"
 
 	"github.com/MattCheramie/GopherTrunk/internal/tui/client"
 	"github.com/MattCheramie/GopherTrunk/internal/tui/state"
@@ -15,8 +14,8 @@ import (
 
 // SystemsPanel renders the configured trunking systems.
 type SystemsPanel struct {
-	tbl    table.Model
-	count  int
+	tbl      table.Model
+	lastHash uint64
 }
 
 func NewSystems() *SystemsPanel {
@@ -32,8 +31,14 @@ func (SystemsPanel) Title() string       { return "Systems" }
 func (SystemsPanel) Keys() []key.Binding { return nil }
 
 func (p *SystemsPanel) Update(msg tea.Msg, s *state.SharedState) (Panel, tea.Cmd) {
-	if len(s.Systems) != p.count {
+	h := hashRows(s.Systems, func(sys client.SystemDTO) string {
+		return fmt.Sprintf("%s|%s|%v|%d|%d|%d|%d",
+			sys.Name, sys.Protocol, sys.ControlChannels,
+			sys.WACN, sys.SystemID, sys.RFSS, sys.Site)
+	})
+	if h != p.lastHash {
 		p.refresh(s.Systems)
+		p.lastHash = h
 	}
 	if k, ok := msg.(tea.KeyMsg); ok && k.String() == "enter" {
 		row := p.tbl.SelectedRow()
@@ -66,7 +71,6 @@ func (p *SystemsPanel) refresh(sys []client.SystemDTO) {
 		rows = append(rows, table.Row{s.Name, s.Protocol, ccs, strings.Join(ids, " ")})
 	}
 	p.tbl.SetRows(rows)
-	p.count = len(sys)
 }
 
 func (p *SystemsPanel) View(width, height int, focused bool, s *state.SharedState) string {
@@ -97,36 +101,3 @@ func systemsColumns(w int) []table.Column {
 	}
 }
 
-// panelFrame is shared by all table panels: rounded border, title,
-// focus colour.
-func panelFrame(title string, w, h int, focused bool, body string) string {
-	border := lipgloss.NewStyle().
-		Border(lipgloss.RoundedBorder()).
-		BorderForeground(lipgloss.Color("240")).
-		Padding(0, 1)
-	if focused {
-		border = border.BorderForeground(lipgloss.Color("39"))
-	}
-	if w > 4 {
-		border = border.Width(w - 2)
-	}
-	if h > 4 {
-		border = border.Height(h - 2)
-	}
-	header := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("39")).Render(title)
-	return border.Render(header + "\n" + body)
-}
-
-func tableStyles() table.Styles {
-	s := table.DefaultStyles()
-	s.Header = s.Header.
-		BorderStyle(lipgloss.NormalBorder()).
-		BorderForeground(lipgloss.Color("240")).
-		BorderBottom(true).
-		Bold(true).
-		Foreground(lipgloss.Color("39"))
-	s.Selected = s.Selected.
-		Foreground(lipgloss.Color("231")).
-		Background(lipgloss.Color("57"))
-	return s
-}

--- a/internal/tui/panels/theme.go
+++ b/internal/tui/panels/theme.go
@@ -1,0 +1,39 @@
+package panels
+
+import (
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/MattCheramie/GopherTrunk/internal/tui/theme"
+)
+
+// Package-level inline-text styles consumed by every panel. Held as
+// var rather than func so call sites stay terse (`dashHeader.Render`
+// instead of `dashHeader().Render`). RefreshTheme rebuilds them after
+// a runtime palette swap (--no-color, future light-mode toggle, etc.)
+// so the root model can flip the whole panel package's colours in
+// one call.
+var (
+	dashHeader lipgloss.Style
+	dashOK     lipgloss.Style
+	dashErr    lipgloss.Style
+	dashDim    lipgloss.Style
+	dashAlert  lipgloss.Style
+	dashWarn   lipgloss.Style
+	dashAccent lipgloss.Style
+)
+
+func init() { RefreshTheme() }
+
+// RefreshTheme rebuilds the package-level styles from the active
+// theme.Theme(). Safe to call any time; mutates module-level vars so
+// don't call concurrently with a render.
+func RefreshTheme() {
+	p := theme.Theme()
+	dashHeader = p.Title()
+	dashOK = p.OK()
+	dashErr = p.Error()
+	dashDim = p.Dim()
+	dashAlert = p.Alert()
+	dashWarn = p.Warn()
+	dashAccent = p.Accented()
+}

--- a/internal/tui/panels/tones.go
+++ b/internal/tui/panels/tones.go
@@ -14,8 +14,9 @@ import (
 
 // TonesPanel renders the tone-alert ring buffer.
 type TonesPanel struct {
-	tbl  table.Model
-	last int
+	tbl      table.Model
+	last     int
+	lastHash uint64
 }
 
 func NewTones() *TonesPanel {
@@ -56,8 +57,13 @@ func (p *TonesPanel) Update(msg tea.Msg, s *state.SharedState) (Panel, tea.Cmd) 
 		}
 		return p, Emit(req)
 	}
-	if s.ToneAlerts != nil && s.ToneAlerts.Len() != p.last {
-		p.refresh(s)
+	if s.ToneAlerts != nil {
+		// Only the Len changes drive a refresh today (ring buffer is
+		// append-only). Hashing the snapshot is overkill — Len is the
+		// canonical invalidation signal.
+		if s.ToneAlerts.Len() != p.last {
+			p.refresh(s)
+		}
 	}
 	var cmd tea.Cmd
 	p.tbl, cmd = p.tbl.Update(msg)

--- a/internal/tui/panels/util.go
+++ b/internal/tui/panels/util.go
@@ -1,11 +1,66 @@
 package panels
 
 import (
+	"encoding/binary"
 	"encoding/json"
 	"fmt"
+	"hash/maphash"
 	"strings"
 	"time"
 )
+
+// hashSeed is the per-process maphash seed. Held module-wide so
+// successive hashRows calls on the same payload return the same
+// digest across an entire daemon run.
+var hashSeed = maphash.MakeSeed()
+
+// hashRows produces a stable digest over a slice of rows. Panels
+// call it on the latest snapshot from SharedState; if the digest
+// hasn't changed since the last refresh, the bubbles/table rebuild
+// is skipped — the user-flagged "rebuilt every tick" path.
+//
+// keyFn must return a deterministic string for each row covering
+// every field the table renders. Order matters; reordering a slice
+// counts as a change even if the contents are identical.
+func hashRows[T any](rows []T, keyFn func(T) string) uint64 {
+	var h maphash.Hash
+	h.SetSeed(hashSeed)
+	var buf [8]byte
+	binary.LittleEndian.PutUint64(buf[:], uint64(len(rows)))
+	_, _ = h.Write(buf[:])
+	for _, r := range rows {
+		_, _ = h.WriteString(keyFn(r))
+		_, _ = h.Write([]byte{0})
+	}
+	return h.Sum64()
+}
+
+// hashStringMap is the map-flavoured sibling of hashRows. metrics.go
+// holds map[string]float64; we sort keys so the digest is stable
+// across iteration order.
+func hashStringMap(m map[string]float64) uint64 {
+	var h maphash.Hash
+	h.SetSeed(hashSeed)
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	// stable sort without importing sort package for one call site —
+	// insertion sort over short maps is fine.
+	for i := 1; i < len(keys); i++ {
+		for j := i; j > 0 && keys[j-1] > keys[j]; j-- {
+			keys[j-1], keys[j] = keys[j], keys[j-1]
+		}
+	}
+	for _, k := range keys {
+		_, _ = h.WriteString(k)
+		_, _ = h.Write([]byte{0})
+		var buf [8]byte
+		binary.LittleEndian.PutUint64(buf[:], uint64(int64(m[k]*1000)))
+		_, _ = h.Write(buf[:])
+	}
+	return h.Sum64()
+}
 
 // jsonUnmarshal centralises the json.Unmarshal call so panels don't
 // each pull in encoding/json directly. Returns nil on empty raw.

--- a/internal/tui/state/state.go
+++ b/internal/tui/state/state.go
@@ -83,6 +83,8 @@ type SharedState struct {
 	ScannerErr  error
 	Audio       client.AudioStatusDTO
 	AudioErr    error
+	Runtime     client.RuntimeDTO
+	RuntimeErr  error
 
 	EventLog   RingReader[client.Event]
 	ToneAlerts RingReader[client.Event]

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -1,9 +1,14 @@
 package tui
 
-import "github.com/charmbracelet/lipgloss"
+import (
+	"github.com/charmbracelet/lipgloss"
 
-// styles bundles the lipgloss styles the panels share. Holding them
-// in one place keeps colour decisions in lockstep across panels.
+	"github.com/MattCheramie/GopherTrunk/internal/tui/theme"
+)
+
+// styles bundles the lipgloss styles the root model and modals
+// share. Every style is derived from theme.Theme() so a future
+// light-mode palette swap is a one-line change here.
 type styles struct {
 	border      lipgloss.Style
 	focusBorder lipgloss.Style
@@ -20,31 +25,28 @@ type styles struct {
 	toast       lipgloss.Style
 }
 
-// newStyles builds a style set. If noColor is true colours are
-// stripped — useful when writing to a non-TTY or when --no-color
-// is passed.
+// newStyles builds a style set. If noColor is true the active theme
+// is swapped to the monochrome palette so every accessor across the
+// process collapses to default fg/bg simultaneously.
 func newStyles(noColor bool) styles {
 	if noColor {
 		lipgloss.SetDefaultRenderer(lipgloss.NewRenderer(nil))
+		theme.Set(theme.MonochromePalette())
 	}
-	border := lipgloss.NewStyle().
-		Border(lipgloss.RoundedBorder()).
-		BorderForeground(lipgloss.Color("240")).
-		Padding(0, 1)
-	focus := border.Copy().BorderForeground(lipgloss.Color("39"))
+	p := theme.Theme()
 	return styles{
-		border:      border,
-		focusBorder: focus,
-		header:      lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("39")),
-		tab:         lipgloss.NewStyle().Padding(0, 1).Foreground(lipgloss.Color("245")),
-		activeTab:   lipgloss.NewStyle().Padding(0, 1).Foreground(lipgloss.Color("231")).Background(lipgloss.Color("39")).Bold(true),
-		statusBar:   lipgloss.NewStyle().Foreground(lipgloss.Color("245")).Background(lipgloss.Color("236")).Padding(0, 1),
-		dim:         lipgloss.NewStyle().Foreground(lipgloss.Color("245")),
-		accent:      lipgloss.NewStyle().Foreground(lipgloss.Color("39")).Bold(true),
-		alert:       lipgloss.NewStyle().Foreground(lipgloss.Color("196")).Bold(true),
-		ok:          lipgloss.NewStyle().Foreground(lipgloss.Color("42")),
-		error:       lipgloss.NewStyle().Foreground(lipgloss.Color("196")),
-		help:        lipgloss.NewStyle().Foreground(lipgloss.Color("245")),
-		toast:       lipgloss.NewStyle().Foreground(lipgloss.Color("231")).Background(lipgloss.Color("88")).Padding(0, 1),
+		border:      p.Frame(false),
+		focusBorder: p.Frame(true),
+		header:      p.Header(),
+		tab:         p.Tab(),
+		activeTab:   p.ActiveTab(),
+		statusBar:   p.StatusBar(),
+		dim:         p.Dim(),
+		accent:      p.Accented(),
+		alert:       p.Alert(),
+		ok:          p.OK(),
+		error:       p.Error(),
+		help:        p.Hint(),
+		toast:       p.Toast(),
 	}
 }

--- a/internal/tui/theme/theme.go
+++ b/internal/tui/theme/theme.go
@@ -1,0 +1,196 @@
+// Package theme owns the TUI's semantic colour palette and the
+// derived high-level lipgloss styles. Panels read from theme.Theme()
+// instead of hard-coding lipgloss.Color("…") literals so colour
+// decisions stay in one place and a future light-mode palette is a
+// one-line swap.
+//
+// The package lives outside internal/tui so internal/tui/panels can
+// import it without an import cycle.
+package theme
+
+import (
+	"sync/atomic"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+// Palette is the semantic colour set. Field names describe *role*,
+// not hue — Accent is the canonical highlight colour, Danger is
+// reserved for destructive/error surfaces, etc.
+type Palette struct {
+	Fg          lipgloss.Color
+	FgMuted     lipgloss.Color
+	BgAlt       lipgloss.Color
+	Accent      lipgloss.Color
+	Success     lipgloss.Color
+	Warning     lipgloss.Color
+	Danger      lipgloss.Color
+	Info        lipgloss.Color
+	Border      lipgloss.Color
+	BorderFocus lipgloss.Color
+	SelectBg    lipgloss.Color
+	ToastBg     lipgloss.Color
+}
+
+// DarkPalette is the default 256-colour palette tuned for dark
+// terminals. Numbers map to xterm-256: 39 (dodger blue), 42 (green),
+// 196 (red), 220 (yellow), 245 (light grey), 240 (mid grey), 236
+// (charcoal), 231 (white), 88 (dark red — for toast bg), 57 (purple
+// — for selected row bg).
+func DarkPalette() Palette {
+	return Palette{
+		Fg:          "231",
+		FgMuted:     "245",
+		BgAlt:       "236",
+		Accent:      "39",
+		Success:     "42",
+		Warning:     "220",
+		Danger:      "196",
+		Info:        "39",
+		Border:      "240",
+		BorderFocus: "39",
+		SelectBg:    "57",
+		ToastBg:     "88",
+	}
+}
+
+// MonochromePalette is used when --no-color is passed or stdout
+// isn't a TTY. Every role collapses to default fg/bg so lipgloss
+// emits no ANSI.
+func MonochromePalette() Palette {
+	return Palette{
+		Fg:          "",
+		FgMuted:     "",
+		BgAlt:       "",
+		Accent:      "",
+		Success:     "",
+		Warning:     "",
+		Danger:      "",
+		Info:        "",
+		Border:      "",
+		BorderFocus: "",
+		SelectBg:    "",
+		ToastBg:     "",
+	}
+}
+
+// Title returns the bold accent style used for panel titles and
+// section headers.
+func (p Palette) Title() lipgloss.Style {
+	return lipgloss.NewStyle().Bold(true).Foreground(p.Accent)
+}
+
+// Header is the table-header style — bold accent with a bottom
+// border in the muted colour.
+func (p Palette) Header() lipgloss.Style {
+	return lipgloss.NewStyle().Bold(true).Foreground(p.Accent)
+}
+
+// Hint is the dim helper-text style used in footers and inline
+// usage hints.
+func (p Palette) Hint() lipgloss.Style {
+	return lipgloss.NewStyle().Foreground(p.FgMuted)
+}
+
+// Selected is the highlight applied to the active row inside a
+// table-style panel.
+func (p Palette) Selected() lipgloss.Style {
+	return lipgloss.NewStyle().Foreground(p.Fg).Background(p.SelectBg)
+}
+
+// Frame returns the rounded border style, accenting the border
+// colour when focused. Named Frame rather than Border so it doesn't
+// collide with the Border colour field.
+func (p Palette) Frame(focused bool) lipgloss.Style {
+	s := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(p.Border).
+		Padding(0, 1)
+	if focused {
+		s = s.BorderForeground(p.BorderFocus)
+	}
+	return s
+}
+
+// OK returns the success-coloured inline style for "● ok" indicators.
+func (p Palette) OK() lipgloss.Style { return lipgloss.NewStyle().Foreground(p.Success) }
+
+// Error is the danger-coloured inline style for error indicators.
+func (p Palette) Error() lipgloss.Style { return lipgloss.NewStyle().Foreground(p.Danger) }
+
+// Alert is the bold danger style used for tone-alert-style attention
+// callouts. Same hue as Error but with weight to differentiate from
+// a passive error indicator.
+func (p Palette) Alert() lipgloss.Style {
+	return lipgloss.NewStyle().Bold(true).Foreground(p.Danger)
+}
+
+// Warn is the warning-coloured inline style — used for in-progress /
+// transient states like "hunting".
+func (p Palette) Warn() lipgloss.Style { return lipgloss.NewStyle().Foreground(p.Warning) }
+
+// Dim is the muted-foreground style for de-emphasised text.
+func (p Palette) Dim() lipgloss.Style { return lipgloss.NewStyle().Foreground(p.FgMuted) }
+
+// Accented returns a bold-accent inline style.
+func (p Palette) Accented() lipgloss.Style {
+	return lipgloss.NewStyle().Bold(true).Foreground(p.Accent)
+}
+
+// StatusBar returns the status-bar background style.
+func (p Palette) StatusBar() lipgloss.Style {
+	return lipgloss.NewStyle().Foreground(p.FgMuted).Background(p.BgAlt).Padding(0, 1)
+}
+
+// Tab returns an unselected-tab style.
+func (p Palette) Tab() lipgloss.Style {
+	return lipgloss.NewStyle().Padding(0, 1).Foreground(p.FgMuted)
+}
+
+// ActiveTab returns the selected-tab style — inverse fg/bg in the
+// accent colour.
+func (p Palette) ActiveTab() lipgloss.Style {
+	return lipgloss.NewStyle().Padding(0, 1).Foreground(p.Fg).Background(p.Accent).Bold(true)
+}
+
+// Toast returns the inline notification style — white on dark-red.
+func (p Palette) Toast() lipgloss.Style {
+	return lipgloss.NewStyle().Foreground(p.Fg).Background(p.ToastBg).Padding(0, 1)
+}
+
+// ModalBox returns the modal-window styling shared by the confirm and
+// detail modals. kind is one of "danger" / "info"; kind == "danger"
+// uses the Danger border colour (red), anything else uses Accent.
+func (p Palette) ModalBox(kind string) lipgloss.Style {
+	border := p.Accent
+	if kind == "danger" {
+		border = p.Danger
+	}
+	return lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(border).
+		Padding(1, 2).
+		Background(p.BgAlt).
+		Foreground(p.Fg)
+}
+
+// currentTheme is the process-wide singleton. Read with Theme(),
+// swapped with Set(). atomic.Pointer keeps the swap goroutine-safe
+// without taking a lock on every read.
+var currentTheme atomic.Pointer[Palette]
+
+func init() {
+	p := DarkPalette()
+	currentTheme.Store(&p)
+}
+
+// Theme returns the active palette. Always non-nil.
+func Theme() Palette {
+	return *currentTheme.Load()
+}
+
+// Set swaps the active palette. Pass MonochromePalette() to strip
+// colour, DarkPalette() to restore.
+func Set(p Palette) {
+	currentTheme.Store(&p)
+}

--- a/internal/tui/theme/theme_test.go
+++ b/internal/tui/theme/theme_test.go
@@ -1,0 +1,55 @@
+package theme
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestDarkPalette_NonEmpty(t *testing.T) {
+	p := DarkPalette()
+	if p.Accent == "" || p.Border == "" || p.Danger == "" {
+		t.Fatalf("dark palette has empty roles: %+v", p)
+	}
+}
+
+func TestMonochromePalette_AllEmpty(t *testing.T) {
+	p := MonochromePalette()
+	// Every colour role must collapse to default so lipgloss emits
+	// no ANSI on --no-color.
+	if p.Accent != "" || p.Border != "" || p.Danger != "" || p.Fg != "" {
+		t.Fatalf("monochrome palette has non-empty roles: %+v", p)
+	}
+}
+
+func TestSet_GoroutineSafe(t *testing.T) {
+	// Race-detector smoke: hammer Set and Theme from N goroutines.
+	// The atomic.Pointer swap should keep this clean under -race.
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				if i%2 == 0 {
+					Set(DarkPalette())
+				} else {
+					Set(MonochromePalette())
+				}
+				_ = Theme()
+			}
+		}(i)
+	}
+	wg.Wait()
+	// Restore dark for downstream tests.
+	Set(DarkPalette())
+}
+
+func TestFrame_FocusedHasDifferentBorder(t *testing.T) {
+	p := DarkPalette()
+	// Compare style attributes directly — lipgloss strips ANSI when
+	// the test process has no TTY, so Render output is identical
+	// regardless of colour, but the underlying style fields differ.
+	if p.Frame(false).GetBorderTopForeground() == p.Frame(true).GetBorderTopForeground() {
+		t.Fatal("Frame(true) and Frame(false) share the same border colour")
+	}
+}

--- a/internal/voice/player/alsa_linux.go
+++ b/internal/voice/player/alsa_linux.go
@@ -61,6 +61,11 @@ var (
 	sndPCMRecover   func(pcm uintptr, err int32, silent int32) int32
 )
 
+// loadALSAFn is the indirection that the real loadALSA fills. Tests
+// replace it to simulate a dlopen failure without touching the
+// shared library on disk.
+var loadALSAFn = loadALSA
+
 // loadALSA dlopens libasound2.so.2 once. Subsequent calls return
 // the cached error (if any). Idempotent.
 func loadALSA() error {
@@ -124,7 +129,19 @@ func newALSABackend(cfg Config) (Backend, error) {
 		return newIoctlALSABackend(cfg, spec)
 	}
 
-	if err := loadALSA(); err != nil {
+	if err := loadALSAFn(); err != nil {
+		// Linux distroless / Alpine images often ship the kernel
+		// sound subsystem (so /dev/snd/pcm*p exists) but not the
+		// userspace libasound2.so.2 SONAME. Falling back to the
+		// direct-ioctl backend keeps audio working out of the box
+		// in those environments. Only the dlopen failure path
+		// triggers the fallback — a libasound that loaded but failed
+		// to resolve a symbol is a deeper problem and still bubbles
+		// up. The fallback is gated by AutoFallback (default true)
+		// so tests + advanced operators can pin behaviour.
+		if !cfg.DisableAutoFallback && strings.Contains(err.Error(), "dlopen") {
+			return newIoctlALSABackend(cfg, "")
+		}
 		return nil, err
 	}
 

--- a/internal/voice/player/devices_linux.go
+++ b/internal/voice/player/devices_linux.go
@@ -1,0 +1,39 @@
+//go:build linux
+
+package player
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+)
+
+// listPlatformDevices walks /dev/snd looking for playback PCM nodes
+// matching pcmC{card}D{device}p. Each entry is returned as a string
+// the operator can drop straight into audio.device. Empty when the
+// host has no sound subsystem mounted (CI containers).
+func listPlatformDevices() []string {
+	entries, err := os.ReadDir("/dev/snd")
+	if err != nil {
+		return nil
+	}
+	var out []string
+	for _, e := range entries {
+		name := e.Name()
+		// "pcmC0D0p" → card=0 device=0 playback. Trailing 'p' means
+		// playback; 'c' would be capture. We only care about the
+		// playback side.
+		if !strings.HasPrefix(name, "pcmC") || !strings.HasSuffix(name, "p") {
+			continue
+		}
+		core := strings.TrimSuffix(strings.TrimPrefix(name, "pcmC"), "p")
+		i := strings.IndexByte(core, 'D')
+		if i < 0 {
+			continue
+		}
+		out = append(out, fmt.Sprintf("ioctl:hw:%s,%s", core[:i], core[i+1:]))
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/voice/player/devices_other.go
+++ b/internal/voice/player/devices_other.go
@@ -1,0 +1,9 @@
+//go:build !linux
+
+package player
+
+// listPlatformDevices is a no-op on non-Linux platforms. macOS and
+// Windows route through oto, which doesn't expose per-device
+// enumeration today; the canonical "default (system output)" entry
+// listed by ListDevices is the only choice.
+func listPlatformDevices() []string { return nil }

--- a/internal/voice/player/fallback_linux_test.go
+++ b/internal/voice/player/fallback_linux_test.go
@@ -1,0 +1,79 @@
+//go:build linux
+
+package player
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// TestNewALSABackend_FallsBackToIoctlOnDlopenFailure stubs loadALSAFn
+// to simulate a missing libasound2.so.2 and asserts the backend
+// constructor reaches the direct-ioctl path. The ioctl backend
+// itself is allowed to fail (no /dev/snd in CI) — we only care that
+// the *fallback was attempted*, which the distinct error wording
+// reveals.
+func TestNewALSABackend_FallsBackToIoctlOnDlopenFailure(t *testing.T) {
+	prev := loadALSAFn
+	loadALSAFn = func() error {
+		return errors.New("dlopen libasound.so.2: image not found")
+	}
+	defer func() { loadALSAFn = prev }()
+
+	_, err := newALSABackend(Config{
+		Enabled:    true,
+		SampleRate: 8000,
+		BufferMs:   80,
+	})
+	// Expect an ioctl-prefixed error if /dev/snd isn't available in
+	// the test environment, or no error if it is.
+	if err == nil {
+		return
+	}
+	if !strings.Contains(err.Error(), "ioctl-alsa:") {
+		t.Fatalf("error not from ioctl path: %v", err)
+	}
+}
+
+// TestNewALSABackend_NoFallbackWhenDisabled asserts the
+// DisableAutoFallback knob actually disables the fallback.
+func TestNewALSABackend_NoFallbackWhenDisabled(t *testing.T) {
+	prev := loadALSAFn
+	loadALSAFn = func() error {
+		return errors.New("dlopen libasound.so.2: image not found")
+	}
+	defer func() { loadALSAFn = prev }()
+
+	_, err := newALSABackend(Config{
+		Enabled:             true,
+		SampleRate:          8000,
+		DisableAutoFallback: true,
+	})
+	if err == nil {
+		t.Fatal("expected dlopen error to bubble up, got nil")
+	}
+	if !strings.Contains(err.Error(), "dlopen") {
+		t.Fatalf("expected dlopen error, got: %v", err)
+	}
+}
+
+// TestListDevices_IncludesNullAndDefault makes sure the new entries
+// land in the output. Ioctl entries are platform-dependent (no
+// /dev/snd in CI sandboxes) so we don't assert on them here.
+func TestListDevices_IncludesNullAndDefault(t *testing.T) {
+	got := ListDevices()
+	wantPrefixes := []string{"default", "null"}
+	for _, want := range wantPrefixes {
+		var found bool
+		for _, d := range got {
+			if strings.HasPrefix(d, want) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("missing %q entry in %v", want, got)
+		}
+	}
+}

--- a/internal/voice/player/player.go
+++ b/internal/voice/player/player.go
@@ -47,6 +47,12 @@ type Config struct {
 	Volume float32
 	// Muted is the initial mute state.
 	Muted bool
+	// DisableAutoFallback turns OFF the default Linux behaviour of
+	// transparently dropping to the direct-ioctl backend when
+	// libasound2.so.2 fails to dlopen (typical on distroless /
+	// Alpine images). Zero value (false) = auto-fallback enabled.
+	// Other platforms ignore the flag.
+	DisableAutoFallback bool
 }
 
 // Backend is the per-OS audio sink the Player drives. Production
@@ -293,14 +299,15 @@ func (p *Player) run() {
 }
 
 // ListDevices returns the audio outputs the linked backend can route
-// to. Both the oto-based backend (macOS / Windows) and the ALSA-based
-// backend (Linux) route to the OS default sink — neither exposes a
-// device picker today — so the listing is always one entry. Kept on
-// the package surface so `gophertrunk audio list` has something to
-// print and future backends can plug in real enumeration without
-// changing the CLI shape.
+// to. On Linux the listing includes "default" (system sink via
+// libasound2 or the ioctl fallback), "null" (no-op backend), plus an
+// entry per /dev/snd/pcmC*D*p the kernel exposes — the latter are
+// what audio.device: "ioctl:hw:C,D" selects. On macOS / Windows the
+// list is short by design (oto routes to the OS default sink).
 func ListDevices() []string {
-	return []string{"default (system output)"}
+	devs := []string{"default (system output)", "null (no-op)"}
+	devs = append(devs, listPlatformDevices()...)
+	return devs
 }
 
 // String returns a human-readable description of the player state,


### PR DESCRIPTION
Polish the TUI against ten design principles and surface every
config knob, output, protocol, and setting the daemon exposes —
plus make the binary run dependency-free on Linux/macOS/Windows
× amd64/arm64 out of the box.

Theme & spatial consistency
- internal/tui/theme: semantic palette (Fg/FgMuted/BgAlt/Accent/
  Success/Warning/Danger/Info/Border/BorderFocus/SelectBg/ToastBg)
  with Dark + Monochrome presets; atomic.Pointer-backed Theme()
  getter so --no-color flips every accessor at once
- panels migrate every ad-hoc lipgloss.Color literal to the
  palette; panelFrame inverts the title bar on focus for clearer
  visual focus indication
- internal/tui/panels/frame.go consolidates panelFrame +
  tableStyles in one place

Command palette + keyboard-first
- ctrl+p opens a fuzzy-matching palette over: panel jumps,
  audio mutations (vol/mute/record), retention sweep, scanner
  hold/resume, system + talkgroup + device drill-ins (tg list
  capped at 200 for legibility); up/down + enter + esc
- ? help overlay shows global + active-panel keybinds in two
  columns; closes with ? / esc / q

Responsive reflow + mouse
- renderTabs collapses to compact "1 2 3 ⋯ ⌃P more" strip
  when the full label set won't fit; full strip otherwise
- tab strip caches per-tab x-rects; tea.MouseMsg left-click in
  row 0 maps back to the panel and switches active
- Dashboard cards stack single-column below 80 cols

Differential rendering
- hash/maphash content hash gates table rebuilds across Systems,
  Active, History, Devices, Settings, Metrics; tables only
  SetRows when the underlying snapshot actually changed

Operator console (every feature visible)
- /api/v1/runtime serves a sanitized RuntimeDTO (API listeners,
  storage paths, retention windows, recording config + CMA EQ,
  audio device list, SDR backends, scanner CC-hunt timing,
  tone-out profiles, vocoder map per protocol, log + metrics
  flags). Daemon supplies the impl from cfg + registries.
- TUI Settings panel becomes a tabbed inspector — Daemon /
  Storage / Audio / Recording / Tones / API / Vocoders / SDR /
  FEC opt-ins; tabs cycle with [ ] h l ← →
- Polling Cmd added at 30s cadence

Audio auto-fallback (Linux dependency-free by default)
- newALSABackend: if libasound2.so.2 dlopen fails, transparently
  fall through to the direct-ioctl path (no libasound2 needed on
  distroless / Alpine). Opt-out via cfg.DisableAutoFallback.
- player.ListDevices enumerates /dev/snd/pcmC*D*p so the Audio
  tab shows real ioctl:hw:C,D choices alongside "default" /
  "null"

Cross-platform build
- make cross-build emits CGO_ENABLED=0 binaries for
  linux/darwin/windows × amd64/arm64 under dist/
- make release-archives wraps each in tar.gz / .zip

Tests
- internal/tui/theme: palette role coverage, atomic swap race
- internal/tui/palette_test: fuzzy scorer, panel-jump discovery,
  Enter dispatch, Esc dismiss
- internal/tui/mouse_test: hit-test selects clicked tab, ignores
  body clicks
- internal/tui/panels/diff_test: hash stability under reorder +
  content change, map order invariance
- internal/voice/player/fallback_linux_test: stubs loadALSAFn to
  simulate dlopen failure, asserts ioctl path engaged;
  DisableAutoFallback opts out cleanly; ListDevices includes
  default + null
- internal/api/handlers_runtime_test: 503 when unconfigured,
  round-trips DTO when wired

https://claude.ai/code/session_013UdgEk62qv27bpRiNu161A