### PR TITLE
docs(downloads): pick latest prerelease when no stable exists

### DIFF
--- a/docs/downloads.md
+++ b/docs/downloads.md
@@ -5,9 +5,28 @@ description: Install GopherTrunk on Linux, macOS, or Windows
 nav_group: Install
 ---
 
-{%- assign latest = site.github.latest_release -%}
-{%- if latest and latest.tag_name -%}
-  {%- assign ver = latest.tag_name -%}
+{%- comment -%}
+Resolve the version string the download cards should point at.
+Three-tier resolution so the page stays useful no matter what the
+release state looks like:
+
+  1. site.github.latest_release — GitHub's "latest stable" endpoint.
+     Excludes prereleases, so this returns null while every release
+     is a v0.x.y (which release.yml flags prerelease per SemVer §4).
+     Once v1.0.0+ ships stable, this is the right answer.
+  2. site.github.releases[0] — the most recent release of any kind,
+     prereleases included. Drives the page through the pre-1.0
+     window.
+  3. Hardcoded tag — last-ditch fallback if the GitHub metadata
+     API call fails during the Pages build (rare). Bump on each
+     release as a defensive matter, but it should never be the
+     value users actually see.
+{%- endcomment -%}
+{%- assign ver = nil -%}
+{%- if site.github.latest_release and site.github.latest_release.tag_name -%}
+  {%- assign ver = site.github.latest_release.tag_name -%}
+{%- elsif site.github.releases and site.github.releases[0] and site.github.releases[0].tag_name -%}
+  {%- assign ver = site.github.releases[0].tag_name -%}
 {%- else -%}
   {%- assign ver = "v0.1.5" -%}
 {%- endif -%}


### PR DESCRIPTION
## What

Resolves the download-card version in `docs/downloads.md` from a three-tier source instead of `site.github.latest_release` only:

1. `site.github.latest_release` — stable; right answer once v1.0.0 ships.
2. `site.github.releases[0]` — newest release of any kind; handles the pre-1.0 prerelease window we're currently in.
3. Hardcoded `"v0.1.5"` — defensive fallback for the rare API-failure build.

## Why

`release.yml:332` flags every v0.x.y tag as prerelease per SemVer §4 ("major version zero is for initial development"). GitHub's "latest stable" endpoint (`site.github.latest_release`) excludes prereleases — so through the entire pre-1.0 window it returns null and **the hardcoded `"v0.1.5"` fallback is what drives the page**. We just bumped it manually in PR #253; without this PR it'd need bumping on every release.

Cross-checked from outside the sandbox:

```
$ curl -s https://api.github.com/repos/MattCheramie/GopherTrunk/releases/latest
{"message":"Not Found", ...}   ← no stable, all are prereleases
```

After this PR, `site.github.releases[0]` resolves to the most-recent prerelease (currently v0.1.5), the fallback stops being load-bearing, and there's nothing version-coupled to remember on future releases.

## Risk

Zero behavior change once v1.0.0+ stable ships — `latest_release` populates and tier 1 wins; tiers 2 and 3 never fire. Until then the page picks up new prereleases the moment Pages rebuilds, with no manual bump.

## Test

After merge, `pages.yml` runs against the new template. The rendered downloads page should pin `ver = v0.1.5` from `site.github.releases[0]` — same as today, but no longer from the hardcoded line. The next release will validate the auto-pickup by changing the resolved version without any docs edit.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M8Fv44UfmtkGL39bnSBnPc)_