### PR TITLE
internal/voice/dvsi: DVSI USB-3000 / AMBE-3003 backend scaffolding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,3 +89,22 @@ jobs:
         env:
           CGO_ENABLED: "0"
         run: go test -count=1 ./internal/sdr/rtlsdr/usb/...
+
+  # dvsi exercises the patent-encumbered DVSI USB-3000 / AMBE-3003
+  # hardware backend behind the `-tags dvsi` build tag. The tagged
+  # tests use a scripted mock Transport and a software-loopback
+  # Transport so the wire protocol + Vocoder state machine + the
+  # voice.Vocoder interface conformance run in CI without a real chip.
+  dvsi:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+      - name: Vet (tagged)
+        run: go vet -tags dvsi ./internal/voice/dvsi/...
+      - name: Build (tagged)
+        run: go build -tags dvsi ./internal/voice/dvsi/...
+      - name: Test (tagged)
+        run: make test-dvsi

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ TAGS    ?=
 GO      ?= go
 PKGS    := ./...
 
-.PHONY: all build test integration integration-cc integration-cc-grant integration-cc-nxdn integration-cc-dmr integration-cc-dpmr integration-cc-edacs integration-cc-motorola integration-cc-tetra integration-cc-p25p2 integration-cc-mpt1327 integration-cc-ltr integration-cc-ysf lint tidy vet clean run proto cross-build release-archives
+.PHONY: all build test test-dvsi integration integration-cc integration-cc-grant integration-cc-nxdn integration-cc-dmr integration-cc-dpmr integration-cc-edacs integration-cc-motorola integration-cc-tetra integration-cc-p25p2 integration-cc-mpt1327 integration-cc-ltr integration-cc-ysf lint tidy vet clean run proto cross-build release-archives
 
 all: build
 
@@ -14,6 +14,16 @@ build:
 
 test:
 	$(GO) test -tags "$(TAGS)" -race -count=1 $(PKGS)
+
+# test-dvsi runs the DVSI hardware-backend tests under the -tags dvsi
+# build. The Vocoder + Transport + USB-enumeration codepath is gated
+# behind the build tag (patent-encumbered AMBE+2 hardware backend
+# documented in docs/vocoders.md). The tagged unit tests use a
+# scripted mock Transport and a software-loopback Transport so the
+# wire protocol + Vocoder state machine + voice.Vocoder interface
+# conformance all exercise in CI without a real DVSI USB-3000.
+test-dvsi:
+	$(GO) test -tags "dvsi $(TAGS)" -race -count=1 ./internal/voice/dvsi/...
 
 # integration boots the wired daemon (no real SDR) end-to-end and asserts
 # the engine + recorder + call log + metrics + API agree on a synthetic

--- a/README.md
+++ b/README.md
@@ -281,12 +281,18 @@ sourcing.
 What's still on the table. Order isn't fixed; each item is contained
 to its own package and lands independently.
 
