### PR TITLE
p25/phase2: complete TDMA decode path and SDRtrunk parity

### DIFF
--- a/cmd/gophertrunk/integration_cc_p25p2_test.go
+++ b/cmd/gophertrunk/integration_cc_p25p2_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/MattCheramie/GopherTrunk/internal/config"
 	"github.com/MattCheramie/GopherTrunk/internal/dsp/demod"
 	"github.com/MattCheramie/GopherTrunk/internal/events"
-	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
 	p25phase2 "github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase2"
 	"github.com/MattCheramie/GopherTrunk/internal/sdr"
 )
@@ -48,10 +47,13 @@ func TestDaemonCCDecodesP25Phase2(t *testing.T) {
 		sps        = 8
 		span       = 8
 		alpha      = 0.20
-		pduRepeats = 80
+		// Each repeat is a full 12-sub-frame superframe; a handful is
+		// ample for the Gardner clock to settle and the superframe
+		// decoder to lock.
+		superframeRepeats = 8
 	)
 
-	dibits := buildP25Phase2MACPTTStream(pduRepeats)
+	dibits := buildP25Phase2MACPTTStream(superframeRepeats)
 	iq := demod.ModulatePiOver4DQPSK(dibits, sps, span, alpha, math.Pi/8)
 
 	dir := t.TempDir()
@@ -143,33 +145,32 @@ WaitLoop:
 //
 //   - 400-dibit warmup cycling 0..3 so the matched filter +
 //     differential decoder converge on the constellation centre
-//   - `repeats` × (20-dibit outbound sync + 146-dibit
-//     trellis-coded MAC PDU + 30 idle dibits)
+//   - `repeats` × a full 12-sub-frame TDMA superframe, every
+//     sub-frame a MAC sub-frame carrying an OpMACPTT MAC PDU
 //   - 100-dibit trailer for clean flush
 //
-// Each PDU is an OpMACPTT (PTT-on, the canonical "lock me"
-// non-idle MAC PDU). The 72 info dibits run through the
-// TIA-102 Annex A 4-state ½-rate trellis encoder via
-// framing.EncodeP25Trellis.
+// Each superframe is built with EncodeMACSubframe (ISCH + trellis-coded
+// MAC PDU) + EncodeSuperframe (which injects the 20-dibit outbound
+// sync), so the daemon's SuperframeDecoder-backed pipeline locks the
+// superframe, decodes the ISCH SlotTypes, and routes the MAC PDUs into
+// the control-channel state machine. OpMACPTT is the canonical
+// non-idle "lock me" MAC PDU.
 func buildP25Phase2MACPTTStream(repeats int) []uint8 {
 	pdu := p25phase2.MACPDU{Opcode: p25phase2.OpMACPTT, Payload: make([]byte, 17)}
-	pduBits := framing.UnpackBitsMSB(p25phase2.AssembleMACPDU(pdu), 144)
-	infoDibits := framing.BitsToDibits(pduBits)
-	channelDibits := framing.EncodeP25Trellis(infoDibits)
+	var subs [p25phase2.SubframesPerSuperframe][]uint8
+	for i := range subs {
+		subs[i] = p25phase2.EncodeMACSubframe(
+			p25phase2.SlotTypeMACSignaling, uint8(i), pdu,
+			p25phase2.TrellisOn, p25phase2.InterleaveOff)
+	}
+	superframe := p25phase2.EncodeSuperframe(subs)
 
-	frame := make([]uint8, 0, 20+len(channelDibits))
-	frame = append(frame, p25phase2.OutboundSyncDibits()...)
-	frame = append(frame, channelDibits...)
-
-	out := make([]uint8, 0, 400+repeats*(len(frame)+30)+100)
+	out := make([]uint8, 0, 400+repeats*len(superframe)+100)
 	for i := 0; i < 400; i++ {
 		out = append(out, uint8(i&3))
 	}
 	for r := 0; r < repeats; r++ {
-		out = append(out, frame...)
-		for i := 0; i < 30; i++ {
-			out = append(out, uint8(i&3))
-		}
+		out = append(out, superframe...)
 	}
 	for i := 0; i < 100; i++ {
 		out = append(out, uint8(i&3))

--- a/internal/events/bus.go
+++ b/internal/events/bus.go
@@ -55,6 +55,13 @@ const (
 	// instead of waiting for the next 3 s poll tick. Emitted by
 	// the HTTP API's PATCH /api/v1/audio handler.
 	KindAudioState Kind = "audio.state"
+	// KindPatch fires when a trunked system announces (or cancels) a
+	// patch / dynamic-regroup — a super-group that merges several
+	// talkgroups onto one channel. P25 Phase 2 publishes one per
+	// Motorola group-regroup or Harris regroup MAC PDU. The payload
+	// (trunking.Patch) carries the super-group, its member talkgroups,
+	// and whether the patch is being added or removed.
+	KindPatch Kind = "patch"
 )
 
 // Stage names a particular FEC / parser checkpoint inside a protocol

--- a/internal/events/bus.go
+++ b/internal/events/bus.go
@@ -62,6 +62,12 @@ const (
 	// (trunking.Patch) carries the super-group, its member talkgroups,
 	// and whether the patch is being added or removed.
 	KindPatch Kind = "patch"
+	// KindTalkerAlias fires when a radio's display name (its "talker
+	// alias") has been fully reassembled from the multi-fragment vendor
+	// MAC PDUs that carry it. P25 Phase 2 publishes one per completed
+	// alias. The payload (trunking.TalkerAlias) is keyed by source unit
+	// so a consumer can associate it with the active call.
+	KindTalkerAlias Kind = "talker.alias"
 )
 
 // Stage names a particular FEC / parser checkpoint inside a protocol

--- a/internal/radio/p25/phase2/control.go
+++ b/internal/radio/p25/phase2/control.go
@@ -449,6 +449,16 @@ func (c *ControlChannel) Ingest(p MACPDU) {
 		c.hasEncSync = true
 		c.mu.Unlock()
 	}
+	if pg, ok := p.AsMotorolaPatchGroup(); ok {
+		members := make([]uint32, len(pg.Patched))
+		for i, m := range pg.Patched {
+			members[i] = uint32(m)
+		}
+		c.publishPatch(uint32(pg.SuperGroup), members, "motorola")
+	}
+	if hr, ok := p.AsHarrisRegroup(); ok {
+		c.publishPatch(uint32(hr.RegroupGroup), nil, "harris")
+	}
 	if p.IsIdle() {
 		return
 	}
@@ -569,6 +579,30 @@ func (c *ControlChannel) publishGrant(g GroupVoiceChannelGrant, op Opcode, group
 		"src", g.SourceID,
 		"channel_id", g.ChannelID, "channel_num", g.ChannelNumber,
 		"freq_hz", freq, "enc", so.Encrypted(), "emer", so.Emergency())
+}
+
+// publishPatch publishes an events.KindPatch for a vendor patch /
+// dynamic-regroup MAC PDU so the engine can attribute later grants on
+// the super-group to its member talkgroups.
+func (c *ControlChannel) publishPatch(superGroup uint32, members []uint32, vendor string) {
+	if c.bus == nil {
+		return
+	}
+	c.bus.Publish(events.Event{
+		Kind: events.KindPatch,
+		Payload: trunking.Patch{
+			System:     c.systemName,
+			Protocol:   "p25-phase2",
+			SuperGroup: superGroup,
+			Members:    members,
+			Vendor:     vendor,
+			Add:        true,
+			At:         c.now(),
+		},
+	})
+	c.log.Debug("p25/phase2 patch",
+		"system", c.systemName, "vendor", vendor,
+		"super", superGroup, "members", members)
 }
 
 // resolveFreq looks the (channelID, channelNumber) pair up in the band

--- a/internal/radio/p25/phase2/control.go
+++ b/internal/radio/p25/phase2/control.go
@@ -459,10 +459,19 @@ func (c *ControlChannel) Ingest(p MACPDU) {
 		for i, m := range pg.Patched {
 			members[i] = uint32(m)
 		}
-		c.publishPatch(uint32(pg.SuperGroup), members, "motorola")
+		c.publishPatch(uint32(pg.SuperGroup), members, "motorola", true)
 	}
 	if hr, ok := p.AsHarrisRegroup(); ok {
-		c.publishPatch(uint32(hr.RegroupGroup), nil, "harris")
+		c.publishPatch(uint32(hr.RegroupGroup), nil, "harris", true)
+	}
+	if super, ok := p.AsMotorolaPatchDelete(); ok {
+		c.publishPatch(super, nil, "motorola", false)
+	}
+	if g, ok := p.AsGroupAffiliationResponse(); ok {
+		c.publishAffiliation(g)
+	}
+	if u, ok := p.AsUnitRegistrationResponse(); ok {
+		c.publishUnitRegistration(u)
 	}
 	if f, ok := p.AsTalkerAliasFragment(); ok {
 		if alias, src, complete := c.aliasAsm.Add(f); complete {
@@ -593,8 +602,8 @@ func (c *ControlChannel) publishGrant(g GroupVoiceChannelGrant, op Opcode, group
 
 // publishPatch publishes an events.KindPatch for a vendor patch /
 // dynamic-regroup MAC PDU so the engine can attribute later grants on
-// the super-group to its member talkgroups.
-func (c *ControlChannel) publishPatch(superGroup uint32, members []uint32, vendor string) {
+// the super-group to its member talkgroups. add=false cancels a patch.
+func (c *ControlChannel) publishPatch(superGroup uint32, members []uint32, vendor string, add bool) {
 	if c.bus == nil {
 		return
 	}
@@ -606,13 +615,54 @@ func (c *ControlChannel) publishPatch(superGroup uint32, members []uint32, vendo
 			SuperGroup: superGroup,
 			Members:    members,
 			Vendor:     vendor,
-			Add:        true,
+			Add:        add,
 			At:         c.now(),
 		},
 	})
 	c.log.Debug("p25/phase2 patch",
 		"system", c.systemName, "vendor", vendor,
-		"super", superGroup, "members", members)
+		"super", superGroup, "members", members, "add", add)
+}
+
+// publishAffiliation publishes an events.KindAffiliation for a Group
+// Affiliation Response MAC PDU — the Phase 2 counterpart of the Phase 1
+// control channel's opcode-0x28 handling.
+func (c *ControlChannel) publishAffiliation(g GroupAffiliationResponse) {
+	if c.bus == nil {
+		return
+	}
+	c.bus.Publish(events.Event{
+		Kind: events.KindAffiliation,
+		Payload: trunking.Affiliation{
+			System:            c.systemName,
+			Protocol:          "p25-phase2",
+			SourceID:          g.TargetID,
+			GroupID:           uint32(g.GroupAddress),
+			AnnouncementGroup: uint32(g.AnnouncementGroup),
+			Response:          trunking.AffiliationResponse(g.Response),
+			At:                c.now(),
+		},
+	})
+}
+
+// publishUnitRegistration publishes an events.KindUnitRegistration for a
+// Unit Registration Response MAC PDU.
+func (c *ControlChannel) publishUnitRegistration(u UnitRegistrationResponse) {
+	if c.bus == nil {
+		return
+	}
+	c.bus.Publish(events.Event{
+		Kind: events.KindUnitRegistration,
+		Payload: trunking.UnitRegistration{
+			System:   c.systemName,
+			Protocol: "p25-phase2",
+			SourceID: u.SourceID,
+			WACN:     u.WACN,
+			SystemID: u.SystemID,
+			Response: trunking.RegistrationResponse(u.Response),
+			At:       c.now(),
+		},
+	})
 }
 
 // publishTalkerAlias publishes an events.KindTalkerAlias once a radio's

--- a/internal/radio/p25/phase2/control.go
+++ b/internal/radio/p25/phase2/control.go
@@ -41,6 +41,10 @@ type ControlChannel struct {
 	// first Process call.
 	proc *processState
 
+	// aliasAsm reassembles multi-fragment talker-alias MAC PDUs into
+	// a radio's display name. Self-synchronised (its own mutex).
+	aliasAsm *TalkerAliasAssembler
+
 	mu               sync.Mutex
 	locked           bool
 	strictValidation bool
@@ -414,6 +418,7 @@ func New(opts Options) *ControlChannel {
 		systemName: opts.SystemName,
 		freqHz:     opts.FrequencyHz,
 		now:        now,
+		aliasAsm:   NewTalkerAliasAssembler(now),
 	}
 }
 
@@ -458,6 +463,11 @@ func (c *ControlChannel) Ingest(p MACPDU) {
 	}
 	if hr, ok := p.AsHarrisRegroup(); ok {
 		c.publishPatch(uint32(hr.RegroupGroup), nil, "harris")
+	}
+	if f, ok := p.AsTalkerAliasFragment(); ok {
+		if alias, src, complete := c.aliasAsm.Add(f); complete {
+			c.publishTalkerAlias(src, alias)
+		}
 	}
 	if p.IsIdle() {
 		return
@@ -603,6 +613,26 @@ func (c *ControlChannel) publishPatch(superGroup uint32, members []uint32, vendo
 	c.log.Debug("p25/phase2 patch",
 		"system", c.systemName, "vendor", vendor,
 		"super", superGroup, "members", members)
+}
+
+// publishTalkerAlias publishes an events.KindTalkerAlias once a radio's
+// display name has been fully reassembled from its fragment MAC PDUs.
+func (c *ControlChannel) publishTalkerAlias(sourceID uint32, alias string) {
+	if c.bus == nil {
+		return
+	}
+	c.bus.Publish(events.Event{
+		Kind: events.KindTalkerAlias,
+		Payload: trunking.TalkerAlias{
+			System:   c.systemName,
+			Protocol: "p25-phase2",
+			SourceID: sourceID,
+			Alias:    alias,
+			At:       c.now(),
+		},
+	})
+	c.log.Debug("p25/phase2 talker alias",
+		"system", c.systemName, "src", sourceID, "alias", alias)
 }
 
 // resolveFreq looks the (channelID, channelNumber) pair up in the band

--- a/internal/radio/p25/phase2/control.go
+++ b/internal/radio/p25/phase2/control.go
@@ -54,6 +54,12 @@ type ControlChannel struct {
 	// can resolve a voice grant's (ChannelID, ChannelNumber) into a
 	// downlink frequency. Guarded by mu.
 	bandPlan BandPlan
+	// lastEncSync holds the most recently ingested Encryption Sync
+	// (Algorithm ID + Key ID); publishGrant attaches it to an
+	// encrypted grant so encrypted calls surface which algorithm/key
+	// they use. Guarded by mu.
+	lastEncSync EncryptionSync
+	hasEncSync  bool
 }
 
 // TrellisMode selects how the Process adapter interprets the MAC
@@ -437,6 +443,12 @@ func (c *ControlChannel) Ingest(p MACPDU) {
 		c.bandPlan.Apply(u)
 		c.mu.Unlock()
 	}
+	if es, ok := p.AsEncryptionSync(); ok {
+		c.mu.Lock()
+		c.lastEncSync = es
+		c.hasEncSync = true
+		c.mu.Unlock()
+	}
 	if p.IsIdle() {
 		return
 	}
@@ -519,6 +531,21 @@ func (c *ControlChannel) publishGrant(g GroupVoiceChannelGrant, op Opcode, group
 	// before band-plan support landed) so the event surface is
 	// unchanged; the engine drops a zero-frequency grant on its own.
 	freq := c.resolveFreq(g.ChannelID, g.ChannelNumber)
+	// Decode the SVC_OPTIONS byte for the emergency + protected
+	// (encryption) indicators. When the call is protected and an
+	// Encryption Sync has been seen, attach its Algorithm ID / Key ID
+	// so the recorder + API can surface which crypto the call uses.
+	so := ServiceOptions(g.ServiceOptions)
+	var algID uint8
+	var keyID uint16
+	if so.Encrypted() {
+		c.mu.Lock()
+		if c.hasEncSync {
+			algID = c.lastEncSync.AlgorithmID
+			keyID = c.lastEncSync.KeyID
+		}
+		c.mu.Unlock()
+	}
 	c.bus.Publish(events.Event{
 		Kind: events.KindGrant,
 		Payload: trunking.Grant{
@@ -529,6 +556,10 @@ func (c *ControlChannel) publishGrant(g GroupVoiceChannelGrant, op Opcode, group
 			FrequencyHz: freq,
 			ChannelID:   g.ChannelID,
 			ChannelNum:  g.ChannelNumber,
+			Encrypted:   so.Encrypted(),
+			Emergency:   so.Emergency(),
+			AlgorithmID: algID,
+			KeyID:       keyID,
 			At:          c.now(),
 		},
 	})
@@ -537,7 +568,7 @@ func (c *ControlChannel) publishGrant(g GroupVoiceChannelGrant, op Opcode, group
 		"opcode", op, "tg", groupID,
 		"src", g.SourceID,
 		"channel_id", g.ChannelID, "channel_num", g.ChannelNumber,
-		"freq_hz", freq)
+		"freq_hz", freq, "enc", so.Encrypted(), "emer", so.Emergency())
 }
 
 // resolveFreq looks the (channelID, channelNumber) pair up in the band

--- a/internal/radio/p25/phase2/control_patch_test.go
+++ b/internal/radio/p25/phase2/control_patch_test.go
@@ -1,0 +1,68 @@
+package phase2
+
+import (
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+func nextPatch(t *testing.T, sub *events.Subscription) trunking.Patch {
+	t.Helper()
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind == events.KindPatch {
+				return ev.Payload.(trunking.Patch)
+			}
+		default:
+			t.Fatal("no KindPatch event published")
+			return trunking.Patch{}
+		}
+	}
+}
+
+func TestControlChannelPublishesMotorolaPatch(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, SystemName: "p2", FrequencyHz: 851_000_000})
+	cc.Ingest(MACPDU{
+		Opcode:  OpVendorGroupRegroup,
+		MFID:    MFIDMotorola,
+		Payload: []byte{0x12, 0x34, 0x00, 0x0A, 0x00, 0x14, 0x00, 0x00},
+	})
+
+	p := nextPatch(t, sub)
+	if p.SuperGroup != 0x1234 {
+		t.Errorf("patch SuperGroup = %#x, want 0x1234", p.SuperGroup)
+	}
+	if p.Vendor != "motorola" || !p.Add {
+		t.Errorf("patch Vendor=%q Add=%v, want motorola/true", p.Vendor, p.Add)
+	}
+	want := []uint32{10, 20}
+	if len(p.Members) != len(want) || p.Members[0] != 10 || p.Members[1] != 20 {
+		t.Errorf("patch Members = %v, want %v", p.Members, want)
+	}
+}
+
+func TestControlChannelPublishesHarrisRegroup(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, SystemName: "p2", FrequencyHz: 851_000_000})
+	cc.Ingest(MACPDU{
+		Opcode:  OpVendorGroupRegroup,
+		MFID:    MFIDHarris,
+		Payload: []byte{0x05, 0x55, 0x00, 0xBE, 0xEF},
+	})
+
+	p := nextPatch(t, sub)
+	if p.SuperGroup != 0x0555 || p.Vendor != "harris" || !p.Add {
+		t.Errorf("Harris patch = %+v, want super 0x555 / harris / add", p)
+	}
+}

