### PR TITLE
web: add Systems, Talkgroups, Devices, Events read-only panels

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,17 +312,21 @@ to its own package and lands independently.
 
 - **Web operator console — remaining panels.** The browser SPA in
   [`web/`](web/) (Vite + React + TypeScript + Tailwind) currently
-  ships a working Dashboard with the live WebSocket event feed and
-  audio cockpit, a Settings tab (theme / write-mode / forget device),
-  and a ConnectScreen that points the SPA at any daemon on the
-  network. The remaining 9 TUI panels (Systems, Talkgroups, Active,
-  History, Events, Tones, Metrics, Devices, Scanner) are stubbed via
+  ships Dashboard (live WebSocket event feed + audio cockpit),
+  Settings (theme / write-mode / forget device), ConnectScreen
+  (server-URL + token entry), plus the read-only data browsers:
+  **Systems**, **Talkgroups**, **Devices** (sortable tables with
+  detail modals), and **Events** (live ring-buffer viewer with
+  filter + pause + inline JSON expansion). The remaining 5 TUI
+  panels (Active, History, Tones, Metrics, Scanner) are stubbed via
   `Placeholder` and land panel-by-panel in follow-up PRs against the
-  same shared `src/store/` + `src/api/` plumbing. Daemon-side support
-  (CORS middleware, `GET /api/v1/audio/stream` PCM-over-WAV endpoint)
-  already ships; no further Go-side work is required to fill the
-  panels in. Operator playbook for running the daemon on a Raspberry
-  Pi and driving it from a laptop is in [`web/README.md`](web/README.md).
+  same shared `src/store/` + `src/api/` plumbing — Scanner and the
+  Talkgroup-priority / call-end mutations introduce the daemon-write
+  gate UI. Daemon-side support (CORS middleware,
+  `GET /api/v1/audio/stream` PCM-over-WAV endpoint) already ships;
+  no further Go-side work is required to fill the panels in.
+  Operator playbook for running the daemon on a Raspberry Pi and
+  driving it from a laptop is in [`web/README.md`](web/README.md).
 - **DVSI USB-3000 / AMBE-3003 hardware backend (USB transport).**
   The `Vocoder` + AMBE-3003 wire protocol + `voice.Vocoder` interface
   conformance ship in [`internal/voice/dvsi/`](internal/voice/dvsi/)
@@ -2234,7 +2238,7 @@ screen. The SPA is installable as a Progressive Web App (Add to Home
 Screen) and persists server URL + token in browser storage so return
 visits skip the connect screen.
 
-**Status: foundation only.** The current build ships:
+**Status: read panels landing.** The current build ships:
 
 - **ConnectScreen** — server-URL + bearer-token entry with a
   `GET /api/v1/health` reachability probe before commit.
@@ -2243,18 +2247,31 @@ visits skip the connect screen.
   PCM-over-WAV playback from the new `GET /api/v1/audio/stream`
   endpoint, volume / mute / record-toggle wired to
   `PATCH /api/v1/audio`.
+- **Systems** — sortable browser of every trunked system in
+  `GET /api/v1/systems`, with a detail modal exposing protocol,
+  WACN / System ID / RFSS / Site, and control-channel frequencies.
+- **Talkgroups** — sortable, filterable browser of every talkgroup
+  with priority / scan / lockout flag pills and a detail modal. Read-
+  only in this pass; PATCH mutations land with the write-mode pass.
+- **Devices** — SDR pool inspector with attached/detached status,
+  driver / tuner / role columns, and a detail modal for gain / PPM /
+  bias-T. Live via the same `sdr.attached` / `sdr.detached` events
+  the Dashboard already subscribes to.
+- **Events** — live ring-buffer viewer (capped at 500 to mirror the
+  TUI) with substring filter across kind / timestamp / payload, a
+  Pause/Resume toggle that freezes the snapshot for forensic review,
+  and click-to-expand row that pretty-prints the full event JSON.
 - **Settings** — theme toggle (dark / monochrome), write-mode gate
   mirroring the TUI's `--write` flag, "forget this device" to clear
   stored credentials.
 
-The remaining nine TUI panels (Systems, Talkgroups, Active, History,
-Events, Tones, Metrics, Devices, Scanner) are stubbed via
-`Placeholder` and land panel-by-panel in follow-up PRs against the
-same `src/store/` + `src/api/` plumbing — every read and mutation
-endpoint they need already lives on the daemon. See
-[`web/README.md`](web/README.md) for the operator playbook (LAN
-deployment, CORS config, PWA install steps) and the dev workflow
-(`make web-dev`, `make web-build`).
+The remaining five TUI panels (Active, History, Tones, Metrics,
+Scanner) are stubbed via `Placeholder` and land panel-by-panel in
+follow-up PRs against the same `src/store/` + `src/api/` plumbing —
+every read and mutation endpoint they need already lives on the
+daemon. See [`web/README.md`](web/README.md) for the operator
+playbook (LAN deployment, CORS config, PWA install steps) and the
+dev workflow (`make web-dev`, `make web-build`).
 
 For full feature parity with the TUI today, continue using
 `gophertrunk tui` (above).

