### PR TITLE
p25/phase1: complete voice path and SDRtrunk parity

### DIFF
--- a/internal/radio/p25/phase1/control.go
+++ b/internal/radio/p25/phase1/control.go
@@ -323,6 +323,39 @@ func (c *ControlChannel) dispatchTSBK(t TSBK, nac uint16, metric int) {
 			"tx_offset_hz", u.TxOffsetHz)
 	case OpGroupVoiceChannelGrant:
 		c.publishGroupGrant(ParseGroupVoiceChannelGrant(t.Payload), nac)
+	case OpGroupVoiceChannelUpdate:
+		u := ParseGroupVoiceChannelUpdate(t.Payload)
+		c.publishVoiceGrant(voiceGrant{
+			groupID: uint32(u.GroupAddressA), channelID: u.ChannelAID,
+			channelNumber: u.ChannelANumber,
+		}, nac)
+		if u.GroupAddressB != 0 {
+			c.publishVoiceGrant(voiceGrant{
+				groupID: uint32(u.GroupAddressB), channelID: u.ChannelBID,
+				channelNumber: u.ChannelBNumber,
+			}, nac)
+		}
+	case OpGroupVoiceChannelUpdateExpl:
+		c.publishGroupGrant(ParseGroupVoiceChannelUpdateExplicit(t.Payload), nac)
+	case OpUnitToUnitVoiceChannelGrant:
+		g := ParseUnitToUnitVoiceChannelGrant(t.Payload)
+		c.publishVoiceGrant(voiceGrant{
+			groupID: g.TargetID, sourceID: g.SourceID,
+			channelID: g.ChannelID, channelNumber: g.ChannelNumber,
+		}, nac)
+	case OpTelephoneInterconnectGrant:
+		g := ParseTelephoneInterconnectGrant(t.Payload)
+		c.publishVoiceGrant(voiceGrant{
+			groupID: g.TargetID, channelID: g.ChannelID,
+			channelNumber: g.ChannelNumber, serviceOptions: g.ServiceOptions,
+		}, nac)
+	case OpSNDCPDataChannelGrant:
+		g := ParseSNDCPDataChannelGrant(t.Payload)
+		c.publishVoiceGrant(voiceGrant{
+			groupID: g.TargetID, channelID: g.ChannelID,
+			channelNumber: g.ChannelNumber, serviceOptions: g.ServiceOptions,
+			dataCall: true,
+		}, nac)
 	case OpGroupAffiliationResponse:
 		c.publishAffiliation(ParseGroupAffiliationResponse(t.Payload), nac)
 	case OpUnitRegistrationResponse:
@@ -333,47 +366,69 @@ func (c *ControlChannel) dispatchTSBK(t TSBK, nac uint16, metric int) {
 	}
 }
 
-// publishGroupGrant resolves the grant's channel through the band
-// plan and publishes a trunking.Grant on the bus. If the channel ID
-// hasn't been seen yet, a `decode.error` with stage="no-bandplan"
-// is published instead — the engine can't do anything with a
-// zero-frequency grant, and surfacing this lets operators see when
-// a site's IdentifierUpdate cadence is too slow for their capture.
-func (c *ControlChannel) publishGroupGrant(g GroupVoiceChannelGrant, nac uint16) {
-	freq, err := c.bandPlan.Frequency(g.ChannelID, g.ChannelNumber)
+// voiceGrant is the protocol-internal shape publishVoiceGrant resolves
+// and publishes. It generalises the several P25 grant TSBKs (group,
+// group-update, unit-to-unit, telephone, SNDCP data) over one path.
+type voiceGrant struct {
+	groupID        uint32 // talkgroup, or destination unit / phone target
+	sourceID       uint32
+	channelID      uint8
+	channelNumber  uint16
+	serviceOptions uint8
+	dataCall       bool
+}
+
+// publishVoiceGrant resolves a grant's channel through the band plan
+// and publishes a trunking.Grant on the bus. If the channel ID hasn't
+// been seen yet, a `decode.error` with stage="no-bandplan" is
+// published instead — the engine can't do anything with a
+// zero-frequency grant, and surfacing this lets operators see when a
+// site's IdentifierUpdate cadence is too slow for their capture.
+func (c *ControlChannel) publishVoiceGrant(g voiceGrant, nac uint16) {
+	freq, err := c.bandPlan.Frequency(g.channelID, g.channelNumber)
 	if err != nil {
 		c.log.Debug("p25: grant before identifier update",
-			"nac", nac, "id", g.ChannelID, "num", g.ChannelNumber, "err", err)
+			"nac", nac, "id", g.channelID, "num", g.channelNumber, "err", err)
 		c.bus.Publish(events.Event{
 			Kind:    events.KindDecodeError,
 			Payload: events.DecodeError{Protocol: "p25", Stage: events.StageNoBandPlan},
 		})
 		return
 	}
-	// SVC_OPTIONS bit layout per TIA-102.AABF: bit 7 = Emergency,
-	// bit 6 = Protected (encryption indicator).
-	emergency := g.ServiceOptions&0x80 != 0
-	encrypted := g.ServiceOptions&0x40 != 0
+	so := ServiceOptions(g.serviceOptions)
 	c.bus.Publish(events.Event{
 		Kind: events.KindGrant,
 		Payload: trunking.Grant{
 			System:      c.systemName,
 			Protocol:    "p25",
-			GroupID:     uint32(g.GroupAddress),
-			SourceID:    g.SourceID,
+			GroupID:     g.groupID,
+			SourceID:    g.sourceID,
 			FrequencyHz: freq,
-			ChannelID:   g.ChannelID,
-			ChannelNum:  g.ChannelNumber,
-			Encrypted:   encrypted,
-			Emergency:   emergency,
+			ChannelID:   g.channelID,
+			ChannelNum:  g.channelNumber,
+			Encrypted:   so.Encrypted(),
+			Emergency:   so.Emergency(),
+			DataCall:    g.dataCall,
 			At:          c.now(),
 		},
 	})
 	c.log.Debug("p25: grant",
 		"system", c.systemName, "nac", nac,
-		"tg", g.GroupAddress, "src", g.SourceID,
-		"id", g.ChannelID, "num", g.ChannelNumber, "freq_hz", freq,
-		"enc", encrypted, "emer", emergency)
+		"tg", g.groupID, "src", g.sourceID,
+		"id", g.channelID, "num", g.channelNumber, "freq_hz", freq,
+		"enc", so.Encrypted(), "emer", so.Emergency(), "data", g.dataCall)
+}
+
+// publishGroupGrant publishes a standard group voice grant (opcode
+// 0x00 / 0x03) via publishVoiceGrant.
+func (c *ControlChannel) publishGroupGrant(g GroupVoiceChannelGrant, nac uint16) {
+	c.publishVoiceGrant(voiceGrant{
+		groupID:        uint32(g.GroupAddress),
+		sourceID:       g.SourceID,
+		channelID:      g.ChannelID,
+		channelNumber:  g.ChannelNumber,
+		serviceOptions: g.ServiceOptions,
+	}, nac)
 }
 
 // publishAffiliation publishes a trunking.Affiliation on the bus when

--- a/internal/radio/p25/phase1/control.go
+++ b/internal/radio/p25/phase1/control.go
@@ -53,6 +53,10 @@ type ControlChannel struct {
 	buf     []uint8
 	bufBase int
 	pending []pendingHit
+
+	// aliasAsm reassembles multi-fragment vendor talker-alias TSBKs
+	// into a radio's display name. Self-synchronised (its own mutex).
+	aliasAsm *TalkerAliasAssembler
 }
 
 // pendingHit is an FSW match awaiting enough buffered dibits to decode
@@ -97,6 +101,7 @@ func New(opts Options) *ControlChannel {
 		freqHz:     opts.FrequencyHz,
 		bandPlan:   bp,
 		now:        now,
+		aliasAsm:   NewTalkerAliasAssembler(now),
 	}
 }
 
