### PR TITLE
api: add PatchDTO so CC Activity renders super-group + members (issue #374)

### DIFF
--- a/internal/api/sse.go
+++ b/internal/api/sse.go
@@ -97,6 +97,8 @@ func eventToDTO(ev events.Event) EventDTO {
 		dto.Payload = affiliationToDTO(p)
 	case trunking.UnitRegistration:
 		dto.Payload = unitRegistrationToDTO(p)
+	case trunking.Patch:
+		dto.Payload = patchToDTO(p)
 	default:
 		// Includes sdr.SDRStatus (already JSON-tagged) and any
 		// future payload types the api package hasn't grown an

--- a/internal/api/sse_test.go
+++ b/internal/api/sse_test.go
@@ -58,3 +58,29 @@ func TestEventToDTOUnitRegistrationJSON(t *testing.T) {
 		t.Errorf("registration JSON =\n  %s\nwant\n  %s", got, want)
 	}
 }
+
+// TestEventToDTOPatchJSON pins the wire shape of the patch event. The
+// values mirror the report in issue #374 so this test doubles as the
+// regression record for "CC Activity always shows super-group 0".
+func TestEventToDTOPatchJSON(t *testing.T) {
+	dto := eventToDTO(events.Event{
+		Kind: events.KindPatch,
+		Payload: trunking.Patch{
+			System:     "MMR",
+			Protocol:   "p25",
+			SuperGroup: 32301,
+			Members:    []uint32{32501},
+			Vendor:     "motorola",
+			Add:        true,
+		},
+	})
+	body, err := json.Marshal(dto.Payload)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	got := string(body)
+	want := `{"system":"MMR","protocol":"p25","super_group":32301,"members":[32501],"vendor":"motorola","add":true,"at":"0001-01-01T00:00:00Z"}`
+	if got != want {
+		t.Errorf("patch JSON =\n  %s\nwant\n  %s", got, want)
+	}
+}

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -285,6 +285,30 @@ func unitRegistrationToDTO(u trunking.UnitRegistration) UnitRegistrationDTO {
 	}
 }
 
+// PatchDTO mirrors trunking.Patch for SSE / REST consumers. Add=true is
+// a patch becoming active; Add=false is a cancel.
+type PatchDTO struct {
+	System     string    `json:"system"`
+	Protocol   string    `json:"protocol"`
+	SuperGroup uint32    `json:"super_group"`
+	Members    []uint32  `json:"members"`
+	Vendor     string    `json:"vendor,omitempty"`
+	Add        bool      `json:"add"`
+	At         time.Time `json:"at"`
+}
+
+func patchToDTO(p trunking.Patch) PatchDTO {
+	return PatchDTO{
+		System:     p.System,
+		Protocol:   p.Protocol,
+		SuperGroup: p.SuperGroup,
+		Members:    append([]uint32(nil), p.Members...),
+		Vendor:     p.Vendor,
+		Add:        p.Add,
+		At:         p.At,
+	}
+}
+
 // ActiveCallDTO mirrors trunking.ActiveCall for JSON.
 type ActiveCallDTO struct {
 	Grant        GrantDTO      `json:"grant"`

--- a/web/src/panels/CCActivity.test.tsx
+++ b/web/src/panels/CCActivity.test.tsx
@@ -163,6 +163,7 @@ describe("CCActivity panel", () => {
           system: "Metro P25",
           super_group: 999,
           members: [101, 102, 103],
+          add: true,
         },
       },
     ]);
@@ -172,6 +173,27 @@ describe("CCActivity panel", () => {
     expect(row!.textContent).toMatch(/Patch/);
     expect(row!.textContent).toMatch(/super-group 999/);
     expect(row!.textContent).toMatch(/3 members/);
+    expect(row!.textContent).toMatch(/· add/);
+  });
+
+  it("renders patch cancel events when add is false", () => {
+    setEvents([
+      {
+        kind: "patch",
+        timestamp: "2026-05-26T12:00:00Z",
+        payload: {
+          system: "Metro P25",
+          super_group: 999,
+          members: [101],
+          add: false,
+        },
+      },
+    ]);
+    renderPanel();
+    const row = screen.getByText("Metro P25").closest("tr");
+    expect(row).not.toBeNull();
+    expect(row!.textContent).toMatch(/super-group 999/);
+    expect(row!.textContent).toMatch(/· cancel/);
   });
 
   it("renders talker alias events", () => {

--- a/web/src/panels/CCActivity.tsx
+++ b/web/src/panels/CCActivity.tsx
@@ -216,7 +216,7 @@ function renderRow(ev: EventDTO, label: string): Row | null {
       const system = str(payload.system);
       const superGroup = num(payload.super_group ?? payload.regroup_id);
       const members = (payload.members ?? []) as unknown[];
-      const op = payload.cancelled || payload.removed ? "cancel" : "add";
+      const op = payload.add === false || payload.cancelled || payload.removed ? "cancel" : "add";
       const details =
         `super-group ${superGroup}` +
         (members.length ? ` · ${members.length} member${members.length === 1 ? "" : "s"}` : "") +


### PR DESCRIPTION
eventToDTO had no case for trunking.Patch, so the payload fell through
to default and was JSON-marshalled with Go's PascalCase names
(SuperGroup, Members, Add). The CC Activity panel reads snake_case
fields (super_group, members, add) and was getting undefined for all
of them — hence "super-group 0 · add" on every patch.

Add a PatchDTO mirroring the established DTO pattern (snake_case JSON
tags), wire it into eventToDTO, and update the frontend cancel-detect
to honor the actual wire field (add: false) alongside the existing
legacy fallbacks. Pin the wire shape with a sse_test using the values
from the issue report.

https://claude.ai/code/session_012kW4LDCvCRfbXPGUz2xdeg