### PR TITLE
constellation: add IQ scatter diagnostic panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ for tagged releases.
 
 ### Added
 
+- **Constellation viewer.** New web panel at `/constellation` that
+  renders a live 2D scatter of decimated IQ samples (2 ksps
+  default). Brighter dots = newer samples; reference rings at
+  |z|=0.5 and |z|=1.0; per-frame dBFS energy banner. Identifies
+  signal shape visually — PSK clusters, FSK arcs, AM rotation,
+  noise circles, DC bias, frequency-offset spirals — without
+  launching a separate SDR receiver alongside GopherTrunk. Builds
+  on the iqtap broker (PR #365) so multiple subscribers share the
+  same SDR's IQ stream without disturbing decode.
+  `internal/dsp/diag` adds a pure-Go stride decimator + per-frame
+  energy estimator; `WS /api/v1/diag/iq?device=...&rate=2000`
+  exposes it. See [docs/constellation.md](docs/constellation.md).
 - **CC Activity panel.** New web panel at `/cc` that filters the
   events stream down to control-channel chatter: voice grants,
   affiliations, registrations, patches / dynamic regroups, talker

--- a/README.md
+++ b/README.md
@@ -89,6 +89,12 @@ Silicon and Intel. Full per-OS recipes at
   channel chatter (grants, affiliations, registrations, patches,
   talker aliases, CC lock / loss). Pure filter over the events
   stream with per-row payload rendering; web panel at `/cc`.
+- **Constellation viewer** — live IQ scatter visualization that
+  taps the same broker the trunking decoder reads. Useful for
+  identifying signal shape (PSK / QPSK / FSK / C4FM / AM /
+  noise), spotting frequency offset, and checking demod /
+  equalizer health. Decimated to 2 ksps for the wire; canvas
+  scatter with energy banner. Web panel at `/constellation`.
 - **Bookmarks / frequency manager** — UI-managed conventional
   channel list (marine VHF, NOAA weather, FRS/GMRS, repeater
   outputs, public-safety fall-back channels) stored in the

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -896,6 +896,7 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 		}
 		if len(d.iqBrokers) > 0 {
 			opts.Spectrum = newSpectrumProvider(d.pool, d.iqBrokers, log)
+			opts.Diag = newDiagProvider(d.pool, d.iqBrokers, cfg.SDR.SampleRate, log)
 		}
 		if d.bookmarks != nil {
 			opts.Bookmarks = bookmarkProvider{store: d.bookmarks}

--- a/cmd/gophertrunk/diag_provider.go
+++ b/cmd/gophertrunk/diag_provider.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/api"
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/diag"
+	"github.com/MattCheramie/GopherTrunk/internal/sdr"
+	"github.com/MattCheramie/GopherTrunk/internal/sdr/iqtap"
+)
+
+// diagProvider implements api.DiagProvider on top of the daemon's
+// iqtap broker map. Each OpenIQStream call attaches a fresh
+// subscriber to the requested device's broker, runs a per-request
+// diag.Decimator at the negotiated target rate, and pipes the
+// wire frames out for the API's WS handler to drain. Cleanup
+// tears the subscription and decimator goroutine down.
+//
+// One decimator per WS subscriber — same trade-off the spectrum
+// provider makes. CPU scales linearly with #clients; for the
+// single-operator GopherTrunk audience this is fine. A future
+// shared-decimator optimization would be mechanical (the
+// spectrum_provider.go pattern). Defer until profiling shows the
+// wins.
+type diagProvider struct {
+	pool       *sdr.Pool
+	brokers    map[string]*iqtap.Broker
+	sampleRate uint32
+	log        *slog.Logger
+}
+
+func newDiagProvider(pool *sdr.Pool, brokers map[string]*iqtap.Broker, sampleRate uint32, log *slog.Logger) *diagProvider {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &diagProvider{pool: pool, brokers: brokers, sampleRate: sampleRate, log: log}
+}
+
+// OpenIQStream is api.DiagProvider's only method. See its docstring
+// for the wire-side contract; this implementation builds a decimator
+// over the broker subscription and runs it on a goroutine.
+func (p *diagProvider) OpenIQStream(ctx context.Context, serial string, targetRateSPS uint32) (<-chan api.IQFrame, func(), error) {
+	if p == nil {
+		return nil, nil, errors.New("diag: provider not wired")
+	}
+	br, ok := p.brokers[serial]
+	if !ok {
+		return nil, nil, fmt.Errorf("diag: serial %q is not a known SDR", serial)
+	}
+	inputRate := br.SampleRateHz()
+	if inputRate == 0 {
+		inputRate = p.sampleRate
+	}
+	if inputRate == 0 {
+		return nil, nil, errors.New("diag: cannot determine input sample rate")
+	}
+	if targetRateSPS == 0 {
+		targetRateSPS = diag.DefaultDecimatedRateSPS
+	}
+	if targetRateSPS > inputRate {
+		targetRateSPS = inputRate
+	}
+
+	dec, err := diag.New(diag.Options{
+		InputRateSPS:   inputRate,
+		TargetRateSPS:  targetRateSPS,
+		ChunksPerFrame: 4,
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("diag: %w", err)
+	}
+
+	sub := br.Subscribe()
+	internalOut := make(chan diag.IQFrame, 8)
+	wireOut := make(chan api.IQFrame, 8)
+
+	streamCtx, cancel := context.WithCancel(ctx)
+
+	centerHz := func() uint32 { return br.CenterHz() }
+	tsNs := func() int64 { return time.Now().UnixNano() }
+
+	go func() {
+		defer close(internalOut)
+		_ = dec.Run(streamCtx, sub.C, internalOut, centerHz, tsNs)
+	}()
+
+	go func() {
+		defer close(wireOut)
+		for {
+			select {
+			case <-streamCtx.Done():
+				return
+			case f, ok := <-internalOut:
+				if !ok {
+					return
+				}
+				points := make([]api.IQPoint, len(f.Points))
+				for i, pt := range f.Points {
+					points[i] = api.IQPoint{I: pt.I, Q: pt.Q}
+				}
+				wire := api.IQFrame{
+					TimestampNs:  f.TimestampNs,
+					SampleRateHz: f.SampleRate,
+					CenterHz:     f.CenterHz,
+					Points:       points,
+					EnergyDBFS:   f.EnergyDBFS,
+				}
+				select {
+				case wireOut <- wire:
+				case <-streamCtx.Done():
+					return
+				}
+			}
+		}
+	}()
+
+	cleanup := func() {
+		cancel()
+		sub.Close()
+	}
+	return wireOut, cleanup, nil
+}

--- a/docs/_data/nav.yml
+++ b/docs/_data/nav.yml
@@ -33,6 +33,8 @@ groups:
         url: /bookmarks.html
       - title: CC Activity
         url: /cc-activity.html
+      - title: Constellation
+        url: /constellation.html
       - title: rigctld integration
         url: /rigctld.html
       - title: Hardening

--- a/docs/constellation.md
+++ b/docs/constellation.md
@@ -1,0 +1,82 @@
+---
+layout: page
+title: Constellation panel
+description: Live IQ scatter for visually identifying signal shape — PSK, FSK, AM, noise — without launching a separate SDR receiver
+nav_group: Operate
+---
+
+# Constellation panel
+
+The **Constellation panel** (web `/constellation`) renders a live
+2D scatter of the IQ samples coming off whichever SDR you pick.
+It's the "what does this signal *look* like" view — useful for
+identifying modulation shape, checking demod / equalizer health,
+and confirming that the SDR is actually receiving something you
+care about before committing to a deeper decode pipeline.
+
+## What you see
+
+The X axis is the in-phase (I) component, the Y axis is the
+quadrature (Q) component, both normalized to ±1. Brighter dots are
+more recent. Reference rings show |z| = 0.5 and |z| = 1.0 so you
+can eyeball amplitude.
+
+Common shapes:
+
+| Shape | Likely signal |
+| --- | --- |
+| One bright dot off-centre | DC bias / unmodulated carrier |
+| Two clusters at ±0.5 + 0i | BPSK |
+| Four clusters in a square | QPSK / π/4-DQPSK |
+| Two horizontal arcs | 2-FSK |
+| Four arcs (top + bottom of unit circle) | C4FM / 4-FSK |
+| Diffuse rotating cluster, amplitude-modulated | AM voice |
+| Diffuse circle around the origin | Wideband noise / nothing on this frequency |
+| Spiral expanding outward | Strong frequency offset (re-tune or fix PPM) |
+
+## How it works
+
+- The panel opens a WebSocket to `WS /api/v1/diag/iq?device=...&rate=2000`.
+- The daemon decimates the SDR's full-rate IQ stream by a stride
+  (`input_rate / target_rate`) — no anti-alias filter; the goal is
+  visualization, not faithful spectral reconstruction.
+- Frames arrive every ~50 ms with ~100 points each; the panel
+  keeps a rolling buffer of the last 2000 points and repaints the
+  canvas each frame.
+- Energy (the average power of the *pre*-decimation chunk in
+  dBFS) is stamped on every frame and shown in the tuning line —
+  helps tell "signal present" apart from "wideband noise that
+  happens to look circular."
+
+## Limitations
+
+- **Not a demodulator.** This is a sample-domain view of the raw
+  IQ — useful as a sanity check, not as a decoder. To actually
+  decode a signal, configure it as a `trunking.systems` entry or
+  `scanner.conventional` channel and let the per-protocol
+  pipeline take over.
+- **Decimation is brutal.** The stride decimator throws away
+  spectral content above `target_rate / 2`. Wideband signals
+  appear smeared. The constellation is most useful for symbol-
+  domain signals that have already been narrow-channelized — e.g.
+  pointed at a single FM repeater or P25 voice channel — rather
+  than a 2.4 MHz wideband capture.
+- **Single-SDR-at-a-time.** Each WS subscriber runs its own
+  decimator; CPU scales linearly with the number of open panels.
+  Fine for the single-operator deployments GopherTrunk targets.
+
+## Implementation
+
+| Path | Role |
+| --- | --- |
+| `internal/dsp/diag/iqstream.go` | `Decimator` — decimates IQ chunks by stride, computes per-frame energy, batches points into wire frames |
+| `internal/api/diag.go` | `DiagProvider` interface + `WS /api/v1/diag/iq` handler |
+| `cmd/gophertrunk/diag_provider.go` | Daemon-side `diagProvider` — wires the decimator to the iqtap broker for each WS subscriber |
+| `web/src/api/diag.ts` | Typed client with auto-reconnect / backoff |
+| `web/src/panels/Constellation.tsx` | Canvas scatter renderer |
+
+The decimator runs on top of the iqtap broker (PR #365), so it
+fans out from the same IQ source the trunking decoder is reading
+without disturbing decode. Multiple panels open against the same
+SDR don't double the SDR's CPU cost — they share the broker
+subscription up to the broker's drop-on-full bound.

--- a/internal/api/diag.go
+++ b/internal/api/diag.go
@@ -1,0 +1,127 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// IQPoint and IQFrame mirror the shapes the daemon's diag.Decimator
+// produces. Defined here so the api package stays free of an import
+// dependency on internal/dsp/diag; the DiagProvider interface bridges
+// the two.
+type IQPoint struct {
+	I float32 `json:"i"`
+	Q float32 `json:"q"`
+}
+
+// IQFrame is the wire shape of one decimated-IQ batch.
+type IQFrame struct {
+	TimestampNs  int64     `json:"ts_ns"`
+	SampleRateHz uint32    `json:"sample_rate"`
+	CenterHz     uint32    `json:"center_hz"`
+	Points       []IQPoint `json:"points"`
+	EnergyDBFS   float32   `json:"energy_dbfs"`
+}
+
+// DiagProvider is the daemon-side abstraction the diag endpoints
+// consume. The daemon implements it on top of the iqtap broker
+// map; tests substitute a fake.
+type DiagProvider interface {
+	// OpenIQStream starts a per-request decimator on the named
+	// device. TargetRateSPS clamps the output rate (≤ device
+	// sample_rate). Returns the wire-frame channel and a cleanup
+	// func the caller MUST invoke on disconnect.
+	OpenIQStream(ctx context.Context, serial string, targetRateSPS uint32) (<-chan IQFrame, func(), error)
+}
+
+// handleDiagStream answers WS /api/v1/diag/iq?device=...&rate=....
+//
+// Frames arrive as JSON text messages. Server pings every 30 s to
+// keep proxies from idling the socket. Connection stays open until
+// the client disconnects or the device disappears.
+func (s *Server) handleDiagStream(w http.ResponseWriter, r *http.Request) {
+	if s.diag == nil {
+		writeError(w, http.StatusServiceUnavailable, "diag subsystem not enabled")
+		return
+	}
+	q := r.URL.Query()
+	serial := q.Get("device")
+	if serial == "" {
+		writeError(w, http.StatusBadRequest, "device query parameter is required")
+		return
+	}
+	rate := uint32(parseIntQuery(q, "rate", 2000, 100, 20000))
+
+	upgrader := wsUpgrader
+	if s.cors.enabled() {
+		cors := s.cors
+		upgrader.CheckOrigin = func(req *http.Request) bool {
+			origin := req.Header.Get("Origin")
+			if origin == "" {
+				return true
+			}
+			_, ok := cors.originAllowed(origin)
+			return ok
+		}
+	}
+	conn, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		s.log.Debug("api: diag WS upgrade failed", "err", err)
+		return
+	}
+	defer conn.Close()
+
+	ctx, cancel := context.WithCancel(r.Context())
+	defer cancel()
+
+	frames, cleanup, err := s.diag.OpenIQStream(ctx, serial, rate)
+	if err != nil {
+		s.log.Debug("api: diag OpenIQStream failed", "serial", serial, "err", err)
+		_ = conn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(
+			websocket.CloseInternalServerErr, err.Error()))
+		return
+	}
+	defer cleanup()
+
+	// Drain client → server messages so close frames are processed.
+	go func() {
+		for {
+			if _, _, err := conn.NextReader(); err != nil {
+				cancel()
+				return
+			}
+		}
+	}()
+
+	ping := time.NewTicker(30 * time.Second)
+	defer ping.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ping.C:
+			_ = conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+			if err := conn.WriteMessage(websocket.PingMessage, nil); err != nil {
+				return
+			}
+		case f, ok := <-frames:
+			if !ok {
+				return
+			}
+			body, err := json.Marshal(f)
+			if err != nil {
+				s.log.Debug("api: diag frame marshal", "err", err)
+				continue
+			}
+			_ = conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+			if err := conn.WriteMessage(websocket.TextMessage, body); err != nil {
+				return
+			}
+		}
+	}
+}

