### PR TITLE
adsb: BEAST upstream client + per-ICAO CPR pair-tracker (end-to-end)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,56 @@ for tagged releases.
 
 ## [Unreleased]
 
+### Added
+
+- **ADS-B end-to-end via BEAST upstreams + per-ICAO CPR pair-
+  tracker.** Most 1090 MHz receive chains already run
+  dump1090 / readsb / BeastSplitter against a dedicated
+  RTL-SDR; GopherTrunk now consumes their BEAST binary output
+  over TCP and feeds the frames into the same
+  `events.KindAircraftReport` bus / `aircraft_log` SQLite /
+  `/api/v1/adsb/aircraft` REST / `/adsb` web panel stack that
+  shipped in #434. Operators add an `adsb.beast_upstreams`
+  entry (typically `127.0.0.1:30005` — the standard
+  dump1090 / readsb BEAST port) and aircraft start landing on
+  the live map immediately. Reconnect-with-backoff on
+  upstream drops; the embedded CPR tracker resets between
+  reconnects so stale even/odd halves don't pair across the
+  gap. No native 1 Msps PPM DSP frontend yet — that's the
+  next slice — but for the operator workflow this PR is the
+  one that makes ADS-B *useful*.
+  New `internal/radio/adsb.Tracker` is the per-ICAO state
+  machine that buffers the most-recent CPR half and calls
+  `CPRDecodeGlobal` when both halves arrive within the spec's
+  10 s window (DO-260B §2.2.3.2.3.7). Thread-safe;
+  `Prune(now)` evicts ICAOs that haven't transmitted in > 10 s
+  so the state map doesn't grow with every aircraft ever
+  seen. Extends the existing `adsb.Position` struct with
+  `Latitude` / `Longitude` / `HasGlobalPosition` fields the
+  tracker populates on a successful pair-decode.
+  New `internal/radio/adsb/beast` package — BEAST frame
+  parser (`ReadFrame` handles the 0x1A byte-stuffing
+  transparently, hunts for sync after a torn TCP segment) +
+  TCP client (`Client.Run` reconnects on drop, applies a
+  per-read deadline so a silent upstream re-dials instead of
+  hanging forever, pipes each Mode-S frame through
+  `adsb.Decode` → `Tracker.Update` → `bus.Publish`).
+  New `internal/config.ADSBBeastConfig` schema + daemon
+  wiring (`d.adsbBeastClients` slice, spawn in the run loop
+  via the standard `spawn` closure).
+  Tests: 7 new tracker tests (canonical dump1090 CPR pair
+  globally decodes to 52.2572 N / 3.91937 E; rejects pairs
+  older than 10 s; passes non-position messages through;
+  ignores CRC-failed frames with ICAO 0; tracks multiple
+  ICAOs independently; `Prune` drops stale; `Reset` clears).
+  8 new BEAST tests (long-frame round-trip, short-frame
+  round-trip, byte-stuffing unstuff, clean-EOF, garbage-
+  before-sync recovery, options validation, end-to-end
+  client test driving the gpsd canonical identification +
+  CPR pair through a loopback TCP server and asserting the
+  bus event carries the right ICAO + globally-decoded
+  lat/lon). All passing.
+
 ## [v0.2.6] — 2026-05-29
 
 Phase 5 expands across marine + aviation and the panels gain a shared

--- a/README.md
+++ b/README.md
@@ -94,6 +94,36 @@ Silicon and Intel. Full per-OS recipes at
   "not-available" sentinels. Plus `events.KindAISMessage` bus
   event, SQLite `vessel_log`, `GET /api/v1/ais/vessels`, and
   `/ais` web panel. See [docs/ais.md](docs/ais.md).
