### PR TITLE
broadcast: add outbound call streaming subsystem (WP1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ for tagged releases.
 
 ### Added
 
+- **Outbound call streaming to aggregators and live audio
+  servers.** Completed calls are now encoded to MP3 and streamed
+  to external services, closing the largest functional gap
+  against SDRtrunk. A new `internal/broadcast` subsystem
+  subscribes to a `KindCallComplete` event the recorder
+  publishes once a call's WAV is flushed, encodes the audio via
+  a pure-Go MP3 encoder (`internal/voice/mp3`, no CGO), and
+  fans the call out to every configured backend with bounded
+  exponential-backoff retry. Four backends ship: Broadcastify
+  Calls (two-step metadata + audio upload), RdioScanner
+  (native call-upload API), OpenMHz, and live Icecast/ShoutCast
+  (a continuous paced source connection topped up with silence
+  between calls). Feeds are configured under a new `broadcast:`
+  config section; each feed takes an optional `systems:` filter
+  and a talkgroup can opt out of all feeds with `stream: false`
+  in its CSV/JSON. Feed counters are exposed at
+  `GET /api/v1/broadcast`.
 - **P25 Phase 1 voice decoding and broader control-channel
   coverage** (PR #310). A `p25` voice grant now decodes
   end-to-end — modulated C4FM IQ → Phase 1 receiver → LDU

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,14 @@ for tagged releases.
   and a talkgroup can opt out of all feeds with `stream: false`
   in its CSV/JSON. Feed counters are exposed at
   `GET /api/v1/broadcast`.
+- **Decoded-message log.** A new optional `MessageLog`
+  (`internal/log`) writes a human-readable, timestamped text log of
+  every trunking event the bus carries — grants, control-channel
+  lock/loss, affiliations, registrations, patches, talker aliases,
+  locations, tone alerts, decode errors — the GopherTrunk analogue
+  of SDRtrunk's per-channel decoded message log. The file rotates to
+  `<path>.1` past a configurable size cap. Enabled via a new
+  `log.message_log` config block.
 - **GPS / location subsystem.** Geographic fixes a subscriber unit
   reports over the air now flow through a new `KindLocation` event
   (`trunking.Location` payload) to a `location_log` SQLite table and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,17 @@ for tagged releases.
   and a talkgroup can opt out of all feeds with `stream: false`
   in its CSV/JSON. Feed counters are exposed at
   `GET /api/v1/broadcast`.
+- **Wideband baseband (IQ) recording and offline replay.** A new
+  `internal/sdr/baseband` package adds two capabilities SDRtrunk
+  has and GopherTrunk lacked. A `RecordingDevice` decorator tees a
+  live tuner's IQ stream to a two-channel 16-bit WAV (in-phase in
+  channel 1, quadrature in channel 2 — the same layout as
+  SDRtrunk's baseband recordings). A `FileDriver` mounts those
+  recordings (and SDRtrunk's) back into the SDR pool as virtual
+  tuners, so a capture can be decoded offline with no radio
+  attached; replay loops on EOF to behave like a continuous
+  source. Both are configured under a new `baseband:` config
+  section (`record:` and `replay:` lists).
 - **P25 Phase 1 voice decoding and broader control-channel
   coverage** (PR #310). A `p25` voice grant now decodes
   end-to-end — modulated C4FM IQ → Phase 1 receiver → LDU

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,16 @@ for tagged releases.
   and a talkgroup can opt out of all feeds with `stream: false`
   in its CSV/JSON. Feed counters are exposed at
   `GET /api/v1/broadcast`.
+- **GPS / location subsystem.** Geographic fixes a subscriber unit
+  reports over the air now flow through a new `KindLocation` event
+  (`trunking.Location` payload) to a `location_log` SQLite table and
+  out via `GET /api/v1/locations` for map display. A new
+  `internal/radio/location` package implements a strict NMEA-0183
+  GGA/RMC parser — the format Tait CCDI and many MOTOTRBO GPS
+  profiles transport verbatim — with checksum verification. The
+  per-protocol binary GPS PDU extractors (P25 Motorola Unit GPS,
+  L3Harris Talker GPS, DMR LRRP) and the web map page build on this
+  backbone; their bit-exact wiring is pending capture validation.
 - **DMR vendor-trunking recognition (FID-aware CSBK dispatch).**
   The Tier III control-channel decoder now dispatches each CSBK on
   its feature-set ID (FID) before opcode, so a Motorola or Hytera

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,18 @@ for tagged releases.
   and a talkgroup can opt out of all feeds with `stream: false`
   in its CSV/JSON. Feed counters are exposed at
   `GET /api/v1/broadcast`.
+- **DMR vendor-trunking recognition (FID-aware CSBK dispatch).**
+  The Tier III control-channel decoder now dispatches each CSBK on
+  its feature-set ID (FID) before opcode, so a Motorola or Hytera
+  vendor CSBK is no longer misdecoded against the standard ETSI
+  opcode table — previously a vendor CSBK whose 6-bit opcode
+  collided with `0x30` would emit a bogus voice grant. Motorola
+  Capacity Plus / Capacity Max voice grants (FID 0x10), which carry
+  the ETSI-shaped 8-octet payload, now decode to real grants, and
+  the Capacity Plus rest channel is tracked from its system-info
+  CSBK. Connect Plus and Hytera XPT CSBKs are recognised and routed
+  to a vendor handler; bit-exact decoding of those proprietary
+  payloads is pending on-air capture validation.
 - **Wideband baseband (IQ) recording and offline replay.** A new
   `internal/sdr/baseband` package adds two capabilities SDRtrunk
   has and GopherTrunk lacked. A `RecordingDevice` decorator tees a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ for tagged releases.
   and a talkgroup can opt out of all feeds with `stream: false`
   in its CSV/JSON. Feed counters are exposed at
   `GET /api/v1/broadcast`.
+- **Per-talkgroup recording assignment.** A talkgroup can now be
+  flagged `record: false` (CSV column, JSON field, or
+  `PATCH /api/v1/talkgroups/{id}`) to follow and play its calls live
+  while writing no WAV/raw files for it — the recording analogue of
+  the `stream` opt-out. Both `stream` and `record` are now surfaced
+  in the talkgroup API DTO and accepted by the PATCH endpoint.
 - **Decoded-message log.** A new optional `MessageLog`
   (`internal/log`) writes a human-readable, timestamped text log of
   every trunking event the bus carries — grants, control-channel

--- a/cmd/gophertrunk/broadcast.go
+++ b/cmd/gophertrunk/broadcast.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"log/slog"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/broadcast"
+	"github.com/MattCheramie/GopherTrunk/internal/config"
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+)
+
+// buildBroadcastManager constructs the outbound call-streaming Manager
+// from config. It returns (nil, nil) when no feed is enabled, so the
+// daemon simply skips the subsystem. sampleRate is the recorder PCM
+// rate, used to synthesise inter-call silence for live Icecast feeds.
+func buildBroadcastManager(cfg config.BroadcastConfig, sampleRate int, bus *events.Bus, log *slog.Logger) (*broadcast.Manager, error) {
+	var backends []broadcast.Backend
+
+	for _, f := range cfg.Broadcastify {
+		if !f.Enabled {
+			continue
+		}
+		b, err := broadcast.NewBroadcastify(broadcast.BroadcastifyConfig{
+			Name:     f.Name,
+			APIKey:   f.APIKey,
+			SystemID: f.SystemID,
+			Systems:  f.Systems,
+		}, nil)
+		if err != nil {
+			return nil, err
+		}
+		backends = append(backends, b)
+	}
+	for _, f := range cfg.RdioScanner {
+		if !f.Enabled {
+			continue
+		}
+		b, err := broadcast.NewRdioScanner(broadcast.RdioScannerConfig{
+			Name:     f.Name,
+			URL:      f.URL,
+			APIKey:   f.APIKey,
+			SystemID: f.SystemID,
+			Systems:  f.Systems,
+		}, nil)
+		if err != nil {
+			return nil, err
+		}
+		backends = append(backends, b)
+	}
+	for _, f := range cfg.OpenMHz {
+		if !f.Enabled {
+			continue
+		}
+		b, err := broadcast.NewOpenMHz(broadcast.OpenMHzConfig{
+			Name:      f.Name,
+			APIKey:    f.APIKey,
+			ShortName: f.ShortName,
+			Systems:   f.Systems,
+		}, nil)
+		if err != nil {
+			return nil, err
+		}
+		backends = append(backends, b)
+	}
+	for _, f := range cfg.Icecast {
+		if !f.Enabled {
+			continue
+		}
+		b, err := broadcast.NewIcecast(broadcast.IcecastConfig{
+			Name:       f.Name,
+			Host:       f.Host,
+			Port:       f.Port,
+			Mount:      f.Mount,
+			Username:   f.Username,
+			Password:   f.Password,
+			StreamName: f.StreamName,
+			SampleRate: sampleRate,
+			Systems:    f.Systems,
+		}, log)
+		if err != nil {
+			return nil, err
+		}
+		backends = append(backends, b)
+	}
+
+	if len(backends) == 0 {
+		return nil, nil
+	}
+	return broadcast.NewManager(broadcast.Options{
+		Bus:         bus,
+		Log:         log,
+		Backends:    backends,
+		MinDuration: time.Duration(cfg.MinDurationMs) * time.Millisecond,
+		Workers:     cfg.Workers,
+	})
+}

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -80,28 +80,29 @@ type Daemon struct {
 	log     *slog.Logger
 	writer  *config.Writer // optional; nil when daemon ran without -config
 
-	bus        *events.Bus
-	pool       *sdr.Pool
-	talkgroups *trunking.TalkgroupDB
-	systems    []trunking.System
-	engine     *trunking.Engine
-	voicePool  *trunking.VoicePool
-	recorder   *voice.Recorder
-	broadcast  *broadcast.Manager
-	composer   *composer.Composer
-	player     *player.Player
-	toneout    *toneout.Detector
-	audioPub   *api.AudioPublisher
-	db         *storage.DB
-	callLog    *storage.CallLog
-	retention  *storage.Retention
-	ccCache    *trunking.Cache
-	cchuntSup  *cchunt.Supervisor
-	ccDecoder  *ccdecoder.Decoder
-	convScan   *conventional.Scanner
-	metrics    *metrics.Metrics
-	httpAPI    *api.Server
-	grpcAPI    *api.GRPCServer
+	bus         *events.Bus
+	pool        *sdr.Pool
+	talkgroups  *trunking.TalkgroupDB
+	systems     []trunking.System
+	engine      *trunking.Engine
+	voicePool   *trunking.VoicePool
+	recorder    *voice.Recorder
+	broadcast   *broadcast.Manager
+	composer    *composer.Composer
+	player      *player.Player
+	toneout     *toneout.Detector
+	audioPub    *api.AudioPublisher
+	db          *storage.DB
+	callLog     *storage.CallLog
+	locationLog *storage.LocationLog
+	retention   *storage.Retention
+	ccCache     *trunking.Cache
+	cchuntSup   *cchunt.Supervisor
+	ccDecoder   *ccdecoder.Decoder
+	convScan    *conventional.Scanner
+	metrics     *metrics.Metrics
+	httpAPI     *api.Server
+	grpcAPI     *api.GRPCServer
 
 	// startupWarnings collects non-fatal observations from
 	// NewDaemon / preflight (missing talkgroup CSV, SDR enumeration
@@ -631,6 +632,13 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 		}
 		d.callLog = cl
 
+		ll, err := storage.NewLocationLog(db, d.bus, log)
+		if err != nil {
+			db.Close()
+			return nil, fmt.Errorf("daemon: location log: %w", err)
+		}
+		d.locationLog = ll
+
 		if cfg.Retention.CallLogDays > 0 || cfg.Retention.FilesDays > 0 {
 			interval, err := retentionInterval(cfg.Retention.Interval)
 			if err != nil {
@@ -682,6 +690,9 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 		}
 		if d.db != nil {
 			opts.History = api.HistoryFromStorage(d.db)
+		}
+		if d.locationLog != nil {
+			opts.Locations = api.LocationsFromStorage(d.locationLog)
 		}
 		if d.metrics != nil {
 			opts.MetricsHandler = d.metrics.Handler()
@@ -789,6 +800,11 @@ func (d *Daemon) Run(ctx context.Context) error {
 	if d.callLog != nil {
 		d.spawn(runCtx, "calllog", false, func(ctx context.Context) error {
 			return d.callLog.Run(ctx)
+		})
+	}
+	if d.locationLog != nil {
+		d.spawn(runCtx, "locationlog", false, func(ctx context.Context) error {
+			return d.locationLog.Run(ctx)
 		})
 	}
 	if d.retention != nil {
@@ -931,6 +947,9 @@ func (d *Daemon) Close() {
 		}
 		if d.callLog != nil {
 			_ = d.callLog.Close()
+		}
+		if d.locationLog != nil {
+			_ = d.locationLog.Close()
 		}
 		if d.metrics != nil {
 			_ = d.metrics.Close()

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/MattCheramie/GopherTrunk/internal/api"
+	"github.com/MattCheramie/GopherTrunk/internal/broadcast"
 	"github.com/MattCheramie/GopherTrunk/internal/config"
 	"github.com/MattCheramie/GopherTrunk/internal/events"
 	"github.com/MattCheramie/GopherTrunk/internal/metrics"
@@ -85,6 +86,7 @@ type Daemon struct {
 	engine     *trunking.Engine
 	voicePool  *trunking.VoicePool
 	recorder   *voice.Recorder
+	broadcast  *broadcast.Manager
 	composer   *composer.Composer
 	player     *player.Player
 	toneout    *toneout.Detector
@@ -338,6 +340,24 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 			return nil, fmt.Errorf("daemon: recorder: %w", err)
 		}
 		d.recorder = rec
+	}
+
+	// Outbound call-streaming manager — optional. Subscribes to the
+	// bus at construction so calls completed before Run starts are
+	// not lost. Built only when at least one feed is enabled.
+	{
+		bcastRate := int(cfg.Recordings.SampleRate)
+		if bcastRate == 0 {
+			bcastRate = 8000
+		}
+		mgr, err := buildBroadcastManager(cfg.Broadcast, bcastRate, d.bus, log)
+		if err != nil {
+			return nil, fmt.Errorf("daemon: broadcast: %w", err)
+		}
+		if mgr != nil {
+			d.broadcast = mgr
+			log.Info("outbound call streaming enabled", "backends", mgr.Backends())
+		}
 	}
 
 	// Tone-out detector — optional. Built before the composer so it can
@@ -661,6 +681,9 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 		if d.player != nil || d.recorder != nil {
 			opts.Audio = audioCockpit{player: d.player, recorder: d.recorder}
 		}
+		if d.broadcast != nil {
+			opts.Broadcast = broadcastStatus{d.broadcast}
+		}
 		cfgCopy := cfg
 		opts.Runtime = &runtimeSnapshot{
 			cfg:     &cfgCopy,
@@ -753,6 +776,11 @@ func (d *Daemon) Run(ctx context.Context) error {
 	if d.recorder != nil {
 		d.spawn(runCtx, "recorder", false, func(ctx context.Context) error {
 			return d.recorder.Run(ctx)
+		})
+	}
+	if d.broadcast != nil {
+		d.spawn(runCtx, "broadcast", false, func(ctx context.Context) error {
+			return d.broadcast.Run(ctx)
 		})
 	}
 	if d.composer != nil {
@@ -871,6 +899,9 @@ func (d *Daemon) Close() {
 		}
 		if d.player != nil {
 			_ = d.player.Close()
+		}
+		if d.broadcast != nil {
+			_ = d.broadcast.Close()
 		}
 		if d.recorder != nil {
 			_ = d.recorder.Close()
@@ -1052,6 +1083,13 @@ type playerSink struct{ p *player.Player }
 func (s playerSink) WritePCM(serial string, samples []int16) error {
 	return s.p.WritePCM(serial, samples)
 }
+
+// broadcastStatus adapts the broadcast.Manager into the
+// api.BroadcastStatusProvider interface, keeping the api package free
+// of a compile-time dependency on internal/broadcast.
+type broadcastStatus struct{ mgr *broadcast.Manager }
+
+func (b broadcastStatus) BroadcastStats() any { return b.mgr.Stats() }
 
 // convFanoutRecorder lets the conventional scanner drive both the
 // WAV recorder and the live player. The conventional.Recorder

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -14,6 +14,7 @@ import (
 	"github.com/MattCheramie/GopherTrunk/internal/broadcast"
 	"github.com/MattCheramie/GopherTrunk/internal/config"
 	"github.com/MattCheramie/GopherTrunk/internal/events"
+	gtlog "github.com/MattCheramie/GopherTrunk/internal/log"
 	"github.com/MattCheramie/GopherTrunk/internal/metrics"
 	"github.com/MattCheramie/GopherTrunk/internal/scanner/ccdecoder"
 	"github.com/MattCheramie/GopherTrunk/internal/scanner/cchunt"
@@ -95,6 +96,7 @@ type Daemon struct {
 	db          *storage.DB
 	callLog     *storage.CallLog
 	locationLog *storage.LocationLog
+	messageLog  *gtlog.MessageLog
 	retention   *storage.Retention
 	ccCache     *trunking.Cache
 	cchuntSup   *cchunt.Supervisor
@@ -382,6 +384,20 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 			d.broadcast = mgr
 			log.Info("outbound call streaming enabled", "backends", mgr.Backends())
 		}
+	}
+
+	// Decoded-message log — optional. Subscribes to the bus and writes
+	// a human-readable text log of every trunking event.
+	if cfg.Log.MessageLog.Enabled && cfg.Log.MessageLog.Path != "" {
+		ml, err := gtlog.NewMessageLog(gtlog.MessageLogOptions{
+			Bus:       d.bus,
+			Path:      cfg.Log.MessageLog.Path,
+			MaxSizeMB: cfg.Log.MessageLog.MaxSizeMB,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("daemon: message log: %w", err)
+		}
+		d.messageLog = ml
 	}
 
 	// Tone-out detector — optional. Built before the composer so it can
@@ -807,6 +823,11 @@ func (d *Daemon) Run(ctx context.Context) error {
 			return d.locationLog.Run(ctx)
 		})
 	}
+	if d.messageLog != nil {
+		d.spawn(runCtx, "messagelog", false, func(ctx context.Context) error {
+			return d.messageLog.Run(ctx)
+		})
+	}
 	if d.retention != nil {
 		d.spawn(runCtx, "retention", false, func(ctx context.Context) error {
 			return d.retention.Run(ctx)
@@ -950,6 +971,9 @@ func (d *Daemon) Close() {
 		}
 		if d.locationLog != nil {
 			_ = d.locationLog.Close()
+		}
+		if d.messageLog != nil {
+			_ = d.messageLog.Close()
 		}
 		if d.metrics != nil {
 			_ = d.metrics.Close()

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -19,6 +19,7 @@ import (
 	"github.com/MattCheramie/GopherTrunk/internal/scanner/cchunt"
 	"github.com/MattCheramie/GopherTrunk/internal/scanner/conventional"
 	"github.com/MattCheramie/GopherTrunk/internal/sdr"
+	"github.com/MattCheramie/GopherTrunk/internal/sdr/baseband"
 	"github.com/MattCheramie/GopherTrunk/internal/storage"
 	"github.com/MattCheramie/GopherTrunk/internal/trunking"
 	"github.com/MattCheramie/GopherTrunk/internal/voice"
@@ -258,8 +259,10 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 	}
 
 	// SDR pool — best-effort. Components that need a Voice device
-	// fall through gracefully when the pool is empty.
-	if len(cfg.SDR.Devices) > 0 {
+	// fall through gracefully when the pool is empty. The pool is
+	// also constructed when only baseband replay recordings are
+	// configured, so an offline capture can be decoded with no radio.
+	if len(cfg.SDR.Devices) > 0 || len(cfg.Baseband.Replay) > 0 {
 		d.pool = sdr.NewPool(log)
 		d.pool.SetBus(d.bus)
 		var hints []sdr.Hint
@@ -281,12 +284,32 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 			}
 			hints = append(hints, h)
 		}
+		// Mount baseband replay recordings as virtual tuners. The
+		// FileDriver registers globally; the pool's Open then
+		// enumerates it alongside any real drivers.
+		if len(cfg.Baseband.Replay) > 0 {
+			specs := make([]baseband.ReplaySpec, 0, len(cfg.Baseband.Replay))
+			for _, r := range cfg.Baseband.Replay {
+				loop := true
+				if r.Loop != nil {
+					loop = *r.Loop
+				}
+				specs = append(specs, baseband.ReplaySpec{Path: r.File, Serial: r.Serial, Loop: loop})
+				if r.Serial != "" {
+					hints = append(hints, sdr.Hint{Serial: r.Serial, Role: sdr.ParseRole(r.Role)})
+				}
+			}
+			sdr.Register(baseband.NewFileDriver(specs))
+			log.Info("baseband replay mounted", "recordings", len(specs))
+		}
 		if err := d.pool.Open(cfg.SDR.SampleRate, hints); err != nil {
 			log.Warn("daemon: SDR pool open failed", "err", err)
 			d.addWarning(fmt.Sprintf(
 				"SDR pool failed to open (%v) — no radios will demodulate; check device permissions / cabling / kernel modules",
 				err))
 			d.pool = nil
+		} else {
+			d.wrapBasebandRecorders(cfg, log)
 		}
 	} else if len(cfg.Trunking.Systems) > 0 {
 		// Trunked systems configured but no SDR devices listed —
@@ -1090,6 +1113,34 @@ func (s playerSink) WritePCM(serial string, samples []int16) error {
 type broadcastStatus struct{ mgr *broadcast.Manager }
 
 func (b broadcastStatus) BroadcastStats() any { return b.mgr.Stats() }
+
+// wrapBasebandRecorders replaces the Device of every pool entry whose
+// serial appears in baseband.record with a RecordingDevice, teeing its
+// live IQ to a WAV recording. Runs once at construction, before any
+// streaming starts, so mutating the entry's Device pointer is safe.
+func (d *Daemon) wrapBasebandRecorders(cfg config.Config, log *slog.Logger) {
+	if len(cfg.Baseband.Record) == 0 || d.pool == nil {
+		return
+	}
+	dirBySerial := make(map[string]string, len(cfg.Baseband.Record))
+	for _, r := range cfg.Baseband.Record {
+		dirBySerial[r.Serial] = r.Dir
+	}
+	rate := cfg.SDR.SampleRate
+	if rate == 0 {
+		rate = sdr.DefaultSampleRateHz
+	}
+	for _, e := range d.pool.Entries() {
+		dir, ok := dirBySerial[e.Info.Serial]
+		if !ok {
+			continue
+		}
+		rec := baseband.NewRecordingDevice(e.Device, dir, log)
+		_ = rec.SetSampleRate(rate)
+		e.Device = rec
+		log.Info("baseband recording enabled", "serial", e.Info.Serial, "dir", dir)
+	}
+}
 
 // convFanoutRecorder lets the conventional scanner drive both the
 // WAV recorder and the live player. The conventional.Recorder

--- a/cmd/gophertrunk/integration_test.go
+++ b/cmd/gophertrunk/integration_test.go
@@ -105,7 +105,7 @@ func TestDaemonEndToEnd(t *testing.T) {
 			GroupID: 1234, SourceID: 56789,
 			FrequencyHz: 851_000_000,
 		},
-		Talkgroup:    &trunking.TalkGroup{ID: 1234, AlphaTag: "FIRE-DISP"},
+		Talkgroup:    &trunking.TalkGroup{ID: 1234, AlphaTag: "FIRE-DISP", Record: true},
 		DeviceSerial: "VOICE-1",
 		StartedAt:    startedAt,
 	}

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -362,3 +362,48 @@ tone_out:
     #     - frequency_hz: 1465.3
     #       min_duration: "2.5s"
     #       max_duration: "5s"
+
+# Outbound call streaming. Completed calls are encoded to MP3 and
+# uploaded to call aggregators, or pushed to a live Icecast/ShoutCast
+# mountpoint. Empty == disabled. Each backend takes a list of feeds;
+# a feed with `enabled: false` is parsed but skipped. The optional
+# per-feed `systems:` list restricts a feed to those trunking-system
+# names (omit to stream every system). A talkgroup with `stream: false`
+# in its CSV/JSON is excluded from all feeds.
+broadcast:
+  # Drop calls shorter than this from every feed (squelch crackle,
+  # failed decodes). 0 streams calls of any length.
+  min_duration_ms: 0
+  # Concurrent upload workers. 0 uses the built-in default.
+  workers: 0
+
+  # broadcastify:
+  #   - enabled: true
+  #     name: "metro-p25"
+  #     api_key: "YOUR_BROADCASTIFY_CALLS_API_KEY"
+  #     system_id: 12345
+  #     systems: ["Metro P25"]
+
+  # rdioscanner:
+  #   - enabled: true
+  #     name: "local-rdio"
+  #     url: "https://scanner.example.org"
+  #     api_key: "YOUR_RDIOSCANNER_API_KEY"
+  #     system_id: 1
+
+  # openmhz:
+  #   - enabled: true
+  #     name: "openmhz-metro"
+  #     api_key: "YOUR_OPENMHZ_API_KEY"
+  #     short_name: "metro911"
+
+  # icecast:
+  #   - enabled: true
+  #     name: "live-feed"
+  #     host: "stream.example.org"
+  #     port: 8000
+  #     mount: "/gophertrunk"
+  #     username: "source"
+  #     password: "YOUR_ICECAST_SOURCE_PASSWORD"
+  #     stream_name: "GopherTrunk Live"
+

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -5,6 +5,12 @@
 log:
   level: info       # debug | info | warn | error
   format: text      # text | json
+  # Decoded-message log: a human-readable text log of every trunking
+  # event (grants, CC lock/loss, affiliations, patches, locations).
+  # message_log:
+  #   enabled: true
+  #   path: "logs/messages.log"
+  #   max_size_mb: 16          # rotates to messages.log.1 past this
 
 api:
   http_addr: "127.0.0.1:8080"   # HTTP REST + SSE + WebSocket

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -407,3 +407,18 @@ broadcast:
   #     password: "YOUR_ICECAST_SOURCE_PASSWORD"
   #     stream_name: "GopherTrunk Live"
 
+# Wideband baseband (IQ) recording and offline replay. `record` taps a
+# live tuner and writes its raw IQ to a two-channel 16-bit WAV (the
+# same layout SDRtrunk uses). `replay` mounts recorded WAVs as virtual
+# tuners so a capture can be decoded with no radio attached — record at
+# the same rate as sdr.sample_rate for real-time-correct playback.
+# baseband:
+#   record:
+#     - serial: "00000001"
+#       dir: "baseband/"
+#   replay:
+#     - file: "baseband/00000001_20260521T120000Z.wav"
+#       serial: "replay-01"
+#       role: "control"
+#       loop: true
+

--- a/go.mod
+++ b/go.mod
@@ -14,9 +14,11 @@ toolchain go1.25.10
 require gopkg.in/yaml.v3 v3.0.1
 
 require (
+	github.com/braheezy/shine-mp3 v0.1.0
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/charmbracelet/x/exp/teatest v0.0.0-20260511125431-fe5d686e0c99
 	github.com/ebitengine/oto/v3 v3.3.3
 	github.com/ebitengine/purego v0.10.0
 	github.com/gorilla/websocket v1.5.3
@@ -39,7 +41,6 @@ require (
 	github.com/charmbracelet/x/ansi v0.11.6 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.15 // indirect
 	github.com/charmbracelet/x/exp/golden v0.0.0-20241011142426-46044092ad91 // indirect
-	github.com/charmbracelet/x/exp/teatest v0.0.0-20260511125431-fe5d686e0c99 // indirect
 	github.com/charmbracelet/x/term v0.2.2 // indirect
 	github.com/clipperhouse/displaywidth v0.9.0 // indirect
 	github.com/clipperhouse/stringish v0.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/aymanbagabas/go-udiff v0.3.1 h1:LV+qyBQ2pqe0u42ZsUEtPiCaUoqgA9gYRDs3v
 github.com/aymanbagabas/go-udiff v0.3.1/go.mod h1:G0fsKmG+P6ylD0r6N/KgQD/nWzgfnl8ZBcNLgcbrw8E=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/braheezy/shine-mp3 v0.1.0 h1:N2wZhv6ipCFduTSftaPNdDgZ5xFmQAPvB7JcqA4sSi8=
+github.com/braheezy/shine-mp3 v0.1.0/go.mod h1:0H/pmcpFAd+Fnrj6Pc7du7wL36U/HqtfcgPJuCgc1L4=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/charmbracelet/bubbles v1.0.0 h1:12J8/ak/uCZEMQ6KU7pcfwceyjLlWsDLAxB5fXonfvc=

--- a/internal/api/handlers_broadcast.go
+++ b/internal/api/handlers_broadcast.go
@@ -1,0 +1,18 @@
+package api
+
+import "net/http"
+
+// handleBroadcastStatus returns the outbound call-streaming subsystem's
+// counters. Always 200 — when no broadcast feed is configured the
+// response reports the subsystem as disabled so UIs can render a
+// stable shape.
+func (s *Server) handleBroadcastStatus(w http.ResponseWriter, _ *http.Request) {
+	if s.broadcast == nil {
+		writeJSON(w, http.StatusOK, map[string]any{"enabled": false})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"enabled": true,
+		"stats":   s.broadcast.BroadcastStats(),
+	})
+}

--- a/internal/api/handlers_locations.go
+++ b/internal/api/handlers_locations.go
@@ -1,0 +1,31 @@
+package api
+
+import (
+	"net/http"
+	"strconv"
+)
+
+// handleLocations returns recent geographic fixes for the web map.
+// When the location subsystem is not wired (no storage) an empty list
+// is returned so the UI renders a stable shape.
+func (s *Server) handleLocations(w http.ResponseWriter, r *http.Request) {
+	if s.locations == nil {
+		writeJSON(w, http.StatusOK, map[string]any{"locations": []LocationFix{}})
+		return
+	}
+	limit := 500
+	if v := r.URL.Query().Get("limit"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			limit = n
+		}
+	}
+	fixes, err := s.locations.RecentLocations(limit)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "query locations: "+err.Error())
+		return
+	}
+	if fixes == nil {
+		fixes = []LocationFix{}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"locations": fixes})
+}

--- a/internal/api/handlers_mutations.go
+++ b/internal/api/handlers_mutations.go
@@ -104,6 +104,8 @@ type updateTalkgroupRequest struct {
 	Priority *int  `json:"priority"`
 	Lockout  *bool `json:"lockout"`
 	Scan     *bool `json:"scan"`
+	Stream   *bool `json:"stream"`
+	Record   *bool `json:"record"`
 }
 
 // handleUpdateTalkgroup updates a talkgroup's mutable policy fields
@@ -130,8 +132,9 @@ func (s *Server) handleUpdateTalkgroup(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "invalid json body")
 		return
 	}
-	if req.Priority == nil && req.Lockout == nil && req.Scan == nil {
-		writeError(w, http.StatusBadRequest, "supply priority and/or lockout and/or scan")
+	if req.Priority == nil && req.Lockout == nil && req.Scan == nil &&
+		req.Stream == nil && req.Record == nil {
+		writeError(w, http.StatusBadRequest, "supply priority and/or lockout and/or scan and/or stream and/or record")
 		return
 	}
 	ok := s.talkgroups.UpdateFields(uint32(id), func(tg *trunking.TalkGroup) {
@@ -143,6 +146,12 @@ func (s *Server) handleUpdateTalkgroup(w http.ResponseWriter, r *http.Request) {
 		}
 		if req.Scan != nil {
 			tg.Scan = *req.Scan
+		}
+		if req.Stream != nil {
+			tg.Stream = *req.Stream
+		}
+		if req.Record != nil {
+			tg.Record = *req.Record
 		}
 	})
 	if !ok {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -228,6 +228,7 @@ type Server struct {
 	talkgroups   *trunking.TalkgroupDB
 	systems      []trunking.System
 	history      HistoryQuery
+	locations    LocationQuery
 	metrics      http.Handler
 	log          *slog.Logger
 	version      string
@@ -260,6 +261,25 @@ type Server struct {
 // storage package and lets tests inject fakes.
 type HistoryQuery interface {
 	History(ctx context.Context, f HistoryFilter) ([]CallRow, error)
+}
+
+// LocationFix is one geographic fix returned by GET /api/v1/locations.
+type LocationFix struct {
+	System     string  `json:"system"`
+	Protocol   string  `json:"protocol"`
+	RadioID    uint32  `json:"radio_id"`
+	Talkgroup  uint32  `json:"talkgroup"`
+	Latitude   float64 `json:"latitude"`
+	Longitude  float64 `json:"longitude"`
+	SpeedKnots float64 `json:"speed_knots"`
+	HeadingDeg float64 `json:"heading_deg"`
+	ReportedAt string  `json:"reported_at"` // RFC3339
+}
+
+// LocationQuery is the read side of the GPS/location subsystem,
+// supplying recent fixes for GET /api/v1/locations and the web map.
+type LocationQuery interface {
+	RecentLocations(limit int) ([]LocationFix, error)
 }
 
 // HistoryFilter mirrors storage.HistoryFilter for the api layer's
@@ -305,6 +325,9 @@ type ServerOptions struct {
 	// History is optional. When non-nil the server exposes
 	// GET /api/v1/calls/history.
 	History HistoryQuery
+	// Locations is optional. When non-nil the server exposes
+	// GET /api/v1/locations for the web map.
+	Locations LocationQuery
 	// MetricsHandler is optional. When non-nil it is mounted at
 	// GET /metrics; the daemon passes internal/metrics.Metrics.Handler()
 	// here. Decoupling via http.Handler keeps the api package free of a
@@ -468,6 +491,7 @@ func NewServer(opts ServerOptions) (*Server, error) {
 		talkgroups:     opts.Talkgroups,
 		systems:        append([]trunking.System(nil), opts.Systems...),
 		history:        opts.History,
+		locations:      opts.Locations,
 		metrics:        opts.MetricsHandler,
 		log:            log,
 		version:        opts.Version,
@@ -585,6 +609,7 @@ func (s *Server) routes() *http.ServeMux {
 	mux.HandleFunc("GET /api/v1/talkgroups/{id}", s.handleGetTalkgroup)
 	mux.HandleFunc("GET /api/v1/calls/active", s.handleActiveCalls)
 	mux.HandleFunc("GET /api/v1/calls/history", s.handleCallHistory)
+	mux.HandleFunc("GET /api/v1/locations", s.handleLocations)
 	mux.HandleFunc("GET /api/v1/devices", s.handleListDevices)
 	mux.HandleFunc("GET /api/v1/events", s.handleSSE)
 	mux.HandleFunc("GET /api/v1/events/ws", s.handleWS)

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -89,6 +89,15 @@ type AudioController interface {
 	BackendEnabled() bool
 }
 
+// BroadcastStatusProvider is the read side of the outbound
+// call-streaming subsystem (internal/broadcast). BroadcastStats
+// returns a JSON-serialisable counter snapshot; the daemon adapts
+// broadcast.Manager.Stats() to this interface so the api package
+// keeps no compile-time dependency on internal/broadcast.
+type BroadcastStatusProvider interface {
+	BroadcastStats() any
+}
+
 // ScannerCockpit is the API surface for the police-scanner subsystem:
 // reads the current state (per-system CC hunt, conventional channel
 // list, talkgroup-scan stats) and applies operator mutations from
@@ -209,6 +218,7 @@ type Server struct {
 	devices      DevicesProvider
 	scanner      ScannerCockpit
 	audio        AudioController
+	broadcast    BroadcastStatusProvider
 	runtime      RuntimeProvider
 	configWriter ConfigWriter
 	settings     SettingsApplier
@@ -338,6 +348,10 @@ type ServerOptions struct {
 	// GET + PATCH /api/v1/audio. Optional; when nil, the routes
 	// return 503.
 	Audio AudioController
+	// Broadcast exposes the outbound call-streaming subsystem's
+	// counters for GET /api/v1/broadcast. Optional; when nil, the
+	// route reports the subsystem as disabled.
+	Broadcast BroadcastStatusProvider
 	// Runtime exposes the read-only daemon config snapshot served at
 	// GET /api/v1/runtime. The TUI's tabbed Settings inspector uses
 	// it to surface every config knob. Optional; when nil, the
@@ -444,6 +458,7 @@ func NewServer(opts ServerOptions) (*Server, error) {
 		devices:        opts.Devices,
 		scanner:        opts.Scanner,
 		audio:          opts.Audio,
+		broadcast:      opts.Broadcast,
 		runtime:        opts.Runtime,
 		configWriter:   opts.ConfigWriter,
 		settings:       opts.SettingsApplier,
@@ -589,6 +604,7 @@ func (s *Server) routes() *http.ServeMux {
 
 	// Scanner cockpit — read endpoint is always open; mutations are
 	// gated behind allow_mutations like every other write route.
+	mux.HandleFunc("GET /api/v1/broadcast", s.handleBroadcastStatus)
 	mux.HandleFunc("GET /api/v1/scanner", s.handleScannerStatus)
 	mux.HandleFunc("PATCH /api/v1/scanner", s.gate(s.handleScannerSetMode))
 	mux.HandleFunc("POST /api/v1/scanner/hunt/{system}/hold", s.gate(s.handleHuntHold))

--- a/internal/api/storage_adapter.go
+++ b/internal/api/storage_adapter.go
@@ -2,9 +2,46 @@ package api
 
 import (
 	"context"
+	"time"
 
 	"github.com/MattCheramie/GopherTrunk/internal/storage"
 )
+
+// LocationsFromStorage wraps a *storage.LocationLog as an
+// api.LocationQuery so the daemon can pass it to NewServer without the
+// storage package's row types leaking into the api package.
+func LocationsFromStorage(ll *storage.LocationLog) LocationQuery {
+	if ll == nil {
+		return nil
+	}
+	return &storageLocations{ll: ll}
+}
+
+type storageLocations struct {
+	ll *storage.LocationLog
+}
+
+func (s *storageLocations) RecentLocations(limit int) ([]LocationFix, error) {
+	rows, err := s.ll.Recent(limit)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]LocationFix, len(rows))
+	for i, r := range rows {
+		out[i] = LocationFix{
+			System:     r.System,
+			Protocol:   r.Protocol,
+			RadioID:    r.RadioID,
+			Talkgroup:  r.Talkgroup,
+			Latitude:   r.Latitude,
+			Longitude:  r.Longitude,
+			SpeedKnots: r.SpeedKnots,
+			HeadingDeg: r.HeadingDeg,
+			ReportedAt: r.ReportedAt.UTC().Format(time.RFC3339),
+		}
+	}
+	return out, nil
+}
 
 // HistoryFromStorage wraps a *storage.DB as an api.HistoryQuery so the
 // daemon can pass it to NewServer without the api package's CallRow /

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -89,6 +89,8 @@ type TalkgroupDTO struct {
 	Priority    int    `json:"priority,omitempty"`
 	Lockout     bool   `json:"lockout,omitempty"`
 	Scan        bool   `json:"scan"`
+	Stream      bool   `json:"stream"`
+	Record      bool   `json:"record"`
 }
 
 func talkgroupToDTO(tg *trunking.TalkGroup) *TalkgroupDTO {
@@ -105,6 +107,8 @@ func talkgroupToDTO(tg *trunking.TalkGroup) *TalkgroupDTO {
 		Priority:    tg.Priority,
 		Lockout:     tg.Lockout,
 		Scan:        tg.Scan,
+		Stream:      tg.Stream,
+		Record:      tg.Record,
 	}
 }
 

--- a/internal/broadcast/backends_test.go
+++ b/internal/broadcast/backends_test.go
@@ -1,0 +1,287 @@
+package broadcast
+
+import (
+	"bufio"
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+func testCall(t *testing.T) *Call {
+	t.Helper()
+	now := time.Now()
+	return &Call{
+		System:         "Metro",
+		Protocol:       "p25",
+		Talkgroup:      4321,
+		TalkgroupLabel: "Dispatch",
+		Source:         9001,
+		FrequencyHz:    851_012_500,
+		StartedAt:      now.Add(-3 * time.Second),
+		EndedAt:        now,
+		AudioPath:      writeWAV(t, 0.4),
+		SampleRate:     8000,
+	}
+}
+
+func TestBroadcastifyTwoStepUpload(t *testing.T) {
+	var gotForm, gotAudio bool
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	mux.HandleFunc("/metadata", func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("parse form: %v", err)
+		}
+		if r.PostForm.Get("apiKey") != "KEY" || r.PostForm.Get("systemId") != "77" {
+			t.Errorf("bad metadata form: %v", r.PostForm)
+		}
+		if r.PostForm.Get("tg") != "4321" {
+			t.Errorf("tg = %q, want 4321", r.PostForm.Get("tg"))
+		}
+		gotForm = true
+		io.WriteString(w, "0 "+srv.URL+"/upload")
+	})
+	mux.HandleFunc("/upload", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Errorf("audio upload method = %s, want PUT", r.Method)
+		}
+		body, _ := io.ReadAll(r.Body)
+		if len(body) < 2 || body[0] != 0xFF {
+			t.Errorf("audio body is not MP3 (%d bytes)", len(body))
+		}
+		gotAudio = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	be, err := NewBroadcastify(BroadcastifyConfig{
+		APIKey: "KEY", SystemID: 77, Endpoint: srv.URL + "/metadata",
+	}, srv.Client())
+	if err != nil {
+		t.Fatalf("NewBroadcastify: %v", err)
+	}
+	if err := be.Send(context.Background(), testCall(t)); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if !gotForm || !gotAudio {
+		t.Fatalf("two-step incomplete: form=%v audio=%v", gotForm, gotAudio)
+	}
+}
+
+func TestBroadcastifyRejectsErrorResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		io.WriteString(w, "1 invalid api key")
+	}))
+	defer srv.Close()
+	be, _ := NewBroadcastify(BroadcastifyConfig{
+		APIKey: "BAD", SystemID: 1, Endpoint: srv.URL,
+	}, srv.Client())
+	if err := be.Send(context.Background(), testCall(t)); err == nil {
+		t.Fatal("Send should fail on an error metadata response")
+	}
+}
+
+func TestParseBroadcastifyUploadURL(t *testing.T) {
+	cases := []struct {
+		body, want string
+		wantErr    bool
+	}{
+		{"0 https://up.example/x", "https://up.example/x", false},
+		{"0\nhttps://up.example/y", "https://up.example/y", false},
+		{"https://up.example/z", "https://up.example/z", false},
+		{"1 bad key", "", true},
+		{"", "", true},
+	}
+	for _, c := range cases {
+		got, err := parseBroadcastifyUploadURL(c.body)
+		if c.wantErr {
+			if err == nil {
+				t.Errorf("%q: expected error", c.body)
+			}
+			continue
+		}
+		if err != nil || got != c.want {
+			t.Errorf("%q: got (%q, %v), want %q", c.body, got, err, c.want)
+		}
+	}
+}
+
+func TestRdioScannerUpload(t *testing.T) {
+	var ok bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/call-upload" {
+			t.Errorf("path = %s", r.URL.Path)
+		}
+		if err := r.ParseMultipartForm(8 << 20); err != nil {
+			t.Errorf("parse multipart: %v", err)
+			return
+		}
+		if r.FormValue("key") != "RKEY" || r.FormValue("system") != "12" {
+			t.Errorf("bad fields: key=%q system=%q", r.FormValue("key"), r.FormValue("system"))
+		}
+		if r.FormValue("talkgroup") != "4321" {
+			t.Errorf("talkgroup = %q", r.FormValue("talkgroup"))
+		}
+		f, _, err := r.FormFile("audio")
+		if err != nil {
+			t.Errorf("audio part missing: %v", err)
+			return
+		}
+		defer f.Close()
+		body, _ := io.ReadAll(f)
+		if len(body) < 2 || body[0] != 0xFF {
+			t.Errorf("audio part is not MP3")
+		}
+		ok = true
+		io.WriteString(w, "Call imported successfully.")
+	}))
+	defer srv.Close()
+
+	be, err := NewRdioScanner(RdioScannerConfig{
+		URL: srv.URL, APIKey: "RKEY", SystemID: 12,
+	}, srv.Client())
+	if err != nil {
+		t.Fatalf("NewRdioScanner: %v", err)
+	}
+	if err := be.Send(context.Background(), testCall(t)); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if !ok {
+		t.Fatal("server did not receive a well-formed upload")
+	}
+}
+
+func TestRdioScannerReportsHTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "bad key", http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+	be, _ := NewRdioScanner(RdioScannerConfig{URL: srv.URL, APIKey: "X", SystemID: 1}, srv.Client())
+	if err := be.Send(context.Background(), testCall(t)); err == nil {
+		t.Fatal("Send should fail on HTTP 401")
+	}
+}
+
+func TestOpenMHzUpload(t *testing.T) {
+	var ok bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/metro911/upload" {
+			t.Errorf("path = %s, want /metro911/upload", r.URL.Path)
+		}
+		if err := r.ParseMultipartForm(8 << 20); err != nil {
+			t.Errorf("parse multipart: %v", err)
+			return
+		}
+		if r.FormValue("api_key") != "OKEY" {
+			t.Errorf("api_key = %q", r.FormValue("api_key"))
+		}
+		if r.FormValue("talkgroup_num") != "4321" {
+			t.Errorf("talkgroup_num = %q", r.FormValue("talkgroup_num"))
+		}
+		if _, _, err := r.FormFile("call"); err != nil {
+			t.Errorf("call part missing: %v", err)
+		}
+		ok = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	be, err := NewOpenMHz(OpenMHzConfig{
+		APIKey: "OKEY", ShortName: "metro911", Endpoint: srv.URL,
+	}, srv.Client())
+	if err != nil {
+		t.Fatalf("NewOpenMHz: %v", err)
+	}
+	if err := be.Send(context.Background(), testCall(t)); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if !ok {
+		t.Fatal("server did not receive a well-formed upload")
+	}
+}
+
+func TestBackendConstructorsValidate(t *testing.T) {
+	if _, err := NewBroadcastify(BroadcastifyConfig{SystemID: 1}, nil); err == nil {
+		t.Error("Broadcastify without api_key should error")
+	}
+	if _, err := NewRdioScanner(RdioScannerConfig{APIKey: "x", SystemID: 1}, nil); err == nil {
+		t.Error("RdioScanner without url should error")
+	}
+	if _, err := NewOpenMHz(OpenMHzConfig{APIKey: "x"}, nil); err == nil {
+		t.Error("OpenMHz without short_name should error")
+	}
+	if _, err := NewIcecast(IcecastConfig{Host: "h", Port: 8000}, nil); err == nil {
+		t.Error("Icecast without password should error")
+	}
+}
+
+func TestIcecastSourceHandshakeAndStream(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+	host, port, _ := net.SplitHostPort(ln.Addr().String())
+
+	handshake := make(chan string, 1)
+	streamed := make(chan int, 1)
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		br := bufio.NewReader(conn)
+		reqLine, _ := br.ReadString('\n')
+		// Drain the remaining request headers up to the blank line.
+		for {
+			line, err := br.ReadString('\n')
+			if err != nil || strings.TrimSpace(line) == "" {
+				break
+			}
+		}
+		handshake <- strings.TrimSpace(reqLine)
+		io.WriteString(conn, "HTTP/1.0 200 OK\r\n\r\n")
+		conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+		buf := make([]byte, 64*1024)
+		n, _ := br.Read(buf)
+		streamed <- n
+	}()
+
+	portNum, _ := strconv.Atoi(port)
+	be, err := NewIcecast(IcecastConfig{
+		Host: host, Port: portNum, Mount: "/gt", Password: "hackme",
+	}, nil)
+	if err != nil {
+		t.Fatalf("NewIcecast: %v", err)
+	}
+	defer be.(interface{ Close() error }).Close()
+
+	select {
+	case req := <-handshake:
+		if !strings.HasPrefix(req, "SOURCE /gt") {
+			t.Fatalf("handshake request = %q, want SOURCE /gt ...", req)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("no source handshake received")
+	}
+
+	if err := be.Send(context.Background(), testCall(t)); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	select {
+	case n := <-streamed:
+		if n == 0 {
+			t.Fatal("no bytes streamed to the mountpoint")
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("no audio streamed")
+	}
+}

--- a/internal/broadcast/broadcast.go
+++ b/internal/broadcast/broadcast.go
@@ -1,0 +1,125 @@
+// Package broadcast streams completed trunked-radio calls to external
+// call aggregators — Broadcastify Calls, RdioScanner, OpenMHz — and to
+// live Icecast/ShoutCast audio servers.
+//
+// The Manager subscribes to events.KindCallComplete (published by the
+// recorder once a call's WAV is flushed to disk), resolves which
+// backends want the call, encodes the audio to MP3 once, and dispatches
+// it to each backend with bounded exponential-backoff retry. A call is
+// skipped entirely when its talkgroup is flagged Stream=false or when
+// it is shorter than the configured minimum duration.
+package broadcast
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+	"github.com/MattCheramie/GopherTrunk/internal/voice/mp3"
+)
+
+// Call is a completed call queued for outbound streaming. It carries
+// the call metadata plus a lazy MP3 accessor — the WAV on AudioPath is
+// encoded to MP3 at most once regardless of how many backends consume
+// it.
+type Call struct {
+	System         string
+	Protocol       string
+	Talkgroup      uint32
+	TalkgroupLabel string
+	Source         uint32
+	FrequencyHz    uint32
+	Encrypted      bool
+	Emergency      bool
+	PatchedGroups  []uint32
+	StartedAt      time.Time
+	EndedAt        time.Time
+	AudioPath      string // .wav on disk written by the recorder
+	SampleRate     int
+
+	mu      sync.Mutex
+	mp3Data []byte
+	mp3Err  error
+	mp3Done bool
+}
+
+// Duration reports how long the call ran.
+func (c *Call) Duration() time.Duration { return c.EndedAt.Sub(c.StartedAt) }
+
+// MP3 returns the call audio encoded as an MP3 byte stream. The encode
+// runs once on first use; later calls return the cached result (or the
+// cached error). Safe for concurrent use across backend workers.
+func (c *Call) MP3() ([]byte, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.mp3Done {
+		return c.mp3Data, c.mp3Err
+	}
+	c.mp3Done = true
+	c.mp3Data, _, c.mp3Err = mp3.EncodeWAVFile(c.AudioPath)
+	return c.mp3Data, c.mp3Err
+}
+
+// callFromEvent builds a *Call from a recorder CallComplete payload.
+func callFromEvent(cc trunking.CallComplete) *Call {
+	c := &Call{
+		System:        cc.Grant.System,
+		Protocol:      cc.Grant.Protocol,
+		Talkgroup:     cc.Grant.GroupID,
+		Source:        cc.Grant.SourceID,
+		FrequencyHz:   cc.Grant.FrequencyHz,
+		Encrypted:     cc.Grant.Encrypted,
+		Emergency:     cc.Grant.Emergency,
+		PatchedGroups: cc.Grant.PatchedGroups,
+		StartedAt:     cc.StartedAt,
+		EndedAt:       cc.EndedAt,
+		AudioPath:     cc.AudioPath,
+		SampleRate:    int(cc.SampleRate),
+	}
+	if cc.Talkgroup != nil {
+		c.TalkgroupLabel = cc.Talkgroup.AlphaTag
+	}
+	return c
+}
+
+// Backend is one outbound streaming destination. Implementations must
+// be safe for concurrent Send calls — the Manager runs several upload
+// workers. Send should treat a retry as a fresh attempt; the Manager
+// handles backoff between attempts.
+type Backend interface {
+	// Name is a short stable identifier used in logs and stats.
+	Name() string
+	// Accepts reports whether this backend wants calls from the named
+	// trunking system. An unfiltered backend accepts every system.
+	Accepts(systemName string) bool
+	// Send delivers the call. A non-nil error triggers a retry.
+	Send(ctx context.Context, c *Call) error
+}
+
+// systemFilter restricts a backend to a set of trunking-system names.
+// A zero filter (constructed from an empty list) matches every system.
+type systemFilter struct {
+	systems map[string]bool
+}
+
+func newSystemFilter(names []string) systemFilter {
+	if len(names) == 0 {
+		return systemFilter{}
+	}
+	m := make(map[string]bool, len(names))
+	for _, n := range names {
+		if n != "" {
+			m[n] = true
+		}
+	}
+	return systemFilter{systems: m}
+}
+
+// Accepts reports whether systemName passes the filter.
+func (f systemFilter) Accepts(systemName string) bool {
+	if f.systems == nil {
+		return true
+	}
+	return f.systems[systemName]
+}

--- a/internal/broadcast/broadcast_test.go
+++ b/internal/broadcast/broadcast_test.go
@@ -1,0 +1,129 @@
+package broadcast
+
+import (
+	"encoding/binary"
+	"math"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// writeWAV emits a 16-bit PCM mono WAV of seconds of 440 Hz tone at
+// 8 kHz and returns its path. Used as a Call.AudioPath fixture.
+func writeWAV(t *testing.T, seconds float64) string {
+	t.Helper()
+	const rate = 8000
+	n := int(float64(rate) * seconds)
+	samples := make([]int16, n)
+	for i := range samples {
+		samples[i] = int16(8000 * math.Sin(2*math.Pi*440*float64(i)/float64(rate)))
+	}
+	path := filepath.Join(t.TempDir(), "call.wav")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	dataLen := uint32(n * 2)
+	hdr := make([]byte, 44)
+	copy(hdr[0:4], "RIFF")
+	binary.LittleEndian.PutUint32(hdr[4:8], 36+dataLen)
+	copy(hdr[8:12], "WAVE")
+	copy(hdr[12:16], "fmt ")
+	binary.LittleEndian.PutUint32(hdr[16:20], 16)
+	binary.LittleEndian.PutUint16(hdr[20:22], 1)
+	binary.LittleEndian.PutUint16(hdr[22:24], 1)
+	binary.LittleEndian.PutUint32(hdr[24:28], rate)
+	binary.LittleEndian.PutUint32(hdr[28:32], rate*2)
+	binary.LittleEndian.PutUint16(hdr[32:34], 2)
+	binary.LittleEndian.PutUint16(hdr[34:36], 16)
+	copy(hdr[36:40], "data")
+	binary.LittleEndian.PutUint32(hdr[40:44], dataLen)
+	if _, err := f.Write(hdr); err != nil {
+		t.Fatal(err)
+	}
+	buf := make([]byte, dataLen)
+	for i, s := range samples {
+		binary.LittleEndian.PutUint16(buf[2*i:], uint16(s))
+	}
+	if _, err := f.Write(buf); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestCallMP3CachesEncode(t *testing.T) {
+	c := &Call{AudioPath: writeWAV(t, 0.5), SampleRate: 8000}
+	first, err := c.MP3()
+	if err != nil {
+		t.Fatalf("first MP3: %v", err)
+	}
+	if len(first) == 0 {
+		t.Fatal("first MP3 empty")
+	}
+	second, err := c.MP3()
+	if err != nil {
+		t.Fatalf("second MP3: %v", err)
+	}
+	// The cache returns the same backing array, not a re-encode.
+	if &first[0] != &second[0] {
+		t.Fatal("MP3() re-encoded instead of caching")
+	}
+}
+
+func TestCallMP3ReportsEncodeError(t *testing.T) {
+	c := &Call{AudioPath: "/nonexistent/call.wav"}
+	if _, err := c.MP3(); err == nil {
+		t.Fatal("MP3() on a missing file should error")
+	}
+}
+
+func TestSystemFilter(t *testing.T) {
+	open := newSystemFilter(nil)
+	if !open.Accepts("anything") {
+		t.Fatal("empty filter must accept every system")
+	}
+	scoped := newSystemFilter([]string{"Alpha", "Bravo"})
+	if !scoped.Accepts("Alpha") {
+		t.Fatal("scoped filter must accept a listed system")
+	}
+	if scoped.Accepts("Charlie") {
+		t.Fatal("scoped filter must reject an unlisted system")
+	}
+}
+
+func TestCallFromEvent(t *testing.T) {
+	start := time.Now().Add(-3 * time.Second)
+	end := time.Now()
+	cc := trunking.CallComplete{
+		Grant: trunking.Grant{
+			System:      "Metro",
+			Protocol:    "p25",
+			GroupID:     1234,
+			SourceID:    5678,
+			FrequencyHz: 851_012_500,
+			Emergency:   true,
+		},
+		Talkgroup:  &trunking.TalkGroup{ID: 1234, AlphaTag: "Dispatch"},
+		StartedAt:  start,
+		EndedAt:    end,
+		AudioPath:  "/tmp/call.wav",
+		SampleRate: 8000,
+	}
+	c := callFromEvent(cc)
+	if c.System != "Metro" || c.Talkgroup != 1234 || c.Source != 5678 {
+		t.Fatalf("metadata not copied: %+v", c)
+	}
+	if c.TalkgroupLabel != "Dispatch" {
+		t.Fatalf("talkgroup label = %q, want Dispatch", c.TalkgroupLabel)
+	}
+	if !c.Emergency {
+		t.Fatal("emergency flag not copied")
+	}
+	if c.Duration() < 2*time.Second {
+		t.Fatalf("duration = %v, want ~3s", c.Duration())
+	}
+}

--- a/internal/broadcast/broadcastify.go
+++ b/internal/broadcast/broadcastify.go
@@ -1,0 +1,156 @@
+package broadcast
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+// broadcastifyEndpoint is the production Broadcastify Calls upload API.
+const broadcastifyEndpoint = "https://api.broadcastify.com/call-upload"
+
+// BroadcastifyConfig configures one Broadcastify Calls feed.
+type BroadcastifyConfig struct {
+	// Name is an optional label used in logs; defaults to
+	// "broadcastify".
+	Name string
+	// APIKey is the Broadcastify Calls API key for the system.
+	APIKey string
+	// SystemID is the numeric Broadcastify Calls system ID.
+	SystemID int
+	// Systems restricts the feed to these trunking-system names.
+	// Empty streams every system.
+	Systems []string
+	// Endpoint overrides the upload API URL (tests). Empty uses the
+	// production endpoint.
+	Endpoint string
+}
+
+type broadcastifyBackend struct {
+	systemFilter
+	name     string
+	apiKey   string
+	systemID int
+	endpoint string
+	http     *http.Client
+}
+
+// NewBroadcastify builds a Broadcastify Calls backend.
+func NewBroadcastify(cfg BroadcastifyConfig, hc *http.Client) (Backend, error) {
+	if cfg.APIKey == "" {
+		return nil, errors.New("broadcast/broadcastify: api_key is required")
+	}
+	if cfg.SystemID == 0 {
+		return nil, errors.New("broadcast/broadcastify: system_id is required")
+	}
+	name := cfg.Name
+	if name == "" {
+		name = "broadcastify"
+	}
+	endpoint := cfg.Endpoint
+	if endpoint == "" {
+		endpoint = broadcastifyEndpoint
+	}
+	if hc == nil {
+		hc = http.DefaultClient
+	}
+	return &broadcastifyBackend{
+		systemFilter: newSystemFilter(cfg.Systems),
+		name:         name,
+		apiKey:       cfg.APIKey,
+		systemID:     cfg.SystemID,
+		endpoint:     endpoint,
+		http:         hc,
+	}, nil
+}
+
+func (b *broadcastifyBackend) Name() string { return b.name }
+
+// Send performs the Broadcastify Calls two-step upload: a metadata POST
+// that returns a one-time upload URL, then a PUT of the MP3 audio.
+func (b *broadcastifyBackend) Send(ctx context.Context, c *Call) error {
+	audio, err := c.MP3()
+	if err != nil {
+		return fmt.Errorf("%s: encode mp3: %w", b.name, err)
+	}
+	uploadURL, err := b.requestUploadURL(ctx, c)
+	if err != nil {
+		return err
+	}
+	return b.putAudio(ctx, uploadURL, audio)
+}
+
+func (b *broadcastifyBackend) requestUploadURL(ctx context.Context, c *Call) (string, error) {
+	form := url.Values{}
+	form.Set("apiKey", b.apiKey)
+	form.Set("systemId", strconv.Itoa(b.systemID))
+	form.Set("callDuration", strconv.Itoa(int(c.Duration().Seconds())))
+	form.Set("ts", strconv.FormatInt(c.StartedAt.Unix(), 10))
+	form.Set("tg", strconv.FormatUint(uint64(c.Talkgroup), 10))
+	form.Set("src", strconv.FormatUint(uint64(c.Source), 10))
+	form.Set("freq", strconv.FormatUint(uint64(c.FrequencyHz), 10))
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, b.endpoint,
+		strings.NewReader(form.Encode()))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := b.http.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("%s: metadata post: %w", b.name, err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("%s: metadata post: HTTP %d: %s",
+			b.name, resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	return parseBroadcastifyUploadURL(string(body))
+}
+
+// parseBroadcastifyUploadURL extracts the one-time upload URL from the
+// Broadcastify Calls metadata response. The API answers either
+// "0 <url>" / "0\n<url>" on success or an error string otherwise.
+func parseBroadcastifyUploadURL(body string) (string, error) {
+	fields := strings.Fields(strings.TrimSpace(body))
+	if len(fields) == 0 {
+		return "", errors.New("broadcastify: empty metadata response")
+	}
+	if fields[0] == "0" && len(fields) >= 2 {
+		return fields[1], nil
+	}
+	if strings.HasPrefix(fields[0], "http") {
+		return fields[0], nil
+	}
+	return "", fmt.Errorf("broadcastify: metadata response rejected: %s",
+		strings.TrimSpace(body))
+}
+
+func (b *broadcastifyBackend) putAudio(ctx context.Context, uploadURL string, audio []byte) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, uploadURL,
+		bytes.NewReader(audio))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "audio/mpeg")
+	req.ContentLength = int64(len(audio))
+
+	resp, err := b.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("%s: audio put: %w", b.name, err)
+	}
+	defer resp.Body.Close()
+	io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
+	if resp.StatusCode/100 != 2 {
+		return fmt.Errorf("%s: audio put: HTTP %d", b.name, resp.StatusCode)
+	}
+	return nil
+}

--- a/internal/broadcast/icecast.go
+++ b/internal/broadcast/icecast.go
@@ -1,0 +1,291 @@
+package broadcast
+
+import (
+	"bufio"
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/voice/mp3"
+)
+
+// Icecast streaming constants. The shine encoder emits a 128 kbps CBR
+// MP3, so the live mountpoint is paced at 16000 bytes/second; between
+// calls the pacer tops the stream up with pre-encoded silence so the
+// source connection is never starved and the Icecast server does not
+// time it out.
+const (
+	icecastBitrateBps  = 128000
+	icecastBytesPerSec = icecastBitrateBps / 8
+	icecastTick        = 200 * time.Millisecond
+	icecastReconnect   = 5 * time.Second
+	icecastMaxQueue    = icecastBytesPerSec * 120 // ~2 min of audio
+)
+
+// IcecastConfig configures one live Icecast/ShoutCast feed.
+type IcecastConfig struct {
+	// Name is an optional log label; defaults to "icecast".
+	Name string
+	// Host and Port address the Icecast server.
+	Host string
+	Port int
+	// Mount is the mountpoint path (e.g. "/gophertrunk"). A leading
+	// slash is added when missing.
+	Mount string
+	// Username is the source username; defaults to "source".
+	Username string
+	// Password is the source password.
+	Password string
+	// StreamName is advertised to listeners via the Ice-Name header.
+	StreamName string
+	// SampleRate is the PCM rate used to synthesise inter-call
+	// silence; defaults to 8000.
+	SampleRate int
+	// Systems restricts the feed to these trunking-system names.
+	// Empty streams every system.
+	Systems []string
+}
+
+type icecastBackend struct {
+	systemFilter
+	name    string
+	addr    string
+	mount   string
+	auth    string
+	stream  string
+	log     *slog.Logger
+	silence []byte
+
+	mu     sync.Mutex
+	queue  []byte
+	closed bool
+
+	cancel context.CancelFunc
+	done   chan struct{}
+}
+
+// NewIcecast builds a live Icecast/ShoutCast streaming backend and
+// starts its background source connection.
+func NewIcecast(cfg IcecastConfig, log *slog.Logger) (Backend, error) {
+	if cfg.Host == "" {
+		return nil, errors.New("broadcast/icecast: host is required")
+	}
+	if cfg.Port == 0 {
+		return nil, errors.New("broadcast/icecast: port is required")
+	}
+	if cfg.Password == "" {
+		return nil, errors.New("broadcast/icecast: password is required")
+	}
+	name := cfg.Name
+	if name == "" {
+		name = "icecast"
+	}
+	user := cfg.Username
+	if user == "" {
+		user = "source"
+	}
+	mount := cfg.Mount
+	if mount == "" {
+		mount = "/gophertrunk"
+	}
+	if !strings.HasPrefix(mount, "/") {
+		mount = "/" + mount
+	}
+	rate := cfg.SampleRate
+	if rate == 0 {
+		rate = 8000
+	}
+	if log == nil {
+		log = slog.Default()
+	}
+	stream := cfg.StreamName
+	if stream == "" {
+		stream = "GopherTrunk"
+	}
+	// One second of digital silence, encoded once and cycled by the
+	// pacer to keep the source connection alive between calls.
+	silence, err := mp3.Encode(make([]int16, rate), rate)
+	if err != nil {
+		return nil, fmt.Errorf("broadcast/icecast: encode silence: %w", err)
+	}
+	b := &icecastBackend{
+		systemFilter: newSystemFilter(cfg.Systems),
+		name:         name,
+		addr:         net.JoinHostPort(cfg.Host, strconv.Itoa(cfg.Port)),
+		mount:        mount,
+		auth:         base64.StdEncoding.EncodeToString([]byte(user + ":" + cfg.Password)),
+		stream:       stream,
+		log:          log,
+		silence:      silence,
+		done:         make(chan struct{}),
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	b.cancel = cancel
+	go b.run(ctx)
+	return b, nil
+}
+
+func (b *icecastBackend) Name() string { return b.name }
+
+// Send queues the call audio onto the live stream. Live streaming is
+// best-effort: a wedged or oversized queue drops the call rather than
+// failing (which would trigger pointless Manager retries).
+func (b *icecastBackend) Send(_ context.Context, c *Call) error {
+	audio, err := c.MP3()
+	if err != nil {
+		return fmt.Errorf("%s: encode mp3: %w", b.name, err)
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.closed {
+		return nil
+	}
+	if len(b.queue)+len(audio) > icecastMaxQueue {
+		b.log.Warn("broadcast: icecast queue full, dropping call",
+			"system", c.System, "tg", c.Talkgroup)
+		return nil
+	}
+	b.queue = append(b.queue, audio...)
+	return nil
+}
+
+// Close stops the background source connection.
+func (b *icecastBackend) Close() error {
+	b.mu.Lock()
+	if b.closed {
+		b.mu.Unlock()
+		return nil
+	}
+	b.closed = true
+	b.mu.Unlock()
+	b.cancel()
+	select {
+	case <-b.done:
+	case <-time.After(2 * time.Second):
+	}
+	return nil
+}
+
+// run maintains the source connection, reconnecting with a fixed
+// backoff on failure, until ctx is cancelled.
+func (b *icecastBackend) run(ctx context.Context) {
+	defer close(b.done)
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		if err := b.runStream(ctx); err != nil {
+			b.log.Warn("broadcast: icecast source disconnected",
+				"backend", b.name, "err", err)
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(icecastReconnect):
+		}
+	}
+}
+
+// runStream dials the server, performs the source handshake, then
+// paces the queued audio (topped up with silence) until ctx ends or a
+// write fails.
+func (b *icecastBackend) runStream(ctx context.Context) error {
+	conn, err := (&net.Dialer{Timeout: 10 * time.Second}).DialContext(ctx, "tcp", b.addr)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+	if err := b.handshake(conn); err != nil {
+		return err
+	}
+	b.log.Info("broadcast: icecast source connected", "backend", b.name, "mount", b.mount)
+
+	ticker := time.NewTicker(icecastTick)
+	defer ticker.Stop()
+	chunk := icecastBytesPerSec * int(icecastTick) / int(time.Second)
+	silenceOff := 0
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+		}
+		payload := b.takeChunk(chunk, &silenceOff)
+		if err := conn.SetWriteDeadline(time.Now().Add(10 * time.Second)); err != nil {
+			return err
+		}
+		if _, err := conn.Write(payload); err != nil {
+			return err
+		}
+	}
+}
+
+// handshake sends the Icecast source request and verifies the server
+// accepted it.
+func (b *icecastBackend) handshake(conn net.Conn) error {
+	req := strings.Join([]string{
+		"SOURCE " + b.mount + " HTTP/1.0",
+		"Authorization: Basic " + b.auth,
+		"User-Agent: GopherTrunk",
+		"Content-Type: audio/mpeg",
+		"Ice-Name: " + b.stream,
+		"Ice-Public: 0",
+		"Ice-Audio-Info: bitrate=128",
+		"", "",
+	}, "\r\n")
+	if err := conn.SetWriteDeadline(time.Now().Add(10 * time.Second)); err != nil {
+		return err
+	}
+	if _, err := conn.Write([]byte(req)); err != nil {
+		return err
+	}
+	if err := conn.SetReadDeadline(time.Now().Add(10 * time.Second)); err != nil {
+		return err
+	}
+	status, err := bufio.NewReader(conn).ReadString('\n')
+	if err != nil {
+		return fmt.Errorf("read source response: %w", err)
+	}
+	if !strings.Contains(status, "200") {
+		return fmt.Errorf("source rejected: %s", strings.TrimSpace(status))
+	}
+	return nil
+}
+
+// takeChunk returns up to n bytes of queued call audio, padding any
+// shortfall with cycled silence so the live stream never starves.
+func (b *icecastBackend) takeChunk(n int, silenceOff *int) []byte {
+	out := make([]byte, 0, n)
+	b.mu.Lock()
+	if len(b.queue) > 0 {
+		take := n
+		if take > len(b.queue) {
+			take = len(b.queue)
+		}
+		out = append(out, b.queue[:take]...)
+		b.queue = b.queue[take:]
+	}
+	b.mu.Unlock()
+	for len(out) < n {
+		if len(b.silence) == 0 {
+			break
+		}
+		if *silenceOff >= len(b.silence) {
+			*silenceOff = 0
+		}
+		end := *silenceOff + (n - len(out))
+		if end > len(b.silence) {
+			end = len(b.silence)
+		}
+		out = append(out, b.silence[*silenceOff:end]...)
+		*silenceOff = end
+	}
+	return out
+}

--- a/internal/broadcast/manager.go
+++ b/internal/broadcast/manager.go
@@ -1,0 +1,270 @@
+package broadcast
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// Default tuning for the Manager.
+const (
+	defaultWorkers    = 2
+	defaultMaxRetries = 3
+	defaultRetryBase  = 2 * time.Second
+	defaultQueueDepth = 64
+)
+
+// Options configure a Manager.
+type Options struct {
+	Bus *events.Bus
+	Log *slog.Logger
+	// Backends is the set of outbound destinations. A Manager with no
+	// backends is valid but inert.
+	Backends []Backend
+	// MinDuration drops calls shorter than this from every backend.
+	// Zero streams calls of any length.
+	MinDuration time.Duration
+	// Workers is the number of concurrent upload goroutines. Default 2.
+	Workers int
+	// MaxRetries is the per-backend retry budget on a failed Send.
+	// Default 3.
+	MaxRetries int
+	// RetryBase is the first backoff delay; it doubles per attempt.
+	// Default 2s.
+	RetryBase time.Duration
+}
+
+// Stats is a point-in-time snapshot of a Manager's counters.
+type Stats struct {
+	Queued   int            `json:"queued"`
+	Dropped  int            `json:"dropped"`
+	Sent     map[string]int `json:"sent"`
+	Failed   map[string]int `json:"failed"`
+	Backends []string       `json:"backends"`
+}
+
+// Manager fans completed calls out to the configured backends.
+type Manager struct {
+	bus         *events.Bus
+	log         *slog.Logger
+	backends    []Backend
+	minDuration time.Duration
+	maxRetries  int
+	retryBase   time.Duration
+
+	sub       *events.Subscription
+	jobs      chan *Call
+	wg        sync.WaitGroup
+	runDone   chan struct{}
+	closeOnce sync.Once
+
+	mu      sync.Mutex
+	queued  int
+	dropped int
+	sent    map[string]int
+	failed  map[string]int
+}
+
+// NewManager validates opts and returns a Manager that has already
+// subscribed to the bus (so calls completed before Run starts are not
+// lost). The caller must invoke Run and, on shutdown, Close.
+func NewManager(opts Options) (*Manager, error) {
+	if opts.Bus == nil {
+		return nil, errors.New("broadcast: events.Bus is required")
+	}
+	if opts.Log == nil {
+		opts.Log = slog.Default()
+	}
+	if opts.Workers <= 0 {
+		opts.Workers = defaultWorkers
+	}
+	if opts.MaxRetries <= 0 {
+		opts.MaxRetries = defaultMaxRetries
+	}
+	if opts.RetryBase <= 0 {
+		opts.RetryBase = defaultRetryBase
+	}
+	m := &Manager{
+		bus:         opts.Bus,
+		log:         opts.Log,
+		backends:    opts.Backends,
+		minDuration: opts.MinDuration,
+		maxRetries:  opts.MaxRetries,
+		retryBase:   opts.RetryBase,
+		jobs:        make(chan *Call, defaultQueueDepth),
+		runDone:     make(chan struct{}),
+		sent:        make(map[string]int),
+		failed:      make(map[string]int),
+	}
+	m.sub = opts.Bus.Subscribe()
+	for i := 0; i < opts.Workers; i++ {
+		m.wg.Add(1)
+		go m.worker()
+	}
+	return m, nil
+}
+
+// Backends reports how many outbound destinations are configured.
+func (m *Manager) Backends() int { return len(m.backends) }
+
+// Run drains KindCallComplete events until ctx is cancelled or the bus
+// subscription closes.
+func (m *Manager) Run(ctx context.Context) error {
+	defer close(m.runDone)
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case ev, ok := <-m.sub.C:
+			if !ok {
+				return nil
+			}
+			if ev.Kind != events.KindCallComplete {
+				continue
+			}
+			cc, ok := ev.Payload.(trunking.CallComplete)
+			if !ok {
+				continue
+			}
+			m.dispatch(cc)
+		}
+	}
+}
+
+// dispatch applies the stream gate + minimum-duration filter and
+// enqueues the call when at least one backend wants it.
+func (m *Manager) dispatch(cc trunking.CallComplete) {
+	if len(m.backends) == 0 {
+		return
+	}
+	if cc.Talkgroup != nil && !cc.Talkgroup.Stream {
+		return // talkgroup opted out of all feeds
+	}
+	if m.minDuration > 0 && cc.Duration() < m.minDuration {
+		return
+	}
+	call := callFromEvent(cc)
+	wanted := false
+	for _, b := range m.backends {
+		if b.Accepts(call.System) {
+			wanted = true
+			break
+		}
+	}
+	if !wanted {
+		return
+	}
+	select {
+	case m.jobs <- call:
+		m.mu.Lock()
+		m.queued++
+		m.mu.Unlock()
+	default:
+		// Queue full — a backend is wedged. Drop rather than block
+		// the event loop (and the recorder behind it).
+		m.mu.Lock()
+		m.dropped++
+		m.mu.Unlock()
+		m.log.Warn("broadcast: upload queue full, dropping call",
+			"system", call.System, "tg", call.Talkgroup)
+	}
+}
+
+func (m *Manager) worker() {
+	defer m.wg.Done()
+	for call := range m.jobs {
+		for _, b := range m.backends {
+			if !b.Accepts(call.System) {
+				continue
+			}
+			m.sendWithRetry(b, call)
+		}
+	}
+}
+
+// sendWithRetry attempts b.Send up to maxRetries+1 times with exponential
+// backoff between attempts.
+func (m *Manager) sendWithRetry(b Backend, call *Call) {
+	backoff := m.retryBase
+	for attempt := 0; attempt <= m.maxRetries; attempt++ {
+		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+		err := b.Send(ctx, call)
+		cancel()
+		if err == nil {
+			m.mu.Lock()
+			m.sent[b.Name()]++
+			m.mu.Unlock()
+			m.log.Info("broadcast: call streamed",
+				"backend", b.Name(), "system", call.System,
+				"tg", call.Talkgroup, "attempt", attempt+1)
+			return
+		}
+		m.log.Warn("broadcast: upload failed",
+			"backend", b.Name(), "system", call.System, "tg", call.Talkgroup,
+			"attempt", attempt+1, "of", m.maxRetries+1, "err", err)
+		if attempt < m.maxRetries {
+			time.Sleep(backoff)
+			backoff *= 2
+		}
+	}
+	m.mu.Lock()
+	m.failed[b.Name()]++
+	m.mu.Unlock()
+	m.log.Error("broadcast: giving up on call",
+		"backend", b.Name(), "system", call.System, "tg", call.Talkgroup)
+}
+
+// Stats returns a snapshot of the Manager's counters.
+func (m *Manager) Stats() Stats {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	s := Stats{
+		Queued:  m.queued,
+		Dropped: m.dropped,
+		Sent:    make(map[string]int, len(m.sent)),
+		Failed:  make(map[string]int, len(m.failed)),
+	}
+	for k, v := range m.sent {
+		s.Sent[k] = v
+	}
+	for k, v := range m.failed {
+		s.Failed[k] = v
+	}
+	for _, b := range m.backends {
+		s.Backends = append(s.Backends, b.Name())
+	}
+	return s
+}
+
+// Close releases the bus subscription, waits for Run to drain, then
+// stops the upload workers. Safe to call multiple times.
+func (m *Manager) Close() error {
+	m.closeOnce.Do(func() {
+		m.sub.Close()
+		select {
+		case <-m.runDone:
+		case <-time.After(2 * time.Second):
+		}
+		close(m.jobs)
+		m.wg.Wait()
+		for _, b := range m.backends {
+			if c, ok := b.(interface{ Close() error }); ok {
+				if err := c.Close(); err != nil {
+					m.log.Warn("broadcast: backend close", "backend", b.Name(), "err", err)
+				}
+			}
+		}
+	})
+	return nil
+}
+
+// String renders a one-line Manager summary for log output.
+func (m *Manager) String() string {
+	return fmt.Sprintf("broadcast.Manager(%d backends)", len(m.backends))
+}

--- a/internal/broadcast/manager_test.go
+++ b/internal/broadcast/manager_test.go
@@ -1,0 +1,190 @@
+package broadcast
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// fakeBackend records the calls it receives and can be told to fail a
+// fixed number of leading Send attempts.
+type fakeBackend struct {
+	name      string
+	filter    systemFilter
+	failFirst int
+
+	mu       sync.Mutex
+	attempts int
+	got      []*Call
+}
+
+func (f *fakeBackend) Name() string          { return f.name }
+func (f *fakeBackend) Accepts(s string) bool { return f.filter.Accepts(s) }
+func (f *fakeBackend) Send(_ context.Context, c *Call) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.attempts++
+	if f.attempts <= f.failFirst {
+		return errors.New("transient failure")
+	}
+	f.got = append(f.got, c)
+	return nil
+}
+func (f *fakeBackend) delivered() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.got)
+}
+func (f *fakeBackend) tries() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.attempts
+}
+
+// waitFor polls cond until it holds or the deadline elapses.
+func waitFor(t *testing.T, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal("condition not met before deadline")
+}
+
+// newTestManager builds a Manager wired to bus with fast retries and
+// runs its event loop until the returned cancel is called.
+func newTestManager(t *testing.T, bus *events.Bus, opts Options) *Manager {
+	t.Helper()
+	opts.Bus = bus
+	opts.RetryBase = time.Millisecond
+	m, err := NewManager(opts)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	go m.Run(ctx)
+	t.Cleanup(func() {
+		cancel()
+		m.Close()
+	})
+	return m
+}
+
+func completeEvent(system string, tg uint32, audioPath string, dur time.Duration, tgRec *trunking.TalkGroup) events.Event {
+	now := time.Now()
+	return events.Event{
+		Kind: events.KindCallComplete,
+		Payload: trunking.CallComplete{
+			Grant:      trunking.Grant{System: system, GroupID: tg},
+			Talkgroup:  tgRec,
+			StartedAt:  now.Add(-dur),
+			EndedAt:    now,
+			AudioPath:  audioPath,
+			SampleRate: 8000,
+		},
+	}
+}
+
+func TestManagerStreamsCompletedCall(t *testing.T) {
+	bus := events.NewBus(16)
+	defer bus.Close()
+	be := &fakeBackend{name: "fake"}
+	m := newTestManager(t, bus, Options{Backends: []Backend{be}})
+
+	bus.Publish(completeEvent("Metro", 100, writeWAV(t, 0.4), 2*time.Second, nil))
+	waitFor(t, func() bool { return be.delivered() == 1 })
+
+	if got := be.got[0]; got.System != "Metro" || got.Talkgroup != 100 {
+		t.Fatalf("delivered wrong call: %+v", got)
+	}
+	if s := m.Stats(); s.Sent["fake"] != 1 {
+		t.Fatalf("stats Sent[fake] = %d, want 1", s.Sent["fake"])
+	}
+}
+
+func TestManagerSkipsStreamFalseTalkgroup(t *testing.T) {
+	bus := events.NewBus(16)
+	defer bus.Close()
+	be := &fakeBackend{name: "fake"}
+	newTestManager(t, bus, Options{Backends: []Backend{be}})
+
+	muted := &trunking.TalkGroup{ID: 200, Stream: false}
+	bus.Publish(completeEvent("Metro", 200, writeWAV(t, 0.4), 2*time.Second, muted))
+	// Give the event loop time to process and (correctly) drop it.
+	time.Sleep(200 * time.Millisecond)
+	if be.delivered() != 0 {
+		t.Fatal("call on a Stream=false talkgroup must not be streamed")
+	}
+}
+
+func TestManagerDropsShortCalls(t *testing.T) {
+	bus := events.NewBus(16)
+	defer bus.Close()
+	be := &fakeBackend{name: "fake"}
+	newTestManager(t, bus, Options{Backends: []Backend{be}, MinDuration: time.Second})
+
+	bus.Publish(completeEvent("Metro", 300, writeWAV(t, 0.4), 250*time.Millisecond, nil))
+	time.Sleep(200 * time.Millisecond)
+	if be.delivered() != 0 {
+		t.Fatal("call shorter than MinDuration must be dropped")
+	}
+}
+
+func TestManagerRespectsSystemFilter(t *testing.T) {
+	bus := events.NewBus(16)
+	defer bus.Close()
+	be := &fakeBackend{name: "fake", filter: newSystemFilter([]string{"Alpha"})}
+	newTestManager(t, bus, Options{Backends: []Backend{be}})
+
+	bus.Publish(completeEvent("Bravo", 400, writeWAV(t, 0.4), 2*time.Second, nil))
+	time.Sleep(200 * time.Millisecond)
+	if be.delivered() != 0 {
+		t.Fatal("backend received a call from an unlisted system")
+	}
+
+	bus.Publish(completeEvent("Alpha", 401, writeWAV(t, 0.4), 2*time.Second, nil))
+	waitFor(t, func() bool { return be.delivered() == 1 })
+}
+
+func TestManagerRetriesTransientFailure(t *testing.T) {
+	bus := events.NewBus(16)
+	defer bus.Close()
+	be := &fakeBackend{name: "flaky", failFirst: 2}
+	m := newTestManager(t, bus, Options{Backends: []Backend{be}, MaxRetries: 3})
+
+	bus.Publish(completeEvent("Metro", 500, writeWAV(t, 0.4), 2*time.Second, nil))
+	waitFor(t, func() bool { return be.delivered() == 1 })
+	if be.tries() != 3 {
+		t.Fatalf("attempts = %d, want 3 (2 failures + 1 success)", be.tries())
+	}
+	if s := m.Stats(); s.Sent["flaky"] != 1 || s.Failed["flaky"] != 0 {
+		t.Fatalf("stats wrong after eventual success: %+v", s)
+	}
+}
+
+func TestManagerGivesUpAfterMaxRetries(t *testing.T) {
+	bus := events.NewBus(16)
+	defer bus.Close()
+	be := &fakeBackend{name: "dead", failFirst: 99}
+	m := newTestManager(t, bus, Options{Backends: []Backend{be}, MaxRetries: 2})
+
+	bus.Publish(completeEvent("Metro", 600, writeWAV(t, 0.4), 2*time.Second, nil))
+	waitFor(t, func() bool { return m.Stats().Failed["dead"] == 1 })
+	if be.tries() != 3 {
+		t.Fatalf("attempts = %d, want 3 (MaxRetries 2 + initial)", be.tries())
+	}
+}
+
+func TestManagerRequiresBus(t *testing.T) {
+	if _, err := NewManager(Options{}); err == nil {
+		t.Fatal("NewManager without a bus should error")
+	}
+}

