### PR TITLE
rtlsdr: use 16 MHz reference crystal for R828D tuners (issue #264)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,24 @@ for tagged releases.
 
 ### Fixed
 
+- **RTL-SDR R828D-family tuners (RTL-SDR Blog V4 and similar) now
+  use the correct 16 MHz reference crystal.** `NewR82xx`
+  previously initialized every R820T/R820T2/R828D instance with
+  `r.xtalHz = 28_800_000`, the R820T value. R828D variants run
+  from a 16 MHz crystal per librtlsdr's `R828D_XTAL_FREQ`. The
+  divergence didn't surface during init (the burst uses fixed
+  register values), but every `SetFreq` call on an R828D would
+  compute PLL parameters against the wrong reference — every
+  tuned frequency landed at ~28.8/16 = 1.8× the requested LO,
+  rendering V4 dongles unusable for tuning once they did open.
+  `NewR82xx` now picks the per-chip default; `SetXtal` keeps
+  working as the explicit override for boards with non-standard
+  crystals. Closes [issue #264](https://github.com/MattCheramie/GopherTrunk/issues/264)'s
+  tuning-after-init half; the init-burst EPIPE half is covered
+  by the existing layered defense from issues #248 / PRs
+  #258 / #260 / #262 / #263 / #265, which apply to R828D writes
+  identically.
+
 - **RTL-SDR R820T burst-init now adds a chip-settle window and
   chunk-size fallback for the EPIPE-on-first-burst case.** Sixth
   iteration on issue #248 after PR #263's per-chunk EPIPE retry +

--- a/internal/sdr/rtlsdr/tuners/r82xx.go
+++ b/internal/sdr/rtlsdr/tuners/r82xx.go
@@ -44,19 +44,29 @@ type R82xx struct {
 
 // NewR82xx constructs a driver bound to the given RTL2832U demod and
 // I2C address. Callers normally obtain the right address via the
-// Detect helper.
+// Detect helper. The reference-crystal frequency defaults are
+// per-chip-type: R820T/R820T2 run from 28.8 MHz (the RTL2832U's
+// reference crystal), R828D runs from 16 MHz (a separate on-board
+// crystal). Boards with non-standard crystals can override via
+// [R82xx.SetXtal] after construction.
 func NewR82xx(d *rtl2832u.Demod, i2cAddr uint8, chip Type) *R82xx {
+	xtal := r82xxXtalHz
+	if chip == TypeR828D {
+		xtal = r828dXtalHz
+	}
 	return &R82xx{
 		demod:    d,
 		i2cAddr:  i2cAddr,
 		chipType: chip,
-		xtalHz:   r82xxXtalHz,
+		xtalHz:   xtal,
 	}
 }
 
 // SetXtal overrides the reference-crystal frequency. R820T chips
 // derive every PLL division off the RTL2832U's crystal, so a
-// non-default board crystal must be propagated here too.
+// non-default board crystal must be propagated here too. Per-chip
+// defaults are set by [NewR82xx] (28.8 MHz for R820T/R820T2, 16 MHz
+// for R828D); SetXtal exists for boards that deviate from those.
 func (r *R82xx) SetXtal(hz uint32) { r.xtalHz = hz }
 
 // Type returns the detected chip family.

--- a/internal/sdr/rtlsdr/tuners/r82xx_tables.go
+++ b/internal/sdr/rtlsdr/tuners/r82xx_tables.go
@@ -24,9 +24,17 @@ const (
 	r82xxShadowStart = 0x05
 
 	// r82xxXtalHz matches the RTL2832U reference crystal librtlsdr
-	// drives the R820T from (28.8 MHz). Boards with non-standard
-	// crystals can override via [R82xx.SetXtal].
+	// drives the R820T from (28.8 MHz). R828D variants use 16 MHz —
+	// see r828dXtalHz. Boards with non-standard crystals can override
+	// via [R82xx.SetXtal].
 	r82xxXtalHz uint32 = 28_800_000
+
+	// r828dXtalHz is the reference crystal frequency for R828D-family
+	// tuners (RTL-SDR Blog V4 and similar). librtlsdr exposes this as
+	// R828D_XTAL_FREQ in tuner_r82xx.c. NewR82xx selects this default
+	// when chipType == TypeR828D so SetFreq's PLL math matches what
+	// librtlsdr would compute against the same hardware.
+	r828dXtalHz uint32 = 16_000_000
 
 	// vcoMin / vcoMax bound the R820T VCO range. The PLL math
 	// picks a mixer divider (2/4/8/16/32/64) so freq*div lands

--- a/internal/sdr/rtlsdr/tuners/r82xx_test.go
+++ b/internal/sdr/rtlsdr/tuners/r82xx_test.go
@@ -869,6 +869,48 @@ func TestR82xx_InitBurst_NonEPIPENoRetry(t *testing.T) {
 	}
 }
 
+// TestNewR82xx_DefaultXtalPerChipType pins librtlsdr's per-chip
+// crystal defaults so a future refactor of NewR82xx can't quietly
+// regress the R828D variant back to 28.8 MHz (issue #264). R820T /
+// R820T2 derive PLL division off the RTL2832U's 28.8 MHz reference;
+// R828D has its own 16 MHz crystal. TypeUnknown falls through to
+// the R820T default — a stricter "error on unknown" check would
+// catch one extra test case but break Detect callers that construct
+// R82xx before deciding the variant.
+func TestNewR82xx_DefaultXtalPerChipType(t *testing.T) {
+	cases := []struct {
+		chip Type
+		want uint32
+	}{
+		{TypeR820T, 28_800_000},
+		{TypeR820T2, 28_800_000},
+		{TypeR828D, 16_000_000},
+		{TypeUnknown, 28_800_000},
+	}
+	for _, c := range cases {
+		r := NewR82xx(nil, 0x34, c.chip)
+		if r.xtalHz != c.want {
+			t.Errorf("NewR82xx(chip=%v).xtalHz = %d, want %d", c.chip, r.xtalHz, c.want)
+		}
+	}
+}
+
+// TestR82xx_SetXtal_OverridesPerChipDefault pins the explicit-override
+// path against the per-chip defaults introduced in issue #264. Boards
+// with non-standard crystals (e.g. some R828D variants with a TCXO
+// at a different frequency) must still be able to point R82xx at the
+// right reference via SetXtal after construction.
+func TestR82xx_SetXtal_OverridesPerChipDefault(t *testing.T) {
+	r := NewR82xx(nil, 0x74, TypeR828D)
+	if r.xtalHz != 16_000_000 {
+		t.Fatalf("pre-condition: NewR82xx(R828D).xtalHz = %d, want 16_000_000", r.xtalHz)
+	}
+	r.SetXtal(40_000_000)
+	if r.xtalHz != 40_000_000 {
+		t.Errorf("after SetXtal(40_000_000): r.xtalHz = %d, want 40_000_000", r.xtalHz)
+	}
+}
+
 func TestErrUnsupportedFreq_ErrorMessage(t *testing.T) {
 	e := &ErrUnsupportedFreq{Hz: 2_000_000_000, MinHz: 24_000_000, MaxHz: 1_766_000_000, TunerStr: "R820T2"}
 	msg := e.Error()


### PR DESCRIPTION
## Summary

`@firefighter76` filed issue #264 reporting that v0.1.5 doesn't detect the RTL-SDR Blog V4 (R828D tuner at I²C address `0x74`). The error path is structurally identical to issue #248 (`tuner init: r82xx init: burst write: I2CWrite addr=0x74: broken pipe`) — and **v0.1.5 predates ALL of this cycle's #248 fixes**: PR #258 chunking, #260 PrepareDemod, #262 off-toggle restore, #263 inner+outer retry, #265 5ms settle + halving fallback. Audit confirms `R82xx.Init` (and `writeBurstRaw` / `writeBurstAtSize` / `writeBurstChunk`) have **no chip-type branches** — every #248 fix applies to R828D writes uniformly. So the EPIPE half of this issue is already addressed; the reporter just needs to test latest `main`.

But there's one **real R828D-specific bug** that latest `main` doesn't yet cover: **`NewR82xx` hardcodes the R820T crystal frequency (28.8 MHz) for every variant**, including R828D. librtlsdr uses `R828D_XTAL_FREQ = 16_000_000` for R828D — a different on-board crystal. The divergence doesn't surface during init (the burst writes fixed register values), but every `SetFreq` call on an R828D would compute PLL parameters against the wrong reference: **every tuned frequency lands at ~28.8/16 = 1.8× the requested LO**, rendering V4 dongles unusable for tuning once they did open.

This PR fixes that. `NewR82xx` now picks the per-chip default via a switch on `chipType`. `SetXtal` keeps working as the explicit override for boards with non-standard crystals (e.g. R828D variants with a TCXO at a different frequency).

## Test plan

- [x] `go test ./... -count=1` — all green
- [x] `go test -race ./internal/sdr/rtlsdr/... -count=1` — green
- [x] `go vet ./...` clean
- [x] `gofmt -l .` empty
- [x] `GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 go build ./...` clean
- [x] `GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 go build ./...` clean
- [x] `GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build ./...` clean
- [x] **2 new unit tests pass:**
  - `TestNewR82xx_DefaultXtalPerChipType` — table-driven check that R820T/R820T2/TypeUnknown get 28.8 MHz, R828D gets 16 MHz
  - `TestR82xx_SetXtal_OverridesPerChipDefault` — explicit override path still works (sets R828D's xtal to 40 MHz, asserts)
- [x] **Existing R82xx tests still pass** as regressions (TypeAndIF, GainsLadder, every burst test, every detect test).
- [ ] **Reporter validation (post-merge):** `@firefighter76` to pull main, rebuild, and re-run on the RTL-SDR Blog V4. The init-burst EPIPE is covered by the #248 cycle fixes already in main; once init succeeds, the new xtal frequency makes `SetFreq` land where requested. If the EPIPE persists, the comment will hard-gate the next step on usbmon traces (same recipe as #248 comment 4478379233).

## Out of scope

- **R828D-specific `rafael_chip` cap-default in `xtal_check`.** librtlsdr picks a different fine-tune capacitance default for `CHIP_R828D` vs `CHIP_R820T`. GopherTrunk's `R82xx` doesn't run an xtal-check at init time, so this doesn't surface as a bug today. Defer until any downstream tuning-accuracy issue surfaces specifically against R828D.
- **"device or resource busy" cascade on indexes 1 and 2 from the report.** Enumerator audit found no dedup bug. Most likely environmental (3 separate dongles all failing, or the pool loop racing against the failure-path interface release). Defer until we have evidence it persists after the init fix.

https://claude.ai/code/session_01KUJWjSMQvTxoAYbFHRXoeX

---
_Generated by [Claude Code](https://claude.ai/code/session_01KUJWjSMQvTxoAYbFHRXoeX)_