### PR TITLE
issue #402 phase 2: mirror replay through DDC + state-evolution diagnostics

### DIFF
--- a/cmd/gophertrunk/replay.go
+++ b/cmd/gophertrunk/replay.go
@@ -15,6 +15,7 @@ import (
 	"github.com/MattCheramie/GopherTrunk/internal/events"
 	p25phase1 "github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase1"
 	p25phase1rx "github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase1/receiver"
+	"github.com/MattCheramie/GopherTrunk/internal/scanner/ccdecoder"
 	"github.com/MattCheramie/GopherTrunk/internal/trunking"
 )
 
@@ -135,12 +136,38 @@ FLAGS:`)
 		Rotations:     rotations,
 		NIDSearchSpan: *nidSearchSpan,
 	})
+
+	// Mirror the production ccdecoder DDC for the C4FM path (issue
+	// #402 Phase 2): the daemon decimates raw SDR IQ down to ~48 kHz
+	// before the receiver sees it; without the same step here replay
+	// feeds the receiver wideband IQ (e.g. 2.4 MHz), the matched
+	// filter sizes for ~500 samples per symbol, and AFC / AGC time
+	// constants are off by ~50× compared to what runs in production.
+	// A capture that fails in the daemon would then decode (or fail)
+	// differently in replay, defeating the whole point of using
+	// replay as a reproducer. The DDC is only enabled when the demod
+	// is C4FM and the supplied -sample-rate exceeds the production
+	// target — CQPSK and already-channelized captures are unchanged.
+	var ddc *ccdecoder.Downconverter
+	receiverRate := *sampleRate
+	if demodMode == p25phase1rx.DemodC4FM && *sampleRate > ccdecoder.DDCTargetRateHz {
+		ddc = ccdecoder.NewDownconverter(*sampleRate, ccdecoder.DDCTargetRateHz)
+		receiverRate = ddc.OutRateHz()
+	}
+
 	// Surface the active configuration the same way the ccdecoder
 	// pipeline does, so the replay log line is directly comparable
 	// to a daemon's startup line — and a non-default span (the
 	// bisect knob) is visible without re-reading the command.
 	fmt.Fprintf(os.Stderr, "replay: p25/phase1 configured  demod=%s  rotations=%v  nid_search_span=%d  nid_accept_errs=%d  nid_marginal_max=%d\n",
 		*demod, rotations, *nidSearchSpan, p25phase1.NIDAcceptErrs, p25phase1.NIDMarginalMaxErrs)
+	if ddc != nil {
+		fmt.Fprintf(os.Stderr, "replay: ddc enabled  sdr_rate_hz=%g  pipeline_rate_hz=%g\n",
+			*sampleRate, receiverRate)
+	} else {
+		fmt.Fprintf(os.Stderr, "replay: ddc bypassed  pipeline_rate_hz=%g  (sample rate already at or below the C4FM target, or demod=cqpsk)\n",
+			receiverRate)
+	}
 
 	var dibitCount int64
 	var diagAcc *iqDiag
@@ -148,7 +175,7 @@ FLAGS:`)
 		diagAcc = &iqDiag{}
 	}
 	rxOpts := p25phase1rx.Options{
-		SampleRateHz: *sampleRate,
+		SampleRateHz: receiverRate,
 		DeviationHz:  1800.0,
 		DemodMode:    demodMode,
 		DibitSink: func(dibits []uint8, baseIdx int) {
@@ -175,9 +202,34 @@ FLAGS:`)
 		}
 	}()
 
+	// Per-second receiver-state observer (issue #402 Phase 2): after
+	// every secondsPerStateLog seconds of wall-clock IQ have flowed
+	// through the receiver, log the AFC bias, symbol-AGC level/target,
+	// and Mueller-Müller clock state. Lets the reporter (and us) see
+	// whether one stage's internal state slowly drifts after the CC
+	// locks, which is what the disproven-DC-spike-hypothesis pivot now
+	// points at. The cadence is measured in IQ-stream seconds (totalSamples
+	// / sampleRate), not wall clock — so the same capture produces the
+	// same log lines regardless of how fast replay can chew through it.
+	const stateLogIntervalSec = 1.0
+	var nextStateLogAt float64 = stateLogIntervalSec
+	logReceiverState := func(at float64) {
+		fmt.Fprintf(os.Stderr,
+			"replay: receiver state  t=%.2fs  afc_bias_rad_per_sample=%.6g  afc_hz_est=%.3f  agc_level=%.6g  agc_target=%.6g  agc_gain=%.4g  mm_mu=%.4f  mm_sps=%.2f\n",
+			at,
+			rx.AFCBiasRadPerSample(),
+			rx.AFCBiasRadPerSample()*receiverRate/(2*math.Pi),
+			rx.AGCLevel(),
+			rx.AGCTarget(),
+			ratioOrZero(rx.AGCTarget(), rx.AGCLevel()),
+			rx.MMClockMu(),
+			rx.MMClockSPS())
+	}
+
 	const chunkSamples = 8192
 	buf := make([]byte, chunkSamples*bytesPerSample)
 	samples := make([]complex64, chunkSamples)
+	var ddcOut []complex64 // reused across the read loop
 	var totalSamples int64
 	for {
 		n, rerr := io.ReadFull(f, buf)
@@ -191,8 +243,21 @@ FLAGS:`)
 				samples = make([]complex64, pairs)
 			}
 			decode(buf[:pairs*pairBytes], samples[:pairs])
-			rx.Process(samples[:pairs])
+			feed := samples[:pairs]
+			if ddc != nil {
+				ddcOut = ddc.Process(ddcOut, feed)
+				feed = ddcOut
+			}
+			rx.Process(feed)
 			totalSamples += int64(pairs)
