### PR TITLE
p25/phase1: use the spec C4FM filter, not root-raised-cosine (#275)

### DIFF
--- a/cmd/gophertrunk/integration_cc_test.go
+++ b/cmd/gophertrunk/integration_cc_test.go
@@ -64,9 +64,6 @@ func TestDaemonCCDecodesP25Phase1(t *testing.T) {
 		nac           = 0x293
 		controlFreqHz = 851_000_000
 		sampleRateHz  = 48_000
-		sps           = 10
-		span          = 8
-		alpha         = 0.2
 		deviationHz   = 1800.0
 		frameRepeats  = 30
 	)
@@ -81,14 +78,14 @@ func TestDaemonCCDecodesP25Phase1(t *testing.T) {
 	// centres, so any one of those frames is enough to lock.
 	dibits := buildP25LockedIQDibits(nac, frameRepeats)
 
-	// Modulate the dibit stream through the C4FM TX chain
-	// (impulse train → RRC pulse shape → FM modulator → IQ).
+	// Modulate the dibit stream through the spec P25 C4FM TX chain
+	// (impulse train → P25 transmit pulse shape → FM modulator → IQ).
 	// 48 kHz @ 10 sps = 4800 baud, the spec rate. 1800 Hz peak
 	// deviation matches TIA-102.BAAA-A; the matched
 	// newP25Phase1Pipeline configures the receiver's slicer
 	// thresholds against this same deviation via the
 	// p25phase1rx.Options.DeviationHz knob.
-	iq := demod.ModulateC4FM(dibits, sps, span, alpha, sampleRateHz, deviationHz)
+	iq := demod.ModulateP25C4FM(dibits, sampleRateHz, deviationHz)
 
 	dir := t.TempDir()
 	iqPath := filepath.Join(dir, "p25-cc.cfile")

--- a/internal/dsp/demod/c4fm.go
+++ b/internal/dsp/demod/c4fm.go
@@ -6,10 +6,10 @@ import (
 
 // C4FM is a four-level continuous-phase FSK demodulator (P25 Phase 1 control
 // channel). Operates on a real input stream produced by an FM discriminator;
-// applies an RRC matched filter and slices to the four-level alphabet
+// applies a matched filter and slices to the four-level alphabet
 // {+3, +1, -1, -3} (multiplied by a deviation scale).
 type C4FM struct {
-	rrc       []float32
+	taps      []float32
 	hist      []float32
 	histPos   int
 	deviation float32
@@ -19,19 +19,29 @@ type C4FM struct {
 // samples-per-symbol, span (in symbols), and roll-off α. The deviation
 // scales slicer thresholds to the application; for P25 with 4800 sym/s and
 // ±1.8 kHz outer deviation, downstream code should set this empirically.
+//
+// Note: an RRC matched filter is correct only for an RRC-shaped transmit
+// signal. P25 Phase 1 C4FM is not RRC-shaped — use NewC4FMWithTaps with
+// P25C4FMRxTaps for it (see c4fm_p25.go).
 func NewC4FM(sps, span int, alpha, deviation float64) *C4FM {
-	rrc := filter.RootRaisedCosine(sps, span, alpha)
-	return &C4FM{rrc: rrc, hist: make([]float32, len(rrc)), deviation: float32(deviation)}
+	return NewC4FMWithTaps(filter.RootRaisedCosine(sps, span, alpha), deviation)
 }
 
-// MatchedFilter applies the RRC filter and returns a same-length output.
+// NewC4FMWithTaps returns a C4FM demod whose matched filter uses the
+// supplied FIR taps directly, instead of the default root-raised-cosine.
+// P25 Phase 1 uses this with the spec C4FM receive filter (P25C4FMRxTaps).
+func NewC4FMWithTaps(taps []float32, deviation float64) *C4FM {
+	return &C4FM{taps: taps, hist: make([]float32, len(taps)), deviation: float32(deviation)}
+}
+
+// MatchedFilter applies the matched filter and returns a same-length output.
 func (c *C4FM) MatchedFilter(dst, src []float32) []float32 {
 	if cap(dst) < len(src) {
 		dst = make([]float32, len(src))
 	} else {
 		dst = dst[:len(src)]
 	}
-	N := len(c.rrc)
+	N := len(c.taps)
 	for i, x := range src {
 		c.hist[c.histPos] = x
 		c.histPos = (c.histPos + 1) % N
@@ -41,7 +51,7 @@ func (c *C4FM) MatchedFilter(dst, src []float32) []float32 {
 			idx = N - 1
 		}
 		for k := 0; k < N; k++ {
-			acc += c.rrc[k] * c.hist[idx]
+			acc += c.taps[k] * c.hist[idx]
 			idx--
 			if idx < 0 {
 				idx = N - 1

--- a/internal/dsp/demod/c4fm_modulator.go
+++ b/internal/dsp/demod/c4fm_modulator.go
@@ -36,7 +36,7 @@ import (
 // callers can use the convenience function ModulateC4FM below.
 type C4FMModulator struct {
 	sps        int
-	rrc        []float32
+	shapeTaps  []float32
 	deviation  float64
 	sampleRate float64
 
@@ -62,19 +62,30 @@ type C4FMModulator struct {
 // Panics if sps or span are non-positive — these are deterministic
 // programmer errors, not runtime configuration.
 func NewC4FMModulator(sps, span int, alpha, sampleRate, deviation float64) *C4FMModulator {
-	if sps <= 0 {
-		panic("demod: C4FMModulator sps must be positive")
-	}
 	if span <= 0 {
 		panic("demod: C4FMModulator span must be positive")
 	}
-	rrc := filter.RootRaisedCosine(sps, span, alpha)
+	return NewC4FMModulatorWithTaps(sps, filter.RootRaisedCosine(sps, span, alpha), sampleRate, deviation)
+}
+
+// NewC4FMModulatorWithTaps constructs a modulator whose pulse-shaping
+// filter is the supplied FIR taps, instead of the default
+// root-raised-cosine (NewC4FMModulator). P25 Phase 1 uses this with the
+// spec C4FM transmit filter (P25C4FMTxTaps) so a synthesized stream
+// matches a real P25 transmitter — see ModulateP25C4FM and c4fm_p25.go.
+func NewC4FMModulatorWithTaps(sps int, shapeTaps []float32, sampleRate, deviation float64) *C4FMModulator {
+	if sps <= 0 {
+		panic("demod: C4FMModulator sps must be positive")
+	}
+	if len(shapeTaps) == 0 {
+		panic("demod: C4FMModulator shapeTaps must be non-empty")
+	}
 	return &C4FMModulator{
 		sps:        sps,
-		rrc:        rrc,
+		shapeTaps:  shapeTaps,
 		deviation:  deviation,
 		sampleRate: sampleRate,
-		shapeHist:  make([]float32, len(rrc)),
+		shapeHist:  make([]float32, len(shapeTaps)),
 	}
 }
 
@@ -94,7 +105,7 @@ func (m *C4FMModulator) Reset() {
 // chunked.
 func (m *C4FMModulator) Modulate(dibits []uint8) []complex64 {
 	out := make([]complex64, len(dibits)*m.sps)
-	N := len(m.rrc)
+	N := len(m.shapeTaps)
 	for di, d := range dibits {
 		sym := dibitToC4FMSymbol(d)
 		for k := 0; k < m.sps; k++ {
@@ -114,7 +125,7 @@ func (m *C4FMModulator) Modulate(dibits []uint8) []complex64 {
 				idx = N - 1
 			}
 			for k := 0; k < N; k++ {
-				shaped += m.rrc[k] * m.shapeHist[idx]
+				shaped += m.shapeTaps[k] * m.shapeHist[idx]
 				idx--
 				if idx < 0 {
 					idx = N - 1
@@ -141,6 +152,17 @@ func (m *C4FMModulator) Modulate(dibits []uint8) []complex64 {
 // that don't need cross-call phase continuity.
 func ModulateC4FM(dibits []uint8, sps, span int, alpha, sampleRate, deviation float64) []complex64 {
 	return NewC4FMModulator(sps, span, alpha, sampleRate, deviation).Modulate(dibits)
+}
+
+// ModulateP25C4FM synthesises a spec-faithful P25 Phase 1 C4FM stream:
+// it shapes with the real P25 transmit filter (raised-cosine α=0.2
+// cascaded with the inverse-sinc compensation, P25C4FMTxTaps) rather
+// than the root-raised-cosine ModulateC4FM uses. A real P25 transmitter
+// uses this shaping, so this is what the receiver's spec matched filter
+// (NewC4FMP25) must be tested against. sps is derived as sampleRate/4800.
+func ModulateP25C4FM(dibits []uint8, sampleRate, deviation float64) []complex64 {
+	sps := int(math.Round(sampleRate / p25C4FMSymbolRate))
+	return NewC4FMModulatorWithTaps(sps, P25C4FMTxTaps(sampleRate), sampleRate, deviation).Modulate(dibits)
 }
 
 // dibitToC4FMSymbol is the inverse of phase1.SymbolToDibit: maps

--- a/internal/dsp/demod/c4fm_p25.go
+++ b/internal/dsp/demod/c4fm_p25.go
@@ -1,0 +1,123 @@
+package demod
+
+import "math"
+
+// P25 C4FM pulse-shaping filters, per TIA-102.BAAA (cross-checked against
+// the op25 reference implementation, c4fm_const.py).
+//
+// P25 C4FM is NOT a root-raised-cosine matched-pair system. The transmit
+// baseband filter is a raised-cosine (α=0.2) cascaded with an inverse-sinc
+// compensation; the receive filter is a sinc (a one-symbol-period
+// integrate-and-dump). The transmit inverse-sinc and the receive sinc
+// cancel, so the cascade transmit×receive is a plain raised-cosine —
+// ISI-free at the symbol instants.
+//
+// GopherTrunk previously modelled C4FM as an RRC matched pair on both
+// ends; that is self-consistent in a synthetic harness but does not match
+// a real P25 transmitter, leaving residual inter-symbol interference on
+// real captures (issue #275).
+
+const p25C4FMSymbolRate = 4800.0
+
+// p25C4FMSpan is the span, in symbols, of the generated P25 C4FM filters
+// (ntaps ≈ sps·span). 13 matches the op25 reference and is long enough
+// for the raised-cosine + inverse-sinc impulse response to settle.
+const p25C4FMSpan = 13
+
+// transferFunctionTxP25 returns the P25 C4FM transmit filter's frequency
+// response, sampled at 1 Hz spacing. Index i is the response at i Hz;
+// the response is zero above 2880 Hz.
+//
+//	H(f): raised-cosine α=0.2 — flat to 1920 Hz, cosine roll-off to 2880 Hz
+//	P(f): inverse-sinc compensation (πf/Rs)/sin(πf/Rs)
+func transferFunctionTxP25() []float64 {
+	xfer := make([]float64, 2881)
+	for f := 0; f <= 2880; f++ {
+		var hf float64
+		if f < 1920 {
+			hf = 1.0
+		} else {
+			hf = 0.5 + 0.5*math.Cos(2*math.Pi*float64(f)/1920.0)
+		}
+		t := math.Pi * float64(f) / p25C4FMSymbolRate
+		pf := 1.0
+		if t >= 1e-6 {
+			pf = t / math.Sin(t)
+		}
+		xfer[f] = pf * hf
+	}
+	return xfer
+}
+
+// transferFunctionRxP25 returns the P25 C4FM receive filter's frequency
+// response: D(f) = sinc(f/Rs), a one-symbol integrate-and-dump that
+// undoes the transmit inverse-sinc compensation.
+func transferFunctionRxP25() []float64 {
+	rate := int(p25C4FMSymbolRate)
+	xfer := make([]float64, rate)
+	for f := 0; f < rate; f++ {
+		t := math.Pi * float64(f) / p25C4FMSymbolRate
+		df := 1.0
+		if t >= 1e-6 {
+			df = math.Sin(t) / t
+		}
+		xfer[f] = df
+	}
+	return xfer
+}
+
+// p25C4FMFilterTaps converts a 1 Hz-spaced frequency response into a
+// real, linear-phase FIR of ntaps taps at sampleRate, normalised so the
+// taps sum to dcGain. Mirrors op25's c4fm_taps.generate(): inverse-FFT
+// the transfer function, centre it on its peak, take the central ntaps.
+// The transfer function is real and even, so the inverse FFT reduces to
+// a cosine sum and only the central taps need to be evaluated.
+func p25C4FMFilterTaps(xfer []float64, sampleRate, dcGain float64, ntaps int) []float32 {
+	n := math.Round(sampleRate)
+	half := (ntaps - 1) / 2
+	taps := make([]float32, ntaps)
+	var sum float64
+	for i := 0; i < ntaps; i++ {
+		m := float64(i - half) // tap offset from the centre (peak at m=0)
+		// h[m] = (1/N)·( X[0] + 2·Σ_{k≥1} X[k]·cos(2πkm/N) )
+		acc := xfer[0]
+		for k := 1; k < len(xfer); k++ {
+			acc += 2 * xfer[k] * math.Cos(2*math.Pi*float64(k)*m/n)
+		}
+		h := acc / n
+		taps[i] = float32(h)
+		sum += h
+	}
+	if sum != 0 {
+		g := float32(dcGain / sum)
+		for i := range taps {
+			taps[i] *= g
+		}
+	}
+	return taps
+}
+
+// P25C4FMTxTaps builds the P25 C4FM transmit pulse-shaping filter for
+// the given sample rate, normalised to unit DC gain.
+func P25C4FMTxTaps(sampleRate float64) []float32 {
+	sps := int(math.Round(sampleRate / p25C4FMSymbolRate))
+	return p25C4FMFilterTaps(transferFunctionTxP25(), sampleRate, 1.0, (sps*p25C4FMSpan)|1)
+}
+
+// P25C4FMRxTaps builds the P25 C4FM receive filter for the given sample
+// rate. It is normalised to a DC gain of sps so that, fed an
+// FM-discriminator output, the matched-filtered symbol centres land at
+// ±(2π·deviation/sampleRate) — the level the C4FM slicer's thresholds
+// are calibrated to (a one-symbol impulse carries 1/sps of the DC,
+// which the sps DC gain restores).
+func P25C4FMRxTaps(sampleRate float64) []float32 {
+	sps := int(math.Round(sampleRate / p25C4FMSymbolRate))
+	return p25C4FMFilterTaps(transferFunctionRxP25(), sampleRate, float64(sps), (sps*p25C4FMSpan)|1)
+}
+
+// NewC4FMP25 builds a C4FM demodulator with the spec P25 receive filter
+// (P25C4FMRxTaps) — the correct matched filter for a real P25 Phase 1
+// C4FM transmitter, which NewC4FM's root-raised-cosine is not.
+func NewC4FMP25(sampleRate, deviation float64) *C4FM {
+	return NewC4FMWithTaps(P25C4FMRxTaps(sampleRate), deviation)
+}

--- a/internal/dsp/demod/c4fm_p25_test.go
+++ b/internal/dsp/demod/c4fm_p25_test.go
@@ -1,0 +1,80 @@
+package demod
+
+import (
+	"math"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/filter"
+)
+
+func p25Conv(a, b []float32) []float32 {
+	out := make([]float32, len(a)+len(b)-1)
+	for i, av := range a {
+		for j, bv := range b {
+			out[i+j] += av * bv
+		}
+	}
+	return out
+}
+
+func p25Argmax(s []float32) int {
+	bi, bv := 0, float32(math.Inf(-1))
+	for i, v := range s {
+		if v > bv {
+			bi, bv = i, v
+		}
+	}
+	return bi
+}
+
+// worstISI returns the largest |tap| at the ±k·sps offsets from the
+// peak — the inter-symbol interference a filter cascade leaves at the
+// neighbouring symbol instants — as a fraction of the peak tap.
+func worstISI(casc []float32, sps int) float64 {
+	pk := p25Argmax(casc)
+	var isi float64
+	for k := 1; k <= 5; k++ {
+		for _, idx := range []int{pk - k*sps, pk + k*sps} {
+			if idx >= 0 && idx < len(casc) {
+				if a := math.Abs(float64(casc[idx])); a > isi {
+					isi = a
+				}
+			}
+		}
+	}
+	return isi / math.Abs(float64(casc[pk]))
+}
+
+// TestP25C4FMCascadeISIFree is the regression guard for the issue #275
+// C4FM filter fix. P25 Phase 1 C4FM is not a root-raised-cosine
+// matched-pair system: the transmitter shapes with a raised-cosine
+// cascaded with an inverse-sinc compensation, and the spec receive
+// filter is a sinc that cancels it, leaving the transmit×receive
+// cascade a plain raised-cosine — ISI-free at the symbol instants.
+//
+// The receiver previously used an RRC matched filter. Against a real
+// (spec-shaped) P25 transmit signal an RRC leaves substantial residual
+// ISI — the systematically-corrupted dibits (`errs=11`) that #275's
+// C4FM path hit on-air. This test asserts the spec pair is ISI-free and
+// that the old RRC pairing is not.
+func TestP25C4FMCascadeISIFree(t *testing.T) {
+	const sps = 10
+	tx := P25C4FMTxTaps(48_000)
+	rx := P25C4FMRxTaps(48_000)
+
+	specISI := worstISI(p25Conv(tx, rx), sps)
+	t.Logf("spec TX × spec RX: worst ISI = %.4f%% of peak", specISI*100)
+	if specISI > 0.01 {
+		t.Errorf("spec C4FM transmit×receive ISI = %.3f%% of peak, want <1%% — "+
+			"the spec filter pair should be ISI-free at the symbol instants", specISI*100)
+	}
+
+	// The previous receiver matched filter — a root-raised-cosine — is
+	// the wrong filter for a spec-shaped transmit signal.
+	rrcISI := worstISI(p25Conv(tx, filter.RootRaisedCosine(sps, 8, 0.2)), sps)
+	t.Logf("spec TX × RRC receive: worst ISI = %.4f%% of peak", rrcISI*100)
+	if rrcISI < 0.05 {
+		t.Errorf("spec-TX × RRC-receive ISI = %.3f%% of peak — expected substantial "+
+			"residual ISI (the #275 root cause); the test premise may be wrong", rrcISI*100)
+	}
+}

--- a/internal/radio/p25/phase1/receiver/harness_test.go
+++ b/internal/radio/p25/phase1/receiver/harness_test.go
@@ -120,8 +120,10 @@ func modulateHarness(canonical []uint8, mode DemodMode) []complex64 {
 		}
 		return demod.ModulatePiOver4DQPSK(modIn, harnessSPS, harnessSpan, harnessAlpha, math.Pi/4)
 	}
-	return demod.ModulateC4FM(canonical, harnessSPS, harnessSpan, harnessAlpha,
-		harnessSampleRateHz, harnessDeviationHz)
+	// C4FM: shape with the spec P25 transmit filter (raised-cosine ×
+	// inverse-sinc), matching a real P25 transmitter — the receiver's
+	// matched filter is the spec C4FM receive filter (issue #275).
+	return demod.ModulateP25C4FM(canonical, harnessSampleRateHz, harnessDeviationHz)
 }
 
 // harnessResult is the outcome of one runHarness pass.

--- a/internal/radio/p25/phase1/receiver/receiver.go
+++ b/internal/radio/p25/phase1/receiver/receiver.go
@@ -8,7 +8,8 @@
 //	DemodC4FM (default):
 //	  IQ
 //	    → FM discriminator (internal/dsp/demod.FM)
-//	    → RRC matched filter (internal/dsp/demod.C4FM)
+//	    → spec P25 C4FM matched filter (internal/dsp/demod.C4FM
+//	      with demod.P25C4FMRxTaps — raised-cosine, not RRC)
 //	    → coarse AFC: residual carrier-offset removal
 //	      (internal/dsp/demod.CoarseAFC)
 //	    → Mueller-Müller symbol clock recovery (sync.MuellerMuller)
@@ -186,19 +187,13 @@ func New(opts Options) *Receiver {
 		gain = 0.05
 	}
 
-	// Slicer thresholds are normalised to the FM-discriminator's
-	// output range so ±1 maps to ±deviation. With the FM
-	// discriminator in rad/sample, the FM peak at symbol ±3 is
-	// 2π · DeviationHz / SampleRateHz, so we pass that value
-	// (times the symbol-magnitude reference of 1.0 — symbol +3
-	// produces a peak ±value, +1 produces ±value/3, etc.) as the
-	// "deviation" arg to NewC4FM. The slicer then puts the
-	// +1/+3 boundary at 2/3 of this and the -1/-3 boundary at
-	// -2/3, both proportional to the physical signal level.
-	//
-	// Callers that don't supply DeviationHz fall back to the
-	// legacy slicerScale = 1.0 — matches the existing synthesized
-	// fixture tests that pre-scale their FM levels into ±1.
+	// The C4FM slicer's thresholds are proportional to the physical
+	// signal level: with the FM discriminator in rad/sample, an outer
+	// (±3) symbol peaks at 2π · DeviationHz / SampleRateHz. The spec
+	// C4FM receive filter (demod.P25C4FMRxTaps) is normalised so the
+	// matched-filtered symbol centres land exactly there, so that value
+	// is the slicer scale. Callers that don't supply DeviationHz fall
+	// back to the legacy scale 1.0 (pre-scaled-fixture path).
 	slicerScale := 1.0
 	if opts.DeviationHz > 0 {
 		slicerScale = 2.0 * math.Pi * opts.DeviationHz / opts.SampleRateHz
@@ -213,7 +208,11 @@ func New(opts Options) *Receiver {
 		r.cq = newCQPSKDemod(int(sps+0.5), span, alpha, opts.GardnerGain)
 	default:
 		r.fm = demod.NewFM()
-		r.mf = demod.NewC4FM(int(sps+0.5), span, alpha, slicerScale)
+		// P25 Phase 1 C4FM is not a root-raised-cosine matched-pair
+		// system: the transmitter shapes with a raised-cosine cascaded
+		// with an inverse-sinc, so the matched filter is the spec C4FM
+		// receive filter (a sinc), not an RRC — issue #275.
+		r.mf = demod.NewC4FMP25(opts.SampleRateHz, slicerScale)
 		r.afc = demod.NewCoarseAFC(sps)
 		r.clock = sync.NewMuellerMuller(sps, gain)
 	}

--- a/internal/scanner/ccdecoder/decoder_test.go
+++ b/internal/scanner/ccdecoder/decoder_test.go
@@ -1013,9 +1013,6 @@ func TestDecoderLocksP25Phase1ThroughWidebandDDC(t *testing.T) {
 		controlFreq  = 851_000_000
 		sdrRateHz    = 2_048_000.0
 		narrowRateHz = 48_000.0
-		sps          = 10
-		span         = 8
-		alpha        = 0.2
 		deviationHz  = 1800.0
 		frameRepeats = 30
 	)
@@ -1025,7 +1022,7 @@ func TestDecoderLocksP25Phase1ThroughWidebandDDC(t *testing.T) {
 	// Decoder's down-converter has a genuine wideband chunk to
 	// channelize back down.
 	dibits := buildP25CCDibits(nac, frameRepeats)
-	narrow := demod.ModulateC4FM(dibits, sps, span, alpha, narrowRateHz, deviationHz)
+	narrow := demod.ModulateP25C4FM(dibits, narrowRateHz, deviationHz)
 	wide := dsp.NewResampler(128, 3, 8, 8.0).Process(nil, narrow)
 
 	bus := events.NewBus(256)

--- a/internal/voice/composer/p25p1_voice_test.go
+++ b/internal/voice/composer/p25p1_voice_test.go
@@ -70,16 +70,13 @@ func buildP25P1VoiceStream(t *testing.T, ldus int) (dibits []uint8, want [][]byt
 func TestComposerP25Phase1VoiceChainExtractsRawFrames(t *testing.T) {
 	const (
 		sampleRate = 48_000.0
-		sps        = 10
-		span       = 8
-		alpha      = 0.20
 		deviation  = 1800.0
 		ldus       = 12
 	)
 	framesPerLDU := phase1.LDUVoiceSubframeCount
 
 	dibits, want := buildP25P1VoiceStream(t, ldus)
-	iq := demod.ModulateC4FM(dibits, sps, span, alpha, sampleRate, deviation)
+	iq := demod.ModulateP25C4FM(dibits, sampleRate, deviation)
 
 	src := newFakeSource()
 	bus := events.NewBus(8)


### PR DESCRIPTION
## Summary

This is Stage 2 of the staged #275 C4FM plan. Stage 1 ruled out the DDC (it decimates faithfully). Stage 2 found the real cause of the remaining C4FM corruption.

**Root cause.** GopherTrunk modelled P25 Phase 1 C4FM as a **root-raised-cosine matched-pair** system — the modulator and the receiver's matched filter both root-raised-cosine. RRC×RRC = raised-cosine (ISI-free), so it is self-consistent in a synthetic harness — which is why every C4FM harness test passed — **but it does not match a real P25 transmitter.**

Per TIA-102.BAAA (cross-checked against the op25 reference, `c4fm_const.py`), P25 C4FM is *not* an RRC matched-pair system:
- **transmit** baseband filter = raised-cosine (α=0.2) **cascaded with an inverse-sinc compensation** `(πf/4800)/sin(πf/4800)`;
- **receive** filter = `sinc(f/4800)`, which cancels the inverse-sinc, leaving the transmit×receive cascade a plain raised-cosine — ISI-free at the symbol instants.

Against a real spec-shaped signal, an RRC receive filter leaves **~6% residual inter-symbol interference** — which systematically corrupts the dibits. That is the `errs=11` NID-BCH symptom #275 reported on real C4FM captures (the strong local site that reached NID decoding but never held a lock). The harness couldn't catch it because it used a self-consistent RRC pair at both ends.

## What changed

- **`internal/dsp/demod/c4fm_p25.go`** (new) — the P25 C4FM spec transmit and receive filters, generated from the spec frequency-domain transfer functions via an inverse FFT (`raised-cosine × inverse-sinc`; `sinc`).
- **`demod.C4FM` / `C4FMModulator`** — gain taps-explicit constructors (`NewC4FMWithTaps`, `NewC4FMModulatorWithTaps`) so the shared root-raised-cosine path (**DMR / NXDN / YSF / dPMR**, which are not P25-spec C4FM) is **untouched**. The P25 Phase 1 receiver uses `NewC4FMP25`; P25 synthesized signals use `ModulateP25C4FM`.
- **`TestP25C4FMCascadeISIFree`** guards the diagnosis: the spec transmit×receive pair is ISI-free (0.001% of peak), the old spec-TX × RRC pairing is not (5.75%).

## Test plan

- [x] Every harness C4FM test passes with the spec filters — clean dibit error rate **0.0000**, control channel locks across all symbol-timing phases
- [x] `TestDecoderLocksP25Phase1ThroughWidebandDDC` (C4FM through the DDC) and the P25 voice chain test pass
- [x] `go build ./...`, `go vet ./...`, full `go test ./...` — clean
- [x] `-race` on the affected packages — clean
- [x] Integration tests green: P25 Phase 1, **and** DMR / NXDN / YSF / dPMR (blast radius confirmed contained)

## Note

The spec receive filter is the *zero-ISI* filter, not the SNR-optimal matched filter — this is inherent to C4FM (it is not an RRC matched-pair modulation). So a marginal-SNR harness *characterization* case (10 dB AWGN, non-fatal) now reflects real P25 receive performance rather than the previous idealized RRC-matched-pair number. For #275 — a strong on-air signal failing on ISI — this is the correct trade.

The fix is harness-verified but synthetic; the issue reporter's on-air retest remains the real confirmation.

https://claude.ai/code/session_01Qc4zddc3oMNFsM6JCcXEn6

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qc4zddc3oMNFsM6JCcXEn6)_