### PR TITLE
rtlsdr/usb: open WinUSB child interface of composite (usbccgp) dongles on Windows

### DIFF
--- a/internal/sdr/rtlsdr/usb/child.go
+++ b/internal/sdr/rtlsdr/usb/child.go
@@ -1,0 +1,86 @@
+package usb
+
+import (
+	"strconv"
+	"strings"
+)
+
+// This file holds the platform-independent, pure-function half of the
+// Windows composite-device handling (see child_windows.go for the
+// SetupAPI/CfgMgr glue). Keeping these helpers free of any build tag lets
+// them compile and be table-tested on every platform — the Windows-only
+// syscalls in child_windows.go are thin wrappers around the decisions made
+// here.
+
+// parseInstanceID extracts the VID, PID, and interface number from a Windows
+// device *instance* ID such as:
+//
+//	USB\VID_0BDA&PID_2838&MI_00\6&1234abcd&0&0000
+//
+// Unlike a device-interface path (parsed by parseDevicePath, which is
+// "#"-delimited and lower-cased), an instance ID is "\"-delimited and
+// conventionally upper-cased; comparison here is case-insensitive to tolerate
+// either. The MI_xx token is only present on the child function nodes of a USB
+// composite device — hasMI reports whether it was found, which is how callers
+// tell a composite child apart from a single-interface dongle's whole-device
+// node.
+func parseInstanceID(id string) (vid, pid uint16, mi int, hasMI bool) {
+	lower := strings.ToLower(id)
+	if i := strings.Index(lower, "vid_"); i >= 0 && i+8 <= len(id) {
+		if v, err := strconv.ParseUint(id[i+4:i+8], 16, 16); err == nil {
+			vid = uint16(v)
+		}
+	}
+	if i := strings.Index(lower, "pid_"); i >= 0 && i+8 <= len(id) {
+		if v, err := strconv.ParseUint(id[i+4:i+8], 16, 16); err == nil {
+			pid = uint16(v)
+		}
+	}
+	if i := strings.Index(lower, "mi_"); i >= 0 && i+5 <= len(id) {
+		if v, err := strconv.ParseUint(id[i+3:i+5], 16, 16); err == nil {
+			mi = int(v)
+			hasMI = true
+		}
+	}
+	return vid, pid, mi, hasMI
+}
+
+// isInterfaceZero reports whether an instance ID names the Interface 0
+// (&MI_00) child function node — the RTL-SDR's only data interface and the one
+// Zadig binds to WinUSB on a composite dongle.
+func isInterfaceZero(id string) bool {
+	_, _, mi, hasMI := parseInstanceID(id)
+	return hasMI && mi == 0
+}
+
+// effectiveCompositeService picks the SPDRP_SERVICE value that best represents
+// a device's real driver binding for the `sdr doctor` classifier.
+//
+// For a USB composite device the GUID_DEVINTERFACE_USB_DEVICE node we enumerate
+// is the *parent*, which is always bound to "usbccgp" (correct and normal). The
+// SDR's actual driver lives on the Interface 0 (&MI_00) *child* function node.
+// When such a child is found we report ITS service so the verdict reflects the
+// binding the user actually controls in Zadig — turning a correctly
+// WinUSB-bound composite dongle from a false "BAD" into "OK", and giving an
+// accurate hint (e.g. "libusbK instead of WinUSB") when they bound the wrong
+// driver. With no child found we keep the parent's service so the existing
+// composite-parent guidance still fires.
+func effectiveCompositeService(parentService, childService string, childFound bool) string {
+	if childFound && strings.EqualFold(parentService, "usbccgp") {
+		return childService
+	}
+	return parentService
+}
+
+// firstInterfaceGUID returns the first non-empty entry from a child node's
+// DeviceInterfaceGUIDs (REG_MULTI_SZ) registry value. Zadig/libwdi normally
+// writes exactly one; we tolerate blank padding entries. ok is false when the
+// list holds nothing usable.
+func firstInterfaceGUID(guids []string) (guid string, ok bool) {
+	for _, g := range guids {
+		if t := strings.TrimSpace(g); t != "" {
+			return t, true
+		}
+	}
+	return "", false
+}

