### PR TITLE
cmd+release: ldflags version metadata + AMBE+2 patent banner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,10 +56,12 @@ jobs:
           CGO_ENABLED: "0"
         run: |
           VERSION="${{ steps.version.outputs.version }}"
+          COMMIT="$(git rev-parse --short HEAD)"
+          BUILD_TIME="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           mkdir -p dist/staging
           go build \
             -trimpath \
-            -ldflags "-X github.com/MattCheramie/GopherTrunk/internal/version.Version=${VERSION}" \
+            -ldflags "-X github.com/MattCheramie/GopherTrunk/internal/version.Version=${VERSION} -X github.com/MattCheramie/GopherTrunk/internal/version.Commit=${COMMIT} -X github.com/MattCheramie/GopherTrunk/internal/version.BuildTime=${BUILD_TIME}" \
             -o dist/staging/gophertrunk.exe \
             ./cmd/gophertrunk
 
@@ -118,11 +120,13 @@ jobs:
           CGO_ENABLED: "0"
         run: |
           VERSION="${{ steps.version.outputs.version }}"
+          COMMIT="$(git rev-parse --short HEAD)"
+          BUILD_TIME="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           NAME="gophertrunk-${VERSION}-linux-amd64"
           mkdir -p "dist/${NAME}"
           go build \
             -trimpath \
-            -ldflags "-X github.com/MattCheramie/GopherTrunk/internal/version.Version=${VERSION}" \
+            -ldflags "-X github.com/MattCheramie/GopherTrunk/internal/version.Version=${VERSION} -X github.com/MattCheramie/GopherTrunk/internal/version.Commit=${COMMIT} -X github.com/MattCheramie/GopherTrunk/internal/version.BuildTime=${BUILD_TIME}" \
             -o "dist/${NAME}/gophertrunk" \
             ./cmd/gophertrunk
           cp README.md LICENSE config.example.yaml "dist/${NAME}/"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ for tagged releases.
 
 ### Added
 
+- `internal/version` now exposes `Version`, `Commit`, and
+  `BuildTime` (all `-ldflags`-injectable) plus a `String()`
+  formatter (`"vX.Y.Z (sha=…, built=…)"`). Makefile and the
+  release workflow both populate all three. `gophertrunk version`
+  CLI subcommand prints the formatted string; the daemon logs it
+  on startup.
+- AMBE+2 patent-posture banner: daemon logs a one-line notice at
+  startup pointing operators at
+  [`docs/vocoders.md`](docs/vocoders.md). Suppressible via
+  `GOPHERTRUNK_QUIET_BANNER=1` for CI / test harnesses.
+- `make release-dry-run VERSION=v0.99.0` rehearses the release
+  build locally — produces a `dist/dry-run/gophertrunk` with the
+  supplied version metadata injected and a `SHA256SUMS` file.
+  See [`CONTRIBUTING.md` §"Cutting a release"](CONTRIBUTING.md#cutting-a-release).
+- Toolchain pinned to Go 1.25.10 (closes 23 stdlib CVEs in the
+  default 1.25.0 toolchain auto-downloaded by `go 1.25.0` in
+  go.mod).
 - CI hardening: `vulncheck` job runs `govulncheck` against the
   direct + transitive dependency graph; `licenses` job regenerates
   the transitive-deps inventory via `google/go-licenses` and

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,6 +99,32 @@ every PR. A green CI is required before merge.
    is fine on feature branches; the maintainer squashes on merge
    to keep `main` history clean).
 
+## Cutting a release
+
+Releases are produced by [`.github/workflows/release.yml`](.github/workflows/release.yml),
+triggered by pushing a SemVer tag (`vX.Y.Z`) or via the workflow
+dispatch button in the GitHub Actions UI.
+
+Before tagging a new release, rehearse the build locally so any
+ldflags / packaging breakage surfaces before a tag is cut:
+
+```sh
+make release-dry-run VERSION=v0.99.0
+```
+
+…which produces `dist/dry-run/gophertrunk` with the supplied
+`VERSION`, `COMMIT` (short SHA), and `BUILD_TIME` (UTC ISO-8601)
+injected via `-ldflags`. The script then runs `./gophertrunk
+version` against the built binary and writes a `SHA256SUMS` file —
+match those values against what you expect the production release
+to print before pushing the real tag.
+
+The first production release should be a prerelease (e.g.
+`v0.99.0`) so the full release workflow runs end-to-end against
+the live GitHub Actions infrastructure before a v1.0.0 tag goes
+out. Trigger via the **Actions → Release → Run workflow** button
+with the version field set.
+
 ## Security issues
 
 If you've found a vulnerability, please follow the disclosure

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,15 @@
 VERSION ?= $(shell git describe --tags --dirty --always 2>/dev/null || echo dev)
