### PR TITLE
p25/phase1: add per-dibit error pattern to NID failure diag (#275)

### DIFF
--- a/internal/radio/p25/phase1/control.go
+++ b/internal/radio/p25/phase1/control.go
@@ -318,7 +318,8 @@ func (c *ControlChannel) parseFrame(buf []uint8, nidStart int, fswRot uint8) {
 		c.log.Debug("nid corrected", "errs", best.errs, "nac", best.nid.NAC,
 			"rot", best.rot, "delta", best.delta, "strip", best.strip,
 			"corroborated", best.errs > NIDAcceptErrs,
-			"at_boundary", atSearchBoundary(best.delta))
+			"at_boundary", atSearchBoundary(best.delta),
+			"err_pattern", formatErrPattern(best.errPattern))
 	}
 	if best.nid.DUID != DUIDTrunkingSignaling {
 		// Some non-control DUID — record but don't lock.
@@ -360,14 +361,18 @@ func (c *ControlChannel) parseFrame(buf []uint8, nidStart int, fswRot uint8) {
 // buf starting at nidStart+delta, with interleaved status symbols
 // stripped (strip) or taken contiguously, and the dibit alphabet
 // rotated by rot. tsbkStart is the index the matching TSBK gather
-// begins at.
+// begins at. errPattern is a 32-entry per-dibit bit-error count of the
+// received NID vs the BCH-corrected codeword (issue #275 diag —
+// surfaces error clustering on the closest-miss path so timing slip,
+// status-phase fault, and SNR-limited corruption are distinguishable).
 type nidGuess struct {
-	delta     int
-	strip     bool
-	rot       uint8
-	nid       NID
-	errs      int
-	tsbkStart int
+	delta      int
+	strip      bool
+	rot        uint8
+	nid        NID
+	errs       int
+	tsbkStart  int
+	errPattern [32]uint8
 }
 
 // searchNID evaluates the bounded grid of NID-alignment hypotheses for
@@ -387,6 +392,11 @@ type nidGuess struct {
 // summarises the closest miss for the failure log, turning a silent
 // reject into a measurement (a low marginal errs that fails only TSBK
 // corroboration points at demod-quality corruption, not misalignment).
+// The diag includes an err_pattern=<32-char> field — the per-dibit
+// bit-error count of the closest hypothesis vs its BCH-corrected
+// codeword — so a reporter can see where errors cluster (one end =
+// timing slip, near dibit 31 = status-phase fault, uniform = SNR
+// limited) without re-running the decode.
 func (c *ControlChannel) searchNID(buf []uint8, nidStart int, fswRot uint8) (nidGuess, bool, string) {
 	var best nidGuess
 	found := false
@@ -405,18 +415,18 @@ func (c *ControlChannel) searchNID(buf []uint8, nidStart int, fswRot uint8) (nid
 			rawNID, tsbkStart := gatherFrameDibits(buf, start, 32, fswStart, strip)
 			for _, rot := range c.rotations {
 				tried++
-				nid, errs, err := NIDFromDibits(rotateDibits(rawNID, rot))
+				nid, errs, pattern, err := NIDFromDibitsWithErrors(rotateDibits(rawNID, rot))
 				if err != nil {
 					if errs < 0 {
 						uncorrectable++
 					} else if closestMiss < 0 || errs < closestMiss {
 						closestMiss = errs
-						missAt = nidGuess{delta: delta, strip: strip, rot: rot, errs: errs}
+						missAt = nidGuess{delta: delta, strip: strip, rot: rot, errs: errs, errPattern: pattern}
 					}
 					continue
 				}
 				cand := nidGuess{delta: delta, strip: strip, rot: rot,
-					nid: nid, errs: errs, tsbkStart: tsbkStart}
+					nid: nid, errs: errs, tsbkStart: tsbkStart, errPattern: pattern}
 				if errs > NIDAcceptErrs {
 					// Parity-valid but too far from the received word for
 					// BCH+parity to tell a noisy real NID from a bad
@@ -453,13 +463,13 @@ func (c *ControlChannel) searchNID(buf []uint8, nidStart int, fswRot uint8) (nid
 		}
 		m := marginal[0]
 		return best, false, fmt.Sprintf(
-			"no NID corroborated over %d guesses; closest marginal errs=%d at delta=%d strip=%v rot=%d, TSBK uncorroborated%s",
-			tried, m.errs, m.delta, m.strip, m.rot, boundaryNote(m.delta))
+			"no NID corroborated over %d guesses; closest marginal errs=%d at delta=%d strip=%v rot=%d, TSBK uncorroborated%s; err_pattern=%s",
+			tried, m.errs, m.delta, m.strip, m.rot, boundaryNote(m.delta), formatErrPattern(m.errPattern))
 	}
 	if closestMiss >= 0 {
 		return best, false, fmt.Sprintf(
-			"no NID within accept gate over %d guesses; closest errs=%d at delta=%d strip=%v rot=%d%s",
-			tried, missAt.errs, missAt.delta, missAt.strip, missAt.rot, boundaryNote(missAt.delta))
+			"no NID within accept gate over %d guesses; closest errs=%d at delta=%d strip=%v rot=%d%s; err_pattern=%s",
+			tried, missAt.errs, missAt.delta, missAt.strip, missAt.rot, boundaryNote(missAt.delta), formatErrPattern(missAt.errPattern))
 	}
 	return best, false, fmt.Sprintf(
 		"no NID within accept gate over %d guesses; all %d BCH-uncorrectable", tried, uncorrectable)
@@ -484,6 +494,28 @@ func boundaryNote(delta int) string {
 		return fmt.Sprintf(" — best alignment at search boundary (±%d); true offset may exceed span", NIDSearchSpan)
 	}
 	return ""
+}
+
+// formatErrPattern renders a 32-entry per-dibit bit-error count as a
+// 32-character ASCII string of '0'/'1'/'2' digits, dibit 0 leftmost.
+//
+// Reading the string traces the NID from the first dibit after the FSW
+// (left) to the last dibit before the TSBK (right). Issue #275: errors
+// clustered at one end signal a post-FSW symbol-timing slip; errors
+// clustered around dibits 25–31 signal a status-symbol-phase fault;
+// errors uniformly distributed across all 32 dibits signal SNR-limited
+// demod corruption. Values above 2 are pathological (a dibit has only
+// two bits), but the formatter caps at '9' rather than panic so a
+// future change to the upstream counter cannot break log parsing.
+func formatErrPattern(p [32]uint8) string {
+	out := make([]byte, 32)
+	for i, c := range p {
+		if c > 9 {
+			c = 9
+		}
+		out[i] = '0' + c
+	}
+	return string(out)
 }
 
 // tsbkCorroborates reports whether the 98-dibit TSBK channel block that

--- a/internal/radio/p25/phase1/control_test.go
+++ b/internal/radio/p25/phase1/control_test.go
@@ -851,6 +851,57 @@ func TestControlChannelLocksOnMarginalNIDCorroboratedByTSBK(t *testing.T) {
 	}
 }
 
+// TestSearchNIDClosestMissReportsErrPattern locks down the per-dibit
+// error fingerprint searchNID now appends to the closest-miss diag
+// (issue #275 — the field reporter needs to distinguish post-FSW
+// timing slip from SNR-limited demod corruption on the next retest).
+//
+// Eight known NID dibits get their MSB flipped (= one bit error per
+// dibit, eight bit errors total — inside BCH(63,16,11)'s t=11 radius
+// but past the trusted gate of NIDAcceptErrs=6). The TSBK is corrupted
+// so the marginal tier cannot corroborate, forcing the
+// "no NID corroborated" diag branch — which is where err_pattern is
+// emitted. Asserting on the exact 32-char pattern verifies both that
+// the formatter renders it correctly AND that the canonical-alignment
+// hypothesis (delta=0, strip=true, rot=fswRot) wins marginal[0]
+// (lowest errs of the parity-valid candidates).
+func TestSearchNIDClosestMissReportsErrPattern(t *testing.T) {
+	cap := &diagCapture{}
+	bus := events.NewBus(16)
+	defer bus.Close()
+
+	frame := buildControlFrame(0x293, DUIDTrunkingSignaling,
+		TSBK{LB: true, Opcode: OpRFSSStatusBroadcast})
+	injected := []int{1, 4, 8, 12, 16, 20, 25, 30}
+	for _, i := range injected {
+		frame[24+i] ^= 0b10
+	}
+	for i := 24 + 32; i < 24+32+98; i++ {
+		frame[i] = (^frame[i]) & 0x3
+	}
+	onAir := InjectControlStatusSymbols(frame)
+	stream := make([]uint8, 10+len(onAir)+16)
+	copy(stream[10:], onAir)
+
+	cc := New(Options{Bus: bus, Log: slog.New(cap), FrequencyHz: 851_000_000})
+	cc.Process(stream, 0)
+
+	want := make([]byte, 32)
+	for i := range want {
+		want[i] = '0'
+	}
+	for _, i := range injected {
+		want[i] = '1'
+	}
+	needle := "err_pattern=" + string(want)
+	if !cap.containsDiag(needle) {
+		cap.mu.Lock()
+		seen := append([]string(nil), cap.diags...)
+		cap.mu.Unlock()
+		t.Fatalf("no diag contained %q\nseen diags: %v", needle, seen)
+	}
+}
+
 // TestControlChannelRejectsMarginalNIDWithoutTSBK is the false-lock
 // guard for the marginal tier: the same 8-bit-error NID, but with the
 // TSBK channel block corrupted too. With no clean TSBK to corroborate

--- a/internal/radio/p25/phase1/nid.go
+++ b/internal/radio/p25/phase1/nid.go
@@ -92,15 +92,70 @@ func ParseNID(bits []byte) (NID, int, error) {
 
 // NIDFromDibits is a convenience wrapper that takes 32 dibits (= 64 bits).
 func NIDFromDibits(dibits []uint8) (NID, int, error) {
+	nid, errs, _, err := NIDFromDibitsWithErrors(dibits)
+	return nid, errs, err
+}
+
+// NIDFromDibitsWithErrors is identical to NIDFromDibits but additionally
+// returns a 32-entry per-dibit bit-error count of the received NID
+// against the BCH-corrected codeword (with the corrected parity bit
+// folded into dibit 31). Each entry is 0, 1, or 2. The pattern is
+// always returned; on an uncorrectable codeword it is the zero array
+// (no comparison was possible). On ErrNIDParity the pattern reflects
+// the parity bit's contribution to dibit 31.
+//
+// The searchNID closest-miss diag uses this to surface *where* in the
+// NID the residual bit errors cluster — distinguishing post-FSW timing
+// slip (errors at one end of the NID), a status-symbol-phase fault
+// (errors clustered around the tail dibits), and SNR-limited demod
+// corruption (errors distributed across all 32 dibits). Issue #275.
+func NIDFromDibitsWithErrors(dibits []uint8) (NID, int, [32]uint8, error) {
+	var pattern [32]uint8
 	if len(dibits) < 32 {
-		return NID{}, -1, fmt.Errorf("p25/phase1: NID requires 32 dibits, got %d", len(dibits))
+		return NID{}, -1, pattern, fmt.Errorf("p25/phase1: NID requires 32 dibits, got %d", len(dibits))
 	}
 	bits := make([]byte, 64)
 	for i := 0; i < 32; i++ {
 		bits[2*i] = (dibits[i] >> 1) & 1
 		bits[2*i+1] = dibits[i] & 1
 	}
-	return ParseNID(bits)
+	var cw uint64
+	for i := 0; i < 63; i++ {
+		if bits[i]&1 != 0 {
+			cw |= uint64(1) << uint(62-i)
+		}
+	}
+	rxParity := bits[63] & 1
+
+	data, errs := framing.BCHDecode63_16(cw)
+	if errs < 0 {
+		return NID{}, -1, pattern, ErrNIDUncorrectable
+	}
+	corrected := framing.BCHEncode63_16(data)
+	correctedParity := framing.BCH6316ParityBit(corrected)
+
+	// Per-dibit error count: bit i of the received codeword vs bit i of
+	// the BCH-corrected codeword, with the parity bit (bit 63) folded
+	// into dibit 31.
+	for i := 0; i < 63; i++ {
+		var corBit byte
+		if corrected&(uint64(1)<<uint(62-i)) != 0 {
+			corBit = 1
+		}
+		if bits[i] != corBit {
+			pattern[i/2]++
+		}
+	}
+	if rxParity != correctedParity {
+		pattern[31]++
+	}
+
+	if correctedParity != rxParity {
+		return NID{}, errs, pattern, ErrNIDParity
+	}
+	nac := uint16((data >> 4) & 0xFFF)
+	duid := DUID(data & 0xF)
+	return NID{NAC: nac, DUID: duid}, errs, pattern, nil
 }
 
 // EncodeNIDBits builds the 64 transmitted NID bits (MSB-first) for a


### PR DESCRIPTION
The post-#321 #275 retest on a build that predated #320's widening + the
C4FM rotation restriction reported `closest marginal errs=10 at delta=2
strip=true rot=3` every frame — the classic stale-build signature
(`rot=3` is non-physical on a C4FM FM-discriminator stream and `delta=2`
is the +2 edge of the pre-widening ±2 grid, both fixed by 6b408c7). The
retest is invalid until rebuilt against current main, but the next
retest deserves a sharper diagnostic surface than "8/10/11 BCH errs at
delta D, strip S, rot R".

Add `NIDFromDibitsWithErrors` alongside the existing `NIDFromDibits`:
identical return path, but additionally produces a 32-entry per-dibit
bit-error count of the received NID against the BCH-corrected
codeword. Wire it into `searchNID` so every probed hypothesis carries
the pattern (one branch in the inner loop), and append an
`err_pattern=<32 char>` field to both closest-miss diag formats and the
success "nid corrected" debug log. Each character is '0', '1', or '2'
— the bit-error count of that dibit position, dibit 0 leftmost.

The fingerprint distinguishes three failure modes that all surface as
"NID won't BCH-decode" on the current diag:

  - errors clustered at one end of the 32-char string -> post-FSW
    symbol-timing slip across the FSW->NID transition
  - errors clustered around dibits 25-31 -> status-symbol-phase fault
    (a misaligned status symbol leaking into the NID tail)
  - errors uniformly sprinkled across all 32 dibits -> SNR-limited
    demod corruption, not framing

`TestSearchNIDClosestMissReportsErrPattern` locks the contract: an
eight-bit-error NID with a corrupted TSBK forces the "no NID
corroborated" branch and the diag must report the exact 32-char
pattern matching the injected positions.