@@ -313,6 +318,13 @@ func (c *ControlChannel) logNIDRotationProbe(rawNID []uint8) {
 // logged at debug but not republished, since they're the bulk of what
 // a busy site emits and would drown signal in noise.
 func (c *ControlChannel) dispatchTSBK(t TSBK, nac uint16, metric int) {
+	// Manufacturer-specific TSBKs are decoded in the vendor's opcode
+	// namespace (Motorola patch/regroup, Harris regroup, talker alias)
+	// — see tsbk_vendor.go.
+	if t.IsVendorMFID() {
+		c.dispatchVendorTSBK(t, nac)
+		return
+	}
 	switch t.Opcode {
 	case OpIdentifierUpdate:
 		u := ParseIdentifierUpdate(t.Payload)
@@ -364,6 +376,73 @@ func (c *ControlChannel) dispatchTSBK(t TSBK, nac uint16, metric int) {
 		c.log.Debug("tsbk decoded",
 			"opcode", t.Opcode, "lb", t.LB, "metric", metric, "nac", nac)
 	}
+}
+
+// dispatchVendorTSBK routes a manufacturer-specific TSBK (Motorola or
+// Harris MFID) through the vendor accessors in tsbk_vendor.go and
+// publishes the trunking event it carries.
+func (c *ControlChannel) dispatchVendorTSBK(t TSBK, nac uint16) {
+	if pg, ok := t.AsMotorolaPatchGroup(); ok {
+		members := make([]uint32, len(pg.Patched))
+		for i, m := range pg.Patched {
+			members[i] = uint32(m)
+		}
+		c.publishPatch(uint32(pg.SuperGroup), members, "motorola", true)
+		return
+	}
+	if super, ok := t.AsMotorolaPatchDelete(); ok {
+		c.publishPatch(uint32(super), nil, "motorola", false)
+		return
+	}
+	if hr, ok := t.AsHarrisRegroup(); ok {
+		c.publishPatch(uint32(hr.RegroupGroup), nil, "harris", true)
+		return
+	}
+	if f, ok := t.AsTalkerAliasFragment(); ok {
+		if alias, src, done := c.aliasAsm.Add(f); done {
+			c.publishTalkerAlias(src, alias)
+		}
+		return
+	}
+	c.log.Debug("p25: vendor tsbk", "mfid", t.MFID, "opcode", t.Opcode, "nac", nac)
+}
+
+// publishPatch publishes an events.KindPatch for a vendor patch /
+// dynamic-regroup TSBK so the engine can attribute later grants on the
+// super-group to its member talkgroups. add=false cancels a patch.
+func (c *ControlChannel) publishPatch(superGroup uint32, members []uint32, vendor string, add bool) {
+	c.bus.Publish(events.Event{
+		Kind: events.KindPatch,
+		Payload: trunking.Patch{
+			System:     c.systemName,
+			Protocol:   "p25",
+			SuperGroup: superGroup,
+			Members:    members,
+			Vendor:     vendor,
+			Add:        add,
+			At:         c.now(),
+		},
+	})
+	c.log.Debug("p25: patch",
+		"system", c.systemName, "vendor", vendor,
+		"super", superGroup, "members", members, "add", add)
+}
+
+// publishTalkerAlias publishes an events.KindTalkerAlias once a radio's
+// display name has been fully reassembled from its fragment TSBKs.
+func (c *ControlChannel) publishTalkerAlias(sourceID uint32, alias string) {
+	c.bus.Publish(events.Event{
+		Kind: events.KindTalkerAlias,
+		Payload: trunking.TalkerAlias{
+			System:   c.systemName,
+			Protocol: "p25",
+			SourceID: sourceID,
+			Alias:    alias,
+			At:       c.now(),
+		},
+	})
+	c.log.Debug("p25: talker alias",
+		"system", c.systemName, "src", sourceID, "alias", alias)
 }
 
 // voiceGrant is the protocol-internal shape publishVoiceGrant resolves

--- a/internal/radio/p25/phase1/control.go
+++ b/internal/radio/p25/phase1/control.go
@@ -57,6 +57,16 @@ type ControlChannel struct {
 	// aliasAsm reassembles multi-fragment vendor talker-alias TSBKs
 	// into a radio's display name. Self-synchronised (its own mutex).
 	aliasAsm *TalkerAliasAssembler
+
+	// netModel accumulates the site's status-broadcast TSBKs into a
+	// queryable system-topology snapshot. Self-synchronised.
+	netModel NetworkModel
+}
+
+// NetworkSnapshot returns the system topology accumulated from the
+// site's Network / RFSS / Secondary-CC / Adjacent-Site status TSBKs.
+func (c *ControlChannel) NetworkSnapshot() NetworkConfig {
+	return c.netModel.Snapshot()
 }
 
 // pendingHit is an FSW match awaiting enough buffered dibits to decode
@@ -368,6 +378,14 @@ func (c *ControlChannel) dispatchTSBK(t TSBK, nac uint16, metric int) {
 			channelNumber: g.ChannelNumber, serviceOptions: g.ServiceOptions,
 			dataCall: true,
 		}, nac)
+	case OpNetworkStatusBroadcast:
+		c.netModel.ApplyNetworkStatus(ParseNetworkStatusBroadcast(t.Payload))
+	case OpRFSSStatusBroadcast:
+		c.netModel.ApplyRFSSStatus(ParseRFSSStatusBroadcast(t.Payload))
+	case OpSecondaryControlChannel:
+		c.netModel.ApplySecondaryControlChannel(ParseSecondaryControlChannelBroadcast(t.Payload))
+	case OpAdjacentSiteStatusBroadcast:
+		c.netModel.ApplyAdjacentSite(ParseAdjacentSiteStatusBroadcast(t.Payload))
 	case OpGroupAffiliationResponse:
 		c.publishAffiliation(ParseGroupAffiliationResponse(t.Payload), nac)
 	case OpUnitRegistrationResponse:

--- a/internal/radio/p25/phase1/encryption_sync.go
+++ b/internal/radio/p25/phase1/encryption_sync.go
@@ -1,0 +1,71 @@
+package phase1
+
+// P25 LDU2 Encryption Sync word.
+//
+// An LDU2 carries an Encryption Sync (ES) word in the same 6 × 40-bit
+// LC/ES slots an LDU1 uses for Link Control — so it is protected by the
+// identical 24-codeword shortened Hamming(10,6,3) inner FEC, decoded
+// here by lcInnerDecode (link_control.go). The ES identifies the
+// privacy parameters of an encrypted voice call:
+//
+//   - MessageIndicator: the 72-bit per-call cryptographic sync vector
+//   - AlgorithmID: the encryption algorithm (0x80 = unencrypted/clear,
+//     0x81 = DES-OFB, 0x84 = AES-256, … per the TIA algorithm registry)
+//   - KeyID: which key in the radio's keyset the call uses
+//
+// Like SDRtrunk, GopherTrunk identifies encryption — it surfaces the
+// algorithm and key — but does not decrypt.
+//
+// The 96-bit ES content layout is the project's working model (the
+// 144-bit Hamming-recovered field's first 12 octets); the RS(24,12,13)
+// outer verification is a documented follow-up, as for Link Control.
+//
+//	octets 0-8 : Message Indicator (72 bits)
+//	octet 9    : Algorithm ID
+//	octets 10-11: Key ID
+type EncryptionSync struct {
+	MessageIndicator [9]byte
+	AlgorithmID      uint8
+	KeyID            uint16
+}
+
+// esContentOctets is the ES content size in octets (96 bits).
+const esContentOctets = 12
+
+// AlgorithmClear is the Algorithm ID a clear (unencrypted) call
+// advertises in its Encryption Sync.
+const AlgorithmClear uint8 = 0x80
+
+// Encrypted reports whether the ES describes an encrypted call (any
+// Algorithm ID other than the clear-voice value).
+func (e EncryptionSync) Encrypted() bool { return e.AlgorithmID != AlgorithmClear }
+
+// ParseEncryptionSync decodes the 6 LC/ES blocks of an LDU2 into a
+// structured EncryptionSync, returning the inner-FEC corrected-error
+// count.
+func ParseEncryptionSync(blocks [LDULCESBlockCount][]byte) (EncryptionSync, int, error) {
+	data, errs, err := lcInnerDecode(blocks)
+	if err != nil {
+		return EncryptionSync{}, 0, err
+	}
+	oct := bitsToOctets(data[:esContentOctets*8])
+	var es EncryptionSync
+	copy(es.MessageIndicator[:], oct[0:9])
+	es.AlgorithmID = oct[9]
+	es.KeyID = uint16(oct[10])<<8 | uint16(oct[11])
+	return es, errs, nil
+}
+
+// AssembleEncryptionSync is the inverse of ParseEncryptionSync; it
+// builds the 6 on-wire ES blocks. The RS-parity half of the 144-bit
+// data field is left zero (see the package note above).
+func AssembleEncryptionSync(es EncryptionSync) [LDULCESBlockCount][]byte {
+	oct := make([]byte, esContentOctets)
+	copy(oct[0:9], es.MessageIndicator[:])
+	oct[9] = es.AlgorithmID
+	oct[10], oct[11] = byte(es.KeyID>>8), byte(es.KeyID)
+
+	data := make([]byte, 144)
+	copy(data, octetsToBits(oct))
+	return lcInnerEncode(data)
+}

--- a/internal/radio/p25/phase1/encryption_sync_test.go
+++ b/internal/radio/p25/phase1/encryption_sync_test.go
@@ -1,0 +1,55 @@
+package phase1
+
+import "testing"
+
+func TestEncryptionSyncRoundTrip(t *testing.T) {
+	in := EncryptionSync{
+		MessageIndicator: [9]byte{1, 2, 3, 4, 5, 6, 7, 8, 9},
+		AlgorithmID:      0x84, // AES-256
+		KeyID:            0xBEEF,
+	}
+	got, errs, err := ParseEncryptionSync(AssembleEncryptionSync(in))
+	if err != nil {
+		t.Fatalf("ParseEncryptionSync: %v", err)
+	}
+	if errs != 0 {
+		t.Errorf("clean ES corrected %d errors", errs)
+	}
+	if got != in {
+		t.Errorf("round-trip = %+v, want %+v", got, in)
+	}
+	if !got.Encrypted() {
+		t.Error("AES-256 ES should report Encrypted")
+	}
+}
+
+func TestEncryptionSyncClearCall(t *testing.T) {
+	in := EncryptionSync{AlgorithmID: AlgorithmClear}
+	got, _, err := ParseEncryptionSync(AssembleEncryptionSync(in))
+	if err != nil {
+		t.Fatalf("ParseEncryptionSync: %v", err)
+	}
+	if got.Encrypted() {
+		t.Error("clear-voice ES should not report Encrypted")
+	}
+}
+
+func TestEncryptionSyncCorrectsBitError(t *testing.T) {
+	in := EncryptionSync{
+		MessageIndicator: [9]byte{0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0x11, 0x22, 0x33},
+		AlgorithmID:      0x81,
+		KeyID:            0x1234,
+	}
+	blocks := AssembleEncryptionSync(in)
+	blocks[1][7] ^= 1 // one correctable bit error within a Hamming codeword
+	got, errs, err := ParseEncryptionSync(blocks)
+	if err != nil {
+		t.Fatalf("ParseEncryptionSync: %v", err)
+	}
+	if errs < 1 {
+		t.Errorf("corrected %d errors, want >= 1", errs)
+	}
+	if got != in {
+		t.Errorf("ES after correction = %+v, want %+v", got, in)
+	}
+}

--- a/internal/radio/p25/phase1/hamming10_6.go
+++ b/internal/radio/p25/phase1/hamming10_6.go
@@ -1,0 +1,73 @@
+package phase1
+
+// Shortened Hamming(10, 6, 3) code — 6 data bits + 4 parity bits,
+// single-error-correcting. It is the per-codeword inner FEC the P25
+// LDU Link Control / Encryption Sync word uses (24 codewords spanning
+// the 240-bit LC/ES field). The framing package's Hamming helpers are
+// the (15,11) and (13,9) shortenings, not this one, so it is
+// implemented locally — a small, self-contained table-driven code.
+//
+// hamming10_6ParityCols[i] is the 4-bit parity column for data bit i.
+// Together with the four unit columns 0x8/0x4/0x2/0x1 (the parity-bit
+// positions) all ten columns are distinct and nonzero, which makes
+// single-error correction a syndrome → bit-position lookup.
+var hamming10_6ParityCols = [6]uint8{0x7, 0xB, 0xD, 0xE, 0x3, 0x5}
+
+// hamming10_6Parity computes the 4 parity bits over data[0:6] (0/1 per
+// byte) as a 4-bit value.
+func hamming10_6Parity(data []byte) uint8 {
+	var p uint8
+	for i := 0; i < 6; i++ {
+		if data[i]&1 != 0 {
+			p ^= hamming10_6ParityCols[i]
+		}
+	}
+	return p
+}
+
+// encodeHamming10_6 encodes 6 data bits into a 10-bit codeword (one bit
+// per byte, data in positions 0..5, parity in 6..9).
+func encodeHamming10_6(data []byte) []byte {
+	cw := make([]byte, 10)
+	copy(cw[0:6], data[0:6])
+	p := hamming10_6Parity(data)
+	cw[6] = (p >> 3) & 1
+	cw[7] = (p >> 2) & 1
+	cw[8] = (p >> 1) & 1
+	cw[9] = p & 1
+	return cw
+}
+
+// decodeHamming10_6 corrects up to one bit error in a 10-bit codeword
+// and returns the 6 data bits plus the count of corrected errors.
+func decodeHamming10_6(cw []byte) ([]byte, int) {
+	c := make([]byte, 10)
+	copy(c, cw)
+	rxParity := (c[6]&1)<<3 | (c[7]&1)<<2 | (c[8]&1)<<1 | (c[9] & 1)
+	syn := hamming10_6Parity(c[0:6]) ^ rxParity
+	errs := 0
+	if syn != 0 {
+		pos := -1
+		for i := 0; i < 6; i++ {
+			if hamming10_6ParityCols[i] == syn {
+				pos = i
+				break
+			}
+		}
+		if pos < 0 {
+			for j := 0; j < 4; j++ {
+				if uint8(0x8>>uint(j)) == syn {
+					pos = 6 + j
+					break
+				}
+			}
+		}
+		if pos >= 0 {
+			c[pos] ^= 1
+			errs = 1
+		}
+	}
+	out := make([]byte, 6)
+	copy(out, c[0:6])
+	return out, errs
+}

--- a/internal/radio/p25/phase1/ldu_encode.go
+++ b/internal/radio/p25/phase1/ldu_encode.go
@@ -1,0 +1,57 @@
+package phase1
+
+import "fmt"
+
+// AssembleLDU builds a complete 1728-bit on-air LDU bit stream from its
+// constituent fields — the inverse of ExtractVoiceFrames /
+// ExtractLCESBlocks / ExtractLSDBlocks. It writes the 48-bit frame sync
+// word and the 64-bit NID for (nac, duid), places the 9 voice channel
+// subframes, the 6 LC/ES blocks, and the 2 LSD blocks into the 1680-bit
+// payload at their TIA-102.BAAA offsets, then interleaves zero-valued
+// status symbols via InjectStatusSymbols.
+//
+// Each voice subframe must be LDUVoiceSubframeBits channel bits — the
+// IMBE-encoded channel form, e.g. from imbe.EncodeChannel. A nil LC/ES
+// or LSD block is written as zeros. This is synthesized-fixture
+// scaffolding (GopherTrunk is receive-only); it is the encoder the
+// round-trip tests pair with the extractors.
+func AssembleLDU(nac uint16, duid DUID, voice [LDUVoiceSubframeCount][]byte, lces [LDULCESBlockCount][]byte, lsd [LDULSDBlockCount][]byte) ([]byte, error) {
+	payload := make([]byte, LDUPayloadBits)
+
+	copy(payload[lduFSOffset:lduFSOffset+LDUFrameSyncBits], FrameSyncBits())
+	copy(payload[lduNIDOffset:lduNIDOffset+LDUNIDBits], EncodeNIDBits(nac, duid))
+
+	for i, off := range lduVoiceOffsets {
+		v := voice[i]
+		if len(v) != LDUVoiceSubframeBits {
+			return nil, fmt.Errorf("p25/phase1: AssembleLDU voice subframe %d must be %d bits, got %d",
+				i, LDUVoiceSubframeBits, len(v))
+		}
+		copy(payload[off:off+LDUVoiceSubframeBits], v)
+	}
+	for j, off := range lduLCESBlockOffsets {
+		b := lces[j]
+		if b == nil {
+			continue
+		}
+		if len(b) != LDULCESBlockBits {
+			return nil, fmt.Errorf("p25/phase1: AssembleLDU LC/ES block %d must be %d bits, got %d",
+				j, LDULCESBlockBits, len(b))
+		}
+		copy(payload[off:off+LDULCESBlockBits], b)
+	}
+	for k, off := range lduLSDBlockOffsets {
+		b := lsd[k]
+		if b == nil {
+			continue
+		}
+		if len(b) != LDULSDBlockBits {
+			return nil, fmt.Errorf("p25/phase1: AssembleLDU LSD block %d must be %d bits, got %d",
+				k, LDULSDBlockBits, len(b))
+		}
+		copy(payload[off:off+LDULSDBlockBits], b)
+	}
+
+	var status [LDUStatusSymbolCount]uint8
+	return InjectStatusSymbols(payload, status)
+}

--- a/internal/radio/p25/phase1/ldu_encode_test.go
+++ b/internal/radio/p25/phase1/ldu_encode_test.go
@@ -1,0 +1,51 @@
+package phase1
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/voice/imbe"
+)
+
+func TestAssembleLDURoundTrip(t *testing.T) {
+	var voice [LDUVoiceSubframeCount][]byte
+	var want [LDUVoiceSubframeCount][]byte
+	for s := range voice {
+		info := make([]byte, imbe.InfoBits)
+		for i := range info {
+			info[i] = byte((s*7 + i*3) & 1)
+		}
+		ch, err := imbe.EncodeChannel(info)
+		if err != nil {
+			t.Fatalf("EncodeChannel: %v", err)
+		}
+		onAir, err := imbe.Scramble(ch)
+		if err != nil {
+			t.Fatalf("Scramble: %v", err)
+		}
+		// Scramble/Descramble mutate in place — keep an independent copy
+		// for the LDU so the want computation below cannot corrupt it.
+		voice[s] = append([]byte(nil), onAir...)
+		want[s], _, _ = imbe.DecodeChannelToFrame(onAir)
+	}
+	var lces [LDULCESBlockCount][]byte
+	var lsd [LDULSDBlockCount][]byte
+
+	ldu, err := AssembleLDU(0x123, DUIDLogicalLink1, voice, lces, lsd)
+	if err != nil {
+		t.Fatalf("AssembleLDU: %v", err)
+	}
+	if len(ldu) != LDUTotalBits {
+		t.Fatalf("AssembleLDU len = %d, want %d", len(ldu), LDUTotalBits)
+	}
+
+	frames, _, err := ExtractVoiceFrames(ldu)
+	if err != nil {
+		t.Fatalf("ExtractVoiceFrames: %v", err)
+	}
+	for i := range frames {
+		if !bytes.Equal(frames[i], want[i]) {
+			t.Errorf("subframe %d: extracted frame != assembled frame", i)
+		}
+	}
+}