-- **DVSI USB-3000 / AMBE-3003 hardware backend.** A `Vocoder`
-  factory that opens a connected DVSI USB chip. Same plug-in shape
-  as `internal/voice/ambe2`; the daemon picks the factory by name
-  from `voice.DefaultRegistry`. Useful for operators who want
-  vendor-blessed AMBE+2 decode on jurisdictions where the patent
-  posture matters.
+- **DVSI USB-3000 / AMBE-3003 hardware backend (USB transport).**
+  The `Vocoder` + AMBE-3003 wire protocol + `voice.Vocoder` interface
+  conformance ship in [`internal/voice/dvsi/`](internal/voice/dvsi/)
+  behind `-tags dvsi`; the package's `init()` registers `"dvsi"`
+  with `voice.DefaultRegistry`. CI exercises the wire protocol +
+  Vocoder plumbing through the scripted mock Transport and the
+  software-loopback Transport (`make test-dvsi`). The USB / FTDI
+  bulk-endpoint plumbing that talks to a physical chip remains a
+  stub returning `ErrNoDevice` — the recorder fallback chain
+  activates cleanly when no chip is connected. The actual FTDI
+  hardware integration lands when a DVSI USB-3000 is available for
+  round-trip testing.
 - **Vocoder level calibration.** Pure-Go IMBE / AMBE+2 produce real
   audio end-to-end today. Absolute-level calibration against a
   DSD-FME or OP25 reference recording (capture a P25 P1 / DMR voice

--- a/docs/opt-in-features.md
+++ b/docs/opt-in-features.md
@@ -124,7 +124,7 @@ to flip on by default.
 
 | Feature | Mechanism | Default | Why |
 | --- | --- | --- | --- |
-| **DVSI hardware vocoder backend** | `-tags dvsi` build tag ([`docs/architecture.md`](architecture.md), [`docs/vocoders.md`](vocoders.md)) | Not built | Patent-encumbered. Requires DVSI USB-3000 / AMBE-3003 hardware. Status: planned, not yet shipped. The pure-Go AMBE+2 backend is the default and ships everywhere. Stays opt-in permanently for licensing reasons. |
+| **DVSI hardware vocoder backend** | `-tags dvsi` build tag ([`docs/architecture.md`](architecture.md), [`docs/vocoders.md`](vocoders.md)) | Not built | Patent-encumbered. Requires DVSI USB-3000 / AMBE-3003 hardware. Status: Vocoder + AMBE-3003 wire protocol + voice.Vocoder interface conformance shipping behind the build tag (`internal/voice/dvsi/`); USB / FTDI transport that talks to the physical chip is a stub returning `ErrNoDevice`. Recorder fallback chain activates cleanly when no chip is connected. `make test-dvsi` exercises the wire protocol + scripted-mock Transport + loopback Transport without hardware. The pure-Go AMBE+2 backend is the default and ships everywhere. Stays opt-in permanently for licensing reasons. |
 | **Integration tests** | `-tags integration` build tag | Not run by `go test ./...` | Enables a wired end-to-end daemon test that doesn't need a real SDR. Long-running, intentionally outside the default unit-test wall-time budget. CI runs the tagged suite separately. |
 | **Pure-Go (no CGO)** | implicit `CGO_ENABLED=0` build | On | Already the default everywhere — no `librtlsdr` / `libusb` dependency. Listed for completeness because the README emphasises it as a design property. |
 

--- a/docs/vocoders.md
+++ b/docs/vocoders.md
@@ -44,7 +44,7 @@ type Vocoder interface {
 | `null` (silence)         | none         | yes      | Always available                                |
 | `imbe` (pure-Go, P25 P1) | none         | yes      | Producing intelligible audio; calibration TODO  |
 | `ambe2` (pure-Go)        | none         | yes      | Producing audio; calibration TODO; dual-tone → silence |
-| `dvsi` (USB-3000 chip)   | `-tags dvsi` | **no**   | Hardware backend, planned                       |
+| `dvsi` (USB-3000 chip)   | `-tags dvsi` | **no**   | Wire-protocol + Vocoder scaffolding shipping; USB transport stub (returns `ErrNoDevice`) — hardware integration follows in a separate PR |
 
 ### Live-pipeline auto-decode
 
@@ -153,10 +153,39 @@ This is exactly what SDR# / OP25 / DSD do. The key benefits:
 
 1. The default binary has no external library dependencies for voice
    (no CGO, no system shared library, no install scripts).
-2. Users with DVSI hardware can opt in by building with `-tags dvsi`
-   once that backend lands.
+2. Users with DVSI hardware can opt in by building with `-tags dvsi`.
+   The Vocoder + AMBE-3003 wire protocol + voice.Vocoder interface
+   conformance ship in [`internal/voice/dvsi/`](../internal/voice/dvsi/);
+   the USB / FTDI transport that talks to the physical chip is a stub
+   today (returns `ErrNoDevice`) so the recorder fallback chain
+   activates cleanly. Hardware integration with a real DVSI USB-3000
+   lands in a follow-up. CI exercises the wire protocol + Vocoder
+   plumbing via the scripted mock Transport and the
+   software-loopback Transport (`Options{LoopbackOnly: true}`); both
+   live behind the `-tags dvsi` build tag.
 3. Captures contain raw frames so a researcher can defer the decoding
    choice to post-processing.
+
+## DVSI backend layout (`-tags dvsi`)
+
+[`internal/voice/dvsi/`](../internal/voice/dvsi/):
+
+- `packet.go` — AMBE-3003 wire format (sync byte + length + type +
+  payload). Always compiled — no patent surface in describing a
+  serial wire protocol.
+- `doc.go` — exports `VocoderName = "dvsi"` so config validation
+  paths can reference the key without `-tags dvsi` linked in.
+- `dvsi_enabled.go` (`//go:build dvsi`) — `Vocoder`, `Transport`
+  interface, `loopbackTransport`, `openUSBTransport` stub, and the
+  `init()` registration into `voice.DefaultRegistry`.
+- `dvsi_disabled.go` (`//go:build !dvsi`) — empty; default builds
+  link nothing from the DVSI codepath.
+- `dvsi_test.go` (`//go:build dvsi`) — Vocoder interface
+  conformance, loopback round-trip, scripted-mock wire-format
+  verification, frame-size validation, unexpected-reply rejection.
+
+`make test-dvsi` runs the tagged unit tests; the `dvsi` CI job runs
+the same target on Ubuntu.
 
 ## Future work
 
@@ -167,7 +196,10 @@ This is exactly what SDR# / OP25 / DSD do. The key benefits:
   already synthesise a sinewave at b₁·31.25 Hz with cross-frame
   phase continuity; dual-tone requires an AMBE+2-specific
   (b₁ → freq_a, freq_b) lookup the public spec doesn't document.
-- DVSI USB-3000 / AMBE-3003 hardware backend (`-tags dvsi`).
+- DVSI USB-3000 / AMBE-3003 USB / FTDI transport implementation —
+  the wire-protocol + Vocoder + interface conformance ship now;
+  the actual USB bulk-IN / bulk-OUT plumbing follows when a chip is
+  available for round-trip testing.
 - Optional Opus / FLAC re-encoding of the recorded WAVs to shrink
   long-running archives.
 - Plain AMBE decoder for D-STAR voice (different algorithm from AMBE+2;

--- a/internal/voice/dvsi/doc.go
+++ b/internal/voice/dvsi/doc.go
@@ -1,0 +1,50 @@
+// Package dvsi implements the DVSI USB-3000 / AMBE-3003 hardware
+// vocoder backend.
+//
+// # Build tag
+//
+// The Vocoder, Transport, USB enumeration, and registration into
+// voice.DefaultRegistry all live under the `dvsi` build tag. Default
+// builds (`go build`, `go test`) compile only the patent-surface-free
+// packet framing — VocoderName, the AMBE-3003 wire protocol encoder/
+// decoder, and this package documentation — so nothing in the binary
+// pulls in the DVSI codepath unless an operator has opted in.
+//
+//	go build -tags dvsi ./cmd/gophertrunk     # links the DVSI backend
+//	go test  -tags dvsi ./internal/voice/dvsi # runs the tagged tests
+//
+// # Patent posture
+//
+// AMBE+2 decoding is patent-encumbered. The default GopherTrunk build
+// ships the pure-Go ambe2.Decoder which produces real audio under the
+// open-source-license posture documented in docs/vocoders.md. The
+// DVSI backend exists for operators in jurisdictions where vendor-
+// blessed AMBE+2 decode is required; it expects a connected DVSI
+// USB-3000 (FTDI-FT2232H-based USB device, VID 0x0403 / PID 0x6010)
+// or AMBE-3003 module reachable through a compatible FTDI transport.
+//
+// # Loopback mode (testing only)
+//
+// Options{LoopbackOnly: true} substitutes a software loopback for the
+// USB transport so the AMBE-3003 wire protocol, factory plumbing, and
+// voice.Vocoder interface conformance can be exercised in CI without a
+// real chip. The loopback transport returns synthesized PCM-silence
+// SpeechData packets; it does NOT decode AMBE+2 (the whole point of
+// the DVSI backend is to outsource the patent surface to hardware).
+// Operators must never enable LoopbackOnly outside tests — it would
+// produce silence on a real call.
+//
+// # Registration
+//
+// Under `-tags dvsi` the package init() registers "dvsi" in
+// voice.DefaultRegistry pointing at Open(DefaultOptions()). The
+// recorder picks the factory by name from per-system config; if no
+// USB device matches the configured VID/PID, Open returns
+// ErrNoDevice and the recorder falls back to the operator's chosen
+// non-DVSI vocoder.
+package dvsi
+
+// VocoderName is the registry key the recorder uses to select the
+// DVSI backend. Lives outside the build-tagged Vocoder so callers can
+// reference the name from non-DVSI builds (e.g. for config validation).
+const VocoderName = "dvsi"

--- a/internal/voice/dvsi/dvsi_disabled.go
+++ b/internal/voice/dvsi/dvsi_disabled.go
@@ -1,0 +1,7 @@
+//go:build !dvsi
+
+package dvsi
+
+// Default build: no DVSI registration, no Vocoder type, no Transport.
+// VocoderName is exported from doc.go so config validation paths can
+// reference the key without -tags dvsi linked in.

--- a/internal/voice/dvsi/dvsi_enabled.go
+++ b/internal/voice/dvsi/dvsi_enabled.go
@@ -1,0 +1,260 @@
+//go:build dvsi
+
+package dvsi
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/MattCheramie/GopherTrunk/internal/voice"
+)
+
+// FrameBytes is the input byte count per AMBE+2 frame, matching
+// internal/voice/ambe2.FrameBytes (49 bits packed into 7 bytes with
+// 7 padding bits). The DVSI Vocoder.FrameSize() returns this so
+// recorders can stride raw-frame inputs uniformly across the pure-Go
+// and hardware backends.
+const FrameBytes = 7
+
+// SpeechFrameSamples is the per-frame PCM sample count at 8 kHz mono
+// (20 ms × 8 kHz). The AMBE-3003 chip's PktSpeechData payload is
+// 2 × SpeechFrameSamples bytes (320 bytes, little-endian int16).
+const SpeechFrameSamples = 160
+
+// SpeechFrameBytes is the on-wire byte count of a PktSpeechData
+// payload.
+const SpeechFrameBytes = 2 * SpeechFrameSamples
+
+// Default USB identifiers for the DVSI USB-3000 (FTDI FT2232H-based).
+// Operators with custom-VID modules override via Options.
+const (
+	DefaultUSBVendorID  uint16 = 0x0403 // FTDI
+	DefaultUSBProductID uint16 = 0x6010 // FT2232H Dual UART/FIFO
+)
+
+// ErrNoDevice is returned by Open when no FTDI device matching the
+// configured VID/PID is enumerated. Recorders fall back to the
+// operator's configured non-DVSI vocoder when this surfaces.
+var ErrNoDevice = errors.New("dvsi: no FTDI device matching VID/PID")
+
+// ErrUnexpectedReply is returned by Decode when the chip's response
+// isn't a PktSpeechData of the expected length.
+var ErrUnexpectedReply = errors.New("dvsi: unexpected reply from chip")
+
+// Transport is the byte-stream abstraction the Vocoder uses to talk
+// to the AMBE-3003 chip. The real implementation (usbTransport)
+// wraps an FTDI bulk-IN/bulk-OUT pair; tests use mockTransport for
+// scripted exchanges and loopbackTransport for software-only CI.
+//
+// Write writes one fully-framed packet (PacketSyncByte + length +
+// type + payload, as EncodePacket produces). Read returns the next
+// fully-framed packet, allocating fresh.
+type Transport interface {
+	Write(packet []byte) error
+	Read() ([]byte, error)
+	Close() error
+}
+
+// Options configures a Vocoder. Zero-valued fields fall back to the
+// Default* constants. Most operators leave LoopbackOnly false and set
+// nothing else; integration tests with hardware override the USB
+// identifiers; CI runs with LoopbackOnly = true.
+type Options struct {
+	// USBVendorID / USBProductID select the FTDI device to claim.
+	// 0 falls back to DefaultUSBVendorID / DefaultUSBProductID.
+	USBVendorID  uint16
+	USBProductID uint16
+
+	// SerialMatch, when non-empty, restricts enumeration to FTDI
+	// devices whose iSerialNumber descriptor matches exactly.
+	// Useful on multi-chip hosts.
+	SerialMatch string
+
+	// Transport overrides the default USB transport. Intended for
+	// tests; production code leaves this nil and Open constructs a
+	// real usbTransport (or returns ErrNoDevice). When set, the
+	// supplied Transport's lifetime is owned by the returned
+	// Vocoder — Close shuts it down.
+	Transport Transport
+
+	// LoopbackOnly switches Open to construct a software-loopback
+	// Transport that synthesises silent PktSpeechData responses to
+	// every PktChannelData request. Exercises packet framing + the
+	// Vocoder state machine + the voice.Vocoder interface contract
+	// in CI without a real chip. NEVER set this in production —
+	// every call decodes to silence.
+	LoopbackOnly bool
+}
+
+// DefaultOptions returns Options with VID/PID set to the
+// DVSI USB-3000 defaults and LoopbackOnly off.
+func DefaultOptions() Options {
+	return Options{
+		USBVendorID:  DefaultUSBVendorID,
+		USBProductID: DefaultUSBProductID,
+	}
+}
+
+// Vocoder is the DVSI hardware backend. Implements voice.Vocoder.
+type Vocoder struct {
+	t      Transport
+	closed bool
+}
+
+// Open constructs a Vocoder ready to serve Decode calls. Returns
+// ErrNoDevice (wrapped) when no FTDI device matching opts is
+// enumerated, unless LoopbackOnly is true or opts.Transport is
+// non-nil.
+func Open(opts Options) (*Vocoder, error) {
+	if opts.USBVendorID == 0 {
+		opts.USBVendorID = DefaultUSBVendorID
+	}
+	if opts.USBProductID == 0 {
+		opts.USBProductID = DefaultUSBProductID
+	}
+	var t Transport
+	switch {
+	case opts.Transport != nil:
+		t = opts.Transport
+	case opts.LoopbackOnly:
+		t = newLoopbackTransport()
+	default:
+		usb, err := openUSBTransport(opts)
+		if err != nil {
+			return nil, err
+		}
+		t = usb
+	}
+	return &Vocoder{t: t}, nil
+}
+
+// Name returns "dvsi", matching the registry key.
+func (v *Vocoder) Name() string { return VocoderName }
+
+// FrameSize returns the per-frame input byte count (7).
+func (v *Vocoder) FrameSize() int { return FrameBytes }
+
+// Decode sends frame as a PktChannelData packet, reads the chip's
+// PktSpeechData response, and returns SpeechFrameSamples of 16-bit
+// little-endian PCM.
+func (v *Vocoder) Decode(frame []byte) ([]int16, error) {
+	if v.closed {
+		return nil, errors.New("dvsi: Decode after Close")
+	}
+	if len(frame) != FrameBytes {
+		return nil, fmt.Errorf("dvsi: frame must be %d bytes, got %d", FrameBytes, len(frame))
+	}
+	if err := v.t.Write(EncodePacket(PktChannelData, frame)); err != nil {
+		return nil, fmt.Errorf("dvsi: transport write: %w", err)
+	}
+	reply, err := v.t.Read()
+	if err != nil {
+		return nil, fmt.Errorf("dvsi: transport read: %w", err)
+	}
+	typ, payload, err := DecodePacket(reply)
+	if err != nil {
+		return nil, fmt.Errorf("dvsi: decode reply: %w", err)
+	}
+	if typ != PktSpeechData {
+		return nil, fmt.Errorf("%w: got type %#x, want PktSpeechData %#x",
+			ErrUnexpectedReply, typ, PktSpeechData)
+	}
+	if len(payload) != SpeechFrameBytes {
+		return nil, fmt.Errorf("%w: payload %d bytes, want %d",
+			ErrUnexpectedReply, len(payload), SpeechFrameBytes)
+	}
+	samples := make([]int16, SpeechFrameSamples)
+	for i := 0; i < SpeechFrameSamples; i++ {
+		samples[i] = int16(binary.LittleEndian.Uint16(payload[i*2 : i*2+2]))
+	}
+	return samples, nil
+}
+
+// Reset is a no-op for the DVSI backend — the chip carries no
+// across-call state once a PktSpeechData has been returned.
+func (v *Vocoder) Reset() {}
+
+// Close releases the underlying transport. Idempotent.
+func (v *Vocoder) Close() error {
+	if v.closed {
+		return nil
+	}
+	v.closed = true
+	if v.t == nil {
+		return nil
+	}
+	return v.t.Close()
+}
+
+// Compile-time check that Vocoder satisfies voice.Vocoder.
+var _ voice.Vocoder = (*Vocoder)(nil)
+
+func init() {
+	voice.DefaultRegistry.Register(VocoderName, func() (voice.Vocoder, error) {
+		return Open(DefaultOptions())
+	})
+}
+
+// loopbackTransport synthesises silent PktSpeechData responses to
+// every PktChannelData request. Exercises the full packet roundtrip
+// in CI without a real chip. NEVER use outside tests.
+type loopbackTransport struct {
+	pending []byte // staged reply for the next Read call
+	closed  bool
+}
+
+func newLoopbackTransport() *loopbackTransport { return &loopbackTransport{} }
+
+func (l *loopbackTransport) Write(packet []byte) error {
+	if l.closed {
+		return io.ErrClosedPipe
+	}
+	typ, _, err := DecodePacket(packet)
+	if err != nil {
+		return err
+	}
+	switch typ {
+	case PktChannelData:
+		// Stage a 320-byte zero-PCM SpeechData reply.
+		silence := make([]byte, SpeechFrameBytes)
+		l.pending = EncodePacket(PktSpeechData, silence)
+	case PktControl:
+		// Mirror as Ack.
+		l.pending = EncodePacket(PktAck, nil)
+	default:
+		// Unknown packet types: ack and move on.
+		l.pending = EncodePacket(PktAck, nil)
+	}
+	return nil
+}
+
+func (l *loopbackTransport) Read() ([]byte, error) {
+	if l.closed {
+		return nil, io.ErrClosedPipe
+	}
+	if l.pending == nil {
+		return nil, errors.New("dvsi loopback: Read with no pending reply")
+	}
+	out := l.pending
+	l.pending = nil
+	return out, nil
+}
+
+func (l *loopbackTransport) Close() error {
+	l.closed = true
+	return nil
+}
+
+// openUSBTransport constructs a real USB transport against an FTDI
+// device matching opts.USBVendorID / USBProductID. The actual FTDI
+// MPSSE / bulk-endpoint plumbing lands in a follow-up — the public
+// USB transport interface is in place, and operators with hardware
+// can replace this stub. Today this returns ErrNoDevice
+// unconditionally so the recorder's fallback chain takes over and
+// the build still links cleanly under -tags dvsi.
+func openUSBTransport(opts Options) (Transport, error) {
+	return nil, fmt.Errorf("%w: USB transport stub — hardware integration follows in a separate PR (VID=%#04x PID=%#04x serial=%q)",
+		ErrNoDevice, opts.USBVendorID, opts.USBProductID, opts.SerialMatch)
+}

--- a/internal/voice/dvsi/dvsi_test.go
+++ b/internal/voice/dvsi/dvsi_test.go
@@ -1,0 +1,259 @@
+//go:build dvsi
+
+package dvsi
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/voice"
+)
+
+// TestVocoderInterfaceConformance is the compile-time + runtime
+// check that *Vocoder satisfies voice.Vocoder. The compile-time
+// assertion is at the end of dvsi_enabled.go; this test confirms the
+// runtime values match too.
+func TestVocoderInterfaceConformance(t *testing.T) {
+	v, err := Open(Options{LoopbackOnly: true})
+	if err != nil {
+		t.Fatalf("Open loopback: %v", err)
+	}
+	defer v.Close()
+	var _ voice.Vocoder = v
+	if v.Name() != VocoderName {
+		t.Errorf("Name() = %q, want %q", v.Name(), VocoderName)
+	}
+	if v.FrameSize() != FrameBytes {
+		t.Errorf("FrameSize() = %d, want %d", v.FrameSize(), FrameBytes)
+	}
+}
+
+// TestVocoderRegisteredInRegistry confirms the init() side effect:
+// after importing this package under -tags dvsi, the
+// voice.DefaultRegistry contains the "dvsi" name. The factory call
+// itself will hit ErrNoDevice (no real chip) but the registration is
+// what matters.
+func TestVocoderRegisteredInRegistry(t *testing.T) {
+	names := voice.DefaultRegistry.Names()
+	found := false
+	for _, n := range names {
+		if n == VocoderName {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("voice.DefaultRegistry doesn't contain %q; names = %v",
+			VocoderName, names)
+	}
+
+	// The factory call returns ErrNoDevice on this test host (no
+	// hardware) — that's the expected fall-through behaviour the
+	// recorder's fallback chain handles.
+	_, err := voice.DefaultRegistry.New(VocoderName)
+	if !errors.Is(err, ErrNoDevice) {
+		t.Errorf("New(%q) err = %v, want ErrNoDevice", VocoderName, err)
+	}
+}
+
+// TestVocoderLoopbackRoundTrip exercises the full
+// AMBE+2-frame -> packet -> transport -> packet -> PCM-decode chain
+// against the loopback transport. Confirms FrameSize(),
+// Decode([]byte), and Reset()/Close() all wire up correctly.
+func TestVocoderLoopbackRoundTrip(t *testing.T) {
+	v, err := Open(Options{LoopbackOnly: true})
+	if err != nil {
+		t.Fatalf("Open loopback: %v", err)
+	}
+	defer v.Close()
+
+	frame := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07}
+	pcm, err := v.Decode(frame)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if len(pcm) != SpeechFrameSamples {
+		t.Errorf("len(pcm) = %d, want %d", len(pcm), SpeechFrameSamples)
+	}
+	// Loopback returns silence — every sample should be 0.
+	for i, s := range pcm {
+		if s != 0 {
+			t.Errorf("pcm[%d] = %d, want 0 (loopback silence)", i, s)
+			break
+		}
+	}
+
+	// Reset is a no-op but should never error.
+	v.Reset()
+
+	// Close + double-close should be idempotent.
+	if err := v.Close(); err != nil {
+		t.Errorf("Close: %v", err)
+	}
+	if err := v.Close(); err != nil {
+		t.Errorf("double Close: %v", err)
+	}
+
+	// Decode after Close fails cleanly (no panic).
+	if _, err := v.Decode(frame); err == nil {
+		t.Error("Decode after Close: want error, got nil")
+	}
+}
+
+// TestVocoderRejectsWrongFrameSize confirms the Vocoder validates
+// frame length before serialising the packet, so callers can't
+// accidentally send malformed input to the chip.
+func TestVocoderRejectsWrongFrameSize(t *testing.T) {
+	v, err := Open(Options{LoopbackOnly: true})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer v.Close()
+
+	if _, err := v.Decode(make([]byte, FrameBytes-1)); err == nil {
+		t.Error("Decode with short frame: want error, got nil")
+	}
+	if _, err := v.Decode(make([]byte, FrameBytes+1)); err == nil {
+		t.Error("Decode with long frame: want error, got nil")
+	}
+}
+
+// scriptedTransport is a deterministic mock that asserts the
+// outgoing packet shape and returns a scripted reply. Used to verify
+// the wire protocol byte-by-byte without a chip or the loopback's
+// silence shortcut.
+type scriptedTransport struct {
+	t            *testing.T
+	expectedOut  []byte
+	reply        []byte
+	writeCalled  int
+	readCalled   int
+	closeCalled  int
+	readNoPending bool
+}
+
+func (s *scriptedTransport) Write(packet []byte) error {
+	s.writeCalled++
+	if !bytes.Equal(packet, s.expectedOut) {
+		s.t.Errorf("Write packet mismatch:\n got: %x\nwant: %x", packet, s.expectedOut)
+	}
+	return nil
+}
+
+func (s *scriptedTransport) Read() ([]byte, error) {
+	s.readCalled++
+	if s.readNoPending {
+		return nil, io.EOF
+	}
+	return s.reply, nil
+}
+
+func (s *scriptedTransport) Close() error {
+	s.closeCalled++
+	return nil
+}
+
+// TestVocoderScriptedExchange asserts the wire-format bytes a Vocoder
+// produces match the AMBE-3003 datasheet exactly: a
+// PktChannelData packet wrapping the 7-byte AMBE+2 frame, followed by
+// reading a PktSpeechData reply and unpacking it as little-endian
+// int16 PCM samples.
+func TestVocoderScriptedExchange(t *testing.T) {
+	frame := []byte{0xAA, 0x55, 0xCA, 0xFE, 0xBA, 0xBE, 0xDE}
+	// Build the expected outgoing packet by hand: sync, big-endian
+	// length covering type + payload, PktChannelData byte, frame.
+	wantOut := []byte{
+		PacketSyncByte,
+		0x00, 0x08, // length = 1 (type) + 7 (frame) = 8
+		byte(PktChannelData),
+	}
+	wantOut = append(wantOut, frame...)
+
+	// Build the chip's "reply" packet — 320 bytes of nonzero PCM so
+	// we know the Vocoder unpacks rather than just zeros.
+	pcm := make([]int16, SpeechFrameSamples)
+	for i := range pcm {
+		pcm[i] = int16(i - 80) // -80, -79, ..., +79
+	}
+	replyPayload := make([]byte, SpeechFrameBytes)
+	for i, s := range pcm {
+		binary.LittleEndian.PutUint16(replyPayload[i*2:i*2+2], uint16(s))
+	}
+	reply := EncodePacket(PktSpeechData, replyPayload)
+
+	scripted := &scriptedTransport{t: t, expectedOut: wantOut, reply: reply}
+	v, err := Open(Options{Transport: scripted})
+	if err != nil {
+		t.Fatalf("Open with scripted transport: %v", err)
+	}
+
+	got, err := v.Decode(frame)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if scripted.writeCalled != 1 {
+		t.Errorf("Write called %d times, want 1", scripted.writeCalled)
+	}
+	if scripted.readCalled != 1 {
+		t.Errorf("Read called %d times, want 1", scripted.readCalled)
+	}
+	for i := range pcm {
+		if got[i] != pcm[i] {
+			t.Errorf("pcm[%d] = %d, want %d", i, got[i], pcm[i])
+			break
+		}
+	}
+
+	if err := v.Close(); err != nil {
+		t.Errorf("Close: %v", err)
+	}
+	if scripted.closeCalled != 1 {
+		t.Errorf("transport Close called %d times, want 1", scripted.closeCalled)
+	}
+}
+
+// TestVocoderRejectsUnexpectedReply confirms a chip reply that's not
+// a PktSpeechData (or has the wrong payload length) surfaces as
+// ErrUnexpectedReply rather than corrupting the PCM stream.
+func TestVocoderRejectsUnexpectedReply(t *testing.T) {
+	frame := make([]byte, FrameBytes)
+	cases := []struct {
+		name  string
+		reply []byte
+	}{
+		{"ack_instead_of_speech", EncodePacket(PktAck, nil)},
+		{"short_speech_payload", EncodePacket(PktSpeechData, make([]byte, SpeechFrameBytes/2))},
+		{"control_packet", EncodePacket(PktControl, []byte{0x01, 0x02})},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			scripted := &scriptedTransport{
+				t:           t,
+				expectedOut: EncodePacket(PktChannelData, frame),
+				reply:       tc.reply,
+			}
+			v, err := Open(Options{Transport: scripted})
+			if err != nil {
+				t.Fatalf("Open: %v", err)
+			}
+			defer v.Close()
+			_, err = v.Decode(frame)
+			if !errors.Is(err, ErrUnexpectedReply) {
+				t.Errorf("err = %v, want ErrUnexpectedReply", err)
+			}
+		})
+	}
+}
+
+// TestOpenWithoutHardwareReturnsErrNoDevice confirms the
+// no-Transport, no-LoopbackOnly path returns the sentinel error so
+// the recorder fallback chain works as documented.
+func TestOpenWithoutHardwareReturnsErrNoDevice(t *testing.T) {
+	_, err := Open(DefaultOptions())
+	if !errors.Is(err, ErrNoDevice) {
+		t.Errorf("Open(DefaultOptions()) err = %v, want ErrNoDevice", err)
+	}
+}

