### PR TITLE
Flip FEC + clock defaults to on; document opt-ins

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,15 +124,13 @@ The remaining gaps:
   live capture to characterise.
 - **Symbol-time clock recovery on complex IQ.** The Gardner
   timing-recovery primitive in `internal/dsp/sync/gardner.go`
-  is now threaded into both the **P25 Phase 2** and **TETRA**
-  receivers via a per-receiver `ClockMode` opt-in
-  (`ClockNaive` default preserves the pre-Gardner behaviour for
-  existing tests; `ClockGardner` routes the matched-filter
-  output through the Gardner loop). Noisier on-air captures
-  whose symbol clock isn't aligned with the SDR sample clock
-  should lock cleanly under `ClockGardner`. The connector
-  configuration for picking the mode at runtime is the
-  follow-up.
+  is threaded into both the **P25 Phase 2** and **TETRA**
+  receivers via a per-system `ClockMode`. The connector now
+  reads `p25_phase2_clock_mode` / `tetra_clock_mode` from the
+  per-system YAML and constructs the receiver with
+  `ClockGardner` (the new default — recommended for live SDR
+  captures). Operators feeding sample-aligned synthesized IQ
+  fixtures can opt back to `naive` per-system if needed.
 - **Digital-voice level calibration.** Pure-Go IMBE / AMBE+2 emit
   real audio end-to-end with shared AGC, frame-repeat on bad-frame
   indicator, phase-aware fade-in, and §6.2 spectral enhancement

--- a/README.md
+++ b/README.md
@@ -1957,40 +1957,41 @@ hold/resume/retune/dwell + scan_mode flip) start the daemon with
 gate independently because the HTTP API has no authentication.
 See [`docs/tui.md`](docs/tui.md) for the full reference.
 
-## FEC opt-ins
+## FEC opt-outs
 
-Every protocol that has a public-spec FEC chain ships the chain as
-an **opt-in**: the connector constructs each `ControlChannel` in
-its legacy raw-bit mode by default and only flips on the FEC layer
-when the operator sets a per-system key in `config.yaml`. Empty /
-absent keys preserve the legacy path so the synthesized-fixture
-tests stay green and operators with pre-stripped capture files
-(DSD-FME `-r` dumps, OP25 fixtures) don't see surprise CRC
-failures.
+Every protocol that has a public-spec FEC chain ships its
+spec-correct decoder chain **on by default**: the connector
+constructs each `ControlChannel` with the full on-air FEC layer
+applied, and operators with pre-stripped capture files (DSD-FME
+`-r` dumps, OP25 fixtures, MMDVMHost / DSDcc test data) opt out
+per-system with `<key>: off` in `config.yaml`. Empty / absent
+keys map to the new on-default for every protocol.
 
-Verify which opt-ins are active by opening the **Settings** panel
-in the TUI — it lists every configured system with a one-line
-summary of its FEC opt-in state (`channel coding: on (colour=…,
-sch/f)`, `viterbi: off`, `bch: on`, etc.). The panel is read-only;
-runtime mutation is a future PR. To change a mode, edit
-`config.yaml` and restart the daemon.
+Verify which protocols are on / off in the **Settings** panel of
+the TUI — it lists every configured system with a one-line summary
+of its FEC state (`channel coding: on (colour=…, sch/f)`, `viterbi:
+spec`, `bch: on`, etc.). The panel is read-only; runtime mutation
+is a future PR. To change a mode, edit `config.yaml` and restart
+the daemon.
 
-| Protocol | YAML key(s) | Off (default) | On |
+| Protocol | YAML key(s) | On (default) | Off (opt-out) |
 | --- | --- | --- | --- |
-| TETRA | `tetra_colour_code` (uint32, low 30 bits), `tetra_channel` (`"sch/hd"` / `"sch/f"` / `"sch/hu"` / `"bsch"` / `"aach"`, default `sch/hd`) | Legacy 48-dibit raw-PDU path. CRC fails on live captures. | Full ETSI EN 300 392-2 §8.3.1 type-5 → type-1 chain (descramble + deinterleave + depuncture + Viterbi + CRC-16 verify + tail strip) per burst. Non-zero `tetra_colour_code` flips it on. |
-| LTR | `ltr_fcs_mode` (`""` / `"off"` / `"on"`), `ltr_manchester_mode` (`""` / `"off"` / `"nrz"` / `"strict"` / `"soft"`) | NRZ Status bits, no FCS verification. Matches synthesized-fixture path. | CRC-7 FCS check against sdrtrunk's CRCLTR.java layout (`on`) and/or Manchester decode of sub-audible signaling (`soft` = majority decode, `strict` = require mid-bit transition). Live sub-audible captures typically need `manchester: soft` + `fcs: on`. |
-| P25 Phase 2 | `p25_phase2_trellis_mode` (`""` / `"off"` / `"on"`) | Legacy 72-dibit raw-MAC-PDU path. | 4-state ½-rate trellis FEC over the MAC PDU window (146 channel dibits → 72 info dibits per TIA-102.AABF). |
-| NXDN | `nxdn_viterbi_mode` (`""` / `"off"` / `"on"` / `"spec"`) | Legacy 44-dibit raw-CAC path. | `on`: simplified K=5 ½-rate Viterbi over the CAC region (92 dibits → 88 info bits + 4 tail zeros — matches the older MMDVMHost / DSDcc fixtures). `spec`: full NXDN-TS-1-A rev 1.3 §4.5.1.1 outbound chain (150 dibits = 300 channel bits → deinterleave 25×12 → depuncture 50/350 → K=5 Viterbi → 16-bit CRC verify → 155 info bits = 8 SR + 144 L3 + 3 Null). Use `spec` for live captures; `on` for back-compat with the older synthesized fixtures. |
-| EDACS | `edacs_bch_mode` (`""` / `"off"` / `"on"`) | Legacy pre-stripped 40-bit CCW; payload struct's LCN bit 0 + Aux fields are data. | BCH(40, 28, 2) with single/double-bit correction over the 40-bit on-wire CCW; under `on` the effective CCW carries 28 info bits (Command + Status + Address + high LCN bits), the remaining bits become BCH parity. |
-| MPT 1327 | `mpt1327_bch_mode` (`""` / `"off"` / `"on"`) | Legacy 38-bit pre-stripped codeword. | BCH(63, 38) decode over the 64-bit on-wire codeword. |
-| Motorola Type II | `motorola_bch_mode` (`""` / `"off"` / `"on"`) | Legacy 32-bit raw-OSW path. | Two 64-bit BCH(64, 16, 11) codewords reassembled into the 32-bit OSW with single- through 11-bit-error correction per codeword. Live captures should set `on`. |
+| TETRA | `tetra_colour_code` (uint32, low 30 bits — required for non-BSCH), `tetra_channel` (`"sch/hd"` / `"sch/f"` / `"sch/hu"` / `"bsch"` / `"aach"`, default `sch/hd`), `tetra_channel_coding` (`""` / `"on"` / `"off"`) | Full ETSI EN 300 392-2 §8.3.1 type-5 → type-1 chain (descramble + deinterleave + depuncture + Viterbi + CRC-16 verify + tail strip) per burst. `tetra_colour_code` of 0 is only valid for BSCH; non-BSCH channels need the per-cell colour code or descrambling produces garbage (the connector warn-logs this case). | `tetra_channel_coding: off` falls back to the legacy 48-dibit raw-PDU path. CRC will fail on live captures; only useful for pre-stripped fixtures. |
+| LTR | `ltr_fcs_mode` (`""` / `"on"` / `"off"`), `ltr_manchester_mode` (`""` / `"on"` / `"soft"` / `"strict"` / `"off"` / `"nrz"`) | `fcs: on` — CRC-7 FCS check against sdrtrunk's CRCLTR.java layout. `manchester: soft` — majority-decode each pair (matches the dominant on-air encoding for sub-audible LTR signaling). | `fcs: off` skips the CRC check (synthesized fixtures whose FCS trailer isn't populated). `manchester: off` / `nrz` treats the stream as raw NRZ (synthesized NRZ fixtures). |
+| P25 Phase 2 | `p25_phase2_trellis_mode` (`""` / `"on"` / `"off"`) | 4-state ½-rate trellis FEC over the MAC PDU window (146 channel dibits → 72 info dibits per TIA-102.AABF). | Falls back to the legacy 72-dibit raw-MAC-PDU path for pre-stripped fixtures. |
+| NXDN | `nxdn_viterbi_mode` (`""` / `"spec"` / `"on"` / `"off"`) | `spec` — full NXDN-TS-1-A rev 1.3 §4.5.1.1 outbound CAC chain (150 dibits → deinterleave 25×12 → depuncture 50/350 → K=5 Viterbi → 16-bit CRC verify → 155 info bits). | `on` — intermediate 92-dibit K=5 Viterbi path for older MMDVMHost / DSDcc fixtures. `off` — legacy 44-dibit raw-CAC path for pre-stripped fixtures. |
+| EDACS | `edacs_bch_mode` (`""` / `"on"` / `"off"`) | BCH(40, 28, 2) with single/double-bit correction over the 40-bit on-wire CCW; the effective CCW carries 28 info bits (Command + Status + Address + high LCN bits), the remaining bits become BCH parity. | Falls back to the legacy pre-stripped 40-bit CCW; payload struct's LCN bit 0 + Aux fields are treated as data instead of parity. |
+| MPT 1327 | `mpt1327_bch_mode` (`""` / `"on"` / `"off"`) | BCH(63, 38) decode over the 64-bit on-wire codeword. | Falls back to the legacy 38-bit pre-stripped codeword. |
+| Motorola Type II | `motorola_bch_mode` (`""` / `"on"` / `"off"`) | Two 64-bit BCH(64, 16, 11) codewords reassembled into the 32-bit OSW with single- through 11-bit-error correction per codeword. | Falls back to the legacy 32-bit raw-OSW path for pre-stripped DSD-FME `-r` fixtures. |
 
 All string values are case-insensitive with whitespace tolerated;