--- a/internal/radio/p25/phase1/link_control.go
+++ b/internal/radio/p25/phase1/link_control.go
@@ -1,0 +1,146 @@
+package phase1
+
+import "errors"
+
+// P25 LDU1 Link Control word.
+//
+// The 240-bit LC field (6 × 40-bit LC/ES blocks, as returned by
+// ExtractLCESBlocks) carries a 72-bit Link Control word wrapped in FEC:
+// 24 shortened Hamming(10,6,3) codewords protect 144 bits, of which the
+// first 72 are the LC content and the remaining 72 are an RS(24,12,13)
+// outer parity (TIA-102.BAAA). This file decodes the inner Hamming
+// layer and parses the 72-bit LC content; the RS outer verification is
+// a documented follow-up — without the spec's RS generator polynomial
+// it cannot be done reliably, and the inner Hamming layer already
+// single-error-corrects each codeword.
+//
+// LC content layout is the project's working model — TIA-102.BAAA's
+// per-LCO field tables are not in the repo. It is confined here with a
+// symmetric encoder so a spec correction stays local.
+//
+//	octet 0   : Link Control Format (the LCO opcode)
+//	octet 1   : service options
+//	octets 2-3: talkgroup / destination group
+//	octets 4-6: source unit ID (24 bits)
+//	octets 7-8: reserved
+type LinkControl struct {
+	LCFormat       uint8
+	ServiceOptions uint8
+	TalkgroupID    uint16
+	SourceID       uint32
+}
+
+// lcContentOctets is the LC content size in octets (72 bits).
+const lcContentOctets = 9
+
+// ErrLinkControlLength is returned when ParseLinkControl is handed
+// blocks that are not each LDULCESBlockBits long.
+var ErrLinkControlLength = errors.New("p25/phase1: LC blocks must each be 40 bits")
+
+// lcInnerDecode runs the 24 Hamming(10,6,3) inner codewords over the
+// 240-bit LC/ES field and returns the 144 recovered data bits plus the
+// total corrected-error count. It is shared by ParseLinkControl and the
+// Encryption Sync parser.
+func lcInnerDecode(blocks [LDULCESBlockCount][]byte) ([]byte, int, error) {
+	var field []byte
+	for _, b := range blocks {
+		if len(b) != LDULCESBlockBits {
+			return nil, 0, ErrLinkControlLength
+		}
+		field = append(field, b...)
+	}
+	// 240 bits = 24 codewords × 10 bits → 24 × 6 = 144 data bits.
+	data := make([]byte, 0, 144)
+	totalErrs := 0
+	for i := 0; i < 24; i++ {
+		dec, errs := decodeHamming10_6(field[i*10 : i*10+10])
+		totalErrs += errs
+		data = append(data, dec...)
+	}
+	return data, totalErrs, nil
+}
+
+// lcInnerEncode is the inverse of lcInnerDecode: 144 data bits → 240
+// on-wire bits as 6 × 40-bit blocks.
+func lcInnerEncode(data []byte) [LDULCESBlockCount][]byte {
+	var field []byte
+	for i := 0; i < 24; i++ {
+		field = append(field, encodeHamming10_6(data[i*6:i*6+6])...)
+	}
+	var blocks [LDULCESBlockCount][]byte
+	for j := range blocks {
+		blocks[j] = append([]byte(nil), field[j*LDULCESBlockBits:(j+1)*LDULCESBlockBits]...)
+	}
+	return blocks
+}
+
+// ParseLinkControl decodes the 6 LC blocks of an LDU1 into a structured
+// LinkControl. It returns the parsed word and the inner-FEC corrected-
+// error count.
+func ParseLinkControl(blocks [LDULCESBlockCount][]byte) (LinkControl, int, error) {
+	data, errs, err := lcInnerDecode(blocks)
+	if err != nil {
+		return LinkControl{}, 0, err
+	}
+	oct := bitsToOctets(data[:lcContentOctets*8])
+	return LinkControl{
+		LCFormat:       oct[0],
+		ServiceOptions: oct[1],
+		TalkgroupID:    uint16(oct[2])<<8 | uint16(oct[3]),
+		SourceID:       uint32(oct[4])<<16 | uint32(oct[5])<<8 | uint32(oct[6]),
+	}, errs, nil
+}
+
+// AssembleLinkControl is the inverse of ParseLinkControl; it builds the
+// 6 on-wire LC blocks for a LinkControl word. The RS-parity half of the
+// 144-bit data field is left zero (see the package note above).
+func AssembleLinkControl(lc LinkControl) [LDULCESBlockCount][]byte {
+	oct := make([]byte, lcContentOctets)
+	oct[0] = lc.LCFormat
+	oct[1] = lc.ServiceOptions
+	oct[2], oct[3] = byte(lc.TalkgroupID>>8), byte(lc.TalkgroupID)
+	oct[4], oct[5], oct[6] = byte(lc.SourceID>>16), byte(lc.SourceID>>8), byte(lc.SourceID)
+
+	data := make([]byte, 144)
+	copy(data, octetsToBits(oct))
+	return lcInnerEncode(data)
+}
+
+// LDUDuid returns the DUID encoded in an on-air LDU's NID — used to
+// tell an LDU1 (Link Control) from an LDU2 (Encryption Sync) before
+// interpreting its 6 LC/ES blocks.
+func LDUDuid(ldu []byte) (DUID, error) {
+	payload, err := StripStatusSymbols(ldu)
+	if err != nil {
+		return 0, err
+	}
+	nid, _, err := ParseNID(payload[lduNIDOffset : lduNIDOffset+LDUNIDBits])
+	if err != nil {
+		return 0, err
+	}
+	return nid.DUID, nil
+}
+
+// bitsToOctets packs a bit slice (0/1 per byte, MSB-first) into octets.
+func bitsToOctets(bits []byte) []byte {
+	out := make([]byte, len(bits)/8)
+	for i := range out {
+		var b byte
+		for j := 0; j < 8; j++ {
+			b = b<<1 | (bits[i*8+j] & 1)
+		}
+		out[i] = b
+	}
+	return out
+}
+
+// octetsToBits is the inverse of bitsToOctets.
+func octetsToBits(oct []byte) []byte {
+	out := make([]byte, len(oct)*8)
+	for i, b := range oct {
+		for j := 0; j < 8; j++ {
+			out[i*8+j] = (b >> uint(7-j)) & 1
+		}
+	}
+	return out
+}

--- a/internal/radio/p25/phase1/link_control_test.go
+++ b/internal/radio/p25/phase1/link_control_test.go
@@ -1,0 +1,92 @@
+package phase1
+
+import "testing"
+
+func TestHamming10_6RoundTrip(t *testing.T) {
+	for v := 0; v < 64; v++ {
+		data := make([]byte, 6)
+		for i := range data {
+			data[i] = byte(v>>uint(5-i)) & 1
+		}
+		cw := encodeHamming10_6(data)
+		if len(cw) != 10 {
+			t.Fatalf("codeword len = %d, want 10", len(cw))
+		}
+		got, errs := decodeHamming10_6(cw)
+		if errs != 0 {
+			t.Errorf("clean codeword for %d corrected %d errors", v, errs)
+		}
+		for i := range data {
+			if got[i] != data[i] {
+				t.Errorf("v=%d: data bit %d = %d, want %d", v, i, got[i], data[i])
+			}
+		}
+	}
+}
+
+func TestHamming10_6CorrectsSingleError(t *testing.T) {
+	data := []byte{1, 0, 1, 1, 0, 1}
+	cw := encodeHamming10_6(data)
+	for pos := 0; pos < 10; pos++ {
+		bad := append([]byte(nil), cw...)
+		bad[pos] ^= 1
+		got, errs := decodeHamming10_6(bad)
+		if errs != 1 {
+			t.Errorf("flip at %d: corrected %d errors, want 1", pos, errs)
+		}
+		for i := range data {
+			if got[i] != data[i] {
+				t.Errorf("flip at %d: data bit %d not recovered", pos, i)
+			}
+		}
+	}
+}
+
+func TestLinkControlRoundTrip(t *testing.T) {
+	in := LinkControl{
+		LCFormat:       0x44,
+		ServiceOptions: 0xC0,
+		TalkgroupID:    0x1234,
+		SourceID:       0x00ABCD,
+	}
+	got, errs, err := ParseLinkControl(AssembleLinkControl(in))
+	if err != nil {
+		t.Fatalf("ParseLinkControl: %v", err)
+	}
+	if errs != 0 {
+		t.Errorf("clean LC corrected %d errors", errs)
+	}
+	if got != in {
+		t.Errorf("round-trip = %+v, want %+v", got, in)
+	}
+}
+
+func TestLinkControlCorrectsBitError(t *testing.T) {
+	in := LinkControl{LCFormat: 0x00, ServiceOptions: 0x00, TalkgroupID: 0x5678, SourceID: 0x00BEEF}
+	blocks := AssembleLinkControl(in)
+	// One bit error per 40-bit block is within the per-codeword
+	// Hamming(10,6,3) correction radius.
+	blocks[0][3] ^= 1
+	blocks[3][27] ^= 1
+	got, errs, err := ParseLinkControl(blocks)
+	if err != nil {
+		t.Fatalf("ParseLinkControl: %v", err)
+	}
+	if errs < 2 {
+		t.Errorf("corrected %d errors, want >= 2", errs)
+	}
+	if got != in {
+		t.Errorf("LC after correction = %+v, want %+v", got, in)
+	}
+}
+
+func TestParseLinkControlLengthError(t *testing.T) {
+	var blocks [LDULCESBlockCount][]byte
+	for i := range blocks {
+		blocks[i] = make([]byte, LDULCESBlockBits)
+	}
+	blocks[2] = make([]byte, 39) // wrong length
+	if _, _, err := ParseLinkControl(blocks); err == nil {
+		t.Error("ParseLinkControl accepted a wrong-length block")
+	}
+}

--- a/internal/radio/p25/phase1/network.go
+++ b/internal/radio/p25/phase1/network.go
@@ -1,0 +1,109 @@
+package phase1
+
+import "sync"
+
+// P25 trunked-system topology model.
+//
+// A P25 site repeats a set of status-broadcast TSBKs — Network Status
+// (0x3B), RFSS Status (0x3A), Secondary Control Channel (0x39), and
+// Adjacent Site Status (0x3C) — that together describe the system's
+// identity and neighbours. NetworkModel accumulates them into a
+// queryable NetworkConfig, the rough equivalent of SDRtrunk's P25
+// network-configuration monitor. It is fed from the control channel's
+// dispatchTSBK and snapshot-read by the daemon / API.
+
+// Channel is a (band-plan ID, channel number) pair.
+type Channel struct {
+	ChannelID     uint8
+	ChannelNumber uint16
+}
+
+// NeighborSite is one adjacent site a radio may roam to.
+type NeighborSite struct {
+	RFSS          uint8
+	Site          uint8
+	ChannelID     uint8
+	ChannelNumber uint16
+}
+
+// NetworkConfig is a snapshot of the accumulated system topology.
+type NetworkConfig struct {
+	WACN      uint32 // 20-bit Wide-Area Communication Network ID
+	SystemID  uint16 // 12-bit System ID
+	RFSS      uint8  // RF Sub-System ID of the camped site
+	Site      uint8  // Site ID of the camped site
+	LRA       uint8  // Location Registration Area
+	Secondary []Channel
+	Neighbors []NeighborSite
+}
+
+// NetworkModel is the thread-safe accumulator behind NetworkConfig.
+// The zero value is ready to use.
+type NetworkModel struct {
+	mu  sync.Mutex
+	cfg NetworkConfig
+}
+
+// ApplyNetworkStatus folds a Network Status Broadcast (0x3B) in.
+func (m *NetworkModel) ApplyNetworkStatus(n NetworkStatusBroadcast) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.cfg.WACN = n.WACN
+	m.cfg.SystemID = n.SystemID
+}
+
+// ApplyRFSSStatus folds an RFSS Status Broadcast (0x3A) in.
+func (m *NetworkModel) ApplyRFSSStatus(r RFSSStatusBroadcast) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.cfg.SystemID = r.SystemID
+	m.cfg.RFSS = r.RFSS
+	m.cfg.Site = r.Site
+	m.cfg.LRA = r.LRA
+}
+
+// ApplySecondaryControlChannel folds a Secondary Control Channel
+// Broadcast (0x39) in, de-duplicating by channel.
+func (m *NetworkModel) ApplySecondaryControlChannel(s SecondaryControlChannelBroadcast) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.cfg.Secondary = upsertChannel(m.cfg.Secondary, Channel{s.ChannelAID, s.ChannelANumber})
+	if s.ChannelBID != 0 || s.ChannelBNumber != 0 {
+		m.cfg.Secondary = upsertChannel(m.cfg.Secondary, Channel{s.ChannelBID, s.ChannelBNumber})
+	}
+}
+
+// ApplyAdjacentSite folds an Adjacent Site Status Broadcast (0x3C) in,
+// de-duplicating by (RFSS, Site).
+func (m *NetworkModel) ApplyAdjacentSite(a AdjacentSiteStatusBroadcast) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	ns := NeighborSite{RFSS: a.RFSS, Site: a.Site, ChannelID: a.ChannelID, ChannelNumber: a.ChannelNumber}
+	for i, e := range m.cfg.Neighbors {
+		if e.RFSS == ns.RFSS && e.Site == ns.Site {
+			m.cfg.Neighbors[i] = ns
+			return
+		}
+	}
+	m.cfg.Neighbors = append(m.cfg.Neighbors, ns)
+}
+
+// Snapshot returns a deep copy of the accumulated topology.
+func (m *NetworkModel) Snapshot() NetworkConfig {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := m.cfg
+	out.Secondary = append([]Channel(nil), m.cfg.Secondary...)
+	out.Neighbors = append([]NeighborSite(nil), m.cfg.Neighbors...)
+	return out
+}
+
+// upsertChannel appends ch to chans if not already present.
+func upsertChannel(chans []Channel, ch Channel) []Channel {
+	for _, e := range chans {
+		if e == ch {
+			return chans
+		}
+	}
+	return append(chans, ch)
+}

--- a/internal/radio/p25/phase1/network_test.go
+++ b/internal/radio/p25/phase1/network_test.go
@@ -1,0 +1,70 @@
+package phase1
+
+import (
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+)
+
+func TestNetworkModelAccumulates(t *testing.T) {
+	var m NetworkModel
+	m.ApplyNetworkStatus(NetworkStatusBroadcast{WACN: 0xABCDE, SystemID: 0x123})
+	m.ApplyRFSSStatus(RFSSStatusBroadcast{SystemID: 0x123, RFSS: 4, Site: 7, LRA: 9})
+	m.ApplySecondaryControlChannel(SecondaryControlChannelBroadcast{
+		ChannelAID: 1, ChannelANumber: 100, ChannelBID: 1, ChannelBNumber: 200})
+	m.ApplyAdjacentSite(AdjacentSiteStatusBroadcast{RFSS: 4, Site: 8, ChannelID: 1, ChannelNumber: 300})
+	m.ApplyAdjacentSite(AdjacentSiteStatusBroadcast{RFSS: 4, Site: 9, ChannelID: 1, ChannelNumber: 301})
+	// Re-broadcast of site 8 must update in place, not duplicate.
+	m.ApplyAdjacentSite(AdjacentSiteStatusBroadcast{RFSS: 4, Site: 8, ChannelID: 1, ChannelNumber: 305})
+
+	cfg := m.Snapshot()
+	if cfg.WACN != 0xABCDE || cfg.SystemID != 0x123 {
+		t.Errorf("WACN/SystemID = %#x/%#x", cfg.WACN, cfg.SystemID)
+	}
+	if cfg.RFSS != 4 || cfg.Site != 7 || cfg.LRA != 9 {
+		t.Errorf("RFSS/Site/LRA = %d/%d/%d", cfg.RFSS, cfg.Site, cfg.LRA)
+	}
+	if len(cfg.Secondary) != 2 {
+		t.Errorf("Secondary = %v, want 2 channels", cfg.Secondary)
+	}
+	if len(cfg.Neighbors) != 2 {
+		t.Fatalf("Neighbors = %v, want 2 (site 8 deduped)", cfg.Neighbors)
+	}
+	for _, n := range cfg.Neighbors {
+		if n.Site == 8 && n.ChannelNumber != 305 {
+			t.Errorf("site 8 neighbour not updated: %+v", n)
+		}
+	}
+}
+
+// TestControlChannelAccumulatesTopology drives status-broadcast TSBKs
+// through the control channel and checks NetworkSnapshot reflects them.
+func TestControlChannelAccumulatesTopology(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	cc := New(Options{Bus: bus, SystemName: "S"})
+
+	// NSB payload: WACN 0xABCDE (p0<<12|p1<<4|p2>>4), SystemID 0x123
+	// ((p2&0x0F)<<8|p3) — see ParseNetworkStatusBroadcast.
+	nsb := TSBK{Opcode: OpNetworkStatusBroadcast,
+		Payload: [8]byte{0xAB, 0xCD, 0xE1, 0x23}}
+	// RFSS payload: LRA p0, RFSS p2, Site p3 — see ParseRFSSStatusBroadcast.
+	rfss := TSBK{Opcode: OpRFSSStatusBroadcast,
+		Payload: [8]byte{9, 0, 4, 7}}
+	adj := TSBK{Opcode: OpAdjacentSiteStatusBroadcast,
+		Payload: AssembleAdjacentSiteStatusBroadcast(AdjacentSiteStatusBroadcast{RFSS: 4, Site: 8, ChannelID: 1, ChannelNumber: 300})}
+
+	base := 0
+	for _, tsbk := range []TSBK{nsb, rfss, adj} {
+		cc.Process(buildLockedStreamWithTSBK(10, 0x293, DUIDTrunkingSignaling, tsbk), base)
+		base += 1 << 20
+	}
+
+	cfg := cc.NetworkSnapshot()
+	if cfg.WACN != 0xABCDE || cfg.RFSS != 4 || cfg.Site != 7 {
+		t.Errorf("snapshot = %+v, want WACN 0xABCDE / RFSS 4 / Site 7", cfg)
+	}
+	if len(cfg.Neighbors) != 1 || cfg.Neighbors[0].Site != 8 {
+		t.Errorf("neighbours = %v, want one site-8 entry", cfg.Neighbors)
+	}
+}

