### PR TITLE
ci: add GitHub rulesets for main branch and release tags

### DIFF
--- a/.github/rulesets/main-branch-protection.json
+++ b/.github/rulesets/main-branch-protection.json
@@ -1,0 +1,39 @@
+{
+  "name": "Protect main",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["~DEFAULT_BRANCH"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": false,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": true,
+        "allowed_merge_methods": ["merge", "squash", "rebase"]
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": false,
+        "do_not_enforce_on_create": false,
+        "required_status_checks": [
+          { "context": "build-test" },
+          { "context": "usb-windows" },
+          { "context": "usb-macos" }
+        ]
+      }
+    }
+  ],
+  "bypass_actors": []
+}

--- a/.github/rulesets/release-tags-protection.json
+++ b/.github/rulesets/release-tags-protection.json
@@ -1,0 +1,16 @@
+{
+  "name": "Protect release tags",
+  "target": "tag",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/tags/v*"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    { "type": "deletion" },
+    { "type": "update" }
+  ],
+  "bypass_actors": []
+}


### PR DESCRIPTION
Version-controlled ruleset definitions to harden the repo ahead of going
fully public. Import via Settings -> Rules -> Rulesets -> "Import a ruleset".

- main: require PRs, block direct push / force-push / deletion, require
  conversation resolution, require build-test + usb-windows + usb-macos
  status checks from CI.
- v*.*.* tags: block update and deletion so published release artifacts
  stay pinned to their original commits.

https://claude.ai/code/session_01DWG5bvVSPc4cfK4NKCPocV