### PR TITLE
airspy: fix wrong vendor opcodes, SET_SAMPLERATE format, phantom SET_…

### DIFF
--- a/internal/sdr/airspy/airspy.go
+++ b/internal/sdr/airspy/airspy.go
@@ -34,16 +34,16 @@ const (
 // libairspy vendor request opcodes (subset).
 const (
 	reqReceiverMode   uint8 = 1
-	reqSetSampleType  uint8 = 11
-	reqSetFreq        uint8 = 12
-	reqGetSamplerates uint8 = 13
-	reqSetSamplerate  uint8 = 14
-	reqSetLNAGain     uint8 = 19
-	reqSetMixerGain   uint8 = 20
-	reqSetVGAGain     uint8 = 21
-	reqSetLNAAGC      uint8 = 22
-	reqSetMixerAGC    uint8 = 23
-	reqSetRFBiasCmd   uint8 = 24
+	reqSetSampleType  uint8 = 11  // NOTE: libairspy has BOARD_PARTID_SERIALNO_READ at 11; SET_SAMPLE_TYPE has no opcode in current firmware
+	reqSetFreq        uint8 = 13
+	reqGetSamplerates uint8 = 25
+	reqSetSamplerate  uint8 = 12
+	reqSetLNAGain     uint8 = 14
+	reqSetMixerGain   uint8 = 15
+	reqSetVGAGain     uint8 = 16
+	reqSetLNAAGC      uint8 = 17
+	reqSetMixerAGC    uint8 = 18
+	reqSetRFBiasCmd   uint8 = 20
 )
 
 // Sample-type values for reqSetSampleType.
@@ -216,12 +216,16 @@ func (d *Device) SetCenterFreq(hz uint32) error {
 
 // SetSampleRate selects the firmware-advertised rate closest to hz. If
 // the supported-rate table is unavailable, index 0 is used.
+// Patched: match libairspy — IN direction, wValue=0, wIndex=idx, expects a 1-byte
+// status reply. The upstream code used ControlOut with wValue/wIndex swapped,
+// which the Airspy R2/Mini firmware rejects.
 func (d *Device) SetSampleRate(hz uint32) error {
 	if d.isClosed() {
 		return usb.ErrClosed
 	}
 	idx := d.closestRateIndex(hz)
-	return d.t.ControlOut(reqSetSamplerate, uint16(idx), 0, nil, controlTimeoutMs)
+	_, err := d.t.ControlIn(reqSetSamplerate, 0, uint16(idx), 1, controlTimeoutMs)
+	return err
 }
 
 // closestRateIndex returns the index of the supported sample rate
@@ -363,17 +367,12 @@ func (d *Device) StreamIQ(ctx context.Context) (<-chan []complex64, error) {
 	needSampleType := !d.sampleTypeSet
 	d.mu.Unlock()
 
-	// Pin the device to INT16_IQ — the format the StreamIQ decoder
-	// expects. libairspy issues this inside airspy_start_rx rather
-	// than during open; mirroring that ordering avoids a firmware /
-	// Windows-driver NAK on the first vendor OUT (issue #270).
+	// Patched: libairspy's airspy_set_sample_type is purely host-side —
+	// there is no SET_SAMPLE_TYPE vendor opcode in current firmware
+	// (opcode 11 is BOARD_PARTID_SERIALNO_READ). The firmware always
+	// streams raw INT16 IQ; decodeInt16IQ handles it host-side. Just
+	// mark the flag so we don't try this phantom request again.
 	if needSampleType {
-		if err := d.t.ControlOut(reqSetSampleType, sampleTypeInt16IQ, 0, nil, controlTimeoutMs); err != nil {
-			d.mu.Lock()
-			d.streaming = false
-			d.mu.Unlock()
-			return nil, fmt.Errorf("airspy: set sample type: %w", err)
-		}
 		d.mu.Lock()
 		d.sampleTypeSet = true
 		d.mu.Unlock()


### PR DESCRIPTION
…SAMPLE_TYPE

The pure-Go Airspy driver in internal/sdr/airspy/airspy.go did not interop with current Airspy R2/Mini firmware. Three independent bugs:

1. Ten vendor opcodes were off vs libairspy's airspy_commands.h. Most notably GET_SAMPLERATES was 13 (firmware: 25) and SET_SAMPLERATE was 14 (firmware: 12), so every command was dispatched to the wrong handler:
     SET_SAMPLERATE   14 -> 12
     SET_FREQ         12 -> 13
     SET_LNA_GAIN     19 -> 14
     SET_MIXER_GAIN   20 -> 15
     SET_VGA_GAIN     21 -> 16
     SET_LNA_AGC      22 -> 17
     SET_MIXER_AGC    23 -> 18
     SET_RF_BIAS_CMD  24 -> 20
     GET_SAMPLERATES  13 -> 25

2. SetSampleRate sent the wrong USB request layout vs libairspy's airspy_set_samplerate: it used ControlOut with wValue=idx, wIndex=0 and no return buffer. libairspy uses ControlIn (the firmware returns a 1-byte status), wValue=0, wIndex=samplerate. Fixed to match.

3. StreamIQ issued a phantom ControlOut for reqSetSampleType=11. libairspy's airspy_set_sample_type is purely host-side; firmware has no SET_SAMPLE_TYPE opcode (opcode 11 is BOARD_PARTID_SERIALNO_READ). Firmware always streams INT16 IQ on the bulk endpoint, which decodeInt16IQ already handles host-side. The phantom request returned EOVERFLOW from the kernel. Removed; the flag is still set so the no-op path is skipped on subsequent stream starts.

Verified end-to-end on an Airspy Mini (USB 1d50:60a1, firmware "AirSpy MINI v1.0.0-rc10-6-g4008185 2020-05-08") on a Raspberry Pi 4 running Debian 13 (trixie) arm64. With the patch, `gophertrunk run` opens the device at role=wideband, the Tier-II DDC channelizer starts on a configured 438.325 MHz channel, the kernel logs zero USBDEVFS_CONTROL errors, and `airspy_info`/`airspy_rx` (libairspy 1.0.11) continue to work side-by-side.

Side note: USBDEVFS_RESET against the Airspy Mini destabilizes the device (kernel logs "device not accepting address ... error -71" until a physical replug). Confirmed the wrong fix path during debugging; not applied here.

<!--
Thanks for the PR. Please fill in the sections below. If a section
doesn't apply, write "n/a" rather than deleting it — that makes review
go faster.

PR scoping rules live in CONTRIBUTING.md. Briefly: one logical change
per PR; bug fixes ship with a regression test; refactors stay separate
from behaviour changes.
-->

## Summary

<!-- One or two sentences. Why is this change needed? What's broken or
     missing today? -->

## Changes

<!-- Bulleted list of what changed. The diff itself documents the
     "how"; this list helps reviewers navigate. -->

-

## Test plan

<!-- How did you verify this? Which tests cover the new behaviour? Any
     manual smoke tests against hardware? -->

- [ ] `make vet test` is green locally
- [ ] `make integration` is green locally (if the change touches the
      daemon)
- [ ] Added or updated tests where appropriate
- [ ] Smoke-tested against real hardware (if SDR / USB / vocoder code
      changed) — describe the dongle / capture used

## Breaking changes

<!-- Does this change config-file keys, CLI flags, REST endpoints,
     gRPC schemas, or default behaviour an existing operator depends
     on? If yes, describe the migration path. If no, write "none". -->

## Docs / CHANGELOG

- [ ] Added a `## [Unreleased]` bullet to [`CHANGELOG.md`](../CHANGELOG.md)
      if this is user-visible
- [ ] Updated [`README.md`](../README.md) or [`docs/`](../docs/) if
      operator-facing behaviour changed

## Linked issues

<!-- Closes #NNN / Refs #NNN. Leave blank if there's no tracked issue. -->
