### PR TITLE
Release: add Linux arm64 + Windows arm64 builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,9 +11,11 @@ name: Release
 #
 # Outputs in the GitHub Release:
 #
-#   gophertrunk-<ver>-windows-amd64-setup.exe   one-click installer
-#   gophertrunk-<ver>-windows-amd64.zip         portable ZIP (no installer)
-#   gophertrunk-<ver>-linux-amd64.tar.gz        Linux tarball
+#   gophertrunk-<ver>-windows-amd64-setup.exe   one-click installer (x64)
+#   gophertrunk-<ver>-windows-amd64.zip         portable ZIP (x64)
+#   gophertrunk-<ver>-windows-arm64.zip         portable ZIP (Windows on ARM)
+#   gophertrunk-<ver>-linux-amd64.tar.gz        Linux x86_64 tarball
+#   gophertrunk-<ver>-linux-arm64.tar.gz        Linux aarch64 tarball
 #   gophertrunk-<ver>-darwin-amd64.tar.gz       macOS Intel tarball
 #   gophertrunk-<ver>-darwin-arm64.tar.gz       macOS Apple Silicon tarball
 #   SHA256SUMS                                  per-file SHA-256 checksums
@@ -75,7 +77,7 @@ jobs:
           cp README.md LICENSE config.example.yaml "$STAGE/"
           cp docs/install-windows.md "$STAGE/INSTALL-WINDOWS.md"
 
-      - name: Build portable ZIP
+      - name: Build portable ZIP (amd64)
         shell: bash
         run: |
           set -eu
@@ -85,21 +87,43 @@ jobs:
           cp -r dist/staging/. "dist/${NAME}/"
           (cd dist && 7z a "${NAME}.zip" "${NAME}")
 
-      - name: Build Inno Setup installer
+      - name: Build Inno Setup installer (amd64)
         uses: Minionguyjpro/Inno-Setup-Action@v1.2.5
         with:
           path: installer/windows/gophertrunk.iss
           options: /DAppVersion=${{ steps.version.outputs.version }} /Qp
 
+      - name: Build gophertrunk.exe (arm64)
+        shell: bash
+        env:
+          CGO_ENABLED: "0"
+          GOOS: windows
+          GOARCH: arm64
+        run: |
+          set -eu
+          VERSION="${{ steps.version.outputs.version }}"
+          COMMIT="$(git rev-parse --short HEAD)"
+          BUILD_TIME="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          NAME="gophertrunk-${VERSION}-windows-arm64"
+          mkdir -p "dist/${NAME}"
+          go build \
+            -trimpath \
+            -ldflags "-X github.com/MattCheramie/GopherTrunk/internal/version.Version=${VERSION} -X github.com/MattCheramie/GopherTrunk/internal/version.Commit=${COMMIT} -X github.com/MattCheramie/GopherTrunk/internal/version.BuildTime=${BUILD_TIME}" \
+            -o "dist/${NAME}/gophertrunk.exe" \
+            ./cmd/gophertrunk
+          cp README.md LICENSE config.example.yaml "dist/${NAME}/"
+          cp docs/install-windows.md "dist/${NAME}/INSTALL-WINDOWS.md"
+          (cd dist && 7z a "${NAME}.zip" "${NAME}")
+
       - uses: actions/upload-artifact@v4
         with:
