### PR TITLE
p25/live: harden control-channel acquisition path against #402 regressions

### DIFF
--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -114,6 +114,74 @@ func warnGainUnits(log *slog.Logger, serial, raw string, tenthDB int) {
 		"hint", "gain: is in TENTHS of a dB (\"320\" = 32 dB). SDRTrunk/OP25/gqrx users multiply dB by 10. Use 'gain: auto' or run 'gophertrunk sdr list' for the supported ladder.")
 }
 
+// lowManualGainTenthDB is the floor below which a manual gain is suspiciously
+// low for digital decode on an RTL-SDR. Real manual P25/C4FM gains run
+// ~150-496 tenths (15-49.6 dB); below ~15 dB the tuner front-end rarely lifts
+// the on-channel signal far enough above the noise floor to acquire sync,
+// even when a hot wideband input keeps the aggregate IQ power gauge healthy
+// (issue #402: 8.7 dB applied vs the 49 dB the same site decoded at, no FSW).
+const lowManualGainTenthDB = 150
+
+// gainLooksTooLow reports whether a manual (non-auto) gain is below the
+// digital-decode floor but above the tenths-of-dB-mistake band that
+// gainLooksLikeDBMistake already covers. The two checks partition the
+// suspicious range so an operator sees exactly one warning: <=50 tenths reads
+// as a forgotten 10x (warnGainUnits); (50,150) tenths reads as a real-but-too-
+// low manual gain (warnLowGain).
+func gainLooksTooLow(raw string, tenthDB int) bool {
+	if gainLooksLikeDBMistake(raw, tenthDB) {
+		return false
+	}
+	return tenthDB > 0 && tenthDB < lowManualGainTenthDB
+}
+
+// warnLowGain emits a WARN when a manual gain parses cleanly but is too low
+// for reliable digital decode (see gainLooksTooLow). Surfaces the role so a
+// control/voice dongle that won't lock points the operator straight at the
+// front-end gain. No-op for auto, plausible, or already-dB-mistake gains.
+func warnLowGain(log *slog.Logger, serial string, role sdr.Role, raw string, tenthDB int) {
+	if !gainLooksTooLow(raw, tenthDB) {
+		return
+	}
+	log.Warn("daemon: manual gain is unusually low for digital decode — the on-channel signal may be too weak to acquire sync even if the IQ power gauge looks healthy",
+		"serial", serial,
+		"role", role.String(),
+		"configured", raw,
+		"applied_db", float64(tenthDB)/10.0,
+		"hint", "manual P25/C4FM gains typically run 150-496 tenths (15-49.6 dB). gain: is in TENTHS of a dB; a reference 'gain 49' means ~49 dB -> gain: \"490\". Use 'gain: auto' or run 'gophertrunk sdr list' for the supported ladder.")
+}
+
+// effectiveControlRate returns the IQ sample rate the control-channel
+// down-converter should be built from. The RTL2832U quantizes a requested
+// rate to its resampler divisor, so a requested rate that isn't an exact
+// divisor of the crystal streams at a slightly different rate; deriving the
+// decimation ratio from the requested value (rather than the delivered one)
+// drifts the symbol clock on the live path while offline replay — which reads
+// a file at exactly the configured rate — stays correct (issue #402).
+//
+// Backends that model the quantization expose the optional
+// ActualSampleRate() extension; those that don't (file replay, rtl_tcp)
+// deliver exactly the configured rate, so the requested value is returned
+// unchanged. A WARN fires only when the delivered rate actually differs, so a
+// correct exact-divisor config (2.4 / 0.96 MS/s) stays quiet.
+func effectiveControlRate(log *slog.Logger, dev sdr.Device, serial string, requested uint32) uint32 {
+	ar, ok := dev.(interface{ ActualSampleRate() (uint32, error) })
+	if !ok {
+		return requested
+	}
+	actual, err := ar.ActualSampleRate()
+	if err != nil || actual == 0 {
+		return requested
+	}
+	if actual != requested {
+		log.Warn("daemon: control SDR streams a different sample rate than requested; building the down-converter from the actual hardware rate so the symbol clock stays aligned (issue #402)",
+			"serial", serial,
+			"requested_hz", requested,
+			"actual_hz", actual)
+	}
+	return actual
+}
+
 // looksDriveRootedOnWindows reports whether p, when used on Windows,
 // would resolve to the root of the *current* drive (e.g. the Unix-style
 // default "/var/lib/gophertrunk/recordings" becomes "C:\var\lib\...")
