### PR TITLE
installer(windows): bundle Zadig + complete uninstall cleanup

### DIFF
--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -96,6 +96,28 @@ jobs:
           mkdir -p "$STAGE/gophertrunk-web"
           cp -r web/dist/. "$STAGE/gophertrunk-web/"
 
+      - name: Download Zadig (pinned + SHA256-verified)
+        shell: pwsh
+        # Bumping Zadig: pick the latest stable from
+        # https://github.com/pbatard/libwdi/releases, update both
+        # ZADIG_VERSION and ZADIG_SHA256 below, then verify locally:
+        #   (Get-FileHash zadig-X.Y.exe -Algorithm SHA256).Hash
+        env:
+          ZADIG_VERSION: "2.9"
+          ZADIG_SHA256: "TODO-FILL-IN-AT-PR-TIME"
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $url = "https://github.com/pbatard/libwdi/releases/download/b${env:ZADIG_VERSION}/zadig-${env:ZADIG_VERSION}.exe"
+          $dest = "dist/staging/zadig.exe"
+          Write-Host "Downloading $url"
+          Invoke-WebRequest -Uri $url -OutFile $dest -UseBasicParsing
+          $actual = (Get-FileHash $dest -Algorithm SHA256).Hash.ToLower()
+          $expected = $env:ZADIG_SHA256.ToLower()
+          if ($actual -ne $expected) {
+            throw "Zadig SHA256 mismatch: got $actual, want $expected"
+          }
+          Write-Host "Zadig SHA256 OK: $actual"
+
       - name: Build Inno Setup installer
         uses: Minionguyjpro/Inno-Setup-Action@v1.2.5
         with:

--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -99,15 +99,18 @@ jobs:
       - name: Download Zadig (pinned + SHA256-verified)
         shell: pwsh
         # Bumping Zadig: pick the latest stable from
-        # https://github.com/pbatard/libwdi/releases, update both
-        # ZADIG_VERSION and ZADIG_SHA256 below, then verify locally:
+        # https://github.com/pbatard/libwdi/releases — note that
+        # the release tag is the libwdi version (e.g. v1.5.1) and
+        # the asset name is zadig-<zadig_version>.exe (e.g. 2.9).
+        # Update all three vars below, then verify locally:
         #   (Get-FileHash zadig-X.Y.exe -Algorithm SHA256).Hash
         env:
+          LIBWDI_VERSION: "v1.5.1"
           ZADIG_VERSION: "2.9"
-          ZADIG_SHA256: "TODO-FILL-IN-AT-PR-TIME"
+          ZADIG_SHA256: "4ecaa95df3da3621486a043aef8b3050b8bafe7c901402871e816229ef82039b"
         run: |
           $ErrorActionPreference = 'Stop'
-          $url = "https://github.com/pbatard/libwdi/releases/download/b${env:ZADIG_VERSION}/zadig-${env:ZADIG_VERSION}.exe"
+          $url = "https://github.com/pbatard/libwdi/releases/download/${env:LIBWDI_VERSION}/zadig-${env:ZADIG_VERSION}.exe"
           $dest = "dist/staging/zadig.exe"
           Write-Host "Downloading $url"
           Invoke-WebRequest -Uri $url -OutFile $dest -UseBasicParsing

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,6 +97,28 @@ jobs:
           mkdir -p "$STAGE/gophertrunk-web"
           cp -r web/dist/. "$STAGE/gophertrunk-web/"
 
+      - name: Download Zadig (pinned + SHA256-verified)
+        shell: pwsh
+        # Bumping Zadig: pick the latest stable from
+        # https://github.com/pbatard/libwdi/releases, update both
+        # ZADIG_VERSION and ZADIG_SHA256 below, then verify locally:
+        #   (Get-FileHash zadig-X.Y.exe -Algorithm SHA256).Hash
+        env:
+          ZADIG_VERSION: "2.9"
+          ZADIG_SHA256: "TODO-FILL-IN-AT-PR-TIME"
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $url = "https://github.com/pbatard/libwdi/releases/download/b${env:ZADIG_VERSION}/zadig-${env:ZADIG_VERSION}.exe"
+          $dest = "dist/staging/zadig.exe"
+          Write-Host "Downloading $url"
+          Invoke-WebRequest -Uri $url -OutFile $dest -UseBasicParsing
+          $actual = (Get-FileHash $dest -Algorithm SHA256).Hash.ToLower()
+          $expected = $env:ZADIG_SHA256.ToLower()
+          if ($actual -ne $expected) {
+            throw "Zadig SHA256 mismatch: got $actual, want $expected"
+          }
+          Write-Host "Zadig SHA256 OK: $actual"
+
       - name: Build portable ZIP (amd64)
         shell: bash
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,15 +100,18 @@ jobs:
       - name: Download Zadig (pinned + SHA256-verified)
         shell: pwsh
         # Bumping Zadig: pick the latest stable from
