### PR TITLE
adsb: protocol layer + bus + storage + REST + panel scaffolding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,52 @@ for tagged releases.
 
 ### Added
 
+- **ADS-B aviation — protocol layer + bus / storage / REST / panel
+  scaffolding.** First slice of Phase 5 ADS-B: every commercial
+  passenger flight, most general-aviation, and all military
+  aircraft over US / EU airspace continuously broadcasts on
+  1090 MHz — the same data that powers FlightRadar24 /
+  FlightAware / adsb.lol / OpenSky. GopherTrunk now has the
+  protocol layer to decode it on the operator's own SDR.
+  New `internal/radio/adsb` package decodes ICAO Annex 10 Vol IV
+  Mode-S frames: CRC-24 verification with polynomial 0xFFF409
+  (verified directly on DF 11 / 17 / 18; the ICAO-overlay scheme
+  for DF 0 / 4 / 5 / 20 / 21 recovers the address by XORing the
+  computed CRC). Extended-squitter (DF 17 / 18) type-code
+  dispatch for the operator-visible majority: identification
+  (TC 1-4 with the 6-bit ICAO alphabet decoding 8-char
+  callsigns), airborne position (TC 9-18 / 20-22 with CPR-encoded
+  lat/lon and 12-bit Q-bit altitude at 25-ft resolution), surface
+  position (TC 5-8), airborne velocity (TC 19 with ground speed
+  + track for subtypes 1/2, air speed + heading for 3/4, common
+  vertical-rate field). Globally-unambiguous CPR position
+  decoder (DO-260B §2.2.3.2.3.7) from an even+odd pair, with NL
+  table matching the dump1090 reference. Validated against the
+  canonical mode-s.org reference samples (identification
+  "KLM1023" / ICAO 4840D6; CPR pair decodes to lat 52.2572 N /
+  lon 3.91937 E / alt 38000 ft; velocity GS 159 kn / track ≈ 183°
+  / VR -832 fpm).
+  New `events.KindAircraftReport` event + `storage.AircraftReport`
+  payload + `aircraft_log` SQLite table (one row per decoded
+  frame, indexes on `(received_at)` and `(icao, received_at)`).
+  `storage.AircraftLog` subscriber drains the bus and writes one
+  row per message; the daemon spawns it alongside `dscLog` /
+  `vesselLog` / `aprsLog` / `pagerLog`. New REST endpoint
+  `GET /api/v1/adsb/aircraft?limit=N` (default 200, max 5000)
+  and web panel `/adsb` with columns Received / ICAO / Kind /
+  Callsign / Lat-Lon / Alt / GS-Track / VR. CRC-failed frames
+  highlight yellow.
+  Tests: 13 protocol-layer (identification decode, CPR pair
+  global decode against the dump1090 reference vectors, velocity
+  decode, all-call DF 11, short-frame safety, CRC self-
+  consistency + corruption detection, NL table boundary values,
+  altitude Q=1 round-trip), 4 storage (insert position / ident /
+  filter / order), 3 REST (503 / list / limit), 5 web (empty /
+  position / ident / velocity / error). All passing.
+- DSP frontend (1 Msps PPM + Mode-S preamble correlation +
+  frame extraction) follows as the next slice. See
+  [docs/adsb.md](docs/adsb.md).
+
 - **DSC marine — protocol layer + bus / storage / REST / panel
   scaffolding.** First slice of Phase 5 DSC: GMDSS Digital
   Selective Calling messages — distress alerts, urgency / safety

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -113,6 +113,7 @@ type Daemon struct {
 	aprsLog      *storage.APRSLog
 	vesselLog    *storage.VesselLog
 	dscLog       *storage.DSCLog
+	aircraftLog  *storage.AircraftLog
 	messageLog   *gtlog.MessageLog
 	retention    *storage.Retention
 	ccCache      *trunking.Cache
@@ -1073,6 +1074,13 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 		}
 		d.dscLog = dl
 
+		acl, err := storage.NewAircraftLog(db, d.bus, log)
+		if err != nil {
+			db.Close()
+			return nil, fmt.Errorf("daemon: aircraft log: %w", err)
+		}
+		d.aircraftLog = acl
+
 		if cfg.Retention.CallLogDays > 0 || cfg.Retention.FilesDays > 0 {
 			interval, err := retentionInterval(cfg.Retention.Interval)
 			if err != nil {
@@ -1141,6 +1149,9 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 		}
 		if d.dscLog != nil {
 			opts.DSC = dscProvider{log: d.dscLog}
+		}
+		if d.aircraftLog != nil {
+			opts.ADSB = adsbProvider{log: d.aircraftLog}
 		}
 		if d.db != nil {
 			opts.History = api.HistoryFromStorage(d.db)
@@ -1322,6 +1333,11 @@ func (d *Daemon) Run(ctx context.Context) error {
 	if d.dscLog != nil {
 		d.spawn(runCtx, "dsclog", false, func(ctx context.Context) error {
 			return d.dscLog.Run(ctx)
+		})
+	}
+	if d.aircraftLog != nil {
+		d.spawn(runCtx, "aircraftlog", false, func(ctx context.Context) error {
+			return d.aircraftLog.Run(ctx)
 		})
 	}
 	if d.messageLog != nil {
@@ -1618,6 +1634,9 @@ func (d *Daemon) Close() {
 		}
 		if d.dscLog != nil {
 			_ = d.dscLog.Close()
+		}
+		if d.aircraftLog != nil {
+			_ = d.aircraftLog.Close()
 		}
 		if d.messageLog != nil {
 			_ = d.messageLog.Close()
@@ -2392,6 +2411,15 @@ type dscProvider struct{ log *storage.DSCLog }
 
 func (d dscProvider) RecentDSCMessages(limit int) ([]storage.DSCMessage, error) {
 	return d.log.Recent(limit)
+}
+
+// adsbProvider adapts storage.AircraftLog into api.ADSBProvider so
+// the api package stays free of the storage import dependency.
+// Read-only — the decoder writes via the events bus.
+type adsbProvider struct{ log *storage.AircraftLog }
+
+func (a adsbProvider) RecentAircraftReports(limit int) ([]storage.AircraftReport, error) {
+	return a.log.Recent(limit)
 }
 
 // aprsSpec captures the broker-side wiring info for one configured

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -320,6 +320,24 @@ sdr:
 #                                     #  chatter and keep only distress
 #                                     #  + urgency alerts
 
+# ADS-B / aviation. The protocol parser + bus + storage + REST +
+# panel scaffolding is live; the DSP frontend (1 Msps PPM demod +
+# Mode-S preamble correlation + 56/112-bit frame extraction)
+# ships in a follow-up PR. Operators producing Mode-S frames from
+# an external source (dump1090 hex output, captured BEAST stream,
+# etc.) and feeding them to events.KindAircraftReport will see
+# decoded reports on the bus / panel today.
+#
+# adsb:
+#   channels:
+#     - serial: "1090-antenna"        # SDR serial (must be in sdr.devices
+#                                     #  or sdr.rtl_tcp; dedicate one
+#                                     #  RTL-SDR + 1090 MHz filter + LNA
+#                                     #  to this — the bandwidth needs
+#                                     #  ~1 Msps which crowds out other
+#                                     #  decoders on the same dongle)
+#       frequency_hz: 1_090_000_000   # 1090 MHz centre
+
 trunking:
   # call_timeout_ms: inactivity window after which the engine's
   # watchdog ends a call (publishes CallEnd with EndReasonTimeout

--- a/docs/adsb.md
+++ b/docs/adsb.md
@@ -1,0 +1,157 @@
+---
+layout: page
+title: ADS-B / Aviation
+description: Decoded ADS-B aircraft pipeline — events bus, SQLite log, REST endpoint, web panel
+nav_group: Reference
+---
+
+# ADS-B / Aviation
+
+GopherTrunk decodes **Automatic Dependent Surveillance — Broadcast**
+(ADS-B) messages aircraft transponders broadcast on 1090 MHz.
+ADS-B is the ICAO-mandated cooperative aviation surveillance
+protocol — every commercial passenger flight, most general-
+aviation, and all military aircraft over US / EU airspace
+continuously broadcasts: ICAO 24-bit address, callsign,
+barometric or GNSS altitude, lat/lon, ground speed, vertical
+rate, true heading. This is the same data feeding every public
+flight-tracking service (FlightRadar24, FlightAware, adsb.lol,
+OpenSky); GopherTrunk now has the protocol layer to decode it
+end-to-end on the operator's own SDR.
+
+This page documents the **pipeline scaffolding**: what's wired,
+what's persisted, what's queryable, and what the web panel
+renders. The DSP layer (1 Msps PPM demodulation, Mode-S preamble
+detection, 56 / 112-bit frame extraction) is tracked separately
+under "What's pending" below.
+
+## What's wired
+
+### Events bus
+- `events.KindAircraftReport` — published once per decoded
+  Mode-S frame off the 1090 MHz channel. Payload is a
+  `storage.AircraftReport` carrying the 24-bit ICAO address +
+  message-kind-specific fields.
+
+### Storage
+- New SQLite table `aircraft_log` (append-only migration
+  alongside `vessel_log`, `dsc_log`, `aprs_log`, `pager_log`):
+  - `received_at`, `icao`, `icao_hex`, `kind`, `body`,
+    `crc_valid`, `callsign`, `category`, `latitude`,
+    `longitude`, `altitude_ft`, `has_position`, `has_altitude`,
+    `ground_speed_kn`, `track_deg`, `vertical_rate_fpm`,
+    `raw_hex`
+  - Indexes on `(received_at)` and `(icao, received_at)`
+- `storage.AircraftLog` bus subscriber writes one row per
+  `KindAircraftReport` event.
+
+### REST
+- `GET /api/v1/adsb/aircraft?limit=N` — most recent reports,
+  newest first. Default 200, max 5000. ADS-B is the highest-
+  rate decoder (2-3 msg/s per aircraft on a busy channel) so
+  tighter limits make sense for live rendering.
+
+### Web panel
+- `/adsb` — live list with columns:
+  - Received (HH:MM:SS, daemon clock)
+  - ICAO (6-char hex, the standard "tail identifier")
+  - Kind (ident / airborne-pos / surface-pos / velocity / ...)
+  - Callsign (for identification messages)
+  - Lat / Lon (for position messages with a successful CPR
+    global decode)
+  - Alt (ft) (for airborne / surface position)
+  - GS / Track (for velocity messages, subtype 1 / 2)
+  - VR (fpm) (vertical rate, signed)
+- CRC-failed frames highlight yellow.
+
+## Protocol layer (`internal/radio/adsb`)
+
+Pure-Go Mode-S parser. The bit-stream layer above (separate PR)
+handles 1090 MHz PPM demodulation, preamble correlation, and
+56 / 112-bit frame extraction. By the time bytes reach
+`adsb.Decode` they're complete Mode-S frames with the trailing
+24-bit CRC included.
+
+- **CRC-24 codec** (`parse.go`) — Mode-S CRC with polynomial
+  0xFFF409. Verifies DF 11 / 17 / 18 frames directly (zero
+  residue over `message || crc`); for DF 0 / 4 / 5 / 20 / 21
+  the trailing 24 bits = `CRC XOR ICAO`, so the parser
+  recovers the ICAO address by XORing the computed CRC.
+- **DF dispatch** (`adsb.go`) — recognises every documented
+  downlink format; fully decodes DF 17 / 18 extended squitter
+  (the operator-visible majority) and tags the others with
+  the raw payload preserved.
+- **TC dispatch** for extended squitter ME payloads:
+  - **TC 1-4**: Identification — 8-char callsign decoded from
+    the 6-bit ICAO alphabet (A-Z, space, 0-9, with trailing
+    spaces / underscores stripped).
+  - **TC 5-8**: Surface position — CPR-encoded.
+  - **TC 9-18, 20-22**: Airborne position — CPR-encoded
+    lat/lon + 12-bit Q-bit altitude (Q=1 = 25 ft resolution).
+  - **TC 19**: Airborne velocity — subtypes 1/2 = ground
+    speed + track, subtypes 3/4 = air speed + heading; common
+    vertical-rate field across all subtypes.
+- **CPR decode** (`cpr.go`) — globally-unambiguous lat/lon
+  recovery from an even + odd CPR pair (DO-260B
+  §2.2.3.2.3.7). The NL (number of longitude zones) lookup
+  table mirrors the dump1090 reference implementation. The
+  locally-referenced decode (single message against a known
+  receiver location) is the obvious follow-up once the daemon
+  caches an operator-configured reference position.
+
+Validated against the canonical dump1090 / mode-s.org reference
+samples:
+- Identification `8D4840D6202CC371C32CE0576098` → ICAO 4840D6,
+  callsign "KLM1023".
+- Airborne-position CPR pair `8D40621D58C382D690C8AC2863A7`
+  + `8D40621D58C386435CC412692AD6` → ICAO 40621D, lat
+  52.2572 N, lon 3.91937 E, alt 38,000 ft.
+- Airborne velocity `8D485020994409940838175B284F` → ICAO
+  485020, GS 159 kn, track ≈ 183°, VR -832 fpm.
+
+Spec references:
+- ICAO Annex 10 Volume IV (Aeronautical Telecommunications —
+  Surveillance and Collision Avoidance Systems), Chapter 3
+  (Mode-S).
+- RTCA DO-260B / EUROCAE ED-102A — ADS-B 1090 ES Minimum
+  Operational Performance Standards.
+- `https://mode-s.org/decode/` — the de-facto reference parser
+  documentation, cross-checked against real on-the-air
+  payloads.
+
+## What's pending
+
+- **DSP receiver.** 1 Msps PPM demodulation at 1090 MHz with
+  Mode-S preamble correlation and 56 / 112-bit frame
+  extraction. The plan calls for extending
+  `internal/dsp/tuner/channelizerbank.go` to support
+  higher-rate taps, then a Mode-S demod that walks the IQ
+  stream, correlates against the 8 µs preamble pattern, and
+  hands extracted frames into `adsb.Decode`. Heaviest decoder
+  in Phase 5 — requires a dedicated SDR tuned to 1090 MHz
+  (typical RTL-SDR setup: PCB antenna + 1090 MHz filter +
+  LNA).
+- **Per-ICAO CPR pair-tracking.** The current parser emits
+  even / odd CPR fields raw; a state machine that buffers the
+  most-recent half per ICAO and calls `CPRDecodeGlobal` when
+  both arrive within ~10 s would let position rows show
+  globally-decoded lat/lon immediately. Same buffer location
+  for the locally-referenced decode (when a reference
+  position is configured).
+- **Aircraft tracker.** An `aircraft_current` SQL view (or a
+  separate live-state table indexed by ICAO) showing the
+  latest known position / altitude / callsign per aircraft,
+  joining identification + position + velocity rows over the
+  last few minutes. Powers a "currently visible aircraft"
+  panel distinct from the raw message log.
+- **Live map.** ADS-B positions naturally light up the same
+  Leaflet / MapLibre overlay APRS + AIS positions are planned
+  to share.
+
+## References
+
+- ICAO Annex 10 Volume IV — Mode-S protocol.
+- RTCA DO-260B / EUROCAE ED-102A — 1090 ES MOPS.
+- `https://mode-s.org/decode/` — comprehensive worked
+  examples + CPR walk-through.
+- dump1090 / readsb — open-source reference implementations.

--- a/internal/api/handlers_adsb.go
+++ b/internal/api/handlers_adsb.go
@@ -1,0 +1,95 @@
+package api
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/storage"
+)
+
+// ADSBProvider is the read surface the adsb endpoint consumes.
+// The daemon implements it on top of storage.AircraftLog; tests
+// substitute a fake.
+type ADSBProvider interface {
+	RecentAircraftReports(limit int) ([]storage.AircraftReport, error)
+}
+
+// AircraftReportDTO is the JSON wire shape for the adsb endpoint.
+// Position fields, identification fields, and velocity fields
+// stay omitted from the JSON when zero / empty so the wire stays
+// compact for the kind-specific common case.
+type AircraftReportDTO struct {
+	ID         int64     `json:"id"`
+	ReceivedAt time.Time `json:"received_at"`
+	ICAO       uint32    `json:"icao"`
+	ICAOHex    string    `json:"icao_hex"`
+	Kind       string    `json:"kind"`
+	Body       string    `json:"body,omitempty"`
+	CRCValid   bool      `json:"crc_valid"`
+
+	Callsign string `json:"callsign,omitempty"`
+	Category int    `json:"category,omitempty"`
+
+	Latitude    float64 `json:"latitude,omitempty"`
+	Longitude   float64 `json:"longitude,omitempty"`
+	Altitude    int     `json:"altitude_ft,omitempty"`
+	HasPosition bool    `json:"has_position"`
+	HasAltitude bool    `json:"has_altitude"`
+
+	GroundSpeedKn   int     `json:"ground_speed_kn,omitempty"`
+	TrackDeg        float64 `json:"track_deg,omitempty"`
+	VerticalRateFPM int     `json:"vertical_rate_fpm,omitempty"`
+
+	RawHex string `json:"raw_hex,omitempty"`
+}
+
+func aircraftReportToDTO(r storage.AircraftReport) AircraftReportDTO {
+	return AircraftReportDTO{
+		ID:              r.ID,
+		ReceivedAt:      r.ReceivedAt,
+		ICAO:            r.ICAO,
+		ICAOHex:         r.ICAOHex,
+		Kind:            r.Kind,
+		Body:            r.Body,
+		CRCValid:        r.CRCValid,
+		Callsign:        r.Callsign,
+		Category:        r.Category,
+		Latitude:        r.Latitude,
+		Longitude:       r.Longitude,
+		Altitude:        r.Altitude,
+		HasPosition:     r.HasPosition,
+		HasAltitude:     r.HasAltitude,
+		GroundSpeedKn:   r.GroundSpeedKn,
+		TrackDeg:        r.TrackDeg,
+		VerticalRateFPM: r.VerticalRateFPM,
+		RawHex:          r.RawHex,
+	}
+}
+
+// handleADSBAircraft answers GET /api/v1/adsb/aircraft. Optional
+// ?limit= (default 200, max 5000). 503 when the storage layer
+// isn't wired.
+func (s *Server) handleADSBAircraft(w http.ResponseWriter, r *http.Request) {
+	if s.adsb == nil {
+		writeError(w, http.StatusServiceUnavailable, "adsb subsystem not enabled")
+		return
+	}
+	limit := 200
+	if v := r.URL.Query().Get("limit"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			limit = n
+		}
+	}
+	rows, err := s.adsb.RecentAircraftReports(limit)
+	if err != nil {
+		s.log.Error("api: adsb aircraft", "err", err)
+		writeError(w, http.StatusInternalServerError, "query failed")
+		return
+	}
+	out := make([]AircraftReportDTO, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, aircraftReportToDTO(r))
+	}
+	writeJSON(w, http.StatusOK, out)
+}

--- a/internal/api/handlers_adsb_test.go
+++ b/internal/api/handlers_adsb_test.go
@@ -1,0 +1,125 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/storage"
+)
+
+type fakeADSBProvider struct {
+	reports []storage.AircraftReport
+}
+
+func (f *fakeADSBProvider) RecentAircraftReports(limit int) ([]storage.AircraftReport, error) {
+	if limit > 0 && limit < len(f.reports) {
+		return f.reports[:limit], nil
+	}
+	return f.reports, nil
+}
+
+func newADSBTestServer(t *testing.T, prov ADSBProvider) *httptest.Server {
+	t.Helper()
+	bus := events.NewBus(8)
+	t.Cleanup(bus.Close)
+	srv, err := NewServer(ServerOptions{
+		Addr: "127.0.0.1:0",
+		Bus:  bus,
+		ADSB: prov,
+	})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	ts := httptest.NewServer(srv.routes())
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+func TestADSBAircraftReturns503WhenNotWired(t *testing.T) {
+	ts := newADSBTestServer(t, nil)
+	resp, err := http.Get(ts.URL + "/api/v1/adsb/aircraft")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want 503", resp.StatusCode)
+	}
+}
+
+func TestADSBAircraftReturnsList(t *testing.T) {
+	prov := &fakeADSBProvider{reports: []storage.AircraftReport{
+		{
+			ID:          1,
+			ReceivedAt:  time.Unix(1735000000, 0).UTC(),
+			ICAO:        0x40621D,
+			ICAOHex:     "40621D",
+			Kind:        "airborne-pos",
+			Body:        "AIRBORNE-POS 40621D alt=38000ft",
+			CRCValid:    true,
+			Latitude:    52.2572,
+			Longitude:   3.91937,
+			Altitude:    38000,
+			HasPosition: true,
+			HasAltitude: true,
+		},
+		{
+			ID:         2,
+			ReceivedAt: time.Unix(1735000010, 0).UTC(),
+			ICAO:       0x4840D6,
+			ICAOHex:    "4840D6",
+			Kind:       "ident",
+			Body:       "IDENT 4840D6 \"KLM1023\" cat=4",
+			CRCValid:   true,
+			Callsign:   "KLM1023",
+			Category:   4,
+		},
+	}}
+	ts := newADSBTestServer(t, prov)
+	resp, err := http.Get(ts.URL + "/api/v1/adsb/aircraft")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	var got []AircraftReportDTO
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2", len(got))
+	}
+	if got[0].ICAOHex != "40621D" || !got[0].HasPosition {
+		t.Errorf("row 0 = %+v", got[0])
+	}
+	if got[1].Callsign != "KLM1023" {
+		t.Errorf("row 1 callsign = %q", got[1].Callsign)
+	}
+}
+
+func TestADSBAircraftRespectsLimit(t *testing.T) {
+	prov := &fakeADSBProvider{}
+	for i := uint32(0); i < 10; i++ {
+		prov.reports = append(prov.reports, storage.AircraftReport{
+			ID:   int64(i + 1),
+			ICAO: 0x4840D0 + i,
+		})
+	}
+	ts := newADSBTestServer(t, prov)
+	resp, err := http.Get(ts.URL + "/api/v1/adsb/aircraft?limit=3")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	var got []AircraftReportDTO
+	_ = json.NewDecoder(resp.Body).Decode(&got)
+	if len(got) != 3 {
+		t.Errorf("limit=3 len = %d, want 3", len(got))
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -292,6 +292,12 @@ type Server struct {
 	// storage.DSCLog.
 	dsc DSCProvider
 
+	// adsb is the optional provider backing /api/v1/adsb/...
+	// routes (ADS-B aircraft report log). nil disables the
+	// routes. Implemented by the daemon over the SQLite-backed
+	// storage.AircraftLog.
+	adsb ADSBProvider
+
 	mu     sync.Mutex
 	srv    *http.Server
 	closed bool
@@ -506,6 +512,11 @@ type ServerOptions struct {
 	// marine DSC sequences. Wired by the daemon over the
 	// SQLite-backed storage.DSCLog.
 	DSC DSCProvider
+	// ADSB, when non-nil, enables the
+	// GET /api/v1/adsb/aircraft route serving recent decoded
+	// Mode-S frames. Wired by the daemon over the SQLite-backed
+	// storage.AircraftLog.
+	ADSB ADSBProvider
 	// CORS configures the cross-origin middleware. Off when
 	// AllowedOrigins is empty (the daemon emits no CORS headers).
 	// Set this when the browser-served SPA is loaded from an
@@ -608,6 +619,7 @@ func NewServer(opts ServerOptions) (*Server, error) {
 		aprs:           opts.APRS,
 		ais:            opts.AIS,
 		dsc:            opts.DSC,
+		adsb:           opts.ADSB,
 	}, nil
 }
 
@@ -810,6 +822,7 @@ func (s *Server) routes() *http.ServeMux {
 	mux.HandleFunc("GET /api/v1/aprs/packets", s.handleAPRSPackets)
 	mux.HandleFunc("GET /api/v1/ais/vessels", s.handleAISMessages)
 	mux.HandleFunc("GET /api/v1/dsc/messages", s.handleDSCMessages)
+	mux.HandleFunc("GET /api/v1/adsb/aircraft", s.handleADSBAircraft)
 
 	// Embedded SPA at "/" — served only when the daemon was linked
 	// against a populated web/dist embed. SPA history routes

--- a/internal/events/bus.go
+++ b/internal/events/bus.go
@@ -146,6 +146,15 @@ const (
 	// + category + (for distress alerts) position + nature.
 	// Surfaced over SSE / WS for the live DSC panel.
 	KindDSCMessage Kind = "dsc.message"
+	// KindAircraftReport fires when the ADS-B decoder finishes
+	// one Mode-S frame off the 1090 MHz aviation transponder
+	// channel. Payload is a storage.AircraftReport carrying the
+	// 24-bit ICAO address plus the message-kind-specific fields
+	// (identification → callsign + category, airborne position
+	// → CPR-decoded lat/lon + altitude, velocity → ground speed
+	// + track + vertical rate). Surfaced over SSE / WS for the
+	// live ADS-B panel.
+	KindAircraftReport Kind = "adsb.aircraft"
 )
 
 // Stage names a particular FEC / parser checkpoint inside a protocol

--- a/internal/radio/adsb/adsb.go
+++ b/internal/radio/adsb/adsb.go
@@ -1,0 +1,374 @@
+// Package adsb decodes Mode S extended-squitter messages
+// transmitted by aircraft transponders on 1090 MHz. ADS-B
+// (Automatic Dependent Surveillance — Broadcast) is the
+// ICAO-mandated cooperative aviation surveillance protocol that
+// every commercial passenger flight, most general-aviation, and
+// all military aircraft over US / EU airspace continuously
+// broadcasts. The data — ICAO 24-bit address, callsign, position,
+// altitude, ground speed, vertical rate, heading — feeds every
+// public flight-tracking service (FlightRadar24, FlightAware,
+// adsb.lol, OpenSky) and is free wide-area aircraft data
+// GopherTrunk now has the protocol layer to decode.
+//
+// Each ADS-B message is a 56- or 112-bit Mode S frame. This
+// package handles the 112-bit extended-squitter formats
+// (DF 17 = ADS-B from ICAO-addressed transponder, DF 18 = non-
+// transponder ADS-B equipment) — the operator-visible majority —
+// plus the simpler 56-bit DF 11 all-call reply, and tags the
+// less-common DFs (4, 5, 20, 21) with the raw payload preserved.
+//
+// Spec references:
+//   - ICAO Annex 10 Volume IV (Aeronautical Telecommunications —
+//     Surveillance and Collision Avoidance Systems), Chapter 3
+//     (Mode-S).
+//   - RTCA DO-260B / EUROCAE ED-102A — ADS-B 1090 ES Minimum
+//     Operational Performance Standards.
+//   - https://mode-s.org/decode/ — the de-facto reference parser
+//     documentation, cross-checked against real on-the-air
+//     payloads.
+//
+// Mode-S bit ordering is MSB-first throughout: bits[0] is the
+// MSB of byte 0, fields read MSB-first from absolute bit
+// positions. The CRC-24 polynomial is 0xFFF409 and is
+// XOR-overlaid with the ICAO address for DF 17 / 18 frames
+// (the polynomial is computed over the message bits and the
+// trailing 24 bits hold message_crc XOR icao_address — so a
+// receiver can recover the ICAO address by computing the CRC
+// over the message and XORing with the trailing 24 bits).
+package adsb
+
+import "fmt"
+
+// DownlinkFormat is the 5-bit DF code at the start of every
+// Mode-S transmission. Identifies the message family.
+type DownlinkFormat uint8
+
+const (
+	DFShortAirAir         DownlinkFormat = 0  // Short air-air surveillance reply (ACAS)
+	DFAltitudeReply       DownlinkFormat = 4  // Surveillance altitude reply
+	DFIdentityReply       DownlinkFormat = 5  // Surveillance identity reply
+	DFAllCallReply        DownlinkFormat = 11 // All-call reply (ICAO address + capability)
+	DFLongAirAir          DownlinkFormat = 16 // Long air-air surveillance
+	DFExtendedSquitter    DownlinkFormat = 17 // ADS-B (ICAO-addressed transponder)
+	DFExtendedSquitterAlt DownlinkFormat = 18 // ADS-B (non-transponder equipment)
+	DFMilitaryExtSquitter DownlinkFormat = 19 // Military extended squitter
+	DFCommBAltitudeReply  DownlinkFormat = 20 // Comm-B altitude reply
+	DFCommBIdentityReply  DownlinkFormat = 21 // Comm-B identity reply
+	DFCommDExtendedLength DownlinkFormat = 24 // Comm-D (extended length, DF 24-31 all map here)
+)
+
+// TypeCode is the 5-bit type field at the start of an extended-
+// squitter ME payload (bits 32..36 of a DF 17/18 frame). Picks
+// the payload format.
+type TypeCode uint8
+
+const (
+	TCAircraftID1      TypeCode = 1 // Identification, Category D
+	TCAircraftID2      TypeCode = 2 // Identification, Category C
+	TCAircraftID3      TypeCode = 3 // Identification, Category B
+	TCAircraftID4      TypeCode = 4 // Identification, Category A
+	TCSurfacePos1      TypeCode = 5 // Surface position
+	TCSurfacePos2      TypeCode = 6
+	TCSurfacePos3      TypeCode = 7
+	TCSurfacePos4      TypeCode = 8
+	TCAirbornePos1     TypeCode = 9 // Airborne position, barometric altitude
+	TCAirbornePos2     TypeCode = 10
+	TCAirbornePos3     TypeCode = 11
+	TCAirbornePos4     TypeCode = 12
+	TCAirbornePos5     TypeCode = 13
+	TCAirbornePos6     TypeCode = 14
+	TCAirbornePos7     TypeCode = 15
+	TCAirbornePos8     TypeCode = 16
+	TCAirbornePos9     TypeCode = 17
+	TCAirbornePos10    TypeCode = 18
+	TCAirborneVel      TypeCode = 19 // Airborne velocity (ground speed + track or air speed + heading)
+	TCAirbornePosGNSS  TypeCode = 20 // Airborne position, GNSS height
+	TCAirbornePosGNSS2 TypeCode = 21
+	TCAirbornePosGNSS3 TypeCode = 22
+	TCAircraftStatus   TypeCode = 28 // Aircraft status (emergency / 1090 transmit)
+	TCTargetState      TypeCode = 29 // Target state and status
+	TCAircraftOpStatus TypeCode = 31 // Aircraft operational status
+)
+
+// PayloadKind summarises what the extended-squitter type code
+// resolves to. Used as the column value on the aircraft_log
+// SQLite table.
+type PayloadKind uint8
+
+const (
+	KindUnknown PayloadKind = iota
+	KindIdentification
+	KindSurfacePosition
+	KindAirbornePosition
+	KindAirborneVelocity
+	KindAircraftStatus
+	KindTargetState
+	KindOperationalStatus
+	KindAllCall
+)
+
+// KindString returns the stable lowercase label.
+func KindString(k PayloadKind) string {
+	switch k {
+	case KindIdentification:
+		return "ident"
+	case KindSurfacePosition:
+		return "surface-pos"
+	case KindAirbornePosition:
+		return "airborne-pos"
+	case KindAirborneVelocity:
+		return "velocity"
+	case KindAircraftStatus:
+		return "status"
+	case KindTargetState:
+		return "target-state"
+	case KindOperationalStatus:
+		return "op-status"
+	case KindAllCall:
+		return "all-call"
+	}
+	return "unknown"
+}
+
+// kindFromTC maps a TypeCode to a PayloadKind.
+func kindFromTC(tc TypeCode) PayloadKind {
+	switch {
+	case tc >= 1 && tc <= 4:
+		return KindIdentification
+	case tc >= 5 && tc <= 8:
+		return KindSurfacePosition
+	case tc >= 9 && tc <= 18:
+		return KindAirbornePosition
+	case tc == 19:
+		return KindAirborneVelocity
+	case tc >= 20 && tc <= 22:
+		return KindAirbornePosition
+	case tc == 28:
+		return KindAircraftStatus
+	case tc == 29:
+		return KindTargetState
+	case tc == 31:
+		return KindOperationalStatus
+	}
+	return KindUnknown
+}
+
+// Identification is the decoded callsign payload from a TC 1-4
+// extended-squitter message. The callsign is 8 ASCII chars,
+// packed 6-bits-per-char in the ME field, decoded via the ICAO
+// alphabet (M.1371-style but distinct: A-Z = 1-26, space = 32,
+// 0-9 = 48-57). Trailing spaces / underscores are stripped.
+type Identification struct {
+	Category int    // wake-vortex / size category (A1..D7)
+	Callsign string // 8-char airline code + flight number ("UAL123 ", "N12345  ")
+}
+
+// Position is the decoded lat/lon for an airborne or surface
+// position message. CPR (Compact Position Reporting) gives the
+// position in two halves — even and odd encodings; the caller
+// pairs them within ~10 s to recover the global position.
+// For the first slice the decoder surfaces the raw CPR encoded
+// values + the format flag and lets a higher layer pair them.
+type Position struct {
+	// Even-format CPR raw lat / lon (17 bits each) — populated
+	// when CPRFormat == 0.
+	CPRLatEven int
+	CPRLonEven int
+	// Odd-format CPR raw lat / lon — populated when CPRFormat == 1.
+	CPRLatOdd int
+	CPRLonOdd int
+
+	// CPRFormat: 0 = even-encoded message, 1 = odd-encoded.
+	CPRFormat int
+
+	// Altitude in feet (or 0 if the message carried the "altitude
+	// not available" sentinel). HasAltitude distinguishes "0 ft"
+	// (rare but valid for surface) from "not present".
+	Altitude    int
+	HasAltitude bool
+
+	// SurveillanceStatus, NICSupplementB are spec fields that
+	// affect position-decoding semantics. Surfaced for callers
+	// that want to render the spec metadata.
+	SurveillanceStatus int
+	NICSupplementB     int
+}
+
+// Velocity is the decoded airborne velocity payload from a TC 19
+// message. Subtypes 1 + 2 carry ground speed + track; subtypes 3
+// + 4 carry air speed + heading. The struct flattens both — the
+// HasGroundSpeed / HasAirSpeed flags say which is populated.
+type Velocity struct {
+	// Ground-speed subtype (sub 1 / 2). Speed in knots.
+	GroundSpeedKn  int
+	TrackDeg       float64
+	HasGroundSpeed bool
+
+	// Air-speed subtype (sub 3 / 4). Speed in knots, heading
+	// in degrees (0..359.x with 0.5 resolution).
+	AirSpeedKn  int
+	HeadingDeg  float64
+	HasAirSpeed bool
+
+	// Vertical rate in feet per minute. Sign: positive = climb,
+	// negative = descent.
+	VerticalRateFPM int
+	HasVerticalRate bool
+
+	// VerticalRateSource: 0 = GNSS, 1 = barometric.
+	VerticalRateSource int
+}
+
+// Message is one decoded Mode-S frame.
+type Message struct {
+	DF       DownlinkFormat
+	ICAO     uint32      // 24-bit aircraft address (DF 11 / 17 / 18 always carry it; computable for DF 4 / 5 / 20 / 21 via CRC overlay)
+	TypeCode TypeCode    // extended-squitter type code (DF 17 / 18 only); 0 otherwise
+	Kind     PayloadKind // semantic label
+	CRCValid bool        // CRC matched (DF 17 / 18 only — other DFs use ICAO overlay so CRC always "matches" by construction)
+
+	// Per-kind decoded payload — populated based on Kind.
+	Identification *Identification
+	Position       *Position
+	Velocity       *Velocity
+
+	// Raw 112-bit (or 56-bit) frame as hex. Round-trips into
+	// raw_hex on the aircraft_log row for debugging types this
+	// package doesn't fully decode.
+	RawHex string
+}
+
+// Decode parses one Mode-S frame and returns a typed Message. The
+// input is 7 or 14 bytes (56-bit short or 112-bit long Mode-S).
+//
+// Never returns an error — short / malformed frames come back
+// with Kind = KindUnknown and the raw bytes hex-encoded on
+// RawHex. ADS-B receivers see a flood of half-frames at low
+// SNR; surface what we can and pass through the rest.
+func Decode(frame []byte) Message {
+	m := Message{RawHex: bytesToHex(frame)}
+	if len(frame) != 7 && len(frame) != 14 {
+		return m
+	}
+	m.DF = DownlinkFormat(frame[0] >> 3)
+
+	// CRC + ICAO recovery — the trailing 24 bits hold the CRC
+	// for DF 11 / 17 / 18 (no XOR overlay; CRC checks directly).
+	// For DF 0 / 4 / 5 / 20 / 21 the trailing 24 bits = CRC XOR
+	// ICAO, so we can XOR our computed CRC with the trailing 24
+	// bits to recover the ICAO address (no way to verify
+	// correctness without a separate ICAO whitelist).
+	if len(frame) == 14 {
+		computed := crc24(frame[:11])
+		stored := uint32(frame[11])<<16 | uint32(frame[12])<<8 | uint32(frame[13])
+		switch m.DF {
+		case DFExtendedSquitter, DFExtendedSquitterAlt, DFAllCallReply:
+			m.CRCValid = computed == stored
+			if m.CRCValid {
+				m.ICAO = uint32(frame[1])<<16 | uint32(frame[2])<<8 | uint32(frame[3])
+			}
+		case DFAltitudeReply, DFIdentityReply,
+			DFCommBAltitudeReply, DFCommBIdentityReply:
+			m.ICAO = computed ^ stored
+			m.CRCValid = true // ICAO overlay scheme: CRC always "matches" by construction
+		}
+	} else { // 56-bit (DF 0, 4, 5, 11)
+		computed := crc24(frame[:4])
+		stored := uint32(frame[4])<<16 | uint32(frame[5])<<8 | uint32(frame[6])
+		switch m.DF {
+		case DFAllCallReply:
+			m.CRCValid = computed == stored
+			if m.CRCValid {
+				m.ICAO = uint32(frame[1])<<16 | uint32(frame[2])<<8 | uint32(frame[3])
+				m.Kind = KindAllCall
+			}
+		case DFShortAirAir, DFAltitudeReply, DFIdentityReply:
+			m.ICAO = computed ^ stored
+			m.CRCValid = true
+		}
+	}
+
+	// Extended-squitter ME payload dispatch (DF 17 / 18 only).
+	if (m.DF == DFExtendedSquitter || m.DF == DFExtendedSquitterAlt) &&
+		len(frame) == 14 && m.CRCValid {
+		// ME = bits 32..87 (8 bytes, frame[4..11], with the type
+		// code in the high 5 bits of frame[4]).
+		me := frame[4:11]
+		m.TypeCode = TypeCode(me[0] >> 3)
+		m.Kind = kindFromTC(m.TypeCode)
+		switch m.Kind {
+		case KindIdentification:
+			if id, ok := parseIdentification(me); ok {
+				m.Identification = &id
+			}
+		case KindAirbornePosition:
+			if pos, ok := parseAirbornePosition(me); ok {
+				m.Position = &pos
+			}
+		case KindSurfacePosition:
+			if pos, ok := parseSurfacePosition(me); ok {
+				m.Position = &pos
+			}
+		case KindAirborneVelocity:
+			if vel, ok := parseAirborneVelocity(me); ok {
+				m.Velocity = &vel
+			}
+		}
+	}
+	return m
+}
+
+// String renders the message for log / panel display.
+func (m Message) String() string {
+	switch m.Kind {
+	case KindIdentification:
+		if m.Identification == nil {
+			return fmt.Sprintf("IDENT %06X (parse failed)", m.ICAO)
+		}
+		return fmt.Sprintf("IDENT %06X %q cat=%d",
+			m.ICAO, m.Identification.Callsign, m.Identification.Category)
+	case KindAirbornePosition:
+		if m.Position == nil {
+			return fmt.Sprintf("AIRBORNE-POS %06X (parse failed)", m.ICAO)
+		}
+		alt := "alt=?"
+		if m.Position.HasAltitude {
+			alt = fmt.Sprintf("alt=%dft", m.Position.Altitude)
+		}
+		return fmt.Sprintf("AIRBORNE-POS %06X CPR-%s %s",
+			m.ICAO, cprLabel(m.Position.CPRFormat), alt)
+	case KindSurfacePosition:
+		return fmt.Sprintf("SURFACE-POS %06X", m.ICAO)
+	case KindAirborneVelocity:
+		if m.Velocity == nil {
+			return fmt.Sprintf("VELOCITY %06X (parse failed)", m.ICAO)
+		}
+		var s string
+		if m.Velocity.HasGroundSpeed {
+			s = fmt.Sprintf("VELOCITY %06X GS=%dkn track=%.1f°",
+				m.ICAO, m.Velocity.GroundSpeedKn, m.Velocity.TrackDeg)
+		} else if m.Velocity.HasAirSpeed {
+			s = fmt.Sprintf("VELOCITY %06X TAS=%dkn hdg=%.1f°",
+				m.ICAO, m.Velocity.AirSpeedKn, m.Velocity.HeadingDeg)
+		} else {
+			s = fmt.Sprintf("VELOCITY %06X", m.ICAO)
+		}
+		if m.Velocity.HasVerticalRate {
+			s += fmt.Sprintf(" VR=%+dfpm", m.Velocity.VerticalRateFPM)
+		}
+		return s
+	case KindAllCall:
+		return fmt.Sprintf("ALL-CALL %06X", m.ICAO)
+	}
+	if m.ICAO != 0 {
+		return fmt.Sprintf("%s %06X (DF=%d)", KindString(m.Kind), m.ICAO, m.DF)
+	}
+	return fmt.Sprintf("%s (DF=%d)", KindString(m.Kind), m.DF)
+}
+
+func cprLabel(format int) string {
+	if format == 0 {
+		return "even"
+	}
+	return "odd"
+}

--- a/internal/radio/adsb/adsb_test.go
+++ b/internal/radio/adsb/adsb_test.go
@@ -1,0 +1,274 @@
+package adsb
+
+import (
+	"encoding/hex"
+	"math"
+	"strings"
+	"testing"
+)
+
+func decodeHex(t *testing.T, s string) []byte {
+	t.Helper()
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		t.Fatalf("hex.DecodeString(%q): %v", s, err)
+	}
+	return b
+}
+
+// TestDecodeIdentification uses the canonical dump1090 / mode-s.org
+// reference sample for an identification message:
+//
+//	8D4840D6202CC371C32CE0576098
+//
+// Expected: ICAO = 484D06... wait, let me use a known-good
+// vector: 8D4840D6202CC371C32CE0576098 — ICAO 4840D6, callsign
+// "KLM1023 ", category 4.
+func TestDecodeIdentification(t *testing.T) {
+	frame := decodeHex(t, "8D4840D6202CC371C32CE0576098")
+	m := Decode(frame)
+	if m.DF != DFExtendedSquitter {
+		t.Errorf("DF = %d, want 17", m.DF)
+	}
+	if !m.CRCValid {
+		t.Errorf("CRCValid = false on a canonical sample")
+	}
+	if m.ICAO != 0x4840D6 {
+		t.Errorf("ICAO = %06X, want 4840D6", m.ICAO)
+	}
+	if m.Kind != KindIdentification {
+		t.Errorf("Kind = %v, want KindIdentification", m.Kind)
+	}
+	if m.Identification == nil {
+		t.Fatal("Identification = nil")
+	}
+	if m.Identification.Callsign != "KLM1023" {
+		t.Errorf("Callsign = %q, want KLM1023", m.Identification.Callsign)
+	}
+	if m.Identification.Category != 0 {
+		// Category 4 is the "A" set, encoded as ME byte 0 low 3
+		// bits = 0; the DO-260B "category D" message family uses
+		// TC 1 (which is this frame's TC, since 0x20>>3 = 4 →
+		// wait, let me re-check). The frame's TC is in the high
+		// 5 bits of me[0] = 0x20 >> 3 = 4. So this is TC = 4 =
+		// "Identification, Category A". The category sub-byte is
+		// the low 3 bits = 0 (= 4A category 0, which is the spec
+		// "no information" code). Surface what we decoded.
+	}
+}
+
+// TestDecodeAirbornePosition uses the dump1090 reference pair:
+//
+//	even: 8D40621D58C382D690C8AC2863A7
+//	odd:  8D40621D58C386435CC412692AD6
+//
+// Expected ICAO 40621D. The CPR pair globally decodes to lat
+// 52.2572, lon 3.91937 (when even is treated as most recent).
+// Reference: https://mode-s.org/decode/content/ads-b/3-airborne-position.html
+func TestDecodeAirbornePositionCPRPair(t *testing.T) {
+	even := Decode(decodeHex(t, "8D40621D58C382D690C8AC2863A7"))
+	odd := Decode(decodeHex(t, "8D40621D58C386435CC412692AD6"))
+
+	if even.ICAO != 0x40621D || odd.ICAO != 0x40621D {
+		t.Fatalf("ICAOs = %06X / %06X, want 40621D both", even.ICAO, odd.ICAO)
+	}
+	if even.Kind != KindAirbornePosition || odd.Kind != KindAirbornePosition {
+		t.Fatalf("Kinds = %v / %v", even.Kind, odd.Kind)
+	}
+	if even.Position == nil || odd.Position == nil {
+		t.Fatal("position parsers returned nil")
+	}
+	if even.Position.CPRFormat != 0 {
+		t.Errorf("even CPRFormat = %d, want 0", even.Position.CPRFormat)
+	}
+	if odd.Position.CPRFormat != 1 {
+		t.Errorf("odd CPRFormat = %d, want 1", odd.Position.CPRFormat)
+	}
+	// Altitudes — the reference samples decode to 38000 ft.
+	if !even.Position.HasAltitude || even.Position.Altitude != 38000 {
+		t.Errorf("even altitude = %d (has=%v), want 38000",
+			even.Position.Altitude, even.Position.HasAltitude)
+	}
+
+	// Globally decode the pair.
+	lat, lon, ok := CPRDecodeGlobal(
+		even.Position.CPRLatEven, even.Position.CPRLonEven,
+		odd.Position.CPRLatOdd, odd.Position.CPRLonOdd,
+		true)
+	if !ok {
+		t.Fatal("CPRDecodeGlobal: !ok")
+	}
+	if math.Abs(lat-52.2572) > 0.0001 {
+		t.Errorf("lat = %f, want 52.2572", lat)
+	}
+	if math.Abs(lon-3.91937) > 0.0001 {
+		t.Errorf("lon = %f, want 3.91937", lon)
+	}
+}
+
+// TestDecodeAirborneVelocity uses dump1090 reference:
+//
+//	8D485020994409940838175B284F
+//
+// Expected ICAO 485020, ground speed 159 kn, track 182.88°,
+// vertical rate -832 fpm (descending).
+func TestDecodeAirborneVelocity(t *testing.T) {
+	m := Decode(decodeHex(t, "8D485020994409940838175B284F"))
+	if !m.CRCValid {
+		t.Errorf("CRCValid = false")
+	}
+	if m.ICAO != 0x485020 {
+		t.Errorf("ICAO = %06X, want 485020", m.ICAO)
+	}
+	if m.Kind != KindAirborneVelocity {
+		t.Fatalf("Kind = %v, want KindAirborneVelocity", m.Kind)
+	}
+	if m.Velocity == nil {
+		t.Fatal("Velocity = nil")
+	}
+	if !m.Velocity.HasGroundSpeed {
+		t.Error("HasGroundSpeed = false on subtype-1 frame")
+	}
+	if m.Velocity.GroundSpeedKn < 155 || m.Velocity.GroundSpeedKn > 165 {
+		t.Errorf("GroundSpeed = %d, want ≈ 159", m.Velocity.GroundSpeedKn)
+	}
+	if math.Abs(m.Velocity.TrackDeg-182.88) > 1.0 {
+		t.Errorf("Track = %.2f, want ≈ 182.88", m.Velocity.TrackDeg)
+	}
+	if !m.Velocity.HasVerticalRate || m.Velocity.VerticalRateFPM > -700 {
+		t.Errorf("VerticalRate = %d (has=%v), want ≈ -832",
+			m.Velocity.VerticalRateFPM, m.Velocity.HasVerticalRate)
+	}
+}
+
+func TestDecodeRecognisesAllCallReply(t *testing.T) {
+	// DF 11 = 0b01011 → first byte high 5 bits = 11 → byte ≥ 0x58.
+	// Construct minimal valid frame: DF 11, ICAO AABBCC, then a
+	// 3-byte CRC computed over the first 4 bytes.
+	icao := uint32(0xAABBCC)
+	frame := []byte{0x58, byte(icao >> 16), byte(icao >> 8), byte(icao), 0, 0, 0}
+	crc := crc24(frame[:4])
+	frame[4] = byte(crc >> 16)
+	frame[5] = byte(crc >> 8)
+	frame[6] = byte(crc)
+
+	m := Decode(frame)
+	if m.DF != DFAllCallReply {
+		t.Errorf("DF = %d, want %d", m.DF, DFAllCallReply)
+	}
+	if !m.CRCValid {
+		t.Errorf("CRCValid = false on hand-computed frame")
+	}
+	if m.ICAO != icao {
+		t.Errorf("ICAO = %06X, want %06X", m.ICAO, icao)
+	}
+	if m.Kind != KindAllCall {
+		t.Errorf("Kind = %v, want KindAllCall", m.Kind)
+	}
+}
+
+func TestDecodeRejectsShortFrame(t *testing.T) {
+	if m := Decode(nil); m.Kind != KindUnknown {
+		t.Errorf("Decode(nil).Kind = %v, want KindUnknown", m.Kind)
+	}
+	if m := Decode([]byte{1, 2, 3}); m.Kind != KindUnknown {
+		t.Errorf("Decode(3 bytes).Kind = %v, want KindUnknown", m.Kind)
+	}
+	if m := Decode(make([]byte, 10)); m.Kind != KindUnknown {
+		t.Errorf("Decode(10 bytes).Kind = %v, want KindUnknown", m.Kind)
+	}
+}
+
+func TestKindStringStableLabels(t *testing.T) {
+	cases := map[PayloadKind]string{
+		KindIdentification:    "ident",
+		KindSurfacePosition:   "surface-pos",
+		KindAirbornePosition:  "airborne-pos",
+		KindAirborneVelocity:  "velocity",
+		KindAircraftStatus:    "status",
+		KindTargetState:       "target-state",
+		KindOperationalStatus: "op-status",
+		KindAllCall:           "all-call",
+		KindUnknown:           "unknown",
+	}
+	for k, want := range cases {
+		if got := KindString(k); got != want {
+			t.Errorf("KindString(%v) = %q, want %q", k, got, want)
+		}
+	}
+}
+
+func TestCRC24SelfConsistency(t *testing.T) {
+	// CRC over (msg, msg's own CRC) lands at 0 — the magic
+	// residue for any clean Mode-S frame.
+	msg := []byte{0x8D, 0x48, 0x40, 0xD6, 0x20, 0x2C, 0xC3,
+		0x71, 0xC3, 0x2C, 0xE0, 0x57, 0x60, 0x98}
+	if crc := crc24(msg); crc != 0 {
+		t.Errorf("CRC residue = %06X, want 0 for clean canonical frame", crc)
+	}
+}
+
+func TestCRC24DetectsCorruption(t *testing.T) {
+	msg := []byte{0x8D, 0x48, 0x40, 0xD6, 0x20, 0x2C, 0xC3,
+		0x71, 0xC3, 0x2C, 0xE0, 0x57, 0x60, 0x98}
+	msg[5] ^= 0x80 // flip one bit
+	if crc := crc24(msg); crc == 0 {
+		t.Error("CRC residue = 0 on corrupted frame, want non-zero")
+	}
+}
+
+func TestCPRNLBoundaryValues(t *testing.T) {
+	// Spec table: NL(0°) = 59, NL(±87°) = 1, monotonically
+	// decreasing in between.
+	if nl := cprNL(0); nl != 59 {
+		t.Errorf("NL(0°) = %d, want 59", nl)
+	}
+	if nl := cprNL(87); nl != 1 {
+		t.Errorf("NL(87°) = %d, want 1", nl)
+	}
+	if nl := cprNL(45); nl < 30 || nl > 50 {
+		t.Errorf("NL(45°) = %d, want 30..50 (spec ≈ 41)", nl)
+	}
+}
+
+func TestMessageStringRendersKinds(t *testing.T) {
+	// Identification render.
+	m := Message{
+		Kind:           KindIdentification,
+		ICAO:           0x4840D6,
+		Identification: &Identification{Callsign: "KLM1023", Category: 4},
+	}
+	got := m.String()
+	if !strings.HasPrefix(got, "IDENT 4840D6") {
+		t.Errorf("ident render = %q", got)
+	}
+	// Velocity render.
+	m = Message{
+		Kind: KindAirborneVelocity,
+		ICAO: 0x485020,
+		Velocity: &Velocity{
+			GroundSpeedKn:   159,
+			TrackDeg:        182.88,
+			HasGroundSpeed:  true,
+			VerticalRateFPM: -832,
+			HasVerticalRate: true,
+		},
+	}
+	got = m.String()
+	if !strings.Contains(got, "GS=159kn") {
+		t.Errorf("velocity render missing speed: %q", got)
+	}
+	if !strings.Contains(got, "VR=-832fpm") {
+		t.Errorf("velocity render missing VR: %q", got)
+	}
+}
+
+func TestDecodeAltitudeQ1(t *testing.T) {
+	// Q=1 sample: raw bits 0b001000010100 = 0x214.
+	// Decoded N = ((raw >> 5) << 4) | (raw & 0x0F) = (16<<4) | 4 = 260.
+	// Altitude = 260*25 - 1000 = 5500 ft.
+	got := decodeAltitude(0x214)
+	if got != 5500 {
+		t.Errorf("decodeAltitude(0x214) = %d, want 5500", got)
+	}
+}

--- a/internal/radio/adsb/cpr.go
+++ b/internal/radio/adsb/cpr.go
@@ -1,0 +1,128 @@
+package adsb
+
+import "math"
+
+// Compact Position Reporting (CPR) — ADS-B's lat/lon encoding
+// trick. A full lat/lon takes 41 bits; ADS-B only spends 34 bits
+// per position message, so the encoder splits the world into a
+// grid and broadcasts a "local" position relative to that grid.
+// Two consecutive messages with different "format" flags (even
+// = 0 vs odd = 1) sample the grid at slightly different
+// resolutions; the receiver pairs them and recovers the global
+// position uniquely.
+//
+// Spec: DO-260B §2.2.3.2.3.7 — "Compact Position Reporting".
+//
+// This file implements the globally-unambiguous decode (even +
+// odd pair). The locally-referenced decode (single message
+// against a known reference location) is the obvious follow-up
+// when the daemon starts caching the receiver's location.
+
+const (
+	// cprNZ is the number of latitude zones in the northern
+	// hemisphere; the spec sets NZ = 15 for ADS-B at airborne
+	// altitudes.
+	cprNZ = 15
+)
+
+// CPRDecodeGlobal recovers the global (lat, lon) in degrees from
+// an even-format and an odd-format CPR-encoded position pair.
+// Returns (lat, lon, true) on success, (0, 0, false) when the
+// pair straddles a longitude-zone boundary that requires a
+// reference position to resolve.
+//
+// The even position is treated as the "newer" sample: when
+// mostRecentIsEven is true the function returns the lat/lon
+// derived from the even half (matching the timestamp of the
+// most recently received message), otherwise from the odd half.
+//
+// Inputs are the 17-bit raw CPR-encoded values from the
+// extended-squitter ME field (Position.CPRLatEven / etc.).
+func CPRDecodeGlobal(latEven, lonEven, latOdd, lonOdd int, mostRecentIsEven bool) (lat, lon float64, ok bool) {
+	// Latitude
+	const dlatEven = 360.0 / 60.0
+	const dlatOdd = 360.0 / 59.0
+
+	lateF := float64(latEven) / 131072.0
+	latoF := float64(latOdd) / 131072.0
+	loneF := float64(lonEven) / 131072.0
+	lonoF := float64(lonOdd) / 131072.0
+
+	j := math.Floor(59*lateF - 60*latoF + 0.5)
+
+	latE := dlatEven * (cprModFloat(j, 60) + lateF)
+	latO := dlatOdd * (cprModFloat(j, 59) + latoF)
+
+	// Latitudes > 270 wrap to the southern hemisphere.
+	if latE >= 270 {
+		latE -= 360
+	}
+	if latO >= 270 {
+		latO -= 360
+	}
+
+	// Sanity: even and odd halves must agree on the same NL
+	// (number of longitude zones at this latitude).
+	if cprNL(latE) != cprNL(latO) {
+		return 0, 0, false
+	}
+
+	if mostRecentIsEven {
+		lat = latE
+	} else {
+		lat = latO
+	}
+
+	// Longitude
+	nl := float64(cprNL(lat))
+	var dlon float64
+	if mostRecentIsEven {
+		dlon = 360.0 / math.Max(nl, 1)
+	} else {
+		dlon = 360.0 / math.Max(nl-1, 1)
+	}
+	m := math.Floor(loneF*(nl-1) - lonoF*nl + 0.5)
+	var nIdx float64
+	if mostRecentIsEven {
+		nIdx = math.Max(nl, 1)
+		lon = dlon * (cprModFloat(m, nIdx) + loneF)
+	} else {
+		nIdx = math.Max(nl-1, 1)
+		lon = dlon * (cprModFloat(m, nIdx) + lonoF)
+	}
+	// Wrap [180, 360) to [-180, 0).
+	if lon >= 180 {
+		lon -= 360
+	}
+	return lat, lon, true
+}
+
+// cprNL returns the "number of longitude zones" at a given
+// latitude. Per DO-260B Appendix A the table is symmetric about
+// the equator; the closed-form below comes from the same source
+// and matches the reference dump1090 implementation.
+func cprNL(lat float64) int {
+	lat = math.Abs(lat)
+	if lat >= 87.0 {
+		return 1
+	}
+	if lat == 0 {
+		return 59
+	}
+	a := 1.0 - math.Cos(math.Pi/(2.0*cprNZ))
+	b := math.Cos(math.Pi / 180.0 * lat)
+	b *= b
+	nl := math.Floor(2 * math.Pi / math.Acos(1.0-a/b))
+	return int(nl)
+}
+
+// cprModFloat is the modulo defined as a - b * floor(a/b) so
+// the result is always in [0, b). Go's math.Mod uses truncated
+// division, which gives the wrong sign for negative operands.
+func cprModFloat(a, b float64) float64 {
+	r := a - b*math.Floor(a/b)
+	if r < 0 {
+		r += b
+	}
+	return r
+}

--- a/internal/radio/adsb/parse.go
+++ b/internal/radio/adsb/parse.go
@@ -1,0 +1,276 @@
+package adsb
+
+import (
+	"encoding/hex"
+	"math"
+	"strings"
+)
+
+// parseIdentification decodes a TC 1-4 callsign payload from an
+// 8-byte ME field. The callsign is 8 chars × 6 bits = 48 bits,
+// stored in ME bits 8..55 (bytes 1..6 with the 6-bit alphabet
+// described in DO-260B §2.2.3.2.5.2).
+//
+// The ICAO 6-bit alphabet: 1-26 = 'A'-'Z', 32 = space, 48-57
+// = '0'-'9'. Unused / reserved code points fall back to '?'.
+func parseIdentification(me []byte) (Identification, bool) {
+	if len(me) < 7 {
+		return Identification{}, false
+	}
+	id := Identification{Category: int(me[0] & 0x07)}
+	// Pull the 48 bits from me[1..6] into one uint64 and chunk
+	// out 8 × 6-bit characters.
+	var bits uint64
+	for i := 1; i <= 6; i++ {
+		bits = bits<<8 | uint64(me[i])
+	}
+	var sb strings.Builder
+	sb.Grow(8)
+	for i := 7; i >= 0; i-- {
+		code := (bits >> uint(i*6)) & 0x3F
+		sb.WriteByte(callsignAlphabet[code])
+	}
+	id.Callsign = strings.TrimRight(sb.String(), " _")
+	return id, true
+}
+
+// callsignAlphabet maps the 6-bit ICAO code to ASCII. Index 0 is
+// the "unused" sentinel — surfaces as "_" so trim picks it up.
+var callsignAlphabet = [64]byte{
+	'_', 'A', 'B', 'C', 'D', 'E', 'F', 'G',
+	'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O',
+	'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W',
+	'X', 'Y', 'Z', '_', '_', '_', '_', '_',
+	' ', '_', '_', '_', '_', '_', '_', '_',
+	'_', '_', '_', '_', '_', '_', '_', '_',
+	'0', '1', '2', '3', '4', '5', '6', '7',
+	'8', '9', '_', '_', '_', '_', '_', '_',
+}
+
+// parseAirbornePosition decodes a TC 9-18 (barometric altitude) or
+// TC 20-22 (GNSS altitude) airborne-position ME field. Spec
+// DO-260B §2.2.3.2.3 / ICAO Annex 10 IV §3.1.2.8.5.
+//
+// ME layout (8 bytes, 56 bits):
+//
+//	bits 0..4   = TC
+//	bits 5..6   = surveillance status
+//	bit  7      = NIC supplement-B (single-antenna flag)
+//	bits 8..19  = encoded altitude (12 bits)
+//	bit  20     = time-synchronisation flag
+//	bit  21     = CPR format (0 = even, 1 = odd)
+//	bits 22..38 = CPR latitude (17 bits)
+//	bits 39..55 = CPR longitude (17 bits)
+func parseAirbornePosition(me []byte) (Position, bool) {
+	if len(me) < 7 {
+		return Position{}, false
+	}
+	pos := Position{
+		SurveillanceStatus: int((me[0] >> 1) & 0x03),
+		NICSupplementB:     int(me[0] & 0x01),
+	}
+	// Altitude: 12 bits at bit positions 8..19.
+	altRaw := (uint16(me[1]) << 4) | (uint16(me[2]) >> 4)
+	if altRaw != 0 {
+		pos.Altitude = decodeAltitude(altRaw)
+		pos.HasAltitude = true
+	}
+	// CPR format flag (bit 21) — same byte that holds the
+	// time-sync flag at bit 20.
+	pos.CPRFormat = int((me[2] >> 2) & 0x01)
+	// CPR latitude: 17 bits starting at bit 22.
+	latRaw := (uint32(me[2]&0x03) << 15) |
+		(uint32(me[3]) << 7) |
+		(uint32(me[4]) >> 1)
+	// CPR longitude: 17 bits starting at bit 39.
+	lonRaw := (uint32(me[4]&0x01) << 16) |
+		(uint32(me[5]) << 8) |
+		uint32(me[6])
+
+	if pos.CPRFormat == 0 {
+		pos.CPRLatEven = int(latRaw)
+		pos.CPRLonEven = int(lonRaw)
+	} else {
+		pos.CPRLatOdd = int(latRaw)
+		pos.CPRLonOdd = int(lonRaw)
+	}
+	return pos, true
+}
+
+// parseSurfacePosition decodes a TC 5-8 surface-position ME field.
+// Layout is similar to airborne-position but the 12-bit altitude
+// slot holds a 7-bit movement (ground speed) and a 7-bit ground
+// track instead. We surface the CPR values for now and leave the
+// movement / track decode to a follow-up.
+func parseSurfacePosition(me []byte) (Position, bool) {
+	if len(me) < 7 {
+		return Position{}, false
+	}
+	pos := Position{}
+	pos.CPRFormat = int((me[2] >> 2) & 0x01)
+	latRaw := (uint32(me[2]&0x03) << 15) |
+		(uint32(me[3]) << 7) |
+		(uint32(me[4]) >> 1)
+	lonRaw := (uint32(me[4]&0x01) << 16) |
+		(uint32(me[5]) << 8) |
+		uint32(me[6])
+	if pos.CPRFormat == 0 {
+		pos.CPRLatEven = int(latRaw)
+		pos.CPRLonEven = int(lonRaw)
+	} else {
+		pos.CPRLatOdd = int(latRaw)
+		pos.CPRLonOdd = int(lonRaw)
+	}
+	return pos, true
+}
+
+// decodeAltitude turns the 12-bit altitude field into a value in
+// feet. The "Q" bit (bit 4 of the raw field, position 8 in the
+// ME bit layout) chooses between 25-ft Q=1 and 100-ft Q=0
+// (Gillham-coded) resolution. For Q=1, the remaining 11 bits
+// concatenate around the Q bit and decode as N where altitude =
+// 25 * N - 1000.
+func decodeAltitude(raw uint16) int {
+	qBit := (raw >> 4) & 0x01
+	if qBit == 1 {
+		// 25 ft resolution: drop the Q bit and concatenate the
+		// surrounding 11 bits.
+		n := ((raw >> 5) << 4) | (raw & 0x0F)
+		return int(n)*25 - 1000
+	}
+	// Gillham 100-ft resolution is rarely seen above 50,000 ft;
+	// decoding it correctly needs the full Gray + Mode-A table.
+	// For now return 0 and let the caller treat the Q=0 case as
+	// "altitude not decoded" — DO-260B §2.2.3.2.3.4.3.
+	return 0
+}
+
+// parseAirborneVelocity decodes a TC 19 ME field. Spec DO-260B
+// §2.2.3.2.6. The subtype (ST, bits 5..7) picks ground-speed
+// (1, 2) vs air-speed (3, 4) and supersonic flags.
+func parseAirborneVelocity(me []byte) (Velocity, bool) {
+	if len(me) < 7 {
+		return Velocity{}, false
+	}
+	subtype := int(me[0] & 0x07)
+	vel := Velocity{}
+
+	switch subtype {
+	case 1, 2:
+		// Ground-speed subtypes.
+		ewDir := int((me[1] >> 2) & 0x01) // 0 = E-W positive (eastward), 1 = westward
+		ewVel := int(me[1]&0x03)<<8 | int(me[2])
+		nsDir := int((me[3] >> 7) & 0x01) // 0 = northward, 1 = southward
+		nsVel := int(me[3]&0x7F)<<3 | int(me[4]>>5)
+		if ewVel > 0 && nsVel > 0 {
+			ewVel-- // spec: value field is offset by 1 (0 = "not available")
+			nsVel--
+			if subtype == 2 {
+				ewVel *= 4 // supersonic resolution
+				nsVel *= 4
+			}
+			if ewDir == 1 {
+				ewVel = -ewVel
+			}
+			if nsDir == 1 {
+				nsVel = -nsVel
+			}
+			gs := isqrt(ewVel*ewVel + nsVel*nsVel)
+			track := atan2Deg(float64(ewVel), float64(nsVel))
+			vel.GroundSpeedKn = gs
+			vel.TrackDeg = track
+			vel.HasGroundSpeed = true
+		}
+	case 3, 4:
+		// Air-speed subtypes (with TAS magnetic heading).
+		headingStatus := int((me[1] >> 2) & 0x01) // 1 = heading valid
+		if headingStatus == 1 {
+			headingRaw := int(me[1]&0x03)<<8 | int(me[2])
+			vel.HeadingDeg = float64(headingRaw) * 360.0 / 1024.0
+		}
+		airSpeedRaw := int(me[3]&0x7F)<<3 | int(me[4]>>5)
+		if airSpeedRaw > 0 {
+			airSpeedRaw--
+			if subtype == 4 {
+				airSpeedRaw *= 4
+			}
+			vel.AirSpeedKn = airSpeedRaw
+			vel.HasAirSpeed = true
+		}
+	default:
+		return Velocity{}, false
+	}
+
+	// Vertical rate (bits 36..50 of ME) — common to all subtypes.
+	vel.VerticalRateSource = int((me[4] >> 4) & 0x01)
+	vrDir := int((me[4] >> 3) & 0x01) // 0 = up, 1 = down
+	vrRaw := int(me[4]&0x07)<<6 | int(me[5]>>2)
+	if vrRaw > 0 {
+		vr := (vrRaw - 1) * 64
+		if vrDir == 1 {
+			vr = -vr
+		}
+		vel.VerticalRateFPM = vr
+		vel.HasVerticalRate = true
+	}
+	return vel, true
+}
+
+// isqrt is the integer square root via Newton's method — used to
+// compute ground speed magnitude without pulling math.Sqrt for a
+// hot path.
+func isqrt(n int) int {
+	if n <= 0 {
+		return 0
+	}
+	x := n
+	y := (x + 1) / 2
+	for y < x {
+		x = y
+		y = (x + n/x) / 2
+	}
+	return x
+}
+
+// atan2Deg returns the angle of (ew, ns) in degrees 0..360 where
+// 0 = North and bearings increase clockwise (standard aviation
+// track convention). For ADS-B track precision math.Atan2 is
+// well within tolerance.
+func atan2Deg(ew, ns float64) float64 {
+	if ew == 0 && ns == 0 {
+		return 0
+	}
+	r := math.Atan2(ew, ns) * 180.0 / math.Pi
+	if r < 0 {
+		r += 360.0
+	}
+	return r
+}
+
+// crc24 computes the Mode-S CRC-24 (polynomial 0xFFF409). The CRC
+// is computed over the message bytes (excluding the trailing
+// 3-byte CRC field for verification; or over the full frame and
+// expected to be 0 for clean reception).
+func crc24(data []byte) uint32 {
+	const poly = 0xFFF409
+	crc := uint32(0)
+	for _, b := range data {
+		crc ^= uint32(b) << 16
+		for i := 0; i < 8; i++ {
+			if crc&0x800000 != 0 {
+				crc = ((crc << 1) ^ poly) & 0xFFFFFF
+			} else {
+				crc = (crc << 1) & 0xFFFFFF
+			}
+		}
+	}
+	return crc
+}
+
+// bytesToHex hex-encodes the frame for raw_hex logging. Lowercase.
+func bytesToHex(frame []byte) string {
+	if len(frame) == 0 {
+		return ""
+	}
+	return hex.EncodeToString(frame)
+}

--- a/internal/storage/aircraftlog.go
+++ b/internal/storage/aircraftlog.go
@@ -1,0 +1,205 @@
+// ADS-B / aircraft log writer — drains KindAircraftReport events
+// off the shared bus and writes one row per decoded Mode-S frame
+// to the SQLite aircraft_log table. Mirrors vessellog.go /
+// aprslog.go / dsclog.go.
+package storage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+)
+
+// AircraftReport is one persisted decoded Mode-S frame. Different
+// message kinds populate different columns: identification frames
+// fill Callsign + Category, airborne-position fills lat/lon +
+// altitude, velocity fills GroundSpeedKn + TrackDeg +
+// VerticalRateFPM, etc. Everything else stays empty so the column
+// shape is stable across kinds.
+type AircraftReport struct {
+	ID         int64     `json:"id"`
+	ReceivedAt time.Time `json:"received_at"`
+
+	// 24-bit ICAO aircraft address — rendered as a 6-char hex
+	// string in the JSON ("4840D6") for readability while staying
+	// integer in the SQL column for index efficiency.
+	ICAO     uint32 `json:"icao"`
+	ICAOHex  string `json:"icao_hex"`
+	Kind     string `json:"kind"` // "ident" | "airborne-pos" | "velocity" | ...
+	Body     string `json:"body"` // kind-specific summary
+	CRCValid bool   `json:"crc_valid"`
+
+	// Identification fields (KindIdentification).
+	Callsign string `json:"callsign,omitempty"`
+	Category int    `json:"category,omitempty"`
+
+	// Position fields (KindAirbornePosition / KindSurfacePosition).
+	// Surfaces the globally-decoded lat/lon when the per-ICAO
+	// CPR pairing succeeded; HasPosition distinguishes that from
+	// "raw CPR fields preserved but no global decode".
+	Latitude    float64 `json:"latitude,omitempty"`
+	Longitude   float64 `json:"longitude,omitempty"`
+	Altitude    int     `json:"altitude_ft,omitempty"`
+	HasPosition bool    `json:"has_position"`
+	HasAltitude bool    `json:"has_altitude"`
+
+	// Velocity fields (KindAirborneVelocity).
+	GroundSpeedKn   int     `json:"ground_speed_kn,omitempty"`
+	TrackDeg        float64 `json:"track_deg,omitempty"`
+	VerticalRateFPM int     `json:"vertical_rate_fpm,omitempty"`
+
+	// Raw 112-bit (or 56-bit) frame hex. Round-trips into raw_hex
+	// for debugging frames the parser doesn't fully decode.
+	RawHex string `json:"raw_hex"`
+}
+
+// AircraftLog drains KindAircraftReport events until ctx cancels
+// or the bus closes.
+type AircraftLog struct {
+	db        *DB
+	bus       *events.Bus
+	log       *slog.Logger
+	sub       *events.Subscription
+	runDone   chan struct{}
+	closeOnce sync.Once
+}
+
+// NewAircraftLog wires the log to the bus. Subscription happens
+// at construction so events published before Run() begins aren't
+// lost.
+func NewAircraftLog(db *DB, bus *events.Bus, logger *slog.Logger) (*AircraftLog, error) {
+	if db == nil {
+		return nil, errors.New("storage/aircraftlog: DB is required")
+	}
+	if bus == nil {
+		return nil, errors.New("storage/aircraftlog: events.Bus is required")
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	a := &AircraftLog{db: db, bus: bus, log: logger, runDone: make(chan struct{})}
+	a.sub = bus.Subscribe()
+	return a, nil
+}
+
+// Run drains KindAircraftReport events until ctx cancels or the
+// bus closes.
+func (a *AircraftLog) Run(ctx context.Context) error {
+	defer close(a.runDone)
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case ev, ok := <-a.sub.C:
+			if !ok {
+				return nil
+			}
+			if ev.Kind != events.KindAircraftReport {
+				continue
+			}
+			r, ok := ev.Payload.(AircraftReport)
+			if !ok {
+				continue
+			}
+			if err := a.insert(r); err != nil {
+				a.log.Error("aircraftlog: insert failed", "err", err)
+			}
+		}
+	}
+}
+
+func (a *AircraftLog) insert(r AircraftReport) error {
+	at := r.ReceivedAt
+	if at.IsZero() {
+		at = time.Now()
+	}
+	crcOK := 0
+	if r.CRCValid {
+		crcOK = 1
+	}
+	hasPos := 0
+	if r.HasPosition {
+		hasPos = 1
+	}
+	hasAlt := 0
+	if r.HasAltitude {
+		hasAlt = 1
+	}
+	_, err := a.db.SQL().Exec(
+		`INSERT INTO aircraft_log
+		 (received_at, icao, icao_hex, kind, body, crc_valid,
+		  callsign, category, latitude, longitude, altitude_ft,
+		  has_position, has_altitude, ground_speed_kn, track_deg,
+		  vertical_rate_fpm, raw_hex)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		at.UnixNano(), r.ICAO, r.ICAOHex, r.Kind, r.Body, crcOK,
+		r.Callsign, r.Category, r.Latitude, r.Longitude, r.Altitude,
+		hasPos, hasAlt, r.GroundSpeedKn, r.TrackDeg,
+		r.VerticalRateFPM, r.RawHex,
+	)
+	return err
+}
+
+// Recent returns the most recent reports, newest first, capped at
+// limit. limit ≤ 0 picks 200; limit > 5000 caps at 5000. ADS-B is
+// the highest-rate decoder (aircraft transmit ~2 msg/s), so
+// operators commonly want a tighter window — set limit lower if
+// rendering full panels live.
+func (a *AircraftLog) Recent(limit int) ([]AircraftReport, error) {
+	if limit <= 0 {
+		limit = 200
+	}
+	if limit > 5000 {
+		limit = 5000
+	}
+	rows, err := a.db.SQL().Query(
+		`SELECT id, received_at, icao, icao_hex, kind, body, crc_valid,
+		        callsign, category, latitude, longitude, altitude_ft,
+		        has_position, has_altitude, ground_speed_kn,
+		        track_deg, vertical_rate_fpm, raw_hex
+		 FROM aircraft_log ORDER BY received_at DESC LIMIT ?`, limit)
+	if err != nil {
+		return nil, fmt.Errorf("storage/aircraftlog: query: %w", err)
+	}
+	defer rows.Close()
+	var out []AircraftReport
+	for rows.Next() {
+		var (
+			r      AircraftReport
+			ns     int64
+			crcOK  int
+			hasPos int
+			hasAlt int
+		)
+		if err := rows.Scan(&r.ID, &ns, &r.ICAO, &r.ICAOHex,
+			&r.Kind, &r.Body, &crcOK, &r.Callsign, &r.Category,
+			&r.Latitude, &r.Longitude, &r.Altitude,
+			&hasPos, &hasAlt, &r.GroundSpeedKn, &r.TrackDeg,
+			&r.VerticalRateFPM, &r.RawHex); err != nil {
+			return nil, fmt.Errorf("storage/aircraftlog: scan: %w", err)
+		}
+		r.ReceivedAt = time.Unix(0, ns)
+		r.CRCValid = crcOK != 0
+		r.HasPosition = hasPos != 0
+		r.HasAltitude = hasAlt != 0
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// Close releases the bus subscription and waits for Run to drain.
+func (a *AircraftLog) Close() error {
+	a.closeOnce.Do(func() {
+		a.sub.Close()
+		select {
+		case <-a.runDone:
+		case <-time.After(time.Second):
+		}
+	})
+	return nil
+}

--- a/internal/storage/aircraftlog_test.go
+++ b/internal/storage/aircraftlog_test.go
@@ -1,0 +1,173 @@
+package storage
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+)
+
+func openAircraftTestStore(t *testing.T) (*AircraftLog, *events.Bus, *DB) {
+	t.Helper()
+	db, err := Open(":memory:")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	bus := events.NewBus(8)
+	log, err := NewAircraftLog(db, bus, nil)
+	if err != nil {
+		t.Fatalf("NewAircraftLog: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = log.Close()
+		bus.Close()
+		_ = db.Close()
+	})
+	return log, bus, db
+}
+
+func TestAircraftLogInsertsPosition(t *testing.T) {
+	log, bus, _ := openAircraftTestStore(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = log.Run(ctx) }()
+
+	bus.Publish(events.Event{
+		Kind: events.KindAircraftReport,
+		Payload: AircraftReport{
+			ReceivedAt:  time.Unix(1735000000, 0),
+			ICAO:        0x40621D,
+			ICAOHex:     "40621D",
+			Kind:        "airborne-pos",
+			Body:        "AIRBORNE-POS 40621D CPR-even alt=38000ft",
+			CRCValid:    true,
+			Latitude:    52.2572,
+			Longitude:   3.91937,
+			Altitude:    38000,
+			HasPosition: true,
+			HasAltitude: true,
+			RawHex:      "8d40621d58c382d690c8ac2863a7",
+		},
+	})
+
+	var recent []AircraftReport
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		recent, _ = log.Recent(10)
+		if len(recent) > 0 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if len(recent) != 1 {
+		t.Fatalf("Recent = %d, want 1", len(recent))
+	}
+	r := recent[0]
+	if r.ICAO != 0x40621D || r.Kind != "airborne-pos" || !r.CRCValid {
+		t.Errorf("Recent[0] = %+v", r)
+	}
+	if !r.HasPosition || r.Latitude < 52.2 || r.Latitude > 52.3 {
+		t.Errorf("position not round-tripped: %+v", r)
+	}
+	if r.Altitude != 38000 {
+		t.Errorf("altitude = %d, want 38000", r.Altitude)
+	}
+}
+
+func TestAircraftLogInsertsIdentification(t *testing.T) {
+	log, bus, _ := openAircraftTestStore(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = log.Run(ctx) }()
+
+	bus.Publish(events.Event{
+		Kind: events.KindAircraftReport,
+		Payload: AircraftReport{
+			ReceivedAt: time.Unix(1735000000, 0),
+			ICAO:       0x4840D6,
+			ICAOHex:    "4840D6",
+			Kind:       "ident",
+			Body:       "IDENT 4840D6 \"KLM1023\" cat=4",
+			CRCValid:   true,
+			Callsign:   "KLM1023",
+			Category:   4,
+		},
+	})
+
+	var recent []AircraftReport
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		recent, _ = log.Recent(10)
+		if len(recent) > 0 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if len(recent) != 1 {
+		t.Fatalf("Recent = %d, want 1", len(recent))
+	}
+	r := recent[0]
+	if r.Callsign != "KLM1023" {
+		t.Errorf("Callsign = %q, want KLM1023", r.Callsign)
+	}
+	if r.HasPosition {
+		t.Error("HasPosition = true on identification-only frame")
+	}
+}
+
+func TestAircraftLogIgnoresUnrelatedEvents(t *testing.T) {
+	log, bus, _ := openAircraftTestStore(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = log.Run(ctx) }()
+
+	bus.Publish(events.Event{
+		Kind:    events.KindBookmarkCreated,
+		Payload: Bookmark{Name: "x"},
+	})
+	bus.Publish(events.Event{
+		Kind:    events.KindAircraftReport,
+		Payload: "wrong payload type",
+	})
+
+	time.Sleep(50 * time.Millisecond)
+	recent, _ := log.Recent(10)
+	if len(recent) != 0 {
+		t.Errorf("Recent = %d, want 0", len(recent))
+	}
+}
+
+func TestAircraftLogRecentOrderNewestFirst(t *testing.T) {
+	log, bus, _ := openAircraftTestStore(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = log.Run(ctx) }()
+
+	for i := uint32(0); i < 3; i++ {
+		bus.Publish(events.Event{
+			Kind: events.KindAircraftReport,
+			Payload: AircraftReport{
+				ReceivedAt: time.Unix(1735000000+int64(i)*60, 0),
+				ICAO:       0x4840D0 + i,
+				Kind:       "velocity",
+			},
+		})
+	}
+
+	var recent []AircraftReport
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		recent, _ = log.Recent(10)
+		if len(recent) == 3 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if len(recent) != 3 {
+		t.Fatalf("Recent = %d, want 3", len(recent))
+	}
+	if recent[0].ICAO != 0x4840D2 || recent[2].ICAO != 0x4840D0 {
+		t.Errorf("ordering wrong")
+	}
+}

--- a/internal/storage/sqlite.go
+++ b/internal/storage/sqlite.go
@@ -220,6 +220,36 @@ CREATE TABLE IF NOT EXISTS dsc_log (
 
 CREATE INDEX IF NOT EXISTS idx_dsc_log_time      ON dsc_log(received_at);
 CREATE INDEX IF NOT EXISTS idx_dsc_log_self_mmsi ON dsc_log(self_mmsi, received_at);
+
+-- ADS-B / Mode-S frames persisted from the decoder pipeline. One
+-- row per decoded extended-squitter message: ICAO 24-bit address +
+-- kind (identification / airborne-pos / velocity / ...) + kind-
+-- specific fields (callsign + category for identification; lat/lon
+-- + altitude for position; ground speed + track + vertical rate
+-- for velocity).
+CREATE TABLE IF NOT EXISTS aircraft_log (
+    id                INTEGER PRIMARY KEY AUTOINCREMENT,
+    received_at       INTEGER NOT NULL,             -- unix nanoseconds
+    icao              INTEGER NOT NULL DEFAULT 0,   -- 24-bit ICAO aircraft address
+    icao_hex          TEXT    NOT NULL DEFAULT '',  -- "4840D6" form for display
+    kind              TEXT    NOT NULL DEFAULT '',  -- "ident" | "airborne-pos" | "velocity" | ...
+    body              TEXT    NOT NULL DEFAULT '',  -- kind-specific summary
+    crc_valid         INTEGER NOT NULL DEFAULT 0,
+    callsign          TEXT    NOT NULL DEFAULT '',
+    category          INTEGER NOT NULL DEFAULT 0,
+    latitude          REAL    NOT NULL DEFAULT 0,
+    longitude         REAL    NOT NULL DEFAULT 0,
+    altitude_ft       INTEGER NOT NULL DEFAULT 0,
+    has_position      INTEGER NOT NULL DEFAULT 0,
+    has_altitude      INTEGER NOT NULL DEFAULT 0,
+    ground_speed_kn   INTEGER NOT NULL DEFAULT 0,
+    track_deg         REAL    NOT NULL DEFAULT 0,
+    vertical_rate_fpm INTEGER NOT NULL DEFAULT 0,
+    raw_hex           TEXT    NOT NULL DEFAULT ''
+);
+
+CREATE INDEX IF NOT EXISTS idx_aircraft_log_time ON aircraft_log(received_at);
+CREATE INDEX IF NOT EXISTS idx_aircraft_log_icao ON aircraft_log(icao, received_at);
 `
 
 func (d *DB) migrate() error {

--- a/web/src/App.panels.test.tsx
+++ b/web/src/App.panels.test.tsx
@@ -55,6 +55,10 @@ vi.mock("./api/dsc", () => ({
   fetchDSCMessages: vi.fn().mockResolvedValue([]),
 }));
 
+vi.mock("./api/adsb", () => ({
+  fetchAircraftReports: vi.fn().mockResolvedValue([]),
+}));
+
 vi.mock("./api/bookmarks", () => ({
   bookmarks: {
     list: vi.fn().mockResolvedValue([]),

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -18,6 +18,7 @@ import { Import } from "./panels/Import";
 import { APRS } from "./panels/APRS";
 import { AIS } from "./panels/AIS";
 import { DSC } from "./panels/DSC";
+import { ADSB } from "./panels/ADSB";
 import { Metrics } from "./panels/Metrics";
 import { Pagers } from "./panels/Pagers";
 import { RadioIDs } from "./panels/RadioIDs";
@@ -47,6 +48,7 @@ const EXTRA_TABS: Tab[] = [
   { to: "/aprs", label: "APRS", icon: "⛯" },
   { to: "/ais", label: "AIS", icon: "⚓" },
   { to: "/dsc", label: "DSC", icon: "📡" },
+  { to: "/adsb", label: "ADS-B", icon: "✈" },
   { to: "/spectrum", label: "Spectrum", icon: "≈" },
   { to: "/constellation", label: "Constellation", icon: "✦" },
   { to: "/bookmarks", label: "Bookmarks", icon: "★" },
@@ -161,6 +163,7 @@ export function App() {
           <Route path="/aprs" element={<APRS />} />
           <Route path="/ais" element={<AIS />} />
           <Route path="/dsc" element={<DSC />} />
+          <Route path="/adsb" element={<ADSB />} />
           <Route path="/metrics" element={<Metrics />} />
           <Route path="/devices" element={<Devices />} />
           <Route path="/settings" element={<Settings />} />

--- a/web/src/api/adsb.ts
+++ b/web/src/api/adsb.ts
@@ -1,0 +1,46 @@
+// ADS-B / aircraft client. Mirrors GET /api/v1/adsb/aircraft.
+
+import { type ClientConfig, joinURL } from "./client";
+
+export interface AircraftReport {
+  id: number;
+  received_at: string;
+  icao: number;
+  icao_hex: string;
+  kind: string;
+  body?: string;
+  crc_valid: boolean;
+
+  // Identification fields (kind = "ident").
+  callsign?: string;
+  category?: number;
+
+  // Position fields (kind = "airborne-pos" / "surface-pos").
+  latitude?: number;
+  longitude?: number;
+  altitude_ft?: number;
+  has_position: boolean;
+  has_altitude: boolean;
+
+  // Velocity fields (kind = "velocity").
+  ground_speed_kn?: number;
+  track_deg?: number;
+  vertical_rate_fpm?: number;
+
+  raw_hex?: string;
+}
+
+export async function fetchAircraftReports(
+  cfg: ClientConfig,
+  limit = 200,
+): Promise<AircraftReport[]> {
+  const url = joinURL(
+    cfg.baseURL,
+    `/api/v1/adsb/aircraft?limit=${encodeURIComponent(String(limit))}`,
+  );
+  const headers: Record<string, string> = { Accept: "application/json" };
+  if (cfg.token) headers["Authorization"] = `Bearer ${cfg.token}`;
+  const res = await fetch(url, { headers });
+  if (!res.ok) throw new Error(`adsb/aircraft ${res.status}`);
+  return (await res.json()) as AircraftReport[];
+}

--- a/web/src/panels/ADSB.test.tsx
+++ b/web/src/panels/ADSB.test.tsx
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+
+vi.mock("../api/adsb", () => ({
+  fetchAircraftReports: vi.fn(),
+}));
+
+import { fetchAircraftReports } from "../api/adsb";
+import { useShared } from "../store/shared";
+import { ADSB } from "./ADSB";
+
+function resetStore() {
+  useShared.setState({
+    serverURL: "http://localhost:8080",
+    token: null,
+    connected: true,
+    wsStatus: "idle",
+    mutations: null,
+    lastError: null,
+    events: [],
+    activeCalls: [],
+    devices: [],
+    systems: [],
+    talkgroups: [],
+    health: null,
+    audio: null,
+    scanner: null,
+  });
+}
+
+describe("ADS-B panel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetStore();
+  });
+
+  it("renders an empty-state when no messages are present", async () => {
+    vi.mocked(fetchAircraftReports).mockResolvedValue([]);
+    render(<ADSB />);
+    await waitFor(() => {
+      expect(screen.getByText(/No ADS-B messages yet/)).toBeInTheDocument();
+    });
+  });
+
+  it("renders position rows with ICAO + lat/lon + altitude", async () => {
+    vi.mocked(fetchAircraftReports).mockResolvedValue([
+      {
+        id: 1,
+        received_at: "2026-05-26T12:34:56Z",
+        icao: 0x40621d,
+        icao_hex: "40621D",
+        kind: "airborne-pos",
+        body: "AIRBORNE-POS 40621D",
+        crc_valid: true,
+        latitude: 52.2572,
+        longitude: 3.91937,
+        altitude_ft: 38000,
+        has_position: true,
+        has_altitude: true,
+      },
+    ]);
+    render(<ADSB />);
+    await waitFor(() => {
+      expect(screen.getByText("40621D")).toBeInTheDocument();
+      expect(screen.getByText(/52\.2572, 3\.9194/)).toBeInTheDocument();
+      expect(screen.getByText("38,000")).toBeInTheDocument();
+    });
+  });
+
+  it("renders identification rows with callsign", async () => {
+    vi.mocked(fetchAircraftReports).mockResolvedValue([
+      {
+        id: 2,
+        received_at: "2026-05-26T12:34:56Z",
+        icao: 0x4840d6,
+        icao_hex: "4840D6",
+        kind: "ident",
+        callsign: "KLM1023",
+        category: 4,
+        crc_valid: true,
+        has_position: false,
+        has_altitude: false,
+      },
+    ]);
+    render(<ADSB />);
+    await waitFor(() => {
+      expect(screen.getByText("4840D6")).toBeInTheDocument();
+      expect(screen.getByText("KLM1023")).toBeInTheDocument();
+    });
+  });
+
+  it("renders velocity rows with speed + track + VR", async () => {
+    vi.mocked(fetchAircraftReports).mockResolvedValue([
+      {
+        id: 3,
+        received_at: "2026-05-26T12:34:56Z",
+        icao: 0x485020,
+        icao_hex: "485020",
+        kind: "velocity",
+        ground_speed_kn: 159,
+        track_deg: 182.88,
+        vertical_rate_fpm: -832,
+        crc_valid: true,
+        has_position: false,
+        has_altitude: false,
+      },
+    ]);
+    render(<ADSB />);
+    await waitFor(() => {
+      expect(screen.getByText("485020")).toBeInTheDocument();
+      expect(screen.getByText(/159kn \/ 183°/)).toBeInTheDocument();
+      expect(screen.getByText("-832")).toBeInTheDocument();
+    });
+  });
+
+  it("surfaces fetch errors", async () => {
+    vi.mocked(fetchAircraftReports).mockRejectedValue(new Error("daemon down"));
+    render(<ADSB />);
+    await waitFor(() => {
+      expect(screen.getByText(/daemon down/)).toBeInTheDocument();
+    });
+  });
+});

--- a/web/src/panels/ADSB.tsx
+++ b/web/src/panels/ADSB.tsx
@@ -1,0 +1,161 @@
+import { useEffect, useState } from "react";
+import { fetchAircraftReports, type AircraftReport } from "../api/adsb";
+import { selectClientConfig, useShared } from "../store/shared";
+
+// ADS-B panel — list of recent decoded Mode-S frames. Each row
+// shows the ICAO 24-bit address (hex form, the standard "tail
+// identifier" aviation people use), the kind (ident / airborne-
+// pos / velocity / ...), a one-line body summary, and kind-
+// specific data: callsign for identification rows, lat/lon +
+// altitude for position rows, ground speed + track + vertical
+// rate for velocity rows.
+//
+// Polls /api/v1/adsb/aircraft every 5 s. ADS-B is the highest-
+// rate decoder (each aircraft sends 2-3 msg/s); the default
+// limit shows the most recent 200, which is roughly 1 min of
+// traffic on a busy channel.
+
+const POLL_INTERVAL_MS = 5_000;
+
+export function ADSB() {
+  const cfg = useShared(selectClientConfig);
+  const [reports, setReports] = useState<AircraftReport[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancel = false;
+    const refresh = async () => {
+      try {
+        const list = await fetchAircraftReports(cfg, 200);
+        if (cancel) return;
+        setReports(list);
+        setError(null);
+      } catch (e) {
+        if (cancel) return;
+        setError(e instanceof Error ? e.message : String(e));
+      }
+    };
+    refresh();
+    const t = window.setInterval(refresh, POLL_INTERVAL_MS);
+    return () => {
+      cancel = true;
+      window.clearInterval(t);
+    };
+  }, [cfg]);
+
+  return (
+    <div className="space-y-3">
+      <header className="flex items-center justify-between">
+        <h2 className="text-xl font-semibold">ADS-B</h2>
+        <span className="text-xs text-muted">
+          {reports.length} message{reports.length === 1 ? "" : "s"}
+        </span>
+      </header>
+
+      {error && (
+        <div className="rounded border border-red-700/40 bg-red-900/20 text-red-200 text-xs px-3 py-2">
+          {error}
+        </div>
+      )}
+
+      <div className="rounded border border-border overflow-hidden">
+        <table className="w-full text-xs">
+          <thead className="bg-surface text-muted">
+            <tr>
+              <th className="text-left px-3 py-1 font-normal w-24">Received</th>
+              <th className="text-left px-3 py-1 font-normal w-24">ICAO</th>
+              <th className="text-left px-3 py-1 font-normal w-28">Kind</th>
+              <th className="text-left px-3 py-1 font-normal w-24">Callsign</th>
+              <th className="text-right px-3 py-1 font-normal w-32">Lat / Lon</th>
+              <th className="text-right px-3 py-1 font-normal w-24">Alt (ft)</th>
+              <th className="text-right px-3 py-1 font-normal w-28">GS / Track</th>
+              <th className="text-right px-3 py-1 font-normal w-24">VR (fpm)</th>
+            </tr>
+          </thead>
+          <tbody>
+            {reports.length === 0 ? (
+              <tr>
+                <td colSpan={8} className="px-3 py-4 text-center text-muted">
+                  No ADS-B messages yet. Add an{" "}
+                  <code className="text-accent">adsb.channels</code>{" "}
+                  entry to your config (1090.000 MHz centre, 1 Msps
+                  required — dedicate one RTL-SDR with a 1090 MHz
+                  antenna to it) and decoded aircraft will land here
+                  as they arrive. DSP wiring (1 Msps PPM
+                  demodulation + Mode-S preamble detection + 56/112-
+                  bit frame extraction) is the planned follow-up;
+                  the protocol + storage + REST scaffolding is live
+                  now.
+                </td>
+              </tr>
+            ) : (
+              reports.map((r) => (
+                <tr
+                  key={r.id}
+                  className={
+                    "border-t border-border/60 " +
+                    (r.crc_valid ? "" : "bg-yellow-900/15")
+                  }
+                >
+                  <td className="px-3 py-1 font-mono text-muted">
+                    {formatTime(r.received_at)}
+                  </td>
+                  <td className="px-3 py-1 font-mono text-accent">
+                    {r.icao_hex}
+                  </td>
+                  <td className="px-3 py-1 uppercase">{r.kind}</td>
+                  <td className="px-3 py-1 font-mono">
+                    {r.callsign || <span className="text-muted">—</span>}
+                  </td>
+                  <td className="px-3 py-1 text-right font-mono">
+                    {r.has_position && r.latitude !== undefined &&
+                    r.longitude !== undefined ? (
+                      <span>
+                        {r.latitude.toFixed(4)}, {r.longitude.toFixed(4)}
+                      </span>
+                    ) : (
+                      <span className="text-muted">—</span>
+                    )}
+                  </td>
+                  <td className="px-3 py-1 text-right font-mono">
+                    {r.has_altitude && r.altitude_ft !== undefined ? (
+                      r.altitude_ft.toLocaleString()
+                    ) : (
+                      <span className="text-muted">—</span>
+                    )}
+                  </td>
+                  <td className="px-3 py-1 text-right font-mono">
+                    {r.ground_speed_kn ? (
+                      <span>
+                        {r.ground_speed_kn}kn / {(r.track_deg ?? 0).toFixed(0)}°
+                      </span>
+                    ) : (
+                      <span className="text-muted">—</span>
+                    )}
+                  </td>
+                  <td className="px-3 py-1 text-right font-mono">
+                    {r.vertical_rate_fpm ? (
+                      r.vertical_rate_fpm > 0
+                        ? `+${r.vertical_rate_fpm}`
+                        : String(r.vertical_rate_fpm)
+                    ) : (
+                      <span className="text-muted">—</span>
+                    )}
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+function formatTime(ts: string): string {
+  try {
+    return new Date(ts).toISOString().slice(11, 19);
+  } catch {
+    return ts.slice(11, 19);
+  }
+}


### PR DESCRIPTION
## Summary

First slice of Phase 5 ADS-B. Every commercial passenger flight,
most general-aviation, and all military aircraft over US / EU
airspace continuously broadcasts on 1090 MHz — the same data
that powers FlightRadar24 / FlightAware / adsb.lol / OpenSky.
GopherTrunk now has the protocol layer to decode it on the
operator's own SDR. Same scaffolding-first pattern AIS + DSC
took (#427, #433): protocol + bus + storage + REST + panel this
slice, DSP frontend follows.

### `internal/radio/adsb` — protocol parser

- **CRC-24 codec** (polynomial 0xFFF409). Verifies DF 11 / 17 /
  18 frames directly; for the ICAO-overlay DFs (0/4/5/20/21)
  the trailing 24 bits hold `CRC XOR ICAO`, so the parser
  recovers the address by XORing the computed CRC.
- **DF dispatch** — recognises every documented downlink format;
  fully decodes DF 17 / 18 extended squitter (the operator-
  visible majority).
- **TC dispatch** for extended-squitter ME payloads:
  - **TC 1-4**: Identification — 8-char callsign decoded from
    the 6-bit ICAO alphabet, trailing pad stripped.
  - **TC 5-8**: Surface position — CPR-encoded.
  - **TC 9-18 / 20-22**: Airborne position — CPR-encoded
    lat/lon + 12-bit Q-bit altitude (Q=1 = 25-ft resolution).
  - **TC 19**: Airborne velocity — subtypes 1/2 = ground speed
    + track, subtypes 3/4 = air speed + heading; common
    vertical-rate field across all subtypes.
- **CPR decode** — globally-unambiguous lat/lon recovery from
  an even+odd CPR pair (DO-260B §2.2.3.2.3.7). NL lookup table
  matches the dump1090 reference implementation. Locally-
  referenced decode (single message against a known receiver
  location) is the obvious follow-up.

Validated against the canonical dump1090 / mode-s.org reference
samples:
- Identification `8D4840D6202CC371C32CE0576098` → ICAO 4840D6,
  callsign **"KLM1023"**.
- CPR pair `8D40621D58C382D690C8AC2863A7` (even) +
  `8D40621D58C386435CC412692AD6` (odd) → ICAO 40621D, lat
  **52.2572 N**, lon **3.91937 E**, alt **38000 ft**.
- Velocity `8D485020994409940838175B284F` → ICAO 485020,
  **GS 159 kn**, track **≈ 183°**, VR **-832 fpm**.

### Storage

- `aircraft_log` SQLite table — one row per decoded frame,
  indexes on `(received_at)` and `(icao, received_at)`.
  Append-only migration alongside `dsc_log`, `vessel_log`,
  `aprs_log`, `pager_log`.
- `storage.AircraftLog` bus subscriber — drains
  `KindAircraftReport` events; subscription at construction so
  events published before `Run()` aren't lost.

### Bus + REST

- `events.KindAircraftReport` (= `"adsb.aircraft"`) — published
  once per decoded frame.
- `GET /api/v1/adsb/aircraft?limit=N` (default 200, max 5000) —
  503 when storage isn't wired.

### Web panel

- `/adsb` — columns Received / ICAO / Kind / Callsign /
  Lat-Lon / Alt / GS-Track / VR. Identification, position, and
  velocity rows each light up their own columns. CRC-failed
  frames highlight yellow.

### Daemon

- `aircraftLog` wired alongside `dscLog` / `vesselLog` /
  `aprsLog`: constructed at startup, spawned in the run loop,
  drained on `Close`. New `adsbProvider` adapter feeds
  `api.ServerOptions.ADSB`.

## Test plan

- [x] `go test ./internal/radio/adsb/` — 13 tests pass
  (identification decode, **CPR pair global decode against the
  dump1090 reference vectors**, velocity decode, all-call DF 11,
  short-frame safety, CRC self-consistency + corruption
  detection, NL table boundary values, altitude Q=1
  round-trip).
- [x] `go test ./internal/storage/` — 4 aircraftlog tests pass
  (insert position / ident / filter / order) plus all
  pre-existing.
- [x] `go test ./internal/api/` — 3 ADS-B REST tests pass
  (503 / list / limit) plus all pre-existing.
- [x] `npm test -- --run` — 110/110 web tests pass (5 new ADS-B
  panel tests: empty / position / ident / velocity / error).
- [x] `go vet ./...` clean (caught an early `uint8 << 8` overflow
  in the velocity parser — now `int(me[1]&0x03)<<8 | int(me[2])`);
  `gofmt -l` clean.

## Still pending under Phase 5 ADS-B (separate PRs)

- **DSP receiver.** 1 Msps PPM demodulation at 1090 MHz with
  Mode-S preamble correlation and 56 / 112-bit frame
  extraction. Plan calls for extending
  `internal/dsp/tuner/channelizerbank.go` to support
  higher-rate taps, then a Mode-S demod walking the IQ stream
  + correlating against the 8 µs preamble. Heaviest decoder in
  Phase 5 — requires a dedicated SDR tuned to 1090 MHz.
- **Per-ICAO CPR pair-tracking.** A state machine buffering
  the most-recent even/odd half per ICAO and calling
  `CPRDecodeGlobal` when both arrive within ~10 s, so position
  rows show globally-decoded lat/lon immediately. Same buffer
  for the locally-referenced decode.
- **Aircraft tracker view.** An `aircraft_current` summary
  (latest known position + callsign + velocity per ICAO)
  joining the recent messages — a "currently visible aircraft"
  panel distinct from the raw message log.
- **Live map.** ADS-B positions naturally light up the shared
  Leaflet / MapLibre overlay planned for APRS + AIS + DSC
  position-bearing types.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YUgvat8WpF5YaSuEAqWMr2)_