### PR TITLE
widebandt2: decode DMR Tier III control channel on the wideband dongle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,19 +10,25 @@ for tagged releases.
 ### Added
 
 - **`role: wideband` SDR devices — one dongle, many DMR Tier II
-  repeaters.** A single SDR pinned to a centre frequency now decodes
-  every conventional DMR repeater inside its IQ bandwidth (e.g.
+  repeaters and DMR Tier III control channels.** A single SDR pinned
+  to a centre frequency now decodes every conventional DMR repeater
+  AND a DMR Tier III control channel inside its IQ bandwidth (e.g.
   several 12.5 kHz carriers within a 2.4 MHz IQ window around
   453 MHz), no extra hardware needed. Add a `role: wideband` entry to
   `sdr.devices` with a `center_freq_hz` and a `channels: [...]` list
-  binding each repeater frequency to a `trunking.systems` entry; the
-  daemon's new `internal/scanner/widebandt2` engine fans the dongle's
-  IQ out to N independent T2 decoders via the new
-  `internal/dsp/tuner` package (DDC-per-channel or shared polyphase
-  channelizer, picked by channel count). See
+  binding each frequency to a `trunking.systems` entry; per channel,
+  systems with `protocol: dmr-tier2` get a Tier II `ConventionalChannel`
+  state machine, systems with `protocol: dmr` get a Tier III
+  `ControlChannel` (channel frequency must match one of the system's
+  `control_channels`). T2 and T3 can mix on the same dongle. The
+  daemon's `internal/scanner/widebandt2` engine fans the dongle's IQ
+  out via the `internal/dsp/tuner` package (DDC-per-channel or shared
+  polyphase channelizer, picked by channel count). See
   [`docs/hardware.md` § Sharing one dongle across multiple repeaters](docs/hardware.md)
-  and `samples/dmr-tier2-multichannel/`. Tier III trunked-over-
-  wideband is planned as a follow-up; v1 is Tier II conventional.
+  and `samples/dmr-tier2-multichannel/`. Tier III voice grants still
+  route through the existing physical voice pool (a `role: voice`
+  SDR follows the call); decoding T3 voice directly on the wideband
+  dongle via a virtual voice pool is the next planned step.
 - **`gophertrunk sdr doctor` — per-dongle driver-binding report.**
   Many Windows 11 users reported their RTL-SDR dongles weren't being
   recognized despite appearing in Device Manager, mirroring the

--- a/README.md
+++ b/README.md
@@ -77,9 +77,10 @@ Silicon and Intel. Full per-OS recipes at
   [docs/hardware.md](docs/hardware.md).
 - **One dongle, many repeaters** — `role: wideband` pins a single
   SDR to a centre frequency and runs an internal channelizer so
-  one dongle decodes every DMR Tier II conventional repeater that
-  fits inside its IQ bandwidth (e.g. several 12.5 kHz carriers
-  inside a 2.4 MHz IQ window). See
+  one dongle decodes every DMR Tier II conventional repeater AND
+  a DMR Tier III control channel that fit inside its IQ bandwidth
+  (e.g. several 12.5 kHz carriers inside a 2.4 MHz IQ window).
+  Mix T2 and T3 channels on the same dongle. See
   [docs/hardware.md](docs/hardware.md) and
   [samples/dmr-tier2-multichannel/](samples/dmr-tier2-multichannel/).
 - **DSP** — Polyphase channelizer, Kaiser / RRC / Gaussian FIRs,

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -725,6 +725,7 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 				CenterFreqHz:  devCfg.CenterFreqHz,
 				TunerStrategy: devCfg.TunerStrategy,
 				Channels:      channels,
+				Systems:       d.systems,
 			})
 			if err != nil {
 				return nil, fmt.Errorf("daemon: widebandt2 %q: %w", devCfg.Serial, err)

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -120,20 +120,29 @@ sdr:
       bias_tee: false
 
     # role: wideband pins one dongle to a centre frequency and lets a
-    # single SDR cover several conventional DMR Tier II repeaters that
-    # all live inside its IQ bandwidth (typically a 2.4 MHz cluster of
-    # carriers in the same band). The list of repeater frequencies is
-    # set per-dongle, alongside the trunking.systems entry they decode
-    # against. The daemon uses internal/dsp/tuner to extract a separate
-    # narrow-band stream per repeater - no extra hardware needed.
+    # single SDR cover several DMR repeaters that all live inside its
+    # IQ bandwidth (typically a 2.4 MHz cluster of carriers in the
+    # same band). The list of repeater frequencies is set per-dongle,
+    # alongside the trunking.systems entry they decode against. The
+    # daemon uses internal/dsp/tuner to extract a separate narrow-
+    # band stream per repeater - no extra hardware needed.
+    #
+    # Each channel references a trunking.systems entry whose protocol
+    # determines the state machine:
+    #   protocol: dmr-tier2  → Tier II conventional carrier
+    #   protocol: dmr        → Tier III trunked control channel
+    #                          (frequency_hz must be in the system's
+    #                          control_channels list)
+    # T2 and T3 channels can mix on the same dongle. T3 voice grants
+    # still route to the daemon's physical voice pool; the wideband
+    # dongle decodes the CC, not the voice traffic.
     #
     # Constraints (validated at load time):
     #   - serial must match a discovered dongle
     #   - every channel frequency_hz must be within
     #     center_freq_hz ± sample_rate/2 with a 5% guard at each edge
     #   - each referenced system must be declared in trunking.systems
-    #     below with protocol: dmr (Tier III trunked is roadmapped;
-    #     Tier II conventional ships today)
+    #     below with protocol: dmr-tier2 or protocol: dmr
     #
     # tuner_strategy:
     #   auto       (default) - ddc for ≤ 6 channels, polyphase above
@@ -154,6 +163,14 @@ sdr:
     #       system: "regional-dmr-t2"
     #     - frequency_hz: 454_100_000
     #       system: "regional-dmr-t2"
+    #
+    # And a T3 CC tap on the same (or another) wideband dongle:
+    # - serial: "00000004"
+    #   role: wideband
+    #   center_freq_hz: 851_500_000
+    #   channels:
+    #     - frequency_hz: 851_037_500
+    #       system: "regional-dmr-t3"
 
 trunking:
   # call_timeout_ms: inactivity window after which the engine's

--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -241,15 +241,64 @@ sdr:
 trunking:
   systems:
     - name: "regional-dmr-t2"
-      protocol: dmr
+      protocol: dmr-tier2
+      # Tier II is conventional, but trunking.System.Validate()
+      # requires a non-empty control_channels list. List the same
+      # repeater carriers - the wideband engine ignores them when
+      # choosing the state machine.
+      control_channels:
+        - 453_125_000
+        - 453_275_000
+        - 453_775_000
+        - 454_100_000
       talkgroup_file: "/etc/gophertrunk/talkgroups-dmr.csv"
 ```
 
 The daemon programs the dongle's tuner to `center_freq_hz` once, opens
 a single IQ stream, and routes one decimated 48 kHz IQ stream per
-configured `channels[].frequency_hz` into a separate DMR T2 state
+configured `channels[].frequency_hz` into a separate DMR state
 machine. Grants and `cc.locked` events fire per repeater frequency
 just like they do for a dedicated dongle.
+
+### Mixing DMR Tier II and Tier III on one dongle
+
+A wideband dongle can host a DMR Tier III control-channel tap
+alongside Tier II conventional carriers. Use `protocol: dmr` for the
+T3 system, list the T3 control frequency under `control_channels`,
+and have one of the dongle's `channels[]` entries point at that
+frequency:
+
+```yaml
+sdr:
+  devices:
+    - serial: "00000003"
+      role: wideband
+      center_freq_hz: 851_500_000
+      channels:
+        - frequency_hz: 851_037_500    # T3 CC
+          system: "regional-dmr-t3"
+        - frequency_hz: 852_125_000    # T2 conventional carrier
+          system: "neighbour-dmr-t2"
+
+trunking:
+  systems:
+    - name: "regional-dmr-t3"
+      protocol: dmr                    # Tier III trunked
+      control_channels: [851_037_500]  # MUST include the wideband channel above
+    - name: "neighbour-dmr-t2"
+      protocol: dmr-tier2              # Tier II conventional
+      control_channels: [852_125_000]
+```
+
+The engine picks the right state machine per channel (Tier III's
+`ControlChannel` for `protocol: dmr`, Tier II's `ConventionalChannel`
+for `protocol: dmr-tier2`).
+
+T3 voice grants are published on the bus and routed to the daemon's
+existing physical voice pool — add a `role: voice` SDR alongside the
+wideband dongle if you want voice decoded. The follow-up work to
+decode T3 voice grants directly on the wideband dongle (via a virtual
+voice pool that allocates a tuner tap per grant) is roadmapped.
 
 ### Picking a centre frequency and bandwidth
 
@@ -274,13 +323,20 @@ message that names the offending entry.
 
 ### Limits
 
-- **DMR Tier II only in v1.** Tier III trunked support over a wideband
-  dongle is on the roadmap; today the listed channels must be
-  DMR conventional carriers.
+- **DMR only.** Wideband supports `protocol: dmr-tier2` (Tier II
+  conventional) and `protocol: dmr` (Tier III trunked control
+  channel). Other protocols (P25, NXDN, TETRA, …) and Tier III
+  voice grants on the wideband dongle itself are not in scope yet —
+  see "Tier III voice" below.
+- **Tier III voice still needs a physical Voice SDR.** When the
+  wideband T3 tap decodes a grant, the daemon's existing voice pool
+  retunes a `role: voice` dongle to follow the call. The wideband
+  dongle decodes the CC; voice rides on the regular pool. A
+  follow-up will add a virtual voice pool that allocates a tuner
+  tap from the wideband dongle for each grant, removing the need
+  for the second SDR.
 - **The wideband dongle is dedicated.** It can't double as a Voice
   pool member (the daemon needs it pinned to one centre frequency).
-  If you also run a trunked system that allocates voice grants, add a
-  separate Voice dongle for that.
 - **CPU scales with channel count.** Eight DDC taps at 2.4 MS/s is a
   few percent of one modern x86 core; the polyphase mode lands lower
   at the same count.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -733,10 +733,6 @@ func (c Config) Validate() error {
 		return errors.New("sdr.sample_rate must be between 225 kHz and 3.2 MHz")
 	}
 	seenSerials := make(map[string]int, len(c.SDR.Devices))
-	systemProtocols := make(map[string]string, len(c.Trunking.Systems))
-	for _, s := range c.Trunking.Systems {
-		systemProtocols[s.Name] = s.Protocol
-	}
 	for i, d := range c.SDR.Devices {
 		switch d.Role {
 		case "", "control", "voice", "auto", "wideband":
@@ -744,7 +740,7 @@ func (c Config) Validate() error {
 			return fmt.Errorf("sdr.devices[%d]: role must be control|voice|auto|wideband", i)
 		}
 		if d.Role == "wideband" {
-			if err := validateWidebandDevice(i, d, c.SDR.SampleRate, systemProtocols); err != nil {
+			if err := validateWidebandDevice(i, d, c.SDR.SampleRate, c.Trunking.Systems); err != nil {
 				return err
 			}
 		}
@@ -895,7 +891,14 @@ const widebandGuardFrac = 0.05
 // already accepted that as "fall back to the pool default" — in which
 // case the in-band check uses sdr.DefaultSampleRateHz so a missing
 // rate doesn't bypass the per-channel sanity check.
-func validateWidebandDevice(idx int, d DeviceConfig, sampleRateHz uint32, systemProtocols map[string]string) error {
+//
+// Each channel must reference a system whose protocol is either:
+//   - "dmr-tier2" — Tier II conventional; the channel frequency is one
+//     repeater carrier.
+//   - "dmr"       — Tier III trunked; the channel frequency must match
+//     one of the system's control_channels (the wideband dongle is
+//     hosting that CC).
+func validateWidebandDevice(idx int, d DeviceConfig, sampleRateHz uint32, systems []SystemConfig) error {
 	if d.Serial == "" {
 		return fmt.Errorf("sdr.devices[%d]: role: wideband requires serial (the daemon binds the channel list to the device by USB serial)", idx)
 	}
@@ -915,6 +918,10 @@ func validateWidebandDevice(idx int, d DeviceConfig, sampleRateHz uint32, system
 		rate = 2_048_000 // sdr.DefaultSampleRateHz; avoid an import cycle by repeating it
 	}
 	usableHalfBand := float64(rate) * (0.5 - widebandGuardFrac)
+	systemsByName := make(map[string]SystemConfig, len(systems))
+	for _, s := range systems {
+		systemsByName[s.Name] = s
+	}
 	seenFreq := make(map[uint32]int, len(d.Channels))
 	for j, ch := range d.Channels {
 		if ch.FrequencyHz == 0 {
@@ -923,12 +930,35 @@ func validateWidebandDevice(idx int, d DeviceConfig, sampleRateHz uint32, system
 		if ch.System == "" {
 			return fmt.Errorf("sdr.devices[%d].channels[%d]: system required", idx, j)
 		}
-		proto, ok := systemProtocols[ch.System]
+		sys, ok := systemsByName[ch.System]
 		if !ok {
 			return fmt.Errorf("sdr.devices[%d].channels[%d]: system %q is not declared in trunking.systems", idx, j, ch.System)
 		}
-		if proto != "dmr" {
-			return fmt.Errorf("sdr.devices[%d].channels[%d]: system %q has protocol %q; wideband currently supports dmr only", idx, j, ch.System, proto)
+		switch sys.Protocol {
+		case "dmr-tier2", "dmr_tier2", "dmr-t2", "dmrtier2":
+			// Tier II conventional - channel freq is a repeater carrier,
+			// no relationship to system.ControlChannels required.
+		case "dmr":
+			// Tier III trunked - the wideband channel MUST be one of
+			// the system's declared control channels.
+			matched := false
+			for _, cc := range sys.ControlChannels {
+				if cc == ch.FrequencyHz {
+					matched = true
+					break
+				}
+			}
+			if !matched {
+				return fmt.Errorf(
+					"sdr.devices[%d].channels[%d]: frequency_hz %d does not match any of system %q's "+
+						"control_channels %v (wideband T3 channels must sit on a declared control channel)",
+					idx, j, ch.FrequencyHz, ch.System, sys.ControlChannels)
+			}
+		default:
+			return fmt.Errorf(
+				"sdr.devices[%d].channels[%d]: system %q has protocol %q; wideband currently supports dmr-tier2 "+
+					"(Tier II conventional) and dmr (Tier III trunked control channel)",
+				idx, j, ch.System, sys.Protocol)
 		}
 		offset := float64(ch.FrequencyHz) - float64(d.CenterFreqHz)
 		if offset > usableHalfBand || offset < -usableHalfBand {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -89,9 +89,10 @@ func TestValidate(t *testing.T) {
 		{"band_plan zero spacing", Config{Trunking: TrunkingConfig{Systems: []SystemConfig{{Name: "x", Protocol: "p25", P25BandPlan: []P25BandPlanEntryConfig{{ChannelID: 3, BaseHz: 1, SpacingHz: 0}}}}}}, true},
 		{"band_plan zero base", Config{Trunking: TrunkingConfig{Systems: []SystemConfig{{Name: "x", Protocol: "p25", P25BandPlan: []P25BandPlanEntryConfig{{ChannelID: 3, BaseHz: 0, SpacingHz: 1}}}}}}, true},
 		// wideband role: pin a dongle to a centre frequency and list
-		// per-repeater carriers inside its IQ bandwidth. Currently
-		// supports DMR Tier II conventional only.
-		{"wideband ok", Config{
+		// per-repeater carriers inside its IQ bandwidth. Stage 2 added
+		// DMR Tier II conventional; Stage 3 added DMR Tier III trunked
+		// control channel.
+		{"wideband T2 ok", Config{
 			SDR: SDRConfig{SampleRate: 2_400_000, Devices: []DeviceConfig{{
 				Serial: "00000010", Role: "wideband", CenterFreqHz: 453_500_000,
 				Channels: []DeviceChannelConfig{
@@ -99,7 +100,44 @@ func TestValidate(t *testing.T) {
 					{FrequencyHz: 453_775_000, System: "regional-t2"},
 				},
 			}}},
-			Trunking: TrunkingConfig{Systems: []SystemConfig{{Name: "regional-t2", Protocol: "dmr"}}},
+			Trunking: TrunkingConfig{Systems: []SystemConfig{{Name: "regional-t2", Protocol: "dmr-tier2"}}},
+		}, false},
+		{"wideband T3 ok", Config{
+			SDR: SDRConfig{SampleRate: 2_400_000, Devices: []DeviceConfig{{
+				Serial: "00000010", Role: "wideband", CenterFreqHz: 453_500_000,
+				Channels: []DeviceChannelConfig{
+					{FrequencyHz: 453_775_000, System: "regional-t3"},
+				},
+			}}},
+			Trunking: TrunkingConfig{Systems: []SystemConfig{{
+				Name: "regional-t3", Protocol: "dmr",
+				ControlChannels: []uint32{453_775_000},
+			}}},
+		}, false},
+		{"wideband T3 channel not in CC list", Config{
+			SDR: SDRConfig{SampleRate: 2_400_000, Devices: []DeviceConfig{{
+				Serial: "00000010", Role: "wideband", CenterFreqHz: 453_500_000,
+				Channels: []DeviceChannelConfig{
+					{FrequencyHz: 453_125_000, System: "regional-t3"},
+				},
+			}}},
+			Trunking: TrunkingConfig{Systems: []SystemConfig{{
+				Name: "regional-t3", Protocol: "dmr",
+				ControlChannels: []uint32{453_775_000}, // doesn't include 453_125_000
+			}}},
+		}, true},
+		{"wideband mixed T2 + T3", Config{
+			SDR: SDRConfig{SampleRate: 2_400_000, Devices: []DeviceConfig{{
+				Serial: "00000010", Role: "wideband", CenterFreqHz: 453_500_000,
+				Channels: []DeviceChannelConfig{
+					{FrequencyHz: 453_125_000, System: "regional-t2"},
+					{FrequencyHz: 453_775_000, System: "regional-t3"},
+				},
+			}}},
+			Trunking: TrunkingConfig{Systems: []SystemConfig{
+				{Name: "regional-t2", Protocol: "dmr-tier2"},
+				{Name: "regional-t3", Protocol: "dmr", ControlChannels: []uint32{453_775_000}},
+			}},
 		}, false},
 		{"wideband missing serial", Config{
 			SDR: SDRConfig{SampleRate: 2_400_000, Devices: []DeviceConfig{{
@@ -108,7 +146,7 @@ func TestValidate(t *testing.T) {
 					{FrequencyHz: 453_125_000, System: "x"},
 				},
 			}}},
-			Trunking: TrunkingConfig{Systems: []SystemConfig{{Name: "x", Protocol: "dmr"}}},
+			Trunking: TrunkingConfig{Systems: []SystemConfig{{Name: "x", Protocol: "dmr-tier2"}}},
 		}, true},
 		{"wideband missing center", Config{
 			SDR: SDRConfig{SampleRate: 2_400_000, Devices: []DeviceConfig{{
@@ -117,7 +155,7 @@ func TestValidate(t *testing.T) {
 					{FrequencyHz: 453_125_000, System: "x"},
 				},
 			}}},
-			Trunking: TrunkingConfig{Systems: []SystemConfig{{Name: "x", Protocol: "dmr"}}},
+			Trunking: TrunkingConfig{Systems: []SystemConfig{{Name: "x", Protocol: "dmr-tier2"}}},
 		}, true},
 		{"wideband missing channels", Config{
 			SDR: SDRConfig{SampleRate: 2_400_000, Devices: []DeviceConfig{{
@@ -131,7 +169,7 @@ func TestValidate(t *testing.T) {
 					{FrequencyHz: 460_000_000, System: "x"},
 				},
 			}}},
-			Trunking: TrunkingConfig{Systems: []SystemConfig{{Name: "x", Protocol: "dmr"}}},
+			Trunking: TrunkingConfig{Systems: []SystemConfig{{Name: "x", Protocol: "dmr-tier2"}}},
 		}, true},
 		{"wideband unknown system", Config{
 			SDR: SDRConfig{SampleRate: 2_400_000, Devices: []DeviceConfig{{
@@ -158,7 +196,7 @@ func TestValidate(t *testing.T) {
 					{FrequencyHz: 453_125_000, System: "x"},
 				},
 			}}},
-			Trunking: TrunkingConfig{Systems: []SystemConfig{{Name: "x", Protocol: "dmr"}}},
+			Trunking: TrunkingConfig{Systems: []SystemConfig{{Name: "x", Protocol: "dmr-tier2"}}},
 		}, true},
 		{"wideband bad strategy", Config{
 			SDR: SDRConfig{SampleRate: 2_400_000, Devices: []DeviceConfig{{
@@ -167,7 +205,7 @@ func TestValidate(t *testing.T) {
 					{FrequencyHz: 453_125_000, System: "x"},
 				},
 			}}},
-			Trunking: TrunkingConfig{Systems: []SystemConfig{{Name: "x", Protocol: "dmr"}}},
+			Trunking: TrunkingConfig{Systems: []SystemConfig{{Name: "x", Protocol: "dmr-tier2"}}},
 		}, true},
 	}
 	for _, tc := range cases {

--- a/internal/scanner/widebandt2/engine.go
+++ b/internal/scanner/widebandt2/engine.go
@@ -1,9 +1,25 @@
-// Package widebandt2 monitors several DMR Tier II conventional
-// repeaters with a single SDR dongle. The dongle is pinned to a
-// configured centre frequency; an internal/dsp/tuner.Bank extracts
-// one narrow-band IQ stream per repeater carrier inside the dongle's
-// IQ band; each stream feeds a DMR receiver and a tier2 state
-// machine that publishes cc.locked / grant events on the bus.
+// Package widebandt2 monitors several DMR repeaters with a single SDR
+// dongle. The dongle is pinned to a configured centre frequency; an
+// internal/dsp/tuner.Bank extracts one narrow-band IQ stream per
+// repeater carrier inside the dongle's IQ band; each stream feeds a
+// DMR receiver and a per-channel state machine that publishes
+// cc.locked / grant events on the bus.
+//
+// Two DMR variants are supported as channel state machines:
+//
+//   - DMR Tier II conventional (config protocol "dmr-tier2"). Each
+//     channel is a per-repeater carrier; the state machine
+//     (radio/dmr/tier2) emits a grant on every Voice LC Header burst.
+//
+//   - DMR Tier III trunked control channel (config protocol "dmr").
+//     The channel frequency must match one of the system's
+//     control_channels; the state machine (radio/dmr/tier3) emits
+//     grants from the CSBK chain. The published grants flow through
+//     the trunking engine's existing voice-pool allocator, which
+//     binds them to a physical role: voice dongle. Voice grants are
+//     not (yet) decoded by the wideband dongle itself — that needs
+//     a per-call narrow-band composer chain which is roadmapped as
+//     a follow-up.
 //
 // One Engine owns one wideband SDR. Multiple wideband dongles each
 // get their own Engine; they run independently and share only the
@@ -22,7 +38,9 @@ import (
 	"github.com/MattCheramie/GopherTrunk/internal/radio/dmr"
 	"github.com/MattCheramie/GopherTrunk/internal/radio/dmr/receiver"
 	"github.com/MattCheramie/GopherTrunk/internal/radio/dmr/tier2"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/dmr/tier3"
 	"github.com/MattCheramie/GopherTrunk/internal/sdr"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
 )
 
 // narrowbandRateHz is the per-tap sample rate the bank decimates to.
@@ -55,8 +73,9 @@ const channelizerTapsPerBranch = 16
 const channelizerKaiserBeta = 9.0
 
 // ChannelConfig binds one repeater frequency to the trunking system
-// it belongs to. The Engine creates one tier2.ConventionalChannel
-// per entry.
+// it belongs to. The Engine creates one DMR state machine per entry,
+// dispatched by the referenced system's protocol (dmr-tier2 →
+// tier2.ConventionalChannel; dmr → tier3.ControlChannel).
 type ChannelConfig struct {
 	FrequencyHz uint32
 	SystemName  string
@@ -85,6 +104,13 @@ type Options struct {
 	// band (CenterFreqHz ± SampleRateHz/2 minus guardFrac).
 	Channels []ChannelConfig
 
+	// Systems is the trunking-system table. The Engine looks up
+	// each ChannelConfig.SystemName here to decide whether the
+	// channel is a Tier II conventional carrier (protocol
+	// "dmr-tier2") or a Tier III control channel (protocol "dmr").
+	// Required when Channels is non-empty.
+	Systems []trunking.System
+
 	// Now overrides the wall clock the per-channel state machines
 	// use for Grant.At timestamps. nil ⇒ time.Now.
 	Now func() time.Time
@@ -103,11 +129,20 @@ type Engine struct {
 	strategyTag string
 }
 
+// channelProcessor is the per-channel dibit consumer. Tier II's
+// ConventionalChannel and Tier III's ControlChannel both expose
+// Process(dibits []uint8, baseIdx int) int with the same semantics, so
+// the engine treats them uniformly.
+type channelProcessor interface {
+	Process(dibits []uint8, baseIdx int) int
+}
+
 type engineChannel struct {
-	freqHz   uint32
-	sysName  string
-	cc       *tier2.ConventionalChannel
-	receiver *receiver.Receiver
+	freqHz    uint32
+	sysName   string
+	protoTag  string // "dmr-tier2" or "dmr-tier3"
+	processor channelProcessor
+	receiver  *receiver.Receiver
 }
 
 // New constructs an Engine. The device is not opened or streamed
@@ -129,6 +164,13 @@ func New(opts Options) (*Engine, error) {
 	}
 	if len(opts.Channels) == 0 {
 		return nil, errors.New("widebandt2: at least one channel is required")
+	}
+	if len(opts.Systems) == 0 {
+		return nil, errors.New("widebandt2: Systems table is required (used to resolve T2 vs T3 per channel)")
+	}
+	systemsByName := make(map[string]trunking.System, len(opts.Systems))
+	for _, s := range opts.Systems {
+		systemsByName[s.Name] = s
 	}
 	log := opts.Log
 	if log == nil {
@@ -158,33 +200,38 @@ func New(opts Options) (*Engine, error) {
 	}
 
 	for _, ch := range opts.Channels {
+		sys, ok := systemsByName[ch.SystemName]
+		if !ok {
+			return nil, fmt.Errorf("widebandt2: channel freq=%d references unknown system %q",
+				ch.FrequencyHz, ch.SystemName)
+		}
 		offset := float64(ch.FrequencyHz) - float64(opts.CenterFreqHz)
-		cc := tier2.New(tier2.Options{
-			Bus:         opts.Bus,
-			Log:         log.With("system", ch.SystemName, "freq_hz", ch.FrequencyHz),
-			SystemName:  ch.SystemName,
-			FrequencyHz: ch.FrequencyHz,
-			Now:         opts.Now,
-		})
-		// dibitSink hands the receiver's dibits to the Tier II
-		// process adapter. The adapter buffers across calls,
-		// runs sync detection, and emits cc.locked / grant
-		// events on the bus.
-		dibitSink := func(cc *tier2.ConventionalChannel) dmr.DibitSink {
+		processor, protoTag, err := buildProcessor(sys, ch.FrequencyHz, opts.Bus, log, opts.Now)
+		if err != nil {
+			return nil, err
+		}
+		// DibitSink hands the receiver's dibits to the
+		// per-channel state machine's Process adapter. Both
+		// tier2.ConventionalChannel and tier3.ControlChannel
+		// satisfy channelProcessor; the adapter buffers across
+		// calls, runs sync detection, frames bursts, and emits
+		// cc.locked / grant events on the bus.
+		dibitSink := func(p channelProcessor) dmr.DibitSink {
 			return func(dibits []uint8, baseIdx int) {
-				cc.Process(dibits, baseIdx)
+				p.Process(dibits, baseIdx)
 			}
-		}(cc)
+		}(processor)
 		rcv := receiver.New(receiver.Options{
 			SampleRateHz: narrowbandRateHz,
 			DibitSink:    dibitSink,
 			DeviationHz:  receiver.SymbolRate * 0.405, // ~1944 Hz per ETSI TS 102 361-1 §6.3
 		})
 		ec := &engineChannel{
-			freqHz:   ch.FrequencyHz,
-			sysName:  ch.SystemName,
-			cc:       cc,
-			receiver: rcv,
+			freqHz:    ch.FrequencyHz,
+			sysName:   ch.SystemName,
+			protoTag:  protoTag,
+			processor: processor,
+			receiver:  rcv,
 		}
 		sink := func(ec *engineChannel) tuner.SinkFunc {
 			return func(out []complex64) {
@@ -203,6 +250,47 @@ func New(opts Options) (*Engine, error) {
 	return engine, nil
 }
 
+// buildProcessor instantiates the right DMR state machine for a
+// channel: Tier III ControlChannel for protocol "dmr" (the channel
+// frequency must be one of the system's control_channels), Tier II
+// ConventionalChannel for protocol "dmr-tier2".
+func buildProcessor(sys trunking.System, freqHz uint32, bus *events.Bus, log *slog.Logger, now func() time.Time) (channelProcessor, string, error) {
+	switch sys.Protocol {
+	case trunking.ProtocolDMR:
+		matched := false
+		for _, cc := range sys.ControlChannels {
+			if cc == freqHz {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return nil, "", fmt.Errorf("widebandt2: channel freq=%d on system %q (protocol dmr / Tier III) "+
+				"must match one of the system's control_channels %v", freqHz, sys.Name, sys.ControlChannels)
+		}
+		cc := tier3.New(tier3.Options{
+			Bus:         bus,
+			Log:         log.With("system", sys.Name, "freq_hz", freqHz, "tier", 3),
+			SystemName:  sys.Name,
+			FrequencyHz: freqHz,
+			Now:         now,
+		})
+		return cc, "dmr-tier3", nil
+	case trunking.ProtocolDMRTier2:
+		cc := tier2.New(tier2.Options{
+			Bus:         bus,
+			Log:         log.With("system", sys.Name, "freq_hz", freqHz, "tier", 2),
+			SystemName:  sys.Name,
+			FrequencyHz: freqHz,
+			Now:         now,
+		})
+		return cc, "dmr-tier2", nil
+	default:
+		return nil, "", fmt.Errorf("widebandt2: system %q has protocol %q; wideband only supports dmr-tier2 and dmr",
+			sys.Name, sys.Protocol.String())
+	}
+}
+
 // Channels returns the per-channel frequencies the engine is
 // monitoring. Used by callers (the daemon, tests) for logging and
 // status snapshots.
@@ -210,6 +298,18 @@ func (e *Engine) Channels() []uint32 {
 	out := make([]uint32, 0, len(e.channels))
 	for _, c := range e.channels {
 		out = append(out, c.freqHz)
+	}
+	return out
+}
+
+// ChannelProtocolTags returns a frequency → protocol-tag map for the
+// channels this engine drives ("dmr-tier2" or "dmr-tier3"). Used by
+// the daemon's startup log and by tests to verify the dispatcher
+// picked the right state machine per channel.
+func (e *Engine) ChannelProtocolTags() map[uint32]string {
+	out := make(map[uint32]string, len(e.channels))
+	for _, c := range e.channels {
+		out[c.freqHz] = c.protoTag
 	}
 	return out
 }

--- a/internal/scanner/widebandt2/engine_test.go
+++ b/internal/scanner/widebandt2/engine_test.go
@@ -11,7 +11,19 @@ import (
 
 	"github.com/MattCheramie/GopherTrunk/internal/events"
 	"github.com/MattCheramie/GopherTrunk/internal/sdr"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
 )
+
+// t2System / t3System are test helpers that build the trunking.System
+// entries the engine needs for Tier II conventional and Tier III
+// trunked channels respectively.
+func t2System(name string) trunking.System {
+	return trunking.System{Name: name, Protocol: trunking.ProtocolDMRTier2}
+}
+
+func t3System(name string, ccFreq uint32) trunking.System {
+	return trunking.System{Name: name, Protocol: trunking.ProtocolDMR, ControlChannels: []uint32{ccFreq}}
+}
 
 // mockDevice is a synchronous sdr.Device that emits a caller-supplied
 // sequence of IQ chunks, then closes the stream. The test goroutine
@@ -61,7 +73,8 @@ func TestEngineNewRejectsMissingDevice(t *testing.T) {
 	bus := events.NewBus(8)
 	defer bus.Close()
 	if _, err := New(Options{Bus: bus, SampleRateHz: 2_400_000, CenterFreqHz: 453_500_000,
-		Channels: []ChannelConfig{{FrequencyHz: 453_125_000, SystemName: "x"}}}); err == nil {
+		Channels: []ChannelConfig{{FrequencyHz: 453_125_000, SystemName: "x"}},
+		Systems:  []trunking.System{t2System("x")}}); err == nil {
 		t.Errorf("expected error for missing Device")
 	}
 }
@@ -69,7 +82,8 @@ func TestEngineNewRejectsMissingDevice(t *testing.T) {
 func TestEngineNewRejectsMissingBus(t *testing.T) {
 	dev := newMockDevice(nil)
 	if _, err := New(Options{Device: dev, SampleRateHz: 2_400_000, CenterFreqHz: 453_500_000,
-		Channels: []ChannelConfig{{FrequencyHz: 453_125_000, SystemName: "x"}}}); err == nil {
+		Channels: []ChannelConfig{{FrequencyHz: 453_125_000, SystemName: "x"}},
+		Systems:  []trunking.System{t2System("x")}}); err == nil {
 		t.Errorf("expected error for missing Bus")
 	}
 }
@@ -83,6 +97,50 @@ func TestEngineNewRejectsEmptyChannels(t *testing.T) {
 	}
 }
 
+func TestEngineNewRejectsMissingSystems(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	dev := newMockDevice(nil)
+	_, err := New(Options{
+		Device: dev, Bus: bus, SampleRateHz: 2_400_000, CenterFreqHz: 453_500_000,
+		Channels: []ChannelConfig{{FrequencyHz: 453_125_000, SystemName: "x"}},
+	})
+	if err == nil {
+		t.Errorf("expected error for missing Systems table")
+	}
+}
+
+func TestEngineNewRejectsUnknownSystem(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	dev := newMockDevice(nil)
+	_, err := New(Options{
+		Device: dev, Bus: bus, SampleRateHz: 2_400_000, CenterFreqHz: 453_500_000,
+		Channels: []ChannelConfig{{FrequencyHz: 453_125_000, SystemName: "missing"}},
+		Systems:  []trunking.System{t2System("other")},
+	})
+	if err == nil {
+		t.Errorf("expected error for channel referencing unknown system")
+	}
+}
+
+func TestEngineNewRejectsT3ChannelNotInCCList(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	dev := newMockDevice(nil)
+	_, err := New(Options{
+		Device: dev, Bus: bus, SampleRateHz: 2_400_000, CenterFreqHz: 453_500_000,
+		// Channel freq doesn't match the system's CC list — engine
+		// must reject because a T3 wideband tap MUST sit on a
+		// declared control channel.
+		Channels: []ChannelConfig{{FrequencyHz: 453_125_000, SystemName: "t3sys"}},
+		Systems:  []trunking.System{t3System("t3sys", 453_775_000)},
+	})
+	if err == nil {
+		t.Errorf("expected error for T3 channel not in system.ControlChannels")
+	}
+}
+
 func TestEngineNewRejectsOutOfBandChannel(t *testing.T) {
 	bus := events.NewBus(8)
 	defer bus.Close()
@@ -92,6 +150,7 @@ func TestEngineNewRejectsOutOfBandChannel(t *testing.T) {
 		Channels: []ChannelConfig{
 			{FrequencyHz: 470_000_000, SystemName: "x"}, // > 16 MHz away
 		},
+		Systems: []trunking.System{t2System("x")},
 	})
 	if err == nil {
 		t.Errorf("expected error for out-of-band channel")
@@ -110,6 +169,7 @@ func TestEngineStrategyAuto(t *testing.T) {
 				{FrequencyHz: 453_125_000, SystemName: "x"},
 				{FrequencyHz: 453_775_000, SystemName: "x"},
 			},
+			Systems: []trunking.System{t2System("x")},
 		})
 		if err != nil {
 			t.Fatal(err)
@@ -135,6 +195,7 @@ func TestEngineStrategyAuto(t *testing.T) {
 		e, err := New(Options{
 			Device: dev, Bus: bus, SampleRateHz: 2_400_000, CenterFreqHz: 453_500_000,
 			Channels: channels,
+			Systems:  []trunking.System{t2System("x")},
 		})
 		if err != nil {
 			t.Fatal(err)
@@ -163,6 +224,7 @@ func TestEngineStrategyExplicit(t *testing.T) {
 				{FrequencyHz: 453_125_000, SystemName: "x"},
 				{FrequencyHz: 453_775_000, SystemName: "x"},
 			},
+			Systems: []trunking.System{t2System("x")},
 		})
 		if err != nil {
 			t.Fatalf("strategy %q: %v", tc.req, err)
@@ -170,6 +232,39 @@ func TestEngineStrategyExplicit(t *testing.T) {
 		if e.Strategy() != tc.want {
 			t.Errorf("strategy %q: got %q, want %q", tc.req, e.Strategy(), tc.want)
 		}
+	}
+}
+
+func TestEngineMixedT2AndT3Channels(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	dev := newMockDevice(nil)
+	// One wideband dongle covers a T2 repeater cluster AND a T3 CC.
+	// The engine must instantiate the right state machine per
+	// channel based on the referenced system's protocol.
+	e, err := New(Options{
+		Device: dev, Bus: bus, SampleRateHz: 2_400_000, CenterFreqHz: 453_500_000,
+		Channels: []ChannelConfig{
+			{FrequencyHz: 453_125_000, SystemName: "t2sys"},
+			{FrequencyHz: 453_775_000, SystemName: "t3sys"},
+		},
+		Systems: []trunking.System{
+			t2System("t2sys"),
+			t3System("t3sys", 453_775_000),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	tags := e.ChannelProtocolTags()
+	if len(tags) != 2 {
+		t.Fatalf("got %d channel tags, want 2", len(tags))
+	}
+	if tags[453_125_000] != "dmr-tier2" {
+		t.Errorf("freq 453_125_000 tag = %q, want dmr-tier2", tags[453_125_000])
+	}
+	if tags[453_775_000] != "dmr-tier3" {
+		t.Errorf("freq 453_775_000 tag = %q, want dmr-tier3", tags[453_775_000])
 	}
 }
 
@@ -197,6 +292,7 @@ func TestEngineRunSetsCenterFreqAndDrainsStream(t *testing.T) {
 			{FrequencyHz: 453_125_000, SystemName: "regional-t2"},
 			{FrequencyHz: 453_775_000, SystemName: "regional-t2"},
 		},
+		Systems: []trunking.System{t2System("regional-t2")},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -223,6 +319,7 @@ func TestEngineRunPropagatesStreamError(t *testing.T) {
 	e, err := New(Options{
 		Device: dev, Bus: bus, SampleRateHz: 2_400_000, CenterFreqHz: 453_500_000,
 		Channels: []ChannelConfig{{FrequencyHz: 453_125_000, SystemName: "x"}},
+		Systems:  []trunking.System{t2System("x")},
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/samples/dmr-tier2-multichannel/README.md
+++ b/samples/dmr-tier2-multichannel/README.md
@@ -1,29 +1,34 @@
-# One dongle, several DMR Tier II repeaters
+# One dongle, several DMR repeaters
 
 This sample config monitors four conventional DMR Tier II repeaters
 that all live inside a single 2.4 MHz IQ window around 453.5 MHz with
 one RTL-SDR. No extra hardware, no hardware re-tune per call - the
 daemon's internal channelizer (`internal/dsp/tuner`) extracts a
 separate 48 kHz baseband stream per repeater and feeds an independent
-T2 decoder for each.
+DMR decoder for each.
 
 ## When to use this layout
 
 - You have several DMR Tier II repeaters whose carriers cluster
   inside the IQ bandwidth of one dongle (typically ≤ 2.4 MHz of
   total spread).
+- You have a DMR Tier III trunked control channel inside the same
+  IQ window — the wideband engine can decode the T3 CC alongside
+  any T2 carriers. The commented-out section in `config.yaml`
+  shows how. (Voice grants from T3 still need a `role: voice`
+  SDR; the wideband dongle decodes the CC only.)
 - You only own one SDR or want to free your other dongles for
   other systems.
-- All the repeaters belong to the same conventional system - i.e.
-  you'd happily merge their call streams into one talkgroup CSV.
 
 ## What it doesn't do
 
-- Trunked DMR (Tier III) grant chasing is not supported by the
-  wideband role in v1. Add a separate `role: voice` dongle for
-  trunked systems.
+- Decode DMR Tier III voice grants directly on the wideband
+  dongle. Grants from the T3 CC publish on the bus; the daemon's
+  existing voice pool retunes a `role: voice` SDR to follow them.
+  A virtual voice pool that allocates a tuner tap per grant is
+  planned as a follow-up so T3-on-one-dongle becomes possible.
 - Other protocols (P25, NXDN, TETRA, etc.) inside the wideband
-  IQ are not decoded. Wideband is currently DMR Tier II only.
+  IQ. Wideband is currently DMR-only.
 - The wideband dongle is dedicated to this layout - it can't
   double as a voice-pool member or a control-channel hunter.
 
@@ -57,7 +62,10 @@ calls arrive.
 
 ## Limits and follow-ups
 
-- DMR Tier III via wideband is planned (the engine and the DSP can
-  do it - the voice-pool adapter is the remaining piece).
+- DMR Tier III voice on the wideband dongle is planned (the engine
+  and DSP can do it; the missing piece is a virtual voice pool that
+  allocates a tuner tap per grant instead of retuning a physical
+  dongle). Today T3 voice grants from a wideband CC route to a
+  physical `role: voice` SDR.
 - Multi-protocol wideband (P25 + DMR + NXDN sharing one dongle) is
-  not on the v1 roadmap.
+  not on the near-term roadmap.

--- a/samples/dmr-tier2-multichannel/config.yaml
+++ b/samples/dmr-tier2-multichannel/config.yaml
@@ -1,4 +1,5 @@
-# Cover a cluster of DMR Tier II repeaters with one RTL-SDR.
+# Cover a cluster of DMR Tier II repeaters with one RTL-SDR. Optionally
+# add a DMR Tier III control-channel tap on the same dongle.
 #
 # This config monitors four 12.5 kHz conventional DMR repeaters whose
 # carriers all sit inside a single 2.4 MHz IQ window centred at
@@ -35,13 +36,43 @@ sdr:
         - frequency_hz: 454_100_000
           system: "regional-dmr-t2"
 
+    # OPTIONAL: replace one of the T2 lines above (or add a second
+    # wideband dongle entry) with a DMR Tier III control-channel tap.
+    # The channel frequency_hz MUST match one of the system's
+    # control_channels declared below. Voice grants from the T3 CC
+    # still flow through the daemon's physical voice pool (Stage 3
+    # limit) - add a `role: voice` SDR alongside if you want voice
+    # decoded too.
+    #
+    # - serial: "REPLACE_WITH_T3_SERIAL"
+    #   role: wideband
+    #   center_freq_hz: 851_000_000
+    #   channels:
+    #     - frequency_hz: 851_037_500
+    #       system: "regional-dmr-t3"
+
 trunking:
   systems:
     - name: "regional-dmr-t2"
-      protocol: dmr
-      # DMR Tier II is conventional - no control channel. The per-
-      # repeater carrier list lives under sdr.devices[].channels above.
+      protocol: dmr-tier2
+      # Tier II is conventional - there is no real control channel,
+      # but trunking.System.Validate() requires a non-empty list.
+      # List the repeater carriers (the same frequencies the wideband
+      # dongle's channels reference); the wideband engine ignores them
+      # for state-machine selection.
+      control_channels:
+        - 453_125_000
+        - 453_275_000
+        - 453_775_000
+        - 454_100_000
       talkgroup_file: "talkgroups-dmr.csv"
+
+    # OPTIONAL T3 system that pairs with the commented-out wideband
+    # dongle above:
+    # - name: "regional-dmr-t3"
+    #   protocol: dmr
+    #   control_channels: [851_037_500]
+    #   talkgroup_file: "talkgroups-dmr.csv"
 
 recordings:
   dir: "recordings/"


### PR DESCRIPTION
## Summary

Stage 3 of 3 of **"one dongle, many DMR repeaters within a single IQ window."** Adds DMR Tier III trunked control-channel decoding to the wideband engine that landed in Stage 2 (#362). Builds on the `internal/dsp/tuner` package from Stage 1 (#360).

After this PR, a single SDR dongle pinned to a centre frequency can simultaneously decode:
- Several DMR **Tier II conventional** repeater carriers (Stage 2), and
- A DMR **Tier III trunked control channel** (new in this PR)

…all within the dongle's IQ bandwidth, mixed in any combination.

## What's new

- **Per-channel protocol dispatch.** The wideband engine now picks the right DMR state machine per channel from the referenced trunking system's protocol:
  - `protocol: dmr-tier2` → `radio/dmr/tier2.ConventionalChannel`
  - `protocol: dmr` (Tier III) → `radio/dmr/tier3.ControlChannel`
- **T2 and T3 can mix on the same dongle.** Tested in `TestEngineMixedT2AndT3Channels` — one engine, one IQ stream, two different state machines feeding off two taps.
- **Config validator additions.** Wideband channels referencing a `protocol: dmr` system must list a frequency that's in that system's `control_channels` (rejected at load time otherwise). Both protocols are accepted now; everything else still rejected.
- **Stage 2 sample fix.** The `samples/dmr-tier2-multichannel/` config actually failed at startup before this PR because `trunking.System.Validate()` requires a non-empty `control_channels` list for every system. The sample now declares `protocol: dmr-tier2` with the repeater carriers listed under `control_channels`; verified the sample loads end-to-end (`go run ./cmd/gophertrunk run -config …` gets past validation; only error is missing SDR hardware, which is expected on the build host).

## YAML example

```yaml
sdr:
  sample_rate: 2_400_000
  devices:
    - serial: "00000004"
      role: wideband
      center_freq_hz: 851_500_000
      channels:
        - { frequency_hz: 851_037_500, system: "regional-dmr-t3" }   # T3 CC
        - { frequency_hz: 852_125_000, system: "neighbour-dmr-t2" }  # T2 conventional

trunking:
  systems:
    - name: "regional-dmr-t3"
      protocol: dmr
      control_channels: [851_037_500]   # T3 CC frequency MUST appear here
    - name: "neighbour-dmr-t2"
      protocol: dmr-tier2
      control_channels: [852_125_000]   # T2 - listed for the validator
```

## Scope and intentional limit

T3 voice grants from the wideband CC tap publish on the bus and are routed through the daemon's existing physical voice pool — which retunes a `role: voice` SDR to follow the call. **Decoding T3 voice directly on the wideband dongle** (via a virtual voice pool that allocates a tuner tap per grant) is the obvious next step, but it requires composer integration at the narrow-band rate (the existing composer expects wide-band IQ and does its own decimation). That's a separate PR — explicitly called out in `docs/hardware.md` § Limits, the sample README, and CHANGELOG.

In other words: this PR completes "one dongle for CC + multiple T2 repeaters". Voice on the wideband dongle is the next planned step.

## Files

- `internal/scanner/widebandt2/engine.go` — `buildProcessor` dispatches by `sys.Protocol`, returns a uniform `channelProcessor` interface. New `Options.Systems` field is required so the engine can look up tier per channel. New `ChannelProtocolTags()` accessor for tests / logging.
- `internal/scanner/widebandt2/engine_test.go` — 4 new tests covering the dispatch logic and rejection paths (missing systems table, unknown system, T3 channel not in CC list, mixed T2+T3). All 12 tests pass.
- `internal/config/config.go` — `validateWidebandDevice` accepts both protocols, enforces the T3 CC-frequency rule, and threads through the full system list (previously a map) so it can check `control_channels`.
- `internal/config/config_test.go` — 4 new test cases (`wideband T3 ok`, `T3 channel not in CC list`, `mixed T2 + T3`, plus the original `wideband ok` renamed to `wideband T2 ok`), all updated to use `dmr-tier2` for T2 systems. 12 wideband-related cases all pass.
- `cmd/gophertrunk/daemon.go` — passes `d.systems` to `widebandt2.New(Options{...})`.
- `samples/dmr-tier2-multichannel/{config.yaml,README.md}` — fixed protocol to `dmr-tier2`, populated `control_channels`, added commented-out T3 section, documented the T3-voice limit.
- `docs/hardware.md` — new "Mixing DMR Tier II and Tier III on one dongle" subsection, updated Limits section.
- `config.example.yaml` — commented wideband block now shows both T2 and T3 patterns and references both protocols.
- `README.md`, `CHANGELOG.md` — feature line updated to mention T3 CC support and the T3-voice follow-up.

## Test plan

- [x] `go test ./internal/scanner/widebandt2/ -v` — 12 tests pass (4 new, 8 existing updated)
- [x] `go test ./internal/config/ -v` — wideband cases now cover T2, T3, mixed, and 8 rejection paths
- [x] `go test ./...` — full suite green, no regressions
- [x] `go vet ./...` — clean
- [x] `gofmt -l` — clean
- [x] Manual: `go run ./cmd/gophertrunk run -config samples/dmr-tier2-multichannel/config.yaml -headless` loads the (previously broken) Stage 2 sample without errors

## After this merges

The three-PR series that started from the Discord question "can one dongle monitor multiple DMR T2 repeaters?" is feature-complete for what the user asked for: T2 cluster + T3 CC on one dongle. The remaining gap (T3 voice on the same dongle) is documented and queued as the next step.

https://claude.ai/code/session_01WAx7Gs3aMWgJAS8NRp96oU

---
_Generated by [Claude Code](https://claude.ai/code/session_01WAx7Gs3aMWgJAS8NRp96oU)_