### PR TITLE
rtlsdr: make the USB warmup write non-fatal (fix Windows ERROR_GEN_FAILURE)

### DIFF
--- a/docs/install-windows.md
+++ b/docs/install-windows.md
@@ -189,6 +189,7 @@ edits or per-system data.
 | `sdr list` prints nothing              | Zadig WinUSB swap didn't take — see step 3.        |
 | `usb: device disconnected` mid-stream  | The DVB driver re-attached itself — re-run Zadig. |
 | `WinUsb_Initialize` fails              | The dongle is bound to the wrong driver — re-run Zadig and pick **WinUSB**. |
+| `ERROR_GEN_FAILURE` / `device rejected request` on `sdr list` | Clone-dongle cold-start quirk — the first USB control transfer after open is NAK'd. v0.2.x absorbs this automatically (the warmup probe is sacrificial). If it still persists: try a different USB port (front vs. rear use different host controllers), avoid hubs and extension cables, and confirm `gophertrunk sdr doctor` shows **WinUSB** bound to interface 0. |
 | Smart Screen blocks the installer      | Right-click → Properties → Unblock, or **More info → Run anyway**. |
 
 For anything else: open an issue at

--- a/internal/sdr/rtlsdr/purego/driver.go
+++ b/internal/sdr/rtlsdr/purego/driver.go
@@ -153,14 +153,18 @@ func (d *Driver) Open(idx int) (sdr.Device, error) {
 // explicit "kick" to arm the bridge for the multi-byte OUT that
 // follows, even though the demod register already holds the on-value.
 //
-// The whole sequence is wrapped in a bounded reset+retry envelope on
-// EPIPE / ErrDeviceGone / ErrTimeout / ErrPipeStalled — covers the
-// librtlsdr "dummy write probe" recovery case (warmup phase), the
-// NESDR v5 cold-boot I²C-bridge-stall case (issue #248, the chip
-// rejecting the first 17-byte tuner burst even after PR #262's fresh
-// wire toggle is on the wire), and the Windows clone-dongle wedge
-// where one device-rebind isn't enough to clear a stale firmware
-// state. Up to four resets per Open with exponential backoff
+// The whole sequence (InitBaseband onward) is wrapped in a bounded
+// reset+retry envelope on EPIPE / ErrDeviceGone / ErrTimeout /
+// ErrPipeStalled. The warmup dummy write itself is no longer part of
+// this envelope — its failure is swallowed in runBringup (librtlsdr
+// parity; resetting on a warmup NAK only re-arms the first-transfer
+// NAK on the next pass). The envelope covers the NESDR v5 cold-boot
+// I²C-bridge-stall case (issue #248, the chip rejecting the first
+// 17-byte tuner burst even after PR #262's fresh wire toggle is on
+// the wire), and the Windows clone-dongle wedge where one
+// device-rebind isn't enough to clear a stale firmware state — both
+// of which surface from InitBaseband or later. Up to four resets per
+// Open with exponential backoff
 // (200ms / 400ms / 800ms / 1200ms) between the failing attempt and
 // the next retry — gives the WinUSB stack and device firmware time
 // to settle before the next bring-up pass. Worst-case open delay
@@ -283,13 +287,33 @@ var warmupSettleDuration = 10 * time.Millisecond
 // All errors are wrapped with a stage prefix so the outer openDevice
 // can spot resetable EPIPE / ErrDeviceGone via errors.Is.
 func runBringup(demod *rtl2832u.Demod) (tuners.Tuner, error) {
+	// librtlsdr's rtlsdr_open issues this USB-sysctl write purely as a
+	// throwaway "dummy write": its only job is to absorb the
+	// first-control-transfer NAK that some clone dongles (and devices
+	// left dirty by a crashed process) emit right after the interface
+	// is claimed. librtlsdr never inspects its result — it proceeds
+	// straight to rtlsdr_init_baseband. We match that exactly: a warmup
+	// failure is EXPECTED on the affected hardware and must NOT abort
+	// bring-up, because the transfer that actually has to land is the
+	// *next* one (InitBaseband's byte-identical step 0).
+	//
+	// Treating warmup as a hard gate — reset + re-issue it on failure,
+	// as this code did before — re-arms the same first-transfer NAK on
+	// every pass (each transport.Reset re-opens the device), so the
+	// dongle never reaches InitBaseband and Open fails after exhausting
+	// the retry envelope. That's the Windows ERROR_GEN_FAILURE warmup
+	// failure reported against the RTL-SDR clone path (follow-up to the
+	// issue #395 settle fix). Genuine stalls are still caught: if the
+	// device is truly wedged, InitBaseband's step 0 fails too and the
+	// outer openDevice envelope resets + retries the whole sequence.
 	if err := demod.WarmupUSBSysctl(); err != nil {
-		return nil, fmt.Errorf("rtlsdr: USB warmup: %w%s", err, tunerBringupHint(err))
+		usb.DebugLogf("bringup",
+			"sacrificial warmup write failed (expected on some clone dongles / dirty device state), proceeding to InitBaseband: %v", err)
 	}
 	// The first write inside InitBaseband is byte-identical to the
 	// warmup probe — give the dongle's firmware a moment to settle
-	// before re-sending it. See warmupSettleDuration above for the
-	// full reasoning (issue #395).
+	// before sending it. See warmupSettleDuration above for the full
+	// reasoning (issue #395).
 	time.Sleep(warmupSettleDuration)
 	if err := demod.InitBaseband(); err != nil {
 		return nil, fmt.Errorf("rtlsdr: init baseband: %w%s", err, tunerBringupHint(err))
@@ -361,7 +385,7 @@ func claimBusyHint(err error) string {
 		return " (hint: the dongle is already claimed by another process —" +
 			" close any other SDR app holding it (rtl_test, SDR++, GQRX," +
 			" or a second gophertrunk instance) and retry." +
-			" See https://mattcheramie.github.io/GopherTrunk/install-linux.html#troubleshooting)"
+			" See https://gophertrunk.org/install-linux.html#troubleshooting)"
 	}
 	return ""
 }
@@ -390,13 +414,13 @@ func tunerBringupHint(err error) string {
 		return " (hint: tuner did not respond on the I2C bus — common causes:" +
 			" DVB kernel driver still bound (run `sudo modprobe -r dvb_usb_rtl28xxu` and re-plug)," +
 			" marginal USB power, or a flaky cable/hub." +
-			" See https://mattcheramie.github.io/GopherTrunk/install-linux.html#troubleshooting)"
+			" See https://gophertrunk.org/install-linux.html#troubleshooting)"
 	}
 	if errors.Is(err, usb.ErrTimeout) {
 		return " (hint: USB control transfer timed out — common causes:" +
 			" on Windows, the WinUSB driver is not bound to the device (re-run Zadig and select the RTL-SDR);" +
 			" on any OS, marginal USB power, a flaky cable/hub, or another process already holding the device." +
-			" See https://mattcheramie.github.io/GopherTrunk/install-linux.html#troubleshooting)"
+			" See https://gophertrunk.org/install-windows.html#troubleshooting)"
 	}
 	if errors.Is(err, usb.ErrPipeStalled) {
 		return " (hint: the dongle's USB control pipe stalled" +
@@ -408,7 +432,7 @@ func tunerBringupHint(err error) string {
 			" often use different host controllers) and confirm" +
 			" `gophertrunk sdr doctor` reports WinUSB bound to interface 0." +
 			" Avoid USB hubs and powered extension cables." +
-			" See https://mattcheramie.github.io/GopherTrunk/install-linux.html#troubleshooting)"
+			" See https://gophertrunk.org/install-windows.html#troubleshooting)"
 	}
 	return ""
 }

--- a/internal/sdr/rtlsdr/purego/driver_test.go
+++ b/internal/sdr/rtlsdr/purego/driver_test.go
@@ -261,70 +261,84 @@ func TestOpenDevice_WarmupToInitBasebandSettle_Issue395(t *testing.T) {
 	}
 }
 
-// Regression for issue #248: when the warmup write returns EPIPE, the
-// driver must call transport.Reset, re-claim interface 0, and retry the
-// warmup once. The retry succeeds and openDevice proceeds — we again
-// terminate early via ErrTimeout on the first InitBaseband write.
-func TestOpenDevice_WarmupEPIPETriggersResetAndRetry(t *testing.T) {
+// Regression for the Windows ERROR_GEN_FAILURE warmup failure
+// (follow-up to issue #395): the warmup write is librtlsdr's sacrificial
+// dummy write. When it NAKs (ErrPipeStalled, the WinUSB mapping of
+// ERROR_GEN_FAILURE), runBringup must SWALLOW the error and proceed
+// straight to InitBaseband — whose byte-identical step 0 is the transfer
+// that actually has to land. Resetting + re-issuing the warmup (the old
+// behaviour) only re-armed the same first-transfer NAK and the dongle
+// never came up. This pins that a warmup NAK followed by a healthy
+// InitBaseband step 0 reaches step 1 with NO reset.
+func TestOpenDevice_WarmupNonFatal_ProceedsToInitBaseband(t *testing.T) {
 	m := usb.NewMockTransport()
 	m.Script = []usb.CtrlExchange{
-		warmupUSBSysctlExchange(syscall.EPIPE),
+		// Sacrificial warmup NAKs with ERROR_GEN_FAILURE.
+		warmupUSBSysctlExchange(usb.ErrPipeStalled),
+		// InitBaseband step 0 (byte-identical to the warmup) now lands —
+		// the cold first-transfer NAK was absorbed by the warmup.
 		warmupUSBSysctlExchange(nil),
+		// InitBaseband step 1 (USBEpaMaxpkt=0x0002, n=2). Fail it with a
+		// non-resetable error to unwind the bring-up without scripting the
+		// full init flood — proving we advanced past step 0.
 		{
 			In:       false,
 			BRequest: 0,
-			WValue:   0x2000,
+			WValue:   0x2158, // USBEpaMaxpkt
 			WIndex:   uint16(1)<<8 | 0x10,
-			Data:     []byte{0x09},
+			Data:     []byte{0x00, 0x02},
 			Err:      usb.ErrClosed,
 		},
 	}
-	desc := usb.Descriptor{VID: 0x0bda, PID: 0x2838, Serial: "test-warmup-retry"}
+	desc := usb.Descriptor{VID: 0x0bda, PID: 0x2838, Serial: "test-warmup-nonfatal"}
 	_, err := openDevice(m, desc, 0)
 	if err == nil {
-		t.Fatal("openDevice succeeded; expected init-baseband terminator to fail the test")
+		t.Fatal("openDevice succeeded; expected the InitBaseband step-1 terminator to fail the test")
 	}
 	if !strings.Contains(err.Error(), "init baseband") {
-		t.Errorf("err = %v, want substring \"init baseband\" (proves warmup retry succeeded and InitBaseband ran)", err)
+		t.Errorf("err = %v, want substring \"init baseband\" (proves the swallowed warmup let InitBaseband run)", err)
 	}
-	if m.ResetCalls != 1 {
-		t.Errorf("ResetCalls = %d, want 1 (EPIPE on warmup must trigger one USBDEVFS_RESET)", m.ResetCalls)
+	if !errors.Is(err, usb.ErrClosed) {
+		t.Errorf("err = %v, want errors.Is(err, usb.ErrClosed) (the step-1 terminator)", err)
 	}
-	if m.ClaimCalls != 2 {
-		t.Errorf("ClaimCalls = %d, want 2 (initial claim + post-reset re-claim)", m.ClaimCalls)
+	if m.ResetCalls != 0 {
+		t.Errorf("ResetCalls = %d, want 0 (a swallowed warmup NAK must NOT trip the reset envelope)", m.ResetCalls)
+	}
+	if m.ClaimCalls != 1 {
+		t.Errorf("ClaimCalls = %d, want 1 (no reset ⇒ single ClaimInterface)", m.ClaimCalls)
 	}
 }
 
-// Regression for issue #248: when every warmup attempt returns EPIPE,
-// openDevice must surface the wrapped error with the tunerBringupHint
-// appended — that's the actionable message the user sees and which
-// points them at the DVB / power / cable workarounds. The envelope
-// runs 5 attempts (4 resets) since #395.
-func TestOpenDevice_WarmupEPIPEFiveTimesReturnsHintError(t *testing.T) {
-	m := usb.NewMockTransport()
-	m.Script = []usb.CtrlExchange{
-		warmupUSBSysctlExchange(syscall.EPIPE),
-		warmupUSBSysctlExchange(syscall.EPIPE),
-		warmupUSBSysctlExchange(syscall.EPIPE),
-		warmupUSBSysctlExchange(syscall.EPIPE),
-		warmupUSBSysctlExchange(syscall.EPIPE),
-	}
-	desc := usb.Descriptor{VID: 0x0bda, PID: 0x2838, Serial: "test-warmup-fail"}
-	_, err := openDevice(m, desc, 0)
-	if err == nil {
-		t.Fatal("openDevice succeeded; expected EPIPE-five-times to fail open")
-	}
-	if !errors.Is(err, syscall.EPIPE) {
-		t.Errorf("err = %v, want errors.Is(err, syscall.EPIPE) (the underlying cause must remain inspectable)", err)
-	}
-	if !strings.Contains(err.Error(), "USB warmup") {
-		t.Errorf("err = %v, want substring \"USB warmup\" (identifies the failing stage)", err)
-	}
-	if !strings.Contains(err.Error(), "dvb_usb_rtl28xxu") {
-		t.Errorf("err = %v, want substring \"dvb_usb_rtl28xxu\" (proves tunerBringupHint was appended)", err)
-	}
-	if m.ResetCalls != 4 {
-		t.Errorf("ResetCalls = %d, want 4 (envelope retries four times before surfacing the error)", m.ResetCalls)
+// The warmup write is swallowed regardless of the error class it fails
+// with — EPIPE (Linux), ErrTimeout (WinUSB cold-boot), ErrPipeStalled
+// (WinUSB ERROR_GEN_FAILURE), or even ErrClosed. In every case bring-up
+// advances to InitBaseband: no "USB warmup" stage error and no reset
+// keyed off the warmup. Here InitBaseband step 0 is failed with a
+// non-resetable ErrClosed so the bring-up unwinds immediately.
+func TestOpenDevice_WarmupErrorSwallowedRegardlessOfClass(t *testing.T) {
+	for _, warmupErr := range []error{syscall.EPIPE, usb.ErrTimeout, usb.ErrPipeStalled, usb.ErrClosed} {
+		m := usb.NewMockTransport()
+		m.Script = []usb.CtrlExchange{
+			warmupUSBSysctlExchange(warmupErr),     // warmup NAKs (swallowed)
+			warmupUSBSysctlExchange(usb.ErrClosed), // InitBaseband step 0: non-resetable terminator
+		}
+		desc := usb.Descriptor{VID: 0x0bda, PID: 0x2838, Serial: "test-warmup-swallow"}
+		_, err := openDevice(m, desc, 0)
+		if err == nil {
+			t.Fatalf("warmupErr=%v: openDevice succeeded; expected the InitBaseband terminator to fail", warmupErr)
+		}
+		if !strings.Contains(err.Error(), "init baseband") {
+			t.Errorf("warmupErr=%v: err = %v, want substring \"init baseband\" (warmup must be swallowed, not surfaced)", warmupErr, err)
+		}
+		if strings.Contains(err.Error(), "USB warmup") {
+			t.Errorf("warmupErr=%v: err = %v, must NOT contain \"USB warmup\" (the stage is no longer a hard gate)", warmupErr, err)
+		}
+		if m.ResetCalls != 0 {
+			t.Errorf("warmupErr=%v: ResetCalls = %d, want 0 (warmup failure must not reset)", warmupErr, m.ResetCalls)
+		}
+		if m.ClaimCalls != 1 {
+			t.Errorf("warmupErr=%v: ClaimCalls = %d, want 1", warmupErr, m.ClaimCalls)
+		}
 	}
 }
 
@@ -437,12 +451,12 @@ func TestTunerBringupHint(t *testing.T) {
 		{
 			name:    "ErrTimeout_through_wrap",
 			err:     fmt.Errorf("wrap: %w", usb.ErrTimeout),
-			wantSub: []string{"Zadig", "install-linux.html#troubleshooting"},
+			wantSub: []string{"Zadig", "install-windows.html#troubleshooting"},
 		},
 		{
 			name:    "ErrPipeStalled_through_wrap",
 			err:     fmt.Errorf("winusb: device rejected request: %w", usb.ErrPipeStalled),
-			wantSub: []string{"control pipe stalled", "ERROR_GEN_FAILURE", "issue #395", "sdr doctor", "install-linux.html#troubleshooting"},
+			wantSub: []string{"control pipe stalled", "ERROR_GEN_FAILURE", "issue #395", "sdr doctor", "install-windows.html#troubleshooting"},
 		},
 	}
 	for _, c := range cases {
@@ -463,72 +477,42 @@ func TestTunerBringupHint(t *testing.T) {
 	}
 }
 
-// Regression: on Windows the cold-boot warmup probe surfaces as
-// usb.ErrTimeout (ERROR_SEM_TIMEOUT from WinUsb_ControlTransfer) rather
-// than EPIPE. openDevice must treat that as resetable and run the same
-// reset + re-claim + retry envelope it uses for EPIPE — otherwise
-// `gophertrunk sdr list --probe` fails on cold-plugged dongles with
-// "rtlsdr: USB warmup: ... usb: transfer timed out".
-func TestOpenDevice_WarmupTimeoutTriggersResetAndRetry(t *testing.T) {
+// Mode B (Windows cold-boot, the genuinely-wedged case): the warmup
+// NAKs AND InitBaseband's byte-identical step 0 NAKs too (ErrPipeStalled
+// from ERROR_GEN_FAILURE). The warmup failure is swallowed, but the
+// step-0 failure is caught by the outer envelope, which resets
+// (WinUsb_ResetPipe / re-open) and retries the whole bring-up; the
+// post-reset pass lands step 0 and proceeds. This is the recovery path
+// that survives moving the hard gate from warmup to InitBaseband — it
+// also covers the cold-boot ErrTimeout class, which is resetable the
+// same way.
+func TestOpenDevice_WarmupAndInitBasebandStall_ResetRecovers(t *testing.T) {
 	m := usb.NewMockTransport()
 	m.Script = []usb.CtrlExchange{
-		warmupUSBSysctlExchange(usb.ErrTimeout),
-		warmupUSBSysctlExchange(nil),
-		// Terminate the bring-up with a non-resetable error on
-		// InitBaseband's first write so the script stays minimal.
+		warmupUSBSysctlExchange(usb.ErrPipeStalled), // pass 1: warmup NAK (swallowed)
+		warmupUSBSysctlExchange(usb.ErrPipeStalled), // pass 1: InitBaseband step 0 NAK → resetable
+		warmupUSBSysctlExchange(usb.ErrPipeStalled), // pass 2: warmup NAK (swallowed, post-reset)
+		warmupUSBSysctlExchange(nil),                // pass 2: InitBaseband step 0 OK
+		// pass 2: InitBaseband step 1 (USBEpaMaxpkt) non-resetable terminator.
 		{
 			In:       false,
 			BRequest: 0,
-			WValue:   0x2000,
+			WValue:   0x2158,
 			WIndex:   uint16(1)<<8 | 0x10,
-			Data:     []byte{0x09},
+			Data:     []byte{0x00, 0x02},
 			Err:      usb.ErrClosed,
 		},
 	}
-	desc := usb.Descriptor{VID: 0x0bda, PID: 0x2838, Serial: "test-warmup-timeout-retry"}
+	desc := usb.Descriptor{VID: 0x0bda, PID: 0x2838, Serial: "test-warmup-and-init-stall"}
 	_, err := openDevice(m, desc, 0)
 	if err == nil {
-		t.Fatal("openDevice succeeded; expected init-baseband terminator to fail the test")
+		t.Fatal("openDevice succeeded; expected the InitBaseband step-1 terminator to fail the test")
 	}
 	if !strings.Contains(err.Error(), "init baseband") {
-		t.Errorf("err = %v, want substring \"init baseband\" (proves warmup retry succeeded and InitBaseband ran)", err)
+		t.Errorf("err = %v, want substring \"init baseband\"", err)
 	}
 	if m.ResetCalls != 1 {
-		t.Errorf("ResetCalls = %d, want 1 (ErrTimeout on warmup must trigger one USBDEVFS_RESET)", m.ResetCalls)
-	}
-	if m.ClaimCalls != 2 {
-		t.Errorf("ClaimCalls = %d, want 2 (initial claim + post-reset re-claim)", m.ClaimCalls)
-	}
-}
-
-// The WinUSB cold-boot stall surfaces as ErrPipeStalled (mapped from
-// ERROR_GEN_FAILURE). The bring-up envelope must treat it as resetable
-// so WinUsb_ResetPipe(0) clears the control pipe halt and the retry
-// pass succeeds — matching the Linux EPIPE recovery path.
-func TestOpenDevice_WarmupPipeStalledTriggersResetAndRetry(t *testing.T) {
-	m := usb.NewMockTransport()
-	m.Script = []usb.CtrlExchange{
-		warmupUSBSysctlExchange(usb.ErrPipeStalled),
-		warmupUSBSysctlExchange(nil),
-		{
-			In:       false,
-			BRequest: 0,
-			WValue:   0x2000,
-			WIndex:   uint16(1)<<8 | 0x10,
-			Data:     []byte{0x09},
-			Err:      usb.ErrClosed,
-		},
-	}
-	desc := usb.Descriptor{VID: 0x0bda, PID: 0x2838, Serial: "test-warmup-pipestalled-retry"}
-	_, err := openDevice(m, desc, 0)
-	if err == nil {
-		t.Fatal("openDevice succeeded; expected init-baseband terminator to fail the test")
-	}
-	if !strings.Contains(err.Error(), "init baseband") {
-		t.Errorf("err = %v, want substring \"init baseband\" (proves warmup retry succeeded and InitBaseband ran)", err)
-	}
-	if m.ResetCalls != 1 {
-		t.Errorf("ResetCalls = %d, want 1 (ErrPipeStalled on warmup must trigger one clear-halt)", m.ResetCalls)
+		t.Errorf("ResetCalls = %d, want 1 (the step-0 stall on the cold pass triggers one reset; warmup NAKs do not)", m.ResetCalls)
 	}
 	if m.ClaimCalls != 2 {
 		t.Errorf("ClaimCalls = %d, want 2 (initial claim + post-reset re-claim)", m.ClaimCalls)
@@ -608,19 +592,20 @@ func TestOpenDevice_BringupPipeStalledFiveTimes_ReturnsHintError(t *testing.T) {
 	}
 }
 
-// Regression: when ErrTimeout recurs on every warmup retry pass, the
-// surfaced error must carry the Windows-aware hint that points at the
-// WinUSB / Zadig step. Bounded to four USBDEVFS_RESETs per Open call.
-func TestOpenDevice_WarmupTimeoutFiveTimesReturnsHintError(t *testing.T) {
+// Regression: when ErrTimeout recurs on every bring-up pass (warmup
+// swallowed, then InitBaseband step 0 times out), the surfaced error
+// must carry the Windows-aware hint that points at the WinUSB / Zadig
+// step. Bounded to four resets per Open call.
+func TestOpenDevice_BringupTimeoutFiveTimesReturnsHintError(t *testing.T) {
 	m := usb.NewMockTransport()
 	m.Script = []usb.CtrlExchange{
-		warmupUSBSysctlExchange(usb.ErrTimeout),
-		warmupUSBSysctlExchange(usb.ErrTimeout),
-		warmupUSBSysctlExchange(usb.ErrTimeout),
-		warmupUSBSysctlExchange(usb.ErrTimeout),
-		warmupUSBSysctlExchange(usb.ErrTimeout),
+		warmupUSBSysctlExchange(nil), warmupUSBSysctlExchange(usb.ErrTimeout), // pass 1
+		warmupUSBSysctlExchange(nil), warmupUSBSysctlExchange(usb.ErrTimeout), // pass 2
+		warmupUSBSysctlExchange(nil), warmupUSBSysctlExchange(usb.ErrTimeout), // pass 3
+		warmupUSBSysctlExchange(nil), warmupUSBSysctlExchange(usb.ErrTimeout), // pass 4
+		warmupUSBSysctlExchange(nil), warmupUSBSysctlExchange(usb.ErrTimeout), // pass 5
 	}
-	desc := usb.Descriptor{VID: 0x0bda, PID: 0x2838, Serial: "test-warmup-timeout-fail"}
+	desc := usb.Descriptor{VID: 0x0bda, PID: 0x2838, Serial: "test-bringup-timeout-fail"}
 	_, err := openDevice(m, desc, 0)
 	if err == nil {
 		t.Fatal("openDevice succeeded; expected ErrTimeout-five-times to fail open")
@@ -628,8 +613,8 @@ func TestOpenDevice_WarmupTimeoutFiveTimesReturnsHintError(t *testing.T) {
 	if !errors.Is(err, usb.ErrTimeout) {
 		t.Errorf("err = %v, want errors.Is(err, usb.ErrTimeout) (the underlying cause must remain inspectable)", err)
 	}
-	if !strings.Contains(err.Error(), "USB warmup") {
-		t.Errorf("err = %v, want substring \"USB warmup\" (identifies the failing stage)", err)
+	if !strings.Contains(err.Error(), "init baseband") {
+		t.Errorf("err = %v, want substring \"init baseband\" (identifies the failing stage)", err)
 	}
 	if !strings.Contains(err.Error(), "Zadig") {
 		t.Errorf("err = %v, want substring \"Zadig\" (proves the Windows-aware tunerBringupHint was appended)", err)
@@ -641,18 +626,27 @@ func TestOpenDevice_WarmupTimeoutFiveTimesReturnsHintError(t *testing.T) {
 
 // Regression: a clone dongle on Windows can require two full resets to
 // clear a wedged firmware state (the first WinUsb_Initialize rebind
-// doesn't always settle the device, but the second one does). The
-// bring-up envelope must keep retrying after the first reset and let
-// the second attempt succeed if the third one would.
-func TestOpenDevice_WarmupRecoversOnSecondRetry(t *testing.T) {
+// doesn't always settle the device, but the second one does). With the
+// hard gate now on InitBaseband step 0, the envelope must keep retrying
+// after the first reset and let a later pass succeed. Each pass: warmup
+// swallowed, then InitBaseband step 0 stalls (passes 1-2) or lands
+// (pass 3).
+func TestOpenDevice_BringupStallRecoversOnSecondReset(t *testing.T) {
 	m := usb.NewMockTransport()
 	m.Script = []usb.CtrlExchange{
-		warmupUSBSysctlExchange(usb.ErrPipeStalled), // pass 1: stalls
-		warmupUSBSysctlExchange(usb.ErrPipeStalled), // pass 2: still stalls
-		warmupUSBSysctlExchange(nil),                // pass 3: warmup OK
-		warmupUSBSysctlExchange(usb.ErrClosed),      // pass 3: non-resetable terminator
+		warmupUSBSysctlExchange(nil), warmupUSBSysctlExchange(usb.ErrPipeStalled), // pass 1: step 0 stalls
+		warmupUSBSysctlExchange(nil), warmupUSBSysctlExchange(usb.ErrPipeStalled), // pass 2: step 0 stalls
+		warmupUSBSysctlExchange(nil), warmupUSBSysctlExchange(nil), // pass 3: step 0 OK
+		{ // pass 3: InitBaseband step 1 non-resetable terminator
+			In:       false,
+			BRequest: 0,
+			WValue:   0x2158,
+			WIndex:   uint16(1)<<8 | 0x10,
+			Data:     []byte{0x00, 0x02},
+			Err:      usb.ErrClosed,
+		},
 	}
-	desc := usb.Descriptor{VID: 0x0bda, PID: 0x2838, Serial: "test-warmup-second-retry"}
+	desc := usb.Descriptor{VID: 0x0bda, PID: 0x2838, Serial: "test-bringup-second-reset"}
 	_, err := openDevice(m, desc, 0)
 	if err == nil {
 		t.Fatal("openDevice succeeded; expected init-baseband terminator to fail the test")
@@ -661,26 +655,32 @@ func TestOpenDevice_WarmupRecoversOnSecondRetry(t *testing.T) {
 		t.Errorf("err = %v, want substring \"init baseband\" (proves the third attempt reached InitBaseband)", err)
 	}
 	if m.ResetCalls != 2 {
-		t.Errorf("ResetCalls = %d, want 2 (one reset after each failed warmup)", m.ResetCalls)
+		t.Errorf("ResetCalls = %d, want 2 (one reset after each stalled InitBaseband step 0)", m.ResetCalls)
 	}
 	if m.ClaimCalls != 3 {
 		t.Errorf("ClaimCalls = %d, want 3 (initial claim + two post-reset re-claims)", m.ClaimCalls)
 	}
 }
 
-// Regression for issue #395: pins that the new attempt-4 slot in the
-// retry envelope is actually consulted. The prior 3-attempt envelope
-// surfaced an error here; the 5-attempt envelope must let the bring-up
-// succeed on attempt 4 (zero-indexed) after four warmup stalls.
-func TestOpenDevice_BringupPipeStalledRecoversOnFifthAttempt(t *testing.T) {
+// Regression for issue #395: pins that the attempt-4 slot in the retry
+// envelope is actually consulted. The bring-up must succeed on attempt 4
+// (zero-indexed) after four InitBaseband step-0 stalls.
+func TestOpenDevice_BringupStallRecoversOnFifthAttempt(t *testing.T) {
 	m := usb.NewMockTransport()
 	m.Script = []usb.CtrlExchange{
-		warmupUSBSysctlExchange(usb.ErrPipeStalled), // pass 1: stalls
-		warmupUSBSysctlExchange(usb.ErrPipeStalled), // pass 2: stalls
-		warmupUSBSysctlExchange(usb.ErrPipeStalled), // pass 3: stalls
-		warmupUSBSysctlExchange(usb.ErrPipeStalled), // pass 4: stalls
-		warmupUSBSysctlExchange(nil),                // pass 5: warmup OK
-		warmupUSBSysctlExchange(usb.ErrClosed),      // pass 5: non-resetable terminator
+		warmupUSBSysctlExchange(nil), warmupUSBSysctlExchange(usb.ErrPipeStalled), // pass 1: stalls
+		warmupUSBSysctlExchange(nil), warmupUSBSysctlExchange(usb.ErrPipeStalled), // pass 2: stalls
+		warmupUSBSysctlExchange(nil), warmupUSBSysctlExchange(usb.ErrPipeStalled), // pass 3: stalls
+		warmupUSBSysctlExchange(nil), warmupUSBSysctlExchange(usb.ErrPipeStalled), // pass 4: stalls
+		warmupUSBSysctlExchange(nil), warmupUSBSysctlExchange(nil), // pass 5: step 0 OK
+		{ // pass 5: InitBaseband step 1 non-resetable terminator
+			In:       false,
+			BRequest: 0,
+			WValue:   0x2158,
+			WIndex:   uint16(1)<<8 | 0x10,
+			Data:     []byte{0x00, 0x02},
+			Err:      usb.ErrClosed,
+		},
 	}
 	desc := usb.Descriptor{VID: 0x0bda, PID: 0x2838, Serial: "test-bringup-fifth-attempt"}
 	_, err := openDevice(m, desc, 0)
@@ -691,7 +691,7 @@ func TestOpenDevice_BringupPipeStalledRecoversOnFifthAttempt(t *testing.T) {
 		t.Errorf("err = %v, want substring \"init baseband\" (proves the fifth attempt reached InitBaseband)", err)
 	}
 	if m.ResetCalls != 4 {
-		t.Errorf("ResetCalls = %d, want 4 (one reset after each of the first four failed warmups)", m.ResetCalls)
+		t.Errorf("ResetCalls = %d, want 4 (one reset after each of the first four stalled step 0s)", m.ResetCalls)
 	}
 	if m.ClaimCalls != 5 {
 		t.Errorf("ClaimCalls = %d, want 5 (initial claim + four post-reset re-claims)", m.ClaimCalls)
@@ -747,16 +747,19 @@ func TestOpenDevice_ClaimBusySurfacesHint(t *testing.T) {
 	}
 }
 
-// Regression: a non-resetable error class (here usb.ErrClosed) on the
-// warmup probe must surface immediately without any USB reset — reset
-// is the wrong hammer for "transport already closed" and would obscure
-// the real cause.
-func TestOpenDevice_WarmupNonResetableErrorDoesNotReset(t *testing.T) {
+// Regression: a non-resetable error class (here usb.ErrClosed) on a
+// post-warmup transfer — InitBaseband step 0 — must surface immediately
+// without any USB reset. Reset is the wrong hammer for "transport
+// already closed" and would obscure the real cause. (Warmup-stage
+// failures are now swallowed entirely; see
+// TestOpenDevice_WarmupErrorSwallowedRegardlessOfClass.)
+func TestOpenDevice_InitBasebandNonResetableErrorDoesNotReset(t *testing.T) {
 	m := usb.NewMockTransport()
 	m.Script = []usb.CtrlExchange{
-		warmupUSBSysctlExchange(usb.ErrClosed),
+		warmupUSBSysctlExchange(nil),           // warmup OK
+		warmupUSBSysctlExchange(usb.ErrClosed), // InitBaseband step 0: non-resetable
 	}
-	desc := usb.Descriptor{VID: 0x0bda, PID: 0x2838, Serial: "test-warmup-closed"}
+	desc := usb.Descriptor{VID: 0x0bda, PID: 0x2838, Serial: "test-init-closed"}
 	_, err := openDevice(m, desc, 0)
 	if err == nil {
 		t.Fatal("openDevice succeeded; expected ErrClosed to fail open")

--- a/internal/sdr/rtlsdr/rtl2832u/demod.go
+++ b/internal/sdr/rtlsdr/rtl2832u/demod.go
@@ -116,12 +116,16 @@ func (d *Demod) DeinitBaseband() error {
 
 // WarmupUSBSysctl issues the single USB-block write that librtlsdr's
 // rtlsdr_open uses as a dummy-write probe immediately after claiming
-// the interface — if it returns EPIPE the caller is expected to
-// libusb_reset_device and retry. The wire bytes match initBasebandSteps[0]
-// on purpose: librtlsdr also repeats the write inside the full init
-// flood, and the chip is happy to receive it twice. Kept separate so
-// the open path can run it with reset-on-EPIPE recovery without
-// dragging the whole baseband sequence into the retry.
+// the interface. The wire bytes match initBasebandSteps[0] on purpose:
+// librtlsdr also repeats the write inside the full init flood, and the
+// chip is happy to receive it twice. Its job is purely sacrificial —
+// to absorb the first-control-transfer NAK that some clone dongles
+// emit right after the interface is claimed — so the caller
+// (runBringup in purego/driver.go) deliberately SWALLOWS any error
+// this returns and proceeds straight to InitBaseband, matching
+// librtlsdr. A genuine stall re-surfaces on InitBaseband's
+// byte-identical step 0, where the open-path reset+retry envelope can
+// act on it.
 func (d *Demod) WarmupUSBSysctl() error {
 	d.mu.Lock()
 	defer d.mu.Unlock()

--- a/internal/sdr/rtlsdr/usb/usb_debug.go
+++ b/internal/sdr/rtlsdr/usb/usb_debug.go
@@ -58,6 +58,17 @@ func debugLogf(component, format string, args ...interface{}) {
 	fmt.Fprintln(w, "rtlsdr-usb ["+component+"]: "+fmt.Sprintf(format, args...))
 }
 
+// DebugLogf is the exported entry point to the gated debug sink for
+// callers outside this package (e.g. the rtlsdr bring-up path in
+// purego/driver.go, which logs the swallowed sacrificial-warmup
+// failure). Like debugLogf it only emits when RTLSDR_DEBUG_USB is set,
+// writes to the same sink (so SetDebugSink works in tests), and uses
+// the same "rtlsdr-usb [component]" line prefix — keeping every USB
+// diagnostic on one diffable channel.
+func DebugLogf(component, format string, args ...interface{}) {
+	debugLogf(component, format, args...)
+}
+
 // MaybeWrapDebug returns t wrapped in a debug-logging Transport when
 // RTLSDR_DEBUG_USB is set in the environment; otherwise it returns t
 // unchanged. Wrapping is gated at Open time so the rest of the code


### PR DESCRIPTION
## Problem

On Windows, `gophertrunk sdr list --probe` fails for every dongle at the **warmup write**:

```
probe rtlsdr[0]: rtlsdr: USB warmup: rtl2832u: write block=1 addr=0x2000 val=0x0009:
  winusb: WinUsb_ControlTransfer OUT: winusb: device rejected request
  (ERROR_GEN_FAILURE 0x1F — firmware NAK / stalled pipe / wrong driver bound)
```

The device **is** WinUSB-bound (`WinUsb_Initialize` succeeds). This is the well-known clone-dongle quirk: the **first control transfer after a fresh WinUSB open is NAK'd** with `ERROR_GEN_FAILURE`.

## Root cause

The warmup write is librtlsdr's sacrificial *dummy write* — its only job is to absorb that first-transfer NAK, after which librtlsdr proceeds straight to `rtlsdr_init_baseband` without checking the result.

GopherTrunk instead treated warmup as a **must-succeed gate**: on failure it reset the device and re-issued the warmup. But each `transport.Reset` re-opens the device, which **re-arms the same first-transfer NAK** — so the dongle never reached `InitBaseband` and `Open` failed after exhausting the 5-attempt envelope.

## Fix

`runBringup` now **swallows any warmup error** (logging it under `RTLSDR_DEBUG_USB`) and proceeds to `InitBaseband`, whose byte-identical step 0 is the transfer that actually needs to land — matching librtlsdr exactly. Genuine stalls are still recovered: if the device is truly wedged, `InitBaseband` step 0 fails too and the existing outer reset+retry envelope handles it (now keyed off the `init baseband` stage rather than `USB warmup`).

Also:
- Corrected the stale troubleshooting URLs in the bring-up hints (`mattcheramie.github.io/GopherTrunk` → `gophertrunk.org`), and routed the **Windows**-specific hints (timeout, pipe-stall) to `install-windows.html` instead of the Linux page.
- Added a Windows troubleshooting-table row for the `ERROR_GEN_FAILURE` cold-start quirk.

## Context

Related to the long-running RTL-SDR Blog V4 / R828D cold-boot saga in #264, but this is the Windows-side analog at the *earliest* bring-up stage (warmup), which none of the #264 / #395 fixes touched. Making warmup non-fatal lets clone dongles (incl. the V4) reach the already-fixed downstream stages on Windows.

## Verification

- `go test ./...` — all pass (warmup error swallowed regardless of class; warmup NAK + healthy InitBaseband step 0 reaches step 1 with no reset; reset recovery still fires when step 0 stalls).
- `go build ./...`, `go vet ./...`, and `GOOS=windows GOARCH={amd64,arm64} go build ./...` all clean.
- End-to-end confirmation requires the affected Windows hardware — the `Windows installer (PR)` workflow on this PR produces a downloadable `setup.exe` artifact for that test.

https://claude.ai/code/session_01Ph6iruL2n2JKZDZUsRmRvK

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ph6iruL2n2JKZDZUsRmRvK)_