### PR TITLE
dsc: protocol layer + bus + storage + REST + panel scaffolding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,52 @@ for tagged releases.
 
 ### Added
 
+- **DSC marine — protocol layer + bus / storage / REST / panel
+  scaffolding.** First slice of Phase 5 DSC: GMDSS Digital
+  Selective Calling messages — distress alerts, urgency / safety
+  broadcasts, individual / group / all-ships routine calls — are
+  the SOLAS-mandated digital signalling on marine VHF channel 70
+  (156.525 MHz) and the HF DSC channels. A coast-guard MMSI
+  lighting up the channel-70 stream is near-instant visibility
+  into SAR activity.
+  New `internal/radio/dsc` package decodes ITU-R M.493-15
+  formats: Distress (self-MMSI + nature + position + UTC time),
+  All-Ships safety / urgency / routine, Individual call
+  (target + source MMSI), Group, Geographic-area, and
+  Auto-Individual. BCH(10,7) syndrome check (CRC-3 with
+  `g(x) = x³+x+1`) — the spec calls it "BCH" but min Hamming
+  distance is 2, so single-bit errors are reliably **detected**
+  but not corrected at this layer; DSC achieves the actual
+  correction via DX / RX redundancy at the bit-stream layer
+  above (each character is sent twice and the receiver compares
+  the two streams).
+  MMSI codec unpacks 5 symbols × 2 digits → 9-digit MMSI.
+  Position codec decodes the 10-digit `Q.DD.MM.DDD.MM` format
+  with quadrant-bit hemisphere flip (0 = NE, 1 = NW, 2 = SE,
+  3 = SW). The all-9s "position unknown" sentinel collapses
+  `HasPosition` to false.
+  New `events.KindDSCMessage` event + `storage.DSCMessage`
+  payload + `dsc_log` SQLite table (one row per decoded
+  sequence, indexes on `(received_at)` and
+  `(self_mmsi, received_at)`). `storage.DSCLog` subscriber
+  drains the bus and writes one row per message; the daemon
+  spawns it alongside `vesselLog` / `aprsLog` / `pagerLog`.
+  New REST endpoint `GET /api/v1/dsc/messages?limit=N` (default
+  200, max 5000) and web panel `/dsc` with columns Received /
+  Format / Category / Self MMSI / Target-or-Nature / Body /
+  Lat-Lon. Rows tint by category — distress = red, urgency =
+  orange, safety = blue, routine = default.
+  Tests: 15 protocol-layer (BCH round-trip + syndrome check +
+  single-bit error detection, MMSI codec, position quadrant
+  signs, position unknown-sentinel, end-to-end distress decode
+  with position + nature + UTC time, individual-call decode,
+  all-ships safety decode, short-payload safety), 4 storage
+  (insert distress / individual / filter / order), 3 REST
+  (503 / list / limit), 4 web (empty / distress / individual /
+  error). All passing.
+- DSP frontend (1200 Bd FSK at 1300 / 2100 Hz tones + 10-bit
+  symbol assembly + DX/RX redundancy merge) follows as the
+  next slice. See [docs/dsc.md](docs/dsc.md).
 - **AIS DSP frontend + receiver glue — pipeline is now end-to-end.**
   Second slice of Phase 5 AIS: `internal/radio/ais/receiver` is the
   bit-stream orchestrator (HDLC framer → CRC-CCITT validation →

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -112,6 +112,7 @@ type Daemon struct {
 	pagerLog     *storage.PagerLog
 	aprsLog      *storage.APRSLog
 	vesselLog    *storage.VesselLog
+	dscLog       *storage.DSCLog
 	messageLog   *gtlog.MessageLog
 	retention    *storage.Retention
 	ccCache      *trunking.Cache
@@ -1065,6 +1066,13 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 		}
 		d.vesselLog = vl
 
+		dl, err := storage.NewDSCLog(db, d.bus, log)
+		if err != nil {
+			db.Close()
+			return nil, fmt.Errorf("daemon: dsc log: %w", err)
+		}
+		d.dscLog = dl
+
 		if cfg.Retention.CallLogDays > 0 || cfg.Retention.FilesDays > 0 {
 			interval, err := retentionInterval(cfg.Retention.Interval)
 			if err != nil {
@@ -1130,6 +1138,9 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 		}
 		if d.vesselLog != nil {
 			opts.AIS = aisProvider{log: d.vesselLog}
+		}
+		if d.dscLog != nil {
+			opts.DSC = dscProvider{log: d.dscLog}
 		}
 		if d.db != nil {
 			opts.History = api.HistoryFromStorage(d.db)
@@ -1306,6 +1317,11 @@ func (d *Daemon) Run(ctx context.Context) error {
 	if d.vesselLog != nil {
 		d.spawn(runCtx, "vessellog", false, func(ctx context.Context) error {
 			return d.vesselLog.Run(ctx)
+		})
+	}
+	if d.dscLog != nil {
+		d.spawn(runCtx, "dsclog", false, func(ctx context.Context) error {
+			return d.dscLog.Run(ctx)
 		})
 	}
 	if d.messageLog != nil {
@@ -1599,6 +1615,9 @@ func (d *Daemon) Close() {
 		}
 		if d.vesselLog != nil {
 			_ = d.vesselLog.Close()
+		}
+		if d.dscLog != nil {
+			_ = d.dscLog.Close()
 		}
 		if d.messageLog != nil {
 			_ = d.messageLog.Close()
@@ -2364,6 +2383,15 @@ type aisProvider struct{ log *storage.VesselLog }
 
 func (a aisProvider) RecentAISMessages(limit int) ([]storage.AISMessage, error) {
 	return a.log.Recent(limit)
+}
+
+// dscProvider adapts storage.DSCLog into api.DSCProvider so the
+// api package stays free of the storage import dependency. Read-only
+// — the decoder writes via the events bus.
+type dscProvider struct{ log *storage.DSCLog }
+
+func (d dscProvider) RecentDSCMessages(limit int) ([]storage.DSCMessage, error) {
+	return d.log.Recent(limit)
 }
 
 // aprsSpec captures the broker-side wiring info for one configured

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -301,6 +301,25 @@ sdr:
 #                                     #  messages and keep only vessel
 #                                     #  position reports
 
+# DSC marine distress / safety / routine calls. The DSP frontend
+# (1200 Bd FSK on channel 70 = 156.525 MHz, mark 1300 Hz / space
+# 2100 Hz) ships in a follow-up PR; the protocol parser + bus +
+# storage + REST + panel scaffolding is live now. Operators
+# subscribing to the events.KindDSCMessage bus topic (e.g. a
+# custom CL replay tool) get decoded messages as soon as they
+# feed symbols into dsc.Decode.
+#
+# dsc:
+#   channels:
+#     - serial: "marine-antenna"      # SDR serial (must be in sdr.devices
+#                                     #  or sdr.rtl_tcp)
+#       frequency_hz: 156_525_000     # marine VHF channel 70 (or one of
+#                                     #  the HF DSC channels: 2_187_500,
+#                                     #  8_414_500, 12_577_000, 16_804_500)
+#       drop_non_distress: false      # true to drop routine / safety
+#                                     #  chatter and keep only distress
+#                                     #  + urgency alerts
+
 trunking:
   # call_timeout_ms: inactivity window after which the engine's
   # watchdog ends a call (publishes CallEnd with EndReasonTimeout

--- a/docs/dsc.md
+++ b/docs/dsc.md
@@ -1,0 +1,131 @@
+---
+layout: page
+title: DSC / Marine Distress
+description: Decoded marine DSC pipeline — events bus, SQLite log, REST endpoint, web panel
+nav_group: Reference
+---
+
+# DSC / Marine Distress
+
+GopherTrunk decodes **Digital Selective Calling** messages —
+the SOLAS-mandated digital signalling that triggers distress /
+urgency / safety / routine calls on marine VHF channel 70
+(156.525 MHz) and the medium / high-frequency DSC channels
+(2.187.5, 8.414.5, 12.577, 16.804.5 kHz). DSC is what fires every
+GMDSS distress alert; the routine calls broadcast the working
+voice channel two stations are about to switch to. A coast-guard
+MMSI lighting up the channel-70 stream is near-instant visibility
+into search-and-rescue activity.
+
+This page documents the **pipeline scaffolding**: what's wired,
+what's persisted, what's queryable, and what the web panel
+renders. The DSP layer (1200 Bd FSK at 1300 / 2100 Hz tones →
+10-bit symbol assembly → BCH check + DX/RX redundancy → 7-bit
+symbol stream to `dsc.Decode`) is tracked separately under
+"What's pending" below.
+
+## What's wired
+
+### Events bus
+- `events.KindDSCMessage` — published once per decoded DSC
+  sequence. Payload is a `storage.DSCMessage` carrying source
+  MMSI + format (distress / all-ships / individual / ...) +
+  category (distress / urgency / safety / routine) + nature
+  (for distress alerts) + position (for distress alerts that
+  included one) + time UTC.
+
+### Storage
+- New SQLite table `dsc_log` (append-only migration alongside
+  `vessel_log`, `aprs_log`, `pager_log`):
+  - `received_at` (nanoseconds), `format`, `category`,
+    `self_mmsi`, `target_mmsi`, `nature`, `time_utc`,
+    `latitude`, `longitude`, `has_position`, `body`, `raw_hex`
+  - Indexes on `(received_at)` and `(self_mmsi, received_at)`
+- `storage.DSCLog` bus subscriber writes one row per
+  `KindDSCMessage` event. Mirrors the `VesselLog` / `APRSLog`
+  lifecycle — subscribes at construction so events published
+  before `Run()` begins aren't lost.
+
+### REST
+- `GET /api/v1/dsc/messages?limit=N` — most recent sequences,
+  newest first. Default 200, max 5000. Returns 503 when the
+  storage layer isn't wired (daemon started without
+  `storage.path`).
+
+### Web panel
+- `/dsc` — live list with columns:
+  - Received (HH:MM:SS, daemon clock)
+  - Format (distress / all-ships / individual / group / ...)
+  - Category (distress / urgency / safety / routine)
+  - Self MMSI
+  - Target / Nature (target MMSI for individual / group calls;
+    distress nature for distress alerts)
+  - Body (one-line summary; distress alerts include the time
+    UTC on a second line)
+  - Lat / Lon (em-dash for non-position-bearing messages)
+- Polls every 5 s. Rows tint by category: distress = red,
+  urgency = orange, safety = blue, routine = default.
+
+## Protocol layer (`internal/radio/dsc`)
+
+Pure-Go DSC message parser. The bit-stream layer above
+(separate PR) handles sync detection, BCH(10,7) syndrome check,
+and the DX / RX redundancy merge — by the time symbols reach
+`dsc.Decode` each entry is one 7-bit value 0..127.
+
+- **BCH(10,7) codec** (`bch.go`) — encode + check helpers
+  for the CRC-3 wrapper ITU-R M.493-15 §3.4 specifies. Generator
+  polynomial `g(x) = x³ + x + 1` (binary `1011`). The code's
+  minimum Hamming distance is **2**, not 3, so the syndrome
+  reliably **detects** single-bit errors but doesn't reliably
+  **correct** them at this layer — DSC achieves the actual
+  correction via DX/RX redundancy (each character is sent
+  twice on the wire and the receiver compares the two streams).
+- **MMSI codec** (`codec.go`) — 5 symbols × 2 decimal digits
+  per symbol decode to a 9-digit MMSI (the 10th digit is the
+  format-extension nibble and ignored).
+- **Position codec** (`codec.go`) — 5 symbols carrying a
+  10-digit position string `Q.DD.MM.DDD.MM` where `Q` is the
+  quadrant (0 = NE, 1 = NW, 2 = SE, 3 = SW). The all-9s sentinel
+  for "position unknown" surfaces as `HasPosition = false`.
+- **Type dispatch** (`dsc.go`) — recognises every numbered
+  format (112 = Distress, 116 = AllShips, 114 = Group, 120 =
+  Individual, 102 = Geographic, 123 = AutoIndividual) and
+  decodes the format-specific payload:
+  - **Distress**: self-MMSI + nature of distress + position +
+    time UTC.
+  - **Non-distress**: target MMSI + category + self-MMSI;
+    remaining fields stay on `RawSymbols` for the follow-up
+    per-format parser.
+
+Spec references:
+- ITU-R M.493-15 (Recommendation, 2019) — DSC message format,
+  symbol table, BCH(10,7) check, nature-of-distress codes.
+- ITU-R M.541 — operational use, station identification,
+  category routing.
+
+## What's pending
+
+- **DSP receiver.** 1200 Bd FSK (mark 1300 Hz, space 2100 Hz)
+  on channel 70 (VHF) or one of the HF DSC channels. Pipeline:
+  iqtap broker subscriber → FM demod → FFSK discriminator
+  (reusing `internal/dsp/demod/ffsk` with DSC's tone
+  frequencies) → symbol-time recovery → 10-bit symbol assembly
+  → BCH syndrome check → DX / RX redundancy merge → 7-bit
+  symbol stream into `dsc.Decode`. Pattern matches the APRS /
+  AIS DSP frontends.
+- **Multi-frame protocol.** A few DSC sequence types span
+  multiple slots when transmitted (Auto-Individual ACK chains,
+  multi-recipient calls). The single-frame parser covers the
+  operational majority; the multi-frame path needs a per-MMSI
+  buffer plus a sequence reassembler.
+- **Live map.** Distress alerts that include a position can
+  light up the same Leaflet / MapLibre overlay APRS + AIS
+  positions are planned to share.
+
+## References
+
+- ITU-R M.493-15 (2019) "Digital selective-calling system for
+  use in the maritime mobile service" —
+  `https://www.itu.int/rec/R-REC-M.493`
+- ITU-R M.541 — operational guidance.

--- a/internal/api/handlers_dsc.go
+++ b/internal/api/handlers_dsc.go
@@ -1,0 +1,82 @@
+package api
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/storage"
+)
+
+// DSCProvider is the read surface the dsc-log endpoint consumes.
+// The daemon implements it on top of storage.DSCLog; tests
+// substitute a fake.
+type DSCProvider interface {
+	RecentDSCMessages(limit int) ([]storage.DSCMessage, error)
+}
+
+// DSCMessageDTO is the JSON wire shape for the dsc-log endpoint.
+// Position fields and distress-only fields stay omitted from the
+// JSON when zero / empty so the routine-call wire stays compact.
+type DSCMessageDTO struct {
+	ID         int64     `json:"id"`
+	ReceivedAt time.Time `json:"received_at"`
+	Format     string    `json:"format"`
+	Category   string    `json:"category"`
+	SelfMMSI   uint64    `json:"self_mmsi"`
+	TargetMMSI uint64    `json:"target_mmsi,omitempty"`
+	Nature     string    `json:"nature,omitempty"`
+	TimeUTC    string    `json:"time_utc,omitempty"`
+
+	Latitude    float64 `json:"latitude,omitempty"`
+	Longitude   float64 `json:"longitude,omitempty"`
+	HasPosition bool    `json:"has_position"`
+
+	Body   string `json:"body,omitempty"`
+	RawHex string `json:"raw_hex,omitempty"`
+}
+
+func dscMessageToDTO(m storage.DSCMessage) DSCMessageDTO {
+	return DSCMessageDTO{
+		ID:          m.ID,
+		ReceivedAt:  m.ReceivedAt,
+		Format:      m.Format,
+		Category:    m.Category,
+		SelfMMSI:    m.SelfMMSI,
+		TargetMMSI:  m.TargetMMSI,
+		Nature:      m.Nature,
+		TimeUTC:     m.TimeUTC,
+		Latitude:    m.Latitude,
+		Longitude:   m.Longitude,
+		HasPosition: m.HasPosition,
+		Body:        m.Body,
+		RawHex:      m.RawHex,
+	}
+}
+
+// handleDSCMessages answers GET /api/v1/dsc/messages. Optional
+// ?limit= (default 200, max 5000). 503 when the storage layer
+// isn't wired (daemon started without storage.path).
+func (s *Server) handleDSCMessages(w http.ResponseWriter, r *http.Request) {
+	if s.dsc == nil {
+		writeError(w, http.StatusServiceUnavailable, "dsc subsystem not enabled")
+		return
+	}
+	limit := 200
+	if v := r.URL.Query().Get("limit"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			limit = n
+		}
+	}
+	rows, err := s.dsc.RecentDSCMessages(limit)
+	if err != nil {
+		s.log.Error("api: dsc messages", "err", err)
+		writeError(w, http.StatusInternalServerError, "query failed")
+		return
+	}
+	out := make([]DSCMessageDTO, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, dscMessageToDTO(r))
+	}
+	writeJSON(w, http.StatusOK, out)
+}

--- a/internal/api/handlers_dsc_test.go
+++ b/internal/api/handlers_dsc_test.go
@@ -1,0 +1,122 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/storage"
+)
+
+type fakeDSCProvider struct {
+	msgs []storage.DSCMessage
+}
+
+func (f *fakeDSCProvider) RecentDSCMessages(limit int) ([]storage.DSCMessage, error) {
+	if limit > 0 && limit < len(f.msgs) {
+		return f.msgs[:limit], nil
+	}
+	return f.msgs, nil
+}
+
+func newDSCTestServer(t *testing.T, prov DSCProvider) *httptest.Server {
+	t.Helper()
+	bus := events.NewBus(8)
+	t.Cleanup(bus.Close)
+	srv, err := NewServer(ServerOptions{
+		Addr: "127.0.0.1:0",
+		Bus:  bus,
+		DSC:  prov,
+	})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	ts := httptest.NewServer(srv.routes())
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+func TestDSCMessagesReturns503WhenNotWired(t *testing.T) {
+	ts := newDSCTestServer(t, nil)
+	resp, err := http.Get(ts.URL + "/api/v1/dsc/messages")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want 503", resp.StatusCode)
+	}
+}
+
+func TestDSCMessagesReturnsList(t *testing.T) {
+	prov := &fakeDSCProvider{msgs: []storage.DSCMessage{
+		{
+			ID:          1,
+			ReceivedAt:  time.Unix(1735000000, 0).UTC(),
+			Format:      "distress",
+			Category:    "distress",
+			SelfMMSI:    366053209,
+			Nature:      "fire / explosion",
+			TimeUTC:     "14:25",
+			Latitude:    37.8,
+			Longitude:   122.4,
+			HasPosition: true,
+			Body:        "DISTRESS MMSI=366053209",
+		},
+		{
+			ID:         2,
+			ReceivedAt: time.Unix(1735000010, 0).UTC(),
+			Format:     "individual",
+			Category:   "routine",
+			SelfMMSI:   366053210,
+			TargetMMSI: 3660000,
+			Body:       "INDIVIDUAL routine",
+		},
+	}}
+	ts := newDSCTestServer(t, prov)
+	resp, err := http.Get(ts.URL + "/api/v1/dsc/messages")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	var got []DSCMessageDTO
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2", len(got))
+	}
+	if got[0].Format != "distress" || !got[0].HasPosition {
+		t.Errorf("row 0 = %+v", got[0])
+	}
+	if got[1].TargetMMSI != 3660000 {
+		t.Errorf("row 1 target = %d", got[1].TargetMMSI)
+	}
+}
+
+func TestDSCMessagesRespectsLimit(t *testing.T) {
+	prov := &fakeDSCProvider{}
+	for i := uint64(0); i < 10; i++ {
+		prov.msgs = append(prov.msgs, storage.DSCMessage{
+			ID:       int64(i + 1),
+			SelfMMSI: 366050000 + i,
+		})
+	}
+	ts := newDSCTestServer(t, prov)
+	resp, err := http.Get(ts.URL + "/api/v1/dsc/messages?limit=3")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	var got []DSCMessageDTO
+	_ = json.NewDecoder(resp.Body).Decode(&got)
+	if len(got) != 3 {
+		t.Errorf("limit=3 len = %d, want 3", len(got))
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -286,6 +286,12 @@ type Server struct {
 	// storage.VesselLog.
 	ais AISProvider
 
+	// dsc is the optional provider backing /api/v1/dsc/...
+	// routes (marine DSC sequence log). nil disables the routes.
+	// Implemented by the daemon over the SQLite-backed
+	// storage.DSCLog.
+	dsc DSCProvider
+
 	mu     sync.Mutex
 	srv    *http.Server
 	closed bool
@@ -495,6 +501,11 @@ type ServerOptions struct {
 	// AIS messages. Wired by the daemon over the SQLite-backed
 	// storage.VesselLog.
 	AIS AISProvider
+	// DSC, when non-nil, enables the
+	// GET /api/v1/dsc/messages route serving recent decoded
+	// marine DSC sequences. Wired by the daemon over the
+	// SQLite-backed storage.DSCLog.
+	DSC DSCProvider
 	// CORS configures the cross-origin middleware. Off when
 	// AllowedOrigins is empty (the daemon emits no CORS headers).
 	// Set this when the browser-served SPA is loaded from an
@@ -596,6 +607,7 @@ func NewServer(opts ServerOptions) (*Server, error) {
 		pager:          opts.Pager,
 		aprs:           opts.APRS,
 		ais:            opts.AIS,
+		dsc:            opts.DSC,
 	}, nil
 }
 
@@ -797,6 +809,7 @@ func (s *Server) routes() *http.ServeMux {
 	// the decoder writes via the events bus → APRSLog.
 	mux.HandleFunc("GET /api/v1/aprs/packets", s.handleAPRSPackets)
 	mux.HandleFunc("GET /api/v1/ais/vessels", s.handleAISMessages)
+	mux.HandleFunc("GET /api/v1/dsc/messages", s.handleDSCMessages)
 
 	// Embedded SPA at "/" — served only when the daemon was linked
 	// against a populated web/dist embed. SPA history routes

--- a/internal/events/bus.go
+++ b/internal/events/bus.go
@@ -139,6 +139,13 @@ const (
 	// position + speed + course + vessel name (where available).
 	// Surfaced over SSE / WS for the live AIS panel.
 	KindAISMessage Kind = "ais.message"
+	// KindDSCMessage fires when the DSC decoder finishes one
+	// sequence off the marine VHF channel-70 (156.525 MHz) DSC
+	// channel or one of the HF DSC channels. Payload is a
+	// storage.DSCMessage carrying source / target MMSI + format
+	// + category + (for distress alerts) position + nature.
+	// Surfaced over SSE / WS for the live DSC panel.
+	KindDSCMessage Kind = "dsc.message"
 )
 
 // Stage names a particular FEC / parser checkpoint inside a protocol

--- a/internal/radio/dsc/bch.go
+++ b/internal/radio/dsc/bch.go
@@ -1,0 +1,65 @@
+package dsc
+
+// BCH(10,7) is the forward-error-correction code DSC wraps around
+// every 7-bit data symbol. ITU-R M.493-15 §3.4: each transmitted
+// "character" is 10 bits — 7 data bits (LSB-first inside the
+// codeword) followed by 3 check bits computed as a CRC-3 with
+// generator polynomial g(x) = x³ + x + 1 (binary 1011).
+//
+// Despite the "BCH" label the spec uses, the code's minimum
+// Hamming distance is 2 — single-bit errors are reliably
+// **detected** but not reliably **corrected** at this layer.
+// Multiple legal codewords lie within distance 1 of any received
+// word (for example, encode(69) and encode(85) differ in only 2
+// bits, so flipping the right bit of a corrupted encode(85) can
+// produce a valid encode(69)). DSC achieves the actual error
+// correction through DX / RX redundancy: each character is sent
+// twice, the receiver compares the two streams, and a mismatch
+// triggers re-acquisition via the next available redundant copy.
+// That comparison lives in the bit-stream layer above this
+// package.
+//
+// Encoding: the codeword is the systematic form data×2³ +
+// (data×2³) mod g(x). Decoding here is just the syndrome check —
+// callers should treat a non-zero syndrome as "this symbol
+// failed; drop it and rely on the DX/RX redundant pair".
+
+// BCHEncode wraps a 7-bit data symbol into its 10-bit BCH(10,7)
+// codeword. data must be in 0..127; values outside are masked to
+// the low 7 bits.
+func BCHEncode(data uint16) uint16 {
+	data &= 0x7F
+	// Shift data left 3 to make room for parity, then compute
+	// parity = (data << 3) mod g(x). g(x) = x³ + x + 1 = 0b1011 = 11.
+	dividend := data << 3
+	for i := 9; i >= 3; i-- {
+		if dividend&(1<<uint(i)) != 0 {
+			dividend ^= 0xB << uint(i-3)
+		}
+	}
+	return (data << 3) | (dividend & 0x7)
+}
+
+// BCHCheck verifies the 10-bit codeword's CRC-3 parity. Returns
+// (data, true) when the syndrome is zero (no error detected),
+// (data, false) when the syndrome is non-zero. In both cases the
+// returned data is the raw 7 data bits from the codeword; on
+// !ok the caller is expected to drop the symbol and rely on the
+// DX / RX redundant copy.
+func BCHCheck(codeword uint16) (uint16, bool) {
+	codeword &= 0x3FF
+	syndrome := bchSyndrome(codeword)
+	return (codeword >> 3) & 0x7F, syndrome == 0
+}
+
+// bchSyndrome computes the 3-bit syndrome of a codeword by
+// dividing it by g(x) = 0x0B and returning the remainder.
+func bchSyndrome(codeword uint16) uint16 {
+	r := codeword & 0x3FF
+	for i := 9; i >= 3; i-- {
+		if r&(1<<uint(i)) != 0 {
+			r ^= 0xB << uint(i-3)
+		}
+	}
+	return r & 0x7
+}

--- a/internal/radio/dsc/bch_test.go
+++ b/internal/radio/dsc/bch_test.go
@@ -1,0 +1,49 @@
+package dsc
+
+import "testing"
+
+func TestBCHEncodeCheckRoundTrip(t *testing.T) {
+	// Every 7-bit data value should encode → check back to itself
+	// with the "clean" success signal.
+	for data := uint16(0); data < 128; data++ {
+		cw := BCHEncode(data)
+		got, ok := BCHCheck(cw)
+		if !ok {
+			t.Errorf("BCHCheck(encode(%d)) = !ok", data)
+		}
+		if got != data {
+			t.Errorf("round-trip: data = %d, got %d", data, got)
+		}
+	}
+}
+
+func TestBCHFlagsSingleBitErrorsAsSyndromeMismatch(t *testing.T) {
+	// Single-bit errors on parity bits (0..2) and most data bits
+	// flip the syndrome away from zero, so BCHCheck signals !ok.
+	// (The "BCH" name is a misnomer — the code's minimum Hamming
+	// distance is 2, not 3, so a single flip can also land on a
+	// neighbour codeword for some bit positions; the check
+	// detects only when the syndrome differs.)
+	data := uint16(0x55)
+	cw := BCHEncode(data)
+	flagged := 0
+	for bit := 0; bit < 10; bit++ {
+		corrupted := cw ^ (1 << uint(bit))
+		_, ok := BCHCheck(corrupted)
+		if !ok {
+			flagged++
+		}
+	}
+	if flagged < 7 {
+		t.Errorf("flagged %d/10 single-bit errors; want most of them", flagged)
+	}
+}
+
+func TestBCHSyndromeZeroForValidCodeword(t *testing.T) {
+	for data := uint16(0); data < 128; data++ {
+		cw := BCHEncode(data)
+		if syn := bchSyndrome(cw); syn != 0 {
+			t.Errorf("syndrome(encode(%d)) = %d, want 0", data, syn)
+		}
+	}
+}

--- a/internal/radio/dsc/codec.go
+++ b/internal/radio/dsc/codec.go
@@ -1,0 +1,116 @@
+package dsc
+
+import (
+	"encoding/hex"
+	"strconv"
+)
+
+// decodeMMSI decodes 5 consecutive 7-bit DSC symbols into a 9-digit
+// MMSI. ITU-R M.493-15 §3.5.3: each symbol encodes two decimal
+// digits (00..99). The 10th digit (low digit of the 5th symbol) is
+// the format-extension byte; the MMSI proper is the high 9 digits.
+//
+// Returns (mmsi, true) on a clean decode, (0, false) when any
+// symbol is out of range (>99, the spec's "not used" zone).
+func decodeMMSI(symbols []byte) (uint64, bool) {
+	if len(symbols) != 5 {
+		return 0, false
+	}
+	var mmsi uint64
+	for i, s := range symbols {
+		if s > 99 {
+			return 0, false
+		}
+		if i < 4 {
+			// First 4 symbols → 8 digits.
+			mmsi = mmsi*100 + uint64(s)
+		} else {
+			// 5th symbol's high digit is the 9th MMSI digit;
+			// low digit is the format extension (ignored).
+			mmsi = mmsi*10 + uint64(s)/10
+		}
+	}
+	return mmsi, true
+}
+
+// decodeDigitsPair turns one 7-bit symbol (0..99) into a 2-char
+// decimal string. Returns "" for invalid / "not used" symbols.
+func decodeDigitsPair(s byte) string {
+	if s > 99 {
+		return ""
+	}
+	return leftPad2(int(s))
+}
+
+// leftPad2 formats an integer 0..99 as a zero-padded 2-char string.
+func leftPad2(n int) string {
+	if n < 10 {
+		return "0" + strconv.Itoa(n)
+	}
+	return strconv.Itoa(n)
+}
+
+// decodePosition decodes 5 DSC symbols holding a 10-digit position
+// per ITU-R M.493-15 §3.5.3.6: 1 quadrant digit + 4 latitude digits
+// (DDMM) + 5 longitude digits (DDDMM). The first symbol's high
+// nibble is the quadrant code (0 = NE, 1 = NW, 2 = SE, 3 = SW); the
+// low nibble starts the latitude. The spec sentinel for "unknown
+// position" is all 9s — we collapse HasPosition to false in that
+// case.
+func decodePosition(symbols []byte) (Position, bool) {
+	if len(symbols) != 5 {
+		return Position{}, false
+	}
+	for _, s := range symbols {
+		if s > 99 {
+			return Position{}, false
+		}
+	}
+	// Build a 10-digit string Q.DD.MM.DDD.MM.
+	digits := make([]byte, 0, 10)
+	for _, s := range symbols {
+		digits = append(digits, '0'+(s/10), '0'+(s%10))
+	}
+	// Unknown sentinel: any digit being '9' for all 10 → position
+	// not available.
+	allNine := true
+	for _, d := range digits {
+		if d != '9' {
+			allNine = false
+			break
+		}
+	}
+	if allNine {
+		return Position{}, true
+	}
+	quadrant := digits[0] - '0'
+	if quadrant > 3 {
+		return Position{}, false
+	}
+	latDeg, err1 := strconv.Atoi(string(digits[1:3]))
+	latMin, err2 := strconv.Atoi(string(digits[3:5]))
+	lonDeg, err3 := strconv.Atoi(string(digits[5:8]))
+	lonMin, err4 := strconv.Atoi(string(digits[8:10]))
+	if err1 != nil || err2 != nil || err3 != nil || err4 != nil {
+		return Position{}, false
+	}
+	lat := float64(latDeg) + float64(latMin)/60.0
+	lon := float64(lonDeg) + float64(lonMin)/60.0
+	// Quadrant: bit 0 set = West, bit 1 set = South.
+	if quadrant&2 != 0 {
+		lat = -lat
+	}
+	if quadrant&1 != 0 {
+		lon = -lon
+	}
+	return Position{Latitude: lat, Longitude: lon, HasPosition: true}, true
+}
+
+// symbolsToHex hex-encodes the 7-bit symbol stream for raw_payload
+// logging. Each symbol packs into one byte.
+func symbolsToHex(symbols []byte) string {
+	if len(symbols) == 0 {
+		return ""
+	}
+	return hex.EncodeToString(symbols)
+}

--- a/internal/radio/dsc/dsc.go
+++ b/internal/radio/dsc/dsc.go
@@ -1,0 +1,296 @@
+// Package dsc decodes Digital Selective Calling messages
+// transmitted on marine VHF channel 70 (156.525 MHz) and
+// medium / high-frequency DSC channels (2.187.5 kHz, 8.414.5 kHz,
+// etc.). DSC is the SOLAS-mandated digital calling protocol used
+// for distress / urgency / safety alerts, ship-to-ship paging,
+// and the routine call-up that precedes a voice working-frequency
+// hand-off — every Class A AIS-equipped vessel also carries a DSC
+// controller, and shore stations (CG, RCC, coast radio) listen
+// continuously.
+//
+// Why DSC: distress alerts are the highest-priority operational
+// data on marine VHF, and DSC is what triggers them. A coast-
+// guard MMSI on the channel-70 DSC stream landing in the bus
+// gives operators near-instant visibility into search-and-rescue
+// activity; the routine calls give working-frequency
+// announcements (which channel two stations are about to switch
+// to for voice traffic).
+//
+// This package owns the protocol parsing: 7-bit data symbols
+// (already BCH-corrected by the bit-stream layer above) come in,
+// a typed Message with the format / category / source MMSI /
+// (where present) position + time + working channel comes out.
+// Less-common formats stay tagged with TypeUnknown and the raw
+// symbols preserved.
+//
+// Spec references:
+//   - ITU-R M.493-15 (Recommendation, 2019) — DSC message format,
+//     symbol table, BCH(10,7) FEC. Authoritative.
+//   - ITU-R M.541 — operational use, station identification.
+package dsc
+
+import (
+	"fmt"
+)
+
+// Format identifies the DSC message format specifier — the first
+// byte after the phasing sequence. ITU-R M.493-15 Table 3.5.
+type Format uint8
+
+const (
+	FormatUnknown        Format = 0
+	FormatDistress       Format = 112 // "Distress alert"
+	FormatAllShips       Format = 116 // "All ships"
+	FormatGroup          Format = 114 // "Group call"
+	FormatIndividual     Format = 120 // "Individual call"
+	FormatGeographic     Format = 102 // "Geographic-area call"
+	FormatDistressRelay  Format = 116 // Same byte as AllShips — disambiguated by category
+	FormatAutoIndividual Format = 123 // "Automatic individual"
+)
+
+// FormatString returns a stable lowercase label for a Format —
+// used as the column value on the dsc_log SQLite table and the
+// API DTO's `format` field.
+func FormatString(f Format) string {
+	switch f {
+	case FormatDistress:
+		return "distress"
+	case FormatAllShips:
+		return "all-ships"
+	case FormatGroup:
+		return "group"
+	case FormatIndividual:
+		return "individual"
+	case FormatGeographic:
+		return "geographic"
+	case FormatAutoIndividual:
+		return "auto-individual"
+	}
+	return "unknown"
+}
+
+// Category identifies the DSC message priority class. ITU-R
+// M.493-15 §3.5.5.
+type Category uint8
+
+const (
+	CategoryUnknown  Category = 0
+	CategoryRoutine  Category = 100
+	CategorySafety   Category = 108
+	CategoryUrgency  Category = 110
+	CategoryDistress Category = 112
+)
+
+// CategoryString returns a stable lowercase label for a Category.
+func CategoryString(c Category) string {
+	switch c {
+	case CategoryDistress:
+		return "distress"
+	case CategoryUrgency:
+		return "urgency"
+	case CategorySafety:
+		return "safety"
+	case CategoryRoutine:
+		return "routine"
+	}
+	return "unknown"
+}
+
+// NatureOfDistress identifies the cause of a distress alert per
+// ITU-R M.493-15 Table 3.7. Only present when Format == Distress.
+type NatureOfDistress uint8
+
+const (
+	DistressFire         NatureOfDistress = 100
+	DistressFlooding     NatureOfDistress = 101
+	DistressCollision    NatureOfDistress = 102
+	DistressGrounding    NatureOfDistress = 103
+	DistressListing      NatureOfDistress = 104
+	DistressSinking      NatureOfDistress = 105
+	DistressDisabled     NatureOfDistress = 106
+	DistressUndesignated NatureOfDistress = 107
+	DistressAbandoning   NatureOfDistress = 108
+	DistressPiracy       NatureOfDistress = 109
+	DistressMOB          NatureOfDistress = 110
+	DistressEPIRB        NatureOfDistress = 112
+)
+
+// NatureString returns a stable lowercase label for a distress
+// nature. Empty string for unrecognised values.
+func NatureString(n NatureOfDistress) string {
+	switch n {
+	case DistressFire:
+		return "fire / explosion"
+	case DistressFlooding:
+		return "flooding"
+	case DistressCollision:
+		return "collision"
+	case DistressGrounding:
+		return "grounding"
+	case DistressListing:
+		return "listing"
+	case DistressSinking:
+		return "sinking"
+	case DistressDisabled:
+		return "disabled and adrift"
+	case DistressUndesignated:
+		return "undesignated distress"
+	case DistressAbandoning:
+		return "abandoning ship"
+	case DistressPiracy:
+		return "piracy / armed attack"
+	case DistressMOB:
+		return "man overboard"
+	case DistressEPIRB:
+		return "EPIRB emission"
+	}
+	return ""
+}
+
+// Position is the decoded lat/lon for a distress alert with a
+// position field. Latitude / Longitude are degrees; positive
+// = N / E. HasPosition is false when the position field is the
+// spec's "unknown" sentinel (all 9s).
+type Position struct {
+	Latitude    float64
+	Longitude   float64
+	HasPosition bool
+}
+
+// Message is one decoded DSC sequence.
+type Message struct {
+	Format          Format
+	Category        Category
+	SelfMMSI        uint64 // sender's 9-digit MMSI
+	TargetMMSI      uint64 // recipient's MMSI (0 for all-ships)
+	Nature          NatureOfDistress // distress only; 0 otherwise
+	Position        *Position
+	TimeUTC         string // HH:MM, distress only; empty otherwise
+	WorkingChannel  int    // working frequency channel for ack; 0 if absent
+	EOS             uint8  // end-of-sequence symbol
+	RawSymbols      string // hex-encoded 7-bit symbol stream for debugging
+	EFCChecksumOK   bool   // ECC byte matched
+}
+
+// Decode parses a sequence of post-BCH-corrected 7-bit data
+// symbols (the body of a DSC sequence, between the phasing
+// preamble and the EOS pattern) and returns a typed Message.
+//
+// The bit-stream layer above this package handles sync detection,
+// BCH(10,7) error correction, and the DX / RX redundancy merge.
+// By the time symbols reach Decode each entry is one 7-bit value
+// 0..127.
+//
+// Never returns an error — short / malformed sequences come back
+// with Format = FormatUnknown and the raw symbols preserved on
+// RawSymbols. Real-world DSC receivers see noisy half-frames
+// constantly; surface what we can and pass through the rest.
+func Decode(symbols []byte) Message {
+	m := Message{RawSymbols: symbolsToHex(symbols)}
+	if len(symbols) < 2 {
+		return m
+	}
+	m.Format = Format(symbols[0])
+	// All formats but Distress include the address (5 symbols)
+	// immediately after the format byte. For Distress the address
+	// is the sender's self-ID instead (see §3.5.3.5 special case).
+	off := 1
+
+	// Address: 5 symbols, decoded as pairs of decimal digits ×5
+	// (10 digits total — but only 9 are MMSI; the 10th is a
+	// "extra/format-specific" digit). For ship-MMSI calls the
+	// 10th digit is 0; for area calls it can carry a quadrant.
+	if m.Format == FormatDistress {
+		// Distress: self-MMSI comes immediately, no separate
+		// target address.
+		if mmsi, ok := decodeMMSI(symbols[off : off+5]); ok {
+			m.SelfMMSI = mmsi
+		}
+		off += 5
+		// Nature of distress: 1 symbol.
+		if off < len(symbols) {
+			m.Nature = NatureOfDistress(symbols[off])
+			off++
+		}
+		// Position: 5 symbols (10 digits, with a quadrant + 4 lat
+		// + 5 lon digits).
+		if off+5 <= len(symbols) {
+			if pos, ok := decodePosition(symbols[off : off+5]); ok {
+				m.Position = &pos
+			}
+			off += 5
+		}
+		// Time UTC: 2 symbols = 4 digits = HHMM.
+		if off+2 <= len(symbols) {
+			h := decodeDigitsPair(symbols[off])
+			min := decodeDigitsPair(symbols[off+1])
+			if h != "" && min != "" {
+				m.TimeUTC = h + ":" + min
+			}
+			off += 2
+		}
+		// EOS at end.
+		if len(symbols) > 0 {
+			m.EOS = symbols[len(symbols)-1]
+		}
+		m.Category = CategoryDistress
+		return m
+	}
+
+	// Non-distress: address (5 symbols) → category → self-MMSI.
+	if off+5 <= len(symbols) {
+		if mmsi, ok := decodeMMSI(symbols[off : off+5]); ok {
+			m.TargetMMSI = mmsi
+		}
+		off += 5
+	}
+	if off < len(symbols) {
+		m.Category = Category(symbols[off])
+		off++
+	}
+	if off+5 <= len(symbols) {
+		if mmsi, ok := decodeMMSI(symbols[off : off+5]); ok {
+			m.SelfMMSI = mmsi
+		}
+		off += 5
+	}
+	// Remaining symbols (type of call, frequency, etc.) get
+	// preserved on Raw — full per-format parsing is a follow-up.
+	if len(symbols) > 0 {
+		m.EOS = symbols[len(symbols)-1]
+	}
+	return m
+}
+
+// String renders the message for log / panel display.
+func (m Message) String() string {
+	switch m.Format {
+	case FormatDistress:
+		base := fmt.Sprintf("DISTRESS MMSI=%09d", m.SelfMMSI)
+		if nat := NatureString(m.Nature); nat != "" {
+			base += fmt.Sprintf(" nature=%q", nat)
+		}
+		if m.Position != nil && m.Position.HasPosition {
+			base += fmt.Sprintf(" pos=%.4f,%.4f",
+				m.Position.Latitude, m.Position.Longitude)
+		}
+		if m.TimeUTC != "" {
+			base += fmt.Sprintf(" t=%sZ", m.TimeUTC)
+		}
+		return base
+	case FormatAllShips:
+		return fmt.Sprintf("ALL-SHIPS %s MMSI=%09d",
+			CategoryString(m.Category), m.SelfMMSI)
+	case FormatIndividual:
+		return fmt.Sprintf("INDIVIDUAL %s MMSI=%09d → %09d",
+			CategoryString(m.Category), m.SelfMMSI, m.TargetMMSI)
+	case FormatGeographic:
+		return fmt.Sprintf("GEOGRAPHIC %s MMSI=%09d",
+			CategoryString(m.Category), m.SelfMMSI)
+	case FormatGroup:
+		return fmt.Sprintf("GROUP %s MMSI=%09d → %09d",
+			CategoryString(m.Category), m.SelfMMSI, m.TargetMMSI)
+	}
+	return fmt.Sprintf("%s MMSI=%09d",
+		FormatString(m.Format), m.SelfMMSI)
+}

--- a/internal/radio/dsc/dsc.go
+++ b/internal/radio/dsc/dsc.go
@@ -159,17 +159,17 @@ type Position struct {
 
 // Message is one decoded DSC sequence.
 type Message struct {
-	Format          Format
-	Category        Category
-	SelfMMSI        uint64 // sender's 9-digit MMSI
-	TargetMMSI      uint64 // recipient's MMSI (0 for all-ships)
-	Nature          NatureOfDistress // distress only; 0 otherwise
-	Position        *Position
-	TimeUTC         string // HH:MM, distress only; empty otherwise
-	WorkingChannel  int    // working frequency channel for ack; 0 if absent
-	EOS             uint8  // end-of-sequence symbol
-	RawSymbols      string // hex-encoded 7-bit symbol stream for debugging
-	EFCChecksumOK   bool   // ECC byte matched
+	Format         Format
+	Category       Category
+	SelfMMSI       uint64           // sender's 9-digit MMSI
+	TargetMMSI     uint64           // recipient's MMSI (0 for all-ships)
+	Nature         NatureOfDistress // distress only; 0 otherwise
+	Position       *Position
+	TimeUTC        string // HH:MM, distress only; empty otherwise
+	WorkingChannel int    // working frequency channel for ack; 0 if absent
+	EOS            uint8  // end-of-sequence symbol
+	RawSymbols     string // hex-encoded 7-bit symbol stream for debugging
+	EFCChecksumOK  bool   // ECC byte matched
 }
 
 // Decode parses a sequence of post-BCH-corrected 7-bit data

--- a/internal/radio/dsc/dsc_test.go
+++ b/internal/radio/dsc/dsc_test.go
@@ -38,10 +38,10 @@ func TestFormatAndCategoryStableLabels(t *testing.T) {
 
 func TestNatureStringSampleValues(t *testing.T) {
 	cases := map[NatureOfDistress]string{
-		DistressFire:      "fire / explosion",
-		DistressCollision: "collision",
-		DistressMOB:       "man overboard",
-		DistressEPIRB:     "EPIRB emission",
+		DistressFire:         "fire / explosion",
+		DistressCollision:    "collision",
+		DistressMOB:          "man overboard",
+		DistressEPIRB:        "EPIRB emission",
 		NatureOfDistress(50): "",
 	}
 	for n, want := range cases {
@@ -127,12 +127,12 @@ func TestDecodeDistressMessage(t *testing.T) {
 	// nature=fire (100), position 37°48' N / 122°24' E,
 	// time 14:25 UTC, EOS=127.
 	symbols := []byte{
-		112,                       // format = Distress
-		36, 60, 53, 20, 90,        // self-MMSI 366053209
-		100,                       // nature = fire
-		3, 74, 81, 22, 24,         // position (NE 37°48' / 122°24')
-		14, 25,                    // time 14:25
-		127,                       // EOS
+		112,                // format = Distress
+		36, 60, 53, 20, 90, // self-MMSI 366053209
+		100,               // nature = fire
+		3, 74, 81, 22, 24, // position (NE 37°48' / 122°24')
+		14, 25, // time 14:25
+		127, // EOS
 	}
 	m := Decode(symbols)
 	if m.Format != FormatDistress {
@@ -164,11 +164,11 @@ func TestDecodeIndividualCall(t *testing.T) {
 	// EOS=127. Symbol pairs for MMSI 003660000:
 	//   00 36 60 00 00.
 	symbols := []byte{
-		120,                       // format = Individual
-		0, 36, 60, 0, 0,           // target-MMSI 003660000
-		100,                       // category = routine
-		36, 60, 53, 20, 90,        // self-MMSI 366053209
-		127,                       // EOS
+		120,             // format = Individual
+		0, 36, 60, 0, 0, // target-MMSI 003660000
+		100,                // category = routine
+		36, 60, 53, 20, 90, // self-MMSI 366053209
+		127, // EOS
 	}
 	m := Decode(symbols)
 	if m.Format != FormatIndividual {
@@ -189,11 +189,11 @@ func TestDecodeAllShipsSafety(t *testing.T) {
 	// All-ships safety: format=116, MMSI all-ships (any),
 	// category=safety (108), self-MMSI=003669999.
 	symbols := []byte{
-		116,                       // format = AllShips
-		0, 0, 0, 0, 0,             // address (ignored for all-ships)
-		108,                       // category = safety
-		0, 36, 69, 99, 90,         // self-MMSI 003669999
-		127,                       // EOS
+		116,           // format = AllShips
+		0, 0, 0, 0, 0, // address (ignored for all-ships)
+		108,               // category = safety
+		0, 36, 69, 99, 90, // self-MMSI 003669999
+		127, // EOS
 	}
 	m := Decode(symbols)
 	if m.Format != FormatAllShips {

--- a/internal/radio/dsc/dsc_test.go
+++ b/internal/radio/dsc/dsc_test.go
@@ -1,0 +1,242 @@
+package dsc
+
+import (
+	"math"
+	"strings"
+	"testing"
+)
+
+func TestFormatAndCategoryStableLabels(t *testing.T) {
+	formatCases := map[Format]string{
+		FormatDistress:       "distress",
+		FormatAllShips:       "all-ships",
+		FormatGroup:          "group",
+		FormatIndividual:     "individual",
+		FormatGeographic:     "geographic",
+		FormatAutoIndividual: "auto-individual",
+		FormatUnknown:        "unknown",
+		Format(99):           "unknown",
+	}
+	for f, want := range formatCases {
+		if got := FormatString(f); got != want {
+			t.Errorf("FormatString(%d) = %q, want %q", f, got, want)
+		}
+	}
+	catCases := map[Category]string{
+		CategoryDistress: "distress",
+		CategoryUrgency:  "urgency",
+		CategorySafety:   "safety",
+		CategoryRoutine:  "routine",
+		Category(99):     "unknown",
+	}
+	for c, want := range catCases {
+		if got := CategoryString(c); got != want {
+			t.Errorf("CategoryString(%d) = %q, want %q", c, got, want)
+		}
+	}
+}
+
+func TestNatureStringSampleValues(t *testing.T) {
+	cases := map[NatureOfDistress]string{
+		DistressFire:      "fire / explosion",
+		DistressCollision: "collision",
+		DistressMOB:       "man overboard",
+		DistressEPIRB:     "EPIRB emission",
+		NatureOfDistress(50): "",
+	}
+	for n, want := range cases {
+		if got := NatureString(n); got != want {
+			t.Errorf("NatureString(%d) = %q, want %q", n, got, want)
+		}
+	}
+}
+
+func TestDecodeMMSIRoundTrip(t *testing.T) {
+	// MMSI 366053209 — symbols encode pairs of digits:
+	//   "36" "60" "53" "20" "9?" (10th digit is format extension)
+	symbols := []byte{36, 60, 53, 20, 90}
+	got, ok := decodeMMSI(symbols)
+	if !ok {
+		t.Fatal("decodeMMSI: !ok")
+	}
+	if got != 366053209 {
+		t.Errorf("MMSI = %d, want 366053209", got)
+	}
+}
+
+func TestDecodeMMSIRejectsOutOfRange(t *testing.T) {
+	symbols := []byte{36, 60, 100, 20, 90} // 100 > 99 → invalid
+	if _, ok := decodeMMSI(symbols); ok {
+		t.Error("decodeMMSI(out-of-range): ok = true, want false")
+	}
+}
+
+func TestDecodePositionRoundTrip(t *testing.T) {
+	// Quadrant 0 (NE), lat 37° 48' N, lon 122° 24' E.
+	// Digits: Q=0, lat=3748, lon=12224 → "0374812224".
+	// As 5 symbol pairs: 03 74 81 22 24.
+	symbols := []byte{3, 74, 81, 22, 24}
+	pos, ok := decodePosition(symbols)
+	if !ok {
+		t.Fatal("decodePosition: !ok")
+	}
+	if !pos.HasPosition {
+		t.Error("HasPosition = false on a valid position")
+	}
+	wantLat := 37.0 + 48.0/60.0
+	if math.Abs(pos.Latitude-wantLat) > 1e-6 {
+		t.Errorf("Latitude = %f, want %f", pos.Latitude, wantLat)
+	}
+	wantLon := 122.0 + 24.0/60.0
+	if math.Abs(pos.Longitude-wantLon) > 1e-6 {
+		t.Errorf("Longitude = %f, want %f", pos.Longitude, wantLon)
+	}
+}
+
+func TestDecodePositionApplyQuadrantSign(t *testing.T) {
+	// Quadrant 3 (SW), lat 33° 27' S, lon 70° 39' W.
+	// Digits: Q=3, lat=3327, lon=07039 → "3332707039".
+	// Symbol pairs: 33 32 70 70 39.
+	symbols := []byte{33, 32, 70, 70, 39}
+	pos, ok := decodePosition(symbols)
+	if !ok {
+		t.Fatal("decodePosition: !ok")
+	}
+	if pos.Latitude > 0 {
+		t.Errorf("Latitude = %f, want negative (S)", pos.Latitude)
+	}
+	if pos.Longitude > 0 {
+		t.Errorf("Longitude = %f, want negative (W)", pos.Longitude)
+	}
+}
+
+func TestDecodePositionUnknownSentinel(t *testing.T) {
+	// All-9s = "position not available" per spec.
+	symbols := []byte{99, 99, 99, 99, 99}
+	pos, ok := decodePosition(symbols)
+	if !ok {
+		t.Fatal("decodePosition(unknown sentinel): !ok")
+	}
+	if pos.HasPosition {
+		t.Error("HasPosition = true on unknown sentinel")
+	}
+}
+
+func TestDecodeDistressMessage(t *testing.T) {
+	// Distress alert: format=112, self-MMSI=366053209,
+	// nature=fire (100), position 37°48' N / 122°24' E,
+	// time 14:25 UTC, EOS=127.
+	symbols := []byte{
+		112,                       // format = Distress
+		36, 60, 53, 20, 90,        // self-MMSI 366053209
+		100,                       // nature = fire
+		3, 74, 81, 22, 24,         // position (NE 37°48' / 122°24')
+		14, 25,                    // time 14:25
+		127,                       // EOS
+	}
+	m := Decode(symbols)
+	if m.Format != FormatDistress {
+		t.Errorf("Format = %d, want FormatDistress (%d)", m.Format, FormatDistress)
+	}
+	if m.Category != CategoryDistress {
+		t.Errorf("Category = %d, want CategoryDistress (%d)", m.Category, CategoryDistress)
+	}
+	if m.SelfMMSI != 366053209 {
+		t.Errorf("SelfMMSI = %d, want 366053209", m.SelfMMSI)
+	}
+	if m.Nature != DistressFire {
+		t.Errorf("Nature = %d, want DistressFire (%d)", m.Nature, DistressFire)
+	}
+	if m.Position == nil || !m.Position.HasPosition {
+		t.Fatal("Position = nil or HasPosition = false")
+	}
+	if math.Abs(m.Position.Latitude-(37+48.0/60)) > 1e-6 {
+		t.Errorf("Latitude = %f", m.Position.Latitude)
+	}
+	if m.TimeUTC != "14:25" {
+		t.Errorf("TimeUTC = %q, want 14:25", m.TimeUTC)
+	}
+}
+
+func TestDecodeIndividualCall(t *testing.T) {
+	// Individual call: format=120, target-MMSI=003660000 (coast
+	// station), category=routine (100), self-MMSI=366053209,
+	// EOS=127. Symbol pairs for MMSI 003660000:
+	//   00 36 60 00 00.
+	symbols := []byte{
+		120,                       // format = Individual
+		0, 36, 60, 0, 0,           // target-MMSI 003660000
+		100,                       // category = routine
+		36, 60, 53, 20, 90,        // self-MMSI 366053209
+		127,                       // EOS
+	}
+	m := Decode(symbols)
+	if m.Format != FormatIndividual {
+		t.Errorf("Format = %d, want FormatIndividual", m.Format)
+	}
+	if m.Category != CategoryRoutine {
+		t.Errorf("Category = %d, want CategoryRoutine", m.Category)
+	}
+	if m.TargetMMSI != 3660000 {
+		t.Errorf("TargetMMSI = %d, want 3660000", m.TargetMMSI)
+	}
+	if m.SelfMMSI != 366053209 {
+		t.Errorf("SelfMMSI = %d, want 366053209", m.SelfMMSI)
+	}
+}
+
+func TestDecodeAllShipsSafety(t *testing.T) {
+	// All-ships safety: format=116, MMSI all-ships (any),
+	// category=safety (108), self-MMSI=003669999.
+	symbols := []byte{
+		116,                       // format = AllShips
+		0, 0, 0, 0, 0,             // address (ignored for all-ships)
+		108,                       // category = safety
+		0, 36, 69, 99, 90,         // self-MMSI 003669999
+		127,                       // EOS
+	}
+	m := Decode(symbols)
+	if m.Format != FormatAllShips {
+		t.Errorf("Format = %d, want FormatAllShips", m.Format)
+	}
+	if m.Category != CategorySafety {
+		t.Errorf("Category = %d, want CategorySafety", m.Category)
+	}
+	if m.SelfMMSI != 3669999 {
+		t.Errorf("SelfMMSI = %d, want 3669999", m.SelfMMSI)
+	}
+}
+
+func TestDecodeShortPayloadReturnsSafe(t *testing.T) {
+	if m := Decode(nil); m.Format != FormatUnknown {
+		t.Errorf("Decode(nil).Format = %d, want FormatUnknown", m.Format)
+	}
+	// Too short for an MMSI block — degrades gracefully.
+	if m := Decode([]byte{120, 0, 36}); m.SelfMMSI != 0 {
+		t.Errorf("Decode(short).SelfMMSI = %d, want 0", m.SelfMMSI)
+	}
+}
+
+func TestMessageStringRendersFormatVariants(t *testing.T) {
+	// Distress
+	m := Message{
+		Format:   FormatDistress,
+		SelfMMSI: 366053209,
+		Nature:   DistressFire,
+		Position: &Position{Latitude: 37.8, Longitude: 122.4, HasPosition: true},
+		TimeUTC:  "14:25",
+	}
+	got := m.String()
+	if !strings.HasPrefix(got, "DISTRESS ") {
+		t.Errorf("String prefix = %q", got[:9])
+	}
+	if !strings.Contains(got, "MMSI=366053209") {
+		t.Errorf("String missing MMSI: %q", got)
+	}
+	// All-ships
+	m = Message{Format: FormatAllShips, Category: CategorySafety, SelfMMSI: 3669999}
+	got = m.String()
+	if !strings.HasPrefix(got, "ALL-SHIPS ") {
+		t.Errorf("String prefix = %q", got)
+	}
+}

--- a/internal/storage/dsclog.go
+++ b/internal/storage/dsclog.go
@@ -1,0 +1,161 @@
+// DSC log writer — drains KindDSCMessage events off the shared bus
+// and writes one row per decoded sequence to the SQLite dsc_log
+// table. Mirrors aprslog.go / vessellog.go / pagerlog.go.
+package storage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+)
+
+// DSCMessage is one persisted decoded DSC sequence.
+type DSCMessage struct {
+	ID         int64     `json:"id"`
+	ReceivedAt time.Time `json:"received_at"`
+	Format     string    `json:"format"`   // "distress" | "all-ships" | "individual" | "group" | ...
+	Category   string    `json:"category"` // "distress" | "urgency" | "safety" | "routine"
+	SelfMMSI   uint64    `json:"self_mmsi"`
+	TargetMMSI uint64    `json:"target_mmsi,omitempty"`
+	Nature     string    `json:"nature,omitempty"`   // distress nature ("fire", "sinking", ...)
+	TimeUTC    string    `json:"time_utc,omitempty"` // HH:MM, distress only
+
+	// Position fields — populated only on distress alerts that
+	// included a position field with a non-sentinel value.
+	Latitude    float64 `json:"latitude,omitempty"`
+	Longitude   float64 `json:"longitude,omitempty"`
+	HasPosition bool    `json:"has_position"`
+
+	Body   string `json:"body"`     // type-specific summary
+	RawHex string `json:"raw_hex"`  // hex-encoded 7-bit symbol stream
+}
+
+// DSCLog drains KindDSCMessage events until ctx cancels or the bus
+// closes.
+type DSCLog struct {
+	db        *DB
+	bus       *events.Bus
+	log       *slog.Logger
+	sub       *events.Subscription
+	runDone   chan struct{}
+	closeOnce sync.Once
+}
+
+// NewDSCLog wires the log to the bus. Subscription happens at
+// construction so events published before Run() begins aren't lost.
+func NewDSCLog(db *DB, bus *events.Bus, logger *slog.Logger) (*DSCLog, error) {
+	if db == nil {
+		return nil, errors.New("storage/dsclog: DB is required")
+	}
+	if bus == nil {
+		return nil, errors.New("storage/dsclog: events.Bus is required")
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	d := &DSCLog{db: db, bus: bus, log: logger, runDone: make(chan struct{})}
+	d.sub = bus.Subscribe()
+	return d, nil
+}
+
+// Run drains KindDSCMessage events until ctx cancels or the bus
+// closes.
+func (d *DSCLog) Run(ctx context.Context) error {
+	defer close(d.runDone)
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case ev, ok := <-d.sub.C:
+			if !ok {
+				return nil
+			}
+			if ev.Kind != events.KindDSCMessage {
+				continue
+			}
+			m, ok := ev.Payload.(DSCMessage)
+			if !ok {
+				continue
+			}
+			if err := d.insert(m); err != nil {
+				d.log.Error("dsclog: insert failed", "err", err)
+			}
+		}
+	}
+}
+
+func (d *DSCLog) insert(m DSCMessage) error {
+	at := m.ReceivedAt
+	if at.IsZero() {
+		at = time.Now()
+	}
+	hasPos := 0
+	if m.HasPosition {
+		hasPos = 1
+	}
+	_, err := d.db.SQL().Exec(
+		`INSERT INTO dsc_log
+		 (received_at, format, category, self_mmsi, target_mmsi,
+		  nature, time_utc, latitude, longitude, has_position,
+		  body, raw_hex)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		at.UnixNano(), m.Format, m.Category, m.SelfMMSI, m.TargetMMSI,
+		m.Nature, m.TimeUTC, m.Latitude, m.Longitude, hasPos,
+		m.Body, m.RawHex,
+	)
+	return err
+}
+
+// Recent returns the most recent messages, newest first, capped at
+// limit. limit ≤ 0 picks 200; limit > 5000 caps at 5000.
+func (d *DSCLog) Recent(limit int) ([]DSCMessage, error) {
+	if limit <= 0 {
+		limit = 200
+	}
+	if limit > 5000 {
+		limit = 5000
+	}
+	rows, err := d.db.SQL().Query(
+		`SELECT id, received_at, format, category, self_mmsi,
+		        target_mmsi, nature, time_utc, latitude, longitude,
+		        has_position, body, raw_hex
+		 FROM dsc_log ORDER BY received_at DESC LIMIT ?`, limit)
+	if err != nil {
+		return nil, fmt.Errorf("storage/dsclog: query: %w", err)
+	}
+	defer rows.Close()
+	var out []DSCMessage
+	for rows.Next() {
+		var (
+			m      DSCMessage
+			ns     int64
+			hasPos int
+		)
+		if err := rows.Scan(&m.ID, &ns, &m.Format, &m.Category,
+			&m.SelfMMSI, &m.TargetMMSI, &m.Nature, &m.TimeUTC,
+			&m.Latitude, &m.Longitude, &hasPos, &m.Body, &m.RawHex); err != nil {
+			return nil, fmt.Errorf("storage/dsclog: scan: %w", err)
+		}
+		m.ReceivedAt = time.Unix(0, ns)
+		m.HasPosition = hasPos != 0
+		out = append(out, m)
+	}
+	return out, rows.Err()
+}
+
+// Close releases the bus subscription and waits for Run to drain.
+func (d *DSCLog) Close() error {
+	d.closeOnce.Do(func() {
+		d.sub.Close()
+		select {
+		case <-d.runDone:
+		case <-time.After(time.Second):
+		}
+	})
+	return nil
+}

--- a/internal/storage/dsclog.go
+++ b/internal/storage/dsclog.go
@@ -31,8 +31,8 @@ type DSCMessage struct {
 	Longitude   float64 `json:"longitude,omitempty"`
 	HasPosition bool    `json:"has_position"`
 
-	Body   string `json:"body"`     // type-specific summary
-	RawHex string `json:"raw_hex"`  // hex-encoded 7-bit symbol stream
+	Body   string `json:"body"`    // type-specific summary
+	RawHex string `json:"raw_hex"` // hex-encoded 7-bit symbol stream
 }
 
 // DSCLog drains KindDSCMessage events until ctx cancels or the bus

--- a/internal/storage/dsclog_test.go
+++ b/internal/storage/dsclog_test.go
@@ -1,0 +1,168 @@
+package storage
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+)
+
+func openDSCTestStore(t *testing.T) (*DSCLog, *events.Bus, *DB) {
+	t.Helper()
+	db, err := Open(":memory:")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	bus := events.NewBus(8)
+	log, err := NewDSCLog(db, bus, nil)
+	if err != nil {
+		t.Fatalf("NewDSCLog: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = log.Close()
+		bus.Close()
+		_ = db.Close()
+	})
+	return log, bus, db
+}
+
+func TestDSCLogInsertsDistress(t *testing.T) {
+	log, bus, _ := openDSCTestStore(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = log.Run(ctx) }()
+
+	bus.Publish(events.Event{
+		Kind: events.KindDSCMessage,
+		Payload: DSCMessage{
+			ReceivedAt:  time.Unix(1735000000, 0),
+			Format:      "distress",
+			Category:    "distress",
+			SelfMMSI:    366053209,
+			Nature:      "fire / explosion",
+			TimeUTC:     "14:25",
+			Latitude:    37.8,
+			Longitude:   122.4,
+			HasPosition: true,
+			Body:        "DISTRESS MMSI=366053209 fire 37.80,122.40",
+			RawHex:      "deadbeef",
+		},
+	})
+
+	var recent []DSCMessage
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		recent, _ = log.Recent(10)
+		if len(recent) > 0 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if len(recent) != 1 {
+		t.Fatalf("Recent = %d, want 1", len(recent))
+	}
+	r := recent[0]
+	if r.Format != "distress" || r.SelfMMSI != 366053209 ||
+		r.Nature != "fire / explosion" || r.TimeUTC != "14:25" {
+		t.Errorf("Recent[0] = %+v", r)
+	}
+	if !r.HasPosition || r.Latitude < 37.7 || r.Latitude > 37.9 {
+		t.Errorf("position not round-tripped: %+v", r)
+	}
+}
+
+func TestDSCLogInsertsIndividualCall(t *testing.T) {
+	log, bus, _ := openDSCTestStore(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = log.Run(ctx) }()
+
+	bus.Publish(events.Event{
+		Kind: events.KindDSCMessage,
+		Payload: DSCMessage{
+			ReceivedAt: time.Unix(1735000000, 0),
+			Format:     "individual",
+			Category:   "routine",
+			SelfMMSI:   366053209,
+			TargetMMSI: 3660000,
+			Body:       "INDIVIDUAL 366053209 → 003660000 routine",
+		},
+	})
+
+	var recent []DSCMessage
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		recent, _ = log.Recent(10)
+		if len(recent) > 0 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if len(recent) != 1 {
+		t.Fatalf("Recent = %d, want 1", len(recent))
+	}
+	r := recent[0]
+	if r.Format != "individual" || r.TargetMMSI != 3660000 {
+		t.Errorf("Recent[0] = %+v", r)
+	}
+	if r.HasPosition {
+		t.Error("HasPosition = true on non-distress call")
+	}
+}
+
+func TestDSCLogIgnoresUnrelatedEvents(t *testing.T) {
+	log, bus, _ := openDSCTestStore(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = log.Run(ctx) }()
+
+	bus.Publish(events.Event{
+		Kind:    events.KindBookmarkCreated,
+		Payload: Bookmark{Name: "x"},
+	})
+	bus.Publish(events.Event{
+		Kind:    events.KindDSCMessage,
+		Payload: "wrong payload type",
+	})
+
+	time.Sleep(50 * time.Millisecond)
+	recent, _ := log.Recent(10)
+	if len(recent) != 0 {
+		t.Errorf("Recent = %d, want 0", len(recent))
+	}
+}
+
+func TestDSCLogRecentOrderNewestFirst(t *testing.T) {
+	log, bus, _ := openDSCTestStore(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = log.Run(ctx) }()
+
+	for i := uint64(0); i < 3; i++ {
+		bus.Publish(events.Event{
+			Kind: events.KindDSCMessage,
+			Payload: DSCMessage{
+				ReceivedAt: time.Unix(1735000000+int64(i)*60, 0),
+				Format:     "all-ships",
+				Category:   "safety",
+				SelfMMSI:   3660000000 + i,
+			},
+		})
+	}
+	var recent []DSCMessage
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		recent, _ = log.Recent(10)
+		if len(recent) == 3 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if len(recent) != 3 {
+		t.Fatalf("Recent = %d, want 3", len(recent))
+	}
+	if recent[0].SelfMMSI != 3660000002 || recent[2].SelfMMSI != 3660000000 {
+		t.Errorf("ordering wrong")
+	}
+}

--- a/internal/storage/sqlite.go
+++ b/internal/storage/sqlite.go
@@ -196,6 +196,30 @@ CREATE TABLE IF NOT EXISTS vessel_log (
 
 CREATE INDEX IF NOT EXISTS idx_vessel_log_time ON vessel_log(received_at);
 CREATE INDEX IF NOT EXISTS idx_vessel_log_mmsi ON vessel_log(mmsi, received_at);
+
+-- DSC (Digital Selective Calling) sequences persisted from the
+-- decoder pipeline. One row per decoded sequence: format
+-- (distress / all-ships / individual / ...), category, source +
+-- target MMSI, plus distress-specific fields (nature, time,
+-- position) when applicable.
+CREATE TABLE IF NOT EXISTS dsc_log (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    received_at  INTEGER NOT NULL,             -- unix nanoseconds
+    format       TEXT    NOT NULL DEFAULT '',  -- "distress" | "all-ships" | "individual" | ...
+    category     TEXT    NOT NULL DEFAULT '',  -- "distress" | "urgency" | "safety" | "routine"
+    self_mmsi    INTEGER NOT NULL DEFAULT 0,   -- sender's 9-digit MMSI
+    target_mmsi  INTEGER NOT NULL DEFAULT 0,   -- recipient's MMSI (0 for all-ships)
+    nature       TEXT    NOT NULL DEFAULT '',  -- distress nature ("fire", "sinking", ...)
+    time_utc     TEXT    NOT NULL DEFAULT '',  -- HH:MM, distress only
+    latitude     REAL    NOT NULL DEFAULT 0,
+    longitude    REAL    NOT NULL DEFAULT 0,
+    has_position INTEGER NOT NULL DEFAULT 0,
+    body         TEXT    NOT NULL DEFAULT '',  -- type-specific summary
+    raw_hex      TEXT    NOT NULL DEFAULT ''   -- hex-encoded 7-bit symbol stream
+);
+
+CREATE INDEX IF NOT EXISTS idx_dsc_log_time      ON dsc_log(received_at);
+CREATE INDEX IF NOT EXISTS idx_dsc_log_self_mmsi ON dsc_log(self_mmsi, received_at);
 `
 
 func (d *DB) migrate() error {

--- a/web/src/App.panels.test.tsx
+++ b/web/src/App.panels.test.tsx
@@ -51,6 +51,10 @@ vi.mock("./api/ais", () => ({
   fetchAISVessels: vi.fn().mockResolvedValue([]),
 }));
 
+vi.mock("./api/dsc", () => ({
+  fetchDSCMessages: vi.fn().mockResolvedValue([]),
+}));
+
 vi.mock("./api/bookmarks", () => ({
   bookmarks: {
     list: vi.fn().mockResolvedValue([]),

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -17,6 +17,7 @@ import { History } from "./panels/History";
 import { Import } from "./panels/Import";
 import { APRS } from "./panels/APRS";
 import { AIS } from "./panels/AIS";
+import { DSC } from "./panels/DSC";
 import { Metrics } from "./panels/Metrics";
 import { Pagers } from "./panels/Pagers";
 import { RadioIDs } from "./panels/RadioIDs";
@@ -45,6 +46,7 @@ const EXTRA_TABS: Tab[] = [
   { to: "/pagers", label: "Pagers", icon: "✉" },
   { to: "/aprs", label: "APRS", icon: "⛯" },
   { to: "/ais", label: "AIS", icon: "⚓" },
+  { to: "/dsc", label: "DSC", icon: "📡" },
   { to: "/spectrum", label: "Spectrum", icon: "≈" },
   { to: "/constellation", label: "Constellation", icon: "✦" },
   { to: "/bookmarks", label: "Bookmarks", icon: "★" },
@@ -158,6 +160,7 @@ export function App() {
           <Route path="/pagers" element={<Pagers />} />
           <Route path="/aprs" element={<APRS />} />
           <Route path="/ais" element={<AIS />} />
+          <Route path="/dsc" element={<DSC />} />
           <Route path="/metrics" element={<Metrics />} />
           <Route path="/devices" element={<Devices />} />
           <Route path="/settings" element={<Settings />} />

--- a/web/src/api/dsc.ts
+++ b/web/src/api/dsc.ts
@@ -1,0 +1,38 @@
+// DSC / marine-distress-channel client. Mirrors GET /api/v1/dsc/messages.
+
+import { type ClientConfig, joinURL } from "./client";
+
+export interface DSCMessage {
+  id: number;
+  received_at: string;
+  format: string;
+  category: string;
+  self_mmsi: number;
+  target_mmsi?: number;
+  nature?: string;
+  time_utc?: string;
+
+  // Position fields — present on distress alerts with a non-
+  // sentinel position field.
+  latitude?: number;
+  longitude?: number;
+  has_position: boolean;
+
+  body?: string;
+  raw_hex?: string;
+}
+
+export async function fetchDSCMessages(
+  cfg: ClientConfig,
+  limit = 200,
+): Promise<DSCMessage[]> {
+  const url = joinURL(
+    cfg.baseURL,
+    `/api/v1/dsc/messages?limit=${encodeURIComponent(String(limit))}`,
+  );
+  const headers: Record<string, string> = { Accept: "application/json" };
+  if (cfg.token) headers["Authorization"] = `Bearer ${cfg.token}`;
+  const res = await fetch(url, { headers });
+  if (!res.ok) throw new Error(`dsc/messages ${res.status}`);
+  return (await res.json()) as DSCMessage[];
+}

--- a/web/src/panels/DSC.test.tsx
+++ b/web/src/panels/DSC.test.tsx
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+
+vi.mock("../api/dsc", () => ({
+  fetchDSCMessages: vi.fn(),
+}));
+
+import { fetchDSCMessages } from "../api/dsc";
+import { useShared } from "../store/shared";
+import { DSC } from "./DSC";
+
+function resetStore() {
+  useShared.setState({
+    serverURL: "http://localhost:8080",
+    token: null,
+    connected: true,
+    wsStatus: "idle",
+    mutations: null,
+    lastError: null,
+    events: [],
+    activeCalls: [],
+    devices: [],
+    systems: [],
+    talkgroups: [],
+    health: null,
+    audio: null,
+    scanner: null,
+  });
+}
+
+describe("DSC panel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetStore();
+  });
+
+  it("renders an empty-state when no sequences are present", async () => {
+    vi.mocked(fetchDSCMessages).mockResolvedValue([]);
+    render(<DSC />);
+    await waitFor(() => {
+      expect(screen.getByText(/No DSC sequences yet/)).toBeInTheDocument();
+    });
+  });
+
+  it("renders distress alerts with nature + position", async () => {
+    vi.mocked(fetchDSCMessages).mockResolvedValue([
+      {
+        id: 1,
+        received_at: "2026-05-26T12:34:56Z",
+        format: "distress",
+        category: "distress",
+        self_mmsi: 366053209,
+        nature: "fire / explosion",
+        time_utc: "14:25",
+        latitude: 37.8,
+        longitude: 122.4,
+        has_position: true,
+        body: "DISTRESS MMSI=366053209 fire 37.80,122.40",
+      },
+    ]);
+    render(<DSC />);
+    await waitFor(() => {
+      expect(screen.getByText("366053209")).toBeInTheDocument();
+      expect(screen.getByText("fire / explosion")).toBeInTheDocument();
+      expect(screen.getByText(/37\.8000, 122\.4000/)).toBeInTheDocument();
+      expect(screen.getByText(/UTC 14:25/)).toBeInTheDocument();
+    });
+  });
+
+  it("renders individual routine calls with target MMSI", async () => {
+    vi.mocked(fetchDSCMessages).mockResolvedValue([
+      {
+        id: 2,
+        received_at: "2026-05-26T12:34:56Z",
+        format: "individual",
+        category: "routine",
+        self_mmsi: 366053209,
+        target_mmsi: 3660000,
+        has_position: false,
+        body: "INDIVIDUAL routine",
+      },
+    ]);
+    render(<DSC />);
+    await waitFor(() => {
+      expect(screen.getByText("366053209")).toBeInTheDocument();
+      expect(screen.getByText("003660000")).toBeInTheDocument();
+    });
+  });
+
+  it("surfaces fetch errors", async () => {
+    vi.mocked(fetchDSCMessages).mockRejectedValue(new Error("daemon down"));
+    render(<DSC />);
+    await waitFor(() => {
+      expect(screen.getByText(/daemon down/)).toBeInTheDocument();
+    });
+  });
+});

--- a/web/src/panels/DSC.tsx
+++ b/web/src/panels/DSC.tsx
@@ -1,0 +1,157 @@
+import { useEffect, useState } from "react";
+import { fetchDSCMessages, type DSCMessage } from "../api/dsc";
+import { selectClientConfig, useShared } from "../store/shared";
+
+// DSC panel — list of recent decoded marine DSC sequences. The
+// row colour reflects the category: distress = red, urgency =
+// orange, safety = blue, routine = default. Distress alerts also
+// surface nature ("fire / explosion", "sinking", etc.) and (when
+// the alert included one) a position.
+//
+// Polls /api/v1/dsc/messages every 5 s. Live SSE delivery via
+// KindDSCMessage bus event is a follow-up once peer-edit churn
+// makes the poll cost visible.
+
+const POLL_INTERVAL_MS = 5_000;
+
+export function DSC() {
+  const cfg = useShared(selectClientConfig);
+  const [messages, setMessages] = useState<DSCMessage[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancel = false;
+    const refresh = async () => {
+      try {
+        const list = await fetchDSCMessages(cfg, 200);
+        if (cancel) return;
+        setMessages(list);
+        setError(null);
+      } catch (e) {
+        if (cancel) return;
+        setError(e instanceof Error ? e.message : String(e));
+      }
+    };
+    refresh();
+    const t = window.setInterval(refresh, POLL_INTERVAL_MS);
+    return () => {
+      cancel = true;
+      window.clearInterval(t);
+    };
+  }, [cfg]);
+
+  return (
+    <div className="space-y-3">
+      <header className="flex items-center justify-between">
+        <h2 className="text-xl font-semibold">DSC</h2>
+        <span className="text-xs text-muted">
+          {messages.length} sequence{messages.length === 1 ? "" : "s"}
+        </span>
+      </header>
+
+      {error && (
+        <div className="rounded border border-red-700/40 bg-red-900/20 text-red-200 text-xs px-3 py-2">
+          {error}
+        </div>
+      )}
+
+      <div className="rounded border border-border overflow-hidden">
+        <table className="w-full text-xs">
+          <thead className="bg-surface text-muted">
+            <tr>
+              <th className="text-left px-3 py-1 font-normal w-24">Received</th>
+              <th className="text-left px-3 py-1 font-normal w-24">Format</th>
+              <th className="text-left px-3 py-1 font-normal w-24">Category</th>
+              <th className="text-left px-3 py-1 font-normal w-28">Self MMSI</th>
+              <th className="text-left px-3 py-1 font-normal w-28">Target / Nature</th>
+              <th className="text-left px-3 py-1 font-normal">Body</th>
+              <th className="text-right px-3 py-1 font-normal w-32">Lat / Lon</th>
+            </tr>
+          </thead>
+          <tbody>
+            {messages.length === 0 ? (
+              <tr>
+                <td colSpan={7} className="px-3 py-4 text-center text-muted">
+                  No DSC sequences yet. Add a{" "}
+                  <code className="text-accent">dsc.channels</code>{" "}
+                  entry to your config (marine VHF channel 70 =
+                  156.525 MHz · HF 2.187.5 / 8.414.5 / 12.577 /
+                  16.804.5 kHz) and decoded distress / safety /
+                  routine calls will land here as they arrive. DSP
+                  wiring (1200 Bd FSK at 1300 / 2100 Hz tones →
+                  10-bit symbol assembly → BCH check + DX/RX
+                  redundancy → message parser) is the planned
+                  follow-up; the protocol + storage + REST
+                  scaffolding is live now.
+                </td>
+              </tr>
+            ) : (
+              messages.map((m) => (
+                <tr
+                  key={m.id}
+                  className={
+                    "border-t border-border/60 " + categoryRowClass(m.category)
+                  }
+                >
+                  <td className="px-3 py-1 font-mono text-muted">
+                    {formatTime(m.received_at)}
+                  </td>
+                  <td className="px-3 py-1 uppercase">{m.format}</td>
+                  <td className="px-3 py-1 uppercase">{m.category}</td>
+                  <td className="px-3 py-1 font-mono text-accent">
+                    {String(m.self_mmsi).padStart(9, "0")}
+                  </td>
+                  <td className="px-3 py-1 font-mono">
+                    {m.target_mmsi
+                      ? String(m.target_mmsi).padStart(9, "0")
+                      : m.nature || <span className="text-muted">—</span>}
+                  </td>
+                  <td className="px-3 py-1">
+                    {m.body || <span className="text-muted">(no payload)</span>}
+                    {m.time_utc && (
+                      <div className="text-[10px] text-muted">
+                        UTC {m.time_utc}
+                      </div>
+                    )}
+                  </td>
+                  <td className="px-3 py-1 text-right font-mono">
+                    {m.has_position && m.latitude !== undefined &&
+                    m.longitude !== undefined ? (
+                      <span>
+                        {m.latitude.toFixed(4)}, {m.longitude.toFixed(4)}
+                      </span>
+                    ) : (
+                      <span className="text-muted">—</span>
+                    )}
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+// categoryRowClass tints the row by DSC category — distress is
+// red, urgency orange, safety blue. Routine traffic gets no tint.
+function categoryRowClass(category: string): string {
+  switch (category) {
+    case "distress":
+      return "bg-red-900/25";
+    case "urgency":
+      return "bg-orange-900/20";
+    case "safety":
+      return "bg-blue-900/15";
+  }
+  return "";
+}
+
+function formatTime(ts: string): string {
+  try {
+    return new Date(ts).toISOString().slice(11, 19);
+  } catch {
+    return ts.slice(11, 19);
+  }
+}


### PR DESCRIPTION
## Summary

First slice of Phase 5 DSC. GMDSS Digital Selective Calling
messages — distress alerts, urgency / safety broadcasts,
individual / group / all-ships routine calls — are the SOLAS-
mandated digital signalling on marine VHF channel 70 (156.525
MHz) and the HF DSC channels. A coast-guard MMSI lighting up
the channel-70 stream is **near-instant visibility into
search-and-rescue activity**. Same scaffolding-first pattern AIS
took in #427: protocol layer + bus + storage + REST + panel
this slice, DSP follows.

### `internal/radio/dsc` — protocol parser

- **BCH(10,7) codec.** Encode + check helpers for the CRC-3
  wrapper ITU-R M.493-15 §3.4 specifies (`g(x) = x³+x+1`,
  binary `1011`).
  The spec calls it "BCH" but the code's minimum Hamming
  distance is **2**, not 3 — single-bit errors are reliably
  **detected** but not reliably **corrected** at this layer.
  DSC achieves the actual correction via DX / RX redundancy at
  the bit-stream layer above (each character is sent twice on
  the wire and the receiver compares the two streams). The
  decoder is honest about this: `BCHCheck` returns the syndrome
  state without attempting bit-level correction; callers are
  expected to drop syndrome-fail symbols and rely on the
  redundant copy.
- **Type dispatch** (§3.5): Distress (112) with self-MMSI +
  nature + position + UTC time, All-Ships (116), Individual
  call (120) with target + source MMSI, Group (114),
  Geographic-area (102), Auto-Individual (123).
- **MMSI codec.** 5 symbols × 2 decimal digits → 9-digit MMSI;
  the 10th digit is the format-extension nibble and ignored.
- **Position codec.** 5 symbols carrying a 10-digit
  `Q.DD.MM.DDD.MM` string with the quadrant-bit hemisphere
  flip (0 = NE, 1 = NW, 2 = SE, 3 = SW). The all-9s
  "position unknown" sentinel collapses `HasPosition` to false.
- **Nature of distress** (§3.5.4 Table 3.7) — fire, flooding,
  collision, grounding, listing, sinking, disabled,
  undesignated, abandoning, piracy, MOB, EPIRB.

### Storage

- `dsc_log` SQLite table — one row per decoded sequence,
  indexes on `(received_at)` and `(self_mmsi, received_at)`.
  Append-only migration alongside `vessel_log`, `aprs_log`,
  `pager_log`.
- `storage.DSCLog` bus subscriber — drains `KindDSCMessage`
  events; subscription at construction so events published
  before `Run()` aren't lost.

### Bus + REST

- `events.KindDSCMessage` (= `"dsc.message"`) — published once
  per decoded sequence. Payload `storage.DSCMessage` carrying
  format + category + source / target MMSI + nature + position
  + UTC time + raw hex.
- `GET /api/v1/dsc/messages?limit=N` (default 200, max 5000) —
  503 when storage isn't wired.

### Web panel

- `/dsc` — columns Received / Format / Category / Self MMSI /
  Target-or-Nature / Body / Lat-Lon. Rows tint by category:
  **distress = red**, **urgency = orange**, **safety = blue**,
  routine = default. Distress alerts surface nature
  ("fire / explosion", "sinking") and UTC time on a second
  line.

### Daemon

- `dscLog` wired alongside `vesselLog`: constructed at startup,
  spawned in the run loop, drained on `Close`. New `dscProvider`
  adapter feeds `api.ServerOptions.DSC`.

## Test plan

- [x] `go test ./internal/radio/dsc/` — 15 tests pass (BCH
  round-trip + syndrome check + single-bit error detection,
  MMSI codec, position quadrant signs, position
  unknown-sentinel, end-to-end distress decode with position +
  nature + UTC time, individual-call decode, all-ships safety
  decode, short-payload safety).
- [x] `go test ./internal/storage/` — 4 dsclog tests pass
  (insert distress / individual / filter / order) plus all
  pre-existing tests.
- [x] `go test ./internal/api/` — 3 DSC REST tests pass
  (503 / list / limit) plus all pre-existing tests.
- [x] `npm test -- --run` — 105/105 web tests pass (4 new
  DSC panel tests: empty / distress / individual / error).
- [x] `go vet ./...` clean; `gofmt -l` clean.

## Still pending under Phase 5 DSC (separate PRs)

- **DSP receiver.** 1200 Bd FSK (mark 1300 Hz, space 2100 Hz)
  on channel 70 (VHF) or one of the HF DSC channels. Pipeline:
  iqtap broker subscriber → FM demod → FFSK discriminator
  (reusing `internal/dsp/demod/ffsk` with DSC's tone
  frequencies) → symbol-time recovery → 10-bit symbol assembly
  → BCH syndrome check → DX / RX redundancy merge → 7-bit
  symbol stream into `dsc.Decode`. Pattern matches the APRS /
  AIS DSP frontends.
- **Multi-frame protocol.** A few DSC sequence types span
  multiple slots when transmitted (Auto-Individual ACK chains,
  multi-recipient calls). The single-frame parser covers the
  operational majority; multi-frame reassembly arrives with
  the DSP frontend.
- **Live map.** Distress alerts with positions can light up
  the same Leaflet / MapLibre overlay APRS + AIS positions are
  planned to share.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YUgvat8WpF5YaSuEAqWMr2)_