### PR TITLE
p25/phase2: backfill source RID + encryption from voice-channel MAC PDUs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,49 @@ for tagged releases.
 
 ### Added
 
+- **P25 Phase 2 traffic-channel metadata backfill (issue #376
+  follow-up).** Resolves the symptoms surfaced by @er-imagery's
+  2026-05-28 MMR field test: Phase 2 grants on encrypted
+  talkgroups arrived with `src=0` + `enc=false`, ALGID/KID never
+  populated, and `composer: p25p2 talker alias` log lines never
+  fired — even after #403 wired alias dispatch into the voice
+  chain. Root cause: the MAC opcode constant `OpMACPTT = 0x01`
+  was a fictional name; the real TIA-102 / SDRTrunk opcode at
+  0x01 is `GROUP_VOICE_CHANNEL_USER_ABBREVIATED`, the in-call
+  broadcast that carries SOURCE_ID + SVC_OPTIONS on the traffic
+  channel during an active call. Real MMR PDUs at 0x01 were
+  being parsed as "MAC PTT" and discarded.
+  - `phase2.OpMACPTT` is removed and replaced by
+    `phase2.OpGroupVoiceChannelUserAbbreviated = 0x01`. New
+    `OpGroupVoiceChannelUserExtended = 0x21` covers the SUID-
+    extended variant.
+  - New `phase2.GroupVoiceChannelUser` struct +
+    `MACPDU.AsGroupVoiceChannelUser()` accessor parses the
+    SDRTrunk-confirmed layout: SVC_OPTIONS at payload[0],
+    GROUP_ADDRESS at payload[1..2], SOURCE_ADDRESS at
+    payload[3..5].
+  - New `events.KindCallSourceUpdate` event +
+    `trunking.CallSourceUpdate` payload + `VoicePool.UpdateSource`
+    method + `Engine.handleCallSourceUpdate` handler form the
+    backfill path: composer publishes, engine patches
+    `ActiveCall.Grant.SourceID/.Encrypted`, republishes with the
+    call's identity. `AffiliationTracker` subscribes so RID
+    chips populate from the backfilled source.
+  - The voice composer's Phase 2 chain now also dispatches
+    in-call `OpEncryptionSync` (existing parser, just hooked up)
+    via the existing `KindCallEncryption` event, mirroring the
+    Phase 1 LDU2 path. ALGID/KID flow onto the active call as
+    the EncryptionSync PDU arrives.
+  - Diagnostic safety net: one Info log line per (opcode, MFID)
+    per call —
+    `composer: p25p2 mac pdu system=… serial=… opcode=… mfid=…
+    payload_len=…` — so if MMR emits a vendor opcode we still
+    don't dispatch (e.g. a different talker-alias opcode), the
+    next field test pinpoints exactly what we saw.
+  - Pre-existing `phase2.OpGroupVoiceChannelUserExt = 0x46` is
+    renamed to `OpUnitToUnitGrantUpdateAbbreviated` to match
+    its actual TIA-102 / SDRTrunk identity. No parser was
+    wired to it; the rename is name-only.
 - **P25 Phase 2 voice-channel talker-alias decode.** Resolves the
   follow-up half of #376: on Motorola MMR (and any Phase 2 system
   whose CC never emits talker-alias PDUs), display names ride MAC

--- a/cmd/gophertrunk/integration_cc_p25p2_test.go
+++ b/cmd/gophertrunk/integration_cc_p25p2_test.go
@@ -146,17 +146,17 @@ WaitLoop:
 //   - 400-dibit warmup cycling 0..3 so the matched filter +
 //     differential decoder converge on the constellation centre
 //   - `repeats` × a full 12-sub-frame TDMA superframe, every
-//     sub-frame a MAC sub-frame carrying an OpMACPTT MAC PDU
+//     sub-frame a MAC sub-frame carrying an OpGroupVoiceChannelUserAbbreviated MAC PDU
 //   - 100-dibit trailer for clean flush
 //
 // Each superframe is built with EncodeMACSubframe (ISCH + trellis-coded
 // MAC PDU) + EncodeSuperframe (which injects the 20-dibit outbound
 // sync), so the daemon's SuperframeDecoder-backed pipeline locks the
 // superframe, decodes the ISCH SlotTypes, and routes the MAC PDUs into
