### PR TITLE
Handle Windows USB timeout during device warmup probe

### DIFF
--- a/internal/sdr/rtlsdr/purego/driver.go
+++ b/internal/sdr/rtlsdr/purego/driver.go
@@ -245,23 +245,39 @@ func runBringup(demod *rtl2832u.Demod) (tuners.Tuner, error) {
 	return tuner, nil
 }
 
-// isBringupResetable reports whether err is an EPIPE/ErrDeviceGone in
-// any wrap layer — the two error classes USBDEVFS_RESET is the right
-// hammer for. Other errors (timeout, ErrClosed, validation failures)
-// should NOT trigger reset: reset is ~200ms of latency and obscures
-// the real cause when applied to the wrong class.
+// isBringupResetable reports whether err is one of the three error
+// classes a USB port reset is the right hammer for during open-time
+// bring-up: EPIPE (Linux/USBDEVFS cold-boot stall, the librtlsdr "dummy
+// write probe" case), ErrDeviceGone (the chip dropped off the bus
+// mid-bringup), or ErrTimeout (Windows/WinUSB cold-boot — same root
+// cause as the Linux EPIPE, but WinUsb_ControlTransfer surfaces it as
+// ERROR_SEM_TIMEOUT instead of stalling the pipe). The retry is bounded
+// to one reset per Open so even if a reset is wasted on a non-cold-boot
+// timeout the cost is capped at ~200ms before the original error
+// surfaces. Other errors (ErrClosed, validation failures) stay
+// non-resetable.
 func isBringupResetable(err error) bool {
-	return errors.Is(err, syscall.EPIPE) || errors.Is(err, usb.ErrDeviceGone)
+	return errors.Is(err, syscall.EPIPE) ||
+		errors.Is(err, usb.ErrDeviceGone) ||
+		errors.Is(err, usb.ErrTimeout)
 }
 
 // tunerBringupHint returns a parenthesized, space-prefixed remediation
