### PR TITLE
p25/phase1: add coarse AFC to tolerate C4FM carrier offset (#275)

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,6 +403,24 @@ to its own package and lands independently.
 
 ### Recently shipped
 
+- **Coarse AFC: P25 C4FM control channel tolerates a real tuner's
+  frequency offset (issue #275).** A residual RTL-SDR carrier offset
+  leaves the FM discriminator as a constant DC bias; against the C4FM
+  4-level slicer's fixed thresholds that shifted the whole eye off its
+  decision regions, and at ≥500 Hz the Frame Sync Word stopped
+  correlating entirely — the control channel never locked, no matter
+  how the operator swept PPM. A new coarse-AFC stage
+  (`internal/dsp/demod/afc.go`, `demod.CoarseAFC`) sits between the
+  matched filter and the symbol clock on the P25 Phase 1 C4FM path: it
+  tracks the bias with a slow single-pole average (time constant far
+  below the symbol rate, so it follows the carrier offset rather than
+  the data) and subtracts it, recentring the eye. On a clean signal the
+  estimate converges to ~0 and the stage is a near-noop. The #275
+  IQ-impairment harness now hard-asserts a C4FM lock across a
+  ±1500 Hz offset sweep (`TestHarnessC4FMToleratesCarrierOffset`); every
+  impaired C4FM case in the harness — carrier offset, DC spike, IQ
+  imbalance, AWGN, and all combined — now locks, where the carrier-offset
+  cases previously could not detect the FSW at all.
 - **P25 CQPSK control channel now locks on real RTL-SDR chunk sizes
   (issue #275).** The CQPSK / LSM simulcast demod recovered symbols
   correctly only when fed large IQ blocks. The Gardner timing-recovery

--- a/internal/dsp/demod/afc.go
+++ b/internal/dsp/demod/afc.go
@@ -1,0 +1,61 @@
+package demod
+
+// CoarseAFC removes the residual carrier-frequency offset from an
+// FM-discriminator output stream.
+//
+// A constant carrier offset Δf leaves the FM discriminator as a
+// constant DC bias of 2π·Δf/Fs radians/sample. The C4FM 4-level slicer
+// thresholds are fixed, so an un-removed bias shifts every symbol off
+// its decision region and the recovered dibit stream is systematically
+// wrong — on a real RTL-SDR the P25 control channel never locks (issue
+// #275: a ≥500 Hz tuner offset stopped the Frame Sync Word correlating
+// at all).
+//
+// CoarseAFC tracks the bias with a slow single-pole IIR average and
+// subtracts it, recentring the 4-level eye on the slicer thresholds.
+// The averaging pole sits far below the symbol rate, so the estimate
+// follows the carrier offset rather than the data modulation — a
+// balanced 4-level stream has zero mean. On a signal with no offset the
+// estimate converges to ~0 and the stage is a near-noop.
+//
+// It is a coarse correction: it removes the static frequency error a
+// real tuner carries, not per-symbol phase jitter — enough to put the
+// eye back inside the slicer's decision margins.
+type CoarseAFC struct {
+	beta float64 // single-pole smoothing coefficient
+	dc   float64 // current bias estimate
+}
+
+// coarseAFCSymbols is the CoarseAFC averaging time constant in symbol
+// periods. ~64 symbols is slow enough to ignore the 4800-baud data
+// modulation yet converges well inside a typical control-channel
+// warmup preamble.
+const coarseAFCSymbols = 64
+
+// NewCoarseAFC builds a coarse-AFC DC tracker for an FM-discriminator
+// output sampled at sps samples per symbol. Panics if sps is not
+// positive.
+func NewCoarseAFC(sps float64) *CoarseAFC {
+	if sps <= 0 {
+		panic("demod: CoarseAFC sps must be positive")
+	}
+	return &CoarseAFC{beta: 1.0 / (coarseAFCSymbols * sps)}
+}
+
+// Process updates the bias estimate from buf and subtracts it in place.
+// buf is a real FM-discriminator (or matched-filter) output; the
+// estimate carries across calls so a chunked stream converges once.
+func (a *CoarseAFC) Process(buf []float32) {
+	for i, x := range buf {
+		a.dc += a.beta * (float64(x) - a.dc)
+		buf[i] = float32(float64(x) - a.dc)
+	}
+}
+
+// Offset returns the current bias estimate in radians/sample; the
+// residual carrier offset is Offset()·Fs/(2π) hertz.
+func (a *CoarseAFC) Offset() float64 { return a.dc }
+
+// Reset clears the estimate. Call on stream re-tune so a stale offset
+// doesn't bleed across the discontinuity.
+func (a *CoarseAFC) Reset() { a.dc = 0 }

--- a/internal/dsp/demod/afc_test.go
+++ b/internal/dsp/demod/afc_test.go
@@ -1,0 +1,65 @@
+package demod
+
+import (
+	"math"
+	"testing"
+)
+
+// TestCoarseAFCRemovesConstantBias feeds a balanced 4-level stream with
+// a constant DC bias (the signature of a carrier-frequency offset on an
+// FM-discriminator output) and confirms the tracker estimates the bias
+// and subtracts it back to a near-zero-mean stream.
+func TestCoarseAFCRemovesConstantBias(t *testing.T) {
+	const sps = 10
+	const bias = 0.0654 // ≈ 500 Hz offset at 48 kHz, in rad/sample
+	levels := []float32{1, 3, -1, -3}
+
+	buf := make([]float32, 20000)
+	for i := range buf {
+		buf[i] = levels[i%4] + float32(bias)
+	}
+	afc := NewCoarseAFC(sps)
+	afc.Process(buf)
+
+	if math.Abs(afc.Offset()-bias) > 0.05*bias {
+		t.Errorf("Offset() = %.5f, want within 5%% of %.5f", afc.Offset(), bias)
+	}
+	// After convergence the corrected stream's mean should be ~0 (the
+	// balanced levels), not the input mean of `bias`.
+	var sum float64
+	tail := buf[len(buf)-4000:]
+	for _, x := range tail {
+		sum += float64(x)
+	}
+	if mean := sum / float64(len(tail)); math.Abs(mean) > 0.01 {
+		t.Errorf("post-AFC tail mean = %.4f, want ≈ 0", mean)
+	}
+}
+
+// TestCoarseAFCResetClearsEstimate confirms Reset returns the tracker
+// to its initial state so a re-tune doesn't carry a stale offset.
+func TestCoarseAFCResetClearsEstimate(t *testing.T) {
+	afc := NewCoarseAFC(10)
+	buf := make([]float32, 5000)
+	for i := range buf {
+		buf[i] = 0.2
+	}
+	afc.Process(buf)
+	if afc.Offset() == 0 {
+		t.Fatalf("Offset() = 0 after processing a biased stream, want non-zero")
+	}
+	afc.Reset()
+	if afc.Offset() != 0 {
+		t.Errorf("Offset() = %v after Reset, want 0", afc.Offset())
+	}
+}
+
+// TestNewCoarseAFCRejectsBadSps documents the constructor precondition.
+func TestNewCoarseAFCRejectsBadSps(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Error("NewCoarseAFC(0) did not panic")
+		}
+	}()
+	NewCoarseAFC(0)
+}

--- a/internal/radio/p25/phase1/receiver/harness_test.go
+++ b/internal/radio/p25/phase1/receiver/harness_test.go
@@ -293,6 +293,26 @@ func TestHarnessCQPSKChunkBoundary(t *testing.T) {
 	}
 }
 
