### PR TITLE
hackrf: add configurable RF amp hint

### DIFF
--- a/cmd/gophertrunk/ccdecoder_retry_test.go
+++ b/cmd/gophertrunk/ccdecoder_retry_test.go
@@ -252,6 +252,7 @@ func (d *reacquireSDRDevice) SetSampleRate(hz uint32) error { d.sampleRate = hz;
 func (d *reacquireSDRDevice) SetGain(int) error             { return nil }
 func (d *reacquireSDRDevice) SetPPM(int) error              { return nil }
 func (d *reacquireSDRDevice) SetBiasTee(bool) error         { return nil }
+func (d *reacquireSDRDevice) SetAmp(bool) error             { return nil }
 func (d *reacquireSDRDevice) Close() error                  { d.closed.Store(true); return nil }
 func (d *reacquireSDRDevice) StreamIQ(ctx context.Context) (<-chan []complex64, error) {
 	if d.closed.Load() {

--- a/cmd/gophertrunk/config_template.go
+++ b/cmd/gophertrunk/config_template.go
@@ -78,6 +78,7 @@ type wizardSDR struct {
 	PPM     int
 	Gain    string // "auto" or tenths-of-dB integer ("496" = 49.6 dB)
 	BiasTee bool
+	Amp     bool
 }
 
 // defaultWizardAnswers seeds the wizard with values that satisfy
@@ -261,6 +262,7 @@ sdr:
       ppm: {{.PPM}}
       gain: {{yamlString .Gain}}        # "auto" or tenths-of-dB string ("496" = 49.6 dB)
       bias_tee: {{.BiasTee}}
+      amp: {{.Amp}}
 {{- end}}
 {{- else}}
   # devices is empty — the daemon will start but won't lock any control
@@ -273,6 +275,7 @@ sdr:
   #     ppm: 0                 # 0 is fine for TCXO-equipped units (NESDR Smart v5)
   #     gain: "auto"           # "auto" or tenths-of-dB ("496" = 49.6 dB)
   #     bias_tee: false
+  #     amp: false            # HackRF RF amp; leave false unless needed
 {{- end}}
 
 trunking:

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -403,6 +403,9 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 					h = h.WithGain(gain)
 				}
 			}
+			if dev.Amp {
+				h = h.WithAmp(true)
+			}
 			hints = append(hints, h)
 		}
 		// Mount baseband replay recordings as virtual tuners. The

