### PR TITLE
web: add Active calls and History call-log panels

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,19 +314,22 @@ to its own package and lands independently.
   [`web/`](web/) (Vite + React + TypeScript + Tailwind) currently
   ships Dashboard (live WebSocket event feed + audio cockpit),
   Settings (theme / write-mode / forget device), ConnectScreen
-  (server-URL + token entry), plus the read-only data browsers:
+  (server-URL + token entry), the read-only data browsers
   **Systems**, **Talkgroups**, **Devices** (sortable tables with
-  detail modals), and **Events** (live ring-buffer viewer with
-  filter + pause + inline JSON expansion). The remaining 5 TUI
-  panels (Active, History, Tones, Metrics, Scanner) are stubbed via
-  `Placeholder` and land panel-by-panel in follow-up PRs against the
-  same shared `src/store/` + `src/api/` plumbing — Scanner and the
-  Talkgroup-priority / call-end mutations introduce the daemon-write
-  gate UI. Daemon-side support (CORS middleware,
-  `GET /api/v1/audio/stream` PCM-over-WAV endpoint) already ships;
-  no further Go-side work is required to fill the panels in.
-  Operator playbook for running the daemon on a Raspberry Pi and
-  driving it from a laptop is in [`web/README.md`](web/README.md).
+  detail modals) and **Events** (live ring-buffer viewer with
+  filter + pause + inline JSON expansion), and the call-lifecycle
+  panels **Active** (per-call detail, live duration ticker) and
+  **History** (filterable call-log explorer over `/api/v1/calls/history`).
+  The remaining 3 TUI panels (Tones, Metrics, Scanner) are stubbed
+  via `Placeholder` and land panel-by-panel in follow-up PRs against
+  the same shared `src/store/` + `src/api/` plumbing — Scanner and
+  the Talkgroup-priority / call-end / retention-sweep mutations
+  introduce the daemon-write gate UI. Daemon-side support (CORS
+  middleware, `GET /api/v1/audio/stream` PCM-over-WAV endpoint)
+  already ships; no further Go-side work is required to fill the
+  panels in. Operator playbook for running the daemon on a
+  Raspberry Pi and driving it from a laptop is in
+  [`web/README.md`](web/README.md).
 - **DVSI USB-3000 / AMBE-3003 hardware backend (USB transport).**
   The `Vocoder` + AMBE-3003 wire protocol + `voice.Vocoder` interface
   conformance ship in [`internal/voice/dvsi/`](internal/voice/dvsi/)
@@ -2247,6 +2250,14 @@ visits skip the connect screen.
   PCM-over-WAV playback from the new `GET /api/v1/audio/stream`
   endpoint, volume / mute / record-toggle wired to
   `PATCH /api/v1/audio`.
+- **Active** — full active-call list with per-call detail modal
+  (grant breakdown: TGID / source / frequency / channel / flags),
+  live elapsed-time ticker, and a multi-column sortable table that
+  mirrors the TUI's Active panel.
+- **History** — filterable call-log explorer over
+  `GET /api/v1/calls/history?limit&system&group_id` with a form-
+  driven filter and a per-row detail modal showing duration,
+  end-reason, encryption / emergency / data flags.
 - **Systems** — sortable browser of every trunked system in
   `GET /api/v1/systems`, with a detail modal exposing protocol,
   WACN / System ID / RFSS / Site, and control-channel frequencies.
@@ -2265,13 +2276,13 @@ visits skip the connect screen.
   mirroring the TUI's `--write` flag, "forget this device" to clear
   stored credentials.
 
-The remaining five TUI panels (Active, History, Tones, Metrics,
-Scanner) are stubbed via `Placeholder` and land panel-by-panel in
-follow-up PRs against the same `src/store/` + `src/api/` plumbing —
-every read and mutation endpoint they need already lives on the
-daemon. See [`web/README.md`](web/README.md) for the operator
-playbook (LAN deployment, CORS config, PWA install steps) and the
-dev workflow (`make web-dev`, `make web-build`).
+The remaining three TUI panels (Tones, Metrics, Scanner) are stubbed
+via `Placeholder` and land panel-by-panel in follow-up PRs against
+the same `src/store/` + `src/api/` plumbing — every read and
+mutation endpoint they need already lives on the daemon. See
+[`web/README.md`](web/README.md) for the operator playbook (LAN
+deployment, CORS config, PWA install steps) and the dev workflow
+(`make web-dev`, `make web-build`).
 
 For full feature parity with the TUI today, continue using
 `gophertrunk tui` (above).