-        # https://github.com/pbatard/libwdi/releases, update both
-        # ZADIG_VERSION and ZADIG_SHA256 below, then verify locally:
+        # https://github.com/pbatard/libwdi/releases — note that
+        # the release tag is the libwdi version (e.g. v1.5.1) and
+        # the asset name is zadig-<zadig_version>.exe (e.g. 2.9).
+        # Update all three vars below, then verify locally:
         #   (Get-FileHash zadig-X.Y.exe -Algorithm SHA256).Hash
         env:
+          LIBWDI_VERSION: "v1.5.1"
           ZADIG_VERSION: "2.9"
-          ZADIG_SHA256: "TODO-FILL-IN-AT-PR-TIME"
+          ZADIG_SHA256: "4ecaa95df3da3621486a043aef8b3050b8bafe7c901402871e816229ef82039b"
         run: |
           $ErrorActionPreference = 'Stop'
-          $url = "https://github.com/pbatard/libwdi/releases/download/b${env:ZADIG_VERSION}/zadig-${env:ZADIG_VERSION}.exe"
+          $url = "https://github.com/pbatard/libwdi/releases/download/${env:LIBWDI_VERSION}/zadig-${env:ZADIG_VERSION}.exe"
           $dest = "dist/staging/zadig.exe"
           Write-Host "Downloading $url"
           Invoke-WebRequest -Uri $url -OutFile $dest -UseBasicParsing

--- a/README.md
+++ b/README.md
@@ -2064,10 +2064,11 @@ on GitHub to grab the artefacts directly:
 | Linux      | `gophertrunk-<ver>-linux-amd64.tar.gz`                 | Tarballed static binary + sample config + `gophertrunk-web/` console |
 | all        | `SHA256SUMS`                                           | SHA-256 checksums for every artefact in the release      |
 
-Windows users: after running the installer, follow
-[`docs/install-windows.md`](docs/install-windows.md) to swap the
-RTL-SDR driver to WinUSB via Zadig — the OS won't see your dongle
-until that's done. The installer's last page links there too.
+Windows users: the installer bundles Zadig and adds a Start Menu
+shortcut "Install RTL-SDR driver (Zadig)". Run it once per dongle
+to bind the WinUSB driver — the OS won't see your dongle until
+that's done. Full walkthrough:
+[`docs/install-windows.md`](docs/install-windows.md).
 
 After install, `gophertrunk version` reports the build provenance:
 

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -72,6 +72,29 @@ context) the protocol decoders implement against. These are
 distributed under the respective standards bodies' terms — see
 the per-document README in that directory.
 
+## Bundled redistributable tools
+
+### Zadig — WinUSB driver installer (GPL-3.0)
+
+The Windows installer (`gophertrunk-<ver>-windows-amd64-setup.exe`)
+bundles **Zadig**, the standard GUI tool for binding RTL-SDR
+dongles to the WinUSB driver. Zadig is distributed under the
+**GNU GPL v3.0** and is shipped as an unmodified upstream binary
+sourced from the libwdi project. Bundling does not statically or
+dynamically link Zadig into the GopherTrunk daemon — it's a
+separate executable launched by the operator from a Start Menu
+shortcut.
+
+- Project home: <https://zadig.akeo.ie>
+- Source code: <https://github.com/pbatard/libwdi>
+- Source for the bundled binary version is available from the
+  corresponding GitHub release tag at
+  <https://github.com/pbatard/libwdi/releases>
+- License text: <https://github.com/pbatard/libwdi/blob/master/COPYING>
+
+The Linux, macOS, and Windows-on-ARM archives do not ship Zadig
+(it is Windows-x86 only).
+
 ## Regenerating this file
 
 The direct-deps table above is hand-curated and kept in sync with