-LDFLAGS := -X github.com/MattCheramie/GopherTrunk/internal/version.Version=$(VERSION)
+COMMIT  ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "")
+BUILD_TIME ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
+LDFLAGS := -X github.com/MattCheramie/GopherTrunk/internal/version.Version=$(VERSION) \
+           -X github.com/MattCheramie/GopherTrunk/internal/version.Commit=$(COMMIT) \
+           -X github.com/MattCheramie/GopherTrunk/internal/version.BuildTime=$(BUILD_TIME)
 TAGS    ?=
 
 GO      ?= go
 PKGS    := ./...
 
-.PHONY: all build test test-dvsi test-integration integration integration-cc integration-cc-grant integration-cc-nxdn integration-cc-dmr integration-cc-dpmr integration-cc-edacs integration-cc-motorola integration-cc-tetra integration-cc-p25p2 integration-cc-mpt1327 integration-cc-ltr integration-cc-ysf lint tidy vet vulncheck licenses clean run proto cross-build release-archives
+.PHONY: all build test test-dvsi test-integration integration integration-cc integration-cc-grant integration-cc-nxdn integration-cc-dmr integration-cc-dpmr integration-cc-edacs integration-cc-motorola integration-cc-tetra integration-cc-p25p2 integration-cc-mpt1327 integration-cc-ltr integration-cc-ysf lint tidy vet vulncheck licenses clean run proto cross-build release-archives release-dry-run
 
 all: build
 
@@ -199,6 +203,27 @@ cross-build:
 	    done; \
 	done
 	@ls -lh dist/
+
+# release-dry-run rehearses the release.yml linux job locally so an
+# operator can validate ldflags wiring + version-string injection
+# before pushing a tag. Skips the GitHub Release publish step; just
+# produces the tarball + checksum under dist/. Run with
+#   make release-dry-run VERSION=v0.99.0
+# to exercise a prerelease build; default VERSION picks up the same
+# git-describe value the release workflow would compute.
+release-dry-run:
+	@echo "→ Rehearsing release build for version $(VERSION)"
+	@echo "→ COMMIT=$(COMMIT) BUILD_TIME=$(BUILD_TIME)"
+	@rm -rf dist/dry-run
+	@mkdir -p dist/dry-run
+	CGO_ENABLED=0 $(GO) build -trimpath \
+	    -ldflags "$(LDFLAGS)" \
+	    -o dist/dry-run/gophertrunk \
+	    ./cmd/gophertrunk
+	@echo "→ Built binary reports:"
+	@dist/dry-run/gophertrunk version
+	@cd dist/dry-run && sha256sum gophertrunk > SHA256SUMS && cat SHA256SUMS
+	@echo "✓ Dry-run complete. Output: dist/dry-run/"
 
 # release-archives wraps the cross-build outputs in per-target
 # tarballs (linux/darwin) and zips (windows). Run `make cross-build`

--- a/README.md
+++ b/README.md
@@ -322,6 +322,17 @@ to its own package and lands independently.
 
 ### Recently shipped
 
