### PR TITLE
import-pdf: native RR CSV, parser diagnostics, doc fix for #271

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,17 @@ for tagged releases.
   `gophertrunk_sdr_bias_tee{driver,serial,role}`. SDR tuning gauges
   come from a scrape-time snapshot collector so they always reflect
   live pool state.
+- **Native RadioReference CSV import** for `gophertrunk import-pdf`
+  (issue #271). RadioReference's `/db/sid/<sid>/download` CSV is a
+  flat talkgroup list with no metadata — the importer auto-detects
+  the format and the new `-name` / `-sysid` flags supply the missing
+  fields (filename stem is used when `-name` is omitted). Native CSV
+  carries no sites; combine with a `-pdf` (or bundle CSV) when you
+  need control-channel frequencies.
+- **`-extract-only` flag for `gophertrunk import-pdf`.** Paired with
+  a single `-pdf`, dumps the positioned-text rows extracted from the
+  PDF as JSON to stdout and exits, so parser bug reports can ship a
+  ready-to-replay fixture without sharing the original PDF.
 
 ### Changed
 
@@ -28,6 +39,21 @@ for tagged releases.
   GaugeVec keyed by `{system,protocol}` (was a bare gauge). Dashboards
   that previously scraped the unlabeled shape can recover with
   `sum without(system,protocol,encrypted) (gophertrunk_calls_total)`.
+- `docs/import.md` and `docs/user-guide-windows.md`: RadioReference
+  moved the PDF export from the page footer to the top **Download**
+  menu (PDF / CSV / DSD options at `/db/sid/<sid>/download`).
+  Instructions updated.
+
+### Fixed
+
+- `gophertrunk import-pdf` no-System-Name error now prints the first
+  ~30 extracted rows inline so the failure is self-diagnosing
+  (issue #271).
+- `parseMetaLine` accepts case-insensitive and whitespace-variant
+  labels (`SYSTEM NAME:`, `System Name :`, double-spaces). Falls back
+  to the page-title banner ("`<System> Menu`") when no explicit
+  `System Name:` line is present, so a minor RadioReference layout
+  tweak no longer breaks extraction (issue #271).
 
 ## [v0.1.6] — 2026-05-18
 

--- a/cmd/gophertrunk/import.go
+++ b/cmd/gophertrunk/import.go
@@ -25,24 +25,39 @@ func runImport(args []string) {
 	dryRun := fs.Bool("dry-run", false, "print the planned changes and exit without writing")
 	force := fs.Bool("force", false, "overwrite an existing trunking.systems entry with the same name")
 	wizard := fs.Bool("wizard", false, "launch the interactive config-builder wizard before any import")
+	extractOnly := fs.Bool("extract-only", false, "dump positioned-text rows from a -pdf as JSON to stdout and exit (for parser bug reports)")
+	nameOverride := fs.String("name", "", "system name for native RadioReference CSV imports (bundle CSVs ignore this — use the metadata section)")
+	sysidOverride := fs.String("sysid", "", "system ID for native RadioReference CSV imports")
 	var pdfPaths repeatedString
 	var csvPaths repeatedString
 	fs.Var(&pdfPaths, "pdf", "path to a RadioReference PDF system export (repeatable)")
-	fs.Var(&csvPaths, "csv", "path to a structured CSV bundle (repeatable; see docs/import.md)")
+	fs.Var(&csvPaths, "csv", "path to a CSV file (repeatable). Either a multi-section bundle (see docs/import.md) or RadioReference's native /db/sid/<sid>/download CSV.")
 	fs.Usage = func() {
 		fmt.Fprintf(fs.Output(), `gophertrunk import-pdf — import system definitions into config.yaml
 
 Sources:
   -pdf <file.pdf>   RadioReference.com PDF export (auto-extracts metadata,
-                    sites, and talkgroups).
-  -csv <file.csv>   Multi-section structured CSV bundle. One file per system,
-                    with metadata / sites / talkgroups sections. See
-                    docs/import.md for the format spec and an annotated example.
+                    sites, and talkgroups). Available from the "Download"
+                    menu at the top of a trunked-system page (URL pattern
+                    https://www.radioreference.com/db/sid/<sid>/download).
+  -csv <file.csv>   Either a multi-section structured CSV bundle (one file
+                    per system; see docs/import.md) OR RadioReference's
+                    native talkgroup CSV from the same Download menu. The
+                    importer auto-detects which format the file is. Native
+                    RR CSVs carry no metadata — combine with -name / -sysid
+                    to supply it (the filename stem is used when -name is
+                    omitted).
 
 Both flags are repeatable and may be combined in a single invocation. The
 parsed systems are merged into config.yaml (preserving comments) and a
 per-system Trunk-Recorder-style talkgroup CSV is written next to the config
 (or to -csv-dir).
+
+Bug reports:
+  -extract-only     Combined with a single -pdf, dumps the positioned-text
+                    rows extracted from the PDF as JSON to stdout, then
+                    exits. Attach the output to a parser bug report so
+                    maintainers can reproduce without the original PDF.
 
 By default the importer launches an interactive TUI so you can prune sites,
 toggle Scan/Lockout flags, and set priorities before write. Pass -no-tui to
@@ -72,6 +87,26 @@ Flags:
 	if !*wizard && len(pdfPaths) == 0 && len(csvPaths) == 0 {
 		fs.Usage()
 		fail("at least one of -wizard, -pdf, or -csv is required")
+	}
+
+	// -extract-only is a diagnostic dump: must be paired with exactly
+	// one -pdf and nothing else, so we never silently merge anything
+	// when the operator just wanted to share a fixture.
+	if *extractOnly {
+		if *wizard || len(csvPaths) > 0 {
+			fail("-extract-only cannot be combined with -wizard or -csv")
+		}
+		if len(pdfPaths) != 1 {
+			fail("-extract-only requires exactly one -pdf <file>")
+		}
+		rows, err := extractPDFRows(pdfPaths[0])
+		if err != nil {
+			fail(err.Error())
+		}
+		if err := dumpParseRowsJSON(os.Stdout, rows); err != nil {
+			fail("write rows: " + err.Error())
+		}
+		return
 	}
 
 	// Wizard mode: run the interactive config builder first. The
@@ -123,8 +158,9 @@ Flags:
 		fmt.Fprintf(os.Stderr, "import-pdf: parsed PDF %s: %s (%d sites, %d talkgroups)\n",
 			p, sys.Name, len(sys.Sites), len(sys.Talkgroups))
 	}
+	csvOpts := csvImportOpts{Name: *nameOverride, SysID: *sysidOverride}
 	for _, p := range csvPaths {
-		sys, err := parseCSVFile(p)
+		sys, err := parseCSVFile(p, csvOpts)
 		if err != nil {
 			fail(err.Error())
 		}

--- a/cmd/gophertrunk/import_csv.go
+++ b/cmd/gophertrunk/import_csv.go
@@ -2,31 +2,65 @@ package main
 
 import (
 	"bufio"
+	"bytes"
 	"errors"
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 )
 
-// parseCSVFile loads a multi-section CSV bundle from disk and turns it
-// into a parsedSystem. See docs/import.md for the format. Sections
-// supported: metadata, sites, talkgroups. Order doesn't matter; any
-// section may be omitted (but metadata.name is required and at least
-// one of sites/talkgroups must be present).
-func parseCSVFile(path string) (parsedSystem, error) {
-	f, err := os.Open(path)
+// csvImportOpts carries operator-supplied metadata for CSV imports.
+// The fields are only consulted by the native-RadioReference-CSV path
+// (which has no metadata section); the multi-section bundle format
+// ignores them and continues to require metadata.name in the file.
+type csvImportOpts struct {
+	Name  string
+	SysID string
+}
+
+// parseCSVFile loads a CSV from disk and turns it into a parsedSystem.
+// Two formats are supported and detected by content sniffing:
+//
+//   - **Multi-section bundle** — `# Section: …` markers delimit
+//     metadata / sites / talkgroups blocks. See docs/import.md.
+//   - **Native RadioReference CSV** — the flat talkgroup table that
+//     RadioReference's `/db/sid/<sid>/download` page serves. Carries
+//     no metadata; opts.Name and opts.SysID supply it (with the
+//     filename stem as a fallback for the name).
+func parseCSVFile(path string, opts csvImportOpts) (parsedSystem, error) {
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return parsedSystem{}, fmt.Errorf("import-pdf: open %s: %w", path, err)
 	}
-	defer f.Close()
-	sys, err := parseCSVStream(f)
+	var sys parsedSystem
+	if looksLikeRRNativeCSV(data) {
+		fillOpts := opts
+		if fillOpts.Name == "" {
+			fillOpts.Name = filenameStem(path)
+		}
+		sys, err = parseRRNativeCSVStream(bytes.NewReader(data), fillOpts)
+	} else {
+		sys, err = parseCSVStream(bytes.NewReader(data))
+	}
 	if err != nil {
 		return parsedSystem{}, fmt.Errorf("import-pdf: %s: %w", path, err)
 	}
 	sys.SourcePath = path
 	return sys, nil
+}
+
+// filenameStem returns the base filename with its extension stripped —
+// used as the default system name for native RR CSV imports when the
+// operator didn't pass -name.
+func filenameStem(path string) string {
+	base := filepath.Base(path)
+	if i := strings.LastIndexByte(base, '.'); i > 0 {
+		base = base[:i]
+	}
+	return base
 }
 
 // csvSection collects raw lines (as []string slices, already CSV-split)
@@ -373,6 +407,22 @@ func parseCSVFrequencies(s string) ([]parsedFreq, error) {
 	return out, nil
 }
 
+// talkgroupAliases is the canonical column-alias map shared by both the
+// bundle's `talkgroups` section and the native-RR-CSV parser. Keeping
+// it in one place means a single header change covers both formats.
+var talkgroupAliases = map[string][]string{
+	"decimal":     {"dec"},
+	"hex":         {"hexadecimal"},
+	"mode":        {"type"},
+	"alpha_tag":   {"alpha tag", "alphatag", "tag_short"},
+	"description": {"desc", "name"},
+	"tag":         {"category"},
+	"group":       {"group_name", "alpha_group"},
+	"priority":    {"prio", "pri"},
+	"lockout":     {"locked", "block"},
+	"scan":        {"active", "monitor"},
+}
+
 // parseTalkgroupsSection expects decimal + alpha_tag at minimum.
 // Aliases match Trunk Recorder's CSV column names exactly so users can
 // reuse files they already have.
@@ -381,18 +431,7 @@ func parseTalkgroupsSection(sec csvSection) ([]parsedTalkgroup, error) {
 		return nil, errors.New("talkgroups section is empty")
 	}
 	header := sec.rows[0]
-	col, _ := columnMap(header, map[string][]string{
-		"decimal":     {"dec"},
-		"hex":         {"hexadecimal"},
-		"mode":        {"type"},
-		"alpha_tag":   {"alpha tag", "alphatag", "tag_short"},
-		"description": {"desc", "name"},
-		"tag":         {"category"},
-		"group":       {"group_name", "alpha_group"},
-		"priority":    {"prio", "pri"},
-		"lockout":     {"locked", "block"},
-		"scan":        {"active", "monitor"},
-	})
+	col, _ := columnMap(header, talkgroupAliases)
 	if _, ok := col["decimal"]; !ok {
 		return nil, fmt.Errorf("talkgroups header missing required column `decimal` (or `dec`) (header: %s)", strings.Join(header, ","))
 	}
@@ -400,53 +439,176 @@ func parseTalkgroupsSection(sec csvSection) ([]parsedTalkgroup, error) {
 	var out []parsedTalkgroup
 	for i, row := range sec.rows[1:] {
 		lineNum := sec.startLn + i + 1
-		decStr := cell(row, col, "decimal")
-		if decStr == "" {
+		tg, ok, err := tgFromCSVRow(row, col, lineNum)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
 			continue
 		}
-		dec64, err := strconv.ParseUint(decStr, 10, 32)
-		if err != nil {
-			return nil, fmt.Errorf("talkgroups row %d: invalid decimal %q: %w", lineNum, decStr, err)
-		}
-		hex := strings.ToLower(strings.TrimSpace(cell(row, col, "hex")))
-		if hex == "" {
-			hex = fmt.Sprintf("%x", dec64)
-		}
-		mode := strings.ToUpper(cell(row, col, "mode"))
-		switch mode {
-		case "", "D", "A", "M":
-			// ok
-		case "DE":
-			mode = "D"
-		case "TE", "T":
-			mode = "D"
-		default:
-			return nil, fmt.Errorf("talkgroups row %d: invalid mode %q (use D, A, or M)", lineNum, mode)
-		}
-		if mode == "" {
-			mode = "D"
-		}
-		pri := 0
-		if p := cell(row, col, "priority"); p != "" {
-			pri, err = strconv.Atoi(p)
-			if err != nil {
-				return nil, fmt.Errorf("talkgroups row %d: invalid priority %q", lineNum, p)
-			}
-		}
-		out = append(out, parsedTalkgroup{
-			Dec:         uint32(dec64),
-			Hex:         hex,
-			Mode:        mode,
-			AlphaTag:    cell(row, col, "alpha_tag"),
-			Description: cell(row, col, "description"),
-			Tag:         cell(row, col, "tag"),
-			Group:       cell(row, col, "group"),
-			Priority:    pri,
-			Lockout:     parseBool(cell(row, col, "lockout"), false),
-			Scan:        parseBool(cell(row, col, "scan"), true),
-		})
+		out = append(out, tg)
 	}
 	return out, nil
+}
+
+// tgFromCSVRow turns one CSV row into a parsedTalkgroup using the
+// canonical column map. ok=false (with nil error) for rows that have
+// no decimal value — typically blank rows or footer comments left in
+// place by spreadsheet exports.
+func tgFromCSVRow(row []string, col map[string]int, lineNum int) (parsedTalkgroup, bool, error) {
+	decStr := cell(row, col, "decimal")
+	if decStr == "" {
+		return parsedTalkgroup{}, false, nil
+	}
+	dec64, err := strconv.ParseUint(decStr, 10, 32)
+	if err != nil {
+		return parsedTalkgroup{}, false, fmt.Errorf("talkgroups row %d: invalid decimal %q: %w", lineNum, decStr, err)
+	}
+	hex := strings.ToLower(strings.TrimSpace(cell(row, col, "hex")))
+	if hex == "" {
+		hex = fmt.Sprintf("%x", dec64)
+	}
+	mode := strings.ToUpper(cell(row, col, "mode"))
+	switch mode {
+	case "", "D", "A", "M":
+		// ok
+	case "DE":
+		mode = "D"
+	case "TE", "T":
+		mode = "D"
+	default:
+		return parsedTalkgroup{}, false, fmt.Errorf("talkgroups row %d: invalid mode %q (use D, A, or M)", lineNum, mode)
+	}
+	if mode == "" {
+		mode = "D"
+	}
+	pri := 0
+	if p := cell(row, col, "priority"); p != "" {
+		pri, err = strconv.Atoi(p)
+		if err != nil {
+			return parsedTalkgroup{}, false, fmt.Errorf("talkgroups row %d: invalid priority %q", lineNum, p)
+		}
+	}
+	return parsedTalkgroup{
+		Dec:         uint32(dec64),
+		Hex:         hex,
+		Mode:        mode,
+		AlphaTag:    cell(row, col, "alpha_tag"),
+		Description: cell(row, col, "description"),
+		Tag:         cell(row, col, "tag"),
+		Group:       cell(row, col, "group"),
+		Priority:    pri,
+		Lockout:     parseBool(cell(row, col, "lockout"), false),
+		Scan:        parseBool(cell(row, col, "scan"), true),
+	}, true, nil
+}
+
+// looksLikeRRNativeCSV returns true when the input looks like a
+// RadioReference-native talkgroup CSV: no `# Section: …` markers
+// anywhere AND a header row whose normalised column names include at
+// least three of the canonical talkgroup fields. The check stops after
+// scanning the first 8 KiB so it stays cheap on large files.
+func looksLikeRRNativeCSV(data []byte) bool {
+	head := data
+	const peek = 8 * 1024
+	if len(head) > peek {
+		head = head[:peek]
+	}
+	scanner := bufio.NewScanner(bytes.NewReader(head))
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	var headerLine string
+	for scanner.Scan() {
+		line := scanner.Text()
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		// Any section marker disqualifies the file: it's a bundle.
+		if _, ok := matchSectionMarker(trimmed); ok {
+			return false
+		}
+		// Other comments are skipped; the bundle format uses them
+		// freely and RR's native export never does, but a stray "#"
+		// at the top shouldn't trip the sniffer either way.
+		if strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		if headerLine == "" {
+			headerLine = line
+		}
+	}
+	if headerLine == "" {
+		return false
+	}
+	fields, err := splitCSVLine(headerLine)
+	if err != nil || len(fields) < 5 {
+		return false
+	}
+	known := map[string]bool{
+		"dec": true, "decimal": true, "hex": true, "mode": true,
+		"alpha tag": true, "alpha_tag": true, "alphatag": true,
+		"description": true, "tag": true, "category": true, "group": true,
+	}
+	hits := 0
+	for _, f := range fields {
+		norm := strings.ToLower(strings.TrimSpace(f))
+		if known[norm] {
+			hits++
+		}
+	}
+	return hits >= 3
+}
+
+// parseRRNativeCSVStream parses RadioReference's flat talkgroup CSV
+// (the file served from `/db/sid/<sid>/download`). The format has no
+// metadata or sites — the operator supplies the system name and ID
+// out-of-band via opts. Empty Name yields an error: the caller is
+// expected to default to the filename stem before calling.
+func parseRRNativeCSVStream(r io.Reader, opts csvImportOpts) (parsedSystem, error) {
+	sys := parsedSystem{Protocol: "p25", Name: opts.Name, SysID: opts.SysID}
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	var header []string
+	var col map[string]int
+	lineNum := 0
+	for scanner.Scan() {
+		lineNum++
+		raw := scanner.Text()
+		trimmed := strings.TrimSpace(raw)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		fields, err := splitCSVLine(raw)
+		if err != nil {
+			return sys, fmt.Errorf("line %d: %w", lineNum, err)
+		}
+		if header == nil {
+			header = fields
+			col, _ = columnMap(header, talkgroupAliases)
+			if _, ok := col["decimal"]; !ok {
+				return sys, fmt.Errorf("native RR CSV header missing `decimal`/`dec` column (header: %s)", strings.Join(header, ","))
+			}
+			continue
+		}
+		tg, ok, err := tgFromCSVRow(fields, col, lineNum)
+		if err != nil {
+			return sys, err
+		}
+		if !ok {
+			continue
+		}
+		sys.Talkgroups = append(sys.Talkgroups, tg)
+	}
+	if err := scanner.Err(); err != nil {
+		return sys, fmt.Errorf("csv scan: %w", err)
+	}
+	if sys.Name == "" {
+		return sys, errors.New("native RR CSV: missing system name (pass -name or use a filename stem)")
+	}
+	if len(sys.Talkgroups) == 0 {
+		return sys, errors.New("native RR CSV: no talkgroups found")
+	}
+	return sys, nil
 }
 
 // parseBool turns the Trunk-Recorder-style yes/no/Y/N/1/0/true/false

--- a/cmd/gophertrunk/import_csv_test.go
+++ b/cmd/gophertrunk/import_csv_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"os"
 	"strings"
 	"testing"
 )
@@ -201,7 +202,7 @@ func TestParseCSVFrequencies_Separators(t *testing.T) {
 }
 
 func TestParseCSVFile_ExampleFixture(t *testing.T) {
-	sys, err := parseCSVFile("../../samples/rr-import/example.csv")
+	sys, err := parseCSVFile("../../samples/rr-import/example.csv", csvImportOpts{})
 	if err != nil {
 		t.Fatalf("parseCSVFile: %v", err)
 	}
@@ -256,5 +257,138 @@ decimal,alpha_tag,tag
 	}
 	if len(res.CSVs) != 1 {
 		t.Errorf("expected 1 CSV output, got %d", len(res.CSVs))
+	}
+}
+
+func TestLooksLikeRRNativeCSV(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{
+			name: "rr native header",
+			in:   "DEC,HEX,Mode,Alpha Tag,Description,Tag,Group\n1000,3e8,D,OPS,Operations,Law Dispatch,Police\n",
+			want: true,
+		},
+		{
+			name: "lower-case columns",
+			in:   "decimal,hex,mode,alpha_tag,description,tag,group\n1000,3e8,D,OPS,Ops,Law Dispatch,Police\n",
+			want: true,
+		},
+		{
+			name: "bundle with section marker",
+			in:   "# Section: metadata\nkey,value\nname,Foo\n# Section: talkgroups\ndecimal,alpha_tag\n1000,OPS\n",
+			want: false,
+		},
+		{
+			name: "blank file",
+			in:   "",
+			want: false,
+		},
+		{
+			name: "single column",
+			in:   "name\nfoo\n",
+			want: false,
+		},
+		{
+			name: "unrelated csv",
+			in:   "a,b,c,d,e,f\n1,2,3,4,5,6\n",
+			want: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := looksLikeRRNativeCSV([]byte(tc.in))
+			if got != tc.want {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseRRNativeCSVStream(t *testing.T) {
+	const in = `DEC,HEX,Mode,Alpha Tag,Description,Tag,Group
+1000,3e8,D,OPS,Operations,Law Dispatch,Police
+1001,3e9,D,TAC1,Tactical 1,Law Tac,Police
+1002,,D,FIRE,Fire Dispatch,Fire Dispatch,Fire
+`
+	sys, err := parseRRNativeCSVStream(strings.NewReader(in), csvImportOpts{Name: "Test", SysID: "49A"})
+	if err != nil {
+		t.Fatalf("parseRRNativeCSVStream: %v", err)
+	}
+	if sys.Name != "Test" {
+		t.Errorf("Name = %q, want Test", sys.Name)
+	}
+	if sys.SysID != "49A" {
+		t.Errorf("SysID = %q, want 49A", sys.SysID)
+	}
+	if sys.Protocol != "p25" {
+		t.Errorf("Protocol = %q, want p25", sys.Protocol)
+	}
+	if len(sys.Talkgroups) != 3 {
+		t.Fatalf("Talkgroups = %d, want 3", len(sys.Talkgroups))
+	}
+	if sys.Talkgroups[2].Hex != "3ea" {
+		t.Errorf("third hex auto-fill = %q, want 3ea", sys.Talkgroups[2].Hex)
+	}
+	if len(sys.Sites) != 0 {
+		t.Errorf("Sites should be empty for RR native CSV, got %d", len(sys.Sites))
+	}
+}
+
+func TestParseRRNativeCSVStream_MissingName(t *testing.T) {
+	const in = "DEC,HEX,Mode,Alpha Tag,Description,Tag,Group\n1000,3e8,D,OPS,Operations,Law Dispatch,Police\n"
+	_, err := parseRRNativeCSVStream(strings.NewReader(in), csvImportOpts{})
+	if err == nil {
+		t.Fatal("expected error for missing name, got nil")
+	}
+	if !strings.Contains(err.Error(), "missing system name") {
+		t.Errorf("error %q missing expected phrase", err.Error())
+	}
+}
+
+func TestParseCSVFile_RRNativeWithFilenameStem(t *testing.T) {
+	dir := t.TempDir()
+	path := dir + "/maricopa-49A.csv"
+	body := "DEC,HEX,Mode,Alpha Tag,Description,Tag,Group\n1000,3e8,D,OPS,Operations,Law Dispatch,Police\n"
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sys, err := parseCSVFile(path, csvImportOpts{})
+	if err != nil {
+		t.Fatalf("parseCSVFile: %v", err)
+	}
+	if sys.Name != "maricopa-49A" {
+		t.Errorf("Name = %q, want maricopa-49A (filename stem fallback)", sys.Name)
+	}
+	if len(sys.Talkgroups) != 1 {
+		t.Errorf("Talkgroups = %d, want 1", len(sys.Talkgroups))
+	}
+}
+
+func TestParseCSVFile_BundleStillWorks(t *testing.T) {
+	// parseCSVFile must continue to dispatch bundle files to
+	// parseCSVStream — the sniffer should reject them.
+	dir := t.TempDir()
+	path := dir + "/bundle.csv"
+	body := `# Section: metadata
+key,value
+name,BundleTest
+protocol,p25
+
+# Section: talkgroups
+decimal,alpha_tag
+1000,OPS
+`
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sys, err := parseCSVFile(path, csvImportOpts{})
+	if err != nil {
+		t.Fatalf("parseCSVFile: %v", err)
+	}
+	if sys.Name != "BundleTest" {
+		t.Errorf("Name = %q, want BundleTest", sys.Name)
 	}
 }

--- a/cmd/gophertrunk/import_parser.go
+++ b/cmd/gophertrunk/import_parser.go
@@ -273,7 +273,16 @@ func parseSystem(rows []parseRow) (parsedSystem, error) {
 	}
 
 	if sys.Name == "" {
-		return sys, errors.New("import-pdf: no System Name found — wrong PDF?")
+		// Fallback: RadioReference pages have a "<System> Menu"
+		// banner at the top of page 1. If the explicit "System
+		// Name:" line is missing (e.g. RR tweaked the field label)
+		// we can still recover the name from the banner.
+		if name := inferSystemNameFromPageTitle(rows); name != "" {
+			sys.Name = name
+		}
+	}
+	if sys.Name == "" {
+		return sys, formatNoSystemNameError(rows)
 	}
 	if len(sys.Sites) == 0 && len(sys.Talkgroups) == 0 {
 		return sys, errors.New("import-pdf: PDF contained no sites or talkgroups")
@@ -568,27 +577,139 @@ func isTGNavLine(line string) bool {
 }
 
 // parseMetaLine extracts "System Name: …", "Location: …", "System ID: …"
-// metadata. Lines that don't match any known prefix are ignored.
+// metadata. Matching is case-insensitive and tolerates extra whitespace
+// around the label (e.g. "SYSTEM NAME : Foo", "  System Name:   Foo  ")
+// — RadioReference occasionally tweaks the PDF capitalisation and we'd
+// rather extract correctly than re-issue a parser patch every time.
+// Lines that don't match any known key are ignored.
 func parseMetaLine(line string, sys *parsedSystem) {
-	switch {
-	case strings.HasPrefix(line, "System Name:"):
-		sys.Name = strings.TrimSpace(strings.TrimPrefix(line, "System Name:"))
-	case strings.HasPrefix(line, "Location:"):
-		sys.Location = strings.TrimSpace(strings.TrimPrefix(line, "Location:"))
-	case strings.HasPrefix(line, "County:"):
-		sys.County = strings.TrimSpace(strings.TrimPrefix(line, "County:"))
-	case strings.HasPrefix(line, "System Type:"):
-		sys.SystemType = strings.TrimSpace(strings.TrimPrefix(line, "System Type:"))
-	case strings.HasPrefix(line, "System ID:"):
-		rest := strings.TrimSpace(strings.TrimPrefix(line, "System ID:"))
-		// "Sysid: 49A WACN: BEE00"
-		if i := strings.Index(rest, "WACN:"); i >= 0 {
-			sys.SysID = strings.TrimSpace(strings.TrimPrefix(rest[:i], "Sysid:"))
-			sys.WACN = strings.TrimSpace(rest[i+len("WACN:"):])
+	key, val, ok := splitMetaLine(line)
+	if !ok {
+		return
+	}
+	switch key {
+	case "system name":
+		sys.Name = val
+	case "location":
+		sys.Location = val
+	case "county":
+		sys.County = val
+	case "system type":
+		sys.SystemType = val
+	case "system id":
+		// "Sysid: 49A WACN: BEE00" appears as the value when the
+		// label is "System ID:" — split on the inner WACN: token.
+		if i := indexFoldASCII(val, "WACN:"); i >= 0 {
+			left := strings.TrimSpace(val[:i])
+			left = strings.TrimPrefix(left, "Sysid:")
+			left = strings.TrimPrefix(left, "sysid:")
+			left = strings.TrimPrefix(left, "SYSID:")
+			sys.SysID = strings.TrimSpace(left)
+			sys.WACN = strings.TrimSpace(val[i+len("WACN:"):])
 		} else {
-			sys.SysID = rest
+			sys.SysID = val
 		}
 	}
+}
+
+// splitMetaLine splits a "Key: Value" line at the first colon, returning
+// the normalised key (lower-case, whitespace-collapsed) and the trimmed
+// value. ok=false when the line has no colon or an empty key.
+func splitMetaLine(line string) (key, val string, ok bool) {
+	i := strings.IndexByte(line, ':')
+	if i <= 0 {
+		return "", "", false
+	}
+	rawKey := strings.TrimSpace(line[:i])
+	if rawKey == "" {
+		return "", "", false
+	}
+	key = strings.ToLower(collapseSpaces(rawKey))
+	val = strings.TrimSpace(line[i+1:])
+	return key, val, true
+}
+
+// indexFoldASCII is a case-insensitive strings.Index for ASCII needles.
+func indexFoldASCII(haystack, needle string) int {
+	if needle == "" {
+		return 0
+	}
+	lh := strings.ToLower(haystack)
+	ln := strings.ToLower(needle)
+	return strings.Index(lh, ln)
+}
+
+// pageTitleRE matches RadioReference's top-of-page nav banner — the
+// system page title followed by " Menu" (the dropdown trigger). When the
+// PDF lacks an explicit "System Name:" line we fall back to this row.
+// "Menu" is kept case-sensitive on purpose: the banner uses it
+// verbatim, and a relaxed match would catch unrelated rows.
+var pageTitleRE = regexp.MustCompile(`^(.+?)\s+Menu\s*$`)
+
+// inferSystemNameFromPageTitle scans page 1 for the "<Name> Menu" banner
+// row and returns the captured name. Empty string when no candidate is
+// found. Used only when parseMetaLine never set sys.Name.
+func inferSystemNameFromPageTitle(rows []parseRow) string {
+	for _, r := range rows {
+		if r.Page != 1 {
+			continue
+		}
+		txt := strings.TrimSpace(r.Text)
+		if txt == "" {
+			continue
+		}
+		m := pageTitleRE.FindStringSubmatch(txt)
+		if m == nil {
+			continue
+		}
+		name := strings.TrimSpace(m[1])
+		if name == "" {
+			continue
+		}
+		return name
+	}
+	return ""
+}
+
+// formatNoSystemNameError builds the diagnostic error returned when the
+// parser can't find a system name in the PDF. The error string carries
+// the first 30 (or 4 KiB of) extracted rows so reporters and
+// maintainers see the actual PDF contents without having to re-run with
+// -extract-only. Each row's text is truncated at 120 runes.
+func formatNoSystemNameError(rows []parseRow) error {
+	const (
+		maxRows  = 30
+		maxBytes = 4 * 1024
+		maxText  = 120
+	)
+	var b strings.Builder
+	b.WriteString("import-pdf: no System Name found — wrong PDF?\n")
+	b.WriteString("hint: re-run with -extract-only to share a JSON fixture (see docs/import.md)\n")
+	b.WriteString("first extracted rows (page/Y/text, text truncated at 120 runes):")
+	count := 0
+	for _, r := range rows {
+		if count >= maxRows {
+			break
+		}
+		line := fmt.Sprintf("\n  p%d y=%.2f %q", r.Page, r.Y, truncateRunes(r.Text, maxText))
+		if b.Len()+len(line) > maxBytes {
+			break
+		}
+		b.WriteString(line)
+		count++
+	}
+	if count == 0 {
+		b.WriteString("\n  (no rows extracted — the PDF may be empty or use an unsupported encoding)")
+	}
+	return errors.New(b.String())
+}
+
+func truncateRunes(s string, max int) string {
+	r := []rune(s)
+	if len(r) <= max {
+		return s
+	}
+	return string(r[:max]) + "…"
 }
 
 // loadParseRowsJSON loads a serialised []parseRow from disk (used by

--- a/cmd/gophertrunk/import_parser_test.go
+++ b/cmd/gophertrunk/import_parser_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"flag"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -220,6 +221,98 @@ func TestSplitTalkgroupTail(t *testing.T) {
 				t.Errorf("tag = %q, want %q", g, tc.wantTag)
 			}
 		})
+	}
+}
+
+func TestParseMetaLine_Variants(t *testing.T) {
+	cases := []struct {
+		in        string
+		wantName  string
+		wantLoc   string
+		wantSysID string
+		wantWACN  string
+	}{
+		{in: "System Name: Foo", wantName: "Foo"},
+		{in: "System Name : Foo", wantName: "Foo"},
+		{in: "  System Name:   Foo  ", wantName: "Foo"},
+		{in: "SYSTEM NAME: Foo", wantName: "Foo"},
+		{in: "system name: Foo Bar", wantName: "Foo Bar"},
+		{in: "Location: Phoenix, AZ", wantLoc: "Phoenix, AZ"},
+		{in: "System ID: Sysid: 49A WACN: BEE00", wantSysID: "49A", wantWACN: "BEE00"},
+		{in: "SYSTEM ID: sysid: 49A wacn: BEE00", wantSysID: "49A", wantWACN: "BEE00"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			var sys parsedSystem
+			parseMetaLine(tc.in, &sys)
+			if sys.Name != tc.wantName {
+				t.Errorf("Name = %q, want %q", sys.Name, tc.wantName)
+			}
+			if sys.Location != tc.wantLoc {
+				t.Errorf("Location = %q, want %q", sys.Location, tc.wantLoc)
+			}
+			if sys.SysID != tc.wantSysID {
+				t.Errorf("SysID = %q, want %q", sys.SysID, tc.wantSysID)
+			}
+			if sys.WACN != tc.wantWACN {
+				t.Errorf("WACN = %q, want %q", sys.WACN, tc.wantWACN)
+			}
+		})
+	}
+}
+
+func TestParseSystem_PageTitleFallback(t *testing.T) {
+	// No "System Name:" line — only the "<Name> Menu" banner.
+	// Followed by a minimum-viable Sites section so the parser
+	// doesn't trip the "neither sites nor talkgroups" check.
+	rows := []parseRow{
+		{Y: 700, Page: 1, Text: "Maricopa County  Menu"},
+		{Y: 650, Page: 1, Text: "Sites and Frequencies"},
+		{Y: 600, Page: 1, Text: "1 (1) 016 (10) Oatman Mountain Maricopa 769.54375c 770.04375"},
+	}
+	sys, err := parseSystem(rows)
+	if err != nil {
+		t.Fatalf("parseSystem: %v", err)
+	}
+	if sys.Name != "Maricopa County" {
+		t.Errorf("Name = %q, want %q", sys.Name, "Maricopa County")
+	}
+	if len(sys.Sites) != 1 {
+		t.Fatalf("Sites = %d, want 1", len(sys.Sites))
+	}
+}
+
+func TestParseSystem_NoSystemNameDumpsRows(t *testing.T) {
+	// 50 rows, no system name anywhere, no page-title banner.
+	rows := make([]parseRow, 50)
+	for i := range rows {
+		rows[i] = parseRow{Y: float64(700 - i), Page: 1, Text: fmt.Sprintf("row-%02d-content", i)}
+	}
+	_, err := parseSystem(rows)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "no System Name found") {
+		t.Errorf("error missing canonical phrase: %s", msg)
+	}
+	if !strings.Contains(msg, "first extracted rows") {
+		t.Errorf("error missing diagnostic dump header: %s", msg)
+	}
+	if !strings.Contains(msg, "row-00-content") {
+		t.Errorf("error missing first row text: %s", msg)
+	}
+	if strings.Contains(msg, "row-30-content") {
+		t.Errorf("error should cap at 30 rows but contains row-30: %s", msg)
+	}
+}
+
+func TestTruncateRunes(t *testing.T) {
+	if got := truncateRunes("abc", 10); got != "abc" {
+		t.Errorf("short string truncated: %q", got)
+	}
+	if got := truncateRunes("abcdefghij", 5); got != "abcde…" {
+		t.Errorf("truncate = %q, want abcde…", got)
 	}
 }
 

--- a/cmd/gophertrunk/importer.go
+++ b/cmd/gophertrunk/importer.go
@@ -140,7 +140,7 @@ func parseImportFile(path string, kind api.ImportSourceKind) (parsedSystem, erro
 	case api.ImportSourcePDF:
 		return parsePDFFile(path)
 	case api.ImportSourceCSV:
-		return parseCSVFile(path)
+		return parseCSVFile(path, csvImportOpts{})
 	}
 	return parsedSystem{}, fmt.Errorf("import: unsupported kind %q", kind)
 }

--- a/docs/import.md
+++ b/docs/import.md
@@ -11,8 +11,14 @@ The `import-pdf` subcommand parses trunked-system data from two sources
 and merges it into your `config.yaml`, generating per-system Trunk-
 Recorder-style talkgroup CSVs as it goes:
 
-- **RadioReference.com PDF exports** — the page-footer "Export PDF"
-  button on any P25 trunking-system page.
+- **RadioReference.com PDF exports** — choose **PDF** from the
+  **Download** menu near the top of any P25 trunking-system page (URL
+  pattern `https://www.radioreference.com/db/sid/<sid>/download`).
+- **RadioReference.com native CSV exports** — the **CSV** option from
+  the same Download menu. A flat talkgroup list with no metadata or
+  sites — combine with `-name` / `-sysid` (see [native-CSV quick
+  start](#quick-start--radioreference-native-csv)) and a separate
+  `-pdf` (or bundle CSV) when you need control-channel frequencies.
 - **Structured CSV bundles** — a single multi-section CSV file per
   system, format documented below. Use this when your data comes from
   somewhere other than RadioReference (the radio wiki for your region,
@@ -32,7 +38,10 @@ regardless of input format.
 
 1. Sign in to RadioReference and open the trunking-system page (e.g.
    the "Maricopa County" or "Regional Wireless Cooperative" page).
-2. Click "Export PDF" in the page footer; save the file.
+2. Click **Download** in the page header (the menu next to **Menu**)
+   and choose **PDF**. The same menu also offers a CSV talkgroup list
+   and a DSD export; save the PDF file. URL pattern:
+   `https://www.radioreference.com/db/sid/<sid>/download`.
 3. Run:
 
    ```
@@ -46,7 +55,29 @@ regardless of input format.
    on talkgroups, then press <kbd>w</kbd> to write or <kbd>q</kbd> to
    discard.
 
-## Quick start — CSV
+## Quick start — RadioReference native CSV
+
+RadioReference's **Download → CSV** option serves a flat talkgroup
+table with no system metadata and no site/frequency rows. Pair it
+with `-name` and (optionally) `-sysid` to supply the missing data:
+
+```
+gophertrunk import-pdf \
+  -csv talkgroups-49A.csv \
+  -name "Maricopa County" -sysid 49A \
+  -config /etc/gophertrunk/config.yaml
+```
+
+If `-name` is omitted, the filename stem is used as the system name.
+The CSV is auto-detected by content — there's no separate flag to
+pick the format.
+
+Trunked operators still need control-channel frequencies, which the
+native CSV doesn't carry. Either pass a `-pdf` alongside the `-csv`
+in the same invocation, or hand-edit the resulting
+`trunking.systems[].control_channels` block after the import.
+
+## Quick start — CSV bundle
 
 1. Build a CSV file in the format below (one file per system).
 2. Run:
@@ -221,13 +252,16 @@ Without `-force` the importer aborts before touching anything on disk.
 | Flag | Description |
 | --- | --- |
 | `-pdf <file.pdf>` | RadioReference PDF (repeatable). |
-| `-csv <file.csv>` | Structured CSV bundle (repeatable). |
+| `-csv <file.csv>` | CSV file (repeatable). Either a multi-section bundle (this page) or RadioReference's native CSV (auto-detected). |
 | `-config <path>` | Existing `config.yaml` (merged in place). Default `./config.yaml`. |
 | `-csv-dir <dir>` | Where to write talkgroup CSVs. Default: directory of `-config`. |
 | `-no-tui` | Skip the review TUI; merge straight from parsed defaults. |
 | `-dry-run` | Print the planned changes and exit without writing. |
 | `-force` | Overwrite an existing `trunking.systems[]` entry with the same name. |
 | `-wizard` | Launch the interactive config-builder wizard (see below). |
+| `-name <name>` | System name for native RadioReference CSV imports (bundle CSVs ignore this — use the `metadata` section). |
+| `-sysid <id>` | System ID for native RadioReference CSV imports. |
+| `-extract-only` | Combined with a single `-pdf`, dumps the positioned-text rows extracted from the PDF as JSON to stdout, then exits. Attach the output to a parser bug report. |
 
 ## Config-file builder (`-wizard`)
 
@@ -324,7 +358,16 @@ correct for Phase 1 captures.
   subset where every glyph's encoded byte sits 27 below its real
   ASCII codepoint. The importer reverses the shift per-glyph during
   extraction. If RadioReference changes the encoding the importer
-  will produce gibberish — open an issue with a sample PDF attached.
+  will produce gibberish — open an issue and attach the JSON output of
+  `gophertrunk import-pdf -pdf <file> -extract-only` (and the PDF
+  itself if you can). The dump is also surfaced inline whenever the
+  parser fails to find a system name.
+- **Field-label tolerance.** Metadata labels (`System Name:`,
+  `Location:`, `County:`, `System Type:`, `System ID:`) are matched
+  case-insensitively with whitespace flexibility. When no
+  `System Name:` line is found the importer falls back to the top-of-
+  page banner ("`<System> Menu`"), so a layout tweak that drops the
+  explicit label still works.
 - **Ligature drops.** The font subset has no `ﬃ`/`ﬁ`/`ﬂ` glyphs, so
   words like "Office" arrive as "ONce". The importer applies a small
   fix-up table (`Office`, `Officers`, `Official`, …). If you see

--- a/docs/user-guide-windows.md
+++ b/docs/user-guide-windows.md
@@ -501,8 +501,10 @@ The `import-pdf` subcommand parses two source types and merges them
 into your `config.yaml`, generating Trunk-Recorder-style talkgroup
 CSVs as it goes:
 
-- **RadioReference.com PDF exports** — the "Export PDF" button on
-  any P25 trunking-system page.
+- **RadioReference.com PDF exports** — the **Download** menu near the
+  top of any P25 trunking-system page (offers PDF / CSV / DSD).
+- **RadioReference native CSV** — the **CSV** option from the same
+  Download menu. Flat talkgroup list; pair with `-name` and `-sysid`.
 - **Structured CSV bundles** — a single multi-section CSV file per
   system (format documented in
   [`import.md#csv-format`]({{ '/import.html#csv-format' | relative_url }})).
@@ -510,8 +512,9 @@ CSVs as it goes:
 ### Quick start — RadioReference PDF
 
 1. Sign in to RadioReference, open the trunking-system page (e.g.
-   "Maricopa County"), click **Export PDF** in the footer, save the
-   file.
+   "Maricopa County"), click **Download → PDF** in the page header,
+   save the file. (URL pattern:
+   `https://www.radioreference.com/db/sid/<sid>/download`.)
 2. Run:
 
    ```powershell


### PR DESCRIPTION
Issue #271 reports two failures in the RadioReference import flow:
the docs point users to a "footer" Export PDF button that RR moved
to a top "Download" menu (PDF / CSV / DSD options), and the PDF
parser errors out with the opaque "no System Name found" message
on current RR exports.

Without the failing PDF in hand we can't pinpoint the layout change,
so this lands the defensive + diagnostic + alternate-path pieces:

- Native RadioReference CSV support: parseCSVFile content-sniffs
  the file and dispatches RR's flat /db/sid/<sid>/download talkgroup
  table through a new parseRRNativeCSVStream. The new -name / -sysid
  flags supply the metadata RR omits; filename stem is the default
  system name.
- -extract-only flag: dumps positioned-text rows from a PDF as JSON
  to stdout so bug reports can ship a parser-ready fixture without
  the original PDF.
- The "no System Name found" error now inlines the first ~30 rows
  (capped at 4 KiB, text truncated at 120 runes) so the next failure
  is self-diagnosing.
- parseMetaLine is now case-insensitive and whitespace-tolerant,
  with a page-title fallback ("<System> Menu" banner on page 1) for
  when the explicit "System Name:" label is missing.
- Docs (import.md, user-guide-windows.md) updated to describe the
  top Download menu, native-CSV quick start, and new flags.