### PR TITLE
docs: ship CNAME + site url for gophertrunk.com custom domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -1977,7 +1977,7 @@ to its own package and lands independently.
 
 ### Download a prebuilt release
 
-The fastest path is the **[Downloads page]({{ site.url | default: "https://gophertrunk.com" }}/downloads.html)**
+The fastest path is the **[Downloads page]({{ site.url | default: "https://gophertrunk.org" }}/downloads.html)**
 on the project site — it has per-platform recipes (Linux / Windows /
 macOS / Docker), checksum-verification commands, and pointers to
 the latest tag. Or jump straight to the **[Releases page][releases]**

--- a/README.md
+++ b/README.md
@@ -1977,7 +1977,7 @@ to its own package and lands independently.
 
 ### Download a prebuilt release
 
-The fastest path is the **[Downloads page]({{ site.url | default: "https://mattcheramie.github.io/GopherTrunk" }}/downloads.html)**
+The fastest path is the **[Downloads page]({{ site.url | default: "https://gophertrunk.com" }}/downloads.html)**
 on the project site — it has per-platform recipes (Linux / Windows /
 macOS / Docker), checksum-verification commands, and pointers to
 the latest tag. Or jump straight to the **[Releases page][releases]**

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+gophertrunk.com

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,1 +1,1 @@
-gophertrunk.com
+gophertrunk.org

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,6 +1,6 @@
 title: GopherTrunk
 description: Pure-Go digital trunking radio scanner engine
-url: https://gophertrunk.com
+url: https://gophertrunk.org
 theme: jekyll-theme-cayman
 show_downloads: false
 markdown: kramdown

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,5 +1,6 @@
 title: GopherTrunk
 description: Pure-Go digital trunking radio scanner engine
+url: https://gophertrunk.com
 theme: jekyll-theme-cayman
 show_downloads: false
 markdown: kramdown


### PR DESCRIPTION
GitHub Pages is published via .github/workflows/pages.yml using the
"GitHub Actions" deployment source. With that source, deploy-pages
clears the Pages custom-domain setting on every run unless a CNAME
file ships inside the build artifact. The repo had no docs/CNAME, so
each rebuild was unsetting gophertrunk.com and the site stopped
serving on the custom domain.

- docs/CNAME: pins the apex (gophertrunk.com) into every Pages deploy
- docs/_config.yml: set url so {% seo %} / absolute_url resolve to
  gophertrunk.com instead of falling back to mattcheramie.github.io
- README.md: switch the Downloads-page fallback to gophertrunk.com so
  the rendered link is correct when site.url is unavailable

DNS reminder (manual, outside this repo): apex A records must point
at GitHub's Pages IPs (185.199.108-111.153) and AAAA at the matching
2606:50c0:8000-8003::153 set, with HTTPS enforced in Settings → Pages
after the first successful deploy.

https://claude.ai/code/session_01FMDN3JbmEHAh7j2774d28K