### PR TITLE
p25/phase1: decode TDMA IDEN_UP + queue grants pending IDEN_UP (#345)

### DIFF
--- a/internal/radio/p25/phase1/control.go
+++ b/internal/radio/p25/phase1/control.go
@@ -730,6 +730,15 @@ func (c *ControlChannel) dispatchTSBK(t TSBK, nac uint16, metric int) {
 			"tx_offset_hz", u.TxOffsetHz,
 			"bandwidth_hz", u.BandwidthHz)
 		c.drainPendingGrants(u.ChannelID, nac)
+	case OpIdentifierUpdateTDMA:
+		u := ParseIdentifierUpdateTDMA(t.Payload)
+		c.bandPlan.Apply(u)
+		c.log.Debug("p25: identifier update (TDMA)",
+			"nac", nac, "id", u.ChannelID,
+			"base_hz", u.BaseHz, "spacing_hz", u.SpacingHz,
+			"tx_offset_hz", u.TxOffsetHz,
+			"bandwidth_hz", u.BandwidthHz)
+		c.drainPendingGrants(u.ChannelID, nac)
 	case OpGroupVoiceChannelGrant:
 		c.publishGroupGrant(ParseGroupVoiceChannelGrant(t.Payload), nac)
 	case OpGroupVoiceChannelUpdate:

--- a/internal/radio/p25/phase1/control_test.go
+++ b/internal/radio/p25/phase1/control_test.go
@@ -1215,3 +1215,125 @@ func TestControlChannelDeferredGrantsBoundedByRingCap(t *testing.T) {
 		}
 	}
 }
