### PR TITLE
wbvoice: one SDR for trunked control + voice (virtual voice pool)

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,13 +112,21 @@ Silicon and Intel. Full per-OS recipes at
   outputs, public-safety fall-back channels) stored in the
   daemon's SQLite database. Edit / create / delete from the web
   panel under `/bookmarks`; REST at `/api/v1/bookmarks`.
-- **One dongle, many repeaters** — `role: wideband` pins a single
+- **One dongle, many carriers** — `role: wideband` pins a single
   SDR to a centre frequency and runs an internal channelizer so
-  one dongle decodes every DMR Tier II conventional repeater AND
-  a DMR Tier III control channel that fit inside its IQ bandwidth
-  (e.g. several 12.5 kHz carriers inside a 2.4 MHz IQ window).
-  Mix T2 and T3 channels on the same dongle. See
-  [docs/hardware.md](docs/hardware.md) and
+  one dongle decodes every DMR Tier II conventional repeater, DMR
+  Tier III control channel, P25 Phase 1 control channel, AND P25
+  Phase 2 control channel that fit inside its IQ bandwidth (e.g.
+  several 12.5 kHz carriers inside a 2.4 MHz IQ window). Mix
+  protocols on the same dongle.
+- **One dongle, control + voice** — with `voice_taps: N` on a
+  wideband entry, the daemon allocates per-grant DDC tuners from
+  the dongle's IQ stream so trunked voice grants (DMR T3, P25
+  Phase 1, P25 Phase 2) decode inline on the same SDR that's
+  already hosting the control channel — no separate `role: voice`
+  dongle needed for grants inside the wideband window. Out-of-
+  window grants spill over to a physical voice SDR when present.
+  See [docs/hardware.md](docs/hardware.md) and
   [samples/dmr-tier2-multichannel/](samples/dmr-tier2-multichannel/).
 - **DSP** — Polyphase channelizer, Kaiser / RRC / Gaussian FIRs,
   FM / C4FM / GFSK / FFSK / DQPSK / π/4-DQPSK / π/8-H-DQPSK

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -27,6 +27,7 @@ import (
 	"github.com/MattCheramie/GopherTrunk/internal/sdr/baseband"
 	"github.com/MattCheramie/GopherTrunk/internal/sdr/iqtap"
 	"github.com/MattCheramie/GopherTrunk/internal/sdr/rtltcp"
+	"github.com/MattCheramie/GopherTrunk/internal/sdr/wbvoice"
 	"github.com/MattCheramie/GopherTrunk/internal/storage"
 	"github.com/MattCheramie/GopherTrunk/internal/trunking"
 	"github.com/MattCheramie/GopherTrunk/internal/voice"
@@ -124,6 +125,14 @@ type Daemon struct {
 	controlSampleRate uint32
 	convScan          *conventional.Scanner
 	widebandT2        []*widebandt2.Engine
+	// virtualVoiceTuners holds one VirtualTuner per voice tap on a
+	// wideband dongle. Each implements both trunking.Tuner (the voice
+	// pool calls SetCenterFreq on bind) and composer.IQSource (the
+	// composer reads decimated 48 kHz IQ during the call). Wired up
+	// alongside each wideband Engine in NewDaemon; surfaced into the
+	// voice pool via collectVoiceDevices and into the composer via
+	// poolDevices.virtualMap. See internal/sdr/wbvoice.
+	virtualVoiceTuners []*wbvoice.VirtualTuner
 	// pocsagReceivers holds one POCSAG receiver per configured
 	// paging.pocsag entry. Each subscribes to the iqtap broker
 	// for its assigned SDR and publishes pages onto the events
@@ -599,7 +608,7 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 		}
 		comp, err := composer.New(composer.Options{
 			Bus:           d.bus,
-			Devices:       &poolDevices{pool: d.pool},
+			Devices:       &poolDevices{pool: d.pool, rateHz: cfg.SDR.SampleRate, virtualMap: d.virtualVoiceMap()},
 			Sink:          sink,
 			Engine:        d.engine,
 			Log:           log,
@@ -839,6 +848,41 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 				return nil, fmt.Errorf("daemon: widebandt2 %q: %w", devCfg.Serial, err)
 			}
 			d.widebandT2 = append(d.widebandT2, eng)
+			// Spin up virtual voice tuners on this wideband dongle so
+			// trunked voice grants whose frequency lands inside the
+			// IQ window can be followed without retuning a separate
+			// physical role: voice SDR. The taps subscribe to the
+			// dongle's iqtap broker on each StreamIQ call, run a
+			// single-tap DDC, and emit 48 kHz IQ to the composer.
+			// Out-of-window grants surface ErrOutOfBand and fall
+			// back to a physical voice SDR (when present) via the
+			// voice pool's bind retry.
+			taps := devCfg.VoiceTaps
+			if taps < 0 {
+				taps = 0
+			}
+			br := d.iqBrokers[entry.Info.Serial]
+			if br == nil && taps > 0 {
+				log.Warn("daemon: wideband: voice_taps requested but no iqtap broker; virtual voice disabled",
+					"serial", devCfg.Serial, "voice_taps", taps)
+				taps = 0
+			}
+			for i := 0; i < taps; i++ {
+				vt, err := wbvoice.New(wbvoice.Options{
+					Serial:           fmt.Sprintf("wb:%s:tap-%d", entry.Info.Serial, i),
+					Broker:           br,
+					WidebandCenterHz: devCfg.CenterFreqHz,
+					SDRSampleRateHz:  cfg.SDR.SampleRate,
+					Log:              log,
+				})
+				if err != nil {
+					return nil, fmt.Errorf("daemon: wbvoice %q tap %d: %w", devCfg.Serial, i, err)
+				}
+				d.virtualVoiceTuners = append(d.virtualVoiceTuners, vt)
+				log.Info("daemon: wideband: virtual voice tap registered",
+					"wideband_serial", entry.Info.Serial,
+					"tap_serial", vt.Serial())
+			}
 		}
 	}
 
