### PR TITLE
cc-activity: add CC chatter panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ for tagged releases.
 
 ### Added
 
+- **CC Activity panel.** New web panel at `/cc` that filters the
+  events stream down to control-channel chatter: voice grants,
+  affiliations, registrations, patches / dynamic regroups, talker
+  aliases, CC lock / loss, and call start/end. Per-row rendering
+  pulls the right detail out of each payload (talkgroup + source
+  + frequency + tags for grants, member count for patches,
+  response codes for affiliations, the alias string for talker
+  aliases). Kind + system substring filters narrow the view; a
+  pause button freezes the display without disconnecting the
+  bus. Pure filter view over events already on the bus — no new
+  bus kinds or storage.
 - **Bookmarks / frequency manager.** UI-managed conventional
   channel list (marine VHF, NOAA weather, FRS/GMRS, repeater
   outputs, public-safety conventional fall-backs) backed by a new

--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ Silicon and Intel. Full per-OS recipes at
   trunking-adjacent decoders (paging, AIS, ADS-B, ...) tap the
   same source without disturbing CC decode. `GET /api/v1/spectrum/devices`
   + `WS /api/v1/spectrum/stream`; web panel under `/spectrum`.
+- **CC Activity panel** — focused web view of the trunked control-
+  channel chatter (grants, affiliations, registrations, patches,
+  talker aliases, CC lock / loss). Pure filter over the events
+  stream with per-row payload rendering; web panel at `/cc`.
 - **Bookmarks / frequency manager** — UI-managed conventional
   channel list (marine VHF, NOAA weather, FRS/GMRS, repeater
   outputs, public-safety fall-back channels) stored in the

--- a/docs/_data/nav.yml
+++ b/docs/_data/nav.yml
@@ -31,6 +31,8 @@ groups:
         url: /import.html
       - title: Bookmarks
         url: /bookmarks.html
+      - title: CC Activity
+        url: /cc-activity.html
       - title: rigctld integration
         url: /rigctld.html
       - title: Hardening