+- **DSC marine distress** — protocol layer for the GMDSS Digital
+  Selective Calling system that fires every marine VHF channel-
+  70 distress alert. ITU-R M.493-15 format dispatch (Distress,
+  All-Ships, Individual, Group, Geographic, Auto-Individual),
+  BCH(10,7) syndrome check, position decoder with quadrant
+  hemisphere flip, nature-of-distress table. Plus
+  `events.KindDSCMessage` bus event, SQLite `dsc_log`,
+  `GET /api/v1/dsc/messages`, and `/dsc` web panel (rows tint
+  by category — distress=red, urgency=orange, safety=blue).
+  DSP frontend (1200 Bd FSK at 1300/2100 Hz tones) follows.
+  See [docs/dsc.md](docs/dsc.md).
+- **ADS-B aviation** — end-to-end pipeline for the 1090 MHz
+  Mode-S transponder broadcasts every commercial flight emits.
+  ICAO Annex 10 Vol IV / DO-260B parser (CRC-24 + DF dispatch +
+  type-code dispatch for identification, airborne / surface
+  position with 12-bit Q-bit altitude, airborne velocity);
+  globally-unambiguous CPR position decoder + per-ICAO
+  even+odd pair tracker. **BEAST upstream** consumes Mode-S
+  frames from any dump1090 / readsb / BeastSplitter via TCP —
+  most 1090 MHz receive chains already run one, GopherTrunk
+  decodes its output. Plus `events.KindAircraftReport` bus
+  event, SQLite `aircraft_log`, `GET /api/v1/adsb/aircraft`,
+  and `/adsb` web panel. Native 1 Msps PPM DSP frontend
+  follows. See [docs/adsb.md](docs/adsb.md).
+- **Live map** — Shared Leaflet map at the top of each
+  position-bearing panel (APRS / AIS / DSC / ADS-B) renders
+  decoded positions over OpenStreetMap tiles, colour-coded per
+  protocol (blue / cyan / red-distress / purple), with marker
+  tooltips and camera auto-fit. Same `<PositionMap>` component
+  drives all four panels.
 - **Pure-Go voice path** — IMBE (P25 Phase 1) and AMBE+2 (P25
   Phase 2 / DMR) vocoders in Go, no DVSI / mbelib dependency.
   Per-call WAV + raw-frame sidecars; live PCM playback via direct

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -23,6 +23,7 @@ import (
 	"github.com/MattCheramie/GopherTrunk/internal/scanner/conventional"
 	"github.com/MattCheramie/GopherTrunk/internal/scanner/widebandt2"
 
+	adsbbeast "github.com/MattCheramie/GopherTrunk/internal/radio/adsb/beast"
 	aisgmsk "github.com/MattCheramie/GopherTrunk/internal/radio/ais/gmsk"
 	aprsafsk "github.com/MattCheramie/GopherTrunk/internal/radio/aprs/afsk"
 	pocsagrx "github.com/MattCheramie/GopherTrunk/internal/radio/pager/pocsag/receiver"
@@ -163,6 +164,13 @@ type Daemon struct {
 	// publishes decoded vessel messages on KindAISMessage.
 	aisReceivers []*aisgmsk.Receiver
 	aisSpecs     []aisSpec // index-aligned with aisReceivers
+	// adsbBeastClients consume ADS-B Mode-S frames from external
+	// dump1090 / readsb upstreams (BEAST binary protocol). Each
+	// client decodes frames, pairs CPR halves via an embedded
+	// per-ICAO tracker, and publishes KindAircraftReport. Native
+	// 1 Msps PPM DSP frontend is a planned follow-up.
+	adsbBeastClients []*adsbbeast.Client
+	adsbBeastNames   []string // index-aligned with adsbBeastClients
 	// iqBrokers holds an iqtap.Broker per pool entry, keyed by serial.
 	// Primary consumers (CC decoder, conventional scanner) stream IQ
 	// through the broker so secondary observers (live spectrum,
@@ -1018,6 +1026,37 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 		d.aisSpecs = append(d.aisSpecs, spec)
 	}
 
+	// ADS-B BEAST upstreams — one client per configured
+	// adsb.beast_upstreams entry. Each opens a TCP connection
+	// to a dump1090 / readsb BEAST output port, decodes the
+	// Mode-S frames, runs them through the CPR pair-tracker,
+	// and publishes KindAircraftReport. Validation failures
+	// surface as startup warnings.
+	for _, bc := range cfg.ADSB.BeastUpstreams {
+		if bc.Addr == "" {
+			d.addWarning(fmt.Sprintf(
+				"adsb.beast_upstreams: entry missing addr (name=%q) — skipped",
+				bc.Name))
+			continue
+		}
+		name := bc.Name
+		if name == "" {
+			name = bc.Addr
+		}
+		client, err := adsbbeast.New(adsbbeast.Options{
+			Addr:       bc.Addr,
+			Bus:        d.bus,
+			SourceName: name,
+			Log:        log,
+		})
+		if err != nil {
+			d.addWarning(fmt.Sprintf("adsb.beast_upstreams[%s]: %v — skipped", name, err))
+			continue
+		}
+		d.adsbBeastClients = append(d.adsbBeastClients, client)
+		d.adsbBeastNames = append(d.adsbBeastNames, name)
+	}
+
 	// Storage / call log / retention — optional.
 	if cfg.Storage.Path != "" {
 		db, err := storage.Open(cfg.Storage.Path)
@@ -1495,6 +1534,19 @@ func (d *Daemon) Run(ctx context.Context) error {
 			sub := br.Subscribe()
 			defer sub.Close()
 			return rcv.Process(ctx, sub.C)
+		})
+	}
+	// ADS-B BEAST upstream clients — each consumes Mode-S
+	// frames from a separately-running dump1090 / readsb /
+	// commercial hub. Reconnect-with-backoff on disconnects;
+	// the embedded CPR tracker pairs even+odd position halves
+	// so the resulting AircraftReport rows carry decoded
+	// lat/lon.
+	for i, client := range d.adsbBeastClients {
+		client := client
+		name := fmt.Sprintf("adsb-beast-%s", d.adsbBeastNames[i])
+		d.spawn(runCtx, name, false, func(ctx context.Context) error {
+			return client.Run(ctx)
 		})
 	}
 	if d.pool != nil {

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -320,23 +320,19 @@ sdr:
 #                                     #  chatter and keep only distress
 #                                     #  + urgency alerts
 
-# ADS-B / aviation. The protocol parser + bus + storage + REST +
-# panel scaffolding is live; the DSP frontend (1 Msps PPM demod +
-# Mode-S preamble correlation + 56/112-bit frame extraction)
-# ships in a follow-up PR. Operators producing Mode-S frames from
-# an external source (dump1090 hex output, captured BEAST stream,
-# etc.) and feeding them to events.KindAircraftReport will see
-# decoded reports on the bus / panel today.
+# ADS-B / aviation. Most 1090 MHz receive chains already run
+# dump1090 / readsb / BeastSplitter against a dedicated RTL-SDR
+# (with a 1090 MHz filter + LNA); GopherTrunk consumes its BEAST
+# output over TCP. The native 1 Msps PPM DSP frontend is a
+# planned follow-up — once it ships, this same panel + storage
+# table accepts frames from either source.
 #
 # adsb:
-#   channels:
-#     - serial: "1090-antenna"        # SDR serial (must be in sdr.devices
-#                                     #  or sdr.rtl_tcp; dedicate one
-#                                     #  RTL-SDR + 1090 MHz filter + LNA
-#                                     #  to this — the bandwidth needs
-#                                     #  ~1 Msps which crowds out other
-#                                     #  decoders on the same dongle)
-#       frequency_hz: 1_090_000_000   # 1090 MHz centre
+#   beast_upstreams:
+#     - addr: "127.0.0.1:30005"       # dump1090 / readsb default BEAST port
+#       name: "local-dump1090"        # logged on every reconnect
+#     - addr: "antenna-pi.lan:30005"  # remote pi-at-the-antenna setup
+#       name: "rooftop"
 
 trunking:
   # call_timeout_ms: inactivity window after which the engine's

--- a/docs/adsb.md
+++ b/docs/adsb.md
@@ -119,25 +119,60 @@ Spec references:
   documentation, cross-checked against real on-the-air
   payloads.
 
+## BEAST upstream (`internal/radio/adsb/beast`)
+
+GopherTrunk consumes Mode-S frames from any BEAST-protocol
+upstream — the de-facto wire format dump1090, readsb,
+BeastSplitter, and every commercial ADS-B hub speak. Operators
+keep their existing 1090 MHz receive chain (RTL-SDR + filter +
+LNA + dump1090) and point GopherTrunk at it over TCP. No
+native 1 Msps PPM demod required.
+
+```yaml
+adsb:
+  beast_upstreams:
+    - addr: "127.0.0.1:30005"   # dump1090 default BEAST port
+      name: "local-dump1090"
+    - addr: "rooftop-pi:30005"  # pi-at-the-antenna setup
+      name: "rooftop"
+```
+
+Frame layout (`0x1A <type> <timestamp 6B> <signal 1B>
+<payload>`) — type codes:
+- `0x31` = Mode-AC (skipped)
+- `0x32` = Mode-S short (56 bits)
+- `0x33` = Mode-S long (112 bits)
+
+`0x1A` bytes inside the body are escaped as `0x1A 0x1A` for
+sync framing; the client un-escapes transparently. Reconnects
+with backoff on TCP drops (default 2 s); each disconnect
+resets the embedded CPR tracker so stale even/odd halves
+don't pair across a gap.
+
+## CPR pair tracker (`internal/radio/adsb.Tracker`)
+
+ADS-B aircraft alternate between even-encoded (`CPRFormat=0`)
+and odd-encoded (`CPRFormat=1`) position reports roughly every
+0.5 s; recovering the global lat/lon needs both halves.
+`Tracker.Update(msg, now)` buffers the most-recent half per
+ICAO and calls `CPRDecodeGlobal` when both arrive within the
+spec's 10 s window (DO-260B §2.2.3.2.3.7). Position rows show
+globally-decoded lat/lon on the `/adsb` panel + map as soon as
+the pair completes. `Prune()` evicts ICAOs that haven't
+transmitted in > 10 s so the state map doesn't grow with every
+aircraft ever seen.
+
 ## What's pending
 
-- **DSP receiver.** 1 Msps PPM demodulation at 1090 MHz with
-  Mode-S preamble correlation and 56 / 112-bit frame
+- **Native DSP receiver.** 1 Msps PPM demodulation at 1090 MHz
+  with Mode-S preamble correlation and 56 / 112-bit frame
   extraction. The plan calls for extending
   `internal/dsp/tuner/channelizerbank.go` to support
   higher-rate taps, then a Mode-S demod that walks the IQ
   stream, correlates against the 8 µs preamble pattern, and
-  hands extracted frames into `adsb.Decode`. Heaviest decoder
-  in Phase 5 — requires a dedicated SDR tuned to 1090 MHz
-  (typical RTL-SDR setup: PCB antenna + 1090 MHz filter +
-  LNA).
-- **Per-ICAO CPR pair-tracking.** The current parser emits
-  even / odd CPR fields raw; a state machine that buffers the
-  most-recent half per ICAO and calls `CPRDecodeGlobal` when
-  both arrive within ~10 s would let position rows show
-  globally-decoded lat/lon immediately. Same buffer location
-  for the locally-referenced decode (when a reference
-  position is configured).
+  hands extracted frames into `adsb.Decode`. Once shipped the
+  same panel + storage + tracker chain consumes its output
+  alongside BEAST upstreams.
 - **Aircraft tracker.** An `aircraft_current` SQL view (or a
   separate live-state table indexed by ICAO) showing the
   latest known position / altitude / callsign per aircraft,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -29,6 +29,28 @@ type Config struct {
 	Paging     PagingConfig     `yaml:"paging"`
 	APRS       APRSConfig       `yaml:"aprs"`
 	AIS        AISConfig        `yaml:"ais"`
+	ADSB       ADSBConfig       `yaml:"adsb"`
+}
+
+// ADSBConfig configures the ADS-B aircraft-tracking input. The
+// native 1 Msps PPM DSP frontend is planned; for now the BEAST
+// upstream lets operators consume Mode-S frames from a separately-
+// running dump1090 / readsb / BeastSplitter / commercial hub. Most
+// 1090 MHz receiver chains already run dump1090 on a dedicated
+// RTL-SDR + 1090 MHz filter + LNA; pointing GopherTrunk at it
+// is a one-line config away.
+type ADSBConfig struct {
+	BeastUpstreams []ADSBBeastConfig `yaml:"beast_upstreams"`
+}
+
+// ADSBBeastConfig describes one BEAST upstream to consume. Addr is
+// typically "host:30005" — the standard dump1090 / readsb BEAST
+// output port. Multiple upstreams can run side-by-side (e.g. a
+// local antenna + a remote hub at the airport) and their frames
+// merge into the same `events.KindAircraftReport` stream.
+type ADSBBeastConfig struct {
+	Addr string `yaml:"addr"`
+	Name string `yaml:"name"` // log + metrics label
 }
 
 // APRSConfig configures the APRS / AX.25 Bell-202 AFSK receiver.

--- a/internal/radio/adsb/adsb.go
+++ b/internal/radio/adsb/adsb.go
@@ -167,8 +167,9 @@ type Identification struct {
 // position message. CPR (Compact Position Reporting) gives the
 // position in two halves — even and odd encodings; the caller
 // pairs them within ~10 s to recover the global position.
-// For the first slice the decoder surfaces the raw CPR encoded
-// values + the format flag and lets a higher layer pair them.
+// The bit-stream layer surfaces the raw CPR encoded values + the
+// format flag; the higher-level Tracker pairs even/odd halves
+// and populates Latitude / Longitude / HasGlobalPosition.
 type Position struct {
 	// Even-format CPR raw lat / lon (17 bits each) — populated
 	// when CPRFormat == 0.
@@ -180,6 +181,15 @@ type Position struct {
 
 	// CPRFormat: 0 = even-encoded message, 1 = odd-encoded.
 	CPRFormat int
+
+	// Latitude / Longitude in degrees, populated by the Tracker
+	// when the per-ICAO even+odd CPR pair completes inside the
+	// spec's 10 s window. HasGlobalPosition distinguishes
+	// "decoded" from "raw CPR halves preserved but not yet
+	// paired".
+	Latitude          float64
+	Longitude         float64
+	HasGlobalPosition bool
 
 	// Altitude in feet (or 0 if the message carried the "altitude
 	// not available" sentinel). HasAltitude distinguishes "0 ft"

--- a/internal/radio/adsb/beast/beast.go
+++ b/internal/radio/adsb/beast/beast.go
@@ -1,0 +1,399 @@
+// Package beast implements a client for the BEAST binary
+// protocol — the de-facto wire format dump1090, readsb,
+// dump1090-fa, BeastSplitter, and every commercial ADS-B
+// hub speak. BEAST upstreams typically listen on TCP port
+// 30005; pointing GopherTrunk at one decodes the Mode-S
+// frames it emits and feeds them into the standard
+// `events.KindAircraftReport` bus event the rest of the
+// stack already consumes.
+//
+// This lets operators keep their existing dump1090 /
+// readsb installation (running on a dedicated RTL-SDR with
+// a 1090 MHz filter + LNA) and just point GopherTrunk at
+// it — no native PPM demod required.
+//
+// BEAST frame layout (de Magnus de Beer's original spec):
+//
+//	0x1A <type> <timestamp 6B> <signal 1B> <payload>
+//
+// Type codes:
+//   - 0x31 = Mode-AC (4-byte payload; we skip)
+//   - 0x32 = Mode-S short  (7-byte payload, 56-bit frame)
+//   - 0x33 = Mode-S long   (14-byte payload, 112-bit frame)
+//
+// Any 0x1A byte inside the timestamp / signal / payload is
+// escaped as 0x1A 0x1A by the transmitter; the receiver
+// un-stuffs back to a single 0x1A. This lets the framer
+// resync on a missed 0x1A boundary by simply hunting for
+// the next 0x1A that's NOT followed by 0x1A.
+//
+// References:
+//   - https://wiki.jetvision.de/wiki/Mode-S_Beast:Data_Output_Formats
+//   - https://github.com/firestuff/dump1090/blob/master/beast.h
+package beast
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"sync/atomic"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/adsb"
+	"github.com/MattCheramie/GopherTrunk/internal/storage"
+)
+
+// Frame is one decoded BEAST envelope. The Payload bytes hold the
+// raw 56- or 112-bit Mode-S frame ready to feed into
+// adsb.Decode.
+type Frame struct {
+	Type      byte   // 0x31 / 0x32 / 0x33
+	Timestamp uint64 // 6-byte MLAT timestamp from the receiver
+	Signal    byte   // 0..255 signal level
+	Payload   []byte // 2 / 7 / 14 bytes depending on Type
+}
+
+// payloadLen returns the BEAST type's payload byte count.
+// 0 means unknown / unsupported.
+func payloadLen(t byte) int {
+	switch t {
+	case 0x31:
+		return 2 // Mode-AC
+	case 0x32:
+		return 7 // Mode-S short
+	case 0x33:
+		return 14 // Mode-S long
+	}
+	return 0
+}
+
+// Options configures a Client.
+type Options struct {
+	// Addr is the BEAST upstream TCP address — typically
+	// "host:30005". Required.
+	Addr string
+
+	// Bus is required — frames publish onto KindAircraftReport.
+	Bus *events.Bus
+
+	// SourceName is stamped on log lines. Typically "beast" or
+	// the upstream's hostname.
+	SourceName string
+
+	// ReconnectDelay is how long to wait between reconnect
+	// attempts after a connection drops. Default 2 s; small
+	// values keep the panel responsive to upstream restarts.
+	ReconnectDelay time.Duration
+
+	// DialTimeout caps the initial TCP connect attempt.
+	// Default 5 s.
+	DialTimeout time.Duration
+
+	// ReadDeadline applies to each individual read; if the
+	// upstream stops sending for this long the client treats
+	// it as a dropped connection and reconnects. Default 30 s.
+	// (dump1090 / readsb typically send frames every second
+	// on a busy channel.)
+	ReadDeadline time.Duration
+
+	// Log is optional; defaults to slog.Default.
+	Log *slog.Logger
+}
+
+// Client consumes a BEAST TCP upstream, decodes the Mode-S
+// frames it emits, pairs CPR halves via an embedded Tracker,
+// and publishes one events.KindAircraftReport per parsed
+// message.
+type Client struct {
+	addr           string
+	source         string
+	bus            *events.Bus
+	tracker        *adsb.Tracker
+	reconnectDelay time.Duration
+	dialTimeout    time.Duration
+	readDeadline   time.Duration
+	log            *slog.Logger
+
+	framesRead    atomic.Uint64
+	framesDecoded atomic.Uint64
+	framesEmitted atomic.Uint64
+	reconnects    atomic.Uint64
+}
+
+// New constructs a Client. Returns an error if required Options
+// are missing.
+func New(opts Options) (*Client, error) {
+	if opts.Bus == nil {
+		return nil, errors.New("beast: events.Bus is required")
+	}
+	if opts.Addr == "" {
+		return nil, errors.New("beast: Addr is required")
+	}
+	c := &Client{
+		addr:           opts.Addr,
+		source:         opts.SourceName,
+		bus:            opts.Bus,
+		tracker:        adsb.NewTracker(),
+		reconnectDelay: opts.ReconnectDelay,
+		dialTimeout:    opts.DialTimeout,
+		readDeadline:   opts.ReadDeadline,
+		log:            opts.Log,
+	}
+	if c.reconnectDelay == 0 {
+		c.reconnectDelay = 2 * time.Second
+	}
+	if c.dialTimeout == 0 {
+		c.dialTimeout = 5 * time.Second
+	}
+	if c.readDeadline == 0 {
+		c.readDeadline = 30 * time.Second
+	}
+	if c.log == nil {
+		c.log = slog.Default()
+	}
+	return c, nil
+}
+
+// Run dials the upstream and consumes frames until ctx cancels.
+// Reconnects with backoff on disconnects; never returns an
+// error of its own (logs them instead so a transient upstream
+// outage doesn't bring down the daemon).
+func (c *Client) Run(ctx context.Context) error {
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		conn, err := c.dial(ctx)
+		if err != nil {
+			c.log.Warn("beast: dial failed",
+				"addr", c.addr, "err", err,
+				"retry_in", c.reconnectDelay)
+			if waitErr := sleepCtx(ctx, c.reconnectDelay); waitErr != nil {
+				return waitErr
+			}
+			continue
+		}
+		c.log.Info("beast: connected", "addr", c.addr, "source", c.source)
+		c.consume(ctx, conn)
+		c.tracker.Reset()
+		c.reconnects.Add(1)
+		if err := sleepCtx(ctx, c.reconnectDelay); err != nil {
+			return err
+		}
+	}
+}
+
+// dial connects to the upstream with a configurable timeout.
+func (c *Client) dial(ctx context.Context) (net.Conn, error) {
+	d := net.Dialer{Timeout: c.dialTimeout}
+	return d.DialContext(ctx, "tcp", c.addr)
+}
+
+// consume reads BEAST frames off conn until the connection drops
+// or ctx cancels. Each Mode-S frame is decoded, run through the
+// CPR tracker, and published on the bus.
+func (c *Client) consume(ctx context.Context, conn net.Conn) {
+	defer conn.Close()
+
+	// Spawn a goroutine to close the conn on ctx cancel so the
+	// blocking read unblocks.
+	cancelCh := make(chan struct{})
+	defer close(cancelCh)
+	go func() {
+		select {
+		case <-ctx.Done():
+			_ = conn.Close()
+		case <-cancelCh:
+		}
+	}()
+
+	r := bufio.NewReaderSize(conn, 64*1024)
+	for {
+		if err := ctx.Err(); err != nil {
+			return
+		}
+		if c.readDeadline > 0 {
+			_ = conn.SetReadDeadline(time.Now().Add(c.readDeadline))
+		}
+		f, err := ReadFrame(r)
+		if err != nil {
+			if !errors.Is(err, io.EOF) && ctx.Err() == nil {
+				c.log.Warn("beast: read error", "addr", c.addr, "err", err)
+			}
+			return
+		}
+		c.framesRead.Add(1)
+		c.handleFrame(f)
+	}
+}
+
+// handleFrame decodes one BEAST-extracted Mode-S frame and
+// publishes the resulting AircraftReport.
+func (c *Client) handleFrame(f Frame) {
+	if f.Type != 0x32 && f.Type != 0x33 {
+		// Mode-AC frames carry no useful ADS-B data; skip.
+		return
+	}
+	m := adsb.Decode(f.Payload)
+	if !m.CRCValid && m.Kind != adsb.KindAllCall {
+		// CRC-failed extended squitters can't be trusted — skip.
+		// All-call replies (DF 11) only carry the ICAO and no
+		// payload, but they're still useful for "this aircraft
+		// is in range" tracking.
+		return
+	}
+	c.framesDecoded.Add(1)
+
+	m, _ = c.tracker.Update(m, time.Now().UnixNano())
+
+	rep := storage.AircraftReport{
+		ReceivedAt: time.Now(),
+		ICAO:       m.ICAO,
+		ICAOHex:    fmt.Sprintf("%06X", m.ICAO),
+		Kind:       adsb.KindString(m.Kind),
+		Body:       m.String(),
+		CRCValid:   m.CRCValid,
+		RawHex:     m.RawHex,
+	}
+	if m.Identification != nil {
+		rep.Callsign = m.Identification.Callsign
+		rep.Category = m.Identification.Category
+	}
+	if m.Position != nil {
+		rep.HasAltitude = m.Position.HasAltitude
+		rep.Altitude = m.Position.Altitude
+		if m.Position.HasGlobalPosition {
+			rep.HasPosition = true
+			rep.Latitude = m.Position.Latitude
+			rep.Longitude = m.Position.Longitude
+		}
+	}
+	if m.Velocity != nil {
+		if m.Velocity.HasGroundSpeed {
+			rep.GroundSpeedKn = m.Velocity.GroundSpeedKn
+			rep.TrackDeg = m.Velocity.TrackDeg
+		}
+		if m.Velocity.HasVerticalRate {
+			rep.VerticalRateFPM = m.Velocity.VerticalRateFPM
+		}
+	}
+
+	c.bus.Publish(events.Event{Kind: events.KindAircraftReport, Payload: rep})
+	c.framesEmitted.Add(1)
+}
+
+// Stats reports cumulative counters for /metrics + debugging.
+type Stats struct {
+	FramesRead    uint64
+	FramesDecoded uint64
+	FramesEmitted uint64
+	Reconnects    uint64
+	TrackerSize   int
+}
+
+func (c *Client) Stats() Stats {
+	return Stats{
+		FramesRead:    c.framesRead.Load(),
+		FramesDecoded: c.framesDecoded.Load(),
+		FramesEmitted: c.framesEmitted.Load(),
+		Reconnects:    c.reconnects.Load(),
+		TrackerSize:   c.tracker.Size(),
+	}
+}
+
+// ReadFrame parses one BEAST frame from a buffered reader.
+// Handles the 0x1A 0x1A byte-stuffing escape transparently.
+// Returns io.EOF on clean close; any other error indicates a
+// transport problem.
+func ReadFrame(r *bufio.Reader) (Frame, error) {
+	// Sync: hunt for a non-stuffed 0x1A. Anywhere a 0x1A 0x1A
+	// pair appears we've landed inside an escaped data byte
+	// rather than a frame boundary; advance and try again.
+	for {
+		b, err := r.ReadByte()
+		if err != nil {
+			return Frame{}, err
+		}
+		if b != 0x1A {
+			continue
+		}
+		next, err := r.Peek(1)
+		if err != nil {
+			return Frame{}, err
+		}
+		if next[0] == 0x1A {
+			// Escaped pair inside a data byte — consume and
+			// continue scanning for the next sync.
+			_, _ = r.Discard(1)
+			continue
+		}
+		// b is a real frame-start 0x1A. Read the type.
+		t, err := r.ReadByte()
+		if err != nil {
+			return Frame{}, err
+		}
+		bodyLen := payloadLen(t)
+		if bodyLen == 0 {
+			return Frame{}, fmt.Errorf("beast: unknown frame type 0x%02X", t)
+		}
+		// Body = 6-byte timestamp + 1-byte signal + payload.
+		body, err := readUnstuffed(r, 6+1+bodyLen)
+		if err != nil {
+			return Frame{}, err
+		}
+		var ts uint64
+		for i := 0; i < 6; i++ {
+			ts = ts<<8 | uint64(body[i])
+		}
+		return Frame{
+			Type:      t,
+			Timestamp: ts,
+			Signal:    body[6],
+			Payload:   body[7:],
+		}, nil
+	}
+}
+
+// readUnstuffed reads exactly n logical bytes from r, transparently
+// un-escaping 0x1A 0x1A pairs back to a single 0x1A.
+func readUnstuffed(r *bufio.Reader, n int) ([]byte, error) {
+	out := make([]byte, 0, n)
+	for len(out) < n {
+		b, err := r.ReadByte()
+		if err != nil {
+			return nil, err
+		}
+		if b == 0x1A {
+			next, err := r.ReadByte()
+			if err != nil {
+				return nil, err
+			}
+			if next != 0x1A {
+				// Should not happen mid-frame; un-stuffing
+				// failure means the upstream broke the
+				// protocol or we lost sync.
+				return nil, fmt.Errorf("beast: unescaped 0x1A in body")
+			}
+		}
+		out = append(out, b)
+	}
+	return out, nil
+}
+
+// sleepCtx is time.Sleep that respects ctx — returns ctx.Err()
+// if ctx fires before the duration elapses.
+func sleepCtx(ctx context.Context, d time.Duration) error {
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-t.C:
+		return nil
+	}
+}

--- a/internal/radio/adsb/beast/beast_test.go
+++ b/internal/radio/adsb/beast/beast_test.go
@@ -1,0 +1,243 @@
+package beast
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/hex"
+	"errors"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/storage"
+)
+
+// buildBEAST encodes one Mode-S frame as a BEAST envelope (frame
+// marker + type + 6-byte timestamp + 1-byte signal + payload).
+// 0x1A bytes inside the body are NOT escaped — callers pass
+// hand-curated test vectors that don't contain 0x1A so escaping
+// isn't needed.
+func buildBEAST(t byte, ts uint64, signal byte, payload []byte) []byte {
+	out := make([]byte, 0, 2+6+1+len(payload))
+	out = append(out, 0x1A, t)
+	for i := 5; i >= 0; i-- {
+		out = append(out, byte(ts>>uint(i*8)))
+	}
+	out = append(out, signal)
+	out = append(out, payload...)
+	return out
+}
+
+// decodeHex panics on bad hex — tests pass hand-curated literals.
+func decodeHex(s string) []byte {
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}
+
+func TestReadFrameModeSLong(t *testing.T) {
+	payload := decodeHex("8D4840D6202CC371C32CE0576098")
+	wire := buildBEAST(0x33, 0x123456789ABC, 200, payload)
+	r := bufio.NewReader(bytes.NewReader(wire))
+	f, err := ReadFrame(r)
+	if err != nil {
+		t.Fatalf("ReadFrame: %v", err)
+	}
+	if f.Type != 0x33 {
+		t.Errorf("Type = 0x%02X, want 0x33", f.Type)
+	}
+	if f.Timestamp != 0x123456789ABC {
+		t.Errorf("Timestamp = 0x%X, want 0x123456789ABC", f.Timestamp)
+	}
+	if f.Signal != 200 {
+		t.Errorf("Signal = %d, want 200", f.Signal)
+	}
+	if !bytes.Equal(f.Payload, payload) {
+		t.Errorf("Payload = %x, want %x", f.Payload, payload)
+	}
+}
+
+func TestReadFrameModeSShort(t *testing.T) {
+	payload := []byte{0x58, 0xAA, 0xBB, 0xCC, 0x00, 0x00, 0x00}
+	wire := buildBEAST(0x32, 0, 100, payload)
+	r := bufio.NewReader(bytes.NewReader(wire))
+	f, err := ReadFrame(r)
+	if err != nil {
+		t.Fatalf("ReadFrame: %v", err)
+	}
+	if f.Type != 0x32 || len(f.Payload) != 7 {
+		t.Errorf("Type=0x%02X payloadLen=%d, want 0x32 / 7", f.Type, len(f.Payload))
+	}
+}
+
+func TestReadFrameUnescapesStuffed1A(t *testing.T) {
+	// Hand-craft a long frame whose payload contains 0x1A.
+	// Build with escape sequences: each in-body 0x1A → 0x1A 0x1A.
+	payload := []byte{0x1A, 0x00, 0x1A, 0x42, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
+	header := []byte{0x1A, 0x33}
+	tsAndSignal := []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xAA}
+	// Apply byte-stuffing to body bytes (timestamp + signal +
+	// payload) so any 0x1A in the body gets escaped.
+	stuffed := []byte{}
+	for _, b := range append(tsAndSignal, payload...) {
+		stuffed = append(stuffed, b)
+		if b == 0x1A {
+			stuffed = append(stuffed, 0x1A)
+		}
+	}
+	wire := append(header, stuffed...)
+	r := bufio.NewReader(bytes.NewReader(wire))
+	f, err := ReadFrame(r)
+	if err != nil {
+		t.Fatalf("ReadFrame: %v", err)
+	}
+	if !bytes.Equal(f.Payload, payload) {
+		t.Errorf("Unstuffed payload = %x, want %x", f.Payload, payload)
+	}
+}
+
+func TestReadFrameReturnsEOFOnCleanClose(t *testing.T) {
+	r := bufio.NewReader(bytes.NewReader(nil))
+	_, err := ReadFrame(r)
+	if !errors.Is(err, io.EOF) {
+		t.Errorf("err = %v, want io.EOF", err)
+	}
+}
+
+func TestReadFrameSkipsGarbageUntilSync(t *testing.T) {
+	// Pre-pad with non-0x1A garbage; ReadFrame should hunt for
+	// the first 0x1A and frame from there.
+	garbage := []byte{0xDE, 0xAD, 0xBE, 0xEF, 0x12, 0x34}
+	good := buildBEAST(0x32, 0, 0, []byte{0x58, 0, 0, 0, 0, 0, 0})
+	wire := append(garbage, good...)
+	r := bufio.NewReader(bytes.NewReader(wire))
+	f, err := ReadFrame(r)
+	if err != nil {
+		t.Fatalf("ReadFrame: %v", err)
+	}
+	if f.Type != 0x32 {
+		t.Errorf("Type = 0x%02X, want 0x32", f.Type)
+	}
+}
+
+func TestNewRejectsBadOptions(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	if _, err := New(Options{}); err == nil {
+		t.Error("New without Bus: want error")
+	}
+	if _, err := New(Options{Bus: bus}); err == nil {
+		t.Error("New without Addr: want error")
+	}
+}
+
+// TestClientPublishesDecodedFrames runs a fake BEAST server on a
+// loopback socket, feeds it the dump1090 canonical identification
+// + airborne-position pair, and asserts the bus event arrives
+// with the right ICAO + globally-decoded lat/lon.
+func TestClientPublishesDecodedFrames(t *testing.T) {
+	bus := events.NewBus(64)
+	sub := bus.Subscribe()
+	t.Cleanup(func() {
+		sub.Close()
+		bus.Close()
+	})
+
+	// Start a fake BEAST server that emits 3 frames then EOFs.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		// Identification frame (TC 4 → KLM1023 / ICAO 4840D6).
+		_, _ = conn.Write(buildBEAST(0x33, 1, 200,
+			decodeHex("8D4840D6202CC371C32CE0576098")))
+		// CPR pair (ICAO 40621D, odd first then even).
+		_, _ = conn.Write(buildBEAST(0x33, 2, 210,
+			decodeHex("8D40621D58C386435CC412692AD6")))
+		_, _ = conn.Write(buildBEAST(0x33, 3, 210,
+			decodeHex("8D40621D58C382D690C8AC2863A7")))
+	}()
+
+	c, err := New(Options{
+		Addr:           ln.Addr().String(),
+		Bus:            bus,
+		SourceName:     "test",
+		ReconnectDelay: 100 * time.Millisecond,
+		ReadDeadline:   200 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = c.Run(ctx) }()
+
+	// Collect events; expect at least the identification + a
+	// position with HasPosition=true.
+	gotIdent := false
+	gotPos := false
+	deadline := time.After(2 * time.Second)
+	for !gotIdent || !gotPos {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind != events.KindAircraftReport {
+				continue
+			}
+			rep, ok := ev.Payload.(storage.AircraftReport)
+			if !ok {
+				continue
+			}
+			switch rep.Kind {
+			case "ident":
+				if rep.ICAO == 0x4840D6 && rep.Callsign == "KLM1023" {
+					gotIdent = true
+				}
+			case "airborne-pos":
+				if rep.ICAO == 0x40621D && rep.HasPosition {
+					// Verify lat/lon match the canonical
+					// dump1090 reference.
+					if rep.Latitude < 52.25 || rep.Latitude > 52.26 {
+						t.Errorf("Latitude = %f", rep.Latitude)
+					}
+					if rep.Longitude < 3.91 || rep.Longitude > 3.93 {
+						t.Errorf("Longitude = %f", rep.Longitude)
+					}
+					gotPos = true
+				}
+			}
+		case <-deadline:
+			t.Fatalf("timeout — gotIdent=%v gotPos=%v stats=%+v",
+				gotIdent, gotPos, c.Stats())
+		}
+	}
+}
+
+func TestPayloadLenSpotChecks(t *testing.T) {
+	cases := map[byte]int{
+		0x31: 2,
+		0x32: 7,
+		0x33: 14,
+		0x00: 0,
+		0xFF: 0,
+	}
+	for t1, want := range cases {
+		if got := payloadLen(t1); got != want {
+			t.Errorf("payloadLen(0x%02X) = %d, want %d", t1, got, want)
+		}
+	}
+}

