### PR TITLE
sdr+scanner: surface silent-degradation paths at startup (#356)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ for tagged releases.
 
 ### Fixed
 
+- **P25 Phase 1 voice chain now honours `p25_phase1_demod_mode`
+  (issue #356 follow-up, reporter @v2maldo).** The per-call P25
+  Phase 1 voice receiver was hardcoded to the C4FM
+  FM-discriminator path regardless of the system-level
+  `trunking.systems[].p25_phase1_demod_mode` setting. On a
+  simulcast / LSM site the control channel decoded fine (the
+  ccdecoder connector already honoured the setting) but every
+  voice grant landed in an FM-discriminator that couldn't sync on
+  LSM-modulated dibits — the LDU sink never fired, the
+  frame-activity counter from #356's earlier fix never advanced,
+  and the watchdog reaped the call at `call_timeout_ms` with an
+  empty WAV. The mode string is now plumbed through
+  `trunking.Grant` and the voice composer passes it into
+  `p25p1rx.Options.DemodMode`. Empty / unrecognised values warn-log
+  and fall back to C4FM so a typo doesn't silently kill a
+  previously-working system.
 - **RTL-SDR cold-boot stall on Windows: wider recovery envelope for the
   most stubborn clone dongles (issue #395).** A Windows 10 reporter on
   v0.2.4 still hit `rtlsdr: init baseband: init baseband step 0 ...
@@ -28,6 +44,23 @@ for tagged releases.
 
 ### Changed
 
+- **Operator-visible warnings for two silent-degradation paths
+  surfaced by issue #356 triage.** Both fix observability gaps
+  rather than behaviour, so a working config keeps working but a
+  misconfigured one now logs a single line at startup pointing
+  the operator at the fix.
+  - `sdr: no gain configured for device ... use \`gain: auto\` for
+    AGC or a specific tenth-dB value` — fires once per device that
+    has a `sdr.devices[]` entry but no `gain:` key. The librtlsdr
+    default isn't safe across every tuner / antenna / LNA chain;
+    on some clones it leaves the SDR deaf and the symptom looks
+    like a broken voice chain. See [docs/hardware.md](docs/hardware.md).
+  - `conv: tone gating configured but scanner sample rate is zero;
+    tone gate disabled` — fires when a conventional-scanner channel
+    has `tone.mode: ctcss` or `dcs` but `sdr.sample_rate` is
+    unset. The channel previously appeared in scan rotation with
+    the gate silently bypassed (every signal passing), with no log
+    explaining why CTCSS / DCS wasn't engaging.
 - **Motorola voice-channel talker-alias decoder (issue #376
   follow-up).** Field-testing on a real MMR system surfaced that
   the standard TIA-102.AABF HEADER + BLOCK1 + BLOCK2 form #389

--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -65,6 +65,16 @@ sdr:
       bias_tee: true           # 5V on the SMA — only enable if you want it
 ```
 
+> **Always set `gain:` explicitly.** A device listed in
+> `sdr.devices[]` with no `gain:` key opens at whatever the librtlsdr
+> default chose for the tuner — typically a middle-range fixed value
+> that's too low for many LNA + antenna combinations. The field
+> symptom is "voice grants land on a Voice SDR but every call ends
+> `reason=timeout` with an empty WAV" (issue #356 follow-up). The
+> daemon now surfaces this at startup with `sdr: no gain configured
+> for device ...`; if you see that line, set `gain: "auto"` for AGC
+> or pick a tenth-dB value that matches your front-end.
+
 ### HackRF tested combinations
 
 | Device | PID | Coverage | Gain chain | Bias-tee | Notes |

--- a/internal/scanner/conventional/ctcss_test.go
+++ b/internal/scanner/conventional/ctcss_test.go
@@ -1,7 +1,10 @@
 package conventional
 
 import (
+	"bytes"
+	"log/slog"
 	"math"
+	"strings"
 	"testing"
 )
 
@@ -166,14 +169,14 @@ func TestValidateTone(t *testing.T) {
 }
 
 func TestBuildDetector_CTCSSReturnsDetector(t *testing.T) {
-	d := buildDetector(ToneConfig{Mode: "ctcss", CTCSSHz: 100}, 48_000)
+	d := buildDetector(ToneConfig{Mode: "ctcss", CTCSSHz: 100}, 48_000, nil)
 	if d == nil {
 		t.Fatal("expected detector for ctcss/100Hz")
 	}
 }
 
 func TestBuildDetector_DCSReturnsDetector(t *testing.T) {
-	d := buildDetector(ToneConfig{Mode: "dcs", DCSCode: "023"}, 48_000)
+	d := buildDetector(ToneConfig{Mode: "dcs", DCSCode: "023"}, 48_000, nil)
 	if d == nil {
 		t.Fatal("expected detector for dcs/023")
 	}
@@ -186,13 +189,52 @@ func TestBuildDetector_DCSReturnsDetector(t *testing.T) {
 }
 
 func TestBuildDetector_NoneReturnsNil(t *testing.T) {
-	if buildDetector(ToneConfig{}, 48_000) != nil {
+	if buildDetector(ToneConfig{}, 48_000, nil) != nil {
 		t.Error("empty mode should yield nil")
 	}
 }
 
 func TestBuildDetector_NoSampleRateReturnsNil(t *testing.T) {
-	if buildDetector(ToneConfig{Mode: "ctcss", CTCSSHz: 100}, 0) != nil {
+	if buildDetector(ToneConfig{Mode: "ctcss", CTCSSHz: 100}, 0, nil) != nil {
 		t.Error("zero SampleHz should yield nil so the scanner runs without tone gating")
+	}
+}
+
+// TestBuildDetector_WarnsOnZeroSampleRateWithToneConfigured guards the
+// issue #356 follow-up: previously buildDetector silently returned nil
+// when SampleHz<=0 even though the channel had Mode="ctcss", leaving
+// operators unable to tell from logs why their CTCSS gate wasn't
+// engaging. The warn-log path is wired through Scanner.opts.Log, so
+// here we capture into a buffer and assert the message fires.
+func TestBuildDetector_WarnsOnZeroSampleRateWithToneConfigured(t *testing.T) {
+	var buf bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	if d := buildDetector(ToneConfig{Mode: "ctcss", CTCSSHz: 100}, 0, log); d != nil {
+		t.Fatalf("expected nil detector on zero sample rate, got %T", d)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "tone gating configured but scanner sample rate is zero") {
+		t.Errorf("expected warn log about zero sample rate, got %q", out)
+	}
+	if !strings.Contains(out, "ctcss") {
+		t.Errorf("warn log should include the configured tone mode; got %q", out)
+	}
+}
+
+// TestBuildDetector_SilentForUngatedChannel pins down the other half
+// of the contract: the warn ONLY fires when tone gating is actually
+// configured. The hot path through New() calls buildDetector on every
+// channel (ungated or not), so a noisy warn here would flood the
+// startup log on a 200-channel scan list.
+func TestBuildDetector_SilentForUngatedChannel(t *testing.T) {
+	var buf bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	if d := buildDetector(ToneConfig{}, 0, log); d != nil {
+		t.Fatalf("expected nil detector for empty mode, got %T", d)
+	}
+	if out := buf.String(); out != "" {
+		t.Errorf("ungated channel should emit no log output; got %q", out)
 	}
 }

--- a/internal/scanner/conventional/scanner.go
+++ b/internal/scanner/conventional/scanner.go
@@ -240,7 +240,7 @@ func New(opts Options) (*Scanner, error) {
 	}
 	detectors := make([]toneDetector, len(channels))
 	for i, ch := range channels {
-		if d := buildDetector(ch.Tone, opts.SampleRateHz); d != nil {
+		if d := buildDetector(ch.Tone, opts.SampleRateHz, opts.Log); d != nil {
 			detectors[i] = d
 		}
 	}
@@ -319,8 +319,24 @@ type toneDetector interface {
 // Goertzel-based CTCSSDetector; DCS routes to the Golay-based
 // DCSDetector. Returns nil for ungated channels or when SampleHz is
 // zero. The scanner treats nil as "no gating".
-func buildDetector(t ToneConfig, sampleHz float64) toneDetector {
+//
+// When tone gating IS configured but the detector can't be built
+// (zero sample rate, or the detector constructor refuses the inputs)
+// the function warn-logs through log so operators see why a CTCSS /
+// DCS channel they configured is passing every signal through
+// ungated. Issue #356 follow-up: the silent-nil path used to make
+// "my CTCSS doesn't work" impossible to diagnose from the logs
+// alone. log==nil suppresses the warning — kept for the existing
+// in-package unit tests that call buildDetector directly.
+func buildDetector(t ToneConfig, sampleHz float64, log *slog.Logger) toneDetector {
+	if t.Mode == "" || t.Mode == "none" {
+		return nil
+	}
 	if sampleHz <= 0 {
+		if log != nil {
+			log.Warn("conv: tone gating configured but scanner sample rate is zero; tone gate disabled — every signal passes the gate",
+				"mode", t.Mode, "ctcss_hz", t.CTCSSHz, "dcs_code", t.DCSCode)
+		}
 		return nil
 	}
 	switch t.Mode {
@@ -328,9 +344,17 @@ func buildDetector(t ToneConfig, sampleHz float64) toneDetector {
 		if d := NewCTCSSDetector(CTCSSConfig{SampleHz: sampleHz, TargetHz: t.CTCSSHz}); d != nil {
 			return d
 		}
+		if log != nil {
+			log.Warn("conv: CTCSS detector failed to initialise; tone gate disabled — every signal passes the gate",
+				"ctcss_hz", t.CTCSSHz, "sample_hz", sampleHz)
+		}
 	case "dcs":
 		if d := NewDCSDetector(DCSConfig{SampleHz: sampleHz, Code: t.DCSCode}); d != nil {
 			return d
+		}
+		if log != nil {
+			log.Warn("conv: DCS detector failed to initialise; tone gate disabled — every signal passes the gate",
+				"dcs_code", t.DCSCode, "sample_hz", sampleHz)
 		}
 	}
 	return nil
@@ -681,7 +705,7 @@ func (s *Scanner) AddTemporaryChannel(ch Channel) int {
 		s.log.Warn("conv: dropping invalid tone config on temp channel", "err", err)
 		ch.Tone = ToneConfig{}
 	}
-	det := buildDetector(ch.Tone, s.opts.SampleRateHz)
+	det := buildDetector(ch.Tone, s.opts.SampleRateHz, s.log)
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	idx := len(s.channels)

--- a/internal/sdr/pool.go
+++ b/internal/sdr/pool.go
@@ -283,6 +283,18 @@ func (p *Pool) applyHintSettings(dev Device, info Info, h Hint) {
 		if err := dev.SetGain(h.Gain); err != nil {
 			p.log.Warn("set gain failed", "serial", info.Serial, "gain", h.Gain, "err", err)
 		}
+	} else {
+		// Surface the "no `gain:` in config" path explicitly. Without
+		// this warn, a device whose driver default happens to be too
+		// low for the user's antenna + LNA chain reads as completely
+		// deaf — the field symptom in issue #356 (v0.2.4 follow-up,
+		// reporter @v2maldo). The driver-default gain varies between
+		// chips and even firmware revisions; surfacing it once at open
+		// gives the operator a chance to set `gain: auto` (AGC) or a
+		// specific tenth-dB value before chasing harder hypotheses
+		// like a broken voice chain.
+		p.log.Warn("sdr: no gain configured for device; using driver default — set `gain: auto` for AGC or a specific tenth-dB value (e.g. \"496\" = 49.6 dB) if reception is weak",
+			"serial", info.Serial, "role", h.Role.String())
 	}
 	if h.BiasTee {
 		if err := dev.SetBiasTee(true); err != nil {

--- a/internal/sdr/pool_test.go
+++ b/internal/sdr/pool_test.go
@@ -1,9 +1,12 @@
 package sdr
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"io"
+	"log/slog"
+	"strings"
 	"testing"
 )
 
@@ -174,6 +177,80 @@ func TestPoolFirstByRole(t *testing.T) {
 	}
 	if e := p.FirstByRole(RoleVoice); e == nil || e.Info.Serial != "Y" {
 		t.Errorf("voice = %+v, want Y", e)
+	}
+}
+
+// TestPoolWarnsOnHintWithoutGain guards the issue #356 follow-up
+// observation: a device that's listed in config but without a `gain:`
+// key was opened with whatever the driver default chose, with no
+// startup log to tell the operator. On clones whose default is too
+// low for the user's LNA + antenna chain the SDR reads as completely
+// deaf and the operator has no path from the symptom ("voice grants
+// time out with no audio") to the root cause ("no gain configured").
+// The warn must fire on every role, since a deaf control / wideband
+// device is just as bad as a deaf voice device.
+func TestPoolWarnsOnHintWithoutGain(t *testing.T) {
+	drv := &fakeDriver{name: "fake-nogain", infos: []Info{
+		{Driver: "fake-nogain", Index: 0, Serial: "NOGAIN-1"},
+	}}
+	registryMu.Lock()
+	registry["fake-nogain"] = drv
+	registryMu.Unlock()
+	t.Cleanup(func() {
+		registryMu.Lock()
+		delete(registry, "fake-nogain")
+		registryMu.Unlock()
+	})
+
+	var buf bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	p := NewPool(log)
+	// Hint with serial only — gain is unset.
+	if err := p.Open(0, []Hint{{Serial: "NOGAIN-1", Role: RoleVoice}}); err != nil {
+		t.Fatal(err)
+	}
+	defer p.Close()
+
+	out := buf.String()
+	if !strings.Contains(out, "no gain configured") {
+		t.Errorf("expected no-gain warn for NOGAIN-1; log was: %q", out)
+	}
+	if !strings.Contains(out, "NOGAIN-1") {
+		t.Errorf("warn should include the device serial; log was: %q", out)
+	}
+	if !strings.Contains(out, "gain: auto") {
+		t.Errorf("warn should suggest `gain: auto`; log was: %q", out)
+	}
+}
+
+// TestPoolSilentOnHintWithGain confirms the warn does NOT fire when
+// gain is explicitly configured (auto or numeric). A noisy warn here
+// would train operators to ignore the no-gain warn above.
+func TestPoolSilentOnHintWithGain(t *testing.T) {
+	drv := &fakeDriver{name: "fake-withgain", infos: []Info{
+		{Driver: "fake-withgain", Index: 0, Serial: "G-AUTO"},
+		{Driver: "fake-withgain", Index: 1, Serial: "G-FIXED"},
+	}}
+	registryMu.Lock()
+	registry["fake-withgain"] = drv
+	registryMu.Unlock()
+	t.Cleanup(func() {
+		registryMu.Lock()
+		delete(registry, "fake-withgain")
+		registryMu.Unlock()
+	})
+
+	var buf bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	p := NewPool(log)
+	autoHint := Hint{Serial: "G-AUTO", Role: RoleVoice}.WithGain(-1)
+	fixedHint := Hint{Serial: "G-FIXED", Role: RoleVoice}.WithGain(496)
+	if err := p.Open(0, []Hint{autoHint, fixedHint}); err != nil {
+		t.Fatal(err)
+	}
+	defer p.Close()
+	if out := buf.String(); strings.Contains(out, "no gain configured") {
+		t.Errorf("hints with gain set should not warn; log was: %q", out)
 	}
 }
 


### PR DESCRIPTION
## Summary

Picks up the two deferred items from issue #356 triage that don't depend on a user response — both are silent-degradation paths the operator can hit today with no log explaining what went wrong.

- **`sdr: no gain configured for device …`** — `internal/sdr/pool.go` now warn-logs when a device hinted via `sdr.devices[]` has no `gain:` key. The librtlsdr default isn't safe across every tuner / antenna / LNA chain; on some clones it leaves the SDR deaf. This is the field symptom @v2maldo reported (voice grants → `reason=timeout`, empty WAV) once the demod-mode plumbing in #399 ruled out the C4FM-on-LSM cause.
- **`conv: tone gating configured but scanner sample rate is zero; tone gate disabled`** — `internal/scanner/conventional/scanner.go::buildDetector` used to return `nil` silently when `Mode="ctcss"/"dcs"` and `SampleHz<=0`, so the gate was bypassed (every signal passing) with no log. The ungated-channel path stays silent so startup logs don't flood on large scan lists.

Both are observability-only — working configs keep working, only misconfigured ones get the new warn.

`docs/hardware.md` gets a callout next to the existing config snippet, and `CHANGELOG.md` covers these two changes plus the already-merged #399 demod-mode plumbing follow-up (which wasn't in `[Unreleased]` yet).

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./...` exit 0 (full suite)
- [x] New unit tests:
  - `TestBuildDetector_WarnsOnZeroSampleRateWithToneConfigured`
  - `TestBuildDetector_SilentForUngatedChannel`
  - `TestPoolWarnsOnHintWithoutGain`
  - `TestPoolSilentOnHintWithGain`
- [ ] Manual: bring up a daemon with an `sdr.devices[]` entry missing `gain:` and confirm the warn appears once at startup; add `gain: auto` and confirm it stops.
- [ ] Manual: configure a `tone.mode: ctcss` scanner channel with `sdr.sample_rate` unset and confirm the warn fires; set the rate and confirm it stops.

Out of scope (deferred to a separate issue pending @v2maldo's IQ capture + scanner config): the "synthetic NFM squelch stays open" and "CTCSS doesn't fire on -20 dB injected tone" observations from the issue #356 comment thread.

https://claude.ai/code/session_01XxtJA4JAhvweuSRFcajYHo

---
_Generated by [Claude Code](https://claude.ai/code/session_01XxtJA4JAhvweuSRFcajYHo)_