### PR TITLE
sdr: IQ-power gauge + per-VID/PID bias-tee table (#275 follow-ups)

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,6 +388,24 @@ to its own package and lands independently.
 
 ### Recently shipped
 
+- **RTL-SDR diagnostics for silent-failure cases (issue #275).** The
+  pool now programs the configured IQ sample rate on every device at
+  open time — closes the librtlsdr-parity gap that left the chip's
+  resampler at an undefined power-on state and silently fed garbage
+  symbols into the decoder. The pure-Go driver also programs a
+  2.048 MS/s safety default during `runBringup` so any consumer that
+  forgets to set the rate still gets coherent IQ. A new
+  `gophertrunk_sdr_iq_power_dbfs{system}` Prometheus gauge (window
+  ≈ 1 s, idle ≈ -45 dBFS, healthy signal ≈ -25 dBFS) makes the silent
+  side of "cc-hunt: trying repeats forever" observable; the cc decoder
+  also emits a throttled debug log when the level drops below -55 dBFS
+  ("check antenna, gain, USB"). The P25 phase 1 + phase 2 control
+  channels throttle-log "no FSW/sync hits in chunk" instead of staying
+  silent when sync detection produces nothing. Bias-tee GPIO is now a
+  per-(VID, PID) override in `internal/sdr/rtlsdr/purego/devices.go`
+  — current rows inherit the historical GPIO 0 default, but boards
+  with a different pinout can be added without forking the device
+  driver.
 - **Web operator console reaches feature parity with the TUI.**
   Every TUI panel now has a browser counterpart in [`web/`](web/)
   (Vite + React + TypeScript + Tailwind), shipped as the

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -291,6 +291,23 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 		d.addWarning("trunking.systems configured but sdr.devices is empty — daemon has nothing to demodulate; add at least one device")
 	}
 
+	// Metrics — constructed early so downstream components (notably
+	// the cc decoder's IQ-power gauge) can publish into it. Run +
+	// Close are still kicked off later from Daemon.Run / Daemon.Close
+	// so the subscription does no work until the daemon is actually
+	// running.
+	if cfg.Metrics.Enabled {
+		var pool metrics.Snapshotter
+		if d.pool != nil {
+			pool = d.pool
+		}
+		m, err := metrics.New(d.bus, pool, version)
+		if err != nil {
+			return nil, fmt.Errorf("daemon: metrics: %w", err)
+		}
+		d.metrics = m
+	}
+
 	// Voice device list from the pool; empty when no SDRs.
 	d.voicePool = trunking.NewVoicePool(d.collectVoiceDevices())
 
@@ -461,6 +478,14 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 				// stays in `state=hunting`. See README for the
 				// per-protocol Process(stream, baseIdx) adapter
 				// follow-ups.
+				// Avoid the typed-nil trap: a nil *metrics.Metrics
+				// wrapped in IQPowerObserver still tests as non-nil
+				// inside the decoder. Hand the interface only when
+				// the concrete pointer is alive.
+				var iqObs ccdecoder.IQPowerObserver
+				if d.metrics != nil {
+					iqObs = d.metrics
+				}
 				dec, err := ccdecoder.New(ccdecoder.Options{
 					Bus:          d.bus,
 					Log:          log,
@@ -468,6 +493,7 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 					IQ:           controlEntry.Device,
 					Systems:      d.systems,
 					SampleRateHz: float64(cfg.SDR.SampleRate),
+					Metrics:      iqObs,
 				})
 				if err != nil {
 					return nil, fmt.Errorf("daemon: ccdecoder: %w", err)
@@ -578,22 +604,6 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 			}
 			d.retention = r
 		}
-	}
-
-	// Metrics — optional. Subscribes to the bus at construction time.
-	if cfg.Metrics.Enabled {
-		// Avoid the typed-nil interface trap: when d.pool is nil
-		// (no SDRs configured), pass a nil interface explicitly so
-		// the snapshot collector skips itself.
-		var pool metrics.Snapshotter
-		if d.pool != nil {
-			pool = d.pool
-		}
-		m, err := metrics.New(d.bus, pool, version)
-		if err != nil {
-			return nil, fmt.Errorf("daemon: metrics: %w", err)
-		}
-		d.metrics = m
 	}
 
 	// HTTP API — optional.