--- a/web/README.md
+++ b/web/README.md
@@ -118,6 +118,8 @@ Shipping today:
 | ------------- | ----------------------------------------------- |
 | ConnectScreen | `GET /api/v1/health` reachability probe         |
 | Dashboard     | `GET /api/v1/{health,calls/active,devices,audio}` + WebSocket event feed + `/api/v1/audio/stream` |
+| Active        | `GET /api/v1/calls/active` (sortable list, live elapsed ticker, detail modal) |
+| History       | `GET /api/v1/calls/history?limit&system&group_id` (form-driven filter + per-row detail) |
 | Systems       | `GET /api/v1/systems` (sortable list + detail)  |
 | Talkgroups    | `GET /api/v1/talkgroups` (sortable list + filter + detail) |
 | Devices       | `GET /api/v1/devices` (live attach/detach)      |
@@ -128,8 +130,6 @@ Pending — stubbed by `Placeholder` and arriving in follow-up PRs:
 
 | Panel        | Will mirror                                     |
 | ------------ | ----------------------------------------------- |
-| Active       | `GET /api/v1/calls/active` + end-call mutation  |
-| History      | `GET /api/v1/calls/history` + filters           |
 | Tones        | `tone.alert` ring + per-device reset            |
 | Metrics      | `GET /metrics` charted via Chart.js             |
 | Scanner      | `GET /api/v1/scanner` + hold/resume/retune/lockout mutations |

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -6,9 +6,11 @@ import { ConnectScreen } from "./components/ConnectScreen";
 import { TabBar, type Tab } from "./components/TabBar";
 import { AudioPlayer } from "./components/AudioPlayer";
 import { InstallPrompt } from "./components/InstallPrompt";
+import { Active } from "./panels/Active";
 import { Dashboard } from "./panels/Dashboard";
 import { Devices } from "./panels/Devices";
 import { Events } from "./panels/Events";
+import { History } from "./panels/History";
 import { Placeholder } from "./panels/Placeholder";
 import { Settings } from "./panels/Settings";
 import { Systems } from "./panels/Systems";
