### PR TITLE
rtltcp: add remote rtl_tcp SDR driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ for tagged releases.
 
 ## [Unreleased]
 
+### Added
+
+- **Remote `rtl_tcp` SDRs.** A new `rtltcp` driver mounts any number
+  of remote `rtl_tcp` servers as virtual tuners alongside locally-
+  attached USB dongles. The driver speaks the well-known librtlsdr
+  wire protocol (12-byte `RTL0` header, u8 IQ stream, 5-byte command
+  packets) used by SDR++, Gqrx, and OpenWebRX, so any host running
+  `rtl_tcp` can publish its dongle to the daemon. Configure under
+  `sdr.rtl_tcp` in `config.yaml`; each entry carries `addr`,
+  optional `serial`, `role`, `ppm`, `gain`, `bias_tee`, and
+  `connect_timeout_ms`. Pool roles, broker fan-out, baseband
+  recording, and the live spectrum panel all work against remote
+  sources just like local ones. Plaintext on the wire — restrict
+  to trusted networks or wrap with SSH/WireGuard/Tailscale. See
+  [docs/hardware.md](docs/hardware.md).
+
 ### Fixed
 
 - **Wideband DMR receiver loop-gain now matches the single-channel

--- a/README.md
+++ b/README.md
@@ -75,6 +75,16 @@ Silicon and Intel. Full per-OS recipes at
   dongles that drop off the bus and re-enumerate without
   restarting the daemon. See
   [docs/hardware.md](docs/hardware.md).
