### PR TITLE
p25/cqpsk: fire the carrier seed under streaming chunk sizes (#492)

### DIFF
--- a/internal/radio/p25/phase1/receiver/cqpsk.go
+++ b/internal/radio/p25/phase1/receiver/cqpsk.go
@@ -107,6 +107,14 @@ func seedCarrierOffsetHz(x []complex64, fs float64) float64 {
 		accR += ar*br + ai*bi
 		accI += ai*br - ar*bi
 	}
+	return seedHzFromAcc(accR, accI, fs)
+}
+
+// seedHzFromAcc converts running lag-1 autocorrelation accumulators
+// (Σ x[n]·conj(x[n−1])) to a clamped coarse carrier estimate in Hz. Shared
+// by seedCarrierOffsetHz (slice) and the streaming seed that accumulates
+// across process() calls, so both use identical math.
+func seedHzFromAcc(accR, accI, fs float64) float64 {
 	hz := math.Atan2(accI, accR) * fs / (2 * math.Pi)
 	if hz > cqpskSeedClampHz {
 		hz = cqpskSeedClampHz
@@ -145,6 +153,19 @@ type cqpskDemod struct {
 	fs     float64 // IQ sample rate, for the NCO seed and Hz reporting
 	seeded bool    // coarse carrier seed applied
 	seedHz float64 // coarse carrier offset the NCO removes (Hz)
+
+	// Coarse-seed accumulators. Production feeds the receiver only
+	// ~160–200 complex samples per process() call (the ccdecoder DDC
+	// output), far below cqpskSeedMinSamples, so the seed cannot key off a
+	// single chunk's length — it must accumulate the lag-1 autocorrelation
+	// Σ x[n]·conj(x[n−1]) across calls until it has seen enough raw samples,
+	// then fire once. Without this the per-call gate never trips on a
+	// streamed input and the NCO stays an identity mix (issue #492).
+	seedAccR     float64   // running Re Σ x[n]·conj(x[n−1])
+	seedAccI     float64   // running Im Σ x[n]·conj(x[n−1])
+	seedCount    int       // lag-1 products folded into the accumulators
+	seedHavePrev bool      // seedPrev holds a valid cross-call boundary sample
+	seedPrev     complex64 // last raw IQ sample of the previous chunk
 
 	// cmaErr is the CMA's most recent |y|²−R² convergence proxy,
 	// retained for the replay receiver-state diagnostic (issue #492).
@@ -185,18 +206,46 @@ func newCQPSKDemod(sampleRateHz float64, sps int, span int, alpha float64, gardn
 // not corrupt the stream.
 func (c *cqpskDemod) process(iq []complex64) []uint8 {
 	// Carrier recovery, coarse stage: a real tuner's residual offset is
-	// far outside the fine loop's ±baud/8 pull-in, so estimate it once
-	// from the raw IQ and tune it out with the NCO. Estimate on the raw
+	// far outside the fine loop's ±baud/8 pull-in, so estimate it from the
+	// raw IQ and tune it out with the NCO. Estimate on the raw
 	// (pre-matched-filter) stream: the RRC matched filter is a lowpass
 	// centred at DC, so it clips the high sideband of an offset signal and
 	// would bias the estimate toward zero. De-rotating before the matched
-	// filter also presents the filter a centred channel. Until seeded the
-	// NCO is an identity mix, so a centred/zero-offset stream is unaffected;
-	// the fine Costas loop then cleans up the residual and tracks drift.
-	if !c.seeded && len(iq) >= cqpskSeedMinSamples {
-		c.seedHz = seedCarrierOffsetHz(iq, c.fs)
-		c.nco.SetOffset(c.seedHz, c.fs)
-		c.seeded = true
+	// filter also presents the filter a centred channel.
+	//
+	// Production delivers only ~160–200 samples per call, so the seed must
+	// accumulate the lag-1 autocorrelation across calls (carrying the
+	// boundary sample) until it has enough, rather than keying off one
+	// chunk's length — otherwise the gate never trips on a streamed input
+	// and the NCO stays an identity mix (issue #492). Until seeded the NCO
+	// is identity, so a centred/zero-offset stream is unaffected; the fine
+	// Costas loop then cleans up the residual and tracks drift.
+	if !c.seeded {
+		for n := 0; n < len(iq); n++ {
+			if c.seedHavePrev {
+				ar, ai := float64(real(iq[n])), float64(imag(iq[n]))
+				br, bi := float64(real(c.seedPrev)), float64(imag(c.seedPrev))
+				c.seedAccR += ar*br + ai*bi // Re x[n]·conj(x[n−1])
+				c.seedAccI += ai*br - ar*bi // Im x[n]·conj(x[n−1])
+				c.seedCount++
+			}
+			c.seedPrev = iq[n]
+			c.seedHavePrev = true
+		}
+		if c.seedCount >= cqpskSeedMinSamples {
+			c.seedHz = seedHzFromAcc(c.seedAccR, c.seedAccI, c.fs)
+			c.nco.SetOffset(c.seedHz, c.fs)
+			c.seeded = true
+			// The pre-seed samples ran through with an identity NCO, so the
+			// Costas frequency integrator wound toward the uncorrected offset
+			// (railing at its ±baud/8 clamp) and the CMA adapted to a spinning
+			// constellation. Reset both so they re-acquire on the now-centred
+			// signal instead of over-de-rotating. Gardner is left running — it
+			// re-locks on clean input within a few symbols, and leaving it
+			// preserves symbol timing/alignment.
+			c.costas.Reset()
+			c.cma.Reset()
+		}
 	}
 	c.rotated = c.nco.Mix(c.rotated, iq)
 	c.matched = c.dq.MatchedFilter(c.matched, c.rotated)
@@ -248,4 +297,9 @@ func (c *cqpskDemod) reset() {
 	c.costas.Reset()
 	c.seeded = false
 	c.seedHz = 0
+	c.seedAccR = 0
+	c.seedAccI = 0
+	c.seedCount = 0
+	c.seedHavePrev = false
+	c.seedPrev = 0
 }

--- a/internal/radio/p25/phase1/receiver/cqpsk_test.go
+++ b/internal/radio/p25/phase1/receiver/cqpsk_test.go
@@ -192,6 +192,26 @@ func TestCQPSKDemodRecoversFSW(t *testing.T) {
 // both signs, and one case with additive noise so a too-tight loop that
 // can only acquire on a perfectly clean fixture is caught.
 func TestCQPSKDemodRecoversFSWWithCarrierOffset(t *testing.T) {
+	// Single-buffer path: one chunk larger than the whole fixture.
+	runCQPSKCarrierOffsetSweep(t, 4096)
+}
+
+// TestCQPSKDemodRecoversFSWWithCarrierOffsetStreaming is the same sweep fed
+// in production-realistic small chunks. The live SDR + replay both hand the
+// receiver only ~160–200 samples per Process() call (8192 SDR samples ÷ the
+// ~42× DDC ratio), far below cqpskSeedMinSamples. The earlier 4096-chunk
+// test fired the coarse seed on its first chunk and so never exercised the
+// streamed path — where the per-call length gate never tripped, the NCO
+// stayed identity, the carrier was never removed, and the post-Gardner
+// Costas railed at its ±baud/8 clamp (issue #492 round 2). This guards that
+// the accumulated seed fires across many tiny chunks, including the >600 Hz
+// offsets the Costas clamp alone cannot reach.
+func TestCQPSKDemodRecoversFSWWithCarrierOffsetStreaming(t *testing.T) {
+	runCQPSKCarrierOffsetSweep(t, 192)
+}
+
+func runCQPSKCarrierOffsetSweep(t *testing.T, chunk int) {
+	t.Helper()
 	const sampleRate = 48_000.0
 	const sps = 10
 
@@ -245,7 +265,6 @@ func TestCQPSKDemodRecoversFSWWithCarrierOffset(t *testing.T) {
 				DibitSink:    func(d []uint8, _ int) { captured = append(captured, d...) },
 			})
 			shifted := base[k:]
-			const chunk = 4096
 			for i := 0; i < len(shifted); i += chunk {
 				end := i + chunk
 				if end > len(shifted) {
@@ -259,8 +278,8 @@ func TestCQPSKDemodRecoversFSWWithCarrierOffset(t *testing.T) {
 			}
 		}
 		if locked < 6 {
-			t.Errorf("offset=%.0f Hz snr=%.0f dB: recovered FSW from only %d/%d starting phases; want >= 6 (issue #492 carrier recovery)",
-				tc.offsetHz, tc.snrDB, locked, sps)
+			t.Errorf("chunk=%d offset=%.0f Hz snr=%.0f dB: recovered FSW from only %d/%d starting phases; want >= 6 (issue #492 carrier recovery)",
+				chunk, tc.offsetHz, tc.snrDB, locked, sps)
 		}
 	}
 }


### PR DESCRIPTION
Follow-up to #497. The reporter re-tested the merged carrier recovery on `main` and CQPSK **still never locks**: `carrier_hz_est` slews up and then **rails at ~600 Hz** (the `QPSKCostas` ±baud/8 clamp) for the whole run, `gardner_mu` drifts, 0 FSW hits.

## Root cause

The coarse carrier seed only fired when a *single* `process()` call carried `>= cqpskSeedMinSamples` (2048) samples. **Production never delivers chunks that big.** The SDR hands the ccdecoder ~8192 samples and the downconverter decimates 2–2.4 MHz → 48 kHz, so the P25 receiver gets only **~160–200 complex samples per `Process()` call** (same on the live and replay paths). The per-call length gate never tripped → `seedHz` stayed 0 → the NCO was an identity mix → the full tuner offset reached Gardner (~0.78 rad of rotation between symbol-spaced samples at 48 kHz), wrecking the timing-error detector, and the post-Gardner Costas (clamped at ±baud/8) could neither rescue timing nor reach the true offset.

The offset test added in #497 fed **4096-sample chunks**, so the seed fired in-test and the streaming bug stayed hidden.

## Fix

- **Accumulate the lag-1 autocorrelation (`Σ x[n]·conj(x[n-1])`) across `process()` calls** — carrying the cross-call boundary sample — until `cqpskSeedMinSamples` products have been seen, then seed once. The estimator math is unchanged (factored into a shared `seedHzFromAcc`, also used by the slice version); only the *gate* moves from per-call length to an accumulated count.
- **Reset the Costas and CMA when the seed fires.** During the ~43 ms pre-seed window they adapt to the uncorrected, spinning signal (the Costas integrator winds toward the railing clamp; the CMA to a rotating constellation), so without a reset they would over-de-rotate the now-centred stream for seconds. Gardner is left running — it re-locks on the cleaned input within a few symbols and keeping it preserves symbol timing/alignment.

## Tests

The offset sweep is now a shared helper run at two chunk sizes:
- `TestCQPSKDemodRecoversFSWWithCarrierOffsetStreaming` feeds **192-sample chunks** (below the seed threshold, matching production) across ±200…±2500 Hz plus an 18 dB-SNR case. Pre-fix the seed never fires at that chunk size and the >600 Hz cases never lock; post-fix all lock.
- `TestCQPSKDemodRecoversFSWWithCarrierOffset` keeps the 4096-chunk single-buffer path.

Full regression green: `internal/radio/p25/phase1/receiver` (incl. C4FM) and `internal/dsp/sync`, plus `go build ./...`.

## Verification on a real capture

Replayed the committed `samples/mmr/mmr-s9-1.cfile` (C4FM locks it: nac=0x164, 41 TSBK). With this fix the **carrier no longer rails** — `carrier_hz_est` is stable (~−350 Hz) instead of slewing to 600. That capture still doesn't fully lock on CQPSK because it is heavy simulcast **multipath** that closes the eye (`gardner_mu` drifts from eye-closure, not carrier) — a separate issue-#275 concern, not the #492 carrier bug.

The reporter's own capture is clean (C4FM 100%, `effective baud 4800.0`), so its `gardner_mu` drift was caused by the *railing carrier* closing the eye — which this fix removes. Asking the reporter to re-confirm on their capture.

https://claude.ai/code/session_01WpictPD5YAE9mTJgAWKdh4

---
_Generated by [Claude Code](https://claude.ai/code/session_01WpictPD5YAE9mTJgAWKdh4)_