### PR TITLE
nxdn real-air harness skeleton + TUI deviation display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,38 @@ for tagged releases.
 
 ### Added
 
+- **NXDN deviation surfaces on the TUI Settings → FEC tab.**
+  The `nxdn_deviation_hz` knob shipped in [PR #243](https://github.com/MattCheramie/GopherTrunk/pull/243)
+  but wasn't visible from the operator console. The
+  per-system FEC summary now appends `deviation: 1800 Hz`
+  (or whatever override is configured) alongside the existing
+  `viterbi:` mode, matching the pattern P25 Phase 2 / MPT 1327
+  use for their per-protocol opt-outs. The hash gate that
+  controls FEC table refresh covers the new field so a
+  config-reloaded override surfaces inside one SSE round-trip.
+- **NXDN real-air integration harness skeleton.**
+  [`cmd/gophertrunk/integration_cc_nxdn_realair_test.go`](cmd/gophertrunk/integration_cc_nxdn_realair_test.go)
+  is the skip-gated companion to the existing synthesized
+  `TestDaemonCCDecodesNXDN`. When a contributor drops a single
+  `*.cfile` + sibling `*.metadata.json` pair into
+  [`samples/nxdn/`](samples/nxdn/), the harness:
+   - registers the in-tree `sdr.MockFloat32Driver` against the
+     capture,
+   - tunes the daemon to `metadata.center_freq_hz` at
+     `metadata.sample_rate_hz` (both required at the top level
+     since GNU Radio cfiles don't embed them),
+   - boots the daemon with `nxdn_viterbi_mode: spec`,
+   - waits up to 3 s wall time for `events.KindCCLocked`,
+   - asserts `LockState.SystemID` / `SiteID` / `FrequencyHz`
+     match the documented `metadata.expected` values
+     byte-for-byte.
+  
+  CI stays green via a documented `t.Skipf` fall-through until
+  a capture lands. Multiple `*.cfile` candidates surface as an
+  explicit test error so the contributor knows to disambiguate.
+  Metadata schema documented in
+  [`samples/nxdn/README.md`](samples/nxdn/README.md).
+
 - **Per-system NXDN deviation tunability** (`nxdn_deviation_hz`).
   The NXDN receiver's 4-FSK slicer was hardcoded to the Common Air
   Interface spec value of 1800 Hz peak deviation, which produces a

--- a/README.md
+++ b/README.md
@@ -121,7 +121,13 @@ The remaining gaps:
     dibit distribution at the slicer output — can be rebalanced
     without code changes. See
     [`samples/nxdn/README.md`](samples/nxdn/README.md#tuning-deviation-for-non-spec-captures)
-    for the sweep recipe.
+    for the sweep recipe. The skip-gated real-air harness at
+    [`cmd/gophertrunk/integration_cc_nxdn_realair_test.go`](cmd/gophertrunk/integration_cc_nxdn_realair_test.go)
+    runs the SystemID + SiteID + 3 s lock-latency acceptance
+    criteria automatically as soon as a contributor drops a
+    `.cfile` + `.metadata.json` pair into `samples/nxdn/` per the
+    documented schema; CI stays green in the meantime via a
+    documented `t.Skipf` fall-through.
   - **P25 Phase 2 FEC chain (trellis + outer RS + PN44
     scrambler + per-burst offset probe, all shipping).** The
     full TIA-102 chain wraps the MAC PDU in three layers, each

--- a/cmd/gophertrunk/integration_cc_nxdn_realair_test.go
+++ b/cmd/gophertrunk/integration_cc_nxdn_realair_test.go
@@ -1,0 +1,267 @@
+//go:build integration
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/config"
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/nxdn"
+	"github.com/MattCheramie/GopherTrunk/internal/sdr"
+)
+
+// realairCaptureMetadata is the in-test schema for the JSON sidecar
+// dropped alongside each *.cfile in samples/<proto>/. Mirrors the
+// schema documented in samples/<proto>/README.md "Metadata schema"
+// sections, plus two top-level fields the test needs to drive the
+// mock SDR (`sample_rate_hz`, `center_freq_hz`) that the operator
+// MUST supply since GNU Radio cfiles don't embed them.
+type realairCaptureMetadata struct {
+	Source         string `json:"source"`
+	ToolCrossCheck string `json:"tool_cross_check"`
+	// SampleRateHz is the IQ sample rate the capture was recorded
+	// at — the mock SDR's SampleRate must match for the receiver's
+	// matched-filter cascade + clock recovery to lock. The samples
+	// READMEs document acceptable ranges per protocol (NXDN: ≥
+	// 48 kHz, TETRA: ≥ 36 kHz, etc.).
+	SampleRateHz uint32 `json:"sample_rate_hz"`
+	// CenterFreqHz is the IQ centre frequency the operator tuned
+	// when recording — the test feeds this into both the SDR
+	// device config and the per-system ControlChannels list so the
+	// ccdecoder pipeline knows what to tune to.
+	CenterFreqHz uint32 `json:"center_freq_hz"`
+	// Expected carries the ground-truth values the decoded LockState
+	// must match. Protocol-specific shape; see per-protocol parsers
+	// below.
+	Expected json.RawMessage `json:"expected"`
+}
+
+// nxdnExpected is the inner shape for samples/nxdn/*.metadata.json
+// "expected" objects. system_id / site_id arrive as hex strings
+// ("0x1234") because that's how an operator would copy them from a
+// MMDVMHost / DSDcc log. RAN is parsed but not yet asserted —
+// nxdn.LockState doesn't carry it; when the field lands the
+// assertion is one line.
+type nxdnExpected struct {
+	SystemID string `json:"system_id"`
+	SiteID   string `json:"site_id"`
+	RAN      uint8  `json:"ran"`
+}
+
+// findRealairCaptures returns the (cfile, metadata.json) path pair
+// for the supplied protocol's samples directory, or two empty
+// strings if no pair is present. A pair is matched when the cfile's
+// stem (basename minus extension) has a sibling .metadata.json.
+//
+// The contract is intentionally narrow: exactly one capture pair is
+// the supported case. A directory with multiple .cfile files
+// surfaces an error so the contributor knows to disambiguate
+// (typically by deleting older captures rather than running them
+// concurrently).
+func findRealairCapture(t *testing.T, proto string) (cfilePath, metaPath string) {
+	t.Helper()
+	dir := filepath.Join("..", "..", "samples", proto)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", ""
+		}
+		t.Fatalf("read samples/%s: %v", proto, err)
+	}
+	var cfiles []string
+	for _, e := range entries {
+		if !strings.HasSuffix(e.Name(), ".cfile") {
+			continue
+		}
+		cfiles = append(cfiles, e.Name())
+	}
+	if len(cfiles) == 0 {
+		return "", ""
+	}
+	if len(cfiles) > 1 {
+		t.Fatalf("samples/%s: %d .cfile candidates (%v) — exactly one is supported; delete or rename extras",
+			proto, len(cfiles), cfiles)
+	}
+	stem := strings.TrimSuffix(cfiles[0], ".cfile")
+	metaName := stem + ".metadata.json"
+	metaFullPath := filepath.Join(dir, metaName)
+	if _, err := os.Stat(metaFullPath); err != nil {
+		t.Fatalf("samples/%s/%s: no sibling %s (capture without metadata is unusable for validation)",
+			proto, cfiles[0], metaName)
+	}
+	return filepath.Join(dir, cfiles[0]), metaFullPath
+}
+
+func loadRealairMetadata(t *testing.T, path string) realairCaptureMetadata {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	var m realairCaptureMetadata
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+	if m.SampleRateHz == 0 {
+		t.Fatalf("%s: sample_rate_hz is required (the GNU Radio cfile doesn't embed it)", path)
+	}
+	if m.CenterFreqHz == 0 {
+		t.Fatalf("%s: center_freq_hz is required (used to tune the mock SDR)", path)
+	}
+	return m
+}
+
+// TestDaemonCCDecodesNXDNRealAir is the skip-gated companion to
+// TestDaemonCCDecodesNXDN. The synthesized sibling proves the IQ →
+// CC pipeline round-trips against in-tree fixtures; this one proves
+// it against an actual on-air capture once a contributor drops a
+// .cfile + .metadata.json pair into samples/nxdn/ per the schema
+// documented in samples/nxdn/README.md.
+//
+// Acceptance criteria (also in samples/nxdn/README.md):
+//
+//  1. Lock latency. CCLocked event arrives within 3 s wall time of
+//     daemon start. NXDN locks faster than TETRA because there's
+//     no Gardner step in the receiver chain.
+//  2. System metadata match. Decoded SystemID + SiteID + RAN match
+//     the metadata.json's "expected" values byte-for-byte.
+//
+// CRC-verified CAC burst rate (≥ 80% target from the README) is
+// not asserted here yet — the in-tree control-channel state machine
+// doesn't currently surface a CRC-pass histogram on the bus. The
+// test will start asserting that rate when the corresponding metric
+// lands (per the "Acceptance criteria" §1 note in the README, the
+// histogram and capture land together).
+func TestDaemonCCDecodesNXDNRealAir(t *testing.T) {
+	cfilePath, metaPath := findRealairCapture(t, "nxdn")
+	if cfilePath == "" {
+		t.Skipf("samples/nxdn/: no *.cfile present — drop a capture + metadata pair to run this test (see samples/nxdn/README.md)")
+	}
+	meta := loadRealairMetadata(t, metaPath)
+
+	var exp nxdnExpected
+	if err := json.Unmarshal(meta.Expected, &exp); err != nil {
+		t.Fatalf("parse expected payload: %v", err)
+	}
+	wantSystemID, err := parseHex16(exp.SystemID)
+	if err != nil {
+		t.Fatalf("metadata expected.system_id=%q: %v", exp.SystemID, err)
+	}
+	wantSiteID, err := parseHex16(exp.SiteID)
+	if err != nil {
+		t.Fatalf("metadata expected.site_id=%q: %v", exp.SiteID, err)
+	}
+
+	sdr.Register(&sdr.MockFloat32Driver{Files: []string{cfilePath}})
+
+	cfg := config.Default()
+	cfg.SDR.SampleRate = meta.SampleRateHz
+	cfg.SDR.Devices = []config.DeviceConfig{
+		{Serial: "mockf32-00", Role: "control"},
+	}
+	cfg.Trunking.Systems = []config.SystemConfig{
+		{
+			Name:            "NXDNRealAir",
+			Protocol:        "nxdn",
+			ControlChannels: []uint32{meta.CenterFreqHz},
+			NXDNViterbiMode: "spec",
+		},
+	}
+	cfg.API.HTTPAddr = freeAddr(t)
+	cfg.Metrics.Enabled = true
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	d, err := NewDaemon(cfg, "integration-cc-nxdn-realair", logger)
+	if err != nil {
+		t.Fatalf("NewDaemon: %v", err)
+	}
+	sub := d.Bus().Subscribe()
+	defer sub.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	runErrCh := make(chan error, 1)
+	go func() { runErrCh <- d.Run(ctx) }()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case <-runErrCh:
+		case <-time.After(3 * time.Second):
+		}
+	})
+
+	base := "http://" + cfg.API.HTTPAddr
+	waitReachable(t, base+"/api/v1/health", 5*time.Second)
+
+	// 3 s lock-latency budget per samples/nxdn/README.md §3.
+	deadline := time.After(3 * time.Second)
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind != events.KindCCLocked {
+				continue
+			}
+			ls, ok := ev.Payload.(nxdn.LockState)
+			if !ok {
+				t.Errorf("CCLocked payload type = %T, want nxdn.LockState", ev.Payload)
+				continue
+			}
+			if ls.SystemID != wantSystemID {
+				t.Errorf("LockState.SystemID = %#x, want %#x (from metadata expected.system_id)",
+					ls.SystemID, wantSystemID)
+			}
+			if ls.SiteID != wantSiteID {
+				t.Errorf("LockState.SiteID = %#x, want %#x (from metadata expected.site_id)",
+					ls.SiteID, wantSiteID)
+			}
+			if ls.FrequencyHz != meta.CenterFreqHz {
+				t.Errorf("LockState.FrequencyHz = %d, want %d (from metadata center_freq_hz)",
+					ls.FrequencyHz, meta.CenterFreqHz)
+			}
+			return
+		case <-deadline:
+			t.Fatalf("no cc.locked event arrived within 3s (capture=%s)", filepath.Base(cfilePath))
+		}
+	}
+}
+
+// parseHex16 accepts "0x1234" / "1234" / "0X1234" style strings and
+// returns the parsed uint16. Used for metadata fields the operator
+// copies from MMDVMHost / DSDcc logs, where hex is the dominant
+// convention.
+func parseHex16(s string) (uint16, error) {
+	s = strings.TrimSpace(s)
+	s = strings.TrimPrefix(s, "0x")
+	s = strings.TrimPrefix(s, "0X")
+	var v uint64
+	for _, c := range s {
+		var nib uint64
+		switch {
+		case c >= '0' && c <= '9':
+			nib = uint64(c - '0')
+		case c >= 'a' && c <= 'f':
+			nib = uint64(c-'a') + 10
+		case c >= 'A' && c <= 'F':
+			nib = uint64(c-'A') + 10
+		default:
+			return 0, errors.New("non-hex digit")
+		}
+		v = v<<4 | nib
+		if v > 0xFFFF {
+			return 0, errors.New("value exceeds uint16")
+		}
+	}
+	if s == "" {
+		return 0, errors.New("empty")
+	}
+	return uint16(v), nil
+}

