### PR TITLE
rtlsdr/usb: fix purego array panic in macOS IOKit load (fix #257)

### DIFF
--- a/cmd/gophertrunk/main.go
+++ b/cmd/gophertrunk/main.go
@@ -270,7 +270,10 @@ func listSDRs(args []string) {
 		}
 	}
 
-	infos := sdr.EnumerateAll()
+	infos, errs := sdr.EnumerateAll()
+	for _, err := range errs {
+		fmt.Fprintln(os.Stderr, "enumerate:", err)
+	}
 	if len(infos) == 0 {
 		fmt.Println("no SDR devices found")
 		return

--- a/internal/sdr/registry.go
+++ b/internal/sdr/registry.go
@@ -38,15 +38,20 @@ func DriverByName(name string) (Driver, error) {
 	return d, nil
 }
 
-// EnumerateAll asks every registered driver to list its devices.
-func EnumerateAll() []Info {
+// EnumerateAll asks every registered driver to list its devices. It
+// returns the combined device list plus one error per driver that
+// failed to enumerate, so callers can surface the failure instead of
+// silently reporting an empty list.
+func EnumerateAll() ([]Info, []error) {
 	var out []Info
+	var errs []error
 	for _, d := range Drivers() {
 		infos, err := d.Enumerate()
 		if err != nil {
+			errs = append(errs, err)
 			continue
 		}
 		out = append(out, infos...)
 	}
-	return out
+	return out, errs
 }

--- a/internal/sdr/rtlsdr/usb/usb_darwin.go
+++ b/internal/sdr/rtlsdr/usb/usb_darwin.go
@@ -417,12 +417,12 @@ func findServiceByLocation(wantLoc uint32) (ioService, bool) {
 func openDeviceInterface(svc ioService) (uintptr, error) {
 	var plugin *uintptr
 	var score int32
-	pluginUUID := cfUUIDCreateFromUUIDBytes(kCFAllocatorDefault, uuidIOUSBDeviceUserClientType)
+	pluginUUID := makeCFUUID(uuidIOUSBDeviceUserClientType)
 	if pluginUUID == 0 {
 		return 0, errors.New("usb: CFUUIDCreateFromUUIDBytes(IOUSBDeviceUserClientType) returned NULL")
 	}
 	defer cfRelease(pluginUUID)
-	ifaceUUID := cfUUIDCreateFromUUIDBytes(kCFAllocatorDefault, uuidIOCFPlugInInterface)
+	ifaceUUID := makeCFUUID(uuidIOCFPlugInInterface)
 	if ifaceUUID == 0 {
 		return 0, errors.New("usb: CFUUIDCreateFromUUIDBytes(IOCFPlugInInterface) returned NULL")
 	}
@@ -555,12 +555,12 @@ func (t *darwinTransport) ClaimInterface(num int) error {
 
 	var plugin *uintptr
 	var score int32
-	pluginUUID := cfUUIDCreateFromUUIDBytes(kCFAllocatorDefault, uuidIOUSBDeviceUserClientType)
+	pluginUUID := makeCFUUID(uuidIOUSBDeviceUserClientType)
 	if pluginUUID == 0 {
 		return errors.New("usb: CFUUIDCreateFromUUIDBytes(IOUSBDeviceUserClientType) returned NULL")
 	}
 	defer cfRelease(pluginUUID)
-	pluginIfaceUUID := cfUUIDCreateFromUUIDBytes(kCFAllocatorDefault, uuidIOCFPlugInInterface)
+	pluginIfaceUUID := makeCFUUID(uuidIOCFPlugInInterface)
 	if pluginIfaceUUID == 0 {
 		return errors.New("usb: CFUUIDCreateFromUUIDBytes(IOCFPlugInInterface) returned NULL")
 	}

--- a/internal/sdr/rtlsdr/usb/usb_darwin_iokit.go
+++ b/internal/sdr/rtlsdr/usb/usb_darwin_iokit.go
@@ -3,6 +3,7 @@
 package usb
 
 import (
+	"encoding/binary"
 	"fmt"
 	"unsafe"
 
@@ -81,8 +82,9 @@ var (
 )
 
 // cfUUIDBytes mirrors Apple's CFUUIDBytes — 16 raw bytes of a UUID.
-// Layout matches the C struct exactly, so the value can be passed
-// to CFUUIDCreateFromUUIDBytes by reference.
+// purego cannot marshal an array-typed value across the FFI boundary,
+// so this type is never named in a registered function signature;
+// callers split it into two uint64 register halves (see makeCFUUID).
 type cfUUIDBytes [16]byte
 
 // IOCFPlugInInterface vtable indices we need (after the IUnknown
@@ -155,8 +157,10 @@ var (
 	cfStringCreateWithCString func(alloc cfAllocatorRef, str *byte, encoding uint32) cfStringRef
 	cfStringGetCString        func(theString cfStringRef, buffer *byte, bufferSize int64, encoding uint32) bool
 	cfNumberGetValue          func(num cfNumberRef, theType uint32, valuePtr unsafe.Pointer) bool
-	cfUUIDCreateFromUUIDBytes func(alloc cfAllocatorRef, bytes cfUUIDBytes) cfTypeRef
-	cfUUIDGetUUIDBytes        func(uuid cfTypeRef) cfUUIDBytes
+	// cfUUIDCreateFromUUIDBytes takes a CFUUIDBytes by value. purego
+	// can't marshal the 16-byte struct, so the two 8-byte halves are
+	// passed as separate register-sized args — see makeCFUUID.
+	cfUUIDCreateFromUUIDBytes func(alloc cfAllocatorRef, lo, hi uint64) cfTypeRef
 )
 
 // IOKit function pointers.
@@ -219,7 +223,6 @@ func loadIOKit() (err error) {
 	purego.RegisterLibFunc(&cfStringGetCString, cf, "CFStringGetCString")
 	purego.RegisterLibFunc(&cfNumberGetValue, cf, "CFNumberGetValue")
 	purego.RegisterLibFunc(&cfUUIDCreateFromUUIDBytes, cf, "CFUUIDCreateFromUUIDBytes")
-	purego.RegisterLibFunc(&cfUUIDGetUUIDBytes, cf, "CFUUIDGetUUIDBytes")
 	purego.RegisterLibFunc(&ioServiceMatching, io, "IOServiceMatching")
 	purego.RegisterLibFunc(&ioServiceGetMatchingServices, io, "IOServiceGetMatchingServices")
 	purego.RegisterLibFunc(&ioIteratorNext, io, "IOIteratorNext")
@@ -277,25 +280,33 @@ func translateIOReturn(rc uintptr) error {
 	}
 }
 
+// makeCFUUID builds a CFUUIDRef from raw UUID bytes. CFUUIDBytes is a
+// 16-byte by-value struct; purego can't pass it directly, so the two
+// 8-byte halves go in as separate register-sized args. Both supported
+// Darwin arches are little-endian, so LittleEndian.Uint64 reproduces
+// the in-register byte layout the C ABI expects.
+func makeCFUUID(u cfUUIDBytes) cfTypeRef {
+	lo := binary.LittleEndian.Uint64(u[0:8])
+	hi := binary.LittleEndian.Uint64(u[8:16])
+	return cfUUIDCreateFromUUIDBytes(kCFAllocatorDefault, lo, hi)
+}
+
 // queryInterface invokes IOCFPlugInInterface::QueryInterface to
 // obtain a typed COM-style interface handle (e.g. IOUSBDeviceInterface)
 // from a plug-in. plugin is a **IOCFPlugInInterface (the indirect
 // pointer IOCreatePlugInInterfaceForService returns). uuid is one of
 // the package-level UUID constants (uuidIOUSBDeviceInterface, etc.).
+//
+// QueryInterface on macOS is (this, REFIID iid, void **ppv) where
+// REFIID is a CFUUIDBytes passed BY VALUE — a 16-byte struct the ABI
+// splits across two registers. The uuid is handed over as its two
+// 8-byte halves; vtableCall places them in consecutive registers.
 func queryInterface(plugin uintptr, uuid cfUUIDBytes) (uintptr, error) {
-	cfUUID := cfUUIDCreateFromUUIDBytes(kCFAllocatorDefault, uuid)
-	if cfUUID == 0 {
-		return 0, fmt.Errorf("usb: CFUUIDCreateFromUUIDBytes returned NULL")
-	}
-	defer cfRelease(cfUUID)
-	uuidBytes := cfUUIDGetUUIDBytes(cfUUID)
+	lo := binary.LittleEndian.Uint64(uuid[0:8])
+	hi := binary.LittleEndian.Uint64(uuid[8:16])
 	var iface uintptr
 	rc := vtableCall(plugin, pluginQueryInterface,
-		// QueryInterface signature on macOS: (this, REFIID *, void**)
-		// REFIID is passed by value but it's a 16-byte CFUUIDBytes.
-		// purego splits multi-word values across registers per the
-		// SysV ABI used on Darwin amd64 / AAPCS64 on arm64.
-		uintptr(unsafe.Pointer(&uuidBytes)),
+		uintptr(lo), uintptr(hi),
 		uintptr(unsafe.Pointer(&iface)),
 	)
 	if rc != 0 {

--- a/internal/sdr/rtlsdr/usb/usb_darwin_test.go
+++ b/internal/sdr/rtlsdr/usb/usb_darwin_test.go
@@ -129,6 +129,22 @@ func TestUUIDByteSize(t *testing.T) {
 // invoking IORegistryEntryCreateCFProperty with a synthesised bogus
 // handle segfaults inside the framework rather than degrading
 // gracefully — so this is the deepest test we can write portably.
+// TestLoadIOKitNoPanic is the regression guard for issue #257. The
+// macOS USB enumerator panicked inside purego.RegisterLibFunc with
+// "unsupported kind array" because two CoreFoundation function
+// pointers named the array type cfUUIDBytes in their signatures —
+// loadIOKit recovered the panic into an error and every macOS user
+// got zero devices. Calling loadIOKit directly (not via the
+// platformEnumerator sync.Once) and asserting a nil error fails
+// loudly if an array type ever creeps back into a registered
+// signature. TestDarwinEnumeratorCallable can't catch this: it
+// accepts "iokit-load-failed" as a valid outcome.
+func TestLoadIOKitNoPanic(t *testing.T) {
+	if err := loadIOKit(); err != nil {
+		t.Fatalf("loadIOKit() = %v, want nil", err)
+	}
+}
+
 func TestReadUSBStringHandlesMissingSymbol(t *testing.T) {
 	// Force the unloaded path by saving + nilling the resolved
 	// function pointer; restore after the assertion.


### PR DESCRIPTION
The macOS USB enumerator declared CoreFoundation function pointers
whose signatures named cfUUIDBytes ([16]byte). purego v0.10.0's
RegisterLibFunc panics with "unsupported kind array" on any array
type in a registered signature, so loadIOKit failed for every macOS
user before a single IOKit call ran -- sdr list found no devices.
The earlier IOKit class-union work (#261) addressed a different
hypothesized cause and never reached this panic.

Pass the 16-byte CFUUIDBytes as two uint64 register halves instead:
re-register CFUUIDCreateFromUUIDBytes with a scalar signature behind
the new makeCFUUID helper, drop the unused CFUUIDGetUUIDBytes, and
hand QueryInterface its REFIID by value (the correct macOS COM ABI;
the old code passed a single pointer).

Also surface per-driver enumerate errors from EnumerateAll so
gophertrunk sdr list prints the failure instead of a silent empty
list, and add TestLoadIOKitNoPanic as a regression guard.

https://claude.ai/code/session_01DdmHrU3Cc3g6Bj1uRC42bs