### PR TITLE
trunking: distinguish carrier-drop natural end from silent-timeout (#356)

### DIFF
--- a/internal/trunking/engine.go
+++ b/internal/trunking/engine.go
@@ -57,8 +57,13 @@ type EngineOptions struct {
 	Log        *slog.Logger
 	VoicePool  *VoicePool
 	Talkgroups *TalkgroupDB
-	// CallTimeout is how long a call can run without a Touch before the
-	// watchdog ends it as EndReasonTimeout. Default 30 s.
+	// CallTimeout is how long a call can run without a Touch before
+	// the watchdog reaps it. Default 30 s. The end reason depends on
+	// whether the call ever decoded frames: EndReasonNormal when
+	// frames arrived and the carrier later dropped (P25's natural
+	// end-of-call mechanism, since the CC has no explicit channel
+	// release); EndReasonTimeout when no frames ever arrived (silent
+	// decode failure).
 	CallTimeout time.Duration
 	// Now is injectable for tests; defaults to time.Now.
 	Now func() time.Time
@@ -500,19 +505,35 @@ func (e *Engine) runWatchdog() {
 	cutoff := now.Add(-e.timeout)
 	for _, ac := range e.pool.Active() {
 		if ac.LastHeardAt.Before(cutoff) {
-			// Surface the exact timing the watchdog used before
-			// firing — issue #356 follow-up where a field log showed
-			// reason=timeout calls that didn't square with the
-			// configured trunking.call_timeout_ms, with no log to
-			// disambiguate which side of the comparison was wrong.
+			// Distinguish carrier-drop natural end from silent-from-
+			// start decode failure. P25 trunking has no explicit
+			// channel-release message on the CC for most calls, so
+			// the only natural end-of-call signal IS the grace
+			// timeout after the last LDU. A call whose LastHeardAt
+			// advanced past StartedAt received frames at least once
+			// — its end is "carrier dropped, watchdog reaped after
+			// the grace window" → EndReasonNormal. A call whose
+			// LastHeardAt is still equal to StartedAt never decoded
+			// a single frame → EndReasonTimeout (the real failure
+			// mode issue #356 wants to surface). Issue #356
+			// follow-up: a field log showed three healthy calls all
+			// reported as reason=timeout, leading the operator to
+			// believe the decode was still broken when it was
+			// actually a terminology problem.
+			reason := EndReasonTimeout
+			if ac.LastHeardAt.After(ac.StartedAt) {
+				reason = EndReasonNormal
+			}
 			e.log.Debug("watchdog: reaping call",
 				"device", ac.Device.Serial,
 				"grant", ac.Grant.String(),
 				"last_heard_at", ac.LastHeardAt,
+				"started_at", ac.StartedAt,
 				"now", now,
 				"elapsed", now.Sub(ac.LastHeardAt),
-				"timeout", e.timeout)
-			e.endCall(ac, EndReasonTimeout)
+				"timeout", e.timeout,
+				"reason", reason)
+			e.endCall(ac, reason)
 		}
 	}
 }

--- a/internal/trunking/engine_test.go
+++ b/internal/trunking/engine_test.go
@@ -403,10 +403,16 @@ loop:
 	}
 }
 
