### PR TITLE
rtlsdr: clear-halt + retry stalled control writes, append USB diagnostics

### DIFF
--- a/docs/install-windows.md
+++ b/docs/install-windows.md
@@ -189,7 +189,7 @@ edits or per-system data.
 | `sdr list` prints nothing              | Zadig WinUSB swap didn't take — see step 3.        |
 | `usb: device disconnected` mid-stream  | The DVB driver re-attached itself — re-run Zadig. |
 | `WinUsb_Initialize` fails              | The dongle is bound to the wrong driver — re-run Zadig and pick **WinUSB**. |
-| `ERROR_GEN_FAILURE` / `device rejected request` on `sdr list` | Clone-dongle cold-start quirk — the first USB control transfer after open is NAK'd. v0.2.x absorbs this automatically (the warmup probe is sacrificial). If it still persists: try a different USB port (front vs. rear use different host controllers), avoid hubs and extension cables, and confirm `gophertrunk sdr doctor` shows **WinUSB** bound to interface 0. |
+| `ERROR_GEN_FAILURE` / `device rejected request` on `sdr list` | Clone-dongle cold-start quirk — the first USB control transfer after open is NAK'd. v0.2.x absorbs this automatically (the warmup probe is sacrificial, and a stalled control pipe is cleared and the write retried). If it still persists, the probe error prints a **`--- USB diagnostics ---`** block (bound driver, device/config descriptors, a control-IN read probe) — copy that whole block into a GitHub issue. Meanwhile: try a different USB port (front vs. rear use different host controllers), avoid hubs and extension cables, and confirm `gophertrunk sdr doctor` shows **WinUSB** (not libusbK) bound to interface 0. |
 | Smart Screen blocks the installer      | Right-click → Properties → Unblock, or **More info → Run anyway**. |
 
 For anything else: open an issue at

--- a/internal/sdr/rtlsdr/purego/driver.go
+++ b/internal/sdr/rtlsdr/purego/driver.go
@@ -210,7 +210,7 @@ func openDevice(transport usb.Transport, desc usb.Descriptor, idx int) (*Device,
 			break
 		}
 		if attempt == maxAttempts-1 || !isBringupResetable(err) {
-			return nil, err
+			return nil, withTransportDiagnostics(transport, err)
 		}
 		if resetErr := transport.Reset(); resetErr != nil {
 			return nil, fmt.Errorf("rtlsdr: bring-up hit %w; reset failed: %w", err, resetErr)
@@ -370,6 +370,27 @@ func isBringupResetable(err error) bool {
 		errors.Is(err, usb.ErrDeviceGone) ||
 		errors.Is(err, usb.ErrTimeout) ||
 		errors.Is(err, usb.ErrPipeStalled)
+}
+
+// withTransportDiagnostics appends a USB diagnostic dump to err when the
+// transport can produce one (the Windows WinUSB transport today, via
+// usb.Diagnoser). Gathered once, on the final bring-up failure, so a
+// single `gophertrunk sdr list --probe` run captures the bound driver,
+// the device + configuration descriptors, and a control-IN read probe —
+// the data needed to triage a dongle that rejects control transfers even
+// with WinUSB reportedly bound. No-op on transports that don't implement
+// Diagnoser or that return an empty dump, so non-Windows error messages
+// stay unchanged.
+func withTransportDiagnostics(transport usb.Transport, err error) error {
+	dg, ok := transport.(usb.Diagnoser)
+	if !ok {
+		return err
+	}
+	diag := dg.Diagnostics()
+	if diag == "" {
+		return err
+	}
+	return fmt.Errorf("%w\n--- USB diagnostics (gophertrunk; attach this to the issue) ---\n%s------------------------------------------------------------", err, diag)
 }
 
 // claimBusyHint returns a parenthesized, space-prefixed remediation

--- a/internal/sdr/rtlsdr/purego/driver_test.go
+++ b/internal/sdr/rtlsdr/purego/driver_test.go
@@ -771,3 +771,58 @@ func TestOpenDevice_InitBasebandNonResetableErrorDoesNotReset(t *testing.T) {
 		t.Errorf("ResetCalls = %d, want 0 (non-resetable error must not trigger reset)", m.ResetCalls)
 	}
 }
