### PR TITLE
airspy: defer SET_SAMPLE_TYPE to StreamIQ; clarify Windows USB errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ for tagged releases.
 
 ## [Unreleased]
 
+### Fixed
+
+- **airspy**: Defer `SET_SAMPLE_TYPE` from `Open()` to `StreamIQ()`,
+  matching libairspy's open ordering (`GET_SAMPLERATES` IN first,
+  no vendor OUT during open). Fixes Airspy R2 failing to open on
+  Windows with `winusb: WinUsb_ControlTransfer OUT: usb: device
+  disconnected` even though `sdr list` detected the device
+  (issue #270, reporter @VA7DBI).
+- **windows usb backend**: Stop folding `ERROR_GEN_FAILURE` into
+  `ErrDeviceGone`. That conflation printed "usb: device
+  disconnected" for what is actually a firmware NAK / stalled
+  pipe / wrong-driver-bound condition, and actively misled the
+  issue #270 reporter. The error now names the Win32 code and
+  suggests re-binding via Zadig.
+
 ## [v0.2.2] — 2026-05-25
 
 Operational-recovery + Mt Anakie follow-up release. The reporter in

--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -175,6 +175,13 @@ dropdown, choose the WinUSB driver, click Replace. See
 [`install-windows.md`]({{ '/install-windows.html' | relative_url }})
 for the click-by-click walkthrough.
 
+Airspy R2 / Mini in particular: the official Airspy installer
+typically binds **libusbK**, which is not the in-box WinUSB.sys
+GopherTrunk talks to. If `sdr list` shows the device but
+`gophertrunk -config …` fails on open with `winusb: device rejected
+request (ERROR_GEN_FAILURE …)`, re-bind to WinUSB via Zadig — the
+hardware is reachable but the function driver is mismatched.
+
 ## Verifying the build
 
 ```sh

--- a/internal/sdr/airspy/airspy.go
+++ b/internal/sdr/airspy/airspy.go
@@ -128,8 +128,9 @@ func tunerNameFor(product string) string {
 }
 
 // Open claims the device at idx and returns an sdr.Device. The
-// returned device defaults to INT16_IQ sample mode and the highest
-// rate the firmware advertises.
+// returned device defaults to INT16_IQ sample mode (applied lazily
+// at StreamIQ time, matching libairspy) and the highest rate the
+// firmware advertises.
 func (d *Driver) Open(idx int) (sdr.Device, error) {
 	d.mu.Lock()
 	cached := d.cached
@@ -165,14 +166,11 @@ func (d *Driver) Open(idx int) (sdr.Device, error) {
 			TunerName:    tunerNameFor(desc.Product),
 		},
 	}
-	// Pin the device to INT16_IQ — the format the StreamIQ decoder
-	// expects.
-	if err := t.ControlOut(reqSetSampleType, sampleTypeInt16IQ, 0, nil, controlTimeoutMs); err != nil {
-		_ = dev.Close()
-		return nil, fmt.Errorf("airspy: set sample type: %w", err)
-	}
-	// Read the supported-samplerate table so SetSampleRate can match
-	// the requested rate against an index.
+	// Read the supported-samplerate table. This is the first vendor
+	// transfer after claim — matching libairspy's open ordering
+	// (vendor IN first, no SET_SAMPLE_TYPE during open). Some firmware
+	// / Windows driver bindings reject a vendor OUT as the very first
+	// transfer (issue #270).
 	rates, err := dev.fetchSampleRates()
 	if err != nil {
 		// Non-fatal: keep the device usable; SetSampleRate will fall
@@ -196,10 +194,11 @@ type Device struct {
 	t    usb.Transport
 	info sdr.Info
 
-	mu        sync.Mutex
-	closed    bool
-	streaming bool
-	rates     []uint32 // supported sample rates, Hz, descending order
+	mu             sync.Mutex
+	closed         bool
+	streaming      bool
+	sampleTypeSet  bool     // true once SET_SAMPLE_TYPE has been issued
+	rates          []uint32 // supported sample rates, Hz, descending order
 }
 
 // Info implements sdr.Device.
@@ -361,7 +360,24 @@ func (d *Device) StreamIQ(ctx context.Context) (<-chan []complex64, error) {
 		return nil, errors.New("airspy: stream already active")
 	}
 	d.streaming = true
+	needSampleType := !d.sampleTypeSet
 	d.mu.Unlock()
+
+	// Pin the device to INT16_IQ — the format the StreamIQ decoder
+	// expects. libairspy issues this inside airspy_start_rx rather
+	// than during open; mirroring that ordering avoids a firmware /
+	// Windows-driver NAK on the first vendor OUT (issue #270).
+	if needSampleType {
+		if err := d.t.ControlOut(reqSetSampleType, sampleTypeInt16IQ, 0, nil, controlTimeoutMs); err != nil {
+			d.mu.Lock()
+			d.streaming = false
+			d.mu.Unlock()
+			return nil, fmt.Errorf("airspy: set sample type: %w", err)
+		}
+		d.mu.Lock()
+		d.sampleTypeSet = true
+		d.mu.Unlock()
+	}
 
 	if err := d.setReceiver(receiverModeOn); err != nil {
 		d.mu.Lock()

--- a/internal/sdr/airspy/airspy.go
+++ b/internal/sdr/airspy/airspy.go
@@ -194,11 +194,11 @@ type Device struct {
 	t    usb.Transport
 	info sdr.Info
 
-	mu             sync.Mutex
-	closed         bool
-	streaming      bool
-	sampleTypeSet  bool     // true once SET_SAMPLE_TYPE has been issued
-	rates          []uint32 // supported sample rates, Hz, descending order
+	mu            sync.Mutex
+	closed        bool
+	streaming     bool
+	sampleTypeSet bool     // true once SET_SAMPLE_TYPE has been issued
+	rates         []uint32 // supported sample rates, Hz, descending order
 }
 
 // Info implements sdr.Device.

--- a/internal/sdr/airspy/airspy_test.go
+++ b/internal/sdr/airspy/airspy_test.go
@@ -16,10 +16,10 @@ func withDevice(t *testing.T) (*Device, *usb.MockTransport) {
 	return &Device{t: mt, info: sdr.Info{Driver: driverName, Serial: "test"}}, mt
 }
 
-func TestDriverEnumerateOpenSetsSampleType(t *testing.T) {
-	// On Open the driver pins INT16_IQ and reads the samplerate table
-	// (count first, then list). Provide both calls in the OpenFunc'd
-	// transport.
+func TestDriverOpenReadsSamplerates(t *testing.T) {
+	// On Open the driver reads the samplerate table (count first,
+	// then list) and does NOT issue SET_SAMPLE_TYPE — that's deferred
+	// to StreamIQ, matching libairspy's ordering (issue #270).
 	openCalled := false
 	enum := &usb.MockEnumerator{
 		Devices: []usb.Descriptor{
@@ -34,7 +34,6 @@ func TestDriverEnumerateOpenSetsSampleType(t *testing.T) {
 			binary.LittleEndian.PutUint32(list[0:4], 10_000_000)
 			binary.LittleEndian.PutUint32(list[4:8], 2_500_000)
 			mt.Script = []usb.CtrlExchange{
-				{BRequest: reqSetSampleType, WValue: sampleTypeInt16IQ},
 				{In: true, BRequest: reqGetSamplerates, WValue: 0, WIndex: 0, Reply: count, N: 4},
 				{In: true, BRequest: reqGetSamplerates, WValue: 0, WIndex: 2, Reply: list, N: 8},
 			}
@@ -59,6 +58,9 @@ func TestDriverEnumerateOpenSetsSampleType(t *testing.T) {
 	asDev := dev.(*Device)
 	if len(asDev.rates) != 2 || asDev.rates[0] != 10_000_000 {
 		t.Fatalf("samplerate table = %v", asDev.rates)
+	}
+	if asDev.sampleTypeSet {
+		t.Error("Open issued SET_SAMPLE_TYPE; expected it deferred to StreamIQ (#270)")
 	}
 	if err := dev.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
@@ -244,6 +246,8 @@ func TestDecodeInt16IQ(t *testing.T) {
 func TestStreamIQFlipsReceiverAndStops(t *testing.T) {
 	dev, mt := withDevice(t)
 	mt.Script = []usb.CtrlExchange{
+		// SET_SAMPLE_TYPE moved out of Open; first StreamIQ pins it.
+		{BRequest: reqSetSampleType, WValue: sampleTypeInt16IQ},
 		{BRequest: reqReceiverMode, WValue: receiverModeOn},
 		{BRequest: reqReceiverMode, WValue: receiverModeOff},
 	}
@@ -251,6 +255,9 @@ func TestStreamIQFlipsReceiverAndStops(t *testing.T) {
 	ch, err := dev.StreamIQ(ctx)
 	if err != nil {
 		t.Fatalf("StreamIQ: %v", err)
+	}
+	if !dev.sampleTypeSet {
+		t.Error("StreamIQ did not record sampleTypeSet")
 	}
 	cancel()
 	deadline := time.Now().Add(time.Second)

--- a/internal/sdr/rtlsdr/usb/usb.go
+++ b/internal/sdr/rtlsdr/usb/usb.go
@@ -139,7 +139,11 @@ var (
 
 	// ErrDeviceGone is returned by any operation after the device has
 	// been physically removed or the kernel has decided it's dead.
-	// Maps to ENODEV on Linux and ERROR_GEN_FAILURE on Windows.
+	// Maps to ENODEV on Linux and ERROR_DEVICE_NOT_CONNECTED /
+	// ERROR_NO_SUCH_DEVICE / ERROR_DEV_NOT_EXIST on Windows. Note
+	// ERROR_GEN_FAILURE is NOT mapped here — that's a firmware
+	// reject / driver-binding issue, not a physical disconnect
+	// (see winErr in usb_windows.go; issue #270).
 	ErrDeviceGone = errors.New("usb: device disconnected")
 
 	// ErrTimeout is returned when a control transfer didn't complete

--- a/internal/sdr/rtlsdr/usb/usb_windows.go
+++ b/internal/sdr/rtlsdr/usb/usb_windows.go
@@ -658,6 +658,12 @@ func parseDevicePath(p string) (vid, pid uint16, serial string) {
 // winErr maps Windows error codes to the package's sentinel errors;
 // unmapped errors come through wrapped as-is so callers can still
 // inspect the underlying code via errors.As(*windows.Errno).
+//
+// ERROR_GEN_FAILURE (0x1F) is deliberately NOT folded into
+// ErrDeviceGone: it commonly means the device firmware NAK'd the
+// request, the pipe stalled, or the wrong function driver is bound
+// (e.g. libusbK rather than in-box WinUSB.sys). Conflating it with
+// physical disconnect actively misled the issue #270 reporter.
 func winErr(errno error) error {
 	if errno == nil {
 		return nil
@@ -665,9 +671,10 @@ func winErr(errno error) error {
 	switch errno {
 	case windows.ERROR_DEVICE_NOT_CONNECTED,
 		windows.ERROR_NO_SUCH_DEVICE,
-		windows.ERROR_DEV_NOT_EXIST,
-		windows.ERROR_GEN_FAILURE:
+		windows.ERROR_DEV_NOT_EXIST:
 		return ErrDeviceGone
+	case windows.ERROR_GEN_FAILURE:
+		return fmt.Errorf("winusb: device rejected request (ERROR_GEN_FAILURE 0x1F — firmware NAK / stalled pipe / wrong driver bound; try re-binding to WinUSB via Zadig): %w", errno)
 	case windows.ERROR_SEM_TIMEOUT, windows.ERROR_TIMEOUT:
 		return ErrTimeout
 	}

--- a/internal/sdr/rtlsdr/usb/usb_windows_test.go
+++ b/internal/sdr/rtlsdr/usb/usb_windows_test.go
@@ -3,8 +3,12 @@
 package usb
 
 import (
+	"errors"
+	"strings"
 	"testing"
 	"unsafe"
+
+	"golang.org/x/sys/windows"
 )
 
 func TestParseDevicePath_RTLSDR(t *testing.T) {
@@ -98,5 +102,34 @@ func TestPlatformEnumeratorIsWinUSB(t *testing.T) {
 	e := DefaultEnumerator()
 	if got, want := e.Name(), "winusb"; got != want {
 		t.Errorf("backend Name() = %q, want %q", got, want)
+	}
+}
+
+func TestWinErr_GenFailureIsNotDeviceGone(t *testing.T) {
+	// ERROR_GEN_FAILURE used to be folded into ErrDeviceGone, which
+	// printed "usb: device disconnected" and misled the issue #270
+	// reporter when their (still-connected) Airspy NAK'd a vendor
+	// request. Keep them distinct.
+	got := winErr(windows.ERROR_GEN_FAILURE)
+	if errors.Is(got, ErrDeviceGone) {
+		t.Errorf("winErr(ERROR_GEN_FAILURE) erroneously folds into ErrDeviceGone: %v", got)
+	}
+	if !errors.Is(got, windows.ERROR_GEN_FAILURE) {
+		t.Errorf("winErr(ERROR_GEN_FAILURE) lost the underlying errno (need errors.Is to find it): %v", got)
+	}
+	if !strings.Contains(got.Error(), "ERROR_GEN_FAILURE") {
+		t.Errorf("winErr(ERROR_GEN_FAILURE) message should name the Win32 code: %q", got.Error())
+	}
+}
+
+func TestWinErr_DisconnectCodesMapToDeviceGone(t *testing.T) {
+	for _, errno := range []windows.Errno{
+		windows.ERROR_DEVICE_NOT_CONNECTED,
+		windows.ERROR_NO_SUCH_DEVICE,
+		windows.ERROR_DEV_NOT_EXIST,
+	} {
+		if got := winErr(errno); !errors.Is(got, ErrDeviceGone) {
+			t.Errorf("winErr(%v) = %v, want ErrDeviceGone", errno, got)
+		}
 	}
 }


### PR DESCRIPTION
Fix Airspy R2 failing to open on Windows even though `sdr list`
detects it. Previously Open() issued SET_SAMPLE_TYPE (vendor OUT,
request 11) as its first transfer; some firmware / Windows-driver
bindings reject a vendor OUT as the very first request, returning
ERROR_GEN_FAILURE which the backend then mislabeled as "device
disconnected". Reorder Open() to match upstream libairspy: read
GET_SAMPLERATES (vendor IN) first, defer SET_SAMPLE_TYPE to
StreamIQ where libairspy itself runs it (inside airspy_start_rx).

Also stop folding ERROR_GEN_FAILURE into ErrDeviceGone — that
conflation actively misled the issue #270 reporter when their
still-connected Airspy NAK'd the request. The new wrapped error
names the Win32 code and points to Zadig as the likely fix when
the function driver is mismatched.

Fixes #270.