### PR TITLE
issue #402 phase 1: diagnostics for RTL-SDR DC-spike on P25 control

### DIFF
--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -1490,6 +1490,23 @@ func (d *Daemon) HTTPListenAddr() string {
 // synthetic events.
 func (d *Daemon) Bus() *events.Bus { return d.bus }
 
+// IQBroker returns the iqtap.Broker for the SDR with the given serial,
+// or nil when no such SDR is in the pool. Used by the --iq-capture
+// flag in main.go to attach a raw-IQ file writer to a live control
+// SDR (issue #402 diagnostic).
+func (d *Daemon) IQBroker(serial string) *iqtap.Broker { return d.iqBrokers[serial] }
+
+// IQBrokerSerials returns the serials of every SDR currently wired
+// through an iqtap.Broker. Used by --iq-capture to validate the
+// requested serial and to print a friendly hint on a miss.
+func (d *Daemon) IQBrokerSerials() []string {
+	out := make([]string, 0, len(d.iqBrokers))
+	for s := range d.iqBrokers {
+		out = append(out, s)
+	}
+	return out
+}
+
 // spawn runs fn in a goroutine. essential=true means a non-context
 // error from fn aborts the whole daemon (the launcher / TUI rely on
 // these components — silently demoting their failures to log warnings

--- a/cmd/gophertrunk/iqcapture.go
+++ b/cmd/gophertrunk/iqcapture.go
@@ -1,0 +1,204 @@
+package main
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"math"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/sdr/iqtap"
+)
+
+// iqCaptureSpec is the parsed form of the `--iq-capture` flag.
+// Empty Serial means the flag wasn't set; runIQCapture is a no-op.
+//
+// File format default is "f32" (GNU Radio cfile, little-endian
+// interleaved float32) — the IQ broker delivers complex64 chunks
+// directly, so f32 round-trips losslessly through replay.go's
+// decodeF32Replay. "u8" emits the rtl_sdr-native unsigned-8-bit shape
+// for operators who want to feed the capture into other tooling.
+type iqCaptureSpec struct {
+	Serial  string
+	Path    string
+	Seconds int
+	Format  string // "f32" or "u8"
+}
+
+// parseIQCaptureSpec parses "serial=<s>,path=<file>,seconds=<n>[,format=u8|f32]".
+// Returns the zero value when input is empty (flag not set).
+func parseIQCaptureSpec(s string) (iqCaptureSpec, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return iqCaptureSpec{}, nil
+	}
+	spec := iqCaptureSpec{Format: "f32"}
+	for _, kv := range strings.Split(s, ",") {
+		kv = strings.TrimSpace(kv)
+		if kv == "" {
+			continue
+		}
+		k, v, ok := strings.Cut(kv, "=")
+		if !ok {
+			return iqCaptureSpec{}, fmt.Errorf("iq-capture: malformed key=value %q", kv)
+		}
+		k = strings.ToLower(strings.TrimSpace(k))
+		v = strings.TrimSpace(v)
+		switch k {
+		case "serial":
+			spec.Serial = v
+		case "path":
+			spec.Path = v
+		case "seconds":
+			n, err := strconv.Atoi(v)
+			if err != nil || n <= 0 {
+				return iqCaptureSpec{}, fmt.Errorf("iq-capture: seconds must be a positive integer, got %q", v)
+			}
+			spec.Seconds = n
+		case "format":
+			f := strings.ToLower(v)
+			switch f {
+			case "f32", "u8":
+				spec.Format = f
+			default:
+				return iqCaptureSpec{}, fmt.Errorf("iq-capture: format must be u8 or f32, got %q", v)
+			}
+		default:
+			return iqCaptureSpec{}, fmt.Errorf("iq-capture: unknown key %q", k)
+		}
+	}
+	if spec.Serial == "" {
+		return iqCaptureSpec{}, errors.New("iq-capture: serial=<s> is required")
+	}
+	if spec.Path == "" {
+		return iqCaptureSpec{}, errors.New("iq-capture: path=<file> is required")
+	}
+	if spec.Seconds == 0 {
+		return iqCaptureSpec{}, errors.New("iq-capture: seconds=<n> is required")
+	}
+	return spec, nil
+}
+
+// runIQCapture subscribes to broker, writes the configured number of
+// seconds of raw IQ to spec.Path, then returns. ctx cancels the
+// capture early. Subscriber drops are counted in the broker's drop
+// counter and surfaced once at the end so the operator knows the
+// capture is incomplete — drops are NOT retried (the primary IQ
+// stream is what the daemon needs unimpeded). Issue #402 diagnostic.
+func runIQCapture(ctx context.Context, broker *iqtap.Broker, spec iqCaptureSpec, log *slog.Logger) error {
+	if broker == nil {
+		return fmt.Errorf("iq-capture: no broker for serial %q", spec.Serial)
+	}
+
+	f, err := os.Create(spec.Path)
+	if err != nil {
+		return fmt.Errorf("iq-capture: create %s: %w", spec.Path, err)
+	}
+	defer f.Close()
+
+	sub := broker.Subscribe()
+	defer sub.Close()
+
+	// Encode chunk → bytes per the requested format. Reused scratch
+	// buffer keeps the per-chunk allocation amortised.
+	var scratch []byte
+	encode := encodeF32
+	bytesPerSample := 8
+	if spec.Format == "u8" {
+		encode = encodeU8
+		bytesPerSample = 2
+	}
+
+	deadline := time.Now().Add(time.Duration(spec.Seconds) * time.Second)
+	log.Info("iq-capture: started",
+		"serial", spec.Serial, "path", spec.Path,
+		"seconds", spec.Seconds, "format", spec.Format)
+
+	var samplesWritten int64
+	for {
+		select {
+		case <-ctx.Done():
+			return finishIQCapture(log, spec, f, samplesWritten, bytesPerSample, sub.Dropped(), ctx.Err())
+		case chunk, ok := <-sub.C:
+			if !ok {
+				return finishIQCapture(log, spec, f, samplesWritten, bytesPerSample, sub.Dropped(), errors.New("iq-capture: broker closed before capture finished"))
+			}
+			if cap(scratch) < len(chunk)*bytesPerSample {
+				scratch = make([]byte, len(chunk)*bytesPerSample)
+			} else {
+				scratch = scratch[:len(chunk)*bytesPerSample]
+			}
+			encode(scratch, chunk)
+			if _, err := f.Write(scratch); err != nil {
+				return finishIQCapture(log, spec, f, samplesWritten, bytesPerSample, sub.Dropped(), fmt.Errorf("write: %w", err))
+			}
+			samplesWritten += int64(len(chunk))
+			if time.Now().After(deadline) {
+				return finishIQCapture(log, spec, f, samplesWritten, bytesPerSample, sub.Dropped(), nil)
+			}
+		}
+	}
+}
+
+func finishIQCapture(log *slog.Logger, spec iqCaptureSpec, f io.Closer, samples int64, bytesPerSample int, drops uint64, runErr error) error {
+	// Best-effort close; the deferred Close in runIQCapture also fires
+	// but we want flush/error visibility right here.
+	closeErr := f.Close()
+	args := []any{
+		"serial", spec.Serial, "path", spec.Path,
+		"samples", samples, "bytes", samples * int64(bytesPerSample),
+		"drops", drops,
+	}
+	if runErr != nil {
+		args = append(args, "err", runErr)
+		log.Warn("iq-capture: stopped", args...)
+		// Closing twice is harmless on *os.File; ignore the second
+		// "file already closed" error.
+		if closeErr != nil && !errors.Is(closeErr, os.ErrClosed) {
+			return fmt.Errorf("%w (and close: %v)", runErr, closeErr)
+		}
+		return runErr
+	}
+	log.Info("iq-capture: finished", args...)
+	if closeErr != nil && !errors.Is(closeErr, os.ErrClosed) {
+		return closeErr
+	}
+	return nil
+}
+
+// encodeF32 packs complex64 samples into interleaved little-endian
+// float32 — the GNU Radio cfile shape replay.go's decodeF32Replay
+// reads back.
+func encodeF32(dst []byte, src []complex64) {
+	for i, c := range src {
+		binary.LittleEndian.PutUint32(dst[8*i:], math.Float32bits(real(c)))
+		binary.LittleEndian.PutUint32(dst[8*i+4:], math.Float32bits(imag(c)))
+	}
+}
+
+// encodeU8 packs complex64 samples back into the rtl_sdr-native
+// unsigned-8-bit shape (inverse of decodeU8Replay): centre at 127.5,
+// scale by 127.5, clip to [0, 255]. Lossy — favour f32 unless the
+// downstream tool only consumes rtl_sdr-native bytes.
+func encodeU8(dst []byte, src []complex64) {
+	for i, c := range src {
+		dst[2*i] = clipU8(float64(real(c))*127.5 + 127.5)
+		dst[2*i+1] = clipU8(float64(imag(c))*127.5 + 127.5)
+	}
+}
+
+func clipU8(x float64) byte {
+	if x < 0 {
+		return 0
+	}
+	if x > 255 {
+		return 255
+	}
+	return byte(x + 0.5)
+}

