### PR TITLE
p25/phase1: fix DDA-AFC handoff regression that froze a wrong carrier offset (#402)

### DIFF
--- a/cmd/gophertrunk/replay.go
+++ b/cmd/gophertrunk/replay.go
@@ -215,7 +215,7 @@ FLAGS:`)
 	var nextStateLogAt float64 = stateLogIntervalSec
 	logReceiverState := func(at float64) {
 		fmt.Fprintf(os.Stderr,
-			"replay: receiver state  t=%.2fs  afc_bias_rad_per_sample=%.6g  afc_hz_est=%.3f  agc_level=%.6g  agc_target=%.6g  agc_gain=%.4g  mm_mu=%.4f  mm_sps=%.2f\n",
+			"replay: receiver state  t=%.2fs  afc_bias_rad_per_sample=%.6g  afc_hz_est=%.3f  agc_level=%.6g  agc_target=%.6g  agc_gain=%.4g  mm_mu=%.4f  mm_sps=%.2f  dda_active=%t  dda_rearms=%d\n",
 			at,
 			rx.AFCBiasRadPerSample(),
 			rx.AFCBiasRadPerSample()*receiverRate/(2*math.Pi),
@@ -223,7 +223,9 @@ FLAGS:`)
 			rx.AGCTarget(),
 			ratioOrZero(rx.AGCTarget(), rx.AGCLevel()),
 			rx.MMClockMu(),
-			rx.MMClockSPS())
+			rx.MMClockSPS(),
+			rx.DDAActive(),
+			rx.DDARearms())
 	}
 
 	const chunkSamples = 8192

--- a/internal/dsp/demod/afc.go
+++ b/internal/dsp/demod/afc.go
@@ -112,6 +112,9 @@ type DecisionDirectedAFC struct {
 	dc                float64 // current bias estimate (rad/sample at input)
 	clampRadPerSample float64 // |dc| safety bound
 	gateNorm          float64 // skip updates with |residual_norm| > gateNorm
+
+	residMeanBeta float64 // smoothing coefficient for residMean
+	residMean     float64 // EMA of accepted residuals (normalised, signed)
 }
 
 // ddaSymbols is the DDA averaging time constant in symbol periods.
@@ -119,6 +122,14 @@ type DecisionDirectedAFC struct {
 // errors and short bursts of slicer overshoot without losing real
 // thermal-drift tracking on an RTL-SDR.
 const ddaSymbols = 1024
+
+// ddaResidMeanSymbols is the time constant (in accepted symbols) of the
+// running mean the receiver reads via AcceptedResidualMean to tell a
+// genuinely open eye (mean ≈ 0) from a uniformly-biased false lock
+// (sustained non-zero mean). Shorter than ddaSymbols so the estimate is
+// trustworthy by the time the handoff fires (~256 accepted updates).
+// Issue #402.
+const ddaResidMeanSymbols = 128
 
 // NewDecisionDirectedAFC builds a decision-directed tracker calibrated
 // for a slicer whose outer-symbol nominal value (in the post-AGC
@@ -142,6 +153,7 @@ func NewDecisionDirectedAFC(maxOffsetHz, sampleRateHz, slicerScaleNorm float64) 
 		beta:              1.0 / float64(ddaSymbols),
 		clampRadPerSample: 2.0 * math.Pi * maxOffsetHz / sampleRateHz,
 		gateNorm:          slicerScaleNorm / 3.0,
+		residMeanBeta:     1.0 / float64(ddaResidMeanSymbols),
 	}
 }
 
@@ -177,8 +189,21 @@ func (a *DecisionDirectedAFC) Update(softNorm, expectedNorm, agcUnscale float32)
 	} else if a.dc < -a.clampRadPerSample {
 		a.dc = -a.clampRadPerSample
 	}
+	// Track the running mean of accepted residuals (in normalised
+	// units). On correct decisions this is ~0 for any symbol
+	// distribution; a uniformly-biased eye that still slips inside the
+	// gate leaves a sustained non-zero mean — the signal a count-only
+	// handoff gate can't see. Issue #402.
+	a.residMean += a.residMeanBeta * (residualNorm - a.residMean)
 	return true
 }
+
+// AcceptedResidualMean returns the EMA of accepted residuals in the
+// post-AGC normalised space (signed). It is ~0 when decisions are
+// correct (the DDA's data-immunity premise) and trends toward the
+// slicer bias when the eye is uniformly off-centre — the receiver uses
+// it to refuse a handoff onto a biased false lock. Issue #402.
+func (a *DecisionDirectedAFC) AcceptedResidualMean() float64 { return a.residMean }
 
 // Apply subtracts the current bias estimate from buf in place. Called
 // once per matched-filter buffer alongside CoarseAFC's correction.
@@ -208,4 +233,7 @@ func (a *DecisionDirectedAFC) AddOffset(v float64) {
 }
 
 // Reset clears the estimate. Call on stream re-tune.
-func (a *DecisionDirectedAFC) Reset() { a.dc = 0 }
+func (a *DecisionDirectedAFC) Reset() {
+	a.dc = 0
+	a.residMean = 0
+}

