### PR TITLE
sdr/widebandt2: cover a cluster of DMR T2 repeaters with one dongle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ for tagged releases.
 
 ### Added
 
+- **`role: wideband` SDR devices — one dongle, many DMR Tier II
+  repeaters.** A single SDR pinned to a centre frequency now decodes
+  every conventional DMR repeater inside its IQ bandwidth (e.g.
+  several 12.5 kHz carriers within a 2.4 MHz IQ window around
+  453 MHz), no extra hardware needed. Add a `role: wideband` entry to
+  `sdr.devices` with a `center_freq_hz` and a `channels: [...]` list
+  binding each repeater frequency to a `trunking.systems` entry; the
+  daemon's new `internal/scanner/widebandt2` engine fans the dongle's
+  IQ out to N independent T2 decoders via the new
+  `internal/dsp/tuner` package (DDC-per-channel or shared polyphase
+  channelizer, picked by channel count). See
+  [`docs/hardware.md` § Sharing one dongle across multiple repeaters](docs/hardware.md)
+  and `samples/dmr-tier2-multichannel/`. Tier III trunked-over-
+  wideband is planned as a follow-up; v1 is Tier II conventional.
 - **`gophertrunk sdr doctor` — per-dongle driver-binding report.**
   Many Windows 11 users reported their RTL-SDR dongles weren't being
   recognized despite appearing in Device Manager, mirroring the

--- a/README.md
+++ b/README.md
@@ -75,6 +75,13 @@ Silicon and Intel. Full per-OS recipes at
   dongles that drop off the bus and re-enumerate without
   restarting the daemon. See
   [docs/hardware.md](docs/hardware.md).
+- **One dongle, many repeaters** — `role: wideband` pins a single
+  SDR to a centre frequency and runs an internal channelizer so
+  one dongle decodes every DMR Tier II conventional repeater that
+  fits inside its IQ bandwidth (e.g. several 12.5 kHz carriers
+  inside a 2.4 MHz IQ window). See
+  [docs/hardware.md](docs/hardware.md) and
+  [samples/dmr-tier2-multichannel/](samples/dmr-tier2-multichannel/).
 - **DSP** — Polyphase channelizer, Kaiser / RRC / Gaussian FIRs,
   FM / C4FM / GFSK / FFSK / DQPSK / π/4-DQPSK / π/8-H-DQPSK
   demods, Mueller-Müller + Gardner clock recovery, LMS + CMA

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -19,6 +19,7 @@ import (
 	"github.com/MattCheramie/GopherTrunk/internal/scanner/ccdecoder"
 	"github.com/MattCheramie/GopherTrunk/internal/scanner/cchunt"
 	"github.com/MattCheramie/GopherTrunk/internal/scanner/conventional"
+	"github.com/MattCheramie/GopherTrunk/internal/scanner/widebandt2"
 	"github.com/MattCheramie/GopherTrunk/internal/sdr"
 	"github.com/MattCheramie/GopherTrunk/internal/sdr/baseband"
 	"github.com/MattCheramie/GopherTrunk/internal/storage"
@@ -114,6 +115,7 @@ type Daemon struct {
 	controlSerial     string
 	controlSampleRate uint32
 	convScan          *conventional.Scanner
+	widebandT2        []*widebandt2.Engine
 	metrics           *metrics.Metrics
 	httpAPI           *api.Server
 	grpcAPI           *api.GRPCServer
@@ -691,6 +693,46 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 		}
 	}
 
