### PR TITLE
p25/phase1: wire IdentifierUpdateVUHF (opcode 0x34) into the dispatcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ for tagged releases.
 
 ## [Unreleased]
 
+- **P25 Phase 1 `IdentifierUpdateVUHF` (TSBK opcode 0x34) now wired
+  through the dispatcher — UHF P25 sites resolve voice grants without
+  stalling on `no-bandplan`.** The 0x34 opcode constant was already
+  defined in `internal/radio/p25/phase1/opcodes.go`, but it had no
+  parser and no `switch` case, so `IDEN_UP_VUHF` TSBKs arriving from a
+  VHF / UHF site were silently dropped — the `BandPlan` stayed empty
+  and every subsequent `GroupVoiceChannelGrant` emitted
+  `decode.error stage=no-bandplan`. The CC lock itself worked fine; the
+  failure was downstream of the lock and invisible without inspecting
+  the events bus. `ParseIdentifierUpdateVUHF` /
+  `AssembleIdentifierUpdateVUHF` decode the VHF/UHF bit packing per
+  TIA-102.AABF Table 14a (4-bit `BW` lookup → 6.25 / 12.5 kHz per
+  Table 16, 1-bit sign + 13-bit magnitude `TxOffset` whose unit is the
+  channel step rather than a fixed 250 kHz, plus the same 10-bit
+  `STEP × 125 Hz` and 32-bit `FREQ × 5 Hz` as the 0x3D variant) and
+  populate the existing `IdentifierUpdate` struct, so
+  `BandPlan.Apply` / `BandPlan.Frequency` need no change. Cross-checked
+  bit-by-bit against OP25 (`op25/gr-op25_repeater/apps/trunking.py`
+  `iden_up vhf uhf`) and SDRTrunk (`FrequencyBandUpdateVUHF.java`).
+  Round-trip tests cover both negative offset (the typical UHF -5 MHz
+  case) and positive offset (sign-bit coverage); a new end-to-end test
+  feeds a VUHF `IdentifierUpdate` plus a subsequent grant through the
+  real `ControlChannel.Process` chain and asserts the grant resolves
+  to the expected frequency rather than falling to `decode.error`.
+
 ## [v0.2.0] — 2026-05-23
 
 SDR-fleet + DMR-voice + P25-lock release. The pure-Go SDR

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Full per-OS install (Windows installer / macOS Apple Silicon / Linux aarch64): *
 
 ## Features
 
-**Trunked-radio control-channel decoders** — P25 Phase 1 + Phase 2 (full TIA-102 chain with RS(24,16,9) outer verifier + PN44 scrambler), DMR Tier II + Tier III, NXDN, Motorola Type II / SmartZone, EDACS / GE-Marc, LTR, MPT 1327, dPMR Mode 3, TETRA TMO. All run live on IQ via `internal/scanner/ccdecoder` with per-protocol FEC chains default-on.
+**Trunked-radio control-channel decoders** — P25 Phase 1 + Phase 2 (full TIA-102 chain with RS(24,16,9) outer verifier + PN44 scrambler; both the 0x3D 700/800/900 MHz and 0x34 VHF/UHF `IdentifierUpdate` band-plan variants are wired into the dispatcher, so UHF P25 sites resolve grants without a no-bandplan stall), DMR Tier II + Tier III, NXDN, Motorola Type II / SmartZone, EDACS / GE-Marc, LTR, MPT 1327, dPMR Mode 3, TETRA TMO. All run live on IQ via `internal/scanner/ccdecoder` with per-protocol FEC chains default-on.
 
 **Amateur-radio digital modes** — D-STAR (JARL DV-mode K=5 R=½ Viterbi + PN15 scrambler + 22×30 interleaver) and Yaesu System Fusion (C4FM + FICH trellis).
 

