### PR TITLE
voice/composer: route P25 Phase 1 voice through system demod mode

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -324,7 +324,12 @@ trunking:
   #                                     # P25 simulcast sites whose CC
   #                                     # is transmitted as Linear
   #                                     # Simulcast Modulation rather
-  #                                     # than C4FM (issue #275)
+  #                                     # than C4FM (issue #275). Also
+  #                                     # routes the per-call voice chain
+  #                                     # through the LSM path; without
+  #                                     # this voice grants on simulcast
+  #                                     # sites time out with no audio
+  #                                     # (issue #356).
   #
   #   - name: "Legacy-P25-Phase2"
   #     protocol: p25

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -469,8 +469,12 @@ type SystemConfig struct {
 	// (the linear / LSM path — complex RRC + Gardner + differential
 	// QPSK; required for simulcast P25 deployments whose control
 	// channel transmits Linear Simulcast Modulation rather than
-	// straight C4FM, see issue #275 and TIA-102.BAAA). Ignored for
-	// non-P25-Phase-1 protocols.
+	// straight C4FM, see issue #275 and TIA-102.BAAA). Applies to
+	// both the control channel decoder and the per-call voice
+	// chain — without the voice-chain side a simulcast site would
+	// lock the CC fine but never decode an LDU on a granted voice
+	// call (issue #356 follow-up). Ignored for non-P25-Phase-1
+	// protocols.
 	P25Phase1DemodMode string `yaml:"p25_phase1_demod_mode"`
 	// P25Phase2TrellisMode enables the 4-state ½-rate trellis FEC
 	// decoder on the P25 Phase 2 MAC PDU window. Recognised values:

--- a/internal/radio/p25/phase1/control.go
+++ b/internal/radio/p25/phase1/control.go
@@ -90,6 +90,15 @@ type ControlChannel struct {
 	// Options falls back to NIDSearchSpan, so production wiring is
 	// unaffected.
 	nidSearchSpan int
+
+	// p25Phase1DemodMode is the system-level operator-set demod-mode
+	// string (e.g. "cqpsk" / "c4fm"). Stamped onto every published
+	// trunking.Grant so the voice composer can route the voice IQ
+	// through the matching symbol-recovery path; without this an LSM
+	// simulcast site's voice grants would land in a hardcoded C4FM
+	// voice receiver and never decode (issue #356 follow-up). Empty
+	// string preserves the C4FM default in the voice chain.
+	p25Phase1DemodMode string
 }
 
 // NetworkSnapshot returns the system topology accumulated from the
@@ -136,6 +145,14 @@ type Options struct {
 	// the search reach a true alignment that lies past the default
 	// edge.
 	NIDSearchSpan int
+
+	// P25Phase1DemodMode is the raw system-level demod-mode string
+	// (e.g. "cqpsk" / "c4fm") from the system config. Stamped onto
+	// every published trunking.Grant so the voice composer can route
+	// the voice IQ through the matching symbol-recovery path. Empty
+	// preserves the C4FM default in the voice chain — and is what the
+	// existing replay / unit tests pass.
+	P25Phase1DemodMode string
 }
 
 // New constructs a ControlChannel from Options. SystemName ends up on
@@ -163,16 +180,17 @@ func New(opts Options) *ControlChannel {
 		span = NIDSearchSpan
 	}
 	return &ControlChannel{
-		bus:           opts.Bus,
-		log:           log,
-		det:           det,
-		systemName:    opts.SystemName,
-		freqHz:        opts.FrequencyHz,
-		bandPlan:      bp,
-		now:           now,
-		aliasAsm:      NewTalkerAliasAssembler(now),
-		rotations:     resolveRotations(opts.Rotations),
-		nidSearchSpan: span,
+		bus:                opts.Bus,
+		log:                log,
+		det:                det,
+		systemName:         opts.SystemName,
+		freqHz:             opts.FrequencyHz,
+		bandPlan:           bp,
+		now:                now,
+		aliasAsm:           NewTalkerAliasAssembler(now),
+		rotations:          resolveRotations(opts.Rotations),
+		nidSearchSpan:      span,
+		p25Phase1DemodMode: opts.P25Phase1DemodMode,
 	}
 }
 
