### PR TITLE
docs: post-release v0.2.6 — promote CHANGELOG + bump hardcoded refs + social drafts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ for tagged releases.
 
 ## [Unreleased]
 
+## [v0.2.6] — 2026-05-29
+
+Phase 5 expands across marine + aviation and the panels gain a shared
+map. AIS reaches end-to-end live: #427 lands the protocol layer + bus /
+storage / REST / `/ais` panel scaffolding, #428 wires the 9600 Bd GMSK
+DSP frontend + receiver glue (FM demod → 76,800 sps resample → GFSK
+matched filter at BT 0.4 → Mueller-Müller timing → NRZI → HDLC → CRC →
+`ais.Decode`), so pinning one SDR to 161.975 / 162.025 MHz lights up
+vessel positions. #433 adds the DSC marine scaffolding (ITU-R M.493-15
+distress / urgency / safety / routine call decode, BCH(10,7) syndrome
+check, MMSI + position codecs) and #434 the ADS-B aviation scaffolding
+(ICAO Annex 10 Mode-S CRC-24, DF 17 / 18 extended-squitter
+identification / position / velocity decode, globally-unambiguous CPR).
+#435 ties them together with a shared Leaflet `PositionMap` across the
+APRS / AIS / DSC / ADS-B panels — per-protocol marker colours, XSS-safe
+tooltips, camera auto-fit. Plus #419 ports the full APRS Mic-E decoder.
+Trunking robustness: #426 distinguishes a carrier-drop natural call end
+from a silent-timeout reap and #431 fans raw IMBE / AMBE frames out to
+`rawFrameSinks` (both issue #356); #417 makes `sdr.devices` a strict-mode
+allowlist (issue #264); #418 settles the warmup→step-0 race on Windows
+clone dongles (issue #395); #423 builds the wideband voice taps before
+the voice pool (fix #422) and #424 makes voice-grant preemption
+frequency-aware; #425 corrects the Motorola alias cipher stop
+recurrence. Issue #402 (RTL-SDR DC-spike on P25 control) continues:
+#429 fixes the DDA-AFC handoff regression that froze a wrong carrier
+offset, #430 defaults to CoarseAFC-alone and fixes the 10x AFC
+diagnostic, and #432 swaps in an adaptive 4-level C4FM slicer that
+tracks an asymmetric eye.
+
 ### Added
 
 - **Live map across APRS / AIS / DSC / ADS-B.** Position-bearing

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ this exist? Read **[The Story of GopherTrunk](https://gophertrunk.org/story.html
 
 ```sh
 # Linux x86_64 — see https://gophertrunk.org/downloads.html for macOS, Windows, ARM64.
-VERSION=v0.2.5
+VERSION=v0.2.6
 curl -L -o gophertrunk.tar.gz \
   https://github.com/MattCheramie/GopherTrunk/releases/download/${VERSION}/gophertrunk-${VERSION}-linux-amd64.tar.gz
 tar xzf gophertrunk.tar.gz && cd gophertrunk-${VERSION}-linux-amd64

--- a/docs/announcements/v0.2.6.md
+++ b/docs/announcements/v0.2.6.md
@@ -1,0 +1,57 @@
+# GopherTrunk v0.2.6 — social announcement drafts
+
+One-click copy-paste blurbs for posting the v0.2.6 release. Each block
+below is a fenced code block so the rendered-markdown "copy" button
+grabs exactly what you'd paste.
+
+Release: https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.2.6
+
+---
+
+## Reddit — title
+
+```
+GopherTrunk v0.2.6 — AIS marine live end-to-end, DSC + ADS-B decoders, live map across all panels
+```
+
+## Reddit — body
+
+```markdown
+**[GopherTrunk](https://gophertrunk.org) v0.2.6 is out** — pure-Go digital-trunking scanner for RTL-SDR / HackRF / Airspy. P25 (Phase 1+2), DMR (AMBE+2 voice), NXDN, Motorola Type II, EDACS, LTR, MPT 1327, dPMR, D-STAR, YSF, plus APRS, POCSAG paging, and now AIS / DSC / ADS-B. No CGO, single static binary for Linux / macOS / Windows.
+
+**What's new since v0.2.5:**
+
+* **AIS marine is now end-to-end live** (#427, #428) — protocol layer (ITU-R M.1371-5 Class A/B position, base-station, static + voyage data) plus a 9600 Bd GMSK DSP frontend: FM demod → 76,800 sps resample → GFSK matched filter (BT 0.4) → Mueller-Müller timing → NRZI → HDLC → CRC-CCITT → decode. Pin one SDR to 161.975 (87B) or 162.025 MHz (88B) and vessel positions land on the bus, the `vessel_log` SQLite table, `/api/v1/ais/vessels`, and the `/ais` web panel.
+* **DSC marine decoder** (#433) — GMDSS Digital Selective Calling on VHF channel 70 (156.525 MHz): ITU-R M.493-15 distress / urgency / safety / routine call decode, BCH(10,7) syndrome check, MMSI + position codecs. A coast-guard MMSI lighting up the stream is near-instant SAR visibility. Protocol layer + bus / storage / REST / `/dsc` panel; DSP frontend follows.
+* **ADS-B aviation decoder** (#434) — the 1090 MHz data that powers FlightRadar24 / FlightAware. ICAO Annex 10 Mode-S CRC-24, DF 17 / 18 extended-squitter identification / airborne + surface position (globally-unambiguous CPR) / velocity, validated against the mode-s.org reference vectors. Protocol layer + bus / storage / REST / `/adsb` panel; DSP frontend follows.
+* **Live map across APRS / AIS / DSC / ADS-B** (#435) — a shared Leaflet `PositionMap` at the top of each protocol panel. APRS fixes plot blue, AIS vessels cyan, DSC distress red, ADS-B aircraft purple; XSS-safe tooltips, camera auto-fits to the active points on every poll.
+* **Full APRS Mic-E decoder** (#419) — the compressed Mic-E position/status format real APRS trackers emit now decodes alongside the uncompressed positions.
+* **Trunking robustness** (#426, #431, issue #356) — distinguish a carrier-drop natural call end from a silent-timeout reap; fan raw IMBE / AMBE frames out to raw-frame sinks.
+* **RTL-SDR DC-spike on P25 control, continued** (#429, #430, #432, issue #402) — fix the DDA-AFC handoff regression that froze a wrong carrier offset, default to CoarseAFC-alone with a fixed 10x AFC diagnostic, and add an adaptive 4-level C4FM slicer that tracks an asymmetric eye.
+* **SDR / Windows fixes** — `sdr.devices` is now a strict-mode allowlist (#417, issue #264); the warmup→step-0 race on Windows clone dongles is settled (#418, issue #395); wideband voice taps build before the voice pool (#423, fix #422) and voice-grant preemption is frequency-aware (#424); Motorola alias cipher stop recurrence corrected (#425).
+
+**Downloads** (Linux / macOS / Windows, x64 + ARM64): https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.2.6
+
+**Docs:** https://gophertrunk.org
+
+Heads-up: the v0.x line is still flagged prerelease — actively developed, feedback / captures / bug reports very welcome.
+```
+
+## Discord
+
+```markdown
+**GopherTrunk v0.2.6 is out** — pure-Go trunking scanner for RTL-SDR / HackRF / Airspy. P25, DMR, NXDN, analog trunked, APRS, POCSAG, and now AIS / DSC / ADS-B. Single static binary, zero CGO.
+
+**What's new since v0.2.5:**
+- **AIS marine end-to-end live** (#427, #428) — ITU-R M.1371-5 protocol layer + 9600 Bd GMSK DSP frontend (FM → 76.8 ksps → GFSK matched filter → M&M timing → NRZI → HDLC → CRC → decode). Pin an SDR to 161.975 / 162.025 MHz and vessels land on the bus / SQLite log / REST / `/ais` panel.
+- **DSC marine decoder** (#433) — GMDSS DSC on VHF ch 70: distress / urgency / safety / routine, BCH(10,7) syndrome check, MMSI + position codecs. Protocol layer + `/dsc` panel; DSP follows.
+- **ADS-B aviation decoder** (#434) — 1090 MHz Mode-S CRC-24 + DF 17/18 ident / position (CPR) / velocity, validated against mode-s.org vectors. Protocol layer + `/adsb` panel; DSP follows.
+- **Live map across APRS / AIS / DSC / ADS-B** (#435) — shared Leaflet map per panel, per-protocol marker colours, XSS-safe tooltips, camera auto-fit.
+- **Full APRS Mic-E decoder** (#419).
+- **Trunking** (#426, #431, #356) — carrier-drop natural end vs silent-timeout reap; raw IMBE/AMBE fan-out to raw-frame sinks.
+- **P25 DC-spike on CC, continued** (#429, #430, #432, issue #402) — DDA-AFC handoff fix, CoarseAFC-alone default + 10x AFC diag fix, adaptive 4-level C4FM slicer.
+- **SDR/Windows** — strict-mode `sdr.devices` allowlist (#417), clone-dongle warmup race fix (#418), wideband voice taps before pool (#423), frequency-aware preemption (#424), Motorola alias cipher stop fix (#425).
+
+Download: <https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.2.6>
+Docs: <https://gophertrunk.org>
+```

--- a/docs/downloads.md
+++ b/docs/downloads.md
@@ -28,7 +28,7 @@ release state looks like:
 {%- elsif site.github.releases and site.github.releases[0] and site.github.releases[0].tag_name -%}
   {%- assign ver = site.github.releases[0].tag_name -%}
 {%- else -%}
-  {%- assign ver = "v0.2.5" -%}
+  {%- assign ver = "v0.2.6" -%}
 {%- endif -%}
 {%- assign rel_url = "https://github.com/MattCheramie/GopherTrunk/releases/download/" | append: ver -%}
 


### PR DESCRIPTION
Standard post-release docs sweep for v0.2.6 (tagged 2026-05-29). Promotes
the [Unreleased] CHANGELOG section to [v0.2.6] with the dominant themes in
the intro paragraph (Phase 5 marine + aviation expansion — AIS end-to-end
live via #427/#428, DSC #433 and ADS-B #434 scaffolding, shared live map
#435; full APRS Mic-E #419; trunking carrier-drop vs silent-timeout #426 +
raw-frame fan-out #431; issue #402 RTL-SDR DC-spike continued via
#429/#430/#432). Bumps the hardcoded VERSION reference in README.md and the
Liquid fallback in docs/downloads.md from v0.2.5 to v0.2.6, and adds
docs/announcements/v0.2.6.md with copy-paste Reddit + Discord blurbs.