### PR TITLE
iqtap/rtlsdr: fix broker close race + surface live IQ drops (#402)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ for tagged releases.
 
 ## [Unreleased]
 
+### Fixed
+
+- **iqtap broker `send on closed channel` panic** (#402) — closing an IQ
+  subscriber (live spectrum, `--iq-capture`, diagnostics) concurrently
+  with an in-flight fan-out could crash the daemon: `fanout` checked the
+  closed flag and then sent after dropping `subsMu`, while `Subscriber.Close`
+  closed the channel under the lock, leaving a window where the send
+  raced the close. Per-subscriber send and close now share a `sendMu` so a
+  fan-out send can never land on a closed channel. Covered by a new
+  `-race` regression test in `internal/sdr/iqtap`.
+
+### Added
+
+- **Live IQ-drop telemetry** (#402) — IQ chunks dropped on overrun by an
+  SDR backend (the consumer falling behind) were silent, making live IQ
+  loss indistinguishable from RF problems. Drops now bump the existing
+  `iq_underruns_total` Prometheus counter (labelled by driver + serial)
+  and emit a warning throttled to one line per second per device, via a
+  process-wide `sdr.SetIQDropObserver` hook the daemon installs at
+  start-up. A rising counter during decode confirms a live-path overrun
+  (offline replay never drops) and explains downstream TSBK CRC failures.
+
+### Changed
+
+- **iqtap broker primary handoff is now lightly buffered** (#402) — the
+  broker's primary IQ channel gained a small (2-chunk) buffer so the
+  fan-out goroutine isn't stalled by a momentarily-busy primary consumer
+  (the per-chunk copy plus a brief decode hiccup), which previously could
+  back up the SDR reaper and force whole-chunk drops. The inner driver's
+  buffer still bounds latency, so sustained back-pressure still drops as
+  before.
+
 ## [v0.2.9] — 2026-06-01
 
 Phase 3 paging completes and M17 joins the digital lineup, while the

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/MattCheramie/GopherTrunk/internal/api"
@@ -581,6 +582,13 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 		}
 		d.metrics = m
 	}
+
+	// Surface live IQ chunk drops (silent before issue #402): wire the
+	// process-wide drop observer so an overrunning SDR reaper bumps
+	// iq_underruns_total and logs a rate-limited warning. This is the
+	// signal that distinguishes a live-path overrun (replay never drops)
+	// from an RF problem.
+	d.installIQDropObserver(log)
 
 	// Voice device list from the pool; empty when no SDRs.
 	d.voicePool = trunking.NewVoicePool(d.collectVoiceDevices())
@@ -2158,6 +2166,42 @@ func (d *Daemon) HTTPListenAddr() string {
 // Bus returns the daemon's events bus. Tests use it to inject
 // synthetic events.
 func (d *Daemon) Bus() *events.Bus { return d.bus }
+
+// installIQDropObserver wires the process-wide SDR drop observer
+// (sdr.SetIQDropObserver) so every IQ chunk a backend discards on overrun
+// bumps the iq_underruns_total metric and emits a rate-limited warning.
+// Before issue #402 these drops were silent, leaving live IQ loss
+// indistinguishable from RF problems; the metric/log let an operator
+// confirm a live-path overrun (replay never drops) and correlate it with
+// downstream TSBK CRC failures. The warning is throttled to one line per
+// second per dropping device, carrying the count accumulated since the
+// last line so a steady overrun doesn't flood the log.
+func (d *Daemon) installIQDropObserver(log *slog.Logger) {
+	type dropState struct {
+		lastLogNanos atomic.Int64
+		sinceLog     atomic.Uint64
+	}
+	var states sync.Map // serial -> *dropState
+	sdr.SetIQDropObserver(func(info sdr.Info) {
+		if d.metrics != nil {
+			d.metrics.RecordIQUnderrun(info.Driver, info.Serial)
+		}
+		v, _ := states.LoadOrStore(info.Serial, &dropState{})
+		st := v.(*dropState)
+		st.sinceLog.Add(1)
+		now := time.Now().UnixNano()
+		prev := st.lastLogNanos.Load()
+		if now-prev < int64(time.Second) {
+			return
+		}
+		if !st.lastLogNanos.CompareAndSwap(prev, now) {
+			return // another drop won this second's log slot
+		}
+		log.Warn("sdr: dropping live IQ chunks; consumer can't keep up",
+			"driver", info.Driver, "serial", info.Serial,
+			"dropped_since_last", st.sinceLog.Swap(0))
+	})
+}
 
 // IQBroker returns the iqtap.Broker for the SDR with the given serial,
 // or nil when no such SDR is in the pool. Used by the --iq-capture

--- a/internal/sdr/iqdrop.go
+++ b/internal/sdr/iqdrop.go
@@ -1,0 +1,36 @@
+package sdr
+
+import "sync/atomic"
+
+// iqDropObserver, when set, is invoked once per IQ chunk a driver
+// discards because the primary consumer fell behind. It is process-wide
+// because SDR backends self-register via init() with a zero-value driver,
+// so there is no constructor seam to thread a per-device sink through.
+// The daemon installs an observer once during bring-up; tools and tests
+// that don't wire metrics leave it nil. The atomic pointer keeps the
+// hot-path read lock-free and safe against the one-time set. Issue #402:
+// live chunk drops were silent before this hook, so live IQ loss could
+// not be told apart from RF problems.
+var iqDropObserver atomic.Pointer[func(Info)]
+
+// SetIQDropObserver installs fn as the process-wide IQ-drop observer. fn
+// is called (on the dropping driver's reaper goroutine) once per dropped
+// chunk with the device's Info, so the caller can record the
+// iq_underruns_total metric and emit a rate-limited warning. Passing nil
+// clears the observer. Safe to call concurrently with active streams.
+func SetIQDropObserver(fn func(Info)) {
+	if fn == nil {
+		iqDropObserver.Store(nil)
+		return
+	}
+	iqDropObserver.Store(&fn)
+}
+
+// NotifyIQDrop reports that the device described by info dropped one IQ
+// chunk. Backends call it from their stream reaper's overrun branch. It
+// is a no-op when no observer is installed. Safe for any goroutine.
+func NotifyIQDrop(info Info) {
+	if obs := iqDropObserver.Load(); obs != nil {
+		(*obs)(info)
+	}
+}

--- a/internal/sdr/iqtap/broker.go
+++ b/internal/sdr/iqtap/broker.go
@@ -47,6 +47,17 @@ import (
 // fast enough to be visible in the drop counter.
 const DefaultSubBuffer = 16
 
+// primaryHandoffDepth is the buffer depth (in IQ chunks) of the broker's
+// primary handoff channel returned by StreamIQ. A small buffer lets the
+// fan-out goroutine stay ahead of a momentarily-busy primary consumer (the
+// per-chunk fanout copy plus a brief decode hiccup) without stalling its
+// drain of the inner device's bounded reaper buffer — which would otherwise
+// force the driver to drop whole IQ chunks mid-frame (issue #402). It stays
+// small so the inner driver's buffer remains the dominant latency bound and
+// a wedged consumer still falls behind fast enough to surface in the drop
+// counter.
+const primaryHandoffDepth = 2
+
 // Broker wraps an sdr.Device, exposing the same Device interface
 // while internally fanning each IQ chunk out to any registered
 // Subscribers. The primary consumer that calls StreamIQ sees no
@@ -85,6 +96,13 @@ type Subscriber struct {
 	dropped atomic.Uint64
 	b       *Broker
 	closed  atomic.Bool
+
+	// sendMu serialises a non-blocking send (trySend) against Close so a
+	// fanout send can never race the close(ch): Close holds sendMu while
+	// it closes the channel, and trySend re-checks closed under sendMu
+	// before sending. The atomic closed flag remains the cheap, lock-free
+	// pre-check used by fanout and Stats.
+	sendMu sync.Mutex
 }
 
 // Stats reports broker-level counters. Useful for /metrics and for
@@ -216,10 +234,11 @@ func (b *Broker) Close() error {
 // primary channel, matching the contract every real driver
 // implementation honours.
 //
-// The primary's channel is unbuffered so back-pressure from a slow
-// primary propagates upstream exactly as it does today (i.e. the
-// underlying driver's USB reaper buffer absorbs jitter; if it fills,
-// the driver drops). Secondaries are decoupled via their own bounded
+// The primary's channel has a small buffer (primaryHandoffDepth) so the
+// fan-out goroutine isn't stalled by a momentarily-busy primary consumer;
+// sustained back-pressure from a slow primary still propagates upstream
+// (i.e. the underlying driver's USB reaper buffer absorbs jitter; if it
+// fills, the driver drops). Secondaries are decoupled via their own bounded
 // channels and never block the primary.
 func (b *Broker) StreamIQ(ctx context.Context) (<-chan []complex64, error) {
 	b.innerMu.RLock()
@@ -234,7 +253,7 @@ func (b *Broker) StreamIQ(ctx context.Context) (<-chan []complex64, error) {
 	}
 	b.streamActive.Store(true)
 
-	out := make(chan []complex64)
+	out := make(chan []complex64, primaryHandoffDepth)
 	go func() {
 		defer close(out)
 		defer b.streamActive.Store(false)
@@ -258,10 +277,10 @@ func (b *Broker) fanout(chunk []complex64) {
 		b.subsMu.Unlock()
 		return
 	}
-	// Snapshot the subscriber set so we can drop the lock before
-	// allocating + sending — a concurrent Subscribe / Close can't
-	// race a send into a closed channel because Close transitions
-	// the closed flag under the same lock we just dropped.
+	// Snapshot the subscriber set so we can drop subsMu before allocating
+	// + sending. The closed-vs-send race is handled per subscriber by
+	// trySend / Close sharing s.sendMu — not by subsMu — so a concurrent
+	// Subscribe / Close here is safe.
 	subs := make([]*Subscriber, 0, len(b.subs))
 	for s := range b.subs {
 		subs = append(subs, s)
@@ -269,17 +288,34 @@ func (b *Broker) fanout(chunk []complex64) {
 	b.subsMu.Unlock()
 
 	for _, s := range subs {
+		// Cheap lock-free early-out: skip the allocation for a
+		// subscriber that's already closed. trySend re-checks under
+		// s.sendMu for correctness.
 		if s.closed.Load() {
 			continue
 		}
 		cp := make([]complex64, len(chunk))
 		copy(cp, chunk)
-		select {
-		case s.ch <- cp:
-		default:
-			s.dropped.Add(1)
-			b.subsDropped.Add(1)
-		}
+		s.trySend(cp)
+	}
+}
+
+// trySend delivers a pre-copied chunk to the subscriber's channel without
+// blocking. s.sendMu serialises the non-blocking send against Close: Close
+// holds the same mutex while it closes the channel, so re-checking closed
+// under the lock here guarantees the send can never land on a closed
+// channel. Drops (full buffer) are counted, never blocking.
+func (s *Subscriber) trySend(cp []complex64) {
+	s.sendMu.Lock()
+	defer s.sendMu.Unlock()
+	if s.closed.Load() {
+		return
+	}
+	select {
+	case s.ch <- cp:
+	default:
+		s.dropped.Add(1)
+		s.b.subsDropped.Add(1)
 	}
 }
 
@@ -315,11 +351,15 @@ func (s *Subscriber) Close() {
 	if s.closed.Swap(true) {
 		return
 	}
-	s.b.subsMu.Lock()
-	if _, ok := s.b.subs[s]; ok {
-		delete(s.b.subs, s)
-	}
+	// Close the channel under sendMu so it can't interleave a concurrent
+	// trySend. closed is already true (set above), so any trySend that
+	// acquires sendMu after this returns without sending.
+	s.sendMu.Lock()
 	close(s.ch)
+	s.sendMu.Unlock()
+
+	s.b.subsMu.Lock()
+	delete(s.b.subs, s)
 	s.b.subsMu.Unlock()
 }
 

--- a/internal/sdr/iqtap/broker_test.go
+++ b/internal/sdr/iqtap/broker_test.go
@@ -532,3 +532,66 @@ func TestBrokerSeedZeroLeavesFieldsUnchanged(t *testing.T) {
 		t.Errorf("SampleRateHz after Seed(0, 1_024_000) = %d, want 1_024_000", got)
 	}
 }
+
+// TestBrokerFanoutCloseRace exercises the concurrent-Close-vs-fanout path
+// that previously panicked with "send on closed channel": fanout snapshots
+// the subscriber set and sends after dropping subsMu, so a Close that ran
+// close(s.ch) between the closed-flag check and the send would crash. With
+// trySend / Close sharing s.sendMu the send can never land on a closed
+// channel. Run under `go test -race` to also surface data races.
+func TestBrokerFanoutCloseRace(t *testing.T) {
+	dev := newFakeDevice("dev-race")
+	b := New(dev, 1, nil) // tiny buffer so fanout frequently hits the send
+
+	chunk := []complex64{complex(1, 0), complex(2, 0)}
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	// Fanout hammer: repeatedly fan the same chunk out to whatever
+	// subscribers currently exist. This is the goroutine that used to
+	// panic.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				b.fanout(chunk)
+			}
+		}
+	}()
+
+	// Churn: continuously Subscribe, (maybe) read, and Close so a Close
+	// races concurrent fanout sends. A second goroutine drains some
+	// subscribers to keep buffers cycling.
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			deadline := time.Now().Add(200 * time.Millisecond)
+			for time.Now().Before(deadline) {
+				s := b.Subscribe()
+				// Drain a few chunks then close; also exercise the
+				// drop path by sometimes not draining at all.
+				done := make(chan struct{})
+				go func() {
+					for range s.C {
+					}
+					close(done)
+				}()
+				time.Sleep(time.Millisecond)
+				s.Close()
+				<-done
+				// Close again to assert idempotency under concurrency.
+				s.Close()
+			}
+		}()
+	}
+
+	time.Sleep(220 * time.Millisecond)
+	close(stop)
+	wg.Wait()
+}

--- a/internal/sdr/rtlsdr/purego/device.go
+++ b/internal/sdr/rtlsdr/purego/device.go
@@ -42,8 +42,19 @@ type Device struct {
 	out      chan []complex64
 	stopOnce sync.Once
 
+	// dropped counts IQ chunks discarded by deliver's overrun branch
+	// over this device's lifetime. Exposed via DroppedChunks for tests
+	// and as the per-drop signal behind the dropObserver hook.
+	dropped atomic.Uint64
+
 	closed atomic.Bool
 }
+
+// DroppedChunks returns the cumulative number of IQ chunks deliver has
+// discarded because the consumer fell behind. A rising value is the
+// device-level signal behind the iq_underruns_total metric — deliver
+// also reports each drop via [sdr.NotifyIQDrop].
+func (d *Device) DroppedChunks() uint64 { return d.dropped.Load() }
 
 // Info returns the descriptor populated by [Driver.Open] — driver
 // name, USB index, serial / manufacturer / product strings, tuner

--- a/internal/sdr/rtlsdr/purego/stream.go
+++ b/internal/sdr/rtlsdr/purego/stream.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+
+	"github.com/MattCheramie/GopherTrunk/internal/sdr"
 )
 
 // Async-bulk geometry copied verbatim from the CGO driver
@@ -99,9 +101,16 @@ func (d *Device) deliver(buf []byte) {
 	select {
 	case out <- samples:
 	default:
-		// Consumer can't keep up. Drop. The application's
-		// `iq-underrun` Prometheus counter is the operator-facing
-		// telemetry for this — see internal/metrics.
+		// Consumer can't keep up. Drop the whole chunk and record it:
+		// this was silent before issue #402, which is why live IQ loss
+		// could not be distinguished from RF problems. A non-zero
+		// iq_underruns_total / drop count during decode points at a
+		// live-path overrun rather than the air. The dropObserver hook
+		// drives the operator-facing Prometheus counter + a
+		// rate-limited warning — see internal/metrics and
+		// sdr.SetIQDropObserver.
+		d.dropped.Add(1)
+		sdr.NotifyIQDrop(d.info)
 	}
 }
 

--- a/internal/sdr/rtlsdr/purego/stream_test.go
+++ b/internal/sdr/rtlsdr/purego/stream_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"math"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -339,5 +340,59 @@ func TestStreamConstants_MatchCGOGeometry(t *testing.T) {
 	}
 	if bulkInEndpoint != 0x81 {
 		t.Errorf("bulkInEndpoint = 0x%02x, want 0x81", bulkInEndpoint)
+	}
+}
+
+// TestDeliver_DropsAndNotifiesObserverOnOverrun is the issue-#402
+// regression: a chunk dropped because the consumer is behind must bump
+// the device drop counter AND fire sdr.NotifyIQDrop with the device's
+// Info, so the daemon can surface it as iq_underruns_total + a warning.
+// Before #402 the overrun branch was silent.
+func TestDeliver_DropsAndNotifiesObserverOnOverrun(t *testing.T) {
+	d := newDeviceWithFakeTuner(usb.NewMockTransport(), &fakeTuner{})
+	d.info = sdr.Info{Driver: DriverName, Serial: "drop-test"}
+
+	// Unbuffered channel with no reader: every non-blocking send takes
+	// the default (drop) branch.
+	d.out = make(chan []complex64)
+
+	var observed atomic.Int64
+	var mu sync.Mutex
+	var gotInfo sdr.Info
+	sdr.SetIQDropObserver(func(info sdr.Info) {
+		observed.Add(1)
+		mu.Lock()
+		gotInfo = info
+		mu.Unlock()
+	})
+	t.Cleanup(func() { sdr.SetIQDropObserver(nil) })
+
+	const n = 3
+	for i := 0; i < n; i++ {
+		d.deliver([]byte{127, 128, 127, 128})
+	}
+
+	if got := d.DroppedChunks(); got != n {
+		t.Errorf("DroppedChunks = %d, want %d", got, n)
+	}
+	if got := observed.Load(); got != int64(n) {
+		t.Errorf("observer invoked %d times, want %d", got, n)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if gotInfo.Serial != "drop-test" || gotInfo.Driver != DriverName {
+		t.Errorf("observer info = %+v, want Driver=%q Serial=drop-test", gotInfo, DriverName)
+	}
+}
+
+// TestDeliver_NoObserverIsSafe ensures the overrun branch still counts
+// drops and never panics when no observer is installed (tools, tests).
+func TestDeliver_NoObserverIsSafe(t *testing.T) {
+	sdr.SetIQDropObserver(nil)
+	d := newDeviceWithFakeTuner(usb.NewMockTransport(), &fakeTuner{})
+	d.out = make(chan []complex64)
+	d.deliver([]byte{127, 128})
+	if got := d.DroppedChunks(); got != 1 {
+		t.Errorf("DroppedChunks = %d, want 1", got)
 	}
 }


### PR DESCRIPTION
Issue #402's live decode showed persistent TSBK CRC failures
(predominantly block=2) while offline replay decoded the same captures
perfectly, plus an intermittent "send on closed channel" panic. Both
trace to the live-only iqtap broker path that replay never exercises.

Broker panic: fanout checked Subscriber.closed and then sent after
dropping subsMu, while Subscriber.Close closed the channel under that
lock — leaving a window where the send raced the close. Per-subscriber
send and close now share a sendMu so a fan-out send can never land on a
closed channel. Adds a -race regression test that reproduces the panic
on the old code.

Live IQ drops: the pure-Go RTL-SDR backend silently dropped whole IQ
chunks on consumer overrun (deliver's default branch), so live IQ loss
was indistinguishable from RF — and a mid-TSDU gap corrupts the latest
TSBK block first, matching the block=2 pattern. Drops now bump the
existing iq_underruns_total counter and emit a rate-limited warning via
a new process-wide sdr.SetIQDropObserver hook the daemon installs at
start-up; replay never drops, so a rising counter confirms a live-path
overrun.

Also give the broker's primary handoff a small buffer so the fan-out
goroutine isn't stalled by a momentarily-busy primary consumer, which
previously could back up the reaper and force drops.

https://claude.ai/code/session_01U4fxKomYJpuBEePndU1iRv