--- a/internal/dsp/demod/afc_test.go
+++ b/internal/dsp/demod/afc_test.go
@@ -203,6 +203,77 @@ func TestDDAClampHolds(t *testing.T) {
 	}
 }
 
+// TestDDAAcceptedResidualMeanZeroOnCorrectDecisions: when every
+// decision is correct (soft == expected) the mean accepted residual
+// stays ~0 for any symbol distribution — the property the receiver
+// relies on to tell a real lock from a biased false lock. Issue #402.
+func TestDDAAcceptedResidualMeanZeroOnCorrectDecisions(t *testing.T) {
+	const (
+		slicerScale = 0.2356
+		sampleRate  = 48000.0
+		maxOffset   = 25000.0
+	)
+	dda := NewDecisionDirectedAFC(maxOffset, sampleRate, slicerScale)
+
+	// Heavily unbalanced symbol stream, but every decision correct.
+	syms := []float64{slicerScale, slicerScale, slicerScale, -slicerScale / 3}
+	for i := 0; i < 8*ddaSymbols; i++ {
+		s := float32(syms[i%len(syms)])
+		dda.Update(s, s, 1.0)
+	}
+	if math.Abs(dda.AcceptedResidualMean()) > 1e-6 {
+		t.Errorf("AcceptedResidualMean() = %v on correct decisions, want ~0", dda.AcceptedResidualMean())
+	}
+}
+
+// TestDDAAcceptedResidualMeanNonzeroOnBiasedEye: a uniformly-biased
+// eye whose residuals still land inside the gate leaves a sustained
+// non-zero mean tracking the bias — the signal a count-only handoff
+// gate misses and that drove the stable-but-wrong lock in issue #402.
+func TestDDAAcceptedResidualMeanNonzeroOnBiasedEye(t *testing.T) {
+	const (
+		slicerScale = 0.2356
+		sampleRate  = 48000.0
+		maxOffset   = 25000.0
+	)
+	dda := NewDecisionDirectedAFC(maxOffset, sampleRate, slicerScale)
+
+	// Bias inside the gate (gate = slicerScale/3).
+	bias := slicerScale / 6.0
+	syms := []float64{slicerScale, slicerScale / 3, -slicerScale / 3, -slicerScale}
+	for i := 0; i < 8*ddaSymbols; i++ {
+		expected := float32(syms[i%4])
+		soft := float32(syms[i%4] + bias)
+		if !dda.Update(soft, expected, 1.0) {
+			t.Fatalf("within-gate biased residual was rejected at i=%d", i)
+		}
+	}
+	if got := dda.AcceptedResidualMean(); math.Abs(got-bias) > 0.05*bias {
+		t.Errorf("AcceptedResidualMean() = %.5f, want within 5%% of bias %.5f", got, bias)
+	}
+}
+
+// TestDDAResetClearsResidualMean confirms Reset wipes the accepted-
+// residual-mean accumulator alongside the integrator.
+func TestDDAResetClearsResidualMean(t *testing.T) {
+	const (
+		slicerScale = 0.2356
+		sampleRate  = 48000.0
+		maxOffset   = 25000.0
+	)
+	dda := NewDecisionDirectedAFC(maxOffset, sampleRate, slicerScale)
+	for i := 0; i < ddaSymbols; i++ {
+		dda.Update(float32(slicerScale/6), 0, 1.0)
+	}
+	if dda.AcceptedResidualMean() == 0 {
+		t.Fatal("AcceptedResidualMean() = 0 after biased updates, want non-zero")
+	}
+	dda.Reset()
+	if dda.AcceptedResidualMean() != 0 {
+		t.Errorf("AcceptedResidualMean() = %v after Reset, want 0", dda.AcceptedResidualMean())
+	}
+}
+
 // TestNewDecisionDirectedAFCRejectsBadArgs documents the constructor
 // preconditions — symmetric with TestNewCoarseAFCRejectsBadSps.
 func TestNewDecisionDirectedAFCRejectsBadArgs(t *testing.T) {

--- a/internal/radio/p25/phase1/receiver/receiver.go
+++ b/internal/radio/p25/phase1/receiver/receiver.go
@@ -78,7 +78,39 @@ const ddaHandoffSymbols = 256
 // 0.157 outer threshold), the wrong-decision residual lands inside
 // the DDA's gate, and the contaminated estimate breaks lock once it
 // folds into the post-handoff loop. Issue #402.
+//
+// Once warmup completes the receiver freezes CoarseAFC (subtract-only)
+// for the whole learning window so the eye is stationary while the DDA
+// integrates: the handoff then folds in exactly the CoarseAFC value the
+// DDA learned against, with no "instantaneous − average" error. The
+// earlier code kept CoarseAFC adapting through the learning window, so
+// the fold-in captured a wandering data-mean value and the DDA settled
+// onto a stable-but-wrong offset that broke lock (issue #402 regression
+// after the first DDA cut).
 const ddaWarmupSymbols = 512
+
+// Handoff is committed only when the eye also looks genuinely open, not
+// just when enough within-gate updates have accrued: a uniformly-biased
+// eye still produces within-gate ("accepted") residuals, so the count
+// alone can't tell a real lock from a biased false lock. Issue #402.
+const (
+	// ddaHandoffMinAcceptRate is the minimum fraction of learning-window
+	// symbols that must land inside the DDA gate before handoff. Catches
+	// a grossly-broken eye (many out-of-gate decisions); the residual-
+	// mean test catches the subtler within-gate bias.
+	ddaHandoffMinAcceptRate = 0.66
+
+	// ddaMaxDriftHz bounds how far the DDA's estimate may wander from the
+	// value it carried at handoff before the receiver reverts to
+	// CoarseAFC-alone. A locked transmitter's residual drift is a tuner-
+	// ppm affair (tens to low hundreds of Hz); a DDA that walks kilohertz
+	// away from a gate-verified handoff is tracking something it
+	// shouldn't, so falling back to the open-loop tracker can only help.
+	// This is the reversibility guarantee: the post-handoff error is
+	// bounded by the handoff gate plus this drift, so the DDA can never
+	// strand the receiver below the pre-DDA behaviour. Issue #402.
+	ddaMaxDriftHz = 4000.0
+)
 
 // P25 Phase 1 on-air parameters.
 const (
@@ -185,8 +217,15 @@ type Receiver struct {
 	clock            *sync.MuellerMuller
 	agc              c4fmSymbolAGC
 	ddaNominal       [4]float32 // post-AGC nominal value for sliced ±1, ±3
+	ddaResidMeanGate float64    // max |AcceptedResidualMean| for handoff (slicerScale units)
+	ddaMaxDrift      float64    // max |DDA − handoff estimate| before re-arm (rad/sample)
+	ddaLearning      bool       // true once the DDA is integrating: CoarseAFC frozen (subtract-only)
 	ddaActive        bool       // true after handoff: afc frozen, dda carries the estimate
-	ddaValidUpdates  int        // accepted-update count; when it crosses ddaHandoffSymbols the handoff fires
+	ddaValidUpdates  int        // accepted-update count this learning attempt; crossing ddaHandoffSymbols arms the handoff
+	ddaTotalUpdates  int        // total DDA updates this learning attempt; with ddaValidUpdates gives the accept-rate
+	ddaWarmupDoneAt  int        // c4fmSymbolsTotal at which learning may (re)start; bumped on a watchdog re-arm
+	afcAtHandoff     float64    // total AFC estimate the DDA carried at handoff; the watchdog bounds drift from this
+	ddaRearms        int        // number of watchdog re-arms (diagnostic)
 	c4fmSymbolsTotal int        // symbols processed; the DDA waits ddaWarmupSymbols of these before learning
 
 	// CQPSK / LSM path: complex RRC + Gardner + DQPSK quadrant
@@ -320,6 +359,16 @@ func New(opts Options) *Receiver {
 				float32(+slicerScale / 3), // sliced = +1
 				float32(+slicerScale),     // sliced = +3
 			}
+			// Refuse a handoff when the mean accepted residual sits
+			// further than an eighth of the slicer scale off zero —
+			// a quarter of the gate (slicerScale/3). A converged,
+			// correctly-decided eye sits well inside this; a
+			// uniformly-biased false lock does not. Issue #402.
+			r.ddaResidMeanGate = slicerScale / 8.0
+			// Drift bound in matched-filter output units (same sps-gain
+			// scale as the CoarseAFC/DDA estimates — see the clamp).
+			r.ddaMaxDrift = 2.0 * math.Pi * ddaMaxDriftHz * sps / opts.SampleRateHz
+			r.ddaWarmupDoneAt = ddaWarmupSymbols
 		}
 	}
 	if opts.Sink != nil {
@@ -345,14 +394,25 @@ func (r *Receiver) Process(iq []complex64) {
 	} else {
 		r.disc = r.fm.Process(r.disc, iq)
 		r.matched = r.mf.MatchedFilter(r.matched, r.disc)
+		// Freeze CoarseAFC the moment the DDA is eligible to learn
+		// (warmup complete, AGC seeded). Once frozen the eye is
+		// stationary for the whole learning window, so the value
+		// folded into the DDA at handoff is exactly the one the DDA
+		// learned against — no wandering-data-mean error. Latched
+		// here, before the CoarseAFC step, so the freeze takes effect
+		// from the first learning batch. Issue #402.
+		if r.dda != nil && !r.ddaActive && !r.ddaLearning &&
+			r.agc.seeded && r.agc.target > 0 && r.c4fmSymbolsTotal >= r.ddaWarmupDoneAt {
+			r.ddaLearning = true
+		}
 		// Coarse AFC: track and subtract the residual carrier-offset
 		// DC bias before the symbol clock + slicer see it, so a real
 		// tuner's frequency error doesn't shift the 4-level eye off
-		// the slicer's fixed thresholds (issue #275). Once the DDA
-		// has handed off (issue #402), CoarseAFC is frozen at zero
-		// — Subtract is a no-op then — and the DDA carries the
-		// estimate via its Apply call below.
-		if r.ddaActive {
+		// the slicer's fixed thresholds (issue #275). While the DDA is
+		// learning or has handed off (issue #402), CoarseAFC is frozen
+		// — Subtract keeps removing its held value while the DDA
+		// carries any further drift via its Apply call below.
+		if r.ddaActive || r.ddaLearning {
 			r.afc.Subtract(r.matched)
 		} else {
 			r.afc.Process(r.matched)
@@ -364,11 +424,11 @@ func (r *Receiver) Process(iq []complex64) {
 		if len(r.symbols) == 0 {
 			return
 		}
-		// Snapshot the AGC's pre-process level so the DDA's
-		// un-normalisation matches the gain *this* batch was
-		// scaled by, not the gain the next sample is about to see.
-		// AGC.process mutates level in place per sample.
-		r.agc.process(r.symbols)
+		// agcLevel is the mean gain level this batch was actually
+		// scaled against (process mutates level per sample), so the
+		// DDA's un-normalisation matches the gain its residuals were
+		// formed under rather than the next sample's gain. Issue #402.
+		agcLevel := r.agc.process(r.symbols)
 		if r.softSink != nil {
 			r.softSink(r.symbols)
 		}
@@ -381,37 +441,60 @@ func (r *Receiver) Process(iq []complex64) {
 		for i, sym := range r.sliced {
 			r.dibits[i] = phase1.SymbolToDibit(sym)
 		}
-		// Decision-directed AFC update + handoff. Three gates:
+		// Decision-directed AFC update, handoff, and watchdog. Gates
+		// for learning:
 		//
-		//   - c4fmSymbolsTotal ≥ ddaWarmupSymbols: CoarseAFC has
-		//     had time to converge; before that, the slicer
-		//     mis-decides inner symbols at any offset above ~1 kHz
-		//     and the DDA would learn from those wrong-decision
-		//     residuals.
-		//   - agc.seeded: the un-normalisation factor
-		//     (level/target) is valid; without that the DDA folds
-		//     gain noise into the estimate.
+		//   - c4fmSymbolsTotal ≥ ddaWarmupDoneAt: CoarseAFC has had
+		//     time to converge; before that, the slicer mis-decides
+		//     inner symbols at any offset above ~1 kHz and the DDA
+		//     would learn from those wrong-decision residuals. The
+		//     threshold is bumped past a watchdog re-arm so CoarseAFC
+		//     gets to re-converge before the DDA tries again.
+		//   - agc.seeded: the un-normalisation factor (level/target)
+		//     is valid; without that the DDA folds gain noise in.
 		//   - r.dda non-nil: skipped on the CQPSK / legacy-fixture
 		//     paths the receiver doesn't allocate it on.
-		//
-		// Each accepted update is a within-gate sample, i.e. a
-		// decision the loop trusts; ddaHandoffSymbols of them is
-		// the receiver's "decisions are reliable" signal and
-		// triggers the freeze-CoarseAFC / fold-into-DDA handoff
-		// so the open-loop tracker stops drifting on data.
 		r.c4fmSymbolsTotal += len(r.sliced)
-		if r.dda != nil && r.c4fmSymbolsTotal >= ddaWarmupSymbols && r.agc.seeded && r.agc.target > 0 && r.agc.level > 0 {
-			agcUnscale := r.agc.level / r.agc.target
+		if r.dda != nil && r.c4fmSymbolsTotal >= r.ddaWarmupDoneAt && r.agc.seeded && r.agc.target > 0 && agcLevel > 0 {
+			agcUnscale := float32(agcLevel) / r.agc.target
 			for i, sym := range r.sliced {
 				idx := (sym + 3) / 2 // -3,-1,+1,+3 → 0,1,2,3
 				if r.dda.Update(r.symbols[i], r.ddaNominal[idx], agcUnscale) {
 					r.ddaValidUpdates++
 				}
+				r.ddaTotalUpdates++
 			}
-			if !r.ddaActive && r.ddaValidUpdates >= ddaHandoffSymbols {
-				r.dda.AddOffset(r.afc.Offset())
-				r.afc.SetOffset(0)
-				r.ddaActive = true
+			if !r.ddaActive {
+				// Commit the handoff only when decisions are both
+				// plentiful (count + accept-rate) and unbiased
+				// (mean accepted residual near zero). The CoarseAFC
+				// value is folded in exactly, since it has been
+				// frozen for the whole learning window.
+				if r.ddaHandoffReady() {
+					r.dda.AddOffset(r.afc.Offset())
+					r.afc.SetOffset(0)
+					r.afcAtHandoff = r.dda.Offset()
+					r.ddaActive = true
+				}
+			} else if math.Abs(r.dda.Offset()-r.afcAtHandoff) > r.ddaMaxDrift {
+				// Post-handoff watchdog: the DDA has walked too far
+				// from the gate-verified handoff estimate to still be
+				// tracking the same carrier — revert to CoarseAFC-
+				// alone (the pre-DDA behaviour) so the receiver can
+				// never end up worse than it was before the DDA. Hand
+				// the DDA's current estimate back to CoarseAFC so the
+				// eye stays continuous, then re-arm warmup so
+				// CoarseAFC re-converges before the DDA tries again.
+				// Issue #402.
+				r.afc.SetOffset(r.dda.Offset())
+				r.dda.Reset()
+				r.ddaActive = false
+				r.ddaLearning = false
+				r.ddaValidUpdates = 0
+				r.ddaTotalUpdates = 0
+				r.afcAtHandoff = 0
+				r.ddaWarmupDoneAt = r.c4fmSymbolsTotal + ddaWarmupSymbols
+				r.ddaRearms++
 			}
 		}
 	}
@@ -426,6 +509,42 @@ func (r *Receiver) Process(iq []complex64) {
 		r.assembler.Process(r.dibits)
 	}
 }
+
+// ddaHandoffReady reports whether the learning window has produced
+// decisions trustworthy enough to fold CoarseAFC into the DDA and let
+// the DDA carry the estimate alone. It requires three things, not just
+// the raw accepted-update count the first cut used (issue #402):
+//
+//   - enough accepted (within-gate) updates — the loop has data;
+//   - a high accept-rate over the learning window — the eye isn't
+//     grossly broken (many out-of-gate decisions);
+//   - a mean accepted residual near zero — the eye isn't uniformly
+//     biased. A biased eye still yields within-gate "accepted"
+//     residuals, so the count + accept-rate alone can't see it; the
+//     residual-mean gate is what stops the handoff from locking onto
+//     the stable-but-wrong offset that broke decode in #402.
+func (r *Receiver) ddaHandoffReady() bool {
+	if r.dda == nil || r.ddaValidUpdates < ddaHandoffSymbols || r.ddaTotalUpdates == 0 {
+		return false
+	}
+	if float64(r.ddaValidUpdates)/float64(r.ddaTotalUpdates) < ddaHandoffMinAcceptRate {
+		return false
+	}
+	return math.Abs(r.dda.AcceptedResidualMean()) <= r.ddaResidMeanGate
+}
+
+// DDAActive reports whether the decision-directed AFC has handed off
+// and is carrying the estimate alone (CoarseAFC frozen). On a healthy
+// lock this goes true shortly after warmup and stays true. Issue #402
+// diagnostic.
+func (r *Receiver) DDAActive() bool { return r.ddaActive }
+
+// DDARearms returns how many times the post-handoff watchdog has
+// reverted the DDA to CoarseAFC-alone (the DDA walked too far from its
+// gate-verified handoff value). 0 on a stable lock; a climbing count
+// means the DDA can't hold this signal and the receiver is repeatedly
+// falling back. Issue #402 diagnostic.
+func (r *Receiver) DDARearms() int { return r.ddaRearms }
 
 // AFCBiasRadPerSample returns the C4FM AFC's *total* current DC bias
 // estimate on the FM-discriminator output, in radians per sample at
@@ -507,8 +626,13 @@ func (r *Receiver) Reset() {
 	if r.dda != nil {
 		r.dda.Reset()
 	}
+	r.ddaLearning = false
 	r.ddaActive = false
 	r.ddaValidUpdates = 0
+	r.ddaTotalUpdates = 0
+	r.ddaWarmupDoneAt = ddaWarmupSymbols
+	r.afcAtHandoff = 0
+	r.ddaRearms = 0
 	r.c4fmSymbolsTotal = 0
 	r.agc.reset()
 	// FM discriminator's `last` is harmless to leave alone — the
@@ -540,10 +664,18 @@ type c4fmSymbolAGC struct {
 // regardless of how the IQ is chunked — the chunk-boundary
 // determinism the Mueller-Müller fix already guarantees on the
 // clock side (TestHarnessC4FMChunkBoundary, issue #275).
-func (a *c4fmSymbolAGC) process(symbols []float32) {
+//
+// Returns the mean level the batch was scaled against (the mean of the
+// per-sample EMA estimate). The DDA un-normalises its residuals by
+// level/target, so it needs the gain *this* batch saw, not the
+// post-batch level a later sample will see. Returns 0 when calibration
+// is disabled or no sample seeded the loop. Issue #402.
+func (a *c4fmSymbolAGC) process(symbols []float32) float64 {
 	if a.target <= 0 {
-		return // calibration disabled (legacy DeviationHz=0 path)
+		return 0 // calibration disabled (legacy DeviationHz=0 path)
 	}
+	var levelSum float64
+	var levelN int
 	for i, x := range symbols {
 		ax := x
 		if ax < 0 {
@@ -562,8 +694,14 @@ func (a *c4fmSymbolAGC) process(symbols []float32) {
 		if a.level > 1e-12 {
 			g := a.target / a.level
 			symbols[i] = x * g
+			levelSum += float64(a.level)
+			levelN++
 		}
 	}
+	if levelN == 0 {
+		return 0
+	}
+	return levelSum / float64(levelN)
 }
 
 // reset clears the level estimate so a stream re-sync starts from a

--- a/internal/radio/p25/phase1/receiver/receiver_test.go
+++ b/internal/radio/p25/phase1/receiver/receiver_test.go
@@ -435,7 +435,11 @@ func TestReceiverDDAHandoffFiresOnCleanLockedStream(t *testing.T) {
 		DeviationHz:  dev,
 		DibitSink:    func(d []uint8, _ int) { totalDibits += len(d) },
 	})
-	r.Process(iq)
+	// Feed in chunks — the freeze-then-handoff state machine advances
+	// per Process call, so a single whole-stream call can't exercise it
+	// (and is correctly refused by the handoff gate, since CoarseAFC
+	// never freezes mid-call). Issue #402.
+	feedChunked(r, iq, 200, nil)
 
 	if totalDibits == 0 {
 		t.Fatalf("receiver emitted no dibits")
@@ -460,16 +464,20 @@ func TestReceiverDDAResetClearsHandoffState(t *testing.T) {
 		DeviationHz:  1800,
 		Sink:         func([]byte) {},
 	})
-	// Drive enough biased traffic through to push past handoff.
+	// Drive enough traffic through (chunked, so the handoff fires) to
+	// populate the DDA state Reset must clear.
 	dibits := make([]uint8, 8000)
 	for i := range dibits {
 		dibits[i] = uint8((i*7 + 3) & 3)
 	}
 	iq := demod.ModulateP25C4FM(dibits, 48_000, 1800)
-	iq = demod.ApplyImpairments(iq, 48_000, demod.Impairments{FreqOffsetHz: 3000})
-	r.Process(iq)
+	iq = demod.ApplyImpairments(iq, 48_000, demod.Impairments{FreqOffsetHz: 1500})
+	feedChunked(r, iq, 200, nil)
 	if r.AFCBiasRadPerSample() == 0 {
-		t.Fatalf("AFC didn't accumulate any estimate on a 3 kHz-offset stream — receiver state setup is broken")
+		t.Fatalf("AFC didn't accumulate any estimate on an offset stream — receiver state setup is broken")
+	}
+	if !r.ddaActive {
+		t.Fatalf("DDA never handed off — Reset's handoff-state clearing would be untested")
 	}
 
 	r.Reset()
@@ -479,10 +487,245 @@ func TestReceiverDDAResetClearsHandoffState(t *testing.T) {
 	if r.ddaActive {
 		t.Error("ddaActive remained true after Reset")
 	}
+	if r.ddaLearning {
+		t.Error("ddaLearning remained true after Reset")
+	}
 	if r.ddaValidUpdates != 0 {
 		t.Errorf("ddaValidUpdates = %d after Reset, want 0", r.ddaValidUpdates)
 	}
+	if r.ddaTotalUpdates != 0 {
+		t.Errorf("ddaTotalUpdates = %d after Reset, want 0", r.ddaTotalUpdates)
+	}
+	if r.afcAtHandoff != 0 {
+		t.Errorf("afcAtHandoff = %v after Reset, want 0", r.afcAtHandoff)
+	}
+	if r.ddaRearms != 0 {
+		t.Errorf("ddaRearms = %d after Reset, want 0", r.ddaRearms)
+	}
+	if r.ddaWarmupDoneAt != ddaWarmupSymbols {
+		t.Errorf("ddaWarmupDoneAt = %d after Reset, want %d", r.ddaWarmupDoneAt, ddaWarmupSymbols)
+	}
 	if r.c4fmSymbolsTotal != 0 {
 		t.Errorf("c4fmSymbolsTotal = %d after Reset, want 0", r.c4fmSymbolsTotal)
+	}
+}
+
+// feedChunked pushes iq through r in fixed-size chunks, calling after
+// each Process call. This exercises the per-batch freeze/handoff/
+// watchdog state machine the way the live daemon (small USB transfers)
+// does — a single Process(iq) call can't, since the freeze takes
+// effect only from the batch after warmup completes. Issue #402.
+func feedChunked(r *Receiver, iq []complex64, chunk int, after func()) {
+	for i := 0; i < len(iq); i += chunk {
+		end := i + chunk
+		if end > len(iq) {
+			end = len(iq)
+		}
+		r.Process(iq[i:end])
+		if after != nil {
+			after()
+		}
+	}
+}
+
+// TestReceiverFreezesCoarseAFCAtWarmupBoundary pins Part A of the
+// issue #402 fix: once the DDA starts learning, CoarseAFC is frozen
+// (subtract-only) for the entire learning window, so its estimate is
+// constant from the first learning batch through handoff. A constant
+// estimate is what makes the handoff fold-in exact (no wandering-data-
+// mean error).
+func TestReceiverFreezesCoarseAFCAtWarmupBoundary(t *testing.T) {
+	const (
+		sr       = 48_000.0
+		dev      = 1800.0
+		offsetHz = 1_000.0
+		nDibits  = 4_000
+	)
+	dibits := make([]uint8, nDibits)
+	for i := range dibits {
+		dibits[i] = uint8((i*7 + 3) & 3)
+	}
+	iq := demod.ModulateP25C4FM(dibits, sr, dev)
+	iq = demod.ApplyImpairments(iq, sr, demod.Impairments{FreqOffsetHz: offsetHz})
+
+	r := New(Options{
+		SampleRateHz: sr,
+		DeviationHz:  dev,
+		DibitSink:    func([]uint8, int) {},
+	})
+
+	var afcAtLearnStart, afcBeforeHandoff float64
+	learnSeen := false
+	feedChunked(r, iq, 200, func() {
+		if r.ddaLearning && !learnSeen {
+			afcAtLearnStart = r.afc.Offset()
+			learnSeen = true
+		}
+		if learnSeen && !r.ddaActive {
+			afcBeforeHandoff = r.afc.Offset()
+		}
+	})
+
+	if !learnSeen {
+		t.Fatal("DDA never entered the learning window")
+	}
+	if !r.ddaActive {
+		t.Fatal("DDA never handed off")
+	}
+	if math.Abs(afcAtLearnStart-afcBeforeHandoff) > 1e-9 {
+		t.Errorf("CoarseAFC moved during the learning window: %.9f at start vs %.9f before handoff — freeze didn't take",
+			afcAtLearnStart, afcBeforeHandoff)
+	}
+	if afcAtLearnStart == 0 {
+		t.Error("CoarseAFC froze at 0 — it never converged during warmup")
+	}
+}
+
+// TestReceiverHandoffDataImmuneAcrossUnbalancedLearning is the headline
+// regression test for issue #402. A swinging, unbalanced symbol stream
+// (the field condition that made CoarseAFC's estimate oscillate) must
+// hand off to the same AFC estimate as a balanced stream at the same
+// carrier offset — proving the DDA carries the true carrier offset and
+// not the data mean the open-loop tracker confused it with. Before the
+// fix, CoarseAFC kept adapting through the learning window and the
+// fold-in captured a wandering value, so the unbalanced stream settled
+// on a different (wrong) offset and decode collapsed.
+func TestReceiverHandoffDataImmuneAcrossUnbalancedLearning(t *testing.T) {
+	const (
+		sr       = 48_000.0
+		dev      = 1800.0
+		offsetHz = 1_200.0
+		nDibits  = 12_000
+	)
+	balanced := make([]uint8, nDibits)
+	for i := range balanced {
+		balanced[i] = uint8(i & 3)
+	}
+	// Swinging skew: alternating positive- and negative-heavy runs,
+	// net-balanced over time but with a strong local data mean that
+	// drags an open-loop tracker around.
+	unbalanced := make([]uint8, nDibits)
+	posHeavy := []uint8{0, 1, 0, 1, 2, 3} // dibits 0,1 → +1,+3 ; 2,3 → -1,-3
+	negHeavy := []uint8{2, 3, 2, 3, 0, 1}
+	for i := range unbalanced {
+		pat := posHeavy
+		if (i/80)%2 == 1 {
+			pat = negHeavy
+		}
+		unbalanced[i] = pat[i%len(pat)]
+	}
+
+	runAFC := func(dibits []uint8) float64 {
+		iq := demod.ModulateP25C4FM(dibits, sr, dev)
+		iq = demod.ApplyImpairments(iq, sr, demod.Impairments{FreqOffsetHz: offsetHz})
+		r := New(Options{
+			SampleRateHz: sr,
+			DeviationHz:  dev,
+			DibitSink:    func([]uint8, int) {},
+		})
+		feedChunked(r, iq, 200, nil)
+		if !r.ddaActive {
+			t.Fatalf("DDA never handed off")
+		}
+		return r.AFCBiasRadPerSample()
+	}
+
+	ref := runAFC(balanced)
+	got := runAFC(unbalanced)
+	if ref == 0 {
+		t.Fatal("balanced reference AFC is 0")
+	}
+	if rel := math.Abs(got-ref) / math.Abs(ref); rel > 0.20 {
+		t.Errorf("unbalanced-stream AFC = %.4f, balanced reference = %.4f (%.0f%% off) — handoff not data-immune",
+			got, ref, rel*100)
+	}
+}
+
+// TestReceiverHandoffReadyBlocksBiasedEye pins Part B's validity gate
+// (issue #402): a uniformly-biased eye produces plenty of within-gate
+// ("accepted") updates, so the raw count alone would green-light a
+// handoff onto a stable-but-wrong offset. ddaHandoffReady must refuse
+// it because the mean accepted residual is non-zero, and must allow a
+// clean (near-zero-mean) eye.
+func TestReceiverHandoffReadyBlocksBiasedEye(t *testing.T) {
+	const (
+		sr  = 48_000.0
+		dev = 1800.0
+	)
+	slicerScale := 2.0 * math.Pi * dev / sr
+
+	newRx := func() *Receiver {
+		return New(Options{SampleRateHz: sr, DeviationHz: dev, DibitSink: func([]uint8, int) {}})
+	}
+
+	// Drive the DDA directly with the same call shape Process uses, so
+	// the gate sees realistic counters and residual mean.
+	drive := func(r *Receiver, bias float64) {
+		syms := []float64{slicerScale, slicerScale / 3, -slicerScale / 3, -slicerScale}
+		for i := 0; i < 4*1024; i++ {
+			expected := float32(syms[i%4])
+			soft := float32(syms[i%4] + bias)
+			if r.dda.Update(soft, expected, 1.0) {
+				r.ddaValidUpdates++
+			}
+			r.ddaTotalUpdates++
+		}
+	}
+
+	clean := newRx()
+	drive(clean, 0)
+	if !clean.ddaHandoffReady() {
+		t.Errorf("ddaHandoffReady = false on a clean eye (residMean=%.5f) — gate too strict", clean.dda.AcceptedResidualMean())
+	}
+
+	biased := newRx()
+	drive(biased, slicerScale/6) // within the gate, but clearly off-centre
+	if biased.ddaHandoffReady() {
+		t.Errorf("ddaHandoffReady = true on a biased eye (residMean=%.5f, gate=%.5f) — false lock not blocked",
+			biased.dda.AcceptedResidualMean(), biased.ddaResidMeanGate)
+	}
+}
+
+// TestReceiverWatchdogReArmsOnRunawayDrift pins Part B's watchdog
+// (issue #402): after a healthy handoff, if the DDA's estimate walks
+// far from the gate-verified handoff value (here forced by a large
+// post-handoff carrier-offset step the DDA chases), the receiver
+// reverts to CoarseAFC-alone rather than staying stuck on a DDA
+// estimate it can no longer trust. This is the reversibility guarantee
+// — the receiver can never wander into a worse-than-CoarseAFC state.
+func TestReceiverWatchdogReArmsOnRunawayDrift(t *testing.T) {
+	const (
+		sr        = 48_000.0
+		dev       = 1800.0
+		offsetHz  = 1_000.0
+		stepHz    = 9_000.0 // large step past the drift bound (4 kHz)
+		chunkSize = 200
+	)
+	clean := make([]uint8, 6_000)
+	for i := range clean {
+		clean[i] = uint8((i*7 + 3) & 3)
+	}
+	cleanIQ := demod.ModulateP25C4FM(clean, sr, dev)
+	cleanIQ = demod.ApplyImpairments(cleanIQ, sr, demod.Impairments{FreqOffsetHz: offsetHz})
+
+	r := New(Options{SampleRateHz: sr, DeviationHz: dev, DibitSink: func([]uint8, int) {}})
+	feedChunked(r, cleanIQ, chunkSize, nil)
+	if !r.ddaActive {
+		t.Fatal("DDA never handed off on the clean stream")
+	}
+	rearmsBefore := r.ddaRearms
+
+	// Step the carrier far enough that the DDA, chasing it, walks past
+	// the drift bound and trips the watchdog.
+	stepped := make([]uint8, 30_000)
+	for i := range stepped {
+		stepped[i] = uint8((i*7 + 3) & 3)
+	}
+	steppedIQ := demod.ModulateP25C4FM(stepped, sr, dev)
+	steppedIQ = demod.ApplyImpairments(steppedIQ, sr, demod.Impairments{FreqOffsetHz: offsetHz + stepHz})
+	feedChunked(r, steppedIQ, chunkSize, nil)
+
+	if r.ddaRearms <= rearmsBefore {
+		t.Errorf("watchdog never re-armed on a runaway-drift step (rearms=%d) — receiver can't fall back to CoarseAFC", r.ddaRearms)
 	}
 }


### PR DESCRIPTION
The decision-directed AFC handoff added for issue #402 stopped the
CoarseAFC swing but settled onto a stable-but-wrong offset that broke
control-channel lock on MMR Site 9 — decode went from ~60% to 0%. Three
interacting defects:

  1. CoarseAFC kept adapting through the DDA learning window, so the
     value folded into the DDA at handoff was an instantaneous
     data-mean excursion rather than the average the DDA had learned
     against — injecting a fixed offset error.
  2. The handoff was irreversible: once the DDA took over, CoarseAFC
     was permanently frozen, so a wrong lock could never recover.
  3. The handoff fired on within-gate update counts alone, which a
     uniformly-biased eye satisfies — there was no check that decisions
     were actually correct.

Fixes:

  - Freeze CoarseAFC (subtract-only) the moment the DDA starts learning,
    so the eye is stationary across the learning window and the handoff
    fold-in is exact.
  - Gate the handoff on accept-rate and a near-zero mean accepted
    residual (new DecisionDirectedAFC.AcceptedResidualMean), so a biased
    false lock can't hand off.
  - Add a post-handoff watchdog that reverts to CoarseAFC-alone if the
    DDA's estimate walks past a drift bound from its gate-verified
    handoff value — the receiver can never end up worse than the
    pre-DDA behaviour.
  - Un-normalise DDA residuals by the gain the batch was actually scaled
    against (c4fmSymbolAGC.process now returns the mean level), matching
    the comment that previously described an unimplemented snapshot.
  - Surface dda_active / dda_rearms in the replay receiver-state log.

Adds unit tests for the residual-mean detector and Reset, plus receiver
integration tests for the warmup freeze, data-immune handoff across an
unbalanced learning window, the biased-eye handoff gate, and the
runaway-drift watchdog re-arm.

https://claude.ai/code/session_0149tZvntzrxH18SkYULqCF9