+
+// TestControlChannelAppliesTDMAIdentifierUpdateAndPublishesGrant
+// covers the issue #345 round-3 fix: the Mt Anakie site broadcasts
+// IDEN_UP for channel id=10 as opcode 0x33 (TDMA-2), not 0x34 VUHF.
+// With 0x33 now wired into dispatchTSBK, a subsequent grant on
+// (id=10, num=176) must resolve through the freshly applied band-plan
+// slot to 468.6125 MHz — the exact downlink the operator should see
+// pop into /api/v1/calls/active.
+func TestControlChannelAppliesTDMAIdentifierUpdateAndPublishesGrant(t *testing.T) {
+	bus := events.NewBus(16)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	identTSBK := TSBK{LB: false, Opcode: OpIdentifierUpdateTDMA}
+	identTSBK.Payload = AssembleIdentifierUpdateTDMA(IdentifierUpdate{
+		ChannelID:   10,
+		BandwidthHz: 6_250,
+		SpacingHz:   6_250,
+		TxOffsetHz:  -10_000_000,
+		BaseHz:      467_512_500,
+	})
+
+	// num=176 = 0x0B0 — exact Mt Anakie grant the operator reported.
+	grantTSBK := TSBK{LB: true, Opcode: OpGroupVoiceChannelGrant, Payload: [8]byte{
+		0x00,
+		(10 << 4) | 0x00, 0xB0,
+		0x12, 0x34,
+		0xAB, 0xCD, 0xEF,
+	}}
+
+	stream1 := buildLockedStreamWithTSBK(10, 0x164, DUIDTrunkingSignaling, identTSBK)
+	stream2 := buildLockedStreamWithTSBK(0, 0x164, DUIDTrunkingSignaling, grantTSBK)
+
+	cc := New(Options{
+		Bus: bus, SystemName: "MMR", FrequencyHz: 420_087_500,
+		Now: func() time.Time { return time.Unix(1_700_000_000, 0).UTC() },
+	})
+	cc.Process(stream1, 0)
+	cc.Process(stream2, len(stream1))
+
+	var got *trunking.Grant
+	deadline := time.After(time.Second)
+	for got == nil {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind == events.KindDecodeError {
+				de := ev.Payload.(events.DecodeError)
+				if de.Stage == "no-bandplan" {
+					t.Fatal("TDMA IdentifierUpdate was not applied: grant fell to no-bandplan")
+				}
+			}
+			if ev.Kind == events.KindGrant {
+				g := ev.Payload.(trunking.Grant)
+				got = &g
+			}
+		case <-deadline:
+			t.Fatal("no grant event published")
+		}
+	}
+	if got.ChannelID != 10 || got.ChannelNum != 0x0B0 {
+		t.Errorf("grant channel = %d.%d, want 10.176", got.ChannelID, got.ChannelNum)
+	}
+	// base 467_512_500 + 176 * 6250 = 468_612_500
+	if got.FrequencyHz != 468_612_500 {
+		t.Errorf("freq = %d, want 468_612_500", got.FrequencyHz)
+	}
+}
+
+// TestControlChannelDeferredGrantReplayedAfterTDMAIdentifierUpdate
+// composes the prior fix (deferred queue) with the new TDMA dispatch:
+// a grant arrives before its TDMA IDEN_UP, lands in the pending ring,
+// then the IDEN_UP arrives via the 0x33 path and drains it.
+func TestControlChannelDeferredGrantReplayedAfterTDMAIdentifierUpdate(t *testing.T) {
+	bus := events.NewBus(16)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	grantTSBK := TSBK{LB: true, Opcode: OpGroupVoiceChannelGrant, Payload: [8]byte{
+		0x00,
+		(10 << 4) | 0x00, 0xB0,
+		0x12, 0x34,
+		0xAB, 0xCD, 0xEF,
+	}}
+	identTSBK := TSBK{LB: false, Opcode: OpIdentifierUpdateTDMA}
+	identTSBK.Payload = AssembleIdentifierUpdateTDMA(IdentifierUpdate{
+		ChannelID:   10,
+		BandwidthHz: 6_250,
+		SpacingHz:   6_250,
+		TxOffsetHz:  -10_000_000,
+		BaseHz:      467_512_500,
+	})
+
+	stream1 := buildLockedStreamWithTSBK(10, 0x164, DUIDTrunkingSignaling, grantTSBK)
+	stream2 := buildLockedStreamWithTSBK(0, 0x164, DUIDTrunkingSignaling, identTSBK)
+
+	base := time.Unix(1_700_000_000, 0).UTC()
+	cc := New(Options{
+		Bus: bus, SystemName: "MMR", FrequencyHz: 420_087_500,
+		Now: func() time.Time { return base },
+	})
+	cc.Process(stream1, 0)
+	cc.Process(stream2, len(stream1))
+
+	var got *trunking.Grant
+	deadline := time.After(time.Second)
+	for got == nil {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind == events.KindGrant {
+				g := ev.Payload.(trunking.Grant)
+				got = &g
+			}
+		case <-deadline:
+			t.Fatal("no grant event published after TDMA IDEN_UP drained the queue")
+		}
+	}
+	if got.FrequencyHz != 468_612_500 {
+		t.Errorf("freq = %d, want 468_612_500", got.FrequencyHz)
+	}
+}

