### PR TITLE
p25/phase1: publish affiliation + unit-registration events (slice of #268)

### DIFF
--- a/internal/api/sse.go
+++ b/internal/api/sse.go
@@ -91,6 +91,10 @@ func eventToDTO(ev events.Event) EventDTO {
 		dto.Payload = callEndToDTO(p)
 	case trunking.Grant:
 		dto.Payload = grantToDTO(p)
+	case trunking.Affiliation:
+		dto.Payload = affiliationToDTO(p)
+	case trunking.UnitRegistration:
+		dto.Payload = unitRegistrationToDTO(p)
 	default:
 		// Includes sdr.SDRStatus (already JSON-tagged) and any
 		// future payload types the api package hasn't grown an

--- a/internal/api/sse_test.go
+++ b/internal/api/sse_test.go
@@ -1,0 +1,60 @@
+package api
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// TestEventToDTOAffiliationJSON pins the wire shape of the affiliation
+// event so downstream consumers (Grafana, dashboards) don't break on a
+// silent field-name change.
+func TestEventToDTOAffiliationJSON(t *testing.T) {
+	dto := eventToDTO(events.Event{
+		Kind: events.KindAffiliation,
+		Payload: trunking.Affiliation{
+			System:            "MMR",
+			Protocol:          "p25",
+			SourceID:          0xABCDEF,
+			GroupID:           0x1234,
+			AnnouncementGroup: 0xAABB,
+			Response:          trunking.AffiliationAccepted,
+		},
+	})
+	body, err := json.Marshal(dto.Payload)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	got := string(body)
+	want := `{"system":"MMR","protocol":"p25","source_id":11259375,"group_id":4660,"announcement_group":43707,"response":"accepted"}`
+	if got != want {
+		t.Errorf("affiliation JSON =\n  %s\nwant\n  %s", got, want)
+	}
+}
+
+// TestEventToDTOUnitRegistrationJSON pins the wire shape of the
+// registration event for the same reason.
+func TestEventToDTOUnitRegistrationJSON(t *testing.T) {
+	dto := eventToDTO(events.Event{
+		Kind: events.KindUnitRegistration,
+		Payload: trunking.UnitRegistration{
+			System:   "MMR",
+			Protocol: "p25",
+			SourceID: 0x112233,
+			WACN:     0xBEE08,
+			SystemID: 0x534,
+			Response: trunking.RegistrationAccepted,
+		},
+	})
+	body, err := json.Marshal(dto.Payload)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	got := string(body)
+	want := `{"system":"MMR","protocol":"p25","source_id":1122867,"wacn":781832,"system_id":1332,"response":"accepted"}`
+	if got != want {
+		t.Errorf("registration JSON =\n  %s\nwant\n  %s", got, want)
+	}
+}

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -131,6 +131,46 @@ func grantToDTO(g trunking.Grant) GrantDTO {
 	}
 }
 
+// AffiliationDTO mirrors trunking.Affiliation.
+type AffiliationDTO struct {
+	System            string `json:"system"`
+	Protocol          string `json:"protocol"`
+	SourceID          uint32 `json:"source_id"`
+	GroupID           uint32 `json:"group_id"`
+	AnnouncementGroup uint32 `json:"announcement_group,omitempty"`
+	Response          string `json:"response"`
+}
+
+func affiliationToDTO(a trunking.Affiliation) AffiliationDTO {
+	return AffiliationDTO{
+		System: a.System, Protocol: a.Protocol,
+		SourceID:          a.SourceID,
+		GroupID:           a.GroupID,
+		AnnouncementGroup: a.AnnouncementGroup,
+		Response:          a.Response.String(),
+	}
+}
+
+// UnitRegistrationDTO mirrors trunking.UnitRegistration.
+type UnitRegistrationDTO struct {
+	System   string `json:"system"`
+	Protocol string `json:"protocol"`
+	SourceID uint32 `json:"source_id"`
+	WACN     uint32 `json:"wacn"`
+	SystemID uint16 `json:"system_id"`
+	Response string `json:"response"`
+}
+
+func unitRegistrationToDTO(u trunking.UnitRegistration) UnitRegistrationDTO {
+	return UnitRegistrationDTO{
+		System: u.System, Protocol: u.Protocol,
+		SourceID: u.SourceID,
+		WACN:     u.WACN,
+		SystemID: u.SystemID,
+		Response: u.Response.String(),
+	}
+}
+
 // ActiveCallDTO mirrors trunking.ActiveCall for JSON.
 type ActiveCallDTO struct {
 	Grant        GrantDTO      `json:"grant"`

--- a/internal/events/bus.go
+++ b/internal/events/bus.go
@@ -32,6 +32,22 @@ const (
 	//     so operators can see "retry in 5 s".
 	KindHuntProgress Kind = "cchunt.progress"
 	KindHuntFailed   Kind = "cchunt.failed"
+	// KindAffiliation fires when a radio unit affiliates with a
+	// talkgroup. P25 control-channel publishes one per Group
+	// Affiliation Response TSBK (opcode 0x28); the payload identifies
+	// the source unit, the group it's joining, and the response code
+	// (accepted / denied / refused / failed) from the system. Useful
+	// downstream as a "who is listening where" feed for telemetry
+	// dashboards.
+	//
+	// KindUnitRegistration fires when a radio registers (or
+	// deregisters) on a site. P25 control-channel publishes one per
+	// Unit Registration Response TSBK (opcode 0x2C); the payload
+	// identifies the source unit, the WACN + System ID it's
+	// registering on, and the response code. Useful as a "which
+	// radios are on which site" feed.
+	KindAffiliation      Kind = "affiliation"
+	KindUnitRegistration Kind = "registration"
 	// KindAudioState fires when an operator changes the live-audio
 	// cockpit — volume, mute, or recording-gate. The payload is the
 	// new state (the same shape as GET /api/v1/audio). Subscribers

--- a/internal/radio/p25/phase1/control.go
+++ b/internal/radio/p25/phase1/control.go
@@ -198,6 +198,10 @@ func (c *ControlChannel) dispatchTSBK(t TSBK, nac uint16, metric int) {
 			"tx_offset_hz", u.TxOffsetHz)
 	case OpGroupVoiceChannelGrant:
 		c.publishGroupGrant(ParseGroupVoiceChannelGrant(t.Payload), nac)
+	case OpGroupAffiliationResponse:
+		c.publishAffiliation(ParseGroupAffiliationResponse(t.Payload), nac)
+	case OpUnitRegistrationResponse:
+		c.publishUnitRegistration(ParseUnitRegistrationResponse(t.Payload), nac)
 	default:
 		c.log.Debug("tsbk decoded",
 			"opcode", t.Opcode, "lb", t.LB, "metric", metric, "nac", nac)
@@ -245,6 +249,50 @@ func (c *ControlChannel) publishGroupGrant(g GroupVoiceChannelGrant, nac uint16)
 		"tg", g.GroupAddress, "src", g.SourceID,
 		"id", g.ChannelID, "num", g.ChannelNumber, "freq_hz", freq,
 		"enc", encrypted, "emer", emergency)
+}
+
+// publishAffiliation publishes a trunking.Affiliation on the bus when
+// the site issues a Group Affiliation Response (opcode 0x28). No
+// band-plan resolution is needed — affiliations don't carry channel
+// info.
+func (c *ControlChannel) publishAffiliation(g GroupAffiliationResponse, nac uint16) {
+	c.bus.Publish(events.Event{
+		Kind: events.KindAffiliation,
+		Payload: trunking.Affiliation{
+			System:            c.systemName,
+			Protocol:          "p25",
+			SourceID:          g.TargetID,
+			GroupID:           uint32(g.GroupAddress),
+			AnnouncementGroup: uint32(g.AnnouncementGroup),
+			Response:          trunking.AffiliationResponse(g.Response),
+			At:                c.now(),
+		},
+	})
+	c.log.Debug("p25: affiliation",
+		"system", c.systemName, "nac", nac,
+		"src", g.TargetID, "tg", g.GroupAddress,
+		"ann", g.AnnouncementGroup, "rsp", g.Response)
+}
+
+// publishUnitRegistration publishes a trunking.UnitRegistration on the
+// bus when the site issues a Unit Registration Response (opcode 0x2C).
+func (c *ControlChannel) publishUnitRegistration(u UnitRegistrationResponse, nac uint16) {
+	c.bus.Publish(events.Event{
+		Kind: events.KindUnitRegistration,
+		Payload: trunking.UnitRegistration{
+			System:   c.systemName,
+			Protocol: "p25",
+			SourceID: u.SourceID,
+			WACN:     u.WACN,
+			SystemID: u.SystemID,
+			Response: trunking.RegistrationResponse(u.Response),
+			At:       c.now(),
+		},
+	})
+	c.log.Debug("p25: registration",
+		"system", c.systemName, "nac", nac,
+		"src", u.SourceID, "wacn", u.WACN, "sysid", u.SystemID,
+		"rsp", u.Response)
 }
 
 // MarkLost publishes a CCLost event for the current frequency and resets

--- a/internal/radio/p25/phase1/control_test.go
+++ b/internal/radio/p25/phase1/control_test.go
@@ -203,6 +203,112 @@ func TestControlChannelAppliesIdentifierUpdateAndPublishesGrant(t *testing.T) {
 	}
 }
 
