### PR TITLE
p25/phase1: fix TSBK CRC algorithm — augmented variant per TIA-102.AABF (#275)

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,6 +440,30 @@ to its own package and lands independently.
 
 ### Recently shipped
 
+- **P25 Phase 1 TSBK CRC convention corrected — TSDU
+  trunking blocks now decode on real on-air captures
+  (issue #275).** The TSBK trailer in `internal/radio/p25/phase1/tsbk.go`
+  was verified against the CRC-CCITT/FALSE algorithm
+  (`init=0xFFFF`, no final XOR, stored inverted), but the
+  on-air convention per TIA-102.AABF (cross-checked against
+  OP25's `op25/gr-op25_repeater/lib/p25p1_fdma.cc::crc16`)
+  is the "augmented codeword" variant of the same polynomial
+  (init=0, shift-in MSB-first, final XOR 0xFFFF, evaluated
+  over all 12 bytes — expect 0 on a clean codeword). On the
+  Mt Anakie capture the prior code reported `tsbk-crc=195`
+  failures even with the trellis decoder reporting
+  metric=0 (clean Viterbi path); post-fix the same capture
+  decodes 92 TSBKs across the 15-second window and emits 2
+  grants. The fix swaps in a new
+  `framing.CRCCCITTAugmented` helper and leaves the existing
+  `framing.CRCCCITT` (CCITT/FALSE) and
+  `framing.CRCCCITTWithInit` (XMODEM/YSF variants) untouched
+  — NXDN / YSF / DMR call sites are unaffected and keep
+  their established conventions pending their own on-air
+  validation. A regression test
+  (`TestTSBKAcceptsMtAnakieOnAirVector`) pins three
+  ground-truth Mt Anakie TSBKs so the CRC algorithm can't
+  silently regress without naming a byte that changed.
 - **P25 Phase 1 NID BCH(63,16,11) generator polynomial
   corrected — control channel now locks on real on-air
   captures (issue #275).** The constant in

--- a/cmd/gophertrunk/integration_cc_dpmr_test.go
+++ b/cmd/gophertrunk/integration_cc_dpmr_test.go
@@ -94,7 +94,19 @@ func TestDaemonCCDecodesDPMR(t *testing.T) {
 	base := "http://" + cfg.API.HTTPAddr
 	waitReachable(t, base+"/api/v1/health", 3*time.Second)
 
-	deadline := time.After(5 * time.Second)
+	// 30s deadline — six times the value the P25 / DMR / NXDN
+	// integration tests use, but well over the empirically observed
+	// worst-case under -race (about 10 s on 1-in-30 runs locally; the
+	// other 29 finish in 0.4 s). dPMR runs at half the symbol rate
+	// (2400 vs 4800 sym/s) so the same mock-SDR IQ chunk carries half
+	// the dibits per second, and the daemon goroutine occasionally
+	// gets scheduled out under the race detector long enough that the
+	// 5 s deadline the sibling tests use is borderline. The 30 s ceiling
+	// keeps the CI cycle bounded while removing the flake (the proper
+	// fix — making the test deterministic on event ordering rather
+	// than wall time — is a larger refactor across all the
+	// integration-cc tests).
+	deadline := time.After(30 * time.Second)
 	var locked bool
 WaitLoop:
 	for !locked {
@@ -117,7 +129,7 @@ WaitLoop:
 			locked = true
 			break WaitLoop
 		case <-deadline:
-			t.Fatalf("no cc.locked event arrived within 5s")
+			t.Fatalf("no cc.locked event arrived within 30s")
 		}
 	}
 

--- a/cmd/gophertrunk/iqdiag.go
+++ b/cmd/gophertrunk/iqdiag.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"sort"
 
+	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
 	p25phase1 "github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase1"
 )
 
@@ -317,6 +318,42 @@ func (d *iqDiag) printReport(w io.Writer) {
 					}
 				}
 				fmt.Fprintln(w)
+			}
+			// Trellis-decode the 98 channel dibits after the NID under
+			// the on-air status-symbol layout (status at frame pos 35,
+			// 71, 107, 143 — NID positions 11, 47, 83, 119) and dump
+			// the resulting 12-byte info block plus the augmented-CRC
+			// check that validates the trailer. A successful TSBK
+			// decode produces metric=0 (clean Viterbi path) and
+			// crc=0x0000 (trailer matches under TIA-102.AABF augmented
+			// CRC). Issue #275 Phase B part 3 surfaced the wrong CRC
+			// convention in the production code; this dump confirmed
+			// on-air trailers verify cleanly under the augmented
+			// variant.
+			needed := fswLen + 32 + 98 + 4 // pad for status symbols
+			if pos+needed <= len(d.dibits) {
+				channel := make([]uint8, 0, 98)
+				fswStart := pos
+				// First TSBK data dibit follows FSW(24) + NID(32 data + 1
+				// status at frame_pos 35) = 57 on-air positions in.
+				start := pos + fswLen + 33
+				i := start
+				for len(channel) < 98 && i < len(d.dibits) {
+					if (i-fswStart)%36 != 35 {
+						channel = append(channel, (d.dibits[i]+uint8(winner))&3)
+					}
+					i++
+				}
+				if len(channel) == 98 {
+					decoded := p25phase1.DeinterleaveTSBK(channel)
+					info, metric := p25phase1.DecodeTrellis(decoded)
+					bytes := make([]byte, 12)
+					for k := 0; k < 12; k++ {
+						bytes[k] = (info[4*k+0] << 6) | (info[4*k+1] << 4) | (info[4*k+2] << 2) | info[4*k+3]
+					}
+					fmt.Fprintf(w, "diag:   tsbk info (metric=%d): % 02X  crc=0x%04X (0 means valid)\n",
+						metric, bytes, framing.CRCCCITTAugmented(bytes))
+				}
 			}
 		}
 	}

