### PR TITLE
dsc: add FFSK DSP frontend and bit-stream receiver

### DIFF
--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -26,6 +26,7 @@ import (
 	adsbbeast "github.com/MattCheramie/GopherTrunk/internal/radio/adsb/beast"
 	aisgmsk "github.com/MattCheramie/GopherTrunk/internal/radio/ais/gmsk"
 	aprsafsk "github.com/MattCheramie/GopherTrunk/internal/radio/aprs/afsk"
+	dscffsk "github.com/MattCheramie/GopherTrunk/internal/radio/dsc/ffsk"
 	mdc1200afsk "github.com/MattCheramie/GopherTrunk/internal/radio/mdc1200/afsk"
 	pocsagrx "github.com/MattCheramie/GopherTrunk/internal/radio/pager/pocsag/receiver"
 	"github.com/MattCheramie/GopherTrunk/internal/sdr"
@@ -201,6 +202,12 @@ type Daemon struct {
 	// publishes decoded vessel messages on KindAISMessage.
 	aisReceivers []*aisgmsk.Receiver
 	aisSpecs     []aisSpec // index-aligned with aisReceivers
+	// dscReceivers holds one DSC FFSK receiver per configured
+	// dsc.channels entry. Same shape as the AIS receivers above: each
+	// subscribes to its assigned SDR's iqtap broker and publishes
+	// decoded DSC sequences on KindDSCMessage.
+	dscReceivers []*dscffsk.Receiver
+	dscSpecs     []dscSpec // index-aligned with dscReceivers
 	// mdc1200Receivers holds one MDC1200 FFSK receiver per configured
 	// mdc1200.channels entry. Same shape as the APRS receivers above:
 	// each subscribes to its assigned SDR's iqtap broker and publishes
@@ -1071,6 +1078,38 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 		d.aisSpecs = append(d.aisSpecs, spec)
 	}
 
+	// DSC FFSK receivers — one per configured dsc.channels entry.
+	// Same construction shape as AIS / MDC1200 above: per-entry
+	// validation in the receiver, failures surface as a startup
+	// warning and skip the entry (nil slot preserved for stable
+	// indexing).
+	for _, dc := range cfg.DSC.Channels {
+		spec := dscSpec{serial: dc.Serial, freq: dc.FrequencyHz}
+		if dc.Serial == "" || dc.FrequencyHz == 0 {
+			d.addWarning(fmt.Sprintf(
+				"dsc.channels: entry missing serial or frequency_hz (serial=%q freq=%d) — skipped",
+				dc.Serial, dc.FrequencyHz))
+			d.dscReceivers = append(d.dscReceivers, nil)
+			d.dscSpecs = append(d.dscSpecs, spec)
+			continue
+		}
+		rcv, err := dscffsk.New(dscffsk.Options{
+			InputRateHz: cfg.SDR.SampleRate,
+			SourceName:  dc.Serial,
+			Bus:         d.bus,
+			DropBadFCS:  dc.DropBadFCS,
+			Log:         log,
+		})
+		if err != nil {
+			d.addWarning(fmt.Sprintf("dsc.channels[%s]: %v — skipped", dc.Serial, err))
+			d.dscReceivers = append(d.dscReceivers, nil)
+			d.dscSpecs = append(d.dscSpecs, spec)
+			continue
+		}
+		d.dscReceivers = append(d.dscReceivers, rcv)
+		d.dscSpecs = append(d.dscSpecs, spec)
+	}
+
 	// MDC1200 FFSK receivers — one per configured mdc1200.channels
 	// entry. Same construction shape as APRS / AIS above: per-entry
 	// validation in the receiver, failures surface as a startup
@@ -1620,6 +1659,38 @@ func (d *Daemon) Run(ctx context.Context) error {
 			}
 			if err := br.SetCenterFreq(spec.freq); err != nil {
 				d.log.Warn("ais: SetCenterFreq failed",
+					"serial", spec.serial, "freq_hz", spec.freq, "err", err)
+				return nil
+			}
+			sub := br.Subscribe()
+			defer sub.Close()
+			return rcv.Process(ctx, sub.C)
+		})
+	}
+	// DSC receivers — same shape as AIS above. Each subscribes to its
+	// assigned SDR's iqtap broker and runs the FFSK pipeline (FM demod
+	// → FFSK discriminator at 1300/2100 Hz → symbol-timing recovery →
+	// direct-FSK slicer → BCH character sync → ITU-R M.493 parser),
+	// publishing sequences onto the events bus where the DSCLog
+	// subscriber persists them and the /dsc panel renders them.
+	// Non-essential: a missing SDR or misconfigured frequency is
+	// logged but doesn't bring down the trunking pipeline.
+	for i, rcv := range d.dscReceivers {
+		if rcv == nil {
+			continue // skipped at construction; warning already logged
+		}
+		rcv := rcv
+		spec := d.dscSpecs[i]
+		name := fmt.Sprintf("dsc-%s-%d", spec.serial, spec.freq)
+		d.spawn(runCtx, name, false, func(ctx context.Context) error {
+			br := d.iqBrokers[spec.serial]
+			if br == nil {
+				d.log.Warn("dsc: SDR not found, skipping receiver",
+					"serial", spec.serial, "freq_hz", spec.freq)
+				return nil
+			}
+			if err := br.SetCenterFreq(spec.freq); err != nil {
+				d.log.Warn("dsc: SetCenterFreq failed",
 					"serial", spec.serial, "freq_hz", spec.freq, "err", err)
 				return nil
 			}
@@ -2624,6 +2695,15 @@ type aprsSpec struct {
 // loop can spawn each receiver without re-walking the YAML. Mirrors
 // aprsSpec / pocsagSpec.
 type aisSpec struct {
+	serial string
+	freq   uint32
+}
+
+// dscSpec captures the broker-side wiring info for one configured DSC
+// channel. Index-aligned with Daemon.dscReceivers so the Run loop can
+// spawn each receiver without re-walking the YAML. Mirrors aisSpec /
+// mdc1200Spec.
+type dscSpec struct {
 	serial string
 	freq   uint32
 }

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -326,13 +326,15 @@ sdr:
 #                                     #  bursts instead of publishing them
 #                                     #  with crc_ok=false
 
-# DSC marine distress / safety / routine calls. The DSP frontend
-# (1200 Bd FSK on channel 70 = 156.525 MHz, mark 1300 Hz / space
-# 2100 Hz) ships in a follow-up PR; the protocol parser + bus +
-# storage + REST + panel scaffolding is live now. Operators
-# subscribing to the events.KindDSCMessage bus topic (e.g. a
-# custom CL replay tool) get decoded messages as soon as they
-# feed symbols into dsc.Decode.
+# DSC marine distress / safety / routine calls. Each entry pins one
+# SDR to a DSC channel and decodes the calls. Pipeline: FM demod →
+# FFSK discriminator (DSC tones, mark 1300 Hz / space 2100 Hz,
+# 1200 baud) → symbol-timing recovery → direct-FSK slicer →
+# BCH(10,7) character sync → ITU-R M.493 sequence parser. Decoded
+# sequences publish on events.KindDSCMessage; storage.DSCLog
+# persists them to the dsc_log SQLite table, the REST endpoint at
+# /api/v1/dsc/messages returns the most recent N, and the /dsc web
+# panel renders them live (distress alerts, MMSIs, positions).
 #
 # dsc:
 #   channels:
@@ -341,9 +343,9 @@ sdr:
 #       frequency_hz: 156_525_000     # marine VHF channel 70 (or one of
 #                                     #  the HF DSC channels: 2_187_500,
 #                                     #  8_414_500, 12_577_000, 16_804_500)
-#       drop_non_distress: false      # true to drop routine / safety
-#                                     #  chatter and keep only distress
-#                                     #  + urgency alerts
+#       drop_bad_fcs: false           # true to silently drop sequences
+#                                     #  with a BCH-failed character instead
+#                                     #  of publishing them flagged
 
 # ADS-B / aviation. Most 1090 MHz receive chains already run
 # dump1090 / readsb / BeastSplitter against a dedicated RTL-SDR

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -29,6 +29,7 @@ type Config struct {
 	Paging     PagingConfig     `yaml:"paging"`
 	APRS       APRSConfig       `yaml:"aprs"`
 	AIS        AISConfig        `yaml:"ais"`
+	DSC        DSCConfig        `yaml:"dsc"`
 	MDC1200    MDC1200Config    `yaml:"mdc1200"`
 	ADSB       ADSBConfig       `yaml:"adsb"`
 }
@@ -108,6 +109,33 @@ type AISChannelConfig struct {
 	FrequencyHz     uint32 `yaml:"frequency_hz"`
 	DropBadFCS      bool   `yaml:"drop_bad_fcs"`
 	DropNonPosition bool   `yaml:"drop_non_position"`
+}
+
+// DSCConfig configures the marine Digital Selective Calling receiver.
+// Each entry pins an SDR to a DSC channel — VHF channel 70 is
+// 156.525 MHz; HF DSC rides 2187.5 / 8414.5 / 12577 / 16804.5 kHz
+// among others — and runs the DSP frontend (FM demod → FFSK tone
+// discriminator at 1300/2100 Hz → symbol-timing recovery → direct-FSK
+// slicer → BCH(10,7) character sync → ITU-R M.493 sequence parser)
+// against its full IQ stream. Decoded sequences publish on
+// events.KindDSCMessage; storage.DSCLog persists them, the REST
+// endpoint at /api/v1/dsc/messages and the /dsc web panel render them.
+type DSCConfig struct {
+	Channels []DSCChannelConfig `yaml:"channels"`
+}
+
+// DSCChannelConfig describes one DSC channel to decode. Serial picks
+// the SDR; the daemon tunes it to FrequencyHz and runs the FFSK
+// receiver against its full IQ stream. The VHF calling channel 70
+// (156.525 MHz) is the most common target — it carries distress /
+// urgency / safety alerts and the routine call-ups that precede a
+// voice working-channel hand-off. DropBadFCS matches the receiver's
+// option: leave it false to see BCH-marginal sequences on the panel
+// (flagged), flip it on for noisy channels.
+type DSCChannelConfig struct {
+	Serial      string `yaml:"serial"`
+	FrequencyHz uint32 `yaml:"frequency_hz"`
+	DropBadFCS  bool   `yaml:"drop_bad_fcs"`
 }
 
 // MDC1200Config configures the Motorola MDC1200 FFSK signaling

--- a/internal/radio/dsc/ffsk/receiver.go
+++ b/internal/radio/dsc/ffsk/receiver.go
@@ -1,0 +1,223 @@
+// Package ffsk wires the DSC DSP pipeline together: an IQ stream from
+// the iqtap broker becomes 1200-baud FFSK audio, then a direct-FSK bit
+// stream, then decoded DSC sequences on the events bus. The pipeline
+// is:
+//
+//	IQ chunks (Fs Hz, complex64)
+//	  → FM demod (internal/dsp/demod.FM)
+//	  → real resampler (internal/dsp/resampler_real) to AudioRateHz
+//	  → FFSK tone discriminator (internal/dsp/demod.FFSK,
+//	    markHz=1300, spaceHz=2100 — ITU-R M.493 DSC tones)
+//	  → Mueller-Müller symbol-timing recovery
+//	    (internal/dsp/sync.MuellerMuller, 8 sps → 1 sample/symbol)
+//	  → DC-tracking slicer (direct-FSK bit on the wire)
+//	  → dsc/receiver.Receiver.Push(bit)
+//	  → events.KindDSCMessage on the bus
+//
+// Layout mirrors internal/radio/mdc1200/afsk: one Receiver per (SDR,
+// DSC-frequency) pair, the daemon pumps the broker subscription into
+// Process. Like MDC1200 — and unlike APRS / AIS — DSC carries no NRZI
+// line code, so the sliced bit feeds the framer directly; the tones
+// are the DSC pair (1300/2100 Hz) rather than CCIR FFSK's 1200/1800.
+//
+// Channel 70 (156.525 MHz) is the VHF DSC calling channel; HF DSC
+// rides 2187.5 / 8414.5 / 12577 / 16804.5 kHz among others. The
+// receiver is frequency-agnostic — the daemon tunes the SDR.
+package ffsk
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync/atomic"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp"
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/demod"
+	dspsync "github.com/MattCheramie/GopherTrunk/internal/dsp/sync"
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	dscrx "github.com/MattCheramie/GopherTrunk/internal/radio/dsc/receiver"
+)
+
+// DSC FSK tone frequencies per ITU-R M.493-15 §3.1.
+const (
+	MarkHz  = 1300.0 // binary 1 ("B")
+	SpaceHz = 2100.0 // binary 0 ("Y")
+)
+
+// BaudHz is the VHF DSC signalling rate (1200 baud; HF DSC uses 100
+// baud, not handled by this frontend).
+const BaudHz = 1200
+
+// Oversample is the number of FFSK-discriminator samples per DSC bit
+// fed into the Mueller-Müller timing-recovery loop. 8 matches the
+// APRS / AIS / MDC1200 frontends — enough sub-sample resolution to
+// track the symbol clock, cheap at 1200 baud.
+const Oversample = 8
+
+// AudioRateHz is the audio rate the FFSK discriminator runs at:
+// baud × Oversample = 1200 × 8 = 9600.
+const AudioRateHz = BaudHz * Oversample
+
+// mmGain is the Mueller-Müller loop gain — the same conventional
+// AFSK-paired starting point the other narrowband-FSK frontends use.
+const mmGain = 0.05
+
+// Options configures a Receiver.
+type Options struct {
+	// InputRateHz is the IQ sample rate the broker is feeding at.
+	InputRateHz uint32
+
+	// SourceName is stamped on log lines and surfaces in metrics.
+	SourceName string
+
+	// Bus is required — messages publish onto KindDSCMessage via the
+	// dsc/receiver orchestrator.
+	Bus *events.Bus
+
+	// DropBadFCS, when true, drops sequences with a BCH-failed DX
+	// character at the orchestrator. Defaults to false.
+	DropBadFCS bool
+
+	// Log is optional; defaults to slog.Default.
+	Log *slog.Logger
+}
+
+// Receiver runs a DSC FFSK decode pipeline against a stream of IQ
+// chunks. One Receiver per (SDR, DSC-frequency) pair.
+type Receiver struct {
+	inputRate uint32
+	source    string
+	log       *slog.Logger
+
+	fm    *demod.FM
+	rsmp  *dsp.RealResampler
+	ffsk  *demod.FFSK
+	mm    *dspsync.MuellerMuller
+	inner *dscrx.Receiver
+
+	// Per-call scratch buffers reused across Process iterations so the
+	// hot path never allocates.
+	demodBuf    []float32
+	rsmpBuf     []float32
+	ffskBuf     []float32
+	symBuf      []float32
+	meanEMA     float32
+	meanReady   bool
+	samplesSeen atomic.Uint64
+	bitsEmitted atomic.Uint64
+}
+
+// New constructs a Receiver. Returns an error if opts.Bus is nil or
+// InputRateHz is unset.
+func New(opts Options) (*Receiver, error) {
+	if opts.Bus == nil {
+		return nil, errors.New("dsc/ffsk: Bus is required")
+	}
+	if opts.InputRateHz == 0 {
+		return nil, errors.New("dsc/ffsk: InputRateHz is required")
+	}
+	log := opts.Log
+	if log == nil {
+		log = slog.Default()
+	}
+
+	out := uint32(AudioRateHz)
+	g := gcd(out, opts.InputRateHz)
+	L := int(out / g)
+	M := int(opts.InputRateHz / g)
+	if L == 0 || M == 0 {
+		return nil, fmt.Errorf("dsc/ffsk: bad resample ratio L=%d M=%d", L, M)
+	}
+
+	return &Receiver{
+		inputRate: opts.InputRateHz,
+		source:    opts.SourceName,
+		log:       log,
+		fm:        demod.NewFM(),
+		rsmp:      dsp.NewRealResampler(L, M, 16, 7.0),
+		ffsk:      demod.NewFFSK(float64(AudioRateHz), MarkHz, SpaceHz),
+		mm:        dspsync.NewMuellerMuller(float64(Oversample), mmGain),
+		inner: dscrx.New(dscrx.Options{
+			Bus:        opts.Bus,
+			DropBadFCS: opts.DropBadFCS,
+		}),
+	}, nil
+}
+
+// Process pumps IQ chunks from in through the decode pipeline until
+// ctx cancels or in closes.
+func (r *Receiver) Process(ctx context.Context, in <-chan []complex64) error {
+	if in == nil {
+		return errors.New("dsc/ffsk: input channel is nil")
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case chunk, ok := <-in:
+			if !ok {
+				return nil
+			}
+			r.processChunk(chunk)
+		}
+	}
+}
+
+// processChunk runs one IQ chunk through FM → resample → FFSK
+// discrimination → MM symbol-time recovery → slice → push.
+func (r *Receiver) processChunk(chunk []complex64) {
+	r.samplesSeen.Add(uint64(len(chunk)))
+	r.demodBuf = r.fm.Process(r.demodBuf, chunk)
+	r.rsmpBuf = r.rsmp.Process(r.rsmpBuf, r.demodBuf)
+	r.ffskBuf = r.ffsk.Discriminate(r.ffskBuf, r.rsmpBuf)
+	r.symBuf = r.mm.Process(r.symBuf, r.ffskBuf)
+	for _, s := range r.symBuf {
+		r.feedSymbol(s)
+	}
+}
+
+// feedSymbol slices one recovered symbol to a direct-FSK bit (tracking
+// DC bias with a slow EMA) and pushes it into the framer. DSC has no
+// NRZI stage. Tone-sense ambiguity is resolved by the orchestrator's
+// dual-polarity phasing hunt, so a fixed mark=1 slicer is sufficient
+// here.
+func (r *Receiver) feedSymbol(s float32) {
+	if !r.meanReady {
+		r.meanEMA = s
+		r.meanReady = true
+	} else {
+		r.meanEMA += (s - r.meanEMA) * (1.0 / 64.0)
+	}
+	var bit byte
+	if s > r.meanEMA {
+		bit = 1
+	}
+	r.inner.Push(bit)
+	r.bitsEmitted.Add(1)
+}
+
+// Inner returns the bit-stream orchestrator the frontend is driving.
+// Exposed so the daemon can read Stats() for /metrics.
+func (r *Receiver) Inner() *dscrx.Receiver { return r.inner }
+
+// Stats reports cumulative DSP-frontend counters.
+type Stats struct {
+	IQSamplesSeen uint64 // raw IQ samples Process has consumed
+	BitsEmitted   uint64 // bits handed to the orchestrator
+}
+
+func (r *Receiver) Stats() Stats {
+	return Stats{
+		IQSamplesSeen: r.samplesSeen.Load(),
+		BitsEmitted:   r.bitsEmitted.Load(),
+	}
+}
+
+// gcd computes the greatest common divisor via Euclid's algorithm.
+func gcd(a, b uint32) uint32 {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}

--- a/internal/radio/dsc/ffsk/receiver_test.go
+++ b/internal/radio/dsc/ffsk/receiver_test.go
@@ -1,0 +1,162 @@
+package ffsk
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/demod"
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/dsc"
+	"github.com/MattCheramie/GopherTrunk/internal/storage"
+)
+
+func TestNewRejectsBadOptions(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+
+	if _, err := New(Options{}); err == nil {
+		t.Error("New without Bus: want error")
+	}
+	if _, err := New(Options{Bus: bus}); err == nil {
+		t.Error("New without InputRateHz: want error")
+	}
+}
+
+func TestNewSetsUpInner(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	r, err := New(Options{InputRateHz: 96_000, Bus: bus})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if r.Inner() == nil {
+		t.Error("Inner() = nil, want non-nil orchestrator")
+	}
+}
+
+func TestProcessPropagatesContextCancel(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	r, err := New(Options{InputRateHz: 96_000, Bus: bus})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	in := make(chan []complex64)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- r.Process(ctx, in) }()
+	cancel()
+	select {
+	case err := <-done:
+		if err != context.Canceled {
+			t.Errorf("Process err = %v, want context.Canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Process did not exit after ctx cancel")
+	}
+}
+
+func TestProcessNilInputErrors(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	r, _ := New(Options{InputRateHz: 96_000, Bus: bus})
+	if err := r.Process(context.Background(), nil); err == nil {
+		t.Error("Process with nil input: want error")
+	}
+}
+
+// charBits / phasingDX are duplicated from the receiver package's
+// unexported constants for the test's bit-builder.
+const (
+	charBits  = 10
+	phasingDX = 125
+)
+
+// appendChar appends one 10-bit DSC character (BCH-encoded from a
+// 7-bit symbol), MSB-first, as 0/1 bytes.
+func appendChar(bits []byte, sym byte) []byte {
+	cw := dsc.BCHEncode(uint16(sym))
+	for i := charBits - 1; i >= 0; i-- {
+		bits = append(bits, byte((cw>>uint(i))&1))
+	}
+	return bits
+}
+
+// buildWireBits assembles a complete DSC bit stream: a dotting
+// preamble (for symbol-timing lock), a phasing run, then the message
+// symbols transmitted DX-then-RX on the 10-bit grid.
+func buildWireBits(syms []byte) []byte {
+	var bits []byte
+	// Dotting: alternating bits give the Mueller-Müller loop and the
+	// FFSK discriminator time to settle before the phasing run.
+	for i := 0; i < 240; i++ {
+		bits = append(bits, byte(i&1))
+	}
+	for i := 0; i < 12; i++ {
+		bits = appendChar(bits, phasingDX)       // DX
+		bits = appendChar(bits, byte(111-(i%8))) // RX placeholder
+	}
+	for _, s := range syms {
+		bits = appendChar(bits, s) // DX
+		bits = appendChar(bits, s) // RX twin
+	}
+	return bits
+}
+
+// TestEndToEndDistressDecode modulates a DSC distress sequence to an
+// IQ stream, runs it through the full frontend, and asserts the
+// decoded message lands on the bus. This validates the FM → resample
+// → FFSK → symbol-timing → slicer → BCH-sync → parser chain together.
+func TestEndToEndDistressDecode(t *testing.T) {
+	bus := events.NewBus(64)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	const inputRate = 96_000
+	r, err := New(Options{InputRateHz: inputRate, Bus: bus})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	syms := []byte{112, 36, 60, 53, 20, 90, 100, 3, 74, 81, 22, 24, 14, 25, 127}
+	bits := buildWireBits(syms)
+	iq := demod.ModulateFFSK(bits, float64(inputRate), float64(BaudHz), MarkHz, SpaceHz)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	in := make(chan []complex64, 1)
+	done := make(chan struct{})
+	go func() {
+		_ = r.Process(ctx, in)
+		close(done)
+	}()
+	in <- iq
+	close(in)
+	<-done
+
+	deadline := time.After(time.Second)
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind != events.KindDSCMessage {
+				continue
+			}
+			m := ev.Payload.(storage.DSCMessage)
+			if m.Format != "distress" {
+				t.Errorf("Format = %q, want distress", m.Format)
+			}
+			if m.SelfMMSI != 366053209 {
+				t.Errorf("SelfMMSI = %d, want 366053209", m.SelfMMSI)
+			}
+			if !m.HasPosition {
+				t.Error("HasPosition = false, want true")
+			}
+			return
+		case <-deadline:
+			t.Fatalf("no DSC message decoded; frontend stats = %+v, inner = %+v",
+				r.Stats(), r.Inner().Stats())
+		}
+	}
+}

