### PR TITLE
p25/phase1: AGC the CQPSK path to fix gain-sensitive locking (#275)

### DIFF
--- a/internal/dsp/agc.go
+++ b/internal/dsp/agc.go
@@ -2,13 +2,18 @@ package dsp
 
 import "math"
 
-// AGC is a feedback automatic-gain-control loop that drives the average
-// magnitude of a complex IQ stream toward Reference.
+// AGC normalises the average magnitude of a complex IQ stream toward
+// Reference. It tracks signal power with an exponential moving average
+// and applies that as a feed-forward scale, so an occasional near-zero
+// sample — a linear-modulation symbol stream passes through the origin
+// on π phase transitions — cannot spike the gain the way a per-sample
+// feedback loop would.
 type AGC struct {
 	Reference float32 // target output magnitude (default 1.0)
-	Rate      float32 // adaptation step (typical 1e-3 to 1e-2)
-	MaxGain   float32 // ceiling to avoid runaway on dead-air
-	gain      float32
+	Rate      float32 // power-EMA coefficient (typical 1e-3 to 1e-2)
+	MaxGain   float32 // ceiling that bounds the gain on near-silent input
+	power     float32 // EMA of input power
+	seeded    bool
 }
 
 func NewAGC(reference, rate, maxGain float32) *AGC {
@@ -21,10 +26,29 @@ func NewAGC(reference, rate, maxGain float32) *AGC {
 	if maxGain <= 0 {
 		maxGain = 65536
 	}
-	return &AGC{Reference: reference, Rate: rate, MaxGain: maxGain, gain: 1}
+	return &AGC{Reference: reference, Rate: rate, MaxGain: maxGain}
 }
 
-func (a *AGC) Gain() float32 { return a.gain }
+// Gain reports the scale Process would currently apply.
+func (a *AGC) Gain() float32 { return a.gainFor(a.power) }
+
+func (a *AGC) gainFor(power float32) float32 {
+	if !a.seeded || power <= 1e-20 {
+		return 1
+	}
+	g := a.Reference / float32(math.Sqrt(float64(power)))
+	if g > a.MaxGain {
+		g = a.MaxGain
+	}
+	return g
+}
+
+// Reset clears the tracked power so a stream re-sync or re-tune does
+// not carry a stale gain into the new signal.
+func (a *AGC) Reset() {
+	a.power = 0
+	a.seeded = false
+}
 
 func (a *AGC) Process(dst, src []complex64) []complex64 {
 	if cap(dst) < len(src) {
@@ -32,26 +56,30 @@ func (a *AGC) Process(dst, src []complex64) []complex64 {
 	} else {
 		dst = dst[:len(src)]
 	}
+	if len(src) == 0 {
+		return dst
+	}
+	// Seed the power EMA from the first batch's mean power so the gain
+	// is correct immediately rather than ramping up from an arbitrary
+	// start — important when batches are short and the caller cannot
+	// afford a long settling transient. A silent batch is not a usable
+	// seed (it would spike the gain when signal arrives), so hold off
+	// and pass through at unity gain until a batch carries energy.
+	if !a.seeded {
+		var sum float32
+		for _, s := range src {
+			sum += real(s)*real(s) + imag(s)*imag(s)
+		}
+		if p := sum / float32(len(src)); p > 1e-20 {
+			a.power = p
+			a.seeded = true
+		}
+	}
 	for i, s := range src {
-		out := complex(real(s)*a.gain, imag(s)*a.gain)
-		mag := float32(math.Hypot(float64(real(out)), float64(imag(out))))
-		// Update gain toward reference.
-		err := a.Reference - mag
-		a.gain += a.Rate * err / max32(mag, 1e-6)
-		if a.gain > a.MaxGain {
-			a.gain = a.MaxGain
-		}
-		if a.gain < 1e-6 {
-			a.gain = 1e-6
-		}
-		dst[i] = out
+		p := real(s)*real(s) + imag(s)*imag(s)
+		a.power += a.Rate * (p - a.power)
+		g := a.gainFor(a.power)
+		dst[i] = complex(real(s)*g, imag(s)*g)
 	}
 	return dst
-}
-
-func max32(a, b float32) float32 {
-	if a > b {
-		return a
-	}
-	return b
 }

--- a/internal/dsp/demod/impair.go
+++ b/internal/dsp/demod/impair.go
@@ -47,12 +47,20 @@ type Impairments struct {
 	SNRdB float64
 	// Seed makes the AWGN draw reproducible across runs.
 	Seed int64
+	// Scale multiplies the whole IQ stream by a constant amplitude
+	// factor, modelling the SDR front-end / ADC gain. The synthetic
+	// modulators emit a fixed unit-ish amplitude; a real capture's level
+	// swings with the tuner gain setting. Zero (the zero value) is
+	// treated as 1.0 — no scaling.
+	Scale float64
 }
 
 // ApplyImpairments returns a new IQ slice degraded by imp; the input is
-// not mutated. Stages run in physical capture order: IQ imbalance (the
-// analog quadrature mixer) → DC offset (summed at the ADC) → carrier
-// frequency offset (LO error) → AWGN (thermal noise, added last).
+// not mutated. Stages run in physical capture order: multipath channel
+// → IQ imbalance (the analog quadrature mixer) → DC offset (summed at
+// the ADC) → carrier frequency offset (LO error) → AWGN (thermal noise)
+// → front-end gain scale, applied last so signal and noise scale
+// together.
 func ApplyImpairments(iq []complex64, sampleRateHz float64, imp Impairments) []complex64 {
 	out := make([]complex64, len(iq))
 	copy(out, iq)
@@ -129,6 +137,15 @@ func ApplyImpairments(iq []complex64, sampleRateHz float64, imp Impairments) []c
 					float32(rng.NormFloat64()*sigma),
 				)
 			}
+		}
+	}
+
+	// Front-end / ADC gain: a constant amplitude scale applied last, so
+	// signal and noise scale together and the SNR is preserved.
+	if imp.Scale != 0 && imp.Scale != 1 {
+		s := float32(imp.Scale)
+		for i := range out {
+			out[i] *= complex(s, 0)
 		}
 	}
 

