### PR TITLE
Add web.tabs config to turn off UI navigation tabs (#455)

### DIFF
--- a/cmd/gophertrunk/runtime.go
+++ b/cmd/gophertrunk/runtime.go
@@ -80,6 +80,7 @@ func (r *runtimeSnapshot) Runtime() api.RuntimeDTO {
 
 		MetricsEnabled: r.metrics,
 		VocoderMap:     vocoderProtocolMap,
+		HiddenTabs:     cfg.Web.HiddenTabs(),
 	}
 	if cfg.Recordings.Equalizer.StepSize != 0 {
 		dto.RecordingEQStepSize = formatFloat(float64(cfg.Recordings.Equalizer.StepSize))

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -713,3 +713,23 @@ broadcast:
 #       role: "control"
 #       loop: true
 
+# User-interface tabs. Every navigation tab shows by default in both the
+# web UI and the terminal TUI. If you run GopherTrunk for one main task
+# (just trunking, just pagers, …) you can declutter the nav by switching
+# the tabs you don't use off here. Setting a tab to false removes it from
+# the nav strip only — the panel is still reachable directly by URL. Omit
+# this section (or leave it empty) to show everything.
+#
+# Valid tab keys: dashboard, active, scanner, settings, systems,
+# talkgroups, rids, history, events, cc, tones, pagers, aprs, ais, dsc,
+# adsb, mdc1200, spectrum, constellation, bookmarks, metrics, devices,
+# import. (The feature tabs pagers/aprs/ais/dsc/adsb/mdc1200 are web-only,
+# so hiding them is a no-op in the TUI.)
+# web:
+#   tabs:
+#     aprs: false
+#     ais: false
+#     dsc: false
+#     adsb: false
+#     mdc1200: false
+

--- a/internal/api/handlers_runtime.go
+++ b/internal/api/handlers_runtime.go
@@ -83,6 +83,11 @@ type RuntimeDTO struct {
 	// failed to open, etc.). Surfaced so the SPA Dashboard can pin
 	// them until the operator dismisses them.
 	StartupWarnings []string `json:"startup_warnings,omitempty"`
+
+	// HiddenTabs lists the navigation tab keys the operator switched
+	// off via web.tabs in config. Both the web SPA and the TUI filter
+	// these out of their nav. Empty/omitted means every tab is shown.
+	HiddenTabs []string `json:"hidden_tabs,omitempty"`
 }
 
 // ToneProfileDTO is the minimal projection of a tone-out profile —

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 	"time"
 
@@ -32,6 +33,65 @@ type Config struct {
 	DSC        DSCConfig        `yaml:"dsc"`
 	MDC1200    MDC1200Config    `yaml:"mdc1200"`
 	ADSB       ADSBConfig       `yaml:"adsb"`
+	Web        WebConfig        `yaml:"web"`
+}
+
+// WebConfig configures the bundled user interfaces (the embedded web SPA
+// and the terminal TUI). Tabs maps a tab key (e.g. "pagers", "metrics")
+// to whether it is shown in the navigation. Absent keys default to
+// visible, so an empty/omitted section shows everything. Set a key to
+// false to turn that tab off — operators running GopherTrunk for a single
+// task can declutter the UI to just the panels they care about. Hiding a
+// tab only removes it from the nav strip; the route/panel is still
+// reachable directly.
+type WebConfig struct {
+	Tabs map[string]bool `yaml:"tabs"`
+}
+
+// KnownUITabs is the canonical set of navigation tab keys both UIs
+// understand. The key is the web route path minus its leading slash; the
+// TUI maps the same keys onto its panels via state.PanelKind.Key(). The
+// web SPA owns the full set; the TUI owns only the core subset, so hiding
+// a web-only tab (pagers/aprs/…) is simply a no-op there. Keep this in
+// sync with web/src/App.tsx (TABS + EXTRA_TABS).
+var KnownUITabs = map[string]bool{
+	"dashboard":     true,
+	"active":        true,
+	"scanner":       true,
+	"settings":      true,
+	"systems":       true,
+	"talkgroups":    true,
+	"rids":          true,
+	"history":       true,
+	"events":        true,
+	"cc":            true,
+	"tones":         true,
+	"pagers":        true,
+	"aprs":          true,
+	"ais":           true,
+	"dsc":           true,
+	"adsb":          true,
+	"mdc1200":       true,
+	"spectrum":      true,
+	"constellation": true,
+	"bookmarks":     true,
+	"metrics":       true,
+	"devices":       true,
+	"import":        true,
+}
+
+// HiddenTabs returns the sorted list of tab keys explicitly switched off
+// (mapped to false). The result feeds /api/v1/runtime so both UIs can
+// filter their navigation from a single source of truth.
+func (w WebConfig) HiddenTabs() []string {
+	var hidden []string
+	for key, visible := range w.Tabs {
+		if !visible {
+			hidden = append(hidden, key)
+		}
+	}
+	sort.Strings(hidden)
+	return hidden
 }
 
 // ADSBConfig configures the ADS-B aircraft-tracking input. The
@@ -1150,6 +1210,16 @@ func (c Config) Validate() error {
 		case "", "control", "voice", "auto":
 		default:
 			return fmt.Errorf("baseband.replay[%d]: role must be control|voice|auto", i)
+		}
+	}
+	for key := range c.Web.Tabs {
+		if !KnownUITabs[key] {
+			valid := make([]string, 0, len(KnownUITabs))
+			for k := range KnownUITabs {
+				valid = append(valid, k)
+			}
+			sort.Strings(valid)
+			return fmt.Errorf("web.tabs: unknown tab %q (valid: %s)", key, strings.Join(valid, ", "))
 		}
 	}
 	return nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -287,6 +287,10 @@ func TestValidate(t *testing.T) {
 			}}},
 			Trunking: TrunkingConfig{Systems: []SystemConfig{{Name: "x", Protocol: "dmr-tier2"}}},
 		}, true},
