### PR TITLE
adsb: native 1090 MHz PPM Mode-S receiver

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,11 @@ Silicon and Intel. Full per-OS recipes at
   `events.KindDSCMessage` bus event, SQLite `dsc_log`,
   `GET /api/v1/dsc/messages`, and `/dsc` web panel (rows tint
   by category — distress=red, urgency=orange, safety=blue).
-  DSP frontend (1200 Bd FSK at 1300/2100 Hz tones) follows.
-  See [docs/dsc.md](docs/dsc.md).
+  **DSP frontend** decodes straight off the air: FM demod →
+  FFSK discriminator (1200 Bd, 1300/2100 Hz tones) →
+  symbol-timing recovery → direct-FSK slicer → BCH(10,7)
+  character sync → ITU-R M.493 parser. Pin an SDR via
+  `dsc.channels`. See [docs/dsc.md](docs/dsc.md).
 - **ADS-B aviation** — end-to-end pipeline for the 1090 MHz
   Mode-S transponder broadcasts every commercial flight emits.
   ICAO Annex 10 Vol IV / DO-260B parser (CRC-24 + DF dispatch +
@@ -125,10 +128,14 @@ Silicon and Intel. Full per-OS recipes at
   even+odd pair tracker. **BEAST upstream** consumes Mode-S
   frames from any dump1090 / readsb / BeastSplitter via TCP —
   most 1090 MHz receive chains already run one, GopherTrunk
-  decodes its output. Plus `events.KindAircraftReport` bus
+  decodes its output. **Native PPM DSP frontend** is the
+  alternative: pin an SDR (>= 2 Msps) to 1090 MHz via
+  `adsb.channels` and GopherTrunk demodulates Mode-S itself —
+  magnitude envelope → 8 µs preamble correlation → PPM bit
+  slice → CRC/DF dispatch — feeding the same decode/track path
+  the BEAST upstream uses. Plus `events.KindAircraftReport` bus
   event, SQLite `aircraft_log`, `GET /api/v1/adsb/aircraft`,
-  and `/adsb` web panel. Native 1 Msps PPM DSP frontend
-  follows. See [docs/adsb.md](docs/adsb.md).
+  and `/adsb` web panel. See [docs/adsb.md](docs/adsb.md).
 - **Live map** — Shared Leaflet map at the top of each
   position-bearing panel (APRS / AIS / DSC / ADS-B) renders
   decoded positions over OpenStreetMap tiles, colour-coded per

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -24,6 +24,7 @@ import (
 	"github.com/MattCheramie/GopherTrunk/internal/scanner/widebandt2"
 
 	adsbbeast "github.com/MattCheramie/GopherTrunk/internal/radio/adsb/beast"
+	adsbppm "github.com/MattCheramie/GopherTrunk/internal/radio/adsb/ppm"
 	aisgmsk "github.com/MattCheramie/GopherTrunk/internal/radio/ais/gmsk"
 	aprsafsk "github.com/MattCheramie/GopherTrunk/internal/radio/aprs/afsk"
 	dscffsk "github.com/MattCheramie/GopherTrunk/internal/radio/dsc/ffsk"
@@ -217,10 +218,15 @@ type Daemon struct {
 	// adsbBeastClients consume ADS-B Mode-S frames from external
 	// dump1090 / readsb upstreams (BEAST binary protocol). Each
 	// client decodes frames, pairs CPR halves via an embedded
-	// per-ICAO tracker, and publishes KindAircraftReport. Native
-	// 1 Msps PPM DSP frontend is a planned follow-up.
+	// per-ICAO tracker, and publishes KindAircraftReport.
 	adsbBeastClients []*adsbbeast.Client
 	adsbBeastNames   []string // index-aligned with adsbBeastClients
+	// adsbPPMReceivers hold one native 1090 MHz Mode-S PPM receiver per
+	// configured adsb.channels entry. Each subscribes to its assigned
+	// SDR's iqtap broker and publishes the same KindAircraftReport the
+	// BEAST clients do.
+	adsbPPMReceivers []*adsbppm.Receiver
+	adsbPPMSpecs     []adsbPPMSpec // index-aligned with adsbPPMReceivers
 	// iqBrokers holds an iqtap.Broker per pool entry, keyed by serial.
 	// Primary consumers (CC decoder, conventional scanner) stream IQ
 	// through the broker so secondary observers (live spectrum,
@@ -1173,6 +1179,38 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 		d.adsbBeastNames = append(d.adsbBeastNames, name)
 	}
 
+	// ADS-B native PPM receivers — one per configured adsb.channels
+	// entry. Each pins an SDR to 1090 MHz and demodulates Mode-S
+	// straight off the air, publishing the same KindAircraftReport the
+	// BEAST clients do. Same construction shape as the AIS receivers.
+	for _, ac := range cfg.ADSB.Channels {
+		freq := ac.FrequencyHz
+		if freq == 0 {
+			freq = 1_090_000_000 // 1090 MHz default
+		}
+		spec := adsbPPMSpec{serial: ac.Serial, freq: freq}
+		if ac.Serial == "" {
+			d.addWarning("adsb.channels: entry missing serial — skipped")
+			d.adsbPPMReceivers = append(d.adsbPPMReceivers, nil)
+			d.adsbPPMSpecs = append(d.adsbPPMSpecs, spec)
+			continue
+		}
+		rcv, err := adsbppm.New(adsbppm.Options{
+			InputRateHz: cfg.SDR.SampleRate,
+			SourceName:  ac.Serial,
+			Bus:         d.bus,
+			Log:         log,
+		})
+		if err != nil {
+			d.addWarning(fmt.Sprintf("adsb.channels[%s]: %v — skipped", ac.Serial, err))
+			d.adsbPPMReceivers = append(d.adsbPPMReceivers, nil)
+			d.adsbPPMSpecs = append(d.adsbPPMSpecs, spec)
+			continue
+		}
+		d.adsbPPMReceivers = append(d.adsbPPMReceivers, rcv)
+		d.adsbPPMSpecs = append(d.adsbPPMSpecs, spec)
+	}
+
 	// Storage / call log / retention — optional.
 	if cfg.Storage.Path != "" {
 		db, err := storage.Open(cfg.Storage.Path)
@@ -1742,6 +1780,35 @@ func (d *Daemon) Run(ctx context.Context) error {
 		name := fmt.Sprintf("adsb-beast-%s", d.adsbBeastNames[i])
 		d.spawn(runCtx, name, false, func(ctx context.Context) error {
 			return client.Run(ctx)
+		})
+	}
+	// ADS-B native PPM receivers — same shape as the AIS receivers.
+	// Each subscribes to its assigned SDR's iqtap broker (pinned to
+	// 1090 MHz) and demodulates Mode-S frames off the air, publishing
+	// KindAircraftReport. Non-essential: a missing SDR is logged but
+	// doesn't bring down the pipeline.
+	for i, rcv := range d.adsbPPMReceivers {
+		if rcv == nil {
+			continue // skipped at construction; warning already logged
+		}
+		rcv := rcv
+		spec := d.adsbPPMSpecs[i]
+		name := fmt.Sprintf("adsb-ppm-%s-%d", spec.serial, spec.freq)
+		d.spawn(runCtx, name, false, func(ctx context.Context) error {
+			br := d.iqBrokers[spec.serial]
+			if br == nil {
+				d.log.Warn("adsb/ppm: SDR not found, skipping receiver",
+					"serial", spec.serial, "freq_hz", spec.freq)
+				return nil
+			}
+			if err := br.SetCenterFreq(spec.freq); err != nil {
+				d.log.Warn("adsb/ppm: SetCenterFreq failed",
+					"serial", spec.serial, "freq_hz", spec.freq, "err", err)
+				return nil
+			}
+			sub := br.Subscribe()
+			defer sub.Close()
+			return rcv.Process(ctx, sub.C)
 		})
 	}
 	if d.pool != nil {
@@ -2704,6 +2771,14 @@ type aisSpec struct {
 // spawn each receiver without re-walking the YAML. Mirrors aisSpec /
 // mdc1200Spec.
 type dscSpec struct {
+	serial string
+	freq   uint32
+}
+
+// adsbPPMSpec captures the broker-side wiring info for one configured
+// native ADS-B PPM channel. Index-aligned with Daemon.adsbPPMReceivers
+// so the Run loop can spawn each receiver without re-walking the YAML.
+type adsbPPMSpec struct {
 	serial string
 	freq   uint32
 }

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -347,12 +347,18 @@ sdr:
 #                                     #  with a BCH-failed character instead
 #                                     #  of publishing them flagged
 
-# ADS-B / aviation. Most 1090 MHz receive chains already run
-# dump1090 / readsb / BeastSplitter against a dedicated RTL-SDR
-# (with a 1090 MHz filter + LNA); GopherTrunk consumes its BEAST
-# output over TCP. The native 1 Msps PPM DSP frontend is a
-# planned follow-up — once it ships, this same panel + storage
-# table accepts frames from either source.
+# ADS-B / aviation. Two ways to feed the aircraft panel; mix freely,
+# their frames merge into one stream.
+#
+#  1. beast_upstreams — consume a separately-running dump1090 / readsb /
+#     BeastSplitter / commercial hub over the BEAST TCP protocol. Most
+#     existing 1090 MHz chains already run one against a dedicated
+#     RTL-SDR (with a 1090 MHz filter + LNA).
+#  2. channels — native PPM demod: pin one of GopherTrunk's own SDRs to
+#     1090 MHz and decode Mode-S straight off the air, no external
+#     decoder. A 1090 MHz SAW filter + LNA ahead of the SDR is strongly
+#     recommended, and the SDR must sample at >= 2 Msps (the receiver
+#     resamples to 2 Msps internally).
 #
 # adsb:
 #   beast_upstreams:
@@ -360,6 +366,10 @@ sdr:
 #       name: "local-dump1090"        # logged on every reconnect
 #     - addr: "antenna-pi.lan:30005"  # remote pi-at-the-antenna setup
 #       name: "rooftop"
+#   channels:
+#     - serial: "1090-antenna"        # SDR serial (must be in sdr.devices
+#                                     #  or sdr.rtl_tcp), sampling >= 2 Msps
+#       frequency_hz: 1_090_000_000   # 1090 MHz (the default when omitted)
 
 trunking:
   # call_timeout_ms: inactivity window after which the engine's

--- a/docs/adsb.md
+++ b/docs/adsb.md
@@ -19,11 +19,11 @@ flight-tracking service (FlightRadar24, FlightAware, adsb.lol,
 OpenSky); GopherTrunk now has the protocol layer to decode it
 end-to-end on the operator's own SDR.
 
-This page documents the **pipeline scaffolding**: what's wired,
-what's persisted, what's queryable, and what the web panel
-renders. The DSP layer (1 Msps PPM demodulation, Mode-S preamble
-detection, 56 / 112-bit frame extraction) is tracked separately
-under "What's pending" below.
+This page documents the **end-to-end pipeline**: two ways frames
+reach the bus — a native PPM DSP frontend on the operator's own
+1090 MHz SDR, and a BEAST upstream that consumes a separately-
+running dump1090 / readsb — plus what's persisted, queryable, and
+rendered on the web panel.
 
 ## What's wired
 
@@ -66,11 +66,13 @@ under "What's pending" below.
 
 ## Protocol layer (`internal/radio/adsb`)
 
-Pure-Go Mode-S parser. The bit-stream layer above (separate PR)
-handles 1090 MHz PPM demodulation, preamble correlation, and
-56 / 112-bit frame extraction. By the time bytes reach
-`adsb.Decode` they're complete Mode-S frames with the trailing
-24-bit CRC included.
+Pure-Go Mode-S parser. The bit-stream layer above (the native
+PPM receiver or a BEAST upstream) hands it complete Mode-S
+frames with the trailing 24-bit CRC included. Both sources go
+through one shared path — `adsb.ProcessFrame(frame, tracker,
+now)` decodes, gates on CRC, runs the CPR tracker, and returns
+the `storage.AircraftReport` — so a frame off the air and the
+same frame from dump1090 produce identical rows.
 
 - **CRC-24 codec** (`parse.go`) — Mode-S CRC with polynomial
   0xFFF409. Verifies DF 11 / 17 / 18 frames directly (zero
@@ -149,6 +151,41 @@ with backoff on TCP drops (default 2 s); each disconnect
 resets the embedded CPR tracker so stale even/odd halves
 don't pair across a gap.
 
+## Native PPM receiver (`internal/radio/adsb/ppm`)
+
+The alternative to a BEAST upstream: pin one of GopherTrunk's own
+SDRs to 1090 MHz and demodulate Mode-S straight off the air, no
+external decoder. A 1090 MHz SAW filter + LNA ahead of the SDR is
+strongly recommended — Mode-S is a weak, bursty signal.
+
+```yaml
+adsb:
+  channels:
+    - serial: "1090-antenna"      # SDR sampling >= 2 Msps
+      frequency_hz: 1_090_000_000 # 1090 MHz (default when omitted)
+```
+
+Pipeline (one goroutine per channel, subscribing to that SDR's
+iqtap broker):
+
+```
+IQ → resample to 2 Msps → magnitude² envelope → 8 µs preamble
+   correlation (pulses at 0, 1, 3.5, 4.5 µs) → PPM bit slice
+   (1 µs/bit: "1" = high-then-low, "0" = low-then-high) → DF
+   frame-length (56 / 112 bit) → adsb.ProcessFrame
+```
+
+The detector and slicer follow the dump1090 magnitude-domain
+baseline at a fixed 2 Msps; the receiver resamples to that rate
+internally if the SDR runs faster. A magnitude carry buffer
+spans chunk boundaries so a preamble split across two IQ chunks
+still decodes. Phase-corrected re-detection and 2.4 Msps
+operation are refinements left for later — the baseline locks
+cleanly on the strong signals a filtered + amplified chain
+delivers. Frames feed the same `adsb.ProcessFrame` path the
+BEAST client uses, so storage, tracker, panel, and map are
+shared.
+
 ## CPR pair tracker (`internal/radio/adsb.Tracker`)
 
 ADS-B aircraft alternate between even-encoded (`CPRFormat=0`)
@@ -164,15 +201,6 @@ aircraft ever seen.
 
 ## What's pending
 
-- **Native DSP receiver.** 1 Msps PPM demodulation at 1090 MHz
-  with Mode-S preamble correlation and 56 / 112-bit frame
-  extraction. The plan calls for extending
-  `internal/dsp/tuner/channelizerbank.go` to support
-  higher-rate taps, then a Mode-S demod that walks the IQ
-  stream, correlates against the 8 µs preamble pattern, and
-  hands extracted frames into `adsb.Decode`. Once shipped the
-  same panel + storage + tracker chain consumes its output
-  alongside BEAST upstreams.
 - **Aircraft tracker.** An `aircraft_current` SQL view (or a
   separate live-state table indexed by ICAO) showing the
   latest known position / altitude / callsign per aircraft,

--- a/docs/dsc.md
+++ b/docs/dsc.md
@@ -17,12 +17,9 @@ voice channel two stations are about to switch to. A coast-guard
 MMSI lighting up the channel-70 stream is near-instant visibility
 into search-and-rescue activity.
 
-This page documents the **pipeline scaffolding**: what's wired,
-what's persisted, what's queryable, and what the web panel
-renders. The DSP layer (1200 Bd FSK at 1300 / 2100 Hz tones →
-10-bit symbol assembly → BCH check + DX/RX redundancy → 7-bit
-symbol stream to `dsc.Decode`) is tracked separately under
-"What's pending" below.
+This page documents the **end-to-end pipeline**: the DSP frontend
+that turns an IQ stream into decoded sequences, what's persisted,
+what's queryable, and what the web panel renders.
 
 ## What's wired
 
@@ -104,16 +101,48 @@ Spec references:
 - ITU-R M.541 — operational use, station identification,
   category routing.
 
+### DSP frontend
+
+The receiver decodes DSC straight off the air. Pin an SDR to a
+DSC channel under `dsc.channels` in the config (channel 70 =
+156.525 MHz on VHF; HF DSC rides 2187.5 / 8414.5 / 12577 /
+16804.5 kHz):
+
+```yaml
+dsc:
+  channels:
+    - serial: "marine-antenna"
+      frequency_hz: 156_525_000
+      drop_bad_fcs: false
+```
+
+Pipeline (one goroutine per channel, subscribing to that SDR's
+iqtap broker):
+
+```
+IQ → FM demod → resample to 9600 sps → FFSK discriminator
+   (1300/2100 Hz) → Mueller-Müller symbol timing → direct-FSK
+   slicer (no NRZI) → 10-bit window → BCH(10,7) phasing sync →
+   DX-grid symbol sampling → dsc.Decode → KindDSCMessage
+```
+
+- `internal/radio/dsc/ffsk` owns IQ → bits (mirrors the MDC1200
+  FFSK frontend); `internal/radio/dsc/receiver` owns bits →
+  message.
+- **Polarity** is auto-resolved: the phasing hunt accepts the DX
+  character (125) in either tone sense and inverts the sampled
+  symbols when it locked on the complement.
+- **DX/RX time diversity:** the first slice takes the documented
+  "drop RX, use DX only" path — it locks the 20-bit DX grid via
+  the repeating phasing character and reads DX symbols. Comparing
+  each DX character against its RX twin to recover BCH failures is
+  a yield-improving follow-up. On-wire bit order, tone sense, and
+  DX/RX offset are validated against a synthetic modulator;
+  confirming them against a captured ITU-R M.493 signal is the
+  remaining real-world calibration step.
+
 ## What's pending
 
-- **DSP receiver.** 1200 Bd FSK (mark 1300 Hz, space 2100 Hz)
-  on channel 70 (VHF) or one of the HF DSC channels. Pipeline:
-  iqtap broker subscriber → FM demod → FFSK discriminator
-  (reusing `internal/dsp/demod/ffsk` with DSC's tone
-  frequencies) → symbol-time recovery → 10-bit symbol assembly
-  → BCH syndrome check → DX / RX redundancy merge → 7-bit
-  symbol stream into `dsc.Decode`. Pattern matches the APRS /
-  AIS DSP frontends.
 - **Multi-frame protocol.** A few DSC sequence types span
   multiple slots when transmitted (Auto-Individual ACK chains,
   multi-recipient calls). The single-frame parser covers the

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -42,7 +42,24 @@ type Config struct {
 // RTL-SDR + 1090 MHz filter + LNA; pointing GopherTrunk at it
 // is a one-line config away.
 type ADSBConfig struct {
-	BeastUpstreams []ADSBBeastConfig `yaml:"beast_upstreams"`
+	BeastUpstreams []ADSBBeastConfig   `yaml:"beast_upstreams"`
+	Channels       []ADSBChannelConfig `yaml:"channels"`
+}
+
+// ADSBChannelConfig describes one SDR pinned to 1090 MHz for the
+// native PPM Mode-S receiver — the alternative to a BEAST upstream for
+// operators who want GopherTrunk to own the whole 1090 MHz chain
+// rather than running a separate dump1090 / readsb. Serial picks the
+// SDR; the daemon tunes it to FrequencyHz (default 1090 MHz) and runs
+// the PPM demodulator against its full IQ stream. A 1090 MHz SAW
+// filter + LNA ahead of the SDR is strongly recommended — Mode-S is a
+// weak, bursty signal. The SDR must sample at ≥ 2 Msps; the receiver
+// resamples to 2 Msps internally. Decoded frames merge into the same
+// events.KindAircraftReport stream the BEAST upstreams feed, so the
+// /aircraft panel and storage are shared.
+type ADSBChannelConfig struct {
+	Serial      string `yaml:"serial"`
+	FrequencyHz uint32 `yaml:"frequency_hz"` // defaults to 1090 MHz when zero
 }
 
 // ADSBBeastConfig describes one BEAST upstream to consume. Addr is

--- a/internal/radio/adsb/beast/beast.go
+++ b/internal/radio/adsb/beast/beast.go
@@ -45,7 +45,6 @@ import (
 
 	"github.com/MattCheramie/GopherTrunk/internal/events"
 	"github.com/MattCheramie/GopherTrunk/internal/radio/adsb"
-	"github.com/MattCheramie/GopherTrunk/internal/storage"
 )
 
 // Frame is one decoded BEAST envelope. The Payload bytes hold the
@@ -239,50 +238,11 @@ func (c *Client) handleFrame(f Frame) {
 		// Mode-AC frames carry no useful ADS-B data; skip.
 		return
 	}
-	m := adsb.Decode(f.Payload)
-	if !m.CRCValid && m.Kind != adsb.KindAllCall {
-		// CRC-failed extended squitters can't be trusted — skip.
-		// All-call replies (DF 11) only carry the ICAO and no
-		// payload, but they're still useful for "this aircraft
-		// is in range" tracking.
+	rep, ok := adsb.ProcessFrame(f.Payload, c.tracker, time.Now())
+	if !ok {
 		return
 	}
 	c.framesDecoded.Add(1)
-
-	m, _ = c.tracker.Update(m, time.Now().UnixNano())
-
-	rep := storage.AircraftReport{
-		ReceivedAt: time.Now(),
-		ICAO:       m.ICAO,
-		ICAOHex:    fmt.Sprintf("%06X", m.ICAO),
-		Kind:       adsb.KindString(m.Kind),
-		Body:       m.String(),
-		CRCValid:   m.CRCValid,
-		RawHex:     m.RawHex,
-	}
-	if m.Identification != nil {
-		rep.Callsign = m.Identification.Callsign
-		rep.Category = m.Identification.Category
-	}
-	if m.Position != nil {
-		rep.HasAltitude = m.Position.HasAltitude
-		rep.Altitude = m.Position.Altitude
-		if m.Position.HasGlobalPosition {
-			rep.HasPosition = true
-			rep.Latitude = m.Position.Latitude
-			rep.Longitude = m.Position.Longitude
-		}
-	}
-	if m.Velocity != nil {
-		if m.Velocity.HasGroundSpeed {
-			rep.GroundSpeedKn = m.Velocity.GroundSpeedKn
-			rep.TrackDeg = m.Velocity.TrackDeg
-		}
-		if m.Velocity.HasVerticalRate {
-			rep.VerticalRateFPM = m.Velocity.VerticalRateFPM
-		}
-	}
-
 	c.bus.Publish(events.Event{Kind: events.KindAircraftReport, Payload: rep})
 	c.framesEmitted.Add(1)
 }

--- a/internal/radio/adsb/ppm/receiver.go
+++ b/internal/radio/adsb/ppm/receiver.go
@@ -1,0 +1,323 @@
+// Package ppm is the native 1090 MHz Mode-S / ADS-B receiver: it
+// demodulates the pulse-position-modulated downlink directly from an
+// IQ stream, with no external dump1090 / readsb required. The pipeline
+// is:
+//
+//	IQ chunks (Fs Hz, complex64)
+//	  → resample to 2 Msps (2 samples/µs; skipped if already 2 Msps)
+//	  → magnitude² envelope (I² + Q²)
+//	  → Mode-S preamble correlation (8 µs pattern: pulses at
+//	    0, 1, 3.5, 4.5 µs)
+//	  → PPM bit slice (1 µs/bit: "1" = high-then-low half, "0" =
+//	    low-then-high half)
+//	  → frame-length from DF (56- vs 112-bit) → 7- or 14-byte frame
+//	  → adsb.ProcessFrame (decode → CPR track → AircraftReport)
+//	  → events.KindAircraftReport on the bus
+//
+// The decode → track → publish stage is the exact path the BEAST
+// upstream client uses (adsb.ProcessFrame), so a frame recovered off
+// the air and the same frame relayed from dump1090 produce identical
+// reports. This package owns only IQ-to-frame.
+//
+// Operators pin one SDR to 1090 MHz (a 1090 MHz SAW filter + LNA is
+// strongly recommended) and add it under adsb.channels. dump1090 users
+// stay on the BEAST upstream; this is for greenfield setups that want
+// GopherTrunk to own the whole chain.
+//
+// The preamble detector and PPM slicer follow the well-trodden
+// dump1090 baseline (fixed 2 Msps, magnitude-domain). Phase-corrected
+// re-detection and 2.4 Msps operation are refinements left for later;
+// this baseline locks cleanly on strong signals, which is what a
+// filtered + amplified 1090 MHz chain delivers.
+package ppm
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync/atomic"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp"
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/adsb"
+)
+
+// SampleRateHz is the fixed internal processing rate: 2 Msps gives
+// 2 samples per microsecond, the minimum to resolve a PPM half-bit.
+const SampleRateHz = 2_000_000
+
+// samplesPerBit is one Mode-S bit period (1 µs) in samples at the
+// internal rate.
+const samplesPerBit = SampleRateHz / 1_000_000
+
+// preambleSamples is the 8 µs Mode-S preamble in samples.
+const preambleSamples = 8 * samplesPerBit // 16
+
+// shortBits / longBits are the two Mode-S frame lengths.
+const (
+	shortBits = 56  // DF 0/4/5/11 — 7 bytes
+	longBits  = 112 // DF 16/17/18/19/20/21/24 — 14 bytes
+)
+
+// frameSpan is the worst-case sample footprint of preamble + a long
+// frame; scanning needs this many samples available to attempt a
+// decode without running off the buffer.
+const frameSpan = preambleSamples + longBits*samplesPerBit // 240
+
+// Options configures a Receiver.
+type Options struct {
+	// InputRateHz is the IQ sample rate the broker is feeding at.
+	// When it is exactly SampleRateHz the magnitude envelope is taken
+	// directly; otherwise the IQ is resampled to SampleRateHz first.
+	InputRateHz uint32
+
+	// SourceName is stamped on log lines and surfaces in metrics.
+	SourceName string
+
+	// Bus is required — reports publish onto KindAircraftReport.
+	Bus *events.Bus
+
+	// Log is optional; defaults to slog.Default.
+	Log *slog.Logger
+}
+
+// Receiver runs a native Mode-S PPM decode pipeline against a stream
+// of IQ chunks. One Receiver per 1090 MHz SDR.
+type Receiver struct {
+	source  string
+	log     *slog.Logger
+	bus     *events.Bus
+	tracker *adsb.Tracker
+
+	rs *dsp.Resampler // nil when InputRateHz == SampleRateHz
+
+	// Scratch + carry buffers reused across chunks. mag accumulates
+	// the magnitude envelope; up to frameSpan-1 samples are retained
+	// across calls so a preamble straddling a chunk boundary still
+	// decodes.
+	rsBuf []complex64
+	mag   []float32
+
+	samplesSeen   atomic.Uint64
+	preamblesSeen atomic.Uint64
+	framesDecoded atomic.Uint64
+	framesEmitted atomic.Uint64
+}
+
+// New constructs a Receiver. Returns an error if opts.Bus is nil or
+// InputRateHz is unset / below the 2 Msps the PPM slicer needs.
+func New(opts Options) (*Receiver, error) {
+	if opts.Bus == nil {
+		return nil, errors.New("adsb/ppm: Bus is required")
+	}
+	if opts.InputRateHz == 0 {
+		return nil, errors.New("adsb/ppm: InputRateHz is required")
+	}
+	if opts.InputRateHz < SampleRateHz {
+		return nil, errors.New("adsb/ppm: InputRateHz must be at least 2 Msps")
+	}
+	log := opts.Log
+	if log == nil {
+		log = slog.Default()
+	}
+	r := &Receiver{
+		source:  opts.SourceName,
+		log:     log,
+		bus:     opts.Bus,
+		tracker: adsb.NewTracker(),
+	}
+	if opts.InputRateHz != SampleRateHz {
+		g := gcd(SampleRateHz, opts.InputRateHz)
+		L := int(SampleRateHz / g)
+		M := int(opts.InputRateHz / g)
+		r.rs = dsp.NewResampler(L, M, 16, 7.0)
+	}
+	return r, nil
+}
+
+// Process pumps IQ chunks from in through the decode pipeline until
+// ctx cancels or in closes.
+func (r *Receiver) Process(ctx context.Context, in <-chan []complex64) error {
+	if in == nil {
+		return errors.New("adsb/ppm: input channel is nil")
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case chunk, ok := <-in:
+			if !ok {
+				return nil
+			}
+			r.processChunk(chunk)
+		}
+	}
+}
+
+func (r *Receiver) processChunk(chunk []complex64) {
+	r.samplesSeen.Add(uint64(len(chunk)))
+	samples := chunk
+	if r.rs != nil {
+		r.rsBuf = r.rs.Process(r.rsBuf, chunk)
+		samples = r.rsBuf
+	}
+	for _, c := range samples {
+		i, q := real(c), imag(c)
+		r.mag = append(r.mag, i*i+q*q)
+	}
+	r.scan()
+}
+
+// scan walks the magnitude buffer hunting Mode-S preambles, demodulates
+// the frame that follows each detection, and retains the unprocessed
+// tail (a frame may straddle the next chunk).
+func (r *Receiver) scan() {
+	i := 0
+	for i+frameSpan <= len(r.mag) {
+		if !detectPreamble(r.mag[i : i+preambleSamples+2]) {
+			i++
+			continue
+		}
+		r.preamblesSeen.Add(1)
+		frame, nbits := r.demodFrame(r.mag[i+preambleSamples:])
+		if nbits == 0 {
+			i++
+			continue
+		}
+		r.handleFrame(frame)
+		// Skip past the consumed frame.
+		i += preambleSamples + nbits*samplesPerBit
+	}
+	// Retain the tail for the next chunk.
+	if i > 0 {
+		n := copy(r.mag, r.mag[i:])
+		r.mag = r.mag[:n]
+	}
+}
+
+// demodFrame slices the PPM data that follows a detected preamble.
+// data points at the first data sample. It reads the 5-bit DF to pick
+// the 56- or 112-bit length, then packs the bits MSB-first into bytes.
+// Returns the frame bytes and the bit count (0 if the magnitude buffer
+// is too short).
+func (r *Receiver) demodFrame(data []float32) ([]byte, int) {
+	// Read DF (first 5 bits) to determine length.
+	if len(data) < 5*samplesPerBit {
+		return nil, 0
+	}
+	df := 0
+	for b := 0; b < 5; b++ {
+		df = df<<1 | sliceBit(data, b)
+	}
+	nbits := shortBits
+	if longFrame(df) {
+		nbits = longBits
+	}
+	if len(data) < nbits*samplesPerBit {
+		return nil, 0
+	}
+	out := make([]byte, nbits/8)
+	for b := 0; b < nbits; b++ {
+		if sliceBit(data, b) == 1 {
+			out[b/8] |= 1 << uint(7-(b%8))
+		}
+	}
+	return out, nbits
+}
+
+// handleFrame runs a demodulated frame through the shared
+// decode → track → publish path and emits the report.
+func (r *Receiver) handleFrame(frame []byte) {
+	rep, ok := adsb.ProcessFrame(frame, r.tracker, time.Now())
+	if !ok {
+		return
+	}
+	r.framesDecoded.Add(1)
+	r.bus.Publish(events.Event{Kind: events.KindAircraftReport, Payload: rep})
+	r.framesEmitted.Add(1)
+}
+
+// sliceBit slices one PPM bit at bit index b within data (which starts
+// at the first data sample). Mode-S PPM: "1" is high-then-low across
+// the two half-bit samples, "0" is low-then-high.
+func sliceBit(data []float32, b int) int {
+	first := data[b*samplesPerBit]
+	second := data[b*samplesPerBit+1]
+	if first > second {
+		return 1
+	}
+	return 0
+}
+
+// longFrame reports whether a downlink format uses the 112-bit frame.
+func longFrame(df int) bool {
+	switch df {
+	case 16, 17, 18, 19, 20, 21, 24:
+		return true
+	}
+	return false
+}
+
+// detectPreamble applies the dump1090 magnitude-domain preamble test
+// to a window starting at the candidate preamble. m must hold at least
+// preambleSamples samples. The pattern is high pulses at sample
+// offsets 0, 2, 7, 9 (µs 0, 1, 3.5, 4.5 at 2 Msps) with quiet gaps and
+// a quiet zone before the data.
+func detectPreamble(m []float32) bool {
+	if len(m) < preambleSamples {
+		return false
+	}
+	if !(m[0] > m[1] &&
+		m[1] < m[2] &&
+		m[2] > m[3] &&
+		m[3] < m[0] &&
+		m[4] < m[0] &&
+		m[5] < m[0] &&
+		m[6] < m[0] &&
+		m[7] > m[8] &&
+		m[8] < m[9] &&
+		m[9] > m[6]) {
+		return false
+	}
+	// Average pulse level. The quiet samples around and after the
+	// preamble must sit clearly below it, which rejects random noise
+	// that happens to satisfy the relative-ordering test above.
+	high := (m[0] + m[2] + m[7] + m[9]) / 6
+	if m[5] >= high || m[6] >= high {
+		return false
+	}
+	for j := 10; j < preambleSamples; j++ {
+		if m[j] >= high {
+			return false
+		}
+	}
+	return true
+}
+
+// Stats reports cumulative counters for /metrics + debugging.
+type Stats struct {
+	IQSamplesSeen uint64
+	PreamblesSeen uint64
+	FramesDecoded uint64
+	FramesEmitted uint64
+	TrackerSize   int
+}
+
+func (r *Receiver) Stats() Stats {
+	return Stats{
+		IQSamplesSeen: r.samplesSeen.Load(),
+		PreamblesSeen: r.preamblesSeen.Load(),
+		FramesDecoded: r.framesDecoded.Load(),
+		FramesEmitted: r.framesEmitted.Load(),
+		TrackerSize:   r.tracker.Size(),
+	}
+}
+
+// gcd computes the greatest common divisor via Euclid's algorithm.
+func gcd(a, b uint32) uint32 {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}

--- a/internal/radio/adsb/ppm/receiver_test.go
+++ b/internal/radio/adsb/ppm/receiver_test.go
@@ -1,0 +1,187 @@
+package ppm
+
+import (
+	"context"
+	"encoding/hex"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/storage"
+)
+
+func TestNewRejectsBadOptions(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+
+	if _, err := New(Options{}); err == nil {
+		t.Error("New without Bus: want error")
+	}
+	if _, err := New(Options{Bus: bus}); err == nil {
+		t.Error("New without InputRateHz: want error")
+	}
+	if _, err := New(Options{Bus: bus, InputRateHz: 1_000_000}); err == nil {
+		t.Error("New with sub-2-Msps rate: want error")
+	}
+	if _, err := New(Options{Bus: bus, InputRateHz: SampleRateHz}); err != nil {
+		t.Errorf("New at 2 Msps: unexpected error %v", err)
+	}
+}
+
+func TestProcessPropagatesContextCancel(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	r, _ := New(Options{InputRateHz: SampleRateHz, Bus: bus})
+	in := make(chan []complex64)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- r.Process(ctx, in) }()
+	cancel()
+	select {
+	case err := <-done:
+		if err != context.Canceled {
+			t.Errorf("Process err = %v, want context.Canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Process did not exit after ctx cancel")
+	}
+}
+
+func TestProcessNilInputErrors(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	r, _ := New(Options{InputRateHz: SampleRateHz, Bus: bus})
+	if err := r.Process(context.Background(), nil); err == nil {
+		t.Error("Process with nil input: want error")
+	}
+}
+
+// modulatePPM synthesises a clean 2 Msps Mode-S IQ burst for one frame:
+// quiet lead-in, the 8 µs preamble (pulses at samples 0, 2, 7, 9), the
+// PPM data bits (1 = high-then-low, 0 = low-then-high), then a quiet
+// tail. Magnitude is 1 for a pulse and 0 for quiet.
+func modulatePPM(frame []byte) []complex64 {
+	const lead = 30
+	hi := complex64(complex(1, 0))
+	var iq []complex64
+	for i := 0; i < lead; i++ {
+		iq = append(iq, 0)
+	}
+	// Preamble: high at 0, 2, 7, 9; low elsewhere across 16 samples.
+	pre := [preambleSamples]complex64{}
+	for _, p := range []int{0, 2, 7, 9} {
+		pre[p] = hi
+	}
+	iq = append(iq, pre[:]...)
+	// Data bits, MSB-first per byte.
+	for _, by := range frame {
+		for b := 7; b >= 0; b-- {
+			if by&(1<<uint(b)) != 0 {
+				iq = append(iq, hi, 0) // 1: high-then-low
+			} else {
+				iq = append(iq, 0, hi) // 0: low-then-high
+			}
+		}
+	}
+	for i := 0; i < frameSpan; i++ {
+		iq = append(iq, 0) // tail so scan has frameSpan headroom
+	}
+	return iq
+}
+
+// TestEndToEndDF17Decode modulates a real DF17 identification frame to
+// a clean IQ burst, runs it through the full PPM pipeline, and asserts
+// the decoded AircraftReport lands on the bus with the right ICAO.
+func TestEndToEndDF17Decode(t *testing.T) {
+	bus := events.NewBus(64)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	r, err := New(Options{InputRateHz: SampleRateHz, Bus: bus})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	// 8D4840D6202CC371C32CE0576098 — ICAO 4840D6, an identification
+	// extended squitter (matches internal/radio/adsb/adsb_test.go).
+	frame, err := hex.DecodeString("8D4840D6202CC371C32CE0576098")
+	if err != nil {
+		t.Fatalf("decode frame: %v", err)
+	}
+	iq := modulatePPM(frame)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	in := make(chan []complex64, 1)
+	done := make(chan struct{})
+	go func() {
+		_ = r.Process(ctx, in)
+		close(done)
+	}()
+	in <- iq
+	close(in)
+	<-done
+
+	deadline := time.After(time.Second)
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind != events.KindAircraftReport {
+				continue
+			}
+			rep := ev.Payload.(storage.AircraftReport)
+			if rep.ICAOHex != "4840D6" {
+				t.Errorf("ICAOHex = %q, want 4840D6", rep.ICAOHex)
+			}
+			if rep.Callsign == "" {
+				t.Errorf("Callsign empty; want the squitter callsign")
+			}
+			if got := r.Stats().FramesEmitted; got != 1 {
+				t.Errorf("FramesEmitted = %d, want 1", got)
+			}
+			return
+		case <-deadline:
+			t.Fatalf("no aircraft report decoded; stats = %+v", r.Stats())
+		}
+	}
+}
+
+// TestChunkBoundarySplit feeds the same burst split across two chunks
+// mid-frame to confirm the carry buffer reassembles it.
+func TestChunkBoundarySplit(t *testing.T) {
+	bus := events.NewBus(64)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	r, _ := New(Options{InputRateHz: SampleRateHz, Bus: bus})
+	frame, _ := hex.DecodeString("8D4840D6202CC371C32CE0576098")
+	iq := modulatePPM(frame)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	in := make(chan []complex64, 2)
+	done := make(chan struct{})
+	go func() {
+		_ = r.Process(ctx, in)
+		close(done)
+	}()
+	// Split partway through the preamble/data so a naive per-chunk
+	// scan would miss it.
+	split := 40
+	in <- iq[:split]
+	in <- iq[split:]
+	close(in)
+	<-done
+
+	select {
+	case ev := <-sub.C:
+		rep := ev.Payload.(storage.AircraftReport)
+		if rep.ICAOHex != "4840D6" {
+			t.Errorf("ICAOHex = %q, want 4840D6", rep.ICAOHex)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("no report across chunk boundary; stats = %+v", r.Stats())
+	}
+}

--- a/internal/radio/adsb/report.go
+++ b/internal/radio/adsb/report.go
@@ -1,0 +1,71 @@
+package adsb
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/storage"
+)
+
+// ProcessFrame decodes a raw Mode-S frame (7 or 14 bytes), gates it on
+// CRC, updates the CPR tracker for even/odd position pairing, and
+// returns the storage.AircraftReport to publish.
+//
+// ok is false for frames that should be dropped: a CRC failure on
+// anything but an all-call reply (DF 11) can't be trusted — extended
+// squitters with a bad CRC carry unreliable payloads, while an
+// all-call reply carries only the ICAO and is still useful for
+// "this aircraft is in range" tracking.
+//
+// This is the single decode → track → report path shared by the BEAST
+// upstream client and the native PPM receiver, so both sources produce
+// byte-for-byte identical AircraftReports. Pass a non-nil tracker to
+// get global CPR positions; pass nil to skip pairing.
+func ProcessFrame(frame []byte, tracker *Tracker, now time.Time) (storage.AircraftReport, bool) {
+	m := Decode(frame)
+	if !m.CRCValid && m.Kind != KindAllCall {
+		return storage.AircraftReport{}, false
+	}
+	if tracker != nil {
+		m, _ = tracker.Update(m, now.UnixNano())
+	}
+	return BuildReport(m, now), true
+}
+
+// BuildReport maps a decoded Message into the storage.AircraftReport
+// the bus carries. Exported for callers that have already decoded /
+// tracked a Message themselves.
+func BuildReport(m Message, now time.Time) storage.AircraftReport {
+	rep := storage.AircraftReport{
+		ReceivedAt: now,
+		ICAO:       m.ICAO,
+		ICAOHex:    fmt.Sprintf("%06X", m.ICAO),
+		Kind:       KindString(m.Kind),
+		Body:       m.String(),
+		CRCValid:   m.CRCValid,
+		RawHex:     m.RawHex,
+	}
+	if m.Identification != nil {
+		rep.Callsign = m.Identification.Callsign
+		rep.Category = m.Identification.Category
+	}
+	if m.Position != nil {
+		rep.HasAltitude = m.Position.HasAltitude
+		rep.Altitude = m.Position.Altitude
+		if m.Position.HasGlobalPosition {
+			rep.HasPosition = true
+			rep.Latitude = m.Position.Latitude
+			rep.Longitude = m.Position.Longitude
+		}
+	}
+	if m.Velocity != nil {
+		if m.Velocity.HasGroundSpeed {
+			rep.GroundSpeedKn = m.Velocity.GroundSpeedKn
+			rep.TrackDeg = m.Velocity.TrackDeg
+		}
+		if m.Velocity.HasVerticalRate {
+			rep.VerticalRateFPM = m.Velocity.VerticalRateFPM
+		}
+	}
+	return rep
+}


### PR DESCRIPTION
## Summary

Completes **Phase 5** by adding a native 1090 MHz PPM Mode-S/ADS-B receiver — the alternative to running a separate dump1090/readsb and consuming its BEAST output. This is Milestone 2 of the remaining-work roadmap (Milestone 1, DSC DSP, landed in #448).

## What's new

- **`internal/radio/adsb/ppm`** — IQ → resample to 2 Msps → magnitude² envelope → dump1090-style 8 µs preamble correlation (pulses at 0, 1, 3.5, 4.5 µs) → PPM bit slice (`1` = high-then-low, `0` = low-then-high) → DF frame-length (56/112-bit) → frame bytes. A magnitude carry buffer spans chunk boundaries so a preamble split across two IQ chunks still decodes.
- **`internal/radio/adsb/report.go`** — factored the `decode → CRC gate → CPR track → AircraftReport` mapping out of the BEAST client into a shared `adsb.ProcessFrame(frame, tracker, now)`, so the native receiver and BEAST upstream produce **byte-for-byte identical reports**. `beast.handleFrame` now calls it (net −40 LOC there).
- **Config** — `ADSBConfig` gains a `channels` list (separate from `beast_upstreams`); `frequency_hz` defaults to 1090 MHz. Documented in `config.example.yaml`.
- **Daemon** — construct + spawn loops mirroring the AIS receivers, pinning the SDR to 1090 MHz off its iqtap broker.

## Testing

- `go build/vet/test ./...` green.
- End-to-end: a real DF17 identification frame (`8D4840D6…`, ICAO 4840D6) modulated to a clean PPM burst decodes through the full pipeline to the correct ICAO + callsign.
- Chunk-boundary split case: same burst delivered across two IQ chunks mid-frame still decodes via the carry buffer.

## Docs

`README.md`, `docs/adsb.md`, and `docs/dsc.md` updated to reflect the now-shipped DSC and ADS-B DSP frontends (both previously documented as "follows"/"pending").

## Notes / follow-ups

- The detector/slicer follow the dump1090 magnitude-domain baseline at a fixed 2 Msps (the receiver resamples to that rate if the SDR runs faster). Phase-corrected re-detection and 2.4 Msps operation are deliberate later refinements; the baseline locks cleanly on the strong signals a filtered + amplified 1090 MHz chain delivers.
- Operators with an existing dump1090 stay on the BEAST upstream unchanged — frames from both sources merge into the same `KindAircraftReport` stream, storage, tracker, panel, and map.

Roadmap continues with FLEX paging (Milestone 3), then M17 + Codec2 (Milestones 4–6).

---
_Generated by [Claude Code](https://claude.ai/code/session_01PccwhG9Ee9S2eqhtPbTWVc)_