+- **Release-ready version metadata + AMBE+2 patent banner.**
+  [`internal/version/`](internal/version/) now exposes `Version`,
+  `Commit`, `BuildTime`, and a `String()` formatter
+  (`"vX.Y.Z (sha=…, built=…)"`); all three are populated via
+  `-ldflags` by the Makefile + release workflow. The daemon logs
+  a one-line AMBE+2 patent-posture notice at startup pointing at
+  [`docs/vocoders.md`](docs/vocoders.md); set
+  `GOPHERTRUNK_QUIET_BANNER=1` in CI / test harnesses to suppress
+  it. New `make release-dry-run VERSION=v0.99.0` target rehearses
+  the release build locally so ldflags + packaging surface before
+  a tag is cut — see [`CONTRIBUTING.md` §"Cutting a release"](CONTRIBUTING.md#cutting-a-release).
 - **CI gates: govulncheck + license audit + full-tree integration
   run.** `.github/workflows/ci.yml` gains a `vulncheck` job
   (govulncheck against the direct + transitive dependency graph),

--- a/cmd/gophertrunk/main.go
+++ b/cmd/gophertrunk/main.go
@@ -38,7 +38,7 @@ func main() {
 	}
 	switch os.Args[1] {
 	case "version", "--version", "-v":
-		fmt.Println(version.Version)
+		fmt.Println(version.String())
 	case "sdr":
 		runSDR(os.Args[2:])
 	case "audio":
@@ -89,12 +89,25 @@ func runDaemon(args []string) {
 	}
 	logger := gtlog.New(cfg.Log.Level, cfg.Log.Format)
 
-	logger.Info("gophertrunk starting", "version", version.Version)
+	logger.Info("gophertrunk starting", "version", version.String())
+
+	// Patent-posture banner — AMBE+2 decoding is patent-encumbered
+	// in some jurisdictions (DVSI IPR portfolio). The pure-Go
+	// decoder ships unconditionally as a clean-room implementation,
+	// but operators in those jurisdictions may need a license. The
+	// full discussion lives in docs/vocoders.md §"Patent posture";
+	// this one-line banner surfaces the link at startup so
+	// operators see it without having to grep the repo. Suppress
+	// with GOPHERTRUNK_QUIET_BANNER=1 (intended for CI / test
+	// harnesses where the banner is just noise).
+	if os.Getenv("GOPHERTRUNK_QUIET_BANNER") == "" {
+		logger.Info("AMBE+2 voice decoding is patent-encumbered in some jurisdictions; see docs/vocoders.md §\"Patent posture\"")
+	}
 
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
 
-	d, err := NewDaemon(cfg, version.Version, logger)
+	d, err := NewDaemon(cfg, version.String(), logger)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "daemon init: %v\n", err)
 		os.Exit(1)

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,3 +1,41 @@
+// Package version exposes build metadata injected at link time via
+// `go build -ldflags "-X ...Version=..." -ldflags "-X ...Commit=..."
+// -ldflags "-X ...BuildTime=..."`. Default values keep development
+// builds informative without requiring an LDFLAGS dance.
 package version
 
+// Version is the human-readable build version. Set at link time by
+// the Makefile + release workflow to the git tag (e.g. "v1.0.0") or
+// `git describe` output for in-development builds. Defaults to "dev"
+// for `go run` / `go test` invocations.
 var Version = "dev"
+
+// Commit is the short git SHA the binary was built from. Set at
+// link time via -ldflags. Empty for non-LDFLAGS builds.
+var Commit = ""
+
+// BuildTime is the ISO-8601 UTC timestamp at which the binary was
+// built. Set at link time via -ldflags. Empty for non-LDFLAGS builds.
+var BuildTime = ""
+
+// String returns a single-line summary suitable for logging or
+// for the `gophertrunk version` subcommand: "vX.Y.Z (sha=ABC1234,
+// built=2026-05-13T19:00:00Z)". Empty Commit / BuildTime are
+// omitted so dev builds stay compact.
+func String() string {
+	out := Version
+	if Commit != "" || BuildTime != "" {
+		out += " ("
+		if Commit != "" {
+			out += "sha=" + Commit
+		}
+		if Commit != "" && BuildTime != "" {
+			out += ", "
+		}
+		if BuildTime != "" {
+			out += "built=" + BuildTime
+		}
+		out += ")"
+	}
+	return out
+}

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,0 +1,68 @@
+package version
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestStringJustVersion(t *testing.T) {
+	saveV, saveC, saveB := Version, Commit, BuildTime
+	defer func() { Version, Commit, BuildTime = saveV, saveC, saveB }()
+	Version, Commit, BuildTime = "v1.2.3", "", ""
+	got := String()
+	if got != "v1.2.3" {
+		t.Errorf("String() = %q, want %q", got, "v1.2.3")
+	}
+}
+
+func TestStringWithCommitAndBuildTime(t *testing.T) {
+	saveV, saveC, saveB := Version, Commit, BuildTime
+	defer func() { Version, Commit, BuildTime = saveV, saveC, saveB }()
+	Version, Commit, BuildTime = "v1.2.3", "abc1234", "2026-05-13T19:00:00Z"
+	got := String()
+	if !strings.HasPrefix(got, "v1.2.3 (") {
+		t.Errorf("String() = %q, want prefix %q", got, "v1.2.3 (")
+	}
+	for _, want := range []string{"sha=abc1234", "built=2026-05-13T19:00:00Z"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("String() = %q, missing %q", got, want)
+		}
+	}
+}
+
+func TestStringWithCommitOnly(t *testing.T) {
+	saveV, saveC, saveB := Version, Commit, BuildTime
+	defer func() { Version, Commit, BuildTime = saveV, saveC, saveB }()
+	Version, Commit, BuildTime = "v1.2.3", "abc1234", ""
+	got := String()
+	want := "v1.2.3 (sha=abc1234)"
+	if got != want {
+		t.Errorf("String() = %q, want %q", got, want)
+	}
+}
+
+func TestStringWithBuildTimeOnly(t *testing.T) {
+	saveV, saveC, saveB := Version, Commit, BuildTime
+	defer func() { Version, Commit, BuildTime = saveV, saveC, saveB }()
+	Version, Commit, BuildTime = "v1.2.3", "", "2026-05-13T19:00:00Z"
+	got := String()
+	want := "v1.2.3 (built=2026-05-13T19:00:00Z)"
+	if got != want {
+		t.Errorf("String() = %q, want %q", got, want)
+	}
+}
+
+func TestDefaultVersionIsDev(t *testing.T) {
+	// Sanity: an unpopulated build (no -ldflags) reports "dev".
+	// This test runs against the package default; if the package
+	// is ever rebuilt with ldflags, the default constant in the
+	// source is what matters.
+	saveV, saveC, saveB := Version, Commit, BuildTime
+	defer func() { Version, Commit, BuildTime = saveV, saveC, saveB }()
+	// Force the defaults via the package-level vars so we don't
+	// depend on the test binary's actual link state.
+	Version, Commit, BuildTime = "dev", "", ""
+	if got := String(); got != "dev" {
+		t.Errorf("default String() = %q, want %q", got, "dev")
+	}
+}


