### PR TITLE
replay/diag: FSW-keyed true-symbol outer-rail eye to localize the #402 spread

### DIFF
--- a/cmd/gophertrunk/iqdiag.go
+++ b/cmd/gophertrunk/iqdiag.go
@@ -82,6 +82,127 @@ func distStats(v []float64) (mean, std, p10, p50, p90 float64) {
 	return mean, std, pct(0.10), pct(0.50), pct(0.90)
 }
 
+// printTrueSymbolEye measures the TRUE outer-rail eye from the FSW hits and
+// localizes the mechanism of the #402 outer-rail spread.
+//
+// Every symbol of the P25 frame-sync word is an outer (±3) symbol and is
+// known, so at each FSW hit the 24 aligned soft samples are attributed to
+// their *known* symbol regardless of how the slicer decided them — an
+// uncontaminated outer-rail distribution (the per-decided-symbol block above
+// conflates true spread with slicer misclassification). Each sample is then
+// split by transition context: whether its true symbol equals the previous
+// FSW symbol (steady) or is a ±6 swing (post-transition). The comparison
+// names the cause:
+//
+//   - post-transition std ≫ steady std → ISI / symbol-timing (steep
+//     transitions are where off-centre sampling and channel ISI bite),
+//   - roughly equal, symmetric → amplitude-intrinsic (FM clicks / SNR, or a
+//     TX nonlinearity) — not an ISI/equalizer fix,
+//   - post-transition skewed (mean ≫ median) → overshoot / ringing.
+//
+// winner is the rotation that aligns the demod's dibits to the canonical
+// FrameSyncWord; the expected natural-frame symbol therefore un-rotates it.
+// Hits with up to `tolerance` mis-sliced dibits are included on purpose —
+// those mis-sliced outer symbols are exactly the heavy-tail outliers we want
+// to see.
+func (d *iqDiag) printTrueSymbolEye(w io.Writer, winner int, positions []int) {
+	all, steady, trans, ok := d.trueSymbolEye(winner, positions)
+	if !ok {
+		return
+	}
+
+	labels := [2]string{"+3", "-3"}
+	fmt.Fprintf(w, "diag: true-symbol outer-rail eye (from %d FSW hits; symbols known, slicer-independent):\n", len(positions))
+	var skew [2]float64
+	for b := 0; b < 2; b++ {
+		mean, std, p10, p50, p90 := distStats(all[b])
+		skew[b] = mean - p50
+		fmt.Fprintf(w, "diag:   true %s: n=%d  mean=%+.4f  std=%.4f  p10/50/90=%+.4f/%+.4f/%+.4f  skew(mean−median)=%+.4f\n",
+			labels[b], len(all[b]), mean, std, p10, p50, p90, skew[b])
+	}
+	var ratio [2]float64
+	for b := 0; b < 2; b++ {
+		_, ss, _, _, _ := distStats(steady[b])
+		_, ts, _, _, _ := distStats(trans[b])
+		ratio[b] = ratioOrInf(ts, ss)
+		fmt.Fprintf(w, "diag:   %s spread: steady std=%.4f (n=%d)  post-transition std=%.4f (n=%d)  ratio=%.2f\n",
+			labels[b], ss, len(steady[b]), ts, len(trans[b]), ratio[b])
+	}
+
+	// Advisory verdict. Thresholds are coarse — the numbers above are the
+	// evidence; this just points at the next move.
+	maxRatio := ratio[0]
+	if ratio[1] > maxRatio {
+		maxRatio = ratio[1]
+	}
+	maxSkew := skew[0]
+	if math.Abs(skew[1]) > math.Abs(maxSkew) {
+		maxSkew = skew[1]
+	}
+	switch {
+	case maxRatio >= 1.5:
+		fmt.Fprintln(w, "diag:   → outer spread is transition-driven (post-transition ≫ steady): ISI / symbol-timing — chase the Mueller-Müller clock or an equalizer.")
+	case math.Abs(maxSkew) >= 0.05:
+		fmt.Fprintln(w, "diag:   → outer spread is skewed but transition-independent: overshoot / TX nonlinearity — not a timing/ISI fix.")
+	default:
+		fmt.Fprintln(w, "diag:   → outer spread is symmetric and transition-independent: amplitude-intrinsic (FM clicks / SNR) — not fixable in the symbol domain.")
+	}
+}
+
+// trueSymbolEye attributes the soft samples at each FSW hit to their known
+// outer symbol (+3 → bucket 0, −3 → bucket 1), overall and split by transition
+// context (steady = true symbol equals the previous FSW symbol; trans = a ±6
+// swing). Returns ok=false when the soft/dibit buffers aren't aligned or there
+// are no hits. Factored out of printTrueSymbolEye for testing.
+func (d *iqDiag) trueSymbolEye(winner int, positions []int) (all, steady, trans [2][]float64, ok bool) {
+	if len(d.soft) != len(d.dibits) || len(positions) == 0 {
+		return all, steady, trans, false
+	}
+	const fswLen = 24
+	dibitToSymbol := [4]int8{1, 3, -1, -3} // dibit 0,1,2,3 → +1,+3,-1,-3
+	// expected[kk] is the natural-frame symbol of FSW position kk: undo the
+	// winning rotation applied to the demod's dibits.
+	var expected [fswLen]int8
+	for kk := 0; kk < fswLen; kk++ {
+		nd := (p25phase1.FrameSyncWord[kk] + 4 - uint8(winner&3)) & 3
+		expected[kk] = dibitToSymbol[nd]
+	}
+	bucket := func(sym int8) int { // outer +3 → 0, outer −3 → 1
+		if sym > 0 {
+			return 0
+		}
+		return 1
+	}
+	for _, pos := range positions {
+		if pos < 0 || pos+fswLen > len(d.soft) {
+			continue
+		}
+		for kk := 0; kk < fswLen; kk++ {
+			b := bucket(expected[kk])
+			v := float64(d.soft[pos+kk])
+			all[b] = append(all[b], v)
+			if kk > 0 {
+				// Transition is rotation-invariant, so compare canonical FSW.
+				if p25phase1.FrameSyncWord[kk] == p25phase1.FrameSyncWord[kk-1] {
+					steady[b] = append(steady[b], v)
+				} else {
+					trans[b] = append(trans[b], v)
+				}
+			}
+		}
+	}
+	return all, steady, trans, true
+}
+
+// ratioOrInf returns a/b, or 0 when b≈0 (avoids a divide-by-zero in the
+// transition-spread comparison when one group is empty).
+func ratioOrInf(a, b float64) float64 {
+	if b < 1e-9 {
+		return 0
+	}
+	return a / b
+}
+
 // observe appends a chunk of dibits to the rolling buffer the EOF
 // report walks. Called from the DibitSink in replay.go when -diag
 // is set.
