### PR TITLE
trunking: replace misleading "voice pool full" warning when pool is empty

### DIFF
--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -1092,6 +1092,14 @@ func (d *Daemon) Run(ctx context.Context) error {
 		"systems", len(d.systems),
 		"voice_devices", len(d.voicePool.Devices()),
 	)
+	// Catch the single-SDR-control-only setup early: trunking systems
+	// declared but no `role: voice` SDR means every grant will drop at
+	// HandleGrant. Warn once at startup so the operator sees it before
+	// the first grant. Issue #379.
+	if len(d.systems) > 0 && len(d.voicePool.Devices()) == 0 {
+		d.log.Warn("no voice SDR configured but trunking systems are defined; voice grants will be dropped — add a role: voice device (see docs/hardware.md)",
+			"systems", len(d.systems))
+	}
 
 	// Wrap ctx so an essential component error can cancel siblings.
 	runCtx, cancel := context.WithCancel(ctx)

--- a/internal/trunking/engine.go
+++ b/internal/trunking/engine.go
@@ -29,6 +29,11 @@ type Engine struct {
 	now        func() time.Time
 	sub        *events.Subscription
 	closeOnce  sync.Once
+	// noVoiceSDROnce gates the actionable "no voice SDR" warning so
+	// it logs once per Engine lifetime instead of once per grant.
+	// Subsequent grants on an empty pool drop at DEBUG. Reset when
+	// the engine is reconstructed (daemon reload / restart).
+	noVoiceSDROnce sync.Once
 
 	// scanMode is read under modeMu so the API cockpit can flip it at
 	// runtime without a daemon restart. HandleGrant takes a snapshot
@@ -191,8 +196,23 @@ func (e *Engine) HandleGrant(g Grant) {
 	// 2) All busy. Look at the lowest-priority active call.
 	victim := e.pool.LowestPriorityActive()
 	if victim == nil {
-		// Shouldn't happen: pool was full but has no actives. Drop.
-		e.log.Warn("voice pool full but no actives", "grant", g.String())
+		// FindFree() and LowestPriorityActive() both nil means the
+		// pool has zero devices — trunking is configured but no
+		// `role: voice` SDR is attached, so every grant is dropped.
+		// Log loudly once with the fix, then DEBUG for the rest of
+		// the daemon's life so we don't spam one WARN per grant.
+		if len(e.pool.Devices()) == 0 {
+			e.noVoiceSDROnce.Do(func() {
+				e.log.Warn("no voice SDR available; voice grants will be dropped — add a role: voice device (see docs/hardware.md)",
+					"grant", g.String())
+			})
+			e.log.Debug("dropping grant: no voice SDR", "grant", g.String())
+			return
+		}
+		// Devices > 0 but no actives recorded — should be
+		// unreachable: a busy device always contributes an active.
+		// Surface as Error so the bug is visible in logs.
+		e.log.Error("voice pool full but no actives (engine bug)", "grant", g.String())
 		return
 	}
 	if !CanPreempt(victim.Grant, victim.Talkgroup, g, tg) {

--- a/internal/trunking/engine_test.go
+++ b/internal/trunking/engine_test.go
@@ -1,7 +1,10 @@
 package trunking
 
 import (
+	"bytes"
 	"context"
+	"log/slog"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -518,6 +521,53 @@ func TestEngineHandleCallEncryptionUnknownDeviceDoesNotPanic(t *testing.T) {
 		AlgorithmID:  0x84,
 		KeyID:        0x1234,
 	})
+}
+
+func TestEngineEmptyVoicePoolWarnsOnceThenDebug(t *testing.T) {
+	// Issue #379: a daemon with trunking systems but zero `role: voice`
+	// SDRs builds an empty VoicePool. Every grant used to log a
+	// misleading "voice pool full but no actives" warning. The engine
+	// now logs one actionable WARN and drops the rest at DEBUG.
+	bus := events.NewBus(8)
+	defer bus.Close()
+	pool, _ := mkPool(0)
+
+	var buf bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	e, err := NewEngine(EngineOptions{
+		Bus:        bus,
+		Log:        log,
+		VoicePool:  pool,
+		Talkgroups: NewTalkgroupDB(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	g := Grant{System: "X", Protocol: "p25", GroupID: 1, FrequencyHz: 851_000_000}
+	e.HandleGrant(g)
+	e.HandleGrant(g)
+	e.HandleGrant(g)
+
+	out := buf.String()
+	// Misleading legacy message must be gone.
+	if strings.Contains(out, "voice pool full but no actives") {
+		t.Errorf("legacy misleading warning still present:\n%s", out)
+	}
+	// Actionable WARN logged exactly once across three grants.
+	warnCount := strings.Count(out, "level=WARN")
+	if warnCount != 1 {
+		t.Errorf("expected exactly one WARN, got %d:\n%s", warnCount, out)
+	}
+	if !strings.Contains(out, "no voice SDR available") {
+		t.Errorf("expected actionable WARN about missing voice SDR:\n%s", out)
+	}
+	// Every grant drops at DEBUG; the first also emits the one-shot WARN.
+	debugCount := strings.Count(out, `msg="dropping grant: no voice SDR"`)
+	if debugCount != 3 {
+		t.Errorf("expected 3 DEBUG drops (one per grant), got %d:\n%s", debugCount, out)
+	}
 }
 
 func TestEngineHandleCallEncryptionEnrichedRepublishDoesNotLoop(t *testing.T) {


### PR DESCRIPTION
When an operator boots with a trunked system but no role: voice SDR
attached, every grant logged "voice pool full but no actives" — which
read as "pool full" while the pool was in fact empty, and gave no clue
that a second SDR or a wideband channelizer is required.

Distinguish the two cases inside HandleGrant: when the pool has zero
devices, log a one-shot actionable WARN pointing at docs/hardware.md
and drop subsequent grants at DEBUG so we don't spam one WARN per
grant. The genuine impossible state (devices > 0 but no actives)
becomes an Error so the bug stays visible.

Also emit a one-shot startup WARN from Daemon.Run when trunking
systems are declared but the voice pool is empty, so the operator
sees the problem before the first grant arrives. Non-trunked
deployments (POCSAG paging, conventional FM scanner, wideband T2
capture-only, baseband recording) still run cleanly because the
warning is gated on len(systems) > 0.

Fixes #379.