--- a/cmd/gophertrunk/iqcapture_test.go
+++ b/cmd/gophertrunk/iqcapture_test.go
@@ -1,0 +1,170 @@
+package main
+
+import (
+	"math"
+	"strings"
+	"testing"
+)
+
+func TestParseIQCaptureSpec(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		want    iqCaptureSpec
+		wantErr string // substring; empty = expect success
+	}{
+		{
+			name: "empty input yields zero spec (flag not set)",
+			in:   "",
+			want: iqCaptureSpec{},
+		},
+		{
+			name: "minimum required keys, default format",
+			in:   "serial=76361606,path=mmr.cfile,seconds=10",
+			want: iqCaptureSpec{Serial: "76361606", Path: "mmr.cfile", Seconds: 10, Format: "f32"},
+		},
+		{
+			name: "explicit f32 format",
+			in:   "serial=ABC,path=x.cfile,seconds=5,format=f32",
+			want: iqCaptureSpec{Serial: "ABC", Path: "x.cfile", Seconds: 5, Format: "f32"},
+		},
+		{
+			name: "u8 format",
+			in:   "serial=ABC,path=x.bin,seconds=5,format=u8",
+			want: iqCaptureSpec{Serial: "ABC", Path: "x.bin", Seconds: 5, Format: "u8"},
+		},
+		{
+			name: "whitespace around keys + values is trimmed",
+			in:   " serial = AAA , path = / tmp / iq , seconds = 3 ",
+			want: iqCaptureSpec{Serial: "AAA", Path: "/ tmp / iq", Seconds: 3, Format: "f32"},
+		},
+		{
+			name:    "missing serial",
+			in:      "path=x,seconds=1",
+			wantErr: "serial",
+		},
+		{
+			name:    "missing path",
+			in:      "serial=A,seconds=1",
+			wantErr: "path",
+		},
+		{
+			name:    "missing seconds",
+			in:      "serial=A,path=x",
+			wantErr: "seconds",
+		},
+		{
+			name:    "zero seconds rejected",
+			in:      "serial=A,path=x,seconds=0",
+			wantErr: "positive",
+		},
+		{
+			name:    "negative seconds rejected",
+			in:      "serial=A,path=x,seconds=-1",
+			wantErr: "positive",
+		},
+		{
+			name:    "bad format rejected",
+			in:      "serial=A,path=x,seconds=1,format=wav",
+			wantErr: "format",
+		},
+		{
+			name:    "unknown key rejected",
+			in:      "serial=A,path=x,seconds=1,wat=1",
+			wantErr: "unknown key",
+		},
+		{
+			name:    "malformed key=value rejected",
+			in:      "serial=A,pathx,seconds=1",
+			wantErr: "malformed",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseIQCaptureSpec(tc.in)
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil (spec=%+v)", tc.wantErr, got)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Errorf("error %q missing substring %q", err.Error(), tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("spec = %+v, want %+v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestEncodeF32RoundTripsThroughReplay locks down the wire shape: the
+// f32 cfile bytes the capture writer emits must round-trip cleanly
+// through replay.go's decodeF32Replay so the captured file can be
+// fed directly into `gophertrunk replay -format f32` without surprises.
+func TestEncodeF32RoundTripsThroughReplay(t *testing.T) {
+	in := []complex64{
+		complex(0.0, 0.0),
+		complex(0.25, -0.25),
+		complex(-0.5, 0.75),
+		complex(1.0, -1.0),
+	}
+	buf := make([]byte, len(in)*8)
+	encodeF32(buf, in)
+
+	out := make([]complex64, len(in))
+	decodeF32Replay(buf, out)
+	for i := range in {
+		if out[i] != in[i] {
+			t.Errorf("[%d] decoded %v, want %v", i, out[i], in[i])
+		}
+	}
+}
+
+// TestEncodeU8RoundTripsThroughReplay verifies the u8 path encodes
+// inversely to replay.go's decodeU8Replay (within the 8-bit
+// quantisation step, ~1/128 ≈ 0.008).
+func TestEncodeU8RoundTripsThroughReplay(t *testing.T) {
+	in := []complex64{
+		complex(0.0, 0.0),
+		complex(0.25, -0.25),
+		complex(-0.5, 0.5),
+		complex(0.99, -0.99),
+	}
+	buf := make([]byte, len(in)*2)
+	encodeU8(buf, in)
+
+	out := make([]complex64, len(in))
+	decodeU8Replay(buf, out)
+	const tol = 1.0 / 127.5 // one quantisation step
+	for i := range in {
+		dR := math.Abs(float64(real(out[i]) - real(in[i])))
+		dI := math.Abs(float64(imag(out[i]) - imag(in[i])))
+		if dR > tol || dI > tol {
+			t.Errorf("[%d] decoded %v, want ~%v (tol=%v)", i, out[i], in[i], tol)
+		}
+	}
+}
+
+// TestEncodeU8Clips checks the saturating-clip behaviour: out-of-range
+// inputs (|x| > 1) shouldn't wrap, they should saturate at the u8
+// endpoints. Real SDR samples land in [-1, +1] but a synthesised
+// test signal might exceed that.
+func TestEncodeU8Clips(t *testing.T) {
+	in := []complex64{
+		complex(5.0, -5.0),
+		complex(-10.0, 10.0),
+	}
+	buf := make([]byte, len(in)*2)
+	encodeU8(buf, in)
+	if buf[0] != 255 || buf[1] != 0 {
+		t.Errorf("positive sat = (%d,%d), want (255,0)", buf[0], buf[1])
+	}
+	if buf[2] != 0 || buf[3] != 255 {
+		t.Errorf("negative sat = (%d,%d), want (0,255)", buf[2], buf[3])
+	}
+}

--- a/cmd/gophertrunk/main.go
+++ b/cmd/gophertrunk/main.go
@@ -98,7 +98,19 @@ func runDaemon(args []string) {
 	wantTUI := fs.Bool("tui", false, "launch the in-process operator TUI after the daemon comes up")
 	wantWeb := fs.Bool("web", false, "open the bundled web UI in the system browser after the daemon comes up")
 	wantHL := fs.Bool("headless", false, "skip the launcher prompt; daemon runs silent (default for non-TTY stdin)")
+	// IQ capture diagnostic — taps a live SDR's iqtap broker and writes
+	// raw IQ samples to a file for offline analysis. Used to capture a
+	// reproducible fixture for replay (issue #402).
+	iqCapture := fs.String("iq-capture", "", "capture raw IQ from a live SDR for offline analysis (issue #402). Format: serial=<s>,path=<file>,seconds=<n>[,format=u8|f32] (default format=f32, GNU Radio cfile)")
 	_ = fs.Parse(args)
+
+	// Parse the iq-capture spec early so a typo doesn't blow up after
+	// the daemon's been running for 10 seconds.
+	captureSpec, err := parseIQCaptureSpec(*iqCapture)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(2)
+	}
 
 	mode, err := pickLaunchMode(*wantTUI, *wantWeb, *wantHL)
 	if err != nil {
@@ -238,6 +250,27 @@ func runDaemon(args []string) {
 			os.Exit(1)
 		}
 		return
+	}
+
+	// --iq-capture (issue #402 diagnostic): with the daemon up,
+	// subscribe to the requested SDR's broker and dump raw IQ to disk
+	// for offline analysis via `gophertrunk replay`. Runs concurrently
+	// with normal decoding; non-fatal on its own — a capture failure
+	// is logged but doesn't tear the daemon down.
+	if captureSpec.Serial != "" {
+		br := d.IQBroker(captureSpec.Serial)
+		if br == nil {
+			fmt.Fprintf(os.Stderr,
+				"iq-capture: no SDR with serial %q in pool (have: %v)\n",
+				captureSpec.Serial, d.IQBrokerSerials())
+			os.Exit(2)
+		}
+		go func() {
+			if err := runIQCapture(ctx, br, captureSpec, logger); err != nil &&
+				!errors.Is(err, context.Canceled) {
+				logger.Warn("iq-capture: failed", "err", err)
+			}
+		}()
 	}
 
 	// Daemon is up. Hand control to the launcher.

--- a/internal/metrics/prom.go
+++ b/internal/metrics/prom.go
@@ -46,6 +46,7 @@ type Metrics struct {
 	ccTransitions *prometheus.CounterVec // by system,event (locked|lost)
 	iqUnderruns   *prometheus.CounterVec
 	iqPowerDbFS   *prometheus.GaugeVec // by system; mean IQ power on the control SDR
+	iqDCRatioDb   *prometheus.GaugeVec // by system; DC-bin power relative to total IQ power, in dB (issue #402)
 	usbReconnects *prometheus.CounterVec
 	decodeErrors  *prometheus.CounterVec
 	sdrAttached   *prometheus.GaugeVec
@@ -133,6 +134,20 @@ func New(bus *events.Bus, pool Snapshotter, version string) (*Metrics, error) {
 		Help:      "Mean IQ power on the control SDR in dBFS (window ~= 1 s). Idle ≈ -45; healthy signal ≈ -25; > -3 indicates clipping.",
 	}, []string{"system"})
 
+	// Diagnostic for the RTL-SDR R820T2 zero-IF DC-spike-on-channel
+	// failure mode (issue #402): the DC bin power of the same window
+	// the iq_power_dbfs gauge is computed over, expressed relative to
+	// total IQ power in dB. 0 dB means all channel power is in the
+	// DC bin; -20 dB or lower is a clean off-DC signal. Watch for
+	// values above -10 dB on a tuned-on-channel P25 control: that's
+	// the spike sitting on top of the channel.
+	m.iqDCRatioDb = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: namespace,
+		Subsystem: "sdr",
+		Name:      "iq_dc_ratio_db",
+		Help:      "DC-bin power relative to total IQ power, in dB (window ~= 1 s). 0 = all power is DC; -20 or lower = clean. > -10 on a tuned-on-channel control SDR hints at the R820T2 DC-spike failure mode tracked in issue #402.",
+	}, []string{"system"})
+
 	m.usbReconnects = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: namespace,
 		Subsystem: "sdr",
