### PR TITLE
fix(api): serve helpful 404 + add `make dist` so daemon embeds the SPA (#290)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,11 +10,17 @@ reviewable pieces.
 ```sh
 git clone https://github.com/mattcheramie/gophertrunk.git
 cd gophertrunk
-make build         # produces ./bin/gophertrunk
+make build         # Go-only — fast iteration; daemon shows a helpful 404 at / until the SPA is bundled
+make dist          # SPA + Go — single binary that serves the operator web console at /
 make test          # unit tests (fast, < 30 s)
 make integration   # daemon end-to-end tests (no SDR required)
 make vet           # static analysis
 ```
+
+Use `make build` while iterating on Go code (no npm needed). Use
+`make dist` when you want a daemon binary that serves the SPA at
+`/` — it runs `make web-build` first so the `//go:embed all:dist`
+snapshot picks up a real bundle.
 
 You need Go 1.24+ — no C toolchain (`CGO_ENABLED=0` everywhere),
 no `librtlsdr`, no `libusb`. macOS / Windows / Linux all build the
@@ -70,7 +76,8 @@ existing code; a few items worth calling out:
 
 | Target | Purpose |
 | --- | --- |
-| `make build` | Build `bin/gophertrunk` (the daemon + CLI) |
+| `make build` | Build `bin/gophertrunk` (Go-only — fast; daemon serves a helpful 404 at `/` until the SPA is bundled) |
+| `make dist` | Build `bin/gophertrunk` with the operator console embedded (`make web-build` then `make build`) |
 | `make test` | Unit tests, `-race`, `-count=1` |
 | `make integration` | Daemon end-to-end test (no SDR) — exercises the full IQ-replay path |
 | `make integration-cc-<proto>` | Per-protocol "lights up live trunked reception" check (P25 P1 / P25 P2 / DMR / NXDN / dPMR / EDACS / Motorola / LTR / MPT 1327 / TETRA / YSF) |

--- a/Makefile
+++ b/Makefile
@@ -9,12 +9,25 @@ TAGS    ?=
 GO      ?= go
 PKGS    := ./...
 
-.PHONY: all build test test-dvsi test-integration integration integration-cc integration-cc-grant integration-cc-nxdn integration-cc-dmr integration-cc-dpmr integration-cc-edacs integration-cc-motorola integration-cc-tetra integration-cc-p25p2 integration-cc-mpt1327 integration-cc-ltr integration-cc-ysf lint tidy vet vulncheck licenses clean run proto cross-build release-archives release-dry-run web-build web-dev web-clean web-test
+.PHONY: all build dist test test-dvsi test-integration integration integration-cc integration-cc-grant integration-cc-nxdn integration-cc-dmr integration-cc-dpmr integration-cc-edacs integration-cc-motorola integration-cc-tetra integration-cc-p25p2 integration-cc-mpt1327 integration-cc-ltr integration-cc-ysf lint tidy vet vulncheck licenses clean run proto cross-build release-archives release-dry-run web-build web-dev web-clean web-test
 
 all: build
 
+# build produces a Go-only daemon binary. The SPA embed
+# (`//go:embed all:dist` in web/embed.go) only picks up an SPA bundle
+# that's already on disk at compile time; running `make build` on a
+# fresh checkout (or after `make web-clean`) produces a daemon that
+# returns a "web console wasn't bundled" 404 at `/`. Use `make dist`
+# to build a daemon that serves its own SPA at `/`.
 build:
 	$(GO) build -tags "$(TAGS)" -ldflags "$(LDFLAGS)" -o bin/gophertrunk ./cmd/gophertrunk
+
+# dist is the operator-facing build: it rebuilds the SPA into web/dist
+# first, then the Go binary, so the embedded console is always in sync
+# with the daemon. Use this when you want a single binary that serves
+# the web UI at `/`. Pure-Go contributors who don't need the UI can
+# keep using `make build`.
+dist: web-build build
 
 test:
 	$(GO) test -tags "$(TAGS)" -race -count=1 $(PKGS)
@@ -188,10 +201,14 @@ licenses:
 # the project uses purego for every system FFI (ALSA / WASAPI /
 # CoreAudio / IOKit / WinUSB) and modernc.org/sqlite for the call
 # log, so no cgo is required. Each output lands under dist/.
+#
+# Depends on `web-build` so every shipped binary embeds the operator
+# console; without that prerequisite the SPA `//go:embed` would
+# snapshot an empty `web/dist/` and the daemon would 404 at `/`.
 GOOSES   ?= linux darwin windows
 GOARCHES ?= amd64 arm64
 
-cross-build:
+cross-build: web-build
 	@mkdir -p dist
 	@for os in $(GOOSES); do \
 	    for arch in $(GOARCHES); do \
@@ -211,7 +228,10 @@ cross-build:
 #   make release-dry-run VERSION=v0.99.0
 # to exercise a prerelease build; default VERSION picks up the same
 # git-describe value the release workflow would compute.
-release-dry-run:
+#
+# Depends on `web-build` so the rehearsed binary embeds the operator
+# console — matches what `cross-build` and the release workflow ship.
+release-dry-run: web-build
 	@echo "→ Rehearsing release build for version $(VERSION)"
 	@echo "→ COMMIT=$(COMMIT) BUILD_TIME=$(BUILD_TIME)"
 	@rm -rf dist/dry-run
@@ -241,7 +261,7 @@ release-archives:
 clean:
 	rm -rf bin/ dist/
 
-run: build
+run: dist
 	./bin/gophertrunk
 
 # --- Web UI -----------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -2387,7 +2387,8 @@ and DVB-driver blacklisting on Linux.
 ### Build, test, run
 
 ```sh
-make build                    # produces ./bin/gophertrunk (preferred — injects -ldflags version stamp)
+make dist                     # SPA + daemon — single binary that serves the web console at /
+make build                    # produces ./bin/gophertrunk (Go-only — daemon shows a helpful 404 at / until bundled)
 make test                     # go test -race ./...
 make web-test                 # Vitest + React Testing Library against the SPA panels
 make integration              # boots the wired daemon end-to-end (no SDR needed)

--- a/docs/launcher.md
+++ b/docs/launcher.md
@@ -69,15 +69,19 @@ file:///path/to/index.html#server=http://localhost:8080
 
 ### Embedded SPA
 
-When the daemon was built with `make web-build` before `go build`
-(the default in release archives), the SPA is baked into the binary
-via Go's `embed` package and the API server registers it at `/`.
-Client-side routes (`/scanner`, `/settings`, `/import`, …) fall back
-to `index.html` so React-Router takes over.
+When the daemon was built with `make dist` (which chains
+`make web-build` and `make build`, the default in release archives),
+the SPA is baked into the binary via Go's `embed` package and the API
+server registers it at `/`. Client-side routes (`/scanner`,
+`/settings`, `/import`, …) fall back to `index.html` so React-Router
+takes over.
 
-Fresh checkouts without `make web-build` use the sibling-directory
-discovery above instead — `web/dist/` contains only a `.gitkeep`
-sentinel in that case and the embedded `HasAssets()` reports false.
+Fresh checkouts built with plain `make build` (or a bare `go build`)
+skip the SPA and use the sibling-directory discovery above instead —
+`web/dist/` contains only a `.gitkeep` sentinel in that case and the
+embedded `HasAssets()` reports false. The daemon also serves a
+helpful HTML 404 at `/` explaining the fix, instead of stdlib's
+blank `404 page not found`.
 
 `xdg-open` is used on Linux, `open` on macOS, and `rundll32
 url.dll,FileProtocolHandler` on Windows. Headless hosts that don't

--- a/docs/web.md
+++ b/docs/web.md
@@ -61,10 +61,15 @@ On a headless host (SSH session, no `$DISPLAY`) the launcher prints
 the URL + a hint instead of trying to launch a browser, so a remote
 operator can open the URL from their laptop.
 
-If you're building the daemon yourself, run `make web-build` (or
-`cd web && npm run build`) before `go build` so `web/dist/` is
-populated for the embed. Without the embed the launcher falls back
-to the standalone-bundle workflow below.
+If you're building the daemon yourself, use **`make dist`** — it
+runs `make web-build` and `make build` in the right order so the
+`//go:embed all:dist` snapshot in `web/embed.go` picks up a real
+bundle and the daemon serves the SPA at `/`. Plain `make build`
+(or a bare `go build`) skips the SPA build, so the embed contains
+only the `.gitkeep` sentinel and the daemon answers a helpful 404
+at `/` explaining the fix. The REST and WebSocket APIs work
+normally in both cases — only the embedded SPA differs. The
+launcher's standalone-bundle fallback (below) also still works.
 
 ## 1. Get the bundle
 
@@ -291,7 +296,8 @@ The web console builds with Vite. The daemon's `Makefile` wraps
 the npm scripts:
 
 ```bash
-make web-build      # produces web/dist/ — the shipped artifact
+make dist           # SPA + daemon — the operator binary that serves / itself
+make web-build      # produces web/dist/ — the shipped artifact (consumed by `make dist`)
 make web-dev        # Vite dev server on :5173 with proxy to :8080
 make web-clean      # removes node_modules/, dist/, dev-dist/
 ```

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -682,11 +682,19 @@ func (s *Server) routes() *http.ServeMux {
 	// Embedded SPA at "/" — served only when the daemon was linked
 	// against a populated web/dist embed. SPA history routes
 	// (/scanner, /settings, /import, ...) fall back to index.html
-	// so React-Router takes over on the client side.
+	// so React-Router takes over on the client side. When the embed
+	// is empty (the binary was built without `make web-build` first),
+	// a fallback handler answers exactly `GET /` with an explanatory
+	// 404 instead of stdlib's blank "404 page not found".
+	embeddedSPA := false
 	if s.webAssets != nil {
 		if _, err := fs.Stat(s.webAssets, "index.html"); err == nil {
 			mux.Handle("GET /", s.spaHandler())
+			embeddedSPA = true
 		}
+	}
+	if !embeddedSPA {
+		mux.Handle("GET /{$}", s.spaMissingHandler())
 	}
 
 	return mux
@@ -721,6 +729,59 @@ func (s *Server) spaHandler() http.Handler {
 		fileSrv.ServeHTTP(w, r2)
 	})
 }
