### PR TITLE
rtlsdr: librtlsdr-parity warmup + reset on Open (issue #248)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ for tagged releases.
 
 ## [Unreleased]
 
+### Fixed
+
+- **RTL-SDR tuner init no longer fails on dongles left in a
+  half-initialised USB state.** Open now performs librtlsdr's
+  dummy-write probe (`USB_SYSCTL = 0x09`) immediately after claiming
+  the interface and, on `EPIPE` / `ErrDeviceGone`, runs a one-shot
+  `USBDEVFS_RESET` + re-claim before retrying. Dongles whose endpoint
+  was left stalled by a crashed prior session or a freshly-unbound
+  DVB kernel driver now open transparently instead of surfacing the
+  EPIPE as "r82xx init: burst write: I2CWrite addr=0x34: broken pipe".
+  When both attempts fail the existing tuner-bringup hint is still
+  appended.
+  Addresses [issue #248](https://github.com/MattCheramie/GopherTrunk/issues/248).
+
 ## [v0.1.5] — 2026-05-16
 
 ### Added

--- a/internal/sdr/rtlsdr/purego/driver.go
+++ b/internal/sdr/rtlsdr/purego/driver.go
@@ -96,12 +96,14 @@ func (d *Driver) Enumerate() ([]sdr.Info, error) {
 // Steps:
 //  1. Open the USB transport via the enumerator.
 //  2. Claim USB interface 0 (RTL-SDR's only interface).
-//  3. Wrap the transport in [rtl2832u.Demod] and run the baseband
-//     init flood.
-//  4. Probe for an R820T-family tuner; set up the [tuners.Tuner]
+//  3. Wrap the transport in [rtl2832u.Demod] and run a single
+//     librtlsdr-parity USB-sysctl warmup write; if it returns EPIPE,
+//     reset the device and retry once (fixes issue #248).
+//  4. Run the baseband init flood.
+//  5. Probe for an R820T-family tuner; set up the [tuners.Tuner]
 //     and run its init.
-//  5. Program the tuner's IF frequency on the demod.
-//  6. Populate [sdr.Info] with the tuner's name and gain ladder.
+//  6. Program the tuner's IF frequency on the demod.
+//  7. Populate [sdr.Info] with the tuner's name and gain ladder.
 //
 // Failure at any step closes the transport and returns the error.
 func (d *Driver) Open(idx int) (sdr.Device, error) {
@@ -126,16 +128,19 @@ func (d *Driver) Open(idx int) (sdr.Device, error) {
 	return dev, nil
 }
 
-// openDevice runs the full bring-up sequence: claim interface, init
-// demod, detect + init tuner, set IF freq. Factored out of Open so
-// tests can drive it directly with a mock transport without going
-// through the enumerator.
+// openDevice runs the full bring-up sequence: claim interface, warm up
+// the USB endpoint, init demod, detect + init tuner, set IF freq.
+// Factored out of Open so tests can drive it directly with a mock
+// transport without going through the enumerator.
 func openDevice(transport usb.Transport, desc usb.Descriptor, idx int) (*Device, error) {
 	if err := transport.ClaimInterface(0); err != nil {
 		return nil, fmt.Errorf("rtlsdr: claim interface 0: %w", err)
 	}
 
 	demod := rtl2832u.New(transport)
+	if err := warmupWithReset(transport, demod); err != nil {
+		return nil, err
+	}
 	if err := demod.InitBaseband(); err != nil {
 		return nil, fmt.Errorf("rtlsdr: init baseband: %w", err)
 	}
@@ -171,6 +176,46 @@ func openDevice(transport usb.Transport, desc usb.Descriptor, idx int) (*Device,
 		tuner:     tuner,
 		info:      info,
 	}, nil
+}
+
+// warmupWithReset mirrors librtlsdr's rtlsdr_open dummy-write probe: it
+// issues one USB-sysctl write to confirm the endpoint is healthy, and
+// on EPIPE / ErrDeviceGone it resets the device and retries once before
+// giving up. Dongles left half-initialised by a crashed previous
+// session (or by a DVB kernel driver that was unbound mid-flight) tend
+// to ack control reads fine but stall the first multi-byte OUT — which
+// in the pre-fix code path showed up as "r82xx init: burst write:
+// I2CWrite addr=0x34: broken pipe" (issue #248). Running the probe
+// here means InitBaseband / tuner.Init see a clean device.
+//
+// USBDEVFS_RESET on Linux invalidates the prior interface claim, so the
+// retry path explicitly re-claims interface 0. On macOS, IOKit
+// ResetDevice may invalidate the device handle entirely; if the
+// re-claim fails we return that error verbatim rather than spinning.
+// On Windows, transport.Reset is a no-op — the retry will EPIPE
+// identically and we surface the wrapped error with the existing hint.
+func warmupWithReset(transport usb.Transport, demod *rtl2832u.Demod) error {
+	const maxAttempts = 2
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		err := demod.WarmupUSBSysctl()
+		if err == nil {
+			return nil
+		}
+		if attempt == maxAttempts-1 {
+			return fmt.Errorf("rtlsdr: USB warmup: %w%s", err, tunerBringupHint(err))
+		}
+		if !errors.Is(err, syscall.EPIPE) && !errors.Is(err, usb.ErrDeviceGone) {
+			return fmt.Errorf("rtlsdr: USB warmup: %w", err)
+		}
+		if resetErr := transport.Reset(); resetErr != nil {
+			return fmt.Errorf("rtlsdr: USB warmup hit %w; reset failed: %w", err, resetErr)
+		}
+		_ = transport.ReleaseInterface(0)
+		if claimErr := transport.ClaimInterface(0); claimErr != nil {
+			return fmt.Errorf("rtlsdr: re-claim interface 0 after reset: %w", claimErr)
+		}
+	}
+	return nil
 }
 
 // tunerBringupHint returns a parenthesized, space-prefixed remediation

--- a/internal/sdr/rtlsdr/purego/driver_test.go
+++ b/internal/sdr/rtlsdr/purego/driver_test.go
@@ -135,6 +135,121 @@ func TestKnownDevicesNoDuplicates(t *testing.T) {
 	}
 }
 
+// warmupUSBSysctlExchange returns the single mock CtrlExchange that
+// matches the wire bytes WarmupUSBSysctl emits — a vendor-OUT write to
+// BlockUSB / USBSysctl with payload 0x09. Err overrides the mock's
+// response so tests can simulate EPIPE recoveries.
+func warmupUSBSysctlExchange(simulateErr error) usb.CtrlExchange {
+	return usb.CtrlExchange{
+		In:       false,
+		BRequest: 0,
+		WValue:   0x2000,              // USBSysctl
+		WIndex:   uint16(1)<<8 | 0x10, // BlockUSB<<8 | 0x10
+		Data:     []byte{0x09},
+		Err:      simulateErr,
+	}
+}
+
+// Regression for issue #248: the warmup probe in openDevice must run
+// exactly once on a healthy device and must not trigger a USB reset.
+// Termination is forced via an unrelated ErrTimeout on the first
+// InitBaseband write so the script stays minimal.
+func TestOpenDevice_WarmupSucceedsFirstTry(t *testing.T) {
+	m := usb.NewMockTransport()
+	m.Script = []usb.CtrlExchange{
+		warmupUSBSysctlExchange(nil),
+		// Make InitBaseband's first write (also USBSysctl=0x09 — the
+		// same wire bytes as the warmup) fail with a non-EPIPE error
+		// so openDevice unwinds cleanly without forcing us to script
+		// the full init flood + tuner detect.
+		{
+			In:       false,
+			BRequest: 0,
+			WValue:   0x2000,
+			WIndex:   uint16(1)<<8 | 0x10,
+			Data:     []byte{0x09},
+			Err:      usb.ErrTimeout,
+		},
+	}
+	desc := usb.Descriptor{VID: 0x0bda, PID: 0x2838, Serial: "test-warmup-ok"}
+	_, err := openDevice(m, desc, 0)
+	if err == nil {
+		t.Fatal("openDevice succeeded; expected init-baseband timeout to terminate the test")
+	}
+	if !strings.Contains(err.Error(), "init baseband") {
+		t.Errorf("err = %v, want substring \"init baseband\" (proves warmup passed and InitBaseband ran)", err)
+	}
+	if m.ResetCalls != 0 {
+		t.Errorf("ResetCalls = %d, want 0 (healthy warmup must not reset)", m.ResetCalls)
+	}
+	if m.ClaimCalls != 1 {
+		t.Errorf("ClaimCalls = %d, want 1 (single ClaimInterface on healthy path)", m.ClaimCalls)
+	}
+}
+
+// Regression for issue #248: when the warmup write returns EPIPE, the
+// driver must call transport.Reset, re-claim interface 0, and retry the
+// warmup once. The retry succeeds and openDevice proceeds — we again
+// terminate early via ErrTimeout on the first InitBaseband write.
+func TestOpenDevice_WarmupEPIPETriggersResetAndRetry(t *testing.T) {
+	m := usb.NewMockTransport()
+	m.Script = []usb.CtrlExchange{
+		warmupUSBSysctlExchange(syscall.EPIPE),
+		warmupUSBSysctlExchange(nil),
+		{
+			In:       false,
+			BRequest: 0,
+			WValue:   0x2000,
+			WIndex:   uint16(1)<<8 | 0x10,
+			Data:     []byte{0x09},
+			Err:      usb.ErrTimeout,
+		},
+	}
+	desc := usb.Descriptor{VID: 0x0bda, PID: 0x2838, Serial: "test-warmup-retry"}
+	_, err := openDevice(m, desc, 0)
+	if err == nil {
+		t.Fatal("openDevice succeeded; expected init-baseband timeout to terminate the test")
+	}
+	if !strings.Contains(err.Error(), "init baseband") {
+		t.Errorf("err = %v, want substring \"init baseband\" (proves warmup retry succeeded and InitBaseband ran)", err)
+	}
+	if m.ResetCalls != 1 {
+		t.Errorf("ResetCalls = %d, want 1 (EPIPE on warmup must trigger one USBDEVFS_RESET)", m.ResetCalls)
+	}
+	if m.ClaimCalls != 2 {
+		t.Errorf("ClaimCalls = %d, want 2 (initial claim + post-reset re-claim)", m.ClaimCalls)
+	}
+}
+
+// Regression for issue #248: when both warmup attempts return EPIPE,
+// openDevice must surface the wrapped error with the tunerBringupHint
+// appended — that's the actionable message the user sees and which
+// points them at the DVB / power / cable workarounds.
+func TestOpenDevice_WarmupEPIPETwiceReturnsHintError(t *testing.T) {
+	m := usb.NewMockTransport()
+	m.Script = []usb.CtrlExchange{
+		warmupUSBSysctlExchange(syscall.EPIPE),
+		warmupUSBSysctlExchange(syscall.EPIPE),
+	}
+	desc := usb.Descriptor{VID: 0x0bda, PID: 0x2838, Serial: "test-warmup-fail"}
+	_, err := openDevice(m, desc, 0)
+	if err == nil {
+		t.Fatal("openDevice succeeded; expected EPIPE-twice to fail open")
+	}
+	if !errors.Is(err, syscall.EPIPE) {
+		t.Errorf("err = %v, want errors.Is(err, syscall.EPIPE) (the underlying cause must remain inspectable)", err)
+	}
+	if !strings.Contains(err.Error(), "USB warmup") {
+		t.Errorf("err = %v, want substring \"USB warmup\" (identifies the failing stage)", err)
+	}
+	if !strings.Contains(err.Error(), "dvb_usb_rtl28xxu") {
+		t.Errorf("err = %v, want substring \"dvb_usb_rtl28xxu\" (proves tunerBringupHint was appended)", err)
+	}
+	if m.ResetCalls != 1 {
+		t.Errorf("ResetCalls = %d, want 1 (one reset attempt between the two warmup tries)", m.ResetCalls)
+	}
+}
+
 // Regression for issue #248: tuner-init failures that look like the
 // I2C-bridge-can't-reach-tuner case (EPIPE from the first burst, or
 // the device disappearing mid-bringup) must carry remediation guidance

--- a/internal/sdr/rtlsdr/rtl2832u/demod.go
+++ b/internal/sdr/rtlsdr/rtl2832u/demod.go
@@ -114,6 +114,20 @@ func (d *Demod) DeinitBaseband() error {
 	return d.writeBlockRegLocked(BlockSys, SysDemodCtl, 0x20, 1)
 }
 
+// WarmupUSBSysctl issues the single USB-block write that librtlsdr's
+// rtlsdr_open uses as a dummy-write probe immediately after claiming
+// the interface — if it returns EPIPE the caller is expected to
+// libusb_reset_device and retry. The wire bytes match initBasebandSteps[0]
+// on purpose: librtlsdr also repeats the write inside the full init
+// flood, and the chip is happy to receive it twice. Kept separate so
+// the open path can run it with reset-on-EPIPE recovery without
+// dragging the whole baseband sequence into the retry.
+func (d *Demod) WarmupUSBSysctl() error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.writeBlockRegLocked(BlockUSB, USBSysctl, 0x09, 1)
+}
+
 // SetFIR uploads custom FIR filter coefficients. Layout matches
 // rtlsdr_set_fir: first 8 entries are 8-bit signed (one byte each),
 // entries 8..15 are 12-bit signed and pack three nibbles per pair —

--- a/internal/sdr/rtlsdr/rtl2832u/demod_test.go
+++ b/internal/sdr/rtlsdr/rtl2832u/demod_test.go
@@ -311,6 +311,27 @@ func TestInitBaseband_FullSequence(t *testing.T) {
 	}
 }
 
