### PR TITLE
p25/#402: fixed slicer by default, improved adaptive slicer behind a flag, + I/Q-imbalance investigation

### DIFF
--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -774,6 +774,13 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 					iqSrc = br
 					tuner = br
 				}
+				iqCorrect := false
+				for _, dev := range cfg.SDR.Devices {
+					if dev.Serial == controlEntry.Info.Serial {
+						iqCorrect = dev.IQCorrect
+						break
+					}
+				}
 				d.ccDecoderOpts = ccdecoder.Options{
 					Bus:          d.bus,
 					Log:          log,
@@ -782,6 +789,7 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 					Systems:      d.systems,
 					SampleRateHz: float64(cfg.SDR.SampleRate),
 					Metrics:      iqObs,
+					IQCorrect:    iqCorrect,
 				}
 				d.controlSerial = controlEntry.Info.Serial
 				d.controlSampleRate = cfg.SDR.SampleRate

--- a/cmd/gophertrunk/iqdiag.go
+++ b/cmd/gophertrunk/iqdiag.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
 	p25phase1 "github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase1"
+	"github.com/MattCheramie/GopherTrunk/internal/sdr/rtlsdr"
 )
 
 // iqDiag accumulates the full dibit stream a replay produced and prints
@@ -48,6 +49,37 @@ type iqDiag struct {
 	// far outside the slicer's threshold, every sample collapses
 	// to ±3 and the dibit histogram skews to {1, 3} only.
 	soft []float32
+	// iqStats accumulates the raw-IQ second-order moments (issue #402),
+	// from which the report derives the front-end I/Q gain/phase imbalance
+	// — the leading suspect for the asymmetric demodulated eye.
+	iqStats rtlsdr.IQImbalanceStats
+}
+
+// distStats returns the mean, standard deviation, and 10th/50th/90th
+// percentiles of v (sorts a copy; v is left unmodified). Zero values for an
+// empty slice.
+func distStats(v []float64) (mean, std, p10, p50, p90 float64) {
+	if len(v) == 0 {
+		return 0, 0, 0, 0, 0
+	}
+	var sum float64
+	for _, x := range v {
+		sum += x
+	}
+	mean = sum / float64(len(v))
+	var sq float64
+	for _, x := range v {
+		d := x - mean
+		sq += d * d
+	}
+	std = math.Sqrt(sq / float64(len(v)))
+	s := append([]float64(nil), v...)
+	sort.Float64s(s)
+	pct := func(p float64) float64 {
+		idx := int(p * float64(len(s)-1))
+		return s[idx]
+	}
+	return mean, std, pct(0.10), pct(0.50), pct(0.90)
 }
 
 // observe appends a chunk of dibits to the rolling buffer the EOF
