### PR TITLE
rtlsdr: fix librtlsdr-parity bugs in R82xx gain + E4000 SetFreq

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ for tagged releases.
 
 ### Fixed
 
+- **RTL-SDR R820T/R820T2 manual gain now uses librtlsdr's balanced
+  LNA+Mixer split.** `R82xx.SetGain` previously walked the LNA gain
+  ladder to maximum-not-exceeding-target, then walked the mixer
+  ladder — landing on the same numeric gain as librtlsdr but with all
+  the gain concentrated on the LNA. The result was a worse noise
+  figure and worse front-end linearity at every ladder entry. The
+  walk now alternates LNA and mixer with pre-increment, matching
+  `r82xx_set_gain` in osmocom librtlsdr. Affects every R820T/R820T2
+  dongle (the common case) the moment the user picks a manual gain.
+- **RTL-SDR E4000 (Elonics) tuner frequency setting now writes the
+  correct synthesizer registers.** `E4000.SetFreq` was writing the
+  fractional `X` value to `SYNTH5`/`SYNTH6` (off-by-one register) and
+  never writing the band-select / R-divider byte to `SYNTH7` at all,
+  so the chip would mistune at every frequency. The PLL math itself
+  was correct; only the wire-level register addresses were wrong.
+  Now matches librtlsdr's `e4k_tune_params` exactly. Affects E4000
+  dongles (legacy hardware — NOXON DAB sticks and similar).
 - **RTL-SDR R820T/R820T2 init burst now chunks at 16 bytes to match
   librtlsdr.** The 27-byte register flood at the top of `R82xx.Init`
   previously went on the wire as a single 28-byte I²C-bridge OUT

