### PR TITLE
installer: include web console in every release + Windows wizard prompts for install location

### DIFF
--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -59,6 +59,20 @@ jobs:
         with:
           go-version: "1.25.10"
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: web/package-lock.json
+
+      - name: Build web console (gophertrunk-web)
+        shell: bash
+        run: |
+          set -eu
+          cd web
+          npm ci --no-audit --no-fund
+          npm run build
+
       - name: Build gophertrunk.exe
         shell: bash
         env:
@@ -72,13 +86,15 @@ jobs:
             -o dist/staging/gophertrunk.exe \
             ./cmd/gophertrunk
 
-      - name: Stage docs
+      - name: Stage docs + web console
         shell: bash
         run: |
           set -eu
           STAGE=dist/staging
           cp README.md LICENSE config.example.yaml "$STAGE/"
           cp docs/install-windows.md "$STAGE/INSTALL-WINDOWS.md"
+          mkdir -p "$STAGE/gophertrunk-web"
+          cp -r web/dist/. "$STAGE/gophertrunk-web/"
 
       - name: Build Inno Setup installer
         uses: Minionguyjpro/Inno-Setup-Action@v1.2.5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,20 @@ jobs:
         with:
           go-version: "1.25.10"
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: web/package-lock.json
+
+      - name: Build web console (gophertrunk-web)
+        shell: bash
+        run: |
+          set -eu
+          cd web
+          npm ci --no-audit --no-fund
+          npm run build
+
       - name: Build gophertrunk.exe
         shell: bash
         env:
@@ -69,13 +83,19 @@ jobs:
             -o dist/staging/gophertrunk.exe \
             ./cmd/gophertrunk
 
-      - name: Stage docs
+      - name: Stage docs + web console
         shell: bash
         run: |
           set -eu
           STAGE=dist/staging
           cp README.md LICENSE config.example.yaml "$STAGE/"
           cp docs/install-windows.md "$STAGE/INSTALL-WINDOWS.md"
+          # Standalone browser console bundled into each release. The
+          # Inno Setup script consumes this directory and asks the
+          # user where to install it; the portable ZIP just includes
+          # it next to the binary.
+          mkdir -p "$STAGE/gophertrunk-web"
+          cp -r web/dist/. "$STAGE/gophertrunk-web/"
 
       - name: Build portable ZIP (amd64)
         shell: bash
@@ -113,6 +133,8 @@ jobs:
             ./cmd/gophertrunk
           cp README.md LICENSE config.example.yaml "dist/${NAME}/"
           cp docs/install-windows.md "dist/${NAME}/INSTALL-WINDOWS.md"
+          mkdir -p "dist/${NAME}/gophertrunk-web"
+          cp -r web/dist/. "dist/${NAME}/gophertrunk-web/"
           (cd dist && 7z a "${NAME}.zip" "${NAME}")
 
       - uses: actions/upload-artifact@v4
@@ -131,6 +153,19 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: "1.25.10"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: web/package-lock.json
+
+      - name: Build web console (gophertrunk-web)
+        run: |
+          set -eu
+          cd web
+          npm ci --no-audit --no-fund
+          npm run build
 
       - name: Compute version
         id: version
@@ -160,6 +195,8 @@ jobs:
               -o "dist/${NAME}/gophertrunk" \
               ./cmd/gophertrunk
             cp README.md LICENSE config.example.yaml "dist/${NAME}/"
+            mkdir -p "dist/${NAME}/gophertrunk-web"
+            cp -r web/dist/. "dist/${NAME}/gophertrunk-web/"
             (cd dist && tar -czf "${NAME}.tar.gz" "${NAME}")
           done
 
@@ -177,6 +214,19 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: "1.25.10"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: web/package-lock.json
+
+      - name: Build web console (gophertrunk-web)
+        run: |
+          set -eu
+          cd web
+          npm ci --no-audit --no-fund
+          npm run build
 
       - name: Compute version
         id: version
@@ -206,6 +256,8 @@ jobs:
               -o "dist/${NAME}/gophertrunk" \
               ./cmd/gophertrunk
             cp README.md LICENSE config.example.yaml "dist/${NAME}/"
+            mkdir -p "dist/${NAME}/gophertrunk-web"
+            cp -r web/dist/. "dist/${NAME}/gophertrunk-web/"
             (cd dist && tar -czf "${NAME}.tar.gz" "${NAME}")
           done
 
@@ -266,12 +318,14 @@ jobs:
           body: |
             ## Install
 
