### PR TITLE
p25: surface ALGID/KID encryption metadata on grants & calls

### DIFF
--- a/internal/api/grpc.go
+++ b/internal/api/grpc.go
@@ -268,6 +268,7 @@ func grantToPB(g trunking.Grant) *apiv1.Grant {
 		FrequencyHz: g.FrequencyHz,
 		ChannelId:   uint32(g.ChannelID), ChannelNumber: uint32(g.ChannelNum),
 		Encrypted: g.Encrypted, Emergency: g.Emergency, DataCall: g.DataCall,
+		AlgorithmId: uint32(g.AlgorithmID), KeyId: uint32(g.KeyID),
 	}
 }
 

--- a/internal/api/pb/v1/events.pb.go
+++ b/internal/api/pb/v1/events.pb.go
@@ -335,6 +335,14 @@ type Grant struct {
 	Encrypted     bool                   `protobuf:"varint,8,opt,name=encrypted,proto3" json:"encrypted,omitempty"`
 	Emergency     bool                   `protobuf:"varint,9,opt,name=emergency,proto3" json:"emergency,omitempty"`
 	DataCall      bool                   `protobuf:"varint,10,opt,name=data_call,json=dataCall,proto3" json:"data_call,omitempty"`
+	// P25 encryption metadata recovered from the in-call signalling
+	// (Phase 1 LDU2 Encryption Sync, Phase 2 MAC EncryptionSync PDU).
+	// Meaningful only when encrypted=true; zero for clear calls and
+	// for encrypted calls whose ALGID/KID has not landed yet
+	// (Phase 1 grants publish before the first LDU2 — the engine
+	// backfills the values via KindCallEncryption).
+	AlgorithmId   uint32 `protobuf:"varint,11,opt,name=algorithm_id,json=algorithmId,proto3" json:"algorithm_id,omitempty"`
+	KeyId         uint32 `protobuf:"varint,12,opt,name=key_id,json=keyId,proto3" json:"key_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -437,6 +445,20 @@ func (x *Grant) GetDataCall() bool {
 		return x.DataCall
 	}
 	return false
+}
+
+func (x *Grant) GetAlgorithmId() uint32 {
+	if x != nil {
+		return x.AlgorithmId
+	}
+	return 0
+}
+
+func (x *Grant) GetKeyId() uint32 {
+	if x != nil {
+		return x.KeyId
+	}
+	return 0
 }
 
 type CallStart struct {
@@ -837,7 +859,7 @@ const file_events_proto_rawDesc = "" +
 	"\n" +
 	"AttrsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xb5\x02\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xef\x02\n" +
 	"\x05Grant\x12\x16\n" +
 	"\x06system\x18\x01 \x01(\tR\x06system\x12\x1a\n" +
 	"\bprotocol\x18\x02 \x01(\tR\bprotocol\x12\x19\n" +
@@ -850,7 +872,9 @@ const file_events_proto_rawDesc = "" +
 	"\tencrypted\x18\b \x01(\bR\tencrypted\x12\x1c\n" +
 	"\temergency\x18\t \x01(\bR\temergency\x12\x1b\n" +
 	"\tdata_call\x18\n" +
-	" \x01(\bR\bdataCall\"\x96\x01\n" +
+	" \x01(\bR\bdataCall\x12!\n" +
+	"\falgorithm_id\x18\v \x01(\rR\valgorithmId\x12\x15\n" +
+	"\x06key_id\x18\f \x01(\rR\x05keyId\"\x96\x01\n" +
 	"\tCallStart\x12+\n" +
 	"\x05grant\x18\x01 \x01(\v2\x15.gophertrunk.v1.GrantR\x05grant\x127\n" +
 	"\ttalkgroup\x18\x02 \x01(\v2\x19.gophertrunk.v1.TalkGroupR\ttalkgroup\x12#\n" +

--- a/internal/api/sse.go
+++ b/internal/api/sse.go
@@ -91,6 +91,8 @@ func eventToDTO(ev events.Event) EventDTO {
 		dto.Payload = callEndToDTO(p)
 	case trunking.Grant:
 		dto.Payload = grantToDTO(p)
+	case trunking.CallEncryption:
+		dto.Payload = callEncryptionToDTO(p)
 	case trunking.Affiliation:
 		dto.Payload = affiliationToDTO(p)
 	case trunking.UnitRegistration:

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -128,6 +128,13 @@ type GrantDTO struct {
 	Encrypted     bool   `json:"encrypted,omitempty"`
 	Emergency     bool   `json:"emergency,omitempty"`
 	DataCall      bool   `json:"data_call,omitempty"`
+	// AlgorithmID / KeyID surface the P25 encryption parameters
+	// recovered from the in-call signalling. Zero when Encrypted is
+	// false; also zero on a Phase 1 grant until the LDU2 Encryption
+	// Sync has been parsed and the engine has backfilled the active
+	// call (see KindCallEncryption).
+	AlgorithmID uint8  `json:"algorithm_id,omitempty"`
+	KeyID       uint16 `json:"key_id,omitempty"`
 }
 
 func grantToDTO(g trunking.Grant) GrantDTO {
@@ -137,7 +144,34 @@ func grantToDTO(g trunking.Grant) GrantDTO {
 		FrequencyHz: g.FrequencyHz,
 		ChannelID:   g.ChannelID, ChannelNumber: g.ChannelNum,
 		Encrypted: g.Encrypted, Emergency: g.Emergency,
-		DataCall: g.DataCall,
+		DataCall:    g.DataCall,
+		AlgorithmID: g.AlgorithmID, KeyID: g.KeyID,
+	}
+}
+
+// CallEncryptionDTO mirrors trunking.CallEncryption for SSE / REST
+// consumers. Subscribers patch the matching active-call row with the
+// new ALGID/KID so the UI flips from "enc" to "enc 0x84 (AES-256)"
+// the moment the LDU2 lands.
+type CallEncryptionDTO struct {
+	DeviceSerial string    `json:"device_serial"`
+	System       string    `json:"system,omitempty"`
+	Protocol     string    `json:"protocol,omitempty"`
+	GroupID      uint32    `json:"group_id,omitempty"`
+	AlgorithmID  uint8     `json:"algorithm_id"`
+	KeyID        uint16    `json:"key_id"`
+	At           time.Time `json:"at"`
+}
+
+func callEncryptionToDTO(c trunking.CallEncryption) CallEncryptionDTO {
+	return CallEncryptionDTO{
+		DeviceSerial: c.DeviceSerial,
+		System:       c.System,
+		Protocol:     c.Protocol,
+		GroupID:      c.GroupID,
+		AlgorithmID:  c.AlgorithmID,
+		KeyID:        c.KeyID,
+		At:           c.At,
 	}
 }
 

--- a/internal/broadcast/broadcast.go
+++ b/internal/broadcast/broadcast.go
@@ -31,12 +31,20 @@ type Call struct {
 	Source         uint32
 	FrequencyHz    uint32
 	Encrypted      bool
-	Emergency      bool
-	PatchedGroups  []uint32
-	StartedAt      time.Time
-	EndedAt        time.Time
-	AudioPath      string // .wav on disk written by the recorder
-	SampleRate     int
+	// AlgorithmID / KeyID surface the P25 encryption parameters when
+	// the in-call signalling has revealed them. Zero on clear calls
+	// and on encrypted calls whose Encryption Sync never arrived
+	// before the call ended. Aggregators that accept the fields can
+	// thread them into their API payload; aggregators that don't will
+	// just ignore them.
+	AlgorithmID   uint8
+	KeyID         uint16
+	Emergency     bool
+	PatchedGroups []uint32
+	StartedAt     time.Time
+	EndedAt       time.Time
+	AudioPath     string // .wav on disk written by the recorder
+	SampleRate    int
 
 	mu      sync.Mutex
 	mp3Data []byte
@@ -70,6 +78,8 @@ func callFromEvent(cc trunking.CallComplete) *Call {
 		Source:        cc.Grant.SourceID,
 		FrequencyHz:   cc.Grant.FrequencyHz,
 		Encrypted:     cc.Grant.Encrypted,
+		AlgorithmID:   cc.Grant.AlgorithmID,
+		KeyID:         cc.Grant.KeyID,
 		Emergency:     cc.Grant.Emergency,
 		PatchedGroups: cc.Grant.PatchedGroups,
 		StartedAt:     cc.StartedAt,

--- a/internal/events/bus.go
+++ b/internal/events/bus.go
@@ -84,6 +84,18 @@ const (
 	// the reporting radio, the lat/lon fix, and optional speed/heading.
 	// The storage layer persists it; the API + web map surface it.
 	KindLocation Kind = "location"
+	// KindCallEncryption fires when the voice composer recovers an
+	// Encryption Sync from the in-call signalling — e.g. a P25 Phase 1
+	// LDU2 Encryption Sync, where ALGID/KID are only available after
+	// the call has started (the grant TSBK carries only the encrypted
+	// bit). The engine subscribes, backfills the bound ActiveCall's
+	// Grant so downstream consumers (storage, SSE, TUI) see the
+	// real algorithm/key on CallEnd, and republishes the event with
+	// the call's system / protocol / group context so live listeners
+	// (SSE, TUI) can patch the active row in flight. P25 Phase 2 and
+	// any protocol whose grant carries ALGID/KID at grant time does
+	// not need this event — the values are already on the Grant.
+	KindCallEncryption Kind = "call.encryption"
 )
 
 // Stage names a particular FEC / parser checkpoint inside a protocol

--- a/internal/log/messagelog.go
+++ b/internal/log/messagelog.go
@@ -156,6 +156,13 @@ func formatEvent(ev events.Event) string {
 			body = fmt.Sprintf("%-12s system=%s proto=%s tg=%d src=%d freq=%d enc=%t emer=%t",
 				"GRANT", g.System, g.Protocol, g.GroupID, g.SourceID,
 				g.FrequencyHz, g.Encrypted, g.Emergency)
+			// ALGID/KID only meaningful when the grant is encrypted
+			// AND the in-call signalling has surfaced them (Phase 2
+			// at grant time; Phase 1 after the first LDU2).
+			if g.Encrypted && (g.AlgorithmID != 0 || g.KeyID != 0) {
+				body += fmt.Sprintf(" alg=0x%02X key=0x%04X",
+					g.AlgorithmID, g.KeyID)
+			}
 		}
 	case events.KindCallStart:
 		if c, ok := ev.Payload.(trunking.CallStart); ok {
@@ -167,6 +174,17 @@ func formatEvent(ev events.Event) string {
 			body = fmt.Sprintf("%-12s system=%s tg=%d dur=%s reason=%s",
 				"CALL-END", c.Grant.System, c.Grant.GroupID,
 				c.Duration().Round(time.Millisecond), c.Reason)
+		}
+	case events.KindCallEncryption:
+		if c, ok := ev.Payload.(trunking.CallEncryption); ok {
+			// Only log the engine's enriched republish (System set);
+			// the raw composer publish has empty identity fields and
+			// would just be noise.
+			if c.System != "" {
+				body = fmt.Sprintf("%-12s system=%s tg=%d dev=%s alg=0x%02X key=0x%04X",
+					"CALL-ENCRYPT", c.System, c.GroupID, c.DeviceSerial,
+					c.AlgorithmID, c.KeyID)
+			}
 		}
 	case events.KindAffiliation:
 		if a, ok := ev.Payload.(trunking.Affiliation); ok {

--- a/internal/radio/p25/algorithm.go
+++ b/internal/radio/p25/algorithm.go
@@ -1,0 +1,51 @@
+// Package p25 holds protocol-neutral helpers shared by the P25 Phase 1
+// and Phase 2 packages. The TIA-102 Algorithm ID registry lookup lives
+// here so log lines, the SSE/REST API and the TUI / web frontend all
+// render encryption metadata the same way.
+package p25
+
+import "fmt"
+
+// AlgorithmClear is the Algorithm ID a clear (unencrypted) P25 call
+// advertises in its Encryption Sync. Mirrors the phase1 constant; kept
+// here so callers outside the phase1 package can reference it without
+// pulling in the LDU2 parser.
+const AlgorithmClear uint8 = 0x80
+
+// AlgorithmName returns the TIA-102 algorithm mnemonic for id, or
+// "unknown" when the value is not in the registry. The table covers
+// the algorithms currently in use on systems GopherTrunk observers
+// monitor; new IDs can be appended as they show up in the wild.
+//
+// Source: TIA-102.AACE-A "Algorithm IDs" registry.
+func AlgorithmName(id uint8) string {
+	switch id {
+	case 0x80:
+		return "CLEAR"
+	case 0x81:
+		return "DES-OFB"
+	case 0x83:
+		return "TDES-2"
+	case 0x84:
+		return "AES-256"
+	case 0x85:
+		return "AES-128"
+	case 0x86:
+		return "TDES"
+	case 0x89:
+		return "AES-256-OFB"
+	case 0xAA:
+		return "ADP/RC4"
+	case 0x9F:
+		return "DES-XL"
+	}
+	return "unknown"
+}
+
+// FormatAlgorithm renders id as "0x84 (AES-256)" for human-readable
+// log lines and UI tooltips. Unknown values render as "0xNN (unknown)"
+// so an operator can still cross-reference the raw ID with SDRtrunk
+// or the TIA registry.
+func FormatAlgorithm(id uint8) string {
+	return fmt.Sprintf("0x%02X (%s)", id, AlgorithmName(id))
+}

--- a/internal/radio/p25/algorithm_test.go
+++ b/internal/radio/p25/algorithm_test.go
@@ -1,0 +1,39 @@
+package p25
+
+import "testing"
+
+func TestAlgorithmName(t *testing.T) {
+	cases := []struct {
+		id   uint8
+		want string
+	}{
+		{0x80, "CLEAR"},
+		{0x81, "DES-OFB"},
+		{0x84, "AES-256"},
+		{0x85, "AES-128"},
+		{0xAA, "ADP/RC4"},
+		{0x00, "unknown"},
+		{0xFF, "unknown"},
+	}
+	for _, c := range cases {
+		if got := AlgorithmName(c.id); got != c.want {
+			t.Errorf("AlgorithmName(0x%02X) = %q, want %q", c.id, got, c.want)
+		}
+	}
+}
+
+func TestFormatAlgorithm(t *testing.T) {
+	cases := []struct {
+		id   uint8
+		want string
+	}{
+		{0x84, "0x84 (AES-256)"},
+		{0x80, "0x80 (CLEAR)"},
+		{0x42, "0x42 (unknown)"},
+	}
+	for _, c := range cases {
+		if got := FormatAlgorithm(c.id); got != c.want {
+			t.Errorf("FormatAlgorithm(0x%02X) = %q, want %q", c.id, got, c.want)
+		}
+	}
+}

--- a/internal/radio/p25/phase1/control.go
+++ b/internal/radio/p25/phase1/control.go
@@ -911,6 +911,9 @@ func (c *ControlChannel) publishVoiceGrant(g voiceGrant, nac uint16) {
 		"tg", g.groupID, "src", g.sourceID,
 		"id", g.channelID, "num", g.channelNumber, "freq_hz", freq,
 		"enc", so.Encrypted(), "emer", so.Emergency(), "data", g.dataCall)
+	// ALGID/KID are unavailable at grant time on Phase 1 (the LDU2
+	// Encryption Sync carries them); the engine backfills via
+	// KindCallEncryption once the voice frame lands.
 }
 
 // drainPendingGrants re-publishes every voice grant that arrived for

--- a/internal/radio/p25/phase2/control.go
+++ b/internal/radio/p25/phase2/control.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/MattCheramie/GopherTrunk/internal/events"
 	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/p25"
 	"github.com/MattCheramie/GopherTrunk/internal/trunking"
 )
 
@@ -592,12 +593,17 @@ func (c *ControlChannel) publishGrant(g GroupVoiceChannelGrant, op Opcode, group
 			At:          c.now(),
 		},
 	})
-	c.log.Debug("p25/phase2 grant",
+	args := []any{
 		"system", c.systemName,
 		"opcode", op, "tg", groupID,
 		"src", g.SourceID,
 		"channel_id", g.ChannelID, "channel_num", g.ChannelNumber,
-		"freq_hz", freq, "enc", so.Encrypted(), "emer", so.Emergency())
+		"freq_hz", freq, "enc", so.Encrypted(), "emer", so.Emergency(),
+	}
+	if so.Encrypted() && (algID != 0 || keyID != 0) {
+		args = append(args, "alg", p25.FormatAlgorithm(algID), "key", keyID)
+	}
+	c.log.Debug("p25/phase2 grant", args...)
 }
 
 // publishPatch publishes an events.KindPatch for a vendor patch /

--- a/internal/trunking/engine.go
+++ b/internal/trunking/engine.go
@@ -131,6 +131,10 @@ func (e *Engine) Run(ctx context.Context) error {
 				if p, ok := ev.Payload.(Patch); ok {
 					e.handlePatch(p)
 				}
+			case events.KindCallEncryption:
+				if c, ok := ev.Payload.(CallEncryption); ok {
+					e.handleCallEncryption(c)
+				}
 			}
 		case <-tick.C:
 			e.runWatchdog()
@@ -198,6 +202,56 @@ func (e *Engine) HandleGrant(g Grant) {
 	// 3) Preempt: end victim, allocate freed device.
 	e.endCall(victim, EndReasonPreempted)
 	e.startCall(victim.Device, g, tg)
+}
+
+// handleCallEncryption updates the bound ActiveCall's Grant with the
+// recovered ALGID/KID from an in-call Encryption Sync, then republishes
+// the event with the call's system / protocol / group context so SSE +
+// TUI consumers can patch their live view. Skipped when System is
+// already populated — that's the engine's own re-publish coming back
+// through the subscription. Logged-and-dropped when no active call
+// matches the device serial (e.g. the call already ended).
+func (e *Engine) handleCallEncryption(c CallEncryption) {
+	if c.System != "" {
+		return
+	}
+	// Trunked calls are bound through the voice pool; synthetic calls
+	// (conventional FM scanner) live on the engine. Try both, pool first.
+	g, ok := e.pool.UpdateEncryption(c.DeviceSerial, c.AlgorithmID, c.KeyID)
+	if !ok {
+		e.mu.Lock()
+		if ac, sok := e.synthetic[c.DeviceSerial]; sok {
+			ac.Grant.AlgorithmID = c.AlgorithmID
+			ac.Grant.KeyID = c.KeyID
+			g = ac.Grant
+			ok = true
+		}
+		e.mu.Unlock()
+	}
+	if !ok {
+		e.log.Debug("call encryption update for unknown call",
+			"device", c.DeviceSerial)
+		return
+	}
+	enriched := CallEncryption{
+		DeviceSerial:     c.DeviceSerial,
+		System:           g.System,
+		Protocol:         g.Protocol,
+		GroupID:          g.GroupID,
+		AlgorithmID:      c.AlgorithmID,
+		KeyID:            c.KeyID,
+		MessageIndicator: c.MessageIndicator,
+		At:               c.At,
+	}
+	e.bus.Publish(events.Event{
+		Kind:    events.KindCallEncryption,
+		Payload: enriched,
+	})
+	e.log.Info("call encryption update",
+		"device", c.DeviceSerial,
+		"system", enriched.System,
+		"tg", enriched.GroupID,
+		"alg", c.AlgorithmID, "key", c.KeyID)
 }
 
 // handlePatch applies a patch announcement to the registry: an Add

--- a/internal/trunking/engine_test.go
+++ b/internal/trunking/engine_test.go
@@ -425,3 +425,132 @@ type fakeClock struct {
 }
 
 func (c *fakeClock) Now() time.Time { return c.t }
+
+func TestEngineHandleCallEncryptionBackfillsActiveCall(t *testing.T) {
+	bus := events.NewBus(16)
+	defer bus.Close()
+	pool, _ := mkPool(1)
+	e, _ := NewEngine(EngineOptions{
+		Bus:         bus,
+		VoicePool:   pool,
+		Talkgroups:  NewTalkgroupDB(),
+		CallTimeout: 5 * time.Second,
+	})
+
+	// Start a Phase 1 call. ALGID/KID are zero (Phase 1 grant TSBK
+	// doesn't carry them).
+	e.HandleGrant(Grant{
+		System: "MMR", Protocol: "p25",
+		GroupID: 4321, FrequencyHz: 851_000_000,
+		Encrypted: true,
+	})
+
+	actives := e.ActiveCalls()
+	if len(actives) != 1 {
+		t.Fatalf("expected 1 active call, got %d", len(actives))
+	}
+	dev := actives[0].Device.Serial
+	if actives[0].Grant.AlgorithmID != 0 || actives[0].Grant.KeyID != 0 {
+		t.Fatalf("pre-backfill alg/key should be zero, got %v/%v",
+			actives[0].Grant.AlgorithmID, actives[0].Grant.KeyID)
+	}
+
+	// Subscribe BEFORE driving the encryption update so we observe
+	// the enriched republish without racing the event loop.
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	// Composer publishes the raw event (System/Protocol/GroupID empty);
+	// the engine must backfill, enrich, and republish.
+	e.handleCallEncryption(CallEncryption{
+		DeviceSerial: dev,
+		AlgorithmID:  0x84, // AES-256
+		KeyID:        0x1234,
+		At:           time.Now(),
+	})
+
+	// The pool's ActiveCall.Grant should now carry the values so the
+	// next CallEnd payload includes them.
+	updated := e.ActiveCalls()
+	if len(updated) != 1 {
+		t.Fatalf("expected 1 active call after backfill, got %d", len(updated))
+	}
+	if updated[0].Grant.AlgorithmID != 0x84 || updated[0].Grant.KeyID != 0x1234 {
+		t.Errorf("backfill did not land on Grant: alg=0x%X key=0x%X",
+			updated[0].Grant.AlgorithmID, updated[0].Grant.KeyID)
+	}
+
+	// Enriched republish should be on the bus with system / tg filled.
+	select {
+	case ev := <-sub.C:
+		if ev.Kind != events.KindCallEncryption {
+			t.Fatalf("expected KindCallEncryption republish, got %s", ev.Kind)
+		}
+		ce, ok := ev.Payload.(CallEncryption)
+		if !ok {
+			t.Fatalf("payload type = %T", ev.Payload)
+		}
+		if ce.System != "MMR" || ce.Protocol != "p25" || ce.GroupID != 4321 {
+			t.Errorf("enriched payload missing identity fields: %+v", ce)
+		}
+		if ce.AlgorithmID != 0x84 || ce.KeyID != 0x1234 {
+			t.Errorf("enriched payload alg/key = 0x%X/0x%X", ce.AlgorithmID, ce.KeyID)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("never received enriched republish")
+	}
+}
+
+func TestEngineHandleCallEncryptionUnknownDeviceDoesNotPanic(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	pool, _ := mkPool(1)
+	e, _ := NewEngine(EngineOptions{
+		Bus:         bus,
+		VoicePool:   pool,
+		Talkgroups:  NewTalkgroupDB(),
+		CallTimeout: 5 * time.Second,
+	})
+
+	// No active call on this device serial. Should silently drop.
+	e.handleCallEncryption(CallEncryption{
+		DeviceSerial: "no-such-device",
+		AlgorithmID:  0x84,
+		KeyID:        0x1234,
+	})
+}
+
+func TestEngineHandleCallEncryptionEnrichedRepublishDoesNotLoop(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	pool, _ := mkPool(1)
+	e, _ := NewEngine(EngineOptions{
+		Bus:         bus,
+		VoicePool:   pool,
+		Talkgroups:  NewTalkgroupDB(),
+		CallTimeout: 5 * time.Second,
+	})
+	e.HandleGrant(Grant{
+		System: "MMR", Protocol: "p25",
+		GroupID: 1, FrequencyHz: 851_000_000, Encrypted: true,
+	})
+	dev := e.ActiveCalls()[0].Device.Serial
+
+	// An event with System already set is the engine's own republish
+	// coming back through the subscription. Must be ignored — otherwise
+	// the engine would publish another republish, and so on.
+	sub := bus.Subscribe()
+	defer sub.Close()
+	e.handleCallEncryption(CallEncryption{
+		DeviceSerial: dev,
+		System:       "MMR",
+		AlgorithmID:  0x84,
+		KeyID:        0x1234,
+	})
+	select {
+	case ev := <-sub.C:
+		t.Fatalf("expected no republish for already-enriched event, got %s", ev.Kind)
+	case <-time.After(100 * time.Millisecond):
+		// pass
+	}
+}

--- a/internal/trunking/grant.go
+++ b/internal/trunking/grant.go
@@ -51,6 +51,13 @@ func (g Grant) String() string {
 	flags := ""
 	if g.Encrypted {
 		flags += "E"
+		// Append ALGID / KID once the in-call signalling has surfaced
+		// them so the log line is self-describing for operators
+		// triaging encrypted traffic. Zero values are suppressed
+		// because a Phase 1 grant publishes before the LDU2 lands.
+		if g.AlgorithmID != 0 || g.KeyID != 0 {
+			flags += fmt.Sprintf("(alg=0x%02X,key=0x%04X)", g.AlgorithmID, g.KeyID)
+		}
 	}
 	if g.Emergency {
 		flags += "!"
@@ -143,3 +150,26 @@ type CallComplete struct {
 
 // Duration returns how long the call ran.
 func (c CallComplete) Duration() time.Duration { return c.EndedAt.Sub(c.StartedAt) }
+
+// CallEncryption is the payload of an events.KindCallEncryption event.
+// It is published by the voice composer when an in-call Encryption Sync
+// is recovered (P25 Phase 1 LDU2 carries it; the grant TSBK has only
+// the encrypted flag). DeviceSerial keys the update to a specific
+// active call; the engine backfills the bound ActiveCall.Grant's
+// AlgorithmID / KeyID and republishes the event with System / Protocol
+// / GroupID populated so SSE + TUI consumers can patch their live
+// view without re-deriving the call's identity.
+//
+// MessageIndicator carries the 72-bit per-call cryptographic sync
+// vector — not surfaced in any DTO today, but plumbed through for
+// future key-discovery tooling.
+type CallEncryption struct {
+	DeviceSerial     string
+	System           string // filled in by the engine on republish
+	Protocol         string
+	GroupID          uint32
+	AlgorithmID      uint8
+	KeyID            uint16
+	MessageIndicator [9]byte
+	At               time.Time
+}

--- a/internal/trunking/voicepool.go
+++ b/internal/trunking/voicepool.go
@@ -185,3 +185,21 @@ func (p *VoicePool) Touch(serial string, now time.Time) {
 		ac.LastHeardAt = now
 	}
 }
+
+// UpdateEncryption backfills ALGID/KID on the active call bound to
+// serial — used by the engine when an in-call Encryption Sync arrives
+// after the original grant (P25 Phase 1 LDU2). Returns a copy of the
+// updated Grant for the caller to publish in an enriched event, plus
+// ok=true when a matching call was found. The mutation runs under the
+// pool's mutex so it stays consistent with concurrent Touch / Release.
+func (p *VoicePool) UpdateEncryption(serial string, algID uint8, keyID uint16) (Grant, bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	ac, ok := p.active[serial]
+	if !ok {
+		return Grant{}, false
+	}
+	ac.Grant.AlgorithmID = algID
+	ac.Grant.KeyID = keyID
+	return ac.Grant, true
+}

--- a/internal/tui/client/types.go
+++ b/internal/tui/client/types.go
@@ -78,6 +78,8 @@ type GrantDTO struct {
 	Encrypted     bool   `json:"encrypted,omitempty"`
 	Emergency     bool   `json:"emergency,omitempty"`
 	DataCall      bool   `json:"data_call,omitempty"`
+	AlgorithmID   uint8  `json:"algorithm_id,omitempty"`
+	KeyID         uint16 `json:"key_id,omitempty"`
 }
 
 // ActiveCallDTO mirrors api.ActiveCallDTO.
@@ -99,6 +101,8 @@ type CallRow struct {
 	SourceID       uint32    `json:"source_id"`
 	FrequencyHz    uint32    `json:"frequency_hz"`
 	Encrypted      bool      `json:"encrypted"`
+	AlgorithmID    uint8     `json:"algorithm_id,omitempty"`
+	KeyID          uint16    `json:"key_id,omitempty"`
 	Emergency      bool      `json:"emergency"`
 	DataCall       bool      `json:"data_call"`
 	DeviceSerial   string    `json:"device_serial"`

--- a/internal/tui/panels/active.go
+++ b/internal/tui/panels/active.go
@@ -56,12 +56,15 @@ func (p *ActivePanel) Update(msg tea.Msg, s *state.SharedState) (Panel, tea.Cmd)
 	}
 	// Refresh on every update — the polling cadence is 1 s. The hash
 	// gate keeps us from rebuilding the bubbles/table on every Update
-	// call when nothing has changed.
+	// call when nothing has changed. AlgorithmID/KeyID participate so
+	// the row repaints when the engine backfills encryption metadata
+	// after an LDU2 lands (P25 Phase 1).
 	h := hashRows(s.ActiveCalls, func(ac client.ActiveCallDTO) string {
-		return fmt.Sprintf("%s|%d|%d|%s|%d|%v|%v",
+		return fmt.Sprintf("%s|%d|%d|%s|%d|%v|%v|%d|%d",
 			ac.DeviceSerial, ac.Grant.GroupID, ac.Grant.SourceID,
 			ac.Grant.System, ac.Grant.FrequencyHz,
-			ac.Grant.Encrypted, ac.Grant.Emergency)
+			ac.Grant.Encrypted, ac.Grant.Emergency,
+			ac.Grant.AlgorithmID, ac.Grant.KeyID)
 	})
 	if h != p.lastHash {
 		p.refresh(s.ActiveCalls)
@@ -82,6 +85,12 @@ func (p *ActivePanel) refresh(calls []client.ActiveCallDTO) {
 		flags := ""
 		if ac.Grant.Encrypted {
 			flags += "E"
+			// Append the ALGID nibble once the LDU2 backfill has
+			// landed so operators can spot AES vs ADP vs DES at a
+			// glance without opening the detail view.
+			if ac.Grant.AlgorithmID != 0 {
+				flags += fmt.Sprintf("(%02X)", ac.Grant.AlgorithmID)
+			}
 		}
 		if ac.Grant.Emergency {
 			flags += "!"
@@ -138,6 +147,6 @@ func activeColumns(w int) []table.Column {
 		{Title: "Sys", Width: sysW},
 		{Title: "Freq", Width: freqW},
 		{Title: "Device", Width: devW},
-		{Title: "E/!", Width: 4},
+		{Title: "E/!", Width: 8},
 	}
 }

--- a/internal/voice/composer/p25p1_encryption_test.go
+++ b/internal/voice/composer/p25p1_encryption_test.go
@@ -1,0 +1,150 @@
+package composer
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/demod"
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase1"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+	"github.com/MattCheramie/GopherTrunk/internal/voice/imbe"
+)
+
+// buildP25P1EncryptedLDU2Stream emits a clock-settling lead-in followed
+// by `ldus` LDU2 frames, each carrying a fresh IMBE voice subframe set
+// and the same Encryption Sync (Algorithm ID + Key ID). Used to drive
+// the composer's encryption-sync publish path.
+func buildP25P1EncryptedLDU2Stream(t *testing.T, ldus int, es phase1.EncryptionSync) []uint8 {
+	t.Helper()
+	dibits := make([]uint8, 400)
+	for i := range dibits {
+		dibits[i] = uint8(i % 4)
+	}
+	frame := 0
+	for l := 0; l < ldus; l++ {
+		var voice [phase1.LDUVoiceSubframeCount][]byte
+		for s := range voice {
+			ch, err := imbe.EncodeChannel(p25p1VoiceInfo(frame))
+			frame++
+			if err != nil {
+				t.Fatalf("EncodeChannel: %v", err)
+			}
+			onAir, err := imbe.Scramble(ch)
+			if err != nil {
+				t.Fatalf("Scramble: %v", err)
+			}
+			voice[s] = append([]byte(nil), onAir...)
+		}
+		lces := phase1.AssembleEncryptionSync(es)
+		var lsd [phase1.LDULSDBlockCount][]byte
+		ldu, err := phase1.AssembleLDU(0x123, phase1.DUIDLogicalLink2, voice, lces, lsd)
+		if err != nil {
+			t.Fatalf("AssembleLDU LDU2: %v", err)
+		}
+		dibits = append(dibits, framing.BitsToDibits(ldu)...)
+	}
+	return dibits
+}
+
+// TestComposerP25Phase1PublishesEncryptionSync wires up a Phase 1 voice
+// chain, feeds it an LDU2 stream with a recognisable Encryption Sync
+// (AES-256 / key 0x1234), and asserts the composer publishes a
+// KindCallEncryption event with the matching ALGID/KID + device serial.
+// This is the LDU2 → engine backfill path that closes issue #353 for
+// Phase 1 calls (Phase 2 already gets ALGID/KID on the grant TSBK).
+func TestComposerP25Phase1PublishesEncryptionSync(t *testing.T) {
+	const (
+		sampleRate = 48_000.0
+		deviation  = 1800.0
+		ldus       = 6
+	)
+	es := phase1.EncryptionSync{
+		MessageIndicator: [9]byte{1, 2, 3, 4, 5, 6, 7, 8, 9},
+		AlgorithmID:      0x84,
+		KeyID:            0x1234,
+	}
+	dibits := buildP25P1EncryptedLDU2Stream(t, ldus, es)
+	iq := demod.ModulateP25C4FM(dibits, sampleRate, deviation)
+
+	src := newFakeSource()
+	bus := events.NewBus(16)
+	sink := &recordingSink{}
+	eng := &fakeEngine{}
+	c, err := New(Options{
+		Bus:           bus,
+		Devices:       &fakeDevices{src: map[string]IQSource{"VOICE-ENC": src}},
+		Sink:          sink,
+		Engine:        eng,
+		IQSampleRate:  uint32(sampleRate),
+		PCMSampleRate: 8000,
+		TouchInterval: 30 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go c.Run(ctx)
+	defer c.Close()
+
+	// Subscribe BEFORE the CallStart so we don't race the chain
+	// goroutine spinning up.
+	encSub := bus.Subscribe()
+	defer encSub.Close()
+
+	bus.Publish(events.Event{
+		Kind: events.KindCallStart,
+		Payload: trunking.CallStart{
+			Grant: trunking.Grant{
+				System: "MMR", Protocol: "p25",
+				GroupID: 4321, FrequencyHz: 851_000_000,
+				Encrypted: true,
+			},
+			DeviceSerial: "VOICE-ENC",
+			StartedAt:    time.Now().UTC(),
+		},
+	})
+
+	waitFor(t, 2*time.Second, func() bool { return len(c.ActiveChains()) == 1 })
+	src.SendIQ(iq)
+
+	// Drain events until a KindCallEncryption from the composer (with
+	// our device serial) lands. Other events on the bus (CallStart
+	// echoes, etc.) are ignored.
+	deadline := time.NewTimer(8 * time.Second)
+	defer deadline.Stop()
+	for {
+		select {
+		case ev, ok := <-encSub.C:
+			if !ok {
+				t.Fatal("bus closed before encryption sync arrived")
+			}
+			if ev.Kind != events.KindCallEncryption {
+				continue
+			}
+			ce, ok := ev.Payload.(trunking.CallEncryption)
+			if !ok {
+				t.Fatalf("CallEncryption payload type = %T", ev.Payload)
+			}
+			if ce.DeviceSerial != "VOICE-ENC" {
+				continue
+			}
+			if ce.AlgorithmID != es.AlgorithmID || ce.KeyID != es.KeyID {
+				t.Errorf("CallEncryption alg/key = 0x%X/0x%X, want 0x%X/0x%X",
+					ce.AlgorithmID, ce.KeyID, es.AlgorithmID, es.KeyID)
+			}
+			// MessageIndicator must round-trip too — Phase 2 OFB
+			// resync relies on it eventually.
+			if ce.MessageIndicator != es.MessageIndicator {
+				t.Errorf("CallEncryption MI = %v, want %v",
+					ce.MessageIndicator, es.MessageIndicator)
+			}
+			return
+		case <-deadline.C:
+			t.Fatal("never received KindCallEncryption from composer")
+		}
+	}
+}

--- a/internal/voice/composer/p25p1_voice.go
+++ b/internal/voice/composer/p25p1_voice.go
@@ -5,8 +5,10 @@ import (
 	"time"
 
 	"github.com/MattCheramie/GopherTrunk/internal/dsp/filter"
+	"github.com/MattCheramie/GopherTrunk/internal/events"
 	"github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase1"
 	p25p1rx "github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase1/receiver"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
 )
 
 // p25p1VoiceIntermediateHz is the rate the wideband IQ is decimated to
@@ -48,6 +50,14 @@ func (c *Composer) runP25Phase1VoiceChain(ctx context.Context, serial string, iq
 	lpf := filter.NewFIR(filter.LowpassKaiser(81, cutoff, 8.6))
 
 	rs, _ := c.sink.(rawFrameSink)
+	// lastES is the last Encryption Sync this chain published on the
+	// bus. The voice frame stream carries one ES per LDU2 (every ~180
+	// ms), but ALGID/KID rarely change inside a single call — gate the
+	// publish so we don't fan out the same event a dozen times.
+	var (
+		lastES    phase1.EncryptionSync
+		hasLastES bool
+	)
 	rx := p25p1rx.New(p25p1rx.Options{
 		SampleRateHz: symbolHz,
 		DeviationHz:  p25p1DeviationHz,
@@ -90,6 +100,24 @@ func (c *Composer) runP25Phase1VoiceChain(ctx context.Context, serial string, iq
 				if es, _, lerr := phase1.ParseEncryptionSync(blocks); lerr == nil && es.Encrypted() {
 					c.log.Debug("composer: p25p1 encryption sync",
 						"serial", serial, "alg", es.AlgorithmID, "key", es.KeyID)
+					// Publish on the bus so the trunking engine
+					// backfills the active call's Grant. Skip when
+					// neither ALGID nor KID has changed since the
+					// last publish.
+					if !hasLastES || es.AlgorithmID != lastES.AlgorithmID || es.KeyID != lastES.KeyID || es.MessageIndicator != lastES.MessageIndicator {
+						c.bus.Publish(events.Event{
+							Kind: events.KindCallEncryption,
+							Payload: trunking.CallEncryption{
+								DeviceSerial:     serial,
+								AlgorithmID:      es.AlgorithmID,
+								KeyID:            es.KeyID,
+								MessageIndicator: es.MessageIndicator,
+								At:               time.Now(),
+							},
+						})
+						lastES = es
+						hasLastES = true
+					}
 				}
 			}
 		},

--- a/proto/events.proto
+++ b/proto/events.proto
@@ -59,6 +59,14 @@ message Grant {
   bool   encrypted       = 8;
   bool   emergency       = 9;
   bool   data_call       = 10;
+  // P25 encryption metadata recovered from the in-call signalling
+  // (Phase 1 LDU2 Encryption Sync, Phase 2 MAC EncryptionSync PDU).
+  // Meaningful only when encrypted=true; zero for clear calls and
+  // for encrypted calls whose ALGID/KID has not landed yet
+  // (Phase 1 grants publish before the first LDU2 — the engine
+  // backfills the values via KindCallEncryption).
+  uint32 algorithm_id    = 11;
+  uint32 key_id          = 12;
 }
 
 message CallStart {

--- a/web/src/api/p25Algorithm.test.ts
+++ b/web/src/api/p25Algorithm.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatP25Algorithm,
+  formatP25KeyID,
+  p25AlgorithmName,
+} from "./p25Algorithm";
+
+describe("p25AlgorithmName", () => {
+  it.each([
+    [0x80, "CLEAR"],
+    [0x81, "DES-OFB"],
+    [0x84, "AES-256"],
+    [0x85, "AES-128"],
+    [0xaa, "ADP/RC4"],
+    [0x00, "unknown"],
+    [0xff, "unknown"],
+  ])("0x%s -> %s", (id, want) => {
+    expect(p25AlgorithmName(id as number)).toBe(want);
+  });
+});
+
+describe("formatP25Algorithm", () => {
+  it("renders ID + mnemonic", () => {
+    expect(formatP25Algorithm(0x84)).toBe("0x84 (AES-256)");
+    expect(formatP25Algorithm(0x42)).toBe("0x42 (unknown)");
+  });
+});
+
+describe("formatP25KeyID", () => {
+  it("renders 16-bit hex with zero padding", () => {
+    expect(formatP25KeyID(0x1234)).toBe("0x1234");
+    expect(formatP25KeyID(0x0001)).toBe("0x0001");
+    expect(formatP25KeyID(0xffff)).toBe("0xFFFF");
+  });
+});

--- a/web/src/api/p25Algorithm.ts
+++ b/web/src/api/p25Algorithm.ts
@@ -1,0 +1,40 @@
+// P25 TIA-102.AACE-A Algorithm ID registry lookup. Mirrors
+// internal/radio/p25/algorithm.go so log lines, the TUI, and the SPA
+// render encryption metadata identically.
+
+export function p25AlgorithmName(id: number): string {
+  switch (id) {
+    case 0x80:
+      return "CLEAR";
+    case 0x81:
+      return "DES-OFB";
+    case 0x83:
+      return "TDES-2";
+    case 0x84:
+      return "AES-256";
+    case 0x85:
+      return "AES-128";
+    case 0x86:
+      return "TDES";
+    case 0x89:
+      return "AES-256-OFB";
+    case 0xaa:
+      return "ADP/RC4";
+    case 0x9f:
+      return "DES-XL";
+    default:
+      return "unknown";
+  }
+}
+
+// formatP25Algorithm renders id as "0x84 (AES-256)" — the same format
+// the daemon uses in its log lines so operators can correlate UI rows
+// with their decoded-message log.
+export function formatP25Algorithm(id: number): string {
+  return `0x${id.toString(16).toUpperCase().padStart(2, "0")} (${p25AlgorithmName(id)})`;
+}
+
+// formatP25KeyID renders the key ID as a 16-bit hex value.
+export function formatP25KeyID(id: number): string {
+  return `0x${id.toString(16).toUpperCase().padStart(4, "0")}`;
+}

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -52,6 +52,11 @@ export interface GrantDTO {
   encrypted?: boolean;
   emergency?: boolean;
   data_call?: boolean;
+  // P25 encryption metadata recovered from the in-call signalling.
+  // Meaningful only when encrypted is true; on Phase 1 they arrive
+  // after the grant via a `call.encryption` SSE event.
+  algorithm_id?: number;
+  key_id?: number;
 }
 
 export interface ActiveCallDTO {
@@ -131,6 +136,8 @@ export interface CallRow {
   source_id?: number;
   frequency_hz: number;
   encrypted?: boolean;
+  algorithm_id?: number;
+  key_id?: number;
   emergency?: boolean;
   data_call?: boolean;
   device_serial?: string;
@@ -139,6 +146,21 @@ export interface CallRow {
   duration_ms?: number;
   end_reason?: string;
   talkgroup_alpha?: string;
+}
+
+// CallEncryptionEvent is the SSE payload published as `call.encryption`
+// when the daemon recovers an Encryption Sync on an active call (P25
+// Phase 1 — Phase 2 carries the values on the original grant). The
+// SPA matches device_serial to the active-call row and patches its
+// algorithm_id / key_id in flight.
+export interface CallEncryptionEvent {
+  device_serial: string;
+  system?: string;
+  protocol?: string;
+  group_id?: number;
+  algorithm_id: number;
+  key_id: number;
+  at: string;
 }
 
 export interface RuntimeDTO {

--- a/web/src/panels/Active.tsx
+++ b/web/src/panels/Active.tsx
@@ -5,6 +5,7 @@ import { Column, DataTable } from "../components/DataTable";
 import { ConfirmModal } from "../components/ConfirmModal";
 import { DetailField, DetailModal } from "../components/DetailModal";
 import type { ActiveCallDTO } from "../api/types";
+import { formatP25Algorithm, formatP25KeyID } from "../api/p25Algorithm";
 import {
   selectCanMutate,
   selectClientConfig,
@@ -103,7 +104,20 @@ export function Active() {
         header: "",
         render: (r) => (
           <div className="flex flex-wrap gap-1">
-            {r.grant.encrypted && <span className="pill-warn">enc</span>}
+            {r.grant.encrypted && (
+              <span
+                className="pill-warn"
+                title={
+                  r.grant.algorithm_id != null
+                    ? `${formatP25Algorithm(r.grant.algorithm_id)} key ${formatP25KeyID(r.grant.key_id ?? 0)}`
+                    : "encryption metadata pending"
+                }
+              >
+                {r.grant.algorithm_id != null
+                  ? `enc ${formatP25Algorithm(r.grant.algorithm_id)}`
+                  : "enc"}
+              </span>
+            )}
             {r.grant.emergency && <span className="pill-err">emerg</span>}
             {r.grant.data_call && <span className="pill">data</span>}
           </div>
@@ -190,6 +204,28 @@ export function Active() {
               value={selected.grant.data_call ? "yes" : "no"}
             />
           </div>
+          {selected.grant.encrypted && (
+            <div className="grid grid-cols-2 gap-3">
+              <DetailField
+                label="Algorithm"
+                mono
+                value={
+                  selected.grant.algorithm_id != null
+                    ? formatP25Algorithm(selected.grant.algorithm_id)
+                    : "pending"
+                }
+              />
+              <DetailField
+                label="Key ID"
+                mono
+                value={
+                  selected.grant.key_id != null
+                    ? formatP25KeyID(selected.grant.key_id)
+                    : "pending"
+                }
+              />
+            </div>
+          )}
           <DetailField
             label="Device"
             mono

--- a/web/src/panels/History.tsx
+++ b/web/src/panels/History.tsx
@@ -5,6 +5,7 @@ import { Column, DataTable } from "../components/DataTable";
 import { ConfirmModal } from "../components/ConfirmModal";
 import { DetailField, DetailModal } from "../components/DetailModal";
 import type { CallRow } from "../api/types";
+import { formatP25Algorithm, formatP25KeyID } from "../api/p25Algorithm";
 import {
   selectCanMutate,
   selectClientConfig,
@@ -131,7 +132,20 @@ export function History() {
         header: "",
         render: (r) => (
           <div className="flex flex-wrap gap-1">
-            {r.encrypted && <span className="pill-warn">enc</span>}
+            {r.encrypted && (
+              <span
+                className="pill-warn"
+                title={
+                  r.algorithm_id != null && r.algorithm_id !== 0
+                    ? `${formatP25Algorithm(r.algorithm_id)} key ${formatP25KeyID(r.key_id ?? 0)}`
+                    : "encryption metadata not captured"
+                }
+              >
+                {r.algorithm_id != null && r.algorithm_id !== 0
+                  ? `enc ${formatP25Algorithm(r.algorithm_id)}`
+                  : "enc"}
+              </span>
+            )}
             {r.emergency && <span className="pill-err">emerg</span>}
             {r.data_call && <span className="pill">data</span>}
           </div>
@@ -288,6 +302,28 @@ export function History() {
               value={selected.data_call ? "yes" : "no"}
             />
           </div>
+          {selected.encrypted && (
+            <div className="grid grid-cols-2 gap-3">
+              <DetailField
+                label="Algorithm"
+                mono
+                value={
+                  selected.algorithm_id != null && selected.algorithm_id !== 0
+                    ? formatP25Algorithm(selected.algorithm_id)
+                    : "not captured"
+                }
+              />
+              <DetailField
+                label="Key ID"
+                mono
+                value={
+                  selected.key_id != null && selected.key_id !== 0
+                    ? formatP25KeyID(selected.key_id)
+                    : "not captured"
+                }
+              />
+            </div>
+          )}
           <DetailField
             label="Device"
             mono

--- a/web/src/store/shared.ts
+++ b/web/src/store/shared.ts
@@ -7,6 +7,7 @@ import { create } from "zustand";
 import type {
   ActiveCallDTO,
   AudioStatusDTO,
+  CallEncryptionEvent,
   DeviceDTO,
   EventDTO,
   Health,
@@ -128,7 +129,33 @@ export const useShared = create<SharedState>((set, get) => ({
       combined.length > cap
         ? combined.slice(combined.length - cap)
         : combined;
-    set({ events: next });
+    // Patch active calls in flight when an encryption-metadata update
+    // arrives. The poll loop in Active.tsx would pick this up within
+    // ~2 s, but patching synchronously avoids the "enc" pill flashing
+    // without its algorithm name for that window.
+    let activeCalls = get().activeCalls;
+    let patched = false;
+    for (const ev of evs) {
+      if (ev.kind !== "call.encryption" || ev.payload == null) continue;
+      const p = ev.payload as CallEncryptionEvent;
+      if (!p.device_serial) continue;
+      const idx = activeCalls.findIndex(
+        (ac) => ac.device_serial === p.device_serial,
+      );
+      if (idx < 0) continue;
+      const ac = activeCalls[idx];
+      activeCalls = activeCalls.slice();
+      activeCalls[idx] = {
+        ...ac,
+        grant: {
+          ...ac.grant,
+          algorithm_id: p.algorithm_id,
+          key_id: p.key_id,
+        },
+      };
+      patched = true;
+    }
+    set(patched ? { events: next, activeCalls } : { events: next });
   },
   setError(msg) {
     set({ lastError: msg });


### PR DESCRIPTION
P25 calls already carry an enc=true / E flag, but the algorithm
(ALGID) and key (KID) identifiers in the in-call signalling were
parsed and dropped on the floor. Operators triaging encrypted
traffic had no way to tell DES-OFB from AES-256 from ADP without
running SDRtrunk on the side.

This threads ALGID/KID end-to-end:

  * trunking.Grant already had the fields; Phase 2 was populating
    them but nothing downstream did. Phase 1 leaves them zero at
    grant time and backfills via a new KindCallEncryption event:
    the voice composer publishes one when it parses an LDU2
    Encryption Sync; the engine updates the bound ActiveCall.Grant
    through a new VoicePool.UpdateEncryption helper and republishes
    with system/protocol/group context for SSE consumers.

  * Wire-format additions: GrantDTO + CallEncryptionDTO (REST/SSE),
    pb Grant message + grpc bridge, TUI client mirror, web GrantDTO
    + CallRow + new CallEncryptionEvent, broadcast.Call. Storage
    schema already had the columns.

  * Display: new internal/radio/p25 algorithm-registry helper plus
    its web mirror render "0x84 (AES-256)" uniformly across log
    lines, the TUI active-call flag column, and both web panels'
    pills + detail views. The SPA also patches in-flight active
    rows from the call.encryption event so the algorithm name
    appears the instant the LDU2 lands rather than on the next
    2 s poll.

Closes #353.