### PR TITLE
rtlsdr: fix RTL-SDR Blog V4 deafness — 28.8 MHz crystal + V4 input routing

### DIFF
--- a/internal/sdr/rtlsdr/purego/driver.go
+++ b/internal/sdr/rtlsdr/purego/driver.go
@@ -3,6 +3,7 @@ package purego
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -222,6 +223,17 @@ func openDevice(transport usb.Transport, desc usb.Descriptor, idx int) (*Device,
 		}
 	}
 
+	// RTL-SDR Blog V4: the R828D needs its 28.8 MHz crystal and per-band
+	// input switching (issue #264). Detect it from the USB descriptor
+	// strings (the V4 sources these from EEPROM) and arm the V4 path on
+	// the tuner before any tune. Gated entirely on this match, so
+	// non-V4 R828D / R820T2 dongles are untouched.
+	if r82, ok := tuner.(*tuners.R82xx); ok {
+		if lite, isV4 := blogV4Variant(desc.Manufacturer, desc.Product); isV4 {
+			r82.SetBlogV4(lite)
+		}
+	}
+
 	kd := lookupKnown(desc.VID, desc.PID)
 	product := desc.Product
 	biasTeeGPIO := defaultBiasTeeGPIO
@@ -276,6 +288,28 @@ const defaultOpenSampleRateHz uint32 = 2_048_000
 // It's a var rather than a const so tests can override it; production
 // callers must treat it as read-only.
 var warmupSettleDuration = 10 * time.Millisecond
+
+// blogV4Variant reports whether the USB iManufacturer/iProduct strings
+// identify an RTL-SDR Blog V4 and, if so, whether it's the two-band
+// "Lite" variant. Mirrors the rtlsdr-blog fork's
+// rtlsdr_check_dongle_model("RTLSDRBlog", "Blog V4"); the V4 carries
+// these strings in its EEPROM, which the OS surfaces as the USB
+// descriptor strings. "Blog V4L" must be tested before "Blog V4"
+// because it shares the prefix.
+func blogV4Variant(manufacturer, product string) (lite, isV4 bool) {
+	if !strings.EqualFold(strings.TrimSpace(manufacturer), "RTLSDRBlog") {
+		return false, false
+	}
+	p := strings.TrimSpace(product)
+	switch {
+	case strings.HasPrefix(p, "Blog V4L"):
+		return true, true
+	case strings.HasPrefix(p, "Blog V4"):
+		return false, true
+	default:
+		return false, false
+	}
+}
 
 // runBringup executes the librtlsdr-parity init sequence on a fresh
 // Demod: USB-sysctl warmup probe → warmupSettleDuration sleep →

--- a/internal/sdr/rtlsdr/purego/driver_test.go
+++ b/internal/sdr/rtlsdr/purego/driver_test.go
@@ -826,3 +826,30 @@ func TestOpenDevice_NoDiagnosticsWhenTransportSilent(t *testing.T) {
 		t.Errorf("err = %v, must NOT contain the diagnostics header when the transport is silent", err)
 	}
 }
+
+// TestBlogV4Variant covers V4 detection from the USB descriptor strings
+// (issue #264): "RTLSDRBlog"/"Blog V4" is the three-band V4, "Blog V4L"
+// is the two-band Lite, and everything else (incl. generic R828D and
+// R820T2 dongles) is neither. Matching is case-insensitive and
+// whitespace-trimmed; "Blog V4L" must win over the "Blog V4" prefix.
+func TestBlogV4Variant(t *testing.T) {
+	cases := []struct {
+		manufacturer, product string
+		wantLite, wantV4      bool
+	}{
+		{"RTLSDRBlog", "Blog V4", false, true},
+		{"RTLSDRBlog", "Blog V4L", true, true},
+		{"  rtlsdrblog ", "  Blog V4 ", false, true}, // trimmed + case-insensitive
+		{"RTLSDRBlog", "Blog V3", false, false},
+		{"Realtek", "RTL2838UHIDIR", false, false},  // generic dongle
+		{"NooElec", "NESDR SMArt v5", false, false}, // R820T2
+		{"", "", false, false},
+	}
+	for _, c := range cases {
+		lite, v4 := blogV4Variant(c.manufacturer, c.product)
+		if v4 != c.wantV4 || lite != c.wantLite {
+			t.Errorf("blogV4Variant(%q,%q) = (lite=%v,v4=%v), want (lite=%v,v4=%v)",
+				c.manufacturer, c.product, lite, v4, c.wantLite, c.wantV4)
+		}
+	}
+}