-recognised on-values include `"on"` / `"true"` / `"1"`, off-values
-`""` / `"off"` / `"false"` / `"0"`. Unrecognised values fall back
-to off with a `warn`-level log line ("ccdecoder: unrecognised
-`<key>`; falling back to off") so a typo doesn't silently break
-the decoder.
+recognised on-values include `""` (empty) / `"on"` / `"true"` /
+`"1"` (NXDN also accepts `"spec"`; LTR Manchester accepts
+`"soft"` / `"strict"`); off-values are `"off"` / `"false"` / `"0"`
+(LTR Manchester also accepts `"nrz"`). Unrecognised values fall
+back to the on-default with a `warn`-level log line ("ccdecoder:
+unrecognised `<key>`; falling back to on") so a typo doesn't
+silently break the decoder.
 
 Each protocol's `ControlChannel` exposes matching getters
 (`tetra.ControlChannel.ChannelCoding()` / `ExpectedChannel()` /
@@ -2017,9 +2018,11 @@ opt-in field as a `omitempty` JSON value.
 - [`docs/hardening.md`](docs/hardening.md) — Prometheus catalogue,
   Docker / compose USB pass-through, smoke-test checklist
 - [`docs/opt-in-features.md`](docs/opt-in-features.md) — every
-  disabled-by-default feature (protocol FEC, receiver clock,
-  daemon-level, build tags), why it's opt-in, and the work to flip
-  the default
+  disabled-by-default feature (receiver clock, daemon-level audio /
+  equalizer / mutations / tone-out, build tags), why it's opt-in,
+  and the work to flip the default. Protocol FEC chains are now
+  on-by-default; see the FEC opt-outs section above for the
+  per-protocol opt-out keys.
 - [`docs/specs/`](docs/specs/) — reference air-interface PDFs the
   on-air FEC implementations derive from (NXDN-TS-1-A,
   ETSI EN 300 392-2 TETRA, plus a negative-reference M/A-COM LBI

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -125,9 +125,11 @@ func NewDaemon(cfg config.Config, version string, log *slog.Logger) (*Daemon, er
 			TETRAColourCode:      sys.TETRAColourCode,
 			TETRAChannel:         sys.TETRAChannel,
 			TETRAChannelCoding:   sys.TETRAChannelCoding,
+			TETRAClockMode:       sys.TETRAClockMode,
 			LTRFCSMode:           sys.LTRFCSMode,
 			LTRManchesterMode:    sys.LTRManchesterMode,
 			P25Phase2TrellisMode: sys.P25Phase2TrellisMode,
+			P25Phase2ClockMode:   sys.P25Phase2ClockMode,
 			NXDNViterbiMode:      sys.NXDNViterbiMode,
 			EDACSBCHMode:         sys.EDACSBCHMode,
 			MPT1327BCHMode:       sys.MPT1327BCHMode,
@@ -366,15 +368,29 @@ func NewDaemon(cfg config.Config, version string, log *slog.Logger) (*Daemon, er
 		}
 	}
 
-	// Conventional FM scanner — opt-in via scanner.conventional list.
+	// Conventional FM scanner — constructed when:
+	//   (a) scanner.conventional channels are configured, OR
+	//   (b) scanner.manual_tune_enabled is explicitly true, OR
+	//   (c) auto-detect finds a spare Voice SDR (>= 2 Voice SDRs
+	//       in the pool) AND manual_tune_disabled is not set.
+	//
 	// Requires its own dedicated Voice SDR (carved out of the pool's
 	// voice fleet) and a recorder to land WAVs into. The scanner
 	// publishes synthetic CallStart/CallEnd events through
 	// Engine.HandleSyntheticCall, so the recorder, call log, and
 	// /api/v1/calls/active surfaces light up like any other call.
-	convWanted := len(cfg.Scanner.Conventional) > 0 || cfg.Scanner.ManualTuneEnabled
+	var voiceEntries []*sdr.PoolEntry
+	if d.pool != nil {
+		voiceEntries = d.pool.AllByRole(sdr.RoleVoice)
+	}
+	hasConventional := len(cfg.Scanner.Conventional) > 0
+	autoEnable := !cfg.Scanner.ManualTuneDisabled && len(voiceEntries) >= 2
+	convWanted := hasConventional || cfg.Scanner.ManualTuneEnabled || autoEnable
+	if convWanted && autoEnable && !cfg.Scanner.ManualTuneEnabled && !hasConventional {
+		log.Info("daemon: scanner: auto-enabling manual tune (spare Voice SDR detected)",
+			"voice_sdrs", len(voiceEntries))
+	}
 	if d.pool != nil && d.recorder != nil && d.engine != nil && convWanted {
-		voiceEntries := d.pool.AllByRole(sdr.RoleVoice)
 		if len(voiceEntries) == 0 {
 			log.Warn("daemon: scanner.conventional / manual_tune_enabled configured but no Voice SDRs in the pool; skipping")
 		} else {

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -124,6 +124,7 @@ func NewDaemon(cfg config.Config, version string, log *slog.Logger) (*Daemon, er
 			ControlChannels:      sys.ControlChannels,
 			TETRAColourCode:      sys.TETRAColourCode,
 			TETRAChannel:         sys.TETRAChannel,
+			TETRAChannelCoding:   sys.TETRAChannelCoding,
 			LTRFCSMode:           sys.LTRFCSMode,
 			LTRManchesterMode:    sys.LTRManchesterMode,
 			P25Phase2TrellisMode: sys.P25Phase2TrellisMode,

--- a/cmd/gophertrunk/integration_cc_ltr_test.go
+++ b/cmd/gophertrunk/integration_cc_ltr_test.go
@@ -60,10 +60,12 @@ func TestDaemonCCDecodesLTR(t *testing.T) {
 			Name:            "LTRSite",
 			Protocol:        "ltr",
 			ControlChannels: []uint32{controlFreqHz},
-			// Leave ltr_manchester_mode + ltr_fcs_mode at their
-			// defaults — the receiver treats the synthesized
-			// stream as NRZ (no Manchester pre-encode) and
-			// Status.FCS isn't validated until FCSOn is flipped.
+			// The synthesized stream is raw NRZ with no Manchester
+			// pre-encode and no Status.FCS populated, so opt out of
+			// the new on-air defaults (ManchesterSoft + FCSOn) for
+			// this fixture.
+			LTRManchesterMode: "off",
+			LTRFCSMode:        "off",
 		},
 	}
 	cfg.API.HTTPAddr = freeAddr(t)

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -94,14 +94,21 @@ scanner:
     dwell_ms: 3000
     backoff_ms: 5000
     max_backoff_ms: 60000
-  # manual_tune_enabled opts in to constructing the conventional
-  # scanner even when no static channels are configured, so the
-  # TUI's `f` key (or POST /api/v1/scanner/manual_tune) can
-  # VFO-tune at runtime. The scanner steals one Voice SDR from
-  # the trunking pool, so only enable if you have a spare Voice
-  # SDR or are willing to trade trunked grant-following for
-  # manual tune.
+  # manual_tune_enabled forces construction of the conventional
+  # scanner so the TUI's `f` key (or POST /api/v1/scanner/manual_tune)
+  # can VFO-tune at runtime even when no static channels are
+  # configured. With this set the scanner steals one Voice SDR
+  # from the trunking pool regardless of how many Voice SDRs
+  # exist.
+  #
+  # Default false; the daemon auto-detects when >= 2 Voice SDRs
+  # are present and constructs the scanner from the spare without
+  # needing this flag. To keep all Voice SDRs reserved for
+  # trunking even with a spare, set manual_tune_disabled: true to
+  # opt out of the auto-detect.
   manual_tune_enabled: false
+  # manual_tune_disabled vetoes the auto-detect rule.
+  manual_tune_disabled: false
   conventional: []
   # Example conventional channels:
   # conventional:

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -59,6 +59,26 @@ trunking:
         - 852_000_000
       talkgroup_file: "/etc/gophertrunk/talkgroups-p25.csv"
 
+  # Per-protocol FEC is on by default — every protocol the daemon
+  # supports (TETRA, LTR, P25 Phase 2, NXDN, EDACS, MPT 1327,
+  # Motorola Type II) ships its spec-correct on-air decoder chain
+  # enabled without needing per-system YAML keys. Operators feeding
+  # pre-stripped capture files (DSD-FME `-r` dumps, OP25 fixtures,
+  # MMDVMHost / DSDcc test data) opt out per-system with the keys
+  # below. TETRA additionally requires a non-zero `tetra_colour_code`
+  # for non-BSCH channels; descrambling produces garbage without it.
+  #
+  # Example opt-outs for operators using pre-stripped captures:
+  #   - name: "Legacy-Motorola"
+  #     protocol: motorola
+  #     control_channels: [851_012_500]
+  #     motorola_bch_mode: "off"   # pre-stripped 32-bit raw OSWs
+  #   - name: "Legacy-LTR"
+  #     protocol: ltr
+  #     control_channels: [935_012_500]
+  #     ltr_fcs_mode: "off"
+  #     ltr_manchester_mode: "off"
+
 # Police-scanner subsystems:
 #   - scan_mode controls the engine's per-grant gate. "all" follows every
 #     non-locked-out grant (the original behavior). "list" only follows

--- a/docs/opt-in-features.md
+++ b/docs/opt-in-features.md
@@ -24,42 +24,54 @@ flip the default to enabled or remove the gate entirely.
 
 ---
 
-## 1. Protocol-layer FEC opt-ins
+## 1. Protocol-layer FEC opt-outs (formerly opt-ins)
 
-Every protocol that has a public-spec forward-error-correction chain
-ships the chain as opt-in. The connector constructs each
-`ControlChannel` in its legacy raw-bit mode by default and only flips
-on the FEC layer when the operator sets a per-system key in
-`config.yaml`. Empty / absent keys preserve the legacy path so the
-synthesized-fixture tests stay green and operators with pre-stripped
-capture files (DSD-FME `-r` dumps, OP25 fixtures) don't see surprise
-CRC failures. The shared rationale is documented in
-[`README.md` §"FEC opt-ins"](../README.md) (the existing reference
-table lives at lines 1960-2005); this section adds the **Remediation**
-column the README does not currently cover.
+**Status: flipped.** Every protocol that has a public-spec
+forward-error-correction chain now ships on by default. The
+ccdecoder connector at
+[`internal/scanner/ccdecoder/pipelines.go`](../internal/scanner/ccdecoder/pipelines.go)
+always runs the per-protocol `Parse*Mode` function over the
+configured YAML value — empty strings map to the new on-defaults.
+Operators with pre-stripped capture files (DSD-FME `-r` dumps,
+OP25 fixtures, MMDVMHost / DSDcc test data) opt out per-system
+with `<key>: off`.
 
-All seven YAML keys are defined on the `System` struct at
-[`internal/trunking/site.go:101-177`](../internal/trunking/site.go).
+The current per-protocol state is documented in the README's
+["FEC opt-outs" section](../README.md#fec-opt-outs); summary:
 
-| Protocol | YAML key(s) | Setter | Why opt-in | Remediation |
-| --- | --- | --- | --- | --- |
-| **TETRA** | `tetra_colour_code` (uint32, low 30 bits), `tetra_channel` (`sch/hd` / `sch/f` / `sch/hu` / `bsch` / `aach`) | `tetra.ControlChannel.SetChannelCoding` at [`internal/radio/tetra/control.go:156`](../internal/radio/tetra/control.go) | Pre-stripped DSD-FME / OP25 fixtures and synthesized in-package fixtures would fail CRC under the full ETSI EN 300 392-2 §8.3.1 descramble + deinterleave + depuncture + Viterbi + CRC-16 chain. Zero colour code is also valid for BSCH, so the field cannot simply infer "on" from non-zero. | Re-encode or capture TETRA TMO fixtures with valid scrambler colour codes and full type-5 → type-1 framing, then flip the connector to construct each `tetra.ControlChannel` with `ChannelCodingOn` by default. Make `tetra_colour_code` a required field for non-BSCH systems and surface validation at config load. |
-| **LTR** | `ltr_fcs_mode` (`off` / `on`), `ltr_manchester_mode` (`off` / `nrz` / `strict` / `soft`) | `ltr.ControlChannel.SetFCSMode` at [`internal/radio/ltr/control.go:108`](../internal/radio/ltr/control.go); `ltr.ControlChannel.SetManchesterMode` at [`internal/radio/ltr/process.go:49`](../internal/radio/ltr/process.go) | Default NRZ + no FCS matches the in-package synthesized fixtures. Live sub-audible captures need `manchester: soft` + `fcs: on`, but flipping the default would break the existing test suite. | Re-encode in-package LTR fixtures with mid-bit transitions and valid CRC-7 FCS trailers (matching sdrtrunk's `CRCLTR.java` layout), then default to `manchester: soft` + `fcs: on`. Keep `nrz` available for synthesized-fixture regression tests behind a test-only knob. |
-| **P25 Phase 2** | `p25_phase2_trellis_mode` (`off` / `on`) | `p25phase2.ControlChannel.SetTrellisMode` at [`internal/radio/p25/phase2/control.go:77`](../internal/radio/p25/phase2/control.go) | Legacy 72-dibit raw-MAC-PDU fixtures predate the trellis decoder. Live captures arrive as 146 channel dibits per the TIA-102.AABF 4-state ½-rate trellis FEC. | Regenerate Phase 2 fixtures as 146-channel-dibit streams that exercise the trellis decoder. Once the suite is green, flip the connector to construct with `TrellisOn` and either drop the raw-MAC-PDU path or relocate it to a test-only fixture mode. |
-| **NXDN** | `nxdn_viterbi_mode` (`off` / `on` / `spec`) | `nxdn.ControlChannel.SetViterbiMode` at [`internal/radio/nxdn/control.go:102`](../internal/radio/nxdn/control.go) | Legacy 44-dibit raw-CAC fixtures from MMDVMHost / DSDcc. `on` matches the older synthesized fixtures (K=5 ½-rate Viterbi over 92 dibits → 88 info + 4 tail). `spec` is the full NXDN-TS-1-A §4.5.1.1 chain (150 dibits → deinterleave 25×12 → depuncture → Viterbi → CRC → 155 info bits). | Re-encode fixtures to the full spec chain, default to `spec`, and remove the intermediate `on` mode. The two-step path is a transitional artefact that costs documentation surface and operator confusion. |
-| **EDACS / GE-Marc** | `edacs_bch_mode` (`off` / `on`) | `edacs.ControlChannel.SetBCHMode` at [`internal/radio/edacs/control.go:96`](../internal/radio/edacs/control.go) | Legacy CCW fixtures arrive pre-stripped: the 40 bits on the wire under `off` are treated as data only, with the LCN bit 0 + Aux fields parsed in place of BCH parity. | Rebuild fixtures with on-wire 40-bit CCWs that include BCH(40, 28, 2) parity. The connector then defaults to `BCHOn`, the parsed payload narrows to the 28 spec-defined info bits, and single/double-bit error correction comes online without operator action. |
-| **MPT 1327** | `mpt1327_bch_mode` (`off` / `on`) | `mpt1327.ControlChannel.SetBCHMode` at [`internal/radio/mpt1327/control.go:108`](../internal/radio/mpt1327/control.go) | Legacy 38-bit pre-stripped codeword path. `on` decodes the 64-bit on-wire BCH(63, 38) form. | Re-encode fixtures as 64-bit BCH(63, 38) codewords, flip the connector default to `BCHOn`. |
-| **Motorola Type II** | `motorola_bch_mode` (`off` / `on`) | `motorola.ControlChannel.SetBCHMode` at [`internal/radio/motorola/process.go:41`](../internal/radio/motorola/process.go) | Legacy 32-bit raw-OSW fixtures (DSD-FME `-r` dumps) carry no BCH parity. Live captures should always set `on` — the README already calls this out. | Re-encode fixtures with the dual BCH(64, 16, 11) codeword layout. Flip the connector default to `BCHOn`. This is the lowest-risk flip in the table — the docs already say live captures need `on`, so the default is actively wrong for any real-RF user. |
+| Protocol | YAML key | New default | Opt-out string |
+| --- | --- | --- | --- |
+| TETRA | `tetra_channel_coding` | ChannelCodingOn (full §8.3.1 chain) | `off` |
+| LTR FCS | `ltr_fcs_mode` | FCSOn | `off` |
+| LTR Manchester | `ltr_manchester_mode` | ManchesterSoft | `off` / `nrz` |
+| P25 Phase 2 | `p25_phase2_trellis_mode` | TrellisOn | `off` |
+| NXDN | `nxdn_viterbi_mode` | ViterbiSpec | `off` |
+| EDACS | `edacs_bch_mode` | BCHOn | `off` |
+| MPT 1327 | `mpt1327_bch_mode` | BCHOn | `off` |
+| Motorola Type II | `motorola_bch_mode` | BCHOn | `off` |
 
-**Shared follow-up.** A single PR can convert all seven simultaneously
-by introducing a `legacy_fixtures` test-only mode that the regression
-suite opts into, then flipping the connector defaults. The
-alternative — runtime auto-detection that tries the FEC path first
-and falls back to raw on N consecutive CRC failures — has been
-discussed for P25 Phase 2 (see the "follow-up" line in
-[`README.md:125-135`](../README.md)) and is applicable to all seven
-protocols. Auto-detect costs a small CPU burst on broken input but
-eliminates the operator config burden entirely.
+### How it works
+
+The in-package `ControlChannel` constructors still zero-value to
+Off mode (so direct callers — primarily unit tests — see the legacy
+behaviour without explicit setup). The connector goes through
+`Parse*Mode(opts.System.X)` which maps empty strings to the new
+on-defaults, then calls `SetXMode(parsed)` on the ControlChannel.
+This keeps the operator-facing default On while preserving the
+in-package fixtures' expectations of an Off zero value.
+
+For TETRA specifically: a new `TETRAChannelCoding` field was added
+to the System struct (yaml: `tetra_channel_coding`) because the
+old "zero colour code = off" rule conflicted with BSCH's
+spec-defined zero colour code. Non-BSCH systems with channel
+coding on need a non-zero `tetra_colour_code`; the connector
+warn-logs the misconfiguration instead of silently dropping
+frames.
+
+### Remediation status
+
+Done in PR 1 on branch `claude/document-opt-in-features-gP90L`
+(this branch). No further remediation needed for FEC opt-ins.
 
 ---
 

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -26,14 +26,17 @@ type SystemDTO struct {
 	RFSS            uint8    `json:"rfss,omitempty"`
 	Site            uint8    `json:"site,omitempty"`
 
-	// Per-protocol FEC opt-in surface. Empty strings / zero
-	// TETRAColourCode indicate the legacy raw-bit path is active
-	// for that protocol. The TUI Settings panel renders these so
-	// operators can verify their config landed; runtime mutation
-	// is a follow-up (currently requires editing config.yaml +
-	// restarting the daemon).
+	// Per-protocol FEC opt-out surface. Empty strings indicate the
+	// new spec-correct default is active (channel coding / FEC on
+	// for every protocol). Non-empty values that parse to "off" /
+	// "false" / "0" opt the operator into the legacy raw-bit path
+	// per-protocol. The TUI Settings panel renders these so operators
+	// can verify their config landed; runtime mutation is a follow-up
+	// (currently requires editing config.yaml + restarting the
+	// daemon).
 	TETRAColourCode      uint32 `json:"tetra_colour_code,omitempty"`
 	TETRAChannel         string `json:"tetra_channel,omitempty"`
+	TETRAChannelCoding   string `json:"tetra_channel_coding,omitempty"`
 	LTRFCSMode           string `json:"ltr_fcs_mode,omitempty"`
 	LTRManchesterMode    string `json:"ltr_manchester_mode,omitempty"`
 	P25Phase2TrellisMode string `json:"p25_phase2_trellis_mode,omitempty"`
@@ -54,6 +57,7 @@ func systemToDTO(s trunking.System) SystemDTO {
 		Site:                 s.Site,
 		TETRAColourCode:      s.TETRAColourCode,
 		TETRAChannel:         s.TETRAChannel,
+		TETRAChannelCoding:   s.TETRAChannelCoding,
 		LTRFCSMode:           s.LTRFCSMode,
 		LTRManchesterMode:    s.LTRManchesterMode,
 		P25Phase2TrellisMode: s.P25Phase2TrellisMode,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -67,14 +67,25 @@ type ScannerConfig struct {
 	CCHunt CCHuntConfig `yaml:"cc_hunt"`
 	// Conventional is the fixed-frequency analog scan list.
 	Conventional []ConvChannelConfig `yaml:"conventional"`
-	// ManualTuneEnabled opts in to constructing the conventional
-	// scanner even when no static channels are configured, so the
-	// TUI's `f` key (or POST /api/v1/scanner/manual_tune) can
-	// VFO-tune at runtime. Off by default — the scanner steals a
-	// Voice SDR from the trunking pool, so operators with only
-	// one Voice SDR need to know they're trading trunked grant-
-	// following for manual tune.
+	// ManualTuneEnabled forces construction of the conventional
+	// scanner so the TUI's `f` key (or POST
+	// /api/v1/scanner/manual_tune) can VFO-tune at runtime even
+	// when no static channels are configured. With this set the
+	// scanner steals one Voice SDR from the trunking pool
+	// regardless of how many Voice SDRs are available.
+	//
+	// Default false; the daemon auto-detects when at least two
+	// Voice SDRs are present (sum >= 2) and constructs the
+	// scanner from the spare without requiring this flag. To
+	// keep all Voice SDRs reserved for trunking even with a
+	// spare, leave this false and the auto-detect rule still
+	// holds — set ManualTuneDisabled to opt out entirely.
 	ManualTuneEnabled bool `yaml:"manual_tune_enabled"`
+	// ManualTuneDisabled vetoes the auto-detect rule. When true,
+	// the conventional scanner is constructed only when
+	// `conventional` channels are explicitly listed or
+	// ManualTuneEnabled is set true.
+	ManualTuneDisabled bool `yaml:"manual_tune_disabled"`
 }
 
 // CCHuntConfig tunes the hunter's dwell + exponential backoff.
@@ -206,6 +217,17 @@ type SystemConfig struct {
 	// "false" / "0" (legacy 72-dibit raw-MAC-PDU path, opt-out for
 	// pre-stripped fixtures). Ignored for non-P25-Phase-2 protocols.
 	P25Phase2TrellisMode string `yaml:"p25_phase2_trellis_mode"`
+	// P25Phase2ClockMode selects the symbol-timing-recovery strategy
+	// for the P25 Phase 2 receiver. Recognised values: "" /
+	// "gardner" / "on" (the new default — non-data-aided Gardner
+	// loop; recommended for live SDR captures) or "naive" / "off"
+	// (decimate every sps-th sample; works on sample-aligned
+	// synthesized IQ). Ignored for non-P25-Phase-2 protocols.
+	P25Phase2ClockMode string `yaml:"p25_phase2_clock_mode"`
+	// TETRAClockMode mirrors P25Phase2ClockMode for the TETRA
+	// receiver. Recognised values: "" / "gardner" / "on" (the new
+	// default) or "naive" / "off". Ignored for non-TETRA protocols.
+	TETRAClockMode string `yaml:"tetra_clock_mode"`
 	// NXDNViterbiMode enables the K=5 ½-rate Viterbi FEC decoder
 	// on the NXDN CAC region. Recognised values: "" / "spec" (the
 	// new default — full NXDN-TS-1-A §4.5.1.1 outbound CAC chain),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -161,12 +161,11 @@ type SystemConfig struct {
 	// TETRAColourCode is the 30-bit extended colour code the TETRA
 	// scrambler uses to seed its LFSR (ETSI EN 300 392-2 §8.2.5).
 	// Set this to the per-cell colour code of the TETRA TMO system
-	// being decoded so the ccdecoder connector turns on the full
-	// §8.3.1 type-5 → type-1 decode chain (descramble + deinterleave
-	// + depuncture + Viterbi + CRC-16). Bits 30..31 are silently
-	// ignored. Zero (the default) keeps the legacy raw-dibit path,
-	// which only works on FEC-free synthesized fixtures. Ignored
-	// for non-TETRA protocols.
+	// being decoded so the descrambler can recover the type-3
+	// stream. Bits 30..31 are silently ignored. Zero is valid only
+	// for BSCH (§8.2.5.2); non-BSCH channels need the per-cell
+	// colour code or descrambling produces garbage. Ignored for
+	// non-TETRA protocols.
 	TETRAColourCode uint32 `yaml:"tetra_colour_code"`
 	// TETRAChannel selects which TETRA logical channel lives in
 	// each burst window under ChannelCodingOn. Recognised values:
@@ -174,57 +173,68 @@ type SystemConfig struct {
 	// defaults to "sch/hd" — the standard signaling channel for
 	// cc.locked / Grant events. Ignored for non-TETRA protocols.
 	TETRAChannel string `yaml:"tetra_channel"`
+	// TETRAChannelCoding gates the full ETSI EN 300 392-2 §8.3.1
+	// channel-coding chain (descramble + deinterleave + depuncture
+	// + Viterbi + CRC-16 verify + tail strip). Recognised values:
+	// "" / "on" / "true" / "1" (the new default — full chain;
+	// required for live on-air captures) or "off" / "false" / "0"
+	// (legacy raw-dibit path, opt-out for operators feeding pre-
+	// stripped DSD-FME / OP25 fixtures). Ignored for non-TETRA
+	// protocols.
+	TETRAChannelCoding string `yaml:"tetra_channel_coding"`
 
 	// LTRFCSMode enables the CRC-7 FCS check on the LTR Status
-	// Ingest path. Recognised values: "" / "off" (default,
-	// no verification — matches pre-PR #40 behaviour) or
-	// "on" / "true" (drop Status words whose FCS trailer doesn't
-	// match). Useful when the upstream framing layer has populated
-	// Status.FCS from the on-air bits and the operator wants to
-	// filter out corrupted frames. Ignored for non-LTR protocols.
+	// Ingest path. Recognised values: "" / "on" / "true" / "1"
+	// (the new default — drop Status words whose FCS trailer
+	// doesn't match) or "off" / "false" / "0" (no verification —
+	// opt-out for synthesized fixtures whose FCS trailer isn't
+	// populated). Ignored for non-LTR protocols.
 	LTRFCSMode string `yaml:"ltr_fcs_mode"`
 	// LTRManchesterMode controls Manchester decoding of the
-	// sub-audible LTR bit stream. Recognised values: "" / "off" /
-	// "nrz" (raw NRZ, default — matches the synthesized-fixture
-	// path), "strict" (require a mid-bit transition per pair,
-	// drop transition-less pairs), "soft" / "on" (majority-decode,
-	// tolerate noise bursts). Live captures of sub-audible LTR
-	// signaling should set "soft". Ignored for non-LTR protocols.
+	// sub-audible LTR bit stream. Recognised values: "" / "on" /
+	// "soft" (the new default — majority-decode + tolerate noise
+	// bursts; matches the dominant on-air encoding), "strict"
+	// (require a mid-bit transition per pair, drop transition-less
+	// pairs), "off" / "nrz" (raw NRZ — opt-out for synthesized NRZ
+	// fixtures). Ignored for non-LTR protocols.
 	LTRManchesterMode string `yaml:"ltr_manchester_mode"`
 
 	// P25Phase2TrellisMode enables the 4-state ½-rate trellis FEC
 	// decoder on the P25 Phase 2 MAC PDU window. Recognised values:
-	// "" / "off" (default, legacy 72-dibit raw-MAC-PDU path) or
-	// "on" (146 channel dibits via the TIA-102.AABF trellis
-	// decoder). Live P25 Phase 2 captures need "on" to recover
-	// MAC PDUs through the FEC layer. Ignored for non-P25-Phase-2
-	// protocols.
+	// "" / "on" / "true" / "1" (the new default — 146 channel
+	// dibits via the TIA-102.AABF trellis decoder) or "off" /
+	// "false" / "0" (legacy 72-dibit raw-MAC-PDU path, opt-out for
+	// pre-stripped fixtures). Ignored for non-P25-Phase-2 protocols.
 	P25Phase2TrellisMode string `yaml:"p25_phase2_trellis_mode"`
 	// NXDNViterbiMode enables the K=5 ½-rate Viterbi FEC decoder
-	// on the NXDN CAC region. Recognised values: "" / "off"
-	// (default, legacy raw-CAC path) or "on" (92 dibits via the
-	// K=5 Viterbi decoder). Live NXDN CAC captures need "on" to
-	// recover the CAC through its FEC. Ignored for non-NXDN
-	// protocols.
+	// on the NXDN CAC region. Recognised values: "" / "spec" (the
+	// new default — full NXDN-TS-1-A §4.5.1.1 outbound CAC chain),
+	// "on" / "true" / "1" (intermediate 92-dibit K=5 Viterbi path
+	// for older MMDVMHost / DSDcc fixtures), or "off" / "false" /
+	// "0" (legacy 44-dibit raw-CAC path, opt-out for pre-stripped
+	// fixtures). Ignored for non-NXDN protocols.
 	NXDNViterbiMode string `yaml:"nxdn_viterbi_mode"`
 	// EDACSBCHMode enables the BCH(40, 28, 2) FEC layer on the
-	// EDACS CCW. Recognised values: "" / "off" (default, legacy
-	// pre-stripped 40-bit CCW) or "on" (40-bit on-wire BCH decode
-	// with single/double-bit correction). Live EDACS CCW captures
-	// should set "on". Ignored for non-EDACS protocols.
+	// EDACS CCW. Recognised values: "" / "on" / "true" / "1" (the
+	// new default — 40-bit on-wire BCH decode with single/double-
+	// bit correction) or "off" / "false" / "0" (legacy pre-stripped
+	// 40-bit CCW, opt-out for pre-stripped fixtures). Ignored for
+	// non-EDACS protocols.
 	EDACSBCHMode string `yaml:"edacs_bch_mode"`
 	// MPT1327BCHMode enables the BCH(63, 38) FEC layer on the MPT
-	// 1327 codeword. Recognised values: "" / "off" (default, legacy
-	// 38-bit pre-stripped codeword) or "on" (64-bit on-wire BCH
-	// decode). Live MPT 1327 captures should set "on". Ignored for
-	// non-MPT-1327 protocols.
+	// 1327 codeword. Recognised values: "" / "on" / "true" / "1"
+	// (the new default — 64-bit on-wire BCH decode) or "off" /
+	// "false" / "0" (legacy 38-bit pre-stripped codeword, opt-out
+	// for pre-stripped fixtures). Ignored for non-MPT-1327
+	// protocols.
 	MPT1327BCHMode string `yaml:"mpt1327_bch_mode"`
 	// MotorolaBCHMode enables the BCH(64, 16, 11) FEC layer on the
-	// Motorola Type II OSW. Recognised values: "" / "off" (default,
-	// legacy 32-bit raw-OSW path) or "on" (two 64-bit BCH(64, 16, 11)
-	// codewords reassembled into the 32-bit OSW with single- through
-	// 11-bit-error correction). Live Motorola Type II captures
-	// should set "on". Ignored for non-Motorola protocols.
+	// Motorola Type II OSW. Recognised values: "" / "on" / "true" /
+	// "1" (the new default — two 64-bit BCH(64, 16, 11) codewords
+	// reassembled into the 32-bit OSW with single- through 11-bit-
+	// error correction) or "off" / "false" / "0" (legacy 32-bit
+	// raw-OSW path, opt-out for pre-stripped fixtures). Ignored
+	// for non-Motorola protocols.
 	MotorolaBCHMode string `yaml:"motorola_bch_mode"`
 }
 

--- a/internal/radio/edacs/control.go
+++ b/internal/radio/edacs/control.go
@@ -56,18 +56,18 @@ type ControlChannel struct {
 // BCHMode selects how the Process adapter interprets the incoming
 // bit stream:
 //
-//   - BCHOff (default): the adapter slices 40-bit pre-stripped
-//     information windows and treats them as CCWs. Works on
-//     synthesized test fixtures whose codewords are not BCH-
-//     protected.
+//   - BCHOff: the adapter slices 40-bit pre-stripped information
+//     windows and treats them as CCWs. Useful only for synthesized
+//     test fixtures whose codewords are not BCH-protected; explicit
+//     opt-out for operators feeding pre-stripped capture files.
 //
-//   - BCHOn: the adapter slices 40-bit on-wire BCH(40,28,2)
-//     codewords (info at bits 12..39 high; 12-bit BCH parity at
-//     bits 0..11 low), runs the
-//     internal/radio/framing/bch_edacs.go primitive to
-//     validate + correct up to 2 bit errors per codeword, then
-//     re-encodes the corrected info into a 40-bit wire word
-//     that the existing CCWFromBits parser consumes.
+//   - BCHOn (default): the adapter slices 40-bit on-wire
+//     BCH(40,28,2) codewords (info at bits 12..39 high; 12-bit BCH
+//     parity at bits 0..11 low), runs the
+//     internal/radio/framing/bch_edacs.go primitive to validate +
+//     correct up to 2 bit errors per codeword, then re-encodes the
+//     corrected info into a 40-bit wire word that the existing
+//     CCWFromBits parser consumes.
 //
 // Under BCHOn the effective CCW model carries:
 //
@@ -107,18 +107,21 @@ func (c *ControlChannel) BCHMode() BCHMode {
 }
 
 // ParseBCHMode maps a config / user-facing string into a BCHMode.
-// Recognised values (case-insensitive): "" / "off" / "false" / "0"
-// → BCHOff (legacy pre-stripped 40-bit CCW path); "on" / "true" /
-// "1" → BCHOn (40-bit on-wire BCH(40, 28, 2) decode + 1/2-bit
-// correction). Unknown strings return BCHOff with `ok = false`.
+// Recognised values (case-insensitive): "" → BCHOn (the new default —
+// 40-bit on-wire BCH(40, 28, 2) decode); "off" / "false" / "0" →
+// BCHOff (legacy pre-stripped 40-bit CCW path, explicit opt-out for
+// pre-stripped fixtures); "on" / "true" / "1" → BCHOn. Unknown
+// strings return BCHOn with `ok = false`.
 func ParseBCHMode(s string) (BCHMode, bool) {
 	switch strings.ToLower(strings.TrimSpace(s)) {
-	case "", "off", "false", "0":
+	case "":
+		return BCHOn, true
+	case "off", "false", "0":
 		return BCHOff, true
 	case "on", "true", "1":
 		return BCHOn, true
 	default:
-		return BCHOff, false
+		return BCHOn, false
 	}
 }
 

--- a/internal/radio/edacs/process_bch_test.go
+++ b/internal/radio/edacs/process_bch_test.go
@@ -277,7 +277,7 @@ func TestParseBCHMode(t *testing.T) {
 		want BCHMode
 		ok   bool
 	}{
-		{"", BCHOff, true},
+		{"", BCHOn, true},
 		{"off", BCHOff, true},
 		{"false", BCHOff, true},
 		{"0", BCHOff, true},
@@ -286,7 +286,7 @@ func TestParseBCHMode(t *testing.T) {
 		{"true", BCHOn, true},
 		{"1", BCHOn, true},
 		{" on ", BCHOn, true},
-		{"nonsense", BCHOff, false},
+		{"nonsense", BCHOn, false},
 	}
 	for _, tc := range cases {
 		got, ok := ParseBCHMode(tc.in)

--- a/internal/radio/ltr/control.go
+++ b/internal/radio/ltr/control.go
@@ -57,8 +57,11 @@ type ControlChannel struct {
 	proc *processState
 
 	// manchesterMode controls Manchester decoding of the input
-	// bit stream — set via SetManchesterMode. Default
-	// ManchesterOff treats the stream as raw NRZ.
+	// bit stream — set via SetManchesterMode. Zero-value
+	// ManchesterOff treats the stream as raw NRZ; production
+	// callers reach ManchesterSoft via the ccdecoder connector
+	// (the parser maps an empty config string to ManchesterSoft,
+	// the dominant on-air encoding for sub-audible LTR signaling).
 	manchesterMode ManchesterDecodeMode
 
 	mu     sync.Mutex
@@ -75,11 +78,13 @@ type ControlChannel struct {
 // FCSMode selects whether the Ingest path verifies the LTR
 // CRC-7 trailer per DSheirer/sdrtrunk's CRCLTR.java.
 //
-//   - FCSOff (default): the Ingest path doesn't run any
-//     checksum verification. The Status.FCS field is treated as
-//     opaque metadata. Existing behaviour pre-PR #40.
+//   - FCSOff: the Ingest path doesn't run any checksum
+//     verification. The Status.FCS field is treated as opaque
+//     metadata. Useful only for synthesized fixtures whose FCS
+//     trailer isn't populated; explicit opt-out for pre-stripped
+//     captures.
 //
-//   - FCSOn: the Ingest path computes the CRC-7 over a 24-bit
+//   - FCSOn (default): the Ingest path computes the CRC-7 over a 24-bit
 //     message built from the Status fields per sdrtrunk's layout
 //     and compares it to the low 7 bits of Status.FCS. Frames
 //     whose CRC doesn't match are silently dropped. Useful when
@@ -128,37 +133,45 @@ func (c *ControlChannel) ManchesterMode() ManchesterDecodeMode {
 }
 
 // ParseFCSMode maps a config / user-facing string into an FCSMode.
-// Recognised values (case-insensitive): "" / "off" → FCSOff (the
-// pre-PR #40 behaviour, no CRC check), "on" / "true" → FCSOn.
-// Unknown strings return FCSOff with `ok = false` so callers can
-// surface the misconfiguration.
+// Recognised values (case-insensitive): "" → FCSOn (the new
+// default), "off" / "false" / "0" → FCSOff (the pre-PR #40
+// behaviour, no CRC check — explicit opt-out for synthesized
+// fixtures), "on" / "true" / "1" → FCSOn. Unknown strings return
+// FCSOn with `ok = false` so callers can surface the
+// misconfiguration.
 func ParseFCSMode(s string) (FCSMode, bool) {
 	switch strings.ToLower(strings.TrimSpace(s)) {
-	case "", "off", "false", "0":
+	case "":
+		return FCSOn, true
+	case "off", "false", "0":
 		return FCSOff, true
 	case "on", "true", "1":
 		return FCSOn, true
 	default:
-		return FCSOff, false
+		return FCSOn, false
 	}
 }
 
 // ParseManchesterMode maps a config / user-facing string into a
 // ManchesterDecodeMode. Recognised values (case-insensitive):
-// "" / "off" / "nrz" → ManchesterOff (raw NRZ), "strict" →
-// ManchesterStrict (drop transition-less pairs), "soft" / "on" →
-// ManchesterSoft (majority-decode + tolerate noise bursts).
-// Unknown strings return ManchesterOff with `ok = false`.
+// "" / "on" → ManchesterSoft (the new default — majority-decode +
+// tolerate noise bursts, matches dominant on-air encoding),
+// "off" / "nrz" → ManchesterOff (raw NRZ, explicit opt-out for
+// synthesized NRZ fixtures), "strict" → ManchesterStrict (drop
+// transition-less pairs), "soft" → ManchesterSoft. Unknown
+// strings return ManchesterSoft with `ok = false`.
 func ParseManchesterMode(s string) (ManchesterDecodeMode, bool) {
 	switch strings.ToLower(strings.TrimSpace(s)) {
-	case "", "off", "nrz":
+	case "":
+		return ManchesterSoft, true
+	case "off", "nrz":
 		return ManchesterOff, true
 	case "strict":
 		return ManchesterStrict, true
 	case "soft", "on":
 		return ManchesterSoft, true
 	default:
-		return ManchesterOff, false
+		return ManchesterSoft, false
 	}
 }
 

--- a/internal/radio/ltr/fcs_test.go
+++ b/internal/radio/ltr/fcs_test.go
@@ -100,9 +100,9 @@ func TestFCSOnDropsCorruptedMessage(t *testing.T) {
 	}
 }
 
-// TestFCSOffIgnoresChecksum: FCSOff (the default) must NOT verify
-// the CRC — a Status with a bogus FCS field still drives the
-// state machine.
+// TestFCSOffIgnoresChecksum: FCSOff (the in-package constructor
+// default) must NOT verify the CRC — a Status with a bogus FCS
+// field still drives the state machine.
 func TestFCSOffIgnoresChecksum(t *testing.T) {
 	bus := events.NewBus(8)
 	defer bus.Close()
@@ -110,7 +110,8 @@ func TestFCSOffIgnoresChecksum(t *testing.T) {
 	defer sub.Close()
 
 	cc := New(Options{Bus: bus, Log: slog.Default(), SystemName: "Sys"})
-	// Default mode is FCSOff; don't call SetFCSMode.
+	// Default mode is FCSOff; production callers reach FCSOn via
+	// the ccdecoder connector. Don't call SetFCSMode.
 
 	s := makeStatusWithValidFCS()
 	s.FCS = 0x7F // bogus checksum
@@ -162,7 +163,7 @@ func TestParseFCSMode(t *testing.T) {
 		want FCSMode
 		ok   bool
 	}{
-		{"", FCSOff, true},
+		{"", FCSOn, true},
 		{"off", FCSOff, true},
 		{"OFF", FCSOff, true},
 		{"false", FCSOff, true},
@@ -172,7 +173,7 @@ func TestParseFCSMode(t *testing.T) {
 		{"true", FCSOn, true},
 		{"1", FCSOn, true},
 		{" on ", FCSOn, true}, // whitespace tolerated
-		{"nonsense", FCSOff, false},
+		{"nonsense", FCSOn, false},
 	}
 	for _, tc := range cases {
 		got, ok := ParseFCSMode(tc.in)
@@ -191,7 +192,7 @@ func TestParseManchesterMode(t *testing.T) {
 		want ManchesterDecodeMode
 		ok   bool
 	}{
-		{"", ManchesterOff, true},
+		{"", ManchesterSoft, true},
 		{"off", ManchesterOff, true},
 		{"nrz", ManchesterOff, true},
 		{"NRZ", ManchesterOff, true},
@@ -201,7 +202,7 @@ func TestParseManchesterMode(t *testing.T) {
 		{"on", ManchesterSoft, true},
 		{"Soft", ManchesterSoft, true},
 		{" strict ", ManchesterStrict, true},
-		{"nonsense", ManchesterOff, false},
+		{"nonsense", ManchesterSoft, false},
 	}
 	for _, tc := range cases {
 		got, ok := ParseManchesterMode(tc.in)

--- a/internal/radio/ltr/process.go
+++ b/internal/radio/ltr/process.go
@@ -23,8 +23,12 @@ type processState struct {
 // Some LTR variants transmit the sub-audible status word in bi-
 // phase / Manchester encoding (each bit doubled, requiring a mid-
 // bit transition); others ship raw NRZ. Operators configure the
-// mode at receiver construction; the default is ManchesterOff
-// since the dominant deployment is NRZ.
+// mode at receiver construction. The zero-value default is
+// ManchesterOff (raw NRZ — matches the in-package synthesized
+// fixtures); production callers reach ManchesterSoft via the
+// ccdecoder connector, whose ParseManchesterMode maps an empty
+// config string to ManchesterSoft (the dominant on-air encoding
+// for sub-audible LTR signaling).
 type ManchesterDecodeMode uint8
 
 const (

--- a/internal/radio/motorola/process.go
+++ b/internal/radio/motorola/process.go
@@ -23,14 +23,16 @@ type BCHMode uint8
 
 const (
 	// BCHOff treats the 32 bits after sync as raw OSW info bits.
-	// Works for test fixtures + clean signals; on-air traffic
-	// usually fails OSW parsing.
+	// Useful only for test fixtures whose codewords are pre-
+	// stripped of the FEC layer; on-air traffic always fails OSW
+	// parsing under BCHOff. Explicit opt-out for operators feeding
+	// pre-stripped capture files.
 	BCHOff BCHMode = iota
-	// BCHOn reads two 64-bit BCH(64,16,11) codewords (128 wire
-	// bits) after sync, decodes each via the framing primitive,
-	// and concatenates the recovered 16-bit halves into the
-	// 32-bit OSW. Uncorrectable codewords (> 11 errors) drop the
-	// frame.
+	// BCHOn (default) reads two 64-bit BCH(64,16,11) codewords
+	// (128 wire bits) after sync, decodes each via the framing
+	// primitive, and concatenates the recovered 16-bit halves into
+	// the 32-bit OSW. Uncorrectable codewords (> 11 errors) drop
+	// the frame.
 	BCHOn
 )
 
@@ -58,19 +60,22 @@ func (c *ControlChannel) BCHMode() BCHMode {
 }
 
 // ParseBCHMode maps a config / user-facing string into a BCHMode.
-// Recognised values (case-insensitive): "" / "off" / "false" /
-// "0" → BCHOff (legacy 32-bit raw-OSW path); "on" / "true" /
-// "1" → BCHOn (two 64-bit BCH(64, 16, 11) codewords reassembled
-// into the 32-bit OSW). Unknown strings return BCHOff with
+// Recognised values (case-insensitive): "" → BCHOn (the new default
+// — two 64-bit BCH(64, 16, 11) codewords reassembled into the
+// 32-bit OSW); "off" / "false" / "0" → BCHOff (legacy 32-bit
+// raw-OSW path, explicit opt-out for pre-stripped fixtures); "on" /
+// "true" / "1" → BCHOn. Unknown strings return BCHOn with
 // `ok = false` so callers can surface the misconfiguration.
 func ParseBCHMode(s string) (BCHMode, bool) {
 	switch strings.ToLower(strings.TrimSpace(s)) {
-	case "", "off", "false", "0":
+	case "":
+		return BCHOn, true
+	case "off", "false", "0":
 		return BCHOff, true
 	case "on", "true", "1":
 		return BCHOn, true
 	default:
-		return BCHOff, false
+		return BCHOn, false
 	}
 }
 

--- a/internal/radio/motorola/process_test.go
+++ b/internal/radio/motorola/process_test.go
@@ -216,8 +216,10 @@ func TestSyncDetectorReset(t *testing.T) {
 }
 
 // TestSetBCHModeDefault confirms the zero-value ControlChannel
-// uses BCHOff, the accessor mirrors the setter, and the
-// SetBCHMode toggle round-trips both ways.
+// uses BCHOff (the in-package fixture default), the accessor
+// mirrors the setter, and SetBCHMode round-trips both ways.
+// Production callers reach the new BCHOn default via the
+// ccdecoder connector (which always runs ParseBCHMode).
 func TestSetBCHModeDefault(t *testing.T) {
 	cc := New(Options{})
 	if cc.bchMode != BCHOff {
@@ -248,7 +250,7 @@ func TestParseBCHMode(t *testing.T) {
 		want BCHMode
 		ok   bool
 	}{
-		{"", BCHOff, true},
+		{"", BCHOn, true},
 		{"off", BCHOff, true},
 		{"false", BCHOff, true},
 		{"0", BCHOff, true},
@@ -257,7 +259,7 @@ func TestParseBCHMode(t *testing.T) {
 		{"true", BCHOn, true},
 		{"1", BCHOn, true},
 		{" on ", BCHOn, true},
-		{"nonsense", BCHOff, false},
+		{"nonsense", BCHOn, false},
 	}
 	for _, tc := range cases {
 		got, ok := ParseBCHMode(tc.in)

--- a/internal/radio/mpt1327/control.go
+++ b/internal/radio/mpt1327/control.go
@@ -72,12 +72,13 @@ func (c *ControlChannel) SetStrictValidation(strict bool) {
 // BCHMode selects how the Process adapter interprets the incoming
 // bit stream:
 //
-//   - BCHOff (default): the adapter reads 38-bit information
-//     windows directly from the wire and treats them as Codewords.
-//     Works on synthesized test fixtures whose codewords are
-//     pre-stripped of the FEC layer.
+//   - BCHOff: the adapter reads 38-bit information windows directly
+//     from the wire and treats them as Codewords. Useful only for
+//     synthesized test fixtures whose codewords are pre-stripped of
+//     the FEC layer; explicit opt-out for operators feeding such
+//     captures.
 //
-//   - BCHOn: the adapter reads 64-bit on-wire codewords, runs
+//   - BCHOn (default): the adapter reads 64-bit on-wire codewords, runs
 //     them through the BCH(64,48,2) check + single-bit correction
 //     in internal/radio/framing/bch_mpt1327.go, and extracts the
 //     38-bit information field expected by the existing
@@ -119,18 +120,21 @@ func (c *ControlChannel) BCHMode() BCHMode {
 }
 
 // ParseBCHMode maps a config / user-facing string into a BCHMode.
-// Recognised values (case-insensitive): "" / "off" / "false" / "0"
-// → BCHOff (legacy 38-bit pre-stripped codeword path); "on" /
-// "true" / "1" → BCHOn (64-bit on-wire BCH(63, 38) decode). Unknown
-// strings return BCHOff with `ok = false`.
+// Recognised values (case-insensitive): "" → BCHOn (the new default —
+// 64-bit on-wire BCH(63, 38) decode); "off" / "false" / "0" → BCHOff
+// (legacy 38-bit pre-stripped codeword path, explicit opt-out for
+// pre-stripped fixtures); "on" / "true" / "1" → BCHOn. Unknown
+// strings return BCHOn with `ok = false`.
 func ParseBCHMode(s string) (BCHMode, bool) {
 	switch strings.ToLower(strings.TrimSpace(s)) {
-	case "", "off", "false", "0":
+	case "":
+		return BCHOn, true
+	case "off", "false", "0":
 		return BCHOff, true
 	case "on", "true", "1":
 		return BCHOn, true
 	default:
-		return BCHOff, false
+		return BCHOn, false
 	}
 }
 

--- a/internal/radio/mpt1327/process_bch_test.go
+++ b/internal/radio/mpt1327/process_bch_test.go
@@ -223,7 +223,7 @@ func TestParseBCHMode(t *testing.T) {
 		want BCHMode
 		ok   bool
 	}{
-		{"", BCHOff, true},
+		{"", BCHOn, true},
 		{"off", BCHOff, true},
 		{"false", BCHOff, true},
 		{"0", BCHOff, true},
@@ -232,7 +232,7 @@ func TestParseBCHMode(t *testing.T) {
 		{"true", BCHOn, true},
 		{"1", BCHOn, true},
 		{" on ", BCHOn, true},
-		{"nonsense", BCHOff, false},
+		{"nonsense", BCHOn, false},
 	}
 	for _, tc := range cases {
 		got, ok := ParseBCHMode(tc.in)

--- a/internal/radio/nxdn/control.go
+++ b/internal/radio/nxdn/control.go
@@ -51,17 +51,19 @@ type ControlChannel struct {
 	proc *processState
 
 	// viterbiMode controls whether Process treats the CAC region
-	// of the Info field as raw on-wire bits (ViterbiOff, default)
-	// or runs the 144 dibits through the K=5 ½-rate Viterbi
-	// primitive before parsing (ViterbiOn). Set via
-	// SetViterbiMode.
+	// of the Info field as raw on-wire bits (ViterbiOff, the
+	// zero-value default) or runs the 144 dibits through the K=5
+	// ½-rate Viterbi primitive before parsing (ViterbiOn /
+	// ViterbiSpec). Production callers reach ViterbiSpec via the
+	// ccdecoder connector (the parser maps an empty config string
+	// to ViterbiSpec). Set via SetViterbiMode.
 	viterbiMode ViterbiMode
 }
 
 // ViterbiMode selects how the Process adapter interprets the CAC
 // region inside the 144-dibit Info field.
 //
-//   - ViterbiOff (default): the adapter reads 44 dibits = 88 raw
+//   - ViterbiOff: the adapter reads 44 dibits = 88 raw
 //     information bits straight off the wire. Works on test
 //     fixtures + clean synthesized streams whose CAC bits aren't
 //     channel-coded; it does NOT match the on-air NXDN encoding,
@@ -77,9 +79,9 @@ type ControlChannel struct {
 //     Inner per-protocol interleaver + puncture are still
 //     deferred.
 //
-//   - ViterbiSpec: the adapter slices the full 150-dibit CAC slot
-//     (= 300 channel bits) and runs the spec-correct chain per
-//     NXDN-TS-1-A rev 1.3 §4.5.1.1 (CAC outbound): deinterleave
+//   - ViterbiSpec (default): the adapter slices the full 150-dibit
+//     CAC slot (= 300 channel bits) and runs the spec-correct chain
+//     per NXDN-TS-1-A rev 1.3 §4.5.1.1 (CAC outbound): deinterleave
 //     25×12 → depuncture 50/350 → K=5 R=½ Viterbi → 16-bit CRC
 //     verify → strip tail. Recovers the 155-bit info block
 //     (8 SR + 144 L3 Data + 3 Null); the first 88 bits of the L3
@@ -111,28 +113,37 @@ func (c *ControlChannel) ViterbiMode() ViterbiMode {
 }
 
 // ParseViterbiMode maps a config / user-facing string into a
-// ViterbiMode. Recognised values (case-insensitive): "" / "off" /
-// "false" / "0" → ViterbiOff (legacy 44-dibit raw-CAC path);
-// "on" / "true" / "1" → ViterbiOn (92 dibits via the simplified
-// K=5 Viterbi path used by older MMDVMHost / DSDcc fixtures);
-// "spec" → ViterbiSpec (150 dibits via the full NXDN-TS-1-A
-// §4.5.1.1 outbound CAC chain — deinterleave + depuncture + K=5
-// Viterbi + 16-bit CRC + tail strip — the path that works on
-// live captures). Unknown strings return ViterbiOff with
-// `ok = false`.
+// ViterbiMode. Recognised values (case-insensitive): "" → ViterbiSpec
+// (the new default — full NXDN-TS-1-A §4.5.1.1 outbound CAC chain);
+// "off" / "false" / "0" → ViterbiOff (legacy 44-dibit raw-CAC path,
+// explicit opt-out for MMDVMHost / DSDcc fixtures that ship
+// pre-stripped); "on" / "true" / "1" → ViterbiOn (92 dibits via the
+// simplified K=5 Viterbi path used by older MMDVMHost / DSDcc
+// fixtures); "spec" → ViterbiSpec (150 dibits via the full
+// NXDN-TS-1-A §4.5.1.1 outbound CAC chain — deinterleave +
+// depuncture + K=5 Viterbi + 16-bit CRC + tail strip). Unknown
+// strings return ViterbiSpec with `ok = false`.
 func ParseViterbiMode(s string) (ViterbiMode, bool) {
 	switch strings.ToLower(strings.TrimSpace(s)) {
-	case "", "off", "false", "0":
+	case "":
+		return ViterbiSpec, true
+	case "off", "false", "0":
 		return ViterbiOff, true
 	case "on", "true", "1":
 		return ViterbiOn, true
 	case "spec":
 		return ViterbiSpec, true
 	default:
-		return ViterbiOff, false
+		return ViterbiSpec, false
 	}
 }
 
+// NewControlChannel constructs a bare ControlChannel with no FEC
+// applied — the constructor matches the in-package fixture
+// behaviour. Production callers reach the new ViterbiSpec default
+// via the ccdecoder connector, which always runs ParseViterbiMode
+// (empty string → ViterbiSpec). Direct callers (tests, embedders)
+// stay on ViterbiOff unless they call SetViterbiMode.
 func NewControlChannel(bus *events.Bus, log *slog.Logger, freqHz uint32, rate BaudRate) *ControlChannel {
 	if log == nil {
 		log = slog.Default()

--- a/internal/radio/nxdn/process_viterbi_test.go
+++ b/internal/radio/nxdn/process_viterbi_test.go
@@ -146,8 +146,11 @@ func TestProcessViterbiOnRejectsRawCACFrame(t *testing.T) {
 	}
 }
 
-// TestSetViterbiModeRetainsViterbiOffDefault confirms the zero-value
-// ControlChannel uses the legacy raw-CAC path.
+// TestSetViterbiModeRetainsViterbiOffDefault confirms a freshly-
+// constructed ControlChannel uses the raw-CAC path. Production
+// callers reach the new ViterbiSpec default via the ccdecoder
+// connector (which always runs ParseViterbiMode); direct callers
+// stay on ViterbiOff unless they call SetViterbiMode.
 func TestSetViterbiModeRetainsViterbiOffDefault(t *testing.T) {
 	cc := NewControlChannel(nil, slog.Default(), 0, Rate9600)
 	if cc.viterbiMode != ViterbiOff {
@@ -178,7 +181,7 @@ func TestParseViterbiMode(t *testing.T) {
 		want ViterbiMode
 		ok   bool
 	}{
-		{"", ViterbiOff, true},
+		{"", ViterbiSpec, true},
 		{"off", ViterbiOff, true},
 		{"false", ViterbiOff, true},
 		{"0", ViterbiOff, true},
@@ -187,7 +190,8 @@ func TestParseViterbiMode(t *testing.T) {
 		{"true", ViterbiOn, true},
 		{"1", ViterbiOn, true},
 		{" on ", ViterbiOn, true},
-		{"nonsense", ViterbiOff, false},
+		{"spec", ViterbiSpec, true},
+		{"nonsense", ViterbiSpec, false},
 	}
 	for _, tc := range cases {
 		got, ok := ParseViterbiMode(tc.in)

--- a/internal/radio/p25/phase2/control.go
+++ b/internal/radio/p25/phase2/control.go
@@ -42,13 +42,13 @@ type ControlChannel struct {
 // TrellisMode selects how the Process adapter interprets the MAC
 // PDU dibit window inside the Phase 2 traffic channel.
 //
-//   - TrellisOff (default): the adapter reads 72 dibits = 144 raw
-//     information bits straight off the wire, parses 18 bytes as
-//     a MAC PDU. Works on test fixtures + clean synthesized
-//     streams whose MAC bits aren't trellis-coded; matches the
-//     legacy adapter behaviour.
+//   - TrellisOff: the adapter reads 72 dibits = 144 raw information
+//     bits straight off the wire, parses 18 bytes as a MAC PDU.
+//     Useful only on synthesized streams whose MAC bits aren't
+//     trellis-coded; explicit opt-out for operators feeding
+//     pre-stripped capture files.
 //
-//   - TrellisOn: the adapter collects 146 channel dibits (72 info
+//   - TrellisOn (default): the adapter collects 146 channel dibits (72 info
 //     + 1 finisher transition × 2 channel dibits per transition),
 //     runs them through the TIA-102 Annex A 4-state ½-rate
 //     trellis Viterbi decoder in
@@ -90,20 +90,23 @@ func (c *ControlChannel) TrellisMode() TrellisMode {
 }
 
 // ParseTrellisMode maps a config / user-facing string into a
-// TrellisMode. Recognised values (case-insensitive): "" / "off" /
-// "false" / "0" → TrellisOff (the legacy 72-dibit raw-MAC-PDU
-// path); "on" / "true" / "1" → TrellisOn (146 channel dibits run
-// through the 4-state ½-rate trellis decoder). Unknown strings
-// return TrellisOff with `ok = false` so callers can surface the
+// TrellisMode. Recognised values (case-insensitive): "" → TrellisOn
+// (the new default — 146 channel dibits run through the 4-state
+// ½-rate trellis decoder); "off" / "false" / "0" → TrellisOff (legacy
+// 72-dibit raw-MAC-PDU path, explicit opt-out for pre-stripped
+// fixtures); "on" / "true" / "1" → TrellisOn. Unknown strings return
+// TrellisOn with `ok = false` so callers can surface the
 // misconfiguration.
 func ParseTrellisMode(s string) (TrellisMode, bool) {
 	switch strings.ToLower(strings.TrimSpace(s)) {
-	case "", "off", "false", "0":
+	case "":
+		return TrellisOn, true
+	case "off", "false", "0":
 		return TrellisOff, true
 	case "on", "true", "1":
 		return TrellisOn, true
 	default:
-		return TrellisOff, false
+		return TrellisOn, false
 	}
 }
 

--- a/internal/radio/p25/phase2/process_trellis_test.go
+++ b/internal/radio/p25/phase2/process_trellis_test.go
@@ -195,7 +195,7 @@ func TestParseTrellisMode(t *testing.T) {
 		want TrellisMode
 		ok   bool
 	}{
-		{"", TrellisOff, true},
+		{"", TrellisOn, true},
 		{"off", TrellisOff, true},
 		{"OFF", TrellisOff, true},
 		{"false", TrellisOff, true},
@@ -205,7 +205,7 @@ func TestParseTrellisMode(t *testing.T) {
 		{"true", TrellisOn, true},
 		{"1", TrellisOn, true},
 		{" on ", TrellisOn, true},
-		{"nonsense", TrellisOff, false},
+		{"nonsense", TrellisOn, false},
 	}
 	for _, tc := range cases {
 		got, ok := ParseTrellisMode(tc.in)

--- a/internal/radio/p25/phase2/receiver/receiver.go
+++ b/internal/radio/p25/phase2/receiver/receiver.go
@@ -27,6 +27,7 @@ package receiver
 
 import (
 	"math"
+	"strings"
 
 	"github.com/MattCheramie/GopherTrunk/internal/dsp/demod"
 	"github.com/MattCheramie/GopherTrunk/internal/dsp/sync"
@@ -101,6 +102,26 @@ const (
 	ClockNaive ClockMode = iota
 	ClockGardner
 )
+
+// ParseClockMode maps a config / user-facing string into a
+// ClockMode. Recognised values (case-insensitive): "" / "gardner" /
+// "on" / "true" / "1" → ClockGardner (the new default — Gardner
+// timing-recovery loop, recommended for live SDR captures); "naive"
+// / "off" / "false" / "0" → ClockNaive (pre-Gardner behaviour,
+// preserved for tests using sample-aligned synthesized IQ
+// fixtures). Unknown strings return ClockGardner with `ok = false`.
+func ParseClockMode(s string) (ClockMode, bool) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "":
+		return ClockGardner, true
+	case "gardner", "on", "true", "1":
+		return ClockGardner, true
+	case "naive", "off", "false", "0":
+		return ClockNaive, true
+	default:
+		return ClockGardner, false
+	}
+}
 
 // Receiver is the composed IQ → dibit pipeline.
 type Receiver struct {

--- a/internal/radio/p25/phase2/receiver/receiver_test.go
+++ b/internal/radio/p25/phase2/receiver/receiver_test.go
@@ -162,3 +162,35 @@ func TestReceiverEmittedDibitsAreValid(t *testing.T) {
 		t.Errorf("%d dibit(s) outside 0..3 range", bad)
 	}
 }
+
+// TestParseClockMode covers the config-string → ClockMode mapping
+// the ccdecoder connector uses to translate the
+// `p25_phase2_clock_mode` YAML field into Options.ClockMode.
+func TestParseClockMode(t *testing.T) {
+	cases := []struct {
+		in   string
+		want ClockMode
+		ok   bool
+	}{
+		{"", ClockGardner, true},
+		{"gardner", ClockGardner, true},
+		{"Gardner", ClockGardner, true},
+		{"on", ClockGardner, true},
+		{"true", ClockGardner, true},
+		{"1", ClockGardner, true},
+		{" gardner ", ClockGardner, true},
+		{"naive", ClockNaive, true},
+		{"NAIVE", ClockNaive, true},
+		{"off", ClockNaive, true},
+		{"false", ClockNaive, true},
+		{"0", ClockNaive, true},
+		{"nonsense", ClockGardner, false},
+	}
+	for _, tc := range cases {
+		got, ok := ParseClockMode(tc.in)
+		if got != tc.want || ok != tc.ok {
+			t.Errorf("ParseClockMode(%q) = (%v, %v), want (%v, %v)",
+				tc.in, got, ok, tc.want, tc.ok)
+		}
+	}
+}

--- a/internal/radio/tetra/control.go
+++ b/internal/radio/tetra/control.go
@@ -150,6 +150,27 @@ func ParseChannelType(s string) (ChannelType, bool) {
 	}
 }
 
+// ParseChannelCoding maps a config / user-facing string into a
+// ChannelCodingMode. Recognised values (case-insensitive): "" →
+// ChannelCodingOn (the new default — full §8.3.1 channel-coding
+// chain); "off" / "false" / "0" → ChannelCodingOff (legacy 48-dibit
+// raw-PDU path, explicit opt-out for pre-stripped fixtures);
+// "on" / "true" / "1" → ChannelCodingOn. Unknown strings return
+// ChannelCodingOn with `ok = false` so callers can surface the
+// misconfiguration.
+func ParseChannelCoding(s string) (ChannelCodingMode, bool) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "":
+		return ChannelCodingOn, true
+	case "off", "false", "0":
+		return ChannelCodingOff, true
+	case "on", "true", "1":
+		return ChannelCodingOn, true
+	default:
+		return ChannelCodingOn, false
+	}
+}
+
 // SetChannelCoding toggles the full EN 300 392-2 §8.3.1 channel
 // coding chain on the Process adapter. See ChannelCodingMode for
 // the trade-offs.

--- a/internal/radio/tetra/process_channel_coding_test.go
+++ b/internal/radio/tetra/process_channel_coding_test.go
@@ -275,6 +275,37 @@ func TestSetChannelCodingDefault(t *testing.T) {
 	}
 }
 
+// TestParseChannelCoding covers the config-string →
+// ChannelCodingMode mapping the ccdecoder connector uses to
+// translate the `tetra_channel_coding` YAML field into a
+// SetChannelCoding call.
+func TestParseChannelCoding(t *testing.T) {
+	cases := []struct {
+		in   string
+		want ChannelCodingMode
+		ok   bool
+	}{
+		{"", ChannelCodingOn, true},
+		{"on", ChannelCodingOn, true},
+		{"ON", ChannelCodingOn, true},
+		{"true", ChannelCodingOn, true},
+		{"1", ChannelCodingOn, true},
+		{" on ", ChannelCodingOn, true},
+		{"off", ChannelCodingOff, true},
+		{"OFF", ChannelCodingOff, true},
+		{"false", ChannelCodingOff, true},
+		{"0", ChannelCodingOff, true},
+		{"nonsense", ChannelCodingOn, false},
+	}
+	for _, tc := range cases {
+		got, ok := ParseChannelCoding(tc.in)
+		if got != tc.want || ok != tc.ok {
+			t.Errorf("ParseChannelCoding(%q) = (%v, %v), want (%v, %v)",
+				tc.in, got, ok, tc.want, tc.ok)
+		}
+	}
+}
+
 // TestParseChannelType covers the config-string → ChannelType
 // mapping the ccdecoder connector uses to translate the
 // `tetra_channel` YAML field into a SetExpectedChannel call.

--- a/internal/radio/tetra/receiver/receiver.go
+++ b/internal/radio/tetra/receiver/receiver.go
@@ -21,6 +21,7 @@ package receiver
 
 import (
 	"math"
+	"strings"
 
 	"github.com/MattCheramie/GopherTrunk/internal/dsp/demod"
 	"github.com/MattCheramie/GopherTrunk/internal/dsp/sync"
@@ -83,6 +84,26 @@ const (
 	ClockNaive ClockMode = iota
 	ClockGardner
 )
+
+// ParseClockMode maps a config / user-facing string into a
+// ClockMode. Recognised values (case-insensitive): "" / "gardner" /
+// "on" / "true" / "1" → ClockGardner (the new default — Gardner
+// timing-recovery loop, recommended for live SDR captures); "naive"
+// / "off" / "false" / "0" → ClockNaive (pre-Gardner behaviour,
+// preserved for tests using sample-aligned synthesized IQ
+// fixtures). Unknown strings return ClockGardner with `ok = false`.
+func ParseClockMode(s string) (ClockMode, bool) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "":
+		return ClockGardner, true
+	case "gardner", "on", "true", "1":
+		return ClockGardner, true
+	case "naive", "off", "false", "0":
+		return ClockNaive, true
+	default:
+		return ClockGardner, false
+	}
+}
 
 // Receiver is the composed IQ → dibit pipeline.
 type Receiver struct {

--- a/internal/radio/tetra/receiver/receiver_test.go
+++ b/internal/radio/tetra/receiver/receiver_test.go
@@ -160,3 +160,35 @@ func TestReceiverEmittedDibitsAreValid(t *testing.T) {
 		t.Errorf("%d dibit(s) outside 0..3 range", bad)
 	}
 }
+
+// TestParseClockMode covers the config-string → ClockMode mapping
+// the ccdecoder connector uses to translate the
+// `tetra_clock_mode` YAML field into Options.ClockMode.
+func TestParseClockMode(t *testing.T) {
+	cases := []struct {
+		in   string
+		want ClockMode
+		ok   bool
+	}{
+		{"", ClockGardner, true},
+		{"gardner", ClockGardner, true},
+		{"Gardner", ClockGardner, true},
+		{"on", ClockGardner, true},
+		{"true", ClockGardner, true},
+		{"1", ClockGardner, true},
+		{" gardner ", ClockGardner, true},
+		{"naive", ClockNaive, true},
+		{"NAIVE", ClockNaive, true},
+		{"off", ClockNaive, true},
+		{"false", ClockNaive, true},
+		{"0", ClockNaive, true},
+		{"nonsense", ClockGardner, false},
+	}
+	for _, tc := range cases {
+		got, ok := ParseClockMode(tc.in)
+		if got != tc.want || ok != tc.ok {
+			t.Errorf("ParseClockMode(%q) = (%v, %v), want (%v, %v)",
+				tc.in, got, ok, tc.want, tc.ok)
+		}
+	}
+}

--- a/internal/scanner/ccdecoder/decoder_test.go
+++ b/internal/scanner/ccdecoder/decoder_test.go
@@ -282,6 +282,15 @@ func TestTETRAFactoryConstructs(t *testing.T) {
 	p, err := newTETRAPipeline(PipelineOptions{
 		Bus: bus, SystemName: "Smoke",
 		FrequencyHz: 412_062_500, SampleRateHz: 144_000,
+		// Smoke test only — set a placeholder colour code so the
+		// connector doesn't warn about zero colour code on the
+		// default non-BSCH channel under the new ChannelCodingOn
+		// default.
+		System: trunking.System{
+			Name: "Smoke", Protocol: trunking.ProtocolTETRA,
+			ControlChannels: []uint32{412_062_500},
+			TETRAColourCode: 0x1,
+		},
 	})
 	if err != nil {
 		t.Fatalf("newTETRAPipeline: %v", err)
@@ -325,10 +334,11 @@ func TestTETRAFactoryEnablesChannelCodingFromSystem(t *testing.T) {
 	}
 }
 
-// TestTETRAFactoryDefaultColourCodeKeepsCodingOff: zero
-// TETRAColourCode preserves the legacy raw-dibit path so existing
-// synthesized-fixture tests stay green.
-func TestTETRAFactoryDefaultColourCodeKeepsCodingOff(t *testing.T) {
+// TestTETRAFactoryDefaultsKeepCodingOn: empty TETRAChannelCoding
+// flips the connector to ChannelCodingOn (the new default — full
+// ETSI EN 300 392-2 §8.3.1 chain) so live captures decode without
+// per-system YAML tweaks.
+func TestTETRAFactoryDefaultsKeepCodingOn(t *testing.T) {
 	bus := events.NewBus(8)
 	defer bus.Close()
 	p, err := newTETRAPipeline(PipelineOptions{
@@ -337,7 +347,32 @@ func TestTETRAFactoryDefaultColourCodeKeepsCodingOff(t *testing.T) {
 		System: trunking.System{
 			Name: "Test", Protocol: trunking.ProtocolTETRA,
 			ControlChannels: []uint32{412_062_500},
-			// TETRAColourCode left at zero.
+			TETRAColourCode: 0x12345,
+			// TETRAChannelCoding left empty → ChannelCodingOn.
+		},
+	})
+	if err != nil {
+		t.Fatalf("newTETRAPipeline: %v", err)
+	}
+	tp := p.(*tetraPipeline)
+	if got := tp.cc.ChannelCoding(); got != tetra.ChannelCodingOn {
+		t.Errorf("ChannelCoding = %v, want ChannelCodingOn", got)
+	}
+}
+
+// TestTETRAFactoryExplicitOffOptsOut: tetra_channel_coding=off opts
+// out of the new ChannelCodingOn default for operators feeding
+// pre-stripped DSD-FME / OP25 captures.
+func TestTETRAFactoryExplicitOffOptsOut(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	p, err := newTETRAPipeline(PipelineOptions{
+		Bus: bus, SystemName: "Test", FrequencyHz: 412_062_500,
+		SampleRateHz: 144_000,
+		System: trunking.System{
+			Name: "Test", Protocol: trunking.ProtocolTETRA,
+			ControlChannels:    []uint32{412_062_500},
+			TETRAChannelCoding: "off",
 		},
 	})
 	if err != nil {
@@ -446,10 +481,10 @@ func TestLTRFactoryAppliesFCSAndManchesterFromSystem(t *testing.T) {
 	}
 }
 
-// TestLTRFactoryDefaultsKeepLegacyModes: empty LTRFCSMode +
-// LTRManchesterMode preserve the legacy FCSOff + ManchesterOff
-// path so existing synthesized-fixture tests stay green.
-func TestLTRFactoryDefaultsKeepLegacyModes(t *testing.T) {
+// TestLTRFactoryDefaultsKeepLiveOnAirModes: empty LTRFCSMode +
+// LTRManchesterMode flip the connector to FCSOn + ManchesterSoft
+// (the new defaults — matches the dominant on-air encoding).
+func TestLTRFactoryDefaultsKeepLiveOnAirModes(t *testing.T) {
 	bus := events.NewBus(8)
 	defer bus.Close()
 	p, err := newLTRPipeline(PipelineOptions{
@@ -459,6 +494,34 @@ func TestLTRFactoryDefaultsKeepLegacyModes(t *testing.T) {
 			Name: "Test", Protocol: trunking.ProtocolLTR,
 			ControlChannels: []uint32{935_012_500},
 			// LTRFCSMode + LTRManchesterMode left empty.
+		},
+	})
+	if err != nil {
+		t.Fatalf("newLTRPipeline: %v", err)
+	}
+	lp := p.(*ltrPipeline)
+	if got := lp.cc.FCSMode(); got != ltr.FCSOn {
+		t.Errorf("FCSMode = %v, want FCSOn", got)
+	}
+	if got := lp.cc.ManchesterMode(); got != ltr.ManchesterSoft {
+		t.Errorf("ManchesterMode = %v, want ManchesterSoft", got)
+	}
+}
+
+// TestLTRFactoryExplicitOffOptsOut: ltr_fcs_mode=off +
+// ltr_manchester_mode=off opt out of the new on-defaults for
+// operators feeding pre-stripped synthesized fixtures.
+func TestLTRFactoryExplicitOffOptsOut(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	p, err := newLTRPipeline(PipelineOptions{
+		Bus: bus, SystemName: "Test", FrequencyHz: 935_012_500,
+		SampleRateHz: 48_000,
+		System: trunking.System{
+			Name: "Test", Protocol: trunking.ProtocolLTR,
+			ControlChannels:   []uint32{935_012_500},
+			LTRFCSMode:        "off",
+			LTRManchesterMode: "off",
 		},
 	})
 	if err != nil {
@@ -513,9 +576,11 @@ func TestMotorolaFactoryAppliesBCHFromSystem(t *testing.T) {
 	}
 }
 
-// TestMotorolaFactoryDefaultsKeepBCHOff: empty MotorolaBCHMode
-// preserves the legacy 32-bit raw-OSW path.
-func TestMotorolaFactoryDefaultsKeepBCHOff(t *testing.T) {
+// TestMotorolaFactoryDefaultsKeepBCHOn: empty MotorolaBCHMode flips
+// the connector to BCHOn (the new default — dual 64-bit
+// BCH(64, 16, 11) reassembly). Live captures always need the FEC
+// layer, so default-on matches operator expectations.
+func TestMotorolaFactoryDefaultsKeepBCHOn(t *testing.T) {
 	bus := events.NewBus(8)
 	defer bus.Close()
 	p, err := newMotorolaPipeline(PipelineOptions{
@@ -524,6 +589,29 @@ func TestMotorolaFactoryDefaultsKeepBCHOff(t *testing.T) {
 		System: trunking.System{
 			Name: "Test", Protocol: trunking.ProtocolMotorola,
 			ControlChannels: []uint32{851_012_500},
+		},
+	})
+	if err != nil {
+		t.Fatalf("newMotorolaPipeline: %v", err)
+	}
+	mp := p.(*motorolaPipeline)
+	if got := mp.cc.BCHMode(); got != motorola.BCHOn {
+		t.Errorf("BCHMode = %v, want BCHOn", got)
+	}
+}
+
+// TestMotorolaFactoryExplicitOffOptsOut: motorola_bch_mode=off opts
+// out of the new BCHOn default for pre-stripped fixtures.
+func TestMotorolaFactoryExplicitOffOptsOut(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	p, err := newMotorolaPipeline(PipelineOptions{
+		Bus: bus, SystemName: "Test", FrequencyHz: 851_012_500,
+		SampleRateHz: 48_000,
+		System: trunking.System{
+			Name: "Test", Protocol: trunking.ProtocolMotorola,
+			ControlChannels: []uint32{851_012_500},
+			MotorolaBCHMode: "off",
 		},
 	})
 	if err != nil {
@@ -627,9 +715,10 @@ func TestP25Phase2FactoryAppliesTrellisFromSystem(t *testing.T) {
 	}
 }
 
-// TestP25Phase2FactoryDefaultsKeepTrellisOff: empty config string
-// preserves the legacy 72-dibit raw-MAC-PDU path.
-func TestP25Phase2FactoryDefaultsKeepTrellisOff(t *testing.T) {
+// TestP25Phase2FactoryDefaultsKeepTrellisOn: empty config string
+// flips the connector to TrellisOn (the new default — full
+// TIA-102.AABF trellis decode).
+func TestP25Phase2FactoryDefaultsKeepTrellisOn(t *testing.T) {
 	bus := events.NewBus(8)
 	defer bus.Close()
 	p, err := newP25Phase2Pipeline(PipelineOptions{
@@ -638,6 +727,30 @@ func TestP25Phase2FactoryDefaultsKeepTrellisOff(t *testing.T) {
 		System: trunking.System{
 			Name: "Test", Protocol: trunking.ProtocolP25Phase2,
 			ControlChannels: []uint32{851_062_500},
+		},
+	})
+	if err != nil {
+		t.Fatalf("newP25Phase2Pipeline: %v", err)
+	}
+	pp := p.(*p25Phase2Pipeline)
+	if got := pp.cc.TrellisMode(); got != p25phase2.TrellisOn {
+		t.Errorf("TrellisMode = %v, want TrellisOn", got)
+	}
+}
+
+// TestP25Phase2FactoryExplicitOffOptsOut: p25_phase2_trellis_mode=off
+// opts out of the new TrellisOn default for pre-stripped MAC-PDU
+// fixtures.
+func TestP25Phase2FactoryExplicitOffOptsOut(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	p, err := newP25Phase2Pipeline(PipelineOptions{
+		Bus: bus, SystemName: "Test", FrequencyHz: 851_062_500,
+		SampleRateHz: 48_000,
+		System: trunking.System{
+			Name: "Test", Protocol: trunking.ProtocolP25Phase2,
+			ControlChannels:      []uint32{851_062_500},
+			P25Phase2TrellisMode: "off",
 		},
 	})
 	if err != nil {

--- a/internal/scanner/ccdecoder/pipelines.go
+++ b/internal/scanner/ccdecoder/pipelines.go
@@ -195,17 +195,23 @@ func newP25Phase2Pipeline(opts PipelineOptions) (ProtocolPipeline, error) {
 			"system", opts.SystemName, "value", opts.System.P25Phase2TrellisMode)
 	}
 	cc.SetTrellisMode(trellisMode)
+	clockMode, clockOK := p25phase2rx.ParseClockMode(opts.System.P25Phase2ClockMode)
+	if !clockOK {
+		opts.Log.Warn("ccdecoder: unrecognised p25_phase2_clock_mode; falling back to gardner",
+			"system", opts.SystemName, "value", opts.System.P25Phase2ClockMode)
+	}
 	rx := p25phase2rx.New(p25phase2rx.Options{
 		SampleRateHz: opts.SampleRateHz,
 		DibitSink: func(dibits []uint8, baseIdx int) {
 			cc.Process(dibits, baseIdx)
 		},
-		ClockMode: p25phase2rx.ClockGardner,
+		ClockMode: clockMode,
 		// Tuned smaller than the 0.03 default — H-DQPSK at
 		// 6000 sym/s has the same slip behaviour as TETRA's
 		// π/4-DQPSK at the default gain (see PR #154). 0.005
 		// tracks both clean synthesized IQ and noisier on-air
 		// captures within the loop's lock-acquisition margin.
+		// Only applied when ClockMode == ClockGardner.
 		GardnerGain: 0.005,
 	})
 	return &p25Phase2Pipeline{rx: rx, cc: cc}, nil
@@ -267,18 +273,24 @@ func newTETRAPipeline(opts PipelineOptions) (ProtocolPipeline, error) {
 				"system", opts.SystemName, "channel", opts.System.TETRAChannel)
 		}
 	}
+	tetraClockMode, tetraClockOK := tetrarx.ParseClockMode(opts.System.TETRAClockMode)
+	if !tetraClockOK {
+		opts.Log.Warn("ccdecoder: unrecognised tetra_clock_mode; falling back to gardner",
+			"system", opts.SystemName, "value", opts.System.TETRAClockMode)
+	}
 	rx := tetrarx.New(tetrarx.Options{
 		SampleRateHz: opts.SampleRateHz,
 		DibitSink: func(dibits []uint8, baseIdx int) {
 			cc.Process(dibits, baseIdx)
 		},
-		ClockMode: tetrarx.ClockGardner,
+		ClockMode: tetraClockMode,
 		// Tuned smaller than the 0.03 default — at TETRA's 18000
 		// sym/s the standard gain over-corrects on clean signals
 		// and slips. 0.005 tracks both clean synthesized IQ (the
 		// integration-cc test) and noisier on-air captures within
 		// the loop's lock-acquisition margin. Same pattern as the
-		// DMR Tier III ClockGain tweak in PR #150.
+		// DMR Tier III ClockGain tweak in PR #150. Only applied
+		// when ClockMode == ClockGardner.
 		GardnerGain: 0.005,
 	})
 	return &tetraPipeline{rx: rx, cc: cc}, nil

--- a/internal/scanner/ccdecoder/pipelines.go
+++ b/internal/scanner/ccdecoder/pipelines.go
@@ -166,10 +166,15 @@ func (p *p25Phase1Pipeline) Close() error            { return nil }
 // newP25Phase2Pipeline wires internal/radio/p25/phase2/receiver into
 // p25phase2.ControlChannel.Process. The receiver's DibitSink forwards
 // H-DQPSK dibits into the state machine (20-dibit outbound sync
-// detect → 72-dibit MAC PDU slice → ParseMACPDU → Ingest), which
-// publishes cc.locked on the first non-idle MAC PDU and grants on
-// GroupVoiceChannelGrant variants. Trellis FEC + slot-type
-// extraction across the full 180-dibit subframe are follow-ups.
+// detect → 146-channel-dibit trellis decode → MAC PDU parse →
+// Ingest), which publishes cc.locked on the first non-idle MAC PDU
+// and grants on GroupVoiceChannelGrant variants.
+//
+// Trellis FEC is on by default: the factory always runs
+// p25phase2.ParseTrellisMode over the per-system config string,
+// which maps an empty string to TrellisOn. Operators feeding
+// pre-stripped MAC-PDU fixtures opt out per-system with
+// `p25_phase2_trellis_mode: off`.
 //
 // The connector wires the receiver with `ClockMode: ClockGardner`
 // — Gardner timing recovery on complex IQ replaces the receiver's
@@ -184,14 +189,12 @@ func newP25Phase2Pipeline(opts PipelineOptions) (ProtocolPipeline, error) {
 		SystemName:  opts.SystemName,
 		FrequencyHz: opts.FrequencyHz,
 	})
-	if v := opts.System.P25Phase2TrellisMode; v != "" {
-		mode, ok := p25phase2.ParseTrellisMode(v)
-		if !ok {
-			opts.Log.Warn("ccdecoder: unrecognised p25_phase2_trellis_mode; falling back to off",
-				"system", opts.SystemName, "value", v)
-		}
-		cc.SetTrellisMode(mode)
+	trellisMode, ok := p25phase2.ParseTrellisMode(opts.System.P25Phase2TrellisMode)
+	if !ok {
+		opts.Log.Warn("ccdecoder: unrecognised p25_phase2_trellis_mode; falling back to on",
+			"system", opts.SystemName, "value", opts.System.P25Phase2TrellisMode)
 	}
+	cc.SetTrellisMode(trellisMode)
 	rx := p25phase2rx.New(p25phase2rx.Options{
 		SampleRateHz: opts.SampleRateHz,
 		DibitSink: func(dibits []uint8, baseIdx int) {
@@ -221,16 +224,17 @@ func (p *p25Phase2Pipeline) Close() error            { return nil }
 // tetra.ControlChannel.Process. The receiver's DibitSink forwards
 // π/4-DQPSK dibits into the state machine.
 //
-// When the supplied trunking.System carries a non-zero TETRAColourCode,
-// the factory flips the CC into ChannelCodingOn — slicing per the
-// configured TETRAChannel (default ChannelSCHHD) and running the full
+// Channel coding is on by default: the factory always runs
+// tetra.ParseChannelCoding over the per-system config string, which
+// maps an empty string to ChannelCodingOn, then slices per the
+// configured TETRAChannel (default ChannelSCHHD) and runs the full
 // ETSI EN 300 392-2 §8.3.1 type-5 → type-1 decode chain (descramble +
 // deinterleave + depuncture + Viterbi + CRC-16 verify + tail strip)
-// per burst. Leaving TETRAColourCode at zero keeps the legacy
-// ChannelCodingOff raw-dibit path (38-dibit normal training-sequence
-// detect → 48-dibit PDU slice → ParsePDU → Ingest), which still
-// works on synthesized fixtures but won't lock on live FEC-encoded
-// captures.
+// per burst. The TETRAColourCode seeds the descrambler — zero is
+// only valid for BSCH; non-BSCH channels need the per-cell colour
+// code or descrambling produces garbage. Operators feeding pre-
+// stripped DSD-FME / OP25 fixtures opt out per-system with
+// `tetra_channel_coding: off`.
 //
 // The connector wires the receiver with `ClockMode: ClockGardner`
 // — Gardner timing recovery on complex IQ replaces the receiver's
@@ -244,15 +248,24 @@ func newTETRAPipeline(opts PipelineOptions) (ProtocolPipeline, error) {
 		SystemName:  opts.SystemName,
 		FrequencyHz: opts.FrequencyHz,
 	})
-	if opts.System.TETRAColourCode != 0 {
-		ch, ok := tetra.ParseChannelType(opts.System.TETRAChannel)
-		if !ok {
+	codingMode, ok := tetra.ParseChannelCoding(opts.System.TETRAChannelCoding)
+	if !ok {
+		opts.Log.Warn("ccdecoder: unrecognised tetra_channel_coding; falling back to on",
+			"system", opts.SystemName, "value", opts.System.TETRAChannelCoding)
+	}
+	cc.SetChannelCoding(codingMode)
+	if codingMode == tetra.ChannelCodingOn {
+		ch, chOK := tetra.ParseChannelType(opts.System.TETRAChannel)
+		if !chOK {
 			opts.Log.Warn("ccdecoder: unrecognised tetra_channel; falling back to SCH/HD",
 				"system", opts.SystemName, "value", opts.System.TETRAChannel)
 		}
-		cc.SetChannelCoding(tetra.ChannelCodingOn)
 		cc.SetExpectedChannel(ch)
 		cc.SetColourCode(opts.System.TETRAColourCode)
+		if opts.System.TETRAColourCode == 0 && ch != tetra.ChannelBSCH {
+			opts.Log.Warn("ccdecoder: tetra_channel_coding=on with zero tetra_colour_code on non-BSCH channel; descrambler will not lock",
+				"system", opts.SystemName, "channel", opts.System.TETRAChannel)
+		}
 	}
 	rx := tetrarx.New(tetrarx.Options{
 		SampleRateHz: opts.SampleRateHz,
@@ -408,14 +421,12 @@ func (p *dmrPipeline) Close() error            { return nil }
 // but typically fail the CAC CRC on real on-air signals.
 func newNXDNPipeline(opts PipelineOptions) (ProtocolPipeline, error) {
 	cc := nxdn.NewControlChannel(opts.Bus, opts.Log, opts.FrequencyHz, nxdn.Rate9600)
-	if v := opts.System.NXDNViterbiMode; v != "" {
-		mode, ok := nxdn.ParseViterbiMode(v)
-		if !ok {
-			opts.Log.Warn("ccdecoder: unrecognised nxdn_viterbi_mode; falling back to off",
-				"system", opts.SystemName, "value", v)
-		}
-		cc.SetViterbiMode(mode)
+	viterbiMode, ok := nxdn.ParseViterbiMode(opts.System.NXDNViterbiMode)
+	if !ok {
+		opts.Log.Warn("ccdecoder: unrecognised nxdn_viterbi_mode; falling back to spec",
+			"system", opts.SystemName, "value", opts.System.NXDNViterbiMode)
 	}
+	cc.SetViterbiMode(viterbiMode)
 	rx := nxdnrx.New(nxdnrx.Options{
 		SampleRateHz: opts.SampleRateHz,
 		// NXDN spec peak deviation per the Common Air Interface
@@ -453,14 +464,12 @@ func newEDACSPipeline(opts PipelineOptions) (ProtocolPipeline, error) {
 		SystemName:  opts.SystemName,
 		FrequencyHz: opts.FrequencyHz,
 	})
-	if v := opts.System.EDACSBCHMode; v != "" {
-		mode, ok := edacs.ParseBCHMode(v)
-		if !ok {
-			opts.Log.Warn("ccdecoder: unrecognised edacs_bch_mode; falling back to off",
-				"system", opts.SystemName, "value", v)
-		}
-		cc.SetBCHMode(mode)
+	bchMode, ok := edacs.ParseBCHMode(opts.System.EDACSBCHMode)
+	if !ok {
+		opts.Log.Warn("ccdecoder: unrecognised edacs_bch_mode; falling back to on",
+			"system", opts.SystemName, "value", opts.System.EDACSBCHMode)
 	}
+	cc.SetBCHMode(bchMode)
 	rx := edacsrx.New(edacsrx.Options{
 		SampleRateHz: opts.SampleRateHz,
 		BitSink: func(bits []byte, baseIdx int) {
@@ -499,14 +508,12 @@ func newMotorolaPipeline(opts PipelineOptions) (ProtocolPipeline, error) {
 		SystemName:  opts.SystemName,
 		FrequencyHz: opts.FrequencyHz,
 	})
-	if v := opts.System.MotorolaBCHMode; v != "" {
-		mode, ok := motorola.ParseBCHMode(v)
-		if !ok {
-			opts.Log.Warn("ccdecoder: unrecognised motorola_bch_mode; falling back to off",
-				"system", opts.SystemName, "value", v)
-		}
-		cc.SetBCHMode(mode)
+	bchMode, ok := motorola.ParseBCHMode(opts.System.MotorolaBCHMode)
+	if !ok {
+		opts.Log.Warn("ccdecoder: unrecognised motorola_bch_mode; falling back to on",
+			"system", opts.SystemName, "value", opts.System.MotorolaBCHMode)
 	}
+	cc.SetBCHMode(bchMode)
 	rx := motorolarx.New(motorolarx.Options{
 		SampleRateHz: opts.SampleRateHz,
 		BitSink: func(bits []byte, baseIdx int) {
@@ -549,22 +556,18 @@ func newLTRPipeline(opts PipelineOptions) (ProtocolPipeline, error) {
 		SystemName:  opts.SystemName,
 		FrequencyHz: opts.FrequencyHz,
 	})
-	if v := opts.System.LTRFCSMode; v != "" {
-		mode, ok := ltr.ParseFCSMode(v)
-		if !ok {
-			opts.Log.Warn("ccdecoder: unrecognised ltr_fcs_mode; falling back to off",
-				"system", opts.SystemName, "value", v)
-		}
-		cc.SetFCSMode(mode)
+	fcsMode, fcsOK := ltr.ParseFCSMode(opts.System.LTRFCSMode)
+	if !fcsOK {
+		opts.Log.Warn("ccdecoder: unrecognised ltr_fcs_mode; falling back to on",
+			"system", opts.SystemName, "value", opts.System.LTRFCSMode)
 	}
-	if v := opts.System.LTRManchesterMode; v != "" {
-		mode, ok := ltr.ParseManchesterMode(v)
-		if !ok {
-			opts.Log.Warn("ccdecoder: unrecognised ltr_manchester_mode; falling back to off",
-				"system", opts.SystemName, "value", v)
-		}
-		cc.SetManchesterMode(mode)
+	cc.SetFCSMode(fcsMode)
+	manchesterMode, manchesterOK := ltr.ParseManchesterMode(opts.System.LTRManchesterMode)
+	if !manchesterOK {
+		opts.Log.Warn("ccdecoder: unrecognised ltr_manchester_mode; falling back to soft",
+			"system", opts.SystemName, "value", opts.System.LTRManchesterMode)
 	}
+	cc.SetManchesterMode(manchesterMode)
 	rx := ltrrx.New(ltrrx.Options{
 		SampleRateHz: opts.SampleRateHz,
 		BitSink: func(bits []byte, baseIdx int) {
@@ -599,14 +602,12 @@ func newMPT1327Pipeline(opts PipelineOptions) (ProtocolPipeline, error) {
 		SystemName:  opts.SystemName,
 		FrequencyHz: opts.FrequencyHz,
 	})
-	if v := opts.System.MPT1327BCHMode; v != "" {
-		mode, ok := mpt1327.ParseBCHMode(v)
-		if !ok {
-			opts.Log.Warn("ccdecoder: unrecognised mpt1327_bch_mode; falling back to off",
-				"system", opts.SystemName, "value", v)
-		}
-		cc.SetBCHMode(mode)
+	bchMode, ok := mpt1327.ParseBCHMode(opts.System.MPT1327BCHMode)
+	if !ok {
+		opts.Log.Warn("ccdecoder: unrecognised mpt1327_bch_mode; falling back to on",
+			"system", opts.SystemName, "value", opts.System.MPT1327BCHMode)
 	}
+	cc.SetBCHMode(bchMode)
 	rx := mpt1327rx.New(mpt1327rx.Options{
 		SampleRateHz: opts.SampleRateHz,
 		BitSink: func(bits []byte, baseIdx int) {

--- a/internal/trunking/site.go
+++ b/internal/trunking/site.go
@@ -158,6 +158,20 @@ type System struct {
 	// into p25phase2.ControlChannel.SetTrellisMode by the ccdecoder
 	// connector after parsing via p25phase2.ParseTrellisMode.
 	P25Phase2TrellisMode string
+	// P25Phase2ClockMode selects the symbol-timing-recovery strategy
+	// for the P25 Phase 2 receiver. Recognised values (case-
+	// insensitive): "" / "gardner" / "on" → ClockGardner (the new
+	// default — non-data-aided Gardner loop; recommended for live
+	// SDR captures); "naive" / "off" → ClockNaive (decimate every
+	// sps-th sample; works on sample-aligned synthesized IQ).
+	// Forwarded into p25phase2rx.Options.ClockMode by the ccdecoder
+	// connector after parsing via p25phase2rx.ParseClockMode.
+	P25Phase2ClockMode string
+	// TETRAClockMode mirrors P25Phase2ClockMode for the TETRA
+	// receiver. Same recognised values + parser semantics; the
+	// underlying ClockMode enums in the two receivers share the
+	// same name + values but are independent types.
+	TETRAClockMode string
 	// NXDNViterbiMode enables the K=5 ½-rate Viterbi FEC decoder
 	// on the NXDN CAC region. Recognised values (case-insensitive):
 	// "" / "spec" → ViterbiSpec (the new default — full NXDN-TS-1-A

--- a/internal/trunking/site.go
+++ b/internal/trunking/site.go
@@ -102,10 +102,11 @@ type System struct {
 	// the TETRA scrambler uses to seed its LFSR per ETSI EN 300 392-2
 	// §8.2.5 ("ec" in the spec). The ccdecoder connector forwards this
 	// into tetra.ControlChannel.SetColourCode under ChannelCodingOn.
-	// Zero is valid (BSCH always uses 0 per §8.2.5.2) but disables
-	// channel coding because the colour code is the per-cell secret
-	// the descrambler needs to recover the type-3 stream. Bits 30..31
-	// are silently ignored downstream.
+	// Zero is valid only for BSCH (§8.2.5.2). For all other channel
+	// types the colour code is the per-cell secret the descrambler
+	// needs to recover the type-3 stream — leaving it at zero with
+	// channel coding on produces garbage. Bits 30..31 are silently
+	// ignored downstream.
 	TETRAColourCode uint32
 	// TETRAChannel selects which TETRA logical channel lives in each
 	// burst window under ChannelCodingOn. Recognised values:
@@ -115,63 +116,84 @@ type System struct {
 	// tetra.ControlChannel.SetExpectedChannel by the ccdecoder
 	// connector after parsing via tetra.ParseChannelType.
 	TETRAChannel string
+	// TETRAChannelCoding gates the full ETSI EN 300 392-2 §8.3.1
+	// channel-coding chain (descramble + deinterleave + depuncture +
+	// Viterbi + CRC-16 verify + tail strip). Recognised values
+	// (case-insensitive): "" / "on" / "true" / "1" → ChannelCodingOn
+	// (the new default; required for live on-air captures); "off" /
+	// "false" / "0" → ChannelCodingOff (legacy raw-dibit path, opt-out
+	// for operators feeding pre-stripped DSD-FME / OP25 fixtures).
+	// Forwarded into tetra.ControlChannel.SetChannelCoding by the
+	// ccdecoder connector after parsing via tetra.ParseChannelCoding.
+	TETRAChannelCoding string
 
 	// LTRFCSMode enables CRC-7 FCS verification on the LTR Status
 	// Ingest path (per DSheirer/sdrtrunk's CRCLTR.java layout).
-	// Recognised values (case-insensitive): "" / "off" — no
-	// verification (default, pre-PR #40 behaviour); "on" / "true" —
-	// drop Status words whose 7-bit FCS trailer doesn't match the
-	// CRC over the 24-bit message vector. Forwarded into
-	// ltr.ControlChannel.SetFCSMode by the ccdecoder connector
-	// after parsing via ltr.ParseFCSMode.
+	// Recognised values (case-insensitive): "" / "on" / "true" / "1" →
+	// FCSOn (the new default; drop Status words whose 7-bit FCS
+	// trailer doesn't match the CRC over the 24-bit message vector);
+	// "off" / "false" / "0" → FCSOff (no verification — opt-out for
+	// pre-stripped fixtures). Forwarded into
+	// ltr.ControlChannel.SetFCSMode by the ccdecoder connector after
+	// parsing via ltr.ParseFCSMode.
 	LTRFCSMode string
 	// LTRManchesterMode controls Manchester decoding of the LTR
 	// sub-audible bit stream. Recognised values (case-insensitive):
-	// "" / "off" / "nrz" — raw NRZ (default, in-package tests);
-	// "strict" — require a mid-bit transition per pair, drop
-	// transition-less pairs; "soft" / "on" — majority-decode each
-	// pair and tolerate noise bursts. Live captures of sub-audible
-	// LTR signaling should use "soft" (the dominant on-air encoding).
-	// Forwarded into ltr.ControlChannel.SetManchesterMode by the
-	// ccdecoder connector after parsing via ltr.ParseManchesterMode.
+	// "" / "on" / "soft" → ManchesterSoft (the new default —
+	// majority-decode each pair; matches the dominant on-air
+	// encoding for sub-audible LTR signaling); "strict" —
+	// require a mid-bit transition per pair, drop transition-less
+	// pairs; "off" / "nrz" → ManchesterOff (raw NRZ — opt-out for
+	// synthesized NRZ fixtures). Forwarded into
+	// ltr.ControlChannel.SetManchesterMode by the ccdecoder
+	// connector after parsing via ltr.ParseManchesterMode.
 	LTRManchesterMode string
 
 	// P25Phase2TrellisMode enables the 4-state ½-rate trellis FEC
 	// decoder on the P25 Phase 2 MAC PDU window. Recognised values
-	// (case-insensitive): "" / "off" → TrellisOff (legacy 72-dibit
-	// raw-MAC-PDU path); "on" → TrellisOn (146 channel dibits via
-	// the TIA-102.AABF trellis decoder). Forwarded into
-	// p25phase2.ControlChannel.SetTrellisMode by the ccdecoder
+	// (case-insensitive): "" / "on" / "true" / "1" → TrellisOn (the
+	// new default — 146 channel dibits via the TIA-102.AABF trellis
+	// decoder); "off" / "false" / "0" → TrellisOff (legacy 72-dibit
+	// raw-MAC-PDU path, opt-out for pre-stripped fixtures). Forwarded
+	// into p25phase2.ControlChannel.SetTrellisMode by the ccdecoder
 	// connector after parsing via p25phase2.ParseTrellisMode.
 	P25Phase2TrellisMode string
 	// NXDNViterbiMode enables the K=5 ½-rate Viterbi FEC decoder
 	// on the NXDN CAC region. Recognised values (case-insensitive):
-	// "" / "off" → ViterbiOff (legacy 44-dibit raw-CAC path);
-	// "on" → ViterbiOn (92 dibits via the K=5 Viterbi decoder).
-	// Forwarded into nxdn.ControlChannel.SetViterbiMode by the
-	// ccdecoder connector after parsing via nxdn.ParseViterbiMode.
+	// "" / "spec" → ViterbiSpec (the new default — full NXDN-TS-1-A
+	// §4.5.1.1 outbound CAC chain); "on" / "true" / "1" → ViterbiOn
+	// (intermediate 92-dibit K=5 Viterbi path for older
+	// MMDVMHost / DSDcc fixtures); "off" / "false" / "0" → ViterbiOff
+	// (legacy 44-dibit raw-CAC path, opt-out for pre-stripped
+	// fixtures). Forwarded into nxdn.ControlChannel.SetViterbiMode
+	// by the ccdecoder connector after parsing via
+	// nxdn.ParseViterbiMode.
 	NXDNViterbiMode string
 	// EDACSBCHMode enables the BCH(40, 28, 2) FEC layer on the
-	// EDACS CCW. Recognised values (case-insensitive): "" / "off"
-	// → BCHOff (legacy pre-stripped 40-bit CCW path); "on" → BCHOn
-	// (40-bit on-wire BCH(40, 28, 2) decode + single/double-bit
-	// correction). Forwarded into edacs.ControlChannel.SetBCHMode
-	// by the ccdecoder connector after parsing via
-	// edacs.ParseBCHMode.
+	// EDACS CCW. Recognised values (case-insensitive): "" / "on" /
+	// "true" / "1" → BCHOn (the new default — 40-bit on-wire
+	// BCH(40, 28, 2) decode + single/double-bit correction); "off" /
+	// "false" / "0" → BCHOff (legacy pre-stripped 40-bit CCW path,
+	// opt-out for pre-stripped fixtures). Forwarded into
+	// edacs.ControlChannel.SetBCHMode by the ccdecoder connector
+	// after parsing via edacs.ParseBCHMode.
 	EDACSBCHMode string
 	// MPT1327BCHMode enables the BCH(63, 38) FEC layer on the MPT
 	// 1327 codeword. Recognised values (case-insensitive): "" /
-	// "off" → BCHOff (legacy 38-bit pre-stripped codeword path);
-	// "on" → BCHOn (64-bit on-wire BCH(63, 38) decode). Forwarded
-	// into mpt1327.ControlChannel.SetBCHMode by the ccdecoder
-	// connector after parsing via mpt1327.ParseBCHMode.
+	// "on" / "true" / "1" → BCHOn (the new default — 64-bit on-wire
+	// BCH(63, 38) decode); "off" / "false" / "0" → BCHOff (legacy
+	// 38-bit pre-stripped codeword path, opt-out for pre-stripped
+	// fixtures). Forwarded into mpt1327.ControlChannel.SetBCHMode
+	// by the ccdecoder connector after parsing via
+	// mpt1327.ParseBCHMode.
 	MPT1327BCHMode string
 	// MotorolaBCHMode enables the BCH(64, 16, 11) FEC layer on the
 	// Motorola Type II OSW. Recognised values (case-insensitive):
-	// "" / "off" → BCHOff (legacy 32-bit raw-OSW path); "on" →
-	// BCHOn (two 64-bit BCH(64, 16, 11) codewords reassembled into
-	// the 32-bit OSW, with up to 11 bit errors corrected per
-	// codeword). Forwarded into
+	// "" / "on" / "true" / "1" → BCHOn (the new default — two
+	// 64-bit BCH(64, 16, 11) codewords reassembled into the 32-bit
+	// OSW, with up to 11 bit errors corrected per codeword); "off" /
+	// "false" / "0" → BCHOff (legacy 32-bit raw-OSW path, opt-out
+	// for pre-stripped fixtures). Forwarded into
 	// motorola.ControlChannel.SetBCHMode by the ccdecoder
 	// connector after parsing via motorola.ParseBCHMode.
 	MotorolaBCHMode string

--- a/internal/tui/client/types.go
+++ b/internal/tui/client/types.go
@@ -34,10 +34,11 @@ type SystemDTO struct {
 	RFSS            uint8    `json:"rfss,omitempty"`
 	Site            uint8    `json:"site,omitempty"`
 
-	// Per-protocol FEC opt-in surface (mirrors api.SystemDTO).
+	// Per-protocol FEC opt-out surface (mirrors api.SystemDTO).
 	// The TUI Settings panel renders these.
 	TETRAColourCode      uint32 `json:"tetra_colour_code,omitempty"`
 	TETRAChannel         string `json:"tetra_channel,omitempty"`
+	TETRAChannelCoding   string `json:"tetra_channel_coding,omitempty"`
 	LTRFCSMode           string `json:"ltr_fcs_mode,omitempty"`
 	LTRManchesterMode    string `json:"ltr_manchester_mode,omitempty"`
 	P25Phase2TrellisMode string `json:"p25_phase2_trellis_mode,omitempty"`

--- a/internal/tui/panels/settings.go
+++ b/internal/tui/panels/settings.go
@@ -101,9 +101,10 @@ func (p *SettingsPanel) Update(msg tea.Msg, s *state.SharedState) (Panel, tea.Cm
 	// to) the FEC tab — the hash gate keeps the cost negligible.
 	if p.tab == tabFEC {
 		h := hashRows(s.Systems, func(sys client.SystemDTO) string {
-			return fmt.Sprintf("%s|%s|%d|%s|%s|%s|%s|%s|%s",
+			return fmt.Sprintf("%s|%s|%d|%s|%s|%s|%s|%s|%s|%s",
 				sys.Name, sys.Protocol,
 				sys.TETRAColourCode, sys.TETRAChannel,
+				sys.TETRAChannelCoding,
 				sys.LTRFCSMode, sys.LTRManchesterMode,
 				sys.P25Phase2TrellisMode, sys.NXDNViterbiMode,
 				sys.EDACSBCHMode)
@@ -320,45 +321,61 @@ func durText(d interface{ Nanoseconds() int64 }) string {
 }
 
 // fecSummary returns a one-line, protocol-scoped summary of the
-// system's FEC opt-in state. Only the keys relevant to the system's
+// system's FEC state. Only the keys relevant to the system's
 // protocol are emitted so the column doesn't drown in N/A noise.
+//
+// FEC is on by default for every protocol; the connector applies
+// the spec-correct chain unless the operator opts out per-protocol
+// via the `*_mode: off` keys. Empty config strings render as the
+// new on-defaults below; explicit "off" renders as "off".
 func fecSummary(s client.SystemDTO) string {
 	var parts []string
 	switch strings.ToLower(s.Protocol) {
 	case "tetra":
-		if s.TETRAColourCode != 0 {
+		coding := orDefault(s.TETRAChannelCoding, "on")
+		if isOff(coding) {
+			parts = append(parts, "channel coding: off (opt-out)")
+		} else {
 			ch := s.TETRAChannel
 			if ch == "" {
 				ch = "sch/hd"
 			}
 			parts = append(parts, fmt.Sprintf("channel coding: on (colour=%#x, %s)", s.TETRAColourCode, ch))
-		} else {
-			parts = append(parts, "channel coding: off (set tetra_colour_code to enable)")
 		}
 	case "ltr":
-		parts = append(parts, "fcs: "+orOff(s.LTRFCSMode))
-		parts = append(parts, "manchester: "+orOff(s.LTRManchesterMode))
+		parts = append(parts, "fcs: "+orDefault(s.LTRFCSMode, "on"))
+		parts = append(parts, "manchester: "+orDefault(s.LTRManchesterMode, "soft"))
 	case "p25-phase2":
-		parts = append(parts, "trellis: "+orOff(s.P25Phase2TrellisMode))
+		parts = append(parts, "trellis: "+orDefault(s.P25Phase2TrellisMode, "on"))
 	case "nxdn":
-		parts = append(parts, "viterbi: "+orOff(s.NXDNViterbiMode))
+		parts = append(parts, "viterbi: "+orDefault(s.NXDNViterbiMode, "spec"))
 	case "edacs":
-		parts = append(parts, "bch: "+orOff(s.EDACSBCHMode))
+		parts = append(parts, "bch: "+orDefault(s.EDACSBCHMode, "on"))
 	case "mpt1327":
-		parts = append(parts, "bch: "+orOff(s.MPT1327BCHMode))
+		parts = append(parts, "bch: "+orDefault(s.MPT1327BCHMode, "on"))
 	case "motorola":
-		parts = append(parts, "bch: "+orOff(s.MotorolaBCHMode))
+		parts = append(parts, "bch: "+orDefault(s.MotorolaBCHMode, "on"))
 	default:
 		parts = append(parts, "—")
 	}
 	return strings.Join(parts, "  ·  ")
 }
 
-// orOff returns the supplied mode string, or "off" when empty —
-// the canonical legacy / not-configured rendering across protocols.
-func orOff(s string) string {
+// orDefault returns s when non-empty, otherwise the connector-level
+// default for that key.
+func orDefault(s, dflt string) string {
 	if s == "" {
-		return "off"
+		return dflt
 	}
 	return s
+}
+
+// isOff reports whether the supplied mode string parses to an
+// explicit opt-out across the per-protocol Parse* functions.
+func isOff(s string) bool {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "off", "false", "0":
+		return true
+	}
+	return false
 }

--- a/internal/tui/panels/settings_test.go
+++ b/internal/tui/panels/settings_test.go
@@ -15,7 +15,7 @@ func TestSettingsPanel_RendersFECSummaryPerProtocol(t *testing.T) {
 	s := &state.SharedState{
 		Systems: []client.SystemDTO{
 			{Name: "Metro", Protocol: "tetra", TETRAColourCode: 0x12345, TETRAChannel: "sch/f"},
-			{Name: "Suburb", Protocol: "tetra"},
+			{Name: "Suburb", Protocol: "tetra", TETRAChannelCoding: "off"},
 			{Name: "Country", Protocol: "ltr", LTRFCSMode: "on", LTRManchesterMode: "soft"},
 			{Name: "P2Sys", Protocol: "p25-phase2", P25Phase2TrellisMode: "on"},
 			{Name: "Mining", Protocol: "edacs", EDACSBCHMode: "on"},
@@ -67,17 +67,19 @@ func TestSettingsPanel_UnknownProtocolFallsBackToDash(t *testing.T) {
 	}
 }
 
-func TestSettingsPanel_EmptyModeRendersOff(t *testing.T) {
+func TestSettingsPanel_EmptyModeRendersConnectorDefault(t *testing.T) {
 	cases := []struct {
-		in, want string
+		in, dflt, want string
 	}{
-		{"", "off"},
-		{"on", "on"},
-		{"soft", "soft"},
+		{"", "on", "on"},
+		{"on", "on", "on"},
+		{"soft", "soft", "soft"},
+		{"", "spec", "spec"},
+		{"off", "on", "off"},
 	}
 	for _, c := range cases {
-		if got := orOff(c.in); got != c.want {
-			t.Errorf("orOff(%q) = %q, want %q", c.in, got, c.want)
+		if got := orDefault(c.in, c.dflt); got != c.want {
+			t.Errorf("orDefault(%q, %q) = %q, want %q", c.in, c.dflt, got, c.want)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Three commits that move every operator-facing opt-in toward sensible
defaults and document the rest:

1. **`c9322d5` — docs:** new `docs/opt-in-features.md` enumerates
   every disabled-by-default feature (protocol FEC, receiver clock,
   daemon-level, build tags), why each is opt-in, and remediation
   sketches.

2. **`f293611` — FEC defaults flipped on across all 7 trunked
   protocols.** The ccdecoder connector now always runs the
   per-protocol `Parse*Mode` over the YAML value and constructs
   each `ControlChannel` with the spec-correct chain by default.
   Operators feeding pre-stripped capture files (DSD-FME `-r`,
   OP25, MMDVMHost / DSDcc) opt out per-system with `<key>: off`.
   - TETRA channel coding → `ChannelCodingOn` (new
     `tetra_channel_coding` YAML key so BSCH's spec-defined zero
     colour code stays valid)
   - LTR FCS → `FCSOn`; LTR Manchester → `ManchesterSoft`
   - P25 Phase 2 trellis → `TrellisOn`
   - NXDN → `ViterbiSpec` (full §4.5.1.1 outbound chain)
   - EDACS / MPT 1327 / Motorola Type II → `BCHOn`
   - In-package `ControlChannel` constructors keep their Off
     zero values so existing direct-construction unit tests are
     undisturbed; the flip lives at the connector.

3. **`b314cf8` — Gardner clock YAML wiring + manual_tune
   auto-detect.**
   - New `p25_phase2_clock_mode` and `tetra_clock_mode` per-system
     keys with `ParseClockMode` (empty → `ClockGardner`). Replaces
     the hardcoded `ClockGardner` in pipelines.go.
   - `scanner.manual_tune_enabled` now auto-enables when ≥ 2 Voice
     SDRs are present; new `manual_tune_disabled` veto for operators
     who want every Voice SDR reserved for trunking even with a
     spare.

Surfaces updated alongside the code: README's FEC section (now
"opt-outs"), Gardner follow-up note retired, `config.example.yaml`
comments, `docs/opt-in-features.md` §1 + §2, TUI Settings panel
rendering, `/api/v1/systems` JSON DTO.

Out of scope (deferred to follow-up PRs per discussion):
comprehensive API auth layer (replacing `allow_mutations`), and
example tone-out profiles + final opt-in-features.md sync. Loopback-
no-auth policy is agreed for when auth lands.

## Test plan

- [x] `go test ./...` clean (default build tags)
- [x] `go test -tags integration ./cmd/gophertrunk/...` clean
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [ ] Smoke: start daemon with default config + 2 Voice SDRs → TUI
      Settings shows the new on-defaults; scanner constructs from
      the spare SDR without explicit `manual_tune_enabled: true`.
- [ ] Smoke: start daemon with `manual_tune_disabled: true` + 2
      Voice SDRs → scanner is not constructed.
- [ ] Smoke: feed a pre-stripped DSD-FME `-r` Motorola fixture with
      `motorola_bch_mode: off` → legacy 32-bit raw-OSW path still
      decodes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Q3vP5jeF8GbKzr4G5nxFwD)_