### PR TITLE
trunking/composer: surface watchdog timing + suppress duplicate grants

### DIFF
--- a/internal/radio/p25/phase1/receiver/modes.go
+++ b/internal/radio/p25/phase1/receiver/modes.go
@@ -31,6 +31,20 @@ const (
 	DemodCQPSK
 )
 
+// String returns the canonical lowercase name for the mode, matching
+// the strings ParseDemodMode accepts so log lines round-trip back to
+// configuration values.
+func (m DemodMode) String() string {
+	switch m {
+	case DemodC4FM:
+		return "c4fm"
+	case DemodCQPSK:
+		return "cqpsk"
+	default:
+		return "unknown"
+	}
+}
+
 // ParseDemodMode maps a config / user-facing string into a DemodMode.
 // Recognised values (case-insensitive): "" / "c4fm" / "fm" → DemodC4FM
 // (the default — matches every previously-shipping config and the

--- a/internal/trunking/engine.go
+++ b/internal/trunking/engine.go
@@ -83,6 +83,13 @@ func NewEngine(opts EngineOptions) (*Engine, error) {
 	if opts.Now == nil {
 		opts.Now = time.Now
 	}
+	// Surface the resolved watchdog timeout once at startup so an operator
+	// can confirm from logs that the configured trunking.call_timeout_ms
+	// is the value the engine is actually using — issue #356 follow-up
+	// where a field log showed calls dying well under the configured
+	// 5 s, and there was no log line to verify what the engine had
+	// applied.
+	opts.Log.Info("engine: configured", "call_timeout", opts.CallTimeout)
 	e := &Engine{
 		bus:        opts.Bus,
 		log:        opts.Log,
@@ -189,6 +196,27 @@ func (e *Engine) HandleGrant(g Grant) {
 		if !scanned {
 			e.log.Debug("grant not in scan list", "grant", g.String())
 			return
+		}
+	}
+
+	// Suppress duplicate grants. The Phase 1 CC repeats voice-grant
+	// TSBKs while a call is active (the user's issue #356 log shows
+	// two grants for tg=32181 freq=773431250 arriving 20 ms apart),
+	// and without this guard the engine binds a second voice SDR to
+	// the same call — wasting a tuner, producing a duplicate WAV, and
+	// confusing the operator's view of which device is serving the
+	// call. Treat a repeat grant as the CC re-asserting "this call is
+	// still going" and refresh the existing bind's LastHeardAt. Skip
+	// when GroupID is zero (grants without a TG can legitimately
+	// share a frequency).
+	if g.GroupID != 0 {
+		for _, ac := range e.pool.Active() {
+			if ac.Grant.GroupID == g.GroupID && ac.Grant.FrequencyHz == g.FrequencyHz {
+				e.pool.Touch(ac.Device.Serial, e.now())
+				e.log.Debug("grant already active; refreshed",
+					"grant", g.String(), "device", ac.Device.Serial)
+				return
+			}
 		}
 	}
 
@@ -450,6 +478,18 @@ func (e *Engine) runWatchdog() {
 	cutoff := now.Add(-e.timeout)
 	for _, ac := range e.pool.Active() {
 		if ac.LastHeardAt.Before(cutoff) {
+			// Surface the exact timing the watchdog used before
+			// firing — issue #356 follow-up where a field log showed
+			// reason=timeout calls that didn't square with the
+			// configured trunking.call_timeout_ms, with no log to
+			// disambiguate which side of the comparison was wrong.
+			e.log.Debug("watchdog: reaping call",
+				"device", ac.Device.Serial,
+				"grant", ac.Grant.String(),
+				"last_heard_at", ac.LastHeardAt,
+				"now", now,
+				"elapsed", now.Sub(ac.LastHeardAt),
+				"timeout", e.timeout)
 			e.endCall(ac, EndReasonTimeout)
 		}
 	}

--- a/internal/trunking/engine_test.go
+++ b/internal/trunking/engine_test.go
@@ -431,6 +431,97 @@ func TestEngineWatchdogTimesOutSilentCall(t *testing.T) {
 	}
 }
 
+// TestEngineHandleGrantDeduplicatesDuplicateGrant covers the issue
+// #356 follow-up where the Phase 1 CC repeats voice-grant TSBKs while
+// the call is active. Before the dedup, the engine bound a second
+// voice SDR to the same TG/freq, producing duplicate WAV files and
+// tying up a tuner the operator needed for other grants. After the
+// fix the second grant refreshes the existing bind's LastHeardAt
+// (treating the repeat as the CC re-asserting "this call is still
+// going") and does not allocate a second device.
+func TestEngineHandleGrantDeduplicatesDuplicateGrant(t *testing.T) {
+	bus := events.NewBus(16)
+	defer bus.Close()
+	pool, tuners := mkPool(2)
+	clock := &fakeClock{t: time.Unix(1000, 0)}
+	e, _ := NewEngine(EngineOptions{
+		Bus:         bus,
+		VoicePool:   pool,
+		Talkgroups:  NewTalkgroupDB(),
+		CallTimeout: 5 * time.Second,
+		Now:         clock.Now,
+	})
+
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	g := Grant{System: "X", Protocol: "p25", GroupID: 32181, FrequencyHz: 773_431_250}
+	e.HandleGrant(g)
+	if got := len(e.ActiveCalls()); got != 1 {
+		t.Fatalf("first grant: active calls = %d, want 1", got)
+	}
+	firstHeard := e.ActiveCalls()[0].LastHeardAt
+	firstDevice := e.ActiveCalls()[0].Device.Serial
+
+	// Advance the clock so the dedup's Touch produces a distinguishable
+	// LastHeardAt and fire the identical grant. The second call must
+	// not allocate device #2 — only one tuner should ever be retuned.
+	clock.t = clock.t.Add(20 * time.Millisecond)
+	e.HandleGrant(g)
+
+	if got := len(e.ActiveCalls()); got != 1 {
+		t.Fatalf("after duplicate grant: active calls = %d, want 1", got)
+	}
+	if got := e.ActiveCalls()[0].Device.Serial; got != firstDevice {
+		t.Errorf("duplicate grant rebound device: got %q, want %q", got, firstDevice)
+	}
+	if got := e.ActiveCalls()[0].LastHeardAt; !got.After(firstHeard) {
+		t.Errorf("duplicate grant did not refresh LastHeardAt: got %v, want >%v", got, firstHeard)
+	}
+	// Verify the second device was never touched.
+	for i, tn := range tuners {
+		if i == 0 {
+			continue
+		}
+		if got := tn.tuned(); len(got) != 0 {
+			t.Errorf("device %d was retuned on duplicate grant: tuned=%v", i, got)
+		}
+	}
+
+	// Drain the bus and confirm exactly one CallStart was published —
+	// the second grant must not emit a second start event.
+	deadline := time.Now().Add(200 * time.Millisecond)
+	starts := 0
+	for time.Now().Before(deadline) {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind == events.KindCallStart {
+				starts++
+			}
+		case <-time.After(50 * time.Millisecond):
+		}
+	}
+	if starts != 1 {
+		t.Errorf("CallStart events = %d, want 1", starts)
+	}
+}
+
+// TestEngineHandleGrantAllowsDifferentFrequencyGrants is the
+// complement guard for the dedup: a same-TG grant on a different
+// frequency (rare but legitimate — e.g. site rebind on multi-site
+// systems) must NOT be suppressed.
+func TestEngineHandleGrantAllowsDifferentFrequencyGrants(t *testing.T) {
+	e, _, bus, _ := mkEngine(t, 2)
+	defer bus.Close()
+
+	e.HandleGrant(Grant{System: "X", Protocol: "p25", GroupID: 100, FrequencyHz: 851_000_000})
+	e.HandleGrant(Grant{System: "X", Protocol: "p25", GroupID: 100, FrequencyHz: 852_000_000})
+
+	if got := len(e.ActiveCalls()); got != 2 {
+		t.Errorf("active calls = %d, want 2 (different frequencies)", got)
+	}
+}
+
 func TestEngineRunDispatchesGrantEvents(t *testing.T) {
 	bus := events.NewBus(8)
 	defer bus.Close()

--- a/internal/voice/composer/p25p1_voice.go
+++ b/internal/voice/composer/p25p1_voice.go
@@ -65,6 +65,18 @@ func (c *Composer) runP25Phase1VoiceChain(ctx context.Context, serial string, iq
 
 	mode := c.resolveP25Phase1DemodMode(serial, demodMode)
 
+	// Surface the resolved demod mode + sample rates once per call so an
+	// operator can confirm from logs that voice grants are running the
+	// same demod mode the CC pipeline already prints at startup
+	// (ccdecoder: p25/phase1 pipeline configured demod=…). Issue #356
+	// follow-up: a field log showed the CC locked on cqpsk but gave no
+	// way to verify the voice chain wasn't silently still on c4fm.
+	// Mirrors the Phase 2 chain's "composer: p25p2 voice chain started"
+	// line.
+	c.log.Info("composer: p25p1 voice chain started",
+		"serial", serial, "demod_mode", mode,
+		"iq_rate_hz", iqHz, "symbol_rate_hz", symbolHz)
+
 	// Front-end LPF: doubles as the anti-aliasing filter for the
 	// decimation, so it is only needed when the IQ is actually
 	// decimated (decim == 1 only in tests that feed IQ already at the

--- a/internal/voice/composer/p25p1_voice_test.go
+++ b/internal/voice/composer/p25p1_voice_test.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"math"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -353,8 +354,8 @@ func TestComposerP25Phase1TouchGatedOnLDUProgress(t *testing.T) {
 // chain now emits one Info line at startup naming the resolved mode.
 func TestComposerP25Phase1VoiceChainLogsDemodMode(t *testing.T) {
 	const sampleRate = 48_000.0
-	var buf bytes.Buffer
-	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	buf := &syncBuffer{}
+	logger := slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
 
 	src := newFakeSource()
 	bus := events.NewBus(8)
@@ -408,4 +409,24 @@ func TestComposerP25Phase1VoiceChainLogsDemodMode(t *testing.T) {
 	if !strings.Contains(out, "demod_mode=cqpsk") {
 		t.Errorf("expected demod_mode=cqpsk in log; got:\n%s", out)
 	}
+}
+
+// syncBuffer is a bytes.Buffer guarded by a mutex so the test
+// goroutine can read the captured log output while the composer
+// chain goroutine concurrently writes to it via slog's handler.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
 }

--- a/internal/voice/composer/p25p1_voice_test.go
+++ b/internal/voice/composer/p25p1_voice_test.go
@@ -1,10 +1,12 @@
 package composer
 
 import (
+	"bytes"
 	"context"
 	"io"
 	"log/slog"
 	"math"
+	"strings"
 	"testing"
 	"time"
 
@@ -340,5 +342,70 @@ func TestComposerP25Phase1TouchGatedOnLDUProgress(t *testing.T) {
 	time.Sleep(300 * time.Millisecond)
 	if got := eng.touched.Load(); got != baseline {
 		t.Fatalf("expected no further touches after IQ stopped; baseline=%d got=%d", baseline, got)
+	}
+}
+
+// TestComposerP25Phase1VoiceChainLogsDemodMode is the operator-visible
+// diagnostic guard for issue #356: the CC pipeline logs the demod mode
+// it locked the control channel with, but until this log was added the
+// voice chain was silent — so on a field report it was impossible to
+// tell from logs whether voice grants were running c4fm or cqpsk. The
+// chain now emits one Info line at startup naming the resolved mode.
+func TestComposerP25Phase1VoiceChainLogsDemodMode(t *testing.T) {
+	const sampleRate = 48_000.0
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	src := newFakeSource()
+	bus := events.NewBus(8)
+	sink := &recordingSink{}
+	eng := &fakeEngine{}
+	c, err := New(Options{
+		Bus:           bus,
+		Log:           logger,
+		Devices:       &fakeDevices{src: map[string]IQSource{"VOICE-1": src}},
+		Sink:          sink,
+		Engine:        eng,
+		IQSampleRate:  uint32(sampleRate),
+		PCMSampleRate: 8000,
+		TouchInterval: 30 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go c.Run(ctx)
+	defer c.Close()
+	defer bus.Close()
+
+	bus.Publish(events.Event{
+		Kind: events.KindCallStart,
+		Payload: trunking.CallStart{
+			Grant: trunking.Grant{
+				System: "Simulcast-P25", Protocol: "p25",
+				GroupID: 42, FrequencyHz: 851_000_000,
+				P25Phase1DemodMode: "cqpsk",
+			},
+			DeviceSerial: "VOICE-1",
+			StartedAt:    time.Now().UTC(),
+		},
+	})
+
+	waitFor(t, 2*time.Second, func() bool { return len(c.ActiveChains()) == 1 })
+
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if strings.Contains(buf.String(), "composer: p25p1 voice chain started") {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "composer: p25p1 voice chain started") {
+		t.Fatalf("expected p25p1 startup log; got:\n%s", out)
+	}
+	if !strings.Contains(out, "demod_mode=cqpsk") {
+		t.Errorf("expected demod_mode=cqpsk in log; got:\n%s", out)
 	}
 }


### PR DESCRIPTION
Issue #356 follow-up. The user's v0.2.5 (sha cd3cf45) log shows two
voice SDRs both binding to tg=32181 freq=773431250 within 20 ms of
each other and both ending at the exact same instant ~600 ms later
with reason=timeout, despite trunking.call_timeout_ms: 5000 being
set. Two gaps made diagnosis impossible from logs alone, and one
latent bug visibly wasted a tuner per grant:

- The CC pipeline already logs the demod mode it locked with
  (ccdecoder: p25/phase1 pipeline configured demod=cqpsk), but the
  P25 Phase 1 voice chain logged nothing — so on a field report
  there was no way to verify voice grants were running the same
  mode. runP25Phase1VoiceChain now emits one Info line at chain
  entry naming the resolved demod_mode + sample rates, mirroring
  the Phase 2 chain's pattern from 8beaf15. p25p1rx.DemodMode also
  gets a String() so the field round-trips to "c4fm" / "cqpsk".

- The engine never logged the resolved CallTimeout, and the
  watchdog's reap published reason=timeout with no context (no
  LastHeardAt, no cutoff, no e.timeout). On the user's log we
  cannot tell whether the watchdog was actually the reaper or
  whether some other code path emitted timeout. NewEngine now
  logs the resolved call_timeout once at startup, and the
  watchdog logs the exact timing (last_heard_at, now, elapsed,
  timeout) at Debug before each reap.

- The Phase 1 CC repeats voice-grant TSBKs while a call is
  active, and HandleGrant had no "is this TG already actively
  bound on this freq?" check — so the engine bound a second
  voice SDR to the same call, producing a duplicate WAV and
  tying up a tuner the operator needed elsewhere. HandleGrant
  now treats a same-(TG, freq) repeat as the CC re-asserting
  "this call is still going" and refreshes the existing bind's
  LastHeardAt via VoicePool.Touch instead of allocating.
  Different-frequency same-TG grants (legitimate on multi-site
  systems) still allocate normally — covered by a complement
  test.

https://claude.ai/code/session_01Wd3QwYCiYJvgFgYc1MgtXt