### PR DESCRIPTION
## Summary

Stacked on #207 (PR-L). Closes Tier 4.8 + 4.10 of the
ship-readiness audit — the last items before tagging a real
v1.0.0.

- **4.8 — Release workflow validation**: `internal/version`
  gains `Commit` + `BuildTime` alongside `Version`; all three
  are populated via `-ldflags`. New `make release-dry-run`
  rehearses the production build locally. CONTRIBUTING.md
  documents the prerelease workflow_dispatch recipe.
- **4.10 — Patent-posture startup banner**: daemon logs a
  one-line AMBE+2 notice at startup pointing operators at
  `docs/vocoders.md`. Suppressible via
  `GOPHERTRUNK_QUIET_BANNER=1` for CI / test harnesses.

## Changes

### `internal/version/version.go`

```diff
 var Version = "dev"
+var Commit = ""
+var BuildTime = ""
+
+func String() string {
+    // "vX.Y.Z (sha=ABC1234, built=2026-05-13T19:00:00Z)"
+    // Empty Commit/BuildTime are omitted.
+}
```

Plus `internal/version/version_test.go` with 5 cases covering
every Commit/BuildTime presence combination.

### `Makefile`

```diff
 VERSION ?= $(shell git describe --tags --dirty --always 2>/dev/null || echo dev)
+COMMIT  ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "")
+BUILD_TIME ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
-LDFLAGS := -X .../version.Version=$(VERSION)
+LDFLAGS := -X .../version.Version=$(VERSION) \
+           -X .../version.Commit=$(COMMIT) \
+           -X .../version.BuildTime=$(BUILD_TIME)
```

New `make release-dry-run VERSION=v0.99.0` target produces
`dist/dry-run/gophertrunk`, runs `./gophertrunk version`
against it, and writes a SHA256SUMS file. Verified end-to-end:

```
→ Rehearsing release build for version v0.99.0
→ COMMIT=ff76b1a BUILD_TIME=2026-05-13T22:49:31Z
→ Built binary reports:
v0.99.0 (sha=ff76b1a, built=2026-05-13T22:49:31Z)
```

### `.github/workflows/release.yml`

Both Windows and Linux build steps now compute `COMMIT` +
`BUILD_TIME` and pass them through `-ldflags`. Previously only
`Version` was injected.

### `cmd/gophertrunk/main.go`

- `gophertrunk version` prints `version.String()` (the new
  formatted output) instead of the bare `Version` var.
- Daemon `Run` logs `version.String()` at startup.
- New patent-posture banner:
  ```
  AMBE+2 voice decoding is patent-encumbered in some
  jurisdictions; see docs/vocoders.md §"Patent posture"
  ```
  Suppressible via `GOPHERTRUNK_QUIET_BANNER=1`.

### `CONTRIBUTING.md`

New **Cutting a release** section: documents `make release-dry-run`,
the `v0.99.0` prerelease recipe through GitHub Actions
**workflow_dispatch**, and the rationale (validate the release
workflow against live infrastructure before cutting `v1.0.0`).

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./internal/version/` — all 5 new tests pass
- [x] `make release-dry-run VERSION=v0.99.0` end-to-end produces
      a binary that reports the injected metadata correctly
- [x] `go test ./...` + `make integration` + `make test-dvsi`
      all green

## Roadmap status

Closes:

- ✅ **PR-M** — Tier 4.8 + 4.10 (release workflow prerelease
  recipe, version ldflags wiring, patent banner)

**Tier 4 is now done.** The remaining roadmap items
(`PR-N` in the plan — capture-spec docs for Tier 5 captures) are
documentation-only and can land independently or be folded into
PR-D / PR-G's existing capture-spec docs.

https://claude.ai/code/session_01LyPnLfVLRAh6ThTENjX59y

---
_Generated by [Claude Code](https://claude.ai/code/session_01LyPnLfVLRAh6ThTENjX59y)_