### PR TITLE
dmr: decode spectrum-inverted (I/Q-reversed) bursts on R828D / V4

### DIFF
--- a/cmd/gophertrunk/integration_cc_dmr_test.go
+++ b/cmd/gophertrunk/integration_cc_dmr_test.go
@@ -139,6 +139,101 @@ WaitLoop:
 	}
 }
 
+// TestDaemonCCDecodesDMRTier3SpectrumInverted is the issue #264
+// regression: an RTL-SDR Blog V4 (R828D) that presents conjugated /
+// spectrum-inverted IQ — "are I and Q reversed?" — must still decode
+// DMR. We replay the exact same synthesized Tier III burst as
+// TestDaemonCCDecodesDMRTier3 but conjugate the IQ (negate Q) before
+// handing it to the mock SDR. Conjugation negates the FM-discriminator
+// output, flipping every symbol (+3↔-3, +1↔-1) — the dibit-domain
+// `+2 mod 4` polarity flip the dual-polarity burst decode recovers.
+// Without the fix the slot-type Hamming decode lands on an
+// ever-changing color code and the daemon never locks.
+func TestDaemonCCDecodesDMRTier3SpectrumInverted(t *testing.T) {
+	const (
+		controlFreqHz = 460_000_000
+		sampleRateHz  = 48_000
+		sps           = 10
+		span          = 8
+		alpha         = 0.20
+		deviationHz   = 1944.0
+		colorCode     = 0xA
+		systemID      = 0x1234
+		burstRepeats  = 80
+	)
+
+	dibits := buildDMRTier3CSBKDibits(burstRepeats, colorCode, systemID)
+	iq := demod.ModulateC4FM(dibits, sps, span, alpha, sampleRateHz, deviationHz)
+	// Simulate the R828D's reversed I/Q: conjugate every sample.
+	for i := range iq {
+		iq[i] = complex(real(iq[i]), -imag(iq[i]))
+	}
+
+	dir := t.TempDir()
+	iqPath := filepath.Join(dir, "dmr-cc-inverted.cfile")
+	if err := writeIQToU8File(iqPath, iq); err != nil {
+		t.Fatalf("write IQ: %v", err)
+	}
+	sdr.Register(&sdr.MockDriver{Files: []string{iqPath}})
+
+	cfg := config.Default()
+	cfg.SDR.SampleRate = sampleRateHz
+	cfg.SDR.Devices = []config.DeviceConfig{
+		{Serial: "mock-00", Role: "control"},
+	}
+	cfg.Trunking.Systems = []config.SystemConfig{
+		{Name: "DMRSite", Protocol: "dmr", ControlChannels: []uint32{controlFreqHz}},
+	}
+	cfg.API.HTTPAddr = freeAddr(t)
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	d, err := NewDaemon(cfg, "integration-cc-dmr-inverted", logger)
+	if err != nil {
+		t.Fatalf("NewDaemon: %v", err)
+	}
+
+	sub := d.Bus().Subscribe()
+	defer sub.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	runErrCh := make(chan error, 1)
+	go func() { runErrCh <- d.Run(ctx) }()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case <-runErrCh:
+		case <-time.After(3 * time.Second):
+		}
+	})
+
+	base := "http://" + cfg.API.HTTPAddr
+	waitReachable(t, base+"/api/v1/health", 3*time.Second)
+
+	deadline := time.After(5 * time.Second)
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind != events.KindCCLocked {
+				continue
+			}
+			ls, ok := ev.Payload.(tier3.LockState)
+			if !ok {
+				t.Errorf("CCLocked payload type = %T, want tier3.LockState", ev.Payload)
+				continue
+			}
+			if ls.SystemID != systemID {
+				t.Errorf("LockState.SystemID = %#x, want %#x", ls.SystemID, systemID)
+			}
+			if ls.ColorCode != colorCode {
+				t.Errorf("LockState.ColorCode = %d, want %d", ls.ColorCode, colorCode)
+			}
+			return
+		case <-deadline:
+			t.Fatalf("no cc.locked event arrived within 5s on spectrum-inverted IQ")
+		}
+	}
+}
+
 // buildDMRTier3CSBKDibits assembles a DMR Tier III dibit stream
 // for the C4FM modulator + receiver chain:
 //

