### PR TITLE
p25/phase1: equalize the CQPSK path for simulcast multipath (#275)

### DIFF
--- a/internal/dsp/demod/impair.go
+++ b/internal/dsp/demod/impair.go
@@ -16,6 +16,16 @@ import (
 // input through unchanged. Each field is independent; combine them to
 // model a realistic capture.
 type Impairments struct {
+	// Multipath is a complex channel FIR modelling a multipath /
+	// simulcast propagation path: the received signal becomes
+	// y[n] = Σ Multipath[k]·x[n-k], where Multipath[k] is the complex
+	// gain of the copy arriving k samples late (Multipath[0] is the
+	// main path). Nil or empty applies no multipath. This is the
+	// inter-symbol-interference source a single-transmitter flat-fading
+	// model cannot produce — it reproduces what the overlapping,
+	// differently-delayed transmitters of a simulcast system do to a
+	// control channel.
+	Multipath []complex64
 	// FreqOffsetHz is a residual carrier frequency offset — tuner
 	// crystal ppm error, or a channel that is not exactly centred in
 	// the SDR passband. Applied as a per-sample phase ramp.
@@ -48,6 +58,23 @@ func ApplyImpairments(iq []complex64, sampleRateHz float64, imp Impairments) []c
 	copy(out, iq)
 	if len(out) == 0 {
 		return out
+	}
+
+	// Multipath / simulcast channel: convolve with the channel FIR
+	// before any receiver-side impairment (multipath is a propagation
+	// effect, upstream of the LO and front-end). out currently mirrors
+	// iq; rebuild it as y[n] = Σ Multipath[k]·iq[n-k].
+	if len(imp.Multipath) > 0 {
+		for n := range out {
+			var acc complex64
+			for k, tap := range imp.Multipath {
+				if n-k < 0 {
+					break
+				}
+				acc += tap * iq[n-k]
+			}
+			out[n] = acc
+		}
 	}
 
 	// IQ gain / phase imbalance: keep I pure, distort Q.

--- a/internal/radio/p25/phase1/receiver/cqpsk.go
+++ b/internal/radio/p25/phase1/receiver/cqpsk.go
@@ -4,6 +4,7 @@ import (
 	"math"
 
 	"github.com/MattCheramie/GopherTrunk/internal/dsp/demod"
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/equalizer"
 	"github.com/MattCheramie/GopherTrunk/internal/dsp/sync"
 )
 
@@ -29,10 +30,26 @@ const lsmRotation = math.Pi / 4
 // demodulation — no rotation search needed for the CQPSK path itself.
 var lsmDibitRemap = [4]uint8{0, 1, 3, 2}
 
+// cqpskEqualizerTaps / cqpskEqualizerStep configure the CMA blind
+// equalizer on the CQPSK symbol stream. The post-Gardner LSM symbols
+// are unit-modulus QPSK points, so the Constant Modulus Algorithm
+// applies: simulcast multipath blurs that constant magnitude and CMA
+// drives it back, opening the constellation so the FSW correlates.
+const (
+	cqpskEqualizerTaps = 11
+	cqpskEqualizerStep = 0.005
+)
+
 // cqpskDemod is the LSM / linear-CQPSK symbol recovery chain for P25
 // Phase 1. It wraps the shared PiOver4DQPSK primitive at rotation π/4
 // and applies lsmDibitRemap so the dibits it emits are interchangeable
 // with the C4FM path downstream.
+//
+// A CMA blind equalizer sits on the recovered symbol stream. LSM is a
+// linear modulation, so simulcast multipath is a linear distortion of
+// the complex symbols and an equalizer can invert it — this is the
+// path simulcast P25 sites need (issue #275: strong multipath closed
+// the constellation and the Frame Sync Word never correlated).
 //
 // Gardner timing-recovery is mandatory on this path (the demod operates
 // on complex IQ at the sample rate; naive every-sps-th decimation
@@ -41,6 +58,7 @@ var lsmDibitRemap = [4]uint8{0, 1, 3, 2}
 type cqpskDemod struct {
 	dq      *demod.PiOver4DQPSK
 	gardner *sync.Gardner
+	cma     *equalizer.CMA
 
 	// Scratch buffers reused across calls.
 	matched []complex64
@@ -59,6 +77,7 @@ func newCQPSKDemod(sps int, span int, alpha float64, gardnerGain float64) *cqpsk
 	return &cqpskDemod{
 		dq:      demod.NewPiOver4DQPSK(sps, span, alpha, lsmRotation),
 		gardner: sync.NewGardner(float64(sps), gardnerGain),
+		cma:     equalizer.NewCMA(cqpskEqualizerTaps, cqpskEqualizerStep, 1.0),
 	}
 }
 
@@ -74,6 +93,12 @@ func (c *cqpskDemod) process(iq []complex64) []uint8 {
 		c.dibits = c.dibits[:0]
 		return c.dibits
 	}
+	// Blind equalizer: CMA pulls the symbols back to constant modulus,
+	// undoing the simulcast-multipath ISI that closes the constellation.
+	for i, s := range c.symbols {
+		y, _ := c.cma.Process(s)
+		c.symbols[i] = y
+	}
 	c.dibits = c.dq.Decode(c.dibits, c.symbols)
 	for i, d := range c.dibits {
 		c.dibits[i] = lsmDibitRemap[d&3]
@@ -87,4 +112,5 @@ func (c *cqpskDemod) process(iq []complex64) []uint8 {
 func (c *cqpskDemod) reset() {
 	c.dq.Reset()
 	c.gardner.Reset()
+	c.cma.Reset()
 }

--- a/internal/radio/p25/phase1/receiver/harness_test.go
+++ b/internal/radio/p25/phase1/receiver/harness_test.go
@@ -334,6 +334,9 @@ func TestHarnessImpairedControlChannelCharacterization(t *testing.T) {
 			FreqOffsetHz: 600, DCOffset: complex(0.08, 0.05),
 			IQGainImbalance: 1.08, SNRdB: 18, Seed: 1,
 		}},
+		{"simulcast", demod.Impairments{
+			Multipath: []complex64{1, 0, 0, 0, 0, 0, 0, 0, complex(0.7, 0.35)},
+		}},
 	}
 	for _, m := range demodModes {
 		for _, tc := range cases {
@@ -343,5 +346,34 @@ func TestHarnessImpairedControlChannelCharacterization(t *testing.T) {
 					m.name, tc.name, res.locked, res.decodeErrors, res.nidErrsSummary())
 			})
 		}
+	}
+}
+
+// TestHarnessCQPSKEqualizerRecoversSimulcast guards the CMA-equalizer
+// fix for issue #275. P25 simulcast covers a channel with several
+// synchronised transmitters; their differently-delayed copies sum to a
+// multipath channel that closes the CQPSK constellation, so the Frame
+// Sync Word stops correlating and the control channel never locks.
+// Because LSM is a linear modulation the distortion is linear in the
+// complex symbols, so the blind CMA equalizer reopens the constellation
+// — the channel locks across a realistic simulcast-echo range.
+func TestHarnessCQPSKEqualizerRecoversSimulcast(t *testing.T) {
+	profiles := []struct {
+		name string
+		taps []complex64
+	}{
+		{"echo_0.56_at_0.5sym", []complex64{1, 0, 0, 0, 0, complex(0.5, 0.25)}},
+		{"echo_0.78_at_0.8sym", []complex64{1, 0, 0, 0, 0, 0, 0, 0, complex(0.7, 0.35)}},
+		{"echo_0.98_at_0.5sym", []complex64{1, 0, 0, 0, 0, complex(0.9, 0.4)}},
+	}
+	for _, p := range profiles {
+		t.Run(p.name, func(t *testing.T) {
+			res := runHarness(DemodCQPSK, demod.Impairments{Multipath: p.taps})
+			if !res.locked {
+				t.Errorf("CQPSK did not lock under simulcast multipath %s "+
+					"(decodeErrors=%d, nidErrs min/max/n=%s)",
+					p.name, res.decodeErrors, res.nidErrsSummary())
+			}
+		})
 	}
 }