--- a/internal/radio/p25/phase1/control.go
+++ b/internal/radio/p25/phase1/control.go
@@ -20,8 +20,9 @@ import (
 // dibits, deinterleave + Viterbi-decode the next 98-dibit TSBK block,
 // validate the CRC trailer, and dispatch on the parsed opcode.
 //
-//   - OpIdentifierUpdate (0x3D) populates the band-plan slot for its
-//     Channel ID.
+//   - OpIdentifierUpdate (0x3D) and OpIdentifierUpdateVUHF (0x34)
+//     populate the band-plan slot for their Channel ID; 0x3D carries
+//     the 700/800/900 MHz packing, 0x34 carries the VHF/UHF packing.
 //   - OpGroupVoiceChannelGrant (0x00) parses the channel/group/source
 //     payload, looks up the frequency in the band plan, and publishes
 //     a trunking.Grant with Protocol="p25" on the bus.
@@ -713,6 +714,14 @@ func (c *ControlChannel) dispatchTSBK(t TSBK, nac uint16, metric int) {
 			"nac", nac, "id", u.ChannelID,
 			"base_hz", u.BaseHz, "spacing_hz", u.SpacingHz,
 			"tx_offset_hz", u.TxOffsetHz)
+	case OpIdentifierUpdateVUHF:
+		u := ParseIdentifierUpdateVUHF(t.Payload)
+		c.bandPlan.Apply(u)
+		c.log.Debug("p25: identifier update (VUHF)",
+			"nac", nac, "id", u.ChannelID,
+			"base_hz", u.BaseHz, "spacing_hz", u.SpacingHz,
+			"tx_offset_hz", u.TxOffsetHz,
+			"bandwidth_hz", u.BandwidthHz)
 	case OpGroupVoiceChannelGrant:
 		c.publishGroupGrant(ParseGroupVoiceChannelGrant(t.Payload), nac)
 	case OpGroupVoiceChannelUpdate:

--- a/internal/radio/p25/phase1/control_test.go
+++ b/internal/radio/p25/phase1/control_test.go
@@ -253,6 +253,79 @@ func TestControlChannelAppliesIdentifierUpdateAndPublishesGrant(t *testing.T) {
 	}
 }
 
+func TestControlChannelAppliesVUHFIdentifierUpdateAndPublishesGrant(t *testing.T) {
+	bus := events.NewBus(16)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	// UHF P25 site (the scenario that motivated wiring opcode 0x34):
+	// IdentifierUpdateVUHF for ChannelID 1, base 460 MHz, 12.5 kHz
+	// spacing, -5 MHz tx offset; followed by a GroupVoiceChannelGrant
+	// on (ID=1, Number=16), which must resolve to 460.2 MHz via the
+	// new dispatcher path.
+	identTSBK := TSBK{LB: false, Opcode: OpIdentifierUpdateVUHF}
+	identTSBK.Payload = AssembleIdentifierUpdateVUHF(IdentifierUpdate{
+		ChannelID:   1,
+		BandwidthHz: 12_500,
+		SpacingHz:   12_500,
+		TxOffsetHz:  -5_000_000,
+		BaseHz:      460_000_000,
+	})
+
+	grantPayload := [8]byte{
+		0x00,                  // service options: cleartext, non-emergency
+		(1 << 4) | 0x00, 0x10, // channel = ID 1, number 0x010 (=16)
+		0x12, 0x34, // group address 0x1234
+		0xAB, 0xCD, 0xEF, // source ID 0xABCDEF
+	}
+	grantTSBK := TSBK{LB: true, Opcode: OpGroupVoiceChannelGrant, Payload: grantPayload}
+
+	stream1 := buildLockedStreamWithTSBK(10, 0x293, DUIDTrunkingSignaling, identTSBK)
+	stream2 := buildLockedStreamWithTSBK(0, 0x293, DUIDTrunkingSignaling, grantTSBK)
+
+	cc := New(Options{
+		Bus:         bus,
+		SystemName:  "UHF-Site",
+		FrequencyHz: 461_437_500,
+		Now:         func() time.Time { return time.Unix(1_700_000_000, 0).UTC() },
+	})
+	cc.Process(stream1, 0)
+	cc.Process(stream2, len(stream1))
+
+	var got *trunking.Grant
+	deadline := time.After(time.Second)
+	for got == nil {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind == events.KindDecodeError {
+				de := ev.Payload.(events.DecodeError)
+				if de.Stage == "no-bandplan" {
+					t.Fatal("VUHF IdentifierUpdate was not applied: grant fell to no-bandplan")
+				}
+			}
+			if ev.Kind == events.KindGrant {
+				g := ev.Payload.(trunking.Grant)
+				got = &g
+			}
+		case <-deadline:
+			t.Fatal("no grant event published")
+		}
+	}
+	if got.System != "UHF-Site" || got.Protocol != "p25" {
+		t.Errorf("identity = %s/%s", got.System, got.Protocol)
+	}
+	if got.GroupID != 0x1234 || got.SourceID != 0xABCDEF {
+		t.Errorf("group/source = %d/%d, want 4660/11259375", got.GroupID, got.SourceID)
+	}
+	if got.ChannelID != 1 || got.ChannelNum != 0x010 {
+		t.Errorf("channel = %d.%d, want 1.16", got.ChannelID, got.ChannelNum)
+	}
+	if got.FrequencyHz != 460_200_000 {
+		t.Errorf("freq = %d, want 460_200_000", got.FrequencyHz)
+	}
+}
+
 // TestControlChannelLocksAndGrantsAcrossSmallChunks feeds a two-frame
 // stream (IdentifierUpdate then GroupVoiceChannelGrant) through Process
 // in 19-dibit batches — the dibit count a real RTL-SDR's 16 KiB USB