--- a/internal/radio/dsc/receiver/receiver.go
+++ b/internal/radio/dsc/receiver/receiver.go
@@ -1,0 +1,310 @@
+// Package receiver frames a demodulated DSC bit stream: it slides a
+// 10-bit window through the bits, uses the BCH(10,7) syndrome check to
+// lock onto the phasing-sequence DX characters (value 125, repeating
+// every 20 bits), then samples the DX cadence to recover the 7-bit
+// data symbols, detects the end-of-sequence character, and hands the
+// symbol run to internal/radio/dsc.Decode. One events.KindDSCMessage
+// publishes per decoded sequence.
+//
+// The DSP layer above this package (internal/radio/dsc/ffsk: FM demod
+// → FFSK tone discrimination at 1300/2100 Hz → symbol-timing recovery
+// → slicer) hands the receiver its bit stream. From bits down through
+// bus event is what this package owns.
+//
+// One Receiver instance per DSC channel. The Push(bit) method is the
+// single entry point — call it once per wire bit. DSC is direct FSK
+// (no NRZI line code, unlike AX.25 / AIS), so the slicer's bit feeds
+// the framer directly.
+//
+// # DX / RX time diversity
+//
+// DSC transmits each information character twice: once in the DX
+// position and again in the RX position, the two interleaved at the
+// 10-bit character cadence so the DX characters land on a 20-bit
+// grid. This first slice takes the simplest viable path the handoff
+// describes — lock the DX grid via the repeating phasing character
+// and read DX only, dropping the RX copies. Comparing DX against its
+// RX twin to recover characters that fail their BCH check is a
+// follow-up (it lifts decode yield on marginal signals); it is not
+// required for clean captures.
+//
+// # Polarity
+//
+// An FM discriminator can present the tones with either sense
+// depending on tuning, so the phasing hunt accepts both the DX
+// character and its bitwise complement; when it locks on the
+// complement the sampled characters are inverted to recover the true
+// symbols. This mirrors the MDC1200 receiver's approach.
+//
+// # On-wire calibration
+//
+// The 10-bit characters are assembled most-significant-bit-first into
+// the codeword integer layout internal/radio/dsc/bch.go defines
+// (7 data bits then 3 check bits). That convention is validated
+// end-to-end against the FFSK modulator in the frontend test; the
+// exact wire bit order, tone-frequency sense, and DX/RX offset of
+// real ITU-R M.493 traffic should be confirmed against a captured
+// signal before relying on field decodes.
+package receiver
+
+import (
+	"sync/atomic"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/dsc"
+	"github.com/MattCheramie/GopherTrunk/internal/storage"
+)
+
+// charBits is the DSC character length: 7 data bits + 3 BCH check
+// bits per ITU-R M.493-15 §3.4.
+const charBits = 10
+
+// dxStride is the DX-character spacing in bits. DX and RX characters
+// interleave at the 10-bit cadence, so successive DX characters land
+// 20 bits apart.
+const dxStride = 2 * charBits
+
+// charMask isolates the low charBits of the sliding window.
+const charMask = (uint16(1) << charBits) - 1
+
+// phasingDX is the DSC phasing-sequence DX character (ITU-R M.493-15
+// §3.2.1). It repeats on the DX grid through the phasing run, giving
+// the receiver a stable pattern to lock the character cadence and
+// polarity onto.
+const phasingDX = 125
+
+// maxSeqSyms caps the symbols collected for one sequence. A runaway
+// capture with no end-of-sequence character is abandoned and the
+// receiver returns to hunting rather than growing without bound. The
+// longest standard DSC sequence (geographic / position call) is well
+// under this.
+const maxSeqSyms = 40
+
+// eosSyms are the DSC end-of-sequence characters: 117 (acknowledge
+// required), 122 (acknowledge), 127 (end of sequence). Any of them on
+// the DX grid closes the sequence.
+var eosSyms = map[byte]bool{117: true, 122: true, 127: true}
+
+type state uint8
+
+const (
+	stateHunt   state = iota // searching for the phasing DX cadence
+	stateLocked              // DX grid + polarity established, reading symbols
+)
+
+// Receiver consumes a DSC bit stream and publishes decoded messages
+// on the shared events bus. Zero-value Receivers are NOT usable —
+// call New.
+type Receiver struct {
+	bus *events.Bus
+
+	// dropBadFCS, when true, discards sequences in which any DX
+	// character failed its BCH check (DX-only decode cannot recover
+	// those). Defaults to false — the sequence still publishes so the
+	// panel can flag a marginal decode.
+	dropBadFCS bool
+
+	st    state
+	reg   uint16 // sliding charBits window, newest bit in the LSB
+	nbits int    // bits pushed since construction (monotonic)
+	full  bool   // window has seen at least charBits bits
+
+	// Hunt state: the most recent phasing-DX sighting, used to
+	// confirm the 20-bit DX cadence.
+	lastDXBit int
+	lastDXPol bool
+	dxSeen    bool
+
+	// Lock state.
+	inverted bool // locked on the complemented character sense
+	lockBit  int  // nbits at the locked DX boundary; DX grid is lockBit + k·dxStride
+	started  bool // saw the first non-phasing DX character (format specifier)
+	syms     []byte
+	badInSeq int // DX characters that failed BCH in the current sequence
+
+	// Counters surfaced for /metrics.
+	seqIn   atomic.Uint64 // sequences whose EOS was reached
+	seqBad  atomic.Uint64 // sequences with ≥1 BCH-failed DX character
+	seqEmit atomic.Uint64 // events published to the bus
+}
+
+// Options configures a Receiver.
+type Options struct {
+	// Bus is required — messages publish onto KindDSCMessage.
+	Bus *events.Bus
+
+	// DropBadFCS discards sequences with a BCH-failed DX character
+	// when true.
+	DropBadFCS bool
+}
+
+// New constructs a Receiver. Panics if opts.Bus is nil — receivers
+// without a bus have nowhere to publish.
+func New(opts Options) *Receiver {
+	if opts.Bus == nil {
+		panic("dsc/receiver: events.Bus is required")
+	}
+	return &Receiver{bus: opts.Bus, dropBadFCS: opts.DropBadFCS}
+}
+
+// Push feeds one wire bit through the framer. Bits outside {0, 1} are
+// clamped to 1.
+func (r *Receiver) Push(bit byte) {
+	if bit > 1 {
+		bit = 1
+	}
+	r.reg = ((r.reg << 1) | uint16(bit)) & charMask
+	r.nbits++
+	if !r.full {
+		if r.nbits >= charBits {
+			r.full = true
+		} else {
+			return
+		}
+	}
+	switch r.st {
+	case stateHunt:
+		r.hunt()
+	case stateLocked:
+		r.collect()
+	}
+}
+
+// hunt looks for two phasing-DX characters one DX stride apart at the
+// same polarity. That confirms the DX cadence and the tone sense, and
+// establishes the DX sampling grid.
+func (r *Receiver) hunt() {
+	pol, ok := r.windowIsPhasingDX()
+	if !ok {
+		return
+	}
+	if r.dxSeen && r.lastDXPol == pol && r.nbits-r.lastDXBit == dxStride {
+		// Cadence confirmed — lock onto this DX boundary.
+		r.st = stateLocked
+		r.inverted = pol
+		r.lockBit = r.nbits
+		r.started = false
+		r.syms = r.syms[:0]
+		r.badInSeq = 0
+		r.dxSeen = false
+		return
+	}
+	r.dxSeen = true
+	r.lastDXBit = r.nbits
+	r.lastDXPol = pol
+}
+
+// windowIsPhasingDX reports whether the current window decodes to the
+// phasing-DX character under either polarity. The bool result is the
+// polarity (true = inverted) when ok.
+func (r *Receiver) windowIsPhasingDX() (pol bool, ok bool) {
+	if data, good := dsc.BCHCheck(r.reg & charMask); good && byte(data) == phasingDX {
+		return false, true
+	}
+	if data, good := dsc.BCHCheck((^r.reg) & charMask); good && byte(data) == phasingDX {
+		return true, true
+	}
+	return false, false
+}
+
+// collect samples the DX grid: at every DX boundary it BCH-checks the
+// window, skips leading phasing characters, then appends data symbols
+// until the end-of-sequence character closes the run.
+func (r *Receiver) collect() {
+	if (r.nbits-r.lockBit)%dxStride != 0 {
+		return
+	}
+	cw := r.reg & charMask
+	if r.inverted {
+		cw = (^r.reg) & charMask
+	}
+	data, ok := dsc.BCHCheck(cw)
+	sym := byte(data)
+
+	if !r.started {
+		if sym == phasingDX {
+			return // still in the phasing run
+		}
+		if !ok {
+			// Noise on the DX grid before the format specifier —
+			// abandon the lock and re-hunt.
+			r.reset()
+			return
+		}
+		r.started = true
+		r.syms = r.syms[:0]
+		r.badInSeq = 0
+	}
+
+	if !ok {
+		r.badInSeq++
+	}
+	r.syms = append(r.syms, sym)
+
+	if eosSyms[sym] {
+		r.finish()
+		return
+	}
+	if len(r.syms) >= maxSeqSyms {
+		r.reset() // runaway sequence, no EOS — give up the lock
+	}
+}
+
+// finish decodes the collected symbol run, publishes it, and returns
+// the receiver to hunting.
+func (r *Receiver) finish() {
+	r.seqIn.Add(1)
+	if r.badInSeq > 0 {
+		r.seqBad.Add(1)
+	}
+	if r.dropBadFCS && r.badInSeq > 0 {
+		r.reset()
+		return
+	}
+
+	m := dsc.Decode(r.syms)
+	out := storage.DSCMessage{
+		ReceivedAt: time.Now(),
+		Format:     dsc.FormatString(m.Format),
+		Category:   dsc.CategoryString(m.Category),
+		SelfMMSI:   m.SelfMMSI,
+		TargetMMSI: m.TargetMMSI,
+		Nature:     dsc.NatureString(m.Nature),
+		TimeUTC:    m.TimeUTC,
+		Body:       m.String(),
+		RawHex:     m.RawSymbols,
+	}
+	if m.Position != nil {
+		out.Latitude = m.Position.Latitude
+		out.Longitude = m.Position.Longitude
+		out.HasPosition = m.Position.HasPosition
+	}
+	r.bus.Publish(events.Event{Kind: events.KindDSCMessage, Payload: out})
+	r.seqEmit.Add(1)
+	r.reset()
+}
+
+// reset drops the current lock and returns to hunting.
+func (r *Receiver) reset() {
+	r.st = stateHunt
+	r.started = false
+	r.syms = r.syms[:0]
+	r.badInSeq = 0
+	r.dxSeen = false
+}
+
+// Stats reports cumulative counters for /metrics + debugging.
+type Stats struct {
+	SequencesIn   uint64 // sequences whose EOS was reached
+	SequencesBad  uint64 // subset with ≥1 BCH-failed DX character
+	SequencesEmit uint64 // events published to the bus
+}
+
+func (r *Receiver) Stats() Stats {
+	return Stats{
+		SequencesIn:   r.seqIn.Load(),
+		SequencesBad:  r.seqBad.Load(),
+		SequencesEmit: r.seqEmit.Load(),
+	}
+}