--- a/internal/radio/p25/phase2/encode.go
+++ b/internal/radio/p25/phase2/encode.go
@@ -49,6 +49,36 @@ func EncodeSuperframe(subframes [SubframesPerSuperframe][]uint8) []uint8 {
 	return out
 }
 
+// EncodeMACSubframe builds a DibitsPerSubframe-long MAC sub-frame: the
+// ISCH for slotType (which must be a MAC SlotType) at counter, followed
+// by the FEC-encoded MAC PDU at MACPayloadOffset. It is the inverse of
+// the slice + decodeMACPDUDibits step IngestSuperframe runs. The PDU is
+// assembled and zero-padded/truncated to the 18-byte (144-bit) MAC PDU
+// width; mode and interleave must match the decoder's configuration.
+// Panics if slotType is not a MAC SlotType.
+func EncodeMACSubframe(slotType SlotType, counter uint8, pdu MACPDU, mode TrellisMode, interleave InterleaveMode) []uint8 {
+	if !slotType.IsMAC() {
+		panic("p25/phase2: EncodeMACSubframe slotType is not a MAC SlotType")
+	}
+	macBytes := AssembleMACPDU(pdu)
+	full := make([]byte, 18)
+	copy(full, macBytes) // pad short / truncate long to the 144-bit MAC PDU
+	infoDibits := framing.BitsToDibits(framing.UnpackBitsMSB(full, 144))
+
+	channelDibits := infoDibits
+	if mode == TrellisOn {
+		channelDibits = framing.EncodeP25Trellis(infoDibits)
+	}
+	if interleave == InterleaveOn {
+		channelDibits = framing.InterleaveMACBurst(channelDibits)
+	}
+
+	sub := IdleSubframe()
+	WriteISCH(sub, slotType, counter)
+	copy(sub[MACPayloadOffset:MACPayloadOffset+len(channelDibits)], channelDibits)
+	return sub
+}
+
 // EncodeVoiceSubframe builds a DibitsPerSubframe-long voice sub-frame:
 // the ISCH for slotType (which must be SlotTypeVoice4V or
 // SlotTypeVoice2V) at counter, followed by the AMBE+2-FEC-encoded voice

--- a/internal/radio/p25/phase2/encode.go
+++ b/internal/radio/p25/phase2/encode.go
@@ -91,6 +91,34 @@ func EncodeEncryptionSync(es EncryptionSync) MACPDU {
 	return MACPDU{Opcode: OpEncryptionSync, Payload: payload}
 }
 
