### PR TITLE
storage/adsb: retention sweep for all log tables + currently-visible aircraft

### DIFF
--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -2916,6 +2916,10 @@ func (a adsbProvider) RecentAircraftReports(limit int) ([]storage.AircraftReport
 	return a.log.Recent(limit)
 }
 
+func (a adsbProvider) CurrentAircraft(maxAge time.Duration) ([]storage.AircraftReport, error) {
+	return a.log.CurrentAircraft(maxAge)
+}
+
 // mdc1200Provider adapts storage.MDC1200Log into api.MDC1200Provider
 // so the api package stays free of the storage import dependency.
 // Read-only — the decoder writes via the events bus.

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -1367,7 +1367,7 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 		}
 		d.mdc1200Log = mdl
 
-		if cfg.Retention.CallLogDays > 0 || cfg.Retention.FilesDays > 0 {
+		if cfg.Retention.CallLogDays > 0 || cfg.Retention.LogDays > 0 || cfg.Retention.FilesDays > 0 {
 			interval, err := retentionInterval(cfg.Retention.Interval)
 			if err != nil {
 				return nil, fmt.Errorf("daemon: retention.interval: %w", err)

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -106,6 +106,9 @@ recordings:
 
 retention:
   call_log_days: 30   # 0 disables call-log row sweep
+  log_days: 30        # 0 disables decoder-log sweep (pager / aprs /
+                      #  vessel / dsc / aircraft / mdc1200 / m17 /
+                      #  location logs, aged by received_at)
   files_days: 14      # 0 disables filesystem sweep
   interval: "1h"      # how often the sweeper runs
 

--- a/docs/adsb.md
+++ b/docs/adsb.md
@@ -199,14 +199,26 @@ the pair completes. `Prune()` evicts ICAOs that haven't
 transmitted in > 10 s so the state map doesn't grow with every
 aircraft ever seen.
 
+## Currently-visible aircraft
+
+`GET /api/v1/adsb/aircraft/current` returns the coalesced latest
+state of each aircraft seen recently — one row per ICAO, distinct
+from the raw per-message log at `/adsb/aircraft`. Because
+identification, position, and velocity arrive as separate Mode-S
+messages, `AircraftLog.CurrentAircraft(maxAge)` folds the most
+recent non-empty value of each field group (callsign, position,
+altitude, velocity) per ICAO over the horizon; `received_at` is the
+aircraft's last-seen time, rows are newest-last-seen first. Optional
+`?max_age_s=` bounds the horizon (default 300 s, max 3600 s). Powers
+a "currently visible aircraft" panel distinct from the raw message
+log.
+
 ## What's pending
 
-- **Aircraft tracker.** An `aircraft_current` SQL view (or a
-  separate live-state table indexed by ICAO) showing the
-  latest known position / altitude / callsign per aircraft,
-  joining identification + position + velocity rows over the
-  last few minutes. Powers a "currently visible aircraft"
-  panel distinct from the raw message log.
+- **Locally-referenced CPR.** Single-message position decode against
+  a configured receiver location, useful for the first seconds before
+  an even+odd CPR pair completes.
+
 ## Live map
 
 Aircraft positions (once the per-ICAO CPR pairing lands) render

--- a/internal/api/handlers_adsb.go
+++ b/internal/api/handlers_adsb.go
@@ -93,3 +93,35 @@ func (s *Server) handleADSBAircraft(w http.ResponseWriter, r *http.Request) {
 	}
 	writeJSON(w, http.StatusOK, out)
 }
+
+// handleADSBAircraftCurrent answers GET /api/v1/adsb/aircraft/current —
+// the coalesced latest state of each aircraft seen recently, one row
+// per ICAO (the "currently visible aircraft" view). Optional
+// ?max_age_s= bounds how long since last-seen an aircraft stays listed
+// (default 300 s, max 3600 s).
+func (s *Server) handleADSBAircraftCurrent(w http.ResponseWriter, r *http.Request) {
+	if s.adsb == nil {
+		writeError(w, http.StatusServiceUnavailable, "adsb subsystem not enabled")
+		return
+	}
+	maxAge := 300 * time.Second
+	if v := r.URL.Query().Get("max_age_s"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			if n > 3600 {
+				n = 3600
+			}
+			maxAge = time.Duration(n) * time.Second
+		}
+	}
+	rows, err := s.adsb.CurrentAircraft(maxAge)
+	if err != nil {
+		s.log.Error("api: adsb aircraft current", "err", err)
+		writeError(w, http.StatusInternalServerError, "query failed")
+		return
+	}
+	out := make([]AircraftReportDTO, 0, len(rows))
+	for _, rr := range rows {
+		out = append(out, aircraftReportToDTO(rr))
+	}
+	writeJSON(w, http.StatusOK, out)
+}

--- a/internal/api/handlers_adsb.go
+++ b/internal/api/handlers_adsb.go
@@ -13,6 +13,9 @@ import (
 // substitute a fake.
 type ADSBProvider interface {
 	RecentAircraftReports(limit int) ([]storage.AircraftReport, error)
+	// CurrentAircraft returns the coalesced latest state per ICAO seen
+	// within maxAge (≤ 0 → provider default).
+	CurrentAircraft(maxAge time.Duration) ([]storage.AircraftReport, error)
 }
 
 // AircraftReportDTO is the JSON wire shape for the adsb endpoint.

--- a/internal/api/handlers_adsb_test.go
+++ b/internal/api/handlers_adsb_test.go
@@ -13,6 +13,7 @@ import (
 
 type fakeADSBProvider struct {
 	reports []storage.AircraftReport
+	current []storage.AircraftReport
 }
 
 func (f *fakeADSBProvider) RecentAircraftReports(limit int) ([]storage.AircraftReport, error) {
@@ -20,6 +21,10 @@ func (f *fakeADSBProvider) RecentAircraftReports(limit int) ([]storage.AircraftR
 		return f.reports[:limit], nil
 	}
 	return f.reports, nil
+}
+
+func (f *fakeADSBProvider) CurrentAircraft(maxAge time.Duration) ([]storage.AircraftReport, error) {
+	return f.current, nil
 }
 
 func newADSBTestServer(t *testing.T, prov ADSBProvider) *httptest.Server {
@@ -121,5 +126,37 @@ func TestADSBAircraftRespectsLimit(t *testing.T) {
 	_ = json.NewDecoder(resp.Body).Decode(&got)
 	if len(got) != 3 {
 		t.Errorf("limit=3 len = %d, want 3", len(got))
+	}
+}
+
+func TestADSBAircraftCurrentReturns503WhenNotWired(t *testing.T) {
+	ts := newADSBTestServer(t, nil)
+	resp, err := http.Get(ts.URL + "/api/v1/adsb/aircraft/current")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want 503", resp.StatusCode)
+	}
+}
+
+func TestADSBAircraftCurrentReturnsList(t *testing.T) {
+	prov := &fakeADSBProvider{current: []storage.AircraftReport{
+		{ICAOHex: "DEF456", Callsign: "UAL1", HasPosition: true, Latitude: 37.5},
+	}}
+	ts := newADSBTestServer(t, prov)
+	resp, err := http.Get(ts.URL + "/api/v1/adsb/aircraft/current?max_age_s=120")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	var got []AircraftReportDTO
+	_ = json.NewDecoder(resp.Body).Decode(&got)
+	if len(got) != 1 || got[0].Callsign != "UAL1" {
+		t.Errorf("unexpected body: %+v", got)
 	}
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -847,6 +847,7 @@ func (s *Server) routes() *http.ServeMux {
 	mux.HandleFunc("GET /api/v1/dsc/messages", s.handleDSCMessages)
 	mux.HandleFunc("GET /api/v1/m17/linksetups", s.handleM17LinkSetups)
 	mux.HandleFunc("GET /api/v1/adsb/aircraft", s.handleADSBAircraft)
+	mux.HandleFunc("GET /api/v1/adsb/aircraft/current", s.handleADSBAircraftCurrent)
 	mux.HandleFunc("GET /api/v1/mdc1200/messages", s.handleMDC1200Messages)
 
 	// Embedded SPA at "/" — served only when the daemon was linked

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1005,9 +1005,14 @@ type MetricsConfig struct {
 // log rows and recorded files. Zero values disable the corresponding
 // sweep; both can be active independently.
 type RetentionConfig struct {
-	CallLogDays int    `yaml:"call_log_days"`
-	FilesDays   int    `yaml:"files_days"`
-	Interval    string `yaml:"interval"` // Go duration string; default 1h
+	CallLogDays int `yaml:"call_log_days"`
+	// LogDays sweeps the decoder log tables (pager_log, aprs_log,
+	// vessel_log, dsc_log, aircraft_log, mdc1200_log, m17_log,
+	// location_log): rows older than this many days are deleted. Zero
+	// (the default) disables the decoder-log sweep.
+	LogDays   int    `yaml:"log_days"`
+	FilesDays int    `yaml:"files_days"`
+	Interval  string `yaml:"interval"` // Go duration string; default 1h
 }
 
 // ToneOutConfig describes paging-tone profiles to monitor. Empty

--- a/internal/storage/aircraftcurrent_test.go
+++ b/internal/storage/aircraftcurrent_test.go
@@ -21,14 +21,14 @@ func TestCurrentAircraftCoalesces(t *testing.T) {
 	defer al.Close()
 
 	now := time.Now().UTC()
-	ins := func(ageSec int, icao uint32, kind, callsign string, hasPos int, lat, lon float64, gs float64) {
+	ins := func(ageSec int, icao uint32, kind, callsign string, hasPos int, lat, lon float64, gs int) {
 		t.Helper()
 		_, err := db.sql.Exec(
 			`INSERT INTO aircraft_log
 			 (received_at, icao, icao_hex, kind, callsign, category,
-			  has_position, latitude, longitude, has_altitude, altitude,
+			  has_position, latitude, longitude, has_altitude, altitude_ft,
 			  ground_speed_kn, track_deg, vertical_rate_fpm, crc_valid, raw_hex, body)
-			 VALUES (?, ?, ?, ?, ?, '', ?, ?, ?, 0, 0, ?, 0, 0, 1, '', '')`,
+			 VALUES (?, ?, ?, ?, ?, 0, ?, ?, ?, 0, 0, ?, 0, 0, 1, '', '')`,
 			now.Add(-time.Duration(ageSec)*time.Second).UnixNano(),
 			icao, "ABC123", kind, callsign, hasPos, lat, lon, gs)
 		if err != nil {
@@ -37,11 +37,11 @@ func TestCurrentAircraftCoalesces(t *testing.T) {
 	}
 
 	// ICAO 0xABC123: identification (oldest), then position, then velocity.
-	ins(120, 0xABC123, "identification", "UAL1", 0, 0, 0, 0)
-	ins(60, 0xABC123, "airborne-position", "", 1, 37.5, -122.0, 0)
-	ins(10, 0xABC123, "velocity", "", 0, 0, 0, 420.0)
+	ins(120, 0xABC123, "ident", "UAL1", 0, 0, 0, 0)
+	ins(60, 0xABC123, "airborne-pos", "", 1, 37.5, -122.0, 0)
+	ins(10, 0xABC123, "velocity", "", 0, 0, 0, 420)
 	// A second, stale aircraft outside the 5-min horizon.
-	ins(1000, 0xDEAD01, "identification", "STALE", 0, 0, 0, 0)
+	ins(1000, 0xDEAD01, "ident", "STALE", 0, 0, 0, 0)
 
 	cur, err := al.CurrentAircraft(5 * time.Minute)
 	if err != nil {
@@ -57,7 +57,7 @@ func TestCurrentAircraftCoalesces(t *testing.T) {
 	if !a.HasPosition || a.Latitude != 37.5 || a.Longitude != -122.0 {
 		t.Errorf("position not coalesced: %+v", a)
 	}
-	if a.GroundSpeedKn != 420.0 {
+	if a.GroundSpeedKn != 420 {
 		t.Errorf("GroundSpeedKn = %v, want 420 (from velocity msg)", a.GroundSpeedKn)
 	}
 }

--- a/internal/storage/aircraftcurrent_test.go
+++ b/internal/storage/aircraftcurrent_test.go
@@ -1,0 +1,78 @@
+package storage
+
+import (
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+)
+
+// TestCurrentAircraftCoalesces verifies that separate identification,
+// position, and velocity messages for one ICAO fold into a single
+// live-state record, and that stale aircraft fall outside the horizon.
+func TestCurrentAircraftCoalesces(t *testing.T) {
+	db := openTestDB(t)
+	bus := events.NewBus(8)
+	defer bus.Close()
+	al, err := NewAircraftLog(db, bus, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer al.Close()
+
+	now := time.Now().UTC()
+	ins := func(ageSec int, icao uint32, kind, callsign string, hasPos int, lat, lon float64, gs float64) {
+		t.Helper()
+		_, err := db.sql.Exec(
+			`INSERT INTO aircraft_log
+			 (received_at, icao, icao_hex, kind, callsign, category,
+			  has_position, latitude, longitude, has_altitude, altitude,
+			  ground_speed_kn, track_deg, vertical_rate_fpm, crc_valid, raw_hex, body)
+			 VALUES (?, ?, ?, ?, ?, '', ?, ?, ?, 0, 0, ?, 0, 0, 1, '', '')`,
+			now.Add(-time.Duration(ageSec)*time.Second).UnixNano(),
+			icao, "ABC123", kind, callsign, hasPos, lat, lon, gs)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// ICAO 0xABC123: identification (oldest), then position, then velocity.
+	ins(120, 0xABC123, "identification", "UAL1", 0, 0, 0, 0)
+	ins(60, 0xABC123, "airborne-position", "", 1, 37.5, -122.0, 0)
+	ins(10, 0xABC123, "velocity", "", 0, 0, 0, 420.0)
+	// A second, stale aircraft outside the 5-min horizon.
+	ins(1000, 0xDEAD01, "identification", "STALE", 0, 0, 0, 0)
+
+	cur, err := al.CurrentAircraft(5 * time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cur) != 1 {
+		t.Fatalf("CurrentAircraft = %d aircraft, want 1 (stale excluded)", len(cur))
+	}
+	a := cur[0]
+	if a.Callsign != "UAL1" {
+		t.Errorf("Callsign = %q, want UAL1 (from identification msg)", a.Callsign)
+	}
+	if !a.HasPosition || a.Latitude != 37.5 || a.Longitude != -122.0 {
+		t.Errorf("position not coalesced: %+v", a)
+	}
+	if a.GroundSpeedKn != 420.0 {
+		t.Errorf("GroundSpeedKn = %v, want 420 (from velocity msg)", a.GroundSpeedKn)
+	}
+}
+
+func TestCurrentAircraftEmpty(t *testing.T) {
+	db := openTestDB(t)
+	bus := events.NewBus(8)
+	defer bus.Close()
+	al, _ := NewAircraftLog(db, bus, nil)
+	defer al.Close()
+	cur, err := al.CurrentAircraft(0) // default horizon
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cur) != 0 {
+		t.Errorf("empty table → %d aircraft, want 0", len(cur))
+	}
+}

--- a/internal/storage/aircraftlog.go
+++ b/internal/storage/aircraftlog.go
@@ -192,6 +192,95 @@ func (a *AircraftLog) Recent(limit int) ([]AircraftReport, error) {
 	return out, rows.Err()
 }
 
+// CurrentAircraft returns the latest known state of each aircraft seen
+// within maxAge, one row per ICAO. Because aircraft_log stores one
+// message type per row (identification, position, and velocity arrive
+// as separate Mode-S messages), this coalesces the most recent
+// non-empty value of each field group — callsign, position, altitude,
+// velocity — into a single live-state record. ReceivedAt is the
+// aircraft's last-seen time. Rows are newest-last-seen first.
+//
+// maxAge ≤ 0 defaults to 5 minutes. This powers the "currently visible
+// aircraft" panel, distinct from the raw message log Recent returns.
+func (a *AircraftLog) CurrentAircraft(maxAge time.Duration) ([]AircraftReport, error) {
+	if maxAge <= 0 {
+		maxAge = 5 * time.Minute
+	}
+	cutoff := time.Now().Add(-maxAge).UnixNano()
+	rows, err := a.db.SQL().Query(
+		`SELECT received_at, icao, icao_hex, kind, callsign, category,
+		        has_position, latitude, longitude, has_altitude, altitude,
+		        ground_speed_kn, track_deg, vertical_rate_fpm
+		 FROM aircraft_log WHERE received_at >= ? ORDER BY received_at ASC`,
+		cutoff)
+	if err != nil {
+		return nil, fmt.Errorf("storage/aircraftlog: current query: %w", err)
+	}
+	defer rows.Close()
+
+	// Fold rows in ascending time order so the last write of each field
+	// group wins. cur keys by ICAO; order preserves first-seen sequence
+	// for a stable sort tiebreak.
+	cur := make(map[uint32]*AircraftReport)
+	var order []uint32
+	for rows.Next() {
+		var (
+			r      AircraftReport
+			ns     int64
+			hasPos int
+			hasAlt int
+		)
+		if err := rows.Scan(&ns, &r.ICAO, &r.ICAOHex, &r.Kind, &r.Callsign,
+			&r.Category, &hasPos, &r.Latitude, &r.Longitude, &hasAlt,
+			&r.Altitude, &r.GroundSpeedKn, &r.TrackDeg, &r.VerticalRateFPM); err != nil {
+			return nil, fmt.Errorf("storage/aircraftlog: current scan: %w", err)
+		}
+		at := time.Unix(0, ns)
+		c := cur[r.ICAO]
+		if c == nil {
+			c = &AircraftReport{ICAO: r.ICAO}
+			cur[r.ICAO] = c
+			order = append(order, r.ICAO)
+		}
+		c.ReceivedAt = at // ASC order → final assignment is last-seen
+		if r.ICAOHex != "" {
+			c.ICAOHex = r.ICAOHex
+		}
+		if r.Callsign != "" {
+			c.Callsign = r.Callsign
+		}
+		if r.Category != "" {
+			c.Category = r.Category
+		}
+		if hasPos != 0 {
+			c.HasPosition = true
+			c.Latitude = r.Latitude
+			c.Longitude = r.Longitude
+		}
+		if hasAlt != 0 {
+			c.HasAltitude = true
+			c.Altitude = r.Altitude
+		}
+		if r.Kind == "velocity" {
+			c.GroundSpeedKn = r.GroundSpeedKn
+			c.TrackDeg = r.TrackDeg
+			c.VerticalRateFPM = r.VerticalRateFPM
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	out := make([]AircraftReport, 0, len(order))
+	for _, icao := range order {
+		out = append(out, *cur[icao])
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].ReceivedAt.After(out[j].ReceivedAt)
+	})
+	return out, nil
+}
+
 // Close releases the bus subscription and waits for Run to drain.
 func (a *AircraftLog) Close() error {
 	a.closeOnce.Do(func() {

--- a/internal/storage/aircraftlog.go
+++ b/internal/storage/aircraftlog.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sort"
 	"sync"
 	"time"
 
@@ -209,7 +210,7 @@ func (a *AircraftLog) CurrentAircraft(maxAge time.Duration) ([]AircraftReport, e
 	cutoff := time.Now().Add(-maxAge).UnixNano()
 	rows, err := a.db.SQL().Query(
 		`SELECT received_at, icao, icao_hex, kind, callsign, category,
-		        has_position, latitude, longitude, has_altitude, altitude,
+		        has_position, latitude, longitude, has_altitude, altitude_ft,
 		        ground_speed_kn, track_deg, vertical_rate_fpm
 		 FROM aircraft_log WHERE received_at >= ? ORDER BY received_at ASC`,
 		cutoff)
@@ -249,7 +250,7 @@ func (a *AircraftLog) CurrentAircraft(maxAge time.Duration) ([]AircraftReport, e
 		if r.Callsign != "" {
 			c.Callsign = r.Callsign
 		}
-		if r.Category != "" {
+		if r.Category != 0 {
 			c.Category = r.Category
 		}
 		if hasPos != 0 {

--- a/internal/storage/retention.go
+++ b/internal/storage/retention.go
@@ -14,7 +14,8 @@ import (
 // decoderLogTables are the append-only decoder log tables keyed by a
 // received_at (unix-nanosecond) column. The sweeper deletes rows older
 // than LogRowMaxAge from each. call_log is swept separately because its
-// timestamp column is started_at.
+// timestamp column is started_at; location_log is swept separately
+// because its timestamp column is reported_at.
 var decoderLogTables = []string{
 	"pager_log",
 	"aprs_log",
@@ -23,7 +24,6 @@ var decoderLogTables = []string{
 	"aircraft_log",
 	"mdc1200_log",
 	"m17_log",
-	"location_log",
 }
 
 // Retention deletes old data on a schedule:
@@ -145,13 +145,20 @@ func (r *Retention) deleteOldRows(ctx context.Context) (int64, error) {
 }
 
 // deleteOldLogRows deletes rows older than logAge from one decoder log
-// table (keyed by its received_at column). The table name comes from
-// the fixed decoderLogTables allow-list, never from user input, so the
-// string interpolation is safe.
+// table keyed by received_at.
 func (r *Retention) deleteOldLogRows(ctx context.Context, table string) (int64, error) {
+	return r.deleteOldByColumn(ctx, table, "received_at")
+}
+
+// deleteOldByColumn deletes rows older than logAge from table, keyed by
+// the named unix-nanosecond timestamp column. Both table and column
+// come from fixed in-code constants (the decoderLogTables allow-list or
+// a literal), never from user input, so the string interpolation is
+// safe.
+func (r *Retention) deleteOldByColumn(ctx context.Context, table, col string) (int64, error) {
 	cutoff := time.Now().Add(-r.logAge).UnixNano()
 	res, err := r.db.sql.ExecContext(ctx,
-		`DELETE FROM `+table+` WHERE received_at < ?`, cutoff)
+		`DELETE FROM `+table+` WHERE `+col+` < ?`, cutoff)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/storage/retention.go
+++ b/internal/storage/retention.go
@@ -11,19 +11,38 @@ import (
 	"time"
 )
 
+// decoderLogTables are the append-only decoder log tables keyed by a
+// received_at (unix-nanosecond) column. The sweeper deletes rows older
+// than LogRowMaxAge from each. call_log is swept separately because its
+// timestamp column is started_at.
+var decoderLogTables = []string{
+	"pager_log",
+	"aprs_log",
+	"vessel_log",
+	"dsc_log",
+	"aircraft_log",
+	"mdc1200_log",
+	"m17_log",
+	"location_log",
+}
+
 // Retention deletes old data on a schedule:
 //  1. call_log rows with started_at older than CallRowMaxAge.
-//  2. WAV / raw files under FilesRoot whose modification time is older
+//  2. decoder log-table rows (pager_log, aprs_log, vessel_log, dsc_log,
+//     aircraft_log, mdc1200_log, m17_log, location_log) with
+//     received_at older than LogRowMaxAge.
+//  3. WAV / raw files under FilesRoot whose modification time is older
 //     than FilesMaxAge.
 //
 // File deletion is opt-in by setting FilesRoot; an empty value skips
 // the filesystem sweep. The sweeper is idempotent and safe to run
-// concurrently with the call-log writer (SQLite serialises).
+// concurrently with the log writers (SQLite serialises).
 type Retention struct {
 	db       *DB
 	log      *slog.Logger
 	files    string
 	dbAge    time.Duration
+	logAge   time.Duration
 	filesAge time.Duration
 	interval time.Duration
 }
@@ -34,9 +53,14 @@ type RetentionOptions struct {
 	// FilesRoot is the directory the voice recorder writes WAV / raw
 	// files under. Empty disables the filesystem sweep.
 	FilesRoot string
-	// CallRowMaxAge: rows with started_at older than this are deleted.
-	// Zero (the default) disables row deletion.
+	// CallRowMaxAge: call_log rows with started_at older than this are
+	// deleted. Zero (the default) disables call-row deletion.
 	CallRowMaxAge time.Duration
+	// LogRowMaxAge: decoder log-table rows (pager_log, aprs_log,
+	// vessel_log, dsc_log, aircraft_log, mdc1200_log, m17_log,
+	// location_log) with received_at older than this are deleted. Zero
+	// (the default) disables decoder-log deletion.
+	LogRowMaxAge time.Duration
 	// FilesMaxAge: files older than this (mtime) are deleted. Zero
 	// disables file deletion.
 	FilesMaxAge time.Duration
@@ -61,6 +85,7 @@ func NewRetention(opts RetentionOptions) (*Retention, error) {
 		log:      log,
 		files:    opts.FilesRoot,
 		dbAge:    opts.CallRowMaxAge,
+		logAge:   opts.LogRowMaxAge,
 		filesAge: opts.FilesMaxAge,
 		interval: opts.Interval,
 	}, nil
@@ -91,6 +116,16 @@ func (r *Retention) SweepOnce(ctx context.Context) {
 			r.log.Info("retention: deleted call rows", "count", n)
 		}
 	}
+	if r.db != nil && r.logAge > 0 {
+		for _, table := range decoderLogTables {
+			n, err := r.deleteOldLogRows(ctx, table)
+			if err != nil {
+				r.log.Warn("retention: log sweep failed", "table", table, "err", err)
+			} else if n > 0 {
+				r.log.Info("retention: deleted log rows", "table", table, "count", n)
+			}
+		}
+	}
 	if r.files != "" && r.filesAge > 0 {
 		if n, err := r.deleteOldFiles(); err != nil {
 			r.log.Warn("retention: file sweep failed", "err", err)
@@ -103,6 +138,20 @@ func (r *Retention) SweepOnce(ctx context.Context) {
 func (r *Retention) deleteOldRows(ctx context.Context) (int64, error) {
 	cutoff := time.Now().Add(-r.dbAge).UnixNano()
 	res, err := r.db.sql.ExecContext(ctx, `DELETE FROM call_log WHERE started_at < ?`, cutoff)
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected()
+}
+
+// deleteOldLogRows deletes rows older than logAge from one decoder log
+// table (keyed by its received_at column). The table name comes from
+// the fixed decoderLogTables allow-list, never from user input, so the
+// string interpolation is safe.
+func (r *Retention) deleteOldLogRows(ctx context.Context, table string) (int64, error) {
+	cutoff := time.Now().Add(-r.logAge).UnixNano()
+	res, err := r.db.sql.ExecContext(ctx,
+		`DELETE FROM `+table+` WHERE received_at < ?`, cutoff)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/storage/retention_test.go
+++ b/internal/storage/retention_test.go
@@ -56,6 +56,78 @@ func TestRetentionDeletesOldRows(t *testing.T) {
 	}
 }
 
+// TestRetentionLogSweepEveryTable verifies the received_at delete path
+// is valid SQL for every table in decoderLogTables — a typo or a table
+// missing its received_at column would surface here as an error. Run
+// against empty tables so it doesn't depend on each table's NOT NULL
+// column set.
+func TestRetentionLogSweepEveryTable(t *testing.T) {
+	db := openTestDB(t)
+	r, err := NewRetention(RetentionOptions{DB: db, LogRowMaxAge: 24 * time.Hour})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, table := range decoderLogTables {
+		if _, err := r.deleteOldLogRows(context.Background(), table); err != nil {
+			t.Errorf("deleteOldLogRows(%q): %v", table, err)
+		}
+	}
+}
+
+// TestRetentionDeletesOldLogRows checks the age cutoff on a
+// representative table (m17_log) end-to-end through SweepOnce.
+func TestRetentionDeletesOldLogRows(t *testing.T) {
+	db := openTestDB(t)
+	now := time.Now().UTC()
+	insert := func(ageHours int, src string) {
+		t.Helper()
+		_, err := db.sql.Exec(
+			`INSERT INTO m17_log (received_at, src, dst) VALUES (?, ?, ?)`,
+			now.Add(-time.Duration(ageHours)*time.Hour).UnixNano(), src, "M17-USA")
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	insert(48, "OLD")
+	insert(1, "FRESH")
+
+	r, err := NewRetention(RetentionOptions{DB: db, LogRowMaxAge: 24 * time.Hour})
+	if err != nil {
+		t.Fatal(err)
+	}
+	r.SweepOnce(context.Background())
+
+	var src string
+	var n int
+	if err := db.sql.QueryRow(`SELECT COUNT(*), COALESCE(MIN(src), '') FROM m17_log`).Scan(&n, &src); err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 || src != "FRESH" {
+		t.Errorf("after sweep: %d rows (src=%q), want 1 (FRESH)", n, src)
+	}
+}
+
+// TestRetentionLogSweepDisabledByDefault confirms a zero LogRowMaxAge
+// leaves the decoder-log rows untouched.
+func TestRetentionLogSweepDisabledByDefault(t *testing.T) {
+	db := openTestDB(t)
+	old := time.Now().Add(-100 * 24 * time.Hour).UnixNano()
+	if _, err := db.sql.Exec(`INSERT INTO m17_log (received_at, src, dst) VALUES (?, ?, ?)`,
+		old, "AB1CDE", "M17-USA"); err != nil {
+		t.Fatal(err)
+	}
+	// Only CallRowMaxAge set — the log sweep must not run.
+	r, _ := NewRetention(RetentionOptions{DB: db, CallRowMaxAge: time.Hour})
+	r.SweepOnce(context.Background())
+	var n int
+	if err := db.sql.QueryRow(`SELECT COUNT(*) FROM m17_log`).Scan(&n); err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Errorf("m17_log: %d rows, want 1 (log sweep should be disabled)", n)
+	}
+}
+
 func TestRetentionDeletesOldFiles(t *testing.T) {
 	dir := t.TempDir()
 	now := time.Now()

--- a/internal/storage/retention_test.go
+++ b/internal/storage/retention_test.go
@@ -57,10 +57,10 @@ func TestRetentionDeletesOldRows(t *testing.T) {
 }
 
 // TestRetentionLogSweepEveryTable verifies the received_at delete path
-// is valid SQL for every table in decoderLogTables — a typo or a table
-// missing its received_at column would surface here as an error. Run
-// against empty tables so it doesn't depend on each table's NOT NULL
-// column set.
+// is valid SQL for every table in decoderLogTables plus the special
+// location_log (reported_at) path — a typo or a table missing its
+// timestamp column would surface here. Run against empty tables so it
+// doesn't depend on each table's NOT NULL column set.
 func TestRetentionLogSweepEveryTable(t *testing.T) {
 	db := openTestDB(t)
 	r, err := NewRetention(RetentionOptions{DB: db, LogRowMaxAge: 24 * time.Hour})
@@ -72,10 +72,13 @@ func TestRetentionLogSweepEveryTable(t *testing.T) {
 			t.Errorf("deleteOldLogRows(%q): %v", table, err)
 		}
 	}
+	if _, err := r.deleteOldByColumn(context.Background(), "location_log", "reported_at"); err != nil {
+		t.Errorf("deleteOldByColumn(location_log, reported_at): %v", err)
+	}
 }
 
-// TestRetentionDeletesOldLogRows checks the age cutoff on a
-// representative table (m17_log) end-to-end through SweepOnce.
+// TestRetentionDeletesOldLogRows checks the age cutoff end-to-end
+// through SweepOnce on a representative table (m17_log).
 func TestRetentionDeletesOldLogRows(t *testing.T) {
 	db := openTestDB(t)
 	now := time.Now().UTC()
@@ -97,8 +100,8 @@ func TestRetentionDeletesOldLogRows(t *testing.T) {
 	}
 	r.SweepOnce(context.Background())
 
-	var src string
 	var n int
+	var src string
 	if err := db.sql.QueryRow(`SELECT COUNT(*), COALESCE(MIN(src), '') FROM m17_log`).Scan(&n, &src); err != nil {
 		t.Fatal(err)
 	}
@@ -108,7 +111,7 @@ func TestRetentionDeletesOldLogRows(t *testing.T) {
 }
 
 // TestRetentionLogSweepDisabledByDefault confirms a zero LogRowMaxAge
-// leaves the decoder-log rows untouched.
+// leaves decoder-log rows untouched even when CallRowMaxAge is set.
 func TestRetentionLogSweepDisabledByDefault(t *testing.T) {
 	db := openTestDB(t)
 	old := time.Now().Add(-100 * 24 * time.Hour).UnixNano()
@@ -116,7 +119,6 @@ func TestRetentionLogSweepDisabledByDefault(t *testing.T) {
 		old, "AB1CDE", "M17-USA"); err != nil {
 		t.Fatal(err)
 	}
-	// Only CallRowMaxAge set — the log sweep must not run.
 	r, _ := NewRetention(RetentionOptions{DB: db, CallRowMaxAge: time.Hour})
 	r.SweepOnce(context.Background())
 	var n int


### PR DESCRIPTION
## Summary

Milestone 7 of the remaining-work roadmap — the non-blocking follow-ups. This PR lands the two highest-value, fully-testable backend items:

1. **Retention sweeper for all decoder log tables** — the plan flagged this as a precondition for shipping each new log table, but in practice the sweeper only ever deleted `call_log` rows (+ recording files). `pager_log`, `aprs_log`, `vessel_log`, `dsc_log`, `aircraft_log`, `mdc1200_log`, `m17_log`, and `location_log` grew unbounded.
   - New `LogRowMaxAge` knob deletes rows older than the cutoff from each decoder log table (keyed by `received_at`), via a fixed table allow-list (no user input in the SQL).
   - `retention.log_days` config drives it; zero (default) disables. Daemon wires it and constructs the sweeper when `log_days` is set.

2. **Currently-visible aircraft endpoint** — `aircraft_log` stores one Mode-S message type per row (identification / position / velocity arrive separately), so the raw log can't answer "what's flying right now".
   - `AircraftLog.CurrentAircraft(maxAge)` coalesces the latest non-empty value of each field group (callsign / position / altitude / velocity) per ICAO over a horizon, newest-last-seen first — the plan's `aircraft_current` view, done as a query method so the horizon is a runtime parameter.
   - `GET /api/v1/adsb/aircraft/current` (`?max_age_s=`, default 300, max 3600).

## Testing

- `go build/vet/test ./...` green.
- Retention: per-table SQL-validity sweep (catches a bad table/column name), end-to-end age cutoff on `m17_log`, disabled-by-default path.
- Aircraft-current: coalescing across id/position/velocity messages with a stale aircraft excluded, empty-table path, and handler 200 + 503 paths.

Docs: `docs/adsb.md`, `docs/hardening.md`, `config.example.yaml` updated.

## Remaining Milestone 7 items (deferred)

The live-map items (tile config `api.tiles.*`, receiver-centred empty-state fallback, track-history polyline) are frontend-coupled (React/TypeScript + the JS build) and are better landed as their own PR. The bus-saturation soak test and APRS/AIS real-fixture validation also remain. **Milestone 5 (pure-Go Codec2)** is still the deferred long pole — per our discussion it needs the upstream BSD tables + `c2dec` reference fixtures vendored, which is a multi-session effort on its own.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PccwhG9Ee9S2eqhtPbTWVc)_