### PR TITLE
sdr: cover all common HackRF + Airspy variants, add HF+ driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,45 @@ for tagged releases.
 
 ### Added
 
+- **Airspy HF+ Discovery / Dual Port / legacy HF+ pure-Go driver.**
+  New `internal/sdr/airspyhf` package implements the `sdr.Driver` /
+  `sdr.Device` interfaces on top of the same pure-Go USB transport
+  (USBDEVFS / WinUSB / IOKit) the RTL-SDR / HackRF / Airspy drivers
+  use — no `libairspyhf` at build or runtime, the zero-CGO
+  single-binary guarantee still holds. The driver speaks the
+  documented libairspyhf USB vendor protocol (RECEIVER_MODE,
+  SET_FREQ, GET_SAMPLERATES, SET_HF_AGC, SET_HF_ATT, SET_HF_LNA,
+  SET_BIAS_TEE, GET_VERSION_STRING) and decodes the HF+'s
+  interleaved int16 IQ payload into complex64. All three known
+  variants (Discovery, Dual Port, legacy) enumerate on VID:PID
+  `0x03eb:0x800c`; the USB descriptor's Product string drives the
+  `TunerName` distinction. Coverage: 9 kHz – 31 MHz HF + 60 –
+  260 MHz VHF; HF AGC plus a 0–48 dB attenuator (6 dB steps) and
+  +6 dB LNA preamp. Registered on init so a blank import from
+  `cmd/gophertrunk` is the only wiring needed. The wire protocol
+  is unit-tested against `usb.MockTransport`; on-air validation
+  against attached HF+ hardware is the documented follow-up.
+
+- **HackRF firmware-aware identification.** The HackRF driver now
+  reads `BOARD_ID_READ` and `VERSION_STRING_READ` at Open time and
+  uses the firmware's self-reported identity (rather than the USB
+  descriptor's Product string) to populate `sdr.Info.Product` as
+  `HackRF One` / `HackRF Jawbreaker` / `Rad1o`. The running
+  firmware version is appended to `TunerName` (`MAX2839+MAX5864
+  (fw git-2024.02.1)`), and PortaPack / Mayhem builds are
+  auto-detected and tagged with `+ PortaPack` so the operator can
+  see at a glance which board is on which USB port. `Enumerate`
+  also normalises Product based on the PID, so listings are
+  consistent even before Open.
+
+- **Airspy R2 vs Mini distinction in `TunerName`.** The Airspy
+  driver now detects the `MINI` substring in the USB Product
+  string at enumeration time and emits `R820T (Airspy R2)` or
+  `R820T (Airspy Mini)` accordingly. Both variants share the same
+  VID:PID, same R820T tuner, and same wire protocol — the split
+  surfaces purely through the operator-visible label so multi-
+  dongle pools can pick the right unit by name.
+
 - **HackRF One and Airspy R2 / Mini pure-Go drivers.** New
   `internal/sdr/hackrf` and `internal/sdr/airspy` packages implement
   the `sdr.Driver` / `sdr.Device` interfaces on top of the same

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <h1 align="center">GopherTrunk</h1>
 
 <p align="center">
-  <strong>Pure-Go digital-trunking radio scanner engine for RTL-SDR · HackRF · Airspy.</strong><br>
+  <strong>Pure-Go digital-trunking radio scanner engine for RTL-SDR · HackRF · Airspy · Airspy HF+.</strong><br>
   P25 · DMR · TETRA · NXDN · Motorola Type II · EDACS · LTR · MPT 1327 · dPMR · D-STAR · YSF.<br>
   Zero CGO, single static binary, headless daemon + Bubbletea TUI cockpit + browser web console.
 </p>
@@ -23,7 +23,7 @@
 
 ## What is this?
 
-GopherTrunk is a software-defined-radio scanner that follows digital trunked-radio voice calls and decodes them to audio. It runs on a pool of RTL-SDR, HackRF One and Airspy R2 / Mini dongles, has no C dependencies (no `librtlsdr` / `libhackrf` / `libairspy` / `libusb` at build or runtime), and ships as a single ~10 MB static binary for Linux, macOS, and Windows. Completed calls stream to Broadcastify Calls, RdioScanner, OpenMHz, and live Icecast / ShoutCast — out of the box, no `libmp3lame`.
+GopherTrunk is a software-defined-radio scanner that follows digital trunked-radio voice calls and decodes them to audio. It runs on a pool of RTL-SDR (every osmocom tuner — R820T / R820T2 / R828D / E4000 / FC0012 / FC0013 / FC2580), HackRF (One / Jawbreaker / Rad1o, with PortaPack / Mayhem firmware auto-detected), Airspy R2 / Mini, and Airspy HF+ (Discovery / Dual Port / legacy) dongles, has no C dependencies (no `librtlsdr` / `libhackrf` / `libairspy` / `libairspyhf` / `libusb` at build or runtime), and ships as a single ~10 MB static binary for Linux, macOS, and Windows. Completed calls stream to Broadcastify Calls, RdioScanner, OpenMHz, and live Icecast / ShoutCast — out of the box, no `libmp3lame`.
 
 Why does this exist? Read **[The Story of GopherTrunk](https://gophertrunk.org/story.html)** — the personal backstory behind the project, from a kid listening to an analog scanner to a pure-Go digital trunking scanner built with the help of modern AI tooling.
 
@@ -56,7 +56,7 @@ Full per-OS install (Windows installer / macOS Apple Silicon / Linux aarch64): *
 
 **Pure-Go voice path** — IMBE (P25 Phase 1) and AMBE+2 (P25 Phase 2 / DMR) vocoders implemented in Go, no DVSI / mbelib dependency. Analog trunking (Motorola Type II / SmartZone, EDACS, LTR, MPT 1327) decodes voice through the composer's FM chain; EDACS ProVoice stays on the `.raw` sidecar path. Per-call WAV + raw-frame sidecars; live PCM playback via direct ALSA / WASAPI / CoreAudio (no `libasound2` at runtime).
 
-**SDR layer** — Pure-Go drivers for **RTL-SDR**, **HackRF One** and **Airspy R2 / Mini**, all sharing the same pure-Go USB transport (USBDEVFS on Linux, WinUSB on Windows, IOKit on macOS) — no `librtlsdr` / `libhackrf` / `libairspy` at build or runtime. The RTL-SDR backend includes wire-level ports of every osmocom tuner (R820T / R820T2 / R828D / E4000 / FC0012 / FC0013 / FC2580) with librtlsdr-parity init burst chunking, EPIPE warmup + reset on Open, balanced LNA+Mixer gain, and the same `rtlsdr_open` probe order + GPIO 4/5/6 dances for non-R820T detection. The HackRF and Airspy drivers speak the documented libhackrf / libairspy USB vendor protocols (set freq / sample rate / gains / bias-tee, bulk-IN sample reaper, real-time sample decode to complex64); on-air validation against attached HackRF / Airspy hardware is the documented follow-up, but the wire protocols are exercised under unit tests against `usb.MockTransport`. Multi-device pool with role assignment, per-device gain / PPM / bias-tee.
+**SDR layer** — Pure-Go drivers for **RTL-SDR**, **HackRF One / Jawbreaker / Rad1o**, **Airspy R2 / Mini**, and the **Airspy HF+ family (Discovery, Dual Port, legacy HF+)**, all sharing the same pure-Go USB transport (USBDEVFS on Linux, WinUSB on Windows, IOKit on macOS) — no `librtlsdr` / `libhackrf` / `libairspy` / `libairspyhf` at build or runtime. The RTL-SDR backend includes wire-level ports of every osmocom tuner (R820T / R820T2 / R828D / E4000 / FC0012 / FC0013 / FC2580) with librtlsdr-parity init burst chunking, EPIPE warmup + reset on Open, balanced LNA+Mixer gain, and the same `rtlsdr_open` probe order + GPIO 4/5/6 dances for non-R820T detection. The HackRF, Airspy, and HF+ drivers speak the documented libhackrf / libairspy / libairspyhf USB vendor protocols (transceiver / receiver mode, set freq / sample rate / per-stage gains / attenuator / bias-tee, bulk-IN sample reaper, real-time sample decode of HackRF int8 IQ and Airspy / HF+ INT16_IQ to complex64); the HackRF driver also reads BOARD_ID + VERSION_STRING at open so `sdr list` surfaces the canonical model name and firmware version (including PortaPack / Mayhem detection), and the Airspy R2 / Mini split is exposed through the `TunerName` field. On-air validation against attached HackRF / Airspy / HF+ hardware is the documented follow-up, but the wire protocols are exercised under unit tests against `usb.MockTransport`. Multi-device pool with role assignment, per-device gain / PPM / bias-tee.
 
 **DSP** — Polyphase channelizer + CIC + halfband, Kaiser / RRC / Gaussian FIR designers, FM / C4FM / GFSK / FFSK / DQPSK / π/4-DQPSK / π/8-H-DQPSK demods, Mueller-Müller + Gardner clock recovery, LMS + CMA blind equalizers, Selection + maximal-ratio diversity combining.
 
@@ -118,11 +118,12 @@ MPT 1327) now decodes voice through the composer's FM chain.
 
 The remaining gaps:
 
