### PR TITLE
p25/ccdecoder: decouple live IQ ingest from decode (#402)

### DIFF
--- a/internal/metrics/prom.go
+++ b/internal/metrics/prom.go
@@ -37,22 +37,23 @@ type Snapshotter interface {
 type Metrics struct {
 	reg *prometheus.Registry
 
-	eventsTotal   *prometheus.CounterVec
-	callsTotal    *prometheus.CounterVec // by system,protocol,encrypted,reason
-	callsStarted  *prometheus.CounterVec // by system,protocol,encrypted
-	activeCalls   *prometheus.GaugeVec   // by system,protocol
-	ccLockedGauge *prometheus.GaugeVec   // by system (1 when CC locked)
-	ccFrequencyHz *prometheus.GaugeVec   // by system; deleted on CC loss
-	ccTransitions *prometheus.CounterVec // by system,event (locked|lost)
-	iqUnderruns   *prometheus.CounterVec
-	iqPowerDbFS   *prometheus.GaugeVec // by system; mean IQ power on the control SDR
-	iqDCRatioDb   *prometheus.GaugeVec // by system; DC-bin power relative to total IQ power, in dB (issue #402)
-	iqClipRatio   *prometheus.GaugeVec // by system; fraction of IQ samples pinned to the ADC rail (issue #402)
-	usbReconnects *prometheus.CounterVec
-	decodeErrors  *prometheus.CounterVec
-	sdrAttached   *prometheus.GaugeVec
-	versionInfo   *prometheus.GaugeVec
-	sdrSnap       *sdrSnapshotCollector
+	eventsTotal    *prometheus.CounterVec
+	callsTotal     *prometheus.CounterVec // by system,protocol,encrypted,reason
+	callsStarted   *prometheus.CounterVec // by system,protocol,encrypted
+	activeCalls    *prometheus.GaugeVec   // by system,protocol
+	ccLockedGauge  *prometheus.GaugeVec   // by system (1 when CC locked)
+	ccFrequencyHz  *prometheus.GaugeVec   // by system; deleted on CC loss
+	ccTransitions  *prometheus.CounterVec // by system,event (locked|lost)
+	iqUnderruns    *prometheus.CounterVec
+	decodeOverruns prometheus.Counter   // chunks dropped at the decode queue (issue #402)
+	iqPowerDbFS    *prometheus.GaugeVec // by system; mean IQ power on the control SDR
+	iqDCRatioDb    *prometheus.GaugeVec // by system; DC-bin power relative to total IQ power, in dB (issue #402)
+	iqClipRatio    *prometheus.GaugeVec // by system; fraction of IQ samples pinned to the ADC rail (issue #402)
+	usbReconnects  *prometheus.CounterVec
+	decodeErrors   *prometheus.CounterVec
+	sdrAttached    *prometheus.GaugeVec
+	versionInfo    *prometheus.GaugeVec
+	sdrSnap        *sdrSnapshotCollector
 
 	bus       *events.Bus
 	sub       *events.Subscription
@@ -120,6 +121,20 @@ func New(bus *events.Bus, pool Snapshotter, version string) (*Metrics, error) {
 		Name:      "iq_underruns_total",
 		Help:      "Times the IQ stream pipeline dropped samples because a downstream stage was too slow.",
 	}, []string{"driver", "serial"})
+
+	// Chunks the live decoder dropped at its internal decode queue because
+	// decode could not keep up with real time (issue #402). Distinct from
+	// sdr_iq_underruns_total: that counts the SDR driver's own delivery
+	// channel overrunning, while this counts the decode goroutine being the
+	// bottleneck (CPU-starved host, contention). A climbing value here, with
+	// iq_underruns_total flat, says "the machine can't sustain this decode"
+	// rather than "the USB transport hiccuped".
+	m.decodeOverruns = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: namespace,
+		Subsystem: "ccdecoder",
+		Name:      "decode_overruns_total",
+		Help:      "Live IQ chunks dropped at the decode queue because decode can't keep up with real time (issue #402). Distinct from sdr_iq_underruns_total (driver-delivery overruns).",
+	})
 
 	// Mean IQ power on the control SDR, expressed in dBFS (0 dBFS = ±1.0
 	// full-scale per the convertU8IQ normalization). Surfaces silent
