### PR TITLE
p25/phase2: ship outer Reed-Solomon RS(24,16,9) verifier (revisits PR E)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,12 +83,19 @@ The remaining gaps:
     interleaver/puncture detail-level matching against captured
     MMDVMHost transmissions is the calibration step that lands
     next.
-  - **P25 Phase 2 Reed-Solomon outer + per-burst block
-    interleaver.** Trellis decoder (`SetTrellisMode(TrellisOn)`)
-    works; the spec's outer RS layer + per-burst block
-    interleaver (TIA-102.BBAB) are documented follow-ups
-    blocked on access to the spec text and a real-air capture
-    to validate against.
+  - **P25 Phase 2 outer Reed-Solomon (now shipping) + per-burst
+    block interleaver (pending TIA-102.BBAC).** The Trellis
+    decoder (`SetTrellisMode(TrellisOn)`) handles the inner
+    4-state ½-rate code. The outer RS(24, 16, 9) layer over
+    GF(2^6) (TIA-102.BAAA-A §5.9, reused by Phase 2 on top of
+    the trellis-decoded MAC PDU) now ships through
+    `SetRSMode(RSOn)` — when enabled, MAC PDUs whose RS
+    syndromes are non-zero are dropped at the framing layer
+    before parsing. The per-burst block interleaver schedule
+    defined in TIA-102.BBAC (MAC Layer) remains a documented
+    follow-up; the spec text was not available at
+    implementation time and a real-air capture is needed to
+    validate the schedule against on-air transmissions.
   - **MPT 1327 inter-codeword interleaver.** BCH(64,48,2) ships
     per-codeword; the inter-codeword bit-interleaver across
     5-codeword CCDB groups still needs spec implementation work
@@ -2047,7 +2054,7 @@ the daemon.
 | --- | --- | --- | --- |
 | TETRA | `tetra_colour_code` (uint32, low 30 bits — required for non-BSCH), `tetra_channel` (`"sch/hd"` / `"sch/f"` / `"sch/hu"` / `"bsch"` / `"aach"`, default `sch/hd`), `tetra_channel_coding` (`""` / `"on"` / `"off"`) | Full ETSI EN 300 392-2 §8.3.1 type-5 → type-1 chain (descramble + deinterleave + depuncture + Viterbi + CRC-16 verify + tail strip) per burst. `tetra_colour_code` of 0 is only valid for BSCH; non-BSCH channels need the per-cell colour code or descrambling produces garbage (the connector warn-logs this case). | `tetra_channel_coding: off` falls back to the legacy 48-dibit raw-PDU path. CRC will fail on live captures; only useful for pre-stripped fixtures. |
 | LTR | `ltr_fcs_mode` (`""` / `"on"` / `"off"`), `ltr_manchester_mode` (`""` / `"on"` / `"soft"` / `"strict"` / `"off"` / `"nrz"`) | `fcs: on` — CRC-7 FCS check against sdrtrunk's CRCLTR.java layout. `manchester: soft` — majority-decode each pair (matches the dominant on-air encoding for sub-audible LTR signaling). | `fcs: off` skips the CRC check (synthesized fixtures whose FCS trailer isn't populated). `manchester: off` / `nrz` treats the stream as raw NRZ (synthesized NRZ fixtures). |
