### PR TITLE
dsp/sync: fix Mueller-Müller symbol miscount across IQ-chunk boundaries (#275)

### DIFF
--- a/internal/dsp/sync/clock.go
+++ b/internal/dsp/sync/clock.go
@@ -14,6 +14,17 @@ type MuellerMuller struct {
 	prevSym float32
 	prevMid float32
 	have    bool
+	// prevTail is the last sample of the previous Process chunk and
+	// havePrev marks it valid. They let a symbol boundary landing on
+	// src[0] of a later chunk interpolate against the correct preceding
+	// sample. Without them the walk skipped src[0] on every call,
+	// losing one sample of clock phase per chunk — on RTL-realistic
+	// ~19-symbol chunks that drifted the C4FM symbol timing and
+	// scattered dibit errors (issue #275). The first call has no
+	// look-back, so it starts at src[1]; contiguous single-call
+	// behaviour is unchanged.
+	prevTail float32
+	havePrev bool
 }
 
 func NewMuellerMuller(sps, gain float64) *MuellerMuller {
@@ -27,26 +38,45 @@ func NewMuellerMuller(sps, gain float64) *MuellerMuller {
 }
 
 // Process consumes oversampled real samples and emits one recovered symbol
-// per nominal symbol period. dst is reused if it has capacity.
+// per nominal symbol period. dst is reused if it has capacity. The symbol
+// clock carries across calls, so a long stream may be processed in chunks
+// without the recovered symbol count depending on the chunk size: prevTail
+// bridges each chunk boundary so src[0] of a continuation chunk is a real
+// clock step rather than being skipped.
 func (m *MuellerMuller) Process(dst []float32, src []float32) []float32 {
 	if cap(dst) < len(src) {
 		dst = make([]float32, 0, len(src)/int(m.sps)+1)
 	} else {
 		dst = dst[:0]
 	}
-	for i := 1; i < len(src); i++ {
+	// On the first call there is no look-back sample, so the walk
+	// starts at src[1] (src[0] only seeds the interpolation), leaving
+	// single-call behaviour unchanged. Later calls carry the previous
+	// chunk's last sample in prevTail, so src[0] is a real clock step
+	// and the recovered symbol stream no longer depends on how the IQ
+	// was chunked (issue #275).
+	start := 0
+	if !m.havePrev {
+		start = 1
+	}
+	for i := start; i < len(src); i++ {
 		m.mu -= 1.0
 		if m.mu > 0 {
 			continue
 		}
-		// We've crossed a symbol boundary; interpolate at this point.
-		// Use linear interpolation between src[i-1] and src[i].
+		// We've crossed a symbol boundary; interpolate at this point
+		// between the previous sample and src[i]. For i == 0 the
+		// previous sample is the last sample of the previous chunk.
+		prev := m.prevTail
+		if i > 0 {
+			prev = src[i-1]
+		}
 		frac := 1.0 + m.mu // mu is in (-1, 0]; frac is in (0, 1]
-		sym := float32(float64(src[i-1])*(1-frac) + float64(src[i])*frac)
+		sym := float32(float64(prev)*(1-frac) + float64(src[i])*frac)
 
 		if m.have {
 			// Mueller-Muller error: e = sgn(prev)*current - sgn(current)*prev
-			err := sgn(m.prevSym)*float64(sym) - sgn(float32(sym))*float64(m.prevSym)
+			err := sgn(m.prevSym)*float64(sym) - sgn(sym)*float64(m.prevSym)
 			m.mu += m.sps + m.gain*err
 		} else {
 			m.mu += m.sps
@@ -54,6 +84,10 @@ func (m *MuellerMuller) Process(dst []float32, src []float32) []float32 {
 		}
 		m.prevSym = sym
 		dst = append(dst, sym)
+	}
+	if len(src) > 0 {
+		m.prevTail = src[len(src)-1]
+		m.havePrev = true
 	}
 	return dst
 }

--- a/internal/dsp/sync/sync_test.go
+++ b/internal/dsp/sync/sync_test.go
@@ -57,6 +57,40 @@ func TestMuellerMullerRecoversSymbolCount(t *testing.T) {
 	}
 }
 
+func TestMuellerMullerChunkInvariance(t *testing.T) {
+	// The recovered symbol stream must not depend on how the input is
+	// chunked. Issue #275: the loop skipped src[0] on every Process
+	// call, losing one sample of clock phase per chunk, so a stream fed
+	// in RTL-realistic small chunks drifted the C4FM symbol timing.
+	const sps = 8
+	src := make([]float32, 4000)
+	for i := range src {
+		sym := float32([]int{-3, -1, 1, 3}[(i/sps*7+1)%4])
+		theta := math.Pi * float64(i%sps) / float64(sps)
+		src[i] = sym * float32(0.5+0.5*math.Cos(theta))
+	}
+	oneShot := NewMuellerMuller(sps, 0.05).Process(nil, src)
+
+	m := NewMuellerMuller(sps, 0.05)
+	var chunked []float32
+	for i := 0; i < len(src); i += 37 { // an awkward, non-sps chunk size
+		end := i + 37
+		if end > len(src) {
+			end = len(src)
+		}
+		chunked = append(chunked, m.Process(nil, src[i:end])...)
+	}
+	if len(chunked) != len(oneShot) {
+		t.Fatalf("chunked symbol count = %d, one-shot = %d", len(chunked), len(oneShot))
+	}
+	for i := range oneShot {
+		if chunked[i] != oneShot[i] {
+			t.Fatalf("symbol %d: chunked = %v, one-shot = %v — Mueller-Müller "+
+				"output depends on chunk size (#275)", i, chunked[i], oneShot[i])
+		}
+	}
+}
+
 func TestCorrelatorFindsPattern(t *testing.T) {
 	pattern := []float32{1, -1, 1, 1, -1}
 	noise := []float32{0, 0, 0.1, -0.1, 0}

--- a/internal/radio/p25/phase1/receiver/harness_test.go
+++ b/internal/radio/p25/phase1/receiver/harness_test.go
@@ -117,6 +117,7 @@ type harnessResult struct {
 	nac          uint16
 	decodeErrors int
 	nidErrs      []int64 // every "errs" value the NID decoder logged
+	recovered    []uint8 // the full recovered dibit stream, in order
 }
 
 // nidErrsSummary renders the captured NID error counts as min/max/count.
@@ -182,11 +183,17 @@ func runHarness(mode DemodMode, imp demod.Impairments) harnessResult {
 		FrequencyHz: harnessControlFreq,
 	})
 
+	var recovered []uint8
 	r := New(Options{
 		SampleRateHz: harnessSampleRateHz,
 		DeviationHz:  harnessDeviationHz,
 		DemodMode:    mode,
-		DibitSink:    func(dibits []uint8, baseIdx int) { cc.Process(dibits, baseIdx) },
+		DibitSink: func(dibits []uint8, baseIdx int) {
+			// The receiver reuses its dibit buffer across calls, so the
+			// slice is only valid during the callback — copy it.
+			recovered = append(recovered, dibits...)
+			cc.Process(dibits, baseIdx)
+		},
 	})
 
 	for i := 0; i < len(iq); i += harnessChunk {
@@ -217,7 +224,58 @@ func runHarness(mode DemodMode, imp demod.Impairments) harnessResult {
 	logCap.mu.Lock()
 	res.nidErrs = logCap.errs
 	logCap.mu.Unlock()
+	res.recovered = recovered
 	return res
+}
+
+// dibitErrorRate aligns recovered against the transmitted canonical
+// stream over a bounded lag window and returns the fraction of differing
+// dibits over the steady-state region (past the symbol-clock warmup,
+// before the trailer). The demod only ever delays the stream, so the
+// lag search is one-sided; a single global lag is used, so a timing slip
+// inflates the rate — intended, since a slip is itself a demod failure.
+func dibitErrorRate(transmitted, recovered []uint8) float64 {
+	const (
+		scoreStart = 256 // past the 200-dibit warmup + clock settling
+		trailerPad = 120 // skip the 100-dibit trailer + margin
+		maxLag     = 96  // matched-filter group delay + warmup slack
+	)
+	scoreEnd := len(transmitted) - trailerPad
+	if scoreEnd <= scoreStart || len(recovered) <= scoreStart {
+		return 1.0
+	}
+	bestErrs, bestLen := -1, 0
+	for lag := 0; lag <= maxLag; lag++ {
+		errs, n := 0, 0
+		for i := scoreStart; i < scoreEnd; i++ {
+			j := i + lag
+			if j >= len(recovered) {
+				break
+			}
+			if transmitted[i] != recovered[j] {
+				errs++
+			}
+			n++
+		}
+		// Pick the lag with the lowest error rate (cross-multiply to
+		// compare errs/n without floats).
+		if n > 0 && (bestErrs < 0 || errs*bestLen < bestErrs*n) {
+			bestErrs, bestLen = errs, n
+		}
+	}
+	if bestLen == 0 {
+		return 1.0
+	}
+	return float64(bestErrs) / float64(bestLen)
+}
+
+// runHarnessDER runs the harness and additionally reports the recovered
+// dibit error rate against the transmitted canonical stream — turning
+// the "close but corrupted" #275 C4FM symptom into a measurable number.
+func runHarnessDER(mode DemodMode, imp demod.Impairments) (der float64, res harnessResult) {
+	res = runHarness(mode, imp)
+	canonical := buildHarnessDibits(harnessNAC, harnessFrameRepeats)
+	return dibitErrorRate(canonical, res.recovered), res
 }
 
 // TestHarnessCleanControlChannelLocks is the regression guard: an
@@ -397,6 +455,96 @@ func TestHarnessCQPSKGainInvariant(t *testing.T) {
 					"(decodeErrors=%d, nidErrs min/max/n=%s) — the CQPSK "+
 					"path is gain-sensitive (#275)",
 					scale, res.decodeErrors, res.nidErrsSummary())
+			}
+		})
+	}
+}
+
+// TestHarnessC4FMChunkBoundary guards the Mueller-Müller chunk-boundary
+// fix for issue #275. The C4FM symbol-clock loop skipped src[0] on every
+// Process call, losing one sample of clock phase per IQ chunk; on a real
+// RTL-SDR's ~19-symbol USB transfers that drifted the symbol timing and
+// scattered dibit errors, so the control channel could not hold a lock
+// even though the same signal decoded when fed in one large block. (Same
+// bug class as the #300 Gardner fix, on the C4FM path's clock.) The fix
+// makes the recovered dibit stream independent of how the IQ is chunked;
+// this test asserts the small-chunk stream is identical to the one-shot
+// stream, dibit for dibit.
+func TestHarnessC4FMChunkBoundary(t *testing.T) {
+	canonical := buildHarnessDibits(harnessNAC, harnessFrameRepeats)
+	iq := modulateHarness(canonical, DemodC4FM)
+
+	recoverDibits := func(chunk int) []uint8 {
+		var rec []uint8
+		r := New(Options{
+			SampleRateHz: harnessSampleRateHz,
+			DeviationHz:  harnessDeviationHz,
+			DemodMode:    DemodC4FM,
+			DibitSink:    func(d []uint8, _ int) { rec = append(rec, d...) },
+		})
+		for i := 0; i < len(iq); i += chunk {
+			end := i + chunk
+			if end > len(iq) {
+				end = len(iq)
+			}
+			r.Process(iq[i:end])
+		}
+		return rec
+	}
+
+	oneShot := recoverDibits(len(iq))
+	small := recoverDibits(harnessChunk)
+
+	t.Logf("#275 C4FM chunk-boundary: one-shot=%d  small-chunk(%d)=%d dibits",
+		len(oneShot), harnessChunk, len(small))
+
+	if len(small) != len(oneShot) {
+		t.Fatalf("C4FM recovered dibit count: small-chunk(%d)=%d, one-shot=%d — the "+
+			"Mueller-Müller loop is miscounting symbols across IQ-chunk boundaries (#275)",
+			harnessChunk, len(small), len(oneShot))
+	}
+	for i := range oneShot {
+		if small[i] != oneShot[i] {
+			t.Fatalf("C4FM recovered dibit %d: small-chunk=%d, one-shot=%d — the symbol "+
+				"stream depends on IQ chunk size (#275)", i, small[i], oneShot[i])
+		}
+	}
+}
+
+// TestHarnessC4FMDibitErrorRate is the diagnostic for the remaining #275
+// C4FM failure: the field decoder reaches NID decoding but the dibits
+// are too corrupted to hold a control-channel lock (NID BCH pegs at its
+// errs=11 ceiling). The harness's binary locked/not-locked outcome and
+// NID-only error counts are too coarse to drive a fix, so this measures
+// the recovered dibit error rate directly across every realistic
+// RTL-SDR impairment. The clean case is a hard assertion — it proves the
+// measurement works and the noiseless C4FM path slices cleanly; the
+// impaired cases are logged so the one(s) reproducing the field symptom
+// (high DER, NID errs at the ceiling, no genuine lock) are named.
+func TestHarnessC4FMDibitErrorRate(t *testing.T) {
+	cases := []struct {
+		name string
+		imp  demod.Impairments
+	}{
+		{"clean", demod.Impairments{}},
+		{"dc_spike", demod.Impairments{DCOffset: complex(0.15, 0.10)}},
+		{"iq_imbalance", demod.Impairments{IQGainImbalance: 1.15, IQPhaseSkewRad: 0.12}},
+		{"awgn_20db", demod.Impairments{SNRdB: 20, Seed: 1}},
+		{"awgn_10db", demod.Impairments{SNRdB: 10, Seed: 1}},
+		{"combined", demod.Impairments{
+			FreqOffsetHz: 600, DCOffset: complex(0.08, 0.05),
+			IQGainImbalance: 1.08, SNRdB: 18, Seed: 1,
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			der, res := runHarnessDER(DemodC4FM, tc.imp)
+			t.Logf("#275 C4FM DER  %-14s  der=%.4f  locked=%-5v  decodeErrors=%-3d  nidErrs(min/max/n)=%s",
+				tc.name, der, res.locked, res.decodeErrors, res.nidErrsSummary())
+			if tc.name == "clean" && der > 0.10 {
+				t.Errorf("clean C4FM dibit error rate = %.4f, want <= 0.10 — "+
+					"well above the ~0.66 of the #275 chunk-boundary bug, so this "+
+					"flags a gross regression in the clean C4FM demod path", der)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

The remaining issue #275 failure was the P25 Phase 1 **C4FM** path producing systematically corrupted dibits — the field decoder reached NID decoding but the NID BCH pegged at its `errs=11` ceiling and the control channel never held a lock, even though SDRTrunk/OP25 decode the same signal fine.

A new harness **dibit-error-rate measurement** pinned the root cause: the C4FM `MuellerMuller` symbol clock is **chunk-size dependent**. One-shot it scored a 0.04 dibit error rate; fed in RTL-realistic ~19-symbol chunks it scored **0.66** (near-random).

`MuellerMuller.Process` started its sample walk at `src[1]` on every call, so `src[0]` never advanced the symbol clock. Fed a long stream in one block that is a harmless one-sample edge effect — but a real RTL-SDR delivers IQ in ~19-symbol USB transfers, and one dropped sample per chunk drifted the C4FM symbol timing and scattered dibit errors across the stream. Same bug class as the #300 Gardner fix, one demod path over.

## The fix

`internal/dsp/sync/clock.go` — carry the previous chunk's last sample as look-back (`prevTail`) so `src[0]` of every continuation chunk is a real clock step. The first call has no look-back and still starts at `src[1]`, so single-call behaviour is unchanged (no existing test or one-shot path shifts).

With the fix the chunked C4FM dibit stream is **byte-identical** to the one-shot stream.

## Tests added

- `TestMuellerMullerChunkInvariance` — `sync`-level guard: one-shot vs awkwardly-chunked output must match.
- `TestHarnessC4FMChunkBoundary` — end-to-end guard: the C4FM recovered dibit stream must be identical regardless of IQ chunk size.
- `TestHarnessC4FMDibitErrorRate` — the diagnostic harness that pinned this down; measures recovered dibit error rate across every realistic RTL-SDR impairment (`runHarnessDER` / `dibitErrorRate`).

## Test plan

- [x] Reproduced first — chunked C4FM DER 0.66 vs 0.04 one-shot before the fix
- [x] After the fix — chunked output byte-identical to one-shot; every C4FM impairment case locks (DER 0.04–0.19, was ~0.68 across the board)
- [x] `go build ./...`, `go vet ./...`, full `go test ./...` — clean
- [x] `-race` on `dsp/sync` and every C4FM-family receiver (P25 Phase 1, DMR, NXDN, YSF — all share `MuellerMuller`, so all benefit) — clean
- [x] `make integration-cc` (P25 Phase 1 control channel) — green

Addresses the C4FM half of #275. A pre-existing ~4% one-shot `MuellerMuller` baseline dibit error (present in the passing integration test, unchanged by this fix) is noted as a separate timing-loop quality follow-up, out of scope here.

https://claude.ai/code/session_01Qc4zddc3oMNFsM6JCcXEn6

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qc4zddc3oMNFsM6JCcXEn6)_