### PR TITLE
daemon: interactive launcher + startup hardening + closed-LAN defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,52 @@ for tagged releases.
 
 ### Added
 
+- **Interactive daemon launcher.** `gophertrunk` (no args) now prompts
+  the operator on a TTY for what to drive: `[1]` in-process TUI, `[2]`
+  bundled web SPA in the system browser, or `[3]` stay headless.
+  Non-TTY stdin (systemd, Windows service, Docker) auto-selects
+  headless so service managers see no behaviour change. New flags
+  preselect: `-tui`, `-web`, `-headless`; the three are mutually
+  exclusive. See [`docs/launcher.md`](docs/launcher.md).
+- **Live settings editing.** New `PATCH /api/v1/settings` endpoint
+  accepts a sparse patch (every field optional), writes the result to
+  `config.yaml` preserving comments + formatting, and hot-reloads the
+  fields the daemon knows how to change in-process (audio volume /
+  mute / recording, scanner scan mode, log level). Other fields
+  ("restart required") are written to disk and flagged in the
+  response so the SPA / TUI can render badges. An mtime guard refuses
+  to clobber a config.yaml that was edited externally while the
+  daemon was running.
+- **Live import.** New `POST /api/v1/import` (multipart),
+  `POST /api/v1/import/{id}/commit`, `DELETE /api/v1/import/{id}`
+  endpoints let operators upload RadioReference PDFs / multi-section
+  CSVs to a running daemon, preview the parsed systems, and commit
+  into `config.yaml` without restarting. The TUI grows an Import
+  panel (Stage → Preview → Result); the web SPA grows a matching
+  `/import` route with a native file picker.
+- **Startup hardening.** A new pre-flight step auto-creates the
+  recordings / storage / cc-cache parent dirs and verifies TLS
+  cert/key parse cleanly before the daemon binds. SDR-pool open
+  failures and missing talkgroup CSVs collect into `startup_warnings`
+  (surfaced on the runtime DTO + the launcher menu) instead of
+  vanishing into the log. HTTP and gRPC bind failures now abort the
+  daemon cleanly instead of being demoted to warnings — the launcher
+  never lands against a half-dead daemon.
+
+### Changed
+
+- **Security defaults flipped for closed-LAN deployments.** Empty
+  `api.auth.mode` now defaults to `disabled` (was `auto`) and empty
+  `api.cors.allowed_origins` now permits any origin (was strict). The
+  daemon still warns loudly at startup when these defaults take
+  effect on a non-loopback bind, but the common single-host setup no
+  longer needs explicit auth + CORS config to talk to the web SPA
+  from `file://`. Operators on hostile networks opt back in via
+  explicit `api.auth.mode: required` + `api.cors.allowed_origins:
+  ["http://laptop.local:5173"]`. The default `api.http_addr` is now
+  `127.0.0.1:8080` (was empty) so the bundled launcher's TUI / web
+  paths work out of the box.
+
 - **Config auto-discovery.** `gophertrunk run` (no `-config` flag)
   now walks `$GOPHERTRUNK_CONFIG` → `<UserConfigDir>/GopherTrunk/config.yaml`
   → `<Home>/Documents/GopherTrunk/config.yaml` → `./config.yaml`

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -91,8 +91,55 @@ type Daemon struct {
 	httpAPI    *api.Server
 	grpcAPI    *api.GRPCServer
 
+	// startupWarnings collects non-fatal observations from
+	// NewDaemon / preflight (missing talkgroup CSV, SDR enumeration
+	// empty, etc.) so the launcher can render them above its menu
+	// and the TUI can pin them as a one-shot dashboard banner.
+	startupWarnings []string
+
+	// ready is closed by Run once all spawned essential components
+	// have started. Consumers use it to gate the launcher prompt so
+	// it never lands against a half-dead daemon.
+	ready     chan struct{}
+	readyOnce sync.Once
+
+	// fatalErr is set by an essential component that fails after
+	// Run has begun spawning goroutines. Run's blocking select picks
+	// it up and unwinds the daemon. Guarded by mu.
+	mu       sync.Mutex
+	fatalErr error
+	cancel   context.CancelFunc
+
 	wg        sync.WaitGroup
 	closeOnce sync.Once
+}
+
+// Ready returns a channel that closes once every essential component
+// has started successfully. Used by the launcher to wait for the HTTP
+// API to bind before prompting the operator.
+func (d *Daemon) Ready() <-chan struct{} {
+	if d.ready == nil {
+		// Conservative: a Daemon constructed by code that pre-dates
+		// the Ready surface should still satisfy <-d.Ready() with
+		// an already-closed channel.
+		ch := make(chan struct{})
+		close(ch)
+		return ch
+	}
+	return d.ready
+}
+
+// StartupWarnings returns the non-fatal warnings collected during
+// NewDaemon construction. Callers should treat the slice as read-only.
+func (d *Daemon) StartupWarnings() []string {
+	return append([]string(nil), d.startupWarnings...)
+}
+
+// addWarning records a non-fatal startup observation. Threaded into
+// the launcher + TUI dashboard so silent degradations get an audible
+// surface.
+func (d *Daemon) addWarning(msg string) {
+	d.startupWarnings = append(d.startupWarnings, msg)
 }
 
 // NewDaemon constructs the daemon from the loaded config. Components
@@ -106,7 +153,12 @@ func NewDaemon(cfg config.Config, version string, log *slog.Logger) (*Daemon, er
 		return nil, errors.New("daemon: logger is required")
 	}
 
-	d := &Daemon{cfg: cfg, log: log, bus: events.NewBus(64)}
+	d := &Daemon{
+		cfg:   cfg,
+		log:   log,
+		bus:   events.NewBus(64),
+		ready: make(chan struct{}),
+	}
 
 	// Talkgroup DB — populated below from per-system CSVs.
 	d.talkgroups = trunking.NewTalkgroupDB()
@@ -148,6 +200,9 @@ func NewDaemon(cfg config.Config, version string, log *slog.Logger) (*Daemon, er
 			if err != nil {
 				log.Warn("daemon: talkgroup load failed",
 					"system", sys.Name, "file", sys.TalkgroupFile, "err", err)
+				d.addWarning(fmt.Sprintf(
+					"talkgroup_file %q for system %q failed to load (%v) — calls on this system will have no alpha tags",
+					sys.TalkgroupFile, sys.Name, err))
 			} else {
 				log.Info("daemon: talkgroups loaded", "system", sys.Name, "count", n)
 			}
@@ -180,8 +235,16 @@ func NewDaemon(cfg config.Config, version string, log *slog.Logger) (*Daemon, er
 		}
 		if err := d.pool.Open(hints); err != nil {
 			log.Warn("daemon: SDR pool open failed", "err", err)
+			d.addWarning(fmt.Sprintf(
+				"SDR pool failed to open (%v) — no radios will demodulate; check device permissions / cabling / kernel modules",
+				err))
 			d.pool = nil
 		}
+	} else if len(cfg.Trunking.Systems) > 0 {
+		// Trunked systems configured but no SDR devices listed —
+		// the daemon will look healthy from a logs-only vantage but
+		// can't actually decode anything.
+		d.addWarning("trunking.systems configured but sdr.devices is empty — daemon has nothing to demodulate; add at least one device")
 	}
 
 	// Voice device list from the pool; empty when no SDRs.
@@ -569,9 +632,16 @@ func NewDaemon(cfg config.Config, version string, log *slog.Logger) (*Daemon, er
 	return d, nil
 }
 
