### PR TITLE
fix(p25p1): correct LDU voice-frame interleaving offsets (#489)

### DIFF
--- a/internal/radio/p25/phase1/ldu.go
+++ b/internal/radio/p25/phase1/ldu.go
@@ -119,31 +119,41 @@ const _ = uintptr(LDUTotalBits - (LDUFrameSyncBits + LDUNIDBits +
 var ErrLDULength = errors.New("p25/phase1: LDU input must be exactly 1728 bits (one bit per byte, 0/1)")
 
 // LDU payload-bit offsets for each field inside the 1680-bit
-// post-status-strip payload. Source: TIA-102.BAAA-A § 8
-// (Logical Link Data Unit 1 / 2 voice-frame layout). The 9 IMBE
-// voice subframes are interleaved with 6 × 40-bit LC (LDU1) or
-// ES (LDU2) blocks and 2 × 16-bit LSD blocks per the table:
+// post-status-strip payload.
+//
+// Field interleaving order is sourced from dsd-neo's
+// p25p1_ldu1.c collect_voice_and_data(): a Link Control (LDU1) /
+// Encryption Sync (LDU2) block is interposed *between every* voice
+// subframe from u_0 through u_6, then both 16-bit Low-Speed Data
+// blocks sit together between u_6 and u_7, and u_7 / u_8 are
+// adjacent at the tail:
+//
+//	u_0, LC1, u_1, LC2, u_2, LC3, u_3, LC4, u_4, LC5,
+//	u_5, LC6, u_6, LSD1, LSD2, u_7, u_8
+//
+// The 9 IMBE voice subframes are 144 bits each, the 6 LC/ES blocks
+// 40 bits each (240 total), and the 2 LSD blocks 16 bits each:
 //
 //	Field                   Length   Cumulative
 //	Frame Sync (FS)             48       48
 //	Network ID (NID)            64      112
 //	Voice Frame 1 (u_0)        144      256
-//	Voice Frame 2 (u_1)        144      400
-//	LC / ES Block 1             40      440
-//	Voice Frame 3 (u_2)        144      584
-//	LC / ES Block 2             40      624
-//	Voice Frame 4 (u_3)        144      768
-//	LC / ES Block 3             40      808
-//	Voice Frame 5 (u_4)        144      952
-//	LC / ES Block 4             40      992
-//	Voice Frame 6 (u_5)        144     1136
-//	LC / ES Block 5             40     1176
-//	Voice Frame 7 (u_6)        144     1320
-//	LC / ES Block 6             40     1360
-//	Voice Frame 8 (u_7)        144     1504
-//	LSD Block 1                 16     1520
-//	Voice Frame 9 (u_8)        144     1664
-//	LSD Block 2                 16     1680
+//	LC / ES Block 1             40      296
+//	Voice Frame 2 (u_1)        144      440
+//	LC / ES Block 2             40      480
+//	Voice Frame 3 (u_2)        144      624
+//	LC / ES Block 3             40      664
+//	Voice Frame 4 (u_3)        144      808
+//	LC / ES Block 4             40      848
+//	Voice Frame 5 (u_4)        144      992
+//	LC / ES Block 5             40     1032
+//	Voice Frame 6 (u_5)        144     1176
+//	LC / ES Block 6             40     1216
+//	Voice Frame 7 (u_6)        144     1360
+//	LSD Block 1                 16     1376
+//	LSD Block 2                 16     1392
+//	Voice Frame 8 (u_7)        144     1536
+//	Voice Frame 9 (u_8)        144     1680
 //
 // (LDU1 carries Link Control bits in the LC/ES slots; LDU2
 // carries Encryption Sync bits at the identical positions.)
@@ -158,33 +168,33 @@ var (
 	// subframe is LDUVoiceSubframeBits = 144 bits long.
 	lduVoiceOffsets = [LDUVoiceSubframeCount]int{
 		112,  // u_0 → ends at 256
-		256,  // u_1 → ends at 400
-		440,  // u_2 → ends at 584  (post LC/ES Block 1)
-		624,  // u_3 → ends at 768  (post LC/ES Block 2)
-		808,  // u_4 → ends at 952  (post LC/ES Block 3)
-		992,  // u_5 → ends at 1136 (post LC/ES Block 4)
-		1176, // u_6 → ends at 1320 (post LC/ES Block 5)
-		1360, // u_7 → ends at 1504 (post LC/ES Block 6)
-		1520, // u_8 → ends at 1664 (post LSD Block 1)
+		296,  // u_1 → ends at 440  (post LC/ES Block 1)
+		480,  // u_2 → ends at 624  (post LC/ES Block 2)
+		664,  // u_3 → ends at 808  (post LC/ES Block 3)
+		848,  // u_4 → ends at 992  (post LC/ES Block 4)
+		1032, // u_5 → ends at 1176 (post LC/ES Block 5)
+		1216, // u_6 → ends at 1360 (post LC/ES Block 6)
+		1392, // u_7 → ends at 1536 (post LSD Blocks 1 & 2)
+		1536, // u_8 → ends at 1680
 	}
 
 	// lduLCESBlockOffsets[j] is the bit offset of LC/ES block j
 	// (0 ≤ j < 6) inside the 1680-bit payload. Each block is
 	// 40 bits = 4 × Hamming(10,6,3) short codewords.
 	lduLCESBlockOffsets = [6]int{
-		400,  // Block 1
-		584,  // Block 2 (post u_2)
-		768,  // Block 3 (post u_3)
-		952,  // Block 4 (post u_4)
-		1136, // Block 5 (post u_5)
-		1320, // Block 6 (post u_6)
+		256,  // Block 1 (post u_0)
+		440,  // Block 2 (post u_1)
+		624,  // Block 3 (post u_2)
+		808,  // Block 4 (post u_3)
+		992,  // Block 5 (post u_4)
+		1176, // Block 6 (post u_5)
 	}
 
 	// lduLSDBlockOffsets[k] is the bit offset of LSD block k
 	// (0 ≤ k < 2). Each block is 16 bits = 1 cyclic codeword.
 	lduLSDBlockOffsets = [2]int{
-		1504, // Block 1 (post u_7)
-		1664, // Block 2 (post u_8)
+		1360, // Block 1 (post u_6)
+		1376, // Block 2 (contiguous with Block 1, before u_7)
 	}
 )
 

--- a/internal/radio/p25/phase1/ldu_e2e_test.go
+++ b/internal/radio/p25/phase1/ldu_e2e_test.go
@@ -174,5 +174,5 @@ func TestLDUEndToEndIntoRecorder(t *testing.T) {
 // package and the internal table is unexported. Keep in sync
 // with ldu.go's lduVoiceOffsets.
 func lduVoiceOffsetForTest(i int) int {
-	return []int{112, 256, 440, 624, 808, 992, 1176, 1360, 1520}[i]
+	return []int{112, 296, 480, 664, 848, 1032, 1216, 1392, 1536}[i]
 }

--- a/internal/radio/p25/phase1/ldu_test.go
+++ b/internal/radio/p25/phase1/ldu_test.go
@@ -250,6 +250,61 @@ func TestLDUFieldsCoverPayloadWithoutOverlap(t *testing.T) {
 	}
 }
 
+// TestLDUVoiceLayoutMatchesDSDOrder pins the exact field
+// *interleaving sequence* inside the 1680-bit payload. The
+// coverage test above only proves the offsets tile the payload
+// with no gaps/overlaps — but many tilings do that, including the
+// pre-issue-#489 one that placed u_0 and u_1 back-to-back and
+// caused ~100% uncorrectable LDUs. This test walks the payload
+// from the end of the NID and asserts the order matches dsd-neo's
+// p25p1_ldu1.c collect_voice_and_data():
+//
+//	u_0, LC1, u_1, LC2, u_2, LC3, u_3, LC4, u_4, LC5,
+//	u_5, LC6, u_6, LSD1, LSD2, u_7, u_8
+//
+// A change that reverts to a different interleaving (or shifts a
+// single field) fails here, forcing it to be deliberate.
+func TestLDUVoiceLayoutMatchesDSDOrder(t *testing.T) {
+	type field struct {
+		name string
+		off  int
+		ln   int
+	}
+	// The expected sequence with each field's width, in order.
+	want := []field{
+		{"u_0", lduVoiceOffsets[0], LDUVoiceSubframeBits},
+		{"LC1", lduLCESBlockOffsets[0], LDULCESBlockBits},
+		{"u_1", lduVoiceOffsets[1], LDUVoiceSubframeBits},
+		{"LC2", lduLCESBlockOffsets[1], LDULCESBlockBits},
+		{"u_2", lduVoiceOffsets[2], LDUVoiceSubframeBits},
+		{"LC3", lduLCESBlockOffsets[2], LDULCESBlockBits},
+		{"u_3", lduVoiceOffsets[3], LDUVoiceSubframeBits},
+		{"LC4", lduLCESBlockOffsets[3], LDULCESBlockBits},
+		{"u_4", lduVoiceOffsets[4], LDUVoiceSubframeBits},
+		{"LC5", lduLCESBlockOffsets[4], LDULCESBlockBits},
+		{"u_5", lduVoiceOffsets[5], LDUVoiceSubframeBits},
+		{"LC6", lduLCESBlockOffsets[5], LDULCESBlockBits},
+		{"u_6", lduVoiceOffsets[6], LDUVoiceSubframeBits},
+		{"LSD1", lduLSDBlockOffsets[0], LDULSDBlockBits},
+		{"LSD2", lduLSDBlockOffsets[1], LDULSDBlockBits},
+		{"u_7", lduVoiceOffsets[7], LDUVoiceSubframeBits},
+		{"u_8", lduVoiceOffsets[8], LDUVoiceSubframeBits},
+	}
+
+	// The sequence must begin right after FS+NID and run
+	// contiguously to the end of the payload.
+	pos := lduNIDOffset + LDUNIDBits // 112
+	for _, f := range want {
+		if f.off != pos {
+			t.Errorf("%s at offset %d, want %d (field order/interleave wrong)", f.name, f.off, pos)
+		}
+		pos += f.ln
+	}
+	if pos != LDUPayloadBits {
+		t.Errorf("fields end at %d, want %d (LDUPayloadBits)", pos, LDUPayloadBits)
+	}
+}
+
 // TestExtractVoiceFramesRoundTrip: build a synthetic LDU by
 // encoding 9 distinct IMBE info-bit patterns through
 // EncodeFrameToChannel (per-vector FEC + §7.4 scramble + §7.5


### PR DESCRIPTION
P25 Phase 1 voice decode stayed ~100% uncorrectable even after the
§7.5 IMBE deinterleaver was added, because the LDU voice-frame slice
offsets were wrong. The on-air LDU interleaves a Link Control / ES
block between every voice subframe (u_0..u_6), with both Low-Speed
Data blocks between u_6 and u_7 and u_7/u_8 adjacent at the tail
(per dsd-neo p25p1_ldu1.c collect_voice_and_data). The previous table
placed u_0 and u_1 back-to-back and only began interleaving LC after
u_1, so only u_0 (offset 112) was sliced correctly — u_1..u_8 landed
on the wrong bits and failed FEC deterministically.

Correct lduVoiceOffsets / lduLCESBlockOffsets / lduLSDBlockOffsets to
the real interleaving (this also fixes LC/ES and LSD extraction), and
add TestLDUVoiceLayoutMatchesDSDOrder to pin the field sequence — the
existing coverage test only checks the offsets tile the payload, which
any valid (including the wrong) tiling satisfies.

https://claude.ai/code/session_01GYwwcfP5gSrbnNmo2SCj1o