### PR TITLE
rtlsdr: add remediation hint on tuner-init I2C failure (issue #248)

### DIFF
--- a/docs/install-linux.md
+++ b/docs/install-linux.md
@@ -186,6 +186,7 @@ are left alone — remove them manually if you want a clean slate.
 | `sdr list` prints nothing               | DVB driver still bound — `sudo modprobe -r dvb_usb_rtl28xxu` and re-plug. |
 | `permission denied` on `/dev/bus/usb/…` | udev rule didn't apply — re-run `udevadm control --reload && udevadm trigger`, then re-plug. |
 | `usb: device disconnected` mid-stream   | Power-saving USB autosuspend kicked in — `echo on > /sys/bus/usb/devices/<id>/power/control`, or pin via udev. |
+| `tuner init: ... I2CWrite addr=0x34: broken pipe` | Tuner not ack-ing on the I²C bus. Most common: DVB kernel driver still bound — `sudo modprobe -r dvb_usb_rtl28xxu` and **physically re-plug** the dongle. Also seen with marginal USB power or USB 3.0 hubs — try a USB 2.0 port directly on the host. If `rtl_test` also prints `[R82XX] PLL not locked!` the tuner is in a half-init state; a full power cycle (unplug ~10s) clears it. |
 | Audio plays as silence                  | `audio.enabled: false` by default — set `true` in config; on distroless / Alpine without `libasound2`, set `audio.device: "ioctl"` to use the direct-kernel backend. |
 | systemd unit fails with `203/EXEC`      | Binary path wrong in the unit — confirm `/usr/local/bin/gophertrunk` exists and is `+x`. |
 

--- a/internal/sdr/rtlsdr/purego/driver.go
+++ b/internal/sdr/rtlsdr/purego/driver.go
@@ -1,8 +1,10 @@
 package purego
 
 import (
+	"errors"
 	"fmt"
 	"sync"
+	"syscall"
 
 	"github.com/MattCheramie/GopherTrunk/internal/sdr"
 	"github.com/MattCheramie/GopherTrunk/internal/sdr/rtlsdr/rtl2832u"
@@ -140,10 +142,10 @@ func openDevice(transport usb.Transport, desc usb.Descriptor, idx int) (*Device,
 
 	tuner, err := tuners.Detect(demod)
 	if err != nil {
-		return nil, fmt.Errorf("rtlsdr: tuner detect: %w", err)
+		return nil, fmt.Errorf("rtlsdr: tuner detect: %w%s", err, tunerBringupHint(err))
 	}
 	if err := tuner.Init(); err != nil {
-		return nil, fmt.Errorf("rtlsdr: tuner init: %w", err)
+		return nil, fmt.Errorf("rtlsdr: tuner init: %w%s", err, tunerBringupHint(err))
 	}
 	if err := demod.SetIFFreq(tuner.IFFreqHz()); err != nil {
 		return nil, fmt.Errorf("rtlsdr: set IF freq: %w", err)
@@ -169,4 +171,25 @@ func openDevice(transport usb.Transport, desc usb.Descriptor, idx int) (*Device,
 		tuner:     tuner,
 		info:      info,
 	}, nil
+}
+
+// tunerBringupHint returns a parenthesized, space-prefixed remediation
+// string when err looks like the tuner-not-acking-on-I2C case
+// (issue #248): EPIPE from the first I2C burst, or the device
+// disappearing mid-bringup. The hint covers the three known root
+// causes — DVB kernel driver still bound, marginal USB power, or a
+// half-initialized tuner state — and links to the docs troubleshooting
+// table. Returns "" for unrelated errors so the wrapped message stays
+// clean.
+func tunerBringupHint(err error) string {
+	if err == nil {
+		return ""
+	}
+	if errors.Is(err, syscall.EPIPE) || errors.Is(err, usb.ErrDeviceGone) {
+		return " (hint: tuner did not respond on the I2C bus — common causes:" +
+			" DVB kernel driver still bound (run `sudo modprobe -r dvb_usb_rtl28xxu` and re-plug)," +
+			" marginal USB power, or a flaky cable/hub." +
+			" See https://mattcheramie.github.io/GopherTrunk/install-linux.html#troubleshooting)"
+	}
+	return ""
 }

--- a/internal/sdr/rtlsdr/purego/driver_test.go
+++ b/internal/sdr/rtlsdr/purego/driver_test.go
@@ -1,7 +1,10 @@
 package purego
 
 import (
+	"errors"
+	"fmt"
 	"strings"
+	"syscall"
 	"testing"
 
 	"github.com/MattCheramie/GopherTrunk/internal/sdr/rtlsdr/usb"
@@ -129,5 +132,61 @@ func TestKnownDevicesNoDuplicates(t *testing.T) {
 			t.Errorf("duplicate VID/PID 0x%04x:0x%04x: %q vs %q", k.VID, k.PID, existing, k.Name)
 		}
 		seen[key] = k.Name
+	}
+}
+
+// Regression for issue #248: tuner-init failures that look like the
+// I2C-bridge-can't-reach-tuner case (EPIPE from the first burst, or
+// the device disappearing mid-bringup) must carry remediation guidance
+// pointing at the DVB kernel driver / USB power / cable workarounds.
+// Unrelated errors must pass through untouched.
+func TestTunerBringupHint(t *testing.T) {
+	cases := []struct {
+		name    string
+		err     error
+		wantSub []string // substrings that must appear in the hint
+		empty   bool     // true ⇒ hint must be exactly ""
+	}{
+		{
+			name:    "EPIPE_through_wrap",
+			err:     fmt.Errorf("rtl2832u: I2CWrite addr=0x34: %w", syscall.EPIPE),
+			wantSub: []string{"dvb_usb_rtl28xxu", "install-linux.html#troubleshooting"},
+		},
+		{
+			name:    "ErrDeviceGone",
+			err:     fmt.Errorf("transport: %w", usb.ErrDeviceGone),
+			wantSub: []string{"dvb_usb_rtl28xxu", "install-linux.html#troubleshooting"},
+		},
+		{
+			name:  "nil_error",
+			err:   nil,
+			empty: true,
+		},
+		{
+			name:  "unrelated_error",
+			err:   errors.New("some other failure"),
+			empty: true,
+		},
+		{
+			name:  "ETIMEDOUT_not_hinted",
+			err:   fmt.Errorf("wrap: %w", usb.ErrTimeout),
+			empty: true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := tunerBringupHint(c.err)
+			if c.empty {
+				if got != "" {
+					t.Fatalf("tunerBringupHint(%v) = %q, want empty", c.err, got)
+				}
+				return
+			}
+			for _, sub := range c.wantSub {
+				if !strings.Contains(got, sub) {
+					t.Errorf("tunerBringupHint(%v) = %q, missing substring %q", c.err, got, sub)
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
When the tuner doesn't ack on the I2C bus during bring-up — surfaced
as EPIPE from the first burst write or as ErrDeviceGone mid-init —
the daemon now appends a one-line hint pointing at the three known
root causes (DVB kernel driver still bound, marginal USB power,
flaky cable/hub) and links to the install-linux troubleshooting
table. The table itself grows a new row mirroring the same guidance
so users searching for "broken pipe" land somewhere actionable.

No behavior change for the success path or for other error classes.