--- a/internal/radio/p25/phase1/opcodes.go
+++ b/internal/radio/p25/phase1/opcodes.go
@@ -125,6 +125,142 @@ func ParseGroupVoiceChannelUpdate(p [8]byte) GroupVoiceChannelUpdate {
 	}
 }
 
+// AssembleGroupVoiceChannelUpdate is the inverse of
+// ParseGroupVoiceChannelUpdate; used by tests.
+func AssembleGroupVoiceChannelUpdate(u GroupVoiceChannelUpdate) [8]byte {
+	var p [8]byte
+	binary.BigEndian.PutUint16(p[0:2], uint16(u.ChannelAID&0x0F)<<12|u.ChannelANumber&0x0FFF)
+	binary.BigEndian.PutUint16(p[2:4], u.GroupAddressA)
+	binary.BigEndian.PutUint16(p[4:6], uint16(u.ChannelBID&0x0F)<<12|u.ChannelBNumber&0x0FFF)
+	binary.BigEndian.PutUint16(p[6:8], u.GroupAddressB)
+	return p
+}
+
+// ParseGroupVoiceChannelUpdateExplicit decodes opcode 0x03, the
+// explicit-channel group voice update. It carries the same channel +
+// group + source fields as a group voice grant (opcode 0x00).
+func ParseGroupVoiceChannelUpdateExplicit(p [8]byte) GroupVoiceChannelGrant {
+	return ParseGroupVoiceChannelGrant(p)
+}
+
+// ServiceOptions decodes the 8-bit SVC_OPTIONS field a P25 voice grant
+// carries (TIA-102.AABF): bit 7 = Emergency, bit 6 = Protected (the
+// encryption indicator), bits 0-2 = call priority.
+type ServiceOptions uint8
+
+// Emergency reports the emergency-call bit.
+func (s ServiceOptions) Emergency() bool { return s&0x80 != 0 }
+
+// Encrypted reports the protected (encryption) bit.
+func (s ServiceOptions) Encrypted() bool { return s&0x40 != 0 }
+
+// Priority returns the 3-bit call-priority field (0 = lowest).
+func (s ServiceOptions) Priority() uint8 { return uint8(s) & 0x07 }
+
+// UnitToUnitVoiceChannelGrant (opcode 0x04) — a private unit-to-unit
+// voice call. Working-model payload layout (TIA-102.AABF):
+//
+//	bytes 0-1 : channel (4-bit ID + 12-bit number)
+//	bytes 2-4 : target unit ID (24 bits)
+//	bytes 5-7 : source unit ID (24 bits)
+type UnitToUnitVoiceChannelGrant struct {
+	ChannelID     uint8
+	ChannelNumber uint16
+	TargetID      uint32
+	SourceID      uint32
+}
+
+// ParseUnitToUnitVoiceChannelGrant decodes payload bytes for opcode 0x04.
+func ParseUnitToUnitVoiceChannelGrant(p [8]byte) UnitToUnitVoiceChannelGrant {
+	ch := binary.BigEndian.Uint16(p[0:2])
+	return UnitToUnitVoiceChannelGrant{
+		ChannelID:     uint8(ch >> 12),
+		ChannelNumber: ch & 0x0FFF,
+		TargetID:      uint32(p[2])<<16 | uint32(p[3])<<8 | uint32(p[4]),
+		SourceID:      uint32(p[5])<<16 | uint32(p[6])<<8 | uint32(p[7]),
+	}
+}
+
+// AssembleUnitToUnitVoiceChannelGrant is the inverse; used by tests.
+func AssembleUnitToUnitVoiceChannelGrant(g UnitToUnitVoiceChannelGrant) [8]byte {
+	var p [8]byte
+	binary.BigEndian.PutUint16(p[0:2], uint16(g.ChannelID&0x0F)<<12|g.ChannelNumber&0x0FFF)
+	p[2], p[3], p[4] = byte(g.TargetID>>16), byte(g.TargetID>>8), byte(g.TargetID)
+	p[5], p[6], p[7] = byte(g.SourceID>>16), byte(g.SourceID>>8), byte(g.SourceID)
+	return p
+}
+
+// TelephoneInterconnectGrant (opcode 0x08) — a grant for a call bridged
+// to the public telephone network. Working-model payload layout:
+//
+//	byte 0    : service options
+//	bytes 1-2 : channel
+//	bytes 3-4 : call timer (units of 100 ms)
+//	bytes 5-7 : target unit ID — the radio on the call
+type TelephoneInterconnectGrant struct {
+	ServiceOptions uint8
+	ChannelID      uint8
+	ChannelNumber  uint16
+	CallTimer      uint16
+	TargetID       uint32
+}
+
+// ParseTelephoneInterconnectGrant decodes payload bytes for opcode 0x08.
+func ParseTelephoneInterconnectGrant(p [8]byte) TelephoneInterconnectGrant {
+	ch := binary.BigEndian.Uint16(p[1:3])
+	return TelephoneInterconnectGrant{
+		ServiceOptions: p[0],
+		ChannelID:      uint8(ch >> 12),
+		ChannelNumber:  ch & 0x0FFF,
+		CallTimer:      binary.BigEndian.Uint16(p[3:5]),
+		TargetID:       uint32(p[5])<<16 | uint32(p[6])<<8 | uint32(p[7]),
+	}
+}
+
+// AssembleTelephoneInterconnectGrant is the inverse; used by tests.
+func AssembleTelephoneInterconnectGrant(g TelephoneInterconnectGrant) [8]byte {
+	var p [8]byte
+	p[0] = g.ServiceOptions
+	binary.BigEndian.PutUint16(p[1:3], uint16(g.ChannelID&0x0F)<<12|g.ChannelNumber&0x0FFF)
+	binary.BigEndian.PutUint16(p[3:5], g.CallTimer)
+	p[5], p[6], p[7] = byte(g.TargetID>>16), byte(g.TargetID>>8), byte(g.TargetID)
+	return p
+}
+
+// SNDCPDataChannelGrant (opcode 0x14) — a grant for a packet-data
+// (SNDCP) channel. Working-model payload layout:
+//
+//	byte 0    : data service options
+//	bytes 1-2 : channel
+//	bytes 3-4 : reserved
+//	bytes 5-7 : target unit ID
+type SNDCPDataChannelGrant struct {
+	ServiceOptions uint8
+	ChannelID      uint8
+	ChannelNumber  uint16
+	TargetID       uint32
+}
+
+// ParseSNDCPDataChannelGrant decodes payload bytes for opcode 0x14.
+func ParseSNDCPDataChannelGrant(p [8]byte) SNDCPDataChannelGrant {
+	ch := binary.BigEndian.Uint16(p[1:3])
+	return SNDCPDataChannelGrant{
+		ServiceOptions: p[0],
+		ChannelID:      uint8(ch >> 12),
+		ChannelNumber:  ch & 0x0FFF,
+		TargetID:       uint32(p[5])<<16 | uint32(p[6])<<8 | uint32(p[7]),
+	}
+}
+
+// AssembleSNDCPDataChannelGrant is the inverse; used by tests.
+func AssembleSNDCPDataChannelGrant(g SNDCPDataChannelGrant) [8]byte {
+	var p [8]byte
+	p[0] = g.ServiceOptions
+	binary.BigEndian.PutUint16(p[1:3], uint16(g.ChannelID&0x0F)<<12|g.ChannelNumber&0x0FFF)
+	p[5], p[6], p[7] = byte(g.TargetID>>16), byte(g.TargetID>>8), byte(g.TargetID)
+	return p
+}
+
 // GroupAffiliationResponse (opcode 0x28) — published when a radio unit
 // is granted (or denied) affiliation with a talkgroup. Payload layout
 // follows OP25's reference decoder (`trunk_p25.py`):

--- a/internal/radio/p25/phase1/opcodes.go
+++ b/internal/radio/p25/phase1/opcodes.go
@@ -359,6 +359,80 @@ type RFSSStatusBroadcast struct {
 	ServiceClass  uint16
 }
 