-// the control-channel state machine. OpMACPTT is the canonical
+// the control-channel state machine. OpGroupVoiceChannelUserAbbreviated is the canonical
 // non-idle "lock me" MAC PDU.
 func buildP25Phase2MACPTTStream(repeats int) []uint8 {
-	pdu := p25phase2.MACPDU{Opcode: p25phase2.OpMACPTT, Payload: make([]byte, 17)}
+	pdu := p25phase2.MACPDU{Opcode: p25phase2.OpGroupVoiceChannelUserAbbreviated, Payload: make([]byte, 17)}
 	var subs [p25phase2.SubframesPerSuperframe][]uint8
 	for i := range subs {
 		subs[i] = p25phase2.EncodeMACSubframe(

--- a/internal/events/bus.go
+++ b/internal/events/bus.go
@@ -96,6 +96,18 @@ const (
 	// any protocol whose grant carries ALGID/KID at grant time does
 	// not need this event — the values are already on the Grant.
 	KindCallEncryption Kind = "call.encryption"
+	// KindCallSourceUpdate fires when the voice composer recovers the
+	// source radio ID + encryption state for an active call from the
+	// traffic-channel signalling — e.g. a P25 Phase 2
+	// GROUP_VOICE_CHANNEL_USER PDU, where the CC grant arrived in a
+	// compressed form without SOURCE_ID or SVC_OPTIONS. The engine
+	// subscribes, backfills the bound ActiveCall's Grant
+	// (SourceID + Encrypted) so downstream consumers (storage, SSE,
+	// TUI, affiliation tracker) see the real source on CallEnd and
+	// during the live call. Protocols whose grant always carries
+	// source ID + encrypted state at grant time do not need this
+	// event — the values are already on the Grant.
+	KindCallSourceUpdate Kind = "call.source"
 	// KindBookmarkCreated / KindBookmarkUpdated / KindBookmarkDeleted
 	// fire whenever the bookmarks store mutates. Payload is a
 	// storage.Bookmark (or {ID} for deletes). Surfaced over SSE / WS

--- a/internal/radio/p25/phase2/encode.go
+++ b/internal/radio/p25/phase2/encode.go
@@ -119,6 +119,26 @@ func EncodeUnitRegistrationResponse(u UnitRegistrationResponse) MACPDU {
 	return MACPDU{Opcode: OpUnitRegistrationResponse, Payload: p}
 }
 
+// EncodeGroupVoiceChannelUser builds the MAC PDU form of a
+// GROUP_VOICE_CHANNEL_USER broadcast — the inverse of
+// MACPDU.AsGroupVoiceChannelUser. Pass extended=true to emit the
+// 0x21 Extended opcode (otherwise 0x01 Abbreviated). The extended
+// SUID fields (WACN/System/ID) are zero-padded; surface them when
+// a follow-up needs them.
+func EncodeGroupVoiceChannelUser(u GroupVoiceChannelUser, extended bool) MACPDU {
+	op := OpGroupVoiceChannelUserAbbreviated
+	if extended {
+		op = OpGroupVoiceChannelUserExtended
+	}
+	payload := make([]byte, 6)
+	payload[0] = u.ServiceOptions
+	binary.BigEndian.PutUint16(payload[1:3], u.GroupAddress)
+	payload[3] = byte(u.SourceID >> 16)
+	payload[4] = byte(u.SourceID >> 8)
+	payload[5] = byte(u.SourceID)
+	return MACPDU{Opcode: op, Payload: payload}
+}
+
 // EncodeTalkerAliasFragment builds the MAC PDU form of a talker-alias
 // fragment — the inverse of MACPDU.AsTalkerAliasFragment.
 func EncodeTalkerAliasFragment(f TalkerAliasFragment) MACPDU {

--- a/internal/radio/p25/phase2/mac.go
+++ b/internal/radio/p25/phase2/mac.go
@@ -34,14 +34,15 @@ type Opcode uint8
 
 const (
 	OpUnknown                           Opcode = 0x00
-	OpMACPTT                            Opcode = 0x01 // PTT-on
+	OpGroupVoiceChannelUserAbbreviated  Opcode = 0x01 // In-call group voice channel user (abbreviated)
 	OpMACEnd                            Opcode = 0x02 // End of transmission
 	OpMACIdle                           Opcode = 0x03 // Channel idle
 	OpMACHangtime                       Opcode = 0x05 // Hang-time
 	OpMACActive                         Opcode = 0x06 // Late-grant active
+	OpGroupVoiceChannelUserExtended     Opcode = 0x21 // In-call group voice channel user (extended; carries SUID)
 	OpGroupVoiceChannelGrantUpdate      Opcode = 0x40
 	OpGroupVoiceChannelGrant            Opcode = 0x44
-	OpGroupVoiceChannelUserExt          Opcode = 0x46
+	OpUnitToUnitGrantUpdateAbbreviated  Opcode = 0x46
 	OpUnitToUnitVoiceChannelGrant       Opcode = 0x48
 	OpUnitToUnitVoiceChannelGrantUpdate Opcode = 0x49
 	OpGroupAffiliationResponse          Opcode = 0x4C
@@ -54,8 +55,10 @@ const (
 
 func (o Opcode) String() string {
 	switch o {
-	case OpMACPTT:
-		return "MAC_PTT"
+	case OpGroupVoiceChannelUserAbbreviated:
+		return "GroupVoiceChannelUserAbbreviated"
+	case OpGroupVoiceChannelUserExtended:
+		return "GroupVoiceChannelUserExtended"
 	case OpMACEnd:
 		return "MAC_END"
 	case OpMACIdle:
@@ -68,8 +71,8 @@ func (o Opcode) String() string {
 		return "GroupVoiceChannelGrant"
 	case OpGroupVoiceChannelGrantUpdate:
 		return "GroupVoiceChannelGrantUpdate"
-	case OpGroupVoiceChannelUserExt:
-		return "GroupVoiceChannelUserExt"
+	case OpUnitToUnitGrantUpdateAbbreviated:
+		return "UnitToUnitGrantUpdateAbbreviated"
 	case OpUnitToUnitVoiceChannelGrant:
 		return "UnitToUnitVoiceChannelGrant"
 	case OpUnitToUnitVoiceChannelGrantUpdate:
@@ -259,9 +262,10 @@ func (p MACPDU) IsIdle() bool {
 // falls outside the recognised set.
 func (o Opcode) IsKnown() bool {
 	switch o {
-	case OpMACPTT, OpMACEnd, OpMACIdle, OpMACHangtime, OpMACActive,
+	case OpGroupVoiceChannelUserAbbreviated, OpGroupVoiceChannelUserExtended,
+		OpMACEnd, OpMACIdle, OpMACHangtime, OpMACActive,
 		OpGroupVoiceChannelGrant, OpGroupVoiceChannelGrantUpdate,
-		OpGroupVoiceChannelUserExt, OpUnitToUnitVoiceChannelGrant,
+		OpUnitToUnitGrantUpdateAbbreviated, OpUnitToUnitVoiceChannelGrant,
 		OpUnitToUnitVoiceChannelGrantUpdate, OpGroupAffiliationResponse,
 		OpUnitRegistrationResponse,
 		OpIdentifierUpdate, OpVendorGroupRegroup, OpVendorTalkerAlias,
@@ -270,6 +274,53 @@ func (o Opcode) IsKnown() bool {
 		return true
 	}
 	return false
+}
+
+// GroupVoiceChannelUser is the structured shape of an in-call
+// GROUP_VOICE_CHANNEL_USER MAC PDU — the traffic-channel broadcast a
+// Phase 2 system emits during an active call to identify the source
+// radio + carry the SVC_OPTIONS for the call. The CC's grant on
+// real systems often arrives without these fields (compressed grant
+// form: src=0, enc=false), so the source RID + encryption flag
+// arrive in-call via this PDU on the voice channel. The voice
+// composer publishes a trunking.CallSourceUpdate when one decodes
+// so the trunking engine can backfill the bound ActiveCall.
+//
+// Both the Abbreviated form (0x01) and the Extended form (0x21)
+// share the same layout for the first three fields per SDRTrunk's
+// GroupVoiceChannelUserAbbreviated.java + Extended.java +
+// MacStructureGroupVoiceService.java + MacStructureVoiceService.java
+// (verified during PR drafting): SVC_OPTIONS at SDRTrunk octet 2,
+// GROUP_ADDRESS at octets 3-4, SOURCE_ADDRESS at octets 5-7. The
+// Extended form adds a 64-bit SUID (WACN+System+ID) after the
+// source address; those fields aren't surfaced here yet — only the
+// in-call source ID + svc_opts matter for the backfill flow.
+type GroupVoiceChannelUser struct {
+	ServiceOptions uint8
+	GroupAddress   uint16
+	SourceID       uint32 // 24-bit source radio ID
+}
+
+// AsGroupVoiceChannelUser returns the structured in-call user
+// broadcast if the PDU opcode is OpGroupVoiceChannelUserAbbreviated
+// or OpGroupVoiceChannelUserExtended, otherwise (zero, false). The
+// payload needs at least 6 bytes to cover svc_opts (1) +
+// group_address (2) + source_id (3); the Extended form's SUID tail
+// is optional and ignored here.
+func (p MACPDU) AsGroupVoiceChannelUser() (GroupVoiceChannelUser, bool) {
+	switch p.Opcode {
+	case OpGroupVoiceChannelUserAbbreviated, OpGroupVoiceChannelUserExtended:
+	default:
+		return GroupVoiceChannelUser{}, false
+	}
+	if len(p.Payload) < 6 {
+		return GroupVoiceChannelUser{}, false
+	}
+	return GroupVoiceChannelUser{
+		ServiceOptions: p.Payload[0],
+		GroupAddress:   binary.BigEndian.Uint16(p.Payload[1:3]),
+		SourceID:       uint32(p.Payload[3])<<16 | uint32(p.Payload[4])<<8 | uint32(p.Payload[5]),
+	}, true
 }
 
 // IsManufacturerSpecific reports whether the opcode falls in the P25

--- a/internal/radio/p25/phase2/mac_standard_test.go
+++ b/internal/radio/p25/phase2/mac_standard_test.go
@@ -35,6 +35,53 @@ func TestAsUnitToUnitVoiceChannelGrant(t *testing.T) {
 	}
 }
 
+// TestAsGroupVoiceChannelUserAbbreviated round-trips the in-call
+// User PDU (MAC opcode 0x01) — the broadcast that backfills source
+// RID + SVC_OPTIONS during an active call on real Phase 2 systems
+// whose CC grant arrives in a compressed form (src=0, enc=false).
+func TestAsGroupVoiceChannelUserAbbreviated(t *testing.T) {
+	in := GroupVoiceChannelUser{
+		ServiceOptions: 0x40, // bit 6 = encrypted
+		GroupAddress:   0x4EEA,
+		SourceID:       315203, // the field reporter's MMR sample RID
+	}
+	got, ok := EncodeGroupVoiceChannelUser(in, false).AsGroupVoiceChannelUser()
+	if !ok {
+		t.Fatal("AsGroupVoiceChannelUser returned !ok for Abbreviated form")
+	}
+	if got != in {
+		t.Errorf("round-trip = %+v, want %+v", got, in)
+	}
+}
+
+// TestAsGroupVoiceChannelUserExtended confirms the Extended form
+// (opcode 0x21) decodes the same first three fields — only the
+// trailing SUID bytes (WACN/System/ID) differ from the Abbreviated
+// form, and AsGroupVoiceChannelUser ignores them here.
+func TestAsGroupVoiceChannelUserExtended(t *testing.T) {
+	in := GroupVoiceChannelUser{
+		ServiceOptions: 0x00,
+		GroupAddress:   0x1234,
+		SourceID:       0xABCDEF,
+	}
+	got, ok := EncodeGroupVoiceChannelUser(in, true).AsGroupVoiceChannelUser()
+	if !ok {
+		t.Fatal("AsGroupVoiceChannelUser returned !ok for Extended form")
+	}
+	if got != in {
+		t.Errorf("round-trip = %+v, want %+v", got, in)
+	}
+}
+
+// TestAsGroupVoiceChannelUserWrongOpcode rejects PDUs that aren't
+// one of the two User opcodes — e.g. an actual grant.
+func TestAsGroupVoiceChannelUserWrongOpcode(t *testing.T) {
+	pdu := MACPDU{Opcode: OpGroupVoiceChannelGrant, Payload: make([]byte, 9)}
+	if _, ok := pdu.AsGroupVoiceChannelUser(); ok {
+		t.Error("AsGroupVoiceChannelUser accepted a non-User opcode")
+	}
+}
+
 func TestAsUnitToUnitWrongOpcode(t *testing.T) {
 	pdu := MACPDU{Opcode: OpGroupVoiceChannelGrant, Payload: make([]byte, 9)}
 	if _, ok := pdu.AsUnitToUnitVoiceChannelGrant(); ok {

--- a/internal/radio/p25/phase2/phase2_test.go
+++ b/internal/radio/p25/phase2/phase2_test.go
@@ -41,7 +41,7 @@ func TestMACPDUIsIdle(t *testing.T) {
 		OpMACIdle:                true,
 		OpMACHangtime:            true,
 		OpMACEnd:                 true,
-		OpMACPTT:                 false,
+		OpGroupVoiceChannelUserAbbreviated:                 false,
 		OpGroupVoiceChannelGrant: false,
 	}
 	for op, want := range cases {
@@ -81,7 +81,7 @@ func TestAsGroupVoiceChannelGrantExtractsFields(t *testing.T) {
 }
 
 func TestAsGroupVoiceChannelGrantWrongOpcode(t *testing.T) {
-	pdu := MACPDU{Opcode: OpMACPTT, Payload: make([]byte, 8)}
+	pdu := MACPDU{Opcode: OpGroupVoiceChannelUserAbbreviated, Payload: make([]byte, 8)}
 	if _, ok := pdu.AsGroupVoiceChannelGrant(); ok {
 		t.Fatal("AsGroupVoiceChannelGrant returned ok for non-grant opcode")
 	}

--- a/internal/radio/p25/phase2/phase2_test.go
+++ b/internal/radio/p25/phase2/phase2_test.go
@@ -38,11 +38,11 @@ func TestMACPDUParseEmpty(t *testing.T) {
 
 func TestMACPDUIsIdle(t *testing.T) {
 	cases := map[Opcode]bool{
-		OpMACIdle:                true,
-		OpMACHangtime:            true,
-		OpMACEnd:                 true,
-		OpGroupVoiceChannelUserAbbreviated:                 false,
-		OpGroupVoiceChannelGrant: false,
+		OpMACIdle:                          true,
+		OpMACHangtime:                      true,
+		OpMACEnd:                           true,
+		OpGroupVoiceChannelUserAbbreviated: false,
+		OpGroupVoiceChannelGrant:           false,
 	}
 	for op, want := range cases {
 		got := MACPDU{Opcode: op}.IsIdle()

--- a/internal/radio/p25/phase2/process_test.go
+++ b/internal/radio/p25/phase2/process_test.go
@@ -10,9 +10,9 @@ import (
 
 // TestProcessLocksOnFirstMACPDUAfterSync: build a dibit stream of
 // 30 padding dibits + 20 outbound sync dibits + 72 dibits whose
-// raw bits form a MAC PDU (opcode = OpMACPTT, no payload). The
+// raw bits form a MAC PDU (opcode = OpGroupVoiceChannelUserAbbreviated, no payload). The
 // state machine should publish a KindCCLocked since
-// OpMACPTT.IsIdle() returns false.
+// OpGroupVoiceChannelUserAbbreviated.IsIdle() returns false.
 func TestProcessLocksOnFirstMACPDUAfterSync(t *testing.T) {
 	bus := events.NewBus(8)
 	defer bus.Close()
@@ -26,7 +26,7 @@ func TestProcessLocksOnFirstMACPDUAfterSync(t *testing.T) {
 		FrequencyHz: 851_062_500,
 	})
 
-	pdu := MACPDU{Opcode: OpMACPTT, Payload: make([]byte, 17)}
+	pdu := MACPDU{Opcode: OpGroupVoiceChannelUserAbbreviated, Payload: make([]byte, 17)}
 	pduBytes := AssembleMACPDU(pdu)
 	if len(pduBytes) != 18 {
 		t.Fatalf("AssembleMACPDU = %d bytes, want 18", len(pduBytes))
@@ -73,7 +73,7 @@ func TestProcessHandlesMACPDUSpanningCalls(t *testing.T) {
 
 	cc := New(Options{Bus: bus, Log: slog.Default(), SystemName: "Sys"})
 
-	pdu := MACPDU{Opcode: OpMACPTT, Payload: make([]byte, 17)}
+	pdu := MACPDU{Opcode: OpGroupVoiceChannelUserAbbreviated, Payload: make([]byte, 17)}
 	pduBits := framing.UnpackBitsMSB(AssembleMACPDU(pdu), 144)
 	pduDibits := framing.BitsToDibits(pduBits)
 

--- a/internal/radio/p25/phase2/process_trellis_test.go
+++ b/internal/radio/p25/phase2/process_trellis_test.go
@@ -31,9 +31,9 @@ func TestProcessTrellisOnDecodesEncodedMACPDU(t *testing.T) {
 	})
 	cc.SetTrellisMode(TrellisOn)
 
-	// MAC PDU with a recognised Opcode (OpMACPTT triggers cc.locked
+	// MAC PDU with a recognised Opcode (OpGroupVoiceChannelUserAbbreviated triggers cc.locked
 	// via the !IsIdle path).
-	pdu := MACPDU{Opcode: OpMACPTT, Payload: make([]byte, 17)}
+	pdu := MACPDU{Opcode: OpGroupVoiceChannelUserAbbreviated, Payload: make([]byte, 17)}
 	pduBits := framing.UnpackBitsMSB(AssembleMACPDU(pdu), 144)
 	infoDibits := framing.BitsToDibits(pduBits)
 	if len(infoDibits) != 72 {
@@ -131,7 +131,7 @@ func TestProcessTrellisOnRejectsRawMACPDU(t *testing.T) {
 	cc := New(Options{Bus: bus, Log: slog.Default(), SystemName: "Sys"})
 	cc.SetTrellisMode(TrellisOn)
 
-	pdu := MACPDU{Opcode: OpMACPTT, Payload: make([]byte, 17)}
+	pdu := MACPDU{Opcode: OpGroupVoiceChannelUserAbbreviated, Payload: make([]byte, 17)}
 	pduBits := framing.UnpackBitsMSB(AssembleMACPDU(pdu), 144)
 	rawDibits := framing.BitsToDibits(pduBits)
 

--- a/internal/radio/p25/phase2/strict_test.go
+++ b/internal/radio/p25/phase2/strict_test.go
@@ -69,9 +69,9 @@ func TestStrictValidationKeepsKnownOpcode(t *testing.T) {
 
 func TestOpcodeIsKnownCoversDocumentedConstants(t *testing.T) {
 	known := []Opcode{
-		OpMACPTT, OpMACEnd, OpMACIdle, OpMACHangtime, OpMACActive,
+		OpGroupVoiceChannelUserAbbreviated, OpMACEnd, OpMACIdle, OpMACHangtime, OpMACActive,
 		OpGroupVoiceChannelGrant, OpGroupVoiceChannelGrantUpdate,
-		OpGroupVoiceChannelUserExt, OpUnitToUnitVoiceChannelGrant,
+		OpUnitToUnitGrantUpdateAbbreviated, OpUnitToUnitVoiceChannelGrant,
 		OpNetworkStatusBroadcastUpdate, OpRFSSStatusBroadcastUpdate,
 	}
 	for _, o := range known {

--- a/internal/trunking/affiliation_tracker.go
+++ b/internal/trunking/affiliation_tracker.go
@@ -140,6 +140,16 @@ func (t *AffiliationTracker) handle(ev events.Event) {
 		if a, ok := ev.Payload.(TalkerAlias); ok && a.SourceID != 0 && a.Alias != "" {
 			t.observeAlias(a.SourceID, a.System, a.Protocol, a.Alias)
 		}
+	case events.KindCallSourceUpdate:
+		// In-call source RID backfill (P25 Phase 2 traffic-channel
+		// GROUP_VOICE_CHANNEL_USER). The grant fired with src=0 so
+		// the original KindGrant case above didn't observe; record
+		// the real source now so /rids and history surface it.
+		// countCall=false because the call was already counted on
+		// the grant; this only stamps the source identity.
+		if u, ok := ev.Payload.(CallSourceUpdate); ok && u.SourceID != 0 {
+			t.observe(u.SourceID, u.GroupID, u.System, u.Protocol, false, false, false)
+		}
 	}
 }
 

--- a/internal/trunking/engine.go
+++ b/internal/trunking/engine.go
@@ -140,6 +140,10 @@ func (e *Engine) Run(ctx context.Context) error {
 				if c, ok := ev.Payload.(CallEncryption); ok {
 					e.handleCallEncryption(c)
 				}
+			case events.KindCallSourceUpdate:
+				if c, ok := ev.Payload.(CallSourceUpdate); ok {
+					e.handleCallSourceUpdate(c)
+				}
 			}
 		case <-tick.C:
 			e.runWatchdog()
@@ -276,6 +280,62 @@ func (e *Engine) handleCallEncryption(c CallEncryption) {
 		"system", enriched.System,
 		"tg", enriched.GroupID,
 		"alg", c.AlgorithmID, "key", c.KeyID)
+}
+
+// handleCallSourceUpdate backfills SourceID + Encrypted on the bound
+// ActiveCall when an in-call GROUP_VOICE_CHANNEL_USER PDU arrives on
+// the voice channel — used by P25 Phase 2 systems whose CC grant
+// arrives in a compressed form (src=0 + enc=false) and the source
+// RID + encryption state only surface in-call on the traffic
+// channel. Republishes the event with the call's system / protocol
+// / group context so SSE + TUI consumers can patch their live view.
+// Skipped when System is already populated — the engine's own
+// re-publish coming back through the subscription. Logged-and-
+// dropped when no active call matches the device serial (e.g. the
+// call already ended).
+func (e *Engine) handleCallSourceUpdate(c CallSourceUpdate) {
+	if c.System != "" {
+		return
+	}
+	g, ok := e.pool.UpdateSource(c.DeviceSerial, c.SourceID, c.Encrypted)
+	if !ok {
+		e.mu.Lock()
+		if ac, sok := e.synthetic[c.DeviceSerial]; sok {
+			if c.SourceID != 0 {
+				ac.Grant.SourceID = c.SourceID
+			}
+			if c.Encrypted {
+				ac.Grant.Encrypted = true
+			}
+			g = ac.Grant
+			ok = true
+		}
+		e.mu.Unlock()
+	}
+	if !ok {
+		e.log.Debug("call source update for unknown call",
+			"device", c.DeviceSerial)
+		return
+	}
+	enriched := CallSourceUpdate{
+		DeviceSerial: c.DeviceSerial,
+		System:       g.System,
+		Protocol:     g.Protocol,
+		GroupID:      g.GroupID,
+		SourceID:     g.SourceID,
+		Encrypted:    g.Encrypted,
+		At:           c.At,
+	}
+	e.bus.Publish(events.Event{
+		Kind:    events.KindCallSourceUpdate,
+		Payload: enriched,
+	})
+	e.log.Info("call source update",
+		"device", c.DeviceSerial,
+		"system", enriched.System,
+		"tg", enriched.GroupID,
+		"src", enriched.SourceID,
+		"enc", enriched.Encrypted)
 }
 
 // handlePatch applies a patch announcement to the registry: an Add

--- a/internal/trunking/engine_test.go
+++ b/internal/trunking/engine_test.go
@@ -563,6 +563,98 @@ func TestEngineHandleCallEncryptionUnknownDeviceDoesNotPanic(t *testing.T) {
 	})
 }
 
+// TestEngineHandleCallSourceUpdateBackfillsActiveCall guards the
+// Phase 2 traffic-channel source / encryption backfill flow (the
+// MMR fix for issue #376). The CC publishes a grant with src=0 and
+// enc=false (compressed grant form); the voice composer recovers
+// the real source RID + encrypted state from an in-call
+// GROUP_VOICE_CHANNEL_USER PDU on the traffic channel and publishes
+// CallSourceUpdate. The engine must (1) patch the bound
+// ActiveCall.Grant via VoicePool.UpdateSource, (2) republish with
+// System / Protocol / GroupID filled.
+func TestEngineHandleCallSourceUpdateBackfillsActiveCall(t *testing.T) {
+	bus := events.NewBus(16)
+	defer bus.Close()
+	pool, _ := mkPool(1)
+	e, _ := NewEngine(EngineOptions{
+		Bus:         bus,
+		VoicePool:   pool,
+		Talkgroups:  NewTalkgroupDB(),
+		CallTimeout: 5 * time.Second,
+	})
+
+	// Phase 2 grant arrives in a compressed form: src=0, enc=false.
+	e.HandleGrant(Grant{
+		System: "MMR", Protocol: "p25-phase2",
+		GroupID: 20202, FrequencyHz: 421_387_500,
+	})
+	actives := e.ActiveCalls()
+	if len(actives) != 1 {
+		t.Fatalf("expected 1 active call, got %d", len(actives))
+	}
+	dev := actives[0].Device.Serial
+	if actives[0].Grant.SourceID != 0 || actives[0].Grant.Encrypted {
+		t.Fatalf("pre-backfill src/enc should be 0/false, got %v/%v",
+			actives[0].Grant.SourceID, actives[0].Grant.Encrypted)
+	}
+
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	e.handleCallSourceUpdate(CallSourceUpdate{
+		DeviceSerial: dev,
+		SourceID:     315203, // @er-imagery's example MMR radio
+		Encrypted:    true,
+		At:           time.Now(),
+	})
+
+	updated := e.ActiveCalls()
+	if len(updated) != 1 {
+		t.Fatalf("expected 1 active call after backfill, got %d", len(updated))
+	}
+	if updated[0].Grant.SourceID != 315203 || !updated[0].Grant.Encrypted {
+		t.Errorf("backfill did not land on Grant: src=%d enc=%v",
+			updated[0].Grant.SourceID, updated[0].Grant.Encrypted)
+	}
+
+	select {
+	case ev := <-sub.C:
+		if ev.Kind != events.KindCallSourceUpdate {
+			t.Fatalf("expected KindCallSourceUpdate republish, got %s", ev.Kind)
+		}
+		c, ok := ev.Payload.(CallSourceUpdate)
+		if !ok {
+			t.Fatalf("payload type = %T", ev.Payload)
+		}
+		if c.System != "MMR" || c.Protocol != "p25-phase2" || c.GroupID != 20202 {
+			t.Errorf("enriched payload missing identity fields: %+v", c)
+		}
+		if c.SourceID != 315203 || !c.Encrypted {
+			t.Errorf("enriched payload src/enc = %d/%v", c.SourceID, c.Encrypted)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("never received enriched republish")
+	}
+}
+
+// TestEngineHandleCallSourceUpdateUnknownDeviceDoesNotPanic guards
+// the late-arriving PDU after a call ends.
+func TestEngineHandleCallSourceUpdateUnknownDeviceDoesNotPanic(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	pool, _ := mkPool(1)
+	e, _ := NewEngine(EngineOptions{
+		Bus:         bus,
+		VoicePool:   pool,
+		Talkgroups:  NewTalkgroupDB(),
+		CallTimeout: 5 * time.Second,
+	})
+	e.handleCallSourceUpdate(CallSourceUpdate{
+		DeviceSerial: "no-such-device",
+		SourceID:     999,
+	})
+}
+
 func TestEngineEmptyVoicePoolWarnsOnceThenDebug(t *testing.T) {
 	// Issue #379: a daemon with trunking systems but zero `role: voice`
 	// SDRs builds an empty VoicePool. Every grant used to log a

--- a/internal/trunking/grant.go
+++ b/internal/trunking/grant.go
@@ -205,3 +205,23 @@ type CallEncryption struct {
 	MessageIndicator [9]byte
 	At               time.Time
 }
+
+// CallSourceUpdate is the payload of an events.KindCallSourceUpdate
+// event. The voice composer publishes one when it recovers the
+// source radio ID + encryption state from in-call traffic-channel
+// signalling — e.g. a P25 Phase 2 GROUP_VOICE_CHANNEL_USER PDU
+// where the CC grant arrived in a compressed form without those
+// fields (src=0 + enc=false). The engine subscribes, backfills the
+// bound ActiveCall.Grant.SourceID + .Encrypted via the voice pool,
+// and republishes the event with System / Protocol / GroupID
+// populated so SSE + TUI consumers can patch their live view.
+// DeviceSerial keys the update to a specific active call.
+type CallSourceUpdate struct {
+	DeviceSerial string
+	System       string // filled in by the engine on republish
+	Protocol     string
+	GroupID      uint32 // filled in by the engine on republish from the bound Grant
+	SourceID     uint32
+	Encrypted    bool
+	At           time.Time
+}

--- a/internal/trunking/voicepool.go
+++ b/internal/trunking/voicepool.go
@@ -235,3 +235,30 @@ func (p *VoicePool) UpdateEncryption(serial string, algID uint8, keyID uint16) (
 	ac.Grant.KeyID = keyID
 	return ac.Grant, true
 }
+
+// UpdateSource backfills SourceID + Encrypted on the active call
+// bound to serial — used by the engine when an in-call
+// GROUP_VOICE_CHANNEL_USER PDU arrives on the traffic channel after
+// a compressed grant whose SOURCE_ID / SVC_OPTIONS were absent
+// (e.g. P25 Phase 2 MMR). SourceID is only overwritten when the
+// new value is non-zero so a later compressed-form update doesn't
+// blank out a legitimate source. Encrypted is OR-merged so an
+// in-call PDU can flip a non-encrypted grant to encrypted but
+// never the other way (the spec doesn't define mid-call
+// decryption). Returns a copy of the updated Grant + ok=true when
+// a matching call was found.
+func (p *VoicePool) UpdateSource(serial string, sourceID uint32, encrypted bool) (Grant, bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	ac, ok := p.active[serial]
+	if !ok {
+		return Grant{}, false
+	}
+	if sourceID != 0 {
+		ac.Grant.SourceID = sourceID
+	}
+	if encrypted {
+		ac.Grant.Encrypted = true
+	}
+	return ac.Grant, true
+}

--- a/internal/voice/composer/p25p2_voice.go
+++ b/internal/voice/composer/p25p2_voice.go
@@ -65,6 +65,11 @@ func (c *Composer) runP25Phase2VoiceChain(ctx context.Context, serial string, sy
 	rs, _ := c.sink.(rawFrameSink)
 	sfDec := p25p2.NewSuperframeDecoder()
 	aliasAsm := p25p2.NewTalkerAliasAssembler(nil)
+	// macSeen rate-limits the diagnostic per-PDU log to one line per
+	// opcode (+ MFID for vendor opcodes) per call — enough to confirm
+	// which transports MMR-style systems actually emit, without
+	// drowning the log when an opcode repeats many times per call.
+	macSeen := make(map[uint16]struct{})
 	// voiceSubframes counts P25 Phase 2 voice-bearing subframes the
 	// receiver delivered — i.e. real voice activity. The touch ticker
 	// (below) only refreshes the engine's LastHeardAt when this counter
@@ -102,15 +107,35 @@ func (c *Composer) runP25Phase2VoiceChain(ctx context.Context, serial string, sy
 					}
 				}
 				for _, pdu := range p25p2.DecodeSuperframeMACPDUs(sf, macCfg) {
-					f, ok := pdu.AsTalkerAliasFragment()
-					if !ok {
+					// Prong C diagnostic: log the first PDU seen per
+					// (opcode, MFID) on this call. If a real on-air
+					// system emits an opcode we don't dispatch
+					// (vendor talker-alias variants, an unexpected
+					// User PDU encoding, …) the log line tells the
+					// next field tester exactly what we saw.
+					key := uint16(pdu.Opcode)<<8 | uint16(pdu.MFID)
+					if _, seen := macSeen[key]; !seen {
+						macSeen[key] = struct{}{}
+						c.log.Info("composer: p25p2 mac pdu",
+							"system", system, "serial", serial,
+							"opcode", pdu.Opcode, "mfid", pdu.MFID,
+							"payload_len", len(pdu.Payload))
+					}
+					if u, ok := pdu.AsGroupVoiceChannelUser(); ok {
+						c.publishP25Phase2CallSource(serial, u)
 						continue
 					}
-					alias, src, complete := aliasAsm.Add(f)
-					if !complete {
+					if es, ok := pdu.AsEncryptionSync(); ok {
+						c.publishP25Phase2CallEncryption(serial, es)
 						continue
 					}
-					c.publishP25Phase2TalkerAlias(system, src, alias)
+					if f, ok := pdu.AsTalkerAliasFragment(); ok {
+						alias, src, complete := aliasAsm.Add(f)
+						if complete {
+							c.publishP25Phase2TalkerAlias(system, src, alias)
+						}
+						continue
+					}
 				}
 			}
 		},
@@ -163,4 +188,45 @@ func (c *Composer) publishP25Phase2TalkerAlias(system string, sourceID uint32, a
 	})
 	c.log.Info("composer: p25p2 talker alias",
 		"system", system, "src", sourceID, "alias", alias)
+}
+
+// publishP25Phase2CallSource publishes a KindCallSourceUpdate event so
+// the trunking engine can backfill the bound ActiveCall's SourceID +
+// Encrypted from an in-call GROUP_VOICE_CHANNEL_USER PDU. The engine
+// fills in System / Protocol / GroupID from the bound Grant on
+// republish — leave them blank here.
+func (c *Composer) publishP25Phase2CallSource(serial string, u p25p2.GroupVoiceChannelUser) {
+	if c.bus == nil {
+		return
+	}
+	so := p25p2.ServiceOptions(u.ServiceOptions)
+	c.bus.Publish(events.Event{
+		Kind: events.KindCallSourceUpdate,
+		Payload: trunking.CallSourceUpdate{
+			DeviceSerial: serial,
+			SourceID:     u.SourceID,
+			Encrypted:    so.Encrypted(),
+			At:           time.Now().UTC(),
+		},
+	})
+}
+
+// publishP25Phase2CallEncryption mirrors the Phase 1 LDU2 in-call
+// encryption-sync path for Phase 2 traffic-channel EncryptionSync MAC
+// PDUs. The engine backfills ALGID/KID onto the bound ActiveCall's
+// Grant and republishes with the call's identity.
+func (c *Composer) publishP25Phase2CallEncryption(serial string, es p25p2.EncryptionSync) {
+	if c.bus == nil {
+		return
+	}
+	c.bus.Publish(events.Event{
+		Kind: events.KindCallEncryption,
+		Payload: trunking.CallEncryption{
+			DeviceSerial:     serial,
+			AlgorithmID:      es.AlgorithmID,
+			KeyID:            es.KeyID,
+			MessageIndicator: es.MessageIndicator,
+			At:               time.Now().UTC(),
+		},
+	})
 }

--- a/internal/voice/composer/p25p2_voice_test.go
+++ b/internal/voice/composer/p25p2_voice_test.go
@@ -297,3 +297,179 @@ func TestComposerP25Phase2TalkerAliasFires(t *testing.T) {
 		}
 	}
 }
+
+// buildP25P2MetadataStream assembles n superframes carrying three
+// in-call MAC PDUs the MMR field test surfaced as missing from the
+// composer dispatch: GROUP_VOICE_CHANNEL_USER (source RID + svc opts),
+// ENCRYPTION_SYNC (ALGID + KID), and a talker-alias fragment pair —
+// interleaved with Voice4V sub-frames.
+func buildP25P2MetadataStream(n int) (dibits []uint8, wantSrc uint32, wantAlias string, wantAlgID uint8, wantKeyID uint16) {
+	wantSrc = 315203 // the reporter's MMR sample radio
+	wantAlias = "UNIT-7"
+	wantAlgID = 0x84 // AES-256
+	wantKeyID = 0x1234
+
+	userPDU := p25p2.EncodeGroupVoiceChannelUser(p25p2.GroupVoiceChannelUser{
+		ServiceOptions: 0x40, // bit 6 = encrypted
+		GroupAddress:   0x4EEA,
+		SourceID:       wantSrc,
+	}, false)
+	encPDU := p25p2.EncodeEncryptionSync(p25p2.EncryptionSync{
+		AlgorithmID:      wantAlgID,
+		KeyID:            wantKeyID,
+		MessageIndicator: [9]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09},
+	})
+	frag0 := p25p2.EncodeTalkerAliasFragment(p25p2.TalkerAliasFragment{
+		SourceID: wantSrc, BlockIndex: 0, BlockCount: 2, Data: []byte("UNIT"),
+	})
+	frag1 := p25p2.EncodeTalkerAliasFragment(p25p2.TalkerAliasFragment{
+		SourceID: wantSrc, BlockIndex: 1, BlockCount: 2, Data: []byte("-7"),
+	})
+
+	dibits = make([]uint8, 600)
+	for i := range dibits {
+		dibits[i] = uint8(i % 4)
+	}
+	for s := 0; s < n; s++ {
+		var subs [p25p2.SubframesPerSuperframe][]uint8
+		for i := range subs {
+			switch i {
+			case 0:
+				subs[i] = p25p2.EncodeMACSubframe(p25p2.SlotTypeMACSignaling, uint8(i),
+					userPDU, p25p2.TrellisOn, p25p2.InterleaveOff)
+			case 3:
+				subs[i] = p25p2.EncodeMACSubframe(p25p2.SlotTypeMACSignaling, uint8(i),
+					encPDU, p25p2.TrellisOn, p25p2.InterleaveOff)
+			case 6:
+				subs[i] = p25p2.EncodeMACSubframe(p25p2.SlotTypeMACSignaling, uint8(i),
+					frag0, p25p2.TrellisOn, p25p2.InterleaveOff)
+			case 9:
+				subs[i] = p25p2.EncodeMACSubframe(p25p2.SlotTypeMACSignaling, uint8(i),
+					frag1, p25p2.TrellisOn, p25p2.InterleaveOff)
+			default:
+				payloads := make([][]byte, p25p2.Voice4VFrameCount)
+				for j := range payloads {
+					payloads[j] = p25p2VoicePayload(s*p25p2.SubframesPerSuperframe*p25p2.Voice4VFrameCount + i*p25p2.Voice4VFrameCount + j)
+				}
+				subs[i] = p25p2.EncodeVoiceSubframe(p25p2.SlotTypeVoice4V, uint8(i), payloads)
+			}
+		}
+		dibits = append(dibits, p25p2.EncodeSuperframe(subs)...)
+	}
+	return dibits, wantSrc, wantAlias, wantAlgID, wantKeyID
+}
+
+// TestComposerP25Phase2InCallMetadataFires drives all three in-call
+// MAC PDU transports the composer now dispatches (User Abbreviated,
+// Encryption Sync, Talker Alias) through the full Phase 2 voice chain
+// and asserts the corresponding bus events fire. This is the
+// regression guard for #376's MMR follow-up: source RID +
+// encryption state + alias must all surface from traffic-channel MAC
+// PDUs when the CC grant is compressed (src=0, enc=false).
+func TestComposerP25Phase2InCallMetadataFires(t *testing.T) {
+	const (
+		sampleRate  = 48_000.0
+		sps         = 8
+		span        = 8
+		alpha       = 0.20
+		superframes = 6
+	)
+
+	dibits, wantSrc, wantAlias, wantAlgID, wantKeyID := buildP25P2MetadataStream(superframes)
+	iq := demod.ModulatePiOver4DQPSK(dibits, sps, span, alpha, math.Pi/8)
+
+	src := newFakeSource()
+	bus := events.NewBus(128)
+	sink := &recordingSink{}
+	eng := &fakeEngine{}
+	c, err := New(Options{
+		Bus:           bus,
+		Devices:       &fakeDevices{src: map[string]IQSource{"VOICE-1": src}},
+		Sink:          sink,
+		Engine:        eng,
+		IQSampleRate:  uint32(sampleRate),
+		PCMSampleRate: 8000,
+		TouchInterval: 30 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go c.Run(ctx)
+	defer c.Close()
+
+	evSub := bus.Subscribe()
+	defer evSub.Close()
+	defer bus.Close()
+
+	bus.Publish(events.Event{
+		Kind: events.KindCallStart,
+		Payload: trunking.CallStart{
+			Grant: trunking.Grant{
+				System: "MMR", Protocol: "p25-phase2",
+				GroupID: 20202, FrequencyHz: 421_387_500,
+				P25Phase2Decode: trunking.P25Phase2Decode{
+					Trellis: uint8(p25p2.TrellisOn),
+				},
+			},
+			DeviceSerial: "VOICE-1",
+			StartedAt:    time.Now().UTC(),
+		},
+	})
+	waitFor(t, 2*time.Second, func() bool { return len(c.ActiveChains()) == 1 })
+	src.SendIQ(iq)
+
+	deadline := time.After(6 * time.Second)
+	var (
+		gotSource, gotEnc, gotAlias bool
+	)
+	for !(gotSource && gotEnc && gotAlias) {
+		select {
+		case ev := <-evSub.C:
+			switch ev.Kind {
+			case events.KindCallSourceUpdate:
+				s, ok := ev.Payload.(trunking.CallSourceUpdate)
+				if !ok {
+					t.Fatalf("KindCallSourceUpdate payload type = %T", ev.Payload)
+				}
+				if s.SourceID != wantSrc {
+					t.Errorf("CallSourceUpdate.SourceID = %#x, want %#x", s.SourceID, wantSrc)
+				}
+				if !s.Encrypted {
+					t.Errorf("CallSourceUpdate.Encrypted = false, want true")
+				}
+				if s.DeviceSerial != "VOICE-1" {
+					t.Errorf("CallSourceUpdate.DeviceSerial = %q, want VOICE-1", s.DeviceSerial)
+				}
+				gotSource = true
+			case events.KindCallEncryption:
+				e, ok := ev.Payload.(trunking.CallEncryption)
+				if !ok {
+					t.Fatalf("KindCallEncryption payload type = %T", ev.Payload)
+				}
+				if e.AlgorithmID != wantAlgID || e.KeyID != wantKeyID {
+					t.Errorf("CallEncryption alg/key = 0x%X/0x%X, want 0x%X/0x%X",
+						e.AlgorithmID, e.KeyID, wantAlgID, wantKeyID)
+				}
+				if e.DeviceSerial != "VOICE-1" {
+					t.Errorf("CallEncryption.DeviceSerial = %q, want VOICE-1", e.DeviceSerial)
+				}
+				gotEnc = true
+			case events.KindTalkerAlias:
+				a, ok := ev.Payload.(trunking.TalkerAlias)
+				if !ok {
+					t.Fatalf("KindTalkerAlias payload type = %T", ev.Payload)
+				}
+				if a.SourceID != wantSrc || a.Alias != wantAlias {
+					t.Errorf("TalkerAlias = (%#x, %q), want (%#x, %q)",
+						a.SourceID, a.Alias, wantSrc, wantAlias)
+				}
+				gotAlias = true
+			}
+		case <-deadline:
+			t.Fatalf("missing events after 6s: source=%v enc=%v alias=%v",
+				gotSource, gotEnc, gotAlias)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Resolves the symptoms from @er-imagery's 2026-05-28 MMR field test ([#376 comment 4559735566](https://github.com/MattCheramie/GopherTrunk/issues/376#issuecomment-4559735566)): Phase 2 grants on encrypted talkgroups arrived with `src=0` + `enc=false`, ALGID/KID never populated, no `composer: p25p2 talker alias` log lines fired — even after #403 wired alias dispatch into the voice chain.

**Root cause** (surfaced during implementation): `OpMACPTT = 0x01` was a fictional opcode name. Per TIA-102 / SDRTrunk, opcode 0x01 is `GROUP_VOICE_CHANNEL_USER_ABBREVIATED` — the in-call broadcast carrying SOURCE_ID + SVC_OPTIONS on the traffic channel during an active call. MMR's real PDUs at 0x01 were being parsed as "MAC PTT" and silently discarded.

- Replace `phase2.OpMACPTT` with `OpGroupVoiceChannelUserAbbreviated = 0x01` + add `OpGroupVoiceChannelUserExtended = 0x21`.
- New `phase2.GroupVoiceChannelUser` struct + `MACPDU.AsGroupVoiceChannelUser()` accessor with SDRTrunk-confirmed layout (SVC_OPTIONS at payload[0], GROUP_ADDRESS at [1..2], SOURCE_ADDRESS at [3..5]).
- New `events.KindCallSourceUpdate` + `trunking.CallSourceUpdate` + `VoicePool.UpdateSource` + `Engine.handleCallSourceUpdate` form the backfill path: composer publishes, engine patches `ActiveCall.Grant.SourceID/.Encrypted`, republishes with the call's identity. `AffiliationTracker` subscribes so RID chips populate from the backfilled source.
- Voice composer also dispatches in-call `OpEncryptionSync` via the existing `KindCallEncryption` infrastructure (Phase 1 LDU2 parity) — ALGID/KID flow onto the active call as the EncryptionSync PDU arrives.
- Diagnostic safety net: one Info log line per `(opcode, MFID)` per call — `composer: p25p2 mac pdu …` — so if MMR emits a vendor opcode we still don't dispatch, the next field test pinpoints exactly what we saw.
- Pre-existing mis-named `OpGroupVoiceChannelUserExt = 0x46` renamed to `OpUnitToUnitGrantUpdateAbbreviated` (name-only; constant had no parser).

## Test plan

- [x] `go test ./internal/radio/p25/phase2/...` — three new `AsGroupVoiceChannelUser` round-trip tests + existing CC + alias tests stay green.
- [x] `go test ./internal/trunking/...` — two new `handleCallSourceUpdate` tests (backfill + unknown-device-no-panic) + existing engine tests stay green.
- [x] `go test ./internal/voice/composer/...` — new `TestComposerP25Phase2InCallMetadataFires` drives all three MAC PDU transports through modulated H-DQPSK IQ end-to-end; asserts `KindCallSourceUpdate` + `KindCallEncryption` + `KindTalkerAlias` all fire with the right payload values. Existing #403 alias test stays green.
- [x] Full `go test ./...` + `go vet ./...` clean.
- [ ] Field re-test on MMR by @er-imagery — primary verifier:
  - Phase 2 grants on encrypted TGs should flip to `enc=true` (look for `call source update device=… src=… enc=true`).
  - Source ID populates (`src=315203` instead of `src=0`).
  - ALGID + KID populate via existing `KindCallEncryption` flow.
  - `composer: p25p2 talker alias system=… src=… alias=…` fires; `talker_alias` populates on `/rids` panel.
  - If still blank: the `composer: p25p2 mac pdu opcode=…` log line pinpoints what MMR actually emits for the next slice.

## Out of scope (deliberately)

- RTL-SDR USB bus-bouncing on open (separate triage — likely #382/#393/#395 over-firing).
- Full Phase 2 opcode enum realignment to TIA-102. Only the constants directly relevant to the reported symptoms (0x01, 0x21, 0x46 name) are touched — opcodes 0x02, 0x03, 0x05, 0x06 keep their existing (likely-misnamed) constants since they're never emitted in fixture-driven test paths.
- Holding grant publish until NSB-Update seed is known (deferred until the diagnostic log confirms whether MMR hits this failure mode).

https://claude.ai/code/session_011Ar859fjM1XMxv96MBogPo

---
_Generated by [Claude Code](https://claude.ai/code/session_011Ar859fjM1XMxv96MBogPo)_