@@ -1563,17 +1607,41 @@ func (d *Daemon) spawn(ctx context.Context, name string, essential bool, fn func
 }
 
 func (d *Daemon) collectVoiceDevices() []*trunking.VoiceDevice {
-	if d.pool == nil {
-		return nil
-	}
 	var voices []*trunking.VoiceDevice
-	for _, e := range d.pool.AllByRole(sdr.RoleVoice) {
+	if d.pool != nil {
+		for _, e := range d.pool.AllByRole(sdr.RoleVoice) {
+			voices = append(voices, &trunking.VoiceDevice{
+				Tuner:  e.Device,
+				Serial: e.Info.Serial,
+			})
+		}
+	}
+	// Append virtual voice tuners after physical ones so the engine's
+	// FindFree prefers a physical SDR when both are free. Out-of-
+	// window grants still surface ErrOutOfBand on virtual tuners and
+	// fall through to the next free device via the engine's bind
+	// retry — see engine.HandleGrant.
+	for _, vt := range d.virtualVoiceTuners {
 		voices = append(voices, &trunking.VoiceDevice{
-			Tuner:  e.Device,
-			Serial: e.Info.Serial,
+			Tuner:  vt,
+			Serial: vt.Serial(),
 		})
 	}
 	return voices
+}
+
+// virtualVoiceMap builds the serial → IQSource map the composer's
+// poolDevices uses to resolve a virtual tuner. Returns nil when no
+// virtual tuners are configured so the lookup is a no-op.
+func (d *Daemon) virtualVoiceMap() map[string]composer.IQSource {
+	if len(d.virtualVoiceTuners) == 0 {
+		return nil
+	}
+	out := make(map[string]composer.IQSource, len(d.virtualVoiceTuners))
+	for _, vt := range d.virtualVoiceTuners {
+		out[vt.Serial()] = vt
+	}
+	return out
 }
 
 func retentionInterval(s string) (time.Duration, error) {
@@ -1855,11 +1923,24 @@ func (a audioCockpit) BackendEnabled() bool {
 	return a.player.Stats().Enabled
 }
 
-// poolDevices adapts *sdr.Pool to composer.Devices. The composer only
-// needs StreamIQ; sdr.Device satisfies that subset directly.
-type poolDevices struct{ pool *sdr.Pool }
+// poolDevices adapts *sdr.Pool to composer.Devices. The composer
+// needs StreamIQ + SampleRateHz; sdr.Device only satisfies the
+// former, so physical entries are wrapped in deviceWithRate that
+// reports the daemon-wide rate. Virtual voice tuners (wideband-
+// derived) already implement both interface methods directly and
+// take precedence — that's how a P25 grant on the same SDR as the
+// wideband CC tap gets followed without retuning a physical voice
+// SDR.
+type poolDevices struct {
+	pool       *sdr.Pool
+	rateHz     uint32
+	virtualMap map[string]composer.IQSource
+}
 
 func (p *poolDevices) FindBySerial(serial string) composer.IQSource {
+	if src, ok := p.virtualMap[serial]; ok {
+		return src
+	}
 	if p.pool == nil {
 		return nil
 	}
@@ -1867,8 +1948,19 @@ func (p *poolDevices) FindBySerial(serial string) composer.IQSource {
 	if e == nil {
 		return nil
 	}
-	return e.Device
+	return deviceWithRate{Device: e.Device, rate: p.rateHz}
 }
+
+// deviceWithRate makes an sdr.Device satisfy composer.IQSource by
+// stamping the daemon-wide configured sample rate onto it. Physical
+// SDRs share one rate (cfg.SDR.SampleRate); the composer uses it
+// to size each call's decimator.
+type deviceWithRate struct {
+	sdr.Device
+	rate uint32
+}
+
+func (d deviceWithRate) SampleRateHz() uint32 { return d.rate }
 
 // brokerRigController adapts an iqtap.Broker into the rigctld
 // Controller interface. Routing through the broker means SetFreq

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -200,9 +200,18 @@ sdr:
     # channel's frequency_hz must appear in its control_channels.
     # Honours `p25_phase1_demod_mode` (c4fm vs cqpsk / LSM) on the
     # system entry just like a dedicated CC dongle.
+    #
+    # `voice_taps: N` (0-8) lets the same SDR host N concurrent
+    # voice grants without a separate `role: voice` dongle: each
+    # grant whose frequency falls inside the wideband IQ window
+    # gets its own per-call DDC tap on this dongle's IQ stream.
+    # Out-of-window grants spill over to a physical voice SDR
+    # when one is configured, or drop with the standard
+    # "no voice device available" log otherwise.
     # - serial: "00000005"
     #   role: wideband
     #   center_freq_hz: 851_500_000
+    #   voice_taps: 4
     #   channels:
     #     - frequency_hz: 851_037_500
     #       system: "regional-p25"

--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -330,11 +330,50 @@ For P25 Phase 2 use `protocol: p25-phase2`; the same per-system
 mode) that apply to a dedicated CC SDR apply to the wideband channel
 too — see the trunking systems section of `config.example.yaml`.
 
-T3 voice grants are published on the bus and routed to the daemon's
-existing physical voice pool — add a `role: voice` SDR alongside the
-wideband dongle if you want voice decoded. The follow-up work to
-decode T3 voice grants directly on the wideband dongle (via a virtual
-voice pool that allocates a tuner tap per grant) is roadmapped.
+### One SDR for control + voice (virtual voice pool)
+
+Voice grants can also be decoded on the same wideband dongle that's
+hosting the CC tap, as long as the grant frequency falls inside the
+dongle's IQ window. Set `voice_taps: N` on the wideband entry; the
+daemon spins up `N` per-grant DDC tuners that subscribe to the
+dongle's IQ stream on demand and emit 48 kHz IQ centred on the grant
+frequency — exactly what the existing P25 / DMR voice composer
+chains expect. The result is a single SDR doing both jobs, with no
+physical `role: voice` dongle required (for grants that fit in the
+window).
+
+```yaml
+sdr:
+  devices:
+    - serial: "00000003"
+      role: wideband
+      center_freq_hz: 851_500_000
+      voice_taps: 4               # allow up to 4 concurrent voice calls
+      channels:
+        - frequency_hz: 851_037_500
+          system: "regional-p25"
+
+trunking:
+  systems:
+    - name: "regional-p25"
+      protocol: p25
+      control_channels: [851_037_500]
+```
+
+How spillover works: when a grant's frequency lands *outside* the
+wideband IQ window (more common on geographically spread P25 systems
+than on a single-site DMR T3 cluster), the virtual tuner returns
+out-of-band and the engine binds a physical `role: voice` SDR
+instead — if one is configured. So a typical mixed setup keeps a
+single physical voice SDR around as the spillover fallback while the
+wideband dongle handles the in-window majority. With no physical
+voice SDR present, out-of-window grants drop with the standard
+"no voice device available" log (issue #379).
+
+CPU is roughly linear in `voice_taps`: each tap runs one NCO mixer +
+polyphase resampler at the SDR rate during its call's lifetime;
+between calls the tap consumes no CPU. The validator caps the value
+at 8 to keep one wideband dongle bounded.
 
 ### Picking a centre frequency and bandwidth
 
@@ -364,20 +403,18 @@ message that names the offending entry.
   `protocol: p25` (P25 Phase 1 trunked control channel — C4FM and
   CQPSK / LSM simulcast), and `protocol: p25-phase2` (P25 Phase 2
   H-DQPSK trunked control channel). Other protocols (NXDN, TETRA,
-  …) and trunked **voice** grants on the wideband dongle itself are
-  not in scope yet — see "Trunked voice" below.
-- **Trunked voice still needs a physical Voice SDR.** When a
-  wideband trunked CC tap (DMR T3, P25 Phase 1, P25 Phase 2)
-  decodes a grant, the daemon's existing voice pool retunes a
-  `role: voice` dongle to follow the call. The wideband
-  dongle decodes the CC; voice rides on the regular pool. A
-  follow-up will add a virtual voice pool that allocates a tuner
-  tap from the wideband dongle for each grant, removing the need
-  for the second SDR.
-- **The wideband dongle is dedicated.** It can't double as a Voice
-  pool member (the daemon needs it pinned to one centre frequency).
-  If you also run a trunked system that allocates voice grants on a
-  separate frequency, add a `role: voice` SDR for it.
+  …) are not in scope yet.
+- **Trunked voice on the same wideband dongle.** With `voice_taps`
+  set, the daemon allocates per-grant DDC tuners from the dongle's
+  IQ stream so DMR T3 / P25 Phase 1 / P25 Phase 2 voice grants
+  decode inline without a physical `role: voice` SDR — see the
+  "One SDR for control + voice" section above. Voice grants whose
+  frequency falls **outside** the wideband IQ window still spill
+  over to a physical `role: voice` SDR (when configured), so a
+  single backup voice dongle covers the edge cases on
+  geographically spread systems. Setups with `voice_taps: 0` (or
+  unset) keep the legacy behaviour where every voice grant routes
+  to the physical pool.
 - **DDC-with-real-signal RX limits.** The wideband engine's per-tap
   DDC (when the SDR sample rate is higher than 48 kHz) uses the same
   Kaiser anti-alias prototype as the single-channel ccdecoder path,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -359,10 +359,25 @@ type DeviceConfig struct {
 
 	// Channels is the list of repeater carriers a wideband dongle
 	// should monitor inside its IQ band. Each entry binds a
-	// frequency to a configured trunking.systems[].name; v1 only
-	// supports DMR Tier II conventional. Ignored for non-wideband
-	// roles.
+	// frequency to a configured trunking.systems[].name. Ignored
+	// for non-wideband roles.
 	Channels []DeviceChannelConfig `yaml:"channels"`
+
+	// VoiceTaps is the number of per-grant DDC tuners the daemon
+	// allocates from this wideband dongle's IQ stream so trunked
+	// voice grants can be followed without retuning a separate
+	// `role: voice` SDR. Each tap subscribes to the dongle's
+	// iqtap broker on demand and emits 48 kHz IQ centred on the
+	// grant frequency.
+	//
+	// Defaults to 0 (no virtual voice taps; voice grants route to
+	// the physical voice pool). Set to 2-4 on a wideband dongle
+	// hosting a trunked CC tap (DMR T3, P25 Phase 1, P25 Phase 2)
+	// so one SDR can cover the full system end-to-end. Out-of-
+	// window grants surface ErrOutOfBand and fall back to a
+	// physical voice SDR when one is configured. Capped at 8 to
+	// keep CPU bounded.
+	VoiceTaps int `yaml:"voice_taps"`
 }
 
 // DeviceChannelConfig is one repeater carrier carried by a
@@ -989,6 +1004,10 @@ const widebandGuardFrac = 0.05
 func validateWidebandDevice(idx int, d DeviceConfig, sampleRateHz uint32, systems []SystemConfig) error {
 	if d.Serial == "" {
 		return fmt.Errorf("sdr.devices[%d]: role: wideband requires serial (the daemon binds the channel list to the device by USB serial)", idx)
+	}
+	if d.VoiceTaps < 0 || d.VoiceTaps > 8 {
+		return fmt.Errorf("sdr.devices[%d]: voice_taps %d out of range; 0 disables, 1-8 allocate that many virtual voice DDC taps on the dongle",
+			idx, d.VoiceTaps)
 	}
 	if d.CenterFreqHz == 0 {
 		return fmt.Errorf("sdr.devices[%d]: role: wideband requires center_freq_hz", idx)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -219,6 +219,44 @@ func TestValidate(t *testing.T) {
 				ControlChannels: []uint32{851_006_250},
 			}}},
 		}, false},
