### PR TITLE
Make voice-grant preemption frequency-aware (follow-up to #422)

### DIFF
--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -377,8 +377,11 @@ out-of-band and the engine binds a physical `role: voice` SDR
 instead — if one is configured. So a typical mixed setup keeps a
 single physical voice SDR around as the spillover fallback while the
 wideband dongle handles the in-window majority. With no physical
-voice SDR present, out-of-window grants drop with the standard
-"no voice device available" log (issue #379).
+voice SDR present, out-of-window grants are dropped and the daemon
+logs a one-shot warning that the grant frequency falls outside every
+voice device's tuning window — widen `sample_rate` or move
+`center_freq_hz` so the repeaters fit, or add a `role: voice` SDR to
+cover the spillover (issues #379, #422).
 
 CPU is roughly linear in `voice_taps`: each tap runs one NCO mixer +
 polyphase resampler at the SDR rate during its call's lifetime;

--- a/internal/trunking/engine.go
+++ b/internal/trunking/engine.go
@@ -34,6 +34,11 @@ type Engine struct {
 	// Subsequent grants on an empty pool drop at DEBUG. Reset when
 	// the engine is reconstructed (daemon reload / restart).
 	noVoiceSDROnce sync.Once
+	// noVoiceCoverageOnce gates the analogous warning for a pool that
+	// has voice devices but none whose tuning window covers the grant
+	// frequency — e.g. a wideband-only rig whose IQ window excludes the
+	// repeater. Logged once, then DEBUG per grant.
+	noVoiceCoverageOnce sync.Once
 
 	// scanMode is read under modeMu so the API cockpit can flip it at
 	// runtime without a daemon restart. HandleGrant takes a snapshot
@@ -229,25 +234,42 @@ func (e *Engine) HandleGrant(g Grant) {
 		e.startCall(free, g, tg)
 		return
 	}
-	// 2) All busy. Look at the lowest-priority active call.
-	victim := e.pool.LowestPriorityActive()
+	// 2) No free device can serve this frequency. Look at the lowest-
+	// priority active call *on a device that can tune the grant* —
+	// preempting a device whose window excludes the frequency would
+	// end an existing call to free a tuner that then can't bind the
+	// incoming grant.
+	victim := e.pool.LowestPriorityActiveForFrequency(g.FrequencyHz)
 	if victim == nil {
-		// FindFree() and LowestPriorityActive() both nil means the
-		// pool has zero devices — trunking is configured but no
-		// `role: voice` SDR is attached, so every grant is dropped.
-		// Log loudly once with the fix, then DEBUG for the rest of
-		// the daemon's life so we don't spam one WARN per grant.
+		// No capable device is busy with a preemptable call. Work out
+		// which of three situations we're in so the operator gets an
+		// actionable message instead of a misleading one.
 		if len(e.pool.Devices()) == 0 {
+			// Pool has zero devices — trunking is configured but no
+			// `role: voice` SDR (or wideband voice tap) is attached, so
+			// every grant is dropped. Log loudly once, then DEBUG for
+			// the rest of the daemon's life so we don't spam per grant.
 			e.noVoiceSDROnce.Do(func() {
-				e.log.Warn("no voice SDR available; voice grants will be dropped — add a role: voice device (see docs/hardware.md)",
+				e.log.Warn("no voice SDR available; voice grants will be dropped — add a role: voice device, or a role: wideband device with voice_taps (see docs/hardware.md)",
 					"grant", g.String())
 			})
 			e.log.Debug("dropping grant: no voice SDR", "grant", g.String())
 			return
 		}
-		// Devices > 0 but no actives recorded — should be
-		// unreachable: a busy device always contributes an active.
-		// Surface as Error so the bug is visible in logs.
+		if !e.pool.HasCapableDevice(g.FrequencyHz) {
+			// Devices exist but none can tune this frequency — e.g.
+			// every voice device is a wideband tap and the grant falls
+			// outside its IQ window. A coverage gap, not an engine bug.
+			e.noVoiceCoverageOnce.Do(func() {
+				e.log.Warn("voice grant frequency outside every voice device's tuning window; widen sdr.sample_rate / adjust center_freq_hz, or add a role: voice SDR (see docs/hardware.md)",
+					"grant", g.String())
+			})
+			e.log.Debug("dropping grant: no voice device covers frequency", "grant", g.String())
+			return
+		}
+		// A capable device exists, none is free (step 1 failed) and
+		// none is active — unreachable unless the active-tracking
+		// invariant broke. Surface as Error so the bug is visible.
 		e.log.Error("voice pool full but no actives (engine bug)", "grant", g.String())
 		return
 	}

--- a/internal/trunking/engine_test.go
+++ b/internal/trunking/engine_test.go
@@ -746,6 +746,100 @@ func TestEngineHandleCallSourceUpdateUnknownDeviceDoesNotPanic(t *testing.T) {
 	})
 }
 
+func TestEngineWidebandOnlyOutOfWindowGrantWarnsNotEngineBug(t *testing.T) {
+	// Issue #422 follow-up: a wideband-only pool (one frequency-
+	// constrained tap, no physical voice SDR) that receives a grant
+	// outside its IQ window must not log the misleading "voice pool
+	// full but no actives (engine bug)" Error. It's a coverage gap:
+	// warn once, drop the rest at DEBUG.
+	bus := events.NewBus(8)
+	defer bus.Close()
+	tap := &constrainedTuner{lo: 851_000_000, hi: 852_000_000}
+	pool := NewVoicePool([]*VoiceDevice{{Tuner: tap, Serial: "wb:dev:tap-0"}})
+
+	var buf bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	e, err := NewEngine(EngineOptions{
+		Bus: bus, Log: log, VoicePool: pool, Talkgroups: NewTalkgroupDB(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// 900 MHz is outside the tap's [851, 852] MHz window.
+	g := Grant{System: "X", Protocol: "p25", GroupID: 1, FrequencyHz: 900_000_000}
+	e.HandleGrant(g)
+	e.HandleGrant(g)
+	e.HandleGrant(g)
+
+	out := buf.String()
+	if strings.Contains(out, "engine bug") || strings.Contains(out, "voice pool full but no actives") {
+		t.Errorf("out-of-window grant mislogged as engine bug:\n%s", out)
+	}
+	if c := strings.Count(out, "level=WARN"); c != 1 {
+		t.Errorf("expected exactly one WARN, got %d:\n%s", c, out)
+	}
+	if !strings.Contains(out, "outside every voice device") {
+		t.Errorf("expected actionable coverage WARN:\n%s", out)
+	}
+	if c := strings.Count(out, `msg="dropping grant: no voice device covers frequency"`); c != 3 {
+		t.Errorf("expected 3 DEBUG drops, got %d:\n%s", c, out)
+	}
+	// The tap must never have been retuned to the out-of-window freq.
+	if len(tap.freqs) != 0 {
+		t.Errorf("constrained tap should not have been retuned, got %v", tap.freqs)
+	}
+}
+
+func TestEnginePreemptsFrequencyCapableDeviceNotLowestPriority(t *testing.T) {
+	// Issue #422 follow-up: preemption must target a device that can
+	// actually tune the incoming grant. Here the globally lowest-
+	// priority call sits on a wideband tap whose window excludes the
+	// grant; the engine must instead preempt the (higher-priority but
+	// frequency-capable) physical SDR, leaving the tap's call intact.
+	bus := events.NewBus(8)
+	defer bus.Close()
+	tap := &constrainedTuner{lo: 851_000_000, hi: 852_000_000}
+	phys := &fakeVoiceTuner{}
+	pool := NewVoicePool([]*VoiceDevice{
+		{Tuner: tap, Serial: "wb:dev:tap-0"}, // listed first; preferred in-window
+		{Tuner: phys, Serial: "phys-voice"},
+	})
+	e, err := NewEngine(EngineOptions{
+		Bus: bus, VoicePool: pool, Talkgroups: NewTalkgroupDB(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	e.talkgroups.Add(&TalkGroup{ID: 200, Priority: 9}) // tap call: lowest priority
+	e.talkgroups.Add(&TalkGroup{ID: 100, Priority: 5}) // phys call
+	e.talkgroups.Add(&TalkGroup{ID: 300, Priority: 1}) // incoming: high priority
+
+	// Bind the tap with an in-window call (group 200).
+	e.HandleGrant(Grant{System: "X", Protocol: "p25", GroupID: 200, FrequencyHz: 851_500_000})
+	// Bind the physical SDR with an out-of-tap-window call (group 100).
+	e.HandleGrant(Grant{System: "X", Protocol: "p25", GroupID: 100, FrequencyHz: 900_000_000})
+	// Incoming high-priority grant at 900 MHz — only the physical SDR
+	// can serve it. It must preempt the physical call (group 100), not
+	// the lower-priority tap call (group 200).
+	e.HandleGrant(Grant{System: "X", Protocol: "p25", GroupID: 300, FrequencyHz: 900_000_001})
+
+	byGroup := map[uint32]*ActiveCall{}
+	for _, ac := range e.ActiveCalls() {
+		byGroup[ac.Grant.GroupID] = ac
+	}
+	if _, ok := byGroup[200]; !ok {
+		t.Error("tap's group-200 call should still be active (tap can't serve 900 MHz)")
+	}
+	if _, ok := byGroup[100]; ok {
+		t.Error("physical's group-100 call should have been preempted")
+	}
+	c300, ok := byGroup[300]
+	if !ok || c300.Device.Serial != "phys-voice" {
+		t.Errorf("incoming group-300 call should be bound to phys-voice, got %+v", c300)
+	}
+}
+
 func TestEngineEmptyVoicePoolWarnsOnceThenDebug(t *testing.T) {
 	// Issue #379: a daemon with trunking systems but zero `role: voice`
 	// SDRs builds an empty VoicePool. Every grant used to log a

--- a/internal/trunking/voicepool.go
+++ b/internal/trunking/voicepool.go
@@ -134,6 +134,47 @@ func (p *VoicePool) LowestPriorityActive() *ActiveCall {
 	return lowest
 }
 
+// HasCapableDevice reports whether any device in the pool — busy or
+// free — can tune hz. A device with no FrequencyChecker (physical SDR)
+// counts as universally capable. The engine uses this to tell a
+// coverage gap (e.g. every voice device is a wideband tap whose IQ
+// window excludes hz) apart from a genuine all-busy or empty-pool
+// condition, so an out-of-window grant isn't mislogged as an engine bug.
+func (p *VoicePool) HasCapableDevice(hz uint32) bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for _, d := range p.devices {
+		if fc, ok := d.Tuner.(FrequencyChecker); ok && !fc.CanTune(hz) {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+// LowestPriorityActiveForFrequency returns the lowest-priority active
+// call among devices that can tune hz, or nil when no such device has
+// an active call. It mirrors LowestPriorityActive but skips devices
+// whose Tuner rejects hz — preempting one of those would end a call to
+// free a device that then can't bind the incoming grant. Physical SDRs
+// (no FrequencyChecker) are always eligible, so for a pool with no
+// frequency-constrained tuners this matches LowestPriorityActive.
+func (p *VoicePool) LowestPriorityActiveForFrequency(hz uint32) *ActiveCall {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	var lowest *ActiveCall
+	for _, ac := range p.active {
+		if fc, ok := ac.Device.Tuner.(FrequencyChecker); ok && !fc.CanTune(hz) {
+			continue
+		}
+		if lowest == nil ||
+			EffectivePriority(ac.Grant, ac.Talkgroup) > EffectivePriority(lowest.Grant, lowest.Talkgroup) {
+			lowest = ac
+		}
+	}
+	return lowest
+}
+
 // Bind retunes the device to grant.FrequencyHz and records an active call.
 // Returns an error if the device is already busy or the tune fails. When
 // SetReacquire is wired, a SetCenterFreq failure triggers one reacquire


### PR DESCRIPTION
## Context

Follow-up to #422 (merged in #423). Now that a wideband-only voice pool is actually populated with virtual taps, two latent edge cases in the engine's grant-dispatch path (`internal/trunking/engine.go`) became reachable. Both are fixed here. Physical-only pools are unaffected — they have no `FrequencyChecker` tuners, so behavior is identical to today.

## Problems

1. **False "engine bug" Error for out-of-window grants.** On a wideband-only rig, a grant outside the dongle's IQ window left `FindFreeForFrequency` nil with devices present and no active calls — hitting the `"voice pool full but no actives (engine bug)"` log at **Error** level. That path assumed a non-busy device is always tunable, which is false for frequency-checked taps.

2. **Frequency-blind preemption.** `LowestPriorityActive` could pick the globally lowest-priority call on a device whose window can't tune the incoming grant. The engine would *end* that call to free the tuner, which then fails to bind the grant (`ErrOutOfBand`) — losing an existing call for nothing.

## Changes

- Add `VoicePool.HasCapableDevice(hz)` and `VoicePool.LowestPriorityActiveForFrequency(hz)` so preemption only targets a device that can actually serve the grant frequency.
- Rework `HandleGrant` to distinguish three drop reasons:
  - empty pool → `"no voice SDR"` (unchanged),
  - **coverage gap** → `"no voice device covers frequency"` + a one-shot WARN pointing the operator at `sample_rate` / `center_freq_hz` or adding a `role: voice` SDR,
  - the genuine engine-bug case → now truly unreachable.
- Broaden the empty-pool WARN to mention wideband voice taps as a valid alternative.
- Update `docs/hardware.md` to describe the new out-of-window warning (the old text referenced the now-replaced generic message).

## Tests

- `TestEngineWidebandOnlyOutOfWindowGrantWarnsNotEngineBug` — out-of-window grant on a wideband-only pool warns once + drops at DEBUG, never logs "engine bug".
- `TestEnginePreemptsFrequencyCapableDeviceNotLowestPriority` — engine preempts the frequency-capable physical SDR and leaves the lower-priority-but-incapable tap call intact.

Verified with `go build ./...`, `go vet ./internal/trunking/`, and `go test -race ./internal/trunking/ ./cmd/gophertrunk/` — all green, existing tests included.

https://claude.ai/code/session_01EraDd9efWvwUd37c6GgqDz

---
_Generated by [Claude Code](https://claude.ai/code/session_01EraDd9efWvwUd37c6GgqDz)_