### PR TITLE
web: live map across APRS / AIS / DSC / ADS-B panels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,33 @@ for tagged releases.
 
 ### Added
 
+- **Live map across APRS / AIS / DSC / ADS-B.** Position-bearing
+  decoded rows now plot on a shared Leaflet map at the top of
+  each protocol panel. APRS station fixes (Mic-E + uncompressed
+  positions) render as blue markers; AIS Class A/B vessel
+  positions as cyan; DSC distress alerts that included a
+  position as red (oversized for high visibility); ADS-B
+  aircraft (once per-ICAO CPR pairing lands) as purple. Marker
+  tooltips render the per-protocol short label (callsign /
+  MMSI / ICAO+altitude / nature-of-distress); the camera
+  auto-fits to the active point set on every poll-refresh.
+  New `web/src/components/PositionMap.tsx` is a single
+  `<PositionMap points={...}>` component the four panels share —
+  one Leaflet `L.map` per panel, points → `L.circleMarker`
+  diff-update keyed by stable row IDs so a row-set update
+  patches markers in place instead of tearing them down. Adds
+  `leaflet@^1.9.4` + `@types/leaflet` as web deps; tiles served
+  from the standard OSM tile servers (compliant with the OSM
+  Tile Usage Policy for the single-user self-hosted operator
+  console; larger fleets configuring their own tile cache is
+  the obvious follow-up). XSS-safe tooltip rendering (HTML
+  escapes on all user-derived label / detail fields).
+  Tests: 5 new (`PositionMap.test.tsx` — container renders,
+  per-kind marker colours, distress radius / colour, HTML
+  escape on tooltips, camera auto-fit). All 115 web tests
+  passing (20 test files).
+
+
 - **ADS-B aviation — protocol layer + bus / storage / REST / panel
   scaffolding.** First slice of Phase 5 ADS-B: every commercial
   passenger flight, most general-aviation, and all military

--- a/docs/adsb.md
+++ b/docs/adsb.md
@@ -144,9 +144,13 @@ Spec references:
   joining identification + position + velocity rows over the
   last few minutes. Powers a "currently visible aircraft"
   panel distinct from the raw message log.
-- **Live map.** ADS-B positions naturally light up the same
-  Leaflet / MapLibre overlay APRS + AIS positions are planned
-  to share.
+## Live map
+
+Aircraft positions (once the per-ICAO CPR pairing lands) render
+as purple markers on the shared Leaflet map at the top of
+`/adsb` — callsign + altitude on hover, camera auto-fits to the
+current rowset. The same `<PositionMap>` component renders on
+`/aprs`, `/ais`, and `/dsc`.
 
 ## References
 

--- a/docs/ais.md
+++ b/docs/ais.md
@@ -177,10 +177,14 @@ skipped — same non-essential treatment as `paging.pocsag` and
   The current parser handles the single-slot variants; the
   multi-slot path needs a per-MMSI buffer plus the channel-A /
   channel-B re-orderer.
-- **Live map.** AIS-position messages all carry lat/lon — a
-  Leaflet / MapLibre overlay shared with `/aprs` showing the
-  most recent vessel fixes is the obvious next step once the
-  panel has real traffic.
+## Live map
+
+Position-bearing rows (Class A / B position reports, base
+station, SAR aircraft) light up the shared Leaflet map at the
+top of `/ais` — cyan markers plotted on the OpenStreetMap tile
+layer with vessel name (or MMSI) on hover, camera auto-fits
+to the current rowset. The same `<PositionMap>` component
+renders on `/aprs`, `/dsc`, and `/adsb`.
 
 ## References
 

--- a/docs/aprs.md
+++ b/docs/aprs.md
@@ -171,10 +171,14 @@ skipped — same non-essential treatment as `paging.pocsag`.
   the standard `latitude` / `longitude` columns. Surfacing the
   rich fields needs an `aprs_log` schema bump + REST DTO + a
   new column on `/aprs`.
