### PR TITLE
p25/phase1: dedup Motorola patch members on parse (#275)

### DIFF
--- a/internal/radio/p25/phase1/tsbk_vendor.go
+++ b/internal/radio/p25/phase1/tsbk_vendor.go
@@ -54,16 +54,40 @@ type MotorolaPatchGroup struct {
 }
 
 // AsMotorolaPatchGroup returns the structured patch group if the TSBK
-// is a Motorola group-regroup add, otherwise (zero, false).
+// is a Motorola group-regroup add, otherwise (zero, false). The wire
+// layout reserves three 16-bit member slots; Motorola's convention for
+// a fewer-than-three-member patch is to repeat the first member's ID
+// in the unused slots rather than zeroing them (issue #275 retest
+// against Mt Anakie observed `0x7EF5 0x7EF5 0x7EF5` for a one-member
+// patch). The accessor deduplicates so Patched reports the logical
+// member set, not the on-wire filler-slot replicas. Downstream
+// consumers (PatchRegistry, Grant.PatchedGroups, OpenMHz broadcaster,
+// call log) iterate Patched literally with no dedup of their own, so
+// the dedup at parse stops three identical IDs from polluting every
+// surface that talks about a single-member patch.
 func (t TSBK) AsMotorolaPatchGroup() (MotorolaPatchGroup, bool) {
 	if t.MFID != MFIDMotorola || t.Opcode != OpMotorolaPatchGroupAdd {
 		return MotorolaPatchGroup{}, false
 	}
 	g := MotorolaPatchGroup{SuperGroup: binary.BigEndian.Uint16(t.Payload[0:2])}
+	var seen [3]uint16
 	for i := 2; i+2 <= 8; i += 2 {
-		if tg := binary.BigEndian.Uint16(t.Payload[i : i+2]); tg != 0 {
-			g.Patched = append(g.Patched, tg)
+		tg := binary.BigEndian.Uint16(t.Payload[i : i+2])
+		if tg == 0 {
+			continue
 		}
+		dup := false
+		for _, s := range seen[:len(g.Patched)] {
+			if s == tg {
+				dup = true
+				break
+			}
+		}
+		if dup {
+			continue
+		}
+		seen[len(g.Patched)] = tg
+		g.Patched = append(g.Patched, tg)
 	}
 	return g, true
 }

--- a/internal/radio/p25/phase1/tsbk_vendor_test.go
+++ b/internal/radio/p25/phase1/tsbk_vendor_test.go
@@ -27,6 +27,67 @@ func TestAsMotorolaPatchGroupRoundTrip(t *testing.T) {
 	}
 }
 
+// TestAsMotorolaPatchGroupSingleMemberTriplicated pins the dedup
+// against the live Mt Anakie observation: a Motorola patch with one
+// active member encodes the same talkgroup ID in all three member
+// slots, and the parser must report Patched = [ID] not [ID, ID, ID].
+// Without dedup the duplicate triples flow through PatchRegistry,
+// Grant.PatchedGroups, and the OpenMHz broadcaster's patch_list JSON
+// — issue #275 retest log showed `members="[32501 32501 32501]"`
+// for what was semantically a one-member patch.
+func TestAsMotorolaPatchGroupSingleMemberTriplicated(t *testing.T) {
+	// Mt Anakie capture: super-group 33601 (0x8341), member 32501 (0x7EF5)
+	// triplicated.
+	payload := [8]byte{0x83, 0x41, 0x7E, 0xF5, 0x7E, 0xF5, 0x7E, 0xF5}
+	tsbk := TSBK{Opcode: OpMotorolaPatchGroupAdd, MFID: MFIDMotorola, Payload: payload}
+	got, ok := tsbk.AsMotorolaPatchGroup()
+	if !ok {
+		t.Fatal("AsMotorolaPatchGroup returned !ok")
+	}
+	if got.SuperGroup != 0x8341 {
+		t.Errorf("SuperGroup = %#x, want 0x8341", got.SuperGroup)
+	}
+	if len(got.Patched) != 1 || got.Patched[0] != 0x7EF5 {
+		t.Errorf("Patched = %v, want [0x7EF5] (single logical member)", got.Patched)
+	}
+}
+
+// TestAsMotorolaPatchGroupTwoDistinctOneRepeated covers the
+// two-member case where the second slot is repeated as filler in the
+// third: payload encodes ID-A, ID-B, ID-A — semantically two members.
+func TestAsMotorolaPatchGroupTwoDistinctOneRepeated(t *testing.T) {
+	payload := [8]byte{0x12, 0x34, 0x00, 0x0A, 0x00, 0x14, 0x00, 0x0A}
+	tsbk := TSBK{Opcode: OpMotorolaPatchGroupAdd, MFID: MFIDMotorola, Payload: payload}
+	got, ok := tsbk.AsMotorolaPatchGroup()
+	if !ok {
+		t.Fatal("AsMotorolaPatchGroup returned !ok")
+	}
+	if len(got.Patched) != 2 || got.Patched[0] != 10 || got.Patched[1] != 20 {
+		t.Errorf("Patched = %v, want [10, 20] (dedup of [10, 20, 10])", got.Patched)
+	}
+}
+
+// TestAsMotorolaPatchGroupThreeDistinct guards that the dedup does
+// not collapse a genuine three-member patch where each slot carries a
+// distinct talkgroup. Without this the dedup might over-fire.
+func TestAsMotorolaPatchGroupThreeDistinct(t *testing.T) {
+	payload := [8]byte{0x12, 0x34, 0x00, 0x0A, 0x00, 0x14, 0x00, 0x1E}
+	tsbk := TSBK{Opcode: OpMotorolaPatchGroupAdd, MFID: MFIDMotorola, Payload: payload}
+	got, ok := tsbk.AsMotorolaPatchGroup()
+	if !ok {
+		t.Fatal("AsMotorolaPatchGroup returned !ok")
+	}
+	want := []uint16{10, 20, 30}
+	if len(got.Patched) != 3 {
+		t.Fatalf("Patched = %v, want %v", got.Patched, want)
+	}
+	for i, w := range want {
+		if got.Patched[i] != w {
+			t.Errorf("Patched[%d] = %d, want %d", i, got.Patched[i], w)
+		}
+	}
+}
+
 func TestAsMotorolaPatchDelete(t *testing.T) {
 	tsbk := TSBK{Opcode: OpMotorolaPatchGroupDelete, MFID: MFIDMotorola,
 		Payload: [8]byte{0x05, 0x55}}


### PR DESCRIPTION
## Summary

er-imagery's [post-PR-#338 live test of Mt Anakie](https://github.com/MattCheramie/GopherTrunk/issues/275#issuecomment-4526552169) showed Motorola patch events emitting members as triples like `members="[32501 32501 32501]"` and `members="[201 201 201]"` — the same talkgroup ID repeated three times in what was semantically a one-member patch.

**Audit ruled out a parser bug**: `AsMotorolaPatchGroup` correctly reads three independent 16-bit fields at byte offsets [2:4]/[4:6]/[6:8], and the on-air payload bytes for the first Mt Anakie patch really are `83 41 7E F5 7E F5 7E F5` — `0x7EF5` triplicated. Motorola's convention for a fewer-than-three-member patch is to repeat the member ID in the unused slots rather than zeroing them, which is what `AsMotorolaPatchGroup`'s existing `tg != 0` zero-slot filter expects.

**Downstream-flow audit found this propagates as a real correctness issue**, not just a log curiosity:

- `internal/trunking/engine.go` (handlePatch) writes `p.Members` literally into `PatchGroup.Members`.
- `internal/trunking/patch.go` (PatchRegistry) stores it as a slice — no dedup.
- `MembersOf` returns a copy that flows into `Grant.PatchedGroups`.
- Grant → OpenMHz broadcaster JSON `patch_list`, `call_log` SQLite table, API stream, TUI all see the duplicate triples.

## Fix

Add a "not already seen" check alongside the existing zero-slot filter in `AsMotorolaPatchGroup`. Uses a small inline `[3]uint16` array as the seen-set (the upper bound is three slots; linear scan is faster than a hashmap allocation and zero-allocates).

## Mt Anakie replay verification

```
Before this PR (post-#339):
  p25: patch system=replay vendor=motorola super=33601 members="[32501 32501 32501]" add=true
  p25: patch system=replay vendor=motorola super=3215  members="[3210 3210 3210]"    add=true
  p25: patch system=replay vendor=motorola super=3202  members="[201 201 201]"       add=true

After this PR:
  p25: patch system=replay vendor=motorola super=33601 members=[32501] add=true
  p25: patch system=replay vendor=motorola super=3215  members=[3210]  add=true
  p25: patch system=replay vendor=motorola super=3202  members=[201]   add=true
```

Three distinct super-groups in the capture, each a one-member patch, all now reporting their single logical member.

## Tests

- `TestAsMotorolaPatchGroupSingleMemberTriplicated` pins the Mt Anakie payload bytes verbatim so a future regression on dedup names the byte that changed.
- `TestAsMotorolaPatchGroupTwoDistinctOneRepeated` covers the two-distinct-plus-repeat encoding (`[10, 20, 10] → [10, 20]`).
- `TestAsMotorolaPatchGroupThreeDistinct` guards against the dedup over-firing on a genuine three-member patch.
- Existing `TestAsMotorolaPatchGroupRoundTrip` unchanged; still passes (uses two distinct members).

No downstream code changed. PatchRegistry, OpenMHz, call_log, API, and TUI all benefit transparently from the cleaner upstream slice.

## Test plan

- [x] `go test ./internal/radio/p25/phase1/... -count=1 -v -run AsMotorolaPatchGroup` — four tests pass (one existing + three new)
- [x] `go test ./... -count=1` — 77 packages green, 0 failures
- [x] `gophertrunk replay -in mt-anakie-420087500-960k-g49.iq -sample-rate 960000 -freq 420087500 -demod c4fm` — `p25: patch` log lines now report single-member patches as `members=[ID]`, not `[ID ID ID]`

---
_Generated by [Claude Code](https://claude.ai/code/session_01BbEg4DKpBNuT8QWkgzyAgV)_