### PR TITLE
sdr: warn when gain looks like dB instead of tenths-of-dB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ for tagged releases.
 
 ## [Unreleased]
 
+### Changed
+
+- **Gain-units guardrail.** `sdr.devices[].gain` (and the rtl_tcp
+  equivalent) is in *tenths* of a dB — `"320"` = 32 dB — but operators
+  coming from SDRTrunk / OP25 / gqrx routinely paste a whole-dB value
+  like `"32"`, which parses to 3.2 dB and snaps to the bottom of the
+  tuner ladder, leaving the radio effectively deaf (no control-channel
+  lock, no decodes) with no feedback. The daemon now WARNs at startup
+  when a bare-integer gain parses to ≤ 5.0 dB (`gain looks like dB, not
+  tenths-of-dB …`, suggesting the ×10 value), and the SDR pool now logs
+  the applied gain in dB on every device (`sdr: gain set … gain_db=…`)
+  so a units mistake is visible without enabling debug. No behaviour
+  change for valid configs; decimal forms like `"32.0"` are still taken
+  as whole dB. Docs (`config.example.yaml`, `docs/hardware.md`) updated.
+
 ### Added
 
 - **MDC1200 Motorola signaling decode** (#438) — end-to-end pipeline

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -73,6 +73,41 @@ func parseGain(s string) (int, bool) {
 	return n, true
 }
 
+// gainLooksLikeDBMistake reports whether a successfully-parsed gain value
+// is almost certainly a dB figure the operator forgot to express in
+// tenths-of-dB. GopherTrunk's gain: string is tenths (so "320" = 32 dB),
+// but SDRTrunk / OP25 / gqrx all take whole dB — a habit that lands "32"
+// (= 3.2 dB, which SetGain then snaps to the bottom of the ladder, leaving
+// the radio effectively deaf) in many first-run configs. A bare integer
+// (no decimal point) that parses to a positive value at or below 50 tenths
+// (5.0 dB) is the tell: real manual gains run ~100-496 tenths and the
+// shipped examples are all three digits, so this never fires on a correct
+// config. Decimal forms like "32.0" are already interpreted as whole dB by
+// parseGain, so they're taken at face value and skipped.
+func gainLooksLikeDBMistake(raw string, tenthDB int) bool {
+	raw = strings.TrimSpace(raw)
+	if strings.ContainsAny(raw, ".,") {
+		return false
+	}
+	return tenthDB > 0 && tenthDB <= 50
+}
+
+// warnGainUnits emits a one-line, actionable WARN when a parsed gain looks
+// like a dB figure that should have been tenths-of-dB (see
+// gainLooksLikeDBMistake). No-op for plausible gains, so it's safe to call
+// unconditionally after every successful parseGain.
+func warnGainUnits(log *slog.Logger, serial, raw string, tenthDB int) {
+	if !gainLooksLikeDBMistake(raw, tenthDB) {
+		return
+	}
+	log.Warn("daemon: gain looks like dB, not tenths-of-dB — radio may be effectively deaf",
+		"serial", serial,
+		"configured", raw,
+		"parsed_db", float64(tenthDB)/10.0,
+		"did_you_mean", strconv.Itoa(tenthDB*10),
+		"hint", "gain: is in TENTHS of a dB (\"320\" = 32 dB). SDRTrunk/OP25/gqrx users multiply dB by 10. Use 'gain: auto' or run 'gophertrunk sdr list' for the supported ladder.")
+}
+
 // Daemon owns the lifecycle of every long-lived component the
 // gophertrunk binary runs: the events bus, SDR pool, trunking engine,
 // per-call recorder, SQLite call log + retention sweeper, Prometheus
@@ -400,6 +435,7 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 					log.Warn("daemon: ignoring unparseable gain",
 						"serial", dev.Serial, "gain", dev.Gain)
 				} else {
+					warnGainUnits(log, dev.Serial, dev.Gain, gain)
 					h = h.WithGain(gain)
 				}
 			}
@@ -456,6 +492,7 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 							log.Warn("daemon: ignoring unparseable rtl_tcp gain",
 								"serial", r.Serial, "gain", r.Gain)
 						} else {
+							warnGainUnits(log, r.Serial, r.Gain, gain)
 							h = h.WithGain(gain)
 						}
 					}

--- a/cmd/gophertrunk/gain_test.go
+++ b/cmd/gophertrunk/gain_test.go
@@ -31,3 +31,39 @@ func TestParseGain(t *testing.T) {
 		}
 	}
 }
