### PR TITLE
rtlsdr: I2C bridge per-method + librtlsdr probe order with GPIO dances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,38 @@ for tagged releases.
   zero allocation when unset. Documented in the install-linux and
   install-macos troubleshooting tables.
 
+### Changed
+
+- **RTL-SDR tuner I²C bridge now toggles per public method instead of
+  per register write.** Every tuner driver (R82xx, E4000, FC0012,
+  FC0013, FC2580) previously turned the RTL2832U I²C repeater on
+  before each `writeReg`/`readReg` and back off after it — three USB
+  control transfers per single-byte chip register access. The
+  repeater is now opened once at the top of each public method
+  (`Init`, `Standby`, `SetFreq`, `SetBandwidth`, `SetGain`,
+  `SetGainMode`) and closed at the end, matching librtlsdr's
+  `rtlsdr_set_tuner_*` wrap pattern. For an R820T2 `SetFreq` call
+  (~10–15 register writes) this drops 40–60 USB control transfers per
+  retune to the steady-state two — measurably faster on USB 2.0 hubs
+  and meaningfully less timing-fragile on marginal cabling. Compatible
+  with the issue #248 fix: `R82xx.Init`'s leading
+  `SetI2CRepeater(true)` is the fresh wire write the chip needs to
+  arm the bridge before its multi-byte burst, and the cache state
+  ends up `false` post-Detect (off-toggle defer) so the on-toggle
+  is real rather than a cache no-op.
+- **RTL-SDR tuner detection now follows librtlsdr's exact rtlsdr_open
+  probe order and GPIO bring-up dance.** The Go port previously
+  probed R820T → R828D → E4000 → FC0013 → FC0012 → FC2580 with no
+  GPIO pulses, which silently broke detection of non-R820T tuners
+  (FC2580/FC0013/E4000/FC0012) on dongles whose chip-enable lines
+  hold the IC in reset until pulsed. The orchestrator now mirrors
+  `librtlsdr.c` exactly: R820T → R828D → GPIO5 high→low reset →
+  FC2580 → GPIO4 output enable → FC0013 → E4000 → FC0012 (followed by
+  a GPIO6 reset pulse if FC0012 was found). FC0012's `Init` also no
+  longer emits the two spurious `0x0C` register writes ("soft-reset")
+  the pre-fix code shipped — librtlsdr never wrote those; the chip
+  reset is the GPIO5 pulse.
+
 ### Fixed
 
 - **RTL-SDR `tuners.Detect` again toggles the I²C repeater off on

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Full per-OS install (Windows installer / macOS Apple Silicon / Linux aarch64): *
 
 **Pure-Go voice path** — IMBE (P25 Phase 1) and AMBE+2 (P25 Phase 2 / DMR / NXDN) vocoders implemented in Go, no DVSI / mbelib dependency. Per-call WAV + raw-frame sidecars; live PCM playback via direct ALSA / WASAPI / CoreAudio (no `libasound2` at runtime).
 
-**SDR layer** — Pure-Go RTL-SDR driver across USBDEVFS (Linux), WinUSB (Windows), IOKit (macOS). All major tuner drivers (R820T / R820T2 / R828D / E4000 / FC0012 / FC0013 / FC2580). Multi-device pool with role assignment, per-device gain / PPM / bias-tee.
+**SDR layer** — Pure-Go RTL-SDR driver across USBDEVFS (Linux), WinUSB (Windows), IOKit (macOS). All major tuner drivers (R820T / R820T2 / R828D / E4000 / FC0012 / FC0013 / FC2580) — each a wire-level port of osmocom librtlsdr's `tuner_*.c`, with librtlsdr-parity init burst chunking, EPIPE warmup + reset on Open, balanced LNA+Mixer gain algorithm, and the same `rtlsdr_open` probe order + GPIO 4/5/6 dances for non-R820T detection. I²C bridge toggles once per public method (`SetFreq`/`SetGain`/...) instead of per register write — drops ~10× the USB control transfers per retune on busy hubs. Multi-device pool with role assignment, per-device gain / PPM / bias-tee.
 
 **DSP** — Polyphase channelizer + CIC + halfband, Kaiser / RRC / Gaussian FIR designers, FM / C4FM / GFSK / FFSK / DQPSK / π/4-DQPSK / π/8-H-DQPSK demods, Mueller-Müller + Gardner clock recovery, LMS + CMA blind equalizers, Selection + maximal-ratio diversity combining.
 
@@ -2011,8 +2011,18 @@ to its own package and lands independently.
   replaced the `librtlsdr` + `libusb` C dependency. Pure-Go USB
   transports for Linux (USBDEVFS), Windows (WinUSB), and macOS (IOKit
   via `purego`); RTL2832U register/I2C layer; R820T/R820T2/R828D +