--- a/internal/voice/dvsi/packet.go
+++ b/internal/voice/dvsi/packet.go
@@ -1,0 +1,123 @@
+package dvsi
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+)
+
+// AMBE-3003 packet wire format (per DVSI's public datasheet):
+//
+//	[0x61] [len_hi] [len_lo] [type] [payload bytes...]
+//
+//	- 0x61 is the fixed sync byte at the start of every packet.
+//	- length is big-endian and covers the type byte + payload (so a
+//	  zero-payload packet has length=1).
+//	- type identifies the packet's purpose; see PacketType constants.
+//
+// The framing primitives are unconditionally compiled (no build tag)
+// because they're pure data — there's no patent surface in describing
+// the chip's serial wire protocol. The Vocoder that actually talks to
+// the chip lives under //go:build dvsi.
+
+// PacketSyncByte is the first byte of every AMBE-3003 packet.
+const PacketSyncByte byte = 0x61
+
+// PacketHeaderBytes is the byte count of the fixed packet header
+// (sync + 2-byte length + 1-byte type) before the payload begins.
+const PacketHeaderBytes = 4
+
+// PacketType is the 1-byte type field of an AMBE-3003 packet.
+type PacketType byte
+
+const (
+	// PktControl carries configuration / status exchanges with the
+	// chip (sample-rate setup, channel-format selection, etc.).
+	PktControl PacketType = 0x00
+
+	// PktChannelData carries a 49-bit AMBE+2 frame (packed in 7
+	// bytes) from the host to the chip for speech synthesis, or
+	// from the chip to the host for encode operations.
+	PktChannelData PacketType = 0x01
+
+	// PktSpeechData carries 160 samples of 16-bit signed PCM
+	// (320 bytes, little-endian) at 8 kHz mono — one 20 ms voice
+	// frame.
+	PktSpeechData PacketType = 0x02
+
+	// PktAck is the chip's response to a control request.
+	PktAck PacketType = 0x06
+)
+
+// ErrPacketTooShort is returned by DecodePacket when the input buffer
+// is shorter than the fixed header length.
+var ErrPacketTooShort = errors.New("dvsi: packet shorter than header")
+
+// ErrPacketBadSync is returned by DecodePacket when the first byte
+// isn't PacketSyncByte.
+var ErrPacketBadSync = errors.New("dvsi: packet missing sync byte")
+
+// ErrPacketLengthMismatch is returned by DecodePacket when the
+// declared length doesn't match the supplied buffer.
+var ErrPacketLengthMismatch = errors.New("dvsi: packet length mismatch")
+
+// EncodePacket serialises a single AMBE-3003 packet. The caller writes
+// the result directly to the FTDI bulk-OUT endpoint. payload may be
+// nil for zero-length control acks.
+func EncodePacket(typ PacketType, payload []byte) []byte {
+	out := make([]byte, PacketHeaderBytes+len(payload))
+	out[0] = PacketSyncByte
+	// length covers the type byte + payload (per the datasheet).
+	binary.BigEndian.PutUint16(out[1:3], uint16(1+len(payload)))
+	out[3] = byte(typ)
+	copy(out[PacketHeaderBytes:], payload)
+	return out
+}
+
+// DecodePacket parses one AMBE-3003 packet from b and returns the
+// type + payload slice (which aliases into b — copy before mutating).
+// The slice b must contain exactly one packet; trailing bytes are
+// rejected with ErrPacketLengthMismatch.
+func DecodePacket(b []byte) (PacketType, []byte, error) {
+	if len(b) < PacketHeaderBytes {
+		return 0, nil, fmt.Errorf("%w: got %d bytes, want >= %d",
+			ErrPacketTooShort, len(b), PacketHeaderBytes)
+	}
+	if b[0] != PacketSyncByte {
+		return 0, nil, fmt.Errorf("%w: first byte = %#x, want %#x",
+			ErrPacketBadSync, b[0], PacketSyncByte)
+	}
+	declared := int(binary.BigEndian.Uint16(b[1:3]))
+	// declared length covers type + payload, so the full packet is
+	// 3 header bytes + declared.
+	wantTotal := 3 + declared
+	if len(b) != wantTotal {
+		return 0, nil, fmt.Errorf("%w: declared %d, buffer %d",
+			ErrPacketLengthMismatch, wantTotal, len(b))
+	}
+	return PacketType(b[3]), b[PacketHeaderBytes:], nil
+}
+
+// SplitPackets walks a stream that may contain multiple back-to-back
+// AMBE-3003 packets and returns the packets it could parse plus the
+// trailing bytes that form an incomplete packet (for buffering across
+// the next read). Stops on the first ErrPacketBadSync — the caller is
+// expected to resync the stream upstream.
+func SplitPackets(stream []byte) (packets [][]byte, leftover []byte, err error) {
+	for len(stream) >= PacketHeaderBytes {
+		if stream[0] != PacketSyncByte {
+			return packets, stream, fmt.Errorf("%w at offset %d",
+				ErrPacketBadSync, 0)
+		}
+		declared := int(binary.BigEndian.Uint16(stream[1:3]))
+		total := 3 + declared
+		if total > len(stream) {
+			// Incomplete trailing packet — caller buffers it.
+			return packets, stream, nil
+		}
+		// Aliased slice into stream; caller copies before mutating.
+		packets = append(packets, stream[:total])
+		stream = stream[total:]
+	}
+	return packets, stream, nil
+}

