### PR TITLE
Pages: mobile-friendly .prose tables (wrap long IDs + horizontal scroll fallback)

### DIFF
--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -128,16 +128,32 @@ button { font: inherit; cursor: pointer; }
 }
 
 .prose table {
-  border-collapse: collapse;
+  display: block;
   width: 100%;
+  max-width: 100%;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  border-collapse: collapse;
   font-size: 0.92rem;
 }
 .prose th, .prose td {
   border: 1px solid var(--border);
   padding: 0.5rem 0.75rem;
   text-align: left;
+  vertical-align: top;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 .prose th { background: var(--bg-elev); }
+.prose th:first-child, .prose td:first-child {
+  min-width: 7rem;
+}
+
+@media (max-width: 800px) {
+  .prose table { font-size: 0.85rem; }
+  .prose th, .prose td { padding: 0.4rem 0.55rem; }
+  .prose th:first-child, .prose td:first-child { min-width: 5.5rem; }
+}
 
 .prose img {
   border-radius: var(--radius-sm);


### PR DESCRIPTION
## Summary

Fixes the features table on the landing page (and every other `.prose` table) overflowing the right edge of mobile viewports. The Component cells contain long unbreakable strings like `R820T/R820T2/R828D/E4000/FC0012/FC0013/FC2580` and backtick paths (`internal/radio/p25/phase2/receiver`) that don't break on word boundaries, so the table grows wider than the screen and the content gets clipped.

## Fix

Two changes layered together in `docs/assets/css/style.scss`:

1. **Cells break aggressively** — `overflow-wrap: anywhere` + `word-break: break-word` so slash-separated identifier runs and long backtick paths wrap at any character. `vertical-align: top` keeps multi-line rows readable.
2. **Table is horizontally scrollable as a fallback** — `display: block` + `overflow-x: auto` + `-webkit-overflow-scrolling: touch`. If cell wrapping still isn't enough on very narrow viewports, the table scrolls instead of clipping.

Plus:
- First-column `min-width: 7rem` (5.5rem on mobile) so the "Area" labels don't get squeezed to one letter per line when the Component column dominates.
- Tighter font (`0.85rem`) and padding (`0.4rem 0.55rem`) on screens ≤800 px.

## Test plan

- [ ] Merge → `pages.yml` deploys
- [ ] Load `https://gophertrunk.org/` on a 360-414 px wide phone — features table fits without right-edge clipping; long identifier strings wrap inside cells
- [ ] If a row is still too wide (e.g. on very narrow displays), the table scrolls horizontally with momentum
- [ ] Desktop ≥800 px — table renders at full width with original padding and font size
- [ ] Light + dark mode both render correctly (no color regressions)
- [ ] Other `.prose` tables (downloads.md "What ships in every release", architecture.md, etc.) all benefit from the same wrapping behavior

https://claude.ai/code/session_01FMDN3JbmEHAh7j2774d28K

---
_Generated by [Claude Code](https://claude.ai/code/session_01FMDN3JbmEHAh7j2774d28K)_