### PR TITLE
Fix #422: build wideband voice taps before voice pool

### DIFF
--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -467,6 +467,15 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 		d.addWarning("trunking.systems configured but sdr.devices is empty — daemon has nothing to demodulate; add at least one device")
 	}
 
+	// Virtual voice taps on any `role: wideband` dongle, built before the
+	// voice pool (below) and the composer's virtualVoiceMap so a wideband-
+	// only topology actually has voice devices to follow grants with.
+	// Building these after the voice pool was the cause of issue #422
+	// (every grant dropped with "no voice SDR").
+	if err := d.buildVirtualVoiceTuners(cfg, log); err != nil {
+		return nil, err
+	}
+
 	// Metrics — constructed early so downstream components (notably
 	// the cc decoder's IQ-power gauge) can publish into it. Run +
 	// Close are still kicked off later from Daemon.Run / Daemon.Close
@@ -883,41 +892,10 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 				return nil, fmt.Errorf("daemon: widebandt2 %q: %w", devCfg.Serial, err)
 			}
 			d.widebandT2 = append(d.widebandT2, eng)
-			// Spin up virtual voice tuners on this wideband dongle so
-			// trunked voice grants whose frequency lands inside the
-			// IQ window can be followed without retuning a separate
-			// physical role: voice SDR. The taps subscribe to the
-			// dongle's iqtap broker on each StreamIQ call, run a
-			// single-tap DDC, and emit 48 kHz IQ to the composer.
-			// Out-of-window grants surface ErrOutOfBand and fall
-			// back to a physical voice SDR (when present) via the
-			// voice pool's bind retry.
-			taps := devCfg.VoiceTaps
-			if taps < 0 {
-				taps = 0
-			}
-			br := d.iqBrokers[entry.Info.Serial]
-			if br == nil && taps > 0 {
-				log.Warn("daemon: wideband: voice_taps requested but no iqtap broker; virtual voice disabled",
-					"serial", devCfg.Serial, "voice_taps", taps)
-				taps = 0
-			}
-			for i := 0; i < taps; i++ {
-				vt, err := wbvoice.New(wbvoice.Options{
-					Serial:           fmt.Sprintf("wb:%s:tap-%d", entry.Info.Serial, i),
-					Broker:           br,
-					WidebandCenterHz: devCfg.CenterFreqHz,
-					SDRSampleRateHz:  cfg.SDR.SampleRate,
-					Log:              log,
-				})
-				if err != nil {
-					return nil, fmt.Errorf("daemon: wbvoice %q tap %d: %w", devCfg.Serial, i, err)
-				}
-				d.virtualVoiceTuners = append(d.virtualVoiceTuners, vt)
-				log.Info("daemon: wideband: virtual voice tap registered",
-					"wideband_serial", entry.Info.Serial,
-					"tap_serial", vt.Serial())
-			}
+			// Virtual voice taps for this dongle are built earlier by
+			// buildVirtualVoiceTuners (before the voice pool and composer
+			// are constructed) so trunked grants inside the IQ window have
+			// a device to land on. See issue #422.
 		}
 	}
 
@@ -1730,6 +1708,61 @@ func (d *Daemon) spawn(ctx context.Context, name string, essential bool, fn func
 		}
 		d.log.Warn("daemon: component exited with error", "component", name, "err", err)
 	}()