+
+			// Throttle the state log on IQ-stream time, not wall
+			// clock. *sampleRate is the input rate even when the
+			// DDC is active — that's the rate totalSamples counts.
+			if t := float64(totalSamples) / *sampleRate; t >= nextStateLogAt {
+				logReceiverState(t)
+				nextStateLogAt = t + stateLogIntervalSec
+			}
 		}
 		if errors.Is(rerr, io.EOF) || errors.Is(rerr, io.ErrUnexpectedEOF) {
 			break
@@ -208,10 +273,21 @@ FLAGS:`)
 	bus.Close()
 	<-doneEvents
 
-	printSummary(filepath.Base(*in), totalSamples, *sampleRate, dibitCount, stats)
+	printSummary(filepath.Base(*in), totalSamples, *sampleRate, dibitCount, stats, cc.Stats())
 	if diagAcc != nil {
 		diagAcc.printReport(os.Stdout)
 	}
+}
+
+// ratioOrZero returns num / den, or 0 if den is too small to divide
+// safely. Used by the state log so a not-yet-seeded AGC level
+// (level=0) renders as gain=0 rather than panicking on divide-by-zero
+// or printing +Inf.
+func ratioOrZero(num, den float64) float64 {
+	if den < 1e-12 && den > -1e-12 {
+		return 0
+	}
+	return num / den
 }
 
 // replayStats accumulates bus events seen during the replay so the
@@ -260,8 +336,11 @@ func handleEvent(ev events.Event, s *replayStats) {
 
 // printSummary writes the EOF report — what the operator pastes into
 // the GitHub issue alongside the live log. Includes the effective-baud
-// self-diagnostic the anakie_short.zip mislabel taught us we need.
-func printSummary(name string, samples int64, sampleRate float64, dibits int64, s replayStats) {
+// self-diagnostic the anakie_short.zip mislabel taught us we need, plus
+// the per-frame outcome breakdown the ControlChannel keeps in CCStats
+// (issue #402 Phase 2: lets the reporter answer "did anything decode?"
+// without scrolling through every debug line).
+func printSummary(name string, samples int64, sampleRate float64, dibits int64, s replayStats, cc p25phase1.CCStats) {
 	fmt.Fprintln(os.Stdout, "----")
 	duration := float64(samples) / sampleRate
 	fmt.Fprintf(os.Stdout, "replay: %s — %d samples (%.2fs at %.0f Hz), %d dibits emitted\n",
@@ -287,13 +366,40 @@ func printSummary(name string, samples int64, sampleRate float64, dibits int64, 
 	if s.grants > 0 {
 		fmt.Fprintf(os.Stdout, "replay: %d grant(s) across %d frequencies\n", s.grants, len(s.grantFreqs))
 	}
+
+	// Per-frame outcome breakdown from CCStats. NID-tier counts split
+	// "passed BCH+parity cleanly" from "needed TSBK corroboration",
+	// and TSBK counts split the failure mode (trellis vs CRC). On a
+	// healthy site every FSW hit becomes NIDTrusted + TSBKDecoded;
+	// the issue-#402 shape is high NIDFailed + high TSBKCRCFailed
+	// (gross dibit corruption that BCH can't recover and Viterbi
+	// barely can).
+	nidAttempts := cc.NIDTrusted + cc.NIDMarginal + cc.NIDFailed
+	tsbkAttempts := cc.TSBKDecoded + cc.TSBKTrellisFailed + cc.TSBKCRCFailed
+	fmt.Fprintf(os.Stdout, "replay: nid   trusted=%d  marginal=%d  uncorrectable=%d  (of %d FSW-hit attempts; %s ok)\n",
+		cc.NIDTrusted, cc.NIDMarginal, cc.NIDFailed, nidAttempts,
+		pctOf(cc.NIDTrusted+cc.NIDMarginal, nidAttempts))
+	fmt.Fprintf(os.Stdout, "replay: tsbk  decoded=%d  trellis_failed=%d  crc_failed=%d  (of %d NID-passed frames; %s ok)\n",
+		cc.TSBKDecoded, cc.TSBKTrellisFailed, cc.TSBKCRCFailed, tsbkAttempts,
+		pctOf(cc.TSBKDecoded, tsbkAttempts))
+
 	if len(s.decodeErrors) > 0 {
 		parts := make([]string, 0, len(s.decodeErrors))
 		for stage, n := range s.decodeErrors {
 			parts = append(parts, fmt.Sprintf("%s=%d", stage, n))
 		}
-		fmt.Fprintf(os.Stdout, "replay: decode errors: %s\n", strings.Join(parts, " "))
+		fmt.Fprintf(os.Stdout, "replay: decode errors (from bus): %s\n", strings.Join(parts, " "))
 	}
+}
+
+// pctOf renders num/den as a percentage string, or "n/a" when den is
+// zero. Used by the EOF summary so "0 / 0 = NaN%" doesn't appear in
+// the operator's pasted output.
+func pctOf(num, den int64) string {
+	if den <= 0 {
+		return "n/a"
+	}
+	return fmt.Sprintf("%.1f%%", 100*float64(num)/float64(den))
 }
 
 // pickSampleDecoder maps the -format flag to a (decoder, bytes-per-IQ-pair)

--- a/cmd/gophertrunk/replay_test.go
+++ b/cmd/gophertrunk/replay_test.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp"
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/demod"
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	p25phase1 "github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase1"
+	p25phase1rx "github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase1/receiver"
+	"github.com/MattCheramie/GopherTrunk/internal/scanner/ccdecoder"
+)
+
+// TestReplayDDCCompositionLocks mirrors what runReplay does at runtime
+// (issue #402 Phase 2): construct the production ccdecoder.Downconverter
+// from outside the ccdecoder package, feed it wideband synthetic IQ,
+// pipe the decimated output into the same p25phase1rx.Receiver +
+// p25phase1.ControlChannel the daemon uses. A lock here proves replay
+// reproduces the production decode path exactly, which is the whole
+// point of the DDC-in-replay wiring — without it, a capture that
+// fails in the daemon would decode (or fail) differently in replay
+// because the matched filter would size for 2.4 MHz instead of 48 kHz.
+//
+// If this test starts failing, the contract that "what the daemon
+// decodes is what replay decodes" has broken — the operator's offline
+// reproducer is no longer trustworthy.
+func TestReplayDDCCompositionLocks(t *testing.T) {
+	const (
+		nac          = 0x293
+		sdrRateHz    = 2_048_000.0
+		narrowRateHz = ccdecoder.DDCTargetRateHz
+		deviationHz  = 1800.0
+		frameRepeats = 30
+	)
+
+	// Synthesize the control channel at the narrowband target rate,
+	// then upsample (L/M = 128/3) to the raw SDR rate so the
+	// Downconverter has genuine wideband IQ to channelize back down.
+	// The L/M and helper match the production wideband-DDC test in
+	// internal/scanner/ccdecoder/decoder_test.go.
+	dibits := buildReplayCCDibits(nac, frameRepeats)
+	narrow := demod.ModulateP25C4FM(dibits, narrowRateHz, deviationHz)
+	wide := dsp.NewResampler(128, 3, 8, 8.0).Process(nil, narrow)
+
+	bus := events.NewBus(256)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := p25phase1.New(p25phase1.Options{
+		Bus:        bus,
+		SystemName: "replay-test",
+		Rotations:  p25phase1.RotationsC4FM,
+	})
+
+	// Build the same Downconverter runReplay builds when the SDR rate
+	// exceeds the C4FM target. The receiver must use the achieved
+	// output rate, NOT the SDR rate — otherwise the matched filter
+	// sizes for 2.4 MHz and the FSW never correlates.
+	ddc := ccdecoder.NewDownconverter(sdrRateHz, narrowRateHz)
+	receiverRate := ddc.OutRateHz()
+	if receiverRate != narrowRateHz {
+		t.Fatalf("DDC achieved rate = %v, want %v", receiverRate, narrowRateHz)
+	}
+
+	rx := p25phase1rx.New(p25phase1rx.Options{
+		SampleRateHz: receiverRate,
+		DeviationHz:  deviationHz,
+		DemodMode:    p25phase1rx.DemodC4FM,
+		DibitSink: func(dibits []uint8, baseIdx int) {
+			cc.Process(dibits, baseIdx)
+		},
+	})
+
+	// Pump in chunks the size of a real RTL-SDR USB transfer (8192
+	// complex samples ≈ 19 P25 symbols after the DDC), draining the
+	// bus after each so a CCLocked event can't be silently dropped
+	// by a full subscriber buffer.
+	const chunk = 8_192
+	var ddcOut []complex64
+	var locked bool
+	for off := 0; off < len(wide) && !locked; off += chunk {
+		end := off + chunk
+		if end > len(wide) {
+			end = len(wide)
+		}
+		ddcOut = ddc.Process(ddcOut, wide[off:end])
+		rx.Process(ddcOut)
+		for drained := false; !drained; {
+			select {
+			case ev := <-sub.C:
+				if ev.Kind == events.KindCCLocked {
+					if ls, ok := ev.Payload.(p25phase1.LockState); ok && ls.NAC == nac {
+						locked = true
+					}
+				}
+			default:
+				drained = true
+			}
+		}
+	}
+
+	if !locked {
+		t.Fatalf("replay composition did NOT lock on NAC %#x after %d wideband samples — production-replay drift",
+			nac, len(wide))
+	}
+
+	// At least one NID + TSBK must have cleared; otherwise the lock
+	// was a fluke and the per-frame stats are zero.
+	deadline := time.Now().Add(10 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		select {
+		case <-sub.C:
+		default:
+			time.Sleep(time.Millisecond)
+		}
+	}
+	got := cc.Stats()
+	if got.NIDTrusted == 0 && got.NIDMarginal == 0 {
+		t.Errorf("Stats after lock = %+v, want at least one NID-accept", got)
+	}
+}
+
+// buildReplayCCDibits assembles a P25 Phase 1 control-channel dibit
+// stream — warmup + repeats × (FSW + NID + trellis-TSBK + idle) +
+// trailer — with the same shape the ccdecoder wideband-DDC test uses,
+// duplicated here so this test stays self-contained and doesn't
+// depend on a package-internal helper.
+func buildReplayCCDibits(nac uint16, repeats int) []uint8 {
+	frame := make([]uint8, 0, 24+32+98)
+	frame = append(frame, p25phase1.FrameSyncWord[:]...)
+	nidBits := p25phase1.EncodeNIDBits(nac, p25phase1.DUIDTrunkingSignaling)
+	for i := 0; i < 32; i++ {
+		frame = append(frame, (nidBits[2*i]<<1)|nidBits[2*i+1])
+	}
+	tsbk := p25phase1.AssembleTSBK(p25phase1.TSBK{
+		LB: true, Opcode: p25phase1.OpRFSSStatusBroadcast,
+	})
+	frame = append(frame, p25phase1.EncodeTSBKChannel(tsbk)...)
+	frame = p25phase1.InjectControlStatusSymbols(frame)
+
+	out := make([]uint8, 0, 200+repeats*(len(frame)+50)+100)
+	for i := 0; i < 200; i++ {
+		out = append(out, uint8(i&3))
+	}
+	for r := 0; r < repeats; r++ {
+		out = append(out, frame...)
+		for i := 0; i < 50; i++ {
+			out = append(out, uint8(i&3))
+		}
+	}
+	for i := 0; i < 100; i++ {
+		out = append(out, uint8(i&3))
+	}
+	return out
+}

--- a/internal/dsp/sync/clock.go
+++ b/internal/dsp/sync/clock.go
@@ -92,6 +92,23 @@ func (m *MuellerMuller) Process(dst []float32, src []float32) []float32 {
 	return dst
 }
 
+// Mu returns the current sub-sample phase accumulator (rad-equivalent;
+// in (-1, sps] depending on where the loop is in the symbol period).
+// At steady state on a noise-free signal mu cycles deterministically
+// around the symbol period; a slow monotonic drift indicates the
+// nominal sps does not match the stream's actual sample-rate / baud
+// ratio. Exposed read-only for issue-#402-style diagnostics where the
+// daemon (or replay) periodically logs the loop's internal state so a
+// persistent clock slip can be distinguished from a slicer / AFC
+// failure. Not safe for concurrent calls with Process.
+func (m *MuellerMuller) Mu() float64 { return m.mu }
+
+// SPS returns the nominal samples-per-symbol the loop was constructed
+// with. Paired with Mu() so a diagnostic log line can render mu as a
+// fraction of the symbol period without re-deriving the construction
+// value.
+func (m *MuellerMuller) SPS() float64 { return m.sps }
+
 func sgn(x float32) float64 {
 	if x > 0 {
 		return 1

--- a/internal/radio/p25/phase1/control.go
+++ b/internal/radio/p25/phase1/control.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"sort"
+	"sync/atomic"
 	"time"
 
 	"github.com/MattCheramie/GopherTrunk/internal/events"
@@ -99,12 +100,63 @@ type ControlChannel struct {
 	// voice receiver and never decode (issue #356 follow-up). Empty
 	// string preserves the C4FM default in the voice chain.
 	p25Phase1DemodMode string
+
+	// stats is the per-frame outcome counter exposed via Stats().
+	// Atomic so the daemon's API / diagnostic goroutines can read it
+	// concurrently with Process. Issue #402: gives replay and any
+	// future operator dashboard a per-run "of the frames the FSW
+	// correlator delivered, how many cleared each acceptance gate"
+	// breakdown — the steady-state shape that distinguishes "demod
+	// is broken" from "demod is fine but one frame in N is corrupt".
+	stats CCStats
+}
+
+// CCStats is the snapshot Stats() returns. All counters are
+// monotonically increasing from ControlChannel construction.
+//
+// NIDTrusted counts NIDs that cleared the BCH+parity gate at
+// errs ≤ NIDAcceptErrs (the searchNID "trusted tier"). NIDMarginal
+// counts NIDs in (NIDAcceptErrs, NIDMarginalMaxErrs] that were
+// admitted only because the frame's 98-dibit TSBK ALSO Viterbi+CRC
+// decoded under the same alignment. NIDFailed counts FSW hits where
+// no alignment in the grid produced an acceptable NID under either
+// tier — the "all 28 BCH-uncorrectable" shape from the issue-#402
+// report.
+//
+// TSBKDecoded counts frames whose 98-dibit channel block cleared
+// Viterbi + CRC and reached dispatchTSBK. TSBKTrellisFailed and
+// TSBKCRCFailed split the post-NID failure mode (Viterbi diverged
+// vs. trellis decoded but the trailer CRC didn't match) — both also
+// surface as events.KindDecodeError on the bus, but the bus event
+// is sampled by tests / Prometheus and may miss frames a synchronous
+// snapshot needs.
+type CCStats struct {
+	NIDTrusted        int64
+	NIDMarginal       int64
+	NIDFailed         int64
+	TSBKDecoded       int64
+	TSBKTrellisFailed int64
+	TSBKCRCFailed     int64
 }
 
 // NetworkSnapshot returns the system topology accumulated from the
 // site's Network / RFSS / Secondary-CC / Adjacent-Site status TSBKs.
 func (c *ControlChannel) NetworkSnapshot() NetworkConfig {
 	return c.netModel.Snapshot()
+}
+
+// Stats returns a snapshot of the per-frame outcome counters. Safe
+// for concurrent calls — each counter is read with atomic.LoadInt64.
+// See CCStats for the meaning of each field. Issue #402.
+func (c *ControlChannel) Stats() CCStats {
+	return CCStats{
+		NIDTrusted:        atomic.LoadInt64(&c.stats.NIDTrusted),
+		NIDMarginal:       atomic.LoadInt64(&c.stats.NIDMarginal),
+		NIDFailed:         atomic.LoadInt64(&c.stats.NIDFailed),
+		TSBKDecoded:       atomic.LoadInt64(&c.stats.TSBKDecoded),
+		TSBKTrellisFailed: atomic.LoadInt64(&c.stats.TSBKTrellisFailed),
+		TSBKCRCFailed:     atomic.LoadInt64(&c.stats.TSBKCRCFailed),
+	}
 }
 
 // pendingHit is an FSW match awaiting enough buffered dibits to decode
@@ -360,6 +412,7 @@ func (c *ControlChannel) Process(dibits []uint8, baseIdx int) int {
 func (c *ControlChannel) parseFrame(buf []uint8, nidStart int, fswRot uint8) {
 	best, found, diag := c.searchNID(buf, nidStart, fswRot)
 	if !found {
+		atomic.AddInt64(&c.stats.NIDFailed, 1)
 		c.log.Debug("nid parse failed", "system", c.systemName,
 			"freq_hz", c.freqHz, "diag", diag)
 		c.bus.Publish(events.Event{
@@ -367,6 +420,15 @@ func (c *ControlChannel) parseFrame(buf []uint8, nidStart int, fswRot uint8) {
 			Payload: events.DecodeError{Protocol: "p25", Stage: events.StageNIDBCH},
 		})
 		return
+	}
+	// Trusted vs. marginal tier discrimination matches the
+	// "corroborated" log field below: a NID with more than
+	// NIDAcceptErrs BCH corrections was only admitted because the
+	// frame TSBK ALSO verified under the same alignment.
+	if best.errs > NIDAcceptErrs {
+		atomic.AddInt64(&c.stats.NIDMarginal, 1)
+	} else {
+		atomic.AddInt64(&c.stats.NIDTrusted, 1)
 	}
 	if best.errs > 0 {
 		c.log.Debug("nid corrected", "errs", best.errs, "nac", best.nid.NAC,
@@ -397,6 +459,11 @@ func (c *ControlChannel) parseFrame(buf []uint8, nidStart int, fswRot uint8) {
 	tsbkChannel, _ := gatherFrameDibits(buf, best.tsbkStart, 98, fswStart, best.strip)
 	tsbk, metric, err := DecodeTSBKChannel(rotateDibits(tsbkChannel, best.rot))
 	if err != nil {
+		if errors.Is(err, CRCError) {
+			atomic.AddInt64(&c.stats.TSBKCRCFailed, 1)
+		} else {
+			atomic.AddInt64(&c.stats.TSBKTrellisFailed, 1)
+		}
 		c.log.Debug("tsbk decode failed", "err", err, "metric", metric, "nac", best.nid.NAC)
 		stage := events.StageTSBKTrellis
 		if errors.Is(err, CRCError) {
@@ -723,6 +790,7 @@ func InjectControlStatusSymbols(stream []uint8) []uint8 {
 // logged at debug but not republished, since they're the bulk of what
 // a busy site emits and would drown signal in noise.
 func (c *ControlChannel) dispatchTSBK(t TSBK, nac uint16, metric int) {
+	atomic.AddInt64(&c.stats.TSBKDecoded, 1)
 	// Manufacturer-specific TSBKs are decoded in the vendor's opcode
 	// namespace (Motorola patch/regroup, Harris regroup, talker alias)
 	// — see tsbk_vendor.go.

--- a/internal/radio/p25/phase1/control_test.go
+++ b/internal/radio/p25/phase1/control_test.go
@@ -1337,3 +1337,87 @@ func TestControlChannelDeferredGrantReplayedAfterTDMAIdentifierUpdate(t *testing
 		t.Errorf("freq = %d, want 468_612_500", got.FrequencyHz)
 	}
 }
+
+// TestControlChannelStatsCountsTrustedDecodes drives a clean TSDU
+// stream through Process and asserts the new CCStats counter for
+// NID-trusted accept + TSBK-decoded both increment per frame. Issue
+// #402 Phase 2: the replay EOF summary depends on these counts to
+// answer "of the FSW hits, what fraction made it through each gate"
+// without parsing every debug log line.
+func TestControlChannelStatsCountsTrustedDecodes(t *testing.T) {
+	bus := events.NewBus(64)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+	// Drain the bus so Publish doesn't block — we only care about the
+	// stats counters here, not the events.
+	go func() {
+		for range sub.C {
+		}
+	}()
+
+	cc := NewControlChannel(bus, nil, 851_000_000)
+	const frames = 5
+	stream := buildLockedStream(10, 0x293, DUIDTrunkingSignaling, OpRFSSStatusBroadcast)
+	// buildLockedStream emits one TSDU frame; concatenate to get N.
+	wide := make([]uint8, 0, len(stream)*frames)
+	for i := 0; i < frames; i++ {
+		wide = append(wide, stream...)
+	}
+	cc.Process(wide, 0)
+
+	got := cc.Stats()
+	if got.NIDTrusted < int64(frames) {
+		t.Errorf("NIDTrusted = %d, want ≥ %d (one per frame)", got.NIDTrusted, frames)
+	}
+	if got.NIDMarginal != 0 || got.NIDFailed != 0 {
+		t.Errorf("clean stream produced marginal/failed NIDs: marginal=%d failed=%d",
+			got.NIDMarginal, got.NIDFailed)
+	}
+	if got.TSBKDecoded < int64(frames) {
+		t.Errorf("TSBKDecoded = %d, want ≥ %d (one per frame)", got.TSBKDecoded, frames)
+	}
+	if got.TSBKTrellisFailed != 0 || got.TSBKCRCFailed != 0 {
+		t.Errorf("clean stream produced TSBK failures: trellis=%d crc=%d",
+			got.TSBKTrellisFailed, got.TSBKCRCFailed)
+	}
+}
+
+// TestControlChannelStatsCountsNIDFailure: a garbage NID after a clean
+// FSW (the same shape TestControlChannelPublishesDecodeErrorOnUncorrectableNID
+// drives) must increment NIDFailed and NOT increment any of the
+// success / TSBK counters.
+func TestControlChannelStatsCountsNIDFailure(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+	go func() {
+		for range sub.C {
+		}
+	}()
+
+	frame := make([]uint8, 24+32+98)
+	copy(frame, FrameSyncWord[:])
+	for i := 0; i < 32; i++ {
+		frame[24+i] = uint8(i*7) & 0x3
+	}
+	onAir := InjectControlStatusSymbols(frame)
+	stream := make([]uint8, 10+len(onAir)+16)
+	copy(stream[10:], onAir)
+
+	cc := NewControlChannel(bus, nil, 851_000_000)
+	cc.Process(stream, 0)
+
+	got := cc.Stats()
+	if got.NIDFailed == 0 {
+		t.Errorf("NIDFailed = 0, want ≥ 1 on a garbage-NID frame")
+	}
+	if got.NIDTrusted != 0 || got.NIDMarginal != 0 {
+		t.Errorf("garbage stream produced NID accepts: trusted=%d marginal=%d",
+			got.NIDTrusted, got.NIDMarginal)
+	}
+	if got.TSBKDecoded != 0 {
+		t.Errorf("garbage stream produced a TSBK decode: %d", got.TSBKDecoded)
+	}
+}

--- a/internal/radio/p25/phase1/receiver/receiver.go
+++ b/internal/radio/p25/phase1/receiver/receiver.go
@@ -316,6 +316,57 @@ func (r *Receiver) Process(iq []complex64) {
 	}
 }
 
+// AFCBiasRadPerSample returns the C4FM coarse-AFC's current DC bias
+// estimate on the FM-discriminator output, in radians per sample at
+// the receiver's input rate. A clean signal converges to ~0; a static
+// carrier offset of Δf Hz leaves the AFC tracking 2π·Δf/SampleRateHz.
+// Returns 0 on the CQPSK path (no AFC stage). Issue #402 diagnostic
+// — exposed so the daemon and replay can periodically log the
+// estimate's evolution after CC lock.
+func (r *Receiver) AFCBiasRadPerSample() float64 {
+	if r.afc == nil {
+		return 0
+	}
+	return r.afc.Offset()
+}
+
+// AGCLevel returns the C4FM symbol-AGC's current EMA estimate of
+// mean|x| on the matched-filter output. Compare to AGCTarget(): the
+// effective slicer gain at any instant is target/level. A level that
+// diverges far from target after CC lock (or oscillates) points at an
+// AGC misbehaviour on the live signal. Returns 0 on the CQPSK path
+// (no symbol-AGC stage). Issue #402 diagnostic.
+func (r *Receiver) AGCLevel() float64 { return float64(r.agc.level) }
+
+// AGCTarget returns the C4FM symbol-AGC's target mean|x|, calibrated
+// at construction from the configured DeviationHz / SampleRateHz so
+// the matched-filter output lands on the slicer's fixed thresholds.
+// Returns 0 on the CQPSK path or when DeviationHz was unset.
+func (r *Receiver) AGCTarget() float64 { return float64(r.agc.target) }
+
+// MMClockMu returns the Mueller-Müller symbol clock's current
+// sub-sample phase accumulator (in [-1, sps]). At steady state on a
+// noise-free input mu cycles deterministically through the symbol
+// period; a slow monotonic drift indicates the receiver's nominal
+// SampleRateHz disagrees with the stream's actual sample-rate / baud
+// ratio. Returns 0 on the CQPSK path (it uses Gardner instead).
+func (r *Receiver) MMClockMu() float64 {
+	if r.clock == nil {
+		return 0
+	}
+	return r.clock.Mu()
+}
+
+// MMClockSPS returns the Mueller-Müller loop's nominal samples per
+// symbol. Paired with MMClockMu() so a diagnostic log can render mu
+// as a fraction of the symbol period.
+func (r *Receiver) MMClockSPS() float64 {
+	if r.clock == nil {
+		return 0
+	}
+	return r.clock.SPS()
+}
+
 // Reset returns the receiver to its initial state. Call on stream
 // re-sync (control-channel hunt success, IQ underrun recovery) so a
 // stale FSW match doesn't bleed across the discontinuity, and so the

--- a/internal/radio/p25/phase1/receiver/receiver_test.go
+++ b/internal/radio/p25/phase1/receiver/receiver_test.go
@@ -336,3 +336,66 @@ func TestC4FMSymbolAGCRescuesCollapsedSlicer(t *testing.T) {
 		}
 	}
 }
+
+// TestReceiverStateAccessorsReturnDefaults pins the contract for the
+// new diagnostic accessors (issue #402 Phase 2): on a freshly-
+// constructed C4FM Receiver, the AFC bias must read 0 (the IIR's
+// initial state), the MM clock's SPS must equal SampleRateHz /
+// SymbolRate, and AGCTarget must match the slicer calibration from
+// DeviationHz. AGCLevel starts at 0 (unseeded EMA) and MMClockMu
+// starts at sps (the constructor's initial state). These read-only
+// snapshots back the periodic state-evolution log in cmd/gophertrunk/
+// replay.go; if any default changes, the log lines change shape and
+// the operator-facing diagnostic gets confusing.
+func TestReceiverStateAccessorsReturnDefaults(t *testing.T) {
+	r := New(Options{
+		SampleRateHz: 48_000,
+		DeviationHz:  1800,
+		Sink:         func([]byte) {},
+	})
+	if got := r.AFCBiasRadPerSample(); got != 0 {
+		t.Errorf("AFCBiasRadPerSample on fresh receiver = %v, want 0", got)
+	}
+	if got := r.AGCLevel(); got != 0 {
+		t.Errorf("AGCLevel on fresh receiver = %v, want 0 (unseeded EMA)", got)
+	}
+	if got := r.AGCTarget(); got <= 0 {
+		t.Errorf("AGCTarget = %v, want > 0 (slicer calibrated from DeviationHz)", got)
+	}
+	wantSPS := 48_000.0 / SymbolRate
+	if got := r.MMClockSPS(); got != wantSPS {
+		t.Errorf("MMClockSPS = %v, want %v", got, wantSPS)
+	}
+	if got := r.MMClockMu(); got != wantSPS {
+		t.Errorf("MMClockMu on fresh receiver = %v, want %v (constructor's initial mu)", got, wantSPS)
+	}
+}
+
+// TestReceiverStateAccessorsZeroOnCQPSKPath: the CQPSK demod path has
+// no AFC or symbol-AGC and uses Gardner instead of Mueller-Müller, so
+// all the C4FM-state accessors must return 0 without panicking — the
+// replay state log relies on that to render a meaningful line on
+// either demod choice.
+func TestReceiverStateAccessorsZeroOnCQPSKPath(t *testing.T) {
+	r := New(Options{
+		SampleRateHz: 48_000,
+		DeviationHz:  1800,
+		DemodMode:    DemodCQPSK,
+		Sink:         func([]byte) {},
+	})
+	if got := r.AFCBiasRadPerSample(); got != 0 {
+		t.Errorf("CQPSK AFCBiasRadPerSample = %v, want 0", got)
+	}
+	if got := r.AGCLevel(); got != 0 {
+		t.Errorf("CQPSK AGCLevel = %v, want 0", got)
+	}
+	if got := r.AGCTarget(); got != 0 {
+		t.Errorf("CQPSK AGCTarget = %v, want 0", got)
+	}
+	if got := r.MMClockMu(); got != 0 {
+		t.Errorf("CQPSK MMClockMu = %v, want 0", got)
+	}
+	if got := r.MMClockSPS(); got != 0 {
+		t.Errorf("CQPSK MMClockSPS = %v, want 0", got)
+	}
+}

--- a/internal/scanner/ccdecoder/ddc.go
+++ b/internal/scanner/ccdecoder/ddc.go
@@ -17,7 +17,18 @@ import (
 // raw SDR rate (commonly 2.048 MHz) instead gives ≈427 samples per
 // symbol and a matched filter spanning a ±1 MHz swath, so the Frame
 // Sync Word never correlates and no protocol locks — see issue #275.
+//
+// Exposed as DDCTargetRateHz so the gophertrunk replay subcommand
+// (which constructs its own Downconverter to mirror the production
+// pipeline; issue #402 Phase 2) can target the same channelized rate
+// without duplicating the constant.
 const ddcTargetRateHz = 48000.0
+
+// DDCTargetRateHz is the exported alias of ddcTargetRateHz. The
+// in-package callers keep using the lowercase name for source
+// stability; new external callers (replay, integration tests) use
+// the exported value.
+const DDCTargetRateHz = ddcTargetRateHz
 
 // tetraDDCTargetRateHz is the channel rate the down-converter uses
 // for TETRA. TETRA's π/4-DQPSK runs at 18000 symbols/s — roughly
@@ -49,7 +60,7 @@ const ddcStopbandTaps = 12
 // ~70 dB peak sidelobe attenuation.
 const ddcKaiserBeta = 7.0
 
-// downconverter decimates a wideband SDR IQ stream to a narrowband
+// Downconverter decimates a wideband SDR IQ stream to a narrowband
 // channel rate.
 //
 // Decimation is a rational polyphase resample (dsp.Resampler) whose
@@ -68,17 +79,24 @@ const ddcKaiserBeta = 7.0
 // the channel no longer sits at 0 Hz) or after the FM discriminator
 // (coarse AFC on the real symbol stream); both are tracked as
 // follow-ups to issue #275.
-type downconverter struct {
+//
+// Exported (issue #402 Phase 2) so the gophertrunk replay subcommand
+// can construct an identical down-converter and exactly mirror the
+// production receiver chain instead of feeding the receiver raw
+// wideband IQ — the latter sizes the matched filter and AFC/AGC
+// time constants for 2.4 MHz instead of 48 kHz, so a replayed
+// capture decodes nothing like its live counterpart.
+type Downconverter struct {
 	resampler *dsp.Resampler // nil ⇒ pass-through (no decimation)
 	outRateHz float64
 }
 
-// newDownconverter builds a down-converter that decimates inRateHz to
-// ~targetHz. The exact achieved output rate is reported by outRateHz
-// (it equals targetHz for every SDR rate that reduces to a sane L/M,
-// and equals inRateHz in pass-through mode).
-func newDownconverter(inRateHz, targetHz float64) *downconverter {
-	d := &downconverter{outRateHz: inRateHz}
+// NewDownconverter builds a down-converter that decimates inRateHz to
+// ~targetHz. The exact achieved output rate is reported by
+// OutRateHz (it equals targetHz for every SDR rate that reduces to
+// a sane L/M, and equals inRateHz in pass-through mode).
+func NewDownconverter(inRateHz, targetHz float64) *Downconverter {
+	d := &Downconverter{outRateHz: inRateHz}
 	in := int(math.Round(inRateHz))
 	target := int(math.Round(targetHz))
 	if in <= 0 || target <= 0 || in <= target {
@@ -94,11 +112,18 @@ func newDownconverter(inRateHz, targetHz float64) *downconverter {
 	return d
 }
 
+// OutRateHz returns the achieved narrowband output rate (equals the
+// requested target for standard SDR rates that reduce to a sane L/M;
+// equals inRateHz in pass-through mode). Callers building a receiver
+// against the downconverter's output should use this value for
+// SampleRateHz so matched-filter sizing matches the actual stream.
+func (d *Downconverter) OutRateHz() float64 { return d.outRateHz }
+
 // Process decimates one raw IQ chunk to the narrowband rate. dst is
 // reused if it has capacity; the returned slice holds the narrowband
 // output (len ≈ len(raw)·outRateHz/inRateHz). In pass-through mode
 // raw is returned unchanged. raw is never mutated.
-func (d *downconverter) Process(dst, raw []complex64) []complex64 {
+func (d *Downconverter) Process(dst, raw []complex64) []complex64 {
 	if d.resampler == nil {
 		return raw
 	}
@@ -108,7 +133,7 @@ func (d *downconverter) Process(dst, raw []complex64) []complex64 {
 // Reset clears the decimation filter history. Called on every
 // pipeline swap so a retune doesn't bleed the previous channel's
 // filter state into the new one.
-func (d *downconverter) Reset() {
+func (d *Downconverter) Reset() {
 	if d.resampler != nil {
 		d.resampler.Reset()
 	}

--- a/internal/scanner/ccdecoder/ddc_test.go
+++ b/internal/scanner/ccdecoder/ddc_test.go
@@ -35,7 +35,7 @@ func rms(s []complex64) float64 {
 // narrowband target the down-converter builds no resampler and
 // forwards the chunk unchanged.
 func TestDownconverterPassthrough(t *testing.T) {
-	d := newDownconverter(48_000, 48_000)
+	d := NewDownconverter(48_000, 48_000)
 	if d.resampler != nil {
 		t.Errorf("expected pass-through (nil resampler) for rate == target")
 	}
@@ -53,7 +53,7 @@ func TestDownconverterPassthrough(t *testing.T) {
 // exactly on the 48 kHz target, and the output chunk length must
 // follow the L/M ratio.
 func TestDownconverterDecimationRate(t *testing.T) {
-	d := newDownconverter(2_048_000, 48_000)
+	d := NewDownconverter(2_048_000, 48_000)
 	if d.resampler == nil {
 		t.Fatalf("expected a resampler for 2.048 MHz → 48 kHz")
 	}
@@ -78,14 +78,14 @@ func TestDownconverterIsolatesChannel(t *testing.T) {
 	const n = 262_144
 
 	// In-channel: +5 kHz, comfortably inside the 48 kHz output band.
-	inband := newDownconverter(sdrRate, 48_000).
+	inband := NewDownconverter(sdrRate, 48_000).
 		Process(nil, complexTone(5_000, sdrRate, n, 1.0))
 	gotIn := rms(inband[100:]) // skip filter start-up transient
 
 	// Out of band: +400 kHz. Without filtering this folds to
 	// 400000 mod 48000 = 16 kHz — right in the passband — so the
 	// anti-alias filter is the only thing that can reject it.
-	interf := newDownconverter(sdrRate, 48_000).
+	interf := NewDownconverter(sdrRate, 48_000).
 		Process(nil, complexTone(400_000, sdrRate, n, 1.0))
 	gotInterf := rms(interf[100:])
 
@@ -101,7 +101,7 @@ func TestDownconverterIsolatesChannel(t *testing.T) {
 // is cleared, so re-processing the same input reproduces the first
 // run bit-for-bit.
 func TestDownconverterReset(t *testing.T) {
-	d := newDownconverter(2_048_000, 48_000)
+	d := NewDownconverter(2_048_000, 48_000)
 	in := complexTone(5_000, 2_048_000, 200_000, 1.0)
 
 	first := append([]complex64(nil), d.Process(nil, in)...)

--- a/internal/scanner/ccdecoder/decoder.go
+++ b/internal/scanner/ccdecoder/decoder.go
@@ -157,7 +157,7 @@ type Decoder struct {
 	// ddcTargetForProtocol). pipelineRateHz is what the per-protocol
 	// factories receive as PipelineOptions.SampleRateHz. All three
 	// are owned by handleProgress / pump under mu.
-	ddc            *downconverter
+	ddc            *Downconverter
 	ddcTarget      float64
 	pipelineRateHz float64
 
@@ -174,7 +174,7 @@ type Decoder struct {
 	activeAt string // system name the active pipeline is bound to
 
 	// ddcOut is the reusable down-converter output buffer — pump
-	// hands it to downconverter.Process each chunk so the decimated
+	// hands it to Downconverter.Process each chunk so the decimated
 	// stream doesn't allocate per call.
 	ddcOut []complex64
 
@@ -364,7 +364,7 @@ func (d *Decoder) ensureDownconverterLocked(targetHz float64) {
 	if d.ddc != nil && d.ddcTarget == targetHz {
 		return
 	}
-	d.ddc = newDownconverter(d.sampleRateHz, targetHz)
+	d.ddc = NewDownconverter(d.sampleRateHz, targetHz)
 	d.ddcTarget = targetHz
 	d.pipelineRateHz = d.ddc.outRateHz
 	d.log.Info("ccdecoder: digital down-converter configured",


### PR DESCRIPTION
Closes the diagnostic-loop gap that surfaced when Phase 1's DC-spike hypothesis was disproven (reporter measured `dc_ratio_db = -45 dB` at MMR Site 9 — clean — yet TSBKs continue to fail with `metric=20` and the NID grid stays "all 28 BCH-uncorrectable"). The failure is somewhere else in the continuous decode path; this PR ships the tooling needed to name which stage.

## Why

Two gaps blocked further progress:

1. **`gophertrunk replay` doesn't reproduce production.** It feeds the receiver wideband IQ at `-sample-rate` (e.g. 2.4 MHz), so the C4FM matched filter sizes for ~500 samples per symbol and the AFC/AGC time constants are off by ~50× compared to the production 48 kHz pipeline. A capture that fails in the daemon would decode (or fail) differently in replay — defeating its value as a reproducer.
2. **No visibility into the receiver's internal state over time.** AFC bias, symbol-AGC level, and Mueller-Müller clock phase are the three loops that could drift after lock; today only the lock event and per-failure debug lines surface, with no continuous trace.

## What

### DDC in replay (mirrors production)

- Export `ccdecoder.Downconverter` + `NewDownconverter` + `DDCTargetRateHz` (mechanical rename — no behaviour change on the daemon side).
- `gophertrunk replay` now builds the same Downconverter on the C4FM path when `-sample-rate` exceeds the C4FM target, decimates incoming chunks, and constructs the receiver at the achieved output rate. Logs `replay: ddc enabled  sdr_rate_hz=...  pipeline_rate_hz=48000` at startup so the line is directly comparable to the production `ccdecoder: digital down-converter configured`. CQPSK and already-channelized captures skip the DDC.

### State-evolution accessors

- `receiver.Receiver.AFCBiasRadPerSample()` — current coarse-AFC DC estimate
- `receiver.Receiver.AGCLevel()` / `AGCTarget()` — symbol-AGC EMA vs. calibrated target
- `receiver.Receiver.MMClockMu()` / `MMClockSPS()` — Mueller-Müller sub-sample phase + nominal sps
- Underlying primitives: `sync.MuellerMuller.Mu()` / `SPS()`
- All return 0 on the CQPSK path where the relevant stage doesn't exist (CQPSK uses Gardner instead of MM, has no AFC / symbol-AGC).

Replay emits a once-per-IQ-stream-second debug log line rendering all six values plus the derived AFC Hz estimate and the effective slicer gain. Throttled on stream-time so the same capture produces identical log lines regardless of replay throughput.

### Per-frame outcome counters

- `p25/phase1.CCStats` struct + `ControlChannel.Stats()` accessor. Atomic counters for NID-accept tier (trusted / marginal / failed) and TSBK outcome (decoded / trellis-failed / crc-failed).
- Replay's EOF summary now prints:
  ```
  replay: nid   trusted=N  marginal=M  uncorrectable=K  (of X attempts; Y% ok)
  replay: tsbk  decoded=N  trellis_failed=M  crc_failed=K  (of X NID-passed; Y% ok)
  ```

The reporter can now run one command on `mmr-s9.cfile` and paste back a small, structured diagnostic bundle (per-second state log + EOF CCStats + the existing iqdiag report) instead of the raw 179 MB capture.

## How to use this

After this lands, the reporter (or anyone repro'ing #402) should run:

```
gophertrunk replay -in mmr-s9.cfile -format f32 -sample-rate 2400000 -demod c4fm -diag
```

And share three sections of the output:

1. The repeating `replay: receiver state  t=...` lines (look for drift after lock).
2. The EOF `replay: nid` / `replay: tsbk` summary lines.
3. The `---- diag ----` block (soft-sample histogram, dibit balance, per-rotation FSW landscape, first 5 perfect-FSW NID+TSBK dumps).

That bundle is what Phase 3's targeted fix will be designed against.

## Test plan

- [x] `internal/scanner/ccdecoder/ddc_test.go` (existing): rename verified, decimation round-trip + isolation + pass-through tests all pass.
- [x] `internal/scanner/ccdecoder/decoder_test.go` (existing): `TestDecoderLocksP25Phase1ThroughWidebandDDC` confirms the renamed type still wires into the production daemon pipeline correctly.
- [x] `internal/radio/p25/phase1/control_test.go`: two new tests pin `CCStats` increments — clean stream → NIDTrusted + TSBKDecoded count up per frame; garbage NID → NIDFailed only.
- [x] `internal/radio/p25/phase1/receiver/receiver_test.go`: pin the default values the periodic state log relies on (both C4FM and CQPSK paths).
- [x] `cmd/gophertrunk/replay_test.go` (new): `TestReplayDDCCompositionLocks` is the regression guard that wiring `ccdecoder.NewDownconverter` + receiver + ControlChannel from outside the ccdecoder package reproduces a production lock on the same wideband synthetic IQ stream that the in-package wideband-DDC test uses. If this fails the operator's offline reproducer has drifted from the live decoder.
- [x] `gofmt -l .` clean, `go vet ./...` clean.
- [ ] Field verification once the reporter pastes their `mmr-s9.cfile` diagnostic bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DnNfGPVwyVBPTMFFE3BL4v)_