### PR TITLE
p25/phase1: route TDMA-channel grants to Phase 2 voice chain

### DIFF
--- a/internal/radio/p25/phase1/control.go
+++ b/internal/radio/p25/phase1/control.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
 	"github.com/MattCheramie/GopherTrunk/internal/trunking"
 )
 
@@ -100,6 +101,19 @@ type ControlChannel struct {
 	// voice receiver and never decode (issue #356 follow-up). Empty
 	// string preserves the C4FM default in the voice chain.
 	p25Phase1DemodMode string
+
+	// p25Phase2Trellis / p25Phase2RS / p25Phase2Interleave /
+	// p25Phase2Scrambler carry the operator-configured Phase 2 FEC
+	// modes the CC stamps onto any grant whose channel ID was
+	// advertised as TDMA via opcode 0x33. Without this, a Phase 1 CC
+	// could not give the voice composer enough information to run
+	// the Phase 2 MAC dispatch path on the traffic channel, so
+	// MMR-class hybrid sites silently lost in-call source ID +
+	// alias + encryption-sync metadata (issue #376).
+	p25Phase2Trellis    uint8
+	p25Phase2RS         uint8
+	p25Phase2Interleave uint8
+	p25Phase2Scrambler  uint8
 
 	// stats is the per-frame outcome counter exposed via Stats().
 	// Atomic so the daemon's API / diagnostic goroutines can read it
@@ -205,6 +219,26 @@ type Options struct {
 	// preserves the C4FM default in the voice chain — and is what the
 	// existing replay / unit tests pass.
 	P25Phase1DemodMode string
+
+	// P25Phase2Trellis / P25Phase2RS / P25Phase2Interleave /
+	// P25Phase2Scrambler hold the per-system FEC mode the voice
+	// composer's Phase 2 chain needs to decode MAC PDUs that
+	// interleave with H-DQPSK voice on a Phase 2 TDMA traffic
+	// channel. Encoded as the uint8 values
+	// trunking.P25Phase2Decode round-trips (numerically aligned to
+	// the phase2 enum constants of the same name). The ccdecoder
+	// pipeline parses the matching YAML keys via phase2.Parse*Mode
+	// and passes the result through; left zero means
+	// Trellis=off/RS=off/Interleave=off/Scrambler=off, which matches
+	// the phase2 ccdecoder's empty-YAML default for symmetry. Issue
+	// #376: needed so a Phase 1 CC can publish grants that target
+	// Phase 2 TDMA carriers (MMR-class systems) with FEC config the
+	// voice composer can use to decode in-call source ID + alias +
+	// encryption-sync PDUs.
+	P25Phase2Trellis    uint8
+	P25Phase2RS         uint8
+	P25Phase2Interleave uint8
+	P25Phase2Scrambler  uint8
 }
 
 // New constructs a ControlChannel from Options. SystemName ends up on
@@ -232,17 +266,21 @@ func New(opts Options) *ControlChannel {
 		span = NIDSearchSpan
 	}
 	return &ControlChannel{
-		bus:                opts.Bus,
-		log:                log,
-		det:                det,
-		systemName:         opts.SystemName,
-		freqHz:             opts.FrequencyHz,
-		bandPlan:           bp,
-		now:                now,
-		aliasAsm:           NewTalkerAliasAssembler(now),
-		rotations:          resolveRotations(opts.Rotations),
-		nidSearchSpan:      span,
-		p25Phase1DemodMode: opts.P25Phase1DemodMode,
+		bus:                 opts.Bus,
+		log:                 log,
+		det:                 det,
+		systemName:          opts.SystemName,
+		freqHz:              opts.FrequencyHz,
+		bandPlan:            bp,
+		now:                 now,
+		aliasAsm:            NewTalkerAliasAssembler(now),
+		rotations:           resolveRotations(opts.Rotations),
+		nidSearchSpan:       span,
+		p25Phase1DemodMode:  opts.P25Phase1DemodMode,
+		p25Phase2Trellis:    opts.P25Phase2Trellis,
+		p25Phase2RS:         opts.P25Phase2RS,
+		p25Phase2Interleave: opts.P25Phase2Interleave,
+		p25Phase2Scrambler:  opts.P25Phase2Scrambler,
 	}
 }
 