-- **Live map.** Position-bearing types have lat/lon — a
-  Leaflet / MapLibre overlay on top of `/aprs` showing the most
-  recent station fixes is an obvious next step once the panel
-  has real traffic.
+## Live map
+
+Position-bearing rows (uncompressed positions, Mic-E) light up
+the shared Leaflet map at the top of `/aprs` — blue markers
+plotted on the OpenStreetMap tile layer with the station
+callsign on hover, camera auto-fits to the current rowset. The
+same `<PositionMap>` component renders on `/ais`, `/dsc` (for
+distress alerts that included a position), and `/adsb`.
 
 ## References
 

--- a/docs/dsc.md
+++ b/docs/dsc.md
@@ -119,9 +119,15 @@ Spec references:
   multi-recipient calls). The single-frame parser covers the
   operational majority; the multi-frame path needs a per-MMSI
   buffer plus a sequence reassembler.
-- **Live map.** Distress alerts that include a position can
-  light up the same Leaflet / MapLibre overlay APRS + AIS
-  positions are planned to share.
+## Live map
+
+Distress alerts that included a position render as red,
+oversized markers on the shared Leaflet map at the top of
+`/dsc` — the larger radius + distress-red colour pull the
+operator's eye immediately. Nature of distress ("fire /
+explosion", "sinking", etc.) appears in the marker tooltip.
+The same `<PositionMap>` component renders on `/aprs`, `/ais`,
+and `/adsb`.
 
 ## References
 

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "chart.js": "^4.4.5",
         "d3-scale": "^4.0.2",
+        "leaflet": "^1.9.4",
         "react": "^18.3.1",
         "react-chartjs-2": "^5.2.0",
         "react-dom": "^18.3.1",
@@ -22,6 +23,7 @@
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
         "@types/d3-scale": "^4.0.8",
+        "@types/leaflet": "^1.9.21",
         "@types/react": "^18.3.11",
         "@types/react-dom": "^18.3.0",
         "@vitejs/plugin-react": "^4.3.2",
@@ -3474,6 +3476,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/leaflet": {
+      "version": "1.9.21",
+      "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.9.21.tgz",
+      "integrity": "sha512-TbAd9DaPGSnzp6QvtYngntMZgcRk+igFELwR2N99XZn7RXUdKgsXMR+28bUO0rPsWp8MIu/f47luLIQuSLYv/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
@@ -6068,6 +6087,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/leaflet": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
+      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/leven": {
       "version": "3.1.0",

--- a/web/package.json
+++ b/web/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "chart.js": "^4.4.5",
     "d3-scale": "^4.0.2",
+    "leaflet": "^1.9.4",
     "react": "^18.3.1",
     "react-chartjs-2": "^5.2.0",
     "react-dom": "^18.3.1",
@@ -27,6 +28,7 @@
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
     "@types/d3-scale": "^4.0.8",
+    "@types/leaflet": "^1.9.21",
     "@types/react": "^18.3.11",
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^4.3.2",