@@ -510,6 +578,7 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 						"serial", dev.Serial, "gain", dev.Gain)
 				} else {
 					warnGainUnits(log, dev.Serial, dev.Gain, gain)
+					warnLowGain(log, dev.Serial, h.Role, dev.Gain, gain)
 					h = h.WithGain(gain)
 				}
 			}
@@ -567,6 +636,7 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 								"serial", r.Serial, "gain", r.Gain)
 						} else {
 							warnGainUnits(log, r.Serial, r.Gain, gain)
+							warnLowGain(log, r.Serial, h.Role, r.Gain, gain)
 							h = h.WithGain(gain)
 						}
 					}
@@ -915,17 +985,23 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 						break
 					}
 				}
+				// Build the down-converter from the rate the hardware
+				// actually delivers, not the requested one (issue #402).
+				effectiveRate := effectiveControlRate(log, controlEntry.Device, controlEntry.Info.Serial, cfg.SDR.SampleRate)
 				d.ccDecoderOpts = ccdecoder.Options{
 					Bus:          d.bus,
 					Log:          log,
 					Tuner:        tuner,
 					IQ:           iqSrc,
 					Systems:      d.systems,
-					SampleRateHz: float64(cfg.SDR.SampleRate),
+					SampleRateHz: float64(effectiveRate),
 					Metrics:      iqObs,
 					IQCorrect:    iqCorrect,
 				}
 				d.controlSerial = controlEntry.Info.Serial
+				// Reacquire re-requests the configured rate (and re-quantizes
+				// on the fresh handle); the decoder, by contrast, is built from
+				// the delivered effectiveRate above.
 				d.controlSampleRate = cfg.SDR.SampleRate
 				dec, err := ccdecoder.New(d.ccDecoderOpts)
 				if err != nil {

--- a/cmd/gophertrunk/effective_rate_test.go
+++ b/cmd/gophertrunk/effective_rate_test.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/sdr"
+)
+
+// rateOnlyDevice is a minimal sdr.Device. quantizeTo, when non-zero, makes it
+// advertise the optional ActualSampleRate() extension and report that exact
+// rate (modelling the RTL2832U resampler quantization). When zero, the device
+// does NOT implement ActualSampleRate at all — modelling file replay / rtl_tcp
+// backends that deliver exactly the requested rate.
+type rateOnlyDevice struct{}
+
+func (rateOnlyDevice) Info() sdr.Info             { return sdr.Info{} }
+func (rateOnlyDevice) SetCenterFreq(uint32) error { return nil }
+func (rateOnlyDevice) SetSampleRate(uint32) error { return nil }
+func (rateOnlyDevice) SetGain(int) error          { return nil }
+func (rateOnlyDevice) SetPPM(int) error           { return nil }
+func (rateOnlyDevice) SetBiasTee(bool) error      { return nil }
+func (rateOnlyDevice) Close() error               { return nil }
+func (rateOnlyDevice) StreamIQ(context.Context) (<-chan []complex64, error) {
+	return nil, nil
+}
+
+// quantizingDevice embeds rateOnlyDevice and additionally implements the
+// optional ActualSampleRate() extension.
+type quantizingDevice struct {
+	rateOnlyDevice
+	actual uint32
+	err    error
+}
+
+func (q quantizingDevice) ActualSampleRate() (uint32, error) { return q.actual, q.err }
+
+func TestEffectiveControlRate(t *testing.T) {
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	const requested = 2_048_000
+
+	cases := []struct {
+		name string
+		dev  sdr.Device
+		want uint32
+	}{
+		{
+			// File replay / rtl_tcp: no ActualSampleRate extension, so the
+			// configured rate is used verbatim.
+			name: "no extension -> requested",
+			dev:  rateOnlyDevice{},
+			want: requested,
+		},
+		{
+			// RTL2832U quantizes 2.048 MS/s to a nearby divisor: the decoder
+			// must be built from the delivered rate, not the requested one.
+			name: "quantized -> actual",
+			dev:  quantizingDevice{actual: 2_048_001},
+			want: 2_048_001,
+		},
+		{
+			// Exact-divisor rate (2.4 / 0.96 MS/s land here): actual ==
+			// requested, no divergence, returned unchanged (and no warn).
+			name: "exact -> requested",
+			dev:  quantizingDevice{actual: requested},
+			want: requested,
+		},
+		{
+			// A read-back error or zero must fall back to the configured
+			// rate rather than zeroing the down-converter input rate.
+			name: "error -> requested",
+			dev:  quantizingDevice{actual: 0, err: io.EOF},
+			want: requested,
+		},
+		{
+			name: "zero -> requested",
+			dev:  quantizingDevice{actual: 0},
+			want: requested,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := effectiveControlRate(log, c.dev, "TESTSERIAL", requested); got != c.want {
+				t.Errorf("effectiveControlRate = %d, want %d", got, c.want)
+			}
+		})
+	}
+}