@@ -976,11 +1014,33 @@ func (c *ControlChannel) publishVoiceGrant(g voiceGrant, nac uint16) {
 		return
 	}
 	so := ServiceOptions(g.serviceOptions)
+	// Hybrid Phase 1 CC + Phase 2 TC sites (issue #376, MMR): when the
+	// granted channel ID was advertised as TDMA via opcode 0x33, route
+	// the grant to the voice composer's Phase 2 chain so it can decode
+	// the MAC PDUs that interleave with H-DQPSK voice on the traffic
+	// channel — source-ID + encryption-sync + talker-alias backfill.
+	// Without this, every grant landed in the Phase 1 voice chain and
+	// the Phase 2 MAC dispatch path PR #409 added was dead code on
+	// MMR-class systems.
+	protocol := "p25"
+	var p2dec trunking.P25Phase2Decode
+	if c.bandPlan.IsTDMA(g.channelID) {
+		protocol = "p25-phase2"
+		net := c.netModel.Snapshot()
+		seed := framing.PN44SeedFromIdentity(net.WACN, net.SystemID, nac&0x0FFF)
+		p2dec = trunking.P25Phase2Decode{
+			Trellis:    c.p25Phase2Trellis,
+			RS:         c.p25Phase2RS,
+			Interleave: c.p25Phase2Interleave,
+			Scrambler:  c.p25Phase2Scrambler,
+			Seed:       seed,
+		}
+	}
 	c.bus.Publish(events.Event{
 		Kind: events.KindGrant,
 		Payload: trunking.Grant{
 			System:             c.systemName,
-			Protocol:           "p25",
+			Protocol:           protocol,
 			GroupID:            g.groupID,
 			SourceID:           g.sourceID,
 			FrequencyHz:        freq,
@@ -990,11 +1050,12 @@ func (c *ControlChannel) publishVoiceGrant(g voiceGrant, nac uint16) {
 			Emergency:          so.Emergency(),
 			DataCall:           g.dataCall,
 			P25Phase1DemodMode: c.p25Phase1DemodMode,
+			P25Phase2Decode:    p2dec,
 			At:                 c.now(),
 		},
 	})
 	c.log.Debug("p25: grant",
-		"system", c.systemName, "nac", nac,
+		"system", c.systemName, "nac", nac, "protocol", protocol,
 		"tg", g.groupID, "src", g.sourceID,
 		"id", g.channelID, "num", g.channelNumber, "freq_hz", freq,
 		"enc", so.Encrypted(), "emer", so.Emergency(), "data", g.dataCall)

--- a/internal/radio/p25/phase1/control_test.go
+++ b/internal/radio/p25/phase1/control_test.go
@@ -326,6 +326,79 @@ func TestControlChannelAppliesVUHFIdentifierUpdateAndPublishesGrant(t *testing.T
 	}
 }
 
