### PR TITLE
p25/cqpsk: add carrier recovery so a real tuner offset stops killing control-channel lock (#492)

### DIFF
--- a/cmd/gophertrunk/replay.go
+++ b/cmd/gophertrunk/replay.go
@@ -279,6 +279,24 @@ FLAGS:`)
 	const stateLogIntervalSec = 1.0
 	var nextStateLogAt float64 = stateLogIntervalSec
 	logReceiverState := func(at float64) {
+		// The CQPSK path shares none of the C4FM receiver state: it uses a
+		// Gardner timing loop (not Mueller-Müller), its own matched-filter
+		// AGC, a CMA equalizer, and a carrier-recovery loop — none of which
+		// the C4FM accessors below report (they all return 0 on CQPSK). Print
+		// a CQPSK-specific line so the diagnostic reflects what the path
+		// actually does, instead of the all-zero Mueller-Müller fields that
+		// misdirected issue #492 toward a phantom timing-loop flat-line.
+		if demodMode == p25phase1rx.DemodCQPSK {
+			fmt.Fprintf(os.Stderr,
+				"replay: receiver state  t=%.2fs  carrier_hz_est=%.3f  gardner_mu=%.4f  gardner_sps=%.2f  agc_gain=%.4g  cma_err=%.4g\n",
+				at,
+				rx.CQPSKCarrierOffsetHz(),
+				rx.GardnerMu(),
+				rx.GardnerSPS(),
+				rx.CQPSKAGCGain(),
+				rx.CMAError())
+			return
+		}
 		// afc_hz_est is the TRUE carrier offset (rx.AFCOffsetHz), which
 		// divides out the matched filter's sps DC-gain. The earlier
 		// AFCBias·Fs/(2π) form over-reported by ≈sps (≈10× at 48 kHz /

--- a/internal/dsp/sync/costas.go
+++ b/internal/dsp/sync/costas.go
@@ -1,0 +1,129 @@
+package sync
+
+import "math"
+
+// QPSKCostas is a non-data-aided carrier-recovery loop for the
+// π/4-DQPSK / QPSK family. It de-rotates a recovered symbol stream to
+// remove a residual carrier-frequency offset — the error a differential
+// decoder cannot fix on its own, because the differential decode cancels
+// a constant carrier *phase* but not a constant per-symbol *rotation*
+// (2π·Δf/baud), which instead spins the whole differential constellation
+// and lands every symbol in the wrong quadrant (issue #492).
+//
+// The error detector is the four-fold-symmetric differential phase: for
+// an ideal π/4-DQPSK symbol the differential product y[n]·conj(y[n−1])
+// sits at one of {±π/4, ±3π/4}, so 4× its angle is ≡ π (mod 2π)
+// regardless of the data and regardless of the π/4 constellation
+// alternation. The wrapped residual of (4·angle − π), scaled back by 4,
+// is the leftover per-symbol carrier rotation — recovered without any
+// symbol decision, so the loop converges before polarity is known and is
+// immune to the alternation that defeats a plain 4th-power-of-symbol
+// estimator on π/4-DQPSK.
+//
+// It is a second-order loop: a proportional path corrects phase quickly
+// and an integrator accumulates the frequency estimate (reported in Hz
+// via OffsetHz). Its unambiguous pull-in is only ±baud/8 (±π/4 per
+// symbol), so a coarse acquisition — e.g. dsp.EstimateCarrierOffsetHz on
+// the matched-filter output — must bring the residual inside that range
+// before this loop is engaged.
+type QPSKCostas struct {
+	baud    float64 // symbol rate (Hz), for the Hz <-> rad/symbol conversion
+	kp, ki  float64 // proportional / integral loop-filter gains
+	freq    float64 // integrator state: estimated offset, rad/symbol
+	phase   float64 // running de-rotation phase, rad
+	maxFreq float64 // clamp on |freq| (rad/symbol) — keeps a noisy start bounded
+	prev    complex64
+	have    bool
+}
+
+// NewQPSKCostas builds a loop tuned to loopBWHz (the loop's noise
+// bandwidth) at the given symbol rate, with the supplied damping
+// (≈0.707 critically). Non-positive baud panics; non-positive loopBWHz
+// or damping fall back to sane defaults. The discrete proportional /
+// integral gains follow the standard second-order PLL design from the
+// normalised loop bandwidth θ = loopBWHz / baudHz.
+func NewQPSKCostas(baudHz, loopBWHz, damping float64) *QPSKCostas {
+	if baudHz <= 0 {
+		panic("qpskcostas: baudHz must be positive")
+	}
+	if loopBWHz <= 0 {
+		loopBWHz = baudHz * 0.0125 // ~1.25% of baud
+	}
+	if damping <= 0 {
+		damping = 0.707
+	}
+	theta := loopBWHz / baudHz
+	denom := 1 + 2*damping*theta + theta*theta
+	kp := 4 * damping * theta / denom
+	ki := 4 * theta * theta / denom
+	return &QPSKCostas{
+		baud:    baudHz,
+		kp:      kp,
+		ki:      ki,
+		maxFreq: math.Pi / 4, // the detector's unambiguous half-range
+	}
+}
+
+// Update consumes one recovered symbol, de-rotates it by the loop's
+// current carrier-phase estimate, advances the loop, and returns the
+// de-rotated symbol. Feed the returned symbols straight to the
+// differential decoder — the carrier rotation has been removed, so the
+// differential phases land back on their nominal {±π/4, ±3π/4} grid.
+func (c *QPSKCostas) Update(y complex64) complex64 {
+	si, co := math.Sincos(-c.phase)
+	rot := complex(float32(co), float32(si))
+	yd := y * rot
+
+	if c.have {
+		// Differential product of consecutive de-rotated symbols. Its
+		// phase is the data phase (±π/4, ±3π/4) plus whatever per-symbol
+		// carrier rotation the loop has not yet removed.
+		pr, pi := real(c.prev), imag(c.prev)
+		yr, yi := real(yd), imag(yd)
+		pdr := yr*pr + yi*pi // Re{yd · conj(prev)}
+		pdi := yi*pr - yr*pi // Im{yd · conj(prev)}
+		ang := math.Atan2(float64(pdi), float64(pdr))
+		// Strip the four-fold data modulation (and the π/4 alternation):
+		// 4·ang ≡ π for any ideal symbol, so the wrapped residual of
+		// (4·ang − π)/4 is the leftover per-symbol carrier rotation,
+		// unambiguous over (−π/4, π/4].
+		e := wrapPi(4*ang-math.Pi) / 4
+		c.freq += c.ki * e
+		if c.freq > c.maxFreq {
+			c.freq = c.maxFreq
+		} else if c.freq < -c.maxFreq {
+			c.freq = -c.maxFreq
+		}
+		c.phase += c.freq + c.kp*e
+	} else {
+		c.phase += c.freq
+	}
+	c.phase = wrapPi(c.phase)
+	c.prev = yd
+	c.have = true
+	return yd
+}
+
+// OffsetHz returns the loop's current estimate of the residual carrier
+// frequency offset in Hz (freq · baud / 2π).
+func (c *QPSKCostas) OffsetHz() float64 { return c.freq * c.baud / (2 * math.Pi) }
+
+// Reset clears the loop so a stream re-sync starts from zero phase and
+// zero frequency estimate.
+func (c *QPSKCostas) Reset() {
+	c.freq = 0
+	c.phase = 0
+	c.prev = 0
+	c.have = false
+}
+
+// wrapPi wraps an angle to (−π, π].
+func wrapPi(a float64) float64 {
+	a = math.Mod(a, 2*math.Pi)
+	if a > math.Pi {
+		a -= 2 * math.Pi
+	} else if a <= -math.Pi {
+		a += 2 * math.Pi
+	}
+	return a
+}

--- a/internal/dsp/sync/costas_test.go
+++ b/internal/dsp/sync/costas_test.go
@@ -1,0 +1,64 @@
+package sync
+
+import (
+	"math"
+	"testing"
+)
+
+// TestQPSKCostasTracksOffset feeds the loop a synthetic π/4-DQPSK symbol
+// stream carrying a known per-symbol carrier rotation (a residual
+// frequency offset) and asserts the loop's OffsetHz converges to it and
+// that the de-rotated symbols land back on the nominal differential grid.
+func TestQPSKCostasTracksOffset(t *testing.T) {
+	const baud = 4800.0
+	// π/4-DQPSK differential phase changes for dibits 0..3.
+	deltas := [4]float64{math.Pi / 4, 3 * math.Pi / 4, -3 * math.Pi / 4, -math.Pi / 4}
+
+	for _, offsetHz := range []float64{0, 120, -300, 500} {
+		// Use the same loop bandwidth the CQPSK path runs at; the frequency
+		// integrator's settling time is ~1/ki symbols, so give it a long
+		// enough run to converge and average the tail.
+		c := NewQPSKCostas(baud, 120, 0.707)
+		// Per-symbol carrier rotation the offset imposes.
+		rot := 2 * math.Pi * offsetHz / baud
+
+		// Build an absolute-phase π/4-DQPSK walk over a pseudo-random dibit
+		// stream, adding the carrier rotation cumulatively.
+		var absPhase, carrier float64
+		seed := uint32(12345)
+		const n = 6000
+		var sum float64
+		var cnt int
+		for i := 0; i < n; i++ {
+			seed = seed*1664525 + 1013904223
+			d := (seed >> 16) & 3
+			absPhase += deltas[d]
+			carrier += rot
+			ph := absPhase + carrier
+			sym := complex(float32(math.Cos(ph)), float32(math.Sin(ph)))
+			c.Update(sym)
+			if i >= n-1000 {
+				sum += c.OffsetHz()
+				cnt++
+			}
+		}
+		got := sum / float64(cnt)
+		if math.Abs(got-offsetHz) > 15 {
+			t.Errorf("offset %.0f Hz: loop converged to %.1f Hz (err %.1f > 15 Hz)",
+				offsetHz, got, got-offsetHz)
+		}
+	}
+}
+
+// TestQPSKCostasReset confirms Reset clears the loop state.
+func TestQPSKCostasReset(t *testing.T) {
+	c := NewQPSKCostas(4800, 60, 0.707)
+	for i := 0; i < 100; i++ {
+		ph := 0.5 * float64(i)
+		c.Update(complex(float32(math.Cos(ph)), float32(math.Sin(ph))))
+	}
+	c.Reset()
+	if c.OffsetHz() != 0 {
+		t.Errorf("after Reset OffsetHz = %v, want 0", c.OffsetHz())
+	}
+}

--- a/internal/dsp/sync/gardner.go
+++ b/internal/dsp/sync/gardner.go
@@ -147,6 +147,17 @@ func (g *Gardner) Process(dst, src []complex64) []complex64 {
 	return dst
 }
 
+// Mu returns the loop's current sub-sample phase accumulator (it counts
+// down from sps toward 0 each input sample and resets by +sps at every
+// emitted symbol). Read-only; exposed for diagnostics so a CQPSK replay
+// can render the timing-loop state the way the C4FM path renders its
+// Mueller-Müller mu (issue #492).
+func (g *Gardner) Mu() float64 { return g.mu }
+
+// SPS returns the loop's nominal samples per symbol. Paired with Mu so a
+// diagnostic can render mu as a fraction of the symbol period.
+func (g *Gardner) SPS() float64 { return g.sps }
+
 // Reset clears the loop state. Call on stream re-tune so the next
 // chunk doesn't carry a stale timing estimate.
 func (g *Gardner) Reset() {

--- a/internal/metrics/prom_test.go
+++ b/internal/metrics/prom_test.go
@@ -92,7 +92,19 @@ func TestCallsActiveTracksStartAndEnd(t *testing.T) {
 	if got := testutil.ToFloat64(active); got != 1 {
 		t.Errorf("active after end = %v, want 1", got)
 	}
-	if got := testutil.ToFloat64(m.callsTotal.WithLabelValues("Alpha", "unknown", "false", "normal")); got != 1 {
+	// callsTotal is incremented on the same CallEnd event that decrements
+	// active, but as a separate operation — so reaching active==1 above does
+	// not guarantee callsTotal has been bumped yet. Poll it the same way
+	// rather than reading once, which raced under the full -race suite.
+	callsTotal := m.callsTotal.WithLabelValues("Alpha", "unknown", "false", "normal")
+	deadline = time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if testutil.ToFloat64(callsTotal) == 1 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if got := testutil.ToFloat64(callsTotal); got != 1 {
 		t.Errorf("calls_total{Alpha,unknown,false,normal} = %v, want 1", got)
 	}
 }

--- a/internal/radio/p25/phase1/receiver/cqpsk.go
+++ b/internal/radio/p25/phase1/receiver/cqpsk.go
@@ -88,6 +88,10 @@ type cqpskDemod struct {
 	agc     *dsp.AGC
 	cma     *equalizer.CMA
 
+	// cmaErr is the CMA's most recent |y|²−R² convergence proxy,
+	// retained for the replay receiver-state diagnostic (issue #492).
+	cmaErr float32
+
 	// Scratch buffers reused across calls.
 	matched []complex64
 	symbols []complex64
@@ -134,8 +138,9 @@ func (c *cqpskDemod) process(iq []complex64) []uint8 {
 	// Blind equalizer: CMA pulls the symbols back to constant modulus,
 	// undoing the simulcast-multipath ISI that closes the constellation.
 	for i, s := range c.symbols {
-		y, _ := c.cma.Process(s)
+		y, e := c.cma.Process(s)
 		c.symbols[i] = y
+		c.cmaErr = e
 	}
 	c.dibits = c.dq.Decode(c.dibits, c.symbols)
 	for i, d := range c.dibits {
@@ -143,6 +148,12 @@ func (c *cqpskDemod) process(iq []complex64) []uint8 {
 	}
 	return c.dibits
 }
+
+// carrierOffsetHz reports the carrier-recovery loop's current estimate
+// of the residual carrier-frequency offset in Hz. Phase A has no carrier
+// recovery on this path, so it reports 0; issue #492 Phase B adds the
+// loop and returns its estimate here.
+func (c *cqpskDemod) carrierOffsetHz() float64 { return 0 }
 
 // reset clears the matched-filter history, the Gardner loop state and
 // the differential reference sample so the next process call starts

--- a/internal/radio/p25/phase1/receiver/cqpsk.go
+++ b/internal/radio/p25/phase1/receiver/cqpsk.go
@@ -64,6 +64,58 @@ const (
 	cqpskAGCMaxGain   = 1e4
 )
 
+// cqpskCarrier* configure the carrier-frequency recovery the CQPSK path
+// gained for issue #492. The differential π/4-DQPSK decoder removes a
+// constant carrier *phase* but not a constant per-symbol *rotation*
+// (2π·Δf/baud) from a residual offset Δf, so a real tuner's offset spins
+// the differential constellation and the Frame Sync Word never
+// correlates. (The C4FM path has CoarseAFC for exactly this; TETRA's
+// π/4-DQPSK tolerates having none only because its 18000-baud rate
+// rotates 3.75× less per symbol than P25's 4800.)
+//
+// cqpskSeedClampHz bounds the one-shot coarse seed; a residual that needs
+// more than this is an un-channelised / mis-tuned stream the upstream DDC
+// + PPM correction should have handled (the channel would not even fit the
+// 48 kHz passband otherwise). cqpskSeedMinSamples is the matched-filter
+// sample count the coarse estimate needs to be usable. cqpskCostasLoopBWHz
+// / cqpskCostasDamping tune the fine tracking loop: ~2.5% of baud gives a
+// few-hundred-symbol acquisition, well inside the control-channel warmup.
+const (
+	cqpskSeedClampHz    = 6000.0
+	cqpskSeedMinSamples = 2048
+	cqpskCostasLoopBWHz = 120.0
+	cqpskCostasDamping  = 0.707
+)
+
+// seedCarrierOffsetHz returns a coarse estimate of the residual carrier
+// offset (Hz) of an oversampled complex stream, via the lag-1
+// autocorrelation (Kay) frequency estimator: the angle of Σ x[n]·conj(x[n−1])
+// is the mean per-sample phase increment, which for a suppressed-carrier
+// symmetric modulation is the carrier rotation (the data's phase changes
+// are symmetric and average out). Unlike peak-picking the PSD, this is
+// unbiased on the flat-topped RRC spectrum of an already-channelised
+// signal, and unambiguous to ±Fs/2 rather than ±baud/8.
+func seedCarrierOffsetHz(x []complex64, fs float64) float64 {
+	if len(x) < 2 || fs <= 0 {
+		return 0
+	}
+	var accR, accI float64
+	for n := 1; n < len(x); n++ {
+		ar, ai := float64(real(x[n])), float64(imag(x[n]))
+		br, bi := float64(real(x[n-1])), float64(imag(x[n-1]))
+		// x[n] · conj(x[n-1])
+		accR += ar*br + ai*bi
+		accI += ai*br - ar*bi
+	}
+	hz := math.Atan2(accI, accR) * fs / (2 * math.Pi)
+	if hz > cqpskSeedClampHz {
+		hz = cqpskSeedClampHz
+	} else if hz < -cqpskSeedClampHz {
+		hz = -cqpskSeedClampHz
+	}
+	return hz
+}
+
 // cqpskDemod is the LSM / linear-CQPSK symbol recovery chain for P25
 // Phase 1. It wraps the shared PiOver4DQPSK primitive at rotation π/4
 // and applies lsmDibitRemap so the dibits it emits are interchangeable
@@ -87,24 +139,32 @@ type cqpskDemod struct {
 	gardner *sync.Gardner
 	agc     *dsp.AGC
 	cma     *equalizer.CMA
+	nco     *dsp.NCO         // removes the coarse carrier seed from the raw IQ
+	costas  *sync.QPSKCostas // fine carrier tracking on the symbol stream
+
+	fs     float64 // IQ sample rate, for the NCO seed and Hz reporting
+	seeded bool    // coarse carrier seed applied
+	seedHz float64 // coarse carrier offset the NCO removes (Hz)
 
 	// cmaErr is the CMA's most recent |y|²−R² convergence proxy,
 	// retained for the replay receiver-state diagnostic (issue #492).
 	cmaErr float32
 
 	// Scratch buffers reused across calls.
+	rotated []complex64 // NCO-de-rotated IQ, fed to the matched filter
 	matched []complex64
 	symbols []complex64
 	dibits  []uint8
 }
 
 // newCQPSKDemod builds a CQPSK / LSM demod for the supplied sample
-// rate and RRC parameters. sps must already be the integer samples-
+// rate and RRC parameters. sampleRateHz is the IQ rate (used by the
+// carrier-recovery NCO); sps must already be the integer samples-
 // per-symbol; span / alpha are the standard P25 RRC parameters
 // (span=8 symbols half-width, α=0.20). gardnerGain ≤ 0 selects
 // defaultGardnerGain, whose value is tuned for this path's 10 sps so the
 // timing loop pulls in from any sub-symbol phase (issue #492).
-func newCQPSKDemod(sps int, span int, alpha float64, gardnerGain float64) *cqpskDemod {
+func newCQPSKDemod(sampleRateHz float64, sps int, span int, alpha float64, gardnerGain float64) *cqpskDemod {
 	if gardnerGain <= 0 {
 		gardnerGain = defaultGardnerGain
 	}
@@ -113,6 +173,9 @@ func newCQPSKDemod(sps int, span int, alpha float64, gardnerGain float64) *cqpsk
 		gardner: sync.NewGardner(float64(sps), gardnerGain),
 		agc:     dsp.NewAGC(cqpskAGCReference, cqpskAGCRate, cqpskAGCMaxGain),
 		cma:     equalizer.NewCMA(cqpskEqualizerTaps, cqpskEqualizerStep, 1.0),
+		nco:     dsp.NewNCO(0, sampleRateHz),
+		costas:  sync.NewQPSKCostas(SymbolRate, cqpskCostasLoopBWHz, cqpskCostasDamping),
+		fs:      sampleRateHz,
 	}
 }
 
@@ -121,7 +184,23 @@ func newCQPSKDemod(sps int, span int, alpha float64, gardnerGain float64) *cqpsk
 // internal buffers carry state across calls so chunk boundaries do
 // not corrupt the stream.
 func (c *cqpskDemod) process(iq []complex64) []uint8 {
-	c.matched = c.dq.MatchedFilter(c.matched, iq)
+	// Carrier recovery, coarse stage: a real tuner's residual offset is
+	// far outside the fine loop's ±baud/8 pull-in, so estimate it once
+	// from the raw IQ and tune it out with the NCO. Estimate on the raw
+	// (pre-matched-filter) stream: the RRC matched filter is a lowpass
+	// centred at DC, so it clips the high sideband of an offset signal and
+	// would bias the estimate toward zero. De-rotating before the matched
+	// filter also presents the filter a centred channel. Until seeded the
+	// NCO is an identity mix, so a centred/zero-offset stream is unaffected;
+	// the fine Costas loop then cleans up the residual and tracks drift.
+	if !c.seeded && len(iq) >= cqpskSeedMinSamples {
+		c.seedHz = seedCarrierOffsetHz(iq, c.fs)
+		c.nco.SetOffset(c.seedHz, c.fs)
+		c.seeded = true
+	}
+	c.rotated = c.nco.Mix(c.rotated, iq)
+	c.matched = c.dq.MatchedFilter(c.matched, c.rotated)
+
 	// AGC: normalise the matched-filter output to the amplitude the
 	// downstream loops are tuned for. The Gardner timing-error detector
 	// and the CMA weight update both use un-normalised, amplitude-
@@ -135,12 +214,15 @@ func (c *cqpskDemod) process(iq []complex64) []uint8 {
 		c.dibits = c.dibits[:0]
 		return c.dibits
 	}
-	// Blind equalizer: CMA pulls the symbols back to constant modulus,
-	// undoing the simulcast-multipath ISI that closes the constellation.
+	// Blind equalizer + fine carrier recovery. CMA pulls the symbols back
+	// to constant modulus, undoing the simulcast-multipath ISI that closes
+	// the constellation; the Costas loop then de-rotates each symbol to
+	// remove the residual per-symbol carrier rotation the coarse seed left
+	// behind, so the differential phases land on their nominal grid.
 	for i, s := range c.symbols {
 		y, e := c.cma.Process(s)
-		c.symbols[i] = y
 		c.cmaErr = e
+		c.symbols[i] = c.costas.Update(y)
 	}
 	c.dibits = c.dq.Decode(c.dibits, c.symbols)
 	for i, d := range c.dibits {
@@ -150,17 +232,20 @@ func (c *cqpskDemod) process(iq []complex64) []uint8 {
 }
 
 // carrierOffsetHz reports the carrier-recovery loop's current estimate
-// of the residual carrier-frequency offset in Hz. Phase A has no carrier
-// recovery on this path, so it reports 0; issue #492 Phase B adds the
-// loop and returns its estimate here.
-func (c *cqpskDemod) carrierOffsetHz() float64 { return 0 }
+// of the residual carrier-frequency offset in Hz: the coarse block seed
+// plus the fine Costas loop's tracked residual.
+func (c *cqpskDemod) carrierOffsetHz() float64 { return c.seedHz + c.costas.OffsetHz() }
 
-// reset clears the matched-filter history, the Gardner loop state and
-// the differential reference sample so the next process call starts
-// from a fresh stream.
+// reset clears the matched-filter history, the Gardner loop state, the
+// carrier-recovery seed/loop and the differential reference sample so the
+// next process call starts from a fresh stream.
 func (c *cqpskDemod) reset() {
 	c.dq.Reset()
 	c.gardner.Reset()
 	c.agc.Reset()
 	c.cma.Reset()
+	c.nco.Reset()
+	c.costas.Reset()
+	c.seeded = false
+	c.seedHz = 0
 }

--- a/internal/radio/p25/phase1/receiver/cqpsk_test.go
+++ b/internal/radio/p25/phase1/receiver/cqpsk_test.go
@@ -33,26 +33,32 @@ func dibitsToLSMIQ(t *testing.T, dibits []uint8, sps, span int, alpha float64) [
 	return demod.ModulatePiOver4DQPSK(pre, sps, span, alpha, math.Pi/4)
 }
 
-// TestCQPSKDemodRoundTripStableTail feeds a long all-zero dibit stream
-// (which under LSM produces a constant-phase carrier) through the
-// modulator → DemodCQPSK demodulator chain and asserts the recovered
-// dibit tail is all zeros after the Gardner loop settles. This is the
-// minimum bar for "the CQPSK path produces canonical TIA-102.BAAA
-// dibits compatible with the FSW + NID + TSBK decoders downstream."
+// TestCQPSKDemodRoundTripIdentity feeds a long pseudo-random dibit stream
+// through the modulator → DemodCQPSK demodulator chain and asserts the
+// recovered dibits match the input, confirming the path produces canonical
+// TIA-102.BAAA dibits compatible with the FSW + NID + TSBK decoders
+// downstream.
 //
-// A round-trip identity test on a random dibit stream would be more
-// general but is over-strict for this demod chain: the Gardner loop
-// on complex IQ converges within ~5 symbols on a clean signal but
-// the matched-filter group delay (~8 symbols) and differential
-// reference sample combine to make exact dibit-by-dibit alignment
-// fragile to construct as a test fixture. The structural guarantee
-// (FSW survives) is covered by TestCQPSKDemodRecoversFSW below.
-func TestCQPSKDemodRoundTripStableTail(t *testing.T) {
+// The fixture uses random (not constant) data on purpose: a constant dibit
+// stream is, under LSM, a single constant-phase-step tone — physically
+// indistinguishable from an unmodulated carrier at +baud/8, which the
+// carrier-recovery stage (issue #492) correctly tunes out. Random data has
+// the broad spectrum symmetric about the carrier that a real (scrambled)
+// control channel does, so the coarse seed reads ~0 and the round trip is a
+// near-identity. The matched-filter group delay and differential reference
+// shift the stream by a fixed amount, so we recover the alignment by a
+// best-match search rather than assuming dibit 0 lines up with sample 0.
+func TestCQPSKDemodRoundTripIdentity(t *testing.T) {
 	const sampleRate = 48_000.0
 	const sps = 10
-	const symbols = 400
+	const symbols = 600
 
+	rng := uint32(0x5eed1234)
 	in := make([]uint8, symbols)
+	for i := range in {
+		rng = rng*1664525 + 1013904223
+		in[i] = uint8((rng >> 16) & 3)
+	}
 	iq := dibitsToLSMIQ(t, in, sps, PulseSpanSymbols, RolloffAlpha)
 
 	var captured []uint8
@@ -71,22 +77,41 @@ func TestCQPSKDemodRoundTripStableTail(t *testing.T) {
 		}
 		r.Process(iq[i:end])
 	}
-
-	if len(captured) < 100 {
-		t.Fatalf("captured %d dibits, want at least 100", len(captured))
+	if len(captured) < symbols/2 {
+		t.Fatalf("captured %d dibits, want at least %d", len(captured), symbols/2)
 	}
-	// Skip the leading 20 dibits — Gardner startup + matched filter
-	// fill — then assert the stable tail is all-zero.
-	tail := captured[20:]
-	nonZero := 0
-	for _, d := range tail {
-		if d != 0 {
-			nonZero++
+
+	// Recover the fixed alignment offset: slide the input over the captured
+	// stream and pick the shift with the most matches over a settled window.
+	const settle = 40 // skip loop-acquisition + matched-filter fill
+	bestShift, bestMatch := 0, -1
+	for shift := 0; shift < 24; shift++ {
+		match, n := 0, 0
+		for i := settle; i < len(in) && i+shift < len(captured); i++ {
+			if in[i] == captured[i+shift] {
+				match++
+			}
+			n++
+		}
+		if n > 0 && match > bestMatch {
+			bestMatch, bestShift = match, shift
 		}
 	}
-	if nonZero > 0 {
-		t.Errorf("post-settle tail has %d/%d non-zero dibits; expected pure zeros under all-zero LSM input",
-			nonZero, len(tail))
+	// Count the match ratio at the recovered alignment.
+	match, total := 0, 0
+	for i := settle; i < len(in) && i+bestShift < len(captured); i++ {
+		if in[i] == captured[i+bestShift] {
+			match++
+		}
+		total++
+	}
+	if total == 0 {
+		t.Fatal("no overlap between input and captured dibits")
+	}
+	ratio := float64(match) / float64(total)
+	if ratio < 0.95 {
+		t.Errorf("round-trip recovered %d/%d dibits (%.1f%%) at shift %d; want >= 95%%",
+			match, total, 100*ratio, bestShift)
 	}
 }
 
@@ -151,6 +176,92 @@ func TestCQPSKDemodRecoversFSW(t *testing.T) {
 	// dependent) count.
 	if locked < 6 {
 		t.Fatalf("CQPSK recovered FSW from only %d/%d starting phases; want >= 6 (issue #492 timing pull-in)", locked, sps)
+	}
+}
+
+// TestCQPSKDemodRecoversFSWWithCarrierOffset is the issue #492 decode-fix
+// guard: it injects a residual carrier-frequency offset (the thing a real
+// tuner carries and that the prior, zero-offset fixtures never modelled)
+// and asserts the path still recovers the FSW. Before the carrier-recovery
+// stage the differential decoder spun the whole constellation by
+// 2π·Δf/baud per symbol and the FSW never correlated at any nonzero
+// offset; the coarse seed + Costas loop must now pull each offset back in.
+//
+// The sweep covers the realistic post-channelisation residual range (a few
+// hundred Hz to a couple kHz, all inside the coarse search half-width) at
+// both signs, and one case with additive noise so a too-tight loop that
+// can only acquire on a perfectly clean fixture is caught.
+func TestCQPSKDemodRecoversFSWWithCarrierOffset(t *testing.T) {
+	const sampleRate = 48_000.0
+	const sps = 10
+
+	// Longer lead-in than the zero-offset test: the carrier loop needs a
+	// few hundred symbols to acquire before the FSW arrives. Use a
+	// pseudo-random dibit stream (a real P25 control channel is scrambled,
+	// so its spectrum is broad and symmetric about the carrier) — a
+	// periodic ramp would put the spectral energy on discrete lines and
+	// defeat the coarse PSD-peak seed, which is a fixture artifact, not a
+	// real-signal property.
+	rng := uint32(0x2c1f00d)
+	nextDibit := func() uint8 {
+		rng = rng*1664525 + 1013904223
+		return uint8((rng >> 16) & 3)
+	}
+	in := make([]uint8, 0)
+	for i := 0; i < 512; i++ {
+		in = append(in, nextDibit())
+	}
+	in = append(in, phase1.FrameSyncWord[:]...)
+	for i := 0; i < 64; i++ {
+		in = append(in, nextDibit())
+	}
+	clean := dibitsToLSMIQ(t, in, sps, PulseSpanSymbols, RolloffAlpha)
+
+	cases := []struct {
+		offsetHz float64
+		snrDB    float64 // 0 = noiseless
+	}{
+		{offsetHz: 200},
+		{offsetHz: -350},
+		{offsetHz: 800},
+		{offsetHz: -1200},
+		{offsetHz: 2000},
+		{offsetHz: -2500},
+		{offsetHz: 1000, snrDB: 18}, // offset + noise
+	}
+
+	for _, tc := range cases {
+		base := demod.ApplyImpairments(clean, sampleRate, demod.Impairments{
+			FreqOffsetHz: tc.offsetHz,
+			SNRdB:        tc.snrDB,
+			Seed:         1,
+		})
+		locked := 0
+		for k := 0; k < sps; k++ {
+			var captured []uint8
+			r := New(Options{
+				SampleRateHz: sampleRate,
+				DemodMode:    DemodCQPSK,
+				DibitSink:    func(d []uint8, _ int) { captured = append(captured, d...) },
+			})
+			shifted := base[k:]
+			const chunk = 4096
+			for i := 0; i < len(shifted); i += chunk {
+				end := i + chunk
+				if end > len(shifted) {
+					end = len(shifted)
+				}
+				r.Process(shifted[i:end])
+			}
+			det := phase1.NewSyncDetector(2)
+			if hits, _ := det.Process(nil, captured, 0); len(hits) > 0 {
+				locked++
+			}
+		}
+		if locked < 6 {
+			t.Errorf("offset=%.0f Hz snr=%.0f dB: recovered FSW from only %d/%d starting phases; want >= 6 (issue #492 carrier recovery)",
+				tc.offsetHz, tc.snrDB, locked, sps)
+		}
 	}
 }
 

--- a/internal/radio/p25/phase1/receiver/receiver.go
+++ b/internal/radio/p25/phase1/receiver/receiver.go
@@ -340,7 +340,7 @@ func New(opts Options) *Receiver {
 	}
 	switch opts.DemodMode {
 	case DemodCQPSK:
-		r.cq = newCQPSKDemod(int(sps+0.5), span, alpha, opts.GardnerGain)
+		r.cq = newCQPSKDemod(opts.SampleRateHz, int(sps+0.5), span, alpha, opts.GardnerGain)
 	default:
 		r.fm = demod.NewFM()
 		// P25 Phase 1 C4FM is not a root-raised-cosine matched-pair

--- a/internal/radio/p25/phase1/receiver/receiver.go
+++ b/internal/radio/p25/phase1/receiver/receiver.go
@@ -730,6 +730,64 @@ func (r *Receiver) MMClockSPS() float64 {
 	return r.clock.SPS()
 }
 
+// GardnerMu returns the CQPSK Gardner timing loop's current sub-sample
+// phase accumulator. It is the CQPSK analogue of MMClockMu (the C4FM
+// path uses Mueller-Müller; CQPSK uses Gardner), so a replay diagnostic
+// can render the actual timing-loop state instead of the all-zero
+// Mueller-Müller fields that misdirected issue #492. Returns 0 on the
+// C4FM path (no Gardner loop).
+func (r *Receiver) GardnerMu() float64 {
+	if r.cq == nil {
+		return 0
+	}
+	return r.cq.gardner.Mu()
+}
+
+// GardnerSPS returns the CQPSK Gardner loop's nominal samples per
+// symbol. Paired with GardnerMu so a diagnostic can render mu as a
+// fraction of the symbol period. Returns 0 on the C4FM path.
+func (r *Receiver) GardnerSPS() float64 {
+	if r.cq == nil {
+		return 0
+	}
+	return r.cq.gardner.SPS()
+}
+
+// CQPSKAGCGain returns the CQPSK path's matched-filter AGC gain (the
+// scale it currently applies to normalise the symbol amplitude the
+// Gardner/CMA loops are tuned against). A gain pinned at 1.0 means the
+// AGC never saw signal energy to seed on. Returns 0 on the C4FM path
+// (which has its own symbol-AGC reported via AGCLevel/AGCTarget).
+func (r *Receiver) CQPSKAGCGain() float64 {
+	if r.cq == nil {
+		return 0
+	}
+	return float64(r.cq.agc.Gain())
+}
+
+// CMAError returns the CQPSK blind equalizer's most recent |y|²−R²
+// convergence proxy. It trends toward 0 as the CMA opens the
+// constellation; a value stuck large means the equalizer has not
+// converged. Returns 0 on the C4FM path (no CMA stage).
+func (r *Receiver) CMAError() float64 {
+	if r.cq == nil {
+		return 0
+	}
+	return float64(r.cq.cmaErr)
+}
+
+// CQPSKCarrierOffsetHz returns the CQPSK carrier-recovery loop's current
+// estimate of the residual carrier-frequency offset in Hz (the coarse
+// block seed plus the tracking loop's residual). A static tuner error of
+// Δf Hz reads back as ≈Δf here once the loop settles. Returns 0 on the
+// C4FM path (which reports its carrier estimate via AFCOffsetHz).
+func (r *Receiver) CQPSKCarrierOffsetHz() float64 {
+	if r.cq == nil {
+		return 0
+	}
+	return r.cq.carrierOffsetHz()
+}
+
 // Reset returns the receiver to its initial state. Call on stream
 // re-sync (control-channel hunt success, IQ underrun recovery) so a
 // stale FSW match doesn't bleed across the discontinuity, and so the


### PR DESCRIPTION
## Summary

Fixes the P25 Phase 1 **CQPSK / LSM** control-channel decode failure in #492. The CQPSK path had **no carrier-frequency recovery at all** — `CoarseAFC` was only ever built on the C4FM path. The π/4-DQPSK differential decoder cancels a constant carrier *phase* but not a constant per-symbol *rotation* (`2π·Δf/baud`), so a real tuner offset spins the whole differential constellation, `lsmDibitRemap` maps every symbol into the wrong quadrant, the dibit histogram skews, and the Frame Sync Word never correlates — exactly the reporter's diag. At P25's 4800 baud even a few-hundred-Hz offset is tens of degrees per symbol; the C4FM path survives via `CoarseAFC` and TETRA's π/4-DQPSK tolerates having none only because its 18000 baud rotates 3.75× less per symbol. The synthetic fixtures injected zero offset, so this stayed invisible behind green tests — which is why the earlier Gardner-gain tuning (#493) never moved the needle on real captures.

## Changes

**Diagnostics (first commit) — lands independently so the reporter can collect a meaningful diag**
- `sync.Gardner` gains read-only `Mu()` / `SPS()` accessors (the C4FM Mueller-Müller loop already had these).
- `Receiver` gains `GardnerMu` / `GardnerSPS` / `CQPSKAGCGain` / `CMAError` / `CQPSKCarrierOffsetHz`.
- `replay -diag` now prints a **CQPSK-specific** receiver-state line (`carrier_hz_est / gardner_mu / gardner_sps / agc_gain / cma_err`) instead of the all-zero C4FM accessors (`mm_*`, `afc_*`, `slicer_*`) that misdirected the diagnosis toward a non-existent Mueller-Müller flat-line. The C4FM line is unchanged.

**Carrier recovery (second commit)**
- **Coarse**: a one-shot lag-1 autocorrelation (Kay) estimate on the **raw IQ** — `angle(Σ x[n]·conj(x[n-1]))·Fs/2π`. For a suppressed-carrier symmetric modulation that mean per-sample phase increment is the carrier rotation (the data's phase steps are symmetric and average out). It runs on the raw stream, not the matched-filter output: the RRC matched filter is a DC-centred lowpass that clips an offset signal's high sideband and would bias the estimate toward zero. The NCO de-rotates the raw IQ, so the matched filter also sees a centred channel.
- **Fine**: new `sync.QPSKCostas`, a second-order decision-free loop. Its error is the four-fold-symmetric differential phase (`4·angle ≡ π` for any ideal π/4-DQPSK symbol, regardless of data or the π/4 alternation), so it needs no symbol decisions and is immune to the alternation a plain 4th-power-of-symbol detector trips on. It de-rotates each symbol and tracks slow drift; its integrator is the reported residual estimate.
- `defaultGardnerGain` stays `0.005`: the real cause was carrier recovery, not timing, so the timing math from #493 is left intact.

> **Note vs. the plan:** the seed does **not** use `dsp.EstimateCarrierOffsetHz`. Peak-picking a flat-topped, already-channelised RRC spectrum lands anywhere in the passband (erratic small-offset failures in testing); the lag-1 estimator is unbiased on that spectrum and unambiguous to ±Fs/2.

## Tests
- `TestCQPSKDemodRecoversFSWWithCarrierOffset` sweeps **±200…±2500 Hz** plus an 18 dB-SNR case and requires the FSW to survive at a strong majority of starting phases. It reproduces #492 (every nonzero offset decoded nothing before this) and guards the fix.
- `TestQPSKCostasTracksOffset` / `TestQPSKCostasReset` cover the loop in isolation.
- The round-trip identity test now uses pseudo-random data (a constant stream is, under LSM, a single tone the carrier recovery correctly tunes out — a fixture artifact, not a real-signal property) and checks recovery by best-match alignment.
- Full regression green: complete `p25/phase1/receiver` suite (incl. C4FM), `dsp/sync`, `dsp/equalizer`, `ccdecoder`, plus `go build ./...` and `go vet`.

## Verification still owed
The only true end-to-end confirmation is a real capture. Asking the reporter to re-run `gophertrunk replay -demod cqpsk -diag` on their `.cfile` and confirm `carrier_hz_est` converges, the histogram approaches ~25%/bin, and FSW hits climb.

Closes #492 pending that confirmation.

https://claude.ai/code/session_01WpictPD5YAE9mTJgAWKdh4

---
_Generated by [Claude Code](https://claude.ai/code/session_01WpictPD5YAE9mTJgAWKdh4)_