--- a/cmd/gophertrunk/gain_test.go
+++ b/cmd/gophertrunk/gain_test.go
@@ -67,3 +67,42 @@ func TestGainLooksLikeDBMistake(t *testing.T) {
 		}
 	}
 }
+
+func TestGainLooksTooLow(t *testing.T) {
+	cases := []struct {
+		raw     string
+		tenthDB int
+		want    bool
+	}{
+		// The (50,150)-tenths band: a real, cleanly-parsed manual gain that
+		// is still too low for digital decode (issue #402: 8.7 dB applied).
+		{"87", 87, true},   // the reported case: 8.7 dB, no FSW
+		{"51", 51, true},   // just above the dB-mistake band
+		{"149", 149, true}, // just below the floor
+		// The dB-mistake band (<=50 tenths) is owned by gainLooksLikeDBMistake,
+		// so gainLooksTooLow must not double-fire there.
+		{"32", 32, false},
+		{"50", 50, false},
+		{"1", 1, false},
+		// Plausible manual gains at or above the floor never warn.
+		{"150", 150, false},
+		{"229", 229, false},
+		{"496", 496, false},
+		// Decimal forms are an explicit dB choice; a low one is taken at face
+		// value here (warnGainUnits already skips decimals), so still flagged
+		// as too-low when below the floor since it's a real applied gain.
+		{"8.7", 87, true},
+		{"15.0", 150, false},
+		// auto / disabled / zero gain must never warn.
+		{"auto", -1, false},
+		{"", -1, false},
+		{"0", 0, false},
+		{"-1", -1, false},
+	}
+	for _, c := range cases {
+		if got := gainLooksTooLow(c.raw, c.tenthDB); got != c.want {
+			t.Errorf("gainLooksTooLow(%q, %d) = %v, want %v",
+				c.raw, c.tenthDB, got, c.want)
+		}
+	}
+}

--- a/internal/radio/p25/phase1/control_test.go
+++ b/internal/radio/p25/phase1/control_test.go
@@ -468,6 +468,93 @@ func TestControlChannelLocksAndGrantsAcrossSmallChunks(t *testing.T) {
 	}
 }
 