--- a/internal/radio/p25/phase1/identifier.go
+++ b/internal/radio/p25/phase1/identifier.go
@@ -5,24 +5,29 @@ import (
 	"fmt"
 )
 
-// IdentifierUpdate carries a P25 IDENT_UP TSBK (opcode 0x3D), the
-// "Identifier Update" announcement that defines the band plan for one
-// channel-ID slot. A site repeats these periodically alongside its
-// status broadcasts; the receiver accumulates them and uses each slot
-// to translate a (Channel ID, Channel Number) pair from a voice grant
-// into a downlink frequency.
+// IdentifierUpdate carries a P25 IDENT_UP TSBK announcement that
+// defines the band plan for one channel-ID slot. A site repeats these
+// periodically alongside its status broadcasts; the receiver
+// accumulates them and uses each slot to translate a (Channel ID,
+// Channel Number) pair from a voice grant into a downlink frequency.
 //
-// Field units come straight from TIA-102.AABF Table 14:
+// Two on-air variants encode the same logical fields with different
+// bit packings, and both parse into this struct:
 //
-//	BandwidthHz   = BW    × 125  Hz
-//	SpacingHz     = STEP  × 125  Hz   (channel step)
-//	TxOffsetHz    = OFF   × 250 kHz   (signed; sign-extended from 9-bit)
-//	BaseHz        = FREQ  × 5    Hz
+//	0x3D  IDEN_UP        — standard 700/800/900 MHz form (ParseIdentifierUpdate)
+//	0x34  IDEN_UP_VUHF   — VHF/UHF form         (ParseIdentifierUpdateVUHF)
 //