--- a/internal/radio/dsc/receiver/receiver_test.go
+++ b/internal/radio/dsc/receiver/receiver_test.go
@@ -1,0 +1,205 @@
+package receiver
+
+import (
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/dsc"
+	"github.com/MattCheramie/GopherTrunk/internal/storage"
+)
+
+// pushChar shifts one 10-bit DSC character (BCH-encoded from a 7-bit
+// symbol) MSB-first into the receiver.
+func pushChar(r *Receiver, sym byte) {
+	cw := dsc.BCHEncode(uint16(sym))
+	for i := 9; i >= 0; i-- {
+		r.Push(byte((cw >> uint(i)) & 1))
+	}
+}
+
+// pushSequence drives a full DSC sequence into the receiver: a phasing
+// run (DX = 125 interleaved with RX placeholders on the 10-bit grid),
+// then the message symbols transmitted DX-then-RX so the DX grid (every
+// 20 bits) carries the data. This mirrors the "drop RX, use DX only"
+// path the receiver decodes.
+func pushSequence(r *Receiver, syms []byte) {
+	// Phasing: 8 DX/RX pairs. RX placeholders count down from 111 — the
+	// receiver samples only the DX grid, so their value is immaterial,
+	// but using valid characters keeps the stream realistic.
+	for i := 0; i < 8; i++ {
+		pushChar(r, phasingDX) // DX
+		pushChar(r, byte(111-i))
+	}
+	// Message: each data symbol on the DX grid, its RX twin following.
+	for _, s := range syms {
+		pushChar(r, s) // DX
+		pushChar(r, s) // RX (dropped)
+	}
+}
+
+func waitForDSC(t *testing.T, sub *events.Subscription) storage.DSCMessage {
+	t.Helper()
+	deadline := time.After(time.Second)
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind != events.KindDSCMessage {
+				continue
+			}
+			m, ok := ev.Payload.(storage.DSCMessage)
+			if !ok {
+				t.Fatalf("payload type = %T, want storage.DSCMessage", ev.Payload)
+			}
+			return m
+		case <-deadline:
+			t.Fatal("timed out waiting for KindDSCMessage")
+			return storage.DSCMessage{}
+		}
+	}
+}
+
+func TestNewRequiresBus(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Error("New(nil bus): want panic")
+		}
+	}()
+	_ = New(Options{})
+}
+
+func TestDecodeDistressSequence(t *testing.T) {
+	bus := events.NewBus(16)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	r := New(Options{Bus: bus})
+
+	// Distress alert mirroring dsc_test.go's TestDecodeDistressMessage:
+	// format=112, self-MMSI 366053209, nature=fire, position, time,
+	// EOS=127.
+	syms := []byte{112, 36, 60, 53, 20, 90, 100, 3, 74, 81, 22, 24, 14, 25, 127}
+	pushSequence(r, syms)
+
+	m := waitForDSC(t, sub)
+	if m.Format != "distress" {
+		t.Errorf("Format = %q, want distress", m.Format)
+	}
+	if m.SelfMMSI != 366053209 {
+		t.Errorf("SelfMMSI = %d, want 366053209", m.SelfMMSI)
+	}
+	if m.Nature != "fire / explosion" {
+		t.Errorf("Nature = %q, want fire / explosion", m.Nature)
+	}
+	if !m.HasPosition {
+		t.Error("HasPosition = false, want true")
+	}
+	if m.TimeUTC != "14:25" {
+		t.Errorf("TimeUTC = %q, want 14:25", m.TimeUTC)
+	}
+	if got := r.Stats().SequencesEmit; got != 1 {
+		t.Errorf("SequencesEmit = %d, want 1", got)
+	}
+}
+
+func TestDecodeIndividualCall(t *testing.T) {
+	bus := events.NewBus(16)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	r := New(Options{Bus: bus})
+
+	// format=120 individual, target 003660000, category routine,
+	// self-MMSI 366053209, EOS=127.
+	syms := []byte{120, 0, 36, 60, 0, 0, 100, 36, 60, 53, 20, 90, 127}
+	pushSequence(r, syms)
+
+	m := waitForDSC(t, sub)
+	if m.Format != "individual" {
+		t.Errorf("Format = %q, want individual", m.Format)
+	}
+	if m.Category != "routine" {
+		t.Errorf("Category = %q, want routine", m.Category)
+	}
+	if m.TargetMMSI != 3660000 {
+		t.Errorf("TargetMMSI = %d, want 3660000", m.TargetMMSI)
+	}
+	if m.SelfMMSI != 366053209 {
+		t.Errorf("SelfMMSI = %d, want 366053209", m.SelfMMSI)
+	}
+}
+
+// TestDecodeInvertedPolarity feeds the whole sequence with every bit
+// complemented; the dual-polarity phasing hunt must still lock and
+// recover the true symbols.
+func TestDecodeInvertedPolarity(t *testing.T) {
+	bus := events.NewBus(16)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	r := New(Options{Bus: bus})
+
+	syms := []byte{116, 0, 0, 0, 0, 0, 108, 0, 36, 69, 99, 90, 127}
+	// Re-implement pushSequence with inverted bits.
+	pushCharInv := func(sym byte) {
+		cw := dsc.BCHEncode(uint16(sym))
+		for i := 9; i >= 0; i-- {
+			r.Push(byte((^(cw >> uint(i))) & 1))
+		}
+	}
+	for i := 0; i < 8; i++ {
+		pushCharInv(phasingDX)
+		pushCharInv(byte(111 - i))
+	}
+	for _, s := range syms {
+		pushCharInv(s)
+		pushCharInv(s)
+	}
+
+	m := waitForDSC(t, sub)
+	if m.Format != "all-ships" {
+		t.Errorf("Format = %q, want all-ships", m.Format)
+	}
+	if m.Category != "safety" {
+		t.Errorf("Category = %q, want safety", m.Category)
+	}
+	if m.SelfMMSI != 3669999 {
+		t.Errorf("SelfMMSI = %d, want 3669999", m.SelfMMSI)
+	}
+}
+
+// TestNoEOSDoesNotPublish confirms a sequence that never reaches an
+// end-of-sequence character is abandoned (no event, no leak).
+func TestNoEOSDoesNotPublish(t *testing.T) {
+	bus := events.NewBus(16)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	r := New(Options{Bus: bus})
+
+	// Phasing then a long run of non-EOS symbols.
+	for i := 0; i < 8; i++ {
+		pushChar(r, phasingDX)
+		pushChar(r, byte(111-i))
+	}
+	for i := 0; i < maxSeqSyms+5; i++ {
+		pushChar(r, 50) // arbitrary non-EOS symbol on the DX grid
+		pushChar(r, 50)
+	}
+
+	select {
+	case ev := <-sub.C:
+		if ev.Kind == events.KindDSCMessage {
+			t.Error("published a DSC message for a sequence with no EOS")
+		}
+	case <-time.After(100 * time.Millisecond):
+		// expected: nothing published
+	}
+	if got := r.Stats().SequencesEmit; got != 0 {
+		t.Errorf("SequencesEmit = %d, want 0", got)
+	}
+}


### PR DESCRIPTION
Closes the last "no DSP" hole in Phase 5: DSC had a protocol parser,
BCH(10,7), storage, REST, and panel scaffolding, but no way to turn
IQ into decoded sequences. This wires the full chain.

- internal/radio/dsc/ffsk: IQ -> FM demod -> resample to 9600 sps ->
  FFSK discriminator (1300/2100 Hz) -> Mueller-Muller symbol timing ->
  direct-FSK slicer. Mirrors the MDC1200 FFSK frontend; no NRZI since
  DSC is direct FSK.
- internal/radio/dsc/receiver: slides a 10-bit window, BCH-syncs on the
  repeating phasing DX character (with dual-polarity detection), samples
  the DX grid to recover 7-bit symbols, detects EOS, and publishes
  KindDSCMessage via dsc.Decode. Takes the "drop RX, use DX only" path.
- config: DSCConfig/DSCChannelConfig wired into Config and the example.
- daemon: construct + spawn loops mirroring the AIS receivers.

Tested end-to-end: a modulated distress sequence decodes through the
full frontend, plus inverted-polarity and no-EOS guard cases.