### PR TITLE
p25/ccdecoder: detect ADC clipping so #402 overload is visible

### DIFF
--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -148,7 +148,7 @@ func warnLowGain(log *slog.Logger, serial string, role sdr.Role, raw string, ten
 		"role", role.String(),
 		"configured", raw,
 		"applied_db", float64(tenthDB)/10.0,
-		"hint", "manual P25/C4FM gains typically run 150-496 tenths (15-49.6 dB). gain: is in TENTHS of a dB; a reference 'gain 49' means ~49 dB -> gain: \"490\". Use 'gain: auto' or run 'gophertrunk sdr list' for the supported ladder.")
+		"hint", "manual P25/C4FM gains typically run 150-496 tenths (15-49.6 dB). gain: is in TENTHS of a dB; a reference 'gain 49' means ~49 dB -> gain: \"490\". Use 'gain: auto' or run 'gophertrunk sdr list' for the supported ladder. NOTE: this assumes the front end is not overloaded — if the iq_clip_ratio metric is non-zero (or iq_power_dbfs sits near 0), the radio is clipping and gain is already too HIGH for this site; reduce it or add attenuation instead of raising it (issue #402).")
 }
 
 // effectiveControlRate returns the IQ sample rate the control-channel

--- a/internal/metrics/prom.go
+++ b/internal/metrics/prom.go
@@ -47,6 +47,7 @@ type Metrics struct {
 	iqUnderruns   *prometheus.CounterVec
 	iqPowerDbFS   *prometheus.GaugeVec // by system; mean IQ power on the control SDR
 	iqDCRatioDb   *prometheus.GaugeVec // by system; DC-bin power relative to total IQ power, in dB (issue #402)
+	iqClipRatio   *prometheus.GaugeVec // by system; fraction of IQ samples pinned to the ADC rail (issue #402)
 	usbReconnects *prometheus.CounterVec
 	decodeErrors  *prometheus.CounterVec
 	sdrAttached   *prometheus.GaugeVec
@@ -131,7 +132,7 @@ func New(bus *events.Bus, pool Snapshotter, version string) (*Metrics, error) {
 		Namespace: namespace,
 		Subsystem: "sdr",
 		Name:      "iq_power_dbfs",
-		Help:      "Mean IQ power on the control SDR in dBFS (window ~= 1 s). Idle ≈ -45; healthy signal ≈ -25; > -3 indicates clipping.",
+		Help:      "Mean IQ power on the control SDR in dBFS (window ~= 1 s). Idle ≈ -45; healthy signal ≈ -25. This is RMS and averages away peak clipping — watch iq_clip_ratio for the authoritative overload signal (issue #402).",
 	}, []string{"system"})
 
 	// Diagnostic for the RTL-SDR R820T2 zero-IF DC-spike-on-channel
