### PR TITLE
flex: FLEX paging decoder (1600/2 mode)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,12 +65,17 @@ Silicon and Intel. Full per-OS recipes at
   Motorola Type II / SmartZone, EDACS / GE-Marc, LTR, MPT 1327,
   dPMR Mode 3, TETRA TMO. Amateur-radio: D-STAR and Yaesu System
   Fusion.
-- **POCSAG paging** — protocol layer for the dominant wireline
-  FSK pager protocol (CCIR 584): BCH(31,21) FEC, batch carve-up,
-  numeric (5 BCD/codeword) + alphanumeric (7-bit packed ASCII)
-  decoders. Foundation for fire / EMS dispatch text alongside
-  the trunked-voice pipeline; DSP wiring follows in the next PR.
-  See [docs/pocsag.md](docs/pocsag.md).
+- **POCSAG + FLEX paging** — protocol + DSP for the two dominant
+  pager protocols, both decoding straight off the air and sharing
+  the `pager_log` table / `/pager` panel (tagged by `protocol`).
+  POCSAG (CCIR 584): BCH(31,21) FEC, batch carve-up, numeric
+  (5 BCD/codeword) + alphanumeric (7-bit packed ASCII), 512 /
+  1200 / 2400 bps. FLEX: 1600 bps / 2-level mode — 32-bit sync +
+  mode code → frame-info word → block de-interleave → BCH(31,21)
+  → BIW / address / vector / message-word walk → alphanumeric /
+  numeric pages. Pin SDRs via `paging.pocsag` / `paging.flex`.
+  Foundation for fire / EMS dispatch text alongside the
+  trunked-voice pipeline. See [docs/pocsag.md](docs/pocsag.md).
 - **APRS / AX.25 packet** — end-to-end pipeline for the
   amateur-radio APRS metadata bus (position beacons, messages,
   bulletins, status, Mic-E mobile-tracker compressed format).

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -29,6 +29,7 @@ import (
 	aprsafsk "github.com/MattCheramie/GopherTrunk/internal/radio/aprs/afsk"
 	dscffsk "github.com/MattCheramie/GopherTrunk/internal/radio/dsc/ffsk"
 	mdc1200afsk "github.com/MattCheramie/GopherTrunk/internal/radio/mdc1200/afsk"
+	flexrx "github.com/MattCheramie/GopherTrunk/internal/radio/pager/flex/receiver"
 	pocsagrx "github.com/MattCheramie/GopherTrunk/internal/radio/pager/pocsag/receiver"
 	"github.com/MattCheramie/GopherTrunk/internal/sdr"
 	"github.com/MattCheramie/GopherTrunk/internal/sdr/baseband"
@@ -190,6 +191,11 @@ type Daemon struct {
 	// is a planned follow-up.
 	pocsagReceivers []*pocsagrx.Receiver
 	pocsagSpecs     []pocsagSpec // index-aligned with pocsagReceivers
+	// flexReceivers holds one FLEX receiver per configured paging.flex
+	// entry. Same shape as the POCSAG receivers; decoded pages share
+	// the pager_log table / panel, tagged protocol="flex".
+	flexReceivers []*flexrx.Receiver
+	flexSpecs     []flexSpec // index-aligned with flexReceivers
 	// aprsReceivers holds one APRS AFSK receiver per configured
 	// aprs.channels entry. Each subscribes to the iqtap broker
 	// for its assigned SDR and publishes packets onto the events
@@ -1026,6 +1032,35 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 		d.pocsagSpecs = append(d.pocsagSpecs, spec)
 	}
 
+	// FLEX paging receivers — one per configured paging.flex entry.
+	// Same construction shape as POCSAG above; decoded pages share the
+	// pager_log table / panel, tagged protocol="flex".
+	for _, fc := range cfg.Paging.FLEX {
+		spec := flexSpec{serial: fc.Serial, freq: fc.FrequencyHz}
+		if fc.Serial == "" || fc.FrequencyHz == 0 {
+			d.addWarning(fmt.Sprintf(
+				"paging.flex: entry missing serial or frequency_hz (serial=%q freq=%d) — skipped",
+				fc.Serial, fc.FrequencyHz))
+			d.flexReceivers = append(d.flexReceivers, nil)
+			d.flexSpecs = append(d.flexSpecs, spec)
+			continue
+		}
+		rcv, err := flexrx.New(flexrx.Options{
+			InputRateHz: cfg.SDR.SampleRate,
+			SourceName:  fc.Serial,
+			Bus:         d.bus,
+			Log:         log,
+		})
+		if err != nil {
+			d.addWarning(fmt.Sprintf("paging.flex[%s]: %v — skipped", fc.Serial, err))
+			d.flexReceivers = append(d.flexReceivers, nil)
+			d.flexSpecs = append(d.flexSpecs, spec)
+			continue
+		}
+		d.flexReceivers = append(d.flexReceivers, rcv)
+		d.flexSpecs = append(d.flexSpecs, spec)
+	}
+
 	// APRS / AX.25 Bell-202 AFSK receivers — one per configured
 	// aprs.channels entry. Same construction shape as POCSAG above:
 	// per-entry validation in the receiver, failures surface as a
@@ -1640,6 +1675,34 @@ func (d *Daemon) Run(ctx context.Context) error {
 			}
 			if err := br.SetCenterFreq(spec.freq); err != nil {
 				d.log.Warn("pocsag: SetCenterFreq failed",
+					"serial", spec.serial, "freq_hz", spec.freq, "err", err)
+				return nil
+			}
+			sub := br.Subscribe()
+			defer sub.Close()
+			return rcv.Process(ctx, sub.C)
+		})
+	}
+	// FLEX paging receivers — same shape as POCSAG above. Each
+	// subscribes to its assigned SDR's iqtap broker and runs the FLEX
+	// pipeline (FM demod → resample → slicer → sync/FIW/de-interleave
+	// → BCH → page assembly), publishing pages on KindPagerMessage.
+	for i, rcv := range d.flexReceivers {
+		if rcv == nil {
+			continue // skipped at construction; warning already logged
+		}
+		rcv := rcv
+		spec := d.flexSpecs[i]
+		name := fmt.Sprintf("flex-%s-%d", spec.serial, spec.freq)
+		d.spawn(runCtx, name, false, func(ctx context.Context) error {
+			br := d.iqBrokers[spec.serial]
+			if br == nil {
+				d.log.Warn("flex: SDR not found, skipping receiver",
+					"serial", spec.serial, "freq_hz", spec.freq)
+				return nil
+			}
+			if err := br.SetCenterFreq(spec.freq); err != nil {
+				d.log.Warn("flex: SetCenterFreq failed",
 					"serial", spec.serial, "freq_hz", spec.freq, "err", err)
 				return nil
 			}
@@ -2707,6 +2770,14 @@ func (p pagerProvider) RecentPagerMessages(limit int) ([]storage.PagerMessage, e
 // POCSAG paging channel. Index-aligned with Daemon.pocsagReceivers so
 // the Run loop can spawn each receiver without re-walking the YAML.
 type pocsagSpec struct {
+	serial string
+	freq   uint32
+}
+
+// flexSpec captures the broker-side wiring info for one configured
+// FLEX paging channel. Index-aligned with Daemon.flexReceivers so the
+// Run loop can spawn each receiver without re-walking the YAML.
+type flexSpec struct {
 	serial string
 	freq   uint32
 }

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -257,6 +257,10 @@ sdr:
 #       frequency_hz: 152_007_500  # local commercial paging / fire
 #                                  #  dispatch / DAPNET / etc.
 #       baud_hz: 1200              # 512 / 1200 / 2400; default 1200
+#   flex:                          # Motorola FLEX (1600 bps / 2-level)
+#     - serial: "antenna-pi2"      # SDR serial; shares the pager_log
+#                                  #  table / panel, tagged protocol=flex
+#       frequency_hz: 929_612_500  # local FLEX paging channel
 
 # APRS / AX.25 Bell-202 AFSK receiver. Each entry pins one SDR to
 # an APRS frequency and runs the full DSP pipeline (FM demod →

--- a/docs/pocsag.md
+++ b/docs/pocsag.md
@@ -11,11 +11,12 @@ GopherTrunk now decodes the **POCSAG** (Post Office Code
 Standardisation Advisory Group, CCIR Recommendation 584) wireline
 FSK pager protocol — the dominant pager protocol globally and the
 one most fire / EMS departments use for tone-out dispatch
-forwarding. The first PR lands the protocol layer (codeword parsing,
-BCH(31,21), batch carve-up, numeric + alphanumeric message
-reassembly) with thorough unit tests. The DSP wiring (FM demod →
-bit slicer → sync detector → batch decoder → bus event) is a
-focused follow-up PR.
+forwarding. The protocol layer (codeword parsing, BCH(31,21), batch
+carve-up, numeric + alphanumeric message reassembly) and the DSP
+wiring (FM demod → bit slicer → sync detector → batch decoder → bus
+event) are both shipped. The higher-rate Motorola **FLEX** protocol
+shares this page's bus event, storage, and panel — see the FLEX
+section below.
 
 ## What's here today
 
@@ -56,11 +57,34 @@ focused follow-up PR.
   will add a DDC tap so several narrow POCSAG channels inside
   one wideband SDR's bandwidth decode concurrently — the same
   primitive `role: wideband` uses for DMR Tier II.
-- **FLEX.** A separate, higher-rate (1600 / 3200 / 6400 sps)
-  Motorola pager protocol that shares the operator workflow but
-  needs its own FEC (Reed-Muller + two-of-three majority decoder)
-  and frame structure. Documented as a planned follow-up; the
-  framework added here is the foundation.
+## FLEX
+
+FLEX is the higher-rate Motorola pager protocol that shares POCSAG's
+operator workflow, bus event, `pager_log` table, and `/pager` panel —
+rows are tagged with `protocol = "flex"`. The decoder
+(`internal/radio/pager/flex`) handles the **1600 bps / 2-level** mode:
+
+```
+IQ → FM demod → resample → slicer → flex.Decoder.Push
+   → 32-bit sync marker (0xA6C6AAAA) + 16-bit mode code (0x870C)
+   → frame-info word → block de-interleave (88 codewords)
+   → BCH(31,21)+parity → BIW → address / vector / message words
+   → KindPagerMessage (Protocol="flex")
+```
+
+- **FEC:** FLEX BCH(31,21) reuses the tested POCSAG primitive via a
+  codeword bit-reversal (`framing.FLEXBCHEncode21` /
+  `FLEXBCHDecode32`), correcting up to 2 bit errors.
+- **De-interleave:** the block transpose `idx = ((c>>5)&0xFFF8)|(c&7)`,
+  bit `(c>>3)&31` per the reference decoders.
+- **Polarity** auto-resolves (the sync hunt accepts the inverted
+  marker), like POCSAG.
+- **Scope / pending:** 3200 / 6400 bps and 4-level multi-phase modes,
+  long (2-word) addresses, and multi-frame message reassembly are
+  follow-ups. The sync framing, BCH bit order, and capcode mapping are
+  validated end-to-end against a synthetic encoder; confirming them
+  against a captured FLEX signal is the remaining real-world
+  calibration step (shared caveat with the DSC frontend).
 
 ## Configuration
 
@@ -72,6 +96,9 @@ paging:
       frequency_hz: 152_007_500  # local commercial paging / fire
                                  # dispatch / DAPNET / etc.
       baud_hz: 1200              # 512 / 1200 / 2400; default 1200
+  flex:
+    - serial: "antenna-pi2"      # SDR serial
+      frequency_hz: 929_612_500  # local FLEX paging channel
 ```
 
 The daemon retunes the named SDR to `frequency_hz` on startup and
@@ -90,9 +117,9 @@ Pages flow onto `events.KindPagerMessage`, land in the SQLite
   uncorrectable codewords + the next address terminate an
   in-progress page.
 - **Bus event** — `events.KindPagerMessage` payload is a
-  `storage.PagerMessage` carrying RIC, function code, encoding
-  ("numeric" | "alpha"), decoded text, and total BCH bit-error
-  count.
+  `storage.PagerMessage` carrying protocol ("pocsag" | "flex"), RIC /
+  capcode, function code, encoding ("numeric" | "alpha" | "tone"),
+  decoded text, and total BCH bit-error count.
 - **SQLite persistence** — `storage.PagerLog` subscribes to the
   bus event and writes to a new `pager_log` table (mirrors
   `call_log` / `location_log`). Retention sweeper can be extended

--- a/internal/api/handlers_pager.go
+++ b/internal/api/handlers_pager.go
@@ -19,6 +19,7 @@ type PagerProvider interface {
 type PagerMessageDTO struct {
 	ID         int64     `json:"id"`
 	ReceivedAt time.Time `json:"received_at"`
+	Protocol   string    `json:"protocol"`
 	RIC        uint32    `json:"ric"`
 	Func       uint8     `json:"func"`
 	Encoding   string    `json:"encoding"`
@@ -27,9 +28,14 @@ type PagerMessageDTO struct {
 }
 
 func pagerMessageToDTO(m storage.PagerMessage) PagerMessageDTO {
+	proto := m.Protocol
+	if proto == "" {
+		proto = "pocsag"
+	}
 	return PagerMessageDTO{
 		ID:         m.ID,
 		ReceivedAt: m.ReceivedAt,
+		Protocol:   proto,
 		RIC:        m.RIC,
 		Func:       m.Func,
 		Encoding:   m.Encoding,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -245,6 +245,18 @@ type MDC1200ChannelConfig struct {
 // runs the per-protocol receiver against its IQ stream.
 type PagingConfig struct {
 	POCSAG []PagingPOCSAGConfig `yaml:"pocsag"`
+	FLEX   []PagingFLEXConfig   `yaml:"flex"`
+}
+
+// PagingFLEXConfig describes one FLEX paging channel to decode. Serial
+// picks the SDR; the daemon tunes it to FrequencyHz and runs the FLEX
+// receiver against its full IQ stream. The frontend handles the
+// 1600 bps / 2-level mode. Decoded pages publish on
+// events.KindPagerMessage with protocol="flex" and share the pager_log
+// table / web panel with POCSAG.
+type PagingFLEXConfig struct {
+	Serial      string `yaml:"serial"`
+	FrequencyHz uint32 `yaml:"frequency_hz"`
 }
 
 // PagingPOCSAGConfig describes one POCSAG paging channel to

--- a/internal/radio/framing/bch_flex.go
+++ b/internal/radio/framing/bch_flex.go
@@ -1,0 +1,49 @@
+package framing
+
+// FLEX paging uses the same BCH(31,21) error-correcting code as POCSAG
+// (generator 0x769, corrects up to 2 bit errors) plus an overall
+// even-parity bit, but lays the codeword out differently on the wire:
+// FLEX puts the 21 information bits in the LOW bits (0..20) and the 10
+// BCH parity bits in the high bits (21..30), with the even-parity bit
+// at bit 31. POCSAG's BCHEncode31_21 / BCHDecode31_21 (this package)
+// put the info in bits 30..10. The two layouts are a bit-reversal of
+// the 31-bit codeword apart, and bit-reversal preserves Hamming
+// distance, so we reuse the tested POCSAG primitive by reversing into
+// and out of its layout. The recovered 21-bit info integer is what the
+// FLEX BIW / VIW / message-field formulas operate on.
+//
+// Wire calibration: the FLEX generator polynomial and codeword bit
+// order are reproduced here as the POCSAG-compatible (31,21,5) code;
+// the encode/decode round-trip and 2-bit correction are unit-tested,
+// but the exact on-wire bit order of real FLEX traffic should be
+// confirmed against a captured signal.
+
+// reverse31 reverses the low 31 bits of x.
+func reverse31(x uint32) uint32 {
+	var r uint32
+	for i := 0; i < 31; i++ {
+		r = (r << 1) | (x & 1)
+		x >>= 1
+	}
+	return r
+}
+
+// FLEXBCHEncode21 encodes 21 information bits into a 32-bit FLEX
+// codeword: info in bits 0..20, 10 BCH parity bits in 21..30, and the
+// overall even-parity bit in bit 31.
+func FLEXBCHEncode21(info uint32) uint32 {
+	cw := reverse31(BCHEncode31_21(info & 0x1FFFFF))
+	if popCount32(cw&0x7FFFFFFF)&1 != 0 {
+		cw |= 1 << 31
+	}
+	return cw
+}
+
+// FLEXBCHDecode32 decodes a 32-bit FLEX codeword, returning the 21-bit
+// information field and the BCH error count (-1 if uncorrectable). The
+// even-parity bit (31) is ignored; the BCH layer carries the
+// correction.
+func FLEXBCHDecode32(cw uint32) (uint32, int) {
+	data, errs := BCHDecode31_21(reverse31(cw & 0x7FFFFFFF))
+	return data & 0x1FFFFF, errs
+}

--- a/internal/radio/pager/flex/decoder.go
+++ b/internal/radio/pager/flex/decoder.go
@@ -1,0 +1,181 @@
+package flex
+
+import (
+	"sync/atomic"
+
+	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+)
+
+// SyncMarker is the 32-bit FLEX frame sync word ('A') that precedes the
+// speed code at the head of every frame's Sync 1 (multimon
+// FLEX_SYNC_MARKER).
+const SyncMarker uint32 = 0xA6C6AAAA
+
+// speed1600x2 is the 16-bit FLEX mode code for 1600 bps / 2-level FSK —
+// the mode this decoder handles. Other modes (1600/4, 3200/2, 3200/4)
+// are recognised enough to be skipped cleanly.
+const speed1600x2 uint16 = 0x870C
+
+// PhaseWords is the number of 32-bit codewords in one phase of a FLEX
+// frame's data portion; PhaseBits is that in bits. At 1600/2 there is
+// one phase (A).
+const (
+	PhaseWords = 88
+	PhaseBits  = PhaseWords * 32 // 2816
+)
+
+type decState uint8
+
+const (
+	stHuntMarker decState = iota // scanning for the 32-bit sync marker
+	stSpeed                      // reading the 16-bit mode code
+	stFIW                        // reading the 32-bit frame info word
+	stData                       // de-interleaving the 88-codeword phase
+)
+
+// Decoder turns a demodulated FLEX bit stream into pages. Push one wire
+// bit at a time; completed pages are returned as they decode. Not safe
+// for concurrent use — one Decoder per channel.
+type Decoder struct {
+	st       decState
+	reg      uint32 // sliding 32-bit window for marker / FIW
+	bitCnt   int    // bits collected in the current fixed-length field
+	inverted bool   // locked on the complemented bit sense
+
+	frame int
+	cycle int
+
+	c     int // data-bit counter within the phase (0..PhaseBits-1)
+	words [PhaseWords]uint32
+
+	// Counters for /metrics.
+	framesSynced atomic.Uint64
+	pagesEmitted atomic.Uint64
+}
+
+// NewDecoder returns a ready Decoder in the marker-hunt state.
+func NewDecoder() *Decoder { return &Decoder{} }
+
+// Push feeds one wire bit. Returns any pages completed by this bit.
+func (d *Decoder) Push(bit byte) []Message {
+	b := uint32(bit & 1)
+	d.reg = (d.reg << 1) | b
+
+	switch d.st {
+	case stHuntMarker:
+		if d.reg == SyncMarker {
+			d.inverted = false
+			d.enterSpeed()
+		} else if (^d.reg) == SyncMarker {
+			d.inverted = true
+			d.enterSpeed()
+		}
+		return nil
+	case stSpeed:
+		d.bitCnt++
+		if d.bitCnt < 16 {
+			return nil
+		}
+		code := uint16(d.reg & 0xFFFF)
+		if d.inverted {
+			code = ^code
+		}
+		if code == speed1600x2 {
+			d.st = stFIW
+			d.bitCnt = 0
+		} else {
+			d.reset() // unsupported / mis-synced mode
+		}
+		return nil
+	case stFIW:
+		d.bitCnt++
+		if d.bitCnt < 32 {
+			return nil
+		}
+		fiw := d.reg
+		if d.inverted {
+			fiw = ^fiw
+		}
+		d.cycle = int((fiw >> 4) & 0x0F)
+		d.frame = int((fiw >> 8) & 0x7F)
+		d.framesSynced.Add(1)
+		d.enterData()
+		return nil
+	case stData:
+		d.placeDataBit(b)
+		d.c++
+		if d.c >= PhaseBits {
+			msgs := d.decodePhase()
+			d.reset()
+			return msgs
+		}
+		return nil
+	}
+	return nil
+}
+
+func (d *Decoder) enterSpeed() {
+	d.st = stSpeed
+	d.bitCnt = 0
+}
+
+func (d *Decoder) enterData() {
+	d.st = stData
+	d.c = 0
+	for i := range d.words {
+		d.words[i] = 0
+	}
+}
+
+// placeDataBit de-interleaves one data bit into its codeword. The FLEX
+// block interleave (multimon): bit counter c maps to codeword index
+// ((c>>5)&0xFFF8)|(c&7) and bit position (c>>3)&31 within that word.
+func (d *Decoder) placeDataBit(b uint32) {
+	bit := b
+	if d.inverted {
+		bit ^= 1
+	}
+	if bit == 0 {
+		return
+	}
+	word := ((d.c >> 5) & 0xFFF8) | (d.c & 7)
+	pos := (d.c >> 3) & 31
+	if word < PhaseWords {
+		d.words[word] |= 1 << uint(pos)
+	}
+}
+
+// decodePhase BCH-decodes the assembled codewords and runs the logical
+// FLEX parse, returning the pages in this phase.
+func (d *Decoder) decodePhase() []Message {
+	infos := make([]uint32, PhaseWords)
+	corr := make([]int, PhaseWords)
+	for i := 0; i < PhaseWords; i++ {
+		info, errs := framing.FLEXBCHDecode32(d.words[i])
+		infos[i] = info
+		corr[i] = errs
+	}
+	msgs := DecodePhase(infos, corr, d.frame, d.cycle)
+	d.pagesEmitted.Add(uint64(len(msgs)))
+	return msgs
+}
+
+// reset returns the decoder to marker-hunt.
+func (d *Decoder) reset() {
+	d.st = stHuntMarker
+	d.bitCnt = 0
+	d.c = 0
+}
+
+// Stats reports cumulative counters.
+type Stats struct {
+	FramesSynced uint64
+	PagesEmitted uint64
+}
+
+func (d *Decoder) Stats() Stats {
+	return Stats{
+		FramesSynced: d.framesSynced.Load(),
+		PagesEmitted: d.pagesEmitted.Load(),
+	}
+}

--- a/internal/radio/pager/flex/decoder_test.go
+++ b/internal/radio/pager/flex/decoder_test.go
@@ -1,0 +1,121 @@
+package flex
+
+import (
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+)
+
+// buildPhaseWords constructs the 88 BCH-decoded info values for a phase
+// carrying one alphanumeric page "HI" to a short capcode.
+func buildAlphaPhase(capcode uint32) [PhaseWords]uint32 {
+	var w [PhaseWords]uint32
+	// One address at word 1, vector at word 2, message at words 3-4.
+	// BIW: voffset=2, aoffset=1.
+	w[0] = (2 << 10) | (0 << 8) // biw
+	w[1] = capcode + 0x8000     // short address word
+	// VIW: type 5 (alpha), mw1=3, len=2.
+	w[2] = (2 << 14) | (3 << 7) | (5 << 4)
+	// Message words: first char of the first word is a skipped header.
+	hdr, h, i := uint32(0x40), uint32('H'), uint32('I')
+	w[3] = hdr | (h << 7) | (i << 14)
+	w[4] = 0x03 // ETX in the first character slot ends the message
+	return w
+}
+
+// encodeFrameBits turns a phase's info words into the full wire bit
+// stream: dotting, the 32-bit sync marker, the 16-bit mode code, the
+// FIW, then the BCH-encoded codewords interleaved per the FLEX block
+// scheme.
+func encodeFrameBits(words [PhaseWords]uint32, frame, cycle int) []byte {
+	var bits []byte
+	push := func(v uint32, n int) {
+		for i := n - 1; i >= 0; i-- {
+			bits = append(bits, byte((v>>uint(i))&1))
+		}
+	}
+	for i := 0; i < 64; i++ { // dotting / bit sync
+		bits = append(bits, byte(i&1))
+	}
+	push(SyncMarker, 32)
+	push(uint32(speed1600x2), 16)
+	fiw := uint32((cycle&0xF)<<4) | uint32((frame&0x7F)<<8)
+	push(fiw, 32)
+
+	var cw [PhaseWords]uint32
+	for i := range words {
+		cw[i] = framing.FLEXBCHEncode21(words[i])
+	}
+	for c := 0; c < PhaseBits; c++ {
+		word := ((c >> 5) & 0xFFF8) | (c & 7)
+		pos := (c >> 3) & 31
+		bits = append(bits, byte((cw[word]>>uint(pos))&1))
+	}
+	return bits
+}
+
+func TestDecodeAlphanumericFrame(t *testing.T) {
+	const capcode = 0x12345
+	bits := encodeFrameBits(buildAlphaPhase(capcode), 7, 3)
+
+	d := NewDecoder()
+	var got []Message
+	for _, b := range bits {
+		got = append(got, d.Push(b)...)
+	}
+	if len(got) != 1 {
+		t.Fatalf("decoded %d messages, want 1 (stats %+v)", len(got), d.Stats())
+	}
+	m := got[0]
+	if m.Capcode != capcode {
+		t.Errorf("Capcode = %#x, want %#x", m.Capcode, capcode)
+	}
+	if m.Type != PageAlphanumeric {
+		t.Errorf("Type = %v, want alphanumeric", m.Type)
+	}
+	if m.Text != "HI" {
+		t.Errorf("Text = %q, want %q", m.Text, "HI")
+	}
+	if m.Frame != 7 || m.Cycle != 3 {
+		t.Errorf("Frame/Cycle = %d/%d, want 7/3", m.Frame, m.Cycle)
+	}
+}
+
+// TestDecodeInvertedPolarity feeds the same frame with every bit
+// complemented; the marker hunt must lock on the inverted sense and
+// recover the true page.
+func TestDecodeInvertedPolarity(t *testing.T) {
+	const capcode = 0x0ABCD
+	bits := encodeFrameBits(buildAlphaPhase(capcode), 1, 1)
+
+	d := NewDecoder()
+	var got []Message
+	for _, b := range bits {
+		got = append(got, d.Push(b^1)...)
+	}
+	if len(got) != 1 {
+		t.Fatalf("decoded %d messages, want 1", len(got))
+	}
+	if got[0].Capcode != capcode {
+		t.Errorf("Capcode = %#x, want %#x", got[0].Capcode, capcode)
+	}
+	if got[0].Text != "HI" {
+		t.Errorf("Text = %q, want HI", got[0].Text)
+	}
+}
+
+// TestBCHCorrectsBitErrors confirms the FLEX BCH layer corrects a
+// couple of flipped bits in a codeword.
+func TestBCHCorrectsBitErrors(t *testing.T) {
+	info := uint32(0x15ABC)
+	cw := framing.FLEXBCHEncode21(info)
+	cw ^= 1 << 3  // flip a data bit
+	cw ^= 1 << 25 // flip a parity bit
+	got, errs := framing.FLEXBCHDecode32(cw)
+	if got != info {
+		t.Errorf("decoded info = %#x, want %#x", got, info)
+	}
+	if errs != 2 {
+		t.Errorf("corrected %d errors, want 2", errs)
+	}
+}

--- a/internal/radio/pager/flex/flex.go
+++ b/internal/radio/pager/flex/flex.go
@@ -1,0 +1,217 @@
+// Package flex decodes Motorola FLEX paging — the high-throughput
+// successor to POCSAG used by most modern paging networks (hospital
+// / EMS dispatch, commercial carriers). FLEX multiplexes many pagers
+// onto one channel with time-framed, interleaved, FEC-protected data
+// at 1600 / 3200 / 6400 bps (2- or 4-level FSK).
+//
+// This package owns the FLEX *logical* layer: given the BCH-decoded
+// 21-bit codeword values of one phase of a frame, it walks the Block
+// Information Word → address words → vector words → message words and
+// produces typed Messages. The streaming bit-level decoder
+// (sync acquisition, frame-info word, block de-interleaving, BCH) is
+// in the Decoder type below; the DSP frontend is in
+// internal/radio/pager/flex/receiver.
+//
+// Scope: this first slice targets the dominant 1600 bps / 2-level mode
+// (single phase A) and alphanumeric / numeric / tone vectors. The
+// 3200 / 6400 bps and 4-level multi-phase modes, long (2-word)
+// addresses, and multi-frame message reassembly are follow-ups. The
+// FLEX constants (sync marker, speed table, field layouts, idle
+// values) are reproduced from the de-facto reference decoders; the
+// de-interleave + BCH + field parse are validated end-to-end against a
+// synthetic encoder, with exact on-wire bit order / generator left for
+// real-capture calibration.
+//
+// References:
+//   - Motorola FLEX protocol (ARIB STD-T44 / TIA-TSB-58 family).
+//   - multimon-ng demod_flex.c — sync table, FIW / BIW / VIW layout.
+package flex
+
+import "strings"
+
+// PageType is the FLEX vector message type (VIW bits 4..6).
+type PageType uint8
+
+const (
+	PageSecure        PageType = 0
+	PageShortInstruct PageType = 3
+	PageTone          PageType = 2
+	PageNumeric       PageType = 1
+	PageNumberedNum   PageType = 6
+	PageAlphanumeric  PageType = 5
+	PageBinary        PageType = 4
+	PageUnknown       PageType = 0xFF
+)
+
+// pageTypeFromVIW maps the 3-bit VIW type field to a PageType.
+func pageTypeFromVIW(t uint32) PageType {
+	switch t {
+	case 0, 1:
+		return PageNumeric
+	case 2:
+		return PageTone
+	case 3:
+		return PageShortInstruct
+	case 4:
+		return PageBinary
+	case 5:
+		return PageAlphanumeric
+	case 6:
+		return PageNumberedNum
+	case 7:
+		return PageAlphanumeric // hex/secure variants carry text too
+	}
+	return PageUnknown
+}
+
+// TypeName returns a stable lowercase label for a PageType — used as
+// the pager_log encoding column value and the panel's display tag.
+func (p PageType) TypeName() string {
+	switch p {
+	case PageNumeric, PageNumberedNum:
+		return "numeric"
+	case PageAlphanumeric:
+		return "alpha"
+	case PageTone:
+		return "tone"
+	case PageShortInstruct:
+		return "short"
+	case PageBinary:
+		return "binary"
+	}
+	return "unknown"
+}
+
+// Message is one decoded FLEX page.
+type Message struct {
+	Capcode   uint32   // recovered pager address (capcode)
+	Type      PageType // vector message type
+	Text      string   // decoded message body (alphanumeric / numeric)
+	Cycle     int      // FIW cycle number (0..15)
+	Frame     int      // FIW frame number (0..127)
+	Corrected int      // BCH bit errors corrected across this page's words
+}
+
+// idle codeword info values per the FLEX spec / multimon: an all-zero
+// word and the all-ones 21-bit message field both mark "no address".
+const (
+	idleZero uint32 = 0x000000
+	idleOnes uint32 = 0x1FFFFF
+)
+
+// DecodePhase walks one phase's BCH-decoded codeword info values
+// (words[0..n-1], each a 21-bit value) and returns the pages it
+// carries. corr is the per-word BCH error count (index-aligned;
+// negative = uncorrectable). frame / cycle come from the FIW.
+//
+// The structure (multimon demod_flex.c): word 0 is the Block
+// Information Word; addresses occupy words [aoffset, voffset); each
+// address's vector word sits at voffset + (i-aoffset); the vector
+// names the message-word span.
+func DecodePhase(words []uint32, corr []int, frame, cycle int) []Message {
+	if len(words) < 2 {
+		return nil
+	}
+	biw := words[0]
+	voffset := int((biw >> 10) & 0x3F)
+	aoffset := int((biw>>8)&0x03) + 1
+	if voffset <= aoffset || voffset >= len(words) {
+		return nil
+	}
+
+	var out []Message
+	for i := aoffset; i < voffset; i++ {
+		aw := words[i]
+		if aw == idleZero || aw == idleOnes {
+			continue // idle / invalid address slot
+		}
+		vIdx := voffset + (i - aoffset)
+		if vIdx >= len(words) {
+			break
+		}
+		viw := words[vIdx]
+		ptype := pageTypeFromVIW((viw >> 4) & 0x07)
+		mw1 := int((viw >> 7) & 0x7F)
+		mlen := int((viw >> 14) & 0x7F)
+
+		msg := Message{
+			Capcode: capcode(aw),
+			Type:    ptype,
+			Frame:   frame,
+			Cycle:   cycle,
+		}
+		if corr != nil && i < len(corr) && corr[i] > 0 {
+			msg.Corrected += corr[i]
+		}
+		if mw1 > 0 && mlen > 0 && mw1+mlen <= len(words) {
+			mwords := words[mw1 : mw1+mlen]
+			switch ptype {
+			case PageAlphanumeric:
+				msg.Text = decodeAlpha(mwords)
+			case PageNumeric, PageNumberedNum:
+				msg.Text = decodeNumeric(mwords)
+			}
+			if corr != nil {
+				for k := mw1; k < mw1+mlen && k < len(corr); k++ {
+					if corr[k] > 0 {
+						msg.Corrected += corr[k]
+					}
+				}
+			}
+		}
+		out = append(out, msg)
+	}
+	return out
+}
+
+// capcode recovers the pager address from a short (single-word)
+// address codeword. Short FLEX addresses in [0x8001, 0x1E0000] map to
+// capcode = word − 0x8000; values outside that range (long / special
+// addresses) pass through unmapped for now.
+func capcode(aw uint32) uint32 {
+	if aw >= 0x8001 && aw <= 0x1E0000 {
+		return aw - 0x8000
+	}
+	return aw
+}
+
+// decodeAlpha decodes FLEX alphanumeric message words: three 7-bit
+// characters per 21-bit word, low group first. The very first
+// character of the first word is a control / fragment header and is
+// skipped; an ETX (0x03) ends the message.
+func decodeAlpha(words []uint32) string {
+	var sb strings.Builder
+	for wi, w := range words {
+		for c := 0; c < 3; c++ {
+			ch := byte((w >> (uint(c) * 7)) & 0x7F)
+			if wi == 0 && c == 0 {
+				continue // first-word header character
+			}
+			if ch == 0x03 {
+				return sb.String() // ETX — end of message
+			}
+			if ch >= 0x20 && ch < 0x7F {
+				sb.WriteByte(ch)
+			}
+		}
+	}
+	return sb.String()
+}
+
+// numericMap is the FLEX 4-bit numeric symbol table.
+var numericMap = []byte("0123456789 U -][")
+
+// decodeNumeric decodes FLEX numeric message words: 4-bit symbols
+// packed low-first across the 21-bit words (5 symbols/word + carry).
+// A best-effort decode — the dominant operational traffic is
+// alphanumeric; numeric is surfaced for completeness.
+func decodeNumeric(words []uint32) string {
+	var sb strings.Builder
+	for _, w := range words {
+		for s := 0; s < 5; s++ {
+			sym := byte((w >> (uint(s) * 4)) & 0x0F)
+			sb.WriteByte(numericMap[sym])
+		}
+	}
+	return strings.TrimRight(sb.String(), " ")
+}

--- a/internal/radio/pager/flex/receiver/receiver.go
+++ b/internal/radio/pager/flex/receiver/receiver.go
@@ -1,0 +1,185 @@
+// Package receiver wires the FLEX protocol layer (sync acquisition,
+// frame-info word, block de-interleaving, BCH, page assembly) onto a
+// live IQ stream from the iqtap broker. The pipeline mirrors the
+// POCSAG receiver:
+//
+//	IQ chunks (Fs Hz, complex64)
+//	  → FM demod (internal/dsp/demod/fm.FM)
+//	  → real resampler (internal/dsp/resampler_real) to baud × 8 sps
+//	  → bit-by-bit integrator + mean-tracking slicer
+//	  → flex.Decoder.Push(bit)
+//	  → events.KindPagerMessage on the bus (Protocol="flex")
+//
+// One Receiver per configured FLEX paging frequency. This frontend
+// handles the 1600 bps / 2-level mode (the decoder's supported mode);
+// the daemon tunes the SDR straight to the paging centre frequency and
+// the receiver consumes the whole IQ stream.
+package receiver
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync/atomic"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp"
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/demod"
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/pager/flex"
+	"github.com/MattCheramie/GopherTrunk/internal/storage"
+)
+
+// BaudHz is the FLEX signalling rate this frontend handles (1600 bps,
+// 2-level FSK — the decoder's supported mode).
+const BaudHz = 1600
+
+// Oversample is the resampled samples per FLEX bit fed to the
+// integrator + slicer. 8 mirrors the POCSAG frontend.
+const Oversample = 8
+
+// Options configures a Receiver.
+type Options struct {
+	// InputRateHz is the IQ sample rate the broker is feeding at.
+	InputRateHz uint32
+
+	// SourceName is stamped on log lines / metrics.
+	SourceName string
+
+	// Bus is required — pages publish onto KindPagerMessage.
+	Bus *events.Bus
+
+	// Log is optional; defaults to slog.Default.
+	Log *slog.Logger
+}
+
+// Receiver runs a FLEX decode pipeline against a stream of IQ chunks.
+type Receiver struct {
+	inputRate uint32
+	source    string
+	bus       *events.Bus
+	log       *slog.Logger
+
+	fm        *demod.FM
+	rsmp      *dsp.RealResampler
+	decoder   *flex.Decoder
+	demodBuf  []float32
+	rsmpBuf   []float32
+	intAcc    float32
+	intCount  int
+	meanEMA   float32
+	meanReady bool
+
+	pagesEmitted atomic.Uint64
+}
+
+// New constructs a Receiver. Returns an error if opts.Bus is nil or
+// InputRateHz is unset.
+func New(opts Options) (*Receiver, error) {
+	if opts.Bus == nil {
+		return nil, errors.New("flex/receiver: Bus is required")
+	}
+	if opts.InputRateHz == 0 {
+		return nil, errors.New("flex/receiver: InputRateHz is required")
+	}
+	log := opts.Log
+	if log == nil {
+		log = slog.Default()
+	}
+	out := uint32(BaudHz) * Oversample
+	g := gcd(out, opts.InputRateHz)
+	L := int(out / g)
+	M := int(opts.InputRateHz / g)
+	if L == 0 || M == 0 {
+		return nil, fmt.Errorf("flex/receiver: bad resample ratio L=%d M=%d", L, M)
+	}
+	return &Receiver{
+		inputRate: opts.InputRateHz,
+		source:    opts.SourceName,
+		bus:       opts.Bus,
+		log:       log,
+		fm:        demod.NewFM(),
+		rsmp:      dsp.NewRealResampler(L, M, 16, 7.0),
+		decoder:   flex.NewDecoder(),
+	}, nil
+}
+
+// Process pumps IQ chunks through the decode pipeline until ctx
+// cancels or in closes.
+func (r *Receiver) Process(ctx context.Context, in <-chan []complex64) error {
+	if in == nil {
+		return errors.New("flex/receiver: input channel is nil")
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case chunk, ok := <-in:
+			if !ok {
+				return nil
+			}
+			r.processChunk(chunk)
+		}
+	}
+}
+
+func (r *Receiver) processChunk(chunk []complex64) {
+	r.demodBuf = r.fm.Process(r.demodBuf, chunk)
+	r.rsmpBuf = r.rsmp.Process(r.rsmpBuf, r.demodBuf)
+	for _, s := range r.rsmpBuf {
+		r.feedSample(s)
+	}
+}
+
+// feedSample integrates one resampled sample; after Oversample samples
+// it slices to a bit (tracking DC bias with a slow EMA, like POCSAG)
+// and pushes it through the FLEX decoder.
+func (r *Receiver) feedSample(s float32) {
+	r.intAcc += s
+	r.intCount++
+	if r.intCount < Oversample {
+		return
+	}
+	avg := r.intAcc / float32(Oversample)
+	r.intAcc = 0
+	r.intCount = 0
+
+	if !r.meanReady {
+		r.meanEMA = avg
+		r.meanReady = true
+	} else {
+		r.meanEMA += (avg - r.meanEMA) * (1.0 / 64.0)
+	}
+	var bit byte
+	if avg > r.meanEMA {
+		bit = 1
+	}
+	for _, m := range r.decoder.Push(bit) {
+		r.publish(m)
+	}
+}
+
+// publish converts a flex.Message into the events bus shape.
+func (r *Receiver) publish(m flex.Message) {
+	msg := storage.PagerMessage{
+		Protocol:  "flex",
+		RIC:       m.Capcode,
+		Encoding:  m.Type.TypeName(),
+		Body:      m.Text,
+		Corrected: m.Corrected,
+	}
+	r.bus.Publish(events.Event{Kind: events.KindPagerMessage, Payload: msg})
+	r.pagesEmitted.Add(1)
+}
+
+// PagesEmitted reports the cumulative pages this receiver has
+// published. Useful for /metrics and end-to-end tests.
+func (r *Receiver) PagesEmitted() uint64 { return r.pagesEmitted.Load() }
+
+// gcd computes the greatest common divisor via Euclid's algorithm.
+func gcd(a, b uint32) uint32 {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}

--- a/internal/radio/pager/flex/receiver/receiver_test.go
+++ b/internal/radio/pager/flex/receiver/receiver_test.go
@@ -1,0 +1,64 @@
+package receiver
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+)
+
+func TestReceiverNewRejectsBadOptions(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+
+	if _, err := New(Options{}); err == nil {
+		t.Error("New without Bus: want error")
+	}
+	if _, err := New(Options{Bus: bus}); err == nil {
+		t.Error("New without InputRateHz: want error")
+	}
+}
+
+func TestReceiverNewSetsUpDecoder(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	r, err := New(Options{InputRateHz: 128_000, Bus: bus})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if r.decoder == nil {
+		t.Error("decoder = nil, want non-nil")
+	}
+}
+
+func TestReceiverPropagatesContextCancel(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	r, err := New(Options{InputRateHz: 128_000, Bus: bus})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	in := make(chan []complex64)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- r.Process(ctx, in) }()
+	cancel()
+	select {
+	case err := <-done:
+		if err != context.Canceled {
+			t.Errorf("Process err = %v, want context.Canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Process did not exit after ctx cancel")
+	}
+}
+
+func TestReceiverNilInputErrors(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	r, _ := New(Options{InputRateHz: 128_000, Bus: bus})
+	if err := r.Process(context.Background(), nil); err == nil {
+		t.Error("Process with nil input: want error")
+	}
+}

--- a/internal/storage/pagerlog.go
+++ b/internal/storage/pagerlog.go
@@ -22,6 +22,7 @@ import (
 type PagerMessage struct {
 	ID         int64     `json:"id"`
 	ReceivedAt time.Time `json:"received_at"`
+	Protocol   string    `json:"protocol"` // "pocsag" | "flex"
 	RIC        uint32    `json:"ric"`
 	Func       uint8     `json:"func"` // 0..3 = A..D
 	Encoding   string    `json:"encoding"`
@@ -89,11 +90,15 @@ func (p *PagerLog) insert(m PagerMessage) error {
 	if at.IsZero() {
 		at = time.Now()
 	}
+	proto := m.Protocol
+	if proto == "" {
+		proto = "pocsag"
+	}
 	_, err := p.db.SQL().Exec(
 		`INSERT INTO pager_log
-		 (received_at, ric, func, encoding, body, corrected)
-		 VALUES (?, ?, ?, ?, ?, ?)`,
-		at.UnixNano(), m.RIC, m.Func, m.Encoding, m.Body, m.Corrected,
+		 (received_at, protocol, ric, func, encoding, body, corrected)
+		 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		at.UnixNano(), proto, m.RIC, m.Func, m.Encoding, m.Body, m.Corrected,
 	)
 	return err
 }
@@ -108,7 +113,7 @@ func (p *PagerLog) Recent(limit int) ([]PagerMessage, error) {
 		limit = 5000
 	}
 	rows, err := p.db.SQL().Query(
-		`SELECT id, received_at, ric, func, encoding, body, corrected
+		`SELECT id, received_at, protocol, ric, func, encoding, body, corrected
 		 FROM pager_log ORDER BY received_at DESC LIMIT ?`, limit)
 	if err != nil {
 		return nil, fmt.Errorf("storage/pagerlog: query: %w", err)
@@ -120,7 +125,7 @@ func (p *PagerLog) Recent(limit int) ([]PagerMessage, error) {
 			m  PagerMessage
 			ns int64
 		)
-		if err := rows.Scan(&m.ID, &ns, &m.RIC, &m.Func, &m.Encoding,
+		if err := rows.Scan(&m.ID, &ns, &m.Protocol, &m.RIC, &m.Func, &m.Encoding,
 			&m.Body, &m.Corrected); err != nil {
 			return nil, fmt.Errorf("storage/pagerlog: scan: %w", err)
 		}

--- a/internal/storage/sqlite.go
+++ b/internal/storage/sqlite.go
@@ -136,12 +136,13 @@ CREATE INDEX IF NOT EXISTS idx_bookmarks_group ON bookmarks(grouping, name);
 -- alphanumeric.
 CREATE TABLE IF NOT EXISTS pager_log (
     id          INTEGER PRIMARY KEY AUTOINCREMENT,
-    received_at INTEGER NOT NULL,            -- unix nanoseconds
-    ric         INTEGER NOT NULL,            -- 21-bit address
-    func        INTEGER NOT NULL,            -- 0..3 (A..D)
-    encoding    TEXT    NOT NULL DEFAULT '', -- "numeric" | "alpha"
+    received_at INTEGER NOT NULL,                  -- unix nanoseconds
+    protocol    TEXT    NOT NULL DEFAULT 'pocsag', -- "pocsag" | "flex"
+    ric         INTEGER NOT NULL,                  -- 21-bit address / capcode
+    func        INTEGER NOT NULL,                  -- 0..3 (A..D); 0 for FLEX
+    encoding    TEXT    NOT NULL DEFAULT '',        -- "numeric" | "alpha" | "tone"
     body        TEXT    NOT NULL DEFAULT '',
-    corrected   INTEGER NOT NULL DEFAULT 0   -- total BCH bit-error count
+    corrected   INTEGER NOT NULL DEFAULT 0          -- total BCH bit-error count
 );
 
 CREATE INDEX IF NOT EXISTS idx_pager_log_time ON pager_log(received_at);
@@ -279,6 +280,11 @@ func (d *DB) migrate() error {
 	if err := d.ensureCallLogColumns(); err != nil {
 		return err
 	}
+	if err := d.ensureColumns("pager_log", []columnAdd{
+		{"protocol", `ALTER TABLE pager_log ADD COLUMN protocol TEXT NOT NULL DEFAULT 'pocsag'`},
+	}); err != nil {
+		return err
+	}
 	// Stamp the current schema version; future migrations check this
 	// row before running.
 	_, _ = d.sql.Exec(`INSERT OR IGNORE INTO schema_version(version) VALUES (2)`)
@@ -325,6 +331,49 @@ func (d *DB) ensureCallLogColumns() error {
 		}
 		if _, err := d.sql.Exec(a.ddl); err != nil {
 			return fmt.Errorf("storage: add call_log.%s: %w", a.name, err)
+		}
+	}
+	return nil
+}
+
+// columnAdd pairs a column name with the ALTER TABLE that introduces
+// it, for ensureColumns.
+type columnAdd struct{ name, ddl string }
+
+// ensureColumns brings an existing table forward with columns added
+// after its initial schema. CREATE TABLE IF NOT EXISTS never alters an
+// existing table, so a database created by an earlier GopherTrunk
+// keeps the old column set; this adds any missing columns. Idempotent
+// — present columns are skipped — so it needs no schema-version gate.
+func (d *DB) ensureColumns(table string, adds []columnAdd) error {
+	rows, err := d.sql.Query(`PRAGMA table_info(` + table + `)`)
+	if err != nil {
+		return fmt.Errorf("storage: inspect %s: %w", table, err)
+	}
+	have := make(map[string]bool)
+	for rows.Next() {
+		var (
+			cid, notnull, pk int
+			name, ctype      string
+			dflt             sql.NullString
+		)
+		if err := rows.Scan(&cid, &name, &ctype, &notnull, &dflt, &pk); err != nil {
+			rows.Close()
+			return fmt.Errorf("storage: inspect %s: %w", table, err)
+		}
+		have[name] = true
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return fmt.Errorf("storage: inspect %s: %w", table, err)
+	}
+	rows.Close()
+	for _, a := range adds {
+		if have[a.name] {
+			continue
+		}
+		if _, err := d.sql.Exec(a.ddl); err != nil {
+			return fmt.Errorf("storage: add %s.%s: %w", table, a.name, err)
 		}
 	}
 	return nil


### PR DESCRIPTION
## Summary

Completes **Phase 3** by adding a FLEX paging decoder alongside POCSAG. Both protocols now decode straight off the air and share the `pager_log` table, REST endpoint, and `/pager` panel — rows are tagged by a new `protocol` column. This is Milestone 3 of the remaining-work roadmap (DSC #448, ADS-B PPM #449 already merged).

## What's new

- **`internal/radio/pager/flex`** — the FLEX logical layer + streaming decoder:
  - Sync acquisition: 32-bit marker `0xA6C6AAAA` + 16-bit mode code `0x870C` (1600 bps / 2-level), with inverted-polarity fallback.
  - Frame-info word → block **de-interleave** (`idx=((c>>5)&0xFFF8)|(c&7)`, 88 codewords) → BCH → BIW (`voffset`/`aoffset`) → address / vector (VIW type, message-word span) → message words.
  - Alphanumeric (3×7-bit/word), numeric, and tone vectors.
- **`internal/radio/framing/bch_flex.go`** — FLEX BCH(31,21)+parity, reusing the tested POCSAG primitive via a codeword bit-reversal (FLEX puts info in the low 21 bits). Round-trip + 2-bit error correction unit-tested.
- **`internal/radio/pager/flex/receiver`** — DSP frontend mirroring POCSAG (FM demod → resample → integrator/slicer → `flex.Decoder`), publishing `KindPagerMessage` with `Protocol="flex"`.
- **Storage** — `protocol` column on `pager_log` (default `'pocsag'`) via a generalized `ensureColumns` migration helper; `PagerMessage.Protocol`.
- **API** — `protocol` surfaced in `PagerMessageDTO`.
- **Config + daemon** — `paging.flex` list; construct + spawn loops mirroring POCSAG.

## Testing

- `go build/vet/test ./...` green.
- FLEX decoder: synthetic frame → alphanumeric page (capcode + text + frame/cycle), inverted-polarity decode, and BCH 2-bit correction all pass end-to-end through the real de-interleave + BCH + parse path.
- Storage migration + DTO covered by existing storage/api suites.

## Grounding & scope

FLEX constants (sync marker, mode code, de-interleave formula, FIW/BIW/VIW layouts, idle values, page types) are reproduced from the **multimon-ng** reference decoder. As with the DSC frontend, the de-interleave + BCH + field parse are validated against a synthetic encoder; the exact on-wire bit order / generator and the **3200·6400 bps / 4-level multi-phase modes**, long (2-word) addresses, and multi-frame reassembly are documented follow-ups (real-capture calibration).

Roadmap continues with M17 link-layer (Milestone 4) → Codec2 port (5) → M17 voice (6).

---
_Generated by [Claude Code](https://claude.ai/code/session_01PccwhG9Ee9S2eqhtPbTWVc)_