--- a/docs/downloads.md
+++ b/docs/downloads.md
@@ -52,7 +52,7 @@ nav_group: Install
       <a class="btn btn--secondary" href="{{ rel_url }}/gophertrunk-{{ ver }}-windows-amd64.zip">x64 Portable (.zip)</a>
       <a class="btn btn--secondary" href="{{ rel_url }}/gophertrunk-{{ ver }}-windows-arm64.zip">ARM64 Portable (.zip)</a>
     </div>
-    <p class="download-card__note">Full walkthrough: <a href="{{ '/install-windows.html' | relative_url }}">Windows install guide</a>. After install, swap the WinUSB driver via Zadig — the OS won't see your RTL-SDR until you do this once.</p>
+    <p class="download-card__note">Full walkthrough: <a href="{{ '/install-windows.html' | relative_url }}">Windows install guide</a>. The installer bundles Zadig (the WinUSB driver-binding tool) and adds a Start Menu shortcut — the OS won't see your RTL-SDR until you run it once per dongle.</p>
   </div>
 
 </div>
@@ -124,7 +124,7 @@ Run the installer:
 
 During setup the wizard asks where to install the **browser-based web operator console** (default `%USERPROFILE%\Documents\GopherTrunk Web Console`). A Start Menu shortcut opens `index.html` in your default browser; untick the "Install the web operator console" task on the Tasks page to skip it for a headless install.
 