@@ -203,6 +218,7 @@ func New(bus *events.Bus, pool Snapshotter, version string) (*Metrics, error) {
 		m.ccFrequencyHz,
 		m.ccTransitions,
 		m.iqUnderruns,
+		m.decodeOverruns,
 		m.iqPowerDbFS,
 		m.iqDCRatioDb,
 		m.iqClipRatio,
@@ -329,6 +345,14 @@ func (m *Metrics) observeEvent(ev events.Event) {
 // RecordIQUnderrun increments the underrun counter for the supplied SDR.
 func (m *Metrics) RecordIQUnderrun(driver, serial string) {
 	m.iqUnderruns.WithLabelValues(driver, serial).Inc()
+}
+
+// RecordDecodeOverrun increments the decode-overrun counter: one live IQ
+// chunk dropped at the decode queue because decode can't keep up with
+// real time (issue #402). Distinct from RecordIQUnderrun, which is the
+// SDR driver's own delivery-channel overrun.
+func (m *Metrics) RecordDecodeOverrun() {
+	m.decodeOverruns.Inc()
 }
 
 // RecordIQPowerDbFS sets the mean-IQ-power gauge for system. Caller

--- a/internal/metrics/prom_test.go
+++ b/internal/metrics/prom_test.go
@@ -161,6 +161,17 @@ func TestRecordHooks(t *testing.T) {
 	}
 }
 
+func TestRecordDecodeOverrun(t *testing.T) {
+	m, _ := New(nil, nil, "test")
+	defer m.Close()
+
+	m.RecordDecodeOverrun()
+	m.RecordDecodeOverrun()
+	if got := testutil.ToFloat64(m.decodeOverruns); got != 2 {
+		t.Errorf("decode overruns = %v, want 2", got)
+	}
+}
+
 func TestRecordIQPowerDbFS(t *testing.T) {
 	m, _ := New(nil, nil, "test")
 	defer m.Close()

--- a/internal/scanner/ccdecoder/decoder.go
+++ b/internal/scanner/ccdecoder/decoder.go
@@ -80,6 +80,12 @@ type IQPowerObserver interface {
 	ClearIQDCRatioDb(system string)
 	RecordIQClipRatio(system string, ratio float64)
 	ClearIQClipRatio(system string)
+	// RecordDecodeOverrun counts one IQ chunk dropped at the decode queue
+	// because decode could not keep up with real time (issue #402). It is
+	// distinct from the SDR driver's iq_underruns_total: a non-zero value
+	// here means the CPU/host can't sustain the decode, not that the USB
+	// delivery channel overran.
+	RecordDecodeOverrun()
 }
 
 // ErrIQStreamClosed is returned by Run whenever the SDR's IQ stream is
@@ -127,6 +133,20 @@ const iqClipThreshold = 0.98
 // rarely rails on P25 C4FM, so a sustained fraction at this level means
 // front-end overload — reduce gain or add attenuation (issue #402).
 const iqClipWarnRatio = 0.002
+
+// decodeQueueDepth is the size of the internal queue between the
+// lightweight IQ forwarder and the decode goroutine (issue #402). The
+// SDR driver drops the instant its own small delivery channel backs up
+// (~27 ms at 2.4 MS/s, ~68 ms at 960 kS/s), so any decode/retune/GC
+// stall longer than that on a single combined goroutine corrupts the
+// continuous symbol stream. The forwarder drains the driver channel into
+// this larger queue so a transient stall backs up here instead of
+// dropping RF; at 65 KB/chunk this is ~8 MB and buys ≈0.44 s of slack at
+// 2.4 MS/s (≈1.1 s at 960 kS/s). Deeper would absorb longer stalls at the
+// cost of higher decode latency under a sustained backlog; 128 balances
+// the two. Sustained overload still drops here — attributably, via
+// RecordDecodeOverrun — rather than silently in the driver.
+const decodeQueueDepth = 128
 
 // Tuner is the subset of sdr.Device the decoder uses for retuning.
 // Matches the same interface cchunt + conventional consume so the
@@ -214,9 +234,9 @@ type Decoder struct {
 	// stream doesn't allocate per call.
 	ddcOut []complex64
 
-	// IQ-power tracking — see pump for the math. Owned by Run's
-	// goroutine via pump; not protected by mu because no other
-	// goroutine reads it.
+	// IQ-power tracking — see observeIQPowerLocked for the math. Owned by
+	// the decode goroutine via pump; not protected by mu beyond pump's own
+	// lock because no other goroutine reads it.
 	metrics      IQPowerObserver
 	pwSumSq      float64
 	pwSumI       float64 // running sum of I samples → DC-bin mean (issue #402)
@@ -310,6 +330,19 @@ func (d *Decoder) Run(ctx context.Context) error {
 
 	defer d.sub.Close()
 
+	// Decouple real-time IQ ingestion from decode (issue #402). The SDR
+	// driver drops a chunk the instant its small delivery channel backs up,
+	// so running decode + retune inline on the goroutine that drains that
+	// channel means any stall longer than a few tens of ms (a pipeline
+	// rebuild, a GC pause, the OS scheduling away under host contention)
+	// silently drops live IQ and splices the continuous symbol stream,
+	// triggering the TSBK/NID CRC cascade. A dedicated lightweight forwarder
+	// keeps the driver channel drained into a larger queue; decode and
+	// retune run here, off the ingestion path, so a stall backs up in the
+	// queue instead of dropping RF.
+	decodeCh := make(chan []complex64, decodeQueueDepth)
+	go d.forwardIQ(ctx, stream, decodeCh)
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -326,11 +359,62 @@ func (d *Decoder) Run(ctx context.Context) error {
 				continue
 			}
 			d.handleProgress(p)
-		case iq, ok := <-stream:
+		case iq, ok := <-decodeCh:
 			if !ok {
+				// forwardIQ closed the queue: either the SDR stream ended
+				// (surface as ErrIQStreamClosed for the daemon's #345 retry
+				// loop) or ctx was cancelled (a clean shutdown, not a stream
+				// death — return ctx.Err() so it isn't retried).
+				if ctx.Err() != nil {
+					return ctx.Err()
+				}
 				return ErrIQStreamClosed
 			}
 			d.pump(iq)
+		}
+	}
+}
+
+// forwardIQ drains the SDR delivery channel into the decode queue (issue
+// #402). Kept deliberately cheap — just a non-blocking enqueue — so it
+// always out-drains the driver's small channel; the larger decodeCh then
+// absorbs transient decode stalls. Under *sustained* overload the queue
+// fills and chunks are dropped here, attributably (RecordDecodeOverrun +
+// a throttled WARN), rather than silently in the driver. Closing out on
+// return propagates stream EOF / ctx cancellation to Run.
+func (d *Decoder) forwardIQ(ctx context.Context, in <-chan []complex64, out chan<- []complex64) {
+	defer close(out)
+	var (
+		dropped   uint64
+		lastLogAt time.Time
+	)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case iq, ok := <-in:
+			if !ok {
+				return
+			}
+			select {
+			case out <- iq:
+			default:
+				// Decode is sustainedly behind real time: the queue is full.
+				// Drop the freshly-arrived chunk (caps latency at the queue
+				// depth) and surface it as a decode overrun, distinct from the
+				// driver's iq_underruns_total, so "CPU can't keep up" is
+				// attributable rather than looking like an RF fault.
+				dropped++
+				if d.metrics != nil {
+					d.metrics.RecordDecodeOverrun()
+				}
+				if now := time.Now(); now.Sub(lastLogAt) >= time.Second {
+					d.log.Warn("ccdecoder: decode can't keep up with real time; dropping IQ at the decode queue (raise CPU / lower sample rate / shed load) — issue #402",
+						"dropped_since_last", dropped)
+					dropped = 0
+					lastLogAt = now
+				}
+			}
 		}
 	}
 }
