### PR TITLE
downloads + install docs: surface binaries, parallel Linux/macOS guides

### DIFF
--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -521,6 +521,25 @@ button { font: inherit; cursor: pointer; }
   font-weight: 600;
   border-bottom: none;
   padding-bottom: 0;
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  flex-wrap: wrap;
+}
+.download-card--match {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 1px var(--accent) inset;
+}
+.download-card__badge {
+  display: inline-block;
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 0.15rem 0.45rem;
+  border-radius: 999px;
+  background: var(--accent);
+  color: #fff;
 }
 .download-card__lede {
   color: var(--fg-muted);

--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -493,6 +493,14 @@ button { font: inherit; cursor: pointer; }
 .downloads-version a { color: var(--fg); }
 .downloads-version a:hover { color: var(--accent); }
 
+.downloads-jump {
+  font-size: 0.92rem;
+  color: var(--fg-muted);
+  margin: 0 0 2rem;
+}
+.downloads-jump a { color: var(--fg); }
+.downloads-jump a:hover { color: var(--accent); }
+
 .download-cards {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));

--- a/docs/assets/js/site.js
+++ b/docs/assets/js/site.js
@@ -23,6 +23,31 @@
     });
   }
 
+  // Downloads page: highlight the card matching the visitor's OS
+  var cards = document.querySelectorAll('.download-card[data-platform]');
+  if (cards.length) {
+    var uad = navigator.userAgentData;
+    var hay = ((uad && uad.platform) || navigator.platform || '') + ' ' + (navigator.userAgent || '');
+    hay = hay.toLowerCase();
+    var detected = null;
+    if (/win/.test(hay))                              detected = 'windows';
+    else if (/mac|darwin|iphone|ipad/.test(hay))      detected = 'macos';
+    else if (/linux|x11|android|cros/.test(hay))      detected = 'linux';
+    if (detected) {
+      cards.forEach(function (card) {
+        if (card.dataset.platform !== detected) return;
+        card.classList.add('download-card--match');
+        var h3 = card.querySelector('h3');
+        if (h3 && !h3.querySelector('.download-card__badge')) {
+          var badge = document.createElement('span');
+          badge.className = 'download-card__badge';
+          badge.textContent = 'Your platform';
+          h3.appendChild(badge);
+        }
+      });
+    }
+  }
+
   // Mobile: tap a group label to expand its submenu (desktop uses :hover/:focus-within)
   var isCoarse = window.matchMedia('(max-width: 800px)').matches;
   if (isCoarse) {

--- a/docs/downloads.md
+++ b/docs/downloads.md
@@ -24,7 +24,7 @@ nav_group: Install
 
 <div class="download-cards">
 
-  <div class="download-card">
+  <div class="download-card" data-platform="linux">
     <h3>Linux</h3>
     <p class="download-card__lede">Tarballed static binary. No <code>librtlsdr</code> or <code>libusb</code> at runtime.</p>
     <div class="download-card__buttons">
@@ -34,7 +34,7 @@ nav_group: Install
     <p class="download-card__note">aarch64 covers Raspberry Pi 4 / 5 + most modern ARM SBCs. RTL-SDR needs <a href="{{ '/hardware.html' | relative_url }}">udev rules + DVB blacklist</a> on first install.</p>
   </div>
 
-  <div class="download-card">
+  <div class="download-card" data-platform="macos">
     <h3>macOS</h3>
     <p class="download-card__lede">Static binary + sample config. Bundled with README and LICENSE.</p>
     <div class="download-card__buttons">
@@ -44,7 +44,7 @@ nav_group: Install
     <p class="download-card__note">Builds are unsigned — right-click → Open the first time to bypass Gatekeeper, or run <code>xattr -dr com.apple.quarantine gophertrunk</code>.</p>
   </div>
 
-  <div class="download-card">
+  <div class="download-card" data-platform="windows">
     <h3>Windows 11</h3>
     <p class="download-card__lede">One-click installer (x64), portable ZIPs for x64 and ARM.</p>
     <div class="download-card__buttons">

--- a/docs/downloads.md
+++ b/docs/downloads.md
@@ -19,9 +19,30 @@ nav_group: Install
   Latest release: <a href="https://github.com/MattCheramie/GopherTrunk/releases/tag/{{ ver }}"><strong>{{ ver }}</strong></a>
   · <a href="https://github.com/MattCheramie/GopherTrunk/releases">all releases</a>
   · <a href="{{ rel_url }}/SHA256SUMS"><code>SHA256SUMS</code></a>
+  · <a href="#verify-your-download">verify</a>
 </p>
 
 <div class="download-cards">
+
+  <div class="download-card">
+    <h3>Linux</h3>
+    <p class="download-card__lede">Tarballed static binary. No <code>librtlsdr</code> or <code>libusb</code> at runtime.</p>
+    <div class="download-card__buttons">
+      <a class="btn btn--primary" href="{{ rel_url }}/gophertrunk-{{ ver }}-linux-amd64.tar.gz">x86_64 (.tar.gz)</a>
+      <a class="btn btn--primary" href="{{ rel_url }}/gophertrunk-{{ ver }}-linux-arm64.tar.gz">aarch64 (.tar.gz)</a>
+    </div>
+    <p class="download-card__note">aarch64 covers Raspberry Pi 4 / 5 + most modern ARM SBCs. RTL-SDR needs <a href="{{ '/hardware.html' | relative_url }}">udev rules + DVB blacklist</a> on first install.</p>
+  </div>
+
+  <div class="download-card">
+    <h3>macOS</h3>
+    <p class="download-card__lede">Static binary + sample config. Bundled with README and LICENSE.</p>
+    <div class="download-card__buttons">
+      <a class="btn btn--primary" href="{{ rel_url }}/gophertrunk-{{ ver }}-darwin-arm64.tar.gz">Apple Silicon (.tar.gz)</a>
+      <a class="btn btn--primary" href="{{ rel_url }}/gophertrunk-{{ ver }}-darwin-amd64.tar.gz">Intel (.tar.gz)</a>
+    </div>
+    <p class="download-card__note">Builds are unsigned — right-click → Open the first time to bypass Gatekeeper, or run <code>xattr -dr com.apple.quarantine gophertrunk</code>.</p>
+  </div>
 
   <div class="download-card">
     <h3>Windows 11</h3>
@@ -34,54 +55,11 @@ nav_group: Install
     <p class="download-card__note">After install, swap the WinUSB driver via <a href="{{ '/install-windows.html' | relative_url }}">Zadig</a> — the OS won't see your RTL-SDR until you do this once.</p>
   </div>
 
-  <div class="download-card">
-    <h3>macOS</h3>
-    <p class="download-card__lede">Static binary + sample config. Bundled with README and LICENSE.</p>
-    <div class="download-card__buttons">
-      <a class="btn btn--primary" href="{{ rel_url }}/gophertrunk-{{ ver }}-darwin-arm64.tar.gz">Apple Silicon (.tar.gz)</a>
-      <a class="btn btn--secondary" href="{{ rel_url }}/gophertrunk-{{ ver }}-darwin-amd64.tar.gz">Intel (.tar.gz)</a>
-    </div>
-    <p class="download-card__note">Builds are unsigned — right-click → Open the first time to bypass Gatekeeper, or run <code>xattr -dr com.apple.quarantine gophertrunk</code>.</p>
-  </div>
-
-  <div class="download-card">
-    <h3>Linux</h3>
-    <p class="download-card__lede">Tarballed static binary. No <code>librtlsdr</code> or <code>libusb</code> at runtime.</p>
-    <div class="download-card__buttons">
-      <a class="btn btn--primary" href="{{ rel_url }}/gophertrunk-{{ ver }}-linux-amd64.tar.gz">x86_64 (.tar.gz)</a>
-      <a class="btn btn--secondary" href="{{ rel_url }}/gophertrunk-{{ ver }}-linux-arm64.tar.gz">aarch64 (.tar.gz)</a>
-    </div>
-    <p class="download-card__note">aarch64 covers Raspberry Pi 4 / 5 + most modern ARM SBCs. RTL-SDR needs <a href="{{ '/hardware.html' | relative_url }}">udev rules + DVB blacklist</a> on first install.</p>
-  </div>
-
 </div>
 
-## Verify your download
-
-Every binary archive is SHA-256-checksummed. Refuse to install on a hash mismatch:
-
-```sh
-# Linux / macOS
-curl -L -O {{ rel_url }}/SHA256SUMS
-sha256sum --ignore-missing -c SHA256SUMS    # Linux
-shasum -a 256 --ignore-missing -c SHA256SUMS  # macOS
-```
-
-```powershell
-# Windows
-$expected = (Get-Content SHA256SUMS | Select-String "windows-amd64-setup.exe").ToString().Split(" ")[0]
-$actual = (Get-FileHash gophertrunk-{{ ver }}-windows-amd64-setup.exe -Algorithm SHA256).Hash.ToLower()
-if ($actual -ne $expected) { throw "checksum mismatch" }
-```
-
-The daemon also self-reports its build provenance — every release pins the commit + build time at link time:
-
-```sh
-$ ./gophertrunk version
-{{ ver }} (sha=abc1234, built=2026-05-13T19:00:00Z)
-```
-
-The `sha=` value matches the commit on the [release tag][releases]; `built=` is the UTC timestamp the CI runner produced the artefact. Both are injected via `-ldflags` and are empty on `go run` / `go test` builds.
+<p class="downloads-jump">
+  Jump to: <a href="#linux">Linux quick start</a> · <a href="#macos">macOS quick start</a> · <a href="#windows-11">Windows quick start</a> · <a href="#verify-your-download">Verify</a> · <a href="#build-from-source">Build from source</a> · <a href="#docker">Docker</a>
+</p>
 
 [releases]: https://github.com/MattCheramie/GopherTrunk/releases
 [latest]: https://github.com/MattCheramie/GopherTrunk/releases/latest
@@ -139,6 +117,33 @@ Run the installer:
 ```
 
 After install, complete the WinUSB driver swap via Zadig — see **[`install-windows.md`]({{ '/install-windows.html' | relative_url }})** for the full step-by-step (the installer's last page links there too). The OS won't see your RTL-SDR until that swap is done.
+
+## Verify your download
+
+Every binary archive is SHA-256-checksummed. Refuse to install on a hash mismatch:
+
+```sh
+# Linux / macOS
+curl -L -O {{ rel_url }}/SHA256SUMS
+sha256sum --ignore-missing -c SHA256SUMS    # Linux
+shasum -a 256 --ignore-missing -c SHA256SUMS  # macOS
+```
+
+```powershell
+# Windows
+$expected = (Get-Content SHA256SUMS | Select-String "windows-amd64-setup.exe").ToString().Split(" ")[0]
+$actual = (Get-FileHash gophertrunk-{{ ver }}-windows-amd64-setup.exe -Algorithm SHA256).Hash.ToLower()
+if ($actual -ne $expected) { throw "checksum mismatch" }
+```
+
+The daemon also self-reports its build provenance — every release pins the commit + build time at link time:
+
+```sh
+$ ./gophertrunk version
+{{ ver }} (sha=abc1234, built=2026-05-13T19:00:00Z)
+```
+
+The `sha=` value matches the commit on the [release tag][releases]; `built=` is the UTC timestamp the CI runner produced the artefact. Both are injected via `-ldflags` and are empty on `go run` / `go test` builds.
 
 ## Build from source
 


### PR DESCRIPTION
## Summary

Reorganize the release/downloads page so binaries are surfaced at the top, and add parallel install guides for Linux and macOS to match the existing Windows install doc.

### Downloads page (`docs/downloads.md`)
- **Cards moved to the top.** Reordered Linux → macOS → Windows (most common deploy target first). Both arch buttons in Linux/macOS cards are now primary so neither is visually demoted.
- **Verify-your-download moved below the OS quick-starts** where it actually belongs in the flow — it used to wedge between the cards and the per-OS curl commands.
- **Jump-nav under the cards** skips straight to Linux/macOS/Windows quick-start, Verify, Build from source, or Docker.
- **Each download card links to its install guide** (Linux / macOS / Windows) so the full walkthrough is one hop from the binary.

### OS auto-detect (`docs/assets/js/site.js` + CSS)
- UA-sniff (`userAgentData.platform` → `navigator.platform` → `userAgent`) tags one of linux/macos/windows and adds `.download-card--match` + a "Your platform" pill so the right binary jumps out without scanning. Pure progressive enhancement — if JS is off or detection misses, all three cards still render side-by-side as before.

### Parallel install guides (new)
- **`docs/install-linux.md`** — five-step walkthrough mirroring the Windows page: download → install binary → udev rule + DVB blacklist (the Linux equivalent of the Zadig WinUSB swap) → verify → run, plus a systemd-service section using the existing `docs/gophertrunk.service` unit, uninstall, and a troubleshooting matrix.
- **`docs/install-macos.md`** — same five-step shape: download → install binary → Gatekeeper quarantine bypass → verify → run, plus a launchd LaunchAgent plist, uninstall, and troubleshooting. Notes that IOKit means no driver swap (no Zadig / udev equivalent).
- **Nav** updated to surface both new pages under the Install group.
- **`docs/hardware.md`** — dropped the stale "macOS lands in a follow-up" line (the IOKit backend is shipped) and added cross-links to the new install pages from the per-OS subsections.

## Test plan

- [ ] Build the Jekyll site locally (`bundle exec jekyll serve`) and load `/downloads.html`
- [ ] Confirm cards appear immediately under the version line, in order Linux → macOS → Windows
- [ ] Confirm the card matching your current OS shows the "Your platform" pill and accent border
- [ ] Switch UA (Chrome DevTools → Network conditions → User agent) and confirm the badge moves between cards
- [ ] Disable JS and confirm all three cards still render cleanly with no badge
- [ ] Click the jump-nav links and confirm they scroll to the right `##` headings
- [ ] Confirm "Verify your download" now sits between the Windows quick-start and "Build from source"
- [ ] Load `/install-linux.html` and `/install-macos.html`; confirm both render and the Install nav group lists all three install pages
- [ ] From each download card, click the install-guide link and confirm it lands on the matching install page
- [ ] Confirm `docs/hardware.md` no longer references the closed macOS follow-up and that the per-OS subsections cross-link to the install pages