### PR TITLE
docs: sync install + user guides with PR #237 behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,38 @@ for tagged releases.
 
 ### Added
 
+- **Config auto-discovery.** `gophertrunk run` (no `-config` flag)
+  now walks `$GOPHERTRUNK_CONFIG` → `<UserConfigDir>/GopherTrunk/config.yaml`
+  → `<Home>/Documents/GopherTrunk/config.yaml` → `./config.yaml`
+  and loads the first match, printing `config: loaded <path>` on
+  startup. When the chosen directory holds 2+ `*.yaml`/`*.yml`
+  files, an interactive numbered picker prompts the operator on
+  stdin (non-TTY launches like Windows services / systemd / CI
+  auto-select the first match with a stderr warning instead of
+  hanging). `internal/config.Discover()` + `DiscoverWith(opts)` for
+  programmatic callers.
+- **Windows installer "editable-files folder" page.** The Inno
+  Setup wizard now asks where the operator's `config.yaml` should
+  live (default `Documents\GopherTrunk`), seeds a starter file
+  there (preserved across re-install + uninstall), pins
+  `HKCU\Environment\GOPHERTRUNK_CONFIG` so the daemon finds it
+  without `-config`, and adds a Start Menu shortcut "Edit my
+  config.yaml (Notepad)". See [`install-windows.md`](docs/install-windows.md).
+- **`gophertrunk sdr list --probe`** opens each enumerated device
+  long enough to run the demod + tuner bring-up, populating the
+  TUNER + gains columns. Without the flag those columns stay
+  blank (Enumerate only reads USB descriptors, so the command is
+  fast and never collides with a running daemon).
+- **Config-builder wizard quality-of-life.** `←` / `→` toggles
+  boolean fields (the footer hint already promised this). The
+  path field expands `%VAR%` (Windows), `$VAR` / `${VAR}` (POSIX),
+  and leading `~` at write time; the review screen shows
+  "resolves to: \<abs\>" when expansion changes the path. The
+  default write target now consults `$GOPHERTRUNK_CONFIG` and
+  falls back to `<UserConfigDir>/GopherTrunk/config.yaml` when
+  the current directory isn't writable (fixes "Access is denied"
+  when the binary is launched from `C:\Program Files\GopherTrunk\`).
+  `MkdirAll` errors on commit are surfaced instead of swallowed.
 - `gophertrunk import-pdf` subcommand parses trunking-system data
   from RadioReference.com PDF exports **and** from structured
   multi-section CSV bundles, merging both into the operator's

--- a/docs/downloads.md
+++ b/docs/downloads.md
@@ -85,8 +85,10 @@ tar xzf gophertrunk.tar.gz
 cd gophertrunk-${VERSION}-${PKG}
 cp config.example.yaml config.yaml          # edit before launch
 ./gophertrunk version                       # confirms ldflags landed
-./gophertrunk run -config config.yaml
+./gophertrunk run                           # auto-discovers ./config.yaml
 ```