+- **Remote rtl_tcp SDRs** — Mount any number of `rtl_tcp`
+  endpoints as virtual tuners alongside local USB dongles. The
+  SDR can live on a Raspberry Pi at the antenna while the daemon
+  runs on a beefier host; one entry per remote in `sdr.rtl_tcp`.
+- **Live spectrum / waterfall** — In-browser FFT waterfall served
+  off the same IQ stream the trunking decoder consumes. New
+  `internal/sdr/iqtap` multi-consumer fan-out lets future
+  trunking-adjacent decoders (paging, AIS, ADS-B, ...) tap the
+  same source without disturbing CC decode. `GET /api/v1/spectrum/devices`
+  + `WS /api/v1/spectrum/stream`; web panel under `/spectrum`.
 - **One dongle, many repeaters** — `role: wideband` pins a single
   SDR to a centre frequency and runs an internal channelizer so
   one dongle decodes every DMR Tier II conventional repeater AND

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -23,6 +23,7 @@ import (
 	"github.com/MattCheramie/GopherTrunk/internal/sdr"
 	"github.com/MattCheramie/GopherTrunk/internal/sdr/baseband"
 	"github.com/MattCheramie/GopherTrunk/internal/sdr/iqtap"
+	"github.com/MattCheramie/GopherTrunk/internal/sdr/rtltcp"
 	"github.com/MattCheramie/GopherTrunk/internal/storage"
 	"github.com/MattCheramie/GopherTrunk/internal/trunking"
 	"github.com/MattCheramie/GopherTrunk/internal/voice"
@@ -304,7 +305,7 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 	// fall through gracefully when the pool is empty. The pool is
 	// also constructed when only baseband replay recordings are
 	// configured, so an offline capture can be decoded with no radio.
-	if len(cfg.SDR.Devices) > 0 || len(cfg.Baseband.Replay) > 0 {
+	if len(cfg.SDR.Devices) > 0 || len(cfg.Baseband.Replay) > 0 || len(cfg.SDR.RTLTCP) > 0 {
 		d.pool = sdr.NewPool(log)
 		d.pool.SetBus(d.bus)
 		var hints []sdr.Hint
@@ -343,6 +344,50 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 			}
 			sdr.Register(baseband.NewFileDriver(specs))
 			log.Info("baseband replay mounted", "recordings", len(specs))
+		}
+		// Mount rtl_tcp endpoints as virtual tuners. Each entry
+		// becomes one pool device; the driver dials lazily inside
+		// Pool.Open so misconfigured / down hosts surface as
+		// "failed to open" warnings rather than blocking daemon
+		// startup. Per-endpoint Hint carries role / ppm / gain /
+		// bias-tee through the same hint-matcher local USB devices
+		// use.
+		if len(cfg.SDR.RTLTCP) > 0 {
+			rspecs := make([]rtltcp.Spec, 0, len(cfg.SDR.RTLTCP))
+			for _, r := range cfg.SDR.RTLTCP {
+				if r.Addr == "" {
+					log.Warn("daemon: rtl_tcp entry missing addr; skipping")
+					continue
+				}
+				rspecs = append(rspecs, rtltcp.Spec{
+					Addr:           r.Addr,
+					Serial:         r.Serial,
+					Role:           r.Role,
+					ConnectTimeout: time.Duration(r.ConnectTimeoutMs) * time.Millisecond,
+				})
+				if r.Serial != "" {
+					h := sdr.Hint{
+						Serial:  r.Serial,
+						Role:    sdr.ParseRole(r.Role),
+						PPM:     r.PPM,
+						BiasTee: r.BiasTee,
+					}
+					if r.Gain != "" {
+						gain, ok := parseGain(r.Gain)
+						if !ok {
+							log.Warn("daemon: ignoring unparseable rtl_tcp gain",
+								"serial", r.Serial, "gain", r.Gain)
+						} else {
+							h = h.WithGain(gain)
+						}
+					}
+					hints = append(hints, h)
+				}
+			}
+			if len(rspecs) > 0 {
+				sdr.Register(rtltcp.New(rspecs, log))
+				log.Info("rtl_tcp endpoints mounted", "count", len(rspecs))
+			}
 		}
 		if err := d.pool.Open(cfg.SDR.SampleRate, hints); err != nil {
 			log.Warn("daemon: SDR pool open failed", "err", err)

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -172,6 +172,22 @@ sdr:
     #     - frequency_hz: 851_037_500
     #       system: "regional-dmr-t3"
 
+  # rtl_tcp remote SDRs. Each entry mounts a host:port rtl_tcp server
+  # as a virtual tuner alongside any local USB dongles. Use when the
+  # SDR hardware lives on a different host from the daemon (e.g. a
+  # Raspberry Pi at the antenna + a beefier box for decode). rtl_tcp
+  # is plaintext — keep it on trusted networks or behind an SSH /
+  # WireGuard tunnel.
+  #
+  # rtl_tcp:
+  #   - addr: "192.168.1.50:1234"
+  #     serial: "antenna-pi"   # generator fills this from addr if blank
+  #     role: control           # control | voice | auto
+  #     ppm: 0
+  #     gain: "auto"            # "auto" or tenths-of-dB ("496" = 49.6 dB)
+  #     bias_tee: false
+  #     connect_timeout_ms: 3000
+
 trunking:
   # call_timeout_ms: inactivity window after which the engine's
   # watchdog ends a call (publishes CallEnd with EndReasonTimeout

--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -20,6 +20,7 @@ transport (USBDEVFS on Linux, IOKit on macOS, WinUSB on Windows).
 | **HackRF One / Jawbreaker / Rad1o** | `hackrf` | `0x1d50:0x6089` · `0x1d50:0x604b` · `0x1d50:0xcc15` | Wire-protocol-complete; on-air validation against attached hardware is the documented follow-up. |
 | **Airspy R2 / Airspy Mini** | `airspy` | `0x1d50:0x60a1` | Wire-protocol-complete; on-air validation against attached hardware is the documented follow-up. |
 | **Airspy HF+ Discovery / HF+ Dual Port / legacy HF+** | `airspyhf` | `0x03eb:0x800c` | Wire-protocol-complete; HF (9 kHz – 31 MHz) + VHF (60 – 260 MHz). On-air validation against attached hardware is the documented follow-up. |
+| **rtl_tcp remote** (any librtlsdr-shipped server) | `rtltcp` | TCP | Remote RTL-SDR mounted over the network. See [Remote rtl_tcp SDRs](#remote-rtl_tcp-sdrs). |
 
 The HackRF and Airspy / Airspy HF+ drivers speak the documented
 libhackrf, libairspy, and libairspyhf USB vendor protocols directly
@@ -351,6 +352,56 @@ message that names the offending entry.
 - **CPU scales with channel count.** Eight DDC taps at 2.4 MS/s is a
   few percent of one modern x86 core; the polyphase mode lands lower
   at the same count.
+
+## Remote rtl_tcp SDRs
+
+`rtl_tcp` ships with librtlsdr and exposes a single RTL-SDR dongle
+over a TCP socket. GopherTrunk's `rtltcp` driver consumes the same
+wire protocol SDR++, Gqrx, and OpenWebRX speak, so any host with a
+USB-attached RTL-SDR can publish its radio to the daemon.
+
+Typical layout:
+
+- **Antenna host** (Raspberry Pi / Mac mini at the antenna, USB
+  range from the antenna minimised): run `rtl_tcp -a 0.0.0.0 -p 1234`
+  against the local dongle.
+- **Daemon host** (the box with CPU + storage for decode): list the
+  endpoint under `sdr.rtl_tcp` in `config.yaml`.
+
+```yaml
+sdr:
+  sample_rate: 2_400_000
+  rtl_tcp:
+    - addr: "192.168.1.50:1234"
+      serial: "antenna-pi"   # generator fills this from addr when blank
+      role: control           # control | voice | auto
+      ppm: 0
+      gain: "auto"            # "auto" or tenths-of-dB ("496" = 49.6 dB)
+      bias_tee: false
+      connect_timeout_ms: 3000
+```
+
+Each entry becomes a pool device alongside any local USB dongles —
+the engine roles them via the same hint matcher (`control` /
+`voice` / `auto`) and the broker / fan-out path is the same as
+local SDRs, so the live spectrum panel, baseband recorder, and CC
+decoder all work against remote sources.
+
+**Limitations:**
+
+- One client per `rtl_tcp` endpoint (the upstream protocol is
+  single-tuner).
+- Plaintext over TCP. Keep it on a trusted network, or tunnel it
+  through SSH / WireGuard / Tailscale before exposing it.
+- Bias-tee + advanced rtlsdr-only knobs (direct sampling, offset
+  tuning, IF gain) are wired through but rely on the remote
+  running librtlsdr ≥ 0.7. Servers that ignore those commands
+  silently no-op them.
+
+**Diagnostics:** the daemon logs `rtltcp: connected addr=... tuner=...`
+on each successful Open, `dial: connection refused` if the remote
+isn't listening, and `header magic = "..."` if the address points
+at something that isn't an `rtl_tcp` server.
 
 ## USB disconnect recovery
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -250,6 +250,14 @@ type MessageLogConfig struct {
 type SDRConfig struct {
 	SampleRate uint32         `yaml:"sample_rate"`
 	Devices    []DeviceConfig `yaml:"devices"`
+	// RTLTCP lists remote rtl_tcp endpoints (host:port + optional
+	// per-endpoint metadata) to mount as virtual tuners. Each entry
+	// becomes a pool device alongside any locally-attached USB
+	// dongles. Useful when the SDR hardware lives on a different
+	// host from the daemon (e.g. a Raspberry Pi by the antenna +
+	// a beefier machine for decode). rtl_tcp is plaintext — use it
+	// on trusted networks only or through an SSH/wireguard tunnel.
+	RTLTCP []RTLTCPConfig `yaml:"rtl_tcp"`
 	// WatchdogIntervalMs governs the periodic USB-disconnect
 	// watchdog that the SDR pool runs while the daemon is up. It
 	// polls the registered drivers, surfaces serials that vanish
@@ -262,6 +270,34 @@ type SDRConfig struct {
 	// In-stream IQ-death recovery (ccdecoder retry loop, voice
 	// Bind reacquire) is unaffected by this knob.
 	WatchdogIntervalMs int `yaml:"watchdog_interval_ms"`
+}
+
+// RTLTCPConfig describes one remote rtl_tcp endpoint to expose as
+// a virtual tuner. Addr is required; Serial / Role follow the same
+// semantics as the local SDR devices block.
+type RTLTCPConfig struct {
+	// Addr is the host:port pair the rtl_tcp server is listening
+	// on, e.g. "192.168.1.50:1234". Required.
+	Addr string `yaml:"addr"`
+	// Serial is the virtual device serial reported on the pool's
+	// /api/v1/devices snapshot. Empty generates one from Addr.
+	Serial string `yaml:"serial"`
+	// Role hints the pool's role assignment: control|voice|auto.
+	Role string `yaml:"role"`
+	// PPM is the frequency-correction tuning sent to the remote on
+	// open (the remote's local rtlsdr layer applies it). Optional;
+	// zero matches every TCXO-equipped dongle.
+	PPM int `yaml:"ppm"`
+	// Gain follows the same rule as DeviceConfig.Gain — "auto" /
+	// "" selects AGC, any other value parses as tenths of dB.
+	Gain string `yaml:"gain"`
+	// BiasTee toggles the remote dongle's 5 V bias-tee output.
+	// Honoured only by servers running librtlsdr ≥ 0.7; older
+	// servers silently ignore the command.
+	BiasTee bool `yaml:"bias_tee"`
+	// ConnectTimeoutMs caps the TCP dial in milliseconds. Zero
+	// picks the driver default (3000).
+	ConnectTimeoutMs int `yaml:"connect_timeout_ms"`
 }
 
 type DeviceConfig struct {
@@ -755,6 +791,28 @@ func (c Config) Validate() error {
 				i, d.Serial, prev)
 		}
 		seenSerials[d.Serial] = i
+	}
+	// Validate rtl_tcp endpoints. Addr is required; role must match
+	// the standard set; serial collisions with local devices are
+	// rejected for the same reason serial dedup runs above.
+	for i, r := range c.SDR.RTLTCP {
+		if r.Addr == "" {
+			return fmt.Errorf("sdr.rtl_tcp[%d]: addr is required (host:port)", i)
+		}
+		switch r.Role {
+		case "", "control", "voice", "auto":
+		default:
+			return fmt.Errorf("sdr.rtl_tcp[%d]: role must be control|voice|auto", i)
+		}
+		if r.Serial == "" {
+			continue
+		}
+		if prev, dup := seenSerials[r.Serial]; dup {
+			return fmt.Errorf(
+				"sdr.rtl_tcp[%d]: serial %q collides with sdr.devices[%d]",
+				i, r.Serial, prev)
+		}
+		seenSerials[r.Serial] = i
 	}
 	if c.Trunking.CallTimeoutMs < 0 {
 		return fmt.Errorf("trunking.call_timeout_ms: %d ms must be ≥ 0", c.Trunking.CallTimeoutMs)

--- a/internal/sdr/rtltcp/driver.go
+++ b/internal/sdr/rtltcp/driver.go
@@ -1,0 +1,399 @@
+// Package rtltcp implements an sdr.Driver that talks to a remote
+// rtl_tcp server. rtl_tcp ships with librtlsdr and exposes a single
+// RTL-SDR dongle over a TCP socket so a host with USB access can
+// share its radio with hosts on the network. SDR++, Gqrx, OpenWebRX,
+// and SDRangel all consume the same protocol — adding it here lets
+// GopherTrunk demodulate trunked systems from an SDR plugged into a
+// remote Raspberry Pi / NUC / VM host.
+//
+// Protocol summary (well-known, unencrypted, single-channel):
+//
+//   - Client opens a TCP connection.
+//   - Server sends a 12-byte header: 4-byte magic "RTL0", 4 bytes
+//     tuner-type (big-endian uint32), 4 bytes tuner gain-count
+//     (big-endian uint32).
+//   - Server then streams unsigned 8-bit IQ samples (interleaved
+//     I, Q, I, Q, ...). Each sample maps to complex64 via
+//     (b - 127.5) / 127.5, matching the local USB rtlsdr driver.
+//   - Client sends commands as 5-byte packets: 1-byte opcode +
+//     4-byte big-endian uint32 parameter. Setters send a command
+//     and immediately return; the server applies the change to its
+//     local dongle.
+//
+// The driver supports one remote per Spec; multiple Specs in one
+// config (each pointing at a different rtl_tcp host) become separate
+// pool entries that the engine roles via the usual control/voice
+// hinting.
+//
+// Limitations:
+//   - rtl_tcp is single-tuner. A single endpoint can host one client.
+//   - rtl_tcp is plaintext. Use it on trusted networks only or over
+//     an SSH/wireguard tunnel.
+//   - Bias-tee + advanced rtlsdr-only knobs (direct sampling, offset
+//     tuning, IF gain) are wired through the command channel but
+//     not exposed on sdr.Device for now; SetBiasTee operates if the
+//     remote runs librtlsdr >= 0.7.
+package rtltcp
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/sdr"
+)
+
+// DriverName is the sdr.Driver name registered with the pool.
+const DriverName = "rtltcp"
+
+// Magic is the four-byte "RTL0" tag that opens the server-sent
+// header.
+var Magic = [4]byte{'R', 'T', 'L', '0'}
+
+// Wire-level commands. Values match the librtlsdr rtl_tcp server.
+const (
+	cmdSetFreq         uint8 = 0x01
+	cmdSetSampleRate   uint8 = 0x02
+	cmdSetGainMode     uint8 = 0x03
+	cmdSetGain         uint8 = 0x04
+	cmdSetFreqCorrPPM  uint8 = 0x05
+	cmdSetIFGain       uint8 = 0x06
+	cmdSetTestMode     uint8 = 0x07
+	cmdSetAGCMode      uint8 = 0x08
+	cmdSetDirectSamp   uint8 = 0x09
+	cmdSetOffsetTuning uint8 = 0x0a
+	cmdSetRTLXtal      uint8 = 0x0b
+	cmdSetTunerXtal    uint8 = 0x0c
+	cmdSetGainByIndex  uint8 = 0x0d
+	cmdSetBiasTee      uint8 = 0x0e
+)
+
+// DefaultConnectTimeout caps the TCP dial used in Open and Enumerate.
+// rtl_tcp servers typically live on the same LAN; if the dial blocks
+// past this bound, the operator probably has the wrong host:port
+// configured and a fast failure is more useful than a hang.
+const DefaultConnectTimeout = 3 * time.Second
+
+// Spec names one rtl_tcp endpoint to expose as a virtual tuner.
+type Spec struct {
+	// Addr is the host:port pair the rtl_tcp server is listening on,
+	// e.g. "192.168.1.50:1234". Required.
+	Addr string
+	// Serial is the virtual device serial the pool reports. Empty
+	// generates one from Addr so multi-endpoint configs stay unique.
+	Serial string
+	// Role hints the pool's role assignment: "control" | "voice" |
+	// "auto". Honoured by the pool's hint matcher.
+	Role string
+	// ConnectTimeout overrides DefaultConnectTimeout when non-zero.
+	ConnectTimeout time.Duration
+}
+
+// Driver implements sdr.Driver. Construct it from config (see the
+// daemon's wiring) and register with sdr.Register before Pool.Open.
+type Driver struct {
+	specs []Spec
+	log   *slog.Logger
+}
+
+// New builds a Driver over the given endpoints.
+func New(specs []Spec, log *slog.Logger) *Driver {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &Driver{specs: specs, log: log}
+}
+
+// Name implements sdr.Driver.
+func (d *Driver) Name() string { return DriverName }
+
+// Enumerate returns one Info per configured endpoint. The driver does
+// NOT probe each server at enumeration time — a remote that's
+// temporarily down would otherwise vanish from the pool until the
+// next restart. Open is the place errors surface.
+func (d *Driver) Enumerate() ([]sdr.Info, error) {
+	out := make([]sdr.Info, 0, len(d.specs))
+	for i, spec := range d.specs {
+		if spec.Addr == "" {
+			continue
+		}
+		out = append(out, sdr.Info{
+			Driver:    DriverName,
+			Index:     i,
+			Serial:    serialFor(spec, i),
+			Product:   "rtl_tcp remote",
+			TunerName: "rtl_tcp",
+			Gains:     standardGainLadder(),
+		})
+	}
+	return out, nil
+}
+
+// Open dials the rtl_tcp server at spec[idx] and returns a Device
+// ready for setters and StreamIQ. The 12-byte header is consumed
+// here; subsequent reads from the connection yield IQ bytes.
+func (d *Driver) Open(idx int) (sdr.Device, error) {
+	if idx < 0 || idx >= len(d.specs) {
+		return nil, fmt.Errorf("rtltcp: index %d out of range", idx)
+	}
+	spec := d.specs[idx]
+	if spec.Addr == "" {
+		return nil, errors.New("rtltcp: spec missing Addr")
+	}
+	timeout := spec.ConnectTimeout
+	if timeout <= 0 {
+		timeout = DefaultConnectTimeout
+	}
+
+	conn, err := net.DialTimeout("tcp", spec.Addr, timeout)
+	if err != nil {
+		return nil, fmt.Errorf("rtltcp: dial %s: %w", spec.Addr, err)
+	}
+	if err := conn.SetReadDeadline(time.Now().Add(timeout)); err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("rtltcp: set read deadline: %w", err)
+	}
+	var hdr [12]byte
+	if _, err := io.ReadFull(conn, hdr[:]); err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("rtltcp: read header: %w", err)
+	}
+	// Validate magic — guards against connecting to a non-rtl_tcp
+	// service on the same port (HTTP server, SSH banner, etc.).
+	if hdr[0] != Magic[0] || hdr[1] != Magic[1] || hdr[2] != Magic[2] || hdr[3] != Magic[3] {
+		conn.Close()
+		return nil, fmt.Errorf("rtltcp: %s: server header magic = %q, want %q", spec.Addr, hdr[:4], Magic[:])
+	}
+	tunerType := binary.BigEndian.Uint32(hdr[4:8])
+	gainCount := binary.BigEndian.Uint32(hdr[8:12])
+	// Clear the read deadline so StreamIQ blocks normally.
+	_ = conn.SetReadDeadline(time.Time{})
+
+	info := sdr.Info{
+		Driver:    DriverName,
+		Index:     idx,
+		Serial:    serialFor(spec, idx),
+		Product:   "rtl_tcp remote",
+		TunerName: tunerName(tunerType),
+		Gains:     standardGainLadder(),
+	}
+	d.log.Info("rtltcp: connected",
+		"addr", spec.Addr,
+		"tuner", info.TunerName,
+		"gain_count", gainCount)
+	return &device{
+		addr: spec.Addr,
+		conn: conn,
+		info: info,
+		log:  d.log,
+	}, nil
+}
+
+// device implements sdr.Device on top of an open rtl_tcp connection.
+type device struct {
+	addr string
+	info sdr.Info
+	log  *slog.Logger
+
+	mu     sync.Mutex
+	conn   net.Conn
+	closed bool
+}
+
+func (d *device) Info() sdr.Info { return d.info }
+
+func (d *device) SetCenterFreq(hz uint32) error { return d.sendCmd(cmdSetFreq, hz) }
+func (d *device) SetSampleRate(hz uint32) error { return d.sendCmd(cmdSetSampleRate, hz) }
+
+func (d *device) SetGain(tenthDB int) error {
+	if tenthDB < 0 {
+		// Negative = AGC: enable gain mode auto (mode 0).
+		return d.sendCmd(cmdSetGainMode, 0)
+	}
+	// Manual gain mode then the absolute gain value.
+	if err := d.sendCmd(cmdSetGainMode, 1); err != nil {
+		return err
+	}
+	return d.sendCmd(cmdSetGain, uint32(tenthDB))
+}
+
+func (d *device) SetPPM(ppm int) error {
+	return d.sendCmd(cmdSetFreqCorrPPM, uint32(int32(ppm)))
+}
+
+func (d *device) SetBiasTee(enable bool) error {
+	var v uint32
+	if enable {
+		v = 1
+	}
+	return d.sendCmd(cmdSetBiasTee, v)
+}
+
+// sendCmd writes one 5-byte command packet on the control side of
+// the rtl_tcp socket. The same socket carries IQ in the other
+// direction; rtl_tcp's protocol relies on the server reading commands
+// out-of-band while writing IQ continuously, which net.Conn supports
+// over the full-duplex TCP connection.
+func (d *device) sendCmd(op uint8, param uint32) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.closed || d.conn == nil {
+		return errors.New("rtltcp: device closed")
+	}
+	var pkt [5]byte
+	pkt[0] = op
+	binary.BigEndian.PutUint32(pkt[1:], param)
+	_ = d.conn.SetWriteDeadline(time.Now().Add(2 * time.Second))
+	if _, err := d.conn.Write(pkt[:]); err != nil {
+		return fmt.Errorf("rtltcp: send cmd 0x%02x: %w", op, err)
+	}
+	_ = d.conn.SetWriteDeadline(time.Time{})
+	return nil
+}
+
+func (d *device) Close() error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.closed {
+		return nil
+	}
+	d.closed = true
+	if d.conn != nil {
+		return d.conn.Close()
+	}
+	return nil
+}
+
+// StreamIQ reads u8 IQ bytes from the rtl_tcp socket and emits
+// complex64 chunks. Chunks are sized at chunkSamples samples (i.e.
+// 2*chunkSamples bytes). Returns a channel that closes when the
+// context cancels or the socket closes.
+func (d *device) StreamIQ(ctx context.Context) (<-chan []complex64, error) {
+	d.mu.Lock()
+	if d.closed || d.conn == nil {
+		d.mu.Unlock()
+		return nil, errors.New("rtltcp: device closed")
+	}
+	conn := d.conn
+	d.mu.Unlock()
+
+	const chunkSamples = 8192
+	out := make(chan []complex64, 8)
+
+	go func() {
+		defer close(out)
+		buf := make([]byte, chunkSamples*2)
+		for {
+			// Allow ctx to interrupt a stalled read.
+			if dl, ok := ctx.Deadline(); ok {
+				_ = conn.SetReadDeadline(dl)
+			}
+			// Use a long deadline so a wedged server can be torn down by
+			// ctx cancel without blocking forever; ctx.Done is checked
+			// after every read.
+			_ = conn.SetReadDeadline(time.Now().Add(30 * time.Second))
+			n, err := io.ReadFull(conn, buf)
+			if err != nil {
+				if !errors.Is(err, io.EOF) && !errors.Is(err, io.ErrUnexpectedEOF) {
+					d.log.Debug("rtltcp: stream read", "addr", d.addr, "err", err)
+				}
+				if n == 0 {
+					return
+				}
+				// Fall through to emit the partial chunk so subscribers
+				// see what arrived before the EOF.
+			}
+			if n > 0 {
+				samples := convertU8(buf[:n])
+				select {
+				case <-ctx.Done():
+					return
+				case out <- samples:
+				}
+			}
+			if err != nil {
+				return
+			}
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+		}
+	}()
+	return out, nil
+}
+
+// convertU8 maps interleaved u8 I,Q,I,Q bytes to complex64 in [-1, 1].
+// Mirrors the rtlsdr/purego driver's convertU8IQ so frames coming off
+// a remote rtl_tcp look identical to frames from a local USB dongle.
+func convertU8(buf []byte) []complex64 {
+	n := len(buf) / 2
+	out := make([]complex64, n)
+	for i := 0; i < n; i++ {
+		iv := float32(buf[2*i]) - 127.5
+		qv := float32(buf[2*i+1]) - 127.5
+		out[i] = complex(iv/127.5, qv/127.5)
+	}
+	return out
+}
+
+func serialFor(spec Spec, idx int) string {
+	if spec.Serial != "" {
+		return spec.Serial
+	}
+	return fmt.Sprintf("rtltcp-%s-%02d", sanitizeAddr(spec.Addr), idx)
+}
+
+func sanitizeAddr(addr string) string {
+	out := make([]byte, 0, len(addr))
+	for i := 0; i < len(addr); i++ {
+		c := addr[i]
+		switch {
+		case c >= 'a' && c <= 'z', c >= 'A' && c <= 'Z', c >= '0' && c <= '9':
+			out = append(out, c)
+		case c == '-' || c == '_':
+			out = append(out, c)
+		default:
+			out = append(out, '_')
+		}
+	}
+	return string(out)
+}
+
+// tunerName decodes the 4-byte tuner-type field from the rtl_tcp
+// header into the librtlsdr-style label.
+func tunerName(code uint32) string {
+	switch code {
+	case 0:
+		return "unknown"
+	case 1:
+		return "E4000"
+	case 2:
+		return "FC0012"
+	case 3:
+		return "FC0013"
+	case 4:
+		return "FC2580"
+	case 5:
+		return "R820T"
+	case 6:
+		return "R828D"
+	default:
+		return fmt.Sprintf("tuner-%d", code)
+	}
+}
+
+// standardGainLadder returns the R820T2 gain ladder librtlsdr exposes
+// over rtl_tcp. Servers running older librtlsdr or non-R820T2 tuners
+// silently quantize gain values to whatever their hardware supports;
+// the wire protocol carries the raw tenths-of-dB value.
+func standardGainLadder() []int {
+	return []int{0, 9, 14, 27, 37, 77, 87, 125, 144, 157, 166, 197, 207, 229, 254, 280, 297, 328, 338, 364, 372, 386, 402, 421, 434, 439, 445, 480, 496}
+}

