### PR TITLE
dmr: voice superframe decoder (#276)

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,14 +343,18 @@ to its own package and lands independently.
   `trunking.systems[].encryption_keys` (`key_id` + `algorithm: rc4` +
   hex `key`); the config is validated at load time, and the
   `algorithm` field keeps the schema open for AES later. The
-  dependency-free RC4 keystream generator ships in
-  [`internal/crypto/rc4/`](internal/crypto/rc4/), verified against the
-  canonical RC4 test vectors. The remaining work is the DMR voice
-  burst → AMBE decode path the descrambler hooks into: GopherTrunk
-  today decodes DMR control channels (grants) but not the voice bursts
-  themselves, so wiring RC4 through to playable audio lands with that
-  path. Decryption is known-key only — no key recovery — matching the
-  SDRTrunk / DSD-FME / OP25 model.
+  dependency-free RC4 keystream generator
+  ([`internal/crypto/rc4/`](internal/crypto/rc4/)) and the DMR voice
+  superframe decoder ([`internal/radio/dmr/voice/`](internal/radio/dmr/voice/))
+  have shipped — the latter locks onto the A–F voice superframe and
+  extracts its 18 on-air AMBE+2 frames, the voice path GopherTrunk
+  previously lacked entirely (DMR decoded control channels only). The
+  remaining work is the AMBE forward-error-correction (72-bit on-air
+  frame → 49-bit vocoder payload), wiring the voice decoder into the
+  per-call composer + recorder, and the RC4 descramble + PI-header
+  (algorithm / key / message-indicator) parsing that together produce
+  playable decrypted audio. Decryption is known-key only — no key
+  recovery — matching the SDRTrunk / DSD-FME / OP25 model.
 - **DVSI USB-3000 / AMBE-3003 hardware backend (USB transport).**
   The `Vocoder` + AMBE-3003 wire protocol + `voice.Vocoder` interface
   conformance ship in [`internal/voice/dvsi/`](internal/voice/dvsi/)

--- a/internal/radio/dmr/burst.go
+++ b/internal/radio/dmr/burst.go
@@ -11,9 +11,9 @@ package dmr
 //   dibits  83..131   (49 dibits, 98 bits)  — info[1]: payload second half
 //
 // The two 98-bit info halves concatenate to form one 196-bit BPTC(196,96)
-// codeword for control/data bursts (CSBKs etc.). For voice bursts the same
-// payload bits carry two AMBE+2 frames; that decoding plugs in via the
-// vocoder registry once the AMBE+2 backend is built.
+// codeword for control/data bursts (CSBKs etc.). Voice bursts use a
+// different split — 108 + 48 + 108 bits, with no slot-type fields —
+// carrying three 72-bit AMBE+2 frames; see internal/radio/dmr/voice.
 
 const (
 	BurstDibits       = 132

--- a/internal/radio/dmr/voice/burst.go
+++ b/internal/radio/dmr/voice/burst.go
@@ -1,0 +1,53 @@
+package voice
+
+import "github.com/MattCheramie/GopherTrunk/internal/radio/dmr"
+
+const (
+	// VoiceHalfDibits is the dibit count of each voice payload half.
+	// A DMR voice burst is 132 dibits: 54 payload + 24 sync/embedded +
+	// 54 payload, with no slot-type fields (unlike a data burst).
+	VoiceHalfDibits = 54
+	// VoicePayloadBits is the total voice-payload bit count per burst
+	// — the two 108-bit halves concatenated.
+	VoicePayloadBits = 216
+	// AMBEFrameBits is the on-air size of one AMBE+2 voice frame.
+	AMBEFrameBits = 72
+	// BurstsPerSuperframe is the burst count of one DMR voice
+	// superframe (bursts A–F).
+	BurstsPerSuperframe = 6
+	// FramesPerBurst is the number of AMBE frames in one voice burst.
+	FramesPerBurst = VoicePayloadBits / AMBEFrameBits // 3
+	// FramesPerSuperframe is the AMBE frame count across bursts A–F.
+	FramesPerSuperframe = FramesPerBurst * BurstsPerSuperframe // 18
+)
+
+// VoiceBits returns the 216 voice-payload bits of a DMR voice burst,
+// one bit per byte MSB-first: the first 54-dibit half followed by the
+// second 54-dibit half, with the central 24-dibit sync / embedded-
+// signalling field skipped. Voice bursts have no slot-type fields, so
+// the payload occupies the dibit positions a data burst uses for slot
+// type.
+func VoiceBits(b *dmr.Burst) []byte {
+	out := make([]byte, 0, VoicePayloadBits)
+	emit := func(d uint8) { out = append(out, (d>>1)&1, d&1) }
+	for i := 0; i < VoiceHalfDibits; i++ {
+		emit(b.Dibits[i])
+	}
+	for i := dmr.BurstDibits - VoiceHalfDibits; i < dmr.BurstDibits; i++ {
+		emit(b.Dibits[i])
+	}
+	return out
+}
+
+// AMBEFrames splits a voice burst into its three 72-bit on-air AMBE+2
+// frames, each one bit per byte MSB-first. The frames are contiguous
+// slices of the 216 voice bits; the middle frame straddles the two
+// payload halves, exactly as transmitted around the sync field.
+func AMBEFrames(b *dmr.Burst) [FramesPerBurst][]byte {
+	bits := VoiceBits(b)
+	var frames [FramesPerBurst][]byte
+	for i := range frames {
+		frames[i] = bits[i*AMBEFrameBits : (i+1)*AMBEFrameBits]
+	}
+	return frames
+}

--- a/internal/radio/dmr/voice/burst_test.go
+++ b/internal/radio/dmr/voice/burst_test.go
@@ -1,0 +1,88 @@
+package voice
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/radio/dmr"
+)
+
+// mkFrame builds a deterministic, distinct 72-bit AMBE frame. The
+// first six bits encode seed in binary so a frame-ordering bug is
+// obvious in test output; the remainder is deterministic filler.
+func mkFrame(seed int) []byte {
+	f := make([]byte, AMBEFrameBits)
+	for i := 0; i < 6; i++ {
+		f[i] = byte((seed >> (5 - i)) & 1)
+	}
+	for i := 6; i < AMBEFrameBits; i++ {
+		f[i] = byte((seed*3 + i*5) & 1)
+	}
+	return f
+}
+
+// bitsToDibits packs a bit slice (one bit per byte, MSB-first) into
+// dibits.
+func bitsToDibits(bits []byte) []uint8 {
+	d := make([]uint8, len(bits)/2)
+	for i := range d {
+		d[i] = bits[2*i]<<1 | bits[2*i+1]
+	}
+	return d
+}
+
+// makeVoiceBurst assembles a 132-dibit voice burst from three 72-bit
+// AMBE frames and a 24-dibit sync / embedded-signalling field.
+func makeVoiceBurst(frames [][]byte, sync [24]uint8) []uint8 {
+	var voiceBits []byte
+	for _, f := range frames {
+		voiceBits = append(voiceBits, f...)
+	}
+	burst := make([]uint8, 0, dmr.BurstDibits)
+	burst = append(burst, bitsToDibits(voiceBits[:108])...)
+	burst = append(burst, sync[:]...)
+	burst = append(burst, bitsToDibits(voiceBits[108:])...)
+	return burst
+}
+
+func TestVoiceBitsLength(t *testing.T) {
+	var b dmr.Burst
+	if got := len(VoiceBits(&b)); got != VoicePayloadBits {
+		t.Errorf("VoiceBits length = %d, want %d", got, VoicePayloadBits)
+	}
+}
+
+func TestAMBEFramesRoundTrip(t *testing.T) {
+	in := [][]byte{mkFrame(1), mkFrame(2), mkFrame(3)}
+	burstDibits := makeVoiceBurst(in, dmr.BSVoice.Dibits)
+
+	var b dmr.Burst
+	copy(b.Dibits[:], burstDibits)
+
+	got := AMBEFrames(&b)
+	for i := 0; i < FramesPerBurst; i++ {
+		if !bytes.Equal(got[i], in[i]) {
+			t.Errorf("frame %d round trip:\n got %v\nwant %v", i, got[i], in[i])
+		}
+	}
+}
+
+func TestAMBEFramesSkipSyncField(t *testing.T) {
+	// The 24-dibit centre field must not leak into any AMBE frame:
+	// fill it with a marker and confirm the extracted frames still
+	// match the input regardless of the centre's contents.
+	in := [][]byte{mkFrame(7), mkFrame(8), mkFrame(9)}
+	var marker [24]uint8
+	for i := range marker {
+		marker[i] = 3
+	}
+	var b dmr.Burst
+	copy(b.Dibits[:], makeVoiceBurst(in, marker))
+
+	got := AMBEFrames(&b)
+	for i := 0; i < FramesPerBurst; i++ {
+		if !bytes.Equal(got[i], in[i]) {
+			t.Errorf("frame %d: centre field leaked into payload", i)
+		}
+	}
+}

--- a/internal/radio/dmr/voice/doc.go
+++ b/internal/radio/dmr/voice/doc.go
@@ -1,0 +1,18 @@
+// Package voice decodes the DMR voice path: it recognises voice
+// superframes in a dibit stream and extracts the AMBE+2 frames they
+// carry.
+//
+// DMR voice is organised into 6-burst superframes (bursts A–F, 360 ms
+// of audio). Burst A is framed by a voice sync word (BS/MS/DM Voice);
+// bursts B–F replace the sync word with embedded signalling, so they
+// carry no sync of their own and must be located by the fixed
+// 132-dibit TDMA cadence relative to burst A. Each burst carries 216
+// voice bits — three 72-bit on-air AMBE+2 frames — for 18 frames per
+// superframe.
+//
+// This package produces the *on-air* AMBE frames (72 bits each, FEC
+// still applied). Decoding the AMBE forward-error-correction down to
+// the 49-bit vocoder payload, the ARC4 descramble for encrypted
+// traffic, and wiring the decoder into the per-call composer/recorder
+// all layer on top — see issue #276.
+package voice

--- a/internal/radio/dmr/voice/superframe.go
+++ b/internal/radio/dmr/voice/superframe.go
@@ -1,0 +1,124 @@
+package voice
+
+import "github.com/MattCheramie/GopherTrunk/internal/radio/dmr"
+
+// VoiceSuperframe is one decoded DMR voice superframe: the 18 on-air
+// AMBE+2 frames carried by bursts A–F. Each frame is 72 bits, one bit
+// per byte MSB-first; AMBE forward-error-correction has not yet been
+// applied.
+type VoiceSuperframe struct {
+	// Frames holds the 18 AMBE frames in transmission order — bursts
+	// A..F, three frames per burst.
+	Frames [FramesPerSuperframe][]byte
+	// SyncName is the voice sync word that framed burst A:
+	// "BS-Voice", "MS-Voice", "DM-Voice-TS1" or "DM-Voice-TS2".
+	SyncName string
+	// StartDibit is the absolute dibit index of burst A's first dibit.
+	StartDibit int
+}
+
+// voiceSyncs are the sync words that frame burst A of a voice
+// superframe. Bursts B–F carry embedded signalling instead, so they
+// produce no sync match and are located by TDMA cadence.
+var voiceSyncs = []dmr.SyncPattern{
+	dmr.BSVoice, dmr.MSVoice, dmr.DMVoice1, dmr.DMVoice2,
+}
+
+// burstLookback is the dibit distance from a sync match (the index of
+// the last sync dibit) back to the burst's first dibit: 54 payload
+// dibits + 24 sync dibits − 1.
+const burstLookback = VoiceHalfDibits + 24 - 1 // 77
+
+// superframeDibits is the dibit span of a full A–F superframe.
+const superframeDibits = dmr.BurstDibits * BurstsPerSuperframe // 792
+
+// bufKeep retains enough dibits that two pending burst-A anchors can
+// each still slice a complete superframe once their trailing bursts
+// arrive. Dibits are one byte each, so the buffer cost is trivial.
+const bufKeep = 2*superframeDibits + dmr.BurstDibits
+
+// Decoder extracts DMR voice superframes from a dibit stream. It is
+// the voice-burst counterpart of the tier2 / tier3 control-channel
+// Process adapters: those slice a burst on every sync match, but
+// voice bursts B–F carry no sync, so the Decoder locks onto burst A
+// via its voice sync word and slices B–F at the fixed 132-dibit TDMA
+// cadence.
+//
+// A Decoder is stateful and not safe for concurrent use; construct
+// one per voice-call decode chain.
+type Decoder struct {
+	det      *dmr.SyncDetector
+	buf      []uint8
+	bufStart int // absolute dibit index of buf[0]
+	pending  []dmr.Match
+}
+
+// NewDecoder returns a Decoder ready to consume dibits.
+func NewDecoder() *Decoder {
+	return &Decoder{det: dmr.NewSyncDetector(voiceSyncs, 2)}
+}
+
+// Reset clears all buffered state. Call on a stream re-sync so a stale
+// burst-A anchor does not slice across the discontinuity.
+func (d *Decoder) Reset() {
+	d.buf = d.buf[:0]
+	d.bufStart = 0
+	d.pending = d.pending[:0]
+	d.det = dmr.NewSyncDetector(voiceSyncs, 2)
+}
+
+// Process consumes a window of dibits and returns every voice
+// superframe that completed within it. baseIdx is the absolute dibit
+// index of dibits[0]; it must be monotonically non-decreasing across
+// calls. Superframes are returned in stream order.
+func (d *Decoder) Process(dibits []uint8, baseIdx int) []VoiceSuperframe {
+	if len(d.buf) == 0 {
+		d.bufStart = baseIdx
+	}
+	d.buf = append(d.buf, dibits...)
+
+	matches, _ := d.det.Process(nil, dibits, baseIdx)
+	d.pending = append(d.pending, matches...)
+
+	var out []VoiceSuperframe
+	bufEnd := d.bufStart + len(d.buf)
+	keep := d.pending[:0]
+	for _, m := range d.pending {
+		start := m.Index - burstLookback
+		if start+superframeDibits > bufEnd {
+			keep = append(keep, m) // trailing bursts not buffered yet
+			continue
+		}
+		if start < d.bufStart {
+			continue // anchor fell off the front of the buffer
+		}
+		out = append(out, d.sliceSuperframe(start, m.Pattern.Name))
+	}
+	d.pending = keep
+
+	if len(d.buf) > bufKeep {
+		drop := len(d.buf) - bufKeep
+		copy(d.buf, d.buf[drop:])
+		d.buf = d.buf[:bufKeep]
+		d.bufStart += drop
+	}
+	return out
+}
+
+// sliceSuperframe cuts the six 132-dibit bursts starting at absolute
+// dibit index start and extracts their 18 AMBE frames. The caller has
+// already confirmed the full span is buffered.
+func (d *Decoder) sliceSuperframe(start int, syncName string) VoiceSuperframe {
+	sf := VoiceSuperframe{SyncName: syncName, StartDibit: start}
+	off := start - d.bufStart
+	frame := 0
+	for b := 0; b < BurstsPerSuperframe; b++ {
+		var burst dmr.Burst
+		copy(burst.Dibits[:], d.buf[off+b*dmr.BurstDibits:off+(b+1)*dmr.BurstDibits])
+		for _, f := range AMBEFrames(&burst) {
+			sf.Frames[frame] = f
+			frame++
+		}
+	}
+	return sf
+}

--- a/internal/radio/dmr/voice/superframe_test.go
+++ b/internal/radio/dmr/voice/superframe_test.go
@@ -1,0 +1,141 @@
+package voice
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/radio/dmr"
+)
+
+// buildStream assembles a dibit stream of n voice superframes preceded
+// by lead dibits of filler. Frame f of the stream carries mkFrame(f),
+// so the caller can verify ordering across the whole stream. Burst A
+// of each superframe is framed by the BS-Voice sync; bursts B–F use a
+// non-voice sync (BS-Data) standing in for embedded signalling so the
+// voice-only SyncDetector ignores them.
+func buildStream(t *testing.T, n, lead int) (stream []uint8, frames [][]byte) {
+	t.Helper()
+	stream = make([]uint8, lead)
+	total := n * FramesPerSuperframe
+	for f := 0; f < total; f++ {
+		frames = append(frames, mkFrame(f))
+	}
+	for s := 0; s < n; s++ {
+		for b := 0; b < BurstsPerSuperframe; b++ {
+			sync := dmr.BSData.Dibits
+			if b == 0 {
+				sync = dmr.BSVoice.Dibits
+			}
+			base := s*FramesPerSuperframe + b*FramesPerBurst
+			stream = append(stream, makeVoiceBurst(frames[base:base+FramesPerBurst], sync)...)
+		}
+	}
+	return stream, frames
+}
+
+func checkFrames(t *testing.T, sf VoiceSuperframe, frames [][]byte, firstFrame int) {
+	t.Helper()
+	for i := 0; i < FramesPerSuperframe; i++ {
+		if !bytes.Equal(sf.Frames[i], frames[firstFrame+i]) {
+			t.Errorf("frame %d:\n got %v\nwant %v", i, sf.Frames[i], frames[firstFrame+i])
+		}
+	}
+}
+
+func TestDecoderExtractsSuperframe(t *testing.T) {
+	stream, frames := buildStream(t, 1, 0)
+
+	d := NewDecoder()
+	got := d.Process(stream, 0)
+
+	if len(got) != 1 {
+		t.Fatalf("got %d superframes, want 1", len(got))
+	}
+	if got[0].SyncName != "BS-Voice" {
+		t.Errorf("SyncName = %q, want BS-Voice", got[0].SyncName)
+	}
+	if got[0].StartDibit != 0 {
+		t.Errorf("StartDibit = %d, want 0", got[0].StartDibit)
+	}
+	checkFrames(t, got[0], frames, 0)
+}
+
+func TestDecoderTwoSuperframes(t *testing.T) {
+	stream, frames := buildStream(t, 2, 0)
+
+	d := NewDecoder()
+	got := d.Process(stream, 0)
+
+	if len(got) != 2 {
+		t.Fatalf("got %d superframes, want 2", len(got))
+	}
+	checkFrames(t, got[0], frames, 0)
+	checkFrames(t, got[1], frames, FramesPerSuperframe)
+	if got[1].StartDibit != superframeDibits {
+		t.Errorf("second StartDibit = %d, want %d", got[1].StartDibit, superframeDibits)
+	}
+}
+
+func TestDecoderLeadingFiller(t *testing.T) {
+	const lead = 137
+	stream, frames := buildStream(t, 1, lead)
+
+	d := NewDecoder()
+	got := d.Process(stream, 0)
+
+	if len(got) != 1 {
+		t.Fatalf("got %d superframes, want 1", len(got))
+	}
+	if got[0].StartDibit != lead {
+		t.Errorf("StartDibit = %d, want %d", got[0].StartDibit, lead)
+	}
+	checkFrames(t, got[0], frames, 0)
+}
+
+func TestDecoderChunkedInput(t *testing.T) {
+	stream, frames := buildStream(t, 1, 0)
+
+	d := NewDecoder()
+	var got []VoiceSuperframe
+	const chunk = 100
+	for off := 0; off < len(stream); off += chunk {
+		end := off + chunk
+		if end > len(stream) {
+			end = len(stream)
+		}
+		got = append(got, d.Process(stream[off:end], off)...)
+	}
+
+	if len(got) != 1 {
+		t.Fatalf("got %d superframes across chunks, want 1", len(got))
+	}
+	checkFrames(t, got[0], frames, 0)
+}
+
+func TestDecoderIncompleteSuperframe(t *testing.T) {
+	stream, _ := buildStream(t, 1, 0)
+	// Truncate to burst A plus two bursts — not a full superframe.
+	truncated := stream[:3*dmr.BurstDibits]
+
+	d := NewDecoder()
+	if got := d.Process(truncated, 0); len(got) != 0 {
+		t.Fatalf("got %d superframes from a partial superframe, want 0", len(got))
+	}
+}
+
+func TestDecoderResetClearsState(t *testing.T) {
+	stream, _ := buildStream(t, 1, 0)
+
+	d := NewDecoder()
+	// Feed burst A only, then reset before the rest arrives.
+	d.Process(stream[:dmr.BurstDibits], 0)
+	d.Reset()
+
+	// A fresh full stream after reset must still decode cleanly.
+	fresh, frames := buildStream(t, 1, 0)
+	got := d.Process(fresh, 0)
+	if len(got) != 1 {
+		t.Fatalf("got %d superframes after reset, want 1", len(got))
+	}
+	checkFrames(t, got[0], frames, 0)
+}