+		// voice_taps: virtual voice DDC tap count per wideband
+		// dongle. 0 disables (default); 1-8 allocates that many.
+		{"wideband voice_taps in range", Config{
+			SDR: SDRConfig{SampleRate: 2_400_000, Devices: []DeviceConfig{{
+				Serial: "00000010", Role: "wideband", CenterFreqHz: 851_500_000, VoiceTaps: 4,
+				Channels: []DeviceChannelConfig{
+					{FrequencyHz: 851_037_500, System: "regional-p25"},
+				},
+			}}},
+			Trunking: TrunkingConfig{Systems: []SystemConfig{{
+				Name: "regional-p25", Protocol: "p25",
+				ControlChannels: []uint32{851_037_500},
+			}}},
+		}, false},
+		{"wideband voice_taps too large", Config{
+			SDR: SDRConfig{SampleRate: 2_400_000, Devices: []DeviceConfig{{
+				Serial: "00000010", Role: "wideband", CenterFreqHz: 851_500_000, VoiceTaps: 99,
+				Channels: []DeviceChannelConfig{
+					{FrequencyHz: 851_037_500, System: "regional-p25"},
+				},
+			}}},
+			Trunking: TrunkingConfig{Systems: []SystemConfig{{
+				Name: "regional-p25", Protocol: "p25",
+				ControlChannels: []uint32{851_037_500},
+			}}},
+		}, true},
+		{"wideband voice_taps negative", Config{
+			SDR: SDRConfig{SampleRate: 2_400_000, Devices: []DeviceConfig{{
+				Serial: "00000010", Role: "wideband", CenterFreqHz: 851_500_000, VoiceTaps: -1,
+				Channels: []DeviceChannelConfig{
+					{FrequencyHz: 851_037_500, System: "regional-p25"},
+				},
+			}}},
+			Trunking: TrunkingConfig{Systems: []SystemConfig{{
+				Name: "regional-p25", Protocol: "p25",
+				ControlChannels: []uint32{851_037_500},
+			}}},
+		}, true},
 		// Non-trunked protocols are still rejected — wideband doesn't
 		// host NXDN / EDACS / etc. yet.
 		{"wideband unsupported protocol", Config{

--- a/internal/sdr/wbvoice/tuner.go
+++ b/internal/sdr/wbvoice/tuner.go
@@ -1,0 +1,232 @@
+// Package wbvoice puts P25 / DMR voice grants on the same SDR that's
+// hosting a trunked control channel via the wideband channelizer.
+//
+// A wideband dongle is pinned to a centre frequency that spans the
+// system's IQ band (typically 2.4 MS/s ≈ ±1.08 MHz). The control
+// channel is already decoded by internal/scanner/widebandt2 from a
+// fixed-offset tap on that band. Voice grants land on different
+// frequencies — but, on most P25 / DMR systems, the same band the
+// CC sits in covers the voice carriers too. A VirtualTuner is the
+// glue that lets the trunking voice pool follow a grant by allocating
+// a per-call DDC tap on the wideband IQ stream instead of retuning
+// a separate role: voice dongle.
+//
+// Each VirtualTuner implements both trunking.Tuner (SetCenterFreq)
+// and the composer's IQSource (StreamIQ + SampleRateHz) — so it
+// plugs into the existing voice-pool + composer machinery as if it
+// were a physical SDR with a sample rate of 48 kHz. The voice pool's
+// engine calls SetCenterFreq once at grant binding; the composer's
+// per-call chain then opens StreamIQ and consumes the decimated
+// narrow-band stream until the call ends.
+//
+// Out-of-window grants (the requested centre frequency falls outside
+// the wideband dongle's IQ band, minus a 5 % guard) return
+// ErrOutOfBand from SetCenterFreq. The trunking engine treats that
+// as a non-fatal "wrong tuner for this grant" signal and tries the
+// next free device — so a daemon configured with one wideband
+// dongle plus a backup physical role: voice SDR still follows the
+// out-of-window grants on the physical SDR.
+package wbvoice
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/tuner"
+	"github.com/MattCheramie/GopherTrunk/internal/sdr/iqtap"
+)
+
+// NarrowbandRateHz is the per-tap sample rate the virtual tuner emits.
+// 48 kHz matches the rate every composer voice chain (DMR, P25 Phase
+// 1, P25 Phase 2) targets after decimation — so the composer's
+// existing decimator collapses to a no-op when the source IS a
+// virtual tuner. See composer.runP25Phase1VoiceChain etc.
+const NarrowbandRateHz = 48_000
+
+// GuardFrac mirrors the constant the wideband config validator uses
+// (5 % of the IQ band at each edge) so a frequency that's accepted
+// here also makes it past load-time validation in nearby code paths.
+const GuardFrac = 0.05
+
+// ErrOutOfBand is returned by SetCenterFreq when the requested centre
+// frequency lies outside the wideband dongle's usable IQ window.
+// The trunking engine surfaces this sentinel to fall back to a
+// physical voice SDR instead of dropping the grant.
+var ErrOutOfBand = errors.New("wbvoice: target frequency out of wideband window")
+
+// VirtualTuner is one per-grant DDC tap on a shared wideband SDR's
+// IQ stream. It is safe for concurrent use by the trunking engine
+// (SetCenterFreq) and the composer (StreamIQ); the two interact
+// through targetHz under tunerMu.
+type VirtualTuner struct {
+	serial     string
+	log        *slog.Logger
+	broker     *iqtap.Broker
+	widebandHz uint32
+	inRateHz   uint32
+
+	tunerMu  sync.Mutex
+	targetHz uint32 // 0 ⇒ no SetCenterFreq yet
+}
+
+// Options bundle the per-tap inputs the daemon supplies at startup.
+type Options struct {
+	// Serial uniquely identifies this virtual tuner across the
+	// daemon's voice pool + composer.FindBySerial lookups. Picked
+	// by the caller (typically "<wideband-serial>:tap-N").
+	Serial string
+	// Broker wraps the underlying wideband SDR's IQ stream. The
+	// virtual tuner subscribes per StreamIQ call; chunks delivered
+	// to subscribers are the same wide-band IQ the channelizer
+	// sees, stamped with the dongle's centre frequency.
+	Broker *iqtap.Broker
+	// WidebandCenterHz is the centre frequency the wideband dongle
+	// is pinned to. The DDC mixes by (target − wideband) Hz to
+	// shift the voice carrier to baseband before decimation.
+	WidebandCenterHz uint32
+	// SDRSampleRateHz is the chunk rate the broker delivers. Used
+	// to size the DDC's decimation ratio and to validate the
+	// requested centre frequency against the usable IQ window.
+	SDRSampleRateHz uint32
+	// Log labels diagnostics. Optional; defaults to slog.Default().
+	Log *slog.Logger
+}
+
+// New validates opts and returns a VirtualTuner ready to plug into
+// the voice pool. Returns an error when opts are obviously invalid
+// (zero rates, nil broker) — that's a daemon wiring bug, not an
+// operator config one.
+func New(opts Options) (*VirtualTuner, error) {
+	if opts.Broker == nil {
+		return nil, errors.New("wbvoice: Broker is required")
+	}
+	if opts.WidebandCenterHz == 0 {
+		return nil, errors.New("wbvoice: WidebandCenterHz is required")
+	}
+	if opts.SDRSampleRateHz == 0 {
+		return nil, errors.New("wbvoice: SDRSampleRateHz is required")
+	}
+	if opts.Serial == "" {
+		return nil, errors.New("wbvoice: Serial is required")
+	}
+	log := opts.Log
+	if log == nil {
+		log = slog.Default()
+	}
+	return &VirtualTuner{
+		serial:     opts.Serial,
+		log:        log.With("wbvoice", opts.Serial),
+		broker:     opts.Broker,
+		widebandHz: opts.WidebandCenterHz,
+		inRateHz:   opts.SDRSampleRateHz,
+	}, nil
+}
+
+// Serial returns the virtual tuner's identity. Matches the serial the
+// daemon registered with the voice pool + composer.FindBySerial.
+func (v *VirtualTuner) Serial() string { return v.serial }
+
+// SampleRateHz reports the per-tap rate this source emits. The
+// composer reads it once per call to size its decimator; for a
+// virtual tuner the rate is already the chain's intermediate
+// rate (48 kHz), so the composer's decimation collapses to a
+// pass-through.
+func (v *VirtualTuner) SampleRateHz() uint32 { return NarrowbandRateHz }
+
+// CanTune reports whether hz lies inside the wideband dongle's usable
+// IQ window. The trunking pool consults this before calling
+// SetCenterFreq so an out-of-window voice grant falls through to a
+// physical voice SDR (if configured) without producing a Bind error.
+func (v *VirtualTuner) CanTune(hz uint32) bool {
+	half := float64(v.inRateHz) * (0.5 - GuardFrac)
+	offset := float64(hz) - float64(v.widebandHz)
+	return offset >= -half && offset <= half
+}
+
+// SetCenterFreq stores the desired tap centre. Returns ErrOutOfBand
+// when hz falls outside the wideband dongle's usable IQ window
+// (centre_freq_hz ± sample_rate/2 with a 5 % guard at each edge);
+// the trunking engine treats that as a non-fatal "wrong tuner"
+// signal and tries another free device.
+//
+// The actual DDC NCO offset isn't applied until the next StreamIQ
+// call — see StreamIQ. Per-grant lifecycle: the engine calls
+// SetCenterFreq once at bind, then the composer immediately opens
+// StreamIQ. SetCenterFreq during an active stream isn't expected
+// from the voice pool (voice grants don't re-bind mid-call) and
+// would not retune an already-open stream.
+func (v *VirtualTuner) SetCenterFreq(hz uint32) error {
+	if !v.CanTune(hz) {
+		return ErrOutOfBand
+	}
+	v.tunerMu.Lock()
+	v.targetHz = hz
+	v.tunerMu.Unlock()
+	return nil
+}
+
+// StreamIQ subscribes to the wideband broker, builds a single-tap
+// DDCBank at the (target − wideband) offset, and returns a channel
+// of decimated 48 kHz IQ chunks centred on the previously-set
+// target. The returned channel closes on ctx cancellation (the
+// composer's per-call chain context).
+//
+// Each call opens a fresh subscription + DDC: a previous call's
+// resampler state and the previous subscriber's drop counter both
+// reset. The DDC tap is rebuilt rather than retuned in place
+// because the upstream tuner.DDCBank doesn't expose a per-tap
+// retune helper; rebuilds at call-start are cheap (the Kaiser FIR
+// prototype is a few thousand floats).
+func (v *VirtualTuner) StreamIQ(ctx context.Context) (<-chan []complex64, error) {
+	v.tunerMu.Lock()
+	target := v.targetHz
+	v.tunerMu.Unlock()
+	if target == 0 {
+		return nil, errors.New("wbvoice: StreamIQ called before SetCenterFreq")
+	}
+	offset := float64(target) - float64(v.widebandHz)
+
+	out := make(chan []complex64, 16)
+
+	bank := tuner.NewDDCBank(float64(v.inRateHz), float64(NarrowbandRateHz), GuardFrac)
+	if err := bank.AddTap(offset, func(narrow []complex64) {
+		if len(narrow) == 0 {
+			return
+		}
+		cp := make([]complex64, len(narrow))
+		copy(cp, narrow)
+		// Blocking send so back-pressure flows back to the
+		// broker subscription (which itself drops at its
+		// bounded buffer when the consumer falls behind). The
+		// ctx check lets the goroutine unwind when the call
+		// ends.
+		select {
+		case out <- cp:
+		case <-ctx.Done():
+		}
+	}); err != nil {
+		close(out)
+		return nil, fmt.Errorf("wbvoice: AddTap offset=%.0f Hz: %w", offset, err)
+	}
+
+	sub := v.broker.Subscribe()
+	go func() {
+		defer close(out)
+		defer sub.Close()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case chunk, ok := <-sub.C:
+				if !ok {
+					return
+				}
+				bank.Process(chunk)
+			}
+		}
+	}()
+	return out, nil
+}

