### PR TITLE
aprs: AX.25 frame parser + APRS info-field decoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ for tagged releases.
 
 ### Added
 
+- **APRS / AX.25 protocol layer.** First slice of Phase 5 (#365).
+  Pure-Go AX.25 frame parser (`internal/radio/aprs/ax25`):
+  7-byte address packing with the spec's bit-shifted ASCII
+  callsigns, up to 8 digipeater path entries, HDLC CRC-16-CCITT
+  validation, display helpers for the conventional `W1AW-9` /
+  `WIDE2-1*` formats. Plus an APRS info-field decoder
+  (`internal/radio/aprs`) covering positions (`!`, `=`, `/`, `@`),
+  messages (`:`) with ack/rej + bulletins, and status (`>`);
+  Mic-E / weather / telemetry / object types are recognised
+  with payloads stashed for the follow-up decoders. DSP wiring
+  (Bell-202 AFSK demod → HDLC de-stuff → frame delivery) is the
+  protocol-first split's planned follow-up. See
+  [docs/aprs.md](docs/aprs.md).
 - **POCSAG DSP receiver + daemon wiring.** Third slice of Phase 3
   (#365). New `internal/radio/pager/pocsag/receiver` package wires
   the FM demod → rational resampler → integrator-and-slicer → bit

--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ Silicon and Intel. Full per-OS recipes at
   decoders. Foundation for fire / EMS dispatch text alongside
   the trunked-voice pipeline; DSP wiring follows in the next PR.
   See [docs/pocsag.md](docs/pocsag.md).
+- **APRS / AX.25 packet** — protocol layer for the amateur-
+  radio APRS metadata bus (position beacons, messages,
+  bulletins, status). HDLC-style AX.25 frame parser with
+  CRC-16-CCITT, plus APRS info-field decoders for the
+  operator-visible majority of packet types. See
+  [docs/aprs.md](docs/aprs.md).
 - **Pure-Go voice path** — IMBE (P25 Phase 1) and AMBE+2 (P25
   Phase 2 / DMR) vocoders in Go, no DVSI / mbelib dependency.
   Per-call WAV + raw-frame sidecars; live PCM playback via direct

--- a/docs/_data/nav.yml
+++ b/docs/_data/nav.yml
@@ -51,6 +51,8 @@ groups:
         url: /dmr-encryption.html
       - title: POCSAG paging
         url: /pocsag.html
+      - title: APRS / AX.25
+        url: /aprs.html
       - title: Opt-in features
         url: /opt-in-features.html
       - title: Status

--- a/docs/aprs.md
+++ b/docs/aprs.md
@@ -1,0 +1,104 @@
+---
+layout: page
+title: APRS / AX.25 protocol layer
+description: AX.25 frame parsing + APRS info-field decoding — positions, messages, status, bulletins
+nav_group: Reference
+---
+
+# APRS / AX.25 protocol layer
+
+GopherTrunk now decodes the **APRS** (Automatic Packet Reporting
+System) packet format that rides on top of **AX.25**, the amateur-
+radio link-layer frame used by packet radio. APRS is the dominant
+amateur-radio metadata bus — position beacons, weather reports,
+messages, bulletins, SAR coordination — and complements the
+trunking-voice pipeline well for emergency-comms-adjacent operators
+who already run GopherTrunk for public-safety scanning.
+
+This PR lands the **protocol layer** in pure Go: AX.25 frame
+parsing with HDLC CRC-16-CCITT validation, plus the APRS info-
+field decoder for the operator-visible majority of packet types
+(position reports, messages, status, bulletins). The DSP wiring
+(1200 Bd Bell-202 AFSK → HDLC bit-stuff/de-stuff → frame
+delimiter) follows in a focused follow-up PR, mirroring the
+POCSAG protocol-first split from #372.
+
+## What's wired
+
+### `internal/radio/aprs/ax25`
+AX.25 UI-frame parser.
+
+- 7-byte AX.25 address packing (callsign + SSID + H/C-bit) with
+  the spec's bit-shifted ASCII convention
+- Up to 8 digipeater path entries past the source address
+- Control + PID byte parsing (UI is the only frame type APRS
+  uses, but the parser passes other types through)
+- **HDLC CRC-16-CCITT** validation via the standard 0x8408
+  reflected-bit polynomial; `frame.FCSOK` distinguishes clean
+  vs. CRC-failed frames
+- Display helpers (`Address.String()` → `"W1AW-9"` or `"WIDE2-1*"`,
+  `Frame.PathString()` → `"WIDE1-1,WIDE2-1*"`)
+
+### `internal/radio/aprs`
+APRS info-field decoder.
+
+Recognised packet types and what we extract:
+
+| DTI byte | Type | Decoded fields |
+| --- | --- | --- |
+| `!` | Position (no timestamp, no msg) | lat/lon, symbol, comment |
+| `=` | Position (no timestamp, messaging) | lat/lon, symbol, comment, `WithMessaging=true` |
+| `/` | Position (timestamp, no msg) | lat/lon, symbol, comment, raw timestamp |
+| `@` | Position (timestamp, messaging) | lat/lon, symbol, comment, raw timestamp, `WithMessaging=true` |
+| `:` | Message / Bulletin | addressee, body, seqno, ack/rej flag |
+| `>` | Status | text |
+| `;` | Object | recognised; payload TBD |
+| `_` | Weather | recognised; payload TBD |
+| `T#` | Telemetry | recognised; payload TBD |
+| `` ` ``, `'`, `0x1C`, `0x1D` | Mic-E (compressed) | recognised; decoder pending |
+| anything else | Unknown | raw bytes preserved |
+
+Position parsing covers:
+- Standard `DDMM.hhH/DDDMM.hhH` lat/lon (hundredths of a minute)
+- Both hemispheres for latitude (`N`/`S`) and longitude (`E`/`W`)
+- Symbol table + symbol code byte pair
+- Free-form comment after the symbol code
+- Ambiguity-space tolerance (the spec allows spaces in low-
+  precision digits — we treat them as 0)
+
+Message parsing covers:
+- 9-character addressee, trimmed of trailing spaces
+- Optional `{NNN}` sequence number suffix
+- `ack` / `rej` short-form replies (body becomes the seqno)
+- Bulletin board (addressee starts with `BLN`) → `Bulletin` struct
+
+## What's pending
+
+- **DSP integration.** 1200 Bd Bell-202 AFSK demodulation, HDLC
+  bit-stuffing reversal, and 0x7E flag-delimited frame extraction.
+  Mirrors the POCSAG receiver pattern (FM demod → bit slicer →
+  syncer); the AX.25 parser is ready to consume frame-delimited
+  bytes the moment the DSP layer exists. Bell-202 itself is
+  audio-band so the demod can run off a narrow-channelized FM
+  audio stream — same path POCSAG uses minus the bit-stuffing.
+- **Mic-E.** The compressed lat/lon format common on mobile
+  trackers (Kenwood TH-D74, Yaesu FT-3D). Adds ~200 LOC for the
+  base-91 unpacking + speed / course / altitude decode.
+- **Weather / telemetry / object payloads.** The decoder
+  recognises the type bytes but leaves the body in `Raw` for
+  now. Operator-visible information from these would be helpful
+  but the spec is involved.
+- **Bus event + SQLite log + REST + web panel.** Once the DSP
+  wiring exists, a new `events.KindAPRSPacket` plus an `aprs_log`
+  table (mirroring `pager_log` from PR #373) ship alongside.
+  The web panel renders position reports on a map and messages /
+  status / bulletins in a chat-style log.
+
+## References
+
+- APRS Protocol Reference 1.0.1 (1998-08-07) — the canonical text.
+  `http://www.aprs.org/doc/APRS101.PDF`
+- AX.25 Link Access Protocol for Amateur Packet Radio, v2.2 — TAPR
+  / ARRL, 1998. `http://www.ax25.net/AX25.2.2-Jul%2098-2.pdf`
+- aprs.fi parser source — cross-reference for the messy real-world
+  variants the spec doesn't fully pin down

--- a/internal/radio/aprs/aprs.go
+++ b/internal/radio/aprs/aprs.go
@@ -1,0 +1,360 @@
+// Package aprs decodes the APRS info-field payload that rides on
+// top of AX.25 (the link layer in package aprs/ax25). APRS is a
+// huge, semi-formal protocol — the spec covers position, weather,
+// message, telemetry, status, object, item, query, and bulletin
+// formats, plus all the trailing-comment compressed variants.
+//
+// This package handles the operator-visible majority: position
+// reports (uncompressed lat/lon-NMEA-style), messages, status, and
+// the catch-all printable-info case. Each decoder produces a
+// strongly-typed Go struct so the storage + UI layers can render
+// it without re-parsing.
+//
+// Spec references:
+//
+//   - APRS Protocol Reference 1.0.1 (1998-08-07) — the canonical
+//     text. http://www.aprs.org/doc/APRS101.PDF
+//   - aprs.fi parser source code as cross-check for the messy
+//     real-world variants the spec doesn't quite pin down.
+package aprs
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// PacketType is what the info field's first byte / leading
+// pattern identifies the payload as. APRS uses an inline data-type
+// indicator (DTI) byte for everything except the comment-only
+// case; the parser dispatches on it.
+type PacketType uint8
+
+const (
+	TypeUnknown   PacketType = iota
+	TypePosition             // "!" (no msg) / "=" (with msg) / "/" / "@" prefixed lat/lon
+	TypeStatus               // ">" prefixed free-text
+	TypeMessage              // ":" addressee + ":" body
+	TypeObject               // ";" — like position but for a named object
+	TypeMicE                 // 0x1C / 0x1D / "'" / "`" — Mic-E compressed (decoder is in the follow-up)
+	TypeWeather              // "_" / "#" / "*" — full weather report
+	TypeTelemetry            // "T#" prefix
+	TypeBulletin             // ":BLNxxxxx:" — addressed bulletin board
+)
+
+// Position is the decoded latitude / longitude payload from an
+// uncompressed position report. APRS encodes latitude as DDMM.mmH
+// where H is N/S, longitude as DDDMM.mmH where H is E/W.
+type Position struct {
+	Latitude  float64
+	Longitude float64
+	// Symbol is the APRS symbol table + char (e.g. "/>" for a car,
+	// "/k" for a truck, "\>" for a vehicle from the alternate
+	// table). Two ASCII bytes.
+	SymbolTable byte
+	SymbolCode  byte
+	// Comment is everything after the symbol char.
+	Comment string
+	// HasTimestamp is true when the report carried a leading
+	// 7-character timestamp (formats "@" and "/"). Stored
+	// unparsed in TimestampRaw to avoid the timezone heuristics
+	// — the bus event carries received-time anyway.
+	HasTimestamp  bool
+	TimestampRaw  string
+	WithMessaging bool // true for "=" and "@" (messaging-capable)
+}
+
+// Message is the decoded payload for the message format:
+// ":ADDRESSEE :body{seqno}".
+type Message struct {
+	Addressee string // 1..9 chars, trimmed of trailing spaces
+	Body      string
+	// SeqNo is the optional ack number when the body ends with
+	// "{NNN}". Empty when not present.
+	SeqNo string
+	// Ack reports whether this is an "ack" / "rej" rather than a
+	// message body. The body shape is "ack123" / "rej123".
+	Ack bool
+	Rej bool
+}
+
+// Status is the decoded payload for the status format: ">body".
+type Status struct {
+	Text string
+}
+
+// Bulletin is the decoded payload for the bulletin format:
+// ":BLNxxxxxx:body".
+type Bulletin struct {
+	ID   string
+	Body string
+}
+
+// Packet is the decoded result of one APRS info field.
+type Packet struct {
+	Type     PacketType
+	Position *Position
+	Message  *Message
+	Status   *Status
+	Bulletin *Bulletin
+	// Raw is the original info field; always populated so the UI
+	// can show the literal bytes when the decoder picks Unknown.
+	Raw string
+}
+
+// Decode parses one APRS info field and returns a typed Packet.
+// Never returns an error — unknown / malformed payloads come
+// back as Type=TypeUnknown with the raw bytes preserved on the
+// Raw field. This matches operator expectations (APRS is messy;
+// we surface what we can and pass through the rest).
+func Decode(info []byte) Packet {
+	raw := string(info)
+	p := Packet{Raw: raw}
+	if len(info) == 0 {
+		return p
+	}
+	dti := info[0]
+	switch dti {
+	case '!':
+		// Uncompressed position without timestamp, no messaging.
+		if pos, ok := parseUncompressedPosition(string(info[1:]), false, false); ok {
+			p.Type = TypePosition
+			p.Position = &pos
+			return p
+		}
+	case '=':
+		// Uncompressed position without timestamp, messaging-capable.
+		if pos, ok := parseUncompressedPosition(string(info[1:]), false, true); ok {
+			p.Type = TypePosition
+			p.Position = &pos
+			return p
+		}
+	case '/':
+		// Uncompressed position with timestamp, no messaging.
+		if len(info) >= 8 {
+			ts := string(info[1:8])
+			if pos, ok := parseUncompressedPosition(string(info[8:]), true, false); ok {
+				pos.HasTimestamp = true
+				pos.TimestampRaw = ts
+				p.Type = TypePosition
+				p.Position = &pos
+				return p
+			}
+		}
+	case '@':
+		// Uncompressed position with timestamp, messaging-capable.
+		if len(info) >= 8 {
+			ts := string(info[1:8])
+			if pos, ok := parseUncompressedPosition(string(info[8:]), true, true); ok {
+				pos.HasTimestamp = true
+				pos.TimestampRaw = ts
+				p.Type = TypePosition
+				p.Position = &pos
+				return p
+			}
+		}
+	case ':':
+		// Message — including bulletins and acks.
+		if msg, bln, isBulletin, ok := parseMessage(string(info[1:])); ok {
+			if isBulletin {
+				p.Type = TypeBulletin
+				p.Bulletin = bln
+			} else {
+				p.Type = TypeMessage
+				p.Message = msg
+			}
+			return p
+		}
+	case '>':
+		p.Type = TypeStatus
+		p.Status = &Status{Text: string(info[1:])}
+		return p
+	case ';':
+		p.Type = TypeObject
+		return p
+	case 0x1C, 0x1D, '`', '\'':
+		// Mic-E — the decoder is involved enough that it lives in
+		// its own file. For now, surface the type so the UI can
+		// render "Mic-E (compressed)" rather than dropping the
+		// packet.
+		p.Type = TypeMicE
+		return p
+	case '_':
+		p.Type = TypeWeather
+		return p
+	case 'T':
+		if len(info) >= 2 && info[1] == '#' {
+			p.Type = TypeTelemetry
+			return p
+		}
+	}
+	return p
+}
+
+// parseUncompressedPosition decodes the "DDMM.mmH/DDDMM.mmH"
+// section that follows the data-type indicator (and optional
+// timestamp). On success returns the populated Position and
+// true; on malformed input returns ok=false so the caller can
+// surface the packet as TypeUnknown.
+func parseUncompressedPosition(s string, _ bool, withMsg bool) (Position, bool) {
+	// Minimum length: 8 (lat) + 1 (sym table) + 9 (lon) + 1 (sym) = 19.
+	if len(s) < 19 {
+		return Position{}, false
+	}
+	latStr := s[0:8] // DDMM.mmH
+	symTable := s[8]
+	lonStr := s[9:18] // DDDMM.mmH
+	symCode := s[18]
+	comment := s[19:]
+
+	lat, ok := parseLatLon(latStr, true)
+	if !ok {
+		return Position{}, false
+	}
+	lon, ok := parseLatLon(lonStr, false)
+	if !ok {
+		return Position{}, false
+	}
+	return Position{
+		Latitude:      lat,
+		Longitude:     lon,
+		SymbolTable:   symTable,
+		SymbolCode:    symCode,
+		Comment:       comment,
+		WithMessaging: withMsg,
+	}, true
+}
+
+// parseLatLon decodes a DDMM.mmH (latitude) or DDDMM.mmH
+// (longitude) string into decimal degrees. Negative south /
+// west. APRS supports "ambiguity spaces" — bytes that should be
+// digits but are space, indicating reduced precision — which
+// this implementation tolerates by treating spaces as 0.
+func parseLatLon(s string, isLat bool) (float64, bool) {
+	wantLen := 8 // DDMM.mmH
+	degDigits := 2
+	if !isLat {
+		wantLen = 9 // DDDMM.mmH
+		degDigits = 3
+	}
+	if len(s) != wantLen {
+		return 0, false
+	}
+	// Replace ambiguity spaces with 0 — they only ever appear in
+	// the minutes' fractional digits, but conservatively treat any
+	// of the numeric positions.
+	clean := []byte(s)
+	for i := 0; i < degDigits+4; i++ { // DD or DDD then MM.mm
+		if clean[i] == ' ' {
+			clean[i] = '0'
+		}
+	}
+	// Skip the "." separator — it lives at index degDigits+2.
+	if clean[degDigits+2] != '.' {
+		return 0, false
+	}
+	deg, err := strconv.ParseFloat(string(clean[:degDigits]), 64)
+	if err != nil {
+		return 0, false
+	}
+	min, err := strconv.ParseFloat(string(clean[degDigits:degDigits+2])+"."+string(clean[degDigits+3:degDigits+5]), 64)
+	if err != nil {
+		return 0, false
+	}
+	val := deg + min/60
+	hemi := clean[wantLen-1]
+	if isLat {
+		switch hemi {
+		case 'N':
+		case 'S':
+			val = -val
+		default:
+			return 0, false
+		}
+	} else {
+		switch hemi {
+		case 'E':
+		case 'W':
+			val = -val
+		default:
+			return 0, false
+		}
+	}
+	return val, true
+}
+
+// parseMessage decodes the ":ADDRESSEE :body{seqno}" payload.
+// Returns (message, bulletin, isBulletin, ok). The bulletin
+// branch fires when the addressee starts with "BLN".
+func parseMessage(s string) (*Message, *Bulletin, bool, bool) {
+	// AX.25 message format: 9-char addressee + ':' + body.
+	if len(s) < 10 || s[9] != ':' {
+		return nil, nil, false, false
+	}
+	addr := strings.TrimRight(s[0:9], " ")
+	body := s[10:]
+	// Bulletin?
+	if strings.HasPrefix(addr, "BLN") {
+		return nil, &Bulletin{ID: addr, Body: body}, true, true
+	}
+	msg := &Message{Addressee: addr, Body: body}
+	// Strip optional "{seq}" suffix.
+	if i := strings.LastIndex(body, "{"); i >= 0 && strings.HasSuffix(body, "}") {
+		msg.SeqNo = body[i+1 : len(body)-1]
+		msg.Body = body[:i]
+	}
+	// Detect ack / rej.
+	if strings.HasPrefix(msg.Body, "ack") {
+		msg.Ack = true
+		msg.SeqNo = msg.Body[3:]
+		msg.Body = ""
+	} else if strings.HasPrefix(msg.Body, "rej") {
+		msg.Rej = true
+		msg.SeqNo = msg.Body[3:]
+		msg.Body = ""
+	}
+	return msg, nil, false, true
+}
+
+// String renders the packet for log / panel display. Always
+// non-empty.
+func (p Packet) String() string {
+	switch p.Type {
+	case TypePosition:
+		if p.Position == nil {
+			break
+		}
+		return fmt.Sprintf("POSITION %.4f,%.4f %q",
+			p.Position.Latitude, p.Position.Longitude, p.Position.Comment)
+	case TypeMessage:
+		if p.Message == nil {
+			break
+		}
+		if p.Message.Ack {
+			return fmt.Sprintf("ACK to %s seq=%s", p.Message.Addressee, p.Message.SeqNo)
+		}
+		if p.Message.Rej {
+			return fmt.Sprintf("REJ to %s seq=%s", p.Message.Addressee, p.Message.SeqNo)
+		}
+		return fmt.Sprintf("MSG to %s: %q", p.Message.Addressee, p.Message.Body)
+	case TypeStatus:
+		if p.Status == nil {
+			break
+		}
+		return fmt.Sprintf("STATUS %q", p.Status.Text)
+	case TypeBulletin:
+		if p.Bulletin == nil {
+			break
+		}
+		return fmt.Sprintf("BULLETIN %s: %q", p.Bulletin.ID, p.Bulletin.Body)
+	case TypeMicE:
+		return "MIC-E (compressed; decoder pending)"
+	case TypeWeather:
+		return "WEATHER " + p.Raw
+	case TypeTelemetry:
+		return "TELEMETRY " + p.Raw
+	case TypeObject:
+		return "OBJECT " + p.Raw
+	}
+	return "UNKNOWN " + p.Raw
+}

--- a/internal/radio/aprs/aprs_test.go
+++ b/internal/radio/aprs/aprs_test.go
@@ -1,0 +1,187 @@
+package aprs
+
+import (
+	"math"
+	"testing"
+)
+
+func TestDecodeUncompressedPositionNoTimestampNoMsg(t *testing.T) {
+	// APRS 1.0.1 spec format: DDMM.hhH/DDDMM.hhH — two-digit
+	// hundredths of a minute. Example "!4903.50N/07201.75W-Test"
+	// is the spec's canonical sample.
+	info := []byte("!4903.50N/07201.75W-Test 001234")
+	p := Decode(info)
+	if p.Type != TypePosition {
+		t.Fatalf("Type = %v, want TypePosition (raw=%q)", p.Type, p.Raw)
+	}
+	if p.Position == nil {
+		t.Fatal("Position is nil")
+	}
+	// 49 deg + 3.50/60 minutes ≈ 49.0583.
+	if math.Abs(p.Position.Latitude-49.0583) > 1e-3 {
+		t.Errorf("lat = %f, want ≈ 49.0583", p.Position.Latitude)
+	}
+	// -(72 deg + 1.75/60 minutes) ≈ -72.0292.
+	if math.Abs(p.Position.Longitude-(-72.0292)) > 1e-3 {
+		t.Errorf("lon = %f, want ≈ -72.0292", p.Position.Longitude)
+	}
+	if p.Position.SymbolTable != '/' || p.Position.SymbolCode != '-' {
+		t.Errorf("symbol = %c%c, want /-", p.Position.SymbolTable, p.Position.SymbolCode)
+	}
+	if p.Position.Comment != "Test 001234" {
+		t.Errorf("comment = %q", p.Position.Comment)
+	}
+	if p.Position.WithMessaging {
+		t.Error("WithMessaging = true on '!' packet; want false")
+	}
+}
+
+func TestDecodeUncompressedPositionWithMessaging(t *testing.T) {
+	info := []byte("=4903.50N/07201.75W-")
+	p := Decode(info)
+	if p.Type != TypePosition || p.Position == nil {
+		t.Fatalf("Type = %v", p.Type)
+	}
+	if !p.Position.WithMessaging {
+		t.Error("WithMessaging = false on '=' packet; want true")
+	}
+}
+
+func TestDecodeSouthernAndWesternHemisphere(t *testing.T) {
+	info := []byte("!3354.40S/15110.20W>Sydney")
+	p := Decode(info)
+	if p.Position == nil {
+		t.Fatal("Position is nil")
+	}
+	if p.Position.Latitude > 0 {
+		t.Errorf("lat = %f, want negative (S)", p.Position.Latitude)
+	}
+	if p.Position.Longitude > 0 {
+		t.Errorf("lon = %f, want negative (W)", p.Position.Longitude)
+	}
+}
+
+func TestDecodePositionWithTimestamp(t *testing.T) {
+	// "/" + 7-char timestamp + position. Timestamp is preserved
+	// raw on the Position; the parser doesn't try to figure out
+	// timezone.
+	info := []byte("/092345z4903.50N/07201.75W-")
+	p := Decode(info)
+	if p.Type != TypePosition || p.Position == nil {
+		t.Fatalf("Type = %v, want TypePosition (raw=%q)", p.Type, p.Raw)
+	}
+	if !p.Position.HasTimestamp {
+		t.Error("HasTimestamp = false")
+	}
+	if p.Position.TimestampRaw != "092345z" {
+		t.Errorf("TimestampRaw = %q, want %q", p.Position.TimestampRaw, "092345z")
+	}
+}
+
+func TestDecodeMessage(t *testing.T) {
+	// 9-char addressee, ":", body, optional "{seq}".
+	info := []byte(":W1AW-1   :Hello from W2XYZ{42}")
+	p := Decode(info)
+	if p.Type != TypeMessage {
+		t.Fatalf("Type = %v, want TypeMessage", p.Type)
+	}
+	if p.Message == nil {
+		t.Fatal("Message is nil")
+	}
+	if p.Message.Addressee != "W1AW-1" {
+		t.Errorf("Addressee = %q", p.Message.Addressee)
+	}
+	if p.Message.Body != "Hello from W2XYZ" {
+		t.Errorf("Body = %q", p.Message.Body)
+	}
+	if p.Message.SeqNo != "42" {
+		t.Errorf("SeqNo = %q, want 42", p.Message.SeqNo)
+	}
+}
+
+func TestDecodeMessageAck(t *testing.T) {
+	info := []byte(":W1AW-1   :ack42")
+	p := Decode(info)
+	if p.Type != TypeMessage || p.Message == nil {
+		t.Fatalf("Type = %v", p.Type)
+	}
+	if !p.Message.Ack {
+		t.Error("Ack = false, want true")
+	}
+	if p.Message.SeqNo != "42" {
+		t.Errorf("SeqNo = %q", p.Message.SeqNo)
+	}
+}
+
+func TestDecodeStatus(t *testing.T) {
+	info := []byte(">Net control on 146.52 simplex")
+	p := Decode(info)
+	if p.Type != TypeStatus || p.Status == nil {
+		t.Fatalf("Type = %v", p.Type)
+	}
+	if p.Status.Text != "Net control on 146.52 simplex" {
+		t.Errorf("Text = %q", p.Status.Text)
+	}
+}
+
+func TestDecodeBulletin(t *testing.T) {
+	info := []byte(":BLN1     :Weekly net Tuesday 19:00 local")
+	p := Decode(info)
+	if p.Type != TypeBulletin {
+		t.Fatalf("Type = %v, want TypeBulletin", p.Type)
+	}
+	if p.Bulletin == nil {
+		t.Fatal("Bulletin is nil")
+	}
+	if p.Bulletin.ID != "BLN1" {
+		t.Errorf("ID = %q, want BLN1", p.Bulletin.ID)
+	}
+}
+
+func TestDecodeMicE(t *testing.T) {
+	// First byte is 0x60 (back-tick) → Mic-E. We don't decode it
+	// yet but the type must be recognised.
+	info := []byte("`hello micE payload")
+	p := Decode(info)
+	if p.Type != TypeMicE {
+		t.Errorf("Type = %v, want TypeMicE", p.Type)
+	}
+}
+
+func TestDecodeUnknownLeavesRawIntact(t *testing.T) {
+	info := []byte("xxxxxx unknown payload")
+	p := Decode(info)
+	if p.Type != TypeUnknown {
+		t.Errorf("Type = %v, want TypeUnknown", p.Type)
+	}
+	if p.Raw != "xxxxxx unknown payload" {
+		t.Errorf("Raw = %q", p.Raw)
+	}
+}
+
+func TestDecodeEmptyInfoSafe(t *testing.T) {
+	p := Decode(nil)
+	if p.Type != TypeUnknown {
+		t.Errorf("Type = %v", p.Type)
+	}
+	if p.Raw != "" {
+		t.Errorf("Raw = %q", p.Raw)
+	}
+}
+
+func TestPacketStringSwitchesOnType(t *testing.T) {
+	for _, c := range []struct {
+		info string
+		want string
+	}{
+		{"!4903.50N/07201.75W-Test", "POSITION 49.0583,-72.0292 \"Test\""},
+		{":W1AW-1   :Hi there", "MSG to W1AW-1: \"Hi there\""},
+		{":W1AW-1   :ack9", "ACK to W1AW-1 seq=9"},
+		{">on the net", "STATUS \"on the net\""},
+	} {
+		got := Decode([]byte(c.info)).String()
+		if got != c.want {
+			t.Errorf("Decode(%q).String() = %q, want %q", c.info, got, c.want)
+		}
+	}
+}

--- a/internal/radio/aprs/ax25/frame.go
+++ b/internal/radio/aprs/ax25/frame.go
@@ -1,0 +1,242 @@
+// Package ax25 decodes the AX.25 link-layer frames APRS rides on top
+// of. AX.25 is a HDLC-derived frame format used by amateur packet
+// radio — modern terrestrial use is dominated by APRS (Automatic
+// Packet Reporting System) on the North-American 144.39 MHz channel,
+// the European 144.800 MHz channel, and other regional allocations.
+//
+// Frame structure (numbers are bytes):
+//
+//	+-----+-----+-----+-----+--------+--------+--------+
+//	| dst | src |  path (0..8)       | control |  PID  |
+//	|  7  |  7  | 0 .. 56            |    1    |   1   |
+//	+-----+-----+-----+-----+--------+--------+--------+
+//	|        info (0..256)            |   FCS (CRC-16) |
+//	|             bytes               |       2 bytes  |
+//	+---------------------------------+----------------+
+//
+// Each address is 6 bytes of base-40 callsign + 1 byte SSID/flags.
+// The path lists digipeaters; the last byte of the LAST address has
+// its bit 0 set ("end of address list") to terminate the chain.
+// FCS is HDLC-style CRC-16-CCITT over the de-stuffed body, with the
+// receive convention that a correct frame has residue 0xF0B8 after
+// running the CRC over the body+FCS bytes.
+//
+// This package handles AX.25 frame parsing only; the on-air bit-
+// stuffing / 0x7E flag delimiting / NRZI decoding happens one layer
+// up (in the DSP receiver). The APRS info-field interpretation
+// happens one layer further up (in package aprs).
+package ax25
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// Address is one entry in the {dst, src, path…} chain. AX.25 packs
+// each as 6 bytes of left-justified callsign (each byte shifted
+// left 1 — bit 0 of every callsign byte is reserved as the HDLC
+// "extension" flag) plus 1 byte carrying the SSID, the H/R bits,
+// and the end-of-address sentinel.
+type Address struct {
+	Callsign string // 0..6 ASCII chars, trailing spaces stripped
+	SSID     uint8  // 0..15
+	// HBit is the "has been digipeated" / repeater-acknowledged
+	// flag (bit 7 of the SSID byte for destination + path entries;
+	// the source address re-purposes it as the C-bit Command/
+	// Response indicator). True when the path entry's frame has
+	// passed through this digipeater.
+	HBit bool
+}
+
+// String returns the conventional CALLSIGN-SSID format
+// (e.g. "W1AW-9"), or just "CALLSIGN" when SSID is 0. Suffix "*"
+// is appended when HBit is set — APRS console convention.
+func (a Address) String() string {
+	s := a.Callsign
+	if a.SSID != 0 {
+		s += fmt.Sprintf("-%d", a.SSID)
+	}
+	if a.HBit {
+		s += "*"
+	}
+	return s
+}
+
+// Frame is one decoded AX.25 frame.
+type Frame struct {
+	Dst     Address
+	Src     Address
+	Path    []Address
+	Control uint8
+	PID     uint8
+	Info    []byte
+	// FCSOK reports whether the CRC trailing the frame matched.
+	// Set by Parse; callers should drop frames where FCSOK is
+	// false unless they're explicitly studying noise.
+	FCSOK bool
+}
+
+// Errors returned by Parse.
+var (
+	ErrFrameTooShort = errors.New("ax25: frame body shorter than minimum (16 bytes)")
+	ErrBadAddress    = errors.New("ax25: address chain malformed (no end-of-address flag in first 9 entries)")
+	ErrUnsupported   = errors.New("ax25: unsupported control / PID combination")
+)
+
+// MinFrameBytes is dst (7) + src (7) + control (1) + PID (1) +
+// FCS (2) = 18 bytes. A frame shorter than this can't possibly be
+// well-formed.
+const MinFrameBytes = 18
+
+// MaxPathEntries is the AX.25 spec limit on digipeater addresses.
+const MaxPathEntries = 8
+
+// Parse decodes one bit-stuffed-and-flag-stripped AX.25 frame body.
+// The input MUST be the byte stream that landed between two 0x7E
+// HDLC flag bytes, after NRZI decoding and de-bit-stuffing. The
+// trailing 2 bytes are the FCS; Parse validates them and reports
+// FCSOK accordingly.
+//
+// Returns the decoded Frame plus a nil error on structural
+// success; FCSOK on the returned frame distinguishes CRC-clean
+// frames from CRC-failed ones. A structural error (too short,
+// malformed address chain) is returned as the second value.
+func Parse(body []byte) (Frame, error) {
+	if len(body) < MinFrameBytes {
+		return Frame{}, ErrFrameTooShort
+	}
+	// Address chain: dst + src + 0..8 path. Each entry is 7 bytes;
+	// the end-of-address sentinel is bit 0 of the last byte of the
+	// final entry.
+	addresses := make([]Address, 0, 2+MaxPathEntries)
+	off := 0
+	endFound := false
+	for i := 0; i < 2+MaxPathEntries; i++ {
+		if off+7 > len(body) {
+			return Frame{}, ErrBadAddress
+		}
+		raw := body[off : off+7]
+		// HBit is only meaningful for path entries (i >= 2). For
+		// the destination + source addresses bit 7 is the C-bit
+		// (Command/Response indicator), which the APRS console
+		// convention ignores. Only set HBit when this is a path
+		// entry.
+		addr := parseAddress(raw, i >= 2)
+		addresses = append(addresses, addr)
+		off += 7
+		// End-of-address: bit 0 of byte 6 is set.
+		if raw[6]&0x01 != 0 {
+			endFound = true
+			break
+		}
+	}
+	if !endFound || len(addresses) < 2 {
+		return Frame{}, ErrBadAddress
+	}
+	// Control + PID + Info + FCS.
+	if len(body)-off < 4 { // control + pid + 2-byte FCS minimum
+		return Frame{}, ErrFrameTooShort
+	}
+	control := body[off]
+	off++
+	// PID is only meaningful for I-frames + UI frames; for now we
+	// always read it. Real-world APRS only ever uses UI frames
+	// (control byte = 0x03, PID = 0xF0); the parser is generic
+	// enough that other frame types pass through with their PID
+	// preserved.
+	pid := body[off]
+	off++
+
+	// FCS is the last 2 bytes; everything in between is the info
+	// field.
+	if len(body)-off < 2 {
+		return Frame{}, ErrFrameTooShort
+	}
+	infoEnd := len(body) - 2
+	info := append([]byte(nil), body[off:infoEnd]...)
+	fcsBytes := body[infoEnd:]
+
+	// CRC-16-CCITT, HDLC variant: poly 0x1021, init 0xFFFF, output
+	// inverted, reflected input + output. The transmitted FCS is
+	// the inverted CRC of everything in front of it; running the
+	// CRC over body+FCS produces the magic residue 0xF0B8 when
+	// clean.
+	calc := computeFCS(body[:infoEnd])
+	wireFCS := uint16(fcsBytes[0]) | uint16(fcsBytes[1])<<8
+	frame := Frame{
+		Dst:     addresses[0],
+		Src:     addresses[1],
+		Path:    addresses[2:],
+		Control: control,
+		PID:     pid,
+		Info:    info,
+		FCSOK:   calc == wireFCS,
+	}
+	return frame, nil
+}
+
+// parseAddress unpacks one 7-byte address entry. isPathEntry is
+// true for entries 2..9 of the address chain (digipeater path);
+// false for dst (entry 0) and src (entry 1) where bit 7 of the
+// SSID byte is the C-bit rather than the H-bit and is ignored by
+// the APRS console convention.
+func parseAddress(raw []byte, isPathEntry bool) Address {
+	var cs strings.Builder
+	for i := 0; i < 6; i++ {
+		c := raw[i] >> 1
+		if c == ' ' || c == 0 {
+			break
+		}
+		cs.WriteByte(c)
+	}
+	ssidByte := raw[6]
+	// SSID is bits 1..4. Bit 7 is the H/C bit (H for path,
+	// C for dst/src). Bit 0 is end-of-address (handled by caller).
+	ssid := (ssidByte >> 1) & 0x0F
+	hbit := isPathEntry && ssidByte&0x80 != 0
+	return Address{
+		Callsign: strings.TrimRight(cs.String(), " "),
+		SSID:     ssid,
+		HBit:     hbit,
+	}
+}
+
+// computeFCS computes the HDLC CRC-16-CCITT over the supplied
+// bytes. The FCS shipped on-wire is the bit-inverted, byte-swapped
+// version of this; the parser compares the wire-form FCS directly,
+// so this helper applies the same inversion + swap convention.
+func computeFCS(data []byte) uint16 {
+	crc := uint16(0xFFFF)
+	for _, b := range data {
+		crc ^= uint16(b)
+		for i := 0; i < 8; i++ {
+			if crc&1 != 0 {
+				crc = (crc >> 1) ^ 0x8408
+			} else {
+				crc >>= 1
+			}
+		}
+	}
+	return ^crc
+}
+
+// IsUI reports whether this is a UI (Unnumbered Information)
+// frame — the only frame type APRS uses on the wire. Control byte
+// 0x03, PID 0xF0 ("no layer 3 protocol").
+func (f Frame) IsUI() bool {
+	return f.Control == 0x03 && f.PID == 0xF0
+}
+
+// PathString renders the digipeater path in APRS console form
+// (e.g. "WIDE1-1,WIDE2-1*"). Empty path returns the empty string.
+func (f Frame) PathString() string {
+	if len(f.Path) == 0 {
+		return ""
+	}
+	parts := make([]string, len(f.Path))
+	for i, a := range f.Path {
+		parts[i] = a.String()
+	}
+	return strings.Join(parts, ",")
+}

--- a/internal/radio/aprs/ax25/frame_test.go
+++ b/internal/radio/aprs/ax25/frame_test.go
@@ -1,0 +1,190 @@
+package ax25
+
+import (
+	"bytes"
+	"testing"
+)
+
+// encodeAddress packs an Address into the 7-byte AX.25 wire format.
+// Test helper — mirrors what a transmitter does.
+func encodeAddress(a Address, last, hOrC bool) []byte {
+	out := make([]byte, 7)
+	cs := a.Callsign
+	for len(cs) < 6 {
+		cs += " "
+	}
+	for i := 0; i < 6; i++ {
+		out[i] = cs[i] << 1
+	}
+	ssid := byte(0b01100000) // reserved bits 5 + 6 set per the spec
+	ssid |= (a.SSID & 0x0F) << 1
+	if hOrC {
+		ssid |= 0x80
+	}
+	if last {
+		ssid |= 0x01
+	}
+	out[6] = ssid
+	return out
+}
+
+// buildFrame assembles a fully-formed AX.25 frame body (post-flag-
+// strip, pre-FCS) and appends a correct FCS.
+func buildFrame(t *testing.T, dst, src Address, path []Address, control, pid byte, info []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	buf.Write(encodeAddress(dst, false, false))
+	buf.Write(encodeAddress(src, len(path) == 0, true)) // src C-bit conventionally set
+	for i, p := range path {
+		last := i == len(path)-1
+		buf.Write(encodeAddress(p, last, p.HBit))
+	}
+	buf.WriteByte(control)
+	buf.WriteByte(pid)
+	buf.Write(info)
+	fcs := computeFCS(buf.Bytes())
+	buf.WriteByte(byte(fcs & 0xFF))
+	buf.WriteByte(byte(fcs >> 8))
+	return buf.Bytes()
+}
+
+func TestParseRoundTrip(t *testing.T) {
+	dst := Address{Callsign: "APRS", SSID: 0}
+	src := Address{Callsign: "W1AW", SSID: 9}
+	path := []Address{
+		{Callsign: "WIDE1", SSID: 1, HBit: false},
+		{Callsign: "WIDE2", SSID: 1, HBit: true},
+	}
+	info := []byte(`!4807.038N/01131.000E>Test`)
+	body := buildFrame(t, dst, src, path, 0x03, 0xF0, info)
+
+	f, err := Parse(body)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if !f.FCSOK {
+		t.Error("FCSOK = false on clean frame; want true")
+	}
+	if f.Dst.Callsign != "APRS" {
+		t.Errorf("dst callsign = %q, want APRS", f.Dst.Callsign)
+	}
+	if f.Src.String() != "W1AW-9" {
+		t.Errorf("src = %q, want W1AW-9", f.Src.String())
+	}
+	if !f.IsUI() {
+		t.Error("IsUI() = false on UI/PID-0xF0 frame")
+	}
+	wantPath := "WIDE1-1,WIDE2-1*"
+	if got := f.PathString(); got != wantPath {
+		t.Errorf("PathString = %q, want %q", got, wantPath)
+	}
+	if !bytes.Equal(f.Info, info) {
+		t.Errorf("info mismatch: got %q want %q", f.Info, info)
+	}
+}
+
+func TestParseDetectsCorruptedFCS(t *testing.T) {
+	body := buildFrame(t,
+		Address{Callsign: "APRS"},
+		Address{Callsign: "W1AW", SSID: 9},
+		nil, 0x03, 0xF0, []byte("test"))
+	// Corrupt one byte of the info field.
+	body[len(body)-3] ^= 0x80
+	f, err := Parse(body)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if f.FCSOK {
+		t.Error("FCSOK = true after bit-flip; want false")
+	}
+}
+
+func TestParseRejectsTooShort(t *testing.T) {
+	if _, err := Parse(make([]byte, 10)); err != ErrFrameTooShort {
+		t.Errorf("Parse(short) = %v, want ErrFrameTooShort", err)
+	}
+}
+
+func TestParseRejectsMissingEndOfAddress(t *testing.T) {
+	// Build a frame with 9 path entries — none has the end-of-
+	// address bit set, so the parser should bail.
+	var buf bytes.Buffer
+	dst := encodeAddress(Address{Callsign: "APRS"}, false, false)
+	src := encodeAddress(Address{Callsign: "W1AW", SSID: 9}, false, true)
+	buf.Write(dst)
+	buf.Write(src)
+	for i := 0; i < 9; i++ {
+		buf.Write(encodeAddress(Address{Callsign: "DIGI", SSID: uint8(i)}, false, false))
+	}
+	buf.WriteByte(0x03)
+	buf.WriteByte(0xF0)
+	buf.WriteByte(0x00)
+	buf.WriteByte(0x00) // wrong FCS; doesn't matter — parse fails earlier
+	if _, err := Parse(buf.Bytes()); err != ErrBadAddress {
+		t.Errorf("Parse(no-end) = %v, want ErrBadAddress", err)
+	}
+}
+
+func TestAddressStringFormats(t *testing.T) {
+	for _, c := range []struct {
+		a    Address
+		want string
+	}{
+		{Address{Callsign: "W1AW", SSID: 0}, "W1AW"},
+		{Address{Callsign: "W1AW", SSID: 9}, "W1AW-9"},
+		{Address{Callsign: "WIDE2", SSID: 1, HBit: true}, "WIDE2-1*"},
+		{Address{Callsign: "APRS", SSID: 0, HBit: true}, "APRS*"},
+	} {
+		if got := c.a.String(); got != c.want {
+			t.Errorf("%+v.String() = %q, want %q", c.a, got, c.want)
+		}
+	}
+}
+
+func TestParseTrimsCallsignSpaces(t *testing.T) {
+	// AX.25 right-pads callsigns to 6 chars with spaces (0x20). The
+	// parser must strip the trailing pad so "W1AW  " arrives as "W1AW".
+	body := buildFrame(t,
+		Address{Callsign: "AB"}, // 2-char callsign, gets 4 spaces padded
+		Address{Callsign: "CD", SSID: 3},
+		nil, 0x03, 0xF0, []byte(""))
+	f, err := Parse(body)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if f.Dst.Callsign != "AB" {
+		t.Errorf("dst.Callsign = %q, want AB", f.Dst.Callsign)
+	}
+	if f.Src.Callsign != "CD" {
+		t.Errorf("src.Callsign = %q, want CD", f.Src.Callsign)
+	}
+}
+
+func TestPathStringEmpty(t *testing.T) {
+	body := buildFrame(t,
+		Address{Callsign: "APRS"},
+		Address{Callsign: "W1AW"},
+		nil, 0x03, 0xF0, []byte(""))
+	f, _ := Parse(body)
+	if got := f.PathString(); got != "" {
+		t.Errorf("PathString with empty path = %q, want \"\"", got)
+	}
+}
+
+func TestNonUIFrameRecognised(t *testing.T) {
+	// Control=0x00 (I-frame N(R)=0 N(S)=0 P=0), PID=0xCC.
+	body := buildFrame(t,
+		Address{Callsign: "DEST"},
+		Address{Callsign: "SRC"},
+		nil, 0x00, 0xCC, []byte(""))
+	f, err := Parse(body)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if f.IsUI() {
+		t.Error("IsUI() = true on I-frame; want false")
+	}
+	if f.Control != 0x00 || f.PID != 0xCC {
+		t.Errorf("control/PID = %#x/%#x, want 0x00/0xCC", f.Control, f.PID)
+	}
+}


### PR DESCRIPTION
## Summary

First slice of **Phase 5** of the trunking-adjacent feature plan (#365): pure-Go protocol layer for **APRS** (Automatic Packet Reporting System) and the **AX.25** link layer it rides on. Complements the trunking-voice pipeline for emergency-comms-adjacent operators already running GopherTrunk for public-safety scanning — APRS carries position beacons, SAR coordination, weather, and messaging on amateur bands.

Mirrors the POCSAG protocol-first split (#372 → #373 → #378): this PR lands the parsers with thorough tests; DSP wiring (1200 Bd Bell-202 AFSK → HDLC bit-stuff/de-stuff → frame delimiter) follows in a focused follow-up.

## What's in the box

### `internal/radio/aprs/ax25` — AX.25 frame parser

- **7-byte address packing** with the spec's bit-shifted ASCII callsigns (each char `<< 1` in the wire byte; bit 0 reserved for HDLC extension flag)
- **Up to 8 digipeater path entries** past the source address
- **Control + PID** byte parsing (UI is the only frame APRS uses; the parser passes other types through with bytes preserved)
- **HDLC CRC-16-CCITT** validation via the standard 0x8408 reflected-bit polynomial; `frame.FCSOK` distinguishes clean from CRC-failed frames
- **Display helpers** matching APRS console convention: `Address.String()` → `"W1AW-9"` or `"WIDE2-1*"`, `Frame.PathString()` → `"WIDE1-1,WIDE2-1*"`
- HBit handling: only meaningful for path entries (bit 7 of the SSID byte); dst + src use the same bit position for the C-bit (Command/Response indicator) which the convention ignores

### `internal/radio/aprs` — APRS info-field decoder

| DTI byte | Type | Decoded fields |
| --- | --- | --- |
| `!` | Position (no timestamp, no msg) | lat/lon, symbol, comment |
| `=` | Position (no timestamp, messaging) | + WithMessaging |
| `/` | Position (timestamp, no msg) | + raw 7-char timestamp |
| `@` | Position (timestamp, messaging) | + raw timestamp + messaging |
| `:` | Message / Bulletin | addressee, body, seqno, ack/rej |
| `>` | Status | text |
| `;` / `_` / `T#` / Mic-E | recognised; decoders pending | type byte only |
| anything else | Unknown | raw bytes preserved |

- **Position**: both hemispheres (N/S, E/W), symbol table+code pair, free-form comment, ambiguity-space tolerance (spec allows low-precision digits as spaces — treated as 0)
- **Message**: 9-char trimmed addressee, optional `{NNN}` seqno, `ack`/`rej` short-form bodies (body becomes seqno), bulletin routing (BLN-prefixed addressee → `Bulletin` struct)

## Tests

- **8 AX.25 tests**: happy-path round-trip, CRC corruption detection, malformed-address rejection, callsign space-trim, address-format helpers, empty path rendering, non-UI frame recognition, too-short rejection
- **11 APRS tests**: position with/without messaging, with/without timestamp, southern + western hemisphere, message+ack+bulletin, status, Mic-E recognition, unknown payload pass-through, empty info safety, `Packet.String()` switch

All clean: **89 Go packages pass** (was 87 — new `internal/radio/aprs` + `internal/radio/aprs/ax25`), `go vet` clean, `gofmt -l .` clean.

## What's pending

Documented in `docs/aprs.md`:

- **DSP integration.** 1200 Bd Bell-202 AFSK demodulation, HDLC bit-stuffing reversal, 0x7E flag-delimited frame extraction. Mirrors the POCSAG receiver pattern; the AX.25 parser is ready the moment frame bytes flow.
- **Mic-E.** Compressed lat/lon format on mobile trackers (Kenwood TH-D74, Yaesu FT-3D). ~200 LOC for base-91 unpacking + speed/course/altitude.
- **Weather / telemetry / object payloads.** Recognised but bodies left in `Raw`.
- **Bus event + SQLite log + REST + web panel.** New `events.KindAPRSPacket` + `aprs_log` table (mirroring `pager_log` from #373) once DSP wiring lands.

## Docs

- **`docs/aprs.md`** — type-by-type table, what's wired, what's pending, APRS 1.0.1 + AX.25 v2.2 + aprs.fi references
- **`docs/_data/nav.yml`** — entry added under "Reference"
- **`README.md`** — APRS / AX.25 bullet under Features
- **`CHANGELOG.md`** — `[Unreleased]` → Added

## Test plan

- [x] `go test ./...` — 89 packages pass
- [x] `go vet ./...` clean
- [x] `gofmt -l .` clean
- [x] `go build ./...` succeeds
- [ ] Decode a real captured APRS-IS packet end-to-end (deferred to the DSP follow-up PR — needs `.cfile` fixture)

## Status of the 7-phase plan

- ✅ Phase 0, 1 (backend+web+spectrum-tune+bookmark-overlay), 2a, 2b, 2c, 4, 6 — shipped (PRs #365–#371)
- ✅ Phase 3 protocol (#372) + syncer/bus/log/REST/UI (#373) + DSP+daemon wiring (#378)
- ✅ Phase 5 APRS / AX.25 protocol layer — this PR
- ⏳ Phase 5 APRS DSP wiring + Mic-E + bus/log/UI; Phase 5 DSC/AIS/ADS-B; Phase 3 FLEX + multi-channel DDC; Phase 1 TUI; Phase 7 (M17 + Codec2) — remaining, each warrants a dedicated PR

https://claude.ai/code/session_01YUgvat8WpF5YaSuEAqWMr2

---
_Generated by [Claude Code](https://claude.ai/code/session_01YUgvat8WpF5YaSuEAqWMr2)_