### PR TITLE
SDRtrunk parity, part 3: HackRF and Airspy pure-Go drivers (WP5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ for tagged releases.
 
 ## [Unreleased]
 
+### Added
+
+- **HackRF One and Airspy R2 / Mini pure-Go drivers.** New
+  `internal/sdr/hackrf` and `internal/sdr/airspy` packages implement
+  the `sdr.Driver` / `sdr.Device` interfaces on top of the same
+  pure-Go USB transport (USBDEVFS / WinUSB / IOKit) the RTL-SDR
+  driver uses — no `libhackrf` or `libairspy` at build or runtime,
+  so the zero-CGO single-binary guarantee holds. The drivers speak
+  the documented libhackrf and libairspy USB vendor protocols
+  (transceiver / receiver mode, frequency, sample rate, LNA / VGA /
+  mixer / amp / bias-tee gains, bulk-IN sample reaper with real-time
+  decode of HackRF int8 IQ and Airspy INT16_IQ into complex64). Both
+  register themselves with the SDR driver registry on init, so a
+  blank import from `cmd/gophertrunk` is the only wiring needed. The
+  wire protocols are unit-tested against `usb.MockTransport`; on-air
+  validation against attached HackRF / Airspy hardware is the
+  documented follow-up.
+
 ### Fixed
 
 - **RTL-SDR dongles now open even with the DVB kernel driver still

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Full per-OS install (Windows installer / macOS Apple Silicon / Linux aarch64): *
 
 **Pure-Go voice path** — IMBE (P25 Phase 1) and AMBE+2 (P25 Phase 2 / DMR / NXDN) vocoders implemented in Go, no DVSI / mbelib dependency. Per-call WAV + raw-frame sidecars; live PCM playback via direct ALSA / WASAPI / CoreAudio (no `libasound2` at runtime).
 
-**SDR layer** — Pure-Go RTL-SDR driver across USBDEVFS (Linux), WinUSB (Windows), IOKit (macOS). All major tuner drivers (R820T / R820T2 / R828D / E4000 / FC0012 / FC0013 / FC2580) — each a wire-level port of osmocom librtlsdr's `tuner_*.c`, with librtlsdr-parity init burst chunking, EPIPE warmup + reset on Open, balanced LNA+Mixer gain algorithm, and the same `rtlsdr_open` probe order + GPIO 4/5/6 dances for non-R820T detection. I²C bridge toggles once per public method (`SetFreq`/`SetGain`/...) instead of per register write — drops ~10× the USB control transfers per retune on busy hubs. Multi-device pool with role assignment, per-device gain / PPM / bias-tee.
+**SDR layer** — Pure-Go drivers for **RTL-SDR**, **HackRF One** and **Airspy R2 / Mini**, all sharing the same pure-Go USB transport (USBDEVFS on Linux, WinUSB on Windows, IOKit on macOS) — no `librtlsdr` / `libhackrf` / `libairspy` at build or runtime. The RTL-SDR backend includes wire-level ports of every osmocom tuner (R820T / R820T2 / R828D / E4000 / FC0012 / FC0013 / FC2580) with librtlsdr-parity init burst chunking, EPIPE warmup + reset on Open, balanced LNA+Mixer gain, and the same `rtlsdr_open` probe order + GPIO 4/5/6 dances for non-R820T detection. The HackRF and Airspy drivers speak the documented libhackrf / libairspy USB vendor protocols (set freq / sample rate / gains / bias-tee, bulk-IN sample reaper, real-time sample decode to complex64); on-air validation against attached HackRF / Airspy hardware is the documented follow-up, but the wire protocols are exercised under unit tests against `usb.MockTransport`. Multi-device pool with role assignment, per-device gain / PPM / bias-tee.
 
 **DSP** — Polyphase channelizer + CIC + halfband, Kaiser / RRC / Gaussian FIR designers, FM / C4FM / GFSK / FFSK / DQPSK / π/4-DQPSK / π/8-H-DQPSK demods, Mueller-Müller + Gardner clock recovery, LMS + CMA blind equalizers, Selection + maximal-ratio diversity combining.
 
@@ -112,11 +112,11 @@ MPT 1327) now decodes voice through the composer's FM chain.
 
 The remaining gaps:
 
-- **Additional SDR hardware.** Only RTL-SDR is supported. Airspy
-  and HackRF are pure-USB and portable to a pure-Go driver like the
-  existing RTL-SDR one, but that work is not yet done; SDRPlay /
-  USRP / BladeRF need vendor C libraries and are out of scope for
-  the zero-CGO build.
+- **Additional SDR hardware.** RTL-SDR, HackRF One and Airspy R2 /
+  Mini are all supported by pure-Go drivers; on-air validation of
+  the HackRF / Airspy backends against attached hardware is the
+  documented follow-up. SDRPlay / USRP / BladeRF need vendor C
+  libraries and are out of scope for the zero-CGO build.
 - **Digital-voice composer chains.** FM (incl. analog trunking),
   DMR and P25 Phase 1/2 decode to audio; NXDN, dPMR, TETRA, YSF and
   D-STAR voice chains, plus EDACS ProVoice, are still bypassed —

