### PR TITLE
widebandt2: route IQ + tuning through iqtap broker for spectrum view

### DIFF
--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -401,7 +401,7 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 			d.pool = nil
 		} else {
 			d.wrapBasebandRecorders(cfg, log)
-			d.wrapIQBrokers(log)
+			d.wrapIQBrokers(cfg, log)
 		}
 	} else if len(cfg.Trunking.Systems) > 0 {
 		// Trunked systems configured but no SDR devices listed —
@@ -801,10 +801,21 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 					SystemName:  ch.System,
 				})
 			}
+			// Route IQ + tuning through the iqtap broker so the live
+			// spectrum view (and any other secondary observer) can
+			// Subscribe to chunk copies. Without the broker indirection
+			// the engine's StreamIQ would bypass the fan-out goroutine
+			// and its SetCenterFreq would skip the broker's centerHz
+			// cache, leaving spectrum frames empty and stamped at 0.
+			// Mirrors the CC decoder wiring above.
+			var iqDev sdr.Device = entry.Device
+			if br := d.iqBrokers[entry.Info.Serial]; br != nil {
+				iqDev = br
+			}
 			eng, err := widebandt2.New(widebandt2.Options{
 				Log:           log,
 				Bus:           d.bus,
-				Device:        entry.Device,
+				Device:        iqDev,
 				SampleRateHz:  cfg.SDR.SampleRate,
 				CenterFreqHz:  devCfg.CenterFreqHz,
 				TunerStrategy: devCfg.TunerStrategy,
@@ -1633,13 +1644,24 @@ func (d *Daemon) wrapBasebandRecorders(cfg config.Config, log *slog.Logger) {
 // device, not a RecordingDevice — baseband recording stops across a
 // USB-disconnect cycle, which is an existing behavior the broker
 // inherits rather than fixes.
-func (d *Daemon) wrapIQBrokers(log *slog.Logger) {
+func (d *Daemon) wrapIQBrokers(cfg config.Config, log *slog.Logger) {
 	if d.pool == nil {
 		return
 	}
+	rate := cfg.SDR.SampleRate
+	if rate == 0 {
+		rate = sdr.DefaultSampleRateHz
+	}
 	d.iqBrokers = make(map[string]*iqtap.Broker, len(d.pool.Entries()))
 	for _, e := range d.pool.Entries() {
-		d.iqBrokers[e.Info.Serial] = iqtap.New(e.Device, 0, log)
+		br := iqtap.New(e.Device, 0, log)
+		// pool.Open already programmed cfg.SDR.SampleRate on the raw
+		// device before we wrapped it, so Broker.SetSampleRate's cache
+		// path never ran. Seed it directly so spectrum frame stamps
+		// (and any other SampleRateHz reader) anchor at the right rate
+		// from the first frame instead of 0.
+		br.Seed(0, rate)
+		d.iqBrokers[e.Info.Serial] = br
 	}
 }
 

--- a/cmd/gophertrunk/spectrum_provider_test.go
+++ b/cmd/gophertrunk/spectrum_provider_test.go
@@ -157,6 +157,58 @@ func TestSpectrumProviderOpenStreamProducesFrames(t *testing.T) {
 	}
 }
 
+// Regression: when only the broker's Seed is used to populate the
+// rate cache (no SetSampleRate call ever made through the broker —
+// matches the daemon's wrapIQBrokers path for the wideband-only
+// config), frames must still stamp the correct SampleRateHz instead
+// of 0. Locks the wideband-T2 spectrum-view bug fix.
+func TestSpectrumProviderFramesIncludeSampleRateAfterSeed(t *testing.T) {
+	dev := newStreamingFake("dev-seeded")
+	br := iqtap.New(dev, 0, nil)
+	// Seeded (not SetSampleRate'd) — the pool already programmed the
+	// raw device before the broker wrapped it.
+	br.Seed(0, 2_400_000)
+	// Center is programmed through the broker by whoever owns tuning
+	// (wideband T2 engine in production).
+	_ = br.SetCenterFreq(453_525_000)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	prim, err := br.StreamIQ(ctx)
+	if err != nil {
+		t.Fatalf("broker StreamIQ: %v", err)
+	}
+	go func() {
+		for range prim {
+		}
+	}()
+
+	p := &spectrumProvider{
+		brokers: map[string]*iqtap.Broker{"dev-seeded": br},
+		log:     slog.New(slog.DiscardHandler),
+	}
+	frames, cleanup, err := p.OpenStream(ctx, "dev-seeded", 64, 50)
+	if err != nil {
+		t.Fatalf("OpenStream: %v", err)
+	}
+	defer cleanup()
+
+	select {
+	case f, ok := <-frames:
+		if !ok {
+			t.Fatal("frame channel closed prematurely")
+		}
+		if f.SampleRateHz != 2_400_000 {
+			t.Errorf("SampleRateHz = %d, want 2_400_000 (seed must populate cache)", f.SampleRateHz)
+		}
+		if f.CenterHz != 453_525_000 {
+			t.Errorf("CenterHz = %d, want 453_525_000", f.CenterHz)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("no frame within 2s")
+	}
+}
+
 func TestSpectrumProviderOpenStreamBadFFTSize(t *testing.T) {
 	dev := newStreamingFake("dev-bad")
 	br := iqtap.New(dev, 0, nil)

--- a/internal/sdr/iqtap/broker.go
+++ b/internal/sdr/iqtap/broker.go
@@ -170,6 +170,21 @@ func (b *Broker) CenterHz() uint32 { return b.centerHz.Load() }
 // via SetSampleRate. Zero before the first call.
 func (b *Broker) SampleRateHz() uint32 { return b.rateHz.Load() }
 
+// Seed populates the centerHz / rateHz caches without calling into the
+// inner device. The daemon uses it to inject the bootstrap sample rate
+// the pool already programmed on the raw device before the broker was
+// wrapped around it, so spectrum frames stamp the correct rate from
+// the very first frame. Zero arguments leave the corresponding field
+// unchanged so callers can seed one field at a time.
+func (b *Broker) Seed(centerHz, rateHz uint32) {
+	if centerHz != 0 {
+		b.centerHz.Store(centerHz)
+	}
+	if rateHz != 0 {
+		b.rateHz.Store(rateHz)
+	}
+}
+
 func (b *Broker) SetGain(tenthDB int) error {
 	b.innerMu.RLock()
 	defer b.innerMu.RUnlock()

--- a/internal/sdr/iqtap/broker_test.go
+++ b/internal/sdr/iqtap/broker_test.go
@@ -481,3 +481,54 @@ func TestBrokerSetterPassThroughs(t *testing.T) {
 		t.Errorf("close count = %d, want 1", got)
 	}
 }
+
+func TestBrokerSeedPopulatesCacheWithoutInnerCall(t *testing.T) {
+	dev := newFakeDevice("dev-seed")
+	b := New(dev, 0, nil)
+
+	b.Seed(0, 2_048_000)
+
+	if got := b.SampleRateHz(); got != 2_048_000 {
+		t.Errorf("SampleRateHz after Seed = %d, want 2_048_000", got)
+	}
+	if got := b.CenterHz(); got != 0 {
+		t.Errorf("CenterHz after Seed(0, ...) = %d, want 0 (untouched)", got)
+	}
+	if got := dev.sampleRate.Load(); got != 0 {
+		t.Errorf("inner SetSampleRate was called: dev.sampleRate = %d, want 0", got)
+	}
+	if got := dev.centerFreq.Load(); got != 0 {
+		t.Errorf("inner SetCenterFreq was called: dev.centerFreq = %d, want 0", got)
+	}
+}
+
+func TestBrokerSeedZeroLeavesFieldsUnchanged(t *testing.T) {
+	dev := newFakeDevice("dev-seed-zero")
+	b := New(dev, 0, nil)
+
+	if err := b.SetCenterFreq(100_000_000); err != nil {
+		t.Fatalf("SetCenterFreq: %v", err)
+	}
+	if err := b.SetSampleRate(2_400_000); err != nil {
+		t.Fatalf("SetSampleRate: %v", err)
+	}
+
+	b.Seed(0, 0)
+
+	if got := b.CenterHz(); got != 100_000_000 {
+		t.Errorf("CenterHz after Seed(0,0) = %d, want 100_000_000", got)
+	}
+	if got := b.SampleRateHz(); got != 2_400_000 {
+		t.Errorf("SampleRateHz after Seed(0,0) = %d, want 2_400_000", got)
+	}
+
+	// Now seed only the rate to a new value; center must remain
+	// unchanged because the new value's zero arg is a sentinel.
+	b.Seed(0, 1_024_000)
+	if got := b.CenterHz(); got != 100_000_000 {
+		t.Errorf("CenterHz after Seed(0, 1_024_000) = %d, want 100_000_000 (untouched)", got)
+	}
+	if got := b.SampleRateHz(); got != 1_024_000 {
+		t.Errorf("SampleRateHz after Seed(0, 1_024_000) = %d, want 1_024_000", got)
+	}
+}


### PR DESCRIPTION
Wideband-only DMR Tier 2 deployments (single SDR, role: wideband,
multiple T2 systems) couldn't render the spectrum waterfall because
the engine consumed StreamIQ from the raw device, never feeding the
broker's fan-out. Pass the broker to widebandt2.New when one exists,
mirroring the CC decoder wiring.

Also seed each broker's sample-rate cache in wrapIQBrokers from
cfg.SDR.SampleRate. The pool programs the rate on the raw device
before the broker wraps it, so Broker.SetSampleRate's cache path
never ran and frames stamped sample_rate_hz=0 for every device.

https://claude.ai/code/session_01VVUmxsvR9imtaACHcHYuyV