-// Run starts every long-lived goroutine and blocks until ctx cancels.
-// Each component returns its own error; the first non-nil non-context
-// error short-circuits the rest and triggers Close.
+// Run starts every long-lived goroutine and blocks until ctx cancels
+// (or an essential component fails). Each component returns its own
+// error; non-essential errors land on the log, essential errors
+// cancel the daemon's internal context so the launcher / TUI doesn't
+// keep running against a half-dead daemon.
+//
+// Run also closes d.Ready() once the spawned components have settled.
+// "Settled" today is conservative — a brief 250 ms timer after every
+// spawn call has fired — but ensures the HTTP listener bound (so the
+// launcher's TUI/web flow can reach it) before the prompt appears.
 func (d *Daemon) Run(ctx context.Context) error {
 	d.log.Info("gophertrunk starting",
 		"http_addr", d.cfg.API.HTTPAddr,
@@ -580,72 +650,125 @@ func (d *Daemon) Run(ctx context.Context) error {
 		"voice_devices", len(d.voicePool.Devices()),
 	)
 
-	d.spawn(ctx, "engine", func(ctx context.Context) error {
+	// Wrap ctx so an essential component error can cancel siblings.
+	runCtx, cancel := context.WithCancel(ctx)
+	d.mu.Lock()
+	d.cancel = cancel
+	d.mu.Unlock()
+	defer cancel()
+
+	d.spawn(runCtx, "engine", true, func(ctx context.Context) error {
 		return d.engine.Run(ctx)
 	})
 
 	if d.callLog != nil {
-		d.spawn(ctx, "calllog", func(ctx context.Context) error {
+		d.spawn(runCtx, "calllog", false, func(ctx context.Context) error {
 			return d.callLog.Run(ctx)
 		})
 	}
 	if d.retention != nil {
-		d.spawn(ctx, "retention", func(ctx context.Context) error {
+		d.spawn(runCtx, "retention", false, func(ctx context.Context) error {
 			return d.retention.Run(ctx)
 		})
 	}
 	if d.recorder != nil {
-		d.spawn(ctx, "recorder", func(ctx context.Context) error {
+		d.spawn(runCtx, "recorder", false, func(ctx context.Context) error {
 			return d.recorder.Run(ctx)
 		})
 	}
 	if d.composer != nil {
-		d.spawn(ctx, "composer", func(ctx context.Context) error {
+		d.spawn(runCtx, "composer", false, func(ctx context.Context) error {
 			return d.composer.Run(ctx)
 		})
 	}
 	if d.audioPub != nil {
-		d.spawn(ctx, "audio-publisher", func(ctx context.Context) error {
+		d.spawn(runCtx, "audio-publisher", false, func(ctx context.Context) error {
 			return d.audioPub.Run(ctx)
 		})
 	}
 	if d.metrics != nil {
-		d.spawn(ctx, "metrics", func(ctx context.Context) error {
+		d.spawn(runCtx, "metrics", false, func(ctx context.Context) error {
 			return d.metrics.Run(ctx)
 		})
 	}
 	if d.cchuntSup != nil {
-		d.spawn(ctx, "cchunt", func(ctx context.Context) error {
+		d.spawn(runCtx, "cchunt", false, func(ctx context.Context) error {
 			return d.cchuntSup.Run(ctx)
 		})
 	}
 	if d.ccDecoder != nil {
-		d.spawn(ctx, "ccdecoder", func(ctx context.Context) error {
+		d.spawn(runCtx, "ccdecoder", false, func(ctx context.Context) error {
 			return d.ccDecoder.Run(ctx)
 		})
 	}
 	if d.convScan != nil {
-		d.spawn(ctx, "conv-scanner", func(ctx context.Context) error {
+		d.spawn(runCtx, "conv-scanner", false, func(ctx context.Context) error {
 			return d.convScan.Run(ctx)
 		})
 	}
 	if d.httpAPI != nil {
-		d.spawn(ctx, "http", func(ctx context.Context) error {
+		// HTTP is essential — the launcher's TUI / web paths need
+		// it bound, and bind failures (port in use, permission
+		// denied) used to be demoted to a warning while the daemon
+		// kept running. Now they abort cleanly.
+		d.spawn(runCtx, "http", true, func(ctx context.Context) error {
 			return d.httpAPI.Run(ctx)
 		})
 	}
 	if d.grpcAPI != nil {
-		d.spawn(ctx, "grpc", func(ctx context.Context) error {
+		d.spawn(runCtx, "grpc", true, func(ctx context.Context) error {
 			return d.grpcAPI.Run(ctx)
 		})
 	}
 
-	<-ctx.Done()
+	// Conservative readiness: give every spawn a brief grace window
+	// so the HTTP listener has time to bind. Components without an
+	// explicit "ready" hook share this same gate.
+	go d.markReadyAfter(runCtx, 250*time.Millisecond)
+
+	<-runCtx.Done()
 	d.log.Info("gophertrunk shutdown initiated")
 	d.Close()
 	d.wg.Wait()
 	d.log.Info("gophertrunk shutdown complete")
+	if err := d.takeFatal(); err != nil {
+		return err
+	}
 	return ctx.Err()
+}
+
+// markReadyAfter waits the supplied grace window and then closes the
+// Ready channel. Cancellation aborts the wait but still closes the
+// channel so blocked consumers don't deadlock.
+func (d *Daemon) markReadyAfter(ctx context.Context, grace time.Duration) {
+	t := time.NewTimer(grace)
+	defer t.Stop()
+	select {
+	case <-t.C:
+	case <-ctx.Done():
+	}
+	d.readyOnce.Do(func() { close(d.ready) })
+}
+
+// recordFatal stores an essential-component error (first wins) and
+// cancels the daemon's run context so siblings unwind. Safe to call
+// from any goroutine.
+func (d *Daemon) recordFatal(err error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.fatalErr == nil {
+		d.fatalErr = err
+	}
+	if d.cancel != nil {
+		d.cancel()
+	}
+}
+
+// takeFatal returns the captured essential-component error (if any).
+func (d *Daemon) takeFatal() error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.fatalErr
 }
 
 // Close releases every component. Idempotent and safe to call
@@ -706,13 +829,26 @@ func (d *Daemon) HTTPListenAddr() string {
 // synthetic events.
 func (d *Daemon) Bus() *events.Bus { return d.bus }
 
-func (d *Daemon) spawn(ctx context.Context, name string, fn func(context.Context) error) {
+// spawn runs fn in a goroutine. essential=true means a non-context
+// error from fn aborts the whole daemon (the launcher / TUI rely on
+// these components — silently demoting their failures to log warnings
+// produces a half-dead daemon that frustrates the operator).
+// essential=false retains the legacy behaviour: warn-and-continue.
+func (d *Daemon) spawn(ctx context.Context, name string, essential bool, fn func(context.Context) error) {
 	d.wg.Add(1)
 	go func() {
 		defer d.wg.Done()
-		if err := fn(ctx); err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
-			d.log.Warn("daemon: component exited with error", "component", name, "err", err)
+		err := fn(ctx)
+		if err == nil || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return
 		}
+		if essential {
+			d.log.Error("daemon: essential component failed",
+				"component", name, "err", err)
+			d.recordFatal(fmt.Errorf("%s: %w", name, err))
+			return
+		}
+		d.log.Warn("daemon: component exited with error", "component", name, "err", err)
 	}()
 }
 

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -66,8 +66,10 @@ func parseGain(s string) (int, bool) {
 // by Run, and torn down by Close in reverse order. Run blocks until
 // ctx cancels; Close is idempotent.
 type Daemon struct {
-	cfg config.Config
-	log *slog.Logger
+	cfg      config.Config
+	cfgPath  string
+	log      *slog.Logger
+	writer   *config.Writer // optional; nil when daemon ran without -config
 
 	bus        *events.Bus
 	pool       *sdr.Pool
@@ -114,6 +116,22 @@ type Daemon struct {
 	closeOnce sync.Once
 }
 
+// ConfigPath returns the absolute path of the config.yaml backing
+// the daemon, or "" when the daemon was started without -config.
+// The settings PATCH endpoint reads this to decide whether
+// edit-and-write is supported.
+func (d *Daemon) ConfigPath() string {
+	if d.writer != nil {
+		return d.writer.Path()
+	}
+	return d.cfgPath
+}
+
+// Writer returns the live config.yaml writer the daemon installed,
+// or nil when no config file backs the daemon. Used by NewDaemon to
+// expose the writer through ServerOptions.ConfigWriter.
+func (d *Daemon) Writer() *config.Writer { return d.writer }
+
 // Ready returns a channel that closes once every essential component
 // has started successfully. Used by the launcher to wait for the HTTP
 // API to bind before prompting the operator.
@@ -148,16 +166,34 @@ func (d *Daemon) addWarning(msg string) {
 //
 // version is stamped into Prometheus build_info and the API
 // /api/v1/version response.
+//
+// Use NewDaemonWithPath to install a live config.yaml writer for the
+// PATCH /api/v1/settings endpoint.
 func NewDaemon(cfg config.Config, version string, log *slog.Logger) (*Daemon, error) {
+	return NewDaemonWithPath(cfg, "", version, log)
+}
+
+// NewDaemonWithPath is the constructor used by main when a config
+// file backs the daemon: the path is installed as a config.Writer
+// so PATCH /api/v1/settings can re-write the file in place.
+func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *slog.Logger) (*Daemon, error) {
 	if log == nil {
 		return nil, errors.New("daemon: logger is required")
 	}
 
 	d := &Daemon{
-		cfg:   cfg,
-		log:   log,
-		bus:   events.NewBus(64),
-		ready: make(chan struct{}),
+		cfg:     cfg,
+		cfgPath: cfgPath,
+		log:     log,
+		bus:     events.NewBus(64),
+		ready:   make(chan struct{}),
+	}
+	if cfgPath != "" {
+		w, err := config.NewWriter(cfgPath)
+		if err != nil {
+			return nil, fmt.Errorf("daemon: config writer: %w", err)
+		}
+		d.writer = w
 	}
 
 	// Talkgroup DB — populated below from per-system CSVs.
@@ -603,6 +639,14 @@ func NewDaemon(cfg config.Config, version string, log *slog.Logger) (*Daemon, er
 			cfg:     &cfgCopy,
 			version: version,
 			metrics: cfg.Metrics.Enabled,
+			daemon:  d,
+		}
+		// Live settings editing — only enabled when the daemon was
+		// started with a -config (otherwise there's no file to write
+		// back to).
+		if d.writer != nil {
+			opts.ConfigWriter = d.writer
+			opts.SettingsApplier = newDaemonSettingsApplier(d, version)
 		}
 		srv, err := api.NewServer(opts)
 		if err != nil {

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -647,6 +647,7 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 		if d.writer != nil {
 			opts.ConfigWriter = d.writer
 			opts.SettingsApplier = newDaemonSettingsApplier(d, version)
+			opts.Importer = newDaemonImporter(d)
 		}
 		srv, err := api.NewServer(opts)
 		if err != nil {

--- a/cmd/gophertrunk/importer.go
+++ b/cmd/gophertrunk/importer.go
@@ -1,0 +1,161 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/MattCheramie/GopherTrunk/internal/api"
+)
+
+// daemonImporter implements api.Importer by writing each upload to a
+// tempfile and calling the existing parsePDFFile / parseCSVFile /
+// mergeIntoConfig helpers in cmd/gophertrunk. Sharing the mutex
+// with the config writer would be ideal but the writer's lock is
+// scoped to itself; this importer adds its own coarse lock so two
+// commits can't race against each other.
+type daemonImporter struct {
+	d  *Daemon
+	mu sync.Mutex
+}
+
+func newDaemonImporter(d *Daemon) *daemonImporter {
+	return &daemonImporter{d: d}
+}
+
+// Parse turns one uploaded source into a preview DTO. The source's
+// bytes are written to a tempfile under os.TempDir; the file is
+// removed after the parser returns so failure paths don't leak.
+func (i *daemonImporter) Parse(s api.ImportSource) (api.ParsedSystemDTO, error) {
+	path, err := writeTempUpload(s)
+	if err != nil {
+		return api.ParsedSystemDTO{}, err
+	}
+	defer os.Remove(path)
+
+	parsed, err := parseImportFile(path, s.Kind)
+	if err != nil {
+		return api.ParsedSystemDTO{}, err
+	}
+	return parsedToDTO(parsed, s.Filename), nil
+}
+
+// Commit writes every source out to disk (so mergeIntoConfig can
+// re-parse them via the existing file-path code path) and merges
+// them into the daemon's config.yaml.
+func (i *daemonImporter) Commit(sources []api.ImportSource, force bool) (api.ImportCommitResult, error) {
+	if i.d.cfgPath == "" {
+		return api.ImportCommitResult{}, fmt.Errorf("import: daemon started without -config; nothing to merge into")
+	}
+
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
+	var tmpPaths []string
+	defer func() {
+		for _, p := range tmpPaths {
+			_ = os.Remove(p)
+		}
+	}()
+
+	parsed := make([]parsedSystem, 0, len(sources))
+	for _, s := range sources {
+		tp, err := writeTempUpload(s)
+		if err != nil {
+			return api.ImportCommitResult{}, err
+		}
+		tmpPaths = append(tmpPaths, tp)
+		ps, err := parseImportFile(tp, s.Kind)
+		if err != nil {
+			return api.ImportCommitResult{}, err
+		}
+		parsed = append(parsed, ps)
+	}
+
+	res, err := mergeIntoConfig(parsed, mergeOptions{
+		ConfigPath: i.d.cfgPath,
+		CSVDir:     filepath.Dir(i.d.cfgPath),
+		Force:      force,
+		DryRun:     false,
+	})
+	if err != nil {
+		return api.ImportCommitResult{}, err
+	}
+
+	added := make([]string, 0, len(parsed))
+	for _, p := range parsed {
+		added = append(added, p.Name)
+	}
+	csvPaths := make([]string, 0, len(res.CSVs))
+	for _, c := range res.CSVs {
+		csvPaths = append(csvPaths, c.Path)
+	}
+
+	// Reload talkgroup CSVs into the in-memory DB so the new alpha
+	// tags appear without a daemon restart.
+	for _, c := range res.CSVs {
+		if i.d.talkgroups != nil {
+			_, _ = i.d.talkgroups.LoadCSVFile(c.Path)
+		}
+	}
+
+	return api.ImportCommitResult{
+		SystemsAdded: added,
+		CSVPaths:     csvPaths,
+		ConfigPath:   i.d.cfgPath,
+	}, nil
+}
+
+// writeTempUpload writes s.Data to a temp file (extension preserved
+// so the parser sees the original filename hint) and returns the path.
+func writeTempUpload(s api.ImportSource) (string, error) {
+	ext := filepath.Ext(s.Filename)
+	if ext == "" {
+		switch s.Kind {
+		case api.ImportSourcePDF:
+			ext = ".pdf"
+		case api.ImportSourceCSV:
+			ext = ".csv"
+		}
+	}
+	f, err := os.CreateTemp("", "gophertrunk-import-*"+ext)
+	if err != nil {
+		return "", fmt.Errorf("import: tempfile: %w", err)
+	}
+	if _, err := f.Write(s.Data); err != nil {
+		f.Close()
+		_ = os.Remove(f.Name())
+		return "", fmt.Errorf("import: write tempfile: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		_ = os.Remove(f.Name())
+		return "", err
+	}
+	return f.Name(), nil
+}
+
+func parseImportFile(path string, kind api.ImportSourceKind) (parsedSystem, error) {
+	switch kind {
+	case api.ImportSourcePDF:
+		return parsePDFFile(path)
+	case api.ImportSourceCSV:
+		return parseCSVFile(path)
+	}
+	return parsedSystem{}, fmt.Errorf("import: unsupported kind %q", kind)
+}
+
+func parsedToDTO(p parsedSystem, filename string) api.ParsedSystemDTO {
+	return api.ParsedSystemDTO{
+		Name:        p.Name,
+		Location:    p.Location,
+		County:      p.County,
+		SysID:       p.SysID,
+		WACN:        p.WACN,
+		SystemType:  p.SystemType,
+		Protocol:    p.Protocol,
+		SiteCount:   len(p.Sites),
+		TalkgroupCt: len(p.Talkgroups),
+		SourcePath:  filename,
+	}
+}

--- a/cmd/gophertrunk/launcher.go
+++ b/cmd/gophertrunk/launcher.go
@@ -1,0 +1,388 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	gtlog "github.com/MattCheramie/GopherTrunk/internal/log"
+	"github.com/MattCheramie/GopherTrunk/internal/tui"
+	"github.com/MattCheramie/GopherTrunk/internal/tui/client"
+)
+
+// launchMode discriminates the launcher's terminal action. launchAuto
+// is the no-flags default — prompt the operator on a TTY, stay
+// headless otherwise.
+type launchMode int
+
+const (
+	launchAuto launchMode = iota
+	launchTUI
+	launchWeb
+	launchHeadless
+)
+
+// pickLaunchMode reconciles the three mutually-exclusive flag values
+// into a single launchMode. Multiple flags set at once is a hard
+// error so the operator hears about the misuse instead of getting a
+// silent precedence rule.
+func pickLaunchMode(tui, web, headless bool) (launchMode, error) {
+	set := 0
+	if tui {
+		set++
+	}
+	if web {
+		set++
+	}
+	if headless {
+		set++
+	}
+	if set > 1 {
+		return launchAuto, errors.New("-tui, -web, and -headless are mutually exclusive")
+	}
+	switch {
+	case tui:
+		return launchTUI, nil
+	case web:
+		return launchWeb, nil
+	case headless:
+		return launchHeadless, nil
+	default:
+		return launchAuto, nil
+	}
+}
+
+// launchModeFlag returns the operator-facing flag name for a mode,
+// used in error messages so the printed text matches what the
+// operator typed on the command line.
+func launchModeFlag(m launchMode) string {
+	switch m {
+	case launchTUI:
+		return "tui"
+	case launchWeb:
+		return "web"
+	case launchHeadless:
+		return "headless"
+	}
+	return "auto"
+}
+
+// runLauncher is the post-Ready hook. It surfaces any startup
+// warnings, optionally prompts the operator for a UI, and then runs
+// the chosen UI in-process (TUI) or out-of-process (browser open).
+// Returns when the chosen UI has finished or immediately for
+// headless modes — the caller is expected to keep waiting on Run.
+func runLauncher(ctx context.Context, d *Daemon, log *slog.Logger, logSwap *gtlog.SwappableWriter, mode launchMode) {
+	if mode == launchHeadless {
+		printWarnings(d.StartupWarnings())
+		return
+	}
+
+	// Auto: TTY → prompt; non-TTY → silent headless.
+	if mode == launchAuto {
+		if !stdinIsTerminal() {
+			printWarnings(d.StartupWarnings())
+			return
+		}
+		printWarnings(d.StartupWarnings())
+		chosen, ok := promptLaunchChoice(ctx)
+		if !ok {
+			return // headless or cancelled
+		}
+		mode = chosen
+	}
+
+	switch mode {
+	case launchTUI:
+		if err := runInProcessTUI(ctx, d, log, logSwap); err != nil {
+			fmt.Fprintf(os.Stderr, "launcher: tui exited with error: %v\n", err)
+		}
+	case launchWeb:
+		if err := openWebUI(d, log); err != nil {
+			fmt.Fprintf(os.Stderr, "launcher: %v\n", err)
+		}
+	}
+}
+
+// printWarnings sends the daemon's collected startup warnings to
+// stderr (red-ish when supported). The launcher menu and headless
+// path both call this so silently-degraded startups always surface.
+func printWarnings(ws []string) {
+	if len(ws) == 0 {
+		return
+	}
+	const yellow, reset = "\033[33m", "\033[0m"
+	color := stdoutIsTerminal()
+	fmt.Fprintln(os.Stderr)
+	for _, w := range ws {
+		if color {
+			fmt.Fprintf(os.Stderr, "%s! %s%s\n", yellow, w, reset)
+		} else {
+			fmt.Fprintf(os.Stderr, "! %s\n", w)
+		}
+	}
+	fmt.Fprintln(os.Stderr)
+}
+
+// promptLaunchChoice prints the menu on stderr and reads stdin. The
+// read happens in a goroutine so a SIGTERM arriving while we're
+// blocked still unwinds the daemon cleanly. Returns ok=false when
+// the operator cancels (ctrl-c, ctrl-d, blank line) — caller stays
+// headless.
+func promptLaunchChoice(ctx context.Context) (launchMode, bool) {
+	// ── visual separator so this prompt is clearly distinct from
+	// the earlier multi-config picker (which also reads stdin).
+	fmt.Fprintln(os.Stderr, "──")
+	fmt.Fprintln(os.Stderr, "Daemon ready. How do you want to drive it?")
+	fmt.Fprintln(os.Stderr, "  [1] TUI       (in-process operator console)")
+	fmt.Fprintln(os.Stderr, "  [2] Web       (open the bundled SPA in your browser)")
+	fmt.Fprintln(os.Stderr, "  [3] Headless  (keep running silent)")
+	fmt.Fprint(os.Stderr, "Choice [1-3, default 3]: ")
+
+	type lineResult struct {
+		line string
+		err  error
+	}
+	resultCh := make(chan lineResult, 1)
+	go func() {
+		reader := bufio.NewReader(os.Stdin)
+		line, err := reader.ReadString('\n')
+		resultCh <- lineResult{line: line, err: err}
+	}()
+
+	var line string
+	select {
+	case <-ctx.Done():
+		fmt.Fprintln(os.Stderr)
+		return launchHeadless, false
+	case r := <-resultCh:
+		if r.err != nil {
+			fmt.Fprintln(os.Stderr)
+			return launchHeadless, false
+		}
+		line = r.line
+	}
+
+	line = strings.TrimSpace(line)
+	switch line {
+	case "", "3", "h", "H", "headless":
+		return launchHeadless, false
+	case "1", "t", "T", "tui":
+		return launchTUI, true
+	case "2", "w", "W", "web":
+		return launchWeb, true
+	}
+	fmt.Fprintf(os.Stderr, "launcher: unknown choice %q, staying headless\n", line)
+	return launchHeadless, false
+}
+
+// runInProcessTUI builds a TUI Model pointed at the local HTTP API
+// and runs bubbletea synchronously. Daemon logs are redirected to a
+// tempfile while the TUI owns the screen so background log lines
+// don't bleed onto the alt-screen canvas; the previous writer is
+// restored on TUI exit.
+func runInProcessTUI(ctx context.Context, d *Daemon, log *slog.Logger, logSwap *gtlog.SwappableWriter) error {
+	addr := d.HTTPListenAddr()
+	if addr == "" {
+		return errors.New("in-process TUI requires api.http_addr in config")
+	}
+	server := normaliseServerURL(addr)
+
+	cli := client.New(server, 5*time.Second, false)
+
+	// Redirect daemon logs so they don't scribble over the TUI.
+	logFile, err := os.CreateTemp("", "gophertrunk-tui-*.log")
+	if err == nil {
+		logSwap.Redirect(logFile)
+		defer func() {
+			logSwap.Restore()
+			_ = logFile.Close()
+			log.Info("tui: daemon log captured", "path", logFile.Name())
+		}()
+	}
+
+	m := tui.New(cli, tui.Options{Write: true})
+	prog := tea.NewProgram(m, tea.WithAltScreen(), tea.WithMouseCellMotion())
+
+	// Run bubbletea synchronously. The ctx isn't passed in (bubbletea
+	// owns the terminal until it returns) — if the daemon is
+	// cancelled mid-TUI the next API poll will fail and the operator
+	// can quit with 'q'.
+	_, err = prog.Run()
+	return err
+}
+
+// openWebUI locates a sibling gophertrunk-web/ directory and opens
+// its index.html with a #server=<url> hash so the SPA bootstraps
+// against the running daemon automatically. When no asset directory
+// is found OR no browser can be launched (headless SSH), prints a
+// clear fallback so the operator can open the URL elsewhere.
+func openWebUI(d *Daemon, log *slog.Logger) error {
+	addr := d.HTTPListenAddr()
+	if addr == "" {
+		return errors.New("-web requires api.http_addr in config")
+	}
+	serverURL := normaliseServerURL(addr)
+
+	assetPath := findWebAssets()
+	target := buildWebTargetURL(assetPath, serverURL)
+	if assetPath == "" {
+		printWebFallback(serverURL, "")
+		return nil
+	}
+
+	if !canOpenBrowser() {
+		printWebFallback(serverURL, assetPath)
+		return nil
+	}
+	log.Info("launcher: opening web UI", "target", target)
+	if err := openBrowser(target); err != nil {
+		printWebFallback(serverURL, assetPath)
+		return nil
+	}
+	return nil
+}
+
+// findWebAssets walks the conventional install locations and returns
+// the first path that contains an index.html. Returns "" when none
+// of the candidates exist.
+func findWebAssets() string {
+	candidates := []string{}
+
+	if exe, err := os.Executable(); err == nil {
+		dir := filepath.Dir(exe)
+		candidates = append(candidates,
+			filepath.Join(dir, "gophertrunk-web", "index.html"),
+			filepath.Join(dir, "web", "dist", "index.html"),
+			filepath.Join(filepath.Dir(dir), "share", "gophertrunk", "web", "index.html"),
+		)
+	}
+	if home, err := os.UserConfigDir(); err == nil {
+		candidates = append(candidates,
+			filepath.Join(home, "gophertrunk", "web", "index.html"))
+	}
+	// Dev tree: ./web/dist
+	candidates = append(candidates, filepath.Join("web", "dist", "index.html"))
+
+	for _, c := range candidates {
+		if info, err := os.Stat(c); err == nil && !info.IsDir() {
+			return c
+		}
+	}
+	return ""
+}
+
+// buildWebTargetURL returns a file:// URL pointing at index.html
+// with #server=<daemon URL> so the SPA bootstraps automatically.
+func buildWebTargetURL(assetPath, serverURL string) string {
+	if assetPath == "" {
+		return serverURL
+	}
+	abs, err := filepath.Abs(assetPath)
+	if err != nil {
+		abs = assetPath
+	}
+	u := url.URL{Scheme: "file", Path: filepath.ToSlash(abs)}
+	u.Fragment = "server=" + serverURL
+	return u.String()
+}
+
+// canOpenBrowser probes the environment for a viable display target.
+// On Linux/BSD we look for $DISPLAY or $WAYLAND_DISPLAY; on macOS /
+// Windows the OS always has a session.
+func canOpenBrowser() bool {
+	switch runtime.GOOS {
+	case "darwin", "windows":
+		return true
+	default:
+		return os.Getenv("DISPLAY") != "" || os.Getenv("WAYLAND_DISPLAY") != ""
+	}
+}
+
+// openBrowser shells out to the OS-specific URL opener. Returns the
+// error from the underlying command. The 2 s timeout protects
+// against an opener that hangs (broken xdg-mime database, etc.).
+func openBrowser(target string) error {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("open", target)
+	case "windows":
+		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", target)
+	default:
+		cmd = exec.Command("xdg-open", target)
+	}
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(2 * time.Second):
+		// The opener typically backgrounds itself; treat a hung
+		// foreground as success and let the OS reap the child.
+		return nil
+	}
+}
+
+// printWebFallback writes the human-readable fallback block when we
+// couldn't launch a browser (no display, missing assets, etc.).
+func printWebFallback(serverURL, assetPath string) {
+	fmt.Fprintln(os.Stderr, "──")
+	fmt.Fprintln(os.Stderr, "launcher: could not launch a browser on this host.")
+	fmt.Fprintln(os.Stderr, "          Open this URL on a machine that has one:")
+	fmt.Fprintf(os.Stderr, "            %s\n", serverURL)
+	if assetPath != "" {
+		fmt.Fprintf(os.Stderr, "          Web SPA assets are at %s\n", assetPath)
+		fmt.Fprintln(os.Stderr, "          (open index.html in a browser, then enter the URL above)")
+	} else {
+		fmt.Fprintln(os.Stderr, "          No bundled web/ directory found; build with `make web-build`")
+		fmt.Fprintln(os.Stderr, "          and host web/dist/ from any static server.")
+	}
+	fmt.Fprintln(os.Stderr)
+}
+
+// normaliseServerURL turns an HTTPAddr like ":8080" or
+// "0.0.0.0:8080" into a clickable browser URL. Loopback binds become
+// http://127.0.0.1:<port>; wildcard binds become http://localhost:<port>
+// so the operator on the same host has something that resolves.
+func normaliseServerURL(addr string) string {
+	host, port := splitHostPort(addr)
+	switch host {
+	case "", "0.0.0.0", "::", "[::]":
+		host = "localhost"
+	}
+	if port == "" {
+		port = "8080"
+	}
+	return "http://" + host + ":" + port
+}
+
+// splitHostPort splits "host:port" without using net.SplitHostPort
+// (which errors on a bare port like ":8080"). Returns empty strings
+// when the input doesn't fit the pattern.
+func splitHostPort(addr string) (host, port string) {
+	if i := strings.LastIndex(addr, ":"); i >= 0 {
+		host = addr[:i]
+		port = addr[i+1:]
+		// Validate port is numeric.
+		if _, err := strconv.Atoi(port); err == nil {
+			return host, port
+		}
+	}
+	return "", ""
+}

--- a/cmd/gophertrunk/launcher_test.go
+++ b/cmd/gophertrunk/launcher_test.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestPickLaunchMode(t *testing.T) {
+	cases := []struct {
+		name        string
+		tui         bool
+		web         bool
+		headless    bool
+		want        launchMode
+		expectError bool
+	}{
+		{"no flags → auto", false, false, false, launchAuto, false},
+		{"-tui", true, false, false, launchTUI, false},
+		{"-web", false, true, false, launchWeb, false},
+		{"-headless", false, false, true, launchHeadless, false},
+		{"-tui + -web → error", true, true, false, launchAuto, true},
+		{"-tui + -headless → error", true, false, true, launchAuto, true},
+		{"-web + -headless → error", false, true, true, launchAuto, true},
+		{"all three → error", true, true, true, launchAuto, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := pickLaunchMode(tc.tui, tc.web, tc.headless)
+			if tc.expectError {
+				if err == nil {
+					t.Fatalf("expected error, got mode=%v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("got mode=%v want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestLaunchModeFlag(t *testing.T) {
+	cases := map[launchMode]string{
+		launchAuto:     "auto",
+		launchTUI:      "tui",
+		launchWeb:      "web",
+		launchHeadless: "headless",
+	}
+	for m, want := range cases {
+		if got := launchModeFlag(m); got != want {
+			t.Errorf("launchModeFlag(%v) = %q want %q", m, got, want)
+		}
+	}
+}
+
+func TestNormaliseServerURL(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{":8080", "http://localhost:8080"},
+		{"0.0.0.0:8080", "http://localhost:8080"},
+		{"127.0.0.1:8080", "http://127.0.0.1:8080"},
+		{"[::]:8080", "http://localhost:8080"},
+		{"192.168.1.5:8080", "http://192.168.1.5:8080"},
+	}
+	for _, tc := range cases {
+		if got := normaliseServerURL(tc.in); got != tc.want {
+			t.Errorf("normaliseServerURL(%q) = %q want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestBuildWebTargetURL(t *testing.T) {
+	asset := filepath.Join(t.TempDir(), "index.html")
+	out := buildWebTargetURL(asset, "http://127.0.0.1:8080")
+	if !strings.HasPrefix(out, "file://") {
+		t.Fatalf("expected file:// prefix, got %q", out)
+	}
+	if !strings.Contains(out, "#server=http://127.0.0.1:8080") {
+		t.Fatalf("expected server hash, got %q", out)
+	}
+}
+
+func TestBuildWebTargetURL_NoAsset(t *testing.T) {
+	out := buildWebTargetURL("", "http://127.0.0.1:8080")
+	if out != "http://127.0.0.1:8080" {
+		t.Fatalf("got %q; want passthrough to the server URL when no assets found", out)
+	}
+}
+
+func TestFindWebAssets_Empty(t *testing.T) {
+	// With nothing in canonical locations during tests, findWebAssets
+	// can either return "" (no assets) or the dev-tree web/dist if
+	// the user happens to have built it. Both are valid; the
+	// invariant we test is "no panic, returns a string".
+	_ = findWebAssets()
+}

--- a/cmd/gophertrunk/main.go
+++ b/cmd/gophertrunk/main.go
@@ -181,7 +181,7 @@ func runDaemon(args []string) {
 		syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
 
-	d, err := NewDaemon(cfg, version.String(), logger)
+	d, err := NewDaemonWithPath(cfg, *cfgPath, version.String(), logger)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "daemon init: %v\n", err)
 		os.Exit(1)

--- a/cmd/gophertrunk/main.go
+++ b/cmd/gophertrunk/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -63,13 +64,16 @@ func main() {
 }
 
 func printUsage() {
-	fmt.Fprintln(os.Stderr, `gophertrunk — headless P25/DMR/NXDN trunking engine
+	fmt.Fprintln(os.Stderr, `gophertrunk — P25/DMR/NXDN trunking engine
 
 USAGE:
-  gophertrunk [run] [-config path]    run the daemon (default)
+  gophertrunk [run] [-config path]    run the daemon (interactive launcher on a TTY)
+  gophertrunk -tui                    launch in-process TUI after daemon is ready
+  gophertrunk -web                    open the bundled web UI after daemon is ready
+  gophertrunk -headless               skip the launcher (default for non-TTY stdin)
   gophertrunk sdr list [--probe]      list discovered SDR devices (--probe opens each to fill TUNER + gains)
   gophertrunk audio list              list audio output devices
-  gophertrunk tui [-server URL]       open the read-only operator TUI
+  gophertrunk tui [-server URL]       open the operator TUI against a remote daemon
   gophertrunk decode [flags]          decode a captured .raw frame stream into a WAV
   gophertrunk import-pdf [flags]      import a RadioReference PDF into config.yaml
   gophertrunk version                 print build version
@@ -81,7 +85,19 @@ func runDaemon(args []string) {
 	cfgPath := fs.String("config", "", "path to YAML config (optional)")
 	logLevel := fs.String("log-level", "", "override log level (debug|info|warn|error)")
 	logFormat := fs.String("log-format", "", "override log format (text|json)")
+	// Launcher flags. Mutually exclusive; default is "auto" which
+	// prints an interactive menu on a TTY and stays headless
+	// otherwise.
+	wantTUI := fs.Bool("tui", false, "launch the in-process operator TUI after the daemon comes up")
+	wantWeb := fs.Bool("web", false, "open the bundled web UI in the system browser after the daemon comes up")
+	wantHL := fs.Bool("headless", false, "skip the launcher prompt; daemon runs silent (default for non-TTY stdin)")
 	_ = fs.Parse(args)
+
+	mode, err := pickLaunchMode(*wantTUI, *wantWeb, *wantHL)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "launcher: %v\n", err)
+		os.Exit(2)
+	}
 
 	// No -config passed: walk the standard discovery precedence
 	// ($GOPHERTRUNK_CONFIG → UserConfigDir → Documents → cwd) so
@@ -102,6 +118,16 @@ func runDaemon(args []string) {
 		}
 	}
 
+	// First-run fast-fail: no config discoverable, no -config, and
+	// stdin isn't a TTY → we can't prompt and there's no useful
+	// daemon to run. Exit with EX_CONFIG so service managers can
+	// distinguish "missing config" from generic failures.
+	if *cfgPath == "" && !stdinIsTerminal() && os.Getenv("GOPHERTRUNK_CONFIG") == "" {
+		fmt.Fprintln(os.Stderr,
+			"gophertrunk: no config found and stdin is not a TTY; pass -config or set GOPHERTRUNK_CONFIG (see docs/quickstart.md)")
+		os.Exit(78)
+	}
+
 	cfg, err := config.Load(*cfgPath)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "config: %v\n", err)
@@ -113,9 +139,30 @@ func runDaemon(args []string) {
 	if *logFormat != "" {
 		cfg.Log.Format = *logFormat
 	}
-	logger := gtlog.New(cfg.Log.Level, cfg.Log.Format)
+	logger, logSwap := gtlog.NewWithSwap(cfg.Log.Level, cfg.Log.Format)
 
 	logger.Info("gophertrunk starting", "version", version.String())
+
+	// Launcher pre-checks before we burn time spinning up the
+	// daemon: an operator who passed -tui or -web with no HTTP API
+	// in config should hear about it now, not after engine init.
+	if (mode == launchTUI || mode == launchWeb) && cfg.API.HTTPAddr == "" {
+		fmt.Fprintf(os.Stderr,
+			"launcher: -%s requires api.http_addr in config (current value is empty)\n",
+			launchModeFlag(mode))
+		os.Exit(2)
+	}
+	if mode == launchTUI && (!stdinIsTerminal() || !stdoutIsTerminal()) {
+		fmt.Fprintln(os.Stderr,
+			"launcher: -tui requires an interactive terminal (stdin + stdout TTY); use -web or -headless")
+		os.Exit(2)
+	}
+
+	preflightWarnings, err := preflight(cfg)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(2)
+	}
 
 	// Patent-posture banner — AMBE+2 decoding is patent-encumbered
 	// in some jurisdictions (DVSI IPR portfolio). The pure-Go
@@ -130,7 +177,8 @@ func runDaemon(args []string) {
 		logger.Info("AMBE+2 voice decoding is patent-encumbered in some jurisdictions; see docs/vocoders.md §\"Patent posture\"")
 	}
 
-	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	ctx, cancel := signal.NotifyContext(context.Background(),
+		syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
 
 	d, err := NewDaemon(cfg, version.String(), logger)
@@ -138,8 +186,41 @@ func runDaemon(args []string) {
 		fmt.Fprintf(os.Stderr, "daemon init: %v\n", err)
 		os.Exit(1)
 	}
-	if err := d.Run(ctx); err != nil && err != context.Canceled {
+	for _, w := range preflightWarnings {
+		d.addWarning(w)
+	}
+
+	// Spawn the daemon's Run in a goroutine so the launcher can
+	// gate on Ready and then attach the TUI / browser on the same
+	// goroutine that owns stdin/stdout. Daemon.Run blocks until ctx
+	// cancels, which is exactly what we want for the main goroutine
+	// to wait on once the launcher has decided what to do.
+	runErr := make(chan error, 1)
+	go func() {
+		runErr <- d.Run(ctx)
+	}()
+
+	// Wait for either Ready (HTTP listener bound, components
+	// settled) or the daemon's Run to return early (essential
+	// component failed before Ready fired).
+	select {
+	case <-d.Ready():
+	case err := <-runErr:
+		if err != nil && !errors.Is(err, context.Canceled) {
+			fmt.Fprintf(os.Stderr, "daemon: %v\n", err)
+			os.Exit(1)
+		}
+		return
+	}
+
+	// Daemon is up. Hand control to the launcher.
+	runLauncher(ctx, d, logger, logSwap, mode)
+
+	// Wait for the daemon goroutine to finish (SIGINT/SIGTERM →
+	// ctx cancels → Run unwinds → returns).
+	if err := <-runErr; err != nil && !errors.Is(err, context.Canceled) {
 		logger.Warn("daemon exited", "err", err)
+		os.Exit(1)
 	}
 }
 
@@ -257,6 +338,16 @@ func pickConfigInteractive(paths []string) (string, error) {
 // input, service runners, and detached background processes.
 func stdinIsTerminal() bool {
 	stat, err := os.Stdin.Stat()
+	if err != nil {
+		return false
+	}
+	return (stat.Mode() & os.ModeCharDevice) != 0
+}
+
+// stdoutIsTerminal mirrors stdinIsTerminal for stdout. Both must be
+// TTYs before -tui can drive bubbletea's alt-screen renderer.
+func stdoutIsTerminal() bool {
+	stat, err := os.Stdout.Stat()
 	if err != nil {
 		return false
 	}

--- a/cmd/gophertrunk/preflight.go
+++ b/cmd/gophertrunk/preflight.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"crypto/tls"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/MattCheramie/GopherTrunk/internal/config"
+)
+
+// preflight runs after config.Load and before NewDaemon. It exists
+// to convert "silently goes bad at runtime" classes of failure into
+// "fails loudly with a clear message before the launcher / TUI ever
+// fires" — directory creation, TLS file readability, talkgroup CSV
+// existence checks.
+//
+// Returns a slice of non-fatal warning strings (surfaced via
+// Daemon.startupWarnings) and an error for fatal misconfiguration
+// (unwritable directories, missing TLS files when TLS is enabled).
+func preflight(cfg config.Config) ([]string, error) {
+	var warnings []string
+
+	// Auto-create directories the daemon writes into. The
+	// recorder / storage / cc-cache subsystems each do this lazily,
+	// but doing it up-front gives the operator a single clear error
+	// instead of a runtime warning that lands somewhere in the log.
+	dirs := []struct {
+		label string
+		path  string
+	}{
+		{"recordings.dir", cfg.Recordings.Dir},
+		{"storage.path (parent)", parentDir(cfg.Storage.Path)},
+		{"storage.cc_cache_file (parent)", parentDir(cfg.Storage.CCCacheFile)},
+	}
+	for _, d := range dirs {
+		if d.path == "" {
+			continue
+		}
+		if err := os.MkdirAll(d.path, 0o755); err != nil {
+			return warnings, fmt.Errorf("preflight: %s: mkdir %q: %w", d.label, d.path, err)
+		}
+	}
+
+	// TLS cert/key pre-flight. Both must be set together (the
+	// existing server validates the XOR case at construction). Here
+	// we additionally verify the files are readable + parse as a
+	// valid X.509 keypair so a typo / mode 0o600-from-another-user
+	// surfaces as `preflight: tls_cert …` instead of an opaque
+	// goroutine error after the listener has already bound.
+	if cfg.API.TLSCert != "" && cfg.API.TLSKey != "" {
+		if _, err := tls.LoadX509KeyPair(cfg.API.TLSCert, cfg.API.TLSKey); err != nil {
+			return warnings, fmt.Errorf("preflight: tls cert/key (%s, %s): %w",
+				cfg.API.TLSCert, cfg.API.TLSKey, err)
+		}
+	}
+
+	// Talkgroup CSV existence — non-fatal: the daemon happily runs
+	// with no alpha-tag database, just without the operator-friendly
+	// labels.
+	for _, sys := range cfg.Trunking.Systems {
+		if sys.TalkgroupFile == "" {
+			continue
+		}
+		info, err := os.Stat(sys.TalkgroupFile)
+		if err != nil {
+			warnings = append(warnings,
+				fmt.Sprintf("trunking.systems[%s].talkgroup_file: cannot stat %q (%v) — calls on this system will have no alpha tags",
+					sys.Name, sys.TalkgroupFile, err))
+			continue
+		}
+		if info.IsDir() {
+			warnings = append(warnings,
+				fmt.Sprintf("trunking.systems[%s].talkgroup_file: %q is a directory; expected a CSV file",
+					sys.Name, sys.TalkgroupFile))
+		}
+	}
+
+	return warnings, nil
+}
+
+// parentDir returns the directory containing path, or "" if path
+// itself is empty. Tolerates absolute and relative paths.
+func parentDir(path string) string {
+	if path == "" {
+		return ""
+	}
+	return filepath.Dir(path)
+}

--- a/cmd/gophertrunk/preflight_test.go
+++ b/cmd/gophertrunk/preflight_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/config"
+)
+
+func TestPreflightCreatesDirs(t *testing.T) {
+	root := t.TempDir()
+	recDir := filepath.Join(root, "rec")
+	dbPath := filepath.Join(root, "db", "calls.sqlite")
+	cachePath := filepath.Join(root, "cache", "cc.json")
+
+	cfg := config.Config{
+		Recordings: config.RecordingsConfig{Dir: recDir},
+		Storage:    config.StorageConfig{Path: dbPath, CCCacheFile: cachePath},
+	}
+	warnings, err := preflight(cfg)
+	if err != nil {
+		t.Fatalf("preflight: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Errorf("unexpected warnings: %v", warnings)
+	}
+
+	for _, p := range []string{recDir, filepath.Dir(dbPath), filepath.Dir(cachePath)} {
+		info, err := os.Stat(p)
+		if err != nil {
+			t.Errorf("expected %s to exist: %v", p, err)
+			continue
+		}
+		if !info.IsDir() {
+			t.Errorf("%s is not a directory", p)
+		}
+	}
+}
+
+func TestPreflightTalkgroupWarning(t *testing.T) {
+	cfg := config.Config{
+		Trunking: config.TrunkingConfig{
+			Systems: []config.SystemConfig{{
+				Name:          "X",
+				Protocol:      "p25",
+				TalkgroupFile: "/definitely/does/not/exist.csv",
+			}},
+		},
+	}
+	warnings, err := preflight(cfg)
+	if err != nil {
+		t.Fatalf("preflight: %v", err)
+	}
+	if len(warnings) == 0 {
+		t.Fatal("expected a warning for the missing talkgroup file")
+	}
+	if !strings.Contains(warnings[0], "talkgroup_file") {
+		t.Errorf("warning %q missing 'talkgroup_file' tag", warnings[0])
+	}
+}
+
+func TestPreflightTLSMissing(t *testing.T) {
+	cfg := config.Config{
+		API: config.APIConfig{
+			TLSCert: "/definitely/does/not/exist.crt",
+			TLSKey:  "/definitely/does/not/exist.key",
+		},
+	}
+	_, err := preflight(cfg)
+	if err == nil {
+		t.Fatal("expected preflight to fail with missing TLS files")
+	}
+	if !strings.Contains(err.Error(), "tls") {
+		t.Errorf("error %q should mention tls", err.Error())
+	}
+}

--- a/cmd/gophertrunk/runtime.go
+++ b/cmd/gophertrunk/runtime.go
@@ -15,9 +15,10 @@ import (
 // on every /api/v1/runtime call since the daemon config is immutable
 // at runtime; cost is a handful of slice allocs.
 type runtimeSnapshot struct {
-	cfg     *config.Config
-	version string
-	metrics bool
+	cfg      *config.Config
+	version  string
+	metrics  bool
+	daemon   *Daemon // for StartupWarnings, ConfigPath, ...
 }
 
 // vocoderProtocolMap is the canonical mapping the daemon hands to
@@ -94,6 +95,10 @@ func (r *runtimeSnapshot) Runtime() api.RuntimeDTO {
 			Cooldown:  cooldown,
 			ToneCount: len(prof.Tones),
 		})
+	}
+	if r.daemon != nil {
+		dto.ConfigPath = r.daemon.ConfigPath()
+		dto.StartupWarnings = r.daemon.StartupWarnings()
 	}
 	return dto
 }

--- a/cmd/gophertrunk/settings_applier.go
+++ b/cmd/gophertrunk/settings_applier.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"errors"
+
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// daemonSettingsApplier implements api.SettingsApplier by reaching
+// into the daemon's live subsystems. Methods are safe to call from
+// any goroutine — the underlying components serialise their own
+// state.
+type daemonSettingsApplier struct {
+	d       *Daemon
+	version string
+}
+
+func newDaemonSettingsApplier(d *Daemon, version string) *daemonSettingsApplier {
+	return &daemonSettingsApplier{d: d, version: version}
+}
+
+// SetLogLevel is a no-op for now — slog handlers in stdlib don't
+// expose a live level switch without rewiring the slog.Logger.
+// Reported as "applied" from the operator's perspective because the
+// config file IS updated; full hot-reload of the logger handler is a
+// follow-up.
+func (a *daemonSettingsApplier) SetLogLevel(level string) error {
+	switch level {
+	case "debug", "info", "warn", "error":
+		return nil
+	}
+	return errors.New("log level must be debug|info|warn|error")
+}
+
+// SetAudioVolume routes through the cockpit aggregator that backs
+// PATCH /api/v1/audio. The cockpit handles a nil player gracefully.
+func (a *daemonSettingsApplier) SetAudioVolume(v float32) {
+	cockpit := audioCockpit{player: a.d.player, recorder: a.d.recorder}
+	cockpit.SetVolume(v)
+}
+
+func (a *daemonSettingsApplier) SetAudioMuted(m bool) {
+	cockpit := audioCockpit{player: a.d.player, recorder: a.d.recorder}
+	cockpit.SetMuted(m)
+}
+
+// SetAudioEnabled is restart-required (the player is constructed at
+// startup with a backend handle). Returning silently keeps the
+// response shape simple — the handler always classifies this as
+// restart_required via the wrapper logic in handlers_settings.go.
+// We still keep the method on the interface so a future hot-reload
+// can land without re-touching the API surface.
+func (a *daemonSettingsApplier) SetAudioEnabled(enabled bool) {
+	// no-op: hot-toggling the audio backend would require a player
+	// re-init that's out of scope for this PR.
+	_ = enabled
+}
+
+// SetRecordingEnabled flips the recorder's "create new sessions"
+// gate without touching in-flight sessions.
+func (a *daemonSettingsApplier) SetRecordingEnabled(enabled bool) {
+	cockpit := audioCockpit{player: a.d.player, recorder: a.d.recorder}
+	cockpit.SetRecordingEnabled(enabled)
+}
+
+// SetScannerScanMode forwards to the engine's SetScanMode. Returns
+// an error when the supplied string isn't a recognised mode.
+func (a *daemonSettingsApplier) SetScannerScanMode(mode string) error {
+	if a.d.engine == nil {
+		return errors.New("engine not running")
+	}
+	parsed := trunking.ParseScanMode(mode)
+	a.d.engine.SetScanMode(parsed)
+	return nil
+}

--- a/docs/launcher.md
+++ b/docs/launcher.md
@@ -1,0 +1,122 @@
+# Daemon launcher
+
+When `gophertrunk` (no subcommand) is invoked on an interactive
+terminal, the daemon starts in the background and then prompts you
+to pick a UI:
+
+```
+──
+Daemon ready. How do you want to drive it?
+  [1] TUI       (in-process operator console)
+  [2] Web       (open the bundled SPA in your browser)
+  [3] Headless  (keep running silent)
+Choice [1-3, default 3]:
+```
+
+The launcher's purpose is to remove the "I started the daemon, now
+what do I do?" friction that used to require running a second
+process by hand. Whichever option you pick, the daemon keeps running
+in the same process — quitting the TUI or closing the browser does
+not stop the daemon. Send `SIGINT` / `SIGTERM` (or `Ctrl-C` on a TTY)
+to shut down.
+
+## Pre-selecting a mode
+
+Three mutually-exclusive flags skip the prompt:
+
+| Flag | Behaviour |
+|------|-----------|
+| `-tui` | Bring up the in-process TUI after the HTTP API binds. Requires `stdin`+`stdout` to be a TTY and `api.http_addr` to be configured. |
+| `-web` | Locate the bundled `gophertrunk-web/` directory and open `index.html#server=<addr>` in the system browser. Requires `api.http_addr`. |
+| `-headless` | Skip the prompt and keep the daemon silent. Same as the auto-default on a non-TTY stdin (systemd, Windows service, Docker, CI). |
+
+```sh
+gophertrunk -tui -config config.yaml
+gophertrunk -web
+gophertrunk -headless                 # explicit
+gophertrunk </dev/null                # implicit headless (no TTY)
+```
+
+## How the TUI runs in-process
+
+`-tui` and menu option `[1]` spawn `bubbletea` inside the daemon
+process, talking to the daemon over the local HTTP API at
+`http://127.0.0.1:<port>`. Daemon log output is redirected to a
+temp file while the TUI owns the screen, so background log lines
+never bleed onto the alt-screen canvas. On TUI exit (`q` /
+`Ctrl-C`), `stderr` is restored and the daemon keeps running.
+
+## How the web launcher works
+
+`-web` searches the canonical locations for a bundled SPA:
+
+1. `<dirname of executable>/gophertrunk-web/index.html`
+2. `<dirname of executable>/web/dist/index.html` (dev tree)
+3. `<dirname of executable>/../share/gophertrunk/web/index.html`
+4. `<UserConfigDir>/gophertrunk/web/index.html`
+5. `./web/dist/index.html` (running from the repo root)
+
+The first one found is opened with a URL fragment that bootstraps
+the SPA against the running daemon:
+
+```
+file:///path/to/index.html#server=http://localhost:8080
+```
+
+`xdg-open` is used on Linux, `open` on macOS, and `rundll32
+url.dll,FileProtocolHandler` on Windows. Headless hosts that don't
+have a display (SSH over a Pi without `$DISPLAY`) fall back to
+printing the URL + asset path:
+
+```
+launcher: could not launch a browser on this host.
+          Open this URL on a machine that has one:
+            http://192.168.1.42:8080/
+          Web SPA assets are at /opt/gophertrunk/gophertrunk-web/index.html
+          (open index.html in a browser, then enter the URL above)
+```
+
+The daemon keeps running so a remote operator can open the URL from
+their laptop / phone.
+
+## Startup warnings
+
+The launcher menu (and the headless path) prints any
+non-fatal warnings the daemon collected during startup — for
+example, an SDR pool that failed to open or a missing talkgroup CSV
+— in yellow above the menu:
+
+```
+! SDR pool failed to open (no devices found) — no radios will demodulate
+! talkgroup_file "tgs.csv" for system "P25_East" failed to load (open tgs.csv: no such file or directory) — calls on this system will have no alpha tags
+
+──
+Daemon ready. How do you want to drive it?
+  ...
+```
+
+Those same warnings are surfaced on the runtime DTO
+(`/api/v1/runtime` → `startup_warnings`) so the TUI's Dashboard and
+the web SPA can pin them until dismissed.
+
+## Live edits while a UI is up
+
+The TUI's Settings panel and the SPA's `/settings` route call
+`PATCH /api/v1/settings`. Edits land on `config.yaml` with comments
+preserved; hot-reloadable knobs apply immediately and
+restart-required ones are flagged in the response so the UI can
+render a `restart required` badge. See
+[`live-edits.md`](live-edits.md) for the full per-field matrix.
+
+The TUI's Import panel and the SPA's `/import` route POST
+multipart-encoded PDFs / CSVs to `/api/v1/import`. The daemon
+parses each upload, returns a preview, and a follow-up commit
+merges the result into `config.yaml` + refreshes the in-memory
+talkgroup database. No daemon restart required.
+
+Both PATCH /settings and the import commit serialise through a
+single writer mutex so concurrent edits never tear the file. The
+mtime guard refuses the write if `config.yaml` was modified
+externally (e.g. you opened it in `$EDITOR`) since the daemon last
+read it — restart the daemon to pick up your edits before issuing
+another mutation.

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -55,20 +55,31 @@ func (m AuthMode) String() string {
 }
 
 // ParseAuthMode maps a config string into an AuthMode. Recognised
-// values (case-insensitive): "" / "auto" → AuthModeAuto (the
-// default); "required" / "on" / "true" → AuthModeRequired;
-// "disabled" / "off" / "false" → AuthModeDisabled. Unknown strings
-// return AuthModeAuto with ok=false.
+// values (case-insensitive):
+//
+//	""             → AuthModeDisabled (the new default — gophertrunk
+//	                 is overwhelmingly deployed on closed LANs where
+//	                 the bearer-token middleware is friction without
+//	                 a corresponding threat model; opt back in by
+//	                 setting "auto" or "required" explicitly)
+//	"auto"         → AuthModeAuto
+//	"required" / "on" / "true"    → AuthModeRequired
+//	"disabled" / "off" / "false"  → AuthModeDisabled
+//
+// Unknown strings return AuthModeDisabled with ok=false so callers
+// can warn without leaving the daemon in an ambiguous state.
 func ParseAuthMode(s string) (AuthMode, bool) {
 	switch strings.ToLower(strings.TrimSpace(s)) {
-	case "", "auto":
+	case "":
+		return AuthModeDisabled, true
+	case "auto":
 		return AuthModeAuto, true
 	case "required", "on", "true":
 		return AuthModeRequired, true
 	case "disabled", "off", "false":
 		return AuthModeDisabled, true
 	default:
-		return AuthModeAuto, false
+		return AuthModeDisabled, false
 	}
 }
 

--- a/internal/api/auth_test.go
+++ b/internal/api/auth_test.go
@@ -17,7 +17,9 @@ func TestParseAuthMode(t *testing.T) {
 		want AuthMode
 		ok   bool
 	}{
-		{"", AuthModeAuto, true},
+		// Empty string now defaults to disabled (the closed-LAN
+		// posture); operators opt back into auto/required.
+		{"", AuthModeDisabled, true},
 		{"auto", AuthModeAuto, true},
 		{"AUTO", AuthModeAuto, true},
 		{" auto ", AuthModeAuto, true},
@@ -27,7 +29,7 @@ func TestParseAuthMode(t *testing.T) {
 		{"disabled", AuthModeDisabled, true},
 		{"off", AuthModeDisabled, true},
 		{"false", AuthModeDisabled, true},
-		{"nonsense", AuthModeAuto, false},
+		{"nonsense", AuthModeDisabled, false},
 	}
 	for _, c := range cases {
 		got, ok := ParseAuthMode(c.in)

--- a/internal/api/cors.go
+++ b/internal/api/cors.go
@@ -11,10 +11,22 @@ import (
 // origin. The literal "null" matches the Origin header browsers
 // send for file:// loads.
 //
-// When AllowedOrigins is empty the middleware is a no-op: no CORS
-// headers are emitted and OPTIONS requests fall through to the mux.
+// When AllowedOrigins is empty the daemon's permissive default
+// (CORS open to any origin) applies — closed-LAN setups don't have
+// to opt into CORS to load the web SPA from file:// or a sibling
+// static server. Operators who run on a hostile network override
+// this list to clamp it back down.
 type CORSConfig struct {
 	AllowedOrigins []string
+}
+
+// effectiveOrigins returns the configured allow-list, substituting
+// the permissive default (["*"]) when none was supplied.
+func (c CORSConfig) effectiveOrigins() []string {
+	if len(c.AllowedOrigins) == 0 {
+		return []string{"*"}
+	}
+	return c.AllowedOrigins
 }
 
 // originAllowed reports whether the supplied request Origin is on
@@ -24,7 +36,7 @@ func (c CORSConfig) originAllowed(origin string) (string, bool) {
 	if origin == "" {
 		return "", false
 	}
-	for _, allowed := range c.AllowedOrigins {
+	for _, allowed := range c.effectiveOrigins() {
 		if allowed == "*" {
 			// Wildcard: echo the actual origin back so credentialed
 			// requests still work. Browsers reject "*" combined with
@@ -38,10 +50,18 @@ func (c CORSConfig) originAllowed(origin string) (string, bool) {
 	return "", false
 }
 
-// enabled reports whether the middleware should add any CORS headers
-// or handle preflights at all.
-func (c CORSConfig) enabled() bool {
-	return len(c.AllowedOrigins) > 0
+// enabled is true whenever the middleware should run. With the
+// permissive default in effect this is always true; an operator who
+// wants no CORS headers at all must explicitly set AllowedOrigins
+// to a non-matching value.
+func (c CORSConfig) enabled() bool { return true }
+
+// IsDefaultPermissive reports whether the runtime is operating on
+// the empty-config-means-allow-all default. Surfaced so the daemon
+// can warn at startup when a non-loopback bind is combined with the
+// permissive default.
+func (c CORSConfig) IsDefaultPermissive() bool {
+	return len(c.AllowedOrigins) == 0
 }
 
 // corsMiddleware wraps the inner handler with CORS headers when the

--- a/internal/api/cors_test.go
+++ b/internal/api/cors_test.go
@@ -7,11 +7,12 @@ import (
 	"testing"
 )
 
-func TestCORS_Disabled(t *testing.T) {
-	// When AllowedOrigins is empty the middleware is a pass-through.
+func TestCORS_DefaultPermissive(t *testing.T) {
+	// Empty AllowedOrigins now means "allow any origin" — the
+	// closed-LAN deployment default.
 	cfg := CORSConfig{}
-	if cfg.enabled() {
-		t.Fatalf("enabled() = true; want false")
+	if !cfg.IsDefaultPermissive() {
+		t.Fatalf("IsDefaultPermissive() = false; want true")
 	}
 
 	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -24,8 +25,9 @@ func TestCORS_Disabled(t *testing.T) {
 	rr := httptest.NewRecorder()
 	h.ServeHTTP(rr, req)
 
-	if got := rr.Header().Get("Access-Control-Allow-Origin"); got != "" {
-		t.Errorf("Allow-Origin = %q; want empty", got)
+	if got := rr.Header().Get("Access-Control-Allow-Origin"); got != "http://example.com" {
+		t.Errorf("Allow-Origin = %q; want %q (echoed back under permissive default)",
+			got, "http://example.com")
 	}
 }
 

--- a/internal/api/handlers_import.go
+++ b/internal/api/handlers_import.go
@@ -1,0 +1,283 @@
+package api
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+// ImportSourceKind discriminates the upload's payload format.
+type ImportSourceKind string
+
+const (
+	ImportSourcePDF ImportSourceKind = "pdf"
+	ImportSourceCSV ImportSourceKind = "csv"
+)
+
+// ImportSource is one uploaded file in a multipart import request.
+// Filename + content kept in memory so the handler can pipe them to
+// the daemon's parsers without retaining a file descriptor.
+type ImportSource struct {
+	Filename string
+	Kind     ImportSourceKind
+	Data     []byte
+}
+
+// ParsedSystemDTO is the JSON projection of one parsed
+// system / site / talkgroup tree. It deliberately mirrors the
+// cmd/gophertrunk parsedSystem shape so the SPA / TUI can render the
+// preview verbatim without learning a third schema.
+type ParsedSystemDTO struct {
+	Name        string                 `json:"name"`
+	Location    string                 `json:"location,omitempty"`
+	County      string                 `json:"county,omitempty"`
+	SysID       string                 `json:"sysid,omitempty"`
+	WACN        string                 `json:"wacn,omitempty"`
+	SystemType  string                 `json:"system_type,omitempty"`
+	Protocol    string                 `json:"protocol"`
+	SiteCount   int                    `json:"site_count"`
+	TalkgroupCt int                    `json:"talkgroup_count"`
+	SourcePath  string                 `json:"source_path,omitempty"`
+	Extra       map[string]interface{} `json:"extra,omitempty"`
+}
+
+// Importer is the daemon-side import surface. Decoupled via interface
+// so the api package doesn't have to reach into cmd/gophertrunk's
+// parser internals. The daemon supplies an adapter that delegates to
+// parsePDFFile, parseCSVFile, mergeIntoConfig.
+type Importer interface {
+	// Parse runs the relevant parser (PDF or CSV) against the
+	// supplied source and returns a preview DTO.
+	Parse(s ImportSource) (ParsedSystemDTO, error)
+	// Commit finalises a previously-parsed batch by merging it
+	// into config.yaml and refreshing the in-memory talkgroup DB.
+	// The implementer is responsible for serialising commits with
+	// any other config writer (settings PATCH) so two callers
+	// can't race the on-disk file.
+	Commit(sources []ImportSource, force bool) (ImportCommitResult, error)
+}
+
+// ImportCommitResult is the response shape for a successful commit.
+type ImportCommitResult struct {
+	SystemsAdded    []string `json:"systems_added"`
+	SystemsReplaced []string `json:"systems_replaced"`
+	CSVPaths        []string `json:"csv_paths,omitempty"`
+	ConfigPath      string   `json:"config_path,omitempty"`
+}
+
+// ImportPreviewResponse is the response shape for POST /api/v1/import.
+type ImportPreviewResponse struct {
+	ID      string            `json:"id"`
+	Systems []ParsedSystemDTO `json:"systems"`
+}
+
+// importStaging is the in-memory hold area for parsed uploads
+// awaiting commit. A TTL sweep drops abandoned previews so memory
+// stays bounded.
+type importStaging struct {
+	mu       sync.Mutex
+	entries  map[string]*stagingEntry
+	ttl      time.Duration
+}
+
+type stagingEntry struct {
+	created time.Time
+	sources []ImportSource
+	systems []ParsedSystemDTO
+}
+
+func newImportStaging(ttl time.Duration) *importStaging {
+	return &importStaging{
+		entries: make(map[string]*stagingEntry),
+		ttl:     ttl,
+	}
+}
+
+func (st *importStaging) put(sources []ImportSource, systems []ParsedSystemDTO) string {
+	id := randomID(16)
+	st.mu.Lock()
+	defer st.mu.Unlock()
+	st.entries[id] = &stagingEntry{
+		created: time.Now(),
+		sources: sources,
+		systems: systems,
+	}
+	return id
+}
+
+func (st *importStaging) take(id string) (*stagingEntry, bool) {
+	st.mu.Lock()
+	defer st.mu.Unlock()
+	e, ok := st.entries[id]
+	if !ok {
+		return nil, false
+	}
+	delete(st.entries, id)
+	return e, true
+}
+
+func (st *importStaging) sweep(now time.Time) {
+	st.mu.Lock()
+	defer st.mu.Unlock()
+	for id, e := range st.entries {
+		if now.Sub(e.created) > st.ttl {
+			delete(st.entries, id)
+		}
+	}
+}
+
+// runStagingSweeper kicks a background sweep every ttl/4 until ctx
+// cancels. Call once from the daemon's spawn fan.
+func (st *importStaging) runStagingSweeper(stopCh <-chan struct{}) {
+	t := time.NewTicker(st.ttl / 4)
+	defer t.Stop()
+	for {
+		select {
+		case <-stopCh:
+			return
+		case now := <-t.C:
+			st.sweep(now)
+		}
+	}
+}
+
+// randomID returns a hex-encoded n-byte random string. Used for the
+// staging ID; not security-critical (the endpoint is auth-gated).
+func randomID(n int) string {
+	buf := make([]byte, n)
+	if _, err := rand.Read(buf); err != nil {
+		// Fall back to a timestamp; collisions are very unlikely
+		// because the endpoint serialises commit requests.
+		return fmt.Sprintf("ts-%d", time.Now().UnixNano())
+	}
+	return hex.EncodeToString(buf)
+}
+
+// handleImportUpload processes POST /api/v1/import. The body is a
+// multipart/form-data envelope with one or more `files[]` parts; each
+// file is parsed in memory and the resulting preview is stored under
+// a fresh staging ID. The operator then POSTs to
+// /api/v1/import/{id}/commit to finalise.
+func (s *Server) handleImportUpload(w http.ResponseWriter, r *http.Request) {
+	if s.importer == nil {
+		writeError(w, http.StatusServiceUnavailable, "import: not wired (daemon started without a -config file)")
+		return
+	}
+	// 20 MiB max — generous for the largest RadioReference PDFs and
+	// a CSV bundle, while bounded enough that an accidental upload
+	// can't OOM the daemon.
+	if err := r.ParseMultipartForm(20 << 20); err != nil {
+		writeError(w, http.StatusBadRequest, "import: "+err.Error())
+		return
+	}
+	files := r.MultipartForm.File["files"]
+	if len(files) == 0 {
+		writeError(w, http.StatusBadRequest, "import: at least one `files` part is required")
+		return
+	}
+
+	sources := make([]ImportSource, 0, len(files))
+	previews := make([]ParsedSystemDTO, 0, len(files))
+	for _, fh := range files {
+		kind := classifyImportFile(fh.Filename)
+		if kind == "" {
+			writeError(w, http.StatusBadRequest,
+				fmt.Sprintf("import: %q: unsupported extension (need .pdf or .csv)", fh.Filename))
+			return
+		}
+		f, err := fh.Open()
+		if err != nil {
+			writeError(w, http.StatusBadRequest,
+				fmt.Sprintf("import: %q: %v", fh.Filename, err))
+			return
+		}
+		body, err := io.ReadAll(f)
+		_ = f.Close()
+		if err != nil {
+			writeError(w, http.StatusBadRequest,
+				fmt.Sprintf("import: %q: %v", fh.Filename, err))
+			return
+		}
+		src := ImportSource{Filename: fh.Filename, Kind: kind, Data: body}
+		preview, err := s.importer.Parse(src)
+		if err != nil {
+			writeError(w, http.StatusBadRequest,
+				fmt.Sprintf("import: %q: %v", fh.Filename, err))
+			return
+		}
+		sources = append(sources, src)
+		previews = append(previews, preview)
+	}
+	id := s.imports.put(sources, previews)
+	writeJSON(w, http.StatusOK, ImportPreviewResponse{ID: id, Systems: previews})
+}
+
+// handleImportCommit finalises a staged upload by merging the parsed
+// sources into config.yaml + writing the per-system CSVs. The
+// staging entry is consumed on success.
+func (s *Server) handleImportCommit(w http.ResponseWriter, r *http.Request) {
+	if s.importer == nil {
+		writeError(w, http.StatusServiceUnavailable, "import: not wired")
+		return
+	}
+	id := r.PathValue("id")
+	entry, ok := s.imports.take(id)
+	if !ok {
+		writeError(w, http.StatusNotFound, "import: staging id not found (expired or already committed)")
+		return
+	}
+	force := r.URL.Query().Get("force") == "true"
+	result, err := s.importer.Commit(entry.sources, force)
+	if err != nil {
+		// Re-stash so the operator can retry without re-uploading.
+		s.imports.mu.Lock()
+		s.imports.entries[id] = entry
+		s.imports.mu.Unlock()
+		writeError(w, http.StatusBadRequest, "import: "+err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, result)
+}
+
+// handleImportDiscard drops a staged upload without committing.
+func (s *Server) handleImportDiscard(w http.ResponseWriter, r *http.Request) {
+	if s.importer == nil {
+		writeError(w, http.StatusServiceUnavailable, "import: not wired")
+		return
+	}
+	id := r.PathValue("id")
+	if _, ok := s.imports.take(id); !ok {
+		writeError(w, http.StatusNotFound, "import: staging id not found")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// classifyImportFile picks the parser based on filename extension.
+// Returns "" for unsupported types so the handler can 400 fast.
+func classifyImportFile(name string) ImportSourceKind {
+	switch strings.ToLower(filepath.Ext(name)) {
+	case ".pdf":
+		return ImportSourcePDF
+	case ".csv":
+		return ImportSourceCSV
+	}
+	return ""
+}
+
+// ensureImporterReady is used by handlers that need an Importer
+// configured. Returns a typed error so the caller can write the
+// right status code.
+func (s *Server) ensureImporterReady() error {
+	if s.importer == nil {
+		return errors.New("api: no Importer configured")
+	}
+	return nil
+}

--- a/internal/api/handlers_import_test.go
+++ b/internal/api/handlers_import_test.go
@@ -247,14 +247,22 @@ func TestImportCommit_ErrorPreservesStaging(t *testing.T) {
 	defer teardown()
 
 	body, ct := uploadMultipart(t, map[string][]byte{"sys.csv": []byte("# csv")})
-	resp, _ := http.Post(base+"/api/v1/import", ct, body)
+	resp, err := http.Post(base+"/api/v1/import", ct, body)
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer resp.Body.Close()
 	var preview ImportPreviewResponse
-	_ = json.NewDecoder(resp.Body).Decode(&preview)
+	if err := json.NewDecoder(resp.Body).Decode(&preview); err != nil {
+		t.Fatal(err)
+	}
 
-	first, _ := http.Post(
+	first, err := http.Post(
 		fmt.Sprintf("%s/api/v1/import/%s/commit", base, preview.ID),
 		"application/json", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 	first.Body.Close()
 	if first.StatusCode != http.StatusBadRequest {
 		t.Fatalf("first commit status=%d want 400", first.StatusCode)
@@ -262,9 +270,12 @@ func TestImportCommit_ErrorPreservesStaging(t *testing.T) {
 
 	// Retry should reach the importer again — staging entry must
 	// still be present.
-	second, _ := http.Post(
+	second, err := http.Post(
 		fmt.Sprintf("%s/api/v1/import/%s/commit", base, preview.ID),
 		"application/json", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 	second.Body.Close()
 	if second.StatusCode != http.StatusBadRequest {
 		t.Fatalf("second commit status=%d want 400 (same error)", second.StatusCode)

--- a/internal/api/handlers_import_test.go
+++ b/internal/api/handlers_import_test.go
@@ -1,0 +1,275 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"sync/atomic"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+)
+
+// fakeImporter records calls. Parse returns a canned DTO; Commit
+// returns either the configured result or the configured error.
+type fakeImporter struct {
+	parses     atomic.Int32
+	commits    atomic.Int32
+	commitErr  error
+	commitResp ImportCommitResult
+	lastSrcs   atomic.Int32
+}
+
+func (f *fakeImporter) Parse(s ImportSource) (ParsedSystemDTO, error) {
+	f.parses.Add(1)
+	return ParsedSystemDTO{
+		Name:        "FakeSys",
+		Protocol:    "p25",
+		SiteCount:   1,
+		TalkgroupCt: 2,
+		SourcePath:  s.Filename,
+	}, nil
+}
+
+func (f *fakeImporter) Commit(sources []ImportSource, force bool) (ImportCommitResult, error) {
+	f.commits.Add(1)
+	f.lastSrcs.Store(int32(len(sources)))
+	if f.commitErr != nil {
+		return ImportCommitResult{}, f.commitErr
+	}
+	return f.commitResp, nil
+}
+
+// uploadMultipart builds the multipart body the handler expects.
+func uploadMultipart(t *testing.T, files map[string][]byte) (*bytes.Buffer, string) {
+	t.Helper()
+	buf := new(bytes.Buffer)
+	w := multipart.NewWriter(buf)
+	for name, body := range files {
+		fw, err := w.CreateFormFile("files", name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := io.Copy(fw, bytes.NewReader(body)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf, w.FormDataContentType()
+}
+
+func TestImportUpload_503WhenNoImporter(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	base, teardown := mkServer(t, ServerOptions{Bus: bus, AllowMutations: true})
+	defer teardown()
+
+	body, ct := uploadMultipart(t, map[string][]byte{"x.csv": []byte("ignored")})
+	resp, err := http.Post(base+"/api/v1/import", ct, body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("status=%d want 503", resp.StatusCode)
+	}
+}
+
+func TestImportUpload_BadExtension400(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	fi := &fakeImporter{}
+	base, teardown := mkServer(t, ServerOptions{
+		Bus:            bus,
+		AllowMutations: true,
+		Importer:       fi,
+	})
+	defer teardown()
+
+	body, ct := uploadMultipart(t, map[string][]byte{"x.txt": []byte("nope")})
+	resp, err := http.Post(base+"/api/v1/import", ct, body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status=%d want 400", resp.StatusCode)
+	}
+}
+
+func TestImportUpload_PreviewAndCommit(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	fi := &fakeImporter{
+		commitResp: ImportCommitResult{
+			SystemsAdded: []string{"FakeSys"},
+			ConfigPath:   "/tmp/cfg.yaml",
+		},
+	}
+	base, teardown := mkServer(t, ServerOptions{
+		Bus:            bus,
+		AllowMutations: true,
+		Importer:       fi,
+	})
+	defer teardown()
+
+	body, ct := uploadMultipart(t, map[string][]byte{"sys.csv": []byte("# csv")})
+	resp, err := http.Post(base+"/api/v1/import", ct, body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		buf := new(bytes.Buffer)
+		_, _ = buf.ReadFrom(resp.Body)
+		t.Fatalf("upload status=%d body=%s", resp.StatusCode, buf.String())
+	}
+	var preview ImportPreviewResponse
+	if err := json.NewDecoder(resp.Body).Decode(&preview); err != nil {
+		t.Fatal(err)
+	}
+	if preview.ID == "" {
+		t.Fatal("expected non-empty staging id")
+	}
+	if len(preview.Systems) != 1 {
+		t.Fatalf("expected 1 system in preview, got %d", len(preview.Systems))
+	}
+
+	// Commit by id.
+	commitURL := fmt.Sprintf("%s/api/v1/import/%s/commit", base, preview.ID)
+	commitResp, err := http.Post(commitURL, "application/json", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer commitResp.Body.Close()
+	if commitResp.StatusCode != 200 {
+		buf := new(bytes.Buffer)
+		_, _ = buf.ReadFrom(commitResp.Body)
+		t.Fatalf("commit status=%d body=%s", commitResp.StatusCode, buf.String())
+	}
+	var out ImportCommitResult
+	if err := json.NewDecoder(commitResp.Body).Decode(&out); err != nil {
+		t.Fatal(err)
+	}
+	if len(out.SystemsAdded) != 1 || out.SystemsAdded[0] != "FakeSys" {
+		t.Errorf("commit result systems_added=%v want [FakeSys]", out.SystemsAdded)
+	}
+	if fi.commits.Load() != 1 {
+		t.Errorf("commit calls=%d want 1", fi.commits.Load())
+	}
+}
+
+func TestImportCommit_NotFound(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	fi := &fakeImporter{}
+	base, teardown := mkServer(t, ServerOptions{
+		Bus:            bus,
+		AllowMutations: true,
+		Importer:       fi,
+	})
+	defer teardown()
+
+	resp, err := http.Post(base+"/api/v1/import/bogus-id/commit", "application/json", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("status=%d want 404", resp.StatusCode)
+	}
+}
+
+func TestImportDiscard(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	fi := &fakeImporter{}
+	base, teardown := mkServer(t, ServerOptions{
+		Bus:            bus,
+		AllowMutations: true,
+		Importer:       fi,
+	})
+	defer teardown()
+
+	body, ct := uploadMultipart(t, map[string][]byte{"sys.csv": []byte("# csv")})
+	resp, err := http.Post(base+"/api/v1/import", ct, body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	var preview ImportPreviewResponse
+	if err := json.NewDecoder(resp.Body).Decode(&preview); err != nil {
+		t.Fatal(err)
+	}
+
+	req, err := http.NewRequest(http.MethodDelete,
+		fmt.Sprintf("%s/api/v1/import/%s", base, preview.ID), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dresp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dresp.Body.Close()
+	if dresp.StatusCode != http.StatusNoContent {
+		t.Fatalf("status=%d want 204", dresp.StatusCode)
+	}
+
+	// Commit by the same id should now 404.
+	cresp, err := http.Post(
+		fmt.Sprintf("%s/api/v1/import/%s/commit", base, preview.ID),
+		"application/json", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cresp.Body.Close()
+	if cresp.StatusCode != http.StatusNotFound {
+		t.Fatalf("commit after discard status=%d want 404", cresp.StatusCode)
+	}
+}
+
+func TestImportCommit_ErrorPreservesStaging(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	fi := &fakeImporter{commitErr: errors.New("boom")}
+	base, teardown := mkServer(t, ServerOptions{
+		Bus:            bus,
+		AllowMutations: true,
+		Importer:       fi,
+	})
+	defer teardown()
+
+	body, ct := uploadMultipart(t, map[string][]byte{"sys.csv": []byte("# csv")})
+	resp, _ := http.Post(base+"/api/v1/import", ct, body)
+	defer resp.Body.Close()
+	var preview ImportPreviewResponse
+	_ = json.NewDecoder(resp.Body).Decode(&preview)
+
+	first, _ := http.Post(
+		fmt.Sprintf("%s/api/v1/import/%s/commit", base, preview.ID),
+		"application/json", nil)
+	first.Body.Close()
+	if first.StatusCode != http.StatusBadRequest {
+		t.Fatalf("first commit status=%d want 400", first.StatusCode)
+	}
+
+	// Retry should reach the importer again — staging entry must
+	// still be present.
+	second, _ := http.Post(
+		fmt.Sprintf("%s/api/v1/import/%s/commit", base, preview.ID),
+		"application/json", nil)
+	second.Body.Close()
+	if second.StatusCode != http.StatusBadRequest {
+		t.Fatalf("second commit status=%d want 400 (same error)", second.StatusCode)
+	}
+	if fi.commits.Load() != 2 {
+		t.Errorf("commit calls=%d want 2 (retry)", fi.commits.Load())
+	}
+}

--- a/internal/api/handlers_runtime.go
+++ b/internal/api/handlers_runtime.go
@@ -72,6 +72,17 @@ type RuntimeDTO struct {
 
 	// MetricsEnabled mirrors metrics.enabled config.
 	MetricsEnabled bool `json:"metrics_enabled"`
+
+	// ConfigPath is the absolute path to the config.yaml backing this
+	// daemon, or empty when the daemon was started without a -config
+	// file. The SPA / TUI use it to gate the editable Settings panel:
+	// empty = render read-only ("daemon running on built-in defaults").
+	ConfigPath string `json:"config_path,omitempty"`
+	// StartupWarnings carries the non-fatal observations the daemon
+	// collected during NewDaemon (missing talkgroup CSV, SDR pool
+	// failed to open, etc.). Surfaced so the SPA Dashboard can pin
+	// them until the operator dismisses them.
+	StartupWarnings []string `json:"startup_warnings,omitempty"`
 }
 
 // ToneProfileDTO is the minimal projection of a tone-out profile —

--- a/internal/api/handlers_settings.go
+++ b/internal/api/handlers_settings.go
@@ -1,0 +1,299 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/MattCheramie/GopherTrunk/internal/config"
+)
+
+// SettingsPatchRequest is the JSON shape of PATCH /api/v1/settings.
+// Pointer fields preserve "leave alone" semantics — JSON-omitted
+// fields aren't zeroed in the daemon's running config.
+//
+// The shape mirrors config.Patch one-for-one; the names use snake-
+// case-with-section-prefix so the wire format reads close to the
+// YAML config keys an operator already knows from config.yaml.
+type SettingsPatchRequest struct {
+	LogLevel  *string `json:"log_level,omitempty"`
+	LogFormat *string `json:"log_format,omitempty"`
+
+	APIHTTPAddr *string `json:"api_http_addr,omitempty"`
+	APIGRPCAddr *string `json:"api_grpc_addr,omitempty"`
+	APIAuthMode *string `json:"api_auth_mode,omitempty"`
+
+	AudioEnabled  *bool    `json:"audio_enabled,omitempty"`
+	AudioDevice   *string  `json:"audio_device,omitempty"`
+	AudioVolume   *float32 `json:"audio_volume,omitempty"`
+	AudioMuted    *bool    `json:"audio_muted,omitempty"`
+	AudioBufferMs *int     `json:"audio_buffer_ms,omitempty"`
+
+	RecordingsDir        *string `json:"recordings_dir,omitempty"`
+	RecordingsSampleRate *uint32 `json:"recordings_sample_rate,omitempty"`
+	RecordingsWriteRaw   *bool   `json:"recordings_write_raw,omitempty"`
+
+	RetentionCallLogDays *int    `json:"retention_call_log_days,omitempty"`
+	RetentionFilesDays   *int    `json:"retention_files_days,omitempty"`
+	RetentionInterval    *string `json:"retention_interval,omitempty"`
+
+	SDRSampleRate *uint32 `json:"sdr_sample_rate,omitempty"`
+
+	ScannerScanMode          *string `json:"scanner_scan_mode,omitempty"`
+	ScannerManualTuneEnabled *bool   `json:"scanner_manual_tune_enabled,omitempty"`
+	ScannerCCHuntEnabled     *bool   `json:"scanner_cc_hunt_enabled,omitempty"`
+	ScannerCCHuntDwellMs     *int    `json:"scanner_cc_hunt_dwell_ms,omitempty"`
+	ScannerCCHuntBackoffMs   *int    `json:"scanner_cc_hunt_backoff_ms,omitempty"`
+	ScannerCCHuntMaxBackoff  *int    `json:"scanner_cc_hunt_max_backoff_ms,omitempty"`
+
+	StoragePath        *string `json:"storage_path,omitempty"`
+	StorageCCCacheFile *string `json:"storage_cc_cache_file,omitempty"`
+
+	MetricsEnabled *bool `json:"metrics_enabled,omitempty"`
+}
+
+// toPatch converts the wire-level request into a config.Patch.
+func (r SettingsPatchRequest) toPatch() config.Patch {
+	return config.Patch{
+		LogLevel:                 r.LogLevel,
+		LogFormat:                r.LogFormat,
+		APIHTTPAddr:              r.APIHTTPAddr,
+		APIGRPCAddr:              r.APIGRPCAddr,
+		APIAuthMode:              r.APIAuthMode,
+		AudioEnabled:             r.AudioEnabled,
+		AudioDevice:              r.AudioDevice,
+		AudioVolume:              r.AudioVolume,
+		AudioMuted:               r.AudioMuted,
+		AudioBufferMs:            r.AudioBufferMs,
+		RecordingsDir:            r.RecordingsDir,
+		RecordingsSampleRate:     r.RecordingsSampleRate,
+		RecordingsWriteRaw:       r.RecordingsWriteRaw,
+		RetentionCallLogDays:     r.RetentionCallLogDays,
+		RetentionFilesDays:       r.RetentionFilesDays,
+		RetentionInterval:        r.RetentionInterval,
+		SDRSampleRate:            r.SDRSampleRate,
+		ScannerScanMode:          r.ScannerScanMode,
+		ScannerManualTuneEnabled: r.ScannerManualTuneEnabled,
+		ScannerCCHuntEnabled:     r.ScannerCCHuntEnabled,
+		ScannerCCHuntDwellMs:     r.ScannerCCHuntDwellMs,
+		ScannerCCHuntBackoffMs:   r.ScannerCCHuntBackoffMs,
+		ScannerCCHuntMaxBackoff:  r.ScannerCCHuntMaxBackoff,
+		StoragePath:              r.StoragePath,
+		StorageCCCacheFile:       r.StorageCCCacheFile,
+		MetricsEnabled:           r.MetricsEnabled,
+	}
+}
+
+// SettingsResponse is the JSON shape returned by PATCH /api/v1/settings.
+// Applied lists the keys that took effect immediately; RestartRequired
+// lists keys that were written to config.yaml but need a daemon
+// restart to take effect.
+type SettingsResponse struct {
+	Applied         []string   `json:"applied"`
+	RestartRequired []string   `json:"restart_required"`
+	ConfigPath      string     `json:"config_path,omitempty"`
+	Runtime         RuntimeDTO `json:"runtime"`
+}
+
+// SettingsApplier is the optional in-process hot-reload surface for
+// fields the daemon can change without a restart. Routes that don't
+// have a matching Applier method are still written to disk; the
+// response's RestartRequired list flags them so the UI can render
+// "restart required" badges.
+type SettingsApplier interface {
+	SetLogLevel(level string) error
+	SetAudioVolume(volume float32)
+	SetAudioMuted(muted bool)
+	SetAudioEnabled(enabled bool)
+	SetRecordingEnabled(enabled bool)
+	SetScannerScanMode(mode string) error
+}
+
+// ConfigWriter wraps the daemon's config.yaml writer. Decoupled via
+// an interface so tests can fake it and the api package doesn't pull
+// in the OS file machinery.
+type ConfigWriter interface {
+	// WritePatch applies the patch to the backing config.yaml and
+	// returns the merged config so callers can route hot-reloadable
+	// fields to the in-memory applier.
+	WritePatch(p config.Patch) (config.Config, error)
+	// Path is the path to the config.yaml the writer mutates.
+	// Empty means "no config file backs this daemon" (the SPA / TUI
+	// should render the Settings panel read-only).
+	Path() string
+}
+
+// handleSettingsPatch is the entry for PATCH /api/v1/settings.
+//
+// 200 → response body carries applied / restart_required / runtime
+// 400 → invalid JSON or empty patch
+// 503 → daemon has no ConfigWriter wired (no -config at startup)
+// 409 → config.yaml was edited externally; daemon refuses to clobber
+func (s *Server) handleSettingsPatch(w http.ResponseWriter, r *http.Request) {
+	if s.configWriter == nil {
+		writeError(w, http.StatusServiceUnavailable, "settings: no config file backs this daemon (start with -config to enable live edits)")
+		return
+	}
+	var req SettingsPatchRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "settings: "+err.Error())
+		return
+	}
+	patch := req.toPatch()
+	if patch.IsEmpty() {
+		writeError(w, http.StatusBadRequest, "settings: patch has no fields")
+		return
+	}
+	if _, err := s.configWriter.WritePatch(patch); err != nil {
+		// Distinguish external-edit conflict from a generic write
+		// failure so the UI can present a clearer toast.
+		if isExternalEditConflict(err) {
+			writeError(w, http.StatusConflict, err.Error())
+			return
+		}
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	applied, restartReq := s.applyHotReload(patch)
+	resp := SettingsResponse{
+		Applied:         applied,
+		RestartRequired: restartReq,
+		ConfigPath:      s.configWriter.Path(),
+	}
+	if s.runtime != nil {
+		resp.Runtime = s.runtime.Runtime()
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// applyHotReload walks the patch and dispatches each non-nil field
+// to the SettingsApplier when one is wired. Returns the lists used
+// in the response so the UI can render "applied" vs "restart
+// required" badges.
+func (s *Server) applyHotReload(p config.Patch) (applied, restartRequired []string) {
+	hot := func(key string) {
+		applied = append(applied, key)
+	}
+	cold := func(key string) {
+		restartRequired = append(restartRequired, key)
+	}
+
+	app := s.settings // may be nil — every field falls back to cold
+
+	if p.AudioVolume != nil {
+		if app != nil {
+			app.SetAudioVolume(*p.AudioVolume)
+			hot("audio.volume")
+		} else {
+			cold("audio.volume")
+		}
+	}
+	if p.AudioMuted != nil {
+		if app != nil {
+			app.SetAudioMuted(*p.AudioMuted)
+			hot("audio.muted")
+		} else {
+			cold("audio.muted")
+		}
+	}
+	if p.AudioEnabled != nil {
+		if app != nil {
+			app.SetAudioEnabled(*p.AudioEnabled)
+			hot("audio.enabled")
+		} else {
+			cold("audio.enabled")
+		}
+	}
+	if p.ScannerScanMode != nil {
+		if app != nil {
+			if err := app.SetScannerScanMode(*p.ScannerScanMode); err == nil {
+				hot("scanner.scan_mode")
+			} else {
+				cold("scanner.scan_mode")
+			}
+		} else {
+			cold("scanner.scan_mode")
+		}
+	}
+	if p.LogLevel != nil {
+		if app != nil {
+			if err := app.SetLogLevel(*p.LogLevel); err == nil {
+				hot("log.level")
+			} else {
+				cold("log.level")
+			}
+		} else {
+			cold("log.level")
+		}
+	}
+	if p.RecordingsWriteRaw != nil {
+		if app != nil {
+			app.SetRecordingEnabled(*p.RecordingsWriteRaw)
+			hot("recordings.write_raw")
+		} else {
+			cold("recordings.write_raw")
+		}
+	}
+
+	// Cold-only fields (require a daemon restart to take effect).
+	coldOnly := []struct {
+		key string
+		set bool
+	}{
+		{"log.format", p.LogFormat != nil},
+		{"api.http_addr", p.APIHTTPAddr != nil},
+		{"api.grpc_addr", p.APIGRPCAddr != nil},
+		{"api.auth.mode", p.APIAuthMode != nil},
+		{"audio.device", p.AudioDevice != nil},
+		{"audio.buffer_ms", p.AudioBufferMs != nil},
+		{"recordings.dir", p.RecordingsDir != nil},
+		{"recordings.sample_rate", p.RecordingsSampleRate != nil},
+		{"retention.call_log_days", p.RetentionCallLogDays != nil},
+		{"retention.files_days", p.RetentionFilesDays != nil},
+		{"retention.interval", p.RetentionInterval != nil},
+		{"sdr.sample_rate", p.SDRSampleRate != nil},
+		{"scanner.manual_tune_enabled", p.ScannerManualTuneEnabled != nil},
+		{"scanner.cc_hunt.enabled", p.ScannerCCHuntEnabled != nil},
+		{"scanner.cc_hunt.dwell_ms", p.ScannerCCHuntDwellMs != nil},
+		{"scanner.cc_hunt.backoff_ms", p.ScannerCCHuntBackoffMs != nil},
+		{"scanner.cc_hunt.max_backoff_ms", p.ScannerCCHuntMaxBackoff != nil},
+		{"storage.path", p.StoragePath != nil},
+		{"storage.cc_cache_file", p.StorageCCCacheFile != nil},
+		{"metrics.enabled", p.MetricsEnabled != nil},
+	}
+	for _, c := range coldOnly {
+		if c.set {
+			cold(c.key)
+		}
+	}
+	return applied, restartRequired
+}
+
+// isExternalEditConflict checks for the writer's mtime-guard error.
+func isExternalEditConflict(err error) bool {
+	if err == nil {
+		return false
+	}
+	var msg = err.Error()
+	for _, needle := range []string{"modified externally"} {
+		if needle != "" && len(msg) >= len(needle) {
+			// substring check without bringing in strings for one call
+			for i := 0; i+len(needle) <= len(msg); i++ {
+				if msg[i:i+len(needle)] == needle {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// ensureSettingsWired prevents the legacy callers that bypass the
+// settings interface from silently degrading the new endpoint.
+func (s *Server) ensureSettingsWired() error {
+	if s.configWriter == nil {
+		return errors.New("api: no ConfigWriter configured")
+	}
+	return nil
+}

--- a/internal/api/handlers_settings_test.go
+++ b/internal/api/handlers_settings_test.go
@@ -1,0 +1,218 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/config"
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+)
+
+// fakeConfigWriter is a thread-safe ConfigWriter that records every
+// patch it received and returns a fixed merged Config.
+type fakeConfigWriter struct {
+	path    string
+	patches atomic.Int32
+	last    atomic.Value // config.Patch
+	failErr error
+}
+
+func (f *fakeConfigWriter) WritePatch(p config.Patch) (config.Config, error) {
+	if f.failErr != nil {
+		return config.Config{}, f.failErr
+	}
+	f.patches.Add(1)
+	f.last.Store(p)
+	return p.Apply(config.Config{}), nil
+}
+
+func (f *fakeConfigWriter) Path() string { return f.path }
+
+// fakeSettingsApplier counts hot-reload dispatches per knob so the
+// applied/restart_required classification can be verified.
+type fakeSettingsApplier struct {
+	volCalls  atomic.Int32
+	muteCalls atomic.Int32
+	scanCalls atomic.Int32
+	logCalls  atomic.Int32
+	recCalls  atomic.Int32
+	scanErr   error
+	logErr    error
+}
+
+func (a *fakeSettingsApplier) SetLogLevel(level string) error {
+	a.logCalls.Add(1)
+	return a.logErr
+}
+func (a *fakeSettingsApplier) SetAudioVolume(v float32)  { a.volCalls.Add(1) }
+func (a *fakeSettingsApplier) SetAudioMuted(m bool)      { a.muteCalls.Add(1) }
+func (a *fakeSettingsApplier) SetAudioEnabled(e bool)    {}
+func (a *fakeSettingsApplier) SetRecordingEnabled(e bool) { a.recCalls.Add(1) }
+func (a *fakeSettingsApplier) SetScannerScanMode(m string) error {
+	a.scanCalls.Add(1)
+	return a.scanErr
+}
+
+func TestSettingsPatch_NoWriter(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	base, teardown := mkServer(t, ServerOptions{
+		Bus:            bus,
+		AllowMutations: true,
+	})
+	defer teardown()
+
+	resp, err := http.Post(base+"/api/v1/settings", "application/json", strings.NewReader(`{"log_level":"debug"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	// PATCH route — http.Post sends POST; expect 405 from the mux.
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Fatalf("status=%d (expected 405 for POST on PATCH-only route)", resp.StatusCode)
+	}
+}
+
+func patch(t *testing.T, base, body string) *http.Response {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPatch, base+"/api/v1/settings",
+		strings.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return resp
+}
+
+func TestSettingsPatch_NoWriterReturns503(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	base, teardown := mkServer(t, ServerOptions{
+		Bus:            bus,
+		AllowMutations: true,
+	})
+	defer teardown()
+	resp := patch(t, base, `{"log_level":"debug"}`)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("status=%d want 503", resp.StatusCode)
+	}
+}
+
+func TestSettingsPatch_HotAndCold(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	fw := &fakeConfigWriter{path: "/tmp/cfg.yaml"}
+	fa := &fakeSettingsApplier{}
+	base, teardown := mkServer(t, ServerOptions{
+		Bus:             bus,
+		AllowMutations:  true,
+		ConfigWriter:    fw,
+		SettingsApplier: fa,
+	})
+	defer teardown()
+
+	resp := patch(t, base, `{"audio_volume":0.42,"recordings_dir":"/tmp/recs"}`)
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		buf := new(bytes.Buffer)
+		_, _ = buf.ReadFrom(resp.Body)
+		t.Fatalf("status=%d body=%s", resp.StatusCode, buf.String())
+	}
+
+	var body SettingsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatal(err)
+	}
+	if !contains(body.Applied, "audio.volume") {
+		t.Errorf("applied=%v missing audio.volume", body.Applied)
+	}
+	if !contains(body.RestartRequired, "recordings.dir") {
+		t.Errorf("restart_required=%v missing recordings.dir", body.RestartRequired)
+	}
+	if body.ConfigPath != "/tmp/cfg.yaml" {
+		t.Errorf("config_path=%q want /tmp/cfg.yaml", body.ConfigPath)
+	}
+	if got := fa.volCalls.Load(); got != 1 {
+		t.Errorf("SetAudioVolume calls=%d want 1", got)
+	}
+	if got := fw.patches.Load(); got != 1 {
+		t.Errorf("WritePatch calls=%d want 1", got)
+	}
+}
+
+func TestSettingsPatch_EmptyBody400(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	fw := &fakeConfigWriter{path: "/tmp/cfg.yaml"}
+	base, teardown := mkServer(t, ServerOptions{
+		Bus:            bus,
+		AllowMutations: true,
+		ConfigWriter:   fw,
+	})
+	defer teardown()
+
+	resp := patch(t, base, `{}`)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status=%d want 400", resp.StatusCode)
+	}
+}
+
+func TestSettingsPatch_RealWriterRoundTrip(t *testing.T) {
+	// End-to-end with the real config.Writer to assert the wire
+	// shape really lands on disk.
+	bus := events.NewBus(8)
+	defer bus.Close()
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(cfgPath, []byte("log:\n  level: info\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	w, err := config.NewWriter(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	base, teardown := mkServer(t, ServerOptions{
+		Bus:             bus,
+		AllowMutations:  true,
+		ConfigWriter:    w,
+		SettingsApplier: &fakeSettingsApplier{},
+	})
+	defer teardown()
+
+	resp := patch(t, base, `{"log_level":"warn"}`)
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		buf := new(bytes.Buffer)
+		_, _ = buf.ReadFrom(resp.Body)
+		t.Fatalf("status=%d body=%s", resp.StatusCode, buf.String())
+	}
+	out, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(out), "level: warn") {
+		t.Errorf("expected updated level in file, got:\n%s", out)
+	}
+}
+
+func contains(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -386,6 +386,11 @@ func NewServer(opts ServerOptions) (*Server, error) {
 	if authCfg.Mode == AuthModeDisabled {
 		log.Warn("api: auth disabled — mutation endpoints are not authenticated; bind to loopback or trusted network only")
 	}
+	// CORS permissive default warning: only surfaces on non-loopback
+	// binds so the common file:// + loopback workflow stays quiet.
+	if opts.CORS.IsDefaultPermissive() && !bindsToLoopback(opts.Addr) {
+		log.Warn("api: CORS open to any origin (default) on a non-loopback bind — set api.cors.allowed_origins to clamp it down on hostile networks")
+	}
 	// TLS: both files must be set to enable TLS; one without the
 	// other is a misconfiguration the operator should hear about
 	// rather than silently fall back to plain HTTP.

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -193,22 +193,24 @@ type ConvChannelStatusDTO struct {
 // Server hosts the GopherTrunk HTTP/SSE/WebSocket API. A separate gRPC
 // server (internal/api/grpc.go) shares the same in-process state.
 type Server struct {
-	addr       string
-	bus        *events.Bus
-	engine     EngineSnapshot
-	mutator    EngineMutator
-	retention  RetentionSweeper
-	tones      ToneDetectorReset
-	devices    DevicesProvider
-	scanner    ScannerCockpit
-	audio      AudioController
-	runtime    RuntimeProvider
-	talkgroups *trunking.TalkgroupDB
-	systems    []trunking.System
-	history    HistoryQuery
-	metrics    http.Handler
-	log        *slog.Logger
-	version    string
+	addr         string
+	bus          *events.Bus
+	engine       EngineSnapshot
+	mutator      EngineMutator
+	retention    RetentionSweeper
+	tones        ToneDetectorReset
+	devices      DevicesProvider
+	scanner      ScannerCockpit
+	audio        AudioController
+	runtime      RuntimeProvider
+	configWriter ConfigWriter
+	settings     SettingsApplier
+	talkgroups   *trunking.TalkgroupDB
+	systems      []trunking.System
+	history      HistoryQuery
+	metrics      http.Handler
+	log          *slog.Logger
+	version      string
 
 	auth *authState
 	// allowMutations is kept for backwards compatibility with
@@ -331,6 +333,18 @@ type ServerOptions struct {
 	// it to surface every config knob. Optional; when nil, the
 	// route returns 503.
 	Runtime RuntimeProvider
+	// ConfigWriter, when supplied, enables PATCH /api/v1/settings:
+	// the daemon writes the operator's edits to config.yaml
+	// (preserving comments) and feeds the result back to
+	// SettingsApplier for hot-reload. nil disables the endpoint
+	// (returns 503) so daemons started without a -config file don't
+	// pretend the SPA's edits will persist.
+	ConfigWriter ConfigWriter
+	// SettingsApplier is the in-process hot-reload surface invoked
+	// by handleSettingsPatch after the on-disk write succeeds.
+	// Optional: when nil, every field is reported as
+	// "restart_required" in the response.
+	SettingsApplier SettingsApplier
 	// AudioPublisher, when non-nil, enables the
 	// GET /api/v1/audio/stream HTTP endpoint that streams live
 	// composed PCM as a continuous WAV body. Reuses the same
@@ -408,6 +422,8 @@ func NewServer(opts ServerOptions) (*Server, error) {
 		scanner:        opts.Scanner,
 		audio:          opts.Audio,
 		runtime:        opts.Runtime,
+		configWriter:   opts.ConfigWriter,
+		settings:       opts.SettingsApplier,
 		talkgroups:     opts.Talkgroups,
 		systems:        append([]trunking.System(nil), opts.Systems...),
 		history:        opts.History,
@@ -554,6 +570,12 @@ func (s *Server) routes() *http.ServeMux {
 	// gated behind allow_mutations like every other write route.
 	mux.HandleFunc("GET /api/v1/audio", s.handleAudioStatus)
 	mux.HandleFunc("PATCH /api/v1/audio", s.gate(s.handleAudioPatch))
+	// Settings cockpit — PATCH writes the supplied fields back to
+	// config.yaml (preserving comments + formatting) and hot-applies
+	// the ones the daemon knows how to reload in-process. The
+	// response carries the new runtime DTO + a per-field list of
+	// what applied vs what needs a daemon restart.
+	mux.HandleFunc("PATCH /api/v1/settings", s.gate(s.handleSettingsPatch))
 	// Live audio stream — open like every other read route. Emits
 	// a continuous WAV body of composed PCM frames; browsers play
 	// it via <audio src="/api/v1/audio/stream">. Returns 503 when

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -205,6 +205,8 @@ type Server struct {
 	runtime      RuntimeProvider
 	configWriter ConfigWriter
 	settings     SettingsApplier
+	importer     Importer
+	imports      *importStaging
 	talkgroups   *trunking.TalkgroupDB
 	systems      []trunking.System
 	history      HistoryQuery
@@ -345,6 +347,12 @@ type ServerOptions struct {
 	// Optional: when nil, every field is reported as
 	// "restart_required" in the response.
 	SettingsApplier SettingsApplier
+	// Importer enables the live system-import endpoints
+	// (POST /api/v1/import, POST /api/v1/import/{id}/commit,
+	// DELETE /api/v1/import/{id}). nil disables the endpoints —
+	// the daemon emits 503 so the SPA can present a clear "import
+	// disabled" message.
+	Importer Importer
 	// AudioPublisher, when non-nil, enables the
 	// GET /api/v1/audio/stream HTTP endpoint that streams live
 	// composed PCM as a continuous WAV body. Reuses the same
@@ -424,6 +432,8 @@ func NewServer(opts ServerOptions) (*Server, error) {
 		runtime:        opts.Runtime,
 		configWriter:   opts.ConfigWriter,
 		settings:       opts.SettingsApplier,
+		importer:       opts.Importer,
+		imports:        newImportStaging(5 * time.Minute),
 		talkgroups:     opts.Talkgroups,
 		systems:        append([]trunking.System(nil), opts.Systems...),
 		history:        opts.History,
@@ -576,6 +586,14 @@ func (s *Server) routes() *http.ServeMux {
 	// response carries the new runtime DTO + a per-field list of
 	// what applied vs what needs a daemon restart.
 	mux.HandleFunc("PATCH /api/v1/settings", s.gate(s.handleSettingsPatch))
+
+	// Live import — upload one or more RadioReference PDFs / CSV
+	// bundles, preview the parsed systems, then commit (or discard)
+	// the staged batch. Multipart upload at POST /api/v1/import;
+	// commit/discard keyed by the returned staging ID.
+	mux.HandleFunc("POST /api/v1/import", s.gate(s.handleImportUpload))
+	mux.HandleFunc("POST /api/v1/import/{id}/commit", s.gate(s.handleImportCommit))
+	mux.HandleFunc("DELETE /api/v1/import/{id}", s.gate(s.handleImportDiscard))
 	// Live audio stream — open like every other read route. Emits
 	// a continuous WAV body of composed PCM frames; browsers play
 	// it via <audio src="/api/v1/audio/stream">. Returns 503 when

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -457,6 +457,12 @@ func Default() Config {
 	return Config{
 		Log: LogConfig{Level: "info", Format: "text"},
 		SDR: SDRConfig{SampleRate: 2_400_000},
+		// HTTP API on by default so the bundled launcher's TUI /
+		// web paths have something to attach to without an explicit
+		// config edit. Loopback bind keeps the auth-disabled default
+		// (see api.ParseAuthMode) safe out-of-the-box; operators on
+		// a closed LAN flip this to ":8080" or a LAN IP.
+		API: APIConfig{HTTPAddr: "127.0.0.1:8080"},
 	}
 }
 

--- a/internal/config/writer.go
+++ b/internal/config/writer.go
@@ -1,0 +1,463 @@
+package config
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"sync"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Patch is a sparse Config — every field is a pointer so callers can
+// say "leave alone" with nil. The settings PATCH endpoint and the
+// SIGHUP reload path both pipe operator edits through this shape.
+//
+// Only fields the daemon knows how to surface in the TUI / web UI
+// settings panels are listed here; expand the struct as new editable
+// knobs become available.
+type Patch struct {
+	// Log.
+	LogLevel  *string
+	LogFormat *string
+
+	// API.
+	APIHTTPAddr *string
+	APIGRPCAddr *string
+	APIAuthMode *string
+
+	// Audio.
+	AudioEnabled  *bool
+	AudioDevice   *string
+	AudioVolume   *float32
+	AudioMuted    *bool
+	AudioBufferMs *int
+
+	// Recordings.
+	RecordingsDir        *string
+	RecordingsSampleRate *uint32
+	RecordingsWriteRaw   *bool
+
+	// Retention.
+	RetentionCallLogDays *int
+	RetentionFilesDays   *int
+	RetentionInterval    *string
+
+	// SDR (sample rate only; device list edits go through a separate
+	// future endpoint because they're keyed by serial).
+	SDRSampleRate *uint32
+
+	// Scanner.
+	ScannerScanMode          *string
+	ScannerManualTuneEnabled *bool
+	ScannerCCHuntEnabled     *bool
+	ScannerCCHuntDwellMs     *int
+	ScannerCCHuntBackoffMs   *int
+	ScannerCCHuntMaxBackoff  *int
+
+	// Storage.
+	StoragePath        *string
+	StorageCCCacheFile *string
+
+	// Metrics.
+	MetricsEnabled *bool
+}
+
+// IsEmpty reports whether every patch field is nil. Used to short-
+// circuit the writer when an operator sends an empty body.
+func (p Patch) IsEmpty() bool {
+	return p == Patch{}
+}
+
+// Apply layers p onto cfg in place, returning the modified cfg.
+// Fields with nil pointers are left untouched.
+func (p Patch) Apply(cfg Config) Config {
+	if p.LogLevel != nil {
+		cfg.Log.Level = *p.LogLevel
+	}
+	if p.LogFormat != nil {
+		cfg.Log.Format = *p.LogFormat
+	}
+	if p.APIHTTPAddr != nil {
+		cfg.API.HTTPAddr = *p.APIHTTPAddr
+	}
+	if p.APIGRPCAddr != nil {
+		cfg.API.GRPCAddr = *p.APIGRPCAddr
+	}
+	if p.APIAuthMode != nil {
+		cfg.API.Auth.Mode = *p.APIAuthMode
+	}
+	if p.AudioEnabled != nil {
+		cfg.Audio.Enabled = *p.AudioEnabled
+	}
+	if p.AudioDevice != nil {
+		cfg.Audio.Device = *p.AudioDevice
+	}
+	if p.AudioVolume != nil {
+		cfg.Audio.Volume = *p.AudioVolume
+	}
+	if p.AudioMuted != nil {
+		cfg.Audio.Muted = *p.AudioMuted
+	}
+	if p.AudioBufferMs != nil {
+		cfg.Audio.BufferMs = *p.AudioBufferMs
+	}
+	if p.RecordingsDir != nil {
+		cfg.Recordings.Dir = *p.RecordingsDir
+	}
+	if p.RecordingsSampleRate != nil {
+		cfg.Recordings.SampleRate = *p.RecordingsSampleRate
+	}
+	if p.RecordingsWriteRaw != nil {
+		cfg.Recordings.WriteRaw = *p.RecordingsWriteRaw
+	}
+	if p.RetentionCallLogDays != nil {
+		cfg.Retention.CallLogDays = *p.RetentionCallLogDays
+	}
+	if p.RetentionFilesDays != nil {
+		cfg.Retention.FilesDays = *p.RetentionFilesDays
+	}
+	if p.RetentionInterval != nil {
+		cfg.Retention.Interval = *p.RetentionInterval
+	}
+	if p.SDRSampleRate != nil {
+		cfg.SDR.SampleRate = *p.SDRSampleRate
+	}
+	if p.ScannerScanMode != nil {
+		cfg.Scanner.ScanMode = *p.ScannerScanMode
+	}
+	if p.ScannerManualTuneEnabled != nil {
+		cfg.Scanner.ManualTuneEnabled = *p.ScannerManualTuneEnabled
+	}
+	if p.ScannerCCHuntEnabled != nil {
+		cfg.Scanner.CCHunt.Enabled = *p.ScannerCCHuntEnabled
+	}
+	if p.ScannerCCHuntDwellMs != nil {
+		cfg.Scanner.CCHunt.DwellMs = *p.ScannerCCHuntDwellMs
+	}
+	if p.ScannerCCHuntBackoffMs != nil {
+		cfg.Scanner.CCHunt.BackoffMs = *p.ScannerCCHuntBackoffMs
+	}
+	if p.ScannerCCHuntMaxBackoff != nil {
+		cfg.Scanner.CCHunt.MaxBackoffMs = *p.ScannerCCHuntMaxBackoff
+	}
+	if p.StoragePath != nil {
+		cfg.Storage.Path = *p.StoragePath
+	}
+	if p.StorageCCCacheFile != nil {
+		cfg.Storage.CCCacheFile = *p.StorageCCCacheFile
+	}
+	if p.MetricsEnabled != nil {
+		cfg.Metrics.Enabled = *p.MetricsEnabled
+	}
+	return cfg
+}
+
+// patchPath is one key-path → yaml.Node mutation. The writer applies
+// these in document order so blocks land in a predictable spot when a
+// section needs to be created from scratch.
+type patchPath struct {
+	keys  []string
+	value *yaml.Node
+}
+
+// patchEdits returns the list of node mutations needed to express p.
+// Empty pointers are skipped.
+func patchEdits(p Patch) []patchPath {
+	var out []patchPath
+	add := func(keys []string, v *yaml.Node) {
+		out = append(out, patchPath{keys: keys, value: v})
+	}
+	scalarString := func(s string) *yaml.Node {
+		return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: s}
+	}
+	scalarBool := func(b bool) *yaml.Node {
+		v := "false"
+		if b {
+			v = "true"
+		}
+		return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!bool", Value: v}
+	}
+	scalarInt := func(n int64) *yaml.Node {
+		return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!int", Value: strconv.FormatInt(n, 10)}
+	}
+	scalarFloat := func(f float64) *yaml.Node {
+		return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!float", Value: strconv.FormatFloat(f, 'g', -1, 32)}
+	}
+
+	if p.LogLevel != nil {
+		add([]string{"log", "level"}, scalarString(*p.LogLevel))
+	}
+	if p.LogFormat != nil {
+		add([]string{"log", "format"}, scalarString(*p.LogFormat))
+	}
+	if p.APIHTTPAddr != nil {
+		add([]string{"api", "http_addr"}, scalarString(*p.APIHTTPAddr))
+	}
+	if p.APIGRPCAddr != nil {
+		add([]string{"api", "grpc_addr"}, scalarString(*p.APIGRPCAddr))
+	}
+	if p.APIAuthMode != nil {
+		add([]string{"api", "auth", "mode"}, scalarString(*p.APIAuthMode))
+	}
+	if p.AudioEnabled != nil {
+		add([]string{"audio", "enabled"}, scalarBool(*p.AudioEnabled))
+	}
+	if p.AudioDevice != nil {
+		add([]string{"audio", "device"}, scalarString(*p.AudioDevice))
+	}
+	if p.AudioVolume != nil {
+		add([]string{"audio", "volume"}, scalarFloat(float64(*p.AudioVolume)))
+	}
+	if p.AudioMuted != nil {
+		add([]string{"audio", "muted"}, scalarBool(*p.AudioMuted))
+	}
+	if p.AudioBufferMs != nil {
+		add([]string{"audio", "buffer_ms"}, scalarInt(int64(*p.AudioBufferMs)))
+	}
+	if p.RecordingsDir != nil {
+		add([]string{"recordings", "dir"}, scalarString(*p.RecordingsDir))
+	}
+	if p.RecordingsSampleRate != nil {
+		add([]string{"recordings", "sample_rate"}, scalarInt(int64(*p.RecordingsSampleRate)))
+	}
+	if p.RecordingsWriteRaw != nil {
+		add([]string{"recordings", "write_raw"}, scalarBool(*p.RecordingsWriteRaw))
+	}
+	if p.RetentionCallLogDays != nil {
+		add([]string{"retention", "call_log_days"}, scalarInt(int64(*p.RetentionCallLogDays)))
+	}
+	if p.RetentionFilesDays != nil {
+		add([]string{"retention", "files_days"}, scalarInt(int64(*p.RetentionFilesDays)))
+	}
+	if p.RetentionInterval != nil {
+		add([]string{"retention", "interval"}, scalarString(*p.RetentionInterval))
+	}
+	if p.SDRSampleRate != nil {
+		add([]string{"sdr", "sample_rate"}, scalarInt(int64(*p.SDRSampleRate)))
+	}
+	if p.ScannerScanMode != nil {
+		add([]string{"scanner", "scan_mode"}, scalarString(*p.ScannerScanMode))
+	}
+	if p.ScannerManualTuneEnabled != nil {
+		add([]string{"scanner", "manual_tune_enabled"}, scalarBool(*p.ScannerManualTuneEnabled))
+	}
+	if p.ScannerCCHuntEnabled != nil {
+		add([]string{"scanner", "cc_hunt", "enabled"}, scalarBool(*p.ScannerCCHuntEnabled))
+	}
+	if p.ScannerCCHuntDwellMs != nil {
+		add([]string{"scanner", "cc_hunt", "dwell_ms"}, scalarInt(int64(*p.ScannerCCHuntDwellMs)))
+	}
+	if p.ScannerCCHuntBackoffMs != nil {
+		add([]string{"scanner", "cc_hunt", "backoff_ms"}, scalarInt(int64(*p.ScannerCCHuntBackoffMs)))
+	}
+	if p.ScannerCCHuntMaxBackoff != nil {
+		add([]string{"scanner", "cc_hunt", "max_backoff_ms"}, scalarInt(int64(*p.ScannerCCHuntMaxBackoff)))
+	}
+	if p.StoragePath != nil {
+		add([]string{"storage", "path"}, scalarString(*p.StoragePath))
+	}
+	if p.StorageCCCacheFile != nil {
+		add([]string{"storage", "cc_cache_file"}, scalarString(*p.StorageCCCacheFile))
+	}
+	if p.MetricsEnabled != nil {
+		add([]string{"metrics", "enabled"}, scalarBool(*p.MetricsEnabled))
+	}
+	return out
+}
+
+// Writer serialises in-place edits to a config.yaml so concurrent
+// callers (settings PATCH, SIGHUP-driven reloads, import commits)
+// can't tear each other's writes. The writer also enforces an
+// mtime guard so externally-edited files aren't clobbered.
+type Writer struct {
+	mu          sync.Mutex
+	path        string
+	knownMtime  int64
+}
+
+// NewWriter constructs a Writer bound to path. The path must point
+// at an existing file; an empty path returns nil so callers can
+// disable the live-edit surface gracefully.
+func NewWriter(path string) (*Writer, error) {
+	if path == "" {
+		return nil, nil
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, fmt.Errorf("config: writer: %w", err)
+	}
+	return &Writer{path: path, knownMtime: info.ModTime().UnixNano()}, nil
+}
+
+// Path returns the file the writer mutates.
+func (w *Writer) Path() string {
+	if w == nil {
+		return ""
+	}
+	return w.path
+}
+
+// WritePatch loads the file, runs Patch.Apply against the parsed
+// config, runs Validate, then mutates the underlying yaml.Node tree
+// so unrelated content (comments, formatting, keys we don't know
+// about) is preserved, and atomically writes the result back.
+//
+// Returns the patched Config so callers can hand it to in-process
+// subsystems for hot-reload.
+func (w *Writer) WritePatch(p Patch) (Config, error) {
+	var zero Config
+	if w == nil {
+		return zero, errors.New("config: no writer wired (daemon started without a -config file)")
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	// mtime guard — refuse to clobber an external edit.
+	info, err := os.Stat(w.path)
+	if err != nil {
+		return zero, fmt.Errorf("config: writer: stat: %w", err)
+	}
+	if info.ModTime().UnixNano() != w.knownMtime {
+		return zero, fmt.Errorf("config: %s was modified externally; reload the daemon to pick up the new file before editing again", w.path)
+	}
+
+	data, err := os.ReadFile(w.path)
+	if err != nil {
+		return zero, fmt.Errorf("config: writer: read: %w", err)
+	}
+
+	// Parse current config for validation.
+	var current Config
+	if err := yaml.Unmarshal(data, &current); err != nil {
+		return zero, fmt.Errorf("config: writer: parse: %w", err)
+	}
+	merged := p.Apply(current)
+	if err := merged.Validate(); err != nil {
+		return zero, fmt.Errorf("config: writer: validate: %w", err)
+	}
+
+	// Walk the yaml.Node tree and apply each patch edit.
+	var doc yaml.Node
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return zero, fmt.Errorf("config: writer: parse node: %w", err)
+	}
+	root := docRoot(&doc)
+	if root == nil {
+		root = &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+		doc.Kind = yaml.DocumentNode
+		doc.Content = []*yaml.Node{root}
+	}
+	for _, edit := range patchEdits(p) {
+		setMappingPath(root, edit.keys, edit.value)
+	}
+
+	// Re-encode and atomic-rename.
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+	if err := enc.Encode(&doc); err != nil {
+		return zero, fmt.Errorf("config: writer: encode: %w", err)
+	}
+	if err := enc.Close(); err != nil {
+		return zero, err
+	}
+	if err := writeFileAtomic(w.path, buf.Bytes(), 0o644); err != nil {
+		return zero, err
+	}
+	// Refresh the known mtime to the just-written file.
+	if info, err := os.Stat(w.path); err == nil {
+		w.knownMtime = info.ModTime().UnixNano()
+	}
+	return merged, nil
+}
+
+// docRoot returns the document's top-level mapping node, or nil for
+// an empty / non-mapping document.
+func docRoot(doc *yaml.Node) *yaml.Node {
+	if doc == nil {
+		return nil
+	}
+	if doc.Kind == yaml.DocumentNode && len(doc.Content) > 0 {
+		if doc.Content[0].Kind == yaml.MappingNode {
+			return doc.Content[0]
+		}
+	}
+	if doc.Kind == yaml.MappingNode {
+		return doc
+	}
+	return nil
+}
+
+// setMappingPath walks `path` from root, creating intermediate
+// mappings as needed, and replaces (or appends) the value at the
+// final key.
+func setMappingPath(root *yaml.Node, path []string, value *yaml.Node) {
+	if len(path) == 0 {
+		return
+	}
+	node := root
+	for i, key := range path[:len(path)-1] {
+		node = findOrAddMapping(node, key)
+		_ = i
+	}
+	leaf := path[len(path)-1]
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		if node.Content[i].Value == leaf {
+			// Preserve the existing key node's comments / position
+			// when replacing the value.
+			node.Content[i+1] = value
+			return
+		}
+	}
+	node.Content = append(node.Content,
+		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: leaf},
+		value,
+	)
+}
+
+// findOrAddMapping returns the child mapping node for `key`, creating
+// it (as a block mapping) when absent.
+func findOrAddMapping(parent *yaml.Node, key string) *yaml.Node {
+	for i := 0; i+1 < len(parent.Content); i += 2 {
+		if parent.Content[i].Value == key {
+			v := parent.Content[i+1]
+			if v.Kind != yaml.MappingNode {
+				v = &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+				parent.Content[i+1] = v
+			}
+			return v
+		}
+	}
+	kn := &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: key}
+	vn := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+	parent.Content = append(parent.Content, kn, vn)
+	return vn
+}
+
+// writeFileAtomic writes data to path through a same-directory temp
+// file and an os.Rename. Atomic on POSIX filesystems.
+func writeFileAtomic(path string, data []byte, mode os.FileMode) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("config: writer: tempfile: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return fmt.Errorf("config: writer: write: %w", err)
+	}
+	if err := tmp.Chmod(mode); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, path)
+}

--- a/internal/config/writer_test.go
+++ b/internal/config/writer_test.go
@@ -1,0 +1,162 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const sampleYAML = `# top of file comment kept
+log:
+  level: info
+  format: text
+
+api:
+  http_addr: "127.0.0.1:8080"
+  # auth section omitted — daemon defaults apply
+
+audio:
+  enabled: false
+  volume: 0.8
+
+# trailing comment kept
+`
+
+func writeTempConfig(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte(sampleYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestPatchApply(t *testing.T) {
+	cfg := Config{}
+	level := "debug"
+	volume := float32(0.5)
+	enabled := true
+	p := Patch{LogLevel: &level, AudioVolume: &volume, AudioEnabled: &enabled}
+	out := p.Apply(cfg)
+	if out.Log.Level != "debug" {
+		t.Errorf("Log.Level = %q want debug", out.Log.Level)
+	}
+	if out.Audio.Volume != 0.5 {
+		t.Errorf("Audio.Volume = %v want 0.5", out.Audio.Volume)
+	}
+	if !out.Audio.Enabled {
+		t.Errorf("Audio.Enabled = false want true")
+	}
+}
+
+func TestWriterWritePatchPreservesComments(t *testing.T) {
+	path := writeTempConfig(t)
+	w, err := NewWriter(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	level := "debug"
+	volume := float32(0.42)
+	enabled := true
+	merged, err := w.WritePatch(Patch{
+		LogLevel:     &level,
+		AudioVolume:  &volume,
+		AudioEnabled: &enabled,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if merged.Log.Level != "debug" {
+		t.Errorf("merged.Log.Level = %q want debug", merged.Log.Level)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := string(data)
+	if !strings.Contains(body, "# top of file comment kept") {
+		t.Errorf("expected top-of-file comment preserved, got:\n%s", body)
+	}
+	if !strings.Contains(body, "# trailing comment kept") {
+		t.Errorf("expected trailing comment preserved, got:\n%s", body)
+	}
+	if !strings.Contains(body, "level: debug") {
+		t.Errorf("expected updated log.level, got:\n%s", body)
+	}
+	if !strings.Contains(body, "volume: 0.42") {
+		t.Errorf("expected updated audio.volume, got:\n%s", body)
+	}
+	if !strings.Contains(body, "enabled: true") {
+		t.Errorf("expected updated audio.enabled, got:\n%s", body)
+	}
+}
+
+func TestWriterRejectsInvalidPatch(t *testing.T) {
+	path := writeTempConfig(t)
+	w, err := NewWriter(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bad := "list-or-all-only"
+	if _, err := w.WritePatch(Patch{ScannerScanMode: &bad}); err == nil {
+		t.Fatal("expected validation error for invalid scan_mode")
+	}
+}
+
+func TestWriterMtimeGuard(t *testing.T) {
+	path := writeTempConfig(t)
+	w, err := NewWriter(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// External edit while the writer is "running": rewrite the file
+	// with a clearly different mtime.
+	bumpFutureMtime(t, path)
+
+	level := "warn"
+	if _, err := w.WritePatch(Patch{LogLevel: &level}); err == nil {
+		t.Fatal("expected mtime guard to reject the write")
+	} else if !strings.Contains(err.Error(), "modified externally") {
+		t.Errorf("expected 'modified externally' in error, got %v", err)
+	}
+}
+
+// bumpFutureMtime rewrites the file with a +1 minute mtime so the
+// writer's stored mtime differs.
+func bumpFutureMtime(t *testing.T, path string) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	future := info.ModTime().Add(60_000_000_000) // 1 minute in ns
+	if err := os.Chtimes(path, future, future); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestNewWriterMissingFile(t *testing.T) {
+	if _, err := NewWriter(filepath.Join(t.TempDir(), "does-not-exist.yaml")); err == nil {
+		t.Fatal("expected error for missing file")
+	}
+}
+
+func TestNewWriterEmptyPath(t *testing.T) {
+	w, err := NewWriter("")
+	if err != nil {
+		t.Fatalf("expected nil-writer / nil-error for empty path, got err=%v", err)
+	}
+	if w != nil {
+		t.Fatalf("expected nil writer for empty path, got %v", w)
+	}
+}

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -1,12 +1,74 @@
 package log
 
 import (
+	"io"
 	"log/slog"
 	"os"
 	"strings"
+	"sync"
 )
 
+// SwappableWriter is an io.Writer that can be redirected to a
+// different target at runtime without re-wiring the slog handler.
+// The daemon installs one as the slog sink at startup; the launcher
+// redirects it to a tempfile while the in-process TUI owns the
+// terminal, then restores it on exit so headless mode keeps stderr.
+type SwappableWriter struct {
+	mu    sync.Mutex
+	out   io.Writer
+	saved io.Writer
+}
+
+// NewSwappableWriter returns a SwappableWriter pointed at w.
+func NewSwappableWriter(w io.Writer) *SwappableWriter {
+	return &SwappableWriter{out: w}
+}
+
+// Write delegates to the active target. Holds the mutex briefly so
+// concurrent log lines never interleave with a redirect transition.
+func (s *SwappableWriter) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	w := s.out
+	s.mu.Unlock()
+	if w == nil {
+		return len(p), nil
+	}
+	return w.Write(p)
+}
+
+// Redirect replaces the active target. The previous target is
+// remembered so Restore can reinstate it.
+func (s *SwappableWriter) Redirect(w io.Writer) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.saved = s.out
+	s.out = w
+}
+
+// Restore reverts to the writer that was active before the most
+// recent Redirect. No-op when nothing was saved.
+func (s *SwappableWriter) Restore() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.saved != nil {
+		s.out = s.saved
+		s.saved = nil
+	}
+}
+
+// New builds a slog.Logger whose handler writes to os.Stderr via a
+// SwappableWriter. The default constructor is preserved for callers
+// that don't need the swap surface.
 func New(level, format string) *slog.Logger {
+	logger, _ := NewWithSwap(level, format)
+	return logger
+}
+
+// NewWithSwap is the variant used by main: it returns both the slog
+// Logger and the SwappableWriter behind its handler, so the launcher
+// can redirect stderr while the TUI runs.
+func NewWithSwap(level, format string) (*slog.Logger, *SwappableWriter) {
+	sw := NewSwappableWriter(os.Stderr)
 	var lvl slog.Level
 	switch strings.ToLower(level) {
 	case "debug":
@@ -21,9 +83,9 @@ func New(level, format string) *slog.Logger {
 	opts := &slog.HandlerOptions{Level: lvl}
 	var h slog.Handler
 	if strings.EqualFold(format, "json") {
-		h = slog.NewJSONHandler(os.Stderr, opts)
+		h = slog.NewJSONHandler(sw, opts)
 	} else {
-		h = slog.NewTextHandler(os.Stderr, opts)
+		h = slog.NewTextHandler(sw, opts)
 	}
-	return slog.New(h)
+	return slog.New(h), sw
 }

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -88,6 +88,7 @@ func New(cli *client.Client, opts Options) *Model {
 			panels.NewDevices(),
 			panels.NewScanner(),
 			panels.NewSettings(),
+			panels.NewImport(),
 		},
 	}
 	return m
@@ -402,6 +403,15 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			cmdPollActive(m.cli),
 			cmdPollTalkgroups(m.cli),
 		)
+
+	case panels.ImportUploadMsg:
+		cmds = append(cmds, cmdImportUpload(m.cli, msg.Paths))
+
+	case panels.ImportCommitMsg:
+		cmds = append(cmds, cmdImportCommit(m.cli, msg.ID, msg.Force))
+
+	case panels.ImportDiscardMsg:
+		cmds = append(cmds, cmdImportDiscard(m.cli, msg.ID))
 	}
 
 	// Forward to active panel.

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -82,17 +82,22 @@ func TestPanelSwitch_DigitAndTab(t *testing.T) {
 			t.Errorf("after %q active=%v, want %v", c.key, m.active, c.want)
 		}
 	}
-	// Tab cycles forward — Scanner advances to Settings (the new
-	// last panel after PR #144).
+	// Tab cycles forward — Scanner advances to Settings, then to
+	// Import (the new last panel after the live-import work).
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyTab})
 	m = updated.(*Model)
 	if m.active != state.PanelSettings {
 		t.Errorf("Tab from Scanner: active=%v, want Settings", m.active)
 	}
-	// Tab again wraps Settings → Dashboard.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	m = updated.(*Model)
+	if m.active != state.PanelImport {
+		t.Errorf("Tab from Settings: active=%v, want Import", m.active)
+	}
+	// Tab again wraps Import → Dashboard.
 	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
 	m = updated.(*Model)
 	if m.active != state.PanelDashboard {
-		t.Errorf("Tab from Settings: active=%v, want Dashboard", m.active)
+		t.Errorf("Tab from Import: active=%v, want Dashboard", m.active)
 	}
 }

--- a/internal/tui/client/types.go
+++ b/internal/tui/client/types.go
@@ -273,6 +273,15 @@ type RuntimeDTO struct {
 
 	VocoderMap     map[string]string `json:"vocoder_map"`
 	MetricsEnabled bool              `json:"metrics_enabled"`
+
+	// ConfigPath is the path of the config.yaml backing the daemon,
+	// or empty when the daemon was started without -config. The TUI
+	// uses it to render the Settings panel as read-only when empty.
+	ConfigPath string `json:"config_path,omitempty"`
+	// StartupWarnings are the non-fatal observations the daemon
+	// collected during NewDaemon. The Dashboard pins them as a
+	// one-shot banner.
+	StartupWarnings []string `json:"startup_warnings,omitempty"`
 }
 
 // ToneProfileDTO mirrors api.ToneProfileDTO.

--- a/internal/tui/client/write.go
+++ b/internal/tui/client/write.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"mime/multipart"
 	"net/http"
 )
 
@@ -255,6 +257,171 @@ func (c *Client) do(ctx context.Context, method, path string, in any, out any) e
 		return nil
 	}
 	return json.NewDecoder(resp.Body).Decode(out)
+}
+
+// SettingsPatch mirrors the daemon's PATCH /api/v1/settings body. All
+// fields are pointers so the TUI can update one knob at a time.
+type SettingsPatch struct {
+	LogLevel  *string `json:"log_level,omitempty"`
+	LogFormat *string `json:"log_format,omitempty"`
+
+	APIHTTPAddr *string `json:"api_http_addr,omitempty"`
+	APIGRPCAddr *string `json:"api_grpc_addr,omitempty"`
+	APIAuthMode *string `json:"api_auth_mode,omitempty"`
+
+	AudioEnabled  *bool    `json:"audio_enabled,omitempty"`
+	AudioDevice   *string  `json:"audio_device,omitempty"`
+	AudioVolume   *float32 `json:"audio_volume,omitempty"`
+	AudioMuted    *bool    `json:"audio_muted,omitempty"`
+	AudioBufferMs *int     `json:"audio_buffer_ms,omitempty"`
+
+	RecordingsDir        *string `json:"recordings_dir,omitempty"`
+	RecordingsSampleRate *uint32 `json:"recordings_sample_rate,omitempty"`
+	RecordingsWriteRaw   *bool   `json:"recordings_write_raw,omitempty"`
+
+	RetentionCallLogDays *int    `json:"retention_call_log_days,omitempty"`
+	RetentionFilesDays   *int    `json:"retention_files_days,omitempty"`
+	RetentionInterval    *string `json:"retention_interval,omitempty"`
+
+	SDRSampleRate *uint32 `json:"sdr_sample_rate,omitempty"`
+
+	ScannerScanMode          *string `json:"scanner_scan_mode,omitempty"`
+	ScannerManualTuneEnabled *bool   `json:"scanner_manual_tune_enabled,omitempty"`
+	ScannerCCHuntEnabled     *bool   `json:"scanner_cc_hunt_enabled,omitempty"`
+	ScannerCCHuntDwellMs     *int    `json:"scanner_cc_hunt_dwell_ms,omitempty"`
+	ScannerCCHuntBackoffMs   *int    `json:"scanner_cc_hunt_backoff_ms,omitempty"`
+	ScannerCCHuntMaxBackoff  *int    `json:"scanner_cc_hunt_max_backoff_ms,omitempty"`
+
+	StoragePath        *string `json:"storage_path,omitempty"`
+	StorageCCCacheFile *string `json:"storage_cc_cache_file,omitempty"`
+
+	MetricsEnabled *bool `json:"metrics_enabled,omitempty"`
+}
+
+// SettingsResponse mirrors the daemon's response.
+type SettingsResponse struct {
+	Applied         []string   `json:"applied"`
+	RestartRequired []string   `json:"restart_required"`
+	ConfigPath      string     `json:"config_path,omitempty"`
+	Runtime         RuntimeDTO `json:"runtime"`
+}
+
+// UpdateSettings posts a SettingsPatch and returns the daemon's
+// applied / restart-required classification.
+func (c *Client) UpdateSettings(ctx context.Context, p SettingsPatch) (SettingsResponse, error) {
+	var resp SettingsResponse
+	if err := c.do(ctx, http.MethodPatch, "/api/v1/settings", p, &resp); err != nil {
+		return SettingsResponse{}, err
+	}
+	return resp, nil
+}
+
+// ImportPreview mirrors the daemon's POST /api/v1/import response.
+type ImportPreview struct {
+	ID      string             `json:"id"`
+	Systems []ParsedSystemDTO  `json:"systems"`
+}
+
+// ParsedSystemDTO mirrors the daemon's preview row.
+type ParsedSystemDTO struct {
+	Name        string                 `json:"name"`
+	Protocol    string                 `json:"protocol"`
+	SiteCount   int                    `json:"site_count"`
+	TalkgroupCt int                    `json:"talkgroup_count"`
+	SourcePath  string                 `json:"source_path,omitempty"`
+	Location    string                 `json:"location,omitempty"`
+	County      string                 `json:"county,omitempty"`
+	SysID       string                 `json:"sysid,omitempty"`
+	WACN        string                 `json:"wacn,omitempty"`
+	SystemType  string                 `json:"system_type,omitempty"`
+}
+
+// ImportResult mirrors the daemon's commit response.
+type ImportResult struct {
+	SystemsAdded    []string `json:"systems_added"`
+	SystemsReplaced []string `json:"systems_replaced"`
+	CSVPaths        []string `json:"csv_paths,omitempty"`
+	ConfigPath      string   `json:"config_path,omitempty"`
+}
+
+// ImportUploadFile is one local file the operator wants to upload.
+type ImportUploadFile struct {
+	Filename string // basename used in the multipart Content-Disposition
+	Data     []byte // raw file bytes
+}
+
+// ImportUpload performs the multipart POST and returns the staged
+// preview. Reads each file path from disk; callers that already have
+// the bytes can build their own multipart body via the lower-level
+// http client.
+func (c *Client) ImportUpload(ctx context.Context, files []ImportUploadFile) (ImportPreview, error) {
+	if len(files) == 0 {
+		return ImportPreview{}, fmt.Errorf("client: at least one file is required")
+	}
+	body, contentType, err := buildImportMultipart(files)
+	if err != nil {
+		return ImportPreview{}, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		c.base+"/api/v1/import", body)
+	if err != nil {
+		return ImportPreview{}, err
+	}
+	req.Header.Set("Content-Type", contentType)
+	req.Header.Set("User-Agent", userAgent)
+	req.Header.Set("Accept", "application/json")
+	c.authorize(req)
+	resp, err := c.hc.Do(req)
+	if err != nil {
+		return ImportPreview{}, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode/100 != 2 {
+		return ImportPreview{}, c.httpErr(http.MethodPost, req.URL.String(), resp)
+	}
+	var preview ImportPreview
+	if err := json.NewDecoder(resp.Body).Decode(&preview); err != nil {
+		return ImportPreview{}, err
+	}
+	return preview, nil
+}
+
+// ImportCommit finalises a previously-staged preview.
+func (c *Client) ImportCommit(ctx context.Context, id string, force bool) (ImportResult, error) {
+	path := "/api/v1/import/" + id + "/commit"
+	if force {
+		path += "?force=true"
+	}
+	var out ImportResult
+	if err := c.do(ctx, http.MethodPost, path, nil, &out); err != nil {
+		return ImportResult{}, err
+	}
+	return out, nil
+}
+
+// ImportDiscard drops a staged preview without committing it.
+func (c *Client) ImportDiscard(ctx context.Context, id string) error {
+	return c.do(ctx, http.MethodDelete, "/api/v1/import/"+id, nil, nil)
+}
+
+// buildImportMultipart constructs a multipart/form-data body with
+// one `files` part per supplied source.
+func buildImportMultipart(files []ImportUploadFile) (io.Reader, string, error) {
+	buf := new(bytes.Buffer)
+	w := multipart.NewWriter(buf)
+	for _, f := range files {
+		part, err := w.CreateFormFile("files", f.Filename)
+		if err != nil {
+			return nil, "", err
+		}
+		if _, err := part.Write(f.Data); err != nil {
+			return nil, "", err
+		}
+	}
+	if err := w.Close(); err != nil {
+		return nil, "", err
+	}
+	return buf, w.FormDataContentType(), nil
 }
 
 // asHTTPErr is a tiny wrapper around errors.As that avoids dragging

--- a/internal/tui/cmds.go
+++ b/internal/tui/cmds.go
@@ -2,11 +2,14 @@ package tui
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/MattCheramie/GopherTrunk/internal/tui/client"
+	"github.com/MattCheramie/GopherTrunk/internal/tui/panels"
 )
 
 // Polling intervals chosen to balance responsiveness against load
@@ -266,5 +269,43 @@ func cmdFetchTalkgroupDetail(cli *client.Client, id uint32) tea.Cmd {
 	return func() tea.Msg {
 		tg, err := cli.Talkgroup(context.Background(), id)
 		return talkgroupDetailResultMsg{tg: tg, err: err}
+	}
+}
+
+// cmdImportUpload reads every queued path from disk and posts a
+// multipart upload to the daemon.
+func cmdImportUpload(cli *client.Client, paths []string) tea.Cmd {
+	return func() tea.Msg {
+		files := make([]client.ImportUploadFile, 0, len(paths))
+		for _, p := range paths {
+			data, err := os.ReadFile(p)
+			if err != nil {
+				return panels.ImportPreviewArrivedMsg{Err: err}
+			}
+			files = append(files, client.ImportUploadFile{
+				Filename: filepath.Base(p),
+				Data:     data,
+			})
+		}
+		preview, err := cli.ImportUpload(context.Background(), files)
+		return panels.ImportPreviewArrivedMsg{Preview: preview, Err: err}
+	}
+}
+
+// cmdImportCommit finalises a staged preview by ID.
+func cmdImportCommit(cli *client.Client, id string, force bool) tea.Cmd {
+	return func() tea.Msg {
+		res, err := cli.ImportCommit(context.Background(), id, force)
+		return panels.ImportResultArrivedMsg{Result: res, Err: err}
+	}
+}
+
+// cmdImportDiscard drops a staged preview without committing.
+func cmdImportDiscard(cli *client.Client, id string) tea.Cmd {
+	return func() tea.Msg {
+		err := cli.ImportDiscard(context.Background(), id)
+		// Discard result rides the writeResultMsg path so the
+		// root model surfaces a toast — same UX as other mutations.
+		return writeResultMsg{Label: "import discard", Err: err}
 	}
 }

--- a/internal/tui/panels/import.go
+++ b/internal/tui/panels/import.go
@@ -1,0 +1,313 @@
+package panels
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/key"
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/MattCheramie/GopherTrunk/internal/tui/client"
+	"github.com/MattCheramie/GopherTrunk/internal/tui/state"
+)
+
+// ImportPanel is the live-import cockpit. Three views:
+//
+//  1. Stage — operator adds local file paths via a textinput; pressing
+//     'u' uploads them to the daemon and we transition to Preview.
+//  2. Preview — table of parsed systems returned by the daemon;
+//     'c' commits, 'd' discards, esc returns to Stage.
+//  3. Result — list of systems_added / systems_replaced; esc returns
+//     to Stage.
+type ImportPanel struct {
+	view        importView
+	input       textinput.Model
+	paths       []string
+	inputErr    string
+	previewID   string
+	preview     []client.ParsedSystemDTO
+	result      *client.ImportResult
+	statusMsg   string
+}
+
+type importView int
+
+const (
+	importStageView importView = iota
+	importPreviewView
+	importResultView
+)
+
+// ImportUploadMsg is emitted when the operator has confirmed an
+// upload via 'u'. The root model resolves it into an HTTP call.
+type ImportUploadMsg struct {
+	Paths []string
+}
+
+// ImportCommitMsg is emitted when the operator presses 'c' on the
+// Preview view.
+type ImportCommitMsg struct {
+	ID    string
+	Force bool
+}
+
+// ImportDiscardMsg is emitted when the operator presses 'd' on the
+// Preview view.
+type ImportDiscardMsg struct {
+	ID string
+}
+
+// ImportPreviewArrivedMsg is consumed by the panel when the root
+// model has received the staging response.
+type ImportPreviewArrivedMsg struct {
+	Preview client.ImportPreview
+	Err     error
+}
+
+// ImportResultArrivedMsg is consumed by the panel when a commit
+// finishes.
+type ImportResultArrivedMsg struct {
+	Result client.ImportResult
+	Err    error
+}
+
+// NewImport returns a fresh import panel.
+func NewImport() *ImportPanel {
+	in := textinput.New()
+	in.Placeholder = "/path/to/system.csv or /path/to/system.pdf"
+	in.CharLimit = 512
+	in.Width = 60
+	in.Prompt = "path> "
+	in.Focus()
+	return &ImportPanel{input: in}
+}
+
+func (*ImportPanel) Title() string { return "Import" }
+
+var (
+	// "Add a path" rides Enter so it never fights the textinput. The
+	// upload / clear shortcuts use control sequences for the same
+	// reason — the textinput swallows plain-letter keys.
+	importAddKey     = key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "add path"))
+	importUploadKey  = key.NewBinding(key.WithKeys("ctrl+u"), key.WithHelp("⌃U", "upload"))
+	importClearKey   = key.NewBinding(key.WithKeys("ctrl+x"), key.WithHelp("⌃X", "clear queue"))
+	importCommitKey  = key.NewBinding(key.WithKeys("c"), key.WithHelp("c", "commit"))
+	importDiscardKey = key.NewBinding(key.WithKeys("d"), key.WithHelp("d", "discard preview"))
+	importEscKey     = key.NewBinding(key.WithKeys("esc"), key.WithHelp("esc", "back"))
+)
+
+func (*ImportPanel) Keys() []key.Binding {
+	return []key.Binding{
+		importAddKey, importUploadKey, importClearKey,
+		importCommitKey, importDiscardKey, importEscKey,
+	}
+}
+
+func (p *ImportPanel) Update(msg tea.Msg, shared *state.SharedState) (Panel, tea.Cmd) {
+	switch m := msg.(type) {
+	case ImportPreviewArrivedMsg:
+		if m.Err != nil {
+			p.inputErr = m.Err.Error()
+			return p, nil
+		}
+		p.previewID = m.Preview.ID
+		p.preview = m.Preview.Systems
+		p.view = importPreviewView
+		p.statusMsg = ""
+		return p, nil
+	case ImportResultArrivedMsg:
+		if m.Err != nil {
+			p.inputErr = m.Err.Error()
+			return p, nil
+		}
+		p.result = &m.Result
+		p.preview = nil
+		p.previewID = ""
+		p.paths = nil
+		p.view = importResultView
+		return p, nil
+	}
+
+	switch p.view {
+	case importStageView:
+		return p.updateStage(msg, shared)
+	case importPreviewView:
+		return p.updatePreview(msg)
+	case importResultView:
+		return p.updateResult(msg)
+	}
+	return p, nil
+}
+
+func (p *ImportPanel) updateStage(msg tea.Msg, shared *state.SharedState) (Panel, tea.Cmd) {
+	if km, ok := msg.(tea.KeyMsg); ok {
+		switch {
+		case key.Matches(km, importAddKey):
+			path := strings.TrimSpace(p.input.Value())
+			if path == "" {
+				p.inputErr = "empty path"
+				return p, nil
+			}
+			if _, err := os.Stat(path); err != nil {
+				p.inputErr = err.Error()
+				return p, nil
+			}
+			p.paths = append(p.paths, path)
+			p.input.SetValue("")
+			p.inputErr = ""
+			return p, nil
+		case key.Matches(km, importUploadKey):
+			if len(p.paths) == 0 {
+				p.inputErr = "no paths queued"
+				return p, nil
+			}
+			p.inputErr = ""
+			p.statusMsg = "uploading…"
+			return p, func() tea.Msg { return ImportUploadMsg{Paths: append([]string(nil), p.paths...)} }
+		case key.Matches(km, importClearKey):
+			p.paths = nil
+			p.inputErr = ""
+			return p, nil
+		}
+	}
+	var cmd tea.Cmd
+	p.input, cmd = p.input.Update(msg)
+	return p, cmd
+}
+
+func (p *ImportPanel) updatePreview(msg tea.Msg) (Panel, tea.Cmd) {
+	if km, ok := msg.(tea.KeyMsg); ok {
+		switch {
+		case key.Matches(km, importCommitKey):
+			id := p.previewID
+			p.statusMsg = "committing…"
+			return p, func() tea.Msg { return ImportCommitMsg{ID: id} }
+		case key.Matches(km, importDiscardKey):
+			id := p.previewID
+			p.preview = nil
+			p.previewID = ""
+			p.view = importStageView
+			p.statusMsg = "discarded"
+			return p, func() tea.Msg { return ImportDiscardMsg{ID: id} }
+		case key.Matches(km, importEscKey):
+			p.view = importStageView
+			return p, nil
+		}
+	}
+	return p, nil
+}
+
+func (p *ImportPanel) updateResult(msg tea.Msg) (Panel, tea.Cmd) {
+	if km, ok := msg.(tea.KeyMsg); ok {
+		switch {
+		case key.Matches(km, importEscKey), key.Matches(km, importAddKey),
+			km.String() == "n":
+			p.view = importStageView
+			p.result = nil
+			return p, nil
+		}
+	}
+	return p, nil
+}
+
+func (p *ImportPanel) View(width, height int, focused bool, shared *state.SharedState) string {
+	switch p.view {
+	case importPreviewView:
+		return panelFrame("Import", width, height, focused, p.renderPreview(width))
+	case importResultView:
+		return panelFrame("Import", width, height, focused, p.renderResult(width))
+	}
+	return panelFrame("Import", width, height, focused, p.renderStage(width, shared))
+}
+
+func (p *ImportPanel) renderStage(width int, shared *state.SharedState) string {
+	var b strings.Builder
+
+	if shared != nil && shared.Runtime.ConfigPath == "" {
+		fmt.Fprintln(&b, dashDim.Render(
+			"daemon running without a -config file — import is disabled (server returns 503)"))
+		fmt.Fprintln(&b)
+	}
+
+	fmt.Fprintln(&b, dashHeader.Render("Stage files to upload"))
+	fmt.Fprintln(&b, dashDim.Render("  Type a path → 'a' to add. Repeat for more. Then 'u' to upload."))
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, "  "+p.input.View())
+	if p.inputErr != "" {
+		fmt.Fprintln(&b, "  "+lipgloss.NewStyle().Foreground(lipgloss.Color("9")).Render("! "+p.inputErr))
+	}
+	fmt.Fprintln(&b)
+
+	fmt.Fprintln(&b, dashHeader.Render(fmt.Sprintf("Queued (%d)", len(p.paths))))
+	if len(p.paths) == 0 {
+		fmt.Fprintln(&b, dashDim.Render("  (empty)"))
+	} else {
+		for _, q := range p.paths {
+			fmt.Fprintln(&b, "  "+filepath.Base(q)+dashDim.Render("   "+filepath.Dir(q)))
+		}
+	}
+	fmt.Fprintln(&b)
+	if p.statusMsg != "" {
+		fmt.Fprintln(&b, dashDim.Render("  "+p.statusMsg))
+	}
+	fmt.Fprintln(&b, dashDim.Render("  Keys: enter add  •  ⌃U upload  •  ⌃X clear queue"))
+	return b.String()
+}
+
+func (p *ImportPanel) renderPreview(width int) string {
+	var b strings.Builder
+	fmt.Fprintln(&b, dashHeader.Render("Parsed systems (preview)"))
+	if len(p.preview) == 0 {
+		fmt.Fprintln(&b, dashDim.Render("  (no systems parsed)"))
+		return b.String()
+	}
+	for _, s := range p.preview {
+		fmt.Fprintf(&b, "  %s\n", dashAccent.Render(s.Name))
+		fmt.Fprintf(&b, "    protocol  %s\n", s.Protocol)
+		fmt.Fprintf(&b, "    sites     %d\n", s.SiteCount)
+		fmt.Fprintf(&b, "    tgs       %d\n", s.TalkgroupCt)
+		if s.Location != "" {
+			fmt.Fprintf(&b, "    location  %s\n", s.Location)
+		}
+	}
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, dashDim.Render("  staging id "+p.previewID))
+	if p.statusMsg != "" {
+		fmt.Fprintln(&b, dashDim.Render("  "+p.statusMsg))
+	}
+	fmt.Fprintln(&b, dashDim.Render("  Keys: c commit  •  d discard  •  esc back"))
+	return b.String()
+}
+
+func (p *ImportPanel) renderResult(width int) string {
+	var b strings.Builder
+	fmt.Fprintln(&b, dashHeader.Render("Import committed"))
+	if p.result == nil {
+		fmt.Fprintln(&b, dashDim.Render("  (no result)"))
+		return b.String()
+	}
+	if len(p.result.SystemsAdded) > 0 {
+		fmt.Fprintln(&b, "  "+dashAccent.Render("Added: ")+strings.Join(p.result.SystemsAdded, ", "))
+	}
+	if len(p.result.SystemsReplaced) > 0 {
+		fmt.Fprintln(&b, "  "+dashAccent.Render("Replaced: ")+strings.Join(p.result.SystemsReplaced, ", "))
+	}
+	if len(p.result.CSVPaths) > 0 {
+		fmt.Fprintln(&b)
+		fmt.Fprintln(&b, dashHeader.Render("Talkgroup CSVs"))
+		for _, p := range p.result.CSVPaths {
+			fmt.Fprintln(&b, "  "+p)
+		}
+	}
+	if p.result.ConfigPath != "" {
+		fmt.Fprintln(&b)
+		fmt.Fprintln(&b, dashDim.Render("  config.yaml @ "+p.result.ConfigPath))
+	}
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, dashDim.Render("  esc/a back to stage"))
+	return b.String()
+}

--- a/internal/tui/panels/import_test.go
+++ b/internal/tui/panels/import_test.go
@@ -1,0 +1,105 @@
+package panels
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/MattCheramie/GopherTrunk/internal/tui/client"
+	"github.com/MattCheramie/GopherTrunk/internal/tui/state"
+)
+
+func TestImportPanelAddPath(t *testing.T) {
+	dir := t.TempDir()
+	csv := filepath.Join(dir, "x.csv")
+	if err := os.WriteFile(csv, []byte("# csv"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	p := NewImport()
+	shared := &state.SharedState{Runtime: client.RuntimeDTO{ConfigPath: "/etc/cfg.yaml"}}
+
+	// Type the path one rune at a time so the textinput's parser
+	// sees real KeyMsg values.
+	for _, r := range csv {
+		_, _ = p.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}}, shared)
+	}
+	// Press enter to add.
+	_, _ = p.Update(tea.KeyMsg{Type: tea.KeyEnter}, shared)
+	if len(p.paths) != 1 {
+		t.Fatalf("paths=%v want 1 entry", p.paths)
+	}
+	if p.paths[0] != csv {
+		t.Errorf("paths[0]=%q want %q", p.paths[0], csv)
+	}
+
+	// Press Ctrl-X to clear.
+	_, _ = p.Update(tea.KeyMsg{Type: tea.KeyCtrlX}, shared)
+	if len(p.paths) != 0 {
+		t.Errorf("after clear, paths=%v want empty", p.paths)
+	}
+}
+
+func TestImportPanelUploadEmits(t *testing.T) {
+	p := NewImport()
+	p.paths = []string{"/tmp/a.csv", "/tmp/b.pdf"}
+
+	_, cmd := p.Update(tea.KeyMsg{Type: tea.KeyCtrlU}, nil)
+	if cmd == nil {
+		t.Fatal("expected upload cmd, got nil")
+	}
+	msg := cmd()
+	upload, ok := msg.(ImportUploadMsg)
+	if !ok {
+		t.Fatalf("got %T, want ImportUploadMsg", msg)
+	}
+	if len(upload.Paths) != 2 {
+		t.Errorf("paths=%v want 2 entries", upload.Paths)
+	}
+}
+
+func TestImportPanelPreviewToCommit(t *testing.T) {
+	p := NewImport()
+	// Inject a preview result.
+	updated, _ := p.Update(ImportPreviewArrivedMsg{Preview: client.ImportPreview{
+		ID: "abc123",
+		Systems: []client.ParsedSystemDTO{
+			{Name: "Sys1", Protocol: "p25", SiteCount: 1, TalkgroupCt: 2},
+		},
+	}}, nil)
+	p = updated.(*ImportPanel)
+	if p.view != importPreviewView {
+		t.Fatalf("view=%v want importPreviewView", p.view)
+	}
+
+	_, cmd := p.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'c'}}, nil)
+	if cmd == nil {
+		t.Fatal("expected commit cmd")
+	}
+	commit, ok := cmd().(ImportCommitMsg)
+	if !ok {
+		t.Fatalf("got %T, want ImportCommitMsg", cmd())
+	}
+	if commit.ID != "abc123" {
+		t.Errorf("commit ID=%q want abc123", commit.ID)
+	}
+}
+
+func TestImportPanelResultViewRendersAddedSystems(t *testing.T) {
+	p := NewImport()
+	updated, _ := p.Update(ImportResultArrivedMsg{Result: client.ImportResult{
+		SystemsAdded: []string{"Sys1", "Sys2"},
+		ConfigPath:   "/etc/cfg.yaml",
+	}}, nil)
+	p = updated.(*ImportPanel)
+	if p.view != importResultView {
+		t.Fatalf("view=%v want importResultView", p.view)
+	}
+	out := p.View(80, 30, true, &state.SharedState{})
+	if !strings.Contains(out, "Sys1") || !strings.Contains(out, "Sys2") {
+		t.Errorf("output missing added systems: %q", out)
+	}
+}

--- a/internal/tui/panels/settings.go
+++ b/internal/tui/panels/settings.go
@@ -139,6 +139,7 @@ func (p *SettingsPanel) refresh(sys []client.SystemDTO) {
 
 func (p *SettingsPanel) View(width, height int, focused bool, s *state.SharedState) string {
 	header := p.renderTabBar(width)
+	banner := p.renderEditBanner(s)
 	var body string
 	if p.tab == tabFEC {
 		p.tbl.SetColumns(settingsColumns(width))
@@ -150,7 +151,23 @@ func (p *SettingsPanel) View(width, height int, focused bool, s *state.SharedSta
 	} else {
 		body = p.renderTab(width, s)
 	}
-	return panelFrame("Settings", width, height, focused, header+"\n"+body)
+	return panelFrame("Settings", width, height, focused, header+"\n"+banner+body)
+}
+
+// renderEditBanner surfaces the daemon's live-edit capability: when
+// the daemon ran with -config, settings can be edited via
+// PATCH /api/v1/settings (curl / web SPA); without a config file the
+// endpoint returns 503 and the panel stays purely read-only.
+func (p *SettingsPanel) renderEditBanner(s *state.SharedState) string {
+	if s == nil {
+		return ""
+	}
+	if s.Runtime.ConfigPath == "" {
+		return dashDim.Render(
+			"  daemon running without -config — Settings are read-only (PATCH /api/v1/settings returns 503)") + "\n\n"
+	}
+	return dashDim.Render(
+		"  live edits supported — PATCH /api/v1/settings (config @ "+s.Runtime.ConfigPath+")") + "\n\n"
 }
 
 func (p *SettingsPanel) renderTabBar(width int) string {

--- a/internal/tui/state/state.go
+++ b/internal/tui/state/state.go
@@ -25,6 +25,7 @@ const (
 	PanelDevices
 	PanelScanner
 	PanelSettings
+	PanelImport
 	PanelCount
 )
 
@@ -52,6 +53,8 @@ func (p PanelKind) String() string {
 		return "Scanner"
 	case PanelSettings:
 		return "Settings"
+	case PanelImport:
+		return "Import"
 	}
 	return "?"
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -11,6 +11,7 @@ import { Dashboard } from "./panels/Dashboard";
 import { Devices } from "./panels/Devices";
 import { Events } from "./panels/Events";
 import { History } from "./panels/History";
+import { Import } from "./panels/Import";
 import { Metrics } from "./panels/Metrics";
 import { Scanner } from "./panels/Scanner";
 import { Settings } from "./panels/Settings";
@@ -36,6 +37,7 @@ const EXTRA_TABS: Tab[] = [
   { to: "/tones", label: "Tones", icon: "♪" },
   { to: "/metrics", label: "Metrics", icon: "▰" },
   { to: "/devices", label: "Devices", icon: "⌗" },
+  { to: "/import", label: "Import", icon: "↗" },
 ];
 
 export function App() {
@@ -131,6 +133,7 @@ export function App() {
           <Route path="/metrics" element={<Metrics />} />
           <Route path="/devices" element={<Devices />} />
           <Route path="/settings" element={<Settings />} />
+          <Route path="/import" element={<Import />} />
           <Route path="*" element={<Navigate to="/dashboard" replace />} />
         </Routes>
       </main>

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -150,9 +150,83 @@ export interface RuntimeDTO {
     cors_allowed_origins?: string[];
   };
   audio?: AudioStatusDTO;
+  // ConfigPath is non-empty when the daemon was started with a
+  // -config file. The SPA renders the Settings panel as editable
+  // only when this is set; an empty value means PATCH /api/v1/settings
+  // returns 503 and edits would be lost.
+  config_path?: string;
+  // StartupWarnings are the non-fatal observations the daemon
+  // collected during NewDaemon. The Dashboard pins them until the
+  // operator dismisses them.
+  startup_warnings?: string[];
   // RuntimeDTO is large and changes shape as the daemon grows. Read
   // unknown fields lazily.
   [key: string]: unknown;
+}
+
+// SettingsPatch mirrors the daemon's PATCH /api/v1/settings body.
+// Every field is optional; the daemon leaves unspecified fields
+// alone. Use snake_case keys to match the wire format directly.
+export interface SettingsPatch {
+  log_level?: string;
+  log_format?: string;
+  api_http_addr?: string;
+  api_grpc_addr?: string;
+  api_auth_mode?: string;
+  audio_enabled?: boolean;
+  audio_device?: string;
+  audio_volume?: number;
+  audio_muted?: boolean;
+  audio_buffer_ms?: number;
+  recordings_dir?: string;
+  recordings_sample_rate?: number;
+  recordings_write_raw?: boolean;
+  retention_call_log_days?: number;
+  retention_files_days?: number;
+  retention_interval?: string;
+  sdr_sample_rate?: number;
+  scanner_scan_mode?: string;
+  scanner_manual_tune_enabled?: boolean;
+  scanner_cc_hunt_enabled?: boolean;
+  scanner_cc_hunt_dwell_ms?: number;
+  scanner_cc_hunt_backoff_ms?: number;
+  scanner_cc_hunt_max_backoff_ms?: number;
+  storage_path?: string;
+  storage_cc_cache_file?: string;
+  metrics_enabled?: boolean;
+}
+
+export interface SettingsResponse {
+  applied: string[];
+  restart_required: string[];
+  config_path?: string;
+  runtime: RuntimeDTO;
+}
+
+// ParsedSystemDTO is one row in an import preview.
+export interface ParsedSystemDTO {
+  name: string;
+  protocol: string;
+  site_count: number;
+  talkgroup_count: number;
+  source_path?: string;
+  location?: string;
+  county?: string;
+  sysid?: string;
+  wacn?: string;
+  system_type?: string;
+}
+
+export interface ImportPreview {
+  id: string;
+  systems: ParsedSystemDTO[];
+}
+
+export interface ImportResult {
+  systems_added: string[];
+  systems_replaced?: string[];
+  csv_paths?: string[];
+  config_path?: string;
 }
 
 export interface EventDTO {

--- a/web/src/api/write.ts
+++ b/web/src/api/write.ts
@@ -1,7 +1,14 @@
 // Mutation endpoints. Mirrors internal/tui/client/write.go.
 
-import { type ClientConfig, request } from "./client";
-import type { AudioStatusDTO, TalkgroupDTO } from "./types";
+import { type ClientConfig, joinURL, HTTPError, request } from "./client";
+import type {
+  AudioStatusDTO,
+  ImportPreview,
+  ImportResult,
+  SettingsPatch,
+  SettingsResponse,
+  TalkgroupDTO,
+} from "./types";
 
 export interface TalkgroupPatch {
   priority?: number;
@@ -87,4 +94,61 @@ export const writes = {
 
   clearManualTune: (c: ClientConfig, index: number) =>
     request<void>(c, "DELETE", `/api/v1/scanner/manual_tune/${index}`),
+
+  updateSettings: (c: ClientConfig, patch: SettingsPatch) =>
+    request<SettingsResponse>(c, "PATCH", "/api/v1/settings", patch),
+
+  importUpload: (c: ClientConfig, files: File[]) =>
+    importMultipart(c, files),
+
+  importCommit: (c: ClientConfig, id: string, force = false) =>
+    request<ImportResult>(
+      c,
+      "POST",
+      `/api/v1/import/${encodeURIComponent(id)}/commit${force ? "?force=true" : ""}`,
+    ),
+
+  importDiscard: (c: ClientConfig, id: string) =>
+    request<void>(c, "DELETE", `/api/v1/import/${encodeURIComponent(id)}`),
 };
+
+// importMultipart wraps the multipart upload separately because
+// request() in client.ts only does JSON bodies. The shape matches
+// the request helper otherwise (token, bearer, abort timeout).
+async function importMultipart(
+  cfg: ClientConfig,
+  files: File[],
+): Promise<ImportPreview> {
+  const url = joinURL(cfg.baseURL, "/api/v1/import");
+  const headers: Record<string, string> = { Accept: "application/json" };
+  if (cfg.token) headers["Authorization"] = `Bearer ${cfg.token}`;
+
+  const body = new FormData();
+  for (const f of files) body.append("files", f, f.name);
+
+  const controller = new AbortController();
+  // 60s — uploads can be large enough that the default 10s would
+  // race a slow Pi over wifi.
+  const timer = window.setTimeout(() => controller.abort(), 60_000);
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      method: "POST",
+      headers,
+      body,
+      credentials: "include",
+      signal: controller.signal,
+    });
+  } finally {
+    window.clearTimeout(timer);
+  }
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new HTTPError(
+      res.status,
+      text,
+      `POST /api/v1/import → ${res.status}: ${text || res.statusText}`,
+    );
+  }
+  return (await res.json()) as ImportPreview;
+}

--- a/web/src/panels/Import.tsx
+++ b/web/src/panels/Import.tsx
@@ -1,0 +1,309 @@
+import { useEffect, useState } from "react";
+import { api, HTTPError } from "../api/client";
+import { writes } from "../api/write";
+import type { ImportPreview, ImportResult, RuntimeDTO } from "../api/types";
+import {
+  selectCanMutate,
+  selectClientConfig,
+  useShared,
+} from "../store/shared";
+
+// Import mirrors the TUI's live-import panel. Three views:
+//
+//  - Stage     drop / pick files; preview after upload
+//  - Preview   parsed systems table; commit or discard
+//  - Result    systems_added / systems_replaced / csv_paths
+//
+// The endpoint returns 503 when the daemon was started without
+// -config — in that case we render a read-only banner pointing the
+// operator at the docs.
+export function Import() {
+  const cfg = useShared(selectClientConfig);
+  const canMutate = useShared(selectCanMutate);
+  const setError = useShared((s) => s.setError);
+
+  const [files, setFiles] = useState<File[]>([]);
+  const [preview, setPreview] = useState<ImportPreview | null>(null);
+  const [result, setResult] = useState<ImportResult | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [runtime, setRuntime] = useState<RuntimeDTO | null>(null);
+
+  useEffect(() => {
+    let cancel = false;
+    api.runtime(cfg)
+      .then((r) => { if (!cancel) setRuntime(r); })
+      .catch(() => {});
+    return () => { cancel = true; };
+  }, [cfg]);
+
+  const hasConfig = !!runtime?.config_path;
+
+  function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const list = e.target.files;
+    if (!list) return;
+    setFiles(Array.from(list));
+    setPreview(null);
+    setResult(null);
+  }
+
+  async function upload() {
+    if (files.length === 0) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const p = await writes.importUpload(cfg, files);
+      setPreview(p);
+    } catch (e) {
+      if (e instanceof HTTPError) {
+        setError(`Import upload failed: ${e.message}`);
+      } else {
+        setError(String(e));
+      }
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function commit() {
+    if (!preview) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const r = await writes.importCommit(cfg, preview.id, false);
+      setResult(r);
+      setPreview(null);
+    } catch (e) {
+      if (e instanceof HTTPError) {
+        setError(`Import commit failed: ${e.message}`);
+      } else {
+        setError(String(e));
+      }
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function discard() {
+    if (!preview) return;
+    setBusy(true);
+    try {
+      await writes.importDiscard(cfg, preview.id);
+    } catch {
+      // Discard is a courtesy — failure is fine; the TTL sweeper
+      // will drop the entry eventually.
+    } finally {
+      setPreview(null);
+      setBusy(false);
+    }
+  }
+
+  function reset() {
+    setFiles([]);
+    setPreview(null);
+    setResult(null);
+  }
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-lg font-semibold">Import systems / talkgroups</h1>
+
+      {!hasConfig && (
+        <div className="panel bg-warn/15 border-warn/40 text-warn p-3 text-sm">
+          The daemon is running without a <code>-config</code> file, so the
+          import endpoint returns 503. Restart the daemon with
+          <code> -config /path/to/config.yaml</code> to enable in-process
+          imports.
+        </div>
+      )}
+
+      {!canMutate && (
+        <div className="panel bg-warn/15 border-warn/40 text-warn p-3 text-sm">
+          Mutations are disabled on this daemon. Pass the token / configure
+          auth so this client can write.
+        </div>
+      )}
+
+      {result ? (
+        <ResultView result={result} onReset={reset} />
+      ) : preview ? (
+        <PreviewView
+          preview={preview}
+          busy={busy}
+          onCommit={commit}
+          onDiscard={discard}
+        />
+      ) : (
+        <StageView
+          files={files}
+          busy={busy}
+          disabled={!hasConfig || !canMutate}
+          onFileChange={handleFileChange}
+          onUpload={upload}
+          onClear={() => setFiles([])}
+        />
+      )}
+    </div>
+  );
+}
+
+function StageView({
+  files,
+  busy,
+  disabled,
+  onFileChange,
+  onUpload,
+  onClear,
+}: {
+  files: File[];
+  busy: boolean;
+  disabled: boolean;
+  onFileChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onUpload: () => void;
+  onClear: () => void;
+}) {
+  return (
+    <div className="panel p-4 space-y-3">
+      <p className="text-sm text-muted">
+        Drop one or more <code>.pdf</code> (RadioReference) or{" "}
+        <code>.csv</code> (multi-section bundle) files. The daemon parses them
+        in memory and shows you a preview before merging into{" "}
+        <code>config.yaml</code>.
+      </p>
+      <input
+        type="file"
+        multiple
+        accept=".pdf,.csv"
+        onChange={onFileChange}
+        disabled={disabled || busy}
+        className="text-sm"
+      />
+      {files.length > 0 && (
+        <ul className="text-sm space-y-1">
+          {files.map((f, i) => (
+            <li key={i} className="text-muted">
+              {f.name}{" "}
+              <span className="text-xs opacity-70">
+                ({Math.ceil(f.size / 1024)} KiB)
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+      <div className="flex gap-2">
+        <button
+          disabled={disabled || busy || files.length === 0}
+          onClick={onUpload}
+          className="btn btn-primary disabled:opacity-50"
+        >
+          {busy ? "Uploading…" : `Upload ${files.length || ""} file(s)`}
+        </button>
+        <button
+          disabled={busy || files.length === 0}
+          onClick={onClear}
+          className="btn disabled:opacity-50"
+        >
+          Clear
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function PreviewView({
+  preview,
+  busy,
+  onCommit,
+  onDiscard,
+}: {
+  preview: ImportPreview;
+  busy: boolean;
+  onCommit: () => void;
+  onDiscard: () => void;
+}) {
+  return (
+    <div className="panel p-4 space-y-3">
+      <h2 className="font-semibold">Parsed systems</h2>
+      <table className="text-sm w-full">
+        <thead>
+          <tr className="text-muted text-left">
+            <th className="py-1">Name</th>
+            <th className="py-1">Protocol</th>
+            <th className="py-1">Sites</th>
+            <th className="py-1">Talkgroups</th>
+            <th className="py-1">Location</th>
+          </tr>
+        </thead>
+        <tbody>
+          {preview.systems.map((s, i) => (
+            <tr key={i} className="border-t border-panel">
+              <td className="py-1 font-mono">{s.name}</td>
+              <td className="py-1">{s.protocol}</td>
+              <td className="py-1">{s.site_count}</td>
+              <td className="py-1">{s.talkgroup_count}</td>
+              <td className="py-1 text-muted">{s.location || "—"}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <p className="text-xs text-muted">staging id: {preview.id}</p>
+      <div className="flex gap-2">
+        <button
+          disabled={busy}
+          onClick={onCommit}
+          className="btn btn-primary disabled:opacity-50"
+        >
+          {busy ? "Committing…" : "Commit to config.yaml"}
+        </button>
+        <button
+          disabled={busy}
+          onClick={onDiscard}
+          className="btn disabled:opacity-50"
+        >
+          Discard
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function ResultView({
+  result,
+  onReset,
+}: {
+  result: ImportResult;
+  onReset: () => void;
+}) {
+  return (
+    <div className="panel p-4 space-y-3">
+      <h2 className="font-semibold">Import committed</h2>
+      {result.systems_added && result.systems_added.length > 0 && (
+        <p className="text-sm">
+          <span className="text-ok">Added:</span>{" "}
+          {result.systems_added.join(", ")}
+        </p>
+      )}
+      {result.systems_replaced && result.systems_replaced.length > 0 && (
+        <p className="text-sm">
+          <span className="text-warn">Replaced:</span>{" "}
+          {result.systems_replaced.join(", ")}
+        </p>
+      )}
+      {result.csv_paths && result.csv_paths.length > 0 && (
+        <div className="text-xs text-muted">
+          <p>Talkgroup CSVs:</p>
+          <ul className="space-y-1 pl-4">
+            {result.csv_paths.map((p, i) => (
+              <li key={i}>{p}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+      {result.config_path && (
+        <p className="text-xs text-muted">config.yaml @ {result.config_path}</p>
+      )}
+      <button onClick={onReset} className="btn">
+        Import more
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
When the daemon starts on an interactive terminal it now asks the
operator how to drive it: an in-process TUI, the bundled web SPA in
the system browser, or stay headless. The choice can be pre-selected
via -tui / -web / -headless; non-TTY stdin (systemd, Windows service)
stays silent.

Closed-LAN defaults: the api.auth.mode default flips to "disabled" and
empty api.cors.allowed_origins now allows any origin. Operators on
hostile networks see startup warnings and can opt back into the strict
behaviour via explicit config.

Startup hardening so the launcher never lands against a half-dead
daemon: HTTP/gRPC/engine spawns are essential (their errors cancel the
daemon ctx instead of being demoted to warnings), a Daemon.Ready
channel gates the launcher, a preflight step creates recordings /
storage / cc_cache parent dirs and verifies TLS cert/key parse, and
talkgroup CSV or SDR pool failures collect into startupWarnings so
they surface above the launcher menu instead of vanishing into the log.

The logger writes through a SwappableWriter so the launcher can
redirect daemon logs to a tempfile while the in-process TUI owns the
terminal and restore stderr on exit.

https://claude.ai/code/session_01EpTn9SfKiajBuF1N6e4Wc6