--- a/internal/api/diag_test.go
+++ b/internal/api/diag_test.go
@@ -1,0 +1,129 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/gorilla/websocket"
+)
+
+type fakeDiagProvider struct {
+	openErr error
+	frames  []IQFrame
+}
+
+func (f *fakeDiagProvider) OpenIQStream(ctx context.Context, _ string, _ uint32) (<-chan IQFrame, func(), error) {
+	if f.openErr != nil {
+		return nil, nil, f.openErr
+	}
+	out := make(chan IQFrame, 4)
+	streamCtx, cancel := context.WithCancel(ctx)
+	go func() {
+		defer close(out)
+		for _, fr := range f.frames {
+			select {
+			case <-streamCtx.Done():
+				return
+			case out <- fr:
+			}
+			time.Sleep(5 * time.Millisecond)
+		}
+		<-streamCtx.Done()
+	}()
+	return out, cancel, nil
+}
+
+func newDiagTestServer(t *testing.T, prov DiagProvider) *httptest.Server {
+	t.Helper()
+	bus := events.NewBus(8)
+	t.Cleanup(bus.Close)
+	srv, err := NewServer(ServerOptions{
+		Addr: "127.0.0.1:0",
+		Bus:  bus,
+		Diag: prov,
+	})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	ts := httptest.NewServer(srv.routes())
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+func TestDiagStreamReturns503WhenNotWired(t *testing.T) {
+	ts := newDiagTestServer(t, nil)
+	resp, err := http.Get(ts.URL + "/api/v1/diag/iq?device=foo")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want 503", resp.StatusCode)
+	}
+}
+
+func TestDiagStreamRejectsMissingDevice(t *testing.T) {
+	ts := newDiagTestServer(t, &fakeDiagProvider{})
+	resp, err := http.Get(ts.URL + "/api/v1/diag/iq")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", resp.StatusCode)
+	}
+}
+
+func TestDiagStreamDeliversFrames(t *testing.T) {
+	prov := &fakeDiagProvider{
+		frames: []IQFrame{
+			{
+				TimestampNs:  1,
+				SampleRateHz: 2000,
+				CenterHz:     851_012_500,
+				Points:       []IQPoint{{I: 0.5, Q: 0.25}, {I: -0.3, Q: 0.7}},
+				EnergyDBFS:   -10,
+			},
+			{
+				TimestampNs:  2,
+				SampleRateHz: 2000,
+				CenterHz:     851_012_500,
+				Points:       []IQPoint{{I: 0.1, Q: 0.1}},
+				EnergyDBFS:   -25,
+			},
+		},
+	}
+	ts := newDiagTestServer(t, prov)
+
+	u, _ := url.Parse(ts.URL)
+	wsURL := "ws://" + u.Host + "/api/v1/diag/iq?device=any&rate=2000"
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	defer conn.Close()
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+
+	for i := 0; i < 2; i++ {
+		_, msg, err := conn.ReadMessage()
+		if err != nil {
+			t.Fatalf("ReadMessage #%d: %v", i, err)
+		}
+		var f IQFrame
+		if err := json.Unmarshal(msg, &f); err != nil {
+			t.Fatalf("unmarshal #%d: %v (raw=%s)", i, err, string(msg))
+		}
+		if f.CenterHz != 851_012_500 {
+			t.Errorf("frame #%d CenterHz = %d", i, f.CenterHz)
+		}
+		if i == 0 && len(f.Points) != 2 {
+			t.Errorf("frame #%d points len = %d, want 2", i, len(f.Points))
+		}
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -262,6 +262,12 @@ type Server struct {
 	// daemon over storage.BookmarkStore.
 	bookmarks BookmarkProvider
 
+	// diag is the optional provider backing /api/v1/diag/...
+	// routes (decimated-IQ stream for the Constellation panel).
+	// nil disables the routes (503). Implemented by the daemon
+	// over the iqtap broker + internal/dsp/diag.
+	diag DiagProvider
+
 	mu     sync.Mutex
 	srv    *http.Server
 	closed bool
@@ -444,6 +450,12 @@ type ServerOptions struct {
 	// returning 503. Wired by the daemon over the SQLite-backed
 	// storage.BookmarkStore.
 	Bookmarks BookmarkProvider
+	// Diag, when non-nil, enables the
+	// WS /api/v1/diag/iq decimated-IQ live stream that backs the
+	// web Constellation panel. The daemon implements this over
+	// the iqtap broker + internal/dsp/diag; nil keeps the route
+	// returning 503.
+	Diag DiagProvider
 	// CORS configures the cross-origin middleware. Off when
 	// AllowedOrigins is empty (the daemon emits no CORS headers).
 	// Set this when the browser-served SPA is loaded from an
@@ -537,6 +549,7 @@ func NewServer(opts ServerOptions) (*Server, error) {
 		audioPub:       opts.AudioPublisher,
 		spectrum:       opts.Spectrum,
 		bookmarks:      opts.Bookmarks,
+		diag:           opts.Diag,
 	}, nil
 }
 
@@ -719,6 +732,11 @@ func (s *Server) routes() *http.ServeMux {
 	mux.HandleFunc("POST /api/v1/bookmarks", s.gate(s.handleCreateBookmark))
 	mux.HandleFunc("PATCH /api/v1/bookmarks/{id}", s.gate(s.handleUpdateBookmark))
 	mux.HandleFunc("DELETE /api/v1/bookmarks/{id}", s.gate(s.handleDeleteBookmark))
+
+	// Diagnostic IQ stream — feeds the web Constellation panel.
+	// Read-only; the daemon doesn't expose any way to inject IQ
+	// via this path. Returns 503 when no SDR is in the pool.
+	mux.HandleFunc("GET /api/v1/diag/iq", s.handleDiagStream)
 
 	// Embedded SPA at "/" — served only when the daemon was linked
 	// against a populated web/dist embed. SPA history routes

--- a/internal/dsp/diag/iqstream.go
+++ b/internal/dsp/diag/iqstream.go
@@ -1,0 +1,213 @@
+// Package diag provides developer/diagnostic helpers — IQ-sample
+// decimation, energy + bandwidth estimation — that feed the web
+// console's Constellation panel. Pure-Go, no CGO.
+//
+// The Constellation panel renders raw IQ samples as a 2D scatter so
+// the operator can visually identify what's on a frequency:
+//
+//   - PSK / QPSK constellations show as small clusters at the symbol
+//     points
+//   - FSK shows as two arcs (or four for C4FM)
+//   - AM voice shows as a rotating cluster modulated in amplitude
+//   - Wideband noise shows as a diffuse circle
+//   - DC bias shows as an offset blob
+//
+// Streaming full-rate IQ to the browser would swamp the wire — a
+// 2.048 MS/s stream is 16 MB/s of complex64. Instead a Decimator
+// downsamples to a configurable target rate (default 2000 samples/s,
+// well below the canvas's render budget) and ships chunks over WS.
+package diag
+
+import (
+	"context"
+	"errors"
+	"math"
+	"sync/atomic"
+)
+
+// DefaultDecimatedRateSPS is the per-WS-subscriber sample rate when
+// the client doesn't override it. 2 ksps is enough density for the
+// canvas to look "lively" without saturating the network.
+const DefaultDecimatedRateSPS = 2000
+
+// IQPoint is one complex sample on the wire. Float32 keeps frames
+// compact; clients render directly without conversion.
+type IQPoint struct {
+	I float32 `json:"i"`
+	Q float32 `json:"q"`
+}
+
+// IQFrame is one batch of decimated points. Sent periodically (every
+// ~50 ms by default) so the browser canvas redraws at a steady rate
+// rather than burning CPU on tiny per-sample frames.
+type IQFrame struct {
+	TimestampNs int64     `json:"ts_ns"`
+	SampleRate  uint32    `json:"sample_rate"`
+	CenterHz    uint32    `json:"center_hz"`
+	Points      []IQPoint `json:"points"`
+	// Energy is the average power of the original (pre-decimation)
+	// chunk in dBFS — the same shape the spectrum producer reports.
+	// Useful as a "is anything there?" indicator while the
+	// constellation is being rendered.
+	EnergyDBFS float32 `json:"energy_dbfs"`
+}
+
+// Decimator consumes a stream of full-rate IQ chunks and emits IQ
+// frames at a controlled output rate. The output rate is achieved by
+// taking every Nth sample (where N = input_rate / target_rate),
+// matching what the spectrum producer's rate-cap loop does at the
+// FFT layer — simple, deterministic, no anti-alias filter needed
+// because the target rate is a tiny fraction of the input and the
+// goal is visualization, not faithful spectral reconstruction.
+type Decimator struct {
+	inputRateSPS   uint32
+	targetRateSPS  uint32
+	stride         int
+	chunksPerFrame int
+
+	pending []IQPoint
+
+	dropped atomic.Uint64
+}
+
+// Options configures a Decimator.
+type Options struct {
+	// InputRateSPS is the upstream IQ sample rate (the SDR's
+	// configured sample rate). Required.
+	InputRateSPS uint32
+	// TargetRateSPS is the post-decimation sample rate emitted to
+	// the WS client. Zero picks DefaultDecimatedRateSPS.
+	TargetRateSPS uint32
+	// ChunksPerFrame batches multiple downsampled chunks into one
+	// IQFrame so the WS write cost stays reasonable. Zero defaults
+	// to 4 (about 50 ms of audio at 2 ksps with 1024-sample input
+	// chunks at 2.048 MS/s).
+	ChunksPerFrame int
+}
+
+// New constructs a Decimator. Returns an error if InputRateSPS is
+// zero or smaller than TargetRateSPS.
+func New(opts Options) (*Decimator, error) {
+	if opts.InputRateSPS == 0 {
+		return nil, errors.New("diag: InputRateSPS is required")
+	}
+	target := opts.TargetRateSPS
+	if target == 0 {
+		target = DefaultDecimatedRateSPS
+	}
+	if target > opts.InputRateSPS {
+		return nil, errors.New("diag: TargetRateSPS must be <= InputRateSPS")
+	}
+	stride := int(opts.InputRateSPS / target)
+	if stride < 1 {
+		stride = 1
+	}
+	chunksPerFrame := opts.ChunksPerFrame
+	if chunksPerFrame <= 0 {
+		chunksPerFrame = 4
+	}
+	return &Decimator{
+		inputRateSPS:   opts.InputRateSPS,
+		targetRateSPS:  target,
+		stride:         stride,
+		chunksPerFrame: chunksPerFrame,
+	}, nil
+}
+
+// Run consumes from in and emits IQFrames on out until ctx cancels
+// or in closes. centerFreq is captured per-frame via the supplied
+// getter so a retune mid-stream is reflected on the next frame.
+//
+// The getter pattern matches the spectrum producer's SetCenter /
+// SetSampleRate hooks; in the daemon both are backed by the iqtap
+// broker so they stay coherent with the underlying SDR's tuning.
+func (d *Decimator) Run(
+	ctx context.Context,
+	in <-chan []complex64,
+	out chan<- IQFrame,
+	centerHz func() uint32,
+	timestampNs func() int64,
+) error {
+	if in == nil {
+		return errors.New("diag: input channel is nil")
+	}
+	if out == nil {
+		return errors.New("diag: output channel is nil")
+	}
+
+	chunksSeen := 0
+	var energySum float64
+	var energyCount int
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case chunk, ok := <-in:
+			if !ok {
+				return nil
+			}
+			// Compute pre-decimation energy for the diagnostic banner.
+			for _, s := range chunk {
+				re := float64(real(s))
+				im := float64(imag(s))
+				energySum += re*re + im*im
+			}
+			energyCount += len(chunk)
+
+			// Downsample by stride.
+			for i := 0; i < len(chunk); i += d.stride {
+				s := chunk[i]
+				d.pending = append(d.pending, IQPoint{
+					I: real(s),
+					Q: imag(s),
+				})
+			}
+
+			chunksSeen++
+			if chunksSeen < d.chunksPerFrame {
+				continue
+			}
+
+			// Emit one frame.
+			points := d.pending
+			d.pending = make([]IQPoint, 0, len(points))
+
+			mean := 1e-30
+			if energyCount > 0 {
+				mean = energySum / float64(energyCount)
+			}
+			if mean < 1e-30 {
+				mean = 1e-30
+			}
+			energy := float32(10 * math.Log10(mean))
+			energySum = 0
+			energyCount = 0
+			chunksSeen = 0
+
+			frame := IQFrame{
+				TimestampNs: timestampNs(),
+				SampleRate:  d.targetRateSPS,
+				CenterHz:    centerHz(),
+				Points:      points,
+				EnergyDBFS:  energy,
+			}
+			select {
+			case out <- frame:
+			default:
+				d.dropped.Add(1)
+			}
+		}
+	}
+}
+
+// TargetRateSPS reports the configured post-decimation sample rate.
+func (d *Decimator) TargetRateSPS() uint32 { return d.targetRateSPS }
+
+// Stride reports the input-to-output downsample ratio.
+func (d *Decimator) Stride() int { return d.stride }
+
+// Dropped reports the cumulative frames dropped because a downstream
+// subscriber's channel was full. Non-zero is expected in practice on
+// a busy SDR; sustained growth indicates a wedged WS client.
+func (d *Decimator) Dropped() uint64 { return d.dropped.Load() }

--- a/internal/dsp/diag/iqstream_test.go
+++ b/internal/dsp/diag/iqstream_test.go
@@ -1,0 +1,203 @@
+package diag
+
+import (
+	"context"
+	"math"
+	"testing"
+	"time"
+)
+
+func TestNewRejectsBadOptions(t *testing.T) {
+	if _, err := New(Options{InputRateSPS: 0}); err == nil {
+		t.Error("zero InputRateSPS: want error")
+	}
+	if _, err := New(Options{InputRateSPS: 1000, TargetRateSPS: 5000}); err == nil {
+		t.Error("TargetRateSPS > InputRateSPS: want error")
+	}
+}
+
+func TestNewDefaultsTargetRate(t *testing.T) {
+	d, err := New(Options{InputRateSPS: 2_048_000})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if d.TargetRateSPS() != DefaultDecimatedRateSPS {
+		t.Errorf("TargetRateSPS = %d, want %d", d.TargetRateSPS(), DefaultDecimatedRateSPS)
+	}
+}
+
+func TestDecimatorStrideMath(t *testing.T) {
+	d, _ := New(Options{InputRateSPS: 2_048_000, TargetRateSPS: 2048})
+	if d.Stride() != 1000 {
+		t.Errorf("stride = %d, want 1000 (2.048M / 2048)", d.Stride())
+	}
+}
+
+func TestRunEmitsFrameAfterChunksPerFrame(t *testing.T) {
+	d, _ := New(Options{
+		InputRateSPS:   1000,
+		TargetRateSPS:  100,
+		ChunksPerFrame: 2,
+	})
+
+	in := make(chan []complex64, 4)
+	out := make(chan IQFrame, 4)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var ts int64 = 1234567
+	go func() {
+		_ = d.Run(ctx, in, out, func() uint32 { return 850_000_000 }, func() int64 { return ts })
+	}()
+
+	// Stride is 10, so each 50-sample chunk yields 5 output points.
+	chunk := make([]complex64, 50)
+	for i := range chunk {
+		chunk[i] = complex(0.5, 0.25)
+	}
+	in <- chunk
+	// First chunk alone shouldn't emit (ChunksPerFrame=2).
+	select {
+	case <-out:
+		t.Fatal("frame emitted after only 1 chunk; ChunksPerFrame=2")
+	case <-time.After(50 * time.Millisecond):
+	}
+	in <- chunk
+	select {
+	case f := <-out:
+		if len(f.Points) != 10 {
+			t.Errorf("Points len = %d, want 10 (2 chunks * 5 strides)", len(f.Points))
+		}
+		if f.SampleRate != 100 {
+			t.Errorf("SampleRate = %d, want 100", f.SampleRate)
+		}
+		if f.CenterHz != 850_000_000 {
+			t.Errorf("CenterHz = %d, want 850_000_000", f.CenterHz)
+		}
+		if f.Points[0].I != 0.5 || f.Points[0].Q != 0.25 {
+			t.Errorf("first point = (%f, %f), want (0.5, 0.25)", f.Points[0].I, f.Points[0].Q)
+		}
+		// 0.5^2 + 0.25^2 = 0.3125 → 10*log10(0.3125) ≈ -5.05 dBFS.
+		if f.EnergyDBFS < -7 || f.EnergyDBFS > -3 {
+			t.Errorf("EnergyDBFS = %f, want roughly -5 dBFS", f.EnergyDBFS)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("no frame emitted within 500 ms")
+	}
+}
+
+func TestRunPropagatesEnergyForDC(t *testing.T) {
+	d, _ := New(Options{
+		InputRateSPS:   1000,
+		TargetRateSPS:  100,
+		ChunksPerFrame: 1,
+	})
+
+	in := make(chan []complex64, 1)
+	out := make(chan IQFrame, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		_ = d.Run(ctx, in, out, func() uint32 { return 0 }, func() int64 { return 0 })
+	}()
+
+	// Unit-amplitude DC: 1+0i. |x|^2 = 1, so energy = 0 dBFS.
+	chunk := make([]complex64, 100)
+	for i := range chunk {
+		chunk[i] = complex(1, 0)
+	}
+	in <- chunk
+
+	select {
+	case f := <-out:
+		if math.Abs(float64(f.EnergyDBFS)) > 0.5 {
+			t.Errorf("EnergyDBFS = %f, want ~0 dBFS", f.EnergyDBFS)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("no frame")
+	}
+}
+
+func TestRunStopsOnContextCancel(t *testing.T) {
+	d, _ := New(Options{InputRateSPS: 1000, TargetRateSPS: 100})
+
+	in := make(chan []complex64)
+	out := make(chan IQFrame, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan error, 1)
+	go func() {
+		done <- d.Run(ctx, in, out, func() uint32 { return 0 }, func() int64 { return 0 })
+	}()
+	cancel()
+	select {
+	case err := <-done:
+		if err != context.Canceled {
+			t.Errorf("Run err = %v, want context.Canceled", err)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("Run did not exit after ctx cancel")
+	}
+}
+
+func TestRunStopsOnInputClose(t *testing.T) {
+	d, _ := New(Options{InputRateSPS: 1000, TargetRateSPS: 100})
+
+	in := make(chan []complex64, 1)
+	out := make(chan IQFrame, 1)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- d.Run(context.Background(), in, out, func() uint32 { return 0 }, func() int64 { return 0 })
+	}()
+	close(in)
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("Run err = %v, want nil on input close", err)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("Run did not exit on input close")
+	}
+}
+
+func TestSlowConsumerCountsDrops(t *testing.T) {
+	d, _ := New(Options{
+		InputRateSPS:   1000,
+		TargetRateSPS:  100,
+		ChunksPerFrame: 1,
+	})
+
+	in := make(chan []complex64, 16)
+	// Tiny out channel that we deliberately don't drain.
+	out := make(chan IQFrame, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		_ = d.Run(ctx, in, out, func() uint32 { return 0 }, func() int64 { return 0 })
+	}()
+
+	// Pump 5 chunks without draining out. The first goes through, the
+	// next four should drop.
+	chunk := make([]complex64, 10)
+	for i := 0; i < 5; i++ {
+		in <- chunk
+	}
+	// Give the run loop a moment to process.
+	time.Sleep(50 * time.Millisecond)
+	if d.Dropped() == 0 {
+		t.Error("Dropped count = 0 after deliberate backpressure; want > 0")
+	}
+}
+
+func TestRunNilChannelsError(t *testing.T) {
+	d, _ := New(Options{InputRateSPS: 1000})
+	if err := d.Run(context.Background(), nil, make(chan IQFrame), nil, nil); err == nil {
+		t.Error("Run with nil in: want error")
+	}
+	if err := d.Run(context.Background(), make(chan []complex64), nil, nil, nil); err == nil {
+		t.Error("Run with nil out: want error")
+	}
+}

--- a/web/src/App.panels.test.tsx
+++ b/web/src/App.panels.test.tsx
@@ -28,6 +28,15 @@ vi.mock("./api/spectrum", () => ({
   ),
 }));
 
+vi.mock("./api/diag", () => ({
+  openIQStream: vi.fn(
+    (_cfg: unknown, opts: { onStatus?: (s: string) => void }) => {
+      opts.onStatus?.("closed");
+      return { close: vi.fn() };
+    },
+  ),
+}));
+
 vi.mock("./api/bookmarks", () => ({
   bookmarks: {
     list: vi.fn().mockResolvedValue([]),
@@ -140,6 +149,7 @@ const ROUTES = [
   "/active",
   "/scanner",
   "/spectrum",
+  "/constellation",
   "/bookmarks",
   "/systems",
   "/talkgroups",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -9,6 +9,7 @@ import { InstallPrompt } from "./components/InstallPrompt";
 import { Active } from "./panels/Active";
 import { Bookmarks } from "./panels/Bookmarks";
 import { CCActivity } from "./panels/CCActivity";
+import { Constellation } from "./panels/Constellation";
 import { Dashboard } from "./panels/Dashboard";
 import { Devices } from "./panels/Devices";
 import { Events } from "./panels/Events";
@@ -37,6 +38,7 @@ const EXTRA_TABS: Tab[] = [
   { to: "/cc", label: "CC Activity", icon: "⌁" },
   { to: "/tones", label: "Tones", icon: "♪" },
   { to: "/spectrum", label: "Spectrum", icon: "≈" },
+  { to: "/constellation", label: "Constellation", icon: "✦" },
   { to: "/bookmarks", label: "Bookmarks", icon: "★" },
   { to: "/metrics", label: "Metrics", icon: "▰" },
   { to: "/devices", label: "Devices", icon: "⌗" },
@@ -136,6 +138,7 @@ export function App() {
           <Route path="/active" element={<Active />} />
           <Route path="/scanner" element={<Scanner />} />
           <Route path="/spectrum" element={<Spectrum />} />
+          <Route path="/constellation" element={<Constellation />} />
           <Route path="/bookmarks" element={<Bookmarks />} />
           <Route path="/systems" element={<Systems />} />
           <Route path="/talkgroups" element={<Talkgroups />} />

--- a/web/src/api/diag.ts
+++ b/web/src/api/diag.ts
@@ -1,0 +1,111 @@
+// Diagnostic IQ-stream client. Mirrors WS /api/v1/diag/iq.
+// Same connect/reconnect scaffolding pattern openSpectrumStream
+// (api/spectrum.ts) uses.
+
+import { type ClientConfig } from "./client";
+
+export interface IQPoint {
+  i: number;
+  q: number;
+}
+
+export interface IQFrame {
+  ts_ns: number;
+  sample_rate: number;
+  center_hz: number;
+  points: IQPoint[];
+  energy_dbfs: number;
+}
+
+export type FrameHandler = (f: IQFrame) => void;
+export type StatusHandler = (s: "connecting" | "open" | "closed") => void;
+
+export interface IQStream {
+  close(): void;
+}
+
+export interface IQOptions {
+  serial: string;
+  rate?: number; // target sample rate (sps), 100..20000, default 2000
+  onFrame: FrameHandler;
+  onStatus?: StatusHandler;
+}
+
+const INITIAL_BACKOFF = 500;
+const MAX_BACKOFF = 30_000;
+
+export function diagWebSocketURL(cfg: ClientConfig, opts: IQOptions): string {
+  const params = new URLSearchParams({ device: opts.serial });
+  if (opts.rate != null) params.set("rate", String(opts.rate));
+  const u = new URL(
+    `/api/v1/diag/iq?${params.toString()}`,
+    cfg.baseURL || window.location.href,
+  );
+  u.protocol = u.protocol === "https:" ? "wss:" : "ws:";
+  return u.toString();
+}
+
+export function openIQStream(cfg: ClientConfig, opts: IQOptions): IQStream {
+  let closed = false;
+  let ws: WebSocket | null = null;
+  let backoff = INITIAL_BACKOFF;
+  let reconnectTimer: number | undefined;
+
+  const setStatus = (s: "connecting" | "open" | "closed") => {
+    if (!closed) opts.onStatus?.(s);
+  };
+
+  const jittered = (base: number) => base / 2 + Math.random() * (base / 2);
+
+  const connect = () => {
+    if (closed) return;
+    setStatus("connecting");
+    const url = diagWebSocketURL(cfg, opts);
+    ws = new WebSocket(url);
+
+    ws.onopen = () => {
+      backoff = INITIAL_BACKOFF;
+      setStatus("open");
+    };
+
+    ws.onmessage = (ev) => {
+      if (closed) return;
+      try {
+        const frame = JSON.parse(ev.data) as IQFrame;
+        if (frame && Array.isArray(frame.points)) {
+          opts.onFrame(frame);
+        }
+      } catch {
+        // Drop malformed.
+      }
+    };
+
+    const onDown = () => {
+      if (closed) return;
+      ws = null;
+      setStatus("closed");
+      const wait = jittered(backoff);
+      backoff = Math.min(backoff * 2, MAX_BACKOFF);
+      reconnectTimer = window.setTimeout(connect, wait);
+    };
+    ws.onerror = onDown;
+    ws.onclose = onDown;
+  };
+
+  connect();
+
+  return {
+    close() {
+      closed = true;
+      setStatus("closed");
+      if (reconnectTimer !== undefined) window.clearTimeout(reconnectTimer);
+      if (ws) {
+        try {
+          ws.close();
+        } catch {
+          // ignore
+        }
+      }
+    },
+  };
+}

--- a/web/src/panels/Constellation.test.tsx
+++ b/web/src/panels/Constellation.test.tsx
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+
+vi.mock("../api/spectrum", () => ({
+  fetchSpectrumDevices: vi.fn(),
+}));
+
+vi.mock("../api/diag", () => ({
+  openIQStream: vi.fn(),
+}));
+
+import { fetchSpectrumDevices } from "../api/spectrum";
+import { openIQStream } from "../api/diag";
+import { useShared } from "../store/shared";
+import { Constellation } from "./Constellation";
+
+function resetStore() {
+  useShared.setState({
+    serverURL: "http://localhost:8080",
+    token: null,
+    connected: true,
+    wsStatus: "idle",
+    mutations: null,
+    lastError: null,
+    events: [],
+    activeCalls: [],
+    devices: [],
+    systems: [],
+    talkgroups: [],
+    health: null,
+    audio: null,
+    scanner: null,
+  });
+}
+
+describe("Constellation panel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetStore();
+  });
+
+  it("renders an empty-state when no SDRs are available", async () => {
+    vi.mocked(fetchSpectrumDevices).mockResolvedValue([]);
+    render(<Constellation />);
+    await waitFor(() => {
+      expect(screen.getByText("No SDRs available")).toBeInTheDocument();
+    });
+    expect(openIQStream).not.toHaveBeenCalled();
+  });
+
+  it("opens a diag IQ stream against the first device", async () => {
+    vi.mocked(fetchSpectrumDevices).mockResolvedValue([
+      {
+        serial: "rtl-1",
+        driver: "rtlsdr",
+        role: "control",
+        center_hz: 851_012_500,
+        sample_rate_hz: 2_048_000,
+      },
+    ]);
+    vi.mocked(openIQStream).mockReturnValue({ close: vi.fn() });
+
+    render(<Constellation />);
+    await waitFor(() => {
+      expect(openIQStream).toHaveBeenCalledTimes(1);
+    });
+    const callArgs = vi.mocked(openIQStream).mock.calls[0]?.[1];
+    expect(callArgs?.serial).toBe("rtl-1");
+    expect(callArgs?.rate).toBeGreaterThan(0);
+  });
+
+  it("shows the live status pill when the WS reports open", async () => {
+    vi.mocked(fetchSpectrumDevices).mockResolvedValue([
+      {
+        serial: "rtl-1",
+        driver: "rtlsdr",
+        role: "control",
+        center_hz: 0,
+        sample_rate_hz: 2_048_000,
+      },
+    ]);
+    vi.mocked(openIQStream).mockImplementation((_cfg, opts) => {
+      opts.onStatus?.("open");
+      return { close: vi.fn() };
+    });
+
+    render(<Constellation />);
+    await waitFor(() => {
+      expect(screen.getByText("live")).toBeInTheDocument();
+    });
+  });
+
+  it("surfaces device-discovery errors", async () => {
+    vi.mocked(fetchSpectrumDevices).mockRejectedValue(new Error("boom"));
+    render(<Constellation />);
+    await waitFor(() => {
+      expect(screen.getByText(/boom/)).toBeInTheDocument();
+    });
+  });
+});

--- a/web/src/panels/Constellation.tsx
+++ b/web/src/panels/Constellation.tsx
@@ -1,0 +1,198 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  fetchSpectrumDevices,
+  type SpectrumDevice,
+} from "../api/spectrum";
+import {
+  openIQStream,
+  type IQFrame,
+  type IQPoint,
+} from "../api/diag";
+import { selectClientConfig, useShared } from "../store/shared";
+
+// Constellation panel — 2D scatter of decimated IQ samples. Useful
+// for spotting the symbol-domain shape of whatever the SDR is tuned
+// to without launching a separate SDR receiver.
+//
+//   - DC bias / unmodulated carrier   →  one bright dot off-centre
+//   - PSK / QPSK                       →  two or four clusters at
+//                                         ±0.5+0i etc.
+//   - C4FM / FSK                       →  two or four arcs
+//   - AM voice                          →  rotating cluster, modulated
+//                                         in amplitude
+//   - Wideband noise                    →  diffuse circle around the
+//                                         origin
+//
+// 2 ksps decimated stream → ~50 ms / frame at 4 chunks per frame → a
+// canvas redraw every 50 ms is responsive without burning CPU.
+
+const TARGET_RATE_SPS = 2000;
+const POINT_BUFFER = 2000;       // how many recent points to render
+const CANVAS_PX = 360;           // square canvas; CSS scales to width
+const AXIS_PADDING = 14;
+
+type ConnState = "connecting" | "open" | "closed";
+
+export function Constellation() {
+  const cfg = useShared(selectClientConfig);
+  const [devices, setDevices] = useState<SpectrumDevice[]>([]);
+  const [selected, setSelected] = useState<string | null>(null);
+  const [conn, setConn] = useState<ConnState>("closed");
+  const [latest, setLatest] = useState<IQFrame | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const bufferRef = useRef<IQPoint[]>([]);
+
+  // Reuse the spectrum devices endpoint — same broker pool.
+  useEffect(() => {
+    let cancel = false;
+    (async () => {
+      try {
+        const list = await fetchSpectrumDevices(cfg);
+        if (cancel) return;
+        setDevices(list);
+        setError(null);
+        if (list.length > 0 && selected == null) setSelected(list[0].serial);
+      } catch (e) {
+        if (cancel) return;
+        setError(e instanceof Error ? e.message : String(e));
+      }
+    })();
+    return () => {
+      cancel = true;
+    };
+  }, [cfg, selected]);
+
+  useEffect(() => {
+    if (!selected) return;
+    bufferRef.current = [];
+    setLatest(null);
+
+    const stream = openIQStream(cfg, {
+      serial: selected,
+      rate: TARGET_RATE_SPS,
+      onFrame: (f) => {
+        setLatest(f);
+        const buf = bufferRef.current;
+        for (const p of f.points) buf.push(p);
+        if (buf.length > POINT_BUFFER) {
+          bufferRef.current = buf.slice(buf.length - POINT_BUFFER);
+        }
+        renderConstellation(canvasRef.current, bufferRef.current);
+      },
+      onStatus: setConn,
+    });
+    return () => stream.close();
+  }, [cfg, selected]);
+
+  const tuningLabel = useMemo(() => {
+    if (!latest) return "";
+    return `${(latest.center_hz / 1e6).toFixed(4)} MHz · ${latest.sample_rate} sps · ${latest.energy_dbfs.toFixed(1)} dBFS`;
+  }, [latest]);
+
+  return (
+    <div className="space-y-3">
+      <header className="flex flex-wrap items-center justify-between gap-3">
+        <h2 className="text-xl font-semibold">Constellation</h2>
+        <div className="flex items-center gap-2 text-xs">
+          <span className="text-muted">SDR:</span>
+          <select
+            className="bg-surface border border-border rounded px-2 py-1"
+            value={selected ?? ""}
+            onChange={(e) => setSelected(e.target.value || null)}
+            disabled={devices.length === 0}
+          >
+            {devices.length === 0 && <option value="">No SDRs available</option>}
+            {devices.map((d) => (
+              <option key={d.serial} value={d.serial}>
+                {d.serial} · {d.role}
+              </option>
+            ))}
+          </select>
+          <ConnPill state={conn} />
+        </div>
+      </header>
+
+      {error && (
+        <div className="rounded border border-red-700/40 bg-red-900/20 text-red-200 text-xs px-3 py-2">
+          {error}
+        </div>
+      )}
+
+      <div className="font-mono text-xs text-muted">{tuningLabel || "—"}</div>
+
+      <div className="rounded border border-border bg-black flex items-center justify-center">
+        <canvas
+          ref={canvasRef}
+          width={CANVAS_PX}
+          height={CANVAS_PX}
+          className="block"
+          style={{ width: CANVAS_PX, height: CANVAS_PX, imageRendering: "pixelated" }}
+          aria-label="IQ constellation scatter"
+        />
+      </div>
+
+      <div className="text-[11px] text-muted">
+        Plots decimated IQ samples ({TARGET_RATE_SPS} sps). Bright = recent.
+        Clusters at ±0.5+0i suggest PSK; concentric arcs suggest FSK;
+        a diffuse circle is wideband noise.
+      </div>
+    </div>
+  );
+}
+
+function ConnPill({ state }: { state: ConnState }) {
+  if (state === "open") return <span className="pill-ok">live</span>;
+  if (state === "connecting") return <span className="pill-warn">connecting</span>;
+  return <span className="pill-err">offline</span>;
+}
+
+function renderConstellation(canvas: HTMLCanvasElement | null, points: IQPoint[]) {
+  if (!canvas) return;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return;
+  const w = canvas.width;
+  const h = canvas.height;
+
+  // Background.
+  ctx.fillStyle = "rgb(0, 0, 0)";
+  ctx.fillRect(0, 0, w, h);
+
+  // Axes.
+  ctx.strokeStyle = "rgba(120, 120, 140, 0.35)";
+  ctx.lineWidth = 1;
+  ctx.beginPath();
+  ctx.moveTo(w / 2, AXIS_PADDING);
+  ctx.lineTo(w / 2, h - AXIS_PADDING);
+  ctx.moveTo(AXIS_PADDING, h / 2);
+  ctx.lineTo(w - AXIS_PADDING, h / 2);
+  ctx.stroke();
+
+  // Reference rings at |z| = 0.5 and |z| = 1.0.
+  ctx.strokeStyle = "rgba(120, 120, 140, 0.2)";
+  ctx.beginPath();
+  ctx.arc(w / 2, h / 2, (w / 2 - AXIS_PADDING) * 0.5, 0, Math.PI * 2);
+  ctx.stroke();
+  ctx.beginPath();
+  ctx.arc(w / 2, h / 2, (w / 2 - AXIS_PADDING) * 1.0, 0, Math.PI * 2);
+  ctx.stroke();
+
+  // Plot points with fade-from-old. Older indices in the buffer are
+  // older samples; render them dimmer.
+  const n = points.length;
+  if (n === 0) return;
+  const half = (w / 2 - AXIS_PADDING);
+  for (let idx = 0; idx < n; idx++) {
+    const p = points[idx];
+    // Map |i|, |q| of 1.0 to half the canvas (so the unit circle
+    // touches the rim).
+    const x = w / 2 + p.i * half;
+    const y = h / 2 - p.q * half; // canvas Y grows downward
+    // Fade: oldest 25% are dim, newest 25% are bright.
+    const age = idx / n; // 0..1
+    const alpha = 0.15 + 0.85 * age * age;
+    ctx.fillStyle = `rgba(120, 210, 255, ${alpha})`;
+    ctx.fillRect(x - 1, y - 1, 2, 2);
+  }
+}


### PR DESCRIPTION
## Summary

Phase 6 of the trunking-adjacent feature plan (#365): adds a **Constellation viewer** — a 2D scatter of decimated IQ samples on a canvas. Useful for visually identifying signal type (PSK / FSK / C4FM / AM / noise), spotting frequency offset, and sanity-checking demod / equalizer health before committing to a deeper decode pipeline.

Builds on the iqtap broker from #365 so the viewer taps the same IQ stream the trunking decoder reads — no extra USB pressure on the SDR.

## What you see

| Shape | Likely signal |
| --- | --- |
| One bright dot off-centre | DC bias / unmodulated carrier |
| Two clusters at ±0.5 + 0i | BPSK |
| Four clusters in a square | QPSK / π/4-DQPSK |
| Two horizontal arcs | 2-FSK |
| Four arcs (top + bottom of unit circle) | C4FM / 4-FSK |
| Diffuse rotating cluster, amplitude-modulated | AM voice |
| Diffuse circle around the origin | Wideband noise / nothing on this frequency |
| Spiral expanding outward | Strong frequency offset (re-tune or fix PPM) |

## What's in the box

- **`internal/dsp/diag/iqstream.go`** — stride decimator (2 ksps default), per-frame dBFS energy estimator, ChunksPerFrame batching. Pure Go, no CGO. No anti-alias filter (visualization, not spectral reconstruction).
- **`internal/api/diag.go`** — `DiagProvider` interface + `WS /api/v1/diag/iq?device=...&rate=...` handler with the same scaffolding the Spectrum WS uses (auto-ping every 30 s, JSON frames, CORS-aware upgrade).
- **`cmd/gophertrunk/diag_provider.go`** — daemon-side provider over the iqtap broker map. Reuses the broker's `CenterHz` / `SampleRateHz` getters so frequency context follows retunes.
- **`web/src/api/diag.ts`** — typed WS client with auto-reconnect / backoff (same pattern as `api/spectrum.ts`).
- **`web/src/panels/Constellation.tsx`** — canvas scatter renderer: fade-from-old (oldest 25% dim, newest bright), reference rings at |z|=0.5 and 1.0, dBFS energy banner, SDR picker shared with the Spectrum panel. Registered under `/constellation` with a ✦ icon.

## Tests

- **9 decimator tests** — stride math, rate-cap, frame emission after `ChunksPerFrame`, energy correctness for unit-amplitude DC, `ctx.Done` + input-close exit paths, slow-consumer drop counting, nil-channel rejection
- **3 API tests** — 503 when provider isn't wired, 400 on missing `device` param, end-to-end WS frame delivery via fake provider
- **4 web panel tests** — empty-state ("No SDRs available"), first-device auto-pick, live status pill, device-discovery error surfacing
- **App.panels regression** — `/constellation` added to the route-mount sweep

All clean: **85 Go packages pass** (was 84 — new `internal/dsp/diag`), **82 web tests pass** (was 77), `go vet` clean, `gofmt -l .` clean, `npm run typecheck` clean, SPA build OK.

## Architecture notes

- **Per-WS-subscriber decimator.** One decimator + broker subscription per open WS. CPU scales linearly with client count; this matches what the Spectrum provider does and is acceptable for the single-operator audience.
- **Decimation by stride, no AA filter.** The target rate (2 ksps) is a tiny fraction of the input (2.048 MS/s typical), and the visualization doesn't care about spectral fidelity — strided sampling is simpler and deterministic. Wideband signals appear smeared; the panel is most useful pointed at a narrow-channelized signal (single FM repeater, P25 voice channel) rather than a wideband capture.
- **Reuses the iqtap broker.** Multiple panels open against the same SDR share the broker subscription up to its drop-on-full bound — they don't double the SDR's USB / CPU cost. Same fan-out plumbing the live Spectrum panel uses.

## Docs

- **`docs/constellation.md`** — shape → modulation cheat sheet, how the decimation works, scope notes (not a demodulator, can't replace per-protocol decode), implementation pointers
- **`docs/_data/nav.yml`** — entry added under "Operate"
- **`README.md`** — Constellation viewer bullet under Features
- **`CHANGELOG.md`** — `[Unreleased]` → Added

## Test plan

- [x] `go test ./...` — 85 packages pass
- [x] `npm run test` — 82 web tests pass (13 test files)
- [x] `npm run typecheck` clean
- [x] `npm run build` — SPA bundle builds
- [x] `go vet ./...` clean
- [x] `gofmt -l .` clean
- [ ] Manual smoke: tune to a known PSK signal and confirm clusters, then to FM voice and confirm arcs (deferred — hardware-on-hand step)

## Status of the 7-phase plan after this

- ✅ Phase 0 (broker) — #365
- ✅ Phase 1 backend+web (Spectrum) — #365
- ✅ Phase 2a (CC Activity) — #369
- ✅ Phase 2b (rigctld) — #367
- ✅ Phase 2c (rtl_tcp client) — #366
- ✅ Phase 4 (Bookmarks) — #368
- ✅ Phase 6 (Constellation) — this PR
- ⏳ Phase 1 TUI, Phase 3 (POCSAG/FLEX paging), Phase 5 (APRS/DSC/AIS/ADS-B), Phase 7 (M17 + Codec2) — remaining

Each remaining phase is substantial DSP / protocol work (multi-week per the original plan) that warrants its own dedicated PR.

https://claude.ai/code/session_01YUgvat8WpF5YaSuEAqWMr2

---
_Generated by [Claude Code](https://claude.ai/code/session_01YUgvat8WpF5YaSuEAqWMr2)_