### PR TITLE
ccdecoder: classify StreamIQ open errors as ErrIQStreamClosed (#345)

### DIFF
--- a/cmd/gophertrunk/ccdecoder_retry_test.go
+++ b/cmd/gophertrunk/ccdecoder_retry_test.go
@@ -146,3 +146,89 @@ func TestRunCCDecoderWithRetry_FatalsAfterRetriesExhausted(t *testing.T) {
 		t.Error("expected recordFatal to fire after retries exhausted")
 	}
 }
+
+// usbDisconnectIQSource models the exact failure pattern reported in
+// issue #345 after the v0.2.1 retry shipped: the first StreamIQ call
+// hands out a healthy channel that the caller-side reaper closes
+// (mid-stream EOF), and every subsequent StreamIQ call returns the
+// underlying USB-disconnect error directly — i.e. the rebuilt decoder
+// hits a dead Tuner handle that rejects the ResetBuffer control
+// transfer. Without the issue-#345 follow-up fix this open-time error
+// is NOT classified as ErrIQStreamClosed, so the daemon's retry loop
+// returns it as-is and (with essential=false) silently swallows it.
+type usbDisconnectIQSource struct {
+	opens atomic.Int32
+}
+
+func (u *usbDisconnectIQSource) StreamIQ(ctx context.Context) (<-chan []complex64, error) {
+	n := u.opens.Add(1)
+	if n == 1 {
+		ch := make(chan []complex64)
+		go func() {
+			defer close(ch)
+			select {
+			case ch <- make([]complex64, 4):
+			case <-ctx.Done():
+				return
+			}
+			// Reaper death: close mid-stream without ctx-cancel.
+		}()
+		return ch, nil
+	}
+	// Every retry sees the device gone.
+	return nil, errors.New("rtl2832u: write block=1 addr=0x2148 val=0x1002: usb: device disconnected")
+}
+
+// TestRunCCDecoderWithRetry_USBDisconnectEscalatesToFatal pins the
+// issue-#345 follow-up: after the initial reaper-death triggers a
+// rebuild and every subsequent StreamIQ open fails with
+// `usb: device disconnected`, the retry loop must classify those
+// open failures as ErrIQStreamClosed (so it stays in the backoff
+// schedule rather than bailing out early) and, on exhaustion, fire
+// recordFatal so the supervisor restarts the process. Pre-fix this
+// test fails because runCCDecoderWithRetry returns the unwrapped
+// open error after one attempt and never records a fatal.
+func TestRunCCDecoderWithRetry_USBDisconnectEscalatesToFatal(t *testing.T) {
+	oldBackoffs := ccDecoderRetryBackoffs
+	ccDecoderRetryBackoffs = []time.Duration{
+		5 * time.Millisecond,
+		5 * time.Millisecond,
+	}
+	defer func() { ccDecoderRetryBackoffs = oldBackoffs }()
+
+	bus := events.NewBus(8)
+	defer bus.Close()
+	src := &usbDisconnectIQSource{}
+	opts := ccdecoder.Options{
+		Bus: bus, IQ: src, SampleRateHz: 48000,
+		Log: slog.New(slog.DiscardHandler),
+	}
+	dec, err := ccdecoder.New(opts)
+	if err != nil {
+		t.Fatalf("ccdecoder.New: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	d := &Daemon{
+		log:           slog.New(slog.DiscardHandler),
+		bus:           bus,
+		systems:       []trunking.System{},
+		ccDecoder:     dec,
+		ccDecoderOpts: opts,
+		cancel:        cancel,
+	}
+
+	got := d.runCCDecoderWithRetry(ctx)
+	if !errors.Is(got, ccdecoder.ErrIQStreamClosed) {
+		t.Errorf("Run = %v, want wrapped ErrIQStreamClosed", got)
+	}
+	if d.takeFatal() == nil {
+		t.Error("expected recordFatal to fire after USB-disconnect retries exhausted")
+	}
+	// Sanity: we should have seen at least one mid-stream death and
+	// one open-time disconnect, proving the new classification covers
+	// both shapes.
+	if got, want := src.opens.Load(), int32(2); got < want {
+		t.Errorf("StreamIQ opens = %d, want >= %d", got, want)
+	}
+}

--- a/internal/scanner/ccdecoder/decoder.go
+++ b/internal/scanner/ccdecoder/decoder.go
@@ -45,6 +45,7 @@ package ccdecoder
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"math"
 	"sync"
@@ -62,12 +63,16 @@ type IQPowerObserver interface {
 	ClearIQPowerDbFS(system string)
 }
 
-// ErrIQStreamClosed is returned by Run when the SDR's IQ channel closes
-// while the context is still live — the underlying USB reaper died of
-// an unrecoverable error (host controller hang, ENODEV, EPROTO storm
-// under load) and the driver propagated EOF instead of hanging forever.
-// The daemon's restart loop watches for this and re-opens the SDR.
-// See issue #345.
+// ErrIQStreamClosed is returned by Run whenever the SDR's IQ stream is
+// unexpectedly unavailable while the context is still live — either the
+// channel closed mid-stream (the USB reaper died of an unrecoverable
+// error: host controller hang, ENODEV, EPROTO storm under load) or
+// StreamIQ failed to open at all on a Run retry (the underlying device
+// has physically disconnected and the dead handle now rejects every
+// control transfer with `usb: device disconnected`). Both shapes feed
+// the same restart loop in the daemon; the underlying error is
+// preserved via %w chaining so callers can still inspect the root
+// cause. See issue #345.
 var ErrIQStreamClosed = errors.New("ccdecoder: IQ stream closed unexpectedly")
 
 // iqPowerWindow is how long the pump aggregates samples before
@@ -207,7 +212,16 @@ func New(opts Options) (*Decoder, error) {
 func (d *Decoder) Run(ctx context.Context) error {
 	stream, err := d.iq.StreamIQ(ctx)
 	if err != nil {
-		return err
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return err
+		}
+		// On the daemon's retry path the previous Tuner handle is
+		// often dead (USB device pulled and re-enumerated). Surface
+		// the open failure as ErrIQStreamClosed so the daemon's
+		// restart loop classifies it the same as a mid-stream reaper
+		// death and either retries or escalates to a clean fatal.
+		// Issue #345.
+		return fmt.Errorf("%w: %w", ErrIQStreamClosed, err)
 	}
 
 	defer d.sub.Close()

--- a/internal/scanner/ccdecoder/decoder_test.go
+++ b/internal/scanner/ccdecoder/decoder_test.go
@@ -182,8 +182,38 @@ func TestRunPropagatesStreamIQError(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
-	if got := d.Run(context.Background()); !errors.Is(got, wantErr) {
-		t.Errorf("Run = %v, want %v", got, wantErr)
+	got := d.Run(context.Background())
+	// The underlying StreamIQ error must remain inspectable so callers
+	// can still log the root cause.
+	if !errors.Is(got, wantErr) {
+		t.Errorf("Run = %v, want underlying %v preserved", got, wantErr)
+	}
+	// A non-context StreamIQ open failure must now classify as
+	// ErrIQStreamClosed so the daemon's restart loop catches it and
+	// either retries or escalates to a clean fatal. Issue #345.
+	if !errors.Is(got, ErrIQStreamClosed) {
+		t.Errorf("Run = %v, want errors.Is(..., ErrIQStreamClosed)", got)
+	}
+}
+
+// TestRunPassesThroughContextCancelFromStreamIQ pins the inverse: a
+// context-cancel error from StreamIQ must NOT be wrapped as
+// ErrIQStreamClosed — shutdown is not a stream failure.
+func TestRunPassesThroughContextCancelFromStreamIQ(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	d, err := New(Options{
+		Bus: bus, IQ: erroringIQSource{err: context.Canceled}, SampleRateHz: 48000,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	got := d.Run(context.Background())
+	if !errors.Is(got, context.Canceled) {
+		t.Errorf("Run = %v, want context.Canceled", got)
+	}
+	if errors.Is(got, ErrIQStreamClosed) {
+		t.Errorf("Run = %v, must not classify ctx cancel as ErrIQStreamClosed", got)
 	}
 }
 


### PR DESCRIPTION
After the v0.2.1 retry shipped, the reporter still saw the daemon's
ccdecoder component silently exit on a real RTL-SDR USB
disconnect/re-enumerate. Trace:

1. Reaper dies mid-stream -> Decoder.Run returns ErrIQStreamClosed.
2. runCCDecoderWithRetry waits 1s and rebuilds the decoder against the
   same Tuner handle (the device has physically disconnected; the
   handle is permanently dead).
3. The rebuilt Run calls StreamIQ -> ResetBuffer -> control transfer,
   which fails with `usb: device disconnected` and returns that error
   straight through Decoder.Run.
4. The retry loop only matches ErrIQStreamClosed, so it returns the
   raw error.
5. ccdecoder is spawned with essential=false, so spawn logs a warning
   and the daemon keeps running with no CC decoder.

Wrap non-context StreamIQ open errors as `%w: %w` against
ErrIQStreamClosed so the daemon classifies both shapes (mid-stream EOF
and open-time `device disconnected`) the same way. The underlying
error is still inspectable via errors.Is for the root cause, and the
existing retry+recordFatal path now reaches the `retries exhausted ->
fatal` arm for genuinely-gone hardware, letting systemd/docker/the
launcher restart the process and re-discover the SDR by serial.

Tests:
- ccdecoder: TestRunPropagatesStreamIQError extended to assert both
  underlying-error preservation and ErrIQStreamClosed classification;
  TestRunPassesThroughContextCancelFromStreamIQ pins the inverse so
  ctx-cancel is not wrapped.
- daemon: TestRunCCDecoderWithRetry_USBDisconnectEscalatesToFatal
  reproduces the reporter's exact pattern (one mid-stream death
  followed by repeated open-time disconnects) and asserts the loop
  exhausts retries and fires recordFatal.