@@ -893,17 +911,18 @@ func (c *ControlChannel) publishVoiceGrant(g voiceGrant, nac uint16) {
 	c.bus.Publish(events.Event{
 		Kind: events.KindGrant,
 		Payload: trunking.Grant{
-			System:      c.systemName,
-			Protocol:    "p25",
-			GroupID:     g.groupID,
-			SourceID:    g.sourceID,
-			FrequencyHz: freq,
-			ChannelID:   g.channelID,
-			ChannelNum:  g.channelNumber,
-			Encrypted:   so.Encrypted(),
-			Emergency:   so.Emergency(),
-			DataCall:    g.dataCall,
-			At:          c.now(),
+			System:             c.systemName,
+			Protocol:           "p25",
+			GroupID:            g.groupID,
+			SourceID:           g.sourceID,
+			FrequencyHz:        freq,
+			ChannelID:          g.channelID,
+			ChannelNum:         g.channelNumber,
+			Encrypted:          so.Encrypted(),
+			Emergency:          so.Emergency(),
+			DataCall:           g.dataCall,
+			P25Phase1DemodMode: c.p25Phase1DemodMode,
+			At:                 c.now(),
 		},
 	})
 	c.log.Debug("p25: grant",

--- a/internal/scanner/ccdecoder/pipelines.go
+++ b/internal/scanner/ccdecoder/pipelines.go
@@ -182,12 +182,13 @@ func newP25Phase1Pipeline(opts PipelineOptions) (ProtocolPipeline, error) {
 		}
 	}
 	cc := p25phase1.New(p25phase1.Options{
-		Bus:         opts.Bus,
-		Log:         opts.Log,
-		SystemName:  opts.SystemName,
-		FrequencyHz: opts.FrequencyHz,
-		BandPlan:    bandPlan,
-		Rotations:   rotations,
+		Bus:                opts.Bus,
+		Log:                opts.Log,
+		SystemName:         opts.SystemName,
+		FrequencyHz:        opts.FrequencyHz,
+		BandPlan:           bandPlan,
+		Rotations:          rotations,
+		P25Phase1DemodMode: opts.System.P25Phase1DemodMode,
 	})
 	rx := p25phase1rx.New(p25phase1rx.Options{
 		SampleRateHz: opts.SampleRateHz,

--- a/internal/trunking/grant.go
+++ b/internal/trunking/grant.go
@@ -43,7 +43,17 @@ type Grant struct {
 	// it from its PatchRegistry so the call can be attributed to every
 	// member. Empty for an ordinary (non-patched) grant.
 	PatchedGroups []uint32
-	At            time.Time
+	// P25Phase1DemodMode mirrors the system-level
+	// trunking.System.P25Phase1DemodMode setting so the voice composer
+	// can pick the matching symbol-recovery path on grants for the
+	// system (C4FM vs CQPSK / LSM). The control-channel decoder
+	// already honours the setting via the ccdecoder connector; without
+	// this field every voice grant landed in a hardcoded C4FM voice
+	// receiver and never decoded on LSM-modulated simulcast sites
+	// (issue #356 follow-up). Populated by the protocol layer when it
+	// publishes the grant; ignored for non-P25-Phase-1 grants.
+	P25Phase1DemodMode string
+	At                 time.Time
 }
 
 // String renders a one-line summary of a Grant for log output.

--- a/internal/voice/composer/composer.go
+++ b/internal/voice/composer/composer.go
@@ -421,7 +421,7 @@ func (c *Composer) handleStart(parent context.Context, cs trunking.CallStart) {
 	case isP25P2Voice:
 		go c.runP25Phase2VoiceChain(chainCtx, cs.DeviceSerial, iqCh, rateHz, ch.done)
 	case isP25P1Voice:
-		go c.runP25Phase1VoiceChain(chainCtx, cs.DeviceSerial, iqCh, rateHz, ch.done)
+		go c.runP25Phase1VoiceChain(chainCtx, cs.DeviceSerial, iqCh, rateHz, cs.Grant.P25Phase1DemodMode, ch.done)
 	default:
 		go c.runFMChain(chainCtx, cs.DeviceSerial, iqCh, rateHz, ch.done)
 	}

--- a/internal/voice/composer/p25p1_voice.go
+++ b/internal/voice/composer/p25p1_voice.go
@@ -22,16 +22,39 @@ const p25p1VoiceIntermediateHz = 48_000
 // per TIA-102.BAAA. It calibrates the receiver's 4-level slicer.
 const p25p1DeviationHz = 1800.0
 
+// resolveP25Phase1DemodMode parses the system-level
+// p25_phase1_demod_mode string carried on the grant into a receiver
+// mode. Unknown values warn-log and fall back to C4FM so a typo doesn't
+// silently kill a previously-working system; empty is the canonical
+// default. Factored out so the wiring is unit-testable independently
+// of the full IQ → LDU pipeline (issue #356 follow-up).
+func (c *Composer) resolveP25Phase1DemodMode(serial, mode string) p25p1rx.DemodMode {
+	parsed, ok := p25p1rx.ParseDemodMode(mode)
+	if !ok {
+		c.log.Warn("composer: unrecognised p25_phase1_demod_mode; voice chain falling back to c4fm",
+			"serial", serial, "value", mode)
+	}
+	return parsed
+}
+
 // runP25Phase1VoiceChain consumes IQ for one P25 Phase 1 voice call. It
 // decimates the wideband IQ to a C4FM-friendly rate, recovers the dibit
 // stream with the Phase 1 receiver, assembles complete 1728-bit LDUs,
 // and for each LDU extracts its 9 IMBE voice frames and appends them to
 // the recorder's .raw sidecar.
 //
+// demodMode is the raw system-level p25_phase1_demod_mode string from
+// the grant ("c4fm" / "cqpsk" / ""). An empty or unrecognised value
+// preserves the legacy C4FM path; "cqpsk" / "lsm" / "linear" routes
+// voice IQ through the linear-CQPSK path required for LSM simulcast
+// sites. Without this the voice chain was hardcoded to C4FM regardless
+// of the system setting and never decoded LDUs on simulcast sites
+// (issue #356 follow-up).
+//
 // The recorder maps protocol "p25" to the pure-Go IMBE vocoder
 // (voice.DefaultVocoderForProtocol), so WriteRawFrame here decodes each
 // 11-byte frame to PCM and into the call's WAV.
-func (c *Composer) runP25Phase1VoiceChain(ctx context.Context, serial string, iqCh <-chan []complex64, iqHz uint32, done chan<- struct{}) {
+func (c *Composer) runP25Phase1VoiceChain(ctx context.Context, serial string, iqCh <-chan []complex64, iqHz uint32, demodMode string, done chan<- struct{}) {
 	defer close(done)
 
 	decim := int(iqHz) / p25p1VoiceIntermediateHz
@@ -39,6 +62,8 @@ func (c *Composer) runP25Phase1VoiceChain(ctx context.Context, serial string, iq
 		decim = 1
 	}
 	symbolHz := float64(iqHz) / float64(decim)
+
+	mode := c.resolveP25Phase1DemodMode(serial, demodMode)
 
 	// Front-end LPF: doubles as the anti-aliasing filter for the
 	// decimation, so it is only needed when the IQ is actually
@@ -81,6 +106,7 @@ func (c *Composer) runP25Phase1VoiceChain(ctx context.Context, serial string, iq
 	rx := p25p1rx.New(p25p1rx.Options{
 		SampleRateHz: symbolHz,
 		DeviationHz:  p25p1DeviationHz,
+		DemodMode:    mode,
 		Sink: func(ldu []byte) {
 			// Bump first so the watchdog gate accounts for LDU
 			// delivery even when there's no raw-frame sink.

--- a/internal/voice/composer/p25p1_voice_test.go
+++ b/internal/voice/composer/p25p1_voice_test.go
@@ -2,6 +2,9 @@ package composer
 
 import (
 	"context"
+	"io"
+	"log/slog"
+	"math"
 	"testing"
 	"time"
 
@@ -9,9 +12,17 @@ import (
 	"github.com/MattCheramie/GopherTrunk/internal/events"
 	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
 	"github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase1"
+	p25p1rx "github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase1/receiver"
 	"github.com/MattCheramie/GopherTrunk/internal/trunking"
 	"github.com/MattCheramie/GopherTrunk/internal/voice/imbe"
 )
+
+// discardLogger returns a slog.Logger that drops every record. Used by
+// unit tests that exercise warn-log code paths without wanting the
+// noise in `go test -v` output.
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
 
 // p25p1VoiceInfo builds a deterministic, unique 88-bit IMBE info frame.
 func p25p1VoiceInfo(seed int) []byte {
@@ -138,6 +149,133 @@ func TestComposerP25Phase1VoiceChainExtractsRawFrames(t *testing.T) {
 	}
 
 	waitFor(t, time.Second, func() bool { return eng.touched.Load() > 0 })
+}
+
+// TestComposerP25Phase1VoiceChainHonoursDemodMode confirms a CallStart
+// whose Grant carries P25Phase1DemodMode="cqpsk" routes the voice IQ
+// through the linear-CQPSK / LSM path. Before the fix the voice chain
+// hardcoded C4FM regardless of the system-level setting, so on a
+// simulcast site the control channel decoded fine but every voice
+// grant landed in an FM-discriminator that couldn't sync on
+// LSM-modulated dibits, the LDU sink never fired, no frames advanced
+// the activity counter, and the watchdog reaped the call at
+// call_timeout_ms with an empty WAV. Issue #356 follow-up.
+func TestComposerP25Phase1VoiceChainHonoursDemodMode(t *testing.T) {
+	const (
+		sampleRate = 48_000.0
+		sps        = 10 // 48 kHz / 4800 baud
+		ldus       = 12
+	)
+	framesPerLDU := phase1.LDUVoiceSubframeCount
+
+	dibits, want := buildP25P1VoiceStream(t, ldus)
+	iq := dibitsToLSMIQTest(dibits, sps, p25p1rx.PulseSpanSymbols, p25p1rx.RolloffAlpha)
+
+	src := newFakeSource()
+	bus := events.NewBus(8)
+	sink := &recordingSink{}
+	eng := &fakeEngine{}
+	c, err := New(Options{
+		Bus:           bus,
+		Devices:       &fakeDevices{src: map[string]IQSource{"VOICE-1": src}},
+		Sink:          sink,
+		Engine:        eng,
+		IQSampleRate:  uint32(sampleRate),
+		PCMSampleRate: 8000,
+		TouchInterval: 30 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go c.Run(ctx)
+	defer c.Close()
+	defer bus.Close()
+
+	bus.Publish(events.Event{
+		Kind: events.KindCallStart,
+		Payload: trunking.CallStart{
+			Grant: trunking.Grant{
+				System: "Simulcast-P25", Protocol: "p25",
+				GroupID: 42, FrequencyHz: 851_000_000,
+				P25Phase1DemodMode: "cqpsk",
+			},
+			DeviceSerial: "VOICE-1",
+			StartedAt:    time.Now().UTC(),
+		},
+	})
+
+	waitFor(t, 2*time.Second, func() bool { return len(c.ActiveChains()) == 1 })
+	src.SendIQ(iq)
+
+	waitFor(t, 6*time.Second, func() bool {
+		return len(sink.rawFrames("VOICE-1")) >= 6*framesPerLDU
+	})
+
+	got := sink.rawFrames("VOICE-1")
+	for _, f := range got {
+		if len(f) != imbe.FrameBytes {
+			t.Fatalf("raw frame length = %d, want %d", len(f), imbe.FrameBytes)
+		}
+	}
+
+	// Round-trip parity: at least one LDU of IMBE frames recovered from
+	// the LSM IQ matches what was modulated — proves the CQPSK path is
+	// the one actually decoding, not a coincidental C4FM lock on the
+	// LSM signal (which would not produce parity-valid LDUs at all).
+	matches := bestAlignmentMatches(got, want)
+	if matches < framesPerLDU {
+		t.Errorf("cqpsk path: only %d of %d captured frames round-tripped; want at least one LDU (%d)",
+			matches, len(got), framesPerLDU)
+	}
+}
+
+// TestComposerResolveP25Phase1DemodMode is the unit-level guard for
+// the wiring: it asserts the composer maps the grant-carried system
+// string to the matching p25p1rx.DemodMode and warn-logs on unknown
+// values. Combined with the end-to-end smoke test above (which proves
+// the resolved mode actually drives the receiver), a regression that
+// re-hardcodes C4FM or drops the parse step would break both.
+func TestComposerResolveP25Phase1DemodMode(t *testing.T) {
+	c := &Composer{log: discardLogger()}
+	cases := []struct {
+		in   string
+		want p25p1rx.DemodMode
+	}{
+		{"", p25p1rx.DemodC4FM},
+		{"c4fm", p25p1rx.DemodC4FM},
+		{"C4FM", p25p1rx.DemodC4FM},
+		{"fm", p25p1rx.DemodC4FM},
+		{"cqpsk", p25p1rx.DemodCQPSK},
+		{"CQPSK", p25p1rx.DemodCQPSK},
+		{"lsm", p25p1rx.DemodCQPSK},
+		{"linear", p25p1rx.DemodCQPSK},
+		{"bogus", p25p1rx.DemodC4FM}, // fallback path, warn-logged
+	}
+	for _, tc := range cases {
+		if got := c.resolveP25Phase1DemodMode("VOICE-X", tc.in); got != tc.want {
+			t.Errorf("resolveP25Phase1DemodMode(%q) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
+// dibitsToLSMIQTest synthesises an LSM IQ stream from a canonical-TIA
+// dibit sequence — the inverse of the receiver's LSM dibit remap
+// (0,1,3,2) feeds a π/4-DQPSK modulator at π/4 rotation. Copied from
+// the receiver package's test helper so the composer test doesn't have
+// to import internal symbols.
+func dibitsToLSMIQTest(dibits []uint8, sps, span int, alpha float64) []complex64 {
+	var lsmDibitRemap = [4]uint8{0, 1, 3, 2}
+	var inv [4]uint8
+	for i, m := range lsmDibitRemap {
+		inv[m] = uint8(i)
+	}
+	pre := make([]uint8, len(dibits))
+	for i, d := range dibits {
+		pre[i] = inv[d&3]
+	}
+	return demod.ModulatePiOver4DQPSK(pre, sps, span, alpha, math.Pi/4)
 }
 
 // TestComposerP25Phase1TouchGatedOnLDUProgress reproduces the


### PR DESCRIPTION
The voice chain hardcoded the C4FM demodulator regardless of the
system-level p25_phase1_demod_mode setting, so on a simulcast / LSM
site the control channel decoded fine (the ccdecoder connector
already honoured the setting) but every voice grant landed in an
FM-discriminator that couldn't sync on LSM-modulated dibits. No
LDU sink fires → the activity counter from the issue #356 fix
never advances → the watchdog cleanly reaps the call as
reason=timeout with an empty WAV. Reported on issue #356 (v0.2.4
follow-up) by @v2maldo.

Plumb the raw mode string from the system config through
p25phase1.Options to every published trunking.Grant, then have the
P25 Phase 1 voice chain parse it via the existing
p25p1rx.ParseDemodMode and pass the result as Options.DemodMode.
Empty / unrecognised values warn-log and fall back to C4FM so a
typo doesn't silently kill a previously-working system.