### PR TITLE
rtlsdr: chunk R82xx init burst at 16 bytes (issue #248)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ for tagged releases.
 
 ### Fixed
 
+- **RTL-SDR R820T/R820T2 init burst now chunks at 16 bytes to match
+  librtlsdr.** The 27-byte register flood at the top of `R82xx.Init`
+  previously went on the wire as a single 28-byte I²C-bridge OUT
+  (1 register pointer + 27 data bytes). Some NESDR v5 dongles stall
+  the very first multi-byte OUT when its data payload exceeds 16
+  bytes — librtlsdr's `r82xx_write` has chunked at `NMAX_WRITES = 16`
+  for exactly this reason. `writeBurstRaw` now splits the data into
+  ≤16-byte segments under one repeater on/off pair, advancing the
+  register pointer per chunk (the chip auto-increments). The wire
+  bytes are otherwise unchanged.
+  Follow-up to the warmup probe shipped earlier in this cycle;
+  addresses the residual reproduction in
+  [issue #248](https://github.com/MattCheramie/GopherTrunk/issues/248).
 - **RTL-SDR tuner init no longer fails on dongles left in a
   half-initialised USB state.** Open now performs librtlsdr's
   dummy-write probe (`USB_SYSCTL = 0x09`) immediately after claiming

--- a/internal/sdr/rtlsdr/tuners/r82xx.go
+++ b/internal/sdr/rtlsdr/tuners/r82xx.go
@@ -457,18 +457,36 @@ func (r *R82xx) writeRegMask(addr uint8, val, mask byte) error {
 	return r.writeBurstRaw(addr, []byte{next})
 }
 
-// writeBurstRaw bypasses the shadow cache and emits one I2C burst
-// (address byte followed by len(data) data bytes) wrapped in
-// I2C-repeater on/off.
+// writeBurstRaw bypasses the shadow cache and emits one or more I2C
+// burst writes (address byte followed by data bytes) wrapped in a
+// single I2C-repeater on/off pair.
+//
+// Data is split into chunks of at most r82xxBurstMaxData bytes to
+// mirror librtlsdr's r82xx_write (NMAX_WRITES = 16). Going beyond
+// that limit stalls the very first multi-byte OUT on some NESDR v5
+// dongles — observed as libusb EPIPE on the 27-byte init flood
+// (issue #248). Each chunk is its own control-OUT under the same
+// repeater session; the register pointer advances by the chunk
+// length between chunks, which matches the chip's auto-increment.
 func (r *R82xx) writeBurstRaw(addr uint8, data []byte) error {
 	if err := r.demod.SetI2CRepeater(true); err != nil {
 		return err
 	}
 	defer r.demod.SetI2CRepeater(false)
-	buf := make([]byte, 1+len(data))
-	buf[0] = addr
-	copy(buf[1:], data)
-	return r.demod.I2CWrite(r.i2cAddr, buf)
+	for pos := 0; pos < len(data); {
+		size := len(data) - pos
+		if size > r82xxBurstMaxData {
+			size = r82xxBurstMaxData
+		}
+		buf := make([]byte, 1+size)
+		buf[0] = addr + uint8(pos)
+		copy(buf[1:], data[pos:pos+size])
+		if err := r.demod.I2CWrite(r.i2cAddr, buf); err != nil {
+			return err
+		}
+		pos += size
+	}
+	return nil
 }
 
 // readRegRaw reads n bytes from the chip starting at addr 0. The

--- a/internal/sdr/rtlsdr/tuners/r82xx_tables.go
+++ b/internal/sdr/rtlsdr/tuners/r82xx_tables.go
@@ -37,6 +37,14 @@ const (
 	// vcoPowerRef is the comparison threshold for fine-tuning
 	// divNum based on the chip's VCO fine-tune status bits.
 	r82xxVCOPowerRef = 2
+
+	// r82xxBurstMaxData caps the data-byte count per I2C-bridge OUT
+	// to the tuner. librtlsdr's r82xx_write uses NMAX_WRITES = 16 for
+	// the same reason: some R820T2 dongles stall the very first
+	// multi-byte burst when it exceeds 16 data bytes (issue #248).
+	// The 1-byte register pointer prepended to each chunk is not
+	// counted toward this limit, matching librtlsdr's behavior.
+	r82xxBurstMaxData = 16
 )
 
 // r82xxInitArray is the 27-byte register flood that lands at addr

--- a/internal/sdr/rtlsdr/tuners/r82xx_test.go
+++ b/internal/sdr/rtlsdr/tuners/r82xx_test.go
@@ -39,6 +39,25 @@ func expectI2CWrite(i2cAddr uint8, data []byte) []usb.CtrlExchange {
 	return out
 }
 
+// expectR82xxInitBurst returns the wire script R82xx.Init produces:
+// repeater-on, the chunked init flood (16 + 11 data bytes at reg
+// 0x05 and 0x15 respectively — matches librtlsdr NMAX_WRITES), and
+// repeater-off. Kept in lockstep with writeBurstRaw's chunking
+// (issue #248).
+func expectR82xxInitBurst() []usb.CtrlExchange {
+	out := append([]usb.CtrlExchange{}, expectRepeaterToggle(true)...)
+	chunk1 := append([]byte{r82xxShadowStart}, r82xxInitArray[:r82xxBurstMaxData]...)
+	chunk2 := append([]byte{r82xxShadowStart + r82xxBurstMaxData}, r82xxInitArray[r82xxBurstMaxData:]...)
+	out = append(out, usb.CtrlExchange{
+		In: false, BRequest: 0, WValue: uint16(r82xxI2CAddr), WIndex: uint16(rtl2832u.BlockIIC)<<8 | 0x10, Data: chunk1,
+	})
+	out = append(out, usb.CtrlExchange{
+		In: false, BRequest: 0, WValue: uint16(r82xxI2CAddr), WIndex: uint16(rtl2832u.BlockIIC)<<8 | 0x10, Data: chunk2,
+	})
+	out = append(out, expectRepeaterToggle(false)...)
+	return out
+}
+
 // expectI2CRead is the read counterpart. n is the byte count;
 // replyOnWire is what the mock returns (the driver bit-reverses).
 func expectI2CRead(i2cAddr uint8, n int, replyOnWire []byte) []usb.CtrlExchange {
@@ -129,9 +148,10 @@ func TestBitReverseTable(t *testing.T) {
 }
 
 func TestR82xx_InitWritesBurst(t *testing.T) {
-	// Init does one burst write of (addr 0x05, then 27 init bytes).
-	burst := append([]byte{r82xxShadowStart}, r82xxInitArray[:]...)
-	r, m := newR82xxForTest(t, expectI2CWrite(r82xxI2CAddr, burst))
+	// Init writes the 27-byte init array as two librtlsdr-style chunks
+	// (16 + 11 data bytes) under one repeater on/off pair. See
+	// r82xxBurstMaxData and issue #248 for the chunking rationale.
+	r, m := newR82xxForTest(t, expectR82xxInitBurst())
 	if err := r.Init(); err != nil {
 		t.Fatalf("Init: %v", err)
 	}
@@ -152,8 +172,7 @@ func TestR82xx_InitWritesBurst(t *testing.T) {
 
 func TestR82xx_InitIdempotent(t *testing.T) {
 	// Second Init call must be a no-op (no I2C traffic).
-	burst := append([]byte{r82xxShadowStart}, r82xxInitArray[:]...)
-	r, m := newR82xxForTest(t, expectI2CWrite(r82xxI2CAddr, burst))
+	r, m := newR82xxForTest(t, expectR82xxInitBurst())
 	if err := r.Init(); err != nil {
 		t.Fatalf("first Init: %v", err)
 	}
@@ -166,10 +185,9 @@ func TestR82xx_InitIdempotent(t *testing.T) {
 }
 
 func TestR82xx_StandbyWritesPowerDownSequence(t *testing.T) {
-	// Build expected script: Init (one burst), then 11 standby writes.
+	// Build expected script: Init (chunked init burst), then standby writes.
 	var script []usb.CtrlExchange
-	initBurst := append([]byte{r82xxShadowStart}, r82xxInitArray[:]...)
-	script = append(script, expectI2CWrite(r82xxI2CAddr, initBurst)...)
+	script = append(script, expectR82xxInitBurst()...)
 	// Note: writes whose new value matches the init-array value are
 	// elided by the shadow cache. 0x0F init = 0x68 (per
 	// r82xxInitArray) and standby also requests 0x68 → skipped.
@@ -205,9 +223,7 @@ func TestR82xx_WriteRegMaskSkipsRedundant(t *testing.T) {
 	// After Init, shadow has known values. Writing a value that
 	// matches the masked region of the shadow must produce no I2C
 	// traffic.
-	initBurst := append([]byte{r82xxShadowStart}, r82xxInitArray[:]...)
-	script := expectI2CWrite(r82xxI2CAddr, initBurst)
-	r, m := newR82xxForTest(t, script)
+	r, m := newR82xxForTest(t, expectR82xxInitBurst())
 	if err := r.Init(); err != nil {
 		t.Fatalf("Init: %v", err)
 	}
@@ -222,11 +238,7 @@ func TestR82xx_WriteRegMaskSkipsRedundant(t *testing.T) {
 }
 
 func TestR82xx_WriteRegMaskOnlyChangesMaskedBits(t *testing.T) {
-	initBurst := append([]byte{r82xxShadowStart}, r82xxInitArray[:]...)
-	r, m := newR82xxForTest(t, append(
-		[]usb.CtrlExchange{},
-		expectI2CWrite(r82xxI2CAddr, initBurst)...,
-	))
+	r, m := newR82xxForTest(t, expectR82xxInitBurst())
 	if err := r.Init(); err != nil {
 		t.Fatalf("Init: %v", err)
 	}
@@ -252,8 +264,7 @@ func TestR82xx_SetGainModeManual(t *testing.T) {
 	// regs[0x07] = 0x75 post-init → 0x75 (bit 4 already set!). Wait, 0x75 = 0111_0101, bit 4 = 1. Hmm.
 	// So writing manual mode (bit 4 = 1) to 0x07 is a no-op. We skip that write.
 	var script []usb.CtrlExchange
-	initBurst := append([]byte{r82xxShadowStart}, r82xxInitArray[:]...)
-	script = append(script, expectI2CWrite(r82xxI2CAddr, initBurst)...)
+	script = append(script, expectR82xxInitBurst()...)
 	// Only the 0x05 write should land (0x07's bit 4 is already 1 post-init).
 	script = append(script, expectI2CWrite(r82xxI2CAddr, []byte{0x05, 0x93})...)
 	r, m := newR82xxForTest(t, script)
@@ -273,8 +284,7 @@ func TestR82xx_SetGainModeManual(t *testing.T) {
 
 func TestR82xx_SetGainOnlyInManualMode(t *testing.T) {
 	// SetGain must be a no-op when AGC is active (default).
-	initBurst := append([]byte{r82xxShadowStart}, r82xxInitArray[:]...)
-	r, m := newR82xxForTest(t, expectI2CWrite(r82xxI2CAddr, initBurst))
+	r, m := newR82xxForTest(t, expectR82xxInitBurst())
 	if err := r.Init(); err != nil {
 		t.Fatalf("Init: %v", err)
 	}
@@ -288,8 +298,7 @@ func TestR82xx_SetGainOnlyInManualMode(t *testing.T) {
 }
 
 func TestR82xx_SetGainNegativeIsNoOp(t *testing.T) {
-	initBurst := append([]byte{r82xxShadowStart}, r82xxInitArray[:]...)
-	r, m := newR82xxForTest(t, expectI2CWrite(r82xxI2CAddr, initBurst))
+	r, m := newR82xxForTest(t, expectR82xxInitBurst())
 	if err := r.Init(); err != nil {
 		t.Fatalf("Init: %v", err)
 	}
@@ -309,8 +318,7 @@ func TestR82xx_SetBandwidthSelectsCoarseIndex(t *testing.T) {
 	// regs[0x0B] post-init = 0x6C.
 	//   new = (0x6C & ^0xF0) | (0 & 0xF0) = 0x0C.
 	var script []usb.CtrlExchange
-	initBurst := append([]byte{r82xxShadowStart}, r82xxInitArray[:]...)
-	script = append(script, expectI2CWrite(r82xxI2CAddr, initBurst)...)
+	script = append(script, expectR82xxInitBurst()...)
 	script = append(script, expectI2CWrite(r82xxI2CAddr, []byte{0x0A, 0xD0})...)
 	script = append(script, expectI2CWrite(r82xxI2CAddr, []byte{0x0B, 0x0C})...)
 	r, m := newR82xxForTest(t, script)
@@ -363,8 +371,7 @@ func TestSelectBWIndex_SmallestFilterAboveTarget(t *testing.T) {
 }
 
 func TestR82xx_SetFreqOutOfRange(t *testing.T) {
-	initBurst := append([]byte{r82xxShadowStart}, r82xxInitArray[:]...)
-	r, _ := newR82xxForTest(t, expectI2CWrite(r82xxI2CAddr, initBurst))
+	r, _ := newR82xxForTest(t, expectR82xxInitBurst())
 	if err := r.Init(); err != nil {
 		t.Fatalf("Init: %v", err)
 	}


### PR DESCRIPTION
The 27-byte register flood at the top of R82xx.Init went on the wire
as a single 28-byte I2C-bridge OUT (1 register pointer + 27 data
bytes). librtlsdr's r82xx_write chunks at NMAX_WRITES=16 for exactly
this reason — some NESDR v5 dongles stall the very first multi-byte
OUT when its data payload exceeds 16 bytes, surfacing as
"r82xx init: burst write: I2CWrite addr=0x34: broken pipe" even on
units that work fine with rtl_test, SDRTrunk, and p25survey.

Two NESDR v5 dongles still reproduced the EPIPE after PR #255's
USB-sysctl warmup probe shipped, with the error coming from the
post-warmup burst rather than the warmup itself — which is what
pointed at the chunking gap.

writeBurstRaw now walks data in <=16-byte segments under one
repeater on/off pair, advancing the register pointer per chunk
(the chip auto-increments). Wire bytes are otherwise unchanged.

https://claude.ai/code/session_01KUJWjSMQvTxoAYbFHRXoeX