### PR TITLE
sdr list --probe + wizard / installer Windows polish

### DIFF
--- a/cmd/gophertrunk/config_wizard.go
+++ b/cmd/gophertrunk/config_wizard.go
@@ -1017,15 +1017,24 @@ func expandWindowsEnv(p string) string {
 }
 
 // defaultConfigPath picks a sensible default location for the
-// generated config.yaml. Returns "./config.yaml" when the current
-// working directory is writable; otherwise falls back to
-// <os.UserConfigDir()>/GopherTrunk/config.yaml.
+// generated config.yaml. Precedence:
+//   1. $GOPHERTRUNK_CONFIG (the Windows installer sets this to
+//      the operator's chosen editable-files directory; honouring
+//      it here means the wizard writes to the same file the
+//      daemon will later discover).
+//   2. ./config.yaml when the current working directory is writable.
+//   3. <os.UserConfigDir()>/GopherTrunk/config.yaml as the final
+//      fallback (~%APPDATA% on Windows, ~/.config on Linux).
 //
 // Windows operators frequently launch the installed binary from
 // C:\Program Files\GopherTrunk\, which is read-only for non-Admin
 // users — defaulting to ./config.yaml there guarantees a write
-// error on the final review screen. The probe sidesteps that.
+// error on the final review screen. The cwd writability probe and
+// the env-var lookup both sidestep that.
 func defaultConfigPath() string {
+	if p := os.Getenv("GOPHERTRUNK_CONFIG"); p != "" {
+		return p
+	}
 	if cwdWritable() {
 		return "./config.yaml"
 	}

--- a/cmd/gophertrunk/main.go
+++ b/cmd/gophertrunk/main.go
@@ -79,6 +79,18 @@ func runDaemon(args []string) {
 	logFormat := fs.String("log-format", "", "override log format (text|json)")
 	_ = fs.Parse(args)
 
+	// No -config passed: walk the standard discovery precedence
+	// ($GOPHERTRUNK_CONFIG → UserConfigDir → Documents → cwd) so
+	// the Windows installer's chosen path (and equivalent setups
+	// on other platforms) is picked up automatically. Empty result
+	// means "use built-in defaults" — Load handles that case.
+	if *cfgPath == "" {
+		if discovered := config.Discover(); discovered != "" {
+			fmt.Fprintf(os.Stderr, "config: loaded %s\n", discovered)
+			*cfgPath = discovered
+		}
+	}
+
 	cfg, err := config.Load(*cfgPath)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "config: %v\n", err)

--- a/cmd/gophertrunk/main.go
+++ b/cmd/gophertrunk/main.go
@@ -1,11 +1,15 @@
 package main
 
 import (
+	"bufio"
 	"context"
 	"flag"
 	"fmt"
 	"os"
 	"os/signal"
+	"path/filepath"
+	"strconv"
+	"strings"
 	"syscall"
 
 	"github.com/MattCheramie/GopherTrunk/internal/config"
@@ -82,10 +86,17 @@ func runDaemon(args []string) {
 	// No -config passed: walk the standard discovery precedence
 	// ($GOPHERTRUNK_CONFIG → UserConfigDir → Documents → cwd) so
 	// the Windows installer's chosen path (and equivalent setups
-	// on other platforms) is picked up automatically. Empty result
-	// means "use built-in defaults" — Load handles that case.
+	// on other platforms) is picked up automatically. When the
+	// chosen directory holds more than one *.yaml / *.yml the
+	// picker prompts the operator on stdin. Empty result means
+	// "use built-in defaults" — Load handles that case.
 	if *cfgPath == "" {
-		if discovered := config.Discover(); discovered != "" {
+		discovered, err := config.DiscoverWith(config.DiscoverOptions{Pick: pickConfigInteractive})
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "config: %v\n", err)
+			os.Exit(2)
+		}
+		if discovered != "" {
 			fmt.Fprintf(os.Stderr, "config: loaded %s\n", discovered)
 			*cfgPath = discovered
 		}
@@ -201,4 +212,53 @@ func truncate(s string, n int) string {
 		return s
 	}
 	return s[:n]
+}
+
+// pickConfigInteractive is the DiscoverOptions.Pick callback for
+// runDaemon. When stdin is a terminal, it prints a numbered list of
+// the candidate configs and reads the operator's choice. When stdin
+// isn't a terminal (Windows service, systemd unit, CI), it falls
+// back to the first match with a stderr warning so the daemon can
+// still start unattended — the operator can pin a specific file
+// later via -config or GOPHERTRUNK_CONFIG.
+func pickConfigInteractive(paths []string) (string, error) {
+	if !stdinIsTerminal() {
+		fmt.Fprintf(os.Stderr,
+			"config: multiple config files in %s, defaulting to %s (set -config or GOPHERTRUNK_CONFIG to pick a specific one)\n",
+			filepath.Dir(paths[0]), paths[0])
+		return paths[0], nil
+	}
+	fmt.Fprintf(os.Stderr, "Multiple config files found in %s:\n", filepath.Dir(paths[0]))
+	for i, p := range paths {
+		fmt.Fprintf(os.Stderr, "  [%d] %s\n", i+1, filepath.Base(p))
+	}
+	fmt.Fprintf(os.Stderr, "Pick one [1-%d, default 1]: ", len(paths))
+
+	line, err := bufio.NewReader(os.Stdin).ReadString('\n')
+	if err != nil {
+		// EOF on stdin (closed pipe, Ctrl+D) — same fallback as
+		// the non-TTY branch: keep the daemon startable.
+		fmt.Fprintln(os.Stderr)
+		return paths[0], nil
+	}
+	line = strings.TrimSpace(line)
+	if line == "" {
+		return paths[0], nil
+	}
+	idx, perr := strconv.Atoi(line)
+	if perr != nil || idx < 1 || idx > len(paths) {
+		return "", fmt.Errorf("invalid config selection %q (want 1..%d)", line, len(paths))
+	}
+	return paths[idx-1], nil
+}
+
+// stdinIsTerminal returns true when stdin is attached to a character
+// device (i.e. an interactive terminal). False for pipes, redirected
+// input, service runners, and detached background processes.
+func stdinIsTerminal() bool {
+	stat, err := os.Stdin.Stat()
+	if err != nil {
+		return false
+	}
+	return (stat.Mode() & os.ModeCharDevice) != 0
 }

--- a/docs/install-windows.md
+++ b/docs/install-windows.md
@@ -108,25 +108,31 @@ cd "C:\Program Files\GopherTrunk"
 
 ## 5. Configure and start the daemon
 
-The installer drops a starter config at:
+The installer asked you for an "editable files folder" (default
+`Documents\GopherTrunk`) and seeded a `config.yaml` there. It also
+set the `GOPHERTRUNK_CONFIG` user environment variable to point at
+that file, so the daemon discovers it automatically — no `-config`
+flag needed. Use the Start Menu shortcut "Edit my config.yaml
+(Notepad)" to open it, set your device serial + control-channel
+frequencies, and save.
 
-```
-C:\Program Files\GopherTrunk\config.example.yaml
-```
-
-Copy it somewhere writable — your home directory is fine — and
-edit the device serial + control-channel frequencies:
-
-```powershell
-cp "C:\Program Files\GopherTrunk\config.example.yaml" "$HOME\gophertrunk.yaml"
-notepad "$HOME\gophertrunk.yaml"
-```
-
-Then run the daemon against it:
+Then start the daemon:
 
 ```powershell
-gophertrunk run -config "$HOME\gophertrunk.yaml"
+gophertrunk run
 ```
+
+The daemon prints `config: loaded <path>` on startup so you can
+confirm it picked up the right file. To override (e.g. running
+against a second config for testing), use `-config`:
+
+```powershell
+gophertrunk run -config "C:\path\to\other.yaml"
+```
+
+A read-only reference copy of the full annotated template lives at
+`C:\Program Files\GopherTrunk\config.example.yaml` (Start Menu →
+"Configuration template").
 
 Logs stream to the terminal. Press `Ctrl+C` to stop cleanly.
 

--- a/docs/install-windows.md
+++ b/docs/install-windows.md
@@ -130,6 +130,14 @@ against a second config for testing), use `-config`:
 gophertrunk run -config "C:\path\to\other.yaml"
 ```
 
+If you drop multiple `*.yaml` files into the editable-files folder
+(e.g. `config.yaml` + `prod.yaml` + `test.yaml`), the daemon prints
+a numbered menu on startup and asks which one to load. Pick the
+number, press Enter, and that file is used. Set `-config` or
+`GOPHERTRUNK_CONFIG` to skip the prompt for unattended runs (a
+non-interactive launch — Windows service, scheduled task —
+auto-selects the first file and logs the choice).
+
 A read-only reference copy of the full annotated template lives at
 `C:\Program Files\GopherTrunk\config.example.yaml` (Start Menu →
 "Configuration template").

--- a/installer/windows/gophertrunk.iss
+++ b/installer/windows/gophertrunk.iss
@@ -54,6 +54,15 @@ Source: "..\..\dist\staging\config.example.yaml"; DestDir: "{app}"; Flags: ignor
 Source: "..\..\dist\staging\README.md";        DestDir: "{app}"; Flags: ignoreversion
 Source: "..\..\dist\staging\LICENSE";          DestDir: "{app}"; Flags: ignoreversion
 Source: "..\..\dist\staging\INSTALL-WINDOWS.md"; DestDir: "{app}"; Flags: ignoreversion
+; Seed the operator's chosen editable-files folder with a starter
+; config.yaml the first time they install. onlyifdoesntexist
+; preserves any edits across re-installs; uninsneveruninstall
+; leaves the file behind on uninstall so the operator doesn't lose
+; the config (and any per-system trunking data alongside it).
+Source: "..\..\dist\staging\config.example.yaml"; \
+  DestDir: "{code:ConfigDir}"; \
+  DestName: "config.yaml"; \
+  Flags: onlyifdoesntexist uninsneveruninstall
 ; The web console is a standalone static folder — index.html plus the
 ; bundled JS/CSS/manifest. The user picks the destination on the
 ; custom WebUIPage below; {code:WebUIDir} resolves to that choice.
@@ -67,7 +76,11 @@ Name: "{group}\GopherTrunk (PowerShell)"; Filename: "{cmd}"; \
   Parameters: "/k cd /d ""{app}"" && gophertrunk help"; \
   WorkingDir: "{app}"; \
   Comment: "Open a console with GopherTrunk on PATH"
-Name: "{group}\Configuration template (open in Notepad)"; \
+Name: "{group}\Edit my config.yaml (Notepad)"; \
+  Filename: "notepad.exe"; \
+  Parameters: """{code:ConfigDir}\config.yaml"""; \
+  Comment: "Open the config file the daemon will load on startup"
+Name: "{group}\Configuration template (read-only reference)"; \
   Filename: "notepad.exe"; \
   Parameters: """{app}\config.example.yaml"""
 Name: "{group}\Windows install instructions"; \
@@ -100,6 +113,17 @@ Root: HKLM; Subkey: "SYSTEM\CurrentControlSet\Control\Session Manager\Environmen
   ValueData: "{olddata};{app}"; \
   Check: NeedsAddPath('{app}'); \
   Tasks: addtopath
+; Per-user env var pointing at the operator's chosen config.yaml.
+; The daemon's internal/config.Discover() reads this first when no
+; -config flag is passed, so launching the daemon from any shell
+; "just works". ChangesEnvironment=yes (above) triggers Inno's
+; WM_SETTINGCHANGE broadcast so newly-opened shells see the value.
+; uninsdeletevalue cleans the variable up if the operator
+; uninstalls, even though the config.yaml file itself is preserved.
+Root: HKCU; Subkey: "Environment"; \
+  ValueType: expandsz; ValueName: "GOPHERTRUNK_CONFIG"; \
+  ValueData: "{code:ConfigDir}\config.yaml"; \
+  Flags: uninsdeletevalue
 
 [Run]
 Filename: "{app}\INSTALL-WINDOWS.md"; \
@@ -116,16 +140,41 @@ Filename: "{code:WebUIDir}\index.html"; \
 
 [Code]
 var
-  WebUIPage: TInputDirWizardPage;
+  ConfigPage: TInputDirWizardPage;
+  WebUIPage:  TInputDirWizardPage;
 
 procedure InitializeWizard;
 begin
-  // CreateInputDirPage gives us a "pick a folder" wizard step with a
-  // Browse button. Placed AFTER wpSelectTasks so we know whether the
-  // user actually wants the web console — ShouldSkipPage hides the
-  // page entirely when the task is unchecked.
-  WebUIPage := CreateInputDirPage(
+  // Editable-files folder: where the operator's config.yaml (and
+  // any per-system data that lands next to it) lives. We default
+  // to Documents\GopherTrunk because it's the spot non-Admin
+  // Windows users can always write to without surprises — and the
+  // [Files] step seeds a starter config.yaml there. The path is
+  // also written to HKCU\Environment\GOPHERTRUNK_CONFIG so the
+  // daemon discovers it without needing -config on the command
+  // line. Placed first so the operator sees the most important
+  // path choice before anything else.
+  ConfigPage := CreateInputDirPage(
     wpSelectTasks,
+    'Select your editable-files folder',
+    'Where should your config.yaml and per-system data live?',
+    'Pick a folder Setup can drop a starter config.yaml in. The ' +
+    'GopherTrunk daemon will look for config.yaml in this folder ' +
+    'automatically — no -config flag needed. The default is your ' +
+    'Documents folder so it''s easy to find and back up; you can ' +
+    'choose anywhere you can write to. If a config.yaml already ' +
+    'exists in the folder it will NOT be overwritten.',
+    False, '');
+  ConfigPage.Add('Editable files folder:');
+  ConfigPage.Values[0] :=
+    ExpandConstant('{userdocs}\GopherTrunk');
+
+  // CreateInputDirPage gives us a "pick a folder" wizard step with a
+  // Browse button. Placed AFTER ConfigPage so the page order matches
+  // the order of importance — config first, web UI second. ShouldSkipPage
+  // hides this one entirely when the webui task is unchecked.
+  WebUIPage := CreateInputDirPage(
+    ConfigPage.ID,
     'Select web operator console location',
     'Where should Setup put the GopherTrunk web console?',
     'Pick a folder for the standalone web UI. Setup will copy a ' +
@@ -148,6 +197,11 @@ begin
   if PageID = WebUIPage.ID then begin
     Result := not WizardIsTaskSelected('webui');
   end;
+end;
+
+function ConfigDir(Param: string): string;
+begin
+  Result := ConfigPage.Values[0];
 end;
 
 function WebUIDir(Param: string): string;

--- a/internal/config/discover.go
+++ b/internal/config/discover.go
@@ -1,0 +1,52 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// Discover walks the standard config-file search precedence and
+// returns the first path that exists, or "" if none does. Used by
+// the daemon when `gophertrunk run` is launched without an explicit
+// -config flag.
+//
+// Precedence:
+//  1. $GOPHERTRUNK_CONFIG (env var; used verbatim, no existence check
+//     — operators set this deliberately so a missing file should
+//     surface as a clear Load error, not a silent fallback).
+//  2. <os.UserConfigDir()>/GopherTrunk/config.yaml
+//     (%APPDATA%\GopherTrunk on Windows, ~/.config/GopherTrunk on
+//     Linux, ~/Library/Application Support/GopherTrunk on macOS).
+//  3. <UserHomeDir>/Documents/GopherTrunk/config.yaml
+//     (the Windows installer's suggested default — operators who
+//     accept that default get the daemon to find it without any
+//     extra flag wiring).
+//  4. ./config.yaml (cwd; legacy / dev convenience).
+//
+// An empty return is the loader's contract for "use defaults".
+func Discover() string {
+	if p := os.Getenv("GOPHERTRUNK_CONFIG"); p != "" {
+		return p
+	}
+	for _, c := range discoverCandidates() {
+		if _, err := os.Stat(c); err == nil {
+			return c
+		}
+	}
+	return ""
+}
+
+// discoverCandidates returns the on-disk paths Discover will stat
+// in order. Factored out so tests can assert the search order
+// without touching the filesystem.
+func discoverCandidates() []string {
+	var out []string
+	if dir, err := os.UserConfigDir(); err == nil {
+		out = append(out, filepath.Join(dir, "GopherTrunk", "config.yaml"))
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		out = append(out, filepath.Join(home, "Documents", "GopherTrunk", "config.yaml"))
+	}
+	out = append(out, "config.yaml")
+	return out
+}

--- a/internal/config/discover.go
+++ b/internal/config/discover.go
@@ -3,50 +3,97 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"sort"
 )
 
-// Discover walks the standard config-file search precedence and
-// returns the first path that exists, or "" if none does. Used by
-// the daemon when `gophertrunk run` is launched without an explicit
-// -config flag.
-//
-// Precedence:
-//  1. $GOPHERTRUNK_CONFIG (env var; used verbatim, no existence check
-//     — operators set this deliberately so a missing file should
-//     surface as a clear Load error, not a silent fallback).
-//  2. <os.UserConfigDir()>/GopherTrunk/config.yaml
-//     (%APPDATA%\GopherTrunk on Windows, ~/.config/GopherTrunk on
-//     Linux, ~/Library/Application Support/GopherTrunk on macOS).
-//  3. <UserHomeDir>/Documents/GopherTrunk/config.yaml
-//     (the Windows installer's suggested default — operators who
-//     accept that default get the daemon to find it without any
-//     extra flag wiring).
-//  4. ./config.yaml (cwd; legacy / dev convenience).
-//
-// An empty return is the loader's contract for "use defaults".
-func Discover() string {
-	if p := os.Getenv("GOPHERTRUNK_CONFIG"); p != "" {
-		return p
-	}
-	for _, c := range discoverCandidates() {
-		if _, err := os.Stat(c); err == nil {
-			return c
-		}
-	}
-	return ""
+// DiscoverOptions tunes DiscoverWith. Pick is invoked when the
+// chosen candidate directory contains more than one config file so
+// the caller (typically the CLI) can prompt the operator. Pick
+// always receives at least two paths; when nil, the first lexical
+// match wins silently.
+type DiscoverOptions struct {
+	Pick func(paths []string) (string, error)
 }
 
-// discoverCandidates returns the on-disk paths Discover will stat
-// in order. Factored out so tests can assert the search order
+// Discover finds the daemon's config file using the standard
+// precedence and returns it (or "" when none exists). Equivalent to
+// DiscoverWith(DiscoverOptions{}): when multiple files share a
+// directory, the first lexical match wins. Callers that want to
+// prompt the operator should use DiscoverWith.
+func Discover() string {
+	p, _ := DiscoverWith(DiscoverOptions{})
+	return p
+}
+
+// DiscoverWith walks the standard precedence and returns the
+// resolved config path (or "" when none exists). Steps:
+//
+//  1. $GOPHERTRUNK_CONFIG — used verbatim, no existence check (an
+//     operator who sets the var should see a clear Load error if
+//     the file is missing, not a silent fallback to a different
+//     config).
+//  2. The first candidate directory containing one or more
+//     *.yaml / *.yml files. Within that directory:
+//       - 1 file → use it.
+//       - 2+ files → call opts.Pick; if nil, take the first.
+//
+// Candidate directories (in order):
+//   - <os.UserConfigDir()>/GopherTrunk
+//     (%APPDATA%\GopherTrunk on Windows, ~/.config/GopherTrunk on
+//     Linux, ~/Library/Application Support/GopherTrunk on macOS).
+//   - <UserHomeDir>/Documents/GopherTrunk
+//     (the Windows installer's default — operators who accept it
+//     get auto-discovery without setting any env var).
+//   - the current working directory.
+//
+// Pick returning an error aborts discovery; the caller should
+// surface the error rather than fall back to a default.
+func DiscoverWith(opts DiscoverOptions) (string, error) {
+	if p := os.Getenv("GOPHERTRUNK_CONFIG"); p != "" {
+		return p, nil
+	}
+	for _, dir := range candidateDirs() {
+		matches := dirConfigFiles(dir)
+		switch {
+		case len(matches) == 0:
+			continue
+		case len(matches) == 1:
+			return matches[0], nil
+		case opts.Pick != nil:
+			return opts.Pick(matches)
+		default:
+			return matches[0], nil
+		}
+	}
+	return "", nil
+}
+
+// candidateDirs returns the directories DiscoverWith will scan, in
+// precedence order. Factored out so tests can assert the order
 // without touching the filesystem.
-func discoverCandidates() []string {
+func candidateDirs() []string {
 	var out []string
 	if dir, err := os.UserConfigDir(); err == nil {
-		out = append(out, filepath.Join(dir, "GopherTrunk", "config.yaml"))
+		out = append(out, filepath.Join(dir, "GopherTrunk"))
 	}
 	if home, err := os.UserHomeDir(); err == nil {
-		out = append(out, filepath.Join(home, "Documents", "GopherTrunk", "config.yaml"))
+		out = append(out, filepath.Join(home, "Documents", "GopherTrunk"))
 	}
-	out = append(out, "config.yaml")
+	out = append(out, ".")
+	return out
+}
+
+// dirConfigFiles returns the *.yaml + *.yml files in dir, sorted
+// lexically. An unreadable / missing dir yields an empty slice so
+// the caller can keep walking the precedence list.
+func dirConfigFiles(dir string) []string {
+	var out []string
+	for _, pattern := range []string{"*.yaml", "*.yml"} {
+		m, err := filepath.Glob(filepath.Join(dir, pattern))
+		if err == nil {
+			out = append(out, m...)
+		}
+	}
+	sort.Strings(out)
 	return out
 }

--- a/internal/config/discover_test.go
+++ b/internal/config/discover_test.go
@@ -1,0 +1,81 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestDiscover_EnvVarWins covers the highest-precedence branch:
+// GOPHERTRUNK_CONFIG is returned verbatim, even if the referenced
+// file doesn't exist yet (Load surfaces the missing-file error to
+// the operator).
+func TestDiscover_EnvVarWins(t *testing.T) {
+	t.Setenv("GOPHERTRUNK_CONFIG", "/no/such/path/config.yaml")
+	if got := Discover(); got != "/no/such/path/config.yaml" {
+		t.Errorf("Discover() = %q, want verbatim env-var value", got)
+	}
+}
+
+// TestDiscover_StatFallback creates a real file at the UserConfigDir
+// candidate, then asserts Discover picks it up when the env var is
+// unset. Uses t.Setenv on the platform-appropriate var that
+// os.UserConfigDir() consults so the test doesn't depend on the host's
+// real config dir.
+func TestDiscover_StatFallback(t *testing.T) {
+	t.Setenv("GOPHERTRUNK_CONFIG", "")
+	dir := t.TempDir()
+
+	// Redirect os.UserConfigDir() to the tempdir. On Linux it reads
+	// XDG_CONFIG_HOME; on macOS HOME; on Windows APPDATA. Setting all
+	// three is harmless and keeps the test cross-platform.
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("APPDATA", dir)
+	t.Setenv("HOME", dir) // macOS UserConfigDir = $HOME/Library/Application Support
+
+	want := filepath.Join(dir, "GopherTrunk", "config.yaml")
+	// macOS path differs; compute it dynamically rather than guessing.
+	if cd, err := os.UserConfigDir(); err == nil {
+		want = filepath.Join(cd, "GopherTrunk", "config.yaml")
+	}
+	if err := os.MkdirAll(filepath.Dir(want), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(want, []byte("log:\n"), 0o644); err != nil {
+		t.Fatalf("write seed config: %v", err)
+	}
+
+	if got := Discover(); got != want {
+		t.Errorf("Discover() = %q, want %q", got, want)
+	}
+}
+
+// TestDiscover_NothingFound returns empty when no candidate exists
+// and the env var isn't set — Load interprets "" as "use defaults".
+func TestDiscover_NothingFound(t *testing.T) {
+	t.Setenv("GOPHERTRUNK_CONFIG", "")
+	// Point every UserConfigDir / UserHomeDir source at an empty
+	// tempdir so the stat loop finds nothing. cwd "./config.yaml"
+	// still gets checked, so we also chdir into the empty dir.
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("APPDATA", dir)
+	t.Setenv("HOME", dir)
+	t.Chdir(dir)
+
+	if got := Discover(); got != "" {
+		t.Errorf("Discover() = %q, want empty (no candidates exist)", got)
+	}
+}
+
+// TestDiscoverCandidates_OrderIncludesCwdLast pins the precedence the
+// installer + docs rely on: UserConfigDir, then Documents, then cwd.
+func TestDiscoverCandidates_OrderIncludesCwdLast(t *testing.T) {
+	got := discoverCandidates()
+	if len(got) == 0 {
+		t.Fatalf("discoverCandidates() returned no entries")
+	}
+	if got[len(got)-1] != "config.yaml" {
+		t.Errorf("last candidate = %q, want %q (cwd entry must be last)", got[len(got)-1], "config.yaml")
+	}
+}

--- a/internal/config/discover_test.go
+++ b/internal/config/discover_test.go
@@ -1,52 +1,133 @@
 package config
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 )
 
 // TestDiscover_EnvVarWins covers the highest-precedence branch:
 // GOPHERTRUNK_CONFIG is returned verbatim, even if the referenced
 // file doesn't exist yet (Load surfaces the missing-file error to
-// the operator).
+// the operator). Pick must NOT be called when the env var is set.
 func TestDiscover_EnvVarWins(t *testing.T) {
 	t.Setenv("GOPHERTRUNK_CONFIG", "/no/such/path/config.yaml")
-	if got := Discover(); got != "/no/such/path/config.yaml" {
+	called := false
+	got, err := DiscoverWith(DiscoverOptions{
+		Pick: func(paths []string) (string, error) {
+			called = true
+			return "", errors.New("should not be called")
+		},
+	})
+	if err != nil {
+		t.Fatalf("DiscoverWith: %v", err)
+	}
+	if got != "/no/such/path/config.yaml" {
 		t.Errorf("Discover() = %q, want verbatim env-var value", got)
+	}
+	if called {
+		t.Errorf("Pick was invoked despite GOPHERTRUNK_CONFIG being set")
 	}
 }
 
-// TestDiscover_StatFallback creates a real file at the UserConfigDir
-// candidate, then asserts Discover picks it up when the env var is
-// unset. Uses t.Setenv on the platform-appropriate var that
-// os.UserConfigDir() consults so the test doesn't depend on the host's
-// real config dir.
-func TestDiscover_StatFallback(t *testing.T) {
+// TestDiscover_SingleFile creates one config in the first candidate
+// directory and asserts it's returned without Pick being called.
+func TestDiscover_SingleFile(t *testing.T) {
 	t.Setenv("GOPHERTRUNK_CONFIG", "")
-	dir := t.TempDir()
+	dir := redirectUserDirs(t)
+	cfgDir, _ := os.UserConfigDir()
+	target := filepath.Join(cfgDir, "GopherTrunk", "config.yaml")
+	mustWrite(t, target, "log:\n")
 
-	// Redirect os.UserConfigDir() to the tempdir. On Linux it reads
-	// XDG_CONFIG_HOME; on macOS HOME; on Windows APPDATA. Setting all
-	// three is harmless and keeps the test cross-platform.
-	t.Setenv("XDG_CONFIG_HOME", dir)
-	t.Setenv("APPDATA", dir)
-	t.Setenv("HOME", dir) // macOS UserConfigDir = $HOME/Library/Application Support
+	called := false
+	got, err := DiscoverWith(DiscoverOptions{
+		Pick: func(paths []string) (string, error) { called = true; return "", nil },
+	})
+	if err != nil {
+		t.Fatalf("DiscoverWith: %v", err)
+	}
+	if got != target {
+		t.Errorf("Discover() = %q, want %q (dir=%s)", got, target, dir)
+	}
+	if called {
+		t.Errorf("Pick called for a single-file directory")
+	}
+}
 
-	want := filepath.Join(dir, "GopherTrunk", "config.yaml")
-	// macOS path differs; compute it dynamically rather than guessing.
-	if cd, err := os.UserConfigDir(); err == nil {
-		want = filepath.Join(cd, "GopherTrunk", "config.yaml")
-	}
-	if err := os.MkdirAll(filepath.Dir(want), 0o755); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
-	if err := os.WriteFile(want, []byte("log:\n"), 0o644); err != nil {
-		t.Fatalf("write seed config: %v", err)
+// TestDiscover_MultipleFiles_CallsPick is the headline test: when
+// two configs share a directory, Pick is called with all matches
+// (sorted) and its return value is what Discover returns.
+func TestDiscover_MultipleFiles_CallsPick(t *testing.T) {
+	t.Setenv("GOPHERTRUNK_CONFIG", "")
+	redirectUserDirs(t)
+	cfgDir, _ := os.UserConfigDir()
+	root := filepath.Join(cfgDir, "GopherTrunk")
+	mustWrite(t, filepath.Join(root, "config.yaml"), "log:\n")
+	mustWrite(t, filepath.Join(root, "prod.yaml"), "log:\n")
+	mustWrite(t, filepath.Join(root, "test.yml"), "log:\n")
+
+	wantPaths := []string{
+		filepath.Join(root, "config.yaml"),
+		filepath.Join(root, "prod.yaml"),
+		filepath.Join(root, "test.yml"),
 	}
 
-	if got := Discover(); got != want {
+	var seen []string
+	got, err := DiscoverWith(DiscoverOptions{
+		Pick: func(paths []string) (string, error) {
+			seen = paths
+			return paths[1], nil // pretend the operator picked "prod.yaml"
+		},
+	})
+	if err != nil {
+		t.Fatalf("DiscoverWith: %v", err)
+	}
+	if !reflect.DeepEqual(seen, wantPaths) {
+		t.Errorf("Pick paths = %v, want %v", seen, wantPaths)
+	}
+	if got != wantPaths[1] {
+		t.Errorf("Discover() = %q, want %q", got, wantPaths[1])
+	}
+}
+
+// TestDiscover_MultipleFiles_NoPick_PicksFirst preserves the
+// existing behaviour of Discover (no Pick) — picks the first match
+// rather than blowing up. Important for tests / non-interactive
+// callers.
+func TestDiscover_MultipleFiles_NoPick_PicksFirst(t *testing.T) {
+	t.Setenv("GOPHERTRUNK_CONFIG", "")
+	redirectUserDirs(t)
+	cfgDir, _ := os.UserConfigDir()
+	root := filepath.Join(cfgDir, "GopherTrunk")
+	mustWrite(t, filepath.Join(root, "config.yaml"), "log:\n")
+	mustWrite(t, filepath.Join(root, "prod.yaml"), "log:\n")
+
+	got := Discover()
+	want := filepath.Join(root, "config.yaml") // lexically first
+	if got != want {
 		t.Errorf("Discover() = %q, want %q", got, want)
+	}
+}
+
+// TestDiscover_PickError_Propagates checks that an interactive
+// picker returning an error (e.g. operator typed an out-of-range
+// number) aborts discovery instead of silently falling through.
+func TestDiscover_PickError_Propagates(t *testing.T) {
+	t.Setenv("GOPHERTRUNK_CONFIG", "")
+	redirectUserDirs(t)
+	cfgDir, _ := os.UserConfigDir()
+	root := filepath.Join(cfgDir, "GopherTrunk")
+	mustWrite(t, filepath.Join(root, "a.yaml"), "log:\n")
+	mustWrite(t, filepath.Join(root, "b.yaml"), "log:\n")
+
+	want := errors.New("invalid selection")
+	_, err := DiscoverWith(DiscoverOptions{
+		Pick: func(paths []string) (string, error) { return "", want },
+	})
+	if !errors.Is(err, want) {
+		t.Errorf("DiscoverWith err = %v, want %v", err, want)
 	}
 }
 
@@ -54,28 +135,46 @@ func TestDiscover_StatFallback(t *testing.T) {
 // and the env var isn't set — Load interprets "" as "use defaults".
 func TestDiscover_NothingFound(t *testing.T) {
 	t.Setenv("GOPHERTRUNK_CONFIG", "")
-	// Point every UserConfigDir / UserHomeDir source at an empty
-	// tempdir so the stat loop finds nothing. cwd "./config.yaml"
-	// still gets checked, so we also chdir into the empty dir.
-	dir := t.TempDir()
-	t.Setenv("XDG_CONFIG_HOME", dir)
-	t.Setenv("APPDATA", dir)
-	t.Setenv("HOME", dir)
-	t.Chdir(dir)
+	redirectUserDirs(t)
+	t.Chdir(t.TempDir())
 
 	if got := Discover(); got != "" {
 		t.Errorf("Discover() = %q, want empty (no candidates exist)", got)
 	}
 }
 
-// TestDiscoverCandidates_OrderIncludesCwdLast pins the precedence the
+// TestCandidateDirs_OrderIncludesCwdLast pins the precedence the
 // installer + docs rely on: UserConfigDir, then Documents, then cwd.
-func TestDiscoverCandidates_OrderIncludesCwdLast(t *testing.T) {
-	got := discoverCandidates()
+func TestCandidateDirs_OrderIncludesCwdLast(t *testing.T) {
+	got := candidateDirs()
 	if len(got) == 0 {
-		t.Fatalf("discoverCandidates() returned no entries")
+		t.Fatalf("candidateDirs() returned no entries")
 	}
-	if got[len(got)-1] != "config.yaml" {
-		t.Errorf("last candidate = %q, want %q (cwd entry must be last)", got[len(got)-1], "config.yaml")
+	if got[len(got)-1] != "." {
+		t.Errorf("last candidate = %q, want %q (cwd entry must be last)", got[len(got)-1], ".")
+	}
+}
+
+// redirectUserDirs points os.UserConfigDir / os.UserHomeDir at a
+// fresh tempdir for the duration of the test, returning the
+// tempdir for path-building. Sets every relevant env var so the
+// test stays cross-platform.
+func redirectUserDirs(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("APPDATA", dir)
+	t.Setenv("HOME", dir)
+	t.Setenv("USERPROFILE", dir)
+	return dir
+}
+
+func mustWrite(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
 	}
 }


### PR DESCRIPTION
## Summary

Fixes a cluster of Windows-first-run papercuts that came out of a single debugging session:

- `gophertrunk sdr list` columns looked like a driver-load failure when they were just blank-by-design.
- The config wizard's "Enable live audio playback" toggle looked stuck because ←/→ didn't work on bool fields.
- The wizard's default write path (`./config.yaml`) failed with "Access is denied" under `C:\Program Files\GopherTrunk\`.
- Typing `%APPDATA%\GopherTrunk\config.yaml` in the wizard succeeded but wrote a file with a literal `%APPDATA%` in its name (no env-var expansion).
- The installer didn't ask where editable files should live, and the daemon had no way to discover the config automatically.
- Operators who keep multiple configs side-by-side could silently load the wrong one.

## Commits

1. **`sdr list --probe` + wizard ←/→ toggles bool** — `sdr list` now accepts `--probe` to open each enumerated device long enough to populate TUNER + gains; ←/→ also toggles bool fields (the footer hint already documented this contract).
2. **Writable default config path** — `defaultConfigPath()` probes cwd; falls back to `<UserConfigDir>/GopherTrunk/config.yaml` when cwd is read-only (Program Files etc.). Review screen suggests a fallback path on permission errors.
3. **Env-var expansion in config path** — `expandConfigPath()` handles `%VAR%`, `$VAR`/`${VAR}`, and leading `~`. `commitReview` resolves + lifts to absolute before write, stops swallowing `MkdirAll` errors, shows "resolves to: \<abs\>" on the review screen.
4. **Installer editable-files folder + auto-discovery** — New Inno Setup wizard page asks where editable files should live (default `%USERDOCS%\GopherTrunk`); installer seeds a starter `config.yaml` there (preserve-on-uninstall), pins `HKCU\Environment\GOPHERTRUNK_CONFIG`, adds a "Edit my config.yaml (Notepad)" Start Menu shortcut. New `config.Discover()` walks `$GOPHERTRUNK_CONFIG` → UserConfigDir → Documents → cwd; `runDaemon` calls it when `-config` is empty.
5. **Multi-config picker** — When the chosen directory holds 2+ `*.yaml`/`*.yml`, `runDaemon` prints a numbered list and reads the operator's choice on stdin. Non-TTY launches (service/CI) auto-pick the first match with a stderr warning so unattended starts don't hang.

## Test plan

- [x] `go test ./...` — all packages green
- [x] New unit tests: `TestExpandConfigPath`, `TestWizard_WritesAfterEnvVarPath`, `TestDiscover_{EnvVarWins, SingleFile, MultipleFiles_CallsPick, MultipleFiles_NoPick_PicksFirst, PickError_Propagates, NothingFound}`, `TestCandidateDirs_OrderIncludesCwdLast`
- [ ] Manual: install on a Windows box, walk the new "editable files folder" page, confirm `config.yaml` is seeded under Documents, confirm `gophertrunk run` (no flag) prints `config: loaded <path>` pointing at that file
- [ ] Manual: drop a second `prod.yaml` next to `config.yaml`, re-run `gophertrunk run`, confirm the numbered picker appears
- [ ] Manual: `gophertrunk sdr list --probe` against an RTL-SDR dongle, confirm TUNER + gains columns are populated

https://claude.ai/code/session_01ECh1b3DWXEXiCjh9hJEsh1

---
_Generated by [Claude Code](https://claude.ai/code/session_01ECh1b3DWXEXiCjh9hJEsh1)_