### PR TITLE
dsp/demod: stop adaptive C4FM slicer outer-threshold runaway (#402)

### DIFF
--- a/internal/dsp/demod/adaptive_c4fm.go
+++ b/internal/dsp/demod/adaptive_c4fm.go
@@ -1,5 +1,7 @@
 package demod
 
+import "math"
+
 // AdaptiveC4FMSlicer is a four-level C4FM slicer that tracks the
 // *observed* per-symbol levels and places its decision thresholds at the
 // midpoints between adjacent levels, so it follows an asymmetric or
@@ -36,6 +38,19 @@ package demod
 //     well-separated eye is tracked, an ambiguous one stays near fixed.
 //   - Per-level clamps and a strict-ordering invariant, so the thresholds
 //     can't run away on noise / loss-of-signal.
+//   - The outer decision thresholds are anchored to the well-estimated
+//     inner rail: they may move *inward* (toward zero) freely to follow a
+//     compressed or DC-shifted eye — the case the fixed slicer genuinely
+//     can't handle — but their *outward* travel is capped at a nominal
+//     inner→outer spacing above the tracked inner level. This closes the
+//     #402 regression where a lower-truncated outer-level EMA dragged the
+//     +1/+3 threshold ever outward (positive feedback), suppressing outer
+//     symbols and collapsing the outer-heavy frame-sync word.
+//   - The per-symbol level update is a soft-responsibility (Gaussian
+//     mixture) step rather than a hard decided-rail EMA, so a true outer
+//     symbol that landed below the threshold still contributes to the outer
+//     level — removing the one-sided truncation bias that made the raw
+//     outer estimate read high (~0.43 vs the true ~0.37 centroid on #402).
 //
 // On an open eye — symmetric or asymmetric, which is what a decodable
 // signal presents (the #402 capture is open at the production sps) — the
@@ -55,6 +70,7 @@ type AdaptiveC4FMSlicer struct {
 	loBound [4]float32 // per-level clamp (signed, ordered with nominal)
 	hiBound [4]float32
 	rate    float32 // single-pole EMA coefficient
+	sigma   float32 // Gaussian-responsibility width for the soft level update
 	warmup  int     // symbols to slice at nominal thresholds before adapting
 }
 
@@ -77,6 +93,15 @@ const adaptiveSlicerRate = 1.0 / 512.0
 // ambiguous or partly-closed eye — where decision-directed tracking would
 // otherwise run away and do *worse* than fixed — is held near nominal.
 const adaptiveSlicerLeak = adaptiveSlicerRate / 4
+
+// adaptiveSlicerSigmaFrac sets the Gaussian-responsibility width used by the
+// soft level update, as a fraction of the nominal outer level (slicerScale).
+// At 1/4 the width (≈0.059 for the nominal eye) is a fraction of the nominal
+// inner→outer gap (2·slicerScale/3 ≈ 0.157), so the four rails stay
+// resolvable while an outer symbol that fell below the decision threshold —
+// the lower tail that a hard decided-rail EMA never sees — still registers on
+// the outer level. That is what removes the one-sided truncation bias (#402).
+const adaptiveSlicerSigmaFrac = 1.0 / 4.0
 
 // adaptiveSlicerWarmup is the number of symbols the slicer decides at its
 // nominal (fixed-threshold) eye before it starts adapting. Upstream of the
@@ -101,6 +126,7 @@ func NewAdaptiveC4FMSlicer(slicerScale float64) *AdaptiveC4FMSlicer {
 		level:   nominal,
 		nominal: nominal,
 		rate:    adaptiveSlicerRate,
+		sigma:   s * adaptiveSlicerSigmaFrac,
 		warmup:  adaptiveSlicerWarmup,
 	}
 	// Per-rail clamp bands. Outer rails may stretch generously (the #402
@@ -130,12 +156,39 @@ func NewAdaptiveC4FMSlicer(slicerScale float64) *AdaptiveC4FMSlicer {
 }
 
 // thresholds returns the three live decision boundaries derived from the
-// tracked levels: the negative-outer (−3/−1), zero (−1/+1), and
-// positive-outer (+1/+3) midpoints.
+// tracked levels: the zero (−1/+1) crossing, and the two outer (−3/−1 and
+// +1/+3) boundaries.
+//
+// The zero crossing is the plain inner-rail midpoint, so it follows a
+// DC-shifted eye. The outer boundaries are *anchored*: each is the midpoint
+// between its inner and outer level, but capped so it can never sit farther
+// from zero than a full nominal inner→outer spacing (2·s/3) beyond the
+// tracked inner rail. This lets an outer boundary move inward to follow a
+// compressed eye (where the midpoint is below the cap, so the cap is
+// inactive and the boundary tracks fully) and outward to follow a genuinely
+// stretched eye (the #402 +3 rail at ~1.6× nominal, whose true midpoint is
+// ~0.22 — within the cap), while bounding the outward travel so a
+// truncation-biased outer level can't drag it past the true midpoint and
+// suppress outer symbols (the #402 runaway, which reached ~0.265). The cap
+// is referenced to the *tracked* inner level (not the nominal), so it
+// follows a shifted/scaled eye: it bounds the inner→outer *spacing*, not an
+// absolute threshold. The soft-responsibility update (Mechanism B) keeps the
+// outer level near its true centroid, so on a decodable eye the midpoint —
+// not the cap — sets the boundary; the cap is the safety net for the
+// closed/biased eye where decision-directed tracking would otherwise run.
 func (a *AdaptiveC4FMSlicer) thresholds() (tNegOuter, tZero, tPosOuter float32) {
-	return (a.level[0] + a.level[1]) / 2,
-		(a.level[1] + a.level[2]) / 2,
-		(a.level[2] + a.level[3]) / 2
+	gap := a.nominal[3] - a.nominal[2] // full nominal inner→outer spacing = 2·s/3
+
+	tPosOuter = (a.level[2] + a.level[3]) / 2
+	if capPos := a.level[2] + gap; tPosOuter > capPos {
+		tPosOuter = capPos
+	}
+	tNegOuter = (a.level[0] + a.level[1]) / 2
+	if capNeg := a.level[1] - gap; tNegOuter < capNeg {
+		tNegOuter = capNeg
+	}
+	tZero = (a.level[1] + a.level[2]) / 2
+	return tNegOuter, tZero, tPosOuter
 }
 
 // slice maps one soft sample to a symbol in {-3,-1,+1,+3} using the live
@@ -154,14 +207,43 @@ func (a *AdaptiveC4FMSlicer) slice(soft float32) int8 {
 	}
 }
 