--- a/internal/radio/p25/phase1/receiver/receiver.go
+++ b/internal/radio/p25/phase1/receiver/receiver.go
@@ -19,6 +19,8 @@
 //	  IQ
 //	    → complex RRC matched filter (demod.PiOver4DQPSK, rotation=π/4)
 //	    → Gardner timing recovery on complex IQ (sync.Gardner)
+//	    → CMA blind equalizer: simulcast-multipath ISI removal
+//	      (internal/dsp/equalizer.CMA)
 //	    → differential QPSK quadrant decode
 //	    → LSM dibit remap → canonical 0..3 dibit
 //


### PR DESCRIPTION
A P25 simulcast site covers a channel with several synchronised
transmitters; their differently-delayed copies sum at the receiver to a
multipath channel. Strong simulcast multipath closed the CQPSK
constellation so the Frame Sync Word never correlated and the control
channel never locked — the "CQPSK never reaches NID" symptom reported
against the MMR site.

Multipath is a *linear* distortion of the IQ signal, so it cannot be
undone after the (nonlinear) FM discriminator — but LSM is a linear
modulation, so on the CQPSK path the distortion is linear in the
complex symbols and an adaptive equalizer can invert it. That is why
simulcast P25 is transmitted as LSM in the first place.

Wire the existing equalizer.CMA blind equalizer onto the CQPSK symbol
stream, between Gardner timing recovery and the differential decode.
The post-Gardner LSM symbols are unit-modulus QPSK points, so the
Constant Modulus Algorithm applies directly: it needs no training
sequence and no absolute phase reference (the path is differential and
the FSW rotation search absorbs any residual rotation), and on a clean
constant-modulus signal its error term is ~0 so it is a near-noop.

Also add a multipath channel model to the #275 IQ-impairment harness
(demod.Impairments.Multipath — a complex channel FIR convolved with the
IQ) so the simulcast failure is reproducible in-tree. New
TestHarnessCQPSKEqualizerRecoversSimulcast hard-asserts a CQPSK lock
across a realistic simulcast-echo range; before the equalizer those
profiles produced no FSW hits at all. The C4FM path is unchanged.

https://claude.ai/code/session_01Qc4zddc3oMNFsM6JCcXEn6