### PR TITLE
trunking/composer: gate Engine.Touch on decoder progress (#356)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,23 @@ for tagged releases.
 
 ### Fixed
 
+- **trunking/composer**: Voice chains no longer keep a call alive
+  forever via an unconditional 1 s heartbeat. The four chains
+  (P25 Phase 1, P25 Phase 2, DMR, NBFM) now gate `Engine.Touch` on
+  actual decoder progress — an LDU / superframe / voice subframe /
+  PCM batch — so the 30 s inactivity watchdog can fire and release
+  the bound voice SDR when transmission stops. Before this fix a
+  stalled decoder (simulcast garbage, vocoder hang) refreshed
+  `LastHeardAt` every tick regardless of whether any voice frames
+  were decoded, leaving the active call permanently locked on a
+  single talkgroup and every subsequent grant logging "no voice
+  device available for grant" (issue #356, reporter @KN4MSH).
+- **config**: New `trunking.call_timeout_ms` knob lets operators
+  tune the watchdog timeout (still 30 s by default). Useful on
+  systems with consistently clean signaling (lower for snappier
+  teardown) or chatty channels with long transmission pauses
+  (higher). Issue #356.
+
 - **airspy**: Defer `SET_SAMPLE_TYPE` from `Open()` to `StreamIQ()`,
   matching libairspy's open ordering (`GET_SAMPLERATES` IN first,
   no vendor OUT during open). Fixes Airspy R2 failing to open on

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -384,11 +384,12 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 	}
 
 	engine, err := trunking.NewEngine(trunking.EngineOptions{
-		Bus:        d.bus,
-		Log:        log,
-		VoicePool:  d.voicePool,
-		Talkgroups: d.talkgroups,
-		ScanMode:   trunking.ParseScanMode(cfg.Scanner.ScanMode),
+		Bus:         d.bus,
+		Log:         log,
+		VoicePool:   d.voicePool,
+		Talkgroups:  d.talkgroups,
+		ScanMode:    trunking.ParseScanMode(cfg.Scanner.ScanMode),
+		CallTimeout: time.Duration(cfg.Trunking.CallTimeoutMs) * time.Millisecond,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("daemon: engine: %w", err)

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -120,6 +120,15 @@ sdr:
       bias_tee: false
 
 trunking:
+  # call_timeout_ms: inactivity window after which the engine's
+  # watchdog ends a call (publishes CallEnd with EndReasonTimeout
+  # and releases the bound voice SDR). The watchdog only fires
+  # when no voice frames have been decoded for this long. Default
+  # 30000 (30 s) when omitted or zero. Lower it on clean systems
+  # for snappier teardown; raise it on chatty systems with long
+  # transmission pauses. Issue #356.
+  call_timeout_ms: 30000
+
   systems:
     - name: "Example-P25"
       protocol: p25

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -285,6 +285,17 @@ type DeviceConfig struct {
 
 type TrunkingConfig struct {
 	Systems []SystemConfig `yaml:"systems"`
+
+	// CallTimeoutMs is the inactivity window after which the engine's
+	// watchdog ends a call (publishes CallEnd with EndReasonTimeout
+	// and releases the bound voice SDR). The watchdog only fires when
+	// no voice frames have been decoded for this long — see
+	// internal/voice/composer for the per-protocol activity gate.
+	// Defaults to 30 000 (30 s) when zero. Negative values are
+	// rejected by Validate; setting it explicitly lets operators tune
+	// teardown on systems whose signaling is consistently clean
+	// (lower) or chatty with long pauses (higher). Issue #356.
+	CallTimeoutMs int `yaml:"call_timeout_ms"`
 }
 
 type SystemConfig struct {
@@ -703,6 +714,9 @@ func (c Config) Validate() error {
 				i, d.Serial, prev)
 		}
 		seenSerials[d.Serial] = i
+	}
+	if c.Trunking.CallTimeoutMs < 0 {
+		return fmt.Errorf("trunking.call_timeout_ms: %d ms must be ≥ 0", c.Trunking.CallTimeoutMs)
 	}
 	for i, s := range c.Trunking.Systems {
 		if s.Name == "" {

--- a/internal/voice/composer/composer.go
+++ b/internal/voice/composer/composer.go
@@ -26,6 +26,7 @@ import (
 	"log/slog"
 	"math"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/MattCheramie/GopherTrunk/internal/dsp"
@@ -527,6 +528,16 @@ func (c *Composer) runFMChain(ctx context.Context, serial string, iqCh <-chan []
 
 	touchTicker := time.NewTicker(c.touchEvery)
 	defer touchTicker.Stop()
+	// pcmWrites counts PCM batches successfully handed to the sink —
+	// i.e. real audio delivery. The touch ticker (below) only refreshes
+	// the engine's LastHeardAt when this counter has advanced since
+	// the previous tick. Without this gate a stalled IQ source still
+	// kept the call alive forever via an unconditional 1 s heartbeat
+	// (issue #356).
+	var (
+		pcmWrites    atomic.Uint64
+		lastPCMWrite uint64
+	)
 
 	// lastSample tracks the most recent PCM sample written so we
 	// can ramp it down to zero when the chain ends. Without this
@@ -560,8 +571,10 @@ func (c *Composer) runFMChain(ctx context.Context, serial string, iqCh <-chan []
 			emitTail()
 			return
 		case <-touchTicker.C:
-			if c.engine != nil {
+			n := pcmWrites.Load()
+			if n != lastPCMWrite && c.engine != nil {
 				c.engine.Touch(serial)
+				lastPCMWrite = n
 			}
 		case iq, ok := <-iqCh:
 			if !ok {
@@ -600,6 +613,7 @@ func (c *Composer) runFMChain(ctx context.Context, serial string, iqCh <-chan []
 			if c.sink != nil && len(pcm) > 0 {
 				_ = c.sink.WritePCM(serial, pcm)
 				lastSample = pcm[len(pcm)-1]
+				pcmWrites.Add(1)
 			}
 		}
 	}

--- a/internal/voice/composer/composer_test.go
+++ b/internal/voice/composer/composer_test.go
@@ -217,7 +217,69 @@ func TestComposerTouchesEngineWhileChainRuns(t *testing.T) {
 	defer teardown()
 
 	publishStartFM(bus, "VOICE-1")
-	waitFor(t, time.Second, func() bool { return eng.touched.Load() >= 2 })
+	// Wait until StreamIQ has been opened so SendIQ doesn't race.
+	waitFor(t, time.Second, func() bool {
+		src.mu.Lock()
+		defer src.mu.Unlock()
+		return len(src.chs) > 0
+	})
+
+	// Touch is gated on actual PCM emission (issue #356) — keep feeding
+	// IQ so the chain produces PCM batches across multiple touch ticks.
+	chunk := make([]complex64, 4096)
+	for i := range chunk {
+		chunk[i] = complex(0.5, 0.5)
+	}
+	stop := make(chan struct{})
+	defer close(stop)
+	go func() {
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			src.SendIQ(chunk)
+			time.Sleep(10 * time.Millisecond)
+		}
+	}()
+
+	waitFor(t, 2*time.Second, func() bool { return eng.touched.Load() >= 2 })
+}
+
+// TestComposerStopsTouchingEngineWhenIQStops asserts the activity gate
+// introduced for issue #356: once PCM emission stops (e.g. simulcast
+// garbage, vocoder hang) the chain MUST stop touching the engine so
+// the trunking watchdog can fire and release the voice SDR. Before
+// the fix the touch ticker ran unconditionally and the call lived
+// forever.
+func TestComposerStopsTouchingEngineWhenIQStops(t *testing.T) {
+	src := newFakeSource()
+	_, bus, _, eng, teardown := mkComposer(t, src)
+	defer teardown()
+
+	publishStartFM(bus, "VOICE-1")
+	waitFor(t, time.Second, func() bool {
+		src.mu.Lock()
+		defer src.mu.Unlock()
+		return len(src.chs) > 0
+	})
+
+	// Push enough IQ to establish baseline Touch activity.
+	chunk := make([]complex64, 4096)
+	for i := range chunk {
+		chunk[i] = complex(0.5, 0.5)
+	}
+	src.SendIQ(chunk)
+	waitFor(t, time.Second, func() bool { return eng.touched.Load() >= 1 })
+
+	// Stop feeding IQ; sample the touch count after several touch
+	// intervals (TouchInterval is 30 ms above; 5× ≈ 150 ms is plenty).
+	baseline := eng.touched.Load()
+	time.Sleep(200 * time.Millisecond)
+	if got := eng.touched.Load(); got != baseline {
+		t.Fatalf("expected no further touches after IQ stopped; baseline=%d got=%d", baseline, got)
+	}
 }
 
 func TestComposerStopsChainOnCallEnd(t *testing.T) {

--- a/internal/voice/composer/dmr_voice.go
+++ b/internal/voice/composer/dmr_voice.go
@@ -2,6 +2,7 @@ package composer
 
 import (
 	"context"
+	"sync/atomic"
 	"time"
 
 	"github.com/MattCheramie/GopherTrunk/internal/dsp/filter"
@@ -57,6 +58,12 @@ func (c *Composer) runDMRVoiceChain(ctx context.Context, serial string, iqCh <-c
 
 	rs, _ := c.sink.(rawFrameSink)
 	voiceDec := dmrvoice.NewDecoder()
+	// superframes counts DMR voice superframes the receiver delivered —
+	// i.e. real voice activity. The touch ticker (below) only refreshes
+	// the engine's LastHeardAt when this counter has advanced since the
+	// previous tick. Without this gate a stalled decoder still kept the
+	// call alive forever via an unconditional 1 s heartbeat (issue #356).
+	var superframes atomic.Uint64
 	rx := dmrrx.New(dmrrx.Options{
 		SampleRateHz: symbolHz,
 		// DMR spec peak deviation per ETSI TS 102 361-1 §6.3 — matches
@@ -64,10 +71,11 @@ func (c *Composer) runDMRVoiceChain(ctx context.Context, serial string, iqCh <-c
 		DeviationHz: 1944.0,
 		ClockGain:   0.025,
 		DibitSink: func(dibits []uint8, baseIdx int) {
-			if rs == nil {
-				return
-			}
 			for _, sf := range voiceDec.Process(dibits, baseIdx) {
+				superframes.Add(1)
+				if rs == nil {
+					continue
+				}
 				for i := range sf.Frames {
 					info, _, err := dmrvoice.DecodeAMBEFrame(sf.Frames[i])
 					if err != nil {
@@ -86,14 +94,17 @@ func (c *Composer) runDMRVoiceChain(ctx context.Context, serial string, iqCh <-c
 
 	touchTicker := time.NewTicker(c.touchEvery)
 	defer touchTicker.Stop()
+	var lastSuperframes uint64
 
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case <-touchTicker.C:
-			if c.engine != nil {
+			n := superframes.Load()
+			if n != lastSuperframes && c.engine != nil {
 				c.engine.Touch(serial)
+				lastSuperframes = n
 			}
 		case iq, ok := <-iqCh:
 			if !ok {

--- a/internal/voice/composer/p25p1_voice.go
+++ b/internal/voice/composer/p25p1_voice.go
@@ -2,6 +2,7 @@ package composer
 
 import (
 	"context"
+	"sync/atomic"
 	"time"
 
 	"github.com/MattCheramie/GopherTrunk/internal/dsp/filter"
@@ -58,19 +59,28 @@ func (c *Composer) runP25Phase1VoiceChain(ctx context.Context, serial string, iq
 		lastES    phase1.EncryptionSync
 		hasLastES bool
 	)
+	// frames counts LDUs delivered by the receiver — i.e. real voice
+	// activity. The touch ticker (below) only refreshes the engine's
+	// LastHeardAt when this counter has advanced since the previous
+	// tick. Without this gate, a stalled decoder still kept the call
+	// alive forever via an unconditional 1 s heartbeat (issue #356).
+	var frames atomic.Uint64
 	rx := p25p1rx.New(p25p1rx.Options{
 		SampleRateHz: symbolHz,
 		DeviationHz:  p25p1DeviationHz,
 		Sink: func(ldu []byte) {
+			// Bump first so the watchdog gate accounts for LDU
+			// delivery even when there's no raw-frame sink.
+			frames.Add(1)
 			if rs == nil {
 				return
 			}
-			frames, _, err := phase1.ExtractVoiceFrames(ldu)
+			fs, _, err := phase1.ExtractVoiceFrames(ldu)
 			if err != nil {
 				c.log.Warn("composer: p25p1 voice extract failed",
 					"serial", serial, "err", err)
 			}
-			for _, f := range frames {
+			for _, f := range fs {
 				if f == nil {
 					continue
 				}
@@ -125,14 +135,17 @@ func (c *Composer) runP25Phase1VoiceChain(ctx context.Context, serial string, iq
 
 	touchTicker := time.NewTicker(c.touchEvery)
 	defer touchTicker.Stop()
+	var lastFrames uint64
 
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case <-touchTicker.C:
-			if c.engine != nil {
+			n := frames.Load()
+			if n != lastFrames && c.engine != nil {
 				c.engine.Touch(serial)
+				lastFrames = n
 			}
 		case iq, ok := <-iqCh:
 			if !ok {

--- a/internal/voice/composer/p25p1_voice_test.go
+++ b/internal/voice/composer/p25p1_voice_test.go
@@ -139,3 +139,68 @@ func TestComposerP25Phase1VoiceChainExtractsRawFrames(t *testing.T) {
 
 	waitFor(t, time.Second, func() bool { return eng.touched.Load() > 0 })
 }
+
+// TestComposerP25Phase1TouchGatedOnLDUProgress reproduces the
+// regression behind issue #356: once LDU delivery stops (e.g. the
+// transmitting unit sent a TDU, the carrier dropped, or the C4FM
+// receiver lost lock on simulcast garbage), the chain MUST stop
+// touching the engine so the trunking watchdog can fire and release
+// the voice SDR. Before the fix the chain emitted a 1 s heartbeat
+// unconditionally and the active call lived forever.
+func TestComposerP25Phase1TouchGatedOnLDUProgress(t *testing.T) {
+	const (
+		sampleRate = 48_000.0
+		deviation  = 1800.0
+		ldus       = 6
+	)
+	dibits, _ := buildP25P1VoiceStream(t, ldus)
+	iq := demod.ModulateP25C4FM(dibits, sampleRate, deviation)
+
+	src := newFakeSource()
+	bus := events.NewBus(8)
+	sink := &recordingSink{}
+	eng := &fakeEngine{}
+	c, err := New(Options{
+		Bus:           bus,
+		Devices:       &fakeDevices{src: map[string]IQSource{"VOICE-1": src}},
+		Sink:          sink,
+		Engine:        eng,
+		IQSampleRate:  uint32(sampleRate),
+		PCMSampleRate: 8000,
+		TouchInterval: 30 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go c.Run(ctx)
+	defer c.Close()
+	defer bus.Close()
+
+	bus.Publish(events.Event{
+		Kind: events.KindCallStart,
+		Payload: trunking.CallStart{
+			Grant: trunking.Grant{
+				System: "P25P1Site", Protocol: "p25",
+				GroupID: 42, FrequencyHz: 851_000_000,
+			},
+			DeviceSerial: "VOICE-1",
+			StartedAt:    time.Now().UTC(),
+		},
+	})
+	waitFor(t, 2*time.Second, func() bool { return len(c.ActiveChains()) == 1 })
+
+	// Feed IQ → LDUs decode → frame counter advances → Touch fires.
+	src.SendIQ(iq)
+	waitFor(t, 6*time.Second, func() bool { return eng.touched.Load() >= 1 })
+
+	// Stop feeding IQ. The chain must stop touching after the last LDU.
+	// 10× TouchInterval (300 ms) is well past any in-flight LDU.
+	time.Sleep(300 * time.Millisecond)
+	baseline := eng.touched.Load()
+	time.Sleep(300 * time.Millisecond)
+	if got := eng.touched.Load(); got != baseline {
+		t.Fatalf("expected no further touches after IQ stopped; baseline=%d got=%d", baseline, got)
+	}
+}

--- a/internal/voice/composer/p25p2_voice.go
+++ b/internal/voice/composer/p25p2_voice.go
@@ -2,6 +2,7 @@ package composer
 
 import (
 	"context"
+	"sync/atomic"
 	"time"
 
 	"github.com/MattCheramie/GopherTrunk/internal/dsp/filter"
@@ -52,17 +53,25 @@ func (c *Composer) runP25Phase2VoiceChain(ctx context.Context, serial string, iq
 
 	rs, _ := c.sink.(rawFrameSink)
 	sfDec := p25p2.NewSuperframeDecoder()
+	// voiceSubframes counts P25 Phase 2 voice-bearing subframes the
+	// receiver delivered — i.e. real voice activity. The touch ticker
+	// (below) only refreshes the engine's LastHeardAt when this counter
+	// has advanced since the previous tick. Without this gate a stalled
+	// decoder still kept the call alive forever via an unconditional
+	// 1 s heartbeat (issue #356).
+	var voiceSubframes atomic.Uint64
 	rx := p25p2rx.New(p25p2rx.Options{
 		SampleRateHz: symbolHz,
 		ClockMode:    p25p2rx.ClockGardner,
 		GardnerGain:  p25p2VoiceGardnerGain,
 		DibitSink: func(dibits []uint8, baseIdx int) {
-			if rs == nil {
-				return
-			}
 			for _, sf := range sfDec.Process(dibits, baseIdx) {
 				for _, sub := range sf.Subframes {
 					if !sub.SlotType.IsVoice() {
+						continue
+					}
+					voiceSubframes.Add(1)
+					if rs == nil {
 						continue
 					}
 					frames, _, err := p25p2.ExtractVoiceFrames(sub)
@@ -86,14 +95,17 @@ func (c *Composer) runP25Phase2VoiceChain(ctx context.Context, serial string, iq
 
 	touchTicker := time.NewTicker(c.touchEvery)
 	defer touchTicker.Stop()
+	var lastSubframes uint64
 
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case <-touchTicker.C:
-			if c.engine != nil {
+			n := voiceSubframes.Load()
+			if n != lastSubframes && c.engine != nil {
 				c.engine.Touch(serial)
+				lastSubframes = n
 			}
 		case iq, ok := <-iqCh:
 			if !ok {


### PR DESCRIPTION
All four voice chains (P25 Phase 1, P25 Phase 2, DMR, NBFM) refreshed
the engine's LastHeardAt on a fixed 1 s ticker regardless of whether
any voice frames were decoded. With the watchdog cutoff at 30 s and
the heartbeat firing every tick the chain goroutine lived, an active
call could never time out — operators saw one talkgroup locked in the
Active Calls panel with the ELAPSED timer climbing indefinitely while
every subsequent grant logged "no voice device available for grant".

Gate the heartbeat behind a per-chain activity counter the receiver's
sink callback bumps on real frame delivery (LDU / superframe / voice
subframe / PCM batch). The ticker now only calls Engine.Touch when
the counter advanced since the previous tick, so a stalled decoder
goes quiet and the existing watchdog releases the voice SDR after
trunking.call_timeout_ms (new knob, defaults to 30 s).