### PR TITLE
sdr: program IQ sample rate at pool open (fix #275 P25 cc never locks)

### DIFF
--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -277,7 +277,7 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 			}
 			hints = append(hints, h)
 		}
-		if err := d.pool.Open(hints); err != nil {
+		if err := d.pool.Open(cfg.SDR.SampleRate, hints); err != nil {
 			log.Warn("daemon: SDR pool open failed", "err", err)
 			d.addWarning(fmt.Sprintf(
 				"SDR pool failed to open (%v) — no radios will demodulate; check device permissions / cabling / kernel modules",

--- a/internal/radio/p25/phase1/control.go
+++ b/internal/radio/p25/phase1/control.go
@@ -39,6 +39,9 @@ type ControlChannel struct {
 	now        func() time.Time
 	locked     bool
 	lastNAC    uint16
+	// lastNoHitsAt throttles the "no FSW hits" debug log so the chunk-rate
+	// emission doesn't flood at debug level. See Process for the rationale.
+	lastNoHitsAt time.Time
 }
 
 // Options configure a ControlChannel.
@@ -99,10 +102,26 @@ type LockState struct {
 func (s LockState) LockedFrequencyHz() uint32 { return s.FrequencyHz }
 func (s LockState) LockedNAC() uint16         { return s.NAC }
 
+// noHitsThrottle bounds how often Process emits its "no FSW hits" debug
+// log when the sync detector is finding nothing in successive chunks.
+// Issue #275 surfaced because that state produced zero logs at all —
+// operators couldn't tell whether the IQ pipeline was alive but
+// unsynchronized or wholly silent. Throttling at 2 s keeps the signal
+// visible without flooding.
+const noHitsThrottle = 2 * time.Second
+
 // Process consumes a window of dibits and runs detection/parsing. baseIdx
 // is the absolute dibit index of dibits[0]. Returns the new baseIndex.
 func (c *ControlChannel) Process(dibits []uint8, baseIdx int) int {
 	hits, next := c.det.Process(nil, dibits, baseIdx)
+	if len(hits) == 0 && len(dibits) > 0 && !c.locked {
+		now := c.now()
+		if now.Sub(c.lastNoHitsAt) >= noHitsThrottle {
+			c.log.Debug("p25/phase1: no FSW hits in chunk",
+				"system", c.systemName, "freq_hz", c.freqHz, "dibits", len(dibits))
+			c.lastNoHitsAt = now
+		}
+	}
 	for _, h := range hits {
 		// FSW ends at index h (relative to the absolute dibit stream). The
 		// 32-dibit NID immediately follows.

--- a/internal/radio/p25/phase2/process.go
+++ b/internal/radio/p25/phase2/process.go
@@ -1,6 +1,8 @@
 package phase2
 
 import (
+	"time"
+
 	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
 )
 
@@ -11,7 +13,17 @@ type processState struct {
 	remaining    int
 	macDibits    []uint8
 	matchScratch []int
+	// lastNoHitsAt throttles the "no sync hits" debug log so the
+	// chunk-rate emission doesn't flood at debug level. See Process.
+	lastNoHitsAt time.Time
 }
+
+// noHitsThrottle bounds how often Process emits its "no sync hits"
+// debug log when the sync detector is finding nothing. Issue #275
+// surfaced because that state produced zero logs at all — operators
+// couldn't tell whether the IQ pipeline was alive but unsynchronized
+// or wholly silent.
+const noHitsThrottle = 2 * time.Second
 
 // macPDUDibits is the count of dibits the adapter collects after
 // each 20-dibit outbound sync match when SetTrellisMode is
@@ -65,6 +77,18 @@ func (c *ControlChannel) Process(dibits []uint8, baseIdx int) int {
 
 	p.matchScratch, _ = p.det.Process(p.matchScratch[:0], dibits, baseIdx)
 	matchIdx := 0
+
+	c.mu.Lock()
+	alreadyLocked := c.locked
+	c.mu.Unlock()
+	if len(p.matchScratch) == 0 && p.remaining == 0 && len(dibits) > 0 && !alreadyLocked {
+		now := c.now()
+		if now.Sub(p.lastNoHitsAt) >= noHitsThrottle {
+			c.log.Debug("p25/phase2: no sync hits in chunk",
+				"system", c.systemName, "freq_hz", c.freqHz, "dibits", len(dibits))
+			p.lastNoHitsAt = now
+		}
+	}
 
 	for i, d := range dibits {
 		absPos := baseIdx + i

--- a/internal/sdr/pool.go
+++ b/internal/sdr/pool.go
@@ -106,15 +106,31 @@ func (h Hint) WithGain(tenthDB int) Hint {
 	return h
 }
 
+// DefaultSampleRateHz mirrors librtlsdr's open-time default and is the
+// rate Pool.Open programs when the caller passes 0. Matches the value
+// the rtlsdr driver also programs during bring-up so the two layers
+// agree on a known-good fallback.
+const DefaultSampleRateHz uint32 = 2_048_000
+
 // Open enumerates every registered driver, opens devices that match the
-// supplied hints (or simply all of them when hints is empty), and assigns
+// supplied hints (or simply all of them when hints is empty), programs
+// the IQ sample rate on each device (issue #275 — without this the chip
+// streams at whatever rate its resampler powered up at), and assigns
 // roles. The first opened device gets RoleControl unless a hint says
-// otherwise; subsequent devices get RoleVoice.
-func (p *Pool) Open(hints []Hint) error {
+// otherwise; subsequent devices get RoleVoice. Passing sampleRateHz == 0
+// falls back to DefaultSampleRateHz. A device whose SetSampleRate
+// fails is closed and skipped — a wrong-rate radio produces silent
+// decoder failures, which is worse than no radio at all.
+func (p *Pool) Open(sampleRateHz uint32, hints []Hint) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	if len(p.entries) > 0 {
 		return errors.New("pool already populated; close first")
+	}
+
+	rate := sampleRateHz
+	if rate == 0 {
+		rate = DefaultSampleRateHz
 	}
 
 	type discovered struct {
@@ -166,6 +182,12 @@ func (p *Pool) Open(hints []Hint) error {
 			p.log.Error("open device failed", "driver", d.drv.Name(), "index", d.info.Index, "err", err)
 			continue
 		}
+		if err := dev.SetSampleRate(rate); err != nil {
+			p.log.Error("set sample rate failed",
+				"driver", d.drv.Name(), "serial", d.info.Serial, "rate_hz", rate, "err", err)
+			_ = dev.Close()
+			continue
+		}
 		// Apply per-device tuning supplied via Hint. Failures are
 		// non-fatal — the device is still usable, just possibly
 		// with the driver's defaults — but they get logged so an
@@ -176,7 +198,8 @@ func (p *Pool) Open(hints []Hint) error {
 		}
 		entry := &PoolEntry{Driver: d.drv, Device: dev, Info: d.info, Role: role, Hint: hint}
 		p.entries = append(p.entries, entry)
-		p.log.Info("device opened", "driver", d.drv.Name(), "serial", d.info.Serial, "role", role.String())
+		p.log.Info("device opened",
+			"driver", d.drv.Name(), "serial", d.info.Serial, "role", role.String(), "rate_hz", rate)
 		p.publish(events.KindSDRAttached, entry.Snapshot(true))
 	}
 	if len(p.entries) == 0 {

--- a/internal/sdr/pool_events_test.go
+++ b/internal/sdr/pool_events_test.go
@@ -27,7 +27,7 @@ func TestPoolPublishesAttachAndDetachEvents(t *testing.T) {
 
 	p := NewPool(nil)
 	p.SetBus(bus)
-	if err := p.Open([]Hint{Hint{Serial: "EV1", PPM: 3, BiasTee: true}.WithGain(496)}); err != nil {
+	if err := p.Open(0, []Hint{Hint{Serial: "EV1", PPM: 3, BiasTee: true}.WithGain(496)}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -83,7 +83,7 @@ func TestPoolSnapshotMatchesEntries(t *testing.T) {
 	})
 
 	p := NewPool(nil)
-	if err := p.Open(nil); err != nil {
+	if err := p.Open(0, nil); err != nil {
 		t.Fatal(err)
 	}
 	defer p.Close()

--- a/internal/sdr/pool_settings_test.go
+++ b/internal/sdr/pool_settings_test.go
@@ -18,7 +18,7 @@ func TestPoolAppliesHintSettings(t *testing.T) {
 	})
 
 	p := NewPool(nil)
-	if err := p.Open([]Hint{
+	if err := p.Open(0, []Hint{
 		Hint{Serial: "S1", PPM: 7, BiasTee: true}.WithGain(496),
 	}); err != nil {
 		t.Fatal(err)
@@ -55,7 +55,7 @@ func TestPoolSkipsBiasTeeWhenHintFalse(t *testing.T) {
 	})
 
 	p := NewPool(nil)
-	if err := p.Open([]Hint{{Serial: "S2"}}); err != nil {
+	if err := p.Open(0, []Hint{{Serial: "S2"}}); err != nil {
 		t.Fatal(err)
 	}
 	defer p.Close()

--- a/internal/sdr/pool_test.go
+++ b/internal/sdr/pool_test.go
@@ -21,11 +21,19 @@ type fakeDevice struct {
 	closed      bool
 	biasTeeOn   bool
 	biasTeeSets int
+	sampleRate  uint32
+	rateErr     error
 }
 
-func (d *fakeDevice) Info() Info                                           { return d.info }
-func (d *fakeDevice) SetCenterFreq(uint32) error                           { return nil }
-func (d *fakeDevice) SetSampleRate(uint32) error                           { return nil }
+func (d *fakeDevice) Info() Info                 { return d.info }
+func (d *fakeDevice) SetCenterFreq(uint32) error { return nil }
+func (d *fakeDevice) SetSampleRate(hz uint32) error {
+	if d.rateErr != nil {
+		return d.rateErr
+	}
+	d.sampleRate = hz
+	return nil
+}
 func (d *fakeDevice) SetGain(int) error                                    { return nil }
 func (d *fakeDevice) SetPPM(int) error                                     { return nil }
 func (d *fakeDevice) SetBiasTee(on bool) error                             { d.biasTeeOn = on; d.biasTeeSets++; return nil }
@@ -54,7 +62,7 @@ func TestPoolAssignsRoles(t *testing.T) {
 	})
 
 	p := NewPool(nil)
-	if err := p.Open([]Hint{{Serial: "BBB", Role: RoleControl}}); err != nil {
+	if err := p.Open(0, []Hint{{Serial: "BBB", Role: RoleControl}}); err != nil {
 		t.Fatal(err)
 	}
 	defer p.Close()
@@ -79,6 +87,69 @@ func TestPoolAssignsRoles(t *testing.T) {
 	}
 }
 
+// TestPoolProgramsSampleRate guards against the bug behind issue #275:
+// without a SetSampleRate call at pool-open time the chip streams at
+// whatever rate its resampler powered up at, the decoder pipeline runs
+// its symbol-timing math against the configured rate, and the result
+// is a silent failure to lock.
+func TestPoolProgramsSampleRate(t *testing.T) {
+	drv := &fakeDriver{name: "fake-rate", infos: []Info{
+		{Driver: "fake-rate", Index: 0, Serial: "R1"},
+		{Driver: "fake-rate", Index: 1, Serial: "R2"},
+	}}
+	registryMu.Lock()
+	registry["fake-rate"] = drv
+	registryMu.Unlock()
+	t.Cleanup(func() {
+		registryMu.Lock()
+		delete(registry, "fake-rate")
+		registryMu.Unlock()
+	})
+
+	p := NewPool(nil)
+	if err := p.Open(2_400_000, nil); err != nil {
+		t.Fatal(err)
+	}
+	defer p.Close()
+
+	for _, e := range p.Entries() {
+		fd, ok := e.Device.(*fakeDevice)
+		if !ok {
+			t.Fatalf("device %s not *fakeDevice", e.Info.Serial)
+		}
+		if fd.sampleRate != 2_400_000 {
+			t.Errorf("%s sample rate = %d, want 2400000", e.Info.Serial, fd.sampleRate)
+		}
+	}
+}
+
+// TestPoolDefaultsZeroSampleRate verifies the librtlsdr-parity fallback
+// when the daemon hasn't been configured with an sdr.sample_rate.
+func TestPoolDefaultsZeroSampleRate(t *testing.T) {
+	drv := &fakeDriver{name: "fake-default-rate", infos: []Info{
+		{Driver: "fake-default-rate", Index: 0, Serial: "D1"},
+	}}
+	registryMu.Lock()
+	registry["fake-default-rate"] = drv
+	registryMu.Unlock()
+	t.Cleanup(func() {
+		registryMu.Lock()
+		delete(registry, "fake-default-rate")
+		registryMu.Unlock()
+	})
+
+	p := NewPool(nil)
+	if err := p.Open(0, nil); err != nil {
+		t.Fatal(err)
+	}
+	defer p.Close()
+
+	fd := p.Entries()[0].Device.(*fakeDevice)
+	if fd.sampleRate != DefaultSampleRateHz {
+		t.Errorf("sample rate = %d, want %d", fd.sampleRate, DefaultSampleRateHz)
+	}
+}
+
 func TestPoolFirstByRole(t *testing.T) {
 	drv := &fakeDriver{name: "fake-first", infos: []Info{
 		{Driver: "fake-first", Index: 0, Serial: "X"},
@@ -94,7 +165,7 @@ func TestPoolFirstByRole(t *testing.T) {
 	})
 
 	p := NewPool(nil)
-	if err := p.Open(nil); err != nil {
+	if err := p.Open(0, nil); err != nil {
 		t.Fatal(err)
 	}
 	defer p.Close()

--- a/internal/sdr/rtlsdr/purego/driver.go
+++ b/internal/sdr/rtlsdr/purego/driver.go
@@ -209,11 +209,18 @@ func openDevice(transport usb.Transport, desc usb.Descriptor, idx int) (*Device,
 	}, nil
 }
 
+// defaultOpenSampleRateHz mirrors librtlsdr's rtlsdr_open: leave the
+// chip at a known-good 2.048 MS/s so consumers that forget to program
+// the rate before streaming still get coherent IQ instead of whatever
+// the resampler's power-on default happens to be.
+const defaultOpenSampleRateHz uint32 = 2_048_000
+
 // runBringup executes the librtlsdr-parity init sequence on a fresh
 // Demod: USB-sysctl warmup probe → baseband init → tuner detect →
 // R820T-family demod prep (no-op for other tuners) → tuner.Init →
 // IF-freq programming (R820T-family programs its own IF inside
-// PrepareDemod, so non-R82xx tuners use the demod-side path).
+// PrepareDemod, so non-R82xx tuners use the demod-side path) →
+// default sample-rate program (librtlsdr parity; see issue #275).
 // Returns the initialized tuner on success. All errors are wrapped
 // with a stage prefix so the outer openDevice can spot resetable
 // EPIPE / ErrDeviceGone via errors.Is.
@@ -241,6 +248,13 @@ func runBringup(demod *rtl2832u.Demod) (tuners.Tuner, error) {
 		if err := demod.SetIFFreq(tuner.IFFreqHz()); err != nil {
 			return nil, fmt.Errorf("rtlsdr: set IF freq: %w%s", err, tunerBringupHint(err))
 		}
+	}
+	actual, err := demod.SetSampleRate(defaultOpenSampleRateHz)
+	if err != nil {
+		return nil, fmt.Errorf("rtlsdr: default sample rate: %w%s", err, tunerBringupHint(err))
+	}
+	if err := tuner.SetBandwidth(actual); err != nil {
+		return nil, fmt.Errorf("rtlsdr: default tuner bandwidth: %w%s", err, tunerBringupHint(err))
 	}
 	return tuner, nil
 }


### PR DESCRIPTION
The pool opened devices and applied PPM / gain / bias-tee, but never
called SetSampleRate. The chip's resampler stayed at whatever divisor it
powered up with while every decoder pipeline downstream did its matched-
filter and symbol-clock math against cfg.SDR.SampleRate. The result on
RTL-SDR hardware is a silent failure: symbol timing is wrong, the FSW /
20-dibit outbound sync detector never matches, and the only log line
that fires is the cc-hunt retune itself.

Pool.Open now takes the rate as its first argument and programs every
device immediately after Open; SetSampleRate failure closes that device
and drops it from the pool rather than letting a wrong-rate radio
poison the decoder. As a belt-and-suspenders default, runBringup also
programs 2.048 MS/s after tuner.Init so any future consumer of the
pure-Go RTL-SDR driver inherits a known-good state.

While here, add a 2 s-throttled debug log on the P25 phase 1 and phase 2
Process paths when the sync detector finds zero hits in a chunk. That
state used to be wholly silent — operators couldn't tell whether IQ
was even reaching the decoder. The throttle keeps the volume sane.