--- a/internal/radio/p25/phase1/receiver/cqpsk.go
+++ b/internal/radio/p25/phase1/receiver/cqpsk.go
@@ -3,6 +3,7 @@ package receiver
 import (
 	"math"
 
+	"github.com/MattCheramie/GopherTrunk/internal/dsp"
 	"github.com/MattCheramie/GopherTrunk/internal/dsp/demod"
 	"github.com/MattCheramie/GopherTrunk/internal/dsp/equalizer"
 	"github.com/MattCheramie/GopherTrunk/internal/dsp/sync"
@@ -35,9 +36,32 @@ var lsmDibitRemap = [4]uint8{0, 1, 3, 2}
 // are unit-modulus QPSK points, so the Constant Modulus Algorithm
 // applies: simulcast multipath blurs that constant magnitude and CMA
 // drives it back, opening the constellation so the FSW correlates.
+//
+// cqpskEqualizerStep is tuned for the AGC-normalised symbol amplitude.
+// CMA convergence speed scales with the input power, so before the AGC
+// the equalizer leaned on the power a multipath echo itself adds; with
+// the level now fixed the step is set to converge at that normalised
+// amplitude instead.
 const (
 	cqpskEqualizerTaps = 11
-	cqpskEqualizerStep = 0.005
+	cqpskEqualizerStep = 0.008
+)
+
+// cqpskAGC* configure the AGC that normalises the matched-filter output
+// ahead of Gardner timing recovery. Both the Gardner timing-error
+// detector and the CMA weight update use un-normalised, amplitude-
+// dependent error terms, so the CQPSK path is gain-sensitive without
+// this — issue #275's regression report measured it locking only in a
+// narrow RTL-SDR gain window. cqpskAGCReference is the matched-filter
+// RMS the two loops are tuned against; normalising every capture to it
+// presents identical signal amplitude downstream regardless of the
+// front-end gain. cqpskAGCRate is the power-EMA coefficient at the IQ
+// sample rate — small, so the gain is effectively static across the
+// CMA's adaptation window and the two loops do not fight.
+const (
+	cqpskAGCReference = 0.95
+	cqpskAGCRate      = 1e-3
+	cqpskAGCMaxGain   = 1e4
 )
 
 // cqpskDemod is the LSM / linear-CQPSK symbol recovery chain for P25
@@ -49,7 +73,10 @@ const (
 // linear modulation, so simulcast multipath is a linear distortion of
 // the complex symbols and an equalizer can invert it — this is the
 // path simulcast P25 sites need (issue #275: strong multipath closed
-// the constellation and the Frame Sync Word never correlated).
+// the constellation and the Frame Sync Word never correlated). An AGC
+// on the matched-filter output normalises signal amplitude ahead of
+// the gain-sensitive Gardner and CMA loops, so the path locks
+// regardless of the RTL-SDR front-end gain.
 //
 // Gardner timing-recovery is mandatory on this path (the demod operates
 // on complex IQ at the sample rate; naive every-sps-th decimation
@@ -58,6 +85,7 @@ const (
 type cqpskDemod struct {
 	dq      *demod.PiOver4DQPSK
 	gardner *sync.Gardner
+	agc     *dsp.AGC
 	cma     *equalizer.CMA
 
 	// Scratch buffers reused across calls.
@@ -77,6 +105,7 @@ func newCQPSKDemod(sps int, span int, alpha float64, gardnerGain float64) *cqpsk
 	return &cqpskDemod{
 		dq:      demod.NewPiOver4DQPSK(sps, span, alpha, lsmRotation),
 		gardner: sync.NewGardner(float64(sps), gardnerGain),
+		agc:     dsp.NewAGC(cqpskAGCReference, cqpskAGCRate, cqpskAGCMaxGain),
 		cma:     equalizer.NewCMA(cqpskEqualizerTaps, cqpskEqualizerStep, 1.0),
 	}
 }
@@ -87,6 +116,13 @@ func newCQPSKDemod(sps int, span int, alpha float64, gardnerGain float64) *cqpsk
 // not corrupt the stream.
 func (c *cqpskDemod) process(iq []complex64) []uint8 {
 	c.matched = c.dq.MatchedFilter(c.matched, iq)
+	// AGC: normalise the matched-filter output to the amplitude the
+	// downstream loops are tuned for. The Gardner timing-error detector
+	// and the CMA weight update both use un-normalised, amplitude-
+	// dependent error terms, so without this the CQPSK path is
+	// gain-sensitive and only locks in a narrow RTL-SDR gain window
+	// (issue #275 regression).
+	c.matched = c.agc.Process(c.matched, c.matched)
 	c.symbols = c.symbols[:0]
 	c.symbols = c.gardner.Process(c.symbols, c.matched)
 	if len(c.symbols) == 0 {
@@ -112,5 +148,6 @@ func (c *cqpskDemod) process(iq []complex64) []uint8 {
 func (c *cqpskDemod) reset() {
 	c.dq.Reset()
 	c.gardner.Reset()
+	c.agc.Reset()
 	c.cma.Reset()
 }

--- a/internal/radio/p25/phase1/receiver/harness_test.go
+++ b/internal/radio/p25/phase1/receiver/harness_test.go
@@ -377,3 +377,27 @@ func TestHarnessCQPSKEqualizerRecoversSimulcast(t *testing.T) {
 		})
 	}
 }
+
+// TestHarnessCQPSKGainInvariant guards the AGC fix for issue #275.
+// Adding the CMA blind equalizer (TestHarnessCQPSKEqualizerRecoversSimulcast)
+// exposed that the CQPSK path is not scale-invariant: both the Gardner
+// timing-error detector and the CMA weight update use un-normalised,
+// amplitude-dependent error terms, so the chain only converges when the
+// signal amplitude sits in a narrow band — on-air the control channel
+// locked only in a narrow RTL-SDR gain window. An AGC on the
+// matched-filter output now normalises the amplitude ahead of both
+// loops, so the channel locks across a wide front-end-gain range,
+// modelled here by the Impairments.Scale IQ-amplitude knob.
+func TestHarnessCQPSKGainInvariant(t *testing.T) {
+	for _, scale := range []float64{0.05, 0.25, 1, 4, 20} {
+		t.Run(fmt.Sprintf("scale_%g", scale), func(t *testing.T) {
+			res := runHarness(DemodCQPSK, demod.Impairments{Scale: scale})
+			if !res.locked {
+				t.Errorf("CQPSK did not lock at IQ amplitude scale %g "+
+					"(decodeErrors=%d, nidErrs min/max/n=%s) — the CQPSK "+
+					"path is gain-sensitive (#275)",
+					scale, res.decodeErrors, res.nidErrsSummary())
+			}
+		})
+	}
+}

--- a/internal/radio/p25/phase1/receiver/receiver.go
+++ b/internal/radio/p25/phase1/receiver/receiver.go
@@ -18,6 +18,7 @@
 //	DemodCQPSK (LSM / simulcast):
 //	  IQ
 //	    → complex RRC matched filter (demod.PiOver4DQPSK, rotation=π/4)
+//	    → AGC: amplitude normalisation (internal/dsp.AGC)
 //	    → Gardner timing recovery on complex IQ (sync.Gardner)
 //	    → CMA blind equalizer: simulcast-multipath ISI removal
 //	      (internal/dsp/equalizer.CMA)


### PR DESCRIPTION
## Summary

PR #306's CMA blind equalizer made the P25 Phase 1 CQPSK path **gain-sensitive** — an on-air retest locked the control channel only in a narrow RTL-SDR gain window (gain 197 broken, 49 partial, 28 broken).

The CQPSK path used to be scale-invariant: its differential decoder is `atan2`-based, so absolute amplitude never mattered. But two adaptive loops — the **Gardner timing-error detector** and the **CMA weight update** — use un-normalised, amplitude-dependent error terms (both scale with amplitude²), so the chain only converges when the signal sits in a narrow amplitude band.

This adds an **AGC on the matched-filter output** that normalises every capture to the amplitude the Gardner and CMA loops are tuned for, restoring scale invariance regardless of front-end gain.

- `internal/dsp/agc.go` — reworked `dsp.AGC` from a per-sample feedback loop (a near-zero symbol of a linear-modulation stream spiked its gain into runaway — measured 26× over-gain) into a robust power-EMA feed-forward normaliser; added `Reset()`.
- `internal/radio/p25/phase1/receiver/cqpsk.go` — AGC ahead of Gardner; retuned the CMA step `0.005`→`0.008` for the now-fixed input level (pre-AGC it leaned on the extra power a multipath echo itself adds).
- `internal/dsp/demod/impair.go` — added an `Impairments.Scale` IQ-amplitude knob to model SDR front-end gain.
- `internal/radio/p25/phase1/receiver/harness_test.go` — added `TestHarnessCQPSKGainInvariant`, a regression guard across scale 0.05–20.
- `receiver.go` — updated the CQPSK pipeline doc diagram.

## Test plan

- [x] Reproduced the regression first — `TestHarnessCQPSKGainInvariant` fails at scale 4/20 without the fix
- [x] `TestHarnessCQPSKGainInvariant` — locks across all 5 scales (0.05–20) with the fix
- [x] `TestHarnessCleanControlChannelLocks` (c4fm + cqpsk), `TestHarnessCQPSKEqualizerRecoversSimulcast` (all 3 echo profiles), `TestHarnessCQPSKChunkBoundary` — pass
- [x] `dsp.AGC` unit test (`TestAGCConvergence`) — passes against the reworked primitive
- [x] `go build ./...`, `go vet ./...`, full `go test ./...` — clean
- [x] `make integration-cc` (P25 Phase 1 control channel, `-race`) — green
- [x] `-race` on all affected packages — clean

Addresses the latest gain-sensitivity regression reported in #275 (introduced by #306). The reporter's non-simulcast local site not locking on the CQPSK path is a separate mode-selection matter and is left out of scope.

https://claude.ai/code/session_01Qc4zddc3oMNFsM6JCcXEn6