--- a/cmd/gophertrunk/main.go
+++ b/cmd/gophertrunk/main.go
@@ -16,9 +16,11 @@ import (
 	"github.com/MattCheramie/GopherTrunk/internal/config"
 	gtlog "github.com/MattCheramie/GopherTrunk/internal/log"
 	"github.com/MattCheramie/GopherTrunk/internal/sdr"
-	// Pure-Go RTL-SDR driver. Registers under the canonical name
-	// "rtlsdr"; PR-09 removed the legacy CGO librtlsdr backend that
-	// previously coexisted under "rtlsdr-cgo".
+	// Pure-Go SDR drivers. Each registers itself under its canonical
+	// name on init; the blank import is what actually links the
+	// package into the binary.
+	_ "github.com/MattCheramie/GopherTrunk/internal/sdr/airspy"
+	_ "github.com/MattCheramie/GopherTrunk/internal/sdr/hackrf"
 	_ "github.com/MattCheramie/GopherTrunk/internal/sdr/rtlsdr/purego"
 	"github.com/MattCheramie/GopherTrunk/internal/version"
 

--- a/internal/sdr/airspy/airspy.go
+++ b/internal/sdr/airspy/airspy.go
@@ -1,0 +1,454 @@
+// Package airspy is a pure-Go driver for the Airspy R2 / Airspy Mini
+// software-defined radios, implementing [sdr.Driver] and [sdr.Device].
+//
+// It speaks the libairspy USB vendor protocol directly over the shared
+// pure-Go USB transport at internal/sdr/rtlsdr/usb — the same transport
+// the RTL-SDR driver uses — so no CGO and no libairspy are pulled into
+// the build. Real-hardware validation against an attached Airspy is a
+// documented follow-up; the in-package tests exercise the wire
+// protocol against a usb.MockTransport.
+//
+// Sample format: this driver pins the device to INT16_IQ — signed
+// 16-bit interleaved IQ pairs (4 bytes per sample) — and converts each
+// pair to a complex64 with components in [-1, 1].
+package airspy
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/MattCheramie/GopherTrunk/internal/sdr"
+	"github.com/MattCheramie/GopherTrunk/internal/sdr/rtlsdr/usb"
+)
+
+// USB IDs. Airspy R2 and Airspy Mini both enumerate on this pair.
+const (
+	vidAirspy uint16 = 0x1d50
+	pidAirspy uint16 = 0x60a1
+)
+
+// libairspy vendor request opcodes (subset).
+const (
+	reqReceiverMode   uint8 = 1
+	reqSetSampleType  uint8 = 11
+	reqSetFreq        uint8 = 12
+	reqGetSamplerates uint8 = 13
+	reqSetSamplerate  uint8 = 14
+	reqSetLNAGain     uint8 = 19
+	reqSetMixerGain   uint8 = 20
+	reqSetVGAGain     uint8 = 21
+	reqSetLNAAGC      uint8 = 22
+	reqSetMixerAGC    uint8 = 23
+	reqSetRFBiasCmd   uint8 = 24
+)
+
+// Sample-type values for reqSetSampleType.
+const (
+	sampleTypeFloat32IQ uint16 = 0
+	sampleTypeInt16IQ   uint16 = 2
+)
+
+const (
+	receiverModeOff uint16 = 0
+	receiverModeOn  uint16 = 1
+
+	bulkInEP   byte = 0x81
+	driverName      = "airspy"
+
+	defaultVGAGain   = 10
+	controlTimeoutMs = 1000
+)
+
+// Driver implements sdr.Driver for Airspy.
+type Driver struct {
+	enum usb.Enumerator
+
+	mu     sync.Mutex
+	cached []usb.Descriptor
+}
+
+// New returns a Driver backed by enum (nil → platform default).
+func New(enum usb.Enumerator) *Driver {
+	if enum == nil {
+		enum = usb.DefaultEnumerator()
+	}
+	return &Driver{enum: enum}
+}
+
+// Name implements sdr.Driver.
+func (d *Driver) Name() string { return driverName }
+
+// Enumerate finds every Airspy on the bus and caches the descriptor
+// list so a subsequent Open reuses the same ordering.
+func (d *Driver) Enumerate() ([]sdr.Info, error) {
+	descs, err := d.enum.List(vidAirspy, pidAirspy)
+	if err != nil {
+		return nil, fmt.Errorf("airspy: enumerate: %w", err)
+	}
+	d.mu.Lock()
+	d.cached = descs
+	d.mu.Unlock()
+
+	out := make([]sdr.Info, len(descs))
+	for i, desc := range descs {
+		serial := desc.Serial
+		if serial == "" {
+			serial = fmt.Sprintf("airspy-%02d", i)
+		}
+		out[i] = sdr.Info{
+			Driver:       driverName,
+			Index:        i,
+			Serial:       serial,
+			Manufacturer: desc.Manufacturer,
+			Product:      desc.Product,
+			TunerName:    "R820T",
+			// Indicative tenth-dB presets; the driver also accepts
+			// a free-form SetGain value.
+			Gains: []int{0, 100, 200, 300, 400, 500},
+		}
+	}
+	return out, nil
+}
+
+// Open claims the device at idx and returns an sdr.Device. The
+// returned device defaults to INT16_IQ sample mode and the highest
+// rate the firmware advertises.
+func (d *Driver) Open(idx int) (sdr.Device, error) {
+	d.mu.Lock()
+	cached := d.cached
+	d.mu.Unlock()
+	if cached == nil {
+		if _, err := d.Enumerate(); err != nil {
+			return nil, err
+		}
+		d.mu.Lock()
+		cached = d.cached
+		d.mu.Unlock()
+	}
+	if idx < 0 || idx >= len(cached) {
+		return nil, fmt.Errorf("airspy: index %d out of range", idx)
+	}
+	desc := cached[idx]
+	t, err := d.enum.Open(desc)
+	if err != nil {
+		return nil, fmt.Errorf("airspy: open %s: %w", desc.Path, err)
+	}
+	if err := t.ClaimInterface(0); err != nil {
+		_ = t.Close()
+		return nil, fmt.Errorf("airspy: claim interface 0: %w", err)
+	}
+	dev := &Device{
+		t: t,
+		info: sdr.Info{
+			Driver:       driverName,
+			Index:        idx,
+			Serial:       fallbackSerial(desc.Serial, idx),
+			Manufacturer: desc.Manufacturer,
+			Product:      desc.Product,
+			TunerName:    "R820T",
+		},
+	}
+	// Pin the device to INT16_IQ — the format the StreamIQ decoder
+	// expects.
+	if err := t.ControlOut(reqSetSampleType, sampleTypeInt16IQ, 0, nil, controlTimeoutMs); err != nil {
+		_ = dev.Close()
+		return nil, fmt.Errorf("airspy: set sample type: %w", err)
+	}
+	// Read the supported-samplerate table so SetSampleRate can match
+	// the requested rate against an index.
+	rates, err := dev.fetchSampleRates()
+	if err != nil {
+		// Non-fatal: keep the device usable; SetSampleRate will fall
+		// back to index 0.
+		dev.rates = nil
+	} else {
+		dev.rates = rates
+	}
+	return dev, nil
+}
+
+func fallbackSerial(s string, idx int) string {
+	if s != "" {
+		return s
+	}
+	return fmt.Sprintf("airspy-%02d", idx)
+}
+
+// Device is one opened Airspy.
+type Device struct {
+	t    usb.Transport
+	info sdr.Info
+
+	mu        sync.Mutex
+	closed    bool
+	streaming bool
+	rates     []uint32 // supported sample rates, Hz, descending order
+}
+
+// Info implements sdr.Device.
+func (d *Device) Info() sdr.Info { return d.info }
+
+// SetCenterFreq programs the R820T to hz Hz.
+func (d *Device) SetCenterFreq(hz uint32) error {
+	if d.isClosed() {
+		return usb.ErrClosed
+	}
+	payload := make([]byte, 4)
+	binary.LittleEndian.PutUint32(payload, hz)
+	return d.t.ControlOut(reqSetFreq, 0, 0, payload, controlTimeoutMs)
+}
+
+// SetSampleRate selects the firmware-advertised rate closest to hz. If
+// the supported-rate table is unavailable, index 0 is used.
+func (d *Device) SetSampleRate(hz uint32) error {
+	if d.isClosed() {
+		return usb.ErrClosed
+	}
+	idx := d.closestRateIndex(hz)
+	return d.t.ControlOut(reqSetSamplerate, uint16(idx), 0, nil, controlTimeoutMs)
+}
+
+// closestRateIndex returns the index of the supported sample rate
+// nearest hz. If no table is known, it returns 0.
+func (d *Device) closestRateIndex(hz uint32) int {
+	d.mu.Lock()
+	rates := d.rates
+	d.mu.Unlock()
+	if len(rates) == 0 {
+		return 0
+	}
+	best, bestDiff := 0, ^uint32(0)
+	for i, r := range rates {
+		diff := r
+		if hz > r {
+			diff = hz - r
+		} else {
+			diff = r - hz
+		}
+		if diff < bestDiff {
+			best, bestDiff = i, diff
+		}
+	}
+	return best
+}
+
+// SetGain accepts a single tenth-dB target and distributes it across
+// the Airspy's three R820T stages (LNA, mixer, VGA), each 0–15. A
+// negative value enables LNA + mixer AGC, matching libairspy's
+// "auto" behaviour, and fixes the VGA at a sensible mid-band value.
+func (d *Device) SetGain(tenthDB int) error {
+	if d.isClosed() {
+		return usb.ErrClosed
+	}
+	if tenthDB < 0 {
+		if err := d.setLNAAGC(true); err != nil {
+			return err
+		}
+		if err := d.setMixerAGC(true); err != nil {
+			return err
+		}
+		return d.setVGAGain(defaultVGAGain)
+	}
+	if err := d.setLNAAGC(false); err != nil {
+		return err
+	}
+	if err := d.setMixerAGC(false); err != nil {
+		return err
+	}
+	lna, mixer, vga := splitAirspyGain(tenthDB)
+	if err := d.setLNAGain(lna); err != nil {
+		return err
+	}
+	if err := d.setMixerGain(mixer); err != nil {
+		return err
+	}
+	return d.setVGAGain(vga)
+}
+
+// splitAirspyGain distributes a tenth-dB target across the three R820T
+// gain stages. Each step covers roughly 3 dB; remaining gain rolls
+// from LNA → mixer → VGA. Values clamp to 0–15 per stage.
+func splitAirspyGain(tenthDB int) (lna, mixer, vga int) {
+	const step = 30 // tenths of dB per stage unit
+	lna = clamp15(tenthDB / step)
+	mixer = clamp15((tenthDB - lna*step) / step)
+	vga = clamp15((tenthDB - lna*step - mixer*step) / step)
+	return
+}
+
+func clamp15(v int) int {
+	if v < 0 {
+		return 0
+	}
+	if v > 15 {
+		return 15
+	}
+	return v
+}
+
+func (d *Device) setLNAGain(v int) error {
+	_, err := d.t.ControlIn(reqSetLNAGain, 0, uint16(v), 1, controlTimeoutMs)
+	return err
+}
+func (d *Device) setMixerGain(v int) error {
+	_, err := d.t.ControlIn(reqSetMixerGain, 0, uint16(v), 1, controlTimeoutMs)
+	return err
+}
+func (d *Device) setVGAGain(v int) error {
+	_, err := d.t.ControlIn(reqSetVGAGain, 0, uint16(v), 1, controlTimeoutMs)
+	return err
+}
+func (d *Device) setLNAAGC(on bool) error {
+	v := uint16(0)
+	if on {
+		v = 1
+	}
+	_, err := d.t.ControlIn(reqSetLNAAGC, 0, v, 1, controlTimeoutMs)
+	return err
+}
+func (d *Device) setMixerAGC(on bool) error {
+	v := uint16(0)
+	if on {
+		v = 1
+	}
+	_, err := d.t.ControlIn(reqSetMixerAGC, 0, v, 1, controlTimeoutMs)
+	return err
+}
+
+// SetPPM is a no-op for Airspy — the Si5351C reference clock is
+// internally trimmed and the libairspy protocol carries no PPM.
+func (d *Device) SetPPM(int) error { return nil }
+
+// SetBiasTee toggles the bias-T on the antenna SMA.
+func (d *Device) SetBiasTee(enable bool) error {
+	if d.isClosed() {
+		return usb.ErrClosed
+	}
+	v := uint16(0)
+	if enable {
+		v = 1
+	}
+	return d.t.ControlOut(reqSetRFBiasCmd, v, 0, nil, controlTimeoutMs)
+}
+
+// StreamIQ flips the receiver on and starts the bulk-IN reaper,
+// delivering one complex64 chunk per URB.
+func (d *Device) StreamIQ(ctx context.Context) (<-chan []complex64, error) {
+	d.mu.Lock()
+	if d.closed {
+		d.mu.Unlock()
+		return nil, usb.ErrClosed
+	}
+	if d.streaming {
+		d.mu.Unlock()
+		return nil, errors.New("airspy: stream already active")
+	}
+	d.streaming = true
+	d.mu.Unlock()
+
+	if err := d.setReceiver(receiverModeOn); err != nil {
+		d.mu.Lock()
+		d.streaming = false
+		d.mu.Unlock()
+		return nil, fmt.Errorf("airspy: receiver on: %w", err)
+	}
+
+	out := make(chan []complex64, 8)
+	onPacket := func(buf []byte) {
+		samples := decodeInt16IQ(buf)
+		select {
+		case out <- samples:
+		case <-ctx.Done():
+		}
+	}
+	if err := d.t.StartBulkIn(bulkInEP, usb.DefaultRingBuffers, usb.DefaultBufferLen, onPacket); err != nil {
+		_ = d.setReceiver(receiverModeOff)
+		d.mu.Lock()
+		d.streaming = false
+		d.mu.Unlock()
+		return nil, fmt.Errorf("airspy: start bulk-in: %w", err)
+	}
+
+	go func() {
+		defer close(out)
+		<-ctx.Done()
+		_ = d.t.StopBulkIn()
+		_ = d.setReceiver(receiverModeOff)
+		d.mu.Lock()
+		d.streaming = false
+		d.mu.Unlock()
+	}()
+	return out, nil
+}
+
+// Close stops any active stream and releases the USB handle.
+func (d *Device) Close() error {
+	d.mu.Lock()
+	if d.closed {
+		d.mu.Unlock()
+		return nil
+	}
+	d.closed = true
+	d.mu.Unlock()
+	if d.streaming {
+		_ = d.t.StopBulkIn()
+		_ = d.setReceiver(receiverModeOff)
+	}
+	_ = d.t.ReleaseInterface(0)
+	return d.t.Close()
+}
+
+func (d *Device) isClosed() bool {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.closed
+}
+
+func (d *Device) setReceiver(mode uint16) error {
+	return d.t.ControlOut(reqReceiverMode, mode, 0, nil, controlTimeoutMs)
+}
+
+// fetchSampleRates reads the firmware's supported-rate table. libairspy's
+// protocol: GET_SAMPLERATES with wIndex=0 returns a u32 count;
+// GET_SAMPLERATES with wIndex=count returns count×u32 rates.
+func (d *Device) fetchSampleRates() ([]uint32, error) {
+	cntBytes, err := d.t.ControlIn(reqGetSamplerates, 0, 0, 4, controlTimeoutMs)
+	if err != nil {
+		return nil, err
+	}
+	if len(cntBytes) < 4 {
+		return nil, fmt.Errorf("airspy: short samplerate count (%d bytes)", len(cntBytes))
+	}
+	count := binary.LittleEndian.Uint32(cntBytes)
+	if count == 0 || count > 32 {
+		return nil, fmt.Errorf("airspy: implausible samplerate count %d", count)
+	}
+	listBytes, err := d.t.ControlIn(reqGetSamplerates, 0, uint16(count), int(count*4), controlTimeoutMs)
+	if err != nil {
+		return nil, err
+	}
+	if len(listBytes) < int(count*4) {
+		return nil, fmt.Errorf("airspy: short samplerate list (%d/%d bytes)", len(listBytes), count*4)
+	}
+	rates := make([]uint32, count)
+	for i := range rates {
+		rates[i] = binary.LittleEndian.Uint32(listBytes[4*i:])
+	}
+	return rates, nil
+}
+
+// decodeInt16IQ converts a libairspy INT16_IQ payload (interleaved
+// little-endian signed 16-bit I,Q) into normalised complex64.
+func decodeInt16IQ(buf []byte) []complex64 {
+	n := len(buf) / 4
+	out := make([]complex64, n)
+	for i := 0; i < n; i++ {
+		iv := int16(binary.LittleEndian.Uint16(buf[4*i:]))
+		qv := int16(binary.LittleEndian.Uint16(buf[4*i+2:]))
+		out[i] = complex(float32(iv)/32768, float32(qv)/32768)
+	}
+	return out
+}