--- a/cmd/gophertrunk/spectrum_provider_test.go
+++ b/cmd/gophertrunk/spectrum_provider_test.go
@@ -42,6 +42,7 @@ func (s *streamingFakeDevice) SetSampleRate(hz uint32) error {
 func (s *streamingFakeDevice) SetGain(int) error     { return nil }
 func (s *streamingFakeDevice) SetPPM(int) error      { return nil }
 func (s *streamingFakeDevice) SetBiasTee(bool) error { return nil }
+func (s *streamingFakeDevice) SetAmp(bool) error     { return nil }
 func (s *streamingFakeDevice) Close() error          { s.closes.Add(1); return nil }
 
 func (s *streamingFakeDevice) StreamIQ(ctx context.Context) (<-chan []complex64, error) {

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -125,11 +125,13 @@ sdr:
       ppm: 0               # 0 is fine for TCXO-equipped units like the NESDR Smart v5
       gain: "auto"         # "auto" or a tenths-of-dB string ("496" = 49.6 dB)
       bias_tee: false      # enable the 5V bias-tee output for an external LNA
+      amp: false           # HackRF RF amp; leave false unless needed
     - serial: "00000002"
       role: voice
       ppm: 0
       gain: "auto"
       bias_tee: false
+      amp: false
 
     # role: wideband pins one dongle to a centre frequency and lets a
     # single SDR cover several carriers that all live inside its

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -443,6 +443,10 @@ type DeviceConfig struct {
 	// GPIO bit that goes nowhere — librtlsdr accepts the call
 	// either way.
 	BiasTee bool `yaml:"bias_tee"`
+	// Amp toggles a driver-specific RF amplifier stage when present.
+	// Currently used by HackRF for its separate RF amp; devices without
+	// a modeled RF amp ignore false and warn on true.
+	Amp bool `yaml:"amp"`
 
 	// CenterFreqHz pins a `role: wideband` dongle to the centre of
 	// the IQ band it should cover. Every Channels[].FrequencyHz must

--- a/internal/sdr/airspy/airspy.go
+++ b/internal/sdr/airspy/airspy.go
@@ -336,6 +336,8 @@ func (d *Device) setMixerAGC(on bool) error {
 func (d *Device) SetPPM(int) error { return nil }
 
 // SetBiasTee toggles the bias-T on the antenna SMA.
+func (d *Device) SetAmp(bool) error { return nil }
+
 func (d *Device) SetBiasTee(enable bool) error {
 	if d.isClosed() {
 		return usb.ErrClosed

--- a/internal/sdr/airspy/airspy.go
+++ b/internal/sdr/airspy/airspy.go
@@ -335,9 +335,10 @@ func (d *Device) setMixerAGC(on bool) error {
 // internally trimmed and the libairspy protocol carries no PPM.
 func (d *Device) SetPPM(int) error { return nil }
 
-// SetBiasTee toggles the bias-T on the antenna SMA.
+// SetAmp is a no-op for Airspy; it has no separate RF amp stage.
 func (d *Device) SetAmp(bool) error { return nil }
 
+// SetBiasTee toggles the bias-T on the antenna SMA.
 func (d *Device) SetBiasTee(enable bool) error {
 	if d.isClosed() {
 		return usb.ErrClosed

--- a/internal/sdr/airspyhf/airspyhf.go
+++ b/internal/sdr/airspyhf/airspyhf.go
@@ -312,10 +312,11 @@ func (d *Device) SetGain(tenthDB int) error {
 // and the libairspyhf wire protocol carries no PPM register.
 func (d *Device) SetPPM(int) error { return nil }
 
-// SetBiasTee toggles the bias-T on the antenna SMA. Dual Port units
-// only expose this on the SMA-1 / HF port; SMA-2 (VHF) is unaffected.
+// SetAmp is a no-op for Airspy HF+; it has no separate RF amp stage.
 func (d *Device) SetAmp(bool) error { return nil }
 
+// SetBiasTee toggles the bias-T on the antenna SMA. Dual Port units
+// only expose this on the SMA-1 / HF port; SMA-2 (VHF) is unaffected.
 func (d *Device) SetBiasTee(enable bool) error {
 	if d.isClosed() {
 		return usb.ErrClosed

--- a/internal/sdr/airspyhf/airspyhf.go
+++ b/internal/sdr/airspyhf/airspyhf.go
@@ -314,6 +314,8 @@ func (d *Device) SetPPM(int) error { return nil }
 
 // SetBiasTee toggles the bias-T on the antenna SMA. Dual Port units
 // only expose this on the SMA-1 / HF port; SMA-2 (VHF) is unaffected.
+func (d *Device) SetAmp(bool) error { return nil }
+
 func (d *Device) SetBiasTee(enable bool) error {
 	if d.isClosed() {
 		return usb.ErrClosed

--- a/internal/sdr/baseband/baseband_test.go
+++ b/internal/sdr/baseband/baseband_test.go
@@ -68,6 +68,7 @@ func (f *fakeDevice) SetCenterFreq(uint32) error { return nil }
 func (f *fakeDevice) SetGain(int) error          { return nil }
 func (f *fakeDevice) SetPPM(int) error           { return nil }
 func (f *fakeDevice) SetBiasTee(bool) error      { return nil }
+func (f *fakeDevice) SetAmp(bool) error          { return nil }
 func (f *fakeDevice) Close() error               { return nil }
 func (f *fakeDevice) SetSampleRate(hz uint32) error {
 	f.rate = hz

--- a/internal/sdr/baseband/driver.go
+++ b/internal/sdr/baseband/driver.go
@@ -110,6 +110,7 @@ func (d *replayDevice) SetCenterFreq(uint32) error { return nil }
 func (d *replayDevice) SetGain(int) error          { return nil }
 func (d *replayDevice) SetPPM(int) error           { return nil }
 func (d *replayDevice) SetBiasTee(bool) error      { return nil }
+func (d *replayDevice) SetAmp(bool) error          { return nil }
 func (d *replayDevice) Close() error               { return nil }
 
 // SetSampleRate overrides the metering rate. A real-time replay needs

--- a/internal/sdr/baseband/recorder.go
+++ b/internal/sdr/baseband/recorder.go
@@ -41,6 +41,7 @@ func (r *RecordingDevice) SetCenterFreq(hz uint32) error { return r.inner.SetCen
 func (r *RecordingDevice) SetGain(tenthDB int) error     { return r.inner.SetGain(tenthDB) }
 func (r *RecordingDevice) SetPPM(ppm int) error          { return r.inner.SetPPM(ppm) }
 func (r *RecordingDevice) SetBiasTee(enable bool) error  { return r.inner.SetBiasTee(enable) }
+func (r *RecordingDevice) SetAmp(enable bool) error      { return r.inner.SetAmp(enable) }
 func (r *RecordingDevice) Close() error                  { return r.inner.Close() }
 
 // SetSampleRate records the rate (for the WAV header) and forwards it.

--- a/internal/sdr/device.go
+++ b/internal/sdr/device.go
@@ -71,6 +71,9 @@ type Device interface {
 	// the circuit silently no-op. Implementations should return nil
 	// if the underlying driver doesn't model bias-tee at all.
 	SetBiasTee(enable bool) error
+	// SetAmp toggles a driver-specific RF amplifier stage when present.
+	// Devices without a separate RF amp should no-op and return nil.
+	SetAmp(enable bool) error
 	StreamIQ(ctx context.Context) (<-chan []complex64, error)
 	Close() error
 }

--- a/internal/sdr/hackrf/hackrf.go
+++ b/internal/sdr/hackrf/hackrf.go
@@ -82,7 +82,7 @@ const (
 	defaultSampleRateHz uint32 = 8_000_000
 	defaultLNAGainDB           = 16
 	defaultVGAGainDB           = 20
-	controlTimeoutMs           = 1000
+	controlTimeoutMs           = 5000
 )
 
 // Driver implements sdr.Driver for HackRF.
@@ -124,7 +124,7 @@ func (d *Driver) Enumerate() ([]sdr.Info, error) {
 	out := make([]sdr.Info, len(descs))
 	for i, desc := range descs {
 		serial := desc.Serial
-		if serial == "" {
+		if !isRealSerial(serial) {
 			serial = fmt.Sprintf("hackrf-%02d", i)
 		}
 		out[i] = sdr.Info{
@@ -183,7 +183,7 @@ func (d *Driver) Open(idx int) (sdr.Device, error) {
 		return nil, fmt.Errorf("hackrf: claim interface 0: %w", err)
 	}
 	serial := desc.Serial
-	if serial == "" {
+	if !isRealSerial(serial) {
 		serial = fmt.Sprintf("hackrf-%02d", idx)
 	}
 	// Best-effort: ask the firmware which board it actually is and
@@ -266,6 +266,18 @@ func cleanVersionString(buf []byte) string {
 func isPortaPack(v string) bool {
 	lv := strings.ToLower(v)
 	return strings.Contains(lv, "portapack") || strings.Contains(lv, "mayhem")
+}
+
+func isRealSerial(serial string) bool {
+	if serial == "" {
+		return false
+	}
+	for _, r := range serial {
+		if r != 0 {
+			return true
+		}
+	}
+	return false
 }
 
 // Device is one opened HackRF.
@@ -393,6 +405,14 @@ func (d *Device) amp(on bool) error {
 		v = 1
 	}
 	return d.t.ControlOut(reqAmpEnable, v, 0, nil, controlTimeoutMs)
+}
+
+// SetAmp toggles the HackRF's separate RF amplifier stage.
+func (d *Device) SetAmp(on bool) error {
+	if d.isClosed() {
+		return usb.ErrClosed
+	}
+	return d.amp(on)
 }
 
 // SetPPM is a no-op for HackRF — the Si5351C reference clock is

--- a/internal/sdr/hackrf/hackrf_test.go
+++ b/internal/sdr/hackrf/hackrf_test.go
@@ -65,6 +65,41 @@ func TestDriverEnumerateAndOpen(t *testing.T) {
 	}
 }
 
+func TestDriverEnumerateAndOpenUseSameFallbackSerial(t *testing.T) {
+	enum := &usb.MockEnumerator{
+		Devices: []usb.Descriptor{
+			{Bus: 1, Address: 7, VID: vidHackRF, PID: pidHackRFOne, Serial: "\x00\x00\x00", Product: "HackRF One", Path: "mock/1"},
+		},
+		OpenFunc: func(usb.Descriptor) (*usb.MockTransport, error) {
+			mt := usb.NewMockTransport()
+			mt.Script = []usb.CtrlExchange{
+				{In: true, BRequest: reqBoardIDRead, Reply: []byte{2}, N: 1},
+				{In: true, BRequest: reqVersionStringRead, Reply: []byte("git-2024.02.1\x00"), N: 255},
+			}
+			return mt, nil
+		},
+	}
+	drv := New(enum)
+	infos, err := drv.Enumerate()
+	if err != nil {
+		t.Fatalf("Enumerate: %v", err)
+	}
+	if len(infos) != 1 {
+		t.Fatalf("infos = %d, want 1", len(infos))
+	}
+	if infos[0].Serial != "hackrf-00" {
+		t.Fatalf("Enumerate serial = %q, want hackrf-00", infos[0].Serial)
+	}
+	dev, err := drv.Open(0)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer dev.Close()
+	if dev.Info().Serial != infos[0].Serial {
+		t.Fatalf("Open serial = %q, want Enumerate serial %q", dev.Info().Serial, infos[0].Serial)
+	}
+}
+
 func TestEnumerateRenamesByPID(t *testing.T) {
 	// Even when the USB descriptor Product is garbage, the canonical
 	// name comes from the PID.
@@ -311,6 +346,23 @@ func TestSetGainIssuesAMPLNAVGA(t *testing.T) {
 	}
 	if mt.Err != nil {
 		t.Fatalf("transport error: %v", mt.Err)
+	}
+}
+
+func TestSetAmpRoundTrips(t *testing.T) {
+	dev, mt := withDevice(t)
+	mt.Script = []usb.CtrlExchange{
+		{BRequest: reqAmpEnable, WValue: 1},
+		{BRequest: reqAmpEnable, WValue: 0},
+	}
+	if err := dev.SetAmp(true); err != nil {
+		t.Fatalf("SetAmp(on): %v", err)
+	}
+	if err := dev.SetAmp(false); err != nil {
+		t.Fatalf("SetAmp(off): %v", err)
+	}
+	if mt.Err != nil {
+		t.Fatalf("transport: %v", mt.Err)
 	}
 }
 

--- a/internal/sdr/iqtap/broker.go
+++ b/internal/sdr/iqtap/broker.go
@@ -197,6 +197,12 @@ func (b *Broker) SetPPM(ppm int) error {
 	return b.inner.SetPPM(ppm)
 }
 
+func (b *Broker) SetAmp(enable bool) error {
+	b.innerMu.RLock()
+	defer b.innerMu.RUnlock()
+	return b.inner.SetAmp(enable)
+}
+
 func (b *Broker) SetBiasTee(enable bool) error {
 	b.innerMu.RLock()
 	defer b.innerMu.RUnlock()
@@ -254,21 +260,8 @@ func (b *Broker) StreamIQ(ctx context.Context) (<-chan []complex64, error) {
 // per subscriber — drops are counted but never block the primary.
 func (b *Broker) fanout(chunk []complex64) {
 	b.subsMu.Lock()
-	if len(b.subs) == 0 {
-		b.subsMu.Unlock()
-		return
-	}
-	// Snapshot the subscriber set so we can drop the lock before
-	// allocating + sending — a concurrent Subscribe / Close can't
-	// race a send into a closed channel because Close transitions
-	// the closed flag under the same lock we just dropped.
-	subs := make([]*Subscriber, 0, len(b.subs))
+	defer b.subsMu.Unlock()
 	for s := range b.subs {
-		subs = append(subs, s)
-	}
-	b.subsMu.Unlock()
-
-	for _, s := range subs {
 		if s.closed.Load() {
 			continue
 		}

--- a/internal/sdr/iqtap/broker_test.go
+++ b/internal/sdr/iqtap/broker_test.go
@@ -41,6 +41,7 @@ func (f *fakeDevice) SetSampleRate(hz uint32) error { f.sampleRate.Store(hz); re
 func (f *fakeDevice) SetGain(g int) error           { f.gain.Store(int32(g)); return nil }
 func (f *fakeDevice) SetPPM(int) error              { return nil }
 func (f *fakeDevice) SetBiasTee(bool) error         { return nil }
+func (f *fakeDevice) SetAmp(bool) error             { return nil }
 func (f *fakeDevice) Close() error                  { f.closes.Add(1); return nil }
 
 func (f *fakeDevice) StreamIQ(ctx context.Context) (<-chan []complex64, error) {

--- a/internal/sdr/mock.go
+++ b/internal/sdr/mock.go
@@ -59,6 +59,7 @@ func (d *MockDevice) SetCenterFreq(uint32) error { return nil }
 func (d *MockDevice) SetGain(int) error          { return nil }
 func (d *MockDevice) SetPPM(int) error           { return nil }
 func (d *MockDevice) SetBiasTee(bool) error      { return nil }
+func (d *MockDevice) SetAmp(bool) error          { return nil }
 func (d *MockDevice) SetSampleRate(hz uint32) error {
 	d.sampleRate = hz
 	return nil
@@ -159,6 +160,7 @@ func (d *mockF32Device) SetCenterFreq(uint32) error    { return nil }
 func (d *mockF32Device) SetGain(int) error             { return nil }
 func (d *mockF32Device) SetPPM(int) error              { return nil }
 func (d *mockF32Device) SetBiasTee(bool) error         { return nil }
+func (d *mockF32Device) SetAmp(bool) error             { return nil }
 func (d *mockF32Device) SetSampleRate(hz uint32) error { d.sampleRate = hz; return nil }
 func (d *mockF32Device) Close() error                  { return nil }
 

--- a/internal/sdr/pool.go
+++ b/internal/sdr/pool.go
@@ -274,7 +274,7 @@ func (p *Pool) OpenWith(opts PoolOpenOptions) error {
 		}
 		entry := &PoolEntry{Driver: d.drv, Device: dev, Info: info, Role: role, Hint: hint}
 		p.entries = append(p.entries, entry)
-		openedSerials[d.info.Serial] = struct{}{}
+		openedSerials[info.Serial] = struct{}{}
 		// Include the per-device tuning in the open log so an
 		// operator can grep the boot log to confirm the value they
 		// put in config.yaml actually landed on this serial (issue

--- a/internal/sdr/pool.go
+++ b/internal/sdr/pool.go
@@ -39,6 +39,7 @@ func (e *PoolEntry) Snapshot(attached bool) SDRStatus {
 		Attached:     attached,
 		PPM:          e.Hint.PPM,
 		BiasTee:      e.Hint.BiasTee,
+		Amp:          e.Hint.Amp,
 		Gains:        append([]int(nil), e.Info.Gains...),
 	}
 	if e.Hint.gainSet {
@@ -91,11 +92,13 @@ type Hint struct {
 	PPM     int
 	Gain    int // tenths of dB; negative = auto
 	BiasTee bool
+	Amp     bool
 	// gainSet distinguishes "Gain not configured" (apply auto) from
 	// the explicit "auto" choice. The daemon sets this when it parses
 	// the YAML; tests that don't care can leave Hint zero-valued and
 	// pool.Open won't touch the device's gain.
 	gainSet bool
+	ampSet  bool
 }
 
 // WithGain returns a copy of h with Gain set and the gain-set flag
@@ -103,6 +106,13 @@ type Hint struct {
 func (h Hint) WithGain(tenthDB int) Hint {
 	h.Gain = tenthDB
 	h.gainSet = true
+	return h
+}
+
+// WithAmp returns a copy of h with a driver-specific RF amplifier flag set.
+func (h Hint) WithAmp(on bool) Hint {
+	h.Amp = on
+	h.ampSet = true
 	return h
 }
 
@@ -244,9 +254,13 @@ func (p *Pool) OpenWith(opts PoolOpenOptions) error {
 				"err", err)
 			continue
 		}
+		info := dev.Info()
+		if info.Driver == "" {
+			info = d.info
+		}
 		if err := dev.SetSampleRate(rate); err != nil {
 			p.log.Error("set sample rate failed",
-				"driver", d.drv.Name(), "serial", d.info.Serial, "rate_hz", rate, "err", err)
+				"driver", d.drv.Name(), "serial", info.Serial, "rate_hz", rate, "err", err)
 			_ = dev.Close()
 			continue
 		}
@@ -256,9 +270,9 @@ func (p *Pool) OpenWith(opts PoolOpenOptions) error {
 		// operator who put bias_tee: true in config sees that the
 		// device rejected it.
 		if hinted {
-			p.applyHintSettings(dev, d.info, hint)
+			p.applyHintSettings(dev, info, hint)
 		}
-		entry := &PoolEntry{Driver: d.drv, Device: dev, Info: d.info, Role: role, Hint: hint}
+		entry := &PoolEntry{Driver: d.drv, Device: dev, Info: info, Role: role, Hint: hint}
 		p.entries = append(p.entries, entry)
 		openedSerials[d.info.Serial] = struct{}{}
 		// Include the per-device tuning in the open log so an
@@ -375,6 +389,15 @@ func (p *Pool) applyHintSettings(dev Device, info Info, h Hint) {
 	if h.BiasTee {
 		if err := dev.SetBiasTee(true); err != nil {
 			p.log.Warn("set bias_tee failed", "serial", info.Serial, "err", err)
+		}
+	}
+	if h.ampSet {
+		if ampDev, ok := dev.(interface{ SetAmp(bool) error }); ok {
+			if err := ampDev.SetAmp(h.Amp); err != nil {
+				p.log.Warn("set rf amp failed", "serial", info.Serial, "amp", h.Amp, "err", err)
+			}
+		} else if h.Amp {
+			p.log.Warn("rf amp requested but device does not support a separate amp stage", "serial", info.Serial)
 		}
 	}
 }

--- a/internal/sdr/pool_settings_test.go
+++ b/internal/sdr/pool_settings_test.go
@@ -41,9 +41,37 @@ func TestPoolAppliesHintSettings(t *testing.T) {
 	}
 }
 
+func TestPoolAppliesAmpHintWhenSet(t *testing.T) {
+	drv := &fakeDriver{name: "fake-amp", infos: []Info{
+		{Driver: "fake-amp", Index: 0, Serial: "S2"},
+	}}
+	registryMu.Lock()
+	registry["fake-amp"] = drv
+	registryMu.Unlock()
+	t.Cleanup(func() {
+		registryMu.Lock()
+		delete(registry, "fake-amp")
+		registryMu.Unlock()
+	})
+
+	p := NewPool(nil)
+	if err := p.Open(0, []Hint{Hint{Serial: "S2"}.WithAmp(true)}); err != nil {
+		t.Fatal(err)
+	}
+	defer p.Close()
+
+	dev := p.Entries()[0].Device.(*fakeDevice)
+	if dev.ampSets != 1 {
+		t.Errorf("SetAmp invocations = %d, want 1", dev.ampSets)
+	}
+	if !dev.ampOn {
+		t.Errorf("ampOn = false, want true")
+	}
+}
+
 func TestPoolSkipsBiasTeeWhenHintFalse(t *testing.T) {
 	drv := &fakeDriver{name: "fake-no-bias", infos: []Info{
-		{Driver: "fake-no-bias", Index: 0, Serial: "S2"},
+		{Driver: "fake-no-bias", Index: 0, Serial: "S3"},
 	}}
 	registryMu.Lock()
 	registry["fake-no-bias"] = drv
@@ -55,12 +83,15 @@ func TestPoolSkipsBiasTeeWhenHintFalse(t *testing.T) {
 	})
 
 	p := NewPool(nil)
-	if err := p.Open(0, []Hint{{Serial: "S2"}}); err != nil {
+	if err := p.Open(0, []Hint{{Serial: "S3"}}); err != nil {
 		t.Fatal(err)
 	}
 	defer p.Close()
 	dev := p.Entries()[0].Device.(*fakeDevice)
 	if dev.biasTeeSets != 0 {
 		t.Errorf("SetBiasTee called %d times when bias_tee was false", dev.biasTeeSets)
+	}
+	if dev.ampSets != 0 {
+		t.Errorf("SetAmp called %d times when amp was unset", dev.ampSets)
 	}
 }

--- a/internal/sdr/pool_test.go
+++ b/internal/sdr/pool_test.go
@@ -24,6 +24,8 @@ type fakeDevice struct {
 	closed      bool
 	biasTeeOn   bool
 	biasTeeSets int
+	ampOn       bool
+	ampSets     int
 	sampleRate  uint32
 	rateErr     error
 	ppm         int
@@ -42,6 +44,7 @@ func (d *fakeDevice) SetSampleRate(hz uint32) error {
 func (d *fakeDevice) SetGain(int) error                                    { return nil }
 func (d *fakeDevice) SetPPM(ppm int) error                                 { d.ppm = ppm; d.ppmSets++; return nil }
 func (d *fakeDevice) SetBiasTee(on bool) error                             { d.biasTeeOn = on; d.biasTeeSets++; return nil }
+func (d *fakeDevice) SetAmp(on bool) error                                 { d.ampOn = on; d.ampSets++; return nil }
 func (d *fakeDevice) StreamIQ(context.Context) (<-chan []complex64, error) { return nil, io.EOF }
 func (d *fakeDevice) Close() error {
 	if d.closed {

--- a/internal/sdr/rtlsdr/purego/device.go
+++ b/internal/sdr/rtlsdr/purego/device.go
@@ -123,6 +123,8 @@ func (d *Device) SetPPM(ppm int) error {
 // comes from the per-(VID, PID) bias-tee table in devices.go; boards
 // that aren't in the table inherit GPIO 0 (the standard for
 // RTL-SDR.com v3+ and NESDR Smart v5).
+func (d *Device) SetAmp(bool) error { return nil }
+
 func (d *Device) SetBiasTee(enable bool) error {
 	if d.closed.Load() {
 		return ErrClosed

--- a/internal/sdr/rtlsdr/purego/device.go
+++ b/internal/sdr/rtlsdr/purego/device.go
@@ -119,12 +119,13 @@ func (d *Device) SetPPM(ppm int) error {
 	return nil
 }
 
+// SetAmp is a no-op for RTL-SDR; it has no separate RF amp stage.
+func (d *Device) SetAmp(bool) error { return nil }
+
 // SetBiasTee toggles the dongle's 5 V LNA-power output. The GPIO pin
 // comes from the per-(VID, PID) bias-tee table in devices.go; boards
 // that aren't in the table inherit GPIO 0 (the standard for
 // RTL-SDR.com v3+ and NESDR Smart v5).
-func (d *Device) SetAmp(bool) error { return nil }
-
 func (d *Device) SetBiasTee(enable bool) error {
 	if d.closed.Load() {
 		return ErrClosed

--- a/internal/sdr/rtltcp/driver.go
+++ b/internal/sdr/rtltcp/driver.go
@@ -227,6 +227,8 @@ func (d *device) SetPPM(ppm int) error {
 	return d.sendCmd(cmdSetFreqCorrPPM, uint32(int32(ppm)))
 }
 
+func (d *device) SetAmp(bool) error { return nil }
+
 func (d *device) SetBiasTee(enable bool) error {
 	var v uint32
 	if enable {

--- a/internal/sdr/status.go
+++ b/internal/sdr/status.go
@@ -27,6 +27,7 @@ type SDRStatus struct {
 	GainAuto    bool `json:"gain_auto"`
 	PPM         int  `json:"ppm"`
 	BiasTee     bool `json:"bias_tee"`
+	Amp         bool `json:"amp,omitempty"`
 
 	// Gains is the tuner's quantized gain ladder (tenths of dB),
 	// useful for UIs that want to render valid choices.

--- a/internal/sdr/wbvoice/tuner_test.go
+++ b/internal/sdr/wbvoice/tuner_test.go
@@ -36,6 +36,7 @@ func (f *fakeDevice) SetSampleRate(uint32) error { return nil }
 func (f *fakeDevice) SetGain(int) error          { return nil }
 func (f *fakeDevice) SetPPM(int) error           { return nil }
 func (f *fakeDevice) SetBiasTee(bool) error      { return nil }
+func (f *fakeDevice) SetAmp(bool) error          { return nil }
 func (f *fakeDevice) Close() error               { return nil }
 func (f *fakeDevice) StreamIQ(ctx context.Context) (<-chan []complex64, error) {
 	if f.err != nil {


### PR DESCRIPTION
## Summary
- add `sdr.devices[].amp` for HackRF RF amp control
- carry amp through SDR pool hints, status snapshots, config parsing, examples, and generated config templates
- implement HackRF `SetAmp` via `AMP_ENABLE`; non-HackRF devices no-op
- make HackRF all-NUL serial fallback consistent between enumerate/open
- fix an iqtap subscriber fanout/close race while touching the SDR device interface

## Tests
- `git diff --check`
- `go test -race ./internal/sdr/iqtap`
- `go test ./internal/sdr/hackrf ./internal/sdr ./internal/sdr/... ./internal/config ./cmd/gophertrunk`
- `go build -o bin/gophertrunk ./cmd/gophertrunk`

## Hardware
- HackRF smoke not run: device is not currently enumerating on this host.
- RTL-SDR is attached, but unrelated to this HackRF amp slice.
