### PR TITLE
launcher: deferred follow-ups — inline-edit Settings, embed SPA, SIGHUP, flock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,37 @@ for tagged releases.
   vanishing into the log. HTTP and gRPC bind failures now abort the
   daemon cleanly instead of being demoted to warnings — the launcher
   never lands against a half-dead daemon.
+- **Embedded web SPA.** The daemon binary now embeds the built SPA
+  (when `make web-build` was run before `go build`) and serves it
+  at `/` on the HTTP API. `gophertrunk -web` opens the daemon URL
+  directly; client-side routes (`/scanner`, `/settings`, `/import`,
+  …) fall back to `index.html` so React-Router takes over. Fresh
+  checkouts without a `web/dist/` build keep the existing sibling-
+  directory discovery path. See [`docs/web.md`](docs/web.md).
+- **Inline-editable Settings.** Every editable runtime knob the
+  daemon hot-reloads (audio volume / mute, log level, scanner scan
+  mode, …) plus the restart-required ones are now editable from
+  both the TUI Settings panel (cursor + Enter to edit, Enter to
+  save, Esc to cancel) and the web SPA's `/settings` route. Rows
+  show a `[restart]` badge when the daemon can't hot-apply.
+- **SIGHUP config reload.** Sending `SIGHUP` to a running daemon
+  reloads `config.yaml`, diff-applies hot-reloadable fields, and
+  logs a list of restart-required changes. The signal handler is a
+  no-op on Windows.
+- **Single-instance lock.** The daemon now flocks
+  `<configdir>/.gophertrunk.lock` at startup so two instances aimed
+  at the same `config.yaml` can't both try to claim the same
+  RTL-SDR devices. The contender exits with a clear "another
+  gophertrunk is running (pid=…, started=…)" message instead of an
+  opaque libusb error.
+- **Friendlier YAML errors.** `config: <path>: parse error …` now
+  carries the resolved config path and a hint to run the wizard or
+  recheck indentation.
+- **Patent-posture notice plumbed through `startup_warnings`.**
+  The AMBE+2 advisory no longer scrolls past on the daemon log
+  immediately before the launcher prompt; it lands in the warnings
+  channel and surfaces on the launcher menu / TUI dashboard / runtime
+  DTO. `GOPHERTRUNK_QUIET_BANNER=1` still suppresses it for CI.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -38,10 +38,13 @@ curl -L -o gophertrunk.tar.gz \
 tar xzf gophertrunk.tar.gz && cd gophertrunk-${VERSION}-linux-amd64
 cp config.example.yaml config.yaml
 ./gophertrunk version