--- a/internal/sdr/airspy/airspy_test.go
+++ b/internal/sdr/airspy/airspy_test.go
@@ -1,0 +1,227 @@
+package airspy
+
+import (
+	"context"
+	"encoding/binary"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/sdr"
+	"github.com/MattCheramie/GopherTrunk/internal/sdr/rtlsdr/usb"
+)
+
+func withDevice(t *testing.T) (*Device, *usb.MockTransport) {
+	t.Helper()
+	mt := usb.NewMockTransport()
+	return &Device{t: mt, info: sdr.Info{Driver: driverName, Serial: "test"}}, mt
+}
+
+func TestDriverEnumerateOpenSetsSampleType(t *testing.T) {
+	// On Open the driver pins INT16_IQ and reads the samplerate table
+	// (count first, then list). Provide both calls in the OpenFunc'd
+	// transport.
+	openCalled := false
+	enum := &usb.MockEnumerator{
+		Devices: []usb.Descriptor{
+			{Bus: 1, Address: 4, VID: vidAirspy, PID: pidAirspy, Serial: "AS1", Product: "Airspy R2", Path: "mock/1"},
+		},
+		OpenFunc: func(d usb.Descriptor) (*usb.MockTransport, error) {
+			openCalled = true
+			mt := usb.NewMockTransport()
+			count := make([]byte, 4)
+			binary.LittleEndian.PutUint32(count, 2)
+			list := make([]byte, 8)
+			binary.LittleEndian.PutUint32(list[0:4], 10_000_000)
+			binary.LittleEndian.PutUint32(list[4:8], 2_500_000)
+			mt.Script = []usb.CtrlExchange{
+				{BRequest: reqSetSampleType, WValue: sampleTypeInt16IQ},
+				{In: true, BRequest: reqGetSamplerates, WValue: 0, WIndex: 0, Reply: count, N: 4},
+				{In: true, BRequest: reqGetSamplerates, WValue: 0, WIndex: 2, Reply: list, N: 8},
+			}
+			return mt, nil
+		},
+	}
+	drv := New(enum)
+	infos, err := drv.Enumerate()
+	if err != nil || len(infos) != 1 || infos[0].Serial != "AS1" {
+		t.Fatalf("Enumerate = %+v, err=%v", infos, err)
+	}
+	dev, err := drv.Open(0)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if !openCalled {
+		t.Fatal("OpenFunc not invoked")
+	}
+	asDev := dev.(*Device)
+	if len(asDev.rates) != 2 || asDev.rates[0] != 10_000_000 {
+		t.Fatalf("samplerate table = %v", asDev.rates)
+	}
+	if err := dev.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+}
+
+func TestSetCenterFreqEncoding(t *testing.T) {
+	dev, mt := withDevice(t)
+	payload := make([]byte, 4)
+	binary.LittleEndian.PutUint32(payload, 162_550_000)
+	mt.Script = []usb.CtrlExchange{
+		{BRequest: reqSetFreq, Data: payload},
+	}
+	if err := dev.SetCenterFreq(162_550_000); err != nil {
+		t.Fatalf("SetCenterFreq: %v", err)
+	}
+	if mt.Err != nil {
+		t.Fatalf("transport: %v", mt.Err)
+	}
+}
+
+func TestClosestRateIndex(t *testing.T) {
+	dev := &Device{rates: []uint32{10_000_000, 2_500_000}}
+	cases := []struct {
+		hz   uint32
+		want int
+	}{
+		{10_000_000, 0},
+		{9_000_000, 0},
+		{4_000_000, 1},
+		{2_500_000, 1},
+	}
+	for _, c := range cases {
+		if got := dev.closestRateIndex(c.hz); got != c.want {
+			t.Errorf("closestRateIndex(%d) = %d, want %d", c.hz, got, c.want)
+		}
+	}
+	// No table → falls back to index 0.
+	if (&Device{}).closestRateIndex(123) != 0 {
+		t.Error("empty table should default to index 0")
+	}
+}
+
+func TestSetSampleRateSelectsClosest(t *testing.T) {
+	dev := &Device{rates: []uint32{10_000_000, 2_500_000}}
+	mt := usb.NewMockTransport()
+	dev.t = mt
+	mt.Script = []usb.CtrlExchange{
+		{BRequest: reqSetSamplerate, WValue: 1}, // 4M is closer to 2.5M than 10M
+	}
+	if err := dev.SetSampleRate(4_000_000); err != nil {
+		t.Fatalf("SetSampleRate: %v", err)
+	}
+	if mt.Err != nil {
+		t.Fatalf("transport: %v", mt.Err)
+	}
+}
+
+func TestSplitAirspyGain(t *testing.T) {
+	cases := []struct {
+		tenthDB                   int
+		wantLNA, wantMix, wantVGA int
+	}{
+		{0, 0, 0, 0},
+		{30, 1, 0, 0},
+		{90, 3, 0, 0},
+		{600, 15, 5, 0},    // saturates LNA; remainder rolls to mixer
+		{1500, 15, 15, 15}, // fully saturated
+	}
+	for _, c := range cases {
+		l, m, v := splitAirspyGain(c.tenthDB)
+		if l != c.wantLNA || m != c.wantMix || v != c.wantVGA {
+			t.Errorf("splitAirspyGain(%d) = (%d,%d,%d), want (%d,%d,%d)",
+				c.tenthDB, l, m, v, c.wantLNA, c.wantMix, c.wantVGA)
+		}
+	}
+}
+
+func TestSetGainAutoEnablesAGC(t *testing.T) {
+	dev, mt := withDevice(t)
+	mt.Script = []usb.CtrlExchange{
+		{In: true, BRequest: reqSetLNAAGC, WIndex: 1, Reply: []byte{0}, N: 1},
+		{In: true, BRequest: reqSetMixerAGC, WIndex: 1, Reply: []byte{0}, N: 1},
+		{In: true, BRequest: reqSetVGAGain, WIndex: defaultVGAGain, Reply: []byte{0}, N: 1},
+	}
+	if err := dev.SetGain(-1); err != nil {
+		t.Fatalf("SetGain(-1): %v", err)
+	}
+	if mt.Err != nil {
+		t.Fatalf("transport: %v", mt.Err)
+	}
+}
+
+func TestSetGainManualDisablesAGC(t *testing.T) {
+	dev, mt := withDevice(t)
+	mt.Script = []usb.CtrlExchange{
+		{In: true, BRequest: reqSetLNAAGC, WIndex: 0, Reply: []byte{0}, N: 1},
+		{In: true, BRequest: reqSetMixerAGC, WIndex: 0, Reply: []byte{0}, N: 1},
+		{In: true, BRequest: reqSetLNAGain, WIndex: 3, Reply: []byte{0}, N: 1},
+		{In: true, BRequest: reqSetMixerGain, WIndex: 0, Reply: []byte{0}, N: 1},
+		{In: true, BRequest: reqSetVGAGain, WIndex: 0, Reply: []byte{0}, N: 1},
+	}
+	if err := dev.SetGain(90); err != nil { // 9 dB target → LNA=3, others 0
+		t.Fatalf("SetGain(90): %v", err)
+	}
+	if mt.Err != nil {
+		t.Fatalf("transport: %v", mt.Err)
+	}
+}
+
+func TestSetBiasTeeRoundTrips(t *testing.T) {
+	dev, mt := withDevice(t)
+	mt.Script = []usb.CtrlExchange{
+		{BRequest: reqSetRFBiasCmd, WValue: 1},
+		{BRequest: reqSetRFBiasCmd, WValue: 0},
+	}
+	if err := dev.SetBiasTee(true); err != nil {
+		t.Fatalf("SetBiasTee(on): %v", err)
+	}
+	if err := dev.SetBiasTee(false); err != nil {
+		t.Fatalf("SetBiasTee(off): %v", err)
+	}
+	if mt.Err != nil {
+		t.Fatalf("transport: %v", mt.Err)
+	}
+}
+
+func TestDecodeInt16IQ(t *testing.T) {
+	// Two samples: (+32767, -32768) → ~(1,-1); (0,0) → (0,0).
+	buf := make([]byte, 8)
+	binary.LittleEndian.PutUint16(buf[0:2], uint16(int16(32767)))
+	var minI16 int16 = -32768
+	binary.LittleEndian.PutUint16(buf[2:4], uint16(minI16))
+	binary.LittleEndian.PutUint16(buf[4:6], 0)
+	binary.LittleEndian.PutUint16(buf[6:8], 0)
+	got := decodeInt16IQ(buf)
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2", len(got))
+	}
+	if real(got[0]) <= 0.99 || imag(got[0]) > -0.99 {
+		t.Errorf("sample 0 = (%f,%f); want near (1,-1)", real(got[0]), imag(got[0]))
+	}
+	if got[1] != 0 {
+		t.Errorf("sample 1 = %v; want 0", got[1])
+	}
+}
+
+func TestStreamIQFlipsReceiverAndStops(t *testing.T) {
+	dev, mt := withDevice(t)
+	mt.Script = []usb.CtrlExchange{
+		{BRequest: reqReceiverMode, WValue: receiverModeOn},
+		{BRequest: reqReceiverMode, WValue: receiverModeOff},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	ch, err := dev.StreamIQ(ctx)
+	if err != nil {
+		t.Fatalf("StreamIQ: %v", err)
+	}
+	cancel()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if _, ok := <-ch; !ok {
+			break
+		}
+	}
+	if mt.Err != nil {
+		t.Fatalf("transport: %v", mt.Err)
+	}
+}

