### PR TITLE
ci: mark v0.x.y + hyphenated tags as GitHub prereleases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,9 +159,22 @@ jobs:
         id: version
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "version=${{ github.event.inputs.version }}" >> "$GITHUB_OUTPUT"
+            VERSION="${{ github.event.inputs.version }}"
           else
-            echo "version=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+            VERSION="${GITHUB_REF#refs/tags/}"
+          fi
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          # SemVer prerelease policy: any v0.x.y tag is treated as a
+          # prerelease (sub-1.0 = "not yet stable" per SemVer §4); any
+          # tag with a hyphenated suffix (e.g. v1.0.0-rc.1, v1.0.0-beta)
+          # is also a prerelease per SemVer §9. Stable releases
+          # (v1.0.0+, no suffix) land with prerelease=false so the
+          # softprops/action-gh-release "latest" auto-detection picks
+          # them as the operator-facing default.
+          if [[ "${VERSION}" =~ ^v0\. ]] || [[ "${VERSION}" == *-* ]]; then
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Publish GitHub Release
@@ -170,6 +183,7 @@ jobs:
           tag_name: ${{ steps.version.outputs.version }}
           name: GopherTrunk ${{ steps.version.outputs.version }}
           generate_release_notes: true
+          prerelease: ${{ steps.version.outputs.prerelease == 'true' }}
           files: |
             out/*
           body: |


### PR DESCRIPTION
## Summary

Small fix needed before pushing the `v0.99.0` tag (a follow-up to
#211): the existing `release.yml` runs `softprops/action-gh-release@v2`
with the default `prerelease=false`, so any tag — including the
intentionally-sub-1.0 `v0.99.0` — lands as a "stable" GitHub
release.

This PR adds a SemVer-aware classification to the **Compute
version** step:

- `v0.x.y` tags → `prerelease=true` (SemVer §4: "anything MAY
  change at any time" until v1.0.0)
- `v*.*.*-suffix` tags (e.g. `v1.0.0-rc.1`, `v1.0.0-beta`) →
  `prerelease=true` (SemVer §9)
- `v1.0.0+` no-suffix tags → `prerelease=false` (stable;
  `softprops/action-gh-release` picks them as the "latest"
  release automatically)

The classification flows directly into the
`prerelease: ${{ steps.version.outputs.prerelease == 'true' }}`
input on the release-publish step.

## Why this lands now

Without this fix, `v0.99.0` would publish with the default
`Latest release` badge — confusing for operators who'd interpret
that as a stable v0.x release. Pushing the fix first lets the
release workflow Do The Right Thing on first run.

## Test plan

The change is on the release workflow, so it only runs on a
tag push (`v*.*.*`) or `workflow_dispatch`. Validated by
inspection: the bash conditional `[[ "${VERSION}" =~ ^v0\. ]] ||
[[ "${VERSION}" == *-* ]]` is the standard SemVer pattern; the
output assignment uses `$GITHUB_OUTPUT` per actions/runner
guidance (no deprecated `set-output`).

After this PR merges, the `v0.99.0` tag can be pushed (or
`workflow_dispatch` triggered) and the release workflow will mark
it prerelease automatically.

https://claude.ai/code/session_01LyPnLfVLRAh6ThTENjX59y

---
_Generated by [Claude Code](https://claude.ai/code/session_01LyPnLfVLRAh6ThTENjX59y)_