### PR TITLE
Surface silent recorder/composer misconfigs from field log report

### DIFF
--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -111,6 +112,48 @@ func warnGainUnits(log *slog.Logger, serial, raw string, tenthDB int) {
 		"parsed_db", float64(tenthDB)/10.0,
 		"did_you_mean", strconv.Itoa(tenthDB*10),
 		"hint", "gain: is in TENTHS of a dB (\"320\" = 32 dB). SDRTrunk/OP25/gqrx users multiply dB by 10. Use 'gain: auto' or run 'gophertrunk sdr list' for the supported ladder.")
+}
+
+// looksDriveRootedOnWindows reports whether p, when used on Windows,
+// would resolve to the root of the *current* drive (e.g. the Unix-style
+// default "/var/lib/gophertrunk/recordings" becomes "C:\var\lib\...")
+// because it is rooted but carries no drive letter and is not a UNC
+// path. Pure string logic so it is testable on any host OS — Go's
+// filepath.VolumeName/Clean use the build OS's rules and cannot be
+// exercised from Linux CI.
+func looksDriveRootedOnWindows(p string) bool {
+	if p == "" {
+		return false
+	}
+	if p[0] != '/' && p[0] != '\\' {
+		return false // relative, or "C:\..." with a drive letter — fine
+	}
+	if len(p) >= 2 && (p[1] == '/' || p[1] == '\\') {
+		return false // UNC path: \\server\share
+	}
+	return true
+}
+
+// warnWindowsDriveRootPaths surfaces config paths that will silently
+// land on the current drive's root on Windows because they were written
+// Unix-style (the hardcoded defaults are "/var/lib/gophertrunk/..."). It
+// is a no-op off Windows and never fails startup — operators on a
+// drive-root path are still functional, just in a surprising location.
+func warnWindowsDriveRootPaths(log *slog.Logger, cfg config.Config) {
+	if runtime.GOOS != "windows" {
+		return
+	}
+	for _, e := range []struct{ key, path string }{
+		{"recordings.dir", cfg.Recordings.Dir},
+		{"storage.path", cfg.Storage.Path},
+		{"storage.cc_cache_file", cfg.Storage.CCCacheFile},
+	} {
+		if looksDriveRootedOnWindows(e.path) {
+			log.Warn("daemon: config path has no drive letter; on Windows it resolves to the current drive's root (e.g. C:\\) and may be hard to find or write — use a drive-qualified path",
+				"key", e.key, "path", e.path,
+				"did_you_mean", "C:\\Users\\<you>\\Documents\\GopherTrunk\\"+filepath.Base(e.path))
+		}
+	}
 }
 
 // Daemon owns the lifecycle of every long-lived component the
@@ -358,6 +401,10 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 		}
 		d.writer = w
 	}
+
+	// Surface Unix-style paths that lose their drive letter on Windows
+	// (the shipped defaults are "/var/lib/gophertrunk/...").
+	warnWindowsDriveRootPaths(log, cfg)
 
 	// Talkgroup DB — populated below from per-system CSVs.
 	d.talkgroups = trunking.NewTalkgroupDB()

--- a/cmd/gophertrunk/daemon_test.go
+++ b/cmd/gophertrunk/daemon_test.go
@@ -1,0 +1,29 @@
+package main
+
+import "testing"
+
+func TestLooksDriveRootedOnWindows(t *testing.T) {
+	cases := []struct {
+		path string
+		want bool
+	}{
+		// Unix-style absolute paths lose their drive on Windows.
+		{"/var/lib/gophertrunk/recordings", true},
+		{"\\var\\lib\\gophertrunk\\recordings", true},
+		{"/calls.db", true},
+		// Drive-qualified and UNC paths are fine.
+		{"C:\\Users\\me\\GopherTrunk", false},
+		{"\\\\server\\share\\recordings", false},
+		{"//server/share", false},
+		// Relative paths are fine.
+		{"recordings", false},
+		{"data/recordings", false},
+		{".\\recordings", false},
+		{"", false},
+	}
+	for _, c := range cases {
+		if got := looksDriveRootedOnWindows(c.path); got != c.want {
+			t.Errorf("looksDriveRootedOnWindows(%q) = %v, want %v", c.path, got, c.want)
+		}
+	}
+}

