### PR TITLE
m17: link-layer metadata decoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,16 @@ Silicon and Intel. Full per-OS recipes at
   the BEAST upstream uses. Plus `events.KindAircraftReport` bus
   event, SQLite `aircraft_log`, `GET /api/v1/adsb/aircraft`,
   and `/adsb` web panel. See [docs/adsb.md](docs/adsb.md).
+- **M17 link layer** — metadata decoder for the open, Codec2-based
+  M17 digital voice mode (4FSK, 4800 sym/s). C4FM demod → symbol
+  timing → 4FSK slice → sync hunt → LICH reassembly (Golay(24,12),
+  six chunks) → Link Setup Frame parse: source / destination
+  base-40 callsigns, mode (voice / data / packet), channel-access
+  number, CRC-16. Recovers "who's talking to whom" from an
+  in-progress transmission without decoding audio (Codec2 voice is
+  a planned follow-up). `events.KindM17LinkSetup` bus event, SQLite
+  `m17_log`, `GET /api/v1/m17/linksetups`. Pin an SDR via
+  `m17.channels`. See [docs/m17.md](docs/m17.md).
 - **Live map** — Shared Leaflet map at the top of each
   position-bearing panel (APRS / AIS / DSC / ADS-B) renders
   decoded positions over OpenStreetMap tiles, colour-coded per

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -28,6 +28,7 @@ import (
 	aisgmsk "github.com/MattCheramie/GopherTrunk/internal/radio/ais/gmsk"
 	aprsafsk "github.com/MattCheramie/GopherTrunk/internal/radio/aprs/afsk"
 	dscffsk "github.com/MattCheramie/GopherTrunk/internal/radio/dsc/ffsk"
+	m17rx "github.com/MattCheramie/GopherTrunk/internal/radio/m17/receiver"
 	mdc1200afsk "github.com/MattCheramie/GopherTrunk/internal/radio/mdc1200/afsk"
 	flexrx "github.com/MattCheramie/GopherTrunk/internal/radio/pager/flex/receiver"
 	pocsagrx "github.com/MattCheramie/GopherTrunk/internal/radio/pager/pocsag/receiver"
@@ -153,6 +154,7 @@ type Daemon struct {
 	aprsLog      *storage.APRSLog
 	vesselLog    *storage.VesselLog
 	dscLog       *storage.DSCLog
+	m17Log       *storage.M17Log
 	aircraftLog  *storage.AircraftLog
 	mdc1200Log   *storage.MDC1200Log
 	messageLog   *gtlog.MessageLog
@@ -196,6 +198,11 @@ type Daemon struct {
 	// the pager_log table / panel, tagged protocol="flex".
 	flexReceivers []*flexrx.Receiver
 	flexSpecs     []flexSpec // index-aligned with flexReceivers
+	// m17Receivers holds one M17 link-layer receiver per configured
+	// m17.channels entry. Each subscribes to its SDR's iqtap broker and
+	// publishes link-setup metadata on KindM17LinkSetup.
+	m17Receivers []*m17rx.Receiver
+	m17Specs     []m17Spec // index-aligned with m17Receivers
 	// aprsReceivers holds one APRS AFSK receiver per configured
 	// aprs.channels entry. Each subscribes to the iqtap broker
 	// for its assigned SDR and publishes packets onto the events
@@ -1061,6 +1068,35 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 		d.flexSpecs = append(d.flexSpecs, spec)
 	}
 
+	// M17 link-layer receivers — one per configured m17.channels entry.
+	// Same construction shape as the paging receivers above; decoded
+	// link metadata publishes on KindM17LinkSetup.
+	for _, mc := range cfg.M17.Channels {
+		spec := m17Spec{serial: mc.Serial, freq: mc.FrequencyHz}
+		if mc.Serial == "" || mc.FrequencyHz == 0 {
+			d.addWarning(fmt.Sprintf(
+				"m17.channels: entry missing serial or frequency_hz (serial=%q freq=%d) — skipped",
+				mc.Serial, mc.FrequencyHz))
+			d.m17Receivers = append(d.m17Receivers, nil)
+			d.m17Specs = append(d.m17Specs, spec)
+			continue
+		}
+		rcv, err := m17rx.New(m17rx.Options{
+			InputRateHz: cfg.SDR.SampleRate,
+			SourceName:  mc.Serial,
+			Bus:         d.bus,
+			Log:         log,
+		})
+		if err != nil {
+			d.addWarning(fmt.Sprintf("m17.channels[%s]: %v — skipped", mc.Serial, err))
+			d.m17Receivers = append(d.m17Receivers, nil)
+			d.m17Specs = append(d.m17Specs, spec)
+			continue
+		}
+		d.m17Receivers = append(d.m17Receivers, rcv)
+		d.m17Specs = append(d.m17Specs, spec)
+	}
+
 	// APRS / AX.25 Bell-202 AFSK receivers — one per configured
 	// aprs.channels entry. Same construction shape as POCSAG above:
 	// per-entry validation in the receiver, failures surface as a
@@ -1310,6 +1346,13 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 		}
 		d.dscLog = dl
 
+		ml, err := storage.NewM17Log(db, d.bus, log)
+		if err != nil {
+			db.Close()
+			return nil, fmt.Errorf("daemon: m17 log: %w", err)
+		}
+		d.m17Log = ml
+
 		acl, err := storage.NewAircraftLog(db, d.bus, log)
 		if err != nil {
 			db.Close()
@@ -1392,6 +1435,9 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 		}
 		if d.dscLog != nil {
 			opts.DSC = dscProvider{log: d.dscLog}
+		}
+		if d.m17Log != nil {
+			opts.M17 = m17Provider{log: d.m17Log}
 		}
 		if d.aircraftLog != nil {
 			opts.ADSB = adsbProvider{log: d.aircraftLog}
@@ -1581,6 +1627,11 @@ func (d *Daemon) Run(ctx context.Context) error {
 			return d.dscLog.Run(ctx)
 		})
 	}
