### PR TITLE
p25/phase1: fix C4FM slicer collapse with symbol-AGC (#275)

### DIFF
--- a/cmd/gophertrunk/iqdiag.go
+++ b/cmd/gophertrunk/iqdiag.go
@@ -1,0 +1,329 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"sort"
+
+	p25phase1 "github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase1"
+)
+
+// iqDiag accumulates the full dibit stream a replay produced and prints
+// a structured demod-quality report at EOF — built for issue #275
+// Phase B, where Phase A's NID-search widening (e60d3c5) ruled
+// alignment out as the dominant failure mode on the Mt Anakie capture.
+// The report surfaces what the existing nid-failure diag cannot:
+//
+//   - dibit-value histogram: a clean C4FM stream slices ~25% into each
+//     of {0,1,2,3}; a strong skew tells the slicer thresholds are
+//     mis-calibrated, an empty bin tells the slicer is collapsed.
+//
+//   - FSW-correlation histogram per rotation: for every dibit position
+//     in the buffer, count the best Hamming distance to the 24-dibit
+//     FrameSyncWord under each of the 4 cyclic rotations. The shape
+//     tells whether the demod produces canonical dibits at all:
+//     - tight low-mismatch peak under rot=0 ≈ clean C4FM
+//     - peak under rot=2 only ≈ inverted discriminator polarity
+//     - peak under rot=1 or rot=3 ≈ I/Q swap or 90° clock-recovery slip
+//       (non-physical on a C4FM stream — strong evidence of a bug)
+//     - no peak under any rotation ≈ SNR / demod-quality limited
+//
+//   - hit count per rotation: how many positions had a best-mismatch ≤
+//     tolerance under each rotation. Asymmetry across rotations is the
+//     same evidence as the peak shape but quantified.
+//
+// Designed to add nothing to the hot path: only allocates and runs
+// when -diag is set.
+type iqDiag struct {
+	dibits []uint8
+	// soft samples (pre-slicer matched-filter output) accumulated
+	// from receiver.Options.SoftSink. Used to surface the slicer's
+	// decision-region behaviour: if the matched-filter centres land
+	// far outside the slicer's threshold, every sample collapses
+	// to ±3 and the dibit histogram skews to {1, 3} only.
+	soft []float32
+}
+
+// observe appends a chunk of dibits to the rolling buffer the EOF
+// report walks. Called from the DibitSink in replay.go when -diag
+// is set.
+func (d *iqDiag) observe(dibits []uint8) {
+	d.dibits = append(d.dibits, dibits...)
+}
+
+// observeSoft appends pre-slicer per-symbol soft samples to the
+// rolling soft buffer.
+func (d *iqDiag) observeSoft(soft []float32) {
+	d.soft = append(d.soft, soft...)
+}
+
+// printReport walks the accumulated dibit stream and emits the full
+// demod-quality report to w. Idempotent.
+func (d *iqDiag) printReport(w io.Writer) {
+	if len(d.dibits) == 0 {
+		fmt.Fprintln(w, "diag: no dibits emitted — receiver produced nothing")
+		return
+	}
+
+	fmt.Fprintln(w, "---- diag ----")
+	fmt.Fprintf(w, "diag: %d dibits buffered\n", len(d.dibits))
+
+	// Pre-slicer soft-sample distribution (C4FM path: matched-filter
+	// output at symbol times, in rad/sample). For a clean P25 Phase 1
+	// signal at 1800 Hz peak deviation, outer centres sit at
+	// ±2π·1800/SampleRateHz and inner at ±(1/3) of that, with the
+	// slicer threshold at ±(2/3)·outer. If outer-bin counts ≫
+	// inner-bin counts, the matched-filter output is bigger than the
+	// slicer expects and inner symbols are being misclassified as
+	// outer (issue #275 Phase B).
+	if len(d.soft) > 0 {
+		var sumAbs, maxAbs float64
+		var negPosInner, negPosOuter, signZero int
+		for _, s := range d.soft {
+			a := float64(s)
+			if a < 0 {
+				a = -a
+			}
+			sumAbs += a
+			if a > maxAbs {
+				maxAbs = a
+			}
+			if s == 0 {
+				signZero++
+			}
+			// Bin into rough quartiles around the abs-mean to spot
+			// inner-vs-outer balance.
+			_, _ = negPosInner, negPosOuter
+		}
+		meanAbs := sumAbs / float64(len(d.soft))
+		// Threshold at the inner-vs-outer slicer boundary the C4FM
+		// stage uses (2/3 of the deviation calibration). Without
+		// access to the receiver's deviation here we use meanAbs as
+		// a proxy mid-point — most useful as a relative comparison.
+		var nInner, nOuter int
+		for _, s := range d.soft {
+			a := float64(s)
+			if a < 0 {
+				a = -a
+			}
+			if a < meanAbs {
+				nInner++
+			} else {
+				nOuter++
+			}
+		}
+		fmt.Fprintf(w, "diag: pre-slicer soft samples: n=%d  mean|x|=%.6f  max|x|=%.6f  <mean|x|: %d (%.1f%%)  ≥mean|x|: %d (%.1f%%)\n",
+			len(d.soft), meanAbs, maxAbs,
+			nInner, 100*float64(nInner)/float64(len(d.soft)),
+			nOuter, 100*float64(nOuter)/float64(len(d.soft)))
+
+		// Coarse histogram of soft sample magnitudes in deciles
+		// of maxAbs — surfaces whether the distribution is bimodal
+		// (clean 4-level eye: two peaks near ±inner and ±outer
+		// centres) or unimodal saturated (everything piled near
+		// ±max).
+		const bins = 10
+		var mhist [bins]int
+		for _, s := range d.soft {
+			a := float64(s)
+			if a < 0 {
+				a = -a
+			}
+			b := int(a / maxAbs * float64(bins))
+			if b >= bins {
+				b = bins - 1
+			}
+			mhist[b]++
+		}
+		fmt.Fprintln(w, "diag: |soft| magnitude histogram (10 bins of max|x|):")
+		for b := 0; b < bins; b++ {
+			fmt.Fprintf(w, "diag:   [%.3f,%.3f): %7d  (%5.2f%%)\n",
+				float64(b)/bins*maxAbs, float64(b+1)/bins*maxAbs,
+				mhist[b], 100*float64(mhist[b])/float64(len(d.soft)))
+		}
+	}
+
+	// Dibit value histogram — should be ~25% per bin on a clean C4FM
+	// control channel carrying TSDU traffic. A bin near zero says the
+	// 4-level slicer collapsed; a single dominant bin says the signal
+	// is below the slicer thresholds and everything quantizes to one
+	// symbol.
+	var hist [4]int
+	for _, db := range d.dibits {
+		hist[db&3]++
+	}
+	fmt.Fprintln(w, "diag: dibit value histogram (expect ~25% per bin on clean C4FM):")
+	total := float64(len(d.dibits))
+	for v := 0; v < 4; v++ {
+		fmt.Fprintf(w, "diag:   %d: %7d  (%5.2f%%)\n", v, hist[v], 100*float64(hist[v])/total)
+	}
+
+	// FSW correlation landscape per rotation. At every dibit position,
+	// compute the Hamming distance from the next 24 dibits to the
+	// canonical FrameSyncWord under each cyclic rotation, and
+	// histogram the best distance per rotation. The shape of the
+	// distribution at low distances tells whether the demod produces
+	// canonical dibits and which rotation aligns the stream.
+	type rotStats struct {
+		hist     [25]int // distance 0..24
+		hits     int     // positions with mismatch ≤ tolerance
+		bestDist int     // global minimum across all positions
+		bestPos  int
+	}
+	const fswLen = 24
+	const tolerance = 4
+	var stats [4]rotStats
+	for i := range stats {
+		stats[i].bestDist = fswLen + 1
+	}
+	if len(d.dibits) >= fswLen {
+		for pos := 0; pos+fswLen <= len(d.dibits); pos++ {
+			for rot := uint8(0); rot < 4; rot++ {
+				mismatch := 0
+				for kk := 0; kk < fswLen; kk++ {
+					if ((d.dibits[pos+kk] + rot) & 3) != p25phase1.FrameSyncWord[kk] {
+						mismatch++
+					}
+				}
+				stats[rot].hist[mismatch]++
+				if mismatch <= tolerance {
+					stats[rot].hits++
+				}
+				if mismatch < stats[rot].bestDist {
+					stats[rot].bestDist = mismatch
+					stats[rot].bestPos = pos
+				}
+			}
+		}
+	}
+
+	fmt.Fprintln(w, "diag: FSW correlation per rotation (Hamming distance histogram, tolerance=4):")
+	fmt.Fprintln(w, "diag:   rot  best_dist  hits≤4   dist=0..6 counts")
+	for rot := 0; rot < 4; rot++ {
+		s := stats[rot]
+		fmt.Fprintf(w, "diag:   %d    %3d (@pos %d)  %6d   %d/%d/%d/%d/%d/%d/%d\n",
+			rot, s.bestDist, s.bestPos, s.hits,
+			s.hist[0], s.hist[1], s.hist[2], s.hist[3], s.hist[4], s.hist[5], s.hist[6])
+	}
+
+	// Pick the rotation with the most low-distance hits as the
+	// "winning" rotation, and show the first few hit positions so the
+	// reader can spot whether they cluster at regular frame intervals
+	// (good) or are scattered (likely false positives).
+	winner := 0
+	for rot := 1; rot < 4; rot++ {
+		if stats[rot].hits > stats[winner].hits {
+			winner = rot
+		}
+	}
+	fmt.Fprintf(w, "diag: winning rotation = %d (%d hits ≤ tolerance)\n", winner, stats[winner].hits)
+	if stats[winner].hits > 0 {
+		positions := make([]int, 0, stats[winner].hits)
+		for pos := 0; pos+fswLen <= len(d.dibits); pos++ {
+			mismatch := 0
+			for kk := 0; kk < fswLen; kk++ {
+				if ((d.dibits[pos+kk]+uint8(winner))&3) != p25phase1.FrameSyncWord[kk] {
+					mismatch++
+				}
+			}
+			if mismatch <= tolerance {
+				positions = append(positions, pos)
+			}
+		}
+		// Inter-hit deltas: a real control channel emits FSWs at
+		// frame intervals (~163 on-air dibits including status
+		// symbols for a TSBK frame, ~864 + status for an LDU). A
+		// modal delta of one of those values says we're detecting
+		// real frames; broadly scattered deltas say most hits are
+		// false positives.
+		var deltas []int
+		for i := 1; i < len(positions); i++ {
+			deltas = append(deltas, positions[i]-positions[i-1])
+		}
+		sort.Ints(deltas)
+		fmt.Fprintf(w, "diag: first %d hit positions (rot=%d):", min(8, len(positions)), winner)
+		for i := 0; i < min(8, len(positions)); i++ {
+			fmt.Fprintf(w, " %d", positions[i])
+		}
+		fmt.Fprintln(w)
+		if len(deltas) > 0 {
+			modal := modalInt(deltas)
+			fmt.Fprintf(w, "diag: inter-hit dibit-deltas: min=%d  median=%d  max=%d  modal=%d  (P25 TSBK frame ≈ 163 on-air dibits, LDU ≈ 864)\n",
+				deltas[0], deltas[len(deltas)/2], deltas[len(deltas)-1], modal)
+		}
+
+		// For each of the first few perfect-distance FSW hits, dump
+		// the FSW + next 32 dibits raw AND run them through the
+		// real BCH NID decoder under both strip modes. If any
+		// decode, the issue is signal-quality (some NIDs corrupt,
+		// some clean); if none decode despite perfect FSW
+		// alignment, framing (status-symbol offset, dibit-bit
+		// ordering) is broken.
+		printed := 0
+		for _, pos := range positions {
+			if printed >= 5 {
+				break
+			}
+			mismatch := 0
+			for kk := 0; kk < fswLen; kk++ {
+				if ((d.dibits[pos+kk]+uint8(winner))&3) != p25phase1.FrameSyncWord[kk] {
+					mismatch++
+				}
+			}
+			if mismatch != 0 || pos+fswLen+33 > len(d.dibits) {
+				continue
+			}
+			printed++
+			fmt.Fprintf(w, "diag: FSW@%d (dist=0, rot=%d) — payload[0..31] then BCH:\n", pos, winner)
+			rawNID := make([]uint8, 33) // 32 NID + 1 for strip variant
+			for j := 0; j < 33; j++ {
+				rawNID[j] = (d.dibits[pos+fswLen+j] + uint8(winner)) & 3
+			}
+			fmt.Fprint(w, "diag:   raw  ")
+			for j := 0; j < 32; j++ {
+				fmt.Fprintf(w, "%d", rawNID[j])
+				if (j+1)%4 == 0 {
+					fmt.Fprint(w, " ")
+				}
+			}
+			fmt.Fprintln(w)
+			// Strip=false: take payload[0..31] directly
+			n0, e0, _, err0 := p25phase1.NIDFromDibitsWithErrors(rawNID[:32])
+			// Strip=true: skip payload[11] (the spec status-symbol position
+			// when FSW is at frame_pos 0..23 and status falls at 35)
+			stripped := make([]uint8, 0, 32)
+			stripped = append(stripped, rawNID[:11]...)
+			stripped = append(stripped, rawNID[12:33]...)
+			n1, e1, _, err1 := p25phase1.NIDFromDibitsWithErrors(stripped)
+			fmt.Fprintf(w, "diag:   strip=false: errs=%d nac=%#x duid=%d err=%v\n", e0, n0.NAC, n0.DUID, err0)
+			fmt.Fprintf(w, "diag:   strip=true:  errs=%d nac=%#x duid=%d err=%v\n", e1, n1.NAC, n1.DUID, err1)
+		}
+	}
+}
+
+// modalInt returns the most-frequent value in a sorted int slice. Ties
+// resolve to the smaller value.
+func modalInt(sorted []int) int {
+	if len(sorted) == 0 {
+		return 0
+	}
+	bestVal := sorted[0]
+	bestCount := 1
+	curVal := sorted[0]
+	curCount := 1
+	for i := 1; i < len(sorted); i++ {
+		if sorted[i] == curVal {
+			curCount++
+		} else {
+			if curCount > bestCount {
+				bestVal, bestCount = curVal, curCount
+			}
+			curVal, curCount = sorted[i], 1
+		}
+	}
+	if curCount > bestCount {
+		bestVal = curVal
+	}
+	return bestVal
+}
+