--- a/internal/sdr/wbvoice/tuner_test.go
+++ b/internal/sdr/wbvoice/tuner_test.go
@@ -30,13 +30,13 @@ func newFakeDevice() *fakeDevice {
 	}
 }
 
-func (f *fakeDevice) Info() sdr.Info                     { return f.info }
-func (f *fakeDevice) SetCenterFreq(uint32) error         { return nil }
-func (f *fakeDevice) SetSampleRate(uint32) error         { return nil }
-func (f *fakeDevice) SetGain(int) error                  { return nil }
-func (f *fakeDevice) SetPPM(int) error                   { return nil }
-func (f *fakeDevice) SetBiasTee(bool) error              { return nil }
-func (f *fakeDevice) Close() error                       { return nil }
+func (f *fakeDevice) Info() sdr.Info             { return f.info }
+func (f *fakeDevice) SetCenterFreq(uint32) error { return nil }
+func (f *fakeDevice) SetSampleRate(uint32) error { return nil }
+func (f *fakeDevice) SetGain(int) error          { return nil }
+func (f *fakeDevice) SetPPM(int) error           { return nil }
+func (f *fakeDevice) SetBiasTee(bool) error      { return nil }
+func (f *fakeDevice) Close() error               { return nil }
 func (f *fakeDevice) StreamIQ(ctx context.Context) (<-chan []complex64, error) {
 	if f.err != nil {
 		return nil, f.err
@@ -47,10 +47,10 @@ func (f *fakeDevice) StreamIQ(ctx context.Context) (<-chan []complex64, error) {
 func TestNewValidatesInputs(t *testing.T) {
 	broker := iqtap.New(newFakeDevice(), 0, slog.New(slog.NewTextHandler(io.Discard, nil)))
 	cases := map[string]Options{
-		"missing broker":  {Serial: "x", WidebandCenterHz: 851_000_000, SDRSampleRateHz: 2_400_000},
-		"missing center":  {Serial: "x", Broker: broker, SDRSampleRateHz: 2_400_000},
-		"missing rate":    {Serial: "x", Broker: broker, WidebandCenterHz: 851_000_000},
-		"missing serial":  {Broker: broker, WidebandCenterHz: 851_000_000, SDRSampleRateHz: 2_400_000},
+		"missing broker": {Serial: "x", WidebandCenterHz: 851_000_000, SDRSampleRateHz: 2_400_000},
+		"missing center": {Serial: "x", Broker: broker, SDRSampleRateHz: 2_400_000},
+		"missing rate":   {Serial: "x", Broker: broker, WidebandCenterHz: 851_000_000},
+		"missing serial": {Broker: broker, WidebandCenterHz: 851_000_000, SDRSampleRateHz: 2_400_000},
 	}
 	for name, opts := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/internal/sdr/wbvoice/tuner_test.go
+++ b/internal/sdr/wbvoice/tuner_test.go
@@ -1,0 +1,271 @@
+package wbvoice
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"math"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/sdr"
+	"github.com/MattCheramie/GopherTrunk/internal/sdr/iqtap"
+)
+
+// fakeDevice is the minimal sdr.Device we need to wire an iqtap.Broker
+// around. The broker only calls Info / StreamIQ / Close on Forward
+// paths; the rest are inert.
+type fakeDevice struct {
+	info   sdr.Info
+	stream chan []complex64
+	err    error
+}
+
+func newFakeDevice() *fakeDevice {
+	return &fakeDevice{
+		info:   sdr.Info{Driver: "fake", Serial: "FAKE"},
+		stream: make(chan []complex64, 16),
+	}
+}
+
+func (f *fakeDevice) Info() sdr.Info                     { return f.info }
+func (f *fakeDevice) SetCenterFreq(uint32) error         { return nil }
+func (f *fakeDevice) SetSampleRate(uint32) error         { return nil }
+func (f *fakeDevice) SetGain(int) error                  { return nil }
+func (f *fakeDevice) SetPPM(int) error                   { return nil }
+func (f *fakeDevice) SetBiasTee(bool) error              { return nil }
+func (f *fakeDevice) Close() error                       { return nil }
+func (f *fakeDevice) StreamIQ(ctx context.Context) (<-chan []complex64, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.stream, nil
+}
+
+func TestNewValidatesInputs(t *testing.T) {
+	broker := iqtap.New(newFakeDevice(), 0, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	cases := map[string]Options{
+		"missing broker":  {Serial: "x", WidebandCenterHz: 851_000_000, SDRSampleRateHz: 2_400_000},
+		"missing center":  {Serial: "x", Broker: broker, SDRSampleRateHz: 2_400_000},
+		"missing rate":    {Serial: "x", Broker: broker, WidebandCenterHz: 851_000_000},
+		"missing serial":  {Broker: broker, WidebandCenterHz: 851_000_000, SDRSampleRateHz: 2_400_000},
+	}
+	for name, opts := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := New(opts); err == nil {
+				t.Errorf("New(%+v) = nil err, want one", opts)
+			}
+		})
+	}
+}
+
+func TestSetCenterFreqAcceptsInBand(t *testing.T) {
+	broker := iqtap.New(newFakeDevice(), 0, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	v, err := New(Options{
+		Serial: "tap-0", Broker: broker,
+		WidebandCenterHz: 851_500_000, SDRSampleRateHz: 2_400_000,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Edge of usable band = ± 2.4 MHz / 2 × 0.95 = ± 1,140,000 Hz.
+	// Pick 851,500,000 + 1,000,000 = 852,500,000 (inside).
+	if err := v.SetCenterFreq(852_500_000); err != nil {
+		t.Errorf("in-band SetCenterFreq returned %v", err)
+	}
+}
+
+func TestSetCenterFreqRejectsOutOfBand(t *testing.T) {
+	broker := iqtap.New(newFakeDevice(), 0, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	v, err := New(Options{
+		Serial: "tap-0", Broker: broker,
+		WidebandCenterHz: 851_500_000, SDRSampleRateHz: 2_400_000,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// 1.5 MHz away — outside ±1.14 MHz usable band.
+	if err := v.SetCenterFreq(853_000_000); !errors.Is(err, ErrOutOfBand) {
+		t.Errorf("out-of-band SetCenterFreq returned %v, want ErrOutOfBand", err)
+	}
+}
+
+func TestStreamIQRequiresSetCenterFreqFirst(t *testing.T) {
+	broker := iqtap.New(newFakeDevice(), 0, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	v, _ := New(Options{
+		Serial: "tap-0", Broker: broker,
+		WidebandCenterHz: 851_500_000, SDRSampleRateHz: 2_400_000,
+	})
+	if _, err := v.StreamIQ(context.Background()); err == nil {
+		t.Errorf("StreamIQ before SetCenterFreq returned nil err, want one")
+	}
+}
+
+func TestSampleRateHzReports48k(t *testing.T) {
+	broker := iqtap.New(newFakeDevice(), 0, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	v, _ := New(Options{
+		Serial: "tap-0", Broker: broker,
+		WidebandCenterHz: 851_500_000, SDRSampleRateHz: 2_400_000,
+	})
+	if got := v.SampleRateHz(); got != NarrowbandRateHz {
+		t.Errorf("SampleRateHz = %d, want %d", got, NarrowbandRateHz)
+	}
+}
+
+// TestStreamIQShiftsCarrierToBaseband injects a complex sinusoid at the
+// target offset through a fake broker; the virtual tuner should
+// down-convert it to a near-DC tone after its DDC. Verifies that the
+// NCO mix + decimation actually produces 48 kHz IQ centred on the
+// SetCenterFreq target.
+func TestStreamIQShiftsCarrierToBaseband(t *testing.T) {
+	const sdrRate = 2_400_000.0
+	const widebandHz = 851_500_000
+	const targetHz = 852_000_000 // 500 kHz offset
+	const offsetHz = targetHz - widebandHz
+
+	fake := newFakeDevice()
+	broker := iqtap.New(fake, 64, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	v, err := New(Options{
+		Serial: "tap-0", Broker: broker,
+		WidebandCenterHz: widebandHz, SDRSampleRateHz: sdrRate,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := v.SetCenterFreq(targetHz); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Drive the broker's primary stream so the fanout to our
+	// subscriber actually runs. We don't care about the primary
+	// channel content — discard it.
+	primary, err := broker.StreamIQ(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	go func() {
+		for range primary {
+		}
+	}()
+
+	iqCh, err := v.StreamIQ(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Generate a continuous complex tone at +offsetHz against the
+	// SDR rate, broken into chunks. Phase accumulates across chunks
+	// to keep the tone coherent (a chunk-boundary phase jump would
+	// broaden the spectrum and mask the DDC's accuracy).
+	const chunkN = 4096
+	const numChunks = 40 // 40 × 4096 = ~163 k input samples → ~3.2 k output samples
+	step := 2 * math.Pi * float64(offsetHz) / sdrRate
+	phase := 0.0
+	var (
+		mu        sync.Mutex
+		all       []complex64
+		collected = make(chan struct{})
+	)
+	const wantSamples = 2048
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case out, ok := <-iqCh:
+				if !ok {
+					return
+				}
+				mu.Lock()
+				all = append(all, out...)
+				done := len(all) >= wantSamples
+				mu.Unlock()
+				if done {
+					select {
+					case <-collected:
+					default:
+						close(collected)
+					}
+					return
+				}
+			}
+		}
+	}()
+
+	for i := 0; i < numChunks; i++ {
+		chunk := make([]complex64, chunkN)
+		for j := range chunk {
+			chunk[j] = complex64(complex(math.Cos(phase), math.Sin(phase)))
+			phase += step
+		}
+		select {
+		case fake.stream <- chunk:
+		case <-time.After(2 * time.Second):
+			t.Fatal("fake stream send blocked")
+		}
+	}
+
+	select {
+	case <-collected:
+	case <-time.After(3 * time.Second):
+		mu.Lock()
+		got := len(all)
+		mu.Unlock()
+		t.Fatalf("collected only %d output samples within deadline, want %d", got, wantSamples)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(all) < 1024 {
+		t.Fatalf("only %d output samples, want >= 1024", len(all))
+	}
+	// Skip the resampler warmup (first half) and analyse the
+	// settled second half — exactly the pattern used by the
+	// upstream tuner.DDCBank tests.
+	settled := all[len(all)/2:]
+	frac := powerNearDC(settled, NarrowbandRateHz, 500)
+	if frac < 0.95 {
+		t.Errorf("post-DDC power near DC = %.1f%%, want >= 95%% (carrier not shifted to baseband)", frac*100)
+	}
+}
+
+// powerNearDC reports the fraction of total energy within ±halfWidthHz
+// of DC. Mirrors the helper in internal/dsp/tuner/ddc_test.go so the
+// virtual-tuner check uses the same spectral metric the DDC suite
+// already relies on.
+func powerNearDC(samples []complex64, sampleRateHz, halfWidthHz float64) float64 {
+	N := len(samples)
+	if N < 8 {
+		return 0
+	}
+	binHz := sampleRateHz / float64(N)
+	maxK := int(math.Ceil(halfWidthHz / binHz))
+	totalPow := 0.0
+	dcPow := 0.0
+	for k := -N / 2; k < N/2; k++ {
+		var sumR, sumI float64
+		w := -2 * math.Pi * float64(k) / float64(N)
+		for i, s := range samples {
+			theta := w * float64(i)
+			c := math.Cos(theta)
+			si := math.Sin(theta)
+			sumR += float64(real(s))*c - float64(imag(s))*si
+			sumI += float64(real(s))*si + float64(imag(s))*c
+		}
+		p := sumR*sumR + sumI*sumI
+		totalPow += p
+		if k >= -maxK && k <= maxK {
+			dcPow += p
+		}
+	}
+	if totalPow == 0 {
+		return 0
+	}
+	return dcPow / totalPow
+}

--- a/internal/trunking/engine.go
+++ b/internal/trunking/engine.go
@@ -188,8 +188,12 @@ func (e *Engine) HandleGrant(g Grant) {
 		}
 	}
 
-	// 1) Free device available? Allocate.
-	if free := e.pool.FindFree(); free != nil {
+	// 1) Free device available? Allocate. FindFreeForFrequency skips
+	// virtual voice tuners whose wideband window doesn't cover the
+	// grant — so a P25 voice grant outside the wideband band falls
+	// through to a physical role: voice SDR (when one is configured)
+	// instead of bouncing on a tap that would reject it at Bind time.
+	if free := e.pool.FindFreeForFrequency(g.FrequencyHz); free != nil {
 		e.startCall(free, g, tg)
 		return
 	}

--- a/internal/trunking/engine_test.go
+++ b/internal/trunking/engine_test.go
@@ -91,6 +91,46 @@ func TestEngineStartsCallOnGrant(t *testing.T) {
 	}
 }
 
+// TestEngineSkipsOutOfBandVirtualTunerInFavorOfPhysical covers the
+// Phase B fallback: when a wideband virtual voice tuner can't serve
+// a grant (frequency outside its IQ window) and a physical voice
+// SDR is also free, the engine binds the physical one instead of
+// dropping. Exercises voicepool.FindFreeForFrequency end-to-end.
+func TestEngineSkipsOutOfBandVirtualTunerInFavorOfPhysical(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	// Wideband tap listed first (preferred for in-band grants); a
+	// physical tuner second (catches the spillover).
+	virtual := &constrainedTuner{lo: 851_000_000, hi: 852_000_000}
+	physical := &fakeVoiceTuner{}
+	pool := NewVoicePool([]*VoiceDevice{
+		{Tuner: virtual, Serial: "wb:00000003:tap-0"},
+		{Tuner: physical, Serial: "phys-voice"},
+	})
+	e, err := NewEngine(EngineOptions{
+		Bus: bus, VoicePool: pool, Talkgroups: NewTalkgroupDB(),
+		CallTimeout: 1 * time.Second,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Out-of-window grant (900 MHz). Should land on the physical
+	// tuner without erroring.
+	e.HandleGrant(Grant{System: "X", Protocol: "p25", GroupID: 1, FrequencyHz: 900_000_000})
+
+	calls := e.ActiveCalls()
+	if len(calls) != 1 || calls[0].Device.Serial != "phys-voice" {
+		t.Fatalf("expected one call on phys-voice, got %+v", calls)
+	}
+	if len(virtual.freqs) != 0 {
+		t.Errorf("virtual tuner should not have been retuned, got %v", virtual.freqs)
+	}
+	if len(physical.tuned()) != 1 || physical.tuned()[0] != 900_000_000 {
+		t.Errorf("physical tuner = %v, want [900_000_000]", physical.tuned())
+	}
+}
+
 func TestEngineTalkgroupForDevice(t *testing.T) {
 	e, _, bus, _ := mkEngine(t, 1)
 	defer bus.Close()

--- a/internal/trunking/voicepool.go
+++ b/internal/trunking/voicepool.go
@@ -86,6 +86,38 @@ func (p *VoicePool) FindFree() *VoiceDevice {
 	return nil
 }
 
+// FrequencyChecker is implemented by Tuners that can serve only a
+// limited range of centre frequencies — e.g. a virtual voice tuner
+// backed by a wideband DDC tap can only follow grants inside the
+// wideband dongle's IQ window. FindFreeForFrequency consults this
+// interface to skip incapable tuners; physical SDRs that don't
+// implement it are treated as universally tunable.
+type FrequencyChecker interface {
+	CanTune(hz uint32) bool
+}
+
+// FindFreeForFrequency returns the first free device whose Tuner
+// either doesn't implement FrequencyChecker (physical SDR — accepted
+// unconditionally) or reports CanTune(hz)=true (virtual tuner whose
+// wideband window covers the target). Order matches the device list,
+// so the daemon's preference (physical voice SDRs first, virtual
+// taps after) is preserved. Returns nil when every free device
+// rejects the target — the engine then falls back to preemption.
+func (p *VoicePool) FindFreeForFrequency(hz uint32) *VoiceDevice {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for _, d := range p.devices {
+		if _, busy := p.active[d.Serial]; busy {
+			continue
+		}
+		if fc, ok := d.Tuner.(FrequencyChecker); ok && !fc.CanTune(hz) {
+			continue
+		}
+		return d
+	}
+	return nil
+}
+
 // LowestPriorityActive returns the active call with the lowest priority
 // among all devices, or nil if no calls are active. Used by the engine
 // when deciding which call to preempt.

--- a/internal/trunking/voicepool_test.go
+++ b/internal/trunking/voicepool_test.go
@@ -106,6 +106,53 @@ func TestPoolReleaseReturnsActiveCall(t *testing.T) {
 	}
 }
 
+// constrainedTuner implements FrequencyChecker by rejecting any
+// frequency outside [lo, hi]. Used to verify FindFreeForFrequency
+// skips it when an out-of-range grant arrives.
+type constrainedTuner struct {
+	lo, hi uint32
+	freqs  []uint32
+}
+
+func (c *constrainedTuner) SetCenterFreq(hz uint32) error {
+	c.freqs = append(c.freqs, hz)
+	return nil
+}
+
+func (c *constrainedTuner) CanTune(hz uint32) bool {
+	return hz >= c.lo && hz <= c.hi
+}
+
+func TestFindFreeForFrequencySkipsConstrainedTuner(t *testing.T) {
+	// Two devices: one constrained (only serves 851 MHz band), one
+	// universal (physical SDR — no FrequencyChecker). For a 900 MHz
+	// grant, FindFreeForFrequency must return the universal one.
+	constrained := &constrainedTuner{lo: 851_000_000, hi: 852_000_000}
+	universal := &fakeVoiceTuner{}
+	p := NewVoicePool([]*VoiceDevice{
+		{Tuner: constrained, Serial: "wb-tap"},
+		{Tuner: universal, Serial: "phys"},
+	})
+	got := p.FindFreeForFrequency(900_000_000)
+	if got == nil || got.Serial != "phys" {
+		t.Errorf("FindFreeForFrequency(900 MHz) = %+v, want phys", got)
+	}
+	// In-range grant takes the first free device (constrained,
+	// because it's listed first).
+	got = p.FindFreeForFrequency(851_500_000)
+	if got == nil || got.Serial != "wb-tap" {
+		t.Errorf("FindFreeForFrequency(851.5 MHz) = %+v, want wb-tap", got)
+	}
+}
+
+func TestFindFreeForFrequencyReturnsNilWhenAllReject(t *testing.T) {
+	constrained := &constrainedTuner{lo: 851_000_000, hi: 852_000_000}
+	p := NewVoicePool([]*VoiceDevice{{Tuner: constrained, Serial: "wb-tap"}})
+	if got := p.FindFreeForFrequency(900_000_000); got != nil {
+		t.Errorf("FindFreeForFrequency on lone out-of-range tuner = %+v, want nil", got)
+	}
+}
+
 func TestLowestPriorityActiveSelectsLeastImportant(t *testing.T) {
 	p, _ := mkPool(3)
 	for i, prio := range []int{2, 7, 5} {

--- a/internal/voice/composer/composer.go
+++ b/internal/voice/composer/composer.go
@@ -60,8 +60,16 @@ type EqualizerConfig struct {
 // IQSource is the subset of sdr.Device the composer needs. Decoupling
 // keeps the package free of a hard import on internal/sdr and makes
 // testing trivial with an in-memory channel.
+//
+// SampleRateHz reports the chunk rate this source delivers. The
+// composer reads it once when a call starts so per-source rates
+// (a wideband-derived virtual voice tuner emits 48 kHz while a
+// physical SDR emits the daemon-wide 2.4 MS/s) drive the right
+// decimation factor. Sources that return 0 fall back to the
+// daemon-wide rate the Composer was constructed with.
 type IQSource interface {
 	StreamIQ(ctx context.Context) (<-chan []complex64, error)
+	SampleRateHz() uint32
 }
 
 // Devices resolves a Voice-role IQ source by its serial. The daemon
@@ -384,6 +392,16 @@ func (c *Composer) handleStart(parent context.Context, cs trunking.CallStart) {
 		c.log.Warn("composer: StreamIQ failed", "serial", cs.DeviceSerial, "err", err)
 		return
 	}
+	// Per-source rate lets a virtual voice tuner (wideband-derived,
+	// emits 48 kHz IQ) coexist with physical SDRs (daemon-wide
+	// rate, typically 2.4 MS/s) in the same composer — the chain
+	// resolves its decimator off this value instead of a fixed
+	// daemon-wide constant. Sources that don't yet know their
+	// rate (return 0) fall back to the daemon-wide setting.
+	rateHz := src.SampleRateHz()
+	if rateHz == 0 {
+		rateHz = c.iqHz
+	}
 	ch := &chain{cancel: cancel, done: make(chan struct{})}
 	c.mu.Lock()
 	c.chains[cs.DeviceSerial] = ch
@@ -399,13 +417,13 @@ func (c *Composer) handleStart(parent context.Context, cs trunking.CallStart) {
 				"device", cs.DeviceSerial, "system", cs.Grant.System,
 				"group", cs.Grant.GroupID)
 		}
-		go c.runDMRVoiceChain(chainCtx, cs.DeviceSerial, iqCh, ch.done)
+		go c.runDMRVoiceChain(chainCtx, cs.DeviceSerial, iqCh, rateHz, ch.done)
 	case isP25P2Voice:
-		go c.runP25Phase2VoiceChain(chainCtx, cs.DeviceSerial, iqCh, ch.done)
+		go c.runP25Phase2VoiceChain(chainCtx, cs.DeviceSerial, iqCh, rateHz, ch.done)
 	case isP25P1Voice:
-		go c.runP25Phase1VoiceChain(chainCtx, cs.DeviceSerial, iqCh, ch.done)
+		go c.runP25Phase1VoiceChain(chainCtx, cs.DeviceSerial, iqCh, rateHz, ch.done)
 	default:
-		go c.runFMChain(chainCtx, cs.DeviceSerial, iqCh, ch.done)
+		go c.runFMChain(chainCtx, cs.DeviceSerial, iqCh, rateHz, ch.done)
 	}
 }
 
@@ -439,11 +457,11 @@ func (c *Composer) cancelAll() {
 // (proper polyphase resamplers, de-emphasis, post-demod LPF) is a
 // follow-up; this is honest passthrough quality good enough to verify
 // the wiring end-to-end and to land the operator-visible plumbing.
-func (c *Composer) runFMChain(ctx context.Context, serial string, iqCh <-chan []complex64, done chan<- struct{}) {
+func (c *Composer) runFMChain(ctx context.Context, serial string, iqCh <-chan []complex64, iqHz uint32, done chan<- struct{}) {
 	defer close(done)
 
 	// Front-end LPF: cutoff = bw / iqHz (normalized 0..0.5).
-	cutoff := float64(c.bw) / float64(c.iqHz)
+	cutoff := float64(c.bw) / float64(iqHz)
 	if cutoff > 0.45 {
 		cutoff = 0.45
 	}
@@ -453,7 +471,7 @@ func (c *Composer) runFMChain(ctx context.Context, serial string, iqCh <-chan []
 	// Naive decimation factors. They aren't exact; resampling-quality
 	// audio lands with the polyphase resampler in a follow-up.
 	const intermediateHz = 48_000
-	decim1 := int(c.iqHz) / intermediateHz
+	decim1 := int(iqHz) / intermediateHz
 	if decim1 < 1 {
 		decim1 = 1
 	}
@@ -477,7 +495,7 @@ func (c *Composer) runFMChain(ctx context.Context, serial string, iqCh <-chan []
 	// treble for SNR; without the matching low-pass the recording
 	// sounds harsh. Filter runs on the real audio at the intermediate
 	// rate (~48 kHz) before the second naive decimation to PCM.
-	intermediateHzf := float64(c.iqHz) / float64(decim1)
+	intermediateHzf := float64(iqHz) / float64(decim1)
 	var deemph *filter.DeEmphasis
 	if c.deemphCfg.Enabled {
 		deemph = filter.NewDeEmphasis(c.deemphCfg.TimeConstant, intermediateHzf)

--- a/internal/voice/composer/composer_test.go
+++ b/internal/voice/composer/composer_test.go
@@ -12,7 +12,9 @@ import (
 )
 
 // fakeSource implements IQSource. Each call to StreamIQ returns a
-// fresh channel; the test pushes IQ chunks through SendIQ.
+// fresh channel; the test pushes IQ chunks through SendIQ. Returns
+// 0 from SampleRateHz so the composer falls back to its
+// daemon-wide IQSampleRate — the default for existing tests.
 type fakeSource struct {
 	mu  sync.Mutex
 	chs []chan []complex64
@@ -32,6 +34,8 @@ func (f *fakeSource) StreamIQ(ctx context.Context) (<-chan []complex64, error) {
 	}()
 	return ch, nil
 }
+
+func (f *fakeSource) SampleRateHz() uint32 { return 0 }
 
 func (f *fakeSource) SendIQ(samples []complex64) {
 	f.mu.Lock()

--- a/internal/voice/composer/dmr_voice.go
+++ b/internal/voice/composer/dmr_voice.go
@@ -37,20 +37,20 @@ type rawFrameSink interface {
 // to its 49-bit vocoder payload before being written. Vocoder decode
 // to PCM is still out of scope — the .raw sidecar carries the
 // post-FEC frames for out-of-band decode (issue #276).
-func (c *Composer) runDMRVoiceChain(ctx context.Context, serial string, iqCh <-chan []complex64, done chan<- struct{}) {
+func (c *Composer) runDMRVoiceChain(ctx context.Context, serial string, iqCh <-chan []complex64, iqHz uint32, done chan<- struct{}) {
 	defer close(done)
 
-	decim := int(c.iqHz) / dmrVoiceIntermediateHz
+	decim := int(iqHz) / dmrVoiceIntermediateHz
 	if decim < 1 {
 		decim = 1
 	}
-	symbolHz := float64(c.iqHz) / float64(decim)
+	symbolHz := float64(iqHz) / float64(decim)
 
 	// Front-end LPF: doubles as the anti-aliasing filter for the
 	// decimation, so it is only needed when the IQ is actually
 	// decimated (the live multi-MS/s path; decim == 1 only in tests
 	// that feed IQ already at the intermediate rate).
-	cutoff := float64(c.bw) / float64(c.iqHz)
+	cutoff := float64(c.bw) / float64(iqHz)
 	if cutoff > 0.45 {
 		cutoff = 0.45
 	}

--- a/internal/voice/composer/p25p1_voice.go
+++ b/internal/voice/composer/p25p1_voice.go
@@ -31,20 +31,20 @@ const p25p1DeviationHz = 1800.0
 // The recorder maps protocol "p25" to the pure-Go IMBE vocoder
 // (voice.DefaultVocoderForProtocol), so WriteRawFrame here decodes each
 // 11-byte frame to PCM and into the call's WAV.
-func (c *Composer) runP25Phase1VoiceChain(ctx context.Context, serial string, iqCh <-chan []complex64, done chan<- struct{}) {
+func (c *Composer) runP25Phase1VoiceChain(ctx context.Context, serial string, iqCh <-chan []complex64, iqHz uint32, done chan<- struct{}) {
 	defer close(done)
 
-	decim := int(c.iqHz) / p25p1VoiceIntermediateHz
+	decim := int(iqHz) / p25p1VoiceIntermediateHz
 	if decim < 1 {
 		decim = 1
 	}
-	symbolHz := float64(c.iqHz) / float64(decim)
+	symbolHz := float64(iqHz) / float64(decim)
 
 	// Front-end LPF: doubles as the anti-aliasing filter for the
 	// decimation, so it is only needed when the IQ is actually
 	// decimated (decim == 1 only in tests that feed IQ already at the
 	// intermediate rate).
-	cutoff := float64(c.bw) / float64(c.iqHz)
+	cutoff := float64(c.bw) / float64(iqHz)
 	if cutoff > 0.45 {
 		cutoff = 0.45
 	}

--- a/internal/voice/composer/p25p2_voice.go
+++ b/internal/voice/composer/p25p2_voice.go
@@ -32,20 +32,20 @@ const p25p2VoiceGardnerGain = 0.005
 // vocoder (voice.DefaultVocoderForProtocol), so WriteRawFrame here
 // decodes each 7-byte frame to PCM and into the call's WAV — unlike the
 // DMR chain, whose pre-FEC frames the vocoder cannot consume.
-func (c *Composer) runP25Phase2VoiceChain(ctx context.Context, serial string, iqCh <-chan []complex64, done chan<- struct{}) {
+func (c *Composer) runP25Phase2VoiceChain(ctx context.Context, serial string, iqCh <-chan []complex64, iqHz uint32, done chan<- struct{}) {
 	defer close(done)
 
-	decim := int(c.iqHz) / p25p2VoiceIntermediateHz
+	decim := int(iqHz) / p25p2VoiceIntermediateHz
 	if decim < 1 {
 		decim = 1
 	}
-	symbolHz := float64(c.iqHz) / float64(decim)
+	symbolHz := float64(iqHz) / float64(decim)
 
 	// Front-end LPF: doubles as the anti-aliasing filter for the
 	// decimation, so it is only needed when the IQ is actually
 	// decimated (decim == 1 only in tests that feed IQ already at the
 	// intermediate rate).
-	cutoff := float64(c.bw) / float64(c.iqHz)
+	cutoff := float64(c.bw) / float64(iqHz)
 	if cutoff > 0.45 {
 		cutoff = 0.45
 	}


### PR DESCRIPTION
## Summary

Phase B of the wideband channelizer extension. Phase A (#385) put a
P25 trunked control channel on a wideband dongle. This PR puts the
trunked **voice** grants for that system on the **same** dongle —
operators with a single SDR no longer need a second `role: voice`
dongle for grants whose frequency fits inside the wideband IQ window.

Closes the original ask in
[issue #379](https://github.com/MattCheramie/GopherTrunk/issues/379)
end-to-end.

## How it works

Set `voice_taps: N` on a wideband entry. The daemon allocates `N`
`wbvoice.VirtualTuner` objects, each implementing both
`trunking.Tuner` (the voice pool calls `SetCenterFreq` at bind) and
`composer.IQSource` (the composer reads decimated 48 kHz IQ during
the call). On each call, the tuner subscribes to the wideband
dongle's existing `iqtap.Broker`, runs a single-tap DDC at the
(target − wideband) NCO offset, and emits 48 kHz IQ. The existing
P25 Phase 1 / Phase 2 / DMR voice composer chains run unchanged
against that IQ — they just sit at a different point in the
demod tree.

Out-of-window grants surface `wbvoice.ErrOutOfBand`. The voice pool
gained `FindFreeForFrequency` that consults an optional
`FrequencyChecker.CanTune` so those grants spill over to a physical
`role: voice` SDR (when configured) instead of bouncing on a tap
that would reject them at bind time. Setups with `voice_taps: 0`
keep the legacy behaviour.

## Files

- **`internal/sdr/wbvoice/`** — new package. `VirtualTuner` type,
  `ErrOutOfBand`. Tests include an end-to-end carrier-shift check
  using a fake `iqtap` broker and the same energy-near-DC metric the
  upstream DDC tests use.
- **`internal/voice/composer/`** — `IQSource` gains `SampleRateHz()`;
  each voice chain takes per-source rate as a parameter. Sources
  reporting 0 fall back to the daemon-wide composer rate, so existing
  fakes keep working.
- **`internal/trunking/voicepool.go`** — new `FindFreeForFrequency`
  + `FrequencyChecker` interface. Physical SDRs without `CanTune`
  are treated as universally tunable (no behavioural change for
  non-wideband setups).
- **`internal/trunking/engine.go`** — `HandleGrant` calls
  `FindFreeForFrequency(g.FrequencyHz)`.
- **`internal/config/config.go`** — new `voice_taps` field
  (0 disables, 1-8 enables N taps).
- **`cmd/gophertrunk/daemon.go`** — builds virtual tuners alongside
  each wideband engine, exposes them via voice pool +
  `poolDevices.FindBySerial`. A small `deviceWithRate` adapter
  stamps the daemon-wide rate onto physical `sdr.Device` entries so
  they satisfy the extended `IQSource` interface.
- **Docs** — `README.md` and `docs/hardware.md` get the
  "one SDR, control + voice" worked example; `config.example.yaml`
  gets the commented `voice_taps` knob.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (full suite green)
- [x] `wbvoice` package: input validation, in-band accept, out-of-band
      reject, StreamIQ-without-SetCenterFreq error, and a carrier-shift
      test that pushes a complex tone through a fake broker and asserts
      ≥95% post-DDC energy lands within ±500 Hz of DC.
- [x] `trunking` package: `FindFreeForFrequency` skips constrained
      tuners; engine spills over to a physical SDR when a virtual
      tuner reports out-of-band.
- [x] `config` package: `voice_taps` range (0, 1-8, 99, -1).
- [x] Existing composer tests stay green with the new per-source
      rate plumbing (regression).
- [ ] Hand-run with a real P25 site whose CC + a voice carrier both
      fit inside one 2.4 MS/s window — for the maintainer to confirm
      on hardware they have.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H88vWRgZAgp52e1be9WqWp)_