### PR TITLE
rtlsdr: R820T burst settle + chunk-size halving fallback (issue #248)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,38 @@ for tagged releases.
 
 ### Fixed
 
+- **RTL-SDR R820T burst-init now adds a chip-settle window and
+  chunk-size fallback for the EPIPE-on-first-burst case.** Sixth
+  iteration on issue #248 after PR #263's per-chunk EPIPE retry +
+  open-path USBDEVFS_RESET envelope still failed to close it on two
+  NESDR SMArt v5 units. The post-#263 trace confirms the USB reset
+  doesn't change the chip's response to the 17-byte burst,
+  `Demod.InitBaseband` matches librtlsdr's `rtlsdr_init_baseband`
+  byte-for-byte across all 20 register writes + the 20-byte FIR
+  upload, the load-bearing `SetI2CRepeater(true)` toggle from PR #262
+  is on the wire immediately before each burst attempt, and EP0
+  stays healthy post-EPIPE (subsequent control transfers succeed
+  without `USBDEVFS_CLEAR_HALT`). Two new defenses ship in this
+  round, layered before the existing inner+outer retry from PR #263:
+  - `R82xx.Init` now sleeps 5 ms between opening the I²C repeater
+    and emitting the burst, covering a chip-settle window librtlsdr
+    gets incidentally via function-call latency that our tight
+    PrepareDemod → Init back-to-back path doesn't.
+  - `writeBurstRaw` now halves the chunk size on
+    EPIPE-after-inner-retry-exhausted (16 → 8 → 4 floor) and re-runs
+    the whole burst at the smaller size before giving up. Probes the
+    chip's effective I²C-bridge FIFO depth empirically — librtlsdr's
+    `NMAX_WRITES = 16` may exceed what specific firmware revisions
+    accept. The final-failure error wraps as
+    `tried chunk sizes 16,8,4; all EPIPE'd: ...` so reporters see
+    attribution. Idempotent-write contract called out at the
+    function comment — register writes through this path must stay
+    safe to replay across the halving walk.
+  If this still reproduces, kernel-level usbmon packet traces become
+  the prerequisite — `LIBUSB_DEBUG=4` doesn't dump payloads and the
+  diagnostic data inferrable from existing traces is exhausted.
+  Continues [issue #248](https://github.com/MattCheramie/GopherTrunk/issues/248).
+
 - **RTL-SDR R820T burst-init EPIPE now recovers via a single in-place
   retry + one-shot open-path reset hammer.** Two NESDR SMArt v5 units
   reproduced an EPIPE on the very first `r82xx_init_array` I²C-bridge

--- a/internal/sdr/rtlsdr/tuners/r82xx.go
+++ b/internal/sdr/rtlsdr/tuners/r82xx.go
@@ -129,8 +129,9 @@ func (r *R82xx) PrepareDemod() error {
 
 // Init walks the librtlsdr power-on sequence: open the I²C repeater
 // (a fresh wire write — load-bearing on NESDR v5 silicon, issue
-// #248), write the 27-byte init flood to registers 0x05..0x1F as
-// 16-byte chunks (NMAX_WRITES parity), close the repeater on return.
+// #248), wait briefly for the chip-settle window, write the 27-byte
+// init flood to registers 0x05..0x1F via writeBurstRaw's halving
+// fallback (16 → 8 → 4), close the repeater on return.
 func (r *R82xx) Init() error {
 	if r.initDone {
 		return nil
@@ -139,6 +140,12 @@ func (r *R82xx) Init() error {
 		return err
 	}
 	defer r.demod.SetI2CRepeater(false)
+	// Brief chip-settle window between the repeater open and the
+	// multi-byte burst — covers a timing gap librtlsdr gets
+	// incidentally via function-call latency that our tight
+	// PrepareDemod → Init back-to-back path doesn't. See
+	// r82xxPostPrepDemodSettleMillis docstring (issue #248).
+	time.Sleep(r82xxPostPrepDemodSettleMillis * time.Millisecond)
 	// Prime the shadow with the init values; the burst write below
 	// makes them real.
 	for i, v := range r82xxInitArray {
@@ -526,18 +533,52 @@ func (r *R82xx) writeRegMask(addr uint8, val, mask byte) error {
 // public method (Init, SetFreq, ...) does this once around its whole
 // body, matching librtlsdr's rtlsdr_set_tuner_* wrap pattern.
 //
-// Data is split into chunks of at most r82xxBurstMaxData bytes to
-// mirror librtlsdr's r82xx_write (NMAX_WRITES = 16). Going beyond
-// that limit stalls the very first multi-byte OUT on some NESDR v5
-// dongles — observed as libusb EPIPE on the 27-byte init flood
-// (issue #248). Each chunk is its own control-OUT; the register
-// pointer advances by the chunk length between chunks, which matches
-// the chip's auto-increment.
+// Data is normally split into chunks of r82xxBurstMaxData bytes to
+// mirror librtlsdr's r82xx_write (NMAX_WRITES = 16). If a chunk
+// EPIPEs even after writeBurstChunk's per-chunk inner retry, the
+// whole burst is replayed at half the previous chunk size, walking
+// 16 → 8 → 4 until one size succeeds (issue #248: two NESDR SMArt
+// v5 units rejected the 17-byte first chunk even after PR #263's
+// inner retry + outer USBDEVFS_RESET hammer; the hypothesis being
+// tested is that the chip's I²C-bridge FIFO depth on that firmware
+// revision is below librtlsdr's 16-byte assumption).
+//
+// Idempotency note: when a later chunk EPIPEs and the burst restarts
+// at a smaller size, chunks already written at the larger size get
+// their wire bytes replayed against the same chip registers. Safe
+// for R820T because every register write is idempotent and the
+// shadow holds the same values across attempts. Future tuner ports
+// that route non-idempotent writes through writeBurstRaw must
+// revisit this contract.
 func (r *R82xx) writeBurstRaw(addr uint8, data []byte) error {
+	var lastErr error
+	for chunkSize := r82xxBurstMaxData; chunkSize >= r82xxBurstMinData; chunkSize /= 2 {
+		err := r.writeBurstAtSize(addr, data, chunkSize)
+		if err == nil {
+			return nil
+		}
+		if !errors.Is(err, syscall.EPIPE) {
+			return err
+		}
+		lastErr = err
+		if chunkSize > r82xxBurstMinData {
+			// Let the chip's I²C bridge drain before the next pass.
+			time.Sleep(r82xxBurstRetryDelayMillis * time.Millisecond)
+		}
+	}
+	return fmt.Errorf("tried chunk sizes 16,8,4; all EPIPE'd: %w", lastErr)
+}
+
+// writeBurstAtSize emits the burst with a specific chunk size cap.
+// Pulled out of writeBurstRaw so the halving-fallback loop has a
+// single per-pass entry point. Each chunk is its own control-OUT;
+// the register pointer advances by chunkSize per OUT, matching the
+// chip's auto-increment.
+func (r *R82xx) writeBurstAtSize(addr uint8, data []byte, chunkSize int) error {
 	for pos := 0; pos < len(data); {
 		size := len(data) - pos
-		if size > r82xxBurstMaxData {
-			size = r82xxBurstMaxData
+		if size > chunkSize {
+			size = chunkSize
 		}
 		if err := r.writeBurstChunk(addr+uint8(pos), data[pos:pos+size]); err != nil {
 			return err

--- a/internal/sdr/rtlsdr/tuners/r82xx_tables.go
+++ b/internal/sdr/rtlsdr/tuners/r82xx_tables.go
@@ -56,6 +56,28 @@ const (
 	// to drain prior PrepareDemod traffic and short enough to be
 	// invisible in the happy path (retry never fires).
 	r82xxBurstRetryDelayMillis = 8
+
+	// r82xxBurstMinData is the smallest chunk size writeBurstRaw will
+	// try before giving up its halving-on-EPIPE retry walk
+	// (16 → 8 → 4). Going below 4 burns wire traffic without
+	// distinguishing a true multi-byte FIFO threshold from any other
+	// behavior — single-byte demod writes already succeed against the
+	// post-EPIPE chip on issue #248's reproduction, so finding a "size
+	// 1 works" branch doesn't tell us anything new. See
+	// writeBurstRaw's halving loop for details.
+	r82xxBurstMinData = 4
+
+	// r82xxPostPrepDemodSettleMillis is a brief chip-settle window
+	// after the I²C repeater opens at the top of R82xx.Init and
+	// before the multi-byte burst goes out. PR #263's trace data
+	// (issue #248) showed the burst EPIPEs on NESDR v5 silicon even
+	// after the load-bearing SetI2CRepeater(true) wire write fired
+	// and after a USBDEVFS_RESET. librtlsdr's rtlsdr_open has
+	// natural latency (function-call boundary + libusb queue
+	// management) between PrepareDemod's last demod-side write and
+	// r82xx_init's first I²C-bridge OUT; gophertrunk's Go code runs
+	// them back-to-back. 5 ms covers that gap.
+	r82xxPostPrepDemodSettleMillis = 5
 )
 
 // r82xxInitArray is the 27-byte register flood that lands at addr

--- a/internal/sdr/rtlsdr/tuners/r82xx_test.go
+++ b/internal/sdr/rtlsdr/tuners/r82xx_test.go
@@ -714,33 +714,131 @@ func TestR82xx_InitBurst_EPIPERetrySucceeds(t *testing.T) {
 	}
 }
 
-// TestR82xx_InitBurst_EPIPETwiceReturnsWrappedError: both attempts on
-// the first chunk EPIPE. writeBurstChunk returns a wrapped error
-// keyed on "after 1 retry on EPIPE" so traces show retry attribution.
-// The underlying syscall.EPIPE remains reachable via errors.Is — the
-// outer openDevice envelope keys off that for its reset+retry. The
-// defer in R82xx.Init still emits the trailing repeater-off so the
-// chip state is clean on return.
-func TestR82xx_InitBurst_EPIPETwiceReturnsWrappedError(t *testing.T) {
-	chunk1, _ := expectR82xxInitBurstChunks()
+// burstChunkAt builds the wire payload for one I²C chunk of the
+// r82xxInitArray at offset pos with `size` data bytes. The 1-byte
+// register-pointer prefix is r82xxShadowStart + pos so the chip
+// auto-increments correctly across the burst.
+func burstChunkAt(pos, size int) []byte {
+	return append([]byte{byte(r82xxShadowStart + pos)}, r82xxInitArray[pos:pos+size]...)
+}
+
+// burstScriptAtSize returns the wire script for writing the whole
+// init array at a fixed chunk size, with per-chunk error injection.
+// errPerChunk[i] (if i < len) becomes the Err on chunk i; trailing
+// chunks get nil. Used by the chunk-size fallback tests below.
+func burstScriptAtSize(chunkSize int, errPerChunk ...error) []usb.CtrlExchange {
+	var script []usb.CtrlExchange
+	chunkIdx := 0
+	for pos := 0; pos < len(r82xxInitArray); chunkIdx++ {
+		size := len(r82xxInitArray) - pos
+		if size > chunkSize {
+			size = chunkSize
+		}
+		var err error
+		if chunkIdx < len(errPerChunk) {
+			err = errPerChunk[chunkIdx]
+		}
+		script = append(script, r82xxChunkExchange(burstChunkAt(pos, size), err))
+		pos += size
+	}
+	return script
+}
+
+// TestR82xx_InitBurst_ChunkSizeFallback_8Succeeds: chunk1 at size 16
+// EPIPEs on both writeBurstChunk attempts (initial + inner retry),
+// writeBurstRaw's halving fallback kicks in, the burst re-runs at
+// size 8 and all four 8-byte chunks succeed. R82xx.Init returns nil
+// and the mock script is fully consumed. Verifies the
+// halving-on-EPIPE path lives in writeBurstRaw, not in writeBurstChunk.
+func TestR82xx_InitBurst_ChunkSizeFallback_8Succeeds(t *testing.T) {
+	chunk1at16 := burstChunkAt(0, r82xxBurstMaxData)
 	script := append([]usb.CtrlExchange{}, expectRepeaterToggle(true)...)
-	script = append(script, r82xxChunkExchange(chunk1, syscall.EPIPE)) // first attempt
-	script = append(script, r82xxChunkExchange(chunk1, syscall.EPIPE)) // retry
+	// Size-16 pass: chunk1 EPIPEs, inner retry of chunk1 also EPIPEs.
+	script = append(script, r82xxChunkExchange(chunk1at16, syscall.EPIPE))
+	script = append(script, r82xxChunkExchange(chunk1at16, syscall.EPIPE))
+	// Size-8 pass: 4 chunks (8+8+8+3 = 27 data bytes), all succeed.
+	script = append(script, burstScriptAtSize(8)...)
+	script = append(script, expectRepeaterToggle(false)...)
+
+	r, m := newR82xxForTest(t, script)
+	if err := r.Init(); err != nil {
+		t.Fatalf("Init: %v (size-8 fallback should have succeeded)", err)
+	}
+	if m.Err != nil {
+		t.Errorf("mock err: %v", m.Err)
+	}
+	if m.Remaining() != 0 {
+		t.Errorf("remaining=%d, want 0", m.Remaining())
+	}
+}
+
+// TestR82xx_InitBurst_ChunkSizeFallback_AllSizesFail: chunk1 EPIPEs
+// at every size in the halving walk (16/8/4) with both inner retries
+// failing too. writeBurstRaw wraps the final error as "tried chunk
+// sizes 16,8,4; all EPIPE'd: ..." so reporters see attribution.
+// errors.Is(err, syscall.EPIPE) still holds — the outer openDevice
+// envelope keys off that for its reset+retry. The defer in R82xx.Init
+// still emits the trailing repeater-off so the chip state is clean.
+func TestR82xx_InitBurst_ChunkSizeFallback_AllSizesFail(t *testing.T) {
+	script := append([]usb.CtrlExchange{}, expectRepeaterToggle(true)...)
+	// Size 16: chunk1 + inner retry both EPIPE.
+	chunk1at16 := burstChunkAt(0, r82xxBurstMaxData)
+	script = append(script, r82xxChunkExchange(chunk1at16, syscall.EPIPE))
+	script = append(script, r82xxChunkExchange(chunk1at16, syscall.EPIPE))
+	// Size 8: chunk1 + inner retry both EPIPE.
+	chunk1at8 := burstChunkAt(0, 8)
+	script = append(script, r82xxChunkExchange(chunk1at8, syscall.EPIPE))
+	script = append(script, r82xxChunkExchange(chunk1at8, syscall.EPIPE))
+	// Size 4 (floor): chunk1 + inner retry both EPIPE.
+	chunk1at4 := burstChunkAt(0, 4)
+	script = append(script, r82xxChunkExchange(chunk1at4, syscall.EPIPE))
+	script = append(script, r82xxChunkExchange(chunk1at4, syscall.EPIPE))
 	script = append(script, expectRepeaterToggle(false)...)
 
 	r, m := newR82xxForTest(t, script)
 	err := r.Init()
 	if err == nil {
-		t.Fatal("Init succeeded; expected wrapped EPIPE")
+		t.Fatal("Init succeeded; expected wrapped EPIPE after all sizes failed")
 	}
 	if !errors.Is(err, syscall.EPIPE) {
 		t.Errorf("err = %v, want errors.Is(err, syscall.EPIPE) (outer envelope keys off this)", err)
 	}
-	if !strings.Contains(err.Error(), "after 1 retry on EPIPE") {
-		t.Errorf("err = %q, want substring \"after 1 retry on EPIPE\" (proves retry fired)", err.Error())
+	if !strings.Contains(err.Error(), "tried chunk sizes 16,8,4") {
+		t.Errorf("err = %q, want substring \"tried chunk sizes 16,8,4\" (proves fallback walked all sizes)", err.Error())
 	}
 	if m.Remaining() != 0 {
 		t.Errorf("remaining=%d, want 0 (deferred repeater-off must still fire)", m.Remaining())
+	}
+}
+
+// TestR82xx_InitBurst_ChunkSizeFallback_NonEPIPEAborts: chunk1 at
+// size 16 EPIPEs (inner retry exhausted), size 8 returns ErrTimeout
+// (a non-EPIPE error). Asserts the halving walk STOPS immediately —
+// no size-4 attempt fires — and the error wraps ErrTimeout, not
+// syscall.EPIPE. Pins the "EPIPE-only fallback" guard so a future
+// change can't quietly widen it.
+func TestR82xx_InitBurst_ChunkSizeFallback_NonEPIPEAborts(t *testing.T) {
+	chunk1at16 := burstChunkAt(0, r82xxBurstMaxData)
+	chunk1at8 := burstChunkAt(0, 8)
+	script := append([]usb.CtrlExchange{}, expectRepeaterToggle(true)...)
+	script = append(script, r82xxChunkExchange(chunk1at16, syscall.EPIPE))
+	script = append(script, r82xxChunkExchange(chunk1at16, syscall.EPIPE))
+	script = append(script, r82xxChunkExchange(chunk1at8, usb.ErrTimeout))
+	script = append(script, expectRepeaterToggle(false)...)
+
+	r, m := newR82xxForTest(t, script)
+	err := r.Init()
+	if err == nil {
+		t.Fatal("Init succeeded; expected wrapped ErrTimeout")
+	}
+	if !errors.Is(err, usb.ErrTimeout) {
+		t.Errorf("err = %v, want errors.Is(err, usb.ErrTimeout)", err)
+	}
+	if strings.Contains(err.Error(), "tried chunk sizes") {
+		t.Errorf("err = %q, must NOT contain the all-sizes-failed wrap (non-EPIPE must abort the halving walk immediately)", err.Error())
+	}
+	if m.Remaining() != 0 {
+		t.Errorf("remaining=%d, want 0 (no size-4 attempt; deferred repeater-off must fire)", m.Remaining())
 	}
 }
 


### PR DESCRIPTION
## Summary

Sixth iteration on issue #248. After PR #263's per-chunk EPIPE retry + outer USBDEVFS_RESET envelope, the reporter's two NESDR SMArt v5 dongles STILL EPIPE on the R820T2's first 17-byte I²C-bridge OUT — both inner retry attempts AND the post-reset second bring-up produce identical EPIPEs on chunk1@16.

### What the post-#263 trace tells us

- The load-bearing `SetI2CRepeater(true)` wire write from PR #262 is on the wire immediately before each burst attempt.
- `Demod.InitBaseband` matches librtlsdr's `rtlsdr_init_baseband` byte-for-byte across all 20 register writes + the 20-byte FIR upload (audited this round).
- EP0 stays healthy post-EPIPE (the deferred `data=10` off-toggle and a subsequent commit read succeed without `USBDEVFS_CLEAR_HALT`).
- `rtl_test` never calls `libusb_reset_device` on these dongles — confirmed by explicit grep of its `LIBUSB_DEBUG=4` trace.

The chip rejects this specific multi-byte OUT regardless of preceding state, but accepts single-byte transfers immediately after. Two complementary defenses ship in this round, layered before PR #263's existing inner+outer retry:

### Defenses

1. **5 ms chip-settle window** at the top of `R82xx.Init` between opening the I²C repeater and emitting the burst. Covers a timing gap librtlsdr gets incidentally via function-call latency that our tight `PrepareDemod → Init` back-to-back path doesn't.
2. **Chunk-size halving fallback** in `writeBurstRaw` on EPIPE-after-inner-retry-exhausted: `16 → 8 → 4` floor. Probes the chip's effective I²C-bridge FIFO depth empirically — librtlsdr's `NMAX_WRITES=16` may exceed what specific firmware revisions accept. The final-failure error wraps as `tried chunk sizes 16,8,4; all EPIPE'd: ...` so reporters see attribution. Idempotent-write contract called out at the function comment.

Cap at 4 (not 1): single-byte writes already succeed post-EPIPE on the demod path, so iterating below 4 burns wire traffic without information gain.

If this round still fails, kernel-level usbmon packet traces become the prerequisite for any further code-side work. `LIBUSB_DEBUG=4` doesn't dump control-transfer payloads and we've exhausted what's inferrable from existing data.

## Test plan

- [x] `go test ./... -count=1` — all green
- [x] `go test -race ./internal/sdr/rtlsdr/... -count=1` — green
- [x] `go vet ./...` clean
- [x] `gofmt -l .` empty
- [x] `GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 go build ./...` clean
- [x] `GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 go build ./...` clean
- [x] `GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build ./...` clean
- [x] **3 new burst tests pass:**
  - `TestR82xx_InitBurst_ChunkSizeFallback_8Succeeds` — chunk1@16 EPIPEs twice, size-8 walk completes
  - `TestR82xx_InitBurst_ChunkSizeFallback_AllSizesFail` — 16/8/4 all EPIPE; error wraps `tried chunk sizes 16,8,4`
  - `TestR82xx_InitBurst_ChunkSizeFallback_NonEPIPEAborts` — `ErrTimeout` at size 8 stops the halving immediately
- [x] **4 existing burst tests still pass** (one repurposed from PR #263's `EPIPETwiceReturnsWrappedError` since the new fallback subsumes its assertion shape)
- [ ] **Reporter validation (post-merge):** `@er-imagery` to pull main, rebuild, and re-run `RTLSDR_DEBUG_USB=1 ./gophertrunk sdr list --probe 2> trace.log`. The error wrap is the diagnostic:
  - Probe succeeds with no fallback markers → settle window alone closed it.
  - Probe succeeds with `tried chunk sizes 16` mid-error → fallback fired at a smaller size and worked; share the trace so we know which size threshold the chip accepts.
  - `tried chunk sizes 16,8,4; all EPIPE'd` → we need usbmon. Following comment walks through capture.

https://claude.ai/code/session_01KUJWjSMQvTxoAYbFHRXoeX

---
_Generated by [Claude Code](https://claude.ai/code/session_01KUJWjSMQvTxoAYbFHRXoeX)_