@@ -55,6 +87,12 @@ type iqDiag struct {
 // is set.
 func (d *iqDiag) observe(dibits []uint8) {
 	d.dibits = append(d.dibits, dibits...)
+}
+
+// observeIQ folds a chunk of raw (pre-DDC) IQ into the I/Q-imbalance
+// moments. Called from the read loop in replay.go when -diag is set.
+func (d *iqDiag) observeIQ(raw []complex64) {
+	d.iqStats.Observe(raw)
 }
 
 // observeSoft appends pre-slicer per-symbol soft samples to the
@@ -190,24 +228,36 @@ func (d *iqDiag) printReport(w io.Writer) {
 			// dibit → label and slice index. Mapping per
 			// phase1.SymbolToDibit: 0:+1, 1:+3, 2:-1, 3:-3.
 			labels := [4]string{"+1", "+3", "-1", "-3"}
-			var csum [4]float64
-			var cnt [4]int
+			var vals [4][]float64
 			for i, s := range d.soft {
 				db := d.dibits[i] & 3
-				csum[db] += float64(s)
-				cnt[db]++
+				vals[db] = append(vals[db], float64(s))
 			}
-			fmt.Fprintln(w, "diag: per-decided-symbol soft centroids (clean eye: ±outer ≈ 3×±inner, symmetric):")
-			// Print in eye order -3,-1,+1,+3 for readability.
-			for _, db := range [4]uint8{3, 2, 0, 1} {
-				mean := 0.0
-				if cnt[db] > 0 {
-					mean = csum[db] / float64(cnt[db])
-				}
-				fmt.Fprintf(w, "diag:   %s (dibit %d): n=%7d (%5.2f%%)  centroid=%+.6f\n",
-					labels[db], db, cnt[db], 100*float64(cnt[db])/float64(len(d.soft)), mean)
+			// Per-rail centroid AND spread (std + 10/50/90 percentiles). The
+			// spread is the #402 discriminator: a rail whose centroid looks
+			// fine but whose p10..p90 is very wide is *spread* (e.g. the +3
+			// outer population landing low), which is why a threshold derived
+			// from the centroid mis-slices it — distinct from a tight cluster.
+			fmt.Fprintln(w, "diag: per-decided-symbol soft distribution (clean eye: ±outer ≈ 3×±inner, symmetric, tight):")
+			for _, db := range [4]uint8{3, 2, 0, 1} { // eye order -3,-1,+1,+3
+				v := vals[db]
+				mean, std, p10, p50, p90 := distStats(v)
+				fmt.Fprintf(w, "diag:   %s (dibit %d): n=%7d (%5.2f%%)  centroid=%+.6f  std=%.6f  p10/50/90=%+.4f/%+.4f/%+.4f\n",
+					labels[db], db, len(v), 100*float64(len(v))/float64(len(d.soft)), mean, std, p10, p50, p90)
 			}
 		}
+	}
+
+	// I/Q imbalance on the raw (pre-DDC) IQ (issue #402). The RX chain is
+	// provably symmetric, so an asymmetric eye must come from the IQ samples;
+	// an uncorrected front-end I/Q imbalance (worst at the on-channel DC the
+	// DDC sits on) is the leading suspect. A clean front-end is balanced
+	// (≈0 dB gain, ≈0° phase) with image rejection ≳ 40 dB. Re-run with
+	// -iq-correct to A/B.
+	if d.iqStats.Count() > 0 {
+		bal := d.iqStats.Balancer()
+		fmt.Fprintf(w, "diag: raw IQ imbalance: gain=%+.3f dB  phase=%+.3f°  image_rejection=%.1f dB  (correction GainQ=%.4f Phase=%+.4f rad)\n",
+			d.iqStats.GainImbalanceDB(), d.iqStats.PhaseImbalanceDeg(), d.iqStats.ImageRejectionDB(), bal.GainQ, bal.Phase)
 	}
 
 	// Dibit value histogram — should be ~25% per bin on a clean C4FM

--- a/cmd/gophertrunk/replay.go
+++ b/cmd/gophertrunk/replay.go
@@ -16,6 +16,7 @@ import (
 	p25phase1 "github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase1"
 	p25phase1rx "github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase1/receiver"
 	"github.com/MattCheramie/GopherTrunk/internal/scanner/ccdecoder"
+	"github.com/MattCheramie/GopherTrunk/internal/sdr/rtlsdr"
 	"github.com/MattCheramie/GopherTrunk/internal/trunking"
 )
 
@@ -71,6 +72,10 @@ func runReplay(args []string) {
 	// slicer outperformed it on the original capture's closed/asymmetric
 	// eye). This knob enables it for A/B experimentation. C4FM only.
 	enableAdaptiveSlicer := fs.Bool("adaptive-slicer", false, "enable the adaptive C4FM slicer on the C4FM path (off by default; see issue #402)")
+	// Issue #402: blind I/Q-imbalance correction on the raw IQ before the DDC.
+	// Off by default; the chain audit found an uncorrected RTL-SDR imbalance is
+	// the leading explanation for the asymmetric demodulated eye on MMR Site 9.
+	iqCorrect := fs.Bool("iq-correct", false, "apply blind I/Q-imbalance correction to the raw IQ before decimation (off by default; see issue #402)")
 	fs.Usage = func() {
 		fmt.Fprintln(fs.Output(), `gophertrunk replay — decode a raw IQ capture file offline.
 
@@ -169,8 +174,8 @@ FLAGS:`)
 	// pipeline does, so the replay log line is directly comparable
 	// to a daemon's startup line — and a non-default span (the
 	// bisect knob) is visible without re-reading the command.
-	fmt.Fprintf(os.Stderr, "replay: p25/phase1 configured  demod=%s  rotations=%v  nid_search_span=%d  nid_accept_errs=%d  nid_marginal_max=%d  dda=%t  adaptive_slicer=%t\n",
-		*demod, rotations, *nidSearchSpan, p25phase1.NIDAcceptErrs, p25phase1.NIDMarginalMaxErrs, *enableDDA, *enableAdaptiveSlicer)
+	fmt.Fprintf(os.Stderr, "replay: p25/phase1 configured  demod=%s  rotations=%v  nid_search_span=%d  nid_accept_errs=%d  nid_marginal_max=%d  dda=%t  adaptive_slicer=%t  iq_correct=%t\n",
+		*demod, rotations, *nidSearchSpan, p25phase1.NIDAcceptErrs, p25phase1.NIDMarginalMaxErrs, *enableDDA, *enableAdaptiveSlicer, *iqCorrect)
 	if ddc != nil {
 		fmt.Fprintf(os.Stderr, "replay: ddc enabled  sdr_rate_hz=%g  pipeline_rate_hz=%g\n",
 			*sampleRate, receiverRate)
@@ -183,6 +188,11 @@ FLAGS:`)
 	var diagAcc *iqDiag
 	if *diag {
 		diagAcc = &iqDiag{}
+	}
+	// Blind I/Q-imbalance correction on the raw IQ (issue #402), opt-in.
+	var iqCorrector *rtlsdr.IQImbalanceCorrector
+	if *iqCorrect {
+		iqCorrector = rtlsdr.NewIQImbalanceCorrector()
 	}
 	rxOpts := p25phase1rx.Options{
 		SampleRateHz:              receiverRate,
@@ -275,6 +285,14 @@ FLAGS:`)
 			}
 			decode(buf[:pairs*pairBytes], samples[:pairs])
 			feed := samples[:pairs]
+			// Measure the raw I/Q imbalance for the diag report, then (opt-in)
+			// correct it — both on the raw IQ, before the DDC (issue #402).
+			if diagAcc != nil {
+				diagAcc.observeIQ(feed)
+			}
+			if iqCorrector != nil {
+				iqCorrector.Process(feed)
+			}
 			if ddc != nil {
 				ddcOut = ddc.Process(ddcOut, feed)
 				feed = ddcOut

--- a/cmd/gophertrunk/replay.go
+++ b/cmd/gophertrunk/replay.go
@@ -67,6 +67,10 @@ func runReplay(args []string) {
 	// for A/B experimentation on a capture without turning it on in
 	// production. C4FM only.
 	enableDDA := fs.Bool("dda", false, "enable the experimental decision-directed AFC on the C4FM path (off by default; see issue #402)")
+	// Issue #402: the adaptive C4FM slicer is off by default (the fixed
+	// slicer outperformed it on the original capture's closed/asymmetric
+	// eye). This knob enables it for A/B experimentation. C4FM only.
+	enableAdaptiveSlicer := fs.Bool("adaptive-slicer", false, "enable the adaptive C4FM slicer on the C4FM path (off by default; see issue #402)")
 	fs.Usage = func() {
 		fmt.Fprintln(fs.Output(), `gophertrunk replay — decode a raw IQ capture file offline.
 
@@ -165,8 +169,8 @@ FLAGS:`)
 	// pipeline does, so the replay log line is directly comparable
 	// to a daemon's startup line — and a non-default span (the
 	// bisect knob) is visible without re-reading the command.
-	fmt.Fprintf(os.Stderr, "replay: p25/phase1 configured  demod=%s  rotations=%v  nid_search_span=%d  nid_accept_errs=%d  nid_marginal_max=%d\n",
-		*demod, rotations, *nidSearchSpan, p25phase1.NIDAcceptErrs, p25phase1.NIDMarginalMaxErrs)
+	fmt.Fprintf(os.Stderr, "replay: p25/phase1 configured  demod=%s  rotations=%v  nid_search_span=%d  nid_accept_errs=%d  nid_marginal_max=%d  dda=%t  adaptive_slicer=%t\n",
+		*demod, rotations, *nidSearchSpan, p25phase1.NIDAcceptErrs, p25phase1.NIDMarginalMaxErrs, *enableDDA, *enableAdaptiveSlicer)
 	if ddc != nil {
 		fmt.Fprintf(os.Stderr, "replay: ddc enabled  sdr_rate_hz=%g  pipeline_rate_hz=%g\n",
 			*sampleRate, receiverRate)
@@ -185,6 +189,7 @@ FLAGS:`)
 		DeviationHz:               1800.0,
 		DemodMode:                 demodMode,
 		EnableDecisionDirectedAFC: *enableDDA,
+		EnableAdaptiveC4FMSlicer:  *enableAdaptiveSlicer,
 		DibitSink: func(dibits []uint8, baseIdx int) {
 			dibitCount += int64(len(dibits))
 			if diagAcc != nil {

--- a/cmd/gophertrunk/replay.go
+++ b/cmd/gophertrunk/replay.go
@@ -234,12 +234,15 @@ FLAGS:`)
 		// raw matched-output-unit value behind it.
 		//
 		// slicer_levels are the adaptive slicer's tracked −3/−1/+1/+3
-		// levels (issue #402). On a clean symmetric eye they sit near
-		// ±agc_target·{3/2, 1/2}; an asymmetric site shows one rail
-		// stretched, and the slicer's midpoint thresholds follow it.
+		// levels; slicer_thresholds are the actual decision boundaries
+		// (neg-outer/zero/pos-outer) the slicer decides on (issue #402: the
+		// OP asked to see the thresholds, not just the levels — on a spread
+		// eye the variance-aware boundary sits below the level midpoint).
+		// Both read zero on the fixed-slicer path (no -adaptive-slicer).
 		lv := rx.SlicerLevels()
+		th := rx.SlicerThresholds()
 		fmt.Fprintf(os.Stderr,
-			"replay: receiver state  t=%.2fs  afc_bias_rad_per_sample=%.6g  afc_hz_est=%.3f  agc_level=%.6g  agc_target=%.6g  agc_gain=%.4g  mm_mu=%.4f  mm_sps=%.2f  dda_active=%t  dda_rearms=%d  slicer_levels=[%.4f %.4f %.4f %.4f]\n",
+			"replay: receiver state  t=%.2fs  afc_bias_rad_per_sample=%.6g  afc_hz_est=%.3f  agc_level=%.6g  agc_target=%.6g  agc_gain=%.4g  mm_mu=%.4f  mm_sps=%.2f  dda_active=%t  dda_rearms=%d  slicer_levels=[%.4f %.4f %.4f %.4f]  slicer_thresholds=[%.4f %.4f %.4f]\n",
 			at,
 			rx.AFCBiasRadPerSample(),
 			rx.AFCOffsetHz(),
@@ -250,7 +253,8 @@ FLAGS:`)
 			rx.MMClockSPS(),
 			rx.DDAActive(),
 			rx.DDARearms(),
-			lv[0], lv[1], lv[2], lv[3])
+			lv[0], lv[1], lv[2], lv[3],
+			th[0], th[1], th[2])
 	}
 
 	const chunkSamples = 8192

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -436,6 +436,14 @@ type DeviceConfig struct {
 	// physical voice SDR when one is configured. Capped at 8 to
 	// keep CPU bounded.
 	VoiceTaps int `yaml:"voice_taps"`
+
+	// IQCorrect enables blind I/Q-imbalance correction on this device's
+	// raw IQ before decimation (issue #402). Off by default. An
+	// uncorrected RTL-SDR I/Q imbalance distorts the demodulated symbol
+	// eye (worst at the on-channel DC the control decoder's DDC sits on);
+	// validate the benefit with `gophertrunk replay -iq-correct -diag`
+	// on a capture from this device before enabling it here.
+	IQCorrect bool `yaml:"iq_correct"`
 }
 
 // DeviceChannelConfig is one repeater carrier carried by a

--- a/internal/dsp/demod/adaptive_c4fm.go
+++ b/internal/dsp/demod/adaptive_c4fm.go
@@ -38,14 +38,19 @@ import "math"
 //     well-separated eye is tracked, an ambiguous one stays near fixed.
 //   - Per-level clamps and a strict-ordering invariant, so the thresholds
 //     can't run away on noise / loss-of-signal.
-//   - The outer decision thresholds are anchored to the well-estimated
-//     inner rail: they may move *inward* (toward zero) freely to follow a
-//     compressed or DC-shifted eye — the case the fixed slicer genuinely
-//     can't handle — but their *outward* travel is capped at a nominal
-//     inner→outer spacing above the tracked inner level. This closes the
-//     #402 regression where a lower-truncated outer-level EMA dragged the
-//     +1/+3 threshold ever outward (positive feedback), suppressing outer
-//     symbols and collapsing the outer-heavy frame-sync word.
+//   - The outer decision thresholds are *inward-only capped*: they may move
+//     toward zero freely (to follow a compressed or DC-shifted eye — the case
+//     the fixed slicer genuinely can't handle) but their outward travel is
+//     capped at a nominal inner→outer half-spacing (s/3) above the tracked
+//     inner rail, i.e. at the fixed nominal threshold. On the #402 capture
+//     every adaptive threshold that rose above the fixed nominal decoded
+//     worse, so the cap keeps the slicer no worse than fixed there.
+//   - The boundaries are *variance-aware*: each sits at the equal-σ-distance
+//     point between adjacent rails (not the plain midpoint), so when an outer
+//     rail's population is *spread* — the #402 +3 rail spreads low — the
+//     boundary moves toward the tighter inner rail, recovering more of the
+//     spread rail's symbols than a midpoint would. Inner-rail σ is clamped
+//     tight so an overlapping outer tail can't inflate it and cancel this.
 //   - The per-symbol level update is a soft-responsibility (Gaussian
 //     mixture) step rather than a hard decided-rail EMA, so a true outer
 //     symbol that landed below the threshold still contributes to the outer
@@ -71,7 +76,18 @@ type AdaptiveC4FMSlicer struct {
 	hiBound [4]float32
 	rate    float32 // single-pole EMA coefficient
 	sigma   float32 // Gaussian-responsibility width for the soft level update
-	warmup  int     // symbols to slice at nominal thresholds before adapting
+	// varia[i] is the running responsibility-weighted EMA of the squared
+	// residual (soft − level[i])² for rail i — the per-rail spread. It lets
+	// thresholds() place each boundary at the equal-σ-distance point between
+	// adjacent rails (toward the tighter rail) rather than the plain
+	// midpoint, so a rail whose population is spread (the #402 +3 outer rail,
+	// spread low) yields a lower decision boundary that recovers more of its
+	// symbols. Seeded equal across rails so the boundary starts at the
+	// midpoint (== fixed nominal under the inward cap).
+	varia  [4]float32
+	sigMin float32    // σ floor (keeps the equal-σ-distance weighting stable)
+	sigMax [4]float32 // per-rail σ ceiling: outer rails may be spread, inner rails are held tight
+	warmup int        // symbols to slice at nominal thresholds before adapting
 }
 
 // adaptiveSlicerRate is the EMA time constant for level tracking, in
@@ -106,6 +122,23 @@ const adaptiveSlicerLeak = adaptiveSlicerRate / 4
 // the outer level. That is what removes the one-sided truncation bias (#402).
 const adaptiveSlicerSigmaFrac = 1.0 / 4.0
 
+// adaptiveSlicerSigmaMinFrac / adaptiveSlicerSigmaMax{Inner,Outer}Frac clamp
+// the tracked per-rail σ (sqrt of varia[i]) used by the variance-aware
+// boundary, as fractions of slicerScale. The floor keeps a near-zero-variance
+// rail from making the equal-σ-distance weighting degenerate. The ceilings
+// are per-rail-type: an OUTER rail may be genuinely spread (the #402 +3
+// population is spread low), so it gets a generous ceiling; an INNER rail is
+// held tight, because on an overlapping eye a spread outer rail's tail leaks
+// partial responsibility onto the adjacent inner rail and would otherwise
+// inflate the inner σ to match — cancelling the very boundary shift we want.
+// Keeping the inner σ tight lets a spread outer rail actually pull the
+// boundary toward the (tight) inner rail.
+const (
+	adaptiveSlicerSigmaMinFrac      = 0.05
+	adaptiveSlicerSigmaMaxOuterFrac = 0.75
+	adaptiveSlicerSigmaMaxInnerFrac = 0.15
+)
+
 // adaptiveSlicerWarmup is the number of symbols the slicer decides at its
 // nominal (fixed-threshold) eye before it starts adapting. Upstream of the
 // slicer, the receiver's symbol-AGC is a 1/256 EMA that takes ~1300 symbols
@@ -130,8 +163,20 @@ func NewAdaptiveC4FMSlicer(slicerScale float64) *AdaptiveC4FMSlicer {
 		nominal: nominal,
 		rate:    adaptiveSlicerRate,
 		sigma:   s * adaptiveSlicerSigmaFrac,
-		warmup:  adaptiveSlicerWarmup,
+		sigMin:  s * adaptiveSlicerSigmaMinFrac,
+		sigMax: [4]float32{
+			s * adaptiveSlicerSigmaMaxOuterFrac, // -3 outer
+			s * adaptiveSlicerSigmaMaxInnerFrac, // -1 inner
+			s * adaptiveSlicerSigmaMaxInnerFrac, // +1 inner
+			s * adaptiveSlicerSigmaMaxOuterFrac, // +3 outer
+		},
+		warmup: adaptiveSlicerWarmup,
 	}
+	// Seed every rail's tracked spread equal, so before any data the
+	// equal-σ-distance boundaries reduce to the plain midpoints (== the fixed
+	// nominal thresholds under the inward cap).
+	seedVar := a.sigma * a.sigma
+	a.varia = [4]float32{seedVar, seedVar, seedVar, seedVar}
 	// Per-rail clamp bands. Outer rails may stretch generously (the #402
 	// site ran +3 at ~1.6× nominal); inner rails are held tighter since a
 	// collapsed inner level is the dangerous case (it would pull the zero
@@ -158,44 +203,76 @@ func NewAdaptiveC4FMSlicer(slicerScale float64) *AdaptiveC4FMSlicer {
 	return a
 }
 
-// thresholds returns the three live decision boundaries derived from the
-// tracked levels: the zero (−1/+1) crossing, and the two outer (−3/−1 and
-// +1/+3) boundaries.
-//
-// The zero crossing is the plain inner-rail midpoint, so it follows a
-// DC-shifted eye. The outer boundaries are *anchored*: each is the midpoint
-// between its inner and outer level, but capped so it can never sit farther
-// from zero than a full nominal inner→outer spacing (2·s/3) beyond the
-// tracked inner rail. This lets an outer boundary move inward to follow a
-// compressed eye (where the midpoint is below the cap, so the cap is
-// inactive and the boundary tracks fully) and outward to follow a genuinely
-// stretched eye (the #402 +3 rail at ~1.6× nominal, whose true midpoint is
-// ~0.22 — within the cap), while bounding the outward travel so a
-// truncation-biased outer level can't drag it past the true midpoint and
-// suppress outer symbols (the #402 runaway, which reached ~0.265). The cap
-// is referenced to the *tracked* inner level (not the nominal), so it
-// follows a shifted/scaled eye: it bounds the inner→outer *spacing*, not an
-// absolute threshold. The soft-responsibility update (Mechanism B) keeps the
-// outer level near its true centroid, so on a decodable eye the midpoint —
-// not the cap — sets the boundary; the cap is the safety net for the
-// closed/biased eye where decision-directed tracking would otherwise run.
-func (a *AdaptiveC4FMSlicer) thresholds() (tNegOuter, tZero, tPosOuter float32) {
-	gap := a.nominal[3] - a.nominal[2] // full nominal inner→outer spacing = 2·s/3
+// boundary returns the decision threshold between two adjacent rails (lo
+// below hi) at the equal-σ-distance point: the value x where
+// (x−μlo)/σlo = (μhi−x)/σhi, i.e. x = (μlo·σhi + μhi·σlo)/(σlo+σhi). This is
+// the plain midpoint when the two spreads are equal, but biases toward the
+// *tighter* rail when one is more spread — so a rail whose population is
+// spread (the #402 +3 outer rail) yields a boundary pulled toward the tight
+// inner rail, recovering more of the spread rail's symbols than a midpoint.
+func (a *AdaptiveC4FMSlicer) boundary(lo, hi int) float32 {
+	slo := a.clampSigma(lo)
+	shi := a.clampSigma(hi)
+	return (a.level[lo]*shi + a.level[hi]*slo) / (slo + shi)
+}
 
-	tPosOuter = (a.level[2] + a.level[3]) / 2
-	if capPos := a.level[2] + gap; tPosOuter > capPos {
+// clampSigma returns rail i's tracked σ (sqrt of varia[i]) clamped to
+// [sigMin, sigMax[i]] (the per-rail-type ceiling).
+func (a *AdaptiveC4FMSlicer) clampSigma(i int) float32 {
+	s := float32(math.Sqrt(float64(a.varia[i])))
+	if s < a.sigMin {
+		return a.sigMin
+	}
+	if s > a.sigMax[i] {
+		return a.sigMax[i]
+	}
+	return s
+}
+
+// thresholds returns the three live decision boundaries: the zero (−1/+1)
+// crossing and the two outer (−3/−1 and +1/+3) boundaries.
+//
+// Each is the variance-aware equal-σ-distance point (see boundary), so a
+// spread rail pulls its boundary toward the tighter neighbour. The two outer
+// boundaries are additionally capped *inward-only*: each may move toward zero
+// freely (to follow a compressed / DC-shifted eye, which the fixed slicer
+// can't) but its outward travel is capped at one nominal inner→outer spacing
+// (s/3) beyond the tracked inner rail — i.e. it can never sit farther out
+// than the fixed nominal threshold. On the #402 stretched/closed eye every
+// adaptive threshold that rose above the fixed nominal decoded worse, so the
+// cap keeps the slicer no worse than fixed there while the variance-aware
+// term lets it do *better* on a genuinely spread eye by moving the boundary
+// inward. The cap references the *tracked* inner level, so it bounds the
+// inner→outer spacing, not an absolute threshold (it follows a shifted eye).
+func (a *AdaptiveC4FMSlicer) thresholds() (tNegOuter, tZero, tPosOuter float32) {
+	// half the nominal inner→outer spacing = (s − s/3)/2 = s/3. The fixed
+	// +1/+3 threshold is nominal_inner + s/3 (= 2s/3), so capping the outer
+	// boundary at tracked_inner + s/3 pins it at the fixed nominal on a
+	// nominal-inner eye and never lets it travel farther outward.
+	half := (a.nominal[3] - a.nominal[2]) / 2
+
+	tPosOuter = a.boundary(2, 3)
+	if capPos := a.level[2] + half; tPosOuter > capPos {
 		tPosOuter = capPos
 	}
-	tNegOuter = (a.level[0] + a.level[1]) / 2
-	if capNeg := a.level[1] - gap; tNegOuter < capNeg {
+	tNegOuter = a.boundary(0, 1)
+	if capNeg := a.level[1] - half; tNegOuter < capNeg {
 		tNegOuter = capNeg
 	}
-	tZero = (a.level[1] + a.level[2]) / 2
+	tZero = a.boundary(1, 2)
 	return tNegOuter, tZero, tPosOuter
 }
 
+// Thresholds returns the three live decision boundaries (negative-outer,
+// zero, positive-outer). Diagnostic: lets replay print the actual thresholds
+// the slicer is deciding on, not just the tracked levels (issue #402).
+func (a *AdaptiveC4FMSlicer) Thresholds() [3]float32 {
+	tNeg, tZero, tPos := a.thresholds()
+	return [3]float32{tNeg, tZero, tPos}
+}
+
 // slice maps one soft sample to a symbol in {-3,-1,+1,+3} using the live
-// midpoint thresholds.
+// thresholds.
 func (a *AdaptiveC4FMSlicer) slice(soft float32) int8 {
 	tNegOuter, tZero, tPosOuter := a.thresholds()
 	switch {
@@ -229,11 +306,11 @@ func (a *AdaptiveC4FMSlicer) update(soft float32, sliced int8) {
 	_ = sliced // the soft responsibilities, not the hard decision, drive the update
 
 	inv2s2 := 1.0 / (2 * a.sigma * a.sigma)
-	var w [4]float32
+	var w, d [4]float32
 	var sum float32
 	for k := 0; k < 4; k++ {
-		d := soft - a.level[k]
-		e := float32(math.Exp(float64(-d * d * inv2s2)))
+		d[k] = soft - a.level[k]
+		e := float32(math.Exp(float64(-d[k] * d[k] * inv2s2)))
 		w[k] = e
 		sum += e
 	}
@@ -251,6 +328,11 @@ func (a *AdaptiveC4FMSlicer) update(soft float32, sliced int8) {
 		// pulling only by rk halved that mix and made the outer rail
 		// under-track — issue #402 follow-up to #439.)
 		a.level[k] += rk * (a.rate*(soft-a.level[k]) + adaptiveSlicerLeak*(a.nominal[k]-a.level[k]))
+		// Track the rail's spread the same way (responsibility-weighted EMA of
+		// the squared residual against the current level), so thresholds() can
+		// place each boundary at the equal-σ-distance point.
+		dk := d[k]
+		a.varia[k] += rk * a.rate * (dk*dk - a.varia[k])
 		a.clampLevel(k)
 	}
 	a.enforceOrder()
@@ -320,5 +402,7 @@ func (a *AdaptiveC4FMSlicer) Levels() [4]float32 { return a.level }
 // discontinuity.
 func (a *AdaptiveC4FMSlicer) Reset() {
 	a.level = a.nominal
+	seedVar := a.sigma * a.sigma
+	a.varia = [4]float32{seedVar, seedVar, seedVar, seedVar}
 	a.warmup = adaptiveSlicerWarmup
 }

--- a/internal/dsp/demod/adaptive_c4fm_test.go
+++ b/internal/dsp/demod/adaptive_c4fm_test.go
@@ -30,6 +30,22 @@ func buildEyeStream(rng *rand.Rand, n int, levels [4]float64, noise float64) (so
 	return soft, truth
 }
 
+// buildEyeStreamPerRailNoise is buildEyeStream with an independent Gaussian
+// spread per rail (−3,−1,+1,+3). It models the #402 eye where one rail's
+// population is spread far wider than the others, which the variance-aware
+// boundary exploits.
+func buildEyeStreamPerRailNoise(rng *rand.Rand, n int, levels, noise [4]float64) (soft []float32, truth []int8) {
+	syms := []int8{-3, -1, 1, 3}
+	soft = make([]float32, n)
+	truth = make([]int8, n)
+	for i := 0; i < n; i++ {
+		k := rng.Intn(4)
+		truth[i] = syms[k]
+		soft[i] = float32(levels[k] + rng.NormFloat64()*noise[k])
+	}
+	return soft, truth
+}
+
 func decodeErrors(dst, truth []int8) int {
 	errs := 0
 	for i := range truth {
@@ -55,94 +71,85 @@ func posOuterConfusions(dst, truth []int8) int {
 	return n
 }
 
-// TestAdaptiveSlicerRecoversAsymmetricEyeWhereFixedFails is the headline
-// issue #402 test: a stream drawn from the MMR Site 9 asymmetric centroids
-// (+3 rail stretched to ~1.6× nominal, negative rail nominal) is mis-sliced
-// by the fixed-threshold slicer but recovered by the adaptive one.
-func TestAdaptiveSlicerRecoversAsymmetricEyeWhereFixedFails(t *testing.T) {
+// TestAdaptiveSlicerVarianceAwareLowersBoundaryOnSpreadEye is the headline
+// issue #402 test for the variance-aware boundary: on an eye whose +3 outer
+// population is stretched high AND spread wide (lands low as well as high),
+// the fixed slicer's 0.157 boundary loses the spread-low +3 tail to +1. The
+// adaptive slicer, tracking +3's large spread, places the +1/+3 boundary
+// toward the tighter +1 rail (below both the equal-variance midpoint and the
+// inward cap), recovering more +3 — the outer symbols the FSW rides on.
+func TestAdaptiveSlicerVarianceAwareLowersBoundaryOnSpreadEye(t *testing.T) {
 	const slicerScale = 0.2356 // 2π·1800/48000
 	rng := rand.New(rand.NewSource(1))
 
-	// Observed #402 eye: nominal negative rail, stretched positive outer
-	// (~1.6× nominal), slightly compressed positive inner. The fixed +1/+3
-	// threshold (2·slicerScale/3 ≈ 0.157) sits close to the +1 rail (0.068,
-	// gap 0.089), so noisy +1 symbols leak into +3. The adaptive slicer keeps
-	// its +1/+3 boundary anchored a nominal spacing above the tracked +1
-	// rail (≈ 0.068 + s/3 ≈ 0.146) — comfortably between the rails — rather
-	// than letting a truncation-biased +3 level drag it outward toward the
-	// 0.221 midpoint (or, on a closed eye, past it), which is the #402
-	// regression covered by TestAdaptiveSlicerNoOuterThresholdRunawayOnClosedEye.
+	levels := [4]float64{-0.239, -0.078, 0.068, 0.374}
+	noise := [4]float64{0.05, 0.05, 0.05, 0.20} // +3 spread ~4× wider than the rest
+	const n = 40_000
+	soft, truth := buildEyeStreamPerRailNoise(rng, n, levels, noise)
+
+	fixed := NewC4FMWithTaps([]float32{1}, slicerScale)
+	fixedOut := fixed.SliceMany(nil, soft)
+
+	adapt := NewAdaptiveC4FMSlicer(slicerScale)
+	adaptOut := adapt.SliceMany(nil, soft)
+	const warm = 14_000 // clear warmup + EMA convergence before scoring
+
+	lv := adapt.Levels()
+	th := adapt.Thresholds()
+	midpoint := (lv[2] + lv[3]) / 2
+	cap := lv[2] + float32(slicerScale)/3 // the inward cap
+	t.Logf("levels=%v thresholds=%v midpoint=%.4f cap=%.4f", lv, th, midpoint, cap)
+
+	// The variance-aware term must pull the +1/+3 boundary below the inward
+	// cap (and so well below the midpoint): the cap alone would sit at ~0.15,
+	// the spread pulls it further toward the tight +1 rail.
+	if th[2] >= cap {
+		t.Errorf("+1/+3 threshold %.4f not below the inward cap %.4f — variance-aware term inactive", th[2], cap)
+	}
+
+	// FSW-relevant win: the adaptive slicer must retain at least as many true
+	// +3 symbols as the fixed slicer (the metric that tracked FSW hits on the
+	// real capture). A lower boundary recovers more of the spread-low +3.
+	fixedRet := outerRetention(fixedOut[warm:], truth[warm:], 3)
+	adaptRet := outerRetention(adaptOut[warm:], truth[warm:], 3)
+	t.Logf("+3 retention: fixed=%.3f adaptive=%.3f", fixedRet, adaptRet)
+	if adaptRet < fixedRet {
+		t.Errorf("+3 retention regressed: adaptive=%.3f < fixed=%.3f", adaptRet, fixedRet)
+	}
+}
+
+// TestAdaptiveSlicerNoWorseThanFixedOnEqualVarianceStretchedEye guards the
+// safety direction: on a stretched-but-equal-variance eye (the variance-aware
+// term is neutral, so only the inward cap acts) the adaptive slicer must
+// decode no worse than the fixed slicer — the #402 lesson that raising the
+// threshold above the fixed nominal harms sync. The cap pins the +1/+3
+// boundary at ≈ fixed, so the two slicers track within noise.
+func TestAdaptiveSlicerNoWorseThanFixedOnEqualVarianceStretchedEye(t *testing.T) {
+	const slicerScale = 0.2356
+	rng := rand.New(rand.NewSource(5))
 	asym := [4]float64{-0.239, -0.078, 0.068, 0.374}
 	const n = 30_000
 	const noise = 0.05
 	soft, truth := buildEyeStream(rng, n, asym, noise)
 
-	// Fixed slicer at nominal thresholds (±2·slicerScale/3 ≈ ±0.157).
 	fixed := NewC4FMWithTaps([]float32{1}, slicerScale)
 	fixedOut := fixed.SliceMany(nil, soft)
-
-	// Adaptive slicer. Skip past the warmup window + EMA convergence
-	// (warmup 2048 then a few thousand symbols at rate 1/512) when scoring.
 	adapt := NewAdaptiveC4FMSlicer(slicerScale)
 	adaptOut := adapt.SliceMany(nil, soft)
 	const warm = 10_000
 
-	// Overall: the adaptive slicer must be strictly better. (The inner-rail
-	// zero-crossing errors are common-mode — both slicers share them — so
-	// the overall gap is modest; the decisive win is at the outer boundary,
-	// checked next.)
+	th := adapt.Thresholds()
+	if th[2] > float32(slicerScale)*2/3+0.01 {
+		t.Errorf("+1/+3 threshold %.4f exceeded the fixed nominal (2s/3=%.4f) — cap not holding", th[2], slicerScale*2/3)
+	}
+
 	fixedErrs := decodeErrors(fixedOut[warm:], truth[warm:])
 	adaptErrs := decodeErrors(adaptOut[warm:], truth[warm:])
-	t.Logf("overall: fixed=%d adaptive=%d (of %d)", fixedErrs, adaptErrs, n-warm)
-	if adaptErrs >= fixedErrs {
-		t.Errorf("adaptive slicer no better overall: adaptive=%d fixed=%d", adaptErrs, fixedErrs)
+	margin := (n - warm) / 50 // within 2% of fixed
+	t.Logf("overall: fixed=%d adaptive=%d (of %d, margin %d)", fixedErrs, adaptErrs, n-warm, margin)
+	if adaptErrs > fixedErrs+margin {
+		t.Errorf("adaptive slicer worse than fixed by >2%%: adaptive=%d fixed=%d", adaptErrs, fixedErrs)
 	}
-
-	// Outer +1/+3 boundary — what the FSW rides on. The fixed slicer confuses
-	// many (its 0.157 threshold sits close to the +1 rail); the adaptive
-	// slicer, with its repositioned midpoint near ~0.20, confuses far fewer.
-	// We assert at least a 3× reduction: the leak-toward-nominal regularizer
-	// settles level[+3] at ~0.33 (not the synthetic-true 0.374), so the
-	// midpoint lands a touch below the 0.221 optimum — a deliberate trade of a
-	// little balanced-eye accuracy for the safety that stops the #402 runaway.
-	fixedConf := posOuterConfusions(fixedOut[warm:], truth[warm:])
-	adaptConf := posOuterConfusions(adaptOut[warm:], truth[warm:])
-	t.Logf("+1/+3 confusions: fixed=%d adaptive=%d", fixedConf, adaptConf)
-	if fixedConf < 50 {
-		t.Fatalf("fixed slicer only %d +1/+3 confusions — test setup too gentle to demonstrate the fix", fixedConf)
-	}
-	if adaptConf*3 > fixedConf {
-		t.Errorf("adaptive slicer +1/+3 confusions=%d, want ≤ fixed/3 (=%d)", adaptConf, fixedConf/3)
-	}
-
-	// The +1/+3 threshold must land in the FSW-safe band: above the +1 rail
-	// (0.068) with margin and near the true midpoint (0.221), but NOT dragged
-	// past it toward the ~0.265 runaway that collapsed the outer-heavy FSW on
-	// the real capture. With Mechanism B debiasing level[+3] the midpoint lands
-	// near ~0.20; the cap only bounds genuine runaway.
-	lv := adapt.Levels()
-	tPosOuter := posOuterThreshold(lv, slicerScale)
-	if tPosOuter < 0.14 || tPosOuter > 0.24 {
-		t.Errorf("positive-outer threshold = %.4f, want in [0.14, 0.24] (near the 0.221 midpoint, below the ~0.265 runaway)", tPosOuter)
-	}
-	// Mechanism B: the soft-responsibility update must converge level[+3]
-	// toward the true centroid (~0.374), not the lower-truncated ~0.43 a hard
-	// decided-rail EMA produced (the value the #402 diag reported).
-	if lv[3] < 0.33 || lv[3] > 0.40 {
-		t.Errorf("tracked +3 level = %.4f, want in [0.33, 0.40] (≈0.8·0.374+0.2·nominal; under 0.33 means the rail is under-tracking)", lv[3])
-	}
-}
-
-// posOuterThreshold mirrors the slicer's anchored +1/+3 decision boundary:
-// the inner/outer midpoint, capped at a full nominal inner→outer spacing
-// (2·s/3) above the tracked +1 level. Kept local to the test.
-func posOuterThreshold(lv [4]float32, slicerScale float64) float32 {
-	gap := float32(slicerScale) * 2 / 3
-	mid := (lv[2] + lv[3]) / 2
-	if cap := lv[2] + gap; mid > cap {
-		return cap
-	}
-	return mid
 }
 
 // buildEyeStreamWeighted is buildEyeStream with a non-uniform symbol
@@ -221,12 +228,12 @@ func TestAdaptiveSlicerNoOuterThresholdRunawayOnClosedEye(t *testing.T) {
 	const warm = 12_000 // clear warmup + EMA convergence before scoring
 
 	lv := adapt.Levels()
-	tPosOuter := posOuterThreshold(lv, slicerScale)
+	tPosOuter := adapt.Thresholds()[2]
 	if tPosOuter > 0.24 {
 		t.Errorf("positive-outer threshold = %.4f, want ≤ 0.24 (pre-fix ran away to ~0.265)", tPosOuter)
 	}
-	if tPosOuter < 0.12 {
-		t.Errorf("positive-outer threshold = %.4f, want ≥ 0.12 (must stay above the +1 rail)", tPosOuter)
+	if tPosOuter < 0.10 {
+		t.Errorf("positive-outer threshold = %.4f, want ≥ 0.10 (must stay above the +1 rail)", tPosOuter)
 	}
 
 	// +3 must not collapse into +1 (pre-fix retention fell to ~11%).

--- a/internal/radio/p25/phase1/receiver/receiver.go
+++ b/internal/radio/p25/phase1/receiver/receiver.go
@@ -675,6 +675,20 @@ func (r *Receiver) SlicerLevels() [4]float64 {
 	return [4]float64{float64(lv[0]), float64(lv[1]), float64(lv[2]), float64(lv[3])}
 }
 
+// SlicerThresholds returns the adaptive slicer's three live decision
+// boundaries (negative-outer, zero, positive-outer) — the values the slicer
+// actually decides on, which on an asymmetric/spread eye differ from the
+// midpoints of the tracked levels (issue #402: the OP asked to see the
+// per-second thresholds, not just the levels). Returns the zero array on the
+// CQPSK path or when no adaptive slicer is allocated (the fixed-slicer path).
+func (r *Receiver) SlicerThresholds() [3]float64 {
+	if r.slicer == nil {
+		return [3]float64{}
+	}
+	th := r.slicer.Thresholds()
+	return [3]float64{float64(th[0]), float64(th[1]), float64(th[2])}
+}
+
 // MMClockMu returns the Mueller-Müller symbol clock's current
 // sub-sample phase accumulator (in [-1, sps]). At steady state on a
 // noise-free input mu cycles deterministically through the symbol

--- a/internal/radio/p25/phase1/receiver/receiver.go
+++ b/internal/radio/p25/phase1/receiver/receiver.go
@@ -200,6 +200,20 @@ type Options struct {
 	// cause is pinned and the handoff is gated on a real lock signal.
 	// Ignored when DemodMode == DemodCQPSK (no AFC stage). Issue #402.
 	EnableDecisionDirectedAFC bool
+	// EnableAdaptiveC4FMSlicer opts the C4FM path into the adaptive
+	// 4-level slicer (issue #402) that tracks the observed per-symbol
+	// eye instead of slicing at fixed nominal thresholds. Default false:
+	// the receiver uses the fixed-threshold slicer. The adaptive slicer
+	// is OFF by default because on the issue #402 capture (a closed,
+	// asymmetric +3 eye whose outer population is spread low) every
+	// adaptive threshold that rose above the fixed nominal decoded worse,
+	// and the fixed slicer was the best performer (the asymmetry is an
+	// RF-domain effect — see the I/Q-imbalance investigation — not
+	// something the slicer can fix). Kept available behind this flag for
+	// sites with a genuinely DC-shifted or compressed (not stretched) eye
+	// and for A/B experimentation. Ignored when DeviationHz <= 0 or when
+	// DemodMode == DemodCQPSK.
+	EnableAdaptiveC4FMSlicer bool
 	// SoftSink, when non-nil, receives the per-symbol soft samples
 	// produced by the matched filter + symbol-clock recovery, just
 	// before slicing. The C4FM path emits the FM-discriminator +
@@ -316,19 +330,17 @@ func New(opts Options) *Receiver {
 		// with an inverse-sinc, so the matched filter is the spec C4FM
 		// receive filter (a sinc), not an RRC — issue #275.
 		r.mf = demod.NewC4FMP25(opts.SampleRateHz, slicerScale)
-		// Adaptive 4-level slicer (issue #402). Default-on for the
-		// real, DeviationHz-calibrated path: it tracks the observed
-		// per-symbol levels and slices at their midpoints, so an
-		// asymmetric / off-nominal eye that the fixed C4FM.Slice
-		// mis-decides (the MMR Site 9 +3-rail skew) decodes correctly.
-		// Skipped on the legacy pre-scaled-fixture path (slicerScale==1,
-		// DeviationHz unset), which keeps the fixed slicer so existing
-		// fixtures are byte-for-byte unchanged. The slicer warms up at,
-		// and is bounded + leak-regularized toward, the fixed nominal
-		// thresholds (see AdaptiveC4FMSlicer), so on a decodable (open)
-		// eye it matches or beats the fixed slicer and on a clean
-		// symmetric eye reproduces its decisions exactly.
-		if opts.DeviationHz > 0 {
+		// Adaptive 4-level slicer (issue #402), OPT-IN via
+		// EnableAdaptiveC4FMSlicer. It tracks the observed per-symbol eye
+		// and slices at variance-aware, inward-capped boundaries, so a
+		// DC-shifted or compressed eye that the fixed C4FM.Slice mis-decides
+		// can decode correctly. Off by default: on the MMR Site 9 capture
+		// (a closed, +3-stretched eye whose outer population is spread low)
+		// the fixed slicer outperformed every adaptive variant, and the
+		// asymmetry is an RF-domain effect, not a slicing problem. Also
+		// requires DeviationHz>0 (the legacy pre-scaled-fixture path keeps
+		// the fixed slicer so fixtures stay byte-for-byte unchanged).
+		if opts.EnableAdaptiveC4FMSlicer && opts.DeviationHz > 0 {
 			r.slicer = demod.NewAdaptiveC4FMSlicer(slicerScale)
 		}
 		r.afc = demod.NewCoarseAFC(sps)

--- a/internal/radio/p25/phase1/receiver/receiver_test.go
+++ b/internal/radio/p25/phase1/receiver/receiver_test.go
@@ -342,7 +342,7 @@ func TestC4FMSymbolAGCRescuesCollapsedSlicer(t *testing.T) {
 // no-regression guard for the issue #402 adaptive slicer. It captures the
 // receiver's post-AGC soft symbols from a clean, symmetric spec-P25 stream
 // (via SoftSink) and slices that identical stream both ways. The adaptive
-// slicer (default-on for the DeviationHz path) must decode at least as
+// slicer (opt-in via EnableAdaptiveC4FMSlicer) must decode at least as
 // faithfully as the fixed slicer it replaces — i.e. it adds no skew of its
 // own when there's no asymmetry to correct. Comparing the two slicers on
 // the same soft stream isolates the slicer from sps-dependent matched-
@@ -369,10 +369,11 @@ func TestAdaptiveSlicerNoRegressionOnCleanC4FMStream(t *testing.T) {
 
 	var soft []float32
 	r := New(Options{
-		SampleRateHz: sr,
-		DeviationHz:  dev,
-		SoftSink:     func(s []float32) { soft = append(soft, s...) },
-		DibitSink:    func([]uint8, int) {}, // required; the soft stream is what we score
+		SampleRateHz:             sr,
+		DeviationHz:              dev,
+		EnableAdaptiveC4FMSlicer: true, // this test is the adaptive-slicer guard
+		SoftSink:                 func(s []float32) { soft = append(soft, s...) },
+		DibitSink:                func([]uint8, int) {}, // required; the soft stream is what we score
 	})
 	r.Process(iq)
 	if len(soft) == 0 {

--- a/internal/scanner/ccdecoder/decoder.go
+++ b/internal/scanner/ccdecoder/decoder.go
@@ -52,6 +52,7 @@ import (
 	"time"
 
 	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/sdr/rtlsdr"
 	"github.com/MattCheramie/GopherTrunk/internal/trunking"
 )
 
@@ -138,6 +139,11 @@ type Options struct {
 	// low-power debug log in place — operators without Prometheus
 	// still get a hint when the dongle goes silent.
 	Metrics IQPowerObserver
+	// IQCorrect enables blind I/Q-imbalance correction on the raw IQ
+	// before decimation (issue #402). Off by default; opt-in per device
+	// via config. Validate with `replay -iq-correct -diag` on a capture
+	// before enabling in production.
+	IQCorrect bool
 }
 
 // Decoder is the long-lived component that converts the control
@@ -190,6 +196,11 @@ type Decoder struct {
 	pwLowLogAt   time.Time
 	pwDCLogAt    time.Time // throttle for the "DC bin dominant" debug line (issue #402)
 	pwLastSystem string
+
+	// iqCorrector, when non-nil (Options.IQCorrect), blindly removes the
+	// front-end I/Q imbalance from the raw IQ in pump before decimation
+	// (issue #402). Owned by pump.
+	iqCorrector *rtlsdr.IQImbalanceCorrector
 }
 
 // New constructs a Decoder. Returns an error when required Options
@@ -216,6 +227,9 @@ func New(opts Options) (*Decoder, error) {
 		systems:      make(map[string]trunking.System, len(opts.Systems)),
 		sub:          opts.Bus.Subscribe(),
 		metrics:      opts.Metrics,
+	}
+	if opts.IQCorrect {
+		d.iqCorrector = rtlsdr.NewIQImbalanceCorrector()
 	}
 	for _, s := range opts.Systems {
 		d.systems[s.Name] = s
@@ -390,7 +404,10 @@ func (d *Decoder) ensureDownconverterLocked(targetHz float64) {
 func (d *Decoder) pump(iq []complex64) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
-	d.observeIQPowerLocked(iq)
+	d.observeIQPowerLocked(iq) // measures the raw IQ (before correction)
+	if d.iqCorrector != nil {
+		d.iqCorrector.Process(iq) // blind I/Q-imbalance correction, in place (issue #402)
+	}
 	if d.active == nil {
 		return
 	}

--- a/internal/sdr/rtlsdr/calibrate.go
+++ b/internal/sdr/rtlsdr/calibrate.go
@@ -54,3 +54,163 @@ func (b IQBalancer) Process(in []complex64) {
 func PPMToHz(ppm int, centerHz uint32) int64 {
 	return int64(ppm) * int64(centerHz) / 1_000_000
 }
+
+// IQImbalanceStats accumulates the second-order moments of a complex stream —
+// E[I²], E[Q²], E[I·Q] — and derives the front-end I/Q gain/phase imbalance
+// from them. For a constant-envelope signal (FM / C4FM) the ideal baseband is
+// circularly symmetric (E[I²] = E[Q²], E[I·Q] = 0), so any departure measures
+// the receiver's I/Q imbalance directly. Used both as a replay diagnostic and
+// as the estimator behind IQImbalanceCorrector (issue #402: an uncorrected
+// RTL-SDR imbalance, worst at the on-channel DC the DDC sits on, is the
+// leading explanation for the asymmetric demodulated eye).
+type IQImbalanceStats struct {
+	sumII, sumQQ, sumIQ float64
+	n                   uint64
+}
+
+// Observe folds a chunk of raw IQ into the running moments.
+func (s *IQImbalanceStats) Observe(in []complex64) {
+	for _, c := range in {
+		i := float64(real(c))
+		q := float64(imag(c))
+		s.sumII += i * i
+		s.sumQQ += q * q
+		s.sumIQ += i * q
+	}
+	s.n += uint64(len(in))
+}
+
+// Count returns the number of samples observed so far.
+func (s *IQImbalanceStats) Count() uint64 { return s.n }
+
+// ok reports whether enough non-degenerate data has accumulated to derive.
+func (s *IQImbalanceStats) ok() bool {
+	return s.n > 0 && s.sumII > 1e-20 && s.sumQQ > 1e-20
+}
+
+// GainImbalanceDB is 10·log10(E[I²]/E[Q²]): the I-vs-Q power imbalance in dB
+// (0 = balanced). Equivalently 20·log10(GainQ).
+func (s *IQImbalanceStats) GainImbalanceDB() float64 {
+	if !s.ok() {
+		return 0
+	}
+	return 10 * math.Log10(s.sumII/s.sumQQ)
+}
+
+// PhaseImbalanceDeg is the I/Q quadrature error in degrees, from the
+// normalized I·Q correlation (0 = perfect quadrature).
+func (s *IQImbalanceStats) PhaseImbalanceDeg() float64 {
+	if !s.ok() {
+		return 0
+	}
+	return math.Asin(s.correlation()) * 180 / math.Pi
+}
+
+// correlation is the normalized E[I·Q] (the sine of the quadrature error).
+func (s *IQImbalanceStats) correlation() float64 {
+	if !s.ok() {
+		return 0
+	}
+	rho := s.sumIQ / math.Sqrt(s.sumII*s.sumQQ)
+	switch {
+	case rho > 1:
+		rho = 1
+	case rho < -1:
+		rho = -1
+	}
+	return rho
+}
+
+// ImageRejectionDB approximates the front-end image-rejection ratio implied by
+// the measured imbalance (higher is better; a clean front-end is ≳ 40 dB). The
+// small-imbalance approximation image/signal ≈ (εgain² + φ²)/4.
+func (s *IQImbalanceStats) ImageRejectionDB() float64 {
+	if !s.ok() {
+		return 0
+	}
+	gainErr := s.balancerGain() - 1
+	phi := math.Asin(s.correlation())
+	denom := gainErr*gainErr + phi*phi
+	if denom < 1e-12 {
+		return 99
+	}
+	return 10 * math.Log10(4/denom)
+}
+
+// balancerGain is the GainQ the IQBalancer needs to equalize the I/Q powers.
+func (s *IQImbalanceStats) balancerGain() float64 {
+	if !s.ok() {
+		return 1
+	}
+	return math.Sqrt(s.sumII / s.sumQQ)
+}
+
+// Balancer returns the IQBalancer coefficients that correct the measured
+// imbalance: GainQ equalizes the I/Q powers and Phase de-correlates I and Q
+// (Q' = GainQ·Q·cosΦ − I·sinΦ ⇒ E[I·Q']=0, E[Q'²]=E[I²]). Identity when
+// insufficient/degenerate data has been seen.
+func (s *IQImbalanceStats) Balancer() IQBalancer {
+	if !s.ok() {
+		return IQBalancer{GainQ: 1, Phase: 0}
+	}
+	return IQBalancer{
+		GainQ: float32(s.balancerGain()),
+		Phase: float32(math.Atan(s.correlation())),
+	}
+}
+
+// IQImbalanceCorrector blindly estimates and removes the front-end I/Q
+// imbalance from a streaming complex signal. It tracks the second-order
+// moments of the *raw* input with a slow EMA, derives the correcting
+// IQBalancer once a warmup has elapsed, and applies it in-place. Because the
+// moments are always measured from the raw input (never the corrected output)
+// there is no feedback loop, and a static hardware imbalance converges and
+// stays. Off the hot path by default — opt-in (issue #402). Not safe for
+// concurrent use.
+type IQImbalanceCorrector struct {
+	alpha         float64
+	mII, mQQ, mIQ float64
+	seen, warmup  uint64
+	bal           IQBalancer
+}
+
+// NewIQImbalanceCorrector returns a corrector with a slow moment EMA (~100k
+// samples, ≈40 ms at 2.4 MSPS) and a short warmup before it starts correcting.
+func NewIQImbalanceCorrector() *IQImbalanceCorrector {
+	return &IQImbalanceCorrector{
+		alpha:  1.0 / 100_000.0,
+		warmup: 50_000,
+		bal:    IQBalancer{GainQ: 1, Phase: 0},
+	}
+}
+
+// Process updates the imbalance estimate from the raw input, then corrects the
+// chunk in-place. During warmup it is a passthrough (GainQ=1, Phase=0).
+func (c *IQImbalanceCorrector) Process(in []complex64) {
+	for _, s := range in {
+		i := float64(real(s))
+		q := float64(imag(s))
+		c.mII += c.alpha * (i*i - c.mII)
+		c.mQQ += c.alpha * (q*q - c.mQQ)
+		c.mIQ += c.alpha * (i*q - c.mIQ)
+	}
+	c.seen += uint64(len(in))
+	if c.seen >= c.warmup && c.mII > 1e-20 && c.mQQ > 1e-20 {
+		rho := c.mIQ / math.Sqrt(c.mII*c.mQQ)
+		switch {
+		case rho > 1:
+			rho = 1
+		case rho < -1:
+			rho = -1
+		}
+		c.bal.GainQ = float32(math.Sqrt(c.mII / c.mQQ))
+		c.bal.Phase = float32(math.Atan(rho))
+	}
+	c.bal.Process(in)
+}
+
+// Coefficients returns the corrector's current GainQ and Phase (radians) — for
+// surfacing the converged estimate in diagnostics.
+func (c *IQImbalanceCorrector) Coefficients() (gainQ, phaseRad float32) {
+	return c.bal.GainQ, c.bal.Phase
+}

--- a/internal/sdr/rtlsdr/calibrate_test.go
+++ b/internal/sdr/rtlsdr/calibrate_test.go
@@ -2,8 +2,109 @@ package rtlsdr
 
 import (
 	"math"
+	"math/rand"
 	"testing"
 )
+
+// makeIQ builds a circularly-symmetric complex stream (ideal: E[I²]=E[Q²],
+// E[I·Q]=0) and applies a gain+cross-leakage imbalance Q_m = gain·Q + leak·I.
+// leak injects an I→Q correlation (a phase-skew stand-in); gain≠1 injects an
+// I/Q power imbalance.
+func makeIQ(rng *rand.Rand, n int, gain, leak float64) []complex64 {
+	out := make([]complex64, n)
+	for i := range out {
+		ii := rng.NormFloat64()
+		qq := rng.NormFloat64()
+		out[i] = complex(float32(ii), float32(gain*qq+leak*ii))
+	}
+	return out
+}
+
+func TestIQImbalanceStatsMeasuresInjectedImbalance(t *testing.T) {
+	rng := rand.New(rand.NewSource(1))
+
+	// Balanced stream reads ~0 imbalance and a high image-rejection.
+	var bal IQImbalanceStats
+	bal.Observe(makeIQ(rng, 200_000, 1.0, 0.0))
+	if db := math.Abs(bal.GainImbalanceDB()); db > 0.1 {
+		t.Errorf("balanced gain imbalance = %.3f dB, want ~0", db)
+	}
+	if deg := math.Abs(bal.PhaseImbalanceDeg()); deg > 0.5 {
+		t.Errorf("balanced phase imbalance = %.3f°, want ~0", deg)
+	}
+	if irr := bal.ImageRejectionDB(); irr < 35 {
+		t.Errorf("balanced image rejection = %.1f dB, want ≳ 35", irr)
+	}
+
+	// Imbalanced stream (Q hot by gain 1.25, plus I→Q leakage) reads clearly
+	// non-zero gain + phase imbalance and a degraded image rejection.
+	var imb IQImbalanceStats
+	imb.Observe(makeIQ(rng, 200_000, 1.25, 0.12))
+	if db := imb.GainImbalanceDB(); db > -1.0 { // Q hotter ⇒ negative
+		t.Errorf("imbalanced gain imbalance = %.3f dB, want clearly < -1", db)
+	}
+	if deg := imb.PhaseImbalanceDeg(); deg < 3 {
+		t.Errorf("imbalanced phase imbalance = %.3f°, want clearly > 3", deg)
+	}
+	if irr := imb.ImageRejectionDB(); irr > 25 {
+		t.Errorf("imbalanced image rejection = %.1f dB, want degraded (< 25)", irr)
+	}
+}
+
+func TestIQImbalanceCorrectorRemovesImbalance(t *testing.T) {
+	rng := rand.New(rand.NewSource(2))
+	const gain, leak = 1.25, 0.12
+
+	// Stats on the raw imbalanced stream, for the before/after comparison.
+	var before IQImbalanceStats
+	before.Observe(makeIQ(rand.New(rand.NewSource(2)), 300_000, gain, leak))
+
+	c := NewIQImbalanceCorrector()
+	var after IQImbalanceStats
+	const chunk = 8192
+	total := 600_000
+	for done := 0; done < total; done += chunk {
+		n := chunk
+		if done+n > total {
+			n = total - done
+		}
+		buf := makeIQ(rng, n, gain, leak)
+		c.Process(buf) // corrects in place
+		if done >= total/2 {
+			after.Observe(buf) // score the converged tail
+		}
+	}
+
+	t.Logf("gain imbalance dB: before=%.3f after=%.3f", before.GainImbalanceDB(), after.GainImbalanceDB())
+	t.Logf("phase imbalance °: before=%.3f after=%.3f", before.PhaseImbalanceDeg(), after.PhaseImbalanceDeg())
+	t.Logf("image rejection dB: before=%.1f after=%.1f", before.ImageRejectionDB(), after.ImageRejectionDB())
+
+	// The corrector must drive the residual I/Q correlation and gain imbalance
+	// far toward zero — at least a 4× reduction on each.
+	if math.Abs(after.PhaseImbalanceDeg())*4 > math.Abs(before.PhaseImbalanceDeg()) {
+		t.Errorf("phase imbalance not reduced ≥4×: before=%.3f° after=%.3f°", before.PhaseImbalanceDeg(), after.PhaseImbalanceDeg())
+	}
+	if math.Abs(after.GainImbalanceDB())*4 > math.Abs(before.GainImbalanceDB()) {
+		t.Errorf("gain imbalance not reduced ≥4×: before=%.3f dB after=%.3f dB", before.GainImbalanceDB(), after.GainImbalanceDB())
+	}
+	if after.ImageRejectionDB() < 35 {
+		t.Errorf("corrected image rejection = %.1f dB, want ≳ 35", after.ImageRejectionDB())
+	}
+
+	// A balanced stream must pass through ~untouched (no spurious correction).
+	cb := NewIQImbalanceCorrector()
+	var passthru IQImbalanceStats
+	for done := 0; done < total; done += chunk {
+		buf := makeIQ(rng, chunk, 1.0, 0.0)
+		cb.Process(buf)
+		if done >= total/2 {
+			passthru.Observe(buf)
+		}
+	}
+	if irr := passthru.ImageRejectionDB(); irr < 35 {
+		t.Errorf("balanced stream image rejection after corrector = %.1f dB, want ≳ 35", irr)
+	}
+}
 
 func TestDCBlockerRemovesBias(t *testing.T) {
 	const n = 4096


### PR DESCRIPTION
Follow-up to #447 on issue #402. The OP's latest retest (on the **original `mmr-s9.cfile`**) was decisive: #447's *correct* rail-tracking made decode **collapse to 0 FSW hits / no lock**, while the plain **fixed slicer is the best performer (10 FSW hits, 6/10 NID)**. Lining up every run on this site shows the trend — the lower the `+1/+3` threshold, the better the decode, and fixed (0.157) wins:

| build | `+1/+3` threshold | FSW hits | NID |
|---|---|---|---|
| **fixed slicer** | **0.157** | **10** | **6/10** |
| #439 (under-track) | ~0.185 | 4 | 2/4 |
| #447 (correct track) | ~0.237 | 0 | 0 |
| #432 (runaway) | ~0.265 | 3 | 2/3 |

The `+3` eye is closed/distorted (its outer population is spread *low*), so a threshold derived from the high `+3` centroid abandons the low `+3` symbols the outer-heavy FSW needs — the midpoint-of-centroids model is wrong for this eye. And a full chain audit (`atan2` FM discriminator, even-symmetric sinc matched filter, scalar mean|x| AGC, symmetric AFC/slicer) proves the RX path is symmetric, so **the asymmetry is RF-domain** — most likely uncorrected RTL-SDR I/Q imbalance, which is worst at the on-channel DC the DDC sits on and cleanly explains the p25_survey-clean / GopherTrunk-skewed differential on the same hardware.

## Part 1 — fixed slicer by default; improved adaptive behind a flag

- **Gate the adaptive slicer off by default** (`bc301ff`), mirroring the #430 DDA precedent: new `Options.EnableAdaptiveC4FMSlicer` (default false) + `replay -adaptive-slicer`. Production pipelines (ccdecoder, widebandt2) leave it unset, so they revert to the fixed slicer — restoring the 6/10 baseline.
- **Improve the adaptive slicer when enabled** (`1f12232`):
  - *Inward-only cap* — tighten the outer-threshold cap from `2·s/3` to `s/3` so the `+1/+3` boundary can move toward zero freely (compressed / DC-shifted eyes) but can never rise above the fixed nominal (~0.157). On the #402 capture every threshold above fixed decoded worse, so this keeps it no worse than fixed.
  - *Variance-aware boundary* — track a per-rail responsibility-weighted variance and place each boundary at the equal-σ-distance point (toward the tighter rail). When an outer rail is spread (the #402 `+3` spreads low) the boundary moves toward the tight inner rail, recovering more outer symbols (the FSW-relevant `+3` retention). Inner-rail σ is clamped tighter so an overlapping outer tail can't inflate it and cancel the effect.
  - *Per-second threshold diagnostic* — `AdaptiveC4FMSlicer.Thresholds()` + `receiver.SlicerThresholds()`; the replay state log now prints `slicer_thresholds` beside `slicer_levels` (the OP explicitly asked to see the decision boundaries, not just the levels).

## Part 2 — I/Q-imbalance investigation (`eee7be5`)

- **Diagnostics** (zero-risk): `IQImbalanceStats` derives gain/phase imbalance + image-rejection from the raw-IQ second-order moments; `replay -diag` now reports the raw I/Q imbalance and a per-rail soft distribution (centroid + std + p10/50/90), so a spread-low `+3` is distinguishable from a tight high cluster.
- **Correction** (candidate RF fix, opt-in, default off): `IQImbalanceCorrector` blindly estimates the imbalance from the raw input moments (no feedback loop) and applies the in-tree `IQBalancer` in place, after a warmup. Wired into the raw-IQ path before decimation: `replay -iq-correct`, and for the daemon `ccdecoder.Options.IQCorrect` ← config `DeviceConfig.iq_correct` (applied in `Decoder.pump`).

## Testing

- New unit tests: the I/Q estimator recovers an injected gain+phase imbalance; the corrector drives residual I/Q correlation and gain imbalance ≥4× toward zero and lifts image rejection past 35 dB (synthetic: 19 → 45 dB); a balanced stream passes through untouched. Slicer tests reworked for the inward-cap + variance-aware model (spread-eye `+3`-retention win; equal-variance stretched eye "no worse than fixed"); determinism / clean-eye / degenerate / reset stay green.
- `go build ./...`, `go vet`, and the touched-package test suites all pass; `replay -iq-correct -diag` smoke-tested end-to-end on a synthetic capture with a known injected imbalance.

## Validation / caveats

- The I/Q correction is a **candidate** fix that can't be validated without the capture, so it's opt-in and the diagnostics are there to confirm the hypothesis first. Next step: the OP A/Bs `mmr-s9.cfile` with `replay -iq-correct -diag` and shares the imbalance figures + decode summary.
- The variance-aware slicer boundary remains heuristic and flag-gated (off by default); if I/Q correction symmetrizes the eye, the fixed slicer should suffice and the adaptive path stays experimental.

https://claude.ai/code/session_01JHEdw6e57j4VReaQDc1VEq

---
_Generated by [Claude Code](https://claude.ai/code/session_01JHEdw6e57j4VReaQDc1VEq)_