### PR TITLE
rtlsdr: widen Windows cold-boot recovery envelope (issue #395)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ for tagged releases.
 
 ## [Unreleased]
 
+### Fixed
+
+- **RTL-SDR cold-boot stall on Windows: wider recovery envelope for the
+  most stubborn clone dongles (issue #395).** A Windows 10 reporter on
+  v0.2.4 still hit `rtlsdr: init baseband: init baseband step 0 ...
+  ERROR_GEN_FAILURE` after the prior #382 + #393 fixes — warmup succeeded
+  but the byte-identical step 0 of `InitBaseband` failed, and all three
+  attempts of the previous 3-attempt / 100 ms+200 ms backoff envelope
+  also failed. The open-time bring-up envelope now runs 5 attempts (4
+  resets) with exponential backoff (200 / 400 / 800 / 1200 ms), and the
+  WinUSB `Reset()` settle grows from 50 ms to 150 ms — both targeted at
+  Windows USB-stack timing for the wedged-firmware recovery path.
+  Healthy dongles still open on attempt 0 with zero delay; only dongles
+  that actually need recovery pay the new costs. The surfaced hint for
+  `ErrPipeStalled` now also recommends unplugging the dongle for 10 s
+  before re-plugging (which physically clears the firmware state) and
+  references the issue for users hitting this after a Windows
+  sleep/resume.
+
 ### Changed
 
 - **Motorola voice-channel talker-alias decoder (issue #376

--- a/internal/sdr/rtlsdr/purego/driver.go
+++ b/internal/sdr/rtlsdr/purego/driver.go
@@ -160,9 +160,16 @@ func (d *Driver) Open(idx int) (sdr.Device, error) {
 // rejecting the first 17-byte tuner burst even after PR #262's fresh
 // wire toggle is on the wire), and the Windows clone-dongle wedge
 // where one device-rebind isn't enough to clear a stale firmware
-// state. Up to two resets per Open with 100ms / 200ms backoff between
-// the failing attempt and the next retry — gives the WinUSB stack and
-// device firmware time to settle before the next bring-up pass.
+// state. Up to four resets per Open with exponential backoff
+// (200ms / 400ms / 800ms / 1200ms) between the failing attempt and
+// the next retry — gives the WinUSB stack and device firmware time
+// to settle before the next bring-up pass. Issue #395 surfaced a
+// reporter on v0.2.4 whose dongle still failed all three attempts
+// of the prior 3-attempt / 100ms+200ms envelope, so this widens
+// both the attempt count and the per-attempt settle window while
+// keeping healthy opens at zero delay (attempt 0 succeeds, no sleep
+// runs). Worst-case open delay for a permanently-broken dongle is
+// ~2.6s of sleep plus the per-reset rebind cost.
 // Non-resetable errors (validation failures, ErrClosed) return
 // immediately — reset is the wrong hammer for them.
 func openDevice(transport usb.Transport, desc usb.Descriptor, idx int) (*Device, error) {
@@ -170,7 +177,19 @@ func openDevice(transport usb.Transport, desc usb.Descriptor, idx int) (*Device,
 		return nil, fmt.Errorf("rtlsdr: claim interface 0: %w%s", err, claimBusyHint(err))
 	}
 
-	const maxAttempts = 3
+	const maxAttempts = 5
+	// backoff[attempt] is the sleep that runs BEFORE the (attempt+1)th
+	// bring-up pass — exponential with a soft cap at 1200ms so a
+	// pathologically wedged dongle still surfaces the error in ~3s
+	// rather than dragging out into a 10s tail. Indexed 0..maxAttempts-2;
+	// the last attempt's failure surfaces immediately with no further
+	// sleep (we're out of retries).
+	backoffs := [maxAttempts - 1]time.Duration{
+		200 * time.Millisecond,
+		400 * time.Millisecond,
+		800 * time.Millisecond,
+		1200 * time.Millisecond,
+	}
 	var (
 		demod *rtl2832u.Demod
 		tuner tuners.Tuner
@@ -188,7 +207,7 @@ func openDevice(transport usb.Transport, desc usb.Descriptor, idx int) (*Device,
 		if resetErr := transport.Reset(); resetErr != nil {
 			return nil, fmt.Errorf("rtlsdr: bring-up hit %w; reset failed: %w", err, resetErr)
 		}
-		time.Sleep(time.Duration(100*(attempt+1)) * time.Millisecond)
+		time.Sleep(backoffs[attempt])
 		_ = transport.ReleaseInterface(0)
 		if claimErr := transport.ClaimInterface(0); claimErr != nil {
 			return nil, fmt.Errorf("rtlsdr: re-claim interface 0 after reset: %w", claimErr)
@@ -283,11 +302,16 @@ func runBringup(demod *rtl2832u.Demod) (tuners.Tuner, error) {
 // ERROR_SEM_TIMEOUT instead of stalling the pipe), or ErrPipeStalled
 // (Windows/WinUSB clone-dongle cold-boot — the chip latches the first
 // USB_SYSCTL write and then NAKs the next identical write with
-// ERROR_GEN_FAILURE). The retry is bounded to two resets per Open
-// (100ms + 200ms backoff between passes) so even if both resets are
-// wasted on a non-cold-boot stall the cost is capped at ~1s before
-// the original error surfaces. Other errors (ErrClosed, validation
-// failures) stay non-resetable.
+// ERROR_GEN_FAILURE). The retry is bounded to four resets per Open
+// (200ms + 400ms + 800ms + 1200ms exponential backoff between passes)
+// so even if all four resets are wasted on a non-cold-boot stall the
+// cost is capped at ~2.6s of sleep before the original error surfaces.
+// The previous 100ms/200ms envelope (#393) wasn't long enough for the
+// Windows clone-dongle in issue #395 — widening to four resets gives
+// the WinUSB stack and firmware enough settle time for the wedged-
+// state recovery without penalising healthy opens (zero delay on
+// attempt 0). Other errors (ErrClosed, validation failures) stay
+// non-resetable.
 func isBringupResetable(err error) bool {
 	return errors.Is(err, syscall.EPIPE) ||
 		errors.Is(err, usb.ErrDeviceGone) ||
@@ -349,9 +373,11 @@ func tunerBringupHint(err error) string {
 		return " (hint: the dongle's USB control pipe stalled on cold boot" +
 			" (Windows ERROR_GEN_FAILURE) — common with clone dongles or" +
 			" marginal USB power. If the automatic retry didn't recover," +
-			" re-run Zadig to confirm WinUSB is bound to interface 0," +
-			" try a different USB port (avoid hubs), and re-plug the device." +
+			" unplug the dongle for 10 seconds and re-plug to clear the wedged" +
+			" firmware state, then re-run Zadig to confirm WinUSB is bound to" +
+			" interface 0, and try a different USB port (avoid hubs)." +
 			" Run `gophertrunk sdr doctor` to inspect the current driver binding." +
+			" If this keeps happening after a Windows sleep/resume, see issue #395." +
 			" See https://mattcheramie.github.io/GopherTrunk/install-linux.html#troubleshooting)"
 	}
 	return ""

--- a/internal/sdr/rtlsdr/purego/driver_test.go
+++ b/internal/sdr/rtlsdr/purego/driver_test.go
@@ -245,13 +245,16 @@ func TestOpenDevice_WarmupEPIPETriggersResetAndRetry(t *testing.T) {
 	}
 }
 
-// Regression for issue #248: when both warmup attempts return EPIPE,
+// Regression for issue #248: when every warmup attempt returns EPIPE,
 // openDevice must surface the wrapped error with the tunerBringupHint
 // appended — that's the actionable message the user sees and which
-// points them at the DVB / power / cable workarounds.
-func TestOpenDevice_WarmupEPIPEThriceReturnsHintError(t *testing.T) {
+// points them at the DVB / power / cable workarounds. The envelope
+// runs 5 attempts (4 resets) since #395.
+func TestOpenDevice_WarmupEPIPEFiveTimesReturnsHintError(t *testing.T) {
 	m := usb.NewMockTransport()
 	m.Script = []usb.CtrlExchange{
+		warmupUSBSysctlExchange(syscall.EPIPE),
+		warmupUSBSysctlExchange(syscall.EPIPE),
 		warmupUSBSysctlExchange(syscall.EPIPE),
 		warmupUSBSysctlExchange(syscall.EPIPE),
 		warmupUSBSysctlExchange(syscall.EPIPE),
@@ -259,7 +262,7 @@ func TestOpenDevice_WarmupEPIPEThriceReturnsHintError(t *testing.T) {
 	desc := usb.Descriptor{VID: 0x0bda, PID: 0x2838, Serial: "test-warmup-fail"}
 	_, err := openDevice(m, desc, 0)
 	if err == nil {
-		t.Fatal("openDevice succeeded; expected EPIPE-thrice to fail open")
+		t.Fatal("openDevice succeeded; expected EPIPE-five-times to fail open")
 	}
 	if !errors.Is(err, syscall.EPIPE) {
 		t.Errorf("err = %v, want errors.Is(err, syscall.EPIPE) (the underlying cause must remain inspectable)", err)
@@ -270,8 +273,8 @@ func TestOpenDevice_WarmupEPIPEThriceReturnsHintError(t *testing.T) {
 	if !strings.Contains(err.Error(), "dvb_usb_rtl28xxu") {
 		t.Errorf("err = %v, want substring \"dvb_usb_rtl28xxu\" (proves tunerBringupHint was appended)", err)
 	}
-	if m.ResetCalls != 2 {
-		t.Errorf("ResetCalls = %d, want 2 (envelope retries twice before surfacing the error)", m.ResetCalls)
+	if m.ResetCalls != 4 {
+		t.Errorf("ResetCalls = %d, want 4 (envelope retries four times before surfacing the error)", m.ResetCalls)
 	}
 }
 
@@ -311,9 +314,9 @@ func TestOpenDevice_BringupEPIPE_TriggersFullReset(t *testing.T) {
 
 // Regression for issue #248: when EPIPE recurs on every retry pass of
 // the bring-up, openDevice must surface the wrapped error with the
-// tunerBringupHint appended. Up to two USBDEVFS_RESETs are allowed per
-// Open call — the envelope is bounded, never an unbounded loop.
-func TestOpenDevice_BringupEPIPEThrice_ReturnsHintError(t *testing.T) {
+// tunerBringupHint appended. Up to four USBDEVFS_RESETs are allowed
+// per Open call — the envelope is bounded, never an unbounded loop.
+func TestOpenDevice_BringupEPIPEFiveTimes_ReturnsHintError(t *testing.T) {
 	m := usb.NewMockTransport()
 	m.Script = []usb.CtrlExchange{
 		warmupUSBSysctlExchange(nil),           // pass 1: warmup OK
@@ -321,12 +324,16 @@ func TestOpenDevice_BringupEPIPEThrice_ReturnsHintError(t *testing.T) {
 		warmupUSBSysctlExchange(nil),           // pass 2: warmup OK
 		warmupUSBSysctlExchange(syscall.EPIPE), // pass 2: InitBaseband EPIPE
 		warmupUSBSysctlExchange(nil),           // pass 3: warmup OK
-		warmupUSBSysctlExchange(syscall.EPIPE), // pass 3: InitBaseband EPIPE again
+		warmupUSBSysctlExchange(syscall.EPIPE), // pass 3: InitBaseband EPIPE
+		warmupUSBSysctlExchange(nil),           // pass 4: warmup OK
+		warmupUSBSysctlExchange(syscall.EPIPE), // pass 4: InitBaseband EPIPE
+		warmupUSBSysctlExchange(nil),           // pass 5: warmup OK
+		warmupUSBSysctlExchange(syscall.EPIPE), // pass 5: InitBaseband EPIPE again
 	}
 	desc := usb.Descriptor{VID: 0x0bda, PID: 0x2838, Serial: "test-bringup-fail"}
 	_, err := openDevice(m, desc, 0)
 	if err == nil {
-		t.Fatal("openDevice succeeded; expected EPIPE-thrice to fail open")
+		t.Fatal("openDevice succeeded; expected EPIPE-five-times to fail open")
 	}
 	if !errors.Is(err, syscall.EPIPE) {
 		t.Errorf("err = %v, want errors.Is(err, syscall.EPIPE)", err)
@@ -337,11 +344,11 @@ func TestOpenDevice_BringupEPIPEThrice_ReturnsHintError(t *testing.T) {
 	if !strings.Contains(err.Error(), "dvb_usb_rtl28xxu") {
 		t.Errorf("err = %v, want substring \"dvb_usb_rtl28xxu\" (proves tunerBringupHint was appended)", err)
 	}
-	if m.ResetCalls != 2 {
-		t.Errorf("ResetCalls = %d, want 2 (bounded envelope: two resets, three attempts)", m.ResetCalls)
+	if m.ResetCalls != 4 {
+		t.Errorf("ResetCalls = %d, want 4 (bounded envelope: four resets, five attempts)", m.ResetCalls)
 	}
-	if m.ClaimCalls != 3 {
-		t.Errorf("ClaimCalls = %d, want 3 (initial claim + two post-reset re-claims)", m.ClaimCalls)
+	if m.ClaimCalls != 5 {
+		t.Errorf("ClaimCalls = %d, want 5 (initial claim + four post-reset re-claims)", m.ClaimCalls)
 	}
 }
 
@@ -507,10 +514,15 @@ func TestOpenDevice_BringupPipeStalled_TriggersFullReset(t *testing.T) {
 }
 
 // When ErrPipeStalled recurs on every retry pass, the surfaced error
-// must carry the clone-dongle / Zadig hint.
-func TestOpenDevice_BringupPipeStalledThrice_ReturnsHintError(t *testing.T) {
+// must carry the clone-dongle / Zadig / unplug-and-replug hint pointing
+// at issue #395.
+func TestOpenDevice_BringupPipeStalledFiveTimes_ReturnsHintError(t *testing.T) {
 	m := usb.NewMockTransport()
 	m.Script = []usb.CtrlExchange{
+		warmupUSBSysctlExchange(nil),
+		warmupUSBSysctlExchange(usb.ErrPipeStalled),
+		warmupUSBSysctlExchange(nil),
+		warmupUSBSysctlExchange(usb.ErrPipeStalled),
 		warmupUSBSysctlExchange(nil),
 		warmupUSBSysctlExchange(usb.ErrPipeStalled),
 		warmupUSBSysctlExchange(nil),
@@ -521,7 +533,7 @@ func TestOpenDevice_BringupPipeStalledThrice_ReturnsHintError(t *testing.T) {
 	desc := usb.Descriptor{VID: 0x0bda, PID: 0x2838, Serial: "test-bringup-pipestalled-fail"}
 	_, err := openDevice(m, desc, 0)
 	if err == nil {
-		t.Fatal("openDevice succeeded; expected ErrPipeStalled-thrice to fail open")
+		t.Fatal("openDevice succeeded; expected ErrPipeStalled-five-times to fail open")
 	}
 	if !errors.Is(err, usb.ErrPipeStalled) {
 		t.Errorf("err = %v, want errors.Is(err, usb.ErrPipeStalled)", err)
@@ -532,20 +544,28 @@ func TestOpenDevice_BringupPipeStalledThrice_ReturnsHintError(t *testing.T) {
 	if !strings.Contains(err.Error(), "Zadig") {
 		t.Errorf("err = %v, want substring \"Zadig\"", err)
 	}
-	if m.ResetCalls != 2 {
-		t.Errorf("ResetCalls = %d, want 2 (bounded envelope: two resets, three attempts)", m.ResetCalls)
+	if !strings.Contains(err.Error(), "unplug the dongle") {
+		t.Errorf("err = %v, want substring \"unplug the dongle\" (proves the #395 hint was appended)", err)
 	}
-	if m.ClaimCalls != 3 {
-		t.Errorf("ClaimCalls = %d, want 3 (initial claim + two post-reset re-claims)", m.ClaimCalls)
+	if !strings.Contains(err.Error(), "#395") {
+		t.Errorf("err = %v, want substring \"#395\" (proves the issue ref was appended)", err)
+	}
+	if m.ResetCalls != 4 {
+		t.Errorf("ResetCalls = %d, want 4 (bounded envelope: four resets, five attempts)", m.ResetCalls)
+	}
+	if m.ClaimCalls != 5 {
+		t.Errorf("ClaimCalls = %d, want 5 (initial claim + four post-reset re-claims)", m.ClaimCalls)
 	}
 }
 
 // Regression: when ErrTimeout recurs on every warmup retry pass, the
 // surfaced error must carry the Windows-aware hint that points at the
-// WinUSB / Zadig step. Bounded to two USBDEVFS_RESETs per Open call.
-func TestOpenDevice_WarmupTimeoutThriceReturnsHintError(t *testing.T) {
+// WinUSB / Zadig step. Bounded to four USBDEVFS_RESETs per Open call.
+func TestOpenDevice_WarmupTimeoutFiveTimesReturnsHintError(t *testing.T) {
 	m := usb.NewMockTransport()
 	m.Script = []usb.CtrlExchange{
+		warmupUSBSysctlExchange(usb.ErrTimeout),
+		warmupUSBSysctlExchange(usb.ErrTimeout),
 		warmupUSBSysctlExchange(usb.ErrTimeout),
 		warmupUSBSysctlExchange(usb.ErrTimeout),
 		warmupUSBSysctlExchange(usb.ErrTimeout),
@@ -553,7 +573,7 @@ func TestOpenDevice_WarmupTimeoutThriceReturnsHintError(t *testing.T) {
 	desc := usb.Descriptor{VID: 0x0bda, PID: 0x2838, Serial: "test-warmup-timeout-fail"}
 	_, err := openDevice(m, desc, 0)
 	if err == nil {
-		t.Fatal("openDevice succeeded; expected ErrTimeout-thrice to fail open")
+		t.Fatal("openDevice succeeded; expected ErrTimeout-five-times to fail open")
 	}
 	if !errors.Is(err, usb.ErrTimeout) {
 		t.Errorf("err = %v, want errors.Is(err, usb.ErrTimeout) (the underlying cause must remain inspectable)", err)
@@ -564,8 +584,8 @@ func TestOpenDevice_WarmupTimeoutThriceReturnsHintError(t *testing.T) {
 	if !strings.Contains(err.Error(), "Zadig") {
 		t.Errorf("err = %v, want substring \"Zadig\" (proves the Windows-aware tunerBringupHint was appended)", err)
 	}
-	if m.ResetCalls != 2 {
-		t.Errorf("ResetCalls = %d, want 2 (bounded envelope: two resets, three attempts)", m.ResetCalls)
+	if m.ResetCalls != 4 {
+		t.Errorf("ResetCalls = %d, want 4 (bounded envelope: four resets, five attempts)", m.ResetCalls)
 	}
 }
 
@@ -595,6 +615,36 @@ func TestOpenDevice_WarmupRecoversOnSecondRetry(t *testing.T) {
 	}
 	if m.ClaimCalls != 3 {
 		t.Errorf("ClaimCalls = %d, want 3 (initial claim + two post-reset re-claims)", m.ClaimCalls)
+	}
+}
+
+// Regression for issue #395: pins that the new attempt-4 slot in the
+// retry envelope is actually consulted. The prior 3-attempt envelope
+// surfaced an error here; the 5-attempt envelope must let the bring-up
+// succeed on attempt 4 (zero-indexed) after four warmup stalls.
+func TestOpenDevice_BringupPipeStalledRecoversOnFifthAttempt(t *testing.T) {
+	m := usb.NewMockTransport()
+	m.Script = []usb.CtrlExchange{
+		warmupUSBSysctlExchange(usb.ErrPipeStalled), // pass 1: stalls
+		warmupUSBSysctlExchange(usb.ErrPipeStalled), // pass 2: stalls
+		warmupUSBSysctlExchange(usb.ErrPipeStalled), // pass 3: stalls
+		warmupUSBSysctlExchange(usb.ErrPipeStalled), // pass 4: stalls
+		warmupUSBSysctlExchange(nil),                // pass 5: warmup OK
+		warmupUSBSysctlExchange(usb.ErrClosed),      // pass 5: non-resetable terminator
+	}
+	desc := usb.Descriptor{VID: 0x0bda, PID: 0x2838, Serial: "test-bringup-fifth-attempt"}
+	_, err := openDevice(m, desc, 0)
+	if err == nil {
+		t.Fatal("openDevice succeeded; expected init-baseband terminator to fail the test")
+	}
+	if !strings.Contains(err.Error(), "init baseband") {
+		t.Errorf("err = %v, want substring \"init baseband\" (proves the fifth attempt reached InitBaseband)", err)
+	}
+	if m.ResetCalls != 4 {
+		t.Errorf("ResetCalls = %d, want 4 (one reset after each of the first four failed warmups)", m.ResetCalls)
+	}
+	if m.ClaimCalls != 5 {
+		t.Errorf("ClaimCalls = %d, want 5 (initial claim + four post-reset re-claims)", m.ClaimCalls)
 	}
 }
 

--- a/internal/sdr/rtlsdr/usb/usb_windows.go
+++ b/internal/sdr/rtlsdr/usb/usb_windows.go
@@ -362,10 +362,14 @@ func (t *winTransport) Reset() error {
 	}
 
 	// Let the WinUSB stack release the file-object and the device
-	// firmware finish internal recovery before we re-open. 50ms is
-	// the conservative settle libusb-1.0 uses on Windows after
-	// libusb_reset_device's close path.
-	time.Sleep(50 * time.Millisecond)
+	// firmware finish internal recovery before we re-open. libusb-1.0
+	// uses 50ms here for clean closes, but the bring-up envelope only
+	// calls Reset() after a wedged-firmware failure (ERROR_GEN_FAILURE
+	// / pipe stall) — issue #395 surfaced a Windows clone dongle whose
+	// firmware needed longer than 50ms to recover, so we settle for
+	// 150ms here. Healthy opens never run this path; the cost only
+	// applies to dongles that actually need recovery.
+	time.Sleep(150 * time.Millisecond)
 
 	wpath, err := windows.UTF16PtrFromString(t.desc.Path)
 	if err != nil {


### PR DESCRIPTION
A reporter on v0.2.4 hit ERROR_GEN_FAILURE on InitBaseband step 0
even after the prior #382 + #393 fixes — warmup succeeded, but the
byte-identical step 0 failed and all three retries of the 100ms/200ms
envelope also failed. Widen the open-time bring-up envelope from 3 to
5 attempts with exponential backoff (200/400/800/1200ms), grow the
WinUSB Reset() settle from 50ms to 150ms, and sharpen the user-facing
hint with unplug-and-replug guidance plus an issue ref so users
hitting this after a Windows sleep/resume know where to look.

Healthy opens still complete on attempt 0 with zero delay; only the
wedged-firmware recovery path pays the new costs.