### PR TITLE
widebandt2: P25 Phase 1 + Phase 2 control channels on one SDR

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -132,29 +132,40 @@ sdr:
       bias_tee: false
 
     # role: wideband pins one dongle to a centre frequency and lets a
-    # single SDR cover several DMR repeaters that all live inside its
+    # single SDR cover several carriers that all live inside its
     # IQ bandwidth (typically a 2.4 MHz cluster of carriers in the
-    # same band). The list of repeater frequencies is set per-dongle,
+    # same band). The list of channel frequencies is set per-dongle,
     # alongside the trunking.systems entry they decode against. The
     # daemon uses internal/dsp/tuner to extract a separate narrow-
-    # band stream per repeater - no extra hardware needed.
+    # band stream per channel - no extra hardware needed.
     #
     # Each channel references a trunking.systems entry whose protocol
     # determines the state machine:
-    #   protocol: dmr-tier2  → Tier II conventional carrier
-    #   protocol: dmr        → Tier III trunked control channel
-    #                          (frequency_hz must be in the system's
-    #                          control_channels list)
-    # T2 and T3 channels can mix on the same dongle. T3 voice grants
-    # still route to the daemon's physical voice pool; the wideband
-    # dongle decodes the CC, not the voice traffic.
+    #   protocol: dmr-tier2   → Tier II conventional carrier
+    #   protocol: dmr         → DMR Tier III trunked control channel
+    #                           (frequency_hz must be in the system's
+    #                           control_channels list)
+    #   protocol: p25         → P25 Phase 1 trunked control channel
+    #                           (frequency_hz must be in
+    #                           control_channels; respects the
+    #                           system's p25_phase1_demod_mode for
+    #                           C4FM vs CQPSK / LSM simulcast)
+    #   protocol: p25-phase2  → P25 Phase 2 trunked control channel
+    #                           (frequency_hz must be in
+    #                           control_channels; respects the
+    #                           per-system p25_phase2_* mode keys)
+    #
+    # Channels of any supported protocol can mix on the same dongle.
+    # Trunked CC channels (dmr / p25 / p25-phase2) decode the control
+    # channel only; voice grants still route to the daemon's physical
+    # voice pool (a role: voice SDR alongside the wideband dongle).
     #
     # Constraints (validated at load time):
     #   - serial must match a discovered dongle
     #   - every channel frequency_hz must be within
     #     center_freq_hz ± sample_rate/2 with a 5% guard at each edge
     #   - each referenced system must be declared in trunking.systems
-    #     below with protocol: dmr-tier2 or protocol: dmr
+    #     below with one of the supported protocols listed above
     #
     # tuner_strategy:
     #   auto       (default) - ddc for ≤ 6 channels, polyphase above
@@ -183,6 +194,29 @@ sdr:
     #   channels:
     #     - frequency_hz: 851_037_500
     #       system: "regional-dmr-t3"
+    #
+    # P25 Phase 1 control channel on a wideband dongle. The
+    # referenced system carries `protocol: p25` and the
+    # channel's frequency_hz must appear in its control_channels.
+    # Honours `p25_phase1_demod_mode` (c4fm vs cqpsk / LSM) on the
+    # system entry just like a dedicated CC dongle.
+    # - serial: "00000005"
+    #   role: wideband
+    #   center_freq_hz: 851_500_000
+    #   channels:
+    #     - frequency_hz: 851_037_500
+    #       system: "regional-p25"
+    #
+    # P25 Phase 2 control channel on a wideband dongle. The
+    # referenced system carries `protocol: p25-phase2`; the
+    # `p25_phase2_*` mode knobs (trellis / RS / interleave /
+    # scrambler / clock) on the system apply transparently.
+    # - serial: "00000006"
+    #   role: wideband
+    #   center_freq_hz: 851_500_000
+    #   channels:
+    #     - frequency_hz: 851_006_250
+    #       system: "regional-p25-p2"
 
   # rtl_tcp remote SDRs. Each entry mounts a host:port rtl_tcp server
   # as a virtual tuner alongside any local USB dongles. Use when the

--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -295,6 +295,41 @@ The engine picks the right state machine per channel (Tier III's
 `ControlChannel` for `protocol: dmr`, Tier II's `ConventionalChannel`
 for `protocol: dmr-tier2`).
 
+### P25 trunked control channel on a wideband dongle
+
+A wideband dongle can also host a P25 control channel — Phase 1 (C4FM
+or CQPSK / LSM simulcast) or Phase 2 (H-DQPSK TDMA). The configuration
+mirrors the DMR Tier III case: the wideband channel sits on the
+system's declared `control_channels`, and the engine decodes the TSBK
+(Phase 1) or MAC PDU (Phase 2) chain inline. Voice grants ride on the
+existing physical voice pool — see the "Limits" section below.
+
+```yaml
+sdr:
+  devices:
+    - serial: "00000003"
+      role: wideband
+      center_freq_hz: 851_500_000
+      channels:
+        - frequency_hz: 851_037_500       # P25 Phase 1 CC
+          system: "regional-p25"
+
+trunking:
+  systems:
+    - name: "regional-p25"
+      protocol: p25                       # Phase 1
+      control_channels: [851_037_500]     # MUST include the wideband channel above
+      # On a simulcast site whose CC is transmitted as Linear
+      # Simulcast Modulation rather than C4FM, opt in to the
+      # linear-CQPSK demod path:
+      # p25_phase1_demod_mode: cqpsk
+```
+
+For P25 Phase 2 use `protocol: p25-phase2`; the same per-system
+`p25_phase2_*` knobs (trellis / RS / interleave / scrambler / clock
+mode) that apply to a dedicated CC SDR apply to the wideband channel
+too — see the trunking systems section of `config.example.yaml`.
+
 T3 voice grants are published on the bus and routed to the daemon's
 existing physical voice pool — add a `role: voice` SDR alongside the
 wideband dongle if you want voice decoded. The follow-up work to