--- a/internal/sdr/rtlsdr/tuners/r82xx.go
+++ b/internal/sdr/rtlsdr/tuners/r82xx.go
@@ -42,7 +42,29 @@ type R82xx struct {
 	bwHz     uint32 // last requested bandwidth
 	freqHz   uint32 // last requested center frequency
 	ppmCorr  int    // tuner-LO frequency correction, parts-per-million
+
+	// blogV4 marks an RTL-SDR Blog V4 (R828D) dongle, which needs the
+	// 28.8 MHz reference crystal (NOT the 16 MHz generic-R828D default)
+	// and per-band switching of its HF/VHF/UHF input bank in SetFreq.
+	// blogV4L is the two-band "Lite" variant (no separate VHF input).
+	// v4Input caches the last-selected input bank so SetFreq only
+	// rewrites the switch registers on a band change. See SetBlogV4.
+	blogV4  bool
+	blogV4L bool
+	v4Input v4Band
 }
+
+// v4Band identifies the RTL-SDR Blog V4's switched input bank. The
+// zero value (v4BandNone) means "no band selected yet", so the first
+// SetFreq always writes the switch registers.
+type v4Band uint8
+
+const (
+	v4BandNone v4Band = iota
+	v4BandHF
+	v4BandVHF
+	v4BandUHF
+)
 
 // NewR82xx constructs a driver bound to the given RTL2832U demod and
 // I2C address. Callers normally obtain the right address via the
