### PR TITLE
Add selectable live audio controls to the web UI

### DIFF
--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -153,11 +153,11 @@ export const api = {
     if (opts.system) q.set("system", opts.system);
     if (opts.group_id != null) q.set("group_id", String(opts.group_id));
     const qs = q.toString();
-    return request<{ rows: CallRow[] }>(
+    return request<{ rows?: CallRow[]; calls?: CallRow[] }>(
       c,
       "GET",
       `/api/v1/calls/history${qs ? `?${qs}` : ""}`,
-    ).then((r) => r.rows ?? []);
+    ).then((r) => r.rows ?? r.calls ?? []);
   },
   devices: (c: ClientConfig) =>
     request<{ devices: DeviceDTO[] }>(c, "GET", "/api/v1/devices").then(

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -153,6 +153,9 @@ export const api = {
     if (opts.system) q.set("system", opts.system);
     if (opts.group_id != null) q.set("group_id", String(opts.group_id));
     const qs = q.toString();
+    // The Go handler currently emits `calls`. Accept `rows` as a temporary
+    // compatibility alias for older/local daemon builds that used the table
+    // naming; remove the fallback after those builds age out.
     return request<{ rows?: CallRow[]; calls?: CallRow[] }>(
       c,
       "GET",

--- a/web/src/api/format.ts
+++ b/web/src/api/format.ts
@@ -1,0 +1,6 @@
+export function formatHz(hz: number): string {
+  if (!Number.isFinite(hz)) return "—";
+  if (hz >= 1_000_000) return `${(hz / 1_000_000).toFixed(4)} MHz`;
+  if (hz >= 1_000) return `${(hz / 1_000).toFixed(3)} kHz`;
+  return `${hz} Hz`;
+}

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -93,6 +93,8 @@ export interface ActiveCallDTO {
   device_serial: string;
   started_at: string;
   ended_at?: string;
+  last_heard_at?: string;
+  signal_dbfs?: number;
 }
 
 export interface DeviceDTO {

--- a/web/src/components/AudioPlayer.test.tsx
+++ b/web/src/components/AudioPlayer.test.tsx
@@ -1,0 +1,162 @@
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AudioPlayer } from "./AudioPlayer";
+import { useShared } from "../store/shared";
+import type { ActiveCallDTO } from "../api/types";
+
+const activeCallsMock = vi.fn(() => Promise.resolve([] as ActiveCallDTO[]));
+
+vi.mock("../api/client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../api/client")>();
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      activeCalls: () => activeCallsMock(),
+    },
+  };
+});
+
+vi.mock("../api/write", () => ({
+  writes: {
+    setAudio: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+function call(overrides: Partial<ActiveCallDTO> & { group: number; tag: string }): ActiveCallDTO {
+  return {
+    grant: {
+      system: "Test System",
+      protocol: "p25",
+      group_id: overrides.group,
+      frequency_hz: 851_000_000 + overrides.group,
+      encrypted: false,
+      data_call: false,
+      ...overrides.grant,
+    },
+    talkgroup: { id: overrides.group, alpha_tag: overrides.tag },
+    device_serial: overrides.device_serial ?? `tap-${overrides.group}`,
+    started_at: overrides.started_at ?? `2026-05-29T12:00:${overrides.group % 60}.000Z`,
+    signal_dbfs: overrides.signal_dbfs,
+    ...overrides,
+  };
+}
+
+function resetStore(activeCalls: ActiveCallDTO[]) {
+  activeCallsMock.mockResolvedValue(activeCalls);
+  useShared.setState({
+    serverURL: "http://radio.test",
+    token: null,
+    activeCalls,
+    audio: null,
+  });
+}
+
+beforeEach(() => {
+  activeCallsMock.mockReset();
+  activeCallsMock.mockResolvedValue([]);
+  HTMLMediaElement.prototype.play = vi.fn().mockResolvedValue(undefined);
+  HTMLMediaElement.prototype.pause = vi.fn();
+  HTMLMediaElement.prototype.load = vi.fn();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("AudioPlayer", () => {
+  it("switches away when the selected call becomes encrypted", async () => {
+    const clearA = call({ group: 101, tag: "Clear A", signal_dbfs: -32 });
+    const clearB = call({ group: 202, tag: "Clear B", signal_dbfs: -35 });
+    resetStore([clearA, clearB]);
+
+    render(<AudioPlayer />);
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "Enable audio" })).not.toBeDisabled());
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Enable audio" }));
+      await Promise.resolve();
+    });
+    const audio = document.querySelector("audio") as HTMLAudioElement;
+    await waitFor(() => expect(audio.src).toContain("talkgroup=101"));
+
+    useShared.setState({
+      activeCalls: [{ ...clearA, grant: { ...clearA.grant, encrypted: true } }, clearB],
+    });
+
+    await waitFor(() => expect(audio.src).toContain("talkgroup=202"));
+    expect(screen.getByLabelText("Audio call")).toHaveTextContent("Clear B");
+  });
+
+  it("does not let an obsolete play rejection disable a newer stream", async () => {
+    const clearA = call({ group: 101, tag: "Clear A", signal_dbfs: -32 });
+    const clearB = call({ group: 202, tag: "Clear B", signal_dbfs: -35 });
+    resetStore([clearA, clearB]);
+
+    let rejectFirst!: (reason?: unknown) => void;
+    const play = vi
+      .spyOn(HTMLMediaElement.prototype, "play")
+      .mockImplementationOnce(
+        () => new Promise<void>((_, reject) => { rejectFirst = reject; }),
+      )
+      .mockResolvedValue(undefined);
+
+    render(<AudioPlayer />);
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "Enable audio" })).not.toBeDisabled());
+    const audio = document.querySelector("audio") as HTMLAudioElement;
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Enable audio" }));
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(rejectFirst).toBeTypeOf("function"));
+
+    await act(async () => {
+      useShared.setState({ activeCalls: [clearB] });
+    });
+    await waitFor(() => expect(audio.src).toContain("talkgroup=202"));
+
+    await act(async () => {
+      rejectFirst(new DOMException("aborted", "AbortError"));
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "Stop audio" })).toBeInTheDocument());
+    expect(play).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not overlap active-call polls", async () => {
+    vi.useFakeTimers();
+    const clearA = call({ group: 101, tag: "Clear A", signal_dbfs: -32 });
+    resetStore([clearA]);
+
+    let resolvePoll!: (calls: ActiveCallDTO[]) => void;
+    activeCallsMock.mockImplementation(
+      () => new Promise<ActiveCallDTO[]>((resolve) => { resolvePoll = resolve; }),
+    );
+
+    render(<AudioPlayer />);
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Enable audio" }));
+      await Promise.resolve();
+    });
+
+    expect(activeCallsMock).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3_000);
+    });
+    expect(activeCallsMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolvePoll([clearA]);
+      await Promise.resolve();
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_000);
+    });
+    expect(activeCallsMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/web/src/components/AudioPlayer.test.tsx
+++ b/web/src/components/AudioPlayer.test.tsx
@@ -36,7 +36,9 @@ function call(overrides: Partial<ActiveCallDTO> & { group: number; tag: string }
     },
     talkgroup: { id: overrides.group, alpha_tag: overrides.tag },
     device_serial: overrides.device_serial ?? `tap-${overrides.group}`,
-    started_at: overrides.started_at ?? `2026-05-29T12:00:${overrides.group % 60}.000Z`,
+    started_at:
+      overrides.started_at ??
+      `2026-05-29T12:00:${String(overrides.group % 60).padStart(2, "0")}.000Z`,
     signal_dbfs: overrides.signal_dbfs,
     ...overrides,
   };