@@ -324,14 +359,17 @@ message that names the offending entry.
 
 ### Limits
 
-- **DMR only.** Wideband supports `protocol: dmr-tier2` (Tier II
-  conventional) and `protocol: dmr` (Tier III trunked control
-  channel). Other protocols (P25, NXDN, TETRA, …) and Tier III
-  voice grants on the wideband dongle itself are not in scope yet —
-  see "Tier III voice" below.
-- **Tier III voice still needs a physical Voice SDR.** When the
-  wideband T3 tap decodes a grant, the daemon's existing voice pool
-  retunes a `role: voice` dongle to follow the call. The wideband
+- **DMR + P25.** Wideband supports `protocol: dmr-tier2` (Tier II
+  conventional), `protocol: dmr` (Tier III trunked control channel),
+  `protocol: p25` (P25 Phase 1 trunked control channel — C4FM and
+  CQPSK / LSM simulcast), and `protocol: p25-phase2` (P25 Phase 2
+  H-DQPSK trunked control channel). Other protocols (NXDN, TETRA,
+  …) and trunked **voice** grants on the wideband dongle itself are
+  not in scope yet — see "Trunked voice" below.
+- **Trunked voice still needs a physical Voice SDR.** When a
+  wideband trunked CC tap (DMR T3, P25 Phase 1, P25 Phase 2)
+  decodes a grant, the daemon's existing voice pool retunes a
+  `role: voice` dongle to follow the call. The wideband
   dongle decodes the CC; voice rides on the regular pool. A
   follow-up will add a virtual voice pool that allocates a tuner
   tap from the wideband dongle for each grant, removing the need

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1026,9 +1026,13 @@ func validateWidebandDevice(idx int, d DeviceConfig, sampleRateHz uint32, system
 		case "dmr-tier2", "dmr_tier2", "dmr-t2", "dmrtier2":
 			// Tier II conventional - channel freq is a repeater carrier,
 			// no relationship to system.ControlChannels required.
-		case "dmr":
-			// Tier III trunked - the wideband channel MUST be one of
-			// the system's declared control channels.
+		case "dmr", "p25", "p25-phase2", "p25_phase2", "p25p2":
+			// Trunked control-channel protocols — the wideband channel
+			// MUST be one of the system's declared control channels.
+			// Tier III DMR's CSBK chain, P25 Phase 1's TSBK chain, and
+			// P25 Phase 2's H-DQPSK MAC chain all run on a frequency
+			// the system advertises in control_channels; voice grants
+			// hop elsewhere.
 			matched := false
 			for _, cc := range sys.ControlChannels {
 				if cc == ch.FrequencyHz {
@@ -1039,13 +1043,14 @@ func validateWidebandDevice(idx int, d DeviceConfig, sampleRateHz uint32, system
 			if !matched {
 				return fmt.Errorf(
 					"sdr.devices[%d].channels[%d]: frequency_hz %d does not match any of system %q's "+
-						"control_channels %v (wideband T3 channels must sit on a declared control channel)",
-					idx, j, ch.FrequencyHz, ch.System, sys.ControlChannels)
+						"control_channels %v (wideband %s channels must sit on a declared control channel)",
+					idx, j, ch.FrequencyHz, ch.System, sys.ControlChannels, sys.Protocol)
 			}
 		default:
 			return fmt.Errorf(
-				"sdr.devices[%d].channels[%d]: system %q has protocol %q; wideband currently supports dmr-tier2 "+
-					"(Tier II conventional) and dmr (Tier III trunked control channel)",
+				"sdr.devices[%d].channels[%d]: system %q has protocol %q; wideband currently supports "+
+					"dmr-tier2 (Tier II conventional), dmr (Tier III trunked control channel), "+
+					"p25 (Phase 1 trunked control channel), and p25-phase2 (Phase 2 trunked control channel)",
 				idx, j, ch.System, sys.Protocol)
 		}
 		offset := float64(ch.FrequencyHz) - float64(d.CenterFreqHz)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -179,14 +179,56 @@ func TestValidate(t *testing.T) {
 				},
 			}}},
 		}, true},
