### PR TITLE
fix(p25p1): apply IMBE §7.5 deinterleave to voice frames

### DIFF
--- a/internal/radio/p25/phase1/ldu.go
+++ b/internal/radio/p25/phase1/ldu.go
@@ -28,9 +28,10 @@ import (
 //	FS  — frame sync, fixed pattern marking the LDU start.
 //	NID — network ID + DUID (already parsed by the existing
 //	      ParseNID / NIDFromDibits in nid.go).
-//	Voice — 9 IMBE subframes, each 144 post-deinterleave bits.
-//	        Hand each to imbe.DecodeChannelToFrame to get the
-//	        11-byte recorder-ready frame.
+//	Voice — 9 IMBE subframes, each 144 on-air channel bits.
+//	        Hand each to imbe.DecodeChannelToFrame, which §7.5
+//	        deinterleaves + §7.4 descrambles + FEC-decodes them
+//	        into the 11-byte recorder-ready frame.
 //	LC  — 240 bits = 24 short Hamming(10,6,3) codewords for the
 //	      Link Control word (24-bit source unit ID, 16/24-bit
 //	      destination, etc.). LDU1 only.
@@ -277,8 +278,9 @@ func InjectStatusSymbols(payload []byte, status [LDUStatusSymbolCount]uint8) ([]
 //
 //	1728-bit on-air ldu
 //	  → StripStatusSymbols     (1680-bit payload)
-//	  → slice u_0..u_8 at lduVoiceOffsets   (9 × 144 bits)
-//	  → imbe.DecodeChannelToFrame for each  (descramble, FEC,
+//	  → slice u_0..u_8 at lduVoiceOffsets   (9 × 144 on-air bits)
+//	  → imbe.DecodeChannelToFrame for each  (deinterleave,
+//	                                         descramble, FEC,
 //	                                         bit-pack → 11 bytes)
 //	  → [9] recorder-ready frames
 //

--- a/internal/radio/p25/phase1/ldu_assembler_test.go
+++ b/internal/radio/p25/phase1/ldu_assembler_test.go
@@ -195,22 +195,19 @@ func TestLDUAssemblerEmitsLDUConsumableByExtractVoiceFrames(t *testing.T) {
 	// so the assembler latches.
 	copy(payload, FrameSyncBits())
 	// Encode 9 synthetic IMBE subframes through the full channel
-	// path: info → EncodeChannel → Scramble → place at the voice
-	// offsets in the payload.
+	// path: info → EncodeFrameToChannel (per-vector FEC + §7.4
+	// scramble + §7.5 interleave) → place at the voice offsets in
+	// the payload.
 	for i := 0; i < LDUVoiceSubframeCount; i++ {
 		info := make([]byte, 88)
 		for k := range info {
 			info[k] = byte((i*7 + k*3) % 2)
 		}
-		encoded, err := imbe.EncodeChannel(info)
+		onAir, err := imbe.EncodeFrameToChannel(info)
 		if err != nil {
-			t.Fatalf("EncodeChannel u_%d: %v", i, err)
+			t.Fatalf("EncodeFrameToChannel u_%d: %v", i, err)
 		}
-		scrambled, err := imbe.Scramble(encoded)
-		if err != nil {
-			t.Fatalf("Scramble u_%d: %v", i, err)
-		}
-		copy(payload[lduVoiceOffsets[i]:lduVoiceOffsets[i]+LDUVoiceSubframeBits], scrambled)
+		copy(payload[lduVoiceOffsets[i]:lduVoiceOffsets[i]+LDUVoiceSubframeBits], onAir)
 	}
 
 	var status [LDUStatusSymbolCount]uint8

--- a/internal/radio/p25/phase1/ldu_e2e_test.go
+++ b/internal/radio/p25/phase1/ldu_e2e_test.go
@@ -27,7 +27,8 @@ import (
 // The pipeline under test:
 //
 //	[synth 9 IMBE info bits]
-//	  → imbe.EncodeChannel + Scramble → 144 ch bits per subframe
+//	  → imbe.EncodeFrameToChannel → 144 on-air ch bits per subframe
+//	    (per-vector FEC + §7.4 scramble + §7.5 interleave)
 //	  → place at lduVoiceOffsets in LDU payload
 //	  → phase1.InjectStatusSymbols → 1728-bit on-air LDU
 //	  ↓
@@ -55,19 +56,15 @@ func TestLDUEndToEndIntoRecorder(t *testing.T) {
 
 	payload := make([]byte, phase1.LDUPayloadBits)
 	for i := 0; i < phase1.LDUVoiceSubframeCount; i++ {
-		encoded, err := imbe.EncodeChannel(infos[i])
+		onAir, err := imbe.EncodeFrameToChannel(infos[i])
 		if err != nil {
-			t.Fatalf("EncodeChannel u_%d: %v", i, err)
-		}
-		scrambled, err := imbe.Scramble(encoded)
-		if err != nil {
-			t.Fatalf("Scramble u_%d: %v", i, err)
+			t.Fatalf("EncodeFrameToChannel u_%d: %v", i, err)
 		}
 		// LDU voice slot offset comes from the package's
 		// internal table; we use the public sequence-builder
 		// approach below to avoid exposing the array.
 		off := lduVoiceOffsetForTest(i)
-		copy(payload[off:off+phase1.LDUVoiceSubframeBits], scrambled)
+		copy(payload[off:off+phase1.LDUVoiceSubframeBits], onAir)
 	}
 	var status [phase1.LDUStatusSymbolCount]uint8
 	ldu, err := phase1.InjectStatusSymbols(payload, status)

--- a/internal/radio/p25/phase1/ldu_encode.go
+++ b/internal/radio/p25/phase1/ldu_encode.go
@@ -10,9 +10,12 @@ import "fmt"
 // payload at their TIA-102.BAAA offsets, then interleaves zero-valued
 // status symbols via InjectStatusSymbols.
 //
-// Each voice subframe must be LDUVoiceSubframeBits channel bits — the
-// IMBE-encoded channel form, e.g. from imbe.EncodeChannel. A nil LC/ES
-// or LSD block is written as zeros. This is synthesized-fixture
+// Each voice subframe must be LDUVoiceSubframeBits on-air channel bits
+// — the fully-encoded IMBE wire form (per-vector FEC + §7.4 scramble +
+// §7.5 interleave), e.g. from imbe.EncodeFrameToChannel. This is the
+// transmission order ExtractVoiceFrames + imbe.DecodeChannelToFrame
+// consume, so the round-trip exercises the real deinterleave. A nil
+// LC/ES or LSD block is written as zeros. This is synthesized-fixture
 // scaffolding (GopherTrunk is receive-only); it is the encoder the
 // round-trip tests pair with the extractors.
 func AssembleLDU(nac uint16, duid DUID, voice [LDUVoiceSubframeCount][]byte, lces [LDULCESBlockCount][]byte, lsd [LDULSDBlockCount][]byte) ([]byte, error) {

--- a/internal/radio/p25/phase1/ldu_encode_test.go
+++ b/internal/radio/p25/phase1/ldu_encode_test.go
@@ -15,18 +15,21 @@ func TestAssembleLDURoundTrip(t *testing.T) {
 		for i := range info {
 			info[i] = byte((s*7 + i*3) & 1)
 		}
-		ch, err := imbe.EncodeChannel(info)
+		// Build the real on-air burst (FEC + §7.4 scramble + §7.5
+		// interleave) so the round-trip exercises the deinterleave
+		// in ExtractVoiceFrames → DecodeChannelToFrame.
+		onAir, err := imbe.EncodeFrameToChannel(info)
 		if err != nil {
-			t.Fatalf("EncodeChannel: %v", err)
+			t.Fatalf("EncodeFrameToChannel: %v", err)
 		}
-		onAir, err := imbe.Scramble(ch)
+		voice[s] = onAir
+		// The recovered frame must equal the original info bits packed
+		// MSB-first — not a re-decode of the same bits, so a no-op
+		// permutation can't make the test pass against itself.
+		want[s], err = imbe.PackInfoBitsToFrame(info)
 		if err != nil {
-			t.Fatalf("Scramble: %v", err)
+			t.Fatalf("PackInfoBitsToFrame: %v", err)
 		}
-		// Scramble/Descramble mutate in place — keep an independent copy
-		// for the LDU so the want computation below cannot corrupt it.
-		voice[s] = append([]byte(nil), onAir...)
-		want[s], _, _ = imbe.DecodeChannelToFrame(onAir)
 	}
 	var lces [LDULCESBlockCount][]byte
 	var lsd [LDULSDBlockCount][]byte
@@ -39,13 +42,16 @@ func TestAssembleLDURoundTrip(t *testing.T) {
 		t.Fatalf("AssembleLDU len = %d, want %d", len(ldu), LDUTotalBits)
 	}
 
-	frames, _, err := ExtractVoiceFrames(ldu)
+	frames, errs, err := ExtractVoiceFrames(ldu)
 	if err != nil {
 		t.Fatalf("ExtractVoiceFrames: %v", err)
 	}
+	if errs != 0 {
+		t.Errorf("ExtractVoiceFrames corrected %d bits on a clean LDU, want 0", errs)
+	}
 	for i := range frames {
 		if !bytes.Equal(frames[i], want[i]) {
-			t.Errorf("subframe %d: extracted frame != assembled frame", i)
+			t.Errorf("subframe %d: extracted frame %x != original info frame %x", i, frames[i], want[i])
 		}
 	}
 }

--- a/internal/radio/p25/phase1/ldu_test.go
+++ b/internal/radio/p25/phase1/ldu_test.go
@@ -252,10 +252,11 @@ func TestLDUFieldsCoverPayloadWithoutOverlap(t *testing.T) {
 
 // TestExtractVoiceFramesRoundTrip: build a synthetic LDU by
 // encoding 9 distinct IMBE info-bit patterns through
-// EncodeChannel + Scramble, placing them at the documented voice
-// offsets, injecting status symbols, then calling
-// ExtractVoiceFrames and confirming each returned frame
-// round-trips back to its original info bits.
+// EncodeFrameToChannel (per-vector FEC + §7.4 scramble + §7.5
+// interleave), placing them at the documented voice offsets,
+// injecting status symbols, then calling ExtractVoiceFrames and
+// confirming each returned frame round-trips back to its original
+// info bits through the deinterleave.
 //
 // This is the load-bearing test for the LDU layout: a single
 // wrong offset in lduVoiceOffsets would surface as a mismatched
@@ -275,15 +276,11 @@ func TestExtractVoiceFramesRoundTrip(t *testing.T) {
 
 	payload := make([]byte, LDUPayloadBits)
 	for i, info := range originals {
-		encoded, err := imbe.EncodeChannel(info)
+		onAir, err := imbe.EncodeFrameToChannel(info)
 		if err != nil {
-			t.Fatalf("EncodeChannel u_%d: %v", i, err)
+			t.Fatalf("EncodeFrameToChannel u_%d: %v", i, err)
 		}
-		scrambled, err := imbe.Scramble(encoded)
-		if err != nil {
-			t.Fatalf("Scramble u_%d: %v", i, err)
-		}
-		copy(payload[lduVoiceOffsets[i]:lduVoiceOffsets[i]+LDUVoiceSubframeBits], scrambled)
+		copy(payload[lduVoiceOffsets[i]:lduVoiceOffsets[i]+LDUVoiceSubframeBits], onAir)
 	}
 	var status [LDUStatusSymbolCount]uint8
 	ldu, err := InjectStatusSymbols(payload, status)

--- a/internal/voice/composer/p25p1_encryption_test.go
+++ b/internal/voice/composer/p25p1_encryption_test.go
@@ -27,16 +27,12 @@ func buildP25P1EncryptedLDU2Stream(t *testing.T, ldus int, es phase1.EncryptionS
 	for l := 0; l < ldus; l++ {
 		var voice [phase1.LDUVoiceSubframeCount][]byte
 		for s := range voice {
-			ch, err := imbe.EncodeChannel(p25p1VoiceInfo(frame))
+			onAir, err := imbe.EncodeFrameToChannel(p25p1VoiceInfo(frame))
 			frame++
 			if err != nil {
-				t.Fatalf("EncodeChannel: %v", err)
+				t.Fatalf("EncodeFrameToChannel: %v", err)
 			}
-			onAir, err := imbe.Scramble(ch)
-			if err != nil {
-				t.Fatalf("Scramble: %v", err)
-			}
-			voice[s] = append([]byte(nil), onAir...)
+			voice[s] = onAir
 		}
 		lces := phase1.AssembleEncryptionSync(es)
 		var lsd [phase1.LDULSDBlockCount][]byte

--- a/internal/voice/composer/p25p1_voice_test.go
+++ b/internal/voice/composer/p25p1_voice_test.go
@@ -51,18 +51,16 @@ func buildP25P1VoiceStream(t *testing.T, ldus int) (dibits []uint8, want [][]byt
 	for l := 0; l < ldus; l++ {
 		var voice [phase1.LDUVoiceSubframeCount][]byte
 		for s := range voice {
-			ch, err := imbe.EncodeChannel(p25p1VoiceInfo(frame))
+			// Build the real on-air burst (per-vector FEC + §7.4
+			// scramble + §7.5 interleave) so the composer's voice
+			// chain decodes it through the deinterleave just like a
+			// real LDU off the air.
+			onAir, err := imbe.EncodeFrameToChannel(p25p1VoiceInfo(frame))
 			frame++
 			if err != nil {
-				t.Fatalf("EncodeChannel: %v", err)
+				t.Fatalf("EncodeFrameToChannel: %v", err)
 			}
-			onAir, err := imbe.Scramble(ch)
-			if err != nil {
-				t.Fatalf("Scramble: %v", err)
-			}
-			// Scramble/Descramble mutate in place — keep an independent
-			// copy for the LDU so the want computation cannot corrupt it.
-			voice[s] = append([]byte(nil), onAir...)
+			voice[s] = onAir
 			wf, _, _ := imbe.DecodeChannelToFrame(onAir)
 			want = append(want, wf)
 		}

--- a/internal/voice/imbe/channel.go
+++ b/internal/voice/imbe/channel.go
@@ -25,17 +25,20 @@ import (
 //     total  144            88
 //
 //  2. A pseudo-random scrambler keyed off u_0 — XOR'd onto the
-//     channel bits of u_1..u_6 to whiten the spectrum (§7.4).
+//     channel bits of u_1..u_6 to whiten the spectrum (§7.4). See
+//     scrambler.go.
 //
 //  3. A 144-bit interleaver permutation that scatters adjacent
 //     codeword bits across the frame so a localised burst error
-//     spreads across vectors (§7.5).
+//     spreads across vectors (§7.5). See interleave.go.
 //
 // This file ships layer 1 — the per-vector FEC encode/decode plus
-// the bit-position constants. Layers 2 and 3 are a self-contained
-// follow-up; the public DecodeChannel / EncodeChannel functions
-// here operate on already-deinterleaved + already-descrambled
-// channel bits so the per-vector FEC can be reviewed in isolation.
+// the bit-position constants. DecodeChannel / EncodeChannel here
+// operate on channel bits in vector order — i.e. already
+// deinterleaved (§7.5) and descrambled (§7.4) — so the per-vector
+// FEC can be reviewed in isolation. The DecodeChannelToFrame /
+// EncodeFrameToChannel helpers wrap those two layers around the
+// per-vector FEC to consume / produce raw on-air bursts.
 
 // Per-vector geometry. Offsets are measured in bits from the start
 // of the (already-deinterleaved + already-descrambled) 144-bit
@@ -166,23 +169,27 @@ func PackInfoBitsToFrame(info []byte) ([]byte, error) {
 }
 
 // DecodeChannelToFrame is the convenience pipeline that bridges
-// "144 channel bits, post-deinterleave" → "FrameBytes-byte
-// recorder-ready IMBE frame". It runs the §7.4 PRBS descrambler,
-// then the per-vector Golay+Hamming FEC inverse, then packs the
-// 88 recovered information bits MSB-first.
+// "144 raw on-air channel bits" → "FrameBytes-byte recorder-ready
+// IMBE frame". It runs the §7.5 deinterleaver, then the §7.4 PRBS
+// descrambler (whose u_0 seed is only valid once the bits are in
+// vector order), then the per-vector Golay+Hamming FEC inverse,
+// then packs the 88 recovered information bits MSB-first.
 //
-// Used by upstream protocol decoders (P25 Phase 1 LDU extraction,
-// future) that hand off post-deinterleave channel bursts: each
-// LDU carries 9 IMBE voice frames, each 144 bits — call this
-// helper for each slot and forward the resulting frame to
-// voice.Recorder.WriteRawFrame.
+// Used by upstream protocol decoders (P25 Phase 1 LDU extraction)
+// that hand off raw on-air channel bursts: each LDU carries 9 IMBE
+// voice frames, each 144 bits — call this helper for each slot and
+// forward the resulting frame to voice.Recorder.WriteRawFrame.
 //
 // Returns the total bit-errors corrected across all FEC vectors.
 // Uncorrectable codewords surface as ErrUncorrectable from
 // DecodeChannel; the partially-recovered frame is still returned
 // so callers can log + frame-repeat upstream.
 func DecodeChannelToFrame(channel []byte) (frame []byte, errs int, err error) {
-	descrambled, err := Descramble(channel)
+	deinterleaved, err := Deinterleave(channel)
+	if err != nil {
+		return nil, 0, err
+	}
+	descrambled, err := Descramble(deinterleaved)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/internal/voice/imbe/channel_test.go
+++ b/internal/voice/imbe/channel_test.go
@@ -218,33 +218,32 @@ func TestPackInfoBitsToFrameRejectsWrongLength(t *testing.T) {
 
 // TestDecodeChannelToFrameRoundTrip: the full channel-decode
 // pipeline must recover the original 88 information bits when
-// fed clean (zero-error) channel bits. The on-air shape is:
+// fed clean (zero-error) on-air channel bits. The on-air shape is:
 //
 //	info → EncodeChannel → 144 channel bits
-//	     → Scramble       → 144 scrambled channel bits  (transmitted)
-//	     → Descramble     → 144 channel bits             (after RX)
+//	     → Scramble       → 144 scrambled channel bits
+//	     → Interleave     → 144 on-air channel bits      (transmitted)
+//	     → Deinterleave   → 144 scrambled channel bits   (after RX)
+//	     → Descramble     → 144 channel bits
 //	     → DecodeChannel  → 88 info bits
 //	     → PackInfoBitsToFrame → 11-byte frame
 //
-// DecodeChannelToFrame collapses the last three steps, so feeding
-// it post-Scramble bits should reproduce the original info inside
-// the packed frame.
+// EncodeFrameToChannel collapses the first three steps and
+// DecodeChannelToFrame the last four, so feeding the helper an
+// on-air burst should reproduce the original info inside the
+// packed frame.
 func TestDecodeChannelToFrameRoundTrip(t *testing.T) {
 	original := make([]byte, InfoBits)
 	for i := range original {
 		// Pseudo-random 0/1 pattern that exercises every vector.
 		original[i] = byte((i*13 + 7) % 2)
 	}
-	encoded, err := EncodeChannel(original)
+	onAir, err := EncodeFrameToChannel(original)
 	if err != nil {
-		t.Fatalf("EncodeChannel: %v", err)
-	}
-	scrambled, err := Scramble(encoded)
-	if err != nil {
-		t.Fatalf("Scramble: %v", err)
+		t.Fatalf("EncodeFrameToChannel: %v", err)
 	}
 
-	frame, errs, err := DecodeChannelToFrame(scrambled)
+	frame, errs, err := DecodeChannelToFrame(onAir)
 	if err != nil {
 		t.Fatalf("DecodeChannelToFrame: %v", err)
 	}
@@ -282,15 +281,11 @@ func TestDecodeChannelToFrameWiresIntoDecoder(t *testing.T) {
 	info[4] = 1
 	info[5] = 0
 
-	encoded, err := EncodeChannel(info)
+	onAir, err := EncodeFrameToChannel(info)
 	if err != nil {
-		t.Fatalf("EncodeChannel: %v", err)
+		t.Fatalf("EncodeFrameToChannel: %v", err)
 	}
-	scrambled, err := Scramble(encoded)
-	if err != nil {
-		t.Fatalf("Scramble: %v", err)
-	}
-	frame, errs, err := DecodeChannelToFrame(scrambled)
+	frame, errs, err := DecodeChannelToFrame(onAir)
 	if err != nil {
 		t.Fatalf("DecodeChannelToFrame: %v", err)
 	}
@@ -331,13 +326,20 @@ func TestDecodeChannelToFrameSurvivesRecoverableError(t *testing.T) {
 		t.Fatalf("Scramble: %v", err)
 	}
 	// Flip a single bit inside u_1 (a Golay(23,12) vector,
-	// correction radius 3). Bits 0..11 of the channel double as
-	// the seed for the §7.4 PRBS scrambler — a flip in that range
+	// correction radius 3). Bits 0..11 of the vector buffer double
+	// as the seed for the §7.4 PRBS scrambler — a flip in that range
 	// would cascade through descrambling of u_1..u_6 and isn't
-	// straightforwardly recoverable. u_1 spans bits 23..45, so
-	// bit 25 sits comfortably past the seed region.
+	// straightforwardly recoverable. u_1 spans vector bits 23..45,
+	// so bit 25 sits comfortably past the seed region. The flip is
+	// applied in vector order then interleaved, so it becomes a
+	// single-bit on-air error the deinterleave scatters back into
+	// u_1 — exactly one correctable Golay error.
 	scrambled[25] ^= 1
-	frame, errs, err := DecodeChannelToFrame(scrambled)
+	onAir, err := Interleave(scrambled)
+	if err != nil {
+		t.Fatalf("Interleave: %v", err)
+	}
+	frame, errs, err := DecodeChannelToFrame(onAir)
 	if err != nil {
 		t.Fatalf("DecodeChannelToFrame: %v", err)
 	}

--- a/internal/voice/imbe/doc.go
+++ b/internal/voice/imbe/doc.go
@@ -24,18 +24,25 @@
 //     11-byte frame from a 144-bit post-deinterleave channel
 //     burst.
 //
-//     2b. Channel coding inverse — pseudo-random scrambler. ← THIS PR.
+//     2b. Channel coding inverse — pseudo-random scrambler.
 //     XORs a 114-bit u_0-keyed LCG PRBS (TIA-102.BABA §7.4) over
 //     the channel bits of u_1..u_6 to whiten the spectrum. u_0
 //     stays unscrambled because it carries the seed; u_7 stays
 //     unscrambled per the spec. See scrambler.go.
 //
-//     Note: there is no separate "bit interleaver" inside the IMBE
-//     codec — the §7.5 ordering is satisfied by how the upstream
-//     P25 LDU1 / LDU2 frame decoder extracts the 144 bits from a
-//     voice frame (a P25 phase1 layer concern, not an IMBE one).
-//     channel.go's per-vector layout already matches the order the
-//     upstream extractor will hand it.
+//     2c. Channel coding inverse — §7.5 bit interleaver.
+//     A 144-bit permutation scatters each vector's codeword bits
+//     across the on-air burst so a localised channel-error burst
+//     spreads over several Golay/Hamming codewords instead of
+//     destroying one vector. Deinterleave / Interleave in
+//     interleave.go undo / apply it; DecodeChannelToFrame runs the
+//     deinterleave FIRST (the descrambler's u_0 seed is only valid
+//     in vector order), so the full receive order is
+//     deinterleave → descramble → per-vector FEC. The permutation
+//     is the standard P25 Phase 1 IMBE schedule (see interleave.go
+//     for the DSD-sourced derivation). Omitting this step made the
+//     per-vector FEC decode interleaved garbage and reported ~100%
+//     uncorrectable LDUs on real signals (issue #489).
 //
 //  3. Parameter unpacking — header.
 //     88 information bits → IMBE Header { W0, L, K, Silent }. The

--- a/internal/voice/imbe/interleave.go
+++ b/internal/voice/imbe/interleave.go
@@ -1,0 +1,122 @@
+package imbe
+
+import "fmt"
+
+// IMBE 4400 channel-bit interleaver (TIA-102.BABA §7.5).
+//
+// After the per-vector FEC encode (channel.go) and the §7.4 PRBS
+// scramble (scrambler.go), the 144 channel bits are interleaved
+// across the eight u_n vectors so a localised on-air burst error
+// spreads over several codewords instead of wiping out a single
+// vector. The receiver must undo this permutation BEFORE the
+// descrambler reads the u_0 seed and before the per-vector FEC
+// runs — hence DecodeChannelToFrame's order is
+// Deinterleave → Descramble → DecodeChannel.
+//
+// # Permutation source
+//
+// imbeDeinterleave below was derived from DSD's published P25
+// Phase 1 IMBE interleave schedule (the iW/iX/iY/iZ tables in
+// szechyjs/dsd include/p25p1_const.h, ISC-licensed), which the
+// project already cites as a structural reference (see
+// internal/voice/imbe/doc.go and docs/vocoders.md). DSD reads the
+// 72 on-air voice dibits and scatters each dibit's two bits into an
+// imbe_fr[row][col] vector array via:
+//
+//	imbe_fr[iW[j]][iX[j]] = dibit_hi   (on-air bit 2j)
+//	imbe_fr[iY[j]][iZ[j]] = dibit_lo   (on-air bit 2j+1)
+//
+// Mapping DSD's (row, col) onto this package's vector-order layout
+// (channel.go: u_0..u_3 at 23-bit strides 0/23/46/69, u_4..u_6 at
+// 15-bit strides 92/107/122, u_7 at 137) yields the table below,
+// where imbeDeinterleave[v] is the on-air bit index that supplies
+// vector-order bit v. It is a verified bijection of 0..143 (see the
+// init guard and TestInterleavePermutationIsBijection); regenerating
+// it from the DSD tables reproduces these exact values.
+//
+// NOTE on real-air validation: this table reproduces the same
+// permutation every open-source P25 decoder uses, but the project
+// ships no real P25 Phase 1 voice fixture, so end-to-end correctness
+// is ultimately confirmed by the live "p25p1 decode quality"
+// uncorrectable-LDU rate dropping on a real capture (issue #489).
+var imbeDeinterleave = [ChannelBits]int{
+	132, 127, 120, 115, 108, 103, 96, 91, 84, 79, 72, 67,
+	60, 55, 48, 43, 36, 31, 24, 19, 12, 7, 0, 126,
+	121, 114, 109, 102, 97, 90, 85, 78, 73, 66, 61, 54,
+	49, 42, 37, 30, 25, 18, 13, 6, 1, 139, 122, 117,
+	110, 105, 98, 93, 86, 81, 74, 69, 62, 57, 50, 45,
+	38, 33, 26, 21, 14, 9, 2, 138, 133, 116, 111, 104,
+	99, 92, 87, 80, 75, 68, 63, 56, 51, 44, 39, 32,
+	27, 20, 15, 8, 3, 141, 134, 129, 64, 59, 52, 47,
+	40, 35, 28, 23, 16, 11, 4, 140, 135, 128, 123, 10,
+	5, 143, 136, 131, 124, 119, 112, 107, 100, 95, 88, 83,
+	76, 71, 101, 94, 89, 82, 77, 70, 65, 58, 53, 46,
+	41, 34, 29, 22, 17, 142, 137, 130, 125, 118, 113, 106,
+}
+
+// init panics if imbeDeinterleave is not a permutation of 0..143.
+// A non-bijective table would silently corrupt every voice frame, so
+// fail loudly at package load rather than ship a subtly-wrong codec.
+func init() {
+	var seen [ChannelBits]bool
+	for v, t := range imbeDeinterleave {
+		if t < 0 || t >= ChannelBits {
+			panic(fmt.Sprintf("imbe: imbeDeinterleave[%d] = %d out of range", v, t))
+		}
+		if seen[t] {
+			panic(fmt.Sprintf("imbe: imbeDeinterleave maps two vector bits to on-air bit %d", t))
+		}
+		seen[t] = true
+	}
+}
+
+// Deinterleave undoes the §7.5 channel-bit interleave: it takes the
+// 144 on-air channel bits (transmission order, one bit per byte,
+// 0/1) and returns the 144 bits in vector order — the u_0..u_7
+// layout DecodeChannel and the descrambler expect. Returns a fresh
+// buffer; the input is not modified.
+func Deinterleave(onAir []byte) ([]byte, error) {
+	if len(onAir) != ChannelBits {
+		return nil, fmt.Errorf("%w: got %d channel bits", ErrChannelLength, len(onAir))
+	}
+	vec := make([]byte, ChannelBits)
+	for v, t := range imbeDeinterleave {
+		vec[v] = onAir[t] & 1
+	}
+	return vec, nil
+}
+
+// Interleave is the inverse of Deinterleave: it takes 144 channel
+// bits in vector order (post-FEC-encode, post-scramble) and returns
+// the on-air transmission-order bits. Used by the encode/fixture
+// path so synthesized LDUs match the real on-air permutation.
+// Returns a fresh buffer; the input is not modified.
+func Interleave(vec []byte) ([]byte, error) {
+	if len(vec) != ChannelBits {
+		return nil, fmt.Errorf("%w: got %d channel bits", ErrChannelLength, len(vec))
+	}
+	onAir := make([]byte, ChannelBits)
+	for v, t := range imbeDeinterleave {
+		onAir[t] = vec[v] & 1
+	}
+	return onAir, nil
+}
+
+// EncodeFrameToChannel is the on-air encode counterpart of
+// DecodeChannelToFrame: 88 information bits → 144 on-air channel
+// bits via per-vector FEC encode (EncodeChannel) → §7.4 scramble
+// (Scramble) → §7.5 interleave (Interleave). The result is the
+// transmission-order burst a real receiver sees, so test fixtures
+// built with it exercise the full deinterleave→descramble→FEC
+// inverse rather than a self-consistent shortcut.
+func EncodeFrameToChannel(info []byte) ([]byte, error) {
+	channel, err := EncodeChannel(info)
+	if err != nil {
+		return nil, err
+	}
+	scrambled, err := Scramble(channel)
+	if err != nil {
+		return nil, err
+	}
+	return Interleave(scrambled)
+}

--- a/internal/voice/imbe/interleave_test.go
+++ b/internal/voice/imbe/interleave_test.go
@@ -1,0 +1,150 @@
+package imbe
+
+import (
+	"math/rand"
+	"testing"
+)
+
+// TestInterleavePermutationIsBijection pins that imbeDeinterleave
+// maps each of the 144 vector-order positions to a distinct on-air
+// position covering 0..143 exactly once. A non-bijective table
+// would silently corrupt every voice frame, so this guards the
+// transcribed DSD schedule against an editing slip. (The init()
+// guard panics on the same condition at load; this surfaces it as a
+// test failure with a useful message.)
+func TestInterleavePermutationIsBijection(t *testing.T) {
+	var seen [ChannelBits]bool
+	for v, onAir := range imbeDeinterleave {
+		if onAir < 0 || onAir >= ChannelBits {
+			t.Fatalf("imbeDeinterleave[%d] = %d out of range [0,%d)", v, onAir, ChannelBits)
+		}
+		if seen[onAir] {
+			t.Fatalf("on-air bit %d targeted by more than one vector bit", onAir)
+		}
+		seen[onAir] = true
+	}
+	for onAir, ok := range seen {
+		if !ok {
+			t.Errorf("on-air bit %d is never produced by the permutation", onAir)
+		}
+	}
+}
+
+// TestInterleaveDeinterleaveRoundTrip: Deinterleave is the exact
+// inverse of Interleave in both directions, over random buffers.
+func TestInterleaveDeinterleaveRoundTrip(t *testing.T) {
+	rng := rand.New(rand.NewSource(42))
+	for trial := 0; trial < 64; trial++ {
+		vec := make([]byte, ChannelBits)
+		for i := range vec {
+			vec[i] = byte(rng.Intn(2))
+		}
+		onAir, err := Interleave(vec)
+		if err != nil {
+			t.Fatalf("trial %d: Interleave: %v", trial, err)
+		}
+		got, err := Deinterleave(onAir)
+		if err != nil {
+			t.Fatalf("trial %d: Deinterleave: %v", trial, err)
+		}
+		for i := range vec {
+			if got[i] != vec[i] {
+				t.Fatalf("trial %d: Deinterleave(Interleave(x)) bit %d = %d, want %d", trial, i, got[i], vec[i])
+			}
+		}
+		// And the other direction: Interleave(Deinterleave(x)) == x.
+		back, err := Interleave(got)
+		if err != nil {
+			t.Fatalf("trial %d: Interleave(Deinterleave): %v", trial, err)
+		}
+		for i := range onAir {
+			if back[i] != onAir[i] {
+				t.Fatalf("trial %d: Interleave(Deinterleave(y)) bit %d = %d, want %d", trial, i, back[i], onAir[i])
+			}
+		}
+	}
+}
+
+// TestInterleaveScattersContiguousVector: a contiguous run of set
+// bits in vector order must land non-contiguously on-air. This
+// catches an accidental identity table (the failure mode where the
+// "fix" compiles, every round-trip test passes, and the codec still
+// does nothing on real air). We set all of u_0's 23 channel bits
+// and assert the resulting on-air positions are not a single
+// contiguous block.
+func TestInterleaveScattersContiguousVector(t *testing.T) {
+	vec := make([]byte, ChannelBits)
+	for i := u0Offset; i < u0Offset+u0Bits; i++ {
+		vec[i] = 1
+	}
+	onAir, err := Interleave(vec)
+	if err != nil {
+		t.Fatalf("Interleave: %v", err)
+	}
+	// Collect the on-air positions of the set bits.
+	var first, last, count int
+	first = -1
+	for i, b := range onAir {
+		if b == 1 {
+			if first < 0 {
+				first = i
+			}
+			last = i
+			count++
+		}
+	}
+	if count != u0Bits {
+		t.Fatalf("set-bit count after interleave = %d, want %d", count, u0Bits)
+	}
+	// If the table were the identity (or any block-preserving map),
+	// the 23 set bits would occupy exactly 23 contiguous positions.
+	if last-first+1 == u0Bits {
+		t.Errorf("u_0's bits stayed contiguous on-air ([%d,%d]) — interleave is a no-op", first, last)
+	}
+}
+
+// TestInterleaveRejectsWrongLength: both directions surface
+// ErrChannelLength for anything other than 144 bits.
+func TestInterleaveRejectsWrongLength(t *testing.T) {
+	for _, n := range []int{0, ChannelBits - 1, ChannelBits + 1} {
+		if _, err := Interleave(make([]byte, n)); err == nil {
+			t.Errorf("Interleave(len=%d) returned no error", n)
+		}
+		if _, err := Deinterleave(make([]byte, n)); err == nil {
+			t.Errorf("Deinterleave(len=%d) returned no error", n)
+		}
+	}
+}
+
+// TestEncodeFrameToChannelDecodes: the on-air encode helper round-
+// trips through DecodeChannelToFrame with zero corrected errors on a
+// clean burst — the encode/decode symmetry the LDU fixtures rely on.
+func TestEncodeFrameToChannelDecodes(t *testing.T) {
+	info := make([]byte, InfoBits)
+	for i := range info {
+		info[i] = byte((i*3 + 1) % 2)
+	}
+	onAir, err := EncodeFrameToChannel(info)
+	if err != nil {
+		t.Fatalf("EncodeFrameToChannel: %v", err)
+	}
+	if len(onAir) != ChannelBits {
+		t.Fatalf("on-air length = %d, want %d", len(onAir), ChannelBits)
+	}
+	frame, errs, err := DecodeChannelToFrame(onAir)
+	if err != nil {
+		t.Fatalf("DecodeChannelToFrame: %v", err)
+	}
+	if errs != 0 {
+		t.Errorf("errs = %d, want 0 on a clean on-air burst", errs)
+	}
+	want, err := PackInfoBitsToFrame(info)
+	if err != nil {
+		t.Fatalf("PackInfoBitsToFrame: %v", err)
+	}
+	for i := range want {
+		if frame[i] != want[i] {
+			t.Fatalf("byte %d: round-trip = %02x, want %02x", i, frame[i], want[i])
+		}
+	}
+}


### PR DESCRIPTION
P25 Phase 1 voice decode reported ~100% uncorrectable LDUs on real
signals (issue #489: uncorrectable_ldus == ldus across every sample).
The cause was a missing channel-coding step: DecodeChannelToFrame ran
descramble + per-vector Golay/Hamming FEC on the raw on-air bits without
first undoing the TIA-102.BABA §7.5 144-bit interleaver. On air the
codeword bits are scattered across vectors, so every Golay/Hamming
codeword exceeded its correction radius and the FEC failed deterministically.

The encode/fixture path was symmetrically non-interleaved, so all
round-trip tests were self-consistent and passed while the live decoder
failed on real air.

- Add internal/voice/imbe/interleave.go: the §7.5 permutation
  (derived + validated from DSD's published iW/iX/iY/iZ schedule),
  Deinterleave/Interleave, an init() bijection guard, and the on-air
  encode helper EncodeFrameToChannel.
- DecodeChannelToFrame now runs deinterleave -> descramble -> FEC (the
  descrambler's u_0 seed is only valid in vector order).
- Update fixture/round-trip tests to build real on-air bursts so they
  exercise the deinterleave instead of a self-consistent shortcut.
- Correct the misleading "no separate bit interleaver" notes in doc.go
  and the "post-deinterleave" comments in channel.go / ldu.go.

Residual risk: no real P25 P1 voice fixture ships in-repo, so final
real-air confirmation is the live "p25p1 decode quality" uncorrectable
rate dropping on a capture. If it stays high, the next suspects are the
LDU voice offsets / status-symbol phase in ldu.go.

https://claude.ai/code/session_01FHseUkA8dKAkDX7FtdNxhk