### PR TITLE
docs: opt-in-features sync + ship example tone-out profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -2105,14 +2105,16 @@ opt-in field as a `omitempty` JSON value.
   IQ capture for replay
 - [`docs/vocoders.md`](docs/vocoders.md) — IMBE / AMBE+2 licensing
   realities and the plugin model
-- [`docs/hardening.md`](docs/hardening.md) — Prometheus catalogue,
-  Docker / compose USB pass-through, smoke-test checklist
-- [`docs/opt-in-features.md`](docs/opt-in-features.md) — every
-  disabled-by-default feature (receiver clock, daemon-level audio /
-  equalizer / mutations / tone-out, build tags), why it's opt-in,
-  and the work to flip the default. Protocol FEC chains are now
-  on-by-default; see the FEC opt-outs section above for the
-  per-protocol opt-out keys.
+- [`docs/hardening.md`](docs/hardening.md) — API authentication,
+  Prometheus catalogue, Docker / compose USB pass-through,
+  smoke-test checklist
+- [`docs/opt-in-features.md`](docs/opt-in-features.md) — operator
+  reference for every default the daemon carries: protocol FEC
+  defaults (on, opt-out per protocol), receiver clock recovery (on,
+  opt-out per protocol), daemon-level features (mix of on / off /
+  auto-detect), and the permanent build-time gates (DVSI patent
+  tag, integration tests). Cross-references the README's relevant
+  sections.
 - [`docs/specs/`](docs/specs/) — reference air-interface PDFs the
   on-air FEC implementations derive from (NXDN-TS-1-A,
   ETSI EN 300 392-2 TETRA, plus a negative-reference M/A-COM LBI

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -177,11 +177,34 @@ audio:
   muted: false
 
 # tone_out fires events.KindToneAlert when the configured paging tones
-# are detected on a Voice device's PCM stream. Empty profiles disable
-# the detector. Two-tone sequential (Quick Call II) is the most common
-# US fire/EMS pattern; supply the A-tone and B-tone in order.
+# are detected on a Voice device's PCM stream. An empty `profiles`
+# list disables the detector (the daemon default).
+#
+# Two-tone sequential (Motorola Quick Call II) is the most common US
+# fire/EMS pattern: an A-tone followed by a B-tone, each with a
+# typical Quick Call II frequency from the Motorola 1000-1400 Hz
+# group. Operators verify tone pairs against their agency's
+# dispatch console — the example below is illustrative only.
+#
+# Per-profile schema (see internal/voice/toneout/profile.go for the
+# Validate() rules):
+#   name                 — required, unique within profiles list
+#   alpha_tag            — human-readable label (UI / webhook / log)
+#   tones                — ordered tone list, ≥ 1 entry
+#     frequency_hz       — target tone (Hz)
+#     min_duration       — required dwell before counting
+#     max_duration       — caps the on-time; 0 = no upper bound
+#   tolerance_hz         — frequency drift tolerance (default 15 Hz)
+#   magnitude_threshold  — Goertzel-magnitude floor (default 0.05)
+#   max_gap              — silence allowed between tones (default 200ms)
+#   cooldown             — re-fire suppression window (default 30s)
+#   system               — restrict to one trunked system (empty = all)
+#   group_id             — restrict to one talkgroup (0 = all)
 tone_out:
   profiles:
+    # Quick Call II two-tone sequential — the canonical US fire/EMS
+    # paging pattern. Replace the frequencies with your agency's
+    # actual A/B tones.
     - name: "station-1-engine"
       alpha_tag: "Station 1 Engine"
       cooldown: "30s"
@@ -192,3 +215,54 @@ tone_out:
         - frequency_hz: 1297.4
           min_duration: "2.5s"
           max_duration: "5s"
+
+    # ---------------------------------------------------------------
+    # Additional example profiles (commented out — uncomment and
+    # adjust per your agency). Multiple profiles can coexist; the
+    # detector fires the first one whose tone sequence matches.
+    # ---------------------------------------------------------------
+    #
+    # # Single-tone supervisory page (older simplex pattern). Useful
+    # # when an agency still uses a one-shot dispatcher tone instead
+    # # of a sequential A/B pair.
+    # - name: "supervisor-recall"
+    #   alpha_tag: "Supervisor Recall"
+    #   cooldown: "60s"
+    #   tones:
+    #     - frequency_hz: 1500.0
+    #       min_duration: "500ms"
+    #       max_duration: "3s"
+    #
+    # # Two-tone with system + talkgroup scoping. Use when the same
+    # # tone pair appears on multiple systems and you only want the
+    # # alert to fire for one talkgroup on one named system.
+    # - name: "metro-fire-dispatch"
+    #   alpha_tag: "Metro Fire Dispatch"
+    #   system: "Example-P25"     # matches trunking.systems[].name
+    #   group_id: 42              # talkgroup ID
+    #   cooldown: "45s"
+    #   tones:
+    #     - frequency_hz: 853.8
+    #       min_duration: "250ms"
+    #       max_duration: "1500ms"
+    #     - frequency_hz: 960.9
+    #       min_duration: "2.5s"
+    #       max_duration: "5s"
+    #
+    # # Tightened tolerances for an agency with very stable
+    # # frequency reference. Drops the default 15 Hz tolerance to
+    # # 5 Hz and raises the magnitude floor to filter weak co-channel
+    # # bleed-over.
+    # - name: "county-ems-tac"
+    #   alpha_tag: "County EMS Tac"
+    #   tolerance_hz: 5.0
+    #   magnitude_threshold: 0.10
+    #   max_gap: "100ms"
+    #   cooldown: "30s"
+    #   tones:
+    #     - frequency_hz: 1122.5
+    #       min_duration: "300ms"
+    #       max_duration: "1500ms"
+    #     - frequency_hz: 1465.3
+    #       min_duration: "2.5s"
+    #       max_duration: "5s"

--- a/docs/opt-in-features.md
+++ b/docs/opt-in-features.md
@@ -1,66 +1,64 @@
-# Opt-in features and protocols
+# Opt-in / opt-out features
 
-GopherTrunk ships many protocol-level and daemon-level capabilities as
-**opt-in**: the daemon constructs the relevant component in its
-legacy / safe-default mode, and only flips the new behaviour on when
-the operator sets a key in `config.yaml`, passes a receiver option, or
-builds with a tag. This is deliberate — every gate either preserves
-backwards compatibility with existing fixtures, avoids a security
-regression, or trades a resource that operators may not be willing to
-spend.
+GopherTrunk's protocol decoders and daemon-level surfaces have a
+mix of:
 
-This document enumerates every opt-in in the tree, the reason it
-ships off, and the concrete work that would let the project either
-flip the default to enabled or remove the gate entirely.
+- features that **were** opt-in and have since been **flipped on
+  by default** (operators can still opt out per-protocol);
+- features that **are still opt-in** because the default is
+  correct for headless / server deployments;
+- features that **stay opt-in by their nature** (per-site
+  signaling, patent-encumbered backends, CI-only tests).
+
+This document is the operator's reference for that landscape: what
+default applies, why, and (where relevant) how to opt out.
 
 ## Contents
 
-1. [Protocol-layer FEC opt-ins](#1-protocol-layer-fec-opt-ins)
-2. [Receiver clock-recovery opt-ins](#2-receiver-clock-recovery-opt-ins)
-3. [Daemon-level opt-ins](#3-daemon-level-opt-ins)
-4. [Build-time opt-ins](#4-build-time-opt-ins)
-5. [Cross-cutting remediation strategies](#5-cross-cutting-remediation-strategies)
-6. [How to verify what's currently enabled](#6-how-to-verify-whats-currently-enabled)
+1. [Protocol-layer FEC defaults](#1-protocol-layer-fec-defaults) — on by default, opt-out per protocol
+2. [Receiver clock recovery](#2-receiver-clock-recovery) — on by default, opt-out per protocol
+3. [Daemon-level features](#3-daemon-level-features) — mix of on / off / auto-detect
+4. [Build-time options](#4-build-time-options) — patent / CI gates that stay opt-in permanently
+5. [How to verify what's currently enabled](#5-how-to-verify-whats-currently-enabled)
 
 ---
 
-## 1. Protocol-layer FEC opt-outs (formerly opt-ins)
+## 1. Protocol-layer FEC defaults
 
-**Status: flipped.** Every protocol that has a public-spec
-forward-error-correction chain now ships on by default. The
-ccdecoder connector at
+**On by default for every protocol.** The ccdecoder connector at
 [`internal/scanner/ccdecoder/pipelines.go`](../internal/scanner/ccdecoder/pipelines.go)
 always runs the per-protocol `Parse*Mode` function over the
-configured YAML value — empty strings map to the new on-defaults.
-Operators with pre-stripped capture files (DSD-FME `-r` dumps,
-OP25 fixtures, MMDVMHost / DSDcc test data) opt out per-system
-with `<key>: off`.
+configured YAML value — empty strings map to the spec-correct
+on-default. Operators with pre-stripped capture files (DSD-FME
+`-r` dumps, OP25 fixtures, MMDVMHost / DSDcc test data) opt out
+per-system with `<key>: off`.
 
-The current per-protocol state is documented in the README's
-["FEC opt-outs" section](../README.md#fec-opt-outs); summary:
-
-| Protocol | YAML key | New default | Opt-out string |
+| Protocol | YAML key | Default | Opt-out string |
 | --- | --- | --- | --- |
-| TETRA | `tetra_channel_coding` | ChannelCodingOn (full §8.3.1 chain) | `off` |
-| LTR FCS | `ltr_fcs_mode` | FCSOn | `off` |
-| LTR Manchester | `ltr_manchester_mode` | ManchesterSoft | `off` / `nrz` |
-| P25 Phase 2 | `p25_phase2_trellis_mode` | TrellisOn | `off` |
-| NXDN | `nxdn_viterbi_mode` | ViterbiSpec | `off` |
-| EDACS | `edacs_bch_mode` | BCHOn | `off` |
-| MPT 1327 | `mpt1327_bch_mode` | BCHOn | `off` |
-| Motorola Type II | `motorola_bch_mode` | BCHOn | `off` |
+| TETRA | `tetra_channel_coding` | `ChannelCodingOn` (full §8.3.1 chain) | `off` |
+| LTR FCS | `ltr_fcs_mode` | `FCSOn` | `off` |
+| LTR Manchester | `ltr_manchester_mode` | `ManchesterSoft` | `off` / `nrz` |
+| P25 Phase 2 | `p25_phase2_trellis_mode` | `TrellisOn` | `off` |
+| NXDN | `nxdn_viterbi_mode` | `ViterbiSpec` | `off` |
+| EDACS | `edacs_bch_mode` | `BCHOn` | `off` |
+| MPT 1327 | `mpt1327_bch_mode` | `BCHOn` | `off` |
+| Motorola Type II | `motorola_bch_mode` | `BCHOn` | `off` |
 
-### How it works
+The README's [FEC opt-outs section](../README.md#fec-opt-outs)
+documents the full reference table with on-default behaviour
+descriptions.
+
+### Implementation note
 
 The in-package `ControlChannel` constructors still zero-value to
-Off mode (so direct callers — primarily unit tests — see the legacy
-behaviour without explicit setup). The connector goes through
+`Off` mode so direct callers (primarily unit tests) see the legacy
+behaviour without explicit setup. The connector goes through
 `Parse*Mode(opts.System.X)` which maps empty strings to the new
 on-defaults, then calls `SetXMode(parsed)` on the ControlChannel.
-This keeps the operator-facing default On while preserving the
-in-package fixtures' expectations of an Off zero value.
+This keeps the operator-facing default `On` while preserving the
+in-package fixtures' expectations of an `Off` zero value.
 
-For TETRA specifically: a new `TETRAChannelCoding` field was added
+For TETRA specifically: the `TETRAChannelCoding` field was added
 to the System struct (yaml: `tetra_channel_coding`) because the
 old "zero colour code = off" rule conflicted with BSCH's
 spec-defined zero colour code. Non-BSCH systems with channel
@@ -68,91 +66,71 @@ coding on need a non-zero `tetra_colour_code`; the connector
 warn-logs the misconfiguration instead of silently dropping
 frames.
 
-### Remediation status
+---
 
-Done in PR 1 on branch `claude/document-opt-in-features-gP90L`
-(this branch). No further remediation needed for FEC opt-ins.
+## 2. Receiver clock recovery
+
+**Gardner timing recovery on by default.** Both the P25 Phase 2
+and TETRA receivers route the matched-filter output through the
+Gardner symbol-timing-recovery loop in
+[`internal/dsp/sync/gardner.go`](../internal/dsp/sync/gardner.go).
+Operators with sample-aligned synthesized IQ fixtures (some tests,
+some replay tools) can opt back to the naive sps-th-sample
+decimator per system.
+
+| Receiver | YAML key | Default | Opt-out string |
+| --- | --- | --- | --- |
+| P25 Phase 2 | `p25_phase2_clock_mode` | `ClockGardner` | `naive` / `off` |
+| TETRA | `tetra_clock_mode` | `ClockGardner` | `naive` / `off` |
+
+Other receivers (DMR, dPMR, NXDN, EDACS, LTR, MPT 1327, Motorola
+Type II, YSF) either don't need timing recovery or use protocol-
+specific clock-tracking primitives. The Gardner loop is wired
+where it had the largest measurable effect on noisier on-air
+captures.
 
 ---
 
-## 2. Receiver clock-recovery opt-ins
+## 3. Daemon-level features
 
-These live at the receiver-option level and are **not yet exposed
-via YAML**. Currently only reachable programmatically (tests + any
-embedder constructing the receiver directly).
+Sources are [`config.example.yaml`](../config.example.yaml) plus
+the config struct in [`internal/config/config.go`](../internal/config/config.go).
 
-| Feature | Source | Default | Opt-in | Why opt-in | Remediation |
-| --- | --- | --- | --- | --- | --- |
-| P25 Phase 2 Gardner clock | [`internal/radio/p25/phase2/receiver/receiver.go:67-70`](../internal/radio/p25/phase2/receiver/receiver.go) | `ClockNaive` (every sps-th sample after the matched filter) | `Options.ClockMode: ClockGardner` | The Gardner timing-recovery loop in `internal/dsp/sync/gardner.go` is new; existing receiver tests use naive timing and would need regeneration. No YAML connector exists yet. | Wire `clock_mode` into [`internal/config/config.go`](../internal/config/config.go) and `internal/trunking/site.go` so the ccdecoder connector can forward it. Regenerate Gardner-friendly fixtures, then flip the receiver default to `ClockGardner`. This is the "follow-up" called out in [`README.md:125-135`](../README.md). |
-| TETRA Gardner clock | [`internal/radio/tetra/receiver/receiver.go:62-68`](../internal/radio/tetra/receiver/receiver.go) | `ClockNaive` | `Options.ClockMode: ClockGardner` | Same as P25 Phase 2: Gardner loop is new, fixtures predate it, no config connector. | Same remediation: add a config field, regenerate fixtures, flip default. The two receivers share the same `ClockMode` enum and Gardner primitive so they can be converted in one PR. |
-
----
-
-## 3. Daemon-level opt-ins
-
-Sources are [`config.example.yaml`](../config.example.yaml) plus the
-config struct in [`internal/config/config.go`](../internal/config/config.go).
-
-| Feature | YAML key | Default | Why opt-in | Remediation |
-| --- | --- | --- | --- | --- |
-| **Live audio playback to speakers** | `audio.enabled` | `false` ([`internal/config/config.go:35-54`](../internal/config/config.go), [`config.example.yaml:108-118`](../config.example.yaml)) | Headless and container deployments stay silent by design. WAV recording is unaffected — recordings land on disk whether playback is on or off. | Keep opt-in. This is the correct posture for a server daemon: the alternative (audio on by default) would crash or warn loudly in distroless / container deployments. If a future TUI-bundled distribution wants live audio out of the box, ship the TUI with a different default config, leaving the daemon's `false` default intact. |
-| **API mutation endpoints** | `api.auth.mode` | `auto` ([`internal/config/config.go`](../internal/config/config.go) APIConfig + APIAuthConfig) | **Resolved.** Bearer-token auth landed with loopback bypass under the `auto` policy. Public-bind listeners now require a token. See [`docs/hardening.md` §"API authentication"](hardening.md). Legacy `allow_mutations: true` maps to `auth.mode: disabled` with a deprecation warning. | Done. |
-| **Manual VFO tune** | `scanner.manual_tune_enabled` | `false` ([`internal/config/config.go:70-77`](../internal/config/config.go), [`config.example.yaml:77-84`](../config.example.yaml)) | The conventional scanner steals a Voice SDR from the trunking pool. Auto-enabling would silently downgrade trunked grant-following for operators with only one Voice SDR. | At startup, count Voice SDRs declared in `sdr.devices` and compare against the maximum simultaneous voice-grants the configured trunking systems can drive. If a spare Voice SDR is present, auto-enable manual tune; otherwise stay opt-in. Document the dedicated-SDR requirement in either case. |
-| **CMA blind equalizer** | `recordings.equalizer.enabled` | `false` ([`config.example.yaml:29-32`](../config.example.yaml)) | Simulcast mitigation costs CPU and may slightly distort clean-RF capture. Benefit is site-specific — operators not on a simulcast site pay the CPU without payoff. | Add an auto-tune heuristic that measures multipath / ISI on the first N seconds of audio per call and toggles the equalizer for that call only. Keep the global `enabled: true` knob for operators who want the equalizer always on. |
-| **Tone-out paging-tone detection** | `tone_out.profiles` | empty list ([`config.example.yaml:120-135`](../config.example.yaml)) | Two-tone sequential (Quick Call II) profiles are per-site / per-agency. No useful zero-config default exists. | Cannot flip the default reasonably. Improve discoverability instead: ship a small set of well-known regional profiles in a commented-out block in `config.example.yaml`, and link this doc from the tone-out section of the README so new operators see the path. |
-| **Scan mode = list** | `scanner.scan_mode` | `"all"` ([`internal/config/config.go:60-65`](../internal/config/config.go)) | `"all"` is the legacy / backwards-compatible behaviour. Tag-based talkgroup curation must be done by the operator before `list` is useful. | Not a default-flip target. Per-deployment configuration choice; the doc should call out that `list` exists and how Emergency grants bypass the gate. |
-| **CTCSS / DCS squelch** | per-channel `tone:` block in `scanner.conventional[]` ([`config.example.yaml:94-102`](../config.example.yaml)) | omitted (no gating) | Sub-audible CTCSS tone or DCS code is per-channel signalling that varies by site, repeater, and agency. No useful zero-config default. | Cannot flip — site-specific. Doc-only: link the README's CTCSS / DCS section (lines 163-197) and call out that omitting the block reverts to carrier-only squelch. |
-| **Raw frame sidecar** | `recordings.write_raw` | `true` in the example ([`config.example.yaml:28`](../config.example.yaml)) | Listed here for completeness — it is **not** off by default in the shipped example. Operators who don't want the `.raw` sidecar can set `false`. | None required; the disable case is documented for symmetry. |
-| **Prometheus metrics** | `metrics.enabled` | `true` ([`config.example.yaml:19`](../config.example.yaml)) | Already on by default; listed for completeness. | None required. |
-| **Call-log retention sweep** | `retention.call_log_days` | `30` (`0` disables, [`config.example.yaml:35`](../config.example.yaml)) | Sensible default already on. | None required; documented for the disable-via-`0` case. |
-| **File retention sweep** | `retention.files_days` | `14` (`0` disables, [`config.example.yaml:36`](../config.example.yaml)) | Sensible default already on. | None required. |
+| Feature | YAML key | Default | Why |
+| --- | --- | --- | --- |
+| **Live audio playback to speakers** | `audio.enabled` | `false` | Headless and container deployments stay silent by design. WAV recording is unaffected — recordings land on disk whether playback is on or off. Stays opt-in: audio-on-by-default would crash or warn loudly in distroless / container deployments. |
+| **API mutation endpoints** | `api.auth.mode` | `auto` | Bearer-token auth with loopback bypass under the `auto` policy. Public-bind listeners require a token. See [`docs/hardening.md` §"API authentication"](hardening.md). Legacy `allow_mutations: true` maps to `auth.mode: disabled` with a deprecation warning. |
+| **Manual VFO tune** | `scanner.manual_tune_enabled` / `scanner.manual_tune_disabled` | auto-detect | Auto-enables when ≥ 2 Voice SDRs are present (the daemon constructs the scanner off the spare). `manual_tune_enabled: true` forces the scanner even with only one Voice SDR; `manual_tune_disabled: true` vetoes the auto-detect for operators who want every Voice SDR reserved for trunking. |
+| **CMA blind equalizer** | `recordings.equalizer.enabled` | `false` | Simulcast mitigation costs CPU and may distort clean-RF capture. Benefit is site-specific — operators not on a simulcast site pay the CPU without payoff. Stays a global opt-in until a per-call auto-tune heuristic ships. |
+| **Tone-out paging-tone detection** | `tone_out.profiles` | empty list | Two-tone sequential (Quick Call II) profiles are per-site / per-agency. No useful zero-config default exists. [`config.example.yaml`](../config.example.yaml) ships an example profile plus three commented-out alternatives (single-tone, system+talkgroup scoped, tightened tolerance) so operators discover the schema without grepping source. |
+| **Scan mode = list** | `scanner.scan_mode` | `"all"` | "all" is the backwards-compatible behaviour. Tag-based talkgroup curation must be done by the operator before "list" is useful. Per-deployment choice. Emergency grants bypass the gate regardless. |
+| **CTCSS / DCS squelch** | per-channel `tone:` block | omitted (no gating) | Sub-audible CTCSS tone / DCS code is per-channel signalling that varies by site, repeater, and agency. No useful zero-config default. Omitting the block reverts to carrier-only squelch. |
+| **Raw frame sidecar** | `recordings.write_raw` | `true` in `config.example.yaml` | On in the shipped example. Operators who don't want the `.raw` sidecar set `false`. |
+| **Prometheus metrics** | `metrics.enabled` | `true` | On by default; listed for completeness. |
+| **Call-log retention sweep** | `retention.call_log_days` | `30` (`0` disables) | Sensible default already on. Set `0` to disable the sweeper. |
+| **File retention sweep** | `retention.files_days` | `14` (`0` disables) | Same as call-log. |
 
 ---
 
-## 4. Build-time opt-ins
+## 4. Build-time options
 
-| Feature | Mechanism | Default | Why opt-in | Remediation |
-| --- | --- | --- | --- | --- |
-| **DVSI hardware vocoder backend** | `-tags dvsi` build tag ([`docs/architecture.md:105`](architecture.md), [`docs/vocoders.md:47`](vocoders.md)) | Not built | Patent-encumbered. Requires DVSI USB-3000 / AMBE-3003 hardware. Status: **planned, not yet shipped** per [`docs/vocoders.md:170`](vocoders.md). The pure-Go AMBE+2 backend is the default and ships everywhere. | None. This is correctly gated for licensing reasons and should stay opt-in permanently. |
-| **Integration tests** | `-tags integration` build tag ([`docs/architecture.md:103`](architecture.md)) | Not run by `go test ./...` | Enables a wired end-to-end daemon test that doesn't need a real SDR. Long-running, intentionally outside the default unit-test wall-time budget. | None. CI runs the tagged suite separately; default `go test` stays fast. |
-| **Pure-Go (no CGO)** | implicit `CGO_ENABLED=0` build | On (default) | Already the default everywhere — no `librtlsdr` / `libusb` dependency. Listed for completeness because the README emphasises it as a design property. | None. |
+These stay opt-in by their nature — none of the three are candidates
+to flip on by default.
 
----
-
-## 5. Cross-cutting remediation strategies
-
-The table rows above cite four recurring remediation patterns. The
-short version:
-
-1. **Re-encode fixtures + flip the default.** Applies to every FEC
-   opt-in. The blocker is legacy DSD-FME / OP25 / MMDVMHost test
-   inputs that predate the spec-correct path. One mechanical PR per
-   protocol once the new fixtures land; the cross-protocol path is to
-   add a `legacy_fixtures` test-only mode that the regression suite
-   opts into so the new on-by-default behaviour can ship without
-   deleting the old fixtures.
-2. **Auto-detect at runtime.** Try the FEC / better path first; fall
-   back to legacy on N consecutive failures. Small CPU burst on
-   broken input, zero operator config. Applies to protocol FEC
-   opt-ins and to the CMA equalizer.
-3. **Add an auth layer.** ✅ Landed. Bearer-token middleware with
-   loopback-bypass under `auto` mode replaces the binary
-   `allow_mutations` gate; see [`docs/hardening.md` §"API
-   authentication"](hardening.md).
-4. **Site-specific config — no useful default.** `tone_out`, per-
-   channel `tone:`, conventional channel lists, and talkgroup files
-   stay opt-in by nature. Improve discoverability with better example
-   YAML and cross-references in the README rather than trying to flip
-   a default.
+| Feature | Mechanism | Default | Why |
+| --- | --- | --- | --- |
+| **DVSI hardware vocoder backend** | `-tags dvsi` build tag ([`docs/architecture.md`](architecture.md), [`docs/vocoders.md`](vocoders.md)) | Not built | Patent-encumbered. Requires DVSI USB-3000 / AMBE-3003 hardware. Status: planned, not yet shipped. The pure-Go AMBE+2 backend is the default and ships everywhere. Stays opt-in permanently for licensing reasons. |
+| **Integration tests** | `-tags integration` build tag | Not run by `go test ./...` | Enables a wired end-to-end daemon test that doesn't need a real SDR. Long-running, intentionally outside the default unit-test wall-time budget. CI runs the tagged suite separately. |
+| **Pure-Go (no CGO)** | implicit `CGO_ENABLED=0` build | On | Already the default everywhere — no `librtlsdr` / `libusb` dependency. Listed for completeness because the README emphasises it as a design property. |
 
 ---
 
-## 6. How to verify what's currently enabled
+## 5. How to verify what's currently enabled
 
-- **FEC opt-ins per system.** Open the **Settings** panel in the
-  TUI — it lists every configured system with a one-line summary of
-  its FEC opt-in state (`channel coding: on (colour=…, sch/f)`,
-  `viterbi: off`, `bch: on`, etc.). See [`README.md:1971-1976`](../README.md).
+- **FEC defaults per system.** Open the **Settings** panel in the
+  TUI — the "FEC opt-ins" tab lists every configured system with a
+  one-line summary (`channel coding: on (colour=…, sch/f)`,
+  `viterbi: spec`, `bch: on`, etc.).
 - **Programmatic introspection.** Each protocol's `ControlChannel`
   exposes matching getters (`tetra.ControlChannel.ChannelCoding()` /
   `ExpectedChannel()` / `ColourCode()`, `ltr.ControlChannel.FCSMode()` /
@@ -160,8 +138,12 @@ short version:
   `nxdn.ControlChannel.ViterbiMode()`, `edacs.ControlChannel.BCHMode()`,
   `mpt1327.ControlChannel.BCHMode()`, `motorola.ControlChannel.BCHMode()`).
 - **JSON over HTTP.** The `/api/v1/systems` endpoint DTO carries
-  every FEC opt-in field as `omitempty` JSON, so a configured-systems
+  every FEC opt-out field as `omitempty` JSON — a configured-systems
   audit is one `curl` away.
-- **Daemon-level opt-ins.** Inspect the running `config.yaml` and
-  the daemon's startup log lines; the config loader logs the
-  effective values for every section as it parses.
+- **Daemon-level state.** Inspect the running `config.yaml` and the
+  daemon's startup log lines; the config loader logs the effective
+  values for every section as it parses.
+- **API auth capability.** `GET /api/v1/mutations` is always open
+  and reports `auth_mode` + `can_mutate` for the current request, so
+  scripts and TUIs can light up write-side keybindings without
+  probing real endpoints.


### PR DESCRIPTION
## Summary

Final PR in the opt-in-features remediation series (#176, #177,
#178). Wraps up the documentation state and ships the tone-out
examples flagged in the original opt-in-features doc as the
remediation for `tone_out.profiles`.

### `config.example.yaml` — expanded tone-out examples

The `tone_out` section now ships:

- One **live** profile (the existing Motorola Quick Call II two-tone
  sequential example) so operators copying the template have
  something working they can rename / adjust.
- **Three commented-out alternatives** demonstrating the full
  `Profile` schema:
  - Single-tone supervisory page (older simplex pattern)
  - Two-tone with `system:` + `group_id:` scoping
  - Two-tone with tightened `tolerance_hz` + `magnitude_threshold`
    for stable agency frequencies
- An inline **schema reference** listing every supported field
  (`tones`, `tolerance_hz`, `magnitude_threshold`, `max_gap`,
  `cooldown`, `system`, `group_id`) so operators don't have to
  reach for `internal/voice/toneout/profile.go`.

### `docs/opt-in-features.md` — cohesion rewrite

The doc was originally written when most features were opt-in and
the table rows carried "remediation" sketches. After PRs 1-3, the
landscape changed:

- FEC defaults flipped on (PR 1 / #177 bundle)
- Gardner clock wired into YAML, manual-tune auto-detect (PR 2 / #177)
- Bearer-token auth replaced `allow_mutations` (PR 3 / #178)

The rewrite reorganises the doc around the **current state** instead
of the historical remediation roadmap:

| § | Content |
| --- | --- |
| 1 | Protocol-layer FEC defaults — on by default, opt-out per protocol |
| 2 | Receiver clock recovery — on by default, opt-out per protocol |
| 3 | Daemon-level features — mix of on / off / auto-detect |
| 4 | Build-time options — patent / CI gates that stay opt-in permanently |
| 5 | How to verify what's currently enabled (TUI / API / getters) |

Resolved items no longer carry remediation columns; they point at
the README sections (FEC opt-outs, API authentication) that own
the live reference tables.

### `README.md`

- `docs/opt-in-features.md` link blurb updated to reflect the doc's
  new role as the operator reference for every default the daemon
  carries (not a remediation roadmap).
- `docs/hardening.md` description now calls out the new API
  authentication section that landed in #178.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` clean (default tags)
- [x] `go test -tags integration ./cmd/gophertrunk/...` clean
- [x] `config.example.yaml` parses through `config.Load`; the live
      profile loads cleanly and the commented alternatives are
      ignored as expected.
- [ ] Smoke: copy `config.example.yaml` to a fresh `config.yaml`,
      start the daemon, and confirm the headline Quick Call II
      profile shows up in the TUI's Settings Tones tab.
- [ ] Smoke: uncomment one of the alternative profiles, restart,
      and confirm the daemon parses + validates it without errors.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Q3vP5jeF8GbKzr4G5nxFwD)_