+// TestHarnessC4FMToleratesCarrierOffset guards the coarse-AFC fix for
+// issue #275. A residual RTL-SDR tuner offset appears as a DC bias on
+// the FM-discriminator output; left in place it shifts the 4-level eye
+// off the slicer's fixed thresholds, and at ≥500 Hz the C4FM Frame Sync
+// Word stopped correlating entirely so the control channel never
+// locked. The coarse-AFC stage tracks and subtracts that bias, so the
+// channel locks across a realistic offset range.
+func TestHarnessC4FMToleratesCarrierOffset(t *testing.T) {
+	for _, offHz := range []float64{-1500, -800, -500, 500, 800, 1000, 1500} {
+		t.Run(fmt.Sprintf("%+gHz", offHz), func(t *testing.T) {
+			res := runHarness(DemodC4FM, demod.Impairments{FreqOffsetHz: offHz})
+			if !res.locked {
+				t.Errorf("C4FM did not lock at %+g Hz carrier offset "+
+					"(decodeErrors=%d, nidErrs min/max/n=%s)",
+					offHz, res.decodeErrors, res.nidErrsSummary())
+			}
+		})
+	}
+}
+
 // TestHarnessImpairedControlChannelCharacterization runs each realistic
 // RTL-SDR impairment through the real demod chain and logs whether the
 // control channel still locks and how the NID decoder fared. It is

--- a/internal/radio/p25/phase1/receiver/receiver.go
+++ b/internal/radio/p25/phase1/receiver/receiver.go
@@ -8,9 +8,12 @@
 //	DemodC4FM (default):
 //	  IQ
 //	    → FM discriminator (internal/dsp/demod.FM)
-//	    → RRC matched filter + 4-level slicer (internal/dsp/demod.C4FM)
+//	    → RRC matched filter (internal/dsp/demod.C4FM)
+//	    → coarse AFC: residual carrier-offset removal
+//	      (internal/dsp/demod.CoarseAFC)
 //	    → Mueller-Müller symbol clock recovery (sync.MuellerMuller)
-//	    → C4FM symbol → 0..3 dibit (phase1.SymbolToDibit)
+//	    → 4-level slicer → C4FM symbol → 0..3 dibit
+//	      (internal/dsp/demod.C4FM, phase1.SymbolToDibit)
 //
 //	DemodCQPSK (LSM / simulcast):
 //	  IQ