--- a/cmd/gophertrunk/import_writer.go
+++ b/cmd/gophertrunk/import_writer.go
@@ -87,6 +87,11 @@ func mergeIntoConfig(systems []parsedSystem, opts mergeOptions) (mergeResult, er
 	// Build the new SystemConfig entries + CSVs.
 	newSystems := make([]config.SystemConfig, 0, len(systems))
 	for _, sys := range systems {
+		// RadioReference occasionally yields a name whose last word is
+		// repeated (e.g. "Cobb Regional Radio System System"), which then
+		// shows up doubled in logs and recording folders. Collapse an exact
+		// trailing duplicate before it is committed to config.
+		sys.Name = collapseTrailingDuplicateWord(sys.Name)
 		slug := buildSlug(sys.Name, sys.SysID)
 		csvPath := filepath.Join(csvDir, "talkgroups-"+slug+".csv")
 		entry := config.SystemConfig{
@@ -202,6 +207,32 @@ func buildSlug(name, sysid string) string {
 		slug += "-" + strings.ToLower(sysid)
 	}
 	return slug
+}
+
+// collapseTrailingDuplicateWord removes the final whitespace-separated
+// word of name when it is an exact, case-insensitive repeat of the word
+// before it (e.g. "Cobb Regional Radio System System" → "Cobb Regional
+// Radio System"). It is deliberately strict — only an identical trailing
+// duplicate is collapsed — so legitimate names are left untouched. The
+// original spacing of the kept portion is preserved.
+func collapseTrailingDuplicateWord(name string) string {
+	fields := strings.Fields(name)
+	if len(fields) < 2 {
+		return name
+	}
+	last := fields[len(fields)-1]
+	prev := fields[len(fields)-2]
+	if !strings.EqualFold(last, prev) {
+		return name
+	}
+	// Trim the trailing duplicate by cutting the original string at the
+	// last occurrence of the repeated word, preserving leading spacing.
+	trimmed := strings.TrimRight(name, " \t")
+	cut := strings.LastIndex(trimmed, last)
+	if cut <= 0 {
+		return name
+	}
+	return strings.TrimRight(trimmed[:cut], " \t")
 }
 
 // buildTalkgroupCSV produces the Trunk-Recorder-style CSV that the

--- a/cmd/gophertrunk/import_writer_test.go
+++ b/cmd/gophertrunk/import_writer_test.go
@@ -238,3 +238,21 @@ func sampleParsedSystem() parsedSystem {
 		},
 	}
 }