+// TestEngineWatchdogTimesOutSilentCall covers the true silent-decode
+// failure mode: a call that never received any frames (LastHeardAt
+// stayed at StartedAt) must reap as EndReasonTimeout — the
+// operator-actionable signal that the chain is broken.
 func TestEngineWatchdogTimesOutSilentCall(t *testing.T) {
 	bus := events.NewBus(8)
 	defer bus.Close()
 	pool, _ := mkPool(1)
+	sub := bus.Subscribe()
+	defer sub.Close()
 	now := time.Unix(1000, 0)
 	clock := &fakeClock{t: now}
 	e, _ := NewEngine(EngineOptions{
@@ -428,6 +434,83 @@ func TestEngineWatchdogTimesOutSilentCall(t *testing.T) {
 	e.runWatchdog()
 	if got := e.ActiveCalls(); len(got) != 0 {
 		t.Errorf("watchdog should have ended the call; active = %+v", got)
+	}
+
+	// Reason must be EndReasonTimeout — no Touch ever fired, so
+	// LastHeardAt is still equal to StartedAt.
+	end := drainCallEnd(t, sub, 500*time.Millisecond)
+	if end.Reason != EndReasonTimeout {
+		t.Errorf("CallEnd.Reason = %v, want EndReasonTimeout (no frames decoded)", end.Reason)
+	}
+}
+
+// TestEngineWatchdogReapsTouchedCallAsNormal covers the carrier-drop
+// natural-end case: a call that received at least one Touch (an LDU
+// was decoded) but then went quiet must reap as EndReasonNormal, not
+// EndReasonTimeout. P25 trunking has no explicit channel-release on
+// the CC for most calls, so this watchdog path IS how a healthy call
+// ends — the operator-visible "timeout" label was a terminology bug
+// that made v2maldo's field report read as a decode failure when the
+// decode was actually working (issue #356 follow-up).
+func TestEngineWatchdogReapsTouchedCallAsNormal(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	pool, _ := mkPool(1)
+	sub := bus.Subscribe()
+	defer sub.Close()
+	clock := &fakeClock{t: time.Unix(1000, 0)}
+	e, _ := NewEngine(EngineOptions{
+		Bus:         bus,
+		VoicePool:   pool,
+		Talkgroups:  NewTalkgroupDB(),
+		CallTimeout: 1 * time.Second,
+		Now:         clock.Now,
+	})
+
+	e.HandleGrant(Grant{GroupID: 200, FrequencyHz: 852_000_000})
+	if len(e.ActiveCalls()) != 1 {
+		t.Fatal("call did not start")
+	}
+	serial := e.ActiveCalls()[0].Device.Serial
+
+	// Simulate the composer delivering frames: advance the clock,
+	// fire Touch (mirrors what runP25Phase1VoiceChain does when the
+	// receiver's LDU sink fires). Then advance past the grace window
+	// without any further Touch and run the watchdog.
+	clock.t = clock.t.Add(100 * time.Millisecond)
+	e.Touch(serial)
+	clock.t = clock.t.Add(2 * time.Second)
+	e.runWatchdog()
+
+	if got := e.ActiveCalls(); len(got) != 0 {
+		t.Errorf("watchdog should have ended the call; active = %+v", got)
+	}
+	end := drainCallEnd(t, sub, 500*time.Millisecond)
+	if end.Reason != EndReasonNormal {
+		t.Errorf("CallEnd.Reason = %v, want EndReasonNormal (frames received then carrier dropped)", end.Reason)
+	}
+}
+
+// drainCallEnd pulls events off sub until it sees a CallEnd or the
+// deadline fires. Tests use it to assert the reason published with a
+// natural-end / silent-timeout reap.
+func drainCallEnd(t *testing.T, sub *events.Subscription, deadline time.Duration) CallEnd {
+	t.Helper()
+	timer := time.NewTimer(deadline)
+	defer timer.Stop()
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind == events.KindCallEnd {
+				ce, ok := ev.Payload.(CallEnd)
+				if !ok {
+					t.Fatalf("CallEnd payload type = %T", ev.Payload)
+				}
+				return ce
+			}
+		case <-timer.C:
+			t.Fatalf("no CallEnd event within %v", deadline)
+		}
 	}
 }
 

--- a/internal/trunking/grant.go
+++ b/internal/trunking/grant.go
@@ -108,12 +108,24 @@ func (g Grant) String() string {
 type EndReason uint8
 
 const (
-	EndReasonUnknown    EndReason = iota
-	EndReasonNormal               // CC announced channel release / talk-off
-	EndReasonTimeout              // engine watchdog fired (no recent activity)
-	EndReasonPreempted            // higher-priority grant kicked us off
-	EndReasonLockout              // talkgroup is locked out by policy
-	EndReasonNoVoiceSDR           // every Voice-role SDR was busy
+	EndReasonUnknown EndReason = iota
+	// EndReasonNormal is the carrier-drop natural end: either the CC
+	// announced a channel release / talk-off, or — far more common
+	// on P25 where no such announcement is ever sent — the watchdog
+	// reaped a call whose Touch advanced past StartedAt (frames were
+	// decoded and then the transmitter stopped). Operator-visible
+	// meaning: the call ended cleanly, no decode problem.
+	EndReasonNormal
+	// EndReasonTimeout is the silent-from-start decode failure: the
+	// watchdog reaped a call whose LastHeardAt never moved past
+	// StartedAt — not a single LDU / voice subframe was delivered.
+	// This is the real failure mode (wrong demod mode, gain too low,
+	// LSM site decoded as C4FM, etc.) — distinct from EndReasonNormal
+	// above, which fires when the radio simply stopped transmitting.
+	EndReasonTimeout
+	EndReasonPreempted  // higher-priority grant kicked us off
+	EndReasonLockout    // talkgroup is locked out by policy
+	EndReasonNoVoiceSDR // every Voice-role SDR was busy
 	EndReasonError
 	EndReasonManual // operator ended the call via API / TUI
 )


### PR DESCRIPTION
## Summary

Issue #356 follow-up. v2maldo's [debug-level log on v0.2.5 + PR #421's diagnostics](https://github.com/MattCheramie/GopherTrunk/issues/356#issuecomment-4567716692) shows the previous round of fixes was working: composer logs confirm `demod_mode=cqpsk`, the watchdog reap line shows the configured `timeout=5s`, the dedup is firing on every repeat, and — critically — `LastHeardAt` was being updated 8–11 s after `StartedAt`. LDUs *were* being delivered, Touch *was* being called, the chain decoded the simulcast voice. Three healthy calls all lived 8–16 s and then died with `reason=timeout`, which made the operator believe the decode was still broken.

The terminology was the actual bug. P25 trunking has no explicit channel-release on the CC for most calls, so the watchdog's grace timeout after the last LDU IS the natural end-of-call mechanism — every healthy call was ending as `reason=timeout`. The reason field collapsed two semantically distinct end states into one:

- **Carrier-drop natural end** — `LastHeardAt` advanced past `StartedAt` (frames decoded), then went quiet, watchdog reaped after the grace window. This is the *expected* P25 call end.
- **Silent-from-start failure** — `LastHeardAt` never moved past `StartedAt` (zero frames decoded), watchdog reaped after the grace window. This is the real failure mode #356 wants to surface (wrong demod mode, gain too low, LSM site decoded as C4FM).

`runWatchdog` now picks the reason based on `LastHeardAt` vs `StartedAt`: `EndReasonNormal` for "frames received then carrier dropped" (operator-visible: clean end, no problem), `EndReasonTimeout` reserved for "no frames ever decoded" (operator-visible: real decode failure to investigate). The existing watchdog Debug log gains a `started_at` field plus the chosen reason so the operator can see at-a-glance which path fired. Doc comments on `EndReasonNormal` / `EndReasonTimeout` and on `EngineOptions.CallTimeout` updated to match.

The only downstream consumer of `EndReasonTimeout` is the API mutation handler (`POST /api/v1/calls/{serial}/end` with `reason="timeout"`), which is operator-initiated classification — unaffected by this engine-internal semantic change. No metrics or counters key on the value.

## Test plan

- [x] `TestEngineWatchdogReapsTouchedCallAsNormal` — bind, Touch once, advance past timeout, run watchdog → assert `CallEnd.Reason == EndReasonNormal`
- [x] `TestEngineWatchdogTimesOutSilentCall` tightened to assert the silent-from-start path still publishes `EndReasonTimeout`
- [x] `go test -race -count=1 ./internal/trunking/... ./internal/voice/composer/...` — green
- [x] `go build ./cmd/gophertrunk` — green
- [x] `go vet` / `gofmt -l` on touched files — clean
- [ ] v2maldo's next field log: healthy carrier-drop calls show `reason=normal`; any remaining `reason=timeout` lines isolate the silent-decode failure mode

https://claude.ai/code/session_01Wd3QwYCiYJvgFgYc1MgtXt

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wd3QwYCiYJvgFgYc1MgtXt)_