### PR TITLE
p25/phase1: make NID-search span configurable per instance (#275)

### DIFF
--- a/cmd/gophertrunk/replay.go
+++ b/cmd/gophertrunk/replay.go
@@ -46,6 +46,14 @@ func runReplay(args []string) {
 	sampleRate := fs.Float64("sample-rate", 2_400_000, "IQ sample rate in Hz")
 	demod := fs.String("demod", "c4fm", "P25 Phase 1 demod mode: c4fm | cqpsk")
 	freq := fs.Uint64("freq", 0, "informational only: the capture's nominal centre frequency in Hz")
+	// Issue #275 bisect knob. The default ±6 grid is the production
+	// value; widening to ±12/±18/±36 on a stubborn capture tells a
+	// span-bounded failure (errs drop at the new optimum) from a
+	// demod-quality-bounded one (errs stay at the BCH(63,16,11)
+	// correction ceiling regardless of alignment). Both acceptance
+	// tiers (BCH+parity + TSBK CRC) reject wrong alignments at any
+	// span, so widening cannot manufacture a false lock.
+	nidSearchSpan := fs.Int("nid-search-span", p25phase1.NIDSearchSpan, "NID-alignment search radius in dibits (default matches the production ccdecoder; widen to bisect a stubborn capture per issue #275)")
 	fs.Usage = func() {
 		fmt.Fprintln(fs.Output(), `gophertrunk replay — decode a raw IQ capture file offline.
 
@@ -76,6 +84,10 @@ FLAGS:`)
 	demodMode, ok := p25phase1rx.ParseDemodMode(*demod)
 	if !ok {
 		fmt.Fprintf(os.Stderr, "replay: unknown -demod %q (want c4fm or cqpsk)\n", *demod)
+		os.Exit(2)
+	}
+	if *nidSearchSpan <= 0 {
+		fmt.Fprintln(os.Stderr, "replay: -nid-search-span must be > 0")
 		os.Exit(2)
 	}
 
@@ -110,12 +122,19 @@ FLAGS:`)
 		rotations = p25phase1.RotationsC4FM
 	}
 	cc := p25phase1.New(p25phase1.Options{
-		Bus:         bus,
-		Log:         logger,
-		SystemName:  "replay",
-		FrequencyHz: uint32(*freq),
-		Rotations:   rotations,
+		Bus:           bus,
+		Log:           logger,
+		SystemName:    "replay",
+		FrequencyHz:   uint32(*freq),
+		Rotations:     rotations,
+		NIDSearchSpan: *nidSearchSpan,
 	})
+	// Surface the active configuration the same way the ccdecoder
+	// pipeline does, so the replay log line is directly comparable
+	// to a daemon's startup line — and a non-default span (the
+	// bisect knob) is visible without re-reading the command.
+	fmt.Fprintf(os.Stderr, "replay: p25/phase1 configured  demod=%s  rotations=%v  nid_search_span=%d  nid_accept_errs=%d  nid_marginal_max=%d\n",
+		*demod, rotations, *nidSearchSpan, p25phase1.NIDAcceptErrs, p25phase1.NIDMarginalMaxErrs)
 
 	var dibitCount int64
 	rx := p25phase1rx.New(p25phase1rx.Options{

--- a/internal/radio/p25/phase1/control.go
+++ b/internal/radio/p25/phase1/control.go
@@ -72,6 +72,17 @@ type ControlChannel struct {
 	// #275, where the post-#321 retest converged on rot=3 on a C4FM
 	// site.
 	rotations RotationSet
+
+	// nidSearchSpan is the per-instance grid radius used by searchNID
+	// in place of the package-level NIDSearchSpan constant — a
+	// bisect knob for issue #275 retests where the closest-miss
+	// keeps pegging at the boundary even after the ±6 default. The
+	// replay subcommand exposes it via -nid-search-span so an
+	// operator can re-run an IQ capture at ±12 or ±36 to rule out
+	// alignment-distance as the dominant failure mode. Zero in
+	// Options falls back to NIDSearchSpan, so production wiring is
+	// unaffected.
+	nidSearchSpan int
 }
 
 // NetworkSnapshot returns the system topology accumulated from the
@@ -105,6 +116,19 @@ type Options struct {
 	// only lets the BCH decoder miscorrect misaligned dibits into a
 	// parity-valid pseudo-NID at a wrong rotation (issue #275).
 	Rotations RotationSet
+
+	// NIDSearchSpan overrides the per-instance NID-alignment grid
+	// radius. Zero falls back to the package-level NIDSearchSpan
+	// constant — the default the ccdecoder pipeline uses in
+	// production. The replay subcommand exposes this as a bisect knob
+	// (-nid-search-span) so issue #275 retests can widen the search
+	// to ±12 / ±18 / ±36 without rebuilding, to tell a span-bounded
+	// failure from a demod-quality-bounded one. The two acceptance
+	// tiers (BCH+parity + TSBK CRC) reject wrong alignments regardless
+	// of span, so widening cannot manufacture a false lock — only let
+	// the search reach a true alignment that lies past the default
+	// edge.
+	NIDSearchSpan int
 }
 
 // New constructs a ControlChannel from Options. SystemName ends up on
@@ -127,16 +151,21 @@ func New(opts Options) *ControlChannel {
 	if len(opts.Rotations) > 0 {
 		det.SetRotations(opts.Rotations)
 	}
+	span := opts.NIDSearchSpan
+	if span <= 0 {
+		span = NIDSearchSpan
+	}
 	return &ControlChannel{
-		bus:        opts.Bus,
-		log:        log,
-		det:        det,
-		systemName: opts.SystemName,
-		freqHz:     opts.FrequencyHz,
-		bandPlan:   bp,
-		now:        now,
-		aliasAsm:   NewTalkerAliasAssembler(now),
-		rotations:  resolveRotations(opts.Rotations),
+		bus:           opts.Bus,
+		log:           log,
+		det:           det,
+		systemName:    opts.SystemName,
+		freqHz:        opts.FrequencyHz,
+		bandPlan:      bp,
+		now:           now,
+		aliasAsm:      NewTalkerAliasAssembler(now),
+		rotations:     resolveRotations(opts.Rotations),
+		nidSearchSpan: span,
 	}
 }
 
@@ -275,7 +304,7 @@ func (c *ControlChannel) Process(dibits []uint8, baseIdx int) int {
 		if nidStart < 0 {
 			continue // buffer already trimmed past this hit — drop it
 		}
-		if nidStart+frameLookahead+NIDSearchSpan > len(c.buf) {
+		if nidStart+frameLookahead+c.nidSearchSpan > len(c.buf) {
 			kept = append(kept, ph) // not enough buffered yet
 			continue
 		}
@@ -318,7 +347,7 @@ func (c *ControlChannel) parseFrame(buf []uint8, nidStart int, fswRot uint8) {
 		c.log.Debug("nid corrected", "errs", best.errs, "nac", best.nid.NAC,
 			"rot", best.rot, "delta", best.delta, "strip", best.strip,
 			"corroborated", best.errs > NIDAcceptErrs,
-			"at_boundary", atSearchBoundary(best.delta),
+			"at_boundary", atSearchBoundary(best.delta, c.nidSearchSpan),
 			"err_pattern", formatErrPattern(best.errPattern))
 	}
 	if best.nid.DUID != DUIDTrunkingSignaling {
@@ -405,7 +434,7 @@ func (c *ControlChannel) searchNID(buf []uint8, nidStart int, fswRot uint8) (nid
 	uncorrectable, tried := 0, 0
 	var marginal []nidGuess // parity-valid NIDs with errs > NIDAcceptErrs
 
-	for delta := -NIDSearchSpan; delta <= NIDSearchSpan; delta++ {
+	for delta := -c.nidSearchSpan; delta <= c.nidSearchSpan; delta++ {
 		start := nidStart + delta
 		if start < 0 || start+frameLookahead > len(buf) {
 			continue
@@ -464,34 +493,37 @@ func (c *ControlChannel) searchNID(buf []uint8, nidStart int, fswRot uint8) (nid
 		m := marginal[0]
 		return best, false, fmt.Sprintf(
 			"no NID corroborated over %d guesses; closest marginal errs=%d at delta=%d strip=%v rot=%d, TSBK uncorroborated%s; err_pattern=%s",
-			tried, m.errs, m.delta, m.strip, m.rot, boundaryNote(m.delta), formatErrPattern(m.errPattern))
+			tried, m.errs, m.delta, m.strip, m.rot, boundaryNote(m.delta, c.nidSearchSpan), formatErrPattern(m.errPattern))
 	}
 	if closestMiss >= 0 {
 		return best, false, fmt.Sprintf(
 			"no NID within accept gate over %d guesses; closest errs=%d at delta=%d strip=%v rot=%d%s; err_pattern=%s",
-			tried, missAt.errs, missAt.delta, missAt.strip, missAt.rot, boundaryNote(missAt.delta), formatErrPattern(missAt.errPattern))
+			tried, missAt.errs, missAt.delta, missAt.strip, missAt.rot, boundaryNote(missAt.delta, c.nidSearchSpan), formatErrPattern(missAt.errPattern))
 	}
 	return best, false, fmt.Sprintf(
 		"no NID within accept gate over %d guesses; all %d BCH-uncorrectable", tried, uncorrectable)
 }
 
 // atSearchBoundary reports whether an alignment hypothesis sits at the
-// edge of the NIDSearchSpan grid. A "best" or closest-miss at the
+// edge of the NID-alignment grid. A "best" or closest-miss at the
 // boundary is the textbook signature of a bounded search pegged at its
 // limit — issue #275, where the post-#321 retest converged on delta=2
 // (the ±2 grid's positive edge) every frame. Flagging it in the logs
 // turns the next retest into a measurement: still pegged at the new
 // edge → the true offset exceeds the span; interior with low errs →
-// the framing was the cause and the fix worked.
-func atSearchBoundary(delta int) bool {
-	return delta == NIDSearchSpan || delta == -NIDSearchSpan
+// the framing was the cause and the fix worked. span is the
+// per-instance grid radius (see ControlChannel.nidSearchSpan); when
+// callers pass the package constant the behaviour is unchanged.
+func atSearchBoundary(delta, span int) bool {
+	return delta == span || delta == -span
 }
 
 // boundaryNote returns a diag-string suffix to append when a closest /
-// best hypothesis sits at the search boundary; empty otherwise.
-func boundaryNote(delta int) string {
-	if atSearchBoundary(delta) {
-		return fmt.Sprintf(" — best alignment at search boundary (±%d); true offset may exceed span", NIDSearchSpan)
+// best hypothesis sits at the search boundary; empty otherwise. span
+// is the same per-instance grid radius searchNID is iterating over.
+func boundaryNote(delta, span int) string {
+	if atSearchBoundary(delta, span) {
+		return fmt.Sprintf(" — best alignment at search boundary (±%d); true offset may exceed span", span)
 	}
 	return ""
 }

--- a/internal/radio/p25/phase1/control_test.go
+++ b/internal/radio/p25/phase1/control_test.go
@@ -592,6 +592,63 @@ func TestControlChannelLocksThroughPostFSWSlipSmallChunks(t *testing.T) {
 	}
 }
 
+// TestControlChannelLocksThroughWiderPostFSWSlip confirms the
+// per-instance Options.NIDSearchSpan override actually widens the
+// search beyond the package-level constant. A 10-dibit post-FSW slip
+// is unreachable for a default ControlChannel (NIDSearchSpan=6) but
+// must lock for one constructed with Options{NIDSearchSpan: 12} — the
+// bisect knob the replay subcommand exposes for issue #275 retests
+// where the closest miss keeps pegging at the ±6 boundary.
+func TestControlChannelLocksThroughWiderPostFSWSlip(t *testing.T) {
+	const slip = 10
+	base := buildLockedStream(10, 0x293, DUIDTrunkingSignaling, OpRFSSStatusBroadcast)
+	slipped := make([]uint8, 0, len(base)+slip)
+	slipped = append(slipped, base[:34]...)
+	for i := 0; i < slip; i++ {
+		slipped = append(slipped, 0)
+	}
+	slipped = append(slipped, base[34:]...)
+
+	// Default span must NOT lock — guards that the test fixture's
+	// slip really does exceed the production grid (and so the wider
+	// span below is the cause of the recovery, not noise).
+	{
+		bus := events.NewBus(8)
+		sub := bus.Subscribe()
+		cc := New(Options{Bus: bus, FrequencyHz: 851_000_000})
+		cc.Process(slipped, 0)
+		select {
+		case ev := <-sub.C:
+			if ev.Kind == events.KindCCLocked {
+				t.Fatalf("default span locked at slip=%d — fixture no longer exercises >±%d offsets", slip, NIDSearchSpan)
+			}
+		case <-time.After(100 * time.Millisecond):
+			// no lock expected — pass
+		}
+		sub.Close()
+		bus.Close()
+	}
+
+	// Wider span MUST lock — proves the per-instance override drives
+	// the grid bounds in searchNID.
+	bus := events.NewBus(8)
+	sub := bus.Subscribe()
+	cc := New(Options{Bus: bus, FrequencyHz: 851_000_000, NIDSearchSpan: 12})
+	cc.Process(slipped, 0)
+	select {
+	case ev := <-sub.C:
+		if ev.Kind != events.KindCCLocked {
+			t.Errorf("kind = %s, want cc.locked", ev.Kind)
+		} else if ls := ev.Payload.(LockState); ls.NAC != 0x293 {
+			t.Errorf("NAC = %#x, want 0x293", ls.NAC)
+		}
+	case <-time.After(time.Second):
+		t.Errorf("no lock at slip=%d under NIDSearchSpan=12 — per-instance span did not widen the grid", slip)
+	}
+	sub.Close()
+	bus.Close()
+}
+
 // TestSearchBoundaryHelpers locks down the boundary-pegged diag the
 // next #275 field retest will hinge on. The two helpers — atSearchBoundary
 // and boundaryNote — together turn the failure diag (and the success
@@ -614,11 +671,11 @@ func TestSearchBoundaryHelpers(t *testing.T) {
 		{NIDSearchSpan + 1, false}, // outside the grid; not "at" boundary
 	}
 	for _, tc := range cases {
-		got := atSearchBoundary(tc.delta)
+		got := atSearchBoundary(tc.delta, NIDSearchSpan)
 		if got != tc.atBoundary {
 			t.Errorf("atSearchBoundary(%d) = %v, want %v", tc.delta, got, tc.atBoundary)
 		}
-		note := boundaryNote(tc.delta)
+		note := boundaryNote(tc.delta, NIDSearchSpan)
 		if tc.atBoundary {
 			if !strings.Contains(note, "search boundary") {
 				t.Errorf("boundaryNote(%d) = %q, want contains \"search boundary\"", tc.delta, note)
@@ -626,6 +683,27 @@ func TestSearchBoundaryHelpers(t *testing.T) {
 		} else if note != "" {
 			t.Errorf("boundaryNote(%d) = %q, want empty", tc.delta, note)
 		}
+	}
+}
+
+// TestSearchBoundaryHelpersHonorPerInstanceSpan exercises the bisect
+// knob #275's diagnostic-widening commit added: a ControlChannel
+// constructed with Options.NIDSearchSpan=12 must report delta=±12 (not
+// ±6) as the boundary, and emit the matching note. Without this guard a
+// refactor could silently revert the helpers to the package constant
+// and quietly invalidate every wider-span replay run.
+func TestSearchBoundaryHelpersHonorPerInstanceSpan(t *testing.T) {
+	const wider = 12
+	if atSearchBoundary(NIDSearchSpan, wider) {
+		t.Errorf("atSearchBoundary(%d, %d) = true, want false (only ±%d is boundary)",
+			NIDSearchSpan, wider, wider)
+	}
+	if !atSearchBoundary(wider, wider) {
+		t.Errorf("atSearchBoundary(%d, %d) = false, want true", wider, wider)
+	}
+	note := boundaryNote(wider, wider)
+	if !strings.Contains(note, "±12") {
+		t.Errorf("boundaryNote(%d, %d) = %q, want contains \"±12\"", wider, wider, note)
 	}
 }
 


### PR DESCRIPTION
Adds Options.NIDSearchSpan and a -nid-search-span replay flag so an
operator can re-run a stubborn capture at ±12 / ±18 / ±36 without
rebuilding. The production ccdecoder pipeline is unchanged (zero in
Options falls back to the NIDSearchSpan constant). On the latest #275
retest the closest miss kept pegging at the new ±6 boundary on a
30-second Mt Anakie capture; widening the grid distinguishes a
span-bounded failure (errs drop at a new optimum) from a
demod-quality-bounded one (errs stay near the BCH ceiling regardless
of alignment), which is the bisect the next round of investigation
needs.

atSearchBoundary / boundaryNote now take the active span as a
parameter so the "at search boundary" diagnostic surfaces the right
edge under a wider grid. Two new tests cover the contract: one shows
the per-instance override actually drives searchNID's grid bounds
(slip=10 locks under span=12 and stays unlocked under the default
span=6); one shows the boundary helpers honor the per-instance value.

https://claude.ai/code/session_01BbEg4DKpBNuT8QWkgzyAgV