### PR TITLE
dmr: RC4 cipher and encryption-key config foundation (#276)

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,21 @@ sourcing.
 What's still on the table. Order isn't fixed; each item is contained
 to its own package and lands independently.
 
+- **DMR ARC4 / RC4 known-key voice decryption (issue #276).** Many
+  DMR systems protect voice with ARC4-based "Enhanced Privacy".
+  Operators authorized to monitor such a system — and holding the
+  key — can list it per-system under
+  `trunking.systems[].encryption_keys` (`key_id` + `algorithm: rc4` +
+  hex `key`); the config is validated at load time, and the
+  `algorithm` field keeps the schema open for AES later. The
+  dependency-free RC4 keystream generator ships in
+  [`internal/crypto/rc4/`](internal/crypto/rc4/), verified against the
+  canonical RC4 test vectors. The remaining work is the DMR voice
+  burst → AMBE decode path the descrambler hooks into: GopherTrunk
+  today decodes DMR control channels (grants) but not the voice bursts
+  themselves, so wiring RC4 through to playable audio lands with that
+  path. Decryption is known-key only — no key recovery — matching the
+  SDRTrunk / DSD-FME / OP25 model.
 - **DVSI USB-3000 / AMBE-3003 hardware backend (USB transport).**
   The `Vocoder` + AMBE-3003 wire protocol + `voice.Vocoder` interface
   conformance ship in [`internal/voice/dvsi/`](internal/voice/dvsi/)

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -188,6 +188,23 @@ trunking:
   #     control_channels: [144_000_000]
   #     dstar_fec_mode: "on"            # default off — flip on for raw 660-bit
   #                                     # on-wire D-STAR JARL DV-mode headers
+  #
+  # Encrypted DMR systems (ARC4 / RC4 "Enhanced Privacy"). If you are
+  # authorized to monitor a DMR system that encrypts voice with ARC4
+  # and you hold the key, list it under `encryption_keys`. GopherTrunk
+  # decrypts only with operator-supplied keys — it performs no key
+  # recovery. `key_id` matches the key identifier the radios carry in
+  # the privacy header (a system may rotate between several keys).
+  # `key` is hex; whitespace and an optional "0x" prefix are ignored.
+  #
+  #   - name: "Example-DMR-Encrypted"
+  #     protocol: dmr
+  #     control_channels: [451_000_000]
+  #     talkgroup_file: "/etc/gophertrunk/talkgroups-dmr.csv"
+  #     encryption_keys:
+  #       - key_id: 1
+  #         algorithm: rc4              # only "rc4" is supported today
+  #         key: "0123456789"           # hex-encoded key
 
 # Police-scanner subsystems:
 #   - scan_mode controls the engine's per-grant gate. "all" follows every

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,9 +1,11 @@
 package config
 
 import (
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/MattCheramie/GopherTrunk/internal/trunking"
@@ -318,6 +320,27 @@ type SystemConfig struct {
 	// chain → 328 info bits → ParseHeader). Ignored for non-D-STAR
 	// protocols.
 	DStarFECMode string `yaml:"dstar_fec_mode"`
+
+	// EncryptionKeys lists operator-supplied decryption keys for this
+	// system. GopherTrunk decrypts only with keys the operator
+	// already holds and is authorized to use — it performs no key
+	// recovery. Today only DMR ARC4/RC4 ("Enhanced Privacy") is
+	// recognised; the per-key `algorithm` field keeps the schema open
+	// so AES can be added later without a config break. Ignored for
+	// protocols without an encryption decoder. See issue #276.
+	EncryptionKeys []EncryptionKeyConfig `yaml:"encryption_keys"`
+}
+
+// EncryptionKeyConfig is one operator-supplied decryption key for a
+// trunking system. KeyID matches the key identifier the radios carry
+// in the protocol's privacy header, so a system that rotates between
+// several keys still resolves to the right one. Key is the raw key
+// hex-encoded; surrounding whitespace, internal spaces, and an
+// optional "0x" prefix are tolerated.
+type EncryptionKeyConfig struct {
+	KeyID     uint16 `yaml:"key_id"`
+	Algorithm string `yaml:"algorithm"`
+	Key       string `yaml:"key"`
 }
 
 // APIConfig controls the HTTP REST + SSE + WebSocket and gRPC servers.
@@ -524,6 +547,30 @@ func (c Config) Validate() error {
 		if _, err := trunking.ParseProtocol(s.Protocol); err != nil {
 			return fmt.Errorf("trunking.systems[%d]: %w", i, err)
 		}
+		seenKeyIDs := make(map[uint16]struct{}, len(s.EncryptionKeys))
+		for k, ek := range s.EncryptionKeys {
+			switch strings.ToLower(strings.TrimSpace(ek.Algorithm)) {
+			case "rc4", "arc4":
+				// supported
+			case "":
+				return fmt.Errorf("trunking.systems[%d].encryption_keys[%d]: algorithm is required (use \"rc4\")", i, k)
+			case "aes", "des":
+				return fmt.Errorf("trunking.systems[%d].encryption_keys[%d]: algorithm %q is not supported yet (only \"rc4\")", i, k, ek.Algorithm)
+			default:
+				return fmt.Errorf("trunking.systems[%d].encryption_keys[%d]: unknown algorithm %q (use \"rc4\")", i, k, ek.Algorithm)
+			}
+			if _, dup := seenKeyIDs[ek.KeyID]; dup {
+				return fmt.Errorf("trunking.systems[%d].encryption_keys[%d]: duplicate key_id %d", i, k, ek.KeyID)
+			}
+			seenKeyIDs[ek.KeyID] = struct{}{}
+			b, err := decodeHexKey(ek.Key)
+			if err != nil {
+				return fmt.Errorf("trunking.systems[%d].encryption_keys[%d]: %w", i, k, err)
+			}
+			if len(b) > 32 {
+				return fmt.Errorf("trunking.systems[%d].encryption_keys[%d]: key is %d bytes, must be 1..32", i, k, len(b))
+			}
+		}
 	}
 	if c.Recordings.SampleRate != 0 && (c.Recordings.SampleRate < 4000 || c.Recordings.SampleRate > 48_000) {
 		return fmt.Errorf("recordings.sample_rate %d outside 4000..48000", c.Recordings.SampleRate)
@@ -581,4 +628,29 @@ func (c Config) Validate() error {
 // the dependency lives in one place and tests can lean on it.
 func parseDurationFlexible(s string) (time.Duration, error) {
 	return time.ParseDuration(s)
+}
+
+// decodeHexKey parses a hex-encoded encryption key. Surrounding and
+// internal whitespace plus an optional "0x"/"0X" prefix are stripped
+// so operators can paste keys in whatever form their radio-programming
+// software displays them.
+func decodeHexKey(s string) ([]byte, error) {
+	clean := strings.Map(func(r rune) rune {
+		switch r {
+		case ' ', '\t', '\n', '\r':
+			return -1
+		default:
+			return r
+		}
+	}, s)
+	clean = strings.TrimPrefix(clean, "0x")
+	clean = strings.TrimPrefix(clean, "0X")
+	if clean == "" {
+		return nil, errors.New("key is empty")
+	}
+	b, err := hex.DecodeString(clean)
+	if err != nil {
+		return nil, fmt.Errorf("key is not valid hex: %w", err)
+	}
+	return b, nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -68,6 +69,15 @@ func TestValidate(t *testing.T) {
 		{"tetra protocol", Config{Trunking: TrunkingConfig{Systems: []SystemConfig{{Name: "x", Protocol: "tetra"}}}}, false},
 		{"nxdn protocol", Config{Trunking: TrunkingConfig{Systems: []SystemConfig{{Name: "x", Protocol: "nxdn"}}}}, false},
 		{"missing name", Config{Trunking: TrunkingConfig{Systems: []SystemConfig{{Protocol: "p25"}}}}, true},
+		{"rc4 key ok", Config{Trunking: TrunkingConfig{Systems: []SystemConfig{{Name: "x", Protocol: "dmr", EncryptionKeys: []EncryptionKeyConfig{{KeyID: 1, Algorithm: "rc4", Key: "0123456789"}}}}}}, false},
+		{"arc4 alias ok", Config{Trunking: TrunkingConfig{Systems: []SystemConfig{{Name: "x", Protocol: "dmr", EncryptionKeys: []EncryptionKeyConfig{{KeyID: 1, Algorithm: "ARC4", Key: "0x AB CD EF"}}}}}}, false},
+		{"missing algorithm", Config{Trunking: TrunkingConfig{Systems: []SystemConfig{{Name: "x", Protocol: "dmr", EncryptionKeys: []EncryptionKeyConfig{{KeyID: 1, Key: "abcd"}}}}}}, true},
+		{"aes not supported", Config{Trunking: TrunkingConfig{Systems: []SystemConfig{{Name: "x", Protocol: "dmr", EncryptionKeys: []EncryptionKeyConfig{{KeyID: 1, Algorithm: "aes", Key: "abcd"}}}}}}, true},
+		{"unknown algorithm", Config{Trunking: TrunkingConfig{Systems: []SystemConfig{{Name: "x", Protocol: "dmr", EncryptionKeys: []EncryptionKeyConfig{{KeyID: 1, Algorithm: "rot13", Key: "abcd"}}}}}}, true},
+		{"bad hex key", Config{Trunking: TrunkingConfig{Systems: []SystemConfig{{Name: "x", Protocol: "dmr", EncryptionKeys: []EncryptionKeyConfig{{KeyID: 1, Algorithm: "rc4", Key: "xyz"}}}}}}, true},
+		{"empty key", Config{Trunking: TrunkingConfig{Systems: []SystemConfig{{Name: "x", Protocol: "dmr", EncryptionKeys: []EncryptionKeyConfig{{KeyID: 1, Algorithm: "rc4", Key: ""}}}}}}, true},
+		{"duplicate key_id", Config{Trunking: TrunkingConfig{Systems: []SystemConfig{{Name: "x", Protocol: "dmr", EncryptionKeys: []EncryptionKeyConfig{{KeyID: 1, Algorithm: "rc4", Key: "ab"}, {KeyID: 1, Algorithm: "rc4", Key: "cd"}}}}}}, true},
+		{"oversized key", Config{Trunking: TrunkingConfig{Systems: []SystemConfig{{Name: "x", Protocol: "dmr", EncryptionKeys: []EncryptionKeyConfig{{KeyID: 1, Algorithm: "rc4", Key: strings.Repeat("ab", 33)}}}}}}, true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/crypto/rc4/doc.go
+++ b/internal/crypto/rc4/doc.go
@@ -1,0 +1,16 @@
+// Package rc4 implements the RC4 stream cipher (also known as ARC4,
+// "alleged RC4") as a keystream generator.
+//
+// GopherTrunk uses it to decode DMR voice traffic protected by
+// ARC4-based "Enhanced Privacy" when the operator already holds the
+// key. The Go standard library's crypto/rc4 is deprecated — it raises
+// staticcheck SA1019 at every call site, which `make lint` rejects —
+// so this small, dependency-free implementation is vendored in its
+// place. It is pinned against the canonical RC4 test vectors in
+// rc4_test.go so codebook drift stays detectable.
+//
+// RC4 is cryptographically broken and must never be used to PROTECT
+// data. It exists here only to DECODE third-party transmissions whose
+// key the operator is authorized to hold — the same known-key model
+// SDRTrunk, DSD-FME and OP25 use. No key recovery is performed.
+package rc4

--- a/internal/crypto/rc4/rc4.go
+++ b/internal/crypto/rc4/rc4.go
@@ -1,0 +1,62 @@
+package rc4
+
+import "fmt"
+
+// Cipher is an RC4 keystream generator. A Cipher is stateful: every
+// call to XORKeyStream or KeyStream advances the internal PRGA state,
+// so one Cipher yields a single continuous keystream. A Cipher is not
+// safe for concurrent use; construct one per call chain.
+type Cipher struct {
+	s    [256]byte
+	i, j uint8
+}
+
+// NewCipher returns a Cipher keyed with key, which must be 1..256
+// bytes. The key-scheduling algorithm (KSA) runs here; the returned
+// Cipher is positioned at the first keystream byte.
+func NewCipher(key []byte) (*Cipher, error) {
+	k := len(key)
+	if k < 1 || k > 256 {
+		return nil, fmt.Errorf("rc4: invalid key length %d, must be 1..256 bytes", k)
+	}
+	c := &Cipher{}
+	for i := range c.s {
+		c.s[i] = byte(i)
+	}
+	var j uint8
+	for i := 0; i < 256; i++ {
+		j += c.s[i] + key[i%k]
+		c.s[i], c.s[j] = c.s[j], c.s[i]
+	}
+	return c, nil
+}
+
+// XORKeyStream XORs each byte of src with the next keystream byte and
+// writes the result to dst, advancing the keystream by len(src). dst
+// must be at least len(src) long; dst and src may be the same slice.
+func (c *Cipher) XORKeyStream(dst, src []byte) {
+	if len(src) == 0 {
+		return
+	}
+	if len(dst) < len(src) {
+		panic("rc4: dst shorter than src")
+	}
+	i, j := c.i, c.j
+	for n, v := range src {
+		i++
+		j += c.s[i]
+		c.s[i], c.s[j] = c.s[j], c.s[i]
+		dst[n] = v ^ c.s[c.s[i]+c.s[j]]
+	}
+	c.i, c.j = i, j
+}
+
+// KeyStream returns the next n bytes of raw keystream and advances the
+// Cipher by n bytes. It is equivalent to XORKeyStream against n zero
+// bytes — convenient when the caller wants the keystream itself, for
+// example to XOR onto a bit-unpacked voice frame.
+func (c *Cipher) KeyStream(n int) []byte {
+	out := make([]byte, n)
+	c.XORKeyStream(out, out)
+	return out
+}

--- a/internal/crypto/rc4/rc4_test.go
+++ b/internal/crypto/rc4/rc4_test.go
@@ -1,0 +1,125 @@
+package rc4
+
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+)
+
+// TestCipherKnownVectors checks the cipher against the canonical RC4
+// test vectors (the widely-published "key / plaintext / ciphertext"
+// triples). These exercise both the key-scheduling algorithm and the
+// pseudo-random generation algorithm end to end.
+func TestCipherKnownVectors(t *testing.T) {
+	cases := []struct {
+		key, plain, cipherHex string
+	}{
+		{"Key", "Plaintext", "bbf316e8d940af0ad3"},
+		{"Wiki", "pedia", "1021bf0420"},
+		{"Secret", "Attack at dawn", "45a01f645fc35b383552544b9bf5"},
+	}
+	for _, tc := range cases {
+		c, err := NewCipher([]byte(tc.key))
+		if err != nil {
+			t.Fatalf("NewCipher(%q): %v", tc.key, err)
+		}
+		want, err := hex.DecodeString(tc.cipherHex)
+		if err != nil {
+			t.Fatalf("bad test vector hex: %v", err)
+		}
+		got := make([]byte, len(tc.plain))
+		c.XORKeyStream(got, []byte(tc.plain))
+		if !bytes.Equal(got, want) {
+			t.Errorf("key=%q plain=%q: got %x, want %x", tc.key, tc.plain, got, want)
+		}
+	}
+}
+
+// TestCipherRFC6229 checks the keystream against RFC 6229's 40-bit-key
+// vector — key 0x0102030405, keystream bytes 0..15. This covers a
+// binary key and the KeyStream accessor.
+func TestCipherRFC6229(t *testing.T) {
+	c, err := NewCipher([]byte{0x01, 0x02, 0x03, 0x04, 0x05})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, _ := hex.DecodeString("b2396305f03dc027ccc3524a0a1118a8")
+	got := c.KeyStream(16)
+	if !bytes.Equal(got, want) {
+		t.Errorf("RFC 6229 40-bit keystream[0:16]: got %x, want %x", got, want)
+	}
+}
+
+// TestCipherRoundTrip confirms encrypt-then-decrypt with the same key
+// recovers the plaintext — the property the DMR descrambler relies on.
+func TestCipherRoundTrip(t *testing.T) {
+	key := []byte("a-known-dmr-key")
+	plain := []byte("eighteen AMBE frames of voice payload, descrambled")
+
+	enc, err := NewCipher(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ct := make([]byte, len(plain))
+	enc.XORKeyStream(ct, plain)
+	if bytes.Equal(ct, plain) {
+		t.Fatal("ciphertext equals plaintext; cipher did nothing")
+	}
+
+	dec, err := NewCipher(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pt := make([]byte, len(ct))
+	dec.XORKeyStream(pt, ct)
+	if !bytes.Equal(pt, plain) {
+		t.Errorf("round trip: got %q, want %q", pt, plain)
+	}
+}
+
+// TestKeyStreamContinuity confirms a Cipher produces one continuous
+// keystream: two short pulls equal one long pull from a fresh Cipher.
+func TestKeyStreamContinuity(t *testing.T) {
+	key := []byte{0xAA, 0xBB, 0xCC, 0xDD, 0xEE}
+
+	split, err := NewCipher(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	joined := append(split.KeyStream(7), split.KeyStream(25)...)
+
+	whole, err := NewCipher(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := whole.KeyStream(32)
+
+	if !bytes.Equal(joined, want) {
+		t.Errorf("keystream not continuous: got %x, want %x", joined, want)
+	}
+}
+
+func TestNewCipherBadKey(t *testing.T) {
+	if _, err := NewCipher(nil); err == nil {
+		t.Error("expected error for empty key")
+	}
+	if _, err := NewCipher([]byte{}); err == nil {
+		t.Error("expected error for zero-length key")
+	}
+	if _, err := NewCipher(make([]byte, 257)); err == nil {
+		t.Error("expected error for oversized key")
+	}
+}
+
+func TestXORKeyStreamShortDst(t *testing.T) {
+	c, err := NewCipher([]byte{0x01})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if recover() == nil {
+			t.Error("expected panic when dst is shorter than src")
+		}
+	}()
+	c.XORKeyStream(make([]byte, 2), make([]byte, 4))
+}

--- a/internal/storage/calllog.go
+++ b/internal/storage/calllog.go
@@ -101,12 +101,13 @@ func (c *CallLog) recordStart(cs trunking.CallStart) error {
 	const q = `
 INSERT OR REPLACE INTO call_log (
     system, protocol, group_id, source_id, frequency_hz,
-    encrypted, emergency, data_call, device_serial, started_at,
-    talkgroup_alpha
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    encrypted, algorithm_id, key_id, emergency, data_call,
+    device_serial, started_at, talkgroup_alpha
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 	_, err := c.db.sql.Exec(q,
 		cs.Grant.System, cs.Grant.Protocol, cs.Grant.GroupID, cs.Grant.SourceID, cs.Grant.FrequencyHz,
-		boolToInt(cs.Grant.Encrypted), boolToInt(cs.Grant.Emergency), boolToInt(cs.Grant.DataCall),
+		boolToInt(cs.Grant.Encrypted), cs.Grant.AlgorithmID, cs.Grant.KeyID,
+		boolToInt(cs.Grant.Emergency), boolToInt(cs.Grant.DataCall),
 		cs.DeviceSerial, cs.StartedAt.UnixNano(),
 		alpha,
 	)
@@ -148,6 +149,8 @@ type CallRow struct {
 	SourceID       uint32    `json:"source_id"`
 	FrequencyHz    uint32    `json:"frequency_hz"`
 	Encrypted      bool      `json:"encrypted"`
+	AlgorithmID    uint8     `json:"algorithm_id"`
+	KeyID          uint16    `json:"key_id"`
 	Emergency      bool      `json:"emergency"`
 	DataCall       bool      `json:"data_call"`
 	DeviceSerial   string    `json:"device_serial"`
@@ -161,8 +164,9 @@ type CallRow struct {
 // History queries the call_log with the supplied filter, newest-first.
 func (d *DB) History(ctx context.Context, f HistoryFilter) ([]CallRow, error) {
 	q := `SELECT id, system, protocol, group_id, source_id, frequency_hz,
-	             encrypted, emergency, data_call, device_serial,
-	             started_at, ended_at, duration_ms, end_reason, talkgroup_alpha
+	             encrypted, algorithm_id, key_id, emergency, data_call,
+	             device_serial, started_at, ended_at, duration_ms,
+	             end_reason, talkgroup_alpha
 	      FROM call_log WHERE 1=1`
 	args := []any{}
 	if f.System != "" {
@@ -202,15 +206,17 @@ func (d *DB) History(ctx context.Context, f HistoryFilter) ([]CallRow, error) {
 		var durMs sql.NullInt64
 		var reason sql.NullString
 		var alpha sql.NullString
-		var enc, emer, data int
+		var enc, emer, data, algID, keyID int
 		if err := rows.Scan(
 			&r.ID, &r.System, &r.Protocol, &r.GroupID, &r.SourceID, &r.FrequencyHz,
-			&enc, &emer, &data, &r.DeviceSerial,
+			&enc, &algID, &keyID, &emer, &data, &r.DeviceSerial,
 			&startNs, &endNs, &durMs, &reason, &alpha,
 		); err != nil {
 			return nil, err
 		}
 		r.Encrypted = enc != 0
+		r.AlgorithmID = uint8(algID)
+		r.KeyID = uint16(keyID)
 		r.Emergency = emer != 0
 		r.DataCall = data != 0
 		r.StartedAt = time.Unix(0, startNs).UTC()

--- a/internal/storage/calllog_test.go
+++ b/internal/storage/calllog_test.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"context"
+	"database/sql"
 	"path/filepath"
 	"testing"
 	"time"
@@ -227,4 +228,74 @@ func TestOpenInMemory(t *testing.T) {
 	if len(rows) != 0 {
 		t.Errorf("rows = %d, want 0", len(rows))
 	}
+}
+
+// TestMigrationAddsEncryptionColumns builds a pre-#276 call_log table
+// (no algorithm_id / key_id), then reopens it through Open and confirms
+// the migration adds the columns and old rows still read back.
+func TestMigrationAddsEncryptionColumns(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "legacy.db")
+
+	raw, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const legacy = `
+CREATE TABLE call_log (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    system          TEXT    NOT NULL,
+    protocol        TEXT    NOT NULL DEFAULT '',
+    group_id        INTEGER NOT NULL,
+    source_id       INTEGER NOT NULL DEFAULT 0,
+    frequency_hz    INTEGER NOT NULL DEFAULT 0,
+    encrypted       INTEGER NOT NULL DEFAULT 0,
+    emergency       INTEGER NOT NULL DEFAULT 0,
+    data_call       INTEGER NOT NULL DEFAULT 0,
+    device_serial   TEXT    NOT NULL,
+    started_at      INTEGER NOT NULL,
+    ended_at        INTEGER,
+    duration_ms     INTEGER,
+    end_reason      TEXT,
+    talkgroup_alpha TEXT
+);`
+	if _, err := raw.Exec(legacy); err != nil {
+		t.Fatalf("create legacy table: %v", err)
+	}
+	if _, err := raw.Exec(
+		`INSERT INTO call_log (system, group_id, device_serial, started_at) VALUES (?, ?, ?, ?)`,
+		"Legacy-Sys", 100, "dev0", int64(1000),
+	); err != nil {
+		t.Fatalf("seed legacy row: %v", err)
+	}
+	if err := raw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	db, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open (migrate): %v", err)
+	}
+	defer db.Close()
+
+	rows, err := db.History(context.Background(), HistoryFilter{})
+	if err != nil {
+		t.Fatalf("History after migration: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("got %d rows, want 1", len(rows))
+	}
+	if rows[0].System != "Legacy-Sys" {
+		t.Errorf("system = %q, want Legacy-Sys", rows[0].System)
+	}
+	if rows[0].AlgorithmID != 0 || rows[0].KeyID != 0 {
+		t.Errorf("migrated row: algorithm_id=%d key_id=%d, want 0/0",
+			rows[0].AlgorithmID, rows[0].KeyID)
+	}
+
+	// Reopening must be idempotent — the columns now exist.
+	db2, err := Open(path)
+	if err != nil {
+		t.Fatalf("second Open: %v", err)
+	}
+	db2.Close()
 }

--- a/internal/storage/sqlite.go
+++ b/internal/storage/sqlite.go
@@ -75,6 +75,8 @@ CREATE TABLE IF NOT EXISTS call_log (
     source_id       INTEGER NOT NULL DEFAULT 0,
     frequency_hz    INTEGER NOT NULL DEFAULT 0,
     encrypted       INTEGER NOT NULL DEFAULT 0,
+    algorithm_id    INTEGER NOT NULL DEFAULT 0,
+    key_id          INTEGER NOT NULL DEFAULT 0,
     emergency       INTEGER NOT NULL DEFAULT 0,
     data_call       INTEGER NOT NULL DEFAULT 0,
     device_serial   TEXT    NOT NULL,
@@ -96,7 +98,56 @@ func (d *DB) migrate() error {
 	if err != nil {
 		return fmt.Errorf("storage: migrate: %w", err)
 	}
-	// Stamp v1; future migrations check this row before running.
-	_, _ = d.sql.Exec(`INSERT OR IGNORE INTO schema_version(version) VALUES (1)`)
+	if err := d.ensureCallLogColumns(); err != nil {
+		return err
+	}
+	// Stamp the current schema version; future migrations check this
+	// row before running.
+	_, _ = d.sql.Exec(`INSERT OR IGNORE INTO schema_version(version) VALUES (2)`)
+	return nil
+}
+
+// ensureCallLogColumns adds call_log columns introduced after the
+// initial schema. CREATE TABLE IF NOT EXISTS never alters an existing
+// table, so a database created by an earlier GopherTrunk keeps the old
+// column set; this brings it forward. It is idempotent — columns
+// already present (fresh databases, repeat opens) are skipped — so it
+// needs no schema-version gate.
+func (d *DB) ensureCallLogColumns() error {
+	rows, err := d.sql.Query(`PRAGMA table_info(call_log)`)
+	if err != nil {
+		return fmt.Errorf("storage: inspect call_log: %w", err)
+	}
+	have := make(map[string]bool)
+	for rows.Next() {
+		var (
+			cid, notnull, pk int
+			name, ctype      string
+			dflt             sql.NullString
+		)
+		if err := rows.Scan(&cid, &name, &ctype, &notnull, &dflt, &pk); err != nil {
+			rows.Close()
+			return fmt.Errorf("storage: inspect call_log: %w", err)
+		}
+		have[name] = true
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return fmt.Errorf("storage: inspect call_log: %w", err)
+	}
+	rows.Close()
+
+	adds := []struct{ name, ddl string }{
+		{"algorithm_id", `ALTER TABLE call_log ADD COLUMN algorithm_id INTEGER NOT NULL DEFAULT 0`},
+		{"key_id", `ALTER TABLE call_log ADD COLUMN key_id INTEGER NOT NULL DEFAULT 0`},
+	}
+	for _, a := range adds {
+		if have[a.name] {
+			continue
+		}
+		if _, err := d.sql.Exec(a.ddl); err != nil {
+			return fmt.Errorf("storage: add call_log.%s: %w", a.name, err)
+		}
+	}
 	return nil
 }

--- a/internal/trunking/grant.go
+++ b/internal/trunking/grant.go
@@ -23,6 +23,13 @@ type Grant struct {
 	ChannelNum  uint16 // raw channel number within the ID
 	Encrypted   bool
 	Emergency   bool
+	// AlgorithmID and KeyID carry the encryption parameters the
+	// protocol's privacy header advertises (the DMR PI header, etc.).
+	// They are meaningful only when Encrypted is true and stay zero
+	// until a privacy header has been parsed. Persisted to the call
+	// log so an operator can see which key a recorded call needs.
+	AlgorithmID uint8
+	KeyID       uint16
 	DataCall    bool // false = voice call (default)
 	// ProVoice marks the grant as an EDACS ProVoice (digital) call. The
 	// vocoder is patent + trade-secret encumbered so we cannot ship a


### PR DESCRIPTION
## Summary

Foundation for issue #276 — decoding DMR voice protected by **ARC4/RC4 "Enhanced Privacy"** with an operator-supplied known key. This PR lands the parts that are fully self-contained and verifiable today:

- **`internal/crypto/rc4/`** — a dependency-free RC4 keystream generator. The Go stdlib `crypto/rc4` is deprecated and trips staticcheck `SA1019` at every call site (which `make lint` rejects), so a small ~50-line implementation is vendored instead. Verified against the canonical RC4 test vectors and the RFC 6229 40-bit-key vector.
- **Encryption-key config** — per-system `trunking.systems[].encryption_keys` (`key_id` + `algorithm` + hex `key`), validated at load time. Only `rc4` is accepted today; the `algorithm` field keeps the schema open so AES can be added later without a config break. Hex parsing tolerates whitespace and an optional `0x` prefix.
- **Call metadata** — `trunking.Grant` and the SQLite `call_log` table carry `algorithm_id` / `key_id` alongside the existing `encrypted` flag. An idempotent `PRAGMA table_info` + `ALTER TABLE` migration upgrades databases created by earlier builds cleanly.

This is **known-key decryption only — no key recovery** — matching the SDRTrunk / DSD-FME / OP25 model.

## Scope / what's next

Wiring RC4 through to playable decrypted audio depends on a **DMR voice-burst → AMBE decode path that does not exist yet**: GopherTrunk's DMR decoders currently handle control channels (grants) only — voice bursts are dropped. Building that path, PI-header parsing (algorithm/key ID + message indicator), and the descramble hook are the planned follow-up work. This PR is the verifiable groundwork; nothing here changes decode behavior on air.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet` clean on touched packages
- [x] `go test ./...` — full suite passes
- [x] RC4 verified against canonical + RFC 6229 vectors (`internal/crypto/rc4/rc4_test.go`)
- [x] Config validation: bad hex, missing/unknown/AES algorithm, duplicate `key_id`, oversized key (`internal/config/config_test.go`)
- [x] Schema migration: a pre-#276 `call_log` table upgrades and old rows still read (`TestMigrationAddsEncryptionColumns`)
- [ ] staticcheck not installed locally — relying on CI (no deprecated `crypto/rc4` use)

Closes nothing yet — issue #276 stays open until the voice-decode path lands.

https://claude.ai/code/session_01MdJGc7Nb7nXv8mBWsDJvWx

---
_Generated by [Claude Code](https://claude.ai/code/session_01MdJGc7Nb7nXv8mBWsDJvWx)_