+
+// Regression for the Windows ERROR_GEN_FAILURE triage path: when
+// bring-up ultimately fails, openDevice must append the transport's
+// Diagnostics (bound driver, descriptors, control-IN read probe) to the
+// error so one `gophertrunk sdr list --probe` run captures everything
+// needed to diagnose a dongle that rejects control transfers even with
+// WinUSB reportedly bound. The mock stands in for the WinUSB transport
+// via the usb.Diagnoser interface.
+func TestOpenDevice_AppendsTransportDiagnosticsOnFailure(t *testing.T) {
+	m := usb.NewMockTransport()
+	m.Diag = "bound driver: service=\"libusbK\" (winusb-bound=false)\n"
+	// Persistent stall on every InitBaseband step 0 (warmup swallowed),
+	// across all five attempts: 2 transfers per attempt × 5 attempts.
+	m.Script = make([]usb.CtrlExchange, 0, 10)
+	for i := 0; i < 5; i++ {
+		m.Script = append(m.Script,
+			warmupUSBSysctlExchange(usb.ErrPipeStalled), // warmup (swallowed)
+			warmupUSBSysctlExchange(usb.ErrPipeStalled), // InitBaseband step 0 (resetable)
+		)
+	}
+	desc := usb.Descriptor{VID: 0x0bda, PID: 0x2838, Serial: "test-diag"}
+	_, err := openDevice(m, desc, 0)
+	if err == nil {
+		t.Fatal("openDevice succeeded; expected persistent stall to fail open")
+	}
+	if !strings.Contains(err.Error(), "USB diagnostics") {
+		t.Errorf("err = %v, want the diagnostics block appended", err)
+	}
+	if !strings.Contains(err.Error(), "libusbK") {
+		t.Errorf("err = %v, want the bound-driver diagnostic included", err)
+	}
+	// The underlying cause must still be inspectable through the wrap.
+	if !errors.Is(err, usb.ErrPipeStalled) {
+		t.Errorf("err = %v, want errors.Is(err, usb.ErrPipeStalled) after diagnostics wrap", err)
+	}
+}
+
+// A transport that produces no diagnostics (the non-Windows case, Diag
+// empty) must leave the error message unchanged — no stray diagnostics
+// header.
+func TestOpenDevice_NoDiagnosticsWhenTransportSilent(t *testing.T) {
+	m := usb.NewMockTransport()
+	m.Script = []usb.CtrlExchange{
+		warmupUSBSysctlExchange(nil),           // warmup OK
+		warmupUSBSysctlExchange(usb.ErrClosed), // InitBaseband step 0: non-resetable
+	}
+	desc := usb.Descriptor{VID: 0x0bda, PID: 0x2838, Serial: "test-no-diag"}
+	_, err := openDevice(m, desc, 0)
+	if err == nil {
+		t.Fatal("openDevice succeeded; expected ErrClosed to fail open")
+	}
+	if strings.Contains(err.Error(), "USB diagnostics") {
+		t.Errorf("err = %v, must NOT contain the diagnostics header when the transport is silent", err)
+	}
+}

