### PR TITLE
p25/phase1: strip control-channel status symbols (#275)

### DIFF
--- a/cmd/gophertrunk/integration_cc_test.go
+++ b/cmd/gophertrunk/integration_cc_test.go
@@ -215,6 +215,9 @@ func buildP25LockedIQDibits(nac uint16, repeats int) []uint8 {
 	}
 	tsbk := phase1.AssembleTSBK(phase1.TSBK{LB: true, Opcode: phase1.OpRFSSStatusBroadcast})
 	frame = append(frame, phase1.EncodeTSBKChannel(tsbk)...)
+	// Interleave the P25 status symbols a real transmitter inserts (one
+	// per 36 dibits); the receiver must strip them to decode the NID.
+	frame = phase1.InjectControlStatusSymbols(frame)
 
 	out := make([]uint8, 0, 200+repeats*(len(frame)+50)+100)
 	for i := 0; i < 200; i++ {
@@ -546,8 +549,9 @@ func buildP25CallChainIQDibits(p buildP25CallChainParams) []uint8 {
 	return out
 }
 
-// buildP25TSBKFrame returns the FSW + NID + trellis-encoded TSBK
-// dibits for a single frame.
+// buildP25TSBKFrame returns the on-air dibits for a single frame: FSW
+// + NID + trellis-encoded TSBK, with P25 status symbols interleaved
+// (one per 36 dibits) the way a real transmitter emits them.
 func buildP25TSBKFrame(nac uint16, tsbk phase1.TSBK) []uint8 {
 	frame := make([]uint8, 0, 24+32+98)
 	frame = append(frame, phase1.FrameSyncWord[:]...)
@@ -556,7 +560,7 @@ func buildP25TSBKFrame(nac uint16, tsbk phase1.TSBK) []uint8 {
 		frame = append(frame, (nidBits[2*i]<<1)|nidBits[2*i+1])
 	}
 	frame = append(frame, phase1.EncodeTSBKChannel(phase1.AssembleTSBK(tsbk))...)
-	return frame
+	return phase1.InjectControlStatusSymbols(frame)
 }
 
 // assembleGroupVoiceChannelGrant packs the 8-byte payload of a

--- a/internal/radio/p25/phase1/control.go
+++ b/internal/radio/p25/phase1/control.go
@@ -144,11 +144,21 @@ func (s LockState) LockedNAC() uint16         { return s.NAC }
 // visible without flooding.
 const noHitsThrottle = 2 * time.Second
 
-// frameLookahead is the number of dibits that must follow the FSW for
-// a full frame to decode: the 32-dibit NID plus the 98-dibit TSBK
-// channel block. Process defers an FSW hit until this many dibits have
-// accumulated, so frame assembly no longer depends on the IQ chunking.
-const frameLookahead = 32 + 98
+// p25StatusStride is the on-air dibit period of P25's interleaved
+// status symbols: 35 data dibits followed by one 2-bit status symbol
+// (TIA-102.BAAA — one status symbol per 70 information bits, the same
+// cadence ldu.go's LDUStatusInterval encodes for voice frames).
+// Counting on-air dibits from the FSW's first dibit, a status symbol
+// falls wherever the index mod p25StatusStride is p25StatusStride-1.
+const p25StatusStride = 36
+
+// frameLookahead is the number of on-air dibits that must follow the
+// FSW for a full frame to decode: the 32-dibit NID plus the 98-dibit
+// TSBK channel block — 130 data dibits — plus the 4 status symbols
+// interleaved into that span at the p25StatusStride cadence. Process
+// defers an FSW hit until this many dibits have accumulated, so frame
+// assembly no longer depends on the IQ chunking.
+const frameLookahead = 130 + 4
 
 // Process consumes a window of dibits and runs detection/parsing.
 // baseIdx is the absolute dibit index of dibits[0]. Returns the
@@ -209,8 +219,16 @@ func (c *ControlChannel) Process(dibits []uint8, baseIdx int) int {
 // adding rot mod 4 to each input dibit, so the canonical dibit values
 // the BCH / trellis decoders expect are recovered by adding rot
 // (rotateDibits) before parsing.
+//
+// P25 interleaves a status symbol into the on-air dibit stream every
+// p25StatusStride dibits; one lands inside the NID region and three
+// inside the TSBK, so the NID and TSBK dibits are gathered around them
+// with gatherDataDibits before decoding.
 func (c *ControlChannel) parseFrame(buf []uint8, nidStart int, rot uint8) {
-	rawNID := buf[nidStart : nidStart+32]
+	// The 24-dibit FSW ends at nidStart-1, so it begins at nidStart-24;
+	// the interleaved status symbols' phase is measured from there.
+	fswStart := nidStart - len(FrameSyncWord)
+	rawNID, tsbkStart := gatherDataDibits(buf, nidStart, 32, fswStart)
 	nid, errs, err := NIDFromDibits(rotateDibits(rawNID, rot))
 	if err != nil {
 		c.log.Debug("nid parse failed", "err", err, "errs", errs, "rot", rot)
@@ -242,10 +260,10 @@ func (c *ControlChannel) parseFrame(buf []uint8, nidStart int, rot uint8) {
 		c.log.Info("control channel locked", "nac", nid.NAC, "freq", c.freqHz, "rot", rot)
 	}
 
-	// The channel TSBK occupies the 98 dibits after the NID.
-	tsbkStart := nidStart + 32
-	tsbkDibits := rotateDibits(buf[tsbkStart:tsbkStart+98], rot)
-	tsbk, metric, err := DecodeTSBKChannel(tsbkDibits)
+	// The channel TSBK occupies the 98 data dibits after the NID,
+	// starting where gatherDataDibits left off.
+	tsbkChannel, _ := gatherDataDibits(buf, tsbkStart, 98, fswStart)
+	tsbk, metric, err := DecodeTSBKChannel(rotateDibits(tsbkChannel, rot))
 	if err != nil {
 		c.log.Debug("tsbk decode failed", "err", err, "metric", metric, "nac", nid.NAC)
 		stage := events.StageTSBKTrellis
@@ -290,6 +308,51 @@ func rotateDibits(src []uint8, rot uint8) []uint8 {
 	out := make([]uint8, len(src))
 	for i, d := range src {
 		out[i] = (d + rot) & 3
+	}
+	return out
+}
+
+// gatherDataDibits copies count P25 data dibits out of buf starting at
+// index start, skipping the status symbols interleaved at the
+// p25StatusStride cadence. fswStart is the index of the frame's first
+// FSW dibit, against which the status-symbol phase is measured (it may
+// be negative if the buffer was trimmed past the FSW — only the
+// distance from it matters, and start is always well past it). It
+// returns the gathered dibits and the index one past the last dibit
+// consumed, so the next field gathers from there. The caller
+// guarantees buf holds enough dibits (see frameLookahead).
+func gatherDataDibits(buf []uint8, start, count, fswStart int) ([]uint8, int) {
+	out := make([]uint8, 0, count)
+	i := start
+	for len(out) < count {
+		if (i-fswStart)%p25StatusStride != p25StatusStride-1 {
+			out = append(out, buf[i])
+		}
+		i++
+	}
+	return out, i
+}
+
+// InjectControlStatusSymbols interleaves P25 status symbols into a
+// contiguous control-channel dibit stream (FSW + NID + TSBK …),
+// producing the on-air dibit stream a real transmitter emits: one
+// status symbol after every p25StatusStride-1 data dibits (TIA-102.BAAA
+// — one status symbol per 70 information bits). It is the inverse of
+// the status-symbol stripping parseFrame applies via gatherDataDibits,
+// and exists to build spec-faithful synthetic streams for tests — the
+// receiver harness, integration tests — that would otherwise feed the
+// decoder an unrealistic status-free stream.
+func InjectControlStatusSymbols(stream []uint8) []uint8 {
+	const dataRun = p25StatusStride - 1
+	out := make([]uint8, 0, len(stream)+len(stream)/dataRun+1)
+	for i, d := range stream {
+		out = append(out, d)
+		if i%dataRun == dataRun-1 {
+			// Cycle the status value through all four symbols so a
+			// test cannot pass by depending on a fixed status value —
+			// the receiver must skip them by position.
+			out = append(out, uint8((i/dataRun)&3))
+		}
 	}
 	return out
 }

--- a/internal/radio/p25/phase1/control_test.go
+++ b/internal/radio/p25/phase1/control_test.go
@@ -17,18 +17,27 @@ func buildLockedStream(offset int, nac uint16, duid DUID, op Opcode) []uint8 {
 	return buildLockedStreamWithTSBK(offset, nac, duid, TSBK{LB: true, Opcode: op})
 }
 
-// buildLockedStreamWithTSBK is the variant that takes a fully-formed
-// TSBK so callers can carry a payload (used by the IdentifierUpdate +
-// grant publication tests).
-func buildLockedStreamWithTSBK(offset int, nac uint16, duid DUID, tsbk TSBK) []uint8 {
-	out := make([]uint8, offset+24+32+98+16)
-	copy(out[offset:], FrameSyncWord[:])
+// buildControlFrame builds one contiguous FSW + NID + TSBK frame (154
+// dibits, no status symbols) for the given NAC / DUID / TSBK.
+func buildControlFrame(nac uint16, duid DUID, tsbk TSBK) []uint8 {
+	frame := make([]uint8, 0, 24+32+98)
+	frame = append(frame, FrameSyncWord[:]...)
 	bits := EncodeNIDBits(nac, duid)
 	for i := 0; i < 32; i++ {
-		out[offset+24+i] = (bits[2*i] << 1) | bits[2*i+1]
+		frame = append(frame, (bits[2*i]<<1)|bits[2*i+1])
 	}
-	channel := EncodeTSBKChannel(AssembleTSBK(tsbk))
-	copy(out[offset+24+32:], channel)
+	return append(frame, EncodeTSBKChannel(AssembleTSBK(tsbk))...)
+}
+
+// buildLockedStreamWithTSBK is the variant that takes a fully-formed
+// TSBK so callers can carry a payload (used by the IdentifierUpdate +
+// grant publication tests). The FSW + NID + TSBK frame is interleaved
+// with P25 status symbols, mirroring a real on-air stream, so the
+// receiver's status-symbol stripping is exercised.
+func buildLockedStreamWithTSBK(offset int, nac uint16, duid DUID, tsbk TSBK) []uint8 {
+	onAir := InjectControlStatusSymbols(buildControlFrame(nac, duid, tsbk))
+	out := make([]uint8, offset+len(onAir)+16)
+	copy(out[offset:], onAir)
 	return out
 }
 
@@ -136,12 +145,16 @@ func TestControlChannelPublishesDecodeErrorOnUncorrectableNID(t *testing.T) {
 	sub := bus.Subscribe()
 	defer sub.Close()
 
-	// Stream with FSW followed by 32 dibits of garbage (not a valid NID).
-	stream := make([]uint8, 10+24+32+98)
-	copy(stream[10:], FrameSyncWord[:])
+	// Stream with FSW followed by 32 dibits of garbage (not a valid
+	// NID), interleaved with status symbols as it arrives on-air.
+	frame := make([]uint8, 24+32+98)
+	copy(frame, FrameSyncWord[:])
 	for i := 0; i < 32; i++ {
-		stream[10+24+i] = uint8(i*7) & 0x3
+		frame[24+i] = uint8(i*7) & 0x3
 	}
+	onAir := InjectControlStatusSymbols(frame)
+	stream := make([]uint8, 10+len(onAir)+16)
+	copy(stream[10:], onAir)
 
 	cc := NewControlChannel(bus, nil, 851_000_000)
 	cc.Process(stream, 0)
@@ -450,14 +463,18 @@ func TestControlChannelPublishesDecodeErrorOnCorruptTSBK(t *testing.T) {
 	sub := bus.Subscribe()
 	defer sub.Close()
 
-	// Valid FSW + valid NID + corrupted TSBK channel block.
-	stream := buildLockedStream(10, 0x111, DUIDTrunkingSignaling, OpRFSSStatusBroadcast)
-	tsbkStart := 10 + 24 + 32
+	// Valid FSW + valid NID + corrupted TSBK channel block. Corrupt the
+	// contiguous TSBK before status symbols are interleaved, so the
+	// flips land squarely on the 98-dibit channel block.
+	frame := buildControlFrame(0x111, DUIDTrunkingSignaling, TSBK{LB: true, Opcode: OpRFSSStatusBroadcast})
 	// Flip every dibit in the TSBK block — well beyond the Viterbi
 	// correction radius, so the CRC trailer will fail.
-	for i := tsbkStart; i < tsbkStart+98; i++ {
-		stream[i] = (^stream[i]) & 0x3
+	for i := 24 + 32; i < 24+32+98; i++ {
+		frame[i] = (^frame[i]) & 0x3
 	}
+	onAir := InjectControlStatusSymbols(frame)
+	stream := make([]uint8, 10+len(onAir)+16)
+	copy(stream[10:], onAir)
 
 	cc := NewControlChannel(bus, nil, 851_000_000)
 	cc.Process(stream, 0)

--- a/internal/radio/p25/phase1/receiver/harness_test.go
+++ b/internal/radio/p25/phase1/receiver/harness_test.go
@@ -69,8 +69,14 @@ var demodModes = []struct {
 
 // buildHarnessDibits assembles a canonical P25 Phase 1 control-channel
 // dibit stream: a 200-dibit warmup so the symbol-clock loop converges,
-// then `repeats` × (FSW + NID + TSBK + 50 idle dibits), then a
-// 100-dibit trailer.
+// then `repeats` × (status-interleaved FSW+NID+TSBK frame + 50 idle
+// dibits), then a 100-dibit trailer.
+//
+// Each frame carries the status symbols a real P25 transmitter
+// interleaves into the on-air stream (one per 36 dibits) — see
+// phase1.InjectControlStatusSymbols. Without them the receiver would
+// be fed an unrealistic status-free stream and the status-symbol
+// stripping in the control-channel decoder would go untested (#275).
 //
 // The warmup / idle / trailer filler is pseudo-random (fixed seed, so
 // the stream stays reproducible) and must not be periodic. Real P25
@@ -90,6 +96,9 @@ func buildHarnessDibits(nac uint16, repeats int) []uint8 {
 	}
 	tsbk := phase1.AssembleTSBK(phase1.TSBK{LB: true, Opcode: phase1.OpRFSSStatusBroadcast})
 	frame = append(frame, phase1.EncodeTSBKChannel(tsbk)...)
+	// Interleave the P25 status symbols a real transmitter inserts; the
+	// receiver must strip them to recover the NID and TSBK (#275).
+	frame = phase1.InjectControlStatusSymbols(frame)
 
 	out := make([]uint8, 0, 200+repeats*(len(frame)+50)+100)
 	for i := 0; i < 200; i++ {
@@ -318,6 +327,52 @@ func TestHarnessCleanControlChannelLocks(t *testing.T) {
 			}
 			if res.nac != harnessNAC {
 				t.Errorf("clean %s: locked NAC = %#x, want %#x", m.name, res.nac, harnessNAC)
+			}
+		})
+	}
+}
+
+// TestHarnessControlChannelStatusSymbols is the #275 regression guard
+// for the status-symbol fix. P25 interleaves a 2-bit status symbol into
+// the on-air dibit stream every 36 dibits (TIA-102.BAAA); buildHarnessDibits
+// now models that faithfully, so the control-channel decoder must strip
+// the status symbols before assembling the NID and TSBK.
+//
+// Before the fix the receiver read 32 contiguous dibits as the NID,
+// swallowing the status symbol that lands at on-air dibit 35 and
+// misaligning every NID dibit after it — the NID BCH error count pegged
+// at its t=11 ceiling on every frame and the channel never locked. The
+// failure was identical on the C4FM and CQPSK paths because the status
+// strip is a shared post-demod stage, so this guards both.
+//
+// The assertion is on the NID error count, not the TSBK: a stripped NID
+// decodes well inside the BCH radius, while the unstripped #275 symptom
+// pegs it at the ceiling. (TSBK decode errors are left to the
+// mode-specific harness tests — the CQPSK demod's residual error rate
+// is a separate concern from status-symbol alignment.)
+func TestHarnessControlChannelStatusSymbols(t *testing.T) {
+	for _, m := range demodModes {
+		t.Run(m.name, func(t *testing.T) {
+			res := runHarness(m.mode, demod.Impairments{})
+			if !res.locked {
+				t.Fatalf("%s: status-interleaved control channel did not lock "+
+					"(decodeErrors=%d, nidErrs min/max/n=%s) — the receiver is not "+
+					"stripping P25 status symbols (#275)",
+					m.name, res.decodeErrors, res.nidErrsSummary())
+			}
+			if res.nac != harnessNAC {
+				t.Errorf("%s: locked NAC = %#x, want %#x", m.name, res.nac, harnessNAC)
+			}
+			// 8 is the "systematically wrong" diagnostic threshold in
+			// control.go; an unstripped status symbol pegs every NID at
+			// the t=11 ceiling (or -1, uncorrectable).
+			for _, e := range res.nidErrs {
+				if e < 0 || e >= 8 {
+					t.Errorf("%s: a NID decoded with errs=%d, near the BCH ceiling — "+
+						"status symbols are not being stripped (#275); all NID "+
+						"errs(min/max/n)=%s", m.name, e, res.nidErrsSummary())
+					break
+				}
 			}
 		})
 	}

--- a/internal/scanner/ccdecoder/decoder_test.go
+++ b/internal/scanner/ccdecoder/decoder_test.go
@@ -981,6 +981,9 @@ func buildP25CCDibits(nac uint16, repeats int) []uint8 {
 		LB: true, Opcode: p25phase1.OpRFSSStatusBroadcast,
 	})
 	frame = append(frame, p25phase1.EncodeTSBKChannel(tsbk)...)
+	// Interleave the P25 status symbols a real transmitter inserts (one
+	// per 36 dibits); the receiver must strip them to decode the NID.
+	frame = p25phase1.InjectControlStatusSymbols(frame)
 
 	out := make([]uint8, 0, 200+repeats*(len(frame)+50)+100)
 	for i := 0; i < 200; i++ {


### PR DESCRIPTION
## Summary

Fixes the post-#316 field symptom on issue #275: after the C4FM filter fix, the decoder reaches NID parsing but the NID BCH pegs at its error ceiling and never locks — **identically on both `c4fm` and `cqpsk`**, which pointed at a shared post-demod stage.

**Root cause:** P25 Phase 1 interleaves a 2-bit status symbol into the on-air dibit stream every 36 dibits (35 data + 1 status) throughout every data unit — TSDU control frames included (TIA-102.BAAA; the same cadence `ldu.go` already models for voice LDUs). The control-channel decoder never stripped them. `parseFrame` read the NID as 32 *contiguous* dibits after the FSW. The 24-dibit FSW is contiguous (first status symbol lands at on-air dibit 35, after it — so FSW detection still worked), but that status symbol falls *inside* the NID region: the receiver swallowed it as NID data and misaligned ~21 of 32 NID dibits, so the BCH(63,16,11) decode never converged. The failure is mode-independent because both demodulators feed the same `parseFrame`.

The harness and integration tests never caught it — they built `FSW+NID+TSBK` as contiguous status-free dibits and modulated/demodulated self-consistently, so a missing strip was invisible.

**The fix:**
- `control.go` — `parseFrame` gathers the 32 NID and 98 TSBK data dibits with the new `gatherDataDibits`, skipping status symbols interleaved at the 36-dibit cadence (phase measured from the FSW). `frameLookahead` grows 130 → 134 to cover the 4 status symbols in the NID+TSBK span.
- `InjectControlStatusSymbols` — the inverse, builds the on-air status-interleaved stream a real transmitter emits, so synthetic test streams are now faithful instead of unrealistically status-free.
- `TestHarnessControlChannelStatusSymbols` — regression guard. Against the old contiguous read it fails on both modes with the exact field symptom (`nidErrs -1/-1/40`, no lock); with the strip both modes lock and decode the NID well inside the BCH radius.
- `control_test.go`, `integration_cc_test.go`, `decoder_test.go` — synthetic P25 control streams are now status-interleaved.

Note: CQPSK locks but still shows ~5% residual demod DER (TSBK CRC failures) — pre-existing and unrelated to status symbols (C4FM is bit-exact through the same harness); out of scope here.

## Test plan

- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test ./...` clean
- [x] `-race` on `phase1` / `receiver` / `ccdecoder` packages clean
- [x] `make integration-cc` and `make integration-cc-grant` pass (incl. `-race`)
- [x] `TestHarnessControlChannelStatusSymbols` reproduces the field bug against the unfixed contiguous read and passes with the fix
- [x] C4FM dibit error rate 0.0000 through the status-interleaved harness
- [ ] On-air retest by the issue reporter (the real confirmation)

https://claude.ai/code/session_01Qc4zddc3oMNFsM6JCcXEn6

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qc4zddc3oMNFsM6JCcXEn6)_