### PR TITLE
web/systems: explain empty WACN/SystemID/RFSS/Site in detail modal

### DIFF
--- a/web/src/App.panels.test.tsx
+++ b/web/src/App.panels.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 
 // Regression coverage for issue #290. The existing App.test.tsx mocks
@@ -190,5 +191,42 @@ describe("App panel mounting (issue #290 regression)", () => {
     await screen.findByText("Metro P25");
     expect(screen.getByText("County Trunk")).toBeInTheDocument();
     expect(screen.queryByText(/Something went wrong/i)).toBeNull();
+  });
+
+  // Empty WACN/SystemID/RFSS/Site in the Systems detail modal should
+  // be replaced with a hunt-state aware hint rather than a bare dash
+  // — otherwise operators can't tell config from "not yet decoded".
+  it("explains empty network identity fields in the Systems detail modal", async () => {
+    vi.mocked(api.systems).mockResolvedValue([
+      {
+        name: "Metro P25",
+        protocol: "p25",
+        control_channels: [851_000_000, 852_000_000],
+      },
+    ]);
+    vi.mocked(api.scanner).mockResolvedValue(IN_HUNT_SCANNER);
+
+    render(
+      <ErrorBoundary>
+        <MemoryRouter initialEntries={["/systems"]}>
+          <App />
+        </MemoryRouter>
+      </ErrorBoundary>,
+    );
+
+    const row = await screen.findByText("Metro P25");
+    await userEvent.click(row);
+
+    const dialog = await screen.findByRole("dialog");
+    expect(
+      within(dialog).getByText("Network identity (decoded live)"),
+    ).toBeInTheDocument();
+    // Four identity fields all share the same hunt-state hint.
+    expect(
+      within(dialog).getAllByText("Hunting control channel"),
+    ).toHaveLength(4);
+    // No em-dash fallback inside the modal — every empty cell now
+    // carries an explanatory hint.
+    expect(within(dialog).queryByText("—")).toBeNull();
   });
 });

--- a/web/src/components/DetailModal.tsx
+++ b/web/src/components/DetailModal.tsx
@@ -62,25 +62,30 @@ export function DetailModal({ title, subtitle, onClose, children }: Props) {
 }
 
 // DetailField renders one label/value pair inside a DetailModal.
