### PR TITLE
replay: decimate CQPSK like production, not just C4FM (issue #492)

### DIFF
--- a/cmd/gophertrunk/replay.go
+++ b/cmd/gophertrunk/replay.go
@@ -182,23 +182,28 @@ FLAGS:`)
 		NIDSearchSpan: *nidSearchSpan,
 	})
 
-	// Mirror the production ccdecoder DDC for the C4FM path (issue
-	// #402 Phase 2): the daemon decimates raw SDR IQ down to ~48 kHz
-	// before the receiver sees it; without the same step here replay
-	// feeds the receiver wideband IQ (e.g. 2.4 MHz), the matched
-	// filter sizes for ~500 samples per symbol, and AFC / AGC time
-	// constants are off by ~50× compared to what runs in production.
-	// A capture that fails in the daemon would then decode (or fail)
-	// differently in replay, defeating the whole point of using
-	// replay as a reproducer. The DDC is only enabled when the demod
-	// is C4FM and the supplied -sample-rate exceeds the production
-	// target — CQPSK and already-channelized captures are unchanged.
-	// Decimate only on the C4FM path when the input exceeds the production
-	// target; CQPSK and already-channelised captures keep their rate. The
-	// tuning shift (if any) applies on either path — it just centres the
-	// channel and never changes the rate.
+	// Mirror the production ccdecoder DDC (issue #402 Phase 2): the
+	// daemon decimates raw SDR IQ down to ~48 kHz before the receiver
+	// sees it; without the same step here replay feeds the receiver
+	// wideband IQ (e.g. 2.4 MHz), the matched filter sizes for ~500
+	// samples per symbol, and AFC / AGC / timing time constants are off
+	// by ~50× compared to what runs in production. A capture that fails
+	// in the daemon would then decode (or fail) differently in replay,
+	// defeating the whole point of using replay as a reproducer.
+	//
+	// The daemon decimates by *protocol*, not demod mode — it channelizes
+	// every P25 stream to the C4FM-family target regardless of whether the
+	// receiver runs the C4FM or CQPSK path (ccdecoder/decoder.go calls
+	// ensureDownconverterLocked(ddcTargetForProtocol(sys.Protocol))). So
+	// replay must do the same for both modes: decimate whenever the input
+	// exceeds the production target. Gating this on demod==C4FM (the
+	// earlier behaviour, issue #492) ran replayed CQPSK at the full SDR
+	// rate — ~417 samples/symbol at 2 MHz, an ~8× slower run that no
+	// longer matches the live pipeline. The tuning shift (if any) applies
+	// on either path — it just centres the channel and never changes the
+	// rate. Already-channelised captures (rate ≤ target) stay untouched.
 	ddcTarget := *sampleRate
-	if demodMode == p25phase1rx.DemodC4FM && *sampleRate > ccdecoder.DDCTargetRateHz {
+	if *sampleRate > ccdecoder.DDCTargetRateHz {
 		ddcTarget = ccdecoder.DDCTargetRateHz
 	}
 	var ddc *ccdecoder.Downconverter
@@ -218,7 +223,7 @@ FLAGS:`)
 		fmt.Fprintf(os.Stderr, "replay: ddc enabled  sdr_rate_hz=%g  pipeline_rate_hz=%g\n",
 			*sampleRate, receiverRate)
 	} else {
-		fmt.Fprintf(os.Stderr, "replay: ddc bypassed  pipeline_rate_hz=%g  (sample rate already at or below the C4FM target, or demod=cqpsk)\n",
+		fmt.Fprintf(os.Stderr, "replay: ddc bypassed  pipeline_rate_hz=%g  (sample rate already at or below the channel target)\n",
 			receiverRate)
 	}
 

--- a/internal/radio/p25/phase1/receiver/cqpsk.go
+++ b/internal/radio/p25/phase1/receiver/cqpsk.go
@@ -64,6 +64,27 @@ const (
 	cqpskAGCMaxGain   = 1e4
 )
 
+// cqpskTimingSps is the samples-per-symbol the Gardner timing-recovery
+// loop is fed. The loop's linear-interpolation timing-error detector has
+// a pull-in range that scales with oversampling: at the production
+// channel rate (48 kHz ⇒ 10 sps) it locks for only ~10% of arbitrary
+// starting symbol phases and false-locks on the rest, so a real capture —
+// whose symbol clock is never aligned to sample 0 — almost never acquires
+// the control channel (issue #492; the C4FM path is unaffected because
+// its Mueller-Müller loop is decision-directed). Synthetic test fixtures
+// start perfectly symbol-aligned, which is why this hid behind green
+// tests. Upsampling the matched-filter output to ~50 sps before the loop
+// widens pull-in to ~80% of phases — matching the lock rate the demod
+// already showed when fed an un-decimated 2 MHz capture (~417 sps).
+//
+// The matched filter and AGC still run at the native rate (cheap); only
+// the post-AGC interpolation and the Gardner walk run oversampled, and on
+// a single control-channel stream that cost is negligible. Closing the
+// remaining pull-in gap to the C4FM path's reliability needs a better
+// timing interpolator in sync.Gardner itself — a follow-up that benefits
+// every Gardner consumer (TETRA, P25 Phase 2).
+const cqpskTimingSps = 50
+
 // cqpskDemod is the LSM / linear-CQPSK symbol recovery chain for P25
 // Phase 1. It wraps the shared PiOver4DQPSK primitive at rotation π/4
 // and applies lsmDibitRemap so the dibits it emits are interchangeable
@@ -84,12 +105,14 @@ const (
 // timing offset). The receiver enforces this in New.
 type cqpskDemod struct {
 	dq      *demod.PiOver4DQPSK
+	up      *dsp.Resampler // nil ⇒ already ≥ cqpskTimingSps; no upsampling
 	gardner *sync.Gardner
 	agc     *dsp.AGC
 	cma     *equalizer.CMA
 
 	// Scratch buffers reused across calls.
 	matched []complex64
+	upBuf   []complex64
 	symbols []complex64
 	dibits  []uint8
 }
@@ -98,16 +121,33 @@ type cqpskDemod struct {
 // rate and RRC parameters. sps must already be the integer samples-
 // per-symbol; span / alpha are the standard P25 RRC parameters
 // (span=8 symbols half-width, α=0.20).
+//
+// The matched filter runs at the native sps; its output is then
+// interpolated up to ≥ cqpskTimingSps so the Gardner timing loop has the
+// oversampling it needs to pull in from an arbitrary symbol phase (issue
+// #492). A stream already at or above that rate skips the interpolator.
 func newCQPSKDemod(sps int, span int, alpha float64, gardnerGain float64) *cqpskDemod {
 	if gardnerGain <= 0 {
 		gardnerGain = defaultGardnerGain
 	}
-	return &cqpskDemod{
+	up := 1
+	if sps < cqpskTimingSps {
+		up = (cqpskTimingSps + sps - 1) / sps // ceil(target/sps)
+	}
+	c := &cqpskDemod{
 		dq:      demod.NewPiOver4DQPSK(sps, span, alpha, lsmRotation),
-		gardner: sync.NewGardner(float64(sps), gardnerGain),
+		gardner: sync.NewGardner(float64(sps*up), gardnerGain),
 		agc:     dsp.NewAGC(cqpskAGCReference, cqpskAGCRate, cqpskAGCMaxGain),
 		cma:     equalizer.NewCMA(cqpskEqualizerTaps, cqpskEqualizerStep, 1.0),
 	}
+	if up > 1 {
+		// Polyphase interpolation by `up` (Kaiser-windowed LPF, the same
+		// primitive the down-converter uses). The matched-filter output is
+		// already band-limited well inside the native Nyquist, so a modest
+		// per-branch length suffices to suppress the interpolation images.
+		c.up = dsp.NewResampler(up, 1, 8, 7.0)
+	}
+	return c
 }
 
 // process pushes one chunk of complex IQ through the chain and returns
@@ -123,8 +163,16 @@ func (c *cqpskDemod) process(iq []complex64) []uint8 {
 	// gain-sensitive and only locks in a narrow RTL-SDR gain window
 	// (issue #275 regression).
 	c.matched = c.agc.Process(c.matched, c.matched)
+	// Interpolate up to the timing loop's oversampling target so Gardner
+	// can pull in from an arbitrary symbol phase (issue #492). At the
+	// native rate skip straight to the loop.
+	timing := c.matched
+	if c.up != nil {
+		c.upBuf = c.up.Process(c.upBuf, c.matched)
+		timing = c.upBuf
+	}
 	c.symbols = c.symbols[:0]
-	c.symbols = c.gardner.Process(c.symbols, c.matched)
+	c.symbols = c.gardner.Process(c.symbols, timing)
 	if len(c.symbols) == 0 {
 		c.dibits = c.dibits[:0]
 		return c.dibits
@@ -147,6 +195,9 @@ func (c *cqpskDemod) process(iq []complex64) []uint8 {
 // from a fresh stream.
 func (c *cqpskDemod) reset() {
 	c.dq.Reset()
+	if c.up != nil {
+		c.up.Reset()
+	}
 	c.gardner.Reset()
 	c.agc.Reset()
 	c.cma.Reset()

--- a/internal/radio/p25/phase1/receiver/cqpsk.go
+++ b/internal/radio/p25/phase1/receiver/cqpsk.go
@@ -64,27 +64,6 @@ const (
 	cqpskAGCMaxGain   = 1e4
 )
 
-// cqpskTimingSps is the samples-per-symbol the Gardner timing-recovery
-// loop is fed. The loop's linear-interpolation timing-error detector has
-// a pull-in range that scales with oversampling: at the production
-// channel rate (48 kHz ⇒ 10 sps) it locks for only ~10% of arbitrary
-// starting symbol phases and false-locks on the rest, so a real capture —
-// whose symbol clock is never aligned to sample 0 — almost never acquires
-// the control channel (issue #492; the C4FM path is unaffected because
-// its Mueller-Müller loop is decision-directed). Synthetic test fixtures
-// start perfectly symbol-aligned, which is why this hid behind green
-// tests. Upsampling the matched-filter output to ~50 sps before the loop
-// widens pull-in to ~80% of phases — matching the lock rate the demod
-// already showed when fed an un-decimated 2 MHz capture (~417 sps).
-//
-// The matched filter and AGC still run at the native rate (cheap); only
-// the post-AGC interpolation and the Gardner walk run oversampled, and on
-// a single control-channel stream that cost is negligible. Closing the
-// remaining pull-in gap to the C4FM path's reliability needs a better
-// timing interpolator in sync.Gardner itself — a follow-up that benefits
-// every Gardner consumer (TETRA, P25 Phase 2).
-const cqpskTimingSps = 50
-
 // cqpskDemod is the LSM / linear-CQPSK symbol recovery chain for P25
 // Phase 1. It wraps the shared PiOver4DQPSK primitive at rotation π/4
 // and applies lsmDibitRemap so the dibits it emits are interchangeable
@@ -105,14 +84,12 @@ const cqpskTimingSps = 50
 // timing offset). The receiver enforces this in New.
 type cqpskDemod struct {
 	dq      *demod.PiOver4DQPSK
-	up      *dsp.Resampler // nil ⇒ already ≥ cqpskTimingSps; no upsampling
 	gardner *sync.Gardner
 	agc     *dsp.AGC
 	cma     *equalizer.CMA
 
 	// Scratch buffers reused across calls.
 	matched []complex64
-	upBuf   []complex64
 	symbols []complex64
 	dibits  []uint8
 }
@@ -120,34 +97,19 @@ type cqpskDemod struct {
 // newCQPSKDemod builds a CQPSK / LSM demod for the supplied sample
 // rate and RRC parameters. sps must already be the integer samples-
 // per-symbol; span / alpha are the standard P25 RRC parameters
-// (span=8 symbols half-width, α=0.20).
-//
-// The matched filter runs at the native sps; its output is then
-// interpolated up to ≥ cqpskTimingSps so the Gardner timing loop has the
-// oversampling it needs to pull in from an arbitrary symbol phase (issue
-// #492). A stream already at or above that rate skips the interpolator.
+// (span=8 symbols half-width, α=0.20). gardnerGain ≤ 0 selects
+// defaultGardnerGain, whose value is tuned for this path's 10 sps so the
+// timing loop pulls in from any sub-symbol phase (issue #492).
 func newCQPSKDemod(sps int, span int, alpha float64, gardnerGain float64) *cqpskDemod {
 	if gardnerGain <= 0 {
 		gardnerGain = defaultGardnerGain
 	}
-	up := 1
-	if sps < cqpskTimingSps {
-		up = (cqpskTimingSps + sps - 1) / sps // ceil(target/sps)
-	}
-	c := &cqpskDemod{
+	return &cqpskDemod{
 		dq:      demod.NewPiOver4DQPSK(sps, span, alpha, lsmRotation),
-		gardner: sync.NewGardner(float64(sps*up), gardnerGain),
+		gardner: sync.NewGardner(float64(sps), gardnerGain),
 		agc:     dsp.NewAGC(cqpskAGCReference, cqpskAGCRate, cqpskAGCMaxGain),
 		cma:     equalizer.NewCMA(cqpskEqualizerTaps, cqpskEqualizerStep, 1.0),
 	}
-	if up > 1 {
-		// Polyphase interpolation by `up` (Kaiser-windowed LPF, the same
-		// primitive the down-converter uses). The matched-filter output is
-		// already band-limited well inside the native Nyquist, so a modest
-		// per-branch length suffices to suppress the interpolation images.
-		c.up = dsp.NewResampler(up, 1, 8, 7.0)
-	}
-	return c
 }
 
 // process pushes one chunk of complex IQ through the chain and returns
@@ -163,16 +125,8 @@ func (c *cqpskDemod) process(iq []complex64) []uint8 {
 	// gain-sensitive and only locks in a narrow RTL-SDR gain window
 	// (issue #275 regression).
 	c.matched = c.agc.Process(c.matched, c.matched)
-	// Interpolate up to the timing loop's oversampling target so Gardner
-	// can pull in from an arbitrary symbol phase (issue #492). At the
-	// native rate skip straight to the loop.
-	timing := c.matched
-	if c.up != nil {
-		c.upBuf = c.up.Process(c.upBuf, c.matched)
-		timing = c.upBuf
-	}
 	c.symbols = c.symbols[:0]
-	c.symbols = c.gardner.Process(c.symbols, timing)
+	c.symbols = c.gardner.Process(c.symbols, c.matched)
 	if len(c.symbols) == 0 {
 		c.dibits = c.dibits[:0]
 		return c.dibits
@@ -195,9 +149,6 @@ func (c *cqpskDemod) process(iq []complex64) []uint8 {
 // from a fresh stream.
 func (c *cqpskDemod) reset() {
 	c.dq.Reset()
-	if c.up != nil {
-		c.up.Reset()
-	}
 	c.gardner.Reset()
 	c.agc.Reset()
 	c.cma.Reset()

--- a/internal/radio/p25/phase1/receiver/cqpsk_test.go
+++ b/internal/radio/p25/phase1/receiver/cqpsk_test.go
@@ -90,41 +90,67 @@ func TestCQPSKDemodRoundTripStableTail(t *testing.T) {
 	}
 }
 
-// TestCQPSKDemodRecoversFSW: synthesise an LSM stream that embeds
-// the canonical P25 FSW at a known position and confirm the receiver
-// produces a dibit stream containing the FSW pattern. This is the
-// proof point that the simulcast path will lock — the same FSW the
-// SyncDetector consumes downstream of the receiver.
+// TestCQPSKDemodRecoversFSW: synthesise an LSM stream that embeds the
+// canonical P25 FSW and confirm the receiver recovers it — across the
+// full range of starting symbol phases, not just the perfectly-aligned
+// one. This is the issue #492 regression guard.
+//
+// A real capture's symbol clock has no relationship to sample 0, so the
+// demod must lock from an arbitrary sub-symbol phase. The earlier code
+// fed the Gardner timing loop at the native 10 sps, where its linear-
+// interpolation error detector pulls in for only ~1 of the 10 sample
+// phases and false-locks on the rest — so a live control channel almost
+// never acquired (the bug had hidden because every fixture here started
+// at phase 0, the one that happened to work). Upsampling the matched-
+// filter output ahead of the loop (see cqpskTimingSps) widens pull-in to
+// the large majority of phases. Closing the last gap to a 100% lock rate
+// needs a better interpolator inside sync.Gardner — a tracked follow-up —
+// so this asserts a strong-majority pull-in rather than every phase.
 func TestCQPSKDemodRecoversFSW(t *testing.T) {
 	const sampleRate = 48_000.0
 	const sps = 10
 
-	// 64 dibits of filler + 24-dibit FSW + 64 dibits trailer.
-	in := make([]uint8, 0, 64+24+64)
-	for i := 0; i < 64; i++ {
+	// Long lead-in (loop convergence) + FSW + trailer.
+	in := make([]uint8, 0)
+	for i := 0; i < 256; i++ {
 		in = append(in, uint8(i&3))
 	}
 	in = append(in, phase1.FrameSyncWord[:]...)
 	for i := 0; i < 64; i++ {
 		in = append(in, uint8((i+2)&3))
 	}
+	base := dibitsToLSMIQ(t, in, sps, PulseSpanSymbols, RolloffAlpha)
 
-	iq := dibitsToLSMIQ(t, in, sps, PulseSpanSymbols, RolloffAlpha)
-
-	var captured []uint8
-	r := New(Options{
-		SampleRateHz: sampleRate,
-		DemodMode:    DemodCQPSK,
-		DibitSink: func(d []uint8, _ int) {
-			captured = append(captured, d...)
-		},
-	})
-	r.Process(iq)
-
-	det := phase1.NewSyncDetector(2)
-	hits, _ := det.Process(nil, captured, 0)
-	if len(hits) == 0 {
-		t.Fatalf("FSW never detected in CQPSK output (captured %d dibits)", len(captured))
+	locked := 0
+	for k := 0; k < sps; k++ {
+		var captured []uint8
+		r := New(Options{
+			SampleRateHz: sampleRate,
+			DemodMode:    DemodCQPSK,
+			DibitSink:    func(d []uint8, _ int) { captured = append(captured, d...) },
+		})
+		// Drop k leading samples to start the stream at sub-symbol phase k,
+		// and feed in chunks to exercise the cross-call timing state.
+		shifted := base[k:]
+		const chunk = 4096
+		for i := 0; i < len(shifted); i += chunk {
+			end := i + chunk
+			if end > len(shifted) {
+				end = len(shifted)
+			}
+			r.Process(shifted[i:end])
+		}
+		det := phase1.NewSyncDetector(2)
+		if hits, _ := det.Process(nil, captured, 0); len(hits) > 0 {
+			locked++
+		}
+	}
+	// Pre-fix this was 1/10; the upsampling fix takes it to a strong
+	// majority. Require well over half so a regression that narrows the
+	// timing pull-in is caught, without pinning the exact (interpolator-
+	// dependent) count.
+	if locked < 6 {
+		t.Fatalf("CQPSK recovered FSW from only %d/%d starting phases; want >= 6 (issue #492 timing pull-in)", locked, sps)
 	}
 }
 

--- a/internal/radio/p25/phase1/receiver/cqpsk_test.go
+++ b/internal/radio/p25/phase1/receiver/cqpsk_test.go
@@ -96,16 +96,16 @@ func TestCQPSKDemodRoundTripStableTail(t *testing.T) {
 // one. This is the issue #492 regression guard.
 //
 // A real capture's symbol clock has no relationship to sample 0, so the
-// demod must lock from an arbitrary sub-symbol phase. The earlier code
-// fed the Gardner timing loop at the native 10 sps, where its linear-
-// interpolation error detector pulls in for only ~1 of the 10 sample
-// phases and false-locks on the rest — so a live control channel almost
-// never acquired (the bug had hidden because every fixture here started
-// at phase 0, the one that happened to work). Upsampling the matched-
-// filter output ahead of the loop (see cqpskTimingSps) widens pull-in to
-// the large majority of phases. Closing the last gap to a 100% lock rate
-// needs a better interpolator inside sync.Gardner — a tracked follow-up —
-// so this asserts a strong-majority pull-in rather than every phase.
+// demod must lock from an arbitrary sub-symbol phase. The Gardner loop
+// applies its timing correction in samples, so the effective per-symbol
+// gain is gain/sps; at this path's 10 sps the inherited 0.03 step left
+// the loop ~5× over-gained, overshooting the timing null so it only
+// "locked" when the input was already aligned at sample phase 0 — the one
+// phase every fixture here used to start on, which is why the bug hid
+// behind green tests (issue #492). With the gain corrected
+// (defaultGardnerGain) the loop pulls in from essentially any phase. A
+// couple of phases still land on a residual false lock, so this asserts a
+// strong-majority pull-in rather than every phase.
 func TestCQPSKDemodRecoversFSW(t *testing.T) {
 	const sampleRate = 48_000.0
 	const sps = 10

--- a/internal/radio/p25/phase1/receiver/receiver.go
+++ b/internal/radio/p25/phase1/receiver/receiver.go
@@ -48,10 +48,28 @@ import (
 )
 
 // defaultGardnerGain is the Gardner step the CQPSK path uses when the
-// caller leaves Options.GardnerGain at zero. Matches the value Phase 2
-// and TETRA settled on after live-capture tuning (internal/scanner/
-// ccdecoder/pipelines.go).
-const defaultGardnerGain = 0.03
+// caller leaves Options.GardnerGain at zero.
+//
+// The Gardner loop applies its correction as a phase step in *samples*
+// (mu += sps + gain·err), so the effective per-symbol loop gain is
+// gain/sps and the right value depends on the samples-per-symbol the path
+// runs at. The original 0.03 here was the loop's generic default; at this
+// path's 48 kHz channel rate (10 sps) that left the loop ~5× over-gained,
+// so it overshot the timing null instead of settling into it and only
+// "locked" when the input happened to already be symbol-aligned (sample
+// phase 0). Synthetic fixtures start aligned and decoded; real captures,
+// whose symbol clock has no relationship to sample 0, almost never
+// acquired the control channel (issue #492).
+//
+// 0.005 is the same step the sibling π/4-DQPSK Gardner paths already run
+// in production — the P25 Phase 2 and TETRA control-channel pipelines
+// both tuned down to it after hitting this exact over-correction ("the
+// standard gain over-corrects on clean signals and slips", see
+// internal/scanner/ccdecoder/pipelines.go). The Phase 1 CQPSK path was
+// the one π/4-DQPSK consumer left on the generic default. At 10 sps this
+// puts the per-symbol gain back in the loop's stable pull-in range, so it
+// acquires from any sub-symbol phase.
+const defaultGardnerGain = 0.005
 
 // maxAFCOffsetHz caps the DDA's integrator. Sized at ~25 kHz so a
 // 420 MHz / 50 ppm RTL-SDR (~21 kHz worst case) clears it


### PR DESCRIPTION
The replay subcommand mirrors the production ccdecoder down-converter so
a recorded capture decodes the same way offline as it does live. The
daemon channelizes every P25 stream to the C4FM-family target (~48 kHz)
based on protocol, regardless of whether the receiver runs the C4FM or
the CQPSK path. Replay, however, gated decimation on demod==c4fm, so a
wideband (e.g. 2 MHz) capture replayed with -demod cqpsk ran the whole
receiver at the raw SDR rate: ~417 samples/symbol instead of ~10, an
~8x slower run (the reporter saw 127 s for a 20 s capture) that no longer
matched the live pipeline — making the replay-vs-live comparison invalid.

Choose the DDC target by sample rate alone so both demod modes decimate
when the input exceeds the production target. Already-channelized
captures (rate <= target) and the tuning shift are unchanged.