+func TestControlChannelPublishesAffiliation(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	// Response = denied (2), AnnGroup = 0xAABB, Group = 0x1234,
+	// TargetID = 0xABCDEF.
+	payload := [8]byte{0x02, 0xAA, 0xBB, 0x12, 0x34, 0xAB, 0xCD, 0xEF}
+	tsbk := TSBK{LB: true, Opcode: OpGroupAffiliationResponse, Payload: payload}
+	stream := buildLockedStreamWithTSBK(10, 0x111, DUIDTrunkingSignaling, tsbk)
+
+	cc := New(Options{
+		Bus:         bus,
+		SystemName:  "TestSys",
+		FrequencyHz: 851_000_000,
+		Now:         func() time.Time { return time.Unix(1_700_000_001, 0).UTC() },
+	})
+	cc.Process(stream, 0)
+
+	var got *trunking.Affiliation
+	deadline := time.After(time.Second)
+	for got == nil {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind == events.KindAffiliation {
+				a := ev.Payload.(trunking.Affiliation)
+				got = &a
+			}
+		case <-deadline:
+			t.Fatal("no affiliation event published")
+		}
+	}
+	if got.System != "TestSys" || got.Protocol != "p25" {
+		t.Errorf("identity = %s/%s", got.System, got.Protocol)
+	}
+	if got.SourceID != 0xABCDEF {
+		t.Errorf("SourceID = %06X, want ABCDEF", got.SourceID)
+	}
+	if got.GroupID != 0x1234 {
+		t.Errorf("GroupID = %04X, want 1234", got.GroupID)
+	}
+	if got.AnnouncementGroup != 0xAABB {
+		t.Errorf("AnnouncementGroup = %04X, want AABB", got.AnnouncementGroup)
+	}
+	if got.Response != trunking.AffiliationDenied {
+		t.Errorf("Response = %v, want denied", got.Response)
+	}
+	if got.At.Unix() != 1_700_000_001 {
+		t.Errorf("At = %v, want injected Now", got.At)
+	}
+}
+
+func TestControlChannelPublishesUnitRegistration(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	// Response = accepted (0), WACN = 0xBEE08, SystemID = 0x534,
+	// SourceID = 0x112233.
+	payload := [8]byte{0x00, 0xBE, 0xE0, 0x85, 0x34, 0x11, 0x22, 0x33}
+	tsbk := TSBK{LB: true, Opcode: OpUnitRegistrationResponse, Payload: payload}
+	stream := buildLockedStreamWithTSBK(10, 0x222, DUIDTrunkingSignaling, tsbk)
+
+	cc := New(Options{
+		Bus:         bus,
+		SystemName:  "TestSys",
+		FrequencyHz: 851_000_000,
+		Now:         func() time.Time { return time.Unix(1_700_000_002, 0).UTC() },
+	})
+	cc.Process(stream, 0)
+
+	var got *trunking.UnitRegistration
+	deadline := time.After(time.Second)
+	for got == nil {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind == events.KindUnitRegistration {
+				u := ev.Payload.(trunking.UnitRegistration)
+				got = &u
+			}
+		case <-deadline:
+			t.Fatal("no registration event published")
+		}
+	}
+	if got.System != "TestSys" || got.Protocol != "p25" {
+		t.Errorf("identity = %s/%s", got.System, got.Protocol)
+	}
+	if got.SourceID != 0x112233 {
+		t.Errorf("SourceID = %06X, want 112233", got.SourceID)
+	}
+	if got.WACN != 0xBEE08 {
+		t.Errorf("WACN = %05X, want BEE08", got.WACN)
+	}
+	if got.SystemID != 0x534 {
+		t.Errorf("SystemID = %03X, want 534", got.SystemID)
+	}
+	if got.Response != trunking.RegistrationAccepted {
+		t.Errorf("Response = %v, want accepted", got.Response)
+	}
+	if got.At.Unix() != 1_700_000_002 {
+		t.Errorf("At = %v, want injected Now", got.At)
+	}
+}
+
 func TestControlChannelGrantBeforeIdentifierUpdateEmitsDecodeError(t *testing.T) {
 	bus := events.NewBus(8)
 	defer bus.Close()

--- a/internal/radio/p25/phase1/opcodes.go
+++ b/internal/radio/p25/phase1/opcodes.go
@@ -68,6 +68,10 @@ func (o Opcode) String() string {
 		return "SecondaryControlChannelBroadcast"
 	case OpIdentifierUpdate:
 		return "IdentifierUpdate"
+	case OpGroupAffiliationResponse:
+		return "GroupAffiliationResponse"
+	case OpUnitRegistrationResponse:
+		return "UnitRegistrationResponse"
 	default:
 		return fmt.Sprintf("Opcode(%02X)", uint8(o))
 	}
@@ -118,6 +122,56 @@ func ParseGroupVoiceChannelUpdate(p [8]byte) GroupVoiceChannelUpdate {
 		ChannelBID:     uint8(cB >> 12),
 		ChannelBNumber: cB & 0x0FFF,
 		GroupAddressB:  binary.BigEndian.Uint16(p[6:8]),
+	}
+}
+
+// GroupAffiliationResponse (opcode 0x28) — published when a radio unit
+// is granted (or denied) affiliation with a talkgroup. Payload layout
+// follows OP25's reference decoder (`trunk_p25.py`):
+//
+//	byte 0:    bits 1-0 = Affiliation Response Value
+//	bytes 1-2: Announcement Group Address (16 bits)
+//	bytes 3-4: Group Address (16 bits) — the talkgroup
+//	bytes 5-7: Target ID (24 bits) — the radio being responded to
+type GroupAffiliationResponse struct {
+	Response          uint8
+	AnnouncementGroup uint16
+	GroupAddress      uint16
+	TargetID          uint32
+}
+
+// ParseGroupAffiliationResponse decodes payload bytes for opcode 0x28.
+func ParseGroupAffiliationResponse(p [8]byte) GroupAffiliationResponse {
+	return GroupAffiliationResponse{
+		Response:          p[0] & 0x03,
+		AnnouncementGroup: binary.BigEndian.Uint16(p[1:3]),
+		GroupAddress:      binary.BigEndian.Uint16(p[3:5]),
+		TargetID:          uint32(p[5])<<16 | uint32(p[6])<<8 | uint32(p[7]),
+	}
+}
+
+// UnitRegistrationResponse (opcode 0x2C) — published when a radio
+// completes (or is denied) registration on a site. Payload layout
+// follows OP25's reference decoder (`trunk_p25.py`):
+//
+//	byte 0:        bits 1-0 = Registration Response Value
+//	bytes 1-3 + top nibble of byte 3: WACN (20 bits)
+//	bottom nibble of byte 3 + byte 4: System ID (12 bits)
+//	bytes 5-7:     Source ID (24 bits) — the radio's WUID
+type UnitRegistrationResponse struct {
+	Response uint8
+	WACN     uint32 // 20-bit
+	SystemID uint16 // 12-bit
+	SourceID uint32 // 24-bit
+}
+
+// ParseUnitRegistrationResponse decodes payload bytes for opcode 0x2C.
+func ParseUnitRegistrationResponse(p [8]byte) UnitRegistrationResponse {
+	return UnitRegistrationResponse{
+		Response: p[0] & 0x03,
+		WACN:     uint32(p[1])<<12 | uint32(p[2])<<4 | uint32(p[3])>>4,
+		SystemID: uint16(p[3]&0x0F)<<8 | uint16(p[4]),
+		SourceID: uint32(p[5])<<16 | uint32(p[6])<<8 | uint32(p[7]),
 	}
 }
 

