### PR TITLE
rtlsdr: settle warmup→step-0 race on Windows clone dongles (issue #395)

### DIFF
--- a/internal/sdr/rtlsdr/purego/driver.go
+++ b/internal/sdr/rtlsdr/purego/driver.go
@@ -163,13 +163,17 @@ func (d *Driver) Open(idx int) (sdr.Device, error) {
 // state. Up to four resets per Open with exponential backoff
 // (200ms / 400ms / 800ms / 1200ms) between the failing attempt and
 // the next retry — gives the WinUSB stack and device firmware time
-// to settle before the next bring-up pass. Issue #395 surfaced a
-// reporter on v0.2.4 whose dongle still failed all three attempts
-// of the prior 3-attempt / 100ms+200ms envelope, so this widens
-// both the attempt count and the per-attempt settle window while
-// keeping healthy opens at zero delay (attempt 0 succeeds, no sleep
-// runs). Worst-case open delay for a permanently-broken dongle is
-// ~2.6s of sleep plus the per-reset rebind cost.
+// to settle before the next bring-up pass. Worst-case open delay
+// for a permanently-broken dongle is ~2.6s of sleep plus the
+// per-reset rebind cost.
+//
+// Inter-attempt backoff is the wrong tool for the issue #395
+// failure mode (warmup OK → step 0 immediately fails with
+// ERROR_GEN_FAILURE because the dongle's firmware can't handle the
+// back-to-back identical write at WinUSB-syscall speed); that's
+// handled inside runBringup via warmupSettleDuration before the
+// first attempt even runs.
+//
 // Non-resetable errors (validation failures, ErrClosed) return
 // immediately — reset is the wrong hammer for them.
 func openDevice(transport usb.Transport, desc usb.Descriptor, idx int) (*Device, error) {
@@ -249,19 +253,44 @@ func openDevice(transport usb.Transport, desc usb.Descriptor, idx int) (*Device,
 // the resampler's power-on default happens to be.
 const defaultOpenSampleRateHz uint32 = 2_048_000
 
+// warmupSettleDuration is the gap inserted between the WarmupUSBSysctl
+// probe and the first InitBaseband write — both of which target
+// (block=USB, addr=USBSysctl, val=0x09) on the wire. librtlsdr emits
+// the same byte-identical pair through libusb on every OS, but
+// libusb's WinUSB backend has multiple stack layers (libusb-1.0.dll
+// → winusb.dll → WinUSB.sys) and naturally spaces those two writes
+// by hundreds of microseconds. GopherTrunk's direct
+// procWinUsbControlTransfer.Call path is several layers thinner, so
+// on some clone dongles the second identical write arrives while the
+// firmware is still processing the first and gets NAK'd with
+// ERROR_GEN_FAILURE (issue #395). 10 ms is enough headroom for the
+// observed clone firmware to settle without being noticeable on
+// healthy hardware. The Linux / macOS USBDEVFS / IOKit paths have
+// their own per-transfer overhead, so the cost is functionally only
+// paid once per Open on every platform.
+//
+// It's a var rather than a const so tests can override it; production
+// callers must treat it as read-only.
+var warmupSettleDuration = 10 * time.Millisecond
+
 // runBringup executes the librtlsdr-parity init sequence on a fresh
-// Demod: USB-sysctl warmup probe → baseband init → tuner detect →
-// R820T-family demod prep (no-op for other tuners) → tuner.Init →
-// IF-freq programming (R820T-family programs its own IF inside
-// PrepareDemod, so non-R82xx tuners use the demod-side path) →
-// default sample-rate program (librtlsdr parity; see issue #275).
-// Returns the initialized tuner on success. All errors are wrapped
-// with a stage prefix so the outer openDevice can spot resetable
-// EPIPE / ErrDeviceGone via errors.Is.
+// Demod: USB-sysctl warmup probe → warmupSettleDuration sleep →
+// baseband init → tuner detect → R820T-family demod prep (no-op for
+// other tuners) → tuner.Init → IF-freq programming (R820T-family
+// programs its own IF inside PrepareDemod, so non-R82xx tuners use
+// the demod-side path) → default sample-rate program (librtlsdr
+// parity; see issue #275). Returns the initialized tuner on success.
+// All errors are wrapped with a stage prefix so the outer openDevice
+// can spot resetable EPIPE / ErrDeviceGone via errors.Is.
 func runBringup(demod *rtl2832u.Demod) (tuners.Tuner, error) {
 	if err := demod.WarmupUSBSysctl(); err != nil {
 		return nil, fmt.Errorf("rtlsdr: USB warmup: %w%s", err, tunerBringupHint(err))
 	}
+	// The first write inside InitBaseband is byte-identical to the
+	// warmup probe — give the dongle's firmware a moment to settle
+	// before re-sending it. See warmupSettleDuration above for the
+	// full reasoning (issue #395).
+	time.Sleep(warmupSettleDuration)
 	if err := demod.InitBaseband(); err != nil {
 		return nil, fmt.Errorf("rtlsdr: init baseband: %w%s", err, tunerBringupHint(err))
 	}
@@ -370,14 +399,15 @@ func tunerBringupHint(err error) string {
 			" See https://mattcheramie.github.io/GopherTrunk/install-linux.html#troubleshooting)"
 	}
 	if errors.Is(err, usb.ErrPipeStalled) {
-		return " (hint: the dongle's USB control pipe stalled on cold boot" +
-			" (Windows ERROR_GEN_FAILURE) — common with clone dongles or" +
-			" marginal USB power. If the automatic retry didn't recover," +
-			" unplug the dongle for 10 seconds and re-plug to clear the wedged" +
-			" firmware state, then re-run Zadig to confirm WinUSB is bound to" +
-			" interface 0, and try a different USB port (avoid hubs)." +
-			" Run `gophertrunk sdr doctor` to inspect the current driver binding." +
-			" If this keeps happening after a Windows sleep/resume, see issue #395." +
+		return " (hint: the dongle's USB control pipe stalled" +
+			" (Windows ERROR_GEN_FAILURE) — on Windows, the bring-up path" +
+			" already inserts a 10 ms settle between the warmup probe and" +
+			" the first InitBaseband write to absorb the clone-dongle" +
+			" firmware timing quirk reported in issue #395. If the failure" +
+			" persists, try a different USB controller (front vs rear ports" +
+			" often use different host controllers) and confirm" +
+			" `gophertrunk sdr doctor` reports WinUSB bound to interface 0." +
+			" Avoid USB hubs and powered extension cables." +
 			" See https://mattcheramie.github.io/GopherTrunk/install-linux.html#troubleshooting)"
 	}
 	return ""

--- a/internal/sdr/rtlsdr/purego/driver_test.go
+++ b/internal/sdr/rtlsdr/purego/driver_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"syscall"
 	"testing"
+	"time"
 
 	"github.com/MattCheramie/GopherTrunk/internal/sdr/rtlsdr/usb"
 )
@@ -211,6 +212,55 @@ func TestOpenDevice_WarmupSucceedsFirstTry(t *testing.T) {
 	}
 }
 
+// Regression for issue #395: WarmupUSBSysctl and the first InitBaseband
+// write are byte-identical (BlockUSB / USBSysctl / 0x09). On Windows
+// through the direct WinUsb_ControlTransfer syscall this back-to-back
+// pair races some clone-dongle firmware and trips ERROR_GEN_FAILURE on
+// the second write. runBringup must sleep warmupSettleDuration between
+// the two transfers so the dongle has time to settle. The test asserts
+// the wall-clock gap from openDevice entry to the InitBaseband
+// terminator error is at least warmupSettleDuration, then restores
+// the original value (the test temporarily widens it to 75 ms so the
+// timing observation stays robust above scheduler noise).
+func TestOpenDevice_WarmupToInitBasebandSettle_Issue395(t *testing.T) {
+	original := warmupSettleDuration
+	warmupSettleDuration = 75 * time.Millisecond
+	t.Cleanup(func() { warmupSettleDuration = original })
+
+	m := usb.NewMockTransport()
+	m.Script = []usb.CtrlExchange{
+		warmupUSBSysctlExchange(nil),
+		// Fail the first InitBaseband write with ErrClosed (non-resetable)
+		// so openDevice unwinds immediately on attempt 0 — we just want
+		// to measure that the settle ran between the warmup and step 0.
+		{
+			In:       false,
+			BRequest: 0,
+			WValue:   0x2000,
+			WIndex:   uint16(1)<<8 | 0x10,
+			Data:     []byte{0x09},
+			Err:      usb.ErrClosed,
+		},
+	}
+	desc := usb.Descriptor{VID: 0x0bda, PID: 0x2838, Serial: "test-warmup-settle"}
+	start := time.Now()
+	_, err := openDevice(m, desc, 0)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("openDevice succeeded; expected init-baseband terminator to fail the test")
+	}
+	if !strings.Contains(err.Error(), "init baseband") {
+		t.Errorf("err = %v, want substring \"init baseband\" (proves warmup passed and InitBaseband ran)", err)
+	}
+	if elapsed < warmupSettleDuration {
+		t.Errorf("openDevice took %v, want >= warmupSettleDuration (%v) — the inter-transfer settle did not run", elapsed, warmupSettleDuration)
+	}
+	if m.ResetCalls != 0 {
+		t.Errorf("ResetCalls = %d, want 0 (the settle path must not invoke reset; the failure here is non-resetable ErrClosed)", m.ResetCalls)
+	}
+}
+
 // Regression for issue #248: when the warmup write returns EPIPE, the
 // driver must call transport.Reset, re-claim interface 0, and retry the
 // warmup once. The retry succeeds and openDevice proceeds — we again
@@ -392,7 +442,7 @@ func TestTunerBringupHint(t *testing.T) {
 		{
 			name:    "ErrPipeStalled_through_wrap",
 			err:     fmt.Errorf("winusb: device rejected request: %w", usb.ErrPipeStalled),
-			wantSub: []string{"control pipe stalled", "Zadig", "sdr doctor", "install-linux.html#troubleshooting"},
+			wantSub: []string{"control pipe stalled", "ERROR_GEN_FAILURE", "issue #395", "sdr doctor", "install-linux.html#troubleshooting"},
 		},
 	}
 	for _, c := range cases {
@@ -541,14 +591,14 @@ func TestOpenDevice_BringupPipeStalledFiveTimes_ReturnsHintError(t *testing.T) {
 	if !strings.Contains(err.Error(), "control pipe stalled") {
 		t.Errorf("err = %v, want substring \"control pipe stalled\" (proves the clone-dongle hint was appended)", err)
 	}
-	if !strings.Contains(err.Error(), "Zadig") {
-		t.Errorf("err = %v, want substring \"Zadig\"", err)
+	if !strings.Contains(err.Error(), "ERROR_GEN_FAILURE") {
+		t.Errorf("err = %v, want substring \"ERROR_GEN_FAILURE\" (proves the Windows-specific hint was appended)", err)
 	}
-	if !strings.Contains(err.Error(), "unplug the dongle") {
-		t.Errorf("err = %v, want substring \"unplug the dongle\" (proves the #395 hint was appended)", err)
+	if !strings.Contains(err.Error(), "issue #395") {
+		t.Errorf("err = %v, want substring \"issue #395\" (proves the issue ref was appended)", err)
 	}
-	if !strings.Contains(err.Error(), "#395") {
-		t.Errorf("err = %v, want substring \"#395\" (proves the issue ref was appended)", err)
+	if !strings.Contains(err.Error(), "sdr doctor") {
+		t.Errorf("err = %v, want substring \"sdr doctor\" (proves the WinUSB-binding remediation was appended)", err)
 	}
 	if m.ResetCalls != 4 {
 		t.Errorf("ResetCalls = %d, want 4 (bounded envelope: four resets, five attempts)", m.ResetCalls)

--- a/internal/sdr/rtlsdr/usb/usb_windows.go
+++ b/internal/sdr/rtlsdr/usb/usb_windows.go
@@ -172,11 +172,38 @@ func (w *winEnumerator) Open(d Descriptor) (Transport, error) {
 			"winusb: WinUsb_Initialize failed for VID_%04X&PID_%04X (current driver: %s%s — expected WinUSB; run Zadig and rebind Interface 0, see `gophertrunk sdr doctor`): %w",
 			d.VID, d.PID, fallbackString(svc, "unknown"), parens(descr), winErr(errno))
 	}
+	// Match libusb's WinUSB backend: explicitly disable the per-pipe
+	// transfer timeout on the control endpoint at open time
+	// (winusbx_configure_endpoints in libusb/os/windows_winusb.c sets
+	// PIPE_TRANSFER_TIMEOUT=0 on pipe 0 as part of claim_interface).
+	// WinUSB's documented default is 5000 ms — without this call the
+	// brief window between open and the first ControlOut would inherit
+	// that default. The lazy applyControlTimeout still overrides this
+	// to CtrlTimeoutMs on the first user-level transfer; this call is
+	// pure parity / hardening, not the issue #395 fix.
+	setControlPipeTimeout(ifaceHandle, 0)
 	return &winTransport{
 		fileHandle:  handle,
 		ifaceHandle: ifaceHandle,
 		desc:        d,
 	}, nil
+}
+
+// setControlPipeTimeout pushes a PIPE_TRANSFER_TIMEOUT policy on the
+// default control endpoint (pipe ID 0). Splitting this out lets both
+// Open (libusb-parity seed) and applyControlTimeout (mid-stream
+// override) share the same syscall shape without either reaching
+// into the other's locking. Errors are ignored — this is best-effort
+// hardening, and the next ControlOut would fail loudly anyway if the
+// handle were already invalid.
+func setControlPipeTimeout(ifaceHandle uintptr, timeoutMs uint32) {
+	procWinUsbSetPipePolicy.Call(
+		ifaceHandle,
+		0,
+		policyPipeTransferTimeout,
+		uintptr(unsafe.Sizeof(timeoutMs)),
+		uintptr(unsafe.Pointer(&timeoutMs)),
+	)
 }
 
 // winTransport is the WinUSB-backed [Transport].
@@ -226,14 +253,7 @@ func (t *winTransport) applyControlTimeout(timeoutMs int) {
 	}
 	t.lastCtlTimeout = v
 	t.timeoutMu.Unlock()
-	// Pipe ID 0 = the default control endpoint.
-	procWinUsbSetPipePolicy.Call(
-		t.ifaceHandle,
-		0,
-		policyPipeTransferTimeout,
-		uintptr(unsafe.Sizeof(v)),
-		uintptr(unsafe.Pointer(&v)),
-	)
+	setControlPipeTimeout(t.ifaceHandle, v)
 }
 
 func (t *winTransport) ControlIn(bRequest uint8, wValue, wIndex uint16, n int, timeoutMs int) ([]byte, error) {
@@ -398,8 +418,10 @@ func (t *winTransport) Reset() error {
 	}
 	t.fileHandle = handle
 	t.ifaceHandle = ifaceHandle
-	// The new ifaceHandle starts with WinUSB defaults — force the
-	// next applyControlTimeout to re-push our timeout policy.
+	// The new ifaceHandle starts with WinUSB defaults — re-seed the
+	// libusb-parity zero timeout on the control endpoint, then force
+	// the next applyControlTimeout to re-push our real timeout.
+	setControlPipeTimeout(ifaceHandle, 0)
 	t.timeoutMu.Lock()
 	t.lastCtlTimeout = 0
 	t.timeoutMu.Unlock()


### PR DESCRIPTION
The reporter's dongle works in SDR# and OP25 Boatbod (both libusb-based)
but fails 100% in gophertrunk: WarmupUSBSysctl succeeds, then the
byte-identical first InitBaseband write immediately returns
ERROR_GEN_FAILURE. The previous 5-attempt / 200-1200 ms inter-attempt
backoff (PR #398) did not help — every retry repeats the same tight
intra-attempt timing.

librtlsdr issues the same double-write pattern, but its libusb-1.0.dll →
winusb.dll → WinUSB.sys path naturally spaces transfers by hundreds of
microseconds. GopherTrunk's direct procWinUsbControlTransfer.Call is
several layers thinner, so on slow clone firmware the second write races
the first one's settle. runBringup now sleeps 10 ms between
WarmupUSBSysctl and InitBaseband to close that gap (tunable via the new
warmupSettleDuration package var so tests can pin it).

Also seeds PIPE_TRANSFER_TIMEOUT=0 on the control endpoint at WinUSB
open time, matching libusb's winusbx_configure_endpoints. Not the
#395 fix, just closes a parity gap that left the brief
post-WinUsb_Initialize window inheriting WinUSB's 5000 ms default.

Rewrites the ErrPipeStalled bring-up hint: drops the "unplug for 10s"
remediation the reporter already disproved, points at the new settle and
at `gophertrunk sdr doctor` for the WinUSB-binding check.

https://claude.ai/code/session_01V5LbSTjigzbaHswMRqHrKW