+// buildControlFrameMultiTSBK builds one FSW + NID followed by several
+// back-to-back 98-dibit TSBK channel blocks — the P25 TSDU layout that packs
+// up to maxTSBKBlocks signalling blocks after a single sync/NID. buildControl-
+// Frame only carries one block; this exercises the multi-block path.
+func buildControlFrameMultiTSBK(nac uint16, duid DUID, tsbks ...TSBK) []uint8 {
+	frame := make([]uint8, 0, 24+32+len(tsbks)*98)
+	frame = append(frame, FrameSyncWord[:]...)
+	bits := EncodeNIDBits(nac, duid)
+	for i := 0; i < 32; i++ {
+		frame = append(frame, (bits[2*i]<<1)|bits[2*i+1])
+	}
+	for _, tsbk := range tsbks {
+		frame = append(frame, EncodeTSBKChannel(AssembleTSBK(tsbk))...)
+	}
+	return frame
+}
+
+// TestControlChannelDecodesAllThreeTSBKBlocksAcrossChunks pins the issue
+// #402 / PR #470 multi-block decode under chunk boundaries: a single TSDU
+// carries three TSBK blocks after one FSW+NID, and parseFrame must decode all
+// three — resuming the trailing blocks across Process() calls — even when the
+// IQ chunk boundary falls mid-TSDU. The live "block=2 fails first" report was
+// a dropped IQ chunk corrupting the last block; this test proves the decode
+// path itself stays continuous when the dibits do, so a future refactor of the
+// resume/continuation bookkeeping can't silently drop blocks 2-3 again (the
+// pre-#470 behaviour that dropped ~2/3 of site signalling).
+func TestControlChannelDecodesAllThreeTSBKBlocksAcrossChunks(t *testing.T) {
+	bus := events.NewBus(32)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	const nac = 0x293
+	// Block 0: identifier update so the grants in blocks 1-2 resolve a freq.
+	ident := TSBK{LB: false, Opcode: OpIdentifierUpdate}
+	ident.Payload = AssembleIdentifierUpdate(IdentifierUpdate{
+		ChannelID: 1, SpacingHz: 12_500, BaseHz: 851_000_000,
+	})
+	// Block 1: grant on channel number 16 -> 851_200_000.
+	grantA := TSBK{LB: false, Opcode: OpGroupVoiceChannelGrant, Payload: [8]byte{
+		0x00, (1 << 4) | 0x00, 0x10, 0x12, 0x34, 0xAB, 0xCD, 0xEF,
+	}}
+	// Block 2 (last): grant on channel number 32 -> 851_400_000. This is the
+	// "block=2" the live report saw fail first.
+	grantB := TSBK{LB: true, Opcode: OpGroupVoiceChannelGrant, Payload: [8]byte{
+		0x00, (1 << 4) | 0x00, 0x20, 0x56, 0x78, 0x11, 0x22, 0x33,
+	}}
+
+	onAir := InjectControlStatusSymbols(buildControlFrameMultiTSBK(nac, DUIDTrunkingSignaling, ident, grantA, grantB))
+	stream := make([]uint8, 10+len(onAir)+16)
+	copy(stream[10:], onAir)
+
+	cc := New(Options{
+		Bus: bus, SystemName: "TestSys", FrequencyHz: 851_000_000,
+		Now: func() time.Time { return time.Unix(1_700_000_000, 0).UTC() },
+	})
+
+	// An odd batch splits the TSDU mid-block so the trailing TSBKs land on a
+	// later Process() call and must be resumed.
+	const batch = 17
+	for off := 0; off < len(stream); off += batch {
+		end := off + batch
+		if end > len(stream) {
+			end = len(stream)
+		}
+		cc.Process(stream[off:end], off)
+	}
+
+	gotFreqs := map[uint32]bool{}
+	for drained := false; !drained; {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind == events.KindGrant {
+				gotFreqs[ev.Payload.(trunking.Grant).FrequencyHz] = true
+			}
+		default:
+			drained = true
+		}
+	}
+	if !gotFreqs[851_200_000] {
+		t.Error("block 1 grant did not decode — second TSBK block dropped")
+	}
+	if !gotFreqs[851_400_000] {
+		t.Error("block 2 grant did not decode — last (block=2) TSBK dropped; multi-block resume regressed")
+	}
+}
+
 func TestControlChannelPublishesAffiliation(t *testing.T) {
 	bus := events.NewBus(8)
 	defer bus.Close()

--- a/internal/radio/p25/phase1/receiver/regression_defaults_test.go
+++ b/internal/radio/p25/phase1/receiver/regression_defaults_test.go
@@ -1,0 +1,58 @@
+package receiver
+
+import "testing"
+
+// TestDefaultC4FMOptionsDisableDDAAndAdaptiveSlicer pins the issue #402
+// reverts so a future change can't silently revive them. The production
+// pipeline (internal/scanner/ccdecoder/pipelines.go) builds the C4FM receiver
+// with neither EnableDecisionDirectedAFC nor EnableAdaptiveC4FMSlicer set:
+//
+//   - The decision-directed AFC (#412) stably false-locked onto a wrong
+//     carrier offset with no FSW/CC-lock feedback to catch it, dropping the
+//     MMR Site 9 capture from ~60% to 0% lock. Reverted by #430.
+//   - The adaptive C4FM slicer (#432/#439/#447) went through truncation-bias
+//     runaway, over- then under-regularization, and finally a catastrophic
+//     0-FSW collapse before being made opt-in. Reverted to the fixed slicer
+//     default by #450.
+//
+// Both remain available as explicit opt-ins (replay -dda / -adaptive-slicer)
+// for experimentation, but the daemon's default C4FM path must stay
+// CoarseAFC-alone with the fixed-threshold slicer.
+func TestDefaultC4FMOptionsDisableDDAAndAdaptiveSlicer(t *testing.T) {
+	// Mirror the production options from pipelines.go: DeviationHz>0 so the
+	// adaptive slicer COULD activate — proving these are off by default, not
+	// merely gated out by a zero deviation.
+	def := New(Options{
+		SampleRateHz: 48_000,
+		DeviationHz:  1800.0,
+		DemodMode:    DemodC4FM,
+		DibitSink:    func([]uint8, int) {},
+	})
+	if def.dda != nil {
+		t.Error("default C4FM receiver constructed a DDA; #412 was reverted (#430) — DDA must stay off by default")
+	}
+	if def.slicer != nil {
+		t.Error("default C4FM receiver constructed the adaptive slicer; #432/#439/#447 were reverted (#450) — fixed slicer must stay the default")
+	}
+	if def.DDAActive() {
+		t.Error("default C4FM receiver reports DDAActive() true before any processing")
+	}
+
+	// Guard against the inverse rot: the opt-in flags must still wire the
+	// components up, so the test above is pinning the DEFAULT rather than a
+	// dead code path that can never activate.
+	on := New(Options{
+		SampleRateHz:              48_000,
+		DeviationHz:               1800.0,
+		DemodMode:                 DemodC4FM,
+		EnableDecisionDirectedAFC: true,
+		EnableAdaptiveC4FMSlicer:  true,
+		DibitSink:                 func([]uint8, int) {},
+	})
+	if on.dda == nil {
+		t.Error("EnableDecisionDirectedAFC=true did not construct the DDA")
+	}
+	if on.slicer == nil {
+		t.Error("EnableAdaptiveC4FMSlicer=true did not construct the adaptive slicer")
+	}
+}

--- a/internal/scanner/ccdecoder/decoder.go
+++ b/internal/scanner/ccdecoder/decoder.go
@@ -178,6 +178,14 @@ type Decoder struct {
 	mu       sync.Mutex
 	active   ProtocolPipeline
 	activeAt string // system name the active pipeline is bound to
+	// activeFreqHz is the frequency the active pipeline is tuned to. A
+	// HuntProgress that repeats the same (system, frequency) — e.g. the
+	// supervisor re-hunting a single-candidate system every dwell —
+	// must NOT tear the pipeline down and flush the DDC + symbol clock,
+	// or acquisition restarts from scratch every few seconds and never
+	// converges on a live stream (issue #402: "no FSW hits in chunk"
+	// cycling with "pipeline configured"). Zero until the first build.
+	activeFreqHz uint32
 
 	// ddcOut is the reusable down-converter output buffer — pump
 	// hands it to Downconverter.Process each chunk so the decimated
@@ -306,6 +314,18 @@ func (d *Decoder) handleProgress(p trunking.HuntProgress) {
 		return
 	}
 	d.mu.Lock()
+	// Idempotent retune: if the supervisor is re-attempting the same
+	// (system, frequency) the active pipeline is already decoding, leave
+	// it running. Rebuilding here would Close the pipeline and Reset the
+	// DDC + symbol clock, discarding partial sync — and on a single-
+	// candidate system the hunter re-attempts every dwell (~3s), so a
+	// rebuild-on-every-attempt loop never lets a live stream acquire FSW
+	// (issue #402). A genuine retune (different freq or protocol) still
+	// rebuilds below.
+	if d.active != nil && d.activeAt == sys.Name && d.activeFreqHz == p.AttemptedFreqHz {
+		d.mu.Unlock()
+		return
+	}
 	// Close the previous pipeline before constructing a new one so
 	// resources don't accumulate on rapid retune storms.
 	if d.active != nil {
@@ -335,6 +355,7 @@ func (d *Decoder) handleProgress(p trunking.HuntProgress) {
 	d.mu.Lock()
 	d.active = p2
 	d.activeAt = sys.Name
+	d.activeFreqHz = p.AttemptedFreqHz
 	// Flush the down-converter so decimation-filter state from the
 	// previous channel doesn't bleed into the freshly-tuned one.
 	d.ddc.Reset()
@@ -360,6 +381,7 @@ func (d *Decoder) clearActiveLocked() {
 		d.metrics.ClearIQDCRatioDb(d.activeAt)
 	}
 	d.activeAt = ""
+	d.activeFreqHz = 0
 	d.pwSumSq = 0
 	d.pwSumI = 0
 	d.pwSumQ = 0

--- a/internal/scanner/ccdecoder/decoder_test.go
+++ b/internal/scanner/ccdecoder/decoder_test.go
@@ -343,6 +343,67 @@ func TestHandleProgressUnknownProtocolClearsActive(t *testing.T) {
 	}
 }
 
+// TestHandleProgressRepeatedSameFreqIsIdempotent pins the issue-#402
+// live-acquisition fix: a HuntProgress that repeats the same (system,
+// frequency) the active pipeline is already decoding must NOT rebuild
+// the pipeline or flush the DDC. On a single-candidate system the
+// supervisor re-attempts every dwell (~3s); a rebuild-on-every-attempt
+// loop flushed the symbol clock + decimation filter each time and the
+// live stream never acquired FSW ("no FSW hits in chunk" cycling with
+// "pipeline configured"). Replay never exercised this because it never
+// re-hunts.
+func TestHandleProgressRepeatedSameFreqIsIdempotent(t *testing.T) {
+	saved := factories
+	builds := 0
+	var rec *recordingPipeline
+	factories = map[trunking.Protocol]PipelineFactory{
+		trunking.ProtocolP25: func(PipelineOptions) (ProtocolPipeline, error) {
+			builds++
+			rec = &recordingPipeline{}
+			return rec, nil
+		},
+	}
+	t.Cleanup(func() { factories = saved })
+
+	bus := events.NewBus(8)
+	defer bus.Close()
+	d, err := New(Options{
+		Bus: bus, IQ: &fakeIQSource{}, SampleRateHz: 48000,
+		Systems: []trunking.System{{
+			Name: "Sys", Protocol: trunking.ProtocolP25,
+			ControlChannels: []uint32{851_012_500},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	prog := trunking.HuntProgress{System: "Sys", AttemptedFreqHz: 851_012_500}
+	d.handleProgress(prog) // first attempt: builds
+	first := rec
+	d.handleProgress(prog) // re-hunt same freq: must be a no-op
+	d.handleProgress(prog)
+
+	if builds != 1 {
+		t.Errorf("pipeline builds = %d, want 1 (repeated same-freq retune must not rebuild)", builds)
+	}
+	if d.active != first {
+		t.Errorf("active pipeline was swapped on a repeated same-freq retune")
+	}
+	if first.closes != 0 {
+		t.Errorf("active pipeline Close calls = %d, want 0 (must not tear down on same-freq retune)", first.closes)
+	}
+
+	// A genuine retune to a different frequency must still rebuild.
+	d.handleProgress(trunking.HuntProgress{System: "Sys", AttemptedFreqHz: 851_025_000})
+	if builds != 2 {
+		t.Errorf("pipeline builds = %d after a real retune, want 2", builds)
+	}
+	if first.closes != 1 {
+		t.Errorf("previous pipeline Close calls = %d after a real retune, want 1", first.closes)
+	}
+}
+
 // TestP25Phase1FactoryConstructs: smoke test that the wired
 // P25 P1 factory builds without error and returns a pipeline whose
 // Process / Reset / Close run cleanly on a small IQ chunk.

--- a/internal/sdr/rtlsdr/purego/device.go
+++ b/internal/sdr/rtlsdr/purego/device.go
@@ -95,6 +95,22 @@ func (d *Device) SetSampleRate(hz uint32) error {
 	return nil
 }
 
+// ActualSampleRate returns the exact IQ rate the RTL2832U is delivering.
+// The demod quantizes a requested rate to its 28.4 fixed-point resampler
+// divisor, so the streamed rate can differ from the value passed to
+// SetSampleRate (e.g. 2.4/0.96 MS/s land exactly, but 2.048/1.024 MS/s and
+// odd custom rates do not). The down-converter's decimation ratio must be
+// derived from THIS rate, not the requested one — otherwise the symbol
+// clock drifts on the live stream while offline replay (which reads a file
+// at exactly the configured rate) stays correct (issue #402). Optional
+// sdr.Device extension; callers type-assert for it.
+func (d *Device) ActualSampleRate() (uint32, error) {
+	if d.closed.Load() {
+		return 0, ErrClosed
+	}
+	return d.demod.GetSampleRate(), nil
+}
+
 // SetGain takes the [sdr.Device] convention: tenthDB < 0 selects AGC,
 // tenthDB ≥ 0 switches to manual mode and applies the closest
 // quantized gain on the chip's ladder. Mirrors librtlsdr's

--- a/internal/sdr/rtlsdr/tuners/r82xx_test.go
+++ b/internal/sdr/rtlsdr/tuners/r82xx_test.go
@@ -770,6 +770,30 @@ func TestR82xx_PPMCorrectionShiftsPLLReference(t *testing.T) {
 	}
 }
 
+// TestR82xx_SetFreqCorrectionZeroIsNoOpRetune pins the issue-#402 ppm:0
+// path: the reporter runs ppm: 0, so the daemon pushes SetPPM(0) ->
+// SetFreqCorrection(0) at startup. With ppmCorr already at its 0 default,
+// this must return before any SetFreq — a spurious LO re-tune mid-
+// acquisition would disturb FSW lock on the live stream — even after a
+// frequency has been tuned. The nil transport here makes an accidental
+// SetFreq panic, so reaching the retune path fails the test loudly rather
+// than silently re-tuning.
+func TestR82xx_SetFreqCorrectionZeroIsNoOpRetune(t *testing.T) {
+	r := NewR82xx(nil, r828dI2CAddr, TypeR828D)
+	r.initDone = true
+	r.freqHz = 420_087_500 // pretend Mt Anakie is already tuned
+
+	if err := r.SetFreqCorrection(0); err != nil {
+		t.Fatalf("SetFreqCorrection(0) = %v, want nil no-op (must not retune)", err)
+	}
+	if r.ppmCorr != 0 {
+		t.Errorf("ppmCorr = %d after SetFreqCorrection(0), want 0", r.ppmCorr)
+	}
+	if got := r.effectiveXtalHz(); got != r828dXtalHz {
+		t.Errorf("effectiveXtalHz = %d after ppm 0, want raw crystal %d", got, r828dXtalHz)
+	}
+}
+
 // Detect orchestrator tests moved to detect_test.go (it walks every
 // candidate tuner, not just R820T, so the scripts that pin its
 // behavior live with the orchestrator).


### PR DESCRIPTION
Issue #402's replay path decodes the reporter's captures cleanly (Mt
Anakie: 58/58 NID, 173/173 TSBK, 0 CRC failures), so the remaining
failure is live-only — the decoder never acquires FSW on air while
replay stays green. That isolates the bug to the live acquisition chain
replay never exercises (SDR driver + tuner + hunt/retune control flow),
not the DSP. The prior AFC (#412) and adaptive-slicer (#432/#439/#447)
iterations that regressed this issue were already reverted (#430/#450);
this change targets the live path and pins the reverts so they can't
silently return.

- gain: warn when a manual gain parses cleanly but is too low for
  digital decode (the 51-149 tenths band the dB-mistake check misses).
  The reporter ran 8.7 dB vs the 49 dB the same site decoded at — low
  tuner gain starves the on-channel SNR even while the aggregate IQ
  power gauge looks healthy.
- ccdecoder: make a HuntProgress retune to the same (system, frequency)
  idempotent. A single-candidate system re-hunts every dwell (~3s);
  rebuilding the pipeline + flushing the DDC/symbol clock on every
  attempt meant a live stream never converged ("no FSW hits in chunk"
  cycling with "pipeline configured"). A genuine retune still rebuilds.
- rtlsdr/purego: expose ActualSampleRate(); build the down-converter
  from the rate the RTL2832U actually delivers, not the requested one,
  so a non-exact-divisor rate doesn't drift the symbol clock on the live
  path (replay reads a file at exactly the configured rate). Warns only
  when the delivered rate differs.

Regression guards (the "ghost" the reporter suspected):
- pin DDA + adaptive C4FM slicer OFF by default in the C4FM receiver.
- confirm SetFreqCorrection(0) is a true no-op (no spurious LO re-tune
  mid-acquisition) for the reporter's ppm: 0.
- multi-block TSBK decode (3 blocks/TSDU) stays continuous across chunk
  boundaries, defending the #470 resume path.

https://claude.ai/code/session_01Vj38prv6tXacU2iW3abYBH