+// Pass `emptyHint` to replace the default em-dash with context-specific
+// copy (e.g. "Awaiting status broadcasts") when the value is missing.
 export function DetailField({
   label,
   value,
   mono,
+  emptyHint,
 }: {
   label: string;
   value: React.ReactNode;
   mono?: boolean;
+  emptyHint?: React.ReactNode;
 }) {
+  const empty = value === null || value === undefined || value === "";
   return (
     <div>
       <p className="text-xs uppercase tracking-wider text-muted">{label}</p>
-      <p
-        className={`text-sm mt-0.5 ${mono ? "font-mono" : ""}`}
-        // Empty fields render a clear em-dash so the operator sees the
-        // gap rather than an invisibly-collapsed row.
-      >
-        {value === null || value === undefined || value === "" ? (
-          <span className="text-muted">—</span>
+      <p className={`text-sm mt-0.5 ${mono && !empty ? "font-mono" : ""}`}>
+        {empty ? (
+          emptyHint != null ? (
+            <span className="text-muted italic">{emptyHint}</span>
+          ) : (
+            <span className="text-muted">—</span>
+          )
         ) : (
           value
         )}

--- a/web/src/panels/Systems.tsx
+++ b/web/src/panels/Systems.tsx
@@ -2,28 +2,48 @@ import { useEffect, useMemo, useState } from "react";
 import { api } from "../api/client";
 import { Column, DataTable } from "../components/DataTable";
 import { DetailField, DetailModal } from "../components/DetailModal";
-import type { SystemDTO } from "../api/types";
+import type { SystemDTO, SystemHuntStatusDTO } from "../api/types";
 import { selectClientConfig, useShared } from "../store/shared";
 
 const POLL_INTERVAL_MS = 10_000;
+
+// Network identity (WACN/System ID/RFSS/Site) is populated from
+// decoded P25 TSBKs 0x3A/0x3B, not config. Translate the live hunt
+// state into operator-facing copy so an empty cell explains itself.
+function identityEmptyHint(hunt: SystemHuntStatusDTO | undefined): string {
+  if (!hunt) return "Scanner offline";
+  switch (hunt.state) {
+    case "locked":
+      return "Awaiting status broadcasts";
+    case "hunting":
+      return "Hunting control channel";
+    default:
+      return hunt.state ? `System not locked (${hunt.state})` : "System not locked";
+  }
+}
 
 export function Systems() {
   const cfg = useShared(selectClientConfig);
   const systems = useShared((s) => s.systems);
   const setSystems = useShared((s) => s.setSystems);
+  const scanner = useShared((s) => s.scanner);
+  const setScanner = useShared((s) => s.setScanner);
   const [selected, setSelected] = useState<SystemDTO | null>(null);
   const [filter, setFilter] = useState("");
 
   useEffect(() => {
     let cancel = false;
     const refresh = async () => {
-      try {
-        const data = await api.systems(cfg);
-        if (!cancel) setSystems(data);
-      } catch {
-        // Toast strip surfaces request errors elsewhere; keep the
-        // previous snapshot on the screen rather than blanking it.
-      }
+      // Poll the scanner snapshot alongside systems so the detail
+      // modal can translate empty WACN/SystemID/RFSS/Site into a
+      // hunt-state hint even when the Scanner panel isn't mounted.
+      const [sysRes, scanRes] = await Promise.allSettled([
+        api.systems(cfg),
+        api.scanner(cfg),
+      ]);
+      if (cancel) return;
+      if (sysRes.status === "fulfilled") setSystems(sysRes.value);
+      if (scanRes.status === "fulfilled") setScanner(scanRes.value);
     };
     refresh();
     const t = window.setInterval(refresh, POLL_INTERVAL_MS);
@@ -31,7 +51,7 @@ export function Systems() {
       cancel = true;
       window.clearInterval(t);
     };
-  }, [cfg, setSystems]);
+  }, [cfg, setSystems, setScanner]);
 
   const filtered = useMemo(() => {
     if (!filter.trim()) return systems;
@@ -132,16 +152,43 @@ export function Systems() {
                 : null
             }
           />
-          <div className="grid grid-cols-2 gap-3">
-            <DetailField label="WACN" mono value={selected.wacn ?? null} />
-            <DetailField
-              label="System ID"
-              mono
-              value={selected.system_id ?? null}
-            />
-            <DetailField label="RFSS" mono value={selected.rfss ?? null} />
-            <DetailField label="Site" mono value={selected.site ?? null} />
-          </div>
+          {(() => {
+            const hunt = scanner?.systems.find((h) => h.name === selected.name);
+            const hint = identityEmptyHint(hunt);
+            return (
+              <div>
+                <p className="text-xs uppercase tracking-wider text-muted mb-2">
+                  Network identity (decoded live)
+                </p>
+                <div className="grid grid-cols-2 gap-3">
+                  <DetailField
+                    label="WACN"
+                    mono
+                    value={selected.wacn ?? null}
+                    emptyHint={hint}
+                  />
+                  <DetailField
+                    label="System ID"
+                    mono
+                    value={selected.system_id ?? null}
+                    emptyHint={hint}
+                  />
+                  <DetailField
+                    label="RFSS"
+                    mono
+                    value={selected.rfss ?? null}
+                    emptyHint={hint}
+                  />
+                  <DetailField
+                    label="Site"
+                    mono
+                    value={selected.site ?? null}
+                    emptyHint={hint}
+                  />
+                </div>
+              </div>
+            );
+          })()}
         </DetailModal>
       )}
     </div>


### PR DESCRIPTION
Those four identity fields are populated from decoded P25 status
broadcasts (TSBK 0x3A/0x3B), not config, so they're empty until the
control channel is locked and the broadcasts arrive. The detail modal
just showed a bare em-dash, leaving operators unable to tell config
mistakes from "not yet decoded". Translate the live scanner hunt
state ("hunting" / "locked" / other) into per-field hint copy via a
new DetailField emptyHint prop, and pull the scanner snapshot from
the Systems panel's poll so the hint stays correct without visiting
the Scanner page first.

https://claude.ai/code/session_01QwhNkFwP6Vssd7BTm9TwBz