--- a/internal/radio/dmr/burst.go
+++ b/internal/radio/dmr/burst.go
@@ -32,6 +32,39 @@ type Burst struct {
 	Dibits [BurstDibits]uint8
 }
 
+// PolarityFlip is the dibit rotation a spectrum-inverted / I-Q-swapped
+// front-end imprints on a C4FM stream (issue #264, the RTL-SDR Blog V4
+// / R828D path). Conjugated IQ negates the FM-discriminator output, so
+// the slicer maps +3↔-3 and +1↔-1, which in dibit space is exactly
+// (dibit + 2) mod 4. The flip is its own inverse (2 + 2 ≡ 0 mod 4), so
+// the same value both models the corruption and undoes it.
+const PolarityFlip uint8 = 2
+
+// CandidatePolarities are the two discriminator polarities a DMR burst
+// can present after C4FM demod: identity (0) and the polarity flip (2).
+// DMR's 9 sync words are closed under the flip — an inverted data sync
+// is byte-identical to a clean voice sync — so the sync match alone
+// cannot resolve the polarity. The Tier II / III Process adapters hand
+// IngestBurst a candidate at each polarity; the slot-type Hamming(20,8)
+// + BPTC(196,96) + CSBK CRC there is the arbiter, dropping the wrong
+// one with no state change. Identity is first so clean R820T2 streams
+// take the same path they always have.
+var CandidatePolarities = [...]uint8{0, PolarityFlip}
+
+// RotateBurstDibits rotates every dibit of the burst in place by k
+// (mod 4): b.Dibits[i] = (b.Dibits[i] + k) & 3. Applied with
+// PolarityFlip it both simulates and undoes a spectrum-inverted
+// front-end (the rotation is self-inverse), recovering the canonical
+// slot-type, BPTC payload, and voice dibits. k=0 short-circuits.
+func RotateBurstDibits(b *Burst, k uint8) {
+	if k == 0 {
+		return
+	}
+	for i := range b.Dibits {
+		b.Dibits[i] = (b.Dibits[i] + k) & 3
+	}
+}
+
 // FirstHalf returns the 49 dibits of the first payload half.
 func (b *Burst) FirstHalf() []uint8 { return b.Dibits[0:HalfPayloadDibits] }
 