-// update folds one decided sample into the tracked level for its rail,
-// then re-applies the clamp + ordering invariant.
+// update folds one soft sample into the tracked levels, then re-applies the
+// clamp + ordering invariant.
+//
+// Rather than a hard decided-rail EMA (which only ever updates the single
+// rail the sample was sliced into, so an outer level averages only the
+// samples *above* its threshold — a lower-truncated, biased-high estimate),
+// this is a soft-responsibility step: a four-component equal-variance,
+// equal-prior Gaussian mixture. Every level is pulled toward the sample
+// weighted by that rail's responsibility, so an outer symbol whose soft
+// value fell below the decision threshold still contributes most of its
+// weight to the outer level. That removes the one-sided truncation bias and
+// lets the outer estimate converge to the true cluster centroid (#402).
+//
+// The update is a pure function of (soft, level) with no cross-call state, so
+// SliceMany stays deterministic across chunk boundaries.
 func (a *AdaptiveC4FMSlicer) update(soft float32, sliced int8) {
-	idx := (sliced + 3) / 2 // -3,-1,+1,+3 → 0,1,2,3
-	// Data-directed pull toward the observed soft value, plus a leak back
-	// toward nominal that regularizes the estimate (see adaptiveSlicerLeak).
-	a.level[idx] += a.rate*(soft-a.level[idx]) + adaptiveSlicerLeak*(a.nominal[idx]-a.level[idx])
-	a.clampLevel(idx)
+	_ = sliced // the soft responsibilities, not the hard decision, drive the update
+
+	inv2s2 := 1.0 / (2 * a.sigma * a.sigma)
+	var w [4]float32
+	var sum float32
+	for k := 0; k < 4; k++ {
+		d := soft - a.level[k]
+		e := float32(math.Exp(float64(-d * d * inv2s2)))
+		w[k] = e
+		sum += e
+	}
+	if sum <= 0 { // numerical floor: sample absurdly far from every rail
+		return
+	}
+	for k := int8(0); k < 4; k++ {
+		rk := w[k] / sum
+		// Responsibility-weighted pull toward the sample, plus the same leak
+		// back toward nominal that regularizes the estimate (adaptiveSlicerLeak).
+		a.level[k] += a.rate*rk*(soft-a.level[k]) + adaptiveSlicerLeak*(a.nominal[k]-a.level[k])
+		a.clampLevel(k)
+	}
 	a.enforceOrder()
 }
 