+}
+
+// buildVirtualVoiceTuners spins up one wbvoice.VirtualTuner per voice tap
+// on every `role: wideband` dongle. The taps subscribe to the dongle's
+// iqtap broker on each StreamIQ call, run a single-tap DDC, and emit
+// 48 kHz IQ to the composer. Out-of-window grants surface ErrOutOfBand
+// and fall back to a physical voice SDR (when present) via the voice
+// pool's bind retry.
+//
+// This must run before the voice pool (collectVoiceDevices) and the
+// composer's virtualVoiceMap are built — otherwise a wideband-only
+// topology yields an empty voice pool and every grant is dropped with
+// "no voice SDR" (issue #422).
+func (d *Daemon) buildVirtualVoiceTuners(cfg config.Config, log *slog.Logger) error {
+	if d.pool == nil {
+		return nil
+	}
+	for _, devCfg := range cfg.SDR.Devices {
+		if devCfg.Role != "wideband" {
+			continue
+		}
+		entry := d.pool.FindBySerial(devCfg.Serial)
+		if entry == nil {
+			// The wideband engine loop logs the missing-dongle warning;
+			// stay quiet here to avoid duplicating it.
+			continue
+		}
+		taps := devCfg.VoiceTaps
+		if taps < 0 {
+			taps = 0
+		}
+		br := d.iqBrokers[entry.Info.Serial]
+		if br == nil && taps > 0 {
+			log.Warn("daemon: wideband: voice_taps requested but no iqtap broker; virtual voice disabled",
+				"serial", devCfg.Serial, "voice_taps", taps)
+			taps = 0
+		}
+		for i := 0; i < taps; i++ {
+			vt, err := wbvoice.New(wbvoice.Options{
+				Serial:           fmt.Sprintf("wb:%s:tap-%d", entry.Info.Serial, i),
+				Broker:           br,
+				WidebandCenterHz: devCfg.CenterFreqHz,
+				SDRSampleRateHz:  cfg.SDR.SampleRate,
+				Log:              log,
+			})
+			if err != nil {
+				return fmt.Errorf("daemon: wbvoice %q tap %d: %w", devCfg.Serial, i, err)
+			}
+			d.virtualVoiceTuners = append(d.virtualVoiceTuners, vt)
+			log.Info("daemon: wideband: virtual voice tap registered",
+				"wideband_serial", entry.Info.Serial,
+				"tap_serial", vt.Serial())
+		}
+	}
+	return nil
 }
 
 func (d *Daemon) collectVoiceDevices() []*trunking.VoiceDevice {

--- a/cmd/gophertrunk/wideband_voice_taps_test.go
+++ b/cmd/gophertrunk/wideband_voice_taps_test.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/config"
+	"github.com/MattCheramie/GopherTrunk/internal/sdr"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// fakeWidebandDriver enumerates a single streamingFakeDevice under a
+// fixed serial so a test can open a pool entry without real hardware.
+type fakeWidebandDriver struct{ dev *streamingFakeDevice }
+
+func (f *fakeWidebandDriver) Name() string { return "fakewb" }
+
+func (f *fakeWidebandDriver) Enumerate() ([]sdr.Info, error) {
+	return []sdr.Info{{Driver: "fakewb", Index: 0, Serial: f.dev.serial, Gains: []int{0}}}, nil
+}
+
+func (f *fakeWidebandDriver) Open(idx int) (sdr.Device, error) { return f.dev, nil }
+
+// TestWidebandOnlyConfigPopulatesVoicePool locks issue #422: a topology
+// with a single role:wideband dongle (no physical role:voice SDR) and
+// voice_taps > 0 must yield a non-empty voice pool. The bug was that
+// buildVirtualVoiceTuners ran *after* the voice pool and composer map
+// were constructed, so every grant dropped with "no voice SDR".
+func TestWidebandOnlyConfigPopulatesVoicePool(t *testing.T) {
+	const serial = "wb-issue422"
+	const centerHz = 859_837_500
+	const sampleRate = 2_400_000
+	const taps = 8
+
+	// Register a driver exposing our serial. Strict mode (engaged below)
+	// means any drivers leaked in by other tests in this package are
+	// skipped, so the global registry's additive nature is harmless.
+	sdr.Register(&fakeWidebandDriver{dev: newStreamingFake(serial)})
+
+	log := slog.New(slog.DiscardHandler)
+	cfg := config.Config{
+		SDR: config.SDRConfig{
+			SampleRate: sampleRate,
+			Devices: []config.DeviceConfig{{
+				Serial:       serial,
+				Role:         "wideband",
+				CenterFreqHz: centerHz,
+				VoiceTaps:    taps,
+			}},
+		},
+	}
+
+	d := &Daemon{pool: sdr.NewPool(log)}
+	if err := d.pool.OpenWith(sdr.PoolOpenOptions{
+		SampleRateHz: sampleRate,
+		Hints:        []sdr.Hint{{Serial: serial, Role: sdr.RoleWideband}},
+		Strict:       true,
+	}); err != nil {
+		t.Fatalf("pool open: %v", err)
+	}
+	d.wrapIQBrokers(cfg, log)
+
+	if err := d.buildVirtualVoiceTuners(cfg, log); err != nil {
+		t.Fatalf("buildVirtualVoiceTuners: %v", err)
+	}
+
+	if got := len(d.virtualVoiceTuners); got != taps {
+		t.Fatalf("virtualVoiceTuners = %d, want %d", got, taps)
+	}
+	if got := len(d.collectVoiceDevices()); got != taps {
+		t.Fatalf("collectVoiceDevices = %d, want %d (wideband-only pool must not be empty)", got, taps)
+	}
+	if got := len(d.virtualVoiceMap()); got != taps {
+		t.Fatalf("virtualVoiceMap = %d, want %d", got, taps)
+	}
+
+	// End-to-end angle: an in-window grant frequency from the issue must
+	// resolve to a tap; a clearly out-of-window one must not.
+	pool := trunking.NewVoicePool(d.collectVoiceDevices())
+	if free := pool.FindFreeForFrequency(859_237_500); free == nil {
+		t.Error("FindFreeForFrequency(859.2375 MHz, in-window) = nil, want a wideband tap")
+	}
+	if free := pool.FindFreeForFrequency(900_000_000); free != nil {
+		t.Errorf("FindFreeForFrequency(900 MHz, out-of-window) = %q, want nil", free.Serial)
+	}
+}


### PR DESCRIPTION
A topology with a single role:wideband dongle and voice_taps > 0 (no
physical role:voice SDR) dropped every trunked voice grant with
"dropping grant: no voice SDR", even when the grant frequency fell
inside the dongle's IQ window.

Root cause was initialization ordering in NewDaemon: the virtual voice
tuners were created inside the role:wideband engine loop, which runs
after both the voice pool (collectVoiceDevices) and the composer's
virtualVoiceMap are constructed. With no physical voice SDR, the pool
was built with zero devices, so engine.HandleGrant always hit the
"no voice SDR" path.

Extract tap creation into buildVirtualVoiceTuners and call it right
after the SDR pool / iqBrokers are ready, before the voice pool and
composer are built. Add a regression test covering the wideband-only
config from the issue.