--- a/web/src/components/PositionMap.test.tsx
+++ b/web/src/components/PositionMap.test.tsx
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+// Leaflet uses DOM APIs jsdom doesn't fully implement (canvas
+// rendering, getBoundingClientRect, etc.). Stub it with a minimal
+// mock that records the operations PositionMap performs so the
+// test asserts behaviour without standing up a real map.
+const mapInstance = {
+  remove: vi.fn(),
+  fitBounds: vi.fn(),
+};
+
+interface MarkerStub {
+  latlng: [number, number];
+  style: { fillColor?: string };
+  tooltipHTML?: string;
+  setLatLng: ReturnType<typeof vi.fn>;
+  setStyle: ReturnType<typeof vi.fn>;
+  bindTooltip: ReturnType<typeof vi.fn>;
+  addTo: ReturnType<typeof vi.fn>;
+  remove: ReturnType<typeof vi.fn>;
+}
+
+const createdMarkers: MarkerStub[] = [];
+
+vi.mock("leaflet", () => {
+  const L = {
+    map: vi.fn(() => mapInstance),
+    tileLayer: vi.fn(() => ({
+      addTo: vi.fn(() => ({})),
+    })),
+    circleMarker: vi.fn((latlng: [number, number], opts: { fillColor: string }) => {
+      const m: MarkerStub = {
+        latlng,
+        style: { fillColor: opts.fillColor },
+        setLatLng: vi.fn(function (this: MarkerStub, ll: [number, number]) {
+          this.latlng = ll;
+          return this;
+        }),
+        setStyle: vi.fn(function (this: MarkerStub, s: { fillColor?: string }) {
+          if (s.fillColor) this.style.fillColor = s.fillColor;
+          return this;
+        }),
+        bindTooltip: vi.fn(function (this: MarkerStub, html: string) {
+          this.tooltipHTML = html;
+          return this;
+        }),
+        addTo: vi.fn(function (this: MarkerStub) {
+          return this;
+        }),
+        remove: vi.fn(),
+      };
+      createdMarkers.push(m);
+      return m;
+    }),
+    latLngBounds: vi.fn((coords: [number, number][]) => ({ coords })),
+  };
+  return { default: L };
+});
+
+// Leaflet ships a CSS file with the package; the dynamic-import
+// side-effect would 404 in jsdom. Stub it.
+vi.mock("leaflet/dist/leaflet.css", () => ({}));
+
+import { PositionMap, type MapPoint } from "./PositionMap";
+
+describe("PositionMap", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    createdMarkers.length = 0;
+  });
+
+  it("renders a map container with a stable test ID", () => {
+    render(<PositionMap points={[]} />);
+    expect(screen.getByTestId("position-map")).toBeInTheDocument();
+  });
+
+  it("creates one CircleMarker per point with the kind's color", () => {
+    const points: MapPoint[] = [
+      {
+        id: "aprs-1",
+        latitude: 49.0,
+        longitude: -72.0,
+        kind: "aprs",
+        label: "W1AW-9",
+      },
+      {
+        id: "adsb-1",
+        latitude: 52.25,
+        longitude: 3.91,
+        kind: "adsb",
+        label: "KLM1023",
+        detail: "38,000 ft",
+      },
+    ];
+    render(<PositionMap points={points} />);
+    expect(createdMarkers).toHaveLength(2);
+    // APRS = blue, ADS-B = purple per the KIND_COLOR table.
+    expect(createdMarkers[0].style.fillColor).toBe("#3b82f6");
+    expect(createdMarkers[1].style.fillColor).toBe("#a855f7");
+  });
+
+  it("escapes HTML in tooltip labels to prevent XSS", () => {
+    const points: MapPoint[] = [
+      {
+        id: "evil",
+        latitude: 0,
+        longitude: 0,
+        kind: "default",
+        label: "<script>alert('x')</script>",
+      },
+    ];
+    render(<PositionMap points={points} />);
+    expect(createdMarkers).toHaveLength(1);
+    expect(createdMarkers[0].tooltipHTML).toContain("&lt;script&gt;");
+    expect(createdMarkers[0].tooltipHTML).not.toContain("<script>");
+  });
+
+  it("highlights distress markers with the red distress color + larger radius", () => {
+    const points: MapPoint[] = [
+      {
+        id: "dsc-1",
+        latitude: 37.8,
+        longitude: -122.4,
+        kind: "dsc-distress",
+        label: "MMSI 366053209",
+        detail: "fire / explosion",
+      },
+    ];
+    render(<PositionMap points={points} />);
+    expect(createdMarkers[0].style.fillColor).toBe("#ef4444");
+  });
+
+  it("auto-fits the camera when points are present", () => {
+    const points: MapPoint[] = [
+      { id: "a", latitude: 49.0, longitude: -72.0, kind: "aprs", label: "" },
+      { id: "b", latitude: 50.0, longitude: -70.0, kind: "aprs", label: "" },
+    ];
+    render(<PositionMap points={points} />);
+    expect(mapInstance.fitBounds).toHaveBeenCalled();
+  });
+});

