### PR TITLE
docs: parallel Linux + macOS install guides

### DIFF
--- a/docs/_data/nav.yml
+++ b/docs/_data/nav.yml
@@ -5,6 +5,10 @@ groups:
         url: /downloads.html
       - title: Hardware
         url: /hardware.html
+      - title: Linux install
+        url: /install-linux.html
+      - title: macOS install
+        url: /install-macos.html
       - title: Windows install
         url: /install-windows.html
   - label: Operate

--- a/docs/downloads.md
+++ b/docs/downloads.md
@@ -31,7 +31,7 @@ nav_group: Install
       <a class="btn btn--primary" href="{{ rel_url }}/gophertrunk-{{ ver }}-linux-amd64.tar.gz">x86_64 (.tar.gz)</a>
       <a class="btn btn--primary" href="{{ rel_url }}/gophertrunk-{{ ver }}-linux-arm64.tar.gz">aarch64 (.tar.gz)</a>
     </div>
-    <p class="download-card__note">aarch64 covers Raspberry Pi 4 / 5 + most modern ARM SBCs. RTL-SDR needs <a href="{{ '/hardware.html' | relative_url }}">udev rules + DVB blacklist</a> on first install.</p>
+    <p class="download-card__note">Full walkthrough: <a href="{{ '/install-linux.html' | relative_url }}">Linux install guide</a>. aarch64 covers Raspberry Pi 4 / 5 + most modern ARM SBCs; RTL-SDR needs udev rules + DVB blacklist on first install.</p>
   </div>
 
   <div class="download-card" data-platform="macos">
@@ -41,7 +41,7 @@ nav_group: Install
       <a class="btn btn--primary" href="{{ rel_url }}/gophertrunk-{{ ver }}-darwin-arm64.tar.gz">Apple Silicon (.tar.gz)</a>
       <a class="btn btn--primary" href="{{ rel_url }}/gophertrunk-{{ ver }}-darwin-amd64.tar.gz">Intel (.tar.gz)</a>
     </div>
-    <p class="download-card__note">Builds are unsigned — right-click → Open the first time to bypass Gatekeeper, or run <code>xattr -dr com.apple.quarantine gophertrunk</code>.</p>
+    <p class="download-card__note">Full walkthrough: <a href="{{ '/install-macos.html' | relative_url }}">macOS install guide</a>. Builds are unsigned — right-click → Open the first time, or run <code>xattr -dr com.apple.quarantine gophertrunk</code>.</p>
   </div>
 
   <div class="download-card" data-platform="windows">
@@ -52,7 +52,7 @@ nav_group: Install
       <a class="btn btn--secondary" href="{{ rel_url }}/gophertrunk-{{ ver }}-windows-amd64.zip">x64 Portable (.zip)</a>
       <a class="btn btn--secondary" href="{{ rel_url }}/gophertrunk-{{ ver }}-windows-arm64.zip">ARM64 Portable (.zip)</a>
     </div>
-    <p class="download-card__note">After install, swap the WinUSB driver via <a href="{{ '/install-windows.html' | relative_url }}">Zadig</a> — the OS won't see your RTL-SDR until you do this once.</p>
+    <p class="download-card__note">Full walkthrough: <a href="{{ '/install-windows.html' | relative_url }}">Windows install guide</a>. After install, swap the WinUSB driver via Zadig — the OS won't see your RTL-SDR until you do this once.</p>
   </div>
 
 </div>

--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -9,9 +9,8 @@ nav_group: Install
 
 GopherTrunk ships with a pure-Go RTL-SDR driver — no `librtlsdr`,
 `libusb`, or C toolchain on the build host. The daemon talks to