+	// Wide-band DMR Tier II engines — one per dongle the operator
+	// pinned to `role: wideband` in config. Each engine fans the
+	// dongle's IQ stream out to N independent T2 receivers + state
+	// machines via internal/dsp/tuner, letting a single SDR cover
+	// every repeater inside its IQ bandwidth (typically a 2.4 MHz
+	// cluster around a chosen centre frequency).
+	if d.pool != nil {
+		for _, devCfg := range cfg.SDR.Devices {
+			if devCfg.Role != "wideband" {
+				continue
+			}
+			entry := d.pool.FindBySerial(devCfg.Serial)
+			if entry == nil {
+				log.Warn("daemon: wideband: dongle with configured serial not in pool",
+					"serial", devCfg.Serial)
+				continue
+			}
+			channels := make([]widebandt2.ChannelConfig, 0, len(devCfg.Channels))
+			for _, ch := range devCfg.Channels {
+				channels = append(channels, widebandt2.ChannelConfig{
+					FrequencyHz: ch.FrequencyHz,
+					SystemName:  ch.System,
+				})
+			}
+			eng, err := widebandt2.New(widebandt2.Options{
+				Log:           log,
+				Bus:           d.bus,
+				Device:        entry.Device,
+				SampleRateHz:  cfg.SDR.SampleRate,
+				CenterFreqHz:  devCfg.CenterFreqHz,
+				TunerStrategy: devCfg.TunerStrategy,
+				Channels:      channels,
+			})
+			if err != nil {
+				return nil, fmt.Errorf("daemon: widebandt2 %q: %w", devCfg.Serial, err)
+			}
+			d.widebandT2 = append(d.widebandT2, eng)
+		}
+	}
+
 	// Storage / call log / retention — optional.
 	if cfg.Storage.Path != "" {
 		db, err := storage.Open(cfg.Storage.Path)
@@ -934,6 +976,13 @@ func (d *Daemon) Run(ctx context.Context) error {
 	if d.convScan != nil {
 		d.spawn(runCtx, "conv-scanner", false, func(ctx context.Context) error {
 			return d.convScan.Run(ctx)
+		})
+	}
+	for i, eng := range d.widebandT2 {
+		eng := eng
+		name := fmt.Sprintf("widebandt2-%d", i)
+		d.spawn(runCtx, name, false, func(ctx context.Context) error {
+			return eng.Run(ctx)
 		})
 	}
 	if d.pool != nil {

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -119,6 +119,42 @@ sdr:
       gain: "auto"
       bias_tee: false
 
+    # role: wideband pins one dongle to a centre frequency and lets a
+    # single SDR cover several conventional DMR Tier II repeaters that
+    # all live inside its IQ bandwidth (typically a 2.4 MHz cluster of
+    # carriers in the same band). The list of repeater frequencies is
+    # set per-dongle, alongside the trunking.systems entry they decode
+    # against. The daemon uses internal/dsp/tuner to extract a separate
+    # narrow-band stream per repeater - no extra hardware needed.
+    #
+    # Constraints (validated at load time):
+    #   - serial must match a discovered dongle
+    #   - every channel frequency_hz must be within
+    #     center_freq_hz ± sample_rate/2 with a 5% guard at each edge
+    #   - each referenced system must be declared in trunking.systems
+    #     below with protocol: dmr (Tier III trunked is roadmapped;
+    #     Tier II conventional ships today)
+    #
+    # tuner_strategy:
+    #   auto       (default) - ddc for ≤ 6 channels, polyphase above
+    #   ddc        - one NCO mixer + rational resampler per channel
+    #   polyphase  - shared polyphase channelizer + fine-tune DDC
+    #
+    # - serial: "00000003"
+    #   role: wideband
+    #   gain: "auto"
+    #   center_freq_hz: 453_500_000
+    #   tuner_strategy: auto
+    #   channels:
+    #     - frequency_hz: 453_125_000
+    #       system: "regional-dmr-t2"
+    #     - frequency_hz: 453_275_000
+    #       system: "regional-dmr-t2"
+    #     - frequency_hz: 453_775_000
+    #       system: "regional-dmr-t2"
+    #     - frequency_hz: 454_100_000
+    #       system: "regional-dmr-t2"
+
 trunking:
   # call_timeout_ms: inactivity window after which the engine's
   # watchdog ends a call (publishes CallEnd with EndReasonTimeout

--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -210,6 +210,81 @@ tuner type, and the supported gain values:
 The `Driver` column reads `rtlsdr`, `hackrf`, `airspy`, or
 `airspyhf` for each row.
 
+## Sharing one dongle across multiple repeaters
+
+A single SDR can monitor several conventional DMR Tier II repeaters as
+long as every carrier falls inside the dongle's IQ bandwidth. The
+dongle is pinned to a centre frequency; an internal channelizer
+extracts one narrow-band IQ stream per repeater and feeds an
+independent T2 decoder for each. No extra hardware is needed beyond
+the one dongle, and there is no per-repeater hardware re-tune.
+
+Add a `role: wideband` entry to `sdr.devices` in your config:
+
+```yaml
+sdr:
+  sample_rate: 2_400_000
+  devices:
+    - serial: "00000003"
+      role: wideband
+      center_freq_hz: 453_500_000
+      channels:
+        - frequency_hz: 453_125_000
+          system: "regional-dmr-t2"
+        - frequency_hz: 453_275_000
+          system: "regional-dmr-t2"
+        - frequency_hz: 453_775_000
+          system: "regional-dmr-t2"
+        - frequency_hz: 454_100_000
+          system: "regional-dmr-t2"
+
+trunking:
+  systems:
+    - name: "regional-dmr-t2"
+      protocol: dmr
+      talkgroup_file: "/etc/gophertrunk/talkgroups-dmr.csv"
+```
+
+The daemon programs the dongle's tuner to `center_freq_hz` once, opens
+a single IQ stream, and routes one decimated 48 kHz IQ stream per
+configured `channels[].frequency_hz` into a separate DMR T2 state
+machine. Grants and `cc.locked` events fire per repeater frequency
+just like they do for a dedicated dongle.
+
+### Picking a centre frequency and bandwidth
+
+The usable IQ band is `center_freq_hz ± sample_rate/2` with a 5 %
+guard at each edge. At `sample_rate: 2_400_000` that's ±1.08 MHz of
+usable spectrum either side of the centre. Put the centre frequency
+such that every repeater you care about fits inside that window. The
+config validator rejects out-of-band channels at load time with a
+message that names the offending entry.
+
+### Tuner strategy
+
+`tuner_strategy` chooses how the dongle's wide IQ stream is sliced:
+
+- `auto` (default) — picks `ddc` for ≤ 6 channels, `polyphase` above.
+- `ddc` — one independent NCO mixer + rational resampler per channel.
+  Linear cost in channel count; no constraint on the spacing between
+  repeaters. Best for a handful (≤ 6) of repeaters.
+- `polyphase` — one shared M-channel polyphase channelizer amortises
+  the wide-band filter across all channels; a per-channel fine-tune
+  DDC cleans up the residual. Wins on CPU once you have 7+ channels.
+
+### Limits
+
+- **DMR Tier II only in v1.** Tier III trunked support over a wideband
+  dongle is on the roadmap; today the listed channels must be
+  DMR conventional carriers.
+- **The wideband dongle is dedicated.** It can't double as a Voice
+  pool member (the daemon needs it pinned to one centre frequency).
+  If you also run a trunked system that allocates voice grants, add a
+  separate Voice dongle for that.
+- **CPU scales with channel count.** Eight DDC taps at 2.4 MS/s is a
+  few percent of one modern x86 core; the polyphase mode lands lower
+  at the same count.
+
 ## USB disconnect recovery
 
 A dongle that physically disconnects from the USB bus mid-run (flaky

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -281,6 +281,42 @@ type DeviceConfig struct {
 	// GPIO bit that goes nowhere — librtlsdr accepts the call
 	// either way.
 	BiasTee bool `yaml:"bias_tee"`
+
+	// CenterFreqHz pins a `role: wideband` dongle to the centre of
+	// the IQ band it should cover. Every Channels[].FrequencyHz must
+	// fall within ±sample_rate/2 of this value, with a 5 % guard.
+	// Required for wideband; ignored for other roles.
+	CenterFreqHz uint32 `yaml:"center_freq_hz"`
+
+	// TunerStrategy picks the DSP layout that extracts each per-
+	// repeater narrow-band stream from the dongle's wide IQ stream:
+	//   - ""        / "auto"      — auto-pick by Channel count
+	//                                (≤ 6 channels: ddc; otherwise
+	//                                polyphase)
+	//   - "ddc"                   — independent NCO mixer + rational
+	//                                resampler per channel.
+	//   - "polyphase"             — shared M-channel polyphase
+	//                                channelizer + fine-tune DDC.
+	// Ignored for non-wideband roles. See internal/dsp/tuner for the
+	// trade-offs.
+	TunerStrategy string `yaml:"tuner_strategy"`
+
+	// Channels is the list of repeater carriers a wideband dongle
+	// should monitor inside its IQ band. Each entry binds a
+	// frequency to a configured trunking.systems[].name; v1 only
+	// supports DMR Tier II conventional. Ignored for non-wideband
+	// roles.
+	Channels []DeviceChannelConfig `yaml:"channels"`
+}
+
+// DeviceChannelConfig is one repeater carrier carried by a
+// `role: wideband` dongle. FrequencyHz must lie inside the dongle's
+// IQ band (CenterFreqHz ± sample_rate/2 minus a guard); System must
+// match an existing trunking.systems[].name with a supported
+// per-channel protocol.
+type DeviceChannelConfig struct {
+	FrequencyHz uint32 `yaml:"frequency_hz"`
+	System      string `yaml:"system"`
 }
 
 type TrunkingConfig struct {
@@ -697,11 +733,20 @@ func (c Config) Validate() error {
 		return errors.New("sdr.sample_rate must be between 225 kHz and 3.2 MHz")
 	}
 	seenSerials := make(map[string]int, len(c.SDR.Devices))
+	systemProtocols := make(map[string]string, len(c.Trunking.Systems))
+	for _, s := range c.Trunking.Systems {
+		systemProtocols[s.Name] = s.Protocol
+	}
 	for i, d := range c.SDR.Devices {
 		switch d.Role {
-		case "", "control", "voice", "auto":
+		case "", "control", "voice", "auto", "wideband":
 		default:
-			return fmt.Errorf("sdr.devices[%d]: role must be control|voice|auto", i)
+			return fmt.Errorf("sdr.devices[%d]: role must be control|voice|auto|wideband", i)
+		}
+		if d.Role == "wideband" {
+			if err := validateWidebandDevice(i, d, c.SDR.SampleRate, systemProtocols); err != nil {
+				return err
+			}
 		}
 		if d.Serial == "" {
 			continue
@@ -835,6 +880,67 @@ func (c Config) Validate() error {
 		default:
 			return fmt.Errorf("baseband.replay[%d]: role must be control|voice|auto", i)
 		}
+	}
+	return nil
+}
+
+// widebandGuardFrac reserves this fraction of the dongle's IQ band at
+// each edge as a guard against alias roll-off. Channel frequencies
+// outside the resulting usable interval are rejected at config load.
+// Mirrors the default passed to internal/dsp/tuner.NewDDCBank.
+const widebandGuardFrac = 0.05
+
+// validateWidebandDevice checks a wideband SDR entry's centre-freq,
+// strategy, and channel list. sampleRateHz may be zero — Validate has
+// already accepted that as "fall back to the pool default" — in which
+// case the in-band check uses sdr.DefaultSampleRateHz so a missing
+// rate doesn't bypass the per-channel sanity check.
+func validateWidebandDevice(idx int, d DeviceConfig, sampleRateHz uint32, systemProtocols map[string]string) error {
+	if d.Serial == "" {
+		return fmt.Errorf("sdr.devices[%d]: role: wideband requires serial (the daemon binds the channel list to the device by USB serial)", idx)
+	}
+	if d.CenterFreqHz == 0 {
+		return fmt.Errorf("sdr.devices[%d]: role: wideband requires center_freq_hz", idx)
+	}
+	switch d.TunerStrategy {
+	case "", "auto", "ddc", "polyphase":
+	default:
+		return fmt.Errorf("sdr.devices[%d]: tuner_strategy must be auto|ddc|polyphase, got %q", idx, d.TunerStrategy)
+	}
+	if len(d.Channels) == 0 {
+		return fmt.Errorf("sdr.devices[%d]: role: wideband requires at least one channel", idx)
+	}
+	rate := sampleRateHz
+	if rate == 0 {
+		rate = 2_048_000 // sdr.DefaultSampleRateHz; avoid an import cycle by repeating it
+	}
+	usableHalfBand := float64(rate) * (0.5 - widebandGuardFrac)
+	seenFreq := make(map[uint32]int, len(d.Channels))
+	for j, ch := range d.Channels {
+		if ch.FrequencyHz == 0 {
+			return fmt.Errorf("sdr.devices[%d].channels[%d]: frequency_hz required", idx, j)
+		}
+		if ch.System == "" {
+			return fmt.Errorf("sdr.devices[%d].channels[%d]: system required", idx, j)
+		}
+		proto, ok := systemProtocols[ch.System]
+		if !ok {
+			return fmt.Errorf("sdr.devices[%d].channels[%d]: system %q is not declared in trunking.systems", idx, j, ch.System)
+		}
+		if proto != "dmr" {
+			return fmt.Errorf("sdr.devices[%d].channels[%d]: system %q has protocol %q; wideband currently supports dmr only", idx, j, ch.System, proto)
+		}
+		offset := float64(ch.FrequencyHz) - float64(d.CenterFreqHz)
+		if offset > usableHalfBand || offset < -usableHalfBand {
+			return fmt.Errorf(
+				"sdr.devices[%d].channels[%d]: frequency_hz %d is %.1f kHz from center; usable band is ±%.1f kHz "+
+					"(sample_rate %d Hz minus %.0f%% guard)",
+				idx, j, ch.FrequencyHz, offset/1000, usableHalfBand/1000, rate, widebandGuardFrac*100)
+		}
+		if prev, dup := seenFreq[ch.FrequencyHz]; dup {
+			return fmt.Errorf("sdr.devices[%d].channels[%d]: duplicate frequency_hz %d (also at channels[%d])", idx, j, ch.FrequencyHz, prev)
+		}
+		seenFreq[ch.FrequencyHz] = j
 	}
 	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -88,6 +88,87 @@ func TestValidate(t *testing.T) {
 		{"band_plan duplicate channel_id", Config{Trunking: TrunkingConfig{Systems: []SystemConfig{{Name: "x", Protocol: "p25", P25BandPlan: []P25BandPlanEntryConfig{{ChannelID: 3, BaseHz: 1, SpacingHz: 1}, {ChannelID: 3, BaseHz: 2, SpacingHz: 2}}}}}}, true},
 		{"band_plan zero spacing", Config{Trunking: TrunkingConfig{Systems: []SystemConfig{{Name: "x", Protocol: "p25", P25BandPlan: []P25BandPlanEntryConfig{{ChannelID: 3, BaseHz: 1, SpacingHz: 0}}}}}}, true},
 		{"band_plan zero base", Config{Trunking: TrunkingConfig{Systems: []SystemConfig{{Name: "x", Protocol: "p25", P25BandPlan: []P25BandPlanEntryConfig{{ChannelID: 3, BaseHz: 0, SpacingHz: 1}}}}}}, true},
+		// wideband role: pin a dongle to a centre frequency and list
+		// per-repeater carriers inside its IQ bandwidth. Currently
+		// supports DMR Tier II conventional only.
+		{"wideband ok", Config{
+			SDR: SDRConfig{SampleRate: 2_400_000, Devices: []DeviceConfig{{
+				Serial: "00000010", Role: "wideband", CenterFreqHz: 453_500_000,
+				Channels: []DeviceChannelConfig{
+					{FrequencyHz: 453_125_000, System: "regional-t2"},
+					{FrequencyHz: 453_775_000, System: "regional-t2"},
+				},
+			}}},
+			Trunking: TrunkingConfig{Systems: []SystemConfig{{Name: "regional-t2", Protocol: "dmr"}}},
+		}, false},
+		{"wideband missing serial", Config{
+			SDR: SDRConfig{SampleRate: 2_400_000, Devices: []DeviceConfig{{
+				Role: "wideband", CenterFreqHz: 453_500_000,
+				Channels: []DeviceChannelConfig{
+					{FrequencyHz: 453_125_000, System: "x"},
+				},
+			}}},
+			Trunking: TrunkingConfig{Systems: []SystemConfig{{Name: "x", Protocol: "dmr"}}},
+		}, true},
+		{"wideband missing center", Config{
+			SDR: SDRConfig{SampleRate: 2_400_000, Devices: []DeviceConfig{{
+				Serial: "00000010", Role: "wideband",
+				Channels: []DeviceChannelConfig{
+					{FrequencyHz: 453_125_000, System: "x"},
+				},
+			}}},
+			Trunking: TrunkingConfig{Systems: []SystemConfig{{Name: "x", Protocol: "dmr"}}},
+		}, true},
+		{"wideband missing channels", Config{
+			SDR: SDRConfig{SampleRate: 2_400_000, Devices: []DeviceConfig{{
+				Serial: "00000010", Role: "wideband", CenterFreqHz: 453_500_000,
+			}}},
+		}, true},
+		{"wideband channel out of band", Config{
+			SDR: SDRConfig{SampleRate: 2_400_000, Devices: []DeviceConfig{{
+				Serial: "00000010", Role: "wideband", CenterFreqHz: 453_500_000,
+				Channels: []DeviceChannelConfig{
+					{FrequencyHz: 460_000_000, System: "x"},
+				},
+			}}},
+			Trunking: TrunkingConfig{Systems: []SystemConfig{{Name: "x", Protocol: "dmr"}}},
+		}, true},
+		{"wideband unknown system", Config{
+			SDR: SDRConfig{SampleRate: 2_400_000, Devices: []DeviceConfig{{
+				Serial: "00000010", Role: "wideband", CenterFreqHz: 453_500_000,
+				Channels: []DeviceChannelConfig{
+					{FrequencyHz: 453_125_000, System: "nope"},
+				},
+			}}},
+		}, true},
+		{"wideband non-dmr protocol", Config{
+			SDR: SDRConfig{SampleRate: 2_400_000, Devices: []DeviceConfig{{
+				Serial: "00000010", Role: "wideband", CenterFreqHz: 453_500_000,
+				Channels: []DeviceChannelConfig{
+					{FrequencyHz: 453_125_000, System: "p25-sys"},
+				},
+			}}},
+			Trunking: TrunkingConfig{Systems: []SystemConfig{{Name: "p25-sys", Protocol: "p25"}}},
+		}, true},
+		{"wideband duplicate frequency", Config{
+			SDR: SDRConfig{SampleRate: 2_400_000, Devices: []DeviceConfig{{
+				Serial: "00000010", Role: "wideband", CenterFreqHz: 453_500_000,
+				Channels: []DeviceChannelConfig{
+					{FrequencyHz: 453_125_000, System: "x"},
+					{FrequencyHz: 453_125_000, System: "x"},
+				},
+			}}},
+			Trunking: TrunkingConfig{Systems: []SystemConfig{{Name: "x", Protocol: "dmr"}}},
+		}, true},
+		{"wideband bad strategy", Config{
+			SDR: SDRConfig{SampleRate: 2_400_000, Devices: []DeviceConfig{{
+				Serial: "00000010", Role: "wideband", CenterFreqHz: 453_500_000, TunerStrategy: "magic",
+				Channels: []DeviceChannelConfig{
+					{FrequencyHz: 453_125_000, System: "x"},
+				},
+			}}},
+			Trunking: TrunkingConfig{Systems: []SystemConfig{{Name: "x", Protocol: "dmr"}}},
+		}, true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/scanner/widebandt2/engine.go
+++ b/internal/scanner/widebandt2/engine.go
@@ -1,0 +1,272 @@
+// Package widebandt2 monitors several DMR Tier II conventional
+// repeaters with a single SDR dongle. The dongle is pinned to a
+// configured centre frequency; an internal/dsp/tuner.Bank extracts
+// one narrow-band IQ stream per repeater carrier inside the dongle's
+// IQ band; each stream feeds a DMR receiver and a tier2 state
+// machine that publishes cc.locked / grant events on the bus.
+//
+// One Engine owns one wideband SDR. Multiple wideband dongles each
+// get their own Engine; they run independently and share only the
+// events.Bus and the metrics surface.
+package widebandt2
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/tuner"
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/dmr"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/dmr/receiver"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/dmr/tier2"
+	"github.com/MattCheramie/GopherTrunk/internal/sdr"
+)
+
+// narrowbandRateHz is the per-tap sample rate the bank decimates to.
+// 48 kHz matches the rate the DMR receiver's matched filter +
+// Mueller-Müller clock loop are sized for (≈10 samples/symbol at
+// 4800 baud), the same rate the existing single-channel ccdecoder
+// down-converter targets.
+const narrowbandRateHz = 48_000.0
+
+// guardFrac is the fraction of the IQ band the tuner reserves at
+// each edge as a guard against alias roll-off. Mirrors the value
+// the config validator uses to reject out-of-band channels.
+const guardFrac = 0.05
+
+// strategyAutoThreshold is the channel-count cutoff for the "auto"
+// tuner strategy: at or below it, DDCBank wins on simplicity;
+// above it, ChannelizerBank's shared wide-band filter pays off.
+const strategyAutoThreshold = 6
+
+// channelizerBins is the bin count NewChannelizerBank uses when
+// strategy=="polyphase" or auto picks it. Power of two, large
+// enough that 12.5 kHz DMR repeater spacing maps to distinct bins
+// inside a 2.4 MS/s IQ band: 2_400_000 / 16 = 150 kHz per bin.
+const channelizerBins = 16
+
+// channelizerTapsPerBranch and channelizerKaiserBeta match the
+// channelizer package's own test defaults — wideband-clean
+// passband, ~70 dB peak sidelobe.
+const channelizerTapsPerBranch = 16
+const channelizerKaiserBeta = 9.0
+
+// ChannelConfig binds one repeater frequency to the trunking system
+// it belongs to. The Engine creates one tier2.ConventionalChannel
+// per entry.
+type ChannelConfig struct {
+	FrequencyHz uint32
+	SystemName  string
+}
+
+// Options bundles the inputs Engine needs at construction time.
+type Options struct {
+	Log *slog.Logger
+	Bus *events.Bus
+
+	// Device is the wideband SDR. It is set to CenterFreqHz, then
+	// streamed continuously until Run's context cancels.
+	Device sdr.Device
+	// SampleRateHz is the dongle's IQ sample rate.
+	SampleRateHz uint32
+	// CenterFreqHz is the wide-band centre frequency.
+	CenterFreqHz uint32
+
+	// TunerStrategy picks the Bank implementation. "" / "auto"
+	// auto-selects by channel count; "ddc" forces DDCBank;
+	// "polyphase" forces ChannelizerBank.
+	TunerStrategy string
+
+	// Channels is the list of per-repeater carriers to monitor.
+	// All FrequencyHz values must fall inside the dongle's IQ
+	// band (CenterFreqHz ± SampleRateHz/2 minus guardFrac).
+	Channels []ChannelConfig
+
+	// Now overrides the wall clock the per-channel state machines
+	// use for Grant.At timestamps. nil ⇒ time.Now.
+	Now func() time.Time
+}
+
+// Engine owns the per-dongle IQ pump goroutine and the per-channel
+// receiver + state-machine fan-out.
+type Engine struct {
+	log         *slog.Logger
+	bus         *events.Bus
+	device      sdr.Device
+	centerHz    uint32
+	sampleRate  uint32
+	bank        tuner.Bank
+	channels    []*engineChannel
+	strategyTag string
+}
+
+type engineChannel struct {
+	freqHz   uint32
+	sysName  string
+	cc       *tier2.ConventionalChannel
+	receiver *receiver.Receiver
+}
+
+// New constructs an Engine. The device is not opened or streamed
+// here; that happens in Run. Returns an error if construction
+// inputs are invalid (offset out of band, colliding channelizer
+// bins, etc.).
+func New(opts Options) (*Engine, error) {
+	if opts.Device == nil {
+		return nil, errors.New("widebandt2: Device is required")
+	}
+	if opts.Bus == nil {
+		return nil, errors.New("widebandt2: Bus is required")
+	}
+	if opts.SampleRateHz == 0 {
+		return nil, errors.New("widebandt2: SampleRateHz is required")
+	}
+	if opts.CenterFreqHz == 0 {
+		return nil, errors.New("widebandt2: CenterFreqHz is required")
+	}
+	if len(opts.Channels) == 0 {
+		return nil, errors.New("widebandt2: at least one channel is required")
+	}
+	log := opts.Log
+	if log == nil {
+		log = slog.Default()
+	}
+
+	strategy, tag := pickStrategy(opts.TunerStrategy, len(opts.Channels))
+	var bank tuner.Bank
+	switch strategy {
+	case "ddc":
+		bank = tuner.NewDDCBank(float64(opts.SampleRateHz), narrowbandRateHz, guardFrac)
+	case "polyphase":
+		bank = tuner.NewChannelizerBank(float64(opts.SampleRateHz), narrowbandRateHz, guardFrac,
+			channelizerBins, channelizerTapsPerBranch, channelizerKaiserBeta)
+	default:
+		return nil, fmt.Errorf("widebandt2: unknown tuner strategy %q", strategy)
+	}
+
+	engine := &Engine{
+		log:         log,
+		bus:         opts.Bus,
+		device:      opts.Device,
+		centerHz:    opts.CenterFreqHz,
+		sampleRate:  opts.SampleRateHz,
+		bank:        bank,
+		strategyTag: tag,
+	}
+
+	for _, ch := range opts.Channels {
+		offset := float64(ch.FrequencyHz) - float64(opts.CenterFreqHz)
+		cc := tier2.New(tier2.Options{
+			Bus:         opts.Bus,
+			Log:         log.With("system", ch.SystemName, "freq_hz", ch.FrequencyHz),
+			SystemName:  ch.SystemName,
+			FrequencyHz: ch.FrequencyHz,
+			Now:         opts.Now,
+		})
+		// dibitSink hands the receiver's dibits to the Tier II
+		// process adapter. The adapter buffers across calls,
+		// runs sync detection, and emits cc.locked / grant
+		// events on the bus.
+		dibitSink := func(cc *tier2.ConventionalChannel) dmr.DibitSink {
+			return func(dibits []uint8, baseIdx int) {
+				cc.Process(dibits, baseIdx)
+			}
+		}(cc)
+		rcv := receiver.New(receiver.Options{
+			SampleRateHz: narrowbandRateHz,
+			DibitSink:    dibitSink,
+			DeviationHz:  receiver.SymbolRate * 0.405, // ~1944 Hz per ETSI TS 102 361-1 §6.3
+		})
+		ec := &engineChannel{
+			freqHz:   ch.FrequencyHz,
+			sysName:  ch.SystemName,
+			cc:       cc,
+			receiver: rcv,
+		}
+		sink := func(ec *engineChannel) tuner.SinkFunc {
+			return func(out []complex64) {
+				if len(out) == 0 {
+					return
+				}
+				ec.receiver.Process(out)
+			}
+		}(ec)
+		if err := bank.AddTap(offset, sink); err != nil {
+			return nil, fmt.Errorf("widebandt2: AddTap freq=%d offset=%.0f Hz: %w",
+				ch.FrequencyHz, offset, err)
+		}
+		engine.channels = append(engine.channels, ec)
+	}
+	return engine, nil
+}
+
+// Channels returns the per-channel frequencies the engine is
+// monitoring. Used by callers (the daemon, tests) for logging and
+// status snapshots.
+func (e *Engine) Channels() []uint32 {
+	out := make([]uint32, 0, len(e.channels))
+	for _, c := range e.channels {
+		out = append(out, c.freqHz)
+	}
+	return out
+}
+
+// Strategy reports which tuner strategy the engine resolved at
+// construction ("ddc" or "polyphase"). Used for diagnostics /
+// startup logging.
+func (e *Engine) Strategy() string { return e.strategyTag }
+
+// Run programs the dongle's centre frequency, opens its IQ stream,
+// and pumps chunks through the tuner bank until ctx cancels. The
+// per-tap fan-out and per-channel receivers / state machines run
+// inline on this goroutine — they are not concurrent with each
+// other, so chunk ordering is preserved.
+func (e *Engine) Run(ctx context.Context) error {
+	if err := e.device.SetCenterFreq(e.centerHz); err != nil {
+		return fmt.Errorf("widebandt2: SetCenterFreq %d Hz: %w", e.centerHz, err)
+	}
+	e.log.Info("widebandt2: starting",
+		"center_freq_hz", e.centerHz,
+		"sample_rate_hz", e.sampleRate,
+		"channels", len(e.channels),
+		"strategy", e.strategyTag,
+	)
+	stream, err := e.device.StreamIQ(ctx)
+	if err != nil {
+		return fmt.Errorf("widebandt2: StreamIQ: %w", err)
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case chunk, ok := <-stream:
+			if !ok {
+				return nil
+			}
+			e.bank.Process(chunk)
+		}
+	}
+}
+
+// pickStrategy resolves the user-facing strategy choice into the
+// internal bank kind. "" / "auto" auto-selects: small channel counts
+// favour DDCBank (linear, no alignment constraint); larger counts
+// favour the shared polyphase channelizer.
+func pickStrategy(requested string, channelCount int) (kind, tag string) {
+	switch requested {
+	case "ddc":
+		return "ddc", "ddc"
+	case "polyphase":
+		return "polyphase", "polyphase"
+	case "", "auto":
+		if channelCount <= strategyAutoThreshold {
+			return "ddc", "auto(ddc)"
+		}
+		return "polyphase", "auto(polyphase)"
+	default:
+		return requested, requested
+	}
+}

--- a/internal/scanner/widebandt2/engine_test.go
+++ b/internal/scanner/widebandt2/engine_test.go
@@ -1,0 +1,235 @@
+package widebandt2
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/sdr"
+)
+
+// mockDevice is a synchronous sdr.Device that emits a caller-supplied
+// sequence of IQ chunks, then closes the stream. The test goroutine
+// blocks on producing each chunk so the engine's loop is driven
+// deterministically.
+type mockDevice struct {
+	chunks       [][]complex64
+	chunkCh      chan []complex64
+	streamErr    error
+	centerFreqHz atomic.Uint32
+	sampleRateHz atomic.Uint32
+	startOnce    sync.Once
+}
+
+func newMockDevice(chunks [][]complex64) *mockDevice {
+	return &mockDevice{chunks: chunks, chunkCh: make(chan []complex64, len(chunks)+1)}
+}
+
+func (m *mockDevice) Info() sdr.Info                { return sdr.Info{Driver: "mock", Serial: "MOCK1"} }
+func (m *mockDevice) SetCenterFreq(hz uint32) error { m.centerFreqHz.Store(hz); return nil }
+func (m *mockDevice) SetSampleRate(hz uint32) error { m.sampleRateHz.Store(hz); return nil }
+func (m *mockDevice) SetGain(int) error             { return nil }
+func (m *mockDevice) SetPPM(int) error              { return nil }
+func (m *mockDevice) SetBiasTee(bool) error         { return nil }
+func (m *mockDevice) Close() error                  { return nil }
+
+func (m *mockDevice) StreamIQ(ctx context.Context) (<-chan []complex64, error) {
+	if m.streamErr != nil {
+		return nil, m.streamErr
+	}
+	m.startOnce.Do(func() {
+		go func() {
+			defer close(m.chunkCh)
+			for _, c := range m.chunks {
+				select {
+				case <-ctx.Done():
+					return
+				case m.chunkCh <- c:
+				}
+			}
+		}()
+	})
+	return m.chunkCh, nil
+}
+
+func TestEngineNewRejectsMissingDevice(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	if _, err := New(Options{Bus: bus, SampleRateHz: 2_400_000, CenterFreqHz: 453_500_000,
+		Channels: []ChannelConfig{{FrequencyHz: 453_125_000, SystemName: "x"}}}); err == nil {
+		t.Errorf("expected error for missing Device")
+	}
+}
+
+func TestEngineNewRejectsMissingBus(t *testing.T) {
+	dev := newMockDevice(nil)
+	if _, err := New(Options{Device: dev, SampleRateHz: 2_400_000, CenterFreqHz: 453_500_000,
+		Channels: []ChannelConfig{{FrequencyHz: 453_125_000, SystemName: "x"}}}); err == nil {
+		t.Errorf("expected error for missing Bus")
+	}
+}
+
+func TestEngineNewRejectsEmptyChannels(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	dev := newMockDevice(nil)
+	if _, err := New(Options{Device: dev, Bus: bus, SampleRateHz: 2_400_000, CenterFreqHz: 453_500_000}); err == nil {
+		t.Errorf("expected error for empty channels")
+	}
+}
+
+func TestEngineNewRejectsOutOfBandChannel(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	dev := newMockDevice(nil)
+	_, err := New(Options{
+		Device: dev, Bus: bus, SampleRateHz: 2_400_000, CenterFreqHz: 453_500_000,
+		Channels: []ChannelConfig{
+			{FrequencyHz: 470_000_000, SystemName: "x"}, // > 16 MHz away
+		},
+	})
+	if err == nil {
+		t.Errorf("expected error for out-of-band channel")
+	}
+}
+
+func TestEngineStrategyAuto(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+
+	t.Run("small fleet picks ddc", func(t *testing.T) {
+		dev := newMockDevice(nil)
+		e, err := New(Options{
+			Device: dev, Bus: bus, SampleRateHz: 2_400_000, CenterFreqHz: 453_500_000,
+			Channels: []ChannelConfig{
+				{FrequencyHz: 453_125_000, SystemName: "x"},
+				{FrequencyHz: 453_775_000, SystemName: "x"},
+			},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if e.Strategy() != "auto(ddc)" {
+			t.Errorf("strategy = %q, want auto(ddc)", e.Strategy())
+		}
+	})
+
+	t.Run("large fleet picks polyphase", func(t *testing.T) {
+		dev := newMockDevice(nil)
+		// 7 channels exceeds strategyAutoThreshold, so auto picks
+		// the channelizer. Frequencies are 200 kHz apart so they
+		// occupy distinct bins (150 kHz bin width at M=16,
+		// 2.4 MS/s).
+		channels := []ChannelConfig{}
+		for i := -3; i <= 3; i++ {
+			channels = append(channels, ChannelConfig{
+				FrequencyHz: uint32(int64(453_500_000) + int64(i)*200_000),
+				SystemName:  "x",
+			})
+		}
+		e, err := New(Options{
+			Device: dev, Bus: bus, SampleRateHz: 2_400_000, CenterFreqHz: 453_500_000,
+			Channels: channels,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if e.Strategy() != "auto(polyphase)" {
+			t.Errorf("strategy = %q, want auto(polyphase)", e.Strategy())
+		}
+	})
+}
+
+func TestEngineStrategyExplicit(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	dev := newMockDevice(nil)
+	cases := []struct {
+		req, want string
+	}{
+		{"ddc", "ddc"},
+		{"polyphase", "polyphase"},
+	}
+	for _, tc := range cases {
+		e, err := New(Options{
+			Device: dev, Bus: bus, SampleRateHz: 2_400_000, CenterFreqHz: 453_500_000,
+			TunerStrategy: tc.req,
+			Channels: []ChannelConfig{
+				{FrequencyHz: 453_125_000, SystemName: "x"},
+				{FrequencyHz: 453_775_000, SystemName: "x"},
+			},
+		})
+		if err != nil {
+			t.Fatalf("strategy %q: %v", tc.req, err)
+		}
+		if e.Strategy() != tc.want {
+			t.Errorf("strategy %q: got %q, want %q", tc.req, e.Strategy(), tc.want)
+		}
+	}
+}
+
+func TestEngineRunSetsCenterFreqAndDrainsStream(t *testing.T) {
+	bus := events.NewBus(64)
+	defer bus.Close()
+
+	// 4 silence chunks of 4800 wide-band samples each. The engine
+	// must consume all of them then exit cleanly when the stream
+	// closes.
+	const chunkLen = 4800
+	chunks := make([][]complex64, 4)
+	for i := range chunks {
+		chunks[i] = make([]complex64, chunkLen)
+	}
+	dev := newMockDevice(chunks)
+
+	e, err := New(Options{
+		Log:          slog.Default(),
+		Device:       dev,
+		Bus:          bus,
+		SampleRateHz: 2_400_000,
+		CenterFreqHz: 453_500_000,
+		Channels: []ChannelConfig{
+			{FrequencyHz: 453_125_000, SystemName: "regional-t2"},
+			{FrequencyHz: 453_775_000, SystemName: "regional-t2"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := e.Run(ctx); err != nil {
+		t.Errorf("Run: %v", err)
+	}
+	if got := dev.centerFreqHz.Load(); got != 453_500_000 {
+		t.Errorf("device centre frequency = %d, want 453_500_000", got)
+	}
+	if got := len(e.Channels()); got != 2 {
+		t.Errorf("Channels() len = %d, want 2", got)
+	}
+}
+
+func TestEngineRunPropagatesStreamError(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	dev := newMockDevice(nil)
+	dev.streamErr = errors.New("device dead")
+	e, err := New(Options{
+		Device: dev, Bus: bus, SampleRateHz: 2_400_000, CenterFreqHz: 453_500_000,
+		Channels: []ChannelConfig{{FrequencyHz: 453_125_000, SystemName: "x"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	if err := e.Run(ctx); err == nil {
+		t.Errorf("expected error from StreamIQ propagated, got nil")
+	}
+}

--- a/internal/sdr/device.go
+++ b/internal/sdr/device.go
@@ -11,6 +11,13 @@ const (
 	RoleAuto Role = iota
 	RoleControl
 	RoleVoice
+	// RoleWideband pins a dongle to a single configured centre
+	// frequency. Several decoders share the IQ stream — each one is
+	// tapped to a different repeater frequency inside the dongle's
+	// IQ bandwidth via the internal/dsp/tuner package. Used to cover
+	// a cluster of co-band conventional repeaters (e.g. several DMR
+	// Tier II carriers around 453 MHz) with a single SDR.
+	RoleWideband
 )
 
 func (r Role) String() string {
@@ -19,6 +26,8 @@ func (r Role) String() string {
 		return "control"
 	case RoleVoice:
 		return "voice"
+	case RoleWideband:
+		return "wideband"
 	default:
 		return "auto"
 	}
@@ -30,6 +39,8 @@ func ParseRole(s string) Role {
 		return RoleControl
 	case "voice":
 		return RoleVoice
+	case "wideband":
+		return RoleWideband
 	default:
 		return RoleAuto
 	}

--- a/samples/dmr-tier2-multichannel/README.md
+++ b/samples/dmr-tier2-multichannel/README.md
@@ -1,0 +1,63 @@
+# One dongle, several DMR Tier II repeaters
+
+This sample config monitors four conventional DMR Tier II repeaters
+that all live inside a single 2.4 MHz IQ window around 453.5 MHz with
+one RTL-SDR. No extra hardware, no hardware re-tune per call - the
+daemon's internal channelizer (`internal/dsp/tuner`) extracts a
+separate 48 kHz baseband stream per repeater and feeds an independent
+T2 decoder for each.
+
+## When to use this layout
+
+- You have several DMR Tier II repeaters whose carriers cluster
+  inside the IQ bandwidth of one dongle (typically ≤ 2.4 MHz of
+  total spread).
+- You only own one SDR or want to free your other dongles for
+  other systems.
+- All the repeaters belong to the same conventional system - i.e.
+  you'd happily merge their call streams into one talkgroup CSV.
+
+## What it doesn't do
+
+- Trunked DMR (Tier III) grant chasing is not supported by the
+  wideband role in v1. Add a separate `role: voice` dongle for
+  trunked systems.
+- Other protocols (P25, NXDN, TETRA, etc.) inside the wideband
+  IQ are not decoded. Wideband is currently DMR Tier II only.
+- The wideband dongle is dedicated to this layout - it can't
+  double as a voice-pool member or a control-channel hunter.
+
+## Tuning
+
+Edit `config.yaml`:
+
+1. **`serial`** - run `gophertrunk sdr list` and copy your dongle's
+   serial. The daemon binds the channel list to the device by serial.
+2. **`center_freq_hz`** - the centre frequency the dongle sits on.
+   Pick a value that puts every `channels[].frequency_hz` inside
+   `center ± sample_rate/2`, with a 5 % guard at each edge (so
+   ±1.08 MHz at the default 2.4 MS/s rate). The config validator
+   rejects out-of-band channels at startup.
+3. **`channels`** - one entry per repeater you want to decode. Each
+   one references the system you declared in `trunking.systems`.
+4. **`tuner_strategy`** (optional) - `auto` (default) picks DDC for
+   ≤ 6 channels and a polyphase channelizer above that. Force `ddc`
+   or `polyphase` to override.
+
+## Running
+
+```sh
+go run ./cmd/gophertrunk run -config samples/dmr-tier2-multichannel/config.yaml
+```
+
+The startup log line `widebandt2: starting` confirms the engine came
+up; `center_freq_hz`, `channels`, and `strategy` fields show what was
+wired. `cc.locked` and `grant` events fire per repeater frequency as
+calls arrive.
+
+## Limits and follow-ups
+
+- DMR Tier III via wideband is planned (the engine and the DSP can
+  do it - the voice-pool adapter is the remaining piece).
+- Multi-protocol wideband (P25 + DMR + NXDN sharing one dongle) is
+  not on the v1 roadmap.

--- a/samples/dmr-tier2-multichannel/config.yaml
+++ b/samples/dmr-tier2-multichannel/config.yaml
@@ -1,0 +1,47 @@
+# Cover a cluster of DMR Tier II repeaters with one RTL-SDR.
+#
+# This config monitors four 12.5 kHz conventional DMR repeaters whose
+# carriers all sit inside a single 2.4 MHz IQ window centred at
+# 453.5 MHz. The daemon pins one dongle to that centre, runs an
+# internal channelizer to split the wide stream into four independent
+# narrow-band streams, and decodes each one with its own DMR Tier II
+# state machine. Per-repeater Voice LC Header and Terminator-with-LC
+# bursts produce grant events on the bus just like a dedicated dongle
+# would.
+#
+# Set the dongle's USB serial below to match what `gophertrunk sdr
+# list` reports.
+
+api:
+  http_addr: "127.0.0.1:8080"
+  auth:
+    mode: auto
+
+sdr:
+  sample_rate: 2_400_000
+  devices:
+    - serial: "REPLACE_WITH_SERIAL"
+      role: wideband
+      center_freq_hz: 453_500_000
+      tuner_strategy: auto        # auto | ddc | polyphase
+      gain: "auto"
+      channels:
+        - frequency_hz: 453_125_000
+          system: "regional-dmr-t2"
+        - frequency_hz: 453_275_000
+          system: "regional-dmr-t2"
+        - frequency_hz: 453_775_000
+          system: "regional-dmr-t2"
+        - frequency_hz: 454_100_000
+          system: "regional-dmr-t2"
+
+trunking:
+  systems:
+    - name: "regional-dmr-t2"
+      protocol: dmr
+      # DMR Tier II is conventional - no control channel. The per-
+      # repeater carrier list lives under sdr.devices[].channels above.
+      talkgroup_file: "talkgroups-dmr.csv"
+
+recordings:
+  dir: "recordings/"


### PR DESCRIPTION
## Summary

Stage 2 of 3 toward **"one dongle, many DMR T2 repeaters within a single 2.4 MHz IQ"** — the Discord user's stated need: monitor a cluster of conventional DMR T2 repeaters around 453 MHz with a single RTL-SDR instead of one dongle per frequency. After this PR merges, that's possible with a few lines of YAML.

Builds on the `internal/dsp/tuner` package that shipped in Stage 1 (#360, merged).

## What's new

- **`role: wideband` SDR device.** Pin a dongle to a centre frequency and list the repeater carriers it should monitor. The daemon's new `internal/scanner/widebandt2` engine runs an internal channelizer that splits the wide IQ stream into one narrow-band 48 kHz stream per repeater, feeds each into its own DMR Tier II state machine, and publishes `cc.locked` / `grant` events per repeater frequency.
- **Per-dongle tuner strategy.** `auto` (default) picks `ddc` for ≤ 6 channels (one independent NCO mixer + rational resampler per tap) and `polyphase` above that (shared M-channel polyphase channelizer + per-tap fine-tune DDC). Operators can force either explicitly.
- **Config schema additions.** `sdr.devices[].center_freq_hz`, `channels[].{frequency_hz, system}`, `tuner_strategy`. Validator enforces: serial required (channel list binds to the physical device), in-band-with-guard channel frequencies, no duplicate frequencies, referenced systems must exist with `protocol: dmr`.
- **Sample config + docs.** `samples/dmr-tier2-multichannel/` is a runnable example; `docs/hardware.md` adds a "Sharing one dongle across multiple repeaters" section with the math on usable IQ band, centre-frequency selection, and the strategy trade-off; `README.md` feature line; `CHANGELOG.md` Unreleased entry.

## YAML example

```yaml
sdr:
  sample_rate: 2_400_000
  devices:
    - serial: "00000003"
      role: wideband
      center_freq_hz: 453_500_000
      tuner_strategy: auto
      channels:
        - { frequency_hz: 453_125_000, system: "regional-dmr-t2" }
        - { frequency_hz: 453_275_000, system: "regional-dmr-t2" }
        - { frequency_hz: 453_775_000, system: "regional-dmr-t2" }
        - { frequency_hz: 454_100_000, system: "regional-dmr-t2" }

trunking:
  systems:
    - name: "regional-dmr-t2"
      protocol: dmr
      talkgroup_file: "talkgroups-dmr.csv"
```

## v1 limits (intentional, documented)

- DMR **Tier II conventional** only. Tier III trunked over a wideband dongle is Stage 3 (the engine + DSP can do it; the voice-pool adapter that allocates a tuner slot instead of retuning a physical dongle is the remaining piece).
- Wideband dongle is dedicated to this layout — it can't double as a voice-pool member.
- Multi-protocol wideband (P25 + DMR sharing one dongle) is out of scope.

## Files

- `internal/sdr/device.go` — `RoleWideband` enum + parsing.
- `internal/config/config.go` + tests — `DeviceConfig` / `DeviceChannelConfig` extensions + `validateWidebandDevice` with 9 new test cases covering ok / missing-serial / missing-center / missing-channels / out-of-band / unknown-system / non-dmr-protocol / duplicate-frequency / bad-strategy.
- `internal/scanner/widebandt2/engine.go` — orchestrator. `New(Options)` constructs the bank, per-channel receivers, and T2 state machines; `Run(ctx)` pumps IQ from the dongle's `StreamIQ()` through `Bank.Process` until cancelled. Strategy auto-selection lives here.
- `internal/scanner/widebandt2/engine_test.go` — 9 tests covering construction validation (missing device / bus / channels / out-of-band), strategy resolution (auto small ⇒ ddc, auto large ⇒ polyphase, explicit ddc/polyphase), `Run()` drains the stream and sets centre frequency, `StreamIQ` errors propagate.
- `cmd/gophertrunk/daemon.go` — for each `role: wideband` device in cfg.SDR.Devices, look up the pool entry by serial, build a `widebandt2.Engine`, spawn it in `Run()`.
- `config.example.yaml`, `docs/hardware.md`, `README.md`, `CHANGELOG.md`, `samples/dmr-tier2-multichannel/{config.yaml,README.md}` — docs + sample.

## Test plan

- [x] `go test ./internal/config/ ./internal/sdr/ ./internal/scanner/widebandt2/ ./internal/dsp/tuner/` — all green
- [x] `go test ./...` — full suite green, no regressions
- [x] `go vet ./...` — clean
- [x] `go build ./...` — clean
- [x] `gofmt -l` — clean
- [x] Validator unit tests for every documented rejection path
- [x] Engine integration test with a mock `sdr.Device` confirms `Run()` sets centre freq, drains the IQ stream, and exits cleanly when the stream closes

## On-air verification path (for the Discord user)

1. Build, copy `samples/dmr-tier2-multichannel/config.yaml`, replace `serial` with `gophertrunk sdr list` output, adjust `center_freq_hz` and `channels` to their cluster.
2. `gophertrunk run -config <path>` — startup log shows `widebandt2: starting center_freq_hz=… channels=… strategy=…`.
3. As repeaters transmit, watch the structured log or `/api/v1/calls/active` — `cc.locked` and `grant` events tag with the per-repeater `frequency_hz`.

## Next

**Stage 3:** `VirtualPool` adapter so DMR Tier III trunked systems whose CC + traffic channels all sit within one 2.4 MHz IQ can run on a single dongle too (allocates a tuner slot per grant instead of retuning a physical dongle).

https://claude.ai/code/session_01WAx7Gs3aMWgJAS8NRp96oU

---
_Generated by [Claude Code](https://claude.ai/code/session_01WAx7Gs3aMWgJAS8NRp96oU)_