### PR TITLE
trunking: treat empty talkgroup CSV as zero records, not a load failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ for tagged releases.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Empty talkgroup CSV no longer reported as a load failure.** A
+  talkgroup CSV that existed but was empty (a freshly-touched
+  placeholder, or a system whose talkgroups aren't catalogued yet)
+  made the daemon log a scary `WARN talkgroup load failed … err="read
+  csv header: EOF"`. An empty file is a legitimate "no talkgroups"
+  state: `LoadCSV` now loads it cleanly as zero records, and preflight
+  surfaces an actionable `talkgroup_file … is empty` warning instead.
+
 ## [v0.1.8] — 2026-05-21
 
 P25 reception + voice-path release. The bulk of the work makes

--- a/cmd/gophertrunk/preflight.go
+++ b/cmd/gophertrunk/preflight.go
@@ -73,6 +73,12 @@ func preflight(cfg config.Config) ([]string, error) {
 			warnings = append(warnings,
 				fmt.Sprintf("trunking.systems[%s].talkgroup_file: %q is a directory; expected a CSV file",
 					sys.Name, sys.TalkgroupFile))
+			continue
+		}
+		if info.Size() == 0 {
+			warnings = append(warnings,
+				fmt.Sprintf("trunking.systems[%s].talkgroup_file: %q is empty — calls on this system will have no alpha tags",
+					sys.Name, sys.TalkgroupFile))
 		}
 	}
 

--- a/cmd/gophertrunk/preflight_test.go
+++ b/cmd/gophertrunk/preflight_test.go
@@ -61,6 +61,35 @@ func TestPreflightTalkgroupWarning(t *testing.T) {
 	}
 }
 
+func TestPreflightTalkgroupEmptyWarning(t *testing.T) {
+	// A talkgroup CSV that exists but is empty (zero bytes) must
+	// surface an actionable preflight warning rather than letting the
+	// daemon trip over a cryptic csv-header EOF at load time.
+	empty := filepath.Join(t.TempDir(), "talkgroups.csv")
+	if err := os.WriteFile(empty, nil, 0o644); err != nil {
+		t.Fatalf("write empty file: %v", err)
+	}
+	cfg := config.Config{
+		Trunking: config.TrunkingConfig{
+			Systems: []config.SystemConfig{{
+				Name:          "X",
+				Protocol:      "p25",
+				TalkgroupFile: empty,
+			}},
+		},
+	}
+	warnings, err := preflight(cfg)
+	if err != nil {
+		t.Fatalf("preflight: %v", err)
+	}
+	if len(warnings) == 0 {
+		t.Fatal("expected a warning for the empty talkgroup file")
+	}
+	if !strings.Contains(warnings[0], "empty") {
+		t.Errorf("warning %q should mention the file is empty", warnings[0])
+	}
+}
+
 func TestPreflightTLSMissing(t *testing.T) {
 	cfg := config.Config{
 		API: config.APIConfig{

--- a/internal/trunking/talkgroup.go
+++ b/internal/trunking/talkgroup.go
@@ -137,6 +137,13 @@ func (d *TalkgroupDB) LoadCSV(r io.Reader) (int, error) {
 	cr.TrimLeadingSpace = true
 	cr.FieldsPerRecord = -1
 	header, err := cr.Read()
+	if errors.Is(err, io.EOF) {
+		// An empty file is a legitimate "no talkgroups" state, not a
+		// load failure — a freshly-touched placeholder CSV or a system
+		// whose talkgroups aren't catalogued yet. Reporting zero loaded
+		// lets the daemon log a clean count instead of a cryptic EOF.
+		return 0, nil
+	}
 	if err != nil {
 		return 0, fmt.Errorf("trunking: read csv header: %w", err)
 	}

--- a/internal/trunking/talkgroup_test.go
+++ b/internal/trunking/talkgroup_test.go
@@ -94,6 +94,32 @@ func TestLoadCSVRequiresDecimal(t *testing.T) {
 	}
 }
 
+func TestLoadCSVEmptyFile(t *testing.T) {
+	// An empty file (zero bytes) is a valid "no talkgroups" state —
+	// it must load cleanly as zero records, not surface a csv-header
+	// EOF error that the daemon would log as a scary load failure.
+	d := NewTalkgroupDB()
+	n, err := d.LoadCSV(strings.NewReader(""))
+	if err != nil {
+		t.Fatalf("LoadCSV(empty): unexpected error %v", err)
+	}
+	if n != 0 {
+		t.Errorf("loaded %d from empty file, want 0", n)
+	}
+}
+
+func TestLoadCSVHeaderOnly(t *testing.T) {
+	// A header with no data rows is also a clean zero-record load.
+	d := NewTalkgroupDB()
+	n, err := d.LoadCSV(strings.NewReader("Decimal,Alpha Tag\n"))
+	if err != nil {
+		t.Fatalf("LoadCSV(header only): unexpected error %v", err)
+	}
+	if n != 0 {
+		t.Errorf("loaded %d from header-only file, want 0", n)
+	}
+}
+
 func TestLoadJSON(t *testing.T) {
 	js := `[
   {"id": 100, "alpha_tag": "OPS-1", "priority": 1},


### PR DESCRIPTION
A talkgroup CSV that existed but was empty made LoadCSV return the
cryptic "read csv header: EOF", which the daemon surfaced as a scary
WARN "talkgroup load failed". An empty file is a legitimate "no
talkgroups" state: LoadCSV now returns 0 records with no error, and
preflight emits an actionable "talkgroup_file is empty" warning.

https://claude.ai/code/session_01Ne7cYh3Ps1mRtB5qraZaz9