--- a/internal/broadcast/multipart.go
+++ b/internal/broadcast/multipart.go
@@ -1,0 +1,43 @@
+package broadcast
+
+import (
+	"bytes"
+	"mime/multipart"
+)
+
+// multipartField is one entry in a multipart/form-data body. When
+// Filename is non-empty the entry is written as a file part carrying
+// Data; otherwise it is a plain text field carrying Value.
+type multipartField struct {
+	Name     string
+	Value    string
+	Filename string
+	Data     []byte
+}
+
+// buildMultipart assembles a multipart/form-data body from fields and
+// returns the encoded buffer together with the Content-Type header
+// value (which carries the generated boundary).
+func buildMultipart(fields []multipartField) (*bytes.Buffer, string, error) {
+	var buf bytes.Buffer
+	w := multipart.NewWriter(&buf)
+	for _, f := range fields {
+		if f.Filename != "" {
+			part, err := w.CreateFormFile(f.Name, f.Filename)
+			if err != nil {
+				return nil, "", err
+			}
+			if _, err := part.Write(f.Data); err != nil {
+				return nil, "", err
+			}
+			continue
+		}
+		if err := w.WriteField(f.Name, f.Value); err != nil {
+			return nil, "", err
+		}
+	}
+	if err := w.Close(); err != nil {
+		return nil, "", err
+	}
+	return &buf, w.FormDataContentType(), nil
+}

