### PR TITLE
fix(p25/phase1): correct Motorola alias cipher stop recurrence

### DIFF
--- a/internal/radio/p25/phase1/motorola_alias_cipher.go
+++ b/internal/radio/p25/phase1/motorola_alias_cipher.go
@@ -16,9 +16,10 @@ package phase1
 //   lut   = motorolaAliasLUT[encoded_byte + 128]              // signed
 //   m1    = (int8)(lut − (accum >> 8))                        // signed
 //   m2    = 1
-//   stop  = (int8)(accum | 1)
+//   stop  = (int8)(accum | 1)        // always odd
+//   inc   = (int8)(stop << 1)        // 2·stop, computed once
 //   while stop != 1 and m2 != -1:
-//       stop = (int8)(stop × 3)
+//       stop = (int8)(stop + inc)    // walks stop·m2 for m2 = 1,3,5,...
 //       m2  += 2
 //   decoded_byte = (int8)(m1 × m2)
 //   accum = (accum + (encoded_byte & 0xFF) + 1) mod 65536
@@ -77,11 +78,17 @@ func decodeAliasBytes(encoded []byte) []byte {
 
 		var m2 int8 = 1
 		stop := int8(accum | 1)
-		// At most 128 iterations: m2 cycles through odd values
-		// 1, 3, 5, ..., 127, -127, -125, ..., -1. The (m2 != -1)
-		// guard guarantees termination even on pathological input.
+		// Walk stop·m2 (mod 256) for m2 = 1, 3, 5, ... by adding
+		// 2·stop_initial each iteration. Only the first iteration is
+		// equivalent to stop*3; subsequent iterations need a fixed
+		// addend, not another multiply, or stop drifts off the
+		// stop_initial·odd-integer track and the modular inverse is
+		// never hit. Since stop_initial is odd (accum|1), gcd with 256
+		// is 1, so a unique odd m2 in 1..255 satisfies stop == 1; the
+		// m2 != -1 guard remains as a belt-and-suspenders bound.
+		increment := stop << 1
 		for stop != 1 && m2 != -1 {
-			stop = int8(int(stop) * 3)
+			stop += increment
 			m2 += 2
 		}
 		decoded[i] = byte(int8(int(m1) * int(m2)))


### PR DESCRIPTION
## Summary

Re-implements the algorithmic fix from #420 — replace the multiplicative `stop = stop * 3` recurrence with the additive `stop += 2·stop_initial` form — with **accurate commentary** about what the original code actually does wrong.

## Why a new PR

#420 correctly identified that the loop's `stop * 3` step is the wrong recurrence, but described the bug as an "infinite loop / CPU hang." That's not what happens — the `m2 != -1` safety guard caps the loop at ~128 iterations on every input. The real bug is **wrong decoded bytes for ~50% of inputs**: the multiplicative form sends `stop` through the cyclic subgroup ⟨3⟩ mod 256, which covers only 64 of the 128 odd residues in (Z/256)*. For inputs whose modular inverse lives outside that subgroup, `stop == 1` is never reached, the safety guard fires instead, and `decoded_byte = -m1` (whatever m2 happens to be at exit) replaces the correct value.

I verified this empirically against every valid odd `stop_initial`:

| Form | Natural termination (`stop==1`) | Guard termination (`m2==-1`) |
|------|---:|---:|
| `stop *= 3` (current main) | 64 / 128 | 64 / 128 |
| `stop += 2·stop_initial` (this PR) | 127 / 128 | 1 / 128 |

The two forms produce different bytes for **125 of 128** odd `stop_initial` values, so this is a behavior change for real captures — that's the intent.

## Changes

- `decodeAliasBytes`: hoist `increment := stop << 1` before the loop, change `stop = int8(int(stop) * 3)` to `stop += increment`. Go's `+=` on `int8` is modular, so the explicit `int8(int(...))` dance from the original PR isn't needed.
- Update the algorithm pseudocode in the file header to reflect the additive recurrence.
- Replace the inline comment that previously described the guard, with one that explains *why* the additive form is correct and the multiplicative form isn't (and notes that the guard remains as a defensive bound, not as termination).

## Differences vs. #420

- **Comments don't claim "infinite loop."** The original code doesn't loop infinitely; the guard ensures termination. The comments here describe the actual bug (wrong output) and the correct algorithm.
- **Pseudocode block at top of file updated** so the documented algorithm matches the implementation.
- **Simpler loop body**: `stop += increment` instead of `stop = int8(int(stop) + int(increment))` — equivalent under Go's defined int8 wrap.

## What's not included (and why)

No pinned input→output regression test. `TestMotorolaCipherIsDeterministic` passes both before and after because it only checks determinism. A real lock-in test would need known-good output from a reference decoder (SDRTrunk / OP25 / DSD-FME); without source captures I didn't want to invent expected values.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./internal/radio/p25/phase1/...` clean
- [x] `go test ./internal/radio/p25/phase1/...` green (phase1 + receiver harness, ~5 min)
- [ ] Smoke-test against a real Motorola P25 capture — not done; would benefit from owner verification

## Breaking changes

None to the API. Decoded alias text will change for real captures that previously hit the buggy path (intended).

## Linked

Supersedes #420.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ARCAqZrt43znd5Ndiaorbn)_