### PR TITLE
sdr: reject duplicate device serials and hint on Windows access-denied (#333)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -649,12 +649,24 @@ func (c Config) Validate() error {
 	if c.SDR.SampleRate != 0 && (c.SDR.SampleRate < 225_000 || c.SDR.SampleRate > 3_200_000) {
 		return errors.New("sdr.sample_rate must be between 225 kHz and 3.2 MHz")
 	}
+	seenSerials := make(map[string]int, len(c.SDR.Devices))
 	for i, d := range c.SDR.Devices {
 		switch d.Role {
 		case "", "control", "voice", "auto":
 		default:
 			return fmt.Errorf("sdr.devices[%d]: role must be control|voice|auto", i)
 		}
+		if d.Serial == "" {
+			continue
+		}
+		if prev, dup := seenSerials[d.Serial]; dup {
+			return fmt.Errorf(
+				"sdr.devices[%d]: duplicate serial %q (also at sdr.devices[%d]) — "+
+					"one physical SDR cannot serve multiple roles; P25 trunking needs "+
+					"separate dongles for control and voice",
+				i, d.Serial, prev)
+		}
+		seenSerials[d.Serial] = i
 	}
 	for i, s := range c.Trunking.Systems {
 		if s.Name == "" {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -77,6 +77,9 @@ func TestValidate(t *testing.T) {
 		{"bad hex key", Config{Trunking: TrunkingConfig{Systems: []SystemConfig{{Name: "x", Protocol: "dmr", EncryptionKeys: []EncryptionKeyConfig{{KeyID: 1, Algorithm: "rc4", Key: "xyz"}}}}}}, true},
 		{"empty key", Config{Trunking: TrunkingConfig{Systems: []SystemConfig{{Name: "x", Protocol: "dmr", EncryptionKeys: []EncryptionKeyConfig{{KeyID: 1, Algorithm: "rc4", Key: ""}}}}}}, true},
 		{"duplicate key_id", Config{Trunking: TrunkingConfig{Systems: []SystemConfig{{Name: "x", Protocol: "dmr", EncryptionKeys: []EncryptionKeyConfig{{KeyID: 1, Algorithm: "rc4", Key: "ab"}, {KeyID: 1, Algorithm: "rc4", Key: "cd"}}}}}}, true},
+		{"duplicate sdr serial", Config{SDR: SDRConfig{Devices: []DeviceConfig{{Serial: "00000006", Role: "control"}, {Serial: "00000006", Role: "voice"}}}}, true},
+		{"distinct sdr serials ok", Config{SDR: SDRConfig{Devices: []DeviceConfig{{Serial: "00000001", Role: "control"}, {Serial: "00000002", Role: "voice"}}}}, false},
+		{"empty sdr serials ok", Config{SDR: SDRConfig{Devices: []DeviceConfig{{Role: "control"}, {Role: "voice"}}}}, false},
 		{"oversized key", Config{Trunking: TrunkingConfig{Systems: []SystemConfig{{Name: "x", Protocol: "dmr", EncryptionKeys: []EncryptionKeyConfig{{KeyID: 1, Algorithm: "rc4", Key: strings.Repeat("ab", 33)}}}}}}, true},
 	}
 	for _, tc := range cases {

--- a/internal/sdr/pool.go
+++ b/internal/sdr/pool.go
@@ -179,7 +179,11 @@ func (p *Pool) Open(sampleRateHz uint32, hints []Hint) error {
 		}
 		dev, err := d.drv.Open(d.info.Index)
 		if err != nil {
-			p.log.Error("open device failed", "driver", d.drv.Name(), "index", d.info.Index, "err", err)
+			p.log.Error("open device failed",
+				"driver", d.drv.Name(),
+				"index", d.info.Index,
+				"serial", d.info.Serial,
+				"err", err)
 			continue
 		}
 		if err := dev.SetSampleRate(rate); err != nil {

--- a/internal/sdr/rtlsdr/purego/driver.go
+++ b/internal/sdr/rtlsdr/purego/driver.go
@@ -124,7 +124,7 @@ func (d *Driver) Open(idx int) (sdr.Device, error) {
 
 	transport, err := d.enumerator().Open(desc)
 	if err != nil {
-		return nil, fmt.Errorf("rtlsdr: open USB %s: %w", desc.Path, err)
+		return nil, fmt.Errorf("rtlsdr: open USB %s: %w%s", desc.Path, err, openUSBHint(err))
 	}
 	transport = usb.MaybeWrapDebug(transport, desc)
 
@@ -332,6 +332,27 @@ func tunerBringupHint(err error) string {
 			" on Windows, the WinUSB driver is not bound to the device (re-run Zadig and select the RTL-SDR);" +
 			" on any OS, marginal USB power, a flaky cable/hub, or another process already holding the device." +
 			" See https://mattcheramie.github.io/GopherTrunk/install-linux.html#troubleshooting)"
+	}
+	return ""
+}
+
+// openUSBHint returns a parenthesized, space-prefixed remediation
+// string when err looks like a Windows ERROR_ACCESS_DENIED from
+// CreateFile — the symptom seen when another user-space process (SDR
+// Sharp, AbracaDABra, rtl_test, a second gophertrunk) already holds
+// the dongle, or when the same serial is listed twice in sdr.devices
+// so the pool tries to open the same physical device for two roles
+// (issue #333). Returns "" for unrelated errors so the wrapped
+// message stays clean. The platform-specific check lives in
+// driver_windows.go / driver_other.go.
+func openUSBHint(err error) string {
+	if isAccessDenied(err) {
+		return " (hint: another process is holding the dongle —" +
+			" close any other SDR app (SDR Sharp, AbracaDABra, rtl_test," +
+			" or a second gophertrunk instance) and retry." +
+			" If only one gophertrunk is running, check that the same serial" +
+			" is not listed twice in sdr.devices — one physical SDR cannot" +
+			" serve two roles.)"
 	}
 	return ""
 }

--- a/internal/sdr/rtlsdr/purego/driver_other.go
+++ b/internal/sdr/rtlsdr/purego/driver_other.go
@@ -1,0 +1,5 @@
+//go:build !windows
+
+package purego
+
+func isAccessDenied(error) bool { return false }

--- a/internal/sdr/rtlsdr/purego/driver_windows.go
+++ b/internal/sdr/rtlsdr/purego/driver_windows.go
@@ -1,0 +1,13 @@
+//go:build windows
+
+package purego
+
+import (
+	"errors"
+
+	"golang.org/x/sys/windows"
+)
+
+func isAccessDenied(err error) bool {
+	return errors.Is(err, windows.ERROR_ACCESS_DENIED)
+}

--- a/internal/sdr/rtlsdr/purego/driver_windows_test.go
+++ b/internal/sdr/rtlsdr/purego/driver_windows_test.go
@@ -1,0 +1,31 @@
+//go:build windows
+
+package purego
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"golang.org/x/sys/windows"
+)
+
+func TestOpenUSBHintAccessDenied(t *testing.T) {
+	wrapped := fmt.Errorf("winusb: CreateFile %q: %w", `\\?\usb#vid_0bda&pid_2838#00000006`, windows.ERROR_ACCESS_DENIED)
+	hint := openUSBHint(wrapped)
+	if hint == "" {
+		t.Fatal("openUSBHint returned empty for ERROR_ACCESS_DENIED; expected remediation text")
+	}
+	if !strings.Contains(hint, "another process is holding the dongle") {
+		t.Errorf("openUSBHint = %q; want substring about another process", hint)
+	}
+	if !strings.Contains(hint, "sdr.devices") {
+		t.Errorf("openUSBHint = %q; want substring about sdr.devices duplicate-serial advice", hint)
+	}
+}
+
+func TestOpenUSBHintUnrelatedError(t *testing.T) {
+	if got := openUSBHint(fmt.Errorf("totally unrelated")); got != "" {
+		t.Errorf("openUSBHint(unrelated) = %q; want empty string", got)
+	}
+}


### PR DESCRIPTION
Issue #333: a Windows user listed the same RTL-SDR serial twice (control
+ voice). The pool silently collapsed the duplicate hint and WinUSB
refused the second CreateFile with "Toegang geweigerd"
(ERROR_ACCESS_DENIED), leaving the user with a cryptic failure.

- internal/config: Validate() now rejects duplicate serials in
  sdr.devices with a message that names both offending indices and
  explains the one-SDR-per-role rule.
- internal/sdr/rtlsdr/purego: openUSBHint() fires on Windows
  ERROR_ACCESS_DENIED with remediation pointing at other SDR apps
  (SDR Sharp, AbracaDABra, rtl_test, second gophertrunk) and the
  duplicate-serial case.
- internal/sdr/pool: include serial alongside index in
  "open device failed" logs so the operator can tell which dongle
  is the offender.

https://claude.ai/code/session_019qpz7G3gTtFKSAryJJsev9