--- a/internal/voice/dvsi/packet_test.go
+++ b/internal/voice/dvsi/packet_test.go
@@ -1,0 +1,130 @@
+package dvsi
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+)
+
+func TestEncodeDecodePacketRoundTrip(t *testing.T) {
+	cases := []struct {
+		name    string
+		typ     PacketType
+		payload []byte
+	}{
+		{"control_empty", PktControl, nil},
+		{"channel_data_7byte_ambe", PktChannelData, []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07}},
+		{"speech_data_8samples", PktSpeechData, bytes.Repeat([]byte{0xAA, 0x55}, 8)},
+		{"ack", PktAck, nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			wire := EncodePacket(tc.typ, tc.payload)
+			if wire[0] != PacketSyncByte {
+				t.Errorf("encoded sync byte = %#x, want %#x", wire[0], PacketSyncByte)
+			}
+			gotType, gotPayload, err := DecodePacket(wire)
+			if err != nil {
+				t.Fatalf("DecodePacket: %v", err)
+			}
+			if gotType != tc.typ {
+				t.Errorf("type = %#x, want %#x", gotType, tc.typ)
+			}
+			if !bytes.Equal(gotPayload, tc.payload) {
+				t.Errorf("payload = %x, want %x", gotPayload, tc.payload)
+			}
+		})
+	}
+}
+
+func TestDecodePacketRejectsBadSync(t *testing.T) {
+	bad := []byte{0x00, 0x00, 0x01, byte(PktControl)}
+	_, _, err := DecodePacket(bad)
+	if !errors.Is(err, ErrPacketBadSync) {
+		t.Errorf("err = %v, want ErrPacketBadSync", err)
+	}
+}
+
+func TestDecodePacketRejectsShortBuffer(t *testing.T) {
+	short := []byte{PacketSyncByte, 0x00}
+	_, _, err := DecodePacket(short)
+	if !errors.Is(err, ErrPacketTooShort) {
+		t.Errorf("err = %v, want ErrPacketTooShort", err)
+	}
+}
+
+func TestDecodePacketRejectsLengthMismatch(t *testing.T) {
+	// Declared length says 5 bytes (type + 4 payload), but the
+	// buffer only has type + 1 payload byte.
+	bad := []byte{PacketSyncByte, 0x00, 0x05, byte(PktChannelData), 0xAA}
+	_, _, err := DecodePacket(bad)
+	if !errors.Is(err, ErrPacketLengthMismatch) {
+		t.Errorf("err = %v, want ErrPacketLengthMismatch", err)
+	}
+}
+
+func TestSplitPacketsBackToBack(t *testing.T) {
+	// Concatenate three packets and confirm SplitPackets walks them.
+	a := EncodePacket(PktChannelData, []byte{1, 2, 3, 4, 5, 6, 7})
+	b := EncodePacket(PktAck, nil)
+	c := EncodePacket(PktSpeechData, bytes.Repeat([]byte{0x55}, 320))
+	stream := append(append(append([]byte{}, a...), b...), c...)
+
+	packets, leftover, err := SplitPackets(stream)
+	if err != nil {
+		t.Fatalf("SplitPackets: %v", err)
+	}
+	if len(leftover) != 0 {
+		t.Errorf("leftover = %d bytes, want 0", len(leftover))
+	}
+	if len(packets) != 3 {
+		t.Fatalf("packets = %d, want 3", len(packets))
+	}
+	for i, want := range [][]byte{a, b, c} {
+		if !bytes.Equal(packets[i], want) {
+			t.Errorf("packet[%d] mismatch", i)
+		}
+	}
+}
+
+func TestSplitPacketsBuffersIncompleteTrailer(t *testing.T) {
+	// Two full packets plus a partial third (header + truncated
+	// payload) — SplitPackets returns the two complete packets and
+	// the partial as leftover.
+	a := EncodePacket(PktChannelData, []byte{1, 2, 3, 4, 5, 6, 7})
+	b := EncodePacket(PktAck, nil)
+	partial := []byte{PacketSyncByte, 0x00, 0x08, byte(PktSpeechData), 0xAA, 0xBB} // declared 7-byte payload, only 2 supplied
+	stream := append(append(append([]byte{}, a...), b...), partial...)
+
+	packets, leftover, err := SplitPackets(stream)
+	if err != nil {
+		t.Fatalf("SplitPackets: %v", err)
+	}
+	if len(packets) != 2 {
+		t.Errorf("packets = %d, want 2 (third should be in leftover)", len(packets))
+	}
+	if !bytes.Equal(leftover, partial) {
+		t.Errorf("leftover length = %d, want %d (the truncated trailer)",
+			len(leftover), len(partial))
+	}
+}
+
+func TestSplitPacketsResyncOnBadSync(t *testing.T) {
+	// First packet OK, second packet starts with garbage —
+	// SplitPackets returns the first packet plus the bad-sync error
+	// so the caller can decide how to resync.
+	a := EncodePacket(PktChannelData, []byte{1, 2, 3, 4, 5, 6, 7})
+	bad := []byte{0xFF, 0x00, 0x01, byte(PktAck)}
+	stream := append(append([]byte{}, a...), bad...)
+
+	packets, leftover, err := SplitPackets(stream)
+	if !errors.Is(err, ErrPacketBadSync) {
+		t.Errorf("err = %v, want ErrPacketBadSync", err)
+	}
+	if len(packets) != 1 {
+		t.Errorf("packets before bad sync = %d, want 1", len(packets))
+	}
+	if !bytes.Equal(leftover, bad) {
+		t.Error("leftover should preserve the bad-sync bytes for upstream resync")
+	}
+}