-// string when err looks like the tuner-not-acking-on-I2C case
-// (issue #248): EPIPE from the first I2C burst, or the device
-// disappearing mid-bringup. The hint covers the three known root
-// causes — DVB kernel driver still bound, marginal USB power, or a
-// half-initialized tuner state — and links to the docs troubleshooting
-// table. Returns "" for unrelated errors so the wrapped message stays
-// clean.
+// string when err looks like one of the two known unrecoverable cold-
+// boot classes (issue #248):
+//
+//   - EPIPE / ErrDeviceGone — the Linux/USBDEVFS cold-boot stall: the
+//     tuner did not ACK on the I²C bridge. Common causes: DVB kernel
+//     driver still bound, marginal USB power, or a flaky cable/hub.
+//
+//   - ErrTimeout — the Windows/WinUSB cold-boot equivalent: the device
+//     accepted the control transfer but never responded within the
+//     CTRL_TIMEOUT window. Common causes: WinUSB driver not bound (the
+//     Zadig step was skipped or installed against the wrong device),
+//     marginal USB power, or a flaky cable/hub.
+//
+// Both branches link to the docs troubleshooting table. Returns "" for
+// unrelated errors so the wrapped message stays clean.
 func tunerBringupHint(err error) string {
 	if err == nil {
 		return ""
@@ -270,6 +286,12 @@ func tunerBringupHint(err error) string {
 		return " (hint: tuner did not respond on the I2C bus — common causes:" +
 			" DVB kernel driver still bound (run `sudo modprobe -r dvb_usb_rtl28xxu` and re-plug)," +
 			" marginal USB power, or a flaky cable/hub." +
+			" See https://mattcheramie.github.io/GopherTrunk/install-linux.html#troubleshooting)"
+	}
+	if errors.Is(err, usb.ErrTimeout) {
+		return " (hint: USB control transfer timed out — common causes:" +
+			" on Windows, the WinUSB driver is not bound to the device (re-run Zadig and select the RTL-SDR);" +
+			" on any OS, marginal USB power, a flaky cable/hub, or another process already holding the device." +
 			" See https://mattcheramie.github.io/GopherTrunk/install-linux.html#troubleshooting)"
 	}
 	return ""

--- a/internal/sdr/rtlsdr/purego/driver_test.go
+++ b/internal/sdr/rtlsdr/purego/driver_test.go
@@ -152,23 +152,24 @@ func warmupUSBSysctlExchange(simulateErr error) usb.CtrlExchange {
 
 // Regression for issue #248: the warmup probe in openDevice must run
 // exactly once on a healthy device and must not trigger a USB reset.
-// Termination is forced via an unrelated ErrTimeout on the first
-// InitBaseband write so the script stays minimal.
+// Termination is forced via ErrClosed on the first InitBaseband write
+// so the script stays minimal — ErrClosed is explicitly non-resetable
+// (see isBringupResetable) and unwinds the bring-up immediately.
 func TestOpenDevice_WarmupSucceedsFirstTry(t *testing.T) {
 	m := usb.NewMockTransport()
 	m.Script = []usb.CtrlExchange{
 		warmupUSBSysctlExchange(nil),
 		// Make InitBaseband's first write (also USBSysctl=0x09 — the
-		// same wire bytes as the warmup) fail with a non-EPIPE error
-		// so openDevice unwinds cleanly without forcing us to script
-		// the full init flood + tuner detect.
+		// same wire bytes as the warmup) fail with a non-resetable
+		// error so openDevice unwinds cleanly without forcing us to
+		// script the full init flood + tuner detect.
 		{
 			In:       false,
 			BRequest: 0,
 			WValue:   0x2000,
 			WIndex:   uint16(1)<<8 | 0x10,
 			Data:     []byte{0x09},
-			Err:      usb.ErrTimeout,
+			Err:      usb.ErrClosed,
 		},
 	}
 	desc := usb.Descriptor{VID: 0x0bda, PID: 0x2838, Serial: "test-warmup-ok"}
@@ -351,9 +352,9 @@ func TestTunerBringupHint(t *testing.T) {
 			empty: true,
 		},
 		{
-			name:  "ETIMEDOUT_not_hinted",
-			err:   fmt.Errorf("wrap: %w", usb.ErrTimeout),
-			empty: true,
+			name:    "ErrTimeout_through_wrap",
+			err:     fmt.Errorf("wrap: %w", usb.ErrTimeout),
+			wantSub: []string{"Zadig", "install-linux.html#troubleshooting"},
 		},
 	}
 	for _, c := range cases {
@@ -371,5 +372,93 @@ func TestTunerBringupHint(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// Regression: on Windows the cold-boot warmup probe surfaces as
+// usb.ErrTimeout (ERROR_SEM_TIMEOUT from WinUsb_ControlTransfer) rather
+// than EPIPE. openDevice must treat that as resetable and run the same
+// reset + re-claim + retry envelope it uses for EPIPE — otherwise
+// `gophertrunk sdr list --probe` fails on cold-plugged dongles with
+// "rtlsdr: USB warmup: ... usb: transfer timed out".
+func TestOpenDevice_WarmupTimeoutTriggersResetAndRetry(t *testing.T) {
+	m := usb.NewMockTransport()
+	m.Script = []usb.CtrlExchange{
+		warmupUSBSysctlExchange(usb.ErrTimeout),
+		warmupUSBSysctlExchange(nil),
+		// Terminate the bring-up with a non-resetable error on
+		// InitBaseband's first write so the script stays minimal.
+		{
+			In:       false,
+			BRequest: 0,
+			WValue:   0x2000,
+			WIndex:   uint16(1)<<8 | 0x10,
+			Data:     []byte{0x09},
+			Err:      usb.ErrClosed,
+		},
+	}
+	desc := usb.Descriptor{VID: 0x0bda, PID: 0x2838, Serial: "test-warmup-timeout-retry"}
+	_, err := openDevice(m, desc, 0)
+	if err == nil {
+		t.Fatal("openDevice succeeded; expected init-baseband terminator to fail the test")
+	}
+	if !strings.Contains(err.Error(), "init baseband") {
+		t.Errorf("err = %v, want substring \"init baseband\" (proves warmup retry succeeded and InitBaseband ran)", err)
+	}
+	if m.ResetCalls != 1 {
+		t.Errorf("ResetCalls = %d, want 1 (ErrTimeout on warmup must trigger one USBDEVFS_RESET)", m.ResetCalls)
+	}
+	if m.ClaimCalls != 2 {
+		t.Errorf("ClaimCalls = %d, want 2 (initial claim + post-reset re-claim)", m.ClaimCalls)
+	}
+}
+
+// Regression: when ErrTimeout recurs on the warmup retry pass, the
+// surfaced error must carry the Windows-aware hint that points at the
+// WinUSB / Zadig step. Only one USBDEVFS_RESET per Open call.
+func TestOpenDevice_WarmupTimeoutTwiceReturnsHintError(t *testing.T) {
+	m := usb.NewMockTransport()
+	m.Script = []usb.CtrlExchange{
+		warmupUSBSysctlExchange(usb.ErrTimeout),
+		warmupUSBSysctlExchange(usb.ErrTimeout),
+	}
+	desc := usb.Descriptor{VID: 0x0bda, PID: 0x2838, Serial: "test-warmup-timeout-fail"}
+	_, err := openDevice(m, desc, 0)
+	if err == nil {
+		t.Fatal("openDevice succeeded; expected ErrTimeout-twice to fail open")
+	}
+	if !errors.Is(err, usb.ErrTimeout) {
+		t.Errorf("err = %v, want errors.Is(err, usb.ErrTimeout) (the underlying cause must remain inspectable)", err)
+	}
+	if !strings.Contains(err.Error(), "USB warmup") {
+		t.Errorf("err = %v, want substring \"USB warmup\" (identifies the failing stage)", err)
+	}
+	if !strings.Contains(err.Error(), "Zadig") {
+		t.Errorf("err = %v, want substring \"Zadig\" (proves the Windows-aware tunerBringupHint was appended)", err)
+	}
+	if m.ResetCalls != 1 {
+		t.Errorf("ResetCalls = %d, want 1 (one reset attempt between the two warmup tries)", m.ResetCalls)
+	}
+}
+
+// Regression: a non-resetable error class (here usb.ErrClosed) on the
+// warmup probe must surface immediately without any USB reset — reset
+// is the wrong hammer for "transport already closed" and would obscure
+// the real cause.
+func TestOpenDevice_WarmupNonResetableErrorDoesNotReset(t *testing.T) {
+	m := usb.NewMockTransport()
+	m.Script = []usb.CtrlExchange{
+		warmupUSBSysctlExchange(usb.ErrClosed),
+	}
+	desc := usb.Descriptor{VID: 0x0bda, PID: 0x2838, Serial: "test-warmup-closed"}
+	_, err := openDevice(m, desc, 0)
+	if err == nil {
+		t.Fatal("openDevice succeeded; expected ErrClosed to fail open")
+	}
+	if !errors.Is(err, usb.ErrClosed) {
+		t.Errorf("err = %v, want errors.Is(err, usb.ErrClosed)", err)
+	}
+	if m.ResetCalls != 0 {
+		t.Errorf("ResetCalls = %d, want 0 (non-resetable error must not trigger reset)", m.ResetCalls)
 	}
 }


### PR DESCRIPTION
## Summary
This change fixes device enumeration failures on Windows by properly handling USB control transfer timeouts during the cold-boot warmup probe. On Windows, WinUSB surfaces cold-boot stalls as `ErrTimeout` rather than `EPIPE` (the Linux behavior), but the code was not treating this as a recoverable error requiring a USB reset and retry.

## Key Changes

- **Updated `isBringupResetable()`**: Now treats `usb.ErrTimeout` as a resetable error class alongside `EPIPE` and `ErrDeviceGone`. This ensures that Windows cold-boot timeouts trigger the same reset + re-claim + retry envelope used for Linux EPIPE stalls.

- **Enhanced `tunerBringupHint()`**: Added Windows-specific remediation guidance for `ErrTimeout` errors, pointing users to the Zadig driver installation step. The hint explains that on Windows, the WinUSB driver must be bound to the device, while also covering cross-platform causes like marginal USB power or flaky cables.

- **Updated test expectations**: Modified `TestOpenDevice_WarmupSucceedsFirstTry` to use `usb.ErrClosed` (a non-resetable error) instead of `ErrTimeout` for cleaner test termination, and updated related test comments to reflect the new error classification.

- **Added comprehensive regression tests**:
  - `TestOpenDevice_WarmupTimeoutTriggersResetAndRetry`: Verifies that `ErrTimeout` on warmup triggers exactly one reset and retry
  - `TestOpenDevice_WarmupTimeoutTwiceReturnsHintError`: Ensures that persistent timeouts surface with the Windows-aware hint
  - `TestOpenDevice_WarmupNonResetableErrorDoesNotReset`: Confirms that non-resetable errors (like `ErrClosed`) do not trigger resets

## Implementation Details

The fix recognizes that Windows and Linux handle cold-boot USB stalls differently at the driver level:
- **Linux/USBDEVFS**: Stalls the pipe, surfaced as `EPIPE`
- **Windows/WinUSB**: Times out the control transfer, surfaced as `ERROR_SEM_TIMEOUT` / `usb.ErrTimeout`

Both are the same root cause (device not responding during initialization) and require the same recovery: reset the USB port and retry. The retry is bounded to one reset per `Open()` call to cap latency at ~200ms even if the timeout is not cold-boot related.

https://claude.ai/code/session_01CZhvjEDXDM1fc2d81d5mj5