### PR TITLE
mdc1200: end-to-end Motorola FFSK signaling decode (#438)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ for tagged releases.
 
 ## [Unreleased]
 
+### Added
+
+- **MDC1200 Motorola signaling decode** (#438) — end-to-end pipeline
+  for the analog FFSK data burst Motorola radios key at the head /
+  tail of a transmission on conventional VHF / UHF voice channels.
+  1200-baud CCIR FFSK DSP frontend (FM demod → FFSK discriminator at
+  1200 / 1800 Hz → Mueller-Müller timing → NRZ slicer, reusing the
+  existing `demod.FFSK`), a 40-bit sync framer with inverted-polarity
+  tolerance, 16×7 de-interleave, op / arg / unit-ID decode with a
+  CRC-16-CCITT check, and an op/arg label table (PTT ANI, emergency,
+  status, radio check, call alert, selective call, radio inhibit /
+  enable, remote monitor). Plus `events.KindMDC1200Message`, SQLite
+  `mdc1200_log`, `GET /api/v1/mdc1200/messages`, the `/mdc1200` web
+  panel, and an `mdc1200.channels` config block. Clean-room
+  implementation under Apache-2.0. See [docs/mdc1200.md](docs/mdc1200.md).
+
 ## [v0.2.6] — 2026-05-29
 
 Phase 5 expands across marine + aviation and the panels gain a shared

--- a/README.md
+++ b/README.md
@@ -94,6 +94,17 @@ Silicon and Intel. Full per-OS recipes at
   "not-available" sentinels. Plus `events.KindAISMessage` bus
   event, SQLite `vessel_log`, `GET /api/v1/ais/vessels`, and
   `/ais` web panel. See [docs/ais.md](docs/ais.md).
+- **MDC1200 signaling** — end-to-end pipeline for Motorola's
+  analog FFSK data burst keyed at the head / tail of a
+  transmission on conventional VHF / UHF voice channels. 1200-baud
+  CCIR FFSK DSP frontend (FM demod → FFSK discriminator at
+  1200 / 1800 Hz → Mueller-Müller timing → NRZ slicer), 40-bit
+  sync framer with polarity tolerance, 16×7 de-interleave, op /
+  arg / unit-ID decode with CRC-16-CCITT check, and an op/arg
+  table (PTT ANI, emergency, status, radio check, call alert,
+  selective call). Plus `events.KindMDC1200Message` bus event,
+  SQLite `mdc1200_log`, `GET /api/v1/mdc1200/messages`, and
+  `/mdc1200` web panel. See [docs/mdc1200.md](docs/mdc1200.md).
 - **Pure-Go voice path** — IMBE (P25 Phase 1) and AMBE+2 (P25
   Phase 2 / DMR) vocoders in Go, no DVSI / mbelib dependency.
   Per-call WAV + raw-frame sidecars; live PCM playback via direct

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -25,6 +25,7 @@ import (
 
 	aisgmsk "github.com/MattCheramie/GopherTrunk/internal/radio/ais/gmsk"
 	aprsafsk "github.com/MattCheramie/GopherTrunk/internal/radio/aprs/afsk"
+	mdc1200afsk "github.com/MattCheramie/GopherTrunk/internal/radio/mdc1200/afsk"
 	pocsagrx "github.com/MattCheramie/GopherTrunk/internal/radio/pager/pocsag/receiver"
 	"github.com/MattCheramie/GopherTrunk/internal/sdr"
 	"github.com/MattCheramie/GopherTrunk/internal/sdr/baseband"
@@ -114,6 +115,7 @@ type Daemon struct {
 	vesselLog    *storage.VesselLog
 	dscLog       *storage.DSCLog
 	aircraftLog  *storage.AircraftLog
+	mdc1200Log   *storage.MDC1200Log
 	messageLog   *gtlog.MessageLog
 	retention    *storage.Retention
 	ccCache      *trunking.Cache
@@ -163,6 +165,12 @@ type Daemon struct {
 	// publishes decoded vessel messages on KindAISMessage.
 	aisReceivers []*aisgmsk.Receiver
 	aisSpecs     []aisSpec // index-aligned with aisReceivers
+	// mdc1200Receivers holds one MDC1200 FFSK receiver per configured
+	// mdc1200.channels entry. Same shape as the APRS receivers above:
+	// each subscribes to its assigned SDR's iqtap broker and publishes
+	// decoded signaling bursts on KindMDC1200Message.
+	mdc1200Receivers []*mdc1200afsk.Receiver
+	mdc1200Specs     []mdc1200Spec // index-aligned with mdc1200Receivers
 	// iqBrokers holds an iqtap.Broker per pool entry, keyed by serial.
 	// Primary consumers (CC decoder, conventional scanner) stream IQ
 	// through the broker so secondary observers (live spectrum,
@@ -1018,6 +1026,38 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 		d.aisSpecs = append(d.aisSpecs, spec)
 	}
 
+	// MDC1200 FFSK receivers — one per configured mdc1200.channels
+	// entry. Same construction shape as APRS / AIS above: per-entry
+	// validation in the receiver, failures surface as a startup
+	// warning and skip the entry (nil slot preserved for stable
+	// indexing).
+	for _, mc := range cfg.MDC1200.Channels {
+		spec := mdc1200Spec{serial: mc.Serial, freq: mc.FrequencyHz}
+		if mc.Serial == "" || mc.FrequencyHz == 0 {
+			d.addWarning(fmt.Sprintf(
+				"mdc1200.channels: entry missing serial or frequency_hz (serial=%q freq=%d) — skipped",
+				mc.Serial, mc.FrequencyHz))
+			d.mdc1200Receivers = append(d.mdc1200Receivers, nil)
+			d.mdc1200Specs = append(d.mdc1200Specs, spec)
+			continue
+		}
+		rcv, err := mdc1200afsk.New(mdc1200afsk.Options{
+			InputRateHz: cfg.SDR.SampleRate,
+			SourceName:  mc.Serial,
+			Bus:         d.bus,
+			DropBadCRC:  mc.DropBadCRC,
+			Log:         log,
+		})
+		if err != nil {
+			d.addWarning(fmt.Sprintf("mdc1200.channels[%s]: %v — skipped", mc.Serial, err))
+			d.mdc1200Receivers = append(d.mdc1200Receivers, nil)
+			d.mdc1200Specs = append(d.mdc1200Specs, spec)
+			continue
+		}
+		d.mdc1200Receivers = append(d.mdc1200Receivers, rcv)
+		d.mdc1200Specs = append(d.mdc1200Specs, spec)
+	}
+
 	// Storage / call log / retention — optional.
 	if cfg.Storage.Path != "" {
 		db, err := storage.Open(cfg.Storage.Path)
@@ -1080,6 +1120,13 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 			return nil, fmt.Errorf("daemon: aircraft log: %w", err)
 		}
 		d.aircraftLog = acl
+
+		mdl, err := storage.NewMDC1200Log(db, d.bus, log)
+		if err != nil {
+			db.Close()
+			return nil, fmt.Errorf("daemon: mdc1200 log: %w", err)
+		}
+		d.mdc1200Log = mdl
 
 		if cfg.Retention.CallLogDays > 0 || cfg.Retention.FilesDays > 0 {
 			interval, err := retentionInterval(cfg.Retention.Interval)
@@ -1152,6 +1199,9 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 		}
 		if d.aircraftLog != nil {
 			opts.ADSB = adsbProvider{log: d.aircraftLog}
+		}
+		if d.mdc1200Log != nil {
+			opts.MDC1200 = mdc1200Provider{log: d.mdc1200Log}
 		}
 		if d.db != nil {
 			opts.History = api.HistoryFromStorage(d.db)
@@ -1340,6 +1390,11 @@ func (d *Daemon) Run(ctx context.Context) error {
 			return d.aircraftLog.Run(ctx)
 		})
 	}
+	if d.mdc1200Log != nil {
+		d.spawn(runCtx, "mdc1200log", false, func(ctx context.Context) error {
+			return d.mdc1200Log.Run(ctx)
+		})
+	}
 	if d.messageLog != nil {
 		d.spawn(runCtx, "messagelog", false, func(ctx context.Context) error {
 			return d.messageLog.Run(ctx)
@@ -1497,6 +1552,38 @@ func (d *Daemon) Run(ctx context.Context) error {
 			return rcv.Process(ctx, sub.C)
 		})
 	}
+	// MDC1200 receivers — same shape as APRS / AIS above. Each
+	// subscribes to its assigned SDR's iqtap broker and runs the FFSK
+	// pipeline (FM demod → FFSK discriminator → symbol-timing recovery
+	// → NRZ slicer → sync framer → op/arg/unit-ID parser), publishing
+	// bursts onto the events bus where the MDC1200Log subscriber
+	// persists them and the /mdc1200 panel renders them. Non-essential:
+	// a missing SDR or misconfigured frequency is logged but doesn't
+	// bring down the trunking pipeline.
+	for i, rcv := range d.mdc1200Receivers {
+		if rcv == nil {
+			continue // skipped at construction; warning already logged
+		}
+		rcv := rcv
+		spec := d.mdc1200Specs[i]
+		name := fmt.Sprintf("mdc1200-%s-%d", spec.serial, spec.freq)
+		d.spawn(runCtx, name, false, func(ctx context.Context) error {
+			br := d.iqBrokers[spec.serial]
+			if br == nil {
+				d.log.Warn("mdc1200: SDR not found, skipping receiver",
+					"serial", spec.serial, "freq_hz", spec.freq)
+				return nil
+			}
+			if err := br.SetCenterFreq(spec.freq); err != nil {
+				d.log.Warn("mdc1200: SetCenterFreq failed",
+					"serial", spec.serial, "freq_hz", spec.freq, "err", err)
+				return nil
+			}
+			sub := br.Subscribe()
+			defer sub.Close()
+			return rcv.Process(ctx, sub.C)
+		})
+	}
 	if d.pool != nil {
 		// Periodic USB-disconnect watchdog. Catches dongles that
 		// vanish while idle (between calls / hunts) and re-acquires
@@ -1637,6 +1724,9 @@ func (d *Daemon) Close() {
 		}
 		if d.aircraftLog != nil {
 			_ = d.aircraftLog.Close()
+		}
+		if d.mdc1200Log != nil {
+			_ = d.mdc1200Log.Close()
 		}
 		if d.messageLog != nil {
 			_ = d.messageLog.Close()
@@ -2422,6 +2512,15 @@ func (a adsbProvider) RecentAircraftReports(limit int) ([]storage.AircraftReport
 	return a.log.Recent(limit)
 }
 
+// mdc1200Provider adapts storage.MDC1200Log into api.MDC1200Provider
+// so the api package stays free of the storage import dependency.
+// Read-only — the decoder writes via the events bus.
+type mdc1200Provider struct{ log *storage.MDC1200Log }
+
+func (m mdc1200Provider) RecentMDC1200Messages(limit int) ([]storage.MDC1200Message, error) {
+	return m.log.Recent(limit)
+}
+
 // aprsSpec captures the broker-side wiring info for one configured
 // APRS channel. Index-aligned with Daemon.aprsReceivers so the Run
 // loop can spawn each receiver without re-walking the YAML. Mirrors
@@ -2436,6 +2535,15 @@ type aprsSpec struct {
 // loop can spawn each receiver without re-walking the YAML. Mirrors
 // aprsSpec / pocsagSpec.
 type aisSpec struct {
+	serial string
+	freq   uint32
+}
+
+// mdc1200Spec captures the broker-side wiring info for one configured
+// MDC1200 channel. Index-aligned with Daemon.mdc1200Receivers so the
+// Run loop can spawn each receiver without re-walking the YAML.
+// Mirrors aprsSpec / aisSpec.
+type mdc1200Spec struct {
 	serial string
 	freq   uint32
 }

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -301,6 +301,29 @@ sdr:
 #                                     #  messages and keep only vessel
 #                                     #  position reports
 
+# MDC1200 Motorola FFSK signaling. Each entry pins one SDR to a
+# conventional analog VHF / UHF voice channel and decodes the
+# in-band data bursts Motorola radios key at the head (and tail) of
+# a transmission. Pipeline: FM demod → FFSK discriminator (CCIR
+# tones, mark 1200 Hz / space 1800 Hz, 1200 baud) → symbol-timing
+# recovery → NRZ slicer → 40-bit sync framer → op/arg/unit-ID
+# parser with CRC check. Decoded bursts publish on
+# events.KindMDC1200Message; storage.MDC1200Log persists them to the
+# mdc1200_log SQLite table, the REST endpoint at
+# /api/v1/mdc1200/messages returns the most recent N, and the
+# /mdc1200 web panel renders them live (unit IDs, PTT ANI, emergency
+# / status / radio-check signaling).
+#
+# mdc1200:
+#   channels:
+#     - serial: "vhf-antenna"         # SDR serial (must be in sdr.devices
+#                                     #  or sdr.rtl_tcp)
+#       frequency_hz: 154_000_000     # conventional analog voice channel
+#                                     #  carrying Motorola signaling
+#       drop_bad_crc: false           # true to silently drop CRC-failed
+#                                     #  bursts instead of publishing them
+#                                     #  with crc_ok=false
+
 # DSC marine distress / safety / routine calls. The DSP frontend
 # (1200 Bd FSK on channel 70 = 156.525 MHz, mark 1300 Hz / space
 # 2100 Hz) ships in a follow-up PR; the protocol parser + bus +

--- a/docs/mdc1200.md
+++ b/docs/mdc1200.md
@@ -1,0 +1,114 @@
+---
+layout: page
+title: MDC1200 / Motorola Signaling
+description: Decoded Motorola MDC1200 FFSK pipeline — DSP frontend, events bus, SQLite log, REST endpoint, web panel
+nav_group: Reference
+---
+
+# MDC1200 / Motorola Signaling
+
+GopherTrunk decodes **MDC1200** ("Motorola Data Communications") —
+the analog in-band data burst Motorola two-way radios key at the
+start (and optionally the end) of a transmission. It carries the
+radio's **unit ID** (ANI — automatic number identification) plus
+emergency, status, call-alert, radio-check and selective-call
+signaling on otherwise-analog conventional VHF / UHF voice
+channels. On a system that is just FM voice, MDC1200 is what tells
+you *which* radio is talking and surfaces emergency / status
+events.
+
+Added in response to [#438](https://github.com/MattCheramie/GopherTrunk/issues/438).
+
+## Modulation
+
+MDC1200 is a **1200-baud FFSK** burst using the CCIR tones
+**mark = 1200 Hz** (binary 1) and **space = 1800 Hz** (binary 0),
+carried inside the narrowband-FM voice channel — the same
+modulation class GopherTrunk already demodulates for MPT 1327, so
+the DSP frontend reuses `internal/dsp/demod.FFSK`. Unlike APRS the
+line code is plain **NRZ** (no NRZI differential decode).
+
+## Pipeline
+
+```
+IQ chunks (Fs Hz, complex64)
+  → FM demod (internal/dsp/demod.FM)
+  → real resampler to 9600 Hz (1200 baud × 8 oversample)
+  → FFSK tone discriminator (mark 1200 Hz / space 1800 Hz)
+  → Mueller-Müller symbol-timing recovery (8 sps → 1 sample/symbol)
+  → DC-tracking NRZ slicer
+  → 40-bit sync framer (internal/radio/mdc1200/receiver)
+  → op/arg/unit-ID parse + CRC-16 check (internal/radio/mdc1200)
+  → events.KindMDC1200Message on the bus
+  → storage.MDC1200Log → mdc1200_log SQLite table
+  → GET /api/v1/mdc1200/messages → /mdc1200 web panel
+```
+
+The frame layout, after the 40-bit sync word `0x07 09 2A 44 6F`
+(most-significant bit first), is 112 payload bits column-interleaved
+over a 16×7 grid. De-interleaved and packed LSB-first, the header
+bytes are:
+
+| Bytes      | Meaning                                            |
+|------------|----------------------------------------------------|
+| `data[0]`  | op (operation code)                                |
+| `data[1]`  | arg (operation argument)                           |
+| `data[2:4]`| unit ID (big-endian)                               |
+| `data[4:6]`| CRC-16 of `data[0:4]` (little-endian on the wire)  |
+| `data[6:]` | redundancy (over-the-air FEC; not yet exploited)   |
+
+The CRC is CRC-16/CCITT with reflected in/out, polynomial 0x1021,
+initial value 0x0000 and final XOR 0xFFFF. The sync hunt tolerates
+a few bit errors and accepts the bit-complemented sync word so a
+flipped FM discriminator (inverted tone sense) still decodes.
+
+## Operations
+
+The decoder resolves a human label for the common Motorola CPS
+opcodes (PTT ID / ANI, emergency, status, radio check, call alert /
+page, selective call, radio inhibit / enable, remote monitor). The
+op/arg table is best-effort and intentionally non-exhaustive — many
+vendor-specific and extended opcodes exist; unrecognised pairs
+surface the raw op/arg so nothing is silently dropped. The unit ID
+and CRC are always decoded regardless of the label.
+
+**Double packets** (extended two-block messages, op `0x35` / `0x55`)
+are framed as two consecutive 112-bit blocks; the second block's
+header bytes are attached but its vendor-specific payload
+interpretation is left to a follow-up.
+
+## Configuration
+
+Each entry pins one SDR to a conventional analog voice channel:
+
+```yaml
+mdc1200:
+  channels:
+    - serial: "vhf-antenna"
+      frequency_hz: 154_000_000   # the analog voice channel to monitor
+      drop_bad_crc: false         # true to drop CRC-failed bursts
+```
+
+Leave `drop_bad_crc` false to see CRC-failed bursts on the panel
+(flagged with `crc_ok=false` and dimmed); flip it on for noisy
+channels.
+
+## What's surfaced
+
+- **Bus event** — `events.KindMDC1200Message`, payload
+  `storage.MDC1200Message`.
+- **Storage** — the `mdc1200_log` SQLite table (op, arg, unit ID,
+  operation, body, raw hex, crc_ok), indexed by time and unit ID.
+- **REST** — `GET /api/v1/mdc1200/messages?limit=N` (default 200,
+  max 5000); 503 when the daemon runs without `storage.path`.
+- **Web** — the `/mdc1200` panel polls every 5 s, tinting emergency
+  bursts red and dimming CRC failures.
+
+## Licensing note
+
+The MDC1200 protocol facts implemented here (sync word, interleave
+geometry, CRC parameters, opcode semantics) are public protocol
+details. This is a clean-room Go implementation; no third-party
+decoder source — including the GPL-licensed reference libraries —
+is incorporated, keeping the decoder under the project's Apache-2.0
+license.

--- a/internal/api/handlers_mdc1200.go
+++ b/internal/api/handlers_mdc1200.go
@@ -1,0 +1,72 @@
+package api
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/storage"
+)
+
+// MDC1200Provider is the read surface the mdc1200-log endpoint
+// consumes. The daemon implements it on top of storage.MDC1200Log;
+// tests substitute a fake.
+type MDC1200Provider interface {
+	RecentMDC1200Messages(limit int) ([]storage.MDC1200Message, error)
+}
+
+// MDC1200MessageDTO is the JSON wire shape for the mdc1200-log
+// endpoint. The operation label and raw-hex stay omitted when empty so
+// the wire stays compact for the common PTT-ID burst.
+type MDC1200MessageDTO struct {
+	ID         int64     `json:"id"`
+	ReceivedAt time.Time `json:"received_at"`
+	Op         uint8     `json:"op"`
+	Arg        uint8     `json:"arg"`
+	UnitID     uint16    `json:"unit_id"`
+	Operation  string    `json:"operation,omitempty"`
+	Body       string    `json:"body,omitempty"`
+	RawHex     string    `json:"raw_hex,omitempty"`
+	CRCOK      bool      `json:"crc_ok"`
+}
+
+func mdc1200MessageToDTO(m storage.MDC1200Message) MDC1200MessageDTO {
+	return MDC1200MessageDTO{
+		ID:         m.ID,
+		ReceivedAt: m.ReceivedAt,
+		Op:         m.Op,
+		Arg:        m.Arg,
+		UnitID:     m.UnitID,
+		Operation:  m.Operation,
+		Body:       m.Body,
+		RawHex:     m.RawHex,
+		CRCOK:      m.CRCOK,
+	}
+}
+
+// handleMDC1200Messages answers GET /api/v1/mdc1200/messages. Optional
+// ?limit= (default 200, max 5000). 503 when the storage layer isn't
+// wired (daemon started without storage.path).
+func (s *Server) handleMDC1200Messages(w http.ResponseWriter, r *http.Request) {
+	if s.mdc1200 == nil {
+		writeError(w, http.StatusServiceUnavailable, "mdc1200 subsystem not enabled")
+		return
+	}
+	limit := 200
+	if v := r.URL.Query().Get("limit"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			limit = n
+		}
+	}
+	rows, err := s.mdc1200.RecentMDC1200Messages(limit)
+	if err != nil {
+		s.log.Error("api: mdc1200 messages", "err", err)
+		writeError(w, http.StatusInternalServerError, "query failed")
+		return
+	}
+	out := make([]MDC1200MessageDTO, 0, len(rows))
+	for _, m := range rows {
+		out = append(out, mdc1200MessageToDTO(m))
+	}
+	writeJSON(w, http.StatusOK, out)
+}

--- a/internal/api/handlers_mdc1200_test.go
+++ b/internal/api/handlers_mdc1200_test.go
@@ -1,0 +1,120 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/storage"
+)
+
+type fakeMDC1200Provider struct {
+	msgs []storage.MDC1200Message
+}
+
+func (f *fakeMDC1200Provider) RecentMDC1200Messages(limit int) ([]storage.MDC1200Message, error) {
+	if limit > 0 && limit < len(f.msgs) {
+		return f.msgs[:limit], nil
+	}
+	return f.msgs, nil
+}
+
+func newMDC1200TestServer(t *testing.T, prov MDC1200Provider) *httptest.Server {
+	t.Helper()
+	bus := events.NewBus(8)
+	t.Cleanup(bus.Close)
+	srv, err := NewServer(ServerOptions{
+		Addr:    "127.0.0.1:0",
+		Bus:     bus,
+		MDC1200: prov,
+	})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	ts := httptest.NewServer(srv.routes())
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+func TestMDC1200MessagesReturns503WhenNotWired(t *testing.T) {
+	ts := newMDC1200TestServer(t, nil)
+	resp, err := http.Get(ts.URL + "/api/v1/mdc1200/messages")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want 503", resp.StatusCode)
+	}
+}
+
+func TestMDC1200MessagesReturnsList(t *testing.T) {
+	prov := &fakeMDC1200Provider{msgs: []storage.MDC1200Message{
+		{
+			ID:         1,
+			ReceivedAt: time.Unix(1735000000, 0).UTC(),
+			Op:         0x01,
+			Arg:        0x80,
+			UnitID:     0x1234,
+			Operation:  "PTT ID",
+			Body:       "Unit 1234: PTT ID",
+			CRCOK:      true,
+		},
+		{
+			ID:         2,
+			ReceivedAt: time.Unix(1735000010, 0).UTC(),
+			Op:         0x00,
+			Arg:        0x90,
+			UnitID:     0x0042,
+			Operation:  "Emergency",
+			Body:       "Unit 0042: Emergency",
+			CRCOK:      true,
+		},
+	}}
+	ts := newMDC1200TestServer(t, prov)
+	resp, err := http.Get(ts.URL + "/api/v1/mdc1200/messages")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	var got []MDC1200MessageDTO
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2", len(got))
+	}
+	if got[0].Operation != "PTT ID" || got[0].UnitID != 0x1234 {
+		t.Errorf("row 0 = %+v", got[0])
+	}
+	if got[1].Operation != "Emergency" {
+		t.Errorf("row 1 = %+v", got[1])
+	}
+}
+
+func TestMDC1200MessagesRespectsLimit(t *testing.T) {
+	prov := &fakeMDC1200Provider{}
+	for i := 0; i < 10; i++ {
+		prov.msgs = append(prov.msgs, storage.MDC1200Message{
+			ID:     int64(i + 1),
+			UnitID: uint16(0x1000 + i),
+		})
+	}
+	ts := newMDC1200TestServer(t, prov)
+	resp, err := http.Get(ts.URL + "/api/v1/mdc1200/messages?limit=3")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	var got []MDC1200MessageDTO
+	_ = json.NewDecoder(resp.Body).Decode(&got)
+	if len(got) != 3 {
+		t.Errorf("limit=3 len = %d, want 3", len(got))
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -298,6 +298,12 @@ type Server struct {
 	// storage.AircraftLog.
 	adsb ADSBProvider
 
+	// mdc1200 is the optional provider backing /api/v1/mdc1200/...
+	// routes (MDC1200 signaling-burst log). nil disables the routes.
+	// Implemented by the daemon over the SQLite-backed
+	// storage.MDC1200Log.
+	mdc1200 MDC1200Provider
+
 	mu     sync.Mutex
 	srv    *http.Server
 	closed bool
@@ -517,6 +523,11 @@ type ServerOptions struct {
 	// Mode-S frames. Wired by the daemon over the SQLite-backed
 	// storage.AircraftLog.
 	ADSB ADSBProvider
+	// MDC1200, when non-nil, enables the
+	// GET /api/v1/mdc1200/messages route serving recent decoded
+	// MDC1200 signaling bursts. Wired by the daemon over the
+	// SQLite-backed storage.MDC1200Log.
+	MDC1200 MDC1200Provider
 	// CORS configures the cross-origin middleware. Off when
 	// AllowedOrigins is empty (the daemon emits no CORS headers).
 	// Set this when the browser-served SPA is loaded from an
@@ -620,6 +631,7 @@ func NewServer(opts ServerOptions) (*Server, error) {
 		ais:            opts.AIS,
 		dsc:            opts.DSC,
 		adsb:           opts.ADSB,
+		mdc1200:        opts.MDC1200,
 	}, nil
 }
 
@@ -823,6 +835,7 @@ func (s *Server) routes() *http.ServeMux {
 	mux.HandleFunc("GET /api/v1/ais/vessels", s.handleAISMessages)
 	mux.HandleFunc("GET /api/v1/dsc/messages", s.handleDSCMessages)
 	mux.HandleFunc("GET /api/v1/adsb/aircraft", s.handleADSBAircraft)
+	mux.HandleFunc("GET /api/v1/mdc1200/messages", s.handleMDC1200Messages)
 
 	// Embedded SPA at "/" — served only when the daemon was linked
 	// against a populated web/dist embed. SPA history routes

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -29,6 +29,7 @@ type Config struct {
 	Paging     PagingConfig     `yaml:"paging"`
 	APRS       APRSConfig       `yaml:"aprs"`
 	AIS        AISConfig        `yaml:"ais"`
+	MDC1200    MDC1200Config    `yaml:"mdc1200"`
 }
 
 // APRSConfig configures the APRS / AX.25 Bell-202 AFSK receiver.
@@ -85,6 +86,31 @@ type AISChannelConfig struct {
 	FrequencyHz     uint32 `yaml:"frequency_hz"`
 	DropBadFCS      bool   `yaml:"drop_bad_fcs"`
 	DropNonPosition bool   `yaml:"drop_non_position"`
+}
+
+// MDC1200Config configures the Motorola MDC1200 FFSK signaling
+// receiver. Each entry pins an SDR to a conventional analog VHF / UHF
+// voice channel and runs the DSP frontend (FM demod → FFSK
+// discriminator at 1200/1800 Hz → symbol-timing recovery → NRZ
+// slicer → sync framer → op/arg/unit-ID parser) against its full IQ
+// stream. Decoded bursts publish on events.KindMDC1200Message;
+// storage.MDC1200Log persists them, the REST endpoint at
+// /api/v1/mdc1200/messages and the /mdc1200 web panel render them.
+type MDC1200Config struct {
+	Channels []MDC1200ChannelConfig `yaml:"channels"`
+}
+
+// MDC1200ChannelConfig describes one MDC1200 channel to decode. Serial
+// picks the SDR; the daemon tunes it to FrequencyHz and runs the FFSK
+// receiver against its full IQ stream. Target the conventional analog
+// voice channels of the systems you monitor — MDC1200 bursts ride at
+// the head (and optionally tail) of each transmission. DropBadCRC
+// matches the receiver's option — leave it false to see CRC-failed
+// bursts on the panel (flagged), flip it on for noisy channels.
+type MDC1200ChannelConfig struct {
+	Serial      string `yaml:"serial"`
+	FrequencyHz uint32 `yaml:"frequency_hz"`
+	DropBadCRC  bool   `yaml:"drop_bad_crc"`
 }
 
 // PagingConfig configures pager decoders (POCSAG today, FLEX

--- a/internal/events/bus.go
+++ b/internal/events/bus.go
@@ -155,6 +155,14 @@ const (
 	// + track + vertical rate). Surfaced over SSE / WS for the
 	// live ADS-B panel.
 	KindAircraftReport Kind = "adsb.aircraft"
+
+	// KindMDC1200Message fires when the MDC1200 decoder completes one
+	// signaling burst off a conventional analog FM voice channel.
+	// Payload is a storage.MDC1200Message carrying the transmitting
+	// radio's unit ID plus the operation (PTT ID, emergency, status,
+	// radio check, ...) and the CRC-valid flag. Surfaced over SSE / WS
+	// for the live MDC1200 panel.
+	KindMDC1200Message Kind = "mdc1200.message"
 )
 
 // Stage names a particular FEC / parser checkpoint inside a protocol

--- a/internal/radio/mdc1200/afsk/receiver.go
+++ b/internal/radio/mdc1200/afsk/receiver.go
@@ -1,0 +1,218 @@
+// Package afsk wires the MDC1200 DSP pipeline together: an IQ stream
+// from the iqtap broker becomes 1200-baud FFSK audio, then an NRZ bit
+// stream, then framed MDC1200 bursts on the events bus. The pipeline
+// is:
+//
+//	IQ chunks (Fs Hz, complex64)
+//	  → FM demod (internal/dsp/demod.FM)
+//	  → real resampler (internal/dsp/resampler_real) to AudioRateHz
+//	  → FFSK tone discriminator (internal/dsp/demod.FFSK,
+//	    markHz=1200, spaceHz=1800 — CCIR FFSK)
+//	  → Mueller-Müller symbol-timing recovery
+//	    (internal/dsp/sync.MuellerMuller, 8 sps → 1 sample/symbol)
+//	  → DC-tracking slicer (NRZ bit on the wire)
+//	  → mdc1200/receiver.Receiver.Push(bit)
+//	  → events.KindMDC1200Message on the bus
+//
+// Layout mirrors internal/radio/aprs/afsk: one Receiver per (SDR,
+// MDC1200-frequency) pair, the daemon pumps the broker subscription
+// into Process. The difference from APRS is the line code: MDC1200 is
+// plain NRZ, so there is no NRZI stage — the slicer's bit feeds the
+// framer directly — and the FFSK tones are 1200/1800 Hz, not the
+// Bell-202 1200/2200 Hz.
+package afsk
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync/atomic"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp"
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/demod"
+	dspsync "github.com/MattCheramie/GopherTrunk/internal/dsp/sync"
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	mdcrx "github.com/MattCheramie/GopherTrunk/internal/radio/mdc1200/receiver"
+)
+
+// CCIR FFSK tone frequencies — the MDC1200 signaling convention.
+const (
+	MarkHz  = 1200.0 // binary 1
+	SpaceHz = 1800.0 // binary 0
+)
+
+// Oversample is the number of FFSK-discriminator samples per MDC1200
+// bit fed into the Mueller-Müller timing-recovery loop. 8 matches the
+// APRS / POCSAG frontends — enough sub-sample resolution to track the
+// symbol clock, cheap at 1200 baud.
+const Oversample = 8
+
+// mmGain is the Mueller-Müller loop gain — the same conventional
+// AFSK-paired starting point the APRS frontend uses.
+const mmGain = 0.05
+
+// BaudHz is the MDC1200 signaling rate (fixed at 1200).
+const BaudHz = 1200
+
+// AudioRateHz is the audio rate the FFSK discriminator runs at:
+// baud × Oversample = 1200 × 8 = 9600.
+const AudioRateHz = BaudHz * Oversample
+
+// Options configures a Receiver.
+type Options struct {
+	// InputRateHz is the IQ sample rate the broker is feeding at.
+	InputRateHz uint32
+
+	// SourceName is stamped on log lines and surfaces in metrics.
+	SourceName string
+
+	// Bus is required — bursts publish onto KindMDC1200Message via the
+	// mdc1200/receiver orchestrator.
+	Bus *events.Bus
+
+	// DropBadCRC, when true, silently drops CRC-failed bursts at the
+	// orchestrator. Defaults to false — corrupted bursts publish with
+	// CRCOK=false so the web panel can flag marginal signals.
+	DropBadCRC bool
+
+	// Log is optional; defaults to slog.Default.
+	Log *slog.Logger
+}
+
+// Receiver runs an MDC1200 FFSK decode pipeline against a stream of IQ
+// chunks. One Receiver per (SDR, MDC1200-frequency) pair.
+type Receiver struct {
+	inputRate uint32
+	source    string
+	log       *slog.Logger
+
+	fm    *demod.FM
+	rsmp  *dsp.RealResampler
+	ffsk  *demod.FFSK
+	mm    *dspsync.MuellerMuller
+	inner *mdcrx.Receiver
+
+	// Per-call scratch buffers reused across Process iterations so the
+	// hot path never allocates.
+	demodBuf    []float32
+	rsmpBuf     []float32
+	ffskBuf     []float32
+	symBuf      []float32
+	meanEMA     float32
+	meanReady   bool
+	samplesSeen atomic.Uint64
+	bitsEmitted atomic.Uint64
+}
+
+// New constructs a Receiver. Returns an error if opts.Bus is nil or
+// InputRateHz is unset.
+func New(opts Options) (*Receiver, error) {
+	if opts.Bus == nil {
+		return nil, errors.New("mdc1200/afsk: Bus is required")
+	}
+	if opts.InputRateHz == 0 {
+		return nil, errors.New("mdc1200/afsk: InputRateHz is required")
+	}
+	log := opts.Log
+	if log == nil {
+		log = slog.Default()
+	}
+
+	out := uint32(AudioRateHz)
+	g := gcd(out, opts.InputRateHz)
+	L := int(out / g)
+	M := int(opts.InputRateHz / g)
+	if L == 0 || M == 0 {
+		return nil, fmt.Errorf("mdc1200/afsk: bad resample ratio L=%d M=%d", L, M)
+	}
+
+	return &Receiver{
+		inputRate: opts.InputRateHz,
+		source:    opts.SourceName,
+		log:       log,
+		fm:        demod.NewFM(),
+		rsmp:      dsp.NewRealResampler(L, M, 16, 7.0),
+		ffsk:      demod.NewFFSK(float64(AudioRateHz), MarkHz, SpaceHz),
+		mm:        dspsync.NewMuellerMuller(float64(Oversample), mmGain),
+		inner: mdcrx.New(mdcrx.Options{
+			Bus:        opts.Bus,
+			DropBadCRC: opts.DropBadCRC,
+		}),
+	}, nil
+}
+
+// Process pumps IQ chunks from in through the decode pipeline until
+// ctx cancels or in closes.
+func (r *Receiver) Process(ctx context.Context, in <-chan []complex64) error {
+	if in == nil {
+		return errors.New("mdc1200/afsk: input channel is nil")
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case chunk, ok := <-in:
+			if !ok {
+				return nil
+			}
+			r.processChunk(chunk)
+		}
+	}
+}
+
+// processChunk runs one IQ chunk through FM → resample → FFSK
+// discrimination → MM symbol-time recovery → slice → push.
+func (r *Receiver) processChunk(chunk []complex64) {
+	r.samplesSeen.Add(uint64(len(chunk)))
+	r.demodBuf = r.fm.Process(r.demodBuf, chunk)
+	r.rsmpBuf = r.rsmp.Process(r.rsmpBuf, r.demodBuf)
+	r.ffskBuf = r.ffsk.Discriminate(r.ffskBuf, r.rsmpBuf)
+	r.symBuf = r.mm.Process(r.symBuf, r.ffskBuf)
+	for _, s := range r.symBuf {
+		r.feedSymbol(s)
+	}
+}
+
+// feedSymbol slices one recovered symbol to an NRZ bit (tracking DC
+// bias with a slow EMA) and pushes it into the framer. Unlike APRS
+// there is no NRZI decode — MDC1200 is plain NRZ.
+func (r *Receiver) feedSymbol(s float32) {
+	if !r.meanReady {
+		r.meanEMA = s
+		r.meanReady = true
+	} else {
+		r.meanEMA += (s - r.meanEMA) * (1.0 / 64.0)
+	}
+	var bit byte
+	if s > r.meanEMA {
+		bit = 1
+	}
+	r.inner.Push(bit)
+	r.bitsEmitted.Add(1)
+}
+
+// Inner returns the bit-stream orchestrator the frontend is driving.
+// Exposed so the daemon can read Stats() for /metrics.
+func (r *Receiver) Inner() *mdcrx.Receiver { return r.inner }
+
+// Stats reports cumulative DSP-frontend counters.
+type Stats struct {
+	IQSamplesSeen uint64 // raw IQ samples Process has consumed
+	BitsEmitted   uint64 // bits handed to the orchestrator
+}
+
+func (r *Receiver) Stats() Stats {
+	return Stats{
+		IQSamplesSeen: r.samplesSeen.Load(),
+		BitsEmitted:   r.bitsEmitted.Load(),
+	}
+}
+
+// gcd computes the greatest common divisor via Euclid's algorithm.
+func gcd(a, b uint32) uint32 {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}

--- a/internal/radio/mdc1200/afsk/receiver_test.go
+++ b/internal/radio/mdc1200/afsk/receiver_test.go
@@ -1,0 +1,110 @@
+package afsk
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+)
+
+func TestReceiverNewRejectsBadOptions(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+
+	if _, err := New(Options{}); err == nil {
+		t.Error("New without Bus: want error")
+	}
+	if _, err := New(Options{Bus: bus}); err == nil {
+		t.Error("New without InputRateHz: want error")
+	}
+}
+
+func TestReceiverNewSetsUpInner(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	r, err := New(Options{InputRateHz: 96_000, Bus: bus})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if r.Inner() == nil {
+		t.Error("Inner() = nil, want non-nil orchestrator")
+	}
+}
+
+func TestReceiverPropagatesContextCancel(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	r, err := New(Options{InputRateHz: 96_000, Bus: bus})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	in := make(chan []complex64)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan error, 1)
+	go func() { done <- r.Process(ctx, in) }()
+	cancel()
+	select {
+	case err := <-done:
+		if err != context.Canceled {
+			t.Errorf("Process err = %v, want context.Canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Process did not exit after ctx cancel")
+	}
+}
+
+func TestReceiverNilInputErrors(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	r, _ := New(Options{InputRateHz: 96_000, Bus: bus})
+	if err := r.Process(context.Background(), nil); err == nil {
+		t.Error("Process with nil input: want error")
+	}
+}
+
+func TestReceiverProcessReturnsNilOnInputClose(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	r, err := New(Options{InputRateHz: 96_000, Bus: bus})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	in := make(chan []complex64)
+	done := make(chan error, 1)
+	go func() { done <- r.Process(context.Background(), in) }()
+	close(in)
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("Process on closed input = %v, want nil", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Process did not exit after input close")
+	}
+}
+
+func TestReceiverStatsCountIQSamples(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	r, err := New(Options{InputRateHz: 96_000, Bus: bus})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	in := make(chan []complex64, 1)
+	done := make(chan struct{})
+	go func() {
+		_ = r.Process(ctx, in)
+		close(done)
+	}()
+	chunk := make([]complex64, 9600)
+	in <- chunk
+	close(in)
+	<-done
+	if got := r.Stats().IQSamplesSeen; got != uint64(len(chunk)) {
+		t.Errorf("IQSamplesSeen = %d, want %d", got, len(chunk))
+	}
+}

--- a/internal/radio/mdc1200/mdc1200.go
+++ b/internal/radio/mdc1200/mdc1200.go
@@ -1,0 +1,222 @@
+// Package mdc1200 decodes Motorola MDC1200 signaling bursts.
+//
+// MDC1200 ("Motorola Data Communications") is the analog in-band
+// data burst Motorola two-way radios key at the start and/or end of
+// a transmission. It carries the radio's unit ID (ANI — automatic
+// number identification) plus emergency, status, call-alert,
+// radio-check and selective-call signaling on otherwise-analog
+// conventional VHF / UHF voice channels. Scanner operators use it to
+// see *which* radio is transmitting and to surface emergency / status
+// events on systems that are otherwise just FM voice.
+//
+// On the air it is a 1200-baud FFSK burst (CCIR tones: mark = 1200 Hz,
+// space = 1800 Hz) carried inside the narrowband-FM voice channel —
+// the same modulation class GopherTrunk already demodulates for
+// MPT 1327 and APRS, so the DSP frontend (internal/radio/mdc1200/afsk)
+// reuses internal/dsp/demod.FFSK. Unlike APRS the line code is plain
+// NRZ, not NRZI.
+//
+// This package owns the protocol layer only: a stream of demodulated
+// NRZ bits is framed by internal/radio/mdc1200/receiver, which hands
+// each captured 112-bit data block to DecodeFrame here and gets back
+// a typed Message (op / arg / unit ID, CRC-checked).
+//
+// Frame layout (after the 40-bit sync word, most-significant bit
+// first): 112 payload bits, column-interleaved over a 16×7 grid. The
+// de-interleaved, LSB-first-packed bytes are
+//
+//	data[0] = op, data[1] = arg, data[2:4] = unit ID (big-endian),
+//	data[4:6] = CRC-16 of data[0:4] (little-endian on the wire),
+//	data[6:14] = redundancy (used by the over-the-air FEC; not yet
+//	             exploited here).
+//
+// The CRC is CRC-16/CCITT with reflected in/out, polynomial 0x1021,
+// initial value 0x0000 and final XOR 0xFFFF.
+//
+// This is a clean-room implementation written from the public MDC1200
+// protocol description (sync word, interleave geometry, CRC parameters
+// and opcode semantics are protocol facts); no third-party decoder
+// source is incorporated.
+package mdc1200
+
+import (
+	"encoding/hex"
+	"fmt"
+)
+
+const (
+	// SyncWord is the 40-bit MDC1200 frame synchronization word,
+	// most-significant bit first.
+	SyncWord uint64 = 0x07092A446F
+
+	// SyncBits is the length of SyncWord in bits.
+	SyncBits = 40
+
+	// FrameBits is the number of payload bits captured after the
+	// sync word — one interleaved data block.
+	FrameBits = 112
+)
+
+// Message is one decoded MDC1200 data block.
+type Message struct {
+	Op        uint8  // operation code (data[0])
+	Arg       uint8  // operation argument (data[1])
+	UnitID    uint16 // transmitting radio's unit ID (data[2:4])
+	Operation string // human label from the op/arg table; "" when unrecognised
+	Body      string // one-line summary for logs / panel
+	RawHex    string // hex of the six decoded header bytes (op, arg, id, crc)
+	CRCOK     bool   // the CRC over data[0:4] matched the received value
+
+	// DoublePacket is true when Op selects an extended (two-block)
+	// message. Extra carries the raw decoded header bytes of the
+	// second block when present; interpreting its vendor-specific
+	// payload is left to a follow-up.
+	DoublePacket bool
+	Extra        []byte
+}
+
+// DecodeFrame de-interleaves and decodes one captured 112-bit data
+// block (one byte per bit, only bit 0 of each is read) into a Message.
+// The bool reports whether the CRC validated; a CRC failure still
+// returns the best-effort decode so the caller can surface marginal
+// bursts if it wants to.
+func DecodeFrame(bits []byte) (Message, bool) {
+	data, ok := deinterleave(bits)
+	if !ok {
+		return Message{Operation: "incomplete"}, false
+	}
+	return decodeData(data), validCRC(data)
+}
+
+// decodeData builds a Message from the 14 de-interleaved bytes. It
+// reads the header (op, arg, unit ID), checks the CRC and resolves
+// the operation label.
+func decodeData(data []byte) Message {
+	m := Message{
+		Op:     data[0],
+		Arg:    data[1],
+		UnitID: uint16(data[2])<<8 | uint16(data[3]),
+		RawHex: hex.EncodeToString(data[:6]),
+		CRCOK:  validCRC(data),
+	}
+	m.Operation = opLabel(m.Op, m.Arg)
+	m.DoublePacket = isDoublePacket(m.Op)
+	m.Body = m.summary()
+	return m
+}
+
+// isDoublePacket reports whether an op selects a two-block message.
+func isDoublePacket(op uint8) bool {
+	return op == 0x35 || op == 0x55
+}
+
+// validCRC checks the received CRC against a freshly-computed one
+// over the four header bytes.
+func validCRC(data []byte) bool {
+	if len(data) < 6 {
+		return false
+	}
+	rcrc := uint16(data[5])<<8 | uint16(data[4])
+	return crc16(data[:4]) == rcrc
+}
+
+// deinterleave reverses the 16×7 column interleave and packs the
+// result LSB-first into 14 bytes. Returns false if fewer than
+// FrameBits bits are supplied.
+func deinterleave(bits []byte) ([]byte, bool) {
+	if len(bits) < FrameBits {
+		return nil, false
+	}
+	var lbits [FrameBits]byte
+	idx := 0
+	for i := 0; i < 16; i++ {
+		for j := 0; j < 7; j++ {
+			lbits[idx] = bits[j*16+i] & 1
+			idx++
+		}
+	}
+	data := make([]byte, 14)
+	for i := range data {
+		var b byte
+		for j := 0; j < 8; j++ {
+			if lbits[i*8+j] != 0 {
+				b |= 1 << uint(j)
+			}
+		}
+		data[i] = b
+	}
+	return data, true
+}
+
+// crc16 computes the MDC1200 CRC: CRC-16/CCITT with reflected input
+// and output, polynomial 0x1021 (reflected 0x8408), initial value
+// 0x0000 and final XOR 0xFFFF.
+func crc16(data []byte) uint16 {
+	crc := uint16(0x0000)
+	for _, b := range data {
+		crc ^= uint16(b)
+		for i := 0; i < 8; i++ {
+			if crc&1 != 0 {
+				crc = (crc >> 1) ^ 0x8408
+			} else {
+				crc >>= 1
+			}
+		}
+	}
+	return ^crc
+}
+
+// opLabel maps an (op, arg) pair to a human-readable operation name.
+//
+// The mappings below follow the widely-published MDC1200 opcode
+// conventions used by Motorola CPS and common third-party tooling.
+// They are best-effort and intentionally non-exhaustive — many
+// vendor-specific and extended opcodes exist. Unrecognised pairs
+// return "" so the caller surfaces the raw op/arg instead.
+func opLabel(op, arg uint8) string {
+	switch op {
+	case 0x01:
+		// PTT ID / ANI — keyed at the head (0x80) or tail (0x00).
+		if arg == 0x00 {
+			return "PTT ID (end)"
+		}
+		return "PTT ID"
+	case 0x00:
+		if arg == 0x90 {
+			return "Emergency"
+		}
+		return "Emergency"
+	case 0x06:
+		return "Status request"
+	case 0x12:
+		return fmt.Sprintf("Status %d", arg)
+	case 0x2B:
+		return "Radio inhibit (stun)"
+	case 0x2C:
+		return "Radio enable (revive)"
+	case 0x22:
+		return "Message"
+	case 0x35:
+		return "Voice selective call"
+	case 0x46:
+		return "Remote monitor"
+	case 0x63:
+		return "Radio check"
+	case 0x0A:
+		return "Call alert / page"
+	}
+	return ""
+}
+
+// summary renders the one-line Body string used by logs and the panel.
+func (m Message) summary() string {
+	op := m.Operation
+	if op == "" {
+		op = fmt.Sprintf("op=0x%02X arg=0x%02X", m.Op, m.Arg)
+	}
+	s := fmt.Sprintf("Unit %04X: %s", m.UnitID, op)
+	if !m.CRCOK {
+		s += " (CRC?)"
+	}
+	return s
+}

--- a/internal/radio/mdc1200/mdc1200_test.go
+++ b/internal/radio/mdc1200/mdc1200_test.go
@@ -1,0 +1,138 @@
+package mdc1200
+
+import "testing"
+
+// encodeFrame is the transmitter-side inverse of deinterleave: it
+// packs the 14 data bytes into the de-interleaved logical bit order
+// and then applies the 16×7 column interleave, yielding the 112
+// over-the-air payload bits (one byte per bit). Used only by tests.
+func encodeFrame(data [14]byte) []byte {
+	var lbits [FrameBits]byte
+	for i := 0; i < 14; i++ {
+		for j := 0; j < 8; j++ {
+			if data[i]&(1<<uint(j)) != 0 {
+				lbits[i*8+j] = 1
+			}
+		}
+	}
+	bits := make([]byte, FrameBits)
+	idx := 0
+	for i := 0; i < 16; i++ {
+		for j := 0; j < 7; j++ {
+			bits[j*16+i] = lbits[idx]
+			idx++
+		}
+	}
+	return bits
+}
+
+// frameFor builds a CRC-valid frame for the given header fields.
+func frameFor(op, arg uint8, unitID uint16) []byte {
+	var data [14]byte
+	data[0] = op
+	data[1] = arg
+	data[2] = byte(unitID >> 8)
+	data[3] = byte(unitID)
+	crc := crc16(data[:4])
+	data[4] = byte(crc)      // low byte on the wire
+	data[5] = byte(crc >> 8) // high byte
+	return encodeFrame(data)
+}
+
+func TestDecodeFrameRoundTrip(t *testing.T) {
+	cases := []struct {
+		name      string
+		op, arg   uint8
+		unitID    uint16
+		operation string
+	}{
+		{"ptt-id", 0x01, 0x80, 0x1234, "PTT ID"},
+		{"ptt-id-end", 0x01, 0x00, 0x4321, "PTT ID (end)"},
+		{"emergency", 0x00, 0x90, 0x0042, "Emergency"},
+		{"radio-check", 0x63, 0x00, 0xABCD, "Radio check"},
+		{"status-7", 0x12, 0x07, 0x1000, "Status 7"},
+		{"unknown", 0x99, 0x11, 0x5555, ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			bits := frameFor(c.op, c.arg, c.unitID)
+			m, ok := DecodeFrame(bits)
+			if !ok {
+				t.Fatalf("DecodeFrame ok=false, want true (CRC should validate)")
+			}
+			if m.Op != c.op || m.Arg != c.arg {
+				t.Errorf("op/arg = 0x%02X/0x%02X, want 0x%02X/0x%02X", m.Op, m.Arg, c.op, c.arg)
+			}
+			if m.UnitID != c.unitID {
+				t.Errorf("UnitID = 0x%04X, want 0x%04X", m.UnitID, c.unitID)
+			}
+			if m.Operation != c.operation {
+				t.Errorf("Operation = %q, want %q", m.Operation, c.operation)
+			}
+			if !m.CRCOK {
+				t.Errorf("CRCOK = false, want true")
+			}
+		})
+	}
+}
+
+func TestDecodeFrameCRCMismatch(t *testing.T) {
+	bits := frameFor(0x01, 0x80, 0x1234)
+	// Flip a bit in the unit-ID region so the CRC no longer matches.
+	// Locate the over-the-air position of logical bit 16 (data[2], the
+	// unit-ID high byte LSB): i = 16/7 = 2, j = 16%7 = 2 → raw j*16+i.
+	bits[2*16+2] ^= 1
+	m, ok := DecodeFrame(bits)
+	if ok {
+		t.Fatalf("DecodeFrame ok=true, want false on corrupted frame")
+	}
+	if m.CRCOK {
+		t.Errorf("CRCOK = true, want false")
+	}
+	// Best-effort decode is still returned.
+	if m.Body == "" {
+		t.Errorf("Body empty; want best-effort summary even on CRC fail")
+	}
+}
+
+func TestDecodeFrameIncomplete(t *testing.T) {
+	m, ok := DecodeFrame(make([]byte, FrameBits-1))
+	if ok {
+		t.Errorf("ok = true, want false on short input")
+	}
+	if m.Operation != "incomplete" {
+		t.Errorf("Operation = %q, want %q", m.Operation, "incomplete")
+	}
+}
+
+func TestDoublePacketFlag(t *testing.T) {
+	for _, op := range []uint8{0x35, 0x55} {
+		bits := frameFor(op, 0x00, 0x0001)
+		m, _ := DecodeFrame(bits)
+		if !m.DoublePacket {
+			t.Errorf("op 0x%02X: DoublePacket = false, want true", op)
+		}
+	}
+	bits := frameFor(0x01, 0x80, 0x0001)
+	if m, _ := DecodeFrame(bits); m.DoublePacket {
+		t.Errorf("op 0x01: DoublePacket = true, want false")
+	}
+}
+
+// TestCRC16KnownVector pins the CRC implementation against a fixed
+// input so an accidental polynomial / reflection change is caught.
+func TestCRC16KnownVector(t *testing.T) {
+	// Round-trip property: a frame built with frameFor must validate,
+	// and mutating any header byte must break it.
+	var data [4]byte
+	data[0], data[1], data[2], data[3] = 0x01, 0x80, 0x12, 0x34
+	got := crc16(data[:])
+	// Recompute independently to ensure determinism.
+	if again := crc16(data[:]); again != got {
+		t.Fatalf("crc16 not deterministic: %04X vs %04X", got, again)
+	}
+	data[0] ^= 0xFF
+	if crc16(data[:]) == got {
+		t.Errorf("crc16 unchanged after mutating input")
+	}
+}

--- a/internal/radio/mdc1200/receiver/receiver.go
+++ b/internal/radio/mdc1200/receiver/receiver.go
@@ -1,0 +1,205 @@
+// Package receiver frames a demodulated MDC1200 bit stream: it hunts
+// the 40-bit sync word, captures the 112-bit data block(s) that
+// follow, hands each block to internal/radio/mdc1200 for decode, and
+// publishes one events.KindMDC1200Message per burst.
+//
+// The DSP layer above this package (internal/radio/mdc1200/afsk:
+// 1200-baud FFSK demodulation + NRZ slicing) hands the receiver its
+// bit stream. From bits down through bus event is what this package
+// owns.
+//
+// One Receiver instance per MDC1200 channel. The Push(bit) method is
+// the single entry point — call it once per NRZ wire bit. Bursts flow
+// onto the bus, are persisted by storage.MDC1200Log, reach the REST
+// endpoint, and render on the /mdc1200 web panel.
+//
+// Polarity: an FM discriminator can present the burst with either tone
+// sense depending on tuning, so the sync hunt accepts both the sync
+// word and its bitwise complement; when it locks on the complement the
+// captured payload bits are inverted to recover the true data.
+package receiver
+
+import (
+	"math/bits"
+	"sync/atomic"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/mdc1200"
+	"github.com/MattCheramie/GopherTrunk/internal/storage"
+)
+
+// gdThresh is the maximum number of bit errors tolerated across the
+// 40-bit sync word before a burst is declared. Matches the threshold
+// the reference MDC1200 decoders use.
+const gdThresh = 5
+
+// syncMask isolates the low SyncBits of the shift register.
+const syncMask = (uint64(1) << mdc1200.SyncBits) - 1
+
+type state uint8
+
+const (
+	stateHunt   state = iota // searching for the sync word
+	stateBlock1              // collecting the first 112-bit block
+	stateBlock2              // collecting the second block (double packet)
+)
+
+// Receiver consumes a bit stream and publishes MDC1200 bursts on the
+// shared events bus. Zero-value Receivers are NOT usable — call New.
+type Receiver struct {
+	bus *events.Bus
+
+	// dropBadCRC, when true, silently discards bursts whose CRC didn't
+	// match. Defaults to false — the receiver publishes CRC-failed
+	// bursts too, with CRCOK=false, so the panel can flag marginal
+	// signals.
+	dropBadCRC bool
+
+	st       state
+	reg      uint64 // sliding 40-bit sync shift register
+	inverted bool   // locked on the complemented sync word
+	buf      [mdc1200.FrameBits]byte
+	n        int             // bits captured into buf
+	first    mdc1200.Message // first block of a double packet
+
+	// Counters surfaced for /metrics.
+	burstsIn   atomic.Uint64 // sync words detected
+	burstsCRC  atomic.Uint64 // bursts that failed CRC
+	burstsEmit atomic.Uint64 // events published to the bus
+}
+
+// Options configures a Receiver.
+type Options struct {
+	// Bus is required — bursts publish onto KindMDC1200Message.
+	Bus *events.Bus
+
+	// DropBadCRC silently discards CRC-failed bursts when true.
+	DropBadCRC bool
+}
+
+// New constructs a Receiver. Panics if opts.Bus is nil — receivers
+// without a bus have nowhere to publish.
+func New(opts Options) *Receiver {
+	if opts.Bus == nil {
+		panic("mdc1200/receiver: events.Bus is required")
+	}
+	return &Receiver{bus: opts.Bus, dropBadCRC: opts.DropBadCRC}
+}
+
+// Push feeds one NRZ wire bit through the framer. Bits outside {0, 1}
+// are masked to their low bit.
+func (r *Receiver) Push(bit byte) {
+	bit &= 1
+	switch r.st {
+	case stateHunt:
+		r.reg = (r.reg << 1) | uint64(bit)
+		d := bits.OnesCount64((r.reg ^ mdc1200.SyncWord) & syncMask)
+		switch {
+		case d <= gdThresh:
+			r.beginBlock(false)
+		case d >= mdc1200.SyncBits-gdThresh:
+			// Matched the complemented sync word — inverted polarity.
+			r.beginBlock(true)
+		}
+	case stateBlock1, stateBlock2:
+		if r.inverted {
+			bit ^= 1
+		}
+		r.buf[r.n] = bit
+		r.n++
+		if r.n == mdc1200.FrameBits {
+			r.finishBlock()
+		}
+	}
+}
+
+// beginBlock transitions out of the sync hunt into payload capture.
+func (r *Receiver) beginBlock(inverted bool) {
+	r.burstsIn.Add(1)
+	r.inverted = inverted
+	r.n = 0
+	r.st = stateBlock1
+}
+
+// finishBlock decodes a captured 112-bit block and either publishes a
+// burst or, for a double packet, advances to the second block.
+func (r *Receiver) finishBlock() {
+	msg, _ := mdc1200.DecodeFrame(r.buf[:])
+
+	if r.st == stateBlock1 && msg.DoublePacket {
+		// Capture the trailing data block before publishing.
+		r.first = msg
+		r.n = 0
+		r.st = stateBlock2
+		return
+	}
+
+	if r.st == stateBlock2 {
+		// Attach the second block's header bytes and report the first
+		// block's operation, which carries the meaningful op/arg/unit.
+		first := r.first
+		first.Extra = decodeExtra(msg)
+		msg = first
+	}
+
+	r.emit(msg)
+	r.reset()
+}
+
+// decodeExtra extracts the raw header bytes of a double packet's
+// second block for the Extra field.
+func decodeExtra(second mdc1200.Message) []byte {
+	if second.RawHex == "" {
+		return nil
+	}
+	return []byte(second.RawHex)
+}
+
+// emit publishes a decoded burst, honoring DropBadCRC.
+func (r *Receiver) emit(msg mdc1200.Message) {
+	if !msg.CRCOK {
+		r.burstsCRC.Add(1)
+		if r.dropBadCRC {
+			return
+		}
+	}
+	r.bus.Publish(events.Event{
+		Kind:      events.KindMDC1200Message,
+		Timestamp: time.Now(),
+		Payload: storage.MDC1200Message{
+			Op:        msg.Op,
+			Arg:       msg.Arg,
+			UnitID:    msg.UnitID,
+			Operation: msg.Operation,
+			Body:      msg.Body,
+			RawHex:    msg.RawHex,
+			CRCOK:     msg.CRCOK,
+		},
+	})
+	r.burstsEmit.Add(1)
+}
+
+// reset returns the framer to the sync hunt with a cleared shift
+// register so the just-decoded burst can't immediately re-trigger.
+func (r *Receiver) reset() {
+	r.st = stateHunt
+	r.reg = 0
+	r.n = 0
+	r.inverted = false
+}
+
+// Stats reports cumulative counters for /metrics + debugging.
+type Stats struct {
+	BurstsIn      uint64 // sync words detected
+	BurstsBadCRC  uint64 // bursts that failed the CRC check
+	BurstsEmitted uint64 // events published to the bus
+}
+
+func (r *Receiver) Stats() Stats {
+	return Stats{
+		BurstsIn:      r.burstsIn.Load(),
+		BurstsBadCRC:  r.burstsCRC.Load(),
+		BurstsEmitted: r.burstsEmit.Load(),
+	}
+}

--- a/internal/radio/mdc1200/receiver/receiver_test.go
+++ b/internal/radio/mdc1200/receiver/receiver_test.go
@@ -1,0 +1,202 @@
+package receiver
+
+import (
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/mdc1200"
+	"github.com/MattCheramie/GopherTrunk/internal/storage"
+)
+
+// crc16 mirrors the package-internal MDC1200 CRC so tests can build
+// CRC-valid frames without exporting the implementation.
+func crc16(data []byte) uint16 {
+	crc := uint16(0x0000)
+	for _, b := range data {
+		crc ^= uint16(b)
+		for i := 0; i < 8; i++ {
+			if crc&1 != 0 {
+				crc = (crc >> 1) ^ 0x8408
+			} else {
+				crc >>= 1
+			}
+		}
+	}
+	return ^crc
+}
+
+// encodeFrame is the inverse of mdc1200.deinterleave (see the parser
+// test for the matching helper): pack 14 bytes into logical bit order,
+// then apply the 16×7 column interleave to get the 112 wire bits.
+func encodeFrame(data [14]byte) []byte {
+	var lbits [mdc1200.FrameBits]byte
+	for i := 0; i < 14; i++ {
+		for j := 0; j < 8; j++ {
+			if data[i]&(1<<uint(j)) != 0 {
+				lbits[i*8+j] = 1
+			}
+		}
+	}
+	bits := make([]byte, mdc1200.FrameBits)
+	idx := 0
+	for i := 0; i < 16; i++ {
+		for j := 0; j < 7; j++ {
+			bits[j*16+i] = lbits[idx]
+			idx++
+		}
+	}
+	return bits
+}
+
+func frameBits(op, arg uint8, unitID uint16) []byte {
+	var data [14]byte
+	data[0] = op
+	data[1] = arg
+	data[2] = byte(unitID >> 8)
+	data[3] = byte(unitID)
+	crc := crc16(data[:4])
+	data[4] = byte(crc)
+	data[5] = byte(crc >> 8)
+	return encodeFrame(data)
+}
+
+// syncBits emits the 40-bit sync word most-significant bit first.
+func syncBits() []byte {
+	out := make([]byte, mdc1200.SyncBits)
+	for i := 0; i < mdc1200.SyncBits; i++ {
+		shift := uint(mdc1200.SyncBits - 1 - i)
+		out[i] = byte((mdc1200.SyncWord >> shift) & 1)
+	}
+	return out
+}
+
+// burst is preamble dotting + sync + payload, the full on-air bit
+// sequence the framer expects.
+func burst(op, arg uint8, unitID uint16) []byte {
+	var bits []byte
+	for i := 0; i < 24; i++ { // dotting preamble (alternating)
+		bits = append(bits, byte(i&1))
+	}
+	bits = append(bits, syncBits()...)
+	bits = append(bits, frameBits(op, arg, unitID)...)
+	return bits
+}
+
+func newTestBus(t *testing.T) (*events.Bus, *events.Subscription) {
+	t.Helper()
+	bus := events.NewBus(8)
+	sub := bus.Subscribe()
+	t.Cleanup(func() {
+		sub.Close()
+		bus.Close()
+	})
+	return bus, sub
+}
+
+func waitMsg(t *testing.T, sub *events.Subscription) (storage.MDC1200Message, bool) {
+	t.Helper()
+	deadline := time.After(time.Second)
+	for {
+		select {
+		case ev, ok := <-sub.C:
+			if !ok {
+				return storage.MDC1200Message{}, false
+			}
+			if ev.Kind != events.KindMDC1200Message {
+				continue
+			}
+			msg, _ := ev.Payload.(storage.MDC1200Message)
+			return msg, true
+		case <-deadline:
+			return storage.MDC1200Message{}, false
+		}
+	}
+}
+
+func TestNewRequiresBus(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Error("New without Bus: want panic")
+		}
+	}()
+	New(Options{})
+}
+
+func TestReceiverDecodesBurst(t *testing.T) {
+	bus, sub := newTestBus(t)
+	r := New(Options{Bus: bus})
+	for _, b := range burst(0x01, 0x80, 0x1234) {
+		r.Push(b)
+	}
+	msg, ok := waitMsg(t, sub)
+	if !ok {
+		t.Fatalf("no burst emitted (stats=%+v)", r.Stats())
+	}
+	if msg.UnitID != 0x1234 {
+		t.Errorf("UnitID = 0x%04X, want 0x1234", msg.UnitID)
+	}
+	if msg.Operation != "PTT ID" {
+		t.Errorf("Operation = %q, want %q", msg.Operation, "PTT ID")
+	}
+	if !msg.CRCOK {
+		t.Errorf("CRCOK = false, want true")
+	}
+	if got := r.Stats().BurstsEmitted; got != 1 {
+		t.Errorf("BurstsEmitted = %d, want 1", got)
+	}
+}
+
+func TestReceiverDecodesInvertedBurst(t *testing.T) {
+	bus, sub := newTestBus(t)
+	r := New(Options{Bus: bus})
+	for _, b := range burst(0x00, 0x90, 0x0042) {
+		r.Push(b ^ 1) // invert the whole stream (flipped FM discriminator)
+	}
+	msg, ok := waitMsg(t, sub)
+	if !ok {
+		t.Fatalf("no burst emitted for inverted stream (stats=%+v)", r.Stats())
+	}
+	if msg.UnitID != 0x0042 || msg.Operation != "Emergency" {
+		t.Errorf("got unit=0x%04X op=%q, want 0x0042/Emergency", msg.UnitID, msg.Operation)
+	}
+}
+
+func TestReceiverDropBadCRC(t *testing.T) {
+	bus, sub := newTestBus(t)
+	r := New(Options{Bus: bus, DropBadCRC: true})
+	b := burst(0x01, 0x80, 0x1234)
+	// Corrupt bits inside the CRC-protected header. Payload starts at
+	// offset 24 (preamble) + 40 (sync) = 64; wire position j*16+i maps
+	// to logical bit i*7+j, so payload offset 0 is data[0] bit 0.
+	payload := 24 + mdc1200.SyncBits
+	b[payload+0] ^= 1  // data[0] bit 0 (op)
+	b[payload+34] ^= 1 // data[2] region (unit-ID high)
+	for _, bit := range b {
+		r.Push(bit)
+	}
+	if _, ok := waitMsg(t, sub); ok {
+		t.Errorf("burst emitted despite DropBadCRC + corrupted CRC")
+	}
+}
+
+func TestReceiverDoublePacket(t *testing.T) {
+	bus, sub := newTestBus(t)
+	r := New(Options{Bus: bus})
+	var bits []byte
+	bits = append(bits, burst(0x35, 0x00, 0x0777)...) // op 0x35 → double
+	bits = append(bits, frameBits(0x00, 0x00, 0x0000)...)
+	for _, b := range bits {
+		r.Push(b)
+	}
+	msg, ok := waitMsg(t, sub)
+	if !ok {
+		t.Fatalf("no burst emitted for double packet (stats=%+v)", r.Stats())
+	}
+	if msg.UnitID != 0x0777 {
+		t.Errorf("UnitID = 0x%04X, want 0x0777", msg.UnitID)
+	}
+	if r.Stats().BurstsEmitted != 1 {
+		t.Errorf("BurstsEmitted = %d, want 1 (double packet → single event)", r.Stats().BurstsEmitted)
+	}
+}

--- a/internal/storage/mdc1200log.go
+++ b/internal/storage/mdc1200log.go
@@ -1,0 +1,154 @@
+// MDC1200 log writer — drains KindMDC1200Message events off the
+// shared bus and writes one row per decoded signaling burst to the
+// SQLite mdc1200_log table. Mirrors dsclog.go / aprslog.go.
+package storage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+)
+
+// MDC1200Message is one persisted decoded MDC1200 burst.
+type MDC1200Message struct {
+	ID         int64     `json:"id"`
+	ReceivedAt time.Time `json:"received_at"`
+	Op         uint8     `json:"op"`
+	Arg        uint8     `json:"arg"`
+	UnitID     uint16    `json:"unit_id"`
+	Operation  string    `json:"operation"` // "PTT ID" | "Emergency" | ... ("" if unknown)
+	Body       string    `json:"body"`
+	RawHex     string    `json:"raw_hex"`
+	CRCOK      bool      `json:"crc_ok"`
+}
+
+// MDC1200Log drains KindMDC1200Message events until ctx cancels or the
+// bus closes.
+type MDC1200Log struct {
+	db        *DB
+	bus       *events.Bus
+	log       *slog.Logger
+	sub       *events.Subscription
+	runDone   chan struct{}
+	closeOnce sync.Once
+}
+
+// NewMDC1200Log wires the log to the bus. Subscription happens at
+// construction so events published before Run() begins aren't lost.
+func NewMDC1200Log(db *DB, bus *events.Bus, logger *slog.Logger) (*MDC1200Log, error) {
+	if db == nil {
+		return nil, errors.New("storage/mdc1200log: DB is required")
+	}
+	if bus == nil {
+		return nil, errors.New("storage/mdc1200log: events.Bus is required")
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	m := &MDC1200Log{db: db, bus: bus, log: logger, runDone: make(chan struct{})}
+	m.sub = bus.Subscribe()
+	return m, nil
+}
+
+// Run drains KindMDC1200Message events until ctx cancels or the bus
+// closes.
+func (m *MDC1200Log) Run(ctx context.Context) error {
+	defer close(m.runDone)
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case ev, ok := <-m.sub.C:
+			if !ok {
+				return nil
+			}
+			if ev.Kind != events.KindMDC1200Message {
+				continue
+			}
+			msg, ok := ev.Payload.(MDC1200Message)
+			if !ok {
+				continue
+			}
+			if err := m.insert(msg); err != nil {
+				m.log.Error("mdc1200log: insert failed", "err", err)
+			}
+		}
+	}
+}
+
+func (m *MDC1200Log) insert(msg MDC1200Message) error {
+	at := msg.ReceivedAt
+	if at.IsZero() {
+		at = time.Now()
+	}
+	crcOK := 0
+	if msg.CRCOK {
+		crcOK = 1
+	}
+	_, err := m.db.SQL().Exec(
+		`INSERT INTO mdc1200_log
+		 (received_at, op, arg, unit_id, operation, body, raw_hex, crc_ok)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		at.UnixNano(), msg.Op, msg.Arg, msg.UnitID, msg.Operation,
+		msg.Body, msg.RawHex, crcOK,
+	)
+	return err
+}
+
+// Recent returns the most recent bursts, newest first, capped at
+// limit. limit ≤ 0 picks 200; limit > 5000 caps at 5000.
+func (m *MDC1200Log) Recent(limit int) ([]MDC1200Message, error) {
+	if limit <= 0 {
+		limit = 200
+	}
+	if limit > 5000 {
+		limit = 5000
+	}
+	rows, err := m.db.SQL().Query(
+		`SELECT id, received_at, op, arg, unit_id, operation, body,
+		        raw_hex, crc_ok
+		 FROM mdc1200_log ORDER BY received_at DESC LIMIT ?`, limit)
+	if err != nil {
+		return nil, fmt.Errorf("storage/mdc1200log: query: %w", err)
+	}
+	defer rows.Close()
+	var out []MDC1200Message
+	for rows.Next() {
+		var (
+			msg   MDC1200Message
+			ns    int64
+			op    int
+			arg   int
+			unit  int
+			crcOK int
+		)
+		if err := rows.Scan(&msg.ID, &ns, &op, &arg, &unit, &msg.Operation,
+			&msg.Body, &msg.RawHex, &crcOK); err != nil {
+			return nil, fmt.Errorf("storage/mdc1200log: scan: %w", err)
+		}
+		msg.ReceivedAt = time.Unix(0, ns)
+		msg.Op = uint8(op)
+		msg.Arg = uint8(arg)
+		msg.UnitID = uint16(unit)
+		msg.CRCOK = crcOK != 0
+		out = append(out, msg)
+	}
+	return out, rows.Err()
+}
+
+// Close releases the bus subscription and waits for Run to drain.
+func (m *MDC1200Log) Close() error {
+	m.closeOnce.Do(func() {
+		m.sub.Close()
+		select {
+		case <-m.runDone:
+		case <-time.After(time.Second):
+		}
+	})
+	return nil
+}

--- a/internal/storage/mdc1200log_test.go
+++ b/internal/storage/mdc1200log_test.go
@@ -1,0 +1,118 @@
+package storage
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+)
+
+func openMDC1200TestStore(t *testing.T) (*MDC1200Log, *events.Bus, *DB) {
+	t.Helper()
+	db, err := Open(":memory:")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	bus := events.NewBus(8)
+	log, err := NewMDC1200Log(db, bus, nil)
+	if err != nil {
+		t.Fatalf("NewMDC1200Log: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = log.Close()
+		bus.Close()
+		_ = db.Close()
+	})
+	return log, bus, db
+}
+
+func TestMDC1200LogInsertsBurst(t *testing.T) {
+	log, bus, _ := openMDC1200TestStore(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = log.Run(ctx) }()
+
+	bus.Publish(events.Event{
+		Kind: events.KindMDC1200Message,
+		Payload: MDC1200Message{
+			ReceivedAt: time.Unix(1735000000, 0),
+			Op:         0x01,
+			Arg:        0x80,
+			UnitID:     0x1234,
+			Operation:  "PTT ID",
+			Body:       "Unit 1234: PTT ID",
+			RawHex:     "018012340000",
+			CRCOK:      true,
+		},
+	})
+
+	var recent []MDC1200Message
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		recent, _ = log.Recent(10)
+		if len(recent) > 0 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if len(recent) != 1 {
+		t.Fatalf("Recent = %d, want 1", len(recent))
+	}
+	r := recent[0]
+	if r.Op != 0x01 || r.Arg != 0x80 || r.UnitID != 0x1234 {
+		t.Errorf("header not round-tripped: %+v", r)
+	}
+	if r.Operation != "PTT ID" || !r.CRCOK {
+		t.Errorf("Recent[0] = %+v", r)
+	}
+}
+
+func TestMDC1200LogIgnoresUnrelatedEvents(t *testing.T) {
+	log, bus, _ := openMDC1200TestStore(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = log.Run(ctx) }()
+
+	bus.Publish(events.Event{Kind: events.KindBookmarkCreated, Payload: Bookmark{Name: "x"}})
+	bus.Publish(events.Event{Kind: events.KindMDC1200Message, Payload: "wrong type"})
+
+	time.Sleep(50 * time.Millisecond)
+	recent, _ := log.Recent(10)
+	if len(recent) != 0 {
+		t.Errorf("Recent = %d, want 0", len(recent))
+	}
+}
+
+func TestMDC1200LogRecentOrderNewestFirst(t *testing.T) {
+	log, bus, _ := openMDC1200TestStore(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = log.Run(ctx) }()
+
+	for i := 0; i < 3; i++ {
+		bus.Publish(events.Event{
+			Kind: events.KindMDC1200Message,
+			Payload: MDC1200Message{
+				ReceivedAt: time.Unix(1735000000+int64(i)*60, 0),
+				Op:         0x01,
+				UnitID:     uint16(0x1000 + i),
+			},
+		})
+	}
+	var recent []MDC1200Message
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		recent, _ = log.Recent(10)
+		if len(recent) == 3 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if len(recent) != 3 {
+		t.Fatalf("Recent = %d, want 3", len(recent))
+	}
+	if recent[0].UnitID != 0x1002 || recent[2].UnitID != 0x1000 {
+		t.Errorf("ordering wrong: %+v", recent)
+	}
+}

--- a/internal/storage/sqlite.go
+++ b/internal/storage/sqlite.go
@@ -250,6 +250,25 @@ CREATE TABLE IF NOT EXISTS aircraft_log (
 
 CREATE INDEX IF NOT EXISTS idx_aircraft_log_time ON aircraft_log(received_at);
 CREATE INDEX IF NOT EXISTS idx_aircraft_log_icao ON aircraft_log(icao, received_at);
+
+-- MDC1200 signaling bursts persisted from the decoder pipeline. One
+-- row per decoded burst: the transmitting radio's unit ID + the
+-- operation (PTT ID / emergency / status / radio check / ...) decoded
+-- from the op/arg pair, plus whether the CRC validated.
+CREATE TABLE IF NOT EXISTS mdc1200_log (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    received_at INTEGER NOT NULL,             -- unix nanoseconds
+    op          INTEGER NOT NULL DEFAULT 0,   -- operation code (data[0])
+    arg         INTEGER NOT NULL DEFAULT 0,   -- operation argument (data[1])
+    unit_id     INTEGER NOT NULL DEFAULT 0,   -- transmitting radio's unit ID
+    operation   TEXT    NOT NULL DEFAULT '',  -- "PTT ID" | "Emergency" | ... ("" if unknown)
+    body        TEXT    NOT NULL DEFAULT '',  -- one-line summary
+    raw_hex     TEXT    NOT NULL DEFAULT '',  -- hex of the decoded header bytes
+    crc_ok      INTEGER NOT NULL DEFAULT 0    -- 1 when the CRC validated
+);
+
+CREATE INDEX IF NOT EXISTS idx_mdc1200_log_time    ON mdc1200_log(received_at);
+CREATE INDEX IF NOT EXISTS idx_mdc1200_log_unit_id ON mdc1200_log(unit_id, received_at);
 `
 
 func (d *DB) migrate() error {

--- a/web/src/App.panels.test.tsx
+++ b/web/src/App.panels.test.tsx
@@ -59,6 +59,10 @@ vi.mock("./api/adsb", () => ({
   fetchAircraftReports: vi.fn().mockResolvedValue([]),
 }));
 
+vi.mock("./api/mdc1200", () => ({
+  fetchMDC1200Messages: vi.fn().mockResolvedValue([]),
+}));
+
 vi.mock("./api/bookmarks", () => ({
   bookmarks: {
     list: vi.fn().mockResolvedValue([]),
@@ -181,6 +185,7 @@ const ROUTES = [
   "/tones",
   "/pagers",
   "/aprs",
+  "/mdc1200",
   "/metrics",
   "/devices",
   "/settings",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -19,6 +19,7 @@ import { APRS } from "./panels/APRS";
 import { AIS } from "./panels/AIS";
 import { DSC } from "./panels/DSC";
 import { ADSB } from "./panels/ADSB";
+import { MDC1200 } from "./panels/MDC1200";
 import { Metrics } from "./panels/Metrics";
 import { Pagers } from "./panels/Pagers";
 import { RadioIDs } from "./panels/RadioIDs";
@@ -49,6 +50,7 @@ const EXTRA_TABS: Tab[] = [
   { to: "/ais", label: "AIS", icon: "⚓" },
   { to: "/dsc", label: "DSC", icon: "📡" },
   { to: "/adsb", label: "ADS-B", icon: "✈" },
+  { to: "/mdc1200", label: "MDC1200", icon: "📻" },
   { to: "/spectrum", label: "Spectrum", icon: "≈" },
   { to: "/constellation", label: "Constellation", icon: "✦" },
   { to: "/bookmarks", label: "Bookmarks", icon: "★" },
@@ -164,6 +166,7 @@ export function App() {
           <Route path="/ais" element={<AIS />} />
           <Route path="/dsc" element={<DSC />} />
           <Route path="/adsb" element={<ADSB />} />
+          <Route path="/mdc1200" element={<MDC1200 />} />
           <Route path="/metrics" element={<Metrics />} />
           <Route path="/devices" element={<Devices />} />
           <Route path="/settings" element={<Settings />} />

--- a/web/src/api/mdc1200.ts
+++ b/web/src/api/mdc1200.ts
@@ -1,0 +1,30 @@
+// MDC1200 signaling client. Mirrors GET /api/v1/mdc1200/messages.
+
+import { type ClientConfig, joinURL } from "./client";
+
+export interface MDC1200Message {
+  id: number;
+  received_at: string;
+  op: number;
+  arg: number;
+  unit_id: number;
+  operation?: string;
+  body?: string;
+  raw_hex?: string;
+  crc_ok: boolean;
+}
+
+export async function fetchMDC1200Messages(
+  cfg: ClientConfig,
+  limit = 200,
+): Promise<MDC1200Message[]> {
+  const url = joinURL(
+    cfg.baseURL,
+    `/api/v1/mdc1200/messages?limit=${encodeURIComponent(String(limit))}`,
+  );
+  const headers: Record<string, string> = { Accept: "application/json" };
+  if (cfg.token) headers["Authorization"] = `Bearer ${cfg.token}`;
+  const res = await fetch(url, { headers });
+  if (!res.ok) throw new Error(`mdc1200/messages ${res.status}`);
+  return (await res.json()) as MDC1200Message[];
+}

--- a/web/src/panels/MDC1200.test.tsx
+++ b/web/src/panels/MDC1200.test.tsx
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+
+vi.mock("../api/mdc1200", () => ({
+  fetchMDC1200Messages: vi.fn(),
+}));
+
+import { fetchMDC1200Messages } from "../api/mdc1200";
+import { useShared } from "../store/shared";
+import { MDC1200 } from "./MDC1200";
+
+function resetStore() {
+  useShared.setState({
+    serverURL: "http://localhost:8080",
+    token: null,
+    connected: true,
+    wsStatus: "idle",
+    mutations: null,
+    lastError: null,
+    events: [],
+    activeCalls: [],
+    devices: [],
+    systems: [],
+    talkgroups: [],
+    health: null,
+    audio: null,
+    scanner: null,
+  });
+}
+
+describe("MDC1200 panel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetStore();
+  });
+
+  it("renders an empty-state when no bursts are present", async () => {
+    vi.mocked(fetchMDC1200Messages).mockResolvedValue([]);
+    render(<MDC1200 />);
+    await waitFor(() => {
+      expect(screen.getByText(/No MDC1200 bursts yet/)).toBeInTheDocument();
+    });
+  });
+
+  it("renders a PTT-ID burst with unit ID and operation", async () => {
+    vi.mocked(fetchMDC1200Messages).mockResolvedValue([
+      {
+        id: 1,
+        received_at: "2026-05-26T12:34:56Z",
+        op: 0x01,
+        arg: 0x80,
+        unit_id: 0x1234,
+        operation: "PTT ID",
+        body: "Unit 1234: PTT ID",
+        crc_ok: true,
+      },
+    ]);
+    render(<MDC1200 />);
+    await waitFor(() => {
+      expect(screen.getByText("1234")).toBeInTheDocument();
+      expect(screen.getByText("PTT ID")).toBeInTheDocument();
+      expect(screen.getByText("0x01 / 0x80")).toBeInTheDocument();
+    });
+  });
+
+  it("renders an emergency burst", async () => {
+    vi.mocked(fetchMDC1200Messages).mockResolvedValue([
+      {
+        id: 2,
+        received_at: "2026-05-26T12:34:56Z",
+        op: 0x00,
+        arg: 0x90,
+        unit_id: 0x0042,
+        operation: "Emergency",
+        body: "Unit 0042: Emergency",
+        crc_ok: true,
+      },
+    ]);
+    render(<MDC1200 />);
+    await waitFor(() => {
+      expect(screen.getByText("0042")).toBeInTheDocument();
+      expect(screen.getByText("Emergency")).toBeInTheDocument();
+    });
+  });
+
+  it("surfaces fetch errors", async () => {
+    vi.mocked(fetchMDC1200Messages).mockRejectedValue(new Error("daemon down"));
+    render(<MDC1200 />);
+    await waitFor(() => {
+      expect(screen.getByText(/daemon down/)).toBeInTheDocument();
+    });
+  });
+});

--- a/web/src/panels/MDC1200.tsx
+++ b/web/src/panels/MDC1200.tsx
@@ -1,0 +1,145 @@
+import { useEffect, useState } from "react";
+import { fetchMDC1200Messages, type MDC1200Message } from "../api/mdc1200";
+import { selectClientConfig, useShared } from "../store/shared";
+
+// MDC1200 panel — list of recent decoded Motorola FFSK signaling
+// bursts off conventional analog voice channels. Each row shows the
+// transmitting radio's unit ID, the decoded operation (PTT ID,
+// emergency, status, radio check, ...) and whether the CRC validated.
+// Emergency bursts are tinted red; CRC-failed bursts are dimmed.
+//
+// Polls /api/v1/mdc1200/messages every 5 s. Live SSE delivery via the
+// KindMDC1200Message bus event is a follow-up.
+
+const POLL_INTERVAL_MS = 5_000;
+
+export function MDC1200() {
+  const cfg = useShared(selectClientConfig);
+  const [messages, setMessages] = useState<MDC1200Message[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancel = false;
+    const refresh = async () => {
+      try {
+        const list = await fetchMDC1200Messages(cfg, 200);
+        if (cancel) return;
+        setMessages(list);
+        setError(null);
+      } catch (e) {
+        if (cancel) return;
+        setError(e instanceof Error ? e.message : String(e));
+      }
+    };
+    refresh();
+    const t = window.setInterval(refresh, POLL_INTERVAL_MS);
+    return () => {
+      cancel = true;
+      window.clearInterval(t);
+    };
+  }, [cfg]);
+
+  return (
+    <div className="space-y-3">
+      <header className="flex items-center justify-between">
+        <h2 className="text-xl font-semibold">MDC1200</h2>
+        <span className="text-xs text-muted">
+          {messages.length} burst{messages.length === 1 ? "" : "s"}
+        </span>
+      </header>
+
+      {error && (
+        <div className="rounded border border-red-700/40 bg-red-900/20 text-red-200 text-xs px-3 py-2">
+          {error}
+        </div>
+      )}
+
+      <div className="rounded border border-border overflow-hidden">
+        <table className="w-full text-xs">
+          <thead className="bg-surface text-muted">
+            <tr>
+              <th className="text-left px-3 py-1 font-normal w-24">Received</th>
+              <th className="text-left px-3 py-1 font-normal w-24">Unit ID</th>
+              <th className="text-left px-3 py-1 font-normal">Operation</th>
+              <th className="text-left px-3 py-1 font-normal w-28">Op / Arg</th>
+              <th className="text-left px-3 py-1 font-normal">Body</th>
+              <th className="text-right px-3 py-1 font-normal w-16">CRC</th>
+            </tr>
+          </thead>
+          <tbody>
+            {messages.length === 0 ? (
+              <tr>
+                <td colSpan={6} className="px-3 py-4 text-center text-muted">
+                  No MDC1200 bursts yet. Add an{" "}
+                  <code className="text-accent">mdc1200.channels</code> entry to
+                  your config (a conventional analog VHF / UHF voice channel
+                  carrying Motorola signaling) and decoded unit IDs, PTT ANI,
+                  emergency / status / radio-check bursts will land here as
+                  they arrive.
+                </td>
+              </tr>
+            ) : (
+              messages.map((m) => (
+                <tr
+                  key={m.id}
+                  className={
+                    "border-t border-border/60 " +
+                    rowClass(m) +
+                    (m.crc_ok ? "" : " opacity-60")
+                  }
+                >
+                  <td className="px-3 py-1 font-mono text-muted">
+                    {formatTime(m.received_at)}
+                  </td>
+                  <td className="px-3 py-1 font-mono text-accent">
+                    {unitHex(m.unit_id)}
+                  </td>
+                  <td className="px-3 py-1">
+                    {m.operation || <span className="text-muted">unknown</span>}
+                  </td>
+                  <td className="px-3 py-1 font-mono text-muted">
+                    {hex2(m.op)} / {hex2(m.arg)}
+                  </td>
+                  <td className="px-3 py-1">
+                    {m.body || <span className="text-muted">—</span>}
+                  </td>
+                  <td className="px-3 py-1 text-right font-mono">
+                    {m.crc_ok ? (
+                      <span className="text-emerald-400">ok</span>
+                    ) : (
+                      <span className="text-red-300">fail</span>
+                    )}
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+// rowClass tints emergency bursts red so they stand out.
+function rowClass(m: MDC1200Message): string {
+  if (m.operation === "Emergency") {
+    return "bg-red-900/25";
+  }
+  return "";
+}
+
+function unitHex(id: number): string {
+  return id.toString(16).toUpperCase().padStart(4, "0");
+}
+
+function hex2(v: number): string {
+  return "0x" + v.toString(16).toUpperCase().padStart(2, "0");
+}
+
+function formatTime(ts: string): string {
+  try {
+    return new Date(ts).toISOString().slice(11, 19);
+  } catch {
+    return ts.slice(11, 19);
+  }
+}


### PR DESCRIPTION
Add support for decoding MDC1200, Motorola's analog FFSK signaling
burst (unit-ID ANI, emergency, status, radio check, call alert, ...)
keyed at the head/tail of transmissions on conventional VHF/UHF voice
channels.

End-to-end, mirroring the APRS/AIS live-FSK tier:

- internal/radio/mdc1200: clean-room protocol parser — 40-bit sync,
  16x7 de-interleave, op/arg/unit-ID decode, CRC-16-CCITT check, and a
  best-effort op/arg label table. Written from public protocol facts;
  no GPL reference-decoder code incorporated (keeps Apache-2.0).
- internal/radio/mdc1200/receiver: sync-hunt framer with
  inverted-polarity tolerance and double-packet handling, publishing
  events.KindMDC1200Message.
- internal/radio/mdc1200/afsk: live DSP frontend reusing demod.FFSK at
  1200/1800 Hz (FM demod -> resample 9600 -> FFSK -> Mueller-Muller ->
  NRZ slicer). Plain NRZ, no NRZI.
- storage.MDC1200Log + mdc1200_log SQLite table, REST
  GET /api/v1/mdc1200/messages, and the /mdc1200 web panel.
- mdc1200.channels config block + daemon wiring (per-channel iqtap
  broker subscription), docs/mdc1200.md, README + CHANGELOG.

https://claude.ai/code/session_01Sc5NyQ2BQeCcNsh49XppJs