### PR TITLE
ccdecoder: log p25/phase1 NID-search params at startup (#275)

### DIFF
--- a/internal/radio/p25/phase1/control.go
+++ b/internal/radio/p25/phase1/control.go
@@ -181,14 +181,14 @@ const p25StatusStride = 36
 // FSW for a full frame to decode: the 32-dibit NID plus the 98-dibit
 // TSBK channel block — 130 data dibits — plus the 4 status symbols
 // interleaved into that span at the p25StatusStride cadence. Process
-// defers an FSW hit until this many dibits (plus nidSearchSpan, so the
+// defers an FSW hit until this many dibits (plus NIDSearchSpan, so the
 // +delta end of the alignment search stays in-buffer) have
 // accumulated, so frame assembly no longer depends on the IQ chunking.
 const frameLookahead = 130 + 4
 
-// nidSearchSpan bounds the parseFrame NID-alignment search: the NID is
+// NIDSearchSpan bounds the parseFrame NID-alignment search: the NID is
 // probed at the FSW-derived start index plus a delta in
-// [-nidSearchSpan, +nidSearchSpan]. ±6 dibits absorbs a compounded
+// [-NIDSearchSpan, +NIDSearchSpan]. ±6 dibits absorbs a compounded
 // post-FSW symbol slip and status-phase fault — issue #275, where the
 // field symptom was a reliably-detected FSW followed by an
 // always-uncorrectable NID, and the post-#321 retest converged on the
@@ -198,9 +198,9 @@ const frameLookahead = 130 + 4
 // of the marginal tier are what reject wrong alignments, so widening
 // the span cannot manufacture a false lock — only let the search
 // reach a true alignment that lies past the old edge.
-const nidSearchSpan = 6
+const NIDSearchSpan = 6
 
-// nidAcceptErrs is the highest BCH-corrected error count searchNID
+// NIDAcceptErrs is the highest BCH-corrected error count searchNID
 // treats as a genuine NID on the strength of the BCH + even-parity
 // gate alone — the "trusted tier". BCH(63,16,11) corrects up to 11,
 // but a parity-valid codeword 7+ corrections from the received word is
@@ -213,14 +213,25 @@ const nidSearchSpan = 6
 // which admits it only if the frame's TSBK also decodes (CRC) under the
 // same alignment. The TSBK CRC is a far stronger validator than the
 // NID's single parity bit, so a wrong alignment cannot fake it.
-const nidAcceptErrs = 6
+const NIDAcceptErrs = 6
 
-// nidCorroborateBudget caps how many marginal-tier NID hypotheses
-// (errs in (nidAcceptErrs, 11]) searchNID will TSBK-corroborate per FSW
-// hit. The grid yields at most 5×2×4 hypotheses; only the lowest-errs
-// few are worth a TSBK Viterbi decode, and the cap bounds the cost on
-// a noisy channel that never produces a trusted NID.
-const nidCorroborateBudget = 8
+// NIDCorroborateBudget caps how many marginal-tier NID hypotheses
+// (errs in (NIDAcceptErrs, NIDMarginalMaxErrs]) searchNID will
+// TSBK-corroborate per FSW hit. The grid yields at most 5×2×4
+// hypotheses; only the lowest-errs few are worth a TSBK Viterbi decode,
+// and the cap bounds the cost on a noisy channel that never produces a
+// trusted NID.
+const NIDCorroborateBudget = 8
+
+// NIDMarginalMaxErrs is the upper bound on the marginal tier's BCH
+// error count — the hard correction ceiling of BCH(63,16,11), the code
+// that protects the NID. Any hypothesis that decodes successfully comes
+// back with errs ≤ NIDMarginalMaxErrs; anything beyond is reported
+// uncorrectable. Exposed alongside NIDSearchSpan / NIDAcceptErrs so the
+// ccdecoder startup log can advertise the full accept envelope and a
+// field reporter can confirm at a glance which build is running (issue
+// #275: a retest cycle was already invalidated once by a stale build).
+const NIDMarginalMaxErrs = 11
 
 // Process consumes a window of dibits and runs detection/parsing.
 // baseIdx is the absolute dibit index of dibits[0]. Returns the
@@ -264,7 +275,7 @@ func (c *ControlChannel) Process(dibits []uint8, baseIdx int) int {
 		if nidStart < 0 {
 			continue // buffer already trimmed past this hit — drop it
 		}
-		if nidStart+frameLookahead+nidSearchSpan > len(c.buf) {
+		if nidStart+frameLookahead+NIDSearchSpan > len(c.buf) {
 			kept = append(kept, ph) // not enough buffered yet
 			continue
 		}
@@ -276,7 +287,7 @@ func (c *ControlChannel) Process(dibits []uint8, baseIdx int) int {
 }
 
 // parseFrame decodes the NID + TSBK of one FSW hit. buf[nidStart:]
-// must hold at least frameLookahead+nidSearchSpan dibits — the caller
+// must hold at least frameLookahead+NIDSearchSpan dibits — the caller
 // guarantees it. fswRot is the FSW-search rotation: the sync detector
 // matched after adding fswRot mod 4 to each input dibit; it seeds the
 // search and breaks ties so a clean frame binds deterministically.
@@ -286,7 +297,7 @@ func (c *ControlChannel) Process(dibits []uint8, baseIdx int) int {
 // not correlate otherwise) but mis-aligned by the post-FSW framing.
 // parseFrame therefore does not trust a single fixed read: searchNID
 // probes a bounded grid of alignment hypotheses (NID start ±
-// nidSearchSpan, status symbols stripped or not, all four dibit
+// NIDSearchSpan, status symbols stripped or not, all four dibit
 // rotations) and accepts the one whose NID clears the BCH(63,16,11) +
 // even-parity gate with the fewest corrections — or, when no NID
 // clears that gate cleanly, a marginal NID whose frame TSBK also
@@ -306,7 +317,7 @@ func (c *ControlChannel) parseFrame(buf []uint8, nidStart int, fswRot uint8) {
 	if best.errs > 0 {
 		c.log.Debug("nid corrected", "errs", best.errs, "nac", best.nid.NAC,
 			"rot", best.rot, "delta", best.delta, "strip", best.strip,
-			"corroborated", best.errs > nidAcceptErrs,
+			"corroborated", best.errs > NIDAcceptErrs,
 			"at_boundary", atSearchBoundary(best.delta))
 	}
 	if best.nid.DUID != DUIDTrunkingSignaling {
@@ -364,10 +375,10 @@ type nidGuess struct {
 // tiers:
 //
 //   - Trusted: a NID that BCH-decodes with a valid even-parity bit and
-//     errs ≤ nidAcceptErrs. If any exists, the fewest-corrections one
+//     errs ≤ NIDAcceptErrs. If any exists, the fewest-corrections one
 //     wins (betterNID) — the original, fast path, unchanged.
 //   - Marginal: only when no trusted NID exists, a NID with errs in
-//     (nidAcceptErrs, 11] is admitted if the frame's 98-dibit TSBK also
+//     (NIDAcceptErrs, 11] is admitted if the frame's 98-dibit TSBK also
 //     decodes (Viterbi + CRC) under the same alignment. The TSBK CRC is
 //     the second validator a wrong alignment cannot fake — issue #275,
 //     where a strong-site NID sat permanently at 9/10/11 BCH errors.
@@ -382,9 +393,9 @@ func (c *ControlChannel) searchNID(buf []uint8, nidStart int, fswRot uint8) (nid
 	closestMiss := -1 // lowest BCH errs of a parity-rejected near-miss
 	var missAt nidGuess
 	uncorrectable, tried := 0, 0
-	var marginal []nidGuess // parity-valid NIDs with errs > nidAcceptErrs
+	var marginal []nidGuess // parity-valid NIDs with errs > NIDAcceptErrs
 
-	for delta := -nidSearchSpan; delta <= nidSearchSpan; delta++ {
+	for delta := -NIDSearchSpan; delta <= NIDSearchSpan; delta++ {
 		start := nidStart + delta
 		if start < 0 || start+frameLookahead > len(buf) {
 			continue
@@ -406,7 +417,7 @@ func (c *ControlChannel) searchNID(buf []uint8, nidStart int, fswRot uint8) (nid
 				}
 				cand := nidGuess{delta: delta, strip: strip, rot: rot,
 					nid: nid, errs: errs, tsbkStart: tsbkStart}
-				if errs > nidAcceptErrs {
+				if errs > NIDAcceptErrs {
 					// Parity-valid but too far from the received word for
 					// BCH+parity to tell a noisy real NID from a bad
 					// alignment's miscorrection. Defer to the marginal
@@ -432,8 +443,8 @@ func (c *ControlChannel) searchNID(buf []uint8, nidStart int, fswRot uint8) (nid
 			return betterNID(marginal[i], marginal[j], fswRot)
 		})
 		budget := len(marginal)
-		if budget > nidCorroborateBudget {
-			budget = nidCorroborateBudget
+		if budget > NIDCorroborateBudget {
+			budget = NIDCorroborateBudget
 		}
 		for _, g := range marginal[:budget] {
 			if tsbkCorroborates(buf, g, nidStart) {
@@ -455,7 +466,7 @@ func (c *ControlChannel) searchNID(buf []uint8, nidStart int, fswRot uint8) (nid
 }
 
 // atSearchBoundary reports whether an alignment hypothesis sits at the
-// edge of the nidSearchSpan grid. A "best" or closest-miss at the
+// edge of the NIDSearchSpan grid. A "best" or closest-miss at the
 // boundary is the textbook signature of a bounded search pegged at its
 // limit — issue #275, where the post-#321 retest converged on delta=2
 // (the ±2 grid's positive edge) every frame. Flagging it in the logs
@@ -463,14 +474,14 @@ func (c *ControlChannel) searchNID(buf []uint8, nidStart int, fswRot uint8) (nid
 // edge → the true offset exceeds the span; interior with low errs →
 // the framing was the cause and the fix worked.
 func atSearchBoundary(delta int) bool {
-	return delta == nidSearchSpan || delta == -nidSearchSpan
+	return delta == NIDSearchSpan || delta == -NIDSearchSpan
 }
 
 // boundaryNote returns a diag-string suffix to append when a closest /
 // best hypothesis sits at the search boundary; empty otherwise.
 func boundaryNote(delta int) string {
 	if atSearchBoundary(delta) {
-		return fmt.Sprintf(" — best alignment at search boundary (±%d); true offset may exceed span", nidSearchSpan)
+		return fmt.Sprintf(" — best alignment at search boundary (±%d); true offset may exceed span", NIDSearchSpan)
 	}
 	return ""
 }

--- a/internal/radio/p25/phase1/control_test.go
+++ b/internal/radio/p25/phase1/control_test.go
@@ -512,7 +512,7 @@ func TestControlChannelPublishesDecodeErrorOnCorruptTSBK(t *testing.T) {
 // reporter observed, where the FSW detects reliably but the NID, shifted
 // by a dibit or two, never BCH-decodes under a fixed single-offset read.
 // parseFrame's bounded alignment search must recover the lock across the
-// full nidSearchSpan range — slips 1..6 after the span was widened from
+// full NIDSearchSpan range — slips 1..6 after the span was widened from
 // the original ±2 (which left field retests pegged at the +2 edge every
 // frame; #275 post-#321).
 func TestControlChannelLocksThroughPostFSWSlip(t *testing.T) {
@@ -553,7 +553,7 @@ func TestControlChannelLocksThroughPostFSWSlip(t *testing.T) {
 // Process call carries only ~19 dibits, so the slipped frame straddles
 // many calls and parseFrame runs under whatever buffer state
 // trimBuffer leaves it in. The widened search must still recover the
-// lock — i.e. the buffer math at the new nidSearchSpan stays
+// lock — i.e. the buffer math at the new NIDSearchSpan stays
 // consistent with cross-call frame assembly (#275 post-#321).
 func TestControlChannelLocksThroughPostFSWSlipSmallChunks(t *testing.T) {
 	for _, slip := range []int{1, 3, 6} {
@@ -607,11 +607,11 @@ func TestSearchBoundaryHelpers(t *testing.T) {
 	}{
 		{0, false},
 		{1, false},
-		{nidSearchSpan - 1, false},
-		{nidSearchSpan, true},
-		{-nidSearchSpan, true},
-		{-(nidSearchSpan - 1), false},
-		{nidSearchSpan + 1, false}, // outside the grid; not "at" boundary
+		{NIDSearchSpan - 1, false},
+		{NIDSearchSpan, true},
+		{-NIDSearchSpan, true},
+		{-(NIDSearchSpan - 1), false},
+		{NIDSearchSpan + 1, false}, // outside the grid; not "at" boundary
 	}
 	for _, tc := range cases {
 		got := atSearchBoundary(tc.delta)
@@ -630,7 +630,7 @@ func TestSearchBoundaryHelpers(t *testing.T) {
 }
 
 // TestSearchNIDFailureDiagFlagsBoundary exercises the wiring of
-// boundaryNote into searchNID's failure diag. A slip past nidSearchSpan
+// boundaryNote into searchNID's failure diag. A slip past NIDSearchSpan
 // can never be recovered; we feed several deliberately-corrupt streams
 // and assert that at least one of the failure diags surfaces the
 // "search boundary" suffix. This guards the format-string call to
@@ -811,7 +811,7 @@ func TestControlChannelNoFalseLockOnNoise(t *testing.T) {
 
 // TestControlChannelLocksOnMarginalNIDCorroboratedByTSBK injects 8 bit
 // errors into the NID — inside BCH(63,16,11)'s t=11 radius but past the
-// nidAcceptErrs=6 trusted threshold — while leaving the TSBK intact.
+// NIDAcceptErrs=6 trusted threshold — while leaving the TSBK intact.
 // searchNID's marginal tier must still lock, because the frame's TSBK
 // decodes cleanly under the same alignment and corroborates the NID.
 // This is issue #275's strong-site symptom: a NID that BCH-decodes but

--- a/internal/scanner/ccdecoder/pipelines.go
+++ b/internal/scanner/ccdecoder/pipelines.go
@@ -186,9 +186,20 @@ func newP25Phase1Pipeline(opts PipelineOptions) (ProtocolPipeline, error) {
 	// what issue reporters paste, and a git-describe string there is
 	// the only reliable way to tell which fixes a build contains —
 	// issue #275 saw a retest invalidated by a silently stale build.
+	//
+	// rotations / nid_search_span / nid_accept_errs / nid_marginal_max
+	// pin the same retest-verification surface to the decode parameters
+	// themselves: a stale build that still uses RotationsAll on a C4FM
+	// site or the old ±2 search will show its signature in this line
+	// without anyone having to read source.
 	log.Info("ccdecoder: p25/phase1 pipeline configured",
 		"system", opts.SystemName, "freq_hz", opts.FrequencyHz,
-		"demod", demodModeLabel(demodMode), "build", version.String())
+		"demod", demodModeLabel(demodMode),
+		"rotations", rotations,
+		"nid_search_span", p25phase1.NIDSearchSpan,
+		"nid_accept_errs", p25phase1.NIDAcceptErrs,
+		"nid_marginal_max", p25phase1.NIDMarginalMaxErrs,
+		"build", version.String())
 	return &p25Phase1Pipeline{rx: rx, cc: cc}, nil
 }
 


### PR DESCRIPTION
The most recent retest comment on issue #275 (er-imagery, 2026-05-22)
was filed against build v0.1.9-6-g6cadd31, which predates commit
6b408c7 — the PR that widened nidSearchSpan from ±2 to ±6 and restricted
the C4FM rotation search to {0, 2}. The reported symptoms (`delta=2`
sitting at the old search boundary; `rot=3` appearing on a C4FM site)
are the textbook signature of that stale build, and a previous retest
on the same issue had already been invalidated by the same stale-build
problem.

Surface the decode parameters in the existing "p25/phase1 pipeline
configured" log line so the very first decoder banner a field reporter
sees pins the build's actual behaviour, not just its version string:
the rotation set, search span, accept gate, and BCH marginal ceiling.
A stale build that still uses RotationsAll on a C4FM site, or the old
±2 search, now shows its signature in that one line.

Export NIDSearchSpan / NIDAcceptErrs / NIDCorroborateBudget (formerly
package-private) and introduce NIDMarginalMaxErrs = 11 for the
BCH(63,16,11) hard correction ceiling — these are documented, stable
parameters and the ccdecoder pipeline now references them by name
instead of duplicating the literals.

https://claude.ai/code/session_01TKRJfYVABRQ1K6FVoph8CA