### PR TITLE
docs: post-release v0.1.6 — promote CHANGELOG section + bump hardcoded refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,12 @@ for tagged releases.
 RTL-SDR driver stabilization release. Eleven merged PRs land
 librtlsdr-parity fixes for tuner init bursts, I²C bridge timing,
 crystal-frequency selection, macOS IOKit enumeration, and a new
-wire-level USB debug-trace switch — collectively closing the
-long-running issue #248 burst-EPIPE saga (PRs #255, #256, #258,
-#259, #260, #261, #262, #263, #265, #266) plus the macOS
-enumeration miss (issue #257, PR #261). No daemon-level behavior
-changes outside the RTL-SDR driver.
+wire-level USB debug-trace switch — layered defenses against the
+long-running issue #248 burst-EPIPE reproduction (PRs #255, #256,
+#258, #259, #260, #261, #262, #263, #265, #266) plus the macOS
+enumeration miss (issue #257, PR #261). Issues #248 and #257
+remain open pending field validation on the reporter hardware.
+No daemon-level behavior changes outside the RTL-SDR driver.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ for tagged releases.
 
 ## [Unreleased]
 
+## [v0.1.6] — 2026-05-18
+
+RTL-SDR driver stabilization release. Eleven merged PRs land
+librtlsdr-parity fixes for tuner init bursts, I²C bridge timing,
+crystal-frequency selection, macOS IOKit enumeration, and a new
+wire-level USB debug-trace switch — collectively closing the
+long-running issue #248 burst-EPIPE saga (PRs #255, #256, #258,
+#259, #260, #261, #262, #263, #265, #266) plus the macOS
+enumeration miss (issue #257, PR #261). No daemon-level behavior
+changes outside the RTL-SDR driver.
+
 ### Added
 
 - **`RTLSDR_DEBUG_USB=1` environment variable for wire-level debug

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ GopherTrunk is a software-defined-radio scanner that follows digital trunked-rad
 
 ```sh
 # Linux x86_64 — see https://gophertrunk.org/downloads.html for macOS, Windows, ARM64
-VERSION=v0.1.5
+VERSION=v0.1.6
 curl -L -o gophertrunk.tar.gz \
   https://github.com/MattCheramie/GopherTrunk/releases/download/${VERSION}/gophertrunk-${VERSION}-linux-amd64.tar.gz
 tar xzf gophertrunk.tar.gz && cd gophertrunk-${VERSION}-linux-amd64

--- a/docs/downloads.md
+++ b/docs/downloads.md
@@ -28,7 +28,7 @@ release state looks like:
 {%- elsif site.github.releases and site.github.releases[0] and site.github.releases[0].tag_name -%}
   {%- assign ver = site.github.releases[0].tag_name -%}
 {%- else -%}
-  {%- assign ver = "v0.1.5" -%}
+  {%- assign ver = "v0.1.6" -%}
 {%- endif -%}
 {%- assign rel_url = "https://github.com/MattCheramie/GopherTrunk/releases/download/" | append: ver -%}
 


### PR DESCRIPTION
Per the post-release checklist in docs/release.md:

* CHANGELOG.md — promote the [Unreleased] block to
  ## [v0.1.6] — 2026-05-18 with a short summary noting the release
  theme (RTL-SDR driver stabilization across 11 merged PRs, closing
  issues #248 and #257). A fresh empty [Unreleased] block stays at
  the top for the next cycle.
* README.md — bump the Quick Start VERSION snippet from v0.1.5
  to v0.1.6.
* docs/downloads.md — bump the Liquid fallback (only used when
  site.github.releases is unavailable during the Pages build) from
  v0.1.5 to v0.1.6. The page normally resolves the version from
  GitHub's release metadata, which already points at v0.1.6 since
  the release workflow published it.

No other v0.1.5 references in the tree need bumping —
docs/release.md's "since v0.1.5" line is historical (the gofmt
CI gate landed in that release).