+// EncodeGroupAffiliationResponse builds the MAC PDU form of a Group
+// Affiliation Response — the inverse of AsGroupAffiliationResponse.
+func EncodeGroupAffiliationResponse(g GroupAffiliationResponse) MACPDU {
+	p := make([]byte, 8)
+	p[0] = g.Response & 0x03
+	binary.BigEndian.PutUint16(p[1:3], g.AnnouncementGroup)
+	binary.BigEndian.PutUint16(p[3:5], g.GroupAddress)
+	p[5] = byte(g.TargetID >> 16)
+	p[6] = byte(g.TargetID >> 8)
+	p[7] = byte(g.TargetID)
+	return MACPDU{Opcode: OpGroupAffiliationResponse, Payload: p}
+}
+
+// EncodeUnitRegistrationResponse builds the MAC PDU form of a Unit
+// Registration Response — the inverse of AsUnitRegistrationResponse.
+func EncodeUnitRegistrationResponse(u UnitRegistrationResponse) MACPDU {
+	p := make([]byte, 8)
+	p[0] = u.Response & 0x03
+	p[1] = byte(u.WACN >> 12)
+	p[2] = byte(u.WACN >> 4)
+	p[3] = byte(u.WACN<<4) | byte((u.SystemID>>8)&0x0F)
+	p[4] = byte(u.SystemID)
+	p[5] = byte(u.SourceID >> 16)
+	p[6] = byte(u.SourceID >> 8)
+	p[7] = byte(u.SourceID)
+	return MACPDU{Opcode: OpUnitRegistrationResponse, Payload: p}
+}
+
 // EncodeTalkerAliasFragment builds the MAC PDU form of a talker-alias
 // fragment — the inverse of MACPDU.AsTalkerAliasFragment.
 func EncodeTalkerAliasFragment(f TalkerAliasFragment) MACPDU {

--- a/internal/radio/p25/phase2/encode.go
+++ b/internal/radio/p25/phase2/encode.go
@@ -91,6 +91,19 @@ func EncodeEncryptionSync(es EncryptionSync) MACPDU {
 	return MACPDU{Opcode: OpEncryptionSync, Payload: payload}
 }
 
+// EncodeTalkerAliasFragment builds the MAC PDU form of a talker-alias
+// fragment — the inverse of MACPDU.AsTalkerAliasFragment.
+func EncodeTalkerAliasFragment(f TalkerAliasFragment) MACPDU {
+	payload := make([]byte, 5+len(f.Data))
+	payload[0] = byte(f.SourceID >> 16)
+	payload[1] = byte(f.SourceID >> 8)
+	payload[2] = byte(f.SourceID)
+	payload[3] = f.BlockIndex
+	payload[4] = f.BlockCount
+	copy(payload[5:], f.Data)
+	return MACPDU{Opcode: OpVendorTalkerAlias, MFID: MFIDMotorola, Payload: payload}
+}
+
 // EncodeVoiceSubframe builds a DibitsPerSubframe-long voice sub-frame:
 // the ISCH for slotType (which must be SlotTypeVoice4V or
 // SlotTypeVoice2V) at counter, followed by the AMBE+2-FEC-encoded voice

--- a/internal/radio/p25/phase2/encode.go
+++ b/internal/radio/p25/phase2/encode.go
@@ -1,6 +1,8 @@
 package phase2
 
 import (
+	"encoding/binary"
+
 	dmrvoice "github.com/MattCheramie/GopherTrunk/internal/radio/dmr/voice"
 	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
 )
@@ -77,6 +79,16 @@ func EncodeMACSubframe(slotType SlotType, counter uint8, pdu MACPDU, mode Trelli
 	WriteISCH(sub, slotType, counter)
 	copy(sub[MACPayloadOffset:MACPayloadOffset+len(channelDibits)], channelDibits)
 	return sub
+}
+
+// EncodeEncryptionSync builds the MAC PDU form of an Encryption Sync —
+// the inverse of MACPDU.AsEncryptionSync.
+func EncodeEncryptionSync(es EncryptionSync) MACPDU {
+	payload := make([]byte, 12)
+	payload[0] = es.AlgorithmID
+	binary.BigEndian.PutUint16(payload[1:3], es.KeyID)
+	copy(payload[3:12], es.MessageIndicator[:])
+	return MACPDU{Opcode: OpEncryptionSync, Payload: payload}
 }
 
 // EncodeVoiceSubframe builds a DibitsPerSubframe-long voice sub-frame:

--- a/internal/radio/p25/phase2/encryption_test.go
+++ b/internal/radio/p25/phase2/encryption_test.go
@@ -1,0 +1,131 @@
+package phase2
+
+import (
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+)
+
+func TestServiceOptionsBits(t *testing.T) {
+	cases := []struct {
+		so        ServiceOptions
+		emergency bool
+		encrypted bool
+		priority  uint8
+	}{
+		{0x00, false, false, 0},
+		{0x80, true, false, 0},
+		{0x40, false, true, 0},
+		{0xC0, true, true, 0},
+		{0xC5, true, true, 5},
+		{0x07, false, false, 7},
+	}
+	for _, c := range cases {
+		if c.so.Emergency() != c.emergency || c.so.Encrypted() != c.encrypted ||
+			c.so.Priority() != c.priority {
+			t.Errorf("ServiceOptions(%#x): emer=%v enc=%v prio=%d, want %v/%v/%d",
+				uint8(c.so), c.so.Emergency(), c.so.Encrypted(), c.so.Priority(),
+				c.emergency, c.encrypted, c.priority)
+		}
+	}
+}
+
+func TestEncryptionSyncRoundTrip(t *testing.T) {
+	in := EncryptionSync{
+		AlgorithmID:      0x84, // AES-256 in the P25 algorithm registry
+		KeyID:            0xBEEF,
+		MessageIndicator: [9]byte{1, 2, 3, 4, 5, 6, 7, 8, 9},
+	}
+	pdu := EncodeEncryptionSync(in)
+	got, ok := pdu.AsEncryptionSync()
+	if !ok {
+		t.Fatal("AsEncryptionSync returned !ok")
+	}
+	if got != in {
+		t.Errorf("round-trip = %+v, want %+v", got, in)
+	}
+
+	// Survives an AssembleMACPDU → ParseMACPDU trip (the wire form).
+	reparsed, err := ParseMACPDU(AssembleMACPDU(pdu))
+	if err != nil {
+		t.Fatalf("ParseMACPDU: %v", err)
+	}
+	if got2, ok := reparsed.AsEncryptionSync(); !ok || got2 != in {
+		t.Errorf("wire round-trip = %+v ok=%v, want %+v", got2, ok, in)
+	}
+}
+
+func TestControlChannelFlagsEncryptedGrant(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, SystemName: "p2", FrequencyHz: 851_000_000})
+
+	es := EncryptionSync{AlgorithmID: 0x84, KeyID: 0x1234}
+	cc.Ingest(EncodeEncryptionSync(es))
+
+	g := grantPDU(0xABCD, 0x00ABCD, 0x1, 0x005)
+	g.Payload[0] = 0xC0 // emergency + protected
+	cc.Ingest(g)
+
+	grants := countGrants(sub)
+	if len(grants) != 1 {
+		t.Fatalf("expected 1 grant, got %d", len(grants))
+	}
+	gr := grants[0]
+	if !gr.Encrypted || !gr.Emergency {
+		t.Errorf("grant Encrypted=%v Emergency=%v, want both true", gr.Encrypted, gr.Emergency)
+	}
+	if gr.AlgorithmID != 0x84 || gr.KeyID != 0x1234 {
+		t.Errorf("grant alg/key = %#x/%#x, want 0x84/0x1234", gr.AlgorithmID, gr.KeyID)
+	}
+}
+
+func TestControlChannelClearGrantNotEncrypted(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, SystemName: "p2", FrequencyHz: 851_000_000})
+	cc.Ingest(grantPDU(0x0042, 0x000123, 0x1, 0x005)) // ServiceOptions byte 0x00
+
+	grants := countGrants(sub)
+	if len(grants) != 1 {
+		t.Fatalf("expected 1 grant, got %d", len(grants))
+	}
+	if grants[0].Encrypted || grants[0].Emergency {
+		t.Errorf("clear grant flagged Encrypted=%v Emergency=%v", grants[0].Encrypted, grants[0].Emergency)
+	}
+	if grants[0].AlgorithmID != 0 || grants[0].KeyID != 0 {
+		t.Errorf("clear grant carried alg/key %#x/%#x", grants[0].AlgorithmID, grants[0].KeyID)
+	}
+}
+
+// TestEncryptedGrantWithoutSyncDegrades confirms a protected grant with
+// no Encryption Sync seen yet still flags Encrypted, with alg/key 0.
+func TestEncryptedGrantWithoutSyncDegrades(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, SystemName: "p2", FrequencyHz: 851_000_000})
+	g := grantPDU(0x0042, 0x000123, 0x1, 0x005)
+	g.Payload[0] = 0x40 // protected, no emergency
+	cc.Ingest(g)
+
+	grants := countGrants(sub)
+	if len(grants) != 1 {
+		t.Fatalf("expected 1 grant, got %d", len(grants))
+	}
+	if !grants[0].Encrypted {
+		t.Error("protected grant not flagged Encrypted")
+	}
+	if grants[0].AlgorithmID != 0 || grants[0].KeyID != 0 {
+		t.Errorf("alg/key should be 0 without an Encryption Sync, got %#x/%#x",
+			grants[0].AlgorithmID, grants[0].KeyID)
+	}
+}

