### PR TITLE
internal/version: auto-stamp from VCS info on bare go build (#275)

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,6 +440,27 @@ to its own package and lands independently.
 
 ### Recently shipped
 
+- **Bare `go build` now auto-stamps the version line from
+  git VCS info (issue #275 retest hygiene).** A user running
+  `go build -o ./bin/gophertrunk ./cmd/gophertrunk` (the
+  intuitive Go-toolchain command, vs the `make build` the
+  README recommends) used to get a binary whose
+  `gophertrunk version` reported just `dev` and whose
+  `ccdecoder: p25/phase1 pipeline configured` log line
+  printed `build=dev`. That defeated the stale-build
+  detection commit `eb543eb` added specifically for issue
+  #275 retest cycles, where pasted decoder log excerpts are
+  often the only signal of which fixes are actually loaded.
+  `internal/version` now falls back to
+  `runtime/debug.ReadBuildInfo()`'s `vcs.revision` /
+  `vcs.modified` / `vcs.time` settings (which Go 1.18+
+  auto-injects on any git-checkout build) when `Commit` /
+  `BuildTime` aren't set by `-ldflags`. Explicit `-ldflags`
+  injection (Makefile, release workflow) still wins — the
+  fallback fires per-field on the empty defaults only. A
+  `-dirty` suffix on the commit sha surfaces an uncommitted
+  working tree at build time so a partially-applied retest
+  is visible at a glance.
 - **P25 Phase 1 TSBK CRC convention corrected — TSDU
   trunking blocks now decode on real on-air captures
   (issue #275).** The TSBK trailer in `internal/radio/p25/phase1/tsbk.go`
@@ -2366,7 +2387,7 @@ and DVB-driver blacklisting on Linux.
 ### Build, test, run
 
 ```sh
-make build                    # produces ./bin/gophertrunk
+make build                    # produces ./bin/gophertrunk (preferred — injects -ldflags version stamp)
 make test                     # go test -race ./...
 make web-test                 # Vitest + React Testing Library against the SPA panels
 make integration              # boots the wired daemon end-to-end (no SDR needed)
@@ -2409,6 +2430,14 @@ make integration-cc-ysf       # YSF "lights up" — 4800-baud C4FM 480-dibit fra
 ./bin/gophertrunk import-pdf -wizard
 ./bin/gophertrunk import-pdf -wizard -pdf maricopa.pdf
 ```
+
+A bare `go build -o ./bin/gophertrunk ./cmd/gophertrunk` works too —
+the binary auto-stamps its version line from Go's built-in VCS info
+(e.g. `dev (sha=abc1234, built=…)`), which matches what `make build`
+produces minus the explicit `git describe` Version prefix. Useful when
+attaching a log to an issue and you want the commit hash in the
+`ccdecoder: p25/phase1 pipeline configured` line without remembering
+the `-ldflags` incantation.
 
 A starter [`config.example.yaml`](config.example.yaml) is in the
 repo root — copy it, set the `serial` of your dongle from

--- a/internal/version/export_test.go
+++ b/internal/version/export_test.go
@@ -1,0 +1,15 @@
+package version
+
+import "sync"
+
+// ResetForTest re-arms the sync.Once that guards populateFromBuildInfo
+// so a test can force the fallback path to run again after mutating
+// the package-level Commit / BuildTime vars. Test-only.
+func ResetForTest() {
+	fallbackOnce = sync.Once{}
+}
+
+// ExtractVCS exposes the unexported extractVCS helper so tests can
+// drive it with synthetic debug.BuildInfo values without depending on
+// the test binary's actual checkout state. Test-only.
+var ExtractVCS = extractVCS

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -4,25 +4,53 @@
 // builds informative without requiring an LDFLAGS dance.
 package version
 
+import (
+	"runtime/debug"
+	"sync"
+)
+
 // Version is the human-readable build version. Set at link time by
 // the Makefile + release workflow to the git tag (e.g. "v1.0.0") or
 // `git describe` output for in-development builds. Defaults to "dev"
-// for `go run` / `go test` invocations.
+// for `go run` / `go test` / bare-`go build` invocations.
 var Version = "dev"
 
-// Commit is the short git SHA the binary was built from. Set at
-// link time via -ldflags. Empty for non-LDFLAGS builds.
+// Commit is the short git SHA the binary was built from. Set at link
+// time via -ldflags; on a bare `go build` of a git checkout falls
+// back to the 7-char prefix of runtime/debug.ReadBuildInfo's
+// vcs.revision (with "-dirty" appended when the working tree had
+// uncommitted changes at build time). Empty when neither source is
+// available — e.g. a tarball build with no .git.
 var Commit = ""
 
 // BuildTime is the ISO-8601 UTC timestamp at which the binary was
-// built. Set at link time via -ldflags. Empty for non-LDFLAGS builds.
+// built. Set at link time via -ldflags; on a bare `go build` of a
+// git checkout falls back to vcs.time from runtime/debug.ReadBuildInfo
+// (the HEAD commit timestamp, which is close enough for diagnostics).
+// Empty when neither source is available.
 var BuildTime = ""
 
-// String returns a single-line summary suitable for logging or
-// for the `gophertrunk version` subcommand: "vX.Y.Z (sha=ABC1234,
-// built=2026-05-13T19:00:00Z)". Empty Commit / BuildTime are
-// omitted so dev builds stay compact.
+// fallbackOnce guards the one-time read of runtime/debug.ReadBuildInfo
+// so concurrent String() callers don't race on the package vars. The
+// read happens on first String() call, not in init(), because some
+// downstream tests reset Version/Commit/BuildTime around the existing
+// String formatter tests and we don't want init() racing those.
+var fallbackOnce sync.Once
+
+// String returns a single-line summary suitable for logging or for
+// the `gophertrunk version` subcommand: "vX.Y.Z (sha=ABC1234,
+// built=2026-05-13T19:00:00Z)". Empty Commit / BuildTime are omitted
+// so the most basic dev builds (no git, no -ldflags) still stay
+// compact ("dev").
+//
+// Issue #275 retest cycles repeatedly tripped on stale builds whose
+// log lines read `build=dev` and gave no hint of which commit was
+// actually loaded. To prevent that recurring without forcing users
+// to remember `-ldflags`, on first call we populate empty Commit /
+// BuildTime from Go's auto-injected VCS info — explicit `-ldflags`
+// still wins (the populate runs only on empty fields).
 func String() string {
+	fallbackOnce.Do(populateFromBuildInfo)
 	out := Version
 	if Commit != "" || BuildTime != "" {
 		out += " ("
@@ -38,4 +66,60 @@ func String() string {
 		out += ")"
 	}
 	return out
+}
+
+// populateFromBuildInfo fills empty Commit / BuildTime from Go's
+// runtime/debug.ReadBuildInfo VCS settings (available since Go 1.18
+// for every `go build` of a git checkout). Skipped per-field when
+// -ldflags already set the value, so production builds via `make
+// build` and the release workflow are unaffected.
+func populateFromBuildInfo() {
+	if Commit != "" && BuildTime != "" {
+		return // both already set via -ldflags
+	}
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return
+	}
+	commit, when := extractVCS(info)
+	if Commit == "" {
+		Commit = commit
+	}
+	if BuildTime == "" {
+		BuildTime = when
+	}
+}
+
+// extractVCS pulls the short commit SHA and HEAD timestamp out of a
+// *debug.BuildInfo's VCS settings. Returns ("", "") if no VCS info
+// is present (tarball builds, etc.). Factored out so tests can drive
+// the logic with synthetic BuildInfo values without depending on the
+// test binary's actual checkout state.
+func extractVCS(info *debug.BuildInfo) (commit, when string) {
+	if info == nil {
+		return "", ""
+	}
+	var rev, modified, vcsTime string
+	for _, s := range info.Settings {
+		switch s.Key {
+		case "vcs.revision":
+			rev = s.Value
+		case "vcs.modified":
+			modified = s.Value
+		case "vcs.time":
+			vcsTime = s.Value
+		}
+	}
+	if rev != "" {
+		short := rev
+		if len(short) > 7 {
+			short = short[:7]
+		}
+		if modified == "true" {
+			short += "-dirty"
+		}
+		commit = short
+	}
+	when = vcsTime
+	return commit, when
 }

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,6 +1,7 @@
 package version
 
 import (
+	"runtime/debug"
 	"strings"
 	"testing"
 )
@@ -53,16 +54,128 @@ func TestStringWithBuildTimeOnly(t *testing.T) {
 }
 
 func TestDefaultVersionIsDev(t *testing.T) {
-	// Sanity: an unpopulated build (no -ldflags) reports "dev".
-	// This test runs against the package default; if the package
-	// is ever rebuilt with ldflags, the default constant in the
-	// source is what matters.
+	// Sanity: an unpopulated build (no -ldflags AND no VCS info)
+	// reports "dev". Resetting fallbackOnce + clearing the package
+	// vars isn't enough on its own here — fallbackOnce.Do will read
+	// the test binary's actual VCS info, which under `go test` is a
+	// real git checkout, so Commit / BuildTime would be populated.
+	// We force the no-VCS branch by leaving fallbackOnce in its
+	// already-consumed state from earlier tests; the remaining
+	// guarantee is that the formatter itself outputs "dev" when all
+	// three vars are empty/default.
 	saveV, saveC, saveB := Version, Commit, BuildTime
 	defer func() { Version, Commit, BuildTime = saveV, saveC, saveB }()
-	// Force the defaults via the package-level vars so we don't
-	// depend on the test binary's actual link state.
 	Version, Commit, BuildTime = "dev", "", ""
+	// Note: we do NOT call ResetForTest() here. fallbackOnce has
+	// already been consumed by some earlier String() call in this
+	// test binary, so the formatter runs over empty fields. This
+	// matches the production "no VCS info" case (a tarball build),
+	// not the "go test with VCS" case which TestStringFillsCommitFromVCSWhenUnset
+	// covers below.
 	if got := String(); got != "dev" {
 		t.Errorf("default String() = %q, want %q", got, "dev")
+	}
+}
+
+// TestExtractVCSPopulatesCommitAndTime drives the VCS-extraction
+// helper with a synthetic BuildInfo so the assertion isn't coupled
+// to whatever sha the test binary was actually built from.
+func TestExtractVCSPopulatesCommitAndTime(t *testing.T) {
+	info := &debug.BuildInfo{
+		Settings: []debug.BuildSetting{
+			{Key: "vcs.revision", Value: "abc1234567890def"},
+			{Key: "vcs.modified", Value: "false"},
+			{Key: "vcs.time", Value: "2026-05-23T20:50:00Z"},
+		},
+	}
+	commit, when := ExtractVCS(info)
+	if commit != "abc1234" {
+		t.Errorf("commit = %q, want %q (7-char prefix of vcs.revision)", commit, "abc1234")
+	}
+	if when != "2026-05-23T20:50:00Z" {
+		t.Errorf("when = %q, want vcs.time verbatim", when)
+	}
+}
+
+// TestExtractVCSDirtyMarker locks in the "-dirty" suffix when the
+// working tree had uncommitted changes at build time. That marker is
+// the only way a log reader can tell a clean retest from a build
+// against partially-applied changes.
+func TestExtractVCSDirtyMarker(t *testing.T) {
+	info := &debug.BuildInfo{
+		Settings: []debug.BuildSetting{
+			{Key: "vcs.revision", Value: "0000000abcdef"},
+			{Key: "vcs.modified", Value: "true"},
+		},
+	}
+	commit, _ := ExtractVCS(info)
+	if !strings.HasSuffix(commit, "-dirty") {
+		t.Errorf("commit = %q, want -dirty suffix", commit)
+	}
+	if !strings.HasPrefix(commit, "0000000") {
+		t.Errorf("commit = %q, want 0000000 prefix", commit)
+	}
+}
+
+// TestExtractVCSNoVCSInfo guards the tarball-build path: no vcs.*
+// settings means empty returns and no panic. The version package
+// must keep working in environments without VCS metadata.
+func TestExtractVCSNoVCSInfo(t *testing.T) {
+	info := &debug.BuildInfo{Settings: []debug.BuildSetting{
+		{Key: "GOOS", Value: "linux"},
+	}}
+	commit, when := ExtractVCS(info)
+	if commit != "" || when != "" {
+		t.Errorf("ExtractVCS(no-vcs) = (%q, %q), want both empty", commit, when)
+	}
+	if c, w := ExtractVCS(nil); c != "" || w != "" {
+		t.Errorf("ExtractVCS(nil) = (%q, %q), want both empty", c, w)
+	}
+}
+
+// TestStringFillsCommitFromVCSWhenUnset drives the full populate
+// path through String(): empty Commit + BuildTime + a fresh sync.Once
+// means the formatter must pull VCS info from the test binary itself
+// (which `go test` builds with VCS auto-injection). Skips when the
+// test binary genuinely has no VCS info — happens when `go test` is
+// run from a tarball or with -buildvcs=false.
+func TestStringFillsCommitFromVCSWhenUnset(t *testing.T) {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		t.Skip("debug.ReadBuildInfo unavailable")
+	}
+	if commit, _ := ExtractVCS(info); commit == "" {
+		t.Skip("test binary built without VCS info (e.g. -buildvcs=false)")
+	}
+	saveV, saveC, saveB := Version, Commit, BuildTime
+	defer func() {
+		Version, Commit, BuildTime = saveV, saveC, saveB
+		ResetForTest()
+	}()
+	Version, Commit, BuildTime = "dev", "", ""
+	ResetForTest()
+	got := String()
+	if !strings.Contains(got, "sha=") {
+		t.Errorf("String() = %q, want sha=… filled in from VCS fallback", got)
+	}
+}
+
+// TestLdflagsBeatsVCSFallback confirms explicit -ldflags injection
+// is preserved across the fallback: if Commit is already set
+// (production case), the VCS info must not overwrite it.
+func TestLdflagsBeatsVCSFallback(t *testing.T) {
+	saveV, saveC, saveB := Version, Commit, BuildTime
+	defer func() {
+		Version, Commit, BuildTime = saveV, saveC, saveB
+		ResetForTest()
+	}()
+	Version, Commit, BuildTime = "v0.2.0", "deadbee", "2026-01-01T00:00:00Z"
+	ResetForTest()
+	got := String()
+	if !strings.Contains(got, "sha=deadbee") {
+		t.Errorf("String() = %q, want explicit sha=deadbee preserved", got)
+	}
+	if !strings.Contains(got, "built=2026-01-01T00:00:00Z") {
+		t.Errorf("String() = %q, want explicit built= preserved", got)
 	}
 }


### PR DESCRIPTION
## Summary

er-imagery's [most recent comment on issue #275](https://github.com/MattCheramie/GopherTrunk/issues/275#issuecomment-4526481571) confirmed PR #337's BCH fix works on the live radio, but flagged a longstanding diagnostic gap: "Version string reports `dev`, but the source HEAD is `e52f10d`". They built with the intuitive `go build -o ./bin/gophertrunk ./cmd/gophertrunk` rather than the `make build` the README prefers. Without the Makefile's `-ldflags` injection the version package stayed at its zero defaults (`Version="dev"`, `Commit=""`, `BuildTime=""`) and the `ccdecoder: p25/phase1 pipeline configured` log line printed `build=dev`. That defeats commit `eb543eb`'s stale-build-detection purpose for issue #275 retest cycles — pasted log excerpts are often the only signal of which fixes are actually loaded, and one retest cycle on this issue was already invalidated by a silently stale build.

## Fix

`internal/version` now falls back to `runtime/debug.ReadBuildInfo()`'s `vcs.revision` / `vcs.modified` / `vcs.time` settings (which Go 1.18+ auto-injects on any git-checkout build) when `Commit` / `BuildTime` aren't set by `-ldflags`. The check is per-field on the empty defaults so explicit `-ldflags` injection (Makefile, `release.yml`) still wins. The `Commit` string is the 7-char prefix of `vcs.revision` with `-dirty` appended when the working tree had uncommitted changes — same shape `git describe` uses.

## End-to-end verification

```
$ go build -o /tmp/gophertrunk ./cmd/gophertrunk && /tmp/gophertrunk version
dev (sha=7ebea9a-dirty, built=2026-05-23T20:50:28Z)      ← was just "dev"

$ make build && ./bin/gophertrunk version
7ebea9a-dirty (sha=7ebea9a, built=2026-05-23T21:11:14Z)  ← unchanged
```

The `-dirty` marker on the bare `go build` is correct because the version.go edits in this PR are uncommitted at build time.

## Tests

- `TestExtractVCSPopulatesCommitAndTime` / `TestExtractVCSDirtyMarker` / `TestExtractVCSNoVCSInfo` drive the helper with synthetic `*debug.BuildInfo` so assertions don't depend on the test binary's actual VCS state.
- `TestStringFillsCommitFromVCSWhenUnset` exercises the full path through `String()` when the test binary has VCS info; skips cleanly when run with `-buildvcs=false`.
- `TestLdflagsBeatsVCSFallback` confirms the per-field precedence rule on the production path.

## Test plan

- [x] `go test ./internal/version/... -v` — all tests pass (one skip on `go test` builds without VCS info, which is expected)
- [x] `go test ./...` — 77 packages green, 0 failures
- [x] `go build ./cmd/gophertrunk && ./gophertrunk version` — output stamped from VCS
- [x] `make build && ./bin/gophertrunk version` — output unchanged (explicit `-ldflags` precedence preserved)
- [x] README updated with a paragraph explaining bare `go build` now stamps too, plus a "Recently shipped" entry

---
_Generated by [Claude Code](https://claude.ai/code/session_01BbEg4DKpBNuT8QWkgzyAgV)_