-- **Additional SDR hardware.** RTL-SDR, HackRF One and Airspy R2 /
-  Mini are all supported by pure-Go drivers; on-air validation of
-  the HackRF / Airspy backends against attached hardware is the
-  documented follow-up. SDRPlay / USRP / BladeRF need vendor C
-  libraries and are out of scope for the zero-CGO build.
+- **Additional SDR hardware.** RTL-SDR, HackRF (One / Jawbreaker /
+  Rad1o), Airspy R2 / Mini, and Airspy HF+ (Discovery / Dual Port /
+  legacy) are all supported by pure-Go drivers; on-air validation
+  of the HackRF / Airspy / HF+ backends against attached hardware
+  is the documented follow-up. SDRPlay / USRP / BladeRF need
+  vendor C libraries and are out of scope for the zero-CGO build.
 - **Digital-voice composer chains.** FM (incl. analog trunking),
   DMR and P25 Phase 1/2 decode to audio; NXDN, dPMR, TETRA, YSF and
   D-STAR voice chains, plus EDACS ProVoice, are still bypassed —

--- a/cmd/gophertrunk/main.go
+++ b/cmd/gophertrunk/main.go
@@ -20,6 +20,7 @@ import (
 	// name on init; the blank import is what actually links the
 	// package into the binary.
 	_ "github.com/MattCheramie/GopherTrunk/internal/sdr/airspy"
+	_ "github.com/MattCheramie/GopherTrunk/internal/sdr/airspyhf"
 	_ "github.com/MattCheramie/GopherTrunk/internal/sdr/hackrf"
 	_ "github.com/MattCheramie/GopherTrunk/internal/sdr/rtlsdr/purego"
 	"github.com/MattCheramie/GopherTrunk/internal/version"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -34,9 +34,10 @@ daemon behaves like a high-end digital-trunking police scanner end-to-end.
 
 ┌──────────────────────────────────────────────────────────────┐
 │  internal/sdr                                                │
-│    Driver registry → rtlsdr · hackrf · airspy (all pure-Go,  │
-│    shared USB transport at rtlsdr/usb); baseband (WAV IQ     │
-│    replay as virtual tuners); mock (raw u8/f32 file replay)  │
+│    Driver registry → rtlsdr · hackrf · airspy · airspyhf     │
+│    (all pure-Go, shared USB transport at rtlsdr/usb);        │
+│    baseband (WAV IQ replay as virtual tuners); mock          │
+│    (raw u8/f32 file replay)                                  │
 │    Pool: enumerates, opens, role-assigns, supervises;        │
 │    publishes sdr.attached/sdr.detached events with per-      │
 │    device SDRStatus payloads                                 │
@@ -134,14 +135,22 @@ chooses what hardware it can talk to:
 - `internal/sdr/rtlsdr/purego` (`rtlsdr`) — pure-Go RTL2832U +
   every osmocom tuner.
 - `internal/sdr/hackrf` (`hackrf`) — pure-Go libhackrf protocol
-  port over the shared `rtlsdr/usb` transport.
+  port covering HackRF One / Jawbreaker / Rad1o, with BOARD_ID and
+  VERSION_STRING readback at open so the operator-visible model
+  name and firmware version (including PortaPack / Mayhem
+  detection) come from the device itself.
 - `internal/sdr/airspy` (`airspy`) — pure-Go libairspy protocol
-  port over the shared transport.
+  port covering Airspy R2 and Airspy Mini, with the R2-vs-Mini
+  split surfaced through the `TunerName` field.
+- `internal/sdr/airspyhf` (`airspyhf`) — pure-Go libairspyhf
+  protocol port covering the Airspy HF+ family (Discovery, Dual
+  Port, legacy HF+). HF (9 kHz – 31 MHz) + VHF (60 – 260 MHz);
+  HF AGC plus a 0–48 dB attenuator and +6 dB LNA preamp.
 - `internal/sdr/baseband` (`baseband-replay`) — mounts recorded
   IQ WAVs as virtual tuners. Registered dynamically by the daemon
   when `baseband.replay` is configured.
 
-`cmd/gophertrunk` blank-imports the three real-hardware drivers
+`cmd/gophertrunk` blank-imports the four real-hardware drivers
 unconditionally; the baseband-replay driver registers at runtime
 when the operator points at a recording.
 

--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -16,18 +16,31 @@ transport (USBDEVFS on Linux, IOKit on macOS, WinUSB on Windows).
 
 | Family | Driver | USB IDs | Status |
 | --- | --- | --- | --- |
-| **RTL-SDR** (RTL2832U + R820T / R820T2 / R828D / E4000 / FC0012 / FC0013 / FC2580) | `rtlsdr` | `0x0bda:0x2838` | Production — on-air-validated across Linux / macOS / Windows. |
-| **HackRF One** (also Jawbreaker / Rad1o) | `hackrf` | `0x1d50:0x6089` · `0x1d50:0x604b` · `0x1d50:0xcc15` | Wire-protocol-complete; on-air validation against attached hardware is the documented follow-up. |
+| **RTL-SDR** (RTL2832U + R820T / R820T2 / R828D / E4000 / FC0012 / FC0013 / FC2580) | `rtlsdr` | `0x0bda:0x2832` · `0x0bda:0x2838` | Production — on-air-validated across Linux / macOS / Windows. |
+| **HackRF One / Jawbreaker / Rad1o** | `hackrf` | `0x1d50:0x6089` · `0x1d50:0x604b` · `0x1d50:0xcc15` | Wire-protocol-complete; on-air validation against attached hardware is the documented follow-up. |
 | **Airspy R2 / Airspy Mini** | `airspy` | `0x1d50:0x60a1` | Wire-protocol-complete; on-air validation against attached hardware is the documented follow-up. |
+| **Airspy HF+ Discovery / HF+ Dual Port / legacy HF+** | `airspyhf` | `0x03eb:0x800c` | Wire-protocol-complete; HF (9 kHz – 31 MHz) + VHF (60 – 260 MHz). On-air validation against attached hardware is the documented follow-up. |
 
-The HackRF and Airspy drivers speak the documented libhackrf /
-libairspy USB vendor protocols directly (transceiver / receiver
-mode, frequency, sample rate, LNA / VGA / mixer / amp / bias-tee
-gains, bulk-IN sample reaper with real-time decode of HackRF int8 IQ
-and Airspy INT16_IQ into `complex64`). Their wire protocols are
-exercised by unit tests against `usb.MockTransport`. SDRPlay, USRP
-and BladeRF require vendor C libraries and are out of scope for the
-zero-CGO build.
+The HackRF and Airspy / Airspy HF+ drivers speak the documented
+libhackrf, libairspy, and libairspyhf USB vendor protocols directly
+(transceiver / receiver mode, frequency, sample rate, LNA / VGA /
+mixer / amp / attenuator / bias-tee, bulk-IN sample reaper with
+real-time decode of HackRF int8 IQ and Airspy / HF+ INT16_IQ into
+`complex64`). Their wire protocols are exercised by unit tests
+against `usb.MockTransport`. SDRPlay, USRP and BladeRF require
+vendor C libraries and are out of scope for the zero-CGO build.
+
+At enumeration time each driver reports the canonical model name
+rather than echoing whatever the USB descriptor happens to carry:
+HackRF maps the PID to `HackRF One` / `HackRF Jawbreaker` / `Rad1o`,
+Airspy R2/Mini detects the `MINI` substring in the descriptor to
+emit `R820T (Airspy R2)` or `R820T (Airspy Mini)`, and the HF+
+driver distinguishes Discovery / Dual Port / legacy units the same
+way. On Open, the HackRF driver also reads the firmware's
+BOARD_ID_READ + VERSION_STRING_READ control transfers, so the
+operator-visible `TunerName` field carries the running firmware
+version and a `+ PortaPack` tag when a PortaPack / Mayhem build is
+detected. The HF+ driver appends its firmware version the same way.
 
 ### RTL-SDR tested combinations
 
@@ -51,6 +64,59 @@ sdr:
       bias_tee: true           # 5V on the SMA — only enable if you want it
 ```
 
+### HackRF tested combinations
+
+| Device | PID | Coverage | Gain chain | Bias-tee | Notes |
+| --- | --- | --- | --- | --- | --- |
+| **HackRF One** | `0x6089` | 1 MHz – 6 GHz, half-duplex 8/10/20 MSPS | RF amp (on/off, +14 dB) + LNA (0–40 dB / 8 dB steps) + VGA (0–62 dB / 2 dB steps) | +3.3 V on `ANT` (HW rev 6+) | Single SMA antenna port. PortaPack add-on (Mayhem firmware) is auto-detected via the VERSION_STRING_READ control transfer — `gophertrunk sdr list` then shows `HackRF One + PortaPack`. |
+| HackRF Jawbreaker | `0x604b` | 30 MHz – 6 GHz prototype | Same as One (MAX2837 + MAX5864) | None | Pre-production batch; functional but rarely seen in the field. |
+| Rad1o | `0xcc15` | 50 MHz – 4 GHz | Same as One | None | Chaos Communication Camp 2015 badge; same firmware family as HackRF One, identical wire protocol. |
+
+The HackRF has no hardware AGC. Passing `gain: "auto"` selects a
+safe fixed split (LNA = 16 dB, VGA = 20 dB, RF amp off); positive
+tenth-dB values are distributed across the three stages. The
+firmware-reported board ID (BOARD_ID_READ) is the canonical model
+identifier and takes precedence over the USB descriptor when the
+two disagree.
+
+```yaml
+sdr:
+  sample_rate: 8_000_000          # HackRF baseband; filter follows automatically
+  devices:
+    - serial: "0000000000000000a06064c8333819cf"
+      role: control
+      gain: "400"                  # 40 dB target distributed across LNA + VGA
+      bias_tee: false              # set true to power an external LNA
+```
+
+### Airspy tested combinations
+
+| Device | PID | Coverage | Max sample rate | Gain chain | Bias-tee | Notes |
+| --- | --- | --- | --- | --- | --- | --- |
+| **Airspy R2** | `0x60a1` (`airspy`) | 24 – 1700 MHz | 10 MSPS | R820T LNA + Mixer + VGA (each 0–15) with per-stage AGC | +4.5 V on SMA | Most common variant. Identified by the USB Product string `Airspy R2`. |
+| **Airspy Mini** | `0x60a1` (`airspy`) | 24 – 1700 MHz | 6 MSPS | Same as R2 | +4.5 V on SMA | Identified by the `MINI` substring in the USB Product string. Same R820T tuner; smaller form factor and lower max rate. |
+| **Airspy HF+ Discovery** | `0x800c` (`airspyhf`) | 9 kHz – 31 MHz HF + 60 – 260 MHz VHF | 768 kSPS | HF AGC (firmware-managed) + HF attenuator 0–48 dB (6 dB steps) + +6 dB LNA preamp | +4.5 V on HF SMA | Most popular HF receiver. `gain: "auto"` enables firmware HF AGC; numeric values map to attenuator step + LNA preamp. |
+| Airspy HF+ Dual Port | `0x800c` (`airspyhf`) | Same as Discovery | 768 kSPS | Same as Discovery | +4.5 V on the HF SMA only | Identified by the `DUAL` substring. The VHF SMA does not carry bias voltage. |
+| Legacy Airspy HF+ | `0x800c` (`airspyhf`) | Same as Discovery | 768 kSPS | Same as Discovery | Hardware-revision dependent | Pre-Discovery hardware; uncommon. |
+
+The R2 / Mini driver pins the device to `INT16_IQ` sample mode at
+open-time and reads the firmware's advertised sample-rate table —
+`SetSampleRate` then picks the closest available rate, so a `gain:
+"auto"` + `sample_rate: 10_000_000` config picks the 10 MSPS slot on
+R2 and the 6 MSPS slot on Mini without per-device overrides. The
+HF+ driver does the same; it also reads VERSION_STRING_READ to
+expose the firmware version in `TunerName`.
+
+```yaml
+sdr:
+  sample_rate: 768_000             # HF+ Discovery max
+  devices:
+    - serial: "3652b46d6e6f8867"
+      role: control
+      gain: "auto"                 # firmware HF AGC handles the HF band well
+      bias_tee: false              # set true to power an active HF antenna
+```
+
 ## Linux
 
 No package install is needed for the build itself; the driver only
@@ -61,6 +127,7 @@ file per family is fine:
 
 ```
 # /etc/udev/rules.d/20-rtlsdr.rules
+SUBSYSTEM=="usb", ATTRS{idVendor}=="0bda", ATTRS{idProduct}=="2832", MODE="0666"
 SUBSYSTEM=="usb", ATTRS{idVendor}=="0bda", ATTRS{idProduct}=="2838", MODE="0666"
 
 # /etc/udev/rules.d/21-hackrf.rules
@@ -70,6 +137,9 @@ SUBSYSTEM=="usb", ATTRS{idVendor}=="1d50", ATTRS{idProduct}=="cc15", MODE="0666"
 
 # /etc/udev/rules.d/22-airspy.rules
 SUBSYSTEM=="usb", ATTRS{idVendor}=="1d50", ATTRS{idProduct}=="60a1", MODE="0666"
+
+# /etc/udev/rules.d/23-airspyhf.rules
+SUBSYSTEM=="usb", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="800c", MODE="0666"
 ```
 
 Reload udev (`sudo udevadm control --reload && sudo udevadm trigger`) and
@@ -100,8 +170,9 @@ service setup.
 Bind each dongle to **WinUSB** with Zadig (bundled in the Windows
 installer — Start Menu → GopherTrunk → "Install RTL-SDR driver
 (Zadig)") once per device. The same Zadig walkthrough also works
-for HackRF and Airspy — pick the device in the dropdown, choose
-the WinUSB driver, click Replace. See [`install-windows.md`]({{ '/install-windows.html' | relative_url }})
+for HackRF, Airspy and Airspy HF+ — pick the device in the
+dropdown, choose the WinUSB driver, click Replace. See
+[`install-windows.md`]({{ '/install-windows.html' | relative_url }})
 for the click-by-click walkthrough.
 
 ## Verifying the build
@@ -112,9 +183,25 @@ make build
 ```
 
 You should see one row per attached dongle with index, serial,
-tuner type (e.g. `R820T2` / `R828D` for RTL-SDR, `MAX2839+MAX5864`
-for HackRF, `R820T` for Airspy), and the supported gain values. The
-`Driver` column reads `rtlsdr`, `hackrf`, or `airspy` for each row.
+tuner type, and the supported gain values:
+
+- **RTL-SDR** dongles report a `R820T2` / `R828D` / `E4000` / `FC0012` /
+  `FC0013` / `FC2580` `TunerName` depending on what the driver detects
+  on the RTL2832U.
+- **HackRF** dongles report `MAX2839+MAX5864 (fw <version>)` —
+  `<version>` is what the firmware returns via `VERSION_STRING_READ`,
+  e.g. `git-2024.02.1`. A `+ PortaPack` suffix appears in `Product`
+  when a Mayhem build is detected.
+- **Airspy R2 / Mini** report `R820T (Airspy R2)` or
+  `R820T (Airspy Mini)`; the variant is inferred from the USB
+  descriptor's Product string.
+- **Airspy HF+** reports `Airspy HF+ Discovery` /
+  `Airspy HF+ Dual Port` / `Airspy HF+` (with a firmware suffix when
+  available) for both `Product` and `TunerName` — there's no
+  conventional tuner chip to name.
+
+The `Driver` column reads `rtlsdr`, `hackrf`, `airspy`, or
+`airspyhf` for each row.
 
 ## Capturing IQ for replay
 

--- a/internal/sdr/airspy/airspy.go
+++ b/internal/sdr/airspy/airspy.go
@@ -18,6 +18,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/MattCheramie/GopherTrunk/internal/sdr"
@@ -104,13 +105,26 @@ func (d *Driver) Enumerate() ([]sdr.Info, error) {
 			Serial:       serial,
 			Manufacturer: desc.Manufacturer,
 			Product:      desc.Product,
-			TunerName:    "R820T",
+			TunerName:    tunerNameFor(desc.Product),
 			// Indicative tenth-dB presets; the driver also accepts
 			// a free-form SetGain value.
 			Gains: []int{0, 100, 200, 300, 400, 500},
 		}
 	}
 	return out, nil