### PR DESCRIPTION
## Summary

Second phase of issue #276. Adds **`internal/radio/dmr/voice/`** — the structural front-end of the DMR voice path.

GopherTrunk's DMR decoders previously handled **control channels only**: voice bursts were sliced and dropped because they carry no slot-type codeword (`tier2`/`tier3` `process.go` discards any burst whose slot-type Hamming fails). This PR builds the layer that recognizes and assembles voice bursts:

- **`VoiceBits` / `AMBEFrames`** — extract a voice burst's 216 payload bits and the three 72-bit on-air AMBE+2 frames it carries (the `108 + 48 + 108` voice-burst layout, which has no slot-type fields, unlike a data burst).
- **`Decoder`** — the voice-burst counterpart of the `tier2`/`tier3` `Process` adapters. It locks onto burst A via the BS/MS/DM voice sync word, then slices bursts B–F at the fixed 132-dibit TDMA cadence (those replace the sync word with embedded signalling, so they produce no sync match). It emits the 18 on-air AMBE frames of each A–F superframe.

Also corrects a stale comment in `internal/radio/dmr/burst.go` — voice bursts carry **three** AMBE frames in a `108+48+108` split, not two.

## Scope / what's next

This PR is the **on-air frame layer only**. It is a self-contained, fully-tested library, not yet wired into the live pipeline — the same staged shape as the RC4 foundation in #298. Still to come:

1. **AMBE forward-error-correction** — the 72-bit on-air frame → 49-bit vocoder payload transform (Golay/Hamming + deinterleave). This needs a bit-exact mbelib reference and is deliberately *not* reconstructed here.
2. **Composer + recorder wiring** — drive the `Decoder` from the per-call composer and feed frames to the recorder.
3. **RC4 descramble + PI-header parsing** — algorithm/key/message-indicator extraction, hooking the #298 RC4 cipher into the voice frames.

Together those produce playable decrypted audio. The README roadmap entry is updated to reflect this staged progress.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./internal/radio/dmr/...` clean
- [x] `go test ./...` — full suite passes
- [x] `internal/radio/dmr/voice/` — 9 tests: burst bit-extraction round-trips, sync-field exclusion, single/multiple superframe extraction, leading filler, chunked (cross-call-boundary) input, incomplete-superframe rejection, decoder reset
- [ ] No on-air capture in `samples/dmr-tier2/`, so real-air validation of the voice path waits for the AMBE-FEC PR — synthetic-stream round-trips cover the structural layer here

Issue #276 stays open until the decode path reaches playable audio.

https://claude.ai/code/session_01MdJGc7Nb7nXv8mBWsDJvWx

---
_Generated by [Claude Code](https://claude.ai/code/session_01MdJGc7Nb7nXv8mBWsDJvWx)_