### PR TITLE
config: accept all supported trunking protocols (fix #291)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
 	"gopkg.in/yaml.v3"
 )
 
@@ -520,10 +521,8 @@ func (c Config) Validate() error {
 		if s.Name == "" {
 			return fmt.Errorf("trunking.systems[%d]: name required", i)
 		}
-		switch s.Protocol {
-		case "p25", "dmr", "nxdn":
-		default:
-			return fmt.Errorf("trunking.systems[%d]: protocol must be p25|dmr|nxdn", i)
+		if _, err := trunking.ParseProtocol(s.Protocol); err != nil {
+			return fmt.Errorf("trunking.systems[%d]: %w", i, err)
 		}
 	}
 	if c.Recordings.SampleRate != 0 && (c.Recordings.SampleRate < 4000 || c.Recordings.SampleRate > 48_000) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -65,6 +65,8 @@ func TestValidate(t *testing.T) {
 		{"bad sample rate", Config{SDR: SDRConfig{SampleRate: 100}}, true},
 		{"bad role", Config{SDR: SDRConfig{Devices: []DeviceConfig{{Role: "bogus"}}}}, true},
 		{"bad protocol", Config{Trunking: TrunkingConfig{Systems: []SystemConfig{{Name: "x", Protocol: "lte"}}}}, true},
+		{"tetra protocol", Config{Trunking: TrunkingConfig{Systems: []SystemConfig{{Name: "x", Protocol: "tetra"}}}}, false},
+		{"nxdn protocol", Config{Trunking: TrunkingConfig{Systems: []SystemConfig{{Name: "x", Protocol: "nxdn"}}}}, false},
 		{"missing name", Config{Trunking: TrunkingConfig{Systems: []SystemConfig{{Protocol: "p25"}}}}, true},
 	}
 	for _, tc := range cases {

--- a/internal/trunking/site.go
+++ b/internal/trunking/site.go
@@ -94,7 +94,8 @@ func ParseProtocol(s string) (Protocol, error) {
 	case "dmr-tier2", "dmr_tier2", "dmr-t2", "dmrtier2":
 		return ProtocolDMRTier2, nil
 	default:
-		return ProtocolUnknown, fmt.Errorf("trunking: unknown protocol %q", s)
+		return ProtocolUnknown, fmt.Errorf("trunking: unknown protocol %q "+
+			"(want p25|p25-phase2|dmr|dmr-tier2|nxdn|dpmr|edacs|motorola|ltr|mpt1327|tetra|ysf|dstar)", s)
 	}
 }
 
@@ -294,7 +295,7 @@ func (s System) Validate() error {
 		return errors.New("trunking: system name is required")
 	}
 	if s.Protocol == ProtocolUnknown {
-		return errors.New("trunking: protocol must be p25|p25-phase2|dmr|nxdn|dpmr|edacs|motorola|ltr|mpt1327|tetra|ysf")
+		return errors.New("trunking: protocol must be p25|p25-phase2|dmr|dmr-tier2|nxdn|dpmr|edacs|motorola|ltr|mpt1327|tetra|ysf|dstar")
 	}
 	if len(s.ControlChannels) == 0 {
 		return errors.New("trunking: at least one control_channel frequency is required")


### PR DESCRIPTION
Config validation hardcoded a p25|dmr|nxdn whitelist that was never
updated as the other ten protocols were added, so a valid `protocol:
tetra` system failed at load with "protocol must be p25|dmr|nxdn"
despite TETRA being fully implemented and documented.

Route config validation through trunking.ParseProtocol — the same
parser the daemon uses — so the canonical protocol list is the single
source of truth and future additions stay in sync. Also enumerate the
accepted values in the ParseProtocol error and sync the stale
System.Validate message.

https://claude.ai/code/session_01EDifqKur8Q5hRjrLq5VMgj