--- a/internal/radio/p25/phase2/mac.go
+++ b/internal/radio/p25/phase2/mac.go
@@ -33,20 +33,23 @@ type MACPDU struct {
 type Opcode uint8
 
 const (
-	OpUnknown                      Opcode = 0x00
-	OpMACPTT                       Opcode = 0x01 // PTT-on
-	OpMACEnd                       Opcode = 0x02 // End of transmission
-	OpMACIdle                      Opcode = 0x03 // Channel idle
-	OpMACHangtime                  Opcode = 0x05 // Hang-time
-	OpMACActive                    Opcode = 0x06 // Late-grant active
-	OpGroupVoiceChannelGrantUpdate Opcode = 0x40
-	OpGroupVoiceChannelGrant       Opcode = 0x44
-	OpGroupVoiceChannelUserExt     Opcode = 0x46
-	OpUnitToUnitVoiceChannelGrant  Opcode = 0x48
-	OpEncryptionSync               Opcode = 0x70
-	OpIdentifierUpdate             Opcode = 0x7D
-	OpNetworkStatusBroadcastUpdate Opcode = 0xFB
-	OpRFSSStatusBroadcastUpdate    Opcode = 0xFA
+	OpUnknown                           Opcode = 0x00
+	OpMACPTT                            Opcode = 0x01 // PTT-on
+	OpMACEnd                            Opcode = 0x02 // End of transmission
+	OpMACIdle                           Opcode = 0x03 // Channel idle
+	OpMACHangtime                       Opcode = 0x05 // Hang-time
+	OpMACActive                         Opcode = 0x06 // Late-grant active
+	OpGroupVoiceChannelGrantUpdate      Opcode = 0x40
+	OpGroupVoiceChannelGrant            Opcode = 0x44
+	OpGroupVoiceChannelUserExt          Opcode = 0x46
+	OpUnitToUnitVoiceChannelGrant       Opcode = 0x48
+	OpUnitToUnitVoiceChannelGrantUpdate Opcode = 0x49
+	OpGroupAffiliationResponse          Opcode = 0x4C
+	OpUnitRegistrationResponse          Opcode = 0x4D
+	OpEncryptionSync                    Opcode = 0x70
+	OpIdentifierUpdate                  Opcode = 0x7D
+	OpNetworkStatusBroadcastUpdate      Opcode = 0xFB
+	OpRFSSStatusBroadcastUpdate         Opcode = 0xFA
 )
 
 func (o Opcode) String() string {
@@ -69,10 +72,18 @@ func (o Opcode) String() string {
 		return "GroupVoiceChannelUserExt"
 	case OpUnitToUnitVoiceChannelGrant:
 		return "UnitToUnitVoiceChannelGrant"
+	case OpUnitToUnitVoiceChannelGrantUpdate:
+		return "UnitToUnitVoiceChannelGrantUpdate"
+	case OpGroupAffiliationResponse:
+		return "GroupAffiliationResponse"
+	case OpUnitRegistrationResponse:
+		return "UnitRegistrationResponse"
 	case OpVendorGroupRegroup:
 		return "VendorGroupRegroup"
 	case OpVendorTalkerAlias:
 		return "VendorTalkerAlias"
+	case OpMotorolaPatchDelete:
+		return "MotorolaPatchDelete"
 	case OpEncryptionSync:
 		return "EncryptionSync"
 	case OpIdentifierUpdate:
@@ -251,8 +262,10 @@ func (o Opcode) IsKnown() bool {
 	case OpMACPTT, OpMACEnd, OpMACIdle, OpMACHangtime, OpMACActive,
 		OpGroupVoiceChannelGrant, OpGroupVoiceChannelGrantUpdate,
 		OpGroupVoiceChannelUserExt, OpUnitToUnitVoiceChannelGrant,
+		OpUnitToUnitVoiceChannelGrantUpdate, OpGroupAffiliationResponse,
+		OpUnitRegistrationResponse,
 		OpIdentifierUpdate, OpVendorGroupRegroup, OpVendorTalkerAlias,
-		OpEncryptionSync,
+		OpMotorolaPatchDelete, OpEncryptionSync,
 		OpNetworkStatusBroadcastUpdate, OpRFSSStatusBroadcastUpdate:
 		return true
 	}

--- a/internal/radio/p25/phase2/mac.go
+++ b/internal/radio/p25/phase2/mac.go
@@ -43,6 +43,7 @@ const (
 	OpGroupVoiceChannelGrant       Opcode = 0x44
 	OpGroupVoiceChannelUserExt     Opcode = 0x46
 	OpUnitToUnitVoiceChannelGrant  Opcode = 0x48
+	OpEncryptionSync               Opcode = 0x70
 	OpIdentifierUpdate             Opcode = 0x7D
 	OpNetworkStatusBroadcastUpdate Opcode = 0xFB
 	OpRFSSStatusBroadcastUpdate    Opcode = 0xFA
@@ -70,6 +71,8 @@ func (o Opcode) String() string {
 		return "UnitToUnitVoiceChannelGrant"
 	case OpVendorGroupRegroup:
 		return "VendorGroupRegroup"
+	case OpEncryptionSync:
+		return "EncryptionSync"
 	case OpIdentifierUpdate:
 		return "IdentifierUpdate"
 	case OpNetworkStatusBroadcastUpdate:
@@ -246,7 +249,7 @@ func (o Opcode) IsKnown() bool {
 	case OpMACPTT, OpMACEnd, OpMACIdle, OpMACHangtime, OpMACActive,
 		OpGroupVoiceChannelGrant, OpGroupVoiceChannelGrantUpdate,
 		OpGroupVoiceChannelUserExt, OpUnitToUnitVoiceChannelGrant,
-		OpIdentifierUpdate, OpVendorGroupRegroup,
+		OpIdentifierUpdate, OpVendorGroupRegroup, OpEncryptionSync,
 		OpNetworkStatusBroadcastUpdate, OpRFSSStatusBroadcastUpdate:
 		return true
 	}

--- a/internal/radio/p25/phase2/mac.go
+++ b/internal/radio/p25/phase2/mac.go
@@ -71,6 +71,8 @@ func (o Opcode) String() string {
 		return "UnitToUnitVoiceChannelGrant"
 	case OpVendorGroupRegroup:
 		return "VendorGroupRegroup"
+	case OpVendorTalkerAlias:
+		return "VendorTalkerAlias"
 	case OpEncryptionSync:
 		return "EncryptionSync"
 	case OpIdentifierUpdate:
@@ -249,7 +251,8 @@ func (o Opcode) IsKnown() bool {
 	case OpMACPTT, OpMACEnd, OpMACIdle, OpMACHangtime, OpMACActive,
 		OpGroupVoiceChannelGrant, OpGroupVoiceChannelGrantUpdate,
 		OpGroupVoiceChannelUserExt, OpUnitToUnitVoiceChannelGrant,
-		OpIdentifierUpdate, OpVendorGroupRegroup, OpEncryptionSync,
+		OpIdentifierUpdate, OpVendorGroupRegroup, OpVendorTalkerAlias,
+		OpEncryptionSync,
 		OpNetworkStatusBroadcastUpdate, OpRFSSStatusBroadcastUpdate:
 		return true
 	}

--- a/internal/radio/p25/phase2/mac_coverage_test.go
+++ b/internal/radio/p25/phase2/mac_coverage_test.go
@@ -1,0 +1,123 @@
+package phase2
+
+import (
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+func TestAsGroupAffiliationResponse(t *testing.T) {
+	in := GroupAffiliationResponse{
+		Response: 2, AnnouncementGroup: 0x00FF, GroupAddress: 0x1234, TargetID: 0x00BEEF,
+	}
+	got, ok := EncodeGroupAffiliationResponse(in).AsGroupAffiliationResponse()
+	if !ok {
+		t.Fatal("AsGroupAffiliationResponse returned !ok")
+	}
+	if got != in {
+		t.Errorf("round-trip = %+v, want %+v", got, in)
+	}
+}
+
+func TestAsUnitRegistrationResponse(t *testing.T) {
+	in := UnitRegistrationResponse{
+		Response: 1, WACN: 0xABCDE, SystemID: 0x123, SourceID: 0x00BEEF,
+	}
+	got, ok := EncodeUnitRegistrationResponse(in).AsUnitRegistrationResponse()
+	if !ok {
+		t.Fatal("AsUnitRegistrationResponse returned !ok")
+	}
+	if got != in {
+		t.Errorf("round-trip = %+v, want %+v", got, in)
+	}
+}
+
+func TestAsUnitToUnitGrantAcceptsUpdateOpcode(t *testing.T) {
+	pdu := u2uPDU(0x00BEEF, 0x00ABCD, 0x2, 0x123)
+	pdu.Opcode = OpUnitToUnitVoiceChannelGrantUpdate
+	if _, ok := pdu.AsUnitToUnitVoiceChannelGrant(); !ok {
+		t.Error("AsUnitToUnitVoiceChannelGrant rejected the grant-update opcode")
+	}
+}
+
+func TestAsMotorolaPatchDelete(t *testing.T) {
+	pdu := MACPDU{Opcode: OpMotorolaPatchDelete, MFID: MFIDMotorola, Payload: []byte{0x12, 0x34}}
+	super, ok := pdu.AsMotorolaPatchDelete()
+	if !ok || super != 0x1234 {
+		t.Errorf("AsMotorolaPatchDelete = (%#x, %v), want (0x1234, true)", super, ok)
+	}
+	// Wrong MFID must not match.
+	pdu.MFID = MFIDHarris
+	if _, ok := pdu.AsMotorolaPatchDelete(); ok {
+		t.Error("AsMotorolaPatchDelete matched a non-Motorola MFID")
+	}
+}
+
+func TestNewOpcodesAreKnown(t *testing.T) {
+	for _, o := range []Opcode{
+		OpUnitToUnitVoiceChannelGrantUpdate, OpGroupAffiliationResponse,
+		OpUnitRegistrationResponse, OpMotorolaPatchDelete,
+	} {
+		if !o.IsKnown() {
+			t.Errorf("opcode %#x should be known", uint8(o))
+		}
+	}
+}
+
+// TestControlChannelEmitsAffiliationAndRegistration confirms the Phase 2
+// control channel publishes the identity events Phase 1 already does.
+func TestControlChannelEmitsAffiliationAndRegistration(t *testing.T) {
+	bus := events.NewBus(16)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, SystemName: "p2", FrequencyHz: 851_000_000})
+	cc.Ingest(EncodeGroupAffiliationResponse(GroupAffiliationResponse{
+		Response: 0, GroupAddress: 0x1234, TargetID: 0x00ABCD,
+	}))
+	cc.Ingest(EncodeUnitRegistrationResponse(UnitRegistrationResponse{
+		Response: 0, WACN: 0xABCDE, SystemID: 0x123, SourceID: 0x00BEEF,
+	}))
+
+	var sawAff, sawReg bool
+	for {
+		select {
+		case ev := <-sub.C:
+			switch ev.Kind {
+			case events.KindAffiliation:
+				if a := ev.Payload.(trunking.Affiliation); a.GroupID == 0x1234 && a.SourceID == 0x00ABCD {
+					sawAff = true
+				}
+			case events.KindUnitRegistration:
+				if r := ev.Payload.(trunking.UnitRegistration); r.SourceID == 0x00BEEF && r.WACN == 0xABCDE {
+					sawReg = true
+				}
+			}
+		default:
+			if !sawAff {
+				t.Error("no KindAffiliation event")
+			}
+			if !sawReg {
+				t.Error("no KindUnitRegistration event")
+			}
+			return
+		}
+	}
+}
+
+func TestControlChannelPatchDelete(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, SystemName: "p2", FrequencyHz: 851_000_000})
+	cc.Ingest(MACPDU{Opcode: OpMotorolaPatchDelete, MFID: MFIDMotorola, Payload: []byte{0x05, 0x55}})
+
+	p := nextPatch(t, sub)
+	if p.SuperGroup != 0x0555 || p.Add {
+		t.Errorf("patch delete = %+v, want super 0x555 / Add false", p)
+	}
+}

--- a/internal/radio/p25/phase2/mac_standard.go
+++ b/internal/radio/p25/phase2/mac_standard.go
@@ -24,9 +24,12 @@ type UnitToUnitVoiceChannelGrant struct {
 }
 
 // AsUnitToUnitVoiceChannelGrant returns the structured grant if the PDU
-// opcode is OpUnitToUnitVoiceChannelGrant, otherwise (zero, false).
+// opcode is a unit-to-unit voice grant or grant-update, otherwise
+// (zero, false).
 func (p MACPDU) AsUnitToUnitVoiceChannelGrant() (UnitToUnitVoiceChannelGrant, bool) {
-	if p.Opcode != OpUnitToUnitVoiceChannelGrant {
+	switch p.Opcode {
+	case OpUnitToUnitVoiceChannelGrant, OpUnitToUnitVoiceChannelGrantUpdate:
+	default:
 		return UnitToUnitVoiceChannelGrant{}, false
 	}
 	if len(p.Payload) < 9 {
@@ -114,6 +117,72 @@ type EncryptionSync struct {
 	AlgorithmID      uint8
 	KeyID            uint16
 	MessageIndicator [9]byte
+}
+
+// GroupAffiliationResponse is the structured shape of a Phase 2 Group
+// Affiliation Response MAC PDU — published when a radio is granted or
+// denied affiliation with a talkgroup. Layout mirrors the Phase 1 TSBK
+// (phase1.GroupAffiliationResponse):
+//
+//	byte 0     : bits 1-0 = affiliation response value
+//	bytes 1-2  : announcement group address
+//	bytes 3-4  : group address (talkgroup)
+//	bytes 5-7  : target unit ID (24 bits)
+type GroupAffiliationResponse struct {
+	Response          uint8
+	AnnouncementGroup uint16
+	GroupAddress      uint16
+	TargetID          uint32
+}
+
+// AsGroupAffiliationResponse returns the structured response if the PDU
+// opcode is OpGroupAffiliationResponse, otherwise (zero, false).
+func (p MACPDU) AsGroupAffiliationResponse() (GroupAffiliationResponse, bool) {
+	if p.Opcode != OpGroupAffiliationResponse {
+		return GroupAffiliationResponse{}, false
+	}
+	if len(p.Payload) < 8 {
+		return GroupAffiliationResponse{}, false
+	}
+	return GroupAffiliationResponse{
+		Response:          p.Payload[0] & 0x03,
+		AnnouncementGroup: binary.BigEndian.Uint16(p.Payload[1:3]),
+		GroupAddress:      binary.BigEndian.Uint16(p.Payload[3:5]),
+		TargetID:          uint32(p.Payload[5])<<16 | uint32(p.Payload[6])<<8 | uint32(p.Payload[7]),
+	}, true
+}
+
+// UnitRegistrationResponse is the structured shape of a Phase 2 Unit
+// Registration Response MAC PDU — published when a radio completes or
+// is denied registration on a site. Layout mirrors the Phase 1 TSBK
+// (phase1.UnitRegistrationResponse):
+//
+//	byte 0       : bits 1-0 = registration response value
+//	bytes 1-3    : WACN (20 bits, upper 20 of bytes 1-3)
+//	bytes 3-4    : System ID (low nibble of byte 3 + byte 4)
+//	bytes 5-7    : source unit ID (24 bits)
+type UnitRegistrationResponse struct {
+	Response uint8
+	WACN     uint32 // 20-bit
+	SystemID uint16 // 12-bit
+	SourceID uint32 // 24-bit
+}
+
+// AsUnitRegistrationResponse returns the structured response if the PDU
+// opcode is OpUnitRegistrationResponse, otherwise (zero, false).
+func (p MACPDU) AsUnitRegistrationResponse() (UnitRegistrationResponse, bool) {
+	if p.Opcode != OpUnitRegistrationResponse {
+		return UnitRegistrationResponse{}, false
+	}
+	if len(p.Payload) < 8 {
+		return UnitRegistrationResponse{}, false
+	}
+	return UnitRegistrationResponse{
+		Response: p.Payload[0] & 0x03,
+		WACN:     uint32(p.Payload[1])<<12 | uint32(p.Payload[2])<<4 | uint32(p.Payload[3])>>4,
+		SystemID: uint16(p.Payload[3]&0x0F)<<8 | uint16(p.Payload[4]),
+		SourceID: uint32(p.Payload[5])<<16 | uint32(p.Payload[6])<<8 | uint32(p.Payload[7]),
+	}, true
 }
 
 // AsEncryptionSync returns the structured Encryption Sync if the PDU

--- a/internal/radio/p25/phase2/mac_standard.go
+++ b/internal/radio/p25/phase2/mac_standard.go
@@ -79,3 +79,56 @@ func (p MACPDU) AsRFSSStatusBroadcast() (RFSSStatusBroadcast, bool) {
 		ChannelNumber: chanField & 0x0FFF,
 	}, true
 }
+
+// ServiceOptions decodes the 8-bit SVC_OPTIONS field a P25 voice grant
+// carries (TIA-102.AABF, reused by the Phase 2 MAC). Bit 7 = Emergency,
+// bit 6 = Protected (the encryption indicator), bits 0-2 = call
+// priority.
+type ServiceOptions uint8
+
+// Emergency reports the emergency call bit.
+func (s ServiceOptions) Emergency() bool { return s&0x80 != 0 }
+
+// Encrypted reports the protected (encryption) bit.
+func (s ServiceOptions) Encrypted() bool { return s&0x40 != 0 }
+
+// Priority returns the 3-bit call-priority field (0 = lowest).
+func (s ServiceOptions) Priority() uint8 { return uint8(s) & 0x07 }
+
+// EncryptionSync is the P25 Encryption Sync identification a Phase 2
+// MAC PDU carries for a protected call — the Algorithm ID, Key ID, and
+// 72-bit Message Indicator. GopherTrunk, like SDRtrunk, identifies
+// encryption (surfaces which algorithm/key) but does not decrypt.
+//
+// Layout note: the encryption-sync MAC opcode (OpEncryptionSync) and
+// this 12-byte payload packing are the project's working model —
+// TIA-102.BBAB does not appear in the repo's spec PDFs. The accessor
+// is confined here so a spec correction is a one-file change; the
+// grant's ServiceOptions "protected" bit flags encryption independently
+// of this, so the feature degrades gracefully if the layout is wrong.
+//
+//	byte 0     : Algorithm ID
+//	bytes 1-2  : Key ID
+//	bytes 3-11 : 72-bit Message Indicator
+type EncryptionSync struct {
+	AlgorithmID      uint8
+	KeyID            uint16
+	MessageIndicator [9]byte
+}
+
+// AsEncryptionSync returns the structured Encryption Sync if the PDU
+// opcode is OpEncryptionSync, otherwise (zero, false).
+func (p MACPDU) AsEncryptionSync() (EncryptionSync, bool) {
+	if p.Opcode != OpEncryptionSync {
+		return EncryptionSync{}, false
+	}
+	if len(p.Payload) < 12 {
+		return EncryptionSync{}, false
+	}
+	es := EncryptionSync{
+		AlgorithmID: p.Payload[0],
+		KeyID:       binary.BigEndian.Uint16(p.Payload[1:3]),
+	}
+	copy(es.MessageIndicator[:], p.Payload[3:12])
+	return es, true
+}

--- a/internal/radio/p25/phase2/mac_vendor.go
+++ b/internal/radio/p25/phase2/mac_vendor.go
@@ -38,6 +38,10 @@ const (
 	// name (talker alias). Both Motorola (MFID 0x90) and Harris
 	// (MFID 0xA4) emit it; AsTalkerAliasFragment decodes either.
 	OpVendorTalkerAlias Opcode = 0x82
+	// OpMotorolaPatchDelete is the Motorola group-regroup delete
+	// command (MOT_GRG_DEL_CMD, MFID 0x90): it cancels a patch
+	// super-group that an earlier OpVendorGroupRegroup established.
+	OpMotorolaPatchDelete Opcode = 0x83
 )
 
 // ManufacturerName returns a human-readable label for an MFID.
@@ -93,6 +97,19 @@ func (p MACPDU) AsMotorolaPatchGroup() (MotorolaPatchGroup, bool) {
 type HarrisRegroup struct {
 	RegroupGroup uint16
 	TargetID     uint32
+}
+
+// AsMotorolaPatchDelete returns the super-group address a Motorola
+// group-regroup delete (MOT_GRG_DEL_CMD) cancels, if the PDU is one,
+// otherwise (0, false).
+func (p MACPDU) AsMotorolaPatchDelete() (uint32, bool) {
+	if p.Opcode != OpMotorolaPatchDelete || p.MFID != MFIDMotorola {
+		return 0, false
+	}
+	if len(p.Payload) < 2 {
+		return 0, false
+	}
+	return uint32(binary.BigEndian.Uint16(p.Payload[0:2])), true
 }
 
 // AsHarrisRegroup returns the structured regroup if the PDU is a Harris

--- a/internal/radio/p25/phase2/mac_vendor.go
+++ b/internal/radio/p25/phase2/mac_vendor.go
@@ -34,6 +34,10 @@ const (
 	// as a Motorola patch group (AsMotorolaPatchGroup) under MFID 0x90
 	// and as a Harris regroup (AsHarrisRegroup) under MFID 0xA4.
 	OpVendorGroupRegroup Opcode = 0x81
+	// OpVendorTalkerAlias carries one fragment of a radio's display
+	// name (talker alias). Both Motorola (MFID 0x90) and Harris
+	// (MFID 0xA4) emit it; AsTalkerAliasFragment decodes either.
+	OpVendorTalkerAlias Opcode = 0x82
 )
 
 // ManufacturerName returns a human-readable label for an MFID.

--- a/internal/radio/p25/phase2/phase2.go
+++ b/internal/radio/p25/phase2/phase2.go
@@ -1,37 +1,56 @@
 // Package phase2 decodes P25 Phase 2 traffic-channel framing per
-// TIA-102.BBAB / BCKB. Phase 2 introduces 2-slot TDMA on top of the
+// TIA-102.BBAB / BBAC. Phase 2 introduces 2-slot TDMA on top of the
 // existing P25 Phase 1 control-channel infrastructure: the control
 // channel itself stays Phase 1 (FDMA, 4800 sym/sec, C4FM), but voice
 // grants direct subscribers to a Phase 2 traffic channel that runs
-// 6000 sym/sec H-DQPSK (or H-CPM in some references) carrying two
-// concurrent timeslots.
+// 6000 sym/sec H-DQPSK carrying two concurrent timeslots.
+//
+// The live decode path is structured: the receiver
+// (internal/radio/p25/phase2/receiver) recovers the H-DQPSK dibit
+// stream, SuperframeDecoder (superframe_decoder.go) locks the 360 ms
+// TDMA superframe and slices its 12 sub-frames, isch.go decodes each
+// sub-frame's SlotType, and IngestSuperframe (superframe_ingest.go)
+// routes the MAC-bearing sub-frames into the control-channel state
+// machine while the composer voice chain extracts voice.
 //
 // What this package gives you:
 //
-//	sync.go        Phase 2 outbound + inbound sync constants.
-//	superframe.go  Superframe + slot-type layout constants.
-//	mac.go         MAC PDU structure + opcode enum + payload
-//	               accessors. MAC PDUs carry late-grant signalling
-//	               (GroupVoiceChannelGrantUpdate, MAC_PTT, etc.)
-//	               on top of the Phase 2 voice frames.
-//	control.go     State machine that ingests MAC PDUs and
-//	               publishes events.KindGrant on the bus, with the
-//	               trunking.Grant.Protocol tag set to
-//	               "p25-phase2".
+//	sync.go               Phase 2 outbound + inbound sync constants.
+//	superframe.go         Superframe + slot-type layout constants.
+//	superframe_decoder.go SuperframeDecoder: dibit stream → 360 ms
+//	                      superframes of 12 SlotType-tagged sub-frames.
+//	isch.go               ISCH (Inter-Slot Channel) SlotType decode.
+//	process.go            Flat sync-window MAC PDU adapter + the
+//	                      decodeMACPDUDibits FEC chain (trellis, RS,
+//	                      PN44 descramble, block deinterleave).
+//	superframe_ingest.go  IngestSuperframe: route MAC sub-frames into
+//	                      the state machine.
+//	voice.go              AMBE+2 voice-frame extraction (4V / 2V slots).
+//	mac.go / mac_standard.go / mac_vendor.go
+//	                      MAC PDU structure, opcode enum, and per-opcode
+//	                      accessors — standard plus Motorola/Harris
+//	                      vendor messages (patch/regroup, talker alias),
+//	                      encryption identification.
+//	talker_alias.go       Multi-fragment talker-alias reassembly.
+//	identifier.go         Band-plan accumulator: resolves a grant's
+//	                      (ChannelID, ChannelNumber) to a frequency.
+//	control.go            State machine that ingests MAC PDUs and
+//	                      publishes events.KindGrant / KindCCLocked /
+//	                      KindPatch / KindAffiliation / KindTalkerAlias,
+//	                      with trunking.Grant.Protocol set to
+//	                      "p25-phase2".
+//	encode.go             Synthesized-fixture encoders (test scaffolding).
 //
-// What's NOT yet wired (honest deferrals):
+// Honest non-goals and working models:
 //
-//   - The H-DQPSK / H-CPM symbol decoder for the Phase 2 traffic
-//     channel. internal/dsp/demod/dqpsk.go is the closest fit;
-//     wiring it through a TDMA superframe-sync stage is the gating
-//     piece for live captures.
-//   - TDMA superframe / sub-slot synchronisation. Phase 2
-//     superframes are scheduled in 12 sub-frames per 360 ms, with
-//     the two timeslots interleaved at the symbol level.
-//   - Voice frame extraction → AMBE+2 vocoder. The frame layout is
-//     here; the AMBE+2 decode lives in internal/voice/ambe2 (pure-Go,
-//     default-on).
-//   - Reed-Solomon / Trellis FEC over the MAC PDU bits. The
-//     parsing here assumes the upstream caller has already
-//     corrected errors.
+//   - Decryption. Like SDRtrunk, this package identifies encryption
+//     (algorithm ID, key ID) but does not decrypt voice.
+//   - Inbound (MS → BS) uplink decoding. Only the outbound downlink is
+//     decoded — the inbound sync constant in sync.go is unused.
+//   - Several TIA-102.BBAB/BBAC wire details — the superframe sync
+//     cadence, the ISCH and voice-slot bit layouts, the encryption-sync
+//     and talker-alias MAC opcodes, the per-burst block interleaver —
+//     are not in the repo's spec PDFs. Each is implemented as a
+//     documented working model confined to one file with a symmetric
+//     encoder, so a real-capture calibration is a local change.
 package phase2

--- a/internal/radio/p25/phase2/process.go
+++ b/internal/radio/p25/phase2/process.go
@@ -111,7 +111,21 @@ func (c *ControlChannel) Process(dibits []uint8, baseIdx int) int {
 }
 
 // tryIngestMACPDU recovers an 18-byte MAC PDU from the collected
-// post-sync dibits. The dibit slice layout depends on TrellisMode:
+// post-sync dibits and, on success, forwards it to Ingest. It is the
+// flat sync-window path; the FEC chain itself lives in the pure
+// decodeMACPDUDibits helper, which the superframe-structured path
+// (superframe_ingest.go) reuses.
+func (c *ControlChannel) tryIngestMACPDU(macDibits []uint8, mode TrellisMode, rsMode RSMode, interleaveMode InterleaveMode, scramblerMode ScramblerMode, scramblerSeed uint64, scramblerOffset int) {
+	if pdu, ok := decodeMACPDUDibits(macDibits, mode, rsMode, interleaveMode, scramblerMode, scramblerSeed, scramblerOffset); ok {
+		c.Ingest(pdu)
+	}
+}
+
+// decodeMACPDUDibits runs the full MAC-PDU recovery chain over a
+// collected dibit window and returns the parsed PDU. It is a pure
+// function (no ControlChannel state) so both the flat Process adapter
+// and the superframe-structured IngestSuperframe can share it. The
+// dibit slice layout depends on TrellisMode:
 //
 //   - TrellisOff: macDibits is exactly macPDUDibits (72) raw
 //     dibits whose bits ARE the MAC PDU information bits.
@@ -121,29 +135,29 @@ func (c *ControlChannel) Process(dibits []uint8, baseIdx int) int {
 //     dibits + 1 finisher transition. DecodeP25Trellis recovers
 //     the 72 information dibits.
 //
+// When interleaveMode is InterleaveOn the per-burst block
+// interleaver (TIA-102.BBAC) is undone before trellis decoding.
+//
 // When scramblerMode is ScramblerOn the recovered 144 info bits
 // are XORed with 144 bits of the PN44 sequence starting at
 // scramblerOffset (per TIA-102.BBAC-1 §7.2.5) before RS check or
 // MAC parse runs.
 //
-// When scramblerMode is ScramblerProbe the adapter tries each of
-// the 12 spec-defined slot offsets in
-// framing.PN44SlotOffsetsOutbound (Figure 7-5) and accepts the
-// first candidate whose outer RS(24, 16, 9) syndromes are zero —
-// the blind-probe form for receivers without superframe
-// synchronization. ScramblerProbe requires rsMode == RSOn;
-// without RS verification there is no way to tell which
-// descrambled candidate is the true PDU, so the adapter degrades
-// to ScramblerOn behaviour (offset 0).
+// When scramblerMode is ScramblerProbe each of the 12 spec-defined
+// slot offsets in framing.PN44SlotOffsetsOutbound (Figure 7-5) is
+// tried and the first candidate whose outer RS(24, 16, 9) syndromes
+// are zero is accepted — the blind-probe form for receivers without
+// superframe synchronization. ScramblerProbe requires rsMode == RSOn;
+// otherwise it degrades to ScramblerOn behaviour at scramblerOffset.
 //
 // When rsMode is RSOn the (post-descramble) 18-byte MAC PDU is
 // re-grouped into 24 hex symbols and verified against the
-// RS(24, 16, 9) outer code per TIA-102.BAAA-A §5.9. PDUs whose
-// syndromes are non-zero are dropped silently.
-func (c *ControlChannel) tryIngestMACPDU(macDibits []uint8, mode TrellisMode, rsMode RSMode, interleaveMode InterleaveMode, scramblerMode ScramblerMode, scramblerSeed uint64, scramblerOffset int) {
-	// Undo the per-burst block interleaver (TIA-102.BBAC) before trellis
-	// decoding, when enabled. DeinterleaveMACBurst returns a fresh slice
-	// so the caller's buffer is untouched.
+// RS(24, 16, 9) outer code per TIA-102.BAAA-A §5.9; PDUs whose
+// syndromes are non-zero are rejected.
+func decodeMACPDUDibits(macDibits []uint8, mode TrellisMode, rsMode RSMode, interleaveMode InterleaveMode, scramblerMode ScramblerMode, scramblerSeed uint64, scramblerOffset int) (MACPDU, bool) {
+	// Undo the per-burst block interleaver before trellis decoding,
+	// when enabled. DeinterleaveMACBurst returns a fresh slice so the
+	// caller's buffer is untouched.
 	if interleaveMode == InterleaveOn {
 		macDibits = framing.DeinterleaveMACBurst(macDibits)
 	}
@@ -151,16 +165,16 @@ func (c *ControlChannel) tryIngestMACPDU(macDibits []uint8, mode TrellisMode, rs
 	switch mode {
 	case TrellisOn:
 		if len(macDibits) != macPDUDibitsTrellis {
-			return
+			return MACPDU{}, false
 		}
 		decoded, _ := framing.DecodeP25Trellis(macDibits)
 		if len(decoded) != macPDUDibits {
-			return
+			return MACPDU{}, false
 		}
 		infoDibits = decoded
 	default:
 		if len(macDibits) != macPDUDibits {
-			return
+			return MACPDU{}, false
 		}
 		infoDibits = macDibits
 	}
@@ -168,14 +182,8 @@ func (c *ControlChannel) tryIngestMACPDU(macDibits []uint8, mode TrellisMode, rs
 
 	switch scramblerMode {
 	case ScramblerProbe:
-		// Probe each spec-defined slot offset; accept the first
-		// whose RS(24, 16, 9) syndromes are zero. Falls through to
-		// the ScramblerOn-with-offset-0 path when rsMode is RSOff
-		// since there's no way to pick a winning candidate without
-		// the verifier.
 		if rsMode != RSOn {
-			c.applyDescrambleAndIngest(rawBits, scramblerSeed, scramblerOffset, rsMode)
-			return
+			return descrambleAndParse(rawBits, scramblerSeed, scramblerOffset, rsMode)
 		}
 		for _, off := range framing.PN44SlotOffsetsOutbound {
 			candidate := append([]byte(nil), rawBits...)
@@ -185,43 +193,43 @@ func (c *ControlChannel) tryIngestMACPDU(macDibits []uint8, mode TrellisMode, rs
 				continue
 			}
 			if pdu, err := ParseMACPDU(info[:18]); err == nil {
-				c.Ingest(pdu)
+				return pdu, true
 			}
-			return
+			return MACPDU{}, false
 		}
-		return
+		return MACPDU{}, false
 	case ScramblerOn:
-		c.applyDescrambleAndIngest(rawBits, scramblerSeed, scramblerOffset, rsMode)
-		return
+		return descrambleAndParse(rawBits, scramblerSeed, scramblerOffset, rsMode)
 	default:
 		info := framing.PackBitsMSB(rawBits)
 		if len(info) < 18 {
-			return
+			return MACPDU{}, false
 		}
 		if rsMode == RSOn && !verifyMACPDURS(info[:18]) {
-			return
+			return MACPDU{}, false
 		}
 		if pdu, err := ParseMACPDU(info[:18]); err == nil {
-			c.Ingest(pdu)
+			return pdu, true
 		}
+		return MACPDU{}, false
 	}
 }
 
-// applyDescrambleAndIngest descrambles in-place at the supplied
-// offset, RS-verifies (when rsMode == RSOn), and forwards the PDU
-// to Ingest if parsing succeeds.
-func (c *ControlChannel) applyDescrambleAndIngest(bits []byte, seed uint64, offset int, rsMode RSMode) {
+// descrambleAndParse descrambles bits in-place at the supplied offset,
+// RS-verifies (when rsMode == RSOn), and returns the parsed PDU.
+func descrambleAndParse(bits []byte, seed uint64, offset int, rsMode RSMode) (MACPDU, bool) {
 	descrambleAtOffset(bits, seed, offset)
 	info := framing.PackBitsMSB(bits)
 	if len(info) < 18 {
-		return
+		return MACPDU{}, false
 	}
 	if rsMode == RSOn && !verifyMACPDURS(info[:18]) {
-		return
+		return MACPDU{}, false
 	}
 	if pdu, err := ParseMACPDU(info[:18]); err == nil {
-		c.Ingest(pdu)
+		return pdu, true
 	}
+	return MACPDU{}, false
 }
 
 // descrambleAtOffset XOR-descrambles bits in-place with the PN44

--- a/internal/radio/p25/phase2/superframe_ingest.go
+++ b/internal/radio/p25/phase2/superframe_ingest.go
@@ -1,0 +1,62 @@
+package phase2
+
+import "github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+
+// MACPayloadOffset is the dibit offset of the MAC PDU within a
+// 180-dibit sub-frame: it follows the SyncDibits-wide region and the
+// ISCH, sharing the same start as a voice sub-frame's first voice
+// frame (VoiceFrameOffset). The MAC PDU width itself is macPDUDibits
+// (raw) or macPDUDibitsTrellis (trellis-coded), selected by TrellisMode.
+const MACPayloadOffset = ISCHOffset + ISCHDibits
+
+// IngestSuperframe routes every MAC-bearing sub-frame of sf through the
+// MAC-PDU FEC chain into Ingest. It is the superframe-structured
+// counterpart of the flat Process adapter: the SuperframeDecoder has
+// already locked the 360 ms superframe, sliced the 12 sub-frames, and
+// decoded each ISCH SlotType, so this routes only the sub-frames whose
+// SlotType.IsMAC() and skips voice sub-frames — the composer voice
+// chain (internal/voice/composer/p25p2_voice.go) owns voice extraction.
+//
+// Because superframe sync pins which of the 12 TDMA slots a sub-frame
+// occupies, the PN44 descrambler can be handed its true per-slot offset
+// (slotPN44Offset) instead of blind-probing every offset.
+func (c *ControlChannel) IngestSuperframe(sf Superframe) {
+	c.mu.Lock()
+	mode := c.trellisMode
+	rsMode := c.rsMode
+	interleaveMode := c.interleaveMode
+	scramblerMode := c.scramblerMode
+	scramblerSeed := c.scramblerSeed
+	c.mu.Unlock()
+
+	macLen := macPDUDibits
+	if mode == TrellisOn {
+		macLen = macPDUDibitsTrellis
+	}
+	for _, sub := range sf.Subframes {
+		if !sub.SlotType.IsMAC() {
+			continue
+		}
+		if len(sub.Dibits) < MACPayloadOffset+macLen {
+			continue
+		}
+		macDibits := sub.Dibits[MACPayloadOffset : MACPayloadOffset+macLen]
+		offset := slotPN44Offset(sub.Index)
+		if pdu, ok := decodeMACPDUDibits(macDibits, mode, rsMode, interleaveMode,
+			scramblerMode, scramblerSeed, offset); ok {
+			c.Ingest(pdu)
+		}
+	}
+}
+
+// slotPN44Offset returns the PN44 sequence offset for sub-frame index
+// (0..11) — the spec-defined per-slot offset, known here because
+// superframe sync pins which slot a sub-frame occupies. Out-of-range
+// indices fall back to offset 0.
+func slotPN44Offset(index int) int {
+	offs := framing.PN44SlotOffsetsOutbound
+	if index < 0 || index >= len(offs) {
+		return 0
+	}
+	return offs[index]
+}

--- a/internal/radio/p25/phase2/superframe_ingest_test.go
+++ b/internal/radio/p25/phase2/superframe_ingest_test.go
@@ -1,0 +1,96 @@
+package phase2
+
+import (
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// decodeOneSuperframe builds a 50-dibit lead-in + the encoded
+// superframe and returns the single decoded Superframe.
+func decodeOneSuperframe(t *testing.T, subs [SubframesPerSuperframe][]uint8) Superframe {
+	t.Helper()
+	stream := append(make([]uint8, 50), EncodeSuperframe(subs)...)
+	got := NewSuperframeDecoder().Process(stream, 0)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 superframe, got %d", len(got))
+	}
+	return got[0]
+}
+
+func countGrants(sub *events.Subscription) []trunking.Grant {
+	var out []trunking.Grant
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind == events.KindGrant {
+				out = append(out, ev.Payload.(trunking.Grant))
+			}
+		default:
+			return out
+		}
+	}
+}
+
+// TestIngestSuperframeRoutesMACSubframes confirms IngestSuperframe
+// decodes the MAC-bearing sub-frames into grants and skips the voice
+// sub-frames.
+func TestIngestSuperframeRoutesMACSubframes(t *testing.T) {
+	bus := events.NewBus(32)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, SystemName: "p2", FrequencyHz: 851_000_000})
+	cc.SetTrellisMode(TrellisOn)
+
+	grant := grantPDU(0x1234, 0x00ABCD, 0x1, 0x005)
+	grant.Payload = append(grant.Payload, make([]byte, 17-len(grant.Payload))...)
+
+	var subs [SubframesPerSuperframe][]uint8
+	for i := range subs {
+		if i == 0 {
+			subs[i] = EncodeMACSubframe(SlotTypeMACSignaling, uint8(i), grant,
+				TrellisOn, InterleaveOff)
+		} else {
+			subs[i] = EncodeVoiceSubframe(SlotTypeVoice4V, uint8(i),
+				voicePayloads(Voice4VFrameCount))
+		}
+	}
+
+	cc.IngestSuperframe(decodeOneSuperframe(t, subs))
+
+	grants := countGrants(sub)
+	if len(grants) != 1 {
+		t.Fatalf("expected exactly 1 grant (voice sub-frames must be skipped), got %d", len(grants))
+	}
+	if grants[0].GroupID != 0x1234 {
+		t.Errorf("grant GroupID = %#x, want 0x1234", grants[0].GroupID)
+	}
+}
+
+// TestIngestSuperframeAllVoicePublishesNothing confirms an all-voice
+// superframe drives no control-channel events — the composer owns voice.
+func TestIngestSuperframeAllVoicePublishesNothing(t *testing.T) {
+	bus := events.NewBus(16)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, SystemName: "p2", FrequencyHz: 851_000_000})
+	cc.SetTrellisMode(TrellisOn)
+
+	var subs [SubframesPerSuperframe][]uint8
+	for i := range subs {
+		subs[i] = EncodeVoiceSubframe(SlotTypeVoice4V, uint8(i),
+			voicePayloads(Voice4VFrameCount))
+	}
+	cc.IngestSuperframe(decodeOneSuperframe(t, subs))
+
+	select {
+	case ev := <-sub.C:
+		t.Errorf("all-voice superframe published an event: %v", ev.Kind)
+	default:
+	}
+}

--- a/internal/radio/p25/phase2/talker_alias.go
+++ b/internal/radio/p25/phase2/talker_alias.go
@@ -1,0 +1,160 @@
+package phase2
+
+import (
+	"sync"
+	"time"
+)
+
+// P25 Phase 2 talker-alias reassembly.
+//
+// A talker alias — the human-readable display name of a radio — is too
+// long for one MAC PDU, so a system sends it as a numbered sequence of
+// fragment PDUs. TalkerAliasAssembler buffers the fragments per source
+// unit and emits the completed name once every block has arrived.
+//
+// Layout note: the talker-alias MAC opcode, the fragment header, and
+// the character encoding are not in the repo's spec PDFs — Motorola and
+// Harris each have their own talker-alias format. This file is the
+// project's working model: a single OpVendorTalkerAlias opcode whose
+// payload is SourceID(3) + BlockIndex(1) + BlockCount(1) + Data, ASCII
+// in the data. All wire detail is confined here; the assembler logic
+// (per-source buffering, completion, staleness eviction) is
+// encoding-independent and tolerant of reordered or missing fragments.
+
+// TalkerAliasFragment is one numbered piece of a radio's talker alias.
+type TalkerAliasFragment struct {
+	SourceID   uint32
+	BlockIndex uint8
+	BlockCount uint8
+	Data       []byte
+}
+
+// AsTalkerAliasFragment returns the fragment if the PDU opcode is
+// OpVendorTalkerAlias, otherwise (zero, false). It is MFID-agnostic —
+// both Motorola and Harris alias PDUs decode through it.
+func (p MACPDU) AsTalkerAliasFragment() (TalkerAliasFragment, bool) {
+	if p.Opcode != OpVendorTalkerAlias {
+		return TalkerAliasFragment{}, false
+	}
+	if len(p.Payload) < 5 {
+		return TalkerAliasFragment{}, false
+	}
+	f := TalkerAliasFragment{
+		SourceID:   uint32(p.Payload[0])<<16 | uint32(p.Payload[1])<<8 | uint32(p.Payload[2]),
+		BlockIndex: p.Payload[3],
+		BlockCount: p.Payload[4],
+	}
+	f.Data = append([]byte(nil), p.Payload[5:]...)
+	return f, true
+}
+
+// Talker-alias assembler bounds.
+const (
+	// aliasStaleAfter is how long an incomplete alias is kept before a
+	// later Add evicts it — a lost final fragment must not leak memory.
+	aliasStaleAfter = 10 * time.Second
+	// aliasMaxPending caps the number of distinct source units buffered
+	// at once; the oldest is dropped when the cap is reached.
+	aliasMaxPending = 64
+	// aliasMaxBlocks caps the block count an alias may claim.
+	aliasMaxBlocks = 16
+)
+
+type aliasBuf struct {
+	count   uint8
+	blocks  map[uint8][]byte
+	updated time.Time
+}
+
+// TalkerAliasAssembler reassembles talker-alias fragments per source
+// unit. It is safe for concurrent use; construct one per ControlChannel.
+type TalkerAliasAssembler struct {
+	now     func() time.Time
+	mu      sync.Mutex
+	pending map[uint32]*aliasBuf
+}
+
+// NewTalkerAliasAssembler returns a ready assembler. now is injectable
+// for tests; nil defaults to time.Now.
+func NewTalkerAliasAssembler(now func() time.Time) *TalkerAliasAssembler {
+	if now == nil {
+		now = time.Now
+	}
+	return &TalkerAliasAssembler{now: now, pending: make(map[uint32]*aliasBuf)}
+}
+
+// Add feeds one fragment to the assembler. When the fragment completes
+// an alias it returns (alias, sourceID, true) and forgets the source;
+// otherwise (\"\", 0, false). Out-of-range or malformed fragments are
+// ignored. Add is tolerant of fragments arriving in any order.
+func (a *TalkerAliasAssembler) Add(f TalkerAliasFragment) (string, uint32, bool) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	a.evictStaleLocked()
+	if f.BlockCount == 0 || f.BlockCount > aliasMaxBlocks || f.BlockIndex >= f.BlockCount {
+		return "", 0, false
+	}
+	buf := a.pending[f.SourceID]
+	if buf == nil {
+		if len(a.pending) >= aliasMaxPending {
+			a.evictOldestLocked()
+		}
+		buf = &aliasBuf{blocks: make(map[uint8][]byte)}
+		a.pending[f.SourceID] = buf
+	}
+	buf.count = f.BlockCount
+	buf.blocks[f.BlockIndex] = append([]byte(nil), f.Data...)
+	buf.updated = a.now()
+
+	if len(buf.blocks) < int(buf.count) {
+		return "", 0, false
+	}
+	var raw []byte
+	for i := uint8(0); i < buf.count; i++ {
+		b, ok := buf.blocks[i]
+		if !ok {
+			return "", 0, false // a duplicate filled the count but a gap remains
+		}
+		raw = append(raw, b...)
+	}
+	delete(a.pending, f.SourceID)
+	return cleanAlias(raw), f.SourceID, true
+}
+
+// evictStaleLocked drops incomplete aliases older than aliasStaleAfter.
+func (a *TalkerAliasAssembler) evictStaleLocked() {
+	cutoff := a.now().Add(-aliasStaleAfter)
+	for src, buf := range a.pending {
+		if buf.updated.Before(cutoff) {
+			delete(a.pending, src)
+		}
+	}
+}
+
+// evictOldestLocked drops the single least-recently-updated alias.
+func (a *TalkerAliasAssembler) evictOldestLocked() {
+	var oldestSrc uint32
+	var oldest time.Time
+	first := true
+	for src, buf := range a.pending {
+		if first || buf.updated.Before(oldest) {
+			oldestSrc, oldest, first = src, buf.updated, false
+		}
+	}
+	if !first {
+		delete(a.pending, oldestSrc)
+	}
+}
+
+// cleanAlias trims trailing NULs and renders the alias bytes as a
+// printable ASCII string, dropping control characters.
+func cleanAlias(raw []byte) string {
+	out := make([]byte, 0, len(raw))
+	for _, b := range raw {
+		if b >= 0x20 && b < 0x7F {
+			out = append(out, b)
+		}
+	}
+	return string(out)
+}

--- a/internal/radio/p25/phase2/talker_alias_test.go
+++ b/internal/radio/p25/phase2/talker_alias_test.go
@@ -1,0 +1,96 @@
+package phase2
+
+import (
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+func TestTalkerAliasFragmentRoundTrip(t *testing.T) {
+	in := TalkerAliasFragment{
+		SourceID: 0x00ABCD, BlockIndex: 2, BlockCount: 4, Data: []byte("NAME"),
+	}
+	got, ok := EncodeTalkerAliasFragment(in).AsTalkerAliasFragment()
+	if !ok {
+		t.Fatal("AsTalkerAliasFragment returned !ok")
+	}
+	if got.SourceID != in.SourceID || got.BlockIndex != in.BlockIndex ||
+		got.BlockCount != in.BlockCount || string(got.Data) != string(in.Data) {
+		t.Errorf("round-trip = %+v, want %+v", got, in)
+	}
+}
+
+func frag(src uint32, idx, count uint8, data string) TalkerAliasFragment {
+	return TalkerAliasFragment{SourceID: src, BlockIndex: idx, BlockCount: count, Data: []byte(data)}
+}
+
+func TestTalkerAliasAssemblerInOrder(t *testing.T) {
+	a := NewTalkerAliasAssembler(nil)
+	if _, _, done := a.Add(frag(1, 0, 3, "FIRE")); done {
+		t.Fatal("block 0 of 3 should not complete")
+	}
+	if _, _, done := a.Add(frag(1, 1, 3, " ENG")); done {
+		t.Fatal("block 1 of 3 should not complete")
+	}
+	alias, src, done := a.Add(frag(1, 2, 3, "INE 1"))
+	if !done {
+		t.Fatal("block 2 of 3 should complete the alias")
+	}
+	if src != 1 || alias != "FIRE ENGINE 1" {
+		t.Errorf("completed alias = (%d, %q), want (1, %q)", src, alias, "FIRE ENGINE 1")
+	}
+}
+
+func TestTalkerAliasAssemblerOutOfOrder(t *testing.T) {
+	a := NewTalkerAliasAssembler(nil)
+	a.Add(frag(9, 2, 3, "INE 1"))
+	a.Add(frag(9, 0, 3, "FIRE"))
+	alias, _, done := a.Add(frag(9, 1, 3, " ENG"))
+	if !done || alias != "FIRE ENGINE 1" {
+		t.Errorf("out-of-order assembly = (%q, %v), want (%q, true)", alias, done, "FIRE ENGINE 1")
+	}
+}
+
+func TestTalkerAliasAssemblerEvictsStale(t *testing.T) {
+	clk := time.Unix(1000, 0)
+	a := NewTalkerAliasAssembler(func() time.Time { return clk })
+
+	if _, _, done := a.Add(frag(0xAA, 0, 2, "AB")); done {
+		t.Fatal("one block of two should not complete")
+	}
+	// Advance past the staleness window; the next Add must evict the
+	// stale block 0 so block 1 alone does not complete.
+	clk = clk.Add(aliasStaleAfter + time.Second)
+	if _, _, done := a.Add(frag(0xAA, 1, 2, "CD")); done {
+		t.Error("stale block 0 should have been evicted; alias must not complete")
+	}
+}
+
+func TestControlChannelPublishesTalkerAlias(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, SystemName: "p2", FrequencyHz: 851_000_000})
+	cc.Ingest(EncodeTalkerAliasFragment(frag(0x1234, 0, 2, "UNIT")))
+	cc.Ingest(EncodeTalkerAliasFragment(frag(0x1234, 1, 2, "-7")))
+
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind == events.KindTalkerAlias {
+				ta := ev.Payload.(trunking.TalkerAlias)
+				if ta.SourceID != 0x1234 || ta.Alias != "UNIT-7" {
+					t.Errorf("talker alias = (%#x, %q), want (0x1234, %q)",
+						ta.SourceID, ta.Alias, "UNIT-7")
+				}
+				return
+			}
+		default:
+			t.Fatal("no KindTalkerAlias event published")
+		}
+	}
+}

--- a/internal/scanner/ccdecoder/pipelines.go
+++ b/internal/scanner/ccdecoder/pipelines.go
@@ -262,10 +262,19 @@ func newP25Phase2Pipeline(opts PipelineOptions) (ProtocolPipeline, error) {
 		opts.Log.Warn("ccdecoder: unrecognised p25_phase2_clock_mode; falling back to gardner",
 			"system", opts.SystemName, "value", opts.System.P25Phase2ClockMode)
 	}
+	// The receiver's dibit stream drives a SuperframeDecoder: it locks
+	// the 360 ms TDMA superframe, slices the 12 sub-frames, decodes
+	// each ISCH SlotType, and IngestSuperframe routes the MAC-bearing
+	// sub-frames into the control-channel state machine. cc.Process
+	// (the flat sync-window adapter) stays available for callers that
+	// feed pre-stripped fixtures, but the live pipeline is structured.
+	sfDec := p25phase2.NewSuperframeDecoder()
 	rx := p25phase2rx.New(p25phase2rx.Options{
 		SampleRateHz: opts.SampleRateHz,
 		DibitSink: func(dibits []uint8, baseIdx int) {
-			cc.Process(dibits, baseIdx)
+			for _, sf := range sfDec.Process(dibits, baseIdx) {
+				cc.IngestSuperframe(sf)
+			}
 		},
 		ClockMode: clockMode,
 		// Tuned smaller than the 0.03 default — H-DQPSK at
@@ -276,17 +285,21 @@ func newP25Phase2Pipeline(opts PipelineOptions) (ProtocolPipeline, error) {
 		// Only applied when ClockMode == ClockGardner.
 		GardnerGain: 0.005,
 	})
-	return &p25Phase2Pipeline{rx: rx, cc: cc}, nil
+	return &p25Phase2Pipeline{rx: rx, cc: cc, sfDec: sfDec}, nil
 }
 
 type p25Phase2Pipeline struct {
-	rx *p25phase2rx.Receiver
-	cc *p25phase2.ControlChannel
+	rx    *p25phase2rx.Receiver
+	cc    *p25phase2.ControlChannel
+	sfDec *p25phase2.SuperframeDecoder
 }
 
 func (p *p25Phase2Pipeline) Process(iq []complex64) { p.rx.Process(iq) }
-func (p *p25Phase2Pipeline) Reset()                 { p.rx.Reset() }
-func (p *p25Phase2Pipeline) Close() error           { return nil }
+func (p *p25Phase2Pipeline) Reset() {
+	p.rx.Reset()
+	p.sfDec.Reset()
+}
+func (p *p25Phase2Pipeline) Close() error { return nil }
 
 // newTETRAPipeline wires internal/radio/tetra/receiver into
 // tetra.ControlChannel.Process. The receiver's DibitSink forwards

--- a/internal/trunking/affiliation.go
+++ b/internal/trunking/affiliation.go
@@ -81,3 +81,16 @@ type UnitRegistration struct {
 	Response RegistrationResponse // accepted / failed / denied / refused
 	At       time.Time
 }
+
+// TalkerAlias is published on the events bus when a radio's display
+// name (the "talker alias") has been fully reassembled from the
+// multi-fragment vendor MAC PDUs that carry it. Emitted by the P25
+// Phase 2 decoder. Keyed by SourceID so a consumer can associate it
+// with the active call whose Grant.SourceID matches.
+type TalkerAlias struct {
+	System   string // System name, matches trunking.System.Name
+	Protocol string // "p25-phase2"
+	SourceID uint32 // radio unit the alias names
+	Alias    string // the reassembled display name
+	At       time.Time
+}

--- a/internal/trunking/engine.go
+++ b/internal/trunking/engine.go
@@ -24,6 +24,7 @@ type Engine struct {
 	log        *slog.Logger
 	pool       *VoicePool
 	talkgroups *TalkgroupDB
+	patches    *PatchRegistry
 	timeout    time.Duration
 	now        func() time.Time
 	sub        *events.Subscription
@@ -82,6 +83,7 @@ func NewEngine(opts EngineOptions) (*Engine, error) {
 		log:        opts.Log,
 		pool:       opts.VoicePool,
 		talkgroups: opts.Talkgroups,
+		patches:    NewPatchRegistry(),
 		timeout:    opts.CallTimeout,
 		now:        opts.Now,
 		scanMode:   opts.ScanMode,
@@ -120,14 +122,16 @@ func (e *Engine) Run(ctx context.Context) error {
 			if !ok {
 				return nil
 			}
-			if ev.Kind != events.KindGrant {
-				continue
+			switch ev.Kind {
+			case events.KindGrant:
+				if g, ok := ev.Payload.(Grant); ok {
+					e.HandleGrant(g)
+				}
+			case events.KindPatch:
+				if p, ok := ev.Payload.(Patch); ok {
+					e.handlePatch(p)
+				}
 			}
-			g, ok := ev.Payload.(Grant)
-			if !ok {
-				continue
-			}
-			e.HandleGrant(g)
 		case <-tick.C:
 			e.runWatchdog()
 		}
@@ -149,11 +153,27 @@ func (e *Engine) HandleGrant(g Grant) {
 		e.log.Info("grant locked out", "grant", g.String(), "tg", tg.AlphaTag)
 		return
 	}
+	// Patch attribution: when GroupID is an active patch super-group,
+	// the call is physically the shared traffic of its member
+	// talkgroups. Tag the grant with the members so the call is
+	// attributed to each of them.
+	if members := e.patches.MembersOf(g.GroupID); len(members) > 0 {
+		g.PatchedGroups = members
+	}
 	// Scan list gate: in ScanModeList, drop grants whose TG is missing
 	// or has Scan==false (Emergency bypasses, matching Lockout's
-	// emergency exception above). In ScanModeAll the gate is a no-op.
+	// emergency exception above). A patched super-group passes if the
+	// super-group OR any member talkgroup is scanned. In ScanModeAll
+	// the gate is a no-op.
 	if e.ScanMode() == ScanModeList && !g.Emergency {
-		if tg == nil || !tg.Scan {
+		scanned := tg != nil && tg.Scan
+		for _, m := range g.PatchedGroups {
+			if mt := e.talkgroups.Lookup(m); mt != nil && mt.Scan {
+				scanned = true
+				break
+			}
+		}
+		if !scanned {
 			e.log.Debug("grant not in scan list", "grant", g.String())
 			return
 		}
@@ -179,6 +199,28 @@ func (e *Engine) HandleGrant(g Grant) {
 	e.endCall(victim, EndReasonPreempted)
 	e.startCall(victim.Device, g, tg)
 }
+
+// handlePatch applies a patch announcement to the registry: an Add
+// records the super-group → members mapping so later grants on the
+// super-group are attributed to its members; a cancel drops it.
+func (e *Engine) handlePatch(p Patch) {
+	if p.Add {
+		e.patches.Apply(PatchGroup{
+			SuperGroup: p.SuperGroup,
+			Members:    p.Members,
+			Vendor:     p.Vendor,
+			UpdatedAt:  e.now(),
+		})
+		e.log.Debug("patch group active",
+			"super", p.SuperGroup, "members", p.Members, "vendor", p.Vendor)
+		return
+	}
+	e.patches.Delete(p.SuperGroup)
+	e.log.Debug("patch group cancelled", "super", p.SuperGroup)
+}
+
+// Patches returns a snapshot of the engine's active patch groups.
+func (e *Engine) Patches() []PatchGroup { return e.patches.Active() }
 
 // EndCall is the explicit external signal that a call has ended (e.g.
 // the protocol decoder saw a channel-release announcement, or an upstream

--- a/internal/trunking/grant.go
+++ b/internal/trunking/grant.go
@@ -37,7 +37,13 @@ type Grant struct {
 	// emit a `.raw` frame sidecar regardless of its global WriteRaw
 	// setting, so researchers can decode out-of-band.
 	ProVoice bool
-	At       time.Time
+	// PatchedGroups, when non-empty, lists the member talkgroups of a
+	// patch / dynamic-regroup super-group: the call on GroupID is
+	// physically the shared traffic of these groups. The engine fills
+	// it from its PatchRegistry so the call can be attributed to every
+	// member. Empty for an ordinary (non-patched) grant.
+	PatchedGroups []uint32
+	At            time.Time
 }
 
 // String renders a one-line summary of a Grant for log output.

--- a/internal/trunking/patch.go
+++ b/internal/trunking/patch.go
@@ -1,0 +1,81 @@
+package trunking
+
+import (
+	"sync"
+	"time"
+)
+
+// PatchGroup associates a P25 super-group / dynamic-regroup talkgroup
+// with the member talkgroups merged into it. A patch makes the member
+// groups share one RF channel, so a call on the super-group physically
+// IS the members' traffic — "following" a patch means attributing the
+// call to every member, not retuning.
+type PatchGroup struct {
+	SuperGroup uint32
+	Members    []uint32
+	Vendor     string // "motorola" | "harris"
+	UpdatedAt  time.Time
+}
+
+// Patch is the events.KindPatch payload — a patch add or cancel a
+// trunked system announced.
+type Patch struct {
+	System     string
+	Protocol   string
+	SuperGroup uint32
+	Members    []uint32
+	Vendor     string
+	Add        bool // true = patch now active, false = patch cancelled
+	At         time.Time
+}
+
+// PatchRegistry is a thread-safe live table of active patch groups
+// keyed by super-group. The engine maintains one and consults it when
+// dispatching grants so a call on a patched super-group is attributed
+// to its member talkgroups.
+type PatchRegistry struct {
+	mu     sync.Mutex
+	groups map[uint32]PatchGroup
+}
+
+// NewPatchRegistry returns an empty registry.
+func NewPatchRegistry() *PatchRegistry {
+	return &PatchRegistry{groups: make(map[uint32]PatchGroup)}
+}
+
+// Apply records (or replaces) a patch group.
+func (r *PatchRegistry) Apply(pg PatchGroup) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.groups[pg.SuperGroup] = pg
+}
+
+// Delete removes a patch group by its super-group address.
+func (r *PatchRegistry) Delete(superGroup uint32) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.groups, superGroup)
+}
+
+// MembersOf returns a copy of the member talkgroups of the patch keyed
+// by group, or nil if group is not an active super-group.
+func (r *PatchRegistry) MembersOf(group uint32) []uint32 {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	pg, ok := r.groups[group]
+	if !ok {
+		return nil
+	}
+	return append([]uint32(nil), pg.Members...)
+}
+
+// Active returns a snapshot of every active patch group.
+func (r *PatchRegistry) Active() []PatchGroup {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]PatchGroup, 0, len(r.groups))
+	for _, pg := range r.groups {
+		out = append(out, pg)
+	}
+	return out
+}

--- a/internal/trunking/patch_test.go
+++ b/internal/trunking/patch_test.go
@@ -1,0 +1,106 @@
+package trunking
+
+import (
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+)
+
+func TestPatchRegistry(t *testing.T) {
+	r := NewPatchRegistry()
+	if r.MembersOf(100) != nil {
+		t.Error("MembersOf on an empty registry should be nil")
+	}
+	r.Apply(PatchGroup{SuperGroup: 100, Members: []uint32{10, 20, 30}, Vendor: "motorola"})
+
+	got := r.MembersOf(100)
+	if len(got) != 3 || got[0] != 10 || got[2] != 30 {
+		t.Errorf("MembersOf(100) = %v, want [10 20 30]", got)
+	}
+	if r.MembersOf(999) != nil {
+		t.Error("MembersOf for an unknown super-group should be nil")
+	}
+	if len(r.Active()) != 1 {
+		t.Errorf("Active() len = %d, want 1", len(r.Active()))
+	}
+	// MembersOf must return a defensive copy.
+	got[0] = 999
+	if r.MembersOf(100)[0] != 10 {
+		t.Error("MembersOf did not return a defensive copy")
+	}
+	r.Delete(100)
+	if r.MembersOf(100) != nil {
+		t.Error("MembersOf after Delete should be nil")
+	}
+}
+
+// TestEngineScanModeListAllowsPatchedMember confirms a grant on a
+// patch super-group passes the scan-list gate when a member talkgroup
+// is scanned, and the call carries the member list.
+func TestEngineScanModeListAllowsPatchedMember(t *testing.T) {
+	e, _, bus, _ := mkEngine(t, 1)
+	defer bus.Close()
+	e.SetScanMode(ScanModeList)
+	// Super-group 500 is not scanned; member 78 is.
+	e.talkgroups.Add(&TalkGroup{ID: 500, AlphaTag: "SUPER", Scan: false})
+	e.talkgroups.Add(&TalkGroup{ID: 78, AlphaTag: "MEMBER", Scan: true})
+	e.handlePatch(Patch{SuperGroup: 500, Members: []uint32{78}, Vendor: "motorola", Add: true})
+
+	sub := bus.Subscribe()
+	defer sub.Close()
+	e.HandleGrant(Grant{System: "X", Protocol: "p25", GroupID: 500, FrequencyHz: 1_000_000})
+
+	deadline := time.After(time.Second)
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind == events.KindCallStart {
+				cs := ev.Payload.(CallStart)
+				if len(cs.Grant.PatchedGroups) != 1 || cs.Grant.PatchedGroups[0] != 78 {
+					t.Errorf("CallStart PatchedGroups = %v, want [78]", cs.Grant.PatchedGroups)
+				}
+				return
+			}
+		case <-deadline:
+			t.Fatal("no CallStart for the patched-member grant")
+		}
+	}
+}
+
+// TestEngineScanModeListDropsPatchWithNoScannedMember confirms a
+// patched super-group is still dropped when neither it nor any member
+// is scanned.
+func TestEngineScanModeListDropsPatchWithNoScannedMember(t *testing.T) {
+	e, _, bus, tuners := mkEngine(t, 1)
+	defer bus.Close()
+	e.SetScanMode(ScanModeList)
+	e.talkgroups.Add(&TalkGroup{ID: 78, AlphaTag: "MEMBER", Scan: false})
+	e.handlePatch(Patch{SuperGroup: 500, Members: []uint32{78}, Add: true})
+
+	sub := bus.Subscribe()
+	defer sub.Close()
+	e.HandleGrant(Grant{System: "X", Protocol: "p25", GroupID: 500, FrequencyHz: 1_000_000})
+
+	select {
+	case ev := <-sub.C:
+		t.Errorf("unexpected event for an all-off-list patch: %s", ev.Kind)
+	case <-time.After(50 * time.Millisecond):
+	}
+	if got := tuners[0].tuned(); len(got) != 0 {
+		t.Errorf("off-list patched grant should not retune; got %v", got)
+	}
+}
+
+func TestEnginePatchDeleteRemoves(t *testing.T) {
+	e, _, bus, _ := mkEngine(t, 1)
+	defer bus.Close()
+	e.handlePatch(Patch{SuperGroup: 500, Members: []uint32{78}, Add: true})
+	if len(e.Patches()) != 1 {
+		t.Fatalf("after Add, Patches() len = %d, want 1", len(e.Patches()))
+	}
+	e.handlePatch(Patch{SuperGroup: 500, Add: false})
+	if len(e.Patches()) != 0 {
+		t.Errorf("after cancel, Patches() len = %d, want 0", len(e.Patches()))
+	}
+}