-          name: windows-amd64
+          name: windows
           path: |
             dist/*.zip
             dist/*setup.exe
 
   linux:
-    name: Build Linux tarball
+    name: Build Linux tarballs
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -117,26 +141,31 @@ jobs:
             echo "version=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Build gophertrunk
+      - name: Build Linux tarballs
         env:
           CGO_ENABLED: "0"
+          GOOS: linux
         run: |
+          set -eu
           VERSION="${{ steps.version.outputs.version }}"
           COMMIT="$(git rev-parse --short HEAD)"
           BUILD_TIME="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-          NAME="gophertrunk-${VERSION}-linux-amd64"
-          mkdir -p "dist/${NAME}"
-          go build \
-            -trimpath \
-            -ldflags "-X github.com/MattCheramie/GopherTrunk/internal/version.Version=${VERSION} -X github.com/MattCheramie/GopherTrunk/internal/version.Commit=${COMMIT} -X github.com/MattCheramie/GopherTrunk/internal/version.BuildTime=${BUILD_TIME}" \
-            -o "dist/${NAME}/gophertrunk" \
-            ./cmd/gophertrunk
-          cp README.md LICENSE config.example.yaml "dist/${NAME}/"
-          (cd dist && tar -czf "${NAME}.tar.gz" "${NAME}")
+          LDFLAGS="-X github.com/MattCheramie/GopherTrunk/internal/version.Version=${VERSION} -X github.com/MattCheramie/GopherTrunk/internal/version.Commit=${COMMIT} -X github.com/MattCheramie/GopherTrunk/internal/version.BuildTime=${BUILD_TIME}"
+          for ARCH in amd64 arm64; do
+            NAME="gophertrunk-${VERSION}-linux-${ARCH}"
+            mkdir -p "dist/${NAME}"
+            GOARCH="${ARCH}" go build \
+              -trimpath \
+              -ldflags "${LDFLAGS}" \
+              -o "dist/${NAME}/gophertrunk" \
+              ./cmd/gophertrunk
+            cp README.md LICENSE config.example.yaml "dist/${NAME}/"
+            (cd dist && tar -czf "${NAME}.tar.gz" "${NAME}")
+          done
 
       - uses: actions/upload-artifact@v4
         with:
-          name: linux-amd64
+          name: linux
           path: dist/*.tar.gz
 
   macos:
@@ -237,10 +266,12 @@ jobs:
           body: |
             ## Install
 
-            **Windows 11:** download `gophertrunk-${{ steps.version.outputs.version }}-windows-amd64-setup.exe` and double-click. The installer adds GopherTrunk to your Start Menu — single static binary, no DLLs to ship. After install, follow [INSTALL-WINDOWS.md](https://github.com/MattCheramie/GopherTrunk/blob/main/docs/install-windows.md) to install the WinUSB driver via Zadig — the OS won't see your RTL-SDR until you do this once.
+            **Windows 11 (x64):** download `gophertrunk-${{ steps.version.outputs.version }}-windows-amd64-setup.exe` and double-click. The installer adds GopherTrunk to your Start Menu — single static binary, no DLLs to ship. After install, follow [INSTALL-WINDOWS.md](https://github.com/MattCheramie/GopherTrunk/blob/main/docs/install-windows.md) to install the WinUSB driver via Zadig — the OS won't see your RTL-SDR until you do this once.
+
+            **Windows on ARM:** extract `gophertrunk-${{ steps.version.outputs.version }}-windows-arm64.zip` (no installer for arm64 yet — portable ZIP only).
 
             **macOS:** extract `gophertrunk-${{ steps.version.outputs.version }}-darwin-arm64.tar.gz` (Apple Silicon) or `gophertrunk-${{ steps.version.outputs.version }}-darwin-amd64.tar.gz` (Intel) and run `./gophertrunk`. Builds are unsigned — right-click → Open the first time to bypass Gatekeeper.
 
-            **Linux:** extract `gophertrunk-${{ steps.version.outputs.version }}-linux-amd64.tar.gz` and run `./gophertrunk`. Single static binary; no system dependencies needed.
+            **Linux:** extract `gophertrunk-${{ steps.version.outputs.version }}-linux-amd64.tar.gz` (x86_64) or `gophertrunk-${{ steps.version.outputs.version }}-linux-arm64.tar.gz` (aarch64, e.g. Raspberry Pi 4/5) and run `./gophertrunk`. Single static binary; no system dependencies needed.
 
             All artifacts are SHA-256-checksummed in `SHA256SUMS`.

--- a/docs/downloads.md
+++ b/docs/downloads.md
@@ -25,10 +25,11 @@ nav_group: Install
 
   <div class="download-card">
     <h3>Windows 11</h3>
-    <p class="download-card__lede">One-click installer, signed static binary, no DLLs to ship.</p>
+    <p class="download-card__lede">One-click installer (x64), portable ZIPs for x64 and ARM.</p>
     <div class="download-card__buttons">
-      <a class="btn btn--primary" href="{{ rel_url }}/gophertrunk-{{ ver }}-windows-amd64-setup.exe">Installer (.exe)</a>
-      <a class="btn btn--secondary" href="{{ rel_url }}/gophertrunk-{{ ver }}-windows-amd64.zip">Portable (.zip)</a>
+      <a class="btn btn--primary" href="{{ rel_url }}/gophertrunk-{{ ver }}-windows-amd64-setup.exe">x64 Installer (.exe)</a>
+      <a class="btn btn--secondary" href="{{ rel_url }}/gophertrunk-{{ ver }}-windows-amd64.zip">x64 Portable (.zip)</a>
+      <a class="btn btn--secondary" href="{{ rel_url }}/gophertrunk-{{ ver }}-windows-arm64.zip">ARM64 Portable (.zip)</a>
     </div>
     <p class="download-card__note">After install, swap the WinUSB driver via <a href="{{ '/install-windows.html' | relative_url }}">Zadig</a> — the OS won't see your RTL-SDR until you do this once.</p>
   </div>
@@ -48,8 +49,9 @@ nav_group: Install
     <p class="download-card__lede">Tarballed static binary. No <code>librtlsdr</code> or <code>libusb</code> at runtime.</p>
     <div class="download-card__buttons">
       <a class="btn btn--primary" href="{{ rel_url }}/gophertrunk-{{ ver }}-linux-amd64.tar.gz">x86_64 (.tar.gz)</a>
+      <a class="btn btn--secondary" href="{{ rel_url }}/gophertrunk-{{ ver }}-linux-arm64.tar.gz">aarch64 (.tar.gz)</a>
     </div>
-    <p class="download-card__note">RTL-SDR needs <a href="{{ '/hardware.html' | relative_url }}">udev rules + DVB blacklist</a> on first install.</p>
+    <p class="download-card__note">aarch64 covers Raspberry Pi 4 / 5 + most modern ARM SBCs. RTL-SDR needs <a href="{{ '/hardware.html' | relative_url }}">udev rules + DVB blacklist</a> on first install.</p>
   </div>
 
 </div>
@@ -90,10 +92,15 @@ The `sha=` value matches the commit on the [release tag][releases]; `built=` is 
 
 ```sh
 VERSION={{ ver }}
+ARCH=$(uname -m)                            # x86_64 or aarch64 / arm64
+case "$ARCH" in
+  x86_64)         PKG=linux-amd64 ;;
+  aarch64|arm64)  PKG=linux-arm64 ;;
+esac
 curl -L -o gophertrunk.tar.gz \
-  https://github.com/MattCheramie/GopherTrunk/releases/download/${VERSION}/gophertrunk-${VERSION}-linux-amd64.tar.gz
+  https://github.com/MattCheramie/GopherTrunk/releases/download/${VERSION}/gophertrunk-${VERSION}-${PKG}.tar.gz
 tar xzf gophertrunk.tar.gz
-cd gophertrunk-${VERSION}-linux-amd64
+cd gophertrunk-${VERSION}-${PKG}
 cp config.example.yaml config.yaml          # edit before launch
 ./gophertrunk version                       # confirms ldflags landed
 ./gophertrunk run -config config.yaml


### PR DESCRIPTION
## Summary

Extends the release matrix to cover the two arm64 platforms that were missing — Linux aarch64 and Windows on ARM. Keeps every existing artifact intact; only adds new ones.

## New artifacts per release

- `gophertrunk-<ver>-linux-arm64.tar.gz` — covers Raspberry Pi 4/5 and most modern ARM SBCs
- `gophertrunk-<ver>-windows-arm64.zip` — portable ZIP for Windows on ARM (no installer yet)

## Changes

### `.github/workflows/release.yml`

- **`linux` job** — renamed to "Build Linux tarballs", now loops over `amd64 + arm64` (mirrors the `macos` job structure). Artifact upload renamed `linux-amd64` → `linux` since it carries multiple archs.
- **`windows` job** — keeps the amd64 portable ZIP + Inno Setup installer as-is, adds a follow-up step that cross-builds arm64 with `GOOS=windows GOARCH=arm64` and packs `gophertrunk-<ver>-windows-arm64.zip`. No arm64 installer because the `.iss` is amd64-only — Windows-on-ARM users are typically fine with portable extraction.
- **Header doc + release-body template** — every archive now lists its arch label so the auto-generated release notes are accurate.

### `docs/downloads.md`

- Windows card adds ARM64 portable ZIP alongside the existing x64 installer + portable
- Linux card adds aarch64 tarball with a note about Pi 4/5 / ARM SBCs
- Linux quick-start `uname -m`s into the right arch package automatically

## Backfilling v0.1.0

Same situation as the macOS job in #217: these new archives won't exist for the already-published `v0.1.0` release. To attach them, re-run the workflow:

```sh
gh workflow run release.yml -f version=v0.1.0
```

Otherwise the next tag picks them up automatically.

## Test plan

- [ ] Push a new tag (or `workflow_dispatch` v0.1.0)
- [ ] All three jobs (`windows`, `linux`, `macos`) succeed
- [ ] GitHub release contains: 2 Windows files (amd64 setup.exe + zip) + 1 Windows arm64 zip + 2 Linux tarballs (amd64 + arm64) + 2 macOS tarballs + SHA256SUMS = 8 files
- [ ] On a Raspberry Pi: `tar xzf gophertrunk-<ver>-linux-arm64.tar.gz && cd ... && ./gophertrunk version` reports the tag
- [ ] On Windows on ARM (or Surface Pro X): extract the arm64 zip and run `gophertrunk.exe version`
- [ ] gophertrunk.org/downloads.html shows all download buttons; each resolves to a real asset

## Future work (out of scope)

- Inno Setup arm64 installer — needs `.iss` updates and a separate iscc invocation per arch
- macOS Universal Binary (single tarball that runs on both Intel + Apple Silicon) — would simplify the macOS card to a single button
- Linux distro packages (.deb / .rpm / Arch) — different scope, different workflow

https://claude.ai/code/session_01FMDN3JbmEHAh7j2774d28K

---
_Generated by [Claude Code](https://claude.ai/code/session_01FMDN3JbmEHAh7j2774d28K)_