### PR TITLE
composer: wire DMR voice chain to the recorder (#276)

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,15 +346,16 @@ to its own package and lands independently.
   dependency-free RC4 keystream generator
   ([`internal/crypto/rc4/`](internal/crypto/rc4/)) and the DMR voice
   superframe decoder ([`internal/radio/dmr/voice/`](internal/radio/dmr/voice/))
-  have shipped — the latter locks onto the A–F voice superframe and
-  extracts its 18 on-air AMBE+2 frames, the voice path GopherTrunk
-  previously lacked entirely (DMR decoded control channels only). The
-  remaining work is the AMBE forward-error-correction (72-bit on-air
-  frame → 49-bit vocoder payload), wiring the voice decoder into the
-  per-call composer + recorder, and the RC4 descramble + PI-header
-  (algorithm / key / message-indicator) parsing that together produce
-  playable decrypted audio. Decryption is known-key only — no key
-  recovery — matching the SDRTrunk / DSD-FME / OP25 model.
+  have shipped, and the composer now runs a DMR voice chain end to
+  end: a DMR voice grant drives an IQ → DMR receiver → superframe
+  decoder pipeline whose on-air AMBE+2 frames are written to the
+  call's `.raw` sidecar (the voice path GopherTrunk previously lacked
+  entirely — DMR decoded control channels only). The remaining work is
+  the AMBE forward-error-correction (72-bit on-air frame → 49-bit
+  vocoder payload), and the RC4 descramble + PI-header (algorithm /
+  key / message-indicator) parsing that together turn the `.raw`
+  capture into playable decrypted audio. Decryption is known-key only
+  — no key recovery — matching the SDRTrunk / DSD-FME / OP25 model.
 - **DVSI USB-3000 / AMBE-3003 hardware backend (USB transport).**
   The `Vocoder` + AMBE-3003 wire protocol + `voice.Vocoder` interface
   conformance ship in [`internal/voice/dvsi/`](internal/voice/dvsi/)

--- a/internal/voice/composer/composer.go
+++ b/internal/voice/composer/composer.go
@@ -13,12 +13,11 @@
 // engine's silent-call watchdog doesn't kill the call
 // mid-conversation.
 //
