### PR TITLE
aprs: full Mic-E decoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@ for tagged releases.
 
 ### Added
 
+- **APRS Mic-E decoder.** Mobile-tracker packets (Kenwood TH-D74,
+  Yaesu FT-3D, vehicle trackers) compressed-encode position +
+  speed + course + altitude + a 3-bit message code across the
+  7-byte AX.25 destination address and a 9-byte info field — a
+  third the size of an uncompressed beacon, which is why every
+  mobile tracker emits it. `aprs.DecodeWithDst(info, dst)` walks
+  the Table 10.5 destination-char encoding (six latitude digits +
+  message bits + N/S + lon-offset + W/E), then the §10.4
+  speed/course interleaved encoding with the standard 800/400
+  wrap corrections, then the optional base-91 `XXX}` altitude
+  marker. Resulting `MicE` carries Latitude / Longitude / Speed
+  (knots) / Course (deg) / SymbolTable / SymbolCode / MessageCode
+  (`"M3 Returning"`, `"Emergency"`, custom-code variants) /
+  Standard (std vs custom range) / Altitude (m) / HasAltitude /
+  Comment. Latitude + Longitude also surface through the standard
+  `Position` field so the storage row, the `/api/v1/aprs/packets`
+  payload, and the `/aprs` panel pick the coordinates up without
+  special-casing Mic-E. The bit-stream orchestrator
+  (`aprs/receiver`) calls `DecodeWithDst` with the AX.25
+  destination call so the path is wired end-to-end. Spec: APRS
+  Protocol Reference 1.0.1 §10. Refreshes the `/aprs` panel
+  empty-state copy now that the DSP frontend has shipped.
 - **APRS DSP frontend — pipeline is now end-to-end.** Fifth and
   load-bearing slice of Phase 5 (#365 plan): the
   `internal/radio/aprs/afsk` package wires an `afsk.Receiver`

--- a/README.md
+++ b/README.md
@@ -73,12 +73,14 @@ Silicon and Intel. Full per-OS recipes at
   See [docs/pocsag.md](docs/pocsag.md).
 - **APRS / AX.25 packet** — end-to-end pipeline for the
   amateur-radio APRS metadata bus (position beacons, messages,
-  bulletins, status). Bell-202 AFSK DSP frontend (FM demod →
-  FFSK tone discriminator → symbol-time recovery → NRZI →
-  HDLC framer), AX.25 frame parser with CRC-16-CCITT, APRS
-  info-field decoders, plus `events.KindAPRSPacket` bus event,
-  SQLite `aprs_log`, `GET /api/v1/aprs/packets`, and `/aprs`
-  web panel. See [docs/aprs.md](docs/aprs.md).
+  bulletins, status, Mic-E mobile-tracker compressed format).
+  Bell-202 AFSK DSP frontend (FM demod → FFSK tone discriminator
+  → symbol-time recovery → NRZI → HDLC framer), AX.25 frame
+  parser with CRC-16-CCITT, APRS info-field decoders including
+  full Mic-E (lat/lon, speed, course, altitude, message code),
+  plus `events.KindAPRSPacket` bus event, SQLite `aprs_log`,
+  `GET /api/v1/aprs/packets`, and `/aprs` web panel.
+  See [docs/aprs.md](docs/aprs.md).
 - **Pure-Go voice path** — IMBE (P25 Phase 1) and AMBE+2 (P25
   Phase 2 / DMR) vocoders in Go, no DVSI / mbelib dependency.
   Per-call WAV + raw-frame sidecars; live PCM playback via direct

--- a/docs/aprs.md
+++ b/docs/aprs.md
@@ -81,8 +81,18 @@ payload the bus / log / REST / UI scaffolding above expects.
     `{seqno}`, `ack` / `rej` short-form) or bulletin
     (`BLN`-prefixed addressee → `Bulletin` struct)
   - `>` — status (free-text)
-  - `;` / `_` / `T#` / Mic-E — type-tagged with payloads
-    stashed for follow-up decoders
+  - `;` / `_` / `T#` — type-tagged with payloads stashed for
+    follow-up decoders
+  - **Mic-E** (0x1C / 0x1D / "`" / "'") — full decode of the
+    compressed mobile-tracker format that packs lat/lon, speed,
+    course, symbol code and table, message code (M0 Off Duty
+    through M7 Priority, plus Emergency and custom codes) into
+    the 7-byte AX.25 destination address + 9 bytes of info
+    field. Optional altitude trailer (`XXX}` base-91, meters
+    above sea level) decoded into the same `MicE` payload.
+    Surfaces lat/lon through the standard `Position` field so
+    the storage / REST / web-panel layers pick it up without
+    special-casing. Spec: APRS 1.0.1 §10.
   - anything else — `TypeUnknown`, raw bytes preserved
 - Position parsing covers both hemispheres (N/S, E/W), the
   spec's "ambiguity space" convention (low-precision digits as
@@ -155,9 +165,12 @@ skipped — same non-essential treatment as `paging.pocsag`.
   captured `.wav` / `.cfile` from a real APRS channel under
   `samples/aprs/` would let the test suite replay through
   `internal/sdr/baseband` and assert the full chain.
-- **Mic-E decoder.** Compressed lat/lon format common on mobile
-  trackers (Kenwood TH-D74, Yaesu FT-3D). ~200 LOC for base-91
-  unpacking + speed / course / altitude decode.
+- **Mic-E rich fields on the panel.** Speed, course, altitude,
+  and the human-readable message code (`M3 Returning`, etc.)
+  decode into the `MicE` struct but the storage row only carries
+  the standard `latitude` / `longitude` columns. Surfacing the
+  rich fields needs an `aprs_log` schema bump + REST DTO + a
+  new column on `/aprs`.
 - **Live map.** Position-bearing types have lat/lon — a
   Leaflet / MapLibre overlay on top of `/aprs` showing the most
   recent station fixes is an obvious next step once the panel