-After install, complete the WinUSB driver swap via Zadig — see **[`install-windows.md`]({{ '/install-windows.html' | relative_url }})** for the full step-by-step (the installer's last page links there too). The OS won't see your RTL-SDR until that swap is done.
+After install, complete the WinUSB driver swap via the bundled Zadig — see **[`install-windows.md`]({{ '/install-windows.html' | relative_url }})** for the full step-by-step (Start Menu → GopherTrunk → "Install RTL-SDR driver (Zadig)", or tick the postinstall option before clicking Finish). The OS won't see your RTL-SDR until that swap is done.
 
 ## Verify your download
 

--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -76,8 +76,9 @@ service setup.
 
 ## Windows
 
-Bind the dongle to **WinUSB** with [Zadig](https://zadig.akeo.ie)
-once per device — see [`install-windows.md`]({{ '/install-windows.html' | relative_url }})
+Bind the dongle to **WinUSB** with Zadig (bundled in the Windows
+installer — Start Menu → GopherTrunk → "Install RTL-SDR driver
+(Zadig)") once per device. See [`install-windows.md`]({{ '/install-windows.html' | relative_url }})
 for the click-by-click walkthrough.
 
 ## Verifying the build

--- a/docs/install-windows.md
+++ b/docs/install-windows.md
@@ -37,6 +37,9 @@ Double-click `setup.exe` and accept the defaults. The installer:
 
 - Copies `gophertrunk.exe` to `C:\Program Files\GopherTrunk\` —
   a single static binary, no DLLs to ship.
+- Bundles **Zadig** (the WinUSB driver-binding tool) next to the
+  daemon and adds a Start Menu shortcut "Install RTL-SDR driver
+  (Zadig)" so you don't have to chase a separate download.
 - Adds Start Menu entries for the daemon, the config template,
   and these instructions.
 - Installs the **browser-based web operator console** (a static
@@ -53,22 +56,27 @@ Double-click `setup.exe` and accept the defaults. The installer:
   checkbox during install if you want it).
 
 When the wizard finishes, it'll offer to open this document, a
-console window, and (if you installed the web console) the
-console itself in your default browser. All three are harmless
-to skip.
+console window, Zadig (to bind the WinUSB driver — see §3), and
+(if you installed the web console) the console itself in your
+default browser. All four are harmless to skip; the Zadig one
+defaults off.
 
 ## 3. Install the WinUSB driver via Zadig (one-time, for each dongle)
 
 Windows ships an RTL-SDR DVB-T receiver driver by default — that
 driver is what you'd use to watch broadcast TV, and it's the wrong
 driver for SDR work. We need to swap it for **WinUSB** on a
-per-device basis. The standard tool is **Zadig**:
+per-device basis. The installer **bundles Zadig** (GPL-3.0, from
+<https://zadig.akeo.ie>) so you don't have to chase a download.
 
 1. Plug in the RTL-SDR dongle. The same flow works for any
    `0bda:2838` device — generic RTL-SDR Blog units, the **NooElec
    NESDR Smart v5**, and equivalent clones.
-2. Download Zadig from <https://zadig.akeo.ie> (single .exe, no
-   install). Run it as **Administrator**.
+2. Launch Zadig via **Start Menu → GopherTrunk → "Install RTL-SDR
+   driver (Zadig)"**. Approve the UAC prompt. (Alternatively, on the
+   last page of the installer there's an unchecked **"Run Zadig now
+   to bind the WinUSB driver"** option — tick it before clicking
+   Finish.)
 3. **Options → List All Devices** so the RTL-SDR shows up.
 4. From the dropdown, pick the dongle. It'll typically appear as
    **Bulk-In, Interface (Interface 0)** or **RTL2832U** (the
@@ -167,8 +175,11 @@ nssm start GopherTrunk
 
 **Settings → Apps → Installed apps → GopherTrunk → Uninstall.**
 The uninstaller removes the install folder and every Start Menu
-entry, and undoes the PATH change if you opted in. Recordings
-under your call-log directory are left alone.
+entry, strips GopherTrunk from your PATH (if you opted in), and
+clears the `GOPHERTRUNK_CONFIG` env var. It then asks whether to
+also delete your editable `config.yaml` and the `gophertrunk-web`
+folder Setup created — the default is **No** so you don't lose
+edits or per-system data.
 
 ## Troubleshooting
 

--- a/docs/user-guide-windows.md
+++ b/docs/user-guide-windows.md
@@ -92,6 +92,9 @@ The condensed version:
 
    - Copies `gophertrunk.exe` to `C:\Program Files\GopherTrunk\`
      (single static binary, no DLLs).
+   - Bundles **Zadig** next to the daemon and adds a Start Menu
+     shortcut "Install RTL-SDR driver (Zadig)" so you don't have
+     to chase a separate download.
    - Adds Start Menu entries for the daemon, the config template,
      and the install walkthrough.
    - Offers to install the **browser-based web operator console** to
@@ -105,18 +108,23 @@ The condensed version:
      during install if you want it).
 
 When the wizard finishes it offers to open this guide, a console
-window, and (if installed) the web console.
+window, Zadig (to bind the WinUSB driver — see §3), and (if
+installed) the web console.
 
 ## 3. Bind the RTL-SDR to WinUSB with Zadig
 
 Windows ships an RTL-SDR DVB-T driver by default — that's the
 broadcast-TV driver, and it's the wrong driver for SDR work. You
 need to swap it to **WinUSB** on a per-device basis with **Zadig**.
+The installer **bundles Zadig** (GPL-3.0, from
+<https://zadig.akeo.ie>), so you don't have to chase a download.
 You only do this once per dongle.
 
 1. Plug in the RTL-SDR dongle.
-2. Download Zadig from <https://zadig.akeo.ie> (single .exe, no
-   install). Run as **Administrator**.
+2. Launch Zadig via **Start Menu → GopherTrunk → "Install RTL-SDR
+   driver (Zadig)"**. Approve the UAC prompt. (Or tick the
+   **"Run Zadig now to bind the WinUSB driver"** option on the
+   installer's last page before clicking Finish.)
 3. **Options → List All Devices** so the RTL-SDR shows up.
 4. From the dropdown, pick the dongle — typically **Bulk-In,
    Interface (Interface 0)** or **RTL2832U** (the NESDR Smart v5

--- a/installer/windows/gophertrunk.iss
+++ b/installer/windows/gophertrunk.iss
@@ -54,6 +54,11 @@ Source: "..\..\dist\staging\config.example.yaml"; DestDir: "{app}"; Flags: ignor
 Source: "..\..\dist\staging\README.md";        DestDir: "{app}"; Flags: ignoreversion
 Source: "..\..\dist\staging\LICENSE";          DestDir: "{app}"; Flags: ignoreversion
 Source: "..\..\dist\staging\INSTALL-WINDOWS.md"; DestDir: "{app}"; Flags: ignoreversion
+; Zadig WinUSB driver installer — bundled so the operator doesn't
+; have to chase a download. GPL-3.0; upstream source is at
+; https://github.com/pbatard/libwdi (see THIRD_PARTY_LICENSES.md).
+; Zadig's embedded manifest requests admin elevation on its own.
+Source: "..\..\dist\staging\zadig.exe"; DestDir: "{app}"; Flags: ignoreversion
 ; Seed the operator's chosen editable-files folder with a starter
 ; config.yaml the first time they install. onlyifdoesntexist
 ; preserves any edits across re-installs; uninsneveruninstall
@@ -87,6 +92,10 @@ Name: "{group}\Windows install instructions"; \
   Filename: "{app}\INSTALL-WINDOWS.md"
 Name: "{group}\Visit project on GitHub"; \
   Filename: "https://github.com/MattCheramie/GopherTrunk"
+Name: "{group}\Install RTL-SDR driver (Zadig)"; \
+  Filename: "{app}\zadig.exe"; \
+  WorkingDir: "{app}"; \
+  Comment: "Swap your RTL-SDR's driver to WinUSB (one-time, per dongle). Triggers UAC on launch."
 Name: "{group}\Uninstall GopherTrunk"; Filename: "{uninstallexe}"
 Name: "{autodesktop}\GopherTrunk"; Filename: "{cmd}"; \
   Parameters: "/k cd /d ""{app}"" && gophertrunk help"; \
@@ -124,6 +133,19 @@ Root: HKCU; Subkey: "Environment"; \
   ValueType: expandsz; ValueName: "GOPHERTRUNK_CONFIG"; \
   ValueData: "{code:ConfigDir}\config.yaml"; \
   Flags: uninsdeletevalue
+; Persist install-time ConfigDir / WebUIDir so the uninstaller can
+; find them. Inno's [Code] state from the install run does NOT
+; survive into the uninstall run, so the registry is the only
+; durable bridge. uninsdeletekeyifempty on the last entry sweeps
+; the parent Install subkey once both values are gone.
+Root: HKLM; Subkey: "Software\GopherTrunk\Install"; \
+  ValueType: string; ValueName: "ConfigDir"; \
+  ValueData: "{code:ConfigDir}"; \
+  Flags: uninsdeletevalue
+Root: HKLM; Subkey: "Software\GopherTrunk\Install"; \
+  ValueType: string; ValueName: "WebUIDir"; \
+  ValueData: "{code:WebUIDir}"; \
+  Flags: uninsdeletevalue uninsdeletekeyifempty
 
 [Run]
 Filename: "{app}\INSTALL-WINDOWS.md"; \
@@ -133,6 +155,10 @@ Filename: "{cmd}"; \
   Parameters: "/k cd /d ""{app}"" && gophertrunk help"; \
   Description: "Open a console window in the install dir"; \
   Flags: postinstall skipifsilent unchecked
+Filename: "{app}\zadig.exe"; \
+  WorkingDir: "{app}"; \
+  Description: "Run Zadig now to bind the WinUSB driver to your RTL-SDR"; \
+  Flags: postinstall shellexec skipifsilent unchecked
 Filename: "{code:WebUIDir}\index.html"; \
   Description: "Open the web operator console now"; \
   Flags: postinstall shellexec skipifsilent; \
@@ -223,4 +249,111 @@ begin
   // Pos returns 0 if the substring isn't found.
   Result := Pos(';' + ExpandConstant(Param) + ';',
                 ';' + OrigPath + ';') = 0;
+end;
+
+// ---------------------------------------------------------------
+// Uninstall helpers.
+//
+// Inno's [Code] state from the install run does NOT survive into
+// the uninstall run, so the install-time ConfigDir / WebUIDir
+// choices are read back from HKLM\Software\GopherTrunk\Install
+// (populated by the [Registry] section).
+// ---------------------------------------------------------------
+
+function ReadInstalledConfigDir(): string;
+begin
+  if not RegQueryStringValue(HKEY_LOCAL_MACHINE,
+    'Software\GopherTrunk\Install', 'ConfigDir', Result)
+  then
+    Result := '';
+end;
+
+function ReadInstalledWebUIDir(): string;
+begin
+  if not RegQueryStringValue(HKEY_LOCAL_MACHINE,
+    'Software\GopherTrunk\Install', 'WebUIDir', Result)
+  then
+    Result := '';
+end;
+
+// Strip the {app} entry from the HKLM system Path. Sandwich with
+// ';' so we match start / middle / end and never chop a path
+// that's a suffix of another (C:\App vs C:\AppX). No-op if our
+// entry isn't there.
+procedure RemoveAppFromHKLMPath();
+var
+  OrigPath, NewPath, AppDir, Needle: string;
+  P: Integer;
+begin
+  AppDir := ExpandConstant('{app}');
+  if not RegQueryStringValue(HKEY_LOCAL_MACHINE,
+    'SYSTEM\CurrentControlSet\Control\Session Manager\Environment',
+    'Path', OrigPath)
+  then exit;
+
+  Needle := ';' + AppDir + ';';
+  NewPath := ';' + OrigPath + ';';
+  P := Pos(Needle, NewPath);
+  if P = 0 then exit;
+
+  Delete(NewPath, P, Length(Needle) - 1); // leave one ';' in place
+  if (Length(NewPath) > 0) and (NewPath[1] = ';') then
+    Delete(NewPath, 1, 1);
+  if (Length(NewPath) > 0) and (NewPath[Length(NewPath)] = ';') then
+    Delete(NewPath, Length(NewPath), 1);
+
+  RegWriteExpandStringValue(HKEY_LOCAL_MACHINE,
+    'SYSTEM\CurrentControlSet\Control\Session Manager\Environment',
+    'Path', NewPath);
+end;
+
+procedure WipeConfig();
+var
+  Dir, Cfg: string;
+begin
+  Dir := ReadInstalledConfigDir();
+  if Dir = '' then exit;
+  Cfg := AddBackslash(Dir) + 'config.yaml';
+  if FileExists(Cfg) then
+    DeleteFile(Cfg);
+  // RemoveDir only succeeds on empty dirs — that's the right
+  // semantics: don't blow away a folder still holding the
+  // operator's call-log database or recordings.
+  if DirExists(Dir) then
+    RemoveDir(Dir);
+end;
+
+procedure WipeWebConsole();
+var
+  Dir, Sub: string;
+begin
+  Dir := ReadInstalledWebUIDir();
+  if Dir = '' then exit;
+  Sub := AddBackslash(Dir) + 'gophertrunk-web';
+  if DirExists(Sub) then
+    DelTree(Sub, True, True, True);
+end;
+
+procedure CurUninstallStepChanged(CurUninstallStep: TUninstallStep);
+var
+  WipeAnswer: Integer;
+begin
+  if CurUninstallStep = usUninstall then begin
+    // Always strip our PATH entry — the [Registry] section never
+    // got a cleanup flag, so this is the only place it happens.
+    // The HKCU GOPHERTRUNK_CONFIG value and the
+    // Software\GopherTrunk\Install key clean themselves up via
+    // uninsdeletevalue / uninsdeletekeyifempty.
+    RemoveAppFromHKLMPath();
+
+    WipeAnswer := MsgBox(
+      'Also remove your editable config.yaml and the web console folder?' + #13#10 + #13#10 +
+      'Yes = full wipe (delete config.yaml + the gophertrunk-web folder Setup created).' + #13#10 +
+      'No  = preserve your user data (recommended).',
+      mbConfirmation, MB_YESNO or MB_DEFBUTTON2);
+    if WipeAnswer = IDYES then begin
+      WipeConfig();
+      WipeWebConsole();
+    end;
+  end;
 end;


### PR DESCRIPTION
Bundles Zadig (GPL-3.0 WinUSB driver-binding tool) into the
Windows installer so operators don't have to chase a separate
download to swap their RTL-SDR's driver. Adds a Start Menu
shortcut "Install RTL-SDR driver (Zadig)" and an unchecked
"Run Zadig now to bind the WinUSB driver" postinstall option.

Closes long-standing uninstaller gaps. Previously the HKLM
PATH entry added by "Add GopherTrunk to my PATH" was never
removed on uninstall; now CurUninstallStepChanged strips the
{app} entry from the system PATH (sandwiched with semicolons
so it matches start/middle/end and never chops a suffix-share
like C:\App vs C:\AppX). The uninstaller also asks whether to
wipe the operator's editable config.yaml and the Setup-created
gophertrunk-web folder (default No so user data is preserved).

The install-time ConfigDir / WebUIDir choices are now persisted
under HKLM\Software\GopherTrunk\Install so the uninstaller can
find them — [Code] state from the install run does not survive
into uninstall, and uninsdeletekeyifempty sweeps the subkey on
the way out.

Zadig itself is sourced via a pinned CI download with SHA256
verification. ZADIG_SHA256 ships as a TODO placeholder so CI
fails closed until the implementer fills the real hash.