+// SecondaryControlChannelBroadcast (opcode 0x39) announces alternate
+// control-channel frequencies for the site. Working-model payload
+// layout:
+//
+//	byte 0    : RFSS ID
+//	byte 1    : Site ID
+//	bytes 2-3 : secondary control channel A
+//	bytes 4-5 : secondary control channel B (zero when only one)
+//	bytes 6-7 : system service class
+type SecondaryControlChannelBroadcast struct {
+	RFSS, Site                     uint8
+	ChannelAID, ChannelBID         uint8
+	ChannelANumber, ChannelBNumber uint16
+}
+
+// ParseSecondaryControlChannelBroadcast decodes payload for opcode 0x39.
+func ParseSecondaryControlChannelBroadcast(p [8]byte) SecondaryControlChannelBroadcast {
+	cA := binary.BigEndian.Uint16(p[2:4])
+	cB := binary.BigEndian.Uint16(p[4:6])
+	return SecondaryControlChannelBroadcast{
+		RFSS:           p[0],
+		Site:           p[1],
+		ChannelAID:     uint8(cA >> 12),
+		ChannelANumber: cA & 0x0FFF,
+		ChannelBID:     uint8(cB >> 12),
+		ChannelBNumber: cB & 0x0FFF,
+	}
+}
+
+// AssembleSecondaryControlChannelBroadcast is the inverse; for tests.
+func AssembleSecondaryControlChannelBroadcast(s SecondaryControlChannelBroadcast) [8]byte {
+	var p [8]byte
+	p[0], p[1] = s.RFSS, s.Site
+	binary.BigEndian.PutUint16(p[2:4], uint16(s.ChannelAID&0x0F)<<12|s.ChannelANumber&0x0FFF)
+	binary.BigEndian.PutUint16(p[4:6], uint16(s.ChannelBID&0x0F)<<12|s.ChannelBNumber&0x0FFF)
+	return p
+}
+
+// AdjacentSiteStatusBroadcast (opcode 0x3C) announces a neighbouring
+// site a radio may roam to. Working-model payload layout:
+//
+//	byte 0    : LRA (Location Registration Area)
+//	byte 1    : RFSS ID
+//	byte 2    : Site ID
+//	bytes 3-4 : the neighbour's control channel
+//	bytes 5-6 : system service class
+//	byte 7    : reserved
+type AdjacentSiteStatusBroadcast struct {
+	LRA           uint8
+	RFSS, Site    uint8
+	ChannelID     uint8
+	ChannelNumber uint16
+}
+
+// ParseAdjacentSiteStatusBroadcast decodes payload for opcode 0x3C.
+func ParseAdjacentSiteStatusBroadcast(p [8]byte) AdjacentSiteStatusBroadcast {
+	ch := binary.BigEndian.Uint16(p[3:5])
+	return AdjacentSiteStatusBroadcast{
+		LRA:           p[0],
+		RFSS:          p[1],
+		Site:          p[2],
+		ChannelID:     uint8(ch >> 12),
+		ChannelNumber: ch & 0x0FFF,
+	}
+}
+
+// AssembleAdjacentSiteStatusBroadcast is the inverse; for tests.
+func AssembleAdjacentSiteStatusBroadcast(a AdjacentSiteStatusBroadcast) [8]byte {
+	var p [8]byte
+	p[0], p[1], p[2] = a.LRA, a.RFSS, a.Site
+	binary.BigEndian.PutUint16(p[3:5], uint16(a.ChannelID&0x0F)<<12|a.ChannelNumber&0x0FFF)
+	return p
+}
+
 func ParseRFSSStatusBroadcast(p [8]byte) RFSSStatusBroadcast {
 	chanField := binary.BigEndian.Uint16(p[4:6])
 	return RFSSStatusBroadcast{

--- a/internal/radio/p25/phase1/opcodes_grants_test.go
+++ b/internal/radio/p25/phase1/opcodes_grants_test.go
@@ -1,0 +1,142 @@
+package phase1
+
+import (
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+func TestServiceOptionsBits(t *testing.T) {
+	for _, c := range []struct {
+		so   ServiceOptions
+		emer bool
+		enc  bool
+		prio uint8
+	}{
+		{0x00, false, false, 0},
+		{0x80, true, false, 0},
+		{0x40, false, true, 0},
+		{0xC5, true, true, 5},
+	} {
+		if c.so.Emergency() != c.emer || c.so.Encrypted() != c.enc || c.so.Priority() != c.prio {
+			t.Errorf("ServiceOptions(%#x) = emer %v / enc %v / prio %d", uint8(c.so),
+				c.so.Emergency(), c.so.Encrypted(), c.so.Priority())
+		}
+	}
+}
+
+func TestParseUnitToUnitVoiceChannelGrant(t *testing.T) {
+	in := UnitToUnitVoiceChannelGrant{ChannelID: 2, ChannelNumber: 0x123, TargetID: 0x00BEEF, SourceID: 0x00ABCD}
+	if got := ParseUnitToUnitVoiceChannelGrant(AssembleUnitToUnitVoiceChannelGrant(in)); got != in {
+		t.Errorf("round-trip = %+v, want %+v", got, in)
+	}
+}
+
+func TestParseTelephoneInterconnectGrant(t *testing.T) {
+	in := TelephoneInterconnectGrant{ServiceOptions: 0x80, ChannelID: 1, ChannelNumber: 0x05, CallTimer: 600, TargetID: 0x00ABCD}
+	if got := ParseTelephoneInterconnectGrant(AssembleTelephoneInterconnectGrant(in)); got != in {
+		t.Errorf("round-trip = %+v, want %+v", got, in)
+	}
+}
+
+func TestParseSNDCPDataChannelGrant(t *testing.T) {
+	in := SNDCPDataChannelGrant{ServiceOptions: 0x10, ChannelID: 3, ChannelNumber: 0x044, TargetID: 0x00BEEF}
+	if got := ParseSNDCPDataChannelGrant(AssembleSNDCPDataChannelGrant(in)); got != in {
+		t.Errorf("round-trip = %+v, want %+v", got, in)
+	}
+}
+
+// drainGrants collects every KindGrant published within a short window.
+func drainGrants(t *testing.T, sub *events.Subscription) []trunking.Grant {
+	t.Helper()
+	var out []trunking.Grant
+	deadline := time.After(time.Second)
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind == events.KindGrant {
+				out = append(out, ev.Payload.(trunking.Grant))
+			}
+		case <-deadline:
+			return out
+		default:
+			return out
+		}
+	}
+}
+
+// TestControlChannelDispatchesNewGrantOpcodes feeds an IdentifierUpdate
+// followed by each newly-wired grant opcode and asserts a resolved
+// trunking.Grant lands on the bus.
+func TestControlChannelDispatchesNewGrantOpcodes(t *testing.T) {
+	const nac = 0x293
+	ident := TSBK{Opcode: OpIdentifierUpdate}
+	ident.Payload = AssembleIdentifierUpdate(IdentifierUpdate{
+		ChannelID: 1, SpacingHz: 12_500, BaseHz: 851_000_000,
+	})
+	// channel ID 1, number 16 → 851_000_000 + 16*12_500 = 851_200_000.
+	const wantFreq = 851_200_000
+
+	cases := []struct {
+		name     string
+		tsbk     TSBK
+		group    uint32
+		source   uint32
+		dataCall bool
+	}{
+		{
+			name: "GroupVoiceChannelUpdate",
+			tsbk: TSBK{Opcode: OpGroupVoiceChannelUpdate, Payload: AssembleGroupVoiceChannelUpdate(
+				GroupVoiceChannelUpdate{ChannelAID: 1, ChannelANumber: 16, GroupAddressA: 0x1234})},
+			group: 0x1234,
+		},
+		{
+			name: "UnitToUnitVoiceChannelGrant",
+			tsbk: TSBK{Opcode: OpUnitToUnitVoiceChannelGrant, Payload: AssembleUnitToUnitVoiceChannelGrant(
+				UnitToUnitVoiceChannelGrant{ChannelID: 1, ChannelNumber: 16, TargetID: 0x00BEEF, SourceID: 0x00ABCD})},
+			group: 0x00BEEF, source: 0x00ABCD,
+		},
+		{
+			name: "TelephoneInterconnectGrant",
+			tsbk: TSBK{Opcode: OpTelephoneInterconnectGrant, Payload: AssembleTelephoneInterconnectGrant(
+				TelephoneInterconnectGrant{ChannelID: 1, ChannelNumber: 16, TargetID: 0x00ABCD})},
+			group: 0x00ABCD,
+		},
+		{
+			name: "SNDCPDataChannelGrant",
+			tsbk: TSBK{Opcode: OpSNDCPDataChannelGrant, Payload: AssembleSNDCPDataChannelGrant(
+				SNDCPDataChannelGrant{ChannelID: 1, ChannelNumber: 16, TargetID: 0x00BEEF})},
+			group: 0x00BEEF, dataCall: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			bus := events.NewBus(16)
+			defer bus.Close()
+			sub := bus.Subscribe()
+			defer sub.Close()
+
+			cc := New(Options{Bus: bus, SystemName: "S", FrequencyHz: 851_000_000})
+			cc.Process(buildLockedStreamWithTSBK(10, nac, DUIDTrunkingSignaling, ident), 0)
+			cc.Process(buildLockedStreamWithTSBK(0, nac, DUIDTrunkingSignaling, tc.tsbk), 1<<20)
+
+			grants := drainGrants(t, sub)
+			if len(grants) != 1 {
+				t.Fatalf("got %d grants, want 1", len(grants))
+			}
+			g := grants[0]
+			if g.GroupID != tc.group || g.SourceID != tc.source {
+				t.Errorf("group/source = %d/%d, want %d/%d", g.GroupID, g.SourceID, tc.group, tc.source)
+			}
+			if g.FrequencyHz != wantFreq {
+				t.Errorf("freq = %d, want %d", g.FrequencyHz, wantFreq)
+			}
+			if g.DataCall != tc.dataCall {
+				t.Errorf("DataCall = %v, want %v", g.DataCall, tc.dataCall)
+			}
+		})
+	}
+}

--- a/internal/radio/p25/phase1/pdu.go
+++ b/internal/radio/p25/phase1/pdu.go
@@ -1,0 +1,98 @@
+package phase1
+
+import "errors"
+
+// P25 Packet Data Unit (PDU) — the data-channel counterpart of the
+// voice LDU and the trunking TSDU. A PDU is a header block followed by
+// N data blocks, each a 12-byte (96-bit) post-FEC unit. This file
+// decodes the structured PDU from already-FEC-decoded block bytes and
+// reassembles the data blocks into a payload (typically an SNDCP
+// message — see sndcp.go).
+//
+// The block bit layout is the project's working model — TIA-102.BAAA's
+// PDU tables are not in the repo — confined here with symmetric
+// encoders and defensive parsers. Receiver-level PDU framing (the
+// dibit-stream FSW → NID → trellis-coded-block chain for DUID 0xC) is a
+// documented follow-up: it needs the same machinery the TSDU path uses
+// wired for a new DUID, best built against real packet-data captures.
+
+// PDUFormat identifies the PDU's format/type.
+type PDUFormat uint8
+
+const (
+	PDUFmtResponse        PDUFormat = 0x03 // response PDU
+	PDUFmtUnconfirmedData PDUFormat = 0x15 // unconfirmed user data
+	PDUFmtConfirmedData   PDUFormat = 0x16 // confirmed user data
+)
+
+// PDUBlockBytes is the byte length of one post-FEC PDU block.
+const PDUBlockBytes = 12
+
+// ErrPDUBlockLength is returned when a PDU block is not PDUBlockBytes long.
+var ErrPDUBlockLength = errors.New("p25/phase1: PDU block must be 12 bytes")
+
+// PDUHeader is the structured PDU header block. Working-model layout:
+//
+//	byte 0     : bit 6 = confirmed flag, bits 0-5 = format
+//	byte 1     : bits 0-5 = SAP (Service Access Point)
+//	byte 2     : MFID
+//	bytes 3-5  : LLID — 24-bit logical link (destination) ID
+//	byte 6     : bits 0-6 = data-block count
+type PDUHeader struct {
+	Format     PDUFormat
+	Confirmed  bool
+	SAP        uint8
+	MFID       uint8
+	LLID       uint32
+	BlockCount uint8
+}
+
+// ParsePDUHeader decodes a 12-byte PDU header block.
+func ParsePDUHeader(b []byte) (PDUHeader, error) {
+	if len(b) < PDUBlockBytes {
+		return PDUHeader{}, ErrPDUBlockLength
+	}
+	return PDUHeader{
+		Format:     PDUFormat(b[0] & 0x3F),
+		Confirmed:  b[0]&0x40 != 0,
+		SAP:        b[1] & 0x3F,
+		MFID:       b[2],
+		LLID:       uint32(b[3])<<16 | uint32(b[4])<<8 | uint32(b[5]),
+		BlockCount: b[6] & 0x7F,
+	}, nil
+}
+
+// AssemblePDUHeader is the inverse of ParsePDUHeader.
+func AssemblePDUHeader(h PDUHeader) []byte {
+	b := make([]byte, PDUBlockBytes)
+	b[0] = byte(h.Format) & 0x3F
+	if h.Confirmed {
+		b[0] |= 0x40
+	}
+	b[1] = h.SAP & 0x3F
+	b[2] = h.MFID
+	b[3], b[4], b[5] = byte(h.LLID>>16), byte(h.LLID>>8), byte(h.LLID)
+	b[6] = h.BlockCount & 0x7F
+	return b
+}
+
+// PDU is a fully-reassembled packet data unit.
+type PDU struct {
+	Header  PDUHeader
+	Payload []byte
+}
+
+// ReassemblePDU concatenates a PDU's data blocks into its payload. The
+// blocks are the post-FEC data blocks (each PDUBlockBytes long), in
+// order. A confirmed PDU's per-block serial-number / CRC octets are not
+// stripped here — that is a documented follow-up.
+func ReassemblePDU(h PDUHeader, blocks [][]byte) (PDU, error) {
+	payload := make([]byte, 0, len(blocks)*PDUBlockBytes)
+	for _, blk := range blocks {
+		if len(blk) != PDUBlockBytes {
+			return PDU{}, ErrPDUBlockLength
+		}
+		payload = append(payload, blk...)
+	}
+	return PDU{Header: h, Payload: payload}, nil
+}

--- a/internal/radio/p25/phase1/pdu_ip.go
+++ b/internal/radio/p25/phase1/pdu_ip.go
@@ -1,0 +1,48 @@
+package phase1
+
+import (
+	"encoding/binary"
+	"errors"
+	"net/netip"
+)
+
+// IPv4 header extraction for P25 packet data. When an SNDCP message
+// (see sndcp.go) encapsulates an IPv4 packet, ParseIPv4 surfaces its
+// source / destination addresses and protocol — the "who is talking to
+// whom" of a P25 data call. Unlike the PDU and SNDCP layers above it,
+// the IPv4 header is a standard, fully-specified format (RFC 791), so
+// this layer is exact rather than a working model.
+
+// IPv4Packet is the parsed header of an IPv4 packet.
+type IPv4Packet struct {
+	HeaderLen   int // header length in bytes
+	TotalLength uint16
+	Protocol    uint8 // 1 = ICMP, 6 = TCP, 17 = UDP
+	Source      netip.Addr
+	Dest        netip.Addr
+}
+
+// ErrNotIPv4 is returned when the input is not a well-formed IPv4
+// packet header.
+var ErrNotIPv4 = errors.New("p25/phase1: not an IPv4 packet")
+
+// ParseIPv4 decodes the fixed 20-byte IPv4 header at the start of b.
+func ParseIPv4(b []byte) (IPv4Packet, error) {
+	if len(b) < 20 {
+		return IPv4Packet{}, ErrNotIPv4
+	}
+	if b[0]>>4 != 4 {
+		return IPv4Packet{}, ErrNotIPv4
+	}
+	ihl := int(b[0]&0x0F) * 4
+	if ihl < 20 || ihl > len(b) {
+		return IPv4Packet{}, ErrNotIPv4
+	}
+	return IPv4Packet{
+		HeaderLen:   ihl,
+		TotalLength: binary.BigEndian.Uint16(b[2:4]),
+		Protocol:    b[9],
+		Source:      netip.AddrFrom4([4]byte{b[12], b[13], b[14], b[15]}),
+		Dest:        netip.AddrFrom4([4]byte{b[16], b[17], b[18], b[19]}),
+	}, nil
+}

