### PR TITLE
cchunt: explain cchunt.failed with the control SDR's live IQ health

### DIFF
--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -909,11 +909,14 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 	// CC hunter supervisor — opt-in via scanner.cc_hunt.enabled OR
 	// by default when at least one trunked system is configured.
 	// Constructs an IQ → CC decoder connector alongside (below) so
-	// the supervisor's retunes drive a live demod pipeline. P25
-	// Phase 1 and YSF have wired pipelines today; other protocols
-	// stay in `state=hunting` until their per-protocol
-	// ControlChannel.Process(stream, baseIdx) adapters ship — see
-	// internal/scanner/ccdecoder/pipelines.go for the factory map.
+	// the supervisor's retunes drive a live demod pipeline. Every
+	// trunked protocol the config accepts now has a wired live
+	// pipeline (P25 Phase 1/2, DMR Tier II/III, NXDN, EDACS, Motorola,
+	// LTR, MPT 1327, dPMR, TETRA, D-STAR, YSF) — see the factory map in
+	// internal/scanner/ccdecoder/pipelines.go. A protocol with no
+	// registered factory would leave its system in `state=hunting`
+	// (the connector skips the retune) rather than emitting
+	// `cchunt.failed`.
 	if d.pool != nil && len(d.systems) > 0 {
 		cchEnabled := cfg.Scanner.CCHunt.Enabled || cfg.Scanner.CCHunt == (config.CCHuntConfig{})
 		if cchEnabled {
@@ -950,13 +953,12 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 				// frequency the supervisor is currently attempting,
 				// and pumps IQ through the matching per-protocol
 				// pipeline so the CC state machine publishes
-				// cc.locked / grant events on the bus. Only P25
-				// Phase 1 and YSF have wired pipelines today —
-				// other protocols log a "no factory" debug message
-				// when their HuntProgress lands and the supervisor
-				// stays in `state=hunting`. See README for the
-				// per-protocol Process(stream, baseIdx) adapter
-				// follow-ups.
+				// cc.locked / grant events on the bus. All trunked
+				// protocols the config accepts are wired (see the
+				// factory map in ccdecoder/pipelines.go); a protocol
+				// with no factory logs a "no factory" debug message
+				// when its HuntProgress lands and the supervisor
+				// stays in `state=hunting`.
 				// Avoid the typed-nil trap: a nil *metrics.Metrics
 				// wrapped in IQPowerObserver still tests as non-nil
 				// inside the decoder. Hand the interface only when
@@ -1008,6 +1010,11 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 					return nil, fmt.Errorf("daemon: ccdecoder: %w", err)
 				}
 				d.ccDecoder = dec
+				// Let the supervisor enrich cchunt.failed with the
+				// decoder's live IQ-health snapshot so field reports
+				// of "constantly getting cchunt.failed" carry the
+				// signal level / sample count / one-line cause.
+				sup.SetIQHealthProvider(dec)
 			} else {
 				log.Warn("daemon: scanner.cc_hunt enabled but no control SDR in pool; skipping")
 			}

--- a/internal/scanner/ccdecoder/decoder.go
+++ b/internal/scanner/ccdecoder/decoder.go
@@ -233,6 +233,22 @@ type Decoder struct {
 	// front-end I/Q imbalance from the raw IQ in pump before decimation
 	// (issue #402). Owned by pump.
 	iqCorrector *rtlsdr.IQImbalanceCorrector
+
+	// Persisted last-window IQ-health snapshot. Unlike the pw* window
+	// accumulators above (reset every iqPowerWindow), these are kept so
+	// IQHealth can answer the cchunt supervisor at hunt-failure time —
+	// the supervisor attaches the result to the cchunt.failed event/log
+	// so a field report explains itself. lastHealthSystem labels which
+	// system the snapshot belongs to; totalSamples is cumulative since
+	// that system became the active pipeline (reset on system change /
+	// clearActive). Guarded by mu (read/written under pump's lock and by
+	// IQHealth).
+	lastHealthSystem string
+	lastHealthAt     time.Time
+	lastDbfs         float64
+	lastClipRatio    float64
+	lastDCRatioDb    float64
+	totalSamples     int64
 }
 
 // New constructs a Decoder. Returns an error when required Options