--- a/internal/broadcast/openmhz.go
+++ b/internal/broadcast/openmhz.go
@@ -1,0 +1,129 @@
+package broadcast
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+// openMHzEndpoint is the production OpenMHz upload API. The system
+// short name is appended as a path segment.
+const openMHzEndpoint = "https://api.openmhz.com"
+
+// OpenMHzConfig configures one OpenMHz upload feed.
+type OpenMHzConfig struct {
+	// Name is an optional log label; defaults to "openmhz".
+	Name string
+	// APIKey is the OpenMHz system API key.
+	APIKey string
+	// ShortName is the OpenMHz system short name (the path segment in
+	// the upload URL).
+	ShortName string
+	// Systems restricts the feed to these trunking-system names.
+	// Empty streams every system.
+	Systems []string
+	// Endpoint overrides the API base URL (tests). Empty uses the
+	// production endpoint.
+	Endpoint string
+}
+
+type openMHzBackend struct {
+	systemFilter
+	name     string
+	apiKey   string
+	endpoint string
+	http     *http.Client
+}
+
+// NewOpenMHz builds an OpenMHz upload backend.
+func NewOpenMHz(cfg OpenMHzConfig, hc *http.Client) (Backend, error) {
+	if cfg.APIKey == "" {
+		return nil, errors.New("broadcast/openmhz: api_key is required")
+	}
+	if cfg.ShortName == "" {
+		return nil, errors.New("broadcast/openmhz: short_name is required")
+	}
+	name := cfg.Name
+	if name == "" {
+		name = "openmhz"
+	}
+	base := cfg.Endpoint
+	if base == "" {
+		base = openMHzEndpoint
+	}
+	if hc == nil {
+		hc = http.DefaultClient
+	}
+	return &openMHzBackend{
+		systemFilter: newSystemFilter(cfg.Systems),
+		name:         name,
+		apiKey:       cfg.APIKey,
+		endpoint:     strings.TrimRight(base, "/") + "/" + cfg.ShortName + "/upload",
+		http:         hc,
+	}, nil
+}
+
+func (b *openMHzBackend) Name() string { return b.name }
+
+// Send uploads the call to OpenMHz as a multipart/form-data POST.
+func (b *openMHzBackend) Send(ctx context.Context, c *Call) error {
+	audio, err := c.MP3()
+	if err != nil {
+		return fmt.Errorf("%s: encode mp3: %w", b.name, err)
+	}
+	emergency := "0"
+	if c.Emergency {
+		emergency = "1"
+	}
+	// source_list and patch_list are JSON arrays OpenMHz expects even
+	// when there is only the single granting unit to report.
+	sourceList := fmt.Sprintf(`[{"src":%d,"time":%d,"pos":0}]`,
+		c.Source, c.StartedAt.Unix())
+	patchList := "[]"
+	if len(c.PatchedGroups) > 0 {
+		parts := make([]string, len(c.PatchedGroups))
+		for i, g := range c.PatchedGroups {
+			parts[i] = strconv.FormatUint(uint64(g), 10)
+		}
+		patchList = "[" + strings.Join(parts, ",") + "]"
+	}
+
+	fields := []multipartField{
+		{Name: "api_key", Value: b.apiKey},
+		{Name: "freq", Value: strconv.FormatUint(uint64(c.FrequencyHz), 10)},
+		{Name: "start_time", Value: strconv.FormatInt(c.StartedAt.Unix(), 10)},
+		{Name: "stop_time", Value: strconv.FormatInt(c.EndedAt.Unix(), 10)},
+		{Name: "call_length", Value: strconv.Itoa(int(c.Duration().Seconds()))},
+		{Name: "talkgroup_num", Value: strconv.FormatUint(uint64(c.Talkgroup), 10)},
+		{Name: "emergency", Value: emergency},
+		{Name: "source_list", Value: sourceList},
+		{Name: "patch_list", Value: patchList},
+		{Name: "call", Filename: audioFilename(c, "mp3"), Data: audio},
+	}
+
+	body, contentType, err := buildMultipart(fields)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, b.endpoint, body)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", contentType)
+
+	resp, err := b.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("%s: post: %w", b.name, err)
+	}
+	defer resp.Body.Close()
+	msg, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	if resp.StatusCode/100 != 2 {
+		return fmt.Errorf("%s: HTTP %d: %s", b.name, resp.StatusCode,
+			strings.TrimSpace(string(msg)))
+	}
+	return nil
+}