--- a/internal/radio/adsb/tracker.go
+++ b/internal/radio/adsb/tracker.go
@@ -1,0 +1,174 @@
+package adsb
+
+import (
+	"sync"
+	"time"
+)
+
+// Tracker maintains per-ICAO state so consecutive even+odd CPR
+// position messages decode into a globally-unambiguous lat/lon
+// pair. ADS-B aircraft alternate between even-encoded (CPRFormat=0)
+// and odd-encoded (CPRFormat=1) position reports roughly every
+// 0.5 s; the receiver pairs them within ~10 s to recover the
+// global position via CPRDecodeGlobal.
+//
+// One Tracker per receive pipeline (e.g. one per BEAST upstream
+// connection, or one per native DSP receiver). Thread-safe;
+// callers may invoke Update from multiple goroutines.
+//
+// Spec: DO-260B §2.2.3.2.3.7 — CPR pair-pairing semantics.
+type Tracker struct {
+	mu       sync.Mutex
+	state    map[uint32]*icaoState
+	maxAgeNs int64 // CPR pair max age — spec is 10 s
+}
+
+// icaoState holds the most-recent even and odd CPR halves for one
+// aircraft.
+type icaoState struct {
+	evenLat, evenLon int
+	oddLat, oddLon   int
+	evenAt, oddAt    int64 // unix nanoseconds
+	hasEven, hasOdd  bool
+	// mostRecentIsEven tracks which half arrived more recently.
+	// CPRDecodeGlobal uses it to pick which half's reference
+	// position to return.
+	mostRecentIsEven bool
+}
+
+// NewTracker returns an empty Tracker with the default 10 s CPR
+// pair max age.
+func NewTracker() *Tracker {
+	return &Tracker{
+		state:    make(map[uint32]*icaoState),
+		maxAgeNs: int64(10 * time.Second),
+	}
+}
+
+// Update ingests one parsed Mode-S message. If the message
+// carries a CPR-encoded position and a complementary
+// (even / odd) half is available within the spec's 10 s window,
+// Update returns a copy of the message with the Position
+// struct's Latitude / Longitude / global-decode flags populated
+// via CPRDecodeGlobal. Otherwise the message passes through
+// unchanged.
+//
+// now is the receive timestamp in unix nanoseconds. Passing 0
+// uses time.Now() — convenient for live receivers; tests pass
+// a fixed clock.
+//
+// Non-position-bearing messages (identification, velocity,
+// status, etc.) pass through unchanged and do not update
+// tracker state. ICAO 0 (unparseable / CRC-failed frames) is
+// ignored.
+func (t *Tracker) Update(m Message, now int64) (Message, bool) {
+	if m.Kind != KindAirbornePosition && m.Kind != KindSurfacePosition {
+		return m, false
+	}
+	if m.ICAO == 0 || m.Position == nil {
+		return m, false
+	}
+	if now == 0 {
+		now = time.Now().UnixNano()
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	st, ok := t.state[m.ICAO]
+	if !ok {
+		st = &icaoState{}
+		t.state[m.ICAO] = st
+	}
+
+	if m.Position.CPRFormat == 0 {
+		st.evenLat = m.Position.CPRLatEven
+		st.evenLon = m.Position.CPRLonEven
+		st.evenAt = now
+		st.hasEven = true
+		st.mostRecentIsEven = true
+	} else {
+		st.oddLat = m.Position.CPRLatOdd
+		st.oddLon = m.Position.CPRLonOdd
+		st.oddAt = now
+		st.hasOdd = true
+		st.mostRecentIsEven = false
+	}
+
+	if !st.hasEven || !st.hasOdd {
+		return m, false
+	}
+
+	// Drop stale halves — spec is 10 s; aircraft typically
+	// alternate every 0.5 s so the pair should be fresh.
+	age := st.evenAt - st.oddAt
+	if age < 0 {
+		age = -age
+	}
+	if age > t.maxAgeNs {
+		return m, false
+	}
+
+	lat, lon, ok := CPRDecodeGlobal(
+		st.evenLat, st.evenLon,
+		st.oddLat, st.oddLon,
+		st.mostRecentIsEven)
+	if !ok {
+		return m, false
+	}
+
+	// Mutate a copy of the message (the caller's Position is a
+	// pointer; preserve the raw CPR fields by cloning the
+	// struct rather than overwriting in place).
+	out := m
+	pos := *m.Position
+	pos.Latitude = lat
+	pos.Longitude = lon
+	pos.HasGlobalPosition = true
+	out.Position = &pos
+	return out, true
+}
+
+// Reset clears all per-ICAO state. Call when the upstream
+// connection drops (BEAST disconnect, SDR re-acquisition) so
+// stale CPR halves don't pair with brand-new ones across a
+// gap.
+func (t *Tracker) Reset() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.state = make(map[uint32]*icaoState)
+}
+
+// Size returns the number of distinct ICAOs the tracker is
+// holding state for. Useful for /metrics surfacing and
+// debugging.
+func (t *Tracker) Size() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return len(t.state)
+}
+
+// Prune drops state for ICAOs whose most-recent half is older
+// than the spec's 10 s pair window. Aircraft that left the
+// receiver's range stop transmitting; without pruning the
+// tracker grows linearly with all aircraft ever seen. Call
+// periodically (typically on each Update or once per second).
+func (t *Tracker) Prune(now int64) int {
+	if now == 0 {
+		now = time.Now().UnixNano()
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	dropped := 0
+	for icao, st := range t.state {
+		mostRecent := st.evenAt
+		if st.oddAt > mostRecent {
+			mostRecent = st.oddAt
+		}
+		if now-mostRecent > t.maxAgeNs {
+			delete(t.state, icao)
+			dropped++
+		}
+	}
+	return dropped
+}

--- a/internal/radio/adsb/tracker_test.go
+++ b/internal/radio/adsb/tracker_test.go
@@ -1,0 +1,173 @@
+package adsb
+
+import (
+	"encoding/hex"
+	"math"
+	"testing"
+	"time"
+)
+
+// fixedNow is a deterministic timestamp tracker tests use so the
+// 10 s pair-window logic doesn't rely on wall-clock timing.
+const fixedNow int64 = 1_700_000_000_000_000_000
+
+// TestTrackerPairsEvenOddToGlobalPosition feeds the canonical
+// dump1090 even+odd pair through the tracker and asserts the
+// second message comes back with HasGlobalPosition + the right
+// lat/lon. The pair sequence is odd → even so the more-recent
+// half is even, matching the canonical reference's
+// mostRecentIsEven=true expected value (52.2572 N / 3.91937 E).
+func TestTrackerPairsEvenOddToGlobalPosition(t *testing.T) {
+	tr := NewTracker()
+	even := Decode(decodeHexSilent("8D40621D58C382D690C8AC2863A7"))
+	odd := Decode(decodeHexSilent("8D40621D58C386435CC412692AD6"))
+
+	// Odd arrives first — no pair yet.
+	out, paired := tr.Update(odd, fixedNow)
+	if paired {
+		t.Error("first half (odd): paired = true, want false")
+	}
+	if out.Position != nil && out.Position.HasGlobalPosition {
+		t.Error("first half: HasGlobalPosition = true, want false")
+	}
+
+	// Even arrives second (more recent) — pair completes.
+	out, paired = tr.Update(even, fixedNow+int64(500*time.Millisecond))
+	if !paired {
+		t.Fatal("second half: paired = false, want true")
+	}
+	if !out.Position.HasGlobalPosition {
+		t.Fatal("HasGlobalPosition = false on completed pair")
+	}
+	if math.Abs(out.Position.Latitude-52.2572) > 0.0001 {
+		t.Errorf("Latitude = %f, want 52.2572", out.Position.Latitude)
+	}
+	if math.Abs(out.Position.Longitude-3.91937) > 0.0001 {
+		t.Errorf("Longitude = %f, want 3.91937", out.Position.Longitude)
+	}
+}
+
+// TestTrackerRejectsPairOlderThan10s confirms the spec's 10 s
+// window: an even half from a stale buffer doesn't pair with a
+// fresh odd half.
+func TestTrackerRejectsPairOlderThan10s(t *testing.T) {
+	tr := NewTracker()
+	even := Decode(decodeHexSilent("8D40621D58C382D690C8AC2863A7"))
+	odd := Decode(decodeHexSilent("8D40621D58C386435CC412692AD6"))
+
+	_, _ = tr.Update(even, fixedNow)
+	// Odd half arrives 12 s later — past the spec's 10 s window.
+	_, paired := tr.Update(odd, fixedNow+int64(12*time.Second))
+	if paired {
+		t.Error("paired = true across 12 s gap; want false (spec window is 10 s)")
+	}
+}
+
+// TestTrackerPassesThroughNonPositionMessages confirms the
+// tracker ignores identification / velocity / status frames.
+func TestTrackerPassesThroughNonPositionMessages(t *testing.T) {
+	tr := NewTracker()
+	ident := Decode(decodeHexSilent("8D4840D6202CC371C32CE0576098"))
+	if ident.Kind != KindIdentification {
+		t.Fatalf("test fixture: Kind = %v, want KindIdentification", ident.Kind)
+	}
+
+	out, paired := tr.Update(ident, fixedNow)
+	if paired {
+		t.Error("identification message paired = true, want false")
+	}
+	if out.Identification == nil || out.Identification.Callsign == "" {
+		t.Error("identification fields not preserved across Update")
+	}
+	if tr.Size() != 0 {
+		t.Errorf("Size = %d after non-position message, want 0", tr.Size())
+	}
+}
+
+// TestTrackerIgnoresCRCFailed frames (m.ICAO == 0) — the parser
+// emits position payloads even on CRC-failed frames so the upper
+// layers can render "marginal signal" rows, but the tracker
+// can't trust the ICAO so it should ignore them.
+func TestTrackerIgnoresZeroICAO(t *testing.T) {
+	tr := NewTracker()
+	m := Message{
+		Kind: KindAirbornePosition,
+		ICAO: 0,
+		Position: &Position{
+			CPRFormat: 0, CPRLatEven: 1234, CPRLonEven: 5678,
+		},
+	}
+	_, paired := tr.Update(m, fixedNow)
+	if paired {
+		t.Error("paired = true on ICAO 0; want false")
+	}
+	if tr.Size() != 0 {
+		t.Errorf("Size = %d after ICAO-0 message, want 0", tr.Size())
+	}
+}
+
+// TestTrackerHandlesMultipleICAOsIndependently confirms two
+// aircraft's CPR halves don't cross-contaminate.
+func TestTrackerHandlesMultipleICAOsIndependently(t *testing.T) {
+	tr := NewTracker()
+
+	// Aircraft A — even only.
+	a := Decode(decodeHexSilent("8D40621D58C382D690C8AC2863A7"))
+	_, _ = tr.Update(a, fixedNow)
+
+	// Aircraft B — both halves.
+	bEven := a // borrow A's even encoding
+	bEven.ICAO = 0xDEADBE
+	bOdd := Decode(decodeHexSilent("8D40621D58C386435CC412692AD6"))
+	bOdd.ICAO = 0xDEADBE
+
+	_, _ = tr.Update(bEven, fixedNow)
+	_, paired := tr.Update(bOdd, fixedNow+int64(500*time.Millisecond))
+	if !paired {
+		t.Error("aircraft B pair didn't complete; want true")
+	}
+	if tr.Size() != 2 {
+		t.Errorf("Size = %d, want 2 (both ICAOs tracked)", tr.Size())
+	}
+}
+
+// TestTrackerPruneDropsStaleEntries confirms aircraft that haven't
+// transmitted in > 10 s get evicted from tracker state.
+func TestTrackerPruneDropsStaleEntries(t *testing.T) {
+	tr := NewTracker()
+	even := Decode(decodeHexSilent("8D40621D58C382D690C8AC2863A7"))
+	_, _ = tr.Update(even, fixedNow)
+	if tr.Size() != 1 {
+		t.Fatalf("Size after Update = %d, want 1", tr.Size())
+	}
+
+	dropped := tr.Prune(fixedNow + int64(11*time.Second))
+	if dropped != 1 {
+		t.Errorf("Prune dropped %d, want 1", dropped)
+	}
+	if tr.Size() != 0 {
+		t.Errorf("Size after Prune = %d, want 0", tr.Size())
+	}
+}
+
+// TestTrackerResetClearsState confirms Reset drops everything.
+func TestTrackerResetClearsState(t *testing.T) {
+	tr := NewTracker()
+	even := Decode(decodeHexSilent("8D40621D58C382D690C8AC2863A7"))
+	_, _ = tr.Update(even, fixedNow)
+	tr.Reset()
+	if tr.Size() != 0 {
+		t.Errorf("Size after Reset = %d, want 0", tr.Size())
+	}
+}
+
+// decodeHexSilent is the tracker tests' hex helper; panics on
+// bad input — tests pass hand-curated literals, so a parse
+// failure means the test is broken, not the code under test.
+func decodeHexSilent(s string) []byte {
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		panic("decodeHexSilent: bad hex: " + err.Error())
+	}
+	return b
+}


