### PR TITLE
sdr: auto-detach DVB kernel driver on RTL-SDR claim EBUSY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ for tagged releases.
 
 ### Fixed
 
+- **RTL-SDR dongles now open even with the DVB kernel driver still
+  bound.** On Linux the kernel binds `dvb_usb_rtl28xxu` (the DVB-T
+  TV-tuner driver) to RTL-SDR dongles at plug time. An operator who
+  hadn't blacklisted that module saw the daemon fail every device
+  with `open device failed … claim interface 0: device or resource
+  busy` followed by `SDR pool open failed … no SDR devices opened` —
+  even though `sdr list` (which only reads USB descriptors) happily
+  showed the dongles. The USB layer now detaches the bound kernel
+  driver and retries the claim — the same auto-detach-kernel-driver
+  behaviour `librtlsdr` gets from libusb — so GopherTrunk opens the
+  dongle out of the box. Blacklisting the module is still recommended
+  (it stops the kernel grabbing the device first) but no longer
+  required. A claim error that survives the auto-detach now carries a
+  hint that another user-space process is holding the dongle.
 - **Empty talkgroup CSV no longer reported as a load failure.** A
   talkgroup CSV that existed but was empty (a freshly-touched
   placeholder, or a system whose talkgroups aren't catalogued yet)

--- a/docs/install-linux.md
+++ b/docs/install-linux.md
@@ -48,11 +48,15 @@ The tarball also bundles `config.example.yaml`, `README.md`, and
 ## 3. Grant USB access (one-time, every host)
 
 Linux ships a kernel DVB driver (`dvb_usb_rtl28xxu`) that grabs RTL-SDR
-dongles before user-space can claim them. We need to (a) stop the
-kernel from binding the device and (b) let your user open the USB
-device node without `sudo`. Both are one-shot config files.
+dongles before user-space can claim them. GopherTrunk detaches that
+driver automatically when it opens a dongle (the same trick `librtlsdr`
+uses), so blacklisting it is **optional** — but still recommended: a
+blacklist stops the kernel binding the device in the first place, one
+less moving part. The udev rule below is the step you do still need, so
+non-root processes can open the USB device node. Both are one-shot
+config files.
 
-**Blacklist the DVB driver** so it leaves the dongle alone:
+**Blacklist the DVB driver** (recommended) so it never touches the dongle:
 
 ```sh
 sudo tee /etc/modprobe.d/blacklist-dvb_usb_rtl28xxu.conf <<'EOF'
@@ -184,6 +188,7 @@ are left alone — remove them manually if you want a clean slate.
 | --------------------------------------- | -------------------------------------------------- |
 | `command not found: gophertrunk`        | Binary isn't on `PATH` — re-check step 2, or run `/usr/local/bin/gophertrunk` directly. |
 | `sdr list` prints nothing               | DVB driver still bound — `sudo modprobe -r dvb_usb_rtl28xxu` and re-plug. |
+| `claim interface 0: device or resource busy` | Another process already holds the dongle — close any other SDR app (`rtl_test`, SDR++, GQRX, or a second `gophertrunk`) and retry. GopherTrunk auto-detaches the DVB kernel driver, so this is no longer the DVB driver itself. |
 | `permission denied` on `/dev/bus/usb/…` | udev rule didn't apply — re-run `udevadm control --reload && udevadm trigger`, then re-plug. |
 | `usb: device disconnected` mid-stream   | Power-saving USB autosuspend kicked in — `echo on > /sys/bus/usb/devices/<id>/power/control`, or pin via udev. |
 | `tuner init: ... I2CWrite addr=0x34: broken pipe` | Tuner not ack-ing on the I²C bus. Most common: DVB kernel driver still bound — `sudo modprobe -r dvb_usb_rtl28xxu` and **physically re-plug** the dongle. Also seen with marginal USB power or USB 3.0 hubs — try a USB 2.0 port directly on the host. If `rtl_test` also prints `[R82XX] PLL not locked!` the tuner is in a half-init state; a full power cycle (unplug ~10s) clears it. If the workarounds above don't help, capture a wire-level trace with `RTLSDR_DEBUG_USB=1 gophertrunk sdr list --probe 2> usb-trace.log` and attach it to the issue alongside the matching `LIBUSB_DEBUG=4 rtl_test -t 2> rtl-test-trace.log` capture — diff-able traces tell us which control transfer is stalling. If those traces show the `data=18` SetI2CRepeater toggle firing right before the failing burst (gophertrunk emits it as of v0.1.6) and you've already pulled the latest release with the burst-EPIPE retry + open-path reset envelope (issue #248), escalate to a kernel-level usbmon capture — `LIBUSB_DEBUG=4` doesn't dump control-transfer payloads, but usbmon does: `sudo modprobe usbmon`, then `lsusb -d 0bda:2838` to find your bus number `N`, then in one session run `sudo tshark -i usbmon${N} -w gophertrunk.pcapng &` followed by the gophertrunk probe, kill the tshark, run a second `sudo tshark -i usbmon${N} -w rtl-test.pcapng &` followed by `LIBUSB_DEBUG=4 rtl_test -t`, kill the tshark, and attach both `.pcapng` files plus both `.log` files. usbmon shows the exact STALL response, NAK counts, and raw wire bytes that prove where librtlsdr and gophertrunk actually diverge on your hardware. |

--- a/internal/sdr/rtlsdr/purego/driver.go
+++ b/internal/sdr/rtlsdr/purego/driver.go
@@ -161,7 +161,7 @@ func (d *Driver) Open(idx int) (sdr.Device, error) {
 // return immediately — reset is the wrong hammer for them.
 func openDevice(transport usb.Transport, desc usb.Descriptor, idx int) (*Device, error) {
 	if err := transport.ClaimInterface(0); err != nil {
-		return nil, fmt.Errorf("rtlsdr: claim interface 0: %w", err)
+		return nil, fmt.Errorf("rtlsdr: claim interface 0: %w%s", err, claimBusyHint(err))
 	}
 
 	var (
@@ -281,6 +281,24 @@ func isBringupResetable(err error) bool {
 	return errors.Is(err, syscall.EPIPE) ||
 		errors.Is(err, usb.ErrDeviceGone) ||
 		errors.Is(err, usb.ErrTimeout)
+}
+
+// claimBusyHint returns a parenthesized, space-prefixed remediation
+// string when err is an EBUSY that survived the USB transport's
+// kernel-driver auto-detach. The transport already detaches the DVB-T
+// driver (dvb_usb_rtl28xxu) and retries, so a surviving EBUSY means the
+// interface is held by another *user-space* process — a second
+// gophertrunk, rtl_test, SDR++, GQRX — which detaching a kernel driver
+// cannot clear. Returns "" for unrelated errors so the wrapped message
+// stays clean.
+func claimBusyHint(err error) string {
+	if errors.Is(err, syscall.EBUSY) {
+		return " (hint: the dongle is already claimed by another process —" +
+			" close any other SDR app holding it (rtl_test, SDR++, GQRX," +
+			" or a second gophertrunk instance) and retry." +
+			" See https://mattcheramie.github.io/GopherTrunk/install-linux.html#troubleshooting)"
+	}
+	return ""
 }
 
 // tunerBringupHint returns a parenthesized, space-prefixed remediation

--- a/internal/sdr/rtlsdr/purego/driver_test.go
+++ b/internal/sdr/rtlsdr/purego/driver_test.go
@@ -464,6 +464,55 @@ func TestOpenDevice_WarmupTimeoutTwiceReturnsHintError(t *testing.T) {
 	}
 }
 
+// Regression for the "claim interface 0: device or resource busy"
+// report: the USB transport detaches the bound DVB kernel driver and
+// retries automatically, so an EBUSY that still reaches openDevice
+// means another user-space process holds the dongle. claimBusyHint
+// must turn that into actionable guidance; unrelated errors and nil
+// must pass through with an empty hint.
+func TestClaimBusyHint(t *testing.T) {
+	busy := claimBusyHint(fmt.Errorf("rtlsdr: claim interface 0: %w", syscall.EBUSY))
+	if !strings.Contains(busy, "another process") {
+		t.Errorf("claimBusyHint(EBUSY) = %q, want it to mention another process", busy)
+	}
+	if !strings.Contains(busy, "install-linux.html#troubleshooting") {
+		t.Errorf("claimBusyHint(EBUSY) = %q, want the troubleshooting link", busy)
+	}
+	if got := claimBusyHint(nil); got != "" {
+		t.Errorf("claimBusyHint(nil) = %q, want empty", got)
+	}
+	if got := claimBusyHint(errors.New("unrelated")); got != "" {
+		t.Errorf("claimBusyHint(unrelated) = %q, want empty", got)
+	}
+}
+
+// Regression for the "claim interface 0: device or resource busy"
+// report: when the USB transport cannot claim interface 0 because the
+// dongle is genuinely held by another process, openDevice must surface
+// the EBUSY wrapped with claimBusyHint — keeping the cause inspectable
+// via errors.Is while pointing the operator at the fix.
+func TestOpenDevice_ClaimBusySurfacesHint(t *testing.T) {
+	m := usb.NewMockTransport()
+	m.ClaimErr = syscall.EBUSY
+	desc := usb.Descriptor{VID: 0x0bda, PID: 0x2838, Serial: "test-claim-busy"}
+	_, err := openDevice(m, desc, 0)
+	if err == nil {
+		t.Fatal("openDevice succeeded; expected claim EBUSY to fail open")
+	}
+	if !errors.Is(err, syscall.EBUSY) {
+		t.Errorf("err = %v, want errors.Is(err, syscall.EBUSY)", err)
+	}
+	if !strings.Contains(err.Error(), "claim interface 0") {
+		t.Errorf("err = %v, want substring \"claim interface 0\" (identifies the failing stage)", err)
+	}
+	if !strings.Contains(err.Error(), "another process") {
+		t.Errorf("err = %v, want the claimBusyHint guidance appended", err)
+	}
+	if m.ResetCalls != 0 {
+		t.Errorf("ResetCalls = %d, want 0 (a claim failure must not trigger a USB reset)", m.ResetCalls)
+	}
+}
+
 // Regression: a non-resetable error class (here usb.ErrClosed) on the
 // warmup probe must surface immediately without any USB reset — reset
 // is the wrong hammer for "transport already closed" and would obscure

--- a/internal/sdr/rtlsdr/usb/usb_linux.go
+++ b/internal/sdr/rtlsdr/usb/usb_linux.go
@@ -52,6 +52,20 @@ type usbdevfsURB struct {
 	Usercontext     *byte
 }
 
+// usbdevfsIoctlArg mirrors struct usbdevfs_ioctl in
+// <linux/usbdevice_fs.h> — the argument to USBDEVFS_IOCTL, the
+// "ioctl within an ioctl" used to drive a bound kernel driver. We use
+// it to issue USBDEVFS_DISCONNECT against a single interface so the
+// kernel unbinds whatever driver currently owns it. The build tag at
+// the top of this file keeps Go's natural layout (int32, int32,
+// pointer) wire-identical to the kernel's struct on every supported
+// arch.
+type usbdevfsIoctlArg struct {
+	Ifno      int32 // interface number the inner ioctl targets
+	IoctlCode int32 // the inner ioctl request (USBDEVFS_DISCONNECT)
+	Data      *byte // inner ioctl payload; nil for DISCONNECT
+}
+
 const (
 	usbdevfsURBTypeBULK = 3
 )
@@ -79,7 +93,9 @@ var (
 	usbdevfsReapURB          = ioc(iocWrite, 'U', 12, unsafe.Sizeof(uintptr(0)))
 	usbdevfsClaimInterface   = ioc(iocRead, 'U', 15, 4)
 	usbdevfsReleaseInterface = ioc(iocRead, 'U', 16, 4)
+	usbdevfsIoctlCmd         = ioc(iocRead|iocWrite, 'U', 18, unsafe.Sizeof(usbdevfsIoctlArg{}))
 	usbdevfsReset            = ioc(iocNone, 'U', 20, 0)
+	usbdevfsDisconnect       = ioc(iocNone, 'U', 22, 0)
 )
 
 func platformEnumerator() Enumerator { return &linuxEnumerator{} }
@@ -248,19 +264,72 @@ func (t *linuxTransport) ControlOut(bRequest uint8, wValue, wIndex uint16, data 
 	return nil
 }
 
+// ClaimInterface tells the kernel this transport owns the given USB
+// interface. If the first attempt fails with EBUSY a kernel driver is
+// bound to the interface — on RTL-SDR dongles that is dvb_usb_rtl28xxu,
+// the DVB-T TV-tuner driver the kernel binds at plug time. We detach it
+// and retry once, mirroring libusb's LIBUSB_OPTION_AUTO_DETACH_KERNEL_-
+// DRIVER, so GopherTrunk claims the dongle even when the operator never
+// blacklisted the module. The driver is intentionally left detached:
+// re-binding it would only let it re-grab the interface and reintroduce
+// the race on the next open.
 func (t *linuxTransport) ClaimInterface(num int) error {
 	if t.closed.Load() {
 		return ErrClosed
 	}
-	n := uint32(num)
-	_, _, errno := unix.Syscall(unix.SYS_IOCTL, uintptr(t.fd), usbdevfsClaimInterface, uintptr(unsafe.Pointer(&n)))
-	if errno != 0 {
-		return translateErrno(errno)
+	if err := claimWithAutoDetach(
+		func() error { return t.claimInterface(num) },
+		func() error { return t.detachKernelDriver(num) },
+	); err != nil {
+		return err
 	}
 	t.claimMu.Lock()
 	t.claimed = append(t.claimed, num)
 	t.claimMu.Unlock()
 	return nil
+}
+
+// claimInterface issues a single USBDEVFS_CLAIMINTERFACE ioctl with no
+// retry and no bookkeeping — the raw building block ClaimInterface
+// drives through claimWithAutoDetach.
+func (t *linuxTransport) claimInterface(num int) error {
+	n := uint32(num)
+	_, _, errno := unix.Syscall(unix.SYS_IOCTL, uintptr(t.fd), usbdevfsClaimInterface, uintptr(unsafe.Pointer(&n)))
+	if errno != 0 {
+		return translateErrno(errno)
+	}
+	return nil
+}
+
+// detachKernelDriver issues USBDEVFS_DISCONNECT against interface num
+// via the USBDEVFS_IOCTL wrapper, telling the kernel to unbind whatever
+// driver currently owns it. Mirrors libusb_detach_kernel_driver.
+func (t *linuxTransport) detachKernelDriver(num int) error {
+	arg := usbdevfsIoctlArg{
+		Ifno:      int32(num),
+		IoctlCode: int32(usbdevfsDisconnect),
+	}
+	_, _, errno := unix.Syscall(unix.SYS_IOCTL, uintptr(t.fd), usbdevfsIoctlCmd, uintptr(unsafe.Pointer(&arg)))
+	if errno != 0 {
+		return translateErrno(errno)
+	}
+	return nil
+}
+
+// claimWithAutoDetach runs claim; on EBUSY (a kernel driver owns the
+// interface) it runs detach once and retries claim a single time.
+// Factored out of ClaimInterface as a pure function so the EBUSY →
+// detach → re-claim policy is unit-testable without a real usbdevfs
+// device node.
+func claimWithAutoDetach(claim, detach func() error) error {
+	err := claim()
+	if !errors.Is(err, unix.EBUSY) {
+		return err
+	}
+	if detachErr := detach(); detachErr != nil {
+		return fmt.Errorf("usbdevfs: interface busy, kernel-driver auto-detach failed: %w (original: %w)", detachErr, err)
+	}
+	return claim()
 }
 
 func (t *linuxTransport) ReleaseInterface(num int) error {

--- a/internal/sdr/rtlsdr/usb/usb_linux_test.go
+++ b/internal/sdr/rtlsdr/usb/usb_linux_test.go
@@ -3,10 +3,13 @@
 package usb
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
 	"unsafe"
+
+	"golang.org/x/sys/unix"
 )
 
 // fakeUSBDevice writes the sysfs files that linuxEnumerator.List reads.
@@ -159,6 +162,11 @@ func TestIoctlEncodings(t *testing.T) {
 	if got, want := usbdevfsReleaseInterface, uintptr(0x80045510); got != want {
 		t.Errorf("usbdevfsReleaseInterface = 0x%X, want 0x%X", got, want)
 	}
+	// USBDEVFS_DISCONNECT is _IO('U', 22) — direction NONE, size 0.
+	// _IOC encoding: (0<<30) | ('U'<<8) | 22 = 0x5516.
+	if got, want := usbdevfsDisconnect, uintptr(0x5516); got != want {
+		t.Errorf("usbdevfsDisconnect = 0x%X, want 0x%X", got, want)
+	}
 }
 
 func TestIoctlEncodings_64Bit(t *testing.T) {
@@ -181,4 +189,93 @@ func TestIoctlEncodings_64Bit(t *testing.T) {
 	if got, want := usbdevfsReapURB, uintptr(0x4008550C); got != want {
 		t.Errorf("usbdevfsReapURB = 0x%X, want 0x%X", got, want)
 	}
+	// USBDEVFS_IOCTL is _IOWR('U', 18, sizeof(struct usbdevfs_ioctl)).
+	// On 64-bit the struct is {int, int, void*} = 16 bytes, so the
+	// encoding is _IOWR('U', 18, 16) = 0xC0105512.
+	if got, want := usbdevfsIoctlCmd, uintptr(0xC0105512); got != want {
+		t.Errorf("usbdevfsIoctlCmd = 0x%X, want 0x%X", got, want)
+	}
+}
+
+// TestClaimWithAutoDetach covers the EBUSY → detach → re-claim policy
+// the Linux transport applies so a DVB-kernel-driver-bound RTL-SDR
+// dongle still opens (the "claim interface 0: device or resource busy"
+// report). The policy is a pure function over two closures, so it is
+// exercised here without a real usbdevfs device node.
+func TestClaimWithAutoDetach(t *testing.T) {
+	t.Run("claim succeeds first try, detach not called", func(t *testing.T) {
+		detachCalls := 0
+		err := claimWithAutoDetach(
+			func() error { return nil },
+			func() error { detachCalls++; return nil },
+		)
+		if err != nil {
+			t.Fatalf("err = %v, want nil", err)
+		}
+		if detachCalls != 0 {
+			t.Errorf("detach called %d times, want 0 (no EBUSY)", detachCalls)
+		}
+	})
+
+	t.Run("EBUSY then detach then re-claim succeeds", func(t *testing.T) {
+		claimCalls, detachCalls := 0, 0
+		err := claimWithAutoDetach(
+			func() error {
+				claimCalls++
+				if claimCalls == 1 {
+					return unix.EBUSY
+				}
+				return nil
+			},
+			func() error { detachCalls++; return nil },
+		)
+		if err != nil {
+			t.Fatalf("err = %v, want nil (re-claim after detach must succeed)", err)
+		}
+		if claimCalls != 2 {
+			t.Errorf("claim called %d times, want 2 (initial + post-detach retry)", claimCalls)
+		}
+		if detachCalls != 1 {
+			t.Errorf("detach called %d times, want 1", detachCalls)
+		}
+	})
+
+	t.Run("EBUSY survives detach and re-claim", func(t *testing.T) {
+		err := claimWithAutoDetach(
+			func() error { return unix.EBUSY },
+			func() error { return nil },
+		)
+		if !errors.Is(err, unix.EBUSY) {
+			t.Errorf("err = %v, want EBUSY (a user-space process still holds the interface)", err)
+		}
+	})
+
+	t.Run("detach failure wraps both errors", func(t *testing.T) {
+		detachErr := errors.New("disconnect ioctl failed")
+		err := claimWithAutoDetach(
+			func() error { return unix.EBUSY },
+			func() error { return detachErr },
+		)
+		if !errors.Is(err, detachErr) {
+			t.Errorf("err = %v, want it to wrap the detach failure", err)
+		}
+		if !errors.Is(err, unix.EBUSY) {
+			t.Errorf("err = %v, want it to also wrap the original EBUSY", err)
+		}
+	})
+
+	t.Run("non-EBUSY error passes through, detach not called", func(t *testing.T) {
+		detachCalls := 0
+		sentinel := errors.New("some other claim failure")
+		err := claimWithAutoDetach(
+			func() error { return sentinel },
+			func() error { detachCalls++; return nil },
+		)
+		if !errors.Is(err, sentinel) {
+			t.Errorf("err = %v, want the original non-EBUSY error", err)
+		}
+		if detachCalls != 0 {
+			t.Errorf("detach called %d times, want 0 (detach is EBUSY-only)", detachCalls)
+		}
+	})
 }

--- a/internal/sdr/rtlsdr/usb/usb_mock.go
+++ b/internal/sdr/rtlsdr/usb/usb_mock.go
@@ -80,6 +80,11 @@ type MockTransport struct {
 	ResetCalls int
 	ClaimCalls int
 
+	// ClaimErr, when non-nil, is returned by ClaimInterface instead of
+	// succeeding — lets tests exercise the driver's claim-failure path
+	// (e.g. an EBUSY that survives kernel-driver auto-detach).
+	ClaimErr error
+
 	BulkPackets  [][]byte
 	BulkInterval time.Duration
 
@@ -176,6 +181,9 @@ func (m *MockTransport) ClaimInterface(num int) error {
 	defer m.mu.Unlock()
 	if m.Closed {
 		return ErrClosed
+	}
+	if m.ClaimErr != nil {
+		return m.ClaimErr
 	}
 	m.ClaimedIfaces[num] = true
 	m.ClaimCalls++


### PR DESCRIPTION
On Linux the kernel binds dvb_usb_rtl28xxu (the DVB-T TV-tuner
driver) to RTL-SDR dongles at plug time. An operator who hadn't
blacklisted that module saw the daemon fail every device with
"claim interface 0: device or resource busy" and "no SDR devices
opened", even though "sdr list" (descriptors only, no claim)
showed the dongles fine.

The Linux USB transport now detaches the bound kernel driver via
USBDEVFS_DISCONNECT and retries the claim once on EBUSY — the same
auto-detach-kernel-driver behaviour librtlsdr gets from libusb — so
GopherTrunk opens the dongle without a manual modprobe blacklist.
A claim error that survives the auto-detach now carries a hint that
another user-space process is holding the dongle.

https://claude.ai/code/session_01KKPU6FpesrCdh7McFD9qkY