+		// web.tabs: turn off nav items. Known keys (in any state) are
+		// fine; an unknown key is rejected so typos surface at load.
+		{"web tabs known ok", Config{Web: WebConfig{Tabs: map[string]bool{"pagers": false, "metrics": true}}}, false},
+		{"web tabs unknown key", Config{Web: WebConfig{Tabs: map[string]bool{"pagerz": false}}}, true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -295,6 +299,28 @@ func TestValidate(t *testing.T) {
 				t.Errorf("err = %v, wantErr = %v", err, tc.wantErr)
 			}
 		})
+	}
+}
+
+func TestWebConfigHiddenTabs(t *testing.T) {
+	w := WebConfig{Tabs: map[string]bool{
+		"pagers":  false,
+		"metrics": false,
+		"aprs":    true, // explicitly visible — not hidden
+	}}
+	got := w.HiddenTabs()
+	want := []string{"metrics", "pagers"} // sorted, value==false only
+	if len(got) != len(want) {
+		t.Fatalf("HiddenTabs() = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("HiddenTabs() = %v, want %v", got, want)
+		}
+	}
+	// Nil/empty map hides nothing.
+	if h := (WebConfig{}).HiddenTabs(); len(h) != 0 {
+		t.Fatalf("empty WebConfig.HiddenTabs() = %v, want none", h)
 	}
 }
 

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -191,40 +191,40 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case key.Matches(msg, m.keys.ToggleTheme):
 			return m, m.toggleTheme()
 		case key.Matches(msg, m.keys.NextPanel):
-			m.active = (m.active + 1) % state.PanelCount
+			m.cyclePanel(1)
 			return m, nil
 		case key.Matches(msg, m.keys.PrevPanel):
-			m.active = (m.active + state.PanelCount - 1) % state.PanelCount
+			m.cyclePanel(-1)
 			return m, nil
 		case key.Matches(msg, m.keys.JumpPanel1):
-			m.active = state.PanelDashboard
+			m.jumpToVisible(0)
 			return m, nil
 		case key.Matches(msg, m.keys.JumpPanel2):
-			m.active = state.PanelSystems
+			m.jumpToVisible(1)
 			return m, nil
 		case key.Matches(msg, m.keys.JumpPanel3):
-			m.active = state.PanelTalkgroups
+			m.jumpToVisible(2)
 			return m, nil
 		case key.Matches(msg, m.keys.JumpPanel4):
-			m.active = state.PanelActive
+			m.jumpToVisible(3)
 			return m, nil
 		case key.Matches(msg, m.keys.JumpPanel5):
-			m.active = state.PanelHistory
+			m.jumpToVisible(4)
 			return m, nil
 		case key.Matches(msg, m.keys.JumpPanel6):
-			m.active = state.PanelEvents
+			m.jumpToVisible(5)
 			return m, nil
 		case key.Matches(msg, m.keys.JumpPanel7):