--- a/internal/sdr/rtltcp/driver_test.go
+++ b/internal/sdr/rtltcp/driver_test.go
@@ -1,0 +1,449 @@
+package rtltcp
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"io"
+	"net"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// fakeServer mimics a librtlsdr rtl_tcp server: sends the 12-byte
+// magic header on Accept, streams whatever IQ bytes the test feeds
+// onto Feed, and records every 5-byte command packet the client
+// sends so tests can assert SetCenterFreq / SetGain etc.
+type fakeServer struct {
+	t  *testing.T
+	ln net.Listener
+
+	mu   sync.Mutex
+	cmds []cmdRecord
+	feed chan []byte
+	conn net.Conn
+
+	tunerType uint32
+	gainCount uint32
+}
+
+type cmdRecord struct {
+	Op    uint8
+	Param uint32
+}
+
+func newFakeServer(t *testing.T) *fakeServer {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	s := &fakeServer{
+		t:         t,
+		ln:        ln,
+		feed:      make(chan []byte, 64),
+		tunerType: 5, // R820T
+		gainCount: 29,
+	}
+	go s.run()
+	t.Cleanup(s.close)
+	return s
+}
+
+func (s *fakeServer) Addr() string { return s.ln.Addr().String() }
+
+func (s *fakeServer) Feed(b []byte) {
+	s.feed <- b
+}
+
+func (s *fakeServer) Commands() []cmdRecord {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]cmdRecord, len(s.cmds))
+	copy(out, s.cmds)
+	return out
+}
+
+func (s *fakeServer) close() {
+	_ = s.ln.Close()
+	s.mu.Lock()
+	if s.conn != nil {
+		_ = s.conn.Close()
+	}
+	s.mu.Unlock()
+}
+
+func (s *fakeServer) run() {
+	conn, err := s.ln.Accept()
+	if err != nil {
+		return
+	}
+	s.mu.Lock()
+	s.conn = conn
+	s.mu.Unlock()
+
+	// Send the 12-byte header.
+	var hdr [12]byte
+	copy(hdr[:4], Magic[:])
+	binary.BigEndian.PutUint32(hdr[4:8], s.tunerType)
+	binary.BigEndian.PutUint32(hdr[8:12], s.gainCount)
+	if _, err := conn.Write(hdr[:]); err != nil {
+		return
+	}
+
+	// Reader goroutine: log every 5-byte command the client sends.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		buf := make([]byte, 5)
+		for {
+			if _, err := io.ReadFull(conn, buf); err != nil {
+				return
+			}
+			s.mu.Lock()
+			s.cmds = append(s.cmds, cmdRecord{
+				Op:    buf[0],
+				Param: binary.BigEndian.Uint32(buf[1:]),
+			})
+			s.mu.Unlock()
+		}
+	}()
+
+	// Writer loop: drain fed IQ onto the wire.
+	for {
+		select {
+		case <-done:
+			return
+		case body, ok := <-s.feed:
+			if !ok {
+				_ = conn.Close()
+				return
+			}
+			if _, err := conn.Write(body); err != nil {
+				return
+			}
+		}
+	}
+}
+
+func newDriver(t *testing.T, addr string) *Driver {
+	t.Helper()
+	return New([]Spec{{Addr: addr, Serial: "test-remote"}}, nil)
+}
+
+func TestEnumerateReportsConfiguredSpecs(t *testing.T) {
+	d := New([]Spec{
+		{Addr: "10.0.0.5:1234"},
+		{Addr: "10.0.0.6:1234", Serial: "kitchen-pi"},
+		{Addr: "", Serial: "skip-empty-addr"}, // skipped
+	}, nil)
+	infos, err := d.Enumerate()
+	if err != nil {
+		t.Fatalf("Enumerate: %v", err)
+	}
+	if len(infos) != 2 {
+		t.Fatalf("len(infos) = %d, want 2", len(infos))
+	}
+	if infos[1].Serial != "kitchen-pi" {
+		t.Errorf("infos[1].Serial = %q, want kitchen-pi", infos[1].Serial)
+	}
+	if infos[0].Serial == "" {
+		t.Error("infos[0].Serial is empty — generator should have filled it")
+	}
+	if infos[0].Driver != DriverName {
+		t.Errorf("infos[0].Driver = %q, want %q", infos[0].Driver, DriverName)
+	}
+}
+
+func TestOpenAndCloseAgainstFakeServer(t *testing.T) {
+	srv := newFakeServer(t)
+
+	d := newDriver(t, srv.Addr())
+	dev, err := d.Open(0)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if dev.Info().Serial != "test-remote" {
+		t.Errorf("Info().Serial = %q", dev.Info().Serial)
+	}
+	if dev.Info().TunerName != "R820T" {
+		t.Errorf("Info().TunerName = %q, want R820T", dev.Info().TunerName)
+	}
+	if err := dev.Close(); err != nil {
+		t.Errorf("Close: %v", err)
+	}
+}
+
+func TestOpenRejectsNonMagicServer(t *testing.T) {
+	// A listener that immediately writes 12 bogus bytes.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	defer ln.Close()
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		_, _ = conn.Write([]byte("HTTP/1.1 200")) // 12 bytes
+	}()
+
+	d := newDriver(t, ln.Addr().String())
+	_, err = d.Open(0)
+	if err == nil {
+		t.Fatal("Open against bogus server: want error, got nil")
+	}
+	if !errInString(err, "magic") {
+		t.Errorf("Open err = %v, want a magic-mismatch error", err)
+	}
+}
+
+func TestOpenDialTimeout(t *testing.T) {
+	// 192.0.2.0/24 is reserved for documentation (RFC 5737) and
+	// reliably non-routable, so the dial hangs until we cap it.
+	d := New([]Spec{{
+		Addr:           "192.0.2.1:1234",
+		ConnectTimeout: 200 * time.Millisecond,
+	}}, nil)
+	start := time.Now()
+	_, err := d.Open(0)
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("Open of unroutable address: want error, got nil")
+	}
+	if elapsed > 2*time.Second {
+		t.Errorf("Open took %v, expected ≤ 2s thanks to ConnectTimeout", elapsed)
+	}
+}
+
+func TestCommandsAreEncodedCorrectly(t *testing.T) {
+	srv := newFakeServer(t)
+	d := newDriver(t, srv.Addr())
+	dev, err := d.Open(0)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer dev.Close()
+
+	if err := dev.SetCenterFreq(851_012_500); err != nil {
+		t.Fatalf("SetCenterFreq: %v", err)
+	}
+	if err := dev.SetSampleRate(2_048_000); err != nil {
+		t.Fatalf("SetSampleRate: %v", err)
+	}
+	if err := dev.SetGain(496); err != nil {
+		t.Fatalf("SetGain(manual): %v", err)
+	}
+	if err := dev.SetGain(-1); err != nil {
+		t.Fatalf("SetGain(auto): %v", err)
+	}
+	if err := dev.SetPPM(42); err != nil {
+		t.Fatalf("SetPPM: %v", err)
+	}
+	if err := dev.SetBiasTee(true); err != nil {
+		t.Fatalf("SetBiasTee: %v", err)
+	}
+
+	// Allow the reader goroutine to drain.
+	waitFor(t, 500*time.Millisecond, func() bool {
+		return len(srv.Commands()) >= 8
+	})
+
+	want := []cmdRecord{
+		{cmdSetFreq, 851_012_500},
+		{cmdSetSampleRate, 2_048_000},
+		{cmdSetGainMode, 1}, // manual mode preamble
+		{cmdSetGain, 496},   // gain value
+		{cmdSetGainMode, 0}, // auto
+		{cmdSetFreqCorrPPM, uint32(int32(42))},
+		{cmdSetBiasTee, 1},
+	}
+	got := srv.Commands()
+	if len(got) < len(want) {
+		t.Fatalf("got %d commands, want at least %d (%+v)", len(got), len(want), got)
+	}
+	for i, w := range want {
+		if got[i] != w {
+			t.Errorf("cmd[%d] = %+v, want %+v", i, got[i], w)
+		}
+	}
+}
+
+func TestStreamIQDeliversConvertedSamples(t *testing.T) {
+	srv := newFakeServer(t)
+	d := newDriver(t, srv.Addr())
+	dev, err := d.Open(0)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer dev.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ch, err := dev.StreamIQ(ctx)
+	if err != nil {
+		t.Fatalf("StreamIQ: %v", err)
+	}
+
+	// Feed one chunk's worth of zero-IQ bytes (127, 128 = ~DC, the
+	// midpoint of the u8 range).
+	const chunkSamples = 8192
+	body := make([]byte, chunkSamples*2)
+	for i := 0; i < chunkSamples; i++ {
+		body[2*i] = 127
+		body[2*i+1] = 128
+	}
+	srv.Feed(body)
+
+	select {
+	case samples, ok := <-ch:
+		if !ok {
+			t.Fatal("stream closed before sample arrived")
+		}
+		if len(samples) != chunkSamples {
+			t.Errorf("samples len = %d, want %d", len(samples), chunkSamples)
+		}
+		// 127 → -0.5/127.5 ≈ -0.00392; 128 → 0.5/127.5 ≈ +0.00392.
+		// Both well below 0.01 — the DC-midpoint sanity bound.
+		got := samples[0]
+		if absF(real(got)) > 0.01 || absF(imag(got)) > 0.01 {
+			t.Errorf("DC-midpoint sample = %v, want |re|,|im| ≤ 0.01", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("no samples received within 2s")
+	}
+}
+
+func TestStreamIQEndsOnServerClose(t *testing.T) {
+	srv := newFakeServer(t)
+	d := newDriver(t, srv.Addr())
+	dev, err := d.Open(0)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer dev.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ch, err := dev.StreamIQ(ctx)
+	if err != nil {
+		t.Fatalf("StreamIQ: %v", err)
+	}
+
+	// Close the server end without sending any IQ; the stream
+	// goroutine must drain and close out.
+	srv.close()
+
+	gotClose := false
+	var received atomic.Int32
+	deadline := time.After(2 * time.Second)
+loop:
+	for {
+		select {
+		case _, ok := <-ch:
+			if !ok {
+				gotClose = true
+				break loop
+			}
+			received.Add(1)
+		case <-deadline:
+			break loop
+		}
+	}
+	if !gotClose {
+		t.Errorf("stream channel did not close after server hang-up (received %d chunks)", received.Load())
+	}
+}
+
+func TestSetterAfterCloseFailsCleanly(t *testing.T) {
+	srv := newFakeServer(t)
+	d := newDriver(t, srv.Addr())
+	dev, err := d.Open(0)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if err := dev.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if err := dev.SetCenterFreq(100_000_000); err == nil {
+		t.Error("SetCenterFreq after Close: want error, got nil")
+	}
+}
+
+func TestSerialDefaultsAreUniqueAcrossSpecs(t *testing.T) {
+	d := New([]Spec{
+		{Addr: "10.0.0.1:1234"},
+		{Addr: "10.0.0.2:1234"},
+	}, nil)
+	infos, _ := d.Enumerate()
+	if infos[0].Serial == infos[1].Serial {
+		t.Errorf("auto-serials collided: %q == %q", infos[0].Serial, infos[1].Serial)
+	}
+}
+
+// waitFor polls cond up to d. Helper for fakeServer command reads
+// arriving on a background goroutine.
+func waitFor(t *testing.T, d time.Duration, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(d)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+func absF(x float32) float32 {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func errInString(err error, sub string) bool {
+	if err == nil {
+		return false
+	}
+	for {
+		if containsCI(err.Error(), sub) {
+			return true
+		}
+		next := errors.Unwrap(err)
+		if next == nil {
+			return false
+		}
+		err = next
+	}
+}
+
+func containsCI(s, sub string) bool {
+	if len(sub) == 0 {
+		return true
+	}
+	for i := 0; i+len(sub) <= len(s); i++ {
+		match := true
+		for j := 0; j < len(sub); j++ {
+			a := s[i+j]
+			b := sub[j]
+			if a >= 'A' && a <= 'Z' {
+				a += 'a' - 'A'
+			}
+			if b >= 'A' && b <= 'Z' {
+				b += 'a' - 'A'
+			}
+			if a != b {
+				match = false
+				break
+			}
+		}
+		if match {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

Adds a pure-Go `rtltcp` driver so GopherTrunk can mount any number of remote `rtl_tcp` servers as virtual tuners alongside locally-attached USB dongles. Lets the SDR live at the antenna (Raspberry Pi, etc.) while the daemon runs on a beefier host — same wire protocol SDR++, Gqrx, and OpenWebRX already consume.

This is the next slice of the trunking-adjacent feature plan from #365 (Phase 2c — small, self-contained, immediately useful).

## What's in the box

- **`internal/sdr/rtltcp/`** — `Driver` + `Device` implementing the documented `rtl_tcp` wire protocol:
  - 12-byte `RTL0` magic header parsed on connect (rejects wrong-port mistakes)
  - u8 IQ stream converted to `complex64` via the same `(b-127.5)/127.5` mapping the local USB driver uses
  - 5-byte command packets for `SetCenterFreq` / `SetSampleRate` / `SetGain` (auto + manual) / `SetPPM` / `SetBiasTee`
  - `ConnectTimeout` so a downed remote fails fast instead of blocking daemon startup
- **`internal/config/config.go`** — new `sdr.rtl_tcp` YAML section (addr, serial, role, ppm, gain, bias_tee, connect_timeout_ms) + `Validate` coverage for addr-required, role allow-list, and serial-collision with local `sdr.devices`
- **`cmd/gophertrunk/daemon.go`** — registers the driver before `pool.Open` when entries exist; per-endpoint `sdr.Hint` carries role/ppm/gain/bias-tee through the existing hint matcher so remote SDRs participate in pool-role assignment exactly like local ones
- **9 driver tests** covering: enumeration with mixed specs, magic-byte rejection, dial timeout against a non-routable IP, full per-opcode command encoding, u8→complex64 conversion, stream teardown on server hang-up, setter-after-close safety, and unique auto-generated serials across multi-endpoint configs. Tests use an in-process fake `rtl_tcp` server.

## Compatibility with existing features

The new driver plugs in at the `sdr.Device` interface, so every existing consumer works against remote SDRs without changes:

- iqtap broker fan-out (#365) — `/spectrum` panel works against a remote SDR
- Baseband recorder — captures IQ from a remote dongle
- CC decoder + cchunt supervisor — control-channel decode works over the wire
- Conventional scanner, composer, etc.

## Docs

- `config.example.yaml` — new commented `sdr.rtl_tcp` block with a realistic example
- `docs/hardware.md` — new "Remote rtl_tcp SDRs" section covering antenna/decode-host split, security caveats (plaintext — tunnel or trust the network), per-knob meaning, and diagnostic log messages
- `README.md` — "Remote rtl_tcp SDRs" bullet under Features
- `CHANGELOG.md` — entry under [Unreleased] → Added

## Test plan

- [x] `go test ./internal/sdr/rtltcp/...` — 9 tests pass
- [x] `go test ./...` — full suite (83 packages) green
- [x] `go vet ./...` clean
- [x] `gofmt -l .` clean
- [x] `make build` succeeds
- [ ] Smoke test against a real `rtl_tcp -a 0.0.0.0 -p 1234` on another host (deferred to hardware-on-hand validation; the fake server in tests exercises the same wire protocol bytes the real server emits)

## Security note

`rtl_tcp` is plaintext on the wire — both the IQ stream and the command channel. Documentation calls this out and recommends tunnelling through SSH / WireGuard / Tailscale before exposing it on anything beyond a trusted LAN.

https://claude.ai/code/session_01YUgvat8WpF5YaSuEAqWMr2

---
_Generated by [Claude Code](https://claude.ai/code/session_01YUgvat8WpF5YaSuEAqWMr2)_