### PR TITLE
tui: finish polish plan — Revealer + MouseAware + async history

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,29 @@ to its own package and lands independently.
 
 ### Recently shipped
 
+- **TUI Revealer / MouseAware: palette + mouse converge on the same
+  row.** Picking a system / talkgroup / device from `Ctrl+P` now
+  jumps to the destination panel and pre-positions the panel's
+  cursor on the matching row before opening the detail modal —
+  follow-up keystrokes (`Enter`, mutation keys) operate on the
+  selection without an extra scroll. A new `panels.Revealer`
+  interface formalises the contract; SystemsPanel (by name),
+  TalkgroupsPanel (by decimal ID), DevicesPanel (by serial), and
+  ScannerPanel (by `sys:<name>` / `conv:<idx>`) implement it.
+  Mouse hit-testing was extended past the tab strip via a sibling
+  `panels.MouseAware` interface: left-clicks on data rows in the
+  three table panels translate the click position to a row index
+  (accounting for the canonical panelFrame chrome offset) and call
+  `SetCursor`. Chrome clicks are ignored; out-of-range clicks
+  clamp to the last row.
+- **Async history refresh off the Update goroutine.** The history
+  panel was the one remaining surface that built its bubbles/table
+  rows inline inside `Update`. The conversion now runs in a
+  `tea.Cmd` and commits via a routed `HistoryRefreshedMsg`; a
+  `pendingAt` guard prevents duplicate dispatch and stale results
+  (a newer snapshot landed mid-flight) are dropped silently. The
+  reducer stays unblocked on row formatting that doesn't need to
+  hold it.
 - **Direct-ioctl ALSA backend (drops the runtime libasound2 dep).**
   Setting `audio.device: ioctl` (or `ioctl:hw:C,D` for a specific
   card / device) on Linux selects a direct-kernel backend that
@@ -1883,6 +1906,7 @@ refresh, automatic reconnect on disconnect:
 | --- | --- |
 | `Tab` / `Shift+Tab` | next / previous panel |
 | `1`–`9`, `0` | jump to Dashboard / Systems / Talkgroups / Active / History / Events / Tones / Metrics / Devices / Scanner |
+| `Ctrl+P` | open fuzzy command palette (panel jumps, system / TG / device drill-ins, audio mutations, retention sweep, scanner hold/resume) |
 | `j` / `k` | move row up / down inside a table |
 | `/` | filter (Talkgroups, Events) |
 | `s` | cycle sort (Talkgroups) |
@@ -1895,6 +1919,18 @@ refresh, automatic reconnect on disconnect:
 | `r` | reload (History) |
 | `?` | toggle help |
 | `q` / `Ctrl+C` | quit |
