### PR TITLE
fix(equalizer): correct complex-LMS weight-update conjugation (#402)

### DIFF
--- a/internal/dsp/equalizer/lms.go
+++ b/internal/dsp/equalizer/lms.go
@@ -5,7 +5,7 @@ package equalizer
 //
 //	y[n]   = sum_k w_k(n) * x[n-k]              // FIR output
 //	e[n]   = d[n] - y[n]                        // training error
-//	w[n+1] = w[n] + μ · x[n] · conj(e[n])       // weight update
+//	w[n+1] = w[n] + μ · e[n] · conj(x[n-k])     // weight update
 //
 // Notes:
 //
@@ -101,18 +101,29 @@ func (e *LMS) Process(x, desired complex64) (complex64, complex64) {
 	// Error e = d - y.
 	err := complex(real(desired)-yr, imag(desired)-yi)
 
-	// Weight update: w_k += μ * x[n-k] * conj(e).
+	// Weight update: w_k += μ · e · conj(x[n-k]).
+	//
+	// For the non-Hermitian filter y = Σ_k w_k·x_k, Wirtinger calculus
+	// gives ∂J/∂w_k* = −e·conj(x_k) with J = |d−y|², so steepest descent
+	// is w_k += μ·e·conj(x_k). The conjugate is on x, NOT on e: the two
+	// differ only in the sign of the imaginary cross-term, so a real-only
+	// channel can't tell them apart — but on a COMPLEX channel the wrong
+	// sign turns the update into ascent on the imaginary axis and the taps
+	// diverge. (The earlier code computed x·conj(e), which is that wrong
+	// sign; it survived only because the package tests used a real-valued
+	// channel coefficient. See TestLMSConvergesOnComplexChannel.)
 	mu := e.stepSize
-	er, ei := real(err), imag(err) // conj(err) = (er, -ei)
+	er, ei := real(err), imag(err)
 	idx = e.histPos - 1
 	if idx < 0 {
 		idx = len(e.hist) - 1
 	}
 	for i := 0; i < len(e.taps); i++ {
 		xr, xi := real(e.hist[idx]), imag(e.hist[idx])
-		// (xr + j*xi) * (er - j*ei) = (xr*er + xi*ei) + j*(xi*er - xr*ei)
-		ur := xr*er + xi*ei
-		ui := xi*er - xr*ei
+		// e · conj(x) = (er + j*ei)(xr - j*xi)
+		//             = (er*xr + ei*xi) + j*(ei*xr - er*xi)
+		ur := er*xr + ei*xi
+		ui := ei*xr - er*xi
 		tr, ti := real(e.taps[i]), imag(e.taps[i])
 		e.taps[i] = complex(tr+mu*ur, ti+mu*ui)
 		idx--

--- a/internal/dsp/equalizer/lms_complex_test.go
+++ b/internal/dsp/equalizer/lms_complex_test.go
@@ -1,0 +1,72 @@
+package equalizer
+
+import (
+	"math"
+	"testing"
+)
+
+// complexChannel applies a 2-tap multipath with a genuinely COMPLEX echo
+// coefficient: y[n] = x[n] + alpha·x[n-1], alpha ∈ ℂ with imag ≠ 0. This is
+// the case the original real-only TestLMSConvergesOnTwoTapChannel could not
+// exercise — and the case that exposed the conjugation sign error in the LMS
+// weight update (e·conj(x), not x·conj(e)).
+func complexChannel(x []complex64, alpha complex64) []complex64 {
+	y := make([]complex64, len(x))
+	for i := range x {
+		y[i] = x[i]
+		if i > 0 {
+			y[i] += alpha * x[i-1]
+		}
+	}
+	return y
+}
+
+// TestLMSConvergesOnComplexChannel is the regression guard for the complex-LMS
+// conjugation fix. With a complex echo coefficient the wrong-sign update
+// (w += μ·x·conj(e)) diverges to NaN; the correct update (w += μ·e·conj(x))
+// converges. We train on known symbols and require the post-convergence MSE to
+// be both finite and small.
+func TestLMSConvergesOnComplexChannel(t *testing.T) {
+	const n = 8000
+	tx := genQPSK(n, 99)
+	rx := complexChannel(tx, complex(0.5, 0.35)) // complex echo: imag ≠ 0
+
+	eq := NewLMS(11, 0.02)
+	const D = 11 / 2 // centre-tap delay: align desired to the FIR group delay
+
+	// Train.
+	for i := 0; i < n-1000; i++ {
+		var desired complex64
+		if i-D >= 0 {
+			desired = tx[i-D]
+		}
+		eq.Process(rx[i], desired)
+	}
+
+	// Taps must be finite (the buggy update diverged to NaN here).
+	for i, tap := range eq.Taps() {
+		if math.IsNaN(float64(real(tap))) || math.IsNaN(float64(imag(tap))) ||
+			math.IsInf(float64(real(tap)), 0) || math.IsInf(float64(imag(tap)), 0) {
+			t.Fatalf("tap[%d] diverged to %v — complex LMS update is unstable", i, tap)
+		}
+	}
+
+	// Post-convergence MSE on a held-out window (no further updates: step 0).
+	eq.SetStepSize(0)
+	var mse float64
+	cnt := 0
+	for i := n - 1000; i < n; i++ {
+		y, _ := eq.Process(rx[i], 0)
+		if i-D < 0 {
+			continue
+		}
+		dr := float64(real(tx[i-D]) - real(y))
+		di := float64(imag(tx[i-D]) - imag(y))
+		mse += dr*dr + di*di
+		cnt++
+	}
+	mse /= float64(cnt)
+	if mse > 0.05 {
+		t.Errorf("complex-channel post-convergence MSE = %g, want < 0.05", mse)
+	}
+}


### PR DESCRIPTION
The complex LMS weight update computed w_k += μ·x·conj(e) instead of the
correct w_k += μ·e·conj(x). For the non-Hermitian FIR y = Σ w_k·x_k,
Wirtinger calculus gives ∂J/∂w_k* = −e·conj(x_k), so steepest descent
puts the conjugate on x, not e. The two forms differ only in the sign of
the imaginary cross-term, so they are identical for a real-valued channel
— which is why the existing TestLMSConvergesOnTwoTapChannel (alpha=0.5+0i)
never caught it. On a genuinely complex channel the wrong sign makes the
update ascend on the imaginary axis and the taps diverge to NaN.

This surfaced while evaluating an IQ-domain equalizer for the issue #402
C4FM multipath: a genie-trained equalizer using the corrected update fully
recovers a two-ray-echo loopback (dibit SER 0.086 → 0.000 through the real
receiver) and is a no-op on clean signal, whereas the buggy update diverged.

Adds TestLMSConvergesOnComplexChannel (complex echo coefficient,
imag ≠ 0) as the regression guard. The shipping CMA update was checked
and is already correct; no production code calls LMS yet, so no behaviour
change ships beyond the equalizer package.

https://claude.ai/code/session_011hB9DhEF4vQnyMLUAmToS4