### PR TITLE
Fix GitHub Pages custom domain (gophertrunk.org) + README logo

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -36,7 +36,11 @@ jobs:
         run: |
           {
             printf -- '---\nlayout: default\ntitle: Home\n---\n\n'
-            cat README.md
+            # Rewrite README image/link paths that are relative to the repo
+            # root so they resolve correctly when served from the Jekyll
+            # site root (./docs is the Jekyll source, so docs/assets/foo
+            # is published at /assets/foo).
+            sed -e 's#docs/assets/#/assets/#g' README.md
           } > docs/index.md
 
       - uses: actions/configure-pages@v5


### PR DESCRIPTION
## Summary
- Ship `docs/CNAME` (`gophertrunk.org`) so the GitHub Actions Pages deploy stops wiping the custom domain on every run
- Set `url: https://gophertrunk.org` in `docs/_config.yml` and update the README Downloads-page fallback to match
- Rewrite `docs/assets/` → `/assets/` when synthesizing `docs/index.md` so the README hero logo renders on the Pages site

## Root cause notes
`pages.yml` deploys via `actions/deploy-pages@v4` (Pages source = "GitHub Actions"). With that source, the custom-domain setting is cleared on every deploy unless a `CNAME` file is published in the build artifact. The repo had no `docs/CNAME`, so each rebuild unset `gophertrunk.org` and the apex stopped resolving to a configured site.

The hero image at `README.md:2` (`<img src="docs/assets/gophertrunk-logo.png">`) is correct for github.com (repo-root relative) but resolves to `/docs/assets/...` once the README is inlined into `docs/index.md` — Jekyll publishes the asset at `/assets/...` because `./docs` is the source root, so the image 404'd. Fixed by sed-rewriting the path during the README → index.md step (README.md itself untouched).

## Manual follow-ups (outside this repo)
- DNS for the `gophertrunk.org` apex: A records to `185.199.108-111.153`, AAAA to `2606:50c0:8000-8003::153`
- After merge + first successful Pages deploy, confirm the custom domain shows in Settings → Pages and tick **Enforce HTTPS**

## Known related issue (not fixed here)
The README has ~25 `](docs/foo.md)` cross-links that have the same root-relative problem on the Pages site. Happy to follow up if wanted.

## Test plan
- [ ] Merge → `pages.yml` runs on `main`
- [ ] Confirm Settings → Pages still shows `gophertrunk.org` after deploy (no longer cleared)
- [ ] Load `https://gophertrunk.org/` — header logo *and* the hero logo below the nav both render
- [ ] Load `https://gophertrunk.org/downloads.html` — page resolves
- [ ] Tick **Enforce HTTPS** once the cert provisions

https://claude.ai/code/session_01FMDN3JbmEHAh7j2774d28K

---
_Generated by [Claude Code](https://claude.ai/code/session_01FMDN3JbmEHAh7j2774d28K)_