### PR TITLE
no-capture follow-ups: nxdn deviation tunability + ambe2 preset bundles + calibrate self-test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,44 @@ for tagged releases.
 
 ## [Unreleased]
 
+### Added
+
+- **Per-system NXDN deviation tunability** (`nxdn_deviation_hz`).
+  The NXDN receiver's 4-FSK slicer was hardcoded to the Common Air
+  Interface spec value of 1800 Hz peak deviation, which produces a
+  bimodal dibit distribution on captures from transmitters that
+  deviate from spec (e.g. `samples/nxdn/NXDN96 IQ.wav` reports
+  3 / 50 / 3 / 44 % through the production pipeline). Operators can
+  now set `nxdn_deviation_hz: 2400` (or any positive value) on a
+  per-system basis to recalibrate the slicer against the captured
+  signal's actual deviation. Zero / unset keeps the spec default.
+  See [`samples/nxdn/README.md`](samples/nxdn/README.md#tuning-deviation-for-non-spec-captures)
+  for the sweep recipe.
+- **AMBE+2 knox preset bundles** (`ambe2.RegisterPreset` /
+  `ambe2.ListPresets`). The existing `SetKnoxTone` hook (b₁ ∈
+  [144, 163]) registers one vendor-specific dual-tone pair at a
+  time; the new preset API takes a named bundle of entries and
+  records the preset name for operator diagnostics. Lets per-vendor
+  sub-packages ship curated tables via a single `RegisterPreset`
+  call instead of repeated `SetKnoxTone`s. The in-tree code ships
+  no vendor presets because the public AMBE+2 spec does not
+  document the [144, 163] frequency range — see
+  [`docs/vocoders.md`](docs/vocoders.md#sourcing-vendor-frequencies)
+  for the sourcing checklist.
+
 ### Internal
+
+- **Calibrate harness math is testable without external fixtures.**
+  Extracted `calibrate.CompareSamples([]int16, []int16) Result` so
+  the RMS-ratio + cross-correlation math can be exercised on
+  synthetic streams. The two existing skip-gated tests
+  (`TestCompareIMBE*`, `TestCompareAMBE2*`) keep waiting for
+  captured DSD-FME / OP25 reference WAVs; the new
+  `TestCompareSamplesSyntheticGainOffset` validates the math
+  unconditionally (a +3 dB louder reference must produce
+  `RMSRatioDb = −3.0 ± 0.5` and `PeakXcorr ≥ 0.99`). Regressions
+  in the loudness / similarity math now fail CI without needing
+  any external reference data to land first.
 
 - **Cleanup & coverage round.**
   - `web/scripts/seal-node-modules.mjs` is registered as the npm

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -228,6 +228,7 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 			P25Phase2ScramblerMode: sys.P25Phase2ScramblerMode,
 			P25Phase2ClockMode:     sys.P25Phase2ClockMode,
 			NXDNViterbiMode:        sys.NXDNViterbiMode,
+			NXDNDeviationHz:        sys.NXDNDeviationHz,
 			EDACSBCHMode:           sys.EDACSBCHMode,
 			MPT1327BCHMode:         sys.MPT1327BCHMode,
 			MPT1327CWSCTolerance:   sys.MPT1327CWSCTolerance,

--- a/docs/vocoders.md
+++ b/docs/vocoders.md
@@ -218,8 +218,10 @@ AMBE+2 tone frames with b1 ∈ [144, 163] are vendor-specific knox /
 call-alert pairs. The public spec doesn't document them; without
 registration, the decoder routes those frames through silence.
 
-Operators with a per-vendor reference can register the
-(freqA, freqB) pair via
+### Single-entry registration
+
+Operators with a per-vendor reference can register one
+(freqA, freqB) pair at a time via
 [`ambe2.SetKnoxTone`](../internal/voice/ambe2/knox.go) (typically
 from a per-vendor sub-package `init()`):
 
@@ -232,9 +234,46 @@ func init() {
 }
 ```
 
+### Preset bundles
+
+For curated tables (a service-manual extract, an open-source
+receiver's vendor table), use
+[`ambe2.RegisterPreset`](../internal/voice/ambe2/knox.go) instead
+of repeated `SetKnoxTone` calls. The preset name shows up in
+`ambe2.ListPresets()` for operator diagnostics:
+
+```go
+import "github.com/MattCheramie/GopherTrunk/internal/voice/ambe2"
+
+func init() {
+    // Hypothetical Vendor X call-alert table. Replace with values
+    // sourced from a verifiable reference (DSDcc, DSD-FME, vendor
+    // service manual) — the public AMBE+2 spec does not document
+    // these frequencies.
+    _ = ambe2.RegisterPreset(ambe2.KnoxPreset{
+        Name: "vendor-x-call-alerts",
+        Entries: map[int][2]float64{
+            150: {1100, 1750},
+            151: {1200, 1800},
+        },
+    })
+}
+```
+
 Registered indices synthesise through the same summed-sinewave
 dual-tone path as DTMF — phase-continuous across consecutive tone
 frames, AGC-scaled, click-free.
+
+### Sourcing vendor frequencies
+
+The in-tree code ships no vendor presets because the AMBE+2 public
+spec does not document the [144, 163] frequency range and the
+maintainers have not had operator-confirmed reference data to copy
+from. Contributors with a verifiable source (cite the file + commit
+or document section in the PR) can land a per-vendor preset under
+`internal/voice/ambe2/presets/<vendor>/`. Open-source receivers
+worth checking: `szechyjs/mbelib`, DSDcc, DSD-FME, OP25 — search
+the tone-decode paths for the b1 index range.
 
 ## Future work
 

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -43,6 +43,7 @@ type SystemDTO struct {
 	P25Phase2RSMode        string `json:"p25_phase2_rs_mode,omitempty"`
 	P25Phase2ScramblerMode string `json:"p25_phase2_scrambler_mode,omitempty"`
 	NXDNViterbiMode        string `json:"nxdn_viterbi_mode,omitempty"`
+	NXDNDeviationHz        float64 `json:"nxdn_deviation_hz,omitempty"`
 	EDACSBCHMode         string `json:"edacs_bch_mode,omitempty"`
 	MPT1327BCHMode       string `json:"mpt1327_bch_mode,omitempty"`
 	MPT1327CWSCTolerance string `json:"mpt1327_cwsc_tolerance,omitempty"`
@@ -67,6 +68,7 @@ func systemToDTO(s trunking.System) SystemDTO {
 		P25Phase2RSMode:        s.P25Phase2RSMode,
 		P25Phase2ScramblerMode: s.P25Phase2ScramblerMode,
 		NXDNViterbiMode:        s.NXDNViterbiMode,
+		NXDNDeviationHz:        s.NXDNDeviationHz,
 		EDACSBCHMode:         s.EDACSBCHMode,
 		MPT1327BCHMode:       s.MPT1327BCHMode,
 		MPT1327CWSCTolerance: s.MPT1327CWSCTolerance,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -257,6 +257,16 @@ type SystemConfig struct {
 	// "0" (legacy 44-dibit raw-CAC path, opt-out for pre-stripped
 	// fixtures). Ignored for non-NXDN protocols.
 	NXDNViterbiMode string `yaml:"nxdn_viterbi_mode"`
+	// NXDNDeviationHz overrides the peak frequency deviation (Hz)
+	// the NXDN receiver's slicer is calibrated against. The Common
+	// Air Interface spec value is 1800 Hz (matched against the
+	// FM-discriminator output level so live captures slice
+	// correctly). Some on-air transmitters deviate from spec —
+	// captures whose dibit distribution is bimodal (outer ±3 levels
+	// dominate, inner ±1 underrepresented) usually want a higher
+	// value (e.g., 2400 Hz). Zero / unset uses the spec default.
+	// Ignored for non-NXDN protocols.
+	NXDNDeviationHz float64 `yaml:"nxdn_deviation_hz,omitempty"`
 	// EDACSBCHMode enables the BCH(40, 28, 2) FEC layer on the
 	// EDACS CCW. Recognised values: "" / "on" / "true" / "1" (the
 	// new default — 40-bit on-wire BCH decode with single/double-

--- a/internal/scanner/ccdecoder/decoder_test.go
+++ b/internal/scanner/ccdecoder/decoder_test.go
@@ -802,6 +802,53 @@ func TestNXDNFactoryAppliesViterbiFromSystem(t *testing.T) {
 	}
 }
 
+// TestNXDNFactoryAppliesDeviationFromSystem: a non-zero
+// NXDNDeviationHz on the system overrides the 1800 Hz spec default
+// the slicer calibrates against.
+func TestNXDNFactoryAppliesDeviationFromSystem(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	p, err := newNXDNPipeline(PipelineOptions{
+		Bus: bus, SystemName: "Test", FrequencyHz: 851_062_500,
+		SampleRateHz: 48_000,
+		System: trunking.System{
+			Name: "Test", Protocol: trunking.ProtocolNXDN,
+			ControlChannels: []uint32{851_062_500},
+			NXDNDeviationHz: 2400.0,
+		},
+	})
+	if err != nil {
+		t.Fatalf("newNXDNPipeline: %v", err)
+	}
+	np := p.(*nxdnPipeline)
+	if np.deviationHz != 2400.0 {
+		t.Errorf("deviationHz = %v, want 2400.0", np.deviationHz)
+	}
+}
+
+// TestNXDNFactoryDefaultsDeviation: a zero / unset NXDNDeviationHz
+// falls back to the 1800 Hz spec default per the Common Air
+// Interface.
+func TestNXDNFactoryDefaultsDeviation(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	p, err := newNXDNPipeline(PipelineOptions{
+		Bus: bus, SystemName: "Test", FrequencyHz: 851_062_500,
+		SampleRateHz: 48_000,
+		System: trunking.System{
+			Name: "Test", Protocol: trunking.ProtocolNXDN,
+			ControlChannels: []uint32{851_062_500},
+		},
+	})
+	if err != nil {
+		t.Fatalf("newNXDNPipeline: %v", err)
+	}
+	np := p.(*nxdnPipeline)
+	if np.deviationHz != 1800.0 {
+		t.Errorf("deviationHz = %v, want 1800.0", np.deviationHz)
+	}
+}
+
 // TestEDACSFactoryAppliesBCHFromSystem: EDACSBCHMode = "on" flips
 // the CCW decoder into BCHOn.
 func TestEDACSFactoryAppliesBCHFromSystem(t *testing.T) {

--- a/internal/scanner/ccdecoder/pipelines.go
+++ b/internal/scanner/ccdecoder/pipelines.go
@@ -525,23 +525,30 @@ func newNXDNPipeline(opts PipelineOptions) (ProtocolPipeline, error) {
 			"system", opts.SystemName, "value", opts.System.NXDNViterbiMode)
 	}
 	cc.SetViterbiMode(viterbiMode)
+	// NXDN spec peak deviation per the Common Air Interface (same
+	// value P25 Phase 1 uses). Calibrates the slicer thresholds
+	// against the FM-discriminator output level so live captures
+	// slice correctly out of the box. Per-system override via
+	// nxdn_deviation_hz for transmitters that deviate from spec —
+	// see samples/nxdn/README.md.
+	deviationHz := 1800.0
+	if opts.System.NXDNDeviationHz > 0 {
+		deviationHz = opts.System.NXDNDeviationHz
+	}
 	rx := nxdnrx.New(nxdnrx.Options{
 		SampleRateHz: opts.SampleRateHz,
-		// NXDN spec peak deviation per the Common Air Interface
-		// (same value P25 Phase 1 uses). Calibrates the slicer
-		// thresholds against the FM-discriminator output level so
-		// live captures slice correctly out of the box.
-		DeviationHz: 1800.0,
+		DeviationHz:  deviationHz,
 		DibitSink: func(dibits []uint8, baseIdx int) {
 			cc.Process(dibits, baseIdx)
 		},
 	})
-	return &nxdnPipeline{rx: rx, cc: cc}, nil
+	return &nxdnPipeline{rx: rx, cc: cc, deviationHz: deviationHz}, nil
 }
 
 type nxdnPipeline struct {
-	rx *nxdnrx.Receiver
-	cc *nxdn.ControlChannel
+	rx          *nxdnrx.Receiver
+	cc          *nxdn.ControlChannel
+	deviationHz float64
 }
 
 func (p *nxdnPipeline) Process(iq []complex64) { p.rx.Process(iq) }

--- a/internal/trunking/site.go
+++ b/internal/trunking/site.go
@@ -213,6 +213,16 @@ type System struct {
 	// by the ccdecoder connector after parsing via
 	// nxdn.ParseViterbiMode.
 	NXDNViterbiMode string
+	// NXDNDeviationHz overrides the peak frequency deviation (Hz)
+	// the NXDN receiver's slicer is calibrated against. Spec value
+	// is 1800 Hz (matches the FM-discriminator output level so live
+	// captures slice correctly out of the box). Operators with
+	// on-air captures whose dibit distribution is bimodal (outer
+	// ±3 dominate, inner ±1 underrepresented) can override here —
+	// see samples/nxdn/README.md for the calibration recipe.
+	// Forwarded into nxdnrx.Options.DeviationHz by the ccdecoder
+	// connector; values <= 0 fall back to the spec default.
+	NXDNDeviationHz float64
 	// EDACSBCHMode enables the BCH(40, 28, 2) FEC layer on the
 	// EDACS CCW. Recognised values (case-insensitive): "" / "on" /
 	// "true" / "1" → BCHOn (the new default — 40-bit on-wire

--- a/internal/tui/client/types.go
+++ b/internal/tui/client/types.go
@@ -45,6 +45,7 @@ type SystemDTO struct {
 	P25Phase2RSMode        string `json:"p25_phase2_rs_mode,omitempty"`
 	P25Phase2ScramblerMode string `json:"p25_phase2_scrambler_mode,omitempty"`
 	NXDNViterbiMode        string `json:"nxdn_viterbi_mode,omitempty"`
+	NXDNDeviationHz        float64 `json:"nxdn_deviation_hz,omitempty"`
 	EDACSBCHMode         string `json:"edacs_bch_mode,omitempty"`
 	MPT1327BCHMode       string `json:"mpt1327_bch_mode,omitempty"`
 	MPT1327CWSCTolerance string `json:"mpt1327_cwsc_tolerance,omitempty"`

--- a/internal/voice/ambe2/knox.go
+++ b/internal/voice/ambe2/knox.go
@@ -91,4 +91,65 @@ func ClearKnoxTones() {
 	for i := range knoxToneTable {
 		knoxToneTable[i] = [2]float64{}
 	}
+	knoxPresetsMu.Lock()
+	knoxPresets = nil
+	knoxPresetsMu.Unlock()
+}
+
+// KnoxPreset is a named bundle of vendor-specific knox / call-alert
+// dual-tone pairs. Entries map a knox b1 index (in [KnoxIndexLow,
+// KnoxIndexHigh]) to its (freqA, freqB) frequencies in Hz.
+//
+// Presets are an opt-in convenience layer over SetKnoxTone for
+// operators who have a curated per-vendor table (sourced from
+// open-source receivers like DSDcc / DSD-FME / mbelib, or from a
+// vendor service manual). The public AMBE+2 spec does not document
+// these frequencies; ship presets with the citation in a comment so
+// future maintainers can verify.
+type KnoxPreset struct {
+	Name    string
+	Entries map[int][2]float64
+}
+
+var (
+	knoxPresetsMu sync.RWMutex
+	knoxPresets   []string
+)
+
+// RegisterPreset applies every entry in p via SetKnoxTone and records
+// the preset name for ListPresets diagnostics. Returns the first
+// SetKnoxTone error encountered (out-of-range b1, etc.); on error,
+// entries applied before the failure stay registered — callers can
+// ClearKnoxTones to reset.
+//
+// Safe to call from package init(). Calling RegisterPreset multiple
+// times with overlapping b1 indices is well-defined: later
+// registrations overwrite earlier ones in tone-table order. The
+// preset name appears in ListPresets for every successful
+// registration even if subsequent presets shadow some of its entries.
+func RegisterPreset(p KnoxPreset) error {
+	if p.Name == "" {
+		return fmt.Errorf("ambe2: knox preset name is required")
+	}
+	for b1, pair := range p.Entries {
+		if err := SetKnoxTone(b1, pair[0], pair[1]); err != nil {
+			return fmt.Errorf("ambe2: preset %q: %w", p.Name, err)
+		}
+	}
+	knoxPresetsMu.Lock()
+	knoxPresets = append(knoxPresets, p.Name)
+	knoxPresetsMu.Unlock()
+	return nil
+}
+
+// ListPresets returns the names of every preset registered via
+// RegisterPreset since the last ClearKnoxTones. Useful for operator
+// diagnostics ("which vendor tables are active right now?") and
+// startup logging.
+func ListPresets() []string {
+	knoxPresetsMu.RLock()
+	defer knoxPresetsMu.RUnlock()
+	out := make([]string, len(knoxPresets))
+	copy(out, knoxPresets)
+	return out
 }

--- a/internal/voice/ambe2/knox_test.go
+++ b/internal/voice/ambe2/knox_test.go
@@ -178,3 +178,100 @@ func absMaxInt16(samples []int16) int {
 	}
 	return peak
 }
+
+func TestRegisterPresetAppliesEntries(t *testing.T) {
+	ClearKnoxTones()
+	defer ClearKnoxTones()
+
+	preset := KnoxPreset{
+		Name: "test-vendor-a",
+		Entries: map[int][2]float64{
+			145: {950, 1450},
+			150: {1100, 1750},
+			160: {1300, 1850},
+		},
+	}
+	if err := RegisterPreset(preset); err != nil {
+		t.Fatalf("RegisterPreset: %v", err)
+	}
+	for b1, want := range preset.Entries {
+		fA, fB, ok := KnoxTone(b1)
+		if !ok {
+			t.Errorf("KnoxTone(%d) ok = false after RegisterPreset", b1)
+			continue
+		}
+		if fA != want[0] || fB != want[1] {
+			t.Errorf("KnoxTone(%d) = (%v, %v), want (%v, %v)",
+				b1, fA, fB, want[0], want[1])
+		}
+	}
+	if names := ListPresets(); len(names) != 1 || names[0] != "test-vendor-a" {
+		t.Errorf("ListPresets() = %v, want [test-vendor-a]", names)
+	}
+}
+
+func TestRegisterPresetRejectsEmptyName(t *testing.T) {
+	ClearKnoxTones()
+	defer ClearKnoxTones()
+	err := RegisterPreset(KnoxPreset{
+		Entries: map[int][2]float64{150: {1100, 1750}},
+	})
+	if err == nil {
+		t.Fatal("RegisterPreset accepted empty name")
+	}
+}
+
+func TestRegisterPresetRejectsOutOfRangeEntries(t *testing.T) {
+	ClearKnoxTones()
+	defer ClearKnoxTones()
+	err := RegisterPreset(KnoxPreset{
+		Name:    "bad-vendor",
+		Entries: map[int][2]float64{100: {1000, 1700}},
+	})
+	if err == nil {
+		t.Fatal("RegisterPreset accepted out-of-range b1")
+	}
+}
+
+func TestRegisterPresetLaterOverridesEarlier(t *testing.T) {
+	ClearKnoxTones()
+	defer ClearKnoxTones()
+
+	if err := RegisterPreset(KnoxPreset{
+		Name:    "vendor-a",
+		Entries: map[int][2]float64{150: {1000, 1700}},
+	}); err != nil {
+		t.Fatalf("RegisterPreset(vendor-a): %v", err)
+	}
+	if err := RegisterPreset(KnoxPreset{
+		Name:    "vendor-b",
+		Entries: map[int][2]float64{150: {1100, 1750}},
+	}); err != nil {
+		t.Fatalf("RegisterPreset(vendor-b): %v", err)
+	}
+	fA, fB, _ := KnoxTone(150)
+	if fA != 1100 || fB != 1750 {
+		t.Errorf("KnoxTone(150) = (%v, %v), want (1100, 1750) from vendor-b", fA, fB)
+	}
+	names := ListPresets()
+	if len(names) != 2 || names[0] != "vendor-a" || names[1] != "vendor-b" {
+		t.Errorf("ListPresets() = %v, want [vendor-a vendor-b]", names)
+	}
+}
+
+func TestClearKnoxTonesAlsoClearsPresets(t *testing.T) {
+	ClearKnoxTones()
+	if err := RegisterPreset(KnoxPreset{
+		Name:    "test-vendor",
+		Entries: map[int][2]float64{150: {1100, 1750}},
+	}); err != nil {
+		t.Fatalf("RegisterPreset: %v", err)
+	}
+	if len(ListPresets()) != 1 {
+		t.Fatal("preset not registered")
+	}
+	ClearKnoxTones()
+	if names := ListPresets(); len(names) != 0 {
+		t.Errorf("ListPresets() after Clear = %v, want []", names)
+	}
+}

--- a/internal/voice/calibrate/calibrate.go
+++ b/internal/voice/calibrate/calibrate.go
@@ -116,6 +116,20 @@ func Compare(rawPath, refWavPath, vocoderName string) (Result, error) {
 			refRate, expectedSampleRate)
 	}
 
+	return CompareSamples(inTree, refSamples), nil
+}
+
+// CompareSamples runs the RMS + cross-correlation math directly on
+// two PCM streams. Compare is the operator-facing entry point that
+// decodes the in-tree vocoder + reads the reference WAV before
+// delegating here; CompareSamples is exposed separately so the
+// loudness / similarity math is testable with synthetic inputs (no
+// vocoder frame fixtures, no on-disk WAV files).
+//
+// Both streams are expected to be 8 kHz / 16-bit / mono PCM. RMS
+// silence in either stream produces RMSRatioDb = 0 (the ratio isn't
+// defined); PeakXcorr will still surface the mismatch.
+func CompareSamples(inTree, refSamples []int16) Result {
 	rmsIn := rms(inTree)
 	rmsRef := rms(refSamples)
 	var rmsDb float64
@@ -136,7 +150,7 @@ func Compare(rawPath, refWavPath, vocoderName string) (Result, error) {
 		LagSamples:        lag,
 		InTreeSampleCount: len(inTree),
 		RefSampleCount:    len(refSamples),
-	}, nil
+	}
 }
 
 // rms returns the root-mean-square amplitude of an int16 sample

--- a/internal/voice/calibrate/calibrate_test.go
+++ b/internal/voice/calibrate/calibrate_test.go
@@ -233,3 +233,66 @@ func TestCompareAMBE2SkipsWithoutFixtures(t *testing.T) {
 			res.PeakXcorr, res.LagSamples)
 	}
 }
+
+// TestCompareSamplesSyntheticGainOffset validates the calibrate
+// math without external fixtures. Generates a 1 s sine through the
+// "in-tree" stream + a +3 dB-louder copy as the "reference", then
+// asserts CompareSamples reports the expected loudness offset and
+// perfect waveform alignment. Keeps the math under test even when
+// the real-air reference WAVs in internal/voice/{imbe,ambe2}/testdata
+// haven't been checked in yet.
+func TestCompareSamplesSyntheticGainOffset(t *testing.T) {
+	const (
+		sampleRateHz = 8000
+		durationSec  = 1.0
+		toneHz       = 440.0
+		inAmplitude  = 5000.0 // int16 RMS of a sine at amplitude A is A/√2.
+	)
+	// gainLinear = 10^(3/20) ≈ 1.4125 → the reference is +3 dB louder
+	// than the in-tree stream. Compare reports RMSRatioDb as
+	// 20·log10(rmsIn / rmsRef), so a louder reference produces a
+	// negative dB value.
+	const wantDb = -3.0
+	gainLinear := math.Pow(10, 3.0/20.0)
+
+	n := int(sampleRateHz * durationSec)
+	inTree := make([]int16, n)
+	refSamples := make([]int16, n)
+	for i := 0; i < n; i++ {
+		v := inAmplitude * math.Sin(2*math.Pi*toneHz*float64(i)/sampleRateHz)
+		inTree[i] = int16(v)
+		refSamples[i] = int16(v * gainLinear)
+	}
+
+	res := CompareSamples(inTree, refSamples)
+
+	if math.Abs(res.RMSRatioDb-wantDb) > 0.5 {
+		t.Errorf("RMSRatioDb = %.3f dB, want %.3f ± 0.5 dB", res.RMSRatioDb, wantDb)
+	}
+	if res.PeakXcorr < 0.99 {
+		t.Errorf("PeakXcorr = %.4f, want >= 0.99 (identical waveforms up to scale)", res.PeakXcorr)
+	}
+	if res.LagSamples != 0 {
+		t.Errorf("LagSamples = %d, want 0 (no delay between identical streams)", res.LagSamples)
+	}
+	if res.InTreeSampleCount != n || res.RefSampleCount != n {
+		t.Errorf("sample counts = (%d, %d), want (%d, %d)",
+			res.InTreeSampleCount, res.RefSampleCount, n, n)
+	}
+}
+
+// TestCompareSamplesSilencePath: one silent stream produces a
+// well-defined zero RMS ratio (vs. NaN / −∞ from a log of zero).
+func TestCompareSamplesSilencePath(t *testing.T) {
+	const n = 800
+	silent := make([]int16, n)
+	noisy := make([]int16, n)
+	for i := range noisy {
+		noisy[i] = int16(1000 * math.Sin(2*math.Pi*440*float64(i)/8000))
+	}
+
+	res := CompareSamples(silent, noisy)
+	if res.RMSRatioDb != 0 {
+		t.Errorf("RMSRatioDb with silent in-tree = %v, want 0", res.RMSRatioDb)
+	}
+}

--- a/samples/nxdn/README.md
+++ b/samples/nxdn/README.md
@@ -95,3 +95,31 @@ integration test
 [`cmd/gophertrunk/integration_cc_nxdn_test.go`](../../cmd/gophertrunk/integration_cc_nxdn_test.go)
 — add a `_realair_test.go` sibling pointing the mock SDR at the
 capture path.
+
+## Tuning deviation for non-spec captures
+
+The NXDN receiver's 4-FSK slicer is calibrated against the Common
+Air Interface spec value of 1800 Hz peak deviation. On-air
+transmitters that deviate from spec produce a **bimodal dibit
+distribution** through the slicer — outer ±3 levels dominate, inner
+±1 levels under-fire (e.g. `samples/nxdn/NXDN96 IQ.wav` reports
+3 / 50 / 3 / 44 % through the production pipeline). Override the
+deviation per-system in `config.yaml`:
+
+```yaml
+trunking:
+  systems:
+    - name: "Local NXDN"
+      protocol: "nxdn"
+      control_channels: [851062500]
+      # Override only if the default 1800 Hz produces a bimodal
+      # dibit distribution. Typical values for non-spec
+      # transmitters land between 2200 and 2700 Hz.
+      nxdn_deviation_hz: 2400
+```
+
+Zero / unset (the default) uses the 1800 Hz spec value. The
+existing `cmd/audio_smoketest` tool prints the empirical dibit
+distribution after slicing — sweep `nxdn_deviation_hz` until the
+distribution flattens toward the spec-ideal 25 / 25 / 25 / 25 %
+before locking in a value.


### PR DESCRIPTION
Three independent no-capture improvements from the README "Status &
known gaps" review:

- Per-system NXDN deviation tunability (nxdn_deviation_hz). The
  4-FSK slicer was hardcoded to 1800 Hz, producing a bimodal
  dibit distribution on captures from non-spec transmitters
  (samples/nxdn/NXDN96 IQ.wav: 3/50/3/44%). Operators can now
  override per-system; zero / unset keeps the spec default.
- ambe2.RegisterPreset / ListPresets for vendor knox tables.
  Curated bundles instead of repeated SetKnoxTone calls, with
  a name surfacing through ListPresets for operator diagnostics.
  No in-tree vendor presets because the public spec does not
  document the [144, 163] frequency range — sourcing checklist
  lives in docs/vocoders.md.
- calibrate.CompareSamples extracted so the RMS + cross-correlation
  math is testable on synthetic PCM (no vocoder fixtures, no WAV
  files). New TestCompareSamplesSyntheticGainOffset validates the
  math unconditionally so regressions surface in CI before
  reference data lands.