@@ -70,6 +92,20 @@ func NewR82xx(d *rtl2832u.Demod, i2cAddr uint8, chip Type) *R82xx {
 // defaults are set by [NewR82xx] (28.8 MHz for R820T/R820T2, 16 MHz
 // for R828D); SetXtal exists for boards that deviate from those.
 func (r *R82xx) SetXtal(hz uint32) { r.xtalHz = hz }
+
+// SetBlogV4 marks this tuner as an RTL-SDR Blog V4 (lite=false) or V4
+// Lite (lite=true) so SetFreq drives the V4's switched HF/VHF/UHF input
+// bank. It also restores the 28.8 MHz reference crystal: the V4 runs
+// its R828D from 28.8 MHz, but NewR82xx defaults every R828D to the
+// 16 MHz generic crystal, which would mis-tune the V4 by ~28.8/16 =
+// 1.8× (issue #264). Detection keys off the V4's USB iManufacturer/
+// iProduct strings; mirrors the rtlsdr-blog fork's per-V4 handling
+// (tuner_r82xx.c). Call once after detection, before the first SetFreq.
+func (r *R82xx) SetBlogV4(lite bool) {
+	r.blogV4 = true
+	r.blogV4L = lite
+	r.xtalHz = r82xxXtalHz // 28.8 MHz, overriding the R828D 16 MHz default
+}
 
 // SetFreqCorrection applies a parts-per-million correction to the
 // tuner LO, mirroring the tuner half of librtlsdr's
@@ -255,7 +291,15 @@ func (r *R82xx) SetFreq(hz uint32) error {
 	if !r.initDone {
 		return errors.New("r82xx: Init not called")
 	}
-	if hz < 24_000_000 || hz > 1_766_000_000 {
+	// On the Blog V4, HF (≤ 28.8 MHz) is reached through the on-board
+	// upconverter, so the R828D mixer/PLL actually sees hz + 28.8 MHz.
+	// VHF/UHF tune directly (target == hz), so this is a no-op outside
+	// HF and leaves every non-V4 path byte-for-byte unchanged.
+	target := hz
+	if r.blogV4 && hz <= r82xxV4HFCrossHz {
+		target = hz + r82xxXtalHz
+	}
+	if target < 24_000_000 || target > 1_766_000_000 {
 		return &ErrUnsupportedFreq{Hz: hz, MinHz: 24_000_000, MaxHz: 1_766_000_000, TunerStr: r.chipType.String()}
 	}
 	if err := r.demod.SetI2CRepeater(true); err != nil {
@@ -263,14 +307,112 @@ func (r *R82xx) SetFreq(hz uint32) error {
 	}
 	defer r.demod.SetI2CRepeater(false)
 	r.freqHz = hz
-	if err := r.setMux(hz); err != nil {
+	if err := r.setMux(target); err != nil {
 		return fmt.Errorf("r82xx SetFreq: setMux: %w", err)
 	}
-	loHz := hz + r82xxIFFreqHz
+	// V4 front-end: select the HF/VHF/UHF input bank and notch for the
+	// *requested* RF frequency (not the upconverted target). Must run
+	// after setMux because the HF tracking-filter bypass overrides the
+	// mux's 0x1A/0x1B writes.
+	if r.blogV4 {
+		if err := r.applyBlogV4Band(hz); err != nil {
+			return fmt.Errorf("r82xx SetFreq: v4 band: %w", err)
+		}
+	}
+	loHz := target + r82xxIFFreqHz
 	if err := r.setPLL(loHz); err != nil {
 		return fmt.Errorf("r82xx SetFreq: setPLL(%d): %w", loHz, err)
 	}
 	return nil
+}
+
+// v4BandFor maps a requested RF frequency to the RTL-SDR Blog V4 input
+// bank: HF ≤ 28.8 MHz (upconverter), VHF (28.8, 250) MHz, UHF ≥ 250 MHz.
+// The two-band V4 Lite has no separate VHF input — everything above HF
+// is UHF. Thresholds match the rtlsdr-blog fork.
+func v4BandFor(hz uint32, lite bool) v4Band {
+	switch {
+	case hz <= r82xxV4HFCrossHz:
+		return v4BandHF
+	case !lite && hz < r82xxV4UHFCrossHz:
+		return v4BandVHF
+	default:
+		return v4BandUHF
+	}
+}
+
+// applyBlogV4Band drives the RTL-SDR Blog V4's switched input bank,
+// notch filter, and (for HF) tracking-filter bypass for the requested
+// RF frequency. Ported verbatim from the rtlsdr-blog fork's
+// r82xx_set_freq V4 block; the stock R828D init leaves every V4 input
+// off, so without these writes the V4 routes no RF and receives only
+// noise (issue #264). hz is the original requested frequency (the band
+// decision is on the antenna-plane frequency, not the upconverted IF
+// target). Caller holds the I2C repeater.
+func (r *R82xx) applyBlogV4Band(hz uint32) error {
+	// Notch ON (0x08) except when tuned inside one of the V4's notch
+	// windows (≤2.2 MHz, 85–112 MHz, 172–242 MHz), where it's OFF.
+	openD := byte(0x08)
+	if hz <= 2_200_000 ||
+		(hz >= 85_000_000 && hz <= 112_000_000) ||
+		(hz >= 172_000_000 && hz <= 242_000_000) {
+		openD = 0x00
+	}
+	if err := r.writeRegMask(0x17, openD, 0x08); err != nil {
+		return err
+	}
+
+	// Band: HF ≤ 28.8 MHz; VHF (28.8, 250) MHz; UHF ≥ 250 MHz. The V4
+	// Lite has no separate VHF input — everything above HF is UHF.
+	band := v4BandFor(hz, r.blogV4L)
+
+	// HF: bypass the tracking filter to cut upconverter insertion loss.
+	// Re-applied every tune since setMux rewrites 0x1A/0x1B above.
+	if band == v4BandHF {
+		if err := r.writeRegMask(0x1A, 0x40, 0xC3); err != nil {
+			return err
+		}
+		if err := r.writeReg(0x1B, 0x00); err != nil {
+			return err
+		}
+	}
+
+	// Only rewrite the input switches on a band change.
+	if band == r.v4Input {
+		return nil
+	}
+	r.v4Input = band
+
+	// Cable 2 = HF input (reg 0x06 bit 3).
+	cable2 := byte(0x00)
+	if band == v4BandHF {
+		cable2 = 0x08
+	}
+	if err := r.writeRegMask(0x06, cable2, 0x08); err != nil {
+		return err
+	}
+	// Upconverter relay on RTL2832 GPIO5: driven high for every band
+	// except HF (the fork's !cable_2_in).
+	if err := r.demod.SetGPIOOutput(5); err != nil {
+		return err
+	}
+	if err := r.demod.SetGPIOBit(5, cable2 == 0x00); err != nil {
+		return err
+	}
+	// Cable 1 = VHF input (reg 0x05 bit 6).
+	cable1 := byte(0x00)
+	if band == v4BandVHF {
+		cable1 = 0x40
+	}
+	if err := r.writeRegMask(0x05, cable1, 0x40); err != nil {
+		return err
+	}
+	// Air-in = UHF input (reg 0x05 bit 5): on for HF/VHF, off for UHF.
+	air := byte(0x20)
+	if band == v4BandUHF {
+		air = 0x00
+	}
+	return r.writeRegMask(0x05, air, 0x20)
 }
 
 // SetBandwidth picks the filter that matches the requested occupied

--- a/internal/sdr/rtlsdr/tuners/r82xx_tables.go
+++ b/internal/sdr/rtlsdr/tuners/r82xx_tables.go
@@ -29,12 +29,21 @@ const (
 	// via [R82xx.SetXtal].
 	r82xxXtalHz uint32 = 28_800_000
 
-	// r828dXtalHz is the reference crystal frequency for R828D-family
-	// tuners (RTL-SDR Blog V4 and similar). librtlsdr exposes this as
-	// R828D_XTAL_FREQ in tuner_r82xx.c. NewR82xx selects this default
-	// when chipType == TypeR828D so SetFreq's PLL math matches what
-	// librtlsdr would compute against the same hardware.
+	// r828dXtalHz is the reference crystal frequency for generic
+	// (non-V4) R828D tuners. librtlsdr exposes this as R828D_XTAL_FREQ
+	// in tuner_r82xx.c. NewR82xx selects this default when chipType ==
+	// TypeR828D; the RTL-SDR Blog V4 overrides it back to 28.8 MHz via
+	// SetBlogV4 because the V4's R828D runs from the 28.8 MHz crystal,
+	// not 16 MHz (issue #264 — the blog fork keeps the V4 at 28.8 MHz
+	// and only applies R828D_XTAL_FREQ to non-V4 R828D dongles).
 	r828dXtalHz uint32 = 16_000_000
+
+	// r82xxV4HFCrossHz / r82xxV4UHFCrossHz are the RTL-SDR Blog V4's
+	// input-bank crossover frequencies: ≤ HF-cross → HF (upconverter),
+	// (HF, UHF) → VHF, ≥ UHF-cross → UHF. Match the rtlsdr-blog fork's
+	// MHZ(28.8) / MHZ(250) thresholds in r82xx_set_freq.
+	r82xxV4HFCrossHz  uint32 = 28_800_000
+	r82xxV4UHFCrossHz uint32 = 250_000_000
 
 	// vcoMin / vcoMax bound the R820T VCO range. The PLL math
 	// picks a mixer divider (2/4/8/16/32/64) so freq*div lands

--- a/internal/sdr/rtlsdr/tuners/r82xx_test.go
+++ b/internal/sdr/rtlsdr/tuners/r82xx_test.go
@@ -1144,3 +1144,158 @@ func TestErrUnsupportedFreq_ErrorMessage(t *testing.T) {
 		}
 	}
 }
+
+// --- RTL-SDR Blog V4 (issue #264) ---------------------------------------
+
+// TestV4BandFor pins the V4 input-bank crossover thresholds and the
+// V4 Lite two-band collapse.
+func TestV4BandFor(t *testing.T) {
+	cases := []struct {
+		hz   uint32
+		lite bool
+		want v4Band
+	}{
+		{1_000_000, false, v4BandHF},    // HF
+		{28_800_000, false, v4BandHF},   // HF upper bound (inclusive)
+		{28_800_001, false, v4BandVHF},  // just into VHF
+		{153_275_000, false, v4BandVHF}, // the reporter's frequency
+		{249_999_999, false, v4BandVHF}, // VHF upper edge
+		{250_000_000, false, v4BandUHF}, // UHF lower bound (inclusive)
+		{460_000_000, false, v4BandUHF}, // UHF
+		{153_275_000, true, v4BandUHF},  // V4 Lite: no VHF, VHF->UHF
+		{1_000_000, true, v4BandHF},     // V4 Lite: HF unchanged
+	}
+	for _, c := range cases {
+		if got := v4BandFor(c.hz, c.lite); got != c.want {
+			t.Errorf("v4BandFor(%d, lite=%v) = %d, want %d", c.hz, c.lite, got, c.want)
+		}
+	}
+}
+
+// TestSetBlogV4OverridesCrystal verifies the V4 fix's core: SetBlogV4
+// restores the 28.8 MHz reference crystal that NewR82xx defaulted to
+// 16 MHz for the R828D, and flags the band variant.
+func TestSetBlogV4OverridesCrystal(t *testing.T) {
+	m := usb.NewMockTransport()
+	demod := rtl2832u.New(m)
+	r := NewR82xx(demod, r828dI2CAddr, TypeR828D)
+	if r.xtalHz != r828dXtalHz {
+		t.Fatalf("R828D default xtal = %d, want %d", r.xtalHz, r828dXtalHz)
+	}
+	r.SetBlogV4(false)
+	if !r.blogV4 || r.blogV4L {
+		t.Errorf("blogV4=%v blogV4L=%v, want true/false", r.blogV4, r.blogV4L)
+	}
+	if r.xtalHz != r82xxXtalHz {
+		t.Errorf("after SetBlogV4 xtal = %d, want %d (28.8 MHz)", r.xtalHz, r82xxXtalHz)
+	}
+	r.SetBlogV4(true)
+	if !r.blogV4L {
+		t.Errorf("SetBlogV4(true) did not set blogV4L")
+	}
+}
+
+// TestBlogV4PLLUsesCorrectCrystal is the root-cause regression: at the
+// V4's 28.8 MHz crystal the reporter's 153.275 MHz tune yields a sane
+// in-range nint, whereas the (wrong-for-V4) 16 MHz default inflated
+// nint by ~1.8× — the mis-tune that put the signal out of band.
+func TestBlogV4PLLUsesCorrectCrystal(t *testing.T) {
+	const loHz uint32 = 153_275_000 + 3_570_000 // requested + IF
+	mixDiv := pickMixDiv(loHz)
+	if mixDiv == 0 {
+		t.Fatalf("no mixDiv for %d Hz", loHz)
+	}
+	vco := uint64(loHz) * uint64(mixDiv)
+	nintV4 := uint32(vco / (2 * uint64(r82xxXtalHz))) // 28.8 MHz (V4)
+	nint16 := uint32(vco / (2 * uint64(r828dXtalHz))) // 16 MHz (wrong for V4)
+	if nintV4 < 13 || nintV4 > r82xxMaxNint {
+		t.Errorf("V4 nint=%d out of valid [13,%d]", nintV4, r82xxMaxNint)
+	}
+	// The 16 MHz assumption inflates nint by ~28.8/16 = 1.8x; that is the
+	// frequency error that made the V4 deaf. Confirm they diverge sharply.
+	if nint16 <= nintV4 {
+		t.Errorf("expected 16MHz nint (%d) > 28.8MHz nint (%d)", nint16, nintV4)
+	}
+	ratio := float64(nint16) / float64(nintV4)
+	if ratio < 1.6 || ratio > 2.0 {
+		t.Errorf("nint ratio = %.2f, want ~1.8 (28.8/16)", ratio)
+	}
+}
+
+// blockRead / blockWrite build the RTL2832 system-block GPIO exchanges
+// the V4 upconverter-relay control emits, mirroring rtl2832u's
+// gpio_test wire format.
+func blockRead(addr uint16, reply byte) usb.CtrlExchange {
+	return usb.CtrlExchange{In: true, BRequest: 0, WValue: addr, WIndex: uint16(rtl2832u.BlockSys) << 8, N: 1, Reply: []byte{reply}}
+}
+func blockWrite(addr uint16, val byte) usb.CtrlExchange {
+	return usb.CtrlExchange{In: false, BRequest: 0, WValue: addr, WIndex: uint16(rtl2832u.BlockSys)<<8 | 0x10, Data: []byte{val}}
+}
+
+// TestApplyBlogV4BandVHF is the deafness regression: tuning a V4 to a
+// VHF frequency must enable the VHF (Cable-1) + Air-In inputs (reg 0x05
+// -> 0xE3), turn the notch ON (reg 0x17 bit3), leave Cable-2 (HF, reg
+// 0x06 bit3) off, and drive the GPIO5 upconverter relay high. The stock
+// R828D init leaves all of these off, so without this the V4 routes no
+// RF and receives only noise.
+func TestApplyBlogV4BandVHF(t *testing.T) {
+	r, m := newR82xxForTest(t, expectR82xxInitBurst())
+	if err := r.Init(); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	// A real V4 detects as R828D at I2C 0x74; rebind the shadow's address
+	// now that the init flood (scripted at 0x34) is consumed.
+	r.chipType = TypeR828D
+	r.i2cAddr = r828dI2CAddr
+	r.SetBlogV4(false)
+
+	// Post-init shadow: 0x05=0x83, 0x06=0x32 (bit3 already 0), 0x17=0x30.
+	// applyBlogV4Band(153.275 MHz) emits, in order:
+	//   notch  : 0x17 -> 0x38 (bit3 set)
+	//   cable-2: 0x06 -> no write (bit3 already 0)
+	//   GPIO5  : configure output (GPD/GPOE) + drive high (GPO)
+	//   cable-1: 0x05 -> 0xC3 (bit6 set)
+	//   air-in : 0x05 -> 0xE3 (bit5 set)
+	m.Script = []usb.CtrlExchange{
+		expectI2CWriteRaw(r828dI2CAddr, []byte{0x17, 0x38}),
+		blockRead(rtl2832u.SysGPD, 0xFF), blockWrite(rtl2832u.SysGPD, 0xDF), // clear bit5 (direction=out)
+		blockRead(rtl2832u.SysGPOE, 0x00), blockWrite(rtl2832u.SysGPOE, 0x20), // enable output bit5
+		blockRead(rtl2832u.SysGPO, 0x00), blockWrite(rtl2832u.SysGPO, 0x20), // drive bit5 high
+		expectI2CWriteRaw(r828dI2CAddr, []byte{0x05, 0xC3}),
+		expectI2CWriteRaw(r828dI2CAddr, []byte{0x05, 0xE3}),
+	}
+	m.Step = 0
+	m.Err = nil
+
+	if err := r.applyBlogV4Band(153_275_000); err != nil {
+		t.Fatalf("applyBlogV4Band: %v", err)
+	}
+	if m.Err != nil {
+		t.Fatalf("wire mismatch: %v", m.Err)
+	}
+	if m.Remaining() != 0 {
+		t.Errorf("remaining=%d, want 0 (step %d/%d)", m.Remaining(), m.Step, len(m.Script))
+	}
+	if r.regs[0x05] != 0xE3 {
+		t.Errorf("reg 0x05 = 0x%02x, want 0xE3 (cable-1 + air-in enabled)", r.regs[0x05])
+	}
+	if r.regs[0x17] != 0x38 {
+		t.Errorf("reg 0x17 = 0x%02x, want 0x38 (notch on)", r.regs[0x17])
+	}
+	if r.v4Input != v4BandVHF {
+		t.Errorf("v4Input = %d, want VHF (%d)", r.v4Input, v4BandVHF)
+	}
+
+	// Re-tuning within VHF must NOT rewrite the input switches (band
+	// unchanged) — only the notch write may re-fire, and here it's a
+	// no-op since 0x17 is already 0x38.
+	m.Script = nil
+	m.Step = 0
+	m.Err = nil
+	if err := r.applyBlogV4Band(160_000_000); err != nil {
+		t.Fatalf("applyBlogV4Band re-tune: %v", err)
+	}
+	if m.Err != nil {
+		t.Fatalf("re-tune emitted unexpected wire traffic: %v", m.Err)
+	}
+}


### PR DESCRIPTION
Fixes #264.

## Evidence

The reporter's raw IQ capture from the V4 at 153.275 MHz (`153275000_ppm-4_2400000_V4.cfile`, 2.4 Msps, complex f32) is **pure complex white noise — no signal anywhere in the band**: balanced/uncorrelated I/Q (`corr ≈ 0.0001`), symmetric spectrum, flat PSD, and a channelized scan across the full ±1.1 MHz passband shows uniform noise with no bursty or continuous carrier. The V4 simply wasn't receiving the DMR signal the NooElec decodes — the earlier "CC changes constantly" was the decoder false-locking on noise.

## Root cause

Cross-referencing the `rtlsdr-blog` librtlsdr fork (the V4's official driver) against this stock-osmocom-derived driver surfaced two V4-specific gaps:

1. **Wrong reference crystal.** The blog fork keeps the V4 on **28.8 MHz** and only applies the 16 MHz `R828D_XTAL_FREQ` to *non-V4* R828D dongles. PR #266 set every R828D to 16 MHz keyed purely on chip type, so on the V4 the PLL math assumed 16 MHz while the hardware crystal is 28.8 MHz — mis-tuning every LO by ~28.8/16 = **1.8×** and putting the wanted signal out of band (also explains the earlier `nint=78` overflow).

2. **Missing input routing.** The V4 has a switched HF/VHF/UHF input bank. The stock R828D init (`reg 0x05 = 0x83`) leaves both Cable-1 (`0x40`) and Air-In (`0x20`) **OFF**, so the V4 routes no RF. The fork selects the input per band in `r82xx_set_freq`; this driver had no such code.

## Fix

Gated entirely on V4 detection, so R820T2 / non-V4 R828D paths are byte-for-byte unchanged:

- Detect the V4 from its USB iManufacturer/iProduct strings (`RTLSDRBlog` / `Blog V4`, plus the `Blog V4L` Lite variant) in the open path and arm the tuner via `SetBlogV4` before the first tune.
- `SetBlogV4` restores the 28.8 MHz crystal.
- `SetFreq`, when V4, ports the fork's `r82xx_set_freq` block: per-band input switching (Cable-1 / Cable-2 / Air-In on regs `0x05`/`0x06`), the notch windows (reg `0x17`), the GPIO5 upconverter relay, the HF tracking-filter bypass (`0x1A`/`0x1B`), and HF upconvert-by-28.8 MHz.

## Tests

- V4 detection (incl. `Blog V4L` vs `Blog V4` and case/whitespace handling)
- the 28.8 MHz crystal override
- the PLL-math fix at 153.275 MHz (in-range `nint` vs the ~1.8×-inflated 16 MHz value)
- the band-crossover thresholds (HF/VHF/UHF + V4 Lite collapse)
- a wire-level assertion that a VHF tune enables Cable-1 + Air-In (`reg 0x05 → 0xE3`), the notch (`reg 0x17`), and drives GPIO5 high

`go build ./...`, `go test ./internal/sdr/rtlsdr/...`, and the full `go test ./...` suite all pass; gofmt/vet clean.

## Hardware validation

The true validator is the reporter's hardware: a rebuilt `main` should now actually receive 153.275 MHz (stable color code, audio), and a re-capture should show a real signal near DC instead of flat noise.

https://claude.ai/code/session_01YLjGTWj9dY1VUEevTADJPx

---
_Generated by [Claude Code](https://claude.ai/code/session_01YLjGTWj9dY1VUEevTADJPx)_