--- a/internal/radio/p25/phase1/pdu_test.go
+++ b/internal/radio/p25/phase1/pdu_test.go
@@ -1,0 +1,121 @@
+package phase1
+
+import (
+	"bytes"
+	"encoding/binary"
+	"net/netip"
+	"testing"
+)
+
+func TestPDUHeaderRoundTrip(t *testing.T) {
+	in := PDUHeader{
+		Format: PDUFmtConfirmedData, Confirmed: true,
+		SAP: 0x04, MFID: 0x90, LLID: 0x00ABCD, BlockCount: 3,
+	}
+	got, err := ParsePDUHeader(AssemblePDUHeader(in))
+	if err != nil {
+		t.Fatalf("ParsePDUHeader: %v", err)
+	}
+	if got != in {
+		t.Errorf("round-trip = %+v, want %+v", got, in)
+	}
+}
+
+func TestReassemblePDU(t *testing.T) {
+	h := PDUHeader{Format: PDUFmtUnconfirmedData, BlockCount: 2}
+	b0 := bytes.Repeat([]byte{0xAA}, PDUBlockBytes)
+	b1 := bytes.Repeat([]byte{0xBB}, PDUBlockBytes)
+	pdu, err := ReassemblePDU(h, [][]byte{b0, b1})
+	if err != nil {
+		t.Fatalf("ReassemblePDU: %v", err)
+	}
+	if len(pdu.Payload) != 2*PDUBlockBytes {
+		t.Errorf("payload len = %d, want %d", len(pdu.Payload), 2*PDUBlockBytes)
+	}
+	if _, err := ReassemblePDU(h, [][]byte{b0, b1[:5]}); err == nil {
+		t.Error("ReassemblePDU accepted a short block")
+	}
+}
+
+func TestSNDCPRoundTrip(t *testing.T) {
+	in := SNDCPMessage{PDUType: 0x0A, NSAPI: 0x05, Payload: []byte("packet-data")}
+	got, err := ParseSNDCP(AssembleSNDCP(in))
+	if err != nil {
+		t.Fatalf("ParseSNDCP: %v", err)
+	}
+	if got.PDUType != in.PDUType || got.NSAPI != in.NSAPI || !bytes.Equal(got.Payload, in.Payload) {
+		t.Errorf("round-trip = %+v, want %+v", got, in)
+	}
+	if _, err := ParseSNDCP([]byte{0x01}); err == nil {
+		t.Error("ParseSNDCP accepted a 1-byte message")
+	}
+}
+
+func TestParseIPv4(t *testing.T) {
+	// Build a minimal 20-byte IPv4 header: 10.0.0.1 → 10.0.0.2, UDP.
+	h := make([]byte, 20)
+	h[0] = 0x45 // version 4, IHL 5 (20 bytes)
+	binary.BigEndian.PutUint16(h[2:4], 48)
+	h[9] = 17 // UDP
+	copy(h[12:16], []byte{10, 0, 0, 1})
+	copy(h[16:20], []byte{10, 0, 0, 2})
+
+	got, err := ParseIPv4(h)
+	if err != nil {
+		t.Fatalf("ParseIPv4: %v", err)
+	}
+	if got.HeaderLen != 20 || got.TotalLength != 48 || got.Protocol != 17 {
+		t.Errorf("header = %+v", got)
+	}
+	if got.Source != netip.AddrFrom4([4]byte{10, 0, 0, 1}) ||
+		got.Dest != netip.AddrFrom4([4]byte{10, 0, 0, 2}) {
+		t.Errorf("addrs = %v → %v", got.Source, got.Dest)
+	}
+
+	if _, err := ParseIPv4(h[:10]); err == nil {
+		t.Error("ParseIPv4 accepted a truncated header")
+	}
+	bad := append([]byte(nil), h...)
+	bad[0] = 0x65 // version 6 in an IPv4 parse
+	if _, err := ParseIPv4(bad); err == nil {
+		t.Error("ParseIPv4 accepted a non-IPv4 version")
+	}
+}
+
+// TestPDUDataToIPEndToEnd walks the full data stack: an IPv4 packet
+// wrapped in SNDCP, carried as a PDU payload, decoded back out.
+func TestPDUDataToIPEndToEnd(t *testing.T) {
+	ip := make([]byte, 20)
+	ip[0] = 0x45
+	binary.BigEndian.PutUint16(ip[2:4], 20)
+	ip[9] = 6 // TCP
+	copy(ip[12:16], []byte{172, 16, 0, 9})
+	copy(ip[16:20], []byte{8, 8, 8, 8})
+
+	sndcp := AssembleSNDCP(SNDCPMessage{PDUType: 1, NSAPI: 2, Payload: ip})
+	// Pad the SNDCP message up to a whole number of 12-byte blocks.
+	for len(sndcp)%PDUBlockBytes != 0 {
+		sndcp = append(sndcp, 0)
+	}
+	var blocks [][]byte
+	for off := 0; off < len(sndcp); off += PDUBlockBytes {
+		blocks = append(blocks, sndcp[off:off+PDUBlockBytes])
+	}
+	h := PDUHeader{Format: PDUFmtUnconfirmedData, BlockCount: uint8(len(blocks))}
+
+	pdu, err := ReassemblePDU(h, blocks)
+	if err != nil {
+		t.Fatalf("ReassemblePDU: %v", err)
+	}
+	msg, err := ParseSNDCP(pdu.Payload)
+	if err != nil {
+		t.Fatalf("ParseSNDCP: %v", err)
+	}
+	got, err := ParseIPv4(msg.Payload)
+	if err != nil {
+		t.Fatalf("ParseIPv4: %v", err)
+	}
+	if got.Protocol != 6 || got.Dest != netip.AddrFrom4([4]byte{8, 8, 8, 8}) {
+		t.Errorf("recovered IPv4 = %+v, want TCP → 8.8.8.8", got)
+	}
+}

--- a/internal/radio/p25/phase1/sndcp.go
+++ b/internal/radio/p25/phase1/sndcp.go
@@ -1,0 +1,48 @@
+package phase1
+
+import "errors"
+
+// SNDCP — the Sub-Network Dependent Convergence Protocol layer P25
+// packet data carries between the PDU and the encapsulated network
+// packet. A reassembled PDU payload (see ReassemblePDU) whose SAP marks
+// it as packet data begins with an SNDCP header; ParseSNDCP peels it
+// off to expose the network-layer packet (commonly IPv4 — see
+// pdu_ip.go).
+//
+// Working-model header layout (TIA-102.BBAB SNDCP tables are not in the
+// repo): the 1-octet header packs a 4-bit PDU type and a 4-bit NSAPI;
+// the network packet follows after a 1-octet reserved field.
+//
+//	byte 0 : bits 4-7 = PDU type, bits 0-3 = NSAPI
+//	byte 1 : reserved
+//	bytes 2.. : encapsulated network-layer packet
+
+// SNDCPMessage is a parsed SNDCP message.
+type SNDCPMessage struct {
+	PDUType uint8  // SNDCP PDU type
+	NSAPI   uint8  // Network Service Access Point Identifier
+	Payload []byte // the encapsulated network-layer packet
+}
+
+// ErrSNDCPShort is returned when an SNDCP message is too short to parse.
+var ErrSNDCPShort = errors.New("p25/phase1: SNDCP message needs at least 2 bytes")
+
+// ParseSNDCP decodes an SNDCP message from a reassembled PDU payload.
+func ParseSNDCP(b []byte) (SNDCPMessage, error) {
+	if len(b) < 2 {
+		return SNDCPMessage{}, ErrSNDCPShort
+	}
+	return SNDCPMessage{
+		PDUType: b[0] >> 4,
+		NSAPI:   b[0] & 0x0F,
+		Payload: append([]byte(nil), b[2:]...),
+	}, nil
+}
+
+// AssembleSNDCP is the inverse of ParseSNDCP.
+func AssembleSNDCP(m SNDCPMessage) []byte {
+	out := make([]byte, 2+len(m.Payload))
+	out[0] = m.PDUType<<4 | m.NSAPI&0x0F
+	copy(out[2:], m.Payload)
+	return out
+}

--- a/internal/radio/p25/phase1/talker_alias.go
+++ b/internal/radio/p25/phase1/talker_alias.go
@@ -1,0 +1,137 @@
+package phase1
+
+import (
+	"sync"
+	"time"
+)
+
+// P25 Phase 1 talker-alias reassembly. A talker alias — a radio's
+// human-readable display name — is too long for one TSBK, so a system
+// sends it as a numbered sequence of vendor TSBK fragments.
+// TalkerAliasAssembler buffers the fragments per source unit and emits
+// the completed name once every block has arrived.
+//
+// This mirrors the Phase 2 assembler (internal/radio/p25/phase2/
+// talker_alias.go); the two packages keep independent copies rather
+// than cross-importing, as phase1/phase2 already do for BandPlan and
+// other shared shapes. The fragment wire layout is the project's
+// working model — see tsbk_vendor.go.
+
+// TalkerAliasFragment is one numbered piece of a radio's talker alias.
+type TalkerAliasFragment struct {
+	SourceID   uint32
+	BlockIndex uint8
+	BlockCount uint8
+	Data       []byte
+}
+
+// Talker-alias assembler bounds.
+const (
+	// aliasStaleAfter is how long an incomplete alias is kept before a
+	// later Add evicts it — a lost final fragment must not leak memory.
+	aliasStaleAfter = 10 * time.Second
+	// aliasMaxPending caps the number of distinct source units buffered
+	// at once; the oldest is dropped when the cap is reached.
+	aliasMaxPending = 64
+	// aliasMaxBlocks caps the block count an alias may claim.
+	aliasMaxBlocks = 16
+)
+
+type aliasBuf struct {
+	count   uint8
+	blocks  map[uint8][]byte
+	updated time.Time
+}
+
+// TalkerAliasAssembler reassembles talker-alias fragments per source
+// unit. It is safe for concurrent use; construct one per ControlChannel.
+type TalkerAliasAssembler struct {
+	now     func() time.Time
+	mu      sync.Mutex
+	pending map[uint32]*aliasBuf
+}
+
+// NewTalkerAliasAssembler returns a ready assembler. now is injectable
+// for tests; nil defaults to time.Now.
+func NewTalkerAliasAssembler(now func() time.Time) *TalkerAliasAssembler {
+	if now == nil {
+		now = time.Now
+	}
+	return &TalkerAliasAssembler{now: now, pending: make(map[uint32]*aliasBuf)}
+}
+
+// Add feeds one fragment to the assembler. When the fragment completes
+// an alias it returns (alias, sourceID, true) and forgets the source;
+// otherwise ("", 0, false). Out-of-range or malformed fragments are
+// ignored. Add tolerates fragments arriving in any order.
+func (a *TalkerAliasAssembler) Add(f TalkerAliasFragment) (string, uint32, bool) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	a.evictStaleLocked()
+	if f.BlockCount == 0 || f.BlockCount > aliasMaxBlocks || f.BlockIndex >= f.BlockCount {
+		return "", 0, false
+	}
+	buf := a.pending[f.SourceID]
+	if buf == nil {
+		if len(a.pending) >= aliasMaxPending {
+			a.evictOldestLocked()
+		}
+		buf = &aliasBuf{blocks: make(map[uint8][]byte)}
+		a.pending[f.SourceID] = buf
+	}
+	buf.count = f.BlockCount
+	buf.blocks[f.BlockIndex] = append([]byte(nil), f.Data...)
+	buf.updated = a.now()
+
+	if len(buf.blocks) < int(buf.count) {
+		return "", 0, false
+	}
+	var raw []byte
+	for i := uint8(0); i < buf.count; i++ {
+		b, ok := buf.blocks[i]
+		if !ok {
+			return "", 0, false // a duplicate filled the count but a gap remains
+		}
+		raw = append(raw, b...)
+	}
+	delete(a.pending, f.SourceID)
+	return cleanAlias(raw), f.SourceID, true
+}
+
+// evictStaleLocked drops incomplete aliases older than aliasStaleAfter.
+func (a *TalkerAliasAssembler) evictStaleLocked() {
+	cutoff := a.now().Add(-aliasStaleAfter)
+	for src, buf := range a.pending {
+		if buf.updated.Before(cutoff) {
+			delete(a.pending, src)
+		}
+	}
+}
+
+// evictOldestLocked drops the single least-recently-updated alias.
+func (a *TalkerAliasAssembler) evictOldestLocked() {
+	var oldestSrc uint32
+	var oldest time.Time
+	first := true
+	for src, buf := range a.pending {
+		if first || buf.updated.Before(oldest) {
+			oldestSrc, oldest, first = src, buf.updated, false
+		}
+	}
+	if !first {
+		delete(a.pending, oldestSrc)
+	}
+}
+
+// cleanAlias renders the alias bytes as a printable ASCII string,
+// dropping control and non-ASCII characters.
+func cleanAlias(raw []byte) string {
+	out := make([]byte, 0, len(raw))
+	for _, b := range raw {
+		if b >= 0x20 && b < 0x7F {
+			out = append(out, b)
+		}
+	}
+	return string(out)
+}

--- a/internal/radio/p25/phase1/tsbk_vendor.go
+++ b/internal/radio/p25/phase1/tsbk_vendor.go
@@ -1,0 +1,153 @@
+package phase1
+
+import "encoding/binary"
+
+// Manufacturer-specific P25 Phase 1 TSBKs. SDRtrunk organises its P25
+// TSBK taxonomy into standard / Motorola / Harris / unknown namespaces;
+// this file is the Phase 1 vendor side — accessors that dispatch on the
+// TSBK's MFID header byte (TSBK.MFID, parsed by ParseTSBK) so the same
+// 6-bit opcode value decodes differently per manufacturer.
+//
+// The vendor opcode values and payload layouts below are the project's
+// working model — TIA-102 vendor extensions are not in the repo's spec
+// PDFs — and are confined to this file with symmetric Assemble* encoders
+// and defensive As* accessors, so a spec correction stays local.
+
+// Manufacturer IDs (MFID) per the TIA-registered P25 manufacturer list.
+const (
+	MFIDStandard    uint8 = 0x00 // standard TIA-102 TSBKs
+	MFIDStandardAlt uint8 = 0x01 // also-standard MFID some systems emit
+	MFIDMotorola    uint8 = 0x90
+	MFIDHarris      uint8 = 0xA4
+)
+
+// Vendor TSBK opcodes. These are interpreted only under their owning
+// MFID — the same 6-bit value means something else under MFIDStandard.
+const (
+	// OpMotorolaPatchGroupAdd / Delete are the Motorola group-regroup
+	// ("patch") add and cancel commands under MFID 0x90.
+	OpMotorolaPatchGroupAdd    Opcode = 0x00
+	OpMotorolaPatchGroupDelete Opcode = 0x01
+	// OpHarrisRegroup is the Harris dynamic-regroup command under
+	// MFID 0xA4.
+	OpHarrisRegroup Opcode = 0x00
+	// OpVendorTalkerAlias carries one fragment of a radio's display
+	// name; emitted under either vendor MFID.
+	OpVendorTalkerAlias Opcode = 0x15
+)
+
+// IsVendorMFID reports whether the TSBK's MFID is a recognised
+// manufacturer-specific ID (Motorola or Harris) rather than standard.
+func (t TSBK) IsVendorMFID() bool {
+	return t.MFID == MFIDMotorola || t.MFID == MFIDHarris
+}
+
+// MotorolaPatchGroup is a Motorola group-regroup ("patch") TSBK
+// (MFID 0x90, opcode OpMotorolaPatchGroupAdd): it aggregates member
+// talkgroups under one super-group address.
+//
+//	bytes 0-1 : super-group address
+//	bytes 2-7 : up to 3 member talkgroups (16 bits each; 0 = unused)
+type MotorolaPatchGroup struct {
+	SuperGroup uint16
+	Patched    []uint16
+}
+
+// AsMotorolaPatchGroup returns the structured patch group if the TSBK
+// is a Motorola group-regroup add, otherwise (zero, false).
+func (t TSBK) AsMotorolaPatchGroup() (MotorolaPatchGroup, bool) {
+	if t.MFID != MFIDMotorola || t.Opcode != OpMotorolaPatchGroupAdd {
+		return MotorolaPatchGroup{}, false
+	}
+	g := MotorolaPatchGroup{SuperGroup: binary.BigEndian.Uint16(t.Payload[0:2])}
+	for i := 2; i+2 <= 8; i += 2 {
+		if tg := binary.BigEndian.Uint16(t.Payload[i : i+2]); tg != 0 {
+			g.Patched = append(g.Patched, tg)
+		}
+	}
+	return g, true
+}
+
+// AssembleMotorolaPatchGroup builds the 8-byte payload; used by tests.
+func AssembleMotorolaPatchGroup(g MotorolaPatchGroup) [8]byte {
+	var p [8]byte
+	binary.BigEndian.PutUint16(p[0:2], g.SuperGroup)
+	for i, tg := range g.Patched {
+		if i >= 3 {
+			break
+		}
+		binary.BigEndian.PutUint16(p[2+i*2:4+i*2], tg)
+	}
+	return p
+}
+
+// AsMotorolaPatchDelete returns the super-group address a Motorola
+// group-regroup delete cancels, if the TSBK is one, otherwise (0, false).
+func (t TSBK) AsMotorolaPatchDelete() (uint16, bool) {
+	if t.MFID != MFIDMotorola || t.Opcode != OpMotorolaPatchGroupDelete {
+		return 0, false
+	}
+	return binary.BigEndian.Uint16(t.Payload[0:2]), true
+}
+
+// HarrisRegroup is a Harris dynamic-regroup TSBK (MFID 0xA4, opcode
+// OpHarrisRegroup): it points a regroup talkgroup at a target unit.
+//
+//	bytes 0-1 : regroup talkgroup
+//	bytes 2-4 : target unit ID (24 bits)
+type HarrisRegroup struct {
+	RegroupGroup uint16
+	TargetID     uint32
+}
+
+// AsHarrisRegroup returns the structured regroup if the TSBK is a
+// Harris dynamic-regroup, otherwise (zero, false).
+func (t TSBK) AsHarrisRegroup() (HarrisRegroup, bool) {
+	if t.MFID != MFIDHarris || t.Opcode != OpHarrisRegroup {
+		return HarrisRegroup{}, false
+	}
+	return HarrisRegroup{
+		RegroupGroup: binary.BigEndian.Uint16(t.Payload[0:2]),
+		TargetID:     uint32(t.Payload[2])<<16 | uint32(t.Payload[3])<<8 | uint32(t.Payload[4]),
+	}, true
+}
+
+// AssembleHarrisRegroup builds the 8-byte payload; used by tests.
+func AssembleHarrisRegroup(r HarrisRegroup) [8]byte {
+	var p [8]byte
+	binary.BigEndian.PutUint16(p[0:2], r.RegroupGroup)
+	p[2], p[3], p[4] = byte(r.TargetID>>16), byte(r.TargetID>>8), byte(r.TargetID)
+	return p
+}
+
+// AsTalkerAliasFragment returns one talker-alias fragment if the TSBK
+// is a vendor talker-alias message, otherwise (zero, false). It is
+// MFID-agnostic — both Motorola and Harris alias TSBKs decode through
+// it. Working-model payload layout:
+//
+//	bytes 0-2 : source unit ID (24 bits)
+//	byte 3    : block index
+//	byte 4    : block count
+//	bytes 5-7 : alias data for this block
+func (t TSBK) AsTalkerAliasFragment() (TalkerAliasFragment, bool) {
+	if !t.IsVendorMFID() || t.Opcode != OpVendorTalkerAlias {
+		return TalkerAliasFragment{}, false
+	}
+	return TalkerAliasFragment{
+		SourceID:   uint32(t.Payload[0])<<16 | uint32(t.Payload[1])<<8 | uint32(t.Payload[2]),
+		BlockIndex: t.Payload[3],
+		BlockCount: t.Payload[4],
+		Data:       append([]byte(nil), t.Payload[5:8]...),
+	}, true
+}
+
+// AssembleTalkerAliasFragment builds the 8-byte payload; used by tests.
+// Data beyond 3 bytes is truncated to the block's on-wire width.
+func AssembleTalkerAliasFragment(f TalkerAliasFragment) [8]byte {
+	var p [8]byte
+	p[0], p[1], p[2] = byte(f.SourceID>>16), byte(f.SourceID>>8), byte(f.SourceID)
+	p[3] = f.BlockIndex
+	p[4] = f.BlockCount
+	copy(p[5:8], f.Data)
+	return p
+}

