### PR TITLE
Add diagnostic banner and verbose error reporting across all surfaces

### DIFF
--- a/cmd/gophertrunk/audio.go
+++ b/cmd/gophertrunk/audio.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/MattCheramie/GopherTrunk/internal/voice/player"
 )
@@ -14,16 +13,15 @@ import (
 // short by design. Kept as a subcommand so future backends can
 // add real enumeration without breaking the CLI shape.
 func runAudio(args []string) {
+	rep := newReporter("audio")
 	if len(args) == 0 {
-		fmt.Fprintln(os.Stderr, "usage: gophertrunk audio list")
-		os.Exit(2)
+		rep.Fatalf(2, "usage: gophertrunk audio list")
 	}
 	switch args[0] {
 	case "list":
 		listAudio()
 	default:
-		fmt.Fprintf(os.Stderr, "unknown audio subcommand: %s\n", args[0])
-		os.Exit(2)
+		rep.Fatalf(2, "unknown audio subcommand: %s", args[0])
 	}
 }
 

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -17,6 +17,7 @@ import (
 	"github.com/MattCheramie/GopherTrunk/internal/api/rigctld"
 	"github.com/MattCheramie/GopherTrunk/internal/broadcast"
 	"github.com/MattCheramie/GopherTrunk/internal/config"
+	gtdiag "github.com/MattCheramie/GopherTrunk/internal/diag"
 	"github.com/MattCheramie/GopherTrunk/internal/events"
 	gtlog "github.com/MattCheramie/GopherTrunk/internal/log"
 	"github.com/MattCheramie/GopherTrunk/internal/metrics"
@@ -432,6 +433,29 @@ func (d *Daemon) StartupWarnings() []string {
 // surface.
 func (d *Daemon) addWarning(msg string) {
 	d.startupWarnings = append(d.startupWarnings, msg)
+}
+
+// newDiagCollector builds the error-diagnostics collector handed to the
+// API/gRPC servers. When the SDR pool is up, it seeds the collector
+// from the live pool snapshot so a banner never triggers a fresh USB
+// enumeration that would race the running pool's device claim. With no
+// pool it falls back to a lazy enumerator (used only if a banner is
+// actually rendered).
+func (d *Daemon) newDiagCollector() *gtdiag.Collector {
+	if d.pool == nil {
+		return gtdiag.NewCollector()
+	}
+	snap := d.pool.Snapshot()
+	dongles := make([]gtdiag.DongleInfo, 0, len(snap))
+	for _, st := range snap {
+		dongles = append(dongles, gtdiag.DongleInfo{
+			Driver:  st.Driver,
+			Serial:  st.Serial,
+			Product: st.Product,
+			Tuner:   st.TunerName,
+		})
+	}
+	return gtdiag.NewCollectorWithDongles(dongles, nil)
 }
 
 // NewDaemon constructs the daemon from the loaded config. Components
@@ -1541,6 +1565,8 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 			Systems:        d.systems,
 			Log:            log,
 			Version:        version,
+			Diagnostics:    d.newDiagCollector(),
+			VerboseErrors:  cfg.Diagnostics.VerboseErrors,
 			AllowMutations: cfg.API.AllowMutations,
 			Auth: api.AuthConfig{
 				Mode:            authMode,
@@ -1672,15 +1698,17 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 	// gRPC — optional.
 	if cfg.API.GRPCAddr != "" {
 		grpcOpts := api.GRPCServerOptions{
-			Addr:       cfg.API.GRPCAddr,
-			Systems:    d.systems,
-			Talkgroups: d.talkgroups,
-			RIDs:       d.rids,
-			Engine:     d.engine,
-			Audio:      d.audioPub,
-			Log:        log,
-			TLSCert:    cfg.API.TLSCert,
-			TLSKey:     cfg.API.TLSKey,
+			Addr:          cfg.API.GRPCAddr,
+			Systems:       d.systems,
+			Talkgroups:    d.talkgroups,
+			RIDs:          d.rids,
+			Engine:        d.engine,
+			Audio:         d.audioPub,
+			Log:           log,
+			Diagnostics:   d.newDiagCollector(),
+			VerboseErrors: cfg.Diagnostics.VerboseErrors,
+			TLSCert:       cfg.API.TLSCert,
+			TLSKey:        cfg.API.TLSKey,
 		}
 		if d.affiliations != nil {
 			grpcOpts.Affiliations = affiliationProvider{d.affiliations}

--- a/cmd/gophertrunk/decode.go
+++ b/cmd/gophertrunk/decode.go
@@ -34,6 +34,7 @@ func runDecode(args []string) {
 	out := fs.String("out", "", "WAV output path (required; must be a regular file for the WAV header to be patched)")
 	vocoderName := fs.String("vocoder", "imbe", "vocoder name from the registry (imbe, ambe2, null, ...)")
 	listVocoders := fs.Bool("list-vocoders", false, "print the registered vocoder names and exit")
+	verboseFlag := fs.Bool("verbose-errors", false, "print full error chain + stack on failures")
 	fs.Usage = func() {
 		fmt.Fprintln(fs.Output(), `gophertrunk decode — decode a captured raw vocoder-frame stream into a WAV.
 
@@ -54,6 +55,8 @@ FLAGS:`)
 		fs.PrintDefaults()
 	}
 	_ = fs.Parse(args)
+	resolveVerbose(*verboseFlag, false)
+	rep := newReporter("decode")
 
 	if *listVocoders {
 		fmt.Println(strings.Join(voice.DefaultRegistry.Names(), "\n"))
@@ -61,22 +64,19 @@ FLAGS:`)
 	}
 
 	if *out == "" {
-		fmt.Fprintln(os.Stderr, "decode: -out is required")
 		fs.Usage()
-		os.Exit(2)
+		rep.Fatalf(2, "-out is required")
 	}
 
 	reader, closer, err := openInput(*in)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "decode: open input: %v\n", err)
-		os.Exit(1)
+		rep.Fatal(1, fmt.Errorf("open input: %w", err))
 	}
 	defer closer()
 
 	outFile, err := os.Create(*out)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "decode: create output: %v\n", err)
-		os.Exit(1)
+		rep.Fatal(1, fmt.Errorf("create output: %w", err))
 	}
 	defer outFile.Close()
 
@@ -86,8 +86,7 @@ FLAGS:`)
 		// Don't exit non-zero — the WAV is playable up to the
 		// partial trailer, which is the operator-friendly outcome.
 	} else if decodeErr != nil {
-		fmt.Fprintf(os.Stderr, "decode: %v\n", decodeErr)
-		os.Exit(1)
+		rep.Fatal(1, decodeErr)
 	}
 	fmt.Printf("decoded %d frame(s) → %s (%d ms of audio)\n",
 		frames, *out, frames*20)

--- a/cmd/gophertrunk/diag.go
+++ b/cmd/gophertrunk/diag.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"log/slog"
+	"os"
+	"strings"
+	"sync"
+
+	"github.com/MattCheramie/GopherTrunk/internal/diag"
+)
+
+// Shared diagnostics state for the CLI. One Collector is built lazily
+// and reused across every reporter so the costly dongle enumeration
+// (see internal/diag) runs at most once per process — and only if an
+// error actually renders a banner.
+var (
+	diagOnce      sync.Once
+	diagCollector *diag.Collector
+	// verboseErrors is the resolved verbose-error setting. Precedence:
+	// -verbose-errors flag > GOPHERTRUNK_VERBOSE_ERRORS env >
+	// diagnostics.verbose_errors in config. It starts from the env var
+	// so the earliest pre-config error sites still honor it, and is
+	// upgraded as the flag/config become available.
+	verboseErrors = envVerbose()
+)
+
+// envVerbose reports whether GOPHERTRUNK_VERBOSE_ERRORS is set to a
+// truthy value.
+func envVerbose() bool {
+	v := strings.TrimSpace(os.Getenv("GOPHERTRUNK_VERBOSE_ERRORS"))
+	return v != "" && v != "0" && !strings.EqualFold(v, "false")
+}
+
+// resolveVerbose folds a flag value and a config value into the
+// package verboseErrors state (env keeps whatever it already set). Call
+// once the flag and/or config are known.
+func resolveVerbose(flagVal, cfgVal bool) {
+	verboseErrors = verboseErrors || flagVal || cfgVal
+}
+
+// sharedCollector returns the process-wide diagnostics collector.
+func sharedCollector() *diag.Collector {
+	diagOnce.Do(func() { diagCollector = diag.NewCollector() })
+	return diagCollector
+}
+
+// newReporter builds a diag.Reporter for a CLI command, wired to the
+// shared collector and the resolved verbose setting.
+func newReporter(prefix string) *diag.Reporter {
+	return diag.NewReporter(prefix, verboseErrors, sharedCollector())
+}
+
+// logErr logs a daemon-side error. The daemon is non-interactive, so
+// there's no prompt: when verbose is on it attaches the full wrapped
+// chain (and a stack dump), otherwise just the flat error string.
+func logErr(l *slog.Logger, verbose bool, msg string, err error) {
+	if l == nil {
+		l = slog.Default()
+	}
+	if verbose {
+		l.Warn(msg,
+			"chain", diag.Chain(err),
+			"stack", string(diag.CaptureStack()))
+		return
+	}
+	l.Warn(msg, "err", err)
+}

--- a/cmd/gophertrunk/import.go
+++ b/cmd/gophertrunk/import.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"os"
 	"strings"
+
+	"github.com/MattCheramie/GopherTrunk/internal/diag"
 )
 
 // runImport is the entry point for `gophertrunk import-pdf`. Parses
@@ -28,6 +31,7 @@ func runImport(args []string) {
 	extractOnly := fs.Bool("extract-only", false, "dump positioned-text rows from a -pdf as JSON to stdout and exit (for parser bug reports)")
 	nameOverride := fs.String("name", "", "system name for native RadioReference CSV imports (bundle CSVs ignore this — use the metadata section)")
 	sysidOverride := fs.String("sysid", "", "system ID for native RadioReference CSV imports")
+	verboseFlag := fs.Bool("verbose-errors", false, "print full error chain + stack on failures")
 	var pdfPaths repeatedString
 	var csvPaths repeatedString
 	fs.Var(&pdfPaths, "pdf", "path to a RadioReference PDF system export (repeatable)")
@@ -83,6 +87,8 @@ Flags:
 		fs.PrintDefaults()
 	}
 	_ = fs.Parse(args)
+	resolveVerbose(*verboseFlag, false)
+	importRep = newReporter("import-pdf")
 
 	if !*wizard && len(pdfPaths) == 0 && len(csvPaths) == 0 {
 		fs.Usage()
@@ -101,10 +107,10 @@ Flags:
 		}
 		rows, err := extractPDFRows(pdfPaths[0])
 		if err != nil {
-			fail(err.Error())
+			failErr(err)
 		}
 		if err := dumpParseRowsJSON(os.Stdout, rows); err != nil {
-			fail("write rows: " + err.Error())
+			failErr(fmt.Errorf("write rows: %w", err))
 		}
 		return
 	}
@@ -118,7 +124,7 @@ Flags:
 		keep := len(pdfPaths) > 0 || len(csvPaths) > 0
 		answers, wrote, err := runConfigWizard(seed, keep)
 		if err != nil {
-			fail("wizard: " + err.Error())
+			failErr(fmt.Errorf("wizard: %w", err))
 		}
 		if !keep {
 			if wrote {
@@ -132,10 +138,10 @@ Flags:
 		// has something to layer trunking.systems on top of.
 		body, err := renderConfigYAML(answers)
 		if err != nil {
-			fail("wizard render: " + err.Error())
+			failErr(fmt.Errorf("wizard render: %w", err))
 		}
 		if err := os.WriteFile(answers.ConfigPath, body, 0o644); err != nil {
-			fail("wizard write: " + err.Error())
+			failErr(fmt.Errorf("wizard write: %w", err))
 		}
 		fmt.Fprintf(os.Stderr, "import-pdf: wizard scaffold written to %s\n", answers.ConfigPath)
 		*cfgPath = answers.ConfigPath
@@ -152,7 +158,7 @@ Flags:
 	for _, p := range pdfPaths {
 		sys, err := parsePDFFile(p)
 		if err != nil {
-			fail(err.Error())
+			failErr(err)
 		}
 		parsed = append(parsed, sys)
 		fmt.Fprintf(os.Stderr, "import-pdf: parsed PDF %s: %s (%d sites, %d talkgroups)\n",
@@ -162,7 +168,7 @@ Flags:
 	for _, p := range csvPaths {
 		sys, err := parseCSVFile(p, csvOpts)
 		if err != nil {
-			fail(err.Error())
+			failErr(err)
 		}
 		parsed = append(parsed, sys)
 		fmt.Fprintf(os.Stderr, "import-pdf: parsed CSV %s: %s (%d sites, %d talkgroups)\n",
@@ -183,7 +189,7 @@ Flags:
 	if *noTUI || *dryRun {
 		res, err := writeFn(parsed)
 		if err != nil {
-			fail(err.Error())
+			failErr(err)
 		}
 		if *dryRun {
 			renderDryRun(os.Stdout, res, *cfgPath)
@@ -198,7 +204,7 @@ Flags:
 
 	wrote, err := runImportTUI(parsed, writeFn)
 	if err != nil {
-		fail(err.Error())
+		failErr(err)
 	}
 	if !wrote {
 		fmt.Fprintln(os.Stderr, "import-pdf: no changes written")
@@ -215,7 +221,21 @@ func (r *repeatedString) Set(v string) error {
 	return nil
 }
 
+// importRep is the diagnostics reporter for the import-pdf command,
+// set at the top of runImport. Both fail and failErr route through it
+// so import errors get the same banner + verbose treatment as the rest
+// of the CLI.
+var importRep *diag.Reporter
+
 func fail(msg string) {
-	fmt.Fprintln(os.Stderr, "import-pdf: "+msg)
-	os.Exit(1)
+	failErr(errors.New(msg))
+}
+
+// failErr reports a real error (preserving its %w chain for verbose
+// mode) and exits 1.
+func failErr(err error) {
+	if importRep == nil {
+		importRep = newReporter("import-pdf")
+	}
+	importRep.Fatal(1, err)
 }

--- a/cmd/gophertrunk/main.go
+++ b/cmd/gophertrunk/main.go
@@ -14,6 +14,7 @@ import (
 	"syscall"
 
 	"github.com/MattCheramie/GopherTrunk/internal/config"
+	"github.com/MattCheramie/GopherTrunk/internal/diag"
 	gtlog "github.com/MattCheramie/GopherTrunk/internal/log"
 	"github.com/MattCheramie/GopherTrunk/internal/sdr"
 	// Pure-Go SDR drivers. Each registers itself under its canonical
@@ -98,24 +99,29 @@ func runDaemon(args []string) {
 	wantTUI := fs.Bool("tui", false, "launch the in-process operator TUI after the daemon comes up")
 	wantWeb := fs.Bool("web", false, "open the bundled web UI in the system browser after the daemon comes up")
 	wantHL := fs.Bool("headless", false, "skip the launcher prompt; daemon runs silent (default for non-TTY stdin)")
+	verboseFlag := fs.Bool("verbose-errors", false, "print full error chain + stack on failures (also set via diagnostics.verbose_errors or GOPHERTRUNK_VERBOSE_ERRORS)")
 	// IQ capture diagnostic — taps a live SDR's iqtap broker and writes
 	// raw IQ samples to a file for offline analysis. Used to capture a
 	// reproducible fixture for replay (issue #402).
 	iqCapture := fs.String("iq-capture", "", "capture raw IQ from a live SDR for offline analysis (issue #402). Format: serial=<s>,path=<file>,seconds=<n>[,format=u8|f32] (default format=f32, GNU Radio cfile)")
 	_ = fs.Parse(args)
 
+	// Resolve verbose-error reporting from the flag now (config folds in
+	// below, env was already picked up at package init) so every error
+	// site in runDaemon routes through the shared diagnostics reporter.
+	resolveVerbose(*verboseFlag, false)
+	rep := newReporter("")
+
 	// Parse the iq-capture spec early so a typo doesn't blow up after
 	// the daemon's been running for 10 seconds.
 	captureSpec, err := parseIQCaptureSpec(*iqCapture)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
-		os.Exit(2)
+		rep.Fatal(2, err)
 	}
 
 	mode, err := pickLaunchMode(*wantTUI, *wantWeb, *wantHL)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "launcher: %v\n", err)
-		os.Exit(2)
+		rep.Fatalf(2, "launcher: %v", err)
 	}
 
 	// No -config passed: walk the standard discovery precedence
@@ -128,8 +134,7 @@ func runDaemon(args []string) {
 	if *cfgPath == "" {
 		discovered, err := config.DiscoverWith(config.DiscoverOptions{Pick: pickConfigInteractive})
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "config: %v\n", err)
-			os.Exit(2)
+			rep.Fatalf(2, "config: %v", err)
 		}
 		if discovered != "" {
 			fmt.Fprintf(os.Stderr, "config: loaded %s\n", discovered)
@@ -142,16 +147,20 @@ func runDaemon(args []string) {
 	// daemon to run. Exit with EX_CONFIG so service managers can
 	// distinguish "missing config" from generic failures.
 	if *cfgPath == "" && !stdinIsTerminal() && os.Getenv("GOPHERTRUNK_CONFIG") == "" {
-		fmt.Fprintln(os.Stderr,
+		rep.Fatalf(78,
 			"gophertrunk: no config found and stdin is not a TTY; pass -config or set GOPHERTRUNK_CONFIG (see docs/quickstart.md)")
-		os.Exit(78)
 	}
 
 	cfg, err := config.Load(*cfgPath)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "config: %v\n", err)
-		os.Exit(2)
+		rep.Fatalf(2, "config: %v", err)
 	}
+	// Fold the config's verbose-error setting into the resolved value so
+	// the flag/env still win but config.diagnostics.verbose_errors takes
+	// effect for everything from here on (daemon, API, gRPC).
+	resolveVerbose(*verboseFlag, cfg.Diagnostics.VerboseErrors)
+	cfg.Diagnostics.VerboseErrors = verboseErrors
+	rep.Verbose = verboseErrors
 	if *logLevel != "" {
 		cfg.Log.Level = *logLevel
 	}
@@ -166,21 +175,18 @@ func runDaemon(args []string) {
 	// daemon: an operator who passed -tui or -web with no HTTP API
 	// in config should hear about it now, not after engine init.
 	if (mode == launchTUI || mode == launchWeb) && cfg.API.HTTPAddr == "" {
-		fmt.Fprintf(os.Stderr,
-			"launcher: -%s requires api.http_addr in config (current value is empty)\n",
+		rep.Fatalf(2,
+			"launcher: -%s requires api.http_addr in config (current value is empty)",
 			launchModeFlag(mode))
-		os.Exit(2)
 	}
 	if mode == launchTUI && (!stdinIsTerminal() || !stdoutIsTerminal()) {
-		fmt.Fprintln(os.Stderr,
+		rep.Fatalf(2,
 			"launcher: -tui requires an interactive terminal (stdin + stdout TTY); use -web or -headless")
-		os.Exit(2)
 	}
 
 	preflightWarnings, err := preflight(cfg)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
-		os.Exit(2)
+		rep.Fatal(2, err)
 	}
 
 	// Single-instance lock. Two daemons aimed at the same config
@@ -189,8 +195,7 @@ func runDaemon(args []string) {
 	// touches the radio.
 	releaseLock, err := acquireInstanceLock(*cfgPath)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
-		os.Exit(1)
+		rep.Fatal(1, err)
 	}
 	defer releaseLock()
 
@@ -215,8 +220,14 @@ func runDaemon(args []string) {
 
 	d, err := NewDaemonWithPath(cfg, *cfgPath, version.String(), logger)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "daemon init: %v\n", err)
-		os.Exit(1)
+		rep.Fatal(1, fmt.Errorf("daemon init: %w", err))
+	}
+	// One-time diagnostics banner in the daemon log so a captured log
+	// carries the same macro context an error banner would — including
+	// the dongles the now-open pool actually claimed. Suppressed by
+	// GOPHERTRUNK_QUIET_BANNER (CI/tests).
+	if banner := diag.FormatBannerPlain(d.newDiagCollector().SysInfo()); banner != "" {
+		logger.Info("diagnostics", "banner", banner)
 	}
 	for _, w := range preflightWarnings {
 		d.addWarning(w)
@@ -246,8 +257,7 @@ func runDaemon(args []string) {
 	case <-d.Ready():
 	case err := <-runErr:
 		if err != nil && !errors.Is(err, context.Canceled) {
-			fmt.Fprintf(os.Stderr, "daemon: %v\n", err)
-			os.Exit(1)
+			rep.Fatal(1, fmt.Errorf("daemon: %w", err))
 		}
 		return
 	}
@@ -260,10 +270,9 @@ func runDaemon(args []string) {
 	if captureSpec.Serial != "" {
 		br := d.IQBroker(captureSpec.Serial)
 		if br == nil {
-			fmt.Fprintf(os.Stderr,
-				"iq-capture: no SDR with serial %q in pool (have: %v)\n",
+			rep.Fatalf(2,
+				"iq-capture: no SDR with serial %q in pool (have: %v)",
 				captureSpec.Serial, d.IQBrokerSerials())
-			os.Exit(2)
 		}
 		go func() {
 			if err := runIQCapture(ctx, br, captureSpec, logger); err != nil &&
@@ -279,7 +288,7 @@ func runDaemon(args []string) {
 	// Wait for the daemon goroutine to finish (SIGINT/SIGTERM →
 	// ctx cancels → Run unwinds → returns).
 	if err := <-runErr; err != nil && !errors.Is(err, context.Canceled) {
-		logger.Warn("daemon exited", "err", err)
+		logErr(logger, verboseErrors, "daemon exited", err)
 		os.Exit(1)
 	}
 }

--- a/cmd/gophertrunk/replay.go
+++ b/cmd/gophertrunk/replay.go
@@ -44,6 +44,7 @@ import (
 // reproducible test fixture.
 func runReplay(args []string) {
 	fs := flag.NewFlagSet("replay", flag.ExitOnError)
+	verboseFlag := fs.Bool("verbose-errors", false, "print full error chain + stack on failures")
 	in := fs.String("in", "", "raw IQ input file (required)")
 	format := fs.String("format", "u8", "sample format: u8 (rtl_sdr 8-bit unsigned interleaved IQ) | f32 (GNU Radio cfile, interleaved float32)")
 	sampleRate := fs.Float64("sample-rate", 2_400_000, "IQ sample rate in Hz")
@@ -108,36 +109,32 @@ FLAGS:`)
 		fs.PrintDefaults()
 	}
 	_ = fs.Parse(args)
+	resolveVerbose(*verboseFlag, false)
+	rep := newReporter("replay")
 
 	if *in == "" {
-		fmt.Fprintln(os.Stderr, "replay: -in is required")
 		fs.Usage()
-		os.Exit(2)
+		rep.Fatalf(2, "-in is required")
 	}
 	if *sampleRate <= 0 {
-		fmt.Fprintln(os.Stderr, "replay: -sample-rate must be > 0")
-		os.Exit(2)
+		rep.Fatalf(2, "-sample-rate must be > 0")
 	}
 	demodMode, ok := p25phase1rx.ParseDemodMode(*demod)
 	if !ok {
-		fmt.Fprintf(os.Stderr, "replay: unknown -demod %q (want c4fm or cqpsk)\n", *demod)
-		os.Exit(2)
+		rep.Fatalf(2, "unknown -demod %q (want c4fm or cqpsk)", *demod)
 	}
 	if *nidSearchSpan <= 0 {
-		fmt.Fprintln(os.Stderr, "replay: -nid-search-span must be > 0")
-		os.Exit(2)
+		rep.Fatalf(2, "-nid-search-span must be > 0")
 	}
 
 	decode, bytesPerSample, err := pickSampleDecoder(*format)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, "replay:", err)
-		os.Exit(2)
+		rep.Fatal(2, err)
 	}
 
 	f, err := os.Open(*in)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "replay: open %s: %v\n", *in, err)
-		os.Exit(1)
+		rep.Fatal(1, fmt.Errorf("open %s: %w", *in, err))
 	}
 	defer f.Close()
 
@@ -149,8 +146,7 @@ FLAGS:`)
 	if *autoTune {
 		est, err := estimateCaptureCarrierHz(f, decode, bytesPerSample, *sampleRate)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "replay: auto-tune failed: %v\n", err)
-			os.Exit(1)
+			rep.Fatal(1, fmt.Errorf("auto-tune failed: %w", err))
 		}
 		tuneHz = est
 		fmt.Fprintf(os.Stderr, "replay: auto-tune  carrier_offset_hz=%.1f\n", tuneHz)
@@ -373,8 +369,7 @@ FLAGS:`)
 			break
 		}
 		if rerr != nil {
-			fmt.Fprintf(os.Stderr, "replay: read %s: %v\n", *in, rerr)
-			os.Exit(1)
+			rep.Fatal(1, fmt.Errorf("read %s: %w", *in, rerr))
 		}
 	}
 

--- a/cmd/gophertrunk/tui.go
+++ b/cmd/gophertrunk/tui.go
@@ -28,14 +28,16 @@ func runTUI(args []string) {
 	write := fs.Bool("write", false, "enable mutation keybindings (end call, set priority/lockout, retention sweep, tone reset). Daemon must also accept mutations (api.auth.mode or legacy api.allow_mutations).")
 	token := fs.String("token", "", "API bearer token (sent as Authorization: Bearer <token>); falls back to GOPHERTRUNK_API_TOKEN")
 	tokenFile := fs.String("token-file", "", "path to a file containing the API bearer token; re-read on every request so daemon-side rotation works without a restart")
+	verboseFlag := fs.Bool("verbose-errors", false, "print full error chain + stack on failures")
 	_ = fs.Parse(args)
+	resolveVerbose(*verboseFlag, false)
+	rep := newReporter("tui")
 
 	cli := client.New(*server, *timeout, *insecure)
 	// Resolve token: -token-file > -token > GOPHERTRUNK_API_TOKEN
 	if *tokenFile != "" {
 		if err := cli.SetTokenFile(*tokenFile); err != nil {
-			fmt.Fprintf(os.Stderr, "tui: -token-file: %v\n", err)
-			os.Exit(1)
+			rep.Fatal(1, fmt.Errorf("-token-file: %w", err))
 		}
 	} else if *token != "" {
 		cli.SetToken(*token)
@@ -46,7 +48,6 @@ func runTUI(args []string) {
 	m := tui.New(cli, tui.Options{NoColor: *noColor, Write: *write})
 	prog := tea.NewProgram(m, tea.WithAltScreen(), tea.WithMouseCellMotion())
 	if _, err := prog.Run(); err != nil {
-		fmt.Fprintf(os.Stderr, "tui: %v\n", err)
-		os.Exit(1)
+		rep.Fatal(1, err)
 	}
 }

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -15,6 +15,18 @@ log:
   #   path: "logs/messages.log"
   #   max_size_mb: 16          # rotates to messages.log.1 past this
 
+# diagnostics — error-reporting verbosity. Every error is prefixed with
+# a diagnostics banner (version, OS, system specs, detected dongles).
+diagnostics:
+  # When true, errors print the full wrapped chain + a goroutine stack
+  # dump (no interactive prompt), and HTTP/gRPC error responses include
+  # the banner + trace. That exposes host + dongle info (hostname,
+  # kernel, serials) to API clients, so only enable it on trusted
+  # networks. When false (default), the CLI instead offers the full
+  # trace interactively on a terminal. Override at runtime with
+  # -verbose-errors or GOPHERTRUNK_VERBOSE_ERRORS=1.
+  verbose_errors: false
+
 api:
   http_addr: "127.0.0.1:8080"   # HTTP REST + SSE + WebSocket
   grpc_addr: "127.0.0.1:50051"  # gRPC

--- a/internal/api/diag.go
+++ b/internal/api/diag.go
@@ -45,13 +45,13 @@ type DiagProvider interface {
 // the client disconnects or the device disappears.
 func (s *Server) handleDiagStream(w http.ResponseWriter, r *http.Request) {
 	if s.diag == nil {
-		writeError(w, http.StatusServiceUnavailable, "diag subsystem not enabled")
+		s.writeError(w, http.StatusServiceUnavailable, "diag subsystem not enabled")
 		return
 	}
 	q := r.URL.Query()
 	serial := q.Get("device")
 	if serial == "" {
-		writeError(w, http.StatusBadRequest, "device query parameter is required")
+		s.writeError(w, http.StatusBadRequest, "device query parameter is required")
 		return
 	}
 	rate := uint32(parseIntQuery(q, "rate", 2000, 100, 20000))

--- a/internal/api/diag_banner_test.go
+++ b/internal/api/diag_banner_test.go
@@ -1,0 +1,109 @@
+package api
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	gtdiag "github.com/MattCheramie/GopherTrunk/internal/diag"
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+)
+
+func newDiagBannerTestServer(t *testing.T, verbose bool) *httptest.Server {
+	t.Helper()
+	t.Setenv(gtdiag.QuietBannerEnv, "") // banner must render in these tests
+	bus := events.NewBus(8)
+	t.Cleanup(bus.Close)
+	srv, err := NewServer(ServerOptions{
+		Addr:          "127.0.0.1:0",
+		Bus:           bus,
+		Diagnostics:   gtdiag.NewCollectorWithDongles(nil, nil),
+		VerboseErrors: verbose,
+	})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	ts := httptest.NewServer(srv.routes())
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+// decodeErrEnvelope reads a JSON error body into its fields.
+func decodeErrEnvelope(t *testing.T, r io.Reader) (msg string, diag map[string]any) {
+	t.Helper()
+	var body struct {
+		Error string         `json:"error"`
+		Diag  map[string]any `json:"diag"`
+	}
+	if err := json.NewDecoder(r).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return body.Error, body.Diag
+}
+
+func TestErrorEnvelopeTerseWhenVerboseOff(t *testing.T) {
+	ts := newDiagBannerTestServer(t, false)
+	// An unknown path under a known prefix; pick a 404-producing route.
+	resp, err := http.Get(ts.URL + "/api/v1/systems/does-not-exist")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	msg, diag := decodeErrEnvelope(t, resp.Body)
+	if msg == "" {
+		t.Errorf("expected an error message")
+	}
+	if diag != nil {
+		t.Errorf("verbose off should omit diag block, got %v", diag)
+	}
+}
+
+func TestErrorEnvelopeIncludesBannerWhenVerboseOn(t *testing.T) {
+	ts := newDiagBannerTestServer(t, true)
+	resp, err := http.Get(ts.URL + "/api/v1/systems/does-not-exist")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	_, diag := decodeErrEnvelope(t, resp.Body)
+	if diag == nil {
+		t.Fatalf("verbose on should include diag block")
+	}
+	if banner, _ := diag["banner"].(string); banner == "" {
+		t.Errorf("diag block missing banner: %v", diag)
+	}
+}
+
+func TestDiagBannerEndpointGating(t *testing.T) {
+	// Verbose off: bare GET is forbidden, ?verbose=1 (loopback, auth
+	// auto) is allowed.
+	ts := newDiagBannerTestServer(t, false)
+	resp, err := http.Get(ts.URL + "/api/v1/diag/banner")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Errorf("bare banner GET status = %d, want 403", resp.StatusCode)
+	}
+
+	resp2, err := http.Get(ts.URL + "/api/v1/diag/banner?verbose=1")
+	if err != nil {
+		t.Fatalf("GET verbose: %v", err)
+	}
+	defer resp2.Body.Close()
+	if resp2.StatusCode != http.StatusOK {
+		t.Errorf("?verbose=1 banner status = %d, want 200", resp2.StatusCode)
+	}
+	var body struct {
+		Banner string `json:"banner"`
+	}
+	if err := json.NewDecoder(resp2.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Banner == "" {
+		t.Errorf("expected a banner string")
+	}
+}

--- a/internal/api/grpc.go
+++ b/internal/api/grpc.go
@@ -6,14 +6,17 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
+	"strings"
 	"time"
 
 	apiv1 "github.com/MattCheramie/GopherTrunk/internal/api/pb/v1"
+	gtdiag "github.com/MattCheramie/GopherTrunk/internal/diag"
 	"github.com/MattCheramie/GopherTrunk/internal/trunking"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/keepalive"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 )
 
@@ -40,6 +43,9 @@ type GRPCServer struct {
 	audio        *AudioPublisher
 	log          *slog.Logger
 
+	diagnostics   *gtdiag.Collector
+	verboseErrors bool
+
 	srv *grpc.Server
 }
 
@@ -65,6 +71,13 @@ type GRPCServerOptions struct {
 	// returns Unavailable rather than streaming frames.
 	Audio *AudioPublisher
 	Log   *slog.Logger
+	// Diagnostics is the shared error-diagnostics collector. When set
+	// with VerboseErrors (or a request carrying the gophertrunk-verbose
+	// metadata key), returned errors are decorated with the diagnostics
+	// banner + wrapped chain via a server interceptor.
+	Diagnostics *gtdiag.Collector
+	// VerboseErrors mirrors diagnostics.verbose_errors.
+	VerboseErrors bool
 	// TLSCert and TLSKey, when both non-empty, switch the gRPC
 	// server to TLS using credentials.NewServerTLSFromFile. Same
 	// disk-loaded-once semantics as the HTTP server's TLS support.
@@ -90,15 +103,17 @@ func NewGRPCServer(opts GRPCServerOptions) (*GRPCServer, error) {
 		opts.RIDs = trunking.NewRIDDB()
 	}
 	g := &GRPCServer{
-		addr:         opts.Addr,
-		systems:      append([]trunking.System(nil), opts.Systems...),
-		talkgroups:   opts.Talkgroups,
-		rids:         opts.RIDs,
-		affiliations: opts.Affiliations,
-		history:      opts.History,
-		engine:       opts.Engine,
-		audio:        opts.Audio,
-		log:          log,
+		addr:          opts.Addr,
+		systems:       append([]trunking.System(nil), opts.Systems...),
+		talkgroups:    opts.Talkgroups,
+		rids:          opts.RIDs,
+		affiliations:  opts.Affiliations,
+		history:       opts.History,
+		engine:        opts.Engine,
+		audio:         opts.Audio,
+		log:           log,
+		diagnostics:   opts.Diagnostics,
+		verboseErrors: opts.VerboseErrors,
 	}
 	// Keep-alive guards long-lived RPCs (StreamAudio in particular)
 	// against silently-dead peers — without server-side pings, a
@@ -119,6 +134,8 @@ func NewGRPCServer(opts GRPCServerOptions) (*GRPCServer, error) {
 	srvOpts := []grpc.ServerOption{
 		grpc.KeepaliveParams(keepaliveParams),
 		grpc.KeepaliveEnforcementPolicy(keepaliveEnforcement),
+		grpc.UnaryInterceptor(g.diagUnaryInterceptor),
+		grpc.StreamInterceptor(g.diagStreamInterceptor),
 	}
 	// TLS: same all-or-nothing semantics as the HTTP server.
 	if (opts.TLSCert == "") != (opts.TLSKey == "") {
@@ -137,6 +154,68 @@ func NewGRPCServer(opts GRPCServerOptions) (*GRPCServer, error) {
 	apiv1.RegisterRIDServiceServer(g.srv, g)
 	apiv1.RegisterAudioServiceServer(g.srv, g)
 	return g, nil
+}
+
+// diagUnaryInterceptor decorates a failing unary RPC's error with the
+// diagnostics banner + wrapped chain when verbose reporting is enabled
+// (config) or the caller opted in via the gophertrunk-verbose metadata
+// key. The status code is always preserved; only the message text is
+// extended, so existing clients that don't parse the suffix are
+// unaffected.
+func (g *GRPCServer) diagUnaryInterceptor(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+	resp, err := handler(ctx, req)
+	if err != nil {
+		return resp, g.decorateErr(ctx, err)
+	}
+	return resp, nil
+}
+
+// diagStreamInterceptor is the streaming-RPC analogue of
+// diagUnaryInterceptor.
+func (g *GRPCServer) diagStreamInterceptor(srv any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+	if err := handler(srv, ss); err != nil {
+		return g.decorateErr(ss.Context(), err)
+	}
+	return nil
+}
+
+// decorateErr appends the diagnostics banner + error chain to a gRPC
+// status message when verbose is on (or requested via metadata) and a
+// collector is wired. The original status code is retained.
+func (g *GRPCServer) decorateErr(ctx context.Context, err error) error {
+	if g.diagnostics == nil || !g.verboseRequested(ctx) {
+		return err
+	}
+	st, _ := status.FromError(err)
+	banner := gtdiag.FormatBannerPlain(g.diagnostics.SysInfo())
+	chain := gtdiag.Chain(err)
+	msg := st.Message()
+	if banner != "" {
+		msg += "\n\n" + banner
+	}
+	if len(chain) > 1 {
+		msg += "\n\nerror chain: " + strings.Join(chain, " <- ")
+	}
+	return status.Error(st.Code(), msg)
+}
+
+// verboseRequested reports whether verbose diagnostics should be
+// attached: either the daemon enabled them globally, or the caller set
+// the gophertrunk-verbose metadata key to a truthy value.
+func (g *GRPCServer) verboseRequested(ctx context.Context) bool {
+	if g.verboseErrors {
+		return true
+	}
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return false
+	}
+	for _, v := range md.Get("gophertrunk-verbose") {
+		if v == "1" || strings.EqualFold(v, "true") {
+			return true
+		}
+	}
+	return false
 }
 
 // Run binds the listener and serves until ctx cancels.

--- a/internal/api/grpc_diag_test.go
+++ b/internal/api/grpc_diag_test.go
@@ -1,0 +1,58 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	gtdiag "github.com/MattCheramie/GopherTrunk/internal/diag"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+func TestGRPCDecorateErrPreservesCodeAndGates(t *testing.T) {
+	t.Setenv(gtdiag.QuietBannerEnv, "") // banner must render
+	orig := status.Error(codes.NotFound, "system not found")
+
+	// Verbose off, no metadata → untouched.
+	g := &GRPCServer{diagnostics: gtdiag.NewCollectorWithDongles(nil, nil), verboseErrors: false}
+	if got := g.decorateErr(context.Background(), orig); got != orig {
+		t.Errorf("verbose off should return the original error, got %v", got)
+	}
+
+	// Verbose on → code preserved, banner appended.
+	g.verboseErrors = true
+	got := g.decorateErr(context.Background(), orig)
+	st, _ := status.FromError(got)
+	if st.Code() != codes.NotFound {
+		t.Errorf("code = %v, want NotFound", st.Code())
+	}
+	if !strings.Contains(st.Message(), "system not found") {
+		t.Errorf("original message lost: %q", st.Message())
+	}
+	if !strings.Contains(st.Message(), "GopherTrunk diagnostics") {
+		t.Errorf("banner not appended: %q", st.Message())
+	}
+}
+
+func TestGRPCVerboseRequestedViaMetadata(t *testing.T) {
+	g := &GRPCServer{diagnostics: gtdiag.NewCollectorWithDongles(nil, nil)}
+	if g.verboseRequested(context.Background()) {
+		t.Errorf("no metadata, verbose off → should be false")
+	}
+	ctx := metadata.NewIncomingContext(context.Background(),
+		metadata.Pairs("gophertrunk-verbose", "1"))
+	if !g.verboseRequested(ctx) {
+		t.Errorf("gophertrunk-verbose=1 metadata should enable verbose")
+	}
+}
+
+func TestGRPCDecorateNilCollector(t *testing.T) {
+	g := &GRPCServer{verboseErrors: true} // no collector
+	orig := errors.New("boom")
+	if got := g.decorateErr(context.Background(), orig); got != orig {
+		t.Errorf("nil collector should leave error untouched, got %v", got)
+	}
+}

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"time"
 
+	gtdiag "github.com/MattCheramie/GopherTrunk/internal/diag"
 	"github.com/MattCheramie/GopherTrunk/internal/sdr"
 )
 
@@ -78,6 +79,36 @@ func (s *Server) handleVersion(w http.ResponseWriter, _ *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]string{"version": v})
 }
 
+// handleDiagBanner serves the diagnostics banner + system snapshot on
+// demand so the web UI can show the same macro context (version, OS,
+// system specs, detected dongles) the CLI error banner shows. The
+// banner exposes host + dongle info, so it is gated: served to any
+// caller when diagnostics.verbose_errors is on, otherwise only when
+// the request opts in with ?verbose=1 AND is authorized (the same
+// trust level the mutation gate grants). Returns 404 when no
+// diagnostics collector is wired.
+func (s *Server) handleDiagBanner(w http.ResponseWriter, r *http.Request) {
+	if s.diagnostics == nil {
+		s.writeError(w, http.StatusNotFound, "diagnostics not available")
+		return
+	}
+	if !s.verboseErrors {
+		if r.URL.Query().Get("verbose") != "1" {
+			s.writeError(w, http.StatusForbidden, "diagnostics banner is restricted; pass ?verbose=1 or enable diagnostics.verbose_errors")
+			return
+		}
+		if status, reason := s.auth.authorize(r); status != 0 {
+			s.writeError(w, status, reason)
+			return
+		}
+	}
+	si := s.diagnostics.SysInfo()
+	writeJSON(w, http.StatusOK, map[string]any{
+		"banner":  gtdiag.FormatBannerPlain(si),
+		"sysinfo": si,
+	})
+}
+
 func (s *Server) handleListSystems(w http.ResponseWriter, _ *http.Request) {
 	out := make([]SystemDTO, 0, len(s.systems))
 	for _, sys := range s.systems {
@@ -94,7 +125,7 @@ func (s *Server) handleGetSystem(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	writeError(w, http.StatusNotFound, "system not found")
+	s.writeError(w, http.StatusNotFound, "system not found")
 }
 
 func (s *Server) handleListTalkgroups(w http.ResponseWriter, _ *http.Request) {
@@ -110,12 +141,12 @@ func (s *Server) handleGetTalkgroup(w http.ResponseWriter, r *http.Request) {
 	idStr := r.PathValue("id")
 	id, err := strconv.ParseUint(idStr, 10, 32)
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "invalid talkgroup id")
+		s.writeError(w, http.StatusBadRequest, "invalid talkgroup id")
 		return
 	}
 	tg := s.talkgroups.Lookup(uint32(id))
 	if tg == nil {
-		writeError(w, http.StatusNotFound, "talkgroup not found")
+		s.writeError(w, http.StatusNotFound, "talkgroup not found")
 		return
 	}
 	writeJSON(w, http.StatusOK, talkgroupToDTO(tg))
@@ -144,7 +175,7 @@ func (s *Server) handleActiveCalls(w http.ResponseWriter, _ *http.Request) {
 //	?only_ended=true    skip calls that haven't ended
 func (s *Server) handleCallHistory(w http.ResponseWriter, r *http.Request) {
 	if s.history == nil {
-		writeError(w, http.StatusServiceUnavailable, "call log persistence is not enabled")
+		s.writeError(w, http.StatusServiceUnavailable, "call log persistence is not enabled")
 		return
 	}
 	q := r.URL.Query()
@@ -155,7 +186,7 @@ func (s *Server) handleCallHistory(w http.ResponseWriter, r *http.Request) {
 	if v := q.Get("group_id"); v != "" {
 		n, err := strconv.ParseUint(v, 10, 32)
 		if err != nil {
-			writeError(w, http.StatusBadRequest, "invalid group_id")
+			s.writeError(w, http.StatusBadRequest, "invalid group_id")
 			return
 		}
 		f.GroupID = uint32(n)
@@ -163,7 +194,7 @@ func (s *Server) handleCallHistory(w http.ResponseWriter, r *http.Request) {
 	if v := q.Get("since"); v != "" {
 		t, err := time.Parse(time.RFC3339, v)
 		if err != nil {
-			writeError(w, http.StatusBadRequest, "invalid since (want RFC3339)")
+			s.writeError(w, http.StatusBadRequest, "invalid since (want RFC3339)")
 			return
 		}
 		f.Since = t
@@ -171,7 +202,7 @@ func (s *Server) handleCallHistory(w http.ResponseWriter, r *http.Request) {
 	if v := q.Get("until"); v != "" {
 		t, err := time.Parse(time.RFC3339, v)
 		if err != nil {
-			writeError(w, http.StatusBadRequest, "invalid until (want RFC3339)")
+			s.writeError(w, http.StatusBadRequest, "invalid until (want RFC3339)")
 			return
 		}
 		f.Until = t
@@ -179,7 +210,7 @@ func (s *Server) handleCallHistory(w http.ResponseWriter, r *http.Request) {
 	if v := q.Get("limit"); v != "" {
 		n, err := strconv.Atoi(v)
 		if err != nil || n < 0 {
-			writeError(w, http.StatusBadRequest, "invalid limit")
+			s.writeError(w, http.StatusBadRequest, "invalid limit")
 			return
 		}
 		if n > 1000 {
@@ -193,7 +224,7 @@ func (s *Server) handleCallHistory(w http.ResponseWriter, r *http.Request) {
 	rows, err := s.history.History(r.Context(), f)
 	if err != nil {
 		s.log.Warn("api: history query failed", "err", err)
-		writeError(w, http.StatusInternalServerError, "history query failed")
+		s.writeError(w, http.StatusInternalServerError, "history query failed")
 		return
 	}
 	if rows == nil {

--- a/internal/api/handlers_adsb.go
+++ b/internal/api/handlers_adsb.go
@@ -75,7 +75,7 @@ func aircraftReportToDTO(r storage.AircraftReport) AircraftReportDTO {
 // isn't wired.
 func (s *Server) handleADSBAircraft(w http.ResponseWriter, r *http.Request) {
 	if s.adsb == nil {
-		writeError(w, http.StatusServiceUnavailable, "adsb subsystem not enabled")
+		s.writeError(w, http.StatusServiceUnavailable, "adsb subsystem not enabled")
 		return
 	}
 	limit := 200
@@ -87,7 +87,7 @@ func (s *Server) handleADSBAircraft(w http.ResponseWriter, r *http.Request) {
 	rows, err := s.adsb.RecentAircraftReports(limit)
 	if err != nil {
 		s.log.Error("api: adsb aircraft", "err", err)
-		writeError(w, http.StatusInternalServerError, "query failed")
+		s.writeError(w, http.StatusInternalServerError, "query failed")
 		return
 	}
 	out := make([]AircraftReportDTO, 0, len(rows))
@@ -104,7 +104,7 @@ func (s *Server) handleADSBAircraft(w http.ResponseWriter, r *http.Request) {
 // (default 300 s, max 3600 s).
 func (s *Server) handleADSBAircraftCurrent(w http.ResponseWriter, r *http.Request) {
 	if s.adsb == nil {
-		writeError(w, http.StatusServiceUnavailable, "adsb subsystem not enabled")
+		s.writeError(w, http.StatusServiceUnavailable, "adsb subsystem not enabled")
 		return
 	}
 	maxAge := 300 * time.Second
@@ -119,7 +119,7 @@ func (s *Server) handleADSBAircraftCurrent(w http.ResponseWriter, r *http.Reques
 	rows, err := s.adsb.CurrentAircraft(maxAge)
 	if err != nil {
 		s.log.Error("api: adsb aircraft current", "err", err)
-		writeError(w, http.StatusInternalServerError, "query failed")
+		s.writeError(w, http.StatusInternalServerError, "query failed")
 		return
 	}
 	out := make([]AircraftReportDTO, 0, len(rows))

--- a/internal/api/handlers_ais.go
+++ b/internal/api/handlers_ais.go
@@ -71,7 +71,7 @@ func aisMessageToDTO(m storage.AISMessage) AISMessageDTO {
 // isn't wired (daemon started without storage.path).
 func (s *Server) handleAISMessages(w http.ResponseWriter, r *http.Request) {
 	if s.ais == nil {
-		writeError(w, http.StatusServiceUnavailable, "ais subsystem not enabled")
+		s.writeError(w, http.StatusServiceUnavailable, "ais subsystem not enabled")
 		return
 	}
 	limit := 200
@@ -83,7 +83,7 @@ func (s *Server) handleAISMessages(w http.ResponseWriter, r *http.Request) {
 	rows, err := s.ais.RecentAISMessages(limit)
 	if err != nil {
 		s.log.Error("api: ais messages", "err", err)
-		writeError(w, http.StatusInternalServerError, "query failed")
+		s.writeError(w, http.StatusInternalServerError, "query failed")
 		return
 	}
 	out := make([]AISMessageDTO, 0, len(rows))

--- a/internal/api/handlers_aprs.go
+++ b/internal/api/handlers_aprs.go
@@ -50,7 +50,7 @@ func aprsPacketToDTO(p storage.APRSPacket) APRSPacketDTO {
 // ?limit= (default 200, max 5000).
 func (s *Server) handleAPRSPackets(w http.ResponseWriter, r *http.Request) {
 	if s.aprs == nil {
-		writeError(w, http.StatusServiceUnavailable, "aprs subsystem not enabled")
+		s.writeError(w, http.StatusServiceUnavailable, "aprs subsystem not enabled")
 		return
 	}
 	limit := 200
@@ -62,7 +62,7 @@ func (s *Server) handleAPRSPackets(w http.ResponseWriter, r *http.Request) {
 	rows, err := s.aprs.RecentAPRSPackets(limit)
 	if err != nil {
 		s.log.Error("api: aprs packets", "err", err)
-		writeError(w, http.StatusInternalServerError, "query failed")
+		s.writeError(w, http.StatusInternalServerError, "query failed")
 		return
 	}
 	out := make([]APRSPacketDTO, 0, len(rows))

--- a/internal/api/handlers_audio.go
+++ b/internal/api/handlers_audio.go
@@ -51,7 +51,7 @@ type audioPatchRequest struct {
 //	503 if the daemon doesn't have an AudioController wired
 func (s *Server) handleAudioStatus(w http.ResponseWriter, _ *http.Request) {
 	if s.audio == nil {
-		writeError(w, http.StatusServiceUnavailable, "audio not wired")
+		s.writeError(w, http.StatusServiceUnavailable, "audio not wired")
 		return
 	}
 	writeJSON(w, http.StatusOK, audioStatusDTO(s.audio))
@@ -72,23 +72,23 @@ func (s *Server) handleAudioStatus(w http.ResponseWriter, _ *http.Request) {
 //	503 if the daemon doesn't have an AudioController wired
 func (s *Server) handleAudioPatch(w http.ResponseWriter, r *http.Request) {
 	if s.audio == nil {
-		writeError(w, http.StatusServiceUnavailable, "audio not wired")
+		s.writeError(w, http.StatusServiceUnavailable, "audio not wired")
 		return
 	}
 	var req audioPatchRequest
 	if r.Body != nil && r.ContentLength != 0 {
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil && err != io.EOF {
-			writeError(w, http.StatusBadRequest, "invalid json body")
+			s.writeError(w, http.StatusBadRequest, "invalid json body")
 			return
 		}
 	}
 	if req.Volume == nil && req.Muted == nil && req.Recording == nil {
-		writeError(w, http.StatusBadRequest, "supply volume, muted, and/or recording_enabled")
+		s.writeError(w, http.StatusBadRequest, "supply volume, muted, and/or recording_enabled")
 		return
 	}
 	if req.Volume != nil {
 		if *req.Volume < 0 || *req.Volume > 1 {
-			writeError(w, http.StatusBadRequest, "volume must be between 0.0 and 1.0")
+			s.writeError(w, http.StatusBadRequest, "volume must be between 0.0 and 1.0")
 			return
 		}
 		s.audio.SetVolume(*req.Volume)

--- a/internal/api/handlers_audio_stream.go
+++ b/internal/api/handlers_audio_stream.go
@@ -28,12 +28,12 @@ import (
 // torn down mid-call.
 func (s *Server) handleAudioStream(w http.ResponseWriter, r *http.Request) {
 	if s.audioPub == nil {
-		writeError(w, http.StatusServiceUnavailable, "audio stream not wired")
+		s.writeError(w, http.StatusServiceUnavailable, "audio stream not wired")
 		return
 	}
 	flusher, ok := w.(http.Flusher)
 	if !ok {
-		writeError(w, http.StatusInternalServerError, "streaming not supported")
+		s.writeError(w, http.StatusInternalServerError, "streaming not supported")
 		return
 	}
 	_ = http.NewResponseController(w).SetWriteDeadline(time.Time{})

--- a/internal/api/handlers_bookmarks.go
+++ b/internal/api/handlers_bookmarks.go
@@ -71,13 +71,13 @@ func dtoToBookmark(d BookmarkDTO) storage.Bookmark {
 // handleListBookmarks answers GET /api/v1/bookmarks. Open route.
 func (s *Server) handleListBookmarks(w http.ResponseWriter, _ *http.Request) {
 	if s.bookmarks == nil {
-		writeError(w, http.StatusServiceUnavailable, "bookmarks store not enabled")
+		s.writeError(w, http.StatusServiceUnavailable, "bookmarks store not enabled")
 		return
 	}
 	rows, err := s.bookmarks.ListBookmarks()
 	if err != nil {
 		s.log.Error("api: list bookmarks", "err", err)
-		writeError(w, http.StatusInternalServerError, "list failed")
+		s.writeError(w, http.StatusInternalServerError, "list failed")
 		return
 	}
 	out := make([]BookmarkDTO, 0, len(rows))
@@ -90,17 +90,17 @@ func (s *Server) handleListBookmarks(w http.ResponseWriter, _ *http.Request) {
 // handleCreateBookmark answers POST /api/v1/bookmarks. Gated.
 func (s *Server) handleCreateBookmark(w http.ResponseWriter, r *http.Request) {
 	if s.bookmarks == nil {
-		writeError(w, http.StatusServiceUnavailable, "bookmarks store not enabled")
+		s.writeError(w, http.StatusServiceUnavailable, "bookmarks store not enabled")
 		return
 	}
 	var body BookmarkDTO
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		s.writeError(w, http.StatusBadRequest, "invalid JSON body")
 		return
 	}
 	created, err := s.bookmarks.CreateBookmark(dtoToBookmark(body))
 	if err != nil {
-		writeError(w, http.StatusBadRequest, err.Error())
+		s.writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 	writeJSON(w, http.StatusCreated, bookmarkToDTO(created))
@@ -109,27 +109,27 @@ func (s *Server) handleCreateBookmark(w http.ResponseWriter, r *http.Request) {
 // handleUpdateBookmark answers PATCH /api/v1/bookmarks/{id}. Gated.
 func (s *Server) handleUpdateBookmark(w http.ResponseWriter, r *http.Request) {
 	if s.bookmarks == nil {
-		writeError(w, http.StatusServiceUnavailable, "bookmarks store not enabled")
+		s.writeError(w, http.StatusServiceUnavailable, "bookmarks store not enabled")
 		return
 	}
 	id, err := strconv.ParseInt(r.PathValue("id"), 10, 64)
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "bad id")
+		s.writeError(w, http.StatusBadRequest, "bad id")
 		return
 	}
 	var body BookmarkDTO
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		s.writeError(w, http.StatusBadRequest, "invalid JSON body")
 		return
 	}
 	body.ID = id
 	updated, err := s.bookmarks.UpdateBookmark(dtoToBookmark(body))
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			writeError(w, http.StatusNotFound, "bookmark not found")
+			s.writeError(w, http.StatusNotFound, "bookmark not found")
 			return
 		}
-		writeError(w, http.StatusBadRequest, err.Error())
+		s.writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 	writeJSON(w, http.StatusOK, bookmarkToDTO(updated))
@@ -138,21 +138,21 @@ func (s *Server) handleUpdateBookmark(w http.ResponseWriter, r *http.Request) {
 // handleDeleteBookmark answers DELETE /api/v1/bookmarks/{id}. Gated.
 func (s *Server) handleDeleteBookmark(w http.ResponseWriter, r *http.Request) {
 	if s.bookmarks == nil {
-		writeError(w, http.StatusServiceUnavailable, "bookmarks store not enabled")
+		s.writeError(w, http.StatusServiceUnavailable, "bookmarks store not enabled")
 		return
 	}
 	id, err := strconv.ParseInt(r.PathValue("id"), 10, 64)
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "bad id")
+		s.writeError(w, http.StatusBadRequest, "bad id")
 		return
 	}
 	if err := s.bookmarks.DeleteBookmark(id); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			writeError(w, http.StatusNotFound, "bookmark not found")
+			s.writeError(w, http.StatusNotFound, "bookmark not found")
 			return
 		}
 		s.log.Error("api: delete bookmark", "err", err)
-		writeError(w, http.StatusInternalServerError, "delete failed")
+		s.writeError(w, http.StatusInternalServerError, "delete failed")
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)

--- a/internal/api/handlers_dsc.go
+++ b/internal/api/handlers_dsc.go
@@ -59,7 +59,7 @@ func dscMessageToDTO(m storage.DSCMessage) DSCMessageDTO {
 // isn't wired (daemon started without storage.path).
 func (s *Server) handleDSCMessages(w http.ResponseWriter, r *http.Request) {
 	if s.dsc == nil {
-		writeError(w, http.StatusServiceUnavailable, "dsc subsystem not enabled")
+		s.writeError(w, http.StatusServiceUnavailable, "dsc subsystem not enabled")
 		return
 	}
 	limit := 200
@@ -71,7 +71,7 @@ func (s *Server) handleDSCMessages(w http.ResponseWriter, r *http.Request) {
 	rows, err := s.dsc.RecentDSCMessages(limit)
 	if err != nil {
 		s.log.Error("api: dsc messages", "err", err)
-		writeError(w, http.StatusInternalServerError, "query failed")
+		s.writeError(w, http.StatusInternalServerError, "query failed")
 		return
 	}
 	out := make([]DSCMessageDTO, 0, len(rows))

--- a/internal/api/handlers_import.go
+++ b/internal/api/handlers_import.go
@@ -167,19 +167,19 @@ func randomID(n int) string {
 // /api/v1/import/{id}/commit to finalise.
 func (s *Server) handleImportUpload(w http.ResponseWriter, r *http.Request) {
 	if s.importer == nil {
-		writeError(w, http.StatusServiceUnavailable, "import: not wired (daemon started without a -config file)")
+		s.writeError(w, http.StatusServiceUnavailable, "import: not wired (daemon started without a -config file)")
 		return
 	}
 	// 20 MiB max — generous for the largest RadioReference PDFs and
 	// a CSV bundle, while bounded enough that an accidental upload
 	// can't OOM the daemon.
 	if err := r.ParseMultipartForm(20 << 20); err != nil {
-		writeError(w, http.StatusBadRequest, "import: "+err.Error())
+		s.writeError(w, http.StatusBadRequest, "import: "+err.Error())
 		return
 	}
 	files := r.MultipartForm.File["files"]
 	if len(files) == 0 {
-		writeError(w, http.StatusBadRequest, "import: at least one `files` part is required")
+		s.writeError(w, http.StatusBadRequest, "import: at least one `files` part is required")
 		return
 	}
 
@@ -188,27 +188,27 @@ func (s *Server) handleImportUpload(w http.ResponseWriter, r *http.Request) {
 	for _, fh := range files {
 		kind := classifyImportFile(fh.Filename)
 		if kind == "" {
-			writeError(w, http.StatusBadRequest,
+			s.writeError(w, http.StatusBadRequest,
 				fmt.Sprintf("import: %q: unsupported extension (need .pdf or .csv)", fh.Filename))
 			return
 		}
 		f, err := fh.Open()
 		if err != nil {
-			writeError(w, http.StatusBadRequest,
+			s.writeError(w, http.StatusBadRequest,
 				fmt.Sprintf("import: %q: %v", fh.Filename, err))
 			return
 		}
 		body, err := io.ReadAll(f)
 		_ = f.Close()
 		if err != nil {
-			writeError(w, http.StatusBadRequest,
+			s.writeError(w, http.StatusBadRequest,
 				fmt.Sprintf("import: %q: %v", fh.Filename, err))
 			return
 		}
 		src := ImportSource{Filename: fh.Filename, Kind: kind, Data: body}
 		preview, err := s.importer.Parse(src)
 		if err != nil {
-			writeError(w, http.StatusBadRequest,
+			s.writeError(w, http.StatusBadRequest,
 				fmt.Sprintf("import: %q: %v", fh.Filename, err))
 			return
 		}
@@ -224,13 +224,13 @@ func (s *Server) handleImportUpload(w http.ResponseWriter, r *http.Request) {
 // staging entry is consumed on success.
 func (s *Server) handleImportCommit(w http.ResponseWriter, r *http.Request) {
 	if s.importer == nil {
-		writeError(w, http.StatusServiceUnavailable, "import: not wired")
+		s.writeError(w, http.StatusServiceUnavailable, "import: not wired")
 		return
 	}
 	id := r.PathValue("id")
 	entry, ok := s.imports.take(id)
 	if !ok {
-		writeError(w, http.StatusNotFound, "import: staging id not found (expired or already committed)")
+		s.writeError(w, http.StatusNotFound, "import: staging id not found (expired or already committed)")
 		return
 	}
 	force := r.URL.Query().Get("force") == "true"
@@ -240,7 +240,7 @@ func (s *Server) handleImportCommit(w http.ResponseWriter, r *http.Request) {
 		s.imports.mu.Lock()
 		s.imports.entries[id] = entry
 		s.imports.mu.Unlock()
-		writeError(w, http.StatusBadRequest, "import: "+err.Error())
+		s.writeError(w, http.StatusBadRequest, "import: "+err.Error())
 		return
 	}
 	writeJSON(w, http.StatusOK, result)
@@ -249,12 +249,12 @@ func (s *Server) handleImportCommit(w http.ResponseWriter, r *http.Request) {
 // handleImportDiscard drops a staged upload without committing.
 func (s *Server) handleImportDiscard(w http.ResponseWriter, r *http.Request) {
 	if s.importer == nil {
-		writeError(w, http.StatusServiceUnavailable, "import: not wired")
+		s.writeError(w, http.StatusServiceUnavailable, "import: not wired")
 		return
 	}
 	id := r.PathValue("id")
 	if _, ok := s.imports.take(id); !ok {
-		writeError(w, http.StatusNotFound, "import: staging id not found")
+		s.writeError(w, http.StatusNotFound, "import: staging id not found")
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)

--- a/internal/api/handlers_locations.go
+++ b/internal/api/handlers_locations.go
@@ -23,7 +23,7 @@ func (s *Server) handleLocations(w http.ResponseWriter, r *http.Request) {
 	}
 	fixes, err := s.locations.RecentLocations(limit)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "query locations: "+err.Error())
+		s.writeError(w, http.StatusInternalServerError, "query locations: "+err.Error())
 		return
 	}
 	if fixes == nil {

--- a/internal/api/handlers_m17.go
+++ b/internal/api/handlers_m17.go
@@ -47,7 +47,7 @@ func m17LinkSetupToDTO(l storage.M17LinkSetup) M17LinkSetupDTO {
 // wired (daemon started without storage.path).
 func (s *Server) handleM17LinkSetups(w http.ResponseWriter, r *http.Request) {
 	if s.m17 == nil {
-		writeError(w, http.StatusServiceUnavailable, "m17 subsystem not enabled")
+		s.writeError(w, http.StatusServiceUnavailable, "m17 subsystem not enabled")
 		return
 	}
 	limit := 200
@@ -59,7 +59,7 @@ func (s *Server) handleM17LinkSetups(w http.ResponseWriter, r *http.Request) {
 	rows, err := s.m17.RecentM17LinkSetups(limit)
 	if err != nil {
 		s.log.Error("api: m17 linksetups", "err", err)
-		writeError(w, http.StatusInternalServerError, "query failed")
+		s.writeError(w, http.StatusInternalServerError, "query failed")
 		return
 	}
 	out := make([]M17LinkSetupDTO, 0, len(rows))

--- a/internal/api/handlers_mdc1200.go
+++ b/internal/api/handlers_mdc1200.go
@@ -49,7 +49,7 @@ func mdc1200MessageToDTO(m storage.MDC1200Message) MDC1200MessageDTO {
 // wired (daemon started without storage.path).
 func (s *Server) handleMDC1200Messages(w http.ResponseWriter, r *http.Request) {
 	if s.mdc1200 == nil {
-		writeError(w, http.StatusServiceUnavailable, "mdc1200 subsystem not enabled")
+		s.writeError(w, http.StatusServiceUnavailable, "mdc1200 subsystem not enabled")
 		return
 	}
 	limit := 200
@@ -61,7 +61,7 @@ func (s *Server) handleMDC1200Messages(w http.ResponseWriter, r *http.Request) {
 	rows, err := s.mdc1200.RecentMDC1200Messages(limit)
 	if err != nil {
 		s.log.Error("api: mdc1200 messages", "err", err)
-		writeError(w, http.StatusInternalServerError, "query failed")
+		s.writeError(w, http.StatusInternalServerError, "query failed")
 		return
 	}
 	out := make([]MDC1200MessageDTO, 0, len(rows))

--- a/internal/api/handlers_mutations.go
+++ b/internal/api/handlers_mutations.go
@@ -51,25 +51,25 @@ type endCallRequest struct {
 //	503 if the daemon doesn't have an EngineMutator wired
 func (s *Server) handleEndCall(w http.ResponseWriter, r *http.Request) {
 	if s.mutator == nil {
-		writeError(w, http.StatusServiceUnavailable, "engine not wired for mutations")
+		s.writeError(w, http.StatusServiceUnavailable, "engine not wired for mutations")
 		return
 	}
 	serial := r.PathValue("deviceSerial")
 	if serial == "" {
-		writeError(w, http.StatusBadRequest, "deviceSerial required")
+		s.writeError(w, http.StatusBadRequest, "deviceSerial required")
 		return
 	}
 	var req endCallRequest
 	if r.Body != nil && r.ContentLength != 0 {
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil && err != io.EOF {
-			writeError(w, http.StatusBadRequest, "invalid json body")
+			s.writeError(w, http.StatusBadRequest, "invalid json body")
 			return
 		}
 	}
 	reason := parseEndReason(req.Reason)
 	ok := s.mutator.EndCall(serial, reason)
 	if !ok {
-		writeError(w, http.StatusNotFound, "no active call on that device")
+		s.writeError(w, http.StatusNotFound, "no active call on that device")
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{
@@ -126,17 +126,17 @@ func (s *Server) handleUpdateTalkgroup(w http.ResponseWriter, r *http.Request) {
 	idStr := r.PathValue("id")
 	id, err := strconv.ParseUint(idStr, 10, 32)
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "invalid talkgroup id")
+		s.writeError(w, http.StatusBadRequest, "invalid talkgroup id")
 		return
 	}
 	var req updateTalkgroupRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid json body")
+		s.writeError(w, http.StatusBadRequest, "invalid json body")
 		return
 	}
 	if req.Priority == nil && req.Lockout == nil && req.Scan == nil &&
 		req.Stream == nil && req.Record == nil && req.Mute == nil && req.Icon == nil {
-		writeError(w, http.StatusBadRequest, "supply at least one of priority, lockout, scan, stream, record, mute, icon")
+		s.writeError(w, http.StatusBadRequest, "supply at least one of priority, lockout, scan, stream, record, mute, icon")
 		return
 	}
 	ok := s.talkgroups.UpdateFields(uint32(id), func(tg *trunking.TalkGroup) {
@@ -163,7 +163,7 @@ func (s *Server) handleUpdateTalkgroup(w http.ResponseWriter, r *http.Request) {
 		}
 	})
 	if !ok {
-		writeError(w, http.StatusNotFound, "talkgroup not found")
+		s.writeError(w, http.StatusNotFound, "talkgroup not found")
 		return
 	}
 	tg := s.talkgroups.Lookup(uint32(id))
@@ -185,7 +185,7 @@ func (s *Server) handleUpdateTalkgroup(w http.ResponseWriter, r *http.Request) {
 //	    call-log persistence configured)
 func (s *Server) handleRetentionSweep(w http.ResponseWriter, r *http.Request) {
 	if s.retention == nil {
-		writeError(w, http.StatusServiceUnavailable, "retention not wired")
+		s.writeError(w, http.StatusServiceUnavailable, "retention not wired")
 		return
 	}
 	s.retention.SweepOnce(r.Context())
@@ -204,12 +204,12 @@ func (s *Server) handleRetentionSweep(w http.ResponseWriter, r *http.Request) {
 //	503 if the daemon doesn't have a tone detector wired
 func (s *Server) handleToneReset(w http.ResponseWriter, r *http.Request) {
 	if s.tones == nil {
-		writeError(w, http.StatusServiceUnavailable, "tone detector not wired")
+		s.writeError(w, http.StatusServiceUnavailable, "tone detector not wired")
 		return
 	}
 	serial := r.PathValue("serial")
 	if serial == "" {
-		writeError(w, http.StatusBadRequest, "serial required")
+		s.writeError(w, http.StatusBadRequest, "serial required")
 		return
 	}
 	s.tones.ResetDevice(serial)

--- a/internal/api/handlers_pager.go
+++ b/internal/api/handlers_pager.go
@@ -48,7 +48,7 @@ func pagerMessageToDTO(m storage.PagerMessage) PagerMessageDTO {
 // Optional ?limit= (default 200, max 5000).
 func (s *Server) handlePagerMessages(w http.ResponseWriter, r *http.Request) {
 	if s.pager == nil {
-		writeError(w, http.StatusServiceUnavailable, "pager subsystem not enabled")
+		s.writeError(w, http.StatusServiceUnavailable, "pager subsystem not enabled")
 		return
 	}
 	limit := 200
@@ -60,7 +60,7 @@ func (s *Server) handlePagerMessages(w http.ResponseWriter, r *http.Request) {
 	rows, err := s.pager.RecentPagerMessages(limit)
 	if err != nil {
 		s.log.Error("api: pager messages", "err", err)
-		writeError(w, http.StatusInternalServerError, "query failed")
+		s.writeError(w, http.StatusInternalServerError, "query failed")
 		return
 	}
 	out := make([]PagerMessageDTO, 0, len(rows))

--- a/internal/api/handlers_rids.go
+++ b/internal/api/handlers_rids.go
@@ -30,7 +30,7 @@ func (s *Server) handleGetRID(w http.ResponseWriter, r *http.Request) {
 	idStr := r.PathValue("id")
 	id64, err := strconv.ParseUint(idStr, 10, 32)
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "invalid rid")
+		s.writeError(w, http.StatusBadRequest, "invalid rid")
 		return
 	}
 	id := uint32(id64)
@@ -47,7 +47,7 @@ func (s *Server) handleGetRID(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	if dto == nil {
-		writeError(w, http.StatusNotFound, "rid not found")
+		s.writeError(w, http.StatusNotFound, "rid not found")
 		return
 	}
 	writeJSON(w, http.StatusOK, dto)
@@ -60,13 +60,13 @@ func (s *Server) handleGetRID(w http.ResponseWriter, r *http.Request) {
 //	GET /api/v1/rids/{id}/history?limit=50
 func (s *Server) handleRIDHistory(w http.ResponseWriter, r *http.Request) {
 	if s.history == nil {
-		writeError(w, http.StatusServiceUnavailable, "call log persistence is not enabled")
+		s.writeError(w, http.StatusServiceUnavailable, "call log persistence is not enabled")
 		return
 	}
 	idStr := r.PathValue("id")
 	id64, err := strconv.ParseUint(idStr, 10, 32)
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "invalid rid")
+		s.writeError(w, http.StatusBadRequest, "invalid rid")
 		return
 	}
 	f := HistoryFilter{
@@ -77,7 +77,7 @@ func (s *Server) handleRIDHistory(w http.ResponseWriter, r *http.Request) {
 	if v := r.URL.Query().Get("limit"); v != "" {
 		n, err := strconv.Atoi(v)
 		if err != nil || n < 0 {
-			writeError(w, http.StatusBadRequest, "invalid limit")
+			s.writeError(w, http.StatusBadRequest, "invalid limit")
 			return
 		}
 		if n > 1000 {
@@ -91,7 +91,7 @@ func (s *Server) handleRIDHistory(w http.ResponseWriter, r *http.Request) {
 	rows, err := s.history.History(r.Context(), f)
 	if err != nil {
 		s.log.Warn("api: rid history query failed", "err", err)
-		writeError(w, http.StatusInternalServerError, "history query failed")
+		s.writeError(w, http.StatusInternalServerError, "history query failed")
 		return
 	}
 	if rows == nil {
@@ -129,24 +129,24 @@ type updateRIDRequest struct {
 // return 404 — operators must add the radio to the alias file first.
 func (s *Server) handleUpdateRID(w http.ResponseWriter, r *http.Request) {
 	if s.rids == nil {
-		writeError(w, http.StatusServiceUnavailable, "rid catalogue not wired")
+		s.writeError(w, http.StatusServiceUnavailable, "rid catalogue not wired")
 		return
 	}
 	idStr := r.PathValue("id")
 	id64, err := strconv.ParseUint(idStr, 10, 32)
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "invalid rid")
+		s.writeError(w, http.StatusBadRequest, "invalid rid")
 		return
 	}
 	var req updateRIDRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid json body")
+		s.writeError(w, http.StatusBadRequest, "invalid json body")
 		return
 	}
 	if req.Alias == nil && req.Description == nil && req.Tag == nil &&
 		req.Group == nil && req.Owner == nil && req.Priority == nil &&
 		req.Lockout == nil && req.Watch == nil && req.Icon == nil {
-		writeError(w, http.StatusBadRequest,
+		s.writeError(w, http.StatusBadRequest,
 			"supply at least one of alias, description, tag, group, owner, priority, lockout, watch, icon")
 		return
 	}
@@ -181,7 +181,7 @@ func (s *Server) handleUpdateRID(w http.ResponseWriter, r *http.Request) {
 		}
 	})
 	if !ok {
-		writeError(w, http.StatusNotFound, "rid not found in static catalogue (add to rid_alias_file first)")
+		s.writeError(w, http.StatusNotFound, "rid not found in static catalogue (add to rid_alias_file first)")
 		return
 	}
 	dto := ridToDTO(s.rids.Lookup(id))

--- a/internal/api/handlers_scanner.go
+++ b/internal/api/handlers_scanner.go
@@ -29,23 +29,23 @@ type scannerSetModeRequest struct {
 
 func (s *Server) handleScannerSetMode(w http.ResponseWriter, r *http.Request) {
 	if s.scanner == nil {
-		writeError(w, http.StatusServiceUnavailable, "scanner not wired")
+		s.writeError(w, http.StatusServiceUnavailable, "scanner not wired")
 		return
 	}
 	var req scannerSetModeRequest
 	if r.Body != nil && r.ContentLength != 0 {
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil && err != io.EOF {
-			writeError(w, http.StatusBadRequest, "invalid json body")
+			s.writeError(w, http.StatusBadRequest, "invalid json body")
 			return
 		}
 	}
 	if req.ScanMode == "" {
-		writeError(w, http.StatusBadRequest, "scan_mode required")
+		s.writeError(w, http.StatusBadRequest, "scan_mode required")
 		return
 	}
 	prev, err := s.scanner.SetScanMode(req.ScanMode)
 	if err != nil {
-		writeError(w, http.StatusBadRequest, err.Error())
+		s.writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{
@@ -70,16 +70,16 @@ func (s *Server) handleHuntRetune(w http.ResponseWriter, r *http.Request) {
 // → 404. The actual mutation is delegated to the supplied func.
 func (s *Server) huntOp(w http.ResponseWriter, r *http.Request, op func(string) bool) {
 	if s.scanner == nil {
-		writeError(w, http.StatusServiceUnavailable, "scanner not wired")
+		s.writeError(w, http.StatusServiceUnavailable, "scanner not wired")
 		return
 	}
 	system := r.PathValue("system")
 	if system == "" {
-		writeError(w, http.StatusBadRequest, "system required")
+		s.writeError(w, http.StatusBadRequest, "system required")
 		return
 	}
 	if !op(system) {
-		writeError(w, http.StatusNotFound, "no such system")
+		s.writeError(w, http.StatusNotFound, "no such system")
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "system": system})
@@ -87,11 +87,11 @@ func (s *Server) huntOp(w http.ResponseWriter, r *http.Request, op func(string) 
 
 func (s *Server) handleConvHold(w http.ResponseWriter, _ *http.Request) {
 	if s.scanner == nil {
-		writeError(w, http.StatusServiceUnavailable, "scanner not wired")
+		s.writeError(w, http.StatusServiceUnavailable, "scanner not wired")
 		return
 	}
 	if !s.scanner.HoldConventional() {
-		writeError(w, http.StatusServiceUnavailable, "conventional scanner not configured")
+		s.writeError(w, http.StatusServiceUnavailable, "conventional scanner not configured")
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"ok": true})
@@ -99,11 +99,11 @@ func (s *Server) handleConvHold(w http.ResponseWriter, _ *http.Request) {
 
 func (s *Server) handleConvResume(w http.ResponseWriter, _ *http.Request) {
 	if s.scanner == nil {
-		writeError(w, http.StatusServiceUnavailable, "scanner not wired")
+		s.writeError(w, http.StatusServiceUnavailable, "scanner not wired")
 		return
 	}
 	if !s.scanner.ResumeConventional() {
-		writeError(w, http.StatusServiceUnavailable, "conventional scanner not configured")
+		s.writeError(w, http.StatusServiceUnavailable, "conventional scanner not configured")
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"ok": true})
@@ -111,17 +111,17 @@ func (s *Server) handleConvResume(w http.ResponseWriter, _ *http.Request) {
 
 func (s *Server) handleConvDwell(w http.ResponseWriter, r *http.Request) {
 	if s.scanner == nil {
-		writeError(w, http.StatusServiceUnavailable, "scanner not wired")
+		s.writeError(w, http.StatusServiceUnavailable, "scanner not wired")
 		return
 	}
 	idxStr := r.PathValue("index")
 	idx, err := strconv.Atoi(idxStr)
 	if err != nil || idx < 0 {
-		writeError(w, http.StatusBadRequest, "invalid index")
+		s.writeError(w, http.StatusBadRequest, "invalid index")
 		return
 	}
 	if !s.scanner.DwellConventional(idx) {
-		writeError(w, http.StatusNotFound, "channel index out of range")
+		s.writeError(w, http.StatusNotFound, "channel index out of range")
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "index": idx})
@@ -155,17 +155,17 @@ func (s *Server) handleConvUnlockout(w http.ResponseWriter, r *http.Request) {
 // handlers stay one-liners.
 func (s *Server) convLockoutOp(w http.ResponseWriter, r *http.Request, op func(int) bool, newState bool) {
 	if s.scanner == nil {
-		writeError(w, http.StatusServiceUnavailable, "scanner not wired")
+		s.writeError(w, http.StatusServiceUnavailable, "scanner not wired")
 		return
 	}
 	idxStr := r.PathValue("index")
 	idx, err := strconv.Atoi(idxStr)
 	if err != nil || idx < 0 {
-		writeError(w, http.StatusBadRequest, "invalid index")
+		s.writeError(w, http.StatusBadRequest, "invalid index")
 		return
 	}
 	if !op(idx) {
-		writeError(w, http.StatusNotFound, "channel index out of range")
+		s.writeError(w, http.StatusNotFound, "channel index out of range")
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{
@@ -191,36 +191,36 @@ func (s *Server) convLockoutOp(w http.ResponseWriter, r *http.Request, op func(i
 //	    carved out for it)
 func (s *Server) handleScannerManualTune(w http.ResponseWriter, r *http.Request) {
 	if s.scanner == nil {
-		writeError(w, http.StatusServiceUnavailable, "scanner not wired")
+		s.writeError(w, http.StatusServiceUnavailable, "scanner not wired")
 		return
 	}
 	var req ManualTuneRequest
 	if r.Body == nil || r.ContentLength == 0 {
-		writeError(w, http.StatusBadRequest, "body required")
+		s.writeError(w, http.StatusBadRequest, "body required")
 		return
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid json body")
+		s.writeError(w, http.StatusBadRequest, "invalid json body")
 		return
 	}
 	if req.FrequencyHz == 0 {
-		writeError(w, http.StatusBadRequest, "frequency_hz required")
+		s.writeError(w, http.StatusBadRequest, "frequency_hz required")
 		return
 	}
 	// Sanity check: 25 MHz – 1.3 GHz is the practical RTL-SDR tuning
 	// range. Looser is fine but a zero or absurd value almost
 	// certainly means the operator mis-typed.
 	if req.FrequencyHz < 25_000_000 || req.FrequencyHz > 1_300_000_000 {
-		writeError(w, http.StatusBadRequest, "frequency_hz outside 25 MHz – 1.3 GHz tuning range")
+		s.writeError(w, http.StatusBadRequest, "frequency_hz outside 25 MHz – 1.3 GHz tuning range")
 		return
 	}
 	if req.Mode != "" && req.Mode != "fm" && req.Mode != "nfm" {
-		writeError(w, http.StatusBadRequest, "mode must be fm or nfm")
+		s.writeError(w, http.StatusBadRequest, "mode must be fm or nfm")
 		return
 	}
 	idx, ok := s.scanner.ManualTune(req)
 	if !ok {
-		writeError(w, http.StatusServiceUnavailable, "conventional scanner not configured")
+		s.writeError(w, http.StatusServiceUnavailable, "conventional scanner not configured")
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{
@@ -244,17 +244,17 @@ func (s *Server) handleScannerManualTune(w http.ResponseWriter, r *http.Request)
 //	503 if the scanner isn't wired
 func (s *Server) handleScannerClearManualTune(w http.ResponseWriter, r *http.Request) {
 	if s.scanner == nil {
-		writeError(w, http.StatusServiceUnavailable, "scanner not wired")
+		s.writeError(w, http.StatusServiceUnavailable, "scanner not wired")
 		return
 	}
 	idxStr := r.PathValue("index")
 	idx, err := strconv.Atoi(idxStr)
 	if err != nil || idx < 0 {
-		writeError(w, http.StatusBadRequest, "invalid index")
+		s.writeError(w, http.StatusBadRequest, "invalid index")
 		return
 	}
 	if !s.scanner.ClearManualTune(idx) {
-		writeError(w, http.StatusNotFound, "no such temporary channel")
+		s.writeError(w, http.StatusNotFound, "no such temporary channel")
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "index": idx})

--- a/internal/api/handlers_settings.go
+++ b/internal/api/handlers_settings.go
@@ -131,27 +131,27 @@ type ConfigWriter interface {
 // 409 → config.yaml was edited externally; daemon refuses to clobber
 func (s *Server) handleSettingsPatch(w http.ResponseWriter, r *http.Request) {
 	if s.configWriter == nil {
-		writeError(w, http.StatusServiceUnavailable, "settings: no config file backs this daemon (start with -config to enable live edits)")
+		s.writeError(w, http.StatusServiceUnavailable, "settings: no config file backs this daemon (start with -config to enable live edits)")
 		return
 	}
 	var req SettingsPatchRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "settings: "+err.Error())
+		s.writeError(w, http.StatusBadRequest, "settings: "+err.Error())
 		return
 	}
 	patch := req.toPatch()
 	if patch.IsEmpty() {
-		writeError(w, http.StatusBadRequest, "settings: patch has no fields")
+		s.writeError(w, http.StatusBadRequest, "settings: patch has no fields")
 		return
 	}
 	if _, err := s.configWriter.WritePatch(patch); err != nil {
 		// Distinguish external-edit conflict from a generic write
 		// failure so the UI can present a clearer toast.
 		if isExternalEditConflict(err) {
-			writeError(w, http.StatusConflict, err.Error())
+			s.writeError(w, http.StatusConflict, err.Error())
 			return
 		}
-		writeError(w, http.StatusBadRequest, err.Error())
+		s.writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	gtdiag "github.com/MattCheramie/GopherTrunk/internal/diag"
 	"github.com/MattCheramie/GopherTrunk/internal/events"
 	"github.com/MattCheramie/GopherTrunk/internal/sdr"
 	"github.com/MattCheramie/GopherTrunk/internal/trunking"
@@ -309,6 +310,14 @@ type Server struct {
 	// storage.MDC1200Log.
 	mdc1200 MDC1200Provider
 
+	// diagnostics is the shared error-diagnostics collector (banner +
+	// system info). nil disables banner enrichment of error responses
+	// and the GET /api/v1/diag/banner route.
+	diagnostics *gtdiag.Collector
+	// verboseErrors mirrors diagnostics.verbose_errors; see
+	// ServerOptions.VerboseErrors.
+	verboseErrors bool
+
 	mu     sync.Mutex
 	srv    *http.Server
 	closed bool
@@ -503,6 +512,17 @@ type ServerOptions struct {
 	// the iqtap broker + internal/dsp/diag; nil keeps the route
 	// returning 503.
 	Diag DiagProvider
+	// Diagnostics is the shared error-diagnostics collector (banner +
+	// system info). The daemon injects one seeded with its SDR pool
+	// snapshot so the error path never re-enumerates USB. Optional; nil
+	// disables banner enrichment and the GET /api/v1/diag/banner route.
+	Diagnostics *gtdiag.Collector
+	// VerboseErrors mirrors diagnostics.verbose_errors. When true, every
+	// JSON error envelope includes the diagnostics banner (exposing host
+	// + dongle info), and GET /api/v1/diag/banner is served to any
+	// caller; when false the banner is only attached on ?verbose=1 from
+	// a trusted (authorized) request.
+	VerboseErrors bool
 	// Pager, when non-nil, enables the
 	// GET /api/v1/pager/messages route serving recent decoded
 	// POCSAG (and eventually FLEX) pager messages. Wired by the
@@ -636,6 +656,8 @@ func NewServer(opts ServerOptions) (*Server, error) {
 		spectrum:       opts.Spectrum,
 		bookmarks:      opts.Bookmarks,
 		diag:           opts.Diag,
+		diagnostics:    opts.Diagnostics,
+		verboseErrors:  opts.VerboseErrors,
 		pager:          opts.Pager,
 		aprs:           opts.APRS,
 		ais:            opts.AIS,
@@ -745,6 +767,7 @@ func (s *Server) routes() *http.ServeMux {
 	mux.HandleFunc("GET /api/v1/health", s.handleHealth)
 	mux.HandleFunc("GET /api/v1/runtime", s.handleRuntime)
 	mux.HandleFunc("GET /api/v1/version", s.handleVersion)
+	mux.HandleFunc("GET /api/v1/diag/banner", s.handleDiagBanner)
 	mux.HandleFunc("GET /api/v1/systems", s.handleListSystems)
 	mux.HandleFunc("GET /api/v1/systems/{name}", s.handleGetSystem)
 	mux.HandleFunc("GET /api/v1/talkgroups", s.handleListTalkgroups)
@@ -962,7 +985,7 @@ const spaMissingBody = `<!doctype html>
 func (s *Server) gate(h http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if status, reason := s.auth.authorize(r); status != 0 {
-			writeError(w, status, reason)
+			s.writeError(w, status, reason)
 			return
 		}
 		h(w, r)
@@ -978,6 +1001,22 @@ func writeJSON(w http.ResponseWriter, status int, body any) {
 	_ = json.NewEncoder(w).Encode(body)
 }
 
-func writeError(w http.ResponseWriter, status int, msg string) {
+// writeError emits the standard {"error": "..."} JSON envelope. When
+// diagnostics.verbose_errors is enabled and a collector is wired, it
+// also attaches a "diag" object carrying the diagnostics banner
+// (version, OS, system specs, detected dongles) so an API consumer
+// triaging a failure gets the same macro context the CLI banner shows.
+// The banner exposes host + dongle info, so it is only included when
+// verbose is explicitly enabled (see ServerOptions.VerboseErrors).
+func (s *Server) writeError(w http.ResponseWriter, status int, msg string) {
+	if s.verboseErrors && s.diagnostics != nil {
+		writeJSON(w, status, map[string]any{
+			"error": msg,
+			"diag": map[string]any{
+				"banner": gtdiag.FormatBannerPlain(s.diagnostics.SysInfo()),
+			},
+		})
+		return
+	}
 	writeJSON(w, status, map[string]string{"error": msg})
 }

--- a/internal/api/spectrum.go
+++ b/internal/api/spectrum.go
@@ -57,7 +57,7 @@ type TuneRequest struct {
 // handleSpectrumDevices answers GET /api/v1/spectrum/devices.
 func (s *Server) handleSpectrumDevices(w http.ResponseWriter, r *http.Request) {
 	if s.spectrum == nil {
-		writeError(w, http.StatusServiceUnavailable, "spectrum subsystem not enabled")
+		s.writeError(w, http.StatusServiceUnavailable, "spectrum subsystem not enabled")
 		return
 	}
 	writeJSON(w, http.StatusOK, s.spectrum.Devices())
@@ -73,26 +73,26 @@ func (s *Server) handleSpectrumDevices(w http.ResponseWriter, r *http.Request) {
 // protocol against the same broker.
 func (s *Server) handleSpectrumTune(w http.ResponseWriter, r *http.Request) {
 	if s.spectrum == nil {
-		writeError(w, http.StatusServiceUnavailable, "spectrum subsystem not enabled")
+		s.writeError(w, http.StatusServiceUnavailable, "spectrum subsystem not enabled")
 		return
 	}
 	serial := r.PathValue("serial")
 	if serial == "" {
-		writeError(w, http.StatusBadRequest, "serial path parameter is required")
+		s.writeError(w, http.StatusBadRequest, "serial path parameter is required")
 		return
 	}
 	var body TuneRequest
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		s.writeError(w, http.StatusBadRequest, "invalid JSON body")
 		return
 	}
 	if body.CenterHz == 0 {
-		writeError(w, http.StatusBadRequest, "center_hz is required and must be > 0")
+		s.writeError(w, http.StatusBadRequest, "center_hz is required and must be > 0")
 		return
 	}
 	if err := s.spectrum.Tune(serial, body.CenterHz); err != nil {
 		s.log.Debug("api: spectrum tune", "serial", serial, "hz", body.CenterHz, "err", err)
-		writeError(w, http.StatusBadRequest, err.Error())
+		s.writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
@@ -106,19 +106,19 @@ func (s *Server) handleSpectrumTune(w http.ResponseWriter, r *http.Request) {
 // reaping the socket — same pattern as handleWS.
 func (s *Server) handleSpectrumStream(w http.ResponseWriter, r *http.Request) {
 	if s.spectrum == nil {
-		writeError(w, http.StatusServiceUnavailable, "spectrum subsystem not enabled")
+		s.writeError(w, http.StatusServiceUnavailable, "spectrum subsystem not enabled")
 		return
 	}
 
 	q := r.URL.Query()
 	serial := q.Get("device")
 	if serial == "" {
-		writeError(w, http.StatusBadRequest, "device query parameter is required")
+		s.writeError(w, http.StatusBadRequest, "device query parameter is required")
 		return
 	}
 	bins := parseIntQuery(q, "bins", 4096, 64, 16384)
 	if bins&(bins-1) != 0 {
-		writeError(w, http.StatusBadRequest, "bins must be a power of two")
+		s.writeError(w, http.StatusBadRequest, "bins must be a power of two")
 		return
 	}
 	fps := parseFloatQuery(q, "fps", 10, 1, 30)

--- a/internal/api/sse.go
+++ b/internal/api/sse.go
@@ -16,7 +16,7 @@ import (
 func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
 	flusher, ok := w.(http.Flusher)
 	if !ok {
-		writeError(w, http.StatusInternalServerError, "streaming not supported")
+		s.writeError(w, http.StatusInternalServerError, "streaming not supported")
 		return
 	}
 	// Disable the server-level WriteTimeout for this connection — the

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,27 +14,41 @@ import (
 )
 
 type Config struct {
-	Log        LogConfig        `yaml:"log"`
-	SDR        SDRConfig        `yaml:"sdr"`
-	Trunking   TrunkingConfig   `yaml:"trunking"`
-	API        APIConfig        `yaml:"api"`
-	Storage    StorageConfig    `yaml:"storage"`
-	Recordings RecordingsConfig `yaml:"recordings"`
-	Metrics    MetricsConfig    `yaml:"metrics"`
-	Retention  RetentionConfig  `yaml:"retention"`
-	ToneOut    ToneOutConfig    `yaml:"tone_out"`
-	Scanner    ScannerConfig    `yaml:"scanner"`
-	Audio      AudioConfig      `yaml:"audio"`
-	Broadcast  BroadcastConfig  `yaml:"broadcast"`
-	Baseband   BasebandConfig   `yaml:"baseband"`
-	Paging     PagingConfig     `yaml:"paging"`
-	APRS       APRSConfig       `yaml:"aprs"`
-	AIS        AISConfig        `yaml:"ais"`
-	DSC        DSCConfig        `yaml:"dsc"`
-	MDC1200    MDC1200Config    `yaml:"mdc1200"`
-	ADSB       ADSBConfig       `yaml:"adsb"`
-	M17        M17Config        `yaml:"m17"`
-	Web        WebConfig        `yaml:"web"`
+	Log         LogConfig         `yaml:"log"`
+	SDR         SDRConfig         `yaml:"sdr"`
+	Trunking    TrunkingConfig    `yaml:"trunking"`
+	API         APIConfig         `yaml:"api"`
+	Storage     StorageConfig     `yaml:"storage"`
+	Recordings  RecordingsConfig  `yaml:"recordings"`
+	Metrics     MetricsConfig     `yaml:"metrics"`
+	Retention   RetentionConfig   `yaml:"retention"`
+	ToneOut     ToneOutConfig     `yaml:"tone_out"`
+	Scanner     ScannerConfig     `yaml:"scanner"`
+	Audio       AudioConfig       `yaml:"audio"`
+	Broadcast   BroadcastConfig   `yaml:"broadcast"`
+	Baseband    BasebandConfig    `yaml:"baseband"`
+	Paging      PagingConfig      `yaml:"paging"`
+	APRS        APRSConfig        `yaml:"aprs"`
+	AIS         AISConfig         `yaml:"ais"`
+	DSC         DSCConfig         `yaml:"dsc"`
+	MDC1200     MDC1200Config     `yaml:"mdc1200"`
+	ADSB        ADSBConfig        `yaml:"adsb"`
+	M17         M17Config         `yaml:"m17"`
+	Web         WebConfig         `yaml:"web"`
+	Diagnostics DiagnosticsConfig `yaml:"diagnostics"`
+}
+
+// DiagnosticsConfig controls error-reporting verbosity. When
+// VerboseErrors is true, every error surface (CLI, daemon log,
+// HTTP/gRPC API) prints the full wrapped error chain plus a goroutine
+// stack dump under the diagnostics banner, with no interactive prompt;
+// the API also expands its error envelopes to include the banner +
+// trace (which exposes host/dongle info — enable only on trusted
+// networks). When false (the default) the CLI instead offers the trace
+// interactively on a TTY. Overridable at runtime by the -verbose-errors
+// flag and the GOPHERTRUNK_VERBOSE_ERRORS env var.
+type DiagnosticsConfig struct {
+	VerboseErrors bool `yaml:"verbose_errors"`
 }
 
 // WebConfig configures the bundled user interfaces (the embedded web SPA

--- a/internal/diag/banner.go
+++ b/internal/diag/banner.go
@@ -1,0 +1,93 @@
+package diag
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// QuietBannerEnv suppresses banner rendering when set (matches the
+// existing GOPHERTRUNK_QUIET_BANNER used by the launcher for CI/tests).
+const QuietBannerEnv = "GOPHERTRUNK_QUIET_BANNER"
+
+// FormatBanner renders the boxed diagnostic banner shown at the top of
+// an error on a terminal. Returns "" when GOPHERTRUNK_QUIET_BANNER is
+// set so CI logs stay clean.
+func FormatBanner(si SysInfo) string {
+	if os.Getenv(QuietBannerEnv) != "" {
+		return ""
+	}
+	lines := bannerLines(si)
+	const top = "┌─ GopherTrunk diagnostics ──────────────────────────────"
+	const bot = "└─────────────────────────────────────────────────────────"
+	var b strings.Builder
+	b.WriteString(top + "\n")
+	for _, ln := range lines {
+		b.WriteString("│ " + ln + "\n")
+	}
+	b.WriteString(bot)
+	return b.String()
+}
+
+// FormatBannerPlain renders the same fields without box-drawing
+// characters, for embedding in JSON error envelopes, structured logs,
+// or non-UTF-8 terminals. Honors GOPHERTRUNK_QUIET_BANNER.
+func FormatBannerPlain(si SysInfo) string {
+	if os.Getenv(QuietBannerEnv) != "" {
+		return ""
+	}
+	return "GopherTrunk diagnostics\n" + strings.Join(bannerLines(si), "\n")
+}
+
+// bannerLines is the shared field rendering for both banner formats.
+// Empty/zero fields are omitted so a platform that can't supply a value
+// never produces a broken line.
+func bannerLines(si SysInfo) []string {
+	var lines []string
+	lines = append(lines, "version : "+orNA(si.Version))
+
+	osLine := si.GOOS + "/" + si.GOARCH
+	if si.KernelOS != "" {
+		osLine += "  (" + si.KernelOS + ")"
+	}
+	lines = append(lines, "os      : "+osLine)
+
+	host := orNA(si.Hostname)
+	hostLine := fmt.Sprintf("%s  cpus=%d  go=%s", host, si.NumCPU, si.GoVersion)
+	if si.MemTotalMB > 0 {
+		hostLine += fmt.Sprintf("  mem=%d/%d MB", si.MemInUseMB, si.MemTotalMB)
+	} else {
+		hostLine += fmt.Sprintf("  mem=%d MB used", si.MemInUseMB)
+	}
+	lines = append(lines, "host    : "+hostLine)
+
+	if len(si.Dongles) == 0 {
+		lines = append(lines, "dongles : none detected")
+	} else {
+		lines = append(lines, fmt.Sprintf("dongles : %d detected", len(si.Dongles)))
+		for _, d := range si.Dongles {
+			detail := fmt.Sprintf("  - %s[%d]", d.Driver, d.Index)
+			if d.Serial != "" {
+				detail += " serial=" + d.Serial
+			}
+			if d.Tuner != "" {
+				detail += " tuner=" + d.Tuner
+			}
+			if d.Product != "" {
+				detail += " product=" + d.Product
+			}
+			lines = append(lines, detail)
+		}
+	}
+	for _, e := range si.DongleErrs {
+		lines = append(lines, "  ! enumerate: "+e)
+	}
+	return lines
+}
+
+func orNA(s string) string {
+	if s == "" {
+		return "(unknown)"
+	}
+	return s
+}

--- a/internal/diag/diag_test.go
+++ b/internal/diag/diag_test.go
@@ -1,0 +1,126 @@
+package diag
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestFormatBannerFields(t *testing.T) {
+	t.Setenv(QuietBannerEnv, "") // ensure not suppressed
+	si := SysInfo{
+		Version:    "v1.2.3 (sha=abc1234)",
+		GOOS:       "linux",
+		GOARCH:     "amd64",
+		KernelOS:   "Linux 6.18.5",
+		Hostname:   "radio-pi",
+		NumCPU:     4,
+		GoVersion:  "go1.25",
+		MemTotalMB: 3942,
+		MemInUseMB: 12,
+		Dongles: []DongleInfo{
+			{Driver: "rtlsdr", Index: 0, Serial: "00000001", Tuner: "R820T", Product: "RTL2838"},
+		},
+	}
+	out := FormatBanner(si)
+	for _, want := range []string{"v1.2.3", "linux/amd64", "Linux 6.18.5", "radio-pi", "cpus=4", "go=go1.25", "3942", "rtlsdr[0]", "serial=00000001", "tuner=R820T", "RTL2838"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("banner missing %q\n%s", want, out)
+		}
+	}
+}
+
+func TestFormatBannerOmitsEmptyAndNoDongles(t *testing.T) {
+	si := SysInfo{GOOS: "darwin", GOARCH: "arm64", NumCPU: 8, GoVersion: "go1.25"}
+	out := FormatBanner(si)
+	if strings.Contains(out, "(") && strings.Contains(out, "kernel") {
+		t.Errorf("expected no kernel parenthetical, got:\n%s", out)
+	}
+	if !strings.Contains(out, "dongles : none detected") {
+		t.Errorf("expected 'none detected', got:\n%s", out)
+	}
+	// MemTotalMB == 0 → no "/NNNN MB" total form.
+	if strings.Contains(out, "/0 MB") {
+		t.Errorf("zero mem total should be omitted, got:\n%s", out)
+	}
+}
+
+func TestFormatBannerQuietEnv(t *testing.T) {
+	t.Setenv(QuietBannerEnv, "1")
+	if got := FormatBanner(SysInfo{GOOS: "linux"}); got != "" {
+		t.Errorf("expected empty banner under quiet env, got %q", got)
+	}
+	if got := FormatBannerPlain(SysInfo{GOOS: "linux"}); got != "" {
+		t.Errorf("expected empty plain banner under quiet env, got %q", got)
+	}
+}
+
+func TestChainUnwrap(t *testing.T) {
+	err := fmt.Errorf("a: %w", fmt.Errorf("b: %w", errors.New("c")))
+	got := Chain(err)
+	if len(got) != 3 {
+		t.Fatalf("want 3 layers, got %d: %v", len(got), got)
+	}
+	if !strings.HasPrefix(got[0], "a: ") || got[2] != "c" {
+		t.Errorf("chain order wrong: %v", got)
+	}
+	if got := Chain(nil); len(got) != 0 {
+		t.Errorf("nil error should yield empty chain, got %v", got)
+	}
+}
+
+func TestChainJoin(t *testing.T) {
+	err := errors.Join(errors.New("first"), errors.New("second"))
+	got := Chain(err)
+	// The joined error itself plus each branch.
+	joined := strings.Join(got, "|")
+	if !strings.Contains(joined, "first") || !strings.Contains(joined, "second") {
+		t.Errorf("join branches missing: %v", got)
+	}
+}
+
+func TestVerboseTrace(t *testing.T) {
+	err := fmt.Errorf("outer: %w", errors.New("inner"))
+	stack := []byte("goroutine 1 [running]:\nmain.main()")
+	out := VerboseTrace(err, stack)
+	for _, want := range []string{"outer: inner", "inner", "goroutine"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("trace missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestCollectorMemoizesAndInjects(t *testing.T) {
+	calls := 0
+	c := &Collector{enumerate: func() ([]DongleInfo, []string) {
+		calls++
+		return []DongleInfo{{Driver: "mock"}}, nil
+	}}
+	for i := 0; i < 3; i++ {
+		si := c.SysInfo()
+		if len(si.Dongles) != 1 || si.Dongles[0].Driver != "mock" {
+			t.Fatalf("dongles not injected: %+v", si.Dongles)
+		}
+	}
+	if calls != 1 {
+		t.Errorf("enumerate should run once, ran %d times", calls)
+	}
+}
+
+func TestCollectDonglesSkipEnv(t *testing.T) {
+	t.Setenv("GOPHERTRUNK_DIAG_NO_ENUMERATE", "1")
+	d, errs := CollectDongles()
+	if d != nil || errs != nil {
+		t.Errorf("expected no dongles when enumeration skipped, got %v / %v", d, errs)
+	}
+}
+
+func TestNewCollectorWithDonglesCopies(t *testing.T) {
+	src := []DongleInfo{{Driver: "rtlsdr"}}
+	c := NewCollectorWithDongles(src, nil)
+	src[0].Driver = "mutated"
+	if got := c.SysInfo().Dongles[0].Driver; got != "rtlsdr" {
+		t.Errorf("collector should copy input, got %q", got)
+	}
+}

--- a/internal/diag/dongles.go
+++ b/internal/diag/dongles.go
@@ -1,0 +1,80 @@
+package diag
+
+import (
+	"os"
+	"sync"
+
+	"github.com/MattCheramie/GopherTrunk/internal/sdr"
+)
+
+// CollectDongles enumerates every registered SDR driver and returns
+// the discovered devices plus stringified enumeration errors.
+//
+// This is COSTLY and has side effects: it walks libusb (or the OS USB
+// stack) for every driver, so it must not be called on every error and
+// must never run concurrently with a daemon that already holds the USB
+// claim. Callers should go through a Collector, which memoizes the
+// result, and the daemon should inject its pool snapshot via
+// NewCollectorWithDongles so the error path never re-enumerates.
+//
+// Setting GOPHERTRUNK_DIAG_NO_ENUMERATE=1 skips enumeration entirely
+// (useful for CI or hosts with slow/hostile USB stacks).
+func CollectDongles() ([]DongleInfo, []string) {
+	if os.Getenv("GOPHERTRUNK_DIAG_NO_ENUMERATE") != "" {
+		return nil, nil
+	}
+	infos, errs := sdr.EnumerateAll()
+	dongles := make([]DongleInfo, 0, len(infos))
+	for _, in := range infos {
+		dongles = append(dongles, DongleInfo{
+			Driver:  in.Driver,
+			Serial:  in.Serial,
+			Product: in.Product,
+			Tuner:   in.TunerName,
+			Index:   in.Index,
+		})
+	}
+	var errStrs []string
+	for _, e := range errs {
+		errStrs = append(errStrs, e.Error())
+	}
+	return dongles, errStrs
+}
+
+// Collector lazily builds and caches a SysInfo (including dongles) so
+// the expensive enumeration runs at most once per process. Safe for
+// concurrent use.
+type Collector struct {
+	once      sync.Once
+	info      SysInfo
+	enumerate func() ([]DongleInfo, []string)
+}
+
+// NewCollector returns a Collector that enumerates dongles lazily the
+// first time SysInfo is requested (i.e. only when an error actually
+// renders a banner). Use this from the CLI, where no live pool exists.
+func NewCollector() *Collector {
+	return &Collector{enumerate: CollectDongles}
+}
+
+// NewCollectorWithDongles returns a Collector seeded with a dongle list
+// the caller already has (e.g. the daemon's Pool snapshot), so the
+// banner never triggers a fresh USB enumeration that would race the
+// running pool's device claim.
+func NewCollectorWithDongles(dongles []DongleInfo, errs []string) *Collector {
+	d := append([]DongleInfo(nil), dongles...)
+	e := append([]string(nil), errs...)
+	return &Collector{enumerate: func() ([]DongleInfo, []string) { return d, e }}
+}
+
+// SysInfo returns the memoized system snapshot, computing it (and
+// enumerating dongles) exactly once.
+func (c *Collector) SysInfo() SysInfo {
+	c.once.Do(func() {
+		c.info = CollectSysInfo()
+		if c.enumerate != nil {
+			c.info.Dongles, c.info.DongleErrs = c.enumerate()
+		}
+	})
+	return c.info
+}

--- a/internal/diag/reporter.go
+++ b/internal/diag/reporter.go
@@ -1,0 +1,138 @@
+package diag
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+// verboseHint is the one-line nudge appended on a non-interactive,
+// non-verbose error so the operator knows how to get the full trace
+// without us blocking on a prompt that nothing will answer.
+const verboseHint = "(set diagnostics.verbose_errors: true, GOPHERTRUNK_VERBOSE_ERRORS=1, or pass -verbose-errors for the full trace)"
+
+// Reporter centralizes CLI/launcher error reporting: it prints the
+// diagnostic banner, a concise message, and then either the full
+// verbose trace (when Verbose) or — on an interactive terminal — an
+// offer to show it. On a non-TTY it prints a hint instead of prompting
+// so service managers and pipes never hang.
+type Reporter struct {
+	Out         io.Writer  // defaults to os.Stderr
+	In          *os.File   // defaults to os.Stdin (prompt source)
+	Collector   *Collector // banner source; lazily falls back to NewCollector()
+	Verbose     bool       // diagnostics.verbose_errors (config/env/flag resolved)
+	Prefix      string     // message prefix, e.g. "config", "import-pdf"; "" for none
+	interactive func() bool
+}
+
+// NewReporter builds a Reporter for a CLI command. prefix is prepended
+// to the concise message ("<prefix>: <err>"); pass "" for no prefix.
+func NewReporter(prefix string, verbose bool, c *Collector) *Reporter {
+	return &Reporter{
+		Out:       os.Stderr,
+		In:        os.Stdin,
+		Collector: c,
+		Verbose:   verbose,
+		Prefix:    prefix,
+	}
+}
+
+// Report prints the banner, the concise error, and then the verbose
+// trace (Verbose) or an interactive offer / hint. The goroutine stack
+// is captured here so it reflects the report site.
+func (r *Reporter) Report(err error) {
+	if err == nil {
+		return
+	}
+	out := r.Out
+	if out == nil {
+		out = os.Stderr
+	}
+	stack := CaptureStack()
+
+	if r.Collector == nil {
+		r.Collector = NewCollector()
+	}
+	if banner := FormatBanner(r.Collector.SysInfo()); banner != "" {
+		fmt.Fprintln(out, banner)
+	}
+
+	fmt.Fprintln(out, r.concise(err))
+
+	switch {
+	case r.Verbose:
+		fmt.Fprintln(out, VerboseTrace(err, stack))
+	case r.isInteractive():
+		r.prompt(out, err, stack)
+	default:
+		fmt.Fprintln(out, verboseHint)
+	}
+}
+
+// Fatal reports err and exits with the given code (preserving the
+// caller's existing exit semantics).
+func (r *Reporter) Fatal(code int, err error) {
+	r.Report(err)
+	os.Exit(code)
+}
+
+// Fatalf is the fmt-string convenience used by the many call sites that
+// build their message inline. Reports and exits with code.
+func (r *Reporter) Fatalf(code int, format string, a ...any) {
+	r.Report(fmt.Errorf(format, a...))
+	os.Exit(code)
+}
+
+// concise renders "<prefix>: <outermost message>".
+func (r *Reporter) concise(err error) string {
+	if r.Prefix == "" {
+		return err.Error()
+	}
+	return r.Prefix + ": " + err.Error()
+}
+
+// prompt offers the verbose trace on an interactive terminal. The
+// default answer is No (Enter / EOF / anything but y[es]).
+func (r *Reporter) prompt(out io.Writer, err error, stack []byte) {
+	in := r.In
+	if in == nil {
+		in = os.Stdin
+	}
+	fmt.Fprint(out, "Show full diagnostic trace? [y/N]: ")
+	line, _ := bufio.NewReader(in).ReadString('\n')
+	switch strings.ToLower(strings.TrimSpace(line)) {
+	case "y", "yes":
+		fmt.Fprintln(out, VerboseTrace(err, stack))
+	}
+}
+
+func (r *Reporter) isInteractive() bool {
+	if r.interactive != nil {
+		return r.interactive()
+	}
+	in := r.In
+	if in == nil {
+		in = os.Stdin
+	}
+	return IsInteractive(in, os.Stdout)
+}
+
+// IsInteractive reports whether both stdin and stdout are attached to a
+// character device (an interactive terminal). Shared so the launcher
+// and the reporter agree on what "interactive" means.
+func IsInteractive(stdin, stdout *os.File) bool {
+	return isCharDevice(stdin) && isCharDevice(stdout)
+}
+
+func isCharDevice(f *os.File) bool {
+	if f == nil {
+		return false
+	}
+	stat, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	return (stat.Mode() & os.ModeCharDevice) != 0
+}

--- a/internal/diag/reporter_test.go
+++ b/internal/diag/reporter_test.go
@@ -1,0 +1,93 @@
+package diag
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+)
+
+// newTestReporter wires a reporter with a buffer sink, a fixed
+// collector, and an explicit interactivity decision so the prompt path
+// is deterministic in tests.
+func newTestReporter(buf *bytes.Buffer, verbose, interactive bool, stdin *os.File) *Reporter {
+	return &Reporter{
+		Out:         buf,
+		In:          stdin,
+		Collector:   NewCollectorWithDongles(nil, nil),
+		Verbose:     verbose,
+		Prefix:      "test",
+		interactive: func() bool { return interactive },
+	}
+}
+
+func TestReporterNonInteractiveTerse(t *testing.T) {
+	t.Setenv(QuietBannerEnv, "1") // keep output focused on the message + hint
+	var buf bytes.Buffer
+	r := newTestReporter(&buf, false, false, nil)
+	r.Report(errors.New("boom"))
+	out := buf.String()
+	if !strings.Contains(out, "test: boom") {
+		t.Errorf("missing concise message: %q", out)
+	}
+	if !strings.Contains(out, "verbose_errors") {
+		t.Errorf("non-interactive non-verbose should print the verbose hint: %q", out)
+	}
+	if strings.Contains(out, "goroutine") {
+		t.Errorf("should not print a stack when not verbose: %q", out)
+	}
+}
+
+func TestReporterVerbosePrintsTrace(t *testing.T) {
+	t.Setenv(QuietBannerEnv, "1")
+	var buf bytes.Buffer
+	r := newTestReporter(&buf, true, false, nil)
+	r.Report(errors.New("kaboom"))
+	out := buf.String()
+	if !strings.Contains(out, "kaboom") || !strings.Contains(out, "goroutine") {
+		t.Errorf("verbose should print chain + stack: %q", out)
+	}
+	if strings.Contains(out, "[y/N]") {
+		t.Errorf("verbose should not prompt: %q", out)
+	}
+}
+
+func TestReporterInteractivePromptYes(t *testing.T) {
+	t.Setenv(QuietBannerEnv, "1")
+	rd, wr, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rd.Close()
+	go func() { _, _ = wr.WriteString("y\n"); wr.Close() }()
+
+	var buf bytes.Buffer
+	r := newTestReporter(&buf, false, true, rd)
+	r.Report(errors.New("explode"))
+	out := buf.String()
+	if !strings.Contains(out, "[y/N]") {
+		t.Errorf("interactive should prompt: %q", out)
+	}
+	if !strings.Contains(out, "goroutine") {
+		t.Errorf("'y' answer should print the trace: %q", out)
+	}
+}
+
+func TestReporterInteractivePromptNo(t *testing.T) {
+	t.Setenv(QuietBannerEnv, "1")
+	rd, wr, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rd.Close()
+	go func() { _, _ = wr.WriteString("\n"); wr.Close() }() // bare Enter → default No
+
+	var buf bytes.Buffer
+	r := newTestReporter(&buf, false, true, rd)
+	r.Report(errors.New("explode"))
+	out := buf.String()
+	if strings.Contains(out, "goroutine") {
+		t.Errorf("default-No answer should not print the trace: %q", out)
+	}
+}

--- a/internal/diag/sysinfo.go
+++ b/internal/diag/sysinfo.go
@@ -1,0 +1,71 @@
+// Package diag produces the diagnostic banner and verbose error
+// traces that GopherTrunk prepends to every error surface (CLI,
+// daemon log, HTTP/gRPC API, web UI). The banner gives whoever is
+// triaging a failure the macro context — build version, host OS,
+// system specs, and the SDR dongles in play — without them having to
+// ask the operator to run a separate diagnostic command.
+//
+// The package intentionally depends only on internal/version and
+// internal/sdr (plus the stdlib and golang.org/x/sys) so it can be
+// imported from cmd/gophertrunk, internal/api, and the daemon without
+// creating an import cycle.
+package diag
+
+import (
+	"os"
+	"runtime"
+
+	"github.com/MattCheramie/GopherTrunk/internal/version"
+)
+
+// SysInfo is the macro/high-level snapshot rendered in the banner.
+// Zero-valued fields (empty KernelOS, zero MemTotalMB, …) are tolerated
+// and omitted by the banner formatter, so a platform that can't supply
+// a value never produces a broken line.
+type SysInfo struct {
+	Version    string // version.String() — "vX.Y.Z (sha=…, built=…)"
+	GOOS       string // runtime.GOOS
+	GOARCH     string // runtime.GOARCH
+	KernelOS   string // OS/kernel release (uname / RtlGetVersion); "" when unavailable
+	Hostname   string // os.Hostname()
+	NumCPU     int    // runtime.NumCPU()
+	GoVersion  string // runtime.Version()
+	MemTotalMB uint64 // physical RAM in MiB; 0 when unavailable
+	MemInUseMB uint64 // process heap Alloc in MiB
+	Dongles    []DongleInfo
+	DongleErrs []string // EnumerateAll errors, stringified
+}
+
+// DongleInfo is the per-device subset of sdr.Info the banner cares
+// about. Kept independent of sdr.Info so the daemon can populate it
+// from a Pool snapshot without re-enumerating USB.
+type DongleInfo struct {
+	Driver  string
+	Serial  string
+	Product string
+	Tuner   string
+	Index   int
+}
+
+// CollectSysInfo gathers the cheap, side-effect-free fields. It does
+// NOT enumerate dongles — that is costly and touches libusb, so it is
+// deferred to the Collector (see dongles.go).
+func CollectSysInfo() SysInfo {
+	host, _ := os.Hostname()
+	var ms runtime.MemStats
+	runtime.ReadMemStats(&ms)
+
+	kernel, memTotal := kernelInfo()
+
+	return SysInfo{
+		Version:    version.String(),
+		GOOS:       runtime.GOOS,
+		GOARCH:     runtime.GOARCH,
+		KernelOS:   kernel,
+		Hostname:   host,
+		NumCPU:     runtime.NumCPU(),
+		GoVersion:  runtime.Version(),
+		MemTotalMB: memTotal,
+		MemInUseMB: ms.Alloc / (1024 * 1024),
+	}
+}

--- a/internal/diag/sysinfo_linux.go
+++ b/internal/diag/sysinfo_linux.go
@@ -1,0 +1,47 @@
+//go:build linux
+
+package diag
+
+import (
+	"bytes"
+
+	"golang.org/x/sys/unix"
+)
+
+// kernelInfo returns the kernel release string ("Linux 6.18.5") and
+// total physical RAM (MiB) via uname(2) and sysinfo(2). Both are
+// best-effort; a failing syscall leaves the zero value, which the
+// banner omits.
+func kernelInfo() (kernel string, memTotalMB uint64) {
+	var u unix.Utsname
+	if err := unix.Uname(&u); err == nil {
+		sys := nulTrim(u.Sysname[:])
+		rel := nulTrim(u.Release[:])
+		switch {
+		case sys != "" && rel != "":
+			kernel = sys + " " + rel
+		case rel != "":
+			kernel = rel
+		default:
+			kernel = sys
+		}
+	}
+
+	var si unix.Sysinfo_t
+	if err := unix.Sysinfo(&si); err == nil {
+		unitsz := uint64(si.Unit)
+		if unitsz == 0 {
+			unitsz = 1
+		}
+		memTotalMB = (uint64(si.Totalram) * unitsz) / (1024 * 1024)
+	}
+	return kernel, memTotalMB
+}
+
+// nulTrim converts a NUL-padded Utsname field to a Go string.
+func nulTrim(b []byte) string {
+	if i := bytes.IndexByte(b, 0); i >= 0 {
+		b = b[:i]
+	}
+	return string(b)
+}

--- a/internal/diag/sysinfo_other.go
+++ b/internal/diag/sysinfo_other.go
@@ -1,0 +1,11 @@
+//go:build !linux && !windows
+
+package diag
+
+// kernelInfo is the portable fallback for platforms without a
+// dedicated implementation (darwin, freebsd, …). GOOS/GOARCH and the
+// Go runtime version still populate the banner; the kernel string and
+// physical-RAM total are simply omitted.
+func kernelInfo() (kernel string, memTotalMB uint64) {
+	return "", 0
+}

--- a/internal/diag/sysinfo_windows.go
+++ b/internal/diag/sysinfo_windows.go
@@ -1,0 +1,23 @@
+//go:build windows
+
+package diag
+
+import (
+	"fmt"
+
+	"golang.org/x/sys/windows"
+)
+
+// kernelInfo returns a Windows version string via RtlGetVersion (which
+// reports the real build numbers, unlike the manifest-shimmed
+// GetVersionEx). Physical RAM is not collected here — x/sys/windows
+// exposes no GlobalMemoryStatusEx wrapper at this version — so it is
+// left zero and the banner omits the mem total. Process heap usage is
+// still reported by CollectSysInfo via runtime.MemStats.
+func kernelInfo() (kernel string, memTotalMB uint64) {
+	if v := windows.RtlGetVersion(); v != nil {
+		kernel = fmt.Sprintf("Windows %d.%d build %d",
+			v.MajorVersion, v.MinorVersion, v.BuildNumber)
+	}
+	return kernel, 0
+}

--- a/internal/diag/trace.go
+++ b/internal/diag/trace.go
@@ -1,0 +1,63 @@
+package diag
+
+import (
+	"errors"
+	"fmt"
+	"runtime/debug"
+	"strings"
+)
+
+// Chain unwraps the %w error chain and returns one entry per layer,
+// outermost first. It also descends into multi-error joins (the
+// Unwrap() []error shape produced by errors.Join). A nil error yields
+// an empty slice.
+//
+// The code base wraps with fmt.Errorf("…: %w", err) and never attaches
+// stack frames to errors, so this gives the full causal chain that
+// today's terse single-line message collapses.
+func Chain(err error) []string {
+	var out []string
+	var walk func(e error)
+	walk = func(e error) {
+		for e != nil {
+			out = append(out, e.Error())
+			// Multi-error join: recurse into each branch, then stop
+			// the linear walk (Unwrap() error and Unwrap() []error are
+			// mutually exclusive on a given value).
+			if joined, ok := e.(interface{ Unwrap() []error }); ok {
+				for _, sub := range joined.Unwrap() {
+					walk(sub)
+				}
+				return
+			}
+			e = errors.Unwrap(e)
+		}
+	}
+	walk(err)
+	return out
+}
+
+// CaptureStack returns a goroutine stack dump for the calling
+// goroutine, captured at the call site. Thin wrapper over
+// runtime/debug.Stack so callers don't import debug directly.
+func CaptureStack() []byte { return debug.Stack() }
+
+// VerboseTrace renders the full error chain followed by the captured
+// goroutine stack as a single multi-line string, suitable for printing
+// under the banner or embedding in a log/JSON field. stack may be nil
+// to omit the dump.
+func VerboseTrace(err error, stack []byte) string {
+	var b strings.Builder
+	chain := Chain(err)
+	if len(chain) > 0 {
+		b.WriteString("error chain (outermost first):\n")
+		for i, layer := range chain {
+			fmt.Fprintf(&b, "  [%d] %s\n", i, layer)
+		}
+	}
+	if len(stack) > 0 {
+		b.WriteString("\ngoroutine stack:\n")
+		b.Write(stack)
+	}
+	return b.String()
+}

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -24,15 +24,43 @@ export interface ClientConfig {
   token: string | null;
 }
 
+// DiagInfo is the optional diagnostics payload the daemon attaches to
+// an error envelope when diagnostics.verbose_errors is enabled. The
+// banner carries version/OS/system/dongle context useful for triage.
+export interface DiagInfo {
+  banner: string;
+  trace?: string[];
+  stack?: string;
+}
+
 export class HTTPError extends Error {
   constructor(
     public readonly status: number,
     public readonly body: string,
     message: string,
+    // diag is populated when the daemon returned a verbose error
+    // envelope ({"error":..., "diag":{"banner":...}}). undefined when
+    // verbose errors are off or the body wasn't the JSON envelope.
+    public readonly diag?: DiagInfo,
   ) {
     super(message);
     this.name = "HTTPError";
   }
+}
+
+// parseErrorBody extracts the {"error", "diag"} envelope from a JSON
+// error body. Returns the concise message and the optional diag block;
+// falls back to the raw text for non-JSON bodies.
+function parseErrorBody(text: string): { message: string; diag?: DiagInfo } {
+  try {
+    const obj = JSON.parse(text) as { error?: string; diag?: DiagInfo };
+    if (obj && typeof obj === "object" && (obj.error || obj.diag)) {
+      return { message: obj.error ?? text, diag: obj.diag };
+    }
+  } catch {
+    // not JSON — fall through to raw text
+  }
+  return { message: text };
 }
 
 /** Default per-request timeout. Long enough for a slow Pi, short enough
@@ -74,10 +102,12 @@ async function request<T>(
 
   if (!res.ok) {
     const text = await safeReadText(res);
+    const { message, diag } = parseErrorBody(text);
     throw new HTTPError(
       res.status,
       text,
-      `${method} ${path} → ${res.status}: ${text || res.statusText}`,
+      `${method} ${path} → ${res.status}: ${message || res.statusText}`,
+      diag,
     );
   }
 

--- a/web/src/components/ErrorBoundary.tsx
+++ b/web/src/components/ErrorBoundary.tsx
@@ -1,4 +1,5 @@
 import { Component, type ErrorInfo, type ReactNode } from "react";
+import { HTTPError } from "../api/client";
 
 interface Props {
   children: ReactNode;
@@ -87,6 +88,20 @@ export class ErrorBoundary extends Component<Props, State> {
           <pre className="text-xs text-err whitespace-pre-wrap break-words">
             {error.message}
           </pre>
+          {error instanceof HTTPError && error.diag ? (
+            <details className="text-xs text-muted">
+              <summary className="cursor-pointer">
+                Show diagnostics
+              </summary>
+              <pre className="mt-2 whitespace-pre-wrap break-words">
+                {error.diag.banner}
+                {error.diag.trace?.length
+                  ? "\n\n" + error.diag.trace.join("\n")
+                  : ""}
+                {error.diag.stack ? "\n\n" + error.diag.stack : ""}
+              </pre>
+            </details>
+          ) : null}
           <button
             className="btn-primary w-full"
             onClick={() => window.location.reload()}


### PR DESCRIPTION
Introduce internal/diag: a shared error-diagnostics package that prepends
a banner (build version, OS/kernel, host specs, detected dongles) to every
error surface and offers a full verbose trace (unwrapped %w chain + a
goroutine stack dump).

- internal/diag: SysInfo collector (per-OS kernel/RAM via x/sys with a
  portable fallback), lazy/injectable dongle Collector that never
  re-enumerates a live USB claim, banner renderer, trace formatter, and a
  CLI Reporter that prints the banner + concise error then either prints the
  trace (verbose) or offers it interactively on a TTY (default No), with a
  non-interactive hint fallback.
- CLI/launcher: route the ad-hoc stderr+os.Exit sites in main, import,
  audio, decode, replay, and tui through the reporter, preserving exit
  codes; emit a one-time banner to the daemon log at startup.
- config: new top-level diagnostics.verbose_errors, overridable by the
  -verbose-errors flag and GOPHERTRUNK_VERBOSE_ERRORS env var.
- HTTP API: writeError becomes a Server method that attaches the banner to
  the JSON envelope when verbose is enabled; new GET /api/v1/diag/banner
  (gated) for on-demand fetch by the web UI.
- gRPC: server interceptors decorate failing RPCs with the banner + chain
  when verbose (config) or the gophertrunk-verbose metadata key is set,
  preserving the status code.
- web: HTTPError carries an optional diag block parsed from the error body;
  ErrorBoundary surfaces it in a collapsible diagnostics panel.

Tests cover banner formatting, chain/join unwrapping, the reporter prompt
paths, collector memoization, the HTTP envelope gating, the banner endpoint,
and the gRPC interceptor.

https://claude.ai/code/session_01JL9L6n17uPZSPDqHwXpwEG