### PR TITLE
tui: rename FEC opt-ins tab to FEC (chains are on by default now)

### DIFF
--- a/docs/opt-in-features.md
+++ b/docs/opt-in-features.md
@@ -128,7 +128,7 @@ to flip on by default.
 ## 5. How to verify what's currently enabled
 
 - **FEC defaults per system.** Open the **Settings** panel in the
-  TUI — the "FEC opt-ins" tab lists every configured system with a
+  TUI — the **FEC** tab lists every configured system with a
   one-line summary (`channel coding: on (colour=…, sch/f)`,
   `viterbi: spec`, `bch: on`, etc.).
 - **Programmatic introspection.** Each protocol's `ControlChannel`

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -161,7 +161,7 @@ Cycle through tabs with `[` / `]` (or `h` / `l` / `←` / `→`):
 | API | HTTP / gRPC / WebSocket / metrics listener addresses, mutations allowed |
 | Vocoders | per-protocol vocoder mapping |
 | SDR | registered backend names, per-device serial / role / gain |
-| FEC | per-system FEC opt-in summary (the original Settings table) |
+| FEC | per-system FEC state — every protocol's chain is on by default, this view surfaces explicit `<key>: off` opt-outs and the current channel-coding / colour-code parameters |
 
 Every config knob the daemon reads has a touch-point here. Mutating
 the settings still requires editing `config.yaml` and restarting

--- a/internal/tui/panels/settings.go
+++ b/internal/tui/panels/settings.go
@@ -50,7 +50,7 @@ func (t settingsTab) String() string {
 	case tabSDR:
 		return "SDR"
 	case tabFEC:
-		return "FEC opt-ins"
+		return "FEC"
 	}
 	return "?"
 }
@@ -62,8 +62,10 @@ func (t settingsTab) String() string {
 type SettingsPanel struct {
 	tab settingsTab
 
-	// FEC opt-ins tab retains the existing table view; the other
-	// tabs render plain text.
+	// FEC tab retains the existing table view; the other tabs
+	// render plain text. The tab summarises each system's FEC
+	// state — every protocol's chain is on by default, so the
+	// table is operationally an opt-out reference.
 	tbl      table.Model
 	lastHash uint64
 }
@@ -142,7 +144,7 @@ func (p *SettingsPanel) View(width, height int, focused bool, s *state.SharedSta
 		if height > 6 {
 			p.tbl.SetHeight(height - 6)
 		}
-		body = p.tbl.View() + "\n\n" + dashDim.Render("Edit config.yaml + restart daemon to change; see the FEC opt-ins section in README.md.")
+		body = p.tbl.View() + "\n\n" + dashDim.Render("Edit config.yaml + restart daemon to change; see the FEC opt-outs section in README.md.")
 	} else {
 		body = p.renderTab(width, s)
 	}
@@ -271,7 +273,7 @@ func settingsColumns(w int) []table.Column {
 	return []table.Column{
 		{Title: "Name", Width: nameW},
 		{Title: "Protocol", Width: protoW},
-		{Title: "FEC opt-ins", Width: fecW},
+		{Title: "FEC", Width: fecW},
 	}
 }
 

--- a/internal/tui/panels/settings_test.go
+++ b/internal/tui/panels/settings_test.go
@@ -25,9 +25,9 @@ func TestSettingsPanel_RendersFECSummaryPerProtocol(t *testing.T) {
 		},
 	}
 	_, _ = p.Update(tea.WindowSizeMsg{Width: 140, Height: 30}, s)
-	// Switch to the FEC opt-ins tab — the inspector defaults to the
-	// Daemon tab and only the FEC tab renders the per-system FEC
-	// summary table this test asserts on.
+	// Switch to the FEC tab — the inspector defaults to the Daemon
+	// tab and only the FEC tab renders the per-system FEC summary
+	// table this test asserts on.
 	for p.tab != tabFEC {
 		_, _ = p.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("]")}, s)
 	}


### PR DESCRIPTION
## Summary

Cleanup PR. The Settings panel's FEC tab still advertised itself as
"FEC opt-ins" and its trailing help text pointed operators at a
README section by that name — but after #177 the FEC defaults
flipped on and the README section was renamed to "FEC opt-outs."
Operators opening Settings today see a tab whose label doesn't
match its semantics or its documentation cross-reference.

### Changes

- `internal/tui/panels/settings.go` — tab label and table column
  header rename from `"FEC opt-ins"` to `"FEC"`. Internal `tabFEC`
  enum identifier is unchanged (rename is cosmetic).
- `internal/tui/panels/settings.go` — trailing help text now points
  at the README's "FEC opt-outs section" so the cross-reference
  resolves.
- `docs/tui.md` — table description rewritten to explain what the
  FEC tab surfaces under the new defaults (on-by-default with
  per-system opt-outs).
- `docs/opt-in-features.md` — verification section updated to
  reference the tab by its new name.
- `internal/tui/panels/settings_test.go` — stale comment updated.

### What was deliberately *not* touched

The README's historical changelog entries (lines ~115, 610,
815-960, 1265+, 1364+, 1420+) still describe past PRs as
introducing FEC "opt-ins." Those are accurate as a historical
record of the work that landed before #177 flipped the defaults
and shouldn't be retroactively rewritten.

Unrelated uses of "opt-in" in the codebase (`internal/voice/composer`,
`internal/storage/retention`, `cmd/gophertrunk/daemon.go`'s CC
hunter comment, etc.) describe genuine opt-in features and are
correct as-is.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/tui/...` clean (renamed tab still
      navigated to by `tabFEC` identifier)
- [x] `go test ./...` clean
- [ ] Smoke: start daemon + TUI; tab bar shows "FEC" instead of
      "FEC opt-ins"; help text under the table reads "see the FEC
      opt-outs section in README.md" and the README anchor
      resolves.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Q3vP5jeF8GbKzr4G5nxFwD)_