### PR TITLE
api: return empty [] instead of nil systems/channels in /api/v1/scanner

### DIFF
--- a/internal/api/handlers_scanner.go
+++ b/internal/api/handlers_scanner.go
@@ -15,11 +15,24 @@ import (
 func (s *Server) handleScannerStatus(w http.ResponseWriter, _ *http.Request) {
 	if s.scanner == nil {
 		writeJSON(w, http.StatusOK, ScannerStatus{
-			ScanMode: "all",
+			ScanMode:     "all",
+			Systems:      []SystemHuntStatusDTO{},
+			Conventional: ConvScannerStatusDTO{Channels: []ConvChannelStatusDTO{}},
 		})
 		return
 	}
-	writeJSON(w, http.StatusOK, s.scanner.Status())
+	st := s.scanner.Status()
+	// Normalize nil slices to empty arrays so the web SPA's .find()/.map()
+	// calls don't crash on null. Go marshals a nil []T as JSON "null"; the
+	// frontend expects [] when there's nothing to show (e.g. cc_hunt
+	// disabled, no conventional channels configured).
+	if st.Systems == nil {
+		st.Systems = []SystemHuntStatusDTO{}
+	}
+	if st.Conventional.Channels == nil {
+		st.Conventional.Channels = []ConvChannelStatusDTO{}
+	}
+	writeJSON(w, http.StatusOK, st)
 }
 
 // scannerSetModeRequest is the PATCH /api/v1/scanner body shape.


### PR DESCRIPTION
The web SPA's Systems view crashes with "can't access property 'find', s.systems is null" when the scanner has no hunted systems wired (e.g. cc_hunt disabled, or running a conventional-only setup). The cause is Go's JSON marshalling: a nil []SystemHuntStatusDTO serialises to "null", but the SPA expects "[]" and calls .find()/.map() directly.

Same nil/[] mismatch existed for ConvScannerStatusDTO.Channels when no conventional channels are configured.

Normalise both slices to empty arrays in handleScannerStatus before writing the response. The "scanner == nil" early-return path now also initialises both slices for the same reason.

Verified on a running daemon with cc_hunt disabled and no conventional channels: GET /api/v1/scanner now returns
  {"scan_mode":"all","systems":[],"conventional":{...,"channels":[]},...}
and the SPA renders the empty Systems view instead of throwing.

<!--
Thanks for the PR. Please fill in the sections below. If a section
doesn't apply, write "n/a" rather than deleting it — that makes review
go faster.

PR scoping rules live in CONTRIBUTING.md. Briefly: one logical change
per PR; bug fixes ship with a regression test; refactors stay separate
from behaviour changes.
-->

## Summary

<!-- One or two sentences. Why is this change needed? What's broken or
     missing today? -->

## Changes

<!-- Bulleted list of what changed. The diff itself documents the
     "how"; this list helps reviewers navigate. -->

-

## Test plan

<!-- How did you verify this? Which tests cover the new behaviour? Any
     manual smoke tests against hardware? -->

- [ ] `make vet test` is green locally
- [ ] `make integration` is green locally (if the change touches the
      daemon)
- [ ] Added or updated tests where appropriate
- [ ] Smoke-tested against real hardware (if SDR / USB / vocoder code
      changed) — describe the dongle / capture used

## Breaking changes

<!-- Does this change config-file keys, CLI flags, REST endpoints,
     gRPC schemas, or default behaviour an existing operator depends
     on? If yes, describe the migration path. If no, write "none". -->

## Docs / CHANGELOG

- [ ] Added a `## [Unreleased]` bullet to [`CHANGELOG.md`](../CHANGELOG.md)
      if this is user-visible
- [ ] Updated [`README.md`](../README.md) or [`docs/`](../docs/) if
      operator-facing behaviour changed

## Linked issues

<!-- Closes #NNN / Refs #NNN. Leave blank if there's no tracked issue. -->
