### PR TITLE
sdr/pool: strict mode honours sdr.devices as an allowlist (issue #264)

### DIFF
--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -441,7 +441,16 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 				log.Info("rtl_tcp endpoints mounted", "count", len(rspecs))
 			}
 		}
-		if err := d.pool.Open(cfg.SDR.SampleRate, hints); err != nil {
+		if err := d.pool.OpenWith(sdr.PoolOpenOptions{
+			SampleRateHz: cfg.SDR.SampleRate,
+			Hints:        hints,
+			// Strict mode: when the operator has listed devices in
+			// sdr.devices, treat that list as an allowlist. Devices
+			// that are physically connected but not named are left
+			// alone — they may belong to another process on the
+			// host (issue #264).
+			Strict: len(cfg.SDR.Devices) > 0,
+		}); err != nil {
 			log.Warn("daemon: SDR pool open failed", "err", err)
 			d.addWarning(fmt.Sprintf(
 				"SDR pool failed to open (%v) — no radios will demodulate; check device permissions / cabling / kernel modules",

--- a/internal/sdr/pool.go
+++ b/internal/sdr/pool.go
@@ -112,23 +112,70 @@ func (h Hint) WithGain(tenthDB int) Hint {
 // agree on a known-good fallback.
 const DefaultSampleRateHz uint32 = 2_048_000
 
-// Open enumerates every registered driver, opens devices that match the
-// supplied hints (or simply all of them when hints is empty), programs
-// the IQ sample rate on each device (issue #275 — without this the chip
-// streams at whatever rate its resampler powered up at), and assigns
-// roles. The first opened device gets RoleControl unless a hint says
-// otherwise; subsequent devices get RoleVoice. Passing sampleRateHz == 0
-// falls back to DefaultSampleRateHz. A device whose SetSampleRate
-// fails is closed and skipped — a wrong-rate radio produces silent
-// decoder failures, which is worse than no radio at all.
+// PoolOpenOptions parameterises Pool.OpenWith. Use this when callers
+// need to engage strict mode; the historical Pool.Open(rate, hints)
+// signature still works and remains the default for code paths that
+// want today's open-everything behaviour.
+type PoolOpenOptions struct {
+	// SampleRateHz is the IQ rate to program on every opened device.
+	// Zero falls back to DefaultSampleRateHz.
+	SampleRateHz uint32
+	// Hints carries the per-device tuning the pool applies once each
+	// device is opened (PPM, gain, bias-tee, role). Hints are matched
+	// to discovered devices by serial.
+	Hints []Hint
+	// Strict treats Hints as an allowlist: a discovered device whose
+	// serial is not present in Hints is logged and skipped instead of
+	// being auto-roled. The daemon engages strict mode when the user
+	// has populated cfg.SDR.Devices — that's the operator's signal
+	// that they want only the devices they named, not whatever else
+	// happens to be on the USB bus.
+	Strict bool
+}
+
+// Open is a backwards-compatible shim over OpenWith. It preserves the
+// historical "open every enumerated device" behaviour; callers that
+// want allowlist semantics should construct PoolOpenOptions and call
+// OpenWith directly.
 func (p *Pool) Open(sampleRateHz uint32, hints []Hint) error {
+	return p.OpenWith(PoolOpenOptions{SampleRateHz: sampleRateHz, Hints: hints})
+}
+
+// OpenWith enumerates every registered driver, opens the devices the
+// options select, programs the IQ sample rate on each one (issue #275 —
+// without this the chip streams at whatever rate its resampler powered
+// up at), and assigns roles. The first opened device gets RoleControl
+// unless a hint says otherwise; subsequent devices get RoleVoice.
+//
+// When opts.Strict is false, every discovered device is opened. A
+// non-hinted device gets an auto-assigned role and runs with the
+// driver's default PPM / gain.
+//
+// When opts.Strict is true, only devices whose serial matches a hint
+// are opened. Discovered devices without a matching hint are logged at
+// INFO and skipped. Hints whose serial doesn't match any discovered
+// device produce a WARN. Hints with empty serial are dropped at ingest
+// with a WARN — an empty-serial hint in strict mode is ambiguous (no
+// way to honour an allowlist entry that doesn't name anything).
+//
+// Strict mode is how operators get "only the devices I listed in
+// config.yaml are touched"; rtl_tcp and baseband replay always
+// originate from explicit config entries, so strict mode applies to
+// them uniformly. An rtl_tcp endpoint without a serial: in config is
+// therefore skipped in strict mode — set serial: on the endpoint to
+// keep it.
+//
+// A device whose SetSampleRate fails is closed and skipped — a
+// wrong-rate radio produces silent decoder failures, which is worse
+// than no radio at all.
+func (p *Pool) OpenWith(opts PoolOpenOptions) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	if len(p.entries) > 0 {
 		return errors.New("pool already populated; close first")
 	}
 
-	rate := sampleRateHz
+	rate := opts.SampleRateHz
 	if rate == 0 {
 		rate = DefaultSampleRateHz
 	}
@@ -154,18 +201,29 @@ func (p *Pool) Open(sampleRateHz uint32, hints []Hint) error {
 
 	hintBySerial := map[string]Hint{}
 	controlClaimed := false
-	for _, h := range hints {
-		if h.Serial != "" {
-			hintBySerial[h.Serial] = h
-			if h.Role == RoleControl {
-				controlClaimed = true
+	for _, h := range opts.Hints {
+		if h.Serial == "" {
+			if opts.Strict {
+				p.log.Warn("ignoring hint with empty serial in strict mode; set serial: in config to use this entry",
+					"role", h.Role.String())
 			}
+			continue
+		}
+		hintBySerial[h.Serial] = h
+		if h.Role == RoleControl {
+			controlClaimed = true
 		}
 	}
 
+	openedSerials := map[string]struct{}{}
 	for _, d := range all {
-		role := RoleAuto
 		hint, hinted := hintBySerial[d.info.Serial]
+		if opts.Strict && !hinted {
+			p.log.Info("skipping non-configured SDR; add its serial to sdr.devices to use it",
+				"driver", d.drv.Name(), "serial", d.info.Serial)
+			continue
+		}
+		role := RoleAuto
 		if hinted {
 			role = hint.Role
 		}
@@ -202,9 +260,27 @@ func (p *Pool) Open(sampleRateHz uint32, hints []Hint) error {
 		}
 		entry := &PoolEntry{Driver: d.drv, Device: dev, Info: d.info, Role: role, Hint: hint}
 		p.entries = append(p.entries, entry)
+		openedSerials[d.info.Serial] = struct{}{}
+		// Include the per-device tuning in the open log so an
+		// operator can grep the boot log to confirm the value they
+		// put in config.yaml actually landed on this serial (issue
+		// #264 surfaced as "ppm of -4 is not adopted" because the
+		// device that received the SetPPM call wasn't the one
+		// driving cchunt).
 		p.log.Info("device opened",
-			"driver", d.drv.Name(), "serial", d.info.Serial, "role", role.String(), "rate_hz", rate)
+			"driver", d.drv.Name(),
+			"serial", d.info.Serial,
+			"role", role.String(),
+			"rate_hz", rate,
+			"ppm", hint.PPM,
+			"bias_tee", hint.BiasTee)
 		p.publish(events.KindSDRAttached, entry.Snapshot(true))
+	}
+	for serial := range hintBySerial {
+		if _, ok := openedSerials[serial]; !ok {
+			p.log.Warn("configured SDR not present on the bus; check the cable / dmesg / lsusb",
+				"serial", serial)
+		}
 	}
 	if len(p.entries) == 0 {
 		return errors.New("no SDR devices opened")

--- a/internal/sdr/pool_test.go
+++ b/internal/sdr/pool_test.go
@@ -26,6 +26,8 @@ type fakeDevice struct {
 	biasTeeSets int
 	sampleRate  uint32
 	rateErr     error
+	ppm         int
+	ppmSets     int
 }
 
 func (d *fakeDevice) Info() Info                 { return d.info }
@@ -37,8 +39,8 @@ func (d *fakeDevice) SetSampleRate(hz uint32) error {
 	d.sampleRate = hz
 	return nil
 }
-func (d *fakeDevice) SetGain(int) error                                    { return nil }
-func (d *fakeDevice) SetPPM(int) error                                     { return nil }
+func (d *fakeDevice) SetGain(int) error      { return nil }
+func (d *fakeDevice) SetPPM(ppm int) error   { d.ppm = ppm; d.ppmSets++; return nil }
 func (d *fakeDevice) SetBiasTee(on bool) error                             { d.biasTeeOn = on; d.biasTeeSets++; return nil }
 func (d *fakeDevice) StreamIQ(context.Context) (<-chan []complex64, error) { return nil, io.EOF }
 func (d *fakeDevice) Close() error {
@@ -396,6 +398,167 @@ func TestPoolReacquireErrorsWhenSerialMissingAfterReenumerate(t *testing.T) {
 	}
 	if !entry.Device.(*fakeDevice).closed {
 		t.Error("stale device handle should be Closed even on failed reacquire")
+	}
+}
+
+// TestPoolStrictOpensOnlyHintedSerial guards the fix for issue #264:
+// when the operator names devices in config.yaml, the pool must treat
+// that list as an allowlist. Previously every enumerated device was
+// opened, which on a multi-stick host meant unrelated dongles got
+// taken over (and worse — a non-hinted dongle could win RoleControl,
+// so the cchunt path bound to a device that hadn't received the
+// operator's PPM correction).
+func TestPoolStrictOpensOnlyHintedSerial(t *testing.T) {
+	drv := &fakeDriver{name: "fake-strict", infos: []Info{
+		{Driver: "fake-strict", Index: 0, Serial: "NOOELEC-1"},
+		{Driver: "fake-strict", Index: 1, Serial: "V4"},
+		{Driver: "fake-strict", Index: 2, Serial: "NOOELEC-2"},
+	}}
+	registerDriver(t, drv.name, drv)
+
+	var buf bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	p := NewPool(log)
+	err := p.OpenWith(PoolOpenOptions{
+		SampleRateHz: 2_400_000,
+		Hints:        []Hint{{Serial: "V4", PPM: -4}},
+		Strict:       true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer p.Close()
+
+	entries := p.Entries()
+	if len(entries) != 1 {
+		t.Fatalf("strict mode opened %d devices, want 1; log was: %q", len(entries), buf.String())
+	}
+	if entries[0].Info.Serial != "V4" {
+		t.Errorf("opened serial = %q, want V4", entries[0].Info.Serial)
+	}
+	// The lone opened device should claim RoleControl via the
+	// unclaimed-control rule, so FirstByRole(RoleControl) hands the
+	// PPM-corrected V4 to cchunt / ccdecoder.
+	if entries[0].Role != RoleControl {
+		t.Errorf("role = %v, want control", entries[0].Role)
+	}
+	dev := entries[0].Device.(*fakeDevice)
+	if dev.ppmSets != 1 || dev.ppm != -4 {
+		t.Errorf("SetPPM not applied: sets=%d ppm=%d, want sets=1 ppm=-4", dev.ppmSets, dev.ppm)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "NOOELEC-1") || !strings.Contains(out, "NOOELEC-2") {
+		t.Errorf("expected skip log for both NooElecs; log was: %q", out)
+	}
+	if !strings.Contains(out, "skipping non-configured SDR") {
+		t.Errorf("expected skip-reason log; log was: %q", out)
+	}
+	if !strings.Contains(out, "ppm=-4") {
+		t.Errorf("device-opened log should surface ppm; log was: %q", out)
+	}
+}
+
+// TestPoolStrictWarnsOnMissingHintSerial covers the operator-error
+// path: a serial in config.yaml that no connected dongle reports.
+// The pool should warn about the missing hint and leave the other
+// physically-present devices closed (strict mode is an allowlist, not
+// a "use these or fall back" preference).
+func TestPoolStrictWarnsOnMissingHintSerial(t *testing.T) {
+	drv := &fakeDriver{name: "fake-strict-missing", infos: []Info{
+		{Driver: "fake-strict-missing", Index: 0, Serial: "PRESENT-1"},
+		{Driver: "fake-strict-missing", Index: 1, Serial: "PRESENT-2"},
+	}}
+	registerDriver(t, drv.name, drv)
+
+	var buf bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	p := NewPool(log)
+	err := p.OpenWith(PoolOpenOptions{
+		Hints:  []Hint{{Serial: "MISSING-ZZZ", Role: RoleControl}},
+		Strict: true,
+	})
+	// All discovered devices are non-hinted, so strict mode skips them
+	// and OpenWith returns "no SDR devices opened".
+	if err == nil {
+		t.Fatal("expected error when no hinted device is present, got nil")
+	}
+	if !strings.Contains(err.Error(), "no SDR devices opened") {
+		t.Errorf("err = %v, want 'no SDR devices opened'", err)
+	}
+	if entries := p.Entries(); len(entries) != 0 {
+		t.Errorf("pool has %d entries, want 0 (the present-but-non-hinted devices must not be opened)", len(entries))
+	}
+	out := buf.String()
+	if !strings.Contains(out, "configured SDR not present") || !strings.Contains(out, "MISSING-ZZZ") {
+		t.Errorf("expected missing-serial warn; log was: %q", out)
+	}
+}
+
+// TestPoolStrictIgnoresEmptySerialHint covers the ambiguous case: an
+// allowlist entry that doesn't name a device. The hint is dropped at
+// ingest with a warn — left in, it would silently match nothing and
+// trigger the missing-serial warn with an empty value, which is the
+// less actionable failure mode.
+func TestPoolStrictIgnoresEmptySerialHint(t *testing.T) {
+	drv := &fakeDriver{name: "fake-strict-empty", infos: []Info{
+		{Driver: "fake-strict-empty", Index: 0, Serial: "S1"},
+	}}
+	registerDriver(t, drv.name, drv)
+
+	var buf bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	p := NewPool(log)
+	err := p.OpenWith(PoolOpenOptions{
+		Hints: []Hint{
+			{Serial: "", Role: RoleControl, PPM: -4},
+			{Serial: "S1"},
+		},
+		Strict: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer p.Close()
+
+	entries := p.Entries()
+	if len(entries) != 1 || entries[0].Info.Serial != "S1" {
+		t.Fatalf("entries = %+v, want exactly S1", entries)
+	}
+	// PPM from the empty-serial hint must NOT have leaked onto S1.
+	if dev := entries[0].Device.(*fakeDevice); dev.ppmSets != 0 {
+		t.Errorf("empty-serial hint leaked SetPPM onto S1: sets=%d ppm=%d", dev.ppmSets, dev.ppm)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "ignoring hint with empty serial in strict mode") {
+		t.Errorf("expected empty-serial warn; log was: %q", out)
+	}
+}
+
+// TestPoolOpenWithNonStrictPreservesLegacyBehavior exercises the new
+// OpenWith entry point with Strict: false to confirm the shim path
+// matches the historical Open(rate, hints) behaviour: every
+// enumerated device opens and non-hinted devices get auto-assigned
+// roles.
+func TestPoolOpenWithNonStrictPreservesLegacyBehavior(t *testing.T) {
+	drv := &fakeDriver{name: "fake-nonstrict", infos: []Info{
+		{Driver: "fake-nonstrict", Index: 0, Serial: "AAA"},
+		{Driver: "fake-nonstrict", Index: 1, Serial: "BBB"},
+		{Driver: "fake-nonstrict", Index: 2, Serial: "CCC"},
+	}}
+	registerDriver(t, drv.name, drv)
+
+	p := NewPool(nil)
+	err := p.OpenWith(PoolOpenOptions{
+		Hints:  []Hint{{Serial: "BBB", Role: RoleControl}},
+		Strict: false,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer p.Close()
+
+	if entries := p.Entries(); len(entries) != 3 {
+		t.Fatalf("non-strict OpenWith opened %d, want 3", len(entries))
 	}
 }
 

--- a/internal/sdr/pool_test.go
+++ b/internal/sdr/pool_test.go
@@ -39,8 +39,8 @@ func (d *fakeDevice) SetSampleRate(hz uint32) error {
 	d.sampleRate = hz
 	return nil
 }
-func (d *fakeDevice) SetGain(int) error      { return nil }
-func (d *fakeDevice) SetPPM(ppm int) error   { d.ppm = ppm; d.ppmSets++; return nil }
+func (d *fakeDevice) SetGain(int) error                                    { return nil }
+func (d *fakeDevice) SetPPM(ppm int) error                                 { d.ppm = ppm; d.ppmSets++; return nil }
 func (d *fakeDevice) SetBiasTee(on bool) error                             { d.biasTeeOn = on; d.biasTeeSets++; return nil }
 func (d *fakeDevice) StreamIQ(context.Context) (<-chan []complex64, error) { return nil, io.EOF }
 func (d *fakeDevice) Close() error {


### PR DESCRIPTION
Previously Pool.Open opened every enumerated USB device regardless of
whether the caller listed it in config. On a host with multiple dongles
this meant unrelated devices got taken over by the daemon — and worse,
a non-hinted dongle could win RoleControl via the auto-claim rule, so
cchunt/ccdecoder bound to a device that hadn't received the operator's
PPM correction.

Add PoolOpenOptions with a Strict flag; keep Open as a thin shim for
existing callers. In strict mode, discovered devices without a matching
hint serial are logged at INFO and skipped, hints whose serial doesn't
appear on the bus produce a WARN, and empty-serial hints are dropped at
ingest. The daemon engages strict mode whenever cfg.SDR.Devices is
non-empty.

Also surface ppm and bias_tee on the existing device-opened INFO line
so operators can grep the boot log to confirm the value they put in
config.yaml landed on the right serial.

https://claude.ai/code/session_01Jk14REyiez22ehdZpqJpAf