--- a/web/src/components/AudioPlayer.tsx
+++ b/web/src/components/AudioPlayer.tsx
@@ -4,6 +4,7 @@ import { writes } from "../api/write";
 import { selectClientConfig, useShared } from "../store/shared";
 import { prefs } from "../store/prefs";
 import type { ActiveCallDTO } from "../api/types";
+import { formatHz } from "../api/format";
 
 // AudioPlayer is a floating, dismissable mini-player that streams
 // /api/v1/audio/stream into a long-lived <audio> element. iOS and
@@ -70,7 +71,7 @@ export function AudioPlayer() {
   // Guard against overlapping requests: slow radios or browsers should
   // not stack /calls/active polls.
   useEffect(() => {
-    if (!cfg.baseURL || (!enabled && selectedKey == null)) return;
+    if (!cfg.baseURL || !enabled) return;
     let cancel = false;
     const refresh = async () => {
       if (activePollInFlightRef.current) return;
@@ -91,7 +92,7 @@ export function AudioPlayer() {
       cancel = true;
       window.clearInterval(t);
     };
-  }, [cfg, enabled, selectedKey, setActiveCalls]);
+  }, [cfg, enabled, setActiveCalls]);
 
   const audioChoices = useMemo(() => {
     const strong = activeCalls.filter(isSelectableForAudio);
@@ -256,7 +257,7 @@ export function AudioPlayer() {
         >
           {audioChoices.map((c) => (
             <option key={callKey(c)} value={callKey(c)}>
-              {callLabel(c)} · {formatMHz(c.grant.frequency_hz)}
+              {callLabel(c)} · {formatHz(c.grant.frequency_hz)}
               {c.signal_dbfs == null ? "" : ` · ${c.signal_dbfs.toFixed(1)} dBFS`}
               {!hasUsableSignal(c) ? " · weak" : ""}
             </option>
@@ -349,6 +350,3 @@ export function AudioPlayer() {
   );
 }
 
-function formatMHz(hz: number): string {
-  return `${(hz / 1_000_000).toFixed(4)} MHz`;
-}

--- a/web/src/components/AudioPlayer.tsx
+++ b/web/src/components/AudioPlayer.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useRef, useState } from "react";
-import { audioStreamURL } from "../api/client";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { api, audioStreamURL } from "../api/client";
 import { writes } from "../api/write";
 import { selectClientConfig, useShared } from "../store/shared";
 import { prefs } from "../store/prefs";
+import type { ActiveCallDTO } from "../api/types";
 
 // AudioPlayer is a floating, dismissable mini-player that streams
 // /api/v1/audio/stream into a long-lived <audio> element. iOS and
@@ -16,14 +17,109 @@ import { prefs } from "../store/prefs";
 //     center with track-style metadata pulled from the active call.
 //   - The audio tag's `preload=none` + manual `src` swap keeps iOS
 //     from auto-starting the stream when the browser is reopened.
+function callKey(call: ActiveCallDTO): string {
+  return `${call.device_serial}|${call.grant.group_id}|${call.started_at}`;
+}
+
+function callLabel(call: ActiveCallDTO): string {
+  return call.talkgroup?.alpha_tag ?? `TG ${call.grant.group_id}`;
+}
+
+const AUDIO_MIN_SIGNAL_DBFS = -50;
+
+function hasUsableSignal(call: ActiveCallDTO): boolean {
+  return call.signal_dbfs == null || call.signal_dbfs >= AUDIO_MIN_SIGNAL_DBFS;
+}
+
+function isPlayable(call: ActiveCallDTO): boolean {
+  return !call.grant.encrypted && !call.grant.data_call;
+}
+
+function isSelectableForAudio(call: ActiveCallDTO): boolean {
+  return isPlayable(call) && hasUsableSignal(call);
+}
+
+function chooseDefaultCall(calls: ActiveCallDTO[]): ActiveCallDTO | null {
+  return calls.find(isSelectableForAudio) ?? calls.find(isPlayable) ?? null;
+}
+
+function stopAudioElement(el: HTMLAudioElement | null) {
+  if (!el) return;
+  el.pause();
+  el.removeAttribute("src");
+  el.load();
+}
+
 export function AudioPlayer() {
   const cfg = useShared(selectClientConfig);
   const activeCalls = useShared((s) => s.activeCalls);
+  const setActiveCalls = useShared((s) => s.setActiveCalls);
   const [enabled, setEnabled] = useState(false);
   const [muted, setMuted] = useState(false);
   const [volume, setVolume] = useState(prefs.audioVolume());
   const [recording, setRecording] = useState<boolean | null>(null);
+  const [selectedKey, setSelectedKey] = useState<string | null>(null);
+  const [manualSelection, setManualSelection] = useState(false);
   const audioRef = useRef<HTMLAudioElement | null>(null);
+  const playAttemptRef = useRef(0);
+  const streamURLRef = useRef<string | null>(null);
+  const activePollInFlightRef = useRef(false);
+
+  // Keep active calls fresh while the global player has a reason to
+  // make call-selection decisions outside the Dashboard/Active panels.
+  // Guard against overlapping requests: slow radios or browsers should
+  // not stack /calls/active polls.
+  useEffect(() => {
+    if (!cfg.baseURL || (!enabled && selectedKey == null)) return;
+    let cancel = false;
+    const refresh = async () => {
+      if (activePollInFlightRef.current) return;
+      activePollInFlightRef.current = true;
+      try {
+        const data = await api.activeCalls(cfg);
+        if (!cancel) setActiveCalls(data);
+      } catch {
+        // Leave the previous snapshot alone; other UI surfaces report
+        // request failures.
+      } finally {
+        activePollInFlightRef.current = false;
+      }
+    };
+    refresh();
+    const t = window.setInterval(refresh, 1_000);
+    return () => {
+      cancel = true;
+      window.clearInterval(t);
+    };
+  }, [cfg, enabled, selectedKey, setActiveCalls]);
+
+  const audioChoices = useMemo(() => {
+    const strong = activeCalls.filter(isSelectableForAudio);
+    if (strong.length > 0) return strong;
+    // Escape hatch: when every clear call is weak, still expose those
+    // options so the operator can force one instead of getting an empty
+    // selector. Encrypted/data calls stay hidden from the listening list.
+    return activeCalls.filter(isPlayable);
+  }, [activeCalls]);
+  const hiddenWeakPlayableCount = useMemo(
+    () => activeCalls.filter((c) => isPlayable(c) && !hasUsableSignal(c)).length,
+    [activeCalls],
+  );
+  const selectedCall = useMemo(
+    () => activeCalls.find((c) => callKey(c) === selectedKey) ?? null,
+    [activeCalls, selectedKey],
+  );
+
+  // Select exactly one call for playback. Manual choice sticks while
+  // that call is alive and playable; if it ends, becomes encrypted, or
+  // turns into a data call, switch to the next playable call.
+  useEffect(() => {
+    if (selectedCall && isPlayable(selectedCall)) return;
+    if (manualSelection) setManualSelection(false);
+    const next = chooseDefaultCall(activeCalls);
+    const nextKey = next ? callKey(next) : null;
+    setSelectedKey((current) => (current === nextKey ? current : nextKey));
+  }, [activeCalls, manualSelection, selectedCall]);
 
   // Reflect the daemon's current audio state into the local toggles.
   const daemonAudio = useShared((s) => s.audio);
@@ -37,7 +133,7 @@ export function AudioPlayer() {
   // metadata so the lock-screen shows what's playing.
   useEffect(() => {
     if (!("mediaSession" in navigator)) return;
-    const top = activeCalls[0];
+    const top = selectedCall;
     if (!top) {
       navigator.mediaSession.metadata = null;
       return;
@@ -48,30 +144,73 @@ export function AudioPlayer() {
       artist: top.grant.system,
       album: top.talkgroup?.group ?? "",
     });
-  }, [activeCalls]);
+  }, [selectedCall]);
 
-  const enable = async () => {
+  const streamURL = selectedCall && isPlayable(selectedCall)
+    ? audioStreamURL(cfg, {
+        device: selectedCall.device_serial,
+        talkgroup: selectedCall.grant.group_id,
+      })
+    : null;
+
+  const playStream = async () => {
     const el = audioRef.current;
-    if (!el || !cfg.baseURL) return;
-    el.src = audioStreamURL(cfg);
+    if (!el || !streamURL) return false;
+    const urlChanged = streamURLRef.current !== streamURL;
+    const attempt = urlChanged ? ++playAttemptRef.current : playAttemptRef.current;
+    const url = streamURL;
+    streamURLRef.current = url;
+    el.src = url;
     el.volume = volume;
-    el.muted = false;
+    el.muted = muted;
+    el.load();
     try {
       await el.play();
-      setEnabled(true);
+      return attempt === playAttemptRef.current && streamURLRef.current === url;
     } catch {
-      // Autoplay blocked. The next user gesture will retry.
-      setEnabled(false);
+      return false;
+    }
+  };
+
+  useEffect(() => {
+    if (!enabled) return;
+    const el = audioRef.current;
+    if (!streamURL) {
+      playAttemptRef.current += 1;
+      streamURLRef.current = null;
+      stopAudioElement(el);
+      return;
+    }
+    if (streamURLRef.current === streamURL) return;
+    void playStream();
+  }, [enabled, streamURL]);
+
+  const selectedCallPlayable = selectedCall != null && isPlayable(selectedCall);
+
+  const enable = async () => {
+    if (!cfg.baseURL) return;
+    if (!selectedCall || !isPlayable(selectedCall)) return;
+    // Chrome/Safari may keep play() pending on an open-ended WAV stream
+    // until enough PCM arrives. The user gesture already happened, so show
+    // the enabled controls immediately and only roll back on a real reject.
+    const attemptedURL = streamURL;
+    const attempt = ++playAttemptRef.current;
+    streamURLRef.current = streamURL;
+    setEnabled(true);
+    if (!(await playStream())) {
+      // Autoplay blocked or the stream failed. The next user gesture retries.
+      // Do not let an obsolete play() rejection from a prior src disable a
+      // newer stream that was selected while the promise was pending.
+      if (attempt === playAttemptRef.current && attemptedURL === streamURLRef.current) {
+        setEnabled(false);
+      }
     }
   };
 
   const disable = () => {
-    const el = audioRef.current;
-    if (el) {
-      el.pause();
-      el.removeAttribute("src");
-      el.load();
-    }
+    playAttemptRef.current += 1;
+    streamURLRef.current = null;
+    stopAudioElement(audioRef.current);
     setEnabled(false);
   };
 
@@ -105,14 +244,52 @@ export function AudioPlayer() {
   if (!cfg.baseURL) return null;
   return (
     <div className="fixed sm:bottom-3 bottom-16 right-3 z-30 panel p-3 flex items-center gap-2 max-w-[calc(100%-1.5rem)]">
+      {audioChoices.length > 0 && (
+        <select
+          value={selectedKey ?? ""}
+          onChange={(e) => {
+            setSelectedKey(e.target.value || null);
+            setManualSelection(!!e.target.value);
+          }}
+          aria-label="Audio call"
+          className="bg-bg border border-panel rounded px-2 py-1 text-xs max-w-44"
+        >
+          {audioChoices.map((c) => (
+            <option key={callKey(c)} value={callKey(c)}>
+              {callLabel(c)} · {formatMHz(c.grant.frequency_hz)}
+              {c.signal_dbfs == null ? "" : ` · ${c.signal_dbfs.toFixed(1)} dBFS`}
+              {!hasUsableSignal(c) ? " · weak" : ""}
+            </option>
+          ))}
+        </select>
+      )}
+      <span className="text-xs text-muted max-w-36 truncate">
+        {selectedCall
+          ? isSelectableForAudio(selectedCall)
+            ? callLabel(selectedCall)
+            : !isPlayable(selectedCall)
+              ? `${callLabel(selectedCall)} has no clear audio`
+              : `${callLabel(selectedCall)} is weak`
+          : activeCalls.length > 0
+            ? hiddenWeakPlayableCount > 0
+              ? `No strong clear audio (${hiddenWeakPlayableCount} weak)`
+              : "No clear audio"
+            : "No active audio"}
+      </span>
       {!enabled ? (
         <button
           type="button"
           onClick={enable}
-          className="btn-primary text-xs"
+          className="btn-primary text-xs disabled:opacity-50 disabled:cursor-not-allowed"
           aria-label="Enable audio"
+          disabled={!selectedCallPlayable}
         >
-          <span aria-hidden>▶</span> Tap to enable audio
+          <span aria-hidden>▶</span>{" "}
+          {selectedCallPlayable
+            ? isSelectableForAudio(selectedCall)
+              ? "Tap to enable audio"
+              : "Tap to enable weak audio"
+            : "No clear audio"}
         </button>
       ) : (
         <>
@@ -170,4 +347,8 @@ export function AudioPlayer() {
       />
     </div>
   );
+}
+
+function formatMHz(hz: number): string {
+  return `${(hz / 1_000_000).toFixed(4)} MHz`;
 }

--- a/web/src/components/AudioPlayer.tsx
+++ b/web/src/components/AudioPlayer.tsx
@@ -349,4 +349,3 @@ export function AudioPlayer() {
     </div>
   );
 }
-

--- a/web/src/panels/Active.tsx
+++ b/web/src/panels/Active.tsx
@@ -91,6 +91,17 @@ export function Active() {
             b.talkgroup?.alpha_tag ?? "",
           ),
       },
+
+      {
+        key: "frequency",
+        header: "Frequency",
+        render: (r) => (
+          <span className="font-mono text-xs tabular-nums">
+            {formatHz(r.grant.frequency_hz)}
+          </span>
+        ),
+        sort: (a, b) => a.grant.frequency_hz - b.grant.frequency_hz,
+      },
       {
         key: "system",
         header: "System",
@@ -98,6 +109,12 @@ export function Active() {
         sort: (a, b) => a.grant.system.localeCompare(b.grant.system),
         className: "hidden md:table-cell",
         headerClassName: "hidden md:table-cell",
+      },
+      {
+        key: "signal",
+        header: "Signal",
+        render: (r) => <SignalBadge dbfs={r.signal_dbfs} />,
+        sort: (a, b) => (a.signal_dbfs ?? -999) - (b.signal_dbfs ?? -999),
       },
       {
         key: "flags",
@@ -302,4 +319,12 @@ function formatHz(hz: number): string {
   if (hz >= 1_000_000) return `${(hz / 1_000_000).toFixed(4)} MHz`;
   if (hz >= 1_000) return `${(hz / 1_000).toFixed(3)} kHz`;
   return `${hz} Hz`;
+}
+
+function SignalBadge({ dbfs }: { dbfs?: number }) {
+  if (dbfs == null || !Number.isFinite(dbfs)) {
+    return <span className="text-xs text-muted">—</span>;
+  }
+  const cls = dbfs > -30 ? "pill-ok" : dbfs > -40 ? "pill-warn" : "pill-err";
+  return <span className={`${cls} font-mono tabular-nums`}>{dbfs.toFixed(1)} dBFS</span>;
 }

--- a/web/src/panels/Active.tsx
+++ b/web/src/panels/Active.tsx
@@ -6,6 +6,7 @@ import { ConfirmModal } from "../components/ConfirmModal";
 import { DetailField, DetailModal } from "../components/DetailModal";
 import type { ActiveCallDTO } from "../api/types";
 import { formatP25Algorithm, formatP25KeyID } from "../api/p25Algorithm";
+import { formatHz } from "../api/format";
 import {
   selectCanMutate,
   selectClientConfig,
@@ -314,12 +315,6 @@ function elapsed(startedAt: string, now: number): string {
   return `${m.toString().padStart(2, "0")}:${s.toString().padStart(2, "0")}`;
 }
 
-function formatHz(hz: number): string {
-  if (!Number.isFinite(hz)) return "—";
-  if (hz >= 1_000_000) return `${(hz / 1_000_000).toFixed(4)} MHz`;
-  if (hz >= 1_000) return `${(hz / 1_000).toFixed(3)} kHz`;
-  return `${hz} Hz`;
-}
 
 function SignalBadge({ dbfs }: { dbfs?: number }) {
   if (dbfs == null || !Number.isFinite(dbfs)) {

--- a/web/src/panels/Dashboard.tsx
+++ b/web/src/panels/Dashboard.tsx
@@ -127,6 +127,7 @@ export function Dashboard() {
                 <span className="text-sm">
                   {c.talkgroup?.alpha_tag ?? c.grant.system}
                 </span>
+                <CallAudioBadge encrypted={!!c.grant.encrypted} data={!!c.grant.data_call} />
                 <span className="ml-auto text-xs text-muted">
                   {c.device_serial}
                 </span>
@@ -160,4 +161,10 @@ function StatCard({
       </p>
     </div>
   );
+}
+
+function CallAudioBadge({ encrypted, data }: { encrypted: boolean; data: boolean }) {
+  if (encrypted) return <span className="pill-warn text-[10px]">encrypted</span>;
+  if (data) return <span className="pill text-[10px]">data</span>;
+  return <span className="pill-ok text-[10px]">clear audio</span>;
 }

--- a/web/src/store/shared.ts
+++ b/web/src/store/shared.ts
@@ -64,8 +64,12 @@ interface SharedState {
   reset(): void;
 }
 
+function initialServerURL(): string | null {
+  return prefs.serverURL();
+}
+
 export const useShared = create<SharedState>((set, get) => ({
-  serverURL: prefs.serverURL(),
+  serverURL: initialServerURL(),
   token: prefs.token(),
   rememberToken: prefs.rememberToken(),
   connected: false,
@@ -156,6 +160,7 @@ export const useShared = create<SharedState>((set, get) => ({
         ...ac,
         grant: {
           ...ac.grant,
+          encrypted: true,
           algorithm_id: p.algorithm_id,
           key_id: p.key_id,
         },

--- a/web/src/store/shared.ts
+++ b/web/src/store/shared.ts
@@ -64,12 +64,8 @@ interface SharedState {
   reset(): void;
 }
 
-function initialServerURL(): string | null {
-  return prefs.serverURL();
-}
-
 export const useShared = create<SharedState>((set, get) => ({
-  serverURL: initialServerURL(),
+  serverURL: prefs.serverURL(),
   token: prefs.token(),
   rememberToken: prefs.rememberToken(),
   connected: false,


### PR DESCRIPTION
## Summary

This improves the web UI around active-call audio selection, stream switching, and call status visibility.

The audio player now narrows playback to one selected playable call using device and talkgroup identity. It prefers strong clear voice calls, hides weak clear calls while stronger clear audio is available, and excludes encrypted/data calls from playback candidates. If the selected call ends or becomes encrypted/data, playback switches to another eligible call or clears the selection.

It also guards stale `audio.play()` rejection handling so an older failed play attempt cannot disable a newer stream, and avoids overlapping active-call polls while the player needs fresh selection state.

Additional UI/API updates:
- Active calls show Frequency and Signal.
- Dashboard cards show simple audio-state badges.
- `call.encryption` websocket events update active-call state, including `grant.encrypted`.
- API client accepts both `rows` and `calls` history response aliases.

## Testing

- `git diff --check`
- `cd web && npm test -- --run AudioPlayer`
  - Passed: 3 tests
- `cd web && npm test -- --run`
  - Passed: 21 files, 118 tests
- `cd web && npm run build`
  - Passed

## Hardware smoke test

Ran a hardware smoke test with `rtl_tcp`/`librtlsdr` using an RTL-SDR stick. GopherTrunk attached the `rtltcp` device, locked AWIN Site045 on `859.7625`, and served the updated PR UI/API.

Limitation: no second/voice SDR was available during the smoke test, so live audio playback was not fully validated end to end with real voice traffic.
