### PR TITLE
ci: bump Go toolchain 1.25.10 → 1.25.11 to clear govulncheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.25.10"
+          go-version: "1.25.11"
       # Linux audio playback runs through internal/voice/player/alsa_linux.go,
       # which dlopens libasound2.so.2 via github.com/ebitengine/purego at
       # runtime. No build-time dev headers required; the runtime library
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.25.10"
+          go-version: "1.25.11"
       - name: Build (CGO disabled)
         env:
           CGO_ENABLED: "0"
@@ -77,7 +77,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.25.10"
+          go-version: "1.25.11"
       - name: Build (CGO disabled)
         env:
           CGO_ENABLED: "0"
@@ -102,7 +102,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.25.10"
+          go-version: "1.25.11"
       - name: Vet (tagged)
         run: go vet -tags dvsi ./internal/voice/dvsi/...
       - name: Build (tagged)
@@ -122,7 +122,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.25.10"
+          go-version: "1.25.11"
       - run: make test-integration
 
   # govulncheck enumerates known CVEs that affect the direct +
@@ -136,7 +136,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.25.10"
+          go-version: "1.25.11"
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest
       - name: Scan
@@ -156,7 +156,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.25.10"
+          go-version: "1.25.11"
       - name: Install go-licenses
         run: go install github.com/google/go-licenses/v2@latest
       - name: Regenerate inventory

--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -57,7 +57,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.25.10"
+          go-version: "1.25.11"
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.25.10"
+          go-version: "1.25.11"
 
       - uses: actions/setup-node@v4
         with:
@@ -177,7 +177,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.25.10"
+          go-version: "1.25.11"
 
       - uses: actions/setup-node@v4
         with:
@@ -238,7 +238,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.25.10"
+          go-version: "1.25.11"
 
       - uses: actions/setup-node@v4
         with:

--- a/go.mod
+++ b/go.mod
@@ -2,14 +2,15 @@ module github.com/MattCheramie/GopherTrunk
 
 go 1.25.0
 
-// Toolchain pinned to 1.25.10 to close the 23 stdlib CVEs
-// govulncheck surfaced against go1.25.0 (html/template XSS,
-// crypto/tls KeyUpdate DoS + ALPN info leak, crypto/x509 chain
-// build + policy validation, net/url IPv6 + query parse, etc.).
-// The toolchain directive auto-downloads 1.25.10 on a build host
-// running an older 1.25.x; CI's setup-go is pinned to the same
-// version so the toolchain download doesn't run at every CI step.
-toolchain go1.25.10
+// Toolchain pinned to 1.25.11 to close the stdlib CVEs govulncheck
+// surfaced against earlier 1.25.x (html/template XSS, crypto/tls
+// KeyUpdate DoS + ALPN info leak, crypto/x509 chain build + policy
+// validation + inefficient hostname parsing, net/url IPv6 + query
+// parse, net/textproto unescaped error inputs, etc.). The toolchain
+// directive auto-downloads 1.25.11 on a build host running an older
+// 1.25.x; CI's setup-go is pinned to the same version so the toolchain
+// download doesn't run at every CI step.
+toolchain go1.25.11
 
 require gopkg.in/yaml.v3 v3.0.1
 


### PR DESCRIPTION
## What

Bump the pinned Go toolchain `1.25.10` → `1.25.11` in `go.mod` and the `setup-go` version across all workflows (`ci.yml`, `installer.yml`, `release.yml`).

## Why

`govulncheck ./...` fails on two **Go standard-library** advisories present in go1.25.10 and fixed in go1.25.11:

| Advisory | Package | Reached via |
|---|---|---|
| [GO-2026-5037](https://pkg.go.dev/vuln/GO-2026-5037) | `crypto/x509` — inefficient candidate hostname parsing | `http.Server.Serve` → x509 verify; `diag.CollectDongles` → `x509.HostnameError.Error` |
| [GO-2026-5039](https://pkg.go.dev/vuln/GO-2026-5039) | `net/textproto` — arbitrary inputs in errors without escaping | `io.ReadAll` → `textproto.Reader.ReadMIMEHeader` (OpenMHz backend) |

Both are toolchain-version issues, not code — the only fix is building against the patched standard library. This is unrelated to any feature work and currently fails `main` and every open PR identically (surfaced on #503); landing it here unblocks all of them.

## Verification

`go build ./...` clean on go1.25.11 (the toolchain directive auto-downloads it). No remaining `1.25.10` references in `go.mod` or `.github/`.

https://claude.ai/code/session_01WpictPD5YAE9mTJgAWKdh4

---
_Generated by [Claude Code](https://claude.ai/code/session_01WpictPD5YAE9mTJgAWKdh4)_