### PR TITLE
sdr: SampleRateGetter so DSP anchors on the chip's actual rate

### DIFF
--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -847,18 +847,23 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 						break
 					}
 				}
+				// Anchor downstream DSP on the device's actual rate so
+				// quantization (RTL2832U fixed-point divisor, Airspy
+				// closest-rate index, R820T2 silent cap) doesn't
+				// produce off-rate audio.
+				ccActualRate := sdr.ActualSampleRate(controlEntry.Device, cfg.SDR.SampleRate)
 				d.ccDecoderOpts = ccdecoder.Options{
 					Bus:          d.bus,
 					Log:          log,
 					Tuner:        tuner,
 					IQ:           iqSrc,
 					Systems:      d.systems,
-					SampleRateHz: float64(cfg.SDR.SampleRate),
+					SampleRateHz: float64(ccActualRate),
 					Metrics:      iqObs,
 					IQCorrect:    iqCorrect,
 				}
 				d.controlSerial = controlEntry.Info.Serial
-				d.controlSampleRate = cfg.SDR.SampleRate
+				d.controlSampleRate = ccActualRate
 				dec, err := ccdecoder.New(d.ccDecoderOpts)
 				if err != nil {
 					return nil, fmt.Errorf("daemon: ccdecoder: %w", err)
@@ -928,7 +933,10 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 				DeviceSerial: convEntry.Info.Serial,
 				SystemName:   "scanner",
 				Channels:     channels,
-				SampleRateHz: float64(cfg.SDR.SampleRate),
+				// Anchor the FM demod chain on the chip's actual rate
+				// — otherwise R820T2's silent cap at ~2.4 MHz turns a
+				// 3 MHz request into off-rate audio (1.25× speed-up).
+				SampleRateHz: float64(sdr.ActualSampleRate(convEntry.Device, cfg.SDR.SampleRate)),
 			})
 			if err != nil {
 				return nil, fmt.Errorf("daemon: conv scanner: %w", err)
@@ -972,11 +980,15 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 			if br := d.iqBrokers[entry.Info.Serial]; br != nil {
 				iqDev = br
 			}
+			// Anchor the polyphase channelizer on the device's actual
+			// rate so per-channel decimation ratios stay correct when
+			// the chip quantizes the requested rate.
+			wbActualRate := sdr.ActualSampleRate(entry.Device, cfg.SDR.SampleRate)
 			eng, err := widebandt2.New(widebandt2.Options{
 				Log:           log,
 				Bus:           d.bus,
 				Device:        iqDev,
-				SampleRateHz:  cfg.SDR.SampleRate,
+				SampleRateHz:  wbActualRate,
 				CenterFreqHz:  devCfg.CenterFreqHz,
 				TunerStrategy: devCfg.TunerStrategy,
 				Channels:      channels,
@@ -2210,12 +2222,17 @@ func (d *Daemon) buildVirtualVoiceTuners(cfg config.Config, log *slog.Logger) er
 				"serial", devCfg.Serial, "voice_taps", taps)
 			taps = 0
 		}
+		// Anchor the virtual voice DDC on the wideband dongle's actual
+		// rate (Airspy R2/Mini in particular silently rounds 2.4 MHz
+		// requests to 3 MHz via its closest-rate table), so the DDC
+		// decimation ratio matches what the chip is really streaming.
+		wbActualRate := sdr.ActualSampleRate(entry.Device, cfg.SDR.SampleRate)
 		for i := 0; i < taps; i++ {
 			vt, err := wbvoice.New(wbvoice.Options{
 				Serial:           fmt.Sprintf("wb:%s:tap-%d", entry.Info.Serial, i),
 				Broker:           br,
 				WidebandCenterHz: devCfg.CenterFreqHz,
-				SDRSampleRateHz:  cfg.SDR.SampleRate,
+				SDRSampleRateHz:  wbActualRate,
 				Log:              log,
 			})
 			if err != nil {

--- a/internal/sdr/airspy/airspy.go
+++ b/internal/sdr/airspy/airspy.go
@@ -199,6 +199,12 @@ type Device struct {
 	streaming     bool
 	sampleTypeSet bool     // true once SET_SAMPLE_TYPE has been issued
 	rates         []uint32 // supported sample rates, Hz, descending order
+	// sampleRate is the firmware-advertised rate the chip actually
+	// landed on after the most recent SetSampleRate (the rates[idx]
+	// the closest-match search chose). Exposed via the
+	// [sdr.SampleRateGetter] surface so downstream DSP anchors on
+	// the chip's truth rather than the operator's request.
+	sampleRate uint32
 }
 
 // Info implements sdr.Device.
@@ -221,7 +227,29 @@ func (d *Device) SetSampleRate(hz uint32) error {
 		return usb.ErrClosed
 	}
 	idx := d.closestRateIndex(hz)
-	return d.t.ControlOut(reqSetSamplerate, uint16(idx), 0, nil, controlTimeoutMs)
+	if err := d.t.ControlOut(reqSetSamplerate, uint16(idx), 0, nil, controlTimeoutMs); err != nil {
+		return err
+	}
+	d.mu.Lock()
+	if idx >= 0 && idx < len(d.rates) {
+		d.sampleRate = d.rates[idx]
+	} else {
+		// Table absent or empty — fall back to the requested rate so
+		// SampleRate at least surfaces what the operator asked for.
+		d.sampleRate = hz
+	}
+	d.mu.Unlock()
+	return nil
+}
+
+// SampleRate returns the actual rate the firmware landed on at the
+// most recent SetSampleRate — the entry from the supported-rate
+// table that closest-match picked. Zero before the first
+// SetSampleRate. Implements [sdr.SampleRateGetter].
+func (d *Device) SampleRate() uint32 {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.sampleRate
 }
 
 // closestRateIndex returns the index of the supported sample rate

--- a/internal/sdr/airspyhf/airspyhf.go
+++ b/internal/sdr/airspyhf/airspyhf.go
@@ -214,6 +214,11 @@ type Device struct {
 	closed    bool
 	streaming bool
 	rates     []uint32 // supported sample rates, Hz
+	// sampleRate is the firmware-advertised rate the chip actually
+	// landed on after the most recent SetSampleRate. Exposed via the
+	// [sdr.SampleRateGetter] surface so downstream DSP anchors on
+	// the chip's truth rather than the operator's request.
+	sampleRate uint32
 }
 
 // Info implements sdr.Device.
@@ -241,7 +246,26 @@ func (d *Device) SetSampleRate(hz uint32) error {
 		return usb.ErrClosed
 	}
 	idx := d.closestRateIndex(hz)
-	return d.t.ControlOut(reqSetSamplerate, uint16(idx), 0, nil, controlTimeoutMs)
+	if err := d.t.ControlOut(reqSetSamplerate, uint16(idx), 0, nil, controlTimeoutMs); err != nil {
+		return err
+	}
+	d.mu.Lock()
+	if idx >= 0 && idx < len(d.rates) {
+		d.sampleRate = d.rates[idx]
+	} else {
+		d.sampleRate = hz
+	}
+	d.mu.Unlock()
+	return nil
+}
+
+// SampleRate returns the actual rate the firmware landed on at the
+// most recent SetSampleRate. Zero before the first SetSampleRate.
+// Implements [sdr.SampleRateGetter].
+func (d *Device) SampleRate() uint32 {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.sampleRate
 }
 
 func (d *Device) closestRateIndex(hz uint32) int {

--- a/internal/sdr/baseband/driver.go
+++ b/internal/sdr/baseband/driver.go
@@ -124,6 +124,17 @@ func (d *replayDevice) SetSampleRate(hz uint32) error {
 	return nil
 }
 
+// SampleRate returns the metering rate the replay is producing IQ
+// at. Implements [sdr.SampleRateGetter] so downstream DSP that
+// queries the device for its actual rate gets the truth — the
+// recording's native wavRate when SetSampleRate was never called,
+// or the override last passed to SetSampleRate.
+func (d *replayDevice) SampleRate() uint32 {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.rate
+}
+
 // StreamIQ replays the recording, metered to the configured rate, and
 // loops on EOF when Loop is set.
 func (d *replayDevice) StreamIQ(ctx context.Context) (<-chan []complex64, error) {

--- a/internal/sdr/device.go
+++ b/internal/sdr/device.go
@@ -75,6 +75,39 @@ type Device interface {
 	Close() error
 }
 
+// SampleRateGetter is an optional interface a Device may implement to
+// surface the rate the underlying hardware actually settled on after
+// SetSampleRate. The Device contract's SetSampleRate returns only an
+// error; backends like rtlsdr's RTL2832U resampler quantize to their
+// fixed-point divisor, and the R820T2 silently caps requests over
+// ~2.4 MHz, so the rate the driver acknowledged and the rate the chip
+// is streaming at can differ. Downstream DSP (the conventional FM
+// demod, the wideband channelizer, the CC decoder) must work against
+// the truth — otherwise resampler ratios are off by a small constant
+// and audio plays back at the wrong speed.
+//
+// Implementations should return 0 to signal "I don't know" (the
+// helper [ActualSampleRate] then falls back to the operator-supplied
+// requested rate).
+type SampleRateGetter interface {
+	SampleRate() uint32
+}
+
+// ActualSampleRate returns the device's reported sample rate when the
+// device implements [SampleRateGetter] and reports a non-zero value;
+// otherwise it falls back to requested. Use this everywhere the
+// daemon plumbs cfg.SDR.SampleRate into DSP options — the demod
+// chain, the channelizer, the CC decoder — so chains stay anchored
+// to the chip's truth rather than the operator's wish.
+func ActualSampleRate(dev Device, requested uint32) uint32 {
+	if rg, ok := dev.(SampleRateGetter); ok {
+		if got := rg.SampleRate(); got > 0 {
+			return got
+		}
+	}
+	return requested
+}
+
 // Driver is the factory each backend exposes.
 type Driver interface {
 	Name() string

--- a/internal/sdr/hackrf/hackrf.go
+++ b/internal/sdr/hackrf/hackrf.go
@@ -323,6 +323,16 @@ func (d *Device) SetSampleRate(hz uint32) error {
 	return nil
 }
 
+// SampleRate returns the rate the baseband sampler was last
+// programmed to. HackRF uses a numerator/divider of (hz, 1) so the
+// hardware streams exactly at the value last passed to
+// SetSampleRate. Implements [sdr.SampleRateGetter].
+func (d *Device) SampleRate() uint32 {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.sampleRate
+}
+
 // SetGain accepts a single tenth-dB target and distributes it across
 // the HackRF's three gain stages (RF amp on/off, LNA 0–40 dB in 8 dB
 // steps, VGA 0–62 dB in 2 dB steps). A negative value selects a

--- a/internal/sdr/rtlsdr/purego/device.go
+++ b/internal/sdr/rtlsdr/purego/device.go
@@ -38,6 +38,15 @@ type Device struct {
 	// override for boards with a different pinout.
 	biasTeeGPIO uint8
 
+	// sampleRate is the actual rate the demod settled on at the most
+	// recent SetSampleRate, exposed through [sdr.SampleRateGetter] so
+	// downstream DSP anchors on the truth. The RTL2832U demod
+	// resampler quantizes to its 28.4 fixed-point divisor (typically
+	// within 1 Hz of requested) and the R820T2 silently caps rates
+	// above ~2.4 MHz, so the value here can differ meaningfully from
+	// what the operator asked for.
+	sampleRate atomic.Uint32
+
 	streamMu sync.Mutex
 	out      chan []complex64
 	stopOnce sync.Once
@@ -66,10 +75,10 @@ func (d *Device) SetCenterFreq(hz uint32) error {
 }
 
 // SetSampleRate programs the demod resampler and the tuner's IF
-// filter to match. Returns the actual rate the chip can produce
-// (the demod quantizes to its 28.4 fixed-point divisor); callers
-// that need the exact value can read it back via [Demod.GetSampleRate]
-// — but the [sdr.Device] contract returns just the error.
+// filter to match. The demod quantizes to its 28.4 fixed-point
+// divisor; the actual landed rate is cached on the device and
+// reachable via [Device.SampleRate] (the [sdr.SampleRateGetter]
+// surface) so downstream DSP can anchor on the truth.
 func (d *Device) SetSampleRate(hz uint32) error {
 	if d.closed.Load() {
 		return ErrClosed
@@ -81,8 +90,15 @@ func (d *Device) SetSampleRate(hz uint32) error {
 	if err := d.tuner.SetBandwidth(actual); err != nil {
 		return fmt.Errorf("rtlsdr: tuner bandwidth: %w", err)
 	}
+	d.sampleRate.Store(actual)
 	return nil
 }
+
+// SampleRate returns the rate the demod resampler is actually
+// running at — the value [Demod.SetSampleRate] last reported back.
+// Zero before the first [SetSampleRate] call. Implements
+// [sdr.SampleRateGetter].
+func (d *Device) SampleRate() uint32 { return d.sampleRate.Load() }
 
 // SetGain takes the [sdr.Device] convention: tenthDB < 0 selects AGC,
 // tenthDB ≥ 0 switches to manual mode and applies the closest

--- a/internal/sdr/rtltcp/driver.go
+++ b/internal/sdr/rtltcp/driver.go
@@ -204,12 +204,35 @@ type device struct {
 	mu     sync.Mutex
 	conn   net.Conn
 	closed bool
+	// sampleRate is the last value passed to SetSampleRate, exposed
+	// via [sdr.SampleRateGetter]. The librtlsdr rtl_tcp wire
+	// protocol has no reply field for SET_SAMPLE_RATE, so the rate
+	// the remote chip actually landed on isn't observable from this
+	// side — returning the requested value still lets the daemon
+	// honour a per-tuner rate override.
+	sampleRate uint32
 }
 
 func (d *device) Info() sdr.Info { return d.info }
 
 func (d *device) SetCenterFreq(hz uint32) error { return d.sendCmd(cmdSetFreq, hz) }
-func (d *device) SetSampleRate(hz uint32) error { return d.sendCmd(cmdSetSampleRate, hz) }
+func (d *device) SetSampleRate(hz uint32) error {
+	if err := d.sendCmd(cmdSetSampleRate, hz); err != nil {
+		return err
+	}
+	d.mu.Lock()
+	d.sampleRate = hz
+	d.mu.Unlock()
+	return nil
+}
+
+// SampleRate returns the rate last passed to SetSampleRate.
+// Implements [sdr.SampleRateGetter].
+func (d *device) SampleRate() uint32 {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.sampleRate
+}
 
 func (d *device) SetGain(tenthDB int) error {
 	if tenthDB < 0 {


### PR DESCRIPTION
## Summary

`sdr.Device.SetSampleRate(hz) error` discards the rate the chip actually
settled on. Every driver quantizes differently — rtl2832u's 28.4
fixed-point divisor truncation, Airspy R2/Mini/HF+'s closest-rate
table index, R820T2's silent cap above ~2.4 MHz — and downstream DSP
that anchored on `cfg.SDR.SampleRate` therefore ran the wrong
decimation ratio whenever the request and the chip's truth diverged.

Two real-world consequences seen on a Pi 4 (Debian trixie, aarch64):

- **Conventional FM demod produced off-rate audio.** At
  `cfg.SDR.SampleRate=3_000_000` the Pi-4 CPU couldn't drain the
  rtl_purego stream at line rate; the `default:` branch in
  `(*Device).deliver` silently dropped samples to keep up; the demod
  chain still assumed 3 MHz input and resampled accordingly; the
  result was audio produced at ~6.4 kHz written into an 8 kHz WAV
  header — playback at **1.25× speed (Donald Duck)**.
- **widebandt2 channelizer was silently off by 25 % on Airspy
  R2/Mini.** The closest-rate table only carries 3 / 6 / 10 MSPS;
  an operator config of `2_400_000` rounds to 3 MHz on the chip,
  but the channelizer was running 2.4 MHz decimation math against
  3 MHz IQ. DMR Tier II decoded "fine" (it's tolerant), so the bug
  was latent.

## Approach

Tiny optional interface, no breaking change:

```go
type SampleRateGetter interface {
    SampleRate() uint32  // 0 = "I don't know"
}

func ActualSampleRate(dev Device, requested uint32) uint32
```

Drivers that know their actual rate implement it; everyone else
(mocks, tests) is unaffected. The helper falls back to `requested`
when the device doesn't expose the value, so nothing breaks.

## Implementations

| Driver | What it stores | Mechanism |
|---|---|---|
| `rtlsdr/purego` | demod-reported `actualHz` | `atomic.Uint32.Store` after `demod.SetSampleRate` returns |
| `airspy`, `airspyhf` | `rates[idx]` the closest-match search chose | under existing struct mutex |
| `hackrf` | already-tracked `d.sampleRate` (1:1 numerator/divider) | trivial accessor |
| `rtltcp` | last value passed to `SetSampleRate` | the wire protocol has no reply field for SET_SAMPLE_RATE — best-effort signal |
| `baseband` replay | WAV's metering rate (or `SetSampleRate` override) | trivial accessor |

## Daemon wiring (4 call sites)

`ccdecoder.Options.SampleRateHz`, `conventional.Options.SampleRateHz`,
`widebandt2.Options.SampleRateHz`, and `wbvoice.Options.SDRSampleRateHz`
now all go through `sdr.ActualSampleRate(entry.Device, cfg.SDR.SampleRate)`.

## Verification

End-to-end on a Pi 4 with an RTL-SDR (RTL2838 + R820T2) tuned to a
local NFM repeater:

- Before fix: WAV duration / real-time = **0.80** (1.25× speed-up)
- After fix:  WAV duration / real-time = **0.9994** on a 16-minute capture (sub-0.1 % clock skew)

`go build ./cmd/gophertrunk` clean; targeted tests pass:
`go test ./internal/sdr/...` and `./internal/config/...` all green.

## Non-goals

- This **does not** fix the underlying overrun-drop in `rtlsdr/purego/stream.go`
  that surfaces above ~2.4 MS/s on weaker hosts. That's a separate
  CPU-bound concern (widen the stream channel buffer, or count drops
  and surface an "effective consumer rate" downstream) and not in scope
  here. The interface change is correct architecture either way.
- This does not refactor the `Device` interface or add `GetSampleRate`
  as a required method — adopting only what's needed keeps the change
  reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