-		{"wideband non-dmr protocol", Config{
+		// P25 Phase 1 wideband CC tap (parallel to the T3 case above):
+		// channel must sit on one of the system's declared
+		// control_channels because a Phase 1 trunked control channel
+		// IS one.
+		{"wideband P25 Phase 1 ok", Config{
+			SDR: SDRConfig{SampleRate: 2_400_000, Devices: []DeviceConfig{{
+				Serial: "00000010", Role: "wideband", CenterFreqHz: 851_500_000,
+				Channels: []DeviceChannelConfig{
+					{FrequencyHz: 851_037_500, System: "regional-p25"},
+				},
+			}}},
+			Trunking: TrunkingConfig{Systems: []SystemConfig{{
+				Name: "regional-p25", Protocol: "p25",
+				ControlChannels: []uint32{851_037_500},
+			}}},
+		}, false},
+		{"wideband P25 Phase 1 channel not in CC list", Config{
+			SDR: SDRConfig{SampleRate: 2_400_000, Devices: []DeviceConfig{{
+				Serial: "00000010", Role: "wideband", CenterFreqHz: 851_500_000,
+				Channels: []DeviceChannelConfig{
+					{FrequencyHz: 851_125_000, System: "regional-p25"},
+				},
+			}}},
+			Trunking: TrunkingConfig{Systems: []SystemConfig{{
+				Name: "regional-p25", Protocol: "p25",
+				ControlChannels: []uint32{851_037_500},
+			}}},
+		}, true},
+		{"wideband P25 Phase 2 ok", Config{
+			SDR: SDRConfig{SampleRate: 2_400_000, Devices: []DeviceConfig{{
+				Serial: "00000010", Role: "wideband", CenterFreqHz: 851_500_000,
+				Channels: []DeviceChannelConfig{
+					{FrequencyHz: 851_006_250, System: "regional-p2"},
+				},
+			}}},
+			Trunking: TrunkingConfig{Systems: []SystemConfig{{
+				Name: "regional-p2", Protocol: "p25-phase2",
+				ControlChannels: []uint32{851_006_250},
+			}}},
+		}, false},
+		// Non-trunked protocols are still rejected — wideband doesn't
+		// host NXDN / EDACS / etc. yet.
+		{"wideband unsupported protocol", Config{
 			SDR: SDRConfig{SampleRate: 2_400_000, Devices: []DeviceConfig{{
 				Serial: "00000010", Role: "wideband", CenterFreqHz: 453_500_000,
 				Channels: []DeviceChannelConfig{
-					{FrequencyHz: 453_125_000, System: "p25-sys"},
+					{FrequencyHz: 453_125_000, System: "nxdn-sys"},
 				},
 			}}},
-			Trunking: TrunkingConfig{Systems: []SystemConfig{{Name: "p25-sys", Protocol: "p25"}}},
+			Trunking: TrunkingConfig{Systems: []SystemConfig{{Name: "nxdn-sys", Protocol: "nxdn"}}},
 		}, true},
 		{"wideband duplicate frequency", Config{
 			SDR: SDRConfig{SampleRate: 2_400_000, Devices: []DeviceConfig{{

--- a/internal/scanner/widebandt2/engine.go
+++ b/internal/scanner/widebandt2/engine.go
@@ -1,11 +1,11 @@
-// Package widebandt2 monitors several DMR repeaters with a single SDR
-// dongle. The dongle is pinned to a configured centre frequency; an
-// internal/dsp/tuner.Bank extracts one narrow-band IQ stream per
-// repeater carrier inside the dongle's IQ band; each stream feeds a
-// DMR receiver and a per-channel state machine that publishes
-// cc.locked / grant events on the bus.
+// Package widebandt2 monitors several trunked / conventional carriers
+// with a single SDR dongle. The dongle is pinned to a configured centre
+// frequency; an internal/dsp/tuner.Bank extracts one narrow-band IQ
+// stream per channel inside the dongle's IQ band; each stream feeds a
+// protocol-specific receiver and per-channel state machine that
+// publishes cc.locked / grant events on the bus.
 //
-// Two DMR variants are supported as channel state machines:
+// Supported channel state machines:
 //
 //   - DMR Tier II conventional (config protocol "dmr-tier2"). Each
 //     channel is a per-repeater carrier; the state machine
@@ -14,12 +14,24 @@
 //   - DMR Tier III trunked control channel (config protocol "dmr").
 //     The channel frequency must match one of the system's
 //     control_channels; the state machine (radio/dmr/tier3) emits
-//     grants from the CSBK chain. The published grants flow through
-//     the trunking engine's existing voice-pool allocator, which
-//     binds them to a physical role: voice dongle. Voice grants are
-//     not (yet) decoded by the wideband dongle itself — that needs
-//     a per-call narrow-band composer chain which is roadmapped as
-//     a follow-up.
+//     grants from the CSBK chain.
+//
+//   - P25 Phase 1 trunked control channel (config protocol "p25").
+//     The channel frequency must match one of the system's
+//     control_channels; the state machine (radio/p25/phase1) emits
+//     grants from the TSBK chain. C4FM vs CQPSK / LSM is selected
+//     via the system's p25_phase1_demod_mode key.
+//
+//   - P25 Phase 2 trunked control channel (config protocol
+//     "p25-phase2"). The channel frequency must match one of the
+//     system's control_channels; the state machine
+//     (radio/p25/phase2) consumes superframes assembled by the
+//     receiver and emits grants from the MAC PDU chain.
+//
+// Published grants flow through the trunking engine's existing
+// voice-pool allocator, which binds them to a physical role: voice
+// dongle. Voice grants are not (yet) decoded by the wideband dongle
+// itself — that's the "virtual voice pool" follow-up.
 //
 // One Engine owns one wideband SDR. Multiple wideband dongles each
 // get their own Engine; they run independently and share only the
@@ -36,9 +48,14 @@ import (
 	"github.com/MattCheramie/GopherTrunk/internal/dsp/tuner"
 	"github.com/MattCheramie/GopherTrunk/internal/events"
 	"github.com/MattCheramie/GopherTrunk/internal/radio/dmr"
-	"github.com/MattCheramie/GopherTrunk/internal/radio/dmr/receiver"
+	dmrrx "github.com/MattCheramie/GopherTrunk/internal/radio/dmr/receiver"
 	"github.com/MattCheramie/GopherTrunk/internal/radio/dmr/tier2"
 	"github.com/MattCheramie/GopherTrunk/internal/radio/dmr/tier3"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+	p25phase1 "github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase1"
+	p25phase1rx "github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase1/receiver"
+	p25phase2 "github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase2"
+	p25phase2rx "github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase2/receiver"
 	"github.com/MattCheramie/GopherTrunk/internal/sdr"
 	"github.com/MattCheramie/GopherTrunk/internal/trunking"
 )
@@ -50,16 +67,28 @@ import (
 // down-converter targets.
 const narrowbandRateHz = 48_000.0
 
-// DMR receiver loop-gain + deviation values mirror the per-pipeline
-// settings the single-frequency CC decoder uses, so wideband-
-// channelized streams behave identically to the dedicated-dongle
-// path. ETSI TS 102 361-1 §6.3 pins the peak deviation at 1944 Hz at
-// symbol ±3; T2's harder symbol distribution (mean transition
-// magnitude 1.27 vs T3's 0.90) needs a more conservative loop gain.
+// Per-protocol receiver constants mirror the per-pipeline settings the
+// single-frequency CC decoder uses, so wideband-channelized streams
+// behave identically to the dedicated-dongle path.
+//
+// DMR (ETSI TS 102 361-1 §6.3): peak deviation 1944 Hz at symbol ±3.
+// T2's harder symbol distribution (mean transition magnitude 1.27 vs
+// T3's 0.90) needs a more conservative loop gain.
+//
+// P25 Phase 1 (TIA-102.BAAA-A): nominal peak deviation 1800 Hz at
+// symbol ±3. Only consulted on the C4FM path; the CQPSK / LSM path
+// is amplitude-invariant after the matched filter.
+//
+// P25 Phase 2 (TIA-102.BBAC): H-DQPSK at 6000 symbols/s. The
+// pipeline factory's tuned Gardner gain (0.005) matches PR #154's
+// observation that π/4-DQPSK family signals slip differently than
+// C4FM at the receiver's default gain.
 const (
-	deviationHz    = 1944.0
-	clockGainTier2 = 0.015 // matches newDMRTier2Pipeline in ccdecoder
-	clockGainTier3 = 0.025 // matches newDMRTier3Pipeline in ccdecoder
+	dmrDeviationHz       = 1944.0
+	dmrClockGainTier2    = 0.015 // matches newDMRTier2Pipeline in ccdecoder
+	dmrClockGainTier3    = 0.025 // matches newDMRTier3Pipeline in ccdecoder
+	p25Phase1DeviationHz = 1800.0
+	p25Phase2GardnerGain = 0.005
 )
 
 // guardFrac is the fraction of the IQ band the tuner reserves at
@@ -141,20 +170,33 @@ type Engine struct {
 	strategyTag string
 }
 
-// channelProcessor is the per-channel dibit consumer. Tier II's
-// ConventionalChannel and Tier III's ControlChannel both expose
+// channelProcessor is the per-channel dibit consumer. DMR Tier II's
+// ConventionalChannel, DMR Tier III's ControlChannel, P25 Phase 1's
+// ControlChannel and P25 Phase 2's ControlChannel all expose
 // Process(dibits []uint8, baseIdx int) int with the same semantics, so
-// the engine treats them uniformly.
+// the engine treats them uniformly. (Phase 2's ControlChannel also
+// exposes IngestSuperframe; the build function wires the receiver's
+// DibitSink through a SuperframeDecoder before calling Process so the
+// engine still only sees a dibit-shaped processor.)
 type channelProcessor interface {
 	Process(dibits []uint8, baseIdx int) int
+}
+
+// narrowbandReceiver consumes the per-channel narrowband IQ stream.
+// Every protocol's receiver (DMR, P25 Phase 1, P25 Phase 2) implements
+// Process([]complex64) — the engine doesn't care which one it holds,
+// only that the receiver's DibitSink is already wired to the channel's
+// channelProcessor at construction.
+type narrowbandReceiver interface {
+	Process(iq []complex64)
 }
 
 type engineChannel struct {
 	freqHz    uint32
 	sysName   string
-	protoTag  string // "dmr-tier2" or "dmr-tier3"
+	protoTag  string // e.g. "dmr-tier2", "dmr-tier3", "p25-phase1", "p25-phase2"
 	processor channelProcessor
-	receiver  *receiver.Receiver
+	receiver  narrowbandReceiver
 }
 
 // New constructs an Engine. The device is not opened or streamed
@@ -218,37 +260,9 @@ func New(opts Options) (*Engine, error) {
 				ch.FrequencyHz, ch.SystemName)
 		}
 		offset := float64(ch.FrequencyHz) - float64(opts.CenterFreqHz)
-		processor, protoTag, err := buildProcessor(sys, ch.FrequencyHz, opts.Bus, log, opts.Now)
+		ec, err := buildChannel(sys, ch, opts.Bus, log, opts.Now)
 		if err != nil {
 			return nil, err
-		}
-		// DibitSink hands the receiver's dibits to the
-		// per-channel state machine's Process adapter. Both
-		// tier2.ConventionalChannel and tier3.ControlChannel
-		// satisfy channelProcessor; the adapter buffers across
-		// calls, runs sync detection, frames bursts, and emits
-		// cc.locked / grant events on the bus.
-		dibitSink := func(p channelProcessor) dmr.DibitSink {
-			return func(dibits []uint8, baseIdx int) {
-				p.Process(dibits, baseIdx)
-			}
-		}(processor)
-		clockGain := clockGainTier2
-		if protoTag == "dmr-tier3" {
-			clockGain = clockGainTier3
-		}
-		rcv := receiver.New(receiver.Options{
-			SampleRateHz: narrowbandRateHz,
-			DibitSink:    dibitSink,
-			DeviationHz:  deviationHz,
-			ClockGain:    clockGain,
-		})
-		ec := &engineChannel{
-			freqHz:    ch.FrequencyHz,
-			sysName:   ch.SystemName,
-			protoTag:  protoTag,
-			processor: processor,
-			receiver:  rcv,
 		}
 		sink := func(ec *engineChannel) tuner.SinkFunc {
 			return func(out []complex64) {
@@ -267,23 +281,22 @@ func New(opts Options) (*Engine, error) {
 	return engine, nil
 }
 
-// buildProcessor instantiates the right DMR state machine for a
-// channel: Tier III ControlChannel for protocol "dmr" (the channel
-// frequency must be one of the system's control_channels), Tier II
-// ConventionalChannel for protocol "dmr-tier2".
-func buildProcessor(sys trunking.System, freqHz uint32, bus *events.Bus, log *slog.Logger, now func() time.Time) (channelProcessor, string, error) {
+// buildChannel instantiates the right per-protocol receiver and state
+// machine for a wideband channel. Trunked control-channel protocols
+// (DMR Tier III, P25 Phase 1, P25 Phase 2) require the channel
+// frequency to match one of the system's declared control_channels;
+// DMR Tier II is conventional and accepts any per-repeater carrier.
+//
+// The returned engineChannel has its receiver's DibitSink already wired
+// to the per-channel state machine — the caller just pumps IQ into
+// receiver.Process and the bus picks up cc.locked / grant events as
+// the protocol's framer locks on.
+func buildChannel(sys trunking.System, ch ChannelConfig, bus *events.Bus, log *slog.Logger, now func() time.Time) (*engineChannel, error) {
+	freqHz := ch.FrequencyHz
 	switch sys.Protocol {
 	case trunking.ProtocolDMR:
-		matched := false
-		for _, cc := range sys.ControlChannels {
-			if cc == freqHz {
-				matched = true
-				break
-			}
-		}
-		if !matched {
-			return nil, "", fmt.Errorf("widebandt2: channel freq=%d on system %q (protocol dmr / Tier III) "+
-				"must match one of the system's control_channels %v", freqHz, sys.Name, sys.ControlChannels)
+		if err := requireControlChannel(sys, freqHz, "dmr / Tier III"); err != nil {
+			return nil, err
 		}
 		cc := tier3.New(tier3.Options{
 			Bus:         bus,
@@ -292,7 +305,14 @@ func buildProcessor(sys trunking.System, freqHz uint32, bus *events.Bus, log *sl
 			FrequencyHz: freqHz,
 			Now:         now,
 		})
-		return cc, "dmr-tier3", nil
+		rx := dmrrx.New(dmrrx.Options{
+			SampleRateHz: narrowbandRateHz,
+			DibitSink:    dmr.DibitSink(func(d []uint8, b int) { cc.Process(d, b) }),
+			DeviationHz:  dmrDeviationHz,
+			ClockGain:    dmrClockGainTier3,
+		})
+		return &engineChannel{freqHz: freqHz, sysName: sys.Name, protoTag: "dmr-tier3", processor: cc, receiver: rx}, nil
+
 	case trunking.ProtocolDMRTier2:
 		cc := tier2.New(tier2.Options{
 			Bus:         bus,
@@ -301,11 +321,148 @@ func buildProcessor(sys trunking.System, freqHz uint32, bus *events.Bus, log *sl
 			FrequencyHz: freqHz,
 			Now:         now,
 		})
-		return cc, "dmr-tier2", nil
+		rx := dmrrx.New(dmrrx.Options{
+			SampleRateHz: narrowbandRateHz,
+			DibitSink:    dmr.DibitSink(func(d []uint8, b int) { cc.Process(d, b) }),
+			DeviationHz:  dmrDeviationHz,
+			ClockGain:    dmrClockGainTier2,
+		})
+		return &engineChannel{freqHz: freqHz, sysName: sys.Name, protoTag: "dmr-tier2", processor: cc, receiver: rx}, nil
+
+	case trunking.ProtocolP25:
+		if err := requireControlChannel(sys, freqHz, "p25 / Phase 1"); err != nil {
+			return nil, err
+		}
+		demodMode, ok := p25phase1rx.ParseDemodMode(sys.P25Phase1DemodMode)
+		if !ok {
+			log.Warn("widebandt2: unrecognised p25_phase1_demod_mode; falling back to c4fm",
+				"system", sys.Name, "value", sys.P25Phase1DemodMode)
+		}
+		// C4FM has only two physical rotations (identity, polarity
+		// flip); the CQPSK / LSM path has the full four-fold QPSK
+		// ambiguity. Mirrors the ccdecoder pipeline.
+		rotations := p25phase1.RotationsAll
+		if demodMode == p25phase1rx.DemodC4FM {
+			rotations = p25phase1.RotationsC4FM
+		}
+		var bandPlan *p25phase1.BandPlan
+		if len(sys.P25BandPlan) > 0 {
+			bandPlan = &p25phase1.BandPlan{}
+			for _, e := range sys.P25BandPlan {
+				bandPlan.Apply(p25phase1.IdentifierUpdate{
+					ChannelID:   e.ChannelID,
+					BaseHz:      e.BaseHz,
+					SpacingHz:   e.SpacingHz,
+					TxOffsetHz:  e.TxOffsetHz,
+					BandwidthHz: e.BandwidthHz,
+				})
+			}
+		}
+		cc := p25phase1.New(p25phase1.Options{
+			Bus:         bus,
+			Log:         log.With("system", sys.Name, "freq_hz", freqHz, "phase", 1),
+			SystemName:  sys.Name,
+			FrequencyHz: freqHz,
+			BandPlan:    bandPlan,
+			Rotations:   rotations,
+		})
+		rx := p25phase1rx.New(p25phase1rx.Options{
+			SampleRateHz: narrowbandRateHz,
+			DeviationHz:  p25Phase1DeviationHz,
+			DemodMode:    demodMode,
+			DibitSink: p25phase1.DibitSink(func(d []uint8, b int) {
+				cc.Process(d, b)
+			}),
+		})
+		return &engineChannel{freqHz: freqHz, sysName: sys.Name, protoTag: "p25-phase1", processor: cc, receiver: rx}, nil
+
+	case trunking.ProtocolP25Phase2:
+		if err := requireControlChannel(sys, freqHz, "p25-phase2 / Phase 2"); err != nil {
+			return nil, err
+		}
+		cc := p25phase2.New(p25phase2.Options{
+			Bus:         bus,
+			Log:         log.With("system", sys.Name, "freq_hz", freqHz, "phase", 2),
+			SystemName:  sys.Name,
+			FrequencyHz: freqHz,
+		})
+		applyP25Phase2Modes(cc, sys, log)
+		clockMode, ok := p25phase2rx.ParseClockMode(sys.P25Phase2ClockMode)
+		if !ok {
+			log.Warn("widebandt2: unrecognised p25_phase2_clock_mode; falling back to gardner",
+				"system", sys.Name, "value", sys.P25Phase2ClockMode)
+		}
+		sfDec := p25phase2.NewSuperframeDecoder()
+		rx := p25phase2rx.New(p25phase2rx.Options{
+			SampleRateHz: narrowbandRateHz,
+			DibitSink: p25phase2.DibitSink(func(d []uint8, b int) {
+				for _, sf := range sfDec.Process(d, b) {
+					cc.IngestSuperframe(sf)
+				}
+			}),
+			ClockMode:   clockMode,
+			GardnerGain: p25Phase2GardnerGain,
+		})
+		return &engineChannel{freqHz: freqHz, sysName: sys.Name, protoTag: "p25-phase2", processor: cc, receiver: rx}, nil
+
 	default:
-		return nil, "", fmt.Errorf("widebandt2: system %q has protocol %q; wideband only supports dmr-tier2 and dmr",
+		return nil, fmt.Errorf(
+			"widebandt2: system %q has protocol %q; wideband supports dmr-tier2, dmr, p25, and p25-phase2",
 			sys.Name, sys.Protocol.String())
 	}
+}
+
+// requireControlChannel rejects a wideband channel that doesn't sit on
+// one of the system's declared control_channels. Used by every trunked
+// protocol case in buildChannel — the protocol's state machine only
+// makes sense on a CC frequency, and the config validator already
+// enforces the same rule at load time.
+func requireControlChannel(sys trunking.System, freqHz uint32, label string) error {
+	for _, cc := range sys.ControlChannels {
+		if cc == freqHz {
+			return nil
+		}
+	}
+	return fmt.Errorf("widebandt2: channel freq=%d on system %q (protocol %s) "+
+		"must match one of the system's control_channels %v",
+		freqHz, sys.Name, label, sys.ControlChannels)
+}
+
+// applyP25Phase2Modes mirrors newP25Phase2Pipeline's per-system mode
+// wiring (trellis / RS / interleave / scrambler) so a wideband Phase 2
+// CC tap decodes traffic identically to the dedicated ccdecoder path.
+func applyP25Phase2Modes(cc *p25phase2.ControlChannel, sys trunking.System, log *slog.Logger) {
+	trellisMode, ok := p25phase2.ParseTrellisMode(sys.P25Phase2TrellisMode)
+	if !ok {
+		log.Warn("widebandt2: unrecognised p25_phase2_trellis_mode; falling back to on",
+			"system", sys.Name, "value", sys.P25Phase2TrellisMode)
+	}
+	cc.SetTrellisMode(trellisMode)
+	rsMode, rsOK := p25phase2.ParseRSMode(sys.P25Phase2RSMode)
+	if !rsOK {
+		log.Warn("widebandt2: unrecognised p25_phase2_rs_mode; falling back to off",
+			"system", sys.Name, "value", sys.P25Phase2RSMode)
+	}
+	cc.SetRSMode(rsMode)
+	interleaveMode, ilOK := p25phase2.ParseInterleaveMode(sys.P25Phase2InterleaveMode)
+	if !ilOK {
+		log.Warn("widebandt2: unrecognised p25_phase2_interleave_mode; falling back to off",
+			"system", sys.Name, "value", sys.P25Phase2InterleaveMode)
+	}
+	cc.SetInterleaveMode(interleaveMode)
+	scramblerMode, scrOK := p25phase2.ParseScramblerMode(sys.P25Phase2ScramblerMode)
+	if !scrOK {
+		log.Warn("widebandt2: unrecognised p25_phase2_scrambler_mode; falling back to off",
+			"system", sys.Name, "value", sys.P25Phase2ScramblerMode)
+	}
+	if scramblerMode == p25phase2.ScramblerProbe && rsMode != p25phase2.RSOn {
+		log.Warn("widebandt2: p25_phase2_scrambler_mode=probe requires p25_phase2_rs_mode=on; descrambler will degrade to offset 0",
+			"system", sys.Name)
+	}
+	cc.SetScramblerMode(scramblerMode)
+	cc.SetScramblerSeed(framing.PN44SeedFromIdentity(
+		sys.WACN, sys.SystemID, uint16(sys.Site),
+	))
 }
 
 // Channels returns the per-channel frequencies the engine is
@@ -320,9 +477,9 @@ func (e *Engine) Channels() []uint32 {
 }
 
 // ChannelProtocolTags returns a frequency → protocol-tag map for the
-// channels this engine drives ("dmr-tier2" or "dmr-tier3"). Used by
-// the daemon's startup log and by tests to verify the dispatcher
-// picked the right state machine per channel.
+// channels this engine drives ("dmr-tier2", "dmr-tier3", "p25-phase1",
+// or "p25-phase2"). Used by the daemon's startup log and by tests to
+// verify the dispatcher picked the right state machine per channel.
 func (e *Engine) ChannelProtocolTags() map[uint32]string {
 	out := make(map[uint32]string, len(e.channels))
 	for _, c := range e.channels {

--- a/internal/scanner/widebandt2/engine_e2e_test.go
+++ b/internal/scanner/widebandt2/engine_e2e_test.go
@@ -56,7 +56,7 @@ func TestEngineEndToEndT2GrantFromSynthesizedIQ(t *testing.T) {
 	// 1. Build the dibit stream + modulate to baseband IQ at the
 	// wideband rate.
 	dibits := buildT2VoiceLCHeaderDibits(burstRepeats, colorCode, groupID, sourceID)
-	baseband := demod.ModulateC4FM(dibits, spsWideband, spanSymbols, alpha, widebandRateHz, deviationHz)
+	baseband := demod.ModulateC4FM(dibits, spsWideband, spanSymbols, alpha, widebandRateHz, dmrDeviationHz)
 
 	// 2. Optionally shift the baseband by offsetHz. At offsetHz=0
 	// this is a no-op; kept as a seam so a future variant of this

--- a/internal/scanner/widebandt2/engine_test.go
+++ b/internal/scanner/widebandt2/engine_test.go
@@ -25,6 +25,17 @@ func t3System(name string, ccFreq uint32) trunking.System {
 	return trunking.System{Name: name, Protocol: trunking.ProtocolDMR, ControlChannels: []uint32{ccFreq}}
 }
 
+// p25Phase1System / p25Phase2System are test helpers for P25 wideband
+// channels — both phases run on declared control channels, just like
+// DMR Tier III.
+func p25Phase1System(name string, ccFreq uint32) trunking.System {
+	return trunking.System{Name: name, Protocol: trunking.ProtocolP25, ControlChannels: []uint32{ccFreq}}
+}
+
+func p25Phase2System(name string, ccFreq uint32) trunking.System {
+	return trunking.System{Name: name, Protocol: trunking.ProtocolP25Phase2, ControlChannels: []uint32{ccFreq}}
+}
+
 // mockDevice is a synchronous sdr.Device that emits a caller-supplied
 // sequence of IQ chunks, then closes the stream. The test goroutine
 // blocks on producing each chunk so the engine's loop is driven
@@ -308,6 +319,90 @@ func TestEngineRunSetsCenterFreqAndDrainsStream(t *testing.T) {
 	}
 	if got := len(e.Channels()); got != 2 {
 		t.Errorf("Channels() len = %d, want 2", got)
+	}
+}
+
+func TestEngineP25Phase1Channel(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	dev := newMockDevice(nil)
+	e, err := New(Options{
+		Device: dev, Bus: bus, SampleRateHz: 2_400_000, CenterFreqHz: 851_500_000,
+		Channels: []ChannelConfig{{FrequencyHz: 851_037_500, SystemName: "p25-sys"}},
+		Systems:  []trunking.System{p25Phase1System("p25-sys", 851_037_500)},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	tags := e.ChannelProtocolTags()
+	if tags[851_037_500] != "p25-phase1" {
+		t.Errorf("tag = %q, want p25-phase1", tags[851_037_500])
+	}
+}
+
+func TestEngineP25Phase2Channel(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	dev := newMockDevice(nil)
+	e, err := New(Options{
+		Device: dev, Bus: bus, SampleRateHz: 2_400_000, CenterFreqHz: 851_500_000,
+		Channels: []ChannelConfig{{FrequencyHz: 851_006_250, SystemName: "p25p2-sys"}},
+		Systems:  []trunking.System{p25Phase2System("p25p2-sys", 851_006_250)},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	tags := e.ChannelProtocolTags()
+	if tags[851_006_250] != "p25-phase2" {
+		t.Errorf("tag = %q, want p25-phase2", tags[851_006_250])
+	}
+}
+
+func TestEngineRejectsP25ChannelNotInCCList(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	dev := newMockDevice(nil)
+	// CC declared at 851_037_500 but the wideband channel claims
+	// 851_125_000 — must reject so we don't try to decode a TSBK
+	// chain on a voice carrier.
+	_, err := New(Options{
+		Device: dev, Bus: bus, SampleRateHz: 2_400_000, CenterFreqHz: 851_500_000,
+		Channels: []ChannelConfig{{FrequencyHz: 851_125_000, SystemName: "p25-sys"}},
+		Systems:  []trunking.System{p25Phase1System("p25-sys", 851_037_500)},
+	})
+	if err == nil {
+		t.Fatal("expected error: P25 wideband channel must sit on a declared control channel")
+	}
+}
+
+func TestEngineMixedDMRAndP25Channels(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	dev := newMockDevice(nil)
+	// One wideband dongle hosts a DMR T2 cluster and a P25 Phase 1
+	// control channel at the other end of its IQ band. The dispatcher
+	// must pick the right state machine per channel based on the
+	// referenced system's protocol.
+	e, err := New(Options{
+		Device: dev, Bus: bus, SampleRateHz: 2_400_000, CenterFreqHz: 852_000_000,
+		Channels: []ChannelConfig{
+			{FrequencyHz: 851_037_500, SystemName: "p25-sys"},
+			{FrequencyHz: 852_775_000, SystemName: "t2-sys"},
+		},
+		Systems: []trunking.System{
+			p25Phase1System("p25-sys", 851_037_500),
+			t2System("t2-sys"),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	tags := e.ChannelProtocolTags()
+	if tags[851_037_500] != "p25-phase1" {
+		t.Errorf("freq 851_037_500 tag = %q, want p25-phase1", tags[851_037_500])
+	}
+	if tags[852_775_000] != "dmr-tier2" {
+		t.Errorf("freq 852_775_000 tag = %q, want dmr-tier2", tags[852_775_000])
 	}
 }
 


### PR DESCRIPTION
## Summary

First half of the wideband channelizer extension mentioned in
[issue #379](https://github.com/MattCheramie/GopherTrunk/issues/379#issuecomment-4547982950).
A single SDR pinned to one centre frequency can now host a **P25
trunked control channel** inside the existing wideband channelizer,
alongside the DMR Tier II and Tier III state machines that were
already supported. Both P25 Phase 1 (TSBK / C4FM + CQPSK / LSM) and
P25 Phase 2 (H-DQPSK MAC PDU chain) are wired.

Voice grants on these protocols still route to the daemon's existing
physical voice pool — the "virtual voice pool" that puts a per-grant
DDC tap on the same wideband dongle is Phase B, planned as a
follow-up PR.

## What's in this PR

- **`internal/scanner/widebandt2/engine.go`** — refactors the
  per-channel wiring to use a small `narrowbandReceiver` interface
  (`Process([]complex64)`). DMR keeps its existing receiver; P25 Phase
  1 and Phase 2 plug in their own receivers with `DibitSink` wired
  straight into `phase1.ControlChannel` / `phase2.ControlChannel`.
  The engine itself stays protocol-agnostic.
- **P25 Phase 1** honours the system's `p25_phase1_demod_mode` (C4FM
  vs CQPSK / LSM) and any operator-supplied `P25BandPlan` entries.
- **P25 Phase 2** reuses the existing per-system trellis / RS /
  interleave / scrambler / clock mode knobs and the PN44 seed
  derivation, so a wideband Phase 2 CC tap decodes identically to a
  dedicated CC dongle.
- **`internal/config/config.go`** — wideband validator accepts
  `protocol: p25` and `protocol: p25-phase2` with the same
  control-channel-membership rule that already applied to DMR T3.
- **Docs + example config** — `docs/hardware.md` Limits section now
  reads "DMR + P25"; worked P25 example added next to the existing
  T2/T3 ones; `config.example.yaml` gains commented P25 Phase 1 +
  Phase 2 wideband examples.

## What's NOT in this PR (Phase B — follow-up)

- Virtual voice pool that allocates a DDC tap on the same wideband
  dongle for each voice grant. With Phase A merged, operators still
  need a second `role: voice` SDR for voice traffic; Phase B removes
  that requirement.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (full suite green)
- [x] New tests cover P25 Phase 1 and Phase 2 wideband channel
      construction, mixed DMR + P25 dispatch, and rejection of a P25
      channel that doesn't sit on a declared `control_channels` entry.
- [x] Config validator tests for `protocol: p25` and `p25-phase2`
      acceptance + the same out-of-CC-list rejection rule.
- [x] Existing DMR T2 / T3 wideband tests stay green (regression).
- [ ] Hand-run with a real P25 site (Phase 1 and Phase 2 separately)
      — for the maintainer to confirm on hardware they have access to.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H88vWRgZAgp52e1be9WqWp)_