--- a/internal/sdr/rtlsdr/tuners/e4k.go
+++ b/internal/sdr/rtlsdr/tuners/e4k.go
@@ -221,23 +221,23 @@ func (e *E4000) SetFreq(hz uint32) error {
 	// X is a 16-bit fractional: (remainder / fosc) * 65536, rounded.
 	x := uint32((remainder * 65536) / fosc)
 
-	// Write synth bytes (Z low + Z high → reg 0x09/0x0A; X low/high
-	// → reg 0x0B/0x0C in librtlsdr layout). E4K's synth reg map
-	// uses 0x09 = Z low, 0x0A = Z high (3 bits), 0x0B = X low,
-	// 0x0C = X high.
+	// E4K synth register layout (e4k_reg.h):
+	//   0x09 SYNTH3 — Z (integer divider, 8 bits is enough across the band table)
+	//   0x0A SYNTH4 — X low byte (fractional)
+	//   0x0B SYNTH5 — X high byte
+	//   0x0D SYNTH7 — R divider (bits 0-2) + 3-phase/band (bits 3-7)
+	// e4kPLLRanges[i].bandSel is the ready-to-write synth7 byte from
+	// librtlsdr's pll_vars table — write it verbatim to reg 0x0D.
 	if err := e.writeReg(0x09, byte(z&0xFF)); err != nil {
 		return err
 	}
-	if err := e.writeReg(0x0A, byte((z>>8)&0x07)|byte(rng.bandSel&0xF0)); err != nil {
+	if err := e.writeReg(0x0A, byte(x&0xFF)); err != nil {
 		return err
 	}
-	if err := e.writeReg(0x0B, byte(x&0xFF)); err != nil {
+	if err := e.writeReg(0x0B, byte((x>>8)&0xFF)); err != nil {
 		return err
 	}
-	if err := e.writeReg(0x0C, byte((x>>8)&0xFF)); err != nil {
-		return err
-	}
-	return nil
+	return e.writeReg(0x0D, rng.bandSel)
 }
 
 // SetBandwidth configures the IF channel filter. The E4000 has three

--- a/internal/sdr/rtlsdr/tuners/e4k_test.go
+++ b/internal/sdr/rtlsdr/tuners/e4k_test.go
@@ -58,13 +58,13 @@ func TestE4000PLLRangeTable_BandPicks(t *testing.T) {
 }
 
 // TestE4000PLLSynthMath replicates the production Σ-Δ math from
-// e4k.go's SetFreq (lines 209–222) and pins the (Z, X) outputs for
-// hand-computed frequencies. Z is the integer divider, X is the
-// 16-bit fractional in (remainder * 65536) / fosc (integer truncation,
-// matching the production uint32 cast). The expected values were
-// derived by hand from fosc = 28.8 MHz and the band table at
-// e4k.go:84-97; a regression in the math or the band-table ordering
-// will flip one of the bytes downstream of register 0x09..0x0C.
+// e4k.go's SetFreq and pins the (Z, X) outputs for hand-computed
+// frequencies. Z is the integer divider, X is the 16-bit fractional
+// in (remainder * 65536) / fosc (integer truncation, matching the
+// production uint32 cast). The expected values were derived by hand
+// from fosc = 28.8 MHz and the band table; a regression in the math
+// or the band-table ordering will flip one of the bytes downstream
+// of register 0x09 (Z), 0x0A/0x0B (X low/high), 0x0D (band/R).
 func TestE4000PLLSynthMath(t *testing.T) {
 	const fosc uint64 = 28_800_000
 	cases := []struct {
@@ -123,11 +123,13 @@ func TestE4000PLLSynthMath(t *testing.T) {
 				t.Errorf("X = %d, want %d (remainder=%d)", x, c.wantX, remainder)
 			}
 
-			// 3. Z must fit in 11 bits (e4k.go:228-233 splits as 8+3).
-			if z >= 1<<11 {
-				t.Errorf("Z = %d overflows the 11-bit synth field", z)
+			// 3. Z must fit in 8 bits (production writes z & 0xFF to
+			//    reg 0x09 with no high-byte counterpart per librtlsdr's
+			//    e4k_tune_params).
+			if z >= 1<<8 {
+				t.Errorf("Z = %d overflows the 8-bit synth field", z)
 			}
-			// 4. X must fit in 16 bits (e4k.go:234-237 splits as 8+8).
+			// 4. X must fit in 16 bits (split 8+8 across reg 0x0A and 0x0B).
 			if x >= 1<<16 {
 				t.Errorf("X = %d overflows the 16-bit fractional field", x)
 			}
@@ -161,6 +163,43 @@ func TestE4000SetFreqBoundaryInclusivity(t *testing.T) {
 			t.Errorf("SetFreq(%d) range-err = %v, want %v (err=%v)",
 				c.hz, isRange, c.wantRange, err)
 		}
+	}
+}
+
+// TestE4000_SetFreq_WireBytes pins the I2C writes E4000.SetFreq emits
+// at 100 MHz against librtlsdr's e4k_tune_params layout (e4k_reg.h):
+//
+//	0x09 SYNTH3 ← Z (integer divider, low byte)
+//	0x0A SYNTH4 ← X low byte (fractional)
+//	0x0B SYNTH5 ← X high byte
+//	0x0D SYNTH7 ← R divider [bits 0-2] + band select [bits 3-7]
+//
+// 100 MHz picks pll_vars row {div=32, bandSel=0x0D}:
+//
+//	fvco = 100_000_000 * 32 = 3_200_000_000
+//	z    = 3_200_000_000 / 28_800_000              = 111   (0x6F)
+//	rem  = 3_200_000_000 - 28_800_000*111          = 3_200_000
+//	x    = (3_200_000 * 65536) / 28_800_000        = 7281  (0x1C71)
+//
+// Pre-fix bug: SetFreq wrote (z>>8)&0x07 | bandSel&0xF0 to 0x0A (zeroed
+// bandSel since values are ≤0x0F), shifted X by one register, never
+// touched 0x0D. A regression to that layout fails this script's
+// strict-order match.
+func TestE4000_SetFreq_WireBytes(t *testing.T) {
+	var script []usb.CtrlExchange
+	script = append(script, expectI2CWrite(e4kI2CAddr, []byte{0x09, 0x6F})...) // Z
+	script = append(script, expectI2CWrite(e4kI2CAddr, []byte{0x0A, 0x71})...) // X low
+	script = append(script, expectI2CWrite(e4kI2CAddr, []byte{0x0B, 0x1C})...) // X high
+	script = append(script, expectI2CWrite(e4kI2CAddr, []byte{0x0D, 0x0D})...) // band/R
+	m := usb.NewMockTransport()
+	m.Script = script
+	e := NewE4000(rtl2832u.New(m))
+	e.initDone = true
+	if err := e.SetFreq(100_000_000); err != nil {
+		t.Fatalf("SetFreq: %v", err)
+	}
+	if m.Remaining() != 0 {
+		t.Errorf("remaining=%d, want 0 (script: %d/%d consumed)", m.Remaining(), m.Step, len(script))
 	}
 }
 

--- a/internal/sdr/rtlsdr/tuners/r82xx.go
+++ b/internal/sdr/rtlsdr/tuners/r82xx.go
@@ -232,19 +232,30 @@ func (r *R82xx) SetGain(tenthDB int) error {
 		// callers use it as a sentinel.
 		return nil
 	}
-	// Walk the LNA + mixer LUTs in lockstep, accumulating gain.
-	// Pick the first index where the next step would exceed tenthDB.
+	// Alternate LNA and mixer increments, pre-incrementing the index
+	// each step. Matches librtlsdr's r82xx_set_gain — the published
+	// gain ladder (r82xxGainsTenthDB) is the alternating sum, so this
+	// is the only walk that lands on a balanced LNA+Mixer split for
+	// each target. The LNA-first-then-mixer alternative produces the
+	// same total at most ladder entries but with all gain concentrated
+	// on LNA — wrong noise figure and front-end linearity.
 	var lnaIdx, mixIdx int
-	var total int
-	for i := 0; i < len(r82xxLNAGainSteps) && total+r82xxLNAGainSteps[i] <= tenthDB; i++ {
-		total += r82xxLNAGainSteps[i]
-		lnaIdx = i
-	}
-	for i := 0; i < len(r82xxMixerGainSteps) && total+r82xxMixerGainSteps[i] <= tenthDB; i++ {
-		if r82xxMixerGainSteps[i] > 0 {
-			total += r82xxMixerGainSteps[i]
+	total := 0
+	for i := 0; i < 15; i++ {
+		if total >= tenthDB {
+			break
 		}
-		mixIdx = i
+		if lnaIdx+1 < len(r82xxLNAGainSteps) {
+			lnaIdx++
+			total += r82xxLNAGainSteps[lnaIdx]
+		}
+		if total >= tenthDB {
+			break
+		}
+		if mixIdx+1 < len(r82xxMixerGainSteps) {
+			mixIdx++
+			total += r82xxMixerGainSteps[mixIdx]
+		}
 	}
 	// Register 0x05 low nibble = LNA gain index; bit 4 must be 0 for manual mode.
 	if err := r.writeRegMask(0x05, byte(lnaIdx&0x0F), 0x0F); err != nil {

--- a/internal/sdr/rtlsdr/tuners/r82xx_test.go
+++ b/internal/sdr/rtlsdr/tuners/r82xx_test.go
@@ -311,6 +311,92 @@ func TestR82xx_SetGainNegativeIsNoOp(t *testing.T) {
 	}
 }
 
+// TestR82xx_AlternatingGainWalk pins the cumulative sums the librtlsdr
+// alternating LNA/Mixer walk produces against the LUTs in
+// r82xx_tables.go. Every entry in the published ladder
+// r82xxGainsTenthDB must appear in this walk (with one exception — the
+// walk yields a transient 483 between 480 and 496 that the curated
+// ladder elides). A regression to "LNA-first then mixer" — same total
+// but all gain on LNA — produces a wildly different walk and fails fast.
+func TestR82xx_AlternatingGainWalk(t *testing.T) {
+	// 15 iterations × 2 increments + the starting zero = 31 totals.
+	wantWalk := []int{
+		0, 9, 14, 27, 37, 77, 87, 125, 144, 157, 166, 197, 207, 229,
+		254, 280, 297, 328, 338, 364, 372, 386, 402, 421, 434, 439,
+		445, 480, 483, 496, 488,
+	}
+	got := []int{0}
+	total, lnaIdx, mixIdx := 0, 0, 0
+	for i := 0; i < 15; i++ {
+		lnaIdx++
+		total += r82xxLNAGainSteps[lnaIdx]
+		got = append(got, total)
+		mixIdx++
+		total += r82xxMixerGainSteps[mixIdx]
+		got = append(got, total)
+	}
+	if len(got) != len(wantWalk) {
+		t.Fatalf("walk produced %d totals; want %d", len(got), len(wantWalk))
+	}
+	for i, want := range wantWalk {
+		if got[i] != want {
+			t.Errorf("walk[%d] = %d, want %d", i, got[i], want)
+		}
+	}
+	// Every published-ladder entry except the elided 483 must appear in
+	// the walk — the ladder is the user-facing menu of "nice" gain
+	// values reachable by stopping the alternating walk early.
+	walkSet := map[int]bool{}
+	for _, v := range wantWalk {
+		walkSet[v] = true
+	}
+	for _, g := range r82xxGainsTenthDB {
+		if !walkSet[g] {
+			t.Errorf("ladder entry %d not reachable by alternating walk", g)
+		}
+	}
+}
+
+// TestR82xx_SetGain_BalancedSplit pins SetGain(144) end-to-end on the
+// mock transport. librtlsdr picks lnaIdx=4, mixIdx=4 — the balanced
+// split for r82xxGainsTenthDB[8] = 144. The pre-fix two-loop algorithm
+// picked lnaIdx=6, mixIdx=0 (all LNA) which would write 0x05=0x96 and
+// 0x07=0x70 — those bytes are NOT in this script, so a regression to
+// the old algorithm fails fast.
+//
+// Post-init shadow values (from r82xxInitArray):
+//
+//	regs[0x05] = 0x83 → SetGainMode(true) writes 0x93 (bit 4 set)
+//	regs[0x07] = 0x75 (bit 4 already set, SetGainMode emits no write)
+//	regs[0x0C] = 0xF5
+//
+// SetGain(144) then writes (with shadow elision):
+//
+//	0x05: 0x93 → (0x93 &^ 0x0F) | 4 = 0x94
+//	0x07: 0x75 → (0x75 &^ 0x0F) | 4 = 0x74
+//	0x0C: 0xF5 → (0xF5 &^ 0x9F) | 0x0B = 0x6B
+func TestR82xx_SetGain_BalancedSplit(t *testing.T) {
+	var script []usb.CtrlExchange
+	script = append(script, expectR82xxInitBurst()...)
+	script = append(script, expectI2CWrite(r82xxI2CAddr, []byte{0x05, 0x93})...)
+	script = append(script, expectI2CWrite(r82xxI2CAddr, []byte{0x05, 0x94})...)
+	script = append(script, expectI2CWrite(r82xxI2CAddr, []byte{0x07, 0x74})...)
+	script = append(script, expectI2CWrite(r82xxI2CAddr, []byte{0x0C, 0x6B})...)
+	r, m := newR82xxForTest(t, script)
+	if err := r.Init(); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	if err := r.SetGainMode(true); err != nil {
+		t.Fatalf("SetGainMode: %v", err)
+	}
+	if err := r.SetGain(144); err != nil {
+		t.Fatalf("SetGain(144): %v", err)
+	}
+	if m.Remaining() != 0 {
+		t.Errorf("remaining=%d, want 0 (script: %d/%d consumed)", m.Remaining(), m.Step, len(script))
+	}
+}
+
 func TestR82xx_SetBandwidthSelectsCoarseIndex(t *testing.T) {
 	// 2.4 MS/s → coarse index 0 (2.4 MHz BW entry, low nibble 0).
 	// regs[0x0A] post-init = 0xD6 (per r82xxInitArray).

--- a/internal/sdr/rtlsdr/tuners/tuner.go
+++ b/internal/sdr/rtlsdr/tuners/tuner.go
@@ -88,8 +88,9 @@ type Tuner interface {
 	// (returned by Gains). Pass -1 to leave the current value alone
 	// — useful when only SetGainMode is changing.
 	SetGain(tenthDB int) error
-	// SetGainMode flips between automatic (true) and manual (false)
-	// gain control.
+	// SetGainMode flips between manual (true) and automatic (false)
+	// gain control. Implementations name the parameter `manual` to make
+	// the polarity obvious at the call site.
 	SetGainMode(manual bool) error
 	// Gains returns the discrete gain ladder, in tenths of dB,
 	// supported by this chip. The slice is sorted ascending.


### PR DESCRIPTION
Three divergences from osmocom librtlsdr that the existing tests didn't
catch:

- R82xx.SetGain walked the LNA ladder to maximum-not-exceeding-target
  then the mixer ladder, instead of alternating LNA / Mixer with
  pre-increment (tuner_r82xx.c r82xx_set_gain). Same numeric gain at
  every ladder entry but with all the gain concentrated on the LNA —
  worse noise figure and front-end linearity. Affects every R820T /
  R820T2 dongle (the common case) the moment the user picks a manual
  gain.
- E4000.SetFreq wrote the fractional X value to SYNTH5/SYNTH6 (one
  register past where librtlsdr's e4k_reg.h puts it) and never wrote
  the band-select / R-divider byte to SYNTH7 at all, so the chip would
  mistune at every frequency. PLL math itself was correct.
- Tuner.SetGainMode docstring claimed `automatic (true), manual
  (false)`; every implementation and the caller in purego/device.go use
  the opposite polarity.

New tests pin both the alternating gain walk (algorithm-level) and one
representative SetGain wire-level emission (verifies the
balanced-vs-LNA-only split fails fast on regression); new E4000 test
pins the four-register SetFreq sequence at 100 MHz against librtlsdr's
e4k_tune_params layout.