### PR TITLE
daemon: fanoutSink fans raw IMBE/AMBE frames to rawFrameSinks (#356)

### DIFF
--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -657,6 +657,16 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 		var sink composer.PCMSink = d.recorder
 		if len(sinks) > 1 {
 			sink = fanoutSink(sinks)
+			// Surface the fanout wiring at startup so operators can
+			// confirm from logs that the raw-frame path is in place.
+			// Before the fanoutSink.WriteRawFrame fix (issue #356), a
+			// multi-sink config silently dropped every IMBE / AMBE
+			// frame and there was nothing in the logs to tell the
+			// operator the audio path was broken.
+			log.Info("composer: sink fanout configured",
+				"count", len(sinks), "raw_frames_supported", true)
+		} else {
+			log.Info("composer: sink direct configured")
 		}
 		comp, err := composer.New(composer.Options{
 			Bus:           d.bus,
@@ -1934,6 +1944,26 @@ type fanoutSink []composer.PCMSink
 func (f fanoutSink) WritePCM(serial string, samples []int16) error {
 	for _, s := range f {
 		_ = s.WritePCM(serial, samples)
+	}
+	return nil
+}
+
+// WriteRawFrame fans raw IMBE / AMBE frames out to every contained
+// sink that implements the rawFrameSink shape — currently just the
+// recorder. Sinks that don't (tone-out, live player, audio publisher)
+// are silently skipped. Without this the voice composer chains'
+// `rs, _ := c.sink.(rawFrameSink)` type assertion fails against a
+// fanoutSink, rs stays nil, and every IMBE / AMBE frame is dropped
+// before reaching disk while the activity counter still bumps —
+// producing healthy-looking call lifecycle logs alongside 0-byte
+// .raw and 44-byte (header-only) .wav files. Issue #356 root cause.
+func (f fanoutSink) WriteRawFrame(serial string, frame []byte) error {
+	for _, s := range f {
+		if rs, ok := s.(interface {
+			WriteRawFrame(string, []byte) error
+		}); ok {
+			_ = rs.WriteRawFrame(serial, frame)
+		}
 	}
 	return nil
 }

--- a/cmd/gophertrunk/daemon_fanout_test.go
+++ b/cmd/gophertrunk/daemon_fanout_test.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"sync"
+	"testing"
+)
+
+// rawFrameRecorder is a test stub that implements both the
+// composer.PCMSink shape (WritePCM) and the rawFrameSink shape
+// (WriteRawFrame). Plays the role of the real *voice.Recorder in
+// production fanouts.
+type rawFrameRecorder struct {
+	mu     sync.Mutex
+	pcm    map[string][][]int16
+	frames map[string][][]byte
+}
+
+func newRawFrameRecorder() *rawFrameRecorder {
+	return &rawFrameRecorder{
+		pcm:    make(map[string][][]int16),
+		frames: make(map[string][][]byte),
+	}
+}
+
+func (r *rawFrameRecorder) WritePCM(serial string, samples []int16) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	cp := append([]int16(nil), samples...)
+	r.pcm[serial] = append(r.pcm[serial], cp)
+	return nil
+}
+
+func (r *rawFrameRecorder) WriteRawFrame(serial string, frame []byte) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	cp := append([]byte(nil), frame...)
+	r.frames[serial] = append(r.frames[serial], cp)
+	return nil
+}
+
+func (r *rawFrameRecorder) framesFor(serial string) [][]byte {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([][]byte, len(r.frames[serial]))
+	copy(out, r.frames[serial])
+	return out
+}
+
+// pcmOnlySink implements only WritePCM. Stands in for sinks like the
+// tone-out detector, the live player, and the audio publisher — none
+// of which consume raw IMBE / AMBE frames.
+type pcmOnlySink struct {
+	mu      sync.Mutex
+	written int
+}
+
+func (s *pcmOnlySink) WritePCM(_ string, _ []int16) error {
+	s.mu.Lock()
+	s.written++
+	s.mu.Unlock()
+	return nil
+}
+
+// TestFanoutSinkWriteRawFrameReachesRawFrameSinks is the regression
+// guard for issue #356. Before the fix, fanoutSink implemented only
+// WritePCM, so the voice composer chains' rs, _ := c.sink.(rawFrameSink)
+// type assertion failed against any multi-sink production wiring (e.g.
+// recorder + audio publisher). rs stayed nil, every IMBE / AMBE frame
+// was dropped at the `if rs == nil { return }` short-circuit, and
+// .raw files came out 0 bytes / .wav files came out 44 bytes (header
+// only). This test asserts that fanoutSink.WriteRawFrame fans the
+// frame out to every contained sink that implements the rawFrameSink
+// shape and silently skips the ones that don't.
+func TestFanoutSinkWriteRawFrameReachesRawFrameSinks(t *testing.T) {
+	rec := newRawFrameRecorder()
+	pcm := &pcmOnlySink{}
+	fanout := fanoutSink{rec, pcm}
+
+	frame := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b}
+	if err := fanout.WriteRawFrame("VOICE-1", frame); err != nil {
+		t.Fatalf("WriteRawFrame: %v", err)
+	}
+
+	got := rec.framesFor("VOICE-1")
+	if len(got) != 1 {
+		t.Fatalf("recorder frames = %d, want 1", len(got))
+	}
+	if string(got[0]) != string(frame) {
+		t.Errorf("recorder frame = %x, want %x", got[0], frame)
+	}
+	if pcm.written != 0 {
+		t.Errorf("pcm-only sink got %d WritePCM calls; WriteRawFrame must not call WritePCM on it", pcm.written)
+	}
+}
+
+// TestFanoutSinkWriteRawFrameNoRawSinks confirms that a fanout with
+// no rawFrameSink-implementing members returns nil without error.
+// Mirrors the "every downstream is PCM-only" edge of the dispatcher.
+func TestFanoutSinkWriteRawFrameNoRawSinks(t *testing.T) {
+	a, b := &pcmOnlySink{}, &pcmOnlySink{}
+	fanout := fanoutSink{a, b}
+
+	if err := fanout.WriteRawFrame("VOICE-1", []byte{0xaa}); err != nil {
+		t.Errorf("WriteRawFrame with no raw sinks should be nil; got %v", err)
+	}
+	if a.written != 0 || b.written != 0 {
+		t.Errorf("WriteRawFrame must not call WritePCM on any sink; got a=%d b=%d", a.written, b.written)
+	}
+}
+
+// TestFanoutSinkWritePCMUnchanged is the negative-space guard: the
+// existing WritePCM fanout behaviour must remain unchanged by the
+// WriteRawFrame addition.
+func TestFanoutSinkWritePCMUnchanged(t *testing.T) {
+	rec := newRawFrameRecorder()
+	pcm := &pcmOnlySink{}
+	fanout := fanoutSink{rec, pcm}
+
+	samples := []int16{1, 2, 3, 4}
+	if err := fanout.WritePCM("VOICE-1", samples); err != nil {
+		t.Fatalf("WritePCM: %v", err)
+	}
+	if pcm.written != 1 {
+		t.Errorf("pcm-only sink WritePCM count = %d, want 1", pcm.written)
+	}
+	rec.mu.Lock()
+	gotPCM := len(rec.pcm["VOICE-1"])
+	rec.mu.Unlock()
+	if gotPCM != 1 {
+		t.Errorf("recorder WritePCM count = %d, want 1", gotPCM)
+	}
+}