--- a/internal/radio/aprs/aprs.go
+++ b/internal/radio/aprs/aprs.go
@@ -111,6 +111,7 @@ type Packet struct {
 	Message  *Message
 	Status   *Status
 	Bulletin *Bulletin
+	MicE     *MicE
 	Raw      string
 }
 
@@ -333,7 +334,21 @@ func (p Packet) String() string {
 		}
 		return fmt.Sprintf("BULLETIN %s: %q", p.Bulletin.ID, p.Bulletin.Body)
 	case TypeMicE:
-		return "MIC-E (compressed; decoder pending)"
+		if p.MicE == nil {
+			return "MIC-E (destination unavailable)"
+		}
+		s := fmt.Sprintf("MIC-E %.4f,%.4f %s",
+			p.MicE.Latitude, p.MicE.Longitude, p.MicE.MessageCode)
+		if p.MicE.Speed != 0 || p.MicE.Course != 0 {
+			s += fmt.Sprintf(" %dkn @ %d°", p.MicE.Speed, p.MicE.Course)
+		}
+		if p.MicE.HasAltitude {
+			s += fmt.Sprintf(" alt=%dm", p.MicE.Altitude)
+		}
+		if p.MicE.Comment != "" {
+			s += fmt.Sprintf(" %q", p.MicE.Comment)
+		}
+		return s
 	case TypeWeather:
 		return "WEATHER " + p.Raw
 	case TypeTelemetry:

--- a/internal/radio/aprs/mice.go
+++ b/internal/radio/aprs/mice.go
@@ -1,0 +1,384 @@
+package aprs
+
+import (
+	"strings"
+)
+
+// MicE is the decoded payload of a Mic-E (Mic-Encoded) APRS packet
+// — the compressed lat/lon/speed/course format common on mobile
+// trackers (Kenwood TH-D74, Yaesu FT-3D, vehicle trackers). The
+// "Mic" originates with the Mic-Encoder, a 1990s plug-in for the
+// Kenwood TM-D700; it packs an APRS position into the 7-byte AX.25
+// destination address + 9 bytes of info field, a third the size
+// of an uncompressed beacon. That saves channel time, which is
+// why almost every mobile tracker uses it.
+//
+// Mic-E is a two-half codec:
+//
+//   - The AX.25 destination address (frame.Dst.Callsign, 6 ASCII
+//     chars) encodes six latitude digits (DDMMhh) plus three
+//     "message" bits, the N/S hemisphere, the longitude offset
+//     (+0° or +100°), and the E/W hemisphere.
+//   - The info field (starting at the DTI byte 0x1C / 0x1D / "'" /
+//     "`") encodes longitude (3 bytes), speed + course (3 bytes),
+//     symbol code + symbol table (2 bytes), and an optional
+//     altitude / comment trailer.
+//
+// Decoding the destination needs the AX.25 envelope, so the entry
+// point is DecodeWithDst(info, dst). The DTI-only Decode(info)
+// preserves the pre-Mic-E behaviour (Type=TypeMicE with the raw
+// bytes preserved on Raw).
+//
+// Spec reference: APRS Protocol Reference 1.0.1, Chapter 10.
+type MicE struct {
+	Latitude  float64
+	Longitude float64
+
+	// Speed in knots (0..799, biased / wrapped per spec).
+	Speed int
+	// Course in degrees (0..359, biased / wrapped per spec).
+	Course int
+
+	// SymbolTable + SymbolCode are the APRS symbol-set identifiers
+	// (e.g. "/" + ">" = car, "\\" + ">" = ambulance). See APRS
+	// Symbols spec for the full table.
+	SymbolTable byte
+	SymbolCode  byte
+
+	// MessageCode is the 3-bit message field decoded as a label
+	// ("M0 Off Duty", "M3 Returning", "Emergency", etc.). Custom
+	// codes from the A-K char range surface as "Custom-N".
+	MessageCode string
+
+	// Standard is true when the message-bit chars are all from the
+	// P-Z range (standard set), false when from A-K (custom set).
+	// Mixing the two ranges in the same packet is invalid per
+	// spec; we report whichever range the third byte falls in.
+	Standard bool
+
+	// Altitude in meters above sea level. Optional — present when
+	// the comment trailer contains the "XXX}" base-91 altitude
+	// marker. HasAltitude distinguishes "0 m" from "absent".
+	Altitude    int
+	HasAltitude bool
+
+	// Comment is the free-form text after the symbol bytes (and
+	// after the optional altitude marker, if any).
+	Comment string
+}
+
+// DecodeWithDst decodes one APRS info field and returns a typed
+// Packet. dst is the AX.25 destination callsign (frame.Dst.Callsign
+// — 6 ASCII chars, no SSID), required for Mic-E because half of
+// the Mic-E payload lives there. Pass nil / "" if the destination
+// is unavailable; Mic-E packets will then come back as
+// Type=TypeMicE with the raw bytes preserved on Raw (i.e. the same
+// behaviour as Decode).
+//
+// Never returns an error — unknown / malformed payloads come back
+// as Type=TypeUnknown with the raw bytes preserved on the Raw
+// field. APRS is messy; we surface what we can and pass through
+// the rest.
+func DecodeWithDst(info, dst []byte) Packet {
+	p := Decode(info)
+	if p.Type != TypeMicE || len(dst) < 6 {
+		return p
+	}
+	if mice, ok := parseMicE(info, dst); ok {
+		p.MicE = &mice
+		// Mic-E carries a position; surface it through the
+		// standard Position field too so existing callers
+		// (storage.APRSPacket.Latitude / .Longitude, the /aprs
+		// web panel) pick it up without special-casing the
+		// Mic-E shape.
+		p.Position = &Position{
+			Latitude:    mice.Latitude,
+			Longitude:   mice.Longitude,
+			SymbolTable: mice.SymbolTable,
+			SymbolCode:  mice.SymbolCode,
+			Comment:     mice.Comment,
+		}
+	}
+	return p
+}
+
+// parseMicE decodes a Mic-E (info, dst) pair. Returns false if the
+// payload is too short or the destination address is malformed.
+// Spec layout (APRS 1.0.1 §10):
+//
+//	dst[0..5]:   6 lat digits (DDMMhh) + 3 msg bits + N/S +
+//	             lon-offset + E/W
+//	info[0]:     DTI (0x1C / 0x1D / "`" / "'")
+//	info[1]:     longitude degrees + 28
+//	info[2]:     longitude minutes  + 28
+//	info[3]:     longitude hundredths-of-minute + 28
+//	info[4..6]:  speed / course (3 bytes, biased + interleaved)
+//	info[7]:     symbol code
+//	info[8]:     symbol table
+//	info[9..]:   optional altitude marker + comment
+func parseMicE(info, dst []byte) (MicE, bool) {
+	if len(info) < 9 || len(dst) < 6 {
+		return MicE{}, false
+	}
+	lat, msgBits, msgFromCustomRange, north, lonOff100, west, ok := parseMicEDest(dst[:6])
+	if !ok {
+		return MicE{}, false
+	}
+
+	// Longitude degrees: byte - 28 (then offset if +100°), with
+	// the printable-ASCII wraparound corrections from APRS101
+	// §10.5 (raw 180-189 → 100-109, raw 190-199 → 0-9).
+	lonDeg := int(info[1]) - 28
+	if lonOff100 {
+		lonDeg += 100
+	}
+	switch {
+	case lonDeg >= 180 && lonDeg <= 189:
+		lonDeg -= 80
+	case lonDeg >= 190 && lonDeg <= 199:
+		lonDeg -= 190
+	}
+
+	// Longitude minutes: byte - 28, biased into 60-69 by some
+	// implementations to keep the byte printable; collapse back
+	// to 0-9.
+	lonMin := int(info[2]) - 28
+	if lonMin >= 60 {
+		lonMin -= 60
+	}
+	lonHun := int(info[3]) - 28
+
+	lon := float64(lonDeg) + (float64(lonMin)+float64(lonHun)/100.0)/60.0
+	if west {
+		lon = -lon
+	}
+	if !north {
+		lat = -lat
+	}
+
+	// Speed + course interleaved encoding (see §10.4):
+	//
+	//	speed  = (sp_byte - 28) * 10 + (dc_byte - 28) / 10
+	//	course = ((dc_byte - 28) % 10) * 100 + (se_byte - 28)
+	//
+	// The 800/400 wrap corrections handle the bias offsets the
+	// printable-ASCII encoding introduces.
+	sp := int(info[4]) - 28
+	dc := int(info[5]) - 28
+	se := int(info[6]) - 28
+	speed := sp*10 + dc/10
+	course := (dc%10)*100 + se
+	if speed >= 800 {
+		speed -= 800
+	}
+	if course >= 400 {
+		course -= 400
+	}
+
+	out := MicE{
+		Latitude:    lat,
+		Longitude:   lon,
+		Speed:       speed,
+		Course:      course,
+		SymbolCode:  info[7],
+		SymbolTable: info[8],
+		MessageCode: micEMessageLabel(msgBits, msgFromCustomRange),
+		Standard:    !msgFromCustomRange,
+	}
+
+	// Optional altitude + comment after the symbol bytes. APRS101
+	// §10.6: altitude lives at the start of the comment as 3
+	// base-91 chars followed by "}", value = base91 - 10000 meters.
+	trailer := info[9:]
+	if alt, rest, hasAlt := extractMicEAltitude(trailer); hasAlt {
+		out.HasAltitude = true
+		out.Altitude = alt
+		out.Comment = string(rest)
+	} else {
+		out.Comment = string(trailer)
+	}
+
+	return out, true
+}
+
+// parseMicEDest decodes the 6-character AX.25 destination callsign
+// into its latitude / message-bit / hemisphere / lon-offset pieces.
+// Returns false if any character is out of range — Mic-E permits
+// only 0-9, A-Z (plus L and K as special "space" carriers).
+func parseMicEDest(dst []byte) (
+	latitude float64,
+	msgBits uint8,
+	msgFromCustomRange bool,
+	north bool,
+	lonOff100 bool,
+	west bool,
+	ok bool,
+) {
+	latDigits := [6]byte{}
+	hasCustom := false
+	hasStandard := false
+	for i := 0; i < 6; i++ {
+		c := dst[i]
+		digit, bit, std, custom, isLat := micEChar(c)
+		if !isLat {
+			return 0, 0, false, false, false, false, false
+		}
+		latDigits[i] = digit
+		switch i {
+		case 0, 1, 2:
+			// Top 3 chars carry the message-bit triplet.
+			if bit {
+				msgBits |= 1 << uint(2-i)
+			}
+			if custom {
+				hasCustom = true
+			}
+			if std {
+				hasStandard = true
+			}
+		case 3:
+			// N/S hemisphere — std/custom range → North, else
+			// South. The "bit" field doubles as the hemisphere
+			// indicator at this position.
+			if bit {
+				north = true
+			}
+		case 4:
+			// Longitude offset — std/custom range → +100°, else 0°.
+			if bit {
+				lonOff100 = true
+			}
+		case 5:
+			// W/E hemisphere — std/custom range → West, else East.
+			if bit {
+				west = true
+			}
+		}
+	}
+
+	// Per spec, a Mic-E with mixed custom + standard chars in the
+	// message-bit positions is malformed. Most receivers fall back
+	// to the standard label set; do the same and prefer "standard"
+	// when the third char is unambiguous.
+	msgFromCustomRange = hasCustom && !hasStandard
+
+	// Assemble latitude DDMM.hh from the 6 digits. Spaces (ambiguity
+	// digits) collapse to 0 — same convention as the uncompressed
+	// position parser.
+	for i := range latDigits {
+		if latDigits[i] == ' ' {
+			latDigits[i] = '0'
+		}
+	}
+	deg := int(latDigits[0]-'0')*10 + int(latDigits[1]-'0')
+	min := int(latDigits[2]-'0')*10 + int(latDigits[3]-'0')
+	hun := int(latDigits[4]-'0')*10 + int(latDigits[5]-'0')
+	latitude = float64(deg) + (float64(min)+float64(hun)/100.0)/60.0
+	ok = true
+	return
+}
+
+// micEChar decodes one Mic-E destination character per APRS101
+// §10.5 Table. Returns the latitude digit ('0'-'9' or ' '), the
+// indicator bit, whether the char is from the standard (P-Z)
+// range, whether it's from the custom (A-K) range, and whether
+// the char is a valid Mic-E destination char at all.
+//
+// The same "bit" doubles as the message bit (positions 0-2), the
+// N/S indicator (position 3), the lon-offset indicator (position
+// 4), and the W/E indicator (position 5) — the caller decides
+// which meaning applies based on position.
+func micEChar(c byte) (digit byte, bit, standard, custom, ok bool) {
+	switch {
+	case c >= '0' && c <= '9':
+		return c, false, false, false, true
+	case c >= 'A' && c <= 'J':
+		return c - 'A' + '0', true, false, true, true
+	case c == 'K':
+		return ' ', true, false, true, true
+	case c == 'L':
+		return ' ', false, false, false, true
+	case c >= 'P' && c <= 'Y':
+		return c - 'P' + '0', true, true, false, true
+	case c == 'Z':
+		return ' ', true, true, false, true
+	}
+	return 0, false, false, false, false
+}
+
+// micEMessageLabel maps the 3-bit message code to a human-readable
+// label per APRS101 §10.3 / 10.4. The std vs custom distinction
+// changes only the friendly name; emergency (all zeros) is shared
+// across both ranges.
+func micEMessageLabel(bits uint8, custom bool) string {
+	if bits == 0b000 {
+		return "Emergency"
+	}
+	if custom {
+		switch bits {
+		case 0b111:
+			return "M0 Custom-0"
+		case 0b110:
+			return "M1 Custom-1"
+		case 0b101:
+			return "M2 Custom-2"
+		case 0b100:
+			return "M3 Custom-3"
+		case 0b011:
+			return "M4 Custom-4"
+		case 0b010:
+			return "M5 Custom-5"
+		case 0b001:
+			return "M6 Custom-6"
+		}
+	}
+	switch bits {
+	case 0b111:
+		return "M0 Off Duty"
+	case 0b110:
+		return "M1 En Route"
+	case 0b101:
+		return "M2 In Service"
+	case 0b100:
+		return "M3 Returning"
+	case 0b011:
+		return "M4 Committed"
+	case 0b010:
+		return "M5 Special"
+	case 0b001:
+		return "M6 Priority"
+	}
+	return "Unknown"
+}
+
+// extractMicEAltitude scans the comment trailer for the optional
+// "XXX}" base-91 altitude marker. Per APRS101 §10.6, the three
+// base-91 chars are at the start of the trailer when the marker
+// is present; some implementations embed it after a leading
+// space-separated comment, so we scan up to the first "}".
+// Returns (altitude_m, remaining_comment_bytes, true) when found,
+// or (0, original, false) otherwise.
+func extractMicEAltitude(trailer []byte) (int, []byte, bool) {
+	// Look for the literal "}" with at least 3 chars preceding it.
+	closer := strings.IndexByte(string(trailer), '}')
+	if closer < 3 {
+		return 0, trailer, false
+	}
+	// Walk back 3 chars; require each to be a valid base-91 char
+	// (printable ASCII 33-123).
+	chars := trailer[closer-3 : closer]
+	for _, b := range chars {
+		if b < '!' || b > '{' {
+			return 0, trailer, false
+		}
+	}
+	value := int(chars[0]-'!')*91*91 + int(chars[1]-'!')*91 + int(chars[2]-'!')
+	altitude := value - 10000
+
+	// Stitch the rest of the comment together: anything before
+	// the 3 marker chars, plus anything after the "}".
+	rest := make([]byte, 0, len(trailer)-4)
+	rest = append(rest, trailer[:closer-3]...)
+	rest = append(rest, trailer[closer+1:]...)
+	return altitude, rest, true
+}

