### PR TITLE
api: optional TLS on HTTP + gRPC + extended /api/v1/health diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,19 @@ to its own package and lands independently.
 
 ### Recently shipped
 
+- **Optional TLS on HTTP + gRPC + extended health endpoint.**
+  `api.tls_cert` / `api.tls_key` in `config.yaml` switches both
+  the HTTP REST/SSE/WebSocket server and the gRPC server to TLS;
+  the daemon refuses to start when one is set without the other.
+  Plain TCP stays the default for loopback / trusted-LAN
+  deployments. `GET /api/v1/health` now returns
+  `pool_attached_count`, `active_calls`, `db_connected`,
+  `metrics_enabled`, `auth_mode`, and `version` alongside the
+  legacy `status` + `now` — supports two-field k8s / Nomad
+  readiness probes that distinguish "process up" from "actually
+  working". See [docs/hardening.md](docs/hardening.md#transport-encryption-tls)
+  for the TLS recipe and [docs/hardening.md](docs/hardening.md#health-endpoint-diagnostics)
+  for the health schema.
 - **API server hardening: HTTP timeouts + gRPC keep-alive + drain
   window.** `internal/api/server.go` now sets `ReadTimeout` /
   `WriteTimeout` / `IdleTimeout` on the HTTP server (30 s / 30 s /

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -504,6 +504,8 @@ func NewDaemon(cfg config.Config, version string, log *slog.Logger) (*Daemon, er
 				TokenFile:       cfg.API.Auth.TokenFile,
 				TrustedNetworks: cfg.API.Auth.TrustedNetworks,
 			},
+			TLSCert: cfg.API.TLSCert,
+			TLSKey:  cfg.API.TLSKey,
 		}
 		if d.db != nil {
 			opts.History = api.HistoryFromStorage(d.db)
@@ -551,6 +553,8 @@ func NewDaemon(cfg config.Config, version string, log *slog.Logger) (*Daemon, er
 			Engine:     d.engine,
 			Audio:      d.audioPub,
 			Log:        log,
+			TLSCert:    cfg.API.TLSCert,
+			TLSKey:     cfg.API.TLSKey,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("daemon: grpc api: %w", err)

--- a/docs/hardening.md
+++ b/docs/hardening.md
@@ -161,6 +161,89 @@ matters for streaming endpoints. gRPC uses
 (including `AudioService.StreamAudio` subscribers) to finish or
 voluntarily close.
 
+## Transport encryption (TLS)
+
+Both the HTTP API (REST + SSE + WebSocket) and the gRPC server
+support optional TLS. Plain TCP stays the default — bearer-token
+auth in `api.auth` is sufficient for loopback / trusted-LAN
+deployments and TLS adds operational overhead (cert rotation, CA
+choice). Public-bind operators should enable TLS.
+
+Wire up by adding two paths to `api` in `config.yaml`:
+
+```yaml
+api:
+  http_addr: ":8080"
+  grpc_addr: ":50051"
+  tls_cert: "/etc/gophertrunk/tls/cert.pem"
+  tls_key:  "/etc/gophertrunk/tls/key.pem"
+```
+
+Both keys must be set together — setting one without the other is
+a config error the daemon refuses to start with rather than
+silently falling back to plain HTTP. The same cert / key pair
+is used for both the HTTP and gRPC listeners. Generate a real
+cert with `certbot`, your CA's tooling, or for testing:
+
+```sh
+openssl req -x509 -newkey rsa:2048 -nodes -days 365 \
+    -keyout /etc/gophertrunk/tls/key.pem \
+    -out    /etc/gophertrunk/tls/cert.pem \
+    -subj "/CN=gophertrunk.example.com" \
+    -addext "subjectAltName=DNS:gophertrunk.example.com,IP:10.0.0.1"
+```
+
+Cert rotation requires a daemon restart — `internal/api/server.go`'s
+`ServeTLS` reads both files at start-up. SIGHUP / auto-reload is a
+follow-up.
+
+Once TLS is up, clients use `https://` and `grpc+tls://`:
+
+```sh
+curl --cacert /etc/gophertrunk/tls/cert.pem \
+     -H "Authorization: Bearer $TOKEN" \
+     https://gophertrunk.example.com:8080/api/v1/health
+
+grpcurl -cacert /etc/gophertrunk/tls/cert.pem \
+        gophertrunk.example.com:50051 \
+        gophertrunk.v1.AudioService/StreamAudio
+```
+
+## Health endpoint diagnostics
+
+`GET /api/v1/health` returns a JSON body shaped like:
+
+```json
+{
+  "status":              "ok",
+  "now":                 "2026-05-13T19:00:00Z",
+  "version":             "v1.2.3",
+  "pool_attached_count": 2,
+  "active_calls":        1,
+  "db_connected":        true,
+  "metrics_enabled":     true,
+  "auth_mode":           "auto"
+}
+```
+
+The endpoint is always open (no token required) so liveness /
+readiness probes can hit it from outside the auth boundary. Every
+field beyond `status` and `now` is best-effort — a daemon
+configured without a particular collaborator (no SDR pool, no
+engine, no history DB) just reports the corresponding field at its
+zero value rather than failing the request.
+
+Suggested probe semantics:
+
+| Probe type | Condition |
+| --- | --- |
+| Liveness | HTTP 200 + body decodes |
+| Readiness | `status == "ok"` AND `pool_attached_count >= 1` AND `db_connected == true` |
+
+The two-field readiness check distinguishes "the daemon process
+is up" from "the daemon process is actually doing work" so
+orchestrators (k8s, Nomad) can roll deployments cleanly.
+
 ## Timeouts and keep-alive
 
 | Knob | Value | What it bounds |

--- a/internal/api/grpc.go
+++ b/internal/api/grpc.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net"
 	"time"
@@ -11,6 +12,7 @@ import (
 	"github.com/MattCheramie/GopherTrunk/internal/trunking"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/status"
 )
@@ -49,6 +51,13 @@ type GRPCServerOptions struct {
 	// returns Unavailable rather than streaming frames.
 	Audio *AudioPublisher
 	Log   *slog.Logger
+	// TLSCert and TLSKey, when both non-empty, switch the gRPC
+	// server to TLS using credentials.NewServerTLSFromFile. Same
+	// disk-loaded-once semantics as the HTTP server's TLS support.
+	// Leave both empty for plain TCP (default; appropriate for
+	// loopback / private-network deployments).
+	TLSCert string
+	TLSKey  string
 }
 
 // NewGRPCServer constructs the server but does not bind a listener.
@@ -87,10 +96,22 @@ func NewGRPCServer(opts GRPCServerOptions) (*GRPCServer, error) {
 		MinTime:             5 * time.Second,
 		PermitWithoutStream: true,
 	}
-	g.srv = grpc.NewServer(
+	srvOpts := []grpc.ServerOption{
 		grpc.KeepaliveParams(keepaliveParams),
 		grpc.KeepaliveEnforcementPolicy(keepaliveEnforcement),
-	)
+	}
+	// TLS: same all-or-nothing semantics as the HTTP server.
+	if (opts.TLSCert == "") != (opts.TLSKey == "") {
+		return nil, errors.New("api: grpc tls_cert and tls_key must both be set or both be empty")
+	}
+	if opts.TLSCert != "" {
+		creds, err := credentials.NewServerTLSFromFile(opts.TLSCert, opts.TLSKey)
+		if err != nil {
+			return nil, fmt.Errorf("api: load gRPC TLS credentials: %w", err)
+		}
+		srvOpts = append(srvOpts, grpc.Creds(creds))
+	}
+	g.srv = grpc.NewServer(srvOpts...)
 	apiv1.RegisterSystemServiceServer(g.srv, g)
 	apiv1.RegisterTalkgroupServiceServer(g.srv, g)
 	apiv1.RegisterAudioServiceServer(g.srv, g)

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -8,11 +8,66 @@ import (
 	"github.com/MattCheramie/GopherTrunk/internal/sdr"
 )
 
+// HealthDTO is the body shape returned by GET /api/v1/health. The
+// extended fields (every key beyond status + now) let k8s / Nomad
+// readiness probes and operator dashboards distinguish "the daemon
+// process is up" from "the daemon process is actually doing work".
+// All fields are best-effort — missing collaborators (no SDR pool,
+// no engine, no history DB) just leave the corresponding field at
+// its zero value rather than failing the request.
+type HealthDTO struct {
+	// Status is always "ok" for a serving daemon — present so old
+	// callers that only check `.status == "ok"` keep working.
+	Status string `json:"status"`
+	// Now is the daemon-side timestamp in UTC. Useful for detecting
+	// clock skew between probe and daemon.
+	Now time.Time `json:"now"`
+	// Version is the daemon build version, redundant with the
+	// dedicated /api/v1/version endpoint but useful so probes can
+	// confirm process identity in one round-trip.
+	Version string `json:"version,omitempty"`
+	// PoolAttachedCount is the number of currently-attached SDR
+	// devices. Zero means no Devices provider is wired OR every
+	// device has detached — both are operator-actionable signals.
+	PoolAttachedCount int `json:"pool_attached_count"`
+	// ActiveCalls is the count of in-flight voice calls.
+	ActiveCalls int `json:"active_calls"`
+	// DBConnected reports whether the call-history database is
+	// wired. A daemon configured without `db_path` legitimately
+	// runs with DBConnected = false.
+	DBConnected bool `json:"db_connected"`
+	// MetricsEnabled reports whether /metrics is mounted.
+	MetricsEnabled bool `json:"metrics_enabled"`
+	// AuthMode echoes the bearer-token auth policy
+	// ("auto" / "required" / "disabled") so probes can flag a
+	// misconfigured production deployment.
+	AuthMode string `json:"auth_mode,omitempty"`
+}
+
 func (s *Server) handleHealth(w http.ResponseWriter, _ *http.Request) {
-	writeJSON(w, http.StatusOK, map[string]any{
-		"status": "ok",
-		"now":    time.Now().UTC(),
-	})
+	body := HealthDTO{
+		Status:         "ok",
+		Now:            time.Now().UTC(),
+		Version:        s.version,
+		DBConnected:    s.history != nil,
+		MetricsEnabled: s.metrics != nil,
+	}
+	if s.devices != nil {
+		attached := 0
+		for _, d := range s.devices.Snapshot() {
+			if d.Attached {
+				attached++
+			}
+		}
+		body.PoolAttachedCount = attached
+	}
+	if s.engine != nil {
+		body.ActiveCalls = len(s.engine.ActiveCalls())
+	}
+	if s.auth != nil {
+		body.AuthMode = s.auth.mode.String()
+	}
+	writeJSON(w, http.StatusOK, body)
 }
 
 func (s *Server) handleVersion(w http.ResponseWriter, _ *http.Request) {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -217,6 +217,9 @@ type Server struct {
 	// AuthModeDisabled state (legacy wide-open behaviour).
 	allowMutations bool
 
+	tlsCert string
+	tlsKey  string
+
 	mu     sync.Mutex
 	srv    *http.Server
 	closed bool
@@ -320,6 +323,14 @@ type ServerOptions struct {
 	// it to surface every config knob. Optional; when nil, the
 	// route returns 503.
 	Runtime RuntimeProvider
+	// TLSCert and TLSKey, when both non-empty, switch the HTTP
+	// server to TLS. Paths point at PEM-encoded files on disk that
+	// the daemon reads at start-up. Leaving either empty serves
+	// plain HTTP (the default — appropriate for loopback / private-
+	// network deployments where the bearer-token auth gate is the
+	// only protection on mutations).
+	TLSCert string
+	TLSKey  string
 }
 
 // NewServer constructs a server but does not yet bind a listener; call
@@ -355,6 +366,12 @@ func NewServer(opts ServerOptions) (*Server, error) {
 	if authCfg.Mode == AuthModeDisabled {
 		log.Warn("api: auth disabled — mutation endpoints are not authenticated; bind to loopback or trusted network only")
 	}
+	// TLS: both files must be set to enable TLS; one without the
+	// other is a misconfiguration the operator should hear about
+	// rather than silently fall back to plain HTTP.
+	if (opts.TLSCert == "") != (opts.TLSKey == "") {
+		return nil, errors.New("api: tls_cert and tls_key must both be set or both be empty")
+	}
 	return &Server{
 		addr:           opts.Addr,
 		bus:            opts.Bus,
@@ -374,6 +391,8 @@ func NewServer(opts ServerOptions) (*Server, error) {
 		version:        opts.Version,
 		auth:           auth,
 		allowMutations: opts.AllowMutations,
+		tlsCert:        opts.TLSCert,
+		tlsKey:         opts.TLSKey,
 	}, nil
 }
 
@@ -405,9 +424,21 @@ func (s *Server) Run(ctx context.Context) error {
 	s.mu.Unlock()
 
 	errCh := make(chan error, 1)
+	tlsEnabled := s.tlsCert != "" && s.tlsKey != ""
 	go func() {
-		s.log.Info("api: listening", "addr", listener.Addr().String())
-		if err := s.srv.Serve(listener); err != nil && err != http.ErrServerClosed {
+		s.log.Info("api: listening",
+			"addr", listener.Addr().String(),
+			"tls", tlsEnabled)
+		var err error
+		if tlsEnabled {
+			// ServeTLS reads the cert / key off disk at start;
+			// rotation requires a daemon restart. Document this
+			// in docs/hardening.md.
+			err = s.srv.ServeTLS(listener, s.tlsCert, s.tlsKey)
+		} else {
+			err = s.srv.Serve(listener)
+		}
+		if err != nil && err != http.ErrServerClosed {
 			errCh <- err
 			return
 		}

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -80,6 +80,27 @@ func TestHealth(t *testing.T) {
 	if body["status"] != "ok" {
 		t.Errorf("health status = %v", body["status"])
 	}
+	if body["version"] != "test" {
+		t.Errorf("health version = %v, want %q", body["version"], "test")
+	}
+	// Extended diagnostic fields default to zero/false when their
+	// collaborators aren't wired (this test doesn't pass Engine,
+	// Devices, History, MetricsHandler).
+	if got := body["pool_attached_count"]; got != 0.0 {
+		t.Errorf("pool_attached_count = %v, want 0", got)
+	}
+	if got := body["active_calls"]; got != 0.0 {
+		t.Errorf("active_calls = %v, want 0", got)
+	}
+	if got := body["db_connected"]; got != false {
+		t.Errorf("db_connected = %v, want false", got)
+	}
+	if got := body["metrics_enabled"]; got != false {
+		t.Errorf("metrics_enabled = %v, want false", got)
+	}
+	if _, ok := body["now"]; !ok {
+		t.Error("health body missing 'now' timestamp")
+	}
 }
 
 func TestVersion(t *testing.T) {

--- a/internal/api/server_tls_test.go
+++ b/internal/api/server_tls_test.go
@@ -1,0 +1,182 @@
+package api
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/json"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+)
+
+// TestServerServesTLSWhenConfigured spins a self-signed cert/key
+// pair, hands the on-disk paths to ServerOptions.TLSCert/TLSKey,
+// and confirms a TLS client can reach /api/v1/health while a plain
+// HTTP client to the same port fails. Covers the
+// http.Server.ServeTLS branch added by PR-J.
+func TestServerServesTLSWhenConfigured(t *testing.T) {
+	dir := t.TempDir()
+	certPath, keyPath := writeSelfSignedCert(t, dir, "127.0.0.1")
+
+	bus := events.NewBus(8)
+	defer bus.Close()
+
+	port := freeTCPPort(t)
+	addr := "127.0.0.1:" + port
+
+	srv, err := NewServer(ServerOptions{
+		Addr:    addr,
+		Bus:     bus,
+		Version: "tls-test",
+		TLSCert: certPath,
+		TLSKey:  keyPath,
+	})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- srv.Run(t.Context()) }()
+	defer srv.Close()
+
+	// Probe loop — TLS server takes a moment to bind.
+	tlsURL := "https://" + addr + "/api/v1/health"
+	insecureClient := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // self-signed cert in test
+		},
+		Timeout: 2 * time.Second,
+	}
+	deadline := time.Now().Add(3 * time.Second)
+	var resp *http.Response
+	for {
+		resp, err = insecureClient.Get(tlsURL)
+		if err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("TLS probe never succeeded: %v", err)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	defer resp.Body.Close()
+	var body map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode TLS body: %v", err)
+	}
+	if body["status"] != "ok" {
+		t.Errorf("TLS health body status = %v, want ok", body["status"])
+	}
+	if body["version"] != "tls-test" {
+		t.Errorf("TLS health body version = %v, want tls-test", body["version"])
+	}
+
+	// A plain HTTP GET to the same port should fail at the TLS
+	// handshake (Go's net/http server sends back a "Bad Request"
+	// response with `Client sent an HTTP request to an HTTPS
+	// server`). The 200 OK from the TLS path above confirmed the
+	// real handler works; here we just confirm we don't get the
+	// same 200 from a plain GET.
+	plainClient := &http.Client{Timeout: 500 * time.Millisecond}
+	if resp2, err := plainClient.Get("http://" + addr + "/api/v1/health"); err == nil {
+		defer resp2.Body.Close()
+		if resp2.StatusCode == http.StatusOK {
+			t.Errorf("plain HTTP probe to TLS port returned 200; expected non-200 or handshake error")
+		}
+	}
+}
+
+// TestNewServerRejectsHalfTLS asserts the all-or-nothing validation:
+// setting TLSCert without TLSKey (or vice versa) is a config error,
+// not a silent fall-back to plain HTTP.
+func TestNewServerRejectsHalfTLS(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+
+	if _, err := NewServer(ServerOptions{
+		Addr: "127.0.0.1:0", Bus: bus, TLSCert: "/tmp/cert.pem",
+	}); err == nil {
+		t.Error("NewServer accepted TLSCert without TLSKey")
+	}
+	if _, err := NewServer(ServerOptions{
+		Addr: "127.0.0.1:0", Bus: bus, TLSKey: "/tmp/key.pem",
+	}); err == nil {
+		t.Error("NewServer accepted TLSKey without TLSCert")
+	}
+}
+
+// writeSelfSignedCert produces a fresh ECDSA P-256 cert + key pair
+// valid for `host` and writes them as PEM files under dir. Returns
+// the (certPath, keyPath) pair.
+func writeSelfSignedCert(t *testing.T, dir, host string) (string, string) {
+	t.Helper()
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: host},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		template.IPAddresses = []net.IP{ip}
+	} else {
+		template.DNSNames = []string{host}
+	}
+	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	if err != nil {
+		t.Fatalf("create cert: %v", err)
+	}
+	certPath := filepath.Join(dir, "cert.pem")
+	keyPath := filepath.Join(dir, "key.pem")
+	cf, err := os.Create(certPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := pem.Encode(cf, &pem.Block{Type: "CERTIFICATE", Bytes: derBytes}); err != nil {
+		t.Fatal(err)
+	}
+	cf.Close()
+	kf, err := os.OpenFile(keyPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyDER, err := x509.MarshalECPrivateKey(priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := pem.Encode(kf, &pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER}); err != nil {
+		t.Fatal(err)
+	}
+	kf.Close()
+	return certPath, keyPath
+}
+
+// freeTCPPort returns a port that's available at call time. Inherent
+// TOCTOU vs. the test binding — caller should bind immediately.
+func freeTCPPort(t *testing.T) string {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr := l.Addr().(*net.TCPAddr)
+	l.Close()
+	return strconv.Itoa(addr.Port)
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -312,10 +312,18 @@ type SystemConfig struct {
 // deprecation warning and maps to `auth.mode: disabled` so the
 // daemon's existing wide-open behaviour is preserved.
 type APIConfig struct {
-	HTTPAddr       string         `yaml:"http_addr"`
-	GRPCAddr       string         `yaml:"grpc_addr"`
-	AllowMutations bool           `yaml:"allow_mutations"`
-	Auth           APIAuthConfig  `yaml:"auth"`
+	HTTPAddr       string        `yaml:"http_addr"`
+	GRPCAddr       string        `yaml:"grpc_addr"`
+	AllowMutations bool          `yaml:"allow_mutations"`
+	Auth           APIAuthConfig `yaml:"auth"`
+	// TLSCert / TLSKey, when both set, switch both the HTTP and
+	// gRPC servers to TLS. Paths point at PEM-encoded files on
+	// disk that the daemon reads at start-up (rotation requires a
+	// restart). Leave both empty for plain TCP (the default;
+	// appropriate for loopback / private-network deployments).
+	// See docs/hardening.md §"Transport encryption (TLS)".
+	TLSCert string `yaml:"tls_cert"`
+	TLSKey  string `yaml:"tls_key"`
 }
 
 // APIAuthConfig configures bearer-token authentication on the HTTP


### PR DESCRIPTION
## Summary

Stacked on #203 (PR-I). Closes the next two ship-readiness audit
findings — both pure config-driven additions that keep existing
plain-TCP / minimal-health-body deployments unchanged.

- **4.3 — Transport encryption (TLS)**: `api.tls_cert` /
  `api.tls_key` in `config.yaml` switches both the HTTP server
  and the gRPC server to TLS. Plain TCP stays the default for
  loopback / trusted-LAN deployments. The daemon refuses to start
  when one is set without the other — that's a config error,
  not a silent fallback.
- **4.4 — Extended health endpoint**: `GET /api/v1/health` now
  returns `pool_attached_count`, `active_calls`, `db_connected`,
  `metrics_enabled`, `auth_mode`, and `version` alongside the
  legacy `status` + `now`. Supports k8s / Nomad readiness probes
  that distinguish "process up" from "actually working".

## Health body

```json
{
  "status":              "ok",
  "now":                 "2026-05-13T19:00:00Z",
  "version":             "v1.2.3",
  "pool_attached_count": 2,
  "active_calls":        1,
  "db_connected":        true,
  "metrics_enabled":     true,
  "auth_mode":           "auto"
}
```

Every field beyond `status` and `now` is best-effort — a daemon
configured without a particular collaborator (no SDR pool, no
engine, no history DB) reports the corresponding field at its zero
value rather than failing. The endpoint stays open (no bearer
token required) so liveness / readiness probes can reach it from
outside the auth boundary.

Suggested readiness check: `status == "ok"` AND
`pool_attached_count >= 1` AND `db_connected == true`.

## TLS wiring

```yaml
api:
  http_addr: ":8080"
  grpc_addr: ":50051"
  tls_cert: "/etc/gophertrunk/tls/cert.pem"
  tls_key:  "/etc/gophertrunk/tls/key.pem"
```

Same cert / key pair drives both servers. Cert rotation requires a
daemon restart — `ServeTLS` and `credentials.NewServerTLSFromFile`
both read off disk at start-up; SIGHUP / auto-reload is a follow-up.

`docs/hardening.md` gains "Transport encryption (TLS)" and
"Health endpoint diagnostics" sections with the openssl recipe,
curl/grpcurl client commands, and probe-semantics table.

## Tests

| Test | What it confirms |
| --- | --- |
| `TestHealth` (extended) | New fields default cleanly when collaborators are absent; legacy `status` + `now` + `version` still ship |
| `TestServerServesTLSWhenConfigured` | Self-signed ECDSA P-256 cert/key pair drives a TLS listener; `https://` probe reaches `/api/v1/health`; plain `http://` probe to the same port doesn't get 200 |
| `TestNewServerRejectsHalfTLS` | All-or-nothing validation — setting `TLSCert` without `TLSKey` (or vice versa) is a construction error |

All three pass; full unit suite + integration suite + `make
test-dvsi` + `go vet` green.

## Changes

- `internal/api/server.go` + `internal/api/grpc.go` — `TLSCert` /
  `TLSKey` in `ServerOptions` / `GRPCServerOptions`; HTTP path
  uses `srv.ServeTLS`, gRPC path uses
  `grpc.Creds(credentials.NewServerTLSFromFile(...))`.
- `internal/api/handlers.go` — new `HealthDTO` returned by
  `handleHealth` with the extended diagnostic fields.
- `internal/config/config.go` — `APIConfig.TLSCert` + `TLSKey`
  YAML keys.
- `cmd/gophertrunk/daemon.go` — threads the config fields through
  to both servers.
- `internal/api/server_tls_test.go` (new) — TLS bootstrap test
  with a self-signed cert.
- `internal/api/server_test.go` — `TestHealth` extended.
- `docs/hardening.md` — "Transport encryption (TLS)" and
  "Health endpoint diagnostics" sections.
- `README.md` §Recently shipped entry.

## Roadmap status

Closes:

- ✅ **PR-J** — Tier 4.3 + 4.4 (TLS + extended health)

Still pending in Tier 4:

- ⏳ **PR-K** — 4.6: SECURITY.md, CHANGELOG.md, CONTRIBUTING.md,
  systemd unit
- ⏳ **PR-L** — 4.7, 4.9: CI integration gate, govulncheck,
  license audit
- ⏳ **PR-M** — 4.8, 4.10: release workflow prerelease test,
  version ldflags wiring, patent banner

https://claude.ai/code/session_01LyPnLfVLRAh6ThTENjX59y

---
_Generated by [Claude Code](https://claude.ai/code/session_01LyPnLfVLRAh6ThTENjX59y)_