+	if d.m17Log != nil {
+		d.spawn(runCtx, "m17log", false, func(ctx context.Context) error {
+			return d.m17Log.Run(ctx)
+		})
+	}
 	if d.aircraftLog != nil {
 		d.spawn(runCtx, "aircraftlog", false, func(ctx context.Context) error {
 			return d.aircraftLog.Run(ctx)
@@ -1703,6 +1754,33 @@ func (d *Daemon) Run(ctx context.Context) error {
 			}
 			if err := br.SetCenterFreq(spec.freq); err != nil {
 				d.log.Warn("flex: SetCenterFreq failed",
+					"serial", spec.serial, "freq_hz", spec.freq, "err", err)
+				return nil
+			}
+			sub := br.Subscribe()
+			defer sub.Close()
+			return rcv.Process(ctx, sub.C)
+		})
+	}
+	// M17 link-layer receivers — same shape as the paging receivers
+	// above. Each subscribes to its SDR's iqtap broker and runs the
+	// C4FM pipeline → LICH reassembly, publishing KindM17LinkSetup.
+	for i, rcv := range d.m17Receivers {
+		if rcv == nil {
+			continue // skipped at construction; warning already logged
+		}
+		rcv := rcv
+		spec := d.m17Specs[i]
+		name := fmt.Sprintf("m17-%s-%d", spec.serial, spec.freq)
+		d.spawn(runCtx, name, false, func(ctx context.Context) error {
+			br := d.iqBrokers[spec.serial]
+			if br == nil {
+				d.log.Warn("m17: SDR not found, skipping receiver",
+					"serial", spec.serial, "freq_hz", spec.freq)
+				return nil
+			}
+			if err := br.SetCenterFreq(spec.freq); err != nil {
+				d.log.Warn("m17: SetCenterFreq failed",
 					"serial", spec.serial, "freq_hz", spec.freq, "err", err)
 				return nil
 			}
@@ -2019,6 +2097,9 @@ func (d *Daemon) Close() {
 		}
 		if d.dscLog != nil {
 			_ = d.dscLog.Close()
+		}
+		if d.m17Log != nil {
+			_ = d.m17Log.Close()
 		}
 		if d.aircraftLog != nil {
 			_ = d.aircraftLog.Close()
@@ -2782,6 +2863,14 @@ type flexSpec struct {
 	freq   uint32
 }
 
+// m17Spec captures the broker-side wiring info for one configured M17
+// channel. Index-aligned with Daemon.m17Receivers so the Run loop can
+// spawn each receiver without re-walking the YAML.
+type m17Spec struct {
+	serial string
+	freq   uint32
+}
+
 // aprsProvider adapts storage.APRSLog into api.APRSProvider so the
 // api package stays free of the storage import dependency. Read-only
 // — the decoder writes via the events bus.
@@ -2807,6 +2896,15 @@ type dscProvider struct{ log *storage.DSCLog }
 
 func (d dscProvider) RecentDSCMessages(limit int) ([]storage.DSCMessage, error) {
 	return d.log.Recent(limit)
+}
+
+// m17Provider adapts storage.M17Log into api.M17Provider so the api
+// package stays free of the storage import dependency. Read-only — the
+// decoder writes via the events bus.
+type m17Provider struct{ log *storage.M17Log }
+
+func (m m17Provider) RecentM17LinkSetups(limit int) ([]storage.M17LinkSetup, error) {
+	return m.log.Recent(limit)
 }
 
 // adsbProvider adapts storage.AircraftLog into api.ADSBProvider so

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -375,6 +375,20 @@ sdr:
 #                                     #  or sdr.rtl_tcp), sampling >= 2 Msps
 #       frequency_hz: 1_090_000_000   # 1090 MHz (the default when omitted)
 
+# M17 digital voice (link-layer metadata). Each entry pins one SDR to
+# an M17 frequency and decodes the link setup — source / destination
+# callsigns and mode — via the stream-frame LICH path. Publishes on
+# events.KindM17LinkSetup; storage.M17Log persists to the m17_log
+# table, GET /api/v1/m17/linksetups returns recent rows. Codec2 voice
+# decode is a planned follow-up.
+#
+# m17:
+#   channels:
+#     - serial: "vhf-antenna"         # SDR serial (must be in sdr.devices
+#                                     #  or sdr.rtl_tcp)
+#       frequency_hz: 144_975_000     # 2 m M17 simplex calling
+#                                     #  (region-dependent; 433_475_000 on 70 cm)
+
 trunking:
   # call_timeout_ms: inactivity window after which the engine's
   # watchdog ends a call (publishes CallEnd with EndReasonTimeout

--- a/docs/m17.md
+++ b/docs/m17.md
@@ -1,0 +1,72 @@
+---
+layout: page
+title: M17 link layer
+description: M17 digital-voice link-layer metadata decoder — callsigns, mode, events bus, SQLite log, REST endpoint
+nav_group: Reference
+---
+
+# M17 link-layer decoder
+
+GopherTrunk decodes the **link layer** of [M17](https://m17project.org)
+— the open, Codec2-based amateur digital-voice protocol (4FSK,
+4800 sym/s). This slice recovers the *metadata* of a transmission:
+who is calling whom, and in what mode. It answers "is M17 active on
+this frequency, and from which station" without decoding audio — the
+pure-Go Codec2 voice path is a planned follow-up.
+
+## Pipeline
+
+```
+IQ → FM demod → resample to 48 kHz → C4FM matched filter
+   → Mueller-Müller symbol timing → 4FSK slice → dibit → bits
+   → sync hunt (stream 0xFF5D) → LICH reassembly → LSF parse
+   → events.KindM17LinkSetup
+```
+
+- `internal/radio/m17/receiver` owns IQ → bits (C4FM, mirrors the P25
+  Phase 1 frontend); `internal/radio/m17` owns bits → Link Setup Frame.
+- **Two LSF routes.** The dedicated LSF frame at the head of a
+  transmission is convolutionally coded + punctured; the **LICH** (Link
+  Information CHannel) embedded in every stream frame carries 1/6 of the
+  LSF, Golay(24,12)-coded. This decoder takes the LICH route — six
+  consecutive LICH chunks reassemble the full 240-bit LSF using only
+  Golay (no convolutional machinery), so a receiver tuned to an
+  in-progress transmission picks up the metadata within ~240 ms.
+- **LSF fields:** DST(48) + SRC(48) + TYPE(16) + META(112) + CRC(16).
+  Addresses are **base-40** callsigns (`DecodeAddress`), with the
+  all-ones address rendered `BROADCAST`. TYPE yields the mode (voice /
+  data / packet) and channel-access number. CRC-16 (poly 0x5935,
+  init 0xFFFF) is checked over DST..META.
+
+## What's wired
+
+- **Bus event** — `events.KindM17LinkSetup`, payload
+  `storage.M17LinkSetup` (src, dst, mode, CAN, hex META, CRC-OK flag,
+  display body).
+- **Storage** — `storage.M17Log` writes one `m17_log` row per
+  reassembled LSF (indexed on `received_at` and `src`).
+- **REST** — `GET /api/v1/m17/linksetups?limit=N` returns the recent
+  rows, newest first.
+- **Config** — pin an SDR under `m17.channels`:
+
+```yaml
+m17:
+  channels:
+    - serial: "vhf-antenna"
+      frequency_hz: 144_975_000   # 2 m M17 simplex calling (region-dependent)
+```
+
+## What's pending
+
+- **Codec2 voice.** The stream-frame payload (frame number + 128-bit
+  Codec2 frame, convolutionally coded) is skipped here; decoding it
+  needs the pure-Go Codec2 port (a later milestone) and the K=5
+  Viterbi + P2 de-puncture path.
+- **Dedicated LSF-frame decode.** The standalone LSF frame (P1
+  puncture + Viterbi) would surface metadata one frame sooner than the
+  LICH route; deferred since the LICH route already covers it.
+- **Calibration.** Sync words, LSF layout, CRC, base-40 alphabet, and
+  the LICH structure are from the M17 specification; the Golay matrix
+  and the C4FM slicer deviation / symbol-timing constants are validated
+  against a synthetic encoder and should be confirmed against a real
+  M17 capture (shared caveat with the DSC / FLEX frontends).

--- a/internal/api/handlers_m17.go
+++ b/internal/api/handlers_m17.go
@@ -1,0 +1,70 @@
+package api
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/storage"
+)
+
+// M17Provider is the read surface the m17-log endpoint consumes. The
+// daemon implements it on top of storage.M17Log; tests substitute a
+// fake.
+type M17Provider interface {
+	RecentM17LinkSetups(limit int) ([]storage.M17LinkSetup, error)
+}
+
+// M17LinkSetupDTO is the JSON wire shape for the m17-log endpoint.
+type M17LinkSetupDTO struct {
+	ID         int64     `json:"id"`
+	ReceivedAt time.Time `json:"received_at"`
+	Src        string    `json:"src"`
+	Dst        string    `json:"dst"`
+	Mode       string    `json:"mode"`
+	CAN        uint8     `json:"can"`
+	Meta       string    `json:"meta,omitempty"`
+	CRCOK      bool      `json:"crc_ok"`
+	Body       string    `json:"body,omitempty"`
+}
+
+func m17LinkSetupToDTO(l storage.M17LinkSetup) M17LinkSetupDTO {
+	return M17LinkSetupDTO{
+		ID:         l.ID,
+		ReceivedAt: l.ReceivedAt,
+		Src:        l.Src,
+		Dst:        l.Dst,
+		Mode:       l.Mode,
+		CAN:        l.CAN,
+		Meta:       l.Meta,
+		CRCOK:      l.CRCOK,
+		Body:       l.Body,
+	}
+}
+
+// handleM17LinkSetups answers GET /api/v1/m17/linksetups. Optional
+// ?limit= (default 200, max 5000). 503 when the storage layer isn't
+// wired (daemon started without storage.path).
+func (s *Server) handleM17LinkSetups(w http.ResponseWriter, r *http.Request) {
+	if s.m17 == nil {
+		writeError(w, http.StatusServiceUnavailable, "m17 subsystem not enabled")
+		return
+	}
+	limit := 200
+	if v := r.URL.Query().Get("limit"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			limit = n
+		}
+	}
+	rows, err := s.m17.RecentM17LinkSetups(limit)
+	if err != nil {
+		s.log.Error("api: m17 linksetups", "err", err)
+		writeError(w, http.StatusInternalServerError, "query failed")
+		return
+	}
+	out := make([]M17LinkSetupDTO, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, m17LinkSetupToDTO(r))
+	}
+	writeJSON(w, http.StatusOK, out)
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -292,6 +292,11 @@ type Server struct {
 	// storage.DSCLog.
 	dsc DSCProvider
 
+	// m17 is the optional provider backing /api/v1/m17/... routes
+	// (M17 link-setup log). nil disables the routes. Implemented by
+	// the daemon over the SQLite-backed storage.M17Log.
+	m17 M17Provider
+
 	// adsb is the optional provider backing /api/v1/adsb/...
 	// routes (ADS-B aircraft report log). nil disables the
 	// routes. Implemented by the daemon over the SQLite-backed
@@ -518,6 +523,11 @@ type ServerOptions struct {
 	// marine DSC sequences. Wired by the daemon over the
 	// SQLite-backed storage.DSCLog.
 	DSC DSCProvider
+	// M17, when non-nil, enables the
+	// GET /api/v1/m17/linksetups route serving recent decoded M17
+	// link-setup frames. Wired by the daemon over the SQLite-backed
+	// storage.M17Log.
+	M17 M17Provider
 	// ADSB, when non-nil, enables the
 	// GET /api/v1/adsb/aircraft route serving recent decoded
 	// Mode-S frames. Wired by the daemon over the SQLite-backed
@@ -630,6 +640,7 @@ func NewServer(opts ServerOptions) (*Server, error) {
 		aprs:           opts.APRS,
 		ais:            opts.AIS,
 		dsc:            opts.DSC,
+		m17:            opts.M17,
 		adsb:           opts.ADSB,
 		mdc1200:        opts.MDC1200,
 	}, nil
@@ -834,6 +845,7 @@ func (s *Server) routes() *http.ServeMux {
 	mux.HandleFunc("GET /api/v1/aprs/packets", s.handleAPRSPackets)
 	mux.HandleFunc("GET /api/v1/ais/vessels", s.handleAISMessages)
 	mux.HandleFunc("GET /api/v1/dsc/messages", s.handleDSCMessages)
+	mux.HandleFunc("GET /api/v1/m17/linksetups", s.handleM17LinkSetups)
 	mux.HandleFunc("GET /api/v1/adsb/aircraft", s.handleADSBAircraft)
 	mux.HandleFunc("GET /api/v1/mdc1200/messages", s.handleMDC1200Messages)
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -33,6 +33,7 @@ type Config struct {
 	DSC        DSCConfig        `yaml:"dsc"`
 	MDC1200    MDC1200Config    `yaml:"mdc1200"`
 	ADSB       ADSBConfig       `yaml:"adsb"`
+	M17        M17Config        `yaml:"m17"`
 	Web        WebConfig        `yaml:"web"`
 }
 
@@ -130,6 +131,27 @@ type ADSBChannelConfig struct {
 type ADSBBeastConfig struct {
 	Addr string `yaml:"addr"`
 	Name string `yaml:"name"` // log + metrics label
+}
+
+// M17Config configures the M17 digital-voice link-layer receiver.
+// Each entry pins an SDR to an M17 frequency and runs the DSP frontend
+// (FM demod → C4FM matched filter → symbol-timing recovery → 4FSK
+// slice → sync hunt → LICH reassembly → Link Setup Frame parse).
+// Decoded link metadata (source / destination callsigns, mode)
+// publishes on events.KindM17LinkSetup; storage.M17Log persists it to
+// the m17_log table and the REST endpoint at /api/v1/m17/linksetups
+// returns the recent rows. Voice (Codec2) decode is a later milestone.
+type M17Config struct {
+	Channels []M17ChannelConfig `yaml:"channels"`
+}
+
+// M17ChannelConfig describes one M17 channel to decode. Serial picks
+// the SDR; the daemon tunes it to FrequencyHz and runs the receiver
+// against its full IQ stream. M17 simplex calling is commonly
+// 144.975 MHz (2 m) / 433.475 MHz (70 cm) in many regions.
+type M17ChannelConfig struct {
+	Serial      string `yaml:"serial"`
+	FrequencyHz uint32 `yaml:"frequency_hz"`
 }
 
 // APRSConfig configures the APRS / AX.25 Bell-202 AFSK receiver.

--- a/internal/events/bus.go
+++ b/internal/events/bus.go
@@ -163,6 +163,13 @@ const (
 	// radio check, ...) and the CRC-valid flag. Surfaced over SSE / WS
 	// for the live MDC1200 panel.
 	KindMDC1200Message Kind = "mdc1200.message"
+
+	// KindM17LinkSetup fires when the M17 decoder reassembles a Link
+	// Setup Frame (via the stream-frame LICH path). Payload is a
+	// storage.M17LinkSetup carrying source / destination callsigns, the
+	// mode (voice / data / packet), channel-access number, and the
+	// CRC-valid flag. Surfaced over SSE / WS for the live M17 panel.
+	KindM17LinkSetup Kind = "m17.linksetup"
 )
 
 // Stage names a particular FEC / parser checkpoint inside a protocol

--- a/internal/radio/m17/decoder.go
+++ b/internal/radio/m17/decoder.go
@@ -1,0 +1,93 @@
+package m17
+
+import "sync/atomic"
+
+// M17 16-bit frame sync words (M17 spec, data-link layer).
+const (
+	SyncStream uint16 = 0xFF5D // stream (voice/data) frame
+	SyncLSF    uint16 = 0x55F7 // dedicated link-setup frame
+	SyncPacket uint16 = 0x75FF // packet frame
+)
+
+// Stream frame geometry (type-4 bits, after the 16-bit sync): the
+// first 96 bits are the Golay-coded LICH; the remaining 272 bits carry
+// the frame number + Codec2 payload (convolutionally coded — decoded by
+// the voice path, skipped here).
+const streamPayloadBits = 368
+
+type m17State uint8
+
+const (
+	stHunt m17State = iota // scanning the bit stream for a frame sync
+	stLICH                 // collecting the 96-bit LICH of a stream frame
+	stSkip                 // skipping the rest of the stream payload
+)
+
+// Decoder turns a demodulated M17 bit stream into Link Setup Frames.
+// Push one wire bit at a time (MSB-first within each dibit); a complete
+// LSF is returned (ok=true) once six LICH chunks reassemble it. Not safe
+// for concurrent use — one Decoder per channel.
+type Decoder struct {
+	st   m17State
+	reg  uint16 // sliding 16-bit window for sync hunt
+	lich [LICHBits]byte
+	n    int // bits collected in the current field
+	asm  *LICHAssembler
+
+	syncs      atomic.Uint64
+	lsfDecoded atomic.Uint64
+}
+
+// NewDecoder returns a ready Decoder.
+func NewDecoder() *Decoder {
+	return &Decoder{asm: NewLICHAssembler()}
+}
+
+// Push feeds one wire bit. Returns the LSF and ok=true when a stream's
+// LICH chunks have reassembled a complete link setup frame.
+func (d *Decoder) Push(bit byte) (LSF, bool) {
+	b := bit & 1
+	switch d.st {
+	case stHunt:
+		d.reg = (d.reg << 1) | uint16(b)
+		if d.reg == SyncStream {
+			d.syncs.Add(1)
+			d.st = stLICH
+			d.n = 0
+		}
+		// LSF / packet syncs are recognised but their payloads need the
+		// convolutional path; the LICH route (stream frames) carries the
+		// same metadata, so we wait for a stream frame.
+		return LSF{}, false
+	case stLICH:
+		d.lich[d.n] = b
+		d.n++
+		if d.n >= LICHBits {
+			d.st = stSkip
+			d.n = LICHBits // count payload bits already consumed
+			if lsf, ok := d.asm.Push(d.lich[:]); ok {
+				d.lsfDecoded.Add(1)
+				return lsf, true
+			}
+		}
+		return LSF{}, false
+	case stSkip:
+		d.n++
+		if d.n >= streamPayloadBits {
+			d.st = stHunt
+			d.reg = 0
+		}
+		return LSF{}, false
+	}
+	return LSF{}, false
+}
+
+// Stats reports cumulative counters.
+type Stats struct {
+	Syncs      uint64
+	LSFDecoded uint64
+}
+
+func (d *Decoder) Stats() Stats {
+	return Stats{Syncs: d.syncs.Load(), LSFDecoded: d.lsfDecoded.Load()}
+}

--- a/internal/radio/m17/lich.go
+++ b/internal/radio/m17/lich.go
@@ -1,0 +1,76 @@
+package m17
+
+import "github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+
+// LICHBits is the Link Information CHannel size in a stream frame: four
+// Golay(24,12) codewords = 96 coded bits carrying a 48-bit chunk.
+const LICHBits = 96
+
+// lichChunks is the number of LICH chunks that reassemble one LSF: each
+// chunk carries 40 of the 240 LSF bits.
+const lichChunks = 6
+
+// LICHAssembler reassembles the Link Setup Frame from the LICH chunks
+// embedded in successive stream frames. Each chunk carries 40 LSF bits
+// plus a modulo-6 counter naming its position; once all six positions
+// are seen the full 240-bit LSF is parsed and its CRC checked.
+type LICHAssembler struct {
+	lsf  [LSFBytes]byte
+	have [lichChunks]bool
+
+	golayErrors uint64
+}
+
+// NewLICHAssembler returns an empty assembler.
+func NewLICHAssembler() *LICHAssembler { return &LICHAssembler{} }
+
+// Push feeds one stream frame's 96-bit LICH (one byte per bit, 0/1,
+// MSB-first as received). It Golay-decodes the four codewords, extracts
+// the 40-bit LSF fragment and its counter, and — once all six fragments
+// are present — returns the parsed LSF with ok=true. A LICH with an
+// uncorrectable Golay codeword is dropped.
+func (a *LICHAssembler) Push(lich []byte) (LSF, bool) {
+	if len(lich) < LICHBits {
+		return LSF{}, false
+	}
+	var chunk uint64 // 48-bit reassembled chunk
+	for i := 0; i < 4; i++ {
+		var cw uint32
+		for j := 0; j < 24; j++ {
+			cw = cw<<1 | uint32(lich[i*24+j]&1)
+		}
+		data, errs := framing.GolayDecode24_12(cw)
+		if errs < 0 {
+			a.golayErrors++
+			return LSF{}, false // uncorrectable codeword
+		}
+		chunk = chunk<<12 | uint64(data&0x0FFF)
+	}
+
+	// chunk is 48 bits: top 40 = LSF fragment, next 3 = counter.
+	frag := chunk >> 8 // top 40 bits
+	cnt := int((chunk >> 5) & 0x07)
+	if cnt >= lichChunks {
+		return LSF{}, false
+	}
+	base := cnt * 5
+	for i := 0; i < 5; i++ {
+		a.lsf[base+i] = byte((frag >> uint(32-i*8)) & 0xFF)
+	}
+	a.have[cnt] = true
+
+	for _, h := range a.have {
+		if !h {
+			return LSF{}, false
+		}
+	}
+	lsf := ParseLSF(a.lsf[:])
+	a.reset()
+	return lsf, true
+}
+
+// reset clears the collected fragments after delivering an LSF so the
+// next transmission starts fresh.
+func (a *LICHAssembler) reset() {
+	a.have = [lichChunks]bool{}
+}

--- a/internal/radio/m17/m17.go
+++ b/internal/radio/m17/m17.go
@@ -1,0 +1,187 @@
+// Package m17 decodes the link layer of the M17 digital voice/data
+// protocol — an open, Codec2-based amateur mode (4FSK, 4800 sym/s).
+// This package owns the *metadata* path: it recovers the Link Setup
+// Frame (LSF) — source and destination callsigns, the TYPE field, and
+// the META block — and publishes it on the bus. The Codec2 voice
+// payload is a later milestone; this slice surfaces "who is
+// transmitting to whom, in what mode" without decoding audio.
+//
+// Two routes carry the LSF:
+//   - the dedicated LSF frame at the head of a transmission
+//     (convolutionally coded + punctured — decoded elsewhere), and
+//   - the LICH (Link Information CHannel) embedded in every stream
+//     frame, which carries 1/6 of the LSF Golay(24,12)-coded. Six
+//     consecutive LICH chunks reassemble the full LSF.
+//
+// This package implements the LICH route (Golay only, no convolutional
+// machinery), so a receiver tuned to an in-progress transmission picks
+// up the link metadata within ~240 ms. See lich.go.
+//
+// Constants (sync words, LSF layout, CRC-16 0x5935, base-40 alphabet,
+// dibit↔symbol map, LICH structure) are from the M17 specification.
+// The Golay(24,12) generator and LSF field parse are validated
+// end-to-end against a synthetic encoder; the exact Golay matrix of
+// real M17 traffic should be confirmed against a capture.
+//
+// Reference: M17 Protocol Specification (spec.m17project.org),
+// data-link layer.
+package m17
+
+import "strings"
+
+// LSFBits / LSFBytes is the Link Setup Frame size after FEC removal:
+// DST(48) + SRC(48) + TYPE(16) + META(112) + CRC(16) = 240 bits.
+const (
+	LSFBits  = 240
+	LSFBytes = LSFBits / 8 // 30
+)
+
+// base40 is the M17 address alphabet (index 0..39). Index 0 is the
+// blank/terminator; the rest are the callsign characters.
+const base40 = " ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-/."
+
+// broadcastAddr is the all-ones 48-bit address (the M17 broadcast
+// destination).
+const broadcastAddr uint64 = 0xFFFFFFFFFFFF
+
+// LSF is a decoded Link Setup Frame.
+type LSF struct {
+	Dst      string // destination callsign / "BROADCAST" / "#RESERVED"
+	Src      string // source callsign
+	Type     uint16 // raw TYPE field
+	Meta     []byte // 14-byte META block (nonce / GNSS / extended callsign)
+	CRCOK    bool   // CRC-16 over DST..META matched the trailing field
+	Stream   bool   // TYPE bit 0: stream (vs packet) mode
+	DataMode uint8  // TYPE bits 1..2: 1 = data, 2 = voice, 3 = voice+data
+	CAN      uint8  // TYPE bits 7..10: channel access number
+}
+
+// DecodeAddress turns a 48-bit M17 address into a callsign string.
+// Returns "BROADCAST" for the all-ones address, "#RESERVED" for values
+// above the encodable range, and "" for the reserved zero address.
+func DecodeAddress(addr uint64) string {
+	addr &= 0xFFFFFFFFFFFF
+	switch {
+	case addr == 0:
+		return ""
+	case addr == broadcastAddr:
+		return "BROADCAST"
+	case addr > 0xEE6B28000000: // > 40^9: not a base-40 callsign
+		return "#RESERVED"
+	}
+	var sb strings.Builder
+	for addr > 0 {
+		sb.WriteByte(base40[addr%40])
+		addr /= 40
+	}
+	return reverse(sb.String())
+}
+
+func reverse(s string) string {
+	b := []byte(s)
+	for i, j := 0, len(b)-1; i < j; i, j = i+1, j-1 {
+		b[i], b[j] = b[j], b[i]
+	}
+	return string(b)
+}
+
+// ParseLSF parses a 30-byte (240-bit) Link Setup Frame and verifies its
+// CRC-16. Never errors — a bad CRC sets CRCOK=false and the fields are
+// still populated (best-effort, for display of marginal decodes).
+func ParseLSF(b []byte) LSF {
+	var l LSF
+	if len(b) < LSFBytes {
+		return l
+	}
+	l.Dst = DecodeAddress(beUint48(b[0:6]))
+	l.Src = DecodeAddress(beUint48(b[6:12]))
+	l.Type = uint16(b[12])<<8 | uint16(b[13])
+	l.Meta = append([]byte(nil), b[14:28]...)
+	want := uint16(b[28])<<8 | uint16(b[29])
+	l.CRCOK = CRC16(b[0:28]) == want
+
+	l.Stream = l.Type&0x0001 != 0
+	l.DataMode = uint8((l.Type >> 1) & 0x03)
+	l.CAN = uint8((l.Type >> 7) & 0x0F)
+	return l
+}
+
+// String renders the LSF for log / panel display.
+func (l LSF) String() string {
+	mode := "packet"
+	if l.Stream {
+		mode = "stream"
+	}
+	dst := l.Dst
+	if dst == "" {
+		dst = "(none)"
+	}
+	return l.Src + " → " + dst + " [" + mode + " CAN=" + itoa(int(l.CAN)) + "]"
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b []byte
+	for n > 0 {
+		b = append([]byte{byte('0' + n%10)}, b...)
+		n /= 10
+	}
+	return string(b)
+}
+
+// ModeString labels the TYPE data-mode field (bits 1..2): 1 = data,
+// 2 = voice, 3 = voice+data, 0 = reserved. Packet-mode frames (TYPE
+// bit 0 clear) report "packet".
+func (l LSF) ModeString() string {
+	if !l.Stream {
+		return "packet"
+	}
+	switch l.DataMode {
+	case 1:
+		return "data"
+	case 2:
+		return "voice"
+	case 3:
+		return "voice+data"
+	}
+	return "reserved"
+}
+
+// MetaHex renders the 14-byte META block as a hex string.
+func (l LSF) MetaHex() string {
+	const hexdigits = "0123456789abcdef"
+	b := make([]byte, 0, len(l.Meta)*2)
+	for _, x := range l.Meta {
+		b = append(b, hexdigits[x>>4], hexdigits[x&0x0F])
+	}
+	return string(b)
+}
+
+// beUint48 reads a 48-bit big-endian unsigned integer.
+func beUint48(b []byte) uint64 {
+	var v uint64
+	for _, x := range b[:6] {
+		v = v<<8 | uint64(x)
+	}
+	return v
+}
+
+// CRC16 computes the M17 CRC-16 (polynomial 0x5935, initial value
+// 0xFFFF, MSB-first, no final XOR) over msg.
+func CRC16(msg []byte) uint16 {
+	const poly = 0x5935
+	crc := uint16(0xFFFF)
+	for _, b := range msg {
+		crc ^= uint16(b) << 8
+		for i := 0; i < 8; i++ {
+			if crc&0x8000 != 0 {
+				crc = (crc << 1) ^ poly
+			} else {
+				crc <<= 1
+			}
+		}
+	}
+	return crc
+}

--- a/internal/radio/m17/m17_test.go
+++ b/internal/radio/m17/m17_test.go
@@ -1,0 +1,130 @@
+package m17
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+)
+
+func encodeAddress(call string) uint64 {
+	var addr uint64
+	for _, r := range call {
+		idx := strings.IndexRune(base40, r)
+		if idx < 0 {
+			idx = 0
+		}
+		addr = addr*40 + uint64(idx)
+	}
+	return addr
+}
+
+func TestAddressRoundTrip(t *testing.T) {
+	for _, call := range []string{"AB1CDE", "W1AW", "N0CALL", "M17-USA"} {
+		addr := encodeAddress(call)
+		if got := DecodeAddress(addr); got != call {
+			t.Errorf("DecodeAddress(encode(%q)) = %q", call, got)
+		}
+	}
+	if DecodeAddress(broadcastAddr) != "BROADCAST" {
+		t.Error("broadcast address not decoded as BROADCAST")
+	}
+	if DecodeAddress(0) != "" {
+		t.Error("zero address should decode empty")
+	}
+}
+
+// buildLSF assembles a 30-byte LSF with a valid CRC.
+func buildLSF(dst, src string, typ uint16) [LSFBytes]byte {
+	var b [LSFBytes]byte
+	putBE48(b[0:6], encodeAddress(dst))
+	putBE48(b[6:12], encodeAddress(src))
+	b[12] = byte(typ >> 8)
+	b[13] = byte(typ)
+	// META left zero.
+	crc := CRC16(b[0:28])
+	b[28] = byte(crc >> 8)
+	b[29] = byte(crc)
+	return b
+}
+
+func putBE48(dst []byte, v uint64) {
+	for i := 5; i >= 0; i-- {
+		dst[i] = byte(v & 0xFF)
+		v >>= 8
+	}
+}
+
+// encodeLICHFrameBits builds one stream frame's wire bits: the 16-bit
+// stream sync, the Golay-coded 96-bit LICH for chunk cnt, then 272 zero
+// payload bits.
+func encodeLICHFrameBits(lsf [LSFBytes]byte, cnt int) []byte {
+	var frag uint64 // 40-bit LSF fragment
+	for i := 0; i < 5; i++ {
+		frag = frag<<8 | uint64(lsf[cnt*5+i])
+	}
+	chunk := (frag << 8) | (uint64(cnt) << 5) // 48 bits: frag(40) | cnt(3) | reserved(5)
+
+	var bits []byte
+	push := func(v uint32, n int) {
+		for i := n - 1; i >= 0; i-- {
+			bits = append(bits, byte((v>>uint(i))&1))
+		}
+	}
+	push(uint32(SyncStream), 16)
+	for i := 0; i < 4; i++ {
+		data12 := uint16((chunk >> uint(36-i*12)) & 0x0FFF)
+		push(GolayEncode24_12Wire(data12), 24)
+	}
+	for i := 0; i < streamPayloadBits-LICHBits; i++ {
+		bits = append(bits, 0)
+	}
+	return bits
+}
+
+// GolayEncode24_12Wire wraps the framing encoder for the test.
+func GolayEncode24_12Wire(data uint16) uint32 { return framing.GolayEncode24_12(data) }
+
+func TestDecodeLSFFromLICHStream(t *testing.T) {
+	lsf := buildLSF("M17-USA", "AB1CDE", 0x0005) // stream + voice
+	d := NewDecoder()
+
+	var got LSF
+	var ok bool
+	for cnt := 0; cnt < lichChunks; cnt++ {
+		for _, b := range encodeLICHFrameBits(lsf, cnt) {
+			if l, done := d.Push(b); done {
+				got, ok = l, true
+			}
+		}
+	}
+	if !ok {
+		t.Fatalf("no LSF decoded after 6 LICH chunks (stats %+v)", d.Stats())
+	}
+	if !got.CRCOK {
+		t.Error("CRCOK = false, want true")
+	}
+	if got.Src != "AB1CDE" {
+		t.Errorf("Src = %q, want AB1CDE", got.Src)
+	}
+	if got.Dst != "M17-USA" {
+		t.Errorf("Dst = %q, want M17-USA", got.Dst)
+	}
+	if !got.Stream {
+		t.Error("Stream = false, want true")
+	}
+	if got.DataMode != 2 {
+		t.Errorf("DataMode = %d, want 2 (voice)", got.DataMode)
+	}
+}
+
+func TestCRC16DetectsCorruption(t *testing.T) {
+	lsf := buildLSF("W1AW", "N0CALL", 0)
+	if !ParseLSF(lsf[:]).CRCOK {
+		t.Fatal("valid LSF: CRCOK false")
+	}
+	lsf[3] ^= 0x20
+	if ParseLSF(lsf[:]).CRCOK {
+		t.Error("corrupted LSF: CRCOK true")
+	}
+}

--- a/internal/radio/m17/receiver/receiver.go
+++ b/internal/radio/m17/receiver/receiver.go
@@ -1,0 +1,198 @@
+// Package receiver wires the M17 link-layer decoder onto a live IQ
+// stream from the iqtap broker. The pipeline is:
+//
+//	IQ chunks (Fs Hz, complex64)
+//	  → FM demod (internal/dsp/demod/fm.FM)
+//	  → real resampler to BaudHz × Oversample
+//	  → C4FM matched filter (internal/dsp/demod.C4FM)
+//	  → Mueller-Müller symbol-timing recovery
+//	  → 4FSK slice → dibit → bit pair
+//	  → m17.Decoder.Push(bit)
+//	  → events.KindM17LinkSetup on the bus
+//
+// One Receiver per configured M17 frequency. This frontend recovers
+// link-setup metadata (source / destination callsigns, mode) via the
+// stream-frame LICH path; the Codec2 voice payload is a later
+// milestone. The slicer deviation / symbol-timing constants are
+// nominal — like the POCSAG frontend, on-air calibration against a
+// real capture is a follow-up; the link-decode logic is covered by the
+// internal/radio/m17 package tests.
+package receiver
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync/atomic"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp"
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/demod"
+	dspsync "github.com/MattCheramie/GopherTrunk/internal/dsp/sync"
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/m17"
+	"github.com/MattCheramie/GopherTrunk/internal/storage"
+)
+
+// M17 4FSK signalling parameters (M17 spec, physical layer).
+const (
+	BaudHz      = 4800 // symbols/s
+	Oversample  = 10   // matched-filter samples per symbol
+	AudioRateHz = BaudHz * Oversample
+	rrcAlpha    = 0.5    // M17 RRC roll-off
+	deviationHz = 2400.0 // peak (outer-symbol) deviation
+	mmGain      = 0.05
+)
+
+// Options configures a Receiver.
+type Options struct {
+	InputRateHz uint32
+	SourceName  string
+	Bus         *events.Bus
+	Log         *slog.Logger
+}
+
+// Receiver runs an M17 link-layer decode pipeline against a stream of
+// IQ chunks.
+type Receiver struct {
+	source string
+	bus    *events.Bus
+	log    *slog.Logger
+
+	fm      *demod.FM
+	rsmp    *dsp.RealResampler
+	c4fm    *demod.C4FM
+	mm      *dspsync.MuellerMuller
+	decoder *m17.Decoder
+
+	demodBuf []float32
+	rsmpBuf  []float32
+	mfBuf    []float32
+	symBuf   []float32
+
+	samplesSeen atomic.Uint64
+	lsfEmitted  atomic.Uint64
+}
+
+// New constructs a Receiver. Returns an error if opts.Bus is nil or
+// InputRateHz is unset.
+func New(opts Options) (*Receiver, error) {
+	if opts.Bus == nil {
+		return nil, errors.New("m17/receiver: Bus is required")
+	}
+	if opts.InputRateHz == 0 {
+		return nil, errors.New("m17/receiver: InputRateHz is required")
+	}
+	log := opts.Log
+	if log == nil {
+		log = slog.Default()
+	}
+	out := uint32(AudioRateHz)
+	g := gcd(out, opts.InputRateHz)
+	L := int(out / g)
+	M := int(opts.InputRateHz / g)
+	if L == 0 || M == 0 {
+		return nil, fmt.Errorf("m17/receiver: bad resample ratio L=%d M=%d", L, M)
+	}
+	// Post-FM-demod soft values are phase steps in radians; the outer
+	// symbol lands at 2π·deviation/Fs, which is the slicer's scale.
+	dev := 2 * 3.141592653589793 * deviationHz / float64(AudioRateHz)
+	return &Receiver{
+		source:  opts.SourceName,
+		bus:     opts.Bus,
+		log:     log,
+		fm:      demod.NewFM(),
+		rsmp:    dsp.NewRealResampler(L, M, 16, 7.0),
+		c4fm:    demod.NewC4FM(Oversample, 8, rrcAlpha, dev),
+		mm:      dspsync.NewMuellerMuller(float64(Oversample), mmGain),
+		decoder: m17.NewDecoder(),
+	}, nil
+}
+
+// Process pumps IQ chunks through the decode pipeline until ctx
+// cancels or in closes.
+func (r *Receiver) Process(ctx context.Context, in <-chan []complex64) error {
+	if in == nil {
+		return errors.New("m17/receiver: input channel is nil")
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case chunk, ok := <-in:
+			if !ok {
+				return nil
+			}
+			r.processChunk(chunk)
+		}
+	}
+}
+
+func (r *Receiver) processChunk(chunk []complex64) {
+	r.samplesSeen.Add(uint64(len(chunk)))
+	r.demodBuf = r.fm.Process(r.demodBuf, chunk)
+	r.rsmpBuf = r.rsmp.Process(r.rsmpBuf, r.demodBuf)
+	r.mfBuf = r.c4fm.MatchedFilter(r.mfBuf, r.rsmpBuf)
+	r.symBuf = r.mm.Process(r.symBuf, r.mfBuf)
+	for _, s := range r.symBuf {
+		r.feedSymbol(s)
+	}
+}
+
+// feedSymbol slices one recovered symbol to a 4FSK level, maps it to
+// the M17 dibit, and pushes the two bits (MSB first) into the decoder.
+func (r *Receiver) feedSymbol(s float32) {
+	dibit := symbolToDibit(r.c4fm.Slice(s))
+	if lsf, ok := r.decoder.Push(byte(dibit >> 1)); ok {
+		r.publish(lsf)
+	}
+	if lsf, ok := r.decoder.Push(byte(dibit & 1)); ok {
+		r.publish(lsf)
+	}
+}
+
+// symbolToDibit maps a C4FM slicer level to the M17 dibit value
+// (M17 spec: +1→00, +3→01, -1→10, -3→11).
+func symbolToDibit(level int) int {
+	switch level {
+	case 1:
+		return 0
+	case 3:
+		return 1
+	case -1:
+		return 2
+	default: // -3
+		return 3
+	}
+}
+
+func (r *Receiver) publish(l m17.LSF) {
+	out := storage.M17LinkSetup{
+		Src:   l.Src,
+		Dst:   l.Dst,
+		Mode:  l.ModeString(),
+		CAN:   l.CAN,
+		Meta:  l.MetaHex(),
+		CRCOK: l.CRCOK,
+		Body:  l.String(),
+	}
+	r.bus.Publish(events.Event{Kind: events.KindM17LinkSetup, Payload: out})
+	r.lsfEmitted.Add(1)
+}
+
+// Stats reports cumulative counters.
+type Stats struct {
+	IQSamplesSeen uint64
+	LSFEmitted    uint64
+}
+
+func (r *Receiver) Stats() Stats {
+	return Stats{IQSamplesSeen: r.samplesSeen.Load(), LSFEmitted: r.lsfEmitted.Load()}
+}
+
+func gcd(a, b uint32) uint32 {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}

--- a/internal/radio/m17/receiver/receiver_test.go
+++ b/internal/radio/m17/receiver/receiver_test.go
@@ -1,0 +1,73 @@
+package receiver
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+)
+
+func TestNewRejectsBadOptions(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+
+	if _, err := New(Options{}); err == nil {
+		t.Error("New without Bus: want error")
+	}
+	if _, err := New(Options{Bus: bus}); err == nil {
+		t.Error("New without InputRateHz: want error")
+	}
+}
+
+func TestNewSetsUpDecoder(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	r, err := New(Options{InputRateHz: 480_000, Bus: bus})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if r.decoder == nil {
+		t.Error("decoder = nil, want non-nil")
+	}
+}
+
+func TestProcessPropagatesContextCancel(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	r, err := New(Options{InputRateHz: 480_000, Bus: bus})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	in := make(chan []complex64)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- r.Process(ctx, in) }()
+	cancel()
+	select {
+	case err := <-done:
+		if err != context.Canceled {
+			t.Errorf("Process err = %v, want context.Canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Process did not exit after ctx cancel")
+	}
+}
+
+func TestProcessNilInputErrors(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	r, _ := New(Options{InputRateHz: 480_000, Bus: bus})
+	if err := r.Process(context.Background(), nil); err == nil {
+		t.Error("Process with nil input: want error")
+	}
+}
+
+func TestSymbolToDibit(t *testing.T) {
+	cases := map[int]int{1: 0, 3: 1, -1: 2, -3: 3}
+	for level, want := range cases {
+		if got := symbolToDibit(level); got != want {
+			t.Errorf("symbolToDibit(%d) = %d, want %d", level, got, want)
+		}
+	}
+}

--- a/internal/storage/m17log.go
+++ b/internal/storage/m17log.go
@@ -1,0 +1,145 @@
+// M17 link-setup log writer — drains KindM17LinkSetup events off the
+// shared bus and writes one row per reassembled Link Setup Frame to the
+// SQLite m17_log table. Mirrors dsclog.go / aprslog.go.
+package storage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+)
+
+// M17LinkSetup is one persisted M17 link-setup frame.
+type M17LinkSetup struct {
+	ID         int64     `json:"id"`
+	ReceivedAt time.Time `json:"received_at"`
+	Src        string    `json:"src"`
+	Dst        string    `json:"dst"`
+	Mode       string    `json:"mode"` // "voice" | "data" | "voice+data" | "packet"
+	CAN        uint8     `json:"can"`  // channel-access number
+	Meta       string    `json:"meta"` // hex-encoded META block
+	CRCOK      bool      `json:"crc_ok"`
+	Body       string    `json:"body"` // display summary
+}
+
+// M17Log drains KindM17LinkSetup events until ctx cancels or the bus
+// closes.
+type M17Log struct {
+	db        *DB
+	bus       *events.Bus
+	log       *slog.Logger
+	sub       *events.Subscription
+	runDone   chan struct{}
+	closeOnce sync.Once
+}
+
+// NewM17Log wires the log to the bus. Subscription happens at
+// construction so events published before Run() begins aren't lost.
+func NewM17Log(db *DB, bus *events.Bus, logger *slog.Logger) (*M17Log, error) {
+	if db == nil {
+		return nil, errors.New("storage/m17log: DB is required")
+	}
+	if bus == nil {
+		return nil, errors.New("storage/m17log: events.Bus is required")
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	m := &M17Log{db: db, bus: bus, log: logger, runDone: make(chan struct{})}
+	m.sub = bus.Subscribe()
+	return m, nil
+}
+
+// Run drains KindM17LinkSetup events until ctx cancels or the bus closes.
+func (m *M17Log) Run(ctx context.Context) error {
+	defer close(m.runDone)
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case ev, ok := <-m.sub.C:
+			if !ok {
+				return nil
+			}
+			if ev.Kind != events.KindM17LinkSetup {
+				continue
+			}
+			ls, ok := ev.Payload.(M17LinkSetup)
+			if !ok {
+				continue
+			}
+			if err := m.insert(ls); err != nil {
+				m.log.Error("m17log: insert failed", "err", err)
+			}
+		}
+	}
+}
+
+func (m *M17Log) insert(ls M17LinkSetup) error {
+	at := ls.ReceivedAt
+	if at.IsZero() {
+		at = time.Now()
+	}
+	crcOK := 0
+	if ls.CRCOK {
+		crcOK = 1
+	}
+	_, err := m.db.SQL().Exec(
+		`INSERT INTO m17_log
+		 (received_at, src, dst, mode, can, meta, crc_ok, body)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		at.UnixNano(), ls.Src, ls.Dst, ls.Mode, ls.CAN, ls.Meta, crcOK, ls.Body,
+	)
+	return err
+}
+
+// Recent returns the most recent link-setup frames, newest first,
+// capped at limit. limit ≤ 0 picks 200; limit > 5000 caps at 5000.
+func (m *M17Log) Recent(limit int) ([]M17LinkSetup, error) {
+	if limit <= 0 {
+		limit = 200
+	}
+	if limit > 5000 {
+		limit = 5000
+	}
+	rows, err := m.db.SQL().Query(
+		`SELECT id, received_at, src, dst, mode, can, meta, crc_ok, body
+		 FROM m17_log ORDER BY received_at DESC LIMIT ?`, limit)
+	if err != nil {
+		return nil, fmt.Errorf("storage/m17log: query: %w", err)
+	}
+	defer rows.Close()
+	var out []M17LinkSetup
+	for rows.Next() {
+		var (
+			ls    M17LinkSetup
+			ns    int64
+			crcOK int
+		)
+		if err := rows.Scan(&ls.ID, &ns, &ls.Src, &ls.Dst, &ls.Mode,
+			&ls.CAN, &ls.Meta, &crcOK, &ls.Body); err != nil {
+			return nil, fmt.Errorf("storage/m17log: scan: %w", err)
+		}
+		ls.ReceivedAt = time.Unix(0, ns)
+		ls.CRCOK = crcOK != 0
+		out = append(out, ls)
+	}
+	return out, rows.Err()
+}
+
+// Close releases the bus subscription and waits for Run to drain.
+func (m *M17Log) Close() error {
+	m.closeOnce.Do(func() {
+		m.sub.Close()
+		select {
+		case <-m.runDone:
+		case <-time.After(time.Second):
+		}
+	})
+	return nil
+}

--- a/internal/storage/sqlite.go
+++ b/internal/storage/sqlite.go
@@ -222,6 +222,25 @@ CREATE TABLE IF NOT EXISTS dsc_log (
 CREATE INDEX IF NOT EXISTS idx_dsc_log_time      ON dsc_log(received_at);
 CREATE INDEX IF NOT EXISTS idx_dsc_log_self_mmsi ON dsc_log(self_mmsi, received_at);
 
+-- M17 link-setup frames persisted from the decoder pipeline. One row
+-- per reassembled Link Setup Frame: source / destination callsigns,
+-- the mode (voice / data / packet), channel-access number, hex META
+-- block, and the CRC-valid flag.
+CREATE TABLE IF NOT EXISTS m17_log (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    received_at INTEGER NOT NULL,            -- unix nanoseconds
+    src         TEXT    NOT NULL DEFAULT '', -- source callsign
+    dst         TEXT    NOT NULL DEFAULT '', -- destination / "BROADCAST"
+    mode        TEXT    NOT NULL DEFAULT '', -- "voice" | "data" | "packet" | ...
+    can         INTEGER NOT NULL DEFAULT 0,  -- channel-access number
+    meta        TEXT    NOT NULL DEFAULT '', -- hex-encoded META block
+    crc_ok      INTEGER NOT NULL DEFAULT 0,
+    body        TEXT    NOT NULL DEFAULT ''
+);
+
+CREATE INDEX IF NOT EXISTS idx_m17_log_time ON m17_log(received_at);
+CREATE INDEX IF NOT EXISTS idx_m17_log_src  ON m17_log(src, received_at);
+
 -- ADS-B / Mode-S frames persisted from the decoder pipeline. One
 -- row per decoded extended-squitter message: ICAO 24-bit address +
 -- kind (identification / airborne-pos / velocity / ...) + kind-


### PR DESCRIPTION
## Summary

Milestone 4 of the remaining-work roadmap and the first half of Phase 7: a decoder for the **link layer** of M17 (the open, Codec2-based digital-voice mode — 4FSK, 4800 sym/s). It recovers transmission *metadata* — source/destination callsigns and mode — without decoding audio. The pure-Go Codec2 voice path is the next milestone; this lands the link layer it will plug into.

DSC #448, ADS-B PPM #449, FLEX #478 already merged.

## What's new

- **`internal/radio/m17`** — the logical layer:
  - **LSF parse**: base-40 callsign decode (`DecodeAddress`, `BROADCAST`/reserved handling), TYPE → mode (voice/data/packet) + channel-access number, and CRC-16 (poly `0x5935`, init `0xFFFF`) over DST..META.
  - **LICH reassembly**: each stream frame carries 1/6 of the LSF, Golay(24,12)-coded; six chunks reassemble the 240-bit LSF using only Golay — no convolutional machinery — so an in-progress transmission is picked up within ~240 ms.
  - **Streaming `Decoder`**: sync hunt on the stream sync word `0xFF5D` → 96-bit LICH → reassembler → parsed LSF.
- **`internal/radio/m17/receiver`** — C4FM DSP frontend (FM demod → resample → matched filter → Mueller-Müller timing → 4FSK slice → dibit), publishing `events.KindM17LinkSetup`.
- **Storage** — `m17_log` table + `M17Log` subscriber + `M17LinkSetup` type.
- **API** — `GET /api/v1/m17/linksetups` + `M17Provider`.
- **Config + daemon** — `m17.channels`, construct + spawn loops, storage-log + API-provider wiring.

## Testing

- `go build/vet/test ./...` green.
- M17 link layer: base-40 callsign round-trip, **full LSF decode from a synthetic 6-chunk LICH stream** (Golay-coded) with CRC verified, mode/CAN parse, and CRC-corruption detection — all through the real reassembly + parse path.
- Receiver: API-surface + dibit-mapping tests (the C4FM frontend mirrors POCSAG's lifecycle-test approach; the link logic is covered in the parent package).

## Grounding & scope

Constants (sync words, LSF layout, CRC-16, base-40 alphabet, dibit↔symbol map `00→+1 01→+3 10→−1 11→−3`, LICH structure) are from the **M17 specification**. As with the DSC/FLEX frontends, the Golay matrix and the C4FM slicer-deviation / symbol-timing constants are validated against a synthetic encoder; real-capture calibration is a documented follow-up. The **Codec2 voice payload** (convolutionally coded stream payload) and the dedicated LSF-frame (P1 puncture + Viterbi) decode are deliberately deferred — the LICH route already surfaces the metadata.

Roadmap next: **Milestone 5 — pure-Go Codec2 port**, then **Milestone 6 — M17 voice integration** (wires Codec2 into this decoder's stream payload + the existing per-call WAV/composer pipeline).

---
_Generated by [Claude Code](https://claude.ai/code/session_01PccwhG9Ee9S2eqhtPbTWVc)_