### PR TITLE
aprs: AX.25 frame parser + APRS info-field decoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ for tagged releases.
 
 ### Added
 
+- **AX.25 frame parser + APRS info-field decoder.** Third slice
+  of Phase 5 (#365), the protocol layer that plugs into the
+  bus/log/REST/UI scaffolding from #384. Pure-Go AX.25 frame
+  parser (`internal/radio/aprs/ax25`): 7-byte address packing,
+  up to 8 digipeater path entries, HDLC CRC-16-CCITT validation,
+  conventional `W1AW-9` / `WIDE2-1*` display helpers. Plus an
+  APRS info-field decoder (`internal/radio/aprs`) for positions
+  (`!`, `=`, `/`, `@`), messages (`:`) with ack/rej + bulletins,
+  status (`>`); Mic-E / weather / telemetry / object types are
+  type-tagged with payloads stashed for follow-up decoders. The
+  DSP receiver (Bell-202 AFSK demod → HDLC de-stuff → frame
+  delivery → bus event) is the next focused PR. See
+  [docs/aprs.md](docs/aprs.md).
 - **Radio IDs as first-class entities (#387, #376).** New
   `trunking.RIDDB` operator-configured alias catalogue mirroring
   `TalkgroupDB`: per-system `rid_alias_file` (CSV or JSON, dispatched

--- a/docs/aprs.md
+++ b/docs/aprs.md
@@ -57,15 +57,40 @@ pending" below.
 - Polls every 5 s. Frames with `fcs_ok = false` highlight in
   yellow as a marginal-signal indicator.
 
+## Protocol layer (`internal/radio/aprs`)
+
+Pure-Go AX.25 frame parser + APRS info-field decoder that turn
+bit-de-stuffed AX.25 frames into the `events.KindAPRSPacket`
+payload the bus / log / REST / UI scaffolding above expects.
+
+- **`internal/radio/aprs/ax25`** — AX.25 UI-frame parser:
+  7-byte address packing with the spec's bit-shifted ASCII
+  callsigns, up to 8 digipeater path entries, HDLC CRC-16-CCITT
+  validation via the standard 0x8408 reflected-bit polynomial,
+  conventional `W1AW-9` / `WIDE2-1*` display helpers. HBit
+  handling is only meaningful for path entries; dst + src use
+  that bit position for the C-bit (Command/Response indicator),
+  which the APRS console convention ignores.
+- **`internal/radio/aprs`** — info-field decoder. Recognised
+  packet types (data-type indicator → decoded fields):
+  - `!` / `=` — position without timestamp; messaging flag set
+    on `=`
+  - `/` / `@` — position with raw 7-char timestamp; messaging
+    flag set on `@`
+  - `:` — message (9-char trimmed addressee, body, optional
+    `{seqno}`, `ack` / `rej` short-form) or bulletin
+    (`BLN`-prefixed addressee → `Bulletin` struct)
+  - `>` — status (free-text)
+  - `;` / `_` / `T#` / Mic-E — type-tagged with payloads
+    stashed for follow-up decoders
+  - anything else — `TypeUnknown`, raw bytes preserved
+- Position parsing covers both hemispheres (N/S, E/W), the
+  spec's "ambiguity space" convention (low-precision digits as
+  space — treated as 0), and the standard `DDMM.hhH` /
+  `DDDMM.hhH` hundredths-of-a-minute encoding.
+
 ## What's pending
 
-- **AX.25 frame parser + APRS info-field decoder.** Pure-Go
-  parsers that turn bit-de-stuffed AX.25 frames into the
-  `events.KindAPRSPacket` payload this pipeline expects. Mirrors
-  the POCSAG protocol-layer split (#372 → #373) — the bus / log
-  / REST / UI ship in their own PR (this one) so the protocol
-  layer can be reviewed against its own concerns. Until that
-  ships, no events fire and the panel stays at the empty state.
 - **DSP receiver.** 1200 Bd Bell-202 AFSK demodulation, HDLC
   bit-stuffing reversal, 0x7E flag-delimited frame extraction.
   Plugs into the AX.25 parser the moment both pieces land.

--- a/internal/radio/aprs/aprs.go
+++ b/internal/radio/aprs/aprs.go
@@ -1,0 +1,345 @@
+// Package aprs decodes the APRS info-field payload that rides on
+// top of AX.25 (the link layer in package aprs/ax25). APRS is a
+// huge, semi-formal protocol — the spec covers position, weather,
+// message, telemetry, status, object, item, query, and bulletin
+// formats, plus all the trailing-comment compressed variants.
+//
+// This package handles the operator-visible majority: position
+// reports (uncompressed lat/lon NMEA-style), messages, status, and
+// bulletins. Mic-E / weather / telemetry / object are recognised
+// by their data-type indicator (DTI) byte but full decoders for
+// those land in follow-ups.
+//
+// Spec references:
+//   - APRS Protocol Reference 1.0.1 (1998-08-07).
+//     http://www.aprs.org/doc/APRS101.PDF
+//   - aprs.fi parser source code as cross-check for the messy
+//     real-world variants the spec doesn't quite pin down.
+package aprs
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// PacketType is what the info field's first byte / leading pattern
+// identifies the payload as. APRS uses an inline data-type
+// indicator (DTI) byte for everything except the comment-only
+// case; the parser dispatches on it.
+type PacketType uint8
+
+const (
+	TypeUnknown   PacketType = iota
+	TypePosition             // "!" / "=" / "/" / "@" prefixed lat/lon
+	TypeStatus               // ">" prefixed free-text
+	TypeMessage              // ":" addressee + ":" body
+	TypeObject               // ";" — like position but for a named object
+	TypeMicE                 // 0x1C / 0x1D / "'" / "`" — Mic-E compressed
+	TypeWeather              // "_" / "#" / "*" — full weather report
+	TypeTelemetry            // "T#" prefix
+	TypeBulletin             // ":BLNxxxxx:" — addressed bulletin board
+)
+
+// TypeString returns a stable lowercase string label for a
+// PacketType — used as the column value on the aprs_log SQLite
+// table and the API DTO's `type` field.
+func TypeString(t PacketType) string {
+	switch t {
+	case TypePosition:
+		return "position"
+	case TypeStatus:
+		return "status"
+	case TypeMessage:
+		return "message"
+	case TypeObject:
+		return "object"
+	case TypeMicE:
+		return "mic-e"
+	case TypeWeather:
+		return "weather"
+	case TypeTelemetry:
+		return "telemetry"
+	case TypeBulletin:
+		return "bulletin"
+	}
+	return "unknown"
+}
+
+// Position is the decoded latitude / longitude payload from an
+// uncompressed position report. APRS encodes latitude as DDMM.hhH
+// (8 chars including the N/S hemisphere) and longitude as
+// DDDMM.hhH (9 chars including E/W). Both hundredths-of-a-minute
+// precision.
+type Position struct {
+	Latitude      float64
+	Longitude     float64
+	SymbolTable   byte
+	SymbolCode    byte
+	Comment       string
+	HasTimestamp  bool
+	TimestampRaw  string
+	WithMessaging bool // true for "=" and "@" (messaging-capable)
+}
+
+// Message is the decoded payload for the message format:
+// ":ADDRESSEE :body{seqno}".
+type Message struct {
+	Addressee string
+	Body      string
+	SeqNo     string
+	Ack       bool
+	Rej       bool
+}
+
+// Status is the decoded payload for the status format: ">body".
+type Status struct {
+	Text string
+}
+
+// Bulletin is the decoded payload for the bulletin format:
+// ":BLNxxxxxx:body".
+type Bulletin struct {
+	ID   string
+	Body string
+}
+
+// Packet is the decoded result of one APRS info field.
+type Packet struct {
+	Type     PacketType
+	Position *Position
+	Message  *Message
+	Status   *Status
+	Bulletin *Bulletin
+	Raw      string
+}
+
+// Decode parses one APRS info field and returns a typed Packet.
+// Never returns an error — unknown / malformed payloads come back
+// as Type=TypeUnknown with the raw bytes preserved on the Raw
+// field. APRS is messy; we surface what we can and pass through
+// the rest.
+func Decode(info []byte) Packet {
+	p := Packet{Raw: string(info)}
+	if len(info) == 0 {
+		return p
+	}
+	dti := info[0]
+	switch dti {
+	case '!':
+		if pos, ok := parseUncompressedPosition(string(info[1:]), false); ok {
+			p.Type = TypePosition
+			p.Position = &pos
+			return p
+		}
+	case '=':
+		if pos, ok := parseUncompressedPosition(string(info[1:]), true); ok {
+			p.Type = TypePosition
+			p.Position = &pos
+			return p
+		}
+	case '/':
+		if len(info) >= 8 {
+			ts := string(info[1:8])
+			if pos, ok := parseUncompressedPosition(string(info[8:]), false); ok {
+				pos.HasTimestamp = true
+				pos.TimestampRaw = ts
+				p.Type = TypePosition
+				p.Position = &pos
+				return p
+			}
+		}
+	case '@':
+		if len(info) >= 8 {
+			ts := string(info[1:8])
+			if pos, ok := parseUncompressedPosition(string(info[8:]), true); ok {
+				pos.HasTimestamp = true
+				pos.TimestampRaw = ts
+				p.Type = TypePosition
+				p.Position = &pos
+				return p
+			}
+		}
+	case ':':
+		if msg, bln, isBulletin, ok := parseMessage(string(info[1:])); ok {
+			if isBulletin {
+				p.Type = TypeBulletin
+				p.Bulletin = bln
+			} else {
+				p.Type = TypeMessage
+				p.Message = msg
+			}
+			return p
+		}
+	case '>':
+		p.Type = TypeStatus
+		p.Status = &Status{Text: string(info[1:])}
+		return p
+	case ';':
+		p.Type = TypeObject
+		return p
+	case 0x1C, 0x1D, '`', '\'':
+		p.Type = TypeMicE
+		return p
+	case '_':
+		p.Type = TypeWeather
+		return p
+	case 'T':
+		if len(info) >= 2 && info[1] == '#' {
+			p.Type = TypeTelemetry
+			return p
+		}
+	}
+	return p
+}
+
+func parseUncompressedPosition(s string, withMsg bool) (Position, bool) {
+	if len(s) < 19 {
+		return Position{}, false
+	}
+	latStr := s[0:8]
+	symTable := s[8]
+	lonStr := s[9:18]
+	symCode := s[18]
+	comment := s[19:]
+
+	lat, ok := parseLatLon(latStr, true)
+	if !ok {
+		return Position{}, false
+	}
+	lon, ok := parseLatLon(lonStr, false)
+	if !ok {
+		return Position{}, false
+	}
+	return Position{
+		Latitude:      lat,
+		Longitude:     lon,
+		SymbolTable:   symTable,
+		SymbolCode:    symCode,
+		Comment:       comment,
+		WithMessaging: withMsg,
+	}, true
+}
+
+// parseLatLon decodes a DDMM.hhH (latitude) or DDDMM.hhH
+// (longitude) string into decimal degrees. Negative south /
+// west. APRS supports "ambiguity spaces" — digit positions sent
+// as space to indicate reduced precision; treat as 0.
+func parseLatLon(s string, isLat bool) (float64, bool) {
+	wantLen := 8
+	degDigits := 2
+	if !isLat {
+		wantLen = 9
+		degDigits = 3
+	}
+	if len(s) != wantLen {
+		return 0, false
+	}
+	clean := []byte(s)
+	for i := 0; i < degDigits+4; i++ {
+		if clean[i] == ' ' {
+			clean[i] = '0'
+		}
+	}
+	if clean[degDigits+2] != '.' {
+		return 0, false
+	}
+	deg, err := strconv.ParseFloat(string(clean[:degDigits]), 64)
+	if err != nil {
+		return 0, false
+	}
+	min, err := strconv.ParseFloat(
+		string(clean[degDigits:degDigits+2])+"."+string(clean[degDigits+3:degDigits+5]),
+		64)
+	if err != nil {
+		return 0, false
+	}
+	val := deg + min/60
+	hemi := clean[wantLen-1]
+	if isLat {
+		switch hemi {
+		case 'N':
+		case 'S':
+			val = -val
+		default:
+			return 0, false
+		}
+	} else {
+		switch hemi {
+		case 'E':
+		case 'W':
+			val = -val
+		default:
+			return 0, false
+		}
+	}
+	return val, true
+}
+
+func parseMessage(s string) (*Message, *Bulletin, bool, bool) {
+	if len(s) < 10 || s[9] != ':' {
+		return nil, nil, false, false
+	}
+	addr := strings.TrimRight(s[0:9], " ")
+	body := s[10:]
+	if strings.HasPrefix(addr, "BLN") {
+		return nil, &Bulletin{ID: addr, Body: body}, true, true
+	}
+	msg := &Message{Addressee: addr, Body: body}
+	if i := strings.LastIndex(body, "{"); i >= 0 && strings.HasSuffix(body, "}") {
+		msg.SeqNo = body[i+1 : len(body)-1]
+		msg.Body = body[:i]
+	}
+	if strings.HasPrefix(msg.Body, "ack") {
+		msg.Ack = true
+		msg.SeqNo = msg.Body[3:]
+		msg.Body = ""
+	} else if strings.HasPrefix(msg.Body, "rej") {
+		msg.Rej = true
+		msg.SeqNo = msg.Body[3:]
+		msg.Body = ""
+	}
+	return msg, nil, false, true
+}
+
+// String renders the packet for log / panel display.
+func (p Packet) String() string {
+	switch p.Type {
+	case TypePosition:
+		if p.Position == nil {
+			break
+		}
+		return fmt.Sprintf("POSITION %.4f,%.4f %q",
+			p.Position.Latitude, p.Position.Longitude, p.Position.Comment)
+	case TypeMessage:
+		if p.Message == nil {
+			break
+		}
+		if p.Message.Ack {
+			return fmt.Sprintf("ACK to %s seq=%s", p.Message.Addressee, p.Message.SeqNo)
+		}
+		if p.Message.Rej {
+			return fmt.Sprintf("REJ to %s seq=%s", p.Message.Addressee, p.Message.SeqNo)
+		}
+		return fmt.Sprintf("MSG to %s: %q", p.Message.Addressee, p.Message.Body)
+	case TypeStatus:
+		if p.Status == nil {
+			break
+		}
+		return fmt.Sprintf("STATUS %q", p.Status.Text)
+	case TypeBulletin:
+		if p.Bulletin == nil {
+			break
+		}
+		return fmt.Sprintf("BULLETIN %s: %q", p.Bulletin.ID, p.Bulletin.Body)
+	case TypeMicE:
+		return "MIC-E (compressed; decoder pending)"
+	case TypeWeather:
+		return "WEATHER " + p.Raw
+	case TypeTelemetry:
+		return "TELEMETRY " + p.Raw
+	case TypeObject:
+		return "OBJECT " + p.Raw
+	}
+	return "UNKNOWN " + p.Raw
+}

--- a/internal/radio/aprs/aprs_test.go
+++ b/internal/radio/aprs/aprs_test.go
@@ -1,0 +1,141 @@
+package aprs
+
+import (
+	"math"
+	"testing"
+)
+
+func TestDecodeUncompressedPositionNoTimestampNoMsg(t *testing.T) {
+	info := []byte("!4903.50N/07201.75W-Test 001234")
+	p := Decode(info)
+	if p.Type != TypePosition {
+		t.Fatalf("Type = %v, want TypePosition", p.Type)
+	}
+	if p.Position == nil {
+		t.Fatal("Position is nil")
+	}
+	if math.Abs(p.Position.Latitude-49.0583) > 1e-3 {
+		t.Errorf("lat = %f", p.Position.Latitude)
+	}
+	if math.Abs(p.Position.Longitude+72.0292) > 1e-3 {
+		t.Errorf("lon = %f", p.Position.Longitude)
+	}
+	if p.Position.SymbolTable != '/' || p.Position.SymbolCode != '-' {
+		t.Errorf("symbol = %c%c", p.Position.SymbolTable, p.Position.SymbolCode)
+	}
+	if p.Position.Comment != "Test 001234" {
+		t.Errorf("comment = %q", p.Position.Comment)
+	}
+}
+
+func TestDecodeUncompressedPositionWithMessaging(t *testing.T) {
+	p := Decode([]byte("=4903.50N/07201.75W-"))
+	if p.Type != TypePosition || !p.Position.WithMessaging {
+		t.Errorf("WithMessaging = false on '='")
+	}
+}
+
+func TestDecodeSouthernAndWesternHemisphere(t *testing.T) {
+	p := Decode([]byte("!3354.40S/15110.20W>"))
+	if p.Position.Latitude > 0 || p.Position.Longitude > 0 {
+		t.Errorf("expected negative S/W: %+v", p.Position)
+	}
+}
+
+func TestDecodePositionWithTimestamp(t *testing.T) {
+	p := Decode([]byte("/092345z4903.50N/07201.75W-"))
+	if p.Type != TypePosition {
+		t.Fatalf("Type = %v", p.Type)
+	}
+	if !p.Position.HasTimestamp || p.Position.TimestampRaw != "092345z" {
+		t.Errorf("timestamp = %+v", p.Position)
+	}
+}
+
+func TestDecodeMessage(t *testing.T) {
+	p := Decode([]byte(":W1AW-1   :Hello from W2XYZ{42}"))
+	if p.Type != TypeMessage {
+		t.Fatalf("Type = %v", p.Type)
+	}
+	if p.Message.Addressee != "W1AW-1" || p.Message.Body != "Hello from W2XYZ" || p.Message.SeqNo != "42" {
+		t.Errorf("Message = %+v", p.Message)
+	}
+}
+
+func TestDecodeMessageAck(t *testing.T) {
+	p := Decode([]byte(":W1AW-1   :ack42"))
+	if !p.Message.Ack || p.Message.SeqNo != "42" {
+		t.Errorf("Message = %+v", p.Message)
+	}
+}
+
+func TestDecodeStatus(t *testing.T) {
+	p := Decode([]byte(">Net control on 146.52"))
+	if p.Type != TypeStatus || p.Status.Text != "Net control on 146.52" {
+		t.Errorf("Status = %+v", p.Status)
+	}
+}
+
+func TestDecodeBulletin(t *testing.T) {
+	p := Decode([]byte(":BLN1     :Weekly net Tuesday"))
+	if p.Type != TypeBulletin || p.Bulletin.ID != "BLN1" {
+		t.Errorf("Bulletin = %+v", p.Bulletin)
+	}
+}
+
+func TestDecodeMicE(t *testing.T) {
+	p := Decode([]byte("`micE payload"))
+	if p.Type != TypeMicE {
+		t.Errorf("Type = %v, want TypeMicE", p.Type)
+	}
+}
+
+func TestDecodeUnknownLeavesRawIntact(t *testing.T) {
+	p := Decode([]byte("xxxxxx unknown payload"))
+	if p.Type != TypeUnknown || p.Raw != "xxxxxx unknown payload" {
+		t.Errorf("packet = %+v", p)
+	}
+}
+
+func TestDecodeEmptyInfoSafe(t *testing.T) {
+	p := Decode(nil)
+	if p.Type != TypeUnknown || p.Raw != "" {
+		t.Errorf("packet = %+v", p)
+	}
+}
+
+func TestPacketStringSwitchesOnType(t *testing.T) {
+	for _, c := range []struct {
+		info string
+		want string
+	}{
+		{"!4903.50N/07201.75W-Test", "POSITION 49.0583,-72.0292 \"Test\""},
+		{":W1AW-1   :Hi there", "MSG to W1AW-1: \"Hi there\""},
+		{":W1AW-1   :ack9", "ACK to W1AW-1 seq=9"},
+		{">on the net", "STATUS \"on the net\""},
+	} {
+		got := Decode([]byte(c.info)).String()
+		if got != c.want {
+			t.Errorf("Decode(%q).String() = %q, want %q", c.info, got, c.want)
+		}
+	}
+}
+
+func TestTypeString(t *testing.T) {
+	cases := map[PacketType]string{
+		TypePosition:  "position",
+		TypeMessage:   "message",
+		TypeStatus:    "status",
+		TypeBulletin:  "bulletin",
+		TypeObject:    "object",
+		TypeMicE:      "mic-e",
+		TypeWeather:   "weather",
+		TypeTelemetry: "telemetry",
+		TypeUnknown:   "unknown",
+	}
+	for k, want := range cases {
+		if got := TypeString(k); got != want {
+			t.Errorf("TypeString(%d) = %q, want %q", k, got, want)
+		}
+	}
+}

--- a/internal/radio/aprs/ax25/frame.go
+++ b/internal/radio/aprs/ax25/frame.go
@@ -1,0 +1,216 @@
+// Package ax25 decodes the AX.25 link-layer frames APRS rides on top
+// of. AX.25 is a HDLC-derived frame format used by amateur packet
+// radio — modern terrestrial use is dominated by APRS (Automatic
+// Packet Reporting System) on the North-American 144.39 MHz channel,
+// the European 144.800 MHz channel, and other regional allocations.
+//
+// Frame structure (numbers are bytes):
+//
+//	+-----+-----+-----+-----+--------+--------+--------+
+//	| dst | src |  path (0..8)       | control |  PID  |
+//	|  7  |  7  | 0 .. 56            |    1    |   1   |
+//	+-----+-----+-----+-----+--------+--------+--------+
+//	|        info (0..256)            |   FCS (CRC-16) |
+//	|             bytes               |       2 bytes  |
+//	+---------------------------------+----------------+
+//
+// Each address is 6 bytes of base-40 callsign + 1 byte SSID/flags.
+// The path lists digipeaters; the last byte of the LAST address has
+// its bit 0 set ("end of address list") to terminate the chain. FCS
+// is HDLC-style CRC-16-CCITT over the address+control+PID+info
+// bytes.
+//
+// This package handles AX.25 frame parsing only; the on-air bit-
+// stuffing / 0x7E flag delimiting / NRZI decoding happens one layer
+// up (in the DSP receiver). The APRS info-field interpretation
+// happens one layer further up (in package aprs).
+package ax25
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// Address is one entry in the {dst, src, path…} chain. AX.25 packs
+// each as 6 bytes of left-justified callsign (each byte shifted
+// left 1 — bit 0 of every callsign byte is reserved as the HDLC
+// "extension" flag) plus 1 byte carrying the SSID, the H/R bits,
+// and the end-of-address sentinel.
+type Address struct {
+	Callsign string // 0..6 ASCII chars, trailing spaces stripped
+	SSID     uint8  // 0..15
+	// HBit is the "has been digipeated" flag (bit 7 of the SSID
+	// byte for path entries). Only meaningful for digipeater
+	// path entries — dst + src use bit 7 as the C-bit
+	// (Command/Response indicator) which the APRS console
+	// convention ignores.
+	HBit bool
+}
+
+// String returns the conventional CALLSIGN-SSID format
+// (e.g. "W1AW-9"), or just "CALLSIGN" when SSID is 0. Suffix "*"
+// is appended when HBit is set — APRS console convention.
+func (a Address) String() string {
+	s := a.Callsign
+	if a.SSID != 0 {
+		s += fmt.Sprintf("-%d", a.SSID)
+	}
+	if a.HBit {
+		s += "*"
+	}
+	return s
+}
+
+// Frame is one decoded AX.25 frame.
+type Frame struct {
+	Dst     Address
+	Src     Address
+	Path    []Address
+	Control uint8
+	PID     uint8
+	Info    []byte
+	// FCSOK reports whether the CRC trailing the frame matched.
+	// Set by Parse; callers should drop frames where FCSOK is
+	// false unless they're explicitly studying noise.
+	FCSOK bool
+}
+
+// Errors returned by Parse.
+var (
+	ErrFrameTooShort = errors.New("ax25: frame body shorter than minimum (16 bytes)")
+	ErrBadAddress    = errors.New("ax25: address chain malformed (no end-of-address flag in first 10 entries)")
+)
+
+// MinFrameBytes is dst (7) + src (7) + control (1) + PID (1) +
+// FCS (2) = 18 bytes. A frame shorter than this can't possibly be
+// well-formed.
+const MinFrameBytes = 18
+
+// MaxPathEntries is the AX.25 spec limit on digipeater addresses.
+const MaxPathEntries = 8
+
+// Parse decodes one bit-stuffed-and-flag-stripped AX.25 frame body.
+// The input MUST be the byte stream that landed between two 0x7E
+// HDLC flag bytes, after NRZI decoding and de-bit-stuffing. The
+// trailing 2 bytes are the FCS; Parse validates them and reports
+// FCSOK accordingly.
+//
+// Returns the decoded Frame plus a nil error on structural
+// success; FCSOK on the returned frame distinguishes CRC-clean
+// frames from CRC-failed ones. A structural error (too short,
+// malformed address chain) is returned as the second value.
+func Parse(body []byte) (Frame, error) {
+	if len(body) < MinFrameBytes {
+		return Frame{}, ErrFrameTooShort
+	}
+	addresses := make([]Address, 0, 2+MaxPathEntries)
+	off := 0
+	endFound := false
+	for i := 0; i < 2+MaxPathEntries; i++ {
+		if off+7 > len(body) {
+			return Frame{}, ErrBadAddress
+		}
+		raw := body[off : off+7]
+		// HBit only for path entries (i >= 2). Dst + src use that
+		// bit position for the C-bit (Command/Response), which the
+		// APRS console convention ignores.
+		addr := parseAddress(raw, i >= 2)
+		addresses = append(addresses, addr)
+		off += 7
+		if raw[6]&0x01 != 0 {
+			endFound = true
+			break
+		}
+	}
+	if !endFound || len(addresses) < 2 {
+		return Frame{}, ErrBadAddress
+	}
+	if len(body)-off < 4 {
+		return Frame{}, ErrFrameTooShort
+	}
+	control := body[off]
+	off++
+	pid := body[off]
+	off++
+	if len(body)-off < 2 {
+		return Frame{}, ErrFrameTooShort
+	}
+	infoEnd := len(body) - 2
+	info := append([]byte(nil), body[off:infoEnd]...)
+	fcsBytes := body[infoEnd:]
+
+	calc := computeFCS(body[:infoEnd])
+	wireFCS := uint16(fcsBytes[0]) | uint16(fcsBytes[1])<<8
+	return Frame{
+		Dst:     addresses[0],
+		Src:     addresses[1],
+		Path:    addresses[2:],
+		Control: control,
+		PID:     pid,
+		Info:    info,
+		FCSOK:   calc == wireFCS,
+	}, nil
+}
+
+// parseAddress unpacks one 7-byte address entry.
+func parseAddress(raw []byte, isPathEntry bool) Address {
+	var cs strings.Builder
+	for i := 0; i < 6; i++ {
+		c := raw[i] >> 1
+		if c == ' ' || c == 0 {
+			break
+		}
+		cs.WriteByte(c)
+	}
+	ssidByte := raw[6]
+	ssid := (ssidByte >> 1) & 0x0F
+	hbit := isPathEntry && ssidByte&0x80 != 0
+	return Address{
+		Callsign: strings.TrimRight(cs.String(), " "),
+		SSID:     ssid,
+		HBit:     hbit,
+	}
+}
+
+// computeFCS computes the HDLC CRC-16-CCITT over the supplied
+// bytes. The reflected-bit polynomial is 0x8408; the running
+// register is initialised to 0xFFFF and inverted at the end. The
+// transmitted FCS bytes are the inverted-and-byte-swapped form,
+// so a clean frame produces the magic residue 0xF0B8 when the
+// CRC is run over body+FCS. We compute it over body only and
+// compare against the wire-form FCS directly.
+func computeFCS(data []byte) uint16 {
+	crc := uint16(0xFFFF)
+	for _, b := range data {
+		crc ^= uint16(b)
+		for i := 0; i < 8; i++ {
+			if crc&1 != 0 {
+				crc = (crc >> 1) ^ 0x8408
+			} else {
+				crc >>= 1
+			}
+		}
+	}
+	return ^crc
+}
+
+// IsUI reports whether this is a UI (Unnumbered Information)
+// frame — the only frame type APRS uses on the wire. Control byte
+// 0x03, PID 0xF0 ("no layer 3 protocol").
+func (f Frame) IsUI() bool {
+	return f.Control == 0x03 && f.PID == 0xF0
+}
+
+// PathString renders the digipeater path in APRS console form
+// (e.g. "WIDE1-1,WIDE2-1*"). Empty path returns the empty string.
+func (f Frame) PathString() string {
+	if len(f.Path) == 0 {
+		return ""
+	}
+	parts := make([]string, len(f.Path))
+	for i, a := range f.Path {
+		parts[i] = a.String()
+	}
+	return strings.Join(parts, ",")
+}

--- a/internal/radio/aprs/ax25/frame_test.go
+++ b/internal/radio/aprs/ax25/frame_test.go
@@ -1,0 +1,171 @@
+package ax25
+
+import (
+	"bytes"
+	"testing"
+)
+
+// encodeAddress packs an Address into the 7-byte AX.25 wire format.
+// Test helper — mirrors what a transmitter does.
+func encodeAddress(a Address, last, hOrC bool) []byte {
+	out := make([]byte, 7)
+	cs := a.Callsign
+	for len(cs) < 6 {
+		cs += " "
+	}
+	for i := 0; i < 6; i++ {
+		out[i] = cs[i] << 1
+	}
+	ssid := byte(0b01100000) // reserved bits 5 + 6 set per the spec
+	ssid |= (a.SSID & 0x0F) << 1
+	if hOrC {
+		ssid |= 0x80
+	}
+	if last {
+		ssid |= 0x01
+	}
+	out[6] = ssid
+	return out
+}
+
+// buildFrame assembles a fully-formed AX.25 frame body and appends
+// a correct FCS.
+func buildFrame(t *testing.T, dst, src Address, path []Address, control, pid byte, info []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	buf.Write(encodeAddress(dst, false, false))
+	buf.Write(encodeAddress(src, len(path) == 0, true))
+	for i, p := range path {
+		last := i == len(path)-1
+		buf.Write(encodeAddress(p, last, p.HBit))
+	}
+	buf.WriteByte(control)
+	buf.WriteByte(pid)
+	buf.Write(info)
+	fcs := computeFCS(buf.Bytes())
+	buf.WriteByte(byte(fcs & 0xFF))
+	buf.WriteByte(byte(fcs >> 8))
+	return buf.Bytes()
+}
+
+func TestParseRoundTrip(t *testing.T) {
+	dst := Address{Callsign: "APRS", SSID: 0}
+	src := Address{Callsign: "W1AW", SSID: 9}
+	path := []Address{
+		{Callsign: "WIDE1", SSID: 1, HBit: false},
+		{Callsign: "WIDE2", SSID: 1, HBit: true},
+	}
+	info := []byte(`!4903.50N/07201.75W-Test`)
+	body := buildFrame(t, dst, src, path, 0x03, 0xF0, info)
+
+	f, err := Parse(body)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if !f.FCSOK {
+		t.Error("FCSOK = false on clean frame; want true")
+	}
+	if f.Src.String() != "W1AW-9" {
+		t.Errorf("src = %q, want W1AW-9", f.Src.String())
+	}
+	if !f.IsUI() {
+		t.Error("IsUI() = false on UI/PID-0xF0 frame")
+	}
+	if got := f.PathString(); got != "WIDE1-1,WIDE2-1*" {
+		t.Errorf("PathString = %q, want WIDE1-1,WIDE2-1*", got)
+	}
+	if !bytes.Equal(f.Info, info) {
+		t.Errorf("info mismatch")
+	}
+}
+
+func TestParseDetectsCorruptedFCS(t *testing.T) {
+	body := buildFrame(t,
+		Address{Callsign: "APRS"},
+		Address{Callsign: "W1AW", SSID: 9},
+		nil, 0x03, 0xF0, []byte("test"))
+	body[len(body)-3] ^= 0x80
+	f, err := Parse(body)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if f.FCSOK {
+		t.Error("FCSOK = true after bit-flip; want false")
+	}
+}
+
+func TestParseRejectsTooShort(t *testing.T) {
+	if _, err := Parse(make([]byte, 10)); err != ErrFrameTooShort {
+		t.Errorf("Parse(short) = %v, want ErrFrameTooShort", err)
+	}
+}
+
+func TestParseRejectsMissingEndOfAddress(t *testing.T) {
+	var buf bytes.Buffer
+	buf.Write(encodeAddress(Address{Callsign: "APRS"}, false, false))
+	buf.Write(encodeAddress(Address{Callsign: "W1AW", SSID: 9}, false, true))
+	for i := 0; i < 9; i++ {
+		buf.Write(encodeAddress(Address{Callsign: "DIGI", SSID: uint8(i)}, false, false))
+	}
+	buf.WriteByte(0x03)
+	buf.WriteByte(0xF0)
+	buf.WriteByte(0x00)
+	buf.WriteByte(0x00)
+	if _, err := Parse(buf.Bytes()); err != ErrBadAddress {
+		t.Errorf("Parse(no-end) = %v, want ErrBadAddress", err)
+	}
+}
+
+func TestAddressStringFormats(t *testing.T) {
+	for _, c := range []struct {
+		a    Address
+		want string
+	}{
+		{Address{Callsign: "W1AW", SSID: 0}, "W1AW"},
+		{Address{Callsign: "W1AW", SSID: 9}, "W1AW-9"},
+		{Address{Callsign: "WIDE2", SSID: 1, HBit: true}, "WIDE2-1*"},
+	} {
+		if got := c.a.String(); got != c.want {
+			t.Errorf("%+v.String() = %q, want %q", c.a, got, c.want)
+		}
+	}
+}
+
+func TestParseTrimsCallsignSpaces(t *testing.T) {
+	body := buildFrame(t,
+		Address{Callsign: "AB"},
+		Address{Callsign: "CD", SSID: 3},
+		nil, 0x03, 0xF0, []byte(""))
+	f, err := Parse(body)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if f.Dst.Callsign != "AB" || f.Src.Callsign != "CD" {
+		t.Errorf("dst.Callsign=%q src.Callsign=%q", f.Dst.Callsign, f.Src.Callsign)
+	}
+}
+
+func TestPathStringEmpty(t *testing.T) {
+	body := buildFrame(t,
+		Address{Callsign: "APRS"},
+		Address{Callsign: "W1AW"},
+		nil, 0x03, 0xF0, []byte(""))
+	f, _ := Parse(body)
+	if got := f.PathString(); got != "" {
+		t.Errorf("PathString = %q, want \"\"", got)
+	}
+}
+
+func TestNonUIFrameRecognised(t *testing.T) {
+	body := buildFrame(t,
+		Address{Callsign: "DEST"},
+		Address{Callsign: "SRC"},
+		nil, 0x00, 0xCC, []byte(""))
+	f, err := Parse(body)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if f.IsUI() {
+		t.Error("IsUI() = true on I-frame; want false")
+	}
+}


### PR DESCRIPTION
## Summary

Third slice of **Phase 5** of the trunking-adjacent feature plan (#365): the **protocol layer** that turns AX.25 bytes into the `events.KindAPRSPacket` payload the bus/log/REST/UI scaffolding from #384 expects. Pure-Go parsers with thorough unit tests; the DSP receiver (Bell-202 AFSK demod → HDLC de-stuff → frame delivery) is the next focused PR.

## What's in the box

### `internal/radio/aprs/ax25` — AX.25 UI-frame parser

- 7-byte address packing with the spec's bit-shifted ASCII callsigns (each char `<< 1` in the wire byte; bit 0 reserved for the HDLC extension flag)
- Up to 8 digipeater path entries past the source address
- Control + PID byte parsing (UI is the only frame APRS uses; parser passes other types through)
- **HDLC CRC-16-CCITT** validation via the standard 0x8408 reflected-bit polynomial; `Frame.FCSOK` distinguishes clean vs. CRC-failed frames
- Display helpers matching APRS console convention: `Address.String()` → `"W1AW-9"` or `"WIDE2-1*"`, `Frame.PathString()` → `"WIDE1-1,WIDE2-1*"`
- HBit handling: only meaningful for path entries; dst + src use that bit position for the C-bit (Command/Response indicator) which the APRS console convention ignores

### `internal/radio/aprs` — info-field decoder

| DTI byte | Type | Decoded fields |
| --- | --- | --- |
| `!` / `=` | Position (no timestamp) | lat/lon, symbol pair, comment, messaging flag (`=`) |
| `/` / `@` | Position (timestamp) | + raw 7-char timestamp + messaging flag (`@`) |
| `:` | Message / Bulletin | 9-char addressee, body, seqno, ack/rej |
| `>` | Status | free-text |
| `;` / `_` / `T#` / Mic-E | type-tagged | payloads stashed for follow-up decoders |
| anything else | `TypeUnknown` | raw bytes preserved |

- **Position**: both hemispheres (N/S, E/W), `DDMM.hhH` / `DDDMM.hhH` hundredths-of-a-minute encoding, ambiguity-space tolerance (spec allows low-precision digits as spaces — treated as 0)
- **Message**: 9-char trimmed addressee, optional `{NNN}` seqno, `ack` / `rej` short-form bodies (body becomes seqno), bulletin routing (`BLN`-prefixed addressee → `Bulletin` struct)
- **`TypeString()`** — canonical lowercase label (`"position"` / `"message"` / `"status"` / `"bulletin"` / `"weather"` / `"telemetry"` / `"object"` / `"mic-e"` / `"unknown"`) matching the column value on `aprs_log` and the API DTO's `type` field

## Tests

- **8 AX.25 tests**: happy-path round-trip, CRC corruption detection, malformed-address rejection, callsign space-trim, address-format helpers, empty path rendering, non-UI frame recognition, too-short rejection
- **12 APRS tests**: position with/without messaging, with/without timestamp, southern + western hemisphere, message+ack+bulletin, status, Mic-E recognition, unknown payload pass-through, empty info safety, `Packet.String()` switch, `TypeString()` coverage

All clean: **90 Go packages pass** (was 87 — new `internal/radio/aprs` + `internal/radio/aprs/ax25`), `go vet` clean, `gofmt -l .` clean.

## How this composes with the rest of the APRS pipeline

After this PR + the scaffolding from #384, the only missing piece is the DSP receiver. The end-to-end shape is:

```
SDR → iqtap broker → AFSK demod → HDLC de-stuff → ax25.Parse(body)
   → aprs.Decode(frame.Info) → storage.APRSPacket
   → bus.Publish(KindAPRSPacket) → APRSLog.insert → /api/v1/aprs/packets → /aprs panel
```

This PR ships `ax25.Parse` + `aprs.Decode`; #384 shipped the bus event + `APRSLog` + REST + panel. The DSP receiver glues them together.

## Docs

- **`docs/aprs.md`** — new "Protocol layer" section detailing the parsers; "What's pending" narrows from `{protocol + DSP + Mic-E + live map}` to `{DSP + Mic-E + live map}`
- **`CHANGELOG.md`** — `[Unreleased]` → Added (above the radio-IDs entry from #387)

## Test plan

- [x] `go test ./...` — 90 packages pass
- [x] `go vet ./...` clean
- [x] `gofmt -l .` clean
- [x] `go build ./...` succeeds
- [ ] End-to-end with a real captured APRS packet (deferred to the DSP follow-up PR)

## Status of the 7-phase plan

- ✅ Phase 0, 1, 2a, 2b, 2c, 4, 6 — shipped (PRs #365–#371)
- ✅ Phase 3 protocol (#372) + syncer/bus/log/REST/UI (#373) + DSP+daemon wiring (#378)
- ✅ Phase 5 scaffolding (#384) + protocol layer (this PR)
- ⏳ Phase 5 DSP receiver + Mic-E + live map; DSC/AIS/ADS-B; Phase 3 FLEX + multi-channel DDC; Phase 1 TUI; Phase 7 (M17+Codec2) — each warrants a dedicated PR

https://claude.ai/code/session_01YUgvat8WpF5YaSuEAqWMr2

---
_Generated by [Claude Code](https://claude.ai/code/session_01YUgvat8WpF5YaSuEAqWMr2)_