### PR TITLE
release: v0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,21 @@ for tagged releases.
 
 ## [Unreleased]
 
+## [v0.1.5] — 2026-05-16
+
 ### Added
 
+- **Remediation hint on tuner-init I²C failures.** The RTL-SDR
+  driver now appends a one-line hint pointing at the three known
+  root causes (DVB kernel driver still bound, marginal USB power,
+  flaky cable / USB 3.0 hub) when the tuner doesn't ack on the I²C
+  bus during bring-up — both the EPIPE-on-first-burst case and the
+  mid-init `ErrDeviceGone` case. `docs/install-linux.md`'s
+  troubleshooting table grows a matching row keyed on the literal
+  error string so operators searching for "broken pipe" land
+  somewhere actionable.
+  Shipped in [PR #251](https://github.com/MattCheramie/GopherTrunk/pull/251),
+  addressing [issue #248](https://github.com/MattCheramie/GopherTrunk/issues/248).
 - **Bundled Zadig WinUSB driver installer in the Windows installer.**
   The Windows `setup.exe` now ships `zadig.exe` alongside
   `gophertrunk.exe`, so first-run operators no longer have to chase a


### PR DESCRIPTION
Promotes `CHANGELOG.md` `[Unreleased]` to `[v0.1.5] — 2026-05-16`. Once this merges, the `v0.1.5` tag pushes from the resulting `main` commit and `.github/workflows/release.yml` builds the Windows installer (Zadig-bundled), portable zips, and Linux/macOS tarballs, attaches them to a fresh GitHub Release with notes from the new CHANGELOG section.

## Pre-release checklist (all green locally on `dc3a8e2`)

- [x] `gofmt -l .` empty (CI gates this since this release)
- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [x] `go test -short -count=1 ./...` green
- [x] `make release-dry-run VERSION=v0.1.5` builds a binary that reports `v0.1.5 (sha=dc3a8e2, …)`
- [x] CHANGELOG covers everything since v0.1.4 (incl. PR #249 Zadig bundling, PR #251 rtlsdr remediation hint, and the earlier launcher / web import / settings-edit / NXDN / AMBE+2 / polish work)
- [x] No release-blocking open issues on reference hardware — #248 addressed by PR #251

## What ships in v0.1.5

The high points (full detail in `CHANGELOG.md`):

- **Windows installer bundles Zadig** + the uninstaller strips PATH and prompts before wiping user data (PR #249).
- **Interactive daemon launcher** with TUI / web / headless prompts, SIGHUP reload, single-instance flock.
- **Live config editing**: `PATCH /api/v1/settings`, inline-editable Settings panel in the web SPA.
- **Live talkgroup import**: `POST /api/v1/import` (multipart) with commit/discard staging.
- **NXDN deviation tunability** + real-air integration harness skeleton.
- **AMBE+2 knox preset bundles** (`ambe2.RegisterPreset` / `ambe2.ListPresets`).
- **Remediation hint** on tuner-init I²C failures + `docs/install-linux.md` troubleshooting row (PR #251, addressing #248).
- **Maintainer**: `docs/release.md` release walkthrough, gofmt CI gate, full-tree gofmt pass (PR #250).

## Post-merge

1. Tag `v0.1.5` from the resulting `main` commit (annotated).
2. Push the tag to fire `release.yml`.
3. Smoke-test the published `gophertrunk-v0.1.5-windows-amd64-setup.exe` per `docs/release.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M8Fv44UfmtkGL39bnSBnPc)_