--- a/internal/sdr/airspy/register.go
+++ b/internal/sdr/airspy/register.go
@@ -1,0 +1,8 @@
+package airspy
+
+import "github.com/MattCheramie/GopherTrunk/internal/sdr"
+
+// Register the Airspy driver under its canonical name so a blank
+// import of this package from cmd/gophertrunk makes the device
+// discoverable through sdr.Pool.Open.
+func init() { sdr.Register(New(nil)) }

--- a/internal/sdr/hackrf/hackrf.go
+++ b/internal/sdr/hackrf/hackrf.go
@@ -1,0 +1,401 @@
+// Package hackrf is a pure-Go driver for the Great Scott Gadgets HackRF
+// One software-defined radio, implementing the [sdr.Driver] and
+// [sdr.Device] interfaces.
+//
+// It speaks the libhackrf USB vendor protocol directly over the shared
+// pure-Go USB transport at internal/sdr/rtlsdr/usb — the same transport
+// that backs the RTL-SDR driver — so no CGO and no libhackrf are
+// pulled into the build. Real-hardware validation against an attached
+// HackRF One is a documented follow-up; the in-package tests exercise
+// the wire protocol against a usb.MockTransport.
+//
+// Sample format: HackRF delivers signed 8-bit interleaved IQ
+// (I,Q,I,Q,…) on bulk endpoint 0x81 once SET_TRANSCEIVER_MODE has been
+// flipped to receive. Each pair is converted to a complex64 sample
+// with components in roughly [-1, 1].
+package hackrf
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/MattCheramie/GopherTrunk/internal/sdr"
+	"github.com/MattCheramie/GopherTrunk/internal/sdr/rtlsdr/usb"
+)
+
+// USB VIDs/PIDs. The HackRF firmware enumerates the device on this VID
+// across several PID variants — One, Jawbreaker prototype, Rad1o.
+const (
+	vidHackRF       uint16 = 0x1d50
+	pidHackRFOne    uint16 = 0x6089
+	pidHackRFJawbrk uint16 = 0x604b
+	pidHackRFRad1o  uint16 = 0xcc15
+)
+
+// libhackrf vendor request opcodes (subset — only the calls this
+// driver actually issues; matches host/libhackrf/src/hackrf.h).
+const (
+	reqSetTransceiverMode  uint8 = 1
+	reqSampleRateSet       uint8 = 6
+	reqBasebandFilterBwSet uint8 = 7
+	reqBoardIDRead         uint8 = 14
+	reqSetFreq             uint8 = 16
+	reqAmpEnable           uint8 = 17
+	reqSetLNAGain          uint8 = 19
+	reqSetVGAGain          uint8 = 20
+	reqAntennaEnable       uint8 = 23
+)
+
+const (
+	transceiverModeOff     uint16 = 0
+	transceiverModeReceive uint16 = 1
+
+	bulkInEP   byte = 0x81
+	driverName      = "hackrf"
+
+	defaultSampleRateHz uint32 = 8_000_000
+	defaultLNAGainDB           = 16
+	defaultVGAGainDB           = 20
+	controlTimeoutMs           = 1000
+)
+
+// Driver implements sdr.Driver for HackRF.
+type Driver struct {
+	enum usb.Enumerator
+
+	mu     sync.Mutex
+	cached []usb.Descriptor
+}
+
+// New returns a Driver that enumerates through the supplied USB
+// backend. Pass nil to use the platform default enumerator.
+func New(enum usb.Enumerator) *Driver {
+	if enum == nil {
+		enum = usb.DefaultEnumerator()
+	}
+	return &Driver{enum: enum}
+}
+
+// Name implements sdr.Driver.
+func (d *Driver) Name() string { return driverName }
+
+// Enumerate scans every HackRF PID variant and returns an sdr.Info per
+// detected device. The descriptor list is cached so a subsequent Open
+// reuses the same ordering.
+func (d *Driver) Enumerate() ([]sdr.Info, error) {
+	descs := make([]usb.Descriptor, 0)
+	for _, pid := range []uint16{pidHackRFOne, pidHackRFJawbrk, pidHackRFRad1o} {
+		found, err := d.enum.List(vidHackRF, pid)
+		if err != nil {
+			return nil, fmt.Errorf("hackrf: enumerate pid=%04x: %w", pid, err)
+		}
+		descs = append(descs, found...)
+	}
+	d.mu.Lock()
+	d.cached = descs
+	d.mu.Unlock()
+
+	out := make([]sdr.Info, len(descs))
+	for i, desc := range descs {
+		serial := desc.Serial
+		if serial == "" {
+			serial = fmt.Sprintf("hackrf-%02d", i)
+		}
+		out[i] = sdr.Info{
+			Driver:       driverName,
+			Index:        i,
+			Serial:       serial,
+			Manufacturer: desc.Manufacturer,
+			Product:      desc.Product,
+			TunerName:    "MAX2839+MAX5864",
+			// Tenth-dB presets the operator can pick from in the UI;
+			// the driver also accepts a free-form value via SetGain.
+			Gains: []int{0, 80, 160, 240, 320, 400, 480, 560},
+		}
+	}
+	return out, nil
+}
+
+// Open claims the device at idx and returns an sdr.Device. The caller
+// is responsible for calling Close.
+func (d *Driver) Open(idx int) (sdr.Device, error) {
+	d.mu.Lock()
+	cached := d.cached
+	d.mu.Unlock()
+	if cached == nil {
+		if _, err := d.Enumerate(); err != nil {
+			return nil, err
+		}
+		d.mu.Lock()
+		cached = d.cached
+		d.mu.Unlock()
+	}
+	if idx < 0 || idx >= len(cached) {
+		return nil, fmt.Errorf("hackrf: index %d out of range", idx)
+	}
+	desc := cached[idx]
+	t, err := d.enum.Open(desc)
+	if err != nil {
+		return nil, fmt.Errorf("hackrf: open %s: %w", desc.Path, err)
+	}
+	if err := t.ClaimInterface(0); err != nil {
+		_ = t.Close()
+		return nil, fmt.Errorf("hackrf: claim interface 0: %w", err)
+	}
+	serial := desc.Serial
+	if serial == "" {
+		serial = fmt.Sprintf("hackrf-%02d", idx)
+	}
+	return &Device{
+		t: t,
+		info: sdr.Info{
+			Driver:       driverName,
+			Index:        idx,
+			Serial:       serial,
+			Manufacturer: desc.Manufacturer,
+			Product:      desc.Product,
+			TunerName:    "MAX2839+MAX5864",
+		},
+	}, nil
+}
+
+// Device is one opened HackRF.
+type Device struct {
+	t    usb.Transport
+	info sdr.Info
+
+	mu         sync.Mutex
+	closed     bool
+	streaming  bool
+	sampleRate uint32
+}
+
+// Info implements sdr.Device.
+func (d *Device) Info() sdr.Info { return d.info }
+
+// SetCenterFreq programs the synthesizer to the requested frequency,
+// in Hz. libhackrf splits the value into MHz + Hz-remainder octets.
+func (d *Device) SetCenterFreq(hz uint32) error {
+	if d.isClosed() {
+		return usb.ErrClosed
+	}
+	payload := make([]byte, 8)
+	binary.LittleEndian.PutUint32(payload[0:4], hz/1_000_000)
+	binary.LittleEndian.PutUint32(payload[4:8], hz%1_000_000)
+	return d.t.ControlOut(reqSetFreq, 0, 0, payload, controlTimeoutMs)
+}
+
+// SetSampleRate programs the baseband sampler. libhackrf encodes the
+// rate as a numerator/divider pair; this driver always uses a divider
+// of 1 so the host sees exactly the requested rate.
+func (d *Device) SetSampleRate(hz uint32) error {
+	if d.isClosed() {
+		return usb.ErrClosed
+	}
+	if hz == 0 {
+		hz = defaultSampleRateHz
+	}
+	payload := make([]byte, 8)
+	binary.LittleEndian.PutUint32(payload[0:4], hz)
+	binary.LittleEndian.PutUint32(payload[4:8], 1)
+	if err := d.t.ControlOut(reqSampleRateSet, 0, 0, payload, controlTimeoutMs); err != nil {
+		return err
+	}
+	// The baseband-filter cutoff tracks the sample rate; matching it
+	// to ~75 % of the rate avoids aliasing.
+	bw := uint32(float64(hz) * 0.75)
+	bwBytes := make([]byte, 4)
+	binary.LittleEndian.PutUint32(bwBytes, bw)
+	_ = d.t.ControlOut(reqBasebandFilterBwSet,
+		uint16(bw&0xFFFF), uint16(bw>>16), nil, controlTimeoutMs)
+	d.mu.Lock()
+	d.sampleRate = hz
+	d.mu.Unlock()
+	return nil
+}
+
+// SetGain accepts a single tenth-dB target and distributes it across
+// the HackRF's three gain stages (RF amp on/off, LNA 0–40 dB in 8 dB
+// steps, VGA 0–62 dB in 2 dB steps). A negative value selects a
+// hardware-friendly preset (amp off, LNA 16 dB, VGA 20 dB) — the
+// HackRF has no true AGC, so "auto" maps to a sane fixed split.
+func (d *Device) SetGain(tenthDB int) error {
+	if d.isClosed() {
+		return usb.ErrClosed
+	}
+	lna, vga, amp := splitGain(tenthDB)
+	if err := d.amp(amp); err != nil {
+		return err
+	}
+	if err := d.setLNAGain(lna); err != nil {
+		return err
+	}
+	return d.setVGAGain(vga)
+}
+
+// splitGain maps an SDR-interface tenth-dB target to the HackRF's
+// (LNA, VGA, AMP-on) triple. LNA must be a multiple of 8; VGA a
+// multiple of 2.
+func splitGain(tenthDB int) (lna, vga int, amp bool) {
+	if tenthDB < 0 {
+		return defaultLNAGainDB, defaultVGAGainDB, false
+	}
+	target := tenthDB / 10
+	lna = (target / 8) * 8
+	if lna > 40 {
+		lna = 40
+	}
+	rem := target - lna
+	vga = (rem / 2) * 2
+	if vga > 62 {
+		vga = 62
+	}
+	return lna, vga, false
+}
+
+func (d *Device) setLNAGain(db int) error {
+	if db < 0 {
+		db = 0
+	}
+	if db > 40 {
+		db = 40
+	}
+	// libhackrf returns 1 byte of status (0=fail, 1=ok). We don't
+	// fail on a missing status byte — the request itself succeeding
+	// means the gain landed.
+	_, err := d.t.ControlIn(reqSetLNAGain, 0, uint16(db), 1, controlTimeoutMs)
+	return err
+}
+
+func (d *Device) setVGAGain(db int) error {
+	if db < 0 {
+		db = 0
+	}
+	if db > 62 {
+		db = 62
+	}
+	_, err := d.t.ControlIn(reqSetVGAGain, 0, uint16(db), 1, controlTimeoutMs)
+	return err
+}
+
+func (d *Device) amp(on bool) error {
+	v := uint16(0)
+	if on {
+		v = 1
+	}
+	return d.t.ControlOut(reqAmpEnable, v, 0, nil, controlTimeoutMs)
+}
+
+// SetPPM is a no-op for HackRF — the Si5351C reference clock is
+// internally trimmed and the protocol carries no PPM correction.
+func (d *Device) SetPPM(int) error { return nil }
+
+// SetBiasTee toggles the +3.3 V antenna-port bias for external LNAs.
+func (d *Device) SetBiasTee(enable bool) error {
+	if d.isClosed() {
+		return usb.ErrClosed
+	}
+	v := uint16(0)
+	if enable {
+		v = 1
+	}
+	return d.t.ControlOut(reqAntennaEnable, v, 0, nil, controlTimeoutMs)
+}
+
+// StreamIQ flips the HackRF into receive mode and reaps bulk-IN URBs,
+// converting each int8 IQ pair into a complex64 sample on the returned
+// channel. Close (or ctx cancellation) stops the stream and returns
+// the device to off-mode.
+func (d *Device) StreamIQ(ctx context.Context) (<-chan []complex64, error) {
+	d.mu.Lock()
+	if d.closed {
+		d.mu.Unlock()
+		return nil, usb.ErrClosed
+	}
+	if d.streaming {
+		d.mu.Unlock()
+		return nil, errors.New("hackrf: stream already active")
+	}
+	d.streaming = true
+	d.mu.Unlock()
+
+	if err := d.setMode(transceiverModeReceive); err != nil {
+		d.mu.Lock()
+		d.streaming = false
+		d.mu.Unlock()
+		return nil, fmt.Errorf("hackrf: set receive mode: %w", err)
+	}
+
+	out := make(chan []complex64, 8)
+	stopped := make(chan struct{})
+
+	onPacket := func(buf []byte) {
+		samples := decodeInt8IQ(buf)
+		select {
+		case out <- samples:
+		case <-ctx.Done():
+		}
+	}
+	if err := d.t.StartBulkIn(bulkInEP, usb.DefaultRingBuffers, usb.DefaultBufferLen, onPacket); err != nil {
+		_ = d.setMode(transceiverModeOff)
+		d.mu.Lock()
+		d.streaming = false
+		d.mu.Unlock()
+		return nil, fmt.Errorf("hackrf: start bulk-in: %w", err)
+	}
+
+	go func() {
+		defer close(out)
+		defer close(stopped)
+		<-ctx.Done()
+		_ = d.t.StopBulkIn()
+		_ = d.setMode(transceiverModeOff)
+		d.mu.Lock()
+		d.streaming = false
+		d.mu.Unlock()
+	}()
+	return out, nil
+}
+
+// Close stops any active stream and releases the USB handle.
+func (d *Device) Close() error {
+	d.mu.Lock()
+	if d.closed {
+		d.mu.Unlock()
+		return nil
+	}
+	d.closed = true
+	d.mu.Unlock()
+	if d.streaming {
+		_ = d.t.StopBulkIn()
+		_ = d.setMode(transceiverModeOff)
+	}
+	_ = d.t.ReleaseInterface(0)
+	return d.t.Close()
+}
+
+func (d *Device) isClosed() bool {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.closed
+}
+
+func (d *Device) setMode(mode uint16) error {
+	return d.t.ControlOut(reqSetTransceiverMode, mode, 0, nil, controlTimeoutMs)
+}
+
+// decodeInt8IQ converts a HackRF bulk-IN payload (signed 8-bit
+// interleaved IQ) into normalised complex64 samples in [-1, 1].
+func decodeInt8IQ(buf []byte) []complex64 {
+	n := len(buf) / 2
+	out := make([]complex64, n)
+	for i := 0; i < n; i++ {
+		iv := float32(int8(buf[2*i])) / 128
+		qv := float32(int8(buf[2*i+1])) / 128
+		out[i] = complex(iv, qv)
+	}
+	return out
+}