+
+func TestCollapseTrailingDuplicateWord(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"Cobb Regional Radio System System", "Cobb Regional Radio System"},
+		{"Cobb Regional Radio System", "Cobb Regional Radio System"},
+		{"System System", "System"},
+		{"system System", "system"}, // case-insensitive match, keeps first
+		{"Foo Bar", "Foo Bar"},
+		{"Foo", "Foo"},
+		{"", ""},
+		{"  Padded  System System  ", "  Padded  System"},
+	}
+	for _, c := range cases {
+		if got := collapseTrailingDuplicateWord(c.in); got != c.want {
+			t.Errorf("collapseTrailingDuplicateWord(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/internal/voice/composer/p25p2_voice.go
+++ b/internal/voice/composer/p25p2_voice.go
@@ -62,6 +62,11 @@ func (c *Composer) runP25Phase2VoiceChain(ctx context.Context, serial string, sy
 	// (issue #451). With the live-decode defaults (ScramblerOn + an
 	// identity-derived seed) none of these fire.
 	switch {
+	case macCfg.Trellis == p25p2.TrellisOff:
+		c.log.Warn("composer: p25p2 trellis is off; live P25 Phase 2 MAC PDUs are trellis-encoded (TIA-102.AABF), so voice/MAC decode will fail — TrellisOff is only for pre-stripped fixtures (set p25_phase2_trellis_mode=on)",
+			"serial", serial, "system", system,
+			"trellis", macCfg.Trellis, "rs", macCfg.RS,
+			"interleave", macCfg.Interleave, "scrambler", macCfg.Scrambler)
 	case macCfg.Seed == 0:
 		c.log.Warn("composer: p25p2 macCfg has no scrambler seed; live MAC PDU decode will fail until the system identity is known (set WACN/SystemID/site, or wait for a Network Status Broadcast on Phase 2 control channels)",
 			"serial", serial, "system", system,

--- a/internal/voice/composer/p25p2_voice_test.go
+++ b/internal/voice/composer/p25p2_voice_test.go
@@ -3,7 +3,9 @@ package composer
 import (
 	"bytes"
 	"context"
+	"log/slog"
 	"math"
+	"strings"
 	"testing"
 	"time"
 
@@ -471,5 +473,47 @@ func TestComposerP25Phase2InCallMetadataFires(t *testing.T) {
 			t.Fatalf("missing events after 6s: source=%v enc=%v alias=%v",
 				gotSource, gotEnc, gotAlias)
 		}
+	}
+}
+
+// TestComposerP25Phase2VoiceChainWarnsTrellisOff confirms the chain-entry
+// diagnostic fires a warning when the grant carries TrellisOff — the
+// inconsistent FEC profile (trellis off while RS/interleave/scrambler are
+// on) that surfaced in a field report and silently fails live decode.
+func TestComposerP25Phase2VoiceChainWarnsTrellisOff(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	c, err := New(Options{
+		Bus:           events.NewBus(8),
+		Devices:       &fakeDevices{src: map[string]IQSource{}},
+		Sink:          &recordingSink{},
+		Engine:        &fakeEngine{},
+		IQSampleRate:  48_000,
+		PCMSampleRate: 8000,
+		TouchInterval: 30 * time.Millisecond,
+		Log:           logger,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// A closed IQ channel makes the chain log its entry diagnostics and
+	// then return immediately (no IQ to process).
+	iqCh := make(chan []complex64)
+	close(iqCh)
+	done := make(chan struct{})
+	c.runP25Phase2VoiceChain(context.Background(), "VOICE-1", "TestSys",
+		p25p2.MACDecodeConfig{
+			Trellis:    p25p2.TrellisOff,
+			RS:         p25p2.RSOn,
+			Interleave: p25p2.InterleaveOn,
+			Scrambler:  p25p2.ScramblerProbe,
+			Seed:       12345,
+		}, iqCh, 48_000, done)
+	<-done
+
+	if out := buf.String(); !strings.Contains(out, "trellis is off") {
+		t.Fatalf("expected trellis-off warning, got:\n%s", out)
 	}
 }


### PR DESCRIPTION
Three defensive diagnostics for issues that previously produced only
INFO-level output with no warning:

- composer: warn at P25 Phase 2 chain start when trellis decoding is
  off. Live over-the-air MAC PDUs are trellis-encoded, so TrellisOff
  silently fails voice/MAC decode; it is only valid for pre-stripped
  fixtures. Slots into the existing seed/scrambler diagnostic switch.

- daemon: on Windows, warn when recordings.dir / storage.path /
  storage.cc_cache_file are rooted but carry no drive letter (the
  shipped Unix-style defaults like /var/lib/gophertrunk/... normalize
  to the current drive root, e.g. C:\var\lib\..., a surprising and
  possibly non-writable location). Warning only; never fails startup.

- import: collapse an exact trailing duplicate word in imported system
  names (e.g. "Cobb Regional Radio System System" -> "... System")
  so it does not appear doubled in logs and recording folders.

Adds unit tests for all three.