@@ -460,16 +544,12 @@ func (d *Decoder) ensureDownconverterLocked(targetHz float64) {
 // against handleProgress's pipeline swap so we never call Process on
 // a half-constructed pipeline.
 //
-// The chunk is decimated to the pipeline's narrowband rate by the
-// down-converter before Process; the IQ-power window below still
-// measures the *raw* chunk so the gauge reflects the SDR's actual
-// input level, not the post-decimation level.
-//
-// While we have the lock, also fold the chunk into the IQ-power
-// window. The window aggregates |IQ|^2 across chunks; once a second
-// of samples has been seen, the mean is converted to dBFS and pushed
-// to the Metrics observer + a throttled debug log fires if the level
-// looks dead. See iqLowPowerThresholdDbFS.
+// While we have the lock, also fold the chunk into the IQ-power window
+// (observeIQPowerLocked). Observation runs here, on the decode goroutine,
+// rather than on the lightweight IQ forwarder so it stays serialised with
+// IQHealth's reads under d.mu (issue #489). The forwarder (issue #402)
+// only decouples ingestion from this decode path; chunks dropped at the
+// decode queue under sustained overload are simply not observed.
 func (d *Decoder) pump(iq []complex64) {
 	d.mu.Lock()
 	defer d.mu.Unlock()

--- a/internal/scanner/ccdecoder/decoder_test.go
+++ b/internal/scanner/ccdecoder/decoder_test.go
@@ -1048,12 +1048,13 @@ func TestMPT1327FactoryAppliesBCHFromSystem(t *testing.T) {
 // tests can assert the decoder's pump-side observation pipeline
 // without depending on the real Prometheus collector.
 type recordingPower struct {
-	sets        []powerSample
-	cleared     []string
-	dcSets      []dcSample
-	dcCleared   []string
-	clipSets    []clipSample
-	clipCleared []string
+	sets         []powerSample
+	cleared      []string
+	dcSets       []dcSample
+	dcCleared    []string
+	clipSets     []clipSample
+	clipCleared  []string
+	decodeOverru int
 }
 
 type powerSample struct {
@@ -1089,10 +1090,13 @@ func (r *recordingPower) RecordIQClipRatio(system string, ratio float64) {
 func (r *recordingPower) ClearIQClipRatio(system string) {
 	r.clipCleared = append(r.clipCleared, system)
 }
+func (r *recordingPower) RecordDecodeOverrun() {
+	r.decodeOverru++
+}
 
 // TestPumpRecordsIQPowerOnceWindowElapses feeds a known signal level
-// through Process and checks the Metrics observer sees the expected
-// dBFS once iqPowerWindow worth of samples have been folded in.
+// through observeIQPowerLocked and checks the Metrics observer sees the
+// expected dBFS once iqPowerWindow worth of samples have been folded in.
 func TestPumpRecordsIQPowerOnceWindowElapses(t *testing.T) {
 	bus := events.NewBus(8)
 	defer bus.Close()
@@ -1115,15 +1119,15 @@ func TestPumpRecordsIQPowerOnceWindowElapses(t *testing.T) {
 		chunk[i] = complex(0.5, 0.5)
 	}
 
-	// First pump primes pwWindowAt — no record yet.
-	d.pump(chunk)
+	// First observation primes pwWindowAt — no record yet.
+	d.observeIQPowerLocked(chunk)
 	if len(pwr.sets) != 0 {
-		t.Fatalf("first pump should not record, got %v", pwr.sets)
+		t.Fatalf("first observation should not record, got %v", pwr.sets)
 	}
 
 	// Force the window timer past iqPowerWindow.
 	d.pwWindowAt = d.pwWindowAt.Add(-2 * iqPowerWindow)
-	d.pump(chunk)
+	d.observeIQPowerLocked(chunk)
 
 	if len(pwr.sets) != 1 {
 		t.Fatalf("after window, sets = %d, want 1", len(pwr.sets))
@@ -1167,9 +1171,9 @@ func TestPumpRecordsIQClipRatioWhenRailed(t *testing.T) {
 		chunk[i] = complex(1.0, 1.0)
 	}
 
-	d.pump(chunk) // primes pwWindowAt, no record yet
+	d.observeIQPowerLocked(chunk) // primes pwWindowAt, no record yet
 	d.pwWindowAt = d.pwWindowAt.Add(-2 * iqPowerWindow)
-	d.pump(chunk)
+	d.observeIQPowerLocked(chunk)
 
 	if len(pwr.clipSets) != 1 {
 		t.Fatalf("after window, clipSets = %d, want 1", len(pwr.clipSets))
@@ -1204,9 +1208,9 @@ func TestPumpRecordsIQDCRatioPureDC(t *testing.T) {
 		chunk[i] = complex(0.3, 0.4) // constant ⇒ mean(IQ) = sample, |mean|² = |sample|²
 	}
 
-	d.pump(chunk)
+	d.observeIQPowerLocked(chunk)
 	d.pwWindowAt = d.pwWindowAt.Add(-2 * iqPowerWindow)
-	d.pump(chunk)
+	d.observeIQPowerLocked(chunk)
 
 	if len(pwr.dcSets) != 1 {
 		t.Fatalf("dcSets = %d, want 1", len(pwr.dcSets))
@@ -1248,9 +1252,9 @@ func TestPumpRecordsIQDCRatioCleanSignal(t *testing.T) {
 		}
 	}
 
-	d.pump(chunk)
+	d.observeIQPowerLocked(chunk)
 	d.pwWindowAt = d.pwWindowAt.Add(-2 * iqPowerWindow)
-	d.pump(chunk)
+	d.observeIQPowerLocked(chunk)
 
 	if len(pwr.dcSets) != 1 {
 		t.Fatalf("dcSets = %d, want 1", len(pwr.dcSets))
@@ -1548,5 +1552,51 @@ func TestIQHealthPartialSamples(t *testing.T) {
 	}
 	if !strings.Contains(diag.Diagnosis, "too short to gauge") {
 		t.Errorf("diag.Diagnosis = %q, want 'too short to gauge'", diag.Diagnosis)
+	}
+}
+
+// TestForwardIQDecouplesIngestFromDecode pins the issue-#402 live-path
+// fix: the forwarder drains the SDR channel into the decode queue,
+// preserves order, drops only when the queue is full (and counts each
+// drop as a decode overrun, distinct from a driver underrun), and closes
+// the queue when the source ends.
+func TestForwardIQDecouplesIngestFromDecode(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	pwr := &recordingPower{}
+	d, err := New(Options{
+		Bus: bus, IQ: &fakeIQSource{}, SampleRateHz: 48000, Metrics: pwr,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	// Pre-load every chunk and close the source. The forwarder's enqueue is
+	// non-blocking (it drops on a full queue), so it runs to completion with
+	// no consumer: the first two chunks land in the cap-2 queue and the next
+	// three are dropped. Waiting for it to finish before draining keeps the
+	// queued set and drop count deterministic (a concurrent drain would race
+	// the last enqueue). Tag each chunk by its first sample to check order.
+	in := make(chan []complex64, 5)
+	out := make(chan []complex64, 2)
+	mk := func(tag float32) []complex64 { return []complex64{complex(tag, 0)} }
+	for i := 0; i < 5; i++ {
+		in <- mk(float32(i))
+	}
+	close(in)
+
+	done := make(chan struct{})
+	go func() { d.forwardIQ(context.Background(), in, out); close(done) }()
+	<-done // forwarder has processed all 5 chunks and closed out
+
+	var got []float32
+	for c := range out {
+		got = append(got, real(c[0]))
+	}
+	if len(got) != 2 || got[0] != 0 || got[1] != 1 {
+		t.Errorf("queued = %v, want [0 1] (first two, in order)", got)
+	}
+	if pwr.decodeOverru != 3 {
+		t.Errorf("decode overruns = %d, want 3", pwr.decodeOverru)
 	}
 }


### PR DESCRIPTION
## Why

Issue #402's latest field data ([comment #35](https://github.com/MattCheramie/GopherTrunk/issues/402#issuecomment-4608280141)): on a busy site the control channel locks but TSBK/NID CRC errors accumulate, `iq_clip_ratio` stays **0** at every gain (clipping ruled out — the gauge added in the previous round did its job), DC is clean, yet the live decoder logs `dropping live IQ chunks; consumer can't keep up`. The **recorded capture has `drops=0` and replays perfectly**. A quiet site decodes fine on the same hardware.

## Root cause (structural, not RF)

`Decoder.Run` decoded **inline** on the single goroutine that also has to drain the SDR's 8-deep delivery channel (~27 ms of slack at 2.4 MS/s, ~68 ms at 960 kS/s). Any stall on that goroutine — a pipeline rebuild in `handleProgress`, a GC pause, or the OS scheduling away under host contention (the reporter ran SDRTrunk alongside) — stops it draining the channel, so the driver **silently drops real-time IQ**. Each dropped chunk splices the continuous C4FM stream and triggers the CRC burst.

Replay (`cmd/gophertrunk/replay.go`) feeds the identical decoder by **direct function call with no real-time deadline**, so a stall just slows the file read — it can never drop. That is the entire "replay green, live fails" asymmetry. Event-bus backpressure (`Publish` is non-blocking) and DDC per-chunk allocation were both ruled out.

## What changed

- **Decouple ingest from decode.** `Run` now launches a lightweight forwarder goroutine that only drains the SDR channel into a larger bounded decode queue (`decodeQueueDepth=128`, ≈0.44 s at 2.4 MS/s / ≈1.1 s at 960 kS/s of slack). Decode and retune run off the ingestion path, so a transient stall backs up in the queue instead of dropping RF. Sustained overload still drops — but at the queue and attributably, not silently in the driver. EOF/`ctx` semantics (issue #345 retry path) preserved.
- **New `gophertrunk_ccdecoder_decode_overruns_total` counter**, distinct from `sdr_iq_underruns_total` (driver-delivery overruns), plus a throttled WARN — so "decode can't keep up" (CPU/host contention) is *provable* rather than guessed.
- **IQ power/clip/DC observation stays on the decode goroutine** (under `d.mu` via `pump`), so it remains serialised with the `IQHealth` snapshot that #489 added — the cchunt supervisor reads that from another goroutine, so moving observation onto the lock-free forwarder would have raced it. Chunks dropped at the decode queue under sustained overload are simply not observed.

The replay path and SDR driver are **not** touched — replay stays byte-identical and continues to decode the reporter's captures.

## Testing

- `go build ./...`, `go vet`, `gofmt` clean.
- `go test ./internal/scanner/ccdecoder/... ./internal/metrics/... ./cmd/gophertrunk/...` — pass.
- `-race` on the full `ccdecoder` package (this adds a goroutine) — clean.
- New tests: deterministic `forwardIQ` queue/drop/order/close test, and the decode-overrun counter. #489's `IQHealth`/`diagnoseIQ` tests retained.

## How to verify in the field

After upgrading, re-test the busy site watching `ccdecoder_decode_overruns_total` and `sdr_iq_underruns_total`:
- Both flat + CRC clears → fixed.
- `decode_overruns_total` keeps climbing → decode is genuinely CPU-starved on that host (shed load / lower sample rate / more CPU) — now visible rather than masquerading as an RF fault.

## Follow-up (not in this PR)

`convertU8IQ` allocates a fresh `[]complex64` per chunk (~7.6 MB/s at 960 kS/s), feeding the GC pressure this buffering rides out. Pooling it is a worthwhile next step if overruns persist; it's pinned bit-identical to the CGO driver so it's out of scope here.

Rebased onto current `main` (clean integration with #489's IQ-health work). Closes #402 pending field confirmation.

https://claude.ai/code/session_01YcMs6iKdAbMTGPsFkLYmB1

---
_Generated by [Claude Code](https://claude.ai/code/session_01YcMs6iKdAbMTGPsFkLYmB1)_