@@ -127,10 +130,12 @@ type Options struct {
 type Receiver struct {
 	demodMode DemodMode
 
-	// C4FM path: FM discriminator → real RRC + 4-level slicer →
-	// Mueller-Müller. Allocated only when demodMode == DemodC4FM.
+	// C4FM path: FM discriminator → real RRC matched filter →
+	// coarse-AFC carrier-offset removal → Mueller-Müller → 4-level
+	// slicer. Allocated only when demodMode == DemodC4FM.
 	fm    *demod.FM
 	mf    *demod.C4FM
+	afc   *demod.CoarseAFC
 	clock *sync.MuellerMuller
 
 	// CQPSK / LSM path: complex RRC + Gardner + DQPSK quadrant
@@ -206,6 +211,7 @@ func New(opts Options) *Receiver {
 	default:
 		r.fm = demod.NewFM()
 		r.mf = demod.NewC4FM(int(sps+0.5), span, alpha, slicerScale)
+		r.afc = demod.NewCoarseAFC(sps)
 		r.clock = sync.NewMuellerMuller(sps, gain)
 	}
 	if opts.Sink != nil {
@@ -231,6 +237,11 @@ func (r *Receiver) Process(iq []complex64) {
 	} else {
 		r.disc = r.fm.Process(r.disc, iq)
 		r.matched = r.mf.MatchedFilter(r.matched, r.disc)
+		// Coarse AFC: track and subtract the residual carrier-offset
+		// DC bias before the symbol clock + slicer see it, so a real
+		// tuner's frequency error doesn't shift the 4-level eye off
+		// the slicer's fixed thresholds (issue #275).
+		r.afc.Process(r.matched)
 		r.symbols = r.clock.Process(r.symbols, r.matched)
 		if len(r.symbols) == 0 {
 			return
@@ -269,6 +280,9 @@ func (r *Receiver) Reset() {
 	r.dibitBase = 0
 	if r.cq != nil {
 		r.cq.reset()
+	}
+	if r.afc != nil {
+		r.afc.Reset()
 	}
 	// FM discriminator's `last` is harmless to leave alone — the
 	// next sample it processes will produce one slightly-wrong


### PR DESCRIPTION
## Summary

The coarse-AFC follow-up to #275. After the Gardner chunk-boundary fix (#300) the CQPSK path locks; this fixes the remaining **C4FM** failure the #275 harness still characterised.

A residual RTL-SDR tuner frequency offset leaves the FM discriminator as a constant DC bias of `2π·Δf/Fs` rad/sample. The C4FM 4-level slicer thresholds are fixed, so an un-removed bias shifts the whole eye off its decision regions — at ≥500 Hz the inner symbols misclassify and the Frame Sync Word stops correlating entirely, so the control channel never locks. Sweeping PPM doesn't help once the offset exceeds the slicer margin (matching the reporter's observation that PPM sweeps changed nothing).

## What changed

- **`internal/dsp/demod/afc.go`** — new `CoarseAFC`: a slow single-pole DC tracker. It estimates the bias and subtracts it. The averaging time constant (~64 symbols) sits far below the 4800-baud symbol rate, so the estimate follows the carrier offset, not the balanced data modulation; on a clean signal it converges to ~0 and the stage is a near-noop.
- **`internal/radio/p25/phase1/receiver/receiver.go`** — wires `CoarseAFC` into the P25 Phase 1 C4FM path, between the RRC matched filter and the Mueller-Müller clock, so both the symbol clock and the slicer see a recentred eye. The differential CQPSK path is untouched (no FM discriminator; inherently offset-tolerant), and the shared `demod.C4FM` primitive is untouched, so the other C4FM-family receivers (DMR / NXDN / YSF / dPMR) are unaffected.
- **`internal/radio/p25/phase1/receiver/harness_test.go`** — new `TestHarnessC4FMToleratesCarrierOffset` hard-asserts a C4FM lock across a ±1500 Hz offset sweep, as a permanent regression guard.
- **`internal/dsp/demod/afc_test.go`** — unit tests for the tracker.
- **`README.md`** — "Recently shipped" entry.

## Verification

- **Before:** the #275 harness `freq_offset_500hz` / `freq_offset_1500hz` / `combined` C4FM cases could not detect the FSW at all (no lock).
- **After:** every impaired C4FM harness case — carrier offset, DC spike, IQ imbalance, AWGN, and all combined — now locks; `TestHarnessC4FMToleratesCarrierOffset` passes across the ±1500 Hz sweep.
- Clean-signal C4FM lock, the CQPSK path, `go test ./...`, `go vet ./...`, `-race` on the affected packages, and `make integration-cc` (ideal-IQ P25 Phase 1 end-to-end) are all unaffected.

## #275 status

With #299 (diagnostics + repro harness), #300 (CQPSK chunk-boundary fix), and this PR (C4FM coarse AFC), both demod paths now lock on the realistic RTL-SDR impairments the harness reproduces. The coarse AFC corrects a static frequency error, not per-symbol phase jitter — sufficient for the residual offsets a real tuner carries.

https://claude.ai/code/session_01Qc4zddc3oMNFsM6JCcXEn6

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qc4zddc3oMNFsM6JCcXEn6)_