--- a/docs/cc-activity.md
+++ b/docs/cc-activity.md
@@ -1,0 +1,84 @@
+---
+layout: page
+title: CC Activity panel
+description: Live filter view of the trunked control-channel chatter — grants, affiliations, patches, talker aliases
+nav_group: Operate
+---
+
+# CC Activity panel
+
+GopherTrunk's web console has a **CC Activity** panel (web `/cc`)
+that filters the events stream down to the chatter you actually
+want to watch live while a trunked system is being decoded:
+
+- **Voice grants** — talkgroup, source radio, frequency, tags (ENC,
+  EMERG, DATA)
+- **Affiliations** — radio → talkgroup with the response code
+- **Registrations** — unit registration / deregistration with the
+  response code
+- **Patches / dynamic regroups** — the super-group plus member
+  count, "add" vs "cancel" verb
+- **Talker aliases** — the decoded display-name string per radio
+  ID
+- **CC lock / loss** — control-channel acquisition + recovery
+- **Call start / end** — actively-decoded voice transitions
+
+Everything here is already on the events bus today; the panel is a
+focused filter view, not a separate subscriber.
+
+## Use cases
+
+- **Onboarding a new system.** Watch the chatter for 30 s and you
+  see which talkgroups are active, who's talking to who, whether
+  encryption is in use, what the patch / regroup patterns look
+  like. Far easier than parsing the raw event log.
+- **Coverage debug.** Watch the CC lock / loss markers correlated
+  against `grant` flow — if grants pause and a `cc.lost` lands
+  followed by `cc.locked` on a different frequency, you have a
+  simulcast / coverage handoff and can plan an antenna change.
+- **Patch tracking.** Patches and dynamic regroups are easy to
+  miss in the raw event firehose; the panel surfaces them with
+  super-group and member counts so you can spot when an incident
+  patches multiple groups together.
+
+## Filters
+
+- **Kind** — show only one kind of event (Grant / Affiliation /
+  Patch / ...). Set to "All kinds" for everything.
+- **System** — substring match against the event's `system`
+  field. Useful when more than one trunked system is configured.
+- **Pause** — freezes the displayed rows; events keep arriving on
+  the bus so when you resume you catch up to the latest state.
+  Doesn't disconnect SSE.
+
+## What's not here
+
+- **Per-call audio playback.** That lives on the Active panel
+  with its own audio player.
+- **TSBK / CSBK / OSW raw PDU view.** The CC Activity panel shows
+  the *decoded* control-channel chatter (the events the engine
+  publishes after the FEC chain has succeeded). A raw-PDU view —
+  the bit-level inspector for debugging a misbehaving decoder —
+  is a separate follow-up; it would need every per-protocol
+  pipeline to publish PDU events on the bus and surface them
+  through a developer-mode panel.
+
+## Implementation notes
+
+The panel is pure web — no daemon changes. It reads the rolling
+events buffer the shared store maintains (capped at the SSE
+consumer's defaults), filters by kind, and renders one row per
+matching event with payload-specific formatting:
+
+| Event kind | Row "Details" column |
+| --- | --- |
+| `grant` / `call.start` | `TG <id> ← <src> @ <freq> MHz · <protocol> · [tags]` |
+| `call.end` | `TG <id> · <reason>` |
+| `affiliation` / `registration` | `radio <id> → TG <id> · resp <code>` |
+| `patch` | `super-group <id> · <N> members · add/cancel` |
+| `talker.alias` | `radio <id>: "<alias>"` |
+| `cc.locked` / `cc.lost` | `@ <freq> MHz` |
+
+When more event payload shapes land (e.g. encryption metadata
+arrives mid-call via `call.encryption`), extending the panel is a
+matter of adding a switch arm in `CCActivity.tsx`'s `renderRow`.

--- a/web/src/App.panels.test.tsx
+++ b/web/src/App.panels.test.tsx
@@ -145,6 +145,7 @@ const ROUTES = [
   "/talkgroups",
   "/history",
   "/events",
+  "/cc",
   "/tones",
   "/metrics",
   "/devices",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -8,6 +8,7 @@ import { AudioPlayer } from "./components/AudioPlayer";
 import { InstallPrompt } from "./components/InstallPrompt";
 import { Active } from "./panels/Active";
 import { Bookmarks } from "./panels/Bookmarks";
+import { CCActivity } from "./panels/CCActivity";
 import { Dashboard } from "./panels/Dashboard";
 import { Devices } from "./panels/Devices";
 import { Events } from "./panels/Events";
@@ -33,6 +34,7 @@ const EXTRA_TABS: Tab[] = [
   { to: "/talkgroups", label: "Talkgroups", icon: "☷" },
   { to: "/history", label: "History", icon: "↺" },
   { to: "/events", label: "Events", icon: "≣" },
+  { to: "/cc", label: "CC Activity", icon: "⌁" },
   { to: "/tones", label: "Tones", icon: "♪" },
   { to: "/spectrum", label: "Spectrum", icon: "≈" },
   { to: "/bookmarks", label: "Bookmarks", icon: "★" },
@@ -139,6 +141,7 @@ export function App() {
           <Route path="/talkgroups" element={<Talkgroups />} />
           <Route path="/history" element={<History />} />
           <Route path="/events" element={<Events />} />
+          <Route path="/cc" element={<CCActivity />} />
           <Route path="/tones" element={<Tones />} />
           <Route path="/metrics" element={<Metrics />} />
           <Route path="/devices" element={<Devices />} />

--- a/web/src/panels/CCActivity.test.tsx
+++ b/web/src/panels/CCActivity.test.tsx
@@ -1,0 +1,184 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { useShared } from "../store/shared";
+import type { EventDTO } from "../api/types";
+import { CCActivity } from "./CCActivity";
+
+function setEvents(events: EventDTO[]) {
+  useShared.setState({
+    serverURL: "http://localhost:8080",
+    token: null,
+    connected: true,
+    wsStatus: "idle",
+    mutations: null,
+    lastError: null,
+    events,
+    activeCalls: [],
+    devices: [],
+    systems: [],
+    talkgroups: [],
+    health: null,
+    audio: null,
+    scanner: null,
+  });
+}
+
+describe("CCActivity panel", () => {
+  beforeEach(() => {
+    setEvents([]);
+  });
+
+  it("renders the empty state when no CC events are in the store", () => {
+    render(<CCActivity />);
+    expect(screen.getByText(/Nothing here yet/)).toBeInTheDocument();
+  });
+
+  it("ignores non-CC events (silence on unrelated kinds)", () => {
+    setEvents([
+      {
+        kind: "tone.alert",
+        timestamp: "2026-05-26T12:00:00Z",
+        payload: { profile: "knox" },
+      },
+      {
+        kind: "sdr.attached",
+        timestamp: "2026-05-26T12:00:00Z",
+        payload: { serial: "rtl-1" },
+      },
+    ]);
+    render(<CCActivity />);
+    expect(screen.getByText(/Nothing here yet/)).toBeInTheDocument();
+  });
+
+  it("renders grant events with talkgroup and frequency", () => {
+    setEvents([
+      {
+        kind: "grant",
+        timestamp: "2026-05-26T12:34:56Z",
+        payload: {
+          system: "Metro P25",
+          protocol: "p25",
+          group_id: 1234,
+          source_id: 5678,
+          frequency_hz: 851_012_500,
+          emergency: true,
+        },
+      },
+    ]);
+    render(<CCActivity />);
+    // "Grant" appears in both the kind-filter <option> and the row's
+    // Kind cell; assert via the row containing the system label.
+    const row = screen.getByText("Metro P25").closest("tr");
+    expect(row).not.toBeNull();
+    expect(row!.textContent).toMatch(/Grant/);
+    expect(row!.textContent).toMatch(/TG 1234/);
+    expect(row!.textContent).toMatch(/851\.0125 MHz/);
+    expect(row!.textContent).toMatch(/EMERG/);
+  });
+
+  it("renders affiliation events with response code", () => {
+    setEvents([
+      {
+        kind: "affiliation",
+        timestamp: "2026-05-26T12:00:00Z",
+        payload: {
+          system: "Metro P25",
+          radio_id: 999,
+          group_id: 100,
+          response_code: 2,
+        },
+      },
+    ]);
+    render(<CCActivity />);
+    const row = screen.getByText("Metro P25").closest("tr");
+    expect(row).not.toBeNull();
+    expect(row!.textContent).toMatch(/Affiliation/);
+    expect(row!.textContent).toMatch(/radio 999/);
+    expect(row!.textContent).toMatch(/TG 100/);
+    expect(row!.textContent).toMatch(/resp 2/);
+  });
+
+  it("supports filtering by kind", async () => {
+    setEvents([
+      {
+        kind: "grant",
+        timestamp: "2026-05-26T12:00:00Z",
+        payload: { system: "Sys-A", group_id: 1 },
+      },
+      {
+        kind: "affiliation",
+        timestamp: "2026-05-26T12:01:00Z",
+        payload: { system: "Sys-A", radio_id: 100, group_id: 1 },
+      },
+    ]);
+    render(<CCActivity />);
+    // Two rows initially.
+    expect(screen.getByText("2 matching events")).toBeInTheDocument();
+
+    await userEvent.selectOptions(screen.getByRole("combobox"), "grant");
+    expect(screen.getByText("1 matching event")).toBeInTheDocument();
+  });
+
+  it("supports filtering by system substring", async () => {
+    setEvents([
+      {
+        kind: "grant",
+        timestamp: "2026-05-26T12:00:00Z",
+        payload: { system: "Metro P25", group_id: 1 },
+      },
+      {
+        kind: "grant",
+        timestamp: "2026-05-26T12:01:00Z",
+        payload: { system: "County DMR", group_id: 2 },
+      },
+    ]);
+    render(<CCActivity />);
+    expect(screen.getByText("Metro P25")).toBeInTheDocument();
+    expect(screen.getByText("County DMR")).toBeInTheDocument();
+
+    await userEvent.type(screen.getByPlaceholderText(/filter system/), "metro");
+    expect(screen.getByText("Metro P25")).toBeInTheDocument();
+    expect(screen.queryByText("County DMR")).not.toBeInTheDocument();
+  });
+
+  it("renders patch events with member count", () => {
+    setEvents([
+      {
+        kind: "patch",
+        timestamp: "2026-05-26T12:00:00Z",
+        payload: {
+          system: "Metro P25",
+          super_group: 999,
+          members: [101, 102, 103],
+        },
+      },
+    ]);
+    render(<CCActivity />);
+    const row = screen.getByText("Metro P25").closest("tr");
+    expect(row).not.toBeNull();
+    expect(row!.textContent).toMatch(/Patch/);
+    expect(row!.textContent).toMatch(/super-group 999/);
+    expect(row!.textContent).toMatch(/3 members/);
+  });
+
+  it("renders talker alias events", () => {
+    setEvents([
+      {
+        kind: "talker.alias",
+        timestamp: "2026-05-26T12:00:00Z",
+        payload: {
+          system: "Metro P25",
+          source: 1234,
+          alias: "ENG-5",
+        },
+      },
+    ]);
+    render(<CCActivity />);
+    const row = screen.getByText("Metro P25").closest("tr");
+    expect(row).not.toBeNull();
+    expect(row!.textContent).toMatch(/Talker alias/);
+    expect(row!.textContent).toMatch(/radio 1234: "ENG-5"/);
+  });
+});

--- a/web/src/panels/CCActivity.tsx
+++ b/web/src/panels/CCActivity.tsx
@@ -1,0 +1,230 @@
+import { useMemo, useState } from "react";
+import { useShared } from "../store/shared";
+import type { EventDTO } from "../api/types";
+
+// CC Activity panel — a focused view of the trunked control-channel
+// "chatter" already flowing on the events bus. Filters the rolling
+// event log down to the kinds an operator wants to watch live while a
+// system is being decoded: voice grants, affiliations, registrations,
+// patch / regroup announcements, talker-alias completions, control-
+// channel lock / loss, and call start/end markers. Useful for spotting
+// what a system is doing in real time without scrolling through the
+// raw Events log.
+//
+// Pure filter-and-render — no extra backend wire. The bus events are
+// already in the shared store thanks to the existing SSE consumer.
+
+const CC_KINDS: Record<string, string> = {
+  "grant": "Grant",
+  "call.start": "Call start",
+  "call.end": "Call end",
+  "affiliation": "Affiliation",
+  "registration": "Registration",
+  "patch": "Patch",
+  "talker.alias": "Talker alias",
+  "cc.locked": "CC locked",
+  "cc.lost": "CC lost",
+};
+
+interface Row {
+  ts: string;
+  kind: string;
+  label: string;
+  system: string;
+  details: string;
+  raw: unknown;
+}
+
+export function CCActivity() {
+  const events = useShared((s) => s.events);
+  const [paused, setPaused] = useState(false);
+  const [systemFilter, setSystemFilter] = useState("");
+  const [kindFilter, setKindFilter] = useState<string>("");
+
+  const rows = useMemo<Row[]>(() => {
+    const list: Row[] = [];
+    for (const ev of events) {
+      const label = CC_KINDS[ev.kind];
+      if (!label) continue;
+      const row = renderRow(ev, label);
+      if (!row) continue;
+      if (systemFilter && !row.system.toLowerCase().includes(systemFilter.toLowerCase())) {
+        continue;
+      }
+      if (kindFilter && ev.kind !== kindFilter) continue;
+      list.push(row);
+    }
+    // Newest first.
+    return list.reverse();
+  }, [events, systemFilter, kindFilter]);
+
+  return (
+    <div className="space-y-3">
+      <header className="flex flex-wrap items-center justify-between gap-3">
+        <h2 className="text-xl font-semibold">CC Activity</h2>
+        <div className="flex items-center gap-2 text-xs">
+          <select
+            className="bg-surface border border-border rounded px-2 py-1"
+            value={kindFilter}
+            onChange={(e) => setKindFilter(e.target.value)}
+          >
+            <option value="">All kinds</option>
+            {Object.entries(CC_KINDS).map(([k, label]) => (
+              <option key={k} value={k}>{label}</option>
+            ))}
+          </select>
+          <input
+            type="text"
+            placeholder="filter system…"
+            className="bg-surface border border-border rounded px-2 py-1"
+            value={systemFilter}
+            onChange={(e) => setSystemFilter(e.target.value)}
+          />
+          <button
+            type="button"
+            className="px-2 py-1 rounded border border-border text-xs"
+            onClick={() => setPaused(!paused)}
+            aria-pressed={paused}
+          >
+            {paused ? "▶ resume" : "❚❚ pause"}
+          </button>
+        </div>
+      </header>
+
+      <div className="text-xs text-muted">
+        {rows.length} matching event{rows.length === 1 ? "" : "s"}
+        {paused && " (paused — display frozen, the daemon is still receiving)"}
+      </div>
+
+      <div className="rounded border border-border overflow-hidden">
+        <table className="w-full text-xs">
+          <thead className="bg-surface text-muted">
+            <tr>
+              <th className="text-left px-3 py-1 font-normal w-24">Time</th>
+              <th className="text-left px-3 py-1 font-normal w-28">Kind</th>
+              <th className="text-left px-3 py-1 font-normal">System</th>
+              <th className="text-left px-3 py-1 font-normal">Details</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.length === 0 ? (
+              <tr>
+                <td colSpan={4} className="px-3 py-4 text-center text-muted">
+                  Nothing here yet — control-channel activity will appear
+                  as the daemon decodes it. Try removing filters or
+                  pointing at a busy system.
+                </td>
+              </tr>
+            ) : (
+              (paused ? rows.slice(0, rows.length) : rows).slice(0, 500).map((r, i) => (
+                <tr key={i} className="border-t border-border/60">
+                  <td className="px-3 py-1 font-mono text-muted">
+                    {formatTime(r.ts)}
+                  </td>
+                  <td className="px-3 py-1">{r.label}</td>
+                  <td className="px-3 py-1 font-mono text-accent">{r.system || "—"}</td>
+                  <td className="px-3 py-1">{r.details}</td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+function renderRow(ev: EventDTO, label: string): Row | null {
+  const payload = (ev.payload ?? {}) as Record<string, unknown>;
+  switch (ev.kind) {
+    case "grant":
+    case "call.start": {
+      const g = (payload.grant ?? payload) as Record<string, unknown>;
+      const system = str(g.system);
+      const protocol = str(g.protocol);
+      const groupID = num(g.group_id);
+      const sourceID = num(g.source_id);
+      const freq = num(g.frequency_hz);
+      const tag: string[] = [];
+      if (g.encrypted) tag.push("ENC");
+      if (g.emergency) tag.push("EMERG");
+      if (g.data_call) tag.push("DATA");
+      const details =
+        `TG ${groupID}` +
+        (sourceID ? ` ← ${sourceID}` : "") +
+        (freq ? ` @ ${(freq / 1e6).toFixed(4)} MHz` : "") +
+        (protocol ? ` · ${protocol}` : "") +
+        (tag.length ? ` · ${tag.join(" ")}` : "");
+      return { ts: ev.timestamp, kind: ev.kind, label, system, details, raw: ev.payload };
+    }
+    case "call.end": {
+      const g = (payload.grant ?? payload) as Record<string, unknown>;
+      const system = str(g.system);
+      const groupID = num(g.group_id);
+      const reason = str(payload.reason);
+      const details = `TG ${groupID}` + (reason ? ` · ${reason}` : "");
+      return { ts: ev.timestamp, kind: ev.kind, label, system, details, raw: ev.payload };
+    }
+    case "affiliation":
+    case "registration": {
+      const system = str(payload.system);
+      const radio = num(payload.radio_id ?? payload.source_id ?? payload.source);
+      const group = num(payload.group_id ?? payload.talkgroup_id);
+      const code = num(payload.response_code ?? payload.response);
+      const details =
+        `radio ${radio}` +
+        (group ? ` → TG ${group}` : "") +
+        (code !== 0 ? ` · resp ${code}` : "");
+      return { ts: ev.timestamp, kind: ev.kind, label, system, details, raw: ev.payload };
+    }
+    case "patch": {
+      const system = str(payload.system);
+      const superGroup = num(payload.super_group ?? payload.regroup_id);
+      const members = (payload.members ?? []) as unknown[];
+      const op = payload.cancelled || payload.removed ? "cancel" : "add";
+      const details =
+        `super-group ${superGroup}` +
+        (members.length ? ` · ${members.length} member${members.length === 1 ? "" : "s"}` : "") +
+        ` · ${op}`;
+      return { ts: ev.timestamp, kind: ev.kind, label, system, details, raw: ev.payload };
+    }
+    case "talker.alias": {
+      const system = str(payload.system);
+      const source = num(payload.source ?? payload.radio_id);
+      const alias = str(payload.alias);
+      const details = `radio ${source}: "${alias}"`;
+      return { ts: ev.timestamp, kind: ev.kind, label, system, details, raw: ev.payload };
+    }
+    case "cc.locked":
+    case "cc.lost": {
+      const system = str(payload.system);
+      const freq = num(payload.frequency_hz);
+      const details =
+        freq ? `@ ${(freq / 1e6).toFixed(4)} MHz` : "";
+      return { ts: ev.timestamp, kind: ev.kind, label, system, details, raw: ev.payload };
+    }
+    default:
+      return null;
+  }
+}
+
+function str(v: unknown): string {
+  return typeof v === "string" ? v : "";
+}
+
+function num(v: unknown): number {
+  if (typeof v === "number") return v;
+  if (typeof v === "string") {
+    const n = parseInt(v, 10);
+    return Number.isFinite(n) ? n : 0;
+  }
+  return 0;
+}
+
+function formatTime(ts: string): string {
+  try {
+    return new Date(ts).toISOString().slice(11, 19);
+  } catch {
+    return ts.slice(11, 19);
+  }
+}


### PR DESCRIPTION
## Summary

Phase 2a (partial) of the trunking-adjacent feature plan (#365): adds a **CC Activity panel** — a focused web view of the trunked control-channel chatter (grants, affiliations, registrations, patches, talker aliases, CC lock/loss, call start/end).

The trunked events GopherTrunk already emits get scattered through the raw Events log mixed with SDR/scanner/audio chatter, making it hard to visually track what a system is doing. The new panel filters the existing event stream down to just CC kinds and renders each with payload-aware columns.

Pure filter view over events already on the bus — **no daemon changes, no new bus kinds, no new storage**.

## What you see

| Kind | Row "Details" column |
| --- | --- |
| `grant` / `call.start` | `TG <id> ← <src> @ <freq> MHz · <protocol> · [tags]` |
| `call.end` | `TG <id> · <reason>` |
| `affiliation` / `registration` | `radio <id> → TG <id> · resp <code>` |
| `patch` | `super-group <id> · <N> members · add/cancel` |
| `talker.alias` | `radio <id>: "<alias>"` |
| `cc.locked` / `cc.lost` | `@ <freq> MHz` |

Tags surfaced from grant flags: ENC (encrypted), EMERG (emergency), DATA (data call).

## Filters

- **Kind dropdown** — narrow to one event type
- **System substring** — useful when multiple trunked systems are configured
- **Pause toggle** — freezes the display without disconnecting SSE

## What's in the box

- **`web/src/panels/CCActivity.tsx`** — the panel itself, pure filter over `useShared(s => s.events)`. Newest-first ordering, capped at 500 rendered rows for jsdom/browser performance.
- **`web/src/App.tsx`** — registered under `/cc` in the secondary tab bar with a ⌁ icon.
- **`web/src/App.panels.test.tsx`** — `/cc` added to the route-mount regression sweep.
- **`web/src/panels/CCActivity.test.tsx`** — 8 tests covering empty-state, kind + system filters, per-kind payload rendering (grant + tags, affiliation + response code, patch + member count, talker alias), and the "non-CC events are silently ignored" behaviour.

## Docs

- **`docs/cc-activity.md`** — operator guide: use cases (onboarding a new system, coverage debug, patch tracking), filter reference, scope notes (no raw TSBK/CSBK PDU view yet — that's a developer-mode follow-up), per-kind rendering table
- **`docs/_data/nav.yml`** — entry added under "Operate"
- **`README.md`** — "CC Activity panel" bullet under Features
- **`CHANGELOG.md`** — `[Unreleased]` → Added

## Test plan

- [x] `go test ./...` — 84 packages pass
- [x] `npm run test` — 77 web tests pass (12 test files)
- [x] `npm run typecheck` clean
- [x] `npm run build` — SPA bundle builds
- [x] `go vet ./...` clean
- [x] `gofmt -l .` clean

## What's not in this PR (and why)

- **Raw TSBK / CSBK / OSW bit-level view.** Would need every per-protocol pipeline under `internal/radio/{p25,dmr,nxdn,...}` to publish PDU events on the bus — different surface area and risk profile (potential bus saturation). Better as its own focused PR once the events bus has a `PublishLossy` variant.
- **TUI CC Activity panel.** The TUI client uses SSE, so adding it is mechanically simple, but the Bubbletea panel scaffolding is its own per-panel cost. Deferred unless someone asks.
- **Spectrum bookmark overlay + click-to-tune.** TODO from #368; needs a daemon-side "tune the spectrum SDR" endpoint distinct from the scanner manual-tune. Deferred.

## Next slice

Per the plan in #365, the next reasonable slices are:
- **Phase 6** — Constellation / eye / classifier diagnostic panel (extends existing demods)
- **Phase 3** — POCSAG / FLEX paging decoder (substantial DSP, multi-week)
- **Phase 5** — APRS / DSC / AIS / ADS-B decoder framework
- **Phase 7** — M17 + pure-Go Codec2 port (schedule's critical path)

https://claude.ai/code/session_01YUgvat8WpF5YaSuEAqWMr2

---
_Generated by [Claude Code](https://claude.ai/code/session_01YUgvat8WpF5YaSuEAqWMr2)_