### PR TITLE
perf(rtlsdr): stop shedding live IQ on the control channel (#489)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -513,6 +513,16 @@ type MessageLogConfig struct {
 }
 
 type SDRConfig struct {
+	// SampleRate is the IQ rate (Hz) every tuner is programmed to.
+	// Default 2_400_000 (2.4 MS/s). Valid range 225_000..3_200_000; the
+	// RTL2832U quantizes to its 28.4 fixed-point divisor so the streamed
+	// rate may differ slightly (see Device.ActualSampleRate). This is
+	// also the primary load lever on CPU-bound hosts: convert + resample
+	// cost scales with it, so if the daemon logs "sdr: dropping live IQ
+	// chunks; consumer can't keep up" (iq_underruns_total climbing),
+	// lowering it — e.g. to 1_024_000 — roughly halves per-chunk decode
+	// work. Running fewer simultaneous dongles on a weak CPU has the same
+	// effect.
 	SampleRate uint32         `yaml:"sample_rate"`
 	Devices    []DeviceConfig `yaml:"devices"`
 	// RTLTCP lists remote rtl_tcp endpoints (host:port + optional

--- a/internal/sdr/rtlsdr/purego/device.go
+++ b/internal/sdr/rtlsdr/purego/device.go
@@ -42,6 +42,16 @@ type Device struct {
 	out      chan []complex64
 	stopOnce sync.Once
 
+	// ring is a small pool of preallocated complex64 buffers that
+	// [Device.deliver] cycles through so the hot IQ path allocates
+	// nothing per chunk (issue #489). It is provisioned by StreamIQ
+	// (sized streamChanDepth+2 so the producer never overwrites a
+	// buffer still queued on out or being processed by the consumer)
+	// and read/advanced only under streamMu. nil outside an active
+	// stream — deliver then falls back to a fresh allocation.
+	ring    [][]complex64
+	ringIdx int
+
 	// dropped counts IQ chunks discarded by deliver's overrun branch
 	// over this device's lifetime. Exposed via DroppedChunks for tests
 	// and as the per-drop signal behind the dropObserver hook.

--- a/internal/sdr/rtlsdr/purego/stream.go
+++ b/internal/sdr/rtlsdr/purego/stream.go
@@ -17,10 +17,16 @@ const (
 	asyncBufCount = 32
 	asyncBufLen   = 16 * 1024
 
-	// streamChanDepth matches rtlsdr_cgo.go:190 — `make(chan
-	// []complex64, 8)`. Drop-on-overrun semantics in [Device.deliver]
-	// rely on this being non-zero.
-	streamChanDepth = 8
+	// streamChanDepth is the consumer-channel depth. The CGO driver
+	// (rtlsdr_cgo.go:190) used 8; the pure-Go backend deliberately runs
+	// deeper — 32 chunks ≈ 110 ms at 2.4 MS/s — to absorb GC/scheduler
+	// jitter on the consumer (e.g. the ccdecoder resample+decode loop)
+	// without dropping live IQ. See issue #489: a CC SDR was shedding
+	// 25–48 % of chunks under a momentarily-busy consumer. Drop-on-overrun
+	// semantics in [Device.deliver] still rely on this being non-zero;
+	// deeper only adds slack, it is not a substitute for the per-chunk
+	// allocation removal (the ring in [Device.ring]) that landed with it.
+	streamChanDepth = 32
 
 	// bulkInEndpoint is the RTL-SDR bulk-IN endpoint address. Hardware
 	// invariant — every RTL2832U exposes the IQ stream here.
@@ -58,6 +64,20 @@ func (d *Device) StreamIQ(ctx context.Context) (<-chan []complex64, error) {
 	d.out = out
 	d.stopOnce = sync.Once{}
 
+	// Provision the reuse ring for this stream (issue #489). Sized
+	// streamChanDepth+2: at most streamChanDepth buffers can sit queued
+	// on out plus one in the consumer, so cycling through depth+2 slots
+	// guarantees the producer never overwrites a buffer still in flight.
+	// Tied to the stream lifetime — a fresh ring per stream means a slow
+	// consumer draining the *previous* (closed) channel can never alias a
+	// buffer the new stream is writing.
+	ring := make([][]complex64, streamChanDepth+2)
+	for i := range ring {
+		ring[i] = make([]complex64, asyncBufLen/2)
+	}
+	d.ring = ring
+	d.ringIdx = 0
+
 	if err := d.transport.StartBulkIn(bulkInEndpoint, asyncBufCount, asyncBufLen, d.deliver, d.onStreamDead); err != nil {
 		d.out = nil
 		return nil, fmt.Errorf("rtlsdr: StartBulkIn: %w", err)
@@ -91,16 +111,32 @@ func (d *Device) onStreamDead(error) {
 // behind. Bit-identical conversion math to rtlsdr_cgo.go:225-240
 // so downstream DSP sees the same bit pattern from either backend.
 func (d *Device) deliver(buf []byte) {
-	samples := convertU8IQ(buf)
+	// The whole critical section runs under streamMu. On Linux/Windows a
+	// single reaper goroutine drives deliver, so the lock is uncontended;
+	// on Darwin the per-slot reapers (usb_darwin.go) call deliver
+	// concurrently, and the lock is what makes the shared reuse ring safe.
+	// The conversion is cheap (a u8→complex64 LUT) — the expensive resample
+	// lives in the consumer — so serializing it costs effectively nothing
+	// against the USB ring's ~110 ms of buffering headroom.
 	d.streamMu.Lock()
 	out := d.out
-	d.streamMu.Unlock()
 	if out == nil {
+		d.streamMu.Unlock()
 		return
 	}
+	samples := d.fillBufferLocked(buf)
 	select {
 	case out <- samples:
+		// Advance the ring only on a successful enqueue: a dropped chunk
+		// reuses the same buffer next time, so a buffer's slot is never
+		// recycled until that chunk has actually been handed to the
+		// consumer.
+		if len(d.ring) > 0 {
+			d.ringIdx = (d.ringIdx + 1) % len(d.ring)
+		}
+		d.streamMu.Unlock()
 	default:
+		d.streamMu.Unlock()
 		// Consumer can't keep up. Drop the whole chunk and record it:
 		// this was silent before issue #402, which is why live IQ loss
 		// could not be distinguished from RF problems. A non-zero
@@ -108,28 +144,73 @@ func (d *Device) deliver(buf []byte) {
 		// live-path overrun rather than the air. The dropObserver hook
 		// drives the operator-facing Prometheus counter + a
 		// rate-limited warning — see internal/metrics and
-		// sdr.SetIQDropObserver.
+		// sdr.SetIQDropObserver. NotifyIQDrop runs outside the lock so the
+		// observer callback can't stall the reaper.
 		d.dropped.Add(1)
 		sdr.NotifyIQDrop(d.info)
 	}
 }
 
-// convertU8IQ translates a slice of unsigned-8-bit IQ pairs into
-// normalized complex64 samples. The conversion is the bit-identical
-// port of rtlsdr_cgo.go:225-240:
+// fillBufferLocked converts one bulk-IN buffer into complex64 samples,
+// reusing the current ring slot to avoid a ~64 KiB allocation per chunk
+// (issue #489: that churn drove GC pauses that pushed the CC consumer
+// over its real-time budget and shed live IQ). Falls back to a fresh
+// allocation when no ring is provisioned (direct deliver in tests) or for
+// the rare oversized packet that would not fit a ring slot. Caller must
+// hold streamMu.
+func (d *Device) fillBufferLocked(buf []byte) []complex64 {
+	n := len(buf) / 2
+	if len(d.ring) == 0 {
+		return convertU8IQ(buf)
+	}
+	dst := d.ring[d.ringIdx]
+	if cap(dst) < n {
+		// Packet larger than a ring slot — don't disturb the ring,
+		// just allocate this one. Should not happen for asyncBufLen URBs.
+		return convertU8IQ(buf)
+	}
+	dst = dst[:n]
+	convertU8IQInto(dst, buf)
+	return dst
+}
+
+// u8ToF32 maps each possible u8 IQ byte to its normalized float32 value,
+// precomputed once so the hot conversion path is two table lookups per
+// sample instead of a subtract+divide (issue #489). Each entry uses the
+// exact same float32 expression as the original per-sample math
+// ((b-127.5)/127.5), so the result is bit-identical — pinned by
+// [TestConvertU8IQ_BitIdenticalWithCGO].
+var u8ToF32 [256]float32
+
+func init() {
+	for b := 0; b < 256; b++ {
+		u8ToF32[b] = (float32(b) - 127.5) / 127.5
+	}
+}
+
+// convertU8IQInto translates a slice of unsigned-8-bit IQ pairs into
+// normalized complex64 samples, writing into dst (which must have room
+// for len(buf)/2 samples). Allocation-free — this is the form the hot
+// deliver path uses against its reuse ring. The conversion is the
+// bit-identical port of rtlsdr_cgo.go:225-240:
 //
 //   - DC bias of 127.5 (mid-range of u8) is subtracted.
 //   - Result is divided by 127.5 to scale to [-1, +1).
+func convertU8IQInto(dst []complex64, buf []byte) {
+	n := len(buf) / 2
+	for i := 0; i < n; i++ {
+		dst[i] = complex(u8ToF32[buf[2*i]], u8ToF32[buf[2*i+1]])
+	}
+}
+
+// convertU8IQ is the allocating convenience wrapper around
+// convertU8IQInto, used where a fresh slice is wanted (tests, the
+// no-ring fallback in [Device.fillBufferLocked]).
 //
 // Pinned by [TestConvertU8IQ_BitIdenticalWithCGO] so any drift from
 // the CGO driver shows up immediately.
 func convertU8IQ(buf []byte) []complex64 {
-	n := len(buf) / 2
-	out := make([]complex64, n)
-	for i := 0; i < n; i++ {
-		i8 := float32(buf[2*i]) - 127.5
-		q8 := float32(buf[2*i+1]) - 127.5
-		out[i] = complex(i8/127.5, q8/127.5)
-	}
+	out := make([]complex64, len(buf)/2)
+	convertU8IQInto(out, buf)
 	return out
 }

--- a/internal/sdr/rtlsdr/purego/stream_test.go
+++ b/internal/sdr/rtlsdr/purego/stream_test.go
@@ -326,7 +326,7 @@ func TestDevice_CloseIdempotent(t *testing.T) {
 }
 
 func TestStreamConstants_MatchCGOGeometry(t *testing.T) {
-	// Pin the buffer geometry so any drift from the CGO driver
+	// Pin the USB-side buffer geometry so any drift from the CGO driver
 	// (which still ships in rtlsdr_cgo.go until PR-09) shows up
 	// as a test failure.
 	if asyncBufCount != 32 {
@@ -335,11 +335,80 @@ func TestStreamConstants_MatchCGOGeometry(t *testing.T) {
 	if asyncBufLen != 16*1024 {
 		t.Errorf("asyncBufLen = %d, want 16384 (matches rtlsdr_cgo.go:44)", asyncBufLen)
 	}
-	if streamChanDepth != 8 {
-		t.Errorf("streamChanDepth = %d, want 8 (matches rtlsdr_cgo.go:190)", streamChanDepth)
-	}
 	if bulkInEndpoint != 0x81 {
 		t.Errorf("bulkInEndpoint = 0x%02x, want 0x81", bulkInEndpoint)
+	}
+	// streamChanDepth deliberately diverges from the CGO driver's 8 — the
+	// pure-Go backend runs deeper (32) to absorb consumer jitter without
+	// shedding live IQ (issue #489). Pin the new value, and keep it
+	// non-zero so [Device.deliver]'s drop-on-overrun select is real.
+	if streamChanDepth != 32 {
+		t.Errorf("streamChanDepth = %d, want 32 (issue #489 headroom)", streamChanDepth)
+	}
+	if streamChanDepth < 1 {
+		t.Errorf("streamChanDepth must be >= 1 for drop-on-overrun semantics")
+	}
+}
+
+// TestConvertU8IQInto_ZeroAllocMatchesAllocating proves the hot-path
+// conversion (issue #489) writes into a caller buffer with no allocation
+// and produces exactly the same samples as the allocating wrapper.
+func TestConvertU8IQInto_ZeroAllocMatchesAllocating(t *testing.T) {
+	buf := []byte{127, 128, 0, 0, 255, 255, 64, 192}
+	want := convertU8IQ(buf)
+	dst := make([]complex64, len(buf)/2)
+	allocs := testing.AllocsPerRun(100, func() { convertU8IQInto(dst, buf) })
+	if allocs != 0 {
+		t.Errorf("convertU8IQInto allocated %.0f times/run, want 0", allocs)
+	}
+	for i := range want {
+		if dst[i] != want[i] {
+			t.Errorf("convertU8IQInto[%d] = %v, want %v", i, dst[i], want[i])
+		}
+	}
+}
+
+// TestDeliver_RingReusesBuffers is the issue-#489 regression: once a
+// stream's reuse ring is provisioned, the steady-state deliver path must
+// recycle a bounded set of buffers rather than allocating a fresh ~64 KiB
+// slice per chunk. Drive many chunks through a consumer that always keeps
+// up and assert the number of distinct backing arrays never exceeds the
+// ring size.
+func TestDeliver_RingReusesBuffers(t *testing.T) {
+	d := newDeviceWithFakeTuner(usb.NewMockTransport(), &fakeTuner{})
+	const ringSize = streamChanDepth + 2
+	d.ring = make([][]complex64, ringSize)
+	for i := range d.ring {
+		d.ring[i] = make([]complex64, asyncBufLen/2)
+	}
+	// Capacity 1 plus draining after every deliver means a send never
+	// hits the drop branch, so the ring advances on every chunk.
+	d.out = make(chan []complex64, 1)
+
+	seen := make(map[*complex64]struct{})
+	buf := []byte{127, 128}
+	for k := 0; k < 5*ringSize; k++ {
+		d.deliver(buf)
+		got := <-d.out
+		seen[&got[0]] = struct{}{}
+	}
+	if len(seen) > ringSize {
+		t.Errorf("observed %d distinct backing buffers over %d chunks, want <= ring size %d (buffers must be reused)",
+			len(seen), 5*ringSize, ringSize)
+	}
+}
+
+func BenchmarkConvertU8IQ(b *testing.B) {
+	buf := make([]byte, asyncBufLen)
+	for i := range buf {
+		buf[i] = byte(i)
+	}
+	dst := make([]complex64, len(buf)/2)
+	b.SetBytes(int64(len(buf)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		convertU8IQInto(dst, buf)
 	}
 }
 


### PR DESCRIPTION
## Problem

On a control-channel SDR (serial `00000501`), the daemon was logging `sdr: dropping live IQ chunks; consumer can't keep up` every second with `dropped_since_last=73…140`. At the default 2.4 MS/s with 8192-sample chunks (~293 chunks/sec) that's **~25–48% of live IQ discarded**, sustained — which corrupts the dibit stream and on its own produces uncorrectable LDUs and TSBK CRC failures. The voice SDR (`00000502`), which uses a different/deeper consumer, dropped only 1–15/sec.

The drop site is the non-blocking send in `Device.deliver`: when the consumer channel (depth **8**) is full, the whole chunk is dropped. The control path's consumer (`ccdecoder.pump`: per-chunk resample + P25 framing under one mutex) runs slightly slower than real time, and two things tipped it over budget:

- `convertU8IQ` allocated a fresh ~64 KiB `[]complex64` **every chunk** (~18 MB/s per dongle), driving GC pauses.
- The consumer channel was only 8 deep (~27 ms), too shallow to absorb GC/scheduler jitter.

## Changes

### Lossless software wins (primary)
Both are **bit-identical** to the previous output — pinned by the existing `TestConvertU8IQ_BitIdenticalWithCGO` — so no functionality or decode quality is lost.

- **Reuse ring in `Device.deliver`.** A per-stream pool of preallocated buffers (`streamChanDepth+2`, advancing only on a successful enqueue) so the hot IQ path allocates nothing per chunk. Guarded by `streamMu` so it is safe under Darwin's concurrent per-slot reapers (`usb_darwin.go`); the conversion is cheap (the expensive resample lives in the consumer), so serializing it costs effectively nothing against the USB ring's ~110 ms of headroom.
- **u8→complex64 lookup table** replacing the per-sample subtract/divide. The LUT uses the identical `float32` expression, so results are unchanged. `convertU8IQInto` writes into a caller buffer (0 alloc); `convertU8IQ` is now a thin allocating wrapper for tests and the no-ring fallback.

### Tunability (secondary)
- Raise `streamChanDepth` **8 → 32** (~110 ms at 2.4 MS/s) for jitter headroom; still non-zero so drop-on-overrun stays real.
- Document `sdr.sample_rate` as the CPU load lever for the same warning (lowering it ~halves per-chunk decode cost).

## Testing
- New `TestConvertU8IQInto_ZeroAllocMatchesAllocating` (0 allocs, identical output) and `TestDeliver_RingReusesBuffers` (bounded buffer reuse) regressions.
- `BenchmarkConvertU8IQ`: **0 allocs/op, ~1.96 GB/s**.
- `go build ./...`, `go vet`, and `go test ./internal/sdr/... ./internal/config/ ./internal/scanner/ccdecoder/` all pass, including `-race` on the streaming path.

## Notes for the reporter
The log build (`90cdcf7`) predates the voice-frame offset fix already on this branch (`ff3dc93`). Re-test from this branch and confirm `dropped_since_last` falls toward 0 on `00000501`; if it stays high, that points to a genuinely CPU-bound host → lower `sdr.sample_rate` and/or run fewer simultaneous dongles.

https://claude.ai/code/session_01GYwwcfP5gSrbnNmo2SCj1o

---
_Generated by [Claude Code](https://claude.ai/code/session_01GYwwcfP5gSrbnNmo2SCj1o)_