### PR DESCRIPTION
## Summary

Stacked on #200 (PR-D). Ships the DVSI USB-3000 / AMBE-3003 hardware
backend scaffolding behind `-tags dvsi`: full Vocoder + Transport +
AMBE-3003 wire protocol + `voice.Vocoder` interface conformance, all
testable in CI via the scripted mock and software-loopback transports
without a physical chip.

The actual FTDI USB bulk-endpoint plumbing remains a stub returning
`ErrNoDevice` so the recorder fallback chain activates cleanly when
no chip is connected. Hardware integration with a real DVSI USB-3000
lands when a chip is available for round-trip testing.

## New package layout

```
internal/voice/dvsi/
├── doc.go               (always compiled) — VocoderName = "dvsi"
├── packet.go            (always compiled) — AMBE-3003 wire format
├── packet_test.go       (always compiled)
├── dvsi_enabled.go      (//go:build dvsi) — Vocoder + Transport + init()
├── dvsi_disabled.go     (//go:build !dvsi) — empty
└── dvsi_test.go         (//go:build dvsi) — Vocoder + Transport tests
```

The wire-format primitives (`EncodePacket` / `DecodePacket` /
`SplitPackets`) are always compiled — there's no patent surface in
describing a serial wire protocol. Everything else (Vocoder,
Transport interface, USB stub, loopback, init() registration) lives
under `-tags dvsi`.