--- a/web/README.md
+++ b/web/README.md
@@ -107,6 +107,33 @@ The dev server proxies `/api/*` and `/metrics` to
 same-origin to the browser and you don't need CORS during
 development.
 
+## Status
+
+The SPA is built incrementally; each PR ships a slice of panels
+behind the same shared store + API client.
+
+Shipping today:
+
+| Panel         | Backed by                                       |
+| ------------- | ----------------------------------------------- |
+| ConnectScreen | `GET /api/v1/health` reachability probe         |
+| Dashboard     | `GET /api/v1/{health,calls/active,devices,audio}` + WebSocket event feed + `/api/v1/audio/stream` |
+| Systems       | `GET /api/v1/systems` (sortable list + detail)  |
+| Talkgroups    | `GET /api/v1/talkgroups` (sortable list + filter + detail) |
+| Devices       | `GET /api/v1/devices` (live attach/detach)      |
+| Events        | WebSocket ring buffer (filter + pause + JSON expansion) |
+| Settings      | theme, write-mode, forget-device                |
+
+Pending — stubbed by `Placeholder` and arriving in follow-up PRs:
+
+| Panel        | Will mirror                                     |
+| ------------ | ----------------------------------------------- |
+| Active       | `GET /api/v1/calls/active` + end-call mutation  |
+| History      | `GET /api/v1/calls/history` + filters           |
+| Tones        | `tone.alert` ring + per-device reset            |
+| Metrics      | `GET /metrics` charted via Chart.js             |
+| Scanner      | `GET /api/v1/scanner` + hold/resume/retune/lockout mutations |
+
 ## Architecture
 
 - **React 18** + **React Router** (hash mode so `file://` works)

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -7,8 +7,12 @@ import { TabBar, type Tab } from "./components/TabBar";
 import { AudioPlayer } from "./components/AudioPlayer";
 import { InstallPrompt } from "./components/InstallPrompt";
 import { Dashboard } from "./panels/Dashboard";
-import { Settings } from "./panels/Settings";
+import { Devices } from "./panels/Devices";
+import { Events } from "./panels/Events";
 import { Placeholder } from "./panels/Placeholder";