--- a/internal/radio/p25/phase1/tsbk_test.go
+++ b/internal/radio/p25/phase1/tsbk_test.go
@@ -54,6 +54,47 @@ func TestParseGroupVoiceChannelGrant(t *testing.T) {
 	}
 }
 
+func TestParseGroupAffiliationResponse(t *testing.T) {
+	// Response = 0x2 (denied), AnnGroup = 0xAABB, Group = 0x1234,
+	// Target = 0xABCDEF. Top 6 bits of byte 0 are reserved; we set
+	// them to 1s to confirm the parser masks them off.
+	p := [8]byte{0xFE, 0xAA, 0xBB, 0x12, 0x34, 0xAB, 0xCD, 0xEF}
+	a := ParseGroupAffiliationResponse(p)
+	if a.Response != 0x2 {
+		t.Errorf("Response = %X, want 2", a.Response)
+	}
+	if a.AnnouncementGroup != 0xAABB {
+		t.Errorf("AnnouncementGroup = %04X, want AABB", a.AnnouncementGroup)
+	}
+	if a.GroupAddress != 0x1234 {
+		t.Errorf("GroupAddress = %04X, want 1234", a.GroupAddress)
+	}
+	if a.TargetID != 0xABCDEF {
+		t.Errorf("TargetID = %06X, want ABCDEF", a.TargetID)
+	}
+}
+
+func TestParseUnitRegistrationResponse(t *testing.T) {
+	// Response = 0x0 (accepted). WACN = 0xBEE08 (20-bit) packed as
+	// byte1 = 0xBE, byte2 = 0xE0, top nibble of byte3 = 0x8.
+	// SystemID = 0x534 (12-bit) packed as bottom nibble of byte3 = 0x5,
+	// byte4 = 0x34. Source = 0x112233.
+	p := [8]byte{0x00, 0xBE, 0xE0, 0x85, 0x34, 0x11, 0x22, 0x33}
+	u := ParseUnitRegistrationResponse(p)
+	if u.Response != 0x0 {
+		t.Errorf("Response = %X, want 0", u.Response)
+	}
+	if u.WACN != 0xBEE08 {
+		t.Errorf("WACN = %05X, want BEE08", u.WACN)
+	}
+	if u.SystemID != 0x534 {
+		t.Errorf("SystemID = %03X, want 534", u.SystemID)
+	}
+	if u.SourceID != 0x112233 {
+		t.Errorf("SourceID = %06X, want 112233", u.SourceID)
+	}
+}
+
 func TestParseNetworkStatusBroadcast(t *testing.T) {
 	// WACN = 0xABCDE (20-bit), SystemID = 0x123 (12-bit).
 	p := [8]byte{0xAB, 0xCD, 0xE1, 0x23, 0x40, 0x10, 0x00, 0x42}

--- a/internal/trunking/affiliation.go
+++ b/internal/trunking/affiliation.go
@@ -8,10 +8,10 @@ import "time"
 type AffiliationResponse uint8
 
 const (
-	AffiliationAccepted  AffiliationResponse = 0
-	AffiliationFailed    AffiliationResponse = 1
-	AffiliationDenied    AffiliationResponse = 2
-	AffiliationRefused   AffiliationResponse = 3
+	AffiliationAccepted AffiliationResponse = 0
+	AffiliationFailed   AffiliationResponse = 1
+	AffiliationDenied   AffiliationResponse = 2
+	AffiliationRefused  AffiliationResponse = 3
 )
 
 func (r AffiliationResponse) String() string {

--- a/internal/trunking/affiliation.go
+++ b/internal/trunking/affiliation.go
@@ -1,0 +1,83 @@
+package trunking
+
+import "time"
+
+// AffiliationResponse encodes the P25 Group Affiliation Response value
+// (TIA-102.AABF Table 7-37). The integer values are wire constants — do
+// not renumber.
+type AffiliationResponse uint8
+
+const (
+	AffiliationAccepted  AffiliationResponse = 0
+	AffiliationFailed    AffiliationResponse = 1
+	AffiliationDenied    AffiliationResponse = 2
+	AffiliationRefused   AffiliationResponse = 3
+)
+
+func (r AffiliationResponse) String() string {
+	switch r {
+	case AffiliationAccepted:
+		return "accepted"
+	case AffiliationFailed:
+		return "failed"
+	case AffiliationDenied:
+		return "denied"
+	case AffiliationRefused:
+		return "refused"
+	default:
+		return "unknown"
+	}
+}
+
+// Affiliation is published on the events bus when a radio unit
+// affiliates with a talkgroup. Emitted by P25 control-channel decoders
+// on opcode 0x28 (Group Affiliation Response).
+type Affiliation struct {
+	System            string              // System name, matches trunking.System.Name
+	Protocol          string              // "p25" / "dmr" / "nxdn"
+	SourceID          uint32              // radio unit being affiliated
+	GroupID           uint32              // talkgroup the unit is joining
+	AnnouncementGroup uint32              // optional announcement-group association (0 if unused)
+	Response          AffiliationResponse // accepted / failed / denied / refused
+	At                time.Time
+}
+
+// RegistrationResponse encodes the P25 Unit Registration Response value
+// (TIA-102.AABF Table 7-43). The integer values are wire constants — do
+// not renumber.
+type RegistrationResponse uint8
+
+const (
+	RegistrationAccepted RegistrationResponse = 0
+	RegistrationFailed   RegistrationResponse = 1
+	RegistrationDenied   RegistrationResponse = 2
+	RegistrationRefused  RegistrationResponse = 3
+)
+
+func (r RegistrationResponse) String() string {
+	switch r {
+	case RegistrationAccepted:
+		return "accepted"
+	case RegistrationFailed:
+		return "failed"
+	case RegistrationDenied:
+		return "denied"
+	case RegistrationRefused:
+		return "refused"
+	default:
+		return "unknown"
+	}
+}
+
+// UnitRegistration is published on the events bus when a radio unit
+// registers (or attempts to register) on a site. Emitted by P25
+// control-channel decoders on opcode 0x2C (Unit Registration Response).
+type UnitRegistration struct {
+	System   string               // System name, matches trunking.System.Name
+	Protocol string               // "p25" / "dmr" / "nxdn"
+	SourceID uint32               // radio unit's WUID
+	WACN     uint32               // 20-bit Wide Area Communications Network ID
+	SystemID uint16               // 12-bit system identifier
+	Response RegistrationResponse // accepted / failed / denied / refused
+	At       time.Time
+}


### PR DESCRIPTION
## Summary

- Publish P25 control-channel **affiliation** events (opcode 0x28, Group Affiliation Response) and **unit-registration** events (opcode 0x2C, Unit Registration Response) — both opcodes were already recognised by the decoder but silently dropped in `dispatchTSBK`'s default branch.
- Two new event kinds on the bus: `KindAffiliation` and `KindUnitRegistration`. Both flow through the existing `/api/v1/events` SSE stream (and WebSocket) with JSON-tagged DTOs so downstream consumers can rely on stable field names.

Slice of #268 — closes two of the five named gaps (the issue lists "affiliations" and "registrations" in its required schema). The remaining pieces (webhook delivery, full schema doc, encryption-metadata extension) are out of scope and deferred to follow-up issues.

## Why this slice

Most of #268's infrastructure already exists in the repo: `/api/v1/events` SSE + WebSocket, event bus with 13 kinds, Prometheus, CORS, auth, graceful shutdown. The real gap was that two TSBK opcodes were parsed only enough to be debug-logged — never converted into typed payloads or published. Fixing that follows the existing `publishGroupGrant` template exactly.

## Implementation notes

- **Byte layouts** follow OP25's reference decoder (`trunk_p25.py`) — the same source the rest of the TSBK opcodes in `opcodes.go` are derived from (comment at L11-13 explicitly calls this out).
- **Engine unchanged** — `internal/trunking/engine.go` filters for `KindGrant` only; affiliation/registration events flow only to API subscribers (SSE/WS) without touching the call-routing path.
- **Response codes** ship as small typed enums (`AffiliationResponse`, `RegistrationResponse`) with `String()` so the DTO emits human-readable values (`"accepted"` / `"denied"` / …) rather than raw integers — easier on Grafana / dashboards.

## Out of scope (follow-ups for #268)

- Webhook delivery (`POST` to configured URLs)
- A `docs/api-events.md` documenting the full wire format
- `AlgorithmID` / `KeyID` extension on `Grant` (would benefit from being designed alongside DMR encryption work in #276)
- Location Registration (opcode 0x2B) — close cousin of unit registration, deferred to the same follow-up

## Test plan

- [x] `go test ./internal/radio/p25/phase1 -run 'TestParseGroupAffiliationResponse|TestParseUnitRegistrationResponse|TestControlChannelPublishes'` — parser + end-to-end publish tests
- [x] `go test ./internal/api -run TestEventToDTO` — JSON shape regression tests (snake_case fields, response strings)
- [x] `go test ./...` — full module green, no regressions
- [ ] **Live verification (operator follow-up)**: on a P25 site with active radios, `curl -N http://localhost:8080/api/v1/events` should now show `event: affiliation` and `event: registration` lines interleaved with the existing grants.

https://claude.ai/code/session_01MV9dChSSh8aPEyCXez9Bz1

---
_Generated by [Claude Code](https://claude.ai/code/session_01MV9dChSSh8aPEyCXez9Bz1)_