### PR TITLE
p25/phase1: add CQPSK/LSM demod path for simulcast sites (fix #275)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ for tagged releases.
 
 ## [Unreleased]
 
+### Added
+
+- **P25 Phase 1 CQPSK / LSM demodulator path** for simulcast P25
+  sites (issue #275). New per-system YAML key
+  `p25_phase1_demod_mode: cqpsk` routes the control-channel IQ
+  through a complex RRC matched filter + Gardner timing recovery +
+  differential QPSK quadrant decode with LSM dibit remap, replacing
+  the FM-discriminator + 4-level slicer path that produces near-
+  random dibits on Linear Simulcast Modulation. The C4FM path stays
+  the default for conventional non-simulcast deployments. Pipeline
+  construction now logs `ccdecoder: p25/phase1 pipeline configured
+  demod=…` so operators can confirm which path is active.
+- **Multi-rotation FSW search** on the P25 Phase 1 sync detector.
+  `SyncDetector.ProcessWithRotation` tries all four cyclic shifts
+  of the dibit alphabet against the canonical FrameSyncWord and
+  returns the rotation that matched, absorbing residual symbol-
+  polarity / I-Q-swap ambiguity. The downstream control-channel
+  parser inverts the rotation before NID BCH + TSBK trellis decode.
+  Rotation=0 wins on ties so existing clean-fixture tests stay
+  green.
+
 ## [v0.1.7] — 2026-05-19
 
 Observability + import-pipeline release. Twelve merged PRs land the

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -223,6 +223,7 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 			TETRAClockMode:         sys.TETRAClockMode,
 			LTRFCSMode:             sys.LTRFCSMode,
 			LTRManchesterMode:      sys.LTRManchesterMode,
+			P25Phase1DemodMode:     sys.P25Phase1DemodMode,
 			P25Phase2TrellisMode:   sys.P25Phase2TrellisMode,
 			P25Phase2RSMode:        sys.P25Phase2RSMode,
 			P25Phase2ScramblerMode: sys.P25Phase2ScramblerMode,

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -146,6 +146,15 @@ trunking:
   #                                     # for non-spec transmitters (see
   #                                     # samples/nxdn/README.md sweep recipe)
   #
+  #   - name: "Simulcast-P25"
+  #     protocol: p25
+  #     control_channels: [420_087_500]
+  #     p25_phase1_demod_mode: "cqpsk"  # LSM linear-CQPSK — required on
+  #                                     # P25 simulcast sites whose CC
+  #                                     # is transmitted as Linear
+  #                                     # Simulcast Modulation rather
+  #                                     # than C4FM (issue #275)
+  #
   #   - name: "Legacy-P25-Phase2"
   #     protocol: p25
   #     control_channels: [851_006_250]

--- a/docs/opt-in-features.md
+++ b/docs/opt-in-features.md
@@ -95,6 +95,33 @@ decimator per system.
 | P25 Phase 2 | `p25_phase2_clock_mode` | `ClockGardner` | `naive` / `off` |
 | TETRA | `tetra_clock_mode` | `ClockGardner` | `naive` / `off` |
 
+---
+
+## 2a. P25 Phase 1 demodulator selection
+
+**C4FM on by default; opt into CQPSK/LSM per system.** Conventional
+P25 Phase 1 sites transmit C4FM on the air — the FM-discriminator +
+4-level slicer the receiver ships with handles them. P25 simulcast
+deployments commonly transmit the control channel as
+[Linear Simulcast Modulation](https://www.dsheirer.com/linear-simulcast-modulation/)
+(LSM, TIA-102.BAAA), a CQPSK-shaped variant designed to survive the
+multi-transmitter overlap that destroys pure C4FM. LSM pushed through
+an FM discriminator produces near-random dibits and the FSW never
+matches — the failure mode reported against
+[issue #275](https://github.com/MattCheramie/GopherTrunk/issues/275).
+
+Operators on simulcast sites opt into the CQPSK path per system:
+
+| Receiver | YAML key | Default | Opt-in string |
+| --- | --- | --- | --- |
+| P25 Phase 1 | `p25_phase1_demod_mode` | `c4fm` (FM discriminator + 4-level slicer) | `cqpsk` / `lsm` / `linear` (complex RRC + Gardner + differential QPSK) |
+
+The CQPSK path internally pins Gardner timing recovery on (the LSM
+demod operates on complex IQ at the sample rate; naive sps-th-sample
+decimation produces meaningless symbols at any timing offset). The
+log line `ccdecoder: p25/phase1 pipeline configured demod=…` on
+startup confirms which path is active.
+
 Other receivers (DMR, dPMR, NXDN, EDACS, LTR, MPT 1327, Motorola
 Type II, YSF) either don't need timing recovery or use protocol-
 specific clock-tracking primitives. The Gardner loop is wired

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -39,6 +39,7 @@ type SystemDTO struct {
 	TETRAChannelCoding     string  `json:"tetra_channel_coding,omitempty"`
 	LTRFCSMode             string  `json:"ltr_fcs_mode,omitempty"`
 	LTRManchesterMode      string  `json:"ltr_manchester_mode,omitempty"`
+	P25Phase1DemodMode     string  `json:"p25_phase1_demod_mode,omitempty"`
 	P25Phase2TrellisMode   string  `json:"p25_phase2_trellis_mode,omitempty"`
 	P25Phase2RSMode        string  `json:"p25_phase2_rs_mode,omitempty"`
 	P25Phase2ScramblerMode string  `json:"p25_phase2_scrambler_mode,omitempty"`
@@ -64,6 +65,7 @@ func systemToDTO(s trunking.System) SystemDTO {
 		TETRAChannelCoding:     s.TETRAChannelCoding,
 		LTRFCSMode:             s.LTRFCSMode,
 		LTRManchesterMode:      s.LTRManchesterMode,
+		P25Phase1DemodMode:     s.P25Phase1DemodMode,
 		P25Phase2TrellisMode:   s.P25Phase2TrellisMode,
 		P25Phase2RSMode:        s.P25Phase2RSMode,
 		P25Phase2ScramblerMode: s.P25Phase2ScramblerMode,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -210,6 +210,17 @@ type SystemConfig struct {
 	// fixtures). Ignored for non-LTR protocols.
 	LTRManchesterMode string `yaml:"ltr_manchester_mode"`
 
+	// P25Phase1DemodMode selects the symbol-recovery path for the
+	// P25 Phase 1 receiver. Recognised values: "" / "c4fm" / "fm"
+	// (the default — FM discriminator + 4-level slicer; matches
+	// every previously shipping config and works on conventional
+	// non-simulcast P25 transmitters) or "cqpsk" / "lsm" / "linear"
+	// (the linear / LSM path — complex RRC + Gardner + differential
+	// QPSK; required for simulcast P25 deployments whose control
+	// channel transmits Linear Simulcast Modulation rather than
+	// straight C4FM, see issue #275 and TIA-102.BAAA). Ignored for
+	// non-P25-Phase-1 protocols.
+	P25Phase1DemodMode string `yaml:"p25_phase1_demod_mode"`
 	// P25Phase2TrellisMode enables the 4-state ½-rate trellis FEC
 	// decoder on the P25 Phase 2 MAC PDU window. Recognised values:
 	// "" / "on" / "true" / "1" (the new default — 146 channel

--- a/internal/radio/p25/phase1/control.go
+++ b/internal/radio/p25/phase1/control.go
@@ -113,7 +113,7 @@ const noHitsThrottle = 2 * time.Second
 // Process consumes a window of dibits and runs detection/parsing. baseIdx
 // is the absolute dibit index of dibits[0]. Returns the new baseIndex.
 func (c *ControlChannel) Process(dibits []uint8, baseIdx int) int {
-	hits, next := c.det.Process(nil, dibits, baseIdx)
+	hits, rots, next := c.det.ProcessWithRotation(nil, nil, dibits, baseIdx)
 	if len(hits) == 0 && len(dibits) > 0 && !c.locked {
 		now := c.now()
 		if now.Sub(c.lastNoHitsAt) >= noHitsThrottle {
@@ -122,7 +122,8 @@ func (c *ControlChannel) Process(dibits []uint8, baseIdx int) int {
 			c.lastNoHitsAt = now
 		}
 	}
-	for _, h := range hits {
+	for i, h := range hits {
+		rot := rots[i]
 		// FSW ends at index h (relative to the absolute dibit stream). The
 		// 32-dibit NID immediately follows.
 		startInWindow := h - baseIdx + 1
@@ -130,10 +131,15 @@ func (c *ControlChannel) Process(dibits []uint8, baseIdx int) int {
 			// Crosses the buffer edge; future calls will have the rest.
 			continue
 		}
-		nidDibits := dibits[startInWindow : startInWindow+32]
+		// Apply the inverse rotation to the dibits that follow the FSW
+		// — the sync detector matched the FSW after adding `rot` mod 4
+		// to each input dibit, so the canonical dibit values the BCH /
+		// trellis decoders expect are recovered by subtracting `rot`
+		// (equivalently, adding (4 - rot) mod 4) before parsing.
+		nidDibits := rotateDibits(dibits[startInWindow:startInWindow+32], rot)
 		nid, errs, err := NIDFromDibits(nidDibits)
 		if err != nil {
-			c.log.Debug("nid parse failed", "err", err, "errs", errs)
+			c.log.Debug("nid parse failed", "err", err, "errs", errs, "rot", rot)
 			c.bus.Publish(events.Event{
 				Kind:    events.KindDecodeError,
 				Payload: events.DecodeError{Protocol: "p25", Stage: events.StageNIDBCH},
@@ -141,7 +147,7 @@ func (c *ControlChannel) Process(dibits []uint8, baseIdx int) int {
 			continue
 		}
 		if errs > 0 {
-			c.log.Debug("nid corrected", "errs", errs, "nac", nid.NAC)
+			c.log.Debug("nid corrected", "errs", errs, "nac", nid.NAC, "rot", rot)
 		}
 		if nid.DUID != DUIDTrunkingSignaling {
 			// Some non-control DUID — record but don't lock.
@@ -155,7 +161,7 @@ func (c *ControlChannel) Process(dibits []uint8, baseIdx int) int {
 				Kind:    events.KindCCLocked,
 				Payload: LockState{FrequencyHz: c.freqHz, NAC: nid.NAC, DUID: nid.DUID},
 			})
-			c.log.Info("control channel locked", "nac", nid.NAC, "freq", c.freqHz)
+			c.log.Info("control channel locked", "nac", nid.NAC, "freq", c.freqHz, "rot", rot)
 		}
 
 		// Try to extract the next TSBK that follows the NID. The
@@ -165,7 +171,8 @@ func (c *ControlChannel) Process(dibits []uint8, baseIdx int) int {
 		if tsbkStart+98 > len(dibits) {
 			continue
 		}
-		tsbk, metric, err := DecodeTSBKChannel(dibits[tsbkStart : tsbkStart+98])
+		tsbkDibits := rotateDibits(dibits[tsbkStart:tsbkStart+98], rot)
+		tsbk, metric, err := DecodeTSBKChannel(tsbkDibits)
 		if err != nil {
 			c.log.Debug("tsbk decode failed", "err", err, "metric", metric, "nac", nid.NAC)
 			stage := events.StageTSBKTrellis
@@ -181,6 +188,21 @@ func (c *ControlChannel) Process(dibits []uint8, baseIdx int) int {
 		c.dispatchTSBK(tsbk, nid.NAC, metric)
 	}
 	return next
+}
+
+// rotateDibits returns a copy of src with the inverse FSW-search
+// rotation applied: each dibit value has `rot` subtracted mod 4.
+// rot=0 short-circuits to avoid the copy.
+func rotateDibits(src []uint8, rot uint8) []uint8 {
+	if rot == 0 {
+		return src
+	}
+	inv := (4 - rot) & 3
+	out := make([]uint8, len(src))
+	for i, d := range src {
+		out[i] = (d + inv) & 3
+	}
+	return out
 }
 
 // dispatchTSBK routes a successfully-CRC'd TSBK to the right opcode

--- a/internal/radio/p25/phase1/receiver/cqpsk.go
+++ b/internal/radio/p25/phase1/receiver/cqpsk.go
@@ -1,0 +1,90 @@
+package receiver
+
+import (
+	"math"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/demod"
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/sync"
+)
+
+// lsmRotation is the per-symbol constellation offset for P25 LSM. The
+// TIA-102.BAAA LSM constellation places dibit 0b00 at +π/4, dibit 0b01
+// at +3π/4, dibit 0b10 at -π/4 and dibit 0b11 at -3π/4 — same π/4-DQPSK
+// family OP25's CQPSK receiver decodes. Subtracting π/4 inside the
+// differential decoder centres these on {0, π/2, ±π, -π/2} so the
+// standard DQPSK quadrant classifier produces stable bit pairs.
+const lsmRotation = math.Pi / 4
+
+// lsmDibitRemap converts DQPSK quadrant output to the canonical
+// TIA-102.BAAA dibit convention SymbolToDibit produces from C4FM. The
+// DQPSK quadrants land at:
+//
+//	+0    → 0b00 = 0   (matches spec)
+//	+π/2  → 0b01 = 1   (matches spec)
+//	±π    → 0b10 = 2   (spec dibit for ±π is 3)
+//	-π/2  → 0b11 = 3   (spec dibit for -π/2 is 2)
+//
+// The remap swaps the last two entries so the on-air FSW dibit values
+// (1 and 3) line up with the canonical FrameSyncWord pattern after
+// demodulation — no rotation search needed for the CQPSK path itself.
+var lsmDibitRemap = [4]uint8{0, 1, 3, 2}
+
+// cqpskDemod is the LSM / linear-CQPSK symbol recovery chain for P25
+// Phase 1. It wraps the shared PiOver4DQPSK primitive at rotation π/4
+// and applies lsmDibitRemap so the dibits it emits are interchangeable
+// with the C4FM path downstream.
+//
+// Gardner timing-recovery is mandatory on this path (the demod operates
+// on complex IQ at the sample rate; naive every-sps-th decimation
+// off complex IQ produces meaningless symbols at any non-trivial
+// timing offset). The receiver enforces this in New.
+type cqpskDemod struct {
+	dq      *demod.PiOver4DQPSK
+	gardner *sync.Gardner
+
+	// Scratch buffers reused across calls.
+	matched []complex64
+	symbols []complex64
+	dibits  []uint8
+}
+
+// newCQPSKDemod builds a CQPSK / LSM demod for the supplied sample
+// rate and RRC parameters. sps must already be the integer samples-
+// per-symbol; span / alpha are the standard P25 RRC parameters
+// (span=8 symbols half-width, α=0.20).
+func newCQPSKDemod(sps int, span int, alpha float64, gardnerGain float64) *cqpskDemod {
+	if gardnerGain <= 0 {
+		gardnerGain = defaultGardnerGain
+	}
+	return &cqpskDemod{
+		dq:      demod.NewPiOver4DQPSK(sps, span, alpha, lsmRotation),
+		gardner: sync.NewGardner(float64(sps), gardnerGain),
+	}
+}
+
+// process pushes one chunk of complex IQ through the chain and returns
+// the (possibly empty) batch of dibits this call produced. Reusable
+// internal buffers carry state across calls so chunk boundaries do
+// not corrupt the stream.
+func (c *cqpskDemod) process(iq []complex64) []uint8 {
+	c.matched = c.dq.MatchedFilter(c.matched, iq)
+	c.symbols = c.symbols[:0]
+	c.symbols = c.gardner.Process(c.symbols, c.matched)
+	if len(c.symbols) == 0 {
+		c.dibits = c.dibits[:0]
+		return c.dibits
+	}
+	c.dibits = c.dq.Decode(c.dibits, c.symbols)
+	for i, d := range c.dibits {
+		c.dibits[i] = lsmDibitRemap[d&3]
+	}
+	return c.dibits
+}
+
+// reset clears the matched-filter history, the Gardner loop state and
+// the differential reference sample so the next process call starts
+// from a fresh stream.
+func (c *cqpskDemod) reset() {
+	c.dq.Reset()
+	c.gardner.Reset()
+}

--- a/internal/radio/p25/phase1/receiver/cqpsk_test.go
+++ b/internal/radio/p25/phase1/receiver/cqpsk_test.go
@@ -1,0 +1,157 @@
+package receiver
+
+import (
+	"math"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/demod"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase1"
+)
+
+// dibitsToLSMIQ synthesises an LSM (Linear Simulcast Modulation) IQ
+// stream from a canonical-TIA dibit sequence. The dibits are first
+// remapped through the inverse of lsmDibitRemap so the PiOver4DQPSK
+// modulator (rotation=π/4) emits the spec-correct LSM phase deltas:
+//
+//	canonical dibit 0 → modulator dibit 0 → phase delta +π/4   (spec)
+//	canonical dibit 1 → modulator dibit 1 → phase delta +3π/4  (spec)
+//	canonical dibit 2 → modulator dibit 3 → phase delta -π/4   (spec)
+//	canonical dibit 3 → modulator dibit 2 → phase delta -3π/4  (spec)
+//
+// The pre-remap is the inverse of the demod's post-remap so the
+// round-trip "dibit → IQ → dibit" identity holds end-to-end.
+func dibitsToLSMIQ(t *testing.T, dibits []uint8, sps, span int, alpha float64) []complex64 {
+	t.Helper()
+	var inv [4]uint8
+	for i, m := range lsmDibitRemap {
+		inv[m] = uint8(i)
+	}
+	pre := make([]uint8, len(dibits))
+	for i, d := range dibits {
+		pre[i] = inv[d&3]
+	}
+	return demod.ModulatePiOver4DQPSK(pre, sps, span, alpha, math.Pi/4)
+}
+
+// TestCQPSKDemodRoundTripStableTail feeds a long all-zero dibit stream
+// (which under LSM produces a constant-phase carrier) through the
+// modulator → DemodCQPSK demodulator chain and asserts the recovered
+// dibit tail is all zeros after the Gardner loop settles. This is the
+// minimum bar for "the CQPSK path produces canonical TIA-102.BAAA
+// dibits compatible with the FSW + NID + TSBK decoders downstream."
+//
+// A round-trip identity test on a random dibit stream would be more
+// general but is over-strict for this demod chain: the Gardner loop
+// on complex IQ converges within ~5 symbols on a clean signal but
+// the matched-filter group delay (~8 symbols) and differential
+// reference sample combine to make exact dibit-by-dibit alignment
+// fragile to construct as a test fixture. The structural guarantee
+// (FSW survives) is covered by TestCQPSKDemodRecoversFSW below.
+func TestCQPSKDemodRoundTripStableTail(t *testing.T) {
+	const sampleRate = 48_000.0
+	const sps = 10
+	const symbols = 400
+
+	in := make([]uint8, symbols)
+	iq := dibitsToLSMIQ(t, in, sps, PulseSpanSymbols, RolloffAlpha)
+
+	var captured []uint8
+	r := New(Options{
+		SampleRateHz: sampleRate,
+		DemodMode:    DemodCQPSK,
+		DibitSink: func(d []uint8, _ int) {
+			captured = append(captured, d...)
+		},
+	})
+	chunk := 4096
+	for i := 0; i < len(iq); i += chunk {
+		end := i + chunk
+		if end > len(iq) {
+			end = len(iq)
+		}
+		r.Process(iq[i:end])
+	}
+
+	if len(captured) < 100 {
+		t.Fatalf("captured %d dibits, want at least 100", len(captured))
+	}
+	// Skip the leading 20 dibits — Gardner startup + matched filter
+	// fill — then assert the stable tail is all-zero.
+	tail := captured[20:]
+	nonZero := 0
+	for _, d := range tail {
+		if d != 0 {
+			nonZero++
+		}
+	}
+	if nonZero > 0 {
+		t.Errorf("post-settle tail has %d/%d non-zero dibits; expected pure zeros under all-zero LSM input",
+			nonZero, len(tail))
+	}
+}
+
+// TestCQPSKDemodRecoversFSW: synthesise an LSM stream that embeds
+// the canonical P25 FSW at a known position and confirm the receiver
+// produces a dibit stream containing the FSW pattern. This is the
+// proof point that the simulcast path will lock — the same FSW the
+// SyncDetector consumes downstream of the receiver.
+func TestCQPSKDemodRecoversFSW(t *testing.T) {
+	const sampleRate = 48_000.0
+	const sps = 10
+
+	// 64 dibits of filler + 24-dibit FSW + 64 dibits trailer.
+	in := make([]uint8, 0, 64+24+64)
+	for i := 0; i < 64; i++ {
+		in = append(in, uint8(i&3))
+	}
+	in = append(in, phase1.FrameSyncWord[:]...)
+	for i := 0; i < 64; i++ {
+		in = append(in, uint8((i+2)&3))
+	}
+
+	iq := dibitsToLSMIQ(t, in, sps, PulseSpanSymbols, RolloffAlpha)
+
+	var captured []uint8
+	r := New(Options{
+		SampleRateHz: sampleRate,
+		DemodMode:    DemodCQPSK,
+		DibitSink: func(d []uint8, _ int) {
+			captured = append(captured, d...)
+		},
+	})
+	r.Process(iq)
+
+	det := phase1.NewSyncDetector(2)
+	hits, _ := det.Process(nil, captured, 0)
+	if len(hits) == 0 {
+		t.Fatalf("FSW never detected in CQPSK output (captured %d dibits)", len(captured))
+	}
+}
+
+// TestParseDemodMode locks down the YAML-string → DemodMode mapping
+// shipped via the ccdecoder connector.
+func TestParseDemodMode(t *testing.T) {
+	cases := []struct {
+		in     string
+		wantM  DemodMode
+		wantOk bool
+	}{
+		{"", DemodC4FM, true},
+		{"c4fm", DemodC4FM, true},
+		{"C4FM", DemodC4FM, true},
+		{"fm", DemodC4FM, true},
+		{"cqpsk", DemodCQPSK, true},
+		{"CQPSK", DemodCQPSK, true},
+		{"lsm", DemodCQPSK, true},
+		{"linear", DemodCQPSK, true},
+		{"bogus", DemodC4FM, false},
+	}
+	for _, tc := range cases {
+		got, ok := ParseDemodMode(tc.in)
+		if got != tc.wantM || ok != tc.wantOk {
+			t.Errorf("ParseDemodMode(%q) = (%v, %v), want (%v, %v)",
+				tc.in, got, ok, tc.wantM, tc.wantOk)
+		}
+	}
+}
+

--- a/internal/radio/p25/phase1/receiver/cqpsk_test.go
+++ b/internal/radio/p25/phase1/receiver/cqpsk_test.go
@@ -154,4 +154,3 @@ func TestParseDemodMode(t *testing.T) {
 		}
 	}
 }
-

--- a/internal/radio/p25/phase1/receiver/modes.go
+++ b/internal/radio/p25/phase1/receiver/modes.go
@@ -1,0 +1,57 @@
+package receiver
+
+import "strings"
+
+// DemodMode selects how the receiver recovers symbols from the
+// complex IQ stream.
+//
+//   - DemodC4FM (default) is the pre-existing path: FM
+//     discriminator → real-valued RRC matched filter → 4-level
+//     slicer. Works on conventional non-simulcast P25 Phase 1
+//     transmitters that use straight C4FM on the wire.
+//
+//   - DemodCQPSK is the linear-modulation path: complex RRC matched
+//     filter → symbol-time decimation → differential QPSK decode.
+//     This is the path operators on simulcast P25 sites need:
+//     simulcast deployments commonly transmit Linear Simulcast
+//     Modulation (LSM, TIA-102.BAAA), a CQPSK-shaped variant
+//     designed to survive multi-transmitter overlap. LSM pushed
+//     through a quadrature FM discriminator produces near-random
+//     dibits and the FSW never matches — the failure mode reported
+//     against issue #275 on the MMR system.
+//
+// The dibit value emitted by DemodCQPSK after the LSM remap matches
+// the canonical TIA-102.BAAA convention SymbolToDibit produces from
+// C4FM, so downstream code (FSW detect, NID parse, TSBK trellis) is
+// demod-agnostic.
+type DemodMode uint8
+
+const (
+	DemodC4FM DemodMode = iota
+	DemodCQPSK
+)
+
+// ParseDemodMode maps a config / user-facing string into a DemodMode.
+// Recognised values (case-insensitive): "" / "c4fm" / "fm" → DemodC4FM
+// (the default — matches every previously-shipping config and the
+// receiver's pre-CQPSK behaviour); "cqpsk" / "lsm" / "linear" →
+// DemodCQPSK (the simulcast / LSM path). Unknown strings return
+// DemodC4FM with ok=false so the caller can warn-log and fall back.
+func ParseDemodMode(s string) (DemodMode, bool) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "", "c4fm", "fm":
+		return DemodC4FM, true
+	case "cqpsk", "lsm", "linear":
+		return DemodCQPSK, true
+	default:
+		return DemodC4FM, false
+	}
+}
+
+// Clock-mode selection is intentionally not exposed on this
+// receiver. The C4FM path uses Mueller-Müller (proven on Phase 1
+// for years; well-suited to the real-valued FM-discriminator
+// output) and the CQPSK path uses Gardner (mandatory — the LSM
+// demod operates on complex IQ at the sample rate where naive
+// every-sps-th decimation produces meaningless symbols at any
+// non-trivial timing offset).

--- a/internal/radio/p25/phase1/receiver/receiver.go
+++ b/internal/radio/p25/phase1/receiver/receiver.go
@@ -1,16 +1,29 @@
-// Package receiver wires the IQ → C4FM dibit chain that feeds either
-// the P25 Phase 1 LDU assembler (voice path) or the control-channel
-// state machine (CC path) — or both at once. It composes primitives
-// that already live in internal/dsp + internal/radio/p25/phase1:
+// Package receiver wires the IQ → dibit chain that feeds either the
+// P25 Phase 1 LDU assembler (voice path) or the control-channel state
+// machine (CC path) — or both at once. It composes primitives that
+// already live in internal/dsp + internal/radio/p25/phase1.
 //
-//	IQ samples
-//	  → FM discriminator (internal/dsp/demod.FM)
-//	  → RRC matched filter + 4-level slicer (internal/dsp/demod.C4FM)
-//	  → Mueller-Müller symbol clock recovery (internal/dsp/sync.MuellerMuller)
-//	  → C4FM symbol → 0..3 dibit (phase1.SymbolToDibit)
-//	  → dibit fan-out:
-//	      • Options.DibitSink (raw dibits → phase1.ControlChannel.Process)
-//	      • Options.Sink      (LDU assembler → phase1.LDUSink)
+// Two demod paths are selectable via Options.DemodMode (see modes.go):
+//
+//	DemodC4FM (default):
+//	  IQ
+//	    → FM discriminator (internal/dsp/demod.FM)
+//	    → RRC matched filter + 4-level slicer (internal/dsp/demod.C4FM)
+//	    → Mueller-Müller symbol clock recovery (sync.MuellerMuller)
+//	    → C4FM symbol → 0..3 dibit (phase1.SymbolToDibit)
+//
+//	DemodCQPSK (LSM / simulcast):
+//	  IQ
+//	    → complex RRC matched filter (demod.PiOver4DQPSK, rotation=π/4)
+//	    → Gardner timing recovery on complex IQ (sync.Gardner)
+//	    → differential QPSK quadrant decode
+//	    → LSM dibit remap → canonical 0..3 dibit
+//
+// In both cases the dibit stream the receiver emits matches the
+// TIA-102.BAAA convention, so downstream code (FSW detect, NID parse,
+// TSBK trellis) is demod-agnostic. CQPSK demod is the path operators
+// on simulcast P25 sites need — issue #275 surfaced because the
+// FM-discriminator path produces near-random dibits on an LSM signal.
 //
 // Either sink may be nil; at least one must be set. The receiver is
 // stateful and not safe for concurrent Process calls. Instantiate one
@@ -26,6 +39,12 @@ import (
 	"github.com/MattCheramie/GopherTrunk/internal/dsp/sync"
 	"github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase1"
 )
+
+// defaultGardnerGain is the Gardner step the CQPSK path uses when the
+// caller leaves Options.GardnerGain at zero. Matches the value Phase 2
+// and TETRA settled on after live-capture tuning (internal/scanner/
+// ccdecoder/pipelines.go).
+const defaultGardnerGain = 0.03
 
 // P25 Phase 1 on-air parameters.
 const (
@@ -90,19 +109,41 @@ type Options struct {
 	// normalised-to-±1" assumption, which only fires for
 	// synthesized fixtures that pre-scale their signal levels.
 	DeviationHz float64
+	// DemodMode selects the symbol recovery path. Zero value is
+	// DemodC4FM (the legacy FM-discriminator → Mueller-Müller
+	// path). DemodCQPSK routes IQ through the LSM / linear-CQPSK
+	// chain (complex RRC → Gardner → π/4-DQPSK + LSM dibit remap)
+	// — required for simulcast P25 sites whose control channel is
+	// on the wire as LSM rather than C4FM. See modes.go.
+	DemodMode DemodMode
+	// GardnerGain overrides the Gardner loop step used by the
+	// CQPSK path. <=0 uses defaultGardnerGain. Ignored when
+	// DemodMode == DemodC4FM (the C4FM path uses Mueller-Müller).
+	GardnerGain float64
 }
 
 // Receiver is the composed IQ → dibit → LDU pipeline. Process is the
 // only hot path; instantiate once per call chain and reuse.
 type Receiver struct {
-	fm        *demod.FM
-	mf        *demod.C4FM
-	clock     *sync.MuellerMuller
+	demodMode DemodMode
+
+	// C4FM path: FM discriminator → real RRC + 4-level slicer →
+	// Mueller-Müller. Allocated only when demodMode == DemodC4FM.
+	fm    *demod.FM
+	mf    *demod.C4FM
+	clock *sync.MuellerMuller
+
+	// CQPSK / LSM path: complex RRC + Gardner + DQPSK quadrant
+	// decode + LSM dibit remap. Allocated only when demodMode ==
+	// DemodCQPSK.
+	cq *cqpskDemod
+
 	assembler *phase1.LDUAssembler
 	dibitSink phase1.DibitSink
 	dibitBase int
 
-	// Reusable scratch slices so Process doesn't allocate per call.
+	// Reusable scratch slices so Process doesn't allocate per call
+	// on the C4FM path.
 	disc    []float32
 	matched []float32
 	symbols []float32
@@ -156,10 +197,16 @@ func New(opts Options) *Receiver {
 	}
 
 	r := &Receiver{
-		fm:        demod.NewFM(),
-		mf:        demod.NewC4FM(int(sps+0.5), span, alpha, slicerScale),
-		clock:     sync.NewMuellerMuller(sps, gain),
+		demodMode: opts.DemodMode,
 		dibitSink: opts.DibitSink,
+	}
+	switch opts.DemodMode {
+	case DemodCQPSK:
+		r.cq = newCQPSKDemod(int(sps+0.5), span, alpha, opts.GardnerGain)
+	default:
+		r.fm = demod.NewFM()
+		r.mf = demod.NewC4FM(int(sps+0.5), span, alpha, slicerScale)
+		r.clock = sync.NewMuellerMuller(sps, gain)
 	}
 	if opts.Sink != nil {
 		r.assembler = phase1.NewLDUAssembler(opts.Sink, opts.Tolerance)
@@ -176,20 +223,30 @@ func (r *Receiver) Process(iq []complex64) {
 	if len(iq) == 0 {
 		return
 	}
-	r.disc = r.fm.Process(r.disc, iq)
-	r.matched = r.mf.MatchedFilter(r.matched, r.disc)
-	r.symbols = r.clock.Process(r.symbols, r.matched)
-	if len(r.symbols) == 0 {
-		return
-	}
-	r.sliced = r.mf.SliceMany(r.sliced, r.symbols)
-	if cap(r.dibits) < len(r.sliced) {
-		r.dibits = make([]uint8, len(r.sliced))
+	if r.demodMode == DemodCQPSK {
+		// cq.process returns its internal dibit buffer; we hand
+		// it directly to the sinks below — both consume
+		// synchronously before the next Process call.
+		r.dibits = r.cq.process(iq)
 	} else {
-		r.dibits = r.dibits[:len(r.sliced)]
+		r.disc = r.fm.Process(r.disc, iq)
+		r.matched = r.mf.MatchedFilter(r.matched, r.disc)
+		r.symbols = r.clock.Process(r.symbols, r.matched)
+		if len(r.symbols) == 0 {
+			return
+		}
+		r.sliced = r.mf.SliceMany(r.sliced, r.symbols)
+		if cap(r.dibits) < len(r.sliced) {
+			r.dibits = make([]uint8, len(r.sliced))
+		} else {
+			r.dibits = r.dibits[:len(r.sliced)]
+		}
+		for i, sym := range r.sliced {
+			r.dibits[i] = phase1.SymbolToDibit(sym)
+		}
 	}
-	for i, sym := range r.sliced {
-		r.dibits[i] = phase1.SymbolToDibit(sym)
+	if len(r.dibits) == 0 {
+		return
 	}
 	if r.dibitSink != nil {
 		r.dibitSink(r.dibits, r.dibitBase)
@@ -210,6 +267,9 @@ func (r *Receiver) Reset() {
 		r.assembler.Reset()
 	}
 	r.dibitBase = 0
+	if r.cq != nil {
+		r.cq.reset()
+	}
 	// FM discriminator's `last` is harmless to leave alone — the
 	// next sample it processes will produce one slightly-wrong
 	// derivative, which the matched filter smooths out.

--- a/internal/radio/p25/phase1/sync.go
+++ b/internal/radio/p25/phase1/sync.go
@@ -43,6 +43,19 @@ func FrameSyncBits() []byte { return framing.DibitsToBits(FrameSyncWord[:]) }
 // SyncDetector slides a window over an incoming dibit stream and emits the
 // (zero-based) dibit index where the FSW best matches above tolerance.
 // Tolerance is the maximum allowed dibit-symbol mismatch; default 4.
+//
+// The detector tries all four cyclic rotations of the dibit alphabet
+// (k ∈ {0, 1, 2, 3}, applied as (dibit + k) mod 4 before comparing
+// against the canonical FrameSyncWord) and records the rotation that
+// matched. The rotation absorbs residual symbol-polarity / I-Q-swap
+// ambiguities the front-end may have introduced — without it the C4FM
+// path slipped to dibit 3↔0 / 1↔2 on conjugated IQ inputs, and the
+// CQPSK path on rare DQPSK quadrant slips. Rotation=0 wins on ties so
+// existing clean-fixture tests bind the same hit they always have.
+//
+// Callers needing the rotation per hit use ProcessWithRotation; the
+// simpler Process API stays at the same signature for the rest of the
+// pipeline.
 type SyncDetector struct {
 	tolerance int
 	hist      [24]uint8
@@ -59,7 +72,22 @@ func NewSyncDetector(tolerance int) *SyncDetector {
 
 // Process appends to dst the indices (relative to baseIndex) where the FSW
 // is detected. baseIndex is the absolute dibit index of src[0].
+//
+// Equivalent to ProcessWithRotation with the rotation values discarded.
 func (s *SyncDetector) Process(dst []int, src []uint8, baseIndex int) ([]int, int) {
+	dst, _, next := s.ProcessWithRotation(dst, nil, src, baseIndex)
+	return dst, next
+}
+
+// ProcessWithRotation behaves like Process but also returns the
+// rotation k ∈ {0, 1, 2, 3} that produced each emitted hit. The
+// returned dst and rots slices stay in lockstep — rots[i] is the
+// rotation that recovered the hit at dst[i]. Callers that only need
+// the indices can use Process and discard rots.
+//
+// Pass nil for rots to let the detector allocate; the returned rots
+// slice is non-nil whenever dst is non-empty after this call.
+func (s *SyncDetector) ProcessWithRotation(dst []int, rots []uint8, src []uint8, baseIndex int) ([]int, []uint8, int) {
 	for i, d := range src {
 		s.hist[s.pos] = d
 		s.pos = (s.pos + 1) % 24
@@ -67,21 +95,32 @@ func (s *SyncDetector) Process(dst []int, src []uint8, baseIndex int) ([]int, in
 			s.primed++
 			continue
 		}
-		mismatch := 0
-		idx := s.pos
-		for k := 0; k < 24; k++ {
-			if s.hist[idx] != FrameSyncWord[k] {
-				mismatch++
-				if mismatch > s.tolerance {
+		bestMis := s.tolerance + 1
+		var bestRot uint8
+		for k := uint8(0); k < 4; k++ {
+			mismatch := 0
+			idx := s.pos
+			for kk := 0; kk < 24; kk++ {
+				if ((s.hist[idx] + k) & 3) != FrameSyncWord[kk] {
+					mismatch++
+					if mismatch >= bestMis {
+						break
+					}
+				}
+				idx = (idx + 1) % 24
+			}
+			if mismatch < bestMis {
+				bestMis = mismatch
+				bestRot = k
+				if bestMis == 0 {
 					break
 				}
 			}
-			idx = (idx + 1) % 24
 		}
-		if mismatch <= s.tolerance {
-			// Match position: end of the FSW lands at this index.
+		if bestMis <= s.tolerance {
 			dst = append(dst, baseIndex+i)
+			rots = append(rots, bestRot)
 		}
 	}
-	return dst, baseIndex + len(src)
+	return dst, rots, baseIndex + len(src)
 }

--- a/internal/radio/p25/phase1/sync_test.go
+++ b/internal/radio/p25/phase1/sync_test.go
@@ -46,3 +46,50 @@ func TestSyncDetectorRejectsTooManyErrors(t *testing.T) {
 		t.Errorf("hits = %v, want []", hits)
 	}
 }
+
+// TestSyncDetectorMatchesAllRotations: the FSW search must accept the
+// canonical pattern shifted by k ∈ {0, 1, 2, 3} mod 4 (the residual
+// symbol-polarity / I-Q-swap ambiguity that can survive front-end
+// processing) and return the rotation that matched so downstream
+// parsing can invert it.
+func TestSyncDetectorMatchesAllRotations(t *testing.T) {
+	for k := uint8(0); k < 4; k++ {
+		det := NewSyncDetector(0)
+		stream := make([]uint8, 100)
+		for i := range stream {
+			stream[i] = 0
+		}
+		// Embed the FSW with k subtracted from each dibit so the
+		// detector has to add k back via its rotation search.
+		for i, d := range FrameSyncWord {
+			stream[40+i] = (d + 4 - k) & 3
+		}
+		hits, rots, _ := det.ProcessWithRotation(nil, nil, stream, 0)
+		if len(hits) != 1 {
+			t.Errorf("k=%d hits = %v, want exactly 1", k, hits)
+			continue
+		}
+		if rots[0] != k {
+			t.Errorf("k=%d rots[0] = %d, want %d", k, rots[0], k)
+		}
+		if hits[0] != 40+24-1 {
+			t.Errorf("k=%d hits[0] = %d, want %d", k, hits[0], 40+24-1)
+		}
+	}
+}
+
+// TestSyncDetectorPrefersRotationZero: when two rotations tie on
+// mismatch count, k=0 must win so existing clean-fixture tests
+// keep producing the same hit they always have.
+func TestSyncDetectorPrefersRotationZero(t *testing.T) {
+	det := NewSyncDetector(0)
+	stream := make([]uint8, 80)
+	copy(stream[30:], FrameSyncWord[:])
+	_, rots, _ := det.ProcessWithRotation(nil, nil, stream, 0)
+	if len(rots) != 1 {
+		t.Fatalf("rots = %v, want length 1", rots)
+	}
+	if rots[0] != 0 {
+		t.Errorf("rots[0] = %d, want 0 (clean FSW must bind rotation=0)", rots[0])
+	}
+}

--- a/internal/scanner/ccdecoder/pipelines.go
+++ b/internal/scanner/ccdecoder/pipelines.go
@@ -143,6 +143,15 @@ func newP25Phase1Pipeline(opts PipelineOptions) (ProtocolPipeline, error) {
 		SystemName:  opts.SystemName,
 		FrequencyHz: opts.FrequencyHz,
 	})
+	log := opts.Log
+	if log == nil {
+		log = slog.Default()
+	}
+	demodMode, ok := p25phase1rx.ParseDemodMode(opts.System.P25Phase1DemodMode)
+	if !ok {
+		log.Warn("ccdecoder: unrecognised p25_phase1_demod_mode; falling back to c4fm",
+			"system", opts.SystemName, "value", opts.System.P25Phase1DemodMode)
+	}
 	rx := p25phase1rx.New(p25phase1rx.Options{
 		SampleRateHz: opts.SampleRateHz,
 		// P25 Phase 1 nominal peak deviation per TIA-102.BAAA-A
@@ -151,13 +160,28 @@ func newP25Phase1Pipeline(opts PipelineOptions) (ProtocolPipeline, error) {
 		// p25phase1rx.Options.DeviationHz). Hardcoded since the
 		// air-interface deviation is spec-fixed; if a future
 		// site uses non-standard deviation the connector can
-		// expose this as a per-system YAML key.
+		// expose this as a per-system YAML key. Only consulted on
+		// the C4FM path; the CQPSK path is amplitude-invariant
+		// after the matched filter so DeviationHz isn't used.
 		DeviationHz: 1800.0,
+		DemodMode:   demodMode,
 		DibitSink: func(dibits []uint8, baseIdx int) {
 			cc.Process(dibits, baseIdx)
 		},
 	})
+	log.Info("ccdecoder: p25/phase1 pipeline configured",
+		"system", opts.SystemName, "freq_hz", opts.FrequencyHz,
+		"demod", demodModeLabel(demodMode))
 	return &p25Phase1Pipeline{rx: rx, cc: cc}, nil
+}
+
+func demodModeLabel(m p25phase1rx.DemodMode) string {
+	switch m {
+	case p25phase1rx.DemodCQPSK:
+		return "cqpsk"
+	default:
+		return "c4fm"
+	}
 }
 
 type p25Phase1Pipeline struct {

--- a/internal/trunking/site.go
+++ b/internal/trunking/site.go
@@ -159,6 +159,20 @@ type System struct {
 	// connector after parsing via ltr.ParseManchesterMode.
 	LTRManchesterMode string
 
+	// P25Phase1DemodMode selects the symbol-recovery path for the
+	// P25 Phase 1 receiver. Recognised values (case-insensitive):
+	// "" / "c4fm" / "fm" → DemodC4FM (the default — FM
+	// discriminator + 4-level slicer; matches every previously
+	// shipping config and works on conventional non-simulcast P25
+	// transmitters); "cqpsk" / "lsm" / "linear" → DemodCQPSK (the
+	// linear / LSM path — complex RRC + Gardner + differential
+	// QPSK; required for simulcast P25 deployments whose control
+	// channel transmits Linear Simulcast Modulation rather than
+	// straight C4FM, see issue #275 and TIA-102.BAAA). Forwarded
+	// into p25phase1rx.Options.DemodMode by the ccdecoder connector
+	// after parsing via p25phase1rx.ParseDemodMode.
+	P25Phase1DemodMode string
+
 	// P25Phase2TrellisMode enables the 4-state ½-rate trellis FEC
 	// decoder on the P25 Phase 2 MAC PDU window. Recognised values
 	// (case-insensitive): "" / "on" / "true" / "1" → TrellisOn (the

--- a/internal/tui/client/types.go
+++ b/internal/tui/client/types.go
@@ -41,6 +41,7 @@ type SystemDTO struct {
 	TETRAChannelCoding     string  `json:"tetra_channel_coding,omitempty"`
 	LTRFCSMode             string  `json:"ltr_fcs_mode,omitempty"`
 	LTRManchesterMode      string  `json:"ltr_manchester_mode,omitempty"`
+	P25Phase1DemodMode     string  `json:"p25_phase1_demod_mode,omitempty"`
 	P25Phase2TrellisMode   string  `json:"p25_phase2_trellis_mode,omitempty"`
 	P25Phase2RSMode        string  `json:"p25_phase2_rs_mode,omitempty"`
 	P25Phase2ScramblerMode string  `json:"p25_phase2_scrambler_mode,omitempty"`

--- a/internal/tui/panels/settings.go
+++ b/internal/tui/panels/settings.go
@@ -194,11 +194,12 @@ fecRefresh:
 	// to) the FEC tab — the hash gate keeps the cost negligible.
 	if p.tab == tabFEC {
 		h := hashRows(s.Systems, func(sys client.SystemDTO) string {
-			return fmt.Sprintf("%s|%s|%d|%s|%s|%s|%s|%s|%s|%s|%s|%.1f|%s",
+			return fmt.Sprintf("%s|%s|%d|%s|%s|%s|%s|%s|%s|%s|%s|%s|%.1f|%s",
 				sys.Name, sys.Protocol,
 				sys.TETRAColourCode, sys.TETRAChannel,
 				sys.TETRAChannelCoding,
 				sys.LTRFCSMode, sys.LTRManchesterMode,
+				sys.P25Phase1DemodMode,
 				sys.P25Phase2TrellisMode, sys.P25Phase2RSMode,
 				sys.P25Phase2ScramblerMode,
 				sys.NXDNViterbiMode,
@@ -466,6 +467,8 @@ func fecSummary(s client.SystemDTO) string {
 	case "ltr":
 		parts = append(parts, "fcs: "+orDefault(s.LTRFCSMode, "on"))
 		parts = append(parts, "manchester: "+orDefault(s.LTRManchesterMode, "soft"))
+	case "p25":
+		parts = append(parts, "demod: "+orDefault(s.P25Phase1DemodMode, "c4fm"))
 	case "p25-phase2":
 		parts = append(parts, "trellis: "+orDefault(s.P25Phase2TrellisMode, "on"))
 		parts = append(parts, "rs: "+orDefault(s.P25Phase2RSMode, "off"))


### PR DESCRIPTION
The reporter on issue #275 (MMR site) confirmed via p25-survey/OP25
that their RF chain decodes the control channel at 100% on identical
hardware while gophertrunk loops on "no FSW hits in chunk" forever.
Root cause: gophertrunk's P25 Phase 1 receiver only demodulates C4FM
via FM discriminator + 4-level slicer. P25 simulcast deployments
commonly transmit the control channel as Linear Simulcast Modulation
(LSM, TIA-102.BAAA) — a CQPSK-shaped variant. LSM through an FM
discriminator produces near-random dibits and the FSW never matches.

This change adds:

1. A CQPSK / LSM demod path on the Phase 1 receiver: complex RRC
   matched filter + Gardner timing recovery + π/4-DQPSK quadrant
   decode + LSM dibit remap. The remap (lsmDibitRemap) restores the
   canonical TIA-102.BAAA dibit ordering DQPSK loses on the 2 ↔ 3
   quadrant swap, so the FSW + NID + TSBK decoders downstream stay
   demod-agnostic. Selected via per-system YAML:
   `p25_phase1_demod_mode: cqpsk`. Defaults to c4fm.

2. Multi-rotation FSW search on the Phase 1 sync detector. Tries
   all four cyclic dibit-alphabet shifts against FrameSyncWord and
   returns the rotation that matched. The control-channel parser
   inverts the rotation before BCH + trellis decode. Rotation=0
   wins on ties so existing clean-fixture tests bind the same hit.

3. Plumbing: trunking.System / config / api / TUI DTOs carry the
   new P25Phase1DemodMode field. The ccdecoder pipeline factory
   warn-logs unrecognised values and surfaces the chosen path via
   `ccdecoder: p25/phase1 pipeline configured demod=…` on startup
   so operators can confirm via logs.

Tests: CQPSK FSW recovery + all-zero round-trip on the receiver,
rotated-FSW + rotation=0 tie-break on the sync detector.

Docs: config.example.yaml + opt-in-features.md add the new key with
the simulcast guidance.

https://claude.ai/code/session_01P6Mjgbps3HD8Hean4yHKgJ