-// Only the standard 700/800/900 MHz form is parsed here (opcode 0x3D).
-// VHF/UHF (0x34) and Phase-2 TDMA (0x33) variants encode the same
-// fields with different bit packings and are out of scope for this
-// pass; lighting them up is incremental.
+// Field units after parsing (independent of variant):
+//
+//	BandwidthHz   — channel bandwidth in Hz
+//	SpacingHz     — channel-to-channel step in Hz
+//	TxOffsetHz    — signed transmit offset (uplink = downlink + offset)
+//	BaseHz        — downlink base frequency for channel 0 in Hz
+//
+// The 0x33 Phase-2 TDMA variant remains a follow-up — it adds slot
+// count plus a different packing of the same fields. See
+// internal/radio/p25/phase2/identifier.go for the Phase 2 variant
+// shipped today (which is also a 0x3D-style packing).
 type IdentifierUpdate struct {
 	ChannelID   uint8  // 4-bit slot identifier (0..15)
 	BandwidthHz uint32 // channel bandwidth
@@ -53,6 +58,121 @@ func ParseIdentifierUpdate(p [8]byte) IdentifierUpdate {
 		SpacingHz:   uint32(step) * 125,
 		TxOffsetHz:  int64(off) * 250_000,
 		BaseHz:      uint64(freq5Hz) * 5,
+	}
+}
+
+// ParseIdentifierUpdateVUHF decodes the 8-byte payload of opcode 0x34
+// (OpIdentifierUpdateVUHF), the VHF/UHF variant. The bit layout, MSB
+// first, per TIA-102.AABF Table 14a:
+//
+//	[ ChanID(4) | BW(4) | TxOffsetSign(1) | TxOffsetMag(13) | STEP(10) | FREQ(32) ]
+//
+// Differences from the 0x3D variant:
+//
+//   - BW is a 4-bit lookup code (Table 16) rather than a 9-bit ×125 Hz
+//     field: 0x4 → 6.25 kHz, 0x5 → 12.5 kHz, others → 0 (unknown). The
+//     value is informational only — BandPlan.Frequency does not
+//     consult it.
+//
+//   - TxOffset is a 1-bit sign + 13-bit magnitude pair, and the
+//     magnitude unit is the channel step (SpacingHz) rather than a
+//     fixed 250 kHz. The same convention as 0x3D applies to the
+//     stored TxOffsetHz: positive = uplink above downlink ("mob Tx+"),
+//     negative = uplink below downlink ("mob Tx-").
+//
+// STEP, FREQ, and the resulting SpacingHz / BaseHz values use the same
+// scaling as 0x3D (×125 Hz / ×5 Hz).
+//
+// Cross-checked against OP25 (`op25/gr-op25_repeater/apps/trunking.py`
+// `iden_up vhf uhf`) and SDRTrunk
+// (`FrequencyBandUpdateVUHF.java`).
+func ParseIdentifierUpdateVUHF(p [8]byte) IdentifierUpdate {
+	chanID := p[0] >> 4
+	bwCode := p[0] & 0x0F
+	toff14 := uint16(p[1])<<6 | uint16(p[2])>>2
+	toffSign := (toff14 >> 13) & 0x1
+	toffMag := toff14 & 0x1FFF
+	step := uint16(p[2]&0x03)<<8 | uint16(p[3])
+	freq5Hz := uint32(p[4])<<24 | uint32(p[5])<<16 | uint32(p[6])<<8 | uint32(p[7])
+
+	spacingHz := uint32(step) * 125
+	offsetMagHz := int64(toffMag) * int64(spacingHz)
+	txOffsetHz := offsetMagHz
+	if toffSign == 0 {
+		txOffsetHz = -offsetMagHz
+	}
+
+	return IdentifierUpdate{
+		ChannelID:   chanID,
+		BandwidthHz: vuhfBandwidthHz(bwCode),
+		SpacingHz:   spacingHz,
+		TxOffsetHz:  txOffsetHz,
+		BaseHz:      uint64(freq5Hz) * 5,
+	}
+}
+
+// AssembleIdentifierUpdateVUHF is the inverse of ParseIdentifierUpdateVUHF;
+// useful for synthetic test streams. Out-of-range fields are silently
+// truncated to their on-air widths. TxOffsetHz that isn't an integer
+// multiple of SpacingHz is truncated toward zero; a zero SpacingHz
+// produces a zero on-air offset regardless of TxOffsetHz.
+func AssembleIdentifierUpdateVUHF(u IdentifierUpdate) [8]byte {
+	bwCode := vuhfBandwidthCode(u.BandwidthHz) & 0x0F
+	step := uint16(u.SpacingHz/125) & 0x3FF
+
+	var toffSign uint8
+	var toffMag uint16
+	if u.TxOffsetHz >= 0 {
+		toffSign = 1
+		if u.SpacingHz > 0 {
+			toffMag = uint16(uint64(u.TxOffsetHz)/uint64(u.SpacingHz)) & 0x1FFF
+		}
+	} else {
+		toffSign = 0
+		if u.SpacingHz > 0 {
+			toffMag = uint16(uint64(-u.TxOffsetHz)/uint64(u.SpacingHz)) & 0x1FFF
+		}
+	}
+	toff14 := uint16(toffSign)<<13 | (toffMag & 0x1FFF)
+
+	freq5 := uint32(u.BaseHz / 5)
+
+	var p [8]byte
+	p[0] = (u.ChannelID&0x0F)<<4 | bwCode
+	p[1] = byte(toff14 >> 6)
+	p[2] = byte((toff14&0x3F)<<2) | byte(step>>8)
+	p[3] = byte(step)
+	p[4] = byte(freq5 >> 24)
+	p[5] = byte(freq5 >> 16)
+	p[6] = byte(freq5 >> 8)
+	p[7] = byte(freq5)
+	return p
+}
+
+// vuhfBandwidthHz maps the 4-bit BW code in opcode 0x34 to channel
+// bandwidth in Hz per TIA-102.AABF Table 16. Unknown codes return 0;
+// BandPlan.Frequency does not consult this field.
+func vuhfBandwidthHz(code uint8) uint32 {
+	switch code & 0x0F {
+	case 0x4:
+		return 6250
+	case 0x5:
+		return 12500
+	default:
+		return 0
+	}
+}
+
+// vuhfBandwidthCode is the inverse of vuhfBandwidthHz used by
+// AssembleIdentifierUpdateVUHF. Unrecognised bandwidths emit code 0.
+func vuhfBandwidthCode(hz uint32) uint8 {
+	switch hz {
+	case 6250:
+		return 0x4
+	case 12500:
+		return 0x5
+	default:
+		return 0
 	}
 }
 