@@ -413,6 +429,11 @@ func (d *Decoder) clearActiveLocked() {
 	d.pwClipped = 0
 	d.pwSamples = 0
 	d.pwLastSystem = ""
+	// Drop the persisted health snapshot so a torn-down system's IQ
+	// health can't answer a later IQHealth query for a different one.
+	d.lastHealthSystem = ""
+	d.lastHealthAt = time.Time{}
+	d.totalSamples = 0
 }
 
 // ensureDownconverterLocked (re)builds the down-converter when the
@@ -477,7 +498,12 @@ func (d *Decoder) observeIQPowerLocked(iq []complex64) {
 		d.pwClipped = 0
 		d.pwSamples = 0
 		d.pwLastSystem = d.activeAt
+		d.totalSamples = 0
 	}
+	// Cumulative sample count for the active system (reset above on a
+	// system change). Distinguishes "SDR delivered nothing" from "IQ
+	// flowed but never locked" in the cchunt.failed diagnosis.
+	d.totalSamples += int64(len(iq))
 	for _, c := range iq {
 		r := float64(real(c))
 		i := float64(imag(c))
@@ -530,6 +556,13 @@ func (d *Decoder) observeIQPowerLocked(iq []complex64) {
 	// clips on peaks; this is the signal that distinguishes the two and
 	// the smoking gun for the issue #402 overload failure mode.
 	clipRatio := float64(d.pwClipped) / n
+	// Persist this window so IQHealth can report it at hunt-failure
+	// time (the pw* accumulators reset below every window).
+	d.lastHealthSystem = d.activeAt
+	d.lastHealthAt = now
+	d.lastDbfs = dbfs
+	d.lastClipRatio = clipRatio
+	d.lastDCRatioDb = ratioDb
 	if d.activeAt != "" && d.metrics != nil {
 		d.metrics.RecordIQPowerDbFS(d.activeAt, dbfs)
 		d.metrics.RecordIQDCRatioDb(d.activeAt, ratioDb)
@@ -565,6 +598,62 @@ func (d *Decoder) observeIQPowerLocked(iq []complex64) {
 	d.pwClipped = 0
 	d.pwSamples = 0
 	d.pwWindowAt = now
+}
+
+// IQHealth returns a best-effort snapshot of the control SDR's IQ
+// health for the named system, for the cchunt supervisor to attach to
+// a cchunt.failed event/log. ok is false when the decoder has no
+// observations for that system — most often because the SDR delivered
+// no IQ at all, or a different system is currently being decoded — and
+// the supervisor then publishes its own "no IQ observed" diagnosis.
+//
+// Satisfies the cchunt.IQHealthProvider interface (structurally; the
+// supervisor decouples via that interface so it doesn't import this
+// package).
+func (d *Decoder) IQHealth(system string) (trunking.HuntDiagnostics, bool) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	pipelineActive := d.active != nil && d.activeAt == system
+	haveWindow := d.lastHealthSystem == system && !d.lastHealthAt.IsZero()
+	haveSamples := d.activeAt == system && d.totalSamples > 0
+	if !haveWindow && !haveSamples {
+		return trunking.HuntDiagnostics{}, false
+	}
+	diag := trunking.HuntDiagnostics{
+		IQObserved:     true,
+		IQSamples:      d.totalSamples,
+		PipelineActive: pipelineActive,
+	}
+	if haveWindow {
+		diag.IQPowerDbFS = d.lastDbfs
+		diag.IQClipRatio = d.lastClipRatio
+		diag.IQDCRatioDb = d.lastDCRatioDb
+	}
+	diag.Diagnosis = diagnoseIQ(diag, haveWindow)
+	return diag, true
+}
+
+// diagnoseIQ turns an IQ-health snapshot into a one-line operator hint,
+// reusing the same thresholds the live pump logs fire on so the two
+// never disagree. haveWindow is false when only a partial (sub-window)
+// sample count is available, so we can't yet judge signal level.
+func diagnoseIQ(d trunking.HuntDiagnostics, haveWindow bool) string {
+	if !d.PipelineActive {
+		return "no live decode pipeline for this protocol — check the system's `protocol` setting"
+	}
+	if !haveWindow {
+		return "IQ is flowing but the dwell was too short to gauge signal level — let it run, or raise scanner.cc_hunt.dwell_ms"
+	}
+	switch {
+	case d.IQPowerDbFS <= iqLowPowerThresholdDbFS:
+		return "IQ level very low — check the antenna is connected, raise gain, and confirm the dongle is streaming (`sdr list --probe`)"
+	case d.IQClipRatio > iqClipWarnRatio:
+		return "front-end overload (ADC clipping) — reduce gain or add attenuation; do NOT raise gain (issue #402)"
+	case d.IQDCRatioDb > iqDCRatioWarnDb:
+		return "an on-channel DC spike dominates the passband (RTL-SDR zero-IF) — offset the tuned frequency slightly or use a different dongle (issue #402)"
+	default:
+		return "signal present but no control-channel lock — verify the control-channel frequency is correct and current, set the right ppm, and confirm the system is active"
+	}
 }
 
 // Close releases the active pipeline. Safe to call from outside Run;

--- a/internal/scanner/ccdecoder/decoder_test.go
+++ b/internal/scanner/ccdecoder/decoder_test.go
@@ -3,6 +3,7 @@ package ccdecoder
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -1444,5 +1445,108 @@ func TestClearActiveClearsIQPowerSeries(t *testing.T) {
 	d.clearActive()
 	if len(pwr.cleared) != 1 || pwr.cleared[0] != "TestSys" {
 		t.Errorf("cleared = %v, want [TestSys]", pwr.cleared)
+	}
+}
+
+// TestDiagnoseIQ exercises every branch of the cchunt.failed cause
+// classifier so the one-line hint stays in lock-step with the live
+// pump's thresholds.
+func TestDiagnoseIQ(t *testing.T) {
+	cases := []struct {
+		name       string
+		diag       trunking.HuntDiagnostics
+		haveWindow bool
+		wantSubstr string
+	}{
+		{
+			name:       "no pipeline",
+			diag:       trunking.HuntDiagnostics{PipelineActive: false},
+			haveWindow: true,
+			wantSubstr: "no live decode pipeline",
+		},
+		{
+			name:       "partial window",
+			diag:       trunking.HuntDiagnostics{PipelineActive: true},
+			haveWindow: false,
+			wantSubstr: "too short to gauge",
+		},
+		{
+			name:       "low power",
+			diag:       trunking.HuntDiagnostics{PipelineActive: true, IQPowerDbFS: iqLowPowerThresholdDbFS - 1},
+			haveWindow: true,
+			wantSubstr: "IQ level very low",
+		},
+		{
+			name:       "clipping",
+			diag:       trunking.HuntDiagnostics{PipelineActive: true, IQPowerDbFS: -10, IQClipRatio: iqClipWarnRatio + 0.01},
+			haveWindow: true,
+			wantSubstr: "front-end overload",
+		},
+		{
+			name:       "dc spike",
+			diag:       trunking.HuntDiagnostics{PipelineActive: true, IQPowerDbFS: -10, IQDCRatioDb: iqDCRatioWarnDb + 1},
+			haveWindow: true,
+			wantSubstr: "DC spike",
+		},
+		{
+			name:       "healthy but no lock",
+			diag:       trunking.HuntDiagnostics{PipelineActive: true, IQPowerDbFS: -30, IQClipRatio: 0, IQDCRatioDb: -25},
+			haveWindow: true,
+			wantSubstr: "no control-channel lock",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := diagnoseIQ(tc.diag, tc.haveWindow)
+			if !strings.Contains(got, tc.wantSubstr) {
+				t.Errorf("diagnoseIQ(%s) = %q, want substring %q", tc.name, got, tc.wantSubstr)
+			}
+		})
+	}
+}
+
+// TestIQHealthUnknownSystem: with no observations for a system, IQHealth
+// reports ok=false so the supervisor falls back to its "no IQ observed"
+// diagnosis.
+func TestIQHealthUnknownSystem(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	d, err := New(Options{Bus: bus, IQ: &fakeIQSource{}, SampleRateHz: 48000})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if _, ok := d.IQHealth("Nope"); ok {
+		t.Fatal("IQHealth(unknown) ok = true, want false")
+	}
+}
+
+// TestIQHealthPartialSamples: once IQ has flowed for the active system
+// but no full power window has elapsed, IQHealth reports the sample
+// count with the "dwell too short" hint.
+func TestIQHealthPartialSamples(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	d, err := New(Options{Bus: bus, IQ: &fakeIQSource{}, SampleRateHz: 48000})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	// Stand up an active pipeline for "Sys" and fold one chunk of IQ
+	// through the power observer without letting a window elapse.
+	d.active = &recordingPipeline{}
+	d.activeAt = "Sys"
+	d.observeIQPowerLocked(make([]complex64, 1024))
+
+	diag, ok := d.IQHealth("Sys")
+	if !ok {
+		t.Fatal("IQHealth(Sys) ok = false, want true")
+	}
+	if !diag.IQObserved || diag.IQSamples != 1024 {
+		t.Errorf("diag = %+v, want IQObserved with 1024 samples", diag)
+	}
+	if !diag.PipelineActive {
+		t.Errorf("diag.PipelineActive = false, want true")
+	}
+	if !strings.Contains(diag.Diagnosis, "too short to gauge") {
+		t.Errorf("diag.Diagnosis = %q, want 'too short to gauge'", diag.Diagnosis)
 	}
 }

--- a/internal/scanner/cchunt/supervisor.go
+++ b/internal/scanner/cchunt/supervisor.go
@@ -19,6 +19,22 @@ type Tuner interface {
 	SetCenterFreq(hz uint32) error
 }
 
+// IQHealthProvider is the optional hook the supervisor queries when a
+// hunt round fails, so the cchunt.failed event/log can explain why
+// rather than just reporting the symptom. internal/scanner/ccdecoder's
+// Decoder satisfies it. Decoupled via an interface so the supervisor
+// doesn't import the decoder (avoids a cycle) and tests can substitute
+// a fake or omit it entirely.
+type IQHealthProvider interface {
+	IQHealth(system string) (trunking.HuntDiagnostics, bool)
+}
+
+// noIQDiagnosis is published when the decoder reports no observations
+// for a failed system — the strongest single hint that the control SDR
+// isn't delivering IQ at all (USB/driver binding, a dead handle, or
+// nothing tuned).
+const noIQDiagnosis = "no IQ observed from the control SDR during the hunt — confirm the dongle is streaming (`sdr list --probe`), the driver is bound (`sdr doctor`), and the antenna is connected"
+
 // Options configure a new Supervisor.
 type Options struct {
 	Bus     *events.Bus
@@ -51,6 +67,10 @@ type Supervisor struct {
 	mu     sync.RWMutex
 	states map[string]*systemRuntime
 	order  []string // stable iteration order for round-robin + Snapshot
+	// iqHealth is the optional decoder hook queried on hunt failure to
+	// enrich the cchunt.failed event/log. Set once before Run via
+	// SetIQHealthProvider; guarded by mu. Nil disables enrichment.
+	iqHealth IQHealthProvider
 }
 
 // systemRuntime is the per-system mutable state the supervisor owns.
@@ -273,6 +293,16 @@ func (s *Supervisor) startRound(name string) {
 	}
 }
 
+// SetIQHealthProvider wires an optional IQ-health source the supervisor
+// queries on hunt failure to enrich the cchunt.failed event/log. Call
+// before Run (the daemon does, right after building the ccdecoder).
+// Safe to call with nil to clear it.
+func (s *Supervisor) SetIQHealthProvider(p IQHealthProvider) {
+	s.mu.Lock()
+	s.iqHealth = p
+	s.mu.Unlock()
+}
+
 func (s *Supervisor) markFailed(name string) {
 	s.mu.Lock()
 	rt := s.states[name]
@@ -292,16 +322,52 @@ func (s *Supervisor) markFailed(name string) {
 	if rt.backoffWindow > s.maxBO {
 		rt.backoffWindow = s.maxBO
 	}
+	provider := s.iqHealth
 	s.mu.Unlock()
+
+	// Capture the control SDR's IQ health *outside* s.mu — the provider
+	// (the ccdecoder) takes its own lock, and we must not hold ours
+	// across a foreign call.
+	diag := diagnoseFailure(provider, name)
+
+	// A WARN here is the channel operators actually paste in bug
+	// reports; the structured fields + one-line diagnosis turn a
+	// "constantly getting cchunt.failed" report into a self-triaging
+	// log entry. Fires once per failed hunt round, then backs off.
+	s.log.Warn("cchunt: hunt failed — no control-channel lock",
+		"system", name,
+		"backoff_ms", int(wait/time.Millisecond),
+		"iq_observed", diag.IQObserved,
+		"iq_samples", diag.IQSamples,
+		"iq_power_dbfs", diag.IQPowerDbFS,
+		"iq_clip_ratio", diag.IQClipRatio,
+		"iq_dc_ratio_db", diag.IQDCRatioDb,
+		"pipeline_active", diag.PipelineActive,
+		"diagnosis", diag.Diagnosis)
 
 	s.bus.Publish(events.Event{
 		Kind: events.KindHuntFailed,
 		Payload: trunking.HuntFailed{
-			System:    name,
-			At:        now,
-			BackoffMs: int(wait / time.Millisecond),
+			System:      name,
+			At:          now,
+			BackoffMs:   int(wait / time.Millisecond),
+			Diagnostics: diag,
 		},
 	})
+}
+
+// diagnoseFailure queries the IQ-health provider (if wired) for a
+// failed system. When the provider has no observations for it, that
+// absence is itself the diagnosis (noIQDiagnosis). With no provider at
+// all (unit tests) the zero value is returned and Diagnosis stays empty.
+func diagnoseFailure(p IQHealthProvider, name string) trunking.HuntDiagnostics {
+	if p == nil {
+		return trunking.HuntDiagnostics{}
+	}
+	if d, ok := p.IQHealth(name); ok {
+		return d
+	}
+	return trunking.HuntDiagnostics{Diagnosis: noIQDiagnosis}
 }
 
 func (s *Supervisor) backoffRemaining(name string) time.Duration {

--- a/internal/scanner/cchunt/supervisor_test.go
+++ b/internal/scanner/cchunt/supervisor_test.go
@@ -283,3 +283,75 @@ func TestSupervisorRunReturnsCtxErr(t *testing.T) {
 		t.Errorf("Run() = %v, want context.DeadlineExceeded", got)
 	}
 }
+
+// fakeIQHealth is a stub IQHealthProvider for the markFailed enrichment
+// tests. When ok is false it models a decoder that saw no IQ for the
+// system, so the supervisor must fall back to noIQDiagnosis.
+type fakeIQHealth struct {
+	diag trunking.HuntDiagnostics
+	ok   bool
+}
+
+func (f fakeIQHealth) IQHealth(string) (trunking.HuntDiagnostics, bool) {
+	return f.diag, f.ok
+}
+
+// TestMarkFailedAttachesDiagnostics: a wired provider's snapshot rides
+// along on the cchunt.failed event.
+func TestMarkFailedAttachesDiagnostics(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sup, err := New(Options{
+		Bus:     bus,
+		Tuner:   &fakeTuner{},
+		Systems: []trunking.System{{Name: "R", Protocol: trunking.ProtocolP25, ControlChannels: []uint32{1}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := trunking.HuntDiagnostics{
+		IQObserved: true, IQSamples: 4096, IQPowerDbFS: -42,
+		PipelineActive: true, Diagnosis: "signal present but no control-channel lock — verify the control-channel",
+	}
+	sup.SetIQHealthProvider(fakeIQHealth{diag: want, ok: true})
+
+	sub := bus.Subscribe()
+	defer sub.Close()
+	sup.markFailed("R")
+
+	select {
+	case ev := <-sub.C:
+		f, ok := ev.Payload.(trunking.HuntFailed)
+		if !ok {
+			t.Fatalf("payload type = %T, want HuntFailed", ev.Payload)
+		}
+		if f.Diagnostics != want {
+			t.Errorf("Diagnostics = %+v, want %+v", f.Diagnostics, want)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("never saw cchunt.failed event")
+	}
+}
+
+// TestMarkFailedNoIQDiagnosis: a provider reporting no observations
+// (ok=false) means the SDR likely isn't streaming — the supervisor
+// substitutes noIQDiagnosis.
+func TestMarkFailedNoIQDiagnosis(t *testing.T) {
+	got := diagnoseFailure(fakeIQHealth{ok: false}, "R")
+	if got.Diagnosis != noIQDiagnosis {
+		t.Errorf("Diagnosis = %q, want noIQDiagnosis", got.Diagnosis)
+	}
+	if got.IQObserved {
+		t.Errorf("IQObserved = true, want false when no IQ seen")
+	}
+}
+
+// TestMarkFailedNoProvider: with no provider wired (the default) the
+// event still publishes with an empty diagnosis — no panic, no change
+// for existing consumers.
+func TestMarkFailedNoProvider(t *testing.T) {
+	got := diagnoseFailure(nil, "R")
+	if got != (trunking.HuntDiagnostics{}) {
+		t.Errorf("diagnoseFailure(nil) = %+v, want zero value", got)
+	}
+}

--- a/internal/trunking/cchunt.go
+++ b/internal/trunking/cchunt.go
@@ -185,6 +185,47 @@ type HuntFailed struct {
 	System    string    `json:"system"`
 	At        time.Time `json:"at"`
 	BackoffMs int       `json:"backoff_ms"`
+	// Diagnostics is a best-effort IQ-health snapshot captured when the
+	// hunt failed, so a `cchunt.failed` event/log explains *why* without
+	// a round-trip to the operator. Zero value (and an empty Diagnosis)
+	// when no decoder is wired to the supervisor — e.g. in unit tests.
+	Diagnostics HuntDiagnostics `json:"diagnostics"`
+}
+
+// HuntDiagnostics is an optional snapshot of the control SDR's IQ
+// health at the moment a hunt round failed. The cchunt supervisor
+// fills it from the live ccdecoder (internal/scanner/ccdecoder) so
+// `cchunt.failed` answers the operator's first question — distinguishing
+// a silent SDR (USB/driver binding, dead handle, no antenna) from
+// front-end overload, an on-channel DC spike, or a clean signal that
+// simply never carried a decodable control channel. All fields are
+// best-effort; the zero value means "no decoder wired".
+type HuntDiagnostics struct {
+	// IQObserved is true when the decoder saw at least one IQ sample
+	// for this system during the hunt. False is the strongest single
+	// signal that the SDR isn't streaming at all.
+	IQObserved bool `json:"iq_observed"`
+	// IQSamples is the cumulative raw IQ sample count the decoder
+	// processed for this system since it became the active pipeline.
+	IQSamples int64 `json:"iq_samples"`
+	// IQPowerDbFS is the last window-averaged IQ power in dBFS. Very
+	// low (≲ -55) points at antenna / gain / USB; near 0 with a high
+	// clip ratio is front-end overload.
+	IQPowerDbFS float64 `json:"iq_power_dbfs"`
+	// IQClipRatio is the last window's fraction of ADC-rail-clipped
+	// samples — front-end overload when sustained (≳ 0.002).
+	IQClipRatio float64 `json:"iq_clip_ratio"`
+	// IQDCRatioDb is the last window's DC-bin power relative to total
+	// channel power, in dB — an on-channel DC spike when ≳ -10.
+	IQDCRatioDb float64 `json:"iq_dc_ratio_db"`
+	// PipelineActive is true when a live decode pipeline for the
+	// system's protocol was running during the hunt. (A protocol with
+	// no wired pipeline sits in state=hunting rather than failing, so
+	// this is rarely false on a real failure.)
+	PipelineActive bool `json:"pipeline_active"`
+	// Diagnosis is a one-line, human-readable best guess at the cause,
+	// derived from the fields above. Empty when no decoder is wired.
+	Diagnosis string `json:"diagnosis,omitempty"`
 }
 
 // ErrNoControlChannel is returned when every candidate frequency exhausts


### PR DESCRIPTION
`cchunt.failed` only ever reported the symptom — the hunter retuned to
every configured control channel, dwelled, and got no lock — leaving
operators (and field bug reports like "constantly getting cchunt.failed
on dmr and p25") with no idea *why*. Because both DMR and P25 share the
same upstream IQ path, the answer almost always lives there: a silent
SDR (USB/driver binding, dead handle, no antenna), front-end overload,
an on-channel DC spike, or a clean signal that simply never carried a
decodable control channel.

The ccdecoder already computes exactly those signals per IQ window
(dBFS power, DC-bin ratio, clip ratio — issue #402); they were just
never surfaced on failure. This:

  - Persists the decoder's last IQ-health window + a cumulative sample
    count, and adds Decoder.IQHealth(system) returning a
    trunking.HuntDiagnostics with a one-line diagnosis derived from the
    same thresholds the live pump logs fire on.
  - Adds an optional cchunt.IQHealthProvider the supervisor queries in
    markFailed (decoupled via interface; no import cycle). The snapshot
    rides along on the cchunt.failed event payload and a new WARN log
    line — the channel operators actually paste in reports. When the
    decoder saw no IQ at all, that absence becomes the diagnosis
    (check sdr list --probe / sdr doctor / antenna).
  - Wires the daemon's ccdecoder into the supervisor.

Also corrects two stale daemon.go comments claiming only P25 Phase 1 +
YSF have wired live pipelines — every trunked protocol the config
accepts is wired today (see ccdecoder/pipelines.go).

https://claude.ai/code/session_01YPg7bphEKRomzBPttF7cAN