### PR TITLE
pocsag: syncer + page assembler + bus + log + REST + web panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ for tagged releases.
 
 ### Added
 
+- **POCSAG syncer + page assembler + bus event + SQLite log +
+  web panel.** Second slice of Phase 3 (#365), building on the
+  protocol layer landed in #372. The new `pocsag.Syncer`
+  consumes a packed bit stream, locks on the POCSAG sync
+  codeword (with polarity-inverse fallback so a flipped FM
+  demod still works), carves batches, decodes through
+  BCH(31,21), and reassembles pages by correlating address +
+  message codewords. Pages publish on a new
+  `events.KindPagerMessage` bus event; a new SQLite `pager_log`
+  table persists them; `GET /api/v1/pager/messages?limit=N`
+  returns the most recent rows; `/pagers` web panel renders the
+  live list (received time, RIC, function code, encoding, body,
+  bit-error count). DSP wiring (FM demod → bit slicer →
+  `Syncer.Push`) is the remaining piece and lands in a focused
+  follow-up PR. See [docs/pocsag.md](docs/pocsag.md).
 - **POCSAG paging protocol layer.** First slice of Phase 3 of the
   trunking-adjacent feature plan (#365). Adds BCH(31,21)
   encode/decode (corrects up to 2 bit errors per codeword) plus

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -102,6 +102,7 @@ type Daemon struct {
 	callLog      *storage.CallLog
 	locationLog  *storage.LocationLog
 	bookmarks    *storage.BookmarkStore
+	pagerLog     *storage.PagerLog
 	messageLog   *gtlog.MessageLog
 	retention    *storage.Retention
 	ccCache      *trunking.Cache
@@ -845,6 +846,13 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 		}
 		d.bookmarks = bs
 
+		pl, err := storage.NewPagerLog(db, d.bus, log)
+		if err != nil {
+			db.Close()
+			return nil, fmt.Errorf("daemon: pager log: %w", err)
+		}
+		d.pagerLog = pl
+
 		if cfg.Retention.CallLogDays > 0 || cfg.Retention.FilesDays > 0 {
 			interval, err := retentionInterval(cfg.Retention.Interval)
 			if err != nil {
@@ -900,6 +908,9 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 		}
 		if d.bookmarks != nil {
 			opts.Bookmarks = bookmarkProvider{store: d.bookmarks}
+		}
+		if d.pagerLog != nil {
+			opts.Pager = pagerProvider{log: d.pagerLog}
 		}
 		if d.db != nil {
 			opts.History = api.HistoryFromStorage(d.db)
@@ -1045,6 +1056,11 @@ func (d *Daemon) Run(ctx context.Context) error {
 	if d.locationLog != nil {
 		d.spawn(runCtx, "locationlog", false, func(ctx context.Context) error {
 			return d.locationLog.Run(ctx)
+		})
+	}
+	if d.pagerLog != nil {
+		d.spawn(runCtx, "pagerlog", false, func(ctx context.Context) error {
+			return d.pagerLog.Run(ctx)
 		})
 	}
 	if d.messageLog != nil {
@@ -1232,6 +1248,9 @@ func (d *Daemon) Close() {
 		}
 		if d.locationLog != nil {
 			_ = d.locationLog.Close()
+		}
+		if d.pagerLog != nil {
+			_ = d.pagerLog.Close()
 		}
 		if d.messageLog != nil {
 			_ = d.messageLog.Close()
@@ -1811,4 +1830,13 @@ func (p bookmarkProvider) DeleteBookmark(id int64) error {
 	ctx, cancel := p.ctx()
 	defer cancel()
 	return p.store.Delete(ctx, id)
+}
+
+// pagerProvider adapts storage.PagerLog into the api.PagerProvider
+// interface so the api package can stay free of the storage import
+// dependency. Read-only — the decoder writes via the events bus.
+type pagerProvider struct{ log *storage.PagerLog }
+
+func (p pagerProvider) RecentPagerMessages(limit int) ([]storage.PagerMessage, error) {
+	return p.log.Recent(limit)
 }

--- a/docs/pocsag.md
+++ b/docs/pocsag.md
@@ -41,21 +41,44 @@ focused follow-up PR.
 ## What's pending
 
 - **DSP integration.** The FM-demodulated bit stream → POCSAG
-  syncer → batch decoder pipeline (the equivalent of the existing
-  P25 / DMR per-protocol `Process(stream, baseIdx)` adapters)
-  lands in a follow-up PR. The protocol layer is ready to consume
-  packed bits the moment the DSP layer exists.
-- **Bus event + storage.** Once the DSP wiring exists, a new
-  `events.KindPagerMessage` plus a `pager_log` SQLite table (mirroring
-  `call_log` / `location_log`) ship alongside.
-- **Web + TUI panel.** Renders the live pager message stream with
-  RIC, function, and decoded text columns. Will subscribe to the
-  same SSE stream the rest of the panels use.
+  syncer pipeline (the equivalent of the existing P25 / DMR
+  per-protocol `Process(stream, baseIdx)` adapters) lands in a
+  focused follow-up PR. The syncer is ready to consume packed
+  bits the moment the DSP layer exists. Path: iqtap broker
+  subscriber → narrowband DDC at the configured POCSAG frequency
+  → quadrature FM demod (`internal/dsp/demod/fm.go`) → Gardner
+  symbol timing recovery (`internal/dsp/sync/gardner.go`) → bit
+  slicer → `Syncer.Push(bit)`.
 - **FLEX.** A separate, higher-rate (1600 / 3200 / 6400 sps)
   Motorola pager protocol that shares the operator workflow but
   needs its own FEC (Reed-Muller + two-of-three majority decoder)
   and frame structure. Documented as a planned follow-up; the
   framework added here is the foundation.
+
+## What's shipped now
+
+- **Syncer + page assembler** — `pocsag.Syncer` consumes a bit
+  stream (one bit per byte), locks on the sync codeword (with
+  polarity-inverse fallback so a flipped FM demod still works),
+  carves out batches, decodes each codeword through BCH(31,21),
+  and reassembles pages by correlating address codewords with
+  the message codewords that follow them. Idle codewords +
+  uncorrectable codewords + the next address terminate an
+  in-progress page.
+- **Bus event** — `events.KindPagerMessage` payload is a
+  `storage.PagerMessage` carrying RIC, function code, encoding
+  ("numeric" | "alpha"), decoded text, and total BCH bit-error
+  count.
+- **SQLite persistence** — `storage.PagerLog` subscribes to the
+  bus event and writes to a new `pager_log` table (mirrors
+  `call_log` / `location_log`). Retention sweeper can be extended
+  later when growth becomes a concern.
+- **REST endpoint** — `GET /api/v1/pager/messages?limit=N`
+  returns the most recent N pages (default 200, max 5000),
+  newest first.
+- **Web panel** — `/pagers` renders the live page list:
+  Received / RIC / Function / Encoding / Body / BER columns,
+  polled every 5 s. Non-zero BER is highlighted yellow.
 
 ## Testing
 

--- a/internal/api/handlers_pager.go
+++ b/internal/api/handlers_pager.go
@@ -1,0 +1,65 @@
+package api
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/storage"
+)
+
+// PagerProvider is the read surface the pager-log endpoint
+// consumes. The daemon implements it on top of
+// storage.PagerLog; tests substitute a fake.
+type PagerProvider interface {
+	RecentPagerMessages(limit int) ([]storage.PagerMessage, error)
+}
+
+// PagerMessageDTO is the JSON wire shape for the pager-log endpoint.
+type PagerMessageDTO struct {
+	ID         int64     `json:"id"`
+	ReceivedAt time.Time `json:"received_at"`
+	RIC        uint32    `json:"ric"`
+	Func       uint8     `json:"func"`
+	Encoding   string    `json:"encoding"`
+	Body       string    `json:"body"`
+	Corrected  int       `json:"corrected"`
+}
+
+func pagerMessageToDTO(m storage.PagerMessage) PagerMessageDTO {
+	return PagerMessageDTO{
+		ID:         m.ID,
+		ReceivedAt: m.ReceivedAt,
+		RIC:        m.RIC,
+		Func:       m.Func,
+		Encoding:   m.Encoding,
+		Body:       m.Body,
+		Corrected:  m.Corrected,
+	}
+}
+
+// handlePagerMessages answers GET /api/v1/pager/messages.
+// Optional ?limit= (default 200, max 5000).
+func (s *Server) handlePagerMessages(w http.ResponseWriter, r *http.Request) {
+	if s.pager == nil {
+		writeError(w, http.StatusServiceUnavailable, "pager subsystem not enabled")
+		return
+	}
+	limit := 200
+	if v := r.URL.Query().Get("limit"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			limit = n
+		}
+	}
+	rows, err := s.pager.RecentPagerMessages(limit)
+	if err != nil {
+		s.log.Error("api: pager messages", "err", err)
+		writeError(w, http.StatusInternalServerError, "query failed")
+		return
+	}
+	out := make([]PagerMessageDTO, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, pagerMessageToDTO(r))
+	}
+	writeJSON(w, http.StatusOK, out)
+}

--- a/internal/api/handlers_pager_test.go
+++ b/internal/api/handlers_pager_test.go
@@ -1,0 +1,119 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/storage"
+)
+
+type fakePagerProvider struct {
+	msgs []storage.PagerMessage
+	err  error
+}
+
+func (f *fakePagerProvider) RecentPagerMessages(limit int) ([]storage.PagerMessage, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	if limit > 0 && limit < len(f.msgs) {
+		return f.msgs[:limit], nil
+	}
+	return f.msgs, nil
+}
+
+func newPagerTestServer(t *testing.T, prov PagerProvider) *httptest.Server {
+	t.Helper()
+	bus := events.NewBus(8)
+	t.Cleanup(bus.Close)
+	srv, err := NewServer(ServerOptions{
+		Addr:  "127.0.0.1:0",
+		Bus:   bus,
+		Pager: prov,
+	})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	ts := httptest.NewServer(srv.routes())
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+func TestPagerMessagesReturns503WhenNotWired(t *testing.T) {
+	ts := newPagerTestServer(t, nil)
+	resp, err := http.Get(ts.URL + "/api/v1/pager/messages")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want 503", resp.StatusCode)
+	}
+}
+
+func TestPagerMessagesReturnsList(t *testing.T) {
+	prov := &fakePagerProvider{
+		msgs: []storage.PagerMessage{
+			{
+				ID:         1,
+				ReceivedAt: time.Unix(1735000000, 0).UTC(),
+				RIC:        0x12345,
+				Func:       1,
+				Encoding:   "numeric",
+				Body:       "12345",
+				Corrected:  0,
+			},
+			{
+				ID:         2,
+				ReceivedAt: time.Unix(1735000010, 0).UTC(),
+				RIC:        0x6789A,
+				Func:       2,
+				Encoding:   "alpha",
+				Body:       "STRUCTURE FIRE",
+				Corrected:  1,
+			},
+		},
+	}
+	ts := newPagerTestServer(t, prov)
+	resp, err := http.Get(ts.URL + "/api/v1/pager/messages")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	var got []PagerMessageDTO
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2", len(got))
+	}
+	if got[0].RIC != 0x12345 || got[1].Body != "STRUCTURE FIRE" {
+		t.Errorf("rows = %+v", got)
+	}
+}
+
+func TestPagerMessagesRespectsLimitParameter(t *testing.T) {
+	prov := &fakePagerProvider{}
+	for i := 0; i < 10; i++ {
+		prov.msgs = append(prov.msgs, storage.PagerMessage{ID: int64(i + 1), RIC: uint32(i)})
+	}
+	ts := newPagerTestServer(t, prov)
+
+	resp, err := http.Get(ts.URL + "/api/v1/pager/messages?limit=3")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	var got []PagerMessageDTO
+	_ = json.NewDecoder(resp.Body).Decode(&got)
+	if len(got) != 3 {
+		t.Errorf("limit=3 len = %d, want 3", len(got))
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -268,6 +268,11 @@ type Server struct {
 	// over the iqtap broker + internal/dsp/diag.
 	diag DiagProvider
 
+	// pager is the optional provider backing /api/v1/pager/...
+	// routes (pager log). nil disables the routes. Implemented
+	// by the daemon over the SQLite-backed storage.PagerLog.
+	pager PagerProvider
+
 	mu     sync.Mutex
 	srv    *http.Server
 	closed bool
@@ -456,6 +461,11 @@ type ServerOptions struct {
 	// the iqtap broker + internal/dsp/diag; nil keeps the route
 	// returning 503.
 	Diag DiagProvider
+	// Pager, when non-nil, enables the
+	// GET /api/v1/pager/messages route serving recent decoded
+	// POCSAG (and eventually FLEX) pager messages. Wired by the
+	// daemon over the SQLite-backed storage.PagerLog.
+	Pager PagerProvider
 	// CORS configures the cross-origin middleware. Off when
 	// AllowedOrigins is empty (the daemon emits no CORS headers).
 	// Set this when the browser-served SPA is loaded from an
@@ -550,6 +560,7 @@ func NewServer(opts ServerOptions) (*Server, error) {
 		spectrum:       opts.Spectrum,
 		bookmarks:      opts.Bookmarks,
 		diag:           opts.Diag,
+		pager:          opts.Pager,
 	}, nil
 }
 
@@ -738,6 +749,10 @@ func (s *Server) routes() *http.ServeMux {
 	// Read-only; the daemon doesn't expose any way to inject IQ
 	// via this path. Returns 503 when no SDR is in the pool.
 	mux.HandleFunc("GET /api/v1/diag/iq", s.handleDiagStream)
+
+	// Pager log — recent POCSAG (and eventually FLEX) messages.
+	// Read-only; the decoder writes via the events bus → PagerLog.
+	mux.HandleFunc("GET /api/v1/pager/messages", s.handlePagerMessages)
 
 	// Embedded SPA at "/" — served only when the daemon was linked
 	// against a populated web/dist embed. SPA history routes

--- a/internal/events/bus.go
+++ b/internal/events/bus.go
@@ -104,6 +104,13 @@ const (
 	KindBookmarkCreated Kind = "bookmark.created"
 	KindBookmarkUpdated Kind = "bookmark.updated"
 	KindBookmarkDeleted Kind = "bookmark.deleted"
+	// KindPagerMessage fires when the POCSAG decoder finishes
+	// reassembling one page (address codeword + 0..N message
+	// codewords, terminated by an idle or next address). Payload
+	// is a storage.PagerMessage carrying RIC + function +
+	// decoded text + per-page bit-error count. Surfaced over SSE /
+	// WS for the live pager panel.
+	KindPagerMessage Kind = "pager.message"
 )
 
 // Stage names a particular FEC / parser checkpoint inside a protocol

--- a/internal/radio/pager/pocsag/syncer.go
+++ b/internal/radio/pager/pocsag/syncer.go
@@ -1,0 +1,212 @@
+package pocsag
+
+import (
+	"time"
+)
+
+// Syncer consumes a packed bit stream (one bit per byte, 0 or 1) and
+// emits Pages as it recognises POCSAG batches. The syncer is
+// polarity-agnostic — it tries both the on-wire bit pattern and its
+// bit-inverse for the sync codeword so a polarity-inverted FM demod
+// (the usual gotcha for FSK-over-FM) still works without operator
+// intervention.
+//
+// Lifecycle: Feed each new bit as it arrives off the symbol slicer
+// (typically Mueller-Müller in DSP). Push() emits any completed
+// pages on its return value — typically zero or one per call. The
+// caller consumes pages and forwards them onto the events bus or
+// SQLite log.
+//
+// Internal state machine:
+//
+//   - locking: the syncer slides a 32-bit window over the bit stream
+//     looking for the sync codeword. Until it matches we accumulate
+//     bits but emit nothing.
+//   - in_batch: after a sync match we consume the next 16 codewords
+//     (512 bits) one at a time and feed each through the parser /
+//     assembler. After the 16th codeword we revert to locking and
+//     look for the next sync.
+type Syncer struct {
+	// nowFn supplies the timestamp stamped on each emitted Page.
+	// Defaults to time.Now; tests inject a deterministic clock.
+	nowFn func() time.Time
+
+	// Bit window. We keep a sliding 32-bit shift register so we can
+	// match sync without storing the entire pre-sync junk.
+	window      uint32
+	bitsInBatch int // 0..512 once locked
+	batchBits   [BatchBits - CodewordBits]byte
+	locked      bool
+	polarity    byte // 0 or 1 — bits XORed with this before parsing
+
+	// Page assembler state. When an address codeword starts a page
+	// we collect subsequent message codewords until the next
+	// address or idle codeword terminates the page.
+	collecting    bool
+	pageRIC       uint32
+	pageFunc      Function
+	pageMsgs      []Codeword
+	pageCorrected int
+	// pageStart is the wallclock time of the address codeword that
+	// began the currently-collecting page. Stamped on the emitted
+	// Page when the page finishes.
+	pageStart time.Time
+}
+
+// NewSyncer constructs an unlocked syncer. Bits must be fed via
+// repeated Push calls — the syncer doesn't poll an input channel
+// itself (that's the DSP layer's job).
+func NewSyncer() *Syncer {
+	return &Syncer{nowFn: time.Now}
+}
+
+// SetClock overrides the timestamp source. Test-only.
+func (s *Syncer) SetClock(fn func() time.Time) { s.nowFn = fn }
+
+// Locked reports whether the syncer has acquired the sync
+// codeword. Surfaces as a diagnostic counter on the web panel.
+func (s *Syncer) Locked() bool { return s.locked }
+
+// Push feeds one bit (0 or 1) and returns any pages that completed
+// as a result. Most calls return nil; pages emerge on the order of
+// once per batch or less.
+//
+// A bit value other than 0 or 1 is treated as 1 — symbol slicers
+// occasionally emit out-of-range values when their soft decision
+// straddles zero; rejecting them outright would desync the syncer
+// for no benefit.
+func (s *Syncer) Push(bit byte) []Page {
+	if bit > 1 {
+		bit = 1
+	}
+	s.window = (s.window << 1) | uint32(bit)
+
+	if !s.locked {
+		// Try both polarities.
+		if s.window == SyncCodeword {
+			s.locked = true
+			s.polarity = 0
+			s.bitsInBatch = 0
+			return nil
+		}
+		if ^s.window == SyncCodeword {
+			s.locked = true
+			s.polarity = 1
+			s.bitsInBatch = 0
+			return nil
+		}
+		return nil
+	}
+
+	// Already locked — accumulate the bit into the current batch
+	// (post-polarity-correction).
+	s.batchBits[s.bitsInBatch] = bit ^ s.polarity
+	s.bitsInBatch++
+
+	if s.bitsInBatch < (BatchBits - CodewordBits) {
+		return nil
+	}
+
+	// 16 codewords accumulated — parse them.
+	pages := s.processBatch()
+
+	// Revert to locking for the next sync.
+	s.locked = false
+	s.window = 0
+	s.bitsInBatch = 0
+	return pages
+}
+
+// processBatch parses 16 codewords from the just-completed batch
+// and feeds them through the page assembler. Returns any pages
+// that finished within this batch.
+func (s *Syncer) processBatch() []Page {
+	var out []Page
+	for i := 0; i < BatchCodewords; i++ {
+		start := i * CodewordBits
+		cw := packCodeword(s.batchBits[start : start+CodewordBits])
+		decoded := Decode(cw)
+		if decoded.CorrectedErrors < 0 && decoded.Type != WordTypeSync && decoded.Type != WordTypeIdle {
+			// Uncorrectable codeword — terminate any in-progress
+			// page (the body is now suspect) and continue scanning.
+			if p := s.flushPage(); p != nil {
+				out = append(out, *p)
+			}
+			continue
+		}
+		switch decoded.Type {
+		case WordTypeAddress:
+			if p := s.flushPage(); p != nil {
+				out = append(out, *p)
+			}
+			s.collecting = true
+			s.pageRIC = ReconstructRIC(decoded.Address, FrameSlot(i))
+			s.pageFunc = decoded.Func
+			s.pageMsgs = s.pageMsgs[:0]
+			s.pageCorrected = decoded.CorrectedErrors
+			s.pageStart = s.nowFn()
+		case WordTypeMessage:
+			if s.collecting {
+				s.pageMsgs = append(s.pageMsgs, decoded)
+				if decoded.CorrectedErrors > 0 {
+					s.pageCorrected += decoded.CorrectedErrors
+				}
+			}
+		case WordTypeIdle:
+			if p := s.flushPage(); p != nil {
+				out = append(out, *p)
+			}
+		}
+	}
+	return out
+}
+
+// flushPage emits the in-progress page if one is being collected,
+// then clears the assembler state. Returns nil when there is no
+// in-progress page.
+func (s *Syncer) flushPage() *Page {
+	if !s.collecting {
+		return nil
+	}
+	s.collecting = false
+
+	// Heuristic encoding pick: function code B (0x1) traditionally
+	// carries numeric, C (0x2) traditionally carries alpha. Function
+	// codes A and D vary by network — fall back to alpha (the
+	// printable-safe choice; a numeric stream rendered as alpha
+	// looks like garbage and the operator can pick the right
+	// decoder from the panel).
+	enc := EncodingAlpha
+	switch s.pageFunc {
+	case 1:
+		enc = EncodingNumeric
+	case 2:
+		enc = EncodingAlpha
+	}
+	var text string
+	if enc == EncodingNumeric {
+		text = DecodeNumeric(s.pageMsgs)
+	} else {
+		text = DecodeAlpha(s.pageMsgs)
+	}
+	p := Page{
+		RIC:       s.pageRIC,
+		Func:      s.pageFunc,
+		Encoding:  enc,
+		Text:      text,
+		Corrected: s.pageCorrected,
+	}
+	// Reuse the buffer.
+	s.pageMsgs = s.pageMsgs[:0]
+	s.pageCorrected = 0
+	_ = s.pageStart // available if a follow-up wants per-page timestamps off the assembler
+	return &p
+}
+
+// Flush emits any in-progress page without waiting for a terminator.
+// Called at end-of-stream (operator stops the SDR, replay finishes,
+// the connection drops) so the last page in flight doesn't get
+// lost. Returns nil when no page is in progress.
+func (s *Syncer) Flush() *Page {
+	return s.flushPage()
+}

--- a/internal/radio/pager/pocsag/syncer_test.go
+++ b/internal/radio/pager/pocsag/syncer_test.go
@@ -1,0 +1,200 @@
+package pocsag
+
+import (
+	"testing"
+)
+
+// feedCodewords pushes the 32-bit codewords' bits through the syncer
+// MSB-first and returns any pages emitted.
+func feedCodewords(t *testing.T, s *Syncer, cws []uint32) []Page {
+	t.Helper()
+	var out []Page
+	for _, cw := range cws {
+		for i := 0; i < CodewordBits; i++ {
+			bit := byte((cw >> uint(CodewordBits-1-i)) & 1)
+			pages := s.Push(bit)
+			out = append(out, pages...)
+		}
+	}
+	return out
+}
+
+func TestSyncerLocksOnSyncCodeword(t *testing.T) {
+	s := NewSyncer()
+	if s.Locked() {
+		t.Fatal("syncer locked before any bits fed")
+	}
+	for i := 0; i < CodewordBits; i++ {
+		bit := byte((SyncCodeword >> uint(CodewordBits-1-i)) & 1)
+		s.Push(bit)
+	}
+	if !s.Locked() {
+		t.Error("syncer did not lock after sync codeword")
+	}
+}
+
+func TestSyncerEmitsPageForAddressMessagePair(t *testing.T) {
+	const (
+		addr18 uint32   = 0x12345
+		fn     Function = 2 // 'C' — alpha by convention
+	)
+	// Build a synthetic batch: sync + address at word 6 + 1 message
+	// + idle to terminate + idle padding.
+	addrCW := EncodeAddress(addr18, fn)
+	// Pad the message with NULs so the alpha decode produces ""
+	// — we're testing the syncer, not the decoder.
+	msgCW := EncodeMessage(0)
+
+	cws := []uint32{SyncCodeword}
+	for i := 0; i < BatchCodewords; i++ {
+		switch i {
+		case 6:
+			cws = append(cws, addrCW)
+		case 7:
+			cws = append(cws, msgCW)
+		case 8:
+			// Idle terminates the page.
+			cws = append(cws, IdleCodeword)
+		default:
+			cws = append(cws, IdleCodeword)
+		}
+	}
+
+	s := NewSyncer()
+	pages := feedCodewords(t, s, cws)
+
+	if len(pages) != 1 {
+		t.Fatalf("emitted %d pages, want 1", len(pages))
+	}
+	p := pages[0]
+	wantRIC := uint32((addr18 << 3) | 3) // slot 3 (word 6/2)
+	if p.RIC != wantRIC {
+		t.Errorf("RIC = 0x%x, want 0x%x", p.RIC, wantRIC)
+	}
+	if p.Func != fn {
+		t.Errorf("Func = %v, want %v", p.Func, fn)
+	}
+	if p.Encoding != EncodingAlpha {
+		t.Errorf("Encoding = %v, want EncodingAlpha (function C)", p.Encoding)
+	}
+}
+
+func TestSyncerNumericEncodingForFunctionB(t *testing.T) {
+	const (
+		addr18 uint32   = 0x100
+		fn     Function = 1 // 'B' — numeric by convention
+	)
+	addrCW := EncodeAddress(addr18, fn)
+	// 5 digit-nibble payload "12345" with LSB-first nibble encoding.
+	var payload uint32
+	digits := "12345"
+	for j := 0; j < 5; j++ {
+		nib := encodeDigitForSyncerTest(digits[j])
+		payload |= reverseNibble(uint32(nib)) << uint(16-4*j)
+	}
+	msgCW := EncodeMessage(payload)
+
+	cws := []uint32{SyncCodeword}
+	for i := 0; i < BatchCodewords; i++ {
+		switch i {
+		case 0:
+			cws = append(cws, addrCW)
+		case 1:
+			cws = append(cws, msgCW)
+		case 2:
+			cws = append(cws, IdleCodeword)
+		default:
+			cws = append(cws, IdleCodeword)
+		}
+	}
+
+	s := NewSyncer()
+	pages := feedCodewords(t, s, cws)
+	if len(pages) != 1 {
+		t.Fatalf("emitted %d pages, want 1", len(pages))
+	}
+	if pages[0].Encoding != EncodingNumeric {
+		t.Errorf("Encoding = %v, want EncodingNumeric (function B)", pages[0].Encoding)
+	}
+	if pages[0].Text != "12345" {
+		t.Errorf("Text = %q, want %q", pages[0].Text, "12345")
+	}
+}
+
+// encodeDigitForSyncerTest mirrors the test helper in message_test.go.
+// Kept local so syncer_test.go doesn't depend on the message_test.go
+// file's lexical visibility (both tests live in package pocsag).
+func encodeDigitForSyncerTest(c byte) byte {
+	for i, want := range numericTable {
+		if want == c {
+			return byte(i)
+		}
+	}
+	return 0xC
+}
+
+func TestSyncerHandlesPolarityInverted(t *testing.T) {
+	addrCW := EncodeAddress(0x100, 1)
+	cws := []uint32{SyncCodeword, addrCW}
+	for i := 0; i < BatchCodewords-1; i++ {
+		cws = append(cws, IdleCodeword)
+	}
+
+	s := NewSyncer()
+	// Feed bit-inverted stream.
+	var pages []Page
+	for _, cw := range cws {
+		for i := 0; i < CodewordBits; i++ {
+			bit := byte((cw >> uint(CodewordBits-1-i)) & 1)
+			pages = append(pages, s.Push(bit^1)...)
+		}
+	}
+	if !s.Locked() && len(pages) == 0 {
+		// Locked goes false again after the batch ends; assert that
+		// a page made it out instead.
+	}
+	if len(pages) != 1 {
+		t.Fatalf("inverted-polarity feed emitted %d pages, want 1", len(pages))
+	}
+}
+
+func TestSyncerFlushReleasesInProgressPage(t *testing.T) {
+	addrCW := EncodeAddress(0x100, 1)
+	msgCW := EncodeMessage(0)
+	// Build a batch where the page isn't terminated by an idle —
+	// the address + message are followed by more idles but flushPage
+	// always fires on the batch boundary because flushPage is
+	// triggered by the next address/idle. Validate Flush() releases
+	// the page when the operator stops the stream mid-page.
+	cws := []uint32{SyncCodeword, addrCW, msgCW}
+	for i := 0; i < BatchCodewords-2; i++ {
+		cws = append(cws, IdleCodeword)
+	}
+	s := NewSyncer()
+	pages := feedCodewords(t, s, cws)
+	// The idle codewords inside the batch will already have flushed
+	// the page; Flush should return nil.
+	if len(pages) != 1 {
+		t.Fatalf("emitted %d pages from batch with idle terminator, want 1", len(pages))
+	}
+	if p := s.Flush(); p != nil {
+		t.Errorf("Flush after page emission returned %+v, want nil", p)
+	}
+
+	// Now test the opposite: a page in-flight with no terminator.
+	s2 := NewSyncer()
+	addrOnly := []uint32{SyncCodeword, addrCW}
+	for i := 0; i < BatchCodewords-1; i++ {
+		addrOnly = append(addrOnly, msgCW)
+	}
+	pages2 := feedCodewords(t, s2, addrOnly)
+	// Batch boundary doesn't flush; only an address / idle terminator
+	// or operator-driven Flush does. The whole batch is message after
+	// the address, with no terminator → no emission.
+	if len(pages2) != 0 {
+		t.Errorf("emitted %d pages without terminator, want 0 (page in-progress)", len(pages2))
+	}
+	if p := s2.Flush(); p == nil {
+		t.Error("Flush on in-progress page returned nil")
+	}
+}

--- a/internal/storage/pagerlog.go
+++ b/internal/storage/pagerlog.go
@@ -1,0 +1,143 @@
+// PagerLog persists POCSAG (and eventually FLEX) pager messages to
+// the SQLite pager_log table by subscribing to events.KindPagerMessage
+// on the shared bus. The decoder pipeline publishes one event per
+// fully-reassembled page; this consumer writes a row and the web
+// panel queries the recent rows via /api/v1/pager/messages.
+package storage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+)
+
+// PagerMessage is one persisted page. Mirrors the pocsag.Page shape
+// but with the "encoding" enum widened to a string for storage +
+// JSON convenience.
+type PagerMessage struct {
+	ID         int64     `json:"id"`
+	ReceivedAt time.Time `json:"received_at"`
+	RIC        uint32    `json:"ric"`
+	Func       uint8     `json:"func"` // 0..3 = A..D
+	Encoding   string    `json:"encoding"`
+	Body       string    `json:"body"`
+	Corrected  int       `json:"corrected"`
+}
+
+// PagerLog drains KindPagerMessage off the bus and writes one row
+// per page. Mirrors LocationLog's Run/Close lifecycle.
+type PagerLog struct {
+	db        *DB
+	bus       *events.Bus
+	log       *slog.Logger
+	sub       *events.Subscription
+	runDone   chan struct{}
+	closeOnce sync.Once
+}
+
+// NewPagerLog wires the log to the bus. The bus subscription happens
+// at construction time so the decoder can publish before Run begins
+// without losing events.
+func NewPagerLog(db *DB, bus *events.Bus, logger *slog.Logger) (*PagerLog, error) {
+	if db == nil {
+		return nil, errors.New("storage/pagerlog: DB is required")
+	}
+	if bus == nil {
+		return nil, errors.New("storage/pagerlog: events.Bus is required")
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	p := &PagerLog{db: db, bus: bus, log: logger, runDone: make(chan struct{})}
+	p.sub = bus.Subscribe()
+	return p, nil
+}
+
+// Run drains KindPagerMessage events until ctx cancels or the bus
+// closes.
+func (p *PagerLog) Run(ctx context.Context) error {
+	defer close(p.runDone)
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case ev, ok := <-p.sub.C:
+			if !ok {
+				return nil
+			}
+			if ev.Kind != events.KindPagerMessage {
+				continue
+			}
+			msg, ok := ev.Payload.(PagerMessage)
+			if !ok {
+				continue
+			}
+			if err := p.insert(msg); err != nil {
+				p.log.Error("pagerlog: insert failed", "err", err)
+			}
+		}
+	}
+}
+
+func (p *PagerLog) insert(m PagerMessage) error {
+	at := m.ReceivedAt
+	if at.IsZero() {
+		at = time.Now()
+	}
+	_, err := p.db.SQL().Exec(
+		`INSERT INTO pager_log
+		 (received_at, ric, func, encoding, body, corrected)
+		 VALUES (?, ?, ?, ?, ?, ?)`,
+		at.UnixNano(), m.RIC, m.Func, m.Encoding, m.Body, m.Corrected,
+	)
+	return err
+}
+
+// Recent returns the most recent pages, newest first, capped at
+// limit. limit ≤ 0 picks 200; limit > 5000 caps at 5000.
+func (p *PagerLog) Recent(limit int) ([]PagerMessage, error) {
+	if limit <= 0 {
+		limit = 200
+	}
+	if limit > 5000 {
+		limit = 5000
+	}
+	rows, err := p.db.SQL().Query(
+		`SELECT id, received_at, ric, func, encoding, body, corrected
+		 FROM pager_log ORDER BY received_at DESC LIMIT ?`, limit)
+	if err != nil {
+		return nil, fmt.Errorf("storage/pagerlog: query: %w", err)
+	}
+	defer rows.Close()
+	var out []PagerMessage
+	for rows.Next() {
+		var (
+			m  PagerMessage
+			ns int64
+		)
+		if err := rows.Scan(&m.ID, &ns, &m.RIC, &m.Func, &m.Encoding,
+			&m.Body, &m.Corrected); err != nil {
+			return nil, fmt.Errorf("storage/pagerlog: scan: %w", err)
+		}
+		m.ReceivedAt = time.Unix(0, ns)
+		out = append(out, m)
+	}
+	return out, rows.Err()
+}
+
+// Close releases the bus subscription and waits for Run to drain.
+func (p *PagerLog) Close() error {
+	p.closeOnce.Do(func() {
+		p.sub.Close()
+		select {
+		case <-p.runDone:
+		case <-time.After(time.Second):
+		}
+	})
+	return nil
+}

--- a/internal/storage/pagerlog_test.go
+++ b/internal/storage/pagerlog_test.go
@@ -1,0 +1,133 @@
+package storage
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+)
+
+func openPagerTestStore(t *testing.T) (*PagerLog, *events.Bus, *DB) {
+	t.Helper()
+	db, err := Open(":memory:")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	bus := events.NewBus(8)
+	log, err := NewPagerLog(db, bus, nil)
+	if err != nil {
+		t.Fatalf("NewPagerLog: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = log.Close()
+		bus.Close()
+		_ = db.Close()
+	})
+	return log, bus, db
+}
+
+func TestPagerLogInsertsBusMessage(t *testing.T) {
+	log, bus, _ := openPagerTestStore(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = log.Run(ctx) }()
+
+	bus.Publish(events.Event{
+		Kind: events.KindPagerMessage,
+		Payload: PagerMessage{
+			ReceivedAt: time.Unix(1735000000, 0),
+			RIC:        0x12345,
+			Func:       1,
+			Encoding:   "numeric",
+			Body:       "12345",
+			Corrected:  0,
+		},
+	})
+
+	// Poll briefly for the row to land.
+	var recent []PagerMessage
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		recent, _ = log.Recent(10)
+		if len(recent) > 0 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if len(recent) != 1 {
+		t.Fatalf("Recent = %d rows, want 1", len(recent))
+	}
+	r := recent[0]
+	if r.RIC != 0x12345 || r.Func != 1 || r.Body != "12345" || r.Encoding != "numeric" {
+		t.Errorf("Recent[0] = %+v", r)
+	}
+}
+
+func TestPagerLogIgnoresUnrelatedEvents(t *testing.T) {
+	log, bus, _ := openPagerTestStore(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = log.Run(ctx) }()
+
+	// Wrong kind — should be silently ignored.
+	bus.Publish(events.Event{
+		Kind:    events.KindBookmarkCreated,
+		Payload: Bookmark{Name: "x"},
+	})
+	// Right kind, wrong payload type — also ignored.
+	bus.Publish(events.Event{
+		Kind:    events.KindPagerMessage,
+		Payload: "not a pager message",
+	})
+
+	time.Sleep(50 * time.Millisecond)
+	recent, err := log.Recent(10)
+	if err != nil {
+		t.Fatalf("Recent: %v", err)
+	}
+	if len(recent) != 0 {
+		t.Errorf("Recent = %d, want 0 (no real pager events fired)", len(recent))
+	}
+}
+
+func TestPagerLogRecentOrderNewestFirst(t *testing.T) {
+	log, bus, _ := openPagerTestStore(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = log.Run(ctx) }()
+
+	for i, ts := range []time.Time{
+		time.Unix(1700000000, 0),
+		time.Unix(1700000100, 0),
+		time.Unix(1700000050, 0),
+	} {
+		bus.Publish(events.Event{
+			Kind: events.KindPagerMessage,
+			Payload: PagerMessage{
+				ReceivedAt: ts,
+				RIC:        uint32(0x100 + i),
+				Body:       "x",
+				Encoding:   "alpha",
+			},
+		})
+	}
+
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		recent, _ := log.Recent(10)
+		if len(recent) == 3 {
+			// Newest first.
+			if recent[0].RIC != 0x101 || recent[1].RIC != 0x102 || recent[2].RIC != 0x100 {
+				t.Errorf("order = %d, %d, %d; want 0x101, 0x102, 0x100",
+					recent[0].RIC, recent[1].RIC, recent[2].RIC)
+			}
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal("did not receive all three rows within 1s")
+}

--- a/internal/storage/sqlite.go
+++ b/internal/storage/sqlite.go
@@ -128,6 +128,24 @@ CREATE TABLE IF NOT EXISTS bookmarks (
 
 CREATE INDEX IF NOT EXISTS idx_bookmarks_freq  ON bookmarks(freq_hz);
 CREATE INDEX IF NOT EXISTS idx_bookmarks_group ON bookmarks(grouping, name);
+
+-- POCSAG pager messages persisted from the decoder pipeline. Each
+-- row is one fully-reassembled page (address codeword + N message
+-- codewords). The function field is the 2-bit code from the
+-- address codeword (A/B/C/D); encoding distinguishes numeric vs.
+-- alphanumeric.
+CREATE TABLE IF NOT EXISTS pager_log (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    received_at INTEGER NOT NULL,            -- unix nanoseconds
+    ric         INTEGER NOT NULL,            -- 21-bit address
+    func        INTEGER NOT NULL,            -- 0..3 (A..D)
+    encoding    TEXT    NOT NULL DEFAULT '', -- "numeric" | "alpha"
+    body        TEXT    NOT NULL DEFAULT '',
+    corrected   INTEGER NOT NULL DEFAULT 0   -- total BCH bit-error count
+);
+
+CREATE INDEX IF NOT EXISTS idx_pager_log_time ON pager_log(received_at);
+CREATE INDEX IF NOT EXISTS idx_pager_log_ric  ON pager_log(ric, received_at);
 `
 
 func (d *DB) migrate() error {

--- a/web/src/App.panels.test.tsx
+++ b/web/src/App.panels.test.tsx
@@ -37,6 +37,12 @@ vi.mock("./api/diag", () => ({
   ),
 }));
 
+vi.mock("./api/pagers", () => ({
+  fetchPagerMessages: vi.fn().mockResolvedValue([]),
+  functionLabel: (n: number) =>
+    n >= 0 && n <= 3 ? String.fromCharCode(65 + n) : "?",
+}));
+
 vi.mock("./api/bookmarks", () => ({
   bookmarks: {
     list: vi.fn().mockResolvedValue([]),
@@ -157,6 +163,7 @@ const ROUTES = [
   "/events",
   "/cc",
   "/tones",
+  "/pagers",
   "/metrics",
   "/devices",
   "/settings",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -16,6 +16,7 @@ import { Events } from "./panels/Events";
 import { History } from "./panels/History";
 import { Import } from "./panels/Import";
 import { Metrics } from "./panels/Metrics";
+import { Pagers } from "./panels/Pagers";
 import { Scanner } from "./panels/Scanner";
 import { Settings } from "./panels/Settings";
 import { Spectrum } from "./panels/Spectrum";
@@ -37,6 +38,7 @@ const EXTRA_TABS: Tab[] = [
   { to: "/events", label: "Events", icon: "≣" },
   { to: "/cc", label: "CC Activity", icon: "⌁" },
   { to: "/tones", label: "Tones", icon: "♪" },
+  { to: "/pagers", label: "Pagers", icon: "✉" },
   { to: "/spectrum", label: "Spectrum", icon: "≈" },
   { to: "/constellation", label: "Constellation", icon: "✦" },
   { to: "/bookmarks", label: "Bookmarks", icon: "★" },
@@ -146,6 +148,7 @@ export function App() {
           <Route path="/events" element={<Events />} />
           <Route path="/cc" element={<CCActivity />} />
           <Route path="/tones" element={<Tones />} />
+          <Route path="/pagers" element={<Pagers />} />
           <Route path="/metrics" element={<Metrics />} />
           <Route path="/devices" element={<Devices />} />
           <Route path="/settings" element={<Settings />} />

--- a/web/src/api/pagers.ts
+++ b/web/src/api/pagers.ts
@@ -1,0 +1,33 @@
+// Pager log client. Mirrors GET /api/v1/pager/messages.
+
+import { type ClientConfig, joinURL } from "./client";
+
+export interface PagerMessage {
+  id: number;
+  received_at: string;
+  ric: number;
+  func: number;
+  encoding: string;
+  body: string;
+  corrected: number;
+}
+
+export async function fetchPagerMessages(
+  cfg: ClientConfig,
+  limit = 200,
+): Promise<PagerMessage[]> {
+  const url = joinURL(
+    cfg.baseURL,
+    `/api/v1/pager/messages?limit=${encodeURIComponent(String(limit))}`,
+  );
+  const headers: Record<string, string> = { Accept: "application/json" };
+  if (cfg.token) headers["Authorization"] = `Bearer ${cfg.token}`;
+  const res = await fetch(url, { headers });
+  if (!res.ok) throw new Error(`pager/messages ${res.status}`);
+  return (await res.json()) as PagerMessage[];
+}
+
+export function functionLabel(fn: number): string {
+  if (fn >= 0 && fn <= 3) return String.fromCharCode("A".charCodeAt(0) + fn);
+  return "?";
+}

--- a/web/src/panels/Pagers.test.tsx
+++ b/web/src/panels/Pagers.test.tsx
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+
+vi.mock("../api/pagers", () => ({
+  fetchPagerMessages: vi.fn(),
+  functionLabel: (n: number) =>
+    n >= 0 && n <= 3 ? String.fromCharCode(65 + n) : "?",
+}));
+
+import { fetchPagerMessages } from "../api/pagers";
+import { useShared } from "../store/shared";
+import { Pagers } from "./Pagers";
+
+function resetStore() {
+  useShared.setState({
+    serverURL: "http://localhost:8080",
+    token: null,
+    connected: true,
+    wsStatus: "idle",
+    mutations: null,
+    lastError: null,
+    events: [],
+    activeCalls: [],
+    devices: [],
+    systems: [],
+    talkgroups: [],
+    health: null,
+    audio: null,
+    scanner: null,
+  });
+}
+
+describe("Pagers panel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetStore();
+  });
+
+  it("renders an empty-state when no messages are present", async () => {
+    vi.mocked(fetchPagerMessages).mockResolvedValue([]);
+    render(<Pagers />);
+    await waitFor(() => {
+      expect(screen.getByText(/No pager messages yet/)).toBeInTheDocument();
+    });
+  });
+
+  it("renders rows with RIC, function, and body", async () => {
+    vi.mocked(fetchPagerMessages).mockResolvedValue([
+      {
+        id: 1,
+        received_at: "2026-05-26T12:34:56Z",
+        ric: 1234567,
+        func: 2,
+        encoding: "alpha",
+        body: "STRUCTURE FIRE",
+        corrected: 0,
+      },
+      {
+        id: 2,
+        received_at: "2026-05-26T12:35:00Z",
+        ric: 7654321,
+        func: 1,
+        encoding: "numeric",
+        body: "911",
+        corrected: 1,
+      },
+    ]);
+    render(<Pagers />);
+    await waitFor(() => {
+      expect(screen.getByText("STRUCTURE FIRE")).toBeInTheDocument();
+      expect(screen.getByText("911")).toBeInTheDocument();
+      expect(screen.getByText("1234567")).toBeInTheDocument();
+      expect(screen.getByText("C")).toBeInTheDocument(); // function 2 = C
+      expect(screen.getByText("B")).toBeInTheDocument(); // function 1 = B
+    });
+  });
+
+  it("surfaces fetch errors", async () => {
+    vi.mocked(fetchPagerMessages).mockRejectedValue(new Error("daemon down"));
+    render(<Pagers />);
+    await waitFor(() => {
+      expect(screen.getByText(/daemon down/)).toBeInTheDocument();
+    });
+  });
+});

--- a/web/src/panels/Pagers.tsx
+++ b/web/src/panels/Pagers.tsx
@@ -1,0 +1,122 @@
+import { useEffect, useState } from "react";
+import {
+  fetchPagerMessages,
+  functionLabel,
+  type PagerMessage,
+} from "../api/pagers";
+import { selectClientConfig, useShared } from "../store/shared";
+
+// Pagers panel — list of recent POCSAG (and eventually FLEX) pages
+// decoded by the daemon. Each row carries RIC, function code (A/B/C/D),
+// numeric / alphanumeric encoding, decoded body, and the BCH bit-error
+// count (a non-zero value indicates the page was marginal).
+//
+// Live updates piggyback on the events bus once SSE delivery is wired;
+// for v1 the panel polls /api/v1/pager/messages every 5 s.
+
+const POLL_INTERVAL_MS = 5_000;
+
+export function Pagers() {
+  const cfg = useShared(selectClientConfig);
+  const [messages, setMessages] = useState<PagerMessage[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancel = false;
+    const refresh = async () => {
+      try {
+        const list = await fetchPagerMessages(cfg, 200);
+        if (cancel) return;
+        setMessages(list);
+        setError(null);
+      } catch (e) {
+        if (cancel) return;
+        setError(e instanceof Error ? e.message : String(e));
+      }
+    };
+    refresh();
+    const t = window.setInterval(refresh, POLL_INTERVAL_MS);
+    return () => {
+      cancel = true;
+      window.clearInterval(t);
+    };
+  }, [cfg]);
+
+  return (
+    <div className="space-y-3">
+      <header className="flex items-center justify-between">
+        <h2 className="text-xl font-semibold">Pagers</h2>
+        <span className="text-xs text-muted">
+          {messages.length} message{messages.length === 1 ? "" : "s"}
+        </span>
+      </header>
+
+      {error && (
+        <div className="rounded border border-red-700/40 bg-red-900/20 text-red-200 text-xs px-3 py-2">
+          {error}
+        </div>
+      )}
+
+      <div className="rounded border border-border overflow-hidden">
+        <table className="w-full text-xs">
+          <thead className="bg-surface text-muted">
+            <tr>
+              <th className="text-left px-3 py-1 font-normal w-32">Received</th>
+              <th className="text-right px-3 py-1 font-normal w-24">RIC</th>
+              <th className="text-left px-3 py-1 font-normal w-12">Fn</th>
+              <th className="text-left px-3 py-1 font-normal w-16">Enc</th>
+              <th className="text-left px-3 py-1 font-normal">Body</th>
+              <th className="text-right px-3 py-1 font-normal w-16">BER</th>
+            </tr>
+          </thead>
+          <tbody>
+            {messages.length === 0 ? (
+              <tr>
+                <td colSpan={6} className="px-3 py-4 text-center text-muted">
+                  No pager messages yet. POCSAG pages decoded by the
+                  daemon will appear here as they arrive — typical
+                  workflow is to point one SDR at the local paging
+                  frequency (e.g. 152.0075 MHz commercial paging,
+                  the local fire department dispatch tone-out
+                  freq, or 439.9875 MHz DAPNET).
+                </td>
+              </tr>
+            ) : (
+              messages.map((m) => (
+                <tr key={m.id} className="border-t border-border/60">
+                  <td className="px-3 py-1 font-mono text-muted">
+                    {formatTime(m.received_at)}
+                  </td>
+                  <td className="px-3 py-1 text-right font-mono text-accent">
+                    {m.ric}
+                  </td>
+                  <td className="px-3 py-1">{functionLabel(m.func)}</td>
+                  <td className="px-3 py-1 uppercase text-muted">
+                    {m.encoding || "?"}
+                  </td>
+                  <td className="px-3 py-1">{m.body || <span className="text-muted">(empty)</span>}</td>
+                  <td className="px-3 py-1 text-right font-mono">
+                    {m.corrected > 0 ? (
+                      <span className="text-yellow-300">{m.corrected}</span>
+                    ) : (
+                      <span className="text-muted">0</span>
+                    )}
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+function formatTime(ts: string): string {
+  try {
+    const d = new Date(ts);
+    return d.toISOString().slice(11, 19);
+  } catch {
+    return ts.slice(11, 19);
+  }
+}


### PR DESCRIPTION
## Summary

Second slice of **Phase 3** of the trunking-adjacent feature plan (#365), building on the protocol layer from #372. Adds everything needed to turn a packed bit stream into operator-visible POCSAG pages — **the DSP layer (FM demod → bit slicer → `Syncer.Push`) is the only remaining piece** and lands as its own focused PR after this.

## What's in the box

### `internal/radio/pager/pocsag/syncer.go`
Stateful bit consumer.
- Slides a 32-bit shift register looking for the POCSAG sync codeword
- **Polarity-inverse fallback** — accepts either the on-wire bit pattern or its bit-inverse so a flipped FM demod still works
- Once locked, accumulates 512 bits = 16 codewords = 1 batch, runs each through `Decode` (BCH(31,21) correction inside), feeds the page assembler
- **Page assembler** correlates each address codeword with the message codewords that follow; flushes on next address / idle / uncorrectable codeword
- Operator-driven `Flush()` releases any in-progress page at end-of-stream
- Encoding heuristic: function B = numeric, others = alphanumeric (CCIR 584 convention)

### `internal/events/bus.go`
New `KindPagerMessage` event. Payload: `storage.PagerMessage` (RIC + function + encoding + body + corrected-error count).

### `internal/storage/sqlite.go` + `pagerlog.go`
- Append-only `CREATE TABLE` for `pager_log` (id, received_at, ric, func, encoding, body, corrected) with indexes on (received_at) and (ric, received_at)
- Bus-driven log writer mirroring `LocationLog`: subscribes on construction so events published before `Run()` begins aren't lost; silently ignores wrong-kind / wrong-payload events
- `Recent(limit)` feeds the REST endpoint

### `internal/api/handlers_pager.go`
`PagerProvider` interface + `GET /api/v1/pager/messages?limit=N` handler. Default 200, max 5000. 503 when not wired.

### `cmd/gophertrunk/daemon.go`
`PagerLog` constructed alongside `CallLog` / `LocationLog` / `BookmarkStore` when `storage.path` is set; wired into `ServerOptions.Pager` via a thin adapter; Run + Close plumbed identically to the other bus consumers.

### `web/src/panels/Pagers.tsx` + `api/pagers.ts`
Panel polls `/api/v1/pager/messages` every 5 s, renders Received / RIC / Function / Encoding / Body / BER. **Non-zero BER highlighted yellow** as a marginal-signal indicator. Registered at `/pagers` with a ✉ icon.

## Tests

- **5 syncer tests**: sync acquisition, single-page address+message round-trip, numeric routing for function B, polarity-inverse stream, `Flush()` behaviour (both no-op when there's nothing in-flight and release when there's an in-progress page)
- **3 pager log tests**: bus insertion happy path, wrong-kind / wrong-payload silent ignore, newest-first ordering
- **3 API tests**: 503 when not wired, list happy path, `?limit=N` respected
- **3 web panel tests**: empty-state, row rendering with mocked fetch, fetch-error surfacing
- **App.panels regression** — `/pagers` added to the route-mount sweep

All clean: **86 Go packages pass**, **87 web tests pass** (was 83), `go vet` clean, `gofmt -l .` clean, `npm run typecheck` clean, SPA build OK.

## Why this is split from the DSP layer

Splitting the DSP layer into its own PR keeps the protocol/bus/storage/REST/UI vertical reviewable on its own merits. The syncer's `Push(bit)` interface is the contract the DSP layer needs to implement — and is fully testable here without any IQ fixtures. When the DSP PR lands, the only new code will be the per-protocol "Process(stream, baseIdx)" adapter that demods FM and slices bits; everything else is already wired and proven.

## Docs

- **`docs/pocsag.md`** — "What's pending" section narrowed from "DSP + bus + storage + panel" to just "DSP integration" and "FLEX". A new "What's shipped now" section walks operators through the syncer, bus event, SQLite table, REST endpoint, and web panel
- **`CHANGELOG.md`** — `[Unreleased]` → Added (above the protocol-layer entry from #372)

## Test plan

- [x] `go test ./...` — 86 packages pass
- [x] `npm run test` — 87 web tests pass (14 test files)
- [x] `npm run typecheck` clean
- [x] `npm run build` — SPA bundle builds
- [x] `go vet ./...` clean
- [x] `gofmt -l .` clean
- [ ] Push a real packed bit stream through `Syncer` and confirm pages flow to `/pagers` (deferred to the DSP PR — needs the FM demod hookup)

## Status of the 7-phase plan

- ✅ Phase 0, 1 backend+web (Spectrum + click-to-tune), 2a, 2b, 2c, 4, 6 — shipped (PRs #365–#371)
- ✅ Phase 3 protocol layer + this PR's syncer/bus/log/REST/UI — shipped (#372 + this PR)
- ⏳ Phase 3 DSP wiring (FM demod → bit slicer → `Syncer.Push`), Phase 3 FLEX, Phase 1 TUI, Phase 5 (APRS/DSC/AIS/ADS-B), Phase 7 (M17 + Codec2) — remaining, each warrants a dedicated PR

https://claude.ai/code/session_01YUgvat8WpF5YaSuEAqWMr2

---
_Generated by [Claude Code](https://claude.ai/code/session_01YUgvat8WpF5YaSuEAqWMr2)_