+// TestControlChannelRoutesTDMAChannelGrantAsPhase2 confirms the fix
+// for issue #376: when the Phase 1 CC has accepted an IdentifierUpdate
+// for a Phase 2 TDMA channel (opcode 0x33), a subsequent voice grant
+// on that channel ID must publish with Protocol="p25-phase2" + a
+// populated P25Phase2Decode so the voice composer routes the call
+// into the Phase 2 MAC dispatch path. Before this fix, all Phase 1 CC
+// grants — including TDMA ones — published Protocol="p25", the
+// composer never entered runP25Phase2VoiceChain, and PR #409's MAC
+// PDU dispatch was dead code on MMR-class hybrid systems.
+func TestControlChannelRoutesTDMAChannelGrantAsPhase2(t *testing.T) {
+	bus := events.NewBus(16)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	identTSBK := TSBK{LB: false, Opcode: OpIdentifierUpdateTDMA}
+	identTSBK.Payload = AssembleIdentifierUpdateTDMA(IdentifierUpdate{
+		ChannelID:   1,
+		BandwidthHz: 12_500,
+		SpacingHz:   12_500,
+		BaseHz:      851_000_000,
+	})
+
+	grantPayload := [8]byte{
+		0xC0,                  // service options: emergency + encrypted
+		(1 << 4) | 0x00, 0x10, // channel = ID 1, number 0x010 (=16)
+		0x12, 0x34,
+		0xAB, 0xCD, 0xEF,
+	}
+	grantTSBK := TSBK{LB: true, Opcode: OpGroupVoiceChannelGrant, Payload: grantPayload}
+
+	stream1 := buildLockedStreamWithTSBK(10, 0x293, DUIDTrunkingSignaling, identTSBK)
+	stream2 := buildLockedStreamWithTSBK(0, 0x293, DUIDTrunkingSignaling, grantTSBK)
+
+	cc := New(Options{
+		Bus:                bus,
+		SystemName:         "MMR",
+		FrequencyHz:        851_000_000,
+		P25Phase2Trellis:   1, // TrellisOn
+		P25Phase2Scrambler: 1, // ScramblerOn
+		Now:                func() time.Time { return time.Unix(1_700_000_000, 0).UTC() },
+	})
+	cc.Process(stream1, 0)
+	cc.Process(stream2, len(stream1))
+
+	var got *trunking.Grant
+	deadline := time.After(time.Second)
+	for got == nil {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind == events.KindGrant {
+				g := ev.Payload.(trunking.Grant)
+				got = &g
+			}
+		case <-deadline:
+			t.Fatal("no grant event published")
+		}
+	}
+
+	if got.Protocol != "p25-phase2" {
+		t.Errorf("Protocol = %q, want %q", got.Protocol, "p25-phase2")
+	}
+	if got.P25Phase2Decode.Trellis != 1 {
+		t.Errorf("P25Phase2Decode.Trellis = %d, want 1 (TrellisOn)", got.P25Phase2Decode.Trellis)
+	}
+	if got.P25Phase2Decode.Scrambler != 1 {
+		t.Errorf("P25Phase2Decode.Scrambler = %d, want 1 (ScramblerOn)", got.P25Phase2Decode.Scrambler)
+	}
+	if got.FrequencyHz != 851_200_000 {
+		t.Errorf("FrequencyHz = %d, want 851_200_000", got.FrequencyHz)
+	}
+}
+
 // TestControlChannelLocksAndGrantsAcrossSmallChunks feeds a two-frame
 // stream (IdentifierUpdate then GroupVoiceChannelGrant) through Process
 // in 19-dibit batches — the dibit count a real RTL-SDR's 16 KiB USB

--- a/internal/radio/p25/phase1/identifier.go
+++ b/internal/radio/p25/phase1/identifier.go
@@ -39,6 +39,15 @@ type IdentifierUpdate struct {
 	SpacingHz   uint32 // channel-to-channel step
 	TxOffsetHz  int64  // signed transmit offset (uplink = downlink + offset)
 	BaseHz      uint64 // downlink base frequency for channel 0
+	// AccessTDMA is true when this slot was advertised via opcode 0x33
+	// (OpIdentifierUpdateTDMA) — i.e. the granted voice channels are
+	// P25 Phase 2 H-DQPSK TDMA carriers. The Phase 1 control channel
+	// uses this to route grants on TDMA channels into the Phase 2
+	// voice composer chain (Protocol="p25-phase2") rather than the
+	// Phase 1 FDMA chain. Issue #376: without this, MMR-class systems
+	// (Phase 1 CC + Phase 2 TC) silently lose their Phase 2 MAC PDU
+	// dispatch (talker alias, in-call src/enc backfill).
+	AccessTDMA bool
 }
 
 // ParseIdentifierUpdate decodes the 8-byte payload of opcode 0x3D
@@ -201,6 +210,7 @@ func ParseIdentifierUpdateTDMA(p [8]byte) IdentifierUpdate {
 		SpacingHz:   spacingHz,
 		TxOffsetHz:  txOffsetHz,
 		BaseHz:      uint64(freq5Hz) * 5,
+		AccessTDMA:  true,
 	}
 }
 