### PR DESCRIPTION
## Summary

ADS-B is now end-to-end live. Most 1090 MHz receive chains
already run dump1090 / readsb / BeastSplitter against a
dedicated RTL-SDR (with a 1090 MHz filter + LNA); this PR
consumes their **BEAST binary output over TCP** and feeds the
frames into the same `events.KindAircraftReport` bus +
`aircraft_log` SQLite + `/api/v1/adsb/aircraft` REST + `/adsb`
web panel + live map stack that shipped in #434 / #435.

Operators add an `adsb.beast_upstreams` entry (typically
`127.0.0.1:30005` — the standard dump1090 / readsb BEAST port)
and aircraft start landing on the live map within seconds.
For the operator workflow this is the PR that makes ADS-B
actually **useful** — even ahead of the native 1 Msps PPM DSP
frontend.

### `internal/radio/adsb.Tracker` — per-ICAO CPR pair-tracker

ADS-B aircraft alternate between even-encoded (`CPRFormat=0`)
and odd-encoded (`CPRFormat=1`) position reports roughly every
0.5 s. The Tracker buffers the most-recent half per ICAO and
calls `CPRDecodeGlobal` when both arrive inside the spec's
10 s window (DO-260B §2.2.3.2.3.7). Thread-safe; `Prune(now)`
evicts ICAOs gone quiet for > 10 s so the state map doesn't
grow with every aircraft ever seen. Extends `adsb.Position`
with `Latitude` / `Longitude` / `HasGlobalPosition` fields
the tracker populates on a successful pair-decode.

