### PR TITLE
voice: force vocoder-native WAV rate + decode-quality telemetry (#356)

### DIFF
--- a/internal/voice/composer/dmr_voice.go
+++ b/internal/voice/composer/dmr_voice.go
@@ -64,6 +64,14 @@ func (c *Composer) runDMRVoiceChain(ctx context.Context, serial string, iqCh <-c
 	// previous tick. Without this gate a stalled decoder still kept the
 	// call alive forever via an unconditional 1 s heartbeat (issue #356).
 	var superframes atomic.Uint64
+	// Decode-quality telemetry — see runP25Phase1VoiceChain for the
+	// rationale. A high uncorrectable AMBE-frame rate is the measurable
+	// signature of weak signal / wrong gain behind garbled audio (issue
+	// #356 follow-up).
+	var (
+		uncorrectableFrames atomic.Uint64
+		corrErrBits         atomic.Uint64
+	)
 	rx := dmrrx.New(dmrrx.Options{
 		SampleRateHz: symbolHz,
 		// DMR spec peak deviation per ETSI TS 102 361-1 §6.3 — matches
@@ -77,9 +85,13 @@ func (c *Composer) runDMRVoiceChain(ctx context.Context, serial string, iqCh <-c
 					continue
 				}
 				for i := range sf.Frames {
-					info, _, err := dmrvoice.DecodeAMBEFrame(sf.Frames[i])
+					info, errBits, err := dmrvoice.DecodeAMBEFrame(sf.Frames[i])
+					if errBits > 0 {
+						corrErrBits.Add(uint64(errBits))
+					}
 					if err != nil {
-						c.log.Warn("composer: DMR AMBE FEC decode failed",
+						uncorrectableFrames.Add(1)
+						c.log.Debug("composer: DMR AMBE FEC decode failed",
 							"serial", serial, "err", err)
 						continue
 					}
@@ -95,10 +107,27 @@ func (c *Composer) runDMRVoiceChain(ctx context.Context, serial string, iqCh <-c
 	touchTicker := time.NewTicker(c.touchEvery)
 	defer touchTicker.Stop()
 	var lastSuperframes uint64
+	// logDecodeQuality emits a rolling decode-quality summary, gated to a
+	// burst of superframes so it does not spam the log every touch tick
+	// (issue #356 follow-up). See runP25Phase1VoiceChain.
+	var lastQualityLogSuperframes uint64
+	const qualityLogEverySuperframes = 25
+	logDecodeQuality := func(final bool) {
+		n := superframes.Load()
+		if n == 0 || (!final && n-lastQualityLogSuperframes < qualityLogEverySuperframes) {
+			return
+		}
+		lastQualityLogSuperframes = n
+		c.log.Info("composer: dmr decode quality",
+			"serial", serial,
+			"superframes", n, "uncorrectable_frames", uncorrectableFrames.Load(),
+			"corrected_bit_errs", corrErrBits.Load())
+	}
 
 	for {
 		select {
 		case <-ctx.Done():
+			logDecodeQuality(true)
 			return
 		case <-touchTicker.C:
 			n := superframes.Load()
@@ -106,8 +135,10 @@ func (c *Composer) runDMRVoiceChain(ctx context.Context, serial string, iqCh <-c
 				c.engine.Touch(serial)
 				lastSuperframes = n
 			}
+			logDecodeQuality(false)
 		case iq, ok := <-iqCh:
 			if !ok {
+				logDecodeQuality(true)
 				return
 			}
 			samples := iq

--- a/internal/voice/composer/p25p1_voice.go
+++ b/internal/voice/composer/p25p1_voice.go
@@ -115,6 +115,17 @@ func (c *Composer) runP25Phase1VoiceChain(ctx context.Context, serial string, iq
 	// tick. Without this gate, a stalled decoder still kept the call
 	// alive forever via an unconditional 1 s heartbeat (issue #356).
 	var frames atomic.Uint64
+	// Decode-quality telemetry. An LDU whose IMBE FEC could not fully
+	// correct a subframe still yields (degraded) audio, so a high
+	// uncorrectable rate is the measurable signature of weak signal /
+	// wrong gain — exactly the "multiple uncorrectable errors" an
+	// operator sees when audio is garbled. Surfacing a rolling summary
+	// lets them watch the rate fall as they raise gain (issue #356
+	// follow-up). corrErrBits sums the bit errors the FEC *did* correct.
+	var (
+		uncorrectableLDUs atomic.Uint64
+		corrErrBits       atomic.Uint64
+	)
 	rx := p25p1rx.New(p25p1rx.Options{
 		SampleRateHz: symbolHz,
 		DeviationHz:  p25p1DeviationHz,
@@ -126,9 +137,13 @@ func (c *Composer) runP25Phase1VoiceChain(ctx context.Context, serial string, iq
 			if rs == nil {
 				return
 			}
-			fs, _, err := phase1.ExtractVoiceFrames(ldu)
+			fs, errBits, err := phase1.ExtractVoiceFrames(ldu)
+			if errBits > 0 {
+				corrErrBits.Add(uint64(errBits))
+			}
 			if err != nil {
-				c.log.Warn("composer: p25p1 voice extract failed",
+				uncorrectableLDUs.Add(1)
+				c.log.Debug("composer: p25p1 voice extract uncorrectable subframe",
 					"serial", serial, "err", err)
 			}
 			for _, f := range fs {
@@ -217,10 +232,27 @@ func (c *Composer) runP25Phase1VoiceChain(ctx context.Context, serial string, iq
 	touchTicker := time.NewTicker(c.touchEvery)
 	defer touchTicker.Stop()
 	var lastFrames uint64
+	// logDecodeQuality emits a rolling decode-quality summary. Gated to
+	// fire only after a burst of LDUs (~4.5 s of voice at 9 frames /
+	// 180 ms per LDU) so it does not spam the log every touch tick.
+	var lastQualityLogLDUs uint64
+	const qualityLogEveryLDUs = 25
+	logDecodeQuality := func(final bool) {
+		n := frames.Load()
+		if n == 0 || (!final && n-lastQualityLogLDUs < qualityLogEveryLDUs) {
+			return
+		}
+		lastQualityLogLDUs = n
+		c.log.Info("composer: p25p1 decode quality",
+			"serial", serial, "demod_mode", mode,
+			"ldus", n, "uncorrectable_ldus", uncorrectableLDUs.Load(),
+			"corrected_bit_errs", corrErrBits.Load())
+	}
 
 	for {
 		select {
 		case <-ctx.Done():
+			logDecodeQuality(true)
 			return
 		case <-touchTicker.C:
 			n := frames.Load()
@@ -228,8 +260,10 @@ func (c *Composer) runP25Phase1VoiceChain(ctx context.Context, serial string, iq
 				c.engine.Touch(serial)
 				lastFrames = n
 			}
+			logDecodeQuality(false)
 		case iq, ok := <-iqCh:
 			if !ok {
+				logDecodeQuality(true)
 				return
 			}
 			samples := iq

--- a/internal/voice/composer/p25p1_voice_test.go
+++ b/internal/voice/composer/p25p1_voice_test.go
@@ -411,6 +411,74 @@ func TestComposerP25Phase1VoiceChainLogsDemodMode(t *testing.T) {
 	}
 }
 
+// TestComposerP25Phase1VoiceChainLogsDecodeQuality drives enough live
+// LDUs through the chain to trip the rolling decode-quality summary and
+// asserts the line is emitted with the per-call counters. This is the
+// metric a field operator watches to tell whether raising the voice SDR
+// gain reduces uncorrectable subframes behind garbled audio — issue
+// #356 follow-up.
+func TestComposerP25Phase1VoiceChainLogsDecodeQuality(t *testing.T) {
+	const (
+		sampleRate = 48_000.0
+		deviation  = 1800.0
+		ldus       = 40 // well past the 25-LDU summary threshold
+	)
+	dibits, _ := buildP25P1VoiceStream(t, ldus)
+	iq := demod.ModulateP25C4FM(dibits, sampleRate, deviation)
+
+	buf := &syncBuffer{}
+	logger := slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	src := newFakeSource()
+	bus := events.NewBus(8)
+	sink := &recordingSink{}
+	eng := &fakeEngine{}
+	c, err := New(Options{
+		Bus:           bus,
+		Log:           logger,
+		Devices:       &fakeDevices{src: map[string]IQSource{"VOICE-1": src}},
+		Sink:          sink,
+		Engine:        eng,
+		IQSampleRate:  uint32(sampleRate),
+		PCMSampleRate: 8000,
+		TouchInterval: 30 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go c.Run(ctx)
+	defer c.Close()
+	defer bus.Close()
+
+	bus.Publish(events.Event{
+		Kind: events.KindCallStart,
+		Payload: trunking.CallStart{
+			Grant: trunking.Grant{
+				System: "P25P1Site", Protocol: "p25",
+				GroupID: 42, FrequencyHz: 851_000_000,
+			},
+			DeviceSerial: "VOICE-1",
+			StartedAt:    time.Now().UTC(),
+		},
+	})
+
+	waitFor(t, 2*time.Second, func() bool { return len(c.ActiveChains()) == 1 })
+	src.SendIQ(iq)
+
+	waitFor(t, 6*time.Second, func() bool {
+		return strings.Contains(buf.String(), "composer: p25p1 decode quality")
+	})
+	out := buf.String()
+	if !strings.Contains(out, "composer: p25p1 decode quality") {
+		t.Fatalf("expected p25p1 decode quality log; got:\n%s", out)
+	}
+	if !strings.Contains(out, "ldus=") || !strings.Contains(out, "uncorrectable_ldus=") {
+		t.Errorf("expected ldus= and uncorrectable_ldus= fields in decode quality log; got:\n%s", out)
+	}
+}
+
 // syncBuffer is a bytes.Buffer guarded by a mutex so the test
 // goroutine can read the captured log output while the composer
 // chain goroutine concurrently writes to it via slog's handler.

--- a/internal/voice/composer/p25p2_voice.go
+++ b/internal/voice/composer/p25p2_voice.go
@@ -94,6 +94,13 @@ func (c *Composer) runP25Phase2VoiceChain(ctx context.Context, serial string, sy
 	// decoder still kept the call alive forever via an unconditional
 	// 1 s heartbeat (issue #356).
 	var voiceSubframes atomic.Uint64
+	// Decode-quality telemetry — see runP25Phase1VoiceChain for the
+	// rationale. A high uncorrectable rate is the measurable signature of
+	// weak signal / wrong gain behind garbled audio (issue #356 follow-up).
+	var (
+		uncorrectableSubframes atomic.Uint64
+		corrErrBits            atomic.Uint64
+	)
 	rx := p25p2rx.New(p25p2rx.Options{
 		SampleRateHz: symbolHz,
 		ClockMode:    p25p2rx.ClockGardner,
@@ -108,9 +115,13 @@ func (c *Composer) runP25Phase2VoiceChain(ctx context.Context, serial string, sy
 					if rs == nil {
 						continue
 					}
-					frames, _, err := p25p2.ExtractVoiceFrames(sub)
+					frames, errBits, err := p25p2.ExtractVoiceFrames(sub)
+					if errBits > 0 {
+						corrErrBits.Add(uint64(errBits))
+					}
 					if err != nil {
-						c.log.Warn("composer: p25p2 voice extract failed",
+						uncorrectableSubframes.Add(1)
+						c.log.Debug("composer: p25p2 voice extract uncorrectable subframe",
 							"serial", serial, "err", err)
 					}
 					for _, f := range frames {
@@ -161,10 +172,27 @@ func (c *Composer) runP25Phase2VoiceChain(ctx context.Context, serial string, sy
 	touchTicker := time.NewTicker(c.touchEvery)
 	defer touchTicker.Stop()
 	var lastSubframes uint64
+	// logDecodeQuality emits a rolling decode-quality summary, gated to a
+	// burst of voice subframes so it does not spam the log every touch
+	// tick (issue #356 follow-up). See runP25Phase1VoiceChain.
+	var lastQualityLogSubframes uint64
+	const qualityLogEverySubframes = 50
+	logDecodeQuality := func(final bool) {
+		n := voiceSubframes.Load()
+		if n == 0 || (!final && n-lastQualityLogSubframes < qualityLogEverySubframes) {
+			return
+		}
+		lastQualityLogSubframes = n
+		c.log.Info("composer: p25p2 decode quality",
+			"serial", serial, "system", system,
+			"voice_subframes", n, "uncorrectable_subframes", uncorrectableSubframes.Load(),
+			"corrected_bit_errs", corrErrBits.Load())
+	}
 
 	for {
 		select {
 		case <-ctx.Done():
+			logDecodeQuality(true)
 			return
 		case <-touchTicker.C:
 			n := voiceSubframes.Load()
@@ -172,8 +200,10 @@ func (c *Composer) runP25Phase2VoiceChain(ctx context.Context, serial string, sy
 				c.engine.Touch(serial)
 				lastSubframes = n
 			}
+			logDecodeQuality(false)
 		case iq, ok := <-iqCh:
 			if !ok {
+				logDecodeQuality(true)
 				return
 			}
 			samples := iq

--- a/internal/voice/recorder.go
+++ b/internal/voice/recorder.go
@@ -324,13 +324,50 @@ func (r *Recorder) handleStart(cs trunking.CallStart) {
 		return
 	}
 	base := r.basenameFor(cs)
+	s := &recordingSession{startedAt: cs.StartedAt}
+	// Instantiate a vocoder for the protocol if one is mapped. This must
+	// happen before the WAV is opened so the header rate can track the
+	// vocoder's native output rate (below). Construction failure (unknown
+	// registry name) logs a warning and proceeds with no auto-decode —
+	// the sidecar (if any) is still the safety net.
+	if name, ok := r.vocoderForProtocol[cs.Grant.Protocol]; ok && name != "" {
+		v, err := DefaultRegistry.New(name)
+		if err != nil {
+			r.log.Warn("recorder: cannot instantiate vocoder; auto-decode disabled for this call",
+				"device", cs.DeviceSerial, "protocol", cs.Grant.Protocol,
+				"vocoder", name, "err", err)
+		} else {
+			s.vocoder = v
+			s.vocoderName = name
+		}
+	}
+	// Pick the WAV header rate. Vocoder output is always 8 kHz (see the
+	// Vocoder interface contract) and WriteRawFrame appends those samples
+	// to the WAV without resampling, so a decoded call's header MUST be
+	// 8 kHz regardless of recordings.sample_rate — otherwise clean audio
+	// plays back at the wrong speed (garbled). recordings.sample_rate
+	// only applies to analog/NBFM calls fed via WritePCM. Issue #356
+	// follow-up.
+	s.sampleRate = r.sampleRate
+	if s.vocoder != nil {
+		s.sampleRate = pcmHzDefault
+		if r.sampleRate != pcmHzDefault {
+			r.log.Warn("recorder: forcing WAV rate to vocoder-native 8000; recordings.sample_rate applies to analog/NBFM only",
+				"device", cs.DeviceSerial, "protocol", cs.Grant.Protocol,
+				"recordings_sample_rate", r.sampleRate)
+		}
+	}
 	wavPath := filepath.Join(dir, base+".wav")
-	wav, err := NewWavFile(wavPath, r.sampleRate)
+	wav, err := NewWavFile(wavPath, s.sampleRate)
 	if err != nil {
 		r.log.Error("recorder: open wav", "path", wavPath, "err", err)
+		if s.vocoder != nil {
+			_ = s.vocoder.Close()
+		}
 		return
 	}
-	s := &recordingSession{wav: wav, wavPath: wavPath, startedAt: cs.StartedAt}
+	s.wav = wav
+	s.wavPath = wavPath
 	// ProVoice and DMR voice grants always get a sidecar — neither has
 	// an in-process vocoder, so the .raw file is the only capture of
 	// the call.
@@ -342,21 +379,6 @@ func (r *Recorder) handleStart(cs trunking.CallStart) {
 		} else {
 			s.raw = raw
 			s.rawPath = rawPath
-		}
-	}
-	// Instantiate a vocoder for the protocol if one is mapped.
-	// Construction failure (unknown registry name) logs a warning and
-	// proceeds with no auto-decode — the sidecar (if any) is still the
-	// safety net.
-	if name, ok := r.vocoderForProtocol[cs.Grant.Protocol]; ok && name != "" {
-		v, err := DefaultRegistry.New(name)
-		if err != nil {
-			r.log.Warn("recorder: cannot instantiate vocoder; auto-decode disabled for this call",
-				"device", cs.DeviceSerial, "protocol", cs.Grant.Protocol,
-				"vocoder", name, "err", err)
-		} else {
-			s.vocoder = v
-			s.vocoderName = name
 		}
 	}
 	r.sessions[cs.DeviceSerial] = s
@@ -400,7 +422,7 @@ func (r *Recorder) handleEnd(ce trunking.CallEnd) {
 				EndedAt:      ce.EndedAt,
 				Reason:       ce.Reason,
 				AudioPath:    s.wavPath,
-				SampleRate:   r.sampleRate,
+				SampleRate:   s.sampleRate,
 			},
 		})
 	}
@@ -457,6 +479,7 @@ type recordingSession struct {
 	rawPath     string
 	vocoder     Vocoder
 	vocoderName string
+	sampleRate  uint32
 	startedAt   time.Time
 }
 

--- a/internal/voice/recorder_samplerate_test.go
+++ b/internal/voice/recorder_samplerate_test.go
@@ -1,0 +1,160 @@
+package voice
+
+import (
+	"context"
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// fakeVocoder is a minimal Vocoder that emits one 20 ms / 160-sample
+// frame at the vocoder-native 8 kHz rate, regardless of input. It lets
+// the recorder tests exercise the decoded-WAV path without linking the
+// patented IMBE/AMBE decoders into the test binary.
+type fakeVocoder struct{}
+
+func (fakeVocoder) Name() string                   { return "fake-voc" }
+func (fakeVocoder) FrameSize() int                 { return 11 }
+func (fakeVocoder) Decode([]byte) ([]int16, error) { return make([]int16, 160), nil }
+func (fakeVocoder) Reset()                         {}
+func (fakeVocoder) Close() error                   { return nil }
+
+func waitForSession(t *testing.T, r *Recorder, serial string, want bool) {
+	t.Helper()
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if r.HasSession(serial) == want {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("session %q HasSession != %v after timeout", serial, want)
+}
+
+func wavHeaderRate(t *testing.T, path string) uint32 {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read wav %s: %v", path, err)
+	}
+	if len(b) < wavHeaderSize {
+		t.Fatalf("wav %s too short: %d bytes", path, len(b))
+	}
+	return binary.LittleEndian.Uint32(b[24:28])
+}
+
+// TestRecorderForcesVocoderNativeRate verifies that a call whose protocol
+// maps to a vocoder gets a WAV header at the vocoder-native 8 kHz even
+// when recordings.sample_rate is configured to something else. Without
+// this guard the recorder wrote the vocoder's 8 kHz PCM under a 48 kHz
+// header, so clean audio played back 6x too fast (garbled) — issue #356.
+func TestRecorderForcesVocoderNativeRate(t *testing.T) {
+	DefaultRegistry.Register("fake-voc", func() (Vocoder, error) { return fakeVocoder{}, nil })
+
+	bus := events.NewBus(8)
+	defer bus.Close()
+	dir := t.TempDir()
+	r, err := NewRecorder(RecorderOptions{
+		Bus:                bus,
+		OutDir:             dir,
+		SampleRate:         48000, // intentionally != 8000
+		VocoderForProtocol: map[string]string{"p25-fake": "fake-voc"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go r.Run(ctx)
+
+	cs := trunking.CallStart{
+		Grant: trunking.Grant{
+			System:   "S",
+			Protocol: "p25-fake",
+			GroupID:  7,
+			SourceID: 42,
+		},
+		Talkgroup:    &trunking.TalkGroup{ID: 7, AlphaTag: "FIRE", Record: true},
+		DeviceSerial: "VOICE-1",
+		StartedAt:    time.Date(2026, 5, 29, 17, 25, 2, 0, time.UTC),
+	}
+	bus.Publish(events.Event{Kind: events.KindCallStart, Payload: cs})
+	waitForSession(t, r, "VOICE-1", true)
+
+	if err := r.WriteRawFrame("VOICE-1", make([]byte, 11)); err != nil {
+		t.Fatal(err)
+	}
+
+	bus.Publish(events.Event{Kind: events.KindCallEnd, Payload: trunking.CallEnd{
+		Grant:        cs.Grant,
+		Talkgroup:    cs.Talkgroup,
+		DeviceSerial: "VOICE-1",
+		StartedAt:    cs.StartedAt,
+		EndedAt:      cs.StartedAt.Add(time.Second),
+		Reason:       trunking.EndReasonNormal,
+	}})
+	waitForSession(t, r, "VOICE-1", false)
+
+	wav := filepath.Join(dir, "S", "FIRE", "20260529T172502Z_src42.wav")
+	if got := wavHeaderRate(t, wav); got != pcmHzDefault {
+		t.Errorf("decoded-call WAV header rate = %d, want %d", got, pcmHzDefault)
+	}
+}
+
+// TestRecorderAnalogKeepsConfiguredRate verifies the complement: a call
+// with no vocoder mapping (analog/NBFM fed via WritePCM) keeps the
+// configured recordings.sample_rate in its WAV header.
+func TestRecorderAnalogKeepsConfiguredRate(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	dir := t.TempDir()
+	r, err := NewRecorder(RecorderOptions{
+		Bus:                bus,
+		OutDir:             dir,
+		SampleRate:         16000,
+		VocoderForProtocol: map[string]string{}, // no vocoder for any protocol
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go r.Run(ctx)
+
+	cs := trunking.CallStart{
+		Grant:        trunking.Grant{System: "S", Protocol: "nbfm", GroupID: 9, SourceID: 1},
+		Talkgroup:    &trunking.TalkGroup{ID: 9, AlphaTag: "ANALOG", Record: true},
+		DeviceSerial: "VOICE-2",
+		StartedAt:    time.Date(2026, 5, 29, 17, 30, 12, 0, time.UTC),
+	}
+	bus.Publish(events.Event{Kind: events.KindCallStart, Payload: cs})
+	waitForSession(t, r, "VOICE-2", true)
+
+	if err := r.WritePCM("VOICE-2", make([]int16, 320)); err != nil {
+		t.Fatal(err)
+	}
+
+	bus.Publish(events.Event{Kind: events.KindCallEnd, Payload: trunking.CallEnd{
+		Grant:        cs.Grant,
+		Talkgroup:    cs.Talkgroup,
+		DeviceSerial: "VOICE-2",
+		StartedAt:    cs.StartedAt,
+		EndedAt:      cs.StartedAt.Add(time.Second),
+		Reason:       trunking.EndReasonNormal,
+	}})
+	waitForSession(t, r, "VOICE-2", false)
+
+	wav := filepath.Join(dir, "S", "ANALOG", "20260529T173012Z_src1.wav")
+	if got := wavHeaderRate(t, wav); got != 16000 {
+		t.Errorf("analog WAV header rate = %d, want 16000", got)
+	}
+}


### PR DESCRIPTION
Issue #356 follow-up. The original stuck-TG / empty-recording symptoms
are resolved on main; the reporter's remaining complaint is garbled
clear-channel audio plus "multiple uncorrectable errors". This addresses
both the one code-level way clean audio comes out garbled and the lack
of a measurable decode-health signal.

Sample-rate guard (internal/voice/recorder.go):
The IMBE/AMBE vocoders always emit 8 kHz PCM and the recorder appends
those samples to the WAV without resampling, but the WAV header used
recordings.sample_rate (validated 4000..48000). A non-default rate made
decoded P25/DMR calls play back at the wrong speed (garbled). handleStart
now instantiates the vocoder before opening the WAV and forces the
header to the vocoder-native 8 kHz for decoded calls (analog/NBFM fed via
WritePCM still honour the configured rate), and CallComplete publishes the
session's actual rate. Matches the offline decoder, which already
hardcodes 8 kHz.

Decode-quality telemetry (internal/voice/composer/{p25p1,p25p2,dmr}_voice.go):
All three voice chains discarded the FEC corrected-error count and only
warned per-LDU on an uncorrectable subframe. They now aggregate per-call
counters and emit a rolling "composer: <proto> decode quality" summary
(gated to a burst of LDUs/subframes to avoid log spam, plus a final
summary at chain shutdown) so an operator can watch the uncorrectable
rate fall as they raise gain. The per-LDU warn is demoted to Debug.

Tests: recorder_samplerate_test.go asserts the 8 kHz override for a
vocoder protocol at a 48 kHz configured rate and the configured rate for
an analog session; a composer test asserts the decode-quality line is
emitted with its counters.

https://claude.ai/code/session_01FMzVPQ8QMSGcCZgdNzK9Eg