@@ -380,4 +390,16 @@ func (b *BandPlan) Known(channelID uint8) bool {
 		return false
 	}
 	return b.known[channelID]
+}
+
+// IsTDMA reports whether the channel ID was advertised via opcode 0x33
+// (OpIdentifierUpdateTDMA). Returns false for unknown channel IDs and
+// for FDMA channels. The Phase 1 control channel queries this at grant
+// publish time so voice grants targeting Phase 2 TDMA carriers get
+// routed to the composer's Phase 2 MAC dispatch path.
+func (b *BandPlan) IsTDMA(channelID uint8) bool {
+	if int(channelID) >= len(b.known) || !b.known[channelID] {
+		return false
+	}
+	return b.slots[channelID].AccessTDMA
 }

--- a/internal/radio/p25/phase1/identifier_test.go
+++ b/internal/radio/p25/phase1/identifier_test.go
@@ -81,6 +81,7 @@ func TestIdentifierUpdateTDMARoundTripMtAnakieID10(t *testing.T) {
 		SpacingHz:   6_250,
 		TxOffsetHz:  -10_000_000,
 		BaseHz:      467_512_500,
+		AccessTDMA:  true,
 	}
 	out := ParseIdentifierUpdateTDMA(AssembleIdentifierUpdateTDMA(in))
 	if out != in {
@@ -97,6 +98,7 @@ func TestIdentifierUpdateTDMARoundTripPositiveOffset(t *testing.T) {
 		SpacingHz:   12_500,
 		TxOffsetHz:  5_000_000,
 		BaseHz:      420_000_000,
+		AccessTDMA:  true,
 	}
 	out := ParseIdentifierUpdateTDMA(AssembleIdentifierUpdateTDMA(in))
 	if out != in {
@@ -198,5 +200,62 @@ func TestBandPlanRejectsOverflow(t *testing.T) {
 	bp.Apply(IdentifierUpdate{ChannelID: 0, SpacingHz: 1_000_000, BaseHz: 4_000_000_000})
 	if _, err := bp.Frequency(0, 1000); err == nil {
 		t.Error("expected overflow error for >4.29 GHz resolved frequency")
+	}
+}
+
+// TestParseIdentifierUpdateTDMASetsAccessFlag confirms the TDMA
+// variant flips AccessTDMA so the Phase 1 control channel can route
+// grants on the channel ID into the Phase 2 voice chain (issue #376).
+// FDMA variants (the 0x3D and 0x34 forms) must leave it false.
+func TestParseIdentifierUpdateTDMASetsAccessFlag(t *testing.T) {
+	tdma := AssembleIdentifierUpdateTDMA(IdentifierUpdate{
+		ChannelID:   3,
+		BandwidthHz: 12500,
+		SpacingHz:   12_500,
+		BaseHz:      851_000_000,
+	})
+	if u := ParseIdentifierUpdateTDMA(tdma); !u.AccessTDMA {
+		t.Errorf("TDMA: AccessTDMA = false, want true")
+	}
+
+	fdma := AssembleIdentifierUpdate(IdentifierUpdate{
+		ChannelID: 4, SpacingHz: 12_500, BaseHz: 851_000_000,
+	})
+	if u := ParseIdentifierUpdate(fdma); u.AccessTDMA {
+		t.Errorf("FDMA 0x3D: AccessTDMA = true, want false")
+	}
+
+	vuhf := AssembleIdentifierUpdateVUHF(IdentifierUpdate{
+		ChannelID: 5, SpacingHz: 6_250, BaseHz: 460_000_000,
+	})
+	if u := ParseIdentifierUpdateVUHF(vuhf); u.AccessTDMA {
+		t.Errorf("VUHF 0x34: AccessTDMA = true, want false")
+	}
+}
+
+// TestBandPlanIsTDMA round-trips a TDMA IdentifierUpdate through Apply
+// and confirms IsTDMA reports true only for channel IDs advertised via
+// opcode 0x33. Unknown IDs return false (no false positives), and FDMA
+// slots return false even when they are Known.
+func TestBandPlanIsTDMA(t *testing.T) {
+	bp := &BandPlan{}
+	bp.Apply(IdentifierUpdate{
+		ChannelID: 1, SpacingHz: 12_500, BaseHz: 851_000_000, AccessTDMA: true,
+	})
+	bp.Apply(IdentifierUpdate{
+		ChannelID: 2, SpacingHz: 12_500, BaseHz: 851_500_000, // AccessTDMA defaults to false
+	})
+
+	if !bp.IsTDMA(1) {
+		t.Error("IsTDMA(1) = false, want true (TDMA slot)")
+	}
+	if bp.IsTDMA(2) {
+		t.Error("IsTDMA(2) = true, want false (FDMA slot)")
+	}
+	if bp.IsTDMA(7) {
+		t.Error("IsTDMA(7) = true on unknown ID, want false")
+	}
+	if bp.IsTDMA(99) {
+		t.Error("IsTDMA(99) = true on out-of-range ID, want false")
 	}
 }

--- a/internal/scanner/ccdecoder/pipelines.go
+++ b/internal/scanner/ccdecoder/pipelines.go
@@ -181,14 +181,46 @@ func newP25Phase1Pipeline(opts PipelineOptions) (ProtocolPipeline, error) {
 				"spacing_hz", e.SpacingHz, "tx_offset_hz", e.TxOffsetHz)
 		}
 	}
