### PR TITLE
p25/phase1: default to CoarseAFC-alone, fix 10x AFC diagnostic (#402)

### DIFF
--- a/cmd/gophertrunk/iqdiag.go
+++ b/cmd/gophertrunk/iqdiag.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"io"
+	"math"
 	"sort"
 
 	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
@@ -145,6 +146,67 @@ func (d *iqDiag) printReport(w io.Writer) {
 			fmt.Fprintf(w, "diag:   [%.3f,%.3f): %7d  (%5.2f%%)\n",
 				float64(b)/bins*maxAbs, float64(b+1)/bins*maxAbs,
 				mhist[b], 100*float64(mhist[b])/float64(len(d.soft)))
+		}
+
+		// Signed-eye summary (issue #402). The magnitude histogram above
+		// folds sign away, so it cannot see the eye-skew the reporter is
+		// hitting — a heavily negative dibit distribution can sit under a
+		// "sane-looking" |x| spread. These two views keep the sign:
+		//
+		//   - Overall signed mean (DC): the AFC should have driven this to
+		//     ~0. A non-zero value is residual carrier DC shifting the
+		//     whole eye off the slicer's symmetric thresholds — outer-
+		//     positive symbols then fall short of the +threshold while
+		//     outer-negative overshoot, exactly the inner/negative-heavy
+		//     skew #402 shows.
+		//
+		//   - Per-decided-symbol centroids: the mean soft value of the
+		//     samples the slicer assigned to each of +3/+1/-1/-3 (decided
+		//     dibit 1/0/2/3 — see phase1.SymbolToDibit). On a clean eye
+		//     these are symmetric (|+3|≈|-3|, |+1|≈|-1|) and the outer/
+		//     inner ratio is ~3. Asymmetry localises the fault: a uniform
+		//     offset = DC shift, compressed outer centroids = scale error
+		//     (outer symbols not reaching the eye corners), one-sided =
+		//     gain/deviation-calibration asymmetry.
+		var signedSum float64
+		for _, s := range d.soft {
+			signedSum += float64(s)
+		}
+		signedMean := signedSum / float64(len(d.soft))
+		var sqdev float64
+		for _, s := range d.soft {
+			dv := float64(s) - signedMean
+			sqdev += dv * dv
+		}
+		std := math.Sqrt(sqdev / float64(len(d.soft)))
+		fmt.Fprintf(w, "diag: signed soft samples: mean=%+.6f (DC; want ~0)  stddev=%.6f\n", signedMean, std)
+
+		// Group soft samples by the slicer's decision. d.dibits and
+		// d.soft are appended in lockstep (one dibit and one soft sample
+		// per recovered symbol, same order), so they align index-for-
+		// index when their lengths match. Skip if they don't (e.g. a
+		// future caller wires only one sink).
+		if len(d.dibits) == len(d.soft) {
+			// dibit → label and slice index. Mapping per
+			// phase1.SymbolToDibit: 0:+1, 1:+3, 2:-1, 3:-3.
+			labels := [4]string{"+1", "+3", "-1", "-3"}
+			var csum [4]float64
+			var cnt [4]int
+			for i, s := range d.soft {
+				db := d.dibits[i] & 3
+				csum[db] += float64(s)
+				cnt[db]++
+			}
+			fmt.Fprintln(w, "diag: per-decided-symbol soft centroids (clean eye: ±outer ≈ 3×±inner, symmetric):")
+			// Print in eye order -3,-1,+1,+3 for readability.
+			for _, db := range [4]uint8{3, 2, 0, 1} {
+				mean := 0.0
+				if cnt[db] > 0 {
+					mean = csum[db] / float64(cnt[db])
+				}
+				fmt.Fprintf(w, "diag:   %s (dibit %d): n=%7d (%5.2f%%)  centroid=%+.6f\n",
+					labels[db], db, cnt[db], 100*float64(cnt[db])/float64(len(d.soft)), mean)
+			}
 		}
 	}
 

