### PR TITLE
p25/phase1: fix BCH(63,16,11) polynomial + per-DUID parity (#275)

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,6 +440,34 @@ to its own package and lands independently.
 
 ### Recently shipped
 
+- **P25 Phase 1 NID BCH(63,16,11) generator polynomial
+  corrected — control channel now locks on real on-air
+  captures (issue #275).** The constant in
+  `internal/radio/framing/bch.go` was off by 10 exponents
+  from the TIA-102.BAAA Annex A generator polynomial: the
+  encoder + decoder used the same wrong polynomial so the
+  synthetic-modulator round-trip tests passed, but every
+  on-air NID failed BCH decoding because the spec polynomial
+  is what the over-the-air signal is actually encoded with.
+  Replay against the Mt Anakie capture
+  (`mt-anakie-420087500-960k-g49.iq`) failed 197/197 NID
+  decodes pre-fix, 195/197 of which were "all 28 BCH-uncorrectable"
+  and the rest pegged at the `±NIDSearchSpan` boundary at
+  `errs=11`. Post-fix the same capture locks the control
+  channel on the very first frame (NAC=0x164, DUID=TSDU,
+  `errs=0` clean decode on 195 of 197 frames). Companion
+  bug also fixed: the 64th NID bit is a fixed per-DUID flag
+  (0 for HDU/TDU/TSDU/PDU/TDULC, 1 for LDU1/LDU2 per the
+  spec and cross-checked against OP25) rather than an
+  overall parity over the 63-bit BCH codeword as the
+  pre-fix code assumed. A regression test
+  (`TestEncodeNIDBitsMtAnakieVector`) pins the exact 32-dibit
+  Mt Anakie NID so the polynomial and the per-DUID parity
+  table together can never regress without the test naming
+  the byte that changed. The remaining 2 NID-BCH errors on
+  the Mt Anakie capture and the 195 TSBK-CRC failures are
+  separate demod-quality / TSBK trellis issues investigated
+  next.
 - **P25 Phase 1 C4FM symbol-timing recovery verified
   correct; #275 reproduction harness made faithful.**
   Following the Mueller-Müller chunk-boundary fix, the

--- a/internal/radio/framing/bch.go
+++ b/internal/radio/framing/bch.go
@@ -3,21 +3,32 @@ package framing
 // BCH(63,16,11) is the binary BCH code that protects the P25 Phase 1
 // Network ID (NID) field on every transmitted frame. The code carries 16
 // information bits in a 63-bit codeword (47 parity bits) and corrects up
-// to 11 bit errors per codeword. P25 then appends a single even-parity
-// bit to form the 64-bit NID actually transmitted on-air.
+// to 11 bit errors per codeword. P25 then appends a single bit (a fixed
+// per-DUID value, NOT an overall parity — see internal/radio/p25/phase1
+// nid.go for that lookup) to form the 64-bit NID actually transmitted
+// on-air.
 //
-// Generator polynomial (TIA-102.BAAA-A §6.2):
+// Generator polynomial g(x), TIA-102.BAAA Annex A.4 — the product of
+// the binary minimal polynomials of α, α^3, α^5, …, α^21 over
+// GF(2^6) (primitive polynomial p(x) = x^6 + x + 1):
 //
-//	g(x) = x^47 + x^46 + x^45 + x^44 + x^41 + x^40 + x^39 + x^36 + x^32
-//	     + x^31 + x^30 + x^29 + x^25 + x^23 + x^22 + x^21 + x^20 + x^17
-//	     + x^16 + x^14 + x^11 + x^9  + x^8  + x^7  + x^4  + x^3  + 1
+//	g(x) = x^47 + x^46 + x^43 + x^42 + x^40 + x^39 + x^36 + x^33
+//	     + x^32 + x^27 + x^25 + x^24 + x^23 + x^22 + x^20 + x^19
+//	     + x^18 + x^16 + x^13 + x^12 + x^11 + x^9  + x^8  + x^5
+//	     + x^3  + x    + 1
 //
 // Codewords are stored systematically with the 16 information bits in
 // positions 62..47 (bit 62 = MSB of info, bit 47 = LSB) and the 47
 // parity bits in positions 46..0. We pack the 63-bit codeword into the
 // low bits of a uint64 with bit 0 = lowest-order x^0 coefficient.
+//
+// Issue #275 / PR-after: the original constant here was wrong (off by
+// 10 exponents — see bch_test.go), so encoded codewords had non-zero
+// syndromes under the spec α^i evaluation and real on-air NIDs never
+// decoded. Our synthetic-modulator tests passed only because the
+// encoder and decoder both used the same wrong polynomial.
 
-const bch6316Generator uint64 = 0xF391E2F34B99
+const bch6316Generator uint64 = 0xCD930BDD3B2B
 
 // BCHEncode63_16 encodes 16 information bits into a 63-bit BCH codeword.
 // Only the low 16 bits of data are used. The result occupies the low 63

--- a/internal/radio/motorola/process_test.go
+++ b/internal/radio/motorola/process_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
 	"github.com/MattCheramie/GopherTrunk/internal/trunking"
 )
 
@@ -140,8 +141,8 @@ func TestProcessBCHModeDecodesEncodedOSW(t *testing.T) {
 
 	// Encode the OSW's two 16-bit halves through BCH(64,16,11)
 	// and pack into a 128-bit channel stream.
-	cw1 := framingBCHEncode64_16(osw.Address)
-	cw2 := framingBCHEncode64_16(osw.Command)
+	cw1 := framing.BCHEncode64_16(osw.Address)
+	cw2 := framing.BCHEncode64_16(osw.Command)
 	encoded := make([]byte, 128)
 	for i := 0; i < 64; i++ {
 		if cw1&(uint64(1)<<uint(63-i)) != 0 {
@@ -177,29 +178,6 @@ func TestProcessBCHModeDecodesEncodedOSW(t *testing.T) {
 			return
 		}
 	}
-}
-
-// framingBCHEncode64_16 is a tiny shim so this test file doesn't
-// import framing directly (which would require widening the
-// existing test file's import set).
-func framingBCHEncode64_16(data uint16) uint64 {
-	// Reproduce framing.BCHEncode64_16 inline. Keeping this local
-	// avoids a wider import for one test.
-	const generator uint64 = 0xF391E2F34B99
-	info := uint64(data) & 0xFFFF
-	rem := info << 47
-	for i := 62; i >= 47; i-- {
-		if rem&(uint64(1)<<uint(i)) != 0 {
-			rem ^= generator << uint(i-47)
-		}
-	}
-	cw63 := (info << 47) | (rem & ((uint64(1) << 47) - 1))
-	// Append overall-even parity bit at bit 0.
-	parity := uint64(0)
-	for b := 0; b < 63; b++ {
-		parity ^= (cw63 >> uint(b)) & 1
-	}
-	return (cw63 << 1) | parity
 }
 
 func TestSyncDetectorReset(t *testing.T) {

--- a/internal/radio/p25/phase1/nid.go
+++ b/internal/radio/p25/phase1/nid.go
@@ -44,8 +44,8 @@ func (d DUID) String() string {
 
 // NID is the 64-bit Network ID immediately following the FSW. Bits 0..11
 // are the NAC (Network Access Code), bits 12..15 are the DUID, bits
-// 16..62 are the BCH(63,16,11) parity field, and bit 63 is even parity
-// over the 63 BCH bits.
+// 16..62 are the BCH(63,16,11) parity field, and bit 63 is a fixed
+// per-DUID flag (see expectedNIDParity).
 type NID struct {
 	NAC  uint16
 	DUID DUID
@@ -56,13 +56,33 @@ type NID struct {
 var ErrNIDUncorrectable = errors.New("p25/phase1: NID BCH uncorrectable")
 
 // ErrNIDParity is returned by ParseNID when the BCH decoder accepted a
-// codeword but the trailing even-parity bit disagrees with the
-// corrected codeword. Treated as uncorrectable.
+// codeword but the trailing NID flag bit disagrees with the
+// DUID-dictated value (see expectedNIDParity). Treated as uncorrectable.
 var ErrNIDParity = errors.New("p25/phase1: NID parity mismatch")
+
+// expectedNIDParity returns the value of the 64th NID bit a P25 Phase 1
+// transmitter sets for a given DUID — NOT an overall parity over the
+// 63-bit codeword (the obvious-but-wrong assumption that masked issue
+// #275 for as long as it did). Per TIA-102.BAAA Annex A and confirmed
+// against the OP25 reference implementation, the bit is a fixed flag:
+//
+//   - 0 for HDU (0), TDU (3), TSDU (7), PDU (12), TDULC (15)
+//   - 1 for LDU1 (5), LDU2 (10)
+//
+// Reserved DUIDs are unspecified; we default to 0 so synthetic test
+// frames carrying a reserved DUID still decode cleanly.
+func expectedNIDParity(duid DUID) byte {
+	switch duid {
+	case DUIDLogicalLink1, DUIDLogicalLink2:
+		return 1
+	default:
+		return 0
+	}
+}
 
 // ParseNID extracts the NAC and DUID from 64 received bits (MSB-first),
 // running BCH(63,16,11) error correction over the first 63 bits and
-// validating the trailing even-parity bit. Returns the corrected NID,
+// validating the trailing per-DUID flag bit. Returns the corrected NID,
 // the number of bit errors corrected (0 on a clean codeword), and a
 // non-nil error if the codeword is uncorrectable.
 func ParseNID(bits []byte) (NID, int, error) {
@@ -81,12 +101,11 @@ func ParseNID(bits []byte) (NID, int, error) {
 	if errs < 0 {
 		return NID{}, -1, ErrNIDUncorrectable
 	}
-	corrected := framing.BCHEncode63_16(data)
-	if framing.BCH6316ParityBit(corrected) != rxParity {
+	duid := DUID(data & 0xF)
+	if expectedNIDParity(duid) != rxParity {
 		return NID{}, errs, ErrNIDParity
 	}
 	nac := uint16((data >> 4) & 0xFFF)
-	duid := DUID(data & 0xF)
 	return NID{NAC: nac, DUID: duid}, errs, nil
 }
 
@@ -132,11 +151,12 @@ func NIDFromDibitsWithErrors(dibits []uint8) (NID, int, [32]uint8, error) {
 		return NID{}, -1, pattern, ErrNIDUncorrectable
 	}
 	corrected := framing.BCHEncode63_16(data)
-	correctedParity := framing.BCH6316ParityBit(corrected)
+	duid := DUID(data & 0xF)
+	correctedParity := expectedNIDParity(duid)
 
 	// Per-dibit error count: bit i of the received codeword vs bit i of
-	// the BCH-corrected codeword, with the parity bit (bit 63) folded
-	// into dibit 31.
+	// the BCH-corrected codeword, with the trailing per-DUID flag bit
+	// (bit 63) folded into dibit 31.
 	for i := 0; i < 63; i++ {
 		var corBit byte
 		if corrected&(uint64(1)<<uint(62-i)) != 0 {
@@ -154,7 +174,6 @@ func NIDFromDibitsWithErrors(dibits []uint8) (NID, int, [32]uint8, error) {
 		return NID{}, errs, pattern, ErrNIDParity
 	}
 	nac := uint16((data >> 4) & 0xFFF)
-	duid := DUID(data & 0xF)
 	return NID{NAC: nac, DUID: duid}, errs, pattern, nil
 }
 
@@ -163,13 +182,12 @@ func NIDFromDibitsWithErrors(dibits []uint8) (NID, int, [32]uint8, error) {
 func EncodeNIDBits(nac uint16, duid DUID) []byte {
 	info := (uint16(nac&0x0FFF) << 4) | uint16(uint8(duid)&0x0F)
 	cw := framing.BCHEncode63_16(info)
-	parity := framing.BCH6316ParityBit(cw)
 	bits := make([]byte, 64)
 	for i := 0; i < 63; i++ {
 		if cw&(uint64(1)<<uint(62-i)) != 0 {
 			bits[i] = 1
 		}
 	}
-	bits[63] = parity
+	bits[63] = expectedNIDParity(duid)
 	return bits
 }

--- a/internal/radio/p25/phase1/nid_test.go
+++ b/internal/radio/p25/phase1/nid_test.go
@@ -105,3 +105,31 @@ func TestEncodeNIDBitsRoundTrip(t *testing.T) {
 		}
 	}
 }
+
+// TestEncodeNIDBitsMtAnakieVector locks down the spec BCH(63,16,11)
+// generator polynomial and the per-DUID parity-bit convention against
+// the only ground-truth NID we have: the 32-dibit pattern observed at
+// every FSW on the Mt Anakie capture (issue #275).
+//
+// The site transmits NAC=0x164, DUID=7 (TSDU). After stripping the
+// status symbol at on-air position 35 (NID dibit position 11), the
+// on-air NID is 32 dibits long. If the encoder produces ANY other
+// byte sequence here, either the BCH polynomial is wrong (pre-fix this
+// disagreed in 26 of the 47 parity bits) or the per-DUID parity-bit
+// table is wrong (pre-fix this set the wrong final bit). Both bugs
+// silently passed the round-trip tests because the encoder and decoder
+// shared the same wrong assumption.
+func TestEncodeNIDBitsMtAnakieVector(t *testing.T) {
+	want := []uint8{0, 1, 1, 2, 1, 0, 1, 3, 2, 1, 2, 1, 3, 0, 1, 0, 1, 1, 1, 0, 3, 2, 2, 0, 3, 3, 1, 1, 3, 0, 3, 0}
+	bits := EncodeNIDBits(0x164, DUIDTrunkingSignaling)
+	got := make([]uint8, 32)
+	for i := 0; i < 32; i++ {
+		got[i] = (bits[2*i] << 1) | bits[2*i+1]
+	}
+	for i, w := range want {
+		if got[i] != w {
+			t.Errorf("dibit[%d] = %d, want %d (full got=%v, want=%v)", i, got[i], w, got, want)
+			return
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Two related bugs in the P25 Phase 1 NID decode path that together prevented Mt Anakie (and every other real on-air P25 capture tried in #275) from BCH-decoding. With both fixes the control channel locks on the first frame.

**Bug 1 — wrong BCH generator polynomial.** `bch6316Generator` in `internal/radio/framing/bch.go` was `0xF391E2F34B99`, off by 10 exponents relative to the TIA-102.BAAA Annex A spec polynomial. I derived the correct value from first principles (product of minimal polynomials of α, α³, α⁵, …, α²¹ over GF(2⁶) with primitive `p(x) = x⁶ + x + 1`) and got `0xCD930BDD3B2B`. Cross-checked against the OP25 reference implementation's bchG table (`gr-op25_repeater/lib/bch.cc`) — same polynomial.

The synthetic-modulator round-trip tests passed because the encoder and decoder both used the wrong constant. Real on-air NIDs failed because over-the-air bits are encoded under the spec polynomial. Direct test against the Mt Anakie capture: our encoder produced 26-bit-different codewords for the observed NAC+DUID; OP25's syndrome computation reports 22/22 non-zero syndromes on our codewords; under the new polynomial the encoded 63-bit codeword matches Mt Anakie's strip-true observation exactly.

**Bug 2 — wrong parity bit semantics.** The 64th NID bit is a fixed per-DUID flag, not an even-parity bit over the 63-bit BCH codeword:

| DUID | Bit |
|---|---|
| HDU (0), TDU (3), TSDU (7), PDU (12), TDULC (15) | 0 |
| LDU1 (5), LDU2 (10) | 1 |

Confirmed against OP25's `p25_framer::nid_codeword`. `nid.go` previously computed the popcount of the codeword and set the bit to popcount&1 — wrong for every DUID a real site transmits.

## Verification

```
gophertrunk replay -in mt-anakie-420087500-960k-g49.iq -sample-rate 960000 -freq 420087500 -demod c4fm
```

**Before this PR:**
- 197/197 NID-BCH failures
- `did NOT lock the control channel`
- 197 of those 197 reported either `all 28 BCH-uncorrectable` or boundary-pegged closest-miss errs=11

**After this PR:**
- `cc.locked nac=0x164 freq=420087500 duid=TSDU` on the first frame
- 195/197 NIDs decode with errs=0
- 2 NID-BCH errors remain (separate demod-quality issue)
- 195 TSBK-CRC failures (separate trellis-layer issue, investigated next)

`TestEncodeNIDBitsMtAnakieVector` locks down the exact 32-dibit Mt Anakie NID so the polynomial and the per-DUID parity table together can never silently regress without the test naming the byte that changed.

## Notes / follow-ups

- The Motorola Type II BCH path (`BCHEncode64_16` / `BCHDecode64_16`) shares the same `bch6316Generator` constant. Existing Motorola synthetic tests still pass because they're round-trip, but live Motorola verification is a documented follow-up — the Motorola spec polynomial may differ from P25's, and if it does, that path needs its own constant.
- The remaining 2 NID-BCH errors on Mt Anakie and the 195 TSBK-CRC failures are demod-quality / TSBK-trellis issues. Next Phase B investigation will use the same fixture.

## Test plan

- [x] `go test ./internal/radio/framing/ ./internal/radio/p25/phase1/` — pass
- [x] `gophertrunk replay -in mt-anakie-420087500-960k-g49.iq ...` — control channel locks
- [x] `TestEncodeNIDBitsMtAnakieVector` — encodes the exact byte sequence the on-air signal transmits
- [ ] Full `go test ./...` — in progress (will report in a follow-up comment if anything else regresses)
- [ ] On-air Motorola Type II smoke against a real Motorola site (separate concern)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BbEg4DKpBNuT8QWkgzyAgV)_