-| P25 Phase 2 | `p25_phase2_trellis_mode` (`""` / `"on"` / `"off"`) | 4-state ½-rate trellis FEC over the MAC PDU window (146 channel dibits → 72 info dibits per TIA-102.AABF). | Falls back to the legacy 72-dibit raw-MAC-PDU path for pre-stripped fixtures. |
+| P25 Phase 2 | `p25_phase2_trellis_mode` (`""` / `"on"` / `"off"`), `p25_phase2_rs_mode` (`""` / `"on"` / `"off"`) | `trellis: on` — 4-state ½-rate trellis FEC over the MAC PDU window (146 channel dibits → 72 info dibits per TIA-102.AABF). `rs: off` — the outer RS(24, 16, 9) layer (TIA-102.BAAA-A §5.9, reused for Phase 2) is shipped but defaults off because the per-burst block interleaver schedule from TIA-102.BBAC is still pending. | `trellis: off` — legacy 72-dibit raw-MAC-PDU path for pre-stripped fixtures. `rs: on` — verify RS(24, 16, 9) syndromes on the trellis-decoded MAC PDU; PDUs whose syndromes are non-zero are dropped before parsing. |
 | NXDN | `nxdn_viterbi_mode` (`""` / `"spec"` / `"on"` / `"off"`) | `spec` — full NXDN-TS-1-A rev 1.3 §4.5.1.1 outbound CAC chain (150 dibits → deinterleave 25×12 → depuncture 50/350 → K=5 Viterbi → 16-bit CRC verify → 155 info bits). | `on` — intermediate 92-dibit K=5 Viterbi path for older MMDVMHost / DSDcc fixtures. `off` — legacy 44-dibit raw-CAC path for pre-stripped fixtures. |
 | EDACS | `edacs_bch_mode` (`""` / `"on"` / `"off"`) | BCH(40, 28, 2) with single/double-bit correction over the 40-bit on-wire CCW; the effective CCW carries 28 info bits (Command + Status + Address + high LCN bits), the remaining bits become BCH parity. | Falls back to the legacy pre-stripped 40-bit CCW; payload struct's LCN bit 0 + Aux fields are treated as data instead of parity. |
 | MPT 1327 | `mpt1327_bch_mode` (`""` / `"on"` / `"off"`) | BCH(63, 38) decode over the 64-bit on-wire codeword. | Falls back to the legacy 38-bit pre-stripped codeword. |

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -129,6 +129,7 @@ func NewDaemon(cfg config.Config, version string, log *slog.Logger) (*Daemon, er
 			LTRFCSMode:           sys.LTRFCSMode,
 			LTRManchesterMode:    sys.LTRManchesterMode,
 			P25Phase2TrellisMode: sys.P25Phase2TrellisMode,
+			P25Phase2RSMode:      sys.P25Phase2RSMode,
 			P25Phase2ClockMode:   sys.P25Phase2ClockMode,
 			NXDNViterbiMode:      sys.NXDNViterbiMode,
 			EDACSBCHMode:         sys.EDACSBCHMode,

--- a/docs/opt-in-features.md
+++ b/docs/opt-in-features.md
@@ -39,7 +39,8 @@ per-system with `<key>: off`.
 | TETRA | `tetra_channel_coding` | `ChannelCodingOn` (full §8.3.1 chain) | `off` |
 | LTR FCS | `ltr_fcs_mode` | `FCSOn` | `off` |
 | LTR Manchester | `ltr_manchester_mode` | `ManchesterSoft` | `off` / `nrz` |
-| P25 Phase 2 | `p25_phase2_trellis_mode` | `TrellisOn` | `off` |
+| P25 Phase 2 (inner trellis) | `p25_phase2_trellis_mode` | `TrellisOn` | `off` |
+| P25 Phase 2 (outer RS) | `p25_phase2_rs_mode` | `RSOff` (RS(24, 16, 9) verifier shipped; default off pending per-burst interleaver schedule) | `on` flips RS verification on |
 | NXDN | `nxdn_viterbi_mode` | `ViterbiSpec` | `off` |
 | EDACS | `edacs_bch_mode` | `BCHOn` | `off` |
 | MPT 1327 | `mpt1327_bch_mode` | `BCHOn` | `off` |
@@ -137,7 +138,7 @@ real-air capture to validate against:
 | Item | Status | Blocker |
 | --- | --- | --- |
 | **NXDN per-protocol interleaver + puncture inner layer** | `ViterbiSpec` mode wired through the connector; calibration against a captured MMDVMHost / DSDcc transmission lands next | Real-air capture |
-| **P25 Phase 2 outer Reed-Solomon + per-burst block interleaver** | Trellis decoder shipping (`SetTrellisMode(TrellisOn)`); the spec's outer RS layer + per-burst block interleaver are pending | TIA-102.BBAB spec access + real-air capture |
+| **P25 Phase 2 per-burst block interleaver** | Trellis decoder shipping (`SetTrellisMode(TrellisOn)`); the outer RS(24, 16, 9) verifier shipping as opt-in via `SetRSMode(RSOn)` per TIA-102.BAAA-A §5.9. The per-burst block interleaver schedule that the Phase 2 spec wraps around the trellis-coded MAC PDU still pending | TIA-102.BBAC (Two-Slot TDMA MAC Layer) spec access + real-air capture |
 | **MPT 1327 inter-codeword interleaver** | BCH(64, 48, 2) ships per-codeword; the inter-codeword bit-interleaver across 5-codeword CCDB groups still pending | MPT 1327 spec implementation work + real-air capture |
 | **YSF FICH interleaver / puncture validation** | K=5 ½-rate trellis encoder + decoder round-trip in unit tests; validating against a captured YSF transmission's exact schedule remains | Real-air capture |
 | **TETRA on-air recovery margins** | Full §8.3.1 chain ships and unit tests round-trip clean fixtures; on-air recovery margins (Viterbi correction depth vs. real co-channel + adjacent-channel interference) need profiling | Live capture |

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -40,6 +40,7 @@ type SystemDTO struct {
 	LTRFCSMode           string `json:"ltr_fcs_mode,omitempty"`
 	LTRManchesterMode    string `json:"ltr_manchester_mode,omitempty"`
 	P25Phase2TrellisMode string `json:"p25_phase2_trellis_mode,omitempty"`
+	P25Phase2RSMode      string `json:"p25_phase2_rs_mode,omitempty"`
 	NXDNViterbiMode      string `json:"nxdn_viterbi_mode,omitempty"`
 	EDACSBCHMode         string `json:"edacs_bch_mode,omitempty"`
 	MPT1327BCHMode       string `json:"mpt1327_bch_mode,omitempty"`
@@ -61,6 +62,7 @@ func systemToDTO(s trunking.System) SystemDTO {
 		LTRFCSMode:           s.LTRFCSMode,
 		LTRManchesterMode:    s.LTRManchesterMode,
 		P25Phase2TrellisMode: s.P25Phase2TrellisMode,
+		P25Phase2RSMode:      s.P25Phase2RSMode,
 		NXDNViterbiMode:      s.NXDNViterbiMode,
 		EDACSBCHMode:         s.EDACSBCHMode,
 		MPT1327BCHMode:       s.MPT1327BCHMode,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -217,6 +217,16 @@ type SystemConfig struct {
 	// "false" / "0" (legacy 72-dibit raw-MAC-PDU path, opt-out for
 	// pre-stripped fixtures). Ignored for non-P25-Phase-2 protocols.
 	P25Phase2TrellisMode string `yaml:"p25_phase2_trellis_mode"`
+	// P25Phase2RSMode enables the outer Reed-Solomon RS(24, 16, 9)
+	// verification layer on top of the trellis-decoded MAC PDU.
+	// Recognised values: "" / "off" / "false" / "0" (the default —
+	// no outer RS verification; matches historical decoder
+	// behaviour) or "on" / "true" / "1" (verify RS syndromes per
+	// TIA-102.BAAA-A §5.9; drop MAC PDUs whose syndromes are
+	// non-zero before parsing). The per-burst block interleaver
+	// schedule defined in TIA-102.BBAC remains a follow-up.
+	// Ignored for non-P25-Phase-2 protocols.
+	P25Phase2RSMode string `yaml:"p25_phase2_rs_mode"`
 	// P25Phase2ClockMode selects the symbol-timing-recovery strategy
 	// for the P25 Phase 2 receiver. Recognised values: "" /
 	// "gardner" / "on" (the new default — non-data-aided Gardner

--- a/internal/radio/framing/rs_gf64.go
+++ b/internal/radio/framing/rs_gf64.go
@@ -1,0 +1,255 @@
+package framing
+
+// Reed-Solomon codes over GF(2^6) per TIA-102.BAAA-A §5.9 — the
+// three shortened RS codes Project 25 uses for voice information
+// and link control protection, which P25 Phase 2 also reuses on
+// top of the 4-state ½-rate trellis code that protects MAC PDU
+// channel dibits.
+//
+// All three codes share the same Galois field: GF(2^6) generated
+// by the primitive characteristic polynomial α^6 + α + 1 = 0.
+// Field elements are represented as 6-bit values 0..63 where bit i
+// corresponds to α^i; α itself is the value 0b000010 = 2.
+//
+// The codes are shortened from the natural (63, K, D) form by
+// deleting the leftmost (63 - 24) or (63 - 36) information symbols.
+// Encoding is systematic: the first K codeword symbols are the K
+// information symbols verbatim; the trailing R = N - K symbols are
+// parity computed by matrix-multiplying the information vector by
+// the right-hand parity columns of the spec's K × N generator
+// matrix.
+//
+//	Code             | K  | N  | D  | t   | Use in P25
+//	-----------------+----+----+----+-----+----------------------------
+//	RS(24, 12, 13)   | 12 | 24 | 13 | 6   | Link Control words (LCW),
+//	                 |    |    |    |     | Phase 2 SACCH outer FEC
+//	RS(24, 16,  9)   | 16 | 24 |  9 | 4   | Encryption Sync (ES),
+//	                 |    |    |    |     | Phase 2 FACCH outer FEC
+//	RS(36, 20, 17)   | 20 | 36 | 17 | 8   | Header Data Unit (HDU)
+//
+// This pass implements encoder + syndrome verifier for all three
+// codes. Single-symbol error correction via Berlekamp-Massey +
+// Chien + Forney is a future follow-up — verification alone tells
+// the higher layer whether the inner trellis/Golay correction was
+// successful, which is the primary use of the outer RS layer.
+
+// rsGF64 is the singleton GF(2^6) field. Built at init time.
+var rsGF64 *rsField64
+
+type rsField64 struct {
+	exp [126]byte // exp[i] = α^i for i in 0..62 (and repeated for 63..125 to avoid mod in hot loops)
+	log [64]byte  // log[a] = i such that α^i = a (log[0] unused)
+}
+
+func init() {
+	f := &rsField64{}
+	x := byte(1)
+	for i := 0; i < 63; i++ {
+		f.exp[i] = x
+		f.log[x] = byte(i)
+		// Multiply by α: shift left, reduce mod α^6 + α + 1 if bit 6 set.
+		// The primitive polynomial in bit form is 0b1000011 (= 0x43). If
+		// the pre-shift value had bit 5 set the post-shift value has bit 6
+		// set, so we XOR with 0b1000011 then mask to 6 bits — equivalent
+		// to XOR with the reduction polynomial 0b000011 = 3 after masking.
+		preShift := f.exp[i]
+		x = byte((int(x) << 1) & 0x3F)
+		if preShift&0x20 != 0 {
+			x ^= 0x03
+		}
+	}
+	// Double-period table so multiplication can index exp[(la+lb)] without
+	// taking mod 63 in every call.
+	for i := 63; i < 126; i++ {
+		f.exp[i] = f.exp[i-63]
+	}
+	rsGF64 = f
+}
+
+// gf64Mul multiplies two GF(2^6) elements via the log/exp tables.
+func gf64Mul(a, b byte) byte {
+	if a == 0 || b == 0 {
+		return 0
+	}
+	return rsGF64.exp[int(rsGF64.log[a])+int(rsGF64.log[b])]
+}
+
+// gf64Pow returns α^n with n folded into the [0, 62] range.
+func gf64Pow(n int) byte {
+	n %= 63
+	if n < 0 {
+		n += 63
+	}
+	return rsGF64.exp[n]
+}
+
+// rsParity24_12 is the right-hand 12 × 12 parity sub-matrix of the
+// GLC generator matrix for the shortened RS(24, 12, 13) code per
+// TIA-102.BAAA-A §5.9 (Table "GLC matrix"). Entries are in the
+// octal representation the spec uses; each value is a 6-bit GF(2^6)
+// element where octal digit d_i contributes bits (3*i+2 .. 3*i) of
+// the element.
+//
+// Indexing: rsParity24_12[i][j] is the parity contribution of the
+// i-th information symbol to the j-th parity symbol (j = 0 is the
+// leftmost parity column, immediately after the K identity columns).
+var rsParity24_12 = [12][12]byte{
+	{0o62, 0o44, 0o03, 0o25, 0o14, 0o16, 0o27, 0o03, 0o53, 0o04, 0o36, 0o47},
+	{0o11, 0o12, 0o11, 0o11, 0o16, 0o64, 0o67, 0o55, 0o01, 0o76, 0o26, 0o73},
+	{0o03, 0o01, 0o05, 0o75, 0o14, 0o06, 0o20, 0o44, 0o66, 0o06, 0o70, 0o66},
+	{0o21, 0o70, 0o27, 0o45, 0o16, 0o67, 0o23, 0o64, 0o73, 0o33, 0o44, 0o21},
+	{0o30, 0o22, 0o03, 0o75, 0o15, 0o15, 0o33, 0o15, 0o51, 0o03, 0o53, 0o50},
+	{0o01, 0o41, 0o27, 0o56, 0o76, 0o64, 0o21, 0o53, 0o04, 0o25, 0o01, 0o12},
+	{0o61, 0o76, 0o21, 0o55, 0o76, 0o01, 0o63, 0o35, 0o30, 0o13, 0o64, 0o70},
+	{0o24, 0o22, 0o71, 0o56, 0o21, 0o35, 0o73, 0o42, 0o57, 0o74, 0o43, 0o76},
+	{0o72, 0o42, 0o05, 0o20, 0o43, 0o47, 0o33, 0o56, 0o01, 0o16, 0o13, 0o76},
+	{0o72, 0o14, 0o65, 0o54, 0o35, 0o25, 0o41, 0o16, 0o15, 0o40, 0o71, 0o26},
+	{0o73, 0o65, 0o36, 0o61, 0o42, 0o22, 0o17, 0o04, 0o44, 0o20, 0o25, 0o05},
+	{0o71, 0o05, 0o55, 0o03, 0o71, 0o34, 0o60, 0o11, 0o74, 0o02, 0o41, 0o50},
+}
+
+// rsParity24_16 is the right-hand 16 × 8 parity sub-matrix of the
+// GES generator matrix for the shortened RS(24, 16, 9) code per
+// TIA-102.BAAA-A §5.9 (Table "GES matrix").
+var rsParity24_16 = [16][8]byte{
+	{0o51, 0o45, 0o67, 0o15, 0o64, 0o67, 0o52, 0o12},
+	{0o57, 0o25, 0o63, 0o73, 0o71, 0o22, 0o40, 0o15},
+	{0o05, 0o01, 0o31, 0o04, 0o16, 0o54, 0o25, 0o76},
+	{0o73, 0o07, 0o47, 0o14, 0o41, 0o77, 0o47, 0o11},
+	{0o75, 0o15, 0o51, 0o51, 0o17, 0o67, 0o17, 0o57},
+	{0o20, 0o32, 0o14, 0o42, 0o75, 0o42, 0o70, 0o54},
+	{0o02, 0o75, 0o43, 0o05, 0o01, 0o40, 0o12, 0o64},
+	{0o24, 0o74, 0o15, 0o72, 0o24, 0o26, 0o74, 0o61},
+	{0o42, 0o64, 0o07, 0o22, 0o61, 0o20, 0o40, 0o65},
+	{0o32, 0o32, 0o55, 0o41, 0o57, 0o66, 0o21, 0o77},
+	{0o65, 0o36, 0o25, 0o07, 0o50, 0o16, 0o40, 0o51},
+	{0o64, 0o06, 0o54, 0o32, 0o76, 0o46, 0o14, 0o36},
+	{0o62, 0o63, 0o74, 0o70, 0o05, 0o27, 0o37, 0o46},
+	{0o55, 0o43, 0o34, 0o71, 0o57, 0o76, 0o50, 0o64},
+	{0o24, 0o23, 0o23, 0o05, 0o50, 0o70, 0o42, 0o23},
+	{0o67, 0o75, 0o45, 0o60, 0o57, 0o24, 0o06, 0o26},
+}
+
+// rsParity36_20 is the right-hand 20 × 16 parity sub-matrix of the
+// PHDR generator matrix for the shortened RS(36, 20, 17) code per
+// TIA-102.BAAA-A §5.9 (Table "PHDR matrix").
+var rsParity36_20 = [20][16]byte{
+	{0o74, 0o37, 0o34, 0o06, 0o02, 0o07, 0o44, 0o64, 0o26, 0o14, 0o26, 0o44, 0o54, 0o13, 0o77, 0o05},
+	{0o04, 0o17, 0o50, 0o24, 0o11, 0o05, 0o30, 0o57, 0o33, 0o03, 0o02, 0o02, 0o15, 0o16, 0o25, 0o26},
+	{0o07, 0o23, 0o37, 0o46, 0o56, 0o75, 0o43, 0o45, 0o55, 0o21, 0o50, 0o31, 0o45, 0o27, 0o71, 0o62},
+	{0o26, 0o05, 0o07, 0o63, 0o63, 0o27, 0o63, 0o40, 0o06, 0o04, 0o40, 0o45, 0o47, 0o30, 0o75, 0o07},
+	{0o23, 0o73, 0o73, 0o41, 0o72, 0o34, 0o21, 0o51, 0o67, 0o16, 0o31, 0o74, 0o11, 0o21, 0o12, 0o21},
+	{0o24, 0o51, 0o25, 0o23, 0o22, 0o41, 0o74, 0o66, 0o74, 0o65, 0o70, 0o36, 0o67, 0o45, 0o64, 0o01},
+	{0o52, 0o33, 0o14, 0o02, 0o20, 0o06, 0o14, 0o25, 0o52, 0o23, 0o35, 0o74, 0o75, 0o75, 0o43, 0o27},
+	{0o55, 0o62, 0o56, 0o25, 0o73, 0o60, 0o15, 0o30, 0o13, 0o17, 0o20, 0o02, 0o70, 0o55, 0o14, 0o47},
+	{0o54, 0o51, 0o32, 0o65, 0o77, 0o12, 0o54, 0o13, 0o35, 0o32, 0o56, 0o12, 0o75, 0o01, 0o72, 0o63},
+	{0o74, 0o41, 0o30, 0o41, 0o43, 0o22, 0o51, 0o06, 0o64, 0o33, 0o03, 0o47, 0o27, 0o12, 0o55, 0o47},
+	{0o54, 0o70, 0o11, 0o03, 0o13, 0o22, 0o16, 0o57, 0o03, 0o45, 0o72, 0o31, 0o30, 0o56, 0o35, 0o22},
+	{0o51, 0o07, 0o72, 0o30, 0o65, 0o54, 0o06, 0o21, 0o36, 0o63, 0o50, 0o61, 0o64, 0o52, 0o01, 0o60},
+	{0o01, 0o65, 0o32, 0o70, 0o13, 0o44, 0o73, 0o24, 0o12, 0o52, 0o21, 0o55, 0o12, 0o35, 0o14, 0o72},
+	{0o11, 0o70, 0o05, 0o10, 0o65, 0o24, 0o15, 0o77, 0o22, 0o24, 0o24, 0o74, 0o07, 0o44, 0o07, 0o46},
+	{0o06, 0o02, 0o65, 0o11, 0o41, 0o20, 0o45, 0o42, 0o46, 0o54, 0o35, 0o12, 0o40, 0o64, 0o65, 0o33},
+	{0o34, 0o31, 0o01, 0o15, 0o44, 0o64, 0o16, 0o24, 0o52, 0o16, 0o06, 0o62, 0o20, 0o13, 0o55, 0o57},
+	{0o63, 0o43, 0o25, 0o44, 0o77, 0o63, 0o17, 0o17, 0o64, 0o14, 0o40, 0o74, 0o31, 0o72, 0o54, 0o06},
+	{0o71, 0o21, 0o70, 0o44, 0o56, 0o04, 0o30, 0o74, 0o04, 0o23, 0o71, 0o70, 0o63, 0o45, 0o56, 0o43},
+	{0o02, 0o01, 0o53, 0o74, 0o02, 0o14, 0o52, 0o74, 0o12, 0o57, 0o24, 0o63, 0o15, 0o42, 0o52, 0o33},
+	{0o34, 0o35, 0o02, 0o23, 0o21, 0o27, 0o22, 0o33, 0o64, 0o42, 0o05, 0o73, 0o51, 0o46, 0o73, 0o60},
+}
+
+// EncodeRS24_12 produces the 24-symbol codeword for 12 information
+// symbols using the GLC generator matrix per TIA-102.BAAA-A §5.9.
+// The first 12 codeword symbols are the information symbols
+// verbatim; the trailing 12 are parity. Each input/output symbol
+// is a 6-bit GF(2^6) element (only the low 6 bits are meaningful).
+func EncodeRS24_12(info [12]byte) [24]byte {
+	var cw [24]byte
+	copy(cw[:12], info[:])
+	for j := 0; j < 12; j++ {
+		var p byte
+		for i := 0; i < 12; i++ {
+			p ^= gf64Mul(info[i], rsParity24_12[i][j])
+		}
+		cw[12+j] = p
+	}
+	return cw
+}
+
+// EncodeRS24_16 produces the 24-symbol codeword for 16 information
+// symbols using the GES generator matrix per TIA-102.BAAA-A §5.9.
+func EncodeRS24_16(info [16]byte) [24]byte {
+	var cw [24]byte
+	copy(cw[:16], info[:])
+	for j := 0; j < 8; j++ {
+		var p byte
+		for i := 0; i < 16; i++ {
+			p ^= gf64Mul(info[i], rsParity24_16[i][j])
+		}
+		cw[16+j] = p
+	}
+	return cw
+}
+
+// EncodeRS36_20 produces the 36-symbol codeword for 20 information
+// symbols using the PHDR generator matrix per TIA-102.BAAA-A §5.9.
+func EncodeRS36_20(info [20]byte) [36]byte {
+	var cw [36]byte
+	copy(cw[:20], info[:])
+	for j := 0; j < 16; j++ {
+		var p byte
+		for i := 0; i < 20; i++ {
+			p ^= gf64Mul(info[i], rsParity36_20[i][j])
+		}
+		cw[20+j] = p
+	}
+	return cw
+}
+
+// VerifyRS24_12 reports whether the supplied 24-symbol codeword
+// satisfies the RS(24, 12, 13) parity equations. Returns false if
+// len(cw) != 24 or any input symbol has bits outside the GF(2^6)
+// range.
+//
+// The generator polynomial roots are α^1 through α^12; a valid
+// codeword evaluates to zero at each of those points. Polynomial
+// convention: cw[0] is the highest-degree coefficient (x^23) and
+// cw[23] is the constant term, so c(α^j) is computed by Horner
+// from the leading coefficient down.
+func VerifyRS24_12(cw []byte) bool {
+	return verifyRSGF64(cw, 24, 12)
+}
+
+// VerifyRS24_16 reports whether the supplied 24-symbol codeword
+// satisfies the RS(24, 16, 9) parity equations.
+func VerifyRS24_16(cw []byte) bool {
+	return verifyRSGF64(cw, 24, 8)
+}
+
+// VerifyRS36_20 reports whether the supplied 36-symbol codeword
+// satisfies the RS(36, 20, 17) parity equations.
+func VerifyRS36_20(cw []byte) bool {
+	return verifyRSGF64(cw, 36, 16)
+}
+
+func verifyRSGF64(cw []byte, n, r int) bool {
+	if len(cw) != n {
+		return false
+	}
+	for _, s := range cw {
+		if s&^0x3F != 0 {
+			return false
+		}
+	}
+	// Syndromes s_j = c(α^j) for j = 1..r. The spec defines
+	// g(x) = (x + α^1)(x + α^2)...(x + α^r), so roots start at α^1.
+	for j := 1; j <= r; j++ {
+		alphaJ := gf64Pow(j)
+		var s byte
+		for i := 0; i < n; i++ {
+			s = gf64Mul(s, alphaJ) ^ cw[i]
+		}
+		if s != 0 {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/radio/framing/rs_gf64_test.go
+++ b/internal/radio/framing/rs_gf64_test.go
@@ -1,0 +1,149 @@
+package framing
+
+import (
+	"testing"
+)
+
+// TestRSGF64FieldClosure validates the GF(2^6) log/exp tables: every
+// non-zero element should appear exactly once in the exp[] cycle, and
+// log[exp[i]] should round-trip.
+func TestRSGF64FieldClosure(t *testing.T) {
+	seen := make(map[byte]int)
+	for i := 0; i < 63; i++ {
+		v := rsGF64.exp[i]
+		if v == 0 {
+			t.Fatalf("exp[%d] = 0; GF(2^6) cycle should not include zero", i)
+		}
+		if v >= 64 {
+			t.Fatalf("exp[%d] = %d; out of range for GF(2^6)", i, v)
+		}
+		if prev, ok := seen[v]; ok {
+			t.Fatalf("exp[%d] = exp[%d] = %d; duplicate in cycle", i, prev, v)
+		}
+		seen[v] = i
+		if rsGF64.log[v] != byte(i) {
+			t.Fatalf("log[exp[%d]=%d] = %d, want %d", i, v, rsGF64.log[v], i)
+		}
+	}
+	if len(seen) != 63 {
+		t.Fatalf("expected 63 distinct non-zero elements, saw %d", len(seen))
+	}
+}
+
+// TestRSGF64MulIdentity checks that α^0 = 1 acts as the multiplicative
+// identity and 0 absorbs.
+func TestRSGF64MulIdentity(t *testing.T) {
+	if rsGF64.exp[0] != 1 {
+		t.Fatalf("α^0 = %d, want 1", rsGF64.exp[0])
+	}
+	for a := byte(0); a < 64; a++ {
+		if got := gf64Mul(a, 1); got != a {
+			t.Fatalf("a * 1 = %d, want %d", got, a)
+		}
+		if got := gf64Mul(a, 0); got != 0 {
+			t.Fatalf("a * 0 = %d, want 0", got)
+		}
+	}
+}
+
+// TestEncodeRS24_12_RoundTrip verifies the encoder produces a
+// codeword that satisfies the verifier for every information vector
+// in a small sample plus a stress sweep.
+func TestEncodeRS24_12_RoundTrip(t *testing.T) {
+	cases := [][]byte{
+		{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+		{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12},
+		{0o77, 0o76, 0o75, 0o74, 0o73, 0o72, 0o71, 0o70, 0o67, 0o66, 0o65, 0o64},
+		{63, 63, 63, 63, 63, 63, 63, 63, 63, 63, 63, 63},
+	}
+	for ci, info := range cases {
+		var a [12]byte
+		copy(a[:], info)
+		cw := EncodeRS24_12(a)
+		if !VerifyRS24_12(cw[:]) {
+			t.Errorf("case %d: VerifyRS24_12 returned false for freshly-encoded codeword", ci)
+		}
+		// Flip a single bit in any data symbol; the codeword should now
+		// fail verification (RS detects up to d-1 = 12 symbol errors,
+		// trivially detecting a single-bit flip).
+		bad := cw
+		bad[3] ^= 0x01
+		if VerifyRS24_12(bad[:]) {
+			t.Errorf("case %d: VerifyRS24_12 accepted a single-bit-flipped codeword", ci)
+		}
+	}
+}
+
+// TestEncodeRS24_16_RoundTrip mirrors TestEncodeRS24_12_RoundTrip for
+// the 16-info / 8-parity ES code.
+func TestEncodeRS24_16_RoundTrip(t *testing.T) {
+	cases := [][]byte{
+		{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+		{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
+		{63, 0, 63, 0, 63, 0, 63, 0, 63, 0, 63, 0, 63, 0, 63, 0},
+		{0o31, 0o12, 0o42, 0o77, 0o00, 0o63, 0o25, 0o14, 0o55, 0o22, 0o44, 0o70, 0o03, 0o01, 0o66, 0o57},
+	}
+	for ci, info := range cases {
+		var a [16]byte
+		copy(a[:], info)
+		cw := EncodeRS24_16(a)
+		if !VerifyRS24_16(cw[:]) {
+			t.Errorf("case %d: VerifyRS24_16 returned false for freshly-encoded codeword", ci)
+		}
+		bad := cw
+		bad[7] ^= 0x02
+		if VerifyRS24_16(bad[:]) {
+			t.Errorf("case %d: VerifyRS24_16 accepted a single-bit-flipped codeword", ci)
+		}
+	}
+}
+
+// TestEncodeRS36_20_RoundTrip mirrors for the 20-info / 16-parity HDU
+// code.
+func TestEncodeRS36_20_RoundTrip(t *testing.T) {
+	cases := [][]byte{
+		{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+		{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20},
+		{63, 0, 63, 0, 63, 0, 63, 0, 63, 0, 63, 0, 63, 0, 63, 0, 63, 0, 63, 0},
+	}
+	for ci, info := range cases {
+		var a [20]byte
+		copy(a[:], info)
+		cw := EncodeRS36_20(a)
+		if !VerifyRS36_20(cw[:]) {
+			t.Errorf("case %d: VerifyRS36_20 returned false for freshly-encoded codeword", ci)
+		}
+		bad := cw
+		bad[19] ^= 0x04
+		if VerifyRS36_20(bad[:]) {
+			t.Errorf("case %d: VerifyRS36_20 accepted a single-bit-flipped codeword", ci)
+		}
+	}
+}
+
+// TestRSGF64InvalidLength confirms each verifier rejects mis-sized
+// input rather than panicking or reading out of bounds.
+func TestRSGF64InvalidLength(t *testing.T) {
+	if VerifyRS24_12(make([]byte, 23)) {
+		t.Errorf("VerifyRS24_12 accepted 23-byte input")
+	}
+	if VerifyRS24_12(make([]byte, 25)) {
+		t.Errorf("VerifyRS24_12 accepted 25-byte input")
+	}
+	if VerifyRS24_16(make([]byte, 22)) {
+		t.Errorf("VerifyRS24_16 accepted 22-byte input")
+	}
+	if VerifyRS36_20(make([]byte, 35)) {
+		t.Errorf("VerifyRS36_20 accepted 35-byte input")
+	}
+}
+
+// TestRSGF64InvalidSymbol confirms symbols with bits outside the
+// 6-bit field are rejected.
+func TestRSGF64InvalidSymbol(t *testing.T) {
+	cw := make([]byte, 24)
+	cw[5] = 0x80 // bit 7 set, outside GF(2^6)
+	if VerifyRS24_12(cw) {
+		t.Errorf("VerifyRS24_12 accepted symbol with bits outside GF(2^6)")
+	}
+}

--- a/internal/radio/p25/phase2/control.go
+++ b/internal/radio/p25/phase2/control.go
@@ -37,6 +37,7 @@ type ControlChannel struct {
 	locked           bool
 	strictValidation bool
 	trellisMode      TrellisMode
+	rsMode           RSMode
 }
 
 // TrellisMode selects how the Process adapter interprets the MAC
@@ -107,6 +108,69 @@ func ParseTrellisMode(s string) (TrellisMode, bool) {
 		return TrellisOn, true
 	default:
 		return TrellisOn, false
+	}
+}
+
+// RSMode selects whether the Process adapter applies the outer
+// Reed-Solomon verification layer per TIA-102.BAAA-A §5.9 on top
+// of the trellis-decoded MAC PDU.
+//
+//   - RSOff (default): the trellis-decoded 144-bit MAC PDU is parsed
+//     straight into the state machine. Matches every shipped capture
+//     fixture in the test suite and the historical decoder output.
+//
+//   - RSOn: the trellis-decoded 144-bit MAC PDU is treated as 24
+//     hex symbols and verified with the RS(24, 16, 9) outer code
+//     (8-symbol parity, t = 4 corrections of detection). MAC PDUs
+//     whose syndromes are non-zero are dropped at the framing layer
+//     before reaching the state machine.
+//
+// RSOn is currently the only opt-in setting that exercises the
+// outer RS layer; the per-burst block interleaver schedule defined
+// in TIA-102.BBAC (MAC Layer) is documented as a follow-up because
+// the spec text was not available at implementation time. The
+// framing primitives (EncodeRS24_*, VerifyRS24_*) are spec-correct
+// per TIA-102.BAAA-A §5.9 and round-trip through unit tests.
+type RSMode uint8
+
+const (
+	RSOff RSMode = iota
+	RSOn
+)
+
+// SetRSMode toggles the outer Reed-Solomon verification layer on
+// the trellis-decoded MAC PDU window. See RSMode for the trade-offs.
+// The mode applies to every subsequent Process call; the Ingest
+// entry point is unaffected (callers that pre-parse MAC PDUs
+// don't go through this adapter).
+func (c *ControlChannel) SetRSMode(mode RSMode) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.rsMode = mode
+}
+
+// RSMode returns the current RSMode.
+func (c *ControlChannel) RSMode() RSMode {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.rsMode
+}
+
+// ParseRSMode maps a config / user-facing string into an RSMode.
+// Recognised values (case-insensitive): "" / "off" / "false" / "0"
+// → RSOff (the default — outer RS verification is off; matches the
+// historical decoder behaviour); "on" / "true" / "1" → RSOn (outer
+// RS(24, 16, 9) verification on top of trellis-decoded MAC PDU).
+// Unknown strings return RSOff with `ok = false` so callers can
+// surface the misconfiguration.
+func ParseRSMode(s string) (RSMode, bool) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "", "off", "false", "0":
+		return RSOff, true
+	case "on", "true", "1":
+		return RSOn, true
+	default:
+		return RSOff, false
 	}
 }
 

--- a/internal/radio/p25/phase2/process.go
+++ b/internal/radio/p25/phase2/process.go
@@ -53,6 +53,7 @@ func (c *ControlChannel) Process(dibits []uint8, baseIdx int) int {
 	p := c.proc
 	c.mu.Lock()
 	mode := c.trellisMode
+	rsMode := c.rsMode
 	c.mu.Unlock()
 	frameLen := macPDUDibits
 	if mode == TrellisOn {
@@ -68,7 +69,7 @@ func (c *ControlChannel) Process(dibits []uint8, baseIdx int) int {
 			p.macDibits = append(p.macDibits, d)
 			p.remaining--
 			if p.remaining == 0 {
-				c.tryIngestMACPDU(p.macDibits, mode)
+				c.tryIngestMACPDU(p.macDibits, mode, rsMode)
 				p.macDibits = p.macDibits[:0]
 			}
 		}
@@ -91,7 +92,12 @@ func (c *ControlChannel) Process(dibits []uint8, baseIdx int) int {
 //     channel dibits = the trellis-encoded form of the 72 info
 //     dibits + 1 finisher transition. DecodeP25Trellis recovers
 //     the 72 information dibits.
-func (c *ControlChannel) tryIngestMACPDU(macDibits []uint8, mode TrellisMode) {
+//
+// When rsMode is RSOn the recovered 18-byte (144-bit) MAC PDU is
+// re-grouped into 24 hex symbols and verified against the
+// RS(24, 16, 9) outer code per TIA-102.BAAA-A §5.9. PDUs whose
+// syndromes are non-zero are dropped silently.
+func (c *ControlChannel) tryIngestMACPDU(macDibits []uint8, mode TrellisMode, rsMode RSMode) {
 	var infoDibits []uint8
 	switch mode {
 	case TrellisOn:
@@ -114,9 +120,38 @@ func (c *ControlChannel) tryIngestMACPDU(macDibits []uint8, mode TrellisMode) {
 	if len(info) < 18 {
 		return
 	}
+	if rsMode == RSOn && !verifyMACPDURS(info[:18]) {
+		return
+	}
 	if pdu, err := ParseMACPDU(info[:18]); err == nil {
 		c.Ingest(pdu)
 	}
+}
+
+// verifyMACPDURS treats the 18-byte (144-bit) MAC PDU as 24 hex
+// symbols and runs the RS(24, 16, 9) outer-code syndrome check per
+// TIA-102.BAAA-A §5.9. Bit packing: the 144 information bits are
+// read MSB-first from the byte stream, then grouped into 24 6-bit
+// hex symbols where the first 6 bits form symbol 0.
+func verifyMACPDURS(pdu []byte) bool {
+	if len(pdu) != 18 {
+		return false
+	}
+	var bits [144]byte
+	for i := 0; i < 18; i++ {
+		for j := 0; j < 8; j++ {
+			bits[i*8+j] = (pdu[i] >> uint(7-j)) & 1
+		}
+	}
+	var syms [24]byte
+	for i := 0; i < 24; i++ {
+		var s byte
+		for j := 0; j < 6; j++ {
+			s = (s << 1) | bits[i*6+j]
+		}
+		syms[i] = s
+	}
+	return framing.VerifyRS24_16(syms[:])
 }
 
 // Reset clears the SyncDetector's history so a stale match doesn't

--- a/internal/radio/p25/phase2/process_rs_test.go
+++ b/internal/radio/p25/phase2/process_rs_test.go
@@ -1,0 +1,106 @@
+package phase2
+
+import (
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+)
+
+// TestParseRSMode covers the user-facing config-string → RSMode
+// mapping. Empty / off / false / 0 → RSOff (the default); on / true /
+// 1 → RSOn; everything else returns RSOff with ok = false.
+func TestParseRSMode(t *testing.T) {
+	cases := []struct {
+		in   string
+		want RSMode
+		ok   bool
+	}{
+		{"", RSOff, true},
+		{"off", RSOff, true},
+		{"OFF", RSOff, true},
+		{"false", RSOff, true},
+		{"0", RSOff, true},
+		{"on", RSOn, true},
+		{"On", RSOn, true},
+		{"true", RSOn, true},
+		{"1", RSOn, true},
+		{" on ", RSOn, true},
+		{"yes", RSOff, false},
+		{"rs", RSOff, false},
+	}
+	for _, c := range cases {
+		got, ok := ParseRSMode(c.in)
+		if got != c.want || ok != c.ok {
+			t.Errorf("ParseRSMode(%q) = (%d, %v); want (%d, %v)", c.in, got, ok, c.want, c.ok)
+		}
+	}
+}
+
+// TestSetRSModeDefault verifies the ControlChannel boots with RSOff
+// (no outer RS verification on the MAC PDU). SetRSMode round-trips
+// through RSMode().
+func TestSetRSModeDefault(t *testing.T) {
+	cc := New(Options{
+		Bus:         events.NewBus(8),
+		SystemName:  "P25P2",
+		FrequencyHz: 851_000_000,
+	})
+	if got := cc.RSMode(); got != RSOff {
+		t.Errorf("New() RSMode = %d, want %d (RSOff)", got, RSOff)
+	}
+	cc.SetRSMode(RSOn)
+	if got := cc.RSMode(); got != RSOn {
+		t.Errorf("SetRSMode(RSOn) did not take effect; RSMode = %d", got)
+	}
+	cc.SetRSMode(RSOff)
+	if got := cc.RSMode(); got != RSOff {
+		t.Errorf("SetRSMode(RSOff) did not take effect; RSMode = %d", got)
+	}
+}
+
+// TestVerifyMACPDURSAcceptsEncodedCodeword feeds an 18-byte payload
+// that has been packed from a valid 24-symbol RS(24, 16, 9) codeword
+// through verifyMACPDURS and asserts true. The reverse — flipping
+// any bit — asserts false. This exercises the bit-packing path the
+// Process adapter uses when RSMode == RSOn.
+func TestVerifyMACPDURSAcceptsEncodedCodeword(t *testing.T) {
+	info := [16]byte{0o31, 0o12, 0o42, 0o77, 0o00, 0o63, 0o25, 0o14,
+		0o55, 0o22, 0o44, 0o70, 0o03, 0o01, 0o66, 0o57}
+	cw := framing.EncodeRS24_16(info)
+	// Pack the 24 hex symbols (6 bits each) into 18 bytes MSB-first.
+	var pdu [18]byte
+	bitIdx := 0
+	for _, sym := range cw {
+		for b := 5; b >= 0; b-- {
+			if (sym>>uint(b))&1 == 1 {
+				pdu[bitIdx>>3] |= 1 << uint(7-(bitIdx&7))
+			}
+			bitIdx++
+		}
+	}
+	if !verifyMACPDURS(pdu[:]) {
+		t.Errorf("verifyMACPDURS rejected a freshly-encoded codeword")
+	}
+	// Flip the most-significant bit of the 5th symbol (bit 24 of the
+	// 144-bit stream) and confirm rejection.
+	bad := pdu
+	bad[3] ^= 0x01
+	if verifyMACPDURS(bad[:]) {
+		t.Errorf("verifyMACPDURS accepted a single-bit-flipped codeword")
+	}
+}
+
+// TestVerifyMACPDURSRejectsWrongLength confirms the helper rejects
+// any input that isn't exactly 18 bytes.
+func TestVerifyMACPDURSRejectsWrongLength(t *testing.T) {
+	if verifyMACPDURS(make([]byte, 17)) {
+		t.Errorf("verifyMACPDURS accepted 17-byte input")
+	}
+	if verifyMACPDURS(make([]byte, 19)) {
+		t.Errorf("verifyMACPDURS accepted 19-byte input")
+	}
+	if verifyMACPDURS(nil) {
+		t.Errorf("verifyMACPDURS accepted nil input")
+	}
+}

--- a/internal/scanner/ccdecoder/pipelines.go
+++ b/internal/scanner/ccdecoder/pipelines.go
@@ -200,6 +200,12 @@ func newP25Phase2Pipeline(opts PipelineOptions) (ProtocolPipeline, error) {
 			"system", opts.SystemName, "value", opts.System.P25Phase2TrellisMode)
 	}
 	cc.SetTrellisMode(trellisMode)
+	rsMode, rsOK := p25phase2.ParseRSMode(opts.System.P25Phase2RSMode)
+	if !rsOK {
+		opts.Log.Warn("ccdecoder: unrecognised p25_phase2_rs_mode; falling back to off",
+			"system", opts.SystemName, "value", opts.System.P25Phase2RSMode)
+	}
+	cc.SetRSMode(rsMode)
 	clockMode, clockOK := p25phase2rx.ParseClockMode(opts.System.P25Phase2ClockMode)
 	if !clockOK {
 		opts.Log.Warn("ccdecoder: unrecognised p25_phase2_clock_mode; falling back to gardner",

--- a/internal/trunking/site.go
+++ b/internal/trunking/site.go
@@ -168,6 +168,16 @@ type System struct {
 	// into p25phase2.ControlChannel.SetTrellisMode by the ccdecoder
 	// connector after parsing via p25phase2.ParseTrellisMode.
 	P25Phase2TrellisMode string
+	// P25Phase2RSMode enables the outer Reed-Solomon RS(24, 16, 9)
+	// verification layer on top of the trellis-decoded MAC PDU.
+	// Recognised values (case-insensitive): "" / "off" / "false" /
+	// "0" → RSOff (the default — no outer RS verification; matches
+	// historical decoder behaviour); "on" / "true" / "1" → RSOn
+	// (verify RS syndromes per TIA-102.BAAA-A §5.9; drop MAC PDUs
+	// whose syndromes are non-zero before parsing). Forwarded into
+	// p25phase2.ControlChannel.SetRSMode by the ccdecoder connector
+	// after parsing via p25phase2.ParseRSMode.
+	P25Phase2RSMode string
 	// P25Phase2ClockMode selects the symbol-timing-recovery strategy
 	// for the P25 Phase 2 receiver. Recognised values (case-
 	// insensitive): "" / "gardner" / "on" → ClockGardner (the new

--- a/internal/tui/client/types.go
+++ b/internal/tui/client/types.go
@@ -42,6 +42,7 @@ type SystemDTO struct {
 	LTRFCSMode           string `json:"ltr_fcs_mode,omitempty"`
 	LTRManchesterMode    string `json:"ltr_manchester_mode,omitempty"`
 	P25Phase2TrellisMode string `json:"p25_phase2_trellis_mode,omitempty"`
+	P25Phase2RSMode      string `json:"p25_phase2_rs_mode,omitempty"`
 	NXDNViterbiMode      string `json:"nxdn_viterbi_mode,omitempty"`
 	EDACSBCHMode         string `json:"edacs_bch_mode,omitempty"`
 	MPT1327BCHMode       string `json:"mpt1327_bch_mode,omitempty"`

--- a/internal/tui/panels/settings.go
+++ b/internal/tui/panels/settings.go
@@ -104,12 +104,13 @@ func (p *SettingsPanel) Update(msg tea.Msg, s *state.SharedState) (Panel, tea.Cm
 	// to) the FEC tab — the hash gate keeps the cost negligible.
 	if p.tab == tabFEC {
 		h := hashRows(s.Systems, func(sys client.SystemDTO) string {
-			return fmt.Sprintf("%s|%s|%d|%s|%s|%s|%s|%s|%s|%s",
+			return fmt.Sprintf("%s|%s|%d|%s|%s|%s|%s|%s|%s|%s|%s",
 				sys.Name, sys.Protocol,
 				sys.TETRAColourCode, sys.TETRAChannel,
 				sys.TETRAChannelCoding,
 				sys.LTRFCSMode, sys.LTRManchesterMode,
-				sys.P25Phase2TrellisMode, sys.NXDNViterbiMode,
+				sys.P25Phase2TrellisMode, sys.P25Phase2RSMode,
+				sys.NXDNViterbiMode,
 				sys.EDACSBCHMode)
 		})
 		if h != p.lastHash {
@@ -350,6 +351,7 @@ func fecSummary(s client.SystemDTO) string {
 		parts = append(parts, "manchester: "+orDefault(s.LTRManchesterMode, "soft"))
 	case "p25-phase2":
 		parts = append(parts, "trellis: "+orDefault(s.P25Phase2TrellisMode, "on"))
+		parts = append(parts, "rs: "+orDefault(s.P25Phase2RSMode, "off"))
 	case "nxdn":
 		parts = append(parts, "viterbi: "+orDefault(s.NXDNViterbiMode, "spec"))
 	case "edacs":


### PR DESCRIPTION
## Summary

Revisits PR E from the audit plan using the attached TIA spec PDFs as reference. Closes the **outer Reed-Solomon** half of the README's Phase 2 FEC follow-up; correctly re-attributes the still-pending **per-burst block interleaver** half from TIA-102.BBAB (cited in the old README) to TIA-102.BBAC (the actual MAC Layer spec).

- New `internal/radio/framing/rs_gf64.go`: three shortened RS codes over GF(2^6) per **TIA-102.BAAA-A §5.9** — `RS(24, 12, 13)` (GLC), `RS(24, 16, 9)` (GES), `RS(36, 20, 17)` (PHDR). Encoder + syndrome verifier for each; primitive polynomial α⁶ + α + 1; generator matrices transcribed from the spec.
- Phase 2 `ControlChannel.SetRSMode(RSOn)` runs `RS(24, 16, 9)` syndrome verification on top of the trellis-decoded 18-byte MAC PDU; PDUs with non-zero syndromes drop at the framing layer before `ParseMACPDU`.
- Wired through `config.yaml` (`p25_phase2_rs_mode: on`) → `trunking.System` → `ccdecoder.newP25Phase2Pipeline` → `SetRSMode`, with the API DTO + TUI Settings panel rendering the configured mode.
- Default stays `RSOff` so historical decoder behaviour is unchanged.

## Why the README spec citation was wrong

The old README pointed at TIA-102.**BBAB** as the missing spec. Reading the actual PDF: BBAB is the physical-layer spec (modulation + burst structure) and contains no FEC content. The outer RS codes live in TIA-102.**BAAA-A** §5.9 (Phase 1 CAI), which Phase 2 reuses on top of its inner trellis layer. The per-burst block interleaver schedule lives in TIA-102.**BBAC** (Two-Slot TDMA MAC Layer), still needs spec access. `docs/opt-in-features.md` §5 is corrected.

## Test plan

- [x] `go test ./internal/radio/framing/...` — GF(2^6) field closure, multiplicative identity, round-trip encode/verify for all three codes, single-bit corruption detection, invalid length / out-of-field-range rejection
- [x] `go test ./internal/radio/p25/phase2/...` — `ParseRSMode` coverage, default `RSOff` boot, `verifyMACPDURS` bit-packing round-trip via `EncodeRS24_16`, single-bit flip rejection, wrong-length rejection
- [x] `go test ./...` — full suite green
- [x] `go test -tags integration ./cmd/gophertrunk/...` — green
- [x] `go vet ./...` — clean

https://claude.ai/code/session_01Q3vP5jeF8GbKzr4G5nxFwD

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q3vP5jeF8GbKzr4G5nxFwD)_