--- a/cmd/gophertrunk/iqdiag.go
+++ b/cmd/gophertrunk/iqdiag.go
@@ -22,11 +22,15 @@ import (
 //     in the buffer, count the best Hamming distance to the 24-dibit
 //     FrameSyncWord under each of the 4 cyclic rotations. The shape
 //     tells whether the demod produces canonical dibits at all:
-//     - tight low-mismatch peak under rot=0 ≈ clean C4FM
-//     - peak under rot=2 only ≈ inverted discriminator polarity
-//     - peak under rot=1 or rot=3 ≈ I/Q swap or 90° clock-recovery slip
-//       (non-physical on a C4FM stream — strong evidence of a bug)
-//     - no peak under any rotation ≈ SNR / demod-quality limited
+//
+//   - tight low-mismatch peak under rot=0 ≈ clean C4FM
+//
+//   - peak under rot=2 only ≈ inverted discriminator polarity
+//
+//   - peak under rot=1 or rot=3 ≈ I/Q swap or 90° clock-recovery slip
+//     (non-physical on a C4FM stream — strong evidence of a bug)
+//
+//   - no peak under any rotation ≈ SNR / demod-quality limited
 //
 //   - hit count per rotation: how many positions had a best-mismatch ≤
 //     tolerance under each rotation. Asymmetry across rotations is the
@@ -222,7 +226,7 @@ func (d *iqDiag) printReport(w io.Writer) {
 		for pos := 0; pos+fswLen <= len(d.dibits); pos++ {
 			mismatch := 0
 			for kk := 0; kk < fswLen; kk++ {
-				if ((d.dibits[pos+kk]+uint8(winner))&3) != p25phase1.FrameSyncWord[kk] {
+				if ((d.dibits[pos+kk] + uint8(winner)) & 3) != p25phase1.FrameSyncWord[kk] {
 					mismatch++
 				}
 			}
@@ -266,7 +270,7 @@ func (d *iqDiag) printReport(w io.Writer) {
 			}
 			mismatch := 0
 			for kk := 0; kk < fswLen; kk++ {
-				if ((d.dibits[pos+kk]+uint8(winner))&3) != p25phase1.FrameSyncWord[kk] {
+				if ((d.dibits[pos+kk] + uint8(winner)) & 3) != p25phase1.FrameSyncWord[kk] {
 					mismatch++
 				}
 			}
@@ -326,4 +330,3 @@ func modalInt(sorted []int) int {
 	}
 	return bestVal
 }
-

--- a/cmd/gophertrunk/replay.go
+++ b/cmd/gophertrunk/replay.go
@@ -54,6 +54,12 @@ func runReplay(args []string) {
 	// tiers (BCH+parity + TSBK CRC) reject wrong alignments at any
 	// span, so widening cannot manufacture a false lock.
 	nidSearchSpan := fs.Int("nid-search-span", p25phase1.NIDSearchSpan, "NID-alignment search radius in dibits (default matches the production ccdecoder; widen to bisect a stubborn capture per issue #275)")
+	// Issue #275 Phase B knob — after Phase A's widening ruled out
+	// alignment, this surfaces what the NID-failure diag cannot: the
+	// dibit-value histogram and the per-rotation FSW-correlation
+	// landscape across the whole capture. Off by default since it
+	// allocates an O(numDibits) buffer.
+	diag := fs.Bool("diag", false, "print a demod-quality diagnostic report (dibit histogram + per-rotation FSW correlation landscape) at EOF")
 	fs.Usage = func() {
 		fmt.Fprintln(fs.Output(), `gophertrunk replay — decode a raw IQ capture file offline.
 
@@ -137,15 +143,26 @@ FLAGS:`)
 		*demod, rotations, *nidSearchSpan, p25phase1.NIDAcceptErrs, p25phase1.NIDMarginalMaxErrs)
 
 	var dibitCount int64
-	rx := p25phase1rx.New(p25phase1rx.Options{
+	var diagAcc *iqDiag
+	if *diag {
+		diagAcc = &iqDiag{}
+	}
+	rxOpts := p25phase1rx.Options{
 		SampleRateHz: *sampleRate,
 		DeviationHz:  1800.0,
 		DemodMode:    demodMode,
 		DibitSink: func(dibits []uint8, baseIdx int) {
 			dibitCount += int64(len(dibits))
+			if diagAcc != nil {
+				diagAcc.observe(dibits)
+			}
 			cc.Process(dibits, baseIdx)
 		},
-	})
+	}
+	if diagAcc != nil {
+		rxOpts.SoftSink = diagAcc.observeSoft
+	}
+	rx := p25phase1rx.New(rxOpts)
 
 	// Drain bus events to stdout in the background so they print
 	// interleaved with the decoder log going to stderr.
@@ -192,6 +209,9 @@ FLAGS:`)
 	<-doneEvents
 
 	printSummary(filepath.Base(*in), totalSamples, *sampleRate, dibitCount, stats)
+	if diagAcc != nil {
+		diagAcc.printReport(os.Stdout)
+	}
 }
 
 // replayStats accumulates bus events seen during the replay so the

--- a/internal/radio/p25/phase1/receiver/receiver.go
+++ b/internal/radio/p25/phase1/receiver/receiver.go
@@ -127,6 +127,17 @@ type Options struct {
 	// CQPSK path. <=0 uses defaultGardnerGain. Ignored when
 	// DemodMode == DemodC4FM (the C4FM path uses Mueller-Müller).
 	GardnerGain float64
+	// SoftSink, when non-nil, receives the per-symbol soft samples
+	// produced by the matched filter + symbol-clock recovery, just
+	// before slicing. The C4FM path emits the FM-discriminator +
+	// matched-filtered + MM-clock-recovered samples (rad/sample,
+	// typically ±2π·DeviationHz/SampleRateHz at the outer-symbol
+	// centres). The CQPSK path emits the real part of the rotated
+	// DQPSK quadrant decision per symbol. Nil by default — meant for
+	// offline diagnostics (issue #275: surfacing the matched-filter
+	// output level distribution when the slicer collapses to outer
+	// symbols only).
+	SoftSink func(softSamples []float32)
 }
 
 // Receiver is the composed IQ → dibit → LDU pipeline. Process is the
@@ -135,12 +146,14 @@ type Receiver struct {
 	demodMode DemodMode
 
 	// C4FM path: FM discriminator → real RRC matched filter →
-	// coarse-AFC carrier-offset removal → Mueller-Müller → 4-level
-	// slicer. Allocated only when demodMode == DemodC4FM.
+	// coarse-AFC carrier-offset removal → Mueller-Müller →
+	// symbol-AGC → 4-level slicer. Allocated only when demodMode ==
+	// DemodC4FM.
 	fm    *demod.FM
 	mf    *demod.C4FM
 	afc   *demod.CoarseAFC
 	clock *sync.MuellerMuller
+	agc   c4fmSymbolAGC
 
 	// CQPSK / LSM path: complex RRC + Gardner + DQPSK quadrant
 	// decode + LSM dibit remap. Allocated only when demodMode ==
@@ -149,6 +162,7 @@ type Receiver struct {
 
 	assembler *phase1.LDUAssembler
 	dibitSink phase1.DibitSink
+	softSink  func([]float32)
 	dibitBase int
 
 	// Reusable scratch slices so Process doesn't allocate per call
@@ -202,6 +216,7 @@ func New(opts Options) *Receiver {
 	r := &Receiver{
 		demodMode: opts.DemodMode,
 		dibitSink: opts.DibitSink,
+		softSink:  opts.SoftSink,
 	}
 	switch opts.DemodMode {
 	case DemodCQPSK:
@@ -215,6 +230,33 @@ func New(opts Options) *Receiver {
 		r.mf = demod.NewC4FMP25(opts.SampleRateHz, slicerScale)
 		r.afc = demod.NewCoarseAFC(sps)
 		r.clock = sync.NewMuellerMuller(sps, gain)
+		// Symbol-AGC bridges the level mismatch between the spec-
+		// faithful matched filter on a real P25 transmission and the
+		// 4-level slicer's fixed thresholds: on real RTL-SDR captures
+		// the matched-filter outer-symbol centres land at
+		// sps × 2π·deviation/sampleRate radians (the filter has a
+		// DC gain of sps so it integrates a full symbol's
+		// FM-discriminator output), which is ~sps× larger than the
+		// slicerScale the synthetic-modulator harness produces.
+		// Without AGC, every real sample exceeds the slicer
+		// threshold and the 4-level slicer collapses to ±3 only —
+		// the dibit stream becomes {1, 3} only, NIDs fail BCH at
+		// errs=10..11 regardless of alignment, and the control
+		// channel never locks (issue #275 Phase B). The AGC
+		// normalises the running mean|x| to the slicer's expected
+		// threshold (slicerScale × 2/3 — what mean|x| equals on a
+		// balanced inner/outer stream), so the slicer behaves
+		// correctly across the full range of real and synthetic
+		// signal levels. Time constant is ~256 symbols so the loop
+		// rides out short bursts of skewed content (a long FSW
+		// preamble is all-outer; an idle TDU run leans inner) but
+		// follows real signal-level changes (channel fades, AGC
+		// settling on the front-end) within a frame's worth of
+		// symbols.
+		r.agc = c4fmSymbolAGC{
+			target: float32(slicerScale * 2.0 / 3.0),
+			rate:   1.0 / 256.0,
+		}
 	}
 	if opts.Sink != nil {
 		r.assembler = phase1.NewLDUAssembler(opts.Sink, opts.Tolerance)
@@ -247,6 +289,10 @@ func (r *Receiver) Process(iq []complex64) {
 		r.symbols = r.clock.Process(r.symbols, r.matched)
 		if len(r.symbols) == 0 {
 			return
+		}
+		r.agc.process(r.symbols)
+		if r.softSink != nil {
+			r.softSink(r.symbols)
 		}
 		r.sliced = r.mf.SliceMany(r.sliced, r.symbols)
 		if cap(r.dibits) < len(r.sliced) {
@@ -286,7 +332,65 @@ func (r *Receiver) Reset() {
 	if r.afc != nil {
 		r.afc.Reset()
 	}
+	r.agc.reset()
 	// FM discriminator's `last` is harmless to leave alone — the
 	// next sample it processes will produce one slightly-wrong
 	// derivative, which the matched filter smooths out.
+}
+
+// c4fmSymbolAGC tracks a running estimate of mean|x| over the
+// per-symbol matched-filter output and scales each symbol so the
+// estimate matches a target reference. The C4FM slicer's fixed
+// thresholds are designed against a specific signal level; the AGC
+// reconciles that with whatever level the upstream filter actually
+// produces (issue #275 Phase B).
+//
+// State is a single EMA scalar — the loop is feed-forward (each
+// output is the input scaled by the current estimate), so an
+// occasional near-zero sample cannot drive the gain unbounded the
+// way a feedback loop would.
+type c4fmSymbolAGC struct {
+	target float32 // desired mean|x| in the output stream
+	rate   float32 // single-pole EMA coefficient (rate-of-tracking)
+	level  float32 // current mean|x| estimate of the input
+	seeded bool
+}
+
+// process scales symbols in place so the running mean|x| matches
+// target. Seeds the EMA from the first non-trivial sample's |x| (not
+// the first batch's mean) so the recovered stream is byte-identical
+// regardless of how the IQ is chunked — the chunk-boundary
+// determinism the Mueller-Müller fix already guarantees on the
+// clock side (TestHarnessC4FMChunkBoundary, issue #275).
+func (a *c4fmSymbolAGC) process(symbols []float32) {
+	if a.target <= 0 {
+		return // calibration disabled (legacy DeviationHz=0 path)
+	}
+	for i, x := range symbols {
+		ax := x
+		if ax < 0 {
+			ax = -ax
+		}
+		if !a.seeded {
+			if ax > 1e-12 {
+				a.level = ax
+				a.seeded = true
+			} else {
+				continue
+			}
+		} else {
+			a.level += a.rate * (ax - a.level)
+		}
+		if a.level > 1e-12 {
+			g := a.target / a.level
+			symbols[i] = x * g
+		}
+	}
+}
+
+// reset clears the level estimate so a stream re-sync starts from a
+// fresh seed.
+func (a *c4fmSymbolAGC) reset() {
+	a.level = 0
+	a.seeded = false
 }

--- a/internal/radio/p25/phase1/receiver/receiver_test.go
+++ b/internal/radio/p25/phase1/receiver/receiver_test.go
@@ -3,6 +3,8 @@ package receiver
 import (
 	"math"
 	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/demod"
 )
 
 // TestReceiverConstructsAndProcessesSilence is a smoke test: make
@@ -261,4 +263,76 @@ func TestReceiverConstructorRequiresAtLeastOneSink(t *testing.T) {
 		}
 	}()
 	_ = New(Options{SampleRateHz: 48_000})
+}
+
+// TestC4FMSymbolAGCRescuesCollapsedSlicer guards the Phase B fix for
+// issue #275. Before the symbol-AGC, a real RTL-SDR capture's
+// matched-filter output landed ~sps× above the 4-level slicer's fixed
+// threshold (P25C4FMRxTaps has a DC gain of sps, the slicer is
+// calibrated to 2π·deviation/sampleRate), so every sample sliced to
+// the outer rails and the dibit stream became {1, 3} only — no NID
+// ever decoded even though the FSW correlated perfectly (the FSW is
+// all-outer, so a collapsed slicer still recovers it).
+//
+// The AGC normalises the running mean|x| to the slicer's expected
+// threshold, restoring the 4-level eye on any input level. This test
+// drives the receiver with a synthetic stream scaled to a level where
+// the un-AGC'd slicer would collapse to outers, then asserts the
+// recovered dibit histogram is roughly balanced (~25% per bin, not
+// 50/0/50/0). The exact balance depends on the synthetic dibit
+// distribution, so the assertion is a sanity bound rather than an
+// exact ratio.
+func TestC4FMSymbolAGCRescuesCollapsedSlicer(t *testing.T) {
+	// Build a balanced random dibit stream and modulate with the
+	// spec P25 transmitter at 960 kHz (sps=200) — the same
+	// parameters the Mt Anakie capture used. At this sample rate
+	// the matched filter's DC-gain-sps normalisation puts the
+	// matched-filter outer-symbol centres at sps× the slicerScale
+	// the un-AGC'd code computes, so the slicer would collapse to
+	// {1, 3} without AGC.
+	const (
+		sr  = 960_000.0
+		dev = 1800.0
+		n   = 8000
+	)
+	dibits := make([]uint8, n)
+	for i := range dibits {
+		dibits[i] = uint8((i*7 + 3) & 3)
+	}
+	iq := demod.ModulateP25C4FM(dibits, sr, dev)
+	// Scale the IQ up so the matched-filter output dwarfs the
+	// pre-AGC slicer threshold (mimicking the Mt Anakie capture
+	// where mean|MF output| was ~150× the calibrated slicerScale).
+	for i := range iq {
+		iq[i] *= 100
+	}
+
+	var hist [4]int
+	r := New(Options{
+		SampleRateHz: sr,
+		DeviationHz:  dev,
+		DibitSink: func(d []uint8, _ int) {
+			for _, v := range d {
+				hist[v&3]++
+			}
+		},
+	})
+	r.Process(iq)
+
+	total := hist[0] + hist[1] + hist[2] + hist[3]
+	if total == 0 {
+		t.Fatalf("receiver emitted no dibits")
+	}
+	// All four bins should carry meaningful mass — at least 10% of
+	// total each — proving the slicer didn't collapse to outers
+	// only. The exact ratio depends on the synthetic dibit stream,
+	// so 10% is a loose-but-decisive bound (a collapsed slicer
+	// yields ~50/0/50/0; a working one ~25/25/25/25).
+	for v := 0; v < 4; v++ {
+		pct := 100 * float64(hist[v]) / float64(total)
+		if pct < 10 {
+			t.Errorf("dibit value %d at %.1f%% (%d/%d) — slicer collapsed to outers (issue #275 Phase B regression)",
+				v, pct, hist[v], total)
+		}
+	}
 }


### PR DESCRIPTION
## Summary

- Phase B of issue #275. Phase A (`#334`) widened the NID-alignment grid and ruled alignment out as the dominant failure on the Mt Anakie capture — `-nid-search-span 36` still produces 253 NID-BCH failures with closest-miss errs flat at 9-11 across the entire ±36 range. That confirmed the failure is demod-quality bounded, not alignment bounded.
- Root cause this PR addresses: `P25C4FMRxTaps` is normalized to a DC gain of `sps`, so the matched filter integrates one symbol's worth of FM-discriminator output. On real RTL-SDR captures that puts the outer-symbol centres at `sps × 2π·deviation/sampleRate` radians — roughly `sps×` larger than the slicer's calibrated threshold. Every sample exceeds the 4-level slicer's outer threshold and the dibit stream collapses to `{1, 3}` only. Smoking gun on the Mt Anakie IQ: dibit histogram was **50/0/50/0**. FSWs still correlated (the FSW pattern uses only outer symbols), but every NID failed BCH regardless of alignment.
- The synthetic-modulator harness happens to land at the calibrated `slicerScale` because its impulse-train shaping produces matched-filter output one impulse-area-worth — not one symbol-DC-worth — large, which is why the existing tests passed against the mismatch.
- Fix: a symbol-domain AGC between Mueller-Müller clock recovery and the slicer that normalises the running `mean|x|` to the slicer's expected threshold (`slicerScale × 2/3` — the `mean|x|` of a balanced inner/outer stream). On the Mt Anakie capture the dibit histogram recovers to **28/22/27/23** (vs the expected ~25 each), the 4-level eye opens, and closest-miss errs drops from 11 → 8-9 with the wider span.
- Determinism: seeded from the first non-trivial per-sample `|x|`, not from the first batch's mean, so the recovered dibit stream is byte-identical regardless of IQ chunking. Guards `TestHarnessC4FMChunkBoundary`.

## Also lands here

- `receiver.Options.SoftSink` — optional pre-slicer per-symbol soft tap, for diagnostics like the iq-diag tool below.
- `cmd/gophertrunk replay -diag` — dibit-value histogram, pre-slicer soft-sample distribution, per-rotation FSW correlation landscape, and BCH decode attempts at the first few perfect-FSW positions. This is the off-path diagnostic that pinpointed the slicer collapse on Mt Anakie and would surface the same class of bug on the next stubborn IQ capture without a code excursion.

## Remaining gap (not addressed here)

Even with the AGC fix the NID still doesn't BCH-decode on Mt Anakie: closest-miss `errs=8..9` is over the trusted `NIDAcceptErrs=6` gate, and the TSBK CRC doesn't corroborate any of the marginal hypotheses. The 5 sampled NIDs at distance-0 FSWs are byte-identical across frames (consistent with a fixed NAC+DUID), but not a valid BCH codeword under any dibit-bit ordering tried. Likely next investigations: matched-filter shape (the spec sinc-receive may not match real Mt Anakie transmitters), MM clock recovery gain, or AFC residual.

## Test plan

- [x] `go test ./...` — 77 packages green, 0 failures
- [x] `go test ./internal/radio/p25/phase1/receiver/... -count=1` — receiver tests including `TestHarnessC4FMChunkBoundary` pass (chunk-boundary determinism preserved)
- [x] `gophertrunk replay -in mt-anakie-420087500-960k-g49.iq -sample-rate 960000 -freq 420087500 -demod c4fm` — reproduces 253 NID-BCH failures on `main`; with this PR the dibit histogram and closest-miss errs both improve
- [x] `gophertrunk replay ... -diag` — surfaces histogram + soft-sample + FSW-correlation diagnostics
- [ ] On-air smoke against a known-good C4FM site to confirm the AGC doesn't regress sites that already locked under the broken slicer (the synthetic harness only stresses the impulse-train case)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BbEg4DKpBNuT8QWkgzyAgV)_