### PR TITLE
p25/phase1: assemble control frames across IQ-chunk boundaries (fix #275)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,15 @@ for tagged releases.
   per-protocol receivers are matched-filter-tuned for — ~48 kHz for
   the 4800-baud C4FM family, 144 kHz for TETRA — before the pipeline
   sees it. The IQ-power gauge still reports the raw SDR input level.
+- **P25 Phase 1 control channel never locked on live SDR chunking**
+  (issue #275). The control-channel state machine discarded every
+  Frame Sync Word hit unless the whole 154-dibit frame (FSW + NID +
+  TSBK) fell inside a single `Process` call. A live RTL-SDR delivers
+  16 KiB USB transfers — only ~19 P25 symbols per call — so the NID
+  never fit and the channel never locked, even with the IQ stream
+  correctly channelized. `ControlChannel.Process` now accumulates
+  dibits across calls and assembles frames that straddle IQ-chunk
+  boundaries.
 
 ## [v0.1.7] — 2026-05-19
 

--- a/internal/radio/p25/phase1/control.go
+++ b/internal/radio/p25/phase1/control.go
@@ -42,6 +42,25 @@ type ControlChannel struct {
 	// lastNoHitsAt throttles the "no FSW hits" debug log so the chunk-rate
 	// emission doesn't flood at debug level. See Process for the rationale.
 	lastNoHitsAt time.Time
+
+	// buf accumulates dibits across Process calls so a frame whose
+	// FSW + NID + TSBK straddles IQ-chunk boundaries is still
+	// assembled; bufBase is the absolute dibit index of buf[0].
+	// pending holds FSW hits whose NID + TSBK has not been fully
+	// buffered yet. See Process — this is the fix for issue #275,
+	// where a live SDR's small IQ chunks delivered far fewer than a
+	// frame's worth of dibits per call.
+	buf     []uint8
+	bufBase int
+	pending []pendingHit
+}
+
+// pendingHit is an FSW match awaiting enough buffered dibits to decode
+// its NID + TSBK. end is the absolute dibit index of the FSW's last
+// dibit; rot is the cyclic rotation the sync detector matched under.
+type pendingHit struct {
+	end int
+	rot uint8
 }
 
 // Options configure a ControlChannel.
@@ -110,8 +129,22 @@ func (s LockState) LockedNAC() uint16         { return s.NAC }
 // visible without flooding.
 const noHitsThrottle = 2 * time.Second
 
-// Process consumes a window of dibits and runs detection/parsing. baseIdx
-// is the absolute dibit index of dibits[0]. Returns the new baseIndex.
+// frameLookahead is the number of dibits that must follow the FSW for
+// a full frame to decode: the 32-dibit NID plus the 98-dibit TSBK
+// channel block. Process defers an FSW hit until this many dibits have
+// accumulated, so frame assembly no longer depends on the IQ chunking.
+const frameLookahead = 32 + 98
+
+// Process consumes a window of dibits and runs detection/parsing.
+// baseIdx is the absolute dibit index of dibits[0]. Returns the
+// absolute index one past the last consumed dibit.
+//
+// Dibits are accumulated into an internal buffer that spans calls, so
+// a frame whose FSW + NID + TSBK straddles several Process calls is
+// still assembled. This matters on live hardware: a 16 KiB RTL-SDR USB
+// transfer carries only ~19 P25 symbols — far short of the 154-dibit
+// frame — so without cross-call buffering every FSW hit was discarded
+// and the control channel never locked (issue #275).
 func (c *ControlChannel) Process(dibits []uint8, baseIdx int) int {
 	hits, rots, next := c.det.ProcessWithRotation(nil, nil, dibits, baseIdx)
 	if len(hits) == 0 && len(dibits) > 0 && !c.locked {
@@ -122,72 +155,108 @@ func (c *ControlChannel) Process(dibits []uint8, baseIdx int) int {
 			c.lastNoHitsAt = now
 		}
 	}
-	for i, h := range hits {
-		rot := rots[i]
-		// FSW ends at index h (relative to the absolute dibit stream). The
-		// 32-dibit NID immediately follows.
-		startInWindow := h - baseIdx + 1
-		if startInWindow+32 > len(dibits) {
-			// Crosses the buffer edge; future calls will have the rest.
-			continue
-		}
-		// Apply the inverse rotation to the dibits that follow the FSW
-		// — the sync detector matched the FSW after adding `rot` mod 4
-		// to each input dibit, so the canonical dibit values the BCH /
-		// trellis decoders expect are recovered by subtracting `rot`
-		// (equivalently, adding (4 - rot) mod 4) before parsing.
-		nidDibits := rotateDibits(dibits[startInWindow:startInWindow+32], rot)
-		nid, errs, err := NIDFromDibits(nidDibits)
-		if err != nil {
-			c.log.Debug("nid parse failed", "err", err, "errs", errs, "rot", rot)
-			c.bus.Publish(events.Event{
-				Kind:    events.KindDecodeError,
-				Payload: events.DecodeError{Protocol: "p25", Stage: events.StageNIDBCH},
-			})
-			continue
-		}
-		if errs > 0 {
-			c.log.Debug("nid corrected", "errs", errs, "nac", nid.NAC, "rot", rot)
-		}
-		if nid.DUID != DUIDTrunkingSignaling {
-			// Some non-control DUID — record but don't lock.
-			c.log.Debug("non-control DUID", "duid", nid.DUID, "nac", nid.NAC)
-			continue
-		}
-		if !c.locked || c.lastNAC != nid.NAC {
-			c.locked = true
-			c.lastNAC = nid.NAC
-			c.bus.Publish(events.Event{
-				Kind:    events.KindCCLocked,
-				Payload: LockState{FrequencyHz: c.freqHz, NAC: nid.NAC, DUID: nid.DUID},
-			})
-			c.log.Info("control channel locked", "nac", nid.NAC, "freq", c.freqHz, "rot", rot)
-		}
 
-		// Try to extract the next TSBK that follows the NID. The
-		// channel TSBK occupies 98 dibits; if the buffer is short we
-		// defer to a later call (the buffer-edge case).
-		tsbkStart := startInWindow + 32
-		if tsbkStart+98 > len(dibits) {
-			continue
-		}
-		tsbkDibits := rotateDibits(dibits[tsbkStart:tsbkStart+98], rot)
-		tsbk, metric, err := DecodeTSBKChannel(tsbkDibits)
-		if err != nil {
-			c.log.Debug("tsbk decode failed", "err", err, "metric", metric, "nac", nid.NAC)
-			stage := events.StageTSBKTrellis
-			if errors.Is(err, CRCError) {
-				stage = events.StageTSBKCRC
-			}
-			c.bus.Publish(events.Event{
-				Kind:    events.KindDecodeError,
-				Payload: events.DecodeError{Protocol: "p25", Stage: stage},
-			})
-			continue
-		}
-		c.dispatchTSBK(tsbk, nid.NAC, metric)
+	// Accumulate the new dibits. The receiver hands them over in
+	// contiguous, in-order batches, so buf stays a faithful copy of
+	// the dibit stream from bufBase onward.
+	if len(c.buf) == 0 {
+		c.bufBase = baseIdx
 	}
+	c.buf = append(c.buf, dibits...)
+	for i, h := range hits {
+		c.pending = append(c.pending, pendingHit{end: h, rot: rots[i]})
+	}
+
+	// Parse every pending FSW hit whose full frame has now been
+	// buffered; keep the rest for a later call once more dibits land.
+	kept := c.pending[:0]
+	for _, ph := range c.pending {
+		// FSW ends at absolute index ph.end; the 32-dibit NID
+		// immediately follows.
+		nidStart := ph.end + 1 - c.bufBase
+		if nidStart < 0 {
+			continue // buffer already trimmed past this hit — drop it
+		}
+		if nidStart+frameLookahead > len(c.buf) {
+			kept = append(kept, ph) // not enough buffered yet
+			continue
+		}
+		c.parseFrame(c.buf, nidStart, ph.rot)
+	}
+	c.pending = kept
+	c.trimBuffer()
 	return next
+}
+
+// parseFrame decodes the NID + TSBK of one FSW hit. buf[nidStart:]
+// must hold at least frameLookahead dibits — the caller guarantees it.
+// rot is the FSW-search rotation: the sync detector matched after
+// adding rot mod 4 to each input dibit, so the canonical dibit values
+// the BCH / trellis decoders expect are recovered by subtracting rot
+// (rotateDibits) before parsing.
+func (c *ControlChannel) parseFrame(buf []uint8, nidStart int, rot uint8) {
+	nidDibits := rotateDibits(buf[nidStart:nidStart+32], rot)
+	nid, errs, err := NIDFromDibits(nidDibits)
+	if err != nil {
+		c.log.Debug("nid parse failed", "err", err, "errs", errs, "rot", rot)
+		c.bus.Publish(events.Event{
+			Kind:    events.KindDecodeError,
+			Payload: events.DecodeError{Protocol: "p25", Stage: events.StageNIDBCH},
+		})
+		return
+	}
+	if errs > 0 {
+		c.log.Debug("nid corrected", "errs", errs, "nac", nid.NAC, "rot", rot)
+	}
+	if nid.DUID != DUIDTrunkingSignaling {
+		// Some non-control DUID — record but don't lock.
+		c.log.Debug("non-control DUID", "duid", nid.DUID, "nac", nid.NAC)
+		return
+	}
+	if !c.locked || c.lastNAC != nid.NAC {
+		c.locked = true
+		c.lastNAC = nid.NAC
+		c.bus.Publish(events.Event{
+			Kind:    events.KindCCLocked,
+			Payload: LockState{FrequencyHz: c.freqHz, NAC: nid.NAC, DUID: nid.DUID},
+		})
+		c.log.Info("control channel locked", "nac", nid.NAC, "freq", c.freqHz, "rot", rot)
+	}
+
+	// The channel TSBK occupies the 98 dibits after the NID.
+	tsbkStart := nidStart + 32
+	tsbkDibits := rotateDibits(buf[tsbkStart:tsbkStart+98], rot)
+	tsbk, metric, err := DecodeTSBKChannel(tsbkDibits)
+	if err != nil {
+		c.log.Debug("tsbk decode failed", "err", err, "metric", metric, "nac", nid.NAC)
+		stage := events.StageTSBKTrellis
+		if errors.Is(err, CRCError) {
+			stage = events.StageTSBKCRC
+		}
+		c.bus.Publish(events.Event{
+			Kind:    events.KindDecodeError,
+			Payload: events.DecodeError{Protocol: "p25", Stage: stage},
+		})
+		return
+	}
+	c.dispatchTSBK(tsbk, nid.NAC, metric)
+}
+
+// trimBuffer drops dibits no pending hit needs any more. With no
+// pending hits the whole buffer is released; otherwise everything
+// before the earliest pending hit's NID is dropped — keeping buf
+// bounded to roughly one frame.
+func (c *ControlChannel) trimBuffer() {
+	keep := len(c.buf)
+	for _, ph := range c.pending {
+		if s := ph.end + 1 - c.bufBase; s >= 0 && s < keep {
+			keep = s
+		}
+	}
+	if keep > 0 {
+		c.buf = append(c.buf[:0], c.buf[keep:]...)
+		c.bufBase += keep
+	}
 }
 
 // rotateDibits returns a copy of src with the inverse FSW-search
@@ -326,6 +395,10 @@ func (c *ControlChannel) MarkLost() {
 		return
 	}
 	c.locked = false
+	// Drop accumulated dibits + pending hits so a re-acquisition
+	// starts from a clean slate.
+	c.buf = c.buf[:0]
+	c.pending = c.pending[:0]
 	c.bus.Publish(events.Event{
 		Kind:    events.KindCCLost,
 		Payload: LockState{FrequencyHz: c.freqHz, NAC: c.lastNAC},

--- a/internal/radio/p25/phase1/control_test.go
+++ b/internal/radio/p25/phase1/control_test.go
@@ -203,6 +203,75 @@ func TestControlChannelAppliesIdentifierUpdateAndPublishesGrant(t *testing.T) {
 	}
 }
 
+// TestControlChannelLocksAndGrantsAcrossSmallChunks feeds a two-frame
+// stream (IdentifierUpdate then GroupVoiceChannelGrant) through Process
+// in 19-dibit batches — the dibit count a real RTL-SDR's 16 KiB USB
+// transfer yields per call. No single batch holds a whole 154-dibit
+// frame, so locking + granting here proves Process assembles frames
+// across call boundaries (issue #275 — previously every FSW hit was
+// discarded because the NID/TSBK lookahead had to fit in one call).
+func TestControlChannelLocksAndGrantsAcrossSmallChunks(t *testing.T) {
+	bus := events.NewBus(32)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	const nac = 0x293
+	identTSBK := TSBK{LB: false, Opcode: OpIdentifierUpdate}
+	identTSBK.Payload = AssembleIdentifierUpdate(IdentifierUpdate{
+		ChannelID: 1, SpacingHz: 12_500, BaseHz: 851_000_000,
+	})
+	grantTSBK := TSBK{LB: true, Opcode: OpGroupVoiceChannelGrant, Payload: [8]byte{
+		0x00,
+		(1 << 4) | 0x00, 0x10, // channel = ID 1, number 16
+		0x12, 0x34, // group address 0x1234
+		0xAB, 0xCD, 0xEF, // source ID 0xABCDEF
+	}}
+
+	stream := append(
+		buildLockedStreamWithTSBK(10, nac, DUIDTrunkingSignaling, identTSBK),
+		buildLockedStreamWithTSBK(10, nac, DUIDTrunkingSignaling, grantTSBK)...,
+	)
+
+	cc := New(Options{
+		Bus: bus, SystemName: "TestSys", FrequencyHz: 851_000_000,
+		Now: func() time.Time { return time.Unix(1_700_000_000, 0).UTC() },
+	})
+
+	const batch = 19
+	for off := 0; off < len(stream); off += batch {
+		end := off + batch
+		if end > len(stream) {
+			end = len(stream)
+		}
+		cc.Process(stream[off:end], off)
+	}
+
+	var locked, granted bool
+	for drained := false; !drained; {
+		select {
+		case ev := <-sub.C:
+			switch ev.Kind {
+			case events.KindCCLocked:
+				locked = true
+			case events.KindGrant:
+				if g := ev.Payload.(trunking.Grant); g.FrequencyHz != 851_200_000 {
+					t.Errorf("grant freq = %d, want 851_200_000", g.FrequencyHz)
+				}
+				granted = true
+			}
+		default:
+			drained = true
+		}
+	}
+	if !locked {
+		t.Error("no cc.locked event — frame not assembled across 19-dibit batches")
+	}
+	if !granted {
+		t.Error("no grant event — TSBK not assembled across 19-dibit batches")
+	}
+}
+
 func TestControlChannelPublishesAffiliation(t *testing.T) {
 	bus := events.NewBus(8)
 	defer bus.Close()

--- a/internal/scanner/ccdecoder/decoder_test.go
+++ b/internal/scanner/ccdecoder/decoder_test.go
@@ -1061,10 +1061,11 @@ func TestDecoderLocksP25Phase1ThroughWidebandDDC(t *testing.T) {
 		t.Fatalf("pipelineRateHz = %v, want %v", d.pipelineRateHz, narrowRateHz)
 	}
 
-	// Pump the wideband stream through in SDR-sized chunks, draining
-	// the bus after each so a full subscriber buffer can't drop the
-	// cc.locked event.
-	const chunk = 131_072
+	// Pump the wideband stream through in chunks the size of a real
+	// RTL-SDR USB transfer (16 KiB = 8192 complex samples ≈ 19 P25
+	// symbols after the down-converter), draining the bus after each
+	// so a full subscriber buffer can't drop the cc.locked event.
+	const chunk = 8_192
 	var locked bool
 	var lockState p25phase1.LockState
 	for off := 0; off < len(wide) && !locked; off += chunk {


### PR DESCRIPTION
## Summary

Follow-up to #289. After the digital down-converter (#289) channelized the
IQ stream, the reporter retested on a live RTL-SDR and the P25 control
channel **still never locked** — ~19-20 dibits logged per chunk, repeated
`no FSW hits in chunk`. Investigation found a second, independent bug.

`ControlChannel.Process` discarded **every** Frame Sync Word hit unless the
whole 154-dibit frame (FSW + 32-dibit NID + 98-dibit TSBK) fell inside a
single `Process` call's dibit slice:

```go
startInWindow := h - baseIdx + 1
if startInWindow+32 > len(dibits) {   // control.go:130
    continue                          // "future calls will have the rest" — but nothing carried it
}
```

The `SyncDetector`'s 24-dibit ring buffer spans calls, so the FSW *is*
detected — but the NID/TSBK lookahead was read straight out of the current
call's slice with no cross-call buffer. A real RTL-SDR delivers 16 KiB USB
transfers — only **~19 P25 symbols per call** — so the 32-dibit NID never
fit and the channel could never lock, even with the IQ stream correctly
channelized.

Why the tests missed it: the integration test runs the mock SDR at 48 kHz
(~819 dibits/chunk) and #289's wideband test used 131072-sample chunks
(~307 dibits) — both far larger than real hardware.

## The fix

`ControlChannel.Process` now accumulates dibits in a rolling buffer that
spans calls and defers each FSW hit (a `pending` queue) until its full
frame has buffered — frame assembly no longer depends on IQ chunking. The
hit-parsing body is factored into `parseFrame`; `MarkLost` clears the
buffer. All changes are contained in `internal/radio/p25/phase1/control.go`.

## Test plan

- [x] Reproduced first: setting the wideband `Decoder` test to 8192-sample
      chunks (the real RTL-SDR USB transfer size) **fails** on pre-fix code
      and **passes** after — it's now the permanent regression guard
- [x] New `TestControlChannelLocksAndGrantsAcrossSmallChunks` — feeds a
      two-frame stream (IdentifierUpdate + grant) through `Process` in
      19-dibit batches, asserts `cc.locked` + grant
- [x] `go test ./...` — full unit suite green
- [x] `go test -tags integration ./cmd/gophertrunk/` — full integration
      suite green, all 13 protocols
- [ ] Manual on-air retest by the reporter on a live RTL-SDR

## Out of scope

DMR / NXDN / dPMR / TETRA / EDACS / Motorola / LTR / MPT1327 each have their
own `ControlChannel.Process` and may share this cross-chunk frame-assembly
weakness; their integration tests likewise run the mock SDR at low rates and
wouldn't catch it. Worth a follow-up audit — this PR stays scoped to the P25
issue in #275.

https://claude.ai/code/session_01P6Mjgbps3HD8Hean4yHKgJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01P6Mjgbps3HD8Hean4yHKgJ)_