### PR TITLE
rtlsdr/winusb: pass WINUSB_SETUP_PACKET by value (fix all vendor control I/O on Windows)

### DIFF
--- a/internal/sdr/rtlsdr/usb/usb_windows.go
+++ b/internal/sdr/rtlsdr/usb/usb_windows.go
@@ -242,6 +242,30 @@ type winusbSetupPacket struct {
 	Length      uint16
 }
 
+// pack folds the setup packet into a single uintptr. This is load-bearing
+// and the reason vendor control transfers never worked on real Windows
+// hardware before: the WinUsb_ControlTransfer prototype takes the
+// WINUSB_SETUP_PACKET **by value**, and the x64/arm64 calling convention
+// passes an 8-byte struct in one integer register. Go's
+// syscall.proc.Call(...uintptr) marshals each argument as exactly one
+// register, so the setup packet must arrive as the 8 bytes packed into a
+// uintptr — NOT as a pointer to the struct. Passing a pointer made WinUSB
+// interpret the pointer's low bytes as bmRequestType/bRequest/wValue/...,
+// i.e. a garbage vendor request the device timed out on or rejected with
+// ERROR_GEN_FAILURE, while standard descriptor requests (which go through
+// WinUsb_GetDescriptor, a different prototype) kept working — exactly the
+// split the field diagnostics showed. The byte order below matches the
+// struct's little-endian in-memory layout on every supported target
+// (amd64, arm64), so it is identical to what a by-value struct push would
+// place in the register.
+func (p winusbSetupPacket) pack() uintptr {
+	return uintptr(uint64(p.RequestType) |
+		uint64(p.Request)<<8 |
+		uint64(p.Value)<<16 |
+		uint64(p.Index)<<32 |
+		uint64(p.Length)<<48)
+}
+
 func (t *winTransport) applyControlTimeout(timeoutMs int) {
 	if timeoutMs <= 0 {
 		return
@@ -281,7 +305,7 @@ func (t *winTransport) ControlIn(bRequest uint8, wValue, wIndex uint16, n int, t
 	var transferred uint32
 	ret, _, errno := procWinUsbControlTransfer.Call(
 		t.ifaceHandle,
-		uintptr(unsafe.Pointer(&pkt)),
+		pkt.pack(), // WINUSB_SETUP_PACKET is passed BY VALUE (see pack)
 		bufPtr,
 		uintptr(n),
 		uintptr(unsafe.Pointer(&transferred)),
@@ -315,7 +339,7 @@ func (t *winTransport) ControlOut(bRequest uint8, wValue, wIndex uint16, data []
 	var transferred uint32
 	ret, _, errno := procWinUsbControlTransfer.Call(
 		t.ifaceHandle,
-		uintptr(unsafe.Pointer(&pkt)),
+		pkt.pack(), // WINUSB_SETUP_PACKET is passed BY VALUE (see pack)
 		dataPtr,
 		uintptr(len(data)),
 		uintptr(unsafe.Pointer(&transferred)),
@@ -338,7 +362,7 @@ func (t *winTransport) ControlOut(bRequest uint8, wValue, wIndex uint16, data []
 			procWinUsbResetPipe.Call(t.ifaceHandle, 0)
 			ret, _, errno = procWinUsbControlTransfer.Call(
 				t.ifaceHandle,
-				uintptr(unsafe.Pointer(&pkt)),
+				pkt.pack(), // WINUSB_SETUP_PACKET is passed BY VALUE (see pack)
 				dataPtr,
 				uintptr(len(data)),
 				uintptr(unsafe.Pointer(&transferred)),

--- a/internal/sdr/rtlsdr/usb/usb_windows_test.go
+++ b/internal/sdr/rtlsdr/usb/usb_windows_test.go
@@ -90,6 +90,36 @@ func TestSetupPacketSize(t *testing.T) {
 	}
 }
 
+func TestSetupPacketPack_MatchesByValueLayout(t *testing.T) {
+	// WinUsb_ControlTransfer takes WINUSB_SETUP_PACKET BY VALUE; the
+	// x64/arm64 ABI passes the 8-byte struct in one integer register, so
+	// pack() must produce exactly the bytes a by-value struct push would
+	// place there. Compare pack() against the struct's own little-endian
+	// in-memory image — the ground truth for the register contents.
+	pkt := winusbSetupPacket{
+		RequestType: VendorIn, // 0xC0
+		Request:     0x02,
+		Value:       0x3000,
+		Index:       0x0110,
+		Length:      0x0001,
+	}
+	want := *(*uint64)(unsafe.Pointer(&pkt))
+	if got := uint64(pkt.pack()); got != want {
+		t.Errorf("pack() = 0x%016x, want 0x%016x (must equal the by-value register image)", got, want)
+	}
+
+	// Spot-check the field placement explicitly so a future struct
+	// reorder can't silently pass via the layout-equality check alone.
+	const wantExplicit = uint64(0xC0) |
+		uint64(0x02)<<8 |
+		uint64(0x3000)<<16 |
+		uint64(0x0110)<<32 |
+		uint64(0x0001)<<48
+	if got := uint64(pkt.pack()); got != wantExplicit {
+		t.Errorf("pack() = 0x%016x, want 0x%016x (explicit field placement)", got, wantExplicit)
+	}
+}
+
 func TestDeviceInterfaceDataSize(t *testing.T) {
 	// SP_DEVICE_INTERFACE_DATA on x64 must be 32 bytes for
 	// SetupDiEnumDeviceInterfaces to accept the input.


### PR DESCRIPTION
## The actual root cause

This is **why RTL-SDR control transfers have never worked on real Windows hardware**, and the reason the timing fixes in #481 / #482 couldn't help.

`WinUsb_ControlTransfer` takes the `WINUSB_SETUP_PACKET` **by value** — the x64/arm64 calling convention passes the 8-byte struct in a single integer register. The code was passing a **pointer** to the struct instead. WinUSB then read the pointer's low bytes as `bmRequestType/bRequest/wValue/wIndex/wLength` — a garbage vendor request the device either timed out on (`ERROR_SEM_TIMEOUT`) or rejected with `ERROR_GEN_FAILURE`. The malformed transfer never made it onto the wire correctly, so no amount of warmup/settle/clear-halt tuning could fix it.

## How the field diagnostics proved it

The `--- USB diagnostics ---` dump added in #482 made it unambiguous on the user's two dongles:

```
bound driver: service="winusb" ... (winusb-bound=true)        ✅ driver correct
device descriptor: ... idVendor=0bda idProduct=2838 ...        ✅ reads work
config descriptor: numInterfaces=1 ... endpoint addr=0x81 ...  ✅ reads work
control-IN probe (read block=USB addr=0x2000): transfer timed out   ❌ vendor I/O fails
```

Standard descriptor requests succeed (they go through `WinUsb_GetDescriptor`, a different prototype) while **every** vendor control transfer — reads *and* writes — fails. That exact split is the by-value-vs-by-pointer bug, not driver binding, power, or firmware timing.

## Fix

- Add `winusbSetupPacket.pack()` to fold the 8-byte packet into the `uintptr` argument (little-endian, matching the struct's in-memory image on amd64/arm64 — identical to a by-value register push).
- Use it at all three `WinUsb_ControlTransfer` call sites: `ControlIn`, `ControlOut`, and the clear-halt retry.
- Golden test pins `pack()` against the struct's by-value register image **and** the explicit field placement (so a future field reorder can't silently regress it).

The warmup-non-fatal (#481) and clear-halt-retry + diagnostics (#482) changes remain correct defenses for genuine clone-firmware stalls — but this packing fix is what lets the first vendor transfer succeed at all.

## Verification

- `go test ./...` — all pass.
- `go build`, `go vet`, and `GOOS=windows GOARCH={amd64,arm64} go vet` (compiles the Windows test files incl. the new `pack` golden test) — all clean.
- End-to-end confirmation needs the affected Windows hardware; the `Windows installer (PR)` workflow on this PR produces a downloadable `setup.exe` for that test.

https://claude.ai/code/session_01Ph6iruL2n2JKZDZUsRmRvK

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ph6iruL2n2JKZDZUsRmRvK)_