## Tests

Default build (no tag):

| Test | What it confirms |
| --- | --- |
| `TestEncodeDecodePacketRoundTrip` | All 4 PacketTypes round-trip cleanly |
| `TestDecodePacketRejectsBadSync` | First byte must be `0x61` |
| `TestDecodePacketRejectsShortBuffer` | Header-length validation |
| `TestDecodePacketRejectsLengthMismatch` | Declared length must match buffer |
| `TestSplitPacketsBackToBack` | Multi-packet stream walking |
| `TestSplitPacketsBuffersIncompleteTrailer` | Partial trailing packet returned as leftover |
| `TestSplitPacketsResyncOnBadSync` | Bad sync surfaces error + preserves leftover |

Tagged build (`-tags dvsi`):

| Test | What it confirms |
| --- | --- |
| `TestVocoderInterfaceConformance` | `*Vocoder` satisfies `voice.Vocoder` |
| `TestVocoderRegisteredInRegistry` | `init()` registered `"dvsi"`; factory returns `ErrNoDevice` without hardware |
| `TestVocoderLoopbackRoundTrip` | Full encode→transport→decode→PCM round-trip via the loopback Transport |
| `TestVocoderRejectsWrongFrameSize` | Frame length validated before transport write |
| `TestVocoderScriptedExchange` | Outgoing wire bytes match the AMBE-3003 datasheet exactly; chip reply unpacks as little-endian int16 PCM |
| `TestVocoderRejectsUnexpectedReply` | Ack-instead-of-speech / short-speech-payload / wrong-type all surface `ErrUnexpectedReply` |
| `TestOpenWithoutHardwareReturnsErrNoDevice` | `Open(DefaultOptions())` returns the sentinel so the recorder fallback chain works |

