### PR TITLE
p25p2: default scrambler to on so live MAC PDU decode works

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -720,15 +720,15 @@ type SystemConfig struct {
 	P25Phase2InterleaveMode string `yaml:"p25_phase2_interleave_mode"`
 	// P25Phase2ScramblerMode enables the PN44 descrambling layer
 	// per TIA-102.BBAC-1 §7.2.5 on top of the trellis-decoded MAC
-	// PDU. Recognised values: "" / "off" / "false" / "0" (the
-	// default — no PN44 descrambling; matches historical decoder
-	// behaviour and synthesized-fixture expectations) or "on" /
-	// "true" / "1" (XOR the trellis-decoded 144-bit MAC PDU with
-	// the leading 144 bits of the PN44 sequence). The scrambler
-	// seed is derived from (WACN, SystemID, Color Code = NAC) per
-	// spec equation (5); the zero-seed edge case maps to (2^44 - 1).
-	// Full superframe-aware per-burst offset tracking is a
-	// follow-up. Ignored for non-P25-Phase-2 protocols.
+	// PDU. Recognised values: "" / "on" / "true" / "1" (the
+	// default — every on-air P25 Phase 2 MAC PDU is PN44 scrambled,
+	// so descrambling is required for live decode; XOR the
+	// trellis-decoded 144-bit MAC PDU with the leading 144 bits of
+	// the PN44 sequence) or "off" / "false" / "0" (no PN44
+	// descrambling; the opt-out for synthesized, unscrambled
+	// fixtures). The scrambler seed is derived from (WACN, SystemID,
+	// Color Code = NAC) per spec equation (5); the zero-seed edge
+	// case maps to (2^44 - 1). Ignored for non-P25-Phase-2 protocols.
 	P25Phase2ScramblerMode string `yaml:"p25_phase2_scrambler_mode"`
 	// P25Phase2ClockMode selects the symbol-timing-recovery strategy
 	// for the P25 Phase 2 receiver. Recognised values: "" /

--- a/internal/radio/p25/phase2/control.go
+++ b/internal/radio/p25/phase2/control.go
@@ -256,13 +256,15 @@ func ParseInterleaveMode(s string) (InterleaveMode, bool) {
 // PN44 descrambler per TIA-102.BBAC-1 §7.2.5 to the trellis-decoded
 // MAC PDU.
 //
-//   - ScramblerOff (default): the trellis-decoded 144-bit MAC PDU
-//     is parsed straight into the state machine. Matches every
-//     shipped capture fixture in the test suite (the fixtures
-//     synthesize MAC PDUs without applying scrambling) and the
-//     historical decoder output.
+//   - ScramblerOff: the trellis-decoded 144-bit MAC PDU is parsed
+//     straight into the state machine. Matches every shipped capture
+//     fixture in the test suite (the fixtures synthesize MAC PDUs
+//     without applying scrambling) and the historical decoder output.
+//     Available as an explicit opt-out; live on-air traffic is always
+//     scrambled, so the config default (ParseScramblerMode) is
+//     ScramblerOn.
 //
-//   - ScramblerOn: the trellis-decoded 144-bit MAC PDU is XORed
+//   - ScramblerOn (config default): the trellis-decoded 144-bit MAC PDU is XORed
 //     with the leading 144 bits of the PN44 scrambling sequence
 //     derived from the configured (WACN_ID, System_ID, Color_Code)
 //     seed before ParseMACPDU runs. SetScramblerSeed must be
@@ -355,30 +357,38 @@ func (c *ControlChannel) ScramblerOffset() int {
 }
 
 // ParseScramblerMode maps a config / user-facing string into a
-// ScramblerMode. Recognised values (case-insensitive): "" / "off" /
-// "false" / "0" → ScramblerOff (the default — no PN44 descrambling);
-// "on" / "true" / "1" → ScramblerOn (XOR the trellis-decoded MAC
-// PDU bits with the PN44 sequence starting at the configured
-// per-burst offset); "probe" / "auto" → ScramblerProbe (try each
-// of the 12 spec-defined slot offsets and accept the first that
-// passes RS verification).
+// ScramblerMode. Recognised values (case-insensitive): "" →
+// ScramblerOn (the default — every on-air P25 Phase 2 MAC PDU is
+// PN44 scrambled per TIA-102.BBAC-1 §7.2.5, and the production MAC
+// paths supply the correct per-slot offset from superframe sync, so
+// descrambling decodes live traffic out of the box); "off" /
+// "false" / "0" → ScramblerOff (opt-out for the synthesized,
+// unscrambled test fixtures); "on" / "true" / "1" → ScramblerOn
+// (XOR the trellis-decoded MAC PDU bits with the PN44 sequence
+// starting at the configured per-burst offset); "probe" / "auto" →
+// ScramblerProbe (try each of the 12 spec-defined slot offsets and
+// accept the first that passes RS verification).
 //
 // ScramblerProbe is only meaningful when RSMode is RSOn — without
 // RS verification there's no way to tell which offset produced the
 // real PDU; the connector emits a warning if probe is selected
 // without RSOn and degrades to ScramblerOn behaviour.
 //
-// Unknown strings return ScramblerOff with `ok = false`.
+// Unknown strings return ScramblerOn with `ok = false` so callers
+// can surface the misconfiguration while still defaulting to the
+// live-decode behaviour.
 func ParseScramblerMode(s string) (ScramblerMode, bool) {
 	switch strings.ToLower(strings.TrimSpace(s)) {
-	case "", "off", "false", "0":
+	case "":
+		return ScramblerOn, true
+	case "off", "false", "0":
 		return ScramblerOff, true
 	case "on", "true", "1":
 		return ScramblerOn, true
 	case "probe", "auto":
 		return ScramblerProbe, true
 	default:
-		return ScramblerOff, false
+		return ScramblerOn, false
 	}
 }
 

--- a/internal/radio/p25/phase2/process_scrambler_test.go
+++ b/internal/radio/p25/phase2/process_scrambler_test.go
@@ -15,7 +15,7 @@ func TestParseScramblerMode(t *testing.T) {
 		want ScramblerMode
 		ok   bool
 	}{
-		{"", ScramblerOff, true},
+		{"", ScramblerOn, true},
 		{"off", ScramblerOff, true},
 		{"false", ScramblerOff, true},
 		{"0", ScramblerOff, true},
@@ -26,8 +26,8 @@ func TestParseScramblerMode(t *testing.T) {
 		{"probe", ScramblerProbe, true},
 		{"PROBE", ScramblerProbe, true},
 		{"auto", ScramblerProbe, true},
-		{"yes", ScramblerOff, false},
-		{"scramble", ScramblerOff, false},
+		{"yes", ScramblerOn, false},
+		{"scramble", ScramblerOn, false},
 	}
 	for _, c := range cases {
 		got, ok := ParseScramblerMode(c.in)

--- a/internal/scanner/ccdecoder/pipelines.go
+++ b/internal/scanner/ccdecoder/pipelines.go
@@ -206,7 +206,7 @@ func newP25Phase1Pipeline(opts PipelineOptions) (ProtocolPipeline, error) {
 	}
 	p2Scrambler, p2ScrOK := p25phase2.ParseScramblerMode(opts.System.P25Phase2ScramblerMode)
 	if !p2ScrOK {
-		log.Warn("ccdecoder: unrecognised p25_phase2_scrambler_mode; falling back to off",
+		log.Warn("ccdecoder: unrecognised p25_phase2_scrambler_mode; falling back to on",
 			"system", opts.SystemName, "value", opts.System.P25Phase2ScramblerMode)
 	}
 	cc := p25phase1.New(p25phase1.Options{
@@ -329,7 +329,7 @@ func newP25Phase2Pipeline(opts PipelineOptions) (ProtocolPipeline, error) {
 	cc.SetInterleaveMode(interleaveMode)
 	scramblerMode, scrOK := p25phase2.ParseScramblerMode(opts.System.P25Phase2ScramblerMode)
 	if !scrOK {
-		opts.Log.Warn("ccdecoder: unrecognised p25_phase2_scrambler_mode; falling back to off",
+		opts.Log.Warn("ccdecoder: unrecognised p25_phase2_scrambler_mode; falling back to on",
 			"system", opts.SystemName, "value", opts.System.P25Phase2ScramblerMode)
 	}
 	if scramblerMode == p25phase2.ScramblerProbe && rsMode != p25phase2.RSOn {

--- a/internal/scanner/widebandt2/engine.go
+++ b/internal/scanner/widebandt2/engine.go
@@ -452,7 +452,7 @@ func applyP25Phase2Modes(cc *p25phase2.ControlChannel, sys trunking.System, log 
 	cc.SetInterleaveMode(interleaveMode)
 	scramblerMode, scrOK := p25phase2.ParseScramblerMode(sys.P25Phase2ScramblerMode)
 	if !scrOK {
-		log.Warn("widebandt2: unrecognised p25_phase2_scrambler_mode; falling back to off",
+		log.Warn("widebandt2: unrecognised p25_phase2_scrambler_mode; falling back to on",
 			"system", sys.Name, "value", sys.P25Phase2ScramblerMode)
 	}
 	if scramblerMode == p25phase2.ScramblerProbe && rsMode != p25phase2.RSOn {

--- a/internal/trunking/site.go
+++ b/internal/trunking/site.go
@@ -227,9 +227,10 @@ type System struct {
 	P25Phase2InterleaveMode string
 	// P25Phase2ScramblerMode enables the PN44 descrambler per
 	// TIA-102.BBAC-1 §7.2.5 on the trellis-decoded MAC PDU bits.
-	// Recognised values (case-insensitive): "" / "off" / "false" /
-	// "0" → ScramblerOff (the default — no PN44 descrambling);
-	// "on" / "true" / "1" → ScramblerOn. The seed is computed from
+	// Recognised values (case-insensitive): "" / "on" / "true" /
+	// "1" → ScramblerOn (the default — live Phase 2 traffic is
+	// always scrambled); "off" / "false" / "0" → ScramblerOff
+	// (opt-out for unscrambled fixtures). The seed is computed from
 	// (WACN, SystemID, low 12 bits of Site as the spec's Color
 	// Code = NAC) per spec equation (5). Forwarded into
 	// p25phase2.ControlChannel.SetScramblerMode +

--- a/internal/tui/panels/settings.go
+++ b/internal/tui/panels/settings.go
@@ -472,7 +472,7 @@ func fecSummary(s client.SystemDTO) string {
 	case "p25-phase2":
 		parts = append(parts, "trellis: "+orDefault(s.P25Phase2TrellisMode, "on"))
 		parts = append(parts, "rs: "+orDefault(s.P25Phase2RSMode, "off"))
-		parts = append(parts, "scrambler: "+orDefault(s.P25Phase2ScramblerMode, "off"))
+		parts = append(parts, "scrambler: "+orDefault(s.P25Phase2ScramblerMode, "on"))
 	case "nxdn":
 		parts = append(parts, "viterbi: "+orDefault(s.NXDNViterbiMode, "spec"))
 		if s.NXDNDeviationHz > 0 {

--- a/internal/voice/composer/p25p2_voice.go
+++ b/internal/voice/composer/p25p2_voice.go
@@ -57,10 +57,23 @@ func (c *Composer) runP25Phase2VoiceChain(ctx context.Context, serial string, sy
 		"trellis", macCfg.Trellis, "rs", macCfg.RS,
 		"interleave", macCfg.Interleave, "scrambler", macCfg.Scrambler,
 		"seed", macCfg.Seed)
-	if macCfg.Scrambler == p25p2.ScramblerOff || macCfg.Seed == 0 {
-		c.log.Warn("composer: p25p2 macCfg suggests live MAC PDU decode will fail",
+	// Surface the specific reason live MAC PDU decode would fail so the
+	// operator knows which knob to turn, rather than one opaque catch-all
+	// (issue #451). With the live-decode defaults (ScramblerOn + an
+	// identity-derived seed) none of these fire.
+	switch {
+	case macCfg.Seed == 0:
+		c.log.Warn("composer: p25p2 macCfg has no scrambler seed; live MAC PDU decode will fail until the system identity is known (set WACN/SystemID/site, or wait for a Network Status Broadcast on Phase 2 control channels)",
 			"serial", serial, "system", system,
 			"scrambler", macCfg.Scrambler, "seed", macCfg.Seed)
+	case macCfg.Scrambler == p25p2.ScramblerOff:
+		c.log.Warn("composer: p25p2 scrambler is off; live P25 Phase 2 MAC PDUs are always PN44-scrambled, so MAC decode will fail (set p25_phase2_scrambler_mode=on)",
+			"serial", serial, "system", system,
+			"scrambler", macCfg.Scrambler, "seed", macCfg.Seed)
+	case macCfg.Scrambler == p25p2.ScramblerProbe && macCfg.RS != p25p2.RSOn:
+		c.log.Warn("composer: p25p2 scrambler=probe requires p25_phase2_rs_mode=on to verify the slot offset; it will degrade to offset 0 and likely fail",
+			"serial", serial, "system", system,
+			"scrambler", macCfg.Scrambler, "rs", macCfg.RS, "seed", macCfg.Seed)
 	}
 
 	decim := int(iqHz) / p25p2VoiceIntermediateHz


### PR DESCRIPTION
Issue #451: a live P25 Phase 2 system logged "composer: p25p2 macCfg
suggests live MAC PDU decode will fail" with a valid identity-derived
seed but scrambler=0 (off). Every on-air P25 Phase 2 MAC PDU is PN44
scrambled per TIA-102.BBAC-1 §7.2.5, so with descrambling disabled MAC
decode (source ID, talker alias, encryption sync) can never succeed.

The default was wrong: ParseScramblerMode("") returned ScramblerOff,
which only suits the synthesized, unscrambled test fixtures. Flip the
empty/unrecognised config default to ScramblerOn, mirroring how
ParseTrellisMode already defaults to on for live traffic. ScramblerOn
(not Probe) is correct because both production MAC paths — the voice
chain (DecodeSuperframeMACPDUs) and the CC (IngestSuperframe) — already
feed the spec per-slot PN44 offset from superframe sync via
slotPN44Offset, so no RS verification is needed to pick the offset.

RS verification is deliberately left at its off default to avoid the
risk of dropping valid PDUs; explicit p25_phase2_scrambler_mode: off
remains available for fixtures.

Also split the single decode-will-fail warning into specific,
actionable messages (no seed / scrambler off / probe-without-rs) so
operators know which knob to turn.

https://claude.ai/code/session_01Ai23uLEe5a7GuyQ1Pd9wDH