@@ -146,6 +147,20 @@ func New(bus *events.Bus, pool Snapshotter, version string) (*Metrics, error) {
 		Subsystem: "sdr",
 		Name:      "iq_dc_ratio_db",
 		Help:      "DC-bin power relative to total IQ power, in dB (window ~= 1 s). 0 = all power is DC; -20 or lower = clean. > -10 on a tuned-on-channel control SDR hints at the R820T2 DC-spike failure mode tracked in issue #402.",
+	}, []string{"system"})
+
+	// Fraction of IQ samples whose I or Q component hit the ADC rail over
+	// the same window iq_power_dbfs is computed over (issue #402). The
+	// power gauge is RMS, so a high-crest signal can clip on peaks while
+	// the average still reads merely "hot" (~ -5 dBFS); this gauge is the
+	// authoritative overload signal. 0 = no clipping; a sustained value
+	// above ~0.002 means the front end is overloaded — reduce gain or add
+	// attenuation (raising gain makes it worse).
+	m.iqClipRatio = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: namespace,
+		Subsystem: "sdr",
+		Name:      "iq_clip_ratio",
+		Help:      "Fraction of control-SDR IQ samples pinned to the ADC rail (window ~= 1 s). 0 = no clipping; a sustained value above ~0.002 means front-end overload — reduce gain or add attenuation, do not raise gain (issue #402).",
 	}, []string{"system"})
 
 	m.usbReconnects = prometheus.NewCounterVec(prometheus.CounterOpts{
@@ -190,6 +205,7 @@ func New(bus *events.Bus, pool Snapshotter, version string) (*Metrics, error) {
 		m.iqUnderruns,
 		m.iqPowerDbFS,
 		m.iqDCRatioDb,
+		m.iqClipRatio,
 		m.usbReconnects,
 		m.decodeErrors,
 		m.sdrAttached,
@@ -352,6 +368,26 @@ func (m *Metrics) ClearIQDCRatioDb(system string) {
 		return
 	}
 	m.iqDCRatioDb.DeleteLabelValues(system)
+}
+
+// RecordIQClipRatio sets the rail-clipping-fraction gauge for system.
+// The decoder computes this once per IQ-power window; the metrics package
+// just stores it. See iqClipRatio's Help text for interpretation (issue
+// #402).
+func (m *Metrics) RecordIQClipRatio(system string, ratio float64) {
+	if system == "" {
+		system = "unknown"
+	}
+	m.iqClipRatio.WithLabelValues(system).Set(ratio)
+}
+
+// ClearIQClipRatio drops the clip-ratio gauge series for system. Called
+// alongside ClearIQPowerDbFS when a decoder pipeline tears down.
+func (m *Metrics) ClearIQClipRatio(system string) {
+	if system == "" {
+		return
+	}
+	m.iqClipRatio.DeleteLabelValues(system)
 }
 
 // RecordUSBReconnect increments the reconnect counter for the supplied SDR.

--- a/internal/metrics/prom_test.go
+++ b/internal/metrics/prom_test.go
@@ -204,6 +204,31 @@ func TestRecordIQDCRatioDb(t *testing.T) {
 	}
 }
 
+func TestRecordIQClipRatio(t *testing.T) {
+	m, _ := New(nil, nil, "test")
+	defer m.Close()
+
+	m.RecordIQClipRatio("MMR", 0.0)
+	if got := testutil.ToFloat64(m.iqClipRatio.WithLabelValues("MMR")); got != 0.0 {
+		t.Errorf("iq clip ratio = %v, want 0.0", got)
+	}
+
+	m.RecordIQClipRatio("MMR", 0.25) // front end overloaded
+	if got := testutil.ToFloat64(m.iqClipRatio.WithLabelValues("MMR")); got != 0.25 {
+		t.Errorf("iq clip ratio after update = %v, want 0.25", got)
+	}
+
+	m.ClearIQClipRatio("MMR")
+	if testutil.CollectAndCount(m.iqClipRatio) != 0 {
+		t.Errorf("iq clip ratio series count after clear != 0")
+	}
+
+	m.RecordIQClipRatio("", 0.1)
+	if got := testutil.ToFloat64(m.iqClipRatio.WithLabelValues("unknown")); got != 0.1 {
+		t.Errorf("iq clip ratio unknown = %v, want 0.1", got)
+	}
+}
+
 func TestHandlerScrapeContainsExpectedSeries(t *testing.T) {
 	m, _ := New(nil, nil, "v1.2.3")
 	defer m.Close()

--- a/internal/scanner/ccdecoder/decoder.go
+++ b/internal/scanner/ccdecoder/decoder.go
@@ -68,11 +68,18 @@ import (
 // DC bin dominates the 48 kHz pipeline passband and the C4FM eye
 // collapses. Healthy off-channel signals show ≤ -20 dB; a
 // DC-dominated capture shows within ~5 dB of 0.
+// RecordIQClipRatio reports the per-window fraction of IQ samples with
+// an I or Q component pinned to the ADC rail (0 = none). Sustained
+// non-zero values mean front-end overload/clipping — the average
+// iq_power_dbfs gauge is RMS and hides peak clipping, so this is the
+// authoritative clipping signal behind issue #402.
 type IQPowerObserver interface {
 	RecordIQPowerDbFS(system string, dbfs float64)
 	ClearIQPowerDbFS(system string)
 	RecordIQDCRatioDb(system string, ratioDb float64)
 	ClearIQDCRatioDb(system string)
+	RecordIQClipRatio(system string, ratio float64)
+	ClearIQClipRatio(system string)
 }
 
 // ErrIQStreamClosed is returned by Run whenever the SDR's IQ stream is
@@ -105,6 +112,21 @@ const iqLowPowerThresholdDbFS = -55.0
 // ~5 dB of total channel power) without firing on benign captures
 // of a tone-rich broadcast channel. Issue #402.
 const iqDCRatioWarnDb = -10.0
+
+// iqClipThreshold is the normalized magnitude at or above which an I or
+// Q component is treated as ADC rail-clipping. convertU8IQ maps u8 0 ->
+// -1.0 and u8 255 -> +1.0 (rtlsdr/purego/stream.go convertU8IQ), so the
+// rail samples u8 in {0,1,254,255} land at |x| >= ~0.992; 0.98 catches
+// them without flagging healthy signal peaks. A front end driven into
+// the rail distorts the C4FM eye and fails TSBK CRC continuously even
+// while NID's stronger BCH still locks (issue #402).
+const iqClipThreshold = 0.98
+
+// iqClipWarnRatio is the per-window fraction of clipped samples above
+// which observeIQPowerLocked emits a throttled WARN. A clean front end
+// rarely rails on P25 C4FM, so a sustained fraction at this level means
+// front-end overload — reduce gain or add attenuation (issue #402).
+const iqClipWarnRatio = 0.002
 
 // Tuner is the subset of sdr.Device the decoder uses for retuning.
 // Matches the same interface cchunt + conventional consume so the
@@ -199,10 +221,12 @@ type Decoder struct {
 	pwSumSq      float64
 	pwSumI       float64 // running sum of I samples → DC-bin mean (issue #402)
 	pwSumQ       float64 // running sum of Q samples → DC-bin mean (issue #402)
+	pwClipped    int     // count of rail-clipped samples in the window (issue #402)
 	pwSamples    int
 	pwWindowAt   time.Time
 	pwLowLogAt   time.Time
 	pwDCLogAt    time.Time // throttle for the "DC bin dominant" debug line (issue #402)
+	pwClipLogAt  time.Time // throttle for the "front-end clipping" warn line (issue #402)
 	pwLastSystem string
 
 	// iqCorrector, when non-nil (Options.IQCorrect), blindly removes the
@@ -379,12 +403,14 @@ func (d *Decoder) clearActiveLocked() {
 	if d.activeAt != "" && d.metrics != nil {
 		d.metrics.ClearIQPowerDbFS(d.activeAt)
 		d.metrics.ClearIQDCRatioDb(d.activeAt)
+		d.metrics.ClearIQClipRatio(d.activeAt)
 	}
 	d.activeAt = ""
 	d.activeFreqHz = 0
 	d.pwSumSq = 0
 	d.pwSumI = 0
 	d.pwSumQ = 0
+	d.pwClipped = 0
 	d.pwSamples = 0
 	d.pwLastSystem = ""
 }
@@ -448,6 +474,7 @@ func (d *Decoder) observeIQPowerLocked(iq []complex64) {
 		d.pwSumSq = 0
 		d.pwSumI = 0
 		d.pwSumQ = 0
+		d.pwClipped = 0
 		d.pwSamples = 0
 		d.pwLastSystem = d.activeAt
 	}
@@ -457,6 +484,12 @@ func (d *Decoder) observeIQPowerLocked(iq []complex64) {
 		d.pwSumSq += r*r + i*i
 		d.pwSumI += r
 		d.pwSumQ += i
+		// Count samples pinned to the ADC rail (issue #402): either
+		// component at full scale means the 8-bit RTL ADC clipped, which
+		// the RMS power gauge below averages away.
+		if r >= iqClipThreshold || r <= -iqClipThreshold || i >= iqClipThreshold || i <= -iqClipThreshold {
+			d.pwClipped++
+		}
 	}
 	d.pwSamples += len(iq)
 
@@ -492,14 +525,30 @@ func (d *Decoder) observeIQPowerLocked(iq []complex64) {
 	}
 	dcDbfs := 10 * math.Log10(dcPower)
 	ratioDb := dcDbfs - dbfs
+	// Fraction of samples that hit the ADC rail this window. RMS dbfs can
+	// read merely "hot" (e.g. -5 dBFS) while a high-crest signal still
+	// clips on peaks; this is the signal that distinguishes the two and
+	// the smoking gun for the issue #402 overload failure mode.
+	clipRatio := float64(d.pwClipped) / n
 	if d.activeAt != "" && d.metrics != nil {
 		d.metrics.RecordIQPowerDbFS(d.activeAt, dbfs)
 		d.metrics.RecordIQDCRatioDb(d.activeAt, ratioDb)
+		d.metrics.RecordIQClipRatio(d.activeAt, clipRatio)
 	}
 	if dbfs < iqLowPowerThresholdDbFS && now.Sub(d.pwLowLogAt) >= 5*time.Second {
 		d.log.Debug("ccdecoder: iq power very low — check antenna, gain, USB",
 			"system", d.activeAt, "dbfs", dbfs, "dc_dbfs", dcDbfs, "dc_ratio_db", ratioDb)
 		d.pwLowLogAt = now
+	} else if clipRatio > iqClipWarnRatio && now.Sub(d.pwClipLogAt) >= 30*time.Second {
+		// Front end is pinning the ADC rail — overload/clipping. This
+		// shreds the C4FM eye and fails TSBK CRC continuously even while
+		// the channel stays locked (issue #402). The fix is less RF, not
+		// more: reduce gain or add attenuation/filtering. Warned (not
+		// debug) because it silently defeats decode and the startup
+		// low-gain hint points the wrong way for an overloaded front end.
+		d.log.Warn("ccdecoder: iq clipping — front end overloaded; reduce gain or add attenuation (do NOT raise gain). issue #402",
+			"system", d.activeAt, "clip_ratio", clipRatio, "dbfs", dbfs)
+		d.pwClipLogAt = now
 	} else if ratioDb > iqDCRatioWarnDb && now.Sub(d.pwDCLogAt) >= 30*time.Second {
 		// DC bin within iqDCRatioWarnDb of total — the channel of
 		// interest sits on top of the tuner zero. Logged at debug so
@@ -513,6 +562,7 @@ func (d *Decoder) observeIQPowerLocked(iq []complex64) {
 	d.pwSumSq = 0
 	d.pwSumI = 0
 	d.pwSumQ = 0
+	d.pwClipped = 0
 	d.pwSamples = 0
 	d.pwWindowAt = now
 }

--- a/internal/scanner/ccdecoder/decoder_test.go
+++ b/internal/scanner/ccdecoder/decoder_test.go
@@ -1047,10 +1047,12 @@ func TestMPT1327FactoryAppliesBCHFromSystem(t *testing.T) {
 // tests can assert the decoder's pump-side observation pipeline
 // without depending on the real Prometheus collector.
 type recordingPower struct {
-	sets      []powerSample
-	cleared   []string
-	dcSets    []dcSample
-	dcCleared []string
+	sets        []powerSample
+	cleared     []string
+	dcSets      []dcSample
+	dcCleared   []string
+	clipSets    []clipSample
+	clipCleared []string
 }
 
 type powerSample struct {
@@ -1061,6 +1063,11 @@ type powerSample struct {
 type dcSample struct {
 	system  string
 	ratioDb float64
+}
+
+type clipSample struct {
+	system string
+	ratio  float64
 }
 
 func (r *recordingPower) RecordIQPowerDbFS(system string, dbfs float64) {
@@ -1074,6 +1081,12 @@ func (r *recordingPower) RecordIQDCRatioDb(system string, ratioDb float64) {
 }
 func (r *recordingPower) ClearIQDCRatioDb(system string) {
 	r.dcCleared = append(r.dcCleared, system)
+}
+func (r *recordingPower) RecordIQClipRatio(system string, ratio float64) {
+	r.clipSets = append(r.clipSets, clipSample{system, ratio})
+}
+func (r *recordingPower) ClearIQClipRatio(system string) {
+	r.clipCleared = append(r.clipCleared, system)
 }
 
 // TestPumpRecordsIQPowerOnceWindowElapses feeds a known signal level
@@ -1121,6 +1134,51 @@ func TestPumpRecordsIQPowerOnceWindowElapses(t *testing.T) {
 	// |0.5+0.5i|^2 = 0.5 → 10*log10(0.5) = -3.01 dBFS
 	if got.dbfs < -3.5 || got.dbfs > -2.5 {
 		t.Errorf("dbfs = %v, want roughly -3", got.dbfs)
+	}
+	// A mid-scale chunk is nowhere near the ADC rail → no clipping.
+	if len(pwr.clipSets) != 1 {
+		t.Fatalf("after window, clipSets = %d, want 1", len(pwr.clipSets))
+	}
+	if r := pwr.clipSets[0].ratio; r != 0 {
+		t.Errorf("clip_ratio = %v, want 0 for a mid-scale chunk", r)
+	}
+}
+
+// TestPumpRecordsIQClipRatioWhenRailed feeds a window of rail-pinned
+// samples and asserts the new clip-ratio gauge reports ~1.0 — the
+// front-end overload failure mode behind issue #402 that the RMS
+// iq_power_dbfs gauge averages away.
+func TestPumpRecordsIQClipRatioWhenRailed(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	pwr := &recordingPower{}
+	d, err := New(Options{
+		Bus: bus, IQ: &fakeIQSource{}, SampleRateHz: 48000, Metrics: pwr,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	d.activeAt = "TestSys"
+
+	// Both components at full scale (the ADC rail) on every sample.
+	chunk := make([]complex64, 128)
+	for i := range chunk {
+		chunk[i] = complex(1.0, 1.0)
+	}
+
+	d.pump(chunk) // primes pwWindowAt, no record yet
+	d.pwWindowAt = d.pwWindowAt.Add(-2 * iqPowerWindow)
+	d.pump(chunk)
+
+	if len(pwr.clipSets) != 1 {
+		t.Fatalf("after window, clipSets = %d, want 1", len(pwr.clipSets))
+	}
+	got := pwr.clipSets[0]
+	if got.system != "TestSys" {
+		t.Errorf("system = %q, want TestSys", got.system)
+	}
+	if got.ratio < 0.999 {
+		t.Errorf("clip_ratio = %v, want ~1.0 for a fully-railed window", got.ratio)
 	}
 }
 


### PR DESCRIPTION
Issue #402's control channel locks but fails TSBK CRC continuously while
underruns stay flat and replay is green. The reporter's latest data shows
iq_power_dbfs at -5/-6 dBFS with a clean DC ratio (-48..-53) and only
8.7 dB tuner gain — a hot, strong-signal site (CBD) where the same
hardware decodes a clean site (Mt Anakie) fine. That signature is
front-end overload: a high-crest signal pinning the 8-bit RTL ADC rail
distorts the C4FM eye and shreds TSBK CRC while NID's stronger BCH still
locks once.

The RMS iq_power_dbfs gauge averages peak clipping away, so the operator
had no signal for this, and the startup warnLowGain hint actively pointed
the wrong way (it told them to raise gain, which clips harder).

- ccdecoder: count rail-pinned IQ samples in the existing power window
  (no extra pass), expose iq_clip_ratio, and fire a throttled WARN on
  sustained clipping advising to reduce gain / add attenuation.
- metrics: add the iq_clip_ratio gauge; note on iq_power_dbfs that it is
  RMS and to watch iq_clip_ratio for clipping.
- daemon: warnLowGain now caveats that an overloaded (clipping) front end
  means gain is already too high, not too low.
- tests for the clip-ratio path on both the decoder and metrics sides.

https://claude.ai/code/session_01YcMs6iKdAbMTGPsFkLYmB1