### PR TITLE
sdr+ccdecoder: surface USB reaper death so decoder doesn't stall (#345)

### DIFF
--- a/cmd/gophertrunk/ccdecoder_retry_test.go
+++ b/cmd/gophertrunk/ccdecoder_retry_test.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/scanner/ccdecoder"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// flakyIQSource is an IQSource that closes its channel n times
+// (simulating n consecutive USB reaper deaths) and then returns a
+// healthy never-closing channel — models the daemon's
+// reopen-and-restart loop hitting a transient device fault.
+type flakyIQSource struct {
+	deaths   int32
+	maxDeath int32
+}
+
+func (f *flakyIQSource) StreamIQ(ctx context.Context) (<-chan []complex64, error) {
+	ch := make(chan []complex64)
+	go func() {
+		defer close(ch)
+		select {
+		case ch <- make([]complex64, 4):
+		case <-ctx.Done():
+			return
+		}
+		if atomic.AddInt32(&f.deaths, 1) <= f.maxDeath {
+			// Simulate reaper death: close the channel mid-stream
+			// without waiting on ctx.
+			return
+		}
+		// Healthy stream — block on ctx.
+		<-ctx.Done()
+	}()
+	return ch, nil
+}
+
+// TestRunCCDecoderWithRetry_RecoversAfterTransientDeath pins the
+// issue-#345 restart loop: an IQ-stream death triggers a rebuild with
+// backoff, and a subsequent healthy run keeps the loop alive (no
+// fatal). Then ctx-cancel returns cleanly.
+func TestRunCCDecoderWithRetry_RecoversAfterTransientDeath(t *testing.T) {
+	// Shrink the backoff schedule so the test doesn't sit for 18s.
+	oldBackoffs := ccDecoderRetryBackoffs
+	ccDecoderRetryBackoffs = []time.Duration{
+		10 * time.Millisecond,
+		20 * time.Millisecond,
+		50 * time.Millisecond,
+	}
+	defer func() { ccDecoderRetryBackoffs = oldBackoffs }()
+
+	bus := events.NewBus(8)
+	defer bus.Close()
+	src := &flakyIQSource{maxDeath: 2}
+	opts := ccdecoder.Options{
+		Bus: bus, IQ: src, SampleRateHz: 48000,
+		Log: slog.New(slog.DiscardHandler),
+	}
+	dec, err := ccdecoder.New(opts)
+	if err != nil {
+		t.Fatalf("ccdecoder.New: %v", err)
+	}
+	d := &Daemon{
+		log:           slog.New(slog.DiscardHandler),
+		bus:           bus,
+		systems:       []trunking.System{},
+		ccDecoder:     dec,
+		ccDecoderOpts: opts,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- d.runCCDecoderWithRetry(ctx) }()
+
+	// Give the loop time to weather both deaths, rebuild, and settle
+	// into the healthy run.
+	select {
+	case err := <-done:
+		t.Fatalf("loop exited early: %v", err)
+	case <-time.After(500 * time.Millisecond):
+	}
+	// Confirm no fatal was recorded.
+	if got := d.takeFatal(); got != nil {
+		t.Errorf("recordFatal fired during transient deaths: %v", got)
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("loop exit err = %v, want context.Canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("loop did not exit after ctx cancel")
+	}
+}
+
+// TestRunCCDecoderWithRetry_FatalsAfterRetriesExhausted pins the
+// terminal escalation: if the IQ stream dies more times than the
+// backoff schedule covers (and never gets a healthy run in between),
+// the loop records a fatal so the daemon exits non-zero.
+func TestRunCCDecoderWithRetry_FatalsAfterRetriesExhausted(t *testing.T) {
+	oldBackoffs := ccDecoderRetryBackoffs
+	ccDecoderRetryBackoffs = []time.Duration{
+		5 * time.Millisecond,
+		5 * time.Millisecond,
+	}
+	defer func() { ccDecoderRetryBackoffs = oldBackoffs }()
+
+	bus := events.NewBus(8)
+	defer bus.Close()
+	// maxDeath=999 means every reopen dies — no healthy window ever
+	// hits, retries get exhausted.
+	src := &flakyIQSource{maxDeath: 999}
+	opts := ccdecoder.Options{
+		Bus: bus, IQ: src, SampleRateHz: 48000,
+		Log: slog.New(slog.DiscardHandler),
+	}
+	dec, err := ccdecoder.New(opts)
+	if err != nil {
+		t.Fatalf("ccdecoder.New: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	d := &Daemon{
+		log:           slog.New(slog.DiscardHandler),
+		bus:           bus,
+		systems:       []trunking.System{},
+		ccDecoder:     dec,
+		ccDecoderOpts: opts,
+		cancel:        cancel,
+	}
+
+	got := d.runCCDecoderWithRetry(ctx)
+	if !errors.Is(got, ccdecoder.ErrIQStreamClosed) {
+		t.Errorf("Run = %v, want wrapped ErrIQStreamClosed", got)
+	}
+	if d.takeFatal() == nil {
+		t.Error("expected recordFatal to fire after retries exhausted")
+	}
+}

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -108,9 +108,9 @@ type Daemon struct {
 	// needed to restart cleanly (issue #345).
 	ccDecoderOpts ccdecoder.Options
 	convScan      *conventional.Scanner
-	metrics      *metrics.Metrics
-	httpAPI      *api.Server
-	grpcAPI      *api.GRPCServer
+	metrics       *metrics.Metrics
+	httpAPI       *api.Server
+	grpcAPI       *api.GRPCServer
 
 	// startupWarnings collects non-fatal observations from
 	// NewDaemon / preflight (missing talkgroup CSV, SDR enumeration

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -102,7 +102,12 @@ type Daemon struct {
 	ccCache      *trunking.Cache
 	cchuntSup    *cchunt.Supervisor
 	ccDecoder    *ccdecoder.Decoder
-	convScan     *conventional.Scanner
+	// ccDecoderOpts is captured at construction so the spawn closure
+	// can rebuild the decoder after an IQ-stream death — Decoder.Run
+	// closes its bus subscription on exit, so a fresh instance is
+	// needed to restart cleanly (issue #345).
+	ccDecoderOpts ccdecoder.Options
+	convScan      *conventional.Scanner
 	metrics      *metrics.Metrics
 	httpAPI      *api.Server
 	grpcAPI      *api.GRPCServer
@@ -560,7 +565,7 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 				if d.metrics != nil {
 					iqObs = d.metrics
 				}
-				dec, err := ccdecoder.New(ccdecoder.Options{
+				d.ccDecoderOpts = ccdecoder.Options{
 					Bus:          d.bus,
 					Log:          log,
 					Tuner:        controlEntry.Device,
@@ -568,7 +573,8 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 					Systems:      d.systems,
 					SampleRateHz: float64(cfg.SDR.SampleRate),
 					Metrics:      iqObs,
-				})
+				}
+				dec, err := ccdecoder.New(d.ccDecoderOpts)
 				if err != nil {
 					return nil, fmt.Errorf("daemon: ccdecoder: %w", err)
 				}
@@ -884,9 +890,7 @@ func (d *Daemon) Run(ctx context.Context) error {
 		})
 	}
 	if d.ccDecoder != nil {
-		d.spawn(runCtx, "ccdecoder", false, func(ctx context.Context) error {
-			return d.ccDecoder.Run(ctx)
-		})
+		d.spawn(runCtx, "ccdecoder", false, d.runCCDecoderWithRetry)
 	}
 	if d.convScan != nil {
 		d.spawn(runCtx, "conv-scanner", false, func(ctx context.Context) error {
@@ -1049,6 +1053,82 @@ func (d *Daemon) Bus() *events.Bus { return d.bus }
 // these components — silently demoting their failures to log warnings
 // produces a half-dead daemon that frustrates the operator).
 // essential=false retains the legacy behaviour: warn-and-continue.
+// ccDecoderRetryBackoffs is the per-attempt sleep schedule used after
+// an IQ-stream death. After the schedule is exhausted, the daemon
+// escalates to a fatal error so an external supervisor (systemd,
+// docker, the launcher) restarts a clean process. See issue #345.
+var ccDecoderRetryBackoffs = []time.Duration{
+	1 * time.Second,
+	2 * time.Second,
+	5 * time.Second,
+	10 * time.Second,
+}
+
+// ccDecoderHealthyRunDuration is how long a successful Run must last
+// before the retry counter resets. Anything shorter is treated as a
+// repeated failure (e.g. the device immediately re-dies on reopen).
+const ccDecoderHealthyRunDuration = 60 * time.Second
+
+// runCCDecoderWithRetry drives the ccdecoder under a small restart
+// loop. On ErrIQStreamClosed (the USB reaper died, the consumer
+// channel closed — see issue #345) it sleeps with backoff, rebuilds
+// the decoder against the same SDR, and retries. When the backoff
+// schedule is exhausted it records a fatal error so the daemon's
+// supervisor restarts a clean process. ctx cancel and any other Run
+// error end the loop without escalation.
+func (d *Daemon) runCCDecoderWithRetry(ctx context.Context) error {
+	dec := d.ccDecoder
+	var attempt int
+	for {
+		started := time.Now()
+		err := dec.Run(ctx)
+		if err == nil || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return err
+		}
+		if !errors.Is(err, ccdecoder.ErrIQStreamClosed) {
+			return err
+		}
+		// A Run that survived a healthy window means the previous
+		// recovery succeeded; reset the attempt counter so a fresh
+		// failure stretch gets its own retry budget.
+		if time.Since(started) >= ccDecoderHealthyRunDuration {
+			attempt = 0
+		}
+		if attempt >= len(ccDecoderRetryBackoffs) {
+			d.log.Error("daemon: ccdecoder: IQ stream died and retries exhausted; escalating to fatal",
+				"attempts", attempt, "err", err)
+			fatal := fmt.Errorf("ccdecoder: %w", err)
+			d.recordFatal(fatal)
+			return fatal
+		}
+		wait := ccDecoderRetryBackoffs[attempt]
+		attempt++
+		d.log.Warn("daemon: ccdecoder: IQ stream died; retrying",
+			"attempt", attempt, "max_attempts", len(ccDecoderRetryBackoffs),
+			"backoff", wait, "err", err)
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(wait):
+		}
+		// Rebuild the decoder so it gets a fresh bus subscription —
+		// Decoder.Run defers Close on its subscription, so reusing
+		// the existing instance would see an immediately-closed
+		// channel and exit on the first event.
+		next, nerr := ccdecoder.New(d.ccDecoderOpts)
+		if nerr != nil {
+			d.log.Error("daemon: ccdecoder: rebuild failed; escalating to fatal", "err", nerr)
+			fatal := fmt.Errorf("ccdecoder rebuild: %w", nerr)
+			d.recordFatal(fatal)
+			return fatal
+		}
+		dec = next
+		d.mu.Lock()
+		d.ccDecoder = dec
+		d.mu.Unlock()
+	}
+}
+
 func (d *Daemon) spawn(ctx context.Context, name string, essential bool, fn func(context.Context) error) {
 	d.wg.Add(1)
 	go func() {

--- a/internal/scanner/ccdecoder/decoder.go
+++ b/internal/scanner/ccdecoder/decoder.go
@@ -62,6 +62,14 @@ type IQPowerObserver interface {
 	ClearIQPowerDbFS(system string)
 }
 
+// ErrIQStreamClosed is returned by Run when the SDR's IQ channel closes
+// while the context is still live — the underlying USB reaper died of
+// an unrecoverable error (host controller hang, ENODEV, EPROTO storm
+// under load) and the driver propagated EOF instead of hanging forever.
+// The daemon's restart loop watches for this and re-opens the SDR.
+// See issue #345.
+var ErrIQStreamClosed = errors.New("ccdecoder: IQ stream closed unexpectedly")
+
 // iqPowerWindow is how long the pump aggregates samples before
 // recomputing the mean dBFS and updating the gauge / debug log.
 const iqPowerWindow = time.Second
@@ -222,7 +230,7 @@ func (d *Decoder) Run(ctx context.Context) error {
 			d.handleProgress(p)
 		case iq, ok := <-stream:
 			if !ok {
-				return nil
+				return ErrIQStreamClosed
 			}
 			d.pump(iq)
 		}

--- a/internal/scanner/ccdecoder/decoder_test.go
+++ b/internal/scanner/ccdecoder/decoder_test.go
@@ -118,6 +118,60 @@ func TestNewRequiresSampleRate(t *testing.T) {
 	}
 }
 
+// closingIQSource returns a channel that closes after dispatching
+// `chunks` worth of IQ — regardless of ctx state. Models the SDR
+// driver's behaviour when its USB reaper dies (issue #345): the
+// channel closes, the decoder must surface ErrIQStreamClosed so the
+// daemon's restart loop can re-open the SDR.
+type closingIQSource struct {
+	chunks [][]complex64
+}
+
+func (c *closingIQSource) StreamIQ(ctx context.Context) (<-chan []complex64, error) {
+	ch := make(chan []complex64)
+	go func() {
+		defer close(ch)
+		for _, chunk := range c.chunks {
+			select {
+			case <-ctx.Done():
+				return
+			case ch <- chunk:
+			}
+		}
+	}()
+	return ch, nil
+}
+
+// TestRunReturnsErrIQStreamClosedOnStreamEOF pins the issue-#345
+// surface: when the IQ stream closes while ctx is still live (the
+// SDR's USB reaper died and the driver propagated EOF), Run must
+// return ErrIQStreamClosed so the daemon's restart loop can fire.
+// Before the fix, Run returned nil and the daemon swallowed the exit
+// silently — the entire pipeline went idle at 0% CPU.
+func TestRunReturnsErrIQStreamClosedOnStreamEOF(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	src := &closingIQSource{
+		chunks: [][]complex64{make([]complex64, 4)},
+	}
+	d, err := New(Options{Bus: bus, IQ: src, SampleRateHz: 48000})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	done := make(chan error, 1)
+	go func() {
+		done <- d.Run(context.Background())
+	}()
+	select {
+	case got := <-done:
+		if !errors.Is(got, ErrIQStreamClosed) {
+			t.Errorf("Run = %v, want ErrIQStreamClosed", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Run did not return after stream EOF")
+	}
+}
+
 func TestRunPropagatesStreamIQError(t *testing.T) {
 	bus := events.NewBus(8)
 	defer bus.Close()

--- a/internal/sdr/airspy/airspy.go
+++ b/internal/sdr/airspy/airspy.go
@@ -378,7 +378,18 @@ func (d *Device) StreamIQ(ctx context.Context) (<-chan []complex64, error) {
 		case <-ctx.Done():
 		}
 	}
-	if err := d.t.StartBulkIn(bulkInEP, usb.DefaultRingBuffers, usb.DefaultBufferLen, onPacket); err != nil {
+	// streamDead fires (exactly once, via streamDeadOnce) when the USB
+	// reaper exits without StopBulkIn being called — every URB died of
+	// an unrecoverable error. The cleanup goroutine below treats it
+	// just like a ctx-cancel: tear the stream down and close `out`
+	// so the IQ consumer sees a real EOF instead of hanging forever
+	// (issue #345).
+	streamDead := make(chan struct{})
+	var streamDeadOnce sync.Once
+	onStreamDead := func(error) {
+		streamDeadOnce.Do(func() { close(streamDead) })
+	}
+	if err := d.t.StartBulkIn(bulkInEP, usb.DefaultRingBuffers, usb.DefaultBufferLen, onPacket, onStreamDead); err != nil {
 		_ = d.setReceiver(receiverModeOff)
 		d.mu.Lock()
 		d.streaming = false
@@ -388,7 +399,10 @@ func (d *Device) StreamIQ(ctx context.Context) (<-chan []complex64, error) {
 
 	go func() {
 		defer close(out)
-		<-ctx.Done()
+		select {
+		case <-ctx.Done():
+		case <-streamDead:
+		}
 		_ = d.t.StopBulkIn()
 		_ = d.setReceiver(receiverModeOff)
 		d.mu.Lock()

--- a/internal/sdr/airspyhf/airspyhf.go
+++ b/internal/sdr/airspyhf/airspyhf.go
@@ -355,7 +355,18 @@ func (d *Device) StreamIQ(ctx context.Context) (<-chan []complex64, error) {
 		case <-ctx.Done():
 		}
 	}
-	if err := d.t.StartBulkIn(bulkInEP, usb.DefaultRingBuffers, usb.DefaultBufferLen, onPacket); err != nil {
+	// streamDead fires (exactly once, via streamDeadOnce) when the USB
+	// reaper exits without StopBulkIn being called — every URB died of
+	// an unrecoverable error. The cleanup goroutine below treats it
+	// just like a ctx-cancel: tear the stream down and close `out`
+	// so the IQ consumer sees a real EOF instead of hanging forever
+	// (issue #345).
+	streamDead := make(chan struct{})
+	var streamDeadOnce sync.Once
+	onStreamDead := func(error) {
+		streamDeadOnce.Do(func() { close(streamDead) })
+	}
+	if err := d.t.StartBulkIn(bulkInEP, usb.DefaultRingBuffers, usb.DefaultBufferLen, onPacket, onStreamDead); err != nil {
 		_ = d.setReceiver(receiverModeOff)
 		d.mu.Lock()
 		d.streaming = false
@@ -365,7 +376,10 @@ func (d *Device) StreamIQ(ctx context.Context) (<-chan []complex64, error) {
 
 	go func() {
 		defer close(out)
-		<-ctx.Done()
+		select {
+		case <-ctx.Done():
+		case <-streamDead:
+		}
 		_ = d.t.StopBulkIn()
 		_ = d.setReceiver(receiverModeOff)
 		d.mu.Lock()

--- a/internal/sdr/hackrf/hackrf.go
+++ b/internal/sdr/hackrf/hackrf.go
@@ -445,7 +445,18 @@ func (d *Device) StreamIQ(ctx context.Context) (<-chan []complex64, error) {
 		case <-ctx.Done():
 		}
 	}
-	if err := d.t.StartBulkIn(bulkInEP, usb.DefaultRingBuffers, usb.DefaultBufferLen, onPacket); err != nil {
+	// streamDead fires (exactly once, via streamDeadOnce) when the USB
+	// reaper exits without StopBulkIn being called — every URB died of
+	// an unrecoverable error. The cleanup goroutine below treats it
+	// just like a ctx-cancel: tear the stream down and close `out`
+	// so the IQ consumer sees a real EOF instead of hanging forever
+	// (issue #345).
+	streamDead := make(chan struct{})
+	var streamDeadOnce sync.Once
+	onStreamDead := func(error) {
+		streamDeadOnce.Do(func() { close(streamDead) })
+	}
+	if err := d.t.StartBulkIn(bulkInEP, usb.DefaultRingBuffers, usb.DefaultBufferLen, onPacket, onStreamDead); err != nil {
 		_ = d.setMode(transceiverModeOff)
 		d.mu.Lock()
 		d.streaming = false
@@ -456,7 +467,10 @@ func (d *Device) StreamIQ(ctx context.Context) (<-chan []complex64, error) {
 	go func() {
 		defer close(out)
 		defer close(stopped)
-		<-ctx.Done()
+		select {
+		case <-ctx.Done():
+		case <-streamDead:
+		}
 		_ = d.t.StopBulkIn()
 		_ = d.setMode(transceiverModeOff)
 		d.mu.Lock()

--- a/internal/sdr/rtlsdr/purego/stream.go
+++ b/internal/sdr/rtlsdr/purego/stream.go
@@ -56,7 +56,7 @@ func (d *Device) StreamIQ(ctx context.Context) (<-chan []complex64, error) {
 	d.out = out
 	d.stopOnce = sync.Once{}
 
-	if err := d.transport.StartBulkIn(bulkInEndpoint, asyncBufCount, asyncBufLen, d.deliver); err != nil {
+	if err := d.transport.StartBulkIn(bulkInEndpoint, asyncBufCount, asyncBufLen, d.deliver, d.onStreamDead); err != nil {
 		d.out = nil
 		return nil, fmt.Errorf("rtlsdr: StartBulkIn: %w", err)
 	}
@@ -69,6 +69,18 @@ func (d *Device) StreamIQ(ctx context.Context) (<-chan []complex64, error) {
 	}()
 
 	return out, nil
+}
+
+// onStreamDead is the [usb.Transport] StartBulkIn callback fired when
+// every bulk-IN URB dies of an unrecoverable USB error and the reaper
+// exits without StopBulkIn being called. It runs cancelStream so the
+// consumer channel closes and the IQ consumer (e.g. ccdecoder) sees a
+// real EOF rather than hanging forever. Idempotent via d.stopOnce.
+// The underlying error surfaces upstream as ccdecoder.ErrIQStreamClosed;
+// the daemon logs it once and decides whether to retry / exit. See
+// issue #345.
+func (d *Device) onStreamDead(error) {
+	d.cancelStream()
 }
 
 // deliver receives one bulk-IN buffer from the transport reaper,

--- a/internal/sdr/rtlsdr/purego/stream_test.go
+++ b/internal/sdr/rtlsdr/purego/stream_test.go
@@ -240,6 +240,45 @@ loop:
 	}
 }
 
+// TestStreamIQ_ChannelClosesOnReaperDeath is the issue-#345 regression:
+// when the USB reaper dies unexpectedly (every URB unrecoverable), the
+// driver must close its consumer channel so the IQ consumer
+// (ccdecoder) sees EOF and can restart, rather than blocking forever
+// at 0% CPU. Cancellation of ctx is NOT triggered here — the close
+// must happen purely from the dead-reaper path.
+func TestStreamIQ_ChannelClosesOnReaperDeath(t *testing.T) {
+	mock := usb.NewMockTransport()
+	mock.Script = []usb.CtrlExchange{
+		{In: false, BRequest: 0, WValue: rtl2832u.USBEpaCtl, WIndex: uint16(rtl2832u.BlockUSB)<<8 | 0x10, Data: []byte{0x10, 0x02}},
+		{In: false, BRequest: 0, WValue: rtl2832u.USBEpaCtl, WIndex: uint16(rtl2832u.BlockUSB)<<8 | 0x10, Data: []byte{0x00, 0x00}},
+	}
+	mock.BulkPackets = [][]byte{{127, 128, 127, 128}}
+	mock.BulkSimulateDeath = true
+	d := newDeviceWithFakeTuner(mock, &fakeTuner{})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ch, err := d.StreamIQ(ctx)
+	if err != nil {
+		t.Fatalf("StreamIQ: %v", err)
+	}
+	// Drain the one queued sample then wait for the reaper-death path
+	// to close the channel — without cancelling ctx.
+	deadline := time.NewTimer(time.Second)
+	defer deadline.Stop()
+loop:
+	for {
+		select {
+		case _, ok := <-ch:
+			if !ok {
+				break loop
+			}
+		case <-deadline.C:
+			t.Fatal("channel did not close after simulated reaper death")
+		}
+	}
+}
+
 func TestStreamIQ_DoubleStartFails(t *testing.T) {
 	mock := usb.NewMockTransport()
 	mock.Script = []usb.CtrlExchange{

--- a/internal/sdr/rtlsdr/tuners/detect_test.go
+++ b/internal/sdr/rtlsdr/tuners/detect_test.go
@@ -172,6 +172,6 @@ func (p *permissiveMockTransport) ReleaseInterface(int) error                   
 func (p *permissiveMockTransport) StartBulkIn(byte, int, int, func([]byte), func(error)) error {
 	return nil
 }
-func (p *permissiveMockTransport) StopBulkIn() error                                      { return nil }
-func (p *permissiveMockTransport) Reset() error                                           { return nil }
-func (p *permissiveMockTransport) Close() error                                           { return nil }
+func (p *permissiveMockTransport) StopBulkIn() error { return nil }
+func (p *permissiveMockTransport) Reset() error      { return nil }
+func (p *permissiveMockTransport) Close() error      { return nil }

--- a/internal/sdr/rtlsdr/tuners/detect_test.go
+++ b/internal/sdr/rtlsdr/tuners/detect_test.go
@@ -169,7 +169,9 @@ func (p *permissiveMockTransport) ControlIn(_ uint8, _, _ uint16, n int, _ int) 
 func (p *permissiveMockTransport) ControlOut(_ uint8, _, _ uint16, _ []byte, _ int) error { return nil }
 func (p *permissiveMockTransport) ClaimInterface(int) error                               { return nil }
 func (p *permissiveMockTransport) ReleaseInterface(int) error                             { return nil }
-func (p *permissiveMockTransport) StartBulkIn(byte, int, int, func([]byte)) error         { return nil }
+func (p *permissiveMockTransport) StartBulkIn(byte, int, int, func([]byte), func(error)) error {
+	return nil
+}
 func (p *permissiveMockTransport) StopBulkIn() error                                      { return nil }
 func (p *permissiveMockTransport) Reset() error                                           { return nil }
 func (p *permissiveMockTransport) Close() error                                           { return nil }

--- a/internal/sdr/rtlsdr/usb/usb.go
+++ b/internal/sdr/rtlsdr/usb/usb.go
@@ -78,7 +78,19 @@ type Transport interface {
 	// URB completes; the slice passed to it is owned by the transport
 	// and reused once onPacket returns — callers must copy any bytes
 	// they wish to retain.
-	StartBulkIn(epAddr byte, ringBufs, bufLen int, onPacket func([]byte)) error
+	//
+	// onStreamDead, when non-nil, is invoked exactly once when every URB
+	// has died of an unrecoverable USB error (host controller hang,
+	// ENODEV, EPROTO storm under load, ...) — i.e. the stream ended
+	// **without** StopBulkIn being called. Implementations must not
+	// invoke it on the normal StopBulkIn path, and must dispatch the
+	// callback from a fresh goroutine — never from the reaper itself,
+	// because the callback typically calls StopBulkIn (to close the
+	// driver's consumer channel) and StopBulkIn waits for the reaper to
+	// exit. Drivers use this hook to surface "stream died" to their IQ
+	// consumer; without it, a silent reaper exit leaves the consumer
+	// blocked forever (issue #345).
+	StartBulkIn(epAddr byte, ringBufs, bufLen int, onPacket func([]byte), onStreamDead func(error)) error
 
 	// StopBulkIn cancels every in-flight URB, drains the reaper, and
 	// returns once the goroutine has exited. Safe to call concurrently

--- a/internal/sdr/rtlsdr/usb/usb_darwin.go
+++ b/internal/sdr/rtlsdr/usb/usb_darwin.go
@@ -458,6 +458,28 @@ type darwinTransport struct {
 	bulkSlots    []*darwinBulkSlot
 	bulkStopFlag atomic.Int32
 	bulkDone     chan struct{}
+
+	// Stream-death aggregation. bulkAlive starts at len(bulkSlots) when
+	// StartBulkIn spawns the per-slot reapers; each goroutine decrements
+	// it on exit. When the count hits zero with bulkStopFlag still
+	// unset, the LAST goroutine fires bulkOnDead exactly once so the
+	// driver can close its consumer channel — fixes issue #345's
+	// "process alive at 0% CPU, all event counters frozen" stall.
+	bulkAlive    atomic.Int32
+	bulkOnDead   func(error)
+	bulkErrMu    sync.Mutex
+	bulkDeadErr  error // first non-stop slot error wins
+	bulkDeadOnce sync.Once
+}
+
+// recordBulkErr stashes err as the first-failing-slot reason if no
+// earlier error has won yet. Safe to call from per-slot goroutines.
+func (t *darwinTransport) recordBulkErr(err error) {
+	t.bulkErrMu.Lock()
+	defer t.bulkErrMu.Unlock()
+	if t.bulkDeadErr == nil {
+		t.bulkDeadErr = err
+	}
 }
 
 type darwinBulkSlot struct {
@@ -610,7 +632,7 @@ func (t *darwinTransport) Reset() error {
 // across the C/Go boundary, no run-loop thread to babysit. Cost is
 // ringBufs OS threads (32 default → ~32 MB stack). Acceptable for
 // a foreground SDR daemon.
-func (t *darwinTransport) StartBulkIn(epAddr byte, ringBufs, bufLen int, onPacket func([]byte)) error {
+func (t *darwinTransport) StartBulkIn(epAddr byte, ringBufs, bufLen int, onPacket func([]byte), onStreamDead func(error)) error {
 	if t.closed.Load() {
 		return ErrClosed
 	}
@@ -638,6 +660,12 @@ func (t *darwinTransport) StartBulkIn(epAddr byte, ringBufs, bufLen int, onPacke
 	t.bulkActive = true
 	t.bulkStopFlag.Store(0)
 	t.bulkDone = make(chan struct{}, ringBufs)
+	t.bulkOnDead = onStreamDead
+	t.bulkErrMu.Lock()
+	t.bulkDeadErr = nil
+	t.bulkErrMu.Unlock()
+	t.bulkDeadOnce = sync.Once{}
+	t.bulkAlive.Store(int32(len(slots)))
 	for _, s := range slots {
 		go t.bulkLoop(pipeRef, s, onPacket)
 	}
@@ -681,10 +709,34 @@ func (t *darwinTransport) findPipeRef(epAddr byte) (uint8, error) {
 // bulkLoop runs in a dedicated OS-thread-pinned goroutine. ReadPipe
 // blocks the kernel side; on AbortPipe + close-flag we exit. Each
 // successful read is delivered via onPacket.
+//
+// On exit the goroutine decrements bulkAlive; when the last live
+// goroutine returns with bulkStopFlag unset (every slot died of an
+// unrecoverable USB error rather than being aborted by StopBulkIn),
+// it fires bulkOnDead exactly once so the driver can surface "stream
+// died" to its IQ consumer — see issue #345.
 func (t *darwinTransport) bulkLoop(pipeRef uint8, slot *darwinBulkSlot, onPacket func([]byte)) {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
-	defer func() { t.bulkDone <- struct{}{} }()
+	defer func() {
+		t.bulkDone <- struct{}{}
+		if t.bulkAlive.Add(-1) == 0 && t.bulkStopFlag.Load() == 0 && t.bulkOnDead != nil {
+			t.bulkDeadOnce.Do(func() {
+				t.bulkErrMu.Lock()
+				err := t.bulkDeadErr
+				t.bulkErrMu.Unlock()
+				if err == nil {
+					err = ErrDeviceGone
+				}
+				// Dispatch from a fresh goroutine: bulkOnDead
+				// typically calls StopBulkIn (via the driver's cancel
+				// path) which drains bulkDone — and this slot's
+				// goroutine has not finished yet, so calling it inline
+				// would deadlock waiting on its own done event.
+				go t.bulkOnDead(err)
+			})
+		}
+	}()
 	for {
 		if t.bulkStopFlag.Load() != 0 {
 			return
@@ -702,6 +754,7 @@ func (t *darwinTransport) bulkLoop(pipeRef uint8, slot *darwinBulkSlot, onPacket
 			// kIOReturnAborted (cancellation) and any other
 			// transport error both exit the loop. ResetPipe
 			// below would be needed before re-Start.
+			t.recordBulkErr(fmt.Errorf("usb: ReadPipe: 0x%08x", uint32(rc)))
 			return
 		}
 		if size > 0 {

--- a/internal/sdr/rtlsdr/usb/usb_debug.go
+++ b/internal/sdr/rtlsdr/usb/usb_debug.go
@@ -150,9 +150,16 @@ func (d *debugTransport) ReleaseInterface(num int) error {
 	return d.inner.ReleaseInterface(num)
 }
 
-func (d *debugTransport) StartBulkIn(epAddr byte, ringBufs, bufLen int, onPacket func([]byte)) error {
+func (d *debugTransport) StartBulkIn(epAddr byte, ringBufs, bufLen int, onPacket func([]byte), onStreamDead func(error)) error {
 	d.logf("StartBulkIn ep=0x%02x ring=%d bufLen=%d", epAddr, ringBufs, bufLen)
-	return d.inner.StartBulkIn(epAddr, ringBufs, bufLen, onPacket)
+	wrappedDead := onStreamDead
+	if onStreamDead != nil {
+		wrappedDead = func(err error) {
+			d.logf("onStreamDead: %v", err)
+			onStreamDead(err)
+		}
+	}
+	return d.inner.StartBulkIn(epAddr, ringBufs, bufLen, onPacket, wrappedDead)
 }
 
 func (d *debugTransport) StopBulkIn() error {

--- a/internal/sdr/rtlsdr/usb/usb_linux.go
+++ b/internal/sdr/rtlsdr/usb/usb_linux.go
@@ -363,7 +363,7 @@ func (t *linuxTransport) Reset() error {
 	return nil
 }
 
-func (t *linuxTransport) StartBulkIn(epAddr byte, ringBufs, bufLen int, onPacket func([]byte)) error {
+func (t *linuxTransport) StartBulkIn(epAddr byte, ringBufs, bufLen int, onPacket func([]byte), onStreamDead func(error)) error {
 	if t.closed.Load() {
 		return ErrClosed
 	}
@@ -400,7 +400,7 @@ func (t *linuxTransport) StartBulkIn(epAddr byte, ringBufs, bufLen int, onPacket
 	t.bulkStopFlag.Store(0)
 	t.bulkDone = make(chan struct{})
 
-	go t.reapLoop(onPacket, slots, t.bulkSubmitted, t.bulkDone)
+	go t.reapLoop(onPacket, onStreamDead, slots, t.bulkSubmitted, t.bulkDone)
 	return nil
 }
 
@@ -416,10 +416,16 @@ func (t *linuxTransport) drainSubmitted(n int) {
 	}
 }
 
-func (t *linuxTransport) reapLoop(onPacket func([]byte), slots []*bulkSlot, submitted int, done chan struct{}) {
+func (t *linuxTransport) reapLoop(onPacket func([]byte), onStreamDead func(error), slots []*bulkSlot, submitted int, done chan struct{}) {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 	defer close(done)
+	// firstErr keeps the first non-EINTR errno we see — either a ReapURB
+	// failure or a resubmit failure. When the loop exits with the stop
+	// flag unset (i.e. every URB died of an unrecoverable error rather
+	// than being aborted by StopBulkIn), we hand it to onStreamDead so
+	// the driver can surface "stream died" to its IQ consumer.
+	var firstErr error
 	remaining := submitted
 	for remaining > 0 {
 		var ptr uintptr
@@ -428,7 +434,10 @@ func (t *linuxTransport) reapLoop(onPacket func([]byte), slots []*bulkSlot, subm
 			if errno == unix.EINTR {
 				continue
 			}
-			return
+			if firstErr == nil {
+				firstErr = fmt.Errorf("usbdevfs: REAPURB: %w", translateErrno(errno))
+			}
+			break
 		}
 		// The kernel returns the address of the URB we previously submitted.
 		// Don't deref the raw uintptr — look it up against our slot ring
@@ -447,11 +456,23 @@ func (t *linuxTransport) reapLoop(onPacket func([]byte), slots []*bulkSlot, subm
 			urb.Status = 0
 			_, _, errno = unix.Syscall(unix.SYS_IOCTL, uintptr(t.fd), usbdevfsSubmitURB, uintptr(unsafe.Pointer(urb)))
 			if errno != 0 {
+				if firstErr == nil {
+					firstErr = fmt.Errorf("usbdevfs: SUBMITURB resubmit: %w", translateErrno(errno))
+				}
 				remaining--
 			}
 			continue
 		}
 		remaining--
+	}
+	if t.bulkStopFlag.Load() == 0 && onStreamDead != nil {
+		if firstErr == nil {
+			firstErr = ErrDeviceGone
+		}
+		// Dispatch from a fresh goroutine: onStreamDead typically calls
+		// StopBulkIn (via the driver's cancel path) which waits on
+		// `done` — which is only closed after this function returns.
+		go onStreamDead(firstErr)
 	}
 }
 

--- a/internal/sdr/rtlsdr/usb/usb_mock.go
+++ b/internal/sdr/rtlsdr/usb/usb_mock.go
@@ -87,6 +87,13 @@ type MockTransport struct {
 
 	BulkPackets  [][]byte
 	BulkInterval time.Duration
+	// BulkSimulateDeath, when true, makes the bulk-IN goroutine fire
+	// onStreamDead (with BulkDeathErr, or ErrDeviceGone if nil) after
+	// dispatching all BulkPackets instead of blocking on StopBulkIn.
+	// Tests use it to assert drivers close their consumer channel when
+	// the USB reaper dies unexpectedly (issue #345).
+	BulkSimulateDeath bool
+	BulkDeathErr      error
 
 	mu       sync.Mutex
 	bulkActv bool
@@ -197,7 +204,7 @@ func (m *MockTransport) ReleaseInterface(num int) error {
 	return nil
 }
 
-func (m *MockTransport) StartBulkIn(epAddr byte, ringBufs, bufLen int, onPacket func([]byte)) error {
+func (m *MockTransport) StartBulkIn(epAddr byte, ringBufs, bufLen int, onPacket func([]byte), onStreamDead func(error)) error {
 	m.mu.Lock()
 	if m.Closed {
 		m.mu.Unlock()
@@ -212,6 +219,8 @@ func (m *MockTransport) StartBulkIn(epAddr byte, ringBufs, bufLen int, onPacket 
 	m.bulkDone = make(chan struct{})
 	packets := append([][]byte(nil), m.BulkPackets...)
 	interval := m.BulkInterval
+	simulateDeath := m.BulkSimulateDeath
+	deathErr := m.BulkDeathErr
 	m.mu.Unlock()
 
 	go func() {
@@ -232,6 +241,19 @@ func (m *MockTransport) StartBulkIn(epAddr byte, ringBufs, bufLen int, onPacket 
 				case <-time.After(interval):
 				}
 			}
+		}
+		if simulateDeath {
+			if onStreamDead != nil {
+				if deathErr == nil {
+					deathErr = ErrDeviceGone
+				}
+				// Dispatch from a fresh goroutine — matches the real
+				// transports' contract: onStreamDead typically calls
+				// StopBulkIn, which waits on bulkDone (closed only
+				// after this goroutine returns).
+				go onStreamDead(deathErr)
+			}
+			return
 		}
 		<-m.bulkStop
 	}()

--- a/internal/sdr/rtlsdr/usb/usb_test.go
+++ b/internal/sdr/rtlsdr/usb/usb_test.go
@@ -154,7 +154,7 @@ func TestMockTransport_BulkInDispatch(t *testing.T) {
 		copy(c, p)
 		got = append(got, c)
 		mu.Unlock()
-	}); err != nil {
+	}, nil); err != nil {
 		t.Fatalf("StartBulkIn: %v", err)
 	}
 	// Wait for the goroutine to dispatch both packets and park on bulkStop.
@@ -183,10 +183,10 @@ func TestMockTransport_BulkInDispatch(t *testing.T) {
 
 func TestMockTransport_DoubleStartFails(t *testing.T) {
 	m := NewMockTransport()
-	if err := m.StartBulkIn(0x81, 1, 8, func([]byte) {}); err != nil {
+	if err := m.StartBulkIn(0x81, 1, 8, func([]byte) {}, nil); err != nil {
 		t.Fatalf("first StartBulkIn: %v", err)
 	}
-	if err := m.StartBulkIn(0x81, 1, 8, func([]byte) {}); !errors.Is(err, ErrBulkActive) {
+	if err := m.StartBulkIn(0x81, 1, 8, func([]byte) {}, nil); !errors.Is(err, ErrBulkActive) {
 		t.Errorf("second StartBulkIn err = %v, want ErrBulkActive", err)
 	}
 	_ = m.StopBulkIn()
@@ -233,7 +233,7 @@ func TestMockTransport_CloseIdempotent(t *testing.T) {
 
 func TestMockTransport_CloseStopsBulk(t *testing.T) {
 	m := NewMockTransport()
-	if err := m.StartBulkIn(0x81, 1, 8, func([]byte) {}); err != nil {
+	if err := m.StartBulkIn(0x81, 1, 8, func([]byte) {}, nil); err != nil {
 		t.Fatalf("StartBulkIn: %v", err)
 	}
 	done := make(chan struct{})
@@ -245,6 +245,66 @@ func TestMockTransport_CloseStopsBulk(t *testing.T) {
 	case <-done:
 	case <-time.After(time.Second):
 		t.Fatal("Close did not return")
+	}
+}
+
+// TestMockTransport_OnStreamDeadFiresWhenSimulated pins the issue-#345
+// contract: when BulkSimulateDeath is set, the mock fires onStreamDead
+// after dispatching all packets — drivers wire this into their consumer-
+// channel teardown path so a real reaper death doesn't leave the IQ
+// consumer (ccdecoder) blocked forever at 0% CPU.
+func TestMockTransport_OnStreamDeadFiresWhenSimulated(t *testing.T) {
+	m := NewMockTransport()
+	m.BulkPackets = [][]byte{{0xaa}}
+	m.BulkSimulateDeath = true
+	m.BulkDeathErr = ErrDeviceGone
+
+	deadCh := make(chan error, 1)
+	if err := m.StartBulkIn(0x81, 1, 8, func([]byte) {}, func(err error) {
+		deadCh <- err
+	}); err != nil {
+		t.Fatalf("StartBulkIn: %v", err)
+	}
+	select {
+	case err := <-deadCh:
+		if !errors.Is(err, ErrDeviceGone) {
+			t.Errorf("onStreamDead err = %v, want ErrDeviceGone", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("onStreamDead did not fire after simulated death")
+	}
+	// onStreamDead must not fire a second time even if Stop is called.
+	if err := m.StopBulkIn(); err != nil {
+		t.Fatalf("StopBulkIn: %v", err)
+	}
+	select {
+	case err := <-deadCh:
+		t.Errorf("onStreamDead fired again after StopBulkIn: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+// TestMockTransport_OnStreamDeadNotFiredOnNormalStop guards against
+// false positives: a clean StopBulkIn (no simulated death) must not
+// fire onStreamDead, or the daemon's restart loop would trigger on
+// every normal shutdown.
+func TestMockTransport_OnStreamDeadNotFiredOnNormalStop(t *testing.T) {
+	m := NewMockTransport()
+	m.BulkPackets = [][]byte{{0xaa}}
+	called := make(chan struct{}, 1)
+	if err := m.StartBulkIn(0x81, 1, 8, func([]byte) {}, func(error) { called <- struct{}{} }); err != nil {
+		t.Fatalf("StartBulkIn: %v", err)
+	}
+	// Wait briefly so the goroutine dispatches the packet and parks
+	// on bulkStop (rather than racing StopBulkIn).
+	time.Sleep(20 * time.Millisecond)
+	if err := m.StopBulkIn(); err != nil {
+		t.Fatalf("StopBulkIn: %v", err)
+	}
+	select {
+	case <-called:
+		t.Fatal("onStreamDead fired on normal StopBulkIn")
+	case <-time.After(50 * time.Millisecond):
 	}
 }
 

--- a/internal/sdr/rtlsdr/usb/usb_windows.go
+++ b/internal/sdr/rtlsdr/usb/usb_windows.go
@@ -331,7 +331,7 @@ func (t *winTransport) Reset() error {
 	return nil
 }
 
-func (t *winTransport) StartBulkIn(epAddr byte, ringBufs, bufLen int, onPacket func([]byte)) error {
+func (t *winTransport) StartBulkIn(epAddr byte, ringBufs, bufLen int, onPacket func([]byte), onStreamDead func(error)) error {
 	if t.closed.Load() {
 		return ErrClosed
 	}
@@ -417,7 +417,7 @@ func (t *winTransport) StartBulkIn(epAddr byte, ringBufs, bufLen int, onPacket f
 	t.bulkStopFlag.Store(0)
 	t.bulkDone = make(chan struct{})
 
-	go t.reapLoop(onPacket)
+	go t.reapLoop(onPacket, onStreamDead)
 	return nil
 }
 
@@ -444,14 +444,32 @@ func (t *winTransport) issueReadPipe(epAddr byte, s *winBulkSlot) error {
 	return nil
 }
 
-func (t *winTransport) reapLoop(onPacket func([]byte)) {
+func (t *winTransport) reapLoop(onPacket func([]byte), onStreamDead func(error)) {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 	defer close(t.bulkDone)
 
+	// firstErr stashes the first error that took a slot out of rotation.
+	// When the loop exits with the stop flag unset (i.e. every slot died
+	// of an unrecoverable error rather than being aborted by
+	// StopBulkIn), we hand it to onStreamDead so the driver can surface
+	// "stream died" to its IQ consumer.
+	var firstErr error
 	// Active mask — once a slot's I/O is taken to completion under stop
 	// we mark it consumed; we exit when no slot is still in flight.
 	consumed := make([]bool, len(t.bulkSlots))
+	defer func() {
+		if t.bulkStopFlag.Load() == 0 && onStreamDead != nil {
+			if firstErr == nil {
+				firstErr = ErrDeviceGone
+			}
+			// Dispatch from a fresh goroutine: onStreamDead typically
+			// calls StopBulkIn (via the driver's cancel path) which
+			// waits on `bulkDone` — which is only closed by this
+			// reaper's defer chain (registered earlier, runs after).
+			go onStreamDead(firstErr)
+		}
+	}()
 	for {
 		// Build a wait list of unfinished events.
 		wait := make([]windows.Handle, 0, len(t.bulkSlots))
@@ -467,10 +485,16 @@ func (t *winTransport) reapLoop(onPacket func([]byte)) {
 		}
 		ret, err := windows.WaitForMultipleObjects(wait, false, windows.INFINITE)
 		if err != nil {
+			if firstErr == nil {
+				firstErr = fmt.Errorf("winusb: WaitForMultipleObjects: %w", err)
+			}
 			return
 		}
 		raw := int(ret - windows.WAIT_OBJECT_0)
 		if raw < 0 || raw >= len(wait) {
+			if firstErr == nil {
+				firstErr = fmt.Errorf("winusb: WaitForMultipleObjects returned %d outside slot range", ret)
+			}
 			return
 		}
 		slotIdx := idxMap[raw]
@@ -492,6 +516,9 @@ func (t *winTransport) reapLoop(onPacket func([]byte)) {
 		}
 		if err := t.issueReadPipe(t.bulkEpAddr, slot); err != nil {
 			// Slot is dead; mark consumed so we don't wait on its event.
+			if firstErr == nil {
+				firstErr = fmt.Errorf("winusb: ReadPipe resubmit: %w", err)
+			}
 			consumed[slotIdx] = true
 		}
 	}


### PR DESCRIPTION
The shared bulk-IN reaper goroutine on every platform (linux,
windows, darwin) exited silently when every URB became
unrecoverable, leaving the driver's IQ consumer channel neither
sending nor closed. ccdecoder's select blocked on the dead stream
forever, decoder.pump stopped running, and every downstream
events.Publish stopped — the daemon went idle at 0% CPU with all
gophertrunk_events_total counters frozen, alive but inert.

Fix in three layers:

- usb.Transport.StartBulkIn grows an onStreamDead callback fired
  exactly once when the reaper exits without StopBulkIn. The
  callback is dispatched from a fresh goroutine so it may safely
  call back into StopBulkIn without deadlocking on bulkDone.
  Implemented in usb_linux.go, usb_windows.go, usb_darwin.go,
  usb_mock.go (BulkSimulateDeath toggle), usb_debug.go.
- Each hardware driver (purego, airspy, airspyhf, hackrf) wires
  onStreamDead into its existing cleanup goroutine via a
  streamDead channel + sync.Once so the consumer channel always
  closes — exactly once — on either ctx-cancel or reaper death.
- ccdecoder.Run now returns ErrIQStreamClosed (instead of nil) on
  unexpected stream EOF. The daemon wraps ccdecoder.Run in a
  backoff-driven restart loop: 1s/2s/5s/10s, with the attempt
  counter reset after a 60s healthy run. Exhausting the schedule
  escalates to recordFatal so an external supervisor restarts a
  clean process.

Regression tests:
- usb mock: onStreamDead fires once on BulkSimulateDeath, never on
  normal StopBulkIn.
- purego: StreamIQ consumer channel closes after a simulated reaper
  death without ctx-cancel.
- ccdecoder: Run returns ErrIQStreamClosed when its IQ source EOFs
  while ctx is live.
- daemon: restart loop recovers across transient deaths and
  escalates to fatal once retries are exhausted.