--- a/internal/sdr/rtlsdr/usb/child_test.go
+++ b/internal/sdr/rtlsdr/usb/child_test.go
@@ -1,0 +1,93 @@
+package usb
+
+import "testing"
+
+func TestParseInstanceID(t *testing.T) {
+	tests := []struct {
+		name  string
+		id    string
+		vid   uint16
+		pid   uint16
+		mi    int
+		hasMI bool
+	}{
+		{"composite child interface 0", `USB\VID_0BDA&PID_2838&MI_00\6&1234abcd&0&0000`, 0x0bda, 0x2838, 0, true},
+		{"composite child interface 1", `USB\VID_0BDA&PID_2838&MI_01\6&1234abcd&0&0001`, 0x0bda, 0x2838, 1, true},
+		{"single-interface whole device (no MI)", `USB\VID_0BDA&PID_2832\77771111153705700`, 0x0bda, 0x2832, 0, false},
+		{"lower-case tokens", `usb\vid_1209&pid_2832&mi_00\x`, 0x1209, 0x2832, 0, true},
+		{"garbage", `nonsense`, 0, 0, 0, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vid, pid, mi, hasMI := parseInstanceID(tt.id)
+			if vid != tt.vid || pid != tt.pid || mi != tt.mi || hasMI != tt.hasMI {
+				t.Errorf("parseInstanceID(%q) = (%#04x,%#04x,%d,%v), want (%#04x,%#04x,%d,%v)",
+					tt.id, vid, pid, mi, hasMI, tt.vid, tt.pid, tt.mi, tt.hasMI)
+			}
+		})
+	}
+}
+
+func TestIsInterfaceZero(t *testing.T) {
+	tests := []struct {
+		id   string
+		want bool
+	}{
+		{`USB\VID_0BDA&PID_2838&MI_00\x`, true},
+		{`USB\VID_0BDA&PID_2838&MI_01\x`, false},
+		{`USB\VID_0BDA&PID_2832\x`, false}, // single-interface: no MI token
+		{`garbage`, false},
+	}
+	for _, tt := range tests {
+		if got := isInterfaceZero(tt.id); got != tt.want {
+			t.Errorf("isInterfaceZero(%q) = %v, want %v", tt.id, got, tt.want)
+		}
+	}
+}
+
+func TestEffectiveCompositeService(t *testing.T) {
+	tests := []struct {
+		name   string
+		parent string
+		child  string
+		found  bool
+		want   string
+	}{
+		{"composite parent + winusb child → child wins (OK)", "usbccgp", "WinUSB", true, "WinUSB"},
+		{"composite parent + libusbK child → child wins (accurate hint)", "usbccgp", "libusbK", true, "libusbK"},
+		{"composite parent, no child found → keep parent (BAD)", "usbccgp", "", false, "usbccgp"},
+		{"non-composite parent is never overridden", "WinUSB", "anything", true, "WinUSB"},
+		{"case-insensitive parent match", "USBCCGP", "WinUSB", true, "WinUSB"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := effectiveCompositeService(tt.parent, tt.child, tt.found); got != tt.want {
+				t.Errorf("effectiveCompositeService(%q,%q,%v) = %q, want %q",
+					tt.parent, tt.child, tt.found, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFirstInterfaceGUID(t *testing.T) {
+	tests := []struct {
+		name   string
+		in     []string
+		want   string
+		wantOK bool
+	}{
+		{"single", []string{"{abc}"}, "{abc}", true},
+		{"skips blank padding", []string{"", "  ", "{def}"}, "{def}", true},
+		{"trims whitespace", []string{"  {ghi}  "}, "{ghi}", true},
+		{"empty list", nil, "", false},
+		{"all blank", []string{"", " "}, "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := firstInterfaceGUID(tt.in)
+			if got != tt.want || ok != tt.wantOK {
+				t.Errorf("firstInterfaceGUID(%q) = (%q,%v), want (%q,%v)", tt.in, got, ok, tt.want, tt.wantOK)
+			}
+		})
+	}
+}

--- a/internal/sdr/rtlsdr/usb/child_windows.go
+++ b/internal/sdr/rtlsdr/usb/child_windows.go
@@ -1,0 +1,119 @@
+//go:build windows && (amd64 || arm64)
+
+package usb
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"golang.org/x/sys/windows"
+	"golang.org/x/sys/windows/registry"
+)
+
+// errNoWinUSBChild is returned by findInterfaceZeroChild when no Interface 0
+// (&MI_00) child function node exists for the target VID/PID — i.e. the device
+// is not a composite device, or its child is not present. Callers treat it as
+// "fall back to the parent-node behaviour".
+var errNoWinUSBChild = errors.New("winusb: no Interface 0 child found")
+
+// findInterfaceZeroChild locates the Interface 0 (&MI_00) child function node
+// of the composite USB device VID:PID and reports the driver bound to it
+// (childService) and, when that driver is WinUSB, a CreateFile-openable
+// device-interface path for it (childPath).
+//
+// Why this exists: winEnumerator.List/Open and winDriverInspector.Inspect only
+// ever walk the GUID_DEVINTERFACE_USB_DEVICE interface, which a composite
+// device registers on its usbccgp PARENT node. The SDR's real driver (WinUSB,
+// after Zadig) lives on the &MI_00 CHILD node, which registers its own
+// per-install device-interface GUID instead of GUID_DEVINTERFACE_USB_DEVICE —
+// so the parent walk can never reach it. We walk the raw USB device-node tree
+// here, match VID/PID + &MI_00, read the child's SPDRP_SERVICE, and (for
+// WinUSB) resolve its symbolic-link path.
+//
+// childPath is non-empty only when childService is WinUSB. When an &MI_00 child
+// exists but is bound to something else (libusbK, the in-box DVB driver, ...)
+// we still return childService (with an empty path) so the doctor can give an
+// accurate hint. Returns errNoWinUSBChild when no &MI_00 child for VID:PID is
+// present.
+//
+// NOTE: matching is by VID/PID + &MI_00 only; the dongle serial lives on the
+// parent, not the child instance ID. Two *identical* composite dongles would
+// be indistinguishable here — an acceptable limitation today (the pool already
+// disambiguates by serial at the List layer, and the single-interface path is
+// unaffected).
+func findInterfaceZeroChild(vid, pid uint16) (childService, childPath string, err error) {
+	devSet, err := windows.SetupDiGetClassDevsEx(nil, "USB", 0, windows.DIGCF_PRESENT|windows.DIGCF_ALLCLASSES, 0, "")
+	if err != nil {
+		return "", "", fmt.Errorf("winusb: SetupDiGetClassDevsEx(USB): %w", err)
+	}
+	defer windows.SetupDiDestroyDeviceInfoList(devSet)
+
+	for i := 0; ; i++ {
+		devInfo, e := windows.SetupDiEnumDeviceInfo(devSet, i)
+		if e != nil {
+			break // ERROR_NO_MORE_ITEMS (or any walk error) ends the scan
+		}
+		instID, e := windows.SetupDiGetDeviceInstanceId(devSet, devInfo)
+		if e != nil {
+			continue
+		}
+		v, p, _, hasMI := parseInstanceID(instID)
+		if !hasMI || v != vid || p != pid || !isInterfaceZero(instID) {
+			continue
+		}
+		// Matched the Interface 0 child. Read its bound kernel service.
+		svc := ""
+		if val, e := windows.SetupDiGetDeviceRegistryProperty(devSet, devInfo, windows.SPDRP_SERVICE); e == nil {
+			svc, _ = val.(string)
+		}
+		if !strings.EqualFold(svc, "winusb") {
+			// Child exists but isn't WinUSB-bound: report the service (no
+			// openable path) so the doctor hint is accurate.
+			return svc, "", nil
+		}
+		path, e := childInterfacePath(devSet, devInfo, instID)
+		if e != nil {
+			return svc, "", e
+		}
+		return svc, path, nil
+	}
+	return "", "", errNoWinUSBChild
+}
+
+// childInterfacePath resolves the CreateFile-openable device-interface path for
+// a WinUSB-bound composite child. Zadig/libwdi records the per-install
+// interface GUID in the child's "Device Parameters\DeviceInterfaceGUIDs"
+// (REG_MULTI_SZ); we read it, then ask CfgMgr for that GUID's live symbolic
+// links scoped to this device instance.
+func childInterfacePath(devSet windows.DevInfo, devInfo *windows.DevInfoData, instID string) (string, error) {
+	hkey, err := windows.SetupDiOpenDevRegKey(devSet, devInfo, windows.DICS_FLAG_GLOBAL, 0, windows.DIREG_DEV, windows.KEY_READ)
+	if err != nil {
+		return "", fmt.Errorf("winusb: open child Device Parameters: %w", err)
+	}
+	key := registry.Key(hkey)
+	defer key.Close()
+
+	guids, _, err := key.GetStringsValue("DeviceInterfaceGUIDs")
+	if err != nil {
+		return "", fmt.Errorf("winusb: read DeviceInterfaceGUIDs: %w", err)
+	}
+	guidStr, ok := firstInterfaceGUID(guids)
+	if !ok {
+		return "", errors.New("winusb: child node has no DeviceInterfaceGUIDs")
+	}
+	guid, err := windows.GUIDFromString(guidStr)
+	if err != nil {
+		return "", fmt.Errorf("winusb: bad interface GUID %q: %w", guidStr, err)
+	}
+	paths, err := windows.CM_Get_Device_Interface_List(instID, &guid, windows.CM_GET_DEVICE_INTERFACE_LIST_PRESENT)
+	if err != nil {
+		return "", fmt.Errorf("winusb: CM_Get_Device_Interface_List: %w", err)
+	}
+	for _, p := range paths {
+		if strings.TrimSpace(p) != "" {
+			return p, nil
+		}
+	}
+	return "", errors.New("winusb: no live device-interface path for child")
+}

--- a/internal/sdr/rtlsdr/usb/diag_windows.go
+++ b/internal/sdr/rtlsdr/usb/diag_windows.go
@@ -105,6 +105,16 @@ func (w *winDriverInspector) Inspect(vid, pid uint16) ([]DriverBinding, error) {
 		}
 		service := readDevRegistryString(devSet, &devInfo, spdrpService)
 		descr := readDevRegistryString(devSet, &devInfo, spdrpDeviceDesc)
+		// A "usbccgp" service means this GUID_DEVINTERFACE_USB_DEVICE node is a
+		// USB composite parent — the SDR's real driver lives on its Interface 0
+		// (&MI_00) child. Report the child's binding so a correctly
+		// WinUSB-bound composite dongle reads OK instead of a false BAD (and a
+		// wrong-driver child still gets an accurate hint).
+		if strings.EqualFold(service, "usbccgp") {
+			if childSvc, _, derr := findInterfaceZeroChild(v, p); derr == nil && childSvc != "" {
+				service = effectiveCompositeService(service, childSvc, true)
+			}
+		}
 		out = append(out, classifyWindows(desc, service, descr))
 	}
 	return out, nil

--- a/internal/sdr/rtlsdr/usb/usb_windows.go
+++ b/internal/sdr/rtlsdr/usb/usb_windows.go
@@ -144,13 +144,22 @@ func (w *winEnumerator) List(vid, pid uint16) ([]Descriptor, error) {
 	return out, nil
 }
 
-func (w *winEnumerator) Open(d Descriptor) (Transport, error) {
-	if d.Path == "" {
-		return nil, errors.New("winusb: Descriptor.Path empty (re-enumerate)")
-	}
-	wpath, err := windows.UTF16PtrFromString(d.Path)
+// errWinUSBCreateFile tags failures from the CreateFile stage of
+// createAndInitWinUSB (as opposed to the WinUsb_Initialize stage). Open keys on
+// it to keep CreateFile-level failures — most importantly ERROR_ACCESS_DENIED
+// when another process already holds the dongle (issue #333) — surfacing
+// verbatim, instead of misattributing them to a driver-binding problem and
+// uselessly triggering the composite-child fallback.
+var errWinUSBCreateFile = errors.New("winusb: CreateFile")
+
+// createAndInitWinUSB opens a device-interface path and binds it to WinUSB,
+// returning the file + WinUSB interface handles on success. A CreateFile-stage
+// failure is wrapped with errWinUSBCreateFile; a WinUsb_Initialize-stage
+// failure returns winErr(errno) directly, so Open can tell the two apart.
+func createAndInitWinUSB(path string) (windows.Handle, uintptr, error) {
+	wpath, err := windows.UTF16PtrFromString(path)
 	if err != nil {
-		return nil, fmt.Errorf("winusb: bad path %q: %w", d.Path, err)
+		return 0, 0, fmt.Errorf("%w %q: %w", errWinUSBCreateFile, path, err)
 	}
 	handle, err := windows.CreateFile(
 		wpath,
@@ -162,16 +171,13 @@ func (w *winEnumerator) Open(d Descriptor) (Transport, error) {
 		0,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("winusb: CreateFile %q: %w", d.Path, err)
+		return 0, 0, fmt.Errorf("%w %q: %w", errWinUSBCreateFile, path, err)
 	}
 	var ifaceHandle uintptr
 	ret, _, errno := procWinUsbInitialize.Call(uintptr(handle), uintptr(unsafe.Pointer(&ifaceHandle)))
 	if ret == 0 {
 		windows.CloseHandle(handle)
-		svc, descr := lookupBoundDriver(d.Path)
-		return nil, fmt.Errorf(
-			"winusb: WinUsb_Initialize failed for VID_%04X&PID_%04X (current driver: %s%s — expected WinUSB; run Zadig and rebind Interface 0, see `gophertrunk sdr doctor`): %w",
-			d.VID, d.PID, fallbackString(svc, "unknown"), parens(descr), winErr(errno))
+		return 0, 0, winErr(errno)
 	}
 	// Match libusb's WinUSB backend: explicitly disable the per-pipe
 	// transfer timeout on the control endpoint at open time
@@ -183,11 +189,42 @@ func (w *winEnumerator) Open(d Descriptor) (Transport, error) {
 	// to CtrlTimeoutMs on the first user-level transfer; this call is
 	// pure parity / hardening, not the issue #395 fix.
 	setControlPipeTimeout(ifaceHandle, 0)
-	return &winTransport{
-		fileHandle:  handle,
-		ifaceHandle: ifaceHandle,
-		desc:        d,
-	}, nil
+	return handle, ifaceHandle, nil
+}
+
+func (w *winEnumerator) Open(d Descriptor) (Transport, error) {
+	if d.Path == "" {
+		return nil, errors.New("winusb: Descriptor.Path empty (re-enumerate)")
+	}
+	handle, ifaceHandle, err := createAndInitWinUSB(d.Path)
+	if err == nil {
+		return &winTransport{fileHandle: handle, ifaceHandle: ifaceHandle, desc: d}, nil
+	}
+	// A CreateFile-stage failure (e.g. ERROR_ACCESS_DENIED — another process
+	// holds the dongle, issue #333) is not a driver-binding problem; surface it
+	// verbatim so openUSBHint / isAccessDenied upstream still fire.
+	if errors.Is(err, errWinUSBCreateFile) {
+		return nil, err
+	}
+	// WinUsb_Initialize failed. The GUID_DEVINTERFACE_USB_DEVICE node we
+	// enumerated may be a USB composite parent (bound to usbccgp), whose
+	// WinUSB-capable SDR lives on the Interface 0 (&MI_00) child function node.
+	// Find and open that child before surfacing the bind failure — this lets a
+	// correctly-bound RTL-SDR V4 (and other composite dongles) open without the
+	// user having to chase the right entry in Zadig. Store the child path in the
+	// returned transport's descriptor so Reset() re-opens the child, not the
+	// parent.
+	if _, childPath, derr := findInterfaceZeroChild(d.VID, d.PID); derr == nil && childPath != "" {
+		if ch, cif, cerr := createAndInitWinUSB(childPath); cerr == nil {
+			cd := d
+			cd.Path = childPath
+			return &winTransport{fileHandle: ch, ifaceHandle: cif, desc: cd}, nil
+		}
+	}
+	svc, descr := lookupBoundDriver(d.Path)
+	return nil, fmt.Errorf(
+		"winusb: WinUsb_Initialize failed for VID_%04X&PID_%04X (current driver: %s%s — expected WinUSB; run Zadig and rebind Interface 0, see `gophertrunk sdr doctor`): %w",
+		d.VID, d.PID, fallbackString(svc, "unknown"), parens(descr), err)
 }
 
 // setControlPipeTimeout pushes a PIPE_TRANSFER_TIMEOUT policy on the


### PR DESCRIPTION
A USB composite RTL-SDR (e.g. the RTL-SDR Blog V4) presents its parent node
bound to usbccgp (normal) and its real SDR driver on the Interface 0 (&MI_00)
child function node, which is what Zadig binds to WinUSB. GopherTrunk only ever
walked the GUID_DEVINTERFACE_USB_DEVICE interface — registered by the *parent* —
so:

  - winEnumerator.Open CreateFile'd the usbccgp parent and WinUsb_Initialize
    failed, and
  - sdr doctor read the parent's SPDRP_SERVICE (usbccgp) and reported a false
    BAD even when the child was correctly WinUSB-bound.

Add Windows-only discovery (findInterfaceZeroChild) that walks the USB device-
node tree, matches VID/PID + &MI_00, reads the child's bound service, and — for
WinUSB — resolves its CreateFile-openable device-interface path via the child's
DeviceInterfaceGUIDs + CM_Get_Device_Interface_List.

  - Open: on a WinUsb_Initialize failure, fall back to opening the WinUSB child
    and store its path in the transport descriptor so Reset() re-opens the child.
    CreateFile-stage failures (e.g. ERROR_ACCESS_DENIED, issue #333) are tagged
    and surfaced verbatim so they don't trigger the fallback.
  - Inspect: when a node's service is usbccgp, report the child's binding so a
    correctly-bound composite dongle reads OK (and a wrong-driver child gets an
    accurate hint).

The decision/parsing logic is factored into pure, platform-independent helpers
(child.go) with table tests that run on every platform; the SetupAPI/CfgMgr glue
is Windows-only and needs a real composite dongle to validate end to end.

https://claude.ai/code/session_01FhfTVewQG9PtCLdMyyHBnF