### PR TITLE
p25/phase1: fix harness filler that mis-measured C4FM timing (#275)

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,6 +407,24 @@ to its own package and lands independently.
 
 ### Recently shipped
 
+- **P25 Phase 1 C4FM symbol-timing recovery verified
+  correct; #275 reproduction harness made faithful.**
+  Following the Mueller-Müller chunk-boundary fix, the
+  residual clean-signal C4FM dibit error rate was
+  investigated and found to be a harness artifact, not a
+  demod fault. The #275 harness filled its warmup / idle /
+  trailer dibits with a periodic 0,1,2,3 ramp; the
+  Mueller-Müller symbol-timing detector is data-pattern
+  dependent, so that periodic filler biased the detector's
+  equilibrium off the eye centre — the harness mis-measured
+  the C4FM demod and falsely failed symbol-timing-phase
+  acquisition. The filler is now pseudo-random (fixed seed),
+  matching the effectively-random dibit stream of a real
+  trellis-coded P25 control channel. With it the
+  clean-signal C4FM dibit error rate is zero and the control
+  channel locks at every symbol-timing phase — a coverage
+  gap the harness never exercised before, now guarded by
+  `TestHarnessC4FMTimingPhaseAcquisition`.
 - **P25 Phase 1 voice decoding and SDRtrunk feature parity.**
   A `p25` voice grant now decodes end-to-end — the composer's
   `runP25Phase1VoiceChain` takes modulated C4FM IQ → Phase 1

--- a/internal/radio/p25/phase1/receiver/harness_test.go
+++ b/internal/radio/p25/phase1/receiver/harness_test.go
@@ -31,6 +31,7 @@ import (
 	"fmt"
 	"log/slog"
 	"math"
+	"math/rand"
 	"sync"
 	"testing"
 
@@ -52,6 +53,9 @@ const (
 	// symbols' worth — close to a real 16 KiB RTL-SDR USB transfer —
 	// so the cross-chunk frame assembly added in #292 stays exercised.
 	harnessChunk = 192
+	// harnessFillerSeed seeds the pseudo-random warmup / idle / trailer
+	// filler in buildHarnessDibits. Fixed, so the stream is reproducible.
+	harnessFillerSeed = 0x9275
 )
 
 // demodModes is the set of demod paths the harness exercises.
@@ -66,9 +70,18 @@ var demodModes = []struct {
 // buildHarnessDibits assembles a canonical P25 Phase 1 control-channel
 // dibit stream: a 200-dibit warmup so the symbol-clock loop converges,
 // then `repeats` × (FSW + NID + TSBK + 50 idle dibits), then a
-// 100-dibit trailer. Mirrors buildP25LockedIQDibits in the integration
-// test so the two harnesses stay comparable.
+// 100-dibit trailer.
+//
+// The warmup / idle / trailer filler is pseudo-random (fixed seed, so
+// the stream stays reproducible) and must not be periodic. Real P25
+// control-channel dibits are effectively random — back-to-back
+// trellis-coded TSBKs — and the Mueller-Müller symbol-timing detector
+// is data-pattern dependent: a periodic filler such as a 0,1,2,3 ramp
+// biases its equilibrium off the eye centre, which made the harness
+// mis-measure the C4FM demod and falsely fail timing-phase acquisition
+// (issue #275).
 func buildHarnessDibits(nac uint16, repeats int) []uint8 {
+	rng := rand.New(rand.NewSource(harnessFillerSeed))
 	frame := make([]uint8, 0, 24+32+98)
 	frame = append(frame, phase1.FrameSyncWord[:]...)
 	nidBits := phase1.EncodeNIDBits(nac, phase1.DUIDTrunkingSignaling)
@@ -80,16 +93,16 @@ func buildHarnessDibits(nac uint16, repeats int) []uint8 {
 
 	out := make([]uint8, 0, 200+repeats*(len(frame)+50)+100)
 	for i := 0; i < 200; i++ {
-		out = append(out, uint8(i&3))
+		out = append(out, uint8(rng.Intn(4)))
 	}
 	for r := 0; r < repeats; r++ {
 		out = append(out, frame...)
 		for i := 0; i < 50; i++ {
-			out = append(out, uint8(i&3))
+			out = append(out, uint8(rng.Intn(4)))
 		}
 	}
 	for i := 0; i < 100; i++ {
-		out = append(out, uint8(i&3))
+		out = append(out, uint8(rng.Intn(4)))
 	}
 	return out
 }
@@ -168,6 +181,14 @@ func (h *nidLogCapture) WithGroup(string) slog.Handler      { return h }
 // reports whether the control channel locked and how the NID decoder
 // fared.
 func runHarness(mode DemodMode, imp demod.Impairments) harnessResult {
+	return runHarnessPhase(mode, imp, 0)
+}
+
+// runHarnessPhase is runHarness with a symbol-timing phase offset: it
+// drops the first skip IQ samples, so the receiver's clock starts at an
+// arbitrary phase relative to the signal — what every real RTL-SDR
+// capture presents, and what the symbol-clock loop must pull in from.
+func runHarnessPhase(mode DemodMode, imp demod.Impairments, skip int) harnessResult {
 	canonical := buildHarnessDibits(harnessNAC, harnessFrameRepeats)
 	iq := demod.ApplyImpairments(modulateHarness(canonical, mode), harnessSampleRateHz, imp)
 
@@ -196,7 +217,7 @@ func runHarness(mode DemodMode, imp demod.Impairments) harnessResult {
 		},
 	})
 
-	for i := 0; i < len(iq); i += harnessChunk {
+	for i := skip; i < len(iq); i += harnessChunk {
 		end := i + harnessChunk
 		if end > len(iq) {
 			end = len(iq)
@@ -541,10 +562,31 @@ func TestHarnessC4FMDibitErrorRate(t *testing.T) {
 			der, res := runHarnessDER(DemodC4FM, tc.imp)
 			t.Logf("#275 C4FM DER  %-14s  der=%.4f  locked=%-5v  decodeErrors=%-3d  nidErrs(min/max/n)=%s",
 				tc.name, der, res.locked, res.decodeErrors, res.nidErrsSummary())
-			if tc.name == "clean" && der > 0.10 {
-				t.Errorf("clean C4FM dibit error rate = %.4f, want <= 0.10 — "+
-					"well above the ~0.66 of the #275 chunk-boundary bug, so this "+
-					"flags a gross regression in the clean C4FM demod path", der)
+			if tc.name == "clean" && der > 0.02 {
+				t.Errorf("clean C4FM dibit error rate = %.4f, want <= 0.02 — "+
+					"the noiseless C4FM demod should slice essentially perfectly", der)
+			}
+		})
+	}
+}
+
+// TestHarnessC4FMTimingPhaseAcquisition guards C4FM symbol-clock
+// acquisition for issue #275. A real RTL-SDR capture arrives at an
+// arbitrary symbol-timing phase relative to the receiver's clock, so the
+// Mueller-Müller loop must pull the clock in from any of them. The
+// harness fed only phase-aligned signals before, so this was never
+// exercised — and a periodic dibit filler biased the symbol-timing
+// detector, so the C4FM control channel only locked when the signal
+// happened to start phase-aligned. This feeds the control channel at
+// every symbol-timing phase and asserts it locks at each.
+func TestHarnessC4FMTimingPhaseAcquisition(t *testing.T) {
+	for skip := 0; skip < harnessSPS; skip++ {
+		t.Run(fmt.Sprintf("phase_%d", skip), func(t *testing.T) {
+			res := runHarnessPhase(DemodC4FM, demod.Impairments{}, skip)
+			if !res.locked {
+				t.Errorf("C4FM did not lock at symbol-timing phase offset %d/%d samples "+
+					"(decodeErrors=%d, nidErrs min/max/n=%s) — the symbol-clock loop "+
+					"failed to acquire (#275)", skip, harnessSPS, res.decodeErrors, res.nidErrsSummary())
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

This is the follow-up to the Mueller-Müller chunk-boundary fix (#311), which flagged a residual ~4% clean-signal C4FM dibit error rate as a "timing-loop quality" follow-up. Investigating it showed the residual was **a harness artifact, not a demod fault** — and uncovered a real coverage gap.

**Root cause.** The #275 reproduction harness filled its warmup / idle / trailer dibits with a periodic `0,1,2,3` ramp. The Mueller-Müller symbol-timing detector is data-pattern dependent: measuring its S-curve showed the periodic filler biased the detector's equilibrium ~2 samples off the eye centre. So the harness measured a ~4% residual error and the C4FM control channel only locked when the signal happened to start exactly phase-aligned — which only synthetic test signals are. On a *random* dibit stream the S-curve crosses zero exactly at the eye centre: **the Mueller-Müller loop is correct.**

**Fix.** Real P25 control-channel dibits are effectively random (back-to-back trellis-coded TSBKs). `buildHarnessDibits` now fills warmup / idle / trailer with pseudo-random dibits (fixed seed, reproducible). With it:
- the clean-signal C4FM dibit error rate drops from 0.042 to **0.000**;
- the C4FM control channel locks at **every** symbol-timing phase (was 4/10).

**New coverage.** `TestHarnessC4FMTimingPhaseAcquisition` feeds the C4FM control channel at every symbol-timing phase offset and asserts a lock. The harness fed only phase-aligned signals before, so symbol-clock acquisition from an arbitrary phase — what every real RTL-SDR capture presents — was never exercised. `runHarness` is refactored over a new `runHarnessPhase(mode, imp, skip)` that applies the phase offset.

This is a **test-only change** — no production code is touched, because the investigation confirmed the demod is correct.

## Test plan

- [x] Investigated via the Mueller-Müller TED S-curve: periodic filler biases the zero to ~+2.2 samples; random filler crosses zero at the eye centre
- [x] `TestHarnessC4FMTimingPhaseAcquisition` — C4FM locks at all 10 symbol-timing phases (was 4/10 with the periodic filler)
- [x] `TestHarnessC4FMDibitErrorRate` — clean DER 0.000 (was 0.042); threshold tightened to 0.02
- [x] All existing harness tests pass (clean lock, carrier offset, chunk boundary, CQPSK gain/equalizer/chunk)
- [x] `go build ./...`, `go vet ./...`, full `go test ./...` — clean
- [x] `-race` on the receiver package, and `make integration-cc` — green

Resolves the residual flagged in #311; confirms the C4FM symbol-timing recovery is sound.

https://claude.ai/code/session_01Qc4zddc3oMNFsM6JCcXEn6

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qc4zddc3oMNFsM6JCcXEn6)_