### PR TITLE
ui/cc-activity: promote patch member TGs over the SG (issue #405)

### DIFF
--- a/web/src/panels/CCActivity.test.tsx
+++ b/web/src/panels/CCActivity.test.tsx
@@ -154,7 +154,7 @@ describe("CCActivity panel", () => {
     expect(screen.queryByText("County DMR")).not.toBeInTheDocument();
   });
 
-  it("renders patch events with member count", () => {
+  it("renders patch add events with member TGs promoted over the SG", () => {
     setEvents([
       {
         kind: "patch",
@@ -171,9 +171,39 @@ describe("CCActivity panel", () => {
     const row = screen.getByText("Metro P25").closest("tr");
     expect(row).not.toBeNull();
     expect(row!.textContent).toMatch(/Patch/);
-    expect(row!.textContent).toMatch(/super-group 999/);
-    expect(row!.textContent).toMatch(/3 members/);
-    expect(row!.textContent).toMatch(/· add/);
+    expect(row!.textContent).toMatch(/Patch Active:/);
+    expect(row!.textContent).toMatch(/TG 101/);
+    expect(row!.textContent).toMatch(/TG 102/);
+    expect(row!.textContent).toMatch(/TG 103/);
+    expect(row!.textContent).toMatch(/\[SG 999\]/);
+  });
+
+  it("resolves member talkgroup aliases from the shared TGDB", () => {
+    setEvents([
+      {
+        kind: "patch",
+        timestamp: "2026-05-26T12:00:00Z",
+        payload: {
+          system: "Metro P25",
+          super_group: 30201,
+          members: [101, 102],
+          add: true,
+        },
+      },
+    ]);
+    useShared.setState({
+      talkgroups: [
+        { id: 101, alpha_tag: "NORTH DISP 1" },
+        { id: 102, alpha_tag: "NORTH TAC 2" },
+      ],
+    });
+    renderPanel();
+    const row = screen.getByText("Metro P25").closest("tr");
+    expect(row).not.toBeNull();
+    expect(row!.textContent).toMatch(/Patch Active:/);
+    expect(row!.textContent).toMatch(/NORTH DISP 1 \(101\)/);
+    expect(row!.textContent).toMatch(/NORTH TAC 2 \(102\)/);
+    expect(row!.textContent).toMatch(/\[SG 30201\]/);
   });
 
   it("renders patch cancel events when add is false", () => {
@@ -192,8 +222,9 @@ describe("CCActivity panel", () => {
     renderPanel();
     const row = screen.getByText("Metro P25").closest("tr");
     expect(row).not.toBeNull();
-    expect(row!.textContent).toMatch(/super-group 999/);
-    expect(row!.textContent).toMatch(/· cancel/);
+    expect(row!.textContent).toMatch(/Patch Cancelled:/);
+    expect(row!.textContent).toMatch(/TG 101/);
+    expect(row!.textContent).toMatch(/\[SG 999\]/);
   });
 
   it("renders talker alias events", () => {

--- a/web/src/panels/CCActivity.tsx
+++ b/web/src/panels/CCActivity.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 import { useShared } from "../store/shared";
-import type { EventDTO } from "../api/types";
+import type { EventDTO, TalkgroupDTO } from "../api/types";
 
 // CC Activity panel — a focused view of the trunked control-channel
 // "chatter" already flowing on the events bus. Filters the rolling
@@ -56,16 +56,19 @@ function ridLink(rid: number) {
 
 export function CCActivity() {
   const events = useShared((s) => s.events);
+  const talkgroups = useShared((s) => s.talkgroups);
   const [paused, setPaused] = useState(false);
   const [systemFilter, setSystemFilter] = useState("");
   const [kindFilter, setKindFilter] = useState<string>("");
 
   const rows = useMemo<Row[]>(() => {
+    const tgByID = new Map<number, TalkgroupDTO>();
+    for (const tg of talkgroups) tgByID.set(tg.id, tg);
     const list: Row[] = [];
     for (const ev of events) {
       const label = CC_KINDS[ev.kind];
       if (!label) continue;
-      const row = renderRow(ev, label);
+      const row = renderRow(ev, label, tgByID);
       if (!row) continue;
       if (systemFilter && !row.system.toLowerCase().includes(systemFilter.toLowerCase())) {
         continue;
@@ -75,7 +78,7 @@ export function CCActivity() {
     }
     // Newest first.
     return list.reverse();
-  }, [events, systemFilter, kindFilter]);
+  }, [events, talkgroups, systemFilter, kindFilter]);
 
   return (
     <div className="space-y-3">
@@ -153,7 +156,11 @@ export function CCActivity() {
   );
 }
 
-function renderRow(ev: EventDTO, label: string): Row | null {
+function renderRow(
+  ev: EventDTO,
+  label: string,
+  tgByID: Map<number, TalkgroupDTO>,
+): Row | null {
   const payload = (ev.payload ?? {}) as Record<string, unknown>;
   switch (ev.kind) {
     case "grant":
@@ -215,12 +222,28 @@ function renderRow(ev: EventDTO, label: string): Row | null {
     case "patch": {
       const system = str(payload.system);
       const superGroup = num(payload.super_group ?? payload.regroup_id);
-      const members = (payload.members ?? []) as unknown[];
+      const memberIDs = ((payload.members ?? []) as unknown[])
+        .map((m) => num(m))
+        .filter((n) => n > 0);
       const op = payload.add === false || payload.cancelled || payload.removed ? "cancel" : "add";
-      const details =
-        `super-group ${superGroup}` +
-        (members.length ? ` · ${members.length} member${members.length === 1 ? "" : "s"}` : "") +
-        ` · ${op}`;
+      const verb = op === "add" ? "Patch Active" : "Patch Cancelled";
+      const memberNodes = memberIDs.map((id, i) => {
+        const tg = tgByID.get(id);
+        const text = tg?.alpha_tag ? `${tg.alpha_tag} (${id})` : `TG ${id}`;
+        return (
+          <span key={id}>
+            {i > 0 ? " & " : ""}
+            {text}
+          </span>
+        );
+      });
+      const details = (
+        <>
+          {`${verb}: `}
+          {memberNodes.length > 0 ? memberNodes : <span className="text-muted">no members</span>}
+          {superGroup ? <span className="text-muted">{` [SG ${superGroup}]`}</span> : null}
+        </>
+      );
       return { ts: ev.timestamp, kind: ev.kind, label, system, details, raw: ev.payload };
     }
     case "talker.alias": {


### PR DESCRIPTION
The patch row used to lead with the Motorola super-group ID
("super-group 30201 · 2 members · add"), but the SG is an internal
patch construct operators don't recognize — the member talkgroups
are the meaningful dispatch identifiers. Reformat the patch row to
lead with the member TG aliases / numbers and demote the SG to muted
secondary text:

    Patch Active: NORTH DISP 1 (201) & NORTH TAC 2 (212) [SG 30201]

Member IDs are already in the patch DTO and the TGDB is already in
the shared store, so this is a CCActivity render change only — no
backend wire changes.