@@ -174,6 +189,7 @@ func New(bus *events.Bus, pool Snapshotter, version string) (*Metrics, error) {
 		m.ccTransitions,
 		m.iqUnderruns,
 		m.iqPowerDbFS,
+		m.iqDCRatioDb,
 		m.usbReconnects,
 		m.decodeErrors,
 		m.sdrAttached,
@@ -316,6 +332,26 @@ func (m *Metrics) ClearIQPowerDbFS(system string) {
 		return
 	}
 	m.iqPowerDbFS.DeleteLabelValues(system)
+}
+
+// RecordIQDCRatioDb sets the DC-bin-to-total IQ power ratio gauge for
+// system. The decoder computes this once per IQ-power window; the
+// metrics package just stores it. See iqDCRatioDb's Help text for
+// interpretation guidance (issue #402).
+func (m *Metrics) RecordIQDCRatioDb(system string, ratioDb float64) {
+	if system == "" {
+		system = "unknown"
+	}
+	m.iqDCRatioDb.WithLabelValues(system).Set(ratioDb)
+}
+
+// ClearIQDCRatioDb drops the DC-ratio gauge series for system. Called
+// alongside ClearIQPowerDbFS when a decoder pipeline tears down.
+func (m *Metrics) ClearIQDCRatioDb(system string) {
+	if system == "" {
+		return
+	}
+	m.iqDCRatioDb.DeleteLabelValues(system)
 }
 
 // RecordUSBReconnect increments the reconnect counter for the supplied SDR.

