### PR TITLE
rtlsdr: apply PPM correction to the tuner LO, not just the resampler (#264)

### DIFF
--- a/internal/sdr/rtlsdr/purego/device.go
+++ b/internal/sdr/rtlsdr/purego/device.go
@@ -118,7 +118,13 @@ func (d *Device) SetGain(tenthDB int) error {
 	return nil
 }
 
-// SetPPM applies a parts-per-million correction to the resampler.
+// SetPPM applies a parts-per-million correction to both the RTL2832U
+// resampler clock and the tuner LO, mirroring librtlsdr's
+// rtlsdr_set_freq_correction (which corrects the sample clock and
+// re-tunes the LO). Correcting only the resampler — as this did before
+// issue #264 — left the tuner carrier offset in the signal, so a
+// configured ppm appeared to have no effect and digital decode broke on
+// dongles whose crystal sits far enough off nominal (the R828D V4).
 // Negative slows the chip; positive speeds it up.
 func (d *Device) SetPPM(ppm int) error {
 	if d.closed.Load() {
@@ -126,6 +132,14 @@ func (d *Device) SetPPM(ppm int) error {
 	}
 	if err := d.demod.SetSampleFreqCorrection(ppm); err != nil {
 		return fmt.Errorf("rtlsdr: SetPPM(%d): %w", ppm, err)
+	}
+	// Push the same correction to the tuner LO. Optional interface so
+	// only tuners that model a reference crystal (the R82xx family)
+	// participate; others inherit the resampler-only behaviour.
+	if t, ok := d.tuner.(interface{ SetFreqCorrection(int) error }); ok {
+		if err := t.SetFreqCorrection(ppm); err != nil {
+			return fmt.Errorf("rtlsdr: SetPPM(%d): tuner LO: %w", ppm, err)
+		}
 	}
 	return nil
 }

--- a/internal/sdr/rtlsdr/tuners/r82xx.go
+++ b/internal/sdr/rtlsdr/tuners/r82xx.go
@@ -41,6 +41,7 @@ type R82xx struct {
 	manual   bool   // gain mode: true = manual, false = AGC
 	bwHz     uint32 // last requested bandwidth
 	freqHz   uint32 // last requested center frequency
+	ppmCorr  int    // tuner-LO frequency correction, parts-per-million
 }
 
 // NewR82xx constructs a driver bound to the given RTL2832U demod and
@@ -69,6 +70,44 @@ func NewR82xx(d *rtl2832u.Demod, i2cAddr uint8, chip Type) *R82xx {
 // defaults are set by [NewR82xx] (28.8 MHz for R820T/R820T2, 16 MHz
 // for R828D); SetXtal exists for boards that deviate from those.
 func (r *R82xx) SetXtal(hz uint32) { r.xtalHz = hz }
+
+// SetFreqCorrection applies a parts-per-million correction to the
+// tuner LO, mirroring the tuner half of librtlsdr's
+// rtlsdr_set_freq_correction. The RTL2832U sample-clock half is
+// applied separately via the demod's SetSampleFreqCorrection; without
+// this method a configured ppm only retimed the resampler and never
+// moved the carrier, so a real crystal offset stayed in the signal
+// (issue #264: the reporter's `ppm: -4` was "not adopted"). A static
+// carrier offset that survives here pushes the C4FM eye off the
+// fixed-threshold slicer and breaks digital decode.
+//
+// The correction biases the PLL reference in setPLL; if a frequency
+// has already been tuned it re-tunes so the change takes effect
+// immediately, otherwise the next SetFreq picks it up. No-op when the
+// value is unchanged.
+func (r *R82xx) SetFreqCorrection(ppm int) error {
+	if r.ppmCorr == ppm {
+		return nil
+	}
+	r.ppmCorr = ppm
+	if r.initDone && r.freqHz != 0 {
+		return r.SetFreq(r.freqHz)
+	}
+	return nil
+}
+
+// effectiveXtalHz returns the reference-crystal frequency adjusted for
+// the configured ppm correction, mirroring librtlsdr's APPLY_PPM_CORR
+// (xtal · (1 + ppm·1e-6)). A positive ppm raises the effective
+// reference so setPLL's registers target a slightly lower nominal LO,
+// compensating a fast crystal. ppm == 0 returns the raw crystal
+// unchanged, so the integer-divider math reproduces byte-for-byte.
+func (r *R82xx) effectiveXtalHz() uint32 {
+	if r.ppmCorr == 0 {
+		return r.xtalHz
+	}
+	return uint32(int64(r.xtalHz) + int64(r.xtalHz)*int64(r.ppmCorr)/1_000_000)
+}
 
 // Type returns the detected chip family.
 func (r *R82xx) Type() Type { return r.chipType }
@@ -430,7 +469,8 @@ func (r *R82xx) setPLL(freqHz uint32) error {
 		return err
 	}
 	vcoFreq := uint64(freqHz) * uint64(mixDiv)
-	pllRef := uint64(r.xtalHz)
+	effXtal := r.effectiveXtalHz()
+	pllRef := uint64(effXtal)
 	nint := uint32(vcoFreq / (2 * pllRef))
 	vcoFra := uint32((vcoFreq - 2*pllRef*uint64(nint)) / 1000)
 	if nint > r82xxMaxNint {
@@ -454,7 +494,7 @@ func (r *R82xx) setPLL(freqHz uint32) error {
 	// converges in ≤16 iterations because n_sdm doubles each step.
 	var sdm uint16
 	nSDM := uint32(2)
-	pllRefkHz := r.xtalHz / 1000
+	pllRefkHz := effXtal / 1000
 	for vcoFra > 1 {
 		if vcoFra > (2 * pllRefkHz / nSDM) {
 			sdm += 32768 / uint16(nSDM/2)

--- a/internal/sdr/rtlsdr/tuners/r82xx_test.go
+++ b/internal/sdr/rtlsdr/tuners/r82xx_test.go
@@ -722,6 +722,54 @@ func TestR82xx_PLLNintWithinEncoding_R828D(t *testing.T) {
 	}
 }
 
+// TestR82xx_PPMCorrectionShiftsPLLReference pins the issue #264 PPM fix:
+// SetPPM now reaches the tuner LO (not just the resampler) by biasing
+// setPLL's reference crystal. ppm == 0 must reproduce the raw crystal
+// exactly so all existing register-write scripts stay byte-identical.
+func TestR82xx_PPMCorrectionShiftsPLLReference(t *testing.T) {
+	r := NewR82xx(nil, r828dI2CAddr, TypeR828D)
+
+	// ppm == 0 reproduces the raw crystal exactly — the byte-for-byte
+	// guarantee for the existing setPLL scripts.
+	if got := r.effectiveXtalHz(); got != r828dXtalHz {
+		t.Errorf("effectiveXtalHz(ppm=0) = %d, want %d", got, r828dXtalHz)
+	}
+
+	// With no frequency tuned yet, SetFreqCorrection just stores the
+	// value (no retune that would deref the nil demod).
+	if err := r.SetFreqCorrection(50); err != nil {
+		t.Fatalf("SetFreqCorrection(50): %v", err)
+	}
+	want := uint32(int64(r828dXtalHz) + int64(r828dXtalHz)*50/1_000_000)
+	if got := r.effectiveXtalHz(); got != want {
+		t.Errorf("effectiveXtalHz(ppm=50) = %d, want %d (xtal·(1+ppm·1e-6))", got, want)
+	}
+
+	// A positive ppm raises the effective reference; a negative one
+	// lowers it. (A larger reference yields a smaller nint for the same
+	// LO, which is how the correction nudges the carrier.)
+	if err := r.SetFreqCorrection(-50); err != nil {
+		t.Fatalf("SetFreqCorrection(-50): %v", err)
+	}
+	if got := r.effectiveXtalHz(); got >= r828dXtalHz {
+		t.Errorf("effectiveXtalHz(ppm=-50) = %d, want < %d", got, r828dXtalHz)
+	}
+
+	// Idempotent: re-setting the same ppm is a no-op (returns before any
+	// retune), so it's safe to call on every SetPPM even with nil demod.
+	if err := r.SetFreqCorrection(-50); err != nil {
+		t.Fatalf("idempotent SetFreqCorrection(-50): %v", err)
+	}
+
+	// R820T/R820T2 share the mechanism off the 28.8 MHz crystal.
+	r2 := NewR82xx(nil, r82xxI2CAddr, TypeR820T2)
+	_ = r2.SetFreqCorrection(100)
+	want2 := uint32(int64(r82xxXtalHz) + int64(r82xxXtalHz)*100/1_000_000)
+	if got := r2.effectiveXtalHz(); got != want2 {
+		t.Errorf("R820T2 effectiveXtalHz(ppm=100) = %d, want %d", got, want2)
+	}
+}
+
 // Detect orchestrator tests moved to detect_test.go (it walks every
 // candidate tuner, not just R820T, so the scripts that pin its
 // behavior live with the orchestrator).


### PR DESCRIPTION
Device.SetPPM only called demod.SetSampleFreqCorrection, which writes the
RTL2832U resampler-ratio registers — it corrected the sample clock but
never re-tuned the tuner LO. librtlsdr's rtlsdr_set_freq_correction does
both, so a configured ppm left the tuner carrier offset in the signal:
the reporter's `ppm: -4` on an RTL-SDR Blog V4 (R828D) had no visible
effect, and the residual carrier offset broke DMR/digital decode while a
NooElec (whose crystal sits closer to nominal) decoded the same signal.

- tuners/r82xx: add SetFreqCorrection + effectiveXtalHz; bias setPLL's
  reference crystal by xtal·(1+ppm·1e-6) (librtlsdr APPLY_PPM_CORR). A
  positive ppm raises the effective reference so the PLL targets a
  slightly lower nominal LO, compensating a fast crystal. ppm==0 returns
  the raw crystal so the integer-divider math reproduces byte-for-byte
  (existing setPLL register scripts unchanged). Re-tunes if a frequency
  is already set; otherwise the next SetFreq picks it up.
- purego/device: SetPPM pushes the correction to the tuner LO via an
  optional interface, alongside the existing resampler correction, so
  only R82xx-family tuners participate.

Note: an in-receiver carrier AFC for DMR was prototyped and dropped — a
mean-based CoarseAFC chases DMR's per-burst symbol-DC and a
decision-directed AFC false-locks on a synthetic asymmetric eye (the
P25 issue #402 failure mode), both regressing the DMR T2 end-to-end
test. Correcting the offset at the tuner LO is the safe fix; a receiver
AFC can be revisited against a real V4 capture.

https://claude.ai/code/session_013aSDPE9Wiz8mktSM29Pfri