--- a/cmd/gophertrunk/replay.go
+++ b/cmd/gophertrunk/replay.go
@@ -61,6 +61,12 @@ func runReplay(args []string) {
 	// landscape across the whole capture. Off by default since it
 	// allocates an O(numDibits) buffer.
 	diag := fs.Bool("diag", false, "print a demod-quality diagnostic report (dibit histogram + per-rotation FSW correlation landscape) at EOF")
+	// Issue #402: the decision-directed AFC is off by default (it can
+	// stably false-lock and broke CC lock on the original capture), so
+	// the daemon and replay run CoarseAFC-alone. This knob re-enables it
+	// for A/B experimentation on a capture without turning it on in
+	// production. C4FM only.
+	enableDDA := fs.Bool("dda", false, "enable the experimental decision-directed AFC on the C4FM path (off by default; see issue #402)")
 	fs.Usage = func() {
 		fmt.Fprintln(fs.Output(), `gophertrunk replay — decode a raw IQ capture file offline.
 
@@ -175,9 +181,10 @@ FLAGS:`)
 		diagAcc = &iqDiag{}
 	}
 	rxOpts := p25phase1rx.Options{
-		SampleRateHz: receiverRate,
-		DeviationHz:  1800.0,
-		DemodMode:    demodMode,
+		SampleRateHz:              receiverRate,
+		DeviationHz:               1800.0,
+		DemodMode:                 demodMode,
+		EnableDecisionDirectedAFC: *enableDDA,
 		DibitSink: func(dibits []uint8, baseIdx int) {
 			dibitCount += int64(len(dibits))
 			if diagAcc != nil {
@@ -214,11 +221,17 @@ FLAGS:`)
 	const stateLogIntervalSec = 1.0
 	var nextStateLogAt float64 = stateLogIntervalSec
 	logReceiverState := func(at float64) {
+		// afc_hz_est is the TRUE carrier offset (rx.AFCOffsetHz), which
+		// divides out the matched filter's sps DC-gain. The earlier
+		// AFCBias·Fs/(2π) form over-reported by ≈sps (≈10× at 48 kHz /
+		// 4800 baud) and sent issue #402 chasing a phantom ~10 kHz
+		// offset that was really ~1 kHz. afc_bias_rad_per_sample is the
+		// raw matched-output-unit value behind it.
 		fmt.Fprintf(os.Stderr,
 			"replay: receiver state  t=%.2fs  afc_bias_rad_per_sample=%.6g  afc_hz_est=%.3f  agc_level=%.6g  agc_target=%.6g  agc_gain=%.4g  mm_mu=%.4f  mm_sps=%.2f  dda_active=%t  dda_rearms=%d\n",
 			at,
 			rx.AFCBiasRadPerSample(),
-			rx.AFCBiasRadPerSample()*receiverRate/(2*math.Pi),
+			rx.AFCOffsetHz(),
 			rx.AGCLevel(),
 			rx.AGCTarget(),
 			ratioOrZero(rx.AGCTarget(), rx.AGCLevel()),

--- a/internal/radio/p25/phase1/receiver/receiver.go
+++ b/internal/radio/p25/phase1/receiver/receiver.go
@@ -186,6 +186,20 @@ type Options struct {
 	// CQPSK path. <=0 uses defaultGardnerGain. Ignored when
 	// DemodMode == DemodC4FM (the C4FM path uses Mueller-Müller).
 	GardnerGain float64
+	// EnableDecisionDirectedAFC opts the C4FM path into the
+	// decision-directed AFC (DDA) layered on top of CoarseAFC.
+	// Default false: the receiver runs CoarseAFC-alone, the
+	// behaviour that predates the DDA. The DDA is currently
+	// experimental and OFF by default because it can stably
+	// false-lock — on the issue #402 capture it held a wrong offset
+	// and broke control-channel lock that CoarseAFC-alone recovered.
+	// The receiver and the control channel are feed-forward siblings
+	// with no FSW / CC-lock feedback into the demod, so nothing
+	// internal catches a biased-but-self-consistent eye, and the DDA
+	// commits a handoff to it. Leave this off until the eye-skew root
+	// cause is pinned and the handoff is gated on a real lock signal.
+	// Ignored when DemodMode == DemodCQPSK (no AFC stage). Issue #402.
+	EnableDecisionDirectedAFC bool
 	// SoftSink, when non-nil, receives the per-symbol soft samples
 	// produced by the matched filter + symbol-clock recovery, just
 	// before slicing. The C4FM path emits the FM-discriminator +
@@ -348,7 +362,13 @@ func New(opts Options) *Receiver {
 		// which carry a DC gain of ~sps relative to the
 		// FM-discriminator input — same scale factor that drives
 		// the existing AGC's target=slicerScale·2/3 calibration.
-		if slicerScale > 0 {
+		//
+		// Allocated only when the caller opts in: with r.dda nil the
+		// Process loop skips every DDA branch (all guarded on
+		// r.dda != nil / ddaActive / ddaLearning) and runs
+		// CoarseAFC-alone. Off by default — see Options.
+		// EnableDecisionDirectedAFC. Issue #402.
+		if opts.EnableDecisionDirectedAFC && slicerScale > 0 {
 			r.dda = demod.NewDecisionDirectedAFC(maxAFCOffsetHz*sps, opts.SampleRateHz, slicerScale)
 			// Nominal post-AGC values for the four slicer
 			// decisions. Indexed by ((sliced+3)/2) — maps
@@ -568,6 +588,26 @@ func (r *Receiver) AFCBiasRadPerSample() float64 {
 		sum += r.dda.Offset()
 	}
 	return sum
+}
+
+// AFCOffsetHz returns the AFC's current estimate of the *true* carrier
+// frequency offset in Hz. This is the physically meaningful number — a
+// static carrier error of Δf Hz reads back as ≈Δf here.
+//
+// It is NOT AFCBiasRadPerSample()·Fs/(2π): the C4FM matched filter
+// (demod.P25C4FMRxTaps) has a DC gain of sps, so the AFC — which tracks
+// on the matched-filter output — carries a value sps× larger than the
+// raw FM-discriminator offset. The true offset divides that gain back
+// out, which (since sps = Fs/SymbolRate) reduces to
+//
+//	AFCBiasRadPerSample · SymbolRate / (2π)
+//
+// independent of the sample rate. Diagnostics that reported
+// AFCBiasRadPerSample·Fs/(2π) over-stated the offset by ≈sps (≈10× at
+// 48 kHz / 4800 baud) and sent issue #402 chasing a phantom ~10 kHz
+// error that was really ~1 kHz. Returns 0 on the CQPSK path (no AFC).
+func (r *Receiver) AFCOffsetHz() float64 {
+	return r.AFCBiasRadPerSample() * SymbolRate / (2.0 * math.Pi)
 }
 
 // AGCLevel returns the C4FM symbol-AGC's current EMA estimate of

--- a/internal/radio/p25/phase1/receiver/receiver_test.go
+++ b/internal/radio/p25/phase1/receiver/receiver_test.go
@@ -431,9 +431,10 @@ func TestReceiverDDAHandoffFiresOnCleanLockedStream(t *testing.T) {
 
 	var totalDibits int
 	r := New(Options{
-		SampleRateHz: sr,
-		DeviationHz:  dev,
-		DibitSink:    func(d []uint8, _ int) { totalDibits += len(d) },
+		SampleRateHz:              sr,
+		DeviationHz:               dev,
+		EnableDecisionDirectedAFC: true,
+		DibitSink:                 func(d []uint8, _ int) { totalDibits += len(d) },
 	})
 	// Feed in chunks — the freeze-then-handoff state machine advances
 	// per Process call, so a single whole-stream call can't exercise it
@@ -460,9 +461,10 @@ func TestReceiverDDAHandoffFiresOnCleanLockedStream(t *testing.T) {
 // slicer.
 func TestReceiverDDAResetClearsHandoffState(t *testing.T) {
 	r := New(Options{
-		SampleRateHz: 48_000,
-		DeviationHz:  1800,
-		Sink:         func([]byte) {},
+		SampleRateHz:              48_000,
+		DeviationHz:               1800,
+		EnableDecisionDirectedAFC: true,
+		Sink:                      func([]byte) {},
 	})
 	// Drive enough traffic through (chunked, so the handoff fires) to
 	// populate the DDA state Reset must clear.
@@ -549,9 +551,10 @@ func TestReceiverFreezesCoarseAFCAtWarmupBoundary(t *testing.T) {
 	iq = demod.ApplyImpairments(iq, sr, demod.Impairments{FreqOffsetHz: offsetHz})
 
 	r := New(Options{
-		SampleRateHz: sr,
-		DeviationHz:  dev,
-		DibitSink:    func([]uint8, int) {},
+		SampleRateHz:              sr,
+		DeviationHz:               dev,
+		EnableDecisionDirectedAFC: true,
+		DibitSink:                 func([]uint8, int) {},
 	})
 
 	var afcAtLearnStart, afcBeforeHandoff float64
@@ -619,9 +622,10 @@ func TestReceiverHandoffDataImmuneAcrossUnbalancedLearning(t *testing.T) {
 		iq := demod.ModulateP25C4FM(dibits, sr, dev)
 		iq = demod.ApplyImpairments(iq, sr, demod.Impairments{FreqOffsetHz: offsetHz})
 		r := New(Options{
-			SampleRateHz: sr,
-			DeviationHz:  dev,
-			DibitSink:    func([]uint8, int) {},
+			SampleRateHz:              sr,
+			DeviationHz:               dev,
+			EnableDecisionDirectedAFC: true,
+			DibitSink:                 func([]uint8, int) {},
 		})
 		feedChunked(r, iq, 200, nil)
 		if !r.ddaActive {
@@ -655,7 +659,7 @@ func TestReceiverHandoffReadyBlocksBiasedEye(t *testing.T) {
 	slicerScale := 2.0 * math.Pi * dev / sr
 
 	newRx := func() *Receiver {
-		return New(Options{SampleRateHz: sr, DeviationHz: dev, DibitSink: func([]uint8, int) {}})
+		return New(Options{SampleRateHz: sr, DeviationHz: dev, EnableDecisionDirectedAFC: true, DibitSink: func([]uint8, int) {}})
 	}
 
 	// Drive the DDA directly with the same call shape Process uses, so
@@ -708,7 +712,7 @@ func TestReceiverWatchdogReArmsOnRunawayDrift(t *testing.T) {
 	cleanIQ := demod.ModulateP25C4FM(clean, sr, dev)
 	cleanIQ = demod.ApplyImpairments(cleanIQ, sr, demod.Impairments{FreqOffsetHz: offsetHz})
 
-	r := New(Options{SampleRateHz: sr, DeviationHz: dev, DibitSink: func([]uint8, int) {}})
+	r := New(Options{SampleRateHz: sr, DeviationHz: dev, EnableDecisionDirectedAFC: true, DibitSink: func([]uint8, int) {}})
 	feedChunked(r, cleanIQ, chunkSize, nil)
 	if !r.ddaActive {
 		t.Fatal("DDA never handed off on the clean stream")
@@ -727,5 +731,91 @@ func TestReceiverWatchdogReArmsOnRunawayDrift(t *testing.T) {
 
 	if r.ddaRearms <= rearmsBefore {
 		t.Errorf("watchdog never re-armed on a runaway-drift step (rearms=%d) — receiver can't fall back to CoarseAFC", r.ddaRearms)
+	}
+}
+
+// TestReceiverDDADisabledByDefault is the issue #402 regression guard:
+// without EnableDecisionDirectedAFC the C4FM path must run CoarseAFC-
+// alone (the pre-DDA behaviour) — no DDA allocated, no handoff, ever —
+// while still emitting dibits and tracking the carrier offset. The DDA
+// is opt-in because it can stably false-lock and broke CC lock on the
+// original capture; the default path must be the known-good one.
+func TestReceiverDDADisabledByDefault(t *testing.T) {
+	const (
+		sr       = 48_000.0
+		dev      = 1800.0
+		offsetHz = 1_500.0
+		nDibits  = 8_000
+	)
+	dibits := make([]uint8, nDibits)
+	for i := range dibits {
+		dibits[i] = uint8((i*7 + 3) & 3)
+	}
+	iq := demod.ModulateP25C4FM(dibits, sr, dev)
+	iq = demod.ApplyImpairments(iq, sr, demod.Impairments{FreqOffsetHz: offsetHz})
+
+	var totalDibits int
+	r := New(Options{
+		SampleRateHz: sr,
+		DeviationHz:  dev,
+		// EnableDecisionDirectedAFC left false — the default.
+		DibitSink: func(d []uint8, _ int) { totalDibits += len(d) },
+	})
+	if r.dda != nil {
+		t.Fatal("DDA was allocated with EnableDecisionDirectedAFC unset — default must be CoarseAFC-alone")
+	}
+	feedChunked(r, iq, 200, nil)
+
+	if totalDibits == 0 {
+		t.Fatal("CoarseAFC-only receiver emitted no dibits")
+	}
+	if r.ddaActive {
+		t.Error("ddaActive went true with the DDA disabled")
+	}
+	if r.ddaLearning {
+		t.Error("ddaLearning went true with the DDA disabled")
+	}
+	if r.ddaRearms != 0 {
+		t.Errorf("ddaRearms = %d with the DDA disabled, want 0", r.ddaRearms)
+	}
+	// CoarseAFC alone must still converge onto the offset.
+	if got := r.AFCBiasRadPerSample(); got <= 0 {
+		t.Errorf("AFCBiasRadPerSample = %.4f on a +%g Hz offset stream with CoarseAFC alone, want > 0", got, offsetHz)
+	}
+}
+
+// TestReceiverAFCOffsetHzUndoesMatchedFilterGain pins the issue #402
+// diagnostic correction: AFCOffsetHz must report the TRUE carrier
+// offset (~offsetHz), not the ≈sps×-inflated AFCBias·Fs/(2π) value the
+// state log used to print. That inflation sent three rounds of #402
+// chasing a phantom ~10 kHz error that was really ~1 kHz.
+func TestReceiverAFCOffsetHzUndoesMatchedFilterGain(t *testing.T) {
+	const (
+		sr       = 48_000.0
+		dev      = 1800.0
+		offsetHz = 1_500.0
+		nDibits  = 8_000
+	)
+	sps := sr / SymbolRate // 10
+	// Balanced stream so CoarseAFC converges cleanly onto the offset.
+	dibits := make([]uint8, nDibits)
+	for i := range dibits {
+		dibits[i] = uint8(i & 3)
+	}
+	iq := demod.ModulateP25C4FM(dibits, sr, dev)
+	iq = demod.ApplyImpairments(iq, sr, demod.Impairments{FreqOffsetHz: offsetHz})
+
+	r := New(Options{SampleRateHz: sr, DeviationHz: dev, DibitSink: func([]uint8, int) {}})
+	feedChunked(r, iq, 200, nil)
+
+	trueHz := r.AFCOffsetHz()
+	if math.Abs(trueHz-offsetHz)/offsetHz > 0.25 {
+		t.Errorf("AFCOffsetHz = %.1f Hz, want ≈ %g Hz (within 25%%) — true-offset conversion is wrong", trueHz, offsetHz)
+	}
+	// The old (wrong) Fs-form is ≈sps× larger; confirm AFCOffsetHz is
+	// NOT that value, i.e. the sps gain really was divided out.
+	oldForm := r.AFCBiasRadPerSample() * sr / (2 * math.Pi)
+	if ratio := oldForm / trueHz; math.Abs(ratio-sps) > 0.5 {
+		t.Errorf("old-form/AFCOffsetHz = %.2f, want ≈ sps = %.0f — AFCOffsetHz isn't dividing out the matched-filter gain", ratio, sps)
 	}
 }

--- a/internal/scanner/ccdecoder/pipelines.go
+++ b/internal/scanner/ccdecoder/pipelines.go
@@ -235,6 +235,11 @@ func newP25Phase1Pipeline(opts PipelineOptions) (ProtocolPipeline, error) {
 		// after the matched filter so DeviationHz isn't used.
 		DeviationHz: 1800.0,
 		DemodMode:   demodMode,
+		// EnableDecisionDirectedAFC intentionally left false: the
+		// daemon runs CoarseAFC-alone (the pre-DDA behaviour). The DDA
+		// can stably false-lock with no FSW/CC-lock feedback to catch
+		// it and was a net regression on the issue #402 capture; keep
+		// it off here until the eye-skew root cause is pinned.
 		DibitSink: func(dibits []uint8, baseIdx int) {
 			cc.Process(dibits, baseIdx)
 		},


### PR DESCRIPTION
## Summary

Addresses the latest round of issue #402 (MMR Site 9 — a P25 Phase 1 C4FM control channel that `p25_survey` decodes cleanly but GopherTrunk does not).

The decision-directed AFC (DDA) that was added to stop CoarseAFC's offset swing turned out to be a **net regression** on the original `mmr-s9` capture: it stably false-locks onto a biased eye and broke control-channel lock that CoarseAFC-alone had recovered (0/10 FSW hits with the DDA vs. **6/10 NID** without it). The receiver and the control channel are feed-forward siblings with **no FSW/CC-lock feedback** into the demod, so nothing internal catches a biased-but-self-consistent eye — yet the handoff commits to it.

Two findings reframed the investigation:
1. **`afc_hz_est` over-reported the offset by ≈`sps` (≈10×).** The C4FM matched filter has a DC gain of `sps`, so `AFCBias·Fs/(2π)` printed ~10 kHz when the true offset was ~1 kHz — three rounds of #402 chased a phantom.
2. **A *stable* wrong offset (DDA) is worse than CoarseAFC's *swing*,** which transiently hit the true value and gave the 6/10.

This PR neutralizes the regression and sharpens the diagnostics for the still-open eye-skew root cause. It does **not** attempt the eye-skew fix itself.

## Changes

- **DDA is now opt-in, default OFF.** Added `Options.EnableDecisionDirectedAFC` (default `false`). When off, `r.dda` is never allocated and the C4FM path runs **CoarseAFC-alone** (the pre-DDA path, every DDA branch is already guarded). The daemon (`pipelines.go`) leaves it off → production reverts to the known-good behaviour; `replay` exposes a `-dda` flag for A/B experimentation. The DDA code and tests are **retained** (gated, not deleted) for a future re-enable behind real lock-gating.

- **Fixed the misleading `afc_hz_est`.** Added `Receiver.AFCOffsetHz()` (`= AFCBias·SymbolRate/(2π)`, which divides the matched-filter `sps` DC-gain back out) and used it in the replay state log; the raw rad/sample value is kept alongside.

- **Added a signed-eye diagnostic** to `replay -diag`. The existing soft-sample histogram is magnitude-only and hid the sign bias; it now also reports the overall signed DC mean and the four per-decided-symbol soft centroids (+3/+1/−1/−3), so the next log bundle can distinguish a DC shift from a scale error from a gain asymmetry.

## Tests

- DDA receiver tests set the new flag.
- New guard: the default path runs CoarseAFC-alone (no DDA allocated, no handoff) while still emitting dibits and tracking the offset.
- New test: `AFCOffsetHz` reports the true offset (~1.5 kHz on a 1.5 kHz synthetic offset), not the `sps`-inflated value.
- `go build ./...`, `go vet`, and the full `internal/radio/p25/phase1/...`, `internal/scanner/ccdecoder/...`, `cmd/gophertrunk/...` suites pass.

## Still open (separate follow-up)

The dibit eye-skew root cause (inner/negative-heavy, +3 suppressed → FSW collapse, capping decode at ~60%) is **not** fixed here. The new signed-eye diagnostic is the instrument to pin it from the next log bundle, and the DDA can be re-enabled once it's gated on a real CC-lock signal.

https://claude.ai/code/session_0149tZvntzrxH18SkYULqCF9

---
_Generated by [Claude Code](https://claude.ai/code/session_0149tZvntzrxH18SkYULqCF9)_