-./gophertrunk run -config config.yaml
+# Plain `./gophertrunk` (no subcommand, on a TTY) drops into the
+# interactive launcher: pick [1] TUI, [2] Web, or [3] Headless.
+# Skip the prompt with -tui / -web / -headless.
+./gophertrunk -config config.yaml
 ```
 
-Full per-OS install (Windows installer / macOS Apple Silicon / Linux aarch64): **[gophertrunk.org/downloads.html](https://gophertrunk.org/downloads.html)** · Web console setup + quick start: **[gophertrunk.org/web.html](https://gophertrunk.org/web.html)** · TUI keybindings: [`docs/tui.md`](docs/tui.md) · Hardware setup (udev rules, WinUSB / Zadig): [`docs/hardware.md`](docs/hardware.md) · Production hardening (TLS, bearer-token auth, Docker): [`docs/hardening.md`](docs/hardening.md).
+Full per-OS install (Windows installer / macOS Apple Silicon / Linux aarch64): **[gophertrunk.org/downloads.html](https://gophertrunk.org/downloads.html)** · Launcher / `-tui` / `-web` / `-headless`: [`docs/launcher.md`](docs/launcher.md) · Web console setup + quick start: **[gophertrunk.org/web.html](https://gophertrunk.org/web.html)** · TUI keybindings: [`docs/tui.md`](docs/tui.md) · Hardware setup (udev rules, WinUSB / Zadig): [`docs/hardware.md`](docs/hardware.md) · Production hardening (TLS, bearer-token auth, Docker): [`docs/hardening.md`](docs/hardening.md).
 
 ## Features
 
@@ -57,7 +60,7 @@ Full per-OS install (Windows installer / macOS Apple Silicon / Linux aarch64): *
 
 **API + observability** — gRPC + HTTP/SSE + WebSocket surfaces, optional TLS + bearer-token auth on mutations, Prometheus `/metrics`, pure-Go SQLite call log, in-process pub/sub event bus with typed payloads.
 
-**Operator surfaces** — first-class Bubbletea TUI cockpit (`gophertrunk tui`) with 11 panels and a sibling **web console** (a pure-browser React/Tailwind SPA, shipped pre-built as `gophertrunk-web/` next to the binary — see [`web/README.md`](web/README.md) and the [§Web console](#web-console) section); conventional FM scanner with CTCSS / DCS squelch, two-tone QC-II paging detector, runtime channel lockout, manual VFO tune.
+**Operator surfaces** — first-class Bubbletea TUI cockpit with 12 panels (including a live Import panel and inline-editable Settings) and a sibling **web console** (a pure-browser React/Tailwind SPA, either embedded into the daemon binary at build time or shipped pre-built as `gophertrunk-web/` next to the binary — see [`web/README.md`](web/README.md) and the [§Web console](#web-console) section); the daemon binary doubles as its own UI launcher (`gophertrunk -tui` / `-web` / `-headless` — see [`docs/launcher.md`](docs/launcher.md)); conventional FM scanner with CTCSS / DCS squelch, two-tone QC-II paging detector, runtime channel lockout, manual VFO tune. Live `PATCH /api/v1/settings` writes operator edits straight to `config.yaml` (comments preserved) and hot-reloads what it safely can; `POST /api/v1/import` accepts PDF / CSV uploads, parses + previews, then merges into the running daemon.
 
 **System bring-up** — `gophertrunk import-pdf` parses RadioReference.com trunking-system PDF exports and structured multi-section CSV bundles, then merges sites + talkgroups into `config.yaml` (preserving comments) plus per-system Trunk-Recorder-format CSVs. Interactive Bubbletea TUI for pruning sites, toggling Scan / Lockout / Priority before write; `-no-tui` / `-dry-run` / `-force` for CI. **`-wizard`** launches an interactive config-builder that walks through every section of `config.yaml` (log, API, auth, CORS, storage, recordings, retention, SDR devices, scanner, audio) so first-time operators get a runnable file without hand-editing YAML. See **[`docs/import.md`](docs/import.md)**.
 

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/MattCheramie/GopherTrunk/internal/api"
 	"github.com/MattCheramie/GopherTrunk/internal/config"
+	gtweb "github.com/MattCheramie/GopherTrunk/web"
 	"github.com/MattCheramie/GopherTrunk/internal/events"
 	"github.com/MattCheramie/GopherTrunk/internal/metrics"
 	"github.com/MattCheramie/GopherTrunk/internal/scanner/ccdecoder"
@@ -648,6 +649,13 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 			opts.ConfigWriter = d.writer
 			opts.SettingsApplier = newDaemonSettingsApplier(d, version)
 			opts.Importer = newDaemonImporter(d)
+		}
+		// Embed the SPA when the build linked in real assets
+		// (see web/embed.go). HasAssets is false for fresh
+		// checkouts without `make web-build` — the launcher falls
+		// back to filesystem discovery in that case.
+		if gtweb.HasAssets() {
+			opts.WebAssets = gtweb.Assets()
 		}
 		srv, err := api.NewServer(opts)
 		if err != nil {

--- a/cmd/gophertrunk/instance_lock_test.go
+++ b/cmd/gophertrunk/instance_lock_test.go
@@ -1,0 +1,71 @@
+//go:build !windows
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestInstanceLock_EmptyPathIsNoop(t *testing.T) {
+	release, err := acquireInstanceLock("")
+	if err != nil {
+		t.Fatalf("acquire: %v", err)
+	}
+	if release == nil {
+		t.Fatal("release func is nil")
+	}
+	release()
+}
+
+func TestInstanceLock_AcquireAndRelease(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(cfgPath, []byte("log:\n  level: info\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	release, err := acquireInstanceLock(cfgPath)
+	if err != nil {
+		t.Fatalf("first acquire: %v", err)
+	}
+
+	// Second acquire on same path should fail with a clear message.
+	_, err2 := acquireInstanceLock(cfgPath)
+	if err2 == nil {
+		t.Fatal("expected second acquire to fail")
+	}
+	if !strings.Contains(err2.Error(), "another gophertrunk is running") {
+		t.Errorf("want 'another gophertrunk is running' in error, got %q", err2.Error())
+	}
+
+	// After release, a fresh acquire succeeds.
+	release()
+	release2, err := acquireInstanceLock(cfgPath)
+	if err != nil {
+		t.Fatalf("re-acquire after release: %v", err)
+	}
+	release2()
+}
+
+func TestInstanceLock_LockFileContents(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(cfgPath, []byte("log:\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	release, err := acquireInstanceLock(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer release()
+	body, err := os.ReadFile(filepath.Join(dir, ".gophertrunk.lock"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(body), "pid=") || !strings.Contains(string(body), "started=") {
+		t.Errorf("lock file should record pid + started timestamp, got %q", string(body))
+	}
+}

--- a/cmd/gophertrunk/instance_lock_unix.go
+++ b/cmd/gophertrunk/instance_lock_unix.go
@@ -1,0 +1,128 @@
+//go:build !windows
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+)
+
+// acquireInstanceLock takes an advisory POSIX flock on a sibling of
+// the supplied config path so two daemons aimed at the same config
+// can't both try to claim the same RTL-SDR dongles via libusb. The
+// lock file holds the running PID + start timestamp so operators
+// who hit the contention case can immediately see who's holding it.
+//
+// Returns a release function that must be called on shutdown (defer
+// in main). releaseFn closes the file descriptor, which drops the
+// lock; the file itself is intentionally left in place so subsequent
+// starts can still inspect "who held this last?" forensically.
+//
+// Daemons started without a -config file (cfgPath == "") get a no-op
+// lock — sharing built-in defaults across multiple instances is fine
+// because no two of them can have configured the same SDR pool.
+func acquireInstanceLock(cfgPath string) (releaseFn func(), err error) {
+	if cfgPath == "" {
+		return func() {}, nil
+	}
+	dir := filepath.Dir(cfgPath)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, fmt.Errorf("instance lock: ensure dir %s: %w", dir, err)
+	}
+	lockPath := filepath.Join(dir, ".gophertrunk.lock")
+	f, err := os.OpenFile(lockPath, os.O_RDWR|os.O_CREATE, 0o644)
+	if err != nil {
+		return nil, fmt.Errorf("instance lock: open %s: %w", lockPath, err)
+	}
+	// Non-blocking exclusive flock — we want the second daemon to
+	// fail fast, not hang waiting for the first to exit.
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		// Read the existing file for forensic context — the previous
+		// holder wrote its PID + start timestamp on acquisition.
+		info := readLockInfo(lockPath)
+		_ = f.Close()
+		if errors.Is(err, syscall.EWOULDBLOCK) {
+			return nil, fmt.Errorf(
+				"another gophertrunk is running against %s%s; use a different -config or stop the other process",
+				cfgPath, info)
+		}
+		return nil, fmt.Errorf("instance lock: flock %s: %w", lockPath, err)
+	}
+
+	// Truncate + write our identity so operators can see who owns
+	// the lock.
+	_ = f.Truncate(0)
+	_, _ = f.Seek(0, 0)
+	body := fmt.Sprintf("pid=%d\nstarted=%s\nconfig=%s\n",
+		os.Getpid(), time.Now().UTC().Format(time.RFC3339), cfgPath)
+	_, _ = f.WriteString(body)
+
+	release := func() {
+		// Drop the lock; flock is released on FD close.
+		_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+		_ = f.Close()
+	}
+	return release, nil
+}
+
+// readLockInfo returns " (pid=42, started=…)" or "" if the lock
+// file can't be parsed. Best-effort — surfaced to the operator
+// purely for context.
+func readLockInfo(path string) string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	var pid, started string
+	for _, line := range strings.Split(string(data), "\n") {
+		k, v, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		switch strings.TrimSpace(k) {
+		case "pid":
+			pid = strings.TrimSpace(v)
+		case "started":
+			started = strings.TrimSpace(v)
+		}
+	}
+	if pid == "" && started == "" {
+		return ""
+	}
+	parts := []string{}
+	if pid != "" {
+		// Verify the PID is still alive — if not, the holder
+		// crashed without releasing and the lock should never have
+		// been contended in the first place. Surface that case so
+		// the operator knows to delete the file.
+		if pidNum, err := strconv.Atoi(pid); err == nil {
+			if !pidAlive(pidNum) {
+				parts = append(parts, fmt.Sprintf("pid=%s (stale, process gone)", pid))
+			} else {
+				parts = append(parts, "pid="+pid)
+			}
+		} else {
+			parts = append(parts, "pid="+pid)
+		}
+	}
+	if started != "" {
+		parts = append(parts, "started="+started)
+	}
+	return " (" + strings.Join(parts, ", ") + ")"
+}
+
+// pidAlive reports whether the process with the given PID is still
+// running. POSIX-specific (kill 0).
+func pidAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	err := syscall.Kill(pid, 0)
+	return err == nil || errors.Is(err, syscall.EPERM)
+}

--- a/cmd/gophertrunk/instance_lock_windows.go
+++ b/cmd/gophertrunk/instance_lock_windows.go
@@ -1,0 +1,47 @@
+//go:build windows
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// acquireInstanceLock takes a Windows-style exclusive open on a
+// sibling of the supplied config path. Unlike the POSIX flock
+// version, this uses O_EXCL semantics — the file is created
+// exclusively at acquire and removed at release.
+//
+// Returns a release function that must be called on shutdown.
+// Daemons started without a -config file get a no-op lock.
+func acquireInstanceLock(cfgPath string) (releaseFn func(), err error) {
+	if cfgPath == "" {
+		return func() {}, nil
+	}
+	dir := filepath.Dir(cfgPath)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, fmt.Errorf("instance lock: ensure dir %s: %w", dir, err)
+	}
+	lockPath := filepath.Join(dir, ".gophertrunk.lock")
+	f, err := os.OpenFile(lockPath, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0o644)
+	if err != nil {
+		if errors.Is(err, os.ErrExist) {
+			return nil, fmt.Errorf(
+				"another gophertrunk is running against %s (lock file %s exists; if no other instance is running, delete it)",
+				cfgPath, lockPath)
+		}
+		return nil, fmt.Errorf("instance lock: open %s: %w", lockPath, err)
+	}
+	body := fmt.Sprintf("pid=%d\nstarted=%s\nconfig=%s\n",
+		os.Getpid(), time.Now().UTC().Format(time.RFC3339), cfgPath)
+	_, _ = f.WriteString(body)
+
+	release := func() {
+		_ = f.Close()
+		_ = os.Remove(lockPath)
+	}
+	return release, nil
+}

--- a/cmd/gophertrunk/launcher.go
+++ b/cmd/gophertrunk/launcher.go
@@ -20,6 +20,7 @@ import (
 	gtlog "github.com/MattCheramie/GopherTrunk/internal/log"
 	"github.com/MattCheramie/GopherTrunk/internal/tui"
 	"github.com/MattCheramie/GopherTrunk/internal/tui/client"
+	gtweb "github.com/MattCheramie/GopherTrunk/web"
 )
 
 // launchMode discriminates the launcher's terminal action. launchAuto
@@ -224,17 +225,35 @@ func runInProcessTUI(ctx context.Context, d *Daemon, log *slog.Logger, logSwap *
 	return err
 }
 
-// openWebUI locates a sibling gophertrunk-web/ directory and opens
-// its index.html with a #server=<url> hash so the SPA bootstraps
-// against the running daemon automatically. When no asset directory
-// is found OR no browser can be launched (headless SSH), prints a
-// clear fallback so the operator can open the URL elsewhere.
+// openWebUI opens the bundled web SPA pointed at the running
+// daemon. Resolution order:
+//
+//  1. If the daemon binary was linked with embedded web/dist assets
+//     (gtweb.HasAssets()), open the daemon URL directly — the
+//     server hosts the SPA at "/" so no file:// hop is needed.
+//  2. Otherwise search sibling-dir locations for a gophertrunk-web/
+//     directory and open its index.html with a #server=<url> hash
+//     so the SPA bootstraps against the daemon.
+//  3. Fallback: print the URL + asset path to stderr so a remote
+//     operator can open them on a machine that has a browser.
 func openWebUI(d *Daemon, log *slog.Logger) error {
 	addr := d.HTTPListenAddr()
 	if addr == "" {
 		return errors.New("-web requires api.http_addr in config")
 	}
 	serverURL := normaliseServerURL(addr)
+
+	if gtweb.HasAssets() {
+		if !canOpenBrowser() {
+			printWebFallback(serverURL, "(embedded in daemon binary)")
+			return nil
+		}
+		log.Info("launcher: opening embedded SPA", "url", serverURL)
+		if err := openBrowser(serverURL); err != nil {
+			printWebFallback(serverURL, "(embedded in daemon binary)")
+		}
+		return nil
+	}
 
 	assetPath := findWebAssets()
 	target := buildWebTargetURL(assetPath, serverURL)

--- a/cmd/gophertrunk/main.go
+++ b/cmd/gophertrunk/main.go
@@ -164,17 +164,30 @@ func runDaemon(args []string) {
 		os.Exit(2)
 	}
 
-	// Patent-posture banner — AMBE+2 decoding is patent-encumbered
+	// Single-instance lock. Two daemons aimed at the same config
+	// would race the RTL-SDR USB claim and crash both libusb hands;
+	// this surfaces the contention as a clear error before either
+	// touches the radio.
+	releaseLock, err := acquireInstanceLock(*cfgPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer releaseLock()
+
+	// Patent-posture notice — AMBE+2 decoding is patent-encumbered
 	// in some jurisdictions (DVSI IPR portfolio). The pure-Go
 	// decoder ships unconditionally as a clean-room implementation,
 	// but operators in those jurisdictions may need a license. The
-	// full discussion lives in docs/vocoders.md §"Patent posture";
-	// this one-line banner surfaces the link at startup so
-	// operators see it without having to grep the repo. Suppress
-	// with GOPHERTRUNK_QUIET_BANNER=1 (intended for CI / test
-	// harnesses where the banner is just noise).
+	// full discussion lives in docs/vocoders.md §"Patent posture".
+	// Threaded through the startup-warnings channel so it surfaces
+	// in the launcher menu / TUI dashboard / runtime DTO rather
+	// than scrolling past on the daemon log right before the
+	// interactive prompt. Suppress with GOPHERTRUNK_QUIET_BANNER=1
+	// (CI / test harnesses).
 	if os.Getenv("GOPHERTRUNK_QUIET_BANNER") == "" {
-		logger.Info("AMBE+2 voice decoding is patent-encumbered in some jurisdictions; see docs/vocoders.md §\"Patent posture\"")
+		preflightWarnings = append(preflightWarnings,
+			"AMBE+2 voice decoding is patent-encumbered in some jurisdictions; see docs/vocoders.md §\"Patent posture\"")
 	}
 
 	ctx, cancel := signal.NotifyContext(context.Background(),
@@ -199,6 +212,10 @@ func runDaemon(args []string) {
 	go func() {
 		runErr <- d.Run(ctx)
 	}()
+
+	// SIGHUP → hot-reload config.yaml (Unix only; no-op on Windows).
+	// Goroutine exits when ctx cancels.
+	go watchReloadSignal(ctx, d, logger)
 
 	// Wait for either Ready (HTTP listener bound, components
 	// settled) or the daemon's Run to return early (essential

--- a/cmd/gophertrunk/reload.go
+++ b/cmd/gophertrunk/reload.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/MattCheramie/GopherTrunk/internal/config"
+)
+
+// Reload re-loads the daemon's config from disk and diff-applies the
+// fields the daemon knows how to hot-reload. Restart-required fields
+// that changed are logged but left untouched in-memory — the operator
+// has to bounce the daemon to pick them up. Returns a one-line
+// summary suitable for the headless console / events bus.
+//
+// Used by the SIGHUP handler in main and (in the future) by the
+// /api/v1/runtime/reload endpoint when that lands.
+func (d *Daemon) Reload() (string, error) {
+	if d.cfgPath == "" {
+		return "", fmt.Errorf("reload: no config file backs this daemon")
+	}
+	newCfg, err := config.Load(d.cfgPath)
+	if err != nil {
+		return "", err
+	}
+
+	app := newDaemonSettingsApplier(d, "")
+	var applied, restartRequired []string
+
+	// Compare hot-reloadable fields against the in-memory config.
+	old := d.cfg
+
+	if newCfg.Log.Level != old.Log.Level {
+		if err := app.SetLogLevel(newCfg.Log.Level); err == nil {
+			applied = append(applied, "log.level")
+		} else {
+			restartRequired = append(restartRequired, "log.level")
+		}
+	}
+	if newCfg.Audio.Volume != old.Audio.Volume {
+		app.SetAudioVolume(newCfg.Audio.Volume)
+		applied = append(applied, "audio.volume")
+	}
+	if newCfg.Audio.Muted != old.Audio.Muted {
+		app.SetAudioMuted(newCfg.Audio.Muted)
+		applied = append(applied, "audio.muted")
+	}
+	if newCfg.Scanner.ScanMode != old.Scanner.ScanMode {
+		if err := app.SetScannerScanMode(newCfg.Scanner.ScanMode); err == nil {
+			applied = append(applied, "scanner.scan_mode")
+		} else {
+			restartRequired = append(restartRequired, "scanner.scan_mode")
+		}
+	}
+
+	// Cold fields — diff and flag but don't apply.
+	coldDiffs := map[string]bool{
+		"log.format":             newCfg.Log.Format != old.Log.Format,
+		"api.http_addr":          newCfg.API.HTTPAddr != old.API.HTTPAddr,
+		"api.grpc_addr":          newCfg.API.GRPCAddr != old.API.GRPCAddr,
+		"api.auth.mode":          newCfg.API.Auth.Mode != old.API.Auth.Mode,
+		"audio.enabled":          newCfg.Audio.Enabled != old.Audio.Enabled,
+		"audio.device":           newCfg.Audio.Device != old.Audio.Device,
+		"audio.sample_rate":      newCfg.Audio.SampleRate != old.Audio.SampleRate,
+		"audio.buffer_ms":        newCfg.Audio.BufferMs != old.Audio.BufferMs,
+		"recordings.dir":         newCfg.Recordings.Dir != old.Recordings.Dir,
+		"recordings.sample_rate": newCfg.Recordings.SampleRate != old.Recordings.SampleRate,
+		"recordings.write_raw":   newCfg.Recordings.WriteRaw != old.Recordings.WriteRaw,
+		"sdr.sample_rate":        newCfg.SDR.SampleRate != old.SDR.SampleRate,
+		"retention.call_log_days": newCfg.Retention.CallLogDays != old.Retention.CallLogDays,
+		"retention.files_days":   newCfg.Retention.FilesDays != old.Retention.FilesDays,
+		"retention.interval":     newCfg.Retention.Interval != old.Retention.Interval,
+		"storage.path":           newCfg.Storage.Path != old.Storage.Path,
+		"storage.cc_cache_file":  newCfg.Storage.CCCacheFile != old.Storage.CCCacheFile,
+		"metrics.enabled":        newCfg.Metrics.Enabled != old.Metrics.Enabled,
+		"scanner.cc_hunt.enabled": newCfg.Scanner.CCHunt.Enabled != old.Scanner.CCHunt.Enabled,
+	}
+	for key, changed := range coldDiffs {
+		if changed {
+			restartRequired = append(restartRequired, key)
+		}
+	}
+
+	// Store the new config so future PATCH /api/v1/settings reads
+	// see the freshly-loaded values when computing diffs.
+	d.cfg = newCfg
+
+	sort.Strings(applied)
+	sort.Strings(restartRequired)
+	summary := fmt.Sprintf("config reloaded: applied=%d restart_required=%d", len(applied), len(restartRequired))
+	if len(applied) > 0 {
+		summary += " (applied: " + joinComma(applied) + ")"
+	}
+	if len(restartRequired) > 0 {
+		summary += " (restart needed: " + joinComma(restartRequired) + ")"
+	}
+	return summary, nil
+}
+
+func joinComma(s []string) string {
+	out := ""
+	for i, v := range s {
+		if i > 0 {
+			out += ", "
+		}
+		out += v
+	}
+	return out
+}

--- a/cmd/gophertrunk/reload_test.go
+++ b/cmd/gophertrunk/reload_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/config"
+)
+
+const reloadInitialYAML = `log:
+  level: info
+audio:
+  enabled: true
+  volume: 0.8
+scanner:
+  scan_mode: all
+`
+
+const reloadUpdatedYAML = `log:
+  level: warn
+audio:
+  enabled: true
+  volume: 0.42
+scanner:
+  scan_mode: list
+recordings:
+  dir: /tmp/recs
+`
+
+func TestDaemonReload(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte(reloadInitialYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("load initial: %v", err)
+	}
+	d, err := NewDaemonWithPath(cfg, path, "test", slog.New(slog.NewTextHandler(os.Stderr, nil)))
+	if err != nil {
+		t.Fatalf("new daemon: %v", err)
+	}
+
+	// Rewrite config.yaml with new values.
+	if err := os.WriteFile(path, []byte(reloadUpdatedYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	summary, err := d.Reload()
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if !strings.Contains(summary, "scanner.scan_mode") {
+		t.Errorf("expected scan_mode in applied list, got %q", summary)
+	}
+	if !strings.Contains(summary, "audio.volume") {
+		t.Errorf("expected audio.volume in applied list, got %q", summary)
+	}
+	if !strings.Contains(summary, "recordings.dir") {
+		t.Errorf("expected recordings.dir in restart-required, got %q", summary)
+	}
+	// In-memory cfg should now reflect the updated file.
+	if d.cfg.Scanner.ScanMode != "list" {
+		t.Errorf("in-memory scan_mode = %q want list", d.cfg.Scanner.ScanMode)
+	}
+}
+
+func TestDaemonReload_NoConfigPath(t *testing.T) {
+	cfg := config.Default()
+	d, err := NewDaemonWithPath(cfg, "", "test", slog.New(slog.NewTextHandler(os.Stderr, nil)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := d.Reload(); err == nil {
+		t.Fatal("expected error for daemon without config file")
+	}
+}

--- a/cmd/gophertrunk/sighup_unix.go
+++ b/cmd/gophertrunk/sighup_unix.go
@@ -1,0 +1,34 @@
+//go:build !windows
+
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+// watchReloadSignal listens for SIGHUP and triggers a daemon config
+// reload on each receipt. Cancellation tears down the signal
+// handler. On Windows there is no SIGHUP (see sighup_windows.go for
+// the no-op build).
+func watchReloadSignal(ctx context.Context, d *Daemon, log *slog.Logger) {
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, syscall.SIGHUP)
+	defer signal.Stop(ch)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ch:
+			summary, err := d.Reload()
+			if err != nil {
+				log.Warn("sighup: reload failed", "err", err)
+				continue
+			}
+			log.Info(summary)
+		}
+	}
+}

--- a/cmd/gophertrunk/sighup_windows.go
+++ b/cmd/gophertrunk/sighup_windows.go
@@ -1,0 +1,14 @@
+//go:build windows
+
+package main
+
+import (
+	"context"
+	"log/slog"
+)
+
+// watchReloadSignal is a no-op on Windows — SIGHUP isn't available
+// there. Operators reload by restarting the daemon (or by issuing
+// PATCH /api/v1/settings, which is the same hot-reload path under
+// the hood).
+func watchReloadSignal(_ context.Context, _ *Daemon, _ *slog.Logger) {}

--- a/docs/hardening.md
+++ b/docs/hardening.md
@@ -13,26 +13,51 @@ assets, and the RTL-SDR USB pass-through recipe.
 
 ## API authentication
 
+> **Default flipped for closed-LAN deployments.** Empty
+> `api.auth.mode` now resolves to `disabled` (was `auto`) and an
+> empty `api.cors.allowed_origins` permits any origin. The daemon
+> logs a loud warning at startup whenever those defaults take effect
+> on a non-loopback bind — see the "Hostile networks" section below
+> for the recipe to opt back in. Operators on closed networks who
+> just want the TUI / SPA to work no longer need any explicit auth
+> config.
+
 Every HTTP mutation endpoint (end-call, talkgroup priority/lockout/
 scan, retention sweep, tone-detector reset, scanner cockpit, audio
-cockpit, manual tune) is gated by `api.auth` in `config.yaml`. The
-default policy (`mode: auto`) is loopback-permissive but requires a
-bearer token on every public-interface bind.
+cockpit, manual tune, **settings PATCH**, **import upload/commit**) is
+gated by `api.auth` in `config.yaml`.
 
 ### Policy modes
 
-- **`auto` (default).** Require a bearer token on non-loopback binds;
-  bypass the check when bound to `127.0.0.1` / `::1`. Reasonable for
+- **`disabled` (default — empty `mode` resolves here).** Wide-open
+  mutations, no auth. Equivalent to the legacy `allow_mutations: true`
+  behaviour; the daemon logs a warning at startup when bound to a
+  non-loopback interface. Appropriate for closed-LAN single-host
+  setups where the operator already has shell on the box.
+- **`auto`.** Require a bearer token on non-loopback binds; bypass
+  the check when bound to `127.0.0.1` / `::1`. Reasonable for
   single-host operator boxes — kernel-enforced reachability is a
   peer-cred proxy. The daemon refuses to start in `auto` mode on a
   public bind without a configured token.
 - **`required`.** Every mutation request must carry a valid Bearer
   token, even from loopback. Use when the daemon shares a host with
   untrusted users.
-- **`disabled`.** Wide-open mutations, no auth. Equivalent to the
-  legacy `allow_mutations: true` behaviour; the daemon logs a warning
-  at startup. Only safe behind an external proxy that does its own
-  auth, or on a strictly trusted segment.
+
+### Hostile networks — opt back into the safer posture
+
+```yaml
+api:
+  http_addr: "0.0.0.0:8080"
+  auth:
+    mode: "required"             # or "auto" for the loopback bypass
+    token_file: "/etc/gophertrunk/api-token"
+  cors:
+    allowed_origins:
+      - "http://laptop.local:5173"   # only your SPA host
+  # TLS optional — see docs/tls.md
+  tls_cert: "/etc/ssl/gophertrunk.crt"
+  tls_key:  "/etc/ssl/gophertrunk.key"
+```
 
 ### Generating a token
 

--- a/docs/launcher.md
+++ b/docs/launcher.md
@@ -48,7 +48,11 @@ never bleed onto the alt-screen canvas. On TUI exit (`q` /
 
 ## How the web launcher works
 
-`-web` searches the canonical locations for a bundled SPA:
+`-web` first checks whether the daemon binary was built with the SPA
+embedded (see [§Embedded SPA](#embedded-spa) below). If so, the
+launcher opens the daemon URL directly — the daemon hosts the SPA
+at `/`. Otherwise the launcher searches the canonical sibling
+locations for a bundled SPA:
 
 1. `<dirname of executable>/gophertrunk-web/index.html`
 2. `<dirname of executable>/web/dist/index.html` (dev tree)
@@ -62,6 +66,18 @@ the SPA against the running daemon:
 ```
 file:///path/to/index.html#server=http://localhost:8080
 ```
+
+### Embedded SPA
+
+When the daemon was built with `make web-build` before `go build`
+(the default in release archives), the SPA is baked into the binary
+via Go's `embed` package and the API server registers it at `/`.
+Client-side routes (`/scanner`, `/settings`, `/import`, …) fall back
+to `index.html` so React-Router takes over.
+
+Fresh checkouts without `make web-build` use the sibling-directory
+discovery above instead — `web/dist/` contains only a `.gitkeep`
+sentinel in that case and the embedded `HasAssets()` reports false.
 
 `xdg-open` is used on Linux, `open` on macOS, and `rundll32
 url.dll,FileProtocolHandler` on Windows. Headless hosts that don't

--- a/docs/live-edits.md
+++ b/docs/live-edits.md
@@ -1,0 +1,111 @@
+---
+layout: page
+title: Live config editing
+description: Per-field matrix for PATCH /api/v1/settings — what hot-reloads, what needs a daemon restart
+nav_group: Operate
+---
+
+# Live config editing
+
+`PATCH /api/v1/settings` writes operator edits straight to
+`config.yaml` (preserving comments and formatting) and hot-applies
+the in-memory subset the daemon knows how to change without a
+restart. The response carries an `applied` list (took effect now)
+and a `restart_required` list (written to disk but waiting for a
+daemon bounce).
+
+Both the TUI's Settings panel and the web SPA's `/settings` route
+drive this endpoint. The matrix below reflects what each field
+does today; expect the `applied` column to grow as more subsystems
+expose hot-reload surfaces.
+
+## Field matrix
+
+| YAML field                     | Hot-reload? | Notes                                                         |
+|--------------------------------|-------------|---------------------------------------------------------------|
+| `log.level`                    | yes         | Logger level switch.                                          |
+| `log.format`                   | restart     | Handler is constructed at startup.                            |
+| `api.http_addr`                | restart     | Listener is bound once.                                       |
+| `api.grpc_addr`                | restart     | Listener is bound once.                                       |
+| `api.auth.mode`                | restart     | Middleware constructed at startup.                            |
+| `api.tls_cert` / `api.tls_key` | restart     | Read at bind time. Pre-flight validates parse cleanly.        |
+| `audio.enabled`                | restart     | Backend handle is opened once.                                |
+| `audio.device`                 | restart     | Backend handle is opened once.                                |
+| `audio.volume`                 | yes         | Software gain — instant.                                      |
+| `audio.muted`                  | yes         | Software gain bypass — instant.                               |
+| `audio.buffer_ms`              | restart     | Buffer allocated at startup.                                  |
+| `recordings.dir`               | restart     | Recorder constructed at startup.                              |
+| `recordings.sample_rate`       | restart     | Recorder constructed at startup.                              |
+| `recordings.write_raw`         | yes         | Routes through the recorder gate.                             |
+| `retention.call_log_days`      | restart     | Sweeper constructed at startup.                               |
+| `retention.files_days`         | restart     | Sweeper constructed at startup.                               |
+| `retention.interval`           | restart     | Ticker constructed at startup.                                |
+| `sdr.sample_rate`              | restart     | SDR pool opened once.                                         |
+| `scanner.scan_mode`            | yes         | Engine atomically swaps the mode.                             |
+| `scanner.manual_tune_enabled`  | restart     | Conventional scanner decision baked at startup.               |
+| `scanner.cc_hunt.*`            | restart     | Supervisor constructed once.                                  |
+| `storage.path`                 | restart     | SQLite handle opened once.                                    |
+| `storage.cc_cache_file`        | restart     | Cache opened once.                                            |
+| `metrics.enabled`              | restart     | Collector wired at startup.                                   |
+
+## Wire format
+
+```
+PATCH /api/v1/settings
+Content-Type: application/json
+
+{
+  "audio_volume": 0.5,
+  "scanner_scan_mode": "list"
+}
+```
+
+Response:
+
+```json
+{
+  "applied": ["audio.volume", "scanner.scan_mode"],
+  "restart_required": [],
+  "config_path": "/etc/gophertrunk/config.yaml",
+  "runtime": { ...full RuntimeDTO... }
+}
+```
+
+## Concurrency + mtime guard
+
+- A single `sync.Mutex` on the daemon's config writer serialises
+  every `PATCH /api/v1/settings` and `POST /api/v1/import/.../commit`
+  call so concurrent writes never tear the file.
+- The writer stat's `config.yaml` before every write and refuses to
+  clobber it when its `mtime` doesn't match what the writer last
+  observed. If you edit `config.yaml` in `$EDITOR` while the daemon
+  is running, the next live edit returns:
+  ```
+  config <path>: config.yaml was modified externally; reload the
+  daemon to pick up the new file before editing again
+  ```
+  Send `SIGHUP` (POSIX) to re-load + apply your edits, or restart
+  the daemon.
+
+## SIGHUP
+
+Sending `SIGHUP` to the daemon process reloads `config.yaml` and
+applies the diff against the in-memory config. The hot-reloadable
+fields above take effect immediately; restart-required fields are
+logged so operators see what's still pending. Windows has no
+SIGHUP — restart the daemon instead.
+
+```sh
+# Edit config.yaml in $EDITOR, then:
+kill -HUP "$(pidof gophertrunk)"
+# → "config reloaded: applied=2 restart_required=1 (applied:
+#    audio.volume, scanner.scan_mode) (restart needed: sdr.sample_rate)"
+```
+
+## See also
+
+- [Launcher overview]({{ '/launcher.html' | relative_url }}) —
+  `gophertrunk -tui` / `-web` / `-headless` and the in-process UI
+  flow.
+- [Hardening]({{ '/hardening.html' | relative_url }}) — re-enable
+  auth + CORS for hostile networks.

--- a/docs/web.md
+++ b/docs/web.md
@@ -8,10 +8,18 @@ nav_group: Operate
 # Web console
 
 GopherTrunk ships a full browser-based operator console alongside the
-TUI. It's a **standalone static SPA** — pure HTML / CSS / JS, no
-Node.js, no embedded web server in the daemon. Open `index.html` in
-any modern browser, point it at a running daemon's URL on the
-connect screen, and operate.
+TUI. Two delivery paths:
+
+- **Embedded.** When the daemon binary was linked against the built
+  SPA, the daemon hosts the console at the HTTP API's `/` (no
+  separate static server). Run `gophertrunk -web` (or pick `[2] Web`
+  from the launcher menu) and your default browser opens against the
+  daemon URL automatically.
+- **Standalone static bundle.** A pure HTML / CSS / JS folder that
+  works without the embedded build. Open `index.html` in any modern
+  browser, point it at a running daemon's URL on the connect screen,
+  and operate. Useful when you don't want to (re)build the daemon
+  binary alongside the SPA.
 
 Every Bubbletea TUI panel has a browser counterpart:
 
@@ -27,11 +35,36 @@ Every Bubbletea TUI panel has a browser counterpart:
 | Tones       | `tone.alert` feed with per-device reset                         |
 | Metrics     | Curated `gophertrunk_*` Prometheus tiles + Chart.js trend       |
 | Scanner     | CC hunter, conventional channels, manual VFO tune, scan_mode    |
-| Settings    | Theme, write-mode toggle, "forget this device"                  |
+| Settings    | Theme, write-mode toggle, **live config editing** (PATCH /api/v1/settings) |
+| Import      | Upload PDFs / CSV bundles, preview, commit into config.yaml     |
 
 The headline scenario: run the daemon on a Raspberry Pi (or any host
 with the RTL-SDR attached), then operate from a laptop, tablet, or
 phone anywhere on the LAN.
+
+## Quick path: `gophertrunk -web`
+
+When the daemon binary was built with the SPA embedded (the default
+in release builds), the launcher's `-web` flag wires everything up
+for you:
+
+```sh
+gophertrunk -config config.yaml -web
+```
+
+The daemon binds the HTTP API, registers the SPA at `/`, and opens
+your default browser at the daemon URL. Same flow when you run
+`gophertrunk` with no flags and pick `[2] Web` from the interactive
+launcher menu (see [`launcher.md`]({{ '/launcher.html' | relative_url }})).
+
+On a headless host (SSH session, no `$DISPLAY`) the launcher prints
+the URL + a hint instead of trying to launch a browser, so a remote
+operator can open the URL from their laptop.
+
+If you're building the daemon yourself, run `make web-build` (or
+`cd web && npm run build`) before `go build` so `web/dist/` is
+populated for the embed. Without the embed the launcher falls back
+to the standalone-bundle workflow below.
 
 ## 1. Get the bundle
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io/fs"
 	"log/slog"
 	"net"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -207,6 +209,7 @@ type Server struct {
 	settings     SettingsApplier
 	importer     Importer
 	imports      *importStaging
+	webAssets    fs.FS
 	talkgroups   *trunking.TalkgroupDB
 	systems      []trunking.System
 	history      HistoryQuery
@@ -353,6 +356,13 @@ type ServerOptions struct {
 	// the daemon emits 503 so the SPA can present a clear "import
 	// disabled" message.
 	Importer Importer
+	// WebAssets, when non-nil and containing an `index.html`, is
+	// served from `/` (and as the SPA fallback for any non-/api
+	// path). Set this to the embedded web/dist filesystem so the
+	// daemon hosts the operator console without a sibling
+	// gophertrunk-web/ directory. Leave nil to keep the SPA
+	// out-of-process.
+	WebAssets fs.FS
 	// AudioPublisher, when non-nil, enables the
 	// GET /api/v1/audio/stream HTTP endpoint that streams live
 	// composed PCM as a continuous WAV body. Reuses the same
@@ -434,6 +444,7 @@ func NewServer(opts ServerOptions) (*Server, error) {
 		settings:       opts.SettingsApplier,
 		importer:       opts.Importer,
 		imports:        newImportStaging(5 * time.Minute),
+		webAssets:      opts.WebAssets,
 		talkgroups:     opts.Talkgroups,
 		systems:        append([]trunking.System(nil), opts.Systems...),
 		history:        opts.History,
@@ -600,7 +611,47 @@ func (s *Server) routes() *http.ServeMux {
 	// the daemon was started without an audio publisher.
 	mux.HandleFunc("GET /api/v1/audio/stream", s.handleAudioStream)
 
+	// Embedded SPA at "/" — served only when the daemon was linked
+	// against a populated web/dist embed. SPA history routes
+	// (/scanner, /settings, /import, ...) fall back to index.html
+	// so React-Router takes over on the client side.
+	if s.webAssets != nil {
+		if _, err := fs.Stat(s.webAssets, "index.html"); err == nil {
+			mux.Handle("GET /", s.spaHandler())
+		}
+	}
+
 	return mux
+}
+
+// spaHandler serves the embedded SPA, falling back to index.html
+// for client-side routes so React-Router can pick them up.
+func (s *Server) spaHandler() http.Handler {
+	fileSrv := http.FileServerFS(s.webAssets)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// API routes never reach this handler — the mux's
+		// more-specific matchers own /api/v1/* and /metrics.
+		// Defence in depth: refuse those paths so a hypothetical
+		// embed override surfaces loudly in tests.
+		if strings.HasPrefix(r.URL.Path, "/api/") || r.URL.Path == "/metrics" {
+			http.NotFound(w, r)
+			return
+		}
+		clean := strings.TrimPrefix(r.URL.Path, "/")
+		if clean == "" {
+			fileSrv.ServeHTTP(w, r)
+			return
+		}
+		if _, err := fs.Stat(s.webAssets, clean); err == nil {
+			fileSrv.ServeHTTP(w, r)
+			return
+		}
+		// Fallback to index.html so the SPA's router resolves
+		// /scanner, /settings, /import, ... on the client.
+		r2 := r.Clone(r.Context())
+		r2.URL.Path = "/"
+		fileSrv.ServeHTTP(w, r2)
+	})
 }
 
 // gate wraps a mutation handler in the auth middleware. The middleware

--- a/internal/api/spa_test.go
+++ b/internal/api/spa_test.go
@@ -1,0 +1,154 @@
+package api
+
+import (
+	"io"
+	"net/http"
+	"testing"
+	"testing/fstest"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+)
+
+// fakeSPAFS is a tiny fstest.MapFS that satisfies the embed contract
+// for SPA-serving tests.
+func fakeSPAFS() fstest.MapFS {
+	return fstest.MapFS{
+		"index.html": &fstest.MapFile{
+			Data: []byte("<!doctype html><html><body>spa-root</body></html>"),
+		},
+		"assets/app.js": &fstest.MapFile{
+			Data: []byte("console.log('hi');"),
+		},
+	}
+}
+
+func TestSPA_RootServesIndex(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	base, teardown := mkServer(t, ServerOptions{
+		Bus:       bus,
+		WebAssets: fakeSPAFS(),
+	})
+	defer teardown()
+
+	resp, err := http.Get(base + "/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("status=%d want 200", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if !contains(splitLines(string(body)), "spa-root") {
+		// Substring check via the helper since contains() in
+		// handlers_settings_test takes []string.
+		if !bytesContains(body, "spa-root") {
+			t.Errorf("body missing 'spa-root', got: %q", string(body))
+		}
+	}
+}
+
+func TestSPA_AssetServesDirectly(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	base, teardown := mkServer(t, ServerOptions{
+		Bus:       bus,
+		WebAssets: fakeSPAFS(),
+	})
+	defer teardown()
+
+	resp, err := http.Get(base + "/assets/app.js")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("status=%d want 200", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if !bytesContains(body, "console.log") {
+		t.Errorf("asset body not served correctly, got: %q", string(body))
+	}
+}
+
+func TestSPA_ClientRouteFallsBackToIndex(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	base, teardown := mkServer(t, ServerOptions{
+		Bus:       bus,
+		WebAssets: fakeSPAFS(),
+	})
+	defer teardown()
+
+	resp, err := http.Get(base + "/scanner")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("status=%d want 200", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if !bytesContains(body, "spa-root") {
+		t.Errorf("client route should fall back to index.html, got: %q", string(body))
+	}
+}
+
+func TestSPA_APIRoutesNotShadowed(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	base, teardown := mkServer(t, ServerOptions{
+		Bus:       bus,
+		WebAssets: fakeSPAFS(),
+		Version:   "test",
+	})
+	defer teardown()
+
+	resp, err := http.Get(base + "/api/v1/health")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("api/health status=%d want 200", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if bytesContains(body, "spa-root") {
+		t.Errorf("/api/v1/health was shadowed by the SPA handler; body=%q",
+			string(body))
+	}
+}
+
+func TestSPA_NoEmbedSkipsRoute(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	base, teardown := mkServer(t, ServerOptions{Bus: bus})
+	defer teardown()
+
+	resp, err := http.Get(base + "/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("status=%d want 404 (no embed configured)", resp.StatusCode)
+	}
+}
+
+func splitLines(s string) []string {
+	out := []string{s}
+	return out
+}
+
+func bytesContains(b []byte, sub string) bool {
+	if len(sub) == 0 {
+		return true
+	}
+	for i := 0; i+len(sub) <= len(b); i++ {
+		if string(b[i:i+len(sub)]) == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -473,13 +473,13 @@ func Load(path string) (Config, error) {
 	}
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return cfg, fmt.Errorf("read config: %w", err)
+		return cfg, fmt.Errorf("config %s: %w", path, err)
 	}
 	if err := yaml.Unmarshal(data, &cfg); err != nil {
-		return cfg, fmt.Errorf("parse config: %w", err)
+		return cfg, fmt.Errorf("config %s: %w\n  hint: check YAML syntax (indentation must be spaces, keys end with ':'). Run `gophertrunk import-pdf -wizard` to regenerate a fresh scaffold.", path, err)
 	}
 	if err := cfg.Validate(); err != nil {
-		return cfg, err
+		return cfg, fmt.Errorf("config %s: %w", path, err)
 	}
 	return cfg, nil
 }

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -412,6 +412,19 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case panels.ImportDiscardMsg:
 		cmds = append(cmds, cmdImportDiscard(m.cli, msg.ID))
+
+	case settingsWriteMsg:
+		if msg.Err != nil {
+			m.toast(formatMutationErr(msg.Label, msg.Err))
+			// Dispatch the inline error back to the Settings panel
+			// on the next tick so it can re-focus the failing row.
+			cmds = append(cmds, func() tea.Msg {
+				return panels.SettingsErrorMsg{Field: msg.Field, Message: msg.Err.Error()}
+			})
+		} else {
+			m.toast(msg.Label + " ok")
+			cmds = append(cmds, cmdPollRuntime(m.cli))
+		}
 	}
 
 	// Forward to active panel.
@@ -651,6 +664,14 @@ func (m *Model) dispatchWrite(r state.WriteRequest) tea.Cmd {
 				r.ScannerManualTune.Mode,
 				r.Label),
 			cmdPollScanner(m.cli),
+		)
+	case state.WriteKindSettings:
+		if r.Settings == nil {
+			return nil
+		}
+		return tea.Batch(
+			cmdUpdateSettings(m.cli, r.Settings.Field, r.Settings.Value, r.Label),
+			cmdPollRuntime(m.cli),
 		)
 	}
 	return nil

--- a/internal/tui/cmds.go
+++ b/internal/tui/cmds.go
@@ -309,3 +309,29 @@ func cmdImportDiscard(cli *client.Client, id string) tea.Cmd {
 		return writeResultMsg{Label: "import discard", Err: err}
 	}
 }
+
+// settingsWriteMsg is the unified result of a PATCH /api/v1/settings
+// dispatch. The root Update fans it out into a toast (via the
+// existing writeResultMsg flow) and an inline error on the Settings
+// panel.
+type settingsWriteMsg struct {
+	Label string
+	Field string
+	Err   error
+}
+
+// cmdUpdateSettings converts a Settings panel edit (dotted field +
+// stringified value) into a SettingsPatch and posts it. Wraps both
+// outcomes (network success / network failure / client-side
+// validation failure) into settingsWriteMsg so the root model can
+// surface a toast and re-focus the row in one place.
+func cmdUpdateSettings(cli *client.Client, field, value, label string) tea.Cmd {
+	return func() tea.Msg {
+		patch, perr := buildSettingsPatch(field, value)
+		if perr != nil {
+			return settingsWriteMsg{Label: label, Field: field, Err: perr}
+		}
+		_, err := cli.UpdateSettings(context.Background(), patch)
+		return settingsWriteMsg{Label: label, Field: field, Err: err}
+	}
+}

--- a/internal/tui/panels/settings.go
+++ b/internal/tui/panels/settings.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/table"
+	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/MattCheramie/GopherTrunk/internal/tui/client"
@@ -68,6 +69,25 @@ type SettingsPanel struct {
 	// table is operationally an opt-out reference.
 	tbl      table.Model
 	lastHash uint64
+
+	// Editing state. editCursor indexes into editableFieldsForTab
+	// for the current tab; editing flips to true while the operator
+	// is typing into editInput. editErr surfaces validation failures
+	// from the daemon's PATCH response (caught at the root model and
+	// passed back via a panel message — see ApplySettingsError).
+	editCursor int
+	editing    bool
+	editInput  textinput.Model
+	editErr    string
+}
+
+// SettingsErrorMsg is dispatched by the root model when a Settings
+// PATCH comes back with an error (validation failure, 503, etc.).
+// The panel re-opens the editor on the failing row and surfaces the
+// message inline so the operator can correct without re-navigating.
+type SettingsErrorMsg struct {
+	Field   string
+	Message string
 }
 
 func NewSettings() *SettingsPanel {
@@ -87,19 +107,89 @@ var (
 )
 
 func (SettingsPanel) Keys() []key.Binding {
-	return []key.Binding{settingsNextTab, settingsPrevTab}
+	return []key.Binding{
+		settingsNextTab, settingsPrevTab,
+		editUpKey, editDownKey, editStart, editCancel,
+	}
 }
 
 func (p *SettingsPanel) Update(msg tea.Msg, s *state.SharedState) (Panel, tea.Cmd) {
 	applyThemeIfChanged(msg, &p.tbl)
+
+	// SettingsErrorMsg comes back from the root model when a
+	// PATCH /api/v1/settings dispatch failed — re-focus the row +
+	// surface the error inline.
+	if em, ok := msg.(SettingsErrorMsg); ok {
+		p.editErr = em.Message
+		return p, nil
+	}
+
+	fields := editableFieldsForTab(p.tab)
+	editable := len(fields) > 0 && s.Runtime.ConfigPath != ""
+
 	if km, ok := msg.(tea.KeyMsg); ok {
+		// Tab switching happens regardless of edit state — the
+		// existing UX guarantees []/h/l always navigate tabs. Fall
+		// through so the FEC-tab refresh below still runs when the
+		// operator lands on that tab.
+		switched := false
 		switch {
 		case key.Matches(km, settingsNextTab):
+			p.editing = false
+			p.editErr = ""
 			p.tab = (p.tab + 1) % tabCount
+			p.editCursor = 0
+			switched = true
 		case key.Matches(km, settingsPrevTab):
+			p.editing = false
+			p.editErr = ""
 			p.tab = (p.tab + tabCount - 1) % tabCount
+			p.editCursor = 0
+			switched = true
+		}
+		if switched {
+			// Skip the edit-mode handling but keep the FEC-tab
+			// refresh further down so the table populates on
+			// landing.
+			goto fecRefresh
+		}
+
+		if editable {
+			if p.editing {
+				// Edit mode: route everything to the textinput
+				// except enter (save) and esc (cancel).
+				switch {
+				case key.Matches(km, editStart):
+					return p, p.commitEdit(fields)
+				case key.Matches(km, editCancel):
+					p.editing = false
+					p.editErr = ""
+					return p, nil
+				}
+				var cmd tea.Cmd
+				p.editInput, cmd = p.editInput.Update(msg)
+				return p, cmd
+			}
+			// Navigation mode.
+			switch {
+			case key.Matches(km, editUpKey):
+				if p.editCursor > 0 {
+					p.editCursor--
+				}
+				return p, nil
+			case key.Matches(km, editDownKey):
+				if p.editCursor < len(fields)-1 {
+					p.editCursor++
+				}
+				return p, nil
+			case key.Matches(km, editStart):
+				p.startEdit(fields, s.Runtime)
+				return p, nil
+			}
 		}
 	}
+
+fecRefresh:
 	// Refresh the FEC table whenever we're on (or have just switched
 	// to) the FEC tab — the hash gate keeps the cost negligible.
 	if p.tab == tabFEC {
@@ -149,7 +239,15 @@ func (p *SettingsPanel) View(width, height int, focused bool, s *state.SharedSta
 		}
 		body = p.tbl.View() + "\n\n" + dashDim.Render("Edit config.yaml + restart daemon to change; see the FEC opt-outs section in README.md.")
 	} else {
-		body = p.renderTab(width, s)
+		// Editable rows first (only when the daemon has a config
+		// file backing it — empty ConfigPath means PATCH returns
+		// 503 and we shouldn't lead the operator on).
+		fields := editableFieldsForTab(p.tab)
+		var head string
+		if len(fields) > 0 && s.Runtime.ConfigPath != "" {
+			head = p.renderEditableRows(fields, s.Runtime)
+		}
+		body = head + p.renderTab(width, s)
 	}
 	return panelFrame("Settings", width, height, focused, header+"\n"+banner+body)
 }

--- a/internal/tui/panels/settings_edit.go
+++ b/internal/tui/panels/settings_edit.go
@@ -1,0 +1,208 @@
+package panels
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/key"
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/MattCheramie/GopherTrunk/internal/tui/client"
+	"github.com/MattCheramie/GopherTrunk/internal/tui/state"
+)
+
+// editableField captures everything the Settings panel needs to know
+// to render one editable row + dispatch a SettingsReq when the
+// operator saves.
+type editableField struct {
+	// Label is what the operator sees on the left side of the row.
+	Label string
+	// Field is the dotted YAML path (e.g. "audio.volume"). Used
+	// as SettingsReq.Field; the root dispatcher converts to the
+	// matching SettingsPatch shape.
+	Field string
+	// Value extracts the current value from the runtime DTO as a
+	// human-readable string.
+	Value func(r client.RuntimeDTO) string
+	// Restart marks fields that aren't hot-reloadable. The renderer
+	// adds a small "restart" badge so operators know the change
+	// won't take effect until they bounce the daemon.
+	Restart bool
+}
+
+// editableFieldsForTab returns the editable rows for the given tab.
+// Returning a slice instead of a map keeps row order stable across
+// renders.
+func editableFieldsForTab(t settingsTab) []editableField {
+	switch t {
+	case tabDaemon:
+		return []editableField{
+			{Label: "Log level", Field: "log.level",
+				Value: func(r client.RuntimeDTO) string { return or(r.LogLevel, "info") }},
+			{Label: "Log format", Field: "log.format", Restart: true,
+				Value: func(r client.RuntimeDTO) string { return or(r.LogFormat, "text") }},
+			{Label: "Metrics enabled", Field: "metrics.enabled", Restart: true,
+				Value: func(r client.RuntimeDTO) string { return boolStr(r.MetricsEnabled) }},
+		}
+	case tabStorage:
+		return []editableField{
+			{Label: "Call log path", Field: "storage.path", Restart: true,
+				Value: func(r client.RuntimeDTO) string { return or(r.StorageDBPath, "") }},
+			{Label: "CC cache file", Field: "storage.cc_cache_file", Restart: true,
+				Value: func(r client.RuntimeDTO) string { return or(r.StorageCCCache, "") }},
+			{Label: "Retention (call log days)", Field: "retention.call_log_days", Restart: true,
+				Value: func(r client.RuntimeDTO) string { return fmt.Sprintf("%d", r.RetentionCallLogDays) }},
+			{Label: "Retention (files days)", Field: "retention.files_days", Restart: true,
+				Value: func(r client.RuntimeDTO) string { return fmt.Sprintf("%d", r.RetentionFilesDays) }},
+			{Label: "Retention interval", Field: "retention.interval", Restart: true,
+				Value: func(r client.RuntimeDTO) string {
+					if r.RetentionInterval == 0 {
+						return ""
+					}
+					return r.RetentionInterval.String()
+				}},
+		}
+	case tabAudio:
+		return []editableField{
+			{Label: "Enabled", Field: "audio.enabled", Restart: true,
+				Value: func(r client.RuntimeDTO) string { return boolStr(r.AudioEnabled) }},
+			{Label: "Device", Field: "audio.device", Restart: true,
+				Value: func(r client.RuntimeDTO) string { return r.AudioDevice }},
+			{Label: "Buffer (ms)", Field: "audio.buffer_ms", Restart: true,
+				Value: func(r client.RuntimeDTO) string { return fmt.Sprintf("%d", r.AudioBufferMs) }},
+		}
+	case tabRecording:
+		return []editableField{
+			{Label: "Output directory", Field: "recordings.dir", Restart: true,
+				Value: func(r client.RuntimeDTO) string { return r.RecordingDir }},
+			{Label: "Sample rate (Hz)", Field: "recordings.sample_rate", Restart: true,
+				Value: func(r client.RuntimeDTO) string { return fmt.Sprintf("%d", r.RecordingSampleRate) }},
+			{Label: "Write raw vocoder frames", Field: "recordings.write_raw",
+				Value: func(r client.RuntimeDTO) string { return boolStr(r.RecordingWriteRaw) }},
+		}
+	case tabAPI:
+		return []editableField{
+			{Label: "HTTP addr", Field: "api.http_addr", Restart: true,
+				Value: func(r client.RuntimeDTO) string { return r.HTTPAddr }},
+			{Label: "gRPC addr", Field: "api.grpc_addr", Restart: true,
+				Value: func(r client.RuntimeDTO) string { return r.GRPCAddr }},
+		}
+	case tabSDR:
+		return []editableField{
+			{Label: "Sample rate (Hz)", Field: "sdr.sample_rate", Restart: true,
+				Value: func(r client.RuntimeDTO) string { return fmt.Sprintf("%d", r.SDRSampleRate) }},
+		}
+	}
+	return nil
+}
+
+// startEdit promotes the focused row to an editable textinput,
+// seeded with the row's current value so the operator can tweak
+// rather than retype.
+func (p *SettingsPanel) startEdit(fields []editableField, r client.RuntimeDTO) {
+	if p.editCursor < 0 || p.editCursor >= len(fields) {
+		return
+	}
+	f := fields[p.editCursor]
+	ti := textinput.New()
+	ti.SetValue(f.Value(r))
+	ti.Prompt = ""
+	ti.Width = 40
+	ti.CharLimit = 256
+	ti.Focus()
+	p.editInput = ti
+	p.editing = true
+	p.editErr = ""
+}
+
+// commitEdit emits a WriteActionMsg with the operator's input and
+// resets the editing state so the next Enter starts fresh.
+func (p *SettingsPanel) commitEdit(fields []editableField) tea.Cmd {
+	if !p.editing || p.editCursor < 0 || p.editCursor >= len(fields) {
+		return nil
+	}
+	val := strings.TrimSpace(p.editInput.Value())
+	field := fields[p.editCursor].Field
+	p.editing = false
+	p.editErr = ""
+	return func() tea.Msg {
+		return WriteActionMsg{Request: state.WriteRequest{
+			Kind:  state.WriteKindSettings,
+			Label: "settings " + field,
+			Settings: &state.SettingsReq{
+				Field: field,
+				Value: val,
+			},
+		}}
+	}
+}
+
+// renderEditableRows produces the row-by-row view for tabs that
+// support editing. Each row gets a cursor marker, label, current
+// value (or live textinput when this row is being edited), and a
+// 'restart' badge when applicable.
+func (p *SettingsPanel) renderEditableRows(fields []editableField, r client.RuntimeDTO) string {
+	if len(fields) == 0 {
+		return ""
+	}
+	maxLabel := 0
+	for _, f := range fields {
+		if l := len([]rune(f.Label)); l > maxLabel {
+			maxLabel = l
+		}
+	}
+	var b strings.Builder
+	for i, f := range fields {
+		cursor := "  "
+		if i == p.editCursor {
+			cursor = "› "
+		}
+		label := f.Label + strings.Repeat(" ", maxLabel-len([]rune(f.Label)))
+		var value string
+		if p.editing && i == p.editCursor {
+			value = p.editInput.View()
+		} else {
+			val := f.Value(r)
+			if val == "" {
+				val = dashDim.Render("(unset)")
+			}
+			value = val
+		}
+		row := cursor + dashDim.Render(label) + "   " + value
+		if f.Restart {
+			row += "   " + lipgloss.NewStyle().Foreground(lipgloss.Color("3")).Render("[restart]")
+		}
+		fmt.Fprintln(&b, row)
+	}
+	if p.editErr != "" {
+		fmt.Fprintln(&b)
+		fmt.Fprintln(&b, lipgloss.NewStyle().Foreground(lipgloss.Color("9")).Render("  ! "+p.editErr))
+	}
+	fmt.Fprintln(&b)
+	if p.editing {
+		fmt.Fprintln(&b, dashDim.Render("  enter save  •  esc cancel"))
+	} else {
+		fmt.Fprintln(&b, dashDim.Render("  j/k or ↑/↓ to move  •  enter to edit"))
+	}
+	return b.String()
+}
+
+// boolStr renders a bool as "true" / "false" for an editable field
+// (so the wire round-trip with the daemon stays unambiguous).
+func boolStr(b bool) string {
+	if b {
+		return "true"
+	}
+	return "false"
+}
+
+// editableSettingsKeys is the set of bindings the help overlay
+// surfaces for the editable rows.
+var (
+	editUpKey   = key.NewBinding(key.WithKeys("up", "k"), key.WithHelp("k/↑", "row up"))
+	editDownKey = key.NewBinding(key.WithKeys("down", "j"), key.WithHelp("j/↓", "row down"))
+	editStart   = key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "edit / save"))
+	editCancel  = key.NewBinding(key.WithKeys("esc"), key.WithHelp("esc", "cancel"))
+)

--- a/internal/tui/panels/settings_edit_test.go
+++ b/internal/tui/panels/settings_edit_test.go
@@ -1,0 +1,117 @@
+package panels
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/MattCheramie/GopherTrunk/internal/tui/client"
+	"github.com/MattCheramie/GopherTrunk/internal/tui/state"
+)
+
+func TestSettingsPanel_EditableFieldsHidenWithoutConfig(t *testing.T) {
+	p := NewSettings()
+	s := &state.SharedState{Runtime: client.RuntimeDTO{}}
+	// No ConfigPath → render path skips the editable rows entirely.
+	view := p.View(120, 30, true, s)
+	if strings.Contains(view, "log.level") {
+		t.Errorf("editable rows should be hidden when ConfigPath is empty; view:\n%s", view)
+	}
+}
+
+func TestSettingsPanel_EditableFieldsShownWithConfig(t *testing.T) {
+	p := NewSettings()
+	s := &state.SharedState{Runtime: client.RuntimeDTO{
+		ConfigPath: "/tmp/cfg.yaml",
+		LogLevel:   "info",
+	}}
+	view := p.View(120, 30, true, s)
+	if !strings.Contains(view, "Log level") {
+		t.Errorf("expected Log level row when ConfigPath is set; view:\n%s", view)
+	}
+}
+
+func TestSettingsPanel_EditDispatchesWriteAction(t *testing.T) {
+	p := NewSettings()
+	s := &state.SharedState{Runtime: client.RuntimeDTO{
+		ConfigPath: "/tmp/cfg.yaml",
+		LogLevel:   "info",
+	}}
+	// Enter promotes the focused row to edit mode.
+	_, _ = p.Update(tea.KeyMsg{Type: tea.KeyEnter}, s)
+	if !p.editing {
+		t.Fatal("expected editing=true after Enter")
+	}
+	// Replace seeded value with "warn".
+	p.editInput.SetValue("warn")
+	// Enter again saves — should return a Cmd that emits a WriteActionMsg.
+	_, cmd := p.Update(tea.KeyMsg{Type: tea.KeyEnter}, s)
+	if cmd == nil {
+		t.Fatal("expected commit cmd, got nil")
+	}
+	msg := cmd()
+	wa, ok := msg.(WriteActionMsg)
+	if !ok {
+		t.Fatalf("got %T, want WriteActionMsg", msg)
+	}
+	if wa.Request.Kind != state.WriteKindSettings {
+		t.Errorf("got Kind=%v, want WriteKindSettings", wa.Request.Kind)
+	}
+	if wa.Request.Settings == nil {
+		t.Fatal("Settings req is nil")
+	}
+	if wa.Request.Settings.Field != "log.level" {
+		t.Errorf("got Field=%q want log.level", wa.Request.Settings.Field)
+	}
+	if wa.Request.Settings.Value != "warn" {
+		t.Errorf("got Value=%q want warn", wa.Request.Settings.Value)
+	}
+}
+
+func TestSettingsPanel_EditCancelEscape(t *testing.T) {
+	p := NewSettings()
+	s := &state.SharedState{Runtime: client.RuntimeDTO{
+		ConfigPath: "/tmp/cfg.yaml",
+		LogLevel:   "info",
+	}}
+	_, _ = p.Update(tea.KeyMsg{Type: tea.KeyEnter}, s)
+	if !p.editing {
+		t.Fatal("editing should be true")
+	}
+	_, _ = p.Update(tea.KeyMsg{Type: tea.KeyEsc}, s)
+	if p.editing {
+		t.Error("editing should be false after esc")
+	}
+}
+
+func TestSettingsPanel_SettingsErrorMsgSurfacesInline(t *testing.T) {
+	p := NewSettings()
+	s := &state.SharedState{Runtime: client.RuntimeDTO{
+		ConfigPath: "/tmp/cfg.yaml",
+		LogLevel:   "info",
+	}}
+	_, _ = p.Update(SettingsErrorMsg{Field: "log.level", Message: "boom"}, s)
+	if p.editErr != "boom" {
+		t.Errorf("editErr = %q want boom", p.editErr)
+	}
+	view := p.View(120, 30, true, s)
+	if !strings.Contains(view, "boom") {
+		t.Errorf("view should include the inline error; got:\n%s", view)
+	}
+}
+
+func TestSettingsPanel_DownArrowMovesCursor(t *testing.T) {
+	p := NewSettings()
+	s := &state.SharedState{Runtime: client.RuntimeDTO{
+		ConfigPath: "/tmp/cfg.yaml",
+		LogLevel:   "info",
+	}}
+	if p.editCursor != 0 {
+		t.Fatal("editCursor should start at 0")
+	}
+	_, _ = p.Update(tea.KeyMsg{Type: tea.KeyDown}, s)
+	if p.editCursor != 1 {
+		t.Errorf("editCursor=%d want 1", p.editCursor)
+	}
+}

--- a/internal/tui/settings_patch.go
+++ b/internal/tui/settings_patch.go
@@ -1,0 +1,164 @@
+package tui
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/MattCheramie/GopherTrunk/internal/tui/client"
+)
+
+// buildSettingsPatch converts a (dotted field, stringified value)
+// pair from the Settings panel into a typed client.SettingsPatch.
+// Validation (parse failure, unrecognised field) returns an error
+// the caller surfaces inline on the editing row.
+func buildSettingsPatch(field, raw string) (client.SettingsPatch, error) {
+	var p client.SettingsPatch
+	switch field {
+	case "log.level":
+		s := raw
+		p.LogLevel = &s
+	case "log.format":
+		s := raw
+		p.LogFormat = &s
+	case "api.http_addr":
+		s := raw
+		p.APIHTTPAddr = &s
+	case "api.grpc_addr":
+		s := raw
+		p.APIGRPCAddr = &s
+	case "api.auth.mode":
+		s := raw
+		p.APIAuthMode = &s
+	case "metrics.enabled":
+		b, err := parseBool(raw)
+		if err != nil {
+			return p, err
+		}
+		p.MetricsEnabled = &b
+	case "audio.enabled":
+		b, err := parseBool(raw)
+		if err != nil {
+			return p, err
+		}
+		p.AudioEnabled = &b
+	case "audio.device":
+		s := raw
+		p.AudioDevice = &s
+	case "audio.volume":
+		f64, err := strconv.ParseFloat(raw, 32)
+		if err != nil {
+			return p, fmt.Errorf("audio.volume: %w (want a float 0..1)", err)
+		}
+		f := float32(f64)
+		if f < 0 || f > 1 {
+			return p, fmt.Errorf("audio.volume %v outside 0..1", f)
+		}
+		p.AudioVolume = &f
+	case "audio.muted":
+		b, err := parseBool(raw)
+		if err != nil {
+			return p, err
+		}
+		p.AudioMuted = &b
+	case "audio.buffer_ms":
+		n, err := strconv.Atoi(raw)
+		if err != nil {
+			return p, fmt.Errorf("audio.buffer_ms: %w (want an integer)", err)
+		}
+		p.AudioBufferMs = &n
+	case "recordings.dir":
+		s := raw
+		p.RecordingsDir = &s
+	case "recordings.sample_rate":
+		n, err := strconv.ParseUint(raw, 10, 32)
+		if err != nil {
+			return p, fmt.Errorf("recordings.sample_rate: %w", err)
+		}
+		v := uint32(n)
+		p.RecordingsSampleRate = &v
+	case "recordings.write_raw":
+		b, err := parseBool(raw)
+		if err != nil {
+			return p, err
+		}
+		p.RecordingsWriteRaw = &b
+	case "retention.call_log_days":
+		n, err := strconv.Atoi(raw)
+		if err != nil {
+			return p, fmt.Errorf("retention.call_log_days: %w", err)
+		}
+		p.RetentionCallLogDays = &n
+	case "retention.files_days":
+		n, err := strconv.Atoi(raw)
+		if err != nil {
+			return p, fmt.Errorf("retention.files_days: %w", err)
+		}
+		p.RetentionFilesDays = &n
+	case "retention.interval":
+		s := raw
+		p.RetentionInterval = &s
+	case "sdr.sample_rate":
+		n, err := strconv.ParseUint(raw, 10, 32)
+		if err != nil {
+			return p, fmt.Errorf("sdr.sample_rate: %w", err)
+		}
+		v := uint32(n)
+		p.SDRSampleRate = &v
+	case "scanner.scan_mode":
+		s := raw
+		p.ScannerScanMode = &s
+	case "scanner.manual_tune_enabled":
+		b, err := parseBool(raw)
+		if err != nil {
+			return p, err
+		}
+		p.ScannerManualTuneEnabled = &b
+	case "scanner.cc_hunt.enabled":
+		b, err := parseBool(raw)
+		if err != nil {
+			return p, err
+		}
+		p.ScannerCCHuntEnabled = &b
+	case "scanner.cc_hunt.dwell_ms":
+		n, err := strconv.Atoi(raw)
+		if err != nil {
+			return p, fmt.Errorf("scanner.cc_hunt.dwell_ms: %w", err)
+		}
+		p.ScannerCCHuntDwellMs = &n
+	case "scanner.cc_hunt.backoff_ms":
+		n, err := strconv.Atoi(raw)
+		if err != nil {
+			return p, fmt.Errorf("scanner.cc_hunt.backoff_ms: %w", err)
+		}
+		p.ScannerCCHuntBackoffMs = &n
+	case "scanner.cc_hunt.max_backoff_ms":
+		n, err := strconv.Atoi(raw)
+		if err != nil {
+			return p, fmt.Errorf("scanner.cc_hunt.max_backoff_ms: %w", err)
+		}
+		p.ScannerCCHuntMaxBackoff = &n
+	case "storage.path":
+		s := raw
+		p.StoragePath = &s
+	case "storage.cc_cache_file":
+		s := raw
+		p.StorageCCCacheFile = &s
+	default:
+		return p, fmt.Errorf("unknown field %q", field)
+	}
+	return p, nil
+}
+
+// parseBool accepts the common forms operators type ("true",
+// "false", "on", "off", "yes", "no") and returns a descriptive
+// error otherwise.
+func parseBool(raw string) (bool, error) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "true", "on", "yes", "1":
+		return true, nil
+	case "false", "off", "no", "0":
+		return false, nil
+	}
+	return false, fmt.Errorf("want true/false (also accepts on/off, yes/no, 1/0)")
+}

--- a/internal/tui/settings_patch_test.go
+++ b/internal/tui/settings_patch_test.go
@@ -1,0 +1,87 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildSettingsPatch_StringField(t *testing.T) {
+	p, err := buildSettingsPatch("log.level", "debug")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.LogLevel == nil || *p.LogLevel != "debug" {
+		t.Errorf("LogLevel = %v want debug", p.LogLevel)
+	}
+}
+
+func TestBuildSettingsPatch_FloatField(t *testing.T) {
+	p, err := buildSettingsPatch("audio.volume", "0.42")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.AudioVolume == nil || *p.AudioVolume != 0.42 {
+		t.Errorf("AudioVolume = %v want 0.42", p.AudioVolume)
+	}
+}
+
+func TestBuildSettingsPatch_VolumeOutOfRange(t *testing.T) {
+	if _, err := buildSettingsPatch("audio.volume", "2.5"); err == nil {
+		t.Fatal("expected out-of-range error")
+	}
+}
+
+func TestBuildSettingsPatch_BoolField(t *testing.T) {
+	p, err := buildSettingsPatch("recordings.write_raw", "true")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.RecordingsWriteRaw == nil || !*p.RecordingsWriteRaw {
+		t.Errorf("RecordingsWriteRaw = %v want true", p.RecordingsWriteRaw)
+	}
+
+	p2, err := buildSettingsPatch("recordings.write_raw", "off")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p2.RecordingsWriteRaw == nil || *p2.RecordingsWriteRaw {
+		t.Errorf("off should map to false, got %v", p2.RecordingsWriteRaw)
+	}
+}
+
+func TestBuildSettingsPatch_BoolBadInput(t *testing.T) {
+	_, err := buildSettingsPatch("audio.muted", "maybe")
+	if err == nil {
+		t.Fatal("expected error for non-bool input")
+	}
+	if !strings.Contains(err.Error(), "true/false") {
+		t.Errorf("error should mention true/false, got %q", err.Error())
+	}
+}
+
+func TestBuildSettingsPatch_IntField(t *testing.T) {
+	p, err := buildSettingsPatch("retention.call_log_days", "30")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.RetentionCallLogDays == nil || *p.RetentionCallLogDays != 30 {
+		t.Errorf("RetentionCallLogDays = %v want 30", p.RetentionCallLogDays)
+	}
+}
+
+func TestBuildSettingsPatch_UintField(t *testing.T) {
+	p, err := buildSettingsPatch("sdr.sample_rate", "2400000")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.SDRSampleRate == nil || *p.SDRSampleRate != 2_400_000 {
+		t.Errorf("SDRSampleRate = %v want 2400000", p.SDRSampleRate)
+	}
+}
+
+func TestBuildSettingsPatch_UnknownField(t *testing.T) {
+	_, err := buildSettingsPatch("nonexistent.knob", "x")
+	if err == nil {
+		t.Fatal("expected error for unknown field")
+	}
+}

--- a/internal/tui/state/state.go
+++ b/internal/tui/state/state.go
@@ -130,6 +130,7 @@ type WriteRequest struct {
 	ScannerConv       *ScannerConvReq
 	ScannerManualTune *ScannerManualTuneReq
 	Audio             *AudioReq
+	Settings          *SettingsReq
 }
 
 // WriteKind discriminates a WriteRequest's payload.
@@ -152,6 +153,7 @@ const (
 	WriteKindScannerConvUnlockout
 	WriteKindAudio
 	WriteKindScannerManualTune
+	WriteKindSettings
 )
 
 // ScannerManualTuneReq adds a temp VFO channel and forces dwell.
@@ -159,6 +161,15 @@ type ScannerManualTuneReq struct {
 	FrequencyHz uint32
 	Label       string
 	Mode        string
+}
+
+// SettingsReq carries a single settings-panel edit. Field is the
+// dotted YAML path (e.g. "audio.volume", "log.level") and Value is
+// the operator's typed input; the dispatcher converts to the right
+// SettingsPatch shape per field.
+type SettingsReq struct {
+	Field string
+	Value string
 }
 
 // AudioReq sets one or more knobs on the audio cockpit. Nil fields

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
-dist/
+dist/*
+!dist/.gitkeep
 dev-dist/
 *.log
 .env

--- a/web/embed.go
+++ b/web/embed.go
@@ -1,0 +1,40 @@
+// Package web embeds the built SPA so the daemon binary can serve
+// the operator console without a sibling `gophertrunk-web/`
+// directory. Build the SPA with `make web-build` (or `cd web &&
+// npm run build`) before `go build`; the embed picks up everything
+// under `dist/` automatically.
+//
+// When `dist/` is empty (fresh checkout, dev build with no `make
+// web-build` yet) the embed contains only the `.gitkeep` sentinel
+// and (*FS).HasAssets reports false. The launcher's web-open path
+// falls back to filesystem discovery in that case so dev workflows
+// aren't blocked.
+package web
+
+import (
+	"embed"
+	"io/fs"
+)
+
+//go:embed all:dist
+var rawDist embed.FS
+
+// Assets returns the embed.FS sub-tree rooted at `dist`. Callers
+// should treat it as a read-only fs.FS — internal/api wires it
+// through http.FileServerFS.
+func Assets() fs.FS {
+	sub, err := fs.Sub(rawDist, "dist")
+	if err != nil {
+		return rawDist
+	}
+	return sub
+}
+
+// HasAssets returns true when the embed contains real build output
+// (index.html in particular). A fresh checkout with only the
+// .gitkeep sentinel returns false; the launcher then falls back to
+// filesystem-search of `gophertrunk-web/` siblings.
+func HasAssets() bool {
+	_, err := fs.Stat(Assets(), "index.html")
+	return err == nil
+}

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -150,6 +150,9 @@ export interface RuntimeDTO {
     cors_allowed_origins?: string[];
   };
   audio?: AudioStatusDTO;