--- a/internal/sdr/rtlsdr/usb/usb_debug.go
+++ b/internal/sdr/rtlsdr/usb/usb_debug.go
@@ -13,6 +13,17 @@ import (
 // transport wrapper. Anything non-empty enables it.
 const debugUSBEnv = "RTLSDR_DEBUG_USB"
 
+// Diagnoser is an optional Transport capability. Implementations that
+// can describe the underlying device — the bound driver, USB descriptors,
+// a control-IN read probe — expose Diagnostics. The bring-up path
+// (purego/driver.go) appends this to a failed Open so a single probe run
+// captures everything needed to triage a dongle that rejects control
+// transfers. The Windows transport implements it; transports that don't
+// simply contribute no extra diagnostics.
+type Diagnoser interface {
+	Diagnostics() string
+}
+
 // debugMaxDataBytes caps how many payload bytes the debug log dumps
 // per ControlOut. 64 bytes is enough to capture the R820T 27-byte
 // init burst (and the chunked variant) in full while keeping log
@@ -186,6 +197,16 @@ func (d *debugTransport) Reset() error {
 func (d *debugTransport) Close() error {
 	d.logf("Close")
 	return d.inner.Close()
+}
+
+// Diagnostics forwards to the wrapped transport's Diagnostics when it
+// implements Diagnoser, so the RTLSDR_DEBUG_USB wrapper doesn't hide the
+// rich device dump the bring-up path appends on failure.
+func (d *debugTransport) Diagnostics() string {
+	if dg, ok := d.inner.(Diagnoser); ok {
+		return dg.Diagnostics()
+	}
+	return ""
 }
 
 // hexBytes returns a space-separated lowercase hex dump of the first

--- a/internal/sdr/rtlsdr/usb/usb_mock.go
+++ b/internal/sdr/rtlsdr/usb/usb_mock.go
@@ -85,6 +85,11 @@ type MockTransport struct {
 	// (e.g. an EBUSY that survives kernel-driver auto-detach).
 	ClaimErr error
 
+	// Diag, when non-empty, is returned by Diagnostics so tests can
+	// assert the bring-up path appends transport diagnostics to a failed
+	// Open. Mirrors the real winTransport.Diagnostics capability.
+	Diag string
+
 	BulkPackets  [][]byte
 	BulkInterval time.Duration
 	// BulkSimulateDeath, when true, makes the bulk-IN goroutine fire
@@ -310,6 +315,11 @@ func (m *MockTransport) Close() error {
 // Remaining returns the number of unconsumed [CtrlExchange] entries in
 // the script. Tests typically assert it is zero after the SUT runs.
 func (m *MockTransport) Remaining() int { return len(m.Script) - m.Step }
+
+// Diagnostics implements the usb.Diagnoser optional interface, returning
+// the canned Diag string. Lets tests assert the bring-up path appends
+// transport diagnostics on a failed Open.
+func (m *MockTransport) Diagnostics() string { return m.Diag }
 
 func bytesEqual(a, b []byte) bool {
 	if len(a) != len(b) {

--- a/internal/sdr/rtlsdr/usb/usb_windows.go
+++ b/internal/sdr/rtlsdr/usb/usb_windows.go
@@ -34,6 +34,7 @@ var (
 	procWinUsbInitialize          = modWinUSB.NewProc("WinUsb_Initialize")
 	procWinUsbFree                = modWinUSB.NewProc("WinUsb_Free")
 	procWinUsbControlTransfer     = modWinUSB.NewProc("WinUsb_ControlTransfer")
+	procWinUsbGetDescriptor       = modWinUSB.NewProc("WinUsb_GetDescriptor")
 	procWinUsbReadPipe            = modWinUSB.NewProc("WinUsb_ReadPipe")
 	procWinUsbAbortPipe           = modWinUSB.NewProc("WinUsb_AbortPipe")
 	procWinUsbResetPipe           = modWinUSB.NewProc("WinUsb_ResetPipe")
@@ -321,7 +322,32 @@ func (t *winTransport) ControlOut(bRequest uint8, wValue, wIndex uint16, data []
 		0,
 	)
 	if ret == 0 {
-		return fmt.Errorf("winusb: WinUsb_ControlTransfer OUT: %w", winErr(errno))
+		// A vendor write that stalls the control pipe (ERROR_GEN_FAILURE,
+		// the clone-dongle cold-boot symptom in issue #395) leaves the
+		// default control endpoint halted. Per the USB spec the next
+		// SETUP should clear a control-endpoint halt automatically, but
+		// some clone RTL2832U firmwares need an explicit CLEAR_FEATURE
+		// before they accept the retried write — which is exactly what
+		// libusb's WinUSB backend does on a control stall. Clear pipe 0
+		// and retry the transfer once before surfacing the error. The
+		// bring-up path's sacrificial warmup relies on this so the
+		// byte-identical InitBaseband step 0 isn't poisoned by the
+		// warmup's stall. Errors from the reset are ignored — the retry
+		// (or the returned error) is the real signal.
+		if errors.Is(winErr(errno), ErrPipeStalled) {
+			procWinUsbResetPipe.Call(t.ifaceHandle, 0)
+			ret, _, errno = procWinUsbControlTransfer.Call(
+				t.ifaceHandle,
+				uintptr(unsafe.Pointer(&pkt)),
+				dataPtr,
+				uintptr(len(data)),
+				uintptr(unsafe.Pointer(&transferred)),
+				0,
+			)
+		}
+		if ret == 0 {
+			return fmt.Errorf("winusb: WinUsb_ControlTransfer OUT: %w", winErr(errno))
+		}
 	}
 	return nil
 }
@@ -670,6 +696,136 @@ func (t *winTransport) Close() error {
 		t.fileHandle = 0
 	}
 	return nil
+}
+
+// ----------------------------------------------------------------------
+// Diagnostics
+
+// USB descriptor type codes (USB 2.0 §9.4) used by getDescriptor.
+const (
+	descTypeDevice = 0x01
+	descTypeConfig = 0x02
+)
+
+// Diagnostics returns a multi-line, human-readable dump of everything we
+// can learn about this device through WinUSB + SetupAPI: the actually
+// bound driver (WinUSB vs libusbK vs the DVB driver vs none), the device
+// path, the raw device + configuration descriptors (interfaces +
+// endpoints), and a control-IN read probe. The bring-up path appends it
+// to a failed Open so a single `gophertrunk sdr list --probe` run
+// captures the data needed to triage a dongle that rejects control
+// transfers even with WinUSB reportedly bound. Every step is
+// best-effort: a failure on one line is reported inline and never aborts
+// the rest. Implements the usb.Diagnoser optional interface.
+func (t *winTransport) Diagnostics() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "device path: %s\n", t.desc.Path)
+	fmt.Fprintf(&b, "matched VID:PID %04x:%04x serial=%q\n", t.desc.VID, t.desc.PID, t.desc.Serial)
+
+	// The single most useful datum: which driver is *actually* bound.
+	// WinUsb_Initialize can succeed against a libusbK-style filter while
+	// the device still rejects raw vendor control writes.
+	svc, descr := lookupBoundDriver(t.desc.Path)
+	db := classifyWindows(t.desc, svc, descr)
+	fmt.Fprintf(&b, "bound driver: service=%q desc=%q (winusb-bound=%t)\n", fallbackString(svc, "<none>"), descr, db.OK)
+	if db.Hint != "" {
+		fmt.Fprintf(&b, "  driver hint: %s\n", db.Hint)
+	}
+
+	if dev, err := t.getDescriptor(descTypeDevice, 0, 18); err != nil {
+		fmt.Fprintf(&b, "device descriptor: unavailable (%v)\n", err)
+	} else if len(dev) >= 18 {
+		fmt.Fprintf(&b, "device descriptor: bcdUSB=%x.%02x class=%d sub=%d proto=%d maxPacket0=%d idVendor=%04x idProduct=%04x bcdDevice=%x.%02x iMfr=%d iProd=%d iSerial=%d numCfg=%d\n",
+			dev[3], dev[2], dev[4], dev[5], dev[6], dev[7],
+			uint16(dev[8])|uint16(dev[9])<<8, uint16(dev[10])|uint16(dev[11])<<8,
+			dev[13], dev[12], dev[14], dev[15], dev[16], dev[17])
+	} else {
+		fmt.Fprintf(&b, "device descriptor: short read (%d bytes: % x)\n", len(dev), dev)
+	}
+
+	// Config descriptor: read the 9-byte header for wTotalLength, then
+	// re-read the whole thing so the interface/endpoint walk is complete.
+	if hdr, err := t.getDescriptor(descTypeConfig, 0, 9); err != nil {
+		fmt.Fprintf(&b, "config descriptor: unavailable (%v)\n", err)
+	} else if len(hdr) >= 9 {
+		total := int(uint16(hdr[2]) | uint16(hdr[3])<<8)
+		if total < 9 || total > 4096 {
+			total = 256
+		}
+		full, err := t.getDescriptor(descTypeConfig, 0, total)
+		if err != nil || len(full) < 9 {
+			full = hdr
+		}
+		fmt.Fprintf(&b, "config descriptor: numInterfaces=%d configValue=%d attrs=0x%02x totalLen=%d\n", hdr[4], hdr[5], hdr[7], total)
+		describeInterfaces(&b, full)
+	}
+
+	// Control-IN read probe: can the device service vendor reads at all?
+	// Reading USB_SYSCTL (block=USB, addr=0x2000) mirrors a rtl2832u
+	// read_reg. If reads succeed while the USB_SYSCTL *write* fails, the
+	// firmware/driver is rejecting OUT transfers specifically — a very
+	// different problem from "the device is wedged".
+	if in, err := t.ControlIn(0, 0x2000, uint16(1)<<8, 1, 300); err != nil {
+		fmt.Fprintf(&b, "control-IN probe (read block=USB addr=0x2000): FAILED (%v)\n", err)
+	} else {
+		fmt.Fprintf(&b, "control-IN probe (read block=USB addr=0x2000): ok, got % x\n", in)
+	}
+	return b.String()
+}
+
+// getDescriptor wraps WinUsb_GetDescriptor for the standard descriptor
+// types, returning the bytes the device actually sent. Best-effort: any
+// failure surfaces as an error the caller folds into the diagnostic dump.
+func (t *winTransport) getDescriptor(descType, index uint8, length int) ([]byte, error) {
+	if t.closed.Load() {
+		return nil, ErrClosed
+	}
+	if length <= 0 {
+		return nil, fmt.Errorf("winusb: bad descriptor length %d", length)
+	}
+	buf := make([]byte, length)
+	var transferred uint32
+	ret, _, errno := procWinUsbGetDescriptor.Call(
+		t.ifaceHandle,
+		uintptr(descType),
+		uintptr(index),
+		0, // LanguageID (0 for device/config descriptors)
+		uintptr(unsafe.Pointer(&buf[0])),
+		uintptr(length),
+		uintptr(unsafe.Pointer(&transferred)),
+	)
+	if ret == 0 {
+		return nil, winErr(errno)
+	}
+	if int(transferred) > len(buf) {
+		transferred = uint32(len(buf))
+	}
+	return buf[:transferred], nil
+}
+
+// describeInterfaces walks a raw USB configuration descriptor and emits
+// one line per interface and per endpoint. It tolerates truncated /
+// malformed input by bailing out the moment a length field doesn't fit.
+func describeInterfaces(b *strings.Builder, cfg []byte) {
+	for i := 0; i+2 <= len(cfg); {
+		l := int(cfg[i])
+		if l < 2 || i+l > len(cfg) {
+			break
+		}
+		switch cfg[i+1] {
+		case 0x04: // INTERFACE
+			if l >= 9 {
+				fmt.Fprintf(b, "  interface: num=%d alt=%d numEndpoints=%d class=%d sub=%d proto=%d\n",
+					cfg[i+2], cfg[i+3], cfg[i+4], cfg[i+5], cfg[i+6], cfg[i+7])
+			}
+		case 0x05: // ENDPOINT
+			if l >= 7 {
+				fmt.Fprintf(b, "    endpoint: addr=0x%02x attrs=0x%02x maxPacket=%d interval=%d\n",
+					cfg[i+2], cfg[i+3], int(uint16(cfg[i+4])|uint16(cfg[i+5])<<8), cfg[i+6])
+			}
+		}
+		i += l
+	}
 }
 
 // ----------------------------------------------------------------------


### PR DESCRIPTION
## Follow-up to #481

#481 made the warmup write non-fatal. The user's retest (new installer) confirmed that fix shipped — the error moved from the warmup stage to **`init baseband step 0`** (the byte-identical write the sacrificial warmup was meant to shield) and now shows the corrected `gophertrunk.org/install-windows.html` URL. But the write still genuinely fails with `ERROR_GEN_FAILURE` on the affected clone dongle, so this PR does two things.

## 1. Clear-halt + retry stalled control writes

`winTransport.ControlOut` now clears the control-pipe halt (`WinUsb_ResetPipe` pipe 0) and **retries the write once** when it stalls with `ERROR_GEN_FAILURE` (`ErrPipeStalled`).

Per the USB spec the next SETUP should auto-clear a control-endpoint halt, but some clone RTL2832U firmwares need the explicit `CLEAR_FEATURE` first — which is exactly what libusb's WinUSB backend does. This gives the byte-identical `InitBaseband` step 0 a clean pipe even when the swallowed warmup stall left the endpoint halted. Adds the `WinUsb_GetDescriptor` binding.

## 2. Append a full USB diagnostics dump on failure

When bring-up ultimately fails, `openDevice` now appends a diagnostics block to the error (new `usb.Diagnoser` optional interface, implemented by the Windows transport):

- the **actually-bound driver** (WinUSB vs libusbK vs DVB vs none) — `WinUsb_Initialize` can succeed against a libusbK filter while the device still rejects raw vendor writes;
- the **device + configuration descriptors** (interfaces + endpoints);
- a **control-IN read probe** — if reads succeed while the `USB_SYSCTL` write fails, the firmware/driver is rejecting OUT transfers specifically, a very different problem from "the device is wedged".

One `gophertrunk sdr list --probe` run now captures everything needed to triage the failure remotely. The dump is forwarded through the `RTLSDR_DEBUG_USB` debug wrapper and stubbed in `MockTransport`.

## Verification

- `go test ./...` — all pass (new tests: diagnostics appended on failure; silent-transport no-op).
- `go build ./...`, `go vet ./...`, and `GOOS=windows GOARCH={amd64,arm64} go build ./...` all clean.
- End-to-end confirmation needs the affected Windows hardware — the `Windows installer (PR)` workflow on this PR builds a downloadable `setup.exe`. If it still fails, the new diagnostics block in the error output is the data needed to pinpoint the cause.

https://claude.ai/code/session_01Ph6iruL2n2JKZDZUsRmRvK

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ph6iruL2n2JKZDZUsRmRvK)_