### PR TITLE
dsp/demod: fix adaptive C4FM slicer outer-rail under-tracking (#402)

### DIFF
--- a/internal/dsp/demod/adaptive_c4fm.go
+++ b/internal/dsp/demod/adaptive_c4fm.go
@@ -83,15 +83,18 @@ type AdaptiveC4FMSlicer struct {
 const adaptiveSlicerRate = 1.0 / 512.0
 
 // adaptiveSlicerLeak is a regularization pull back toward the nominal eye,
-// applied to every tracked level each symbol alongside the data-directed
-// update. It makes "degrade gracefully to the fixed slicer" a real
-// property rather than just a clamp: a level only departs nominal as far
-// as the data persistently supports it. At equilibrium a level settles at
-// rate/(rate+leak) of the way from nominal to the observed centroid — with
-// leak = rate/4 that's 0.8, so a strongly-supported asymmetry (the #402
-// +3 rail at ~1.6× nominal) still tracks most of the way, while an
-// ambiguous or partly-closed eye — where decision-directed tracking would
-// otherwise run away and do *worse* than fixed — is held near nominal.
+// applied alongside the data-directed update. It makes "degrade gracefully
+// to the fixed slicer" a real property rather than just a clamp: a level
+// only departs nominal as far as the data persistently supports it. At
+// equilibrium a level settles at rate/(rate+leak) of the way from nominal
+// to the observed centroid — with leak = rate/4 that's 0.8, so a
+// strongly-supported asymmetry (the #402 +3 rail at ~1.6× nominal) still
+// tracks most of the way, while an ambiguous or partly-closed eye — where
+// decision-directed tracking would otherwise run away and do *worse* than
+// fixed — is held near nominal. Both the data pull and this leak are scaled
+// by the per-symbol responsibility in update(), so each rail is regularized
+// in proportion to the evidence it receives and the 0.8 mix is independent
+// of the symbol prior.
 const adaptiveSlicerLeak = adaptiveSlicerRate / 4
 
 // adaptiveSlicerSigmaFrac sets the Gaussian-responsibility width used by the
@@ -239,9 +242,15 @@ func (a *AdaptiveC4FMSlicer) update(soft float32, sliced int8) {
 	}
 	for k := int8(0); k < 4; k++ {
 		rk := w[k] / sum
-		// Responsibility-weighted pull toward the sample, plus the same leak
-		// back toward nominal that regularizes the estimate (adaptiveSlicerLeak).
-		a.level[k] += a.rate*rk*(soft-a.level[k]) + adaptiveSlicerLeak*(a.nominal[k]-a.level[k])
+		// Responsibility-weighted pull toward the sample AND a
+		// responsibility-weighted leak back toward nominal. Both terms scale
+		// by rk so each rail is updated at the same cadence the hard
+		// decided-rail EMA used (its symbol prior), preserving the intended
+		// equilibrium mix level = rate/(rate+leak) ≈ 0.8 of the way from
+		// nominal to the observed centroid. (Leaking on every sample while
+		// pulling only by rk halved that mix and made the outer rail
+		// under-track — issue #402 follow-up to #439.)
+		a.level[k] += rk * (a.rate*(soft-a.level[k]) + adaptiveSlicerLeak*(a.nominal[k]-a.level[k]))
 		a.clampLevel(k)
 	}
 	a.enforceOrder()

--- a/internal/dsp/demod/adaptive_c4fm_test.go
+++ b/internal/dsp/demod/adaptive_c4fm_test.go
@@ -128,8 +128,8 @@ func TestAdaptiveSlicerRecoversAsymmetricEyeWhereFixedFails(t *testing.T) {
 	// Mechanism B: the soft-responsibility update must converge level[+3]
 	// toward the true centroid (~0.374), not the lower-truncated ~0.43 a hard
 	// decided-rail EMA produced (the value the #402 diag reported).
-	if lv[3] < 0.30 || lv[3] > 0.40 {
-		t.Errorf("tracked +3 level = %.4f, want in [0.30, 0.40] (debiased toward the true 0.374 centroid)", lv[3])
+	if lv[3] < 0.33 || lv[3] > 0.40 {
+		t.Errorf("tracked +3 level = %.4f, want in [0.33, 0.40] (≈0.8·0.374+0.2·nominal; under 0.33 means the rail is under-tracking)", lv[3])
 	}
 }
 
@@ -250,6 +250,47 @@ func TestAdaptiveSlicerNoOuterThresholdRunawayOnClosedEye(t *testing.T) {
 	// Mechanism B: tracked +3 level debiased toward the true centroid.
 	if lv[3] > 0.40 {
 		t.Errorf("tracked +3 level = %.4f, want ≤ 0.40 (pre-fix truncation bias read ~0.43)", lv[3])
+	}
+}
+
+// TestAdaptiveSlicerOuterRailTrackingGain pins the equilibrium tracking gain
+// of the soft-responsibility level update. The intended mix is
+// rate/(rate+leak) = 0.8 of the way from nominal to the observed centroid.
+// The first DDA cut (#439) scaled only the data pull by responsibility and
+// left the leak firing on every sample, which halved the mix to ~0.5 and made
+// the outer rail under-track (the #402 follow-up: +3 settled ~0.30 against a
+// ~0.40 centroid). This test fails on that code and passes once the leak is
+// also responsibility-weighted.
+func TestAdaptiveSlicerOuterRailTrackingGain(t *testing.T) {
+	const slicerScale = 0.2356
+	rng := rand.New(rand.NewSource(11))
+
+	// Balanced eye: negative rail + inner rails nominal, +3 outer stretched to
+	// a known centroid. Low noise + wide separation so the EMA converges to its
+	// equilibrium without eye-closure bias.
+	nom := nominalLevels(slicerScale)
+	const c3 = 0.40
+	levels := [4]float64{nom[0], nom[1], nom[2], c3}
+	const n = 80_000
+	soft, _ := buildEyeStream(rng, n, levels, 0.03)
+
+	a := NewAdaptiveC4FMSlicer(slicerScale)
+	a.SliceMany(nil, soft)
+	lv := a.Levels()
+
+	const mix = 0.8 // rate/(rate+leak) with leak = rate/4
+	want := mix*c3 + (1-mix)*nom[3]
+	got := float64(lv[3])
+	t.Logf("+3 rail: got=%.4f want≈%.4f (centroid=%.3f nominal=%.4f); #439 bug gave ≈%.4f",
+		got, want, c3, nom[3], 0.5*c3+0.5*nom[3])
+	if math.Abs(got-want) > 0.02 {
+		t.Errorf("+3 rail tracking gain off: got=%.4f want≈%.4f (mix should be ~0.8, not the ~0.5 of the #439 bug)", got, want)
+	}
+	// The negative outer rail's centroid is its nominal, so it must stay put —
+	// the leak is responsibility-weighted but a rail at its centroid sees a
+	// zero net pull either way.
+	if math.Abs(float64(lv[0])-nom[0]) > 0.02 {
+		t.Errorf("-3 rail drifted from nominal: got=%.4f want≈%.4f", lv[0], nom[0])
 	}
 }
 


### PR DESCRIPTION
Follow-up to #439. After #439 stopped the `+3` rail runaway, the reporter on #402 found the opposite error: the stretched `+3` rail now **under-tracks**, settling at ~0.30 against a measured ~0.40 centroid, so the `+1/+3` threshold sits below optimal and `+3` decisions stay suppressed (dibit `+3` only ~15%, NID back down to ~50%).

## Root cause

The soft-responsibility level update introduced in #439 scaled the data-directed pull by the per-symbol responsibility `rk` but left the leak-toward-nominal firing at full weight on **every** sample:

```go
a.level[k] += a.rate*rk*(soft-a.level[k]) + adaptiveSlicerLeak*(a.nominal[k]-a.level[k])
//                   ^^^ scaled by rk          ^^^ NOT scaled
```

The original hard decided-rail EMA updated only the decided rail, so both terms acted on a rail at the same cadence (its symbol prior), giving the documented equilibrium

```
level = rate/(rate+leak)·centroid + (leak/(rate+leak))·nominal   →  0.8 mix
```

Leaking every sample while pulling only by `rk` (≈ prior ≈ 0.25) halves the mix to ~0.5, over-regularizing every rail toward nominal. The reporter's `+3` at ~0.30 (mix ≈ 0.38) confirms it.

## Fix

Scale the leak by `rk` as well, so the update is a true responsibility-weighted EMA and the 0.8 mix is restored independent of the symbol prior:

```go
a.level[k] += rk * (a.rate*(soft-a.level[k]) + adaptiveSlicerLeak*(a.nominal[k]-a.level[k]))
```

The `+3` rail now tracks to ~`0.8·centroid + 0.2·nominal` (~0.37 on that capture) and the `+1/+3` threshold lands at the ~0.22 optimal midpoint. The anchored-threshold cap, per-level clamp, and ordering invariants are unchanged; the degenerate-input bound still holds (a low-responsibility rail now also gets little leak, so it stays at nominal rather than being force-pulled).

## Verification

- New `TestAdaptiveSlicerOuterRailTrackingGain` pins the 0.8 equilibrium mix — it fails on the pre-fix ~0.5 mix (got 0.368 vs intended 0.367; the bug gave 0.318), the guard the previous loose `[0.30,0.40]` bound was missing.
- Tightened the headline asymmetric-eye test's `+3`-level lower bound (0.30 → 0.33) so under-tracking is caught there too. Synthetic closed-eye `level[+3]` rose 0.326 → 0.354, threshold 0.205 → 0.228, headline `+1/+3` confusions 39 → 17.
- `go build ./...` and `go test ./internal/dsp/... ./internal/radio/p25/...` all green; `gofmt`/`vet` clean.

## Caveat carried forward

If, after the rail tracks to ~0.37 and the threshold sits at ~0.22, dibit `+3` is still materially below ~25%, the residual is the separate upstream C4FM-matched-filter vs. MMR TX-shaping / deviation-calibration question already flagged on #402 — to be split into its own issue, not chased here. (The reporter is also testing on `mmr-s9-2.cfile` (centroid ~0.40) rather than the original `mmr-s9.cfile` (~0.374); the fix is capture-agnostic but the A/B baseline stays slightly muddied until the same capture is used.)

https://claude.ai/code/session_01JHEdw6e57j4VReaQDc1VEq

---
_Generated by [Claude Code](https://claude.ai/code/session_01JHEdw6e57j4VReaQDc1VEq)_