--- a/internal/sdr/hackrf/hackrf_test.go
+++ b/internal/sdr/hackrf/hackrf_test.go
@@ -1,0 +1,187 @@
+package hackrf
+
+import (
+	"context"
+	"encoding/binary"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/sdr"
+	"github.com/MattCheramie/GopherTrunk/internal/sdr/rtlsdr/usb"
+)
+
+// withDevice returns a Device whose USB transport is a freshly-built
+// MockTransport so each test can populate its own Script.
+func withDevice(t *testing.T) (*Device, *usb.MockTransport) {
+	t.Helper()
+	mt := usb.NewMockTransport()
+	return &Device{t: mt, info: sdr.Info{Driver: driverName, Serial: "test"}}, mt
+}
+
+func TestDriverEnumerateAndOpen(t *testing.T) {
+	enum := &usb.MockEnumerator{
+		Devices: []usb.Descriptor{
+			{Bus: 1, Address: 7, VID: vidHackRF, PID: pidHackRFOne, Serial: "ABC", Product: "HackRF One", Path: "mock/1"},
+		},
+	}
+	drv := New(enum)
+	infos, err := drv.Enumerate()
+	if err != nil {
+		t.Fatalf("Enumerate: %v", err)
+	}
+	if len(infos) != 1 || infos[0].Serial != "ABC" || infos[0].Driver != driverName {
+		t.Fatalf("Enumerate = %+v", infos)
+	}
+	dev, err := drv.Open(0)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if dev.Info().Serial != "ABC" {
+		t.Fatalf("Info.Serial = %q, want ABC", dev.Info().Serial)
+	}
+	if err := dev.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+}
+
+func TestDriverOpenRejectsBadIndex(t *testing.T) {
+	enum := &usb.MockEnumerator{Devices: nil}
+	drv := New(enum)
+	if _, err := drv.Open(0); err == nil {
+		t.Fatal("Open on empty driver should error")
+	}
+}
+
+func TestSetCenterFreqEncoding(t *testing.T) {
+	dev, mt := withDevice(t)
+	mt.Script = []usb.CtrlExchange{{
+		BRequest: reqSetFreq, WValue: 0, WIndex: 0,
+		Data: encodeFreq(851_012_500),
+	}}
+	if err := dev.SetCenterFreq(851_012_500); err != nil {
+		t.Fatalf("SetCenterFreq: %v", err)
+	}
+	if mt.Err != nil {
+		t.Fatalf("transport error: %v", mt.Err)
+	}
+}
+
+func encodeFreq(hz uint32) []byte {
+	buf := make([]byte, 8)
+	binary.LittleEndian.PutUint32(buf[0:4], hz/1_000_000)
+	binary.LittleEndian.PutUint32(buf[4:8], hz%1_000_000)
+	return buf
+}
+
+func TestSetSampleRateProgramsFilter(t *testing.T) {
+	dev, mt := withDevice(t)
+	rateBytes := make([]byte, 8)
+	binary.LittleEndian.PutUint32(rateBytes[0:4], 8_000_000)
+	binary.LittleEndian.PutUint32(rateBytes[4:8], 1)
+	mt.Script = []usb.CtrlExchange{
+		{BRequest: reqSampleRateSet, Data: rateBytes},
+		{BRequest: reqBasebandFilterBwSet, WValue: uint16(6_000_000 & 0xFFFF), WIndex: uint16(6_000_000 >> 16)},
+	}
+	if err := dev.SetSampleRate(8_000_000); err != nil {
+		t.Fatalf("SetSampleRate: %v", err)
+	}
+	if mt.Err != nil {
+		t.Fatalf("transport error: %v", mt.Err)
+	}
+}
+
+func TestSplitGain(t *testing.T) {
+	cases := []struct {
+		tenthDB          int
+		wantLNA, wantVGA int
+	}{
+		{-1, defaultLNAGainDB, defaultVGAGainDB},
+		{0, 0, 0},
+		{160, 16, 0},   // 16 dB → all in LNA
+		{180, 16, 2},   // 16 dB LNA + 2 dB VGA
+		{300, 24, 6},   // 24 + 6 = 30 dB
+		{900, 40, 50},  // clamped: 40 dB LNA, 50 dB VGA
+		{1500, 40, 62}, // both saturated
+	}
+	for _, c := range cases {
+		lna, vga, amp := splitGain(c.tenthDB)
+		if lna != c.wantLNA || vga != c.wantVGA || amp {
+			t.Errorf("splitGain(%d) = (%d,%d,%v), want (%d,%d,false)",
+				c.tenthDB, lna, vga, amp, c.wantLNA, c.wantVGA)
+		}
+	}
+}
+
+func TestSetGainIssuesAMPLNAVGA(t *testing.T) {
+	dev, mt := withDevice(t)
+	mt.Script = []usb.CtrlExchange{
+		{BRequest: reqAmpEnable, WValue: 0},
+		{In: true, BRequest: reqSetLNAGain, WIndex: 16, Reply: []byte{1}, N: 1},
+		{In: true, BRequest: reqSetVGAGain, WIndex: 20, Reply: []byte{1}, N: 1},
+	}
+	if err := dev.SetGain(-1); err != nil {
+		t.Fatalf("SetGain: %v", err)
+	}
+	if mt.Err != nil {
+		t.Fatalf("transport error: %v", mt.Err)
+	}
+}
+
+func TestSetBiasTeeRoundTrips(t *testing.T) {
+	dev, mt := withDevice(t)
+	mt.Script = []usb.CtrlExchange{
+		{BRequest: reqAntennaEnable, WValue: 1},
+		{BRequest: reqAntennaEnable, WValue: 0},
+	}
+	if err := dev.SetBiasTee(true); err != nil {
+		t.Fatalf("SetBiasTee(on): %v", err)
+	}
+	if err := dev.SetBiasTee(false); err != nil {
+		t.Fatalf("SetBiasTee(off): %v", err)
+	}
+	if mt.Err != nil {
+		t.Fatalf("transport: %v", mt.Err)
+	}
+}
+
+func TestDecodeInt8IQ(t *testing.T) {
+	// Three samples: (+127, -127), (0, 0), (-128, +64).
+	buf := []byte{127, 0xFF - 126, 0, 0, 0x80, 64}
+	got := decodeInt8IQ(buf)
+	if len(got) != 3 {
+		t.Fatalf("len = %d, want 3", len(got))
+	}
+	if real(got[0]) <= 0.9 || imag(got[0]) >= -0.9 {
+		t.Errorf("sample 0 = (%f,%f); expected near (+1,-1)", real(got[0]), imag(got[0]))
+	}
+	if real(got[1]) != 0 || imag(got[1]) != 0 {
+		t.Errorf("sample 1 = (%f,%f); expected (0,0)", real(got[1]), imag(got[1]))
+	}
+	if real(got[2]) >= -0.9 || imag(got[2]) < 0.4 || imag(got[2]) > 0.6 {
+		t.Errorf("sample 2 = (%f,%f); expected near (-1, +0.5)", real(got[2]), imag(got[2]))
+	}
+}
+
+func TestStreamIQFlipsModeAndStopsOnCancel(t *testing.T) {
+	dev, mt := withDevice(t)
+	mt.Script = []usb.CtrlExchange{
+		{BRequest: reqSetTransceiverMode, WValue: transceiverModeReceive},
+		{BRequest: reqSetTransceiverMode, WValue: transceiverModeOff},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	ch, err := dev.StreamIQ(ctx)
+	if err != nil {
+		t.Fatalf("StreamIQ: %v", err)
+	}
+	cancel()
+	// Drain until the chain shuts down.
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if _, ok := <-ch; !ok {
+			break
+		}
+	}
+	if mt.Err != nil {
+		t.Fatalf("transport error: %v", mt.Err)
+	}
+}