+
+func TestGainLooksLikeDBMistake(t *testing.T) {
+	cases := []struct {
+		raw     string
+		tenthDB int
+		want    bool
+	}{
+		// Bare integers that parse to <= 5.0 dB are almost certainly a
+		// dB value the operator forgot to express in tenths.
+		{"32", 32, true}, // the reported case: meant 32 dB, got 3.2 dB
+		{"1", 1, true},
+		{"50", 50, true}, // boundary: 5.0 dB still suspicious
+		// Plausible manual gains (>5.0 dB) and the shipped examples.
+		{"51", 51, false},
+		{"229", 229, false},
+		{"320", 320, false}, // the correct value for 32 dB
+		{"496", 496, false},
+		// Decimal forms are interpreted as whole dB by parseGain, so a
+		// decimal is an explicit choice — never flag it.
+		{"32.0", 320, false},
+		{"4.0", 40, false},
+		{"49.6", 496, false},
+		{"3,2", 32, false}, // comma decimal, locale paste
+		// auto / disabled gain must never warn.
+		{"auto", -1, false},
+		{"", -1, false},
+		{"0", 0, false},
+		{"-1", -1, false},
+	}
+	for _, c := range cases {
+		if got := gainLooksLikeDBMistake(c.raw, c.tenthDB); got != c.want {
+			t.Errorf("gainLooksLikeDBMistake(%q, %d) = %v, want %v",
+				c.raw, c.tenthDB, got, c.want)
+		}
+	}
+}

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -123,7 +123,9 @@ sdr:
     - serial: "00000001"   # match `gophertrunk sdr list`; first-found wins when blank
       role: control        # control | voice | auto
       ppm: 0               # 0 is fine for TCXO-equipped units like the NESDR Smart v5
-      gain: "auto"         # "auto" or a tenths-of-dB string ("496" = 49.6 dB)
+      gain: "auto"         # TENTHS of a dB — NOT dB. "496" = 49.6 dB. SDRTrunk/
+                           # OP25/gqrx users: multiply your dB figure by 10
+                           # (32 dB → "320"). "auto" (AGC) is the safe default.
       bias_tee: false      # enable the 5V bias-tee output for an external LNA
     - serial: "00000002"
       role: voice

--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -61,7 +61,7 @@ sdr:
     - serial: "00000001"      # whatever `gophertrunk sdr list` shows
       role: control            # or voice / auto
       ppm: 0                   # 0 is fine for TCXO-equipped units
-      gain: "auto"             # or a numeric tenths-of-dB string like "496"
+      gain: "auto"             # TENTHS of a dB, not dB — "496" = 49.6 dB
       bias_tee: true           # 5V on the SMA — only enable if you want it
 ```
 
@@ -74,6 +74,18 @@ sdr:
 > daemon now surfaces this at startup with `sdr: no gain configured
 > for device ...`; if you see that line, set `gain: "auto"` for AGC
 > or pick a tenth-dB value that matches your front-end.
+
+> **`gain:` is in TENTHS of a dB, not whole dB.** This is the most
+> common first-run footgun for operators coming from SDRTrunk / OP25 /
+> gqrx, which all take whole dB. In GopherTrunk `"320"` = 32 dB and
+> `"496"` = 49.6 dB; a bare `"32"` is parsed as **3.2 dB**, which the
+> driver then snaps to the bottom of the tuner's gain ladder, leaving
+> the radio effectively deaf (no control-channel lock, no decodes).
+> Multiply your usual dB figure by 10, or use `"auto"`. The daemon now
+> warns at startup (`gain looks like dB, not tenths-of-dB ...`) when a
+> bare integer gain parses to ≤ 5.0 dB, and logs the applied gain in dB
+> on every device (`sdr: gain set ... gain_db=...`). A decimal form like
+> `"32.0"` is taken as whole dB, so that works too.
 
 ### HackRF tested combinations
 

--- a/internal/sdr/pool.go
+++ b/internal/sdr/pool.go
@@ -358,6 +358,19 @@ func (p *Pool) applyHintSettings(dev Device, info Info, h Hint) {
 	if h.gainSet {
 		if err := dev.SetGain(h.Gain); err != nil {
 			p.log.Warn("set gain failed", "serial", info.Serial, "gain", h.Gain, "err", err)
+		} else if h.Gain < 0 {
+			p.log.Info("sdr: gain set to automatic (AGC)", "serial", info.Serial, "role", h.Role.String())
+		} else {
+			// Surface the *applied* gain in dB at INFO. The driver snaps
+			// h.Gain to the nearest rung on the tuner's ladder, so a
+			// units mistake (gain: "32" → 3.2 dB, see parseGain) ends up
+			// near the bottom of the ladder and silently deaf. Logging
+			// the dB figure on the normal startup path lets the operator
+			// catch it without enabling debug.
+			p.log.Info("sdr: gain set",
+				"serial", info.Serial,
+				"role", h.Role.String(),
+				"gain_db", float64(h.Gain)/10.0)
 		}
 	} else {
 		// Surface the "no `gain:` in config" path explicitly. Without


### PR DESCRIPTION
sdr.devices[].gain (and the rtl_tcp equivalent) is in tenths of a dB —
"320" = 32 dB — but operators migrating from SDRTrunk / OP25 / gqrx
routinely paste a whole-dB figure like "32", which parses to 3.2 dB and
SetGain then snaps to the bottom of the tuner's gain ladder, leaving the
radio effectively deaf: no control-channel lock, no decodes, and no
feedback explaining why. This is the most likely cause behind several
"can't lock the P25 CC, works fine in SDRTrunk" reports.

Add a startup guardrail and visibility:
- daemon WARNs when a bare-integer gain parses to <= 5.0 dB, naming the
  configured value, the parsed dB, and the likely intended (x10) value.
- the SDR pool now logs the applied gain in dB on every device
  (sdr: gain set ... gain_db=...) so a units mistake is visible without
  enabling debug.
- docs (config.example.yaml, docs/hardware.md) call out tenths-vs-dB.

No behaviour change for valid configs; decimal forms like "32.0" are
still taken as whole dB and never flagged.

https://claude.ai/code/session_01QksKmn64VLNhE6hbgczJqw