-  E4000 + FC0012 + FC0013 + FC2580 tuner drivers. Default builds
-  run `CGO_ENABLED=0` end-to-end.
+  E4000 + FC0012 + FC0013 + FC2580 tuner drivers — each a wire-level
+  port of osmocom librtlsdr's `tuner_*.c`. The tuner layer is
+  librtlsdr-parity in three places that previously diverged: the
+  R820T init burst chunks at 16 bytes (`NMAX_WRITES`) for the
+  NESDR v5 stall, `Open` runs an EPIPE warmup + reset retry, and
+  R82xx `SetGain` walks LNA + Mixer in lockstep (matching
+  `r82xx_set_gain`'s alternating pre-increment) instead of all-LNA
+  first. Detection follows `rtlsdr_open`'s exact probe order with
+  GPIO 4/5/6 reset pulses for non-R820T tuners. I²C bridge state
+  flips once per public method (`SetFreq`/`SetGain`/`Init`/...) —
+  the per-write toggle pattern is gone. Default builds run
+  `CGO_ENABLED=0` end-to-end.
 - **Pure-Go IMBE vocoder** (`internal/voice/imbe/` + shared
   `internal/voice/mbe/`) and **pure-Go AMBE+2 vocoder**
   (`internal/voice/ambe2/`) — both produce intelligible audio

--- a/internal/sdr/rtlsdr/purego/driver.go
+++ b/internal/sdr/rtlsdr/purego/driver.go
@@ -142,13 +142,15 @@ func (d *Driver) Open(idx int) (sdr.Device, error) {
 // tests can drive it directly with a mock transport without going
 // through the enumerator.
 //
-// Each step manages its own I²C repeater state: Detect wraps itself in
-// an on/off pair; PrepareDemod's writes are demod control transfers
-// that don't touch the I²C bridge; tuner.Init's writeBurstRaw emits
-// its own on/off pair around the burst. The fresh on-toggle inside
-// writeBurstRaw is load-bearing on NESDR v5 silicon (issue #248) —
-// the chip needs the explicit "kick" to arm the bridge for the
-// multi-byte OUT.
+// Each step manages its own I²C repeater state. Detect wraps the
+// probe sweep in a single on/off pair (off-on-return); PrepareDemod's
+// writes are demod control transfers that don't touch the I²C bridge;
+// tuner.Init opens the repeater once at the top of its body and
+// closes it on return (the per-public-method pattern shared by every
+// tuner driver). The fresh on-toggle inside tuner.Init is
+// load-bearing on NESDR v5 silicon (issue #248) — the chip needs the
+// explicit "kick" to arm the bridge for the multi-byte OUT that
+// follows, even though the demod register already holds the on-value.
 func openDevice(transport usb.Transport, desc usb.Descriptor, idx int) (*Device, error) {
 	if err := transport.ClaimInterface(0); err != nil {
 		return nil, fmt.Errorf("rtlsdr: claim interface 0: %w", err)

--- a/internal/sdr/rtlsdr/tuners/detect.go
+++ b/internal/sdr/rtlsdr/tuners/detect.go
@@ -8,11 +8,22 @@ import (
 )
 
 // Detect walks the list of supported tuner chips and returns a ready
-// [Tuner] for the first one it finds. Probe order is R820T → R828D →
-// E4000 → FC0013 → FC0012 → FC2580, matching librtlsdr's
-// rtlsdr_open detect flow. Wraps the entire probe in a single
-// SetI2CRepeater(true)/(false) pair so unnecessary repeater toggles
-// don't appear on the bus between candidate chips.
+// [Tuner] for the first one it finds.
+//
+// Probe order matches librtlsdr's rtlsdr_open exactly:
+//
+//  1. R820T  (0x34) — chip-ID byte 0x69
+//  2. R828D  (0x74) — chip-ID byte 0x69
+//  3. GPIO5 setup + pulse high→low — resets the non-R820T tuners
+//  4. FC2580 (0xAC) — chip-ID byte 0x56 (masked 0x7F)
+//  5. GPIO4 output enable — powers FC0013/E4000
+//  6. FC0013 (0xC6) — chip-ID byte 0xA3
+//  7. E4000  (0xC8) — chip-ID byte 0x40
+//  8. FC0012 (0xC6) — chip-ID byte 0xA1; if found, GPIO6 pulse high→low
+//
+// All I2C probes happen under a single SetI2CRepeater(true)/(false)
+// bracket so the bridge isn't flapping between candidates. The GPIO
+// writes are demod-block traffic and don't disturb the repeater state.
 //
 // On success the repeater is toggled OFF before return. The
 // subsequent tuner.Init burst write re-asserts it via
@@ -35,19 +46,58 @@ func Detect(d *rtl2832u.Demod) (Tuner, error) {
 	if t := detectR82xx(d); t != nil {
 		return t, nil
 	}
-	if t := detectE4000(d); t != nil {
-		return t, nil
+
+	// Reset the non-R820T tuners via GPIO5 before probing them.
+	// librtlsdr does this as a chip-enable pulse — without it, some
+	// dongles leave FC2580/FC0013 in an indeterminate state from the
+	// previous session.
+	if err := pulseGPIO(d, 5, true, false); err != nil {
+		return nil, fmt.Errorf("tuners: GPIO5 reset pulse: %w", err)
 	}
-	if t := detectFC0013(d); t != nil {
-		return t, nil
-	}
-	if t := detectFC0012(d); t != nil {
-		return t, nil
-	}
+
 	if t := detectFC2580(d); t != nil {
 		return t, nil
 	}
+
+	// FC0013 and E4000 share GPIO4 as their power-up enable in
+	// librtlsdr's bring-up.
+	if err := d.SetGPIOOutput(4); err != nil {
+		return nil, fmt.Errorf("tuners: GPIO4 output: %w", err)
+	}
+
+	if t := detectFC0013(d); t != nil {
+		return t, nil
+	}
+	if t := detectE4000(d); t != nil {
+		return t, nil
+	}
+
+	if t := detectFC0012(d); t != nil {
+		// FC0012 needs an additional GPIO6 reset pulse after I2C
+		// detection (per librtlsdr rtlsdr_open).
+		if err := pulseGPIO(d, 6, true, false); err != nil {
+			return nil, fmt.Errorf("tuners: GPIO6 FC0012 reset: %w", err)
+		}
+		return t, nil
+	}
 	return nil, ErrNoTunerDetected
+}
+
+// pulseGPIO sets the given pin to output mode and drives it through
+// the requested level sequence. Matches librtlsdr's rtlsdr_open dance
+// (typically "high then low" to assert + release a reset line). The
+// I2C repeater state is not affected — GPIO writes target the system
+// block, not the demod's bridge register.
+func pulseGPIO(d *rtl2832u.Demod, pin uint8, levels ...bool) error {
+	if err := d.SetGPIOOutput(pin); err != nil {
+		return err
+	}
+	for _, lvl := range levels {
+		if err := d.SetGPIOBit(pin, lvl); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // ErrNoTunerDetected is returned by [Detect] when none of the

--- a/internal/sdr/rtlsdr/tuners/detect_test.go
+++ b/internal/sdr/rtlsdr/tuners/detect_test.go
@@ -8,29 +8,62 @@ import (
 	"github.com/MattCheramie/GopherTrunk/internal/sdr/rtlsdr/usb"
 )
 
-// I2CRead at addr A returns 1 byte: 3 USB transfers (no pointer write,
-// auto-increment from 0).
-func expectI2CReadAddr0(addr uint8, replyByte byte) []usb.CtrlExchange {
-	out := append([]usb.CtrlExchange{}, expectRepeaterToggle(true)...)
-	out = append(out, usb.CtrlExchange{
-		In: true, BRequest: 0, WValue: uint16(addr), WIndex: uint16(rtl2832u.BlockIIC) << 8, N: 1, Reply: []byte{replyByte},
-	})
-	out = append(out, expectRepeaterToggle(false)...)
-	return out
+// expectI2CReadRegRaw is the wire sequence for one I2CReadReg call —
+// a 1-byte register-pointer write followed by a 1-byte read, no
+// surrounding repeater toggles. Use when the caller has already
+// established the repeater state (Detect's outer bracket).
+func expectI2CReadRegRaw(addr, reg, replyByte byte) []usb.CtrlExchange {
+	return []usb.CtrlExchange{
+		{In: false, BRequest: 0, WValue: uint16(addr), WIndex: uint16(rtl2832u.BlockIIC)<<8 | 0x10, Data: []byte{reg}},
+		{In: true, BRequest: 0, WValue: uint16(addr), WIndex: uint16(rtl2832u.BlockIIC) << 8, N: 1, Reply: []byte{replyByte}},
+	}
 }
 
-// I2CReadReg(addr, reg) → I2C-bridge write of reg-pointer + I2C read of 1 byte.
-func expectI2CReadReg(addr, reg, replyByte byte) []usb.CtrlExchange {
-	out := append([]usb.CtrlExchange{}, expectRepeaterToggle(true)...)
-	out = append(out, usb.CtrlExchange{
-		In: false, BRequest: 0, WValue: uint16(addr), WIndex: uint16(rtl2832u.BlockIIC)<<8 | 0x10, Data: []byte{reg},
-	})
-	out = append(out, expectRepeaterToggle(false)...)
-	out = append(out, expectRepeaterToggle(true)...)
-	out = append(out, usb.CtrlExchange{
-		In: true, BRequest: 0, WValue: uint16(addr), WIndex: uint16(rtl2832u.BlockIIC) << 8, N: 1, Reply: []byte{replyByte},
-	})
-	out = append(out, expectRepeaterToggle(false)...)
+// expectSetGPIOOutput is the read-modify-write sequence Demod.SetGPIOOutput
+// emits to enable the given pin as a system-block output. Reads GPD and
+// GPOE (returning the supplied starting bytes), then writes back the
+// pin-cleared / pin-set values. Matches gpio.go:setGPIOOutputLocked.
+func expectSetGPIOOutput(pin, gpdStart, gpoeStart byte) []usb.CtrlExchange {
+	const (
+		sysGPOE uint16 = 0x3003
+		sysGPD  uint16 = 0x3004
+	)
+	gpdNew := gpdStart &^ (1 << pin)
+	gpoeNew := gpoeStart | (1 << pin)
+	return []usb.CtrlExchange{
+		{In: true, BRequest: 0, WValue: sysGPD, WIndex: 0x0200, N: 1, Reply: []byte{gpdStart}},
+		{In: false, BRequest: 0, WValue: sysGPD, WIndex: 0x0210, Data: []byte{gpdNew}},
+		{In: true, BRequest: 0, WValue: sysGPOE, WIndex: 0x0200, N: 1, Reply: []byte{gpoeStart}},
+		{In: false, BRequest: 0, WValue: sysGPOE, WIndex: 0x0210, Data: []byte{gpoeNew}},
+	}
+}
+
+// expectSetGPIOBit is the read-modify-write Demod.SetGPIOBit emits.
+// Reads GPO (returning gpoStart), writes back with the pin toggled to
+// `high`. Matches gpio.go:setGPIOBitLocked.
+func expectSetGPIOBit(pin byte, high bool, gpoStart byte) []usb.CtrlExchange {
+	const sysGPO uint16 = 0x3001
+	var v byte = gpoStart
+	if high {
+		v |= 1 << pin
+	} else {
+		v &^= 1 << pin
+	}
+	return []usb.CtrlExchange{
+		{In: true, BRequest: 0, WValue: sysGPO, WIndex: 0x0200, N: 1, Reply: []byte{gpoStart}},
+		{In: false, BRequest: 0, WValue: sysGPO, WIndex: 0x0210, Data: []byte{v}},
+	}
+}
+
+// expectGPIOPulse is the full SetGPIOOutput + per-level SetGPIOBit
+// sequence Detect's pulseGPIO helper emits. All starting register
+// reads return 0x00 (mock has no state — production reads what we
+// say it reads).
+func expectGPIOPulse(pin byte, levels ...bool) []usb.CtrlExchange {
+	out := append([]usb.CtrlExchange{}, expectSetGPIOOutput(pin, 0x00, 0x00)...)
+	for _, lvl := range levels {
+		out = append(out, expectSetGPIOBit(pin, lvl, 0x00)...)
+	}
 	return out
 }
 
@@ -38,9 +71,9 @@ func TestDetect_R820T2MatchesAt0x34(t *testing.T) {
 	// Detect enables the I2C repeater, probes 0x34 (returns
 	// bit-reversed 0x69 = 0x96), then toggles the repeater OFF on
 	// return. The OFF-on-return contract is load-bearing for issue
-	// #248: it leaves writeBurstRaw's leading SetI2CRepeater(true)
-	// as a real wire write rather than a cache-skip, which the
-	// chip's I²C bridge needs to arm the next multi-byte OUT.
+	// #248: it leaves R82xx.Init's leading SetI2CRepeater(true) as
+	// a real wire write rather than a cache-skip, which the chip's
+	// I²C bridge needs to arm the next multi-byte OUT.
 	m := usb.NewMockTransport()
 	m.Script = append(m.Script, expectRepeaterToggle(true)...)
 	m.Script = append(m.Script, usb.CtrlExchange{
@@ -62,18 +95,35 @@ func TestDetect_R820T2MatchesAt0x34(t *testing.T) {
 }
 
 func TestDetect_FallsThroughToE4000(t *testing.T) {
-	// Detect wraps the whole probe sweep in one SetI2CRepeater on/off
-	// pair. Inside, each detect helper emits raw I²C transfers (no
-	// per-helper repeater toggles). Detection order:
-	// R820T@0x34 → R820T@0x74 → E4000@0xC8 dummy → E4000 reg 0x02 →
-	// match → return with the trailing repeater-off (issue #248).
+	// Pins librtlsdr's rtlsdr_open probe order (see detect.go Detect):
+	//   1. SetI2CRepeater(true)
+	//   2. R820T@0x34 chip-ID read → miss
+	//   3. R828D@0x74 chip-ID read → miss
+	//   4. GPIO5 reset pulse: out + high + low
+	//   5. FC2580@0xAC reg 0x01 read → miss
+	//   6. GPIO4 output enable (no pulse — librtlsdr just enables)
+	//   7. FC0013@0xC6 chip-ID read → miss
+	//   8. E4000@0xC8 dummy chip-ID read (mock returns 0x00)
+	//   9. E4000@0xC8 reg 0x02 read → 0x40 → match
+	//  10. SetI2CRepeater(false)
 	m := usb.NewMockTransport()
 	m.Script = append(m.Script, expectRepeaterToggle(true)...)
-	m.Script = append(m.Script, usb.CtrlExchange{In: true, BRequest: 0, WValue: 0x0034, WIndex: uint16(rtl2832u.BlockIIC) << 8, N: 1, Reply: []byte{0x00}})
-	m.Script = append(m.Script, usb.CtrlExchange{In: true, BRequest: 0, WValue: 0x0074, WIndex: uint16(rtl2832u.BlockIIC) << 8, N: 1, Reply: []byte{0x00}})
-	m.Script = append(m.Script, usb.CtrlExchange{In: true, BRequest: 0, WValue: 0x00C8, WIndex: uint16(rtl2832u.BlockIIC) << 8, N: 1, Reply: []byte{0x00}})
-	m.Script = append(m.Script, usb.CtrlExchange{In: false, BRequest: 0, WValue: 0x00C8, WIndex: uint16(rtl2832u.BlockIIC)<<8 | 0x10, Data: []byte{0x02}})
-	m.Script = append(m.Script, usb.CtrlExchange{In: true, BRequest: 0, WValue: 0x00C8, WIndex: uint16(rtl2832u.BlockIIC) << 8, N: 1, Reply: []byte{0x40}})
+	// R820T / R828D both miss.
+	m.Script = append(m.Script, expectI2CReadRaw(0x34, 1, []byte{0x00}))
+	m.Script = append(m.Script, expectI2CReadRaw(0x74, 1, []byte{0x00}))
+	// GPIO5 pulse: high → low.
+	m.Script = append(m.Script, expectGPIOPulse(5, true, false)...)
+	// FC2580 miss — full read-reg sequence.
+	m.Script = append(m.Script, expectI2CReadRegRaw(0xAC, 0x01, 0x00)...)
+	// GPIO4 output enable (no level writes — librtlsdr only flips
+	// the direction, leaves the value undriven).
+	m.Script = append(m.Script, expectSetGPIOOutput(4, 0x00, 0x00)...)
+	// FC0013 miss.
+	m.Script = append(m.Script, expectI2CReadRaw(0xC6, 1, []byte{0x00}))
+	// E4000 dummy read (NAK wakeup) — mock returns 0x00.
+	m.Script = append(m.Script, expectI2CReadRaw(0xC8, 1, []byte{0x00}))
+	// E4000 chip-ID match.
+	m.Script = append(m.Script, expectI2CReadRegRaw(0xC8, 0x02, 0x40)...)
 	m.Script = append(m.Script, expectRepeaterToggle(false)...)
 
 	demod := rtl2832u.New(m)

--- a/internal/sdr/rtlsdr/tuners/e4k.go
+++ b/internal/sdr/rtlsdr/tuners/e4k.go
@@ -124,6 +124,10 @@ func (e *E4000) Init() error {
 	if e.initDone {
 		return nil
 	}
+	if err := e.demod.SetI2CRepeater(true); err != nil {
+		return err
+	}
+	defer e.demod.SetI2CRepeater(false)
 	// Dummy read — librtlsdr does this to wake the I2C engine; the
 	// first transaction is expected to NAK. We swallow the error.
 	_, _ = e.readReg(0)
@@ -183,6 +187,10 @@ func (e *E4000) Standby() error {
 	if !e.initDone {
 		return nil
 	}
+	if err := e.demod.SetI2CRepeater(true); err != nil {
+		return err
+	}
+	defer e.demod.SetI2CRepeater(false)
 	// Clear the master-enable bits — the chip drops into power-down.
 	if err := e.writeReg(e4kRegMaster1, 0x00); err != nil {
 		return fmt.Errorf("e4k standby: %w", err)
@@ -204,6 +212,10 @@ func (e *E4000) SetFreq(hz uint32) error {
 	if hz < 50_000_000 || hz > 2_200_000_000 {
 		return &ErrUnsupportedFreq{Hz: hz, MinHz: 50_000_000, MaxHz: 2_200_000_000, TunerStr: "E4000"}
 	}
+	if err := e.demod.SetI2CRepeater(true); err != nil {
+		return err
+	}
+	defer e.demod.SetI2CRepeater(false)
 	e.freqHz = hz
 
 	rng := e4kPLLRanges[len(e4kPLLRanges)-1]
@@ -249,6 +261,10 @@ func (e *E4000) SetBandwidth(hz uint32) error {
 	if !e.initDone {
 		return errors.New("e4k: Init not called")
 	}
+	if err := e.demod.SetI2CRepeater(true); err != nil {
+		return err
+	}
+	defer e.demod.SetI2CRepeater(false)
 	e.bwHz = hz
 	val := byte(0x0F) // widest channel filter (~9 MHz)
 	switch {
@@ -274,6 +290,10 @@ func (e *E4000) SetGain(tenthDB int) error {
 	if !e.manual || tenthDB < 0 {
 		return nil
 	}
+	if err := e.demod.SetI2CRepeater(true); err != nil {
+		return err
+	}
+	defer e.demod.SetI2CRepeater(false)
 	idx := nearestGainIndex(e4kLNAGains, tenthDB)
 	cur, err := e.readReg(e4kRegGain1)
 	if err != nil {
@@ -289,6 +309,10 @@ func (e *E4000) SetGainMode(manual bool) error {
 	if !e.initDone {
 		return errors.New("e4k: Init not called")
 	}
+	if err := e.demod.SetI2CRepeater(true); err != nil {
+		return err
+	}
+	defer e.demod.SetI2CRepeater(false)
 	e.manual = manual
 	cur, err := e.readReg(e4kRegAGC1)
 	if err != nil {
@@ -305,19 +329,13 @@ func (e *E4000) SetGainMode(manual bool) error {
 // ----------------------------------------------------------------------
 // Internals
 
+// writeReg / readReg are private I2C plumbing. Callers (public
+// methods) own the SetI2CRepeater bracket — librtlsdr's pattern.
 func (e *E4000) writeReg(addr, val byte) error {
-	if err := e.demod.SetI2CRepeater(true); err != nil {
-		return err
-	}
-	defer e.demod.SetI2CRepeater(false)
 	return e.demod.I2CWriteReg(e4kI2CAddr, addr, val)
 }
 
 func (e *E4000) readReg(addr byte) (byte, error) {
-	if err := e.demod.SetI2CRepeater(true); err != nil {
-		return 0, err
-	}
-	defer e.demod.SetI2CRepeater(false)
 	return e.demod.I2CReadReg(e4kI2CAddr, addr)
 }
 

--- a/internal/sdr/rtlsdr/tuners/e4k_test.go
+++ b/internal/sdr/rtlsdr/tuners/e4k_test.go
@@ -186,11 +186,15 @@ func TestE4000SetFreqBoundaryInclusivity(t *testing.T) {
 // touched 0x0D. A regression to that layout fails this script's
 // strict-order match.
 func TestE4000_SetFreq_WireBytes(t *testing.T) {
+	// SetFreq is one public method = one repeater on/off pair around
+	// all four register writes (Z, X low, X high, band/R).
 	var script []usb.CtrlExchange
-	script = append(script, expectI2CWrite(e4kI2CAddr, []byte{0x09, 0x6F})...) // Z
-	script = append(script, expectI2CWrite(e4kI2CAddr, []byte{0x0A, 0x71})...) // X low
-	script = append(script, expectI2CWrite(e4kI2CAddr, []byte{0x0B, 0x1C})...) // X high
-	script = append(script, expectI2CWrite(e4kI2CAddr, []byte{0x0D, 0x0D})...) // band/R
+	script = append(script, expectRepeaterToggle(true)...)
+	script = append(script, expectI2CWriteRaw(e4kI2CAddr, []byte{0x09, 0x6F})) // Z
+	script = append(script, expectI2CWriteRaw(e4kI2CAddr, []byte{0x0A, 0x71})) // X low
+	script = append(script, expectI2CWriteRaw(e4kI2CAddr, []byte{0x0B, 0x1C})) // X high
+	script = append(script, expectI2CWriteRaw(e4kI2CAddr, []byte{0x0D, 0x0D})) // band/R
+	script = append(script, expectRepeaterToggle(false)...)
 	m := usb.NewMockTransport()
 	m.Script = script
 	e := NewE4000(rtl2832u.New(m))

--- a/internal/sdr/rtlsdr/tuners/fc0012.go
+++ b/internal/sdr/rtlsdr/tuners/fc0012.go
@@ -63,19 +63,20 @@ func (f *FC0012) Gains() []int {
 	return out
 }
 
-// Init walks the 20-register init flood plus the chip's soft-reset
-// dance. librtlsdr ships a 4-bit current control quirk: write reg
-// 0x0C twice (0x05 then 0x00) before the rest of the array.
+// Init writes the 20-register init flood (regs 1..20). The chip-reset
+// dance — GPIO 5 high → low → high — happens once in detect.go before
+// the I2C probe, matching librtlsdr's rtlsdr_open ordering. The two
+// 0x0C writes the pre-fix code emitted here ("soft-reset on/off") are
+// NOT in librtlsdr's fc0012_init; the chip reset is a GPIO pulse, not
+// a register write, so we drop them.
 func (f *FC0012) Init() error {
 	if f.initDone {
 		return nil
 	}
-	if err := f.writeReg(0x0C, 0x05); err != nil {
-		return fmt.Errorf("fc0012 init soft-reset on: %w", err)
+	if err := f.demod.SetI2CRepeater(true); err != nil {
+		return err
 	}
-	if err := f.writeReg(0x0C, 0x00); err != nil {
-		return fmt.Errorf("fc0012 init soft-reset off: %w", err)
-	}
+	defer f.demod.SetI2CRepeater(false)
 	for i, v := range fc0012InitArray {
 		if err := f.writeReg(uint8(i+1), v); err != nil {
 			return fmt.Errorf("fc0012 init reg 0x%02x: %w", i+1, err)
@@ -92,6 +93,10 @@ func (f *FC0012) Standby() error {
 	if !f.initDone {
 		return nil
 	}
+	if err := f.demod.SetI2CRepeater(true); err != nil {
+		return err
+	}
+	defer f.demod.SetI2CRepeater(false)
 	if err := f.writeReg(0x06, 0x0F); err != nil {
 		return fmt.Errorf("fc0012 standby: %w", err)
 	}
@@ -115,6 +120,10 @@ func (f *FC0012) SetFreq(hz uint32) error {
 	if hz < 37_000_000 || hz > 1_700_000_000 {
 		return &ErrUnsupportedFreq{Hz: hz, MinHz: 37_000_000, MaxHz: 1_700_000_000, TunerStr: "FC0012"}
 	}
+	if err := f.demod.SetI2CRepeater(true); err != nil {
+		return err
+	}
+	defer f.demod.SetI2CRepeater(false)
 	f.freqHz = hz
 
 	multi, reg5, reg6 := fc0012BandSelect(hz)
@@ -183,6 +192,10 @@ func (f *FC0012) SetGain(tenthDB int) error {
 	if !f.manual || tenthDB < 0 {
 		return nil
 	}
+	if err := f.demod.SetI2CRepeater(true); err != nil {
+		return err
+	}
+	defer f.demod.SetI2CRepeater(false)
 	idx := fc0012NearestGainIndex(tenthDB)
 	cur, err := f.readReg(0x13)
 	if err != nil {
@@ -198,6 +211,10 @@ func (f *FC0012) SetGainMode(manual bool) error {
 	if !f.initDone {
 		return errors.New("fc0012: Init not called")
 	}
+	if err := f.demod.SetI2CRepeater(true); err != nil {
+		return err
+	}
+	defer f.demod.SetI2CRepeater(false)
 	f.manual = manual
 	cur, err := f.readReg(0x06)
 	if err != nil {
@@ -268,43 +285,23 @@ func abs(x int) int {
 	return x
 }
 
-// writeReg is the FC0012 single-byte I2C write helper. Wraps each
-// burst in SetI2CRepeater on/off — librtlsdr's tuner_fc0012 calls
-// the chip through an explicit I2C-bridge state, so we do the same.
-// The cached-toggle behavior in rtl2832u.Demod elides redundant
-// toggles for back-to-back operations from the same caller.
+// writeReg / readReg are private I2C plumbing. Callers (public
+// methods) own the SetI2CRepeater bracket — librtlsdr's pattern.
+// FC0012 doesn't do the bit-reverse trick the R820T family does,
+// so raw bytes come back from the bridge.
 func (f *FC0012) writeReg(addr, val byte) error {
-	if err := f.demod.SetI2CRepeater(true); err != nil {
-		return err
-	}
-	defer f.demod.SetI2CRepeater(false)
 	return f.demod.I2CWriteReg(fc0012I2CAddr, addr, val)
 }
 
-// readReg reads one byte from the chip. FC0012 doesn't do the
-// bit-reverse trick the R820T family does, so raw bytes come back
-// from the bridge.
 func (f *FC0012) readReg(addr byte) (byte, error) {
-	if err := f.demod.SetI2CRepeater(true); err != nil {
-		return 0, err
-	}
-	defer f.demod.SetI2CRepeater(false)
 	return f.demod.I2CReadReg(fc0012I2CAddr, addr)
 }
 
-// detectFC0012 enables the chip via GPIO 5 (required by the bus
-// layout on the dongles that ship with FC0012), reads the chip-ID
-// byte at addr 0, and returns a ready driver if the response matches.
-// Called from the unified [Detect] orchestrator.
+// detectFC0012 reads the chip-ID byte at addr 0 and returns a ready
+// driver if the response matches. The orchestrator in detect.go runs
+// the GPIO 5 reset pulse + GPIO 6 chip-enable pulse before this call,
+// matching librtlsdr's rtlsdr_open order — we just see the I2C side.
 func detectFC0012(d *rtl2832u.Demod) Tuner {
-	// FC0012 enable: GPIO 5 must be high before the bus responds.
-	// librtlsdr does this in rtlsdr_open before probing.
-	if err := d.SetGPIOOutput(fc0012GPIOEnable); err != nil {
-		return nil
-	}
-	if err := d.SetGPIOBit(fc0012GPIOEnable, true); err != nil {
-		return nil
-	}
 	out, err := d.I2CRead(fc0012I2CAddr, 1)
 	if err != nil || len(out) == 0 {
 		return nil

--- a/internal/sdr/rtlsdr/tuners/fc0012_test.go
+++ b/internal/sdr/rtlsdr/tuners/fc0012_test.go
@@ -9,9 +9,18 @@ import (
 )
 
 // expectI2CWriteReg returns the full script for one I2CWriteReg
-// (=2-byte I2C burst wrapped in repeater on/off).
+// (=2-byte I2C burst wrapped in repeater on/off). Use for single-write
+// public methods; for multi-write sequences inside one public call use
+// expectI2CWriteRegRaw to skip the per-write toggle pair.
 func expectI2CWriteReg(addr, reg, val byte) []usb.CtrlExchange {
 	return expectI2CWrite(addr, []byte{reg, val})
+}
+
+// expectI2CWriteRegRaw is the single ControlOut for one register write
+// without surrounding toggles — for when many writes happen inside one
+// public-method bracket (librtlsdr-style).
+func expectI2CWriteRegRaw(addr, reg, val byte) usb.CtrlExchange {
+	return expectI2CWriteRaw(addr, []byte{reg, val})
 }
 
 func TestFC0012_TypeAndIF(t *testing.T) {
@@ -38,17 +47,19 @@ func TestFC0012_GainsLadder(t *testing.T) {
 	}
 }
 
-func TestFC0012_InitDoesSoftResetThenFlood(t *testing.T) {
-	// Init = 2 soft-reset writes + 20 init-array writes (one I2C
-	// burst per write, since FC0012's I2CWriteReg sends a 2-byte
-	// burst at a time).
+func TestFC0012_InitWritesFlood(t *testing.T) {
+	// FC0012.Init writes the 20-register init array (reg 1..20) inside
+	// a single repeater on/off pair. The two 0x0C "soft-reset" writes
+	// the pre-fix code emitted are NOT in librtlsdr's fc0012_init; the
+	// chip reset is the GPIO5 high→low→high pulse, which detect.go
+	// emits before this Init runs (not exercised by this test —
+	// detect_test.go pins the GPIO sequence).
 	m := usb.NewMockTransport()
-	// Soft reset (0x0C ← 0x05 then 0x0C ← 0x00).
-	m.Script = append(m.Script, expectI2CWriteReg(fc0012I2CAddr, 0x0C, 0x05)...)
-	m.Script = append(m.Script, expectI2CWriteReg(fc0012I2CAddr, 0x0C, 0x00)...)
+	m.Script = append(m.Script, expectRepeaterToggle(true)...)
 	for i, v := range fc0012InitArray {
-		m.Script = append(m.Script, expectI2CWriteReg(fc0012I2CAddr, byte(i+1), v)...)
+		m.Script = append(m.Script, expectI2CWriteRegRaw(fc0012I2CAddr, byte(i+1), v))
 	}
+	m.Script = append(m.Script, expectRepeaterToggle(false)...)
 	d := rtl2832u.New(m)
 	f := NewFC0012(d)
 	if err := f.Init(); err != nil {
@@ -64,11 +75,11 @@ func TestFC0012_InitDoesSoftResetThenFlood(t *testing.T) {
 
 func TestFC0012_InitIdempotent(t *testing.T) {
 	m := usb.NewMockTransport()
-	m.Script = append(m.Script, expectI2CWriteReg(fc0012I2CAddr, 0x0C, 0x05)...)
-	m.Script = append(m.Script, expectI2CWriteReg(fc0012I2CAddr, 0x0C, 0x00)...)
+	m.Script = append(m.Script, expectRepeaterToggle(true)...)
 	for i, v := range fc0012InitArray {
-		m.Script = append(m.Script, expectI2CWriteReg(fc0012I2CAddr, byte(i+1), v)...)
+		m.Script = append(m.Script, expectI2CWriteRegRaw(fc0012I2CAddr, byte(i+1), v))
 	}
+	m.Script = append(m.Script, expectRepeaterToggle(false)...)
 	d := rtl2832u.New(m)
 	f := NewFC0012(d)
 	if err := f.Init(); err != nil {

--- a/internal/sdr/rtlsdr/tuners/fc0013.go
+++ b/internal/sdr/rtlsdr/tuners/fc0013.go
@@ -70,6 +70,10 @@ func (f *FC0013) Init() error {
 	if f.initDone {
 		return nil
 	}
+	if err := f.demod.SetI2CRepeater(true); err != nil {
+		return err
+	}
+	defer f.demod.SetI2CRepeater(false)
 	// Soft reset: bit 3 of reg 0x0C set then clear.
 	if err := f.writeReg(0x0C, 0x05); err != nil {
 		return fmt.Errorf("fc0013 init soft-reset on: %w", err)
@@ -90,6 +94,10 @@ func (f *FC0013) Standby() error {
 	if !f.initDone {
 		return nil
 	}
+	if err := f.demod.SetI2CRepeater(true); err != nil {
+		return err
+	}
+	defer f.demod.SetI2CRepeater(false)
 	if err := f.writeReg(0x06, 0x0F); err != nil {
 		return fmt.Errorf("fc0013 standby: %w", err)
 	}
@@ -110,6 +118,10 @@ func (f *FC0013) SetFreq(hz uint32) error {
 	if hz < 22_000_000 || hz > 1_700_000_000 {
 		return &ErrUnsupportedFreq{Hz: hz, MinHz: 22_000_000, MaxHz: 1_700_000_000, TunerStr: "FC0013"}
 	}
+	if err := f.demod.SetI2CRepeater(true); err != nil {
+		return err
+	}
+	defer f.demod.SetI2CRepeater(false)
 	f.freqHz = hz
 
 	multi, reg5, reg6 := fc0013BandSelect(hz)
@@ -172,6 +184,10 @@ func (f *FC0013) SetGain(tenthDB int) error {
 	if !f.manual || tenthDB < 0 {
 		return nil
 	}
+	if err := f.demod.SetI2CRepeater(true); err != nil {
+		return err
+	}
+	defer f.demod.SetI2CRepeater(false)
 	idx := nearestGainIndex(fc0013LNAGains, tenthDB)
 	cur, err := f.readReg(0x14)
 	if err != nil {
@@ -187,6 +203,10 @@ func (f *FC0013) SetGainMode(manual bool) error {
 	if !f.initDone {
 		return errors.New("fc0013: Init not called")
 	}
+	if err := f.demod.SetI2CRepeater(true); err != nil {
+		return err
+	}
+	defer f.demod.SetI2CRepeater(false)
 	f.manual = manual
 	cur, err := f.readReg(0x0D)
 	if err != nil {
@@ -230,19 +250,13 @@ func fc0013BandSelect(hz uint32) (multi uint32, reg5, reg6 byte) {
 	}
 }
 
+// writeReg / readReg are private I2C plumbing. Callers (public
+// methods) own the SetI2CRepeater bracket — librtlsdr's pattern.
 func (f *FC0013) writeReg(addr, val byte) error {
-	if err := f.demod.SetI2CRepeater(true); err != nil {
-		return err
-	}
-	defer f.demod.SetI2CRepeater(false)
 	return f.demod.I2CWriteReg(fc0013I2CAddr, addr, val)
 }
 
 func (f *FC0013) readReg(addr byte) (byte, error) {
-	if err := f.demod.SetI2CRepeater(true); err != nil {
-		return 0, err
-	}
-	defer f.demod.SetI2CRepeater(false)
 	return f.demod.I2CReadReg(fc0013I2CAddr, addr)
 }
 

--- a/internal/sdr/rtlsdr/tuners/fc0013_test.go
+++ b/internal/sdr/rtlsdr/tuners/fc0013_test.go
@@ -30,12 +30,18 @@ func TestFC0013_GainsLadder26Steps(t *testing.T) {
 }
 
 func TestFC0013_InitWritesSoftResetThenFlood(t *testing.T) {
+	// FC0013.Init is one public method = one repeater on/off pair
+	// around all 23 inner writes (2 soft-reset + 21-entry init flood).
+	// FC0013 KEEPS the 0x0C soft-reset; only FC0012's was spurious
+	// (librtlsdr's fc0013_init does the 0x05/0x00 sequence too).
 	m := usb.NewMockTransport()
-	m.Script = append(m.Script, expectI2CWriteReg(fc0013I2CAddr, 0x0C, 0x05)...)
-	m.Script = append(m.Script, expectI2CWriteReg(fc0013I2CAddr, 0x0C, 0x00)...)
+	m.Script = append(m.Script, expectRepeaterToggle(true)...)
+	m.Script = append(m.Script, expectI2CWriteRegRaw(fc0013I2CAddr, 0x0C, 0x05))
+	m.Script = append(m.Script, expectI2CWriteRegRaw(fc0013I2CAddr, 0x0C, 0x00))
 	for i, v := range fc0013InitArray {
-		m.Script = append(m.Script, expectI2CWriteReg(fc0013I2CAddr, byte(i+1), v)...)
+		m.Script = append(m.Script, expectI2CWriteRegRaw(fc0013I2CAddr, byte(i+1), v))
 	}
+	m.Script = append(m.Script, expectRepeaterToggle(false)...)
 	f := NewFC0013(rtl2832u.New(m))
 	if err := f.Init(); err != nil {
 		t.Fatalf("Init: %v", err)

--- a/internal/sdr/rtlsdr/tuners/fc2580.go
+++ b/internal/sdr/rtlsdr/tuners/fc2580.go
@@ -100,6 +100,10 @@ func (f *FC2580) Init() error {
 	if f.initDone {
 		return nil
 	}
+	if err := f.demod.SetI2CRepeater(true); err != nil {
+		return err
+	}
+	defer f.demod.SetI2CRepeater(false)
 	for i, w := range fc2580InitArray {
 		if err := f.writeReg(w.addr, w.val); err != nil {
 			return fmt.Errorf("fc2580 init step %d (0x%02x): %w", i, w.addr, err)
@@ -113,6 +117,10 @@ func (f *FC2580) Standby() error {
 	if !f.initDone {
 		return nil
 	}
+	if err := f.demod.SetI2CRepeater(true); err != nil {
+		return err
+	}
+	defer f.demod.SetI2CRepeater(false)
 	// Power down — reg 0x02 bit 7 enters sleep.
 	if err := f.writeReg(0x02, 0x0E); err != nil {
 		return fmt.Errorf("fc2580 standby: %w", err)
@@ -134,6 +142,10 @@ func (f *FC2580) SetFreq(hz uint32) error {
 	if hz < 50_000_000 || hz > 2_600_000_000 {
 		return &ErrUnsupportedFreq{Hz: hz, MinHz: 50_000_000, MaxHz: 2_600_000_000, TunerStr: "FC2580"}
 	}
+	if err := f.demod.SetI2CRepeater(true); err != nil {
+		return err
+	}
+	defer f.demod.SetI2CRepeater(false)
 	f.freqHz = hz
 
 	band := fc2580Bands[len(fc2580Bands)-1]
@@ -185,6 +197,10 @@ func (f *FC2580) SetGain(tenthDB int) error {
 	if !f.manual || tenthDB < 0 {
 		return nil
 	}
+	if err := f.demod.SetI2CRepeater(true); err != nil {
+		return err
+	}
+	defer f.demod.SetI2CRepeater(false)
 	idx := nearestGainIndex(fc2580Gains, tenthDB)
 	// Reg 0x49 = LNA gain stage on FC2580.
 	return f.writeReg(0x49, byte(idx&0x07))
@@ -194,6 +210,10 @@ func (f *FC2580) SetGainMode(manual bool) error {
 	if !f.initDone {
 		return errors.New("fc2580: Init not called")
 	}
+	if err := f.demod.SetI2CRepeater(true); err != nil {
+		return err
+	}
+	defer f.demod.SetI2CRepeater(false)
 	f.manual = manual
 	cur, err := f.readReg(0x45)
 	if err != nil {
@@ -210,19 +230,13 @@ func (f *FC2580) SetGainMode(manual bool) error {
 // ----------------------------------------------------------------------
 // Internals
 
+// writeReg / readReg are private I2C plumbing. Callers (public
+// methods) own the SetI2CRepeater bracket — librtlsdr's pattern.
 func (f *FC2580) writeReg(addr, val byte) error {
-	if err := f.demod.SetI2CRepeater(true); err != nil {
-		return err
-	}
-	defer f.demod.SetI2CRepeater(false)
 	return f.demod.I2CWriteReg(fc2580I2CAddr, addr, val)
 }
 
 func (f *FC2580) readReg(addr byte) (byte, error) {
-	if err := f.demod.SetI2CRepeater(true); err != nil {
-		return 0, err
-	}
-	defer f.demod.SetI2CRepeater(false)
 	return f.demod.I2CReadReg(fc2580I2CAddr, addr)
 }
 

--- a/internal/sdr/rtlsdr/tuners/r82xx.go
+++ b/internal/sdr/rtlsdr/tuners/r82xx.go
@@ -105,9 +105,11 @@ func detectR82xx(d *rtl2832u.Demod) Tuner {
 // disable Zero-IF mode, enable only the In-phase ADC input, program
 // the 3.57 MHz IF frequency, and enable spectrum inversion. Mirrors
 // the RTLSDR_TUNER_R820T / R828D switch arm in librtlsdr's
-// rtlsdr_open. Callers must invoke this between tuners.Detect (which
-// leaves the I2C repeater on) and Init; PrepareDemod does not touch
-// the repeater so the contract is preserved.
+// rtlsdr_open. All four go through the RTL2832U demod-register path,
+// not the I²C bridge — PrepareDemod intentionally does not touch
+// the SetI2CRepeater state so the post-Detect off-state (from
+// detect.go's defer) is preserved for Init's leading on-toggle
+// (issue #248).
 func (r *R82xx) PrepareDemod() error {
 	if err := r.demod.WriteDemodReg(1, 0xB1, 0x1A, 1); err != nil {
 		return fmt.Errorf("r82xx prep: disable Zero-IF: %w", err)
@@ -124,13 +126,18 @@ func (r *R82xx) PrepareDemod() error {
 	return nil
 }
 
-// Init walks the librtlsdr power-on sequence: write the 27-byte init
-// flood to registers 0x05..0x1F, then perform the standard tuner-side
-// soft-reset by toggling the demod's I2C bridge.
+// Init walks the librtlsdr power-on sequence: open the I²C repeater
+// (a fresh wire write — load-bearing on NESDR v5 silicon, issue
+// #248), write the 27-byte init flood to registers 0x05..0x1F as
+// 16-byte chunks (NMAX_WRITES parity), close the repeater on return.
 func (r *R82xx) Init() error {
 	if r.initDone {
 		return nil
 	}
+	if err := r.demod.SetI2CRepeater(true); err != nil {
+		return err
+	}
+	defer r.demod.SetI2CRepeater(false)
 	// Prime the shadow with the init values; the burst write below
 	// makes them real.
 	for i, v := range r82xxInitArray {
@@ -149,6 +156,10 @@ func (r *R82xx) Standby() error {
 	if !r.initDone {
 		return nil
 	}
+	if err := r.demod.SetI2CRepeater(true); err != nil {
+		return err
+	}
+	defer r.demod.SetI2CRepeater(false)
 	// Sequence taken from osmocom r82xx_standby — power down LDO,
 	// PLL, mixer, LNA, VGA, filter in one burst-style write set.
 	standbyRegs := []struct {
@@ -189,6 +200,10 @@ func (r *R82xx) SetFreq(hz uint32) error {
 	if hz < 24_000_000 || hz > 1_766_000_000 {
 		return &ErrUnsupportedFreq{Hz: hz, MinHz: 24_000_000, MaxHz: 1_766_000_000, TunerStr: r.chipType.String()}
 	}
+	if err := r.demod.SetI2CRepeater(true); err != nil {
+		return err
+	}
+	defer r.demod.SetI2CRepeater(false)
 	r.freqHz = hz
 	if err := r.setMux(hz); err != nil {
 		return fmt.Errorf("r82xx SetFreq: setMux: %w", err)
@@ -207,6 +222,10 @@ func (r *R82xx) SetBandwidth(hz uint32) error {
 	if !r.initDone {
 		return errors.New("r82xx: Init not called")
 	}
+	if err := r.demod.SetI2CRepeater(true); err != nil {
+		return err
+	}
+	defer r.demod.SetI2CRepeater(false)
 	if hz == 0 {
 		hz = 6_000_000 // librtlsdr's default when nothing else is set
 	}
@@ -256,6 +275,10 @@ func (r *R82xx) SetGain(tenthDB int) error {
 		// callers use it as a sentinel.
 		return nil
 	}
+	if err := r.demod.SetI2CRepeater(true); err != nil {
+		return err
+	}
+	defer r.demod.SetI2CRepeater(false)
 	// Alternate LNA and mixer increments, pre-incrementing the index
 	// each step. Matches librtlsdr's r82xx_set_gain — the published
 	// gain ladder (r82xxGainsTenthDB) is the alternating sum, so this
@@ -308,6 +331,10 @@ func (r *R82xx) SetGainMode(manual bool) error {
 	if !r.initDone {
 		return errors.New("r82xx: Init not called")
 	}
+	if err := r.demod.SetI2CRepeater(true); err != nil {
+		return err
+	}
+	defer r.demod.SetI2CRepeater(false)
 	r.manual = manual
 	// LNA gain mode: reg 0x05 bit 4 clear = AGC; set = manual.
 	lnaBit := byte(0x00)
@@ -493,21 +520,19 @@ func (r *R82xx) writeRegMask(addr uint8, val, mask byte) error {
 }
 
 // writeBurstRaw bypasses the shadow cache and emits one or more I2C
-// burst writes (address byte followed by data bytes) wrapped in a
-// single I2C-repeater on/off pair.
+// burst writes (address byte followed by data bytes). The caller is
+// responsible for SetI2CRepeater(true)/(false) bracketing — each
+// public method (Init, SetFreq, ...) does this once around its whole
+// body, matching librtlsdr's rtlsdr_set_tuner_* wrap pattern.
 //
 // Data is split into chunks of at most r82xxBurstMaxData bytes to
 // mirror librtlsdr's r82xx_write (NMAX_WRITES = 16). Going beyond
 // that limit stalls the very first multi-byte OUT on some NESDR v5
 // dongles — observed as libusb EPIPE on the 27-byte init flood
-// (issue #248). Each chunk is its own control-OUT under the same
-// repeater session; the register pointer advances by the chunk
-// length between chunks, which matches the chip's auto-increment.
+// (issue #248). Each chunk is its own control-OUT; the register
+// pointer advances by the chunk length between chunks, which matches
+// the chip's auto-increment.
 func (r *R82xx) writeBurstRaw(addr uint8, data []byte) error {
-	if err := r.demod.SetI2CRepeater(true); err != nil {
-		return err
-	}
-	defer r.demod.SetI2CRepeater(false)
 	for pos := 0; pos < len(data); {
 		size := len(data) - pos
 		if size > r82xxBurstMaxData {
@@ -528,12 +553,9 @@ func (r *R82xx) writeBurstRaw(addr uint8, data []byte) error {
 // chip auto-increments so a single read returns regs 0x00..0x00+n-1.
 // Bytes are bit-reversed on the wire; we un-reverse before returning.
 // The result is also stored into the shadow so callers querying via
-// the cache see fresh values for the read-only block.
+// the cache see fresh values for the read-only block. Caller owns
+// the SetI2CRepeater bracket.
 func (r *R82xx) readRegRaw(addr uint8, n int) ([]byte, error) {
-	if err := r.demod.SetI2CRepeater(true); err != nil {
-		return nil, err
-	}
-	defer r.demod.SetI2CRepeater(false)
 	// The R820T family auto-increments from register 0 on every
 	// read; pointer-setting only matters when addr != 0. For PLL
 	// status reads we always pass addr=0, so we skip the pointer

--- a/internal/sdr/rtlsdr/tuners/r82xx_test.go
+++ b/internal/sdr/rtlsdr/tuners/r82xx_test.go
@@ -29,14 +29,33 @@ func expectRepeaterToggle(on bool) []usb.CtrlExchange {
 }
 
 // expectI2CWrite returns the full script for one tuner-side I2C write
-// burst, wrapped in repeater-on then repeater-off.
+// burst, wrapped in repeater-on then repeater-off. Use this for
+// single-write public methods or as an outer wrapper when chaining
+// several writes via expectI2CWriteRaw.
 func expectI2CWrite(i2cAddr uint8, data []byte) []usb.CtrlExchange {
 	out := append([]usb.CtrlExchange{}, expectRepeaterToggle(true)...)
-	out = append(out, usb.CtrlExchange{
-		In: false, BRequest: 0, WValue: uint16(i2cAddr), WIndex: uint16(rtl2832u.BlockIIC)<<8 | 0x10, Data: data,
-	})
+	out = append(out, expectI2CWriteRaw(i2cAddr, data))
 	out = append(out, expectRepeaterToggle(false)...)
 	return out
+}
+
+// expectI2CWriteRaw is the single ControlOut for one I2C-bridge write
+// — no surrounding repeater toggles. Use when several writes live
+// inside one public-method bracket (librtlsdr-style: one toggle pair
+// per tune/gain/init call, all writes in between).
+func expectI2CWriteRaw(i2cAddr uint8, data []byte) usb.CtrlExchange {
+	return usb.CtrlExchange{
+		In: false, BRequest: 0, WValue: uint16(i2cAddr), WIndex: uint16(rtl2832u.BlockIIC)<<8 | 0x10, Data: data,
+	}
+}
+
+// expectI2CReadRaw is the single ControlIn for one I2C-bridge read —
+// no surrounding repeater toggles. Mirrors expectI2CWriteRaw for the
+// read direction.
+func expectI2CReadRaw(i2cAddr uint8, n int, replyOnWire []byte) usb.CtrlExchange {
+	return usb.CtrlExchange{
+		In: true, BRequest: 0, WValue: uint16(i2cAddr), WIndex: uint16(rtl2832u.BlockIIC) << 8, N: n, Reply: replyOnWire,
+	}
 }
 
 // expectR82xxInitBurst returns the wire script R82xx.Init produces:
@@ -48,12 +67,8 @@ func expectR82xxInitBurst() []usb.CtrlExchange {
 	out := append([]usb.CtrlExchange{}, expectRepeaterToggle(true)...)
 	chunk1 := append([]byte{r82xxShadowStart}, r82xxInitArray[:r82xxBurstMaxData]...)
 	chunk2 := append([]byte{r82xxShadowStart + r82xxBurstMaxData}, r82xxInitArray[r82xxBurstMaxData:]...)
-	out = append(out, usb.CtrlExchange{
-		In: false, BRequest: 0, WValue: uint16(r82xxI2CAddr), WIndex: uint16(rtl2832u.BlockIIC)<<8 | 0x10, Data: chunk1,
-	})
-	out = append(out, usb.CtrlExchange{
-		In: false, BRequest: 0, WValue: uint16(r82xxI2CAddr), WIndex: uint16(rtl2832u.BlockIIC)<<8 | 0x10, Data: chunk2,
-	})
+	out = append(out, expectI2CWriteRaw(r82xxI2CAddr, chunk1))
+	out = append(out, expectI2CWriteRaw(r82xxI2CAddr, chunk2))
 	out = append(out, expectRepeaterToggle(false)...)
 	return out
 }
@@ -62,9 +77,7 @@ func expectR82xxInitBurst() []usb.CtrlExchange {
 // replyOnWire is what the mock returns (the driver bit-reverses).
 func expectI2CRead(i2cAddr uint8, n int, replyOnWire []byte) []usb.CtrlExchange {
 	out := append([]usb.CtrlExchange{}, expectRepeaterToggle(true)...)
-	out = append(out, usb.CtrlExchange{
-		In: true, BRequest: 0, WValue: uint16(i2cAddr), WIndex: uint16(rtl2832u.BlockIIC) << 8, N: n, Reply: replyOnWire,
-	})
+	out = append(out, expectI2CReadRaw(i2cAddr, n, replyOnWire))
 	out = append(out, expectRepeaterToggle(false)...)
 	return out
 }
@@ -254,10 +267,14 @@ func TestR82xx_StandbyWritesPowerDownSequence(t *testing.T) {
 		// {0x0F, 0x68} — skipped: shadow already holds 0x68 post-init.
 		{0x11, 0x03}, {0x17, 0xF4}, {0x19, 0x0C},
 	}
+	// Standby is one public call → one outer repeater toggle pair
+	// wrapping all the inner I2C writes (matches librtlsdr's
+	// rtlsdr_set_tuner_* wrap pattern).
+	script = append(script, expectRepeaterToggle(true)...)
 	for _, s := range standbyVals {
-		// Each standby write is one I2C burst of 2 bytes (addr + val).
-		script = append(script, expectI2CWrite(r82xxI2CAddr, []byte{s.addr, s.val})...)
+		script = append(script, expectI2CWriteRaw(r82xxI2CAddr, []byte{s.addr, s.val}))
 	}
+	script = append(script, expectRepeaterToggle(false)...)
 	r, m := newR82xxForTest(t, script)
 	if err := r.Init(); err != nil {
 		t.Fatalf("Init: %v", err)
@@ -298,7 +315,9 @@ func TestR82xx_WriteRegMaskOnlyChangesMaskedBits(t *testing.T) {
 	}
 	// regs[0x05] = 0x83 = 1000_0011. Apply mask 0x0F with val 0x05.
 	// Expected new value: (0x83 & ^0x0F) | (0x05 & 0x0F) = 0x80 | 0x05 = 0x85.
-	m.Script = expectI2CWrite(r82xxI2CAddr, []byte{0x05, 0x85})
+	// writeRegMask is a private helper — no repeater toggle here.
+	// Callers (public methods) own the SetI2CRepeater bracket.
+	m.Script = []usb.CtrlExchange{expectI2CWriteRaw(r82xxI2CAddr, []byte{0x05, 0x85})}
 	m.Step = 0
 	m.Err = nil
 	if err := r.writeRegMask(0x05, 0x05, 0x0F); err != nil {
@@ -432,10 +451,18 @@ func TestR82xx_AlternatingGainWalk(t *testing.T) {
 func TestR82xx_SetGain_BalancedSplit(t *testing.T) {
 	var script []usb.CtrlExchange
 	script = append(script, expectR82xxInitBurst()...)
-	script = append(script, expectI2CWrite(r82xxI2CAddr, []byte{0x05, 0x93})...)
-	script = append(script, expectI2CWrite(r82xxI2CAddr, []byte{0x05, 0x94})...)
-	script = append(script, expectI2CWrite(r82xxI2CAddr, []byte{0x07, 0x74})...)
-	script = append(script, expectI2CWrite(r82xxI2CAddr, []byte{0x0C, 0x6B})...)
+	// SetGainMode(true): one repeater on/off pair around the single
+	// 0x05 write (0x07 elided — bit 4 already set post-init).
+	script = append(script, expectRepeaterToggle(true)...)
+	script = append(script, expectI2CWriteRaw(r82xxI2CAddr, []byte{0x05, 0x93}))
+	script = append(script, expectRepeaterToggle(false)...)
+	// SetGain(144): one repeater on/off pair around three writes
+	// (LNA 0x05, Mixer 0x07, VGA 0x0C).
+	script = append(script, expectRepeaterToggle(true)...)
+	script = append(script, expectI2CWriteRaw(r82xxI2CAddr, []byte{0x05, 0x94}))
+	script = append(script, expectI2CWriteRaw(r82xxI2CAddr, []byte{0x07, 0x74}))
+	script = append(script, expectI2CWriteRaw(r82xxI2CAddr, []byte{0x0C, 0x6B}))
+	script = append(script, expectRepeaterToggle(false)...)
 	r, m := newR82xxForTest(t, script)
 	if err := r.Init(); err != nil {
 		t.Fatalf("Init: %v", err)
@@ -459,8 +486,11 @@ func TestR82xx_SetBandwidthSelectsCoarseIndex(t *testing.T) {
 	//   new = (0x6C & ^0xF0) | (0 & 0xF0) = 0x0C.
 	var script []usb.CtrlExchange
 	script = append(script, expectR82xxInitBurst()...)
-	script = append(script, expectI2CWrite(r82xxI2CAddr, []byte{0x0A, 0xD0})...)
-	script = append(script, expectI2CWrite(r82xxI2CAddr, []byte{0x0B, 0x0C})...)
+	// SetBandwidth: one repeater on/off pair around the two writes.
+	script = append(script, expectRepeaterToggle(true)...)
+	script = append(script, expectI2CWriteRaw(r82xxI2CAddr, []byte{0x0A, 0xD0}))
+	script = append(script, expectI2CWriteRaw(r82xxI2CAddr, []byte{0x0B, 0x0C}))
+	script = append(script, expectRepeaterToggle(false)...)
 	r, m := newR82xxForTest(t, script)
 	if err := r.Init(); err != nil {
 		t.Fatalf("Init: %v", err)


### PR DESCRIPTION
Finish the two deferred items from the previous PR:

1. **I2C repeater toggle batching.** Every tuner used to wrap each
   private writeReg/readReg in a SetI2CRepeater(true)/(false) pair —
   three USB control transfers per chip-register access. For an
   R820T2 SetFreq (~10-15 register writes) that's 40-60 wasted toggle
   transfers per retune. The repeater now opens once at the top of
   each public method (Init, Standby, SetFreq, SetBandwidth, SetGain,
   SetGainMode) and closes at the end, matching librtlsdr's
   rtlsdr_set_tuner_* wrap pattern. Private writeReg / readReg /
   writeBurstRaw / readRegRaw helpers now assume the caller owns the
   bridge state.

2. **Tuner probe order matches rtlsdr_open exactly.** The Go port
   was probing R820T → R828D → E4000 → FC0013 → FC0012 → FC2580
   with no GPIO pulses. librtlsdr does R820T → R828D → GPIO5 reset
   pulse → FC2580 → GPIO4 output enable → FC0013 → E4000 → FC0012
   (with a GPIO6 reset pulse if FC0012 is found). Missing pulses
   silently broke detection of non-R820T tuners on dongles that
   hold the chip in reset until pulsed. Reordered detect.go and
   added a pulseGPIO helper.

3. **FC0012 Init no longer emits the spurious 0x0C writes.** The
   pre-fix code wrote 0x0C ← 0x05 then 0x0C ← 0x00 labeled
   "soft-reset on/off" — not in librtlsdr's fc0012_init. The chip
   reset is the GPIO5 high→low→high pulse, which detect.go now
   issues before the I2C probe (and FC0012.Init runs only the
   20-register init flood).

Test impact: all multi-write public methods now expect ONE repeater
toggle pair around N inner I2C writes instead of N toggle pairs;
added expectI2CWriteRaw/expectI2CReadRaw/expectSetGPIOOutput/
expectSetGPIOBit/expectGPIOPulse helpers and rewrote the affected
test scripts. detect_test.go gains a wire-level pin of the new
probe sequence (R820T miss → R828D miss → GPIO5 pulse → FC2580 miss
→ GPIO4 enable → FC0013 miss → E4000 match).

Out of scope (still flagged as needs-hardware in source comments):
E4000 IMR / DC-offset calibration sweep, FC2580 band-edge filter
calibration. Both require IQ sampling against real hardware.

README + CHANGELOG updated.