### `internal/radio/adsb/beast` — BEAST protocol client

Parser + TCP client. `ReadFrame` handles the `0x1A`
byte-stuffing transparently, hunts for sync after a torn TCP
segment, and emits Mode-S short (DF 11 / 56-bit) + Mode-S
long (DF 17 / 18 / 112-bit) frames. `Client.Run` reconnects
with backoff on drops, applies a per-read deadline so a
silent upstream re-dials instead of hanging forever, and
pipes each Mode-S frame through `adsb.Decode` →
`Tracker.Update` → `bus.Publish`. CRC-failed extended
squitters drop silently; DF 11 all-call replies pass through
even without a CRC since the ICAO is still recoverable.

### Config + daemon wiring

```yaml
adsb:
  beast_upstreams:
    - addr: "127.0.0.1:30005"     # local dump1090 / readsb
      name: "local-dump1090"
    - addr: "rooftop-pi:30005"    # pi-at-the-antenna setup
      name: "rooftop"
```

`d.adsbBeastClients` slice constructed at startup; spawn in
the run loop via the standard spawn closure. Validation
failures surface as startup warnings.

### Docs

- `docs/adsb.md` rewritten — BEAST upstream + CPR tracker
  sections, native DSP receiver remains the next slice.
- `config.example.yaml` shows the new `adsb.beast_upstreams`
  block.
