### PR TITLE
docs: post-release v0.2.5 — promote CHANGELOG + bump hardcoded refs + social drafts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,41 @@ for tagged releases.
 
 ## [Unreleased]
 
+## [v0.2.5] — 2026-05-28
+
+Issue #376 follow-up (Motorola MMR P25 talker alias) closes end-to-end +
+Phase-5 (APRS) goes live + issue #402 (RTL-SDR DC-spike on P25 control)
+three-phase investigation. The Motorola MMR talker-alias path now lands:
+#397 ports Motorola's vendor LCO 0x15 / 0x17 form for Phase 1 voice
+channels (the standard TIA-102.AABF form #389 implemented doesn't match
+what real MMR systems emit), #403 dispatches MAC PDUs on the Phase 2
+voice chain so MMR Phase 2 talker-alias decodes too, and #409 backfills
+source RID + ALGID / KID encryption from the voice channel by parsing
+`GROUP_VOICE_CHANNEL_USER_ABBREVIATED` (opcode 0x01, previously
+mis-named `OpMACPTT` and silently discarded). APRS reaches end-to-end
+live: #401 adds the HDLC framer + receiver glue, #411 wires the
+Bell-202 AFSK DSP frontend (IQ → FM → real resample → tone
+discriminator → Mueller-Müller timing → NRZI → HDLC → AX.25 + APRS
+info-field → events bus), so configuring `aprs.channels` with a serial
++ frequency lights up the bus, SQLite log, REST endpoint, and `/aprs`
+web panel from #384 / #390. Issue #402 (RTL-SDR DC-spike pulls the
+P25 control-channel offset estimator into the spike) lands in three
+slices: #406 adds CCStats + per-sample recording-power diagnostics,
+#408 mirrors the replay path through the production DDC and adds
+state-evolution diagnostics, and #412 swaps in a decision-directed AFC
+that defeats data-DC integration. Plus: #399 makes the P25 Phase 1
+voice composer honour `trunking.systems[].p25_phase1_demod_mode` so
+simulcast / LSM grants don't silently fail on FM-discriminator
+hardcode; #398 widens the Windows RTL-SDR cold-boot recovery envelope
+to 5 attempts with 200 / 400 / 800 / 1200 ms backoff and 150 ms
+WinUSB settle (issue #395); #400 surfaces two silent-degradation
+paths at startup (no `gain:` configured per SDR, conventional tone
+gating with zero `sdr.sample_rate`); #413 routes Phase 1 TDMA-channel
+grants to the Phase 2 voice chain; #407 promotes Motorola patch
+member talkgroups over the super-group in CC Activity (issue #405);
+and #396 adds a Markdown blog with per-category archives, RSS, and
+SEO meta to the Pages site.
+
 ### Added
 
 - **APRS DSP frontend — pipeline is now end-to-end.** Fifth and

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ this exist? Read **[The Story of GopherTrunk](https://gophertrunk.org/story.html
 
 ```sh
 # Linux x86_64 — see https://gophertrunk.org/downloads.html for macOS, Windows, ARM64.
-VERSION=v0.2.4
+VERSION=v0.2.5
 curl -L -o gophertrunk.tar.gz \
   https://github.com/MattCheramie/GopherTrunk/releases/download/${VERSION}/gophertrunk-${VERSION}-linux-amd64.tar.gz
 tar xzf gophertrunk.tar.gz && cd gophertrunk-${VERSION}-linux-amd64

--- a/docs/announcements/v0.2.5.md
+++ b/docs/announcements/v0.2.5.md
@@ -1,80 +1,46 @@
 # GopherTrunk v0.2.5 — social announcement drafts
 
-Concise copy-paste blurbs for posting the v0.2.5 release. Reddit (with
-reddit-friendly markdown headers + bullets) and Discord (tighter,
-inside the 2000-char limit).
+One-click copy-paste blurbs for posting the v0.2.5 release. Each block
+below is a fenced code block so the rendered-markdown "copy" button
+grabs exactly what you'd paste.
 
 Release: https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.2.5
 
 ---
 
-## Reddit
+## Reddit — title
 
-**Title:** GopherTrunk v0.2.5 — Motorola MMR talker alias + RID + encryption decode, APRS live end-to-end, P25 simulcast voice fix
+```
+GopherTrunk v0.2.5 — Motorola MMR talker alias + RID + encryption decode, APRS live end-to-end, P25 simulcast voice fix
+```
 
-**Body:**
+## Reddit — body
 
-**[GopherTrunk](https://gophertrunk.org) v0.2.5 is out** — pure-Go
-digital-trunking scanner for RTL-SDR / HackRF / Airspy. P25 (Phase 1+2),
-DMR (AMBE+2 voice), NXDN, Motorola Type II, EDACS, LTR, MPT 1327, dPMR,
-D-STAR, YSF, plus APRS and POCSAG paging. No CGO, single static binary
-for Linux / macOS / Windows.
+```markdown
+**[GopherTrunk](https://gophertrunk.org) v0.2.5 is out** — pure-Go digital-trunking scanner for RTL-SDR / HackRF / Airspy. P25 (Phase 1+2), DMR (AMBE+2 voice), NXDN, Motorola Type II, EDACS, LTR, MPT 1327, dPMR, D-STAR, YSF, plus APRS and POCSAG paging. No CGO, single static binary for Linux / macOS / Windows.
 
 **What's new since v0.2.4:**
 
-* **Motorola MMR P25 talker-alias closes end-to-end** (#397, #403, #409,
-  closes #376) — the standard TIA-102 form #389 shipped doesn't match
-  what real Motorola systems emit. New Phase 1 vendor LCO 0x15 / 0x17
-  decoder, Phase 2 MAC-PDU dispatch on the voice chain, and
-  `GROUP_VOICE_CHANNEL_USER_ABBREVIATED` (opcode 0x01, previously
-  mis-named `OpMACPTT` and silently discarded) now backfills source
-  RID + ALGID / KID encryption from the traffic channel for encrypted
-  Phase 2 talkgroups.
-* **APRS is now end-to-end live** (#401, #411) — Bell-202 AFSK DSP
-  frontend + HDLC framer + receiver glue close out the Phase 5
-  pipeline started in v0.2.4. Drop an `aprs.channels` entry
-  (`serial: antenna-pi, frequency_hz: 144_390_000`) and packets land
-  on the bus, the `aprs_log` SQLite table, `/api/v1/aprs/packets`,
-  and the `/aprs` web panel.
-* **P25 simulcast / LSM voice fix** (#399, #356 follow-up) — the
-  Phase 1 voice composer was hardcoded to the C4FM FM-discriminator
-  path regardless of `trunking.systems[].p25_phase1_demod_mode`. On a
-  simulcast site the CC decoded fine but every voice grant landed in
-  an FM-discriminator that couldn't sync on LSM dibits, the LDU sink
-  never fired, and the watchdog reaped the call with an empty WAV.
-  Mode string is now plumbed end-to-end.
-* **RTL-SDR DC-spike on P25 control diagnosis** (#406, #408, #412,
-  issue #402) — three-phase investigation: CCStats + per-sample
-  recording-power diagnostics, replay path mirrored through the
-  production DDC + state-evolution diagnostics, and a
-  decision-directed AFC that defeats data-DC integration so the
-  offset estimator doesn't get pulled into the spike.
-* **Windows RTL-SDR cold-boot: wider recovery envelope** (#398, closes
-  #395) — 5 attempts with 200 / 400 / 800 / 1200 ms exponential
-  backoff and a 150 ms WinUSB settle, for the most stubborn clone
-  dongles that still wedged after v0.2.4's recovery path. Healthy
-  dongles still open on attempt 0 with zero delay.
-* **Silent-degradation warnings at startup** (#400, #356) — fires once
-  per SDR with no `gain:` key, and once per conventional channel with
-  CTCSS / DCS gating configured but `sdr.sample_rate` unset.
-* **Phase 1 TDMA-channel grants → Phase 2 voice chain** (#413) —
-  hybrid Phase 1 CC + Phase 2 voice deployments now route correctly.
-* **CC Activity: patch member TGs over the super-group** (#407, closes
-  #405) — Motorola patch member talkgroups now render first.
-* **Markdown blog on the Pages site** (#396) — per-category archives,
-  RSS, SEO meta.
+* **Motorola MMR P25 talker-alias closes end-to-end** (#397, #403, #409, closes #376) — the standard TIA-102 form #389 shipped doesn't match what real Motorola systems emit. New Phase 1 vendor LCO 0x15 / 0x17 decoder, Phase 2 MAC-PDU dispatch on the voice chain, and `GROUP_VOICE_CHANNEL_USER_ABBREVIATED` (opcode 0x01, previously mis-named `OpMACPTT` and silently discarded) now backfills source RID + ALGID / KID encryption from the traffic channel for encrypted Phase 2 talkgroups.
+* **APRS is now end-to-end live** (#401, #411) — Bell-202 AFSK DSP frontend + HDLC framer + receiver glue close out the Phase 5 pipeline started in v0.2.4. Drop an `aprs.channels` entry (`serial: antenna-pi, frequency_hz: 144_390_000`) and packets land on the bus, the `aprs_log` SQLite table, `/api/v1/aprs/packets`, and the `/aprs` web panel.
+* **P25 simulcast / LSM voice fix** (#399, #356 follow-up) — the Phase 1 voice composer was hardcoded to the C4FM FM-discriminator path regardless of `trunking.systems[].p25_phase1_demod_mode`. On a simulcast site the CC decoded fine but every voice grant landed in an FM-discriminator that couldn't sync on LSM dibits, the LDU sink never fired, and the watchdog reaped the call with an empty WAV. Mode string is now plumbed end-to-end.
+* **RTL-SDR DC-spike on P25 control diagnosis** (#406, #408, #412, issue #402) — three-phase investigation: CCStats + per-sample recording-power diagnostics, replay path mirrored through the production DDC + state-evolution diagnostics, and a decision-directed AFC that defeats data-DC integration so the offset estimator doesn't get pulled into the spike.
+* **Windows RTL-SDR cold-boot: wider recovery envelope** (#398, closes #395) — 5 attempts with 200 / 400 / 800 / 1200 ms exponential backoff and a 150 ms WinUSB settle, for the most stubborn clone dongles that still wedged after v0.2.4's recovery path. Healthy dongles still open on attempt 0 with zero delay.
+* **Silent-degradation warnings at startup** (#400, #356) — fires once per SDR with no `gain:` key, and once per conventional channel with CTCSS / DCS gating configured but `sdr.sample_rate` unset.
+* **Phase 1 TDMA-channel grants → Phase 2 voice chain** (#413) — hybrid Phase 1 CC + Phase 2 voice deployments now route correctly.
+* **CC Activity: patch member TGs over the super-group** (#407, closes #405) — Motorola patch member talkgroups now render first.
+* **Markdown blog on the Pages site** (#396) — per-category archives, RSS, SEO meta.
 
 **Downloads** (Linux / macOS / Windows, x64 + ARM64): https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.2.5
 
 **Docs:** https://gophertrunk.org
 
-Heads-up: the v0.x line is still flagged prerelease — actively
-developed, feedback / captures / bug reports very welcome.
-
----
+Heads-up: the v0.x line is still flagged prerelease — actively developed, feedback / captures / bug reports very welcome.
+```
 
 ## Discord
 
+```markdown
 **GopherTrunk v0.2.5 is out** — pure-Go trunking scanner for RTL-SDR / HackRF / Airspy. P25, DMR, NXDN, analog trunked, APRS, POCSAG. Single static binary, zero CGO.
 
 **What's new since v0.2.4:**
@@ -88,3 +54,4 @@ developed, feedback / captures / bug reports very welcome.
 
 Download: <https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.2.5>
 Docs: <https://gophertrunk.org>
+```

--- a/docs/announcements/v0.2.5.md
+++ b/docs/announcements/v0.2.5.md
@@ -1,0 +1,90 @@
+# GopherTrunk v0.2.5 — social announcement drafts
+
+Concise copy-paste blurbs for posting the v0.2.5 release. Reddit (with
+reddit-friendly markdown headers + bullets) and Discord (tighter,
+inside the 2000-char limit).
+
+Release: https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.2.5
+
+---
+
+## Reddit
+
+**Title:** GopherTrunk v0.2.5 — Motorola MMR talker alias + RID + encryption decode, APRS live end-to-end, P25 simulcast voice fix
+
+**Body:**
+
+**[GopherTrunk](https://gophertrunk.org) v0.2.5 is out** — pure-Go
+digital-trunking scanner for RTL-SDR / HackRF / Airspy. P25 (Phase 1+2),
+DMR (AMBE+2 voice), NXDN, Motorola Type II, EDACS, LTR, MPT 1327, dPMR,
+D-STAR, YSF, plus APRS and POCSAG paging. No CGO, single static binary
+for Linux / macOS / Windows.
+
+**What's new since v0.2.4:**
+
+* **Motorola MMR P25 talker-alias closes end-to-end** (#397, #403, #409,
+  closes #376) — the standard TIA-102 form #389 shipped doesn't match
+  what real Motorola systems emit. New Phase 1 vendor LCO 0x15 / 0x17
+  decoder, Phase 2 MAC-PDU dispatch on the voice chain, and
+  `GROUP_VOICE_CHANNEL_USER_ABBREVIATED` (opcode 0x01, previously
+  mis-named `OpMACPTT` and silently discarded) now backfills source
+  RID + ALGID / KID encryption from the traffic channel for encrypted
+  Phase 2 talkgroups.
+* **APRS is now end-to-end live** (#401, #411) — Bell-202 AFSK DSP
+  frontend + HDLC framer + receiver glue close out the Phase 5
+  pipeline started in v0.2.4. Drop an `aprs.channels` entry
+  (`serial: antenna-pi, frequency_hz: 144_390_000`) and packets land
+  on the bus, the `aprs_log` SQLite table, `/api/v1/aprs/packets`,
+  and the `/aprs` web panel.
+* **P25 simulcast / LSM voice fix** (#399, #356 follow-up) — the
+  Phase 1 voice composer was hardcoded to the C4FM FM-discriminator
+  path regardless of `trunking.systems[].p25_phase1_demod_mode`. On a
+  simulcast site the CC decoded fine but every voice grant landed in
+  an FM-discriminator that couldn't sync on LSM dibits, the LDU sink
+  never fired, and the watchdog reaped the call with an empty WAV.
+  Mode string is now plumbed end-to-end.
+* **RTL-SDR DC-spike on P25 control diagnosis** (#406, #408, #412,
+  issue #402) — three-phase investigation: CCStats + per-sample
+  recording-power diagnostics, replay path mirrored through the
+  production DDC + state-evolution diagnostics, and a
+  decision-directed AFC that defeats data-DC integration so the
+  offset estimator doesn't get pulled into the spike.
+* **Windows RTL-SDR cold-boot: wider recovery envelope** (#398, closes
+  #395) — 5 attempts with 200 / 400 / 800 / 1200 ms exponential
+  backoff and a 150 ms WinUSB settle, for the most stubborn clone
+  dongles that still wedged after v0.2.4's recovery path. Healthy
+  dongles still open on attempt 0 with zero delay.
+* **Silent-degradation warnings at startup** (#400, #356) — fires once
+  per SDR with no `gain:` key, and once per conventional channel with
+  CTCSS / DCS gating configured but `sdr.sample_rate` unset.
+* **Phase 1 TDMA-channel grants → Phase 2 voice chain** (#413) —
+  hybrid Phase 1 CC + Phase 2 voice deployments now route correctly.
+* **CC Activity: patch member TGs over the super-group** (#407, closes
+  #405) — Motorola patch member talkgroups now render first.
+* **Markdown blog on the Pages site** (#396) — per-category archives,
+  RSS, SEO meta.
+
+**Downloads** (Linux / macOS / Windows, x64 + ARM64): https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.2.5
+
+**Docs:** https://gophertrunk.org
+
+Heads-up: the v0.x line is still flagged prerelease — actively
+developed, feedback / captures / bug reports very welcome.
+
+---
+
+## Discord
+
+**GopherTrunk v0.2.5 is out** — pure-Go trunking scanner for RTL-SDR / HackRF / Airspy. P25, DMR, NXDN, analog trunked, APRS, POCSAG. Single static binary, zero CGO.
+
+**What's new since v0.2.4:**
+- **Motorola MMR P25 talker-alias closes end-to-end** (#397, #403, #409, closes #376) — Phase 1 vendor LCO 0x15/0x17 + Phase 2 MAC-PDU dispatch on the voice chain + source RID + ALGID/KID encryption backfilled from `GROUP_VOICE_CHANNEL_USER_ABBREVIATED` (opcode 0x01, was mis-named `OpMACPTT` and silently discarded).
+- **APRS end-to-end live** (#401, #411) — Bell-202 AFSK DSP + HDLC framer + receiver close Phase 5. Drop an `aprs.channels` entry and packets land on the bus / SQLite log / REST / `/aprs` panel.
+- **P25 simulcast/LSM voice fix** (#399, #356 follow-up) — Phase 1 voice composer was hardcoded to C4FM regardless of `p25_phase1_demod_mode`; simulcast grants silently failed. Mode string now plumbed end-to-end.
+- **RTL-SDR DC-spike on P25 CC** (#406, #408, #412, issue #402) — three-phase investigation: CCStats + recording-power diag, replay through production DDC, decision-directed AFC that defeats data-DC integration.
+- **Windows RTL-SDR cold-boot: wider recovery envelope** (#398, closes #395) — 5 attempts with 200/400/800/1200 ms backoff + 150 ms WinUSB settle for stubborn clones.
+- **Silent-degradation warnings at startup** (#400) — no `gain:` per SDR, or CTCSS/DCS gating with zero `sdr.sample_rate`.
+- **Phase 1 TDMA grants → Phase 2 voice chain** (#413), **CC Activity patch members over the SG** (#407, closes #405), **Markdown blog on Pages** (#396).
+
+Download: <https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.2.5>
+Docs: <https://gophertrunk.org>

--- a/docs/downloads.md
+++ b/docs/downloads.md
@@ -28,7 +28,7 @@ release state looks like:
 {%- elsif site.github.releases and site.github.releases[0] and site.github.releases[0].tag_name -%}
   {%- assign ver = site.github.releases[0].tag_name -%}
 {%- else -%}
-  {%- assign ver = "v0.2.4" -%}
+  {%- assign ver = "v0.2.5" -%}
 {%- endif -%}
 {%- assign rel_url = "https://github.com/MattCheramie/GopherTrunk/releases/download/" | append: ver -%}
 


### PR DESCRIPTION
Standard post-release docs sweep for v0.2.5 (tagged 2026-05-28). Promotes
the [Unreleased] CHANGELOG section to [v0.2.5] with the dominant themes
in the intro paragraph (MMR P25 talker-alias closure across #397/#403/#409,
APRS end-to-end via #401/#411, issue #402 RTL-SDR DC-spike three-phase
investigation), bumps the hardcoded VERSION reference in README.md and the
Liquid fallback in docs/downloads.md from v0.2.4 → v0.2.5, and adds
docs/announcements/v0.2.5.md with concise copy-paste Reddit + Discord
blurbs (Discord body is 1704 chars, under the 2000 limit).