+
+// spaMissingHandler answers exactly `GET /` with an HTML 404 that
+// tells the operator how to bundle the SPA. Registered when the
+// daemon binary was built without `make web-build` first, so the
+// `//go:embed all:dist` snapshot contains only the `.gitkeep`
+// sentinel. Status stays 404 so proxies/curl/healthchecks still
+// treat the resource as missing — only the body changes.
+func (s *Server) spaMissingHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(spaMissingBody))
+	})
+}
+
+const spaMissingBody = `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>GopherTrunk — web console not bundled</title>
+<style>
+  body { font-family: system-ui, sans-serif; max-width: 40rem; margin: 4rem auto; padding: 0 1rem; color: #1a1a1a; line-height: 1.5; }
+  code, pre { background: #f4f4f5; padding: 0.1rem 0.3rem; border-radius: 3px; font-size: 0.95em; }
+  pre { padding: 0.8rem 1rem; overflow-x: auto; }
+  h1 { font-size: 1.4rem; }
+  a { color: #2563eb; }
+</style>
+</head>
+<body>
+<h1>Web console wasn&rsquo;t bundled into this daemon</h1>
+<p>
+  The daemon&rsquo;s API is healthy (try
+  <a href="/api/v1/health"><code>/api/v1/health</code></a>),
+  but the operator console at <code>/</code> wasn&rsquo;t embedded into this
+  binary. The Go <code>//go:embed</code> directive snapshots
+  <code>web/dist/</code> at compile time, and this build was produced before
+  the SPA was built.
+</p>
+<p>To fix it, rebuild with the SPA bundled in:</p>
+<pre>make dist
+./bin/gophertrunk</pre>
+<p>
+  Or, equivalently:
+  <code>make web-build &amp;&amp; make build</code>.
+  See <code>docs/web.md</code> for details.
+</p>
+<p>
+  The REST and WebSocket APIs continue to work normally — only the
+  embedded SPA is missing.
+</p>
+</body>
+</html>
+`
 
 // gate wraps a mutation handler in the auth middleware. The middleware
 // returns 401 when a token is required but missing / wrong, 403 when