--- a/internal/radio/dmr/sync.go
+++ b/internal/radio/dmr/sync.go
@@ -55,6 +55,15 @@ func mkSync(name string, hex uint64) SyncPattern {
 
 // SyncDetector slides a 24-dibit window over a stream and emits matches
 // against any of the supplied patterns within the configured tolerance.
+//
+// Note on spectral inversion / I-Q swap (issue #264): the 9 DMR sync
+// words are closed under the discriminator-polarity flip (every dibit
+// + 2 mod 4, i.e. XOR 0xAAAA…) — an inverted data sync is byte-
+// identical to a clean voice sync and vice versa. So this detector
+// already fires on a spectrum-inverted stream (it just reports the
+// flipped twin pattern); the polarity is resolved downstream by
+// decoding the burst at both polarities — see the Tier II / III
+// Process adapters and dmr.RotateBurstDibits.
 type SyncDetector struct {
 	patterns  []SyncPattern
 	tolerance int

--- a/internal/radio/dmr/sync_test.go
+++ b/internal/radio/dmr/sync_test.go
@@ -37,6 +37,62 @@ func TestSyncDetectorMatchesCleanSync(t *testing.T) {
 	}
 }
 
+// TestSyncPairsClosedUnderPolarityFlip documents the property the issue
+// #264 fix relies on: applying the discriminator-polarity flip (every
+// dibit + 2 mod 4) to a downlink voice/data sync word yields its
+// data/voice twin. This is why a spectrum-inverted stream still
+// produces sync hits (so the detector needs no change) AND why the
+// sync match alone can't resolve the polarity (so the burst is decoded
+// at both polarities downstream). MS-RC (the mobile reverse-channel
+// sync) is the lone pattern with no twin and is not used on the
+// downlink control channel.
+func TestSyncPairsClosedUnderPolarityFlip(t *testing.T) {
+	pairs := [][2]SyncPattern{
+		{BSVoice, BSData},
+		{MSVoice, MSData},
+		{DMVoice1, DMData1},
+		{DMVoice2, DMData2},
+	}
+	for _, pr := range pairs {
+		var flipped [24]uint8
+		for i, d := range pr[0].Dibits {
+			flipped[i] = (d + PolarityFlip) & 3
+		}
+		if flipped != pr[1].Dibits {
+			t.Errorf("%s flipped != %s", pr[0].Name, pr[1].Name)
+		}
+		// The flip is symmetric: flipping the twin recovers the first.
+		for i, d := range pr[1].Dibits {
+			flipped[i] = (d + PolarityFlip) & 3
+		}
+		if flipped != pr[0].Dibits {
+			t.Errorf("%s flipped != %s", pr[1].Name, pr[0].Name)
+		}
+	}
+}
+
+// TestRotateBurstDibits pins the de-rotation helper: the polarity flip
+// is self-inverse (applying it twice round-trips), and k=0 is a no-op.
+func TestRotateBurstDibits(t *testing.T) {
+	var orig Burst
+	for i := range orig.Dibits {
+		orig.Dibits[i] = uint8(i) & 3
+	}
+	// Flip then recover.
+	flipped := orig
+	RotateBurstDibits(&flipped, PolarityFlip)
+	RotateBurstDibits(&flipped, PolarityFlip)
+	if flipped.Dibits != orig.Dibits {
+		t.Errorf("double polarity-flip did not round-trip")
+	}
+	// Rotation 0 is a no-op.
+	noop := orig
+	RotateBurstDibits(&noop, 0)
+	if noop.Dibits != orig.Dibits {
+		t.Errorf("rotate-0 mutated the burst")
+	}
+}
+
 func TestSyncDetectorTolerates2Errors(t *testing.T) {
 	det := NewSyncDetector(nil, 2) // all patterns
 	stream := make([]uint8, 50)

--- a/internal/radio/dmr/tier2/process.go
+++ b/internal/radio/dmr/tier2/process.go
@@ -76,14 +76,22 @@ func (c *ConventionalChannel) Process(dibits []uint8, baseIdx int) int {
 			continue
 		}
 		offset := burstStart - p.bufStart
-		var b dmr.Burst
-		copy(b.Dibits[:], p.buf[offset:offset+dmr.BurstDibits])
+		// Decode the burst at both discriminator polarities to recover
+		// spectrum-inverted reception (issue #264, RTL-SDR Blog V4 /
+		// R828D); IngestBurst's FEC drops the wrong polarity with no
+		// state change. Identity (k=0) is tried first. Same as the Tier
+		// III adapter.
+		for _, k := range dmr.CandidatePolarities {
+			var b dmr.Burst
+			copy(b.Dibits[:], p.buf[offset:offset+dmr.BurstDibits])
+			dmr.RotateBurstDibits(&b, k)
 
-		slot, _, err := dmr.ParseSlotType(b.SlotTypeBitsAll())
-		if err != nil {
-			continue
+			slot, _, err := dmr.ParseSlotType(b.SlotTypeBitsAll())
+			if err != nil {
+				continue
+			}
+			c.IngestBurst(&b, slot)
 		}
-		c.IngestBurst(&b, slot)
 	}
 	p.pending = keep
 

--- a/internal/radio/dmr/tier2/process_test.go
+++ b/internal/radio/dmr/tier2/process_test.go
@@ -70,6 +70,65 @@ DrainLoop:
 
 // buildVoiceLCHeaderBurstDibits builds a 132-dibit Voice LC Header
 // burst for the Tier II Process adapter.
+// TestProcess_DecodesPolarityFlippedVoiceLCHeader is the issue #264
+// regression for Tier II: a spectrum-inverted (I/Q-reversed) front-end
+// rotates every dibit by +2 mod 4. The adapter's dual-polarity decode
+// must still recover the Voice LC Header and publish lock + grant.
+func TestProcess_DecodesPolarityFlippedVoiceLCHeader(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{
+		Bus:         bus,
+		Log:         slog.Default(),
+		SystemName:  "TestRepeater",
+		FrequencyHz: 460_500_000,
+	})
+
+	dibits := buildVoiceLCHeaderBurstDibits(0x7, 0x123, 0x456789)
+	stream := make([]uint8, 0, 50+len(dibits)+50)
+	for i := 0; i < 50; i++ {
+		stream = append(stream, uint8(i&3))
+	}
+	stream = append(stream, dibits...)
+	for i := 0; i < 50; i++ {
+		stream = append(stream, uint8(i&3))
+	}
+	// Spectrum inversion: every dibit + 2 mod 4.
+	for i := range stream {
+		stream[i] = (stream[i] + dmr.PolarityFlip) & 3
+	}
+	cc.Process(stream, 0)
+
+	var sawLock, sawGrant bool
+	deadline := time.After(300 * time.Millisecond)
+DrainLoop:
+	for {
+		select {
+		case ev := <-sub.C:
+			switch ev.Kind {
+			case events.KindCCLocked:
+				sawLock = true
+			case events.KindGrant:
+				sawGrant = true
+			}
+			if sawLock && sawGrant {
+				break DrainLoop
+			}
+		case <-deadline:
+			break DrainLoop
+		}
+	}
+	if !sawLock {
+		t.Errorf("no KindCCLocked event observed on polarity-flipped stream")
+	}
+	if !sawGrant {
+		t.Errorf("no KindGrant event observed on polarity-flipped stream")
+	}
+}
+
 func buildVoiceLCHeaderBurstDibits(colorCode uint8, groupID, sourceID uint32) []uint8 {
 	flc := dmr.FLC{
 		FLCO:    dmr.FLCOGroupVoiceUser,

--- a/internal/radio/dmr/tier3/process.go
+++ b/internal/radio/dmr/tier3/process.go
@@ -94,19 +94,29 @@ func (c *ControlChannel) Process(dibits []uint8, baseIdx int) int {
 			continue
 		}
 		offset := burstStart - p.bufStart
-		var b dmr.Burst
-		copy(b.Dibits[:], p.buf[offset:offset+dmr.BurstDibits])
+		// Decode the burst at both discriminator polarities. DMR's sync
+		// alphabet is closed under the spectrum-inversion flip (issue
+		// #264, RTL-SDR Blog V4 / R828D), so the sync match can't tell a
+		// clean burst from an inverted one — we hand IngestBurst a
+		// candidate at each polarity and let its slot-type Hamming(20,8)
+		// + BPTC + CSBK CRC pick the real one (the wrong polarity is
+		// dropped with no state change). Identity (k=0) is tried first
+		// so clean R820T2 streams behave exactly as before.
+		for _, k := range dmr.CandidatePolarities {
+			var b dmr.Burst
+			copy(b.Dibits[:], p.buf[offset:offset+dmr.BurstDibits])
+			dmr.RotateBurstDibits(&b, k)
 
-		// Decode slot type (Hamming(20,8) over the 20 bits of the
-		// slot-type field surrounding the sync). ParseSlotType
-		// returns the slot type + error count; we accept partially-
-		// corrected slot types (positive errs) but drop hard
-		// failures (slot.DataType won't match DTCSBK anyway).
-		slot, _, err := dmr.ParseSlotType(b.SlotTypeBitsAll())
-		if err != nil {
-			continue
+			// ParseSlotType returns the slot type + error count; we
+			// accept partially-corrected slot types (positive errs) but
+			// drop hard failures (slot.DataType won't match DTCSBK
+			// anyway).
+			slot, _, err := dmr.ParseSlotType(b.SlotTypeBitsAll())
+			if err != nil {
+				continue
+			}
+			c.IngestBurst(&b, slot)
 		}
-		c.IngestBurst(&b, slot)
 	}
 	p.pending = keep
 

--- a/internal/radio/dmr/tier3/process_test.go
+++ b/internal/radio/dmr/tier3/process_test.go
@@ -106,6 +106,64 @@ func TestProcessLocksOnAlohaBurst(t *testing.T) {
 	}
 }
 
+// TestProcessLocksOnPolarityFlippedBurst is the issue #264 regression:
+// an RTL-SDR Blog V4 / R828D presenting conjugated (spectrum-inverted)
+// IQ flips the FM-discriminator sign, so every dibit arrives as
+// (dibit + 2) mod 4. The adapter must detect the rotation-2 sync and
+// de-rotate the burst so the same ColorCode + SystemID are recovered
+// as from the canonical burst — i.e. the color code is stable, not
+// "changing constantly".
+func TestProcessLocksOnPolarityFlippedBurst(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{
+		Bus:         bus,
+		Log:         slog.Default(),
+		SystemName:  "Sys",
+		FrequencyHz: 460_000_000,
+	})
+
+	burst := buildAlohaBurst(t, 0xA, 0x1234)
+
+	stream := make([]uint8, 200)
+	stream = append(stream, burst...)
+	stream = append(stream, make([]uint8, 64)...)
+	// Simulate I/Q-reversed / spectrum-inverted reception: every dibit
+	// rotated by +2 mod 4 (the discriminator-polarity-flip rotation).
+	for i := range stream {
+		stream[i] = (stream[i] + 2) & 3
+	}
+
+	cc.Process(stream, 0)
+
+	var sawLock bool
+	var ls LockState
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind == events.KindCCLocked {
+				ls, _ = ev.Payload.(LockState)
+				sawLock = true
+			}
+		default:
+			if !sawLock {
+				t.Errorf("Process did not lock on a polarity-flipped burst")
+				return
+			}
+			if ls.ColorCode != 0xA {
+				t.Errorf("LockState.ColorCode = %d, want 10", ls.ColorCode)
+			}
+			if ls.SystemID != 0x1234 {
+				t.Errorf("LockState.SystemID = %#x, want 0x1234", ls.SystemID)
+			}
+			return
+		}
+	}
+}
+
 // TestProcessHandlesBurstSpanningCalls: a burst whose dibits
 // arrive across two Process calls still drives IngestBurst.
 func TestProcessHandlesBurstSpanningCalls(t *testing.T) {


### PR DESCRIPTION
Issue #264: the RTL-SDR Blog V4 (R828D tuner) failed to decode DMR while
the reporter's NooElec (R820T2) worked, with the color code "changing
constantly" — the classic signature of a conjugated / spectrum-inverted
IQ stream ("are I and Q reversed?"). The FM discriminator
(arg(z[n]·conj(z[n-1]))) negates under conjugation, so the slicer maps
+3<->-3 and +1<->-1, i.e. a (dibit + 2) mod 4 polarity flip. P25 Phase 1
already tolerates this flip; the DMR path did not.

DMR's 9 sync words are closed under that flip (XOR 0xAAAA…): an inverted
data sync is byte-identical to a clean voice sync and vice versa. So the
sync match alone cannot resolve the polarity — the existing detector
already fires on an inverted stream, it just sees the flipped twin. The
disambiguation has to come from the FEC-protected payload.

Fix: the Tier II / III Process adapters now decode each matched burst at
both discriminator polarities (identity and the +2 flip) and hand each
candidate to IngestBurst, whose slot-type Hamming(20,8) + BPTC(196,96) +
CSBK CRC drops the wrong polarity with no state change. Identity is
tried first, so clean R820T2 streams take exactly the same path as
before — the flip recovery is purely additive.

Adds dmr.RotateBurstDibits + CandidatePolarities, unit tests for the
sync-pair closure and both adapters, and an integration test that
conjugates the modulated IQ end-to-end.

No tuner/demod register changes: the R828D's orientation config already
matches the R820T2 and librtlsdr; branching orientation by chip would be
wrong.

https://claude.ai/code/session_01YLjGTWj9dY1VUEevTADJPx