-RTL2832U dongles directly through the platform's USB stack
-(USBDEVFS ioctls on Linux, WinUSB on Windows; macOS lands in a
-follow-up — see [issue #82](https://github.com/MattCheramie/GopherTrunk/issues/82)).
+RTL2832U dongles directly through the platform's USB stack:
+USBDEVFS ioctls on Linux, IOKit on macOS, WinUSB on Windows.
 
 ## Supported devices
 
@@ -63,10 +62,22 @@ Blacklist the kernel's DVB driver, which otherwise grabs the device first:
 blacklist dvb_usb_rtl28xxu
 ```
 
+See [`install-linux.md`]({{ '/install-linux.html' | relative_url }})
+for the full step-by-step including systemd service setup.
+
+## macOS
+
+IOKit lets user-space claim USB devices without rebinding the kernel
+driver, so there's no kext to install and no driver swap to perform.
+Plug in the dongle and run `gophertrunk sdr list`. See
+[`install-macos.md`]({{ '/install-macos.html' | relative_url }}) for
+the full step-by-step including the Gatekeeper bypass and launchd
+service setup.
+
 ## Windows
 
 Bind the dongle to **WinUSB** with [Zadig](https://zadig.akeo.ie)
-once per device — see [docs/install-windows.md](install-windows.md)
+once per device — see [`install-windows.md`]({{ '/install-windows.html' | relative_url }})
 for the click-by-click walkthrough.
 
 ## Verifying the build

--- a/docs/install-linux.md
+++ b/docs/install-linux.md
@@ -1,0 +1,180 @@
+---
+layout: page
+title: Linux install
+description: Five-minute path from a fresh download to a working gophertrunk sdr list on Linux
+nav_group: Install
+---
+
+# Installing GopherTrunk on Linux
+
+Five minutes from a fresh download to a working `gophertrunk sdr list`.
+GopherTrunk on Linux is a single static binary — `CGO_ENABLED=0`, no
+`librtlsdr`, no `libusb`, no glibc version drama. Anything from a 2019-era
+distro forward will run it.
+
+## 1. Download the tarball
+
+Go to the **[GopherTrunk releases page]** and grab the asset matching
+your CPU:
+
+```
+gophertrunk-<version>-linux-amd64.tar.gz    # Intel / AMD x86_64
+gophertrunk-<version>-linux-arm64.tar.gz    # Raspberry Pi 4 / 5, most modern ARM SBCs
+```
+
+If you'd rather curl it, see the one-liner under the [downloads page
+Linux quick-start]({{ '/downloads.html#linux' | relative_url }}).
+
+[GopherTrunk releases page]: https://github.com/MattCheramie/GopherTrunk/releases
+
+> **Verify the download** against `SHA256SUMS` before installing — see
+> the [verify section]({{ '/downloads.html#verify-your-download' | relative_url }})
+> on the downloads page for the exact `sha256sum -c` invocation.
+
+## 2. Install the binary
+
+Extract and place `gophertrunk` somewhere on `PATH`. The conventional
+spot for a single-binary system service is `/usr/local/bin`:
+
+```sh
+tar xzf gophertrunk-<version>-linux-amd64.tar.gz
+cd gophertrunk-<version>-linux-amd64
+sudo install -m 0755 gophertrunk /usr/local/bin/gophertrunk
+```
+
+The tarball also bundles `config.example.yaml`, `README.md`, and
+`LICENSE`. We'll come back to the config in step 5.
+
+## 3. Grant USB access (one-time, every host)
+
+Linux ships a kernel DVB driver (`dvb_usb_rtl28xxu`) that grabs RTL-SDR
+dongles before user-space can claim them. We need to (a) stop the
+kernel from binding the device and (b) let your user open the USB
+device node without `sudo`. Both are one-shot config files.
+
+**Blacklist the DVB driver** so it leaves the dongle alone:
+
+```sh
+sudo tee /etc/modprobe.d/blacklist-dvb_usb_rtl28xxu.conf <<'EOF'
+blacklist dvb_usb_rtl28xxu
+EOF
+sudo modprobe -r dvb_usb_rtl28xxu 2>/dev/null || true
+```
+
+**Add a udev rule** so non-root processes can claim the device:
+
+```sh
+sudo tee /etc/udev/rules.d/20-rtlsdr.rules <<'EOF'
+SUBSYSTEM=="usb", ATTRS{idVendor}=="0bda", ATTRS{idProduct}=="2838", MODE="0666"
+EOF
+sudo udevadm control --reload
+sudo udevadm trigger
+```
+
+Unplug and re-plug the dongle once so the new rule takes effect on a
+freshly-enumerated device. You only do this once per host — the rule
+covers every RTL-SDR you'll ever plug in.
+
+> **Why not `plugdev` group + `0660`?** That works too, and is more
+> conservative if the host has untrusted users. The `MODE="0666"` rule
+> above is the simplest path for a single-operator box. Swap to
+> `MODE="0660", GROUP="plugdev"` if you'd rather scope access.
+
+## 4. Verify everything works
+
+Open a fresh shell (so the udev change takes effect for your session)
+and run:
+
+```sh
+gophertrunk version
+gophertrunk sdr list
+```
+
+`sdr list` should print one line per attached dongle with its driver,
+index, serial, tuner, product string, and the gain settings the tuner
+exposes. If you see `no SDR devices found` and the dongle is plugged
+in:
+
+- Check `lsusb` shows the dongle (typically `0bda:2838` for generic
+  RTL-SDR Blog units / NESDR Smart v5).
+- Check `lsmod | grep dvb_usb_rtl28xxu` — if it's still loaded, the
+  blacklist didn't take. Run `sudo modprobe -r dvb_usb_rtl28xxu` and
+  re-plug the dongle.
+- Check the udev rule applied: `ls -l /dev/bus/usb/<bus>/<dev>` should
+  be world-writable (`crw-rw-rw-`).
+
+See [`hardware.md`]({{ '/hardware.html' | relative_url }}) for the full
+matrix of supported tuners and dongles.
+
+## 5. Configure and start the daemon
+
+The tarball includes `config.example.yaml`. Copy it to a writable
+location and edit the device serial + control-channel frequencies:
+
+```sh
+mkdir -p ~/.config/gophertrunk
+cp config.example.yaml ~/.config/gophertrunk/config.yaml
+${EDITOR:-nano} ~/.config/gophertrunk/config.yaml
+```
+
+Then run the daemon against it:
+
+```sh
+gophertrunk run -config ~/.config/gophertrunk/config.yaml
+```
+
+Logs stream to the terminal. Press `Ctrl+C` to stop cleanly.
+
+### Run as a systemd service
+
+For a long-running setup, GopherTrunk ships an example unit at
+[`docs/gophertrunk.service`](https://github.com/MattCheramie/GopherTrunk/blob/main/docs/gophertrunk.service)
+with `DynamicUser=true` and a tight sandbox profile. Install it
+system-wide:
+
+```sh
+sudo install -d -m 0755 /etc/gophertrunk
+sudo install -m 0640 config.example.yaml /etc/gophertrunk/config.yaml
+sudo ${EDITOR:-nano} /etc/gophertrunk/config.yaml      # edit serials, frequencies
+sudo curl -L -o /etc/systemd/system/gophertrunk.service \
+  https://raw.githubusercontent.com/MattCheramie/GopherTrunk/main/docs/gophertrunk.service
+sudo systemctl daemon-reload
+sudo systemctl enable --now gophertrunk
+journalctl -u gophertrunk -f
+```
+
+The unit file's install header walks through every hardening knob
+(USB device allow-list, supplementary groups, namespace restrictions)
+— read it before deploying to a shared host.
+
+## Uninstall
+
+```sh
+sudo systemctl disable --now gophertrunk 2>/dev/null || true
+sudo rm -f /etc/systemd/system/gophertrunk.service
+sudo rm -f /usr/local/bin/gophertrunk
+sudo rm -f /etc/modprobe.d/blacklist-dvb_usb_rtl28xxu.conf
+sudo rm -f /etc/udev/rules.d/20-rtlsdr.rules
+sudo rm -rf /etc/gophertrunk
+sudo systemctl daemon-reload
+sudo udevadm control --reload
+```
+
+Recordings under your call-log directory (default `/var/lib/gophertrunk`)
+are left alone — remove them manually if you want a clean slate.
+
+## Troubleshooting
+
+| Symptom                                 | Likely cause                                       |
+| --------------------------------------- | -------------------------------------------------- |
+| `command not found: gophertrunk`        | Binary isn't on `PATH` — re-check step 2, or run `/usr/local/bin/gophertrunk` directly. |
+| `sdr list` prints nothing               | DVB driver still bound — `sudo modprobe -r dvb_usb_rtl28xxu` and re-plug. |
+| `permission denied` on `/dev/bus/usb/…` | udev rule didn't apply — re-run `udevadm control --reload && udevadm trigger`, then re-plug. |
+| `usb: device disconnected` mid-stream   | Power-saving USB autosuspend kicked in — `echo on > /sys/bus/usb/devices/<id>/power/control`, or pin via udev. |
+| Audio plays as silence                  | `audio.enabled: false` by default — set `true` in config; on distroless / Alpine without `libasound2`, set `audio.device: "ioctl"` to use the direct-kernel backend. |
+| systemd unit fails with `203/EXEC`      | Binary path wrong in the unit — confirm `/usr/local/bin/gophertrunk` exists and is `+x`. |
+
+For anything else: open an issue at
+<https://github.com/MattCheramie/GopherTrunk/issues> with the
+`gophertrunk version` output and the first few lines of the daemon log
+(`journalctl -u gophertrunk -n 50` if running under systemd).

--- a/docs/install-macos.md
+++ b/docs/install-macos.md
@@ -1,0 +1,190 @@
+---
+layout: page
+title: macOS install
+description: Five-minute path from a fresh download to a working gophertrunk sdr list on macOS
+nav_group: Install
+---
+
+# Installing GopherTrunk on macOS
+
+Five minutes from a fresh download to a working `gophertrunk sdr list`.
+GopherTrunk on macOS is a single static binary that talks to RTL-SDR
+dongles through IOKit — no kext, no `librtlsdr`, no Homebrew formula
+to chase.
+
+## 1. Download the tarball
+
+Go to the **[GopherTrunk releases page]** and grab the asset matching
+your CPU:
+
+```
+gophertrunk-<version>-darwin-arm64.tar.gz    # Apple Silicon (M1 / M2 / M3 / M4)
+gophertrunk-<version>-darwin-amd64.tar.gz    # Intel Macs
+```
+
+If you'd rather curl it, see the one-liner under the [downloads page
+macOS quick-start]({{ '/downloads.html#macos' | relative_url }}).
+
+[GopherTrunk releases page]: https://github.com/MattCheramie/GopherTrunk/releases
+
+> **Verify the download** against `SHA256SUMS` before installing — see
+> the [verify section]({{ '/downloads.html#verify-your-download' | relative_url }})
+> on the downloads page for the exact `shasum -a 256 -c` invocation.
+
+## 2. Install the binary
+
+Extract and place `gophertrunk` somewhere on `PATH`. The conventional
+spot for a single-binary command-line tool on macOS is
+`/usr/local/bin` (Intel) or `/opt/homebrew/bin` (Apple Silicon, if you
+use Homebrew); either works:
+
+```sh
+tar xzf gophertrunk-<version>-darwin-arm64.tar.gz
+cd gophertrunk-<version>-darwin-arm64
+sudo install -m 0755 gophertrunk /usr/local/bin/gophertrunk
+```
+
+The tarball also bundles `config.example.yaml`, `README.md`, and
+`LICENSE`. We'll come back to the config in step 5.
+
+## 3. Clear the Gatekeeper quarantine (one-time, every download)
+
+Builds are unsigned — the first time you run an un-signed,
+quarantined binary, macOS will refuse with "cannot be opened because
+the developer cannot be verified." Two ways to clear it:
+
+**Easy:** right-click `gophertrunk` in Finder → **Open** → confirm in
+the dialog. macOS remembers your approval for that binary.
+
+**CLI:** strip the quarantine xattr directly:
+
+```sh
+sudo xattr -dr com.apple.quarantine /usr/local/bin/gophertrunk
+```
+
+Re-do this every time you upgrade — a fresh download re-attaches the
+`com.apple.quarantine` xattr.
+
+> **No driver swap needed.** Unlike Windows (Zadig → WinUSB) and Linux
+> (DVB blacklist + udev rule), macOS lets user-space claim USB
+> devices via IOKit without rebinding the kernel driver. Plug in the
+> dongle and go.
+
+## 4. Verify everything works
+
+Open Terminal and run:
+
+```sh
+gophertrunk version
+gophertrunk sdr list
+```
+
+`sdr list` should print one line per attached dongle with its driver,
+index, serial, tuner, product string, and the gain settings the tuner
+exposes. If you see `no SDR devices found` and the dongle is plugged
+in:
+
+- Check `system_profiler SPUSBDataType | grep -A 4 RTL2838` shows the
+  dongle (typically `0x0bda:0x2838`).
+- If you have **SDR++**, **GQRX**, or another RTL-SDR app open, close
+  it — IOKit hands the device to whoever claims it first.
+- Some USB-C hubs power-cycle low-power devices aggressively; plug
+  the dongle directly into the Mac or into a powered hub.
+
+See [`hardware.md`]({{ '/hardware.html' | relative_url }}) for the full
+matrix of supported tuners and dongles.
+
+## 5. Configure and start the daemon
+
+The tarball includes `config.example.yaml`. Copy it to a writable
+location and edit the device serial + control-channel frequencies:
+
+```sh
+mkdir -p ~/.config/gophertrunk
+cp config.example.yaml ~/.config/gophertrunk/config.yaml
+${EDITOR:-nano} ~/.config/gophertrunk/config.yaml
+```
+
+Then run the daemon against it:
+
+```sh
+gophertrunk run -config ~/.config/gophertrunk/config.yaml
+```
+
+Logs stream to the terminal. Press `Ctrl+C` to stop cleanly.
+
+### Run as a launchd service
+
+For a long-running setup, register GopherTrunk as a per-user
+`LaunchAgent` so it starts at login and respawns on crash. Drop the
+following at `~/Library/LaunchAgents/org.gophertrunk.daemon.plist`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>org.gophertrunk.daemon</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/usr/local/bin/gophertrunk</string>
+    <string>run</string>
+    <string>-config</string>
+    <string>/Users/YOUR_USER/.config/gophertrunk/config.yaml</string>
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>StandardOutPath</key>
+  <string>/Users/YOUR_USER/Library/Logs/gophertrunk.log</string>
+  <key>StandardErrorPath</key>
+  <string>/Users/YOUR_USER/Library/Logs/gophertrunk.err.log</string>
+</dict>
+</plist>
+```
+
+Then load it:
+
+```sh
+launchctl load ~/Library/LaunchAgents/org.gophertrunk.daemon.plist
+launchctl start org.gophertrunk.daemon
+tail -f ~/Library/Logs/gophertrunk.log
+```
+
+For a system-wide daemon (starts at boot, not login), put the plist
+under `/Library/LaunchDaemons/` and `sudo launchctl bootstrap
+system/<path>` instead. Note that LaunchDaemons run as `root` by
+default — set `UserName` in the plist to drop privileges.
+
+## Uninstall
+
+```sh
+launchctl unload ~/Library/LaunchAgents/org.gophertrunk.daemon.plist 2>/dev/null || true
+rm -f ~/Library/LaunchAgents/org.gophertrunk.daemon.plist
+sudo rm -f /usr/local/bin/gophertrunk
+rm -rf ~/.config/gophertrunk
+rm -f ~/Library/Logs/gophertrunk.log ~/Library/Logs/gophertrunk.err.log
+```
+
+Recordings under your call-log directory are left alone — remove them
+manually if you want a clean slate.
+
+## Troubleshooting
+
+| Symptom                                                  | Likely cause                                                                  |
+| -------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| `cannot be opened because the developer cannot be verified` | Quarantine xattr still attached — re-run the `xattr -dr` from step 3, or right-click → Open. |
+| `command not found: gophertrunk`                         | Binary isn't on `PATH` — re-check step 2, or run from the install path directly. |
+| `sdr list` prints nothing                                | Another RTL-SDR app (SDR++, GQRX) is holding the device — close it and retry. |
+| `usb: claim interface failed`                            | Same — IOKit hands the dongle to whoever opened it first.                     |
+| Audio plays as silence                                   | `audio.enabled: false` by default — set `true` in config. CoreAudio is the default backend on Darwin. |
+| LaunchAgent says `Load failed: 5: Input/output error`    | plist syntax error — `plutil -lint ~/Library/LaunchAgents/org.gophertrunk.daemon.plist` will show the line. |
+
+For anything else: open an issue at
+<https://github.com/MattCheramie/GopherTrunk/issues> with the
+`gophertrunk version` output and the first few lines of the daemon
+log (`tail ~/Library/Logs/gophertrunk.err.log` if running under
+launchd).


### PR DESCRIPTION
## Summary

Match the Windows install doc's structure for the other two platforms. Picks up the install-docs commit that didn't land in #222 before that PR was merged.

- **`docs/install-linux.md`** — five-step walkthrough mirroring the Windows page: download → install binary → udev rule + DVB blacklist (the Linux equivalent of the Zadig WinUSB swap) → verify → run, plus a systemd-service section using the existing `docs/gophertrunk.service` unit, uninstall, and a troubleshooting matrix.
- **`docs/install-macos.md`** — same five-step shape: download → install binary → Gatekeeper quarantine bypass → verify → run, plus a launchd LaunchAgent plist, uninstall, and troubleshooting. Notes that IOKit means no driver swap (no Zadig / udev equivalent).
- **Nav** (`docs/_data/nav.yml`) — surface both new pages under the Install group.
- **`docs/downloads.md`** — each download card now links to its install guide so the full walkthrough is one hop from the binary.
- **`docs/hardware.md`** — dropped the stale "macOS lands in a follow-up" line (the IOKit backend is shipped) and added a macOS subsection plus cross-links to the new install pages.

## Test plan

- [ ] Build the Jekyll site locally (`bundle exec jekyll serve`) and load `/install-linux.html` and `/install-macos.html`
- [ ] Confirm the Install nav group lists Downloads, Hardware, and all three install pages (Linux / macOS / Windows)
- [ ] From each download card on `/downloads.html`, click the install-guide link and confirm it lands on the matching install page
- [ ] Skim `/hardware.html` to confirm it no longer references the closed macOS follow-up and that the per-OS subsections cross-link to the new install pages
- [ ] Sanity-check the systemd / launchd snippets render cleanly in their fenced code blocks

---
_Generated by [Claude Code](https://claude.ai/code/session_014FKdUa3kAEpNUMR4bCVi4d)_