--- a/internal/api/spa_test.go
+++ b/internal/api/spa_test.go
@@ -120,7 +120,7 @@ func TestSPA_APIRoutesNotShadowed(t *testing.T) {
 	}
 }
 
-func TestSPA_NoEmbedSkipsRoute(t *testing.T) {
+func TestSPA_NoEmbedReturnsHelpfulMessage(t *testing.T) {
 	bus := events.NewBus(8)
 	defer bus.Close()
 	base, teardown := mkServer(t, ServerOptions{Bus: bus})
@@ -133,6 +133,44 @@ func TestSPA_NoEmbedSkipsRoute(t *testing.T) {
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusNotFound {
 		t.Fatalf("status=%d want 404 (no embed configured)", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); ct == "" || !bytesContains([]byte(ct), "text/html") {
+		t.Errorf("Content-Type=%q want text/html", ct)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	for _, want := range []string{"make dist", "web console", "/api/v1/health"} {
+		if !bytesContains(body, want) {
+			t.Errorf("missing-embed body does not mention %q; body=%q", want, string(body))
+		}
+	}
+}
+
+// TestSPA_NoEmbedDoesNotShadowSubpaths confirms the fallback handler
+// only attaches to exactly `GET /` — sibling paths like `/scanner`
+// must still 404 normally (no fake SPA fallback), and `/api/v1/...`
+// must continue to dispatch to its real handler.
+func TestSPA_NoEmbedDoesNotShadowSubpaths(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	base, teardown := mkServer(t, ServerOptions{Bus: bus, Version: "test"})
+	defer teardown()
+
+	resp, err := http.Get(base + "/scanner")
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("/scanner status=%d want 404", resp.StatusCode)
+	}
+
+	resp, err = http.Get(base + "/api/v1/health")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("/api/v1/health status=%d want 200 (missing-embed handler must not shadow APIs)", resp.StatusCode)
 	}
 }
 

--- a/web/README.md
+++ b/web/README.md
@@ -96,6 +96,7 @@ autoplay rules).
 # from the repository root:
 make web-dev    # starts Vite at http://127.0.0.1:5173 with proxy to :8080
 make web-build  # produces web/dist/ — the shipping artifact
+make dist       # SPA + daemon — single binary that serves the console at / (runs web-build then build)
 make web-clean  # removes node_modules/, dist/, and SW dev-dist/
 
 # From web/ directly:
@@ -103,6 +104,12 @@ npm install     # one-time
 npm test        # Vitest + React Testing Library against panels
 npm run typecheck
 ```
+
+`make build` on its own is Go-only and skips the SPA — useful while
+iterating on backend code. Use `make dist` when you want a daemon
+binary that serves the operator console at `/`; the `//go:embed
+all:dist` snapshot in `web/embed.go` is captured at Go compile time,
+so the SPA bundle must exist on disk *before* `go build` runs.
 
 Tested with Node.js 20 LTS and npm 10. Older Node versions may
 work but aren't in CI.


### PR DESCRIPTION
Closes the last item on #290 — er-imagery's [2026-05-23 retest comment](https://github.com/MattCheramie/GopherTrunk/issues/290#issuecomment-4526536230) confirmed the React #185 crash is fixed but reported the daemon still answers `404 page not found` at `http://192.168.1.9:8080/` after `make web-build`, forcing them to serve the SPA separately via `python3 -m http.server`.

## Root cause

`//go:embed all:dist` in `web/embed.go:19` snapshots `web/dist/` **at Go compile time**. The Makefile's `build:` target has no dependency on `web-build`, and the same is true for `cross-build` and `release-dry-run`. Unless the operator runs `make web-build` *before* every `go build`, the daemon embeds only the `.gitkeep` sentinel → `web.HasAssets()` returns false → `daemon.go:771` skips `opts.WebAssets` → `server.go:686` skips registering `GET /` → stdlib's default blank 404. The same ordering bug threatens release artifacts.

## Changes

**Build orchestration (`Makefile`)**
- New `make dist` target: `web-build` → `build`. The operator-facing target — single binary that serves the SPA at `/`.
- `cross-build`, `release-dry-run`, and `run` now depend on `web-build` so release artifacts always carry the SPA and `make run` always launches a UI-capable daemon.
- `make build` itself stays Go-only so pure-Go contributors and CI keep their fast path.

**Runtime visibility (`internal/api/server.go`)**
- When the embed is empty, a fallback handler answers exactly `GET /{$}` with HTTP 404 + an HTML body that explains: build with `make dist`, or `make web-build && make build`. Status stays 404 so proxies/curl/healthchecks behave the same; only the response body changes. Subpaths like `/scanner` and `/api/*` are untouched (the `{$}` end-of-path token confines the pattern to `/` exactly).

**Tests (`internal/api/spa_test.go`)**
- Renamed `TestSPA_NoEmbedSkipsRoute` → `TestSPA_NoEmbedReturnsHelpfulMessage`. Keeps the 404 status assertion, adds checks for `Content-Type: text/html` and substrings `make dist`, `web console`, `/api/v1/health`.
- New `TestSPA_NoEmbedDoesNotShadowSubpaths` confirms `/scanner` still returns a plain 404 and `/api/v1/health` still returns 200 when the missing-embed handler is mounted.

**Docs**
- `README.md`, `CONTRIBUTING.md`, `docs/web.md`, `docs/launcher.md`, `web/README.md` updated to surface the new `make dist` workflow and the `make build` vs `make dist` split.

## Verification

```sh
go vet ./...                             # clean
go test -count=1 ./internal/api/...      # all SPA tests pass, including the two new/renamed cases
make build                               # builds clean
```

Suggested field check once merged: ask er-imagery to pull, `make dist`, and confirm `http://192.168.1.9:8080/` loads the SPA without the separate Python http.server.

https://claude.ai/code/session_01TvgnkvVgVuv7RhJhLxy2Ud

---
_Generated by [Claude Code](https://claude.ai/code/session_01TvgnkvVgVuv7RhJhLxy2Ud)_