--- a/docs/hardening.md
+++ b/docs/hardening.md
@@ -162,6 +162,7 @@ Series exposed:
 | `gophertrunk_sdr_ppm{driver,serial,role}`                       | gauge   | Configured frequency-error correction in parts-per-million                                                 |
 | `gophertrunk_sdr_bias_tee{driver,serial,role}`                  | gauge   | `1` when the SDR's 5 V bias-tee output is enabled                                                          |
 | `gophertrunk_sdr_iq_underruns_total{driver,serial}`             | counter | IQ pipeline drops because a downstream stage was too slow                                                  |
+| `gophertrunk_sdr_iq_power_dbfs{system}`                         | gauge   | Mean IQ power on the control SDR (window ≈ 1 s). Idle ≈ -45 dBFS; healthy signal ≈ -25 dBFS; > -3 clips    |
 | `gophertrunk_sdr_usb_reconnects_total{driver,serial}`           | counter | Times the USB driver had to re-open a device                                                               |
 | `gophertrunk_decode_errors_total{protocol,stage}`               | counter | Decode failures by protocol + stage (e.g. `p25`/`tsbk-crc`)                                                |
 | `gophertrunk_build_info{version}`                               | gauge   | Always `1`; carries the build version as a label                                                           |

--- a/docs/user-guide-windows.md
+++ b/docs/user-guide-windows.md
@@ -1094,6 +1094,7 @@ Prometheus exposition (when `metrics.enabled: true`):
 | `gophertrunk_sdr_ppm{driver,serial,role}` | gauge | Configured PPM correction |
 | `gophertrunk_sdr_bias_tee{driver,serial,role}` | gauge | 1 when bias-tee is enabled |
 | `gophertrunk_sdr_iq_underruns_total{driver,serial}` | counter | IQ pipeline drops |
+| `gophertrunk_sdr_iq_power_dbfs{system}` | gauge | Mean control-SDR IQ power, ≈ 1 s window (idle ≈ -45, healthy ≈ -25, clip > -3) |
 | `gophertrunk_sdr_usb_reconnects_total{driver,serial}` | counter | USB re-opens |
 | `gophertrunk_decode_errors_total{protocol,stage}` | counter | Decode failures |
 | `gophertrunk_build_info{version}` | gauge | Always 1; build version label |

--- a/internal/metrics/prom.go
+++ b/internal/metrics/prom.go
@@ -45,6 +45,7 @@ type Metrics struct {
 	ccFrequencyHz *prometheus.GaugeVec   // by system; deleted on CC loss
 	ccTransitions *prometheus.CounterVec // by system,event (locked|lost)
 	iqUnderruns   *prometheus.CounterVec
+	iqPowerDbFS   *prometheus.GaugeVec // by system; mean IQ power on the control SDR
 	usbReconnects *prometheus.CounterVec
 	decodeErrors  *prometheus.CounterVec
 	sdrAttached   *prometheus.GaugeVec
@@ -118,6 +119,20 @@ func New(bus *events.Bus, pool Snapshotter, version string) (*Metrics, error) {
 		Help:      "Times the IQ stream pipeline dropped samples because a downstream stage was too slow.",
 	}, []string{"driver", "serial"})
 
+	// Mean IQ power on the control SDR, expressed in dBFS (0 dBFS = ±1.0
+	// full-scale per the convertU8IQ normalization). Surfaces silent
+	// failure modes that issue #275 was the first instance of: cc-hunt
+	// retunes forever with no decoder progress because the dongle is
+	// either delivering near-zero samples (no antenna, gain at 0, USB
+	// stuck) or clipping. -45 dBFS is typical idle noise; -25 dBFS is
+	// healthy signal; > -3 dBFS indicates clipping.
+	m.iqPowerDbFS = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: namespace,
+		Subsystem: "sdr",
+		Name:      "iq_power_dbfs",
+		Help:      "Mean IQ power on the control SDR in dBFS (window ~= 1 s). Idle ≈ -45; healthy signal ≈ -25; > -3 indicates clipping.",
+	}, []string{"system"})
+
 	m.usbReconnects = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: namespace,
 		Subsystem: "sdr",
