### PR TITLE
Pages: stop hidden mobile drawer from overlaying the nav

### DIFF
--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -150,13 +150,13 @@ button { font: inherit; cursor: pointer; }
   z-index: 100;
   background: var(--bg);
   border-bottom: 1px solid var(--border);
-  backdrop-filter: saturate(180%) blur(8px);
+  padding-top: env(safe-area-inset-top, 0);
 }
 .site-nav__inner {
   display: flex;
   align-items: center;
   gap: 1rem;
-  min-height: 60px;
+  height: 56px;
 }
 .site-nav__brand {
   display: flex;
@@ -164,8 +164,10 @@ button { font: inherit; cursor: pointer; }
   gap: 0.55rem;
   font-weight: 700;
   font-size: 1.05rem;
+  line-height: 1;
   color: var(--fg);
   text-decoration: none;
+  flex-shrink: 0;
 }
 .site-nav__brand:hover { color: var(--fg); text-decoration: none; }
 .site-nav__brand img { width: 28px; height: 28px; }
@@ -299,7 +301,7 @@ button { font: inherit; cursor: pointer; }
   .site-nav__hamburger { display: inline-flex; }
   .site-nav__menu {
     position: fixed;
-    top: 60px;
+    top: calc(56px + env(safe-area-inset-top, 0px));
     right: 0;
     left: 0;
     flex-direction: column;

--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -310,11 +310,18 @@ button { font: inherit; cursor: pointer; }
     background: var(--bg);
     border-bottom: 1px solid var(--border);
     box-shadow: var(--shadow);
-    transform: translateY(-110%);
-    transition: transform 0.18s ease;
+    transform: translateY(-100%);
+    visibility: hidden;
+    pointer-events: none;
+    transition: transform 0.18s ease, visibility 0s linear 0.18s;
     z-index: 99;
   }
-  body.nav-open .site-nav__menu { transform: translateY(0); }
+  body.nav-open .site-nav__menu {
+    transform: translateY(0);
+    visibility: visible;
+    pointer-events: auto;
+    transition: transform 0.18s ease, visibility 0s linear 0s;
+  }
   .site-nav__groups {
     flex-direction: column;
     align-items: stretch;


### PR DESCRIPTION
## Summary

Fixes the mobile nav rendering issue at https://gophertrunk.org/ — the brand wordmark and hamburger button were appearing with their top portion cut off, as if covered by an invisible box.

## Root cause

**The "box covering the nav" is the hidden mobile menu drawer.** `.site-nav__menu` was using `transform: translateY(-110%)` to hide itself when closed, but `-110%` is relative to the drawer's **own height**, not the viewport. For a short drawer (~350-400 px tall on this page) the bottom 20-40 px of the "hidden" element still poked down into the visible nav row, painting its background + border-bottom across the brand wordmark and hamburger button.

Math: with drawer height H and `top: 56px`, after `translateY(-110% of H) = -1.1H` the new bottom edge sits at `56 + H - 1.1H = 56 - 0.1H`. For H = 400 px that's y = 16 px — 40 px of "hidden" drawer bleeding into the nav.

Secondary cleanup: a couple of compounding fragilities in `.site-nav` itself that made the bug worse on mobile Chrome / WebKit.

## Fixes (`docs/assets/css/style.scss`)

**Commit 1 — nav itself**
- Drop `backdrop-filter: saturate(180%) blur(8px)` from `.site-nav`. With `background: var(--bg)` (opaque) the filter is a visual no-op but forces a GPU compositing layer, which on mobile Chrome / WebKit subtly mispositions sticky-element children.
- Switch `.site-nav__inner` from `min-height: 60px` to `height: 56px` — predictable flex sizing under sticky compositing.
- Add `line-height: 1` and `flex-shrink: 0` to `.site-nav__brand` so the wordmark line-box doesn't drift between system font fallbacks.
- Add `padding-top: env(safe-area-inset-top, 0)` to `.site-nav` and track the inset in the mobile drawer's `top`.

**Commit 2 — the actual culprit**
- Closed drawer state: `transform: translateY(-100%)` + `visibility: hidden` + `pointer-events: none`. `visibility: hidden` guarantees the drawer is genuinely gone regardless of how short it is.
- Open drawer state: `transform: translateY(0)` + `visibility: visible` + `pointer-events: auto`.
- Stagger the visibility transition with a 0.18 s delay when closing (so the slide-up animation plays before the drawer vanishes) and 0 s when opening (so the drawer is paintable before the slide-in starts).

## Test plan

- [ ] Merge → `pages.yml` deploys
- [ ] Hard-refresh `https://gophertrunk.org/` on mobile (bypass cached CSS)
- [ ] Brand wordmark, logo, hamburger fully visible and vertically centered in the nav — no "box" overlapping the top
- [ ] Tap hamburger → drawer slides down with all 4 group menus
- [ ] Tap again → drawer slides up and disappears cleanly (no residue painted across the nav)
- [ ] iPhone Safari (notch device) — nav sits below the notch inset
- [ ] Scroll page — sticky nav stays put, no compositing flicker

https://claude.ai/code/session_01FMDN3JbmEHAh7j2774d28K