--- a/internal/radio/p25/phase1/identifier_test.go
+++ b/internal/radio/p25/phase1/identifier_test.go
@@ -37,6 +37,63 @@ func TestIdentifierUpdateRoundTripPositiveOffset(t *testing.T) {
 	}
 }
 
+func TestIdentifierUpdateVUHFRoundTripNegativeOffset(t *testing.T) {
+	// Realistic UHF P25 site fixture: ChannelID 1, base 460.0 MHz,
+	// 12.5 kHz spacing + bandwidth, -5 MHz transmit offset.
+	in := IdentifierUpdate{
+		ChannelID:   1,
+		BandwidthHz: 12_500,
+		SpacingHz:   12_500,
+		TxOffsetHz:  -5_000_000,
+		BaseHz:      460_000_000,
+	}
+	out := ParseIdentifierUpdateVUHF(AssembleIdentifierUpdateVUHF(in))
+	if out != in {
+		t.Errorf("round-trip mismatch:\n got %+v\nwant %+v", out, in)
+	}
+}
+
+func TestIdentifierUpdateVUHFRoundTripPositiveOffset(t *testing.T) {
+	// 6.25 kHz narrowband VHF fixture with a positive offset to exercise
+	// the sign bit.
+	in := IdentifierUpdate{
+		ChannelID:   3,
+		BandwidthHz: 6_250,
+		SpacingHz:   6_250,
+		TxOffsetHz:  5_000_000,
+		BaseHz:      154_000_000,
+	}
+	out := ParseIdentifierUpdateVUHF(AssembleIdentifierUpdateVUHF(in))
+	if out != in {
+		t.Errorf("round-trip mismatch: got %+v want %+v", out, in)
+	}
+}
+
+func TestIdentifierUpdateVUHFUnknownBandwidthCodeMapsToZero(t *testing.T) {
+	// On-air payload with BW code 0 (reserved per TIA-102.AABF Table 16).
+	// Parser must surface BandwidthHz=0 rather than fabricating a value.
+	var p [8]byte
+	p[0] = 0x10 // ChannelID=1, BW code 0
+	p[3] = 0x64 // STEP=100 → 12.5 kHz
+	// FREQ=92_000_000 → 460 MHz at ×5 Hz
+	freq5 := uint32(460_000_000 / 5)
+	p[4] = byte(freq5 >> 24)
+	p[5] = byte(freq5 >> 16)
+	p[6] = byte(freq5 >> 8)
+	p[7] = byte(freq5)
+
+	out := ParseIdentifierUpdateVUHF(p)
+	if out.BandwidthHz != 0 {
+		t.Errorf("BandwidthHz = %d, want 0 for reserved BW code", out.BandwidthHz)
+	}
+	if out.SpacingHz != 12_500 {
+		t.Errorf("SpacingHz = %d, want 12_500", out.SpacingHz)
+	}
+	if out.BaseHz != 460_000_000 {
+		t.Errorf("BaseHz = %d, want 460_000_000", out.BaseHz)
+	}
+}
+
 func TestBandPlanResolvesKnownChannel(t *testing.T) {
 	bp := &BandPlan{}
 	bp.Apply(IdentifierUpdate{


### PR DESCRIPTION
## Summary

UHF P25 sites locked cleanly but every voice grant emitted
`decode.error stage=no-bandplan`. Root cause: the `IDEN_UP_VUHF` TSBK
(opcode **0x34**) — which carries the band plan on VHF/UHF P25 sites —
had its opcode constant declared in
`internal/radio/p25/phase1/opcodes.go` but **no parser and no
dispatcher case**, so it was silently dropped. The 0x3D variant (used
on 700/800/900 MHz) was the only band-plan opcode wired up. The
control-channel lock itself was healthy; the failure lived downstream
of the lock and was invisible without inspecting the events bus.

This PR wires up 0x34 alongside the existing 0x3D handler.

## What changed

- **`internal/radio/p25/phase1/identifier.go`** — adds
  `ParseIdentifierUpdateVUHF` and `AssembleIdentifierUpdateVUHF`. The
  VHF/UHF bit packing per TIA-102.AABF Table 14a differs from 0x3D in
  three places, all decoded here:
  - 4-bit `BW` lookup (Table 16: `0x4` → 6.25 kHz, `0x5` → 12.5 kHz,
    others → 0 / unknown) instead of a 9-bit ×125 Hz field.
  - 1-bit sign + 13-bit magnitude `TxOffset` whose unit is the
    channel step (`SpacingHz`) rather than a fixed 250 kHz. Same
    convention as 0x3D applies to the stored `TxOffsetHz`: positive
    = uplink above downlink ("mob Tx+"), negative = below ("mob Tx-").
  - `STEP × 125 Hz`, `FREQ × 5 Hz` carry over unchanged.

  Both parsers feed the same `IdentifierUpdate` struct, so
  `BandPlan.Apply` / `BandPlan.Frequency` need no change.

- **`internal/radio/p25/phase1/control.go`** — adds the
  `case OpIdentifierUpdateVUHF:` branch in `dispatchTSBK`, mirroring
  the existing 0x3D case and logging an extra `bandwidth_hz` field
  since that's the most variant-distinctive value.

- **Tests** — round-trip coverage in `identifier_test.go` for both
  negative (typical UHF -5 MHz) and positive offset, plus a reserved
  BW-code → 0 case. End-to-end in `control_test.go`: feed a VUHF
  `IdentifierUpdate` + subsequent grant through the real
  `ControlChannel.Process` chain and assert the grant resolves to the
  expected frequency rather than falling to `decode.error
  stage=no-bandplan`.

- **`CHANGELOG.md`** + **`README.md`** — note both 0x3D and 0x34
  variants are now wired through the dispatcher.

## Cross-checks

Bit layout verified against two independent reference
implementations:

- **OP25** —
  `op25/gr-op25_repeater/apps/trunking.py` (`iden_up vhf uhf` branch):
  ```
  toff0 = (tsbk >> 58) & 0x3fff
  toff_sign = (toff0 >> 13) & 1
  toff = toff0 & 0x1fff
  if toff_sign == 0:
      toff = 0 - toff
  self.freq_table[iden]['offset'] = toff * spac * 125
  self.freq_table[iden]['step']   = spac * 125
  ```
- **SDRTrunk** — `FrequencyBandUpdateVUHF.java`:
  bit ranges `BANDWIDTH = {20..23}`, `TRANSMIT_OFFSET_SIGN = 24`,
  `TRANSMIT_OFFSET = {25..37}`, `CHANNEL_SPACING = {38..47}`,
  `BASE_FREQUENCY = {48..79}`; bandwidth table
  `0x4 → 6250`, `0x5 → 12500`; offset = `value × channel_spacing`,
  negated when sign bit clear.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./internal/radio/p25/phase1/...` — clean
- [x] `go test ./internal/radio/p25/...` — all pass; new tests
  exercise both the parser round-trip and the end-to-end
  `IDEN_UP_VUHF` → `BandPlan` → grant resolution path
- [ ] **Live air retest on the UHF site (461.4375 MHz)** that
  surfaced this — expect the `decode.error stage=no-bandplan` events
  to disappear from the TUI Events panel and follow-on
  `KindGrant` events to start firing on actual traffic. At
  `log.level: debug`, the new `"p25: identifier update (VUHF)"` line
  should fire every 10-30 s as the site repeats its IDEN_UP.

## Follow-ups (out of scope here)

- Opcode **0x33** (Phase-2 TDMA `IdentifierUpdate` variant) — same
  architectural approach; not blocking the UHF-Phase-1 use case.
- Promote `ccdecoder: iq power very low` from `Debug` to `Info` (or
  add a periodic dBFS heartbeat) — this PR's debug dispatcher case
  helps, but operator triage would still benefit.
- `p25_phase1_demod_mode: "auto"` to A/B C4FM vs CQPSK during the
  hunt dwell — orthogonal to the band-plan issue but on the same
  operator-friction surface.

https://claude.ai/code/session_01Q1xDKzEbW2ndw5CHPcU5TB

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q1xDKzEbW2ndw5CHPcU5TB)_