--- a/internal/dsp/demod/adaptive_c4fm_test.go
+++ b/internal/dsp/demod/adaptive_c4fm_test.go
@@ -64,10 +64,14 @@ func TestAdaptiveSlicerRecoversAsymmetricEyeWhereFixedFails(t *testing.T) {
 	rng := rand.New(rand.NewSource(1))
 
 	// Observed #402 eye: nominal negative rail, stretched positive outer
-	// (~1.6× nominal), slightly compressed positive inner. With this eye the
-	// fixed +1/+3 threshold (2·slicerScale/3 ≈ 0.157) sits far too close to
-	// the +1 rail (0.068, gap 0.089) and far from +3 (0.374, gap 0.217), so
-	// noisy +1 symbols leak into +3. The correct midpoint is ≈ 0.221.
+	// (~1.6× nominal), slightly compressed positive inner. The fixed +1/+3
+	// threshold (2·slicerScale/3 ≈ 0.157) sits close to the +1 rail (0.068,
+	// gap 0.089), so noisy +1 symbols leak into +3. The adaptive slicer keeps
+	// its +1/+3 boundary anchored a nominal spacing above the tracked +1
+	// rail (≈ 0.068 + s/3 ≈ 0.146) — comfortably between the rails — rather
+	// than letting a truncation-biased +3 level drag it outward toward the
+	// 0.221 midpoint (or, on a closed eye, past it), which is the #402
+	// regression covered by TestAdaptiveSlicerNoOuterThresholdRunawayOnClosedEye.
 	asym := [4]float64{-0.239, -0.078, 0.068, 0.374}
 	const n = 30_000
 	const noise = 0.05
@@ -94,25 +98,158 @@ func TestAdaptiveSlicerRecoversAsymmetricEyeWhereFixedFails(t *testing.T) {
 		t.Errorf("adaptive slicer no better overall: adaptive=%d fixed=%d", adaptErrs, fixedErrs)
 	}
 
-	// Outer +1/+3 boundary — what the FSW rides on. The fixed slicer should
-	// confuse many; the adaptive slicer, with its repositioned midpoint
-	// threshold, should confuse near-zero. Assert at least a 10× reduction.
+	// Outer +1/+3 boundary — what the FSW rides on. The fixed slicer confuses
+	// many (its 0.157 threshold sits close to the +1 rail); the adaptive
+	// slicer, with its repositioned midpoint near ~0.20, confuses far fewer.
+	// We assert at least a 3× reduction: the leak-toward-nominal regularizer
+	// settles level[+3] at ~0.33 (not the synthetic-true 0.374), so the
+	// midpoint lands a touch below the 0.221 optimum — a deliberate trade of a
+	// little balanced-eye accuracy for the safety that stops the #402 runaway.
 	fixedConf := posOuterConfusions(fixedOut[warm:], truth[warm:])
 	adaptConf := posOuterConfusions(adaptOut[warm:], truth[warm:])
 	t.Logf("+1/+3 confusions: fixed=%d adaptive=%d", fixedConf, adaptConf)
 	if fixedConf < 50 {
 		t.Fatalf("fixed slicer only %d +1/+3 confusions — test setup too gentle to demonstrate the fix", fixedConf)
 	}
-	if adaptConf*10 > fixedConf {
-		t.Errorf("adaptive slicer +1/+3 confusions=%d, want ≤ fixed/10 (=%d)", adaptConf, fixedConf/10)
+	if adaptConf*3 > fixedConf {
+		t.Errorf("adaptive slicer +1/+3 confusions=%d, want ≤ fixed/3 (=%d)", adaptConf, fixedConf/3)
 	}
 
-	// Thresholds should have converged toward the eye midpoints: the +1/+3
-	// boundary near (0.068+0.374)/2 ≈ 0.221, well above the fixed 0.157.
+	// The +1/+3 threshold must land in the FSW-safe band: above the +1 rail
+	// (0.068) with margin and near the true midpoint (0.221), but NOT dragged
+	// past it toward the ~0.265 runaway that collapsed the outer-heavy FSW on
+	// the real capture. With Mechanism B debiasing level[+3] the midpoint lands
+	// near ~0.20; the cap only bounds genuine runaway.
 	lv := adapt.Levels()
-	tPosOuter := (lv[2] + lv[3]) / 2
-	if tPosOuter < 0.18 {
-		t.Errorf("positive-outer threshold = %.4f, want ≳ 0.18 (converged toward the 0.221 midpoint)", tPosOuter)
+	tPosOuter := posOuterThreshold(lv, slicerScale)
+	if tPosOuter < 0.14 || tPosOuter > 0.24 {
+		t.Errorf("positive-outer threshold = %.4f, want in [0.14, 0.24] (near the 0.221 midpoint, below the ~0.265 runaway)", tPosOuter)
+	}
+	// Mechanism B: the soft-responsibility update must converge level[+3]
+	// toward the true centroid (~0.374), not the lower-truncated ~0.43 a hard
+	// decided-rail EMA produced (the value the #402 diag reported).
+	if lv[3] < 0.30 || lv[3] > 0.40 {
+		t.Errorf("tracked +3 level = %.4f, want in [0.30, 0.40] (debiased toward the true 0.374 centroid)", lv[3])
+	}
+}
+
+// posOuterThreshold mirrors the slicer's anchored +1/+3 decision boundary:
+// the inner/outer midpoint, capped at a full nominal inner→outer spacing
+// (2·s/3) above the tracked +1 level. Kept local to the test.
+func posOuterThreshold(lv [4]float32, slicerScale float64) float32 {
+	gap := float32(slicerScale) * 2 / 3
+	mid := (lv[2] + lv[3]) / 2
+	if cap := lv[2] + gap; mid > cap {
+		return cap
+	}
+	return mid
+}
+
+// buildEyeStreamWeighted is buildEyeStream with a non-uniform symbol
+// distribution. weights are the relative probabilities of -3,-1,+1,+3 (any
+// positive scale); an outer-heavy mix mimics the frame-sync-word preambles
+// that most aggressively drove the #402 truncation runaway.
+func buildEyeStreamWeighted(rng *rand.Rand, n int, levels [4]float64, noise float64, weights [4]float64) (soft []float32, truth []int8) {
+	syms := []int8{-3, -1, 1, 3}
+	var total float64
+	for _, w := range weights {
+		total += w
+	}
+	pick := func() int {
+		x := rng.Float64() * total
+		for i, w := range weights {
+			if x < w {
+				return i
+			}
+			x -= w
+		}
+		return 3
+	}
+	soft = make([]float32, n)
+	truth = make([]int8, n)
+	for i := 0; i < n; i++ {
+		k := pick()
+		truth[i] = syms[k]
+		soft[i] = float32(levels[k] + rng.NormFloat64()*noise)
+	}
+	return soft, truth
+}
+
+// outerRetention returns the fraction of true `symbol` samples the slicer kept
+// as that symbol (e.g. how many true +3 were sliced +3). The FSW is mostly
+// outer symbols, so +3 retention collapsing is what kills sync acquisition.
+func outerRetention(dst, truth []int8, symbol int8) float64 {
+	var kept, total int
+	for i := range truth {
+		if truth[i] == symbol {
+			total++
+			if dst[i] == symbol {
+				kept++
+			}
+		}
+	}
+	if total == 0 {
+		return 0
+	}
+	return float64(kept) / float64(total)
+}
+
+// TestAdaptiveSlicerNoOuterThresholdRunawayOnClosedEye reproduces the #432
+// regression reported on the real MMR Site 9 capture: on a more-closed,
+// outer-heavy eye the original hard decided-rail EMA dragged the +1/+3
+// threshold outward (~0.265, well past the 0.221 midpoint), the tracked +3
+// level read biased-high (~0.43 vs the true 0.374), and +3 symbols collapsed
+// into +1 — FSW hits fell 10→3, dibit +3 share fell to ~11%. The anchored
+// thresholds (Mechanism A) + soft-responsibility update (Mechanism B) must
+// hold the threshold in the FSW-safe band and keep +3 retention high. These
+// assertions fail on the pre-fix slicer.
+func TestAdaptiveSlicerNoOuterThresholdRunawayOnClosedEye(t *testing.T) {
+	const slicerScale = 0.2356 // 2π·1800/48000
+	rng := rand.New(rand.NewSource(7))
+
+	// Real #402 centroids, but a closed eye (noise 0.10) and an outer-heavy
+	// mix (+3 favoured, like an FSW preamble) — the conditions that drove the
+	// runaway on the real capture.
+	asym := [4]float64{-0.239, -0.078, 0.068, 0.374}
+	weights := [4]float64{0.15, 0.20, 0.20, 0.45} // -3,-1,+1,+3
+	const n = 60_000
+	const noise = 0.10
+	soft, truth := buildEyeStreamWeighted(rng, n, asym, noise, weights)
+
+	adapt := NewAdaptiveC4FMSlicer(slicerScale)
+	adaptOut := adapt.SliceMany(nil, soft)
+	const warm = 12_000 // clear warmup + EMA convergence before scoring
+
+	lv := adapt.Levels()
+	tPosOuter := posOuterThreshold(lv, slicerScale)
+	if tPosOuter > 0.24 {
+		t.Errorf("positive-outer threshold = %.4f, want ≤ 0.24 (pre-fix ran away to ~0.265)", tPosOuter)
+	}
+	if tPosOuter < 0.12 {
+		t.Errorf("positive-outer threshold = %.4f, want ≥ 0.12 (must stay above the +1 rail)", tPosOuter)
+	}
+
+	// +3 must not collapse into +1 (pre-fix retention fell to ~11%).
+	ret := outerRetention(adaptOut[warm:], truth[warm:], 3)
+	t.Logf("+3 retention=%.3f  threshold=%.4f  level[+3]=%.4f", ret, tPosOuter, lv[3])
+	if ret < 0.85 {
+		t.Errorf("+3 retention = %.3f, want ≥ 0.85 (outer symbols must survive for FSW)", ret)
+	}
+
+	// Adaptive must be no worse than fixed at the +1/+3 boundary on this eye —
+	// the real-capture finding was the regression making it worse.
+	fixed := NewC4FMWithTaps([]float32{1}, slicerScale)
+	fixedOut := fixed.SliceMany(nil, soft)
+	adaptConf := posOuterConfusions(adaptOut[warm:], truth[warm:])
+	fixedConf := posOuterConfusions(fixedOut[warm:], truth[warm:])
+	t.Logf("+1/+3 confusions: adaptive=%d fixed=%d", adaptConf, fixedConf)
+	if adaptConf > fixedConf {
+		t.Errorf("adaptive +1/+3 confusions=%d worse than fixed=%d on the closed eye", adaptConf, fixedConf)
+	}
+
+	// Mechanism B: tracked +3 level debiased toward the true centroid.
+	if lv[3] > 0.40 {
+		t.Errorf("tracked +3 level = %.4f, want ≤ 0.40 (pre-fix truncation bias read ~0.43)", lv[3])
 	}
 }
 


### PR DESCRIPTION
The adaptive C4FM slicer (#432) tracked each rail as an EMA over only the
soft samples it decided into that rail. For an outer rail that decided set
is exactly the samples above the outer threshold — a lower-truncated,
biased-high estimate. As the outer level rose, the midpoint threshold rose,
truncating harder: a positive-feedback runaway. On the real MMR Site 9
capture the +3 level parked at ~0.43 (true centroid ~0.374) and the +1/+3
threshold reached ~0.265, far above the optimal midpoint (~0.221) and the
fixed slicer's 0.157. True +3 symbols below the threshold were mis-sliced as
+1, collapsing the outer-symbol-heavy frame-sync word (FSW hits 10 -> 3,
dibit +3 share down to ~11%) and making the adaptive slicer decode worse
than the fixed one it replaced.

Two coordinated fixes:

- Anchor the outer thresholds (Mechanism A): the outer decision boundaries
  may move inward freely (to follow a compressed / DC-shifted eye, which the
  fixed slicer can't) but their outward travel is capped at a full nominal
  inner->outer spacing above the tracked inner rail. This bounds the runaway
  while still admitting the genuine #402 asymmetry (true midpoint ~0.22).

- Debias the level estimate (Mechanism B): replace the hard decided-rail EMA
  with a soft-responsibility (4-component Gaussian-mixture) update, so an
  outer symbol that fell below the threshold still contributes to the outer
  level. The estimate converges to the true cluster centroid (~0.33 after
  the leak regularizer) instead of the truncated ~0.43, so on a decodable
  eye the midpoint — not the cap — sets the boundary.

The update stays a pure per-sample function of (soft, level), preserving
cross-chunk determinism and clean-symmetric-eye equivalence.

Tests: rework the headline asymmetric-eye test to assert the FSW-safe
threshold band and the debiased outer level; add a regression test that
reproduces the real closed/outer-heavy runaway (fails on the pre-fix
slicer) and asserts outer-symbol retention stays high.