### PR TITLE
rtlsdr: recover Windows control-pipe stalls during cold-boot bring-up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,19 @@ for tagged releases.
 
 ### Fixed
 
+- **RTL-SDR cold-boot stall on Windows now self-recovers.** Clone
+  dongles (and some power-marginal hubs) latch the first
+  USB_SYSCTL=0x09 vendor-OUT write, then NAK the byte-identical
+  second write in `init baseband` step 0 with `ERROR_GEN_FAILURE
+  (0x1F)`. The Linux equivalent (`EPIPE`) was already covered by the
+  bring-up reset+retry envelope; the Windows path wasn't because (a)
+  `ERROR_GEN_FAILURE` wasn't classified as resetable, and (b) the
+  WinUSB `Transport.Reset()` was a no-op. WinUSB now clears the
+  control-pipe halt via `WinUsb_ResetPipe(0)` (USB
+  `CLEAR_FEATURE(ENDPOINT_HALT)`), the new `usb.ErrPipeStalled`
+  sentinel keys the existing retry envelope, and a clone-dongle hint
+  pointing at Zadig / port choice / `gophertrunk sdr doctor` is
+  appended when the second attempt still fails.
 - **Wideband DMR receiver loop-gain now matches the single-channel
   ccdecoder path.** The Stage 2 / Stage 3 wideband engine was
   instantiating `dmr/receiver.Receiver` with the default

--- a/internal/sdr/rtlsdr/purego/driver.go
+++ b/internal/sdr/rtlsdr/purego/driver.go
@@ -266,21 +266,24 @@ func runBringup(demod *rtl2832u.Demod) (tuners.Tuner, error) {
 	return tuner, nil
 }
 
-// isBringupResetable reports whether err is one of the three error
+// isBringupResetable reports whether err is one of the four error
 // classes a USB port reset is the right hammer for during open-time
 // bring-up: EPIPE (Linux/USBDEVFS cold-boot stall, the librtlsdr "dummy
 // write probe" case), ErrDeviceGone (the chip dropped off the bus
-// mid-bringup), or ErrTimeout (Windows/WinUSB cold-boot — same root
-// cause as the Linux EPIPE, but WinUsb_ControlTransfer surfaces it as
-// ERROR_SEM_TIMEOUT instead of stalling the pipe). The retry is bounded
-// to one reset per Open so even if a reset is wasted on a non-cold-boot
-// timeout the cost is capped at ~200ms before the original error
-// surfaces. Other errors (ErrClosed, validation failures) stay
-// non-resetable.
+// mid-bringup), ErrTimeout (Windows/WinUSB cold-boot — same root cause
+// as the Linux EPIPE, but WinUsb_ControlTransfer surfaces it as
+// ERROR_SEM_TIMEOUT instead of stalling the pipe), or ErrPipeStalled
+// (Windows/WinUSB clone-dongle cold-boot — the chip latches the first
+// USB_SYSCTL write and then NAKs the next identical write with
+// ERROR_GEN_FAILURE). The retry is bounded to one reset
+// per Open so even if a reset is wasted on a non-cold-boot stall the
+// cost is capped at ~200ms before the original error surfaces. Other
+// errors (ErrClosed, validation failures) stay non-resetable.
 func isBringupResetable(err error) bool {
 	return errors.Is(err, syscall.EPIPE) ||
 		errors.Is(err, usb.ErrDeviceGone) ||
-		errors.Is(err, usb.ErrTimeout)
+		errors.Is(err, usb.ErrTimeout) ||
+		errors.Is(err, usb.ErrPipeStalled)
 }
 
 // claimBusyHint returns a parenthesized, space-prefixed remediation
