### PR TITLE
docs: thorough README + docs pass covering every parity subsystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <h1 align="center">GopherTrunk</h1>
 
 <p align="center">
-  <strong>Pure-Go digital-trunking radio scanner engine for RTL-SDR.</strong><br>
+  <strong>Pure-Go digital-trunking radio scanner engine for RTL-SDR · HackRF · Airspy.</strong><br>
   P25 · DMR · TETRA · NXDN · Motorola Type II · EDACS · LTR · MPT 1327 · dPMR · D-STAR · YSF.<br>
   Zero CGO, single static binary, headless daemon + Bubbletea TUI cockpit + browser web console.
 </p>
@@ -23,7 +23,7 @@
 
 ## What is this?
 
-GopherTrunk is a software-defined-radio scanner that follows digital trunked-radio voice calls and decodes them to audio. It runs on a pool of cheap RTL-SDR dongles, has no C dependencies (no `librtlsdr` / `libusb` at build or runtime), and ships as a single ~10 MB static binary for Linux, macOS, and Windows.
+GopherTrunk is a software-defined-radio scanner that follows digital trunked-radio voice calls and decodes them to audio. It runs on a pool of RTL-SDR, HackRF One and Airspy R2 / Mini dongles, has no C dependencies (no `librtlsdr` / `libhackrf` / `libairspy` / `libusb` at build or runtime), and ships as a single ~10 MB static binary for Linux, macOS, and Windows. Completed calls stream to Broadcastify Calls, RdioScanner, OpenMHz, and live Icecast / ShoutCast — out of the box, no `libmp3lame`.
 
 Why does this exist? Read **[The Story of GopherTrunk](https://gophertrunk.org/story.html)** — the personal backstory behind the project, from a kid listening to an analog scanner to a pure-Go digital trunking scanner built with the help of modern AI tooling.
 
@@ -54,7 +54,7 @@ Full per-OS install (Windows installer / macOS Apple Silicon / Linux aarch64): *
 
 **Amateur-radio digital modes** — D-STAR (JARL DV-mode K=5 R=½ Viterbi + PN15 scrambler + 22×30 interleaver) and Yaesu System Fusion (C4FM + FICH trellis).
 
-**Pure-Go voice path** — IMBE (P25 Phase 1) and AMBE+2 (P25 Phase 2 / DMR / NXDN) vocoders implemented in Go, no DVSI / mbelib dependency. Per-call WAV + raw-frame sidecars; live PCM playback via direct ALSA / WASAPI / CoreAudio (no `libasound2` at runtime).
+**Pure-Go voice path** — IMBE (P25 Phase 1) and AMBE+2 (P25 Phase 2 / DMR) vocoders implemented in Go, no DVSI / mbelib dependency. Analog trunking (Motorola Type II / SmartZone, EDACS, LTR, MPT 1327) decodes voice through the composer's FM chain; EDACS ProVoice stays on the `.raw` sidecar path. Per-call WAV + raw-frame sidecars; live PCM playback via direct ALSA / WASAPI / CoreAudio (no `libasound2` at runtime).
 
 **SDR layer** — Pure-Go drivers for **RTL-SDR**, **HackRF One** and **Airspy R2 / Mini**, all sharing the same pure-Go USB transport (USBDEVFS on Linux, WinUSB on Windows, IOKit on macOS) — no `librtlsdr` / `libhackrf` / `libairspy` at build or runtime. The RTL-SDR backend includes wire-level ports of every osmocom tuner (R820T / R820T2 / R828D / E4000 / FC0012 / FC0013 / FC2580) with librtlsdr-parity init burst chunking, EPIPE warmup + reset on Open, balanced LNA+Mixer gain, and the same `rtlsdr_open` probe order + GPIO 4/5/6 dances for non-R820T detection. The HackRF and Airspy drivers speak the documented libhackrf / libairspy USB vendor protocols (set freq / sample rate / gains / bias-tee, bulk-IN sample reaper, real-time sample decode to complex64); on-air validation against attached HackRF / Airspy hardware is the documented follow-up, but the wire protocols are exercised under unit tests against `usb.MockTransport`. Multi-device pool with role assignment, per-device gain / PPM / bias-tee.
 
@@ -62,13 +62,19 @@ Full per-OS install (Windows installer / macOS Apple Silicon / Linux aarch64): *
 
 **API + observability** — gRPC + HTTP/SSE + WebSocket surfaces, optional TLS + bearer-token auth on mutations, Prometheus `/metrics`, pure-Go SQLite call log, in-process pub/sub event bus with typed payloads.
 
-**Outbound streaming + call distribution** — completed calls are encoded to MP3 (pure-Go, no `libmp3lame`) and streamed to **Broadcastify Calls**, **RdioScanner**, **OpenMHz**, and live **Icecast / ShoutCast** mountpoints, with bounded exponential-backoff retry and per-feed system filtering (`internal/broadcast`, `GET /api/v1/broadcast`).
+**Outbound call streaming** — completed calls are encoded to MP3 with a pure-Go encoder (no `libmp3lame`) and streamed to **Broadcastify Calls**, **RdioScanner**, **OpenMHz**, and live **Icecast / ShoutCast** mountpoints. The Icecast backend keeps the source connection alive with pre-encoded silence so listeners never see a starved mountpoint between calls; every backend uses bounded exponential-backoff retry, per-feed system filtering, and a per-talkgroup opt-out. Live counters at `GET /api/v1/broadcast` (`internal/broadcast`).
 
-**Baseband recording + offline replay** — wideband IQ recording to a two-channel 16-bit WAV (the SDRtrunk layout), and a replay driver that mounts those recordings (and SDRtrunk's) back into the SDR pool as virtual tuners so a capture decodes with no radio attached (`internal/sdr/baseband`).
+**Baseband recording + offline replay** — wideband IQ recording to a two-channel 16-bit WAV (the SDRtrunk layout: in-phase in channel 1, quadrature in channel 2), and a replay driver that mounts those recordings (or SDRtrunk's) back into the SDR pool as virtual tuners so a capture decodes with no radio attached. Looping replay simulates a continuous source (`internal/sdr/baseband`).
 
-**Location + affiliation** — over-the-air geographic fixes decode through a strict NMEA-0183 parser into a `KindLocation` event, a `location_log` SQLite table and `GET /api/v1/locations`; a protocol-agnostic affiliation tracker maintains the live "which unit is on which talkgroup" table at `GET /api/v1/affiliations`. A decoded-message log writes a rotating, human-readable text log of every trunking event.
+**Location subsystem (GPS / NMEA)** — over-the-air geographic fixes decode through a strict NMEA-0183 GGA/RMC parser with checksum verification (the format Tait CCDI and many MOTOTRBO GPS profiles transport verbatim) into a `KindLocation` event, a `location_log` SQLite table, and `GET /api/v1/locations` for map display (`internal/radio/location`).
 
-**Per-talkgroup policy** — priority, lockout, scan-list membership, **stream** (broadcast opt-out), **record** (recorder opt-out), **mute** (live-audio opt-out) and an **icon** name — all settable per talkgroup via CSV / JSON and `PATCH /api/v1/talkgroups/{id}`.
+**Affiliation tracker** — a protocol-agnostic in-memory table of which radio unit is currently on which talkgroup, fed by `KindGrant` (a grant's source/group is ground truth), explicit `KindAffiliation` events, and `KindUnitRegistration`. Works uniformly across P25, DMR (all tiers and vendors), NXDN and the rest with no per-protocol decoding; idle units expire after a TTL. Served at `GET /api/v1/affiliations`.
+
+**Decoded-message log** — a rotating, human-readable text log of every trunking event the bus carries — grants, control-channel lock/loss, affiliations, registrations, patches, talker aliases, locations, tone alerts, decode errors. Enabled via the `log.message_log` config block (`internal/log`).
+
+**Vendor-aware DMR Tier III** — the control-channel decoder dispatches every CSBK on its feature-set ID (FID) before opcode, so vendor CSBKs are routed to a vendor handler instead of being misdecoded as standard ETSI grants. Motorola Capacity Plus / Capacity Max voice grants (FID 0x10) decode to real grants and the Capacity Plus rest channel is tracked from the vendor system-info CSBK. Connect Plus and Hytera XPT CSBKs are recognised; bit-exact decoding of their proprietary payloads is the documented follow-up.
+
+**Per-talkgroup policy** — priority, lockout, scan-list membership, **stream** (broadcast opt-out), **record** (recorder opt-out), **mute** (live-audio opt-out) and an **icon** name — all settable per talkgroup via CSV / JSON and `PATCH /api/v1/talkgroups/{id}`, all surfaced in the talkgroup API DTO. Mute is wired through the player sink: a muted talkgroup's PCM is dropped before the speakers without affecting recording or streaming.
 
 **Operator surfaces** — first-class Bubbletea TUI cockpit with 12 panels (including a live Import panel and inline-editable Settings) and a sibling **web console** (a pure-browser React/Tailwind SPA, either embedded into the daemon binary at build time or shipped pre-built as `gophertrunk-web/` next to the binary — see [`web/README.md`](web/README.md) and the [§Web console](#web-console) section); the daemon binary doubles as its own UI launcher (`gophertrunk -tui` / `-web` / `-headless` — see [`docs/launcher.md`](docs/launcher.md)); conventional FM scanner with CTCSS / DCS squelch, two-tone QC-II paging detector, runtime channel lockout, manual VFO tune. Live `PATCH /api/v1/settings` writes operator edits straight to `config.yaml` (comments preserved) and hot-reloads what it safely can; `POST /api/v1/import` accepts PDF / CSV uploads, parses + previews, then merges into the running daemon.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -34,7 +34,9 @@ daemon behaves like a high-end digital-trunking police scanner end-to-end.
 
 ┌──────────────────────────────────────────────────────────────┐
 │  internal/sdr                                                │
-│    Driver registry → rtlsdr (pure-Go), mock (file replay)    │
+│    Driver registry → rtlsdr · hackrf · airspy (all pure-Go,  │
+│    shared USB transport at rtlsdr/usb); baseband (WAV IQ     │
+│    replay as virtual tuners); mock (raw u8/f32 file replay)  │
 │    Pool: enumerates, opens, role-assigns, supervises;        │
 │    publishes sdr.attached/sdr.detached events with per-      │
 │    device SDRStatus payloads                                 │
@@ -126,10 +128,22 @@ constructed only when its config section is present:
 ## Driver registry
 
 `internal/sdr` maintains a process-global registry. Each backend
-(pure-Go RTL-SDR under `internal/sdr/rtlsdr/purego`, file-replay
-mock, future HackRF/Airspy) calls `sdr.Register` from its `init()`
-so the binary's import set chooses what hardware it can talk to.
-`cmd/gophertrunk` blank-imports the drivers it ships with.
+calls `sdr.Register` from its `init()` so the binary's import set
+chooses what hardware it can talk to:
+
+- `internal/sdr/rtlsdr/purego` (`rtlsdr`) — pure-Go RTL2832U +
+  every osmocom tuner.
+- `internal/sdr/hackrf` (`hackrf`) — pure-Go libhackrf protocol
+  port over the shared `rtlsdr/usb` transport.
+- `internal/sdr/airspy` (`airspy`) — pure-Go libairspy protocol
+  port over the shared transport.
+- `internal/sdr/baseband` (`baseband-replay`) — mounts recorded
+  IQ WAVs as virtual tuners. Registered dynamically by the daemon
+  when `baseband.replay` is configured.
+
+`cmd/gophertrunk` blank-imports the three real-hardware drivers
+unconditionally; the baseband-replay driver registers at runtime
+when the operator points at a recording.
 
 ## Build tags
 

--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -1,24 +1,35 @@
 ---
 layout: page
 title: Hardware setup
-description: RTL-SDR dongles, udev rules, DVB blacklist, and supported USB chipsets
+description: RTL-SDR, HackRF and Airspy dongles, udev rules, DVB blacklist, and supported USB chipsets
 nav_group: Install
 ---
 
 # Hardware Setup
 
-GopherTrunk ships with a pure-Go RTL-SDR driver — no `librtlsdr`,
-`libusb`, or C toolchain on the build host. The daemon talks to
-RTL2832U dongles directly through the platform's USB stack:
-USBDEVFS ioctls on Linux, IOKit on macOS, WinUSB on Windows.
+GopherTrunk ships with pure-Go drivers for three SDR families — no
+`librtlsdr`, `libhackrf`, `libairspy`, `libusb`, or C toolchain on
+the build host. All three drivers share the same pure-Go USB
+transport (USBDEVFS on Linux, IOKit on macOS, WinUSB on Windows).
 
 ## Supported devices
 
-The same code path covers everything `librtlsdr` did — RTL2832U
-paired with R820T / R820T2 / R828D / E4000 / FC0012 / FC0013 /
-FC2580. Tuner detection is automatic on `Open`.
+| Family | Driver | USB IDs | Status |
+| --- | --- | --- | --- |
+| **RTL-SDR** (RTL2832U + R820T / R820T2 / R828D / E4000 / FC0012 / FC0013 / FC2580) | `rtlsdr` | `0x0bda:0x2838` | Production — on-air-validated across Linux / macOS / Windows. |
+| **HackRF One** (also Jawbreaker / Rad1o) | `hackrf` | `0x1d50:0x6089` · `0x1d50:0x604b` · `0x1d50:0xcc15` | Wire-protocol-complete; on-air validation against attached hardware is the documented follow-up. |
+| **Airspy R2 / Airspy Mini** | `airspy` | `0x1d50:0x60a1` | Wire-protocol-complete; on-air validation against attached hardware is the documented follow-up. |
 
-Tested combinations:
+The HackRF and Airspy drivers speak the documented libhackrf /
+libairspy USB vendor protocols directly (transceiver / receiver
+mode, frequency, sample rate, LNA / VGA / mixer / amp / bias-tee
+gains, bulk-IN sample reaper with real-time decode of HackRF int8 IQ
+and Airspy INT16_IQ into `complex64`). Their wire protocols are
+exercised by unit tests against `usb.MockTransport`. SDRPlay, USRP
+and BladeRF require vendor C libraries and are out of scope for the
+zero-CGO build.
+
+### RTL-SDR tested combinations
 
 | Device | Tuner | Notes |
 | --- | --- | --- |
@@ -45,17 +56,27 @@ sdr:
 No package install is needed for the build itself; the driver only
 needs USB-device permissions at runtime.
 
-Add a udev rule so non-root processes can claim the dongle:
+Add a udev rule so non-root processes can claim each dongle. One
+file per family is fine:
 
 ```
 # /etc/udev/rules.d/20-rtlsdr.rules
 SUBSYSTEM=="usb", ATTRS{idVendor}=="0bda", ATTRS{idProduct}=="2838", MODE="0666"
+
+# /etc/udev/rules.d/21-hackrf.rules
+SUBSYSTEM=="usb", ATTRS{idVendor}=="1d50", ATTRS{idProduct}=="6089", MODE="0666"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="1d50", ATTRS{idProduct}=="604b", MODE="0666"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="1d50", ATTRS{idProduct}=="cc15", MODE="0666"
+
+# /etc/udev/rules.d/22-airspy.rules
+SUBSYSTEM=="usb", ATTRS{idVendor}=="1d50", ATTRS{idProduct}=="60a1", MODE="0666"
 ```
 
 Reload udev (`sudo udevadm control --reload && sudo udevadm trigger`) and
 unplug/replug the dongle.
 
-Blacklist the kernel's DVB driver, which otherwise grabs the device first:
+Blacklist the kernel's DVB driver — only matters for RTL-SDR, but
+the file is harmless to ship even on HackRF / Airspy-only hosts:
 
 ```
 # /etc/modprobe.d/blacklist-dvb_usb_rtl28xxu.conf
@@ -76,9 +97,11 @@ service setup.
 
 ## Windows
 
-Bind the dongle to **WinUSB** with Zadig (bundled in the Windows
+Bind each dongle to **WinUSB** with Zadig (bundled in the Windows
 installer — Start Menu → GopherTrunk → "Install RTL-SDR driver
-(Zadig)") once per device. See [`install-windows.md`]({{ '/install-windows.html' | relative_url }})
+(Zadig)") once per device. The same Zadig walkthrough also works
+for HackRF and Airspy — pick the device in the dropdown, choose
+the WinUSB driver, click Replace. See [`install-windows.md`]({{ '/install-windows.html' | relative_url }})
 for the click-by-click walkthrough.
 
 ## Verifying the build
@@ -88,14 +111,26 @@ make build
 ./bin/gophertrunk sdr list
 ```
 
-You should see one row per attached dongle with index, serial, tuner type
-(usually `R820T2` or `R828D`), and the supported gain values. The
-`Driver` column reads `rtlsdr` for every entry.
+You should see one row per attached dongle with index, serial,
+tuner type (e.g. `R820T2` / `R828D` for RTL-SDR, `MAX2839+MAX5864`
+for HackRF, `R820T` for Airspy), and the supported gain values. The
+`Driver` column reads `rtlsdr`, `hackrf`, or `airspy` for each row.
 
 ## Capturing IQ for replay
 
-The mock driver replays raw u8-IQ files (`.cfile` format). You can
-generate one with any tool that produces interleaved unsigned-8-bit
-samples — e.g. `gqrx`'s baseband recorder or a dedicated capture
-utility. Drop `.cfile` files under `testdata/iq/` to use them
-through the mock driver.
+GopherTrunk has two replay paths.
+
+**Wideband baseband replay** — record the full IQ stream of any
+attached tuner with a `baseband.record` config entry (see
+[`opt-in-features.md`]({{ '/opt-in-features.html' | relative_url }})),
+then mount the resulting two-channel 16-bit WAV (or one of
+SDRtrunk's baseband recordings — same layout) as a virtual tuner via
+`baseband.replay`. The replay loops on EOF, so a short capture
+becomes a continuous source.
+
+**Raw cfile mock driver** — the legacy mock driver replays raw u8-IQ
+files (`.cfile` format) generated with `gqrx`, `csdr`, or any tool
+that produces interleaved unsigned-8-bit samples. Drop `.cfile`
+files under `testdata/iq/` to use them through the mock driver. The
+baseband replay path above is the preferred option for new work;
+the cfile mock stays around for the existing integration tests.


### PR DESCRIPTION
## Summary

Docs-only sweep covering every SDRtrunk-parity subsystem landed across
the three earlier PRs (#317, #319, #328). Originally pushed onto the
#328 branch after it was merged, so re-applying as its own PR.

### README

- Hero tagline and "What is this?" mention all three SDR families
  (RTL-SDR / HackRF / Airspy) and the call-streaming integrations out
  of the gate.
- Features split into dedicated bullets for **Outbound call
  streaming**, **Baseband recording + replay**, **Location subsystem
  (NMEA)**, **Affiliation tracker**, **Decoded-message log**,
  **Vendor-aware DMR Tier III**, and **Per-talkgroup policy** (with
  the player-sink mute wiring called out).
- The Pure-Go voice path bullet now notes that analog trunking
  (Motorola / EDACS / LTR / MPT 1327) decodes through the FM composer
  chain; EDACS ProVoice stays on `.raw`.

### docs/architecture.md

- The Layered overview SDR box lists `rtlsdr · hackrf · airspy` and
  baseband (WAV IQ replay) instead of only `rtlsdr`.
- The Driver registry section replaces the "future HackRF/Airspy"
  placeholder with the three shipping drivers plus the dynamic
  baseband-replay registration.

### docs/hardware.md

- Supported-devices section now leads with a per-family table
  (RTL-SDR / HackRF / Airspy) with USB IDs and an explicit
  "wire-protocol-complete; on-air validation is the documented
  follow-up" status for HackRF and Airspy.
- Linux udev rules cover every USB ID across all three families.
- macOS / Windows / verification / IQ-replay sections updated for the
  multi-driver world; baseband replay documented as the preferred
  replacement for the legacy raw-cfile mock driver.

## Test plan

- [x] `go build ./...` clean — docs-only change, no Go code touched
- [x] Re-applied cleanly on top of merged `main` (no conflicts)

https://claude.ai/code/session_01TukmNGna117cn6VbhuKgWm

---
_Generated by [Claude Code](https://claude.ai/code/session_01TukmNGna117cn6VbhuKgWm)_