### PR TITLE
web: fix SPA render loop blanking the UI on connect (fix #290)

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, waitFor } from "@testing-library/react";
+import { HashRouter } from "react-router-dom";
+
+// The real openEventStream synchronously reports "connecting", which
+// writes to the store — the feedback edge that, combined with an
+// unstable `cfg` reference, drove the issue #290 render loop. The mock
+// reproduces that edge so this test genuinely exercises the loop.
+vi.mock("./api/events", () => ({
+  openEventStream: vi.fn(
+    (_cfg: unknown, opts: { onStatus?: (s: string) => void }) => {
+      opts.onStatus?.("connecting");
+      return { close: vi.fn() };
+    },
+  ),
+}));
+
+vi.mock("./api/client", () => ({
+  api: {
+    mutations: vi.fn().mockResolvedValue({ allow_mutations: false }),
+    health: vi.fn().mockResolvedValue({ status: "ok" }),
+  },
+  HTTPError: class HTTPError extends Error {
+    status: number;
+    body: string;
+    constructor(status: number, body: string, message: string) {
+      super(message);
+      this.status = status;
+      this.body = body;
+    }
+  },
+}));
+
+// Stub Routes so the routed panels (and their charts) stay unmounted —
+// this test is only about App's connection effects.
+vi.mock("react-router-dom", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-router-dom")>();
+  return { ...actual, Routes: () => null };
+});
+
+vi.mock("./components/TabBar", () => ({ TabBar: () => null }));
+vi.mock("./components/AudioPlayer", () => ({ AudioPlayer: () => null }));
+vi.mock("./components/InstallPrompt", () => ({ InstallPrompt: () => null }));
+
+import { openEventStream } from "./api/events";
+import { useShared } from "./store/shared";
+import { App } from "./App";
+
+describe("App connection bootstrap", () => {
+  beforeEach(() => {
+    vi.mocked(openEventStream).mockClear();
+    useShared.setState({
+      serverURL: "http://localhost:8080",
+      token: null,
+      connected: true,
+      wsStatus: "idle",
+      mutations: null,
+      lastError: null,
+    });
+  });
+
+  it("opens the event stream exactly once — no render loop (issue #290)", async () => {
+    render(
+      <HashRouter>
+        <App />
+      </HashRouter>,
+    );
+
+    await waitFor(() => expect(openEventStream).toHaveBeenCalled());
+    // A regressed `cfg` reference would re-fire the effect on every
+    // store write; give that loop a window to manifest.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(openEventStream).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { eventsWebSocketURL } from "./client";
+
+// Regression coverage for issue #290: the WebSocket URL must always be
+// a well-formed ws(s):// URL with a host — never "ws:/api/v1/events/ws".
+describe("eventsWebSocketURL", () => {
+  it("derives ws:// from an http base URL", () => {
+    expect(
+      eventsWebSocketURL({ baseURL: "http://host:8080", token: null }),
+    ).toBe("ws://host:8080/api/v1/events/ws");
+  });
+
+  it("derives wss:// from an https base URL", () => {
+    expect(eventsWebSocketURL({ baseURL: "https://host", token: null })).toBe(
+      "wss://host/api/v1/events/ws",
+    );
+  });
+
+  it("normalizes an uppercase scheme", () => {
+    expect(eventsWebSocketURL({ baseURL: "HTTPS://host", token: null })).toBe(
+      "wss://host/api/v1/events/ws",
+    );
+  });
+
+  it("tolerates a trailing slash on the base URL", () => {
+    expect(
+      eventsWebSocketURL({ baseURL: "http://host:8080/", token: null }),
+    ).toBe("ws://host:8080/api/v1/events/ws");
+  });
+
+  it("falls back to the document origin when baseURL is empty", () => {
+    // Same-origin deployment: resolve against the current document.
+    const expected = `${window.location.origin.replace(/^http/, "ws")}/api/v1/events/ws`;
+    expect(eventsWebSocketURL({ baseURL: "", token: null })).toBe(expected);
+  });
+});

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -182,9 +182,14 @@ export function audioStreamURL(
   return joinURL(cfg.baseURL, `/api/v1/audio/stream${qs ? `?${qs}` : ""}`);
 }
 
-// eventsWebSocketURL composes the WS URL. WebSocket's protocol is
-// derived from the base URL (http→ws, https→wss).
+// eventsWebSocketURL composes the WS URL. The scheme is derived from
+// the base URL (http→ws, https→wss); an empty baseURL means the SPA is
+// served same-origin by the daemon, so we resolve against the current
+// document location. The URL constructor (rather than string concat)
+// avoids malformed output like "ws:/api/v1/events/ws" when baseURL
+// lacks a host, and normalizes an uppercase scheme.
 export function eventsWebSocketURL(cfg: ClientConfig): string {
-  const http = joinURL(cfg.baseURL, "/api/v1/events/ws");
-  return http.replace(/^http(s?):/, (_m, s) => `ws${s}:`);
+  const u = new URL("/api/v1/events/ws", cfg.baseURL || window.location.href);
+  u.protocol = u.protocol === "https:" ? "wss:" : "ws:";
+  return u.toString();
 }

--- a/web/src/api/events.ts
+++ b/web/src/api/events.ts
@@ -35,21 +35,23 @@ export function openEventStream(
   const connect = () => {
     if (closed) return;
     setStatus("connecting");
-    let url = eventsWebSocketURL(cfg);
-    if (cfg.token) {
-      // The daemon's WS upgrade does not currently accept a token
-      // via query parameter; if auth is required, deployments must
-      // bind to a trusted network (auto mode) or front the daemon
-      // with a reverse proxy that adds the header. The token is
-      // still forwarded via the optional Sec-WebSocket-Protocol
-      // sub-protocol form as a future extension point.
-      url += url.includes("?") ? "&" : "?";
-      url += `token=${encodeURIComponent(cfg.token)}`;
-    }
 
     try {
+      let url = eventsWebSocketURL(cfg);
+      if (cfg.token) {
+        // The daemon's WS upgrade does not currently accept a token
+        // via query parameter; if auth is required, deployments must
+        // bind to a trusted network (auto mode) or front the daemon
+        // with a reverse proxy that adds the header. The token is
+        // still forwarded via the optional Sec-WebSocket-Protocol
+        // sub-protocol form as a future extension point.
+        url += url.includes("?") ? "&" : "?";
+        url += `token=${encodeURIComponent(cfg.token)}`;
+      }
       ws = new WebSocket(url);
     } catch {
+      // A malformed base URL (eventsWebSocketURL throwing) or a
+      // WebSocket constructor rejection both land here.
       scheduleReconnect();
       return;
     }

--- a/web/src/components/ErrorBoundary.tsx
+++ b/web/src/components/ErrorBoundary.tsx
@@ -1,0 +1,51 @@
+import { Component, type ErrorInfo, type ReactNode } from "react";
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  error: Error | null;
+}
+
+// Top-level error boundary. A render/commit error (e.g. a state-update
+// loop tripping "Maximum update depth exceeded") would otherwise unmount
+// the whole tree and leave a blank page; this catches it and shows an
+// actionable fallback instead.
+export class ErrorBoundary extends Component<Props, State> {
+  state: State = { error: null };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error("Unhandled UI error:", error, info.componentStack);
+  }
+
+  render() {
+    if (!this.state.error) return this.props.children;
+    return (
+      <div className="min-h-full grid place-items-center p-4">
+        <div className="panel w-full max-w-md p-6 space-y-4">
+          <h1 className="text-xl font-semibold tracking-tight">
+            Something went wrong
+          </h1>
+          <p className="text-sm text-muted">
+            The interface hit an unexpected error and stopped rendering.
+            Reloading usually clears it.
+          </p>
+          <pre className="text-xs text-err whitespace-pre-wrap break-words">
+            {this.state.error.message}
+          </pre>
+          <button
+            className="btn-primary w-full"
+            onClick={() => window.location.reload()}
+          >
+            Reload
+          </button>
+        </div>
+      </div>
+    );
+  }
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from "react-dom/client";
 import { HashRouter } from "react-router-dom";
 import { registerSW } from "virtual:pwa-register";
 import { App } from "./App";
+import { ErrorBoundary } from "./components/ErrorBoundary";
 import { prefs } from "./store/prefs";
 import "./styles.css";
 
@@ -21,8 +22,10 @@ if (!root) throw new Error("missing #root");
 
 createRoot(root).render(
   <React.StrictMode>
-    <HashRouter>
-      <App />
-    </HashRouter>
+    <ErrorBoundary>
+      <HashRouter>
+        <App />
+      </HashRouter>
+    </ErrorBoundary>
   </React.StrictMode>,
 );

--- a/web/src/store/shared.test.ts
+++ b/web/src/store/shared.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { useShared, selectClientConfig } from "./shared";
+
+// Regression coverage for issue #290: selectClientConfig must return a
+// referentially-stable object so callers can put `cfg` in useEffect
+// dependency arrays without provoking a render loop.
+describe("selectClientConfig", () => {
+  beforeEach(() => {
+    useShared.setState({
+      serverURL: "http://localhost:8080",
+      token: null,
+      wsStatus: "idle",
+    });
+  });
+
+  it("returns the same reference on repeated calls", () => {
+    const a = selectClientConfig(useShared.getState());
+    const b = selectClientConfig(useShared.getState());
+    expect(b).toBe(a);
+  });
+
+  it("keeps the same reference after an unrelated store change", () => {
+    const before = selectClientConfig(useShared.getState());
+    useShared.setState({ wsStatus: "connecting" });
+    const after = selectClientConfig(useShared.getState());
+    expect(after).toBe(before);
+  });
+
+  it("returns a new reference when serverURL changes", () => {
+    const before = selectClientConfig(useShared.getState());
+    useShared.setState({ serverURL: "http://other:9090" });
+    const after = selectClientConfig(useShared.getState());
+    expect(after).not.toBe(before);
+    expect(after.baseURL).toBe("http://other:9090");
+  });
+
+  it("returns a new reference when the token changes", () => {
+    const before = selectClientConfig(useShared.getState());
+    useShared.setState({ token: "secret" });
+    const after = selectClientConfig(useShared.getState());
+    expect(after).not.toBe(before);
+    expect(after.token).toBe("secret");
+  });
+
+  it("maps a null serverURL to an empty baseURL", () => {
+    useShared.setState({ serverURL: null });
+    expect(selectClientConfig(useShared.getState()).baseURL).toBe("");
+  });
+});

--- a/web/src/store/shared.ts
+++ b/web/src/store/shared.ts
@@ -15,6 +15,7 @@ import type {
   SystemDTO,
   TalkgroupDTO,
 } from "../api/types";
+import type { ClientConfig } from "../api/client";
 import { prefs } from "./prefs";
 
 export type ConnectionStatus = "idle" | "connecting" | "open" | "closed";
@@ -146,9 +147,17 @@ export const useShared = create<SharedState>((set, get) => ({
   },
 }));
 
-/** Convenience selector: a stable ClientConfig snapshot. */
-export function selectClientConfig(s: SharedState) {
-  return { baseURL: s.serverURL ?? "", token: s.token };
+/** Convenience selector: a referentially-stable ClientConfig snapshot.
+ *  Returns the SAME object reference until serverURL or token actually
+ *  change, so callers can place `cfg` in useEffect dependency arrays
+ *  without triggering a render loop (see issue #290). */
+let cachedCfg: ClientConfig = { baseURL: "", token: null };
+export function selectClientConfig(s: SharedState): ClientConfig {
+  const baseURL = s.serverURL ?? "";
+  if (cachedCfg.baseURL !== baseURL || cachedCfg.token !== s.token) {
+    cachedCfg = { baseURL, token: s.token };
+  }
+  return cachedCfg;
 }
 
 /** Can-mutate gate combining write-mode toggle with daemon capability. */


### PR DESCRIPTION
selectClientConfig returned a fresh object on every call, so `cfg` was a
new reference each render. App's WebSocket effect listed `cfg` in its
deps and openEventStream synchronously writes wsStatus to the store,
producing an unbounded render loop (React error #185) that blanked the
UI and churned the WebSocket open/close.

- Memoize selectClientConfig so it returns a stable reference until
  serverURL/token actually change.
- Rebuild eventsWebSocketURL with the URL API: handles uppercase
  schemes, never emits a host-less "ws:/..." URL, and falls back to the
  document origin when served same-origin.
- Guard connect() so a malformed base URL reconnects instead of
  escaping the effect.
- Add a top-level ErrorBoundary so a render crash shows a fallback
  instead of a blank page.
- Add vitest coverage for selector stability, the WS URL builder, and
  the no-render-loop bootstrap.

https://claude.ai/code/session_01V68GjdyoarYcLx3tfz7WEg