### PR TITLE
metrics: per-system call rate, encryption breakdown, CC and SDR health (#269)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ for tagged releases.
 
 ## [Unreleased]
 
+### Added
+
+- **Prometheus metrics for per-system call rate, encryption breakdown,
+  control-channel health, and SDR device tuning state** (issue #269).
+  New series: `gophertrunk_calls_started_total{system,protocol,encrypted}`,
+  `gophertrunk_control_channel_frequency_hz{system}`,
+  `gophertrunk_control_channel_transitions_total{system,event}`,
+  `gophertrunk_sdr_gain_db{driver,serial,role}`,
+  `gophertrunk_sdr_gain_auto{driver,serial,role}`,
+  `gophertrunk_sdr_ppm{driver,serial,role}`,
+  `gophertrunk_sdr_bias_tee{driver,serial,role}`. SDR tuning gauges
+  come from a scrape-time snapshot collector so they always reflect
+  live pool state.
+
+### Changed
+
+- `gophertrunk_calls_total` now carries `{system,protocol,encrypted,reason}`
+  labels (was `{reason}`); `gophertrunk_calls_active` is now a
+  GaugeVec keyed by `{system,protocol}` (was a bare gauge). Dashboards
+  that previously scraped the unlabeled shape can recover with
+  `sum without(system,protocol,encrypted) (gophertrunk_calls_total)`.
+
 ## [v0.1.6] — 2026-05-18
 
 RTL-SDR driver stabilization release. Eleven merged PRs land

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -582,7 +582,14 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 
 	// Metrics — optional. Subscribes to the bus at construction time.
 	if cfg.Metrics.Enabled {
-		m, err := metrics.New(d.bus, d.pool, version)
+		// Avoid the typed-nil interface trap: when d.pool is nil
+		// (no SDRs configured), pass a nil interface explicitly so
+		// the snapshot collector skips itself.
+		var pool metrics.Snapshotter
+		if d.pool != nil {
+			pool = d.pool
+		}
+		m, err := metrics.New(d.bus, pool, version)
 		if err != nil {
 			return nil, fmt.Errorf("daemon: metrics: %w", err)
 		}

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -582,7 +582,7 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 
 	// Metrics — optional. Subscribes to the bus at construction time.
 	if cfg.Metrics.Enabled {
-		m, err := metrics.New(d.bus, version)
+		m, err := metrics.New(d.bus, d.pool, version)
 		if err != nil {
 			return nil, fmt.Errorf("daemon: metrics: %w", err)
 		}

--- a/cmd/gophertrunk/integration_test.go
+++ b/cmd/gophertrunk/integration_test.go
@@ -151,7 +151,8 @@ func TestDaemonEndToEnd(t *testing.T) {
 	// build_info gauge with our supplied version.
 	metricsBody := scrape(t, base+"/metrics")
 	for _, want := range []string{
-		`gophertrunk_calls_active 1`,
+		`gophertrunk_calls_active{protocol="p25",system="Alpha"} 1`,
+		`gophertrunk_calls_started_total{encrypted="false",protocol="p25",system="Alpha"} 1`,
 		`gophertrunk_build_info{version="integration-test"} 1`,
 	} {
 		if !strings.Contains(metricsBody, want) {
@@ -174,14 +175,15 @@ func TestDaemonEndToEnd(t *testing.T) {
 	})
 
 	deadline = time.Now().Add(2 * time.Second)
+	want := `gophertrunk_calls_total{encrypted="false",protocol="p25",reason="normal",system="Alpha"} 1`
 	for time.Now().Before(deadline) {
 		body := scrape(t, base+"/metrics")
-		if strings.Contains(body, `gophertrunk_calls_total{reason="normal"} 1`) {
+		if strings.Contains(body, want) {
 			return
 		}
 		time.Sleep(20 * time.Millisecond)
 	}
-	t.Errorf("metrics never surfaced calls_total{reason=normal}")
+	t.Errorf("metrics never surfaced %s", want)
 }
 
 func waitForRecording(t *testing.T, root, alpha string, timeout time.Duration) {

--- a/docs/hardening.md
+++ b/docs/hardening.md
@@ -147,22 +147,36 @@ collector lives in [`internal/metrics`](../internal/metrics).
 
 Series exposed:
 
-| Series                                                  | Type    | Description                                                       |
-| ------------------------------------------------------- | ------- | ----------------------------------------------------------------- |
-| `gophertrunk_events_total{kind=...}`                    | counter | Every event observed on the internal bus, by kind                 |
-| `gophertrunk_calls_total{reason=...}`                   | counter | Calls completed, labelled by `EndReason` (normal/preempted/...)   |
-| `gophertrunk_calls_active`                              | gauge   | Currently-active call count                                       |
-| `gophertrunk_control_channel_locked{system=...}`        | gauge   | `1` while the named system has its CC locked, `0` otherwise        |
-| `gophertrunk_sdr_iq_underruns_total{driver,serial}`     | counter | IQ pipeline drops because a downstream stage was too slow         |
-| `gophertrunk_sdr_usb_reconnects_total{driver,serial}`   | counter | Times the USB driver had to re-open a device                      |
-| `gophertrunk_decode_errors_total{protocol,stage}`       | counter | Decode failures by protocol + stage (e.g. `p25`/`tsbk-crc`)       |
-| `gophertrunk_sdr_attached{driver,serial,role}`          | gauge   | `1` per currently-attached SDR                                    |
-| `gophertrunk_build_info{version}`                       | gauge   | Always `1`; carries the build version as a label                  |
+| Series                                                          | Type    | Description                                                                                                |
+| --------------------------------------------------------------- | ------- | ---------------------------------------------------------------------------------------------------------- |
+| `gophertrunk_events_total{kind=...}`                            | counter | Every event observed on the internal bus, by kind                                                          |
+| `gophertrunk_calls_started_total{system,protocol,encrypted}`    | counter | Calls started; more reliable rate signal than `_total` when the daemon dies mid-call                       |
+| `gophertrunk_calls_total{system,protocol,encrypted,reason}`     | counter | Calls completed, labelled by `Grant` dimensions and `EndReason`                                            |
+| `gophertrunk_calls_active{system,protocol}`                     | gauge   | Active calls per system+protocol; use `sum()` for the daemon-wide total                                    |
+| `gophertrunk_control_channel_locked{system=...}`                | gauge   | `1` while the named system has its CC locked, `0` otherwise                                                |
+| `gophertrunk_control_channel_frequency_hz{system=...}`          | gauge   | Currently-locked CC frequency in Hz; series is deleted on loss                                             |
+| `gophertrunk_control_channel_transitions_total{system,event}`   | counter | CC lock/lost transitions (`event` ∈ `locked`,`lost`) — useful for spotting churn under poor SNR            |
+| `gophertrunk_sdr_attached{driver,serial,role}`                  | gauge   | Event-driven attach state — `1` per currently-attached SDR                                                 |
+| `gophertrunk_sdr_gain_db{driver,serial,role}`                   | gauge   | Configured gain in dB; `NaN` under AGC (pair with `gophertrunk_sdr_gain_auto` to filter)                   |
+| `gophertrunk_sdr_gain_auto{driver,serial,role}`                 | gauge   | `1` when the tuner is running AGC, `0` otherwise                                                           |
+| `gophertrunk_sdr_ppm{driver,serial,role}`                       | gauge   | Configured frequency-error correction in parts-per-million                                                 |
+| `gophertrunk_sdr_bias_tee{driver,serial,role}`                  | gauge   | `1` when the SDR's 5 V bias-tee output is enabled                                                          |
+| `gophertrunk_sdr_iq_underruns_total{driver,serial}`             | counter | IQ pipeline drops because a downstream stage was too slow                                                  |
+| `gophertrunk_sdr_usb_reconnects_total{driver,serial}`           | counter | Times the USB driver had to re-open a device                                                               |
+| `gophertrunk_decode_errors_total{protocol,stage}`               | counter | Decode failures by protocol + stage (e.g. `p25`/`tsbk-crc`)                                                |
+| `gophertrunk_build_info{version}`                               | gauge   | Always `1`; carries the build version as a label                                                           |
 
-The bus-driven counters (`events_total`, `calls_total`, `calls_active`,
-`control_channel_locked`) update automatically. Subsystems push the
-others via `Metrics.RecordIQUnderrun`, `RecordUSBReconnect`,
-`RecordDecodeError`, and `SetSDRAttached`.
+The bus-driven counters and gauges (`events_total`, `calls_started_total`,
+`calls_total`, `calls_active`, `control_channel_locked`,
+`control_channel_frequency_hz`, `control_channel_transitions_total`)
+update automatically as the trunking engine fires events. Subsystems
+push `iq_underruns_total`, `usb_reconnects_total`, `decode_errors_total`,
+and the event-driven `sdr_attached` gauge via `Metrics.RecordIQUnderrun`,
+`RecordUSBReconnect`, `RecordDecodeError`, and `SetSDRAttached`. The
+per-device tuning gauges (`sdr_gain_db`, `sdr_gain_auto`, `sdr_ppm`,
+`sdr_bias_tee`) come from a scrape-time snapshot collector that reads
+`sdr.Pool.Snapshot()` on every `/metrics` request, so the values always
+reflect live pool state.
 
 ## Graceful shutdown
 

--- a/docs/user-guide-windows.md
+++ b/docs/user-guide-windows.md
@@ -1079,13 +1079,20 @@ Prometheus exposition (when `metrics.enabled: true`):
 | Series | Type | Description |
 | --- | --- | --- |
 | `gophertrunk_events_total{kind=...}` | counter | Every event observed on the internal bus |
-| `gophertrunk_calls_total{reason=...}` | counter | Calls completed by EndReason |
-| `gophertrunk_calls_active` | gauge | Currently-active call count |
+| `gophertrunk_calls_started_total{system,protocol,encrypted}` | counter | Calls started, by system/protocol/encryption |
+| `gophertrunk_calls_total{system,protocol,encrypted,reason}` | counter | Calls completed, by system/protocol/encryption + EndReason |
+| `gophertrunk_calls_active{system,protocol}` | gauge | Active calls per system+protocol (use `sum()` for total) |
 | `gophertrunk_control_channel_locked{system=...}` | gauge | 1 while CC locked |
+| `gophertrunk_control_channel_frequency_hz{system=...}` | gauge | Locked CC frequency in Hz; series deleted on loss |
+| `gophertrunk_control_channel_transitions_total{system,event}` | counter | CC lock/lost transitions |
+| `gophertrunk_sdr_attached{driver,serial,role}` | gauge | 1 per attached SDR (event-driven) |
+| `gophertrunk_sdr_gain_db{driver,serial,role}` | gauge | Configured gain in dB; NaN under AGC |
+| `gophertrunk_sdr_gain_auto{driver,serial,role}` | gauge | 1 when tuner is running AGC |
+| `gophertrunk_sdr_ppm{driver,serial,role}` | gauge | Configured PPM correction |
+| `gophertrunk_sdr_bias_tee{driver,serial,role}` | gauge | 1 when bias-tee is enabled |
 | `gophertrunk_sdr_iq_underruns_total{driver,serial}` | counter | IQ pipeline drops |
 | `gophertrunk_sdr_usb_reconnects_total{driver,serial}` | counter | USB re-opens |
 | `gophertrunk_decode_errors_total{protocol,stage}` | counter | Decode failures |
-| `gophertrunk_sdr_attached{driver,serial,role}` | gauge | 1 per attached SDR |
 | `gophertrunk_build_info{version}` | gauge | Always 1; build version label |
 
 ### `GET /api/v1/health`

--- a/internal/api/metrics_test.go
+++ b/internal/api/metrics_test.go
@@ -13,7 +13,7 @@ import (
 func TestMetricsEndpointExposesPromText(t *testing.T) {
 	bus := events.NewBus(8)
 	defer bus.Close()
-	m, err := metrics.New(nil, "v9.9.9-test")
+	m, err := metrics.New(nil, nil, "v9.9.9-test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/metrics/prom.go
+++ b/internal/metrics/prom.go
@@ -25,20 +25,31 @@ import (
 
 const namespace = "gophertrunk"
 
+// Snapshotter is the subset of sdr.Pool the snapshot collector needs.
+// Declared here (rather than imported from sdr) so callers can pass a
+// nil Pool or a fake without dragging in the full sdr.Pool surface.
+type Snapshotter interface {
+	Snapshot() []sdr.SDRStatus
+}
+
 // Metrics owns the Prometheus registry and counters/gauges used by the
 // daemon.
 type Metrics struct {
 	reg *prometheus.Registry
 
 	eventsTotal   *prometheus.CounterVec
-	callsTotal    *prometheus.CounterVec // by end_reason
-	activeCalls   prometheus.Gauge
-	ccLockedGauge *prometheus.GaugeVec // by system (1 when CC locked)
+	callsTotal    *prometheus.CounterVec // by system,protocol,encrypted,reason
+	callsStarted  *prometheus.CounterVec // by system,protocol,encrypted
+	activeCalls   *prometheus.GaugeVec   // by system,protocol
+	ccLockedGauge *prometheus.GaugeVec   // by system (1 when CC locked)
+	ccFrequencyHz *prometheus.GaugeVec   // by system; deleted on CC loss
+	ccTransitions *prometheus.CounterVec // by system,event (locked|lost)
 	iqUnderruns   *prometheus.CounterVec
 	usbReconnects *prometheus.CounterVec
 	decodeErrors  *prometheus.CounterVec
 	sdrAttached   *prometheus.GaugeVec
 	versionInfo   *prometheus.GaugeVec
+	sdrSnap       *sdrSnapshotCollector
 
 	bus       *events.Bus
 	sub       *events.Subscription
@@ -48,8 +59,9 @@ type Metrics struct {
 
 // New constructs the metrics registry and (optionally) subscribes to the
 // supplied events bus. Pass nil for the bus to use the metrics package
-// purely for the manual Record* methods.
-func New(bus *events.Bus, version string) (*Metrics, error) {
+// purely for the manual Record* methods. Pass nil for pool to skip the
+// SDR snapshot collector.
+func New(bus *events.Bus, pool Snapshotter, version string) (*Metrics, error) {
 	reg := prometheus.NewRegistry()
 	m := &Metrics{
 		reg:     reg,
@@ -66,20 +78,38 @@ func New(bus *events.Bus, version string) (*Metrics, error) {
 	m.callsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: namespace,
 		Name:      "calls_total",
-		Help:      "Total calls completed, by end reason (normal, preempted, timeout, etc.).",
-	}, []string{"reason"})
+		Help:      "Total calls completed, by system, protocol, encryption state, and end reason.",
+	}, []string{"system", "protocol", "encrypted", "reason"})
 
-	m.activeCalls = prometheus.NewGauge(prometheus.GaugeOpts{
+	m.callsStarted = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: namespace,
+		Name:      "calls_started_total",
+		Help:      "Total calls started. More reliable as a rate signal than calls_total because CallEnd can be missed when the daemon dies mid-call.",
+	}, []string{"system", "protocol", "encrypted"})
+
+	m.activeCalls = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: namespace,
 		Name:      "calls_active",
-		Help:      "Number of active calls currently being followed.",
-	})
+		Help:      "Active calls currently being followed, by system and protocol. Use sum() for the daemon-wide total.",
+	}, []string{"system", "protocol"})
 
 	m.ccLockedGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: namespace,
 		Name:      "control_channel_locked",
 		Help:      "1 when GopherTrunk is locked to a control channel for the named system, 0 otherwise.",
 	}, []string{"system"})
+
+	m.ccFrequencyHz = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: namespace,
+		Name:      "control_channel_frequency_hz",
+		Help:      "Currently-locked control-channel frequency for the named system, in Hz. Series is deleted when the CC is lost.",
+	}, []string{"system"})
+
+	m.ccTransitions = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: namespace,
+		Name:      "control_channel_transitions_total",
+		Help:      "Control-channel lock/lost transitions per system, useful for spotting churn under poor SNR.",
+	}, []string{"system", "event"})
 
 	m.iqUnderruns = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: namespace,
@@ -119,17 +149,25 @@ func New(bus *events.Bus, version string) (*Metrics, error) {
 		Help:      "Always 1; carries the build version as a label.",
 	}, []string{"version"})
 
-	for _, c := range []prometheus.Collector{
+	collectors := []prometheus.Collector{
 		m.eventsTotal,
 		m.callsTotal,
+		m.callsStarted,
 		m.activeCalls,
 		m.ccLockedGauge,
+		m.ccFrequencyHz,
+		m.ccTransitions,
 		m.iqUnderruns,
 		m.usbReconnects,
 		m.decodeErrors,
 		m.sdrAttached,
 		m.versionInfo,
-	} {
+	}
+	if pool != nil {
+		m.sdrSnap = newSDRSnapshotCollector(pool)
+		collectors = append(collectors, m.sdrSnap)
+	}
+	for _, c := range collectors {
 		if err := reg.Register(c); err != nil {
 			return nil, err
 		}
@@ -194,20 +232,35 @@ func (m *Metrics) observeEvent(ev events.Event) {
 	m.eventsTotal.WithLabelValues(string(ev.Kind)).Inc()
 	switch ev.Kind {
 	case events.KindCallStart:
-		m.activeCalls.Inc()
+		if cs, ok := ev.Payload.(trunking.CallStart); ok {
+			sys, proto, enc := callLabels(cs.Grant)
+			m.activeCalls.WithLabelValues(sys, proto).Inc()
+			m.callsStarted.WithLabelValues(sys, proto, enc).Inc()
+		}
 	case events.KindCallEnd:
-		m.activeCalls.Dec()
 		if ce, ok := ev.Payload.(trunking.CallEnd); ok {
-			m.callsTotal.WithLabelValues(ce.Reason.String()).Inc()
+			sys, proto, enc := callLabels(ce.Grant)
+			m.activeCalls.WithLabelValues(sys, proto).Dec()
+			m.callsTotal.WithLabelValues(sys, proto, enc, ce.Reason.String()).Inc()
 		}
 	case events.KindCCLocked:
 		// Best-effort system-name extraction; both phase1.LockState and
 		// the DMR / NXDN LockStates have FrequencyHz but not all carry
 		// the system name. We default to "unknown" so the gauge always
 		// has at least one label set.
-		m.ccLockedGauge.WithLabelValues(systemLabel(ev)).Set(1)
+		sys := systemLabel(ev)
+		m.ccLockedGauge.WithLabelValues(sys).Set(1)
+		m.ccTransitions.WithLabelValues(sys, "locked").Inc()
+		if lp, ok := ev.Payload.(trunking.LockedPayload); ok {
+			if hz := lp.LockedFrequencyHz(); hz != 0 {
+				m.ccFrequencyHz.WithLabelValues(sys).Set(float64(hz))
+			}
+		}
 	case events.KindCCLost:
-		m.ccLockedGauge.WithLabelValues(systemLabel(ev)).Set(0)
+		sys := systemLabel(ev)
+		m.ccLockedGauge.WithLabelValues(sys).Set(0)
+		m.ccTransitions.WithLabelValues(sys, "lost").Inc()
+		m.ccFrequencyHz.DeleteLabelValues(sys)
 	case events.KindDecodeError:
 		if de, ok := ev.Payload.(events.DecodeError); ok {
 			m.decodeErrors.WithLabelValues(de.Protocol, string(de.Stage)).Inc()
@@ -260,6 +313,26 @@ func systemLabel(ev events.Event) string {
 		}
 	}
 	return "unknown"
+}
+
+// callLabels derives the (system, protocol, encrypted) label triple for
+// the per-call CounterVecs and GaugeVec. Empty strings fall back to
+// "unknown" so cardinality stays bounded.
+func callLabels(g trunking.Grant) (system, protocol, encrypted string) {
+	system = g.System
+	if system == "" {
+		system = "unknown"
+	}
+	protocol = g.Protocol
+	if protocol == "" {
+		protocol = "unknown"
+	}
+	if g.Encrypted {
+		encrypted = "true"
+	} else {
+		encrypted = "false"
+	}
+	return
 }
 
 // ErrAlreadyRegistered is returned by New when the supplied registry

--- a/internal/metrics/prom_test.go
+++ b/internal/metrics/prom_test.go
@@ -3,6 +3,7 @@ package metrics
 import (
 	"context"
 	"io"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -18,7 +19,7 @@ import (
 func TestEventsCounterIncrements(t *testing.T) {
 	bus := events.NewBus(8)
 	defer bus.Close()
-	m, err := New(bus, "v0.0.0-test")
+	m, err := New(bus, nil, "v0.0.0-test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -47,7 +48,7 @@ func TestEventsCounterIncrements(t *testing.T) {
 func TestCallsActiveTracksStartAndEnd(t *testing.T) {
 	bus := events.NewBus(8)
 	defer bus.Close()
-	m, _ := New(bus, "test")
+	m, _ := New(bus, nil, "test")
 	defer m.Close()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -64,14 +65,15 @@ func TestCallsActiveTracksStartAndEnd(t *testing.T) {
 		StartedAt: time.Now(),
 	}})
 
+	active := m.activeCalls.WithLabelValues("Alpha", "unknown")
 	deadline := time.Now().Add(time.Second)
 	for time.Now().Before(deadline) {
-		if testutil.ToFloat64(m.activeCalls) == 2 {
+		if testutil.ToFloat64(active) == 2 {
 			break
 		}
 		time.Sleep(5 * time.Millisecond)
 	}
-	if got := testutil.ToFloat64(m.activeCalls); got != 2 {
+	if got := testutil.ToFloat64(active); got != 2 {
 		t.Errorf("active = %v, want 2", got)
 	}
 
@@ -82,23 +84,23 @@ func TestCallsActiveTracksStartAndEnd(t *testing.T) {
 	}})
 	deadline = time.Now().Add(time.Second)
 	for time.Now().Before(deadline) {
-		if testutil.ToFloat64(m.activeCalls) == 1 {
+		if testutil.ToFloat64(active) == 1 {
 			break
 		}
 		time.Sleep(5 * time.Millisecond)
 	}
-	if got := testutil.ToFloat64(m.activeCalls); got != 1 {
+	if got := testutil.ToFloat64(active); got != 1 {
 		t.Errorf("active after end = %v, want 1", got)
 	}
-	if got := testutil.ToFloat64(m.callsTotal.WithLabelValues("normal")); got != 1 {
-		t.Errorf("calls_total{normal} = %v, want 1", got)
+	if got := testutil.ToFloat64(m.callsTotal.WithLabelValues("Alpha", "unknown", "false", "normal")); got != 1 {
+		t.Errorf("calls_total{Alpha,unknown,false,normal} = %v, want 1", got)
 	}
 }
 
 func TestDecodeErrorEventIncrementsCounter(t *testing.T) {
 	bus := events.NewBus(8)
 	defer bus.Close()
-	m, _ := New(bus, "test")
+	m, _ := New(bus, nil, "test")
 	defer m.Close()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -124,7 +126,7 @@ func TestDecodeErrorEventIncrementsCounter(t *testing.T) {
 }
 
 func TestRecordHooks(t *testing.T) {
-	m, _ := New(nil, "test")
+	m, _ := New(nil, nil, "test")
 	defer m.Close()
 
 	m.RecordIQUnderrun("rtlsdr", "AAA")
@@ -148,7 +150,7 @@ func TestRecordHooks(t *testing.T) {
 }
 
 func TestHandlerScrapeContainsExpectedSeries(t *testing.T) {
-	m, _ := New(nil, "v1.2.3")
+	m, _ := New(nil, nil, "v1.2.3")
 	defer m.Close()
 	m.RecordDecodeError("p25", "tsbk-crc")
 
@@ -174,7 +176,7 @@ func TestHandlerScrapeContainsExpectedSeries(t *testing.T) {
 func TestCloseIsIdempotent(t *testing.T) {
 	bus := events.NewBus(2)
 	defer bus.Close()
-	m, _ := New(bus, "test")
+	m, _ := New(bus, nil, "test")
 	go m.Run(context.Background())
 	if err := m.Close(); err != nil {
 		t.Fatal(err)
@@ -187,7 +189,7 @@ func TestCloseIsIdempotent(t *testing.T) {
 func TestSDRAttachedGaugeFromBusEvents(t *testing.T) {
 	bus := events.NewBus(8)
 	defer bus.Close()
-	m, err := New(bus, "v0.0.0-test")
+	m, err := New(bus, nil, "v0.0.0-test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -221,5 +223,199 @@ func TestSDRAttachedGaugeFromBusEvents(t *testing.T) {
 	}
 	if got := testutil.ToFloat64(m.sdrAttached.WithLabelValues(st.Driver, st.Serial, st.Role)); got != 0 {
 		t.Errorf("after KindSDRDetached: gauge = %v, want 0", got)
+	}
+}
+
+func TestCallsTotalCarriesGrantDimensions(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	m, _ := New(bus, nil, "test")
+	defer m.Close()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go m.Run(ctx)
+
+	grant := trunking.Grant{
+		System:    "NET-7",
+		Protocol:  "p25",
+		GroupID:   42,
+		Encrypted: true,
+	}
+	start := time.Now()
+	bus.Publish(events.Event{Kind: events.KindCallStart, Payload: trunking.CallStart{
+		Grant: grant, DeviceSerial: "Z", StartedAt: start,
+	}})
+
+	started := m.callsStarted.WithLabelValues("NET-7", "p25", "true")
+	active := m.activeCalls.WithLabelValues("NET-7", "p25")
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if testutil.ToFloat64(started) == 1 && testutil.ToFloat64(active) == 1 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if got := testutil.ToFloat64(started); got != 1 {
+		t.Errorf("calls_started_total{NET-7,p25,true} = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(active); got != 1 {
+		t.Errorf("calls_active{NET-7,p25} = %v, want 1", got)
+	}
+
+	bus.Publish(events.Event{Kind: events.KindCallEnd, Payload: trunking.CallEnd{
+		Grant: grant, DeviceSerial: "Z",
+		StartedAt: start, EndedAt: start.Add(time.Second),
+		Reason: trunking.EndReasonPreempted,
+	}})
+
+	total := m.callsTotal.WithLabelValues("NET-7", "p25", "true", "preempted")
+	deadline = time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if testutil.ToFloat64(total) == 1 && testutil.ToFloat64(active) == 0 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if got := testutil.ToFloat64(total); got != 1 {
+		t.Errorf("calls_total{NET-7,p25,true,preempted} = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(active); got != 0 {
+		t.Errorf("calls_active{NET-7,p25} after end = %v, want 0", got)
+	}
+}
+
+type fakeLockState struct {
+	freq uint32
+	sys  string
+}
+
+func (f fakeLockState) LockedFrequencyHz() uint32 { return f.freq }
+func (f fakeLockState) LockedNAC() uint16         { return 0 }
+func (f fakeLockState) SystemName() string        { return f.sys }
+
+func TestControlChannelFrequencyAndTransitions(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	m, _ := New(bus, nil, "test")
+	defer m.Close()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go m.Run(ctx)
+
+	const freqHz = uint32(851012500)
+	bus.Publish(events.Event{Kind: events.KindCCLocked, Payload: fakeLockState{freq: freqHz, sys: "S"}})
+
+	freqGauge := m.ccFrequencyHz.WithLabelValues("S")
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if testutil.ToFloat64(freqGauge) == float64(freqHz) {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if got := testutil.ToFloat64(freqGauge); got != float64(freqHz) {
+		t.Errorf("control_channel_frequency_hz{S} = %v, want %v", got, freqHz)
+	}
+	if got := testutil.ToFloat64(m.ccTransitions.WithLabelValues("S", "locked")); got != 1 {
+		t.Errorf("transitions{S,locked} = %v, want 1", got)
+	}
+
+	bus.Publish(events.Event{Kind: events.KindCCLost, Payload: fakeLockState{freq: freqHz, sys: "S"}})
+
+	deadline = time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if testutil.ToFloat64(m.ccTransitions.WithLabelValues("S", "lost")) == 1 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if got := testutil.ToFloat64(m.ccTransitions.WithLabelValues("S", "lost")); got != 1 {
+		t.Errorf("transitions{S,lost} = %v, want 1", got)
+	}
+
+	srv := httptest.NewServer(m.Handler())
+	defer srv.Close()
+	resp, err := http.Get(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if strings.Contains(string(body), `gophertrunk_control_channel_frequency_hz{system="S"}`) {
+		t.Errorf("control_channel_frequency_hz{S} should be deleted after CC lost; body:\n%s", string(body))
+	}
+}
+
+type fakePool struct {
+	statuses []sdr.SDRStatus
+}
+
+func (f *fakePool) Snapshot() []sdr.SDRStatus { return f.statuses }
+
+func TestSDRSnapshotCollectorEmitsPerDevice(t *testing.T) {
+	pool := &fakePool{statuses: []sdr.SDRStatus{
+		{Driver: "rtlsdr", Serial: "A", Role: "control", Attached: true, GainTenthDB: 296, GainAuto: false, PPM: -2, BiasTee: true},
+		{Driver: "rtlsdr", Serial: "B", Role: "voice", Attached: true, GainAuto: true, PPM: 0, BiasTee: false},
+		{Driver: "rtlsdr", Serial: "C", Role: "voice", Attached: false, GainTenthDB: 100},
+	}}
+	m, err := New(nil, pool, "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer m.Close()
+
+	srv := httptest.NewServer(m.Handler())
+	defer srv.Close()
+	resp, err := http.Get(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	text := string(body)
+
+	for _, want := range []string{
+		`gophertrunk_sdr_ppm{driver="rtlsdr",role="control",serial="A"} -2`,
+		`gophertrunk_sdr_bias_tee{driver="rtlsdr",role="control",serial="A"} 1`,
+		`gophertrunk_sdr_gain_auto{driver="rtlsdr",role="control",serial="A"} 0`,
+		`gophertrunk_sdr_gain_db{driver="rtlsdr",role="control",serial="A"} 29.6`,
+		`gophertrunk_sdr_gain_auto{driver="rtlsdr",role="voice",serial="B"} 1`,
+		`gophertrunk_sdr_gain_db{driver="rtlsdr",role="voice",serial="B"} NaN`,
+		`gophertrunk_sdr_bias_tee{driver="rtlsdr",role="voice",serial="B"} 0`,
+	} {
+		if !strings.Contains(text, want) {
+			t.Errorf("scrape missing %q.\nbody:\n%s", want, text)
+		}
+	}
+	if strings.Contains(text, `serial="C"`) {
+		t.Errorf("detached device C should not appear in snapshot; body:\n%s", text)
+	}
+
+	// Spot-check the NaN path through the registry gather, since the
+	// scrape text always renders NaN identically — Gather lets us check
+	// the actual float bits.
+	families, err := m.Registry().Gather()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var foundNaN bool
+	for _, fam := range families {
+		if fam.GetName() != "gophertrunk_sdr_gain_db" {
+			continue
+		}
+		for _, mf := range fam.GetMetric() {
+			var serial string
+			for _, lp := range mf.GetLabel() {
+				if lp.GetName() == "serial" {
+					serial = lp.GetValue()
+				}
+			}
+			if serial == "B" && math.IsNaN(mf.GetGauge().GetValue()) {
+				foundNaN = true
+			}
+		}
+	}
+	if !foundNaN {
+		t.Errorf("expected NaN gain_db for serial B (AGC), did not find it")
 	}
 }

--- a/internal/metrics/sdr_snapshot.go
+++ b/internal/metrics/sdr_snapshot.go
@@ -1,0 +1,78 @@
+package metrics
+
+import (
+	"math"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// sdrSnapshotCollector implements prometheus.Collector by snapshotting
+// the SDR pool at scrape time. It exposes the per-device tuning
+// parameters (gain, AGC, PPM, bias-tee) that the event-driven counters
+// in prom.go don't cover. Pull-mode keeps state out of the metrics
+// struct and ensures the values can't go stale relative to the pool.
+type sdrSnapshotCollector struct {
+	pool Snapshotter
+
+	gainDB   *prometheus.Desc
+	gainAuto *prometheus.Desc
+	ppm      *prometheus.Desc
+	biasTee  *prometheus.Desc
+}
+
+func newSDRSnapshotCollector(p Snapshotter) *sdrSnapshotCollector {
+	labels := []string{"driver", "serial", "role"}
+	return &sdrSnapshotCollector{
+		pool: p,
+		gainDB: prometheus.NewDesc(
+			namespace+"_sdr_gain_db",
+			"Configured gain in dB for the SDR. NaN when the tuner is running AGC; pair with gophertrunk_sdr_gain_auto to filter.",
+			labels, nil,
+		),
+		gainAuto: prometheus.NewDesc(
+			namespace+"_sdr_gain_auto",
+			"1 when the tuner is running automatic gain control, 0 otherwise.",
+			labels, nil,
+		),
+		ppm: prometheus.NewDesc(
+			namespace+"_sdr_ppm",
+			"Configured frequency-error correction in parts-per-million.",
+			labels, nil,
+		),
+		biasTee: prometheus.NewDesc(
+			namespace+"_sdr_bias_tee",
+			"1 when the SDR's 5 V bias-tee output is enabled, 0 otherwise.",
+			labels, nil,
+		),
+	}
+}
+
+func (c *sdrSnapshotCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.gainDB
+	ch <- c.gainAuto
+	ch <- c.ppm
+	ch <- c.biasTee
+}
+
+func (c *sdrSnapshotCollector) Collect(ch chan<- prometheus.Metric) {
+	for _, s := range c.pool.Snapshot() {
+		if !s.Attached {
+			continue
+		}
+		gain := math.NaN()
+		if !s.GainAuto {
+			gain = float64(s.GainTenthDB) / 10.0
+		}
+		ch <- prometheus.MustNewConstMetric(c.gainDB, prometheus.GaugeValue, gain, s.Driver, s.Serial, s.Role)
+		ch <- prometheus.MustNewConstMetric(c.gainAuto, prometheus.GaugeValue, boolToFloat(s.GainAuto), s.Driver, s.Serial, s.Role)
+		ch <- prometheus.MustNewConstMetric(c.ppm, prometheus.GaugeValue, float64(s.PPM), s.Driver, s.Serial, s.Role)
+		ch <- prometheus.MustNewConstMetric(c.biasTee, prometheus.GaugeValue, boolToFloat(s.BiasTee), s.Driver, s.Serial, s.Role)
+	}
+}
+
+func boolToFloat(b bool) float64 {
+	if b {
+		return 1
+	}
+	return 0
+}


### PR DESCRIPTION
Expand the Prometheus /metrics endpoint with the dimensions Grafana
dashboards need:

* calls_total / calls_started_total / calls_active gain {system,
  protocol, encrypted} labels (calls_total also keeps {reason}).
* control_channel_frequency_hz{system} surfaces the locked CC; the
  series is deleted on loss to avoid stale values.
* control_channel_transitions_total{system,event} counts lock/lost
  flips, useful for spotting CC churn under poor SNR.
* New scrape-time SDR snapshot collector emits sdr_gain_db,
  sdr_gain_auto, sdr_ppm, and sdr_bias_tee per attached device,
  reading sdr.Pool.Snapshot() directly so the values can never go
  stale relative to the pool.

calls_total / calls_active label changes are intentional and noted in
the changelog; old dashboards recover via `sum without(...)`.

https://claude.ai/code/session_01EYFeoULLZTPwGb48Pu7fA4