-            **Windows 11 (x64):** download `gophertrunk-${{ steps.version.outputs.version }}-windows-amd64-setup.exe` and double-click. The installer adds GopherTrunk to your Start Menu — single static binary, no DLLs to ship. After install, follow [INSTALL-WINDOWS.md](https://github.com/MattCheramie/GopherTrunk/blob/main/docs/install-windows.md) to install the WinUSB driver via Zadig — the OS won't see your RTL-SDR until you do this once.
+            **Windows 11 (x64):** download `gophertrunk-${{ steps.version.outputs.version }}-windows-amd64-setup.exe` and double-click. The installer adds GopherTrunk to your Start Menu — single static binary, no DLLs to ship — and **prompts for a folder to install the browser-based web operator console** (default: `Documents\GopherTrunk Web Console`). After install, follow [INSTALL-WINDOWS.md](https://github.com/MattCheramie/GopherTrunk/blob/main/docs/install-windows.md) to install the WinUSB driver via Zadig — the OS won't see your RTL-SDR until you do this once.
 
-            **Windows on ARM:** extract `gophertrunk-${{ steps.version.outputs.version }}-windows-arm64.zip` (no installer for arm64 yet — portable ZIP only).
+            **Windows on ARM:** extract `gophertrunk-${{ steps.version.outputs.version }}-windows-arm64.zip` (no installer for arm64 yet — portable ZIP only). The web console lives in the `gophertrunk-web\` subfolder inside the zip.
 
             **macOS:** extract `gophertrunk-${{ steps.version.outputs.version }}-darwin-arm64.tar.gz` (Apple Silicon) or `gophertrunk-${{ steps.version.outputs.version }}-darwin-amd64.tar.gz` (Intel) and run `./gophertrunk`. Builds are unsigned — right-click → Open the first time to bypass Gatekeeper.
 
             **Linux:** extract `gophertrunk-${{ steps.version.outputs.version }}-linux-amd64.tar.gz` (x86_64) or `gophertrunk-${{ steps.version.outputs.version }}-linux-arm64.tar.gz` (aarch64, e.g. Raspberry Pi 4/5) and run `./gophertrunk`. Single static binary; no system dependencies needed.
+
+            **Web operator console:** every archive includes a standalone `gophertrunk-web/` folder. Open its `index.html` in any browser and point it at a running daemon. Setup walkthrough: [gophertrunk.org/web.html](https://gophertrunk.org/web.html).
 
             All artifacts are SHA-256-checksummed in `SHA256SUMS`.

--- a/docs/downloads.md
+++ b/docs/downloads.md
@@ -116,6 +116,8 @@ Run the installer:
 .\gophertrunk-{{ ver }}-windows-amd64-setup.exe
 ```
 
+During setup the wizard asks where to install the **browser-based web operator console** (default `%USERPROFILE%\Documents\GopherTrunk Web Console`). A Start Menu shortcut opens `index.html` in your default browser; untick the "Install the web operator console" task on the Tasks page to skip it for a headless install.
+
 After install, complete the WinUSB driver swap via Zadig — see **[`install-windows.md`]({{ '/install-windows.html' | relative_url }})** for the full step-by-step (the installer's last page links there too). The OS won't see your RTL-SDR until that swap is done.
 
 ## Verify your download

--- a/docs/install-windows.md
+++ b/docs/install-windows.md
@@ -39,13 +39,23 @@ Double-click `setup.exe` and accept the defaults. The installer:
   a single static binary, no DLLs to ship.
 - Adds Start Menu entries for the daemon, the config template,
   and these instructions.
+- Installs the **browser-based web operator console** (a static
+  HTML / JS folder you open in any browser) to a location you
+  pick — the wizard offers a "Select web operator console
+  location" page after the Tasks step, defaulting to
+  `%USERPROFILE%\Documents\GopherTrunk Web Console`. Untick the
+  "Install the web operator console" checkbox on the Tasks page
+  to skip it (e.g. for a headless server install). Setup +
+  quick-start guide for the console: **[Web console]({{ '/web.html' | relative_url }})**.
 - Optionally adds `C:\Program Files\GopherTrunk` to your system
   PATH so you can run `gophertrunk` from any PowerShell window
   (off by default — tick the "Add GopherTrunk to my PATH"
   checkbox during install if you want it).
 
-When the wizard finishes, it'll offer to open this document and a
-console window. Both are harmless to skip.
+When the wizard finishes, it'll offer to open this document, a
+console window, and (if you installed the web console) the
+console itself in your default browser. All three are harmless
+to skip.
 
 ## 3. Install the WinUSB driver via Zadig (one-time, for each dongle)
 

--- a/installer/windows/gophertrunk.iss
+++ b/installer/windows/gophertrunk.iss
@@ -45,6 +45,8 @@ Name: "english"; MessagesFile: "compiler:Default.isl"
 [Tasks]
 Name: "addtopath"; Description: "Add GopherTrunk to my PATH (so I can run ""gophertrunk"" from any terminal)"; GroupDescription: "PATH"; Flags: unchecked
 Name: "desktopicon"; Description: "Create a &desktop shortcut"; GroupDescription: "Additional shortcuts:"; Flags: unchecked
+Name: "webui"; Description: "Install the &web operator console (a static HTML / JS folder you open in any browser)"; GroupDescription: "Web operator console:"
+Name: "webui\desktopicon"; Description: "Create a desktop shortcut for the web console"; GroupDescription: "Web operator console:"; Flags: unchecked
 
 [Files]
 Source: "..\..\dist\staging\gophertrunk.exe";  DestDir: "{app}"; Flags: ignoreversion
@@ -52,6 +54,13 @@ Source: "..\..\dist\staging\config.example.yaml"; DestDir: "{app}"; Flags: ignor
 Source: "..\..\dist\staging\README.md";        DestDir: "{app}"; Flags: ignoreversion
 Source: "..\..\dist\staging\LICENSE";          DestDir: "{app}"; Flags: ignoreversion
 Source: "..\..\dist\staging\INSTALL-WINDOWS.md"; DestDir: "{app}"; Flags: ignoreversion
+; The web console is a standalone static folder — index.html plus the
+; bundled JS/CSS/manifest. The user picks the destination on the
+; custom WebUIPage below; {code:WebUIDir} resolves to that choice.
+Source: "..\..\dist\staging\gophertrunk-web\*"; \
+  DestDir: "{code:WebUIDir}"; \
+  Flags: ignoreversion recursesubdirs createallsubdirs; \
+  Tasks: webui
 
 [Icons]
 Name: "{group}\GopherTrunk (PowerShell)"; Filename: "{cmd}"; \
@@ -70,6 +79,17 @@ Name: "{autodesktop}\GopherTrunk"; Filename: "{cmd}"; \
   Parameters: "/k cd /d ""{app}"" && gophertrunk help"; \
   WorkingDir: "{app}"; \
   Tasks: desktopicon
+; Web operator console shortcuts. shellexec opens the file in the
+; user's default browser; the entry resolves to whatever path the
+; user picked on the WebUIPage.
+Name: "{group}\Web operator console"; \
+  Filename: "{code:WebUIDir}\index.html"; \
+  Comment: "Open the GopherTrunk web operator console in your default browser"; \
+  Tasks: webui
+Name: "{autodesktop}\GopherTrunk Web Console"; \
+  Filename: "{code:WebUIDir}\index.html"; \
+  Comment: "Open the GopherTrunk web operator console in your default browser"; \
+  Tasks: webui\desktopicon
 
 [Registry]
 ; Append the install dir to the system PATH if the user opted in. Inno
@@ -89,8 +109,52 @@ Filename: "{cmd}"; \
   Parameters: "/k cd /d ""{app}"" && gophertrunk help"; \
   Description: "Open a console window in the install dir"; \
   Flags: postinstall skipifsilent unchecked
+Filename: "{code:WebUIDir}\index.html"; \
+  Description: "Open the web operator console now"; \
+  Flags: postinstall shellexec skipifsilent; \
+  Tasks: webui
 
 [Code]
+var
+  WebUIPage: TInputDirWizardPage;
+
+procedure InitializeWizard;
+begin
+  // CreateInputDirPage gives us a "pick a folder" wizard step with a
+  // Browse button. Placed AFTER wpSelectTasks so we know whether the
+  // user actually wants the web console — ShouldSkipPage hides the
+  // page entirely when the task is unchecked.
+  WebUIPage := CreateInputDirPage(
+    wpSelectTasks,
+    'Select web operator console location',
+    'Where should Setup put the GopherTrunk web console?',
+    'Pick a folder for the standalone web UI. Setup will copy a ' +
+    'gophertrunk-web folder there containing an index.html you open ' +
+    'in any browser. The default is your Documents folder so it''s ' +
+    'easy to find later; you can choose anywhere — a USB stick, a ' +
+    'network drive, or your desktop. Use Browse to pick a different ' +
+    'folder.',
+    False, '');
+  WebUIPage.Add('Web console folder:');
+  WebUIPage.Values[0] :=
+    ExpandConstant('{userdocs}\GopherTrunk Web Console');
+end;
+
+function ShouldSkipPage(PageID: Integer): Boolean;
+begin
+  Result := False;
+  // Skip the web-UI directory page when the user unchecked the
+  // "Install the web operator console" task.
+  if PageID = WebUIPage.ID then begin
+    Result := not WizardIsTaskSelected('webui');
+  end;
+end;
+
+function WebUIDir(Param: string): string;
+begin
+  Result := WebUIPage.Values[0];
+end;
+
 function NeedsAddPath(Param: string): boolean;
 var
   OrigPath: string;


### PR DESCRIPTION
## Summary

Fixes the reported bug: every prior release shipped only the daemon binary — the web operator console added in #228–#231 was never bundled into release artefacts, so an end user who downloaded the Windows installer (or any other archive) got no web UI. This wires the SPA through every release path and, on Windows, asks the user where to install it.

### Release workflow (`.github/workflows/release.yml`)

- Every platform job (Windows amd64, Windows arm64, Linux amd64/arm64, macOS amd64/arm64) now runs `setup-node@v4` + `npm ci && npm run build` inside `web/` before assembling artefacts.
- The resulting `web/dist/` is copied into each archive as a top-level `gophertrunk-web/` directory:
  - Windows amd64 staging dir → consumed by both the portable zip and the Inno Setup installer
  - Windows arm64 zip
  - Linux + macOS tarballs
- Release notes body gains a **Web operator console** callout; the Windows install paragraph now mentions the new wizard prompt.

### Inno Setup script (`installer/windows/gophertrunk.iss`)

- New **`webui` task** (checked by default): _"Install the web operator console (a static HTML / JS folder you open in any browser)"_. Uncheck it to skip the SPA entirely on headless boxes.
- New **`webui\desktopicon`** child task (unchecked by default): create a Desktop shortcut for the SPA. Auto-disabled when `webui` is.
- New **custom wizard page** (`TInputDirWizardPage`, placed after `wpSelectTasks`): _"Select web operator console location"_ with a Browse button. Default `%USERPROFILE%\Documents\GopherTrunk Web Console`.
- `ShouldSkipPage` hides the directory page when `webui` is unchecked so headless installs don't see an irrelevant prompt.
- `[Files]` entry recursively copies the staged `gophertrunk-web/` to the user's chosen directory.
- `[Icons]` entries — Start Menu shortcut opens `index.html` via the user's default browser (`shellexec`); matching optional desktop shortcut.
- `[Run]` entry: _"Open the web operator console now"_ appears on the Finish page when the task was selected.

### Per-PR installer-validation workflow (`.github/workflows/installer.yml`)

- Same `setup-node` + npm-build + stage step so PRs that touch the SPA or installer surface still produce a working `.exe`. The existing `paths-ignore` already covers markdown-only changes, so docs-only edits don't incur the new ~30 s npm cost.

### Docs

- `docs/install-windows.md` — new wizard step documented, plus the Tasks-page checkbox to skip it.
- `docs/downloads.md` — Windows quick-start paragraph mentions the wizard prompt.

> Note: `docs/web.md` (from PR #232, not yet merged) will get a matching note once that lands.

## Test plan

- [ ] Push a `vX.Y.Z-rc` tag (or trigger `workflow_dispatch` on the release workflow) and verify every produced archive contains `gophertrunk-web/index.html`.
- [ ] Download the resulting Windows `.exe` and confirm:
  - [ ] The Tasks page shows the "Install the web operator console" checkbox (and its child desktop-shortcut option).
  - [ ] When checked, a new wizard page asks for a folder with a Browse button; default is `Documents\GopherTrunk Web Console`.
  - [ ] After install, the chosen folder contains the SPA and a Start Menu shortcut opens `index.html` in the default browser.
  - [ ] When unchecked, no wizard page appears, no folder is written, no shortcuts are created.
- [ ] Sanity-check the Linux/macOS tarballs include `gophertrunk-web/` at the top level.
- [ ] PR-trigger the `installer.yml` workflow on this branch — it should produce a working `.exe` with all the changes above.

https://claude.ai/code/session_016bvS5NUb52afQ1bP95KALs

---
_Generated by [Claude Code](https://claude.ai/code/session_016bvS5NUb52afQ1bP95KALs)_