+func TestWarmupUSBSysctl_SingleWrite(t *testing.T) {
+	// Mirrors librtlsdr's rtlsdr_open dummy-write probe. Wire bytes
+	// must be identical to initBasebandSteps[0] (BlockUSB / USBSysctl
+	// / 0x09 / n=1) so the chip happily accepts both this probe and
+	// the InitBaseband write that follows.
+	m := usb.NewMockTransport()
+	m.Script = []usb.CtrlExchange{
+		expectBlockWrite(BlockUSB, USBSysctl, 0x09, 1),
+	}
+	d := New(m)
+	if err := d.WarmupUSBSysctl(); err != nil {
+		t.Fatalf("WarmupUSBSysctl: %v", err)
+	}
+	if m.Err != nil {
+		t.Errorf("mock err: %v", m.Err)
+	}
+	if m.Remaining() != 0 {
+		t.Errorf("remaining=%d, want 0", m.Remaining())
+	}
+}
+
 func TestDeinitBaseband_ClearsDemodCtl(t *testing.T) {
 	m := usb.NewMockTransport()
 	m.Script = []usb.CtrlExchange{

--- a/internal/sdr/rtlsdr/usb/usb_mock.go
+++ b/internal/sdr/rtlsdr/usb/usb_mock.go
@@ -73,6 +73,13 @@ type MockTransport struct {
 	ClaimedIfaces map[int]bool
 	Closed        bool
 
+	// ResetCalls counts invocations of Reset; tests use it to assert
+	// the USBDEVFS_RESET recovery path ran. ClaimCalls counts
+	// successful ClaimInterface invocations across all interfaces, so
+	// tests can verify post-reset re-claim happened.
+	ResetCalls int
+	ClaimCalls int
+
 	BulkPackets  [][]byte
 	BulkInterval time.Duration
 
@@ -171,6 +178,7 @@ func (m *MockTransport) ClaimInterface(num int) error {
 		return ErrClosed
 	}
 	m.ClaimedIfaces[num] = true
+	m.ClaimCalls++
 	return nil
 }
 
@@ -246,6 +254,7 @@ func (m *MockTransport) Reset() error {
 	if m.Closed {
 		return ErrClosed
 	}
+	m.ResetCalls++
 	return nil
 }
 


### PR DESCRIPTION
Adds a single dummy USB_SYSCTL=0x09 write right after claiming the
interface and, on EPIPE / ErrDeviceGone, runs one USBDEVFS_RESET +
re-claim before retrying. Mirrors the recovery librtlsdr's rtlsdr_open
has shipped for years. NESDR v5 dongles left in a half-initialised
state by a crashed prior session or a freshly-unbound DVB kernel driver
now open transparently instead of surfacing the stalled control transfer
as "r82xx init: burst write: I2CWrite addr=0x34: broken pipe".