+
+The tab strip is also clickable, and a left-click on any data row in
+the Systems / Talkgroups / Devices panels moves the cursor onto that
+row — pair it with `Enter` to open the detail card or with a
+mutation key to act on the selection. Picking a system / talkgroup /
+device from the command palette pre-positions the destination panel's
+cursor on the matching row before opening the detail modal, so
+keyboard and mouse paths converge on the same selection.
+
+Settings is a tabbed inspector (`[` / `]` to cycle) covering
+Daemon · Storage · Audio · Recording · Tones · API · Vocoders · SDR
+— every config knob the daemon reads is visible.
 
 For mutation actions (end-call; set talkgroup priority / lockout /
 scan; retention-sweep; tone-detector reset; scanner cockpit

--- a/internal/tui/mouse.go
+++ b/internal/tui/mouse.go
@@ -3,6 +3,7 @@ package tui
 import (
 	tea "github.com/charmbracelet/bubbletea"
 
+	"github.com/MattCheramie/GopherTrunk/internal/tui/panels"
 	"github.com/MattCheramie/GopherTrunk/internal/tui/state"
 )
 
@@ -14,25 +15,50 @@ type tabRect struct {
 	xStart, xEnd int
 }
 
+// bodyTopY records the row at which the active panel's frame begins —
+// always immediately under the tab strip. Cached at render time so
+// body clicks can be translated into panel-local coordinates without
+// re-measuring.
+//
+// The tab strip is currently a single line in every rendered layout
+// (renderTabs returns one row regardless of wide vs. compact mode),
+// so this defaults to 1. The field is kept on the Model so future
+// multi-line chrome (e.g. a session banner) can update it from one
+// place.
+//
+// We don't measure lipgloss.Height(tabs) here because that would
+// re-invoke renderTabs from a non-View path and force a duplicate
+// render. Storing the height during View() is simpler.
+
 // handleMouseMsg routes a tea.MouseMsg to the right tabbable
-// surface. Currently only the tab strip (top row) and the "more"
-// pill (also top row) are wired. Returns true when the click was
-// consumed.
+// surface. Left-clicks on the tab strip switch panels; left-clicks in
+// the body are delegated to the active panel when it implements
+// panels.MouseAware. Returns true when the click was consumed.
 func (m *Model) handleMouseMsg(msg tea.MouseMsg) (tea.Cmd, bool) {
 	if msg.Button != tea.MouseButtonLeft || msg.Action != tea.MouseActionPress {
 		return nil, false
 	}
-	// Tab strip is always row 0. If the click is below the strip
-	// pass it through to the active panel (delegated below in
-	// Update once panel-side mouse hooks land).
-	if msg.Y != 0 {
+	// Tab strip is always row 0 — both wide and compact tab renderers
+	// emit a single line.
+	if msg.Y == 0 {
+		for _, r := range m.tabRects {
+			if msg.X >= r.xStart && msg.X < r.xEnd {
+				m.active = r.kind
+				return nil, true
+			}
+		}
 		return nil, false
 	}
-	for _, r := range m.tabRects {
-		if msg.X >= r.xStart && msg.X < r.xEnd {
-			m.active = r.kind
-			return nil, true
-		}
+	// Body clicks: delegate to the active panel if it cares. Local Y
+	// is global Y minus the tab strip height (one row).
+	if int(m.active) < 0 || int(m.active) >= len(m.panels) {
+		return nil, false
 	}
-	return nil, false
+	aware, ok := m.panels[m.active].(panels.MouseAware)
+	if !ok {
+		return nil, false
+	}
+	localY := msg.Y - 1
+	cmd := aware.HandleMouseAt(msg.X, localY)
+	return cmd, true
 }

--- a/internal/tui/mouse_test.go
+++ b/internal/tui/mouse_test.go
@@ -5,6 +5,8 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 
+	"github.com/MattCheramie/GopherTrunk/internal/tui/client"
+	"github.com/MattCheramie/GopherTrunk/internal/tui/panels"
 	"github.com/MattCheramie/GopherTrunk/internal/tui/state"
 )
 
@@ -34,22 +36,50 @@ func TestHitTestTab_SelectsClickedTab(t *testing.T) {
 	}
 }
 
-func TestHitTestTab_IgnoresBodyClicks(t *testing.T) {
+func TestHitTestTab_BodyClickDelegatesToActivePanel(t *testing.T) {
 	m := newTestModel(t)
 	m.width = 200
 	m.height = 24
 	_ = m.renderTabs()
-	original := m.active
+	// Land on Systems so the click feeds into a MouseAware panel.
+	m.active = state.PanelSystems
+	m.shared.Systems = []client.SystemDTO{
+		{Name: "A", Protocol: "p25"},
+		{Name: "B", Protocol: "dmr"},
+		{Name: "C", Protocol: "nxdn"},
+	}
+	// One Update tick populates the systems table.
+	_, _ = m.panels[state.PanelSystems].Update(tea.WindowSizeMsg{Width: m.width, Height: m.height}, m.shared)
+
+	// Click on body row 1: global Y == 1 (tab strip) + 3 (border, title, col header) + 1 = 5.
 	msg := tea.MouseMsg{
-		X: 5, Y: 8, // below the tab strip
+		X: 5, Y: 5,
+		Button: tea.MouseButtonLeft,
+		Action: tea.MouseActionPress,
+	}
+	_, consumed := m.handleMouseMsg(msg)
+	if !consumed {
+		t.Fatal("body click on MouseAware panel should be consumed")
+	}
+	if got := m.panels[state.PanelSystems].(*panels.SystemsPanel); got.Cursor() != 1 {
+		t.Errorf("systems cursor = %d, want 1", got.Cursor())
+	}
+}
+
+func TestHitTestTab_BodyClickWithoutMouseAware(t *testing.T) {
+	m := newTestModel(t)
+	m.width = 200
+	m.height = 24
+	_ = m.renderTabs()
+	// Dashboard isn't MouseAware — body clicks should not be consumed.
+	m.active = state.PanelDashboard
+	msg := tea.MouseMsg{
+		X: 5, Y: 8,
 		Button: tea.MouseButtonLeft,
 		Action: tea.MouseActionPress,
 	}
 	_, consumed := m.handleMouseMsg(msg)
 	if consumed {
-		t.Fatal("body click should not be consumed by tab hit-test")
-	}
-	if m.active != original {
-		t.Errorf("active changed unexpectedly: %v → %v", original, m.active)
+		t.Errorf("dashboard body click should be left unconsumed")
 	}
 }

--- a/internal/tui/palette.go
+++ b/internal/tui/palette.go
@@ -287,6 +287,7 @@ func (m *Model) discoverActions() []paletteAction {
 			Label: "Scanner: hold/resume hunt — " + sys.Name,
 			Kind:  "scanner",
 			Run: func(mm *Model) tea.Cmd {
+				mm.revealOn(state.PanelScanner, "sys:"+sys.Name)
 				kind := state.WriteKindScannerHuntHold
 				verb := "hold"
 				if sys.State == "held" {
@@ -303,7 +304,10 @@ func (m *Model) discoverActions() []paletteAction {
 		})
 	}
 
-	// 6) System / talkgroup / device drill-ins — handy nav.
+	// 6) System / talkgroup / device drill-ins — handy nav. Each
+	// action jumps to the relevant panel, pre-positions the panel's
+	// cursor on the matching row via the Revealer interface, and
+	// fires the detail modal where applicable.
 	for _, sys := range m.shared.Systems {
 		sys := sys
 		out = append(out, paletteAction{
@@ -311,6 +315,8 @@ func (m *Model) discoverActions() []paletteAction {
 			Label: "Open system: " + sys.Name + " (" + sys.Protocol + ")",
 			Kind:  "system",
 			Run: func(mm *Model) tea.Cmd {
+				mm.active = state.PanelSystems
+				mm.revealOn(state.PanelSystems, sys.Name)
 				return func() tea.Msg { return panels.SystemDetailMsg{Name: sys.Name} }
 			},
 		})
@@ -332,6 +338,8 @@ func (m *Model) discoverActions() []paletteAction {
 			Label: fmt.Sprintf("Open TG %d  %s", tg.ID, alpha),
 			Kind:  "talkgroup",
 			Run: func(mm *Model) tea.Cmd {
+				mm.active = state.PanelTalkgroups
+				mm.revealOn(state.PanelTalkgroups, fmt.Sprintf("%d", tg.ID))
 				return func() tea.Msg { return panels.TalkgroupDetailMsg{ID: tg.ID} }
 			},
 		})
@@ -344,12 +352,24 @@ func (m *Model) discoverActions() []paletteAction {
 			Kind:  "device",
 			Run: func(mm *Model) tea.Cmd {
 				mm.active = state.PanelDevices
+				mm.revealOn(state.PanelDevices, dev.Serial)
 				return nil
 			},
 		})
 	}
 
 	return out
+}
+
+// revealOn calls Reveal(key) on the target panel if it implements
+// panels.Revealer. Silent no-op otherwise — Revealer is opt-in.
+func (m *Model) revealOn(kind state.PanelKind, key string) {
+	if int(kind) < 0 || int(kind) >= len(m.panels) {
+		return
+	}
+	if r, ok := m.panels[kind].(panels.Revealer); ok {
+		r.Reveal(key)
+	}
 }
 
 func paletteAudioVol(delta float32) func(*Model) tea.Cmd {

--- a/internal/tui/panels/devices.go
+++ b/internal/tui/panels/devices.go
@@ -93,6 +93,25 @@ func (p *DevicesPanel) View(width, height int, focused bool, s *state.SharedStat
 	return panelFrame("Devices", width, height, focused, body)
 }
 
+// Reveal positions the cursor on the row whose Serial matches key.
+func (p *DevicesPanel) Reveal(key string) {
+	for i, row := range p.tbl.Rows() {
+		if len(row) > 0 && row[0] == key {
+			p.tbl.SetCursor(i)
+			return
+		}
+	}
+}
+
+// HandleMouseAt moves the cursor to the clicked data row.
+func (p *DevicesPanel) HandleMouseAt(_, localY int) tea.Cmd {
+	idx := tableRowFromLocalY(localY, len(p.tbl.Rows()))
+	if idx >= 0 {
+		p.tbl.SetCursor(idx)
+	}
+	return nil
+}
+
 func devicesColumns(w int) []table.Column {
 	if w < 60 {
 		w = 60

--- a/internal/tui/panels/history.go
+++ b/internal/tui/panels/history.go
@@ -18,10 +18,24 @@ import (
 // when this panel becomes active and again when the user presses
 // `r`. The panel does not poll continuously — history is a stable
 // list and the daemon already paginates it.
+//
+// Refresh is asynchronous: when the SharedState hash for History
+// changes, Update returns a tea.Cmd that builds the new []table.Row
+// slice off the Update goroutine. The result arrives back as a
+// HistoryRefreshedMsg and is committed only when its hash still
+// matches the latest snapshot — newer results win.
 type HistoryPanel struct {
-	tbl      table.Model
-	lastHash uint64
-	reloadAt time.Time
+	tbl       table.Model
+	lastHash  uint64
+	pendingAt uint64 // hash of the in-flight async refresh, 0 when idle
+	reloadAt  time.Time
+}
+
+// HistoryRefreshedMsg carries the result of an async refresh job.
+// Exported so the root model can route it to the history panel.
+type HistoryRefreshedMsg struct {
+	Hash uint64
+	Rows []table.Row
 }
 
 // NewHistory constructs the panel.
@@ -55,6 +69,15 @@ func (p *HistoryPanel) Update(msg tea.Msg, s *state.SharedState) (Panel, tea.Cmd
 			p.reloadAt = time.Now()
 			return p, nil
 		}
+	case HistoryRefreshedMsg:
+		// Drop stale results — a newer snapshot landed in between
+		// dispatch and completion.
+		if m.Hash == p.pendingAt {
+			p.tbl.SetRows(m.Rows)
+			p.lastHash = m.Hash
+			p.pendingAt = 0
+		}
+		return p, nil
 	}
 	h := hashRows(s.History, func(r client.CallRow) string {
 		return fmt.Sprintf("%s|%s|%d|%s|%d|%s|%s",
@@ -63,37 +86,50 @@ func (p *HistoryPanel) Update(msg tea.Msg, s *state.SharedState) (Panel, tea.Cmd
 			r.GroupID, r.TalkgroupAlpha, r.SourceID,
 			r.System, r.EndReason)
 	})
-	if h != p.lastHash {
-		p.refresh(s.History)
-		p.lastHash = h
+	var refreshCmd tea.Cmd
+	if h != p.lastHash && h != p.pendingAt {
+		// Take a defensive copy so the goroutine sees a stable view
+		// of the input — the root model may overwrite s.History on
+		// the next poll tick.
+		snapshot := append([]client.CallRow(nil), s.History...)
+		p.pendingAt = h
+		refreshCmd = buildHistoryRowsCmd(snapshot, h)
 	}
 	var cmd tea.Cmd
 	p.tbl, cmd = p.tbl.Update(msg)
+	if refreshCmd != nil {
+		cmd = tea.Batch(refreshCmd, cmd)
+	}
 	return p, cmd
 }
 
-func (p *HistoryPanel) refresh(rows []client.CallRow) {
-	out := make([]table.Row, 0, len(rows))
-	for _, r := range rows {
-		alpha := r.TalkgroupAlpha
-		if alpha == "" {
-			alpha = "—"
+// buildHistoryRowsCmd returns a tea.Cmd that formats rows off the
+// Update goroutine and delivers them as a HistoryRefreshedMsg. The
+// hash is echoed so the panel can drop stale results.
+func buildHistoryRowsCmd(rows []client.CallRow, hash uint64) tea.Cmd {
+	return func() tea.Msg {
+		out := make([]table.Row, 0, len(rows))
+		for _, r := range rows {
+			alpha := r.TalkgroupAlpha
+			if alpha == "" {
+				alpha = "—"
+			}
+			ended := "—"
+			if !r.EndedAt.IsZero() {
+				ended = r.EndedAt.Format("15:04:05")
+			}
+			out = append(out, table.Row{
+				r.StartedAt.Format("01-02 15:04:05"),
+				ended,
+				fmt.Sprintf("%d", r.GroupID),
+				alpha,
+				fmt.Sprintf("%d", r.SourceID),
+				r.System,
+				r.EndReason,
+			})
 		}
-		ended := "—"
-		if !r.EndedAt.IsZero() {
-			ended = r.EndedAt.Format("15:04:05")
-		}
-		out = append(out, table.Row{
-			r.StartedAt.Format("01-02 15:04:05"),
-			ended,
-			fmt.Sprintf("%d", r.GroupID),
-			alpha,
-			fmt.Sprintf("%d", r.SourceID),
-			r.System,
-			r.EndReason,
-		})
+		return HistoryRefreshedMsg{Hash: hash, Rows: out}
 	}
-	p.tbl.SetRows(out)
 }
 
 func (p *HistoryPanel) View(width, height int, focused bool, s *state.SharedState) string {

--- a/internal/tui/panels/history_async_test.go
+++ b/internal/tui/panels/history_async_test.go
@@ -1,0 +1,110 @@
+package panels
+
+import (
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/MattCheramie/GopherTrunk/internal/tui/client"
+	"github.com/MattCheramie/GopherTrunk/internal/tui/state"
+)
+
+// historyMsg drives Update with a non-key, non-refresh message so we
+// exercise the hash-diff path without triggering reload-on-keypress.
+type historyMsg struct{}
+
+func TestHistoryPanel_AsyncRefresh_HappyPath(t *testing.T) {
+	p := NewHistory()
+	s := &state.SharedState{History: []client.CallRow{
+		{ID: 1, GroupID: 100, System: "Alpha", TalkgroupAlpha: "DISPATCH",
+			StartedAt: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)},
+		{ID: 2, GroupID: 200, System: "Bravo",
+			StartedAt: time.Date(2024, 1, 1, 0, 1, 0, 0, time.UTC)},
+	}}
+
+	// First Update on a fresh panel: hash mismatch → spawn a refresh
+	// Cmd. Table is still empty (commit only happens when the msg
+	// returns).
+	_, cmd := p.Update(historyMsg{}, s)
+	if cmd == nil {
+		t.Fatal("expected a refresh Cmd on first Update")
+	}
+	if got := len(p.tbl.Rows()); got != 0 {
+		t.Errorf("table rebuilt synchronously: %d rows", got)
+	}
+	if p.pendingAt == 0 {
+		t.Errorf("pendingAt not stamped")
+	}
+
+	// Run the Cmd to completion (tests run synchronously; the Cmd is
+	// just a function returning a tea.Msg).
+	msg := cmd()
+	got, ok := msg.(HistoryRefreshedMsg)
+	if !ok {
+		// Cmd may have been batched with the table's own Update cmd.
+		// Drain a tea.BatchMsg.
+		if bm, isBatch := msg.(tea.BatchMsg); isBatch {
+			for _, c := range bm {
+				if c == nil {
+					continue
+				}
+				if m, ok := c().(HistoryRefreshedMsg); ok {
+					got = m
+					ok = true
+					break
+				}
+			}
+		}
+		if !ok {
+			t.Fatalf("Cmd produced %T, want HistoryRefreshedMsg", msg)
+		}
+	}
+	if len(got.Rows) != 2 {
+		t.Errorf("HistoryRefreshedMsg.Rows = %d, want 2", len(got.Rows))
+	}
+
+	// Feed the msg back into Update — table commits.
+	_, _ = p.Update(got, s)
+	if got := len(p.tbl.Rows()); got != 2 {
+		t.Errorf("after commit table has %d rows, want 2", got)
+	}
+	if p.pendingAt != 0 {
+		t.Errorf("pendingAt should reset after commit, got %d", p.pendingAt)
+	}
+}
+
+func TestHistoryPanel_AsyncRefresh_StaleResultDropped(t *testing.T) {
+	p := NewHistory()
+	stale := HistoryRefreshedMsg{Hash: 42, Rows: nil}
+	// Feeding a msg whose hash doesn't match pendingAt (== 0 on a
+	// fresh panel) must be a no-op.
+	_, _ = p.Update(stale, &state.SharedState{})
+	if got := len(p.tbl.Rows()); got != 0 {
+		t.Errorf("stale msg committed %d rows", got)
+	}
+}
+
+func TestHistoryPanel_AsyncRefresh_NoDuplicateDispatch(t *testing.T) {
+	p := NewHistory()
+	s := &state.SharedState{History: []client.CallRow{
+		{ID: 1, GroupID: 100, System: "A",
+			StartedAt: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)},
+	}}
+	_, cmd1 := p.Update(historyMsg{}, s)
+	if cmd1 == nil {
+		t.Fatal("first Update should dispatch a refresh")
+	}
+	// Second Update with the same snapshot: pendingAt is set, so we
+	// must not dispatch a second goroutine for the same hash.
+	_, cmd2 := p.Update(historyMsg{}, s)
+	if cmd2 != nil {
+		// cmd2 may carry the table's own bubbles/table Cmd, but it
+		// must not contain a buildHistoryRowsCmd. The simplest check:
+		// only one refresh msg arrives across both Cmds.
+		msg2 := cmd2()
+		if _, ok := msg2.(HistoryRefreshedMsg); ok {
+			t.Errorf("second Update dispatched a duplicate refresh")
+		}
+	}
+}

--- a/internal/tui/panels/panel.go
+++ b/internal/tui/panels/panel.go
@@ -20,3 +20,22 @@ type Panel interface {
 	Update(msg tea.Msg, shared *state.SharedState) (Panel, tea.Cmd)
 	View(width, height int, focused bool, shared *state.SharedState) string
 }
+
+// Revealer is an optional interface for panels that can pre-position
+// their internal cursor on a specific row when the operator jumps in
+// from the command palette. key is panel-defined: SystemsPanel takes
+// a system name, TalkgroupsPanel a decimal ID, DevicesPanel a serial,
+// ScannerPanel "sys:<name>" or "conv:<idx>".
+type Revealer interface {
+	Reveal(key string)
+}
+
+// MouseAware is an optional interface for panels that want to react to
+// left-clicks inside their body. localY is the row index relative to
+// the panel's top-left (0 = panel border row). Implementations should
+// translate it into a row index and call SetCursor on their internal
+// table. Returning a tea.Cmd is permitted but most implementations
+// will return nil.
+type MouseAware interface {
+	HandleMouseAt(localX, localY int) tea.Cmd
+}

--- a/internal/tui/panels/reveal_test.go
+++ b/internal/tui/panels/reveal_test.go
@@ -1,0 +1,141 @@
+package panels
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/MattCheramie/GopherTrunk/internal/tui/client"
+	"github.com/MattCheramie/GopherTrunk/internal/tui/state"
+)
+
+func TestSystemsPanel_RevealPositionsCursor(t *testing.T) {
+	p := NewSystems()
+	s := &state.SharedState{Systems: []client.SystemDTO{
+		{Name: "Alpha", Protocol: "p25"},
+		{Name: "Bravo", Protocol: "dmr"},
+		{Name: "Charlie", Protocol: "nxdn"},
+	}}
+	_, _ = p.Update(tea.WindowSizeMsg{Width: 120, Height: 30}, s)
+
+	p.Reveal("Bravo")
+	if got := p.tbl.Cursor(); got != 1 {
+		t.Errorf("cursor = %d, want 1 after Reveal(Bravo)", got)
+	}
+	// Unknown key is a no-op.
+	p.Reveal("Zulu")
+	if got := p.tbl.Cursor(); got != 1 {
+		t.Errorf("cursor = %d, want 1 after Reveal(Zulu)", got)
+	}
+}
+
+func TestTalkgroupsPanel_RevealByID(t *testing.T) {
+	p := NewTalkgroups()
+	s := &state.SharedState{Talkgroups: []client.TalkgroupDTO{
+		{ID: 1001, AlphaTag: "DISPATCH"},
+		{ID: 1002, AlphaTag: "TACTICAL"},
+		{ID: 1003, AlphaTag: "FIRE"},
+	}}
+	_, _ = p.Update(tea.WindowSizeMsg{Width: 120, Height: 30}, s)
+
+	p.Reveal("1003")
+	if got := p.tbl.Cursor(); got != 2 {
+		t.Errorf("cursor = %d, want 2 after Reveal(1003)", got)
+	}
+}
+
+func TestDevicesPanel_RevealBySerial(t *testing.T) {
+	p := NewDevices()
+	s := &state.SharedState{Devices: []client.SDRStatus{
+		{Serial: "AAA"},
+		{Serial: "BBB"},
+	}}
+	_, _ = p.Update(tea.WindowSizeMsg{Width: 120, Height: 30}, s)
+	p.Reveal("BBB")
+	if got := p.tbl.Cursor(); got != 1 {
+		t.Errorf("cursor = %d, want 1 after Reveal(BBB)", got)
+	}
+}
+
+func TestScannerPanel_RevealResolvedOnNextUpdate(t *testing.T) {
+	p := NewScanner()
+	s := &state.SharedState{Scanner: client.ScannerStatusDTO{
+		Systems: []client.SystemHuntStatusDTO{
+			{Name: "Alpha"},
+			{Name: "Bravo"},
+		},
+		Conventional: client.ConvScannerStatusDTO{Enabled: true,
+			Channels: []client.ConvChannelStatusDTO{
+				{Index: 0, Label: "PD"},
+				{Index: 1, Label: "FD"},
+			}},
+	}}
+	// Reveal stashes — cursor hasn't moved yet.
+	p.Reveal("sys:Bravo")
+	if p.cursor != 0 {
+		t.Errorf("cursor moved before Update: %d", p.cursor)
+	}
+	// Update resolves the pending reveal against the snapshot.
+	_, _ = p.Update(struct{}{}, s)
+	if p.cursor != 1 {
+		t.Errorf("cursor = %d, want 1 after sys:Bravo resolved", p.cursor)
+	}
+	// Conventional reveal lands past the systems block.
+	p.Reveal("conv:1")
+	_, _ = p.Update(struct{}{}, s)
+	if p.cursor != 3 {
+		t.Errorf("cursor = %d, want 3 (nSys=2 + conv 1)", p.cursor)
+	}
+	// Malformed key clears without panicking.
+	p.Reveal("conv:bogus")
+	_, _ = p.Update(struct{}{}, s)
+	if p.cursor != 3 {
+		t.Errorf("cursor = %d, want 3 (malformed reveal should not move cursor)", p.cursor)
+	}
+}
+
+func TestSystemsPanel_HandleMouseAtMovesCursor(t *testing.T) {
+	p := NewSystems()
+	s := &state.SharedState{Systems: []client.SystemDTO{
+		{Name: "A"}, {Name: "B"}, {Name: "C"}, {Name: "D"},
+	}}
+	_, _ = p.Update(tea.WindowSizeMsg{Width: 120, Height: 30}, s)
+
+	// localY 0/1/2 are chrome; first data row is local Y == 3.
+	if cmd := p.HandleMouseAt(10, 2); cmd != nil {
+		t.Errorf("expected nil cmd on chrome click")
+	}
+	if got := p.tbl.Cursor(); got != 0 {
+		t.Errorf("chrome click moved cursor to %d", got)
+	}
+	_ = p.HandleMouseAt(10, 4) // row 1
+	if got := p.tbl.Cursor(); got != 1 {
+		t.Errorf("cursor = %d after click on row 1, want 1", got)
+	}
+	// Past-end clamps to the last row.
+	_ = p.HandleMouseAt(10, 50)
+	if got := p.tbl.Cursor(); got != 3 {
+		t.Errorf("cursor = %d after out-of-range click, want 3", got)
+	}
+}
+
+func TestTableRowFromLocalY(t *testing.T) {
+	cases := []struct {
+		y, rows, want int
+	}{
+		{0, 5, -1},  // top border
+		{1, 5, -1},  // title
+		{2, 5, -1},  // column header
+		{3, 5, 0},   // first row
+		{7, 5, 4},   // last row
+		{99, 5, 4},  // past end → clamp
+		{3, 0, -1},  // empty table
+		{-1, 5, -1}, // negative
+	}
+	for _, c := range cases {
+		got := tableRowFromLocalY(c.y, c.rows)
+		if got != c.want {
+			t.Errorf("tableRowFromLocalY(%d, %d) = %d, want %d", c.y, c.rows, got, c.want)
+		}
+	}
+}

--- a/internal/tui/panels/scanner.go
+++ b/internal/tui/panels/scanner.go
@@ -38,6 +38,10 @@ type ScannerPanel struct {
 	manualInput  textinput.Model
 	editingFreq  bool
 	inputErr     string
+
+	// pendingReveal stashes a Reveal() request until the next Update
+	// gives us a SharedState to resolve against. Cleared once applied.
+	pendingReveal string
 }
 
 // NewScanner returns a new read+write scanner cockpit.
@@ -82,6 +86,48 @@ func (ScannerPanel) Keys() []key.Binding {
 // handheld scanner without overshooting on a keyboard.
 const volumeStep = 0.05
 
+// Reveal pre-positions the scanner's virtual cursor on a system or
+// conventional channel. key forms:
+//
+//	"sys:<name>"   — trunked system by name
+//	"conv:<index>" — conventional channel by zero-based index
+//
+// The actual cursor index can't be computed until we see SharedState,
+// so we stash the request and resolve it on the next Update tick.
+func (p *ScannerPanel) Reveal(key string) {
+	p.pendingReveal = key
+}
+
+// applyPendingReveal consumes p.pendingReveal against the current
+// scanner snapshot. Called at the top of Update so subsequent
+// keybindings (hold/resume/retune) operate on the revealed row.
+func (p *ScannerPanel) applyPendingReveal(s *state.SharedState) {
+	if p.pendingReveal == "" {
+		return
+	}
+	key := p.pendingReveal
+	p.pendingReveal = ""
+	if rest, ok := strings.CutPrefix(key, "sys:"); ok {
+		for i, sys := range s.Scanner.Systems {
+			if sys.Name == rest {
+				p.cursor = i
+				return
+			}
+		}
+		return
+	}
+	if rest, ok := strings.CutPrefix(key, "conv:"); ok {
+		idx, err := strconv.Atoi(rest)
+		if err != nil {
+			return
+		}
+		nSys := len(s.Scanner.Systems)
+		if idx >= 0 && idx < len(s.Scanner.Conventional.Channels) {
+			p.cursor = nSys + idx
+		}
+	}
+}
+
 func (p *ScannerPanel) rowCount(s *state.SharedState) int {
 	return len(s.Scanner.Systems) + len(s.Scanner.Conventional.Channels)
 }
@@ -107,6 +153,7 @@ func (p *ScannerPanel) resolveCursor(s *state.SharedState) (string, int) {
 }
 
 func (p *ScannerPanel) Update(msg tea.Msg, s *state.SharedState) (Panel, tea.Cmd) {
+	p.applyPendingReveal(s)
 	km, ok := msg.(tea.KeyMsg)
 	if !ok {
 		return p, nil

--- a/internal/tui/panels/systems.go
+++ b/internal/tui/panels/systems.go
@@ -82,6 +82,31 @@ func (p *SystemsPanel) View(width, height int, focused bool, s *state.SharedStat
 	return panelFrame("Systems", width, height, focused, p.tbl.View())
 }
 
+// Cursor exposes the current table cursor index for tests.
+func (p *SystemsPanel) Cursor() int { return p.tbl.Cursor() }
+
+// Reveal positions the cursor on the row whose Name matches the
+// given key. No-op when the row is absent; the operator still ends
+// up on the panel.
+func (p *SystemsPanel) Reveal(key string) {
+	for i, row := range p.tbl.Rows() {
+		if len(row) > 0 && row[0] == key {
+			p.tbl.SetCursor(i)
+			return
+		}
+	}
+}
+
+// HandleMouseAt moves the cursor to the clicked row when the click
+// lands on a data row; chrome clicks are ignored.
+func (p *SystemsPanel) HandleMouseAt(_, localY int) tea.Cmd {
+	idx := tableRowFromLocalY(localY, len(p.tbl.Rows()))
+	if idx >= 0 {
+		p.tbl.SetCursor(idx)
+	}
+	return nil
+}
+
 func systemsColumns(w int) []table.Column {
 	if w < 40 {
 		w = 40

--- a/internal/tui/panels/talkgroups.go
+++ b/internal/tui/panels/talkgroups.go
@@ -105,6 +105,30 @@ func (p *TalkgroupsPanel) SetFilterValue(v string) {
 // RowCount returns the number of rows currently in the table.
 func (p *TalkgroupsPanel) RowCount() int { return len(p.tbl.Rows()) }
 
+// Reveal positions the cursor on the row whose ID (decimal string in
+// the first column) matches key. Used by the command palette to land
+// the operator on the talkgroup they searched for.
+func (p *TalkgroupsPanel) Reveal(key string) {
+	for i, row := range p.tbl.Rows() {
+		if len(row) > 0 && row[0] == key {
+			p.tbl.SetCursor(i)
+			return
+		}
+	}
+}
+
+// HandleMouseAt moves the cursor to the clicked data row. The first
+// body line is reserved for the filter input + sort summary, so the
+// table starts one row below the canonical chrome offset.
+func (p *TalkgroupsPanel) HandleMouseAt(_, localY int) tea.Cmd {
+	// Account for the extra filter+summary line above the table.
+	idx := tableRowFromLocalY(localY-1, len(p.tbl.Rows()))
+	if idx >= 0 {
+		p.tbl.SetCursor(idx)
+	}
+	return nil
+}
+
 func (p *TalkgroupsPanel) Update(msg tea.Msg, s *state.SharedState) (Panel, tea.Cmd) {
 	switch m := msg.(type) {
 	case tea.KeyMsg:

--- a/internal/tui/panels/util.go
+++ b/internal/tui/panels/util.go
@@ -112,3 +112,24 @@ func containsFold(haystack, needle string) bool {
 	}
 	return strings.Contains(strings.ToLower(haystack), strings.ToLower(needle))
 }
+
+// tableRowFromLocalY maps a panel-local Y (0 = panel's top border) to
+// a bubbles/table row index, accounting for the canonical chrome that
+// panelFrame draws: top border, title line, table column header. The
+// returned index is clamped to [0, rowCount-1]; -1 means the click
+// landed on chrome, not a row.
+func tableRowFromLocalY(localY, rowCount int) int {
+	// panelFrame: row 0 border, row 1 title, row 2 column header.
+	// First data row sits at local Y == 3.
+	idx := localY - 3
+	if idx < 0 {
+		return -1
+	}
+	if rowCount == 0 {
+		return -1
+	}
+	if idx >= rowCount {
+		return rowCount - 1
+	}
+	return idx
+}


### PR DESCRIPTION
## Summary

Finishes the three polish items left over from PR #172:

- **Revealer + MouseAware panel interfaces.** The palette can now
  jump and pre-position a cursor; left-clicks on data rows in the
  Systems / Talkgroups / Devices panels move the cursor onto that
  row. ScannerPanel stashes the reveal key until the next Update
  resolves it against fresh SharedState. The shared
  `tableRowFromLocalY` helper handles the canonical panelFrame
  chrome offset (border + title + column header = 3 rows). Picking
  "Open TG 4321" from `Ctrl+P` now lands the operator on the right
  row before opening the detail modal — keyboard and mouse paths
  converge.
- **Async history refresh.** History was the one remaining panel
  that built its bubbles/table rows inline inside `Update`. The
  conversion now runs in a `tea.Cmd` and commits via a routed
  `HistoryRefreshedMsg`; a `pendingAt` guard prevents duplicate
  dispatch and stale results (a newer snapshot landed mid-flight)
  are dropped silently.
- **README updates.** Two new bullets under "Recently shipped" and
  an expanded TUI section covering `Ctrl+P` palette navigation,
  mouse hit-testing on data rows, and the tabbed Settings inspector.

The fourth originally-outstanding item — focused panel title invert
— shipped in PR #172 (`panels/frame.go` already swaps title bg/fg on
focus), so it's not touched here.

## Commits

1. `tui: Revealer + MouseAware interfaces for cursor pre-positioning`
2. `tui/panels: async history refresh off the Update goroutine`
3. `README: document Revealer / MouseAware + async history refresh`

## Test plan

- [x] `go vet ./...` clean
- [x] `go test -race -count=1 ./internal/tui/...` green
- [x] `go test -race -count=1 ./internal/api/... ./internal/voice/player/...` green
- [x] New tests:
  - `panels/reveal_test.go` — Reveal moves cursor on Systems /
    Talkgroups / Devices / Scanner; unknown keys are no-ops; scanner
    deferred resolution lands on the right slot; mouse click on a
    data row sets the table cursor; chrome clicks ignored;
    out-of-range clicks clamp; `tableRowFromLocalY` table-driven
    cases.
  - `tui/mouse_test.go` — body click on a MouseAware panel moves
    its cursor; body click on a non-MouseAware panel (Dashboard)
    is left unconsumed.
  - `panels/history_async_test.go` — first Update spawns a Cmd,
    table stays empty until the msg returns, msg commits rows;
    stale msg (`Hash != pendingAt`) is a no-op; repeated Update on
    the same snapshot does not redispatch.

https://claude.ai/code/session_013UdgEk62qv27bpRiNu161A

---
_Generated by [Claude Code](https://claude.ai/code/session_013UdgEk62qv27bpRiNu161A)_