@@ -117,15 +119,7 @@ export function App() {
         <Routes>
           <Route path="/" element={<Navigate to="/dashboard" replace />} />
           <Route path="/dashboard" element={<Dashboard />} />
-          <Route
-            path="/active"
-            element={
-              <Placeholder
-                title="Active calls"
-                hint="The dashboard already lists active calls. This panel will add per-call detail, end-call mutations, and audio-cockpit shortcuts."
-              />
-            }
-          />
+          <Route path="/active" element={<Active />} />
           <Route
             path="/scanner"
             element={
@@ -137,10 +131,7 @@ export function App() {
           />
           <Route path="/systems" element={<Systems />} />
           <Route path="/talkgroups" element={<Talkgroups />} />
-          <Route
-            path="/history"
-            element={<Placeholder title="History" hint="Call log explorer." />}
-          />
+          <Route path="/history" element={<History />} />
           <Route path="/events" element={<Events />} />
           <Route
             path="/tones"

--- a/web/src/panels/Active.tsx
+++ b/web/src/panels/Active.tsx
@@ -1,0 +1,224 @@
+import { useEffect, useMemo, useState } from "react";
+import { api } from "../api/client";
+import { Column, DataTable } from "../components/DataTable";
+import { DetailField, DetailModal } from "../components/DetailModal";
+import type { ActiveCallDTO } from "../api/types";
+import { selectClientConfig, useShared } from "../store/shared";
+
+const POLL_INTERVAL_MS = 2_000;
+
+// Active mirrors the TUI's Active Calls panel. The dashboard already
+// surfaces a thumbnail; this panel gives the full call list with
+// per-call detail, grant breakdown, and a duration ticker.
+export function Active() {
+  const cfg = useShared(selectClientConfig);
+  const activeCalls = useShared((s) => s.activeCalls);
+  const setActiveCalls = useShared((s) => s.setActiveCalls);
+  const [selected, setSelected] = useState<ActiveCallDTO | null>(null);
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    let cancel = false;
+    const refresh = async () => {
+      try {
+        const data = await api.activeCalls(cfg);
+        if (!cancel) setActiveCalls(data);
+      } catch {
+        // Toast strip surfaces request errors elsewhere; keep the
+        // previous snapshot rather than blanking the table.
+      }
+    };
+    refresh();
+    const t = window.setInterval(refresh, POLL_INTERVAL_MS);
+    return () => {
+      cancel = true;
+      window.clearInterval(t);
+    };
+  }, [cfg, setActiveCalls]);
+
+  // Tick once a second so the elapsed-time column updates even when
+  // no API response has come back yet.
+  useEffect(() => {
+    const t = window.setInterval(() => setNow(Date.now()), 1_000);
+    return () => window.clearInterval(t);
+  }, []);
+
+  const columns: Column<ActiveCallDTO>[] = useMemo(
+    () => [
+      {
+        key: "tg",
+        header: "TG",
+        render: (r) => (
+          <span className="font-mono text-accent">{r.grant.group_id}</span>
+        ),
+        sort: (a, b) => a.grant.group_id - b.grant.group_id,
+      },
+      {
+        key: "alpha",
+        header: "Alpha tag",
+        render: (r) => (
+          <span className="font-medium">
+            {r.talkgroup?.alpha_tag ?? <em className="text-muted">—</em>}
+          </span>
+        ),
+        sort: (a, b) =>
+          (a.talkgroup?.alpha_tag ?? "").localeCompare(
+            b.talkgroup?.alpha_tag ?? "",
+          ),
+      },
+      {
+        key: "system",
+        header: "System",
+        render: (r) => <span className="text-xs">{r.grant.system}</span>,
+        sort: (a, b) => a.grant.system.localeCompare(b.grant.system),
+        className: "hidden md:table-cell",
+        headerClassName: "hidden md:table-cell",
+      },
+      {
+        key: "flags",
+        header: "",
+        render: (r) => (
+          <div className="flex flex-wrap gap-1">
+            {r.grant.encrypted && <span className="pill-warn">enc</span>}
+            {r.grant.emergency && <span className="pill-err">emerg</span>}
+            {r.grant.data_call && <span className="pill">data</span>}
+          </div>
+        ),
+      },
+      {
+        key: "elapsed",
+        header: "Elapsed",
+        render: (r) => (
+          <span className="font-mono text-xs tabular-nums">
+            {elapsed(r.started_at, now)}
+          </span>
+        ),
+        sort: (a, b) => a.started_at.localeCompare(b.started_at),
+      },
+      {
+        key: "device",
+        header: "Device",
+        render: (r) => (
+          <span className="font-mono text-xs text-muted">{r.device_serial}</span>
+        ),
+        sort: (a, b) => a.device_serial.localeCompare(b.device_serial),
+        className: "hidden lg:table-cell",
+        headerClassName: "hidden lg:table-cell",
+      },
+    ],
+    [now],
+  );
+
+  return (
+    <div className="space-y-3">
+      <header className="flex items-center justify-between gap-3">
+        <h2 className="text-xl font-semibold">Active calls</h2>
+        <span className="text-xs text-muted">{activeCalls.length} in flight</span>
+      </header>
+
+      <DataTable
+        rows={activeCalls}
+        columns={columns}
+        rowKey={(r) => `${r.device_serial}-${r.started_at}`}
+        defaultSortKey="elapsed"
+        defaultSortDirection="desc"
+        onRowClick={(r) => setSelected(r)}
+        emptyMessage="No calls right now. Active grants show up here as soon as the daemon allocates a voice device."
+      />
+
+      {selected && (
+        <DetailModal
+          title={selected.talkgroup?.alpha_tag ?? `TG ${selected.grant.group_id}`}
+          subtitle={`${selected.grant.system} · ${selected.grant.protocol}`}
+          onClose={() => setSelected(null)}
+        >
+          <div className="grid grid-cols-2 gap-3">
+            <DetailField label="TGID" mono value={selected.grant.group_id} />
+            <DetailField
+              label="Source"
+              mono
+              value={selected.grant.source_id ?? null}
+            />
+            <DetailField
+              label="Frequency"
+              mono
+              value={formatHz(selected.grant.frequency_hz)}
+            />
+            <DetailField
+              label="Channel"
+              mono
+              value={
+                selected.grant.channel_number ?? selected.grant.channel_id ?? null
+              }
+            />
+          </div>
+          <div className="grid grid-cols-3 gap-3">
+            <DetailField
+              label="Encrypted"
+              value={selected.grant.encrypted ? "yes" : "no"}
+            />
+            <DetailField
+              label="Emergency"
+              value={selected.grant.emergency ? "yes" : "no"}
+            />
+            <DetailField
+              label="Data"
+              value={selected.grant.data_call ? "yes" : "no"}
+            />
+          </div>
+          <DetailField
+            label="Device"
+            mono
+            value={selected.device_serial}
+          />
+          <div className="grid grid-cols-2 gap-3">
+            <DetailField
+              label="Started"
+              mono
+              value={selected.started_at.replace("T", " ").replace(/\..*$/, "")}
+            />
+            <DetailField
+              label="Elapsed"
+              mono
+              value={elapsed(selected.started_at, now)}
+            />
+          </div>
+          {selected.talkgroup && (
+            <div className="grid grid-cols-2 gap-3 pt-2 border-t border-panel">
+              <DetailField label="Tag" value={selected.talkgroup.tag} />
+              <DetailField label="Group" value={selected.talkgroup.group} />
+              <DetailField
+                label="Priority"
+                mono
+                value={selected.talkgroup.priority ?? null}
+              />
+              <DetailField label="Mode" value={selected.talkgroup.mode} />
+            </div>
+          )}
+          <p className="text-xs text-muted pt-2">
+            End-call mutation lands in a follow-up PR. Use the TUI's
+            <code className="font-mono mx-1">e</code>
+            shortcut for now.
+          </p>
+        </DetailModal>
+      )}
+    </div>
+  );
+}
+
+function elapsed(startedAt: string, now: number): string {
+  const startMs = Date.parse(startedAt);
+  if (Number.isNaN(startMs)) return "—";
+  const ms = Math.max(0, now - startMs);
+  const totalSeconds = Math.floor(ms / 1000);
+  const m = Math.floor(totalSeconds / 60);
+  const s = totalSeconds % 60;
+  return `${m.toString().padStart(2, "0")}:${s.toString().padStart(2, "0")}`;
+}
+
+function formatHz(hz: number): string {
+  if (!Number.isFinite(hz)) return "—";
+  if (hz >= 1_000_000) return `${(hz / 1_000_000).toFixed(4)} MHz`;
+  if (hz >= 1_000) return `${(hz / 1_000).toFixed(3)} kHz`;
+  return `${hz} Hz`;
+}

--- a/web/src/panels/History.tsx
+++ b/web/src/panels/History.tsx
@@ -1,0 +1,296 @@
+import { useEffect, useMemo, useState } from "react";
+import { api } from "../api/client";
+import { Column, DataTable } from "../components/DataTable";
+import { DetailField, DetailModal } from "../components/DetailModal";
+import type { CallRow } from "../api/types";
+import { selectClientConfig, useShared } from "../store/shared";
+
+// History reads /api/v1/calls/history with the same filter shape the
+// daemon accepts: limit, system, group_id. Read-only in this pass;
+// retention-sweep button lands in the mutation pass.
+export function History() {
+  const cfg = useShared(selectClientConfig);
+
+  const [rows, setRows] = useState<CallRow[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Form fields kept separate from the "submitted" filter object so
+  // typing into the inputs doesn't trigger a fetch on every keystroke.
+  const [limitInput, setLimitInput] = useState("200");
+  const [systemInput, setSystemInput] = useState("");
+  const [groupInput, setGroupInput] = useState("");
+  const [filter, setFilter] = useState<{
+    limit?: number;
+    system?: string;
+    group_id?: number;
+  }>({ limit: 200 });
+
+  const [selected, setSelected] = useState<CallRow | null>(null);
+
+  useEffect(() => {
+    let cancel = false;
+    setLoading(true);
+    setError(null);
+    api
+      .history(cfg, filter)
+      .then((data) => {
+        if (cancel) return;
+        setRows(data);
+      })
+      .catch((e: unknown) => {
+        if (cancel) return;
+        setError(e instanceof Error ? e.message : "history fetch failed");
+      })
+      .finally(() => {
+        if (!cancel) setLoading(false);
+      });
+    return () => {
+      cancel = true;
+    };
+  }, [cfg, filter]);
+
+  function applyFilter(e: React.FormEvent) {
+    e.preventDefault();
+    const next: typeof filter = {};
+    const lim = parseInt(limitInput, 10);
+    if (Number.isFinite(lim) && lim > 0) next.limit = lim;
+    if (systemInput.trim()) next.system = systemInput.trim();
+    const gid = parseInt(groupInput, 10);
+    if (Number.isFinite(gid)) next.group_id = gid;
+    setFilter(next);
+  }
+
+  function clearFilter() {
+    setLimitInput("200");
+    setSystemInput("");
+    setGroupInput("");
+    setFilter({ limit: 200 });
+  }
+
+  const columns: Column<CallRow>[] = useMemo(
+    () => [
+      {
+        key: "started",
+        header: "Started",
+        render: (r) => (
+          <span className="font-mono text-xs text-muted whitespace-nowrap">
+            {r.started_at.replace("T", " ").replace(/\..*$/, "")}
+          </span>
+        ),
+        sort: (a, b) => a.started_at.localeCompare(b.started_at),
+      },
+      {
+        key: "tg",
+        header: "TG",
+        render: (r) => (
+          <span className="font-mono text-accent">{r.group_id}</span>
+        ),
+        sort: (a, b) => a.group_id - b.group_id,
+      },
+      {
+        key: "alpha",
+        header: "Alpha tag",
+        render: (r) => (
+          <span className="font-medium">
+            {r.talkgroup_alpha ?? <em className="text-muted">—</em>}
+          </span>
+        ),
+        sort: (a, b) =>
+          (a.talkgroup_alpha ?? "").localeCompare(b.talkgroup_alpha ?? ""),
+      },
+      {
+        key: "system",
+        header: "System",
+        render: (r) => <span className="text-xs">{r.system}</span>,
+        sort: (a, b) => a.system.localeCompare(b.system),
+        className: "hidden md:table-cell",
+        headerClassName: "hidden md:table-cell",
+      },
+      {
+        key: "duration",
+        header: "Duration",
+        render: (r) => (
+          <span className="font-mono text-xs tabular-nums">
+            {formatDuration(r.duration_ms)}
+          </span>
+        ),
+        sort: (a, b) => (a.duration_ms ?? 0) - (b.duration_ms ?? 0),
+      },
+      {
+        key: "flags",
+        header: "",
+        render: (r) => (
+          <div className="flex flex-wrap gap-1">
+            {r.encrypted && <span className="pill-warn">enc</span>}
+            {r.emergency && <span className="pill-err">emerg</span>}
+            {r.data_call && <span className="pill">data</span>}
+          </div>
+        ),
+      },
+    ],
+    [],
+  );
+
+  return (
+    <div className="space-y-3">
+      <header className="flex items-center justify-between gap-3">
+        <h2 className="text-xl font-semibold">Call history</h2>
+        <span className="text-xs text-muted">
+          {loading
+            ? "loading…"
+            : `${rows.length} row${rows.length === 1 ? "" : "s"}`}
+        </span>
+      </header>
+
+      <form
+        onSubmit={applyFilter}
+        className="panel p-3 grid grid-cols-2 sm:grid-cols-4 gap-2 items-end"
+      >
+        <label className="text-xs space-y-1">
+          <span className="text-muted uppercase tracking-wider">Limit</span>
+          <input
+            type="number"
+            min={1}
+            max={5000}
+            className="input w-full"
+            value={limitInput}
+            onChange={(e) => setLimitInput(e.target.value)}
+          />
+        </label>
+        <label className="text-xs space-y-1">
+          <span className="text-muted uppercase tracking-wider">System</span>
+          <input
+            type="text"
+            className="input w-full"
+            placeholder="name"
+            value={systemInput}
+            onChange={(e) => setSystemInput(e.target.value)}
+          />
+        </label>
+        <label className="text-xs space-y-1">
+          <span className="text-muted uppercase tracking-wider">Group ID</span>
+          <input
+            type="number"
+            min={0}
+            className="input w-full"
+            placeholder="e.g. 1001"
+            value={groupInput}
+            onChange={(e) => setGroupInput(e.target.value)}
+          />
+        </label>
+        <div className="flex gap-2 col-span-2 sm:col-span-1">
+          <button type="submit" className="btn-primary flex-1">
+            Apply
+          </button>
+          <button
+            type="button"
+            className="btn-ghost"
+            onClick={clearFilter}
+          >
+            Clear
+          </button>
+        </div>
+      </form>
+
+      {error && (
+        <p className="text-sm text-err" role="alert">
+          {error}
+        </p>
+      )}
+
+      <DataTable
+        rows={rows}
+        columns={columns}
+        rowKey={(r) => String(r.id)}
+        defaultSortKey="started"
+        defaultSortDirection="desc"
+        onRowClick={(r) => setSelected(r)}
+        emptyMessage={
+          loading
+            ? "loading…"
+            : "No calls in the daemon's call log for this filter."
+        }
+      />
+
+      {selected && (
+        <DetailModal
+          title={selected.talkgroup_alpha ?? `TG ${selected.group_id}`}
+          subtitle={`${selected.system} · ${selected.protocol}`}
+          onClose={() => setSelected(null)}
+        >
+          <div className="grid grid-cols-2 gap-3">
+            <DetailField label="Row ID" mono value={selected.id} />
+            <DetailField label="TGID" mono value={selected.group_id} />
+            <DetailField
+              label="Source"
+              mono
+              value={selected.source_id ?? null}
+            />
+            <DetailField
+              label="Frequency"
+              mono
+              value={formatHz(selected.frequency_hz)}
+            />
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            <DetailField
+              label="Started"
+              mono
+              value={selected.started_at.replace("T", " ").replace(/\..*$/, "")}
+            />
+            <DetailField
+              label="Ended"
+              mono
+              value={
+                selected.ended_at
+                  ? selected.ended_at.replace("T", " ").replace(/\..*$/, "")
+                  : null
+              }
+            />
+            <DetailField
+              label="Duration"
+              mono
+              value={formatDuration(selected.duration_ms)}
+            />
+            <DetailField label="End reason" value={selected.end_reason} />
+          </div>
+          <div className="grid grid-cols-3 gap-3">
+            <DetailField
+              label="Encrypted"
+              value={selected.encrypted ? "yes" : "no"}
+            />
+            <DetailField
+              label="Emergency"
+              value={selected.emergency ? "yes" : "no"}
+            />
+            <DetailField
+              label="Data"
+              value={selected.data_call ? "yes" : "no"}
+            />
+          </div>
+          <DetailField
+            label="Device"
+            mono
+            value={selected.device_serial ?? null}
+          />
+        </DetailModal>
+      )}
+    </div>
+  );
+}
+
+function formatDuration(ms?: number): string {
+  if (ms == null || !Number.isFinite(ms)) return "—";
+  const seconds = Math.floor(ms / 1000);
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return `${m}:${s.toString().padStart(2, "0")}`;
+}
+
+function formatHz(hz: number): string {
+  if (!Number.isFinite(hz)) return "—";
+  if (hz >= 1_000_000) return `${(hz / 1_000_000).toFixed(4)} MHz`;
+  if (hz >= 1_000) return `${(hz / 1_000).toFixed(3)} kHz`;
+  return `${hz} Hz`;
+}


### PR DESCRIPTION
## Summary

Fills in two more web-console panels, dropping stubbed-panel count from 5 → 3 (Tones, Metrics, Scanner remain).

- **Active** — sortable per-call list with TGID / alpha tag / system / flag pills / **live elapsed-time** column (m:ss tick once per second). Detail modal exposes the full grant: TGID, source ID, frequency (auto-scaled MHz / kHz / Hz), channel number, encrypted / emergency / data flags, the talkgroup summary (tag / group / priority / mode), device serial, and started/elapsed timestamps. Polls `/api/v1/calls/active` every 2 s into the same store slice the Dashboard already populates, so both views stay coherent.
- **History** — form-driven filter (limit / system / group_id) that maps directly to `/api/v1/calls/history` query params; submitting refetches. Sortable table (newest-first default) with started-at, TGID, alpha tag, system, duration, and flag pills. Detail modal exposes row ID, source, frequency, started/ended/duration, end_reason, flags, and device serial. Default limit 200 (cap 5000) keeps the render fast.

Both panels read-only this pass — end-call (Active) and retention-sweep (History) mutations land with the write-mode UI pass.

## Docs

- `README.md` roadmap entry now lists the 3 remaining panels (Tones, Metrics, Scanner).
- `README.md` Web console section adds Active + History bullets with their backing endpoints.
- `web/README.md` status matrix moves Active + History into the shipping list.

## Test plan

- [x] `npm run typecheck` clean.
- [x] `npm run build` emits the new bundle (~216 kB JS gzipped to ~68 kB).
- [ ] Manual smoke against a running daemon:
  - [ ] Active populates with mock-SDR grants; elapsed-time ticks live; detail modal shows full grant payload.
  - [ ] History loads with default limit; filter form by system / group_id refetches; detail modal shows ended/duration/end_reason.
- [ ] Responsive layout: filter form collapses to 2-col on phones; long-only columns hide on `md`/`lg` breakpoints.

https://claude.ai/code/session_016bvS5NUb52afQ1bP95KALs

---
_Generated by [Claude Code](https://claude.ai/code/session_016bvS5NUb52afQ1bP95KALs)_