### PR TITLE
docs(web): add dedicated Web console page to gophertrunk.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ cp config.example.yaml config.yaml
 ./gophertrunk run -config config.yaml
 ```
 
-Full per-OS install (Windows installer / macOS Apple Silicon / Linux aarch64): **[gophertrunk.org/downloads.html](https://gophertrunk.org/downloads.html)** · TUI keybindings: [`docs/tui.md`](docs/tui.md) · Hardware setup (udev rules, WinUSB / Zadig): [`docs/hardware.md`](docs/hardware.md) · Production hardening (TLS, bearer-token auth, Docker): [`docs/hardening.md`](docs/hardening.md).
+Full per-OS install (Windows installer / macOS Apple Silicon / Linux aarch64): **[gophertrunk.org/downloads.html](https://gophertrunk.org/downloads.html)** · Web console setup + quick start: **[gophertrunk.org/web.html](https://gophertrunk.org/web.html)** · TUI keybindings: [`docs/tui.md`](docs/tui.md) · Hardware setup (udev rules, WinUSB / Zadig): [`docs/hardware.md`](docs/hardware.md) · Production hardening (TLS, bearer-token auth, Docker): [`docs/hardening.md`](docs/hardening.md).
 
 ## Features
 
@@ -2282,8 +2282,11 @@ counterpart:
 All mutations are AND-gated by `selectCanMutate` (write mode +
 daemon `allow_mutations`) and the destructive ones are wrapped in a
 `ConfirmModal` so a fat-finger tap in the bottom nav doesn't end a
-call. See [`web/README.md`](web/README.md) for the operator
-playbook (LAN deployment, CORS config, PWA install steps) and the
+call. See the **setup + quick-start guide at
+[gophertrunk.org/web.html](https://gophertrunk.org/web.html)** (also
+[`docs/web.md`](docs/web.md)) for the operator playbook — LAN
+deployment, CORS config, PWA install — and
+[`web/README.md`](web/README.md) for the developer reference + the
 dev workflow (`make web-dev`, `make web-build`).
 
 ## API authentication
@@ -2422,9 +2425,13 @@ opt-in field as a `omitempty` JSON value.
   concurrency model, driver registry, build tags
 - [`docs/tui.md`](docs/tui.md) — TUI keybindings, panel reference,
   troubleshooting
-- [`web/README.md`](web/README.md) — browser web console (standalone
-  `gophertrunk-web/` package): LAN deployment recipe, CORS config,
-  PWA install steps, dev workflow (`make web-dev` / `make web-build`)
+- [`docs/web.md`](docs/web.md) — browser web console setup + quick
+  start: getting the bundle, daemon CORS/auth config, opening
+  `index.html`, LAN scenario, PWA install, troubleshooting. Also at
+  **[gophertrunk.org/web.html](https://gophertrunk.org/web.html)**
+- [`web/README.md`](web/README.md) — web console developer reference:
+  shipping panel matrix, architecture, dev workflow
+  (`make web-dev` / `make web-build`)
 - [`docs/hardware.md`](docs/hardware.md) — udev rules, DVB blacklist,
   IQ capture for replay
 - [`docs/vocoders.md`](docs/vocoders.md) — IMBE / AMBE+2 licensing

--- a/docs/_data/nav.yml
+++ b/docs/_data/nav.yml
@@ -15,6 +15,8 @@ groups:
     items:
       - title: TUI
         url: /tui.html
+      - title: Web console
+        url: /web.html
       - title: Import (PDF / CSV)
         url: /import.html
       - title: Hardening

--- a/docs/downloads.md
+++ b/docs/downloads.md
@@ -61,6 +61,10 @@ nav_group: Install
   Jump to: <a href="#linux">Linux quick start</a> · <a href="#macos">macOS quick start</a> · <a href="#windows-11">Windows quick start</a> · <a href="#verify-your-download">Verify</a> · <a href="#build-from-source">Build from source</a> · <a href="#docker">Docker</a>
 </p>
 
+<p class="downloads-jump">
+  Every release archive includes the standalone browser console at <code>gophertrunk-web/</code> alongside the daemon binary — open <code>index.html</code> in any browser to operate from a laptop, tablet, or phone on the LAN. Setup walkthrough: <a href="{{ '/web.html' | relative_url }}">Web console quick start</a>.
+</p>
+
 [releases]: https://github.com/MattCheramie/GopherTrunk/releases
 [latest]: https://github.com/MattCheramie/GopherTrunk/releases/latest
 

--- a/docs/web.md
+++ b/docs/web.md
@@ -1,0 +1,279 @@
+---
+layout: page
+title: Web console
+description: Setup and quick-start guide for the standalone browser-based GopherTrunk operator console — runs on any laptop, tablet, or phone over a LAN
+nav_group: Operate
+---
+
+# Web console
+
+GopherTrunk ships a full browser-based operator console alongside the
+TUI. It's a **standalone static SPA** — pure HTML / CSS / JS, no
+Node.js, no embedded web server in the daemon. Open `index.html` in
+any modern browser, point it at a running daemon's URL on the
+connect screen, and operate.
+
+Every Bubbletea TUI panel has a browser counterpart:
+
+| Panel       | What it does                                                    |
+| ----------- | --------------------------------------------------------------- |
+| Dashboard   | Live WebSocket event feed, audio cockpit with PCM-over-WAV playback |
+| Active      | Active-call list with live elapsed ticker + end-call mutation   |
+| History     | Filterable call-log explorer + retention-sweep mutation         |
+| Systems     | Trunked-system browser with detail modal                        |
+| Talkgroups  | Sortable / filterable list with scan / lockout / priority edits |
+| Devices     | SDR pool inspector (live attach / detach)                       |
+| Events      | Live ring-buffer viewer (filter / pause / JSON expansion)       |
+| Tones       | `tone.alert` feed with per-device reset                         |
+| Metrics     | Curated `gophertrunk_*` Prometheus tiles + Chart.js trend       |
+| Scanner     | CC hunter, conventional channels, manual VFO tune, scan_mode    |
+| Settings    | Theme, write-mode toggle, "forget this device"                  |
+
+The headline scenario: run the daemon on a Raspberry Pi (or any host
+with the RTL-SDR attached), then operate from a laptop, tablet, or
+phone anywhere on the LAN.
+
+## 1. Get the bundle
+
+The web console ships as a sibling directory inside every release
+archive — same archive that contains the `gophertrunk` binary:
+
+```
+gophertrunk-<version>-<os>-<arch>/
+├── gophertrunk              # the daemon / CLI binary
+├── gophertrunk-web/         # standalone web console
+│   ├── index.html
+│   ├── assets/…             # bundled React / Tailwind / Chart.js
+│   ├── favicon.svg
+│   ├── manifest.webmanifest
+│   └── sw.js                # PWA service worker
+├── config.example.yaml
+└── samples/…
+```
+
+Download the matching release archive from the
+**[Downloads page]({{ '/downloads.html' | relative_url }})** and unpack
+it. That's the only file you need on the device that will run the
+browser; nothing else is installed.
+
+## 2. Configure the daemon for browser access
+
+Two daemon-side knobs control browser access — both already on the
+existing `api:` block in `config.yaml`. Edit your `config.yaml`:
+
+```yaml
+api:
+  # Bind 0.0.0.0 so a laptop on the same network can reach the daemon.
+  # Use a specific LAN address like 192.168.1.42 if you prefer.
+  http_addr: "0.0.0.0:8080"
+
+  # Browsers send a different Origin than the daemon's bind address,
+  # so the daemon needs an explicit allow-list. Choose ONE of:
+  cors:
+    allowed_origins:
+      - "null"                      # SPA opened via file:// (most common)
+      # - "http://192.168.1.7:9000" # SPA hosted by a static web server on the laptop
+      # - "*"                        # any origin (loopback-only daemons; not for public binds)
+
+  # Require a bearer token when the daemon binds to a non-loopback
+  # interface. The SPA prompts for the token on the connect screen.
+  auth:
+    mode: "required"
+    token_file: "/etc/gophertrunk/api-token"
+```
+
+Restart the daemon for the changes to take effect:
+
+```bash
+./gophertrunk run -config config.yaml
+```
+
+> **Why CORS?** The SPA is loaded from a different origin than the
+> daemon (either `file://` or whatever static host you use), so the
+> browser performs a CORS preflight on every request. `"null"`
+> covers the `file://` case; explicit URLs cover the rest.
+
+## 3. Open the SPA
+
+### On the same machine as the daemon
+
+Double-click `gophertrunk-web/index.html` to open it in your default
+browser. On the connect screen enter:
+
+- **Server URL:** `http://127.0.0.1:8080`
+- **Bearer token:** the contents of your `token_file` (or empty if
+  `auth.mode: disabled`)
+- **Remember on this device:** check it if you want the token to
+  survive a browser restart (it lands in `localStorage` instead of
+  `sessionStorage`).
+
+### From a laptop, tablet, or phone on the same LAN
+
+This is the canonical "headless Pi, operate from the couch"
+scenario.
+
+1. On the host running the daemon, set `api.http_addr: "0.0.0.0:8080"`
+   (or a specific LAN IP) and restart.
+2. Copy `gophertrunk-web/` to the device that will run the browser —
+   USB stick, `scp`, or just unpack the same release archive on that
+   device.
+3. Double-click `gophertrunk-web/index.html`. On the connect screen
+   enter the daemon's URL (e.g. `http://192.168.1.42:8080`) and
+   the bearer token.
+
+The browser remembers the URL across visits.
+
+### Hosted by a static web server (optional)
+
+If you'd rather serve the SPA over HTTP than open `file://`, point
+any static-file HTTP server at `gophertrunk-web/`:
+
+```bash
+# Quick and dirty — any laptop with Python
+cd gophertrunk-web/
+python3 -m http.server 9000
+```
+
+```bash
+# Caddy one-liner
+caddy file-server --root gophertrunk-web --listen :9000
+```
+
+Then add the server's origin to the daemon's CORS list:
+
+```yaml
+api:
+  cors:
+    allowed_origins:
+      - "http://192.168.1.7:9000"
+```
+
+Open `http://192.168.1.7:9000/` in any browser on the network and
+follow the connect-screen flow as above.
+
+## 4. Install as a phone app (optional)
+
+The SPA is a Progressive Web App. After connecting once:
+
+- **Android (Chrome / Edge):** An "Install GopherTrunk" banner
+  appears once the service worker registers — accept it. Or use the
+  browser menu → "Install app".
+- **iOS (Safari):** Open the SPA in Safari, tap the Share button,
+  then "Add to Home Screen". iOS launches the installed app full-
+  screen with a dedicated icon.
+- **Desktop Chrome / Edge:** Click the install icon in the address
+  bar (right side, looks like a small monitor) to install as a
+  desktop app.
+
+The installed PWA still talks to whichever daemon URL you set on the
+connect screen — installation doesn't change the API target. Audio
+playback works on both platforms after a one-time "Tap to enable
+audio" gesture (required by iOS / Android autoplay rules).
+
+## Quick reference
+
+### Connect screen field map
+
+| Field                    | What to enter                                                    |
+| ------------------------ | ---------------------------------------------------------------- |
+| Server URL               | `http://<host>:<port>`, e.g. `http://192.168.1.42:8080`          |
+| Bearer token             | Contents of `api.auth.token_file` — leave empty if auth is `disabled` |
+| Remember on this device  | Move the token from `sessionStorage` → `localStorage` so it survives browser restart |
+
+### Shareable one-click link
+
+The SPA accepts pre-filled credentials via a URL hash:
+
+```
+index.html#server=http://192.168.1.42:8080&token=<your-token>
+```
+
+Bookmark or share that link (with appropriate care for the token).
+The SPA stores the values in browser storage on first load so the
+hash isn't needed again.
+
+### Write mode
+
+Mutation controls (end-call, talkgroup edits, scanner hold / resume
+/ retune / manual-tune, retention sweep, tone-detector reset) are
+hidden by default. To unlock them:
+
+1. Open **Settings**.
+2. Tick **Allow mutations from this browser**.
+3. If the daemon's `/api/v1/mutations` endpoint reports
+   `allow_mutations: false`, the toggle is informational only — fix
+   `api.auth.mode` or the trusted-networks list (see
+   **[Hardening]({{ '/hardening.html#api-authentication' | relative_url }})**) to actually permit writes.
+
+The browser remembers the write-mode flag locally. Destructive
+mutations (end-call, channel lockout, retune, retention sweep)
+always prompt for confirmation before firing.
+
+### Audio playback
+
+The audio cockpit lives at the top of the Dashboard:
+
+- **Volume slider** → `PATCH /api/v1/audio { volume }`
+- **Mute toggle** → `PATCH /api/v1/audio { muted }`
+- **Record toggle** → `PATCH /api/v1/audio { recording_enabled }`
+- **Tap to enable** → required once per session on iOS / Android
+  per the autoplay rules; the SPA shows a one-shot prompt.
+
+The browser streams live PCM from
+`GET /api/v1/audio/stream` — a continuous open-ended WAV body, no
+JavaScript decoding required. Reads are unauthenticated by default;
+authenticate them by binding the daemon to a trusted network or
+requiring TLS + token via your reverse proxy.
+
+### Tabs
+
+Bottom-nav on phones, top-tab strip on desktop:
+
+```
+Dashboard · Active · Scanner · Settings        (always visible)
+Systems · Talkgroups · History · Events ·
+  Tones · Metrics · Devices                    (desktop overflow row)
+```
+
+On phones the overflow row is reachable via the hamburger menu in
+the bottom nav. Keyboard shortcuts are not yet wired (a follow-up
+PR will add the TUI's command palette + jump-to-panel hotkeys).
+
+## Troubleshooting
+
+| Symptom                                                | Likely cause + fix                                                                                            |
+| ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------- |
+| "Failed to fetch" on the connect screen                | Daemon not reachable. Confirm `gophertrunk run` is up and the URL is right (`curl http://<url>/api/v1/health`).        |
+| Browser console shows "CORS preflight rejected"        | The daemon hasn't allow-listed your SPA's origin. Add it under `api.cors.allowed_origins` and restart.        |
+| 401 on every request                                   | Wrong bearer token. Re-check `api.auth.token_file` contents and re-enter on the connect screen.               |
+| Connect succeeds but no events / no audio              | The WebSocket couldn't upgrade. If you're behind a reverse proxy, confirm it forwards `Upgrade` / `Connection` headers. |
+| Audio plays for 2 s then stops                         | iOS / Android autoplay block. Tap the "Tap to enable audio" prompt on the Dashboard.                          |
+| Mutation buttons are invisible                         | Write mode is off or the daemon rejects mutations. Open **Settings** → tick "Allow mutations".                |
+| SPA loads but tabs are stuck on a spinner              | Daemon is reachable but the API rejected the token mid-flight. Open the connect screen and re-enter creds.    |
+| PWA install prompt never appears (Android)             | First-load only — clear the site's data in the browser and revisit.                                           |
+
+## Building from source
+
+The web console builds with Vite. The daemon's `Makefile` wraps
+the npm scripts:
+
+```bash
+make web-build      # produces web/dist/ — the shipped artifact
+make web-dev        # Vite dev server on :5173 with proxy to :8080
+make web-clean      # removes node_modules/, dist/, dev-dist/
+```
+
+Tested with Node.js 20 LTS and npm 10. Older Node versions may work
+but aren't in CI. **End users never run Node** — the dev server is
+a developer convenience only.
+
+The Vite dev server proxies `/api/*` and `/metrics` to
+`http://127.0.0.1:8080`, so the SPA running on `:5173` looks
+same-origin to the browser and CORS isn't required during
+development.
+
+## See also
+
+- [`web/README.md`](https://github.com/MattCheramie/GopherTrunk/blob/main/web/README.md) — full developer reference + architecture
+- [Hardening]({{ '/hardening.html#api-authentication' | relative_url }}) — `api.auth.mode`, `token_file`, trusted networks
+- [TUI]({{ '/tui.html' | relative_url }}) — full-screen terminal cockpit alternative


### PR DESCRIPTION
## Summary

The browser-based operator console now has its own dedicated setup + quick-start guide on **[gophertrunk.org/web.html](https://gophertrunk.org/web.html)**, mirroring [`docs/tui.md`](https://gophertrunk.org/tui.html)'s role for the terminal cockpit.

### New page: `docs/web.md`

- **"What ships in the release archive"** with the `gophertrunk-web/` tree layout.
- **Daemon-side configuration walkthrough** — `api.http_addr`, `api.cors.allowed_origins`, `api.auth.mode` / `token_file`.
- **Three scenarios** with explicit steps:
  1. Same-machine (`file://` + `127.0.0.1`)
  2. Headless Pi + laptop on LAN (the headline scenario)
  3. Static-host (`python -m http.server` / Caddy `file-server`)
- **PWA install steps** for Android, iOS, and desktop Chrome / Edge.
- **Quick reference** — connect-screen field map, shareable hash-link format (`index.html#server=…&token=…`), write-mode unlock, audio-cockpit endpoint map, tab layout.
- **Troubleshooting matrix** covering CORS preflight rejection, 401, WS upgrade failure under a reverse proxy, iOS/Android audio autoplay block, hidden mutation buttons, missing PWA prompt.
- **"Building from source"** pointer for contributors.
- **"See also"** cross-links to `web/README.md`, hardening, and TUI.

### Site wiring

- `docs/_data/nav.yml` — new **Web console** entry under the Operate group, between TUI and Import.
- `docs/downloads.md` — lede paragraph at the top of the OS quick-start section pointing operators at `/web.html`.
- `README.md` — header link line, §Web console section, and Documentation index all link to the new page.

No new content is hidden behind code changes — every fact in the guide reflects the SPA + daemon as shipped in #231.

## Test plan

- [x] Front matter (`layout: page`, `nav_group: Operate`) matches the existing `docs/tui.md` / `docs/import.md` convention.
- [x] `docs/_data/nav.yml` lists the page under Operate so the side nav renders the link.
- [x] Cross-references in `README.md` and `docs/downloads.md` point to `/web.html`.
- [ ] After merge: confirm `gophertrunk.org/web.html` renders the page with the Operate group highlighted in the nav.
- [ ] After merge: confirm the breadcrumb shows `Operate › Web console`.

https://claude.ai/code/session_016bvS5NUb52afQ1bP95KALs

---
_Generated by [Claude Code](https://claude.ai/code/session_016bvS5NUb52afQ1bP95KALs)_