### PR TITLE
rtlsdr: stronger Windows reset + two-retry bring-up envelope (issue #333)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -176,6 +176,19 @@ for tagged releases.
 
 ### Fixed
 
+- **RTL-SDR cold-boot stall on Windows: deeper recovery for wedged
+  clone dongles.** The previous fix mapped `ERROR_GEN_FAILURE (0x1F)`
+  to `ErrPipeStalled` and ran one clear-halt + re-claim retry, which
+  recovers a stale endpoint halt but not a wedged firmware state from
+  a prior crashed process. WinUSB `Transport.Reset()` now matches
+  what `libusb_reset_device` does on Windows: clear-halt the control
+  endpoint, drop the WinUSB handles, then re-open the device via
+  `CreateFile` + `WinUsb_Initialize` (a true device-object re-bind,
+  not just a pipe reset). The open-time bring-up envelope now allows
+  up to two such resets per `Open` with 100ms / 200ms backoff, giving
+  clones that need two settles to come back a chance to recover
+  before surfacing the Zadig / port-choice / `gophertrunk sdr doctor`
+  hint. Healthy dongles still open with zero resets and zero delay.
 - **RTL-SDR cold-boot stall on Windows now self-recovers.** Clone
   dongles (and some power-marginal hubs) latch the first
   USB_SYSCTL=0x09 vendor-OUT write, then NAK the byte-identical

--- a/internal/sdr/rtlsdr/purego/driver.go
+++ b/internal/sdr/rtlsdr/purego/driver.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/MattCheramie/GopherTrunk/internal/sdr"
 	"github.com/MattCheramie/GopherTrunk/internal/sdr/rtlsdr/rtl2832u"
@@ -152,35 +153,42 @@ func (d *Driver) Open(idx int) (sdr.Device, error) {
 // explicit "kick" to arm the bridge for the multi-byte OUT that
 // follows, even though the demod register already holds the on-value.
 //
-// The whole sequence is wrapped in a one-shot reset+retry envelope on
-// EPIPE / ErrDeviceGone — covers both the librtlsdr "dummy write
-// probe" recovery case (warmup phase) and the NESDR v5 cold-boot
-// I²C-bridge-stall case (issue #248, the chip rejecting the first
-// 17-byte tuner burst even after PR #262's fresh wire toggle is on
-// the wire). At most one USBDEVFS_RESET per Open. Non-EPIPE errors
-// return immediately — reset is the wrong hammer for them.
+// The whole sequence is wrapped in a bounded reset+retry envelope on
+// EPIPE / ErrDeviceGone / ErrTimeout / ErrPipeStalled — covers the
+// librtlsdr "dummy write probe" recovery case (warmup phase), the
+// NESDR v5 cold-boot I²C-bridge-stall case (issue #248, the chip
+// rejecting the first 17-byte tuner burst even after PR #262's fresh
+// wire toggle is on the wire), and the Windows clone-dongle wedge
+// where one device-rebind isn't enough to clear a stale firmware
+// state. Up to two resets per Open with 100ms / 200ms backoff between
+// the failing attempt and the next retry — gives the WinUSB stack and
+// device firmware time to settle before the next bring-up pass.
+// Non-resetable errors (validation failures, ErrClosed) return
+// immediately — reset is the wrong hammer for them.
 func openDevice(transport usb.Transport, desc usb.Descriptor, idx int) (*Device, error) {
 	if err := transport.ClaimInterface(0); err != nil {
 		return nil, fmt.Errorf("rtlsdr: claim interface 0: %w%s", err, claimBusyHint(err))
 	}
 
+	const maxAttempts = 3
 	var (
 		demod *rtl2832u.Demod
 		tuner tuners.Tuner
 		err   error
 	)
-	for attempt := 0; attempt < 2; attempt++ {
+	for attempt := 0; attempt < maxAttempts; attempt++ {
 		demod = rtl2832u.New(transport)
 		tuner, err = runBringup(demod)
 		if err == nil {
 			break
 		}
-		if attempt == 1 || !isBringupResetable(err) {
+		if attempt == maxAttempts-1 || !isBringupResetable(err) {
 			return nil, err
 		}
 		if resetErr := transport.Reset(); resetErr != nil {
 			return nil, fmt.Errorf("rtlsdr: bring-up hit %w; reset failed: %w", err, resetErr)
 		}
+		time.Sleep(time.Duration(100*(attempt+1)) * time.Millisecond)
 		_ = transport.ReleaseInterface(0)
 		if claimErr := transport.ClaimInterface(0); claimErr != nil {
 			return nil, fmt.Errorf("rtlsdr: re-claim interface 0 after reset: %w", claimErr)
@@ -275,10 +283,11 @@ func runBringup(demod *rtl2832u.Demod) (tuners.Tuner, error) {
 // ERROR_SEM_TIMEOUT instead of stalling the pipe), or ErrPipeStalled
 // (Windows/WinUSB clone-dongle cold-boot — the chip latches the first
 // USB_SYSCTL write and then NAKs the next identical write with
-// ERROR_GEN_FAILURE). The retry is bounded to one reset
-// per Open so even if a reset is wasted on a non-cold-boot stall the
-// cost is capped at ~200ms before the original error surfaces. Other
-// errors (ErrClosed, validation failures) stay non-resetable.
+// ERROR_GEN_FAILURE). The retry is bounded to two resets per Open
+// (100ms + 200ms backoff between passes) so even if both resets are
+// wasted on a non-cold-boot stall the cost is capped at ~1s before
+// the original error surfaces. Other errors (ErrClosed, validation
+// failures) stay non-resetable.
 func isBringupResetable(err error) bool {
 	return errors.Is(err, syscall.EPIPE) ||
 		errors.Is(err, usb.ErrDeviceGone) ||

--- a/internal/sdr/rtlsdr/purego/driver_test.go
+++ b/internal/sdr/rtlsdr/purego/driver_test.go
@@ -226,13 +226,13 @@ func TestOpenDevice_WarmupEPIPETriggersResetAndRetry(t *testing.T) {
 			WValue:   0x2000,
 			WIndex:   uint16(1)<<8 | 0x10,
 			Data:     []byte{0x09},
-			Err:      usb.ErrTimeout,
+			Err:      usb.ErrClosed,
 		},
 	}
 	desc := usb.Descriptor{VID: 0x0bda, PID: 0x2838, Serial: "test-warmup-retry"}
 	_, err := openDevice(m, desc, 0)
 	if err == nil {
-		t.Fatal("openDevice succeeded; expected init-baseband timeout to terminate the test")
+		t.Fatal("openDevice succeeded; expected init-baseband terminator to fail the test")
 	}
 	if !strings.Contains(err.Error(), "init baseband") {
 		t.Errorf("err = %v, want substring \"init baseband\" (proves warmup retry succeeded and InitBaseband ran)", err)
@@ -249,16 +249,17 @@ func TestOpenDevice_WarmupEPIPETriggersResetAndRetry(t *testing.T) {
 // openDevice must surface the wrapped error with the tunerBringupHint
 // appended — that's the actionable message the user sees and which
 // points them at the DVB / power / cable workarounds.
-func TestOpenDevice_WarmupEPIPETwiceReturnsHintError(t *testing.T) {
+func TestOpenDevice_WarmupEPIPEThriceReturnsHintError(t *testing.T) {
 	m := usb.NewMockTransport()
 	m.Script = []usb.CtrlExchange{
+		warmupUSBSysctlExchange(syscall.EPIPE),
 		warmupUSBSysctlExchange(syscall.EPIPE),
 		warmupUSBSysctlExchange(syscall.EPIPE),
 	}
 	desc := usb.Descriptor{VID: 0x0bda, PID: 0x2838, Serial: "test-warmup-fail"}
 	_, err := openDevice(m, desc, 0)
 	if err == nil {
-		t.Fatal("openDevice succeeded; expected EPIPE-twice to fail open")
+		t.Fatal("openDevice succeeded; expected EPIPE-thrice to fail open")
 	}
 	if !errors.Is(err, syscall.EPIPE) {
 		t.Errorf("err = %v, want errors.Is(err, syscall.EPIPE) (the underlying cause must remain inspectable)", err)
@@ -269,8 +270,8 @@ func TestOpenDevice_WarmupEPIPETwiceReturnsHintError(t *testing.T) {
 	if !strings.Contains(err.Error(), "dvb_usb_rtl28xxu") {
 		t.Errorf("err = %v, want substring \"dvb_usb_rtl28xxu\" (proves tunerBringupHint was appended)", err)
 	}
-	if m.ResetCalls != 1 {
-		t.Errorf("ResetCalls = %d, want 1 (one reset attempt between the two warmup tries)", m.ResetCalls)
+	if m.ResetCalls != 2 {
+		t.Errorf("ResetCalls = %d, want 2 (envelope retries twice before surfacing the error)", m.ResetCalls)
 	}
 }
 
@@ -287,15 +288,15 @@ func TestOpenDevice_WarmupEPIPETwiceReturnsHintError(t *testing.T) {
 func TestOpenDevice_BringupEPIPE_TriggersFullReset(t *testing.T) {
 	m := usb.NewMockTransport()
 	m.Script = []usb.CtrlExchange{
-		warmupUSBSysctlExchange(nil),            // pass 1: warmup OK
-		warmupUSBSysctlExchange(syscall.EPIPE),  // pass 1: InitBaseband first write EPIPE
-		warmupUSBSysctlExchange(nil),            // pass 2: warmup OK (post-reset)
-		warmupUSBSysctlExchange(usb.ErrTimeout), // pass 2: InitBaseband ErrTimeout terminates
+		warmupUSBSysctlExchange(nil),           // pass 1: warmup OK
+		warmupUSBSysctlExchange(syscall.EPIPE), // pass 1: InitBaseband first write EPIPE
+		warmupUSBSysctlExchange(nil),           // pass 2: warmup OK (post-reset)
+		warmupUSBSysctlExchange(usb.ErrClosed), // pass 2: non-resetable terminator
 	}
 	desc := usb.Descriptor{VID: 0x0bda, PID: 0x2838, Serial: "test-bringup-retry"}
 	_, err := openDevice(m, desc, 0)
 	if err == nil {
-		t.Fatal("openDevice succeeded; expected init-baseband timeout to terminate the test")
+		t.Fatal("openDevice succeeded; expected init-baseband terminator to fail the test")
 	}
 	if !strings.Contains(err.Error(), "init baseband") {
 		t.Errorf("err = %v, want substring \"init baseband\" (proves the retry reached InitBaseband)", err)
@@ -308,22 +309,24 @@ func TestOpenDevice_BringupEPIPE_TriggersFullReset(t *testing.T) {
 	}
 }
 
-// Regression for issue #248: when EPIPE recurs on the retry pass of
+// Regression for issue #248: when EPIPE recurs on every retry pass of
 // the bring-up, openDevice must surface the wrapped error with the
-// tunerBringupHint appended. Only one USBDEVFS_RESET is allowed per
-// Open call — the envelope is a one-shot, never a loop.
-func TestOpenDevice_BringupEPIPETwice_ReturnsHintError(t *testing.T) {
+// tunerBringupHint appended. Up to two USBDEVFS_RESETs are allowed per
+// Open call — the envelope is bounded, never an unbounded loop.
+func TestOpenDevice_BringupEPIPEThrice_ReturnsHintError(t *testing.T) {
 	m := usb.NewMockTransport()
 	m.Script = []usb.CtrlExchange{
 		warmupUSBSysctlExchange(nil),           // pass 1: warmup OK
 		warmupUSBSysctlExchange(syscall.EPIPE), // pass 1: InitBaseband EPIPE
 		warmupUSBSysctlExchange(nil),           // pass 2: warmup OK
-		warmupUSBSysctlExchange(syscall.EPIPE), // pass 2: InitBaseband EPIPE again
+		warmupUSBSysctlExchange(syscall.EPIPE), // pass 2: InitBaseband EPIPE
+		warmupUSBSysctlExchange(nil),           // pass 3: warmup OK
+		warmupUSBSysctlExchange(syscall.EPIPE), // pass 3: InitBaseband EPIPE again
 	}
 	desc := usb.Descriptor{VID: 0x0bda, PID: 0x2838, Serial: "test-bringup-fail"}
 	_, err := openDevice(m, desc, 0)
 	if err == nil {
-		t.Fatal("openDevice succeeded; expected EPIPE-twice to fail open")
+		t.Fatal("openDevice succeeded; expected EPIPE-thrice to fail open")
 	}
 	if !errors.Is(err, syscall.EPIPE) {
 		t.Errorf("err = %v, want errors.Is(err, syscall.EPIPE)", err)
@@ -334,11 +337,11 @@ func TestOpenDevice_BringupEPIPETwice_ReturnsHintError(t *testing.T) {
 	if !strings.Contains(err.Error(), "dvb_usb_rtl28xxu") {
 		t.Errorf("err = %v, want substring \"dvb_usb_rtl28xxu\" (proves tunerBringupHint was appended)", err)
 	}
-	if m.ResetCalls != 1 {
-		t.Errorf("ResetCalls = %d, want 1 (envelope is one-shot, not a loop)", m.ResetCalls)
+	if m.ResetCalls != 2 {
+		t.Errorf("ResetCalls = %d, want 2 (bounded envelope: two resets, three attempts)", m.ResetCalls)
 	}
-	if m.ClaimCalls != 2 {
-		t.Errorf("ClaimCalls = %d, want 2 (initial claim + post-reset re-claim)", m.ClaimCalls)
+	if m.ClaimCalls != 3 {
+		t.Errorf("ClaimCalls = %d, want 3 (initial claim + two post-reset re-claims)", m.ClaimCalls)
 	}
 }
 
@@ -485,7 +488,7 @@ func TestOpenDevice_BringupPipeStalled_TriggersFullReset(t *testing.T) {
 		warmupUSBSysctlExchange(nil),                // pass 1: warmup OK
 		warmupUSBSysctlExchange(usb.ErrPipeStalled), // pass 1: InitBaseband step 0 stalls
 		warmupUSBSysctlExchange(nil),                // pass 2: warmup OK (post clear-halt)
-		warmupUSBSysctlExchange(usb.ErrTimeout),     // pass 2: terminate early
+		warmupUSBSysctlExchange(usb.ErrClosed),      // pass 2: non-resetable terminator
 	}
 	desc := usb.Descriptor{VID: 0x0bda, PID: 0x2838, Serial: "test-bringup-pipestalled-retry"}
 	_, err := openDevice(m, desc, 0)
@@ -503,11 +506,13 @@ func TestOpenDevice_BringupPipeStalled_TriggersFullReset(t *testing.T) {
 	}
 }
 
-// When ErrPipeStalled recurs on the retry pass, the surfaced error
+// When ErrPipeStalled recurs on every retry pass, the surfaced error
 // must carry the clone-dongle / Zadig hint.
-func TestOpenDevice_BringupPipeStalledTwice_ReturnsHintError(t *testing.T) {
+func TestOpenDevice_BringupPipeStalledThrice_ReturnsHintError(t *testing.T) {
 	m := usb.NewMockTransport()
 	m.Script = []usb.CtrlExchange{
+		warmupUSBSysctlExchange(nil),
+		warmupUSBSysctlExchange(usb.ErrPipeStalled),
 		warmupUSBSysctlExchange(nil),
 		warmupUSBSysctlExchange(usb.ErrPipeStalled),
 		warmupUSBSysctlExchange(nil),
@@ -516,7 +521,7 @@ func TestOpenDevice_BringupPipeStalledTwice_ReturnsHintError(t *testing.T) {
 	desc := usb.Descriptor{VID: 0x0bda, PID: 0x2838, Serial: "test-bringup-pipestalled-fail"}
 	_, err := openDevice(m, desc, 0)
 	if err == nil {
-		t.Fatal("openDevice succeeded; expected ErrPipeStalled-twice to fail open")
+		t.Fatal("openDevice succeeded; expected ErrPipeStalled-thrice to fail open")
 	}
 	if !errors.Is(err, usb.ErrPipeStalled) {
 		t.Errorf("err = %v, want errors.Is(err, usb.ErrPipeStalled)", err)
@@ -527,24 +532,28 @@ func TestOpenDevice_BringupPipeStalledTwice_ReturnsHintError(t *testing.T) {
 	if !strings.Contains(err.Error(), "Zadig") {
 		t.Errorf("err = %v, want substring \"Zadig\"", err)
 	}
-	if m.ResetCalls != 1 {
-		t.Errorf("ResetCalls = %d, want 1 (envelope is one-shot, not a loop)", m.ResetCalls)
+	if m.ResetCalls != 2 {
+		t.Errorf("ResetCalls = %d, want 2 (bounded envelope: two resets, three attempts)", m.ResetCalls)
+	}
+	if m.ClaimCalls != 3 {
+		t.Errorf("ClaimCalls = %d, want 3 (initial claim + two post-reset re-claims)", m.ClaimCalls)
 	}
 }
 
-// Regression: when ErrTimeout recurs on the warmup retry pass, the
+// Regression: when ErrTimeout recurs on every warmup retry pass, the
 // surfaced error must carry the Windows-aware hint that points at the
-// WinUSB / Zadig step. Only one USBDEVFS_RESET per Open call.
-func TestOpenDevice_WarmupTimeoutTwiceReturnsHintError(t *testing.T) {
+// WinUSB / Zadig step. Bounded to two USBDEVFS_RESETs per Open call.
+func TestOpenDevice_WarmupTimeoutThriceReturnsHintError(t *testing.T) {
 	m := usb.NewMockTransport()
 	m.Script = []usb.CtrlExchange{
+		warmupUSBSysctlExchange(usb.ErrTimeout),
 		warmupUSBSysctlExchange(usb.ErrTimeout),
 		warmupUSBSysctlExchange(usb.ErrTimeout),
 	}
 	desc := usb.Descriptor{VID: 0x0bda, PID: 0x2838, Serial: "test-warmup-timeout-fail"}
 	_, err := openDevice(m, desc, 0)
 	if err == nil {
-		t.Fatal("openDevice succeeded; expected ErrTimeout-twice to fail open")
+		t.Fatal("openDevice succeeded; expected ErrTimeout-thrice to fail open")
 	}
 	if !errors.Is(err, usb.ErrTimeout) {
 		t.Errorf("err = %v, want errors.Is(err, usb.ErrTimeout) (the underlying cause must remain inspectable)", err)
@@ -555,8 +564,37 @@ func TestOpenDevice_WarmupTimeoutTwiceReturnsHintError(t *testing.T) {
 	if !strings.Contains(err.Error(), "Zadig") {
 		t.Errorf("err = %v, want substring \"Zadig\" (proves the Windows-aware tunerBringupHint was appended)", err)
 	}
-	if m.ResetCalls != 1 {
-		t.Errorf("ResetCalls = %d, want 1 (one reset attempt between the two warmup tries)", m.ResetCalls)
+	if m.ResetCalls != 2 {
+		t.Errorf("ResetCalls = %d, want 2 (bounded envelope: two resets, three attempts)", m.ResetCalls)
+	}
+}
+
+// Regression: a clone dongle on Windows can require two full resets to
+// clear a wedged firmware state (the first WinUsb_Initialize rebind
+// doesn't always settle the device, but the second one does). The
+// bring-up envelope must keep retrying after the first reset and let
+// the second attempt succeed if the third one would.
+func TestOpenDevice_WarmupRecoversOnSecondRetry(t *testing.T) {
+	m := usb.NewMockTransport()
+	m.Script = []usb.CtrlExchange{
+		warmupUSBSysctlExchange(usb.ErrPipeStalled), // pass 1: stalls
+		warmupUSBSysctlExchange(usb.ErrPipeStalled), // pass 2: still stalls
+		warmupUSBSysctlExchange(nil),                // pass 3: warmup OK
+		warmupUSBSysctlExchange(usb.ErrClosed),      // pass 3: non-resetable terminator
+	}
+	desc := usb.Descriptor{VID: 0x0bda, PID: 0x2838, Serial: "test-warmup-second-retry"}
+	_, err := openDevice(m, desc, 0)
+	if err == nil {
+		t.Fatal("openDevice succeeded; expected init-baseband terminator to fail the test")
+	}
+	if !strings.Contains(err.Error(), "init baseband") {
+		t.Errorf("err = %v, want substring \"init baseband\" (proves the third attempt reached InitBaseband)", err)
+	}
+	if m.ResetCalls != 2 {
+		t.Errorf("ResetCalls = %d, want 2 (one reset after each failed warmup)", m.ResetCalls)
+	}
+	if m.ClaimCalls != 3 {
+		t.Errorf("ClaimCalls = %d, want 3 (initial claim + two post-reset re-claims)", m.ClaimCalls)
 	}
 }
 

--- a/internal/sdr/rtlsdr/usb/usb_windows.go
+++ b/internal/sdr/rtlsdr/usb/usb_windows.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
 	"unsafe"
 
 	"golang.org/x/sys/windows"
@@ -322,23 +323,82 @@ func (t *winTransport) ClaimInterface(num int) error {
 
 func (t *winTransport) ReleaseInterface(int) error { return nil }
 
+// Reset mirrors what libusb_reset_device does on Windows: clear-halt
+// the control endpoint, then drop the WinUSB handles and re-bind via
+// CreateFile + WinUsb_Initialize. The plain clear-halt that earlier
+// shipped here (WinUsb_ResetPipe(0)) is enough for a stale endpoint
+// halt but does nothing for a wedged firmware state left by a prior
+// crashed process — for that you need a fresh device-object handle.
+//
+// Invariants:
+//   - The bring-up retry envelope in purego/driver.go is the only
+//     caller, and it runs Reset before any bulk-in stream starts.
+//     The bulkMu acquire below is defensive in case a future caller
+//     reuses Reset() after streaming begins.
+//   - On failure mid-sequence the transport is left in a coherent
+//     "closed" state so subsequent ControlOut/ControlIn calls return
+//     ErrClosed rather than dereferencing a freed handle.
 func (t *winTransport) Reset() error {
-	// WinUSB has no equivalent of libusb_reset_device — a full USB
-	// port-reset would require IOCTL_USB_CYCLE_PORT on the parent hub,
-	// which is brittle and almost never the right hammer. What the
-	// bring-up retry envelope actually needs is a clear-halt on the
-	// default control endpoint: that's exactly what WinUsb_ResetPipe
-	// emits (USB CLEAR_FEATURE(ENDPOINT_HALT)). Pipe ID 0 is the
-	// default control endpoint. Recovers the clone-dongle cold-boot
-	// stall surfaced as ERROR_GEN_FAILURE on the second USB_SYSCTL=0x09
-	// write, without disturbing the bulk-IN pipe.
 	if t.closed.Load() {
 		return ErrClosed
 	}
-	ret, _, errno := procWinUsbResetPipe.Call(t.ifaceHandle, 0)
-	if ret == 0 {
-		return fmt.Errorf("winusb: WinUsb_ResetPipe(control): %w", winErr(errno))
+	// Best-effort clear-halt before we drop the handle: clears any
+	// stalled control transfer so the device firmware sees the
+	// CLEAR_FEATURE before the bus re-enumerates us. Errors are
+	// ignored — we're about to throw the handle away anyway.
+	procWinUsbResetPipe.Call(t.ifaceHandle, 0)
+
+	t.bulkMu.Lock()
+	defer t.bulkMu.Unlock()
+	oldIface := t.ifaceHandle
+	oldFile := t.fileHandle
+	t.ifaceHandle = 0
+	t.fileHandle = 0
+	if oldIface != 0 {
+		procWinUsbFree.Call(oldIface)
 	}
+	if oldFile != 0 {
+		windows.CloseHandle(oldFile)
+	}
+
+	// Let the WinUSB stack release the file-object and the device
+	// firmware finish internal recovery before we re-open. 50ms is
+	// the conservative settle libusb-1.0 uses on Windows after
+	// libusb_reset_device's close path.
+	time.Sleep(50 * time.Millisecond)
+
+	wpath, err := windows.UTF16PtrFromString(t.desc.Path)
+	if err != nil {
+		t.closed.Store(true)
+		return fmt.Errorf("winusb: reset bad path %q: %w", t.desc.Path, err)
+	}
+	handle, err := windows.CreateFile(
+		wpath,
+		windows.GENERIC_READ|windows.GENERIC_WRITE,
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE,
+		nil,
+		windows.OPEN_EXISTING,
+		windows.FILE_ATTRIBUTE_NORMAL|windows.FILE_FLAG_OVERLAPPED,
+		0,
+	)
+	if err != nil {
+		t.closed.Store(true)
+		return fmt.Errorf("winusb: reset CreateFile %q: %w", t.desc.Path, err)
+	}
+	var ifaceHandle uintptr
+	ret, _, errno := procWinUsbInitialize.Call(uintptr(handle), uintptr(unsafe.Pointer(&ifaceHandle)))
+	if ret == 0 {
+		windows.CloseHandle(handle)
+		t.closed.Store(true)
+		return fmt.Errorf("winusb: reset WinUsb_Initialize: %w", winErr(errno))
+	}
+	t.fileHandle = handle
+	t.ifaceHandle = ifaceHandle
+	// The new ifaceHandle starts with WinUSB defaults — force the
+	// next applyControlTimeout to re-push our timeout policy.
+	t.timeoutMu.Lock()
+	t.lastCtlTimeout = 0
+	t.timeoutMu.Unlock()
 	return nil
 }
 


### PR DESCRIPTION
WinUSB Transport.Reset() now closes and re-opens the device handle
(CreateFile + WinUsb_Initialize), matching libusb_reset_device on
Windows. A pipe-only clear-halt left wedged clone-dongle firmware
state untouched. The open-time bring-up envelope now allows up to two
resets per Open with 100ms / 200ms backoff between attempts, covering
dongles that need two settles to come back. Healthy dongles still
open with zero resets and zero delay.

https://claude.ai/code/session_01CuWPzyThet2Yr1FWCu2Yqa