### PR DESCRIPTION
## Summary

This builds out P25 Phase 2 from a control-channel-only stub into a functionally complete TDMA decoder, closing the gaps against SDRtrunk's P25 Phase 2 handling. Two stages of work:

**Structural buildout (Phases A–F)**
- **Superframe sync** — `SuperframeDecoder` locks the 360 ms TDMA superframe and slices its 12 sub-frames, tagging each with its timeslot.
- **ISCH / SlotType** — each sub-frame's SlotType is decoded (Golay(24,12,8)), so voice and MAC sub-frames are distinguishable off the wire.
- **Voice path** — `ExtractVoiceFrames` pulls AMBE+2 frames from 4V/2V slots; a composer voice chain takes modulated IQ → receiver → superframe decode → AMBE+2 → WAV.
- **Band plan** — Phase 2 grants resolve `(ChannelID, ChannelNumber)` to a real downlink frequency.
- **MAC opcodes + vendor dispatch** — `MFID`-based dispatch with Motorola/Harris vendor messages.
- **Block interleaver** — opt-in TIA-102.BBAC per-burst deinterleaver.

**SDRtrunk parity completion (Phases 1–6)**
- **Unified decode path** — the live control-channel pipeline now runs through the `SuperframeDecoder` (structured TDMA path) instead of the flat sync-window slicer; the FEC chain was factored into the pure `decodeMACPDUDibits` helper.
- **Encryption identification** — decodes SVC_OPTIONS + an Encryption Sync MAC message and flags `Encrypted`/`Emergency`/`AlgorithmID`/`KeyID` on the grant. Identifies, does not decrypt (matches SDRtrunk).
- **Patch / regroup** — Motorola/Harris patch MAC PDUs feed an engine `PatchRegistry`; patched super-group calls are attributed to member talkgroups and pass the scan-list gate. New `events.KindPatch`.
- **Talker alias** — multi-fragment alias reassembly, reorder-tolerant with staleness eviction. New `events.KindTalkerAlias`.
- **Broader MAC coverage** — unit-to-unit grant-update, Group Affiliation Response, Unit Registration Response, Motorola group-regroup-delete; Phase 2 now emits `KindAffiliation`/`KindUnitRegistration` like Phase 1.
- **Docs** — refreshed the stale `phase2.go` package doc.

