### PR TITLE
config+sdr: skip discovery of dongles listed in sdr.ignore_serials

### DIFF
--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -526,6 +526,12 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 			// alone — they may belong to another process on the
 			// host (issue #264).
 			Strict: len(cfg.SDR.Devices) > 0,
+			// IgnoreSerials is the denylist counterpart to Strict —
+			// used when the operator wants auto-discovery for
+			// everything except specific dongles reserved for
+			// another SDR app on the same host (OpenWebRX+,
+			// SDRangel, dump1090).
+			IgnoreSerials: cfg.SDR.IgnoreSerials,
 		}); err != nil {
 			log.Warn("daemon: SDR pool open failed", "err", err)
 			d.addWarning(fmt.Sprintf(

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -111,6 +111,17 @@ retention:
 
 sdr:
   sample_rate: 2_400_000
+  # ignore_serials: dongle serials the daemon should discover but skip.
+  # Use this to share a host with another SDR app (OpenWebRX+, SDRangel,
+  # dump1090) that needs exclusive USB access to a specific dongle: the
+  # device is still enumerated by the driver (so other libusb consumers
+  # can see it), but no gophertrunk subsystem opens or claims it. Match
+  # is exact and case-sensitive against the driver-reported serial —
+  # copy the value verbatim from `gophertrunk sdr list`'s SERIAL column.
+  # A serial may not appear in both ignore_serials and devices/rtl_tcp.
+  #
+  # ignore_serials:
+  #   - "AIRSPYHF SN:0123456789ABCDEF"   # reserved for OpenWebRX+
   # watchdog_interval_ms: periodic USB-disconnect watchdog cadence
   # (default 30000 = 30 s). Catches dongles that vanish from the bus
   # while idle and re-acquires them by serial on reappear so the next

--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -87,6 +87,38 @@ sdr:
 > on every device (`sdr: gain set ... gain_db=...`). A decimal form like
 > `"32.0"` is taken as whole dB, so that works too.
 
+### Sharing a host with another SDR app — `sdr.ignore_serials`
+
+`sdr.devices[*].role` is the right knob for choosing **how**
+gophertrunk uses a dongle (control / voice / wideband). When you
+need to tell it not to use a dongle at all — because another app on
+the same host (OpenWebRX+ in a container, SDRangel, dump1090, …)
+needs exclusive USB access to it — list the serial under the
+top-level `sdr.ignore_serials`:
+
+```yaml
+sdr:
+  ignore_serials:
+    - "AIRSPYHF SN:0123456789ABCDEF"   # reserved for OpenWebRX+
+```
+
+Matching is exact and case-sensitive against the driver-reported
+serial — copy the value verbatim from the `SERIAL` column of
+`gophertrunk sdr list`. Matched dongles still appear in the
+driver's `Enumerate()` (so libusb consumers in other processes can
+find them) but never enter gophertrunk's pool, so no subsystem
+opens or claims them. A serial may not appear in both
+`ignore_serials` and `sdr.devices[*].serial` / `sdr.rtl_tcp[*].serial`
+— pick one. Entries that match no plugged dongle log
+`sdr: ignore_serials entry matched no discovered device` at startup
+so a typo or an unplugged device is visible.
+
+`ignore_serials` is the **denylist** counterpart to `Strict` mode:
+Strict (auto-engaged when `sdr.devices` is non-empty) treats
+`sdr.devices` as the *allowlist* — only the dongles named there are
+opened. Use `ignore_serials` instead when you want auto-discovery
+for most dongles and only want to opt-out a specific few.
+
 ### HackRF tested combinations
 
 | Device | PID | Coverage | Gain chain | Bias-tee | Notes |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -441,6 +441,19 @@ type SDRConfig struct {
 	// In-stream IQ-death recovery (ccdecoder retry loop, voice
 	// Bind reacquire) is unaffected by this knob.
 	WatchdogIntervalMs int `yaml:"watchdog_interval_ms"`
+	// IgnoreSerials lists dongle serials the daemon discovers but
+	// skips during pool construction. Use this to share a host
+	// with another SDR app (OpenWebRX+, SDRangel, dump1090) that
+	// needs exclusive USB access to a specific dongle: the device
+	// is enumerated by the driver — so it stays visible to other
+	// libusb consumers — but never enters the pool, so no
+	// gophertrunk subsystem opens or claims it. Matching is exact
+	// and case-sensitive against the driver-reported serial (the
+	// value `gophertrunk sdr list` prints in the SERIAL column);
+	// leading/trailing whitespace in YAML entries is trimmed. A
+	// serial may not appear in both Devices/RTLTCP and
+	// IgnoreSerials — pick one.
+	IgnoreSerials []string `yaml:"ignore_serials"`
 }
 
 // RTLTCPConfig describes one remote rtl_tcp endpoint to expose as
@@ -1030,6 +1043,30 @@ func (c Config) Validate() error {
 				i, r.Serial, prev)
 		}
 		seenSerials[r.Serial] = i
+	}
+	// Validate ignore_serials. Each entry must be non-empty (after
+	// trimming whitespace), unique within the list, and disjoint
+	// from any serial already pinned under sdr.devices or
+	// sdr.rtl_tcp — the operator must choose between "use this
+	// dongle with this role" and "leave this dongle entirely
+	// alone".
+	seenIgnored := make(map[string]int, len(c.SDR.IgnoreSerials))
+	for i, raw := range c.SDR.IgnoreSerials {
+		s := strings.TrimSpace(raw)
+		if s == "" {
+			return fmt.Errorf("sdr.ignore_serials[%d]: empty serial not allowed", i)
+		}
+		if prev, dup := seenIgnored[s]; dup {
+			return fmt.Errorf(
+				"sdr.ignore_serials[%d]: duplicate serial %q (also at sdr.ignore_serials[%d])",
+				i, s, prev)
+		}
+		if _, conflict := seenSerials[s]; conflict {
+			return fmt.Errorf(
+				"sdr.ignore_serials[%d]: serial %q is also configured under sdr.devices / sdr.rtl_tcp — pick one",
+				i, s)
+		}
+		seenIgnored[s] = i
 	}
 	if c.Trunking.CallTimeoutMs < 0 {
 		return fmt.Errorf("trunking.call_timeout_ms: %d ms must be ≥ 0", c.Trunking.CallTimeoutMs)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -80,6 +80,17 @@ func TestValidate(t *testing.T) {
 		{"duplicate sdr serial", Config{SDR: SDRConfig{Devices: []DeviceConfig{{Serial: "00000006", Role: "control"}, {Serial: "00000006", Role: "voice"}}}}, true},
 		{"distinct sdr serials ok", Config{SDR: SDRConfig{Devices: []DeviceConfig{{Serial: "00000001", Role: "control"}, {Serial: "00000002", Role: "voice"}}}}, false},
 		{"empty sdr serials ok", Config{SDR: SDRConfig{Devices: []DeviceConfig{{Role: "control"}, {Role: "voice"}}}}, false},
+		// sdr.ignore_serials: a top-level opt-out list for dongles
+		// the daemon should discover-but-skip, e.g. when an HF+ is
+		// reserved for OpenWebRX+ on the same host.
+		{"ignore_serials happy path", Config{SDR: SDRConfig{IgnoreSerials: []string{"AIRSPYHF SN:foo"}}}, false},
+		{"ignore_serials with trim ok", Config{SDR: SDRConfig{IgnoreSerials: []string{"  AIRSPYHF SN:foo  "}}}, false},
+		{"ignore_serials empty entry", Config{SDR: SDRConfig{IgnoreSerials: []string{""}}}, true},
+		{"ignore_serials whitespace entry", Config{SDR: SDRConfig{IgnoreSerials: []string{"   "}}}, true},
+		{"ignore_serials duplicate within list", Config{SDR: SDRConfig{IgnoreSerials: []string{"X", "X"}}}, true},
+		{"ignore_serials duplicate after trim", Config{SDR: SDRConfig{IgnoreSerials: []string{"X", "  X "}}}, true},
+		{"ignore_serials overlaps devices", Config{SDR: SDRConfig{Devices: []DeviceConfig{{Serial: "00000011", Role: "voice"}}, IgnoreSerials: []string{"00000011"}}}, true},
+		{"ignore_serials overlaps rtl_tcp", Config{SDR: SDRConfig{RTLTCP: []RTLTCPConfig{{Addr: "127.0.0.1:1234", Serial: "rtltcp-x", Role: "voice"}}, IgnoreSerials: []string{"rtltcp-x"}}}, true},
 		{"oversized key", Config{Trunking: TrunkingConfig{Systems: []SystemConfig{{Name: "x", Protocol: "dmr", EncryptionKeys: []EncryptionKeyConfig{{KeyID: 1, Algorithm: "rc4", Key: strings.Repeat("ab", 33)}}}}}}, true},
 		// p25_band_plan: the operator's escape hatch for sites that
 		// never broadcast IDEN_UP for some channel ID (issue #345).

--- a/internal/sdr/pool.go
+++ b/internal/sdr/pool.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 	"sync"
 
 	"github.com/MattCheramie/GopherTrunk/internal/events"
@@ -113,9 +114,10 @@ func (h Hint) WithGain(tenthDB int) Hint {
 const DefaultSampleRateHz uint32 = 2_048_000
 
 // PoolOpenOptions parameterises Pool.OpenWith. Use this when callers
-// need to engage strict mode; the historical Pool.Open(rate, hints)
-// signature still works and remains the default for code paths that
-// want today's open-everything behaviour.
+// need to engage strict mode or list serials the daemon should skip;
+// the historical Pool.Open(rate, hints) signature still works and
+// remains the default for code paths that want today's open-
+// everything behaviour.
 type PoolOpenOptions struct {
 	// SampleRateHz is the IQ rate to program on every opened device.
 	// Zero falls back to DefaultSampleRateHz.
@@ -131,12 +133,23 @@ type PoolOpenOptions struct {
 	// that they want only the devices they named, not whatever else
 	// happens to be on the USB bus.
 	Strict bool
+	// IgnoreSerials is a denylist: dongles whose driver-reported
+	// Serial matches an entry here are discovered (so they remain
+	// visible to other libusb consumers on the host) but never
+	// added to the pool, so no gophertrunk subsystem opens or
+	// claims them. Matching is exact and case-sensitive; entries
+	// are trimmed of whitespace before comparison. Complementary
+	// to Strict — Strict is "use only the dongles I named",
+	// IgnoreSerials is "use everything except the ones I named".
+	// Unmatched entries are logged at INFO so an operator with a
+	// typo or an unplugged dongle has visible feedback.
+	IgnoreSerials []string
 }
 
 // Open is a backwards-compatible shim over OpenWith. It preserves the
 // historical "open every enumerated device" behaviour; callers that
-// want allowlist semantics should construct PoolOpenOptions and call
-// OpenWith directly.
+// want allowlist or denylist semantics should construct
+// PoolOpenOptions and call OpenWith directly.
 func (p *Pool) Open(sampleRateHz uint32, hints []Hint) error {
 	return p.OpenWith(PoolOpenOptions{SampleRateHz: sampleRateHz, Hints: hints})
 }
@@ -157,6 +170,11 @@ func (p *Pool) Open(sampleRateHz uint32, hints []Hint) error {
 // device produce a WARN. Hints with empty serial are dropped at ingest
 // with a WARN — an empty-serial hint in strict mode is ambiguous (no
 // way to honour an allowlist entry that doesn't name anything).
+//
+// opts.IgnoreSerials filters discovered devices independently of
+// Strict / Hints: any device whose serial appears in IgnoreSerials is
+// skipped before role assignment, regardless of whether a Hint also
+// names it. Matching is exact and case-sensitive; entries are trimmed.
 //
 // Strict mode is how operators get "only the devices I listed in
 // config.yaml are touched"; rtl_tcp and baseband replay always
@@ -180,6 +198,15 @@ func (p *Pool) OpenWith(opts PoolOpenOptions) error {
 		rate = DefaultSampleRateHz
 	}
 
+	ignoreSet := make(map[string]bool, len(opts.IgnoreSerials))
+	for _, s := range opts.IgnoreSerials {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			continue
+		}
+		ignoreSet[s] = false // false = "configured but not yet seen"
+	}
+
 	type discovered struct {
 		drv  Driver
 		info Info
@@ -192,7 +219,19 @@ func (p *Pool) OpenWith(opts PoolOpenOptions) error {
 			continue
 		}
 		for _, info := range infos {
+			if _, skip := ignoreSet[info.Serial]; skip {
+				p.log.Info("sdr: ignoring device per config",
+					"driver", drv.Name(), "serial", info.Serial)
+				ignoreSet[info.Serial] = true // matched
+				continue
+			}
 			all = append(all, discovered{drv, info})
+		}
+	}
+	for s, matched := range ignoreSet {
+		if !matched {
+			p.log.Info("sdr: ignore_serials entry matched no discovered device",
+				"serial", s)
 		}
 	}
 	if len(all) == 0 {

--- a/internal/sdr/pool_test.go
+++ b/internal/sdr/pool_test.go
@@ -92,6 +92,101 @@ func TestPoolAssignsRoles(t *testing.T) {
 	}
 }
 
+// TestPoolIgnoresConfiguredSerials guards Pool.Open's ignoreSerials
+// filter: any device whose driver-reported Serial matches an entry in
+// the ignore list is discovered (so it stays visible to other libusb
+// consumers via the driver's Enumerate) but never added to the pool.
+// Unmatched entries (typo / unplugged dongle) log an info line so the
+// operator has visible feedback.
+func TestPoolIgnoresConfiguredSerials(t *testing.T) {
+	drv := &fakeDriver{name: "fake-ignore", infos: []Info{
+		{Driver: "fake-ignore", Index: 0, Serial: "AAA"},
+		{Driver: "fake-ignore", Index: 1, Serial: "BBB"},
+		{Driver: "fake-ignore", Index: 2, Serial: "CCC"},
+	}}
+	registryMu.Lock()
+	registry["fake-ignore"] = drv
+	registryMu.Unlock()
+	t.Cleanup(func() {
+		registryMu.Lock()
+		delete(registry, "fake-ignore")
+		registryMu.Unlock()
+	})
+
+	t.Run("skips matching serial", func(t *testing.T) {
+		var buf bytes.Buffer
+		log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+		p := NewPool(log)
+		if err := p.OpenWith(PoolOpenOptions{IgnoreSerials: []string{"BBB"}}); err != nil {
+			t.Fatal(err)
+		}
+		defer p.Close()
+
+		entries := p.Entries()
+		if len(entries) != 2 {
+			t.Fatalf("entries = %d, want 2 (BBB should be skipped)", len(entries))
+		}
+		for _, e := range entries {
+			if e.Info.Serial == "BBB" {
+				t.Errorf("BBB should not be in pool")
+			}
+		}
+		out := buf.String()
+		if !strings.Contains(out, "ignoring device per config") {
+			t.Errorf("expected ignore log line; got: %q", out)
+		}
+		if !strings.Contains(out, "BBB") {
+			t.Errorf("ignore log should mention the serial; got: %q", out)
+		}
+	})
+
+	t.Run("trims whitespace on entries", func(t *testing.T) {
+		p := NewPool(nil)
+		if err := p.OpenWith(PoolOpenOptions{IgnoreSerials: []string{"  AAA  "}}); err != nil {
+			t.Fatal(err)
+		}
+		defer p.Close()
+		for _, e := range p.Entries() {
+			if e.Info.Serial == "AAA" {
+				t.Errorf("AAA should have been skipped after whitespace trim")
+			}
+		}
+	})
+
+	t.Run("unmatched entry logs info but pool opens", func(t *testing.T) {
+		var buf bytes.Buffer
+		log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+		p := NewPool(log)
+		if err := p.OpenWith(PoolOpenOptions{IgnoreSerials: []string{"ZZZ"}}); err != nil {
+			t.Fatal(err)
+		}
+		defer p.Close()
+		if len(p.Entries()) != 3 {
+			t.Errorf("entries = %d, want 3 (ZZZ matches nothing)", len(p.Entries()))
+		}
+		out := buf.String()
+		if !strings.Contains(out, "ignore_serials entry matched no discovered device") {
+			t.Errorf("expected unmatched-entry log; got: %q", out)
+		}
+		if !strings.Contains(out, "ZZZ") {
+			t.Errorf("unmatched log should mention ZZZ; got: %q", out)
+		}
+	})
+
+	t.Run("empty and whitespace entries ignored", func(t *testing.T) {
+		p := NewPool(nil)
+		// OpenWith trims and drops empties — Validate already rejects
+		// these at config-load time, but the pool stays defensive.
+		if err := p.OpenWith(PoolOpenOptions{IgnoreSerials: []string{"", "   "}}); err != nil {
+			t.Fatal(err)
+		}
+		defer p.Close()
+		if len(p.Entries()) != 3 {
+			t.Errorf("entries = %d, want 3 (no effective ignore entries)", len(p.Entries()))
+		}
+	})
+}
+
 // TestPoolProgramsSampleRate guards against the bug behind issue #275:
 // without a SetSampleRate call at pool-open time the chip streams at
 // whatever rate its resampler powered up at, the decoder pipeline runs


### PR DESCRIPTION
## Summary

Adds an `IgnoreSerials []string` field to `sdr.PoolOpenOptions` and a
top-level YAML field `sdr.ignore_serials`. Dongles whose driver-
reported `Serial` matches an entry are discovered (so they remain
visible to other libusb consumers on the host) but never added to the
pool, so no gophertrunk subsystem opens or claims them.

## Why this, given `Strict` exists?

`Strict` (PR #441) is the **allowlist** counterpart — "use only the
dongles I named in `sdr.devices`". `ignore_serials` is the
**denylist** — "use everything discovered, except these few".
Different ergonomics for different setups.

Concrete trigger: a Pi 4 with an Airspy HF+ reserved for OpenWebRX+
running in a separate Docker container. The operator wants
gophertrunk to keep auto-discovering the Airspy R2 (wideband DMR)
and the RTL-SDR (voice scanner), but to leave the HF+ alone for
OpenWebRX+. With Strict you'd have to enumerate every other dongle
you want; with `ignore_serials` you name only the one you don't.

## Behaviour

```yaml
sdr:
  ignore_serials:
    - "AIRSPYHF SN:0123456789ABCDEF"   # reserved for OpenWebRX+
```

- Matching is exact and case-sensitive against the driver-reported
  `Serial` (the value in `gophertrunk sdr list`'s `SERIAL` column).
- Leading/trailing whitespace in YAML entries is trimmed.
- Empty / unset field = no behaviour change (additive).
- A serial may not appear in both `ignore_serials` and
  `sdr.devices[*].serial` / `sdr.rtl_tcp[*].serial` — `Validate()`
  rejects the overlap so the operator picks one.
- An ignore entry that matches no discovered device logs INFO
  `sdr: ignore_serials entry matched no discovered device` so a typo
  or an unplugged dongle is visible.

## Implementation

- `internal/config/config.go`: `SDRConfig.IgnoreSerials []string`,
  validated alongside the existing `seenSerials` cross-check.
- `internal/sdr/pool.go`: `PoolOpenOptions.IgnoreSerials []string`;
  filter inside `OpenWith`, before the per-device open loop.
- `cmd/gophertrunk/daemon.go`: one extra field on the
  `OpenWith(PoolOpenOptions{...})` call site.

`Pool.Open(rate, hints)` shim is **unchanged** — no test signature
churn outside the new test cases.

## Tests

- `internal/config/config_test.go`: 8 new `TestValidate` subtests
  (happy path, whitespace trim, empty / whitespace-only entries,
  intra-list dup, dup after trim, overlap with `Devices`, overlap
  with `RTLTCP`).
- `internal/sdr/pool_test.go`: `TestPoolIgnoresConfiguredSerials`
  with 4 subtests (matched skip, whitespace trim, unmatched entry
  logs INFO, empty / whitespace entries silently ignored).

## Verification

Built and ran on a Pi 4 (Debian trixie, aarch64). With the field
populated for the HF+ serial:

- `/api/v1/devices` shows the Airspy R2 + RTL-SDR but not the HF+.
- Journal: `sdr: ignoring device per config driver=airspyhf serial=...`.
- Inside the OpenWebRX+ container, `SoapySDRUtil --find=driver=airspyhf`
  still finds the HF+ — host-side libusb access is preserved.
- Scanner cockpit (`/api/v1/scanner`) reports the conventional channel
  on the RTL-SDR voice SDR; widebandt2 starts on the Airspy R2.

## Non-goals

- Not a per-driver opt-out (`ignore_drivers: ["airspyhf"]`) — too coarse.
- Not a runtime API to dynamically ignore/unignore.
- Not a "discover-but-reserve" mode where the pool tracks the dongle
  but keeps it closed — the device simply isn't in the pool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