-// Digital protocols (P25 / DMR / NXDN) need vocoders that haven't
-// landed yet — IMBE for P25 Phase 1 is in progress and AMBE+2 stays
-// behind a build tag. Until they ship, a digital grant produces no
-// PCM and only the raw-frame sidecar (when WriteRaw is enabled, or
-// always for EDACS ProVoice grants) is useful. The composer logs a
-// warning per digital grant so the behaviour is visible in operations.
+// DMR voice grants run a dedicated chain (see dmr_voice.go): IQ →
+// DMR receiver → voice superframe decoder → on-air AMBE frames
+// appended to the recorder's .raw sidecar. Other digital protocols
+// (P25, NXDN, ...) have no composer chain yet — their grants are
+// logged and bypassed.
 package composer
 
 import (
@@ -341,17 +340,14 @@ func (c *Composer) ActiveChains() []string {
 }
 
 func (c *Composer) handleStart(parent context.Context, cs trunking.CallStart) {
-	if cs.Grant.Protocol != "" && cs.Grant.Protocol != "fm" && cs.Grant.Protocol != "analog" {
-		// Digital protocols are decoded out of the recorder's
-		// WriteRawFrame path: the recorder auto-instantiates the
-		// vocoder for the call's protocol (see
-		// voice.DefaultVocoderForProtocol) and writes the decoded
-		// PCM into the WAV. The composer's job for digital is the
-		// IQ → vocoder-frame extraction (in the protocol-specific
-		// radio decoder); FM demod doesn't apply because the IQ
-		// carries C4FM / H-DQPSK / 4FSK symbols, not analog audio.
-		c.log.Info("composer: digital protocol; FM chain bypassed (vocoder decode runs in recorder)",
-			"device", cs.DeviceSerial, "protocol", cs.Grant.Protocol,
+	proto := cs.Grant.Protocol
+	isFM := proto == "" || proto == "fm" || proto == "analog"
+	isDMRVoice := proto == "dmr-tier2" || proto == "dmr-tier3"
+	if !isFM && !isDMRVoice {
+		// Other digital protocols (P25, NXDN, ...) have no composer
+		// voice chain yet — their voice bursts are not decoded.
+		c.log.Info("composer: digital protocol not yet decoded; chain bypassed",
+			"device", cs.DeviceSerial, "protocol", proto,
 			"group", cs.Grant.GroupID)
 		return
 	}
@@ -381,7 +377,11 @@ func (c *Composer) handleStart(parent context.Context, cs trunking.CallStart) {
 	c.chains[cs.DeviceSerial] = ch
 	c.mu.Unlock()
 
-	go c.runFMChain(chainCtx, cs.DeviceSerial, iqCh, ch.done)
+	if isDMRVoice {
+		go c.runDMRVoiceChain(chainCtx, cs.DeviceSerial, iqCh, ch.done)
+	} else {
+		go c.runFMChain(chainCtx, cs.DeviceSerial, iqCh, ch.done)
+	}
 }
 
 func (c *Composer) handleEnd(ce trunking.CallEnd) {

--- a/internal/voice/composer/composer_test.go
+++ b/internal/voice/composer/composer_test.go
@@ -51,6 +51,7 @@ func (d *fakeDevices) FindBySerial(s string) IQSource { return d.src[s] }
 type recordingSink struct {
 	mu  sync.Mutex
 	pcm map[string][]int16
+	raw map[string][][]byte
 }
 
 func (r *recordingSink) WritePCM(serial string, samples []int16) error {
@@ -63,10 +64,28 @@ func (r *recordingSink) WritePCM(serial string, samples []int16) error {
 	return nil
 }
 
+func (r *recordingSink) WriteRawFrame(serial string, frame []byte) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.raw == nil {
+		r.raw = make(map[string][][]byte)
+	}
+	r.raw[serial] = append(r.raw[serial], append([]byte(nil), frame...))
+	return nil
+}
+
 func (r *recordingSink) total(serial string) int {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	return len(r.pcm[serial])
+}
+
+func (r *recordingSink) rawFrames(serial string) [][]byte {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([][]byte, len(r.raw[serial]))
+	copy(out, r.raw[serial])
+	return out
 }
 
 type fakeEngine struct {

--- a/internal/voice/composer/dmr_voice.go
+++ b/internal/voice/composer/dmr_voice.go
@@ -1,0 +1,113 @@
+package composer
+
+import (
+	"context"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/filter"
+	dmrrx "github.com/MattCheramie/GopherTrunk/internal/radio/dmr/receiver"
+	dmrvoice "github.com/MattCheramie/GopherTrunk/internal/radio/dmr/voice"
+)
+
+// dmrVoiceIntermediateHz is the rate the wideband IQ is decimated to
+// before the DMR receiver runs. 48 kHz gives the 4800-baud DMR symbol
+// stream 10 samples per symbol — ample for the receiver's RRC matched
+// filter and Mueller-Müller clock recovery, without the cost of
+// running them at the SDR's native multi-MS/s rate.
+const dmrVoiceIntermediateHz = 48_000
+
+// rawFrameSink is the subset of voice.Recorder the DMR voice chain
+// needs. The composer holds its sink as a PCMSink; runDMRVoiceChain
+// type-asserts to this, so a sink that only implements WritePCM
+// (analog-only callers, test stubs) still works for the FM path.
+type rawFrameSink interface {
+	WriteRawFrame(deviceSerial string, frame []byte) error
+}
+
+// runDMRVoiceChain consumes IQ for one DMR voice call. It decimates
+// the wideband IQ to a DMR-symbol-friendly rate, recovers the dibit
+// stream with the shared DMR receiver, assembles A–F voice
+// superframes, and appends each superframe's 18 on-air AMBE+2 frames
+// (72 bits, packed MSB-first into 9 bytes) to the recorder's .raw
+// sidecar.
+//
+// AMBE forward-error-correction and vocoder decode are deliberately
+// not applied here: the .raw sidecar carries the on-air frames for
+// out-of-band decode until the AMBE FEC layer lands (issue #276).
+func (c *Composer) runDMRVoiceChain(ctx context.Context, serial string, iqCh <-chan []complex64, done chan<- struct{}) {
+	defer close(done)
+
+	decim := int(c.iqHz) / dmrVoiceIntermediateHz
+	if decim < 1 {
+		decim = 1
+	}
+	symbolHz := float64(c.iqHz) / float64(decim)
+
+	// Front-end LPF: doubles as the anti-aliasing filter for the
+	// decimation, so it is only needed when the IQ is actually
+	// decimated (the live multi-MS/s path; decim == 1 only in tests
+	// that feed IQ already at the intermediate rate).
+	cutoff := float64(c.bw) / float64(c.iqHz)
+	if cutoff > 0.45 {
+		cutoff = 0.45
+	}
+	lpf := filter.NewFIR(filter.LowpassKaiser(81, cutoff, 8.6))
+
+	rs, _ := c.sink.(rawFrameSink)
+	voiceDec := dmrvoice.NewDecoder()
+	rx := dmrrx.New(dmrrx.Options{
+		SampleRateHz: symbolHz,
+		// DMR spec peak deviation per ETSI TS 102 361-1 §6.3 — matches
+		// the control-channel receiver in internal/scanner/ccdecoder.
+		DeviationHz: 1944.0,
+		ClockGain:   0.025,
+		DibitSink: func(dibits []uint8, baseIdx int) {
+			if rs == nil {
+				return
+			}
+			for _, sf := range voiceDec.Process(dibits, baseIdx) {
+				for i := range sf.Frames {
+					if err := rs.WriteRawFrame(serial, packAMBEFrame(sf.Frames[i])); err != nil {
+						c.log.Warn("composer: DMR raw-frame write failed",
+							"serial", serial, "err", err)
+					}
+				}
+			}
+		},
+	})
+
+	touchTicker := time.NewTicker(c.touchEvery)
+	defer touchTicker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-touchTicker.C:
+			if c.engine != nil {
+				c.engine.Touch(serial)
+			}
+		case iq, ok := <-iqCh:
+			if !ok {
+				return
+			}
+			samples := iq
+			if decim > 1 {
+				samples = decimateComplex(lpf.Process(nil, iq), decim)
+			}
+			rx.Process(samples)
+		}
+	}
+}
+
+// packAMBEFrame packs a 72-element bit slice (one bit per byte,
+// MSB-first) into 9 bytes for the .raw sidecar.
+func packAMBEFrame(bits []byte) []byte {
+	out := make([]byte, (len(bits)+7)/8)
+	for i := range bits {
+		if bits[i]&1 != 0 {
+			out[i>>3] |= 1 << uint(7-(i&7))
+		}
+	}
+	return out
+}

--- a/internal/voice/composer/dmr_voice_test.go
+++ b/internal/voice/composer/dmr_voice_test.go
@@ -1,0 +1,194 @@
+package composer
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/demod"
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/dmr"
+	dmrvoice "github.com/MattCheramie/GopherTrunk/internal/radio/dmr/voice"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+func TestPackAMBEFrame(t *testing.T) {
+	bits := make([]byte, dmrvoice.AMBEFrameBits)
+	for i := range bits {
+		if i%3 == 0 {
+			bits[i] = 1
+		}
+	}
+	got := packAMBEFrame(bits)
+	if len(got) != 9 {
+		t.Fatalf("packed length = %d, want 9", len(got))
+	}
+	for i := 0; i < dmrvoice.AMBEFrameBits; i++ {
+		bit := (got[i>>3] >> uint(7-(i&7))) & 1
+		want := byte(0)
+		if i%3 == 0 {
+			want = 1
+		}
+		if bit != want {
+			t.Errorf("bit %d = %d, want %d", i, bit, want)
+		}
+	}
+}
+
+// mkAMBEFrame builds a deterministic, unique 72-bit AMBE frame from
+// seed (one bit per byte) via a small LCG so every frame in a test
+// stream is distinct.
+func mkAMBEFrame(seed int) []byte {
+	f := make([]byte, dmrvoice.AMBEFrameBits)
+	x := uint32(seed)*2654435761 + 1
+	for i := range f {
+		x = x*1664525 + 1013904223
+		f[i] = byte(x >> 31)
+	}
+	return f
+}
+
+// voiceBurstDibits assembles a 132-dibit voice burst from three 72-bit
+// AMBE frames and a 24-dibit sync / embedded-signalling field.
+func voiceBurstDibits(frames [][]byte, sync [24]uint8) []uint8 {
+	var bits []byte
+	for _, f := range frames {
+		bits = append(bits, f...)
+	}
+	toD := func(b []byte) []uint8 {
+		d := make([]uint8, len(b)/2)
+		for i := range d {
+			d[i] = b[2*i]<<1 | b[2*i+1]
+		}
+		return d
+	}
+	out := make([]uint8, 0, dmr.BurstDibits)
+	out = append(out, toD(bits[:108])...)
+	out = append(out, sync[:]...)
+	out = append(out, toD(bits[108:])...)
+	return out
+}
+
+// buildVoiceStream assembles a dibit stream of n DMR voice superframes
+// preceded by a lead-in (transitions so the receiver's clock recovery
+// settles), and returns the 18*n AMBE frames it carries.
+func buildVoiceStream(n int) (dibits []uint8, frames [][]byte) {
+	dibits = make([]uint8, 240)
+	for i := range dibits {
+		dibits[i] = uint8(i % 4)
+	}
+	for f := 0; f < n*dmrvoice.FramesPerSuperframe; f++ {
+		frames = append(frames, mkAMBEFrame(f))
+	}
+	for s := 0; s < n; s++ {
+		for b := 0; b < dmrvoice.BurstsPerSuperframe; b++ {
+			sync := dmr.BSData.Dibits
+			if b == 0 {
+				sync = dmr.BSVoice.Dibits
+			}
+			base := s*dmrvoice.FramesPerSuperframe + b*dmrvoice.FramesPerBurst
+			dibits = append(dibits, voiceBurstDibits(frames[base:base+dmrvoice.FramesPerBurst], sync)...)
+		}
+	}
+	return dibits, frames
+}
+
+// TestComposerDMRVoiceChainExtractsRawFrames drives the full composer
+// DMR voice path — modulated IQ → DMR receiver → voice superframe
+// decoder → packed AMBE frames → recorder .raw sidecar — and confirms
+// a decoded superframe matches the modulated input exactly.
+func TestComposerDMRVoiceChainExtractsRawFrames(t *testing.T) {
+	const (
+		sampleRate  = 48_000.0
+		sps         = 10
+		span        = 8
+		alpha       = 0.20
+		deviation   = 1944.0
+		superframes = 12
+	)
+	dibits, frames := buildVoiceStream(superframes)
+	iq := demod.ModulateC4FM(dibits, sps, span, alpha, sampleRate, deviation)
+
+	src := newFakeSource()
+	bus := events.NewBus(8)
+	sink := &recordingSink{}
+	eng := &fakeEngine{}
+	c, err := New(Options{
+		Bus:           bus,
+		Devices:       &fakeDevices{src: map[string]IQSource{"VOICE-1": src}},
+		Sink:          sink,
+		Engine:        eng,
+		IQSampleRate:  uint32(sampleRate),
+		PCMSampleRate: 8000,
+		TouchInterval: 30 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go c.Run(ctx)
+	defer c.Close()
+	defer bus.Close()
+
+	bus.Publish(events.Event{
+		Kind: events.KindCallStart,
+		Payload: trunking.CallStart{
+			Grant: trunking.Grant{
+				System: "DMRSite", Protocol: "dmr-tier3",
+				GroupID: 7, FrequencyHz: 460_000_000,
+			},
+			DeviceSerial: "VOICE-1",
+			StartedAt:    time.Now().UTC(),
+		},
+	})
+
+	// Wait for the chain to start (StreamIQ called) before feeding IQ.
+	waitFor(t, 2*time.Second, func() bool { return len(c.ActiveChains()) == 1 })
+	src.SendIQ(iq)
+
+	waitFor(t, 4*time.Second, func() bool {
+		return len(sink.rawFrames("VOICE-1")) >= dmrvoice.FramesPerSuperframe
+	})
+
+	got := sink.rawFrames("VOICE-1")
+	if len(got) == 0 || len(got)%dmrvoice.FramesPerSuperframe != 0 {
+		t.Fatalf("got %d raw frames, want a non-zero multiple of %d",
+			len(got), dmrvoice.FramesPerSuperframe)
+	}
+	for _, f := range got {
+		if len(f) != 9 {
+			t.Fatalf("raw frame length = %d, want 9 (72 bits packed)", len(f))
+		}
+	}
+
+	// At least one decoded superframe must match an input superframe
+	// exactly — proving the chain extracts the right bits in order.
+	if !matchesAnySuperframe(got, frames) {
+		t.Errorf("no decoded superframe matched an input superframe exactly")
+	}
+
+	// The chain keeps the call alive via Engine.Touch; the ticker may
+	// not have fired yet when the frames landed, so wait for it.
+	waitFor(t, time.Second, func() bool { return eng.touched.Load() > 0 })
+}
+
+func matchesAnySuperframe(got [][]byte, frames [][]byte) bool {
+	const sf = dmrvoice.FramesPerSuperframe
+	for in := 0; in+sf <= len(frames); in += sf {
+		for g := 0; g+sf <= len(got); g += sf {
+			ok := true
+			for k := 0; k < sf; k++ {
+				if !bytes.Equal(got[g+k], packAMBEFrame(frames[in+k])) {
+					ok = false
+					break
+				}
+			}
+			if ok {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/internal/voice/recorder.go
+++ b/internal/voice/recorder.go
@@ -102,15 +102,27 @@ type RecorderOptions struct {
 // call) and mutate from there — RecorderOptions.VocoderForProtocol
 // is taken as-is, no merging.
 func DefaultVocoderForProtocol() map[string]string {
+	// DMR is intentionally absent: the composer's DMR voice chain
+	// emits pre-FEC 72-bit on-air AMBE frames, which the AMBE+2
+	// vocoder (49-bit post-FEC frames) cannot decode. DMR voice calls
+	// get a .raw sidecar instead; the mapping returns once the AMBE
+	// forward-error-correction lands (issue #276).
 	return map[string]string{
 		"p25":        "imbe",  // P25 Phase 1 — IMBE 4400
 		"p25-phase2": "ambe2", // P25 Phase 2 — AMBE+2 2400
-		"dmr-tier2":  "ambe2", // DMR Tier II conventional
-		"dmr-tier3":  "ambe2", // DMR Tier III trunked
 		"nxdn":       "ambe2",
 		"dpmr":       "ambe2", // dPMR Mode 3 (digital)
 		"tetra":      "ambe2", // TETRA voice
 	}
+}
+
+// dmrVoiceProtocol reports whether protocol is a DMR voice protocol.
+// DMR voice calls always get a .raw sidecar: the recorder has no
+// in-process vocoder for DMR yet (see DefaultVocoderForProtocol), so
+// the on-air AMBE frames the composer extracts are the only capture
+// of the call.
+func dmrVoiceProtocol(protocol string) bool {
+	return protocol == "dmr-tier2" || protocol == "dmr-tier3"
 }
 
 // NewRecorder validates options and returns a recorder ready to Run.
@@ -314,9 +326,10 @@ func (r *Recorder) handleStart(cs trunking.CallStart) {
 		return
 	}
 	s := &recordingSession{wav: wav, wavPath: wavPath, startedAt: cs.StartedAt}
-	// ProVoice grants always get a sidecar — the vocoder isn't decodable
-	// in-process, so the .raw file is the only way to capture the call.
-	if r.writeRaw || cs.Grant.ProVoice {
+	// ProVoice and DMR voice grants always get a sidecar — neither has
+	// an in-process vocoder, so the .raw file is the only capture of
+	// the call.
+	if r.writeRaw || cs.Grant.ProVoice || dmrVoiceProtocol(cs.Grant.Protocol) {
 		rawPath := filepath.Join(dir, base+".raw")
 		raw, err := os.Create(rawPath)
 		if err != nil {

--- a/internal/voice/recorder_test.go
+++ b/internal/voice/recorder_test.go
@@ -631,11 +631,10 @@ func TestRecorderUnknownVocoderNameLogsAndProceeds(t *testing.T) {
 // silently drop a digital protocol from the auto-decode path.
 func TestDefaultVocoderForProtocolMappings(t *testing.T) {
 	got := DefaultVocoderForProtocol()
+	// DMR is intentionally absent — see DefaultVocoderForProtocol.
 	want := map[string]string{
 		"p25":        "imbe",
 		"p25-phase2": "ambe2",
-		"dmr-tier2":  "ambe2",
-		"dmr-tier3":  "ambe2",
 		"nxdn":       "ambe2",
 		"dpmr":       "ambe2",
 		"tetra":      "ambe2",


### PR DESCRIPTION
## Summary

Third phase of issue #276. Wires the DMR voice decoder (shipped in #301) into the live per-call pipeline.

DMR voice grants previously hit the composer's digital-protocol bypass: the engine followed the call but **no chain ran**, so the call wasn't kept alive (the silent-call watchdog cut it) and nothing was captured. This PR runs the DMR voice path end to end:

- **`runDMRVoiceChain`** — a per-call composer chain that decimates the wideband IQ to a DMR-symbol rate, recovers the dibit stream with the shared `dmr/receiver`, assembles A–F voice superframes with `dmr/voice`, and appends each superframe's 18 on-air AMBE+2 frames (72 bits, packed into 9 bytes) to the recorder's `.raw` sidecar. It `Touch`es the engine so the call runs for its real duration.
- **`handleStart`** routes `dmr-tier2` / `dmr-tier3` grants to the new chain; other digital protocols (P25, NXDN) still bypass.
- **Recorder** — DMR voice grants always get a `.raw` sidecar (like EDACS ProVoice), and DMR is dropped from `DefaultVocoderForProtocol`: the AMBE+2 vocoder expects 49-bit post-FEC frames, not the 72-bit on-air frames this chain emits.

Net effect: a DMR voice call is now **followed, kept alive, and captured** as a `.raw` of on-air AMBE frames + logged with correct duration — the first time DMR voice produces any output.

## Scope / what's next

The `.raw` sidecar holds the **on-air** AMBE frames. Turning that capture into playable decrypted audio still needs:

1. **AMBE forward-error-correction** — 72-bit on-air frame → 49-bit vocoder payload. Needs a bit-exact mbelib reference; deliberately not reconstructed from memory.
2. **RC4 descramble + PI-header parsing** — algorithm / key / message-indicator extraction, hooking the #298 RC4 cipher into the frames.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./internal/voice/...` clean
- [x] `go test ./...` — full unit suite passes
- [x] `TestComposerDMRVoiceChainExtractsRawFrames` — end-to-end: modulates a 12-superframe DMR voice IQ stream with `ModulateC4FM`, feeds it through the composer chain, and confirms a decoded superframe matches the modulated input **exactly** (18 frames, in order) and the engine is `Touch`ed
- [x] `TestPackAMBEFrame` — 72-bit → 9-byte packing
- [x] `make integration-cc-dmr` (Tier III) and `TestDaemonCCDecodesDMRTier2` both still pass — the composer change doesn't disturb the control-channel path

Issue #276 stays open until the decode path reaches playable audio.

https://claude.ai/code/session_01MdJGc7Nb7nXv8mBWsDJvWx

---
_Generated by [Claude Code](https://claude.ai/code/session_01MdJGc7Nb7nXv8mBWsDJvWx)_