+
+The daemon walks `$GOPHERTRUNK_CONFIG` → `~/.config/gophertrunk/config.yaml` → `~/Documents/GopherTrunk/config.yaml` → `./config.yaml` and loads the first match — see [`install-linux.md`]({{ '/install-linux.html' | relative_url }}#5-configure-and-start-the-daemon) for the full discovery rules and the multi-config picker.
 
 For a systemd-managed install, copy [`gophertrunk.service`](https://github.com/MattCheramie/GopherTrunk/blob/main/docs/gophertrunk.service) to `/etc/systemd/system/` and follow the install header.
 
@@ -106,7 +108,7 @@ cd gophertrunk-${VERSION}-${PKG}
 xattr -dr com.apple.quarantine gophertrunk  # bypass Gatekeeper (unsigned build)
 cp config.example.yaml config.yaml
 ./gophertrunk version
-./gophertrunk run -config config.yaml
+./gophertrunk run                           # auto-discovers ./config.yaml
 ```
 
 RTL-SDR on macOS uses the bundled IOKit driver — no kext or driver swap required.

--- a/docs/import.md
+++ b/docs/import.md
@@ -262,7 +262,7 @@ gophertrunk import-pdf -wizard -config /etc/gophertrunk/config.yaml
 | `Enter` | Save the current field and advance — to the next field within a step, or to the next step when on the last field. |
 | `Tab` / `Shift+Tab` | Move between fields within a step (without advancing). |
 | `↑` / `↓` | Same as Shift+Tab / Tab. |
-| `←` / `→` | Cycle through values on a choice field (log level, auth mode, scan mode, …). |
+| `←` / `→` | Cycle through values on a choice field (log level, auth mode, scan mode, …) **or** toggle a boolean field. |
 | `y` / `n` / `Space` | Toggle a boolean field. |
 | `Esc` | Back up one step. |
 | `q` / `Ctrl+C` | Abort without writing. |
@@ -271,6 +271,18 @@ The CORS allow-list and SDR-device builder are list editors —
 type a value and press Enter to append, Backspace to pop. The
 review step (final screen) shows a preview of the rendered YAML;
 press Enter to write or Esc to back up and edit.
+
+**Config-file path field:** the welcome step's path accepts shell-
+style env-var references — `%APPDATA%\GopherTrunk\config.yaml`
+(Windows), `$HOME/.config/gophertrunk/config.yaml` (POSIX), and a
+leading `~` for the home dir all expand at write time. The review
+screen shows "resolves to: \<abs\>" beneath the typed path when
+expansion changes it, so you see the actual destination before
+pressing Enter. The default picked when the wizard starts is
+whatever `$GOPHERTRUNK_CONFIG` points at (the Windows installer
+sets this); otherwise `./config.yaml` when the current directory
+is writable, or `<UserConfigDir>/GopherTrunk/config.yaml` when
+it isn't (e.g. launched from `C:\Program Files\GopherTrunk\`).
 
 ## What the importer writes
 

--- a/docs/install-linux.md
+++ b/docs/install-linux.md
@@ -91,9 +91,16 @@ gophertrunk sdr list
 ```
 
 `sdr list` should print one line per attached dongle with its driver,
-index, serial, tuner, product string, and the gain settings the tuner
-exposes. If you see `no SDR devices found` and the dongle is plugged
-in:
+index, serial, product string, and (when populated) tuner + gain
+ladder. The plain command only reads USB descriptors, so the TUNER
+and gains columns stay blank — pass `--probe` to open each device
+just long enough to enumerate them:
+
+```sh
+gophertrunk sdr list --probe
+```
+
+If you see `no SDR devices found` and the dongle is plugged in:
 
 - Check `lsusb` shows the dongle (typically `0bda:2838` for generic
   RTL-SDR Blog units / NESDR Smart v5).
@@ -108,20 +115,28 @@ matrix of supported tuners and dongles.
 
 ## 5. Configure and start the daemon
 
-The tarball includes `config.example.yaml`. Copy it to a writable
-location and edit the device serial + control-channel frequencies:
+The tarball includes `config.example.yaml`. Drop a copy at
+`~/.config/gophertrunk/config.yaml` and edit it — the daemon walks
+`$GOPHERTRUNK_CONFIG` → `~/.config/gophertrunk/config.yaml` →
+`~/Documents/GopherTrunk/config.yaml` → `./config.yaml` and loads the
+first one it finds, so no `-config` flag is needed:
 
 ```sh
 mkdir -p ~/.config/gophertrunk
 cp config.example.yaml ~/.config/gophertrunk/config.yaml
 ${EDITOR:-nano} ~/.config/gophertrunk/config.yaml
+gophertrunk run
 ```
 
-Then run the daemon against it:
+On startup the daemon prints `config: loaded <path>` so you can
+confirm it picked the right file. Override discovery any time with
+`-config <path>` or by exporting `GOPHERTRUNK_CONFIG`.
 
-```sh
-gophertrunk run -config ~/.config/gophertrunk/config.yaml
-```
+If you keep more than one config in that directory (e.g.
+`config.yaml` + `prod.yaml`), `gophertrunk run` prints a numbered
+menu and asks which to load. Non-interactive launches (systemd,
+cron) auto-pick the first match with a stderr warning; pin a
+specific file via `-config` or `GOPHERTRUNK_CONFIG` for those.
 
 Logs stream to the terminal. Press `Ctrl+C` to stop cleanly.
 

--- a/docs/install-macos.md
+++ b/docs/install-macos.md
@@ -80,9 +80,16 @@ gophertrunk sdr list
 ```
 
 `sdr list` should print one line per attached dongle with its driver,
-index, serial, tuner, product string, and the gain settings the tuner
-exposes. If you see `no SDR devices found` and the dongle is plugged
-in:
+index, serial, product string, and (when populated) tuner + gain
+ladder. The plain command only reads USB descriptors, so the TUNER
+and gains columns stay blank — pass `--probe` to open each device
+just long enough to enumerate them:
+
+```sh
+gophertrunk sdr list --probe
+```
+
+If you see `no SDR devices found` and the dongle is plugged in:
 
 - Check `system_profiler SPUSBDataType | grep -A 4 RTL2838` shows the
   dongle (typically `0x0bda:0x2838`).
@@ -96,20 +103,29 @@ matrix of supported tuners and dongles.
 
 ## 5. Configure and start the daemon
 
-The tarball includes `config.example.yaml`. Copy it to a writable
-location and edit the device serial + control-channel frequencies:
+The tarball includes `config.example.yaml`. Drop a copy at
+`~/Library/Application Support/GopherTrunk/config.yaml` and edit
+it — the daemon walks `$GOPHERTRUNK_CONFIG` →
+`~/Library/Application Support/GopherTrunk/config.yaml` →
+`~/Documents/GopherTrunk/config.yaml` → `./config.yaml` and loads
+the first one it finds, so no `-config` flag is needed:
 
 ```sh
-mkdir -p ~/.config/gophertrunk
-cp config.example.yaml ~/.config/gophertrunk/config.yaml
-${EDITOR:-nano} ~/.config/gophertrunk/config.yaml
+mkdir -p ~/Library/Application\ Support/GopherTrunk
+cp config.example.yaml ~/Library/Application\ Support/GopherTrunk/config.yaml
+${EDITOR:-nano} ~/Library/Application\ Support/GopherTrunk/config.yaml
+gophertrunk run
 ```
 
-Then run the daemon against it:
+On startup the daemon prints `config: loaded <path>` so you can
+confirm it picked the right file. Override discovery any time with
+`-config <path>` or by exporting `GOPHERTRUNK_CONFIG`.
 
-```sh
-gophertrunk run -config ~/.config/gophertrunk/config.yaml
-```
+If you keep more than one config in that directory (e.g.
+`config.yaml` + `prod.yaml`), `gophertrunk run` prints a numbered
+menu and asks which to load. Non-interactive launches (launchd,
+cron) auto-pick the first match with a stderr warning; pin a
+specific file via `-config` or `GOPHERTRUNK_CONFIG` for those.
 
 Logs stream to the terminal. Press `Ctrl+C` to stop cleanly.
 

--- a/docs/install-windows.md
+++ b/docs/install-windows.md
@@ -91,12 +91,20 @@ gophertrunk sdr list
 ```
 
 `sdr list` should print one line per attached dongle with its
-driver, index, serial, tuner, product string, and the gain settings
-the tuner exposes. If you see `no SDR devices found` and you're
-sure the dongle is plugged in, the WinUSB driver swap probably
-didn't take — re-run Zadig with **Options → List All Devices**
-checked and verify the "Driver" column shows **WinUSB** for your
-dongle.
+driver, index, serial, and product string. The TUNER and gains
+columns are blank by design — they need the device to be opened
+(USB claim + RTL2832U baseband init + I2C tuner probe), which `sdr
+list` skips so the command is fast and never collides with a
+running daemon. Pass `--probe` when you want those columns filled:
+
+```powershell
+gophertrunk sdr list --probe
+```
+
+If you see `no SDR devices found` and you're sure the dongle is
+plugged in, the WinUSB driver swap probably didn't take — re-run
+Zadig with **Options → List All Devices** checked and verify the
+"Driver" column shows **WinUSB** for your dongle.
 
 If you didn't tick the PATH option during install, run from the
 install folder instead:

--- a/docs/user-guide-windows.md
+++ b/docs/user-guide-windows.md
@@ -141,10 +141,18 @@ gophertrunk sdr list
 timestamp (all pinned at link time via `-ldflags`).
 
 `sdr list` prints one row per attached dongle with its driver,
-index, serial, tuner, product string, and the supported gain values
-in tenths of a dB:
+index, serial, and product string. The TUNER and gains columns are
+blank by default — `sdr list` only reads USB descriptors, so it's
+fast and never collides with a running daemon. Pass `--probe` when
+you want those columns populated (it opens each device briefly to
+run the demod + tuner bring-up):
 
 ```
+> gophertrunk sdr list
+DRIVER    IDX  SERIAL            TUNER     PRODUCT   gains(0.1 dB)
+rtlsdr    0    00000001                    Generic   []
+
+> gophertrunk sdr list --probe
 DRIVER    IDX  SERIAL            TUNER     PRODUCT   gains(0.1 dB)
 rtlsdr    0    00000001          R820T2    NESDR Sm  [0 9 14 ... 496]
 ```
@@ -170,14 +178,19 @@ gophertrunk audio list
 
 ## 5. Build your first config
 
-The installer drops a starter at
-`C:\Program Files\GopherTrunk\config.example.yaml`. Copy it to a
-writable location and edit:
+The installer asked you for an "editable files folder" (default
+`Documents\GopherTrunk`), seeded a `config.yaml` there, and pinned
+the path in `HKCU\Environment\GOPHERTRUNK_CONFIG` so the daemon
+discovers it automatically. Open it from the Start Menu shortcut
+"Edit my config.yaml (Notepad)" or directly:
 
 ```powershell
-Copy-Item "C:\Program Files\GopherTrunk\config.example.yaml" "$HOME\gophertrunk.yaml"
-notepad "$HOME\gophertrunk.yaml"
+notepad "$env:USERPROFILE\Documents\GopherTrunk\config.yaml"
 ```
+
+A read-only reference copy of the full annotated template stays at
+`C:\Program Files\GopherTrunk\config.example.yaml` (Start Menu →
+"Configuration template").
 
 The full schema reference is in § 11. The bare minimum to get a
 working scanner is:
@@ -219,7 +232,24 @@ Full reference: [`import.md`]({{ '/import.html' | relative_url }}).
 ## 6. Run the daemon
 
 ```powershell
-gophertrunk run -config "$HOME\gophertrunk.yaml"
+gophertrunk run
+```
+
+The daemon walks `$GOPHERTRUNK_CONFIG` →
+`%APPDATA%\GopherTrunk\config.yaml` →
+`%USERPROFILE%\Documents\GopherTrunk\config.yaml` → `.\config.yaml`
+and loads the first one it finds, printing `config: loaded <path>`
+on startup so you can confirm the choice. If you keep multiple
+configs in the editable-files folder (e.g. `config.yaml` plus a
+`prod.yaml`), the daemon prints a numbered menu and asks which to
+load — Enter alone picks #1. A non-interactive launch (Windows
+service, Scheduled Task) auto-selects the first match with a
+stderr warning instead of hanging.
+
+Override discovery any time:
+
+```powershell
+gophertrunk run -config "C:\path\to\other.yaml"
 ```
 
 Logs stream to the terminal. Press `Ctrl+C` to stop cleanly — the
@@ -232,7 +262,7 @@ exit.
 
 | Flag | Description |
 | --- | --- |
-| `-config <path>` | Path to `config.yaml`. Optional — the daemon runs with built-in defaults if omitted. |
+| `-config <path>` | Path to `config.yaml`. Optional — when omitted the daemon walks `$GOPHERTRUNK_CONFIG` → `%APPDATA%\GopherTrunk` → `Documents\GopherTrunk` → cwd and loads the first match (built-in defaults if nothing found). |
 | `-log-level <lvl>` | Override `log.level` (`debug` / `info` / `warn` / `error`). |
 | `-log-format <fmt>` | Override `log.format` (`text` / `json`). |
 


### PR DESCRIPTION
## Summary

Docs-only follow-up to #237 — that PR shipped the behaviour changes but the user-facing documentation still described the old workflow. Sweeps the install guides, downloads page, user guide, and import reference so they match what the binary actually does on main.

## What's updated

| File | What changed |
| --- | --- |
| `CHANGELOG.md` | Four new `[Unreleased]` entries: config auto-discovery + multi-config picker; Windows installer editable-files folder; `sdr list --probe`; wizard QoL (bool `←/→`, env-var expansion, writable default, surfaced `MkdirAll` errors). |
| `docs/install-linux.md` | §4 documents `--probe`; §5 dropped the manual `cp + edit + -config <path>` recipe in favour of the new auto-discovery flow (`gophertrunk run` finds the config in standard locations, prints `config: loaded <path>`, prompts when multiple are present). |
| `docs/install-macos.md` | Same pattern as Linux; §5 anchored on `~/Library/Application Support/GopherTrunk/`. |
| `docs/install-windows.md` | §4 explains why TUNER + gains are blank without `--probe` and documents the flag. |
| `docs/user-guide-windows.md` | §4 shows `sdr list` with-and-without `--probe` side-by-side; §5 rewritten around the installer-set editable-files folder + `GOPHERTRUNK_CONFIG`; §6 covers flagless `gophertrunk run` + multi-config picker, updated `-config` flag table entry. |
| `docs/downloads.md` | Linux + macOS quick-start blocks now run the daemon flagless and cross-link to `install-linux.md` for the discovery rules. |
| `docs/import.md` | Wizard keybindings table notes `←/→` toggles bools too; new paragraph on env-var / `~` expansion + the "resolves to: \<abs\>" review-screen preview + the writable-default fallback. |

## Test plan

- [x] No code changes; full test suite still green (`go test ./...`).
- [ ] Manual: skim each touched doc in a markdown renderer to confirm formatting + links still resolve.

https://claude.ai/code/session_01ECh1b3DWXEXiCjh9hJEsh1

---
_Generated by [Claude Code](https://claude.ai/code/session_01ECh1b3DWXEXiCjh9hJEsh1)_