### PR TITLE
p25/phase1: queue grants pending IDEN_UP + config band-plan seed (#345)

### DIFF
--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -231,10 +231,24 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 		if err != nil {
 			return nil, fmt.Errorf("daemon: %w", err)
 		}
+		var p25BandPlan []trunking.P25BandPlanEntry
+		if len(sys.P25BandPlan) > 0 {
+			p25BandPlan = make([]trunking.P25BandPlanEntry, 0, len(sys.P25BandPlan))
+			for _, e := range sys.P25BandPlan {
+				p25BandPlan = append(p25BandPlan, trunking.P25BandPlanEntry{
+					ChannelID:   e.ChannelID,
+					BaseHz:      e.BaseHz,
+					SpacingHz:   e.SpacingHz,
+					TxOffsetHz:  e.TxOffsetHz,
+					BandwidthHz: e.BandwidthHz,
+				})
+			}
+		}
 		s := trunking.System{
 			Name:                    sys.Name,
 			Protocol:                proto,
 			ControlChannels:         sys.ControlChannels,
+			P25BandPlan:             p25BandPlan,
 			TETRAColourCode:         sys.TETRAColourCode,
 			TETRAChannel:            sys.TETRAChannel,
 			TETRAChannelCoding:      sys.TETRAChannelCoding,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -449,6 +449,14 @@ type SystemConfig struct {
 	// protocols.
 	DStarFECMode string `yaml:"dstar_fec_mode"`
 
+	// P25BandPlan seeds the Phase 1 receiver's BandPlan with static
+	// IdentifierUpdate slot entries — the operator's escape hatch for
+	// sites that route grants through a channel ID they never
+	// broadcast an IDEN_UP TSBK for (issue #345). Over-the-air
+	// IDEN_UPs take precedence; entries here are the startup floor.
+	// Ignored for non-P25-Phase-1 protocols.
+	P25BandPlan []P25BandPlanEntryConfig `yaml:"p25_band_plan"`
+
 	// EncryptionKeys lists operator-supplied decryption keys for this
 	// system. GopherTrunk decrypts only with keys the operator
 	// already holds and is authorized to use — it performs no key
@@ -457,6 +465,22 @@ type SystemConfig struct {
 	// so AES can be added later without a config break. Ignored for
 	// protocols without an encryption decoder. See issue #276.
 	EncryptionKeys []EncryptionKeyConfig `yaml:"encryption_keys"`
+}
+
+// P25BandPlanEntryConfig is one operator-supplied IDEN_UP slot seed
+// for the Phase 1 receiver. ChannelID is the 4-bit IDEN_UP slot index
+// (0..15). BaseHz / SpacingHz / TxOffsetHz / BandwidthHz mirror the
+// on-air IDEN_UP fields per TIA-102.AABF — see
+// internal/radio/p25/phase1/identifier.go for the bit layout. Most
+// operators only need to populate ChannelID + BaseHz + SpacingHz +
+// TxOffsetHz; BandwidthHz is informational and BandPlan.Frequency
+// does not consult it.
+type P25BandPlanEntryConfig struct {
+	ChannelID   uint8  `yaml:"channel_id"`
+	BaseHz      uint64 `yaml:"base_hz"`
+	SpacingHz   uint32 `yaml:"spacing_hz"`
+	TxOffsetHz  int64  `yaml:"tx_offset_hz"`
+	BandwidthHz uint32 `yaml:"bandwidth_hz"`
 }
 
 // EncryptionKeyConfig is one operator-supplied decryption key for a
@@ -686,6 +710,22 @@ func (c Config) Validate() error {
 		}
 		if _, err := trunking.ParseProtocol(s.Protocol); err != nil {
 			return fmt.Errorf("trunking.systems[%d]: %w", i, err)
+		}
+		seenBandPlanIDs := make(map[uint8]int, len(s.P25BandPlan))
+		for k, e := range s.P25BandPlan {
+			if e.ChannelID > 15 {
+				return fmt.Errorf("trunking.systems[%d].p25_band_plan[%d]: channel_id %d outside 0..15", i, k, e.ChannelID)
+			}
+			if prev, dup := seenBandPlanIDs[e.ChannelID]; dup {
+				return fmt.Errorf("trunking.systems[%d].p25_band_plan[%d]: duplicate channel_id %d (also at p25_band_plan[%d])", i, k, e.ChannelID, prev)
+			}
+			seenBandPlanIDs[e.ChannelID] = k
+			if e.SpacingHz == 0 {
+				return fmt.Errorf("trunking.systems[%d].p25_band_plan[%d]: spacing_hz required (nonzero)", i, k)
+			}
+			if e.BaseHz == 0 {
+				return fmt.Errorf("trunking.systems[%d].p25_band_plan[%d]: base_hz required (nonzero)", i, k)
+			}
 		}
 		seenKeyIDs := make(map[uint16]struct{}, len(s.EncryptionKeys))
 		for k, ek := range s.EncryptionKeys {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -81,6 +81,13 @@ func TestValidate(t *testing.T) {
 		{"distinct sdr serials ok", Config{SDR: SDRConfig{Devices: []DeviceConfig{{Serial: "00000001", Role: "control"}, {Serial: "00000002", Role: "voice"}}}}, false},
 		{"empty sdr serials ok", Config{SDR: SDRConfig{Devices: []DeviceConfig{{Role: "control"}, {Role: "voice"}}}}, false},
 		{"oversized key", Config{Trunking: TrunkingConfig{Systems: []SystemConfig{{Name: "x", Protocol: "dmr", EncryptionKeys: []EncryptionKeyConfig{{KeyID: 1, Algorithm: "rc4", Key: strings.Repeat("ab", 33)}}}}}}, true},
+		// p25_band_plan: the operator's escape hatch for sites that
+		// never broadcast IDEN_UP for some channel ID (issue #345).
+		{"band_plan ok", Config{Trunking: TrunkingConfig{Systems: []SystemConfig{{Name: "x", Protocol: "p25", P25BandPlan: []P25BandPlanEntryConfig{{ChannelID: 10, BaseHz: 425_262_500, SpacingHz: 6250, TxOffsetHz: 4_000_000, BandwidthHz: 12500}}}}}}, false},
+		{"band_plan channel_id too high", Config{Trunking: TrunkingConfig{Systems: []SystemConfig{{Name: "x", Protocol: "p25", P25BandPlan: []P25BandPlanEntryConfig{{ChannelID: 16, BaseHz: 1, SpacingHz: 1}}}}}}, true},
+		{"band_plan duplicate channel_id", Config{Trunking: TrunkingConfig{Systems: []SystemConfig{{Name: "x", Protocol: "p25", P25BandPlan: []P25BandPlanEntryConfig{{ChannelID: 3, BaseHz: 1, SpacingHz: 1}, {ChannelID: 3, BaseHz: 2, SpacingHz: 2}}}}}}, true},
+		{"band_plan zero spacing", Config{Trunking: TrunkingConfig{Systems: []SystemConfig{{Name: "x", Protocol: "p25", P25BandPlan: []P25BandPlanEntryConfig{{ChannelID: 3, BaseHz: 1, SpacingHz: 0}}}}}}, true},
+		{"band_plan zero base", Config{Trunking: TrunkingConfig{Systems: []SystemConfig{{Name: "x", Protocol: "p25", P25BandPlan: []P25BandPlanEntryConfig{{ChannelID: 3, BaseHz: 0, SpacingHz: 1}}}}}}, true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/radio/p25/phase1/control.go
+++ b/internal/radio/p25/phase1/control.go
@@ -65,6 +65,12 @@ type ControlChannel struct {
 	// queryable system-topology snapshot. Self-synchronised.
 	netModel NetworkModel
 
+	// pendingGrants buffers voice grants whose channel ID had no
+	// IdentifierUpdate at arrival. publishVoiceGrant adds on a
+	// BandPlan miss; dispatchTSBK drains after BandPlan.Apply lands a
+	// new slot. See pending_grants.go.
+	pendingGrants pendingGrants
+
 	// rotations is the dibit-alphabet rotation set the NID-alignment
 	// search probes. Nil/empty means RotationsAll (the legacy
 	// four-rotation behaviour). The ccdecoder pipeline restricts it
@@ -714,6 +720,7 @@ func (c *ControlChannel) dispatchTSBK(t TSBK, nac uint16, metric int) {
 			"nac", nac, "id", u.ChannelID,
 			"base_hz", u.BaseHz, "spacing_hz", u.SpacingHz,
 			"tx_offset_hz", u.TxOffsetHz)
+		c.drainPendingGrants(u.ChannelID, nac)
 	case OpIdentifierUpdateVUHF:
 		u := ParseIdentifierUpdateVUHF(t.Payload)
 		c.bandPlan.Apply(u)
@@ -722,6 +729,7 @@ func (c *ControlChannel) dispatchTSBK(t TSBK, nac uint16, metric int) {
 			"base_hz", u.BaseHz, "spacing_hz", u.SpacingHz,
 			"tx_offset_hz", u.TxOffsetHz,
 			"bandwidth_hz", u.BandwidthHz)
+		c.drainPendingGrants(u.ChannelID, nac)
 	case OpGroupVoiceChannelGrant:
 		c.publishGroupGrant(ParseGroupVoiceChannelGrant(t.Payload), nac)
 	case OpGroupVoiceChannelUpdate:
@@ -865,6 +873,7 @@ func (c *ControlChannel) publishVoiceGrant(g voiceGrant, nac uint16) {
 	if err != nil {
 		c.log.Debug("p25: grant before identifier update",
 			"nac", nac, "id", g.channelID, "num", g.channelNumber, "err", err)
+		c.pendingGrants.add(g.channelID, g, nac, c.now())
 		c.bus.Publish(events.Event{
 			Kind:    events.KindDecodeError,
 			Payload: events.DecodeError{Protocol: "p25", Stage: events.StageNoBandPlan},
@@ -893,6 +902,24 @@ func (c *ControlChannel) publishVoiceGrant(g voiceGrant, nac uint16) {
 		"tg", g.groupID, "src", g.sourceID,
 		"id", g.channelID, "num", g.channelNumber, "freq_hz", freq,
 		"enc", so.Encrypted(), "emer", so.Emergency(), "data", g.dataCall)
+}
+
+// drainPendingGrants re-publishes every voice grant that arrived for
+// channelID before its IdentifierUpdate landed. Called from
+// dispatchTSBK immediately after BandPlan.Apply populates the slot,
+// so the second publishVoiceGrant pass resolves through the freshly
+// applied band-plan entry. Entries older than pendingGrantTTL are
+// dropped silently — the call they describe has already passed.
+func (c *ControlChannel) drainPendingGrants(channelID uint8, nac uint16) {
+	queued := c.pendingGrants.drain(channelID, c.now())
+	if len(queued) == 0 {
+		return
+	}
+	c.log.Debug("p25: draining deferred grants",
+		"nac", nac, "id", channelID, "count", len(queued))
+	for _, p := range queued {
+		c.publishVoiceGrant(p.g, p.nac)
+	}
 }
 
 // publishGroupGrant publishes a standard group voice grant (opcode

--- a/internal/radio/p25/phase1/control_test.go
+++ b/internal/radio/p25/phase1/control_test.go
@@ -1097,3 +1097,121 @@ func TestControlChannelRejectsMarginalNIDWithoutTSBK(t *testing.T) {
 		}
 	}
 }
+
+// TestControlChannelDeferredGrantReplayedAfterIdentifierUpdate covers
+// the issue #345 follow-up: a Group Voice Channel Grant TSBK arrives
+// before the matching IdentifierUpdate. The grant is queued; the
+// subsequent IDEN_UP drains the queue and the grant resolves through
+// the freshly applied band-plan slot. Operator-visible outcome: a
+// trunking.Grant event lands on the bus with the correct
+// FrequencyHz, restoring call/talkgroup creation in the UI for sites
+// that broadcast IDEN_UP at a slower cadence than the first grant.
+func TestControlChannelDeferredGrantReplayedAfterIdentifierUpdate(t *testing.T) {
+	bus := events.NewBus(16)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	// Same payload layout as the VUHF happy path (id=1, num=16 on a
+	// 460 MHz UHF system) but reversed in arrival order — grant first,
+	// IDEN_UP second.
+	grantPayload := [8]byte{
+		0x00,
+		(1 << 4) | 0x00, 0x10,
+		0x12, 0x34,
+		0xAB, 0xCD, 0xEF,
+	}
+	grantTSBK := TSBK{LB: true, Opcode: OpGroupVoiceChannelGrant, Payload: grantPayload}
+	identTSBK := TSBK{LB: false, Opcode: OpIdentifierUpdateVUHF}
+	identTSBK.Payload = AssembleIdentifierUpdateVUHF(IdentifierUpdate{
+		ChannelID:   1,
+		BandwidthHz: 12_500,
+		SpacingHz:   12_500,
+		TxOffsetHz:  -5_000_000,
+		BaseHz:      460_000_000,
+	})
+
+	stream1 := buildLockedStreamWithTSBK(10, 0x293, DUIDTrunkingSignaling, grantTSBK)
+	stream2 := buildLockedStreamWithTSBK(0, 0x293, DUIDTrunkingSignaling, identTSBK)
+
+	// Clock is monotonic but the two TSBKs land within a few hundred
+	// ms of each other on real systems; keep the test clock well
+	// inside pendingGrantTTL.
+	base := time.Unix(1_700_000_000, 0).UTC()
+	cc := New(Options{
+		Bus: bus, SystemName: "UHF-Site", FrequencyHz: 461_437_500,
+		Now: func() time.Time { return base },
+	})
+	cc.Process(stream1, 0)
+	cc.Process(stream2, len(stream1))
+
+	var got *trunking.Grant
+	deadline := time.After(time.Second)
+	for got == nil {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind == events.KindGrant {
+				g := ev.Payload.(trunking.Grant)
+				got = &g
+			}
+		case <-deadline:
+			t.Fatal("no grant event published after deferred IDEN_UP drained the queue")
+		}
+	}
+	if got.ChannelID != 1 || got.ChannelNum != 0x010 || got.FrequencyHz != 460_200_000 {
+		t.Errorf("grant = id=%d num=%d freq=%d, want 1/16/460200000",
+			got.ChannelID, got.ChannelNum, got.FrequencyHz)
+	}
+	if got.GroupID != 0x1234 || got.SourceID != 0xABCDEF {
+		t.Errorf("group/source = %d/%d, want 4660/11259375", got.GroupID, got.SourceID)
+	}
+}
+
+// TestControlChannelDeferredGrantExpiresAfterTTL covers the cap on
+// the deferred queue: a queued grant older than pendingGrantTTL is
+// dropped on drain. We can't easily advance the receiver's wall clock
+// across the FSM, so we exercise the ring directly — the wiring in
+// control.go is one-line and shares the same Now() injection.
+func TestControlChannelDeferredGrantExpiresAfterTTL(t *testing.T) {
+	var q pendingGrants
+	base := time.Unix(1_700_000_000, 0).UTC()
+	q.add(7, voiceGrant{channelID: 7, channelNumber: 42}, 0x293, base)
+
+	// Advance one second past the TTL boundary — the entry must be dropped.
+	drained := q.drain(7, base.Add(pendingGrantTTL+time.Second))
+	if len(drained) != 0 {
+		t.Fatalf("expected 0 drained entries after TTL, got %d", len(drained))
+	}
+
+	// A fresh add followed by an immediate drain still works.
+	q.add(7, voiceGrant{channelID: 7, channelNumber: 99}, 0x293, base)
+	drained = q.drain(7, base.Add(time.Second))
+	if len(drained) != 1 || drained[0].g.channelNumber != 99 {
+		t.Fatalf("fresh entry not preserved: %+v", drained)
+	}
+}
+
+// TestControlChannelDeferredGrantsBoundedByRingCap ensures the
+// per-channel-ID ring drops oldest entries when full so a stuck
+// channel ID (site never broadcasts the IDEN_UP) can't grow memory
+// unbounded.
+func TestControlChannelDeferredGrantsBoundedByRingCap(t *testing.T) {
+	var q pendingGrants
+	base := time.Unix(1_700_000_000, 0).UTC()
+	for i := 0; i < pendingGrantSlotCap+2; i++ {
+		q.add(3, voiceGrant{channelID: 3, channelNumber: uint16(i)}, 0x111, base)
+	}
+	drained := q.drain(3, base)
+	if len(drained) != pendingGrantSlotCap {
+		t.Fatalf("ring size = %d, want %d", len(drained), pendingGrantSlotCap)
+	}
+	// Oldest two entries (channelNumber 0, 1) should have been
+	// evicted; the surviving range is [2, 2+cap).
+	for i, e := range drained {
+		want := uint16(i + 2)
+		if e.g.channelNumber != want {
+			t.Errorf("drained[%d].channelNumber = %d, want %d (oldest should have been evicted)",
+				i, e.g.channelNumber, want)
+		}
+	}
+}

--- a/internal/radio/p25/phase1/pending_grants.go
+++ b/internal/radio/p25/phase1/pending_grants.go
@@ -1,0 +1,72 @@
+package phase1
+
+import "time"
+
+// pendingGrantTTL bounds how long a grant whose channel ID lacked an
+// IdentifierUpdate at arrival is held in the deferred queue. P25 voice
+// grants address very short live windows — a queued grant older than
+// this describes a call that's already underway on a voice channel
+// without us, so resolving it after the fact buys no operational
+// benefit. The bound also caps memory exposure to a runaway site.
+const pendingGrantTTL = 5 * time.Second
+
+// pendingGrantSlotCap is the per-channel-ID ring capacity. Four covers
+// the legitimate "burst of grants arrived a few hundred ms before the
+// matching IDEN_UP" shape without growing unboundedly when a site
+// genuinely never broadcasts an IDEN_UP for that ID.
+const pendingGrantSlotCap = 4
+
+// pendingGrant is one queued voice grant awaiting its IdentifierUpdate.
+type pendingGrant struct {
+	g   voiceGrant
+	nac uint16
+	at  time.Time
+}
+
+// pendingGrants holds voice grants whose channel ID had no
+// IdentifierUpdate when the grant was dispatched, one bounded ring per
+// channel ID. The control channel calls add() on a BandPlan miss and
+// drain() after a successful BandPlan.Apply for that ID; entries older
+// than pendingGrantTTL are dropped on drain. Not safe for concurrent
+// use — the control channel reads/writes from a single goroutine, the
+// same constraint BandPlan already documents.
+type pendingGrants struct {
+	slots [16][]pendingGrant
+}
+
+// add appends g to channelID's ring. When the ring is full the oldest
+// entry is dropped to make room — a stuck channel ID can't grow memory
+// unbounded. channelID outside [0,15] is silently ignored to match
+// BandPlan.Apply's contract.
+func (p *pendingGrants) add(channelID uint8, g voiceGrant, nac uint16, now time.Time) {
+	if int(channelID) >= len(p.slots) {
+		return
+	}
+	entry := pendingGrant{g: g, nac: nac, at: now}
+	ring := p.slots[channelID]
+	if len(ring) >= pendingGrantSlotCap {
+		ring = append(ring[:0], ring[1:]...)
+	}
+	p.slots[channelID] = append(ring, entry)
+}
+
+// drain returns and clears every entry for channelID whose age is
+// within pendingGrantTTL. Expired entries are dropped silently. The
+// returned slice is fresh per call so the caller may safely retain it.
+func (p *pendingGrants) drain(channelID uint8, now time.Time) []pendingGrant {
+	if int(channelID) >= len(p.slots) {
+		return nil
+	}
+	ring := p.slots[channelID]
+	p.slots[channelID] = nil
+	if len(ring) == 0 {
+		return nil
+	}
+	out := make([]pendingGrant, 0, len(ring))
+	for _, e := range ring {
+		if now.Sub(e.at) <= pendingGrantTTL {
+			out = append(out, e)
+		}
+	}
+	return out
+}

--- a/internal/scanner/ccdecoder/pipelines.go
+++ b/internal/scanner/ccdecoder/pipelines.go
@@ -158,11 +158,35 @@ func newP25Phase1Pipeline(opts PipelineOptions) (ProtocolPipeline, error) {
 	if demodMode == p25phase1rx.DemodC4FM {
 		rotations = p25phase1.RotationsC4FM
 	}
+	// Seed the BandPlan with operator-supplied IDEN_UP entries (issue
+	// #345). Sites that route grants through a channel ID they never
+	// broadcast an IDEN_UP TSBK for would otherwise have those grants
+	// silently dropped; this gives the operator a startup floor that
+	// over-the-air IDEN_UPs naturally override later via the same
+	// BandPlan.Apply path.
+	var bandPlan *p25phase1.BandPlan
+	if len(opts.System.P25BandPlan) > 0 {
+		bandPlan = &p25phase1.BandPlan{}
+		for _, e := range opts.System.P25BandPlan {
+			bandPlan.Apply(p25phase1.IdentifierUpdate{
+				ChannelID:   e.ChannelID,
+				BaseHz:      e.BaseHz,
+				SpacingHz:   e.SpacingHz,
+				TxOffsetHz:  e.TxOffsetHz,
+				BandwidthHz: e.BandwidthHz,
+			})
+			log.Info("ccdecoder: p25/phase1 band-plan seeded",
+				"system", opts.SystemName,
+				"id", e.ChannelID, "base_hz", e.BaseHz,
+				"spacing_hz", e.SpacingHz, "tx_offset_hz", e.TxOffsetHz)
+		}
+	}
 	cc := p25phase1.New(p25phase1.Options{
 		Bus:         opts.Bus,
 		Log:         opts.Log,
 		SystemName:  opts.SystemName,
 		FrequencyHz: opts.FrequencyHz,
+		BandPlan:    bandPlan,
 		Rotations:   rotations,
 	})
 	rx := p25phase1rx.New(p25phase1rx.Options{

--- a/internal/trunking/site.go
+++ b/internal/trunking/site.go
@@ -99,6 +99,19 @@ func ParseProtocol(s string) (Protocol, error) {
 	}
 }
 
+// P25BandPlanEntry is one operator-supplied IDEN_UP slot seed for the
+// P25 Phase 1 receiver — mirrors the on-air phase1.IdentifierUpdate
+// fields without the trunking package having to import phase1. The
+// pipeline factory translates each entry into the receiver's runtime
+// shape and calls BandPlan.Apply before the decoder runs.
+type P25BandPlanEntry struct {
+	ChannelID   uint8  // 0..15; matches the 4-bit IDEN_UP slot index
+	BaseHz      uint64 // downlink base frequency for channel 0, Hz
+	SpacingHz   uint32 // channel-to-channel step, Hz
+	TxOffsetHz  int64  // signed uplink offset (uplink = downlink + offset), Hz
+	BandwidthHz uint32 // informational; not consulted by BandPlan.Frequency
+}
+
 // System describes one trunked radio system the engine should track.
 type System struct {
 	Name            string
@@ -159,6 +172,17 @@ type System struct {
 	// ltr.ControlChannel.SetManchesterMode by the ccdecoder
 	// connector after parsing via ltr.ParseManchesterMode.
 	LTRManchesterMode string
+
+	// P25BandPlan seeds the Phase 1 receiver's BandPlan with operator-
+	// supplied IdentifierUpdate entries before the decoder runs.
+	// Useful for sites that don't broadcast an IDEN_UP TSBK for every
+	// channel ID their grants reference (issue #345 — Mt Anakie
+	// broadcasts grants on id=10 but never the matching IDEN_UP, so
+	// the receiver has nothing to resolve the frequency against).
+	// Over-the-air IDEN_UPs naturally override these via the same
+	// BandPlan.Apply path; entries here are the floor, not the ceiling.
+	// Ignored for non-P25-Phase-1 protocols.
+	P25BandPlan []P25BandPlanEntry
 
 	// P25Phase1DemodMode selects the symbol-recovery path for the
 	// P25 Phase 1 receiver. Recognised values (case-insensitive):


### PR DESCRIPTION
Mt Anakie issue #345 retest after the v0.2.1 USB-retry fix surfaced a
second defect: grants reference channel ID 10 but the site never
broadcasts an IdentifierUpdate VUHF TSBK for that ID, so every grant
on it was dropped with `decode.error stage=no-bandplan` and no call /
talkgroup ever reached the UI.

Two changes feed the same BandPlan.Apply / BandPlan.Frequency surface,
no downstream event shapes touched:

1. Per-channel-ID deferred grant queue (`pending_grants.go`). On a
   BandPlan miss the grant is held in a bounded ring (cap 4 per ID,
   5 s TTL); when the matching IDEN_UP TSBK lands, dispatchTSBK drains
   the ring and re-publishes through publishVoiceGrant against the
   freshly applied slot. Covers the race where IDEN_UP cadence is
   slower than the first grant after CC lock.

2. Config-driven BandPlan seed. New `p25_band_plan` list on
   SystemConfig with channel_id / base_hz / spacing_hz / tx_offset_hz /
   bandwidth_hz fields, validated for range + duplicates. The phase 1
   pipeline factory calls BandPlan.Apply for each entry at startup so
   sites that never broadcast IDEN_UP for some ID can still resolve
   grants. Over-the-air IDEN_UPs override these via the same Apply
   path — entries are a floor, not a ceiling.

Tests: deferred grant replay end-to-end through the FSM, TTL drop,
ring-cap eviction, and the four new config validation cases. All
existing p25/phase1 + config + ccdecoder + trunking tests still pass.