@@ -331,6 +334,15 @@ func tunerBringupHint(err error) string {
 		return " (hint: USB control transfer timed out — common causes:" +
 			" on Windows, the WinUSB driver is not bound to the device (re-run Zadig and select the RTL-SDR);" +
 			" on any OS, marginal USB power, a flaky cable/hub, or another process already holding the device." +
+			" See https://mattcheramie.github.io/GopherTrunk/install-linux.html#troubleshooting)"
+	}
+	if errors.Is(err, usb.ErrPipeStalled) {
+		return " (hint: the dongle's USB control pipe stalled on cold boot" +
+			" (Windows ERROR_GEN_FAILURE) — common with clone dongles or" +
+			" marginal USB power. If the automatic retry didn't recover," +
+			" re-run Zadig to confirm WinUSB is bound to interface 0," +
+			" try a different USB port (avoid hubs), and re-plug the device." +
+			" Run `gophertrunk sdr doctor` to inspect the current driver binding." +
 			" See https://mattcheramie.github.io/GopherTrunk/install-linux.html#troubleshooting)"
 	}
 	return ""

--- a/internal/sdr/rtlsdr/purego/driver_test.go
+++ b/internal/sdr/rtlsdr/purego/driver_test.go
@@ -379,6 +379,11 @@ func TestTunerBringupHint(t *testing.T) {
 			err:     fmt.Errorf("wrap: %w", usb.ErrTimeout),
 			wantSub: []string{"Zadig", "install-linux.html#troubleshooting"},
 		},
+		{
+			name:    "ErrPipeStalled_through_wrap",
+			err:     fmt.Errorf("winusb: device rejected request: %w", usb.ErrPipeStalled),
+			wantSub: []string{"control pipe stalled", "Zadig", "sdr doctor", "install-linux.html#troubleshooting"},
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -433,6 +438,97 @@ func TestOpenDevice_WarmupTimeoutTriggersResetAndRetry(t *testing.T) {
 	}
 	if m.ClaimCalls != 2 {
 		t.Errorf("ClaimCalls = %d, want 2 (initial claim + post-reset re-claim)", m.ClaimCalls)
+	}
+}
+
+// The WinUSB cold-boot stall surfaces as ErrPipeStalled (mapped from
+// ERROR_GEN_FAILURE). The bring-up envelope must treat it as resetable
+// so WinUsb_ResetPipe(0) clears the control pipe halt and the retry
+// pass succeeds — matching the Linux EPIPE recovery path.
+func TestOpenDevice_WarmupPipeStalledTriggersResetAndRetry(t *testing.T) {
+	m := usb.NewMockTransport()
+	m.Script = []usb.CtrlExchange{
+		warmupUSBSysctlExchange(usb.ErrPipeStalled),
+		warmupUSBSysctlExchange(nil),
+		{
+			In:       false,
+			BRequest: 0,
+			WValue:   0x2000,
+			WIndex:   uint16(1)<<8 | 0x10,
+			Data:     []byte{0x09},
+			Err:      usb.ErrClosed,
+		},
+	}
+	desc := usb.Descriptor{VID: 0x0bda, PID: 0x2838, Serial: "test-warmup-pipestalled-retry"}
+	_, err := openDevice(m, desc, 0)
+	if err == nil {
+		t.Fatal("openDevice succeeded; expected init-baseband terminator to fail the test")
+	}
+	if !strings.Contains(err.Error(), "init baseband") {
+		t.Errorf("err = %v, want substring \"init baseband\" (proves warmup retry succeeded and InitBaseband ran)", err)
+	}
+	if m.ResetCalls != 1 {
+		t.Errorf("ResetCalls = %d, want 1 (ErrPipeStalled on warmup must trigger one clear-halt)", m.ResetCalls)
+	}
+	if m.ClaimCalls != 2 {
+		t.Errorf("ClaimCalls = %d, want 2 (initial claim + post-reset re-claim)", m.ClaimCalls)
+	}
+}
+
+// The cold-boot symptom that prompted the fix — warmup succeeds, then
+// the byte-identical first InitBaseband write stalls with
+// ERROR_GEN_FAILURE / ErrPipeStalled. The bring-up envelope must reset
+// and retry the whole flow.
+func TestOpenDevice_BringupPipeStalled_TriggersFullReset(t *testing.T) {
+	m := usb.NewMockTransport()
+	m.Script = []usb.CtrlExchange{
+		warmupUSBSysctlExchange(nil),                  // pass 1: warmup OK
+		warmupUSBSysctlExchange(usb.ErrPipeStalled),   // pass 1: InitBaseband step 0 stalls
+		warmupUSBSysctlExchange(nil),                  // pass 2: warmup OK (post clear-halt)
+		warmupUSBSysctlExchange(usb.ErrTimeout),       // pass 2: terminate early
+	}
+	desc := usb.Descriptor{VID: 0x0bda, PID: 0x2838, Serial: "test-bringup-pipestalled-retry"}
+	_, err := openDevice(m, desc, 0)
+	if err == nil {
+		t.Fatal("openDevice succeeded; expected init-baseband terminator to fail the test")
+	}
+	if !strings.Contains(err.Error(), "init baseband") {
+		t.Errorf("err = %v, want substring \"init baseband\" (proves the retry reached InitBaseband)", err)
+	}
+	if m.ResetCalls != 1 {
+		t.Errorf("ResetCalls = %d, want 1 (one clear-halt between the two bring-up attempts)", m.ResetCalls)
+	}
+	if m.ClaimCalls != 2 {
+		t.Errorf("ClaimCalls = %d, want 2 (initial claim + post-reset re-claim)", m.ClaimCalls)
+	}
+}
+
+// When ErrPipeStalled recurs on the retry pass, the surfaced error
+// must carry the clone-dongle / Zadig hint.
+func TestOpenDevice_BringupPipeStalledTwice_ReturnsHintError(t *testing.T) {
+	m := usb.NewMockTransport()
+	m.Script = []usb.CtrlExchange{
+		warmupUSBSysctlExchange(nil),
+		warmupUSBSysctlExchange(usb.ErrPipeStalled),
+		warmupUSBSysctlExchange(nil),
+		warmupUSBSysctlExchange(usb.ErrPipeStalled),
+	}
+	desc := usb.Descriptor{VID: 0x0bda, PID: 0x2838, Serial: "test-bringup-pipestalled-fail"}
+	_, err := openDevice(m, desc, 0)
+	if err == nil {
+		t.Fatal("openDevice succeeded; expected ErrPipeStalled-twice to fail open")
+	}
+	if !errors.Is(err, usb.ErrPipeStalled) {
+		t.Errorf("err = %v, want errors.Is(err, usb.ErrPipeStalled)", err)
+	}
+	if !strings.Contains(err.Error(), "control pipe stalled") {
+		t.Errorf("err = %v, want substring \"control pipe stalled\" (proves the clone-dongle hint was appended)", err)
+	}
+	if !strings.Contains(err.Error(), "Zadig") {
+		t.Errorf("err = %v, want substring \"Zadig\"", err)
+	}
+	if m.ResetCalls != 1 {
+		t.Errorf("ResetCalls = %d, want 1 (envelope is one-shot, not a loop)", m.ResetCalls)
 	}
 }
 