+import { Settings } from "./panels/Settings";
+import { Systems } from "./panels/Systems";
+import { Talkgroups } from "./panels/Talkgroups";
 import {
   selectClientConfig,
   useShared,
@@ -131,32 +135,13 @@ export function App() {
               />
             }
           />
-          <Route
-            path="/systems"
-            element={<Placeholder title="Systems" hint="Trunked-system browser." />}
-          />
-          <Route
-            path="/talkgroups"
-            element={
-              <Placeholder
-                title="Talkgroups"
-                hint="Priority / lockout / scan toggles per talkgroup."
-              />
-            }
-          />
+          <Route path="/systems" element={<Systems />} />
+          <Route path="/talkgroups" element={<Talkgroups />} />
           <Route
             path="/history"
             element={<Placeholder title="History" hint="Call log explorer." />}
           />
-          <Route
-            path="/events"
-            element={
-              <Placeholder
-                title="Events"
-                hint="Live ring buffer of every event the daemon publishes."
-              />
-            }
-          />
+          <Route path="/events" element={<Events />} />
           <Route
             path="/tones"
             element={
@@ -175,10 +160,7 @@ export function App() {
               />
             }
           />
-          <Route
-            path="/devices"
-            element={<Placeholder title="Devices" hint="SDR pool inspector." />}
-          />
+          <Route path="/devices" element={<Devices />} />
           <Route path="/settings" element={<Settings />} />
           <Route path="*" element={<Navigate to="/dashboard" replace />} />
         </Routes>

--- a/web/src/components/DataTable.tsx
+++ b/web/src/components/DataTable.tsx
@@ -1,0 +1,185 @@
+import { useMemo, useState } from "react";
+
+export interface Column<T> {
+  key: string;
+  header: string;
+  render: (row: T) => React.ReactNode;
+  sort?: (a: T, b: T) => number;
+  className?: string;
+  headerClassName?: string;
+}
+
+interface Props<T> {
+  rows: T[];
+  columns: Column<T>[];
+  rowKey: (row: T, index: number) => string;
+  defaultSortKey?: string;
+  defaultSortDirection?: "asc" | "desc";
+  onRowClick?: (row: T, key: string) => void;
+  emptyMessage?: string;
+  // Optional second-row "expanded" content rendered beneath the row
+  // (used by Events to show payload JSON inline).
+  renderExpansion?: (row: T) => React.ReactNode;
+  expandedKey?: string | null;
+}
+
+export function DataTable<T>({
+  rows,
+  columns,
+  rowKey,
+  defaultSortKey,
+  defaultSortDirection = "asc",
+  onRowClick,
+  emptyMessage = "No data.",
+  renderExpansion,
+  expandedKey,
+}: Props<T>) {
+  const [sortKey, setSortKey] = useState<string | null>(
+    defaultSortKey ?? null,
+  );
+  const [sortDir, setSortDir] = useState<"asc" | "desc">(
+    defaultSortDirection,
+  );
+
+  const sorted = useMemo(() => {
+    if (!sortKey) return rows;
+    const col = columns.find((c) => c.key === sortKey);
+    if (!col?.sort) return rows;
+    const copy = rows.slice();
+    copy.sort(col.sort);
+    if (sortDir === "desc") copy.reverse();
+    return copy;
+  }, [rows, columns, sortKey, sortDir]);
+
+  function toggleSort(key: string) {
+    if (sortKey === key) {
+      setSortDir((d) => (d === "asc" ? "desc" : "asc"));
+    } else {
+      setSortKey(key);
+      setSortDir("asc");
+    }
+  }
+
+  if (rows.length === 0) {
+    return <p className="text-muted text-sm">{emptyMessage}</p>;
+  }
+
+  return (
+    <div className="panel overflow-hidden">
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead className="bg-panel/80 text-xs uppercase tracking-wider text-muted">
+            <tr>
+              {columns.map((c) => {
+                const sortable = !!c.sort;
+                const active = sortKey === c.key;
+                return (
+                  <th
+                    key={c.key}
+                    scope="col"
+                    className={`px-3 py-2 text-left font-medium ${
+                      c.headerClassName ?? ""
+                    } ${sortable ? "cursor-pointer select-none" : ""}`}
+                    onClick={sortable ? () => toggleSort(c.key) : undefined}
+                    aria-sort={
+                      !sortable
+                        ? undefined
+                        : active
+                          ? sortDir === "asc"
+                            ? "ascending"
+                            : "descending"
+                          : "none"
+                    }
+                  >
+                    <span className="inline-flex items-center gap-1">
+                      {c.header}
+                      {sortable && (
+                        <span
+                          aria-hidden
+                          className={active ? "text-accent" : "opacity-40"}
+                        >
+                          {active ? (sortDir === "asc" ? "▲" : "▼") : "⇅"}
+                        </span>
+                      )}
+                    </span>
+                  </th>
+                );
+              })}
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-panel">
+            {sorted.map((row, i) => {
+              const key = rowKey(row, i);
+              const expanded = expandedKey === key;
+              return (
+                <Row
+                  key={key}
+                  row={row}
+                  columns={columns}
+                  onClick={
+                    onRowClick ? () => onRowClick(row, key) : undefined
+                  }
+                  expansion={
+                    renderExpansion && expanded ? renderExpansion(row) : null
+                  }
+                />
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+function Row<T>({
+  row,
+  columns,
+  onClick,
+  expansion,
+}: {
+  row: T;
+  columns: Column<T>[];
+  onClick?: () => void;
+  expansion: React.ReactNode | null;
+}) {
+  return (
+    <>
+      <tr
+        className={
+          onClick
+            ? "hover:bg-panel/40 cursor-pointer focus-within:bg-panel/40"
+            : ""
+        }
+        onClick={onClick}
+        tabIndex={onClick ? 0 : -1}
+        onKeyDown={
+          onClick
+            ? (e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  onClick();
+                }
+              }
+            : undefined
+        }
+      >
+        {columns.map((c) => (
+          <td key={c.key} className={`px-3 py-2 align-top ${c.className ?? ""}`}>
+            {c.render(row)}
+          </td>
+        ))}
+      </tr>
+      {expansion && (
+        <tr>
+          <td
+            colSpan={columns.length}
+            className="px-3 pb-3 pt-0 bg-panel/30 text-xs"
+          >
+            {expansion}
+          </td>
+        </tr>
+      )}
+    </>
+  );
+}

--- a/web/src/components/DetailModal.tsx
+++ b/web/src/components/DetailModal.tsx
@@ -1,0 +1,90 @@
+import { useEffect, useRef } from "react";
+
+interface Props {
+  title: string;
+  subtitle?: string;
+  onClose: () => void;
+  children: React.ReactNode;
+}
+
+// DetailModal renders a right-side sheet on desktop and a bottom-sheet
+// on phones. Mirrors internal/tui/detail.go in spirit: read-only deep
+// view for a single row.
+export function DetailModal({ title, subtitle, onClose, children }: Props) {
+  const dialogRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  useEffect(() => {
+    dialogRef.current?.focus();
+  }, []);
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={title}
+      className="fixed inset-0 z-50 flex items-end sm:items-stretch sm:justify-end bg-black/50 backdrop-blur-sm"
+      onClick={onClose}
+    >
+      <div
+        ref={dialogRef}
+        tabIndex={-1}
+        onClick={(e) => e.stopPropagation()}
+        className="panel w-full sm:max-w-md sm:h-full bg-bg p-4 sm:p-5 overflow-auto rounded-t-lg sm:rounded-none sm:rounded-l-lg outline-none"
+      >
+        <header className="flex items-start gap-3 mb-4">
+          <div className="flex-1">
+            <h3 className="text-lg font-semibold leading-tight">{title}</h3>
+            {subtitle && (
+              <p className="text-xs text-muted mt-0.5">{subtitle}</p>
+            )}
+          </div>
+          <button
+            className="btn-ghost !min-h-0 !p-1.5 text-xs"
+            onClick={onClose}
+            aria-label="Close detail"
+          >
+            ✕
+          </button>
+        </header>
+
+        <div className="space-y-3">{children}</div>
+      </div>
+    </div>
+  );
+}
+
+// DetailField renders one label/value pair inside a DetailModal.
+export function DetailField({
+  label,
+  value,
+  mono,
+}: {
+  label: string;
+  value: React.ReactNode;
+  mono?: boolean;
+}) {
+  return (
+    <div>
+      <p className="text-xs uppercase tracking-wider text-muted">{label}</p>
+      <p
+        className={`text-sm mt-0.5 ${mono ? "font-mono" : ""}`}
+        // Empty fields render a clear em-dash so the operator sees the
+        // gap rather than an invisibly-collapsed row.
+      >
+        {value === null || value === undefined || value === "" ? (
+          <span className="text-muted">—</span>
+        ) : (
+          value
+        )}
+      </p>
+    </div>
+  );
+}

--- a/web/src/panels/Devices.tsx
+++ b/web/src/panels/Devices.tsx
@@ -1,0 +1,139 @@
+import { useEffect, useMemo, useState } from "react";
+import { api } from "../api/client";
+import { Column, DataTable } from "../components/DataTable";
+import { DetailField, DetailModal } from "../components/DetailModal";
+import type { DeviceDTO } from "../api/types";
+import { selectClientConfig, useShared } from "../store/shared";
+
+const POLL_INTERVAL_MS = 5_000;
+
+// Devices reflects the SDR pool. Live updates piggyback on the
+// sdr.attached / sdr.detached event stream feeding the shared store,
+// while this panel polls /api/v1/devices for the canonical snapshot.
+export function Devices() {
+  const cfg = useShared(selectClientConfig);
+  const devices = useShared((s) => s.devices);
+  const setDevices = useShared((s) => s.setDevices);
+  const [selected, setSelected] = useState<DeviceDTO | null>(null);
+
+  useEffect(() => {
+    let cancel = false;
+    const refresh = async () => {
+      try {
+        const data = await api.devices(cfg);
+        if (!cancel) setDevices(data);
+      } catch {
+        // Keep the previous snapshot.
+      }
+    };
+    refresh();
+    const t = window.setInterval(refresh, POLL_INTERVAL_MS);
+    return () => {
+      cancel = true;
+      window.clearInterval(t);
+    };
+  }, [cfg, setDevices]);
+
+  const attachedCount = useMemo(
+    () => devices.filter((d) => d.attached).length,
+    [devices],
+  );
+
+  const columns: Column<DeviceDTO>[] = useMemo(
+    () => [
+      {
+        key: "status",
+        header: "",
+        render: (r) =>
+          r.attached ? (
+            <span className="pill-ok" aria-label="attached">●</span>
+          ) : (
+            <span className="pill-err" aria-label="detached">○</span>
+          ),
+      },
+      {
+        key: "serial",
+        header: "Serial",
+        render: (r) => <span className="font-mono text-accent">{r.serial}</span>,
+        sort: (a, b) => a.serial.localeCompare(b.serial),
+      },
+      {
+        key: "driver",
+        header: "Driver",
+        render: (r) => <span className="text-xs">{r.driver}</span>,
+        sort: (a, b) => a.driver.localeCompare(b.driver),
+      },
+      {
+        key: "tuner",
+        header: "Tuner",
+        render: (r) => <span className="text-xs">{r.tuner ?? "—"}</span>,
+        sort: (a, b) => (a.tuner ?? "").localeCompare(b.tuner ?? ""),
+        className: "hidden md:table-cell",
+        headerClassName: "hidden md:table-cell",
+      },
+      {
+        key: "role",
+        header: "Role",
+        render: (r) => (
+          <span className="text-xs uppercase tracking-wider text-muted">
+            {r.role ?? "unassigned"}
+          </span>
+        ),
+        sort: (a, b) => (a.role ?? "").localeCompare(b.role ?? ""),
+      },
+    ],
+    [],
+  );
+
+  return (
+    <div className="space-y-3">
+      <header className="flex items-center justify-between gap-3">
+        <h2 className="text-xl font-semibold">Devices</h2>
+        <span className="text-xs text-muted">
+          {attachedCount} of {devices.length} attached
+        </span>
+      </header>
+
+      <DataTable
+        rows={devices}
+        columns={columns}
+        rowKey={(r) => r.serial}
+        defaultSortKey="serial"
+        onRowClick={(r) => setSelected(r)}
+        emptyMessage="No SDRs known to the daemon. Check udev rules / WinUSB driver / hardware connection."
+      />
+
+      {selected && (
+        <DetailModal
+          title={selected.serial}
+          subtitle={`${selected.driver}${selected.tuner ? " · " + selected.tuner : ""}`}
+          onClose={() => setSelected(null)}
+        >
+          <div className="grid grid-cols-2 gap-3">
+            <DetailField
+              label="Status"
+              value={selected.attached ? "attached" : "detached"}
+            />
+            <DetailField label="Role" value={selected.role} />
+            <DetailField label="Gain" mono value={selected.gain} />
+            <DetailField
+              label="PPM"
+              mono
+              value={selected.ppm != null ? `${selected.ppm}` : null}
+            />
+            <DetailField
+              label="Bias-T"
+              value={
+                selected.bias_tee == null
+                  ? null
+                  : selected.bias_tee
+                    ? "on"
+                    : "off"
+              }
+            />
+          </div>
+        </DetailModal>
+      )}
+    </div>
+  );
+}

--- a/web/src/panels/Events.tsx
+++ b/web/src/panels/Events.tsx
@@ -1,0 +1,151 @@
+import { useMemo, useState } from "react";
+import { Column, DataTable } from "../components/DataTable";
+import type { EventDTO } from "../api/types";
+import { useShared } from "../store/shared";
+
+// Events renders the live ring buffer the WebSocket stream populates
+// into the shared store. No polling — the stream pushes everything;
+// see App.tsx's openEventStream wire-up.
+export function Events() {
+  const events = useShared((s) => s.events);
+  const wsStatus = useShared((s) => s.wsStatus);
+  const eventCap = useShared((s) => s.eventCap);
+  const [filter, setFilter] = useState("");
+  const [paused, setPaused] = useState(false);
+  const [snapshot, setSnapshot] = useState<EventDTO[] | null>(null);
+  const [expanded, setExpanded] = useState<string | null>(null);
+
+  // When paused, freeze the table at the snapshot the user paused on;
+  // when running, mirror the live store ring.
+  const visible = paused ? (snapshot ?? events) : events;
+
+  const filtered = useMemo(() => {
+    if (!filter.trim()) return visible;
+    const needle = filter.toLowerCase();
+    return visible.filter(
+      (e) =>
+        e.kind.toLowerCase().includes(needle) ||
+        e.timestamp.toLowerCase().includes(needle) ||
+        JSON.stringify(e.payload ?? "").toLowerCase().includes(needle),
+    );
+  }, [visible, filter]);
+
+  // Newest events first — reverse so the latest is at the top, the
+  // mobile-friendly read order.
+  const ordered = useMemo(() => filtered.slice().reverse(), [filtered]);
+
+  const columns: Column<EventDTO>[] = useMemo(
+    () => [
+      {
+        key: "ts",
+        header: "Time",
+        render: (r) => (
+          <span className="font-mono text-xs text-muted whitespace-nowrap">
+            {r.timestamp.replace("T", " ").replace(/\..*$/, "")}
+          </span>
+        ),
+        sort: (a, b) => a.timestamp.localeCompare(b.timestamp),
+      },
+      {
+        key: "kind",
+        header: "Kind",
+        render: (r) => (
+          <span className="font-mono text-accent">{r.kind}</span>
+        ),
+        sort: (a, b) => a.kind.localeCompare(b.kind),
+      },
+      {
+        key: "preview",
+        header: "Payload",
+        render: (r) => (
+          <span className="text-xs font-mono text-muted truncate inline-block max-w-[28ch] sm:max-w-[60ch]">
+            {previewPayload(r.payload)}
+          </span>
+        ),
+      },
+    ],
+    [],
+  );
+
+  function togglePause() {
+    if (paused) {
+      setPaused(false);
+      setSnapshot(null);
+    } else {
+      setSnapshot(events.slice());
+      setPaused(true);
+    }
+  }
+
+  return (
+    <div className="space-y-3">
+      <header className="flex items-center justify-between gap-3">
+        <h2 className="text-xl font-semibold">Events</h2>
+        <div className="flex items-center gap-2 text-xs">
+          <span
+            className={
+              wsStatus === "open"
+                ? "pill-ok"
+                : wsStatus === "connecting"
+                  ? "pill-warn"
+                  : "pill-err"
+            }
+          >
+            {wsStatus}
+          </span>
+          <span className="text-muted">
+            {events.length}/{eventCap}
+          </span>
+        </div>
+      </header>
+
+      <div className="flex flex-wrap gap-2">
+        <input
+          type="search"
+          className="input flex-1 sm:max-w-md"
+          placeholder="Filter by kind, timestamp, or payload…"
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+          aria-label="Filter events"
+        />
+        <button
+          className={paused ? "btn-primary" : "btn-ghost"}
+          onClick={togglePause}
+          aria-pressed={paused}
+        >
+          {paused ? "Resume" : "Pause"}
+        </button>
+      </div>
+
+      <DataTable
+        rows={ordered}
+        columns={columns}
+        rowKey={(r, i) => `${r.timestamp}-${r.kind}-${i}`}
+        onRowClick={(_r, key) =>
+          setExpanded((prev) => (prev === key ? null : key))
+        }
+        renderExpansion={(r) => (
+          <pre className="whitespace-pre-wrap break-words font-mono text-xs text-fg/80">
+            {JSON.stringify(r, null, 2)}
+          </pre>
+        )}
+        expandedKey={expanded}
+        emptyMessage={
+          events.length === 0
+            ? "No events yet — the WebSocket stream pushes new ones live."
+            : "No events match the filter."
+        }
+      />
+    </div>
+  );
+}
+
+function previewPayload(p: unknown): string {
+  if (p == null) return "";
+  try {
+    const s = JSON.stringify(p);
+    return s.length > 120 ? `${s.slice(0, 117)}…` : s;
+  } catch {
+    return String(p);
+  }
+}

--- a/web/src/panels/Systems.tsx
+++ b/web/src/panels/Systems.tsx
@@ -1,0 +1,149 @@
+import { useEffect, useMemo, useState } from "react";
+import { api } from "../api/client";
+import { Column, DataTable } from "../components/DataTable";
+import { DetailField, DetailModal } from "../components/DetailModal";
+import type { SystemDTO } from "../api/types";
+import { selectClientConfig, useShared } from "../store/shared";
+
+const POLL_INTERVAL_MS = 10_000;
+
+export function Systems() {
+  const cfg = useShared(selectClientConfig);
+  const systems = useShared((s) => s.systems);
+  const setSystems = useShared((s) => s.setSystems);
+  const [selected, setSelected] = useState<SystemDTO | null>(null);
+  const [filter, setFilter] = useState("");
+
+  useEffect(() => {
+    let cancel = false;
+    const refresh = async () => {
+      try {
+        const data = await api.systems(cfg);
+        if (!cancel) setSystems(data);
+      } catch {
+        // Toast strip surfaces request errors elsewhere; keep the
+        // previous snapshot on the screen rather than blanking it.
+      }
+    };
+    refresh();
+    const t = window.setInterval(refresh, POLL_INTERVAL_MS);
+    return () => {
+      cancel = true;
+      window.clearInterval(t);
+    };
+  }, [cfg, setSystems]);
+
+  const filtered = useMemo(() => {
+    if (!filter.trim()) return systems;
+    const needle = filter.toLowerCase();
+    return systems.filter(
+      (s) =>
+        s.name.toLowerCase().includes(needle) ||
+        s.protocol.toLowerCase().includes(needle),
+    );
+  }, [systems, filter]);
+
+  const columns: Column<SystemDTO>[] = useMemo(
+    () => [
+      {
+        key: "name",
+        header: "System",
+        render: (r) => <span className="font-medium">{r.name}</span>,
+        sort: (a, b) => a.name.localeCompare(b.name),
+      },
+      {
+        key: "protocol",
+        header: "Protocol",
+        render: (r) => <span className="font-mono text-accent">{r.protocol}</span>,
+        sort: (a, b) => a.protocol.localeCompare(b.protocol),
+      },
+      {
+        key: "ccs",
+        header: "Control channels",
+        render: (r) => (
+          <span className="font-mono text-xs text-muted">
+            {r.control_channels?.length
+              ? `${r.control_channels.length} freq${r.control_channels.length === 1 ? "" : "s"}`
+              : "—"}
+          </span>
+        ),
+        sort: (a, b) =>
+          (a.control_channels?.length ?? 0) -
+          (b.control_channels?.length ?? 0),
+      },
+      {
+        key: "site",
+        header: "Site",
+        render: (r) =>
+          r.site != null ? (
+            <span className="font-mono text-xs">{r.site}</span>
+          ) : (
+            <span className="text-muted">—</span>
+          ),
+        sort: (a, b) => (a.site ?? -1) - (b.site ?? -1),
+      },
+    ],
+    [],
+  );
+
+  return (
+    <div className="space-y-3">
+      <header className="flex items-center justify-between gap-3">
+        <h2 className="text-xl font-semibold">Systems</h2>
+        <span className="text-xs text-muted">
+          {filtered.length} of {systems.length}
+        </span>
+      </header>
+
+      <input
+        type="search"
+        className="input w-full sm:max-w-xs"
+        placeholder="Filter by name or protocol…"
+        value={filter}
+        onChange={(e) => setFilter(e.target.value)}
+        aria-label="Filter systems"
+      />
+
+      <DataTable
+        rows={filtered}
+        columns={columns}
+        rowKey={(r) => r.name}
+        defaultSortKey="name"
+        onRowClick={(r) => setSelected(r)}
+        emptyMessage={
+          systems.length === 0
+            ? "No trunked systems configured."
+            : "No systems match the filter."
+        }
+      />
+
+      {selected && (
+        <DetailModal
+          title={selected.name}
+          subtitle={selected.protocol}
+          onClose={() => setSelected(null)}
+        >
+          <DetailField
+            label="Control channels (Hz)"
+            mono
+            value={
+              selected.control_channels?.length
+                ? selected.control_channels.join("\n")
+                : null
+            }
+          />
+          <div className="grid grid-cols-2 gap-3">
+            <DetailField label="WACN" mono value={selected.wacn ?? null} />
+            <DetailField
+              label="System ID"
+              mono
+              value={selected.system_id ?? null}
+            />
+            <DetailField label="RFSS" mono value={selected.rfss ?? null} />
+            <DetailField label="Site" mono value={selected.site ?? null} />
+          </div>
+        </DetailModal>
+      )}
+    </div>
+  );
+}

--- a/web/src/panels/Talkgroups.tsx
+++ b/web/src/panels/Talkgroups.tsx
@@ -1,0 +1,170 @@
+import { useEffect, useMemo, useState } from "react";
+import { api } from "../api/client";
+import { Column, DataTable } from "../components/DataTable";
+import { DetailField, DetailModal } from "../components/DetailModal";
+import type { TalkgroupDTO } from "../api/types";
+import { selectClientConfig, useShared } from "../store/shared";
+
+const POLL_INTERVAL_MS = 15_000;
+
+// Talkgroups is read-only in this PR. Priority / lockout / scan
+// mutations (PATCH /api/v1/talkgroups/{id}) land in the mutation pass
+// that introduces the daemon-write capability gate UI.
+export function Talkgroups() {
+  const cfg = useShared(selectClientConfig);
+  const talkgroups = useShared((s) => s.talkgroups);
+  const setTalkgroups = useShared((s) => s.setTalkgroups);
+  const [selected, setSelected] = useState<TalkgroupDTO | null>(null);
+  const [filter, setFilter] = useState("");
+
+  useEffect(() => {
+    let cancel = false;
+    const refresh = async () => {
+      try {
+        const data = await api.talkgroups(cfg);
+        if (!cancel) setTalkgroups(data);
+      } catch {
+        // Keep the previous snapshot.
+      }
+    };
+    refresh();
+    const t = window.setInterval(refresh, POLL_INTERVAL_MS);
+    return () => {
+      cancel = true;
+      window.clearInterval(t);
+    };
+  }, [cfg, setTalkgroups]);
+
+  const filtered = useMemo(() => {
+    if (!filter.trim()) return talkgroups;
+    const needle = filter.toLowerCase();
+    return talkgroups.filter((t) => {
+      const idStr = String(t.id);
+      return (
+        idStr.includes(needle) ||
+        (t.alpha_tag ?? "").toLowerCase().includes(needle) ||
+        (t.description ?? "").toLowerCase().includes(needle) ||
+        (t.tag ?? "").toLowerCase().includes(needle) ||
+        (t.group ?? "").toLowerCase().includes(needle)
+      );
+    });
+  }, [talkgroups, filter]);
+
+  const columns: Column<TalkgroupDTO>[] = useMemo(
+    () => [
+      {
+        key: "id",
+        header: "ID",
+        render: (r) => <span className="font-mono">{r.id}</span>,
+        sort: (a, b) => a.id - b.id,
+      },
+      {
+        key: "alpha",
+        header: "Alpha tag",
+        render: (r) => (
+          <span className="font-medium">{r.alpha_tag ?? <em className="text-muted">—</em>}</span>
+        ),
+        sort: (a, b) =>
+          (a.alpha_tag ?? "").localeCompare(b.alpha_tag ?? ""),
+      },
+      {
+        key: "group",
+        header: "Group",
+        render: (r) => <span className="text-xs">{r.group ?? "—"}</span>,
+        sort: (a, b) => (a.group ?? "").localeCompare(b.group ?? ""),
+        className: "hidden md:table-cell",
+        headerClassName: "hidden md:table-cell",
+      },
+      {
+        key: "priority",
+        header: "Pri",
+        render: (r) => (
+          <span className="font-mono text-xs">{r.priority ?? "—"}</span>
+        ),
+        sort: (a, b) => (a.priority ?? 99) - (b.priority ?? 99),
+      },
+      {
+        key: "flags",
+        header: "Flags",
+        render: (r) => (
+          <div className="flex flex-wrap gap-1">
+            {r.scan && <span className="pill-ok">scan</span>}
+            {r.lockout && <span className="pill-err">lock</span>}
+            {r.priority != null && r.priority > 0 && (
+              <span className="pill-warn">pri</span>
+            )}
+          </div>
+        ),
+      },
+    ],
+    [],
+  );
+
+  return (
+    <div className="space-y-3">
+      <header className="flex items-center justify-between gap-3">
+        <h2 className="text-xl font-semibold">Talkgroups</h2>
+        <span className="text-xs text-muted">
+          {filtered.length} of {talkgroups.length}
+        </span>
+      </header>
+
+      <input
+        type="search"
+        className="input w-full sm:max-w-xs"
+        placeholder="Filter by id, alpha tag, group, tag…"
+        value={filter}
+        onChange={(e) => setFilter(e.target.value)}
+        aria-label="Filter talkgroups"
+      />
+
+      <DataTable
+        rows={filtered}
+        columns={columns}
+        rowKey={(r) => String(r.id)}
+        defaultSortKey="id"
+        onRowClick={(r) => setSelected(r)}
+        emptyMessage={
+          talkgroups.length === 0
+            ? "No talkgroups configured."
+            : "No talkgroups match the filter."
+        }
+      />
+
+      {selected && (
+        <DetailModal
+          title={selected.alpha_tag ?? `Talkgroup ${selected.id}`}
+          subtitle={`TGID ${selected.id}`}
+          onClose={() => setSelected(null)}
+        >
+          <DetailField label="Description" value={selected.description} />
+          <div className="grid grid-cols-2 gap-3">
+            <DetailField label="Tag" value={selected.tag} />
+            <DetailField label="Group" value={selected.group} />
+            <DetailField label="Mode" value={selected.mode} />
+            <DetailField
+              label="Priority"
+              mono
+              value={selected.priority ?? null}
+            />
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            <DetailField
+              label="Scan"
+              value={selected.scan ? "enabled" : "disabled"}
+            />
+            <DetailField
+              label="Lockout"
+              value={selected.lockout ? "locked out" : "active"}
+            />
+          </div>
+          <p className="text-xs text-muted pt-2">
+            Mutations (scan / lockout / priority) land in a follow-up
+            PR. Use the TUI's <code className="font-mono">S</code> /
+            priority shortcuts for now.
+          </p>
+        </DetailModal>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Fills in four of the nine stubbed web-console panels and lands the reusable `DataTable` + `DetailModal` components every remaining panel will pull from.

- **Systems** — sortable browser of `GET /api/v1/systems` with substring filter and detail modal (protocol, WACN / System ID / RFSS / Site, control channels).
- **Talkgroups** — sortable, filterable list with priority / scan / lockout flag pills and detail modal. Read-only in this pass; PATCH mutations land with the write-mode pass.
- **Devices** — SDR pool inspector. Attached/detached status, serial / driver / tuner / role columns, detail modal for gain / PPM / bias-T. Lives on the same `sdr.attached` / `sdr.detached` event slice the Dashboard already populates.
- **Events** — live ring-buffer viewer (500 cap, mirrors TUI), substring filter across kind / timestamp / payload, Pause/Resume snapshot for forensic review, click-to-expand row that pretty-prints the full event JSON.

Shared components:

- `DataTable` — sortable headers, keyboard-accessible row clicks (Enter / Space), optional inline expansion row, responsive overflow-x scroll, hidden-on-mobile columns via column-level `className`.
- `DetailModal` + `DetailField` — right-side sheet on desktop, bottom-sheet on phones, Escape-to-close, click-outside-to-dismiss.

Docs:

- Top-level `README.md` roadmap entry now reads "5 remaining panels (Active, History, Tones, Metrics, Scanner)" with the shipped panels itemised in the Web console section, each tagged with its backing endpoint.
- `web/README.md` gains a Status section with a shipping/pending matrix.

## Test plan

- [x] `npm run typecheck` is clean.
- [x] `npm run build` emits the new bundle (~207 kB JS, ~20 kB CSS gzipped to ~66 / 4 kB).
- [ ] Manual smoke against a running daemon:
  - [ ] Systems list renders configured systems; clicking a row opens the detail modal.
  - [ ] Talkgroups list paginates / filters; flag pills reflect `scan` / `lockout` / `priority`.
  - [ ] Devices reflects attach/detach in real time as a dongle is plugged/unplugged.
  - [ ] Events streams live; Pause freezes; filter narrows by kind; click expands to JSON.
- [ ] Cross-browser sanity (Chrome / Firefox / Safari) — load over LAN from a Pi, check responsive layout collapses correctly on a phone.

https://claude.ai/code/session_016bvS5NUb52afQ1bP95KALs

---
_Generated by [Claude Code](https://claude.ai/code/session_016bvS5NUb52afQ1bP95KALs)_