--- a/internal/tui/panels/settings.go
+++ b/internal/tui/panels/settings.go
@@ -194,7 +194,7 @@ fecRefresh:
 	// to) the FEC tab — the hash gate keeps the cost negligible.
 	if p.tab == tabFEC {
 		h := hashRows(s.Systems, func(sys client.SystemDTO) string {
-			return fmt.Sprintf("%s|%s|%d|%s|%s|%s|%s|%s|%s|%s|%s|%s",
+			return fmt.Sprintf("%s|%s|%d|%s|%s|%s|%s|%s|%s|%s|%s|%.1f|%s",
 				sys.Name, sys.Protocol,
 				sys.TETRAColourCode, sys.TETRAChannel,
 				sys.TETRAChannelCoding,
@@ -202,6 +202,7 @@ fecRefresh:
 				sys.P25Phase2TrellisMode, sys.P25Phase2RSMode,
 				sys.P25Phase2ScramblerMode,
 				sys.NXDNViterbiMode,
+				sys.NXDNDeviationHz,
 				sys.EDACSBCHMode)
 		})
 		if h != p.lastHash {
@@ -471,6 +472,11 @@ func fecSummary(s client.SystemDTO) string {
 		parts = append(parts, "scrambler: "+orDefault(s.P25Phase2ScramblerMode, "off"))
 	case "nxdn":
 		parts = append(parts, "viterbi: "+orDefault(s.NXDNViterbiMode, "spec"))
+		if s.NXDNDeviationHz > 0 {
+			parts = append(parts, fmt.Sprintf("deviation: %.0f Hz", s.NXDNDeviationHz))
+		} else {
+			parts = append(parts, "deviation: 1800 Hz")
+		}
 	case "edacs":
 		parts = append(parts, "bch: "+orDefault(s.EDACSBCHMode, "on"))
 	case "mpt1327":

--- a/internal/tui/panels/settings_test.go
+++ b/internal/tui/panels/settings_test.go
@@ -43,7 +43,7 @@ func TestSettingsPanel_RendersFECSummaryPerProtocol(t *testing.T) {
 		"P2Sys", "trellis: on",
 		"Mining", "bch: on",
 		"UK", "bch: on",
-		"PSC", "viterbi: on",
+		"PSC", "viterbi: on", "deviation: 1800 Hz",
 		"Moto", "bch: on",
 		"config.yaml",
 	}
@@ -51,6 +51,37 @@ func TestSettingsPanel_RendersFECSummaryPerProtocol(t *testing.T) {
 		if !strings.Contains(view, w) {
 			t.Errorf("view missing %q in:\n%s", w, view)
 		}
+	}
+}
+
+func TestSettingsPanel_NXDNShowsDeviationOverride(t *testing.T) {
+	cases := []struct {
+		name string
+		sys  client.SystemDTO
+		want string
+	}{
+		{
+			name: "default",
+			sys:  client.SystemDTO{Name: "Default", Protocol: "nxdn"},
+			want: "deviation: 1800 Hz",
+		},
+		{
+			name: "override",
+			sys:  client.SystemDTO{Name: "Override", Protocol: "nxdn", NXDNDeviationHz: 2400.0},
+			want: "deviation: 2400 Hz",
+		},
+		{
+			name: "non-integer",
+			sys:  client.SystemDTO{Name: "Fractional", Protocol: "nxdn", NXDNDeviationHz: 1944.5},
+			want: "deviation: 1944 Hz",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := fecSummary(c.sys); !strings.Contains(got, c.want) {
+				t.Errorf("fecSummary(%+v) = %q, want substring %q", c.sys, got, c.want)
+			}
+		})
 	}
 }
 

--- a/samples/README.md
+++ b/samples/README.md
@@ -16,7 +16,7 @@ protocol subfolder has a `README.md` that describes:
 
 | Subfolder | Protocol | Status | What captures buy |
 | --- | --- | --- | --- |
-| [`nxdn/`](nxdn/) | NXDN (NXDN-TS-1-A) | ⏳ Real-air capture pending | ≥ 80% CRC-verified CAC bursts + SystemID match + 3 s lock latency |
+| [`nxdn/`](nxdn/) | NXDN (NXDN-TS-1-A) | ⏳ Real-air capture pending (harness ready: [`integration_cc_nxdn_realair_test.go`](../cmd/gophertrunk/integration_cc_nxdn_realair_test.go)) | ≥ 80% CRC-verified CAC bursts + SystemID match + 3 s lock latency |
 | [`ysf/`](ysf/) | Yaesu System Fusion | ⏳ Real-air capture pending | Validates MMDVMHost schedule choice for `EncodeFICHOnAir` / `DecodeFICHOnAir`; swap to DSDcc alternate if CRC fails |
 | [`tetra/`](tetra/) | ETSI TETRA | ⏳ Real-air capture pending | 5 s lock latency + ≥ 90% frame recovery + Viterbi correction-depth histogram |
 | [`dmr-tier2/`](dmr-tier2/) | DMR Tier II (conventional) | ✅ Pipeline closed (PR-C); captures optional | Burst-error structure validation + per-call payload diversity |

--- a/samples/nxdn/README.md
+++ b/samples/nxdn/README.md
@@ -25,6 +25,8 @@ least:
 {
   "source": "MMDVMHost log @ <site>",
   "tool_cross_check": "DSDcc 1.9.5",
+  "sample_rate_hz": 48000,
+  "center_freq_hz": 851062500,
   "expected": {
     "system_id": "0x1234",
     "site_id": "0x01",
@@ -38,14 +40,38 @@ least:
 }
 ```
 
-The decoder test will:
+`sample_rate_hz` and `center_freq_hz` are required at the top
+level — the GNU Radio cfile format doesn't embed either, so the
+test harness needs them stated explicitly to tune the mock SDR and
+configure the per-system control channel. Operators copy
+`expected.system_id` / `expected.site_id` as hex strings (with or
+without the `0x` prefix) since that's how they appear in
+MMDVMHost / DSDcc logs.
 
-1. Stream the IQ through `newNXDNPipeline` (factory in
-   `internal/scanner/ccdecoder/pipelines.go`).
-2. Subscribe to the bus, collect `events.KindCCLocked` + `Grant`
-   events.
-3. Assert the decoded system ID / RAN / message sequence matches
-   `metadata.expected`.
+The decoder test
+[`cmd/gophertrunk/integration_cc_nxdn_realair_test.go`](../../cmd/gophertrunk/integration_cc_nxdn_realair_test.go)
+runs automatically under `go test -tags integration ./...` when a
+single `*.cfile` + sibling `*.metadata.json` pair is present in
+this directory. It:
+
+1. Registers the in-tree `sdr.MockFloat32Driver` pointing at the
+   capture, sets `cfg.SDR.SampleRate = metadata.sample_rate_hz`,
+   and configures the system's `control_channels` to
+   `[metadata.center_freq_hz]`.
+2. Streams the IQ through the production `newNXDNPipeline`
+   (factory in `internal/scanner/ccdecoder/pipelines.go`) with
+   `nxdn_viterbi_mode: spec`.
+3. Subscribes to the bus and waits up to 3 s for
+   `events.KindCCLocked`.
+4. Asserts the decoded `LockState.SystemID` /
+   `LockState.SiteID` / `LockState.FrequencyHz` match the
+   `metadata.expected` + `center_freq_hz` values byte-for-byte.
+
+The skeleton skips with a documented `t.Skipf` message when no
+capture is present so CI stays green until the fixture lands.
+Multiple `*.cfile` candidates in the directory surface as an
+explicit test error — exactly one capture pair is the supported
+case.
 
 ## Recommended sources
 


### PR DESCRIPTION
## Summary

Two more no-capture follow-ups bundled per the request to keep CI workflow runtime down.

- **TUI Settings → FEC tab now displays NXDN slicer deviation.** `nxdn_deviation_hz` shipped in #243 but wasn't surfaced from the operator console. The per-system FEC summary now appends `deviation: 1800 Hz` (or the configured override) alongside the existing `viterbi:` mode. Hash gate covers the new field so a config-reloaded override propagates inside one SSE round-trip.
- **`cmd/gophertrunk/integration_cc_nxdn_realair_test.go` — skip-gated real-air NXDN harness.** When a contributor drops a single `*.cfile` + sibling `*.metadata.json` pair into [`samples/nxdn/`](samples/nxdn/), the harness registers the in-tree `sdr.MockFloat32Driver` at the capture, tunes the daemon to `metadata.center_freq_hz` at `metadata.sample_rate_hz`, boots with `nxdn_viterbi_mode: spec`, and asserts `LockState.SystemID` / `SiteID` / `FrequencyHz` match the documented `metadata.expected` values within a 3 s lock-latency budget. Multiple `.cfile` candidates surface as an explicit test error so the contributor knows to disambiguate.
- **Metadata schema extended in `samples/nxdn/README.md`** — `sample_rate_hz` and `center_freq_hz` are now required at the top level since GNU Radio cfiles don't embed either, and the test needs both to tune the mock SDR. `expected.system_id` / `expected.site_id` parse as hex strings since that's how they appear in MMDVMHost / DSDcc logs.
- **README + `samples/README.md`** — point at the new harness from the "Status & known gaps" NXDN bullet and the samples top-level status table so contributors with hardware can find it.

CI stays green via a documented `t.Skipf` fall-through until a capture lands.

## Test plan

- [x] `go build ./...` + `go vet ./...` + `go vet -tags integration ./...`
- [x] `go test ./...` (full suite)
- [x] `go test -tags integration -race -count=1 ./cmd/gophertrunk/` (full integration suite, race detector)
- [x] `TestDaemonCCDecodesNXDNRealAir` skips cleanly with `samples/nxdn/: no *.cfile present` message
- [x] `TestDaemonCCDecodesNXDN` (the existing synthesized sibling) still passes
- [x] `TestSettingsPanel_NXDNShowsDeviationOverride` exercises default / override / fractional cases


---
_Generated by [Claude Code](https://claude.ai/code/session_01CeGGPVXzDfSH3c9VyEpQcY)_