--- a/internal/sdr/rtlsdr/purego/driver_test.go
+++ b/internal/sdr/rtlsdr/purego/driver_test.go
@@ -482,10 +482,10 @@ func TestOpenDevice_WarmupPipeStalledTriggersResetAndRetry(t *testing.T) {
 func TestOpenDevice_BringupPipeStalled_TriggersFullReset(t *testing.T) {
 	m := usb.NewMockTransport()
 	m.Script = []usb.CtrlExchange{
-		warmupUSBSysctlExchange(nil),                  // pass 1: warmup OK
-		warmupUSBSysctlExchange(usb.ErrPipeStalled),   // pass 1: InitBaseband step 0 stalls
-		warmupUSBSysctlExchange(nil),                  // pass 2: warmup OK (post clear-halt)
-		warmupUSBSysctlExchange(usb.ErrTimeout),       // pass 2: terminate early
+		warmupUSBSysctlExchange(nil),                // pass 1: warmup OK
+		warmupUSBSysctlExchange(usb.ErrPipeStalled), // pass 1: InitBaseband step 0 stalls
+		warmupUSBSysctlExchange(nil),                // pass 2: warmup OK (post clear-halt)
+		warmupUSBSysctlExchange(usb.ErrTimeout),     // pass 2: terminate early
 	}
 	desc := usb.Descriptor{VID: 0x0bda, PID: 0x2838, Serial: "test-bringup-pipestalled-retry"}
 	_, err := openDevice(m, desc, 0)

--- a/internal/sdr/rtlsdr/usb/usb.go
+++ b/internal/sdr/rtlsdr/usb/usb.go
@@ -150,6 +150,15 @@ var (
 	// within the supplied timeoutMs window.
 	ErrTimeout = errors.New("usb: transfer timed out")
 
+	// ErrPipeStalled is returned when the device stalled the USB pipe
+	// (CLEAR_FEATURE(ENDPOINT_HALT) recoverable). Maps to ERROR_GEN_FAILURE
+	// on Windows/WinUSB — the clone-dongle cold-boot symptom where the
+	// chip latches the first vendor-OUT write and then NAKs the next one
+	// with byte-identical wire bytes. The librtlsdr-parity Linux
+	// equivalent surfaces as syscall.EPIPE. Callers should clear the
+	// halt via [Transport.Reset] and retry once.
+	ErrPipeStalled = errors.New("usb: pipe stalled")
+
 	// ErrClosed is returned by methods invoked after Close.
 	ErrClosed = errors.New("usb: transport closed")
 )

--- a/internal/sdr/rtlsdr/usb/usb_windows.go
+++ b/internal/sdr/rtlsdr/usb/usb_windows.go
@@ -323,13 +323,21 @@ func (t *winTransport) ClaimInterface(num int) error {
 func (t *winTransport) ReleaseInterface(int) error { return nil }
 
 func (t *winTransport) Reset() error {
-	// WinUSB has no equivalent of libusb_reset_device — issuing a USB
-	// port-reset requires IOCTL_USB_CYCLE_PORT on the parent hub, which
-	// is brittle and rarely needed. Return nil so callers treat it as
-	// a best-effort no-op (matches the Linux backend's behavior on
-	// kernels that don't expose USBDEVFS_RESET).
+	// WinUSB has no equivalent of libusb_reset_device — a full USB
+	// port-reset would require IOCTL_USB_CYCLE_PORT on the parent hub,
+	// which is brittle and almost never the right hammer. What the
+	// bring-up retry envelope actually needs is a clear-halt on the
+	// default control endpoint: that's exactly what WinUsb_ResetPipe
+	// emits (USB CLEAR_FEATURE(ENDPOINT_HALT)). Pipe ID 0 is the
+	// default control endpoint. Recovers the clone-dongle cold-boot
+	// stall surfaced as ERROR_GEN_FAILURE on the second USB_SYSCTL=0x09
+	// write, without disturbing the bulk-IN pipe.
 	if t.closed.Load() {
 		return ErrClosed
+	}
+	ret, _, errno := procWinUsbResetPipe.Call(t.ifaceHandle, 0)
+	if ret == 0 {
+		return fmt.Errorf("winusb: WinUsb_ResetPipe(control): %w", winErr(errno))
 	}
 	return nil
 }
@@ -667,6 +675,10 @@ func parseDevicePath(p string) (vid, pid uint16, serial string) {
 // request, the pipe stalled, or the wrong function driver is bound
 // (e.g. libusbK rather than in-box WinUSB.sys). Conflating it with
 // physical disconnect actively misled the issue #270 reporter.
+// Instead it wraps both ErrPipeStalled (so the bring-up retry envelope
+// in purego/driver.go treats it as resetable, matching the Linux EPIPE
+// path) and the underlying windows.Errno (so existing call-sites that
+// inspect the Win32 code via errors.Is still work).
 func winErr(errno error) error {
 	if errno == nil {
 		return nil
@@ -677,7 +689,7 @@ func winErr(errno error) error {
 		windows.ERROR_DEV_NOT_EXIST:
 		return ErrDeviceGone
 	case windows.ERROR_GEN_FAILURE:
-		return fmt.Errorf("winusb: device rejected request (ERROR_GEN_FAILURE 0x1F — firmware NAK / stalled pipe / wrong driver bound; try re-binding to WinUSB via Zadig): %w", errno)
+		return fmt.Errorf("winusb: device rejected request (ERROR_GEN_FAILURE 0x1F — firmware NAK / stalled pipe / wrong driver bound; try re-binding to WinUSB via Zadig): %w (errno: %w)", ErrPipeStalled, errno)
 	case windows.ERROR_SEM_TIMEOUT, windows.ERROR_TIMEOUT:
 		return ErrTimeout
 	}

--- a/internal/sdr/rtlsdr/usb/usb_windows_test.go
+++ b/internal/sdr/rtlsdr/usb/usb_windows_test.go
@@ -122,6 +122,18 @@ func TestWinErr_GenFailureIsNotDeviceGone(t *testing.T) {
 	}
 }
 
+func TestWinErr_GenFailureMapsToPipeStalled(t *testing.T) {
+	// The WinUSB equivalent of librtlsdr's "dummy write probe stalled
+	// on cold boot" surfaces as ERROR_GEN_FAILURE on the second
+	// USB_SYSCTL=0x09 write. The bring-up retry envelope keys off
+	// ErrPipeStalled to trigger a control-pipe clear-halt and retry
+	// once — matching the Linux EPIPE recovery path.
+	got := winErr(windows.ERROR_GEN_FAILURE)
+	if !errors.Is(got, ErrPipeStalled) {
+		t.Errorf("winErr(ERROR_GEN_FAILURE) = %v, want errors.Is(err, ErrPipeStalled) so the bring-up retry kicks in", got)
+	}
+}
+
 func TestWinErr_DisconnectCodesMapToDeviceGone(t *testing.T) {
 	for _, errno := range []windows.Errno{
 		windows.ERROR_DEVICE_NOT_CONNECTED,


### PR DESCRIPTION
A user reported `gophertrunk sdr list --probe` failing on Windows
with:

  rtlsdr: init baseband: init baseband step 0:
    rtl2832u: write block=1 addr=0x2000 val=0x0009:
    winusb: WinUsb_ControlTransfer OUT:
    winusb: device rejected request (ERROR_GEN_FAILURE 0x1F ...)

Diagnosis: librtlsdr's USB-sysctl warmup (the "dummy write probe"
that surfaces a cold-boot stall before the real init flood) succeeded
— the wrapped error path proves it ran. But the byte-identical first
write inside InitBaseband then stalled. On clone dongles and
power-marginal hubs the chip latches the first vendor-OUT write and
NAKs the next one with `ERROR_GEN_FAILURE`. The Linux equivalent
surfaces as `EPIPE`, which the bring-up reset+retry envelope at
purego/driver.go:172-188 already handles. The Windows path didn't
recover because (a) `ERROR_GEN_FAILURE` wasn't classified as
resetable, and (b) the WinUSB `Transport.Reset()` was a deliberate
no-op — `IOCTL_USB_CYCLE_PORT` was rejected as too heavy.

The actual primitive needed isn't a port reset, it's a clear-halt
on the default control endpoint. `WinUsb_ResetPipe(0)` emits exactly
that (USB `CLEAR_FEATURE(ENDPOINT_HALT)`) and the procedure was
already imported but unused.

internal/sdr/rtlsdr/usb:
  - new `ErrPipeStalled` sentinel for clear-halt-recoverable stalls.
  - `winErr` maps `ERROR_GEN_FAILURE` to wrap both `ErrPipeStalled`
    and the underlying `windows.Errno` (multi-`%w`), so existing
    call-sites that key off the Win32 code keep working while the
    bring-up envelope sees the new sentinel.
  - `winTransport.Reset()` calls `WinUsb_ResetPipe(0)` instead of
    returning nil. Bulk-IN pipe is untouched.
  - `winErr` regression test asserts both the existing
    "not-ErrDeviceGone" invariant and the new ErrPipeStalled wiring.

internal/sdr/rtlsdr/purego:
  - `isBringupResetable` recognises `ErrPipeStalled`; the existing
    one-shot reset+retry envelope handles the recovery for free.
  - `tunerBringupHint` appends a clone-dongle-flavoured hint
    (Zadig / port choice / `gophertrunk sdr doctor`) when the
    second attempt still fails.
  - new MockTransport-driven tests script `ErrPipeStalled` on
    warmup and on InitBaseband step 0, asserting one `Reset` call,
    two `ClaimInterface` calls, and that the surfaced
    error-after-two-failures carries the actionable hint.

CHANGELOG: entry under [Unreleased] → Fixed describing the
recovery path.

https://claude.ai/code/session_019LqHGs7VMfoyAdif2KVVyT