--- a/internal/sdr/hackrf/register.go
+++ b/internal/sdr/hackrf/register.go
@@ -1,0 +1,8 @@
+package hackrf
+
+import "github.com/MattCheramie/GopherTrunk/internal/sdr"
+
+// Register the HackRF driver under its canonical name so a blank
+// import of this package from cmd/gophertrunk makes the device
+// discoverable through sdr.Pool.Open.
+func init() { sdr.Register(New(nil)) }


### PR DESCRIPTION
## Summary

Third (final) SDRtrunk-parity PR: **WP5 — HackRF One and Airspy R2 / Mini pure-Go drivers**.

Two new packages, `internal/sdr/hackrf` and `internal/sdr/airspy`,
implement the `sdr.Driver` / `sdr.Device` interfaces on top of the
existing pure-Go USB transport (USBDEVFS / WinUSB / IOKit) that
already backs the RTL-SDR driver. **No `libhackrf` / `libairspy` at
build or runtime** — the zero-CGO single-binary guarantee holds.

Both drivers speak the documented libhackrf / libairspy USB vendor
protocols:

- `SET_TRANSCEIVER_MODE` (HackRF) / `RECEIVER_MODE` (Airspy)
- `SET_FREQ` — HackRF uses the MHz + Hz-remainder 8-byte encoding;
  Airspy uses a single 4-byte LE Hz value