--- a/internal/radio/aprs/mice_test.go
+++ b/internal/radio/aprs/mice_test.go
@@ -1,0 +1,360 @@
+package aprs
+
+import (
+	"math"
+	"strings"
+	"testing"
+)
+
+// buildMicEInfo synthesises a Mic-E info field byte stream. Helper
+// for the table tests below — the tone of the spec layout makes
+// hand-rolled []byte literals hard to read.
+func buildMicEInfo(dti byte, lonDegRaw, lonMinRaw, lonHunRaw, sp, dc, se, symCode, symTable byte, trailer string) []byte {
+	out := []byte{dti, lonDegRaw, lonMinRaw, lonHunRaw, sp, dc, se, symCode, symTable}
+	out = append(out, []byte(trailer)...)
+	return out
+}
+
+func TestMicECharTableSpotChecks(t *testing.T) {
+	cases := []struct {
+		c          byte
+		wantDigit  byte
+		wantBit    bool
+		wantStd    bool
+		wantCustom bool
+		wantIsLat  bool
+	}{
+		{'0', '0', false, false, false, true},
+		{'9', '9', false, false, false, true},
+		{'A', '0', true, false, true, true},
+		{'J', '9', true, false, true, true},
+		{'K', ' ', true, false, true, true},
+		{'L', ' ', false, false, false, true},
+		{'P', '0', true, true, false, true},
+		{'Y', '9', true, true, false, true},
+		{'Z', ' ', true, true, false, true},
+		{'M', 0, false, false, false, false}, // M is in the gap between J and P; not a valid Mic-E char
+		{'_', 0, false, false, false, false},
+	}
+	for _, c := range cases {
+		digit, bit, std, custom, ok := micEChar(c.c)
+		if digit != c.wantDigit || bit != c.wantBit || std != c.wantStd ||
+			custom != c.wantCustom || ok != c.wantIsLat {
+			t.Errorf("micEChar(%q) = (digit=%q bit=%v std=%v custom=%v ok=%v), "+
+				"want (digit=%q bit=%v std=%v custom=%v ok=%v)",
+				c.c, digit, bit, std, custom, ok,
+				c.wantDigit, c.wantBit, c.wantStd, c.wantCustom, c.wantIsLat)
+		}
+	}
+}
+
+func TestMicEMessageLabels(t *testing.T) {
+	cases := []struct {
+		bits   uint8
+		custom bool
+		want   string
+	}{
+		{0b111, false, "M0 Off Duty"},
+		{0b110, false, "M1 En Route"},
+		{0b101, false, "M2 In Service"},
+		{0b100, false, "M3 Returning"},
+		{0b011, false, "M4 Committed"},
+		{0b010, false, "M5 Special"},
+		{0b001, false, "M6 Priority"},
+		{0b000, false, "Emergency"},
+		{0b000, true, "Emergency"}, // shared across std + custom
+		{0b111, true, "M0 Custom-0"},
+		{0b100, true, "M3 Custom-3"},
+	}
+	for _, c := range cases {
+		got := micEMessageLabel(c.bits, c.custom)
+		if got != c.want {
+			t.Errorf("micEMessageLabel(%03b, custom=%v) = %q, want %q",
+				c.bits, c.custom, got, c.want)
+		}
+	}
+}
+
+// TestParseMicEDestStandardNorth checks a clean standard-range
+// destination encoding a Northern / Western position with the M1
+// En Route message code (3-bit pattern 110).
+func TestParseMicEDestStandardNorth(t *testing.T) {
+	// Lat: 49° 03.50' N → DDMMhh = 49 03 50 = "490350"
+	// Std N/W message bits 1,1,0 in positions 0,1,2.
+	// Std N (pos 3 bit=1): P-Z range → use 'P' (digit 0) for tens of min
+	// Std +100° (pos 4 bit=1): P-Z range
+	// Std W (pos 5 bit=1): P-Z range
+	//
+	// Char picks:
+	//   pos 0: lat=4, msg bit 1 (std) → 'T' (P+4)
+	//   pos 1: lat=9, msg bit 1 (std) → 'Y' (P+9)
+	//   pos 2: lat=0, msg bit 0       → '0'
+	//   pos 3: lat=3, N flag set      → 'S' (P+3)
+	//   pos 4: lat=5, +100° set       → 'U' (P+5)
+	//   pos 5: lat=0, W flag set      → 'P'
+	dst := []byte("TY0SUP")
+	lat, msgBits, custom, north, lonOff100, west, ok := parseMicEDest(dst)
+	if !ok {
+		t.Fatal("parseMicEDest: !ok")
+	}
+	if math.Abs(lat-(49+3.5/60)) > 1e-6 {
+		t.Errorf("Latitude = %f, want ≈ 49.0583", lat)
+	}
+	if msgBits != 0b110 {
+		t.Errorf("msgBits = %03b, want 110", msgBits)
+	}
+	if custom {
+		t.Error("custom = true, want false (std range)")
+	}
+	if !north {
+		t.Error("north = false, want true")
+	}
+	if !lonOff100 {
+		t.Error("lonOff100 = false, want true")
+	}
+	if !west {
+		t.Error("west = false, want true")
+	}
+}
+
+// TestParseMicEDestSouthernEast covers the inverse: 0-9/L chars,
+// S/E hemispheres, no longitude offset.
+func TestParseMicEDestSouthernEast(t *testing.T) {
+	// Lat: 33° 27.50' S → DDMMhh = 33 27 50
+	// All 0-9/L chars (no flags set).
+	// pos 3: lat=2, S (no flag)        → '2'
+	// pos 4: lat=7, +0° (no flag)      → '7'
+	// pos 5: lat=0, E (no flag)        → '0'
+	dst := []byte("332750")
+	lat, msgBits, custom, north, lonOff100, west, ok := parseMicEDest(dst)
+	if !ok {
+		t.Fatal("parseMicEDest: !ok")
+	}
+	wantLat := 33 + 27.5/60
+	if math.Abs(lat-wantLat) > 1e-6 {
+		t.Errorf("Latitude = %f, want ≈ %f", lat, wantLat)
+	}
+	if msgBits != 0 {
+		t.Errorf("msgBits = %03b, want 000", msgBits)
+	}
+	if custom {
+		t.Error("custom = true, want false")
+	}
+	if north {
+		t.Error("north = true, want false (S)")
+	}
+	if lonOff100 {
+		t.Error("lonOff100 = true, want false")
+	}
+	if west {
+		t.Error("west = true, want false (E)")
+	}
+}
+
+func TestParseMicEDestRejectsInvalidChars(t *testing.T) {
+	// 'M' falls in the gap (J = end of A-J, P = start of P-Z), so
+	// it's not a valid Mic-E destination char.
+	dst := []byte("M99999")
+	if _, _, _, _, _, _, ok := parseMicEDest(dst); ok {
+		t.Error("parseMicEDest(M99999): want !ok, got ok")
+	}
+}
+
+func TestParseMicEDestAmbiguityDigits(t *testing.T) {
+	// 'L' carries digit ' ' (space) and 0-bit. Three Ls represent
+	// "low-precision" digits which the spec treats as 0.
+	dst := []byte("33LL00")
+	lat, _, _, _, _, _, ok := parseMicEDest(dst)
+	if !ok {
+		t.Fatal("parseMicEDest: !ok")
+	}
+	wantLat := 33 + 0.0
+	if math.Abs(lat-wantLat) > 1e-6 {
+		t.Errorf("Latitude with ambiguity digits = %f, want ≈ %f", lat, wantLat)
+	}
+}
+
+// TestParseMicEFullRoundTrip uses a known-good test vector adapted
+// from APRS101 §10 worked example: lat 33° 25.64' N, lon 112° 09.18' W,
+// speed 20 knots, course 251°, symbol code '>'  (car) on the
+// primary table. Standard set, M3 Returning (msg bits 100).
+func TestParseMicEFullRoundTrip(t *testing.T) {
+	// Build a destination encoding:
+	//   33 25 64 with M3 Returning (bits 1 0 0), N, +100°, W.
+	//   pos 0: lat=3, msg=1 → S (P+3)
+	//   pos 1: lat=3, msg=0 → '3'
+	//   pos 2: lat=2, msg=0 → '2'
+	//   pos 3: lat=5, N=1   → U (P+5)
+	//   pos 4: lat=6, +100  → V (P+6)
+	//   pos 5: lat=4, W=1   → T (P+4)
+	dst := []byte("S32UVT")
+
+	// Info: longitude 112° 09.18' W. With +100° offset:
+	//   lonDeg field raw value = 112 - 100 = 12  → byte = 12 + 28 = 40 = '('
+	//   lonMin field           = 9              → byte = 9 + 28  = 37 = '%'
+	//   lonHun field           = 18             → byte = 18 + 28 = 46 = '.'
+	// Speed 20 knots, course 251°:
+	//   sp = speed / 10 = 2     → byte = 2 + 28  = 30
+	//   dc = (speed % 10) * 10 + course/100 = 0*10 + 2 = 2 → byte = 2 + 28 = 30
+	//   se = course % 100 = 51  → byte = 51 + 28 = 79 = 'O'
+	// Symbol code '>' (car), table '/' (primary).
+	info := buildMicEInfo(
+		'`',                                 // DTI
+		byte(12+28),                         // lon deg
+		byte(9+28),                          // lon min
+		byte(18+28),                         // lon hun
+		byte(2+28), byte(2+28), byte(51+28), // sp / dc / se
+		'>', '/', // symbol code / table
+		"",
+	)
+
+	p := DecodeWithDst(info, dst)
+	if p.Type != TypeMicE {
+		t.Fatalf("Type = %v, want TypeMicE", p.Type)
+	}
+	if p.MicE == nil {
+		t.Fatal("MicE = nil, want non-nil")
+	}
+	wantLat := 33 + 25.64/60
+	if math.Abs(p.MicE.Latitude-wantLat) > 1e-4 {
+		t.Errorf("Latitude = %f, want ≈ %f", p.MicE.Latitude, wantLat)
+	}
+	wantLon := -(112 + 9.18/60)
+	if math.Abs(p.MicE.Longitude-wantLon) > 1e-4 {
+		t.Errorf("Longitude = %f, want ≈ %f", p.MicE.Longitude, wantLon)
+	}
+	if p.MicE.Speed != 20 {
+		t.Errorf("Speed = %d, want 20", p.MicE.Speed)
+	}
+	if p.MicE.Course != 251 {
+		t.Errorf("Course = %d, want 251", p.MicE.Course)
+	}
+	if p.MicE.MessageCode != "M3 Returning" {
+		t.Errorf("MessageCode = %q, want M3 Returning", p.MicE.MessageCode)
+	}
+	if !p.MicE.Standard {
+		t.Error("Standard = false, want true")
+	}
+	if p.MicE.SymbolCode != '>' || p.MicE.SymbolTable != '/' {
+		t.Errorf("Symbol = %c%c, want />", p.MicE.SymbolTable, p.MicE.SymbolCode)
+	}
+
+	// Also surfaces through the standard Position field so the
+	// receiver / storage layer can read lat/lon without
+	// special-casing Mic-E.
+	if p.Position == nil {
+		t.Fatal("Position = nil for Mic-E; want surfaced for downstream callers")
+	}
+	if math.Abs(p.Position.Latitude-wantLat) > 1e-4 {
+		t.Errorf("Position.Latitude = %f, want ≈ %f", p.Position.Latitude, wantLat)
+	}
+}
+
+func TestDecodeWithDstFallsBackWhenDstMissing(t *testing.T) {
+	// Mic-E packet but caller doesn't have the dst (e.g. an APRS
+	// log replay tool calling Decode directly). Type should stay
+	// TypeMicE, MicE should be nil, Position should be nil.
+	info := []byte("`Mic-E payload no dst")
+	p := DecodeWithDst(info, nil)
+	if p.Type != TypeMicE {
+		t.Errorf("Type = %v, want TypeMicE", p.Type)
+	}
+	if p.MicE != nil {
+		t.Errorf("MicE = %+v, want nil (dst missing)", p.MicE)
+	}
+	if p.Position != nil {
+		t.Errorf("Position = %+v, want nil", p.Position)
+	}
+}
+
+func TestDecodeWithDstNonMicEUnchanged(t *testing.T) {
+	// Non-Mic-E packets pass through unchanged regardless of dst.
+	info := []byte("!4903.50N/07201.75W-Test")
+	dst := []byte("APRS  ")
+	p := DecodeWithDst(info, dst)
+	if p.Type != TypePosition {
+		t.Errorf("Type = %v, want TypePosition", p.Type)
+	}
+	if p.MicE != nil {
+		t.Error("MicE = non-nil for position packet")
+	}
+}
+
+func TestExtractMicEAltitudeRoundTrip(t *testing.T) {
+	// APRS101 §10.6: altitude encoded as 3 base-91 chars + "}".
+	// value = (c0-33)*91*91 + (c1-33)*91 + (c2-33), altitude = value - 10000.
+	// 1000 m altitude → value = 11000 → c0=1, c1=29, c2=80
+	// (11000 = 1·8281 + 29·91 + 80). base-91 char N = '!' + N →
+	// c0='"', c1='>', c2='q'.
+	trailer := []byte(`">q}rest of comment`)
+	alt, rest, ok := extractMicEAltitude(trailer)
+	if !ok {
+		t.Fatal("extractMicEAltitude: !ok")
+	}
+	if alt != 1000 {
+		t.Errorf("altitude = %d, want 1000", alt)
+	}
+	if string(rest) != "rest of comment" {
+		t.Errorf("comment = %q, want %q", string(rest), "rest of comment")
+	}
+}
+
+func TestExtractMicEAltitudeAbsent(t *testing.T) {
+	// No "}" in trailer → altitude not present.
+	alt, rest, ok := extractMicEAltitude([]byte("just a normal comment"))
+	if ok {
+		t.Errorf("extractMicEAltitude(no marker): ok = true (alt=%d)", alt)
+	}
+	if string(rest) != "just a normal comment" {
+		t.Errorf("rest = %q, want trailer unchanged", string(rest))
+	}
+}
+
+func TestDecodeWithDstAttachesAltitudeFromComment(t *testing.T) {
+	// Mic-E packet whose comment trailer carries an altitude
+	// marker. Altitude should surface on the MicE struct.
+	dst := []byte("S32UVT")
+	// Same minimal info as the round-trip test, with the altitude
+	// marker appended as the trailer ("Dn} → 1000 m, no more
+	// comment text).
+	info := buildMicEInfo('`',
+		byte(12+28), byte(9+28), byte(18+28),
+		byte(2+28), byte(2+28), byte(51+28),
+		'>', '/',
+		`">q}`,
+	)
+	p := DecodeWithDst(info, dst)
+	if p.MicE == nil {
+		t.Fatal("MicE = nil")
+	}
+	if !p.MicE.HasAltitude {
+		t.Error("HasAltitude = false, want true")
+	}
+	if p.MicE.Altitude != 1000 {
+		t.Errorf("Altitude = %d, want 1000", p.MicE.Altitude)
+	}
+	if p.MicE.Comment != "" {
+		t.Errorf("Comment = %q, want empty (only altitude in trailer)", p.MicE.Comment)
+	}
+}
+
+func TestPacketStringRendersMicE(t *testing.T) {
+	dst := []byte("S32UVT")
+	info := buildMicEInfo('`',
+		byte(12+28), byte(9+28), byte(18+28),
+		byte(2+28), byte(2+28), byte(51+28),
+		'>', '/',
+		"",
+	)
+	p := DecodeWithDst(info, dst)
+	got := p.String()
+	if !strings.HasPrefix(got, "MIC-E ") {
+		t.Errorf("String() = %q, want MIC-E prefix", got)
+	}
+	if !strings.Contains(got, "M3 Returning") {
+		t.Errorf("String() = %q, want M3 Returning embedded", got)
+	}
+	if !strings.Contains(got, "20kn") {
+		t.Errorf("String() = %q, want 20kn speed embedded", got)
+	}
+}