-			m.active = state.PanelTones
+			m.jumpToVisible(6)
 			return m, nil
 		case key.Matches(msg, m.keys.JumpPanel8):
-			m.active = state.PanelMetrics
+			m.jumpToVisible(7)
 			return m, nil
 		case key.Matches(msg, m.keys.JumpPanel9):
-			m.active = state.PanelDevices
+			m.jumpToVisible(8)
 			return m, nil
 		case key.Matches(msg, m.keys.JumpPanel0):
-			m.active = state.PanelScanner
+			m.jumpToVisible(9)
 			return m, nil
 		}
 
@@ -294,6 +294,10 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case pollRuntimeMsg:
 		if msg.err == nil {
 			m.shared.Runtime = msg.r
+			// web.tabs may now hide the active panel — snap to the
+			// first visible tab so the operator isn't stranded on a
+			// hidden one.
+			m.clampActive()
 		}
 		m.shared.RuntimeErr = msg.err
 		cmds = append(cmds, scheduleAfter(pollRuntimeEvery, cmdPollRuntime(m.cli)))
@@ -464,12 +468,75 @@ func (m *Model) View() string {
 	return full
 }
 
+// visiblePanels returns the panels in display order with any switched
+// off via web.tabs (carried on the runtime snapshot) filtered out. The
+// nav bar, tab cycling, jump keys and mouse hit-testing all key off this
+// list so a hidden tab disappears everywhere consistently. At least one
+// panel is always kept so navigation can never strand the operator.
+func (m *Model) visiblePanels() []state.PanelKind {
+	hidden := make(map[string]bool, len(m.shared.Runtime.HiddenTabs))
+	for _, k := range m.shared.Runtime.HiddenTabs {
+		hidden[k] = true
+	}
+	vis := make([]state.PanelKind, 0, len(m.panels))
+	for i := range m.panels {
+		kind := state.PanelKind(i)
+		if hidden[kind.Key()] {
+			continue
+		}
+		vis = append(vis, kind)
+	}
+	if len(vis) == 0 {
+		vis = append(vis, state.PanelDashboard)
+	}
+	return vis
+}
+
+// jumpToVisible activates the n-th (0-based) visible tab, ignoring
+// out-of-range jumps so a number key bound past the end of a trimmed
+// nav is a no-op.
+func (m *Model) jumpToVisible(n int) {
+	vis := m.visiblePanels()
+	if n >= 0 && n < len(vis) {
+		m.active = vis[n]
+	}
+}
+
+// cyclePanel advances the active tab by delta within the visible list,
+// wrapping at both ends.
+func (m *Model) cyclePanel(delta int) {
+	vis := m.visiblePanels()
+	cur := 0
+	for i, k := range vis {
+		if k == m.active {
+			cur = i
+			break
+		}
+	}
+	n := len(vis)
+	m.active = vis[((cur+delta)%n+n)%n]
+}
+
+// clampActive snaps the active tab to the first visible one when the
+// current selection has been hidden (e.g. config changed under us).
+func (m *Model) clampActive() {
+	vis := m.visiblePanels()
+	for _, k := range vis {
+		if k == m.active {
+			return
+		}
+	}
+	m.active = vis[0]
+}
+
 func (m *Model) renderTabs() string {
-	// Build the full label set first so we can decide if we need to
-	// collapse for narrow terminals.
-	labels := make([]string, state.PanelCount)
-	for i := state.PanelKind(0); i < state.PanelCount; i++ {
-		labels[i] = fmt.Sprintf("%d %s", int(i)+1, m.panels[i].Title())
+	// Build the visible label set first so we can decide if we need to
+	// collapse for narrow terminals. Display numbers track visible
+	// position so they match the 1-9/0 jump keys.
+	vis := m.visiblePanels()
+	labels := make([]string, len(vis))
+	for i, kind := range vis {
+		labels[i] = fmt.Sprintf("%d %s", i+1, m.panels[kind].Title())
 	}
 	// Estimate width: each tab gets 2 padding cells + label runes + 1 separator.
 	full := 0
@@ -481,21 +548,21 @@ func (m *Model) renderTabs() string {
 	// active index inverted, plus a "more" pill that opens the
 	// palette filtered to panel jumps.
 	if m.width > 0 && full > m.width {
-		return m.renderCompactTabs(labels)
+		return m.renderCompactTabs(vis, labels)
 	}
-	parts := make([]string, 0, state.PanelCount)
-	rects := make([]tabRect, 0, state.PanelCount)
+	parts := make([]string, 0, len(vis))
+	rects := make([]tabRect, 0, len(vis))
 	x := 0
-	for i := state.PanelKind(0); i < state.PanelCount; i++ {
+	for i, kind := range vis {
 		var rendered string
-		if i == m.active {
+		if kind == m.active {
 			rendered = m.styles.activeTab.Render(labels[i])
 		} else {
 			rendered = m.styles.tab.Render(labels[i])
 		}
 		parts = append(parts, rendered)
 		w := lipgloss.Width(rendered)
-		rects = append(rects, tabRect{kind: i, xStart: x, xEnd: x + w})
+		rects = append(rects, tabRect{kind: kind, xStart: x, xEnd: x + w})
 		x += w + 1 // +1 for the separator space
 	}
 	m.tabRects = rects
@@ -505,20 +572,20 @@ func (m *Model) renderTabs() string {
 // renderCompactTabs is the narrow-terminal fallback: a strip of
 // numeric indices ("1 2 3 …") with the active one labelled fully, and
 // a trailing "more" pill that points the operator at ctrl+p.
-func (m *Model) renderCompactTabs(labels []string) string {
-	parts := make([]string, 0, state.PanelCount+1)
-	rects := make([]tabRect, 0, state.PanelCount)
+func (m *Model) renderCompactTabs(vis []state.PanelKind, labels []string) string {
+	parts := make([]string, 0, len(vis)+1)
+	rects := make([]tabRect, 0, len(vis))
 	x := 0
-	for i := state.PanelKind(0); i < state.PanelCount; i++ {
+	for i, kind := range vis {
 		var rendered string
-		if i == m.active {
+		if kind == m.active {
 			rendered = m.styles.activeTab.Render(labels[i])
 		} else {
-			rendered = m.styles.tab.Render(fmt.Sprintf("%d", int(i)+1))
+			rendered = m.styles.tab.Render(fmt.Sprintf("%d", i+1))
 		}
 		parts = append(parts, rendered)
 		w := lipgloss.Width(rendered)
-		rects = append(rects, tabRect{kind: i, xStart: x, xEnd: x + w})
+		rects = append(rects, tabRect{kind: kind, xStart: x, xEnd: x + w})
 		x += w + 1
 	}
 	m.tabRects = rects

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -101,3 +101,61 @@ func TestPanelSwitch_DigitAndTab(t *testing.T) {
 		t.Errorf("Tab from Import: active=%v, want Dashboard", m.active)
 	}
 }
+
+func TestHiddenTabs_FilterNav(t *testing.T) {
+	m := newTestModel(t)
+	// Wide terminal so the strip renders full labels (not the compact
+	// numeric fallback) and we can assert on tab names.
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 300, Height: 40})
+	m = updated.(*Model)
+	// Operator turned off Systems + Talkgroups via web.tabs; the daemon
+	// surfaces that on the runtime snapshot.
+	updated, _ = m.Update(pollRuntimeMsg{r: client.RuntimeDTO{
+		HiddenTabs: []string{"systems", "talkgroups"},
+	}})
+	m = updated.(*Model)
+
+	// Hidden panels drop out of the tab strip entirely.
+	tabs := m.renderTabs()
+	if strings.Contains(tabs, "Systems") || strings.Contains(tabs, "Talkgroups") {
+		t.Errorf("hidden tabs still rendered: %q", tabs)
+	}
+	if !strings.Contains(tabs, "Dashboard") || !strings.Contains(tabs, "Active") {
+		t.Errorf("visible tabs missing from strip: %q", tabs)
+	}
+
+	// Jump keys address the Nth *visible* tab: 1=Dashboard, 2=Active
+	// (Systems/Talkgroups skipped).
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("2")})
+	m = updated.(*Model)
+	if m.active != state.PanelActive {
+		t.Errorf("jump 2 with Systems/Talkgroups hidden: active=%v, want Active", m.active)
+	}
+
+	// Tab cycling skips hidden panels: Dashboard → Active.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("1")})
+	m = updated.(*Model)
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	m = updated.(*Model)
+	if m.active != state.PanelActive {
+		t.Errorf("Tab from Dashboard with Systems/Talkgroups hidden: active=%v, want Active", m.active)
+	}
+}
+
+func TestHiddenTabs_ClampActive(t *testing.T) {
+	m := newTestModel(t)
+	// Park on Settings, then hide it via a runtime update — the active
+	// tab must snap back to a visible one rather than strand the user.
+	updated, _ := m.Update(pollRuntimeMsg{r: client.RuntimeDTO{
+		HiddenTabs: []string{"settings"},
+	}})
+	m = updated.(*Model)
+	m.active = state.PanelSettings
+	updated, _ = m.Update(pollRuntimeMsg{r: client.RuntimeDTO{
+		HiddenTabs: []string{"settings"},
+	}})
+	m = updated.(*Model)
+	if m.active == state.PanelSettings {
+		t.Errorf("active stayed on hidden Settings tab")
+	}
+}

--- a/internal/tui/client/types.go
+++ b/internal/tui/client/types.go
@@ -288,6 +288,11 @@ type RuntimeDTO struct {
 	// collected during NewDaemon. The Dashboard pins them as a
 	// one-shot banner.
 	StartupWarnings []string `json:"startup_warnings,omitempty"`
+
+	// HiddenTabs lists the navigation tab keys the operator switched
+	// off via web.tabs in config. The TUI filters these out of its tab
+	// bar. Empty means every tab is shown.
+	HiddenTabs []string `json:"hidden_tabs,omitempty"`
 }
 
 // ToneProfileDTO mirrors api.ToneProfileDTO.

--- a/internal/tui/state/state.go
+++ b/internal/tui/state/state.go
@@ -59,6 +59,40 @@ func (p PanelKind) String() string {
 	return "?"
 }
 
+// Key returns the stable config key for this panel — the same key the
+// web SPA uses (route path minus its leading slash) so a single
+// web.tabs entry hides the tab in both UIs. Keep in sync with
+// config.KnownUITabs and web/src/App.tsx.
+func (p PanelKind) Key() string {
+	switch p {
+	case PanelDashboard:
+		return "dashboard"
+	case PanelSystems:
+		return "systems"
+	case PanelTalkgroups:
+		return "talkgroups"
+	case PanelActive:
+		return "active"
+	case PanelHistory:
+		return "history"
+	case PanelEvents:
+		return "events"
+	case PanelTones:
+		return "tones"
+	case PanelMetrics:
+		return "metrics"
+	case PanelDevices:
+		return "devices"
+	case PanelScanner:
+		return "scanner"
+	case PanelSettings:
+		return "settings"
+	case PanelImport:
+		return "import"
+	}
+	return ""
+}
+
 // RingReader is the read-side interface RingBuf satisfies. Panels
 // only need read access to the event/tone buffers.
 type RingReader[T any] interface {

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -19,6 +19,7 @@ vi.mock("./api/client", () => ({
   api: {
     mutations: vi.fn().mockResolvedValue({ allow_mutations: false }),
     health: vi.fn().mockResolvedValue({ status: "ok" }),
+    runtime: vi.fn().mockResolvedValue({ hidden_tabs: [] }),
   },
   HTTPError: class HTTPError extends Error {
     status: number;

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -70,6 +70,8 @@ export function App() {
   const setConnected = useShared((s) => s.setConnected);
   const setMutations = useShared((s) => s.setMutations);
   const setWSStatus = useShared((s) => s.setWSStatus);
+  const hiddenTabs = useShared((s) => s.hiddenTabs);
+  const setHiddenTabs = useShared((s) => s.setHiddenTabs);
   const appendEvents = useShared((s) => s.appendEvents);
   const lastError = useShared((s) => s.lastError);
   const setError = useShared((s) => s.setError);
@@ -111,6 +113,14 @@ export function App() {
       .then(setMutations)
       .catch(() => setMutations(null));
 
+    // Pull the runtime snapshot once to learn which nav tabs the
+    // operator turned off via web.tabs in config. On failure we leave
+    // the nav untouched (everything visible) rather than blank it.
+    api
+      .runtime(cfg)
+      .then((rt) => setHiddenTabs(rt.hidden_tabs ?? []))
+      .catch(() => setHiddenTabs([]));
+
     const stream = openEventStream(cfg, {
       onEvents: appendEvents,
       onStatus: setWSStatus,
@@ -118,9 +128,30 @@ export function App() {
     return () => {
       stream.close();
     };
-  }, [connected, baseURL, token, appendEvents, setMutations, setWSStatus]);
+  }, [
+    connected,
+    baseURL,
+    token,
+    appendEvents,
+    setMutations,
+    setWSStatus,
+    setHiddenTabs,
+  ]);
 
-  const visibleTabs = useMemo(() => TABS, []);
+  // A hidden tab is dropped from both the main strip and the desktop
+  // overflow row. The key is the route path minus its leading slash —
+  // the same key the daemon emits in hidden_tabs. Routes stay mounted
+  // (nav-only hiding), so a hidden panel is still reachable by URL.
+  const hidden = useMemo(() => new Set(hiddenTabs), [hiddenTabs]);
+  const tabKey = (t: Tab) => String(t.to).replace(/^\//, "");
+  const visibleTabs = useMemo(
+    () => TABS.filter((t) => !hidden.has(tabKey(t))),
+    [hidden],
+  );
+  const visibleExtraTabs = useMemo(
+    () => EXTRA_TABS.filter((t) => !hidden.has(tabKey(t))),
+    [hidden],
+  );
 
   if (!baseURL || !connected) {
     return <ConnectScreen />;
@@ -134,7 +165,7 @@ export function App() {
           bottom-nav-friendly four-tab limit still leaves room for
           everything else. */}
       <div className="hidden sm:flex gap-1 px-3 py-1 border-b border-panel text-xs overflow-x-auto">
-        {EXTRA_TABS.map((t) => (
+        {visibleExtraTabs.map((t) => (
           <button
             key={String(t.to)}
             onClick={() => navigate(t.to)}

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -212,6 +212,9 @@ export interface RuntimeDTO {
   // collected during NewDaemon. The Dashboard pins them until the
   // operator dismisses them.
   startup_warnings?: string[];
+  // HiddenTabs lists the navigation tab keys switched off via
+  // web.tabs in config. The App filters them out of the nav strip.
+  hidden_tabs?: string[];
   // RuntimeDTO is large and changes shape as the daemon grows. Read
   // unknown fields lazily.
   [key: string]: unknown;

--- a/web/src/store/shared.ts
+++ b/web/src/store/shared.ts
@@ -43,6 +43,10 @@ interface SharedState {
   /** Cap the event ring at this many entries to mirror the TUI. */
   eventCap: number;
 
+  /** Tab keys the operator switched off via web.tabs in config. The
+   *  nav bar filters these out. Sourced from /api/v1/runtime. */
+  hiddenTabs: string[];
+
   /** Last error surfaced from any request, for the toast strip. */
   lastError: string | null;
 
@@ -59,6 +63,7 @@ interface SharedState {
   setActiveCalls(a: ActiveCallDTO[]): void;
   setDevices(d: DeviceDTO[]): void;
   setScanner(s: ScannerStatusDTO | null): void;
+  setHiddenTabs(tabs: string[]): void;
   appendEvents(evs: EventDTO[]): void;
   setError(msg: string | null): void;
   reset(): void;
@@ -83,6 +88,7 @@ export const useShared = create<SharedState>((set, get) => ({
   scanner: null,
   events: [],
   eventCap: 500,
+  hiddenTabs: [],
 
   lastError: null,
 
@@ -127,6 +133,9 @@ export const useShared = create<SharedState>((set, get) => ({
   },
   setScanner(s) {
     set({ scanner: s });
+  },
+  setHiddenTabs(tabs) {
+    set({ hiddenTabs: tabs });
   },
   appendEvents(evs) {
     if (evs.length === 0) return;
@@ -181,6 +190,7 @@ export const useShared = create<SharedState>((set, get) => ({
       scanner: null,
       events: [],
       mutations: null,
+      hiddenTabs: [],
       lastError: null,
     });
   },


### PR DESCRIPTION
Operators running GopherTrunk for a single task can now declutter the
navigation by switching off tabs they don't use. Every tab shows by
default; setting a key to false under web.tabs hides it from the nav
strip in both the web SPA and the terminal TUI.

- config: new WebConfig.Tabs map, KnownUITabs canonical set, and
  HiddenTabs() helper; Validate() rejects unknown tab keys.
- api: carry the hidden list on the read-only /api/v1/runtime snapshot
  so both clients filter from a single source of truth.
- web: fetch runtime on connect and filter TABS/EXTRA_TABS by key.
  Routes stay mounted (nav-only hiding).
- tui: PanelKind.Key() maps panels to the shared keys; nav rendering,
  tab cycling, jump keys and mouse hit-testing drive off a derived
  visible list, with the active tab clamped when hidden.

https://claude.ai/code/session_018TMjgajLxsNJw2ACsAuCKq