@@ -368,6 +489,11 @@ func (d *iqDiag) printReport(w io.Writer) {
 			fmt.Fprintf(w, "diag: inter-hit dibit-deltas: min=%d  median=%d  max=%d  modal=%d  (P25 TSBK frame ≈ 163 on-air dibits, LDU ≈ 864)\n",
 				deltas[0], deltas[len(deltas)/2], deltas[len(deltas)-1], modal)
 		}
+
+		// True-symbol outer-rail eye: the FSW symbols are all known (and all
+		// outer), so this measures the real outer-rail spread free of slicer
+		// misclassification, and localizes its mechanism (issue #402).
+		d.printTrueSymbolEye(w, winner, positions)
 
 		// For each of the first few perfect-distance FSW hits, dump
 		// the FSW + next 32 dibits raw AND run them through the

--- a/cmd/gophertrunk/iqdiag_test.go
+++ b/cmd/gophertrunk/iqdiag_test.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"bytes"
+	"math/rand"
+	"strings"
+	"testing"
+
+	p25phase1 "github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase1"
+)
+
+// buildFSWStream plants `hits` canonical frame-sync words (rotation 0) into a
+// dibit stream with random filler between them, and an index-aligned soft
+// stream where each FSW outer symbol is drawn from its nominal level (+3 →
+// +0.37, −3 → −0.24) plus Gaussian noise. Post-transition FSW positions (where
+// the symbol differs from the previous) use transNoise; steady positions use
+// baseNoise — so the diagnostic can be checked against a known mechanism.
+func buildFSWStream(rng *rand.Rand, hits int, baseNoise, transNoise float64) (d iqDiag, positions []int) {
+	for h := 0; h < hits; h++ {
+		positions = append(positions, len(d.dibits))
+		for kk := 0; kk < 24; kk++ {
+			d.dibits = append(d.dibits, p25phase1.FrameSyncWord[kk])
+			level := 0.37
+			if p25phase1.FrameSyncWord[kk] == 3 { // dibit 3 → −3
+				level = -0.24
+			}
+			noise := baseNoise
+			if kk > 0 && p25phase1.FrameSyncWord[kk] != p25phase1.FrameSyncWord[kk-1] {
+				noise = transNoise
+			}
+			d.soft = append(d.soft, float32(level+rng.NormFloat64()*noise))
+		}
+		for f := 0; f < 50; f++ { // filler
+			d.dibits = append(d.dibits, uint8(rng.Intn(4)))
+			d.soft = append(d.soft, float32(rng.NormFloat64()*0.1))
+		}
+	}
+	return d, positions
+}
+
+func stdOf(v []float64) float64 { _, s, _, _, _ := distStats(v); return s }
+
+func TestTrueSymbolEyeFlagsTransitionDrivenSpread(t *testing.T) {
+	rng := rand.New(rand.NewSource(1))
+	// ISI / timing signature: only the post-transition positions are noisy.
+	d, positions := buildFSWStream(rng, 60, 0.03, 0.22)
+
+	_, steady, trans, ok := d.trueSymbolEye(0, positions)
+	if !ok {
+		t.Fatal("trueSymbolEye returned ok=false on a well-formed stream")
+	}
+	for b, label := range []string{"+3", "-3"} {
+		ss, ts := stdOf(steady[b]), stdOf(trans[b])
+		t.Logf("%s: steady std=%.4f  post-transition std=%.4f  ratio=%.2f", label, ss, ts, ratioOrInf(ts, ss))
+		if ratioOrInf(ts, ss) < 1.5 {
+			t.Errorf("%s: post-transition std=%.4f not ≥1.5× steady std=%.4f — transition signature missed", label, ts, ss)
+		}
+	}
+
+	var buf bytes.Buffer
+	d.printTrueSymbolEye(&buf, 0, positions)
+	if !strings.Contains(buf.String(), "ISI / symbol-timing") {
+		t.Errorf("verdict did not flag ISI/timing; got:\n%s", buf.String())
+	}
+}
+
+func TestTrueSymbolEyeFlagsAmplitudeIntrinsicSpread(t *testing.T) {
+	rng := rand.New(rand.NewSource(2))
+	// Amplitude-intrinsic signature: uniform noise on all outer symbols,
+	// symmetric (no skew), independent of transitions.
+	d, positions := buildFSWStream(rng, 60, 0.15, 0.15)
+
+	_, steady, trans, ok := d.trueSymbolEye(0, positions)
+	if !ok {
+		t.Fatal("trueSymbolEye returned ok=false")
+	}
+	for b, label := range []string{"+3", "-3"} {
+		ss, ts := stdOf(steady[b]), stdOf(trans[b])
+		t.Logf("%s: steady std=%.4f  post-transition std=%.4f  ratio=%.2f", label, ss, ts, ratioOrInf(ts, ss))
+		if r := ratioOrInf(ts, ss); r > 1.4 {
+			t.Errorf("%s: transition ratio=%.2f too high for uniform-noise eye (should be ~1)", label, r)
+		}
+	}
+
+	var buf bytes.Buffer
+	d.printTrueSymbolEye(&buf, 0, positions)
+	if !strings.Contains(buf.String(), "amplitude-intrinsic") {
+		t.Errorf("verdict did not flag amplitude-intrinsic; got:\n%s", buf.String())
+	}
+}
+
+func TestTrueSymbolEyeRecoversKnownLevels(t *testing.T) {
+	rng := rand.New(rand.NewSource(3))
+	d, positions := buildFSWStream(rng, 60, 0.05, 0.05)
+	all, _, _, ok := d.trueSymbolEye(0, positions)
+	if !ok {
+		t.Fatal("ok=false")
+	}
+	mP, _, _, _, _ := distStats(all[0]) // +3
+	mN, _, _, _, _ := distStats(all[1]) // −3
+	if mP < 0.34 || mP > 0.40 {
+		t.Errorf("true +3 mean=%.4f, want ≈0.37", mP)
+	}
+	if mN < -0.27 || mN > -0.21 {
+		t.Errorf("true −3 mean=%.4f, want ≈-0.24", mN)
+	}
+}