--- a/internal/metrics/prom_test.go
+++ b/internal/metrics/prom_test.go
@@ -179,6 +179,31 @@ func TestRecordIQPowerDbFS(t *testing.T) {
 	}
 }
 
+func TestRecordIQDCRatioDb(t *testing.T) {
+	m, _ := New(nil, nil, "test")
+	defer m.Close()
+
+	m.RecordIQDCRatioDb("MMR", -22.0)
+	if got := testutil.ToFloat64(m.iqDCRatioDb.WithLabelValues("MMR")); got != -22.0 {
+		t.Errorf("iq dc ratio = %v, want -22.0", got)
+	}
+
+	m.RecordIQDCRatioDb("MMR", -3.0) // DC-dominated capture
+	if got := testutil.ToFloat64(m.iqDCRatioDb.WithLabelValues("MMR")); got != -3.0 {
+		t.Errorf("iq dc ratio after update = %v, want -3.0", got)
+	}
+
+	m.ClearIQDCRatioDb("MMR")
+	if testutil.CollectAndCount(m.iqDCRatioDb) != 0 {
+		t.Errorf("iq dc ratio series count after clear != 0")
+	}
+
+	m.RecordIQDCRatioDb("", -15.0)
+	if got := testutil.ToFloat64(m.iqDCRatioDb.WithLabelValues("unknown")); got != -15.0 {
+		t.Errorf("iq dc ratio unknown = %v, want -15.0", got)
+	}
+}
+
 func TestHandlerScrapeContainsExpectedSeries(t *testing.T) {
 	m, _ := New(nil, nil, "v1.2.3")
 	defer m.Close()

--- a/internal/scanner/ccdecoder/decoder.go
+++ b/internal/scanner/ccdecoder/decoder.go
@@ -58,9 +58,20 @@ import (
 // IQPowerObserver is the minimal Metrics surface the decoder uses to
 // publish its window-averaged dBFS gauge. internal/metrics.Metrics
 // satisfies this; nil disables the gauge entirely.
+//
+// RecordIQDCRatioDb reports the per-window DC-bin power relative to
+// total IQ power, in dB (so 0 means all power is in the DC bin, very
+// negative means the DC content is negligible). It surfaces the
+// RTL-SDR R820T2 DC-spike-on-channel failure mode behind issue #402:
+// when the channel of interest sits on top of the tuner zero, the
+// DC bin dominates the 48 kHz pipeline passband and the C4FM eye
+// collapses. Healthy off-channel signals show ≤ -20 dB; a
+// DC-dominated capture shows within ~5 dB of 0.
 type IQPowerObserver interface {
 	RecordIQPowerDbFS(system string, dbfs float64)
 	ClearIQPowerDbFS(system string)
+	RecordIQDCRatioDb(system string, ratioDb float64)
+	ClearIQDCRatioDb(system string)
 }
 
 // ErrIQStreamClosed is returned by Run whenever the SDR's IQ stream is
@@ -85,6 +96,14 @@ const iqPowerWindow = time.Second
 // the idle-noise floor for an R820T2 at moderate gain (~-45 dBFS)
 // so legitimate weak signal doesn't trip it.
 const iqLowPowerThresholdDbFS = -55.0
+
+// iqDCRatioWarnDb is the dc-to-total power ratio (in dB) above which
+// observeIQPowerLocked emits a throttled debug log noting that the
+// IQ DC bin dominates the channel passband. -10 dB picks up the
+// RTL-SDR R820T2 zero-IF DC-spike case (where the spike is within
+// ~5 dB of total channel power) without firing on benign captures
+// of a tone-rich broadcast channel. Issue #402.
+const iqDCRatioWarnDb = -10.0
 
 // Tuner is the subset of sdr.Device the decoder uses for retuning.
 // Matches the same interface cchunt + conventional consume so the
@@ -164,9 +183,12 @@ type Decoder struct {
 	// goroutine reads it.
 	metrics      IQPowerObserver
 	pwSumSq      float64
+	pwSumI       float64 // running sum of I samples → DC-bin mean (issue #402)
+	pwSumQ       float64 // running sum of Q samples → DC-bin mean (issue #402)
 	pwSamples    int
 	pwWindowAt   time.Time
 	pwLowLogAt   time.Time
+	pwDCLogAt    time.Time // throttle for the "DC bin dominant" debug line (issue #402)
 	pwLastSystem string
 }
 
@@ -321,9 +343,12 @@ func (d *Decoder) clearActiveLocked() {
 	}
 	if d.activeAt != "" && d.metrics != nil {
 		d.metrics.ClearIQPowerDbFS(d.activeAt)
+		d.metrics.ClearIQDCRatioDb(d.activeAt)
 	}
 	d.activeAt = ""
 	d.pwSumSq = 0
+	d.pwSumI = 0
+	d.pwSumQ = 0
 	d.pwSamples = 0
 	d.pwLastSystem = ""
 }
@@ -382,6 +407,8 @@ func (d *Decoder) observeIQPowerLocked(iq []complex64) {
 	// don't fold old samples into the new one's average.
 	if d.activeAt != d.pwLastSystem {
 		d.pwSumSq = 0
+		d.pwSumI = 0
+		d.pwSumQ = 0
 		d.pwSamples = 0
 		d.pwLastSystem = d.activeAt
 	}
@@ -389,6 +416,8 @@ func (d *Decoder) observeIQPowerLocked(iq []complex64) {
 		r := float64(real(c))
 		i := float64(imag(c))
 		d.pwSumSq += r*r + i*i
+		d.pwSumI += r
+		d.pwSumQ += i
 	}
 	d.pwSamples += len(iq)
 
@@ -400,22 +429,51 @@ func (d *Decoder) observeIQPowerLocked(iq []complex64) {
 	if now.Sub(d.pwWindowAt) < iqPowerWindow {
 		return
 	}
-	mean := d.pwSumSq / float64(d.pwSamples)
+	n := float64(d.pwSamples)
+	mean := d.pwSumSq / n
 	// 10*log10(0) is -Inf; clamp with a small epsilon so the gauge
 	// reads as "very low" instead of breaking JSON encoders.
 	if mean < 1e-12 {
 		mean = 1e-12
 	}
 	dbfs := 10 * math.Log10(mean)
+	// DC-bin power: |mean(IQ)|² across the window. The DFT bin at 0 Hz
+	// of a finite window is the sample mean; the per-sample power
+	// contributed by a static carrier at DC is its squared magnitude.
+	// Comparing it to the total mean power (in dB) tells the operator
+	// what fraction of the channel passband is DC content — a smoking
+	// gun for the R820T2 DC-spike-on-channel failure mode behind issue
+	// #402. Healthy off-channel signals: ≤ -20 dB. A
+	// DC-dominated capture sits within ~5 dB of 0.
+	dcMeanI := d.pwSumI / n
+	dcMeanQ := d.pwSumQ / n
+	dcPower := dcMeanI*dcMeanI + dcMeanQ*dcMeanQ
+	if dcPower < 1e-12 {
+		dcPower = 1e-12
+	}
+	dcDbfs := 10 * math.Log10(dcPower)
+	ratioDb := dcDbfs - dbfs
 	if d.activeAt != "" && d.metrics != nil {
 		d.metrics.RecordIQPowerDbFS(d.activeAt, dbfs)
+		d.metrics.RecordIQDCRatioDb(d.activeAt, ratioDb)
 	}
 	if dbfs < iqLowPowerThresholdDbFS && now.Sub(d.pwLowLogAt) >= 5*time.Second {
 		d.log.Debug("ccdecoder: iq power very low — check antenna, gain, USB",
-			"system", d.activeAt, "dbfs", dbfs)
+			"system", d.activeAt, "dbfs", dbfs, "dc_dbfs", dcDbfs, "dc_ratio_db", ratioDb)
 		d.pwLowLogAt = now
+	} else if ratioDb > iqDCRatioWarnDb && now.Sub(d.pwDCLogAt) >= 30*time.Second {
+		// DC bin within iqDCRatioWarnDb of total — the channel of
+		// interest sits on top of the tuner zero. Logged at debug so
+		// the gauge is the primary signal; the throttled log line gives
+		// operators without Prometheus a hint of the failure mode (issue
+		// #402).
+		d.log.Debug("ccdecoder: iq DC bin dominant — RTL-SDR DC spike on channel? see issue #402",
+			"system", d.activeAt, "dbfs", dbfs, "dc_dbfs", dcDbfs, "dc_ratio_db", ratioDb)
+		d.pwDCLogAt = now
 	}
 	d.pwSumSq = 0
+	d.pwSumI = 0
+	d.pwSumQ = 0
 	d.pwSamples = 0
 	d.pwWindowAt = now
 }

--- a/internal/scanner/ccdecoder/decoder_test.go
+++ b/internal/scanner/ccdecoder/decoder_test.go
@@ -986,10 +986,10 @@ func TestMPT1327FactoryAppliesBCHFromSystem(t *testing.T) {
 // tests can assert the decoder's pump-side observation pipeline
 // without depending on the real Prometheus collector.
 type recordingPower struct {
-	sets       []powerSample
-	cleared    []string
-	dcSets     []dcSample
-	dcCleared  []string
+	sets      []powerSample
+	cleared   []string
+	dcSets    []dcSample
+	dcCleared []string
 }
 
 type powerSample struct {

--- a/internal/scanner/ccdecoder/decoder_test.go
+++ b/internal/scanner/ccdecoder/decoder_test.go
@@ -986,8 +986,10 @@ func TestMPT1327FactoryAppliesBCHFromSystem(t *testing.T) {
 // tests can assert the decoder's pump-side observation pipeline
 // without depending on the real Prometheus collector.
 type recordingPower struct {
-	sets    []powerSample
-	cleared []string
+	sets       []powerSample
+	cleared    []string
+	dcSets     []dcSample
+	dcCleared  []string
 }
 
 type powerSample struct {
@@ -995,11 +997,22 @@ type powerSample struct {
 	dbfs   float64
 }
 
+type dcSample struct {
+	system  string
+	ratioDb float64
+}
+
 func (r *recordingPower) RecordIQPowerDbFS(system string, dbfs float64) {
 	r.sets = append(r.sets, powerSample{system, dbfs})
 }
 func (r *recordingPower) ClearIQPowerDbFS(system string) {
 	r.cleared = append(r.cleared, system)
+}
+func (r *recordingPower) RecordIQDCRatioDb(system string, ratioDb float64) {
+	r.dcSets = append(r.dcSets, dcSample{system, ratioDb})
+}
+func (r *recordingPower) ClearIQDCRatioDb(system string) {
+	r.dcCleared = append(r.dcCleared, system)
 }
 
 // TestPumpRecordsIQPowerOnceWindowElapses feeds a known signal level
@@ -1047,6 +1060,116 @@ func TestPumpRecordsIQPowerOnceWindowElapses(t *testing.T) {
 	// |0.5+0.5i|^2 = 0.5 → 10*log10(0.5) = -3.01 dBFS
 	if got.dbfs < -3.5 || got.dbfs > -2.5 {
 		t.Errorf("dbfs = %v, want roughly -3", got.dbfs)
+	}
+}
+
+// TestPumpRecordsIQDCRatioPureDC drives observeIQPowerLocked with a
+// constant-IQ chunk (all energy in the DC bin) and asserts the new
+// DC-ratio gauge reports ~0 dB — the smoking-gun shape of the RTL-SDR
+// R820T2 DC-spike-on-channel failure mode behind issue #402.
+func TestPumpRecordsIQDCRatioPureDC(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	pwr := &recordingPower{}
+	d, err := New(Options{
+		Bus: bus, IQ: &fakeIQSource{}, SampleRateHz: 48000, Metrics: pwr,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	d.activeAt = "TestSys"
+
+	chunk := make([]complex64, 128)
+	for i := range chunk {
+		chunk[i] = complex(0.3, 0.4) // constant ⇒ mean(IQ) = sample, |mean|² = |sample|²
+	}
+
+	d.pump(chunk)
+	d.pwWindowAt = d.pwWindowAt.Add(-2 * iqPowerWindow)
+	d.pump(chunk)
+
+	if len(pwr.dcSets) != 1 {
+		t.Fatalf("dcSets = %d, want 1", len(pwr.dcSets))
+	}
+	got := pwr.dcSets[0]
+	if got.system != "TestSys" {
+		t.Errorf("system = %q, want TestSys", got.system)
+	}
+	// All sample energy is in the mean → DC power == total power → 0 dB.
+	if got.ratioDb < -0.5 || got.ratioDb > 0.5 {
+		t.Errorf("dc_ratio_db = %v, want ~0 (DC-dominated)", got.ratioDb)
+	}
+}
+
+// TestPumpRecordsIQDCRatioCleanSignal drives the observer with a
+// zero-mean signal (a half-rate complex sinusoid) and asserts the
+// DC-ratio gauge reports a very negative value — the shape of a clean
+// off-channel capture, which serves as the regression guard against
+// false-positive DC alarms.
+func TestPumpRecordsIQDCRatioCleanSignal(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	pwr := &recordingPower{}
+	d, err := New(Options{
+		Bus: bus, IQ: &fakeIQSource{}, SampleRateHz: 48000, Metrics: pwr,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	d.activeAt = "TestSys"
+
+	chunk := make([]complex64, 128)
+	for i := range chunk {
+		// Alternating ±(0.5+0.5i) — pure tone at fs/2, sample mean is 0.
+		if i%2 == 0 {
+			chunk[i] = complex(0.5, 0.5)
+		} else {
+			chunk[i] = complex(-0.5, -0.5)
+		}
+	}
+
+	d.pump(chunk)
+	d.pwWindowAt = d.pwWindowAt.Add(-2 * iqPowerWindow)
+	d.pump(chunk)
+
+	if len(pwr.dcSets) != 1 {
+		t.Fatalf("dcSets = %d, want 1", len(pwr.dcSets))
+	}
+	got := pwr.dcSets[0]
+	// Mean(IQ) = 0 → DC power = 0 → DC dBFS clamped at the -120 dBFS
+	// epsilon floor (10·log10(1e-12)). Total dBFS ≈ -3 (|0.5+0.5i|² = 0.5).
+	// ratio = dc - total ≈ -117 dB. Assert well below the
+	// iqDCRatioWarnDb threshold; the exact value is sensitive to the
+	// epsilon floor and not interesting.
+	if got.ratioDb > -60 {
+		t.Errorf("dc_ratio_db = %v, want very negative (zero-mean signal)", got.ratioDb)
+	}
+}
+
+// TestClearActiveClearsDCRatio asserts that tearing the active pipeline
+// down drops the DC-ratio gauge series alongside the IQ-power gauge —
+// so stale ratios don't linger after a retune to a different system.
+func TestClearActiveClearsDCRatio(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	pwr := &recordingPower{}
+	d, err := New(Options{
+		Bus: bus, IQ: &fakeIQSource{}, SampleRateHz: 48000, Metrics: pwr,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	d.activeAt = "TestSys"
+
+	d.mu.Lock()
+	d.clearActiveLocked()
+	d.mu.Unlock()
+
+	if len(pwr.cleared) != 1 || pwr.cleared[0] != "TestSys" {
+		t.Errorf("cleared (power) = %v, want [TestSys]", pwr.cleared)
+	}
+	if len(pwr.dcCleared) != 1 || pwr.dcCleared[0] != "TestSys" {
+		t.Errorf("cleared (dc) = %v, want [TestSys]", pwr.dcCleared)
 	}
 }
 


### PR DESCRIPTION
Adds the two diagnostics the plan calls for before the LO-offset DDC
change ships in phase 2:

  - ccdecoder reports an IQ DC-bin power ratio (in dB relative to total
    IQ power) once per iqPowerWindow alongside the existing iq_power
    gauge. DC-dominated captures sit within ~5 dB of 0 — the smoking-
    gun shape of the R820T2 zero-IF spike landing on the channel of
    interest. A throttled debug log fires above -10 dB so operators
    without Prometheus still see the failure mode. Exposed as the
    gophertrunk_sdr_iq_dc_ratio_db gauge.
  - A --iq-capture=serial=<s>,path=<file>,seconds=<n>[,format=u8|f32]
    daemon flag subscribes to the matching iqtap broker and writes raw
    IQ to disk. Default f32 (lossless GNU Radio cfile) feeds straight
    into gophertrunk replay -format f32 for offline diagnosis on a
    reproducible fixture.

No behaviour change on quiet sites; the gauge is purely informational
and the capture flag is opt-in. Phase 2 (the LO-offset DDC) will land
once the new diagnostics confirm the hypothesis on real hardware.

https://claude.ai/code/session_01DnNfGPVwyVBPTMFFE3BL4v