- `SAMPLE_RATE_SET` (HackRF) / `GET_SAMPLERATES` + `SET_SAMPLERATE`
  (Airspy — reads the firmware's supported-rate table, then picks
  the index closest to the requested rate)
- HackRF gain split across AMP / LNA / VGA; Airspy LNA / mixer / VGA
  with libairspy-style "auto" → LNA-AGC + Mixer-AGC + fixed VGA
- `ANTENNA_ENABLE` / `SET_RF_BIAS_CMD` for the antenna bias-tee
- Bulk-IN reaper on endpoint `0x81` with real-time sample decode
  (HackRF int8 IQ; Airspy INT16_IQ) into `complex64`

Both drivers register themselves on init, so a blank import from
`cmd/gophertrunk` is the only wiring needed:

```go
_ "github.com/MattCheramie/GopherTrunk/internal/sdr/airspy"
_ "github.com/MattCheramie/GopherTrunk/internal/sdr/hackrf"
```

The wire protocols are exercised by unit tests against
`usb.MockTransport` — Driver enumerate / Open, frequency / sample-
rate / gain / bias-tee encodings, sample decode, mode-on/mode-off
on StreamIQ teardown. **On-air validation against attached HackRF /
Airspy hardware is the documented follow-up** (consistent with how
the project flags every other on-air-validation-pending piece).

README and CHANGELOG updated to reflect the new hardware support
(SDR layer bullet now lists all three) and to refresh the
known-gaps section.

## Test plan

- [x] `go build ./...` clean
- [x] `go test -race -count=1 ./...` — all packages green
- [x] `go test -tags integration -race -count=1 ./cmd/gophertrunk/...` — green
- [x] Unit tests for both drivers: enumerate/open, set-freq encoding,
      set-sample-rate (HackRF rate+divider; Airspy closest-index),
      gain distribution + USB command sequence, bias-tee, sample
      decode, StreamIQ mode flip + cancel teardown

https://claude.ai/code/session_01TukmNGna117cn6VbhuKgWm

---
_Generated by [Claude Code](https://claude.ai/code/session_01TukmNGna117cn6VbhuKgWm)_