@@ -158,6 +173,7 @@ func New(bus *events.Bus, pool Snapshotter, version string) (*Metrics, error) {
 		m.ccFrequencyHz,
 		m.ccTransitions,
 		m.iqUnderruns,
+		m.iqPowerDbFS,
 		m.usbReconnects,
 		m.decodeErrors,
 		m.sdrAttached,
@@ -281,6 +297,25 @@ func (m *Metrics) observeEvent(ev events.Event) {
 // RecordIQUnderrun increments the underrun counter for the supplied SDR.
 func (m *Metrics) RecordIQUnderrun(driver, serial string) {
 	m.iqUnderruns.WithLabelValues(driver, serial).Inc()
+}
+
+// RecordIQPowerDbFS sets the mean-IQ-power gauge for system. Caller
+// computes the window mean; the metrics package just stores it.
+func (m *Metrics) RecordIQPowerDbFS(system string, dbfs float64) {
+	if system == "" {
+		system = "unknown"
+	}
+	m.iqPowerDbFS.WithLabelValues(system).Set(dbfs)
+}
+
+// ClearIQPowerDbFS drops the gauge series for system. Called when a
+// decoder pipeline tears down so stale dBFS values don't linger after
+// the SDR is no longer being driven for that system.
+func (m *Metrics) ClearIQPowerDbFS(system string) {
+	if system == "" {
+		return
+	}
+	m.iqPowerDbFS.DeleteLabelValues(system)
 }
 
 // RecordUSBReconnect increments the reconnect counter for the supplied SDR.

--- a/internal/metrics/prom_test.go
+++ b/internal/metrics/prom_test.go
@@ -149,6 +149,36 @@ func TestRecordHooks(t *testing.T) {
 	}
 }
 
+func TestRecordIQPowerDbFS(t *testing.T) {
+	m, _ := New(nil, nil, "test")
+	defer m.Close()
+
+	m.RecordIQPowerDbFS("MMR", -27.5)
+	if got := testutil.ToFloat64(m.iqPowerDbFS.WithLabelValues("MMR")); got != -27.5 {
+		t.Errorf("iq power = %v, want -27.5", got)
+	}
+
+	// Updating overwrites — gauge semantics.
+	m.RecordIQPowerDbFS("MMR", -30.0)
+	if got := testutil.ToFloat64(m.iqPowerDbFS.WithLabelValues("MMR")); got != -30.0 {
+		t.Errorf("iq power after update = %v, want -30.0", got)
+	}
+
+	// Clear drops the series so a stale value doesn't outlive the
+	// decoder pipeline.
+	m.ClearIQPowerDbFS("MMR")
+	if testutil.CollectAndCount(m.iqPowerDbFS) != 0 {
+		t.Errorf("iq power series count after clear != 0")
+	}
+
+	// Empty system name falls back to "unknown" on record but is a
+	// no-op on clear (no series to drop).
+	m.RecordIQPowerDbFS("", -40.0)
+	if got := testutil.ToFloat64(m.iqPowerDbFS.WithLabelValues("unknown")); got != -40.0 {
+		t.Errorf("iq power unknown = %v, want -40.0", got)
+	}
+}
+
 func TestHandlerScrapeContainsExpectedSeries(t *testing.T) {
 	m, _ := New(nil, nil, "v1.2.3")
 	defer m.Close()

--- a/internal/scanner/ccdecoder/decoder.go
+++ b/internal/scanner/ccdecoder/decoder.go
@@ -39,11 +39,32 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"math"
 	"sync"
+	"time"
 
 	"github.com/MattCheramie/GopherTrunk/internal/events"
 	"github.com/MattCheramie/GopherTrunk/internal/trunking"
 )
+
+// IQPowerObserver is the minimal Metrics surface the decoder uses to
+// publish its window-averaged dBFS gauge. internal/metrics.Metrics
+// satisfies this; nil disables the gauge entirely.
+type IQPowerObserver interface {
+	RecordIQPowerDbFS(system string, dbfs float64)
+	ClearIQPowerDbFS(system string)
+}
+
+// iqPowerWindow is how long the pump aggregates samples before
+// recomputing the mean dBFS and updating the gauge / debug log.
+const iqPowerWindow = time.Second
+
+// iqLowPowerThresholdDbFS is the level below which pump emits a
+// throttled debug log warning that the IQ stream looks dead — gain
+// at 0, antenna disconnected, or USB stuck. -55 dBFS sits well below
+// the idle-noise floor for an R820T2 at moderate gain (~-45 dBFS)
+// so legitimate weak signal doesn't trip it.
+const iqLowPowerThresholdDbFS = -55.0
 
 // Tuner is the subset of sdr.Device the decoder uses for retuning.
 // Matches the same interface cchunt + conventional consume so the
@@ -70,6 +91,11 @@ type Options struct {
 	// protocol receiver factories so they can size their matched
 	// filters correctly.
 	SampleRateHz float64
+	// Metrics is the optional IQ-power observer the pump updates
+	// once per iqPowerWindow. Nil disables the gauge but leaves the
+	// low-power debug log in place — operators without Prometheus
+	// still get a hint when the dongle goes silent.
+	Metrics IQPowerObserver
 }
 
 // Decoder is the long-lived component that converts the control
@@ -93,6 +119,16 @@ type Decoder struct {
 	mu       sync.Mutex
 	active   ProtocolPipeline
 	activeAt string // system name the active pipeline is bound to
+
+	// IQ-power tracking — see pump for the math. Owned by Run's
+	// goroutine via pump; not protected by mu because no other
+	// goroutine reads it.
+	metrics      IQPowerObserver
+	pwSumSq      float64
+	pwSamples    int
+	pwWindowAt   time.Time
+	pwLowLogAt   time.Time
+	pwLastSystem string
 }
 
 // New constructs a Decoder. Returns an error when required Options
@@ -118,6 +154,7 @@ func New(opts Options) (*Decoder, error) {
 		sampleRateHz: opts.SampleRateHz,
 		systems:      make(map[string]trunking.System, len(opts.Systems)),
 		sub:          opts.Bus.Subscribe(),
+		metrics:      opts.Metrics,
 	}
 	for _, s := range opts.Systems {
 		d.systems[s.Name] = s
@@ -188,9 +225,7 @@ func (d *Decoder) handleProgress(p trunking.HuntProgress) {
 	// Close the previous pipeline before constructing a new one so
 	// resources don't accumulate on rapid retune storms.
 	if d.active != nil {
-		_ = d.active.Close()
-		d.active = nil
-		d.activeAt = ""
+		d.clearActiveLocked()
 	}
 	d.mu.Unlock()
 
@@ -217,24 +252,91 @@ func (d *Decoder) handleProgress(p trunking.HuntProgress) {
 func (d *Decoder) clearActive() {
 	d.mu.Lock()
 	defer d.mu.Unlock()
+	d.clearActiveLocked()
+}
+
+// clearActiveLocked closes and forgets the active pipeline. Caller
+// holds d.mu. Also drops the IQ-power gauge series for the previously
+// active system so stale dBFS doesn't linger.
+func (d *Decoder) clearActiveLocked() {
 	if d.active != nil {
 		_ = d.active.Close()
 		d.active = nil
-		d.activeAt = ""
 	}
+	if d.activeAt != "" && d.metrics != nil {
+		d.metrics.ClearIQPowerDbFS(d.activeAt)
+	}
+	d.activeAt = ""
+	d.pwSumSq = 0
+	d.pwSamples = 0
+	d.pwLastSystem = ""
 }
 
 // pump forwards an IQ chunk to the active pipeline. Holding the lock
 // for the whole Process call serialises against handleProgress's
 // pipeline swap so we never call Process on a half-constructed
 // pipeline.
+//
+// While we have the lock, also fold the chunk into the IQ-power
+// window. The window aggregates |IQ|^2 across chunks; once a second
+// of samples has been seen, the mean is converted to dBFS and pushed
+// to the Metrics observer + a throttled debug log fires if the level
+// looks dead. See iqLowPowerThresholdDbFS.
 func (d *Decoder) pump(iq []complex64) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
+	d.observeIQPowerLocked(iq)
 	if d.active == nil {
 		return
 	}
 	d.active.Process(iq)
+}
+
+func (d *Decoder) observeIQPowerLocked(iq []complex64) {
+	if len(iq) == 0 || d.sampleRateHz <= 0 {
+		return
+	}
+	// Reset window state if the system the gauge is labelled with
+	// just changed — different system means different gauge label;
+	// don't fold old samples into the new one's average.
+	if d.activeAt != d.pwLastSystem {
+		d.pwSumSq = 0
+		d.pwSamples = 0
+		d.pwLastSystem = d.activeAt
+	}
+	for _, c := range iq {
+		r := float64(real(c))
+		i := float64(imag(c))
+		d.pwSumSq += r*r + i*i
+	}
+	d.pwSamples += len(iq)
+
+	now := time.Now()
+	if d.pwWindowAt.IsZero() {
+		d.pwWindowAt = now
+		return
+	}
+	if now.Sub(d.pwWindowAt) < iqPowerWindow {
+		return
+	}
+	mean := d.pwSumSq / float64(d.pwSamples)
+	// 10*log10(0) is -Inf; clamp with a small epsilon so the gauge
+	// reads as "very low" instead of breaking JSON encoders.
+	if mean < 1e-12 {
+		mean = 1e-12
+	}
+	dbfs := 10 * math.Log10(mean)
+	if d.activeAt != "" && d.metrics != nil {
+		d.metrics.RecordIQPowerDbFS(d.activeAt, dbfs)
+	}
+	if dbfs < iqLowPowerThresholdDbFS && now.Sub(d.pwLowLogAt) >= 5*time.Second {
+		d.log.Debug("ccdecoder: iq power very low — check antenna, gain, USB",
+			"system", d.activeAt, "dbfs", dbfs)
+		d.pwLowLogAt = now
+	}
+	d.pwSumSq = 0
+	d.pwSamples = 0
+	d.pwWindowAt = now
 }
 
 // Close releases the active pipeline. Safe to call from outside Run;
@@ -245,9 +347,9 @@ func (d *Decoder) Close() error {
 	defer d.mu.Unlock()
 	if d.active != nil {
 		err := d.active.Close()
-		d.active = nil
-		d.activeAt = ""
+		d.clearActiveLocked()
 		return err
 	}
+	d.clearActiveLocked()
 	return nil
 }

--- a/internal/scanner/ccdecoder/decoder_test.go
+++ b/internal/scanner/ccdecoder/decoder_test.go
@@ -894,3 +894,91 @@ func TestMPT1327FactoryAppliesBCHFromSystem(t *testing.T) {
 		t.Errorf("BCHMode = %v, want BCHOn", got)
 	}
 }
+
+// recordingPower captures every IQ-power gauge update + clear so
+// tests can assert the decoder's pump-side observation pipeline
+// without depending on the real Prometheus collector.
+type recordingPower struct {
+	sets    []powerSample
+	cleared []string
+}
+
+type powerSample struct {
+	system string
+	dbfs   float64
+}
+
+func (r *recordingPower) RecordIQPowerDbFS(system string, dbfs float64) {
+	r.sets = append(r.sets, powerSample{system, dbfs})
+}
+func (r *recordingPower) ClearIQPowerDbFS(system string) {
+	r.cleared = append(r.cleared, system)
+}
+
+// TestPumpRecordsIQPowerOnceWindowElapses feeds a known signal level
+// through Process and checks the Metrics observer sees the expected
+// dBFS once iqPowerWindow worth of samples have been folded in.
+func TestPumpRecordsIQPowerOnceWindowElapses(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	pwr := &recordingPower{}
+	d, err := New(Options{
+		Bus: bus, IQ: &fakeIQSource{}, SampleRateHz: 48000, Metrics: pwr,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	// Pretend the swap has happened so the gauge has a system label.
+	d.activeAt = "TestSys"
+
+	// 0.1 amplitude → |c|^2 = 0.02 mean → -16.99 dBFS, but we're
+	// computing -16.99 dBFS = 10*log10(0.02). Use a chunk of 0.5
+	// amplitude → |c|^2 = 0.5 → -3 dBFS for a value that survives
+	// rounding clearly.
+	chunk := make([]complex64, 128)
+	for i := range chunk {
+		chunk[i] = complex(0.5, 0.5)
+	}
+
+	// First pump primes pwWindowAt — no record yet.
+	d.pump(chunk)
+	if len(pwr.sets) != 0 {
+		t.Fatalf("first pump should not record, got %v", pwr.sets)
+	}
+
+	// Force the window timer past iqPowerWindow.
+	d.pwWindowAt = d.pwWindowAt.Add(-2 * iqPowerWindow)
+	d.pump(chunk)
+
+	if len(pwr.sets) != 1 {
+		t.Fatalf("after window, sets = %d, want 1", len(pwr.sets))
+	}
+	got := pwr.sets[0]
+	if got.system != "TestSys" {
+		t.Errorf("system = %q, want TestSys", got.system)
+	}
+	// |0.5+0.5i|^2 = 0.5 → 10*log10(0.5) = -3.01 dBFS
+	if got.dbfs < -3.5 || got.dbfs > -2.5 {
+		t.Errorf("dbfs = %v, want roughly -3", got.dbfs)
+	}
+}
+
+// TestClearActiveClearsIQPowerSeries: when the decoder swaps pipelines
+// it must drop the gauge series for the system the previous pipeline
+// owned, so stale dBFS doesn't outlive the active system.
+func TestClearActiveClearsIQPowerSeries(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	pwr := &recordingPower{}
+	d, err := New(Options{
+		Bus: bus, IQ: &fakeIQSource{}, SampleRateHz: 48000, Metrics: pwr,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	d.activeAt = "TestSys"
+	d.clearActive()
+	if len(pwr.cleared) != 1 || pwr.cleared[0] != "TestSys" {
+		t.Errorf("cleared = %v, want [TestSys]", pwr.cleared)
+	}
+}

--- a/internal/sdr/rtlsdr/purego/device.go
+++ b/internal/sdr/rtlsdr/purego/device.go
@@ -13,12 +13,11 @@ import (
 	"github.com/MattCheramie/GopherTrunk/internal/sdr/rtlsdr/usb"
 )
 
-// biasTeeGPIO is the GPIO pin that drives the 5 V LNA-power output on
-// the dominant RTL-SDR designs (RTL-SDR.com v3+, NESDR Smart v5).
-// Other clones map bias-tee to different pins; future work can table
-// this per (VID, PID) — see the per-product mapping comment in
-// rtl2832u.SetBiasTee.
-const biasTeeGPIO uint8 = 0
+// defaultBiasTeeGPIO is the GPIO pin that drives the 5 V LNA-power
+// output on the dominant RTL-SDR designs (RTL-SDR.com v3+, NESDR Smart
+// v5, generic 0x0bda:0x283x). Per-(VID, PID) overrides live in the
+// knownDevices table — see devices.go.
+const defaultBiasTeeGPIO uint8 = 0
 
 // ErrClosed is returned by [Device] methods invoked after [Device.Close].
 var ErrClosed = errors.New("rtlsdr: device closed")
@@ -34,6 +33,11 @@ type Device struct {
 	demod     *rtl2832u.Demod
 	tuner     tuners.Tuner
 	info      sdr.Info
+	// biasTeeGPIO is the per-device override for the 5 V bias-tee
+	// pin, populated from the knownDevices table at open time. Zero
+	// means "the dominant GPIO 0 design"; non-zero is a deliberate
+	// override for boards with a different pinout.
+	biasTeeGPIO uint8
 
 	streamMu sync.Mutex
 	out      chan []complex64
@@ -117,15 +121,14 @@ func (d *Device) SetPPM(ppm int) error {
 }
 
 // SetBiasTee toggles the dongle's 5 V LNA-power output. The GPIO pin
-// is hard-coded to 0 — the standard for RTL-SDR.com v3+ and NESDR
-// Smart v5 dongles. Boards that wire bias-tee to a different pin
-// will silently no-op; per-product pin mapping is a future
-// enhancement (see the comment in rtl2832u.SetBiasTee).
+// comes from the per-(VID, PID) bias-tee table in devices.go; boards
+// that aren't in the table inherit GPIO 0 (the standard for
+// RTL-SDR.com v3+ and NESDR Smart v5).
 func (d *Device) SetBiasTee(enable bool) error {
 	if d.closed.Load() {
 		return ErrClosed
 	}
-	if err := d.demod.SetBiasTee(biasTeeGPIO, enable); err != nil {
+	if err := d.demod.SetBiasTee(d.biasTeeGPIO, enable); err != nil {
 		return fmt.Errorf("rtlsdr: SetBiasTee(%v): %w", enable, err)
 	}
 	return nil

--- a/internal/sdr/rtlsdr/purego/devices.go
+++ b/internal/sdr/rtlsdr/purego/devices.go
@@ -11,9 +11,19 @@ package purego
 // src/librtlsdr.c known_devices. We claim a USB device only if it
 // matches a row in this table — this keeps random USB devices the
 // kernel would let us open from being mistaken for SDR dongles.
+//
+// BiasTeeGPIO selects which RTL2832U GPIO pin drives the 5 V LNA
+// bias-tee output. Most modern dongles (RTL-SDR.com v3+, NESDR Smart
+// v5, generic 0x0bda:0x283x) wire bias-tee to GPIO 0 — that's the
+// zero-value default, so unset entries inherit the dominant pin and
+// nothing breaks. Boards with a different pinout get an explicit
+// override here; the operator can run with `bias_tee: true` and the
+// right pin toggles. Contributions for non-zero mappings welcome —
+// the docs/troubleshooting page tracks the known list.
 type knownDevice struct {
-	VID, PID uint16
-	Name     string // friendly product name for sdr.Info.Product
+	VID, PID    uint16
+	Name        string // friendly product name for sdr.Info.Product
+	BiasTeeGPIO uint8  // RTL2832U GPIO pin for the 5 V bias-tee output
 }
 
 // knownDevices mirrors librtlsdr's known_devices verbatim; ordering

--- a/internal/sdr/rtlsdr/purego/driver.go
+++ b/internal/sdr/rtlsdr/purego/driver.go
@@ -189,8 +189,14 @@ func openDevice(transport usb.Transport, desc usb.Descriptor, idx int) (*Device,
 
 	kd := lookupKnown(desc.VID, desc.PID)
 	product := desc.Product
-	if product == "" && kd != nil {
-		product = kd.Name
+	biasTeeGPIO := defaultBiasTeeGPIO
+	if kd != nil {
+		if product == "" {
+			product = kd.Name
+		}
+		if kd.BiasTeeGPIO != 0 {
+			biasTeeGPIO = kd.BiasTeeGPIO
+		}
 	}
 	info := sdr.Info{
 		Driver:       DriverName,
@@ -202,10 +208,11 @@ func openDevice(transport usb.Transport, desc usb.Descriptor, idx int) (*Device,
 		Gains:        tuner.Gains(),
 	}
 	return &Device{
-		transport: transport,
-		demod:     demod,
-		tuner:     tuner,
-		info:      info,
+		transport:   transport,
+		demod:       demod,
+		tuner:       tuner,
+		info:        info,
+		biasTeeGPIO: biasTeeGPIO,
 	}, nil
 }
 

--- a/internal/sdr/rtlsdr/purego/driver_test.go
+++ b/internal/sdr/rtlsdr/purego/driver_test.go
@@ -135,6 +135,29 @@ func TestKnownDevicesNoDuplicates(t *testing.T) {
 	}
 }
 
+// TestKnownDevicesBiasTeeGPIODefault asserts the zero-value fallback
+// the per-(VID, PID) bias-tee table relies on. The dominant RTL-SDR
+// designs wire bias-tee to GPIO 0, so every entry in the table that
+// doesn't override it must surface as GPIO 0 to keep the historical
+// behaviour. New non-zero entries are deliberate overrides and not
+// covered here.
+func TestKnownDevicesBiasTeeGPIODefault(t *testing.T) {
+	for _, k := range knownDevices {
+		if k.BiasTeeGPIO > 7 {
+			t.Errorf("%s: BiasTeeGPIO = %d, must be 0..7", k.Name, k.BiasTeeGPIO)
+		}
+	}
+	// The standard Realtek reference VID/PID — operators rely on the
+	// historical GPIO 0 mapping.
+	k := lookupKnown(0x0bda, 0x2832)
+	if k == nil {
+		t.Fatalf("generic 0x0bda:0x2832 missing from knownDevices")
+	}
+	if k.BiasTeeGPIO != 0 {
+		t.Errorf("generic RTL2832U bias-tee GPIO = %d, want 0 (regression)", k.BiasTeeGPIO)
+	}
+}
+
 // warmupUSBSysctlExchange returns the single mock CtrlExchange that
 // matches the wire bytes WarmupUSBSysctl emits — a vendor-OUT write to
 // BlockUSB / USBSysctl with payload 0x09. Err overrides the mock's


### PR DESCRIPTION
## Summary

Three follow-ups from the issue #275 plan now ship together because they all chip at the same silent-failure surface: the operator has no way to tell whether the dongle is delivering coherent IQ before the decoder gives up.

- **`gophertrunk_sdr_iq_power_dbfs{system}`** — new Prometheus gauge the cc decoder updates roughly once a second with mean `|IQ|^2` converted to dBFS. Idle ≈ -45 dBFS, healthy signal ≈ -25 dBFS, `> -3` means the ADC is clipping. The series is dropped when a decoder pipeline tears down so stale dBFS doesn't outlive the active system.
- **Throttled low-power debug log** on the same path — below -55 dBFS prints `ccdecoder: iq power very low — check antenna, gain, USB` at most once per 5 s. Catches the gain-at-0 / antenna-disconnected / USB-stuck cases without flooding.
- **Per-(VID, PID) bias-tee GPIO table** — the hardcoded `biasTeeGPIO = 0` constant moved to a `knownDevice.BiasTeeGPIO` field in `internal/sdr/rtlsdr/purego/devices.go`. Every current row inherits GPIO 0 (the dominant RTL-SDR.com v3+ / NESDR Smart v5 pinout), but the mechanism now exists for boards with a different pinout to be added without forking the driver.

Daemon construction order: the metrics object is now built right after the SDR pool instead of after the storage block so the cc decoder can receive it at construction time. Old position deleted — only the one construction site remains.

Out of scope: the PPM auto-suggest tool from the plan's deferred list is a feature rather than a diagnostic; deferred to a separate issue.

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./...` — full suite green
- [x] New unit tests cover the metric, the cleared-on-swap behavior, and the per-VID/PID table default (`internal/metrics/prom_test.go`, `internal/scanner/ccdecoder/decoder_test.go`, `internal/sdr/rtlsdr/purego/driver_test.go`)
- [ ] On hardware: confirm `curl -s :8080/metrics | grep iq_power_dbfs` reports a sane dBFS while a P25 site is locked, drops to noise floor when the antenna is unplugged, and series disappears when the decoder pipeline tears down.

## Docs

- `README.md` "Recently shipped" entry describing the issue #275 closure + these follow-ups.
- `docs/hardening.md` and `docs/user-guide-windows.md` metric catalogues extended with the new gauge.


---
_Generated by [Claude Code](https://claude.ai/code/session_017REtxLYp8t6WgYorD2XhrR)_