### PR TITLE
p25/phase1: standard talker-alias voice LC decoder + Radio IDs docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,31 @@ for tagged releases.
 
 ### Added
 
+- **Radio IDs as first-class entities (#387, #376).** New
+  `trunking.RIDDB` operator-configured alias catalogue mirroring
+  `TalkgroupDB`: per-system `rid_alias_file` (CSV or JSON, dispatched
+  by extension) carrying `Decimal/DEC/ID` plus optional `Alias`,
+  `Description`, `Tag`, `Group`, `Owner`, `Priority`, `Lockout`,
+  `Watch`, `Icon` columns. `AffiliationTracker` gained `TalkerAlias`,
+  `TalkerAliasAt`, `CallCount`, `FirstSeen` on `UnitActivity` and
+  now subscribes to `KindTalkerAlias`. New HTTP routes `GET
+  /api/v1/rids`, `GET /api/v1/rids/{id}`, `GET
+  /api/v1/rids/{id}/history` (backed by `HistoryFilter.SourceID`),
+  and `PATCH /api/v1/rids/{id}`. New gRPC `RIDService`
+  (`ListRIDs` / `GetRID` / `ListRIDHistory`). New `/rids` web panel
+  with the configured ∪ live merge, last-50-calls detail modal, and
+  write-mode mutation controls. CC Activity RID chips are now
+  clickable links into the detail view. See [docs/radio-ids.md](docs/radio-ids.md).
+- **Standard P25 talker-alias voice-channel decoder.** Follow-up to
+  #387 closing the second half of issue #376. Phase 1 LDU1 Link
+  Control opcodes 0x15 (HEADER) / 0x16 (BLOCK1) / 0x17 (BLOCK2) are
+  now reassembled by `phase1.StandardTalkerAliasBuf` (one buffer
+  per active voice chain) and published as `KindTalkerAlias` events
+  with the call's SourceID; the affiliation tracker stamps the
+  decoded alias onto the RID row so it surfaces in
+  `/api/v1/rids` and the Radio IDs panel. The existing Motorola
+  vendor TSBK form (control channel) is unchanged. Phase 2 voice-MAC
+  alias dispatch remains a follow-up.
 - **APRS bus event + SQLite log + REST + web panel.** Second
   slice of Phase 5 (#365), building on the protocol layer from
   #381. New `events.KindAPRSPacket` bus event, `aprs_log`

--- a/README.md
+++ b/README.md
@@ -100,7 +100,20 @@ Silicon and Intel. Full per-OS recipes at
 - **CC Activity panel** — focused web view of the trunked control-
   channel chatter (grants, affiliations, registrations, patches,
   talker aliases, CC lock / loss). Pure filter over the events
-  stream with per-row payload rendering; web panel at `/cc`.
+  stream with per-row payload rendering; web panel at `/cc`. RIDs
+  in the feed are clickable chips that pivot into the per-radio
+  detail view.
+- **Radio IDs panel** — per-radio (subscriber-unit) entity browser
+  with the same shape as Talkgroups. Merges the operator-configured
+  alias catalogue (per-system `rid_alias_file` CSV or JSON: alias,
+  owner, tag, group, priority, lockout, watch) with the live
+  affiliation tracker (last talkgroup, last seen, call count,
+  decoded talker alias). Detail modal pulls the last 50 calls for
+  the RID from the persisted call log. Web panel at `/rids`; REST
+  at `/api/v1/rids`; gRPC `RIDService`. Talker-alias decoders
+  cover the Motorola vendor TSBK form (control channel) and the
+  standard TIA-102.AABF voice-channel LCs (P25 Phase 1 LDU1 LCO
+  0x15/0x16/0x17).
 - **Constellation viewer** — live IQ scatter visualization that
   taps the same broker the trunking decoder reads. Useful for
   identifying signal shape (PSK / QPSK / FSK / C4FM / AM /

--- a/docs/_data/nav.yml
+++ b/docs/_data/nav.yml
@@ -33,6 +33,8 @@ groups:
         url: /bookmarks.html
       - title: CC Activity
         url: /cc-activity.html
+      - title: Radio IDs
+        url: /radio-ids.html
       - title: Constellation
         url: /constellation.html
       - title: rigctld integration

--- a/docs/cc-activity.md
+++ b/docs/cc-activity.md
@@ -19,7 +19,12 @@ want to watch live while a trunked system is being decoded:
 - **Patches / dynamic regroups** — the super-group plus member
   count, "add" vs "cancel" verb
 - **Talker aliases** — the decoded display-name string per radio
-  ID
+  ID. Two paths feed this: the Motorola vendor TSBK form on the
+  control channel, and the standard TIA-102.AABF voice-channel
+  Link Control opcodes (P25 Phase 1 LDU1 LCO 0x15 HEADER, 0x16
+  BLOCK1, 0x17 BLOCK2). Each completed alias is bound to the
+  current call's source ID so the Radio IDs panel can persist it
+  next to the operator-configured catalogue.
 - **CC lock / loss** — control-channel acquisition + recovery
 - **Call start / end** — actively-decoded voice transitions
 
@@ -82,3 +87,9 @@ matching event with payload-specific formatting:
 When more event payload shapes land (e.g. encryption metadata
 arrives mid-call via `call.encryption`), extending the panel is a
 matter of adding a switch arm in `CCActivity.tsx`'s `renderRow`.
+
+Radio IDs in the feed (the `<src>` in a grant row, the `<id>` in an
+affiliation / registration / talker-alias row) are rendered as
+clickable links into the Radio IDs panel's per-radio detail view —
+one click pivots from the live chatter to the radio's recent call
+history.

--- a/docs/radio-ids.md
+++ b/docs/radio-ids.md
@@ -1,0 +1,144 @@
+---
+layout: page
+title: Radio IDs panel
+description: Per-radio (subscriber-unit) entity browser merging the operator alias catalogue with the live affiliation tracker
+nav_group: Operate
+---
+
+# Radio IDs panel
+
+GopherTrunk's **Radio IDs** panel (web `/rids`) gives every
+subscriber unit (the "RID" or `source_id` in grant / call payloads)
+the same first-class treatment talkgroups have always had: a
+filterable list, a detail view, per-RID call history, and operator-
+configurable aliases.
+
+It exists because recurring radios are operationally interesting in
+their own right. The dispatch officer who's on the air all morning,
+the patrol unit that runs the same routes every day, the test radio
+that helps you spot a misconfigured CC — naming them once and
+seeing them as named entities in the live feed makes that workflow
+far easier than scrolling raw `source_id` numbers.
+
+## What you get
+
+- A merged view of two RID sources, keyed by radio ID:
+  - **Configured** rows from a per-system `rid_alias_file` (CSV or
+    JSON) — operator-assigned `alias`, `description`, `tag`,
+    `group`, `owner`, `priority`, `lockout`, `watch`, `icon`.
+  - **Live** rows from the affiliation tracker — `last_seen`,
+    `first_seen`, `last_talkgroup`, observed over-the-air
+    `talker_alias`, and a `call_count` for "how recurring is this
+    radio."
+- Configured + live overlap is merged on `id`; either source can
+  contribute a row by itself.
+- Detail modal with the last 50 calls observed for the RID
+  (queried from the persisted call log by `source_id`).
+- Write-mode edits to the in-memory catalogue (alias / watch /
+  lockout / priority / tag / group / owner / icon).
+
+## Loading aliases
+
+Each trunked system can point at its own RID catalogue with the
+`rid_alias_file` key (mirrors `talkgroup_file`):
+
+```yaml
+trunking:
+  systems:
+    - name: "Example-P25"
+      protocol: p25
+      control_channels: [851_000_000]
+      talkgroup_file: "/etc/gophertrunk/talkgroups-p25.csv"
+      rid_alias_file:  "/etc/gophertrunk/rids-p25.csv"
+```
+
+The file is dispatched by extension: `*.json` goes through the
+JSON loader, anything else through the CSV loader.
+
+### CSV format
+
+Required column (case-insensitive): `Decimal` / `DEC` / `ID`.
+Optional columns: `Alias` (or `Alpha Tag` / `AlphaTag`),
+`Description`, `Tag`, `Group`, `Owner`, `Priority`, `Lockout`,
+`Watch`, `Icon`.
+
+```csv
+Decimal,Alias,Description,Tag,Group,Owner,Priority,Watch
+207545,CPL-SMITH,Patrol corporal,Patrol,Bossier PD,Cpl. Smith,2,
+207546,LOCKED,Decommissioned radio,,,L,,no
+207547,ENG-12,Fire engine 12,Fire,Bossier Fire,Engine 12,1,
+```
+
+`Lockout` accepts `Y` / `yes` / `true` / `1`; the legacy `Priority:L`
+sentinel from talkgroup CSVs also sets `Lockout`. `Watch` defaults
+to true; explicit `no` / `false` / `0` / `n` opts a row out of the
+watch list.
+
+### JSON format
+
+```json
+[
+  {"id": 207545, "alias": "CPL-SMITH", "owner": "Cpl. Smith", "priority": 2},
+  {"id": 207546, "alias": "LOCKED", "lockout": true, "watch": false},
+  {"id": 207547, "alias": "ENG-12", "tag": "Fire", "group": "Bossier Fire"}
+]
+```
+
+The daemon preflights the file the same way it preflights
+`talkgroup_file` — non-fatal warnings for missing / empty paths so
+the daemon still starts and the affiliation tracker still surfaces
+live RIDs.
+
+## REST surface
+
+| Method | Path | Auth | What it does |
+| --- | --- | --- | --- |
+| `GET`   | `/api/v1/rids`                  | open           | Merged list (configured ∪ live). |
+| `GET`   | `/api/v1/rids/{id}`             | open           | Single merged row. |
+| `GET`   | `/api/v1/rids/{id}/history`     | open           | `call_log` filtered by `source_id`. Same query params as `/api/v1/calls/history` (`limit`, `only_ended`, `system`). |
+| `PATCH` | `/api/v1/rids/{id}`             | mutation-gated | Edit alias / description / tag / group / owner / priority / lockout / watch / icon. Only works on rows backed by the static catalogue — live-only rows return 404 with a hint to add the RID to `rid_alias_file` first. |
+
+PATCH mutations live in memory only — the on-disk `rid_alias_file`
+is not rewritten, matching the talkgroup behaviour. Restarting the
+daemon reloads from disk.
+
+## gRPC surface
+
+`RIDService` in `proto/rid.proto` mirrors the HTTP surface:
+
+- `ListRIDs(ListRIDsRequest) → ListRIDsResponse`
+- `GetRID(GetRIDRequest) → GetRIDResponse`
+- `ListRIDHistory(ListRIDHistoryRequest) → ListRIDHistoryResponse`
+
+Read-only for this slice; mutations go through the HTTP PATCH.
+
+## Talker aliases
+
+The decoded over-the-air talker alias (the radio's display name)
+shows up in two places:
+
+- On the RID row as `talker_alias` once the daemon reassembles it,
+  with `talker_alias_at` as the observation timestamp.
+- As a `talker.alias` event on the bus / CC Activity feed at
+  decode time.
+
+Two paths feed it:
+
+- **Motorola vendor TSBK** — control-channel `OpVendorTalkerAlias`
+  0x15, reassembled by `phase1.TalkerAliasAssembler` (Phase 1)
+  and the Phase 2 vendor MAC opcode.
+- **Standard TIA-102.AABF voice-channel LCs** — P25 Phase 1 LDU1
+  Link Control opcodes 0x15 HEADER / 0x16 BLOCK1 / 0x17 BLOCK2,
+  reassembled per call by `phase1.StandardTalkerAliasBuf` in the
+  voice composer.
+
+Phase 2 standard voice-MAC alias dispatch is a follow-up; the
+vendor MAC form on the Phase 2 control channel is already wired.
+
+## See also
+
+- [CC Activity panel](cc-activity.md) — the live chatter feed
+  whose RID chips link into this panel.
+- [Web console](web.md) — overall web UI orientation.
+- [Hardening](hardening.md) — the bearer-token auth gate that
+  protects the PATCH endpoint.

--- a/docs/web.md
+++ b/docs/web.md
@@ -30,6 +30,7 @@ Every Bubbletea TUI panel has a browser counterpart:
 | History     | Filterable call-log explorer + retention-sweep mutation         |
 | Systems     | Trunked-system browser with detail modal                        |
 | Talkgroups  | Sortable / filterable list with scan / lockout / priority edits |
+| Radio IDs   | Per-RID browser merging the operator alias catalogue with the live affiliation tracker; detail modal with last 50 calls per radio; alias / watch / lockout / priority edits |
 | Devices     | SDR pool inspector (live attach / detach)                       |
 | Events      | Live ring-buffer viewer (filter / pause / JSON expansion)       |
 | Tones       | `tone.alert` feed with per-device reset                         |
@@ -268,9 +269,9 @@ requiring TLS + token via your reverse proxy.
 Bottom-nav on phones, top-tab strip on desktop:
 
 ```
-Dashboard · Active · Scanner · Settings        (always visible)
-Systems · Talkgroups · History · Events ·
-  Tones · Metrics · Devices                    (desktop overflow row)
+Dashboard · Active · Scanner · Settings              (always visible)
+Systems · Talkgroups · Radio IDs · History ·
+  Events · Tones · Metrics · Devices                 (desktop overflow row)
 ```
 
 On phones the overflow row is reachable via the hamburger menu in

--- a/internal/radio/p25/phase1/link_control.go
+++ b/internal/radio/p25/phase1/link_control.go
@@ -118,6 +118,22 @@ func ParseLinkControl(blocks [LDULCESBlockCount][]byte) (LinkControl, int, error
 	}, errs, nil
 }
 
+// ParseLinkControlContent decodes the 6 LC blocks of an LDU1 into the
+// raw 9 LC content octets plus the inner-FEC corrected-error count.
+// Used by the talker-alias path so opcodes other than 0x00 (group
+// voice channel user) can read their own octet layout without going
+// through ParseLinkControl's LCO-0-shaped struct.
+func ParseLinkControlContent(blocks [LDULCESBlockCount][]byte) ([lcContentOctets]byte, int, error) {
+	var out [lcContentOctets]byte
+	data, errs, err := lcInnerDecode(blocks)
+	if err != nil {
+		return out, 0, err
+	}
+	oct := bitsToOctets(data[:lcContentOctets*8])
+	copy(out[:], oct)
+	return out, errs, nil
+}
+
 // AssembleLinkControl is the inverse of ParseLinkControl; it builds the
 // 6 on-wire LC blocks for a LinkControl word. The RS-parity half of the
 // 144-bit data field is left zero (see the package note above).

--- a/internal/radio/p25/phase1/talker_alias_standard.go
+++ b/internal/radio/p25/phase1/talker_alias_standard.go
@@ -1,0 +1,198 @@
+package phase1
+
+import "time"
+
+// Standard P25 voice-channel talker-alias reassembly (TIA-102.AABF).
+//
+// Distinct from TalkerAliasAssembler (talker_alias.go), which handles
+// the Motorola vendor *TSBK* form carried on the control channel.
+// Standard alias rides on the **voice channel** during an active
+// call: an LDU1 Link Control word with LCFormat ∈ {0x15, 0x16, 0x17}
+// carries one fragment of a 3-frame HEADER + BLOCK1 + BLOCK2 sequence.
+//
+// Layout (project working model — the per-LCO field tables in
+// TIA-102.AABF are not in the repo's spec PDFs). Each 9-octet LC
+// content carries:
+//
+//	HEADER  (LCF 0x15): octet 0 = LCO,
+//	                    octet 1 = MFID,
+//	                    octet 2 = format / data-format byte,
+//	                    octet 3 = total alias byte length,
+//	                    octets 4-8 = first 5 alias bytes
+//	BLOCK1  (LCF 0x16): octet 0 = LCO,
+//	                    octet 1 = MFID,
+//	                    octets 2-8 = next 7 alias bytes
+//	BLOCK2  (LCF 0x17): octet 0 = LCO,
+//	                    octet 1 = MFID,
+//	                    octets 2-8 = next 7 alias bytes
+//
+// Maximum reassembled alias length: 5 + 7 + 7 = 19 bytes. The
+// assembler uses the HEADER's declared length to trim the trailing
+// padding so a short alias ("ENG-12") doesn't drag along its filler.
+//
+// Talker alias is keyed by the active call's SourceID, but the LC
+// content does NOT carry it inline — the source identity comes from
+// the surrounding voice call (the engine's ActiveCall for the
+// device whose voice chain feeds this assembler). That's why this
+// type is a per-call buffer rather than a per-source map: each
+// active voice call owns one StandardTalkerAliasBuf, and the
+// composer caller publishes the assembled alias with the call's
+// known SourceID.
+
+// standardAliasMaxBytes is the working-model upper bound on the
+// reassembled alias length — 5 (HEADER tail) + 7 (BLOCK1) + 7
+// (BLOCK2). Anything beyond this is truncated.
+const standardAliasMaxBytes = 19
+
+// standardAliasStaleAfter is how long a partial reassembly is kept
+// before the next AddFragment evicts it. Voice-channel LCs ride at
+// ~9 LDU1s per second, so even a 1 s gap is generous; 5 s tolerates
+// a brief decoder stall without dropping the alias.
+const standardAliasStaleAfter = 5 * time.Second
+
+// StandardTalkerAliasBuf reassembles the three voice-channel
+// talker-alias fragments for one active call. Construct one per
+// voice chain, call AddFragment for every LCO 0x15/0x16/0x17 LC the
+// chain observes; AddFragment returns the assembled alias once
+// HEADER + at least one BLOCK have arrived. Safe for single-goroutine
+// use — the voice composer owns one per call and never shares.
+type StandardTalkerAliasBuf struct {
+	now func() time.Time
+
+	haveHeader bool
+	haveBlock1 bool
+	haveBlock2 bool
+
+	// dataLength is the alias byte length declared by HEADER.
+	// Zero before HEADER arrives or when the HEADER octet is itself
+	// zero (some implementations leave length at zero and rely on
+	// trailing-padding stripping). Capped at standardAliasMaxBytes
+	// on use.
+	dataLength uint8
+
+	// headerTail are the 5 alias bytes from HEADER octets 4..8.
+	headerTail [5]byte
+	// block1, block2 are the 7-byte alias payloads of BLOCK1/BLOCK2
+	// (octets 2..8).
+	block1 [7]byte
+	block2 [7]byte
+
+	lastUpdate time.Time
+	// emittedHash is a fingerprint of the last successfully emitted
+	// alias so the assembler doesn't re-emit the same alias on every
+	// LC repeat. Cleared on Reset.
+	emittedHash uint64
+}
+
+// NewStandardTalkerAliasBuf returns a ready buffer. now is injectable
+// for tests; nil defaults to time.Now.
+func NewStandardTalkerAliasBuf(now func() time.Time) *StandardTalkerAliasBuf {
+	if now == nil {
+		now = time.Now
+	}
+	return &StandardTalkerAliasBuf{now: now}
+}
+
+// AddFragment feeds one talker-alias LC's raw 9-octet content into
+// the buffer. lcf must be one of LCOTalkerAliasHeader /
+// LCOTalkerAliasBlock1 / LCOTalkerAliasBlock2; other LCOs are
+// ignored. When enough fragments have arrived to form a complete
+// alias, AddFragment returns (alias, true); otherwise ("", false).
+//
+// The same alias is not returned twice — the second AddFragment
+// after a complete emission returns ("", false) until a new HEADER
+// arrives. Fragments older than standardAliasStaleAfter are dropped
+// on the next call so an interrupted sequence doesn't leak partial
+// state into the next call's reassembly.
+func (b *StandardTalkerAliasBuf) AddFragment(lcf uint8, content [lcContentOctets]byte) (string, bool) {
+	now := b.now()
+	if !b.lastUpdate.IsZero() && now.Sub(b.lastUpdate) > standardAliasStaleAfter {
+		b.resetExceptEmitted()
+	}
+	switch lcf {
+	case LCOTalkerAliasHeader:
+		// HEADER carries the declared length in octet 3 and the
+		// first 5 alias bytes in octets 4..8. A repeated HEADER
+		// resets the assembler — a new alias is being sent.
+		b.dataLength = content[3]
+		copy(b.headerTail[:], content[4:9])
+		b.haveHeader = true
+		b.haveBlock1 = false
+		b.haveBlock2 = false
+	case LCOTalkerAliasBlock1:
+		copy(b.block1[:], content[2:9])
+		b.haveBlock1 = true
+	case LCOTalkerAliasBlock2:
+		copy(b.block2[:], content[2:9])
+		b.haveBlock2 = true
+	default:
+		return "", false
+	}
+	b.lastUpdate = now
+
+	if !b.haveHeader {
+		return "", false
+	}
+	// Emit once both BLOCK1 and BLOCK2 have arrived. Single-BLOCK
+	// emission would let a HEADER+BLOCK1 produce a (truncated) alias
+	// before BLOCK2 lands, but real systems repeat the full sequence
+	// throughout the call so waiting for the BLOCK2 keeps the first
+	// emission complete.
+	if !b.haveBlock1 || !b.haveBlock2 {
+		return "", false
+	}
+
+	raw := make([]byte, 0, standardAliasMaxBytes)
+	raw = append(raw, b.headerTail[:]...)
+	raw = append(raw, b.block1[:]...)
+	raw = append(raw, b.block2[:]...)
+	if int(b.dataLength) > 0 && int(b.dataLength) < len(raw) {
+		raw = raw[:b.dataLength]
+	}
+	alias := cleanAlias(raw)
+	if alias == "" {
+		return "", false
+	}
+	h := aliasFingerprint(alias)
+	if h == b.emittedHash {
+		// Already published this alias on a previous LC repeat;
+		// don't double-emit.
+		return "", false
+	}
+	b.emittedHash = h
+	return alias, true
+}
+
+// Reset clears the buffer including the de-duplication fingerprint —
+// the voice composer calls this when a new call starts on the same
+// device so the previous call's alias doesn't leak forward.
+func (b *StandardTalkerAliasBuf) Reset() {
+	b.resetExceptEmitted()
+	b.emittedHash = 0
+}
+
+func (b *StandardTalkerAliasBuf) resetExceptEmitted() {
+	b.haveHeader = false
+	b.haveBlock1 = false
+	b.haveBlock2 = false
+	b.dataLength = 0
+	b.headerTail = [5]byte{}
+	b.block1 = [7]byte{}
+	b.block2 = [7]byte{}
+	b.lastUpdate = time.Time{}
+}
+
+// aliasFingerprint is a cheap FNV-1a hash used only to suppress
+// repeat emissions of the same alias inside one call.
+func aliasFingerprint(s string) uint64 {
+	const (
+		offset uint64 = 14695981039346656037
+		prime  uint64 = 1099511628211
+	)
+	h := offset
+	for i := 0; i < len(s); i++ {
+		h ^= uint64(s[i])
+		h *= prime
+	}
+	return h
+}

--- a/internal/radio/p25/phase1/talker_alias_standard_test.go
+++ b/internal/radio/p25/phase1/talker_alias_standard_test.go
@@ -1,0 +1,153 @@
+package phase1
+
+import (
+	"testing"
+	"time"
+)
+
+// makeHeader builds an LC content matching the standard talker-alias
+// HEADER working model: MFID + format byte + declared length + 5
+// alias bytes in octets 4..8.
+func makeHeader(length uint8, tail string) [lcContentOctets]byte {
+	var c [lcContentOctets]byte
+	c[0] = LCOTalkerAliasHeader
+	c[3] = length
+	for i := 0; i < 5 && i < len(tail); i++ {
+		c[4+i] = tail[i]
+	}
+	return c
+}
+
+func makeBlock(lcf uint8, payload string) [lcContentOctets]byte {
+	var c [lcContentOctets]byte
+	c[0] = lcf
+	for i := 0; i < 7 && i < len(payload); i++ {
+		c[2+i] = payload[i]
+	}
+	return c
+}
+
+func TestStandardTalkerAliasBufHeaderBlock1Block2(t *testing.T) {
+	b := NewStandardTalkerAliasBuf(nil)
+	// HEADER + BLOCK1 alone shouldn't emit — the assembler waits for
+	// BLOCK2 so the first emission is the full alias.
+	if alias, ok := b.AddFragment(LCOTalkerAliasHeader, makeHeader(13, "ENGIN")); ok {
+		t.Errorf("HEADER alone emitted %q", alias)
+	}
+	if alias, ok := b.AddFragment(LCOTalkerAliasBlock1, makeBlock(LCOTalkerAliasBlock1, "E-12 UN")); ok {
+		t.Errorf("HEADER+BLOCK1 emitted %q before BLOCK2", alias)
+	}
+	alias, ok := b.AddFragment(LCOTalkerAliasBlock2, makeBlock(LCOTalkerAliasBlock2, "IT"))
+	if !ok {
+		t.Fatal("BLOCK2 did not complete the alias")
+	}
+	// HEADER tail = "ENGIN", BLOCK1 = "E-12 UN", BLOCK2 = "IT" → 14
+	// concatenated chars; declared length 13 keeps the first 13.
+	if alias != "ENGINE-12 UNI" {
+		t.Errorf("alias = %q, want ENGINE-12 UNI (13 declared bytes)", alias)
+	}
+}
+
+func TestStandardTalkerAliasBufZeroLengthUsesAllAvailable(t *testing.T) {
+	// Some implementations leave the HEADER's length byte at 0 and
+	// expect the receiver to strip trailing zeros itself. The
+	// assembler keeps all 19 bytes when length is 0, then cleanAlias
+	// drops the non-printable padding.
+	b := NewStandardTalkerAliasBuf(nil)
+	b.AddFragment(LCOTalkerAliasHeader, makeHeader(0, "FIRE\x00"))
+	b.AddFragment(LCOTalkerAliasBlock1, makeBlock(LCOTalkerAliasBlock1, "\x00\x00\x00\x00\x00\x00\x00"))
+	alias, ok := b.AddFragment(LCOTalkerAliasBlock2, makeBlock(LCOTalkerAliasBlock2, "\x00\x00\x00\x00\x00\x00\x00"))
+	if !ok {
+		t.Fatal("BLOCK2 did not complete the alias")
+	}
+	if alias != "FIRE" {
+		t.Errorf("alias = %q, want FIRE (length=0 means strip non-printable)", alias)
+	}
+}
+
+func TestStandardTalkerAliasBufNoEmitWithoutHeader(t *testing.T) {
+	b := NewStandardTalkerAliasBuf(nil)
+	if _, ok := b.AddFragment(LCOTalkerAliasBlock1, makeBlock(LCOTalkerAliasBlock1, "OUTOFORD")); ok {
+		t.Error("BLOCK1 alone should not emit")
+	}
+	if _, ok := b.AddFragment(LCOTalkerAliasBlock2, makeBlock(LCOTalkerAliasBlock2, "ER")); ok {
+		t.Error("BLOCK1+BLOCK2 without HEADER should not emit")
+	}
+}
+
+func TestStandardTalkerAliasBufNoDoubleEmit(t *testing.T) {
+	// The voice channel repeats the same alias sequence throughout
+	// the call; the assembler should suppress duplicate emissions.
+	b := NewStandardTalkerAliasBuf(nil)
+	b.AddFragment(LCOTalkerAliasHeader, makeHeader(7, "UNIT-"))
+	b.AddFragment(LCOTalkerAliasBlock1, makeBlock(LCOTalkerAliasBlock1, "12     "))
+	first, ok := b.AddFragment(LCOTalkerAliasBlock2, makeBlock(LCOTalkerAliasBlock2, "       "))
+	if !ok || first != "UNIT-12" {
+		t.Fatalf("first emission = %q, ok=%v, want UNIT-12", first, ok)
+	}
+	// Replay the same sequence — the second pass must not re-emit.
+	b.AddFragment(LCOTalkerAliasHeader, makeHeader(7, "UNIT-"))
+	b.AddFragment(LCOTalkerAliasBlock1, makeBlock(LCOTalkerAliasBlock1, "12     "))
+	if alias, ok := b.AddFragment(LCOTalkerAliasBlock2, makeBlock(LCOTalkerAliasBlock2, "       ")); ok {
+		t.Errorf("re-emitted same alias %q", alias)
+	}
+}
+
+func TestStandardTalkerAliasBufNewHeaderResetsBlocks(t *testing.T) {
+	// A repeated HEADER means a new alias is being sent — drop any
+	// in-flight BLOCK state so a partial reassembly doesn't blend
+	// with the new alias.
+	b := NewStandardTalkerAliasBuf(nil)
+	b.AddFragment(LCOTalkerAliasHeader, makeHeader(10, "OLDAL"))
+	b.AddFragment(LCOTalkerAliasBlock1, makeBlock(LCOTalkerAliasBlock1, "IAS    "))
+	// New HEADER arrives before BLOCK2 — old BLOCK1 must be cleared.
+	b.AddFragment(LCOTalkerAliasHeader, makeHeader(8, "NEWAL"))
+	if alias, ok := b.AddFragment(LCOTalkerAliasBlock1, makeBlock(LCOTalkerAliasBlock1, "IAS    ")); ok {
+		t.Errorf("emitted %q before BLOCK2 of new alias", alias)
+	}
+	alias, ok := b.AddFragment(LCOTalkerAliasBlock2, makeBlock(LCOTalkerAliasBlock2, "       "))
+	if !ok || alias != "NEWALIAS" {
+		t.Errorf("new alias = %q (ok=%v), want NEWALIAS", alias, ok)
+	}
+}
+
+func TestStandardTalkerAliasBufStaleEviction(t *testing.T) {
+	// A long pause between fragments evicts the partial reassembly
+	// so a stray BLOCK2 from a previous alias doesn't accidentally
+	// complete it after the gap.
+	clk := time.Now()
+	b := NewStandardTalkerAliasBuf(func() time.Time { return clk })
+	b.AddFragment(LCOTalkerAliasHeader, makeHeader(13, "ENGIN"))
+	b.AddFragment(LCOTalkerAliasBlock1, makeBlock(LCOTalkerAliasBlock1, "E-12 UN"))
+	clk = clk.Add(10 * time.Second) // far past staleness window
+	if alias, ok := b.AddFragment(LCOTalkerAliasBlock2, makeBlock(LCOTalkerAliasBlock2, "IT")); ok {
+		t.Errorf("emitted %q after stale eviction", alias)
+	}
+}
+
+func TestStandardTalkerAliasBufResetClearsEmitted(t *testing.T) {
+	// Reset is what the voice composer calls when a new call starts
+	// on the same device — the previous call's emitted-hash must
+	// not block the new call from emitting the same alias.
+	b := NewStandardTalkerAliasBuf(nil)
+	b.AddFragment(LCOTalkerAliasHeader, makeHeader(5, "ENGIN"))
+	b.AddFragment(LCOTalkerAliasBlock1, makeBlock(LCOTalkerAliasBlock1, "       "))
+	first, _ := b.AddFragment(LCOTalkerAliasBlock2, makeBlock(LCOTalkerAliasBlock2, "       "))
+	if first != "ENGIN" {
+		t.Fatalf("setup: first emission %q, want ENGIN", first)
+	}
+	b.Reset()
+	b.AddFragment(LCOTalkerAliasHeader, makeHeader(5, "ENGIN"))
+	b.AddFragment(LCOTalkerAliasBlock1, makeBlock(LCOTalkerAliasBlock1, "       "))
+	second, ok := b.AddFragment(LCOTalkerAliasBlock2, makeBlock(LCOTalkerAliasBlock2, "       "))
+	if !ok || second != "ENGIN" {
+		t.Errorf("after Reset, emitted %q (ok=%v), want ENGIN", second, ok)
+	}
+}
+
+func TestStandardTalkerAliasBufIgnoresUnrelatedLCO(t *testing.T) {
+	b := NewStandardTalkerAliasBuf(nil)
+	if _, ok := b.AddFragment(LCOGroupVoiceChannelUser, [lcContentOctets]byte{}); ok {
+		t.Error("non-alias LCO must not emit")
+	}
+}

--- a/internal/voice/composer/p25p1_voice.go
+++ b/internal/voice/composer/p25p1_voice.go
@@ -59,6 +59,19 @@ func (c *Composer) runP25Phase1VoiceChain(ctx context.Context, serial string, iq
 		lastES    phase1.EncryptionSync
 		hasLastES bool
 	)
+	// aliasBuf reassembles the per-call standard P25 voice-channel
+	// talker alias (TIA-102.AABF LCOs 0x15/0x16/0x17). Distinct from
+	// the Motorola vendor TSBK form, which the control channel
+	// already handles via phase1.TalkerAliasAssembler. One buffer
+	// per voice chain — each chain handles exactly one call's worth
+	// of LDU1s, so per-source tracking isn't needed here.
+	aliasBuf := phase1.NewStandardTalkerAliasBuf(nil)
+	// lastSourceID is the most recently observed SourceID from an
+	// LCO-0 (group voice channel user) LC on this chain. The alias
+	// LCs (0x15/0x16/0x17) carry only payload bytes — no SourceID —
+	// so the voice channel's own LCO-0 LCs are how we tag a decoded
+	// alias with the right radio.
+	var lastSourceID uint32
 	// frames counts LDUs delivered by the receiver — i.e. real voice
 	// activity. The touch ticker (below) only refreshes the engine's
 	// LastHeardAt when this counter has advanced since the previous
@@ -101,21 +114,38 @@ func (c *Composer) runP25Phase1VoiceChain(ctx context.Context, serial string, iq
 			}
 			switch duid {
 			case phase1.DUIDLogicalLink1:
-				if lc, _, lerr := phase1.ParseLinkControl(blocks); lerr == nil {
-					c.log.Debug("composer: p25p1 link control",
-						"serial", serial, "lcf", lc.LCFormat,
-						"tg", lc.TalkgroupID, "src", lc.SourceID)
-					// Surface the standard TIA-102 voice-channel
-					// talker-alias LCOs at Info so operators whose
-					// system uses them can see they're flowing on
-					// the wire even though we don't yet reassemble
-					// them. The Motorola vendor TSBK form is handled
-					// by the control channel today (see
-					// phase1.OpVendorTalkerAlias); the standard
-					// voice-channel form is issue #376 follow-up.
-					if phase1.IsTalkerAliasLCO(lc.LCFormat) {
-						c.log.Info("composer: p25p1 standard talker-alias LC observed (not yet decoded — see issue #376)",
-							"serial", serial, "lcf", lc.LCFormat)
+				// Standard TIA-102 voice-channel talker-alias LCs
+				// (LCO 0x15/0x16/0x17) reuse the LC octets for the
+				// alias payload — ParseLinkControl's TG/SRC view is
+				// only meaningful for LCOGroupVoiceChannelUser (0x00),
+				// so dispatch on the opcode before interpreting the
+				// rest of the content.
+				content, _, cerr := phase1.ParseLinkControlContent(blocks)
+				if cerr != nil {
+					return
+				}
+				lcf := content[0]
+				switch {
+				case phase1.IsTalkerAliasLCO(lcf):
+					if alias, ok := aliasBuf.AddFragment(lcf, content); ok && lastSourceID != 0 {
+						c.bus.Publish(events.Event{
+							Kind: events.KindTalkerAlias,
+							Payload: trunking.TalkerAlias{
+								Protocol: "p25-phase1",
+								SourceID: lastSourceID,
+								Alias:    alias,
+								At:       time.Now(),
+							},
+						})
+					}
+				default:
+					if lc, _, lerr := phase1.ParseLinkControl(blocks); lerr == nil {
+						c.log.Debug("composer: p25p1 link control",
+							"serial", serial, "lcf", lc.LCFormat,
+							"tg", lc.TalkgroupID, "src", lc.SourceID)
+						if lc.LCFormat == phase1.LCOGroupVoiceChannelUser && lc.SourceID != 0 {
+							lastSourceID = lc.SourceID
+						}
 					}
 				}
 			case phase1.DUIDLogicalLink2:


### PR DESCRIPTION
Follow-up to #387 closing the second half of issue #376.

## Summary

- New `phase1.StandardTalkerAliasBuf` reassembles the standard TIA-102.AABF voice-channel talker-alias Link Control opcodes (`0x15` HEADER / `0x16` BLOCK1 / `0x17` BLOCK2). One buffer per active voice chain — HEADER carries the declared length and first 5 alias bytes, BLOCK1 and BLOCK2 each carry 7 more. The buffer waits for the full sequence, trims to the declared length, runs through the existing `cleanAlias` printable-ASCII filter, and de-duplicates against the last emission so per-call LC repeats don't fan out the same event.
- The voice composer (`internal/voice/composer/p25p1_voice.go`) now uses the new `ParseLinkControlContent` to read the raw 9 LC octets before dispatching on the LCO byte — `ParseLinkControl`'s TG/SRC view is only meaningful for `LCOGroupVoiceChannelUser` (0x00), so alias LCs (which reuse those octets as payload) need the raw view. The most recently observed LCO-0 SourceID is captured per chain so the assembled alias publishes with the right radio attached.
- The Motorola vendor TSBK form on the control channel is unchanged — both paths feed the same `KindTalkerAlias` event and surface on the Radio IDs panel through the affiliation tracker.
- Phase 2 voice-MAC alias dispatch remains a separate follow-up.

## Docs

New `docs/radio-ids.md` walks through the per-system `rid_alias_file` config, CSV/JSON formats, the REST + gRPC surface, PATCH semantics, and how both talker-alias paths feed the panel. README + `docs/cc-activity.md` + `docs/web.md` + the docs nav are updated to reference the new panel and decoder. `CHANGELOG.md` covers both the merged #387 work and this follow-up under Unreleased.

## Layout note

The 9-octet LC content layout for the alias LCOs is the project's working model (per the existing note in `link_control.go`, TIA-102.AABF's per-LCO field tables aren't in the repo's spec PDFs). Layout is confined to `talker_alias_standard.go` with a documented working model, so a spec correction is a one-file change. The assembler is tolerant — when HEADER's declared length is 0, `cleanAlias` strips trailing non-printable bytes; when it's non-zero, the assembler trims to that length.

## Test plan

- [x] `go test ./internal/radio/p25/phase1/...` — 8 new tests cover HEADER+BLOCK1+BLOCK2 emission, length trimming, zero-length stripping, ordering (BLOCK1 alone → no emit), no-double-emit on LC repeat, new-HEADER reset of in-flight BLOCK state, stale eviction, and Reset clearing the dedupe fingerprint.
- [x] `go test ./internal/voice/composer/...` — existing composer tests still green; the dispatch hook is additive.
- [x] `go vet ./...` clean.
- [x] `go test ./...` clean.
- [x] `(cd web && npx tsc --noEmit && npm test)` — 95 tests pass.

https://claude.ai/code/session_011Ar859fjM1XMxv96MBogPo

---
_Generated by [Claude Code](https://claude.ai/code/session_011Ar859fjM1XMxv96MBogPo)_