Also fixes a pre-existing race in the DMR voice composer test's superframe-alignment assertion, surfaced under `go test -race ./...`.

## Notes / scope

"Parity" here means functional parity with what SDRtrunk *does*: it identifies encryption rather than decrypting, and decodes the downlink only — both kept as deliberate non-goals. Where TIA-102.BBAB/BBAC on-air detail is absent from the repo (superframe sync cadence, ISCH and voice-slot bit layouts, encryption-sync and talker-alias opcodes, the interleaver table), each is implemented as a documented working model isolated to one file with a symmetric fixture encoder, so a real-capture calibration is a one-file change. Verification is synthesized-fixture based — encoder/decoder round-trips — not real RF captures.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` and `gofmt -l` clean on touched packages
- [x] Per-phase unit tests: encode→decode round-trips, FEC bit-flip cases, control-channel event assertions
- [x] `go test -race` green on `p25/phase2`, `trunking`, `voice/composer`, `scanner/ccdecoder`, `events`
- [x] `make integration-cc-p25p2` green — the daemon locks through the rewired `SuperframeDecoder`-backed pipeline
- [x] Full suite: 70 packages pass, no failures
- [ ] Calibrate the working-model on-air constants against a real P25 Phase 2 capture

https://claude.ai/code/session_015bf3nGyhz7z7AB7w4hoPsi

---
_Generated by [Claude Code](https://claude.ai/code/session_015bf3nGyhz7z7AB7w4hoPsi)_