+  log_level?: string;
+  log_format?: string;
+  metrics_enabled?: boolean;
   // ConfigPath is non-empty when the daemon was started with a
   // -config file. The SPA renders the Settings panel as editable
   // only when this is set; an empty value means PATCH /api/v1/settings

--- a/web/src/panels/Settings.tsx
+++ b/web/src/panels/Settings.tsx
@@ -1,6 +1,13 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { api, HTTPError } from "../api/client";
+import { writes } from "../api/write";
+import type { RuntimeDTO, SettingsPatch } from "../api/types";
 import { prefs, type Theme } from "../store/prefs";
-import { selectCanMutate, useShared } from "../store/shared";
+import {
+  selectCanMutate,
+  selectClientConfig,
+  useShared,
+} from "../store/shared";
 
 // Settings: theme, write mode, audio defaults, "forget device".
 // Mutations panels are AND-gated with the daemon's allow_mutations
@@ -103,6 +110,8 @@ export function Settings() {
         </p>
       </section>
 
+      <LiveConfigSection />
+
       <section className="panel p-4 space-y-3">
         <h3 className="panel-title text-err">Danger zone</h3>
         <button
@@ -119,4 +128,307 @@ export function Settings() {
       </section>
     </div>
   );
+}
+
+// --- Live config editing ---
+//
+// The LiveConfigSection mirrors the TUI's editable settings rows. Each
+// row pulls its current value from the runtime DTO and dispatches a
+// PATCH /api/v1/settings on save. Restart-required fields get a
+// yellow badge; the section is hidden entirely when the daemon was
+// started without a -config file (PATCH would return 503).
+
+interface FieldSpec {
+  field: string;
+  label: string;
+  type: "string" | "number" | "bool";
+  restart?: boolean;
+  read: (r: RuntimeDTO) => string;
+}
+
+function liveConfigFields(): FieldSpec[] {
+  return [
+    {
+      field: "log.level",
+      label: "Log level",
+      type: "string",
+      read: (r) => r.log_level ?? "info",
+    },
+    {
+      field: "log.format",
+      label: "Log format",
+      type: "string",
+      restart: true,
+      read: (r) => r.log_format ?? "text",
+    },
+    {
+      field: "audio.volume",
+      label: "Audio volume (0..1)",
+      type: "number",
+      read: (r) => String(r.audio?.volume ?? 0.8),
+    },
+    {
+      field: "audio.muted",
+      label: "Audio muted",
+      type: "bool",
+      read: (r) => String(r.audio?.muted ?? false),
+    },
+    {
+      field: "scanner.scan_mode",
+      label: "Scanner scan mode (all|list)",
+      type: "string",
+      read: (r) =>
+        (r["scanner_scan_mode"] as string | undefined) ?? "all",
+    },
+    {
+      field: "recordings.dir",
+      label: "Recordings directory",
+      type: "string",
+      restart: true,
+      read: (r) => (r["recording_dir"] as string | undefined) ?? "",
+    },
+    {
+      field: "recordings.sample_rate",
+      label: "Recordings sample rate (Hz)",
+      type: "number",
+      restart: true,
+      read: (r) => String(r["recording_sample_rate"] ?? 8000),
+    },
+    {
+      field: "sdr.sample_rate",
+      label: "SDR sample rate (Hz)",
+      type: "number",
+      restart: true,
+      read: (r) => String(r["sdr_sample_rate"] ?? 2_400_000),
+    },
+    {
+      field: "metrics.enabled",
+      label: "Metrics enabled",
+      type: "bool",
+      restart: true,
+      read: (r) => String(r.metrics_enabled ?? false),
+    },
+  ];
+}
+
+function LiveConfigSection() {
+  const cfg = useShared(selectClientConfig);
+  const canMutate = useShared(selectCanMutate);
+  const [runtime, setRuntime] = useState<RuntimeDTO | null>(null);
+  const [editing, setEditing] = useState<string | null>(null);
+  const [draft, setDraft] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    let cancel = false;
+    const load = async () => {
+      try {
+        const r = await api.runtime(cfg);
+        if (!cancel) setRuntime(r);
+      } catch {
+        // ignore — the daemon may briefly be unavailable during
+        // restart; the section will refresh on the next render.
+      }
+    };
+    load();
+    const t = window.setInterval(load, 5_000);
+    return () => {
+      cancel = true;
+      window.clearInterval(t);
+    };
+  }, [cfg]);
+
+  if (!runtime) {
+    return (
+      <section className="panel p-4 space-y-3">
+        <h3 className="panel-title">Live config</h3>
+        <p className="text-sm text-muted">Loading runtime…</p>
+      </section>
+    );
+  }
+
+  const cfgPath = (runtime["config_path"] as string | undefined) ?? "";
+  if (!cfgPath) {
+    return (
+      <section className="panel p-4 space-y-3">
+        <h3 className="panel-title">Live config</h3>
+        <div className="text-sm panel bg-warn/15 border-warn/40 text-warn p-3">
+          The daemon is running without a <code>-config</code> file, so
+          <code> PATCH /api/v1/settings</code> returns 503. Restart with
+          <code> -config /path/to/config.yaml</code> to enable inline
+          edits.
+        </div>
+      </section>
+    );
+  }
+
+  const fields = liveConfigFields();
+
+  async function save(spec: FieldSpec, raw: string) {
+    setError(null);
+    setBusy(true);
+    try {
+      const patch = buildSettingsPatch(spec, raw);
+      await writes.updateSettings(cfg, patch);
+      // Refresh.
+      const r = await api.runtime(cfg);
+      setRuntime(r);
+      setEditing(null);
+    } catch (e) {
+      if (e instanceof HTTPError) {
+        setError(`${spec.field}: ${e.message}`);
+      } else {
+        setError(`${spec.field}: ${String(e)}`);
+      }
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <section className="panel p-4 space-y-3">
+      <h3 className="panel-title">Live config</h3>
+      <p className="text-xs text-muted">
+        Backed by <code>{cfgPath}</code>. Edits land in config.yaml with
+        comments preserved; hot-reloadable knobs apply immediately,
+        restart-required fields are flagged below.
+      </p>
+      {!canMutate && (
+        <div className="text-sm panel bg-warn/15 border-warn/40 text-warn p-3">
+          Mutations are disabled — daemon auth blocks writes.
+        </div>
+      )}
+      {error && (
+        <div
+          role="alert"
+          className="text-sm panel bg-err/15 border-err/40 text-err p-3"
+        >
+          {error}
+        </div>
+      )}
+      <table className="text-sm w-full">
+        <tbody>
+          {fields.map((f) => (
+            <tr key={f.field} className="border-t border-panel">
+              <td className="py-2 pr-3 text-muted whitespace-nowrap">
+                {f.label}
+                {f.restart && (
+                  <span className="ml-2 text-xs text-warn">
+                    [restart]
+                  </span>
+                )}
+              </td>
+              <td className="py-2">
+                {editing === f.field ? (
+                  <input
+                    autoFocus
+                    className="input w-full"
+                    value={draft}
+                    onChange={(e) => setDraft(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") save(f, draft);
+                      if (e.key === "Escape") setEditing(null);
+                    }}
+                    disabled={busy}
+                  />
+                ) : (
+                  <code className="font-mono">{f.read(runtime) || "—"}</code>
+                )}
+              </td>
+              <td className="py-2 pl-3 text-right whitespace-nowrap">
+                {editing === f.field ? (
+                  <>
+                    <button
+                      className="btn-primary mr-2"
+                      onClick={() => save(f, draft)}
+                      disabled={busy}
+                    >
+                      Save
+                    </button>
+                    <button
+                      className="btn-ghost"
+                      onClick={() => setEditing(null)}
+                      disabled={busy}
+                    >
+                      Cancel
+                    </button>
+                  </>
+                ) : (
+                  <button
+                    className="btn-ghost"
+                    disabled={!canMutate}
+                    onClick={() => {
+                      setEditing(f.field);
+                      setDraft(f.read(runtime));
+                    }}
+                  >
+                    Edit
+                  </button>
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </section>
+  );
+}
+
+// buildSettingsPatch converts a field spec + raw string into the
+// typed SettingsPatch shape the daemon expects.
+function buildSettingsPatch(spec: FieldSpec, raw: string): SettingsPatch {
+  const v = raw.trim();
+  switch (spec.field) {
+    case "log.level":
+      return { log_level: v };
+    case "log.format":
+      return { log_format: v };
+    case "audio.volume": {
+      const n = Number(v);
+      if (Number.isNaN(n) || n < 0 || n > 1) {
+        throw new Error("audio.volume must be a float in [0, 1]");
+      }
+      return { audio_volume: n };
+    }
+    case "audio.muted":
+      return { audio_muted: parseBool(v) };
+    case "scanner.scan_mode":
+      return { scanner_scan_mode: v };
+    case "recordings.dir":
+      return { recordings_dir: v };
+    case "recordings.sample_rate": {
+      const n = Number(v);
+      if (!Number.isFinite(n) || n <= 0) {
+        throw new Error("recordings.sample_rate must be a positive integer");
+      }
+      return { recordings_sample_rate: n };
+    }
+    case "sdr.sample_rate": {
+      const n = Number(v);
+      if (!Number.isFinite(n) || n <= 0) {
+        throw new Error("sdr.sample_rate must be a positive integer");
+      }
+      return { sdr_sample_rate: n };
+    }
+    case "metrics.enabled":
+      return { metrics_enabled: parseBool(v) };
+  }
+  throw new Error(`unknown field ${spec.field}`);
+}
+
+function parseBool(v: string): boolean {
+  switch (v.toLowerCase()) {
+    case "true":
+    case "on":
+    case "yes":
+    case "1":
+      return true;
+    case "false":
+    case "off":
+    case "no":
+    case "0":
+      return false;
+  }
+  throw new Error("expected true/false (also accepts on/off, yes/no, 1/0)");
 }


### PR DESCRIPTION
Closes the deferred items from #239.

## Summary

- **Inline-editable Settings (TUI + web).** Both panels now expose every editable runtime knob as a row with a cursor + Enter to edit, Enter to save, Esc to cancel. Restart-required rows get a `[restart]` badge. Backend validation failures land inline on the failing row via a typed `SettingsErrorMsg`; client-side type checks catch float/int/bool parse errors before the request goes out.
- **Embedded web SPA.** `web/embed.go` baked into the daemon binary serves the SPA at `/` on the HTTP API. `gophertrunk -web` opens the daemon URL directly when the embed is populated, with a client-side fallback to `index.html` for React-Router routes. Fresh checkouts without `make web-build` keep the existing sibling-`gophertrunk-web/` discovery path (only the `.gitkeep` sentinel is in the embed at that point).
- **SIGHUP config reload** (Unix-only, no-op on Windows): re-loads `config.yaml`, diff-applies hot-reloadable fields, logs restart-required changes.
- **Single-instance flock** at `<configdir>/.gophertrunk.lock` so two daemons aimed at the same config don't both fight libusb. PID + start-timestamp metadata in the lock file for forensics; clear "another gophertrunk is running" error on contention.
- **Friendlier YAML errors** — `config: <path>: parse error …` carries the resolved path + a hint to run the wizard.
- **Patent banner deferred** into `startup_warnings` so it doesn't scroll past on the daemon log right before the interactive prompt.

## Docs

- `docs/live-edits.md` — new per-field hot-reload vs restart-required matrix.
- `docs/launcher.md` — covers the embed and adds a SIGHUP note.
- `docs/hardening.md` — opens with the closed-LAN-defaults banner + opt-back-in recipe.
- `docs/web.md` — adds the "Embedded SPA" quick-path section.
- `README.md` — quickstart shows `./gophertrunk` (interactive launcher) as the default flow.
- `CHANGELOG.md` — enumerates the new features.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` — full suite green, including new tests:
  - `cmd/gophertrunk`: `TestInstanceLock_*`, `TestDaemonReload`, `TestDaemonReload_NoConfigPath`
  - `internal/api`: `TestSPA_*` (5 tests covering index, asset, client-route fallback, API not shadowed, no-embed skip)
  - `internal/tui`: `TestBuildSettingsPatch_*` (8 tests covering each field type + parse failures)
  - `internal/tui/panels`: `TestSettingsPanel_Edit*`, `TestSettingsPanel_SettingsError*`, `TestSettingsPanel_DownArrowMovesCursor`
- [x] `cd web && npm run typecheck` clean
- [x] `cd web && npm run build` clean (414 KB / 135 KB gzipped)
- [ ] Manual smoke: `./gophertrunk -tui` → Settings panel → Enter on Log level → type `debug` → Enter → row updates, toast confirms.
- [ ] Manual smoke: `./gophertrunk -web` opens the daemon URL directly when the embed is populated.
- [ ] Manual smoke: `kill -HUP $(pidof gophertrunk)` after editing config.yaml in `$EDITOR` → "config reloaded: …" log line, applied fields take effect.
- [ ] Manual smoke: start two daemons against the same config → second exits with "another gophertrunk is running" error.

https://claude.ai/code/session_01EpTn9SfKiajBuF1N6e4Wc6

---
_Generated by [Claude Code](https://claude.ai/code/session_01EpTn9SfKiajBuF1N6e4Wc6)_