### PR DESCRIPTION
Follow-up to #450 on issue #402. The OP's `-iq-correct` A/B **ruled out I/Q imbalance** (front-end measures **73.7 dB image rejection** — gain +0.003 dB, phase +0.008°; correction gives statistically identical decode), and a matched-filter audit confirmed the C4FM RX chain is **provably zero-ISI** (TX raised-cosine + inverse-sinc × RX sinc cascades to a plain raised-cosine, `TestP25C4FMCascadeISIFree`). So the investigation has now eliminated the entire DSP chain (I/Q, matched filter, AFC, slicer) — the residual distortion is in the received signal.

Decode is actually in a good place now (with the fixed-slicer default restored in #450: **85.7% NID, 14 FSW hits**); the limiter is **TSBK CRC failures (4/12)**. The per-rail soft distribution shows clean tight inner rails (std 0.043) but **outer rails ~6× wider with heavy tails** (+3 std 0.347, p90 0.650, mean 0.367 > median 0.283 → right-skewed). But the existing per-rail block groups samples by the *slicer's decision*, which conflates true spread with misclassification, and the **mechanism** of the spread was undetermined — and each candidate needs a different fix:

- symbol-timing jitter (off-centre sampling spreads steep outer transitions),
- channel multipath ISI (→ equalizer),
- TX overshoot / PA nonlinearity (→ not a linear-DSP fix),
- FM click noise (→ SNR-limited).

## This change — an FSW-keyed true-symbol outer-rail eye diagnostic

Every symbol of the P25 frame-sync word is a **known outer (±3) symbol**, so at each FSW hit the 24 index-aligned soft samples are attributed to their *known* symbol regardless of how the slicer decided them — an uncontaminated outer-rail distribution. Samples are then split by **transition context** (true symbol equals the previous FSW symbol = steady, vs a ±6 swing = post-transition), which names the cause:

- post-transition std ≫ steady std → **ISI / symbol-timing**
- roughly equal, symmetric → **amplitude-intrinsic** (FM clicks / TX nonlinearity)
- skewed (mean ≫ median) → **overshoot / ringing**

`replay -diag` now prints the true +3/−3 distribution (mean / std / p10·p50·p90 / skew), the steady-vs-post-transition std ratio per rail, and an advisory verdict pointing at the next move. The change is **additive only** — no decode-path change — and reuses the existing FSW-hit scan, the index-aligned soft/dibit buffers, and `distStats`.

## Testing

`iqdiag_test.go` plants synthetic FSW streams and checks the diagnostic against known mechanisms:
- transition-driven noise → flags ISI/symbol-timing (observed std ratio ~7.5),
- uniform noise → flags amplitude-intrinsic (ratio ~1),
- recovers the planted true +3/−3 levels.

`go build ./...`, `go vet`, and `go test ./cmd/gophertrunk/` all pass.

## Next

The decisive validation is the OP re-running `replay -in mmr-s9.cfile -diag` and pasting the new `true-symbol outer-rail eye` block. It disambiguates the next move: a large post-transition/steady ratio points at the Mueller-Müller clock or an equalizer; a flat ratio with +3 skew points at an RF-domain limit (TX overshoot / clicks) rather than more DSP. This keeps the next round a targeted fix rather than a guess — the same diagnose-first play that just cleanly ruled out I/Q imbalance.

https://claude.ai/code/session_01JHEdw6e57j4VReaQDc1VEq

---
_Generated by [Claude Code](https://claude.ai/code/session_01JHEdw6e57j4VReaQDc1VEq)_