### PR TITLE
docs: rescue v0.1.9 and v0.2.3 announcement drafts before branch cleanup

### DIFF
--- a/docs/announcements/v0.1.9.md
+++ b/docs/announcements/v0.1.9.md
@@ -1,0 +1,86 @@
+# GopherTrunk v0.1.9 — social announcement drafts
+
+Copy-paste drafts for posting the v0.1.9 release. Two versions below: a
+longer one for Reddit and a tighter one for Discord.
+
+Release: https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.1.9
+
+---
+
+## Reddit
+
+**Title:** GopherTrunk v0.1.9 — call streaming to Broadcastify/RdioScanner, IQ recording & replay, analog trunking voice
+
+**Body:**
+
+**GopherTrunk v0.1.9 is out.** GopherTrunk is a pure-Go digital-trunking
+radio scanner for RTL-SDR — P25 (Phase 1 + 2), DMR, NXDN, Motorola Type II,
+EDACS, LTR, MPT 1327, and more. No CGO, no `librtlsdr`/`libusb` at build or
+runtime, single ~10 MB static binary for Linux, macOS, and Windows, with a
+headless daemon, a TUI cockpit, and a browser web console.
+
+This release closes a big chunk of the gap with SDRtrunk. What's new since
+v0.1.8:
+
+- **Outbound call streaming.** Completed calls are encoded to MP3 (with a
+  pure-Go encoder — still zero CGO) and streamed out to **Broadcastify
+  Calls, RdioScanner, OpenMHz, and live Icecast/ShoutCast**. Per-feed
+  system filters; a talkgroup can opt out with `stream: false`.
+- **Wideband IQ recording + offline replay.** Tee a live tuner's IQ stream
+  to a baseband WAV, then mount that capture — or one of SDRtrunk's — back
+  as a virtual tuner and decode it with no radio attached.
+- **Analog trunking voice.** Motorola Type II / SmartZone, EDACS, LTR, and
+  MPT 1327 calls now decode to audio through the FM voice chain.
+- **GPS / location subsystem.** Subscriber-unit GPS fixes are decoded off
+  the air, logged, and served over the API for map display (strict
+  NMEA-0183 parser).
+- **Protocol-agnostic affiliation tracker.** A live "which radio unit is on
+  which talkgroup" table that works uniformly across P25, DMR (all tiers),
+  and NXDN. Served at `GET /api/v1/affiliations`.
+- **DMR vendor-trunking recognition.** FID-aware CSBK dispatch — Motorola
+  Capacity Plus / Capacity Max voice grants now decode correctly instead of
+  emitting bogus grants from opcode collisions.
+- **Per-talkgroup controls.** Mute, icon assignment, and per-talkgroup
+  record / stream opt-outs (CSV column, JSON field, or PATCH endpoint).
+- **Decoded-message log.** An SDRtrunk-style timestamped text log of every
+  trunking event — grants, control-channel lock/loss, affiliations,
+  registrations, patches, talker aliases, decode errors.
+- **P25 control-channel fixes (#275).** The C4FM path now uses the spec
+  C4FM filter (instead of root-raised-cosine) and strips interleaved status
+  symbols on the control channel — better lock on live RTL-SDR hardware.
+
+Downloads (Linux/macOS/Windows, x64 + ARM64): https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.1.9
+
+Project & docs: https://gophertrunk.org
+
+Heads-up: the v0.1.x line is still prereleases — actively developed, and
+feedback / captures / bug reports are very welcome.
+
+---
+
+## Discord
+
+Discord renders Markdown — headers (`#`/`##`/`###`), `**bold**`, `- `
+bullets, and `-#` subtext. Paste the block below as-is.
+
+```md
+## GopherTrunk v0.1.9 is out
+
+Pure-Go digital-trunking scanner for RTL-SDR — P25/DMR/NXDN/analog trunked, single static binary, zero CGO.
+
+### What's new since v0.1.8
+
+- **Call streaming** — calls now stream to Broadcastify Calls, RdioScanner, OpenMHz, and Icecast/ShoutCast (pure-Go MP3, still no CGO)
+- **IQ recording + replay** — record baseband to WAV, replay captures as virtual tuners with no radio attached
+- **Analog trunking voice** — Motorola Type II/SmartZone, EDACS, LTR, MPT 1327 now decode to audio
+- **GPS / location** — subscriber GPS fixes decoded, logged, and served for map display
+- **Affiliation tracker** — live unit-to-talkgroup table across P25/DMR/NXDN
+- **DMR vendor trunking** — Motorola Capacity Plus / Capacity Max grants decode correctly
+- **Per-talkgroup controls** — mute, icon, record, and stream opt-outs
+- **Decoded-message log** — SDRtrunk-style event log
+- **P25 #275 fixes** — spec C4FM filter + control-channel status-symbol stripping for better live lock
+
+**Download:** <https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.1.9>
+**Docs:** <https://gophertrunk.org>
+-# v0.1.x is a prerelease line — actively developed, feedback welcome.
+```

--- a/docs/announcements/v0.2.3.md
+++ b/docs/announcements/v0.2.3.md
@@ -1,0 +1,192 @@
+# GopherTrunk v0.2.3 — social announcement drafts
+
+Copy-paste drafts for posting the v0.2.3 release. Two versions below: a
+longer one for Reddit and a tighter one for Discord.
+
+Release: https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.2.3
+
+---
+
+## Reddit
+
+**Title:** GopherTrunk v0.2.3 — POCSAG paging, remote rtl_tcp, one dongle covers many DMR repeaters, Hamlib rigctld, new web viz panels
+
+**Body:**
+
+**GopherTrunk v0.2.3 is out.** GopherTrunk is a pure-Go digital-trunking
+radio scanner for RTL-SDR / HackRF / Airspy / Airspy HF+ — P25 (Phase 1 +
+2), DMR (with AMBE+2 voice), NXDN, Motorola Type II, EDACS, LTR, MPT 1327,
+dPMR, D-STAR, YSF. No CGO, no `librtlsdr` / `libhackrf` / `libairspy` /
+`libusb` at build or runtime, single ~10 MB static binary for Linux, macOS,
+and Windows, with a headless daemon, a Bubbletea TUI cockpit, and a
+browser-based web operator console.
+
+This is a big one. v0.2.2 was the operational-recovery release; v0.2.3 is
+the **scope-expansion** release. New mode (POCSAG paging), new dongle
+topology (one wideband SDR covers a whole repeater cluster, plus remote
+`rtl_tcp` sources mounted as virtual tuners), new amateur-radio integration
+(Hamlib `rigctld` TCP server), and four new web panels that turn the
+console from "trunking dashboard" into a full SDR observation surface.
+
+What's new since v0.2.2:
+
+- **POCSAG paging decoder.** New protocol end-to-end: BCH(31,21) FEC
+  (corrects up to 2 bit errors per codeword), sync-codeword locker with
+  polarity-inverse fallback, batch carve-up, full-RIC reconstruction from
+  the 18-bit address-codeword field + slot index, and both message
+  encodings (CCIR 584 extended BCD numeric + 7-bit LSB-first ASCII
+  alphanumeric). Pages publish on a new `events.KindPagerMessage` bus
+  event, persist to a `pager_log` SQLite table, are queryable via `GET
+  /api/v1/pager/messages?limit=N`, and render live in a new `/pagers` web
+  panel (received time, RIC, function code, encoding, body, bit-error
+  count). DSP wiring (FM demod → bit slicer → `Syncer.Push`) lands next.
+- **`role: wideband` SDR devices — one dongle, many DMR Tier II
+  repeaters and DMR Tier III control channels.** A single SDR pinned to
+  a centre frequency now decodes every conventional DMR repeater AND a
+  DMR Tier III control channel inside its IQ bandwidth (e.g. several
+  12.5 kHz carriers within a 2.4 MHz IQ window around 453 MHz), no extra
+  hardware needed. Add a `role: wideband` entry to `sdr.devices` with a
+  `center_freq_hz` and a `channels: [...]` list binding each frequency
+  to a `trunking.systems` entry; T2 and T3 can mix on the same dongle.
+  Fans the IQ out via the new `internal/dsp/tuner` package (DDC-per-
+  channel or shared polyphase channelizer, picked by channel count).
+- **Remote `rtl_tcp` SDRs.** A new `rtltcp` driver mounts any number of
+  remote `rtl_tcp` servers as virtual tuners alongside locally-attached
+  USB dongles. Speaks the well-known librtlsdr wire protocol (12-byte
+  `RTL0` header, u8 IQ stream, 5-byte command packets) used by SDR++,
+  Gqrx, and OpenWebRX, so any host running `rtl_tcp` can publish its
+  dongle to the daemon. Pool roles, broker fan-out, baseband recording,
+  and the live spectrum panel all work against remote sources just like
+  local ones. Plaintext on the wire — restrict to trusted networks or
+  wrap with SSH/WireGuard/Tailscale.
+- **Hamlib `rigctld` TCP server.** Opt-in (`api.rigctld:
+  "127.0.0.1:4532"`) endpoint speaking the standard rigctld wire
+  protocol so external amateur-radio tooling (Cloudlog, GridTracker,
+  PSTRotator, satellite trackers, `rigctl(1)`) can read and set the
+  control SDR's frequency without learning the GopherTrunk REST API.
+  Implements the ~10 commands real clients send; unknown commands
+  return `RPRT -1` per Hamlib's convention. RX-only — `set_ptt 1` is
+  rejected. Tuning routes through the iqtap broker so external retunes
+  stay coherent with the spectrum panel's frequency axis.
+- **Bookmarks / frequency manager.** UI-managed conventional channel
+  list (marine VHF, NOAA weather, FRS/GMRS, repeater outputs, public-
+  safety conventional fall-backs) backed by a `bookmarks` SQLite table.
+  Each row carries name, frequency, mode, optional CTCSS / DCS,
+  freeform notes, and an operator-defined group tag. REST endpoints
+  under `/api/v1/bookmarks`; web panel at `/bookmarks`. Mutations
+  publish `bookmark.{created,updated,deleted}` events so subscribers
+  refresh without polling.
+- **Live spectrum panel with click-to-tune + bookmark markers.** New
+  FFT producer feeds a `/spectrum` web panel rendering a real-time
+  waterfall over the SDR's IQ bandwidth. Clicking anywhere on the
+  canvas posts the bin's centre frequency to `POST
+  /api/v1/spectrum/devices/{serial}/tune` and the SDR retunes
+  immediately. Bookmarks render as small cyan ticks across the top of
+  the waterfall wherever a bookmark frequency falls inside the visible
+  band. Tune goes through the iqtap broker so the frequency stays
+  coherent across the spectrum, constellation, rigctld, and CC decoder
+  views, and survives `pool.Reacquire`.
+- **Constellation viewer.** New web panel at `/constellation` that
+  renders a live 2D scatter of decimated IQ samples (2 ksps default).
+  Brighter dots = newer samples; reference rings at |z|=0.5 and
+  |z|=1.0; per-frame dBFS energy banner. Identifies signal shape
+  visually — PSK clusters, FSK arcs, AM rotation, noise circles, DC
+  bias, frequency-offset spirals — without launching a separate SDR
+  receiver alongside GopherTrunk.
+- **CC Activity panel.** New web panel at `/cc` that filters the
+  events stream down to control-channel chatter: voice grants,
+  affiliations, registrations, patches / dynamic regroups, talker
+  aliases, CC lock / loss, call start/end. Kind + system substring
+  filters narrow the view; pause freezes the display without
+  disconnecting the bus.
+- **IQ tap broker — multi-consumer SDR fan-out.** New broker package
+  lets multiple consumers (decoder + spectrum + constellation +
+  rigctld) share the same SDR's IQ stream without disturbing decode.
+  The foundation under all four of the new web panels and the wideband
+  multi-channel work.
+- **`gophertrunk sdr doctor` — per-dongle driver-binding report.**
+  Many Windows 11 users reported RTL-SDRs not being recognized despite
+  appearing in Device Manager. Windows has no equivalent of
+  `USBDEVFS_DISCONNECT` (you can't programmatically rebind a USB
+  function driver), so the fix is diagnostic rather than mechanical: a
+  new `sdr doctor` subcommand walks the OS USB tree, reads the bound
+  function driver via SetupAPI on Windows or the interface-0 sysfs
+  symlink on Linux, and prints a row per dongle with an actionable
+  next step (run Zadig; pick Interface 0 not the composite parent;
+  re-target WinUSB instead of libusbK; blacklist `dvb_usb_rtl28xxu`).
+  Read-only — safe to run as a regular user alongside a live daemon.
+- **Voice-call watchdog now gates on decoder progress (#356).** Voice
+  chains used to keep a call alive forever via an unconditional 1 s
+  heartbeat. The four chains (P25 Phase 1, P25 Phase 2, DMR, NBFM) now
+  gate `Engine.Touch` on actual decoder progress — an LDU /
+  superframe / voice subframe / PCM batch — so the 30 s inactivity
+  watchdog can fire and release the bound voice SDR when transmission
+  stops. Before this fix a stalled decoder (simulcast garbage, vocoder
+  hang) refreshed `LastHeardAt` every tick regardless, leaving the
+  active call permanently locked on a single talkgroup and every
+  subsequent grant logging "no voice device available for grant".
+- **Airspy R2 Windows open path fixed (#270).** Defer `SET_SAMPLE_TYPE`
+  from `Open()` to `StreamIQ()`, matching libairspy's open ordering
+  (`GET_SAMPLERATES` IN first, no vendor OUT during open). Airspy R2
+  was failing to open on Windows with `winusb: WinUsb_ControlTransfer
+  OUT: usb: device disconnected` even though `sdr list` detected the
+  device. The Windows USB backend also stops folding
+  `ERROR_GEN_FAILURE` into `ErrDeviceGone` — that conflation printed
+  "usb: device disconnected" for what is actually a firmware NAK /
+  stalled pipe / wrong-driver-bound condition.
+
+Downloads (Linux / macOS / Windows, x64 + ARM64): https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.2.3
+
+Project & docs: https://gophertrunk.org
+
+Heads-up: the v0.x line is still flagged prerelease — actively developed,
+and feedback / captures / bug reports are very welcome.
+
+---
+
+## Discord
+
+**GopherTrunk v0.2.3 is out**
+
+Pure-Go digital-trunking scanner for RTL-SDR / HackRF / Airspy — P25, DMR,
+NXDN, analog trunked, single static binary, zero CGO.
+
+Scope-expansion release: new mode, new dongle topologies, new viz panels.
+
+What's new since v0.2.2:
+- **POCSAG paging decoder** — BCH(31,21) FEC, full-RIC reconstruction,
+  numeric + alphanumeric messages, SQLite log, `/pagers` web panel.
+- **`role: wideband` SDR** — one dongle covers many DMR Tier II repeaters
+  AND a Tier III control channel inside its IQ bandwidth. T2 and T3 mix
+  on the same dongle; channelization via DDC-per-channel or shared
+  polyphase channelizer.
+- **Remote `rtl_tcp` SDRs** — mount any number of `rtl_tcp` servers as
+  virtual tuners alongside local USB dongles; speaks the librtlsdr wire
+  protocol used by SDR++, Gqrx, OpenWebRX.
+- **Hamlib `rigctld` TCP server** — Cloudlog / GridTracker / PSTRotator /
+  satellite trackers / `rigctl(1)` can drive the control SDR over the
+  standard amateur-radio control protocol. RX-only.
+- **Bookmarks / frequency manager** — UI-managed conventional channel
+  list backed by SQLite. Marine VHF, NOAA, FRS/GMRS, repeaters; CTCSS /
+  DCS / mode / group tags; live bus events on mutation.
+- **Live spectrum panel** — real-time waterfall over the SDR's IQ
+  bandwidth. Click-to-tune posts the bin frequency to a new tune
+  endpoint; bookmark frequencies render as cyan ticks.
+- **Constellation viewer** — live 2D IQ scatter at `/constellation`,
+  identifies signal shape visually (PSK clusters, FSK arcs, noise
+  circles, frequency offsets).
+- **CC Activity panel** — filtered events stream at `/cc` for
+  control-channel chatter only (grants, affiliations, patches, talker
+  aliases).
+- **IQ tap broker** — multi-consumer SDR fan-out so the decoder,
+  spectrum, constellation, and rigctld can share one dongle's IQ.
+- **`gophertrunk sdr doctor`** — Windows / Linux per-dongle driver-
+  binding report with actionable next steps.
+- **Voice-call watchdog gates on decoder progress (#356)** — stalled
+  decoders can no longer keep a call alive forever; the 30 s inactivity
+  watchdog actually fires now.
+- **Airspy R2 Windows open path fixed (#270)** — defer SET_SAMPLE_TYPE
+  to StreamIQ, matching libairspy's open ordering.
+
+Download: <https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.2.3>
+Docs: <https://gophertrunk.org>


### PR DESCRIPTION
## Summary

Branch-cleanup review found two stale Claude branches with unique social-announcement drafts that never landed on main:

- `claude/release-notes-social-kdR8N` → `docs/announcements/v0.1.9.md` (Reddit + Discord drafts for v0.1.9)
- `claude/release-docs-github-pages-MwMqz` → `docs/announcements/v0.2.3.md` (Reddit + Discord drafts for v0.2.3, superseded on main by PR #394's combined v0.2.4 announcement)

This PR ports just the two announcement files so those branches can be deleted without losing the drafts. No other code changes.

## Branches that can be deleted after this lands

| Branch | Why safe |
|---|---|
| `claude/gophertrunk-sdrtrunk-parity-pt3` | PR #328 merged |
| `claude/plan-issue-275-fix-4KrDu` | PRs #299, #307, #311, #318, #320 all merged |
| `claude/gophertrunk-aprs-protocol` | Equivalent work merged via PR #390; PR #381 should be closed first |
| `claude/release-docs-github-pages-MwMqz` | v0.2.3 draft preserved here |
| `claude/release-notes-social-kdR8N` | v0.1.9 draft preserved here |

## Test plan

- [x] Files copied verbatim from the source branches — no edits
- [x] `docs/announcements/` already contains `v0.2.2.md` and `v0.2.4.md`; adding v0.1.9 and v0.2.3 follows the same convention

https://claude.ai/code/session_016ziSFtKkftqrbqQKd1j1VY

---
_Generated by [Claude Code](https://claude.ai/code/session_016ziSFtKkftqrbqQKd1j1VY)_