--- a/internal/radio/p25/phase1/tsbk_vendor_test.go
+++ b/internal/radio/p25/phase1/tsbk_vendor_test.go
@@ -1,0 +1,147 @@
+package phase1
+
+import (
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+func TestAsMotorolaPatchGroupRoundTrip(t *testing.T) {
+	in := MotorolaPatchGroup{SuperGroup: 0x1234, Patched: []uint16{10, 20}}
+	tsbk := TSBK{Opcode: OpMotorolaPatchGroupAdd, MFID: MFIDMotorola,
+		Payload: AssembleMotorolaPatchGroup(in)}
+	got, ok := tsbk.AsMotorolaPatchGroup()
+	if !ok {
+		t.Fatal("AsMotorolaPatchGroup returned !ok")
+	}
+	if got.SuperGroup != in.SuperGroup || len(got.Patched) != 2 ||
+		got.Patched[0] != 10 || got.Patched[1] != 20 {
+		t.Errorf("round-trip = %+v, want %+v", got, in)
+	}
+	// A standard-MFID TSBK with the same opcode must not match.
+	tsbk.MFID = MFIDStandard
+	if _, ok := tsbk.AsMotorolaPatchGroup(); ok {
+		t.Error("AsMotorolaPatchGroup matched a standard-MFID TSBK")
+	}
+}
+
+func TestAsMotorolaPatchDelete(t *testing.T) {
+	tsbk := TSBK{Opcode: OpMotorolaPatchGroupDelete, MFID: MFIDMotorola,
+		Payload: [8]byte{0x05, 0x55}}
+	super, ok := tsbk.AsMotorolaPatchDelete()
+	if !ok || super != 0x0555 {
+		t.Errorf("AsMotorolaPatchDelete = (%#x, %v), want (0x555, true)", super, ok)
+	}
+}
+
+func TestAsHarrisRegroupRoundTrip(t *testing.T) {
+	in := HarrisRegroup{RegroupGroup: 0x0777, TargetID: 0x00BEEF}
+	tsbk := TSBK{Opcode: OpHarrisRegroup, MFID: MFIDHarris, Payload: AssembleHarrisRegroup(in)}
+	got, ok := tsbk.AsHarrisRegroup()
+	if !ok || got != in {
+		t.Errorf("AsHarrisRegroup = (%+v, %v), want %+v", got, ok, in)
+	}
+}
+
+func TestAsTalkerAliasFragmentRoundTrip(t *testing.T) {
+	in := TalkerAliasFragment{SourceID: 0x00ABCD, BlockIndex: 1, BlockCount: 3, Data: []byte("ABC")}
+	tsbk := TSBK{Opcode: OpVendorTalkerAlias, MFID: MFIDMotorola,
+		Payload: AssembleTalkerAliasFragment(in)}
+	got, ok := tsbk.AsTalkerAliasFragment()
+	if !ok {
+		t.Fatal("AsTalkerAliasFragment returned !ok")
+	}
+	if got.SourceID != in.SourceID || got.BlockIndex != in.BlockIndex ||
+		got.BlockCount != in.BlockCount || string(got.Data) != "ABC" {
+		t.Errorf("round-trip = %+v, want %+v", got, in)
+	}
+}
+
+func TestTalkerAliasAssembler(t *testing.T) {
+	a := NewTalkerAliasAssembler(nil)
+	if _, _, done := a.Add(TalkerAliasFragment{SourceID: 1, BlockIndex: 2, BlockCount: 3, Data: []byte("INE 1")}); done {
+		t.Fatal("one of three blocks should not complete")
+	}
+	a.Add(TalkerAliasFragment{SourceID: 1, BlockIndex: 0, BlockCount: 3, Data: []byte("FIRE")})
+	alias, src, done := a.Add(TalkerAliasFragment{SourceID: 1, BlockIndex: 1, BlockCount: 3, Data: []byte(" ENG")})
+	if !done || src != 1 || alias != "FIRE ENGINE 1" {
+		t.Errorf("assembly = (%q, %d, %v), want (%q, 1, true)", alias, src, done, "FIRE ENGINE 1")
+	}
+}
+
+func TestTalkerAliasAssemblerEvictsStale(t *testing.T) {
+	clk := time.Unix(1000, 0)
+	a := NewTalkerAliasAssembler(func() time.Time { return clk })
+	a.Add(TalkerAliasFragment{SourceID: 0xAA, BlockIndex: 0, BlockCount: 2, Data: []byte("AB")})
+	clk = clk.Add(aliasStaleAfter + time.Second)
+	if _, _, done := a.Add(TalkerAliasFragment{SourceID: 0xAA, BlockIndex: 1, BlockCount: 2, Data: []byte("CD")}); done {
+		t.Error("stale block 0 should have been evicted; alias must not complete")
+	}
+}
+
+func TestControlChannelPublishesMotorolaPatch(t *testing.T) {
+	bus := events.NewBus(16)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, SystemName: "S"})
+	add := TSBK{Opcode: OpMotorolaPatchGroupAdd, MFID: MFIDMotorola,
+		Payload: AssembleMotorolaPatchGroup(MotorolaPatchGroup{SuperGroup: 0x1234, Patched: []uint16{10, 20}})}
+	del := TSBK{Opcode: OpMotorolaPatchGroupDelete, MFID: MFIDMotorola,
+		Payload: [8]byte{0x12, 0x34}}
+	cc.Process(buildLockedStreamWithTSBK(10, 0x293, DUIDTrunkingSignaling, add), 0)
+	cc.Process(buildLockedStreamWithTSBK(0, 0x293, DUIDTrunkingSignaling, del), 1<<20)
+
+	var patches []trunking.Patch
+	deadline := time.After(time.Second)
+	for len(patches) < 2 {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind == events.KindPatch {
+				patches = append(patches, ev.Payload.(trunking.Patch))
+			}
+		case <-deadline:
+			t.Fatalf("got %d patch events, want 2", len(patches))
+		}
+	}
+	if !patches[0].Add || patches[0].SuperGroup != 0x1234 || len(patches[0].Members) != 2 {
+		t.Errorf("add patch = %+v", patches[0])
+	}
+	if patches[1].Add || patches[1].SuperGroup != 0x1234 {
+		t.Errorf("delete patch = %+v, want Add false / super 0x1234", patches[1])
+	}
+}
+
+func TestControlChannelPublishesTalkerAlias(t *testing.T) {
+	bus := events.NewBus(16)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, SystemName: "S"})
+	f0 := TSBK{Opcode: OpVendorTalkerAlias, MFID: MFIDMotorola,
+		Payload: AssembleTalkerAliasFragment(TalkerAliasFragment{SourceID: 0x123, BlockIndex: 0, BlockCount: 2, Data: []byte("UN")})}
+	f1 := TSBK{Opcode: OpVendorTalkerAlias, MFID: MFIDMotorola,
+		Payload: AssembleTalkerAliasFragment(TalkerAliasFragment{SourceID: 0x123, BlockIndex: 1, BlockCount: 2, Data: []byte("IT")})}
+	cc.Process(buildLockedStreamWithTSBK(10, 0x293, DUIDTrunkingSignaling, f0), 0)
+	cc.Process(buildLockedStreamWithTSBK(0, 0x293, DUIDTrunkingSignaling, f1), 1<<20)
+
+	deadline := time.After(time.Second)
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind == events.KindTalkerAlias {
+				ta := ev.Payload.(trunking.TalkerAlias)
+				if ta.SourceID != 0x123 || ta.Alias != "UNIT" {
+					t.Errorf("talker alias = (%#x, %q), want (0x123, %q)", ta.SourceID, ta.Alias, "UNIT")
+				}
+				return
+			}
+		case <-deadline:
+			t.Fatal("no KindTalkerAlias event")
+		}
+	}
+}

--- a/internal/voice/composer/composer.go
+++ b/internal/voice/composer/composer.go
@@ -344,9 +344,10 @@ func (c *Composer) handleStart(parent context.Context, cs trunking.CallStart) {
 	isFM := proto == "" || proto == "fm" || proto == "analog"
 	isDMRVoice := proto == "dmr-tier2" || proto == "dmr-tier3"
 	isP25P2Voice := proto == "p25-phase2"
-	if !isFM && !isDMRVoice && !isP25P2Voice {
-		// Other digital protocols (P25 Phase 1, NXDN, ...) have no
-		// composer voice chain yet — their voice bursts are not decoded.
+	isP25P1Voice := proto == "p25"
+	if !isFM && !isDMRVoice && !isP25P2Voice && !isP25P1Voice {
+		// Other digital protocols (NXDN, ...) have no composer voice
+		// chain yet — their voice bursts are not decoded.
 		c.log.Info("composer: digital protocol not yet decoded; chain bypassed",
 			"device", cs.DeviceSerial, "protocol", proto,
 			"group", cs.Grant.GroupID)
@@ -383,6 +384,8 @@ func (c *Composer) handleStart(parent context.Context, cs trunking.CallStart) {
 		go c.runDMRVoiceChain(chainCtx, cs.DeviceSerial, iqCh, ch.done)
 	case isP25P2Voice:
 		go c.runP25Phase2VoiceChain(chainCtx, cs.DeviceSerial, iqCh, ch.done)
+	case isP25P1Voice:
+		go c.runP25Phase1VoiceChain(chainCtx, cs.DeviceSerial, iqCh, ch.done)
 	default:
 		go c.runFMChain(chainCtx, cs.DeviceSerial, iqCh, ch.done)
 	}

--- a/internal/voice/composer/composer_test.go
+++ b/internal/voice/composer/composer_test.go
@@ -285,7 +285,8 @@ func TestComposerSkipsDigitalProtocol(t *testing.T) {
 	bus.Publish(events.Event{
 		Kind: events.KindCallStart,
 		Payload: trunking.CallStart{
-			Grant:        trunking.Grant{Protocol: "p25", GroupID: 1, FrequencyHz: 851_000_000},
+			// NXDN has no composer voice chain yet — it must be bypassed.
+			Grant:        trunking.Grant{Protocol: "nxdn", GroupID: 1, FrequencyHz: 851_000_000},
 			DeviceSerial: "VOICE-1",
 			StartedAt:    time.Now().UTC(),
 		},

--- a/internal/voice/composer/p25p1_voice.go
+++ b/internal/voice/composer/p25p1_voice.go
@@ -69,6 +69,17 @@ func (c *Composer) runP25Phase1VoiceChain(ctx context.Context, serial string, iq
 						"serial", serial, "err", werr)
 				}
 			}
+			// An LDU1 carries a Link Control word — surface the call's
+			// talkgroup + source unit it identifies.
+			if duid, derr := phase1.LDUDuid(ldu); derr == nil && duid == phase1.DUIDLogicalLink1 {
+				if blocks, berr := phase1.ExtractLCESBlocks(ldu); berr == nil {
+					if lc, _, lerr := phase1.ParseLinkControl(blocks); lerr == nil {
+						c.log.Debug("composer: p25p1 link control",
+							"serial", serial, "lcf", lc.LCFormat,
+							"tg", lc.TalkgroupID, "src", lc.SourceID)
+					}
+				}
+			}
 		},
 	})
 

--- a/internal/voice/composer/p25p1_voice.go
+++ b/internal/voice/composer/p25p1_voice.go
@@ -69,15 +69,27 @@ func (c *Composer) runP25Phase1VoiceChain(ctx context.Context, serial string, iq
 						"serial", serial, "err", werr)
 				}
 			}