## Build / CI

- `Makefile`: new `test-dvsi` target runs the tagged unit tests.
- `.github/workflows/ci.yml`: new `dvsi` Ubuntu job runs
  `go vet -tags dvsi`, `go build -tags dvsi`, and `make test-dvsi`.
- Default `go build ./...`, `go test ./...`, `go vet ./...` stay
  unchanged — no DVSI surface in the default binary.

## Docs

- `docs/vocoders.md`: table row updated; new "DVSI backend layout"
  section documents the package structure; "Future work" entry for
  the USB transport implementation.
- `docs/opt-in-features.md` §4: DVSI status reflects scaffolding
  shipping.
- `README.md` §Roadmap: DVSI item moved from "planned" to
  "scaffolding shipping; USB transport follows".

## Patent posture

`docs/vocoders.md` already states the patent-encumbrance posture; the
DVSI backend exists for operators in jurisdictions where
vendor-blessed AMBE+2 decode is required. The loopback Transport
returns silence (never actual decoded audio); the whole point of the
backend is to outsource the patent surface to hardware. Operators
must never enable `LoopbackOnly` outside tests — every call would
decode to silence.

## Roadmap status

Closes:

- ✅ **PR-E** — Tier 1.2 part 1: packet framing + interfaces + build
  tags + loopback Transport
- ✅ **PR-F** — Tier 1.2 part 2: Vocoder + Transport interface +
  init() registration + CI matrix entry

(Merged into one PR since the scope is small and the two halves are
not independently shippable.)

Remaining roadmap items:

- ⏳ **PR-G** — Tier 3 voice calibration plumbing
- ⏳ **PR-H–N** — docs alignment, ship-readiness gaps, release prep
- ⏳ Real FTDI USB transport (separate PR when a chip is available)

https://claude.ai/code/session_01LyPnLfVLRAh6ThTENjX59y

---
_Generated by [Claude Code](https://claude.ai/code/session_01LyPnLfVLRAh6ThTENjX59y)_