### PR DESCRIPTION
## Summary

Issue #356 root cause. v2maldo's [post-PR-#426 follow-up](https://github.com/MattCheramie/GopherTrunk/issues/356#issuecomment-4569101369) is the smoking-gun report: every `.raw` file is 0 bytes and every `.wav` is 44 bytes (just the RIFF header). The composer's startup line fires, `LastHeardAt` advances past `StartedAt` (so the watchdog now reaps with `reason=normal` — the PR #426 classification working), but no audio reaches disk. That's also the original symptom from issue #356's very first comment ("Also, I have no sound from the VC").

Every production daemon wraps the recorder in a `fanoutSink` because `d.audioPub` is appended unconditionally at `cmd/gophertrunk/daemon.go:656`, so the composer's `Sink` is always the multi-sink wrapper. `fanoutSink` only implemented `WritePCM` — not `WriteRawFrame` — so the voice composer chains' type assertion `rs, _ := c.sink.(rawFrameSink)` failed, `rs` stayed `nil`, and every chain (P25 P1, P25 P2, DMR) short-circuited the IMBE / AMBE write path:

```go
frames.Add(1)                  // bumps Touch → reason=normal at reap
if rs == nil { return }        // ← drops the audio path on the floor
fs, _, err := phase1.ExtractVoiceFrames(ldu)
...
rs.WriteRawFrame(serial, f)    // never reached
```

That's the exact fingerprint of v2maldo's report — the activity counter advances (because `frames.Add(1)` runs before the nil check) but `WriteRawFrame` is never called, so the recorder sees no IMBE / AMBE frames and the WAV writer never appends PCM.

`fanoutSink.WriteRawFrame` now walks contained sinks, type-asserts each against an inline `rawFrameSink` shape, calls `WriteRawFrame` on those that implement it (the recorder), and skips those that don't (tone-out, live player, audio publisher). Errors are swallowed to match the existing `WritePCM` policy — the recorder's own warn logs surface failures.

Also surface the sink wiring at daemon startup so operators can confirm from logs that the raw-frame fanout is in place:

```
composer: sink fanout configured count=N raw_frames_supported=true
```

## Why the existing composer tests didn't catch this

`TestComposerP25Phase1VoiceChainExtractsRawFrames` and the DMR / Phase 2 equivalents all wire a single `recordingSink{}` stub that implements both `WritePCM` and `WriteRawFrame` — they never construct a fanout, so the type-assertion path the production code takes is invisible to the suite. The new test in `cmd/gophertrunk/daemon_fanout_test.go` specifically targets the multi-sink wrapper.

## Test plan

- [x] `TestFanoutSinkWriteRawFrameReachesRawFrameSinks` — fans to a recorder stand-in, skips a PCM-only sink (assert frame received on recorder, no spurious `WritePCM` on the PCM-only one)
- [x] `TestFanoutSinkWriteRawFrameNoRawSinks` — all-PCM-only fanout returns nil without error
- [x] `TestFanoutSinkWritePCMUnchanged` — negative-space guard: WritePCM behaviour unchanged
- [x] `go test -race -count=1 ./cmd/gophertrunk/ ./internal/voice/... ./internal/voice/composer/...` — green
- [x] `go build ./cmd/gophertrunk` — green
- [x] `go vet` / `gofmt -l` on touched files — clean
- [ ] v2maldo's next field log: `.raw` ≥ 99 bytes per LDU (typically thousands of bytes for a multi-second call), `.wav` significantly larger than 44 bytes with audible IMBE-decoded audio, and `composer: sink fanout configured count=N raw_frames_supported=true` at startup

https://claude.ai/code/session_01Wd3QwYCiYJvgFgYc1MgtXt

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wd3QwYCiYJvgFgYc1MgtXt)_