### PR TITLE
docs: bump README + downloads fallback to v0.1.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ GopherTrunk is a software-defined-radio scanner that follows digital trunked-rad
 
 ```sh
 # Linux x86_64 — see https://gophertrunk.org/downloads.html for macOS, Windows, ARM64
-VERSION=v0.1.0
+VERSION=v0.1.5
 curl -L -o gophertrunk.tar.gz \
   https://github.com/MattCheramie/GopherTrunk/releases/download/${VERSION}/gophertrunk-${VERSION}-linux-amd64.tar.gz
 tar xzf gophertrunk.tar.gz && cd gophertrunk-${VERSION}-linux-amd64

--- a/docs/downloads.md
+++ b/docs/downloads.md
@@ -9,7 +9,7 @@ nav_group: Install
 {%- if latest and latest.tag_name -%}
   {%- assign ver = latest.tag_name -%}
 {%- else -%}
-  {%- assign ver = "v0.1.0" -%}
+  {%- assign ver = "v0.1.5" -%}
 {%- endif -%}
 {%- assign rel_url = "https://github.com/MattCheramie/GopherTrunk/releases/download/" | append: ver -%}
 


### PR DESCRIPTION
Post-release docs sync per `docs/release.md`:

- `README.md:35` Quick Start snippet: `VERSION=v0.1.0` → `VERSION=v0.1.5`
- `docs/downloads.md:12` Liquid fallback when `site.github.latest_release` is unavailable: `"v0.1.0"` → `"v0.1.5"`

The downloads page normally resolves `ver` from `site.github.latest_release.tag_name` at Pages build time, so the fallback only matters when the GitHub API call fails during the build — but keeping it on a recent tag means failed builds still ship usable links.

## Heads up — release-side work I cannot do from this session

The GitHub release published as **`V0.1.5` (uppercase V)** is malformed:

| Symptom | Expected | Actual |
| --- | --- | --- |
| Tag | `v0.1.5` (matches v0.1.0–v0.1.4 cadence) | **`V0.1.5`** |
| Title | `GopherTrunk v0.1.5` (set by release.yml:339) | `Patch Release ` (trailing space, hand-typed) |
| Author | `github-actions[bot]` | `MattCheramie` (manual UI) |
| Body | Rich install instructions from release.yml:343-353 | GitHub's auto-generated PR list |
| Prerelease | `true` (v0.x.y rule, release.yml:332) | `false` |

That fingerprint says the release was created manually through the UI — `release.yml` did not run to completion. The downstream impact is that `docs/downloads.md`'s rendered buttons would point at `gophertrunk-V0.1.5-…` filenames that probably don't exist on the release.

**This PR uses lowercase `v0.1.5` because that's the right target.** If you're going to delete and re-cut the release with the correct lowercase tag (recommended — see [recent thread]), merge this PR after the new tag publishes so the rendered Pages site matches the tag string. If you decide to keep `V0.1.5` uppercase and live with it, this PR's `v0.1.5` strings won't line up — close it and I'll redo with uppercase.

## What needs you specifically

To complete the fix:

1. **GitHub UI → Releases → `V0.1.5` → Delete release.**
2. **GitHub UI → Tags → `V0.1.5` → Delete** (or `git push --delete origin V0.1.5`).
3. **From your local machine:**
   ```sh
   git fetch origin
   git tag -a v0.1.5 9af92cf -m "v0.1.5"
   git push origin v0.1.5
   ```
4. Watch Actions; in ~5 min `release.yml` publishes a real `v0.1.5` release with the full artifact set.
5. Merge this PR. Push triggers `pages.yml`, which rebuilds gophertrunk.org with the correct version everywhere.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M8Fv44UfmtkGL39bnSBnPc)_