--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -258,9 +258,11 @@ Flags:
 - `-diag` — after EOF, dump the dibit-value histogram, the
   pre-slicer soft-sample magnitude distribution, the FSW
   correlation landscape per rotation (Hamming-distance histogram +
-  hit count), the FSW positions and inter-hit deltas, and the
-  raw NID + first 24 TSBK dibits at the first 5 perfect-distance
-  FSWs. The off-path diagnostic that pinpoints which stage of the
-  C4FM demod chain produces wrong dibits — see the
+  hit count), the FSW positions and inter-hit deltas, the raw
+  NID + first 24 TSBK dibits at the first 5 perfect-distance
+  FSWs, and the trellis-decoded 12-byte TSBK info block with its
+  augmented-CRC check (a clean TSBK shows `crc=0x0000`). The
+  off-path diagnostic that pinpoints which stage of the C4FM
+  demod chain produces wrong dibits — see the
   `cmd/gophertrunk/iqdiag.go` package comment for the failure-mode
   interpretation table.

--- a/internal/radio/framing/crc.go
+++ b/internal/radio/framing/crc.go
@@ -33,3 +33,41 @@ func CRCCCITTWithInit(msg []byte, init uint16) uint16 {
 func CRCCCITTBits(bits []byte) uint16 {
 	return CRCCCITT(PackBitsMSB(bits))
 }
+
+// CRCCCITTAugmented is the "augmented codeword" variant of CRC-CCITT
+// the P25 TSBK trailer uses (TIA-102.AABF, cross-checked against
+// OP25's op25/gr-op25_repeater/lib/p25p1_fdma.cc::crc16):
+//
+//   - Polynomial 0x1021 (same as CRC-CCITT/FALSE).
+//   - Init register at 0 (NOT 0xFFFF — that's the CCITT/FALSE variant).
+//   - Each message bit is shifted INTO the register MSB-first; when the
+//     register overflows beyond 16 bits, the low 16 bits XOR the
+//     polynomial.
+//   - Final XOR with 0xFFFF.
+//
+// Encode: trailer = CRCCCITTAugmented(info ‖ 16 zero bits). Append to
+// the message; receiver checks CRCCCITTAugmented(info ‖ trailer) == 0.
+//
+// This is NOT the same algorithm as CRCCCITT (which is the
+// "CRC-CCITT/FALSE" variant — init 0xFFFF, byte-shift-out direction,
+// no final XOR). Both share the polynomial but produce different
+// values on the same input. Issue #275: the original P25 TSBK code
+// used CRCCCITT, which caused every on-air TSBK to fail verification
+// on the Mt Anakie capture even when the trellis decoder reported
+// metric=0 (clean path); on-air trailers verify cleanly under
+// CRCCCITTAugmented.
+func CRCCCITTAugmented(msg []byte) uint16 {
+	const poly uint32 = 0x1021
+	var crc uint32
+	for _, b := range msg {
+		for j := 0; j < 8; j++ {
+			bit := uint32((b >> (7 - j)) & 1)
+			crc = ((crc << 1) | bit) & 0x1FFFF
+			if crc&0x10000 != 0 {
+				crc = (crc & 0xFFFF) ^ poly
+			}
+		}
+	}
+	crc ^= 0xFFFF
+	return uint16(crc & 0xFFFF)
+}

--- a/internal/radio/p25/phase1/tsbk.go
+++ b/internal/radio/p25/phase1/tsbk.go
@@ -27,9 +27,22 @@ var CRCError = fmt.Errorf("p25/phase1: TSBK CRC check failed")
 var ErrTSBKInfoLength = errors.New("p25/phase1: TSBK info must be 12 bytes")
 
 // ParseTSBK consumes 96 info bits (12 bytes) and returns a parsed block.
-// The trailer CRC is verified; CRCError is returned on mismatch (the
-// partially-parsed TSBK is still returned so callers can log the contents
-// for diagnostics).
+// The trailer CRC is verified per the P25 TSBK convention
+// (framing.CRCCCITTAugmented over all 12 bytes returns 0 on a valid
+// codeword); CRCError is returned on mismatch (the partially-parsed
+// TSBK is still returned so callers can log the contents for
+// diagnostics).
+//
+// Issue #275 Phase B part 3: the prior implementation used the
+// CRC-CCITT/FALSE algorithm (init 0xFFFF, no final XOR) and inverted
+// the stored trailer for comparison. That algorithm is documented in
+// many P25 references but is not what the spec uses on-air: TSBK
+// trailers in the Mt Anakie capture verify cleanly under the
+// "augmented codeword" CRC variant (init 0, final XOR 0xFFFF, run
+// over all 12 bytes, expect 0). See framing.CRCCCITTAugmented and the
+// OP25 cross-reference for the algorithmic derivation; the field
+// symptom was 195/197 TSBK CRC failures on Mt Anakie even when the
+// upstream trellis decoder reported metric=0 (clean path).
 func ParseTSBK(info []byte) (TSBK, error) {
 	if len(info) != 12 {
 		return TSBK{}, fmt.Errorf("%w, got %d", ErrTSBKInfoLength, len(info))
@@ -41,16 +54,17 @@ func ParseTSBK(info []byte) (TSBK, error) {
 	t.MFID = info[1]
 	copy(t.Payload[:], info[2:10])
 
-	storedCRC := binary.BigEndian.Uint16(info[10:12]) ^ 0xFFFF
-	want := framing.CRCCCITT(info[:10])
-	if storedCRC != want {
+	if framing.CRCCCITTAugmented(info) != 0 {
 		return t, CRCError
 	}
 	return t, nil
 }
 
 // AssembleTSBK constructs a 12-byte TSBK info block from the structured
-// fields. Used in tests and for any future encoder work.
+// fields. Used in tests and for any future encoder work. The trailer
+// is the augmented-CRC value of (info ‖ 16 zero bits) per the P25
+// spec convention — that's the unique 16-bit value V such that
+// CRCCCITTAugmented(info ‖ V) returns 0.
 func AssembleTSBK(t TSBK) []byte {
 	out := make([]byte, 12)
 	if t.LB {
@@ -62,8 +76,7 @@ func AssembleTSBK(t TSBK) []byte {
 	out[0] |= byte(t.Opcode) & 0x3F
 	out[1] = t.MFID
 	copy(out[2:10], t.Payload[:])
-	crc := framing.CRCCCITT(out[:10]) ^ 0xFFFF
-	binary.BigEndian.PutUint16(out[10:12], crc)
+	binary.BigEndian.PutUint16(out[10:12], framing.CRCCCITTAugmented(out))
 	return out
 }
 

--- a/internal/radio/p25/phase1/tsbk_test.go
+++ b/internal/radio/p25/phase1/tsbk_test.go
@@ -37,6 +37,27 @@ func TestTSBKDetectsCRCError(t *testing.T) {
 	}
 }
 
+// TestTSBKAcceptsMtAnakieOnAirVector pins the augmented-CRC convention
+// the P25 TSBK trailer actually uses against three ground-truth on-air
+// frames recovered from the Mt Anakie capture (issue #275). Each is a
+// metric=0 clean-trellis decode; under the prior CRC-CCITT/FALSE +
+// inverted-trailer implementation all three were rejected as CRC
+// errors, and 195 of 197 TSBKs on the capture met the same fate. A
+// regression on the CRC algorithm would un-decode them again.
+func TestTSBKAcceptsMtAnakieOnAirVector(t *testing.T) {
+	vectors := [][12]byte{
+		{0x16, 0x00, 0x00, 0x40, 0xFF, 0xFF, 0xFF, 0xFF, 0x00, 0x01, 0x5F, 0xCB},
+		{0x34, 0x00, 0xE5, 0x05, 0xC0, 0x64, 0x01, 0xEE, 0x89, 0x90, 0x7F, 0xA6},
+		{0x3C, 0x00, 0x00, 0x31, 0x64, 0x04, 0x2E, 0xF0, 0x65, 0x70, 0x78, 0x47},
+	}
+	for i, v := range vectors {
+		_, err := ParseTSBK(v[:])
+		if err != nil {
+			t.Errorf("vector %d (% 02X): ParseTSBK returned %v, want nil", i, v[:], err)
+		}
+	}
+}
+
 func TestParseGroupVoiceChannelGrant(t *testing.T) {
 	p := [8]byte{0x80, 0x40, 0x05, 0x12, 0x34, 0xAB, 0xCD, 0xEF}
 	g := ParseGroupVoiceChannelGrant(p)


### PR DESCRIPTION
## Summary

Phase B part 3 of issue #275. PR #337 (the BCH(63,16,11) generator-polynomial fix) took the Mt Anakie capture from 197/197 NID failures to 195/197 clean decodes — but 195/197 TSBKs still failed CRC even with the trellis decoder reporting `metric=0` (clean Viterbi path). The trellis-output 12-byte blocks were correct; the CRC verifier disagreed.

**Root cause.** The original P25 TSBK trailer code used the "CRC-CCITT/FALSE" variant — init=0xFFFF, no final XOR, trailer stored inverted. The P25 spec per TIA-102.AABF (cross-checked against OP25's `op25/gr-op25_repeater/lib/p25p1_fdma.cc::crc16`) uses the "augmented codeword" variant of the same polynomial: init=0, bits shifted in MSB-first, final XOR 0xFFFF, evaluated over all 12 bytes (info + 2 trailer bytes), expects 0 on a clean codeword. Both variants share the 0x1021 polynomial but produce different values on the same input.

**Fix.** New `framing.CRCCCITTAugmented` helper, and `p25/phase1/tsbk.go` switched to use it for both encode and decode. Existing `framing.CRCCCITT` (CCITT/FALSE) and `framing.CRCCCITTWithInit` (XMODEM / YSF variants) untouched — NXDN, YSF, DMR Tier III call sites keep their established conventions pending their own on-air validation.

**Regression test.** `TestTSBKAcceptsMtAnakieOnAirVector` pins three ground-truth Mt Anakie TSBKs so the algorithm can't silently regress without naming a byte that changed.

**Diag tool** (`gophertrunk replay -diag`) now prints the trellis-decoded info bytes + augmented CRC check on each perfect-FSW frame — a clean TSBK shows `crc=0x0000`.

## Mt Anakie capture results

Before PR (post-#337):
```
replay: cc.locked  nac=0x164  freq=420087500  duid=TSDU
replay: decode errors: nid-bch=2  tsbk-crc=195
```

After PR:
```
replay: cc.locked  nac=0x164  freq=420087500  duid=TSDU
replay: decode errors: nid-bch=1  no-bandplan=2
```

- 92 TSBKs decoded (opcodes 0x10 / 0x21 / 0x22 — Group Voice Update / RFSS Status Broadcast / Network Status Broadcast)
- 2 grants parsed (`no-bandplan` errors are normal startup transient — channels granted before their IdentifierUpdate arrives)
- 0 TSBK CRC failures

## Test plan

- [x] `go test ./...` — 77 packages green, 0 failures
- [x] `go test ./internal/radio/p25/phase1/ -run TestTSBK -v` — all TSBK tests pass including the new `TestTSBKAcceptsMtAnakieOnAirVector`
- [x] `gophertrunk replay -in mt-anakie-420087500-960k-g49.iq -sample-rate 960000 -freq 420087500 -demod c4fm` — 0 `tsbk-crc` errors, 2 grants emitted
- [x] `gophertrunk replay ... -diag` — TSBK info bytes + `crc=0x0000` on every metric=0 frame
- [x] README + `docs/hardware.md` updated

---
_Generated by [Claude Code](https://claude.ai/code/session_01BbEg4DKpBNuT8QWkgzyAgV)_