### PR TITLE
docs: add Google Analytics gtag.js to GitHub Pages

### DIFF
--- a/docs/_includes/head.html
+++ b/docs/_includes/head.html
@@ -4,6 +4,16 @@
 <meta name="theme-color" content="#0d1117" media="(prefers-color-scheme: dark)">
 <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)">
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-ZL0HGHW303"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-ZL0HGHW303');
+</script>
+
 {% seo %}
 
 <link rel="icon" type="image/png" href="{{ '/assets/gophertrunk-logo.png' | relative_url }}">


### PR DESCRIPTION
## Summary

Add the Google Analytics gtag.js snippet (measurement ID `G-ZL0HGHW303`) to every GitHub Pages page.

The snippet is dropped into `docs/_includes/head.html`, which is included from `docs/_layouts/default.html`. Every content page extends `default` (directly via `home.html`, or transitively via `page.html` → `default.html`), so a single edit propagates to the whole site.

Placement: just after the `<meta>` block and before `{% seo %}` — per Google's "as high in `<head>` as possible" guidance, while keeping the SEO / Schema.org blocks below it for parity with the existing structure.

## Test plan

- [ ] Build the Jekyll site locally (`bundle exec jekyll serve`) and view source on `/`, `/downloads.html`, `/install-linux.html`, `/architecture.html`
- [ ] Confirm the `gtag.js` script tag and inline `gtag('config', 'G-ZL0HGHW303')` are present in every page's `<head>`
- [ ] After deploy, load the live site and confirm GA4 Realtime shows the session in the `G-ZL0HGHW303` property
- [ ] Confirm no CSP / mixed-content errors in the browser console (the snippet loads over HTTPS from `googletagmanager.com`)

---
_Generated by [Claude Code](https://claude.ai/code/session_014FKdUa3kAEpNUMR4bCVi4d)_