-			// An LDU1 carries a Link Control word — surface the call's
-			// talkgroup + source unit it identifies.
-			if duid, derr := phase1.LDUDuid(ldu); derr == nil && duid == phase1.DUIDLogicalLink1 {
-				if blocks, berr := phase1.ExtractLCESBlocks(ldu); berr == nil {
-					if lc, _, lerr := phase1.ParseLinkControl(blocks); lerr == nil {
-						c.log.Debug("composer: p25p1 link control",
-							"serial", serial, "lcf", lc.LCFormat,
-							"tg", lc.TalkgroupID, "src", lc.SourceID)
-					}
+			// LDU1 carries a Link Control word, LDU2 an Encryption
+			// Sync — surface the call metadata each identifies.
+			duid, derr := phase1.LDUDuid(ldu)
+			if derr != nil {
+				return
+			}
+			blocks, berr := phase1.ExtractLCESBlocks(ldu)
+			if berr != nil {
+				return
+			}
+			switch duid {
+			case phase1.DUIDLogicalLink1:
+				if lc, _, lerr := phase1.ParseLinkControl(blocks); lerr == nil {
+					c.log.Debug("composer: p25p1 link control",
+						"serial", serial, "lcf", lc.LCFormat,
+						"tg", lc.TalkgroupID, "src", lc.SourceID)
+				}
+			case phase1.DUIDLogicalLink2:
+				if es, _, lerr := phase1.ParseEncryptionSync(blocks); lerr == nil && es.Encrypted() {
+					c.log.Debug("composer: p25p1 encryption sync",
+						"serial", serial, "alg", es.AlgorithmID, "key", es.KeyID)
 				}
 			}
 		},

--- a/internal/voice/composer/p25p1_voice.go
+++ b/internal/voice/composer/p25p1_voice.go
@@ -1,0 +1,97 @@
+package composer
+
+import (
+	"context"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/filter"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase1"
+	p25p1rx "github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase1/receiver"
+)
+
+// p25p1VoiceIntermediateHz is the rate the wideband IQ is decimated to
+// before the P25 Phase 1 receiver runs. 48 kHz gives the 4800-baud
+// C4FM symbol stream 10 samples per symbol — ample for the receiver's
+// RRC matched filter and Mueller-Müller clock recovery.
+const p25p1VoiceIntermediateHz = 48_000
+
+// p25p1DeviationHz is the C4FM peak frequency deviation at symbol ±3
+// per TIA-102.BAAA. It calibrates the receiver's 4-level slicer.
+const p25p1DeviationHz = 1800.0
+
+// runP25Phase1VoiceChain consumes IQ for one P25 Phase 1 voice call. It
+// decimates the wideband IQ to a C4FM-friendly rate, recovers the dibit
+// stream with the Phase 1 receiver, assembles complete 1728-bit LDUs,
+// and for each LDU extracts its 9 IMBE voice frames and appends them to
+// the recorder's .raw sidecar.
+//
+// The recorder maps protocol "p25" to the pure-Go IMBE vocoder
+// (voice.DefaultVocoderForProtocol), so WriteRawFrame here decodes each
+// 11-byte frame to PCM and into the call's WAV.
+func (c *Composer) runP25Phase1VoiceChain(ctx context.Context, serial string, iqCh <-chan []complex64, done chan<- struct{}) {
+	defer close(done)
+
+	decim := int(c.iqHz) / p25p1VoiceIntermediateHz
+	if decim < 1 {
+		decim = 1
+	}
+	symbolHz := float64(c.iqHz) / float64(decim)
+
+	// Front-end LPF: doubles as the anti-aliasing filter for the
+	// decimation, so it is only needed when the IQ is actually
+	// decimated (decim == 1 only in tests that feed IQ already at the
+	// intermediate rate).
+	cutoff := float64(c.bw) / float64(c.iqHz)
+	if cutoff > 0.45 {
+		cutoff = 0.45
+	}
+	lpf := filter.NewFIR(filter.LowpassKaiser(81, cutoff, 8.6))
+
+	rs, _ := c.sink.(rawFrameSink)
+	rx := p25p1rx.New(p25p1rx.Options{
+		SampleRateHz: symbolHz,
+		DeviationHz:  p25p1DeviationHz,
+		Sink: func(ldu []byte) {
+			if rs == nil {
+				return
+			}
+			frames, _, err := phase1.ExtractVoiceFrames(ldu)
+			if err != nil {
+				c.log.Warn("composer: p25p1 voice extract failed",
+					"serial", serial, "err", err)
+			}
+			for _, f := range frames {
+				if f == nil {
+					continue
+				}
+				if werr := rs.WriteRawFrame(serial, f); werr != nil {
+					c.log.Warn("composer: p25p1 raw-frame write failed",
+						"serial", serial, "err", werr)
+				}
+			}
+		},
+	})
+
+	touchTicker := time.NewTicker(c.touchEvery)
+	defer touchTicker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-touchTicker.C:
+			if c.engine != nil {
+				c.engine.Touch(serial)
+			}
+		case iq, ok := <-iqCh:
+			if !ok {
+				return
+			}
+			samples := iq
+			if decim > 1 {
+				samples = decimateComplex(lpf.Process(nil, iq), decim)
+			}
+			rx.Process(samples)
+		}
+	}
+}

--- a/internal/voice/composer/p25p1_voice_test.go
+++ b/internal/voice/composer/p25p1_voice_test.go
@@ -1,0 +1,144 @@
+package composer
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/demod"
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase1"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+	"github.com/MattCheramie/GopherTrunk/internal/voice/imbe"
+)
+
+// p25p1VoiceInfo builds a deterministic, unique 88-bit IMBE info frame.
+func p25p1VoiceInfo(seed int) []byte {
+	bits := make([]byte, imbe.InfoBits)
+	x := uint32(seed)*2654435761 + 1
+	for i := range bits {
+		x = x*1664525 + 1013904223
+		bits[i] = byte(x >> 31)
+	}
+	return bits
+}
+
+// buildP25P1VoiceStream assembles a dibit stream of `ldus` P25 Phase 1
+// LDU1s preceded by a clock-settling lead-in. want holds every IMBE
+// frame it carries, in transmission order.
+func buildP25P1VoiceStream(t *testing.T, ldus int) (dibits []uint8, want [][]byte) {
+	t.Helper()
+	dibits = make([]uint8, 400)
+	for i := range dibits {
+		dibits[i] = uint8(i % 4)
+	}
+	frame := 0
+	for l := 0; l < ldus; l++ {
+		var voice [phase1.LDUVoiceSubframeCount][]byte
+		for s := range voice {
+			ch, err := imbe.EncodeChannel(p25p1VoiceInfo(frame))
+			frame++
+			if err != nil {
+				t.Fatalf("EncodeChannel: %v", err)
+			}
+			onAir, err := imbe.Scramble(ch)
+			if err != nil {
+				t.Fatalf("Scramble: %v", err)
+			}
+			// Scramble/Descramble mutate in place — keep an independent
+			// copy for the LDU so the want computation cannot corrupt it.
+			voice[s] = append([]byte(nil), onAir...)
+			wf, _, _ := imbe.DecodeChannelToFrame(onAir)
+			want = append(want, wf)
+		}
+		var lces [phase1.LDULCESBlockCount][]byte
+		var lsd [phase1.LDULSDBlockCount][]byte
+		ldu, err := phase1.AssembleLDU(0x123, phase1.DUIDLogicalLink1, voice, lces, lsd)
+		if err != nil {
+			t.Fatalf("AssembleLDU: %v", err)
+		}
+		dibits = append(dibits, framing.BitsToDibits(ldu)...)
+	}
+	return dibits, want
+}
+
+// TestComposerP25Phase1VoiceChainExtractsRawFrames drives the full
+// composer Phase 1 voice path — modulated C4FM IQ → Phase 1 receiver →
+// LDU assembler → IMBE voice-frame extraction → recorder .raw sidecar —
+// and confirms the recovered frames round-trip to the modulated ones.
+func TestComposerP25Phase1VoiceChainExtractsRawFrames(t *testing.T) {
+	const (
+		sampleRate = 48_000.0
+		sps        = 10
+		span       = 8
+		alpha      = 0.20
+		deviation  = 1800.0
+		ldus       = 12
+	)
+	framesPerLDU := phase1.LDUVoiceSubframeCount
+
+	dibits, want := buildP25P1VoiceStream(t, ldus)
+	iq := demod.ModulateC4FM(dibits, sps, span, alpha, sampleRate, deviation)
+
+	src := newFakeSource()
+	bus := events.NewBus(8)
+	sink := &recordingSink{}
+	eng := &fakeEngine{}
+	c, err := New(Options{
+		Bus:           bus,
+		Devices:       &fakeDevices{src: map[string]IQSource{"VOICE-1": src}},
+		Sink:          sink,
+		Engine:        eng,
+		IQSampleRate:  uint32(sampleRate),
+		PCMSampleRate: 8000,
+		TouchInterval: 30 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go c.Run(ctx)
+	defer c.Close()
+	defer bus.Close()
+
+	bus.Publish(events.Event{
+		Kind: events.KindCallStart,
+		Payload: trunking.CallStart{
+			Grant: trunking.Grant{
+				System: "P25P1Site", Protocol: "p25",
+				GroupID: 42, FrequencyHz: 851_000_000,
+			},
+			DeviceSerial: "VOICE-1",
+			StartedAt:    time.Now().UTC(),
+		},
+	})
+
+	waitFor(t, 2*time.Second, func() bool { return len(c.ActiveChains()) == 1 })
+	src.SendIQ(iq)
+
+	waitFor(t, 6*time.Second, func() bool {
+		return len(sink.rawFrames("VOICE-1")) >= 6*framesPerLDU
+	})
+
+	got := sink.rawFrames("VOICE-1")
+	for _, f := range got {
+		if len(f) != imbe.FrameBytes {
+			t.Fatalf("raw frame length = %d, want %d", len(f), imbe.FrameBytes)
+		}
+	}
+
+	// At least one full LDU's worth of IMBE frames must round-trip to
+	// the modulated frames, proving the receiver → LDU assembler →
+	// voice-extraction chain is wired correctly through live IQ. (The
+	// C4FM demod is not bit-exact, so a stricter all-frames check
+	// belongs in the receiver's own unit tests, not this wiring test.)
+	matches := bestAlignmentMatches(got, want)
+	if matches < framesPerLDU {
+		t.Errorf("only %d of %d captured frames round-tripped; want at least one LDU (%d)",
+			matches, len(got), framesPerLDU)
+	}
+
+	waitFor(t, time.Second, func() bool { return eng.touched.Load() > 0 })
+}


### PR DESCRIPTION
## Summary

Brings P25 **Phase 1** to functional parity with SDRtrunk, the follow-on to the Phase 2 parity work merged in #309. Seven phases:

- **Voice audio path** — `runP25Phase1VoiceChain`: modulated C4FM IQ → Phase 1 receiver → LDU assembler → IMBE voice-frame extraction → recorder. A `Protocol="p25"` grant now produces a WAV; previously the composer bypassed it. Adds `AssembleLDU`, the synthesized-fixture encoder inverse of `ExtractVoiceFrames`.
- **TSBK grant breadth** — wires the parsed-but-undispatched GroupVoiceChannelUpdate (0x02) and adds the unit-to-unit voice grant (0x04), explicit group update (0x03), telephone-interconnect grant (0x08), and SNDCP data-channel grant (0x14, sets `DataCall`). Factors SVC_OPTIONS into a `ServiceOptions` type.
- **Vendor / MFID dispatch** — decodes manufacturer-specific TSBKs by their MFID header byte: Motorola group-regroup add/delete, Harris regroup, and the multi-fragment vendor talker alias — reusing the protocol-agnostic `events.KindPatch` / `KindTalkerAlias` and the engine `PatchRegistry`.
- **LDU1 Link Control** — decodes the 240-bit LC word through a shortened Hamming(10,6,3) inner FEC into format / service options / talkgroup / source unit.
- **LDU2 Encryption Sync** — surfaces the algorithm ID, key ID, and message indicator of an encrypted call (identify, don't decrypt — matches SDRtrunk).
- **Network topology** — `NetworkModel` accumulates Network / RFSS / Secondary-CC / Adjacent-Site status TSBKs into a queryable `NetworkConfig` (WACN, system/RFSS/site IDs, secondary control channels, neighbour sites).
- **Packet data** — the P25 PDU decode layer: PDU header + multi-block reassembly, the SNDCP convergence layer, and exact IPv4 header extraction — a data call surfaces its source/destination IP and protocol.

## Notes / scope

"Parity" means functional parity with what SDRtrunk *does* — it identifies encryption rather than decrypting. Where TIA-102.BAAA on-air detail is absent from the repo (vendor TSBK opcodes, LC/ES/PDU/SNDCP bit layouts, the Hamming(10,6,3) code), each is a documented working model isolated to one file with a symmetric fixture encoder and round-trip tests, flagged for real-capture calibration.

Two pieces are deliberately deferred, documented in their commits:
- **HDU parsing** — its inner Golay(18,6,8) generator isn't in the repo, and the HDU's call metadata is already covered by the control-channel grant + the LDU2 Encryption Sync.
- **Receiver-level PDU dibit framing** for DUID 0xC — the decode layer (PDU/SNDCP/IP) is complete and tested; wiring the dibit-stream framer needs the FSW/NID/trellis machinery for a new DUID, best built against real packet-data captures.

## Test plan

- [x] `go build ./...` and `go vet` clean; `gofmt -l` clean
- [x] Per-phase unit tests: encode→decode round-trips, FEC bit-flip correction, control-channel event assertions
- [x] `go test -race` green on `p25/phase1`, `p25/phase1/receiver`, `voice/composer`, `trunking`
- [x] P25 Phase 1 + Phase 2 daemon integration tests pass
- [x] Full suite: 70 packages pass, no failures
- [ ] Calibrate the working-model on-air constants against real P25 Phase 1 captures (incl. HDU + PDU dibit framing)

https://claude.ai/code/session_015bf3nGyhz7z7AB7w4hoPsi

---
_Generated by [Claude Code](https://claude.ai/code/session_015bf3nGyhz7z7AB7w4hoPsi)_