--- a/internal/radio/p25/phase1/identifier.go
+++ b/internal/radio/p25/phase1/identifier.go
@@ -11,21 +11,26 @@ import (
 // accumulates them and uses each slot to translate a (Channel ID,
 // Channel Number) pair from a voice grant into a downlink frequency.
 //
-// Two on-air variants encode the same logical fields with different
-// bit packings, and both parse into this struct:
+// Three on-air variants encode the same frequency fields with
+// different byte-0-low-nibble semantics; all three parse into this
+// struct:
 //
 //	0x3D  IDEN_UP        — standard 700/800/900 MHz form (ParseIdentifierUpdate)
 //	0x34  IDEN_UP_VUHF   — VHF/UHF form         (ParseIdentifierUpdateVUHF)
+//	0x33  IDEN_UP_TDMA   — Phase 2 TDMA form    (ParseIdentifierUpdateTDMA)
 //
 // Field units after parsing (independent of variant):
 //
-//	BandwidthHz   — channel bandwidth in Hz
+//	BandwidthHz   — channel bandwidth in Hz (informational only;
+//	                BandPlan.Frequency does not consult it)
 //	SpacingHz     — channel-to-channel step in Hz
 //	TxOffsetHz    — signed transmit offset (uplink = downlink + offset)
 //	BaseHz        — downlink base frequency for channel 0 in Hz
 //
-// The 0x33 Phase-2 TDMA variant remains a follow-up — it adds slot
-// count plus a different packing of the same fields. See
+// The TDMA variant additionally carries a slot count + access mode in
+// its channel-type code (TDMA-1 / TDMA-2 / TDMA-4). The frequency
+// resolver doesn't care; downstream Phase 2 voice decoding would, but
+// that wiring lives outside this package. See
 // internal/radio/p25/phase2/identifier.go for the Phase 2 variant
 // shipped today (which is also a 0x3D-style packing).
 type IdentifierUpdate struct {
@@ -147,6 +152,134 @@ func AssembleIdentifierUpdateVUHF(u IdentifierUpdate) [8]byte {
 	p[6] = byte(freq5 >> 8)
 	p[7] = byte(freq5)
 	return p
+}
+
+// ParseIdentifierUpdateTDMA decodes the 8-byte payload of opcode 0x33
+// (OpIdentifierUpdateTDMA), the Phase-2 TDMA variant. The bit layout,
+// MSB first, per TIA-102.AABF Table 14:
+//
+//	[ ChanID(4) | ChanType(4) | TxOffsetSign(1) | TxOffsetMag(13) | STEP(10) | FREQ(32) ]
+//
+// The packing is identical to VUHF (opcode 0x34) for every field
+// EXCEPT byte 0's lower nibble: where VUHF carries a 4-bit bandwidth
+// code, TDMA carries a 4-bit Channel Type code that simultaneously
+// encodes the slot count (TDMA-1 / TDMA-2 / TDMA-4) and the access
+// mode (FDMA / TDMA) plus a nominal bandwidth. The bandwidth half of
+// that code is mapped into BandwidthHz here for log readability; the
+// slot count is intentionally NOT carried on IdentifierUpdate because
+// BandPlan.Frequency uses only Base + Spacing + ChannelNumber, and
+// downstream Phase 2 voice decoding consumes slot count from the
+// grant payload, not from the band plan.
+//
+// TxOffset semantics match VUHF: 1-bit sign + 13-bit magnitude, the
+// magnitude scaled by SpacingHz (not 250 kHz like the 0x3D form).
+// STEP, FREQ scaling is the same ×125 Hz / ×5 Hz as the other two
+// variants.
+//
+// Cross-checked against OP25 (`op25/gr-op25_repeater/apps/trunking.py`
+// `iden_up_tdma`) and SDRTrunk
+// (`FrequencyBandUpdateTDMA.java`).
+func ParseIdentifierUpdateTDMA(p [8]byte) IdentifierUpdate {
+	chanID := p[0] >> 4
+	chanType := p[0] & 0x0F
+	toff14 := uint16(p[1])<<6 | uint16(p[2])>>2
+	toffSign := (toff14 >> 13) & 0x1
+	toffMag := toff14 & 0x1FFF
+	step := uint16(p[2]&0x03)<<8 | uint16(p[3])
+	freq5Hz := uint32(p[4])<<24 | uint32(p[5])<<16 | uint32(p[6])<<8 | uint32(p[7])
+
+	spacingHz := uint32(step) * 125
+	offsetMagHz := int64(toffMag) * int64(spacingHz)
+	txOffsetHz := offsetMagHz
+	if toffSign == 0 {
+		txOffsetHz = -offsetMagHz
+	}
+
+	return IdentifierUpdate{
+		ChannelID:   chanID,
+		BandwidthHz: tdmaChannelTypeBandwidthHz(chanType),
+		SpacingHz:   spacingHz,
+		TxOffsetHz:  txOffsetHz,
+		BaseHz:      uint64(freq5Hz) * 5,
+	}
+}
+
+// AssembleIdentifierUpdateTDMA is the inverse of
+// ParseIdentifierUpdateTDMA; useful for synthetic test streams.
+// Out-of-range fields are silently truncated to their on-air widths.
+// TxOffsetHz that isn't an integer multiple of SpacingHz is truncated
+// toward zero; a zero SpacingHz produces a zero on-air offset
+// regardless of TxOffsetHz. ChannelType is reverse-mapped from
+// BandwidthHz via tdmaChannelTypeBandwidthCode; the slot-count half
+// of the channel-type encoding isn't carried on IdentifierUpdate so
+// only the bandwidth-derived form round-trips.
+func AssembleIdentifierUpdateTDMA(u IdentifierUpdate) [8]byte {
+	chanType := tdmaChannelTypeBandwidthCode(u.BandwidthHz) & 0x0F
+	step := uint16(u.SpacingHz/125) & 0x3FF
+
+	var toffSign uint8
+	var toffMag uint16
+	if u.TxOffsetHz >= 0 {
+		toffSign = 1
+		if u.SpacingHz > 0 {
+			toffMag = uint16(uint64(u.TxOffsetHz)/uint64(u.SpacingHz)) & 0x1FFF
+		}
+	} else {
+		toffSign = 0
+		if u.SpacingHz > 0 {
+			toffMag = uint16(uint64(-u.TxOffsetHz)/uint64(u.SpacingHz)) & 0x1FFF
+		}
+	}
+	toff14 := uint16(toffSign)<<13 | (toffMag & 0x1FFF)
+
+	freq5 := uint32(u.BaseHz / 5)
+
+	var p [8]byte
+	p[0] = (u.ChannelID&0x0F)<<4 | chanType
+	p[1] = byte(toff14 >> 6)
+	p[2] = byte((toff14&0x3F)<<2) | byte(step>>8)
+	p[3] = byte(step)
+	p[4] = byte(freq5 >> 24)
+	p[5] = byte(freq5 >> 16)
+	p[6] = byte(freq5 >> 8)
+	p[7] = byte(freq5)
+	return p
+}
+
+// tdmaChannelTypeBandwidthHz maps the 4-bit Channel Type code in
+// opcode 0x33 to the nominal channel bandwidth in Hz. The Channel
+// Type field also encodes slot count (TDMA-1 / TDMA-2 / TDMA-4) and
+// access mode; that information isn't carried on IdentifierUpdate.
+// Unknown codes return 0; BandPlan.Frequency does not consult this
+// field, so an unknown code does not prevent grant resolution.
+//
+// The mapping covers the codes a Phase-2 site typically broadcasts;
+// per TIA-102.AABF most TDMA codes target 12.5 kHz outbound on a
+// 6.25 kHz inbound, and the BandwidthHz reported is the inbound /
+// per-slot value most operators expect to see in logs.
+func tdmaChannelTypeBandwidthHz(code uint8) uint32 {
+	switch code & 0x0F {
+	case 0x1, 0x3:
+		return 6250
+	case 0x2:
+		return 12500
+	default:
+		return 0
+	}
+}
+
+// tdmaChannelTypeBandwidthCode is the inverse of
+// tdmaChannelTypeBandwidthHz used by AssembleIdentifierUpdateTDMA.
+// Unrecognised bandwidths emit code 0.
+func tdmaChannelTypeBandwidthCode(hz uint32) uint8 {
+	switch hz {
+	case 6250:
+		return 0x1
+	case 12500:
+		return 0x2
+	default:
+		return 0
+	}
 }
 
 // vuhfBandwidthHz maps the 4-bit BW code in opcode 0x34 to channel

--- a/internal/radio/p25/phase1/identifier_test.go
+++ b/internal/radio/p25/phase1/identifier_test.go
@@ -69,6 +69,63 @@ func TestIdentifierUpdateVUHFRoundTripPositiveOffset(t *testing.T) {
 	}
 }
 
+// TestIdentifierUpdateTDMARoundTripMtAnakieID10 mirrors the VUHF
+// round-trip with the Mt Anakie id=10 fixture from issue #345
+// (TDMA-2 slot, 6.25 kHz channels, base 467.5125 MHz, -10 MHz tx
+// offset). The site's id=10 IDEN_UP arrives as opcode 0x33 — once
+// decoded, grants on (id=10, num=176) resolve to 468.6125 MHz.
+func TestIdentifierUpdateTDMARoundTripMtAnakieID10(t *testing.T) {
+	in := IdentifierUpdate{
+		ChannelID:   10,
+		BandwidthHz: 6_250, // channel type 0x1 → 6.25 kHz
+		SpacingHz:   6_250,
+		TxOffsetHz:  -10_000_000,
+		BaseHz:      467_512_500,
+	}
+	out := ParseIdentifierUpdateTDMA(AssembleIdentifierUpdateTDMA(in))
+	if out != in {
+		t.Errorf("round-trip mismatch:\n got %+v\nwant %+v", out, in)
+	}
+}
+
+func TestIdentifierUpdateTDMARoundTripPositiveOffset(t *testing.T) {
+	// 12.5 kHz TDMA fixture with a positive offset to exercise the
+	// sign bit and the second known channel-type code.
+	in := IdentifierUpdate{
+		ChannelID:   5,
+		BandwidthHz: 12_500, // channel type 0x2 → 12.5 kHz
+		SpacingHz:   12_500,
+		TxOffsetHz:  5_000_000,
+		BaseHz:      420_000_000,
+	}
+	out := ParseIdentifierUpdateTDMA(AssembleIdentifierUpdateTDMA(in))
+	if out != in {
+		t.Errorf("round-trip mismatch: got %+v want %+v", out, in)
+	}
+}
+
+// TestTDMAChannelTypeBandwidthCodes table-checks the channel-type →
+// bandwidth lookup. Codes outside the small documented set fall to 0
+// — the parser still resolves frequency correctly because
+// BandPlan.Frequency does not consult BandwidthHz.
+func TestTDMAChannelTypeBandwidthCodes(t *testing.T) {
+	for _, tc := range []struct {
+		code uint8
+		want uint32
+	}{
+		{0x0, 0}, // reserved
+		{0x1, 6_250},
+		{0x2, 12_500},
+		{0x3, 6_250},
+		{0x4, 0},
+		{0xF, 0},
+	} {
+		if got := tdmaChannelTypeBandwidthHz(tc.code); got != tc.want {
+			t.Errorf("tdmaChannelTypeBandwidthHz(0x%X) = %d, want %d", tc.code, got, tc.want)
+		}
+	}
+}
+
 func TestIdentifierUpdateVUHFUnknownBandwidthCodeMapsToZero(t *testing.T) {
 	// On-air payload with BW code 0 (reserved per TIA-102.AABF Table 16).
 	// Parser must surface BandwidthHz=0 rather than fabricating a value.

--- a/internal/radio/p25/phase1/opcodes.go
+++ b/internal/radio/p25/phase1/opcodes.go
@@ -36,6 +36,7 @@ const (
 	OpUnitRegistrationResponse     Opcode = 0x2C
 	OpUnitRegistrationCommand      Opcode = 0x2D
 	OpDeregistrationAck            Opcode = 0x2F
+	OpIdentifierUpdateTDMA         Opcode = 0x33
 	OpIdentifierUpdateVUHF         Opcode = 0x34
 	OpProtectionParamUpdate        Opcode = 0x35
 	OpSecondaryControlChannel      Opcode = 0x39
@@ -68,6 +69,10 @@ func (o Opcode) String() string {
 		return "SecondaryControlChannelBroadcast"
 	case OpIdentifierUpdate:
 		return "IdentifierUpdate"
+	case OpIdentifierUpdateVUHF:
+		return "IdentifierUpdateVUHF"
+	case OpIdentifierUpdateTDMA:
+		return "IdentifierUpdateTDMA"
 	case OpGroupAffiliationResponse:
 		return "GroupAffiliationResponse"
 	case OpUnitRegistrationResponse:


### PR DESCRIPTION
Fixes the "no call objects/talkgroups appear in the UI" symptom the reporter on issue #345 surfaced after the v0.2.1 USB-retry fix. Two layered changes, both isolated to `internal/radio/p25/phase1/` plus a small config seam.

## Summary

- **TDMA IdentifierUpdate decoding (commit `2de67aa`)** — adds opcode `0x33` (`OpIdentifierUpdateTDMA`) with a parser/assembler mirroring the existing VUHF (`0x34`) bit packing. The Mt Anakie site survey confirmed it broadcasts IDEN_UP for id=10 as the TDMA variant — silently ignored before this change. Now ids 0, 1, 5, 9, 10, 11, 12, 13 populate the BandPlan alongside the FDMA ids (2, 3, 4, 6, 7, 8, 14, 15) that already worked.
- **Deferred grant queue + config band-plan seed (commit `ea6815d`)** — covers the cases the TDMA fix alone doesn't: a per-channel-ID FIFO (cap 4, 5s TTL) holds grants whose IDEN_UP hasn't landed yet and re-publishes on drain; a new `p25_band_plan` YAML list lets operators seed the BandPlan with static entries for sites that genuinely never broadcast a given ID. Over-the-air IDEN_UPs override seeded entries via the same `Apply` path.

The two land together because the TDMA arm in `dispatchTSBK` calls `drainPendingGrants` — so a grant on a TDMA id that arrives before the matching 0x33 IDEN_UP also gets queued and replayed.

### Mt Anakie verification scenario

id=10 + num=176 against the surveyed band (base 467.5125 MHz, step 6.25 kHz, offset −10 MHz) resolves to **468.6125 MHz** — encoded directly in `TestControlChannelAppliesTDMAIdentifierUpdateAndPublishesGrant`.

### Expected log shape after this lands

```
DEBUG p25: identifier update (TDMA) nac=356 id=10 base_hz=467512500 spacing_hz=6250 ...
DEBUG p25: grant ... id=10 num=176 freq_hz=468612500
```

If the IDEN_UP arrives after the grant, the deferred queue intercedes:

```
DEBUG p25: grant before identifier update nac=356 id=10 num=176
DEBUG p25: identifier update (TDMA) nac=356 id=10 ...
DEBUG p25: draining deferred grants nac=356 id=10 count=1
DEBUG p25: grant ... freq_hz=468612500
```

## Test plan

- [x] `go test ./internal/radio/p25/phase1/...` — all existing tests + 8 new ones pass
  - TDMA round-trip with Mt Anakie id=10 fixture
  - TDMA round-trip positive-offset (sign bit + alternate channel-type code)
  - Channel-type → bandwidth lookup table
  - End-to-end FSM test for TDMA IDEN_UP followed by id=10 grant (asserts FrequencyHz = 468_612_500)
  - End-to-end FSM test for grant-before-IDEN_UP via the deferred queue + TDMA drain
  - Deferred-grant replay (VUHF), TTL drop, ring-cap eviction
  - 5 config validation cases for `p25_band_plan` (happy path + invalid channel_id, duplicate, zero spacing, zero base)
- [x] `go test ./internal/config/... ./internal/scanner/ccdecoder/... ./internal/trunking/... ./cmd/gophertrunk/...` — no regressions
- [x] `go vet ./...` clean
- [x] `gofmt -l ./internal/radio/p25/phase1/ ./internal/config/ ./internal/trunking/ ./internal/scanner/ccdecoder/ ./cmd/gophertrunk/` empty
- [ ] On-air Mt Anakie sanity check (operator-side): confirm `"p25: identifier update (TDMA)"` lines appear for ids 0/1/5/9/10/11/12/13 and `gophertrunk_events_total{kind="grant"}` advances on id=10 grants

## Out of scope

- Phase 2 voice decoding for grants that resolve onto TDMA channels — the call object reaches the UI; whether the voice scanner can demod the H-DQPSK audio at that frequency is a separate downstream concern.
- Tracking slot count / phase on `IdentifierUpdate` itself — would ripple through every fixture-literal in the package's tests. Deferred until the voice path needs it.
- MBT (multi-block trunking) IDEN_UP path — no evidence Mt Anakie uses it.

https://claude.ai/code/session_017hdAgYBt8eK2jYsQqRQpwy

---
_Generated by [Claude Code](https://claude.ai/code/session_017hdAgYBt8eK2jYsQqRQpwy)_