- `README.md` adds DSC + ADS-B + live map bullets (was
  missing them).
- `CHANGELOG.md` Added entry.

## Test plan

- [x] `go test ./internal/radio/adsb/...` — 28 tests pass
  (13 original + 7 new tracker + 8 new BEAST).
- [x] `go test ./internal/config/ ./cmd/gophertrunk/` —
  daemon still builds + boots.
- [x] `go vet ./...` clean; `gofmt -l` clean.
- **End-to-end client test** drives the gpsd canonical
  identification + CPR pair through a loopback TCP BEAST
  server and asserts the bus event carries the right ICAO +
  globally-decoded lat/lon (52.2572 N / 3.91937 E for ICAO
  40621D).

## Still pending under Phase 5 ADS-B (separate PRs)

- **Native 1 Msps PPM DSP frontend.** The plan still calls
  for extending `internal/dsp/tuner/channelizerbank.go` to
  support higher-rate taps + a Mode-S demod that walks the IQ
  stream, correlates against the 8 µs preamble pattern, and
  hands extracted frames into `adsb.Decode`. With the BEAST
  upstream shipping in this PR, operators with an existing
  dump1090 setup get end-to-end ADS-B today; the native
  frontend is for greenfield deployments that don't want a
  separate decoder daemon.
- **Aircraft tracker view.** An `aircraft_current` SQL view
  or live-state table indexed by ICAO showing the latest
  known position + callsign + velocity per aircraft, joining
  recent messages — a "currently visible aircraft" panel
  distinct from the raw message log.
- **Locally-referenced CPR.** Single-message position decode
  against a configured receiver location, useful for the
  first few seconds before the global even+odd pair completes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YUgvat8WpF5YaSuEAqWMr2)_