+	// Parse the same Phase 2 FEC YAML knobs newP25Phase2Pipeline reads
+	// (below), so a hybrid Phase 1 CC + Phase 2 TC system (issue #376,
+	// MMR) can stamp its TDMA grants with the FEC config the voice
+	// composer's Phase 2 chain needs. Unrecognised values produce the
+	// same warn-then-fallback behaviour as the Phase 2 pipeline; an
+	// empty per-system value retains the same default (Trellis=on,
+	// everything else=off). Operators with Protocol="p25" override per
+	// system via the existing p25_phase2_*_mode YAML keys.
+	p2Trellis, p2TrellisOK := p25phase2.ParseTrellisMode(opts.System.P25Phase2TrellisMode)
+	if !p2TrellisOK {
+		log.Warn("ccdecoder: unrecognised p25_phase2_trellis_mode; falling back to on",
+			"system", opts.SystemName, "value", opts.System.P25Phase2TrellisMode)
+	}
+	p2RS, p2RSOK := p25phase2.ParseRSMode(opts.System.P25Phase2RSMode)
+	if !p2RSOK {
+		log.Warn("ccdecoder: unrecognised p25_phase2_rs_mode; falling back to off",
+			"system", opts.SystemName, "value", opts.System.P25Phase2RSMode)
+	}
+	p2Interleave, p2IlOK := p25phase2.ParseInterleaveMode(opts.System.P25Phase2InterleaveMode)
+	if !p2IlOK {
+		log.Warn("ccdecoder: unrecognised p25_phase2_interleave_mode; falling back to off",
+			"system", opts.SystemName, "value", opts.System.P25Phase2InterleaveMode)
+	}
+	p2Scrambler, p2ScrOK := p25phase2.ParseScramblerMode(opts.System.P25Phase2ScramblerMode)
+	if !p2ScrOK {
+		log.Warn("ccdecoder: unrecognised p25_phase2_scrambler_mode; falling back to off",
+			"system", opts.SystemName, "value", opts.System.P25Phase2ScramblerMode)
+	}
 	cc := p25phase1.New(p25phase1.Options{
-		Bus:                opts.Bus,
-		Log:                opts.Log,
-		SystemName:         opts.SystemName,
-		FrequencyHz:        opts.FrequencyHz,
-		BandPlan:           bandPlan,
-		Rotations:          rotations,
-		P25Phase1DemodMode: opts.System.P25Phase1DemodMode,
+		Bus:                 opts.Bus,
+		Log:                 opts.Log,
+		SystemName:          opts.SystemName,
+		FrequencyHz:         opts.FrequencyHz,
+		BandPlan:            bandPlan,
+		Rotations:           rotations,
+		P25Phase1DemodMode:  opts.System.P25Phase1DemodMode,
+		P25Phase2Trellis:    uint8(p2Trellis),
+		P25Phase2RS:         uint8(p2RS),
+		P25Phase2Interleave: uint8(p2Interleave),
+		P25Phase2Scrambler:  uint8(p2Scrambler),
 	})
 	rx := p25phase1rx.New(p25phase1rx.Options{
 		SampleRateHz: opts.SampleRateHz,

--- a/internal/voice/composer/p25p2_voice.go
+++ b/internal/voice/composer/p25p2_voice.go
@@ -46,6 +46,23 @@ const p25p2VoiceGardnerGain = 0.005
 func (c *Composer) runP25Phase2VoiceChain(ctx context.Context, serial string, system string, macCfg p25p2.MACDecodeConfig, iqCh <-chan []complex64, iqHz uint32, done chan<- struct{}) {
 	defer close(done)
 
+	// Issue #376 field-diagnostic: the existing "composer: p25p2 mac
+	// pdu" log fires only after a successful FEC decode, so every
+	// failure mode (zero macCfg, ScramblerOff against scrambled
+	// on-air traffic, ISCH FEC corruption) is silent. A single
+	// once-per-call line at chain entry confirms the chain actually
+	// ran and surfaces the exact FEC config the grant carried.
+	c.log.Info("composer: p25p2 voice chain started",
+		"serial", serial, "system", system,
+		"trellis", macCfg.Trellis, "rs", macCfg.RS,
+		"interleave", macCfg.Interleave, "scrambler", macCfg.Scrambler,
+		"seed", macCfg.Seed)
+	if macCfg.Scrambler == p25p2.ScramblerOff || macCfg.Seed == 0 {
+		c.log.Warn("composer: p25p2 macCfg suggests live MAC PDU decode will fail",
+			"serial", serial, "system", system,
+			"scrambler", macCfg.Scrambler, "seed", macCfg.Seed)
+	}
+
 	decim := int(iqHz) / p25p2VoiceIntermediateHz
 	if decim < 1 {
 		decim = 1


### PR DESCRIPTION
Issue #376 / MMR field test: the Phase 1 CC published every voice
grant with Protocol="p25" and an empty P25Phase2Decode, so grants
that pointed at a Phase 2 TDMA traffic channel were silently routed
into the composer's Phase 1 voice chain. PR #409's Phase 2 MAC PDU
dispatch (talker alias, in-call src/enc backfill) was therefore dead
code on hybrid Phase 1 CC + Phase 2 TC deployments — the most common
P25 layout, including MMR.

Make the Phase 1 BandPlan TDMA-aware (new AccessTDMA flag on
IdentifierUpdate, propagated by ParseIdentifierUpdateTDMA; new
BandPlan.IsTDMA accessor) and have publishVoiceGrant publish
Protocol="p25-phase2" with a populated P25Phase2Decode whenever the
granted channel ID was advertised via opcode 0x33. The PN44 seed is
derived at grant time from the NetworkModel's WACN/SystemID + the
NID's NAC (Color Code per TIA-102.BBAC-1 §7.2.5), so operators get
the same auto-seed behaviour the Phase 2 CC's installSeedFromNSB
provides.

The ccdecoder's newP25Phase1Pipeline now parses the same
p25_phase2_{trellis,rs,interleave,scrambler}_mode YAML keys
newP25Phase2Pipeline accepts, so operators with `protocol: p25`
configure the FEC modes per-system the same way Phase 2 CC sites
do.

Field-diagnostic: runP25Phase2VoiceChain logs one Info line at
chain entry with the exact macCfg it received, and a Warn when
Scrambler==Off or Seed==0 — making the failure modes that left
PR #409's `composer: p25p2 mac pdu` line silent in field tests
visible from the first call.

Unit tests cover the new TDMA round-trip flag, BandPlan.IsTDMA,
and the Phase 1 CC publishing Protocol="p25-phase2" +
P25Phase2Decode on a TDMA-channel grant.