### PR TITLE
p25/phase1: fix dibit-rotation inversion so simulcast CC locks

### DIFF
--- a/internal/radio/p25/phase1/control.go
+++ b/internal/radio/p25/phase1/control.go
@@ -192,7 +192,7 @@ func (c *ControlChannel) Process(dibits []uint8, baseIdx int) int {
 // must hold at least frameLookahead dibits — the caller guarantees it.
 // rot is the FSW-search rotation: the sync detector matched after
 // adding rot mod 4 to each input dibit, so the canonical dibit values
-// the BCH / trellis decoders expect are recovered by subtracting rot
+// the BCH / trellis decoders expect are recovered by adding rot
 // (rotateDibits) before parsing.
 func (c *ControlChannel) parseFrame(buf []uint8, nidStart int, rot uint8) {
 	nidDibits := rotateDibits(buf[nidStart:nidStart+32], rot)
@@ -259,17 +259,18 @@ func (c *ControlChannel) trimBuffer() {
 	}
 }
 
-// rotateDibits returns a copy of src with the inverse FSW-search
-// rotation applied: each dibit value has `rot` subtracted mod 4.
-// rot=0 short-circuits to avoid the copy.
+// rotateDibits returns a copy of src with the FSW-search rotation
+// undone. The sync detector reported that adding `rot` mod 4 to each
+// received dibit reproduced the canonical FrameSyncWord, so the
+// canonical NID / TSBK dibits are recovered the same way — by adding
+// `rot` mod 4. rot=0 short-circuits to avoid the copy.
 func rotateDibits(src []uint8, rot uint8) []uint8 {
 	if rot == 0 {
 		return src
 	}
-	inv := (4 - rot) & 3
 	out := make([]uint8, len(src))
 	for i, d := range src {
-		out[i] = (d + inv) & 3
+		out[i] = (d + rot) & 3
 	}
 	return out
 }

--- a/internal/radio/p25/phase1/control_test.go
+++ b/internal/radio/p25/phase1/control_test.go
@@ -59,6 +59,39 @@ func TestControlChannelEmitsLockOnTSDU(t *testing.T) {
 	}
 }
 
+// TestControlChannelLocksUnderDibitRotation feeds a TSDU stream whose
+// dibits have all been shifted by k — the residual quadrant ambiguity
+// the CQPSK/LSM demod leaves on simulcast P25 sites. The sync detector
+// recovers the rotation; parseFrame must undo it so the NID + TSBK
+// still decode. Before the rotateDibits fix, odd rotations (1, 3) —
+// exactly the π/4-DQPSK quadrant slips — corrupted every NID and the
+// control channel never locked.
+func TestControlChannelLocksUnderDibitRotation(t *testing.T) {
+	for k := uint8(0); k < 4; k++ {
+		bus := events.NewBus(8)
+		sub := bus.Subscribe()
+		stream := buildLockedStream(10, 0x293, DUIDTrunkingSignaling, OpRFSSStatusBroadcast)
+		// received = canonical - k, so the detector reports rot == k.
+		for i := range stream {
+			stream[i] = (stream[i] + 4 - k) & 3
+		}
+		cc := NewControlChannel(bus, nil, 851_000_000)
+		cc.Process(stream, 0)
+		select {
+		case ev := <-sub.C:
+			if ev.Kind != events.KindCCLocked {
+				t.Errorf("k=%d kind = %s, want cc.locked", k, ev.Kind)
+			} else if ls := ev.Payload.(LockState); ls.NAC != 0x293 {
+				t.Errorf("k=%d NAC = %#x, want 0x293", k, ls.NAC)
+			}
+		case <-time.After(time.Second):
+			t.Errorf("k=%d no lock — NID not recovered under rotation", k)
+		}
+		sub.Close()
+		bus.Close()
+	}
+}
+
 func TestControlChannelIgnoresNonTSDU(t *testing.T) {
 	bus := events.NewBus(8)
 	defer bus.Close()


### PR DESCRIPTION
The FSW sync detector reports rotation k where (received + k) mod 4 ==
canonical, so the NID/TSBK dibits are recovered by adding k. rotateDibits
instead added (4-rot)&3 (= -rot), which is only correct for even
rotations. Odd rotations (1, 3) — exactly the π/4-DQPSK quadrant slips
the CQPSK/LSM demod path leaves on simulcast P25 sites — recovered every
dibit off by 2, so the NID BCH decode failed and the control channel
never locked.

Add TestControlChannelLocksUnderDibitRotation covering all four
rotations end-to-end through ControlChannel.Process.

https://claude.ai/code/session_01Ptxgzg2dU8fADEPg3jTznp