--- a/internal/radio/aprs/receiver/receiver.go
+++ b/internal/radio/aprs/receiver/receiver.go
@@ -107,7 +107,7 @@ func (r *Receiver) Push(bit byte) {
 		return
 	}
 
-	pkt := aprs.Decode(frame.Info)
+	pkt := aprs.DecodeWithDst(frame.Info, []byte(frame.Dst.Callsign))
 	msg := storage.APRSPacket{
 		Src:     frame.Src.String(),
 		Dst:     frame.Dst.String(),

--- a/internal/radio/aprs/receiver/receiver_test.go
+++ b/internal/radio/aprs/receiver/receiver_test.go
@@ -171,6 +171,47 @@ func TestReceiverEmitsPositionPacket(t *testing.T) {
 	}
 }
 
+// TestReceiverEmitsMicEPacket exercises the Mic-E decode path: the
+// orchestrator hands the AX.25 destination callsign to
+// aprs.DecodeWithDst, so a Mic-E info field arrives with lat/lon
+// populated even though the position lives half in the destination
+// address. Verifies the bus event carries the decoded position so
+// the storage layer + /aprs panel get usable coordinates.
+func TestReceiverEmitsMicEPacket(t *testing.T) {
+	bus, sub := newTestBus(t)
+	r := New(Options{Bus: bus})
+
+	// Dst encodes lat 33° 25.64' N, +100° offset, W hemisphere,
+	// M3 Returning. Info encodes lon 112° 09.18' W, speed 20 kn,
+	// course 251°, car symbol on the primary table.
+	dst := "S32UVT"
+	info := []byte{
+		'`',     // DTI: Mic-E current GPS data
+		12 + 28, // lon deg (raw 12, +100° offset → 112)
+		9 + 28,  // lon min
+		18 + 28, // lon hun
+		2 + 28,  // sp
+		2 + 28,  // dc
+		51 + 28, // se
+		'>',     // symbol code (car)
+		'/',     // symbol table (primary)
+	}
+	body := buildAX25Body(dst, 0, "W1AW", 9, info)
+	bits := wrapHDLC(body)
+	pushAll(r, bits)
+
+	pkt := awaitPacket(t, sub)
+	if pkt.Type != "mic-e" {
+		t.Errorf("Type = %q, want mic-e", pkt.Type)
+	}
+	if pkt.Latitude < 33.4 || pkt.Latitude > 33.5 {
+		t.Errorf("Latitude = %f, want ≈ 33.42", pkt.Latitude)
+	}
+	if pkt.Longitude > -112.1 || pkt.Longitude < -112.2 {
+		t.Errorf("Longitude = %f, want ≈ -112.15", pkt.Longitude)
+	}
+}
+
 func TestReceiverEmitsMessagePacket(t *testing.T) {
 	bus, sub := newTestBus(t)
 	r := New(Options{Bus: bus})

--- a/web/src/panels/APRS.tsx
+++ b/web/src/panels/APRS.tsx
@@ -70,13 +70,13 @@ export function APRS() {
             {packets.length === 0 ? (
               <tr>
                 <td colSpan={5} className="px-3 py-4 text-center text-muted">
-                  No APRS packets yet. Tune an SDR to your local APRS
-                  channel (NA: 144.39 MHz · EU: 144.800 MHz · JP:
-                  144.64 MHz) and decoded packets will land here as
-                  they arrive. DSP wiring (1200 Bd Bell-202 AFSK →
-                  HDLC de-stuff → AX.25 frame) is the planned
-                  follow-up; once that ships, packets will flow
-                  end-to-end into this panel.
+                  No APRS packets yet. Add an{" "}
+                  <code className="text-accent">aprs.channels</code>{" "}
+                  entry to your config (NA primary: 144.39 MHz · EU R1:
+                  144.800 MHz · JP: 144.64 MHz · ISS: 145.825 MHz) and
+                  decoded packets — position beacons, messages,
+                  bulletins, status, Mic-E — will land here as they
+                  arrive.
                 </td>
               </tr>
             ) : (


### PR DESCRIPTION
## Summary

Mobile-tracker packets (Kenwood TH-D74, Yaesu FT-3D, vehicle
trackers) compressed-encode position + speed + course + altitude
+ a 3-bit message code across the 7-byte AX.25 destination
address and a 9-byte info field — a third the size of an
uncompressed beacon, which is why almost every mobile tracker
emits it. Previously the parser recognised the DTI byte but left
the payload undecoded.

### New: `aprs.DecodeWithDst(info, dst) Packet`

Walks the APRS101 §10 layout:

- **Destination char table (§10.5):** 6 latitude digits + 3
  message bits + N/S hemisphere + +0°/+100° longitude offset +
  W/E hemisphere. Custom (A-K) vs standard (P-Z) message-bit
  ranges decode to different labels.
- **Longitude** (info[1..3]): degrees / minutes / hundredths,
  each biased by 28 to keep printable-ASCII, with the §10.5
  wraparound corrections (180-189 → 100-109, 190-199 → 0-9,
  60-69 → 0-9 minutes).
- **Speed + course** (info[4..6]): interleaved encoding with the
  standard 800/400 wrap corrections.
- **Symbol code / table** (info[7..8]).
- **Optional altitude trailer:** 3 base-91 chars + `}`, value -
  10000 m. Comment text both before and after the marker
  preserved.

Resulting `MicE` carries `Latitude` / `Longitude` / `Speed` (knots) /
`Course` (deg) / `SymbolTable` / `SymbolCode` / `MessageCode`
(`"M3 Returning"`, `"Emergency"`, custom-code variants) /
`Standard` (std vs custom range) / `Altitude` (m) / `HasAltitude` /
`Comment`.

Latitude + Longitude also surface through the standard `Position`
field so the storage row, the `/api/v1/aprs/packets` payload, and
the `/aprs` panel pick the coordinates up **without special-casing
Mic-E**.

### Receiver wiring

The bit-stream orchestrator (`aprs/receiver`) now calls
`DecodeWithDst(frame.Info, []byte(frame.Dst.Callsign))`. The path
is wired end-to-end: AFSK frontend (#411) → HDLC framer → AX.25
parser → Mic-E decoder → bus event → `aprs_log` → REST → panel.

Backwards-compatible: `aprs.Decode(info)` still works for callers
without dst context (the Mic-E packet returns with `Type=TypeMicE`
and `MicE=nil`, the pre-this-PR shape).

### Web

Refreshes the `/aprs` panel empty-state copy now that the DSP
frontend has shipped (#411) — the stale "DSP wiring is the
planned follow-up" note no longer applies.

## Test plan

- [x] `go test ./internal/radio/aprs/...` — all packages pass
- [x] `go test ./internal/api/... ./internal/storage/...` — adjacent
  still pass
- [x] `npm test -- --run` — 97/97 web tests pass
- [x] `go vet ./...` clean
- [x] `gofmt -l` clean
- New tests cover:
  - §10.5 character-table spot-checks (digits, A-K range, K/L
    edges, P-Z range, gap chars rejected)
  - 8 message-code labels (M0-M6, Emergency, custom variants)
  - Destination-only decoding (standard vs custom, S/E
    hemispheres, ambiguity-space digits, invalid chars rejected)
  - Full worked example from APRS101 §10 (33° 25.64' N
    / 112° 09.18' W / 20 kn / 251° / M3 Returning / car
    symbol)
  - Altitude-marker round-trip (1000 m → `">q}`)
  - Receiver-level: a synthetic Mic-E frame drives through the
    HDLC framer + AX.25 parser + Mic-E decoder and the bus event
    carries lat/lon ≈ (33.42, -112.15)

## Still pending under Phase 5 (separate PRs)

- **Rich Mic-E fields on the panel.** Speed, course, altitude,
  and the human-readable message code decode into `MicE` but the
  `aprs_log` row only carries `latitude` / `longitude`. Surfacing
  the rich fields needs an `aprs_log` schema bump + REST DTO + a
  new column on `/aprs`.
- **Live map.** Position-bearing types now decode lat/lon
  including Mic-E. A Leaflet / MapLibre overlay on `/aprs`
  showing recent station fixes is the obvious next step.
- **Real-fixture validation.** Captured `samples/aprs/<x>.wav`
  replay through `internal/sdr/baseband` to assert the full
  chain.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YUgvat8WpF5YaSuEAqWMr2)_