+}
+
+// tunerNameFor distinguishes Airspy R2 from Airspy Mini for the
+// TunerName surface. Both share VID:PID 0x1d50:0x60a1 and the same
+// R820T tuner — the USB descriptor's Product string is the only
+// observable difference at enumeration time. A missing Product
+// falls back to the R2 label since R2 is the older, more common
+// variant.
+func tunerNameFor(product string) string {
+	if strings.Contains(strings.ToUpper(product), "MINI") {
+		return "R820T (Airspy Mini)"
+	}
+	return "R820T (Airspy R2)"
 }
 
 // Open claims the device at idx and returns an sdr.Device. The
@@ -148,7 +162,7 @@ func (d *Driver) Open(idx int) (sdr.Device, error) {
 			Serial:       fallbackSerial(desc.Serial, idx),
 			Manufacturer: desc.Manufacturer,
 			Product:      desc.Product,
-			TunerName:    "R820T",
+			TunerName:    tunerNameFor(desc.Product),
 		},
 	}
 	// Pin the device to INT16_IQ — the format the StreamIQ decoder

--- a/internal/sdr/airspyhf/airspyhf.go
+++ b/internal/sdr/airspyhf/airspyhf.go
@@ -1,0 +1,499 @@
+// Package airspyhf is a pure-Go driver for the Airspy HF+ family
+// (Discovery, Dual Port, and the legacy HF+), implementing
+// [sdr.Driver] and [sdr.Device].
+//
+// It speaks the libairspyhf USB vendor protocol directly over the
+// shared pure-Go USB transport at internal/sdr/rtlsdr/usb — the same
+// transport the RTL-SDR, HackRF, and Airspy R2/Mini drivers use — so
+// no CGO and no libairspyhf are pulled into the build. Real-hardware
+// validation against an attached HF+ is a documented follow-up; the
+// in-package tests exercise the wire protocol against a
+// usb.MockTransport.
+//
+// Coverage: 9 kHz–31 MHz HF + 60 MHz–260 MHz VHF. All three known
+// variants (HF+, HF+ Discovery, HF+ Dual Port) enumerate on the same
+// VID:PID (0x03eb:0x800c); the USB Product string distinguishes them.
+//
+// Sample format: the HF+ delivers interleaved int16 IQ pairs (4 bytes
+// per sample) on bulk endpoint 0x81 once RECEIVER_MODE has been
+// flipped to receive. Each pair is decoded to a complex64 with
+// components in [-1, 1].
+package airspyhf
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/MattCheramie/GopherTrunk/internal/sdr"
+	"github.com/MattCheramie/GopherTrunk/internal/sdr/rtlsdr/usb"
+)
+
+// USB IDs. The HF+ family shares one VID:PID across Discovery, Dual
+// Port, and the legacy unit — the descriptor's Product string is the
+// only observable model identifier.
+const (
+	vidAirspyHF uint16 = 0x03eb
+	pidAirspyHF uint16 = 0x800c
+)
+
+// libairspyhf vendor request opcodes (subset — only the calls this
+// driver actually issues; matches libairspyhf/src/airspyhf_commands.h).
+// Note that these are NOT the same opcodes as the R2/Mini's
+// libairspy protocol — sibling devices, sibling protocols.
+const (
+	reqReceiverMode      uint8 = 1
+	reqSetFreq           uint8 = 2
+	reqGetSamplerates    uint8 = 3
+	reqSetSamplerate     uint8 = 4
+	reqGetSerialBoardID  uint8 = 7
+	reqGetVersionString  uint8 = 9
+	reqSetHFAGC          uint8 = 10
+	reqSetHFAGCThreshold uint8 = 11
+	reqSetHFATT          uint8 = 12
+	reqSetHFLNA          uint8 = 13
+	reqSetBiasTee        uint8 = 17
+)
+
+const (
+	receiverModeOff uint16 = 0
+	receiverModeOn  uint16 = 1
+
+	bulkInEP   byte = 0x81
+	driverName      = "airspyhf"
+
+	// HF_ATT covers 0..48 dB in 6 dB steps (step 0..8).
+	hfATTStepTenthDB = 60
+	hfATTMaxStep     = 8
+
+	// HF_LNA adds a fixed +6 dB preamp when enabled.
+	hfLNAGainTenthDB = 60
+
+	controlTimeoutMs = 1000
+)
+
+// Driver implements sdr.Driver for the Airspy HF+ family.
+type Driver struct {
+	enum usb.Enumerator
+
+	mu     sync.Mutex
+	cached []usb.Descriptor
+}
+
+// New returns a Driver backed by enum (nil → platform default).
+func New(enum usb.Enumerator) *Driver {
+	if enum == nil {
+		enum = usb.DefaultEnumerator()
+	}
+	return &Driver{enum: enum}
+}
+
+// Name implements sdr.Driver.
+func (d *Driver) Name() string { return driverName }
+
+// Enumerate finds every Airspy HF+ on the bus and caches the
+// descriptor list so a subsequent Open reuses the same ordering.
+func (d *Driver) Enumerate() ([]sdr.Info, error) {
+	descs, err := d.enum.List(vidAirspyHF, pidAirspyHF)
+	if err != nil {
+		return nil, fmt.Errorf("airspyhf: enumerate: %w", err)
+	}
+	d.mu.Lock()
+	d.cached = descs
+	d.mu.Unlock()
+
+	out := make([]sdr.Info, len(descs))
+	for i, desc := range descs {
+		serial := desc.Serial
+		if serial == "" {
+			serial = fmt.Sprintf("airspyhf-%02d", i)
+		}
+		variant := variantName(desc.Product)
+		out[i] = sdr.Info{
+			Driver:       driverName,
+			Index:        i,
+			Serial:       serial,
+			Manufacturer: desc.Manufacturer,
+			Product:      variant,
+			TunerName:    variant,
+			// 0–48 dB attenuation in 6 dB steps, plus an optional
+			// +6 dB LNA preamp on top.
+			Gains: []int{0, 60, 120, 180, 240, 300, 360, 420, 480, 540},
+		}
+	}
+	return out, nil
+}
+
+// variantName returns the canonical HF+ product label for the USB
+// descriptor's Product string. Unrecognised strings fall back to
+// "Airspy HF+" — that's also what the legacy (pre-Discovery) units
+// report.
+func variantName(product string) string {
+	p := strings.ToUpper(product)
+	switch {
+	case strings.Contains(p, "DISCOVERY"):
+		return "Airspy HF+ Discovery"
+	case strings.Contains(p, "DUAL"):
+		return "Airspy HF+ Dual Port"
+	default:
+		return "Airspy HF+"
+	}
+}
+
+// Open claims the device at idx and returns an sdr.Device. The
+// returned device has its firmware-advertised sample-rate table
+// pre-loaded so SetSampleRate can match an index. Failures reading
+// the table are non-fatal — SetSampleRate falls back to index 0.
+func (d *Driver) Open(idx int) (sdr.Device, error) {
+	d.mu.Lock()
+	cached := d.cached
+	d.mu.Unlock()
+	if cached == nil {
+		if _, err := d.Enumerate(); err != nil {
+			return nil, err
+		}
+		d.mu.Lock()
+		cached = d.cached
+		d.mu.Unlock()
+	}
+	if idx < 0 || idx >= len(cached) {
+		return nil, fmt.Errorf("airspyhf: index %d out of range", idx)
+	}
+	desc := cached[idx]
+	t, err := d.enum.Open(desc)
+	if err != nil {
+		return nil, fmt.Errorf("airspyhf: open %s: %w", desc.Path, err)
+	}
+	if err := t.ClaimInterface(0); err != nil {
+		_ = t.Close()
+		return nil, fmt.Errorf("airspyhf: claim interface 0: %w", err)
+	}
+	variant := variantName(desc.Product)
+	dev := &Device{
+		t: t,
+		info: sdr.Info{
+			Driver:       driverName,
+			Index:        idx,
+			Serial:       fallbackSerial(desc.Serial, idx),
+			Manufacturer: desc.Manufacturer,
+			Product:      variant,
+			TunerName:    variant,
+		},
+	}
+	// Best-effort: read firmware version and append it to TunerName.
+	// HF+ firmware older than v1.5 has the opcode but may NAK on some
+	// shipments — ignore failures.
+	if version, vErr := fetchVersionString(t); vErr == nil && version != "" {
+		dev.info.TunerName = fmt.Sprintf("%s (fw %s)", variant, version)
+	}
+	// Read the firmware's supported-samplerate table so SetSampleRate
+	// can pick an index. Discovery exposes 192k/256k/384k/768k;
+	// Dual Port typically just 768k. Non-fatal on error.
+	if rates, rErr := fetchSampleRates(t); rErr == nil {
+		dev.rates = rates
+	}
+	return dev, nil
+}
+
+func fallbackSerial(s string, idx int) string {
+	if s != "" {
+		return s
+	}
+	return fmt.Sprintf("airspyhf-%02d", idx)
+}
+
+// Device is one opened Airspy HF+.
+type Device struct {
+	t    usb.Transport
+	info sdr.Info
+
+	mu        sync.Mutex
+	closed    bool
+	streaming bool
+	rates     []uint32 // supported sample rates, Hz
+}
+
+// Info implements sdr.Device.
+func (d *Device) Info() sdr.Info { return d.info }
+
+// SetCenterFreq programs the synthesizer to hz Hz. libairspyhf carries
+// the value as a 4-byte little-endian uint32 in the control transfer
+// data stage; wValue and wIndex are unused. The firmware accepts
+// frequencies outside the device's coverage windows (it just won't
+// lock), so the driver forwards verbatim — matching libairspyhf.
+func (d *Device) SetCenterFreq(hz uint32) error {
+	if d.isClosed() {
+		return usb.ErrClosed
+	}
+	payload := make([]byte, 4)
+	binary.LittleEndian.PutUint32(payload, hz)
+	return d.t.ControlOut(reqSetFreq, 0, 0, payload, controlTimeoutMs)
+}
+
+// SetSampleRate selects the firmware-advertised rate closest to hz.
+// If the supported-rate table is unavailable, index 0 is used (which
+// is always the highest rate the unit supports).
+func (d *Device) SetSampleRate(hz uint32) error {
+	if d.isClosed() {
+		return usb.ErrClosed
+	}
+	idx := d.closestRateIndex(hz)
+	return d.t.ControlOut(reqSetSamplerate, uint16(idx), 0, nil, controlTimeoutMs)
+}
+
+func (d *Device) closestRateIndex(hz uint32) int {
+	d.mu.Lock()
+	rates := d.rates
+	d.mu.Unlock()
+	if len(rates) == 0 {
+		return 0
+	}
+	best, bestDiff := 0, ^uint32(0)
+	for i, r := range rates {
+		var diff uint32
+		if hz > r {
+			diff = hz - r
+		} else {
+			diff = r - hz
+		}
+		if diff < bestDiff {
+			best, bestDiff = i, diff
+		}
+	}
+	return best
+}
+
+// SetGain accepts a single tenth-dB target and distributes it across
+// the HF+'s gain chain: HF_AGC (LNA + mixer AGC managed by firmware),
+// HF_ATT (0..48 dB attenuator, 6 dB steps), and HF_LNA (+0 or +6 dB
+// preamp). A negative value enables HF_AGC and zeros out the
+// attenuator + LNA — that matches libairspyhf's default.
+//
+// For positive values the driver disables HF_AGC, computes the
+// attenuator step, and turns on the LNA when the requested gain has
+// not yet been satisfied by attenuator reduction alone.
+//
+// Note: "gain" on the HF+ is mostly *attenuation reduction* — the
+// front-end has a fixed conversion stage and what the operator
+// controls is how much signal to push into the ADC. tenthDB here is
+// interpreted as "headroom to reduce", consistent with libairspyhf.
+func (d *Device) SetGain(tenthDB int) error {
+	if d.isClosed() {
+		return usb.ErrClosed
+	}
+	if tenthDB < 0 {
+		if err := d.setHFAGC(true); err != nil {
+			return err
+		}
+		if err := d.setHFLNA(false); err != nil {
+			return err
+		}
+		return d.setHFATT(0)
+	}
+	if err := d.setHFAGC(false); err != nil {
+		return err
+	}
+	att := tenthDB / hfATTStepTenthDB
+	if att > hfATTMaxStep {
+		att = hfATTMaxStep
+	}
+	remaining := tenthDB - att*hfATTStepTenthDB
+	lnaOn := remaining >= hfLNAGainTenthDB
+	if err := d.setHFATT(att); err != nil {
+		return err
+	}
+	return d.setHFLNA(lnaOn)
+}
+
+// SetPPM is a no-op for the HF+ — the device's TCXO is factory-trimmed
+// and the libairspyhf wire protocol carries no PPM register.
+func (d *Device) SetPPM(int) error { return nil }
+
+// SetBiasTee toggles the bias-T on the antenna SMA. Dual Port units
+// only expose this on the SMA-1 / HF port; SMA-2 (VHF) is unaffected.
+func (d *Device) SetBiasTee(enable bool) error {
+	if d.isClosed() {
+		return usb.ErrClosed
+	}
+	v := uint16(0)
+	if enable {
+		v = 1
+	}
+	return d.t.ControlOut(reqSetBiasTee, v, 0, nil, controlTimeoutMs)
+}
+
+// StreamIQ flips the receiver on and starts the bulk-IN reaper,
+// delivering one complex64 chunk per URB.
+func (d *Device) StreamIQ(ctx context.Context) (<-chan []complex64, error) {
+	d.mu.Lock()
+	if d.closed {
+		d.mu.Unlock()
+		return nil, usb.ErrClosed
+	}
+	if d.streaming {
+		d.mu.Unlock()
+		return nil, errors.New("airspyhf: stream already active")
+	}
+	d.streaming = true
+	d.mu.Unlock()
+
+	if err := d.setReceiver(receiverModeOn); err != nil {
+		d.mu.Lock()
+		d.streaming = false
+		d.mu.Unlock()
+		return nil, fmt.Errorf("airspyhf: receiver on: %w", err)
+	}
+
+	out := make(chan []complex64, 8)
+	onPacket := func(buf []byte) {
+		samples := decodeInt16IQ(buf)
+		select {
+		case out <- samples:
+		case <-ctx.Done():
+		}
+	}
+	if err := d.t.StartBulkIn(bulkInEP, usb.DefaultRingBuffers, usb.DefaultBufferLen, onPacket); err != nil {
+		_ = d.setReceiver(receiverModeOff)
+		d.mu.Lock()
+		d.streaming = false
+		d.mu.Unlock()
+		return nil, fmt.Errorf("airspyhf: start bulk-in: %w", err)
+	}
+
+	go func() {
+		defer close(out)
+		<-ctx.Done()
+		_ = d.t.StopBulkIn()
+		_ = d.setReceiver(receiverModeOff)
+		d.mu.Lock()
+		d.streaming = false
+		d.mu.Unlock()
+	}()
+	return out, nil
+}
+
+// Close stops any active stream and releases the USB handle.
+func (d *Device) Close() error {
+	d.mu.Lock()
+	if d.closed {
+		d.mu.Unlock()
+		return nil
+	}
+	d.closed = true
+	d.mu.Unlock()
+	if d.streaming {
+		_ = d.t.StopBulkIn()
+		_ = d.setReceiver(receiverModeOff)
+	}
+	_ = d.t.ReleaseInterface(0)
+	return d.t.Close()
+}
+
+func (d *Device) isClosed() bool {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.closed
+}
+
+func (d *Device) setReceiver(mode uint16) error {
+	return d.t.ControlOut(reqReceiverMode, mode, 0, nil, controlTimeoutMs)
+}
+
+func (d *Device) setHFAGC(on bool) error {
+	v := uint16(0)
+	if on {
+		v = 1
+	}
+	return d.t.ControlOut(reqSetHFAGC, v, 0, nil, controlTimeoutMs)
+}
+
+func (d *Device) setHFLNA(on bool) error {
+	v := uint16(0)
+	if on {
+		v = 1
+	}
+	return d.t.ControlOut(reqSetHFLNA, v, 0, nil, controlTimeoutMs)
+}
+
+func (d *Device) setHFATT(step int) error {
+	if step < 0 {
+		step = 0
+	}
+	if step > hfATTMaxStep {
+		step = hfATTMaxStep
+	}
+	return d.t.ControlOut(reqSetHFATT, uint16(step), 0, nil, controlTimeoutMs)
+}
+
+// fetchSampleRates reads the firmware's supported-rate table. The
+// libairspyhf protocol mirrors libairspy here: GET_SAMPLERATES with
+// wIndex=0 returns a u32 count; GET_SAMPLERATES with wIndex=count
+// returns count×u32 rates.
+func fetchSampleRates(t usb.Transport) ([]uint32, error) {
+	cntBytes, err := t.ControlIn(reqGetSamplerates, 0, 0, 4, controlTimeoutMs)
+	if err != nil {
+		return nil, err
+	}
+	if len(cntBytes) < 4 {
+		return nil, fmt.Errorf("airspyhf: short samplerate count (%d bytes)", len(cntBytes))
+	}
+	count := binary.LittleEndian.Uint32(cntBytes)
+	if count == 0 || count > 32 {
+		return nil, fmt.Errorf("airspyhf: implausible samplerate count %d", count)
+	}
+	listBytes, err := t.ControlIn(reqGetSamplerates, 0, uint16(count), int(count*4), controlTimeoutMs)
+	if err != nil {
+		return nil, err
+	}
+	if len(listBytes) < int(count*4) {
+		return nil, fmt.Errorf("airspyhf: short samplerate list (%d/%d bytes)", len(listBytes), count*4)
+	}
+	rates := make([]uint32, count)
+	for i := range rates {
+		rates[i] = binary.LittleEndian.Uint32(listBytes[4*i:])
+	}
+	return rates, nil
+}
+
+// fetchVersionString reads the firmware's ASCII version string. Padding
+// NULs and any non-printable bytes are stripped.
+func fetchVersionString(t usb.Transport) (string, error) {
+	reply, err := t.ControlIn(reqGetVersionString, 0, 0, 255, controlTimeoutMs)
+	if err != nil {
+		return "", err
+	}
+	return cleanVersionString(reply), nil
+}
+
+func cleanVersionString(buf []byte) string {
+	end := len(buf)
+	for i, b := range buf {
+		if b == 0 {
+			end = i
+			break
+		}
+	}
+	out := make([]byte, 0, end)
+	for _, b := range buf[:end] {
+		if b >= 0x20 && b < 0x7f {
+			out = append(out, b)
+		}
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// decodeInt16IQ converts an HF+ bulk-IN payload (interleaved
+// little-endian signed 16-bit I,Q) into normalised complex64.
+func decodeInt16IQ(buf []byte) []complex64 {
+	n := len(buf) / 4
+	out := make([]complex64, n)
+	for i := 0; i < n; i++ {
+		iv := int16(binary.LittleEndian.Uint16(buf[4*i:]))
+		qv := int16(binary.LittleEndian.Uint16(buf[4*i+2:]))
+		out[i] = complex(float32(iv)/32768, float32(qv)/32768)
+	}
+	return out
+}

--- a/internal/sdr/airspyhf/airspyhf_test.go
+++ b/internal/sdr/airspyhf/airspyhf_test.go
@@ -1,8 +1,9 @@
-package airspy
+package airspyhf
 
 import (
 	"context"
 	"encoding/binary"
+	"strings"
 	"testing"
 	"time"
 
@@ -16,38 +17,40 @@ func withDevice(t *testing.T) (*Device, *usb.MockTransport) {
 	return &Device{t: mt, info: sdr.Info{Driver: driverName, Serial: "test"}}, mt
 }
 
-func TestDriverEnumerateOpenSetsSampleType(t *testing.T) {
-	// On Open the driver pins INT16_IQ and reads the samplerate table
-	// (count first, then list). Provide both calls in the OpenFunc'd
-	// transport.
+func TestDriverEnumerateOpenReadsVersionAndRates(t *testing.T) {
+	// On Open the driver reads the firmware version string and the
+	// sample-rate table (count then list).
 	openCalled := false
 	enum := &usb.MockEnumerator{
 		Devices: []usb.Descriptor{
-			{Bus: 1, Address: 4, VID: vidAirspy, PID: pidAirspy, Serial: "AS1", Product: "Airspy R2", Path: "mock/1"},
+			{Bus: 1, Address: 4, VID: vidAirspyHF, PID: pidAirspyHF,
+				Serial: "HF1", Product: "Airspy HF+ Discovery", Path: "mock/1"},
 		},
 		OpenFunc: func(d usb.Descriptor) (*usb.MockTransport, error) {
 			openCalled = true
 			mt := usb.NewMockTransport()
 			count := make([]byte, 4)
-			binary.LittleEndian.PutUint32(count, 2)
-			list := make([]byte, 8)
-			binary.LittleEndian.PutUint32(list[0:4], 10_000_000)
-			binary.LittleEndian.PutUint32(list[4:8], 2_500_000)
+			binary.LittleEndian.PutUint32(count, 4)
+			list := make([]byte, 16)
+			binary.LittleEndian.PutUint32(list[0:4], 768_000)
+			binary.LittleEndian.PutUint32(list[4:8], 384_000)
+			binary.LittleEndian.PutUint32(list[8:12], 256_000)
+			binary.LittleEndian.PutUint32(list[12:16], 192_000)
 			mt.Script = []usb.CtrlExchange{
-				{BRequest: reqSetSampleType, WValue: sampleTypeInt16IQ},
+				{In: true, BRequest: reqGetVersionString, Reply: []byte("R3.0.7\x00"), N: 255},
 				{In: true, BRequest: reqGetSamplerates, WValue: 0, WIndex: 0, Reply: count, N: 4},
-				{In: true, BRequest: reqGetSamplerates, WValue: 0, WIndex: 2, Reply: list, N: 8},
+				{In: true, BRequest: reqGetSamplerates, WValue: 0, WIndex: 4, Reply: list, N: 16},
 			}
 			return mt, nil
 		},
 	}
 	drv := New(enum)
 	infos, err := drv.Enumerate()
-	if err != nil || len(infos) != 1 || infos[0].Serial != "AS1" {
+	if err != nil || len(infos) != 1 || infos[0].Serial != "HF1" {
 		t.Fatalf("Enumerate = %+v, err=%v", infos, err)
 	}
-	if infos[0].TunerName != "R820T (Airspy R2)" {
-		t.Errorf("Enumerate TunerName = %q, want R820T (Airspy R2)", infos[0].TunerName)
+	if infos[0].Product != "Airspy HF+ Discovery" {
+		t.Errorf("Enumerate Product = %q, want Airspy HF+ Discovery", infos[0].Product)
 	}
 	dev, err := drv.Open(0)
 	if err != nil {
@@ -57,57 +60,44 @@ func TestDriverEnumerateOpenSetsSampleType(t *testing.T) {
 		t.Fatal("OpenFunc not invoked")
 	}
 	asDev := dev.(*Device)
-	if len(asDev.rates) != 2 || asDev.rates[0] != 10_000_000 {
+	if len(asDev.rates) != 4 || asDev.rates[0] != 768_000 {
 		t.Fatalf("samplerate table = %v", asDev.rates)
+	}
+	if !strings.Contains(asDev.info.TunerName, "R3.0.7") {
+		t.Errorf("TunerName = %q, want firmware suffix", asDev.info.TunerName)
 	}
 	if err := dev.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
 	}
 }
 
-func TestTunerNameDetectsMini(t *testing.T) {
+func TestVariantNameDiscoveryDualLegacy(t *testing.T) {
 	cases := []struct {
 		product string
 		want    string
 	}{
-		{"Airspy R2", "R820T (Airspy R2)"},
-		{"Airspy Mini", "R820T (Airspy Mini)"},
-		{"AIRSPY MINI", "R820T (Airspy Mini)"},
-		{"airspy mini", "R820T (Airspy Mini)"},
-		{"", "R820T (Airspy R2)"},
-		{"Generic Airspy", "R820T (Airspy R2)"},
+		{"Airspy HF+ Discovery", "Airspy HF+ Discovery"},
+		{"AIRSPY HF+ DUAL PORT", "Airspy HF+ Dual Port"},
+		{"airspy hf+ dual-port revB", "Airspy HF+ Dual Port"},
+		{"Airspy HF+", "Airspy HF+"},
+		{"", "Airspy HF+"},
+		{"random-product", "Airspy HF+"},
 	}
 	for _, c := range cases {
-		if got := tunerNameFor(c.product); got != c.want {
-			t.Errorf("tunerNameFor(%q) = %q, want %q", c.product, got, c.want)
+		if got := variantName(c.product); got != c.want {
+			t.Errorf("variantName(%q) = %q, want %q", c.product, got, c.want)
 		}
-	}
-}
-
-func TestEnumerateTagsMini(t *testing.T) {
-	enum := &usb.MockEnumerator{
-		Devices: []usb.Descriptor{
-			{Bus: 1, Address: 9, VID: vidAirspy, PID: pidAirspy, Serial: "MINI1", Product: "Airspy Mini"},
-		},
-	}
-	drv := New(enum)
-	infos, err := drv.Enumerate()
-	if err != nil {
-		t.Fatalf("Enumerate: %v", err)
-	}
-	if len(infos) != 1 || infos[0].TunerName != "R820T (Airspy Mini)" {
-		t.Fatalf("Enumerate = %+v", infos)
 	}
 }
 
 func TestSetCenterFreqEncoding(t *testing.T) {
 	dev, mt := withDevice(t)
 	payload := make([]byte, 4)
-	binary.LittleEndian.PutUint32(payload, 162_550_000)
+	binary.LittleEndian.PutUint32(payload, 14_070_000)
 	mt.Script = []usb.CtrlExchange{
 		{BRequest: reqSetFreq, Data: payload},
 	}
-	if err := dev.SetCenterFreq(162_550_000); err != nil {
+	if err := dev.SetCenterFreq(14_070_000); err != nil {
 		t.Fatalf("SetCenterFreq: %v", err)
 	}
 	if mt.Err != nil {
@@ -116,35 +106,39 @@ func TestSetCenterFreqEncoding(t *testing.T) {
 }
 
 func TestClosestRateIndex(t *testing.T) {
-	dev := &Device{rates: []uint32{10_000_000, 2_500_000}}
+	dev := &Device{rates: []uint32{768_000, 384_000, 256_000, 192_000}}
 	cases := []struct {
 		hz   uint32
 		want int
 	}{
-		{10_000_000, 0},
-		{9_000_000, 0},
-		{4_000_000, 1},
-		{2_500_000, 1},
+		{768_000, 0},
+		{700_000, 0},
+		{500_000, 1}, // closer to 384k (116k) than 768k (268k)
+		{384_000, 1},
+		{300_000, 2}, // closer to 256k (44k) than 384k (84k)
+		{256_000, 2},
+		{192_000, 3},
+		{100_000, 3},
 	}
 	for _, c := range cases {
 		if got := dev.closestRateIndex(c.hz); got != c.want {
 			t.Errorf("closestRateIndex(%d) = %d, want %d", c.hz, got, c.want)
 		}
 	}
-	// No table → falls back to index 0.
+	// Empty table → falls back to index 0.
 	if (&Device{}).closestRateIndex(123) != 0 {
 		t.Error("empty table should default to index 0")
 	}
 }
 
 func TestSetSampleRateSelectsClosest(t *testing.T) {
-	dev := &Device{rates: []uint32{10_000_000, 2_500_000}}
+	dev := &Device{rates: []uint32{768_000, 384_000}}
 	mt := usb.NewMockTransport()
 	dev.t = mt
 	mt.Script = []usb.CtrlExchange{
-		{BRequest: reqSetSamplerate, WValue: 1}, // 4M is closer to 2.5M than 10M
+		{BRequest: reqSetSamplerate, WValue: 1}, // 300k is closer to 384k than 768k
 	}
-	if err := dev.SetSampleRate(4_000_000); err != nil {
+	if err := dev.SetSampleRate(300_000); err != nil {
 		t.Fatalf("SetSampleRate: %v", err)
 	}
 	if mt.Err != nil {
@@ -152,32 +146,12 @@ func TestSetSampleRateSelectsClosest(t *testing.T) {
 	}
 }
 
-func TestSplitAirspyGain(t *testing.T) {
-	cases := []struct {
-		tenthDB                   int
-		wantLNA, wantMix, wantVGA int
-	}{
-		{0, 0, 0, 0},
-		{30, 1, 0, 0},
-		{90, 3, 0, 0},
-		{600, 15, 5, 0},    // saturates LNA; remainder rolls to mixer
-		{1500, 15, 15, 15}, // fully saturated
-	}
-	for _, c := range cases {
-		l, m, v := splitAirspyGain(c.tenthDB)
-		if l != c.wantLNA || m != c.wantMix || v != c.wantVGA {
-			t.Errorf("splitAirspyGain(%d) = (%d,%d,%d), want (%d,%d,%d)",
-				c.tenthDB, l, m, v, c.wantLNA, c.wantMix, c.wantVGA)
-		}
-	}
-}
-
-func TestSetGainAutoEnablesAGC(t *testing.T) {
+func TestSetGainAutoEnablesHFAGC(t *testing.T) {
 	dev, mt := withDevice(t)
 	mt.Script = []usb.CtrlExchange{
-		{In: true, BRequest: reqSetLNAAGC, WIndex: 1, Reply: []byte{0}, N: 1},
-		{In: true, BRequest: reqSetMixerAGC, WIndex: 1, Reply: []byte{0}, N: 1},
-		{In: true, BRequest: reqSetVGAGain, WIndex: defaultVGAGain, Reply: []byte{0}, N: 1},
+		{BRequest: reqSetHFAGC, WValue: 1},
+		{BRequest: reqSetHFLNA, WValue: 0},
+		{BRequest: reqSetHFATT, WValue: 0},
 	}
 	if err := dev.SetGain(-1); err != nil {
 		t.Fatalf("SetGain(-1): %v", err)
@@ -187,17 +161,33 @@ func TestSetGainAutoEnablesAGC(t *testing.T) {
 	}
 }
 
-func TestSetGainManualDisablesAGC(t *testing.T) {
+func TestSetGainManualSplitsATTLNA(t *testing.T) {
+	// 420 tenth-dB → 42 dB → ATT step 7 (42 dB), remainder 0 → LNA off.
 	dev, mt := withDevice(t)
 	mt.Script = []usb.CtrlExchange{
-		{In: true, BRequest: reqSetLNAAGC, WIndex: 0, Reply: []byte{0}, N: 1},
-		{In: true, BRequest: reqSetMixerAGC, WIndex: 0, Reply: []byte{0}, N: 1},
-		{In: true, BRequest: reqSetLNAGain, WIndex: 3, Reply: []byte{0}, N: 1},
-		{In: true, BRequest: reqSetMixerGain, WIndex: 0, Reply: []byte{0}, N: 1},
-		{In: true, BRequest: reqSetVGAGain, WIndex: 0, Reply: []byte{0}, N: 1},
+		{BRequest: reqSetHFAGC, WValue: 0},
+		{BRequest: reqSetHFATT, WValue: 7},
+		{BRequest: reqSetHFLNA, WValue: 0},
 	}
-	if err := dev.SetGain(90); err != nil { // 9 dB target → LNA=3, others 0
-		t.Fatalf("SetGain(90): %v", err)
+	if err := dev.SetGain(420); err != nil {
+		t.Fatalf("SetGain(420): %v", err)
+	}
+	if mt.Err != nil {
+		t.Fatalf("transport: %v", mt.Err)
+	}
+}
+
+func TestSetGainManualLNAOnAboveMaxATT(t *testing.T) {
+	// 540 tenth-dB → 54 dB → ATT step 9 → clamped to 8 (48 dB),
+	// remainder 60 → LNA on (+6 dB preamp).
+	dev, mt := withDevice(t)
+	mt.Script = []usb.CtrlExchange{
+		{BRequest: reqSetHFAGC, WValue: 0},
+		{BRequest: reqSetHFATT, WValue: 8},
+		{BRequest: reqSetHFLNA, WValue: 1},
+	}
+	if err := dev.SetGain(540); err != nil {
+		t.Fatalf("SetGain(540): %v", err)
 	}
 	if mt.Err != nil {
 		t.Fatalf("transport: %v", mt.Err)
@@ -207,8 +197,8 @@ func TestSetGainManualDisablesAGC(t *testing.T) {
 func TestSetBiasTeeRoundTrips(t *testing.T) {
 	dev, mt := withDevice(t)
 	mt.Script = []usb.CtrlExchange{
-		{BRequest: reqSetRFBiasCmd, WValue: 1},
-		{BRequest: reqSetRFBiasCmd, WValue: 0},
+		{BRequest: reqSetBiasTee, WValue: 1},
+		{BRequest: reqSetBiasTee, WValue: 0},
 	}
 	if err := dev.SetBiasTee(true); err != nil {
 		t.Fatalf("SetBiasTee(on): %v", err)
@@ -222,7 +212,7 @@ func TestSetBiasTeeRoundTrips(t *testing.T) {
 }
 
 func TestDecodeInt16IQ(t *testing.T) {
-	// Two samples: (+32767, -32768) → ~(1,-1); (0,0) → (0,0).
+	// Two samples: (+32767, -32768) → ~(1, -1); (0, 0) → (0, 0).
 	buf := make([]byte, 8)
 	binary.LittleEndian.PutUint16(buf[0:2], uint16(int16(32767)))
 	var minI16 int16 = -32768
@@ -261,5 +251,12 @@ func TestStreamIQFlipsReceiverAndStops(t *testing.T) {
 	}
 	if mt.Err != nil {
 		t.Fatalf("transport: %v", mt.Err)
+	}
+}
+
+func TestCleanVersionStringStripsPadding(t *testing.T) {
+	got := cleanVersionString([]byte("R3.0.7\x00garbage"))
+	if got != "R3.0.7" {
+		t.Errorf("cleanVersionString = %q, want R3.0.7", got)
 	}
 }

--- a/internal/sdr/airspyhf/register.go
+++ b/internal/sdr/airspyhf/register.go
@@ -1,0 +1,8 @@
+package airspyhf
+
+import "github.com/MattCheramie/GopherTrunk/internal/sdr"
+
+// Register the Airspy HF+ driver under its canonical name so a blank
+// import of this package from cmd/gophertrunk makes the device
+// discoverable through sdr.Pool.Open.
+func init() { sdr.Register(New(nil)) }

--- a/internal/sdr/hackrf/hackrf.go
+++ b/internal/sdr/hackrf/hackrf.go
@@ -20,6 +20,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/MattCheramie/GopherTrunk/internal/sdr"
@@ -42,12 +43,34 @@ const (
 	reqSampleRateSet       uint8 = 6
 	reqBasebandFilterBwSet uint8 = 7
 	reqBoardIDRead         uint8 = 14
+	reqVersionStringRead   uint8 = 15
 	reqSetFreq             uint8 = 16
 	reqAmpEnable           uint8 = 17
 	reqSetLNAGain          uint8 = 19
 	reqSetVGAGain          uint8 = 20
 	reqAntennaEnable       uint8 = 23
 )
+
+// pidProductNames maps each known HackRF USB PID to the canonical
+// product label we surface in sdr.Info. USB descriptor strings vary
+// across vendors and firmware builds; the PID is the stable identity.
+var pidProductNames = map[uint16]string{
+	pidHackRFOne:    "HackRF One",
+	pidHackRFJawbrk: "HackRF Jawbreaker",
+	pidHackRFRad1o:  "Rad1o",
+}
+
+// boardIDNames mirrors libhackrf's enum hackrf_board_id values. Read
+// from the firmware via reqBoardIDRead at open-time; takes precedence
+// over the PID-based lookup so a flashed-with-the-wrong-firmware unit
+// still reports what's actually running on the board.
+var boardIDNames = map[uint8]string{
+	0:   "Jellybean",
+	1:   "HackRF Jawbreaker",
+	2:   "HackRF One",
+	3:   "Rad1o",
+	255: "Invalid",
+}
 
 const (
 	transceiverModeOff     uint16 = 0
@@ -109,7 +132,7 @@ func (d *Driver) Enumerate() ([]sdr.Info, error) {
 			Index:        i,
 			Serial:       serial,
 			Manufacturer: desc.Manufacturer,
-			Product:      desc.Product,
+			Product:      productForPID(desc.PID, desc.Product),
 			TunerName:    "MAX2839+MAX5864",
 			// Tenth-dB presets the operator can pick from in the UI;
 			// the driver also accepts a free-form value via SetGain.
@@ -117,6 +140,20 @@ func (d *Driver) Enumerate() ([]sdr.Info, error) {
 		}
 	}
 	return out, nil
+}
+
+// productForPID returns the canonical HackRF product label for pid,
+// falling back to the USB descriptor's Product string when the PID
+// isn't in our table (defensive against future firmware revisions
+// that ship under a new PID).
+func productForPID(pid uint16, fallback string) string {
+	if name, ok := pidProductNames[pid]; ok {
+		return name
+	}
+	if fallback != "" {
+		return fallback
+	}
+	return "HackRF"
 }
 
 // Open claims the device at idx and returns an sdr.Device. The caller
@@ -149,6 +186,23 @@ func (d *Driver) Open(idx int) (sdr.Device, error) {
 	if serial == "" {
 		serial = fmt.Sprintf("hackrf-%02d", idx)
 	}
+	// Best-effort: ask the firmware which board it actually is and
+	// what version it's running. Either readback may fail on older
+	// firmware — fall through to the PID-derived product name and a
+	// plain TunerName when that happens.
+	product := productForPID(desc.PID, desc.Product)
+	if bid, err := readBoardID(t); err == nil {
+		if name, ok := boardIDNames[bid]; ok && name != "" {
+			product = name
+		}
+	}
+	tuner := "MAX2839+MAX5864"
+	if version, err := readVersionString(t); err == nil && version != "" {
+		if isPortaPack(version) {
+			product += " + PortaPack"
+		}
+		tuner = fmt.Sprintf("MAX2839+MAX5864 (fw %s)", version)
+	}
 	return &Device{
 		t: t,
 		info: sdr.Info{
@@ -156,10 +210,62 @@ func (d *Driver) Open(idx int) (sdr.Device, error) {
 			Index:        idx,
 			Serial:       serial,
 			Manufacturer: desc.Manufacturer,
-			Product:      desc.Product,
-			TunerName:    "MAX2839+MAX5864",
+			Product:      product,
+			TunerName:    tuner,
 		},
 	}, nil
+}
+
+// readBoardID issues a BOARD_ID_READ vendor request and returns the
+// firmware's self-reported board enum value. A single byte is enough
+// — we tolerate longer replies for forward compatibility.
+func readBoardID(t usb.Transport) (uint8, error) {
+	reply, err := t.ControlIn(reqBoardIDRead, 0, 0, 1, controlTimeoutMs)
+	if err != nil {
+		return 0, err
+	}
+	if len(reply) == 0 {
+		return 0, fmt.Errorf("hackrf: empty board-id reply")
+	}
+	return reply[0], nil
+}
+
+// readVersionString fetches the firmware's printable version string
+// (typically a git describe like "git-2024.02.1" or, on Mayhem builds,
+// something containing "portapack"/"mayhem"). Trailing NUL padding
+// and non-printable bytes are stripped.
+func readVersionString(t usb.Transport) (string, error) {
+	reply, err := t.ControlIn(reqVersionStringRead, 0, 0, 255, controlTimeoutMs)
+	if err != nil {
+		return "", err
+	}
+	return cleanVersionString(reply), nil
+}
+
+func cleanVersionString(buf []byte) string {
+	end := len(buf)
+	for i, b := range buf {
+		if b == 0 {
+			end = i
+			break
+		}
+	}
+	out := make([]byte, 0, end)
+	for _, b := range buf[:end] {
+		if b >= 0x20 && b < 0x7f {
+			out = append(out, b)
+		}
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// isPortaPack reports whether v looks like a PortaPack/Mayhem firmware
+// string. Both spellings appear in the wild — official PortaPack
+// builds tag themselves, and the community Mayhem fork keeps its own
+// name. We match either.
+func isPortaPack(v string) bool {
+	lv := strings.ToLower(v)
+	return strings.Contains(lv, "portapack") || strings.Contains(lv, "mayhem")
 }
 
 // Device is one opened HackRF.

--- a/internal/sdr/hackrf/hackrf_test.go
+++ b/internal/sdr/hackrf/hackrf_test.go
@@ -3,6 +3,7 @@ package hackrf
 import (
 	"context"
 	"encoding/binary"
+	"strings"
 	"testing"
 	"time"
 
@@ -19,9 +20,20 @@ func withDevice(t *testing.T) (*Device, *usb.MockTransport) {
 }
 
 func TestDriverEnumerateAndOpen(t *testing.T) {
+	// Open now issues BOARD_ID_READ + VERSION_STRING_READ control
+	// transfers, so the mock needs a scripted transport (not the
+	// default blank one) — script both readbacks here.
 	enum := &usb.MockEnumerator{
 		Devices: []usb.Descriptor{
 			{Bus: 1, Address: 7, VID: vidHackRF, PID: pidHackRFOne, Serial: "ABC", Product: "HackRF One", Path: "mock/1"},
+		},
+		OpenFunc: func(usb.Descriptor) (*usb.MockTransport, error) {
+			mt := usb.NewMockTransport()
+			mt.Script = []usb.CtrlExchange{
+				{In: true, BRequest: reqBoardIDRead, Reply: []byte{2}, N: 1},
+				{In: true, BRequest: reqVersionStringRead, Reply: []byte("git-2024.02.1\x00"), N: 255},
+			}
+			return mt, nil
 		},
 	}
 	drv := New(enum)
@@ -32,6 +44,9 @@ func TestDriverEnumerateAndOpen(t *testing.T) {
 	if len(infos) != 1 || infos[0].Serial != "ABC" || infos[0].Driver != driverName {
 		t.Fatalf("Enumerate = %+v", infos)
 	}
+	if infos[0].Product != "HackRF One" {
+		t.Errorf("Enumerate Product = %q, want %q", infos[0].Product, "HackRF One")
+	}
 	dev, err := drv.Open(0)
 	if err != nil {
 		t.Fatalf("Open: %v", err)
@@ -39,8 +54,180 @@ func TestDriverEnumerateAndOpen(t *testing.T) {
 	if dev.Info().Serial != "ABC" {
 		t.Fatalf("Info.Serial = %q, want ABC", dev.Info().Serial)
 	}
+	if dev.Info().Product != "HackRF One" {
+		t.Errorf("Info.Product = %q, want %q", dev.Info().Product, "HackRF One")
+	}
+	if !strings.Contains(dev.Info().TunerName, "git-2024.02.1") {
+		t.Errorf("Info.TunerName = %q, want firmware suffix", dev.Info().TunerName)
+	}
 	if err := dev.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
+	}
+}
+
+func TestEnumerateRenamesByPID(t *testing.T) {
+	// Even when the USB descriptor Product is garbage, the canonical
+	// name comes from the PID.
+	enum := &usb.MockEnumerator{
+		Devices: []usb.Descriptor{
+			{Bus: 1, Address: 1, VID: vidHackRF, PID: pidHackRFOne, Serial: "S1", Product: "weird-descriptor"},
+			{Bus: 1, Address: 2, VID: vidHackRF, PID: pidHackRFJawbrk, Serial: "S2", Product: ""},
+			{Bus: 1, Address: 3, VID: vidHackRF, PID: pidHackRFRad1o, Serial: "S3", Product: "Rad1o badge"},
+		},
+	}
+	drv := New(enum)
+	infos, err := drv.Enumerate()
+	if err != nil {
+		t.Fatalf("Enumerate: %v", err)
+	}
+	want := []string{"HackRF One", "HackRF Jawbreaker", "Rad1o"}
+	if len(infos) != len(want) {
+		t.Fatalf("got %d infos, want %d", len(infos), len(want))
+	}
+	for i, w := range want {
+		if infos[i].Product != w {
+			t.Errorf("infos[%d].Product = %q, want %q", i, infos[i].Product, w)
+		}
+	}
+}
+
+func TestProductForPIDFallback(t *testing.T) {
+	cases := []struct {
+		pid      uint16
+		fallback string
+		want     string
+	}{
+		{pidHackRFOne, "ignored", "HackRF One"},
+		{0xbeef, "USB descriptor name", "USB descriptor name"},
+		{0xbeef, "", "HackRF"},
+	}
+	for _, c := range cases {
+		if got := productForPID(c.pid, c.fallback); got != c.want {
+			t.Errorf("productForPID(%#x, %q) = %q, want %q", c.pid, c.fallback, got, c.want)
+		}
+	}
+}
+
+func TestOpenAppendsPortaPackTag(t *testing.T) {
+	enum := &usb.MockEnumerator{
+		Devices: []usb.Descriptor{
+			{Bus: 1, Address: 7, VID: vidHackRF, PID: pidHackRFOne, Serial: "PP1", Product: "HackRF One"},
+		},
+		OpenFunc: func(usb.Descriptor) (*usb.MockTransport, error) {
+			mt := usb.NewMockTransport()
+			mt.Script = []usb.CtrlExchange{
+				{In: true, BRequest: reqBoardIDRead, Reply: []byte{2}, N: 1},
+				{In: true, BRequest: reqVersionStringRead,
+					Reply: []byte("git-portapack-mayhem-v1.7.4\x00"), N: 255},
+			}
+			return mt, nil
+		},
+	}
+	drv := New(enum)
+	if _, err := drv.Enumerate(); err != nil {
+		t.Fatalf("Enumerate: %v", err)
+	}
+	dev, err := drv.Open(0)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer dev.Close()
+	if !strings.Contains(dev.Info().Product, "PortaPack") {
+		t.Errorf("Info.Product = %q, want PortaPack suffix", dev.Info().Product)
+	}
+}
+
+func TestReadBoardIDUnknownFallsBackToPID(t *testing.T) {
+	// Board-ID 99 isn't in boardIDNames — Product must fall back to
+	// the PID-derived name.
+	enum := &usb.MockEnumerator{
+		Devices: []usb.Descriptor{
+			{Bus: 1, Address: 7, VID: vidHackRF, PID: pidHackRFRad1o, Serial: "R1", Product: "Rad1o"},
+		},
+		OpenFunc: func(usb.Descriptor) (*usb.MockTransport, error) {
+			mt := usb.NewMockTransport()
+			mt.Script = []usb.CtrlExchange{
+				{In: true, BRequest: reqBoardIDRead, Reply: []byte{99}, N: 1},
+				{In: true, BRequest: reqVersionStringRead, Reply: []byte("custom-fw\x00"), N: 255},
+			}
+			return mt, nil
+		},
+	}
+	drv := New(enum)
+	if _, err := drv.Enumerate(); err != nil {
+		t.Fatalf("Enumerate: %v", err)
+	}
+	dev, err := drv.Open(0)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer dev.Close()
+	if dev.Info().Product != "Rad1o" {
+		t.Errorf("Info.Product = %q, want Rad1o (PID fallback)", dev.Info().Product)
+	}
+}
+
+func TestReadVersionStringIgnoredOnError(t *testing.T) {
+	// Older firmware that doesn't implement VERSION_STRING_READ
+	// returns an error; Open must still succeed with a plain
+	// TunerName.
+	enum := &usb.MockEnumerator{
+		Devices: []usb.Descriptor{
+			{Bus: 1, Address: 7, VID: vidHackRF, PID: pidHackRFOne, Serial: "OLD", Product: "HackRF One"},
+		},
+		OpenFunc: func(usb.Descriptor) (*usb.MockTransport, error) {
+			mt := usb.NewMockTransport()
+			// Only the board-ID read is scripted — version-string
+			// read has no matching entry, so MockTransport.recordErr
+			// returns an error which our Open is supposed to ignore.
+			mt.Script = []usb.CtrlExchange{
+				{In: true, BRequest: reqBoardIDRead, Reply: []byte{2}, N: 1},
+			}
+			return mt, nil
+		},
+	}
+	drv := New(enum)
+	if _, err := drv.Enumerate(); err != nil {
+		t.Fatalf("Enumerate: %v", err)
+	}
+	dev, err := drv.Open(0)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer dev.Close()
+	if dev.Info().TunerName != "MAX2839+MAX5864" {
+		t.Errorf("Info.TunerName = %q, want plain (no fw suffix)", dev.Info().TunerName)
+	}
+}
+
+func TestCleanVersionStringStripsPaddingAndNonPrintable(t *testing.T) {
+	// Padding NUL, embedded NUL, control char, trailing whitespace.
+	got := cleanVersionString([]byte("git-2024.02.1\x00garbage-after-nul"))
+	if got != "git-2024.02.1" {
+		t.Errorf("cleanVersionString = %q, want %q", got, "git-2024.02.1")
+	}
+	got = cleanVersionString([]byte(" git-foo\x07\x01 \x00"))
+	if got != "git-foo" {
+		t.Errorf("cleanVersionString (control chars) = %q, want %q", got, "git-foo")
+	}
+}
+
+func TestIsPortaPack(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"git-2024.02.1", false},
+		{"git-portapack-v1.7.4", true},
+		{"git-PORTAPACK", true},
+		{"mayhem-v1.7.4", true},
+		{"Mayhem build", true},
+		{"", false},
+	}
+	for _, c := range cases {
+		if got := isPortaPack(c.in); got != c.want {
+			t.Errorf("isPortaPack(%q) = %v, want %v", c.in, got, c.want)
+		}
 	}
 }
 


### PR DESCRIPTION
Adds the Airspy HF+ family (Discovery, Dual Port, legacy HF+) as a
new pure-Go driver at internal/sdr/airspyhf, speaking the documented
libairspyhf USB vendor protocol over the shared rtlsdr/usb transport
— so the zero-CGO, zero-libusb posture extends to the HF+ as well.
Coverage 9 kHz–31 MHz HF + 60–260 MHz VHF, HF AGC plus a 0–48 dB
attenuator and +6 dB LNA preamp; variant detection via the USB
descriptor's Product string (Discovery / Dual Port / legacy).

The existing HackRF driver now reads BOARD_ID_READ and
VERSION_STRING_READ at open so sdr.Info.Product is the canonical
model name from the firmware itself rather than whatever the USB
descriptor happens to carry, and TunerName carries the running
firmware version. PortaPack / Mayhem builds are auto-detected from
the version string and tagged with "+ PortaPack" so the operator
can see which physical board is on which USB port. Enumerate
normalises Product based on the PID as well, so listings stay
consistent even before Open.

The Airspy R2 / Mini driver now distinguishes the two variants by
the "MINI" substring in the USB Product string, surfacing R820T
(Airspy R2) or R820T (Airspy Mini) in TunerName so multi-dongle
pools can pick the right unit by name.

All four drivers register under their canonical names; the new
package wires in via a single blank import in cmd/gophertrunk.
Wire-protocol coverage is via usb.MockTransport unit tests, matching
the existing hackrf_test.go / airspy_test.go pattern. README,
docs/hardware.md, docs/architecture.md and CHANGELOG.md are updated
to reflect the expanded device coverage, the new udev rule, and
the firmware-aware reporting.