--- a/internal/broadcast/rdioscanner.go
+++ b/internal/broadcast/rdioscanner.go
@@ -1,0 +1,119 @@
+package broadcast
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// RdioScannerConfig configures one RdioScanner call-upload feed.
+type RdioScannerConfig struct {
+	// Name is an optional log label; defaults to "rdioscanner".
+	Name string
+	// URL is the RdioScanner base URL (e.g. "https://scanner.example").
+	// The "/api/call-upload" path is appended automatically.
+	URL string
+	// APIKey is the RdioScanner system API key.
+	APIKey string
+	// SystemID is the numeric RdioScanner system ID.
+	SystemID int
+	// Systems restricts the feed to these trunking-system names.
+	// Empty streams every system.
+	Systems []string
+}
+
+type rdioScannerBackend struct {
+	systemFilter
+	name     string
+	endpoint string
+	apiKey   string
+	systemID int
+	http     *http.Client
+}
+
+// NewRdioScanner builds an RdioScanner call-upload backend.
+func NewRdioScanner(cfg RdioScannerConfig, hc *http.Client) (Backend, error) {
+	if cfg.URL == "" {
+		return nil, errors.New("broadcast/rdioscanner: url is required")
+	}
+	if cfg.APIKey == "" {
+		return nil, errors.New("broadcast/rdioscanner: api_key is required")
+	}
+	if cfg.SystemID == 0 {
+		return nil, errors.New("broadcast/rdioscanner: system_id is required")
+	}
+	name := cfg.Name
+	if name == "" {
+		name = "rdioscanner"
+	}
+	if hc == nil {
+		hc = http.DefaultClient
+	}
+	return &rdioScannerBackend{
+		systemFilter: newSystemFilter(cfg.Systems),
+		name:         name,
+		endpoint:     strings.TrimRight(cfg.URL, "/") + "/api/call-upload",
+		apiKey:       cfg.APIKey,
+		systemID:     cfg.SystemID,
+		http:         hc,
+	}, nil
+}
+
+func (b *rdioScannerBackend) Name() string { return b.name }
+
+// Send uploads the call to RdioScanner as a multipart/form-data POST.
+func (b *rdioScannerBackend) Send(ctx context.Context, c *Call) error {
+	audio, err := c.MP3()
+	if err != nil {
+		return fmt.Errorf("%s: encode mp3: %w", b.name, err)
+	}
+	fields := []multipartField{
+		{Name: "key", Value: b.apiKey},
+		{Name: "system", Value: strconv.Itoa(b.systemID)},
+		{Name: "dateTime", Value: c.StartedAt.UTC().Format(time.RFC3339)},
+		{Name: "talkgroup", Value: strconv.FormatUint(uint64(c.Talkgroup), 10)},
+		{Name: "source", Value: strconv.FormatUint(uint64(c.Source), 10)},
+		{Name: "frequency", Value: strconv.FormatUint(uint64(c.FrequencyHz), 10)},
+		{Name: "audioName", Value: audioFilename(c, "mp3")},
+		{Name: "audioType", Value: "audio/mpeg"},
+		{Name: "audio", Filename: audioFilename(c, "mp3"), Data: audio},
+	}
+	if c.TalkgroupLabel != "" {
+		fields = append(fields, multipartField{Name: "talkgroupLabel", Value: c.TalkgroupLabel})
+	}
+	if c.System != "" {
+		fields = append(fields, multipartField{Name: "systemLabel", Value: c.System})
+	}
+
+	body, contentType, err := buildMultipart(fields)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, b.endpoint, body)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", contentType)
+
+	resp, err := b.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("%s: post: %w", b.name, err)
+	}
+	defer resp.Body.Close()
+	msg, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	if resp.StatusCode/100 != 2 {
+		return fmt.Errorf("%s: HTTP %d: %s", b.name, resp.StatusCode,
+			strings.TrimSpace(string(msg)))
+	}
+	return nil
+}
+
+// audioFilename builds a stable per-call filename for an upload part.
+func audioFilename(c *Call, ext string) string {
+	return fmt.Sprintf("%d-%d.%s", c.Talkgroup, c.StartedAt.Unix(), ext)
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -24,6 +24,69 @@ type Config struct {
 	ToneOut    ToneOutConfig    `yaml:"tone_out"`
 	Scanner    ScannerConfig    `yaml:"scanner"`
 	Audio      AudioConfig      `yaml:"audio"`
+	Broadcast  BroadcastConfig  `yaml:"broadcast"`
+}
+
+// BroadcastConfig configures the outbound call-streaming subsystem
+// (internal/broadcast): completed calls are encoded to MP3 and uploaded
+// to call aggregators or pushed to a live Icecast/ShoutCast mountpoint.
+// Empty == disabled; the daemon runs no broadcast manager when no feed
+// is configured.
+type BroadcastConfig struct {
+	// MinDurationMs drops calls shorter than this from every feed
+	// (squelch crackle, failed decodes). 0 streams calls of any
+	// length.
+	MinDurationMs int `yaml:"min_duration_ms"`
+	// Workers is the number of concurrent upload goroutines. 0 uses
+	// the broadcast package default.
+	Workers int `yaml:"workers"`
+	// Broadcastify, RdioScanner, OpenMHz and Icecast each list zero
+	// or more feeds. A feed with enabled=false is parsed but skipped.
+	Broadcastify []BroadcastifyFeedConfig `yaml:"broadcastify"`
+	RdioScanner  []RdioScannerFeedConfig  `yaml:"rdioscanner"`
+	OpenMHz      []OpenMHzFeedConfig      `yaml:"openmhz"`
+	Icecast      []IcecastFeedConfig      `yaml:"icecast"`
+}
+
+// BroadcastifyFeedConfig is one Broadcastify Calls upload feed.
+type BroadcastifyFeedConfig struct {
+	Enabled  bool     `yaml:"enabled"`
+	Name     string   `yaml:"name"`
+	APIKey   string   `yaml:"api_key"`
+	SystemID int      `yaml:"system_id"`
+	Systems  []string `yaml:"systems"` // empty = every system
+}
+
+// RdioScannerFeedConfig is one RdioScanner call-upload feed.
+type RdioScannerFeedConfig struct {
+	Enabled  bool     `yaml:"enabled"`
+	Name     string   `yaml:"name"`
+	URL      string   `yaml:"url"`
+	APIKey   string   `yaml:"api_key"`
+	SystemID int      `yaml:"system_id"`
+	Systems  []string `yaml:"systems"`
+}
+
+// OpenMHzFeedConfig is one OpenMHz upload feed.
+type OpenMHzFeedConfig struct {
+	Enabled   bool     `yaml:"enabled"`
+	Name      string   `yaml:"name"`
+	APIKey    string   `yaml:"api_key"`
+	ShortName string   `yaml:"short_name"`
+	Systems   []string `yaml:"systems"`
+}
+
+// IcecastFeedConfig is one live Icecast/ShoutCast feed.
+type IcecastFeedConfig struct {
+	Enabled    bool     `yaml:"enabled"`
+	Name       string   `yaml:"name"`
+	Host       string   `yaml:"host"`
+	Port       int      `yaml:"port"`
+	Mount      string   `yaml:"mount"`
+	Username   string   `yaml:"username"`
+	Password   string   `yaml:"password"`
+	StreamName string   `yaml:"stream_name"`
+	Systems    []string `yaml:"systems"`
 }
 
 // AudioConfig controls live audio playback to the host's speakers.
@@ -626,6 +689,69 @@ func (c Config) Validate() error {
 			}
 		default:
 			return fmt.Errorf("scanner.conventional[%d].tone.mode must be ctcss|dcs|none", i)
+		}
+	}
+	if err := c.Broadcast.validate(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// validate checks that every enabled broadcast feed carries the fields
+// its backend requires. Disabled feeds are left unchecked so operators
+// can pre-stage credentials.
+func (b BroadcastConfig) validate() error {
+	if b.MinDurationMs < 0 {
+		return errors.New("broadcast.min_duration_ms must not be negative")
+	}
+	for i, f := range b.Broadcastify {
+		if !f.Enabled {
+			continue
+		}
+		if f.APIKey == "" {
+			return fmt.Errorf("broadcast.broadcastify[%d]: api_key required", i)
+		}
+		if f.SystemID == 0 {
+			return fmt.Errorf("broadcast.broadcastify[%d]: system_id required", i)
+		}
+	}
+	for i, f := range b.RdioScanner {
+		if !f.Enabled {
+			continue
+		}
+		if f.URL == "" {
+			return fmt.Errorf("broadcast.rdioscanner[%d]: url required", i)
+		}
+		if f.APIKey == "" {
+			return fmt.Errorf("broadcast.rdioscanner[%d]: api_key required", i)
+		}
+		if f.SystemID == 0 {
+			return fmt.Errorf("broadcast.rdioscanner[%d]: system_id required", i)
+		}
+	}
+	for i, f := range b.OpenMHz {
+		if !f.Enabled {
+			continue
+		}
+		if f.APIKey == "" {
+			return fmt.Errorf("broadcast.openmhz[%d]: api_key required", i)
+		}
+		if f.ShortName == "" {
+			return fmt.Errorf("broadcast.openmhz[%d]: short_name required", i)
+		}
+	}
+	for i, f := range b.Icecast {
+		if !f.Enabled {
+			continue
+		}
+		if f.Host == "" {
+			return fmt.Errorf("broadcast.icecast[%d]: host required", i)
+		}
+		if f.Port == 0 {
+			return fmt.Errorf("broadcast.icecast[%d]: port required", i)
+		}
+		if f.Password == "" {
+			return fmt.Errorf("broadcast.icecast[%d]: password required", i)
 		}
 	}
 	return nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,6 +25,39 @@ type Config struct {
 	Scanner    ScannerConfig    `yaml:"scanner"`
 	Audio      AudioConfig      `yaml:"audio"`
 	Broadcast  BroadcastConfig  `yaml:"broadcast"`
+	Baseband   BasebandConfig   `yaml:"baseband"`
+}
+
+// BasebandConfig configures wideband IQ recording and offline replay.
+// Empty == disabled. `record` taps live tuners and writes their IQ to
+// WAV; `replay` mounts recorded WAVs as virtual tuners so a capture can
+// be decoded offline. Replay recordings should have been made at the
+// same rate as sdr.sample_rate for real-time-correct playback.
+type BasebandConfig struct {
+	Record []BasebandRecordConfig `yaml:"record"`
+	Replay []BasebandReplayConfig `yaml:"replay"`
+}
+
+// BasebandRecordConfig taps one tuner's live IQ to WAV recordings.
+type BasebandRecordConfig struct {
+	// Serial is the SDR serial whose IQ stream is recorded.
+	Serial string `yaml:"serial"`
+	// Dir is the directory recordings are written into.
+	Dir string `yaml:"dir"`
+}
+
+// BasebandReplayConfig mounts one recorded WAV as a virtual tuner.
+type BasebandReplayConfig struct {
+	// File is the path to the baseband WAV recording.
+	File string `yaml:"file"`
+	// Serial is the virtual device serial the pool reports. Empty
+	// generates one.
+	Serial string `yaml:"serial"`
+	// Role is the pool role: control|voice|auto (empty = auto).
+	Role string `yaml:"role"`
+	// Loop restarts the recording on EOF so the offline tuner is a
+	// continuous source. nil defaults to true.
+	Loop *bool `yaml:"loop"`
 }
 
 // BroadcastConfig configures the outbound call-streaming subsystem
@@ -693,6 +726,24 @@ func (c Config) Validate() error {
 	}
 	if err := c.Broadcast.validate(); err != nil {
 		return err
+	}
+	for i, r := range c.Baseband.Record {
+		if r.Serial == "" {
+			return fmt.Errorf("baseband.record[%d]: serial required", i)
+		}
+		if r.Dir == "" {
+			return fmt.Errorf("baseband.record[%d]: dir required", i)
+		}
+	}
+	for i, r := range c.Baseband.Replay {
+		if r.File == "" {
+			return fmt.Errorf("baseband.replay[%d]: file required", i)
+		}
+		switch r.Role {
+		case "", "control", "voice", "auto":
+		default:
+			return fmt.Errorf("baseband.replay[%d]: role must be control|voice|auto", i)
+		}
 	}
 	return nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -232,6 +232,19 @@ type ConvToneConfig struct {
 type LogConfig struct {
 	Level  string `yaml:"level"`
 	Format string `yaml:"format"`
+	// MessageLog configures the optional decoded-message log — a
+	// human-readable, per-event text log of trunking activity
+	// (grants, lock/loss, affiliations, patches, …), the analogue
+	// of SDRtrunk's per-channel decoded message log.
+	MessageLog MessageLogConfig `yaml:"message_log"`
+}
+
+// MessageLogConfig configures the decoded-message log. Empty Path (or
+// Enabled false) disables it.
+type MessageLogConfig struct {
+	Enabled   bool   `yaml:"enabled"`
+	Path      string `yaml:"path"`
+	MaxSizeMB int    `yaml:"max_size_mb"` // default 16
 }
 
 type SDRConfig struct {

--- a/internal/events/bus.go
+++ b/internal/events/bus.go
@@ -18,10 +18,20 @@ const (
 	KindCCLost      Kind = "cc.lost"
 	KindCallStart   Kind = "call.start"
 	KindCallEnd     Kind = "call.end"
-	KindGrant       Kind = "grant"
-	KindToneAlert   Kind = "tone.alert"
-	KindDecodeError Kind = "decode.error"
-	KindError       Kind = "error"
+	// KindCallComplete fires after the recorder has finished writing a
+	// call's WAV to disk — the WAV header length fields are patched and
+	// the file is closed and ready to read. It carries the same call
+	// metadata as KindCallEnd plus the on-disk audio path
+	// (trunking.CallComplete). The outbound-streaming subsystem
+	// (internal/broadcast) subscribes to it to upload completed calls
+	// to Broadcastify Calls / RdioScanner / OpenMHz / Icecast. Distinct
+	// from KindCallEnd because KindCallEnd fires the instant the engine
+	// releases the voice channel, before the WAV is flushed.
+	KindCallComplete Kind = "call.complete"
+	KindGrant        Kind = "grant"
+	KindToneAlert    Kind = "tone.alert"
+	KindDecodeError  Kind = "decode.error"
+	KindError        Kind = "error"
 	// Scanner subsystem (internal/scanner/cchunt):
 	//   KindHuntProgress fires once per CC candidate the hunter
 	//     tries — payload identifies which system + frequency +

--- a/internal/events/bus.go
+++ b/internal/events/bus.go
@@ -78,6 +78,12 @@ const (
 	// alias. The payload (trunking.TalkerAlias) is keyed by source unit
 	// so a consumer can associate it with the active call.
 	KindTalkerAlias Kind = "talker.alias"
+	// KindLocation fires when a subscriber unit reports a geographic
+	// position over the air — P25 Motorola Unit GPS, P25 L3Harris
+	// Talker GPS, or DMR LRRP. The payload (trunking.Location) carries
+	// the reporting radio, the lat/lon fix, and optional speed/heading.
+	// The storage layer persists it; the API + web map surface it.
+	KindLocation Kind = "location"
 )
 
 // Stage names a particular FEC / parser checkpoint inside a protocol

--- a/internal/log/messagelog.go
+++ b/internal/log/messagelog.go
@@ -1,0 +1,206 @@
+package log
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// MessageLog writes a human-readable, per-event decoded-message log —
+// the GopherTrunk analogue of SDRtrunk's per-channel decoded message
+// log. It subscribes to the events bus and appends one timestamped
+// line per trunking event (grants, control-channel lock/loss,
+// affiliations, registrations, patches, talker aliases, locations,
+// tone alerts, decode errors). The file rotates to "<path>.1" when it
+// exceeds the configured size cap.
+type MessageLog struct {
+	bus       *events.Bus
+	path      string
+	maxBytes  int64
+	sub       *events.Subscription
+	runDone   chan struct{}
+	closeOnce sync.Once
+
+	mu   sync.Mutex
+	f    *os.File
+	size int64
+}
+
+// MessageLogOptions configure a MessageLog.
+type MessageLogOptions struct {
+	Bus *events.Bus
+	// Path is the log file path. Required.
+	Path string
+	// MaxSizeMB caps the file size before rotation. Default 16.
+	MaxSizeMB int
+}
+
+// NewMessageLog opens the log file and subscribes to the bus.
+func NewMessageLog(opts MessageLogOptions) (*MessageLog, error) {
+	if opts.Bus == nil {
+		return nil, errors.New("log/messagelog: events.Bus is required")
+	}
+	if opts.Path == "" {
+		return nil, errors.New("log/messagelog: Path is required")
+	}
+	if opts.MaxSizeMB <= 0 {
+		opts.MaxSizeMB = 16
+	}
+	if err := os.MkdirAll(filepath.Dir(opts.Path), 0o755); err != nil {
+		return nil, fmt.Errorf("log/messagelog: mkdir: %w", err)
+	}
+	f, err := os.OpenFile(opts.Path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return nil, fmt.Errorf("log/messagelog: open: %w", err)
+	}
+	info, _ := f.Stat()
+	ml := &MessageLog{
+		bus:      opts.Bus,
+		path:     opts.Path,
+		maxBytes: int64(opts.MaxSizeMB) * 1024 * 1024,
+		runDone:  make(chan struct{}),
+		f:        f,
+	}
+	if info != nil {
+		ml.size = info.Size()
+	}
+	ml.sub = opts.Bus.Subscribe()
+	return ml, nil
+}
+
+// Run drains events until ctx cancels or the bus closes.
+func (m *MessageLog) Run(ctx context.Context) error {
+	defer close(m.runDone)
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case ev, ok := <-m.sub.C:
+			if !ok {
+				return nil
+			}
+			if line := formatEvent(ev); line != "" {
+				m.write(line)
+			}
+		}
+	}
+}
+
+func (m *MessageLog) write(line string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.f == nil {
+		return
+	}
+	if m.maxBytes > 0 && m.size+int64(len(line)) > m.maxBytes {
+		m.rotate()
+	}
+	n, err := m.f.WriteString(line)
+	m.size += int64(n)
+	_ = err
+}
+
+// rotate closes the current file, renames it to "<path>.1", and opens
+// a fresh one. Caller holds m.mu.
+func (m *MessageLog) rotate() {
+	m.f.Close()
+	_ = os.Rename(m.path, m.path+".1")
+	f, err := os.OpenFile(m.path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
+	if err != nil {
+		m.f = nil
+		return
+	}
+	m.f = f
+	m.size = 0
+}
+
+// Close releases the bus subscription, waits for Run to drain, and
+// closes the file.
+func (m *MessageLog) Close() error {
+	m.closeOnce.Do(func() {
+		m.sub.Close()
+		select {
+		case <-m.runDone:
+		case <-time.After(time.Second):
+		}
+		m.mu.Lock()
+		if m.f != nil {
+			m.f.Close()
+			m.f = nil
+		}
+		m.mu.Unlock()
+	})
+	return nil
+}
+
+// formatEvent renders one bus event as a decoded-message log line
+// (newline-terminated). Returns "" for events with no useful textual
+// form so they are skipped.
+func formatEvent(ev events.Event) string {
+	ts := ev.Timestamp
+	if ts.IsZero() {
+		ts = time.Now()
+	}
+	stamp := ts.UTC().Format("2006-01-02T15:04:05.000Z")
+	var body string
+	switch ev.Kind {
+	case events.KindGrant:
+		if g, ok := ev.Payload.(trunking.Grant); ok {
+			body = fmt.Sprintf("%-12s system=%s proto=%s tg=%d src=%d freq=%d enc=%t emer=%t",
+				"GRANT", g.System, g.Protocol, g.GroupID, g.SourceID,
+				g.FrequencyHz, g.Encrypted, g.Emergency)
+		}
+	case events.KindCallStart:
+		if c, ok := ev.Payload.(trunking.CallStart); ok {
+			body = fmt.Sprintf("%-12s system=%s tg=%d src=%d dev=%s",
+				"CALL-START", c.Grant.System, c.Grant.GroupID, c.Grant.SourceID, c.DeviceSerial)
+		}
+	case events.KindCallEnd:
+		if c, ok := ev.Payload.(trunking.CallEnd); ok {
+			body = fmt.Sprintf("%-12s system=%s tg=%d dur=%s reason=%s",
+				"CALL-END", c.Grant.System, c.Grant.GroupID,
+				c.Duration().Round(time.Millisecond), c.Reason)
+		}
+	case events.KindAffiliation:
+		if a, ok := ev.Payload.(trunking.Affiliation); ok {
+			body = fmt.Sprintf("%-12s system=%s proto=%s src=%d tg=%d resp=%s",
+				"AFFILIATION", a.System, a.Protocol, a.SourceID, a.GroupID, a.Response)
+		}
+	case events.KindUnitRegistration:
+		if r, ok := ev.Payload.(trunking.UnitRegistration); ok {
+			body = fmt.Sprintf("%-12s system=%s proto=%s src=%d wacn=%d sysid=%d resp=%s",
+				"REGISTRATION", r.System, r.Protocol, r.SourceID, r.WACN, r.SystemID, r.Response)
+		}
+	case events.KindPatch:
+		body = fmt.Sprintf("%-12s %+v", "PATCH", ev.Payload)
+	case events.KindTalkerAlias:
+		if a, ok := ev.Payload.(trunking.TalkerAlias); ok {
+			body = fmt.Sprintf("%-12s system=%s src=%d alias=%q",
+				"TALKER-ALIAS", a.System, a.SourceID, a.Alias)
+		}
+	case events.KindLocation:
+		if l, ok := ev.Payload.(trunking.Location); ok {
+			body = fmt.Sprintf("%-12s system=%s proto=%s src=%d lat=%.6f lon=%.6f",
+				"LOCATION", l.System, l.Protocol, l.RadioID, l.Latitude, l.Longitude)
+		}
+	case events.KindDecodeError:
+		if d, ok := ev.Payload.(events.DecodeError); ok {
+			body = fmt.Sprintf("%-12s proto=%s stage=%s", "DECODE-ERR", d.Protocol, d.Stage)
+		}
+	case events.KindToneAlert:
+		body = fmt.Sprintf("%-12s %+v", "TONE-ALERT", ev.Payload)
+	default:
+		return ""
+	}
+	if body == "" {
+		return ""
+	}
+	return stamp + " " + body + "\n"
+}

--- a/internal/log/messagelog_test.go
+++ b/internal/log/messagelog_test.go
@@ -1,0 +1,109 @@
+package log
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+func TestMessageLogWritesEventLines(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "messages.log")
+	bus := events.NewBus(16)
+	defer bus.Close()
+
+	ml, err := NewMessageLog(MessageLogOptions{Bus: bus, Path: path})
+	if err != nil {
+		t.Fatalf("NewMessageLog: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	go ml.Run(ctx)
+
+	bus.Publish(events.Event{
+		Kind: events.KindGrant,
+		Payload: trunking.Grant{
+			System: "Metro", Protocol: "p25", GroupID: 1234, SourceID: 99,
+			FrequencyHz: 851_000_000,
+		},
+	})
+	bus.Publish(events.Event{
+		Kind: events.KindAffiliation,
+		Payload: trunking.Affiliation{
+			System: "Metro", Protocol: "dmr", SourceID: 7, GroupID: 50,
+		},
+	})
+
+	var data []byte
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		data, _ = os.ReadFile(path)
+		if strings.Contains(string(data), "GRANT") && strings.Contains(string(data), "AFFILIATION") {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	cancel()
+	ml.Close()
+
+	s := string(data)
+	if !strings.Contains(s, "GRANT") || !strings.Contains(s, "tg=1234") {
+		t.Fatalf("grant line missing from log:\n%s", s)
+	}
+	if !strings.Contains(s, "AFFILIATION") || !strings.Contains(s, "src=7") {
+		t.Fatalf("affiliation line missing from log:\n%s", s)
+	}
+}
+
+func TestMessageLogRotates(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "messages.log")
+	// Pre-fill the file past a 1 MiB cap so the next write rotates.
+	big := make([]byte, 1024*1024+10)
+	for i := range big {
+		big[i] = 'x'
+	}
+	if err := os.WriteFile(path, big, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	bus := events.NewBus(8)
+	defer bus.Close()
+	ml, err := NewMessageLog(MessageLogOptions{Bus: bus, Path: path, MaxSizeMB: 1})
+	if err != nil {
+		t.Fatalf("NewMessageLog: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	go ml.Run(ctx)
+
+	bus.Publish(events.Event{
+		Kind:    events.KindGrant,
+		Payload: trunking.Grant{System: "Metro", GroupID: 1},
+	})
+
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(path + ".1"); err == nil {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	cancel()
+	ml.Close()
+
+	if _, err := os.Stat(path + ".1"); err != nil {
+		t.Fatal("expected rotated file messages.log.1")
+	}
+}
+
+func TestMessageLogValidatesOptions(t *testing.T) {
+	if _, err := NewMessageLog(MessageLogOptions{Path: "x"}); err == nil {
+		t.Error("NewMessageLog without a bus should error")
+	}
+	if _, err := NewMessageLog(MessageLogOptions{Bus: events.NewBus(1)}); err == nil {
+		t.Error("NewMessageLog without a path should error")
+	}
+}

--- a/internal/radio/dmr/tier3/control.go
+++ b/internal/radio/dmr/tier3/control.go
@@ -49,6 +49,11 @@ type ControlChannel struct {
 	locked     bool
 	last       LockState
 
+	// restChannel tracks the LCN a Capacity Plus system currently
+	// advertises as its rest (control) channel. Zero until a
+	// Motorola vendor system-info CSBK has been seen.
+	restChannel uint8
+
 	// proc is the cross-call dibit / sync state the Process adapter
 	// uses (see process.go). Lazily constructed on the first
 	// Process call so tests that drive IngestBurst directly don't
@@ -114,6 +119,13 @@ func (c *ControlChannel) IngestBurst(b *dmr.Burst, slot dmr.SlotType) {
 }
 
 func (c *ControlChannel) handleCSBK(cc uint8, csbk CSBK) {
+	// Dispatch on FID before opcode: a vendor CSBK is routed to the
+	// vendor handler so its opcode is not misread against the
+	// standard ETSI opcode table.
+	if vendor := VendorFromFID(csbk.FID); vendor != VendorStandard {
+		c.handleVendorCSBK(vendor, cc, csbk)
+		return
+	}
 	switch csbk.Opcode {
 	case OpAloha:
 		c.maybeLock(LockState{FrequencyHz: c.freqHz, ColorCode: cc, SystemID: ParseAloha(csbk.Payload).SystemID})
@@ -129,60 +141,51 @@ func (c *ControlChannel) handleCSBK(cc uint8, csbk CSBK) {
 	}
 }
 
-func (c *ControlChannel) publishTVGrant(cc uint8, g TVGrant) {
-	freq, ok := c.resolveLCN(g.LCN)
+// publishGrant resolves an LCN to a downlink frequency and publishes a
+// voice grant on the bus. Shared by the standard and vendor CSBK
+// paths. Returns the resolved frequency and false when the LCN has no
+// band-plan entry (resolveLCN has already published the decode error).
+func (c *ControlChannel) publishGrant(cc, lcn uint8, group, source uint32, serviceOptions uint8) (uint32, bool) {
+	freq, ok := c.resolveLCN(lcn)
 	if !ok {
-		return
+		return 0, false
 	}
-	emergency := g.ServiceOptions&0x80 != 0
-	encrypted := g.ServiceOptions&0x40 != 0
 	c.bus.Publish(events.Event{
 		Kind: events.KindGrant,
 		Payload: trunking.Grant{
 			System:      c.systemName,
 			Protocol:    "dmr-tier3",
-			GroupID:     g.GroupAddress,
-			SourceID:    g.SourceID,
+			GroupID:     group,
+			SourceID:    source,
 			FrequencyHz: freq,
 			ChannelID:   cc,
-			ChannelNum:  uint16(g.LCN),
-			Encrypted:   encrypted,
-			Emergency:   emergency,
+			ChannelNum:  uint16(lcn),
+			Encrypted:   serviceOptions&0x40 != 0,
+			Emergency:   serviceOptions&0x80 != 0,
 			At:          c.now(),
 		},
 	})
+	return freq, true
+}
+
+func (c *ControlChannel) publishTVGrant(cc uint8, g TVGrant) {
+	freq, ok := c.publishGrant(cc, g.LCN, g.GroupAddress, g.SourceID, g.ServiceOptions)
+	if !ok {
+		return
+	}
 	c.log.Debug("dmr/tier3: tv-grant",
 		"system", c.systemName, "cc", cc, "tg", g.GroupAddress, "src", g.SourceID,
-		"lcn", g.LCN, "ts", g.Timeslot, "freq_hz", freq,
-		"enc", encrypted, "emer", emergency)
+		"lcn", g.LCN, "ts", g.Timeslot, "freq_hz", freq)
 }
 
 func (c *ControlChannel) publishPVGrant(cc uint8, g PVGrant) {
-	freq, ok := c.resolveLCN(g.LCN)
+	freq, ok := c.publishGrant(cc, g.LCN, g.DestinationID, g.SourceID, g.ServiceOptions)
 	if !ok {
 		return
 	}
-	emergency := g.ServiceOptions&0x80 != 0
-	encrypted := g.ServiceOptions&0x40 != 0
-	c.bus.Publish(events.Event{
-		Kind: events.KindGrant,
-		Payload: trunking.Grant{
-			System:      c.systemName,
-			Protocol:    "dmr-tier3",
-			GroupID:     g.DestinationID,
-			SourceID:    g.SourceID,
-			FrequencyHz: freq,
-			ChannelID:   cc,
-			ChannelNum:  uint16(g.LCN),
-			Encrypted:   encrypted,
-			Emergency:   emergency,
-			At:          c.now(),
-		},
-	})
 	c.log.Debug("dmr/tier3: pv-grant",
 		"system", c.systemName, "cc", cc, "dst", g.DestinationID, "src", g.SourceID,
-		"lcn", g.LCN, "ts", g.Timeslot, "freq_hz", freq,
-		"enc", encrypted, "emer", emergency)
+		"lcn", g.LCN, "ts", g.Timeslot, "freq_hz", freq)
 }
 
 func (c *ControlChannel) resolveLCN(lcn uint8) (uint32, bool) {

--- a/internal/radio/dmr/tier3/vendor.go
+++ b/internal/radio/dmr/tier3/vendor.go
@@ -1,0 +1,113 @@
+package tier3
+
+// DMR feature-set IDs (FID) — the second octet of a CSBK info block.
+// ETSI TS 102 361-4 reserves FID 0x00 for standard trunking; the major
+// MotoTRBO and Hytera trunking products tag their proprietary CSBKs
+// with a vendor FID. Dispatching on FID before opcode matters: a
+// vendor CSBK whose 6-bit opcode happens to collide with a standard
+// opcode (e.g. 0x30) would otherwise be misdecoded as a standard
+// TalkGroup Voice Channel Grant and produce a bogus trunking.Grant.
+const (
+	FIDStandard    uint8 = 0x00 // ETSI TS 102 361-4
+	FIDMotorola    uint8 = 0x10 // MotoTRBO: Capacity Plus / Capacity Max
+	FIDConnectPlus uint8 = 0x06 // Motorola Connect Plus
+	FIDHytera      uint8 = 0x08 // Hytera XPT
+	FIDHyteraAlt   uint8 = 0x68 // Hytera (alternate feature-set tag)
+)
+
+// Vendor identifies the trunking feature set behind a CSBK's FID.
+type Vendor uint8
+
+const (
+	VendorStandard Vendor = iota
+	VendorMotorola
+	VendorConnectPlus
+	VendorHytera
+)
+
+func (v Vendor) String() string {
+	switch v {
+	case VendorMotorola:
+		return "Motorola Capacity Plus/Max"
+	case VendorConnectPlus:
+		return "Motorola Connect Plus"
+	case VendorHytera:
+		return "Hytera XPT"
+	default:
+		return "ETSI standard"
+	}
+}
+
+// VendorFromFID maps a CSBK FID octet to its trunking vendor.
+func VendorFromFID(fid uint8) Vendor {
+	switch fid {
+	case FIDMotorola:
+		return VendorMotorola
+	case FIDConnectPlus:
+		return VendorConnectPlus
+	case FIDHytera, FIDHyteraAlt:
+		return VendorHytera
+	default:
+		return VendorStandard
+	}
+}
+
+// handleVendorCSBK dispatches a CSBK that carries a recognised vendor
+// FID. Capacity Plus / Capacity Max (Motorola FID 0x10) carry voice
+// grants in the ETSI-shaped 8-octet payload, so those decode through
+// the standard TVGrant / PVGrant parsers; the Capacity Plus rest
+// channel is tracked from its system-info CSBK. Connect Plus and
+// Hytera XPT use materially different proprietary signaling — their
+// CSBKs are recognised and logged here but NOT force-parsed as
+// standard grants, which would emit garbage. On-air capture
+// validation of the Connect Plus / XPT payload layouts is the
+// remaining follow-up.
+func (c *ControlChannel) handleVendorCSBK(vendor Vendor, cc uint8, csbk CSBK) {
+	switch vendor {
+	case VendorMotorola:
+		switch csbk.Opcode {
+		case OpTVGrant:
+			c.publishVendorTVGrant(vendor, cc, ParseTVGrant(csbk.Payload))
+		case OpPVGrant:
+			c.publishVendorPVGrant(vendor, cc, ParsePVGrant(csbk.Payload))
+		case OpSysInfo, OpAloha:
+			// Capacity Plus advertises its current rest channel in
+			// the system-info CSBK; the LCN field doubles as the
+			// rest-channel pointer.
+			rest := ParseSystemInfoBroadcast(csbk.Payload)
+			c.restChannel = rest.SiteID // LCN of the rest channel
+			c.maybeLock(LockState{FrequencyHz: c.freqHz, ColorCode: cc, SystemID: rest.SystemID})
+		default:
+			c.log.Debug("dmr/tier3: motorola vendor csbk",
+				"opcode", csbk.Opcode, "cc", cc)
+		}
+	case VendorConnectPlus, VendorHytera:
+		c.log.Debug("dmr/tier3: vendor csbk recognised (payload decode pending capture validation)",
+			"vendor", vendor.String(), "opcode", csbk.Opcode, "fid", csbk.FID, "cc", cc)
+	}
+}
+
+// publishVendorTVGrant emits a voice grant decoded from a vendor CSBK.
+// The Protocol stays "dmr-tier3" — vendor trunking changes the control
+// layer, not the voice codec, so the engine / recorder / vocoder paths
+// are unaffected.
+func (c *ControlChannel) publishVendorTVGrant(vendor Vendor, cc uint8, g TVGrant) {
+	freq, ok := c.publishGrant(cc, g.LCN, g.GroupAddress, g.SourceID, g.ServiceOptions)
+	if !ok {
+		return
+	}
+	c.log.Debug("dmr/tier3: vendor tv-grant",
+		"vendor", vendor.String(), "system", c.systemName, "cc", cc,
+		"tg", g.GroupAddress, "src", g.SourceID, "lcn", g.LCN, "freq_hz", freq)
+}
+
+// publishVendorPVGrant emits a private voice grant from a vendor CSBK.
+func (c *ControlChannel) publishVendorPVGrant(vendor Vendor, cc uint8, g PVGrant) {
+	freq, ok := c.publishGrant(cc, g.LCN, g.DestinationID, g.SourceID, g.ServiceOptions)
+	if !ok {
+		return
+	}
+	c.log.Debug("dmr/tier3: vendor pv-grant",
+		"vendor", vendor.String(), "system", c.systemName, "cc", cc,
+		"dst", g.DestinationID, "src", g.SourceID, "lcn", g.LCN, "freq_hz", freq)
+}

--- a/internal/radio/dmr/tier3/vendor_test.go
+++ b/internal/radio/dmr/tier3/vendor_test.go
@@ -1,0 +1,144 @@
+package tier3
+
+import (
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/dmr"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+func TestVendorFromFID(t *testing.T) {
+	cases := []struct {
+		fid  uint8
+		want Vendor
+	}{
+		{FIDStandard, VendorStandard},
+		{FIDMotorola, VendorMotorola},
+		{FIDConnectPlus, VendorConnectPlus},
+		{FIDHytera, VendorHytera},
+		{FIDHyteraAlt, VendorHytera},
+		{0x7F, VendorStandard},
+	}
+	for _, c := range cases {
+		if got := VendorFromFID(c.fid); got != c.want {
+			t.Errorf("VendorFromFID(%#x) = %v, want %v", c.fid, got, c.want)
+		}
+	}
+}
+
+// tvGrantPayload builds the 8-octet TVGrant CSBK payload.
+func tvGrantPayload(group, source uint32, lcn uint8) [8]byte {
+	return [8]byte{
+		0x00,
+		byte(group >> 16), byte(group >> 8), byte(group),
+		byte(source >> 16), byte(source >> 8), byte(source),
+		lcn & 0x7F,
+	}
+}
+
+func TestMotorolaVendorGrantEmitted(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{
+		Bus:         bus,
+		FrequencyHz: 851_000_000,
+		Resolver:    TableBandPlan{4: 462_550_000},
+	})
+	// Motorola Capacity Plus/Max voice grant: FID 0x10, ETSI-shaped
+	// 8-octet payload.
+	csbk := CSBK{
+		LB:      true,
+		Opcode:  OpTVGrant,
+		FID:     FIDMotorola,
+		Payload: tvGrantPayload(0x1234, 0x5678, 4),
+	}
+	cc.IngestBurst(burstWithCSBK(csbk), dmr.SlotType{ColorCode: 1, DataType: dmr.DTCSBK})
+
+	select {
+	case ev := <-sub.C:
+		if ev.Kind != events.KindGrant {
+			t.Fatalf("kind = %s, want grant", ev.Kind)
+		}
+		g := ev.Payload.(trunking.Grant)
+		if g.GroupID != 0x1234 || g.SourceID != 0x5678 {
+			t.Errorf("grant ids = tg %d src %d", g.GroupID, g.SourceID)
+		}
+		if g.FrequencyHz != 462_550_000 {
+			t.Errorf("grant freq = %d, want 462550000", g.FrequencyHz)
+		}
+		if g.Protocol != "dmr-tier3" {
+			t.Errorf("grant protocol = %q", g.Protocol)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("no grant event from a Motorola vendor CSBK")
+	}
+}
+
+// TestVendorCSBKNotMisparsedAsStandard is the regression guard for the
+// FID-aware dispatch: a Connect Plus CSBK whose opcode collides with
+// the standard TalkGroup Voice Channel Grant must NOT be force-decoded
+// into a (garbage) standard grant.
+func TestVendorCSBKNotMisparsedAsStandard(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{
+		Bus:         bus,
+		FrequencyHz: 851_000_000,
+		Resolver:    TableBandPlan{4: 462_550_000}, // would resolve if misparsed
+	})
+	csbk := CSBK{
+		LB:      true,
+		Opcode:  OpTVGrant, // 0x30 — collides with the standard opcode
+		FID:     FIDConnectPlus,
+		Payload: tvGrantPayload(0x1234, 0x5678, 4),
+	}
+	cc.IngestBurst(burstWithCSBK(csbk), dmr.SlotType{ColorCode: 1, DataType: dmr.DTCSBK})
+
+	select {
+	case ev := <-sub.C:
+		t.Fatalf("vendor CSBK produced an event %s — should have been routed to the vendor handler", ev.Kind)
+	case <-time.After(150 * time.Millisecond):
+		// No event: the FID-aware dispatch correctly withheld a
+		// standard grant for an unvalidated vendor payload.
+	}
+}
+
+func TestMotorolaVendorSysInfoLocks(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, FrequencyHz: 851_000_000})
+	csbk := CSBK{
+		LB:      true,
+		Opcode:  OpSysInfo,
+		FID:     FIDMotorola,
+		Payload: [8]byte{0xCA, 0xFE, 0x01, 0x07, 0xFF, 0, 0, 0},
+	}
+	cc.IngestBurst(burstWithCSBK(csbk), dmr.SlotType{ColorCode: 3, DataType: dmr.DTCSBK})
+
+	select {
+	case ev := <-sub.C:
+		if ev.Kind != events.KindCCLocked {
+			t.Fatalf("kind = %s, want cc.locked", ev.Kind)
+		}
+		if ls := ev.Payload.(LockState); ls.SystemID != 0xCAFE {
+			t.Errorf("system id = %#x, want 0xCAFE", ls.SystemID)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("no lock event from a Motorola vendor system-info CSBK")
+	}
+	// The rest channel is taken from the system-info SiteID octet.
+	if cc.restChannel != 0x07 {
+		t.Errorf("rest channel = %d, want 7", cc.restChannel)
+	}
+}

--- a/internal/radio/location/nmea.go
+++ b/internal/radio/location/nmea.go
@@ -1,0 +1,177 @@
+// Package location decodes geographic positions reported over the air
+// by trunked-radio subscriber units — P25 Motorola Unit GPS, L3Harris
+// Talker GPS, and DMR LRRP all ultimately carry a latitude/longitude
+// pair, and several (Tait CCDI, many MOTOTRBO GPS profiles) transport
+// it as a verbatim NMEA-0183 sentence.
+//
+// This file implements a strict NMEA-0183 parser for the two sentence
+// types that carry a fix — GGA and RMC. It is the protocol-agnostic
+// core the per-protocol decoders feed once they have extracted the
+// text/data payload of a GPS message.
+package location
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Position is a decoded geographic fix. Latitude is positive north,
+// Longitude positive east, both in decimal degrees.
+type Position struct {
+	Latitude   float64
+	Longitude  float64
+	SpeedKnots float64
+	HeadingDeg float64
+	HasSpeed   bool
+	HasHeading bool
+}
+
+// Valid reports whether the fix is within the geographic coordinate
+// range. A (0,0) fix is treated as invalid — it is the overwhelmingly
+// common "no fix yet" placeholder, and Null Island is in open ocean.
+func (p Position) Valid() bool {
+	if p.Latitude == 0 && p.Longitude == 0 {
+		return false
+	}
+	return p.Latitude >= -90 && p.Latitude <= 90 &&
+		p.Longitude >= -180 && p.Longitude <= 180
+}
+
+// ErrNoFix is returned when a sentence parses cleanly but carries no
+// usable position (empty coordinate fields, or an RMC "void" status).
+var ErrNoFix = errors.New("location: sentence carries no position fix")
+
+// ParseNMEA decodes a single NMEA-0183 sentence. GGA and RMC sentences
+// (any talker ID — GP, GN, GL, …) yield a Position; the optional
+// trailing "*hh" checksum is verified when present.
+func ParseNMEA(sentence string) (Position, error) {
+	s := strings.TrimSpace(sentence)
+	if !strings.HasPrefix(s, "$") {
+		return Position{}, errors.New("location: NMEA sentence must start with '$'")
+	}
+	s = s[1:]
+
+	if star := strings.IndexByte(s, '*'); star >= 0 {
+		body := s[:star]
+		sum := strings.TrimSpace(s[star+1:])
+		if len(sum) >= 2 {
+			want, err := strconv.ParseUint(sum[:2], 16, 8)
+			if err != nil {
+				return Position{}, fmt.Errorf("location: bad NMEA checksum %q", sum)
+			}
+			if got := nmeaChecksum(body); byte(want) != got {
+				return Position{}, fmt.Errorf("location: NMEA checksum mismatch (got %02X, want %02X)", got, want)
+			}
+		}
+		s = body
+	}
+
+	fields := strings.Split(s, ",")
+	if len(fields) == 0 || len(fields[0]) < 5 {
+		return Position{}, errors.New("location: malformed NMEA sentence")
+	}
+	switch fields[0][2:] {
+	case "GGA":
+		return parseGGA(fields)
+	case "RMC":
+		return parseRMC(fields)
+	default:
+		return Position{}, fmt.Errorf("location: unsupported NMEA sentence %q", fields[0])
+	}
+}
+
+// parseGGA decodes a GGA (fix data) sentence: lat in field 2, N/S in
+// 3, lon in 4, E/W in 5.
+func parseGGA(f []string) (Position, error) {
+	if len(f) < 6 {
+		return Position{}, errors.New("location: short GGA sentence")
+	}
+	lat, lon, err := decodeLatLon(f[2], f[3], f[4], f[5])
+	if err != nil {
+		return Position{}, err
+	}
+	return Position{Latitude: lat, Longitude: lon}, nil
+}
+
+// parseRMC decodes an RMC (recommended minimum) sentence: status in
+// field 2 ('A' valid / 'V' void), lat 3, N/S 4, lon 5, E/W 6, speed
+// (knots) 7, course 8.
+func parseRMC(f []string) (Position, error) {
+	if len(f) < 9 {
+		return Position{}, errors.New("location: short RMC sentence")
+	}
+	if strings.EqualFold(f[2], "V") {
+		return Position{}, ErrNoFix
+	}
+	lat, lon, err := decodeLatLon(f[3], f[4], f[5], f[6])
+	if err != nil {
+		return Position{}, err
+	}
+	p := Position{Latitude: lat, Longitude: lon}
+	if f[7] != "" {
+		if spd, err := strconv.ParseFloat(f[7], 64); err == nil {
+			p.SpeedKnots = spd
+			p.HasSpeed = true
+		}
+	}
+	if f[8] != "" {
+		if hdg, err := strconv.ParseFloat(f[8], 64); err == nil {
+			p.HeadingDeg = hdg
+			p.HasHeading = true
+		}
+	}
+	return p, nil
+}
+
+// decodeLatLon converts the NMEA ddmm.mmmm / dddmm.mmmm coordinate
+// pair plus hemisphere letters into signed decimal degrees.
+func decodeLatLon(latStr, ns, lonStr, ew string) (float64, float64, error) {
+	if latStr == "" || lonStr == "" {
+		return 0, 0, ErrNoFix
+	}
+	lat, err := nmeaDegrees(latStr, 2)
+	if err != nil {
+		return 0, 0, fmt.Errorf("location: latitude: %w", err)
+	}
+	lon, err := nmeaDegrees(lonStr, 3)
+	if err != nil {
+		return 0, 0, fmt.Errorf("location: longitude: %w", err)
+	}
+	if strings.EqualFold(ns, "S") {
+		lat = -lat
+	}
+	if strings.EqualFold(ew, "W") {
+		lon = -lon
+	}
+	return lat, lon, nil
+}
+
+// nmeaDegrees converts an NMEA "(d)ddmm.mmmm" string to decimal
+// degrees. degDigits is the count of leading degree digits (2 for
+// latitude, 3 for longitude).
+func nmeaDegrees(s string, degDigits int) (float64, error) {
+	if len(s) < degDigits {
+		return 0, fmt.Errorf("coordinate %q too short", s)
+	}
+	deg, err := strconv.ParseFloat(s[:degDigits], 64)
+	if err != nil {
+		return 0, err
+	}
+	min, err := strconv.ParseFloat(s[degDigits:], 64)
+	if err != nil {
+		return 0, err
+	}
+	return deg + min/60, nil
+}
+
+// nmeaChecksum XORs every byte of an NMEA sentence body (the text
+// between '$' and '*').
+func nmeaChecksum(body string) byte {
+	var c byte
+	for i := 0; i < len(body); i++ {
+		c ^= body[i]
+	}
+	return c
+}

--- a/internal/radio/location/nmea_test.go
+++ b/internal/radio/location/nmea_test.go
@@ -1,0 +1,93 @@
+package location
+
+import (
+	"errors"
+	"math"
+	"testing"
+)
+
+func approx(a, b float64) bool { return math.Abs(a-b) < 1e-3 }
+
+func TestParseGGA(t *testing.T) {
+	p, err := ParseNMEA("$GPGGA,123519,4807.038,N,01131.000,E,1,08,0.9,545.4,M,46.9,M,,*47")
+	if err != nil {
+		t.Fatalf("ParseNMEA GGA: %v", err)
+	}
+	if !approx(p.Latitude, 48.1173) {
+		t.Errorf("latitude = %f, want ~48.1173", p.Latitude)
+	}
+	if !approx(p.Longitude, 11.516667) {
+		t.Errorf("longitude = %f, want ~11.5167", p.Longitude)
+	}
+	if !p.Valid() {
+		t.Error("fix should be valid")
+	}
+}
+
+func TestParseRMC(t *testing.T) {
+	p, err := ParseNMEA("$GPRMC,123519,A,4807.038,N,01131.000,E,022.4,084.4,230394,003.1,W*6A")
+	if err != nil {
+		t.Fatalf("ParseNMEA RMC: %v", err)
+	}
+	if !approx(p.Latitude, 48.1173) || !approx(p.Longitude, 11.516667) {
+		t.Errorf("coords = %f,%f", p.Latitude, p.Longitude)
+	}
+	if !p.HasSpeed || !approx(p.SpeedKnots, 22.4) {
+		t.Errorf("speed = %f (has=%v)", p.SpeedKnots, p.HasSpeed)
+	}
+	if !p.HasHeading || !approx(p.HeadingDeg, 84.4) {
+		t.Errorf("heading = %f (has=%v)", p.HeadingDeg, p.HasHeading)
+	}
+}
+
+func TestParseRMCSouthWest(t *testing.T) {
+	// Same magnitudes, southern + western hemispheres → negative.
+	p, err := ParseNMEA("$GPRMC,123519,A,4807.038,S,01131.000,W,000.0,000.0,230394,,*12")
+	if err != nil {
+		t.Fatalf("ParseNMEA: %v", err)
+	}
+	if p.Latitude >= 0 || p.Longitude >= 0 {
+		t.Errorf("S/W hemispheres should be negative: %f,%f", p.Latitude, p.Longitude)
+	}
+}
+
+func TestParseRMCVoidStatus(t *testing.T) {
+	_, err := ParseNMEA("$GPRMC,,V,,,,,,,,,,N")
+	if !errors.Is(err, ErrNoFix) {
+		t.Fatalf("void RMC error = %v, want ErrNoFix", err)
+	}
+}
+
+func TestParseNMEAChecksumMismatch(t *testing.T) {
+	// Valid body, wrong checksum byte.
+	_, err := ParseNMEA("$GPGGA,123519,4807.038,N,01131.000,E,1,08,0.9,545.4,M,46.9,M,,*00")
+	if err == nil {
+		t.Fatal("a bad checksum should be rejected")
+	}
+}
+
+func TestParseNMEARejects(t *testing.T) {
+	cases := []string{
+		"GPGGA,no,dollar",
+		"$GPXYZ,unsupported",
+		"",
+		"$",
+	}
+	for _, c := range cases {
+		if _, err := ParseNMEA(c); err == nil {
+			t.Errorf("ParseNMEA(%q) should error", c)
+		}
+	}
+}
+
+func TestPositionValid(t *testing.T) {
+	if (Position{}).Valid() {
+		t.Error("zero position (Null Island) must be invalid")
+	}
+	if (Position{Latitude: 91, Longitude: 0}).Valid() {
+		t.Error("out-of-range latitude must be invalid")
+	}
+	if !(Position{Latitude: 40.7, Longitude: -74}).Valid() {
+		t.Error("a real fix must be valid")
+	}
+}

--- a/internal/sdr/baseband/baseband_test.go
+++ b/internal/sdr/baseband/baseband_test.go
@@ -1,0 +1,209 @@
+package baseband
+
+import (
+	"context"
+	"math"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/sdr"
+)
+
+// iqTone builds n IQ samples of a complex exponential.
+func iqTone(n int) []complex64 {
+	s := make([]complex64, n)
+	for i := range s {
+		ph := 2 * math.Pi * 0.05 * float64(i)
+		s[i] = complex(float32(0.6*math.Cos(ph)), float32(0.6*math.Sin(ph)))
+	}
+	return s
+}
+
+func TestIQWriterRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "cap.wav")
+	samples := iqTone(4000)
+
+	w, err := NewIQWriter(path, 2_400_000)
+	if err != nil {
+		t.Fatalf("NewIQWriter: %v", err)
+	}
+	if err := w.Write(samples); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	info, err := ReadIQWavInfo(path)
+	if err != nil {
+		t.Fatalf("ReadIQWavInfo: %v", err)
+	}
+	if info.SampleRate != 2_400_000 {
+		t.Fatalf("sample rate = %d, want 2400000", info.SampleRate)
+	}
+	if info.Channels != 2 {
+		t.Fatalf("channels = %d, want 2", info.Channels)
+	}
+	if info.Samples != len(samples) {
+		t.Fatalf("samples = %d, want %d", info.Samples, len(samples))
+	}
+}
+
+func TestIQWriterRejectsZeroRate(t *testing.T) {
+	if _, err := NewIQWriter(filepath.Join(t.TempDir(), "x.wav"), 0); err == nil {
+		t.Fatal("NewIQWriter with rate 0 should error")
+	}
+}
+
+// fakeDevice is a minimal sdr.Device that emits a fixed chunk list.
+type fakeDevice struct {
+	info   sdr.Info
+	rate   uint32
+	chunks [][]complex64
+}
+
+func (f *fakeDevice) Info() sdr.Info             { return f.info }
+func (f *fakeDevice) SetCenterFreq(uint32) error { return nil }
+func (f *fakeDevice) SetGain(int) error          { return nil }
+func (f *fakeDevice) SetPPM(int) error           { return nil }
+func (f *fakeDevice) SetBiasTee(bool) error      { return nil }
+func (f *fakeDevice) Close() error               { return nil }
+func (f *fakeDevice) SetSampleRate(hz uint32) error {
+	f.rate = hz
+	return nil
+}
+func (f *fakeDevice) StreamIQ(ctx context.Context) (<-chan []complex64, error) {
+	out := make(chan []complex64)
+	go func() {
+		defer close(out)
+		for _, c := range f.chunks {
+			select {
+			case out <- c:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+	return out, nil
+}
+
+func TestRecordingDeviceTeesToWav(t *testing.T) {
+	dir := t.TempDir()
+	inner := &fakeDevice{
+		info:   sdr.Info{Serial: "00000111"},
+		chunks: [][]complex64{iqTone(1000), iqTone(1000), iqTone(500)},
+	}
+	rec := NewRecordingDevice(inner, dir, nil)
+	if err := rec.SetSampleRate(2_400_000); err != nil {
+		t.Fatalf("SetSampleRate: %v", err)
+	}
+
+	ch, err := rec.StreamIQ(context.Background())
+	if err != nil {
+		t.Fatalf("StreamIQ: %v", err)
+	}
+	forwarded := 0
+	for chunk := range ch {
+		forwarded += len(chunk)
+	}
+	if forwarded != 2500 {
+		t.Fatalf("forwarded %d samples, want 2500", forwarded)
+	}
+
+	// The recorder closes the WAV when the inner stream ends; give the
+	// teardown goroutine a moment to flush.
+	var info IQWavInfo
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		matches, _ := filepath.Glob(filepath.Join(dir, "00000111_*.wav"))
+		if len(matches) == 1 {
+			if i, err := ReadIQWavInfo(matches[0]); err == nil && i.Samples == 2500 {
+				info = i
+				break
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if info.Samples != 2500 {
+		t.Fatalf("recorded WAV has %d samples, want 2500", info.Samples)
+	}
+	if info.SampleRate != 2_400_000 {
+		t.Fatalf("recorded WAV rate = %d, want 2400000", info.SampleRate)
+	}
+}
+
+func TestFileDriverEnumerateAndReplay(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "replay.wav")
+	w, _ := NewIQWriter(path, 2_400_000)
+	w.Write(iqTone(20000))
+	w.Close()
+
+	drv := NewFileDriver([]ReplaySpec{{Path: path, Serial: "replay-test", Loop: false}})
+	infos, err := drv.Enumerate()
+	if err != nil {
+		t.Fatalf("Enumerate: %v", err)
+	}
+	if len(infos) != 1 || infos[0].Serial != "replay-test" {
+		t.Fatalf("Enumerate = %+v", infos)
+	}
+
+	dev, err := drv.Open(0)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	ch, err := dev.StreamIQ(ctx)
+	if err != nil {
+		t.Fatalf("StreamIQ: %v", err)
+	}
+	got := 0
+	for chunk := range ch { // non-looping: channel closes at EOF
+		got += len(chunk)
+	}
+	if got != 20000 {
+		t.Fatalf("replayed %d samples, want 20000", got)
+	}
+}
+
+func TestFileDriverLoops(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "loop.wav")
+	w, _ := NewIQWriter(path, 2_400_000)
+	w.Write(iqTone(2000))
+	w.Close()
+
+	drv := NewFileDriver([]ReplaySpec{{Path: path, Loop: true}})
+	dev, err := drv.Open(0)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	ch, err := dev.StreamIQ(ctx)
+	if err != nil {
+		t.Fatalf("StreamIQ: %v", err)
+	}
+	// A looping replay never closes the channel; collect more samples
+	// than the file holds, proving it restarted.
+	got := 0
+	deadline := time.After(4 * time.Second)
+	for got <= 2000 {
+		select {
+		case chunk, ok := <-ch:
+			if !ok {
+				t.Fatal("looping replay closed the channel")
+			}
+			got += len(chunk)
+		case <-deadline:
+			t.Fatalf("only %d samples before deadline, want > 2000", got)
+		}
+	}
+	cancel()
+}
+
+func TestFileDriverOpenRejectsBadIndex(t *testing.T) {
+	drv := NewFileDriver(nil)
+	if _, err := drv.Open(0); err == nil {
+		t.Fatal("Open on an empty driver should error")
+	}
+}

--- a/internal/sdr/baseband/driver.go
+++ b/internal/sdr/baseband/driver.go
@@ -1,0 +1,210 @@
+package baseband
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/sdr"
+)
+
+// FileDriverName is the sdr.Driver name for baseband replay devices.
+const FileDriverName = "baseband-replay"
+
+// ReplaySpec names one baseband WAV recording to mount as a virtual
+// tuner. Path is required; Serial defaults to a generated value and
+// Loop (default true) restarts the recording on EOF so an offline
+// tuner behaves like a continuous source.
+type ReplaySpec struct {
+	Path   string
+	Serial string
+	Loop   bool
+}
+
+// FileDriver mounts baseband WAV recordings as virtual sdr.Devices so
+// they can be opened by the pool exactly like real tuners. Register an
+// instance with sdr.Register before Pool.Open.
+type FileDriver struct {
+	specs []ReplaySpec
+}
+
+// NewFileDriver builds a replay driver over the given recordings.
+func NewFileDriver(specs []ReplaySpec) *FileDriver {
+	return &FileDriver{specs: specs}
+}
+
+// Name implements sdr.Driver.
+func (d *FileDriver) Name() string { return FileDriverName }
+
+// Enumerate validates each recording's header and returns one Info per
+// playable file. A recording that fails to parse is skipped.
+func (d *FileDriver) Enumerate() ([]sdr.Info, error) {
+	var out []sdr.Info
+	for i, spec := range d.specs {
+		if _, err := ReadIQWavInfo(spec.Path); err != nil {
+			continue
+		}
+		out = append(out, sdr.Info{
+			Driver:    FileDriverName,
+			Index:     i,
+			Serial:    replaySerial(spec, i),
+			Product:   "BasebandReplay",
+			TunerName: "file",
+			Gains:     []int{0},
+		})
+	}
+	return out, nil
+}
+
+// Open returns a replay device for the spec at idx.
+func (d *FileDriver) Open(idx int) (sdr.Device, error) {
+	if idx < 0 || idx >= len(d.specs) {
+		return nil, fmt.Errorf("baseband: replay index %d out of range", idx)
+	}
+	spec := d.specs[idx]
+	info, err := ReadIQWavInfo(spec.Path)
+	if err != nil {
+		return nil, fmt.Errorf("baseband: %s: %w", spec.Path, err)
+	}
+	return &replayDevice{
+		path: spec.Path,
+		loop: spec.Loop,
+		info: sdr.Info{
+			Driver:    FileDriverName,
+			Index:     idx,
+			Serial:    replaySerial(spec, idx),
+			Product:   "BasebandReplay",
+			TunerName: "file",
+		},
+		wavRate: info.SampleRate,
+		rate:    info.SampleRate,
+	}, nil
+}
+
+func replaySerial(spec ReplaySpec, idx int) string {
+	if spec.Serial != "" {
+		return spec.Serial
+	}
+	return fmt.Sprintf("replay-%02d", idx)
+}
+
+// replayDevice streams a baseband WAV recording as IQ. SetSampleRate
+// overrides the metering rate; otherwise the WAV's native rate is used.
+type replayDevice struct {
+	path    string
+	loop    bool
+	info    sdr.Info
+	wavRate uint32
+
+	mu   sync.Mutex
+	rate uint32
+}
+
+func (d *replayDevice) Info() sdr.Info             { return d.info }
+func (d *replayDevice) SetCenterFreq(uint32) error { return nil }
+func (d *replayDevice) SetGain(int) error          { return nil }
+func (d *replayDevice) SetPPM(int) error           { return nil }
+func (d *replayDevice) SetBiasTee(bool) error      { return nil }
+func (d *replayDevice) Close() error               { return nil }
+
+// SetSampleRate overrides the metering rate. A real-time replay needs
+// this to match the recording's rate; the daemon documents that
+// sdr.sample_rate should equal the recording rate.
+func (d *replayDevice) SetSampleRate(hz uint32) error {
+	d.mu.Lock()
+	if hz != 0 {
+		d.rate = hz
+	}
+	d.mu.Unlock()
+	return nil
+}
+
+// StreamIQ replays the recording, metered to the configured rate, and
+// loops on EOF when Loop is set.
+func (d *replayDevice) StreamIQ(ctx context.Context) (<-chan []complex64, error) {
+	f, err := os.Open(d.path)
+	if err != nil {
+		return nil, err
+	}
+	dataBytes, _, err := parseIQWavHeader(f)
+	if err != nil {
+		f.Close()
+		return nil, err
+	}
+	dataStart, err := f.Seek(0, io.SeekCurrent)
+	if err != nil {
+		f.Close()
+		return nil, err
+	}
+	d.mu.Lock()
+	rate := d.rate
+	d.mu.Unlock()
+	if rate == 0 {
+		rate = d.wavRate
+	}
+	if rate == 0 {
+		rate = sdr.DefaultSampleRateHz
+	}
+
+	const chunkSamples = 8192
+	out := make(chan []complex64, 8)
+	go func() {
+		defer close(out)
+		defer f.Close()
+		buf := make([]byte, chunkSamples*iqWavBlockAlign)
+		interval := time.Duration(float64(time.Second) * float64(chunkSamples) / float64(rate))
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		remaining := int64(dataBytes)
+		for {
+			if remaining <= 0 {
+				if !d.loop {
+					return
+				}
+				if _, err := f.Seek(dataStart, io.SeekStart); err != nil {
+					return
+				}
+				remaining = int64(dataBytes)
+			}
+			want := int64(len(buf))
+			if want > remaining {
+				want = remaining
+			}
+			n, err := io.ReadFull(f, buf[:want])
+			if err != nil && !errors.Is(err, io.EOF) && !errors.Is(err, io.ErrUnexpectedEOF) {
+				return
+			}
+			remaining -= int64(n)
+			if n > 0 {
+				select {
+				case out <- decodeIQ16(buf[:n]):
+				case <-ctx.Done():
+					return
+				}
+			}
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+			}
+		}
+	}()
+	return out, nil
+}
+
+// decodeIQ16 converts interleaved 16-bit I/Q PCM into complex64.
+func decodeIQ16(buf []byte) []complex64 {
+	n := len(buf) / iqWavBlockAlign
+	out := make([]complex64, n)
+	for i := 0; i < n; i++ {
+		iv := int16(binary.LittleEndian.Uint16(buf[4*i:]))
+		qv := int16(binary.LittleEndian.Uint16(buf[4*i+2:]))
+		out[i] = complex(float32(iv)/32768, float32(qv)/32768)
+	}
+	return out
+}

--- a/internal/sdr/baseband/recorder.go
+++ b/internal/sdr/baseband/recorder.go
@@ -1,0 +1,132 @@
+package baseband
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/sdr"
+)
+
+// RecordingDevice wraps an sdr.Device and tees its IQ stream to a
+// wideband WAV recording while passing every sample through to the
+// normal consumer unchanged. A fresh WAV is opened each time StreamIQ
+// is called and closed when that stream ends.
+type RecordingDevice struct {
+	inner sdr.Device
+	dir   string
+	log   *slog.Logger
+
+	mu   sync.Mutex
+	rate uint32
+}
+
+// NewRecordingDevice wraps inner so its IQ is recorded into dir.
+func NewRecordingDevice(inner sdr.Device, dir string, log *slog.Logger) *RecordingDevice {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &RecordingDevice{inner: inner, dir: dir, log: log}
+}
+
+// Inner returns the wrapped device.
+func (r *RecordingDevice) Inner() sdr.Device { return r.inner }
+
+func (r *RecordingDevice) Info() sdr.Info                { return r.inner.Info() }
+func (r *RecordingDevice) SetCenterFreq(hz uint32) error { return r.inner.SetCenterFreq(hz) }
+func (r *RecordingDevice) SetGain(tenthDB int) error     { return r.inner.SetGain(tenthDB) }
+func (r *RecordingDevice) SetPPM(ppm int) error          { return r.inner.SetPPM(ppm) }
+func (r *RecordingDevice) SetBiasTee(enable bool) error  { return r.inner.SetBiasTee(enable) }
+func (r *RecordingDevice) Close() error                  { return r.inner.Close() }
+
+// SetSampleRate records the rate (for the WAV header) and forwards it.
+func (r *RecordingDevice) SetSampleRate(hz uint32) error {
+	r.mu.Lock()
+	r.rate = hz
+	r.mu.Unlock()
+	return r.inner.SetSampleRate(hz)
+}
+
+// StreamIQ starts the wrapped device's stream, opens a recording WAV,
+// and returns a channel that forwards every chunk while writing it to
+// disk. A recording-open failure is logged and degrades gracefully —
+// the inner stream is returned unrecorded rather than failing.
+func (r *RecordingDevice) StreamIQ(ctx context.Context) (<-chan []complex64, error) {
+	in, err := r.inner.StreamIQ(ctx)
+	if err != nil {
+		return nil, err
+	}
+	r.mu.Lock()
+	rate := r.rate
+	r.mu.Unlock()
+	if rate == 0 {
+		rate = sdr.DefaultSampleRateHz
+	}
+
+	if err := os.MkdirAll(r.dir, 0o755); err != nil {
+		r.log.Warn("baseband: cannot create recording dir; streaming unrecorded",
+			"dir", r.dir, "err", err)
+		return in, nil
+	}
+	path := filepath.Join(r.dir, recordingName(r.inner.Info().Serial))
+	w, err := NewIQWriter(path, rate)
+	if err != nil {
+		r.log.Warn("baseband: cannot open recording; streaming unrecorded",
+			"path", path, "err", err)
+		return in, nil
+	}
+	r.log.Info("baseband: recording started", "path", path, "rate_hz", rate)
+
+	out := make(chan []complex64, 8)
+	go func() {
+		defer close(out)
+		defer func() {
+			if err := w.Close(); err != nil {
+				r.log.Warn("baseband: close recording", "path", path, "err", err)
+			} else {
+				r.log.Info("baseband: recording stopped",
+					"path", path, "bytes", w.BytesWritten())
+			}
+		}()
+		for chunk := range in {
+			if err := w.Write(chunk); err != nil {
+				r.log.Warn("baseband: recording write failed; continuing unrecorded",
+					"path", path, "err", err)
+			}
+			select {
+			case out <- chunk:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+	return out, nil
+}
+
+// recordingName builds a per-stream filename: serial + UTC timestamp.
+func recordingName(serial string) string {
+	s := sanitize(serial)
+	if s == "" {
+		s = "sdr"
+	}
+	return s + "_" + time.Now().UTC().Format("20060102T150405Z") + ".wav"
+}
+
+// sanitize strips path-hostile characters from a serial.
+func sanitize(s string) string {
+	s = strings.TrimSpace(s)
+	return strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+			return r
+		case r == '-' || r == '_':
+			return r
+		default:
+			return '_'
+		}
+	}, s)
+}

--- a/internal/sdr/baseband/wav.go
+++ b/internal/sdr/baseband/wav.go
@@ -1,0 +1,209 @@
+// Package baseband adds wideband IQ recording and offline replay to
+// the SDR layer. A RecordingDevice tees a live device's IQ stream to a
+// WAV file; a FileDriver mounts those recordings (and SDRtrunk's, which
+// use the same layout) back into the pool as virtual tuners.
+//
+// The on-disk format matches SDRtrunk's baseband recordings: a
+// canonical RIFF/WAVE file with two 16-bit signed PCM channels — the
+// in-phase sample in channel 1, the quadrature sample in channel 2 —
+// at the IQ sample rate.
+package baseband
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+)
+
+const (
+	iqWavHeaderSize    = 44
+	iqWavChannels      = 2
+	iqWavBitsPerSample = 16
+	iqWavBlockAlign    = iqWavChannels * iqWavBitsPerSample / 8 // 4 bytes/frame
+)
+
+// IQWriter streams complex64 IQ samples to a two-channel 16-bit WAV.
+// The RIFF/data length fields are patched on Close so a daemon crash
+// still leaves a readable (if short) recording behind.
+type IQWriter struct {
+	f            *os.File
+	sampleRate   uint32
+	bytesWritten uint32
+	closed       bool
+}
+
+// NewIQWriter creates (or truncates) path and writes the WAV header.
+func NewIQWriter(path string, sampleRate uint32) (*IQWriter, error) {
+	if sampleRate == 0 {
+		return nil, errors.New("baseband: IQ WAV sample rate must be > 0")
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		return nil, err
+	}
+	w := &IQWriter{f: f, sampleRate: sampleRate}
+	if err := w.writeHeader(); err != nil {
+		f.Close()
+		return nil, err
+	}
+	return w, nil
+}
+
+// Write appends a block of IQ samples. Each complex64 is clamped to
+// [-1, 1] and scaled to a signed 16-bit pair (I, Q).
+func (w *IQWriter) Write(samples []complex64) error {
+	if w.closed {
+		return errors.New("baseband: IQ writer is closed")
+	}
+	if len(samples) == 0 {
+		return nil
+	}
+	buf := make([]byte, iqWavBlockAlign*len(samples))
+	for i, s := range samples {
+		binary.LittleEndian.PutUint16(buf[4*i:], uint16(floatToI16(real(s))))
+		binary.LittleEndian.PutUint16(buf[4*i+2:], uint16(floatToI16(imag(s))))
+	}
+	n, err := w.f.Write(buf)
+	w.bytesWritten += uint32(n)
+	return err
+}
+
+// BytesWritten reports the IQ payload bytes written so far.
+func (w *IQWriter) BytesWritten() uint32 { return w.bytesWritten }
+
+// Close patches the length fields and closes the file.
+func (w *IQWriter) Close() error {
+	if w.closed {
+		return nil
+	}
+	w.closed = true
+	if err := w.patchHeader(); err != nil {
+		w.f.Close()
+		return err
+	}
+	return w.f.Close()
+}
+
+func (w *IQWriter) writeHeader() error {
+	h := make([]byte, iqWavHeaderSize)
+	copy(h[0:4], "RIFF")
+	copy(h[8:12], "WAVE")
+	copy(h[12:16], "fmt ")
+	binary.LittleEndian.PutUint32(h[16:20], 16)
+	binary.LittleEndian.PutUint16(h[20:22], 1) // PCM
+	binary.LittleEndian.PutUint16(h[22:24], iqWavChannels)
+	binary.LittleEndian.PutUint32(h[24:28], w.sampleRate)
+	binary.LittleEndian.PutUint32(h[28:32], w.sampleRate*iqWavBlockAlign)
+	binary.LittleEndian.PutUint16(h[32:34], iqWavBlockAlign)
+	binary.LittleEndian.PutUint16(h[34:36], iqWavBitsPerSample)
+	copy(h[36:40], "data")
+	_, err := w.f.Write(h)
+	return err
+}
+
+func (w *IQWriter) patchHeader() error {
+	if _, err := w.f.Seek(4, io.SeekStart); err != nil {
+		return err
+	}
+	if err := binary.Write(w.f, binary.LittleEndian, uint32(36+w.bytesWritten)); err != nil {
+		return err
+	}
+	if _, err := w.f.Seek(40, io.SeekStart); err != nil {
+		return err
+	}
+	if err := binary.Write(w.f, binary.LittleEndian, w.bytesWritten); err != nil {
+		return err
+	}
+	_, _ = w.f.Seek(0, io.SeekEnd)
+	return nil
+}
+
+// IQWavInfo describes a baseband WAV without loading its samples.
+type IQWavInfo struct {
+	SampleRate uint32
+	Channels   uint16
+	Samples    int // IQ-sample frames in the data chunk
+}
+
+// ReadIQWavInfo parses just the header of a baseband WAV.
+func ReadIQWavInfo(path string) (IQWavInfo, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return IQWavInfo{}, err
+	}
+	defer f.Close()
+	_, info, err := parseIQWavHeader(f)
+	return info, err
+}
+
+// parseIQWavHeader reads the RIFF chunks up to (and including) the
+// "data" chunk header, leaving f positioned at the first data byte. It
+// returns the data-chunk byte length and the format info.
+func parseIQWavHeader(f *os.File) (dataBytes uint32, info IQWavInfo, err error) {
+	hdr := make([]byte, 12)
+	if _, err = io.ReadFull(f, hdr); err != nil {
+		return 0, info, fmt.Errorf("baseband: read RIFF header: %w", err)
+	}
+	if string(hdr[0:4]) != "RIFF" || string(hdr[8:12]) != "WAVE" {
+		return 0, info, errors.New("baseband: not a RIFF/WAVE file")
+	}
+	var (
+		bits   uint16
+		gotFmt bool
+	)
+	chunkHdr := make([]byte, 8)
+	for {
+		if _, err = io.ReadFull(f, chunkHdr); err != nil {
+			return 0, info, errors.New("baseband: WAV ended before a data chunk")
+		}
+		id := string(chunkHdr[0:4])
+		size := binary.LittleEndian.Uint32(chunkHdr[4:8])
+		switch id {
+		case "fmt ":
+			fmtBuf := make([]byte, size)
+			if _, err = io.ReadFull(f, fmtBuf); err != nil {
+				return 0, info, fmt.Errorf("baseband: read fmt chunk: %w", err)
+			}
+			if len(fmtBuf) < 16 {
+				return 0, info, errors.New("baseband: short fmt chunk")
+			}
+			info.Channels = binary.LittleEndian.Uint16(fmtBuf[2:4])
+			info.SampleRate = binary.LittleEndian.Uint32(fmtBuf[4:8])
+			bits = binary.LittleEndian.Uint16(fmtBuf[14:16])
+			gotFmt = true
+		case "data":
+			if !gotFmt {
+				return 0, info, errors.New("baseband: data chunk before fmt chunk")
+			}
+			if info.Channels != iqWavChannels {
+				return 0, info, fmt.Errorf("baseband: WAV has %d channels, IQ recordings need 2", info.Channels)
+			}
+			if bits != iqWavBitsPerSample {
+				return 0, info, fmt.Errorf("baseband: WAV is %d-bit, IQ recordings need 16-bit", bits)
+			}
+			info.Samples = int(size / iqWavBlockAlign)
+			return size, info, nil
+		default:
+			skip := int64(size)
+			if size%2 == 1 {
+				skip++
+			}
+			if _, err = f.Seek(skip, io.SeekCurrent); err != nil {
+				return 0, info, fmt.Errorf("baseband: skip %q chunk: %w", id, err)
+			}
+		}
+	}
+}
+
+// floatToI16 clamps a normalised sample to [-1, 1] and scales it to a
+// signed 16-bit value.
+func floatToI16(v float32) int16 {
+	if v > 1 {
+		v = 1
+	} else if v < -1 {
+		v = -1
+	}
+	return int16(v * 32767)
+}

--- a/internal/storage/locationlog.go
+++ b/internal/storage/locationlog.go
@@ -1,0 +1,136 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// LocationLog persists geographic fixes to the SQLite location_log
+// table by subscribing to events.KindLocation on the shared bus.
+type LocationLog struct {
+	db        *DB
+	bus       *events.Bus
+	log       *slog.Logger
+	sub       *events.Subscription
+	runDone   chan struct{}
+	closeOnce sync.Once
+}
+
+// LocationRow is one persisted fix, returned by Recent.
+type LocationRow struct {
+	ID         int64     `json:"id"`
+	System     string    `json:"system"`
+	Protocol   string    `json:"protocol"`
+	RadioID    uint32    `json:"radio_id"`
+	Talkgroup  uint32    `json:"talkgroup"`
+	Latitude   float64   `json:"latitude"`
+	Longitude  float64   `json:"longitude"`
+	SpeedKnots float64   `json:"speed_knots"`
+	HeadingDeg float64   `json:"heading_deg"`
+	ReportedAt time.Time `json:"reported_at"`
+}
+
+// NewLocationLog wires the location log to the bus. It subscribes
+// immediately so callers can publish before Run starts.
+func NewLocationLog(db *DB, bus *events.Bus, logger *slog.Logger) (*LocationLog, error) {
+	if db == nil {
+		return nil, errors.New("storage/locationlog: DB is required")
+	}
+	if bus == nil {
+		return nil, errors.New("storage/locationlog: events.Bus is required")
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	l := &LocationLog{db: db, bus: bus, log: logger, runDone: make(chan struct{})}
+	l.sub = bus.Subscribe()
+	return l, nil
+}
+
+// Run drains KindLocation events until ctx cancels or the bus closes.
+func (l *LocationLog) Run(ctx context.Context) error {
+	defer close(l.runDone)
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case ev, ok := <-l.sub.C:
+			if !ok {
+				return nil
+			}
+			if ev.Kind != events.KindLocation {
+				continue
+			}
+			loc, ok := ev.Payload.(trunking.Location)
+			if !ok {
+				continue
+			}
+			if err := l.insert(loc); err != nil {
+				l.log.Error("locationlog: insert failed", "err", err)
+			}
+		}
+	}
+}
+
+func (l *LocationLog) insert(loc trunking.Location) error {
+	at := loc.At
+	if at.IsZero() {
+		at = time.Now()
+	}
+	_, err := l.db.SQL().Exec(
+		`INSERT INTO location_log
+		 (system, protocol, radio_id, talkgroup, latitude, longitude,
+		  speed_knots, heading_deg, reported_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		loc.System, loc.Protocol, loc.RadioID, loc.Talkgroup,
+		loc.Latitude, loc.Longitude, loc.SpeedKnots, loc.HeadingDeg,
+		at.UnixNano())
+	return err
+}
+
+// Recent returns the most recent fixes, newest first, capped at limit.
+func (l *LocationLog) Recent(limit int) ([]LocationRow, error) {
+	if limit <= 0 || limit > 5000 {
+		limit = 500
+	}
+	rows, err := l.db.SQL().Query(
+		`SELECT id, system, protocol, radio_id, talkgroup, latitude,
+		        longitude, speed_knots, heading_deg, reported_at
+		 FROM location_log ORDER BY reported_at DESC LIMIT ?`, limit)
+	if err != nil {
+		return nil, fmt.Errorf("storage/locationlog: query: %w", err)
+	}
+	defer rows.Close()
+	var out []LocationRow
+	for rows.Next() {
+		var r LocationRow
+		var ns int64
+		if err := rows.Scan(&r.ID, &r.System, &r.Protocol, &r.RadioID,
+			&r.Talkgroup, &r.Latitude, &r.Longitude, &r.SpeedKnots,
+			&r.HeadingDeg, &ns); err != nil {
+			return nil, fmt.Errorf("storage/locationlog: scan: %w", err)
+		}
+		r.ReportedAt = time.Unix(0, ns)
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// Close releases the bus subscription and waits for Run to drain.
+func (l *LocationLog) Close() error {
+	l.closeOnce.Do(func() {
+		l.sub.Close()
+		select {
+		case <-l.runDone:
+		case <-time.After(time.Second):
+		}
+	})
+	return nil
+}

--- a/internal/storage/locationlog_test.go
+++ b/internal/storage/locationlog_test.go
@@ -1,0 +1,75 @@
+package storage
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+func TestLocationLogPersistsAndQueries(t *testing.T) {
+	db, err := Open(":memory:")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer db.Close()
+
+	bus := events.NewBus(16)
+	defer bus.Close()
+	ll, err := NewLocationLog(db, bus, nil)
+	if err != nil {
+		t.Fatalf("NewLocationLog: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	go ll.Run(ctx)
+	t.Cleanup(func() { cancel(); ll.Close() })
+
+	bus.Publish(events.Event{
+		Kind: events.KindLocation,
+		Payload: trunking.Location{
+			System:    "Metro",
+			Protocol:  "dmr",
+			RadioID:   4242,
+			Talkgroup: 100,
+			Latitude:  40.7128,
+			Longitude: -74.0060,
+			At:        time.Now(),
+		},
+	})
+
+	var rows []LocationRow
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		rows, err = ll.Recent(50)
+		if err != nil {
+			t.Fatalf("Recent: %v", err)
+		}
+		if len(rows) == 1 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("got %d rows, want 1", len(rows))
+	}
+	r := rows[0]
+	if r.RadioID != 4242 || r.Talkgroup != 100 || r.System != "Metro" {
+		t.Errorf("row metadata wrong: %+v", r)
+	}
+	if r.Latitude < 40.7 || r.Latitude > 40.72 || r.Longitude > -74 || r.Longitude < -74.01 {
+		t.Errorf("row coords wrong: %f,%f", r.Latitude, r.Longitude)
+	}
+}
+
+func TestLocationLogRequiresDBAndBus(t *testing.T) {
+	if _, err := NewLocationLog(nil, events.NewBus(1), nil); err == nil {
+		t.Error("NewLocationLog without a DB should error")
+	}
+	db, _ := Open(":memory:")
+	defer db.Close()
+	if _, err := NewLocationLog(db, nil, nil); err == nil {
+		t.Error("NewLocationLog without a bus should error")
+	}
+}

--- a/internal/storage/sqlite.go
+++ b/internal/storage/sqlite.go
@@ -91,6 +91,22 @@ CREATE INDEX IF NOT EXISTS idx_call_log_started ON call_log(started_at);
 CREATE INDEX IF NOT EXISTS idx_call_log_system  ON call_log(system, started_at);
 CREATE INDEX IF NOT EXISTS idx_call_log_group   ON call_log(group_id, started_at);
 CREATE UNIQUE INDEX IF NOT EXISTS idx_call_log_active ON call_log(device_serial, started_at);
+
+CREATE TABLE IF NOT EXISTS location_log (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    system      TEXT    NOT NULL DEFAULT '',
+    protocol    TEXT    NOT NULL DEFAULT '',
+    radio_id    INTEGER NOT NULL DEFAULT 0,
+    talkgroup   INTEGER NOT NULL DEFAULT 0,
+    latitude    REAL    NOT NULL,
+    longitude   REAL    NOT NULL,
+    speed_knots REAL    NOT NULL DEFAULT 0,
+    heading_deg REAL    NOT NULL DEFAULT 0,
+    reported_at INTEGER NOT NULL  -- unix nanoseconds
+);
+
+CREATE INDEX IF NOT EXISTS idx_location_log_time  ON location_log(reported_at);
+CREATE INDEX IF NOT EXISTS idx_location_log_radio ON location_log(radio_id, reported_at);
 `
 
 func (d *DB) migrate() error {

--- a/internal/trunking/grant.go
+++ b/internal/trunking/grant.go
@@ -123,3 +123,23 @@ type CallEnd struct {
 
 // Duration returns how long the call ran.
 func (c CallEnd) Duration() time.Duration { return c.EndedAt.Sub(c.StartedAt) }
+
+// CallComplete is the payload of an events.KindCallComplete event. The
+// recorder publishes it once a call's WAV has been flushed and closed,
+// so the outbound-streaming subsystem (internal/broadcast) can read the
+// finished file and upload it to call aggregators. AudioPath is the
+// absolute or working-directory-relative path to the .wav the recorder
+// wrote; SampleRate is its PCM rate in Hz.
+type CallComplete struct {
+	Grant        Grant
+	Talkgroup    *TalkGroup
+	DeviceSerial string
+	StartedAt    time.Time
+	EndedAt      time.Time
+	Reason       EndReason
+	AudioPath    string
+	SampleRate   uint32
+}
+
+// Duration returns how long the call ran.
+func (c CallComplete) Duration() time.Duration { return c.EndedAt.Sub(c.StartedAt) }

--- a/internal/trunking/location.go
+++ b/internal/trunking/location.go
@@ -1,0 +1,23 @@
+package trunking
+
+import "time"
+
+// Location is the payload of an events.KindLocation event: a
+// geographic fix a subscriber unit reported over the air. P25 Motorola
+// Unit GPS, P25 L3Harris Talker GPS, and DMR LRRP all ultimately
+// resolve to one of these. Latitude is positive north, Longitude
+// positive east, both in decimal degrees.
+//
+// The storage layer persists every Location to the location_log table
+// and the API surfaces recent fixes for map display.
+type Location struct {
+	System     string  // trunking system name
+	Protocol   string  // "p25", "dmr", ...
+	RadioID    uint32  // reporting subscriber unit
+	Talkgroup  uint32  // associated talkgroup; 0 when not call-associated
+	Latitude   float64 // decimal degrees, positive north
+	Longitude  float64 // decimal degrees, positive east
+	SpeedKnots float64 // 0 when not reported
+	HeadingDeg float64 // 0 when not reported
+	At         time.Time
+}

--- a/internal/trunking/talkgroup.go
+++ b/internal/trunking/talkgroup.go
@@ -31,6 +31,13 @@ type TalkGroup struct {
 	Priority    int    `json:"priority,omitempty"` // 1 = highest, 10 = lowest, 0 = unset
 	Lockout     bool   `json:"lockout,omitempty"`
 	Scan        bool   `json:"scan"`
+	// Stream gates whether completed calls on this talkgroup are
+	// uploaded to the outbound broadcast aggregators
+	// (internal/broadcast). Defaults to true on every loader so a
+	// legacy CSV/JSON without a Stream column keeps streaming every
+	// call; an explicit "no"/"false" in the CSV (or `"stream": false`
+	// in JSON) opts a sensitive talkgroup out of all feeds.
+	Stream bool `json:"stream"`
 }
 
 // TalkgroupDB is a thread-safe lookup over loaded talkgroups.
@@ -156,7 +163,7 @@ func (d *TalkgroupDB) LoadCSV(r io.Reader) (int, error) {
 		if err != nil {
 			continue // skip malformed rows
 		}
-		tg := &TalkGroup{ID: uint32(idVal), Scan: true}
+		tg := &TalkGroup{ID: uint32(idVal), Scan: true, Stream: true}
 		tg.AlphaTag = field(row, colIdx, "alpha tag", "alphatag", "alpha_tag")
 		tg.Description = field(row, colIdx, "description")
 		tg.Mode = field(row, colIdx, "mode")
@@ -182,6 +189,15 @@ func (d *TalkgroupDB) LoadCSV(r io.Reader) (int, error) {
 			switch strings.ToLower(s) {
 			case "n", "no", "false", "0", "off":
 				tg.Scan = false
+			}
+		}
+		// Optional Stream column. Default is true; explicit
+		// "no"/"false"/"0"/"n" opts the talkgroup out of all
+		// outbound broadcast feeds.
+		if s := field(row, colIdx, "stream"); s != "" {
+			switch strings.ToLower(s) {
+			case "n", "no", "false", "0", "off":
+				tg.Stream = false
 			}
 		}
 		d.Add(tg)
@@ -215,6 +231,7 @@ func (d *TalkgroupDB) LoadJSON(r io.Reader) (int, error) {
 		Priority    int    `json:"priority,omitempty"`
 		Lockout     bool   `json:"lockout,omitempty"`
 		Scan        *bool  `json:"scan"`
+		Stream      *bool  `json:"stream"`
 	}
 	var arr []talkGroupRaw
 	if err := json.NewDecoder(r).Decode(&arr); err != nil {
@@ -231,9 +248,13 @@ func (d *TalkgroupDB) LoadJSON(r io.Reader) (int, error) {
 			Priority:    raw.Priority,
 			Lockout:     raw.Lockout,
 			Scan:        true,
+			Stream:      true,
 		}
 		if raw.Scan != nil {
 			tg.Scan = *raw.Scan
+		}
+		if raw.Stream != nil {
+			tg.Stream = *raw.Stream
 		}
 		d.Add(tg)
 	}

--- a/internal/trunking/talkgroup.go
+++ b/internal/trunking/talkgroup.go
@@ -38,6 +38,11 @@ type TalkGroup struct {
 	// call; an explicit "no"/"false" in the CSV (or `"stream": false`
 	// in JSON) opts a sensitive talkgroup out of all feeds.
 	Stream bool `json:"stream"`
+	// Record gates whether calls on this talkgroup are written to
+	// disk by the per-call WAV recorder. Defaults to true on every
+	// loader; an explicit "no"/"false" excludes a talkgroup from
+	// recording (the call is still followed and played live).
+	Record bool `json:"record"`
 }
 
 // TalkgroupDB is a thread-safe lookup over loaded talkgroups.
@@ -163,7 +168,7 @@ func (d *TalkgroupDB) LoadCSV(r io.Reader) (int, error) {
 		if err != nil {
 			continue // skip malformed rows
 		}
-		tg := &TalkGroup{ID: uint32(idVal), Scan: true, Stream: true}
+		tg := &TalkGroup{ID: uint32(idVal), Scan: true, Stream: true, Record: true}
 		tg.AlphaTag = field(row, colIdx, "alpha tag", "alphatag", "alpha_tag")
 		tg.Description = field(row, colIdx, "description")
 		tg.Mode = field(row, colIdx, "mode")
@@ -200,6 +205,15 @@ func (d *TalkgroupDB) LoadCSV(r io.Reader) (int, error) {
 				tg.Stream = false
 			}
 		}
+		// Optional Record column. Default is true; explicit
+		// "no"/"false"/"0"/"n" excludes the talkgroup from the
+		// per-call WAV recorder.
+		if s := field(row, colIdx, "record"); s != "" {
+			switch strings.ToLower(s) {
+			case "n", "no", "false", "0", "off":
+				tg.Record = false
+			}
+		}
 		d.Add(tg)
 		loaded++
 	}
@@ -232,6 +246,7 @@ func (d *TalkgroupDB) LoadJSON(r io.Reader) (int, error) {
 		Lockout     bool   `json:"lockout,omitempty"`
 		Scan        *bool  `json:"scan"`
 		Stream      *bool  `json:"stream"`
+		Record      *bool  `json:"record"`
 	}
 	var arr []talkGroupRaw
 	if err := json.NewDecoder(r).Decode(&arr); err != nil {
@@ -249,12 +264,16 @@ func (d *TalkgroupDB) LoadJSON(r io.Reader) (int, error) {
 			Lockout:     raw.Lockout,
 			Scan:        true,
 			Stream:      true,
+			Record:      true,
 		}
 		if raw.Scan != nil {
 			tg.Scan = *raw.Scan
 		}
 		if raw.Stream != nil {
 			tg.Stream = *raw.Stream
+		}
+		if raw.Record != nil {
+			tg.Record = *raw.Record
 		}
 		d.Add(tg)
 	}

--- a/internal/voice/mp3/mp3.go
+++ b/internal/voice/mp3/mp3.go
@@ -1,0 +1,139 @@
+// Package mp3 provides a pure-Go MP3 encoder used to compress completed
+// call audio before it is streamed to broadcast aggregators
+// (Broadcastify Calls, RdioScanner, OpenMHz, Icecast).
+//
+// It wraps the fixed-point Shine encoder, so the daemon keeps its
+// zero-CGO single-binary guarantee — no libmp3lame / libshine at build
+// or runtime. Shine supports the MPEG-1, MPEG-2 and MPEG-2.5 sample-rate
+// families, so 8 kHz digital-voice audio encodes directly with no
+// resample stage.
+package mp3
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	shine "github.com/braheezy/shine-mp3/pkg/mp3"
+)
+
+// Encode compresses mono 16-bit PCM sampled at sampleRate Hz into a
+// complete MP3 byte stream. The input is treated as a single channel;
+// callers with stereo audio must downmix first.
+func Encode(samples []int16, sampleRate int) ([]byte, error) {
+	if sampleRate <= 0 {
+		return nil, errors.New("mp3: sample rate must be positive")
+	}
+	if len(samples) == 0 {
+		return nil, errors.New("mp3: no samples to encode")
+	}
+	enc := shine.NewEncoder(sampleRate, 1)
+	var buf bytes.Buffer
+	if err := enc.Write(&buf, samples); err != nil {
+		return nil, fmt.Errorf("mp3: encode: %w", err)
+	}
+	if buf.Len() == 0 {
+		return nil, errors.New("mp3: encoder produced no output")
+	}
+	return buf.Bytes(), nil
+}
+
+// EncodeWAVFile reads a 16-bit PCM mono WAV file from path and returns
+// the equivalent MP3 byte stream plus the source sample rate.
+func EncodeWAVFile(path string) ([]byte, int, error) {
+	samples, rate, err := ReadWAV(path)
+	if err != nil {
+		return nil, 0, err
+	}
+	out, err := Encode(samples, rate)
+	if err != nil {
+		return nil, rate, err
+	}
+	return out, rate, nil
+}
+
+// ReadWAV parses a canonical 16-bit PCM mono WAV file and returns its
+// samples and sample rate. It tolerates extra chunks between `fmt ` and
+// `data` (e.g. LIST/INFO) by walking the chunk list. Only mono 16-bit
+// PCM is supported — the format the recorder writes.
+func ReadWAV(path string) ([]int16, int, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer f.Close()
+	return readWAV(f)
+}
+
+func readWAV(r io.Reader) ([]int16, int, error) {
+	hdr := make([]byte, 12)
+	if _, err := io.ReadFull(r, hdr); err != nil {
+		return nil, 0, fmt.Errorf("mp3: read RIFF header: %w", err)
+	}
+	if string(hdr[0:4]) != "RIFF" || string(hdr[8:12]) != "WAVE" {
+		return nil, 0, errors.New("mp3: not a RIFF/WAVE file")
+	}
+	var (
+		sampleRate    int
+		bitsPerSample uint16
+		channels      uint16
+		gotFmt        bool
+	)
+	chunkHdr := make([]byte, 8)
+	for {
+		if _, err := io.ReadFull(r, chunkHdr); err != nil {
+			if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+				return nil, 0, errors.New("mp3: WAV ended before a data chunk")
+			}
+			return nil, 0, fmt.Errorf("mp3: read chunk header: %w", err)
+		}
+		id := string(chunkHdr[0:4])
+		size := binary.LittleEndian.Uint32(chunkHdr[4:8])
+		switch id {
+		case "fmt ":
+			fmtBuf := make([]byte, size)
+			if _, err := io.ReadFull(r, fmtBuf); err != nil {
+				return nil, 0, fmt.Errorf("mp3: read fmt chunk: %w", err)
+			}
+			if len(fmtBuf) < 16 {
+				return nil, 0, errors.New("mp3: short fmt chunk")
+			}
+			channels = binary.LittleEndian.Uint16(fmtBuf[2:4])
+			sampleRate = int(binary.LittleEndian.Uint32(fmtBuf[4:8]))
+			bitsPerSample = binary.LittleEndian.Uint16(fmtBuf[14:16])
+			gotFmt = true
+		case "data":
+			if !gotFmt {
+				return nil, 0, errors.New("mp3: data chunk before fmt chunk")
+			}
+			if channels != 1 {
+				return nil, 0, fmt.Errorf("mp3: WAV has %d channels, only mono is supported", channels)
+			}
+			if bitsPerSample != 16 {
+				return nil, 0, fmt.Errorf("mp3: WAV is %d-bit, only 16-bit PCM is supported", bitsPerSample)
+			}
+			data := make([]byte, size)
+			if _, err := io.ReadFull(r, data); err != nil {
+				return nil, 0, fmt.Errorf("mp3: read data chunk: %w", err)
+			}
+			samples := make([]int16, len(data)/2)
+			for i := range samples {
+				samples[i] = int16(binary.LittleEndian.Uint16(data[2*i:]))
+			}
+			return samples, sampleRate, nil
+		default:
+			// Skip an unrecognised chunk. Chunks are word-aligned, so
+			// an odd size carries a trailing pad byte.
+			skip := int64(size)
+			if size%2 == 1 {
+				skip++
+			}
+			if _, err := io.CopyN(io.Discard, r, skip); err != nil {
+				return nil, 0, fmt.Errorf("mp3: skip %q chunk: %w", id, err)
+			}
+		}
+	}
+}

--- a/internal/voice/mp3/mp3.go
+++ b/internal/voice/mp3/mp3.go
@@ -20,6 +20,12 @@ import (
 	shine "github.com/braheezy/shine-mp3/pkg/mp3"
 )
 
+// shineFrame is the largest MPEG layer-3 samples-per-frame the Shine
+// encoder uses (MPEG-1: 2 granules × 576). It is a multiple of the
+// MPEG-2/2.5 frame size (576), so rounding the input up to a multiple
+// of shineFrame yields whole frames for every supported sample rate.
+const shineFrame = 1152
+
 // Encode compresses mono 16-bit PCM sampled at sampleRate Hz into a
 // complete MP3 byte stream. The input is treated as a single channel;
 // callers with stereo audio must downmix first.
@@ -30,9 +36,20 @@ func Encode(samples []int16, sampleRate int) ([]byte, error) {
 	if len(samples) == 0 {
 		return nil, errors.New("mp3: no samples to encode")
 	}
+	// The Shine encoder's subband/MDCT stage reads a frame of
+	// look-ahead past the final frame it encodes. Backing the input
+	// with extra zeroed headroom (and rounding the encoded length up
+	// to a whole number of frames) keeps that look-ahead inside the
+	// allocation — without it the encoder reads stray heap memory,
+	// which the race detector's checkptr validation aborts on.
+	frames := (len(samples) + shineFrame - 1) / shineFrame
+	encodeLen := frames * shineFrame
+	backed := make([]int16, encodeLen+shineFrame)
+	copy(backed, samples)
+
 	enc := shine.NewEncoder(sampleRate, 1)
 	var buf bytes.Buffer
-	if err := enc.Write(&buf, samples); err != nil {
+	if err := enc.Write(&buf, backed[:encodeLen]); err != nil {
 		return nil, fmt.Errorf("mp3: encode: %w", err)
 	}
 	if buf.Len() == 0 {

--- a/internal/voice/mp3/mp3_test.go
+++ b/internal/voice/mp3/mp3_test.go
@@ -1,0 +1,126 @@
+package mp3
+
+import (
+	"encoding/binary"
+	"math"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// tone builds n samples of a sine wave at freqHz for sample rate rate.
+func tone(n, rate int, freqHz float64) []int16 {
+	s := make([]int16, n)
+	for i := range s {
+		s[i] = int16(8000 * math.Sin(2*math.Pi*freqHz*float64(i)/float64(rate)))
+	}
+	return s
+}
+
+func TestEncodeProducesMP3FrameSync(t *testing.T) {
+	for _, rate := range []int{8000, 16000, 22050, 44100} {
+		out, err := Encode(tone(rate, rate, 440), rate)
+		if err != nil {
+			t.Fatalf("Encode(%d Hz): %v", rate, err)
+		}
+		if len(out) < 100 {
+			t.Fatalf("Encode(%d Hz): output too short: %d bytes", rate, len(out))
+		}
+		// Every MP3 frame opens with an 11-bit sync word.
+		if out[0] != 0xFF || out[1]&0xE0 != 0xE0 {
+			t.Fatalf("Encode(%d Hz): no MP3 frame sync: %02x %02x", rate, out[0], out[1])
+		}
+	}
+}
+
+func TestEncodeRejectsBadInput(t *testing.T) {
+	if _, err := Encode(nil, 8000); err == nil {
+		t.Fatal("Encode(nil) should error")
+	}
+	if _, err := Encode([]int16{1, 2, 3}, 0); err == nil {
+		t.Fatal("Encode(rate=0) should error")
+	}
+}
+
+func TestReadWAVRoundTrip(t *testing.T) {
+	samples := tone(8000, 8000, 440)
+	path := filepath.Join(t.TempDir(), "call.wav")
+	writeWAV(t, path, samples, 8000)
+
+	got, rate, err := ReadWAV(path)
+	if err != nil {
+		t.Fatalf("ReadWAV: %v", err)
+	}
+	if rate != 8000 {
+		t.Fatalf("rate = %d, want 8000", rate)
+	}
+	if len(got) != len(samples) {
+		t.Fatalf("len = %d, want %d", len(got), len(samples))
+	}
+	for i := range got {
+		if got[i] != samples[i] {
+			t.Fatalf("sample %d = %d, want %d", i, got[i], samples[i])
+		}
+	}
+}
+
+func TestEncodeWAVFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "call.wav")
+	writeWAV(t, path, tone(4000, 8000, 600), 8000)
+
+	out, rate, err := EncodeWAVFile(path)
+	if err != nil {
+		t.Fatalf("EncodeWAVFile: %v", err)
+	}
+	if rate != 8000 {
+		t.Fatalf("rate = %d, want 8000", rate)
+	}
+	if out[0] != 0xFF || out[1]&0xE0 != 0xE0 {
+		t.Fatalf("no MP3 frame sync: %02x %02x", out[0], out[1])
+	}
+}
+
+func TestReadWAVRejectsNonWAV(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "bad.bin")
+	if err := os.WriteFile(path, []byte("not a wav file at all"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := ReadWAV(path); err == nil {
+		t.Fatal("ReadWAV on non-WAV should error")
+	}
+}
+
+// writeWAV emits a canonical 44-byte-header 16-bit PCM mono WAV.
+func writeWAV(t *testing.T, path string, samples []int16, rate uint32) {
+	t.Helper()
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	dataLen := uint32(len(samples) * 2)
+	hdr := make([]byte, 44)
+	copy(hdr[0:4], "RIFF")
+	binary.LittleEndian.PutUint32(hdr[4:8], 36+dataLen)
+	copy(hdr[8:12], "WAVE")
+	copy(hdr[12:16], "fmt ")
+	binary.LittleEndian.PutUint32(hdr[16:20], 16)
+	binary.LittleEndian.PutUint16(hdr[20:22], 1)
+	binary.LittleEndian.PutUint16(hdr[22:24], 1)
+	binary.LittleEndian.PutUint32(hdr[24:28], rate)
+	binary.LittleEndian.PutUint32(hdr[28:32], rate*2)
+	binary.LittleEndian.PutUint16(hdr[32:34], 2)
+	binary.LittleEndian.PutUint16(hdr[34:36], 16)
+	copy(hdr[36:40], "data")
+	binary.LittleEndian.PutUint32(hdr[40:44], dataLen)
+	if _, err := f.Write(hdr); err != nil {
+		t.Fatal(err)
+	}
+	buf := make([]byte, dataLen)
+	for i, s := range samples {
+		binary.LittleEndian.PutUint16(buf[2*i:], uint16(s))
+	}
+	if _, err := f.Write(buf); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/voice/recorder.go
+++ b/internal/voice/recorder.go
@@ -371,6 +371,7 @@ func (r *Recorder) handleEnd(ce trunking.CallEnd) {
 	if !ok {
 		return
 	}
+	dataBytes := s.wav.DataBytes()
 	if err := s.close(); err != nil {
 		r.log.Error("recorder: close session", "err", err)
 	}
@@ -379,6 +380,25 @@ func (r *Recorder) handleEnd(ce trunking.CallEnd) {
 		"wav", s.wavPath,
 		"duration", ce.Duration().Round(time.Millisecond),
 		"reason", ce.Reason)
+	// Announce the finished WAV so the outbound-streaming subsystem
+	// can upload it. Skip calls that captured no PCM (digital voice
+	// whose vocoder produced nothing, or an instantly-preempted
+	// grant) — there is nothing to stream.
+	if dataBytes > 0 {
+		r.bus.Publish(events.Event{
+			Kind: events.KindCallComplete,
+			Payload: trunking.CallComplete{
+				Grant:        ce.Grant,
+				Talkgroup:    ce.Talkgroup,
+				DeviceSerial: ce.DeviceSerial,
+				StartedAt:    ce.StartedAt,
+				EndedAt:      ce.EndedAt,
+				Reason:       ce.Reason,
+				AudioPath:    s.wavPath,
+				SampleRate:   r.sampleRate,
+			},
+		})
+	}
 }
 
 func (r *Recorder) directoryFor(cs trunking.CallStart) string {

--- a/internal/voice/recorder.go
+++ b/internal/voice/recorder.go
@@ -304,6 +304,11 @@ func (r *Recorder) handleStart(cs trunking.CallStart) {
 		// completion via handleEnd.
 		return
 	}
+	if cs.Talkgroup != nil && !cs.Talkgroup.Record {
+		// Talkgroup is flagged record=false — follow and play the
+		// call live, but write no WAV/raw files for it.
+		return
+	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if _, busy := r.sessions[cs.DeviceSerial]; busy {

--- a/internal/voice/recorder_test.go
+++ b/internal/voice/recorder_test.go
@@ -43,7 +43,7 @@ func TestRecorderWritesPerCallWav(t *testing.T) {
 			GroupID:  1234,
 			SourceID: 56789,
 		},
-		Talkgroup:    &trunking.TalkGroup{ID: 1234, AlphaTag: "FIRE-DISP"},
+		Talkgroup:    &trunking.TalkGroup{ID: 1234, AlphaTag: "FIRE-DISP", Record: true},
 		DeviceSerial: "VOICE-1",
 		StartedAt:    time.Date(2026, 5, 5, 12, 30, 45, 0, time.UTC),
 	}
@@ -91,6 +91,36 @@ func TestRecorderWritesPerCallWav(t *testing.T) {
 	}
 }
 
+// TestRecorderSkipsRecordFalseTalkgroup confirms a talkgroup flagged
+// Record=false is followed (the CallStart is consumed) but no session
+// — and therefore no .wav — is opened for it.
+func TestRecorderSkipsRecordFalseTalkgroup(t *testing.T) {
+	r, bus, _ := mkRecorder(t, false)
+	defer r.Close()
+	defer bus.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go r.Run(ctx)
+
+	cs := trunking.CallStart{
+		Grant:        trunking.Grant{System: "S", Protocol: "p25", GroupID: 500, SourceID: 1},
+		Talkgroup:    &trunking.TalkGroup{ID: 500, AlphaTag: "PRIVATE", Record: false},
+		DeviceSerial: "VOICE-1",
+		StartedAt:    time.Now(),
+	}
+	bus.Publish(events.Event{Kind: events.KindCallStart, Payload: cs})
+
+	// Give the recorder time to (correctly) drop the CallStart.
+	deadline := time.Now().Add(300 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if r.HasSession("VOICE-1") {
+			t.Fatal("recorder opened a session for a Record=false talkgroup")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
 // TestRecorderGateBlocksNewSessions confirms the runtime
 // SetRecordingEnabled(false) gate stops handleStart from opening
 // new .wav files while leaving in-flight sessions alone. Matches the
@@ -116,7 +146,7 @@ func TestRecorderGateBlocksNewSessions(t *testing.T) {
 			GroupID:  7,
 			SourceID: 8,
 		},
-		Talkgroup:    &trunking.TalkGroup{ID: 7, AlphaTag: "GATE"},
+		Talkgroup:    &trunking.TalkGroup{ID: 7, AlphaTag: "GATE", Record: true},
 		DeviceSerial: "VOICE-G",
 		StartedAt:    time.Date(2026, 5, 5, 12, 0, 0, 0, time.UTC),
 	}

--- a/internal/voice/wav.go
+++ b/internal/voice/wav.go
@@ -73,6 +73,11 @@ func (w *WavWriter) WriteSamples(samples []int16) error {
 	return err
 }
 
+// DataBytes returns the number of PCM payload bytes written so far
+// (excluding the 44-byte header). Stays readable after Close so the
+// recorder can tell whether a call captured any audio.
+func (w *WavWriter) DataBytes() uint32 { return w.bytesWritten }
+
 // Close patches the length fields and closes the underlying file (if the
 // writer owns one).
 func (w *WavWriter) Close() error {


### PR DESCRIPTION
Stream completed calls to external aggregators and live audio
servers, closing the largest functional gap against SDRtrunk.

The new internal/broadcast package subscribes to a KindCallComplete
event the recorder publishes once a call's WAV is flushed, encodes
the audio with a pure-Go MP3 encoder (internal/voice/mp3, no CGO),
and fans the call out to every configured backend with bounded
exponential-backoff retry. Four backends ship: Broadcastify Calls,
RdioScanner, OpenMHz, and live Icecast/ShoutCast.

Feeds are configured under a new broadcast: config section with an
optional per-feed system filter; a talkgroup opts out of all feeds
with stream: false. Feed counters are exposed at
GET /api/v1/broadcast.

https://claude.ai/code/session_01TukmNGna117cn6VbhuKgWm