--- a/web/src/components/PositionMap.tsx
+++ b/web/src/components/PositionMap.tsx
@@ -1,0 +1,190 @@
+import { useEffect, useRef } from "react";
+import L from "leaflet";
+import "leaflet/dist/leaflet.css";
+
+// PositionMap — shared Leaflet-based map for the position-bearing
+// panels (APRS station fixes, AIS vessel tracks, ADS-B aircraft,
+// DSC distress alerts). One <PositionMap points=… /> per panel;
+// the points array drives marker placement, the camera auto-fits
+// to the data on every re-render.
+//
+// Tile source: OpenStreetMap standard via the public tile server
+// at a.tile.openstreetmap.org. Per the OSM tile usage policy this
+// is fine for a single self-hosted operator console (no commercial
+// embedding, no proxying), but power users running large fleets
+// of GopherTrunk daemons should configure their own tile cache
+// (MapTiler / Mapbox / a local tileserver-gl) — this is a follow-
+// up once the tile config surface exists.
+
+export interface MapPoint {
+  // Stable per-row identity. Used as React key in the marker
+  // dictionary so re-renders patch markers in place rather than
+  // tearing them down + re-creating them every poll.
+  id: string;
+
+  latitude: number;
+  longitude: number;
+
+  // Color category — one of the spec colours below. Maps to a
+  // CircleMarker fillColor + outline.
+  kind: "aprs" | "ais" | "adsb" | "dsc-distress" | "default";
+
+  // Tooltip body. Rendered as bold first line + optional
+  // additional details lines.
+  label: string;
+  detail?: string;
+}
+
+interface PositionMapProps {
+  points: MapPoint[];
+  // Map height in CSS pixels. Defaults to 360 — enough to be
+  // readable at a quick glance, short enough to leave the table
+  // beneath visible above the fold.
+  heightPx?: number;
+  // Fixed center to fall back to when points is empty. Default
+  // (37.5, -122.0) → SF Bay, a reasonable land-water mix.
+  fallbackCenter?: [number, number];
+  fallbackZoom?: number;
+}
+
+const KIND_COLOR: Record<MapPoint["kind"], string> = {
+  aprs: "#3b82f6",          // blue — APRS station / Mic-E tracker
+  ais: "#06b6d4",           // cyan — marine vessel
+  adsb: "#a855f7",          // purple — aircraft
+  "dsc-distress": "#ef4444",// red — distress alert
+  default: "#6b7280",       // grey — fallback
+};
+
+const KIND_RADIUS: Record<MapPoint["kind"], number> = {
+  aprs: 5,
+  ais: 5,
+  adsb: 6,
+  "dsc-distress": 8, // emphasise distress
+  default: 4,
+};
+
+export function PositionMap({
+  points,
+  heightPx = 360,
+  fallbackCenter = [37.5, -122.0],
+  fallbackZoom = 8,
+}: PositionMapProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const mapRef = useRef<L.Map | null>(null);
+  const markersRef = useRef<Map<string, L.CircleMarker>>(new Map());
+
+  // Lazy-init the Leaflet map on first mount; tear down on
+  // unmount. The OSM tile layer + attribution are bound here.
+  useEffect(() => {
+    if (!containerRef.current) return;
+    if (mapRef.current) return;
+
+    const map = L.map(containerRef.current, {
+      center: fallbackCenter,
+      zoom: fallbackZoom,
+      zoomControl: true,
+      attributionControl: true,
+      // OSM tile servers are throttled per-IP; the daemon is a
+      // single-user tool so this is fine, but prevent the user
+      // from accidentally pulling thousands of tiles on a quick
+      // pan by clamping max zoom.
+      maxZoom: 18,
+      minZoom: 2,
+    });
+
+    L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
+      attribution: "© OpenStreetMap contributors",
+      maxZoom: 18,
+    }).addTo(map);
+
+    mapRef.current = map;
+    return () => {
+      map.remove();
+      mapRef.current = null;
+      markersRef.current.clear();
+    };
+    // fallbackCenter and fallbackZoom are constants on first
+    // mount; intentionally not re-creating the map on every
+    // re-render — the points-effect below handles update-only
+    // changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Sync markers + auto-fit camera on every points update.
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map) return;
+    const markers = markersRef.current;
+    const seen = new Set<string>();
+
+    for (const p of points) {
+      seen.add(p.id);
+      const existing = markers.get(p.id);
+      const latLng: L.LatLngExpression = [p.latitude, p.longitude];
+      if (existing) {
+        existing.setLatLng(latLng);
+        existing.setStyle({ fillColor: KIND_COLOR[p.kind] });
+        existing.bindTooltip(tooltipHTML(p), { direction: "top" });
+      } else {
+        const m = L.circleMarker(latLng, {
+          radius: KIND_RADIUS[p.kind],
+          fillColor: KIND_COLOR[p.kind],
+          color: "#ffffff",
+          weight: 1,
+          opacity: 1,
+          fillOpacity: 0.85,
+        });
+        m.bindTooltip(tooltipHTML(p), { direction: "top" });
+        m.addTo(map);
+        markers.set(p.id, m);
+      }
+    }
+
+    // Remove markers no longer present.
+    for (const [id, m] of markers.entries()) {
+      if (!seen.has(id)) {
+        m.remove();
+        markers.delete(id);
+      }
+    }
+
+    // Auto-fit camera to the active points, with a reasonable
+    // pad so markers aren't pinned to the edges.
+    if (points.length > 0) {
+      const bounds = L.latLngBounds(
+        points.map((p) => [p.latitude, p.longitude] as L.LatLngTuple),
+      );
+      map.fitBounds(bounds, { padding: [40, 40], maxZoom: 12 });
+    }
+  }, [points]);
+
+  return (
+    <div
+      ref={containerRef}
+      data-testid="position-map"
+      className="rounded border border-border overflow-hidden"
+      style={{ height: heightPx }}
+    />
+  );
+}
+
+function tooltipHTML(p: MapPoint): string {
+  const labelEsc = escapeHTML(p.label);
+  const detail = p.detail ? escapeHTML(p.detail) : "";
+  return detail
+    ? `<strong>${labelEsc}</strong><br/><span>${detail}</span>`
+    : `<strong>${labelEsc}</strong>`;
+}
+
+function escapeHTML(s: string): string {
+  return s.replace(/[&<>"']/g, (c) => {
+    switch (c) {
+      case "&": return "&amp;";
+      case "<": return "&lt;";
+      case ">": return "&gt;";
+      case "\"": return "&quot;";
+      case "'": return "&#39;";
+    }
+    return c;
+  });
+}

--- a/web/src/panels/ADSB.tsx
+++ b/web/src/panels/ADSB.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { fetchAircraftReports, type AircraftReport } from "../api/adsb";
+import { PositionMap, type MapPoint } from "../components/PositionMap";
 import { selectClientConfig, useShared } from "../store/shared";
 
 // ADS-B panel — list of recent decoded Mode-S frames. Each row
@@ -43,6 +44,28 @@ export function ADSB() {
     };
   }, [cfg]);
 
+  const mapPoints = useMemo<MapPoint[]>(
+    () =>
+      reports
+        .filter(
+          (r) =>
+            r.has_position &&
+            typeof r.latitude === "number" &&
+            typeof r.longitude === "number",
+        )
+        .map((r) => ({
+          id: `adsb-${r.id}`,
+          latitude: r.latitude as number,
+          longitude: r.longitude as number,
+          kind: "adsb" as const,
+          label: r.callsign?.trim() || r.icao_hex,
+          detail: r.has_altitude
+            ? `${r.altitude_ft?.toLocaleString()} ft`
+            : undefined,
+        })),
+    [reports],
+  );
+
   return (
     <div className="space-y-3">
       <header className="flex items-center justify-between">
@@ -51,6 +74,8 @@ export function ADSB() {
           {reports.length} message{reports.length === 1 ? "" : "s"}
         </span>
       </header>
+
+      {mapPoints.length > 0 && <PositionMap points={mapPoints} />}
 
       {error && (
         <div className="rounded border border-red-700/40 bg-red-900/20 text-red-200 text-xs px-3 py-2">

--- a/web/src/panels/AIS.tsx
+++ b/web/src/panels/AIS.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { fetchAISVessels, type AISMessage } from "../api/ais";
+import { PositionMap, type MapPoint } from "../components/PositionMap";
 import { selectClientConfig, useShared } from "../store/shared";
 
 // AIS panel — list of recent decoded marine-AIS messages. Each row
@@ -39,6 +40,26 @@ export function AIS() {
     };
   }, [cfg]);
 
+  const mapPoints = useMemo<MapPoint[]>(
+    () =>
+      messages
+        .filter(
+          (m) =>
+            m.has_position &&
+            typeof m.latitude === "number" &&
+            typeof m.longitude === "number",
+        )
+        .map((m) => ({
+          id: `ais-${m.id}`,
+          latitude: m.latitude as number,
+          longitude: m.longitude as number,
+          kind: "ais" as const,
+          label: m.vessel_name || String(m.mmsi).padStart(9, "0"),
+          detail: m.body ?? "",
+        })),
+    [messages],
+  );
+
   return (
     <div className="space-y-3">
       <header className="flex items-center justify-between">
@@ -47,6 +68,8 @@ export function AIS() {
           {messages.length} message{messages.length === 1 ? "" : "s"}
         </span>
       </header>
+
+      {mapPoints.length > 0 && <PositionMap points={mapPoints} />}
 
       {error && (
         <div className="rounded border border-red-700/40 bg-red-900/20 text-red-200 text-xs px-3 py-2">

--- a/web/src/panels/APRS.tsx
+++ b/web/src/panels/APRS.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { fetchAPRSPackets, type APRSPacket } from "../api/aprs";
+import { PositionMap, type MapPoint } from "../components/PositionMap";
 import { selectClientConfig, useShared } from "../store/shared";
 
 // APRS panel — list of recent decoded APRS / AX.25 packets. Each
@@ -40,6 +41,26 @@ export function APRS() {
     };
   }, [cfg]);
 
+  const mapPoints = useMemo<MapPoint[]>(
+    () =>
+      packets
+        .filter(
+          (p) =>
+            typeof p.latitude === "number" &&
+            typeof p.longitude === "number" &&
+            !(p.latitude === 0 && p.longitude === 0),
+        )
+        .map((p) => ({
+          id: `aprs-${p.id}`,
+          latitude: p.latitude as number,
+          longitude: p.longitude as number,
+          kind: "aprs" as const,
+          label: p.src,
+          detail: `${p.type} · ${p.body ?? ""}`.trim(),
+        })),
+    [packets],
+  );
+
   return (
     <div className="space-y-3">
       <header className="flex items-center justify-between">
@@ -48,6 +69,8 @@ export function APRS() {
           {packets.length} packet{packets.length === 1 ? "" : "s"}
         </span>
       </header>
+
+      {mapPoints.length > 0 && <PositionMap points={mapPoints} />}
 
       {error && (
         <div className="rounded border border-red-700/40 bg-red-900/20 text-red-200 text-xs px-3 py-2">

--- a/web/src/panels/DSC.tsx
+++ b/web/src/panels/DSC.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { fetchDSCMessages, type DSCMessage } from "../api/dsc";
+import { PositionMap, type MapPoint } from "../components/PositionMap";
 import { selectClientConfig, useShared } from "../store/shared";
 
 // DSC panel — list of recent decoded marine DSC sequences. The
@@ -40,6 +41,30 @@ export function DSC() {
     };
   }, [cfg]);
 
+  // DSC distress alerts are the only DSC sequence type that
+  // commonly carries a position; surface those alerts on the
+  // shared map with the high-visibility red marker so the
+  // operator's eye is drawn to them immediately.
+  const mapPoints = useMemo<MapPoint[]>(
+    () =>
+      messages
+        .filter(
+          (m) =>
+            m.has_position &&
+            typeof m.latitude === "number" &&
+            typeof m.longitude === "number",
+        )
+        .map((m) => ({
+          id: `dsc-${m.id}`,
+          latitude: m.latitude as number,
+          longitude: m.longitude as number,
+          kind: "dsc-distress" as const,
+          label: `MMSI ${String(m.self_mmsi).padStart(9, "0")}`,
+          detail: m.nature || m.format,
+        })),
+    [messages],
+  );
+
   return (
     <div className="space-y-3">
       <header className="flex items-center justify-between">
@@ -48,6 +73,8 @@ export function DSC() {
           {messages.length} sequence{messages.length === 1 ? "" : "s"}
         </span>
       </header>
+
+      {mapPoints.length > 0 && <PositionMap points={mapPoints} />}
 
       {error && (
         <div className="rounded border border-red-700/40 bg-red-900/20 text-red-200 text-xs px-3 py-2">


### PR DESCRIPTION
## Summary

Position-bearing decoded rows now plot on a shared Leaflet map at
the top of each protocol panel. Until now operators saw tables of
lat/lon; the map view gives real spatial awareness across the
four position-bearing decoders that have shipped in Phase 5
(APRS, AIS, DSC distress, ADS-B). Marked as "Live map (follow-up)"
in `docs/{aprs,ais,dsc,adsb}.md` since the APRS slice — this PR
fulfils it.

### `web/src/components/PositionMap.tsx` — shared component

One Leaflet `L.map` per panel. Points → `L.circleMarker`
diff-updated keyed by stable row IDs, so the 5-second poll
refresh patches markers in place instead of tearing them down +
re-creating them every cycle. Auto-fits the camera to the active
point set on every update.

Marker colours per protocol:
- **APRS** station fix → blue (`#3b82f6`)
- **AIS** vessel → cyan (`#06b6d4`)
- **ADS-B** aircraft → purple (`#a855f7`)
- **DSC** distress alert → red (`#ef4444`), oversized radius so
  distress jumps out at the operator

Tooltips render the per-protocol short label (callsign / MMSI /
ICAO+altitude / nature-of-distress).

### Tiles

Standard OpenStreetMap servers (`a/b/c.tile.openstreetmap.org`).
Compliant with the OSM Tile Usage Policy for the single-user
self-hosted operator console; larger fleets configuring their own
tile cache is an obvious follow-up once the tile config surface
exists. `maxZoom: 18 / minZoom: 2` clamps tile-fetch volume.

### XSS safety

HTML-escape on all user-derived `label` / `detail` fields before
binding to tooltip HTML — even though only daemon-internal data
flows in, defence-in-depth.

### Panel integrations

APRS / AIS / ADS-B / DSC each compute a `useMemo`-cached
`MapPoint[]` from their existing rowset (filtering to
position-bearing rows) and render `<PositionMap>` above the table
when at least one point qualifies. The empty-state copy on each
panel is unchanged — the map only appears once real position data
arrives.

## Dependencies

- `leaflet@^1.9.4` (~40KB gzipped)
- `@types/leaflet@^1.9.21` (dev)

## Test plan

- [x] `npm test -- --run PositionMap` → 5/5 pass (container
  renders, per-kind marker colours, distress radius + colour,
  HTML escape on tooltip labels, camera auto-fit). Leaflet
  mocked so jsdom doesn't trip over canvas /
  `getBoundingClientRect`.
- [x] `npm test -- --run` → 115/115 web tests pass (20 test
  files; existing panel tests still green with the integrated
  map).
- [x] `npm run build` → typechecks + Vite bundle 619 kB (192 kB
  gzipped) — Leaflet ~150 kB raw / ~50 kB gzipped of that.
- [x] `go test ./internal/... ./cmd/...` clean (no Go side
  changes).

## What's pending

- **Tile config surface.** Operators running multiple GopherTrunk
  daemons across a fleet should configure their own tile cache
  (MapTiler / Mapbox / local tileserver-gl). Add an
  `api.tiles.{template_url, attribution, api_key}` config block
  and surface it in the daemon's `ClientConfig` response so
  PositionMap picks it up at panel mount.
- **Receiver-centred fallback.** When the rowset is empty, the
  map falls back to a hard-coded `[37.5, -122.0]` centre (SF
  Bay). Once the operator's location is configurable (config
  or geolocation-pinned), the empty-state map should centre on
  the receiver instead.
- **Track-history rendering.** For ADS-B / AIS, plotting a
  fading polyline of the last N positions per ICAO / MMSI would
  give operators a "where is this thing heading?" view without
  needing a separate timeline panel. Same `<PositionMap>` API,
  just an additional `tracks?: TrackPolyline[]` prop.
- **DSC + APRS message popups.** Currently the marker tooltip
  shows label + detail; clicking the marker could open the full
  message body in a side-panel popup, especially valuable for
  DSC distress alerts where the full text matters.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YUgvat8WpF5YaSuEAqWMr2)_