### PR TITLE
dmr/tier3: wire LCN→frequency band plan so T3 voice grants resolve

### DIFF
--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -525,11 +525,37 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 				})
 			}
 		}
+		var dmrBandPlan *trunking.DMRBandPlan
+		if bp := sys.DMRBandPlan; bp != nil {
+			dmrBandPlan = &trunking.DMRBandPlan{}
+			if bp.Linear != nil {
+				dmrBandPlan.Linear = &trunking.DMRLinearBandPlan{
+					BaseHz:    bp.Linear.BaseHz,
+					SpacingHz: bp.Linear.SpacingHz,
+					Offset:    bp.Linear.Offset,
+				}
+			}
+			for _, e := range bp.Table {
+				dmrBandPlan.Table = append(dmrBandPlan.Table, trunking.DMRBandPlanTableEntry{
+					LCN:    e.LCN,
+					FreqHz: e.FreqHz,
+				})
+			}
+		} else if proto == trunking.ProtocolDMR {
+			// Tier III grants reference channels by LCN; without a band
+			// plan the decoder cannot resolve a downlink frequency and
+			// every voice grant is dropped (decode.error stage=
+			// no-bandplan). CC monitoring still works, so warn rather
+			// than fail the load.
+			log.Warn("daemon: dmr Tier III system has no dmr_band_plan; voice grants will be dropped (no-bandplan)",
+				"system", sys.Name)
+		}
 		s := trunking.System{
 			Name:                    sys.Name,
 			Protocol:                proto,
 			ControlChannels:         sys.ControlChannels,
 			P25BandPlan:             p25BandPlan,
+			DMRBandPlan:             dmrBandPlan,
 			TETRAColourCode:         sys.TETRAColourCode,
 			TETRAChannel:            sys.TETRAChannel,
 			TETRAChannelCoding:      sys.TETRAChannelCoding,

--- a/cmd/gophertrunk/wideband_voice_taps_test.go
+++ b/cmd/gophertrunk/wideband_voice_taps_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/MattCheramie/GopherTrunk/internal/config"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/dmr/tier3"
 	"github.com/MattCheramie/GopherTrunk/internal/sdr"
 	"github.com/MattCheramie/GopherTrunk/internal/trunking"
 )
@@ -82,5 +83,70 @@ func TestWidebandOnlyConfigPopulatesVoicePool(t *testing.T) {
 	}
 	if free := pool.FindFreeForFrequency(900_000_000); free != nil {
 		t.Errorf("FindFreeForFrequency(900 MHz, out-of-window) = %q, want nil", free.Serial)
+	}
+}
+
+// TestWidebandT3GrantResolvedFrequencyLandsOnTap closes the DMR Tier III
+// loop end-to-end: a CSBK voice grant's LCN is resolved to a downlink
+// frequency through the system's dmr_band_plan (tier3.ResolverFromPlan),
+// and that resolved frequency must allocate a virtual voice tap on the
+// wideband dongle hosting the control channel — no physical voice SDR
+// required. An LCN that resolves outside the dongle's IQ window must
+// instead fall through (so it can reach a physical voice SDR, if any).
+func TestWidebandT3GrantResolvedFrequencyLandsOnTap(t *testing.T) {
+	const serial = "wb-t3"
+	const centerHz = 859_837_500
+	const sampleRate = 2_400_000
+	const taps = 4
+
+	sdr.Register(&fakeWidebandDriver{dev: newStreamingFake(serial)})
+
+	log := slog.New(slog.DiscardHandler)
+	cfg := config.Config{
+		SDR: config.SDRConfig{
+			SampleRate: sampleRate,
+			Devices: []config.DeviceConfig{{
+				Serial:       serial,
+				Role:         "wideband",
+				CenterFreqHz: centerHz,
+				VoiceTaps:    taps,
+			}},
+		},
+	}
+
+	d := &Daemon{pool: sdr.NewPool(log)}
+	if err := d.pool.OpenWith(sdr.PoolOpenOptions{
+		SampleRateHz: sampleRate,
+		Hints:        []sdr.Hint{{Serial: serial, Role: sdr.RoleWideband}},
+		Strict:       true,
+	}); err != nil {
+		t.Fatalf("pool open: %v", err)
+	}
+	d.wrapIQBrokers(cfg, log)
+	if err := d.buildVirtualVoiceTuners(cfg, log); err != nil {
+		t.Fatalf("buildVirtualVoiceTuners: %v", err)
+	}
+	pool := trunking.NewVoicePool(d.collectVoiceDevices())
+
+	// Linear grid whose low LCNs sit inside the dongle's IQ window
+	// (centre ± ~1.14 MHz) and whose high LCNs fall outside it.
+	resolver := tier3.ResolverFromPlan(&trunking.DMRBandPlan{
+		Linear: &trunking.DMRLinearBandPlan{BaseHz: 859_000_000, SpacingHz: 25_000, Offset: 1},
+	})
+
+	inHz, err := resolver.Frequency(10) // 859.000M + 9×25k = 859.225 MHz (in window)
+	if err != nil {
+		t.Fatalf("resolve in-window LCN: %v", err)
+	}
+	if free := pool.FindFreeForFrequency(inHz); free == nil {
+		t.Errorf("FindFreeForFrequency(%d, resolved in-window) = nil, want a wideband tap", inHz)
+	}
+
+	outHz, err := resolver.Frequency(100) // 859.000M + 99×25k = 861.475 MHz (out of window)
+	if err != nil {
+		t.Fatalf("resolve out-of-window LCN: %v", err)
+	}
+	if free := pool.FindFreeForFrequency(outHz); free != nil {
+		t.Errorf("FindFreeForFrequency(%d, resolved out-of-window) = %q, want nil", outHz, free.Serial)
 	}
 }

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -224,7 +224,10 @@ sdr:
     # gets its own per-call DDC tap on this dongle's IQ stream.
     # Out-of-window grants spill over to a physical voice SDR
     # when one is configured, or drop with the standard
-    # "no voice device available" log otherwise.
+    # "no voice device available" log otherwise. This works for
+    # P25 Phase 1/2 and DMR Tier III alike — but a DMR Tier III
+    # system needs a `dmr_band_plan` (see the systems section) so
+    # the decoder can turn each grant's LCN into a frequency.
     # - serial: "00000005"
     #   role: wideband
     #   center_freq_hz: 851_500_000
@@ -232,6 +235,18 @@ sdr:
     #   channels:
     #     - frequency_hz: 851_037_500
     #       system: "regional-p25"
+    #
+    # DMR Tier III voice on a wideband dongle: identical wiring,
+    # just point the channel at a `protocol: dmr` system that
+    # carries a `dmr_band_plan`. The CC tap decodes the CSBK chain
+    # and each voice grant lands on a voice_taps DDC tap.
+    # - serial: "00000007"
+    #   role: wideband
+    #   center_freq_hz: 851_500_000
+    #   voice_taps: 4
+    #   channels:
+    #     - frequency_hz: 851_037_500
+    #       system: "regional-dmr-t3"
     #
     # P25 Phase 2 control channel on a wideband dongle. The
     # referenced system carries `protocol: p25-phase2`; the
@@ -429,6 +444,32 @@ trunking:
       # to let the affiliation tracker surface RIDs live without any
       # operator-configured aliases.
       # rid_alias_file: "/etc/gophertrunk/rids-p25.csv"
+
+    # DMR Tier III trunked system. A T3 voice-grant CSBK references its
+    # traffic channel by a 7-bit Logical Channel Number (LCN), never an
+    # absolute frequency, so the decoder needs a `dmr_band_plan` to map
+    # LCN → downlink Hz. WITHOUT it every voice grant is dropped with
+    # decode.error stage=no-bandplan (control-channel monitoring still
+    # works). Provide exactly one of `linear` or `table`.
+    - name: "Example-DMR-T3"
+      protocol: dmr
+      control_channels:
+        - 851_037_500
+      talkgroup_file: "/etc/gophertrunk/talkgroups-dmr.csv"
+      dmr_band_plan:
+        # Linear grid: freq = base_hz + (lcn - offset) * spacing_hz.
+        # offset: 1 matches the common case of sites that number LCNs
+        # from 1 (so LCN 1 == base_hz). Use offset: 0 for 0-indexed sites.
+        linear:
+          base_hz: 851_012_500
+          spacing_hz: 25_000
+          offset: 1
+        # --- OR, for sites whose channels aren't on a regular grid,
+        # an explicit LCN → frequency table (omit `linear` if used): ---
+        # table:
+        #   - { lcn: 1, freq_hz: 851_012_500 }
+        #   - { lcn: 2, freq_hz: 851_037_500 }
+        #   - { lcn: 9, freq_hz: 851_225_000 }
 
   # Per-protocol FEC is on by default — every protocol the daemon
   # supports (TETRA, LTR, P25 Phase 2, NXDN, EDACS, MPT 1327,

--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -316,6 +316,8 @@ trunking:
     - name: "regional-dmr-t3"
       protocol: dmr                    # Tier III trunked
       control_channels: [851_037_500]  # MUST include the wideband channel above
+      dmr_band_plan:                   # REQUIRED for T3 voice (LCN → Hz)
+        linear: { base_hz: 851_012_500, spacing_hz: 25_000, offset: 1 }
     - name: "neighbour-dmr-t2"
       protocol: dmr-tier2              # Tier II conventional
       control_channels: [852_125_000]
@@ -324,6 +326,21 @@ trunking:
 The engine picks the right state machine per channel (Tier III's
 `ControlChannel` for `protocol: dmr`, Tier II's `ConventionalChannel`
 for `protocol: dmr-tier2`).
+
+A DMR Tier III voice-grant CSBK identifies its traffic channel by a
+7-bit Logical Channel Number (LCN), not an absolute frequency, so the
+T3 system **must** carry a `dmr_band_plan` to resolve LCN → downlink
+Hz. Provide exactly one of:
+
+- `linear` — a regular grid: `freq = base_hz + (lcn - offset) × spacing_hz`.
+  Set `offset: 1` for sites that number LCNs from 1 (the common case).
+- `table` — an explicit list of `{ lcn, freq_hz }` pairs for irregular
+  sites.
+
+Without it, T3 control-channel monitoring still works but every voice
+grant is dropped with `decode.error stage=no-bandplan` (and the daemon
+logs a warning at startup). Tier II carries its repeater frequency
+directly and needs no band plan.
 
 ### P25 trunked control channel on a wideband dongle
 
@@ -390,6 +407,13 @@ trunking:
       control_channels: [851_037_500]
 ```
 
+This works identically for **DMR Tier III** — point the channel at a
+`protocol: dmr` system instead. The only extra requirement is that the
+T3 system carry a `dmr_band_plan` (see "Mixing DMR Tier II and Tier III
+on one dongle" above): the voice composer can only follow a grant once
+the decoder has resolved its LCN to a frequency, so a T3 system without
+a band plan emits no voice grants for the taps to serve.
+
 How spillover works: when a grant's frequency lands *outside* the
 wideband IQ window (more common on geographically spread P25 systems
 than on a single-site DMR T3 cluster), the virtual tuner returns
@@ -447,7 +471,9 @@ message that names the offending entry.
   single backup voice dongle covers the edge cases on
   geographically spread systems. Setups with `voice_taps: 0` (or
   unset) keep the legacy behaviour where every voice grant routes
-  to the physical pool.
+  to the physical pool. DMR Tier III additionally requires the
+  system's `dmr_band_plan` (LCN → frequency) before any voice grant
+  — virtual or physical — can be followed.
 - **DDC-with-real-signal RX limits.** The wideband engine's per-tap
   DDC (when the SDR sample rate is higher than 48 kHz) uses the same
   Kaiser anti-alias prototype as the single-channel ccdecoder path,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -865,6 +865,15 @@ type SystemConfig struct {
 	// Ignored for non-P25-Phase-1 protocols.
 	P25BandPlan []P25BandPlanEntryConfig `yaml:"p25_band_plan"`
 
+	// DMRBandPlan maps the 7-bit Logical Channel Number (LCN) carried
+	// in each DMR Tier III voice-grant CSBK to a downlink frequency.
+	// REQUIRED for T3 voice — T3 grants reference a channel by LCN, not
+	// an absolute frequency, so without this plan every grant is
+	// dropped with decode.error stage=no-bandplan. Provide exactly one
+	// of `linear` (regular base+spacing grid) or `table` (explicit
+	// LCN→Hz list). Ignored for non-dmr protocols.
+	DMRBandPlan *DMRBandPlanConfig `yaml:"dmr_band_plan"`
+
 	// EncryptionKeys lists operator-supplied decryption keys for this
 	// system. GopherTrunk decrypts only with keys the operator
 	// already holds and is authorized to use — it performs no key
@@ -889,6 +898,31 @@ type P25BandPlanEntryConfig struct {
 	SpacingHz   uint32 `yaml:"spacing_hz"`
 	TxOffsetHz  int64  `yaml:"tx_offset_hz"`
 	BandwidthHz uint32 `yaml:"bandwidth_hz"`
+}
+
+// DMRBandPlanConfig is the operator-supplied DMR Tier III LCN→frequency
+// band plan for a system. Exactly one of Linear or Table must be set
+// (enforced by Config.Validate). See internal/radio/dmr/tier3/bandplan.go
+// for the resolution math.
+type DMRBandPlanConfig struct {
+	Linear *DMRLinearBandPlanConfig      `yaml:"linear"`
+	Table  []DMRBandPlanTableEntryConfig `yaml:"table"`
+}
+
+// DMRLinearBandPlanConfig lays channels out on a regular grid:
+// freq = base_hz + (lcn - offset) × spacing_hz. Set offset=1 for the
+// common case of sites that number LCNs from 1.
+type DMRLinearBandPlanConfig struct {
+	BaseHz    uint32 `yaml:"base_hz"`
+	SpacingHz uint32 `yaml:"spacing_hz"`
+	Offset    int8   `yaml:"offset"`
+}
+
+// DMRBandPlanTableEntryConfig is one explicit LCN→downlink-frequency
+// mapping for sites whose channels don't fall on a regular grid.
+type DMRBandPlanTableEntryConfig struct {
+	LCN    uint8  `yaml:"lcn"`
+	FreqHz uint32 `yaml:"freq_hz"`
 }
 
 // EncryptionKeyConfig is one operator-supplied decryption key for a
@@ -1178,6 +1212,36 @@ func (c Config) Validate() error {
 			}
 			if e.BaseHz == 0 {
 				return fmt.Errorf("trunking.systems[%d].p25_band_plan[%d]: base_hz required (nonzero)", i, k)
+			}
+		}
+		if bp := s.DMRBandPlan; bp != nil {
+			hasLinear := bp.Linear != nil
+			hasTable := len(bp.Table) > 0
+			switch {
+			case hasLinear && hasTable:
+				return fmt.Errorf("trunking.systems[%d].dmr_band_plan: set either linear or table, not both", i)
+			case !hasLinear && !hasTable:
+				return fmt.Errorf("trunking.systems[%d].dmr_band_plan: one of linear or table is required", i)
+			}
+			if hasLinear {
+				if bp.Linear.SpacingHz == 0 {
+					return fmt.Errorf("trunking.systems[%d].dmr_band_plan.linear: spacing_hz required (nonzero)", i)
+				}
+				if bp.Linear.BaseHz == 0 {
+					return fmt.Errorf("trunking.systems[%d].dmr_band_plan.linear: base_hz required (nonzero)", i)
+				}
+			}
+			if hasTable {
+				seenLCN := make(map[uint8]int, len(bp.Table))
+				for k, e := range bp.Table {
+					if e.FreqHz == 0 {
+						return fmt.Errorf("trunking.systems[%d].dmr_band_plan.table[%d]: freq_hz required (nonzero)", i, k)
+					}
+					if prev, dup := seenLCN[e.LCN]; dup {
+						return fmt.Errorf("trunking.systems[%d].dmr_band_plan.table[%d]: duplicate lcn %d (also at table[%d])", i, k, e.LCN, prev)
+					}
+					seenLCN[e.LCN] = k
+				}
 			}
 		}
 		seenKeyIDs := make(map[uint16]struct{}, len(s.EncryptionKeys))

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -88,6 +88,16 @@ func TestValidate(t *testing.T) {
 		{"band_plan duplicate channel_id", Config{Trunking: TrunkingConfig{Systems: []SystemConfig{{Name: "x", Protocol: "p25", P25BandPlan: []P25BandPlanEntryConfig{{ChannelID: 3, BaseHz: 1, SpacingHz: 1}, {ChannelID: 3, BaseHz: 2, SpacingHz: 2}}}}}}, true},
 		{"band_plan zero spacing", Config{Trunking: TrunkingConfig{Systems: []SystemConfig{{Name: "x", Protocol: "p25", P25BandPlan: []P25BandPlanEntryConfig{{ChannelID: 3, BaseHz: 1, SpacingHz: 0}}}}}}, true},
 		{"band_plan zero base", Config{Trunking: TrunkingConfig{Systems: []SystemConfig{{Name: "x", Protocol: "p25", P25BandPlan: []P25BandPlanEntryConfig{{ChannelID: 3, BaseHz: 0, SpacingHz: 1}}}}}}, true},
+		// dmr_band_plan: DMR Tier III LCN→frequency resolver. Exactly one
+		// of linear / table is required; without it T3 voice grants drop.
+		{"dmr band_plan linear ok", Config{Trunking: TrunkingConfig{Systems: []SystemConfig{{Name: "x", Protocol: "dmr", DMRBandPlan: &DMRBandPlanConfig{Linear: &DMRLinearBandPlanConfig{BaseHz: 866_000_000, SpacingHz: 25_000, Offset: 1}}}}}}, false},
+		{"dmr band_plan table ok", Config{Trunking: TrunkingConfig{Systems: []SystemConfig{{Name: "x", Protocol: "dmr", DMRBandPlan: &DMRBandPlanConfig{Table: []DMRBandPlanTableEntryConfig{{LCN: 1, FreqHz: 866_000_000}, {LCN: 2, FreqHz: 866_025_000}}}}}}}, false},
+		{"dmr band_plan both linear and table", Config{Trunking: TrunkingConfig{Systems: []SystemConfig{{Name: "x", Protocol: "dmr", DMRBandPlan: &DMRBandPlanConfig{Linear: &DMRLinearBandPlanConfig{BaseHz: 1, SpacingHz: 1}, Table: []DMRBandPlanTableEntryConfig{{LCN: 1, FreqHz: 1}}}}}}}, true},
+		{"dmr band_plan empty", Config{Trunking: TrunkingConfig{Systems: []SystemConfig{{Name: "x", Protocol: "dmr", DMRBandPlan: &DMRBandPlanConfig{}}}}}, true},
+		{"dmr band_plan linear zero spacing", Config{Trunking: TrunkingConfig{Systems: []SystemConfig{{Name: "x", Protocol: "dmr", DMRBandPlan: &DMRBandPlanConfig{Linear: &DMRLinearBandPlanConfig{BaseHz: 1, SpacingHz: 0}}}}}}, true},
+		{"dmr band_plan linear zero base", Config{Trunking: TrunkingConfig{Systems: []SystemConfig{{Name: "x", Protocol: "dmr", DMRBandPlan: &DMRBandPlanConfig{Linear: &DMRLinearBandPlanConfig{BaseHz: 0, SpacingHz: 1}}}}}}, true},
+		{"dmr band_plan table zero freq", Config{Trunking: TrunkingConfig{Systems: []SystemConfig{{Name: "x", Protocol: "dmr", DMRBandPlan: &DMRBandPlanConfig{Table: []DMRBandPlanTableEntryConfig{{LCN: 1, FreqHz: 0}}}}}}}, true},
+		{"dmr band_plan table duplicate lcn", Config{Trunking: TrunkingConfig{Systems: []SystemConfig{{Name: "x", Protocol: "dmr", DMRBandPlan: &DMRBandPlanConfig{Table: []DMRBandPlanTableEntryConfig{{LCN: 1, FreqHz: 1}, {LCN: 1, FreqHz: 2}}}}}}}, true},
 		// wideband role: pin a dongle to a centre frequency and list
 		// per-repeater carriers inside its IQ bandwidth. Stage 2 added
 		// DMR Tier II conventional; Stage 3 added DMR Tier III trunked

--- a/internal/radio/dmr/tier3/bandplan.go
+++ b/internal/radio/dmr/tier3/bandplan.go
@@ -3,6 +3,8 @@ package tier3
 import (
 	"errors"
 	"fmt"
+
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
 )
 
 // Resolver maps a 7-bit DMR Tier III LCN to its downlink frequency
@@ -54,4 +56,32 @@ func (t TableBandPlan) Frequency(lcn uint8) (uint32, error) {
 		return 0, fmt.Errorf("%w: lcn=%d", ErrUnknownLCN, lcn)
 	}
 	return hz, nil
+}
+
+// ResolverFromPlan builds a Resolver from the operator-supplied band
+// plan carried on a trunking.System. It returns nil when p is nil or
+// empty so callers can pass the result straight into Options.Resolver
+// and preserve the existing "no band plan ⇒ drop grant with
+// stage=no-bandplan" behaviour. Config validation guarantees exactly
+// one of Linear / Table is set; if both are somehow present Linear
+// wins.
+func ResolverFromPlan(p *trunking.DMRBandPlan) Resolver {
+	if p == nil {
+		return nil
+	}
+	if p.Linear != nil {
+		return LinearBandPlan{
+			BaseHz:    p.Linear.BaseHz,
+			SpacingHz: p.Linear.SpacingHz,
+			Offset:    p.Linear.Offset,
+		}
+	}
+	if len(p.Table) > 0 {
+		t := make(TableBandPlan, len(p.Table))
+		for _, e := range p.Table {
+			t[e.LCN] = e.FreqHz
+		}
+		return t
+	}
+	return nil
 }

--- a/internal/radio/dmr/tier3/bandplan_test.go
+++ b/internal/radio/dmr/tier3/bandplan_test.go
@@ -3,6 +3,8 @@ package tier3
 import (
 	"errors"
 	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
 )
 
 func TestLinearBandPlanWithLCNOffset(t *testing.T) {
@@ -48,5 +50,65 @@ func TestLinearBandPlanRejectsOverflow(t *testing.T) {
 	bp := LinearBandPlan{BaseHz: 4_200_000_000, SpacingHz: 1_000_000}
 	if _, err := bp.Frequency(127); err == nil {
 		t.Error("expected overflow error for >4.29 GHz resolved frequency")
+	}
+}
+
+func TestResolverFromPlanNil(t *testing.T) {
+	if r := ResolverFromPlan(nil); r != nil {
+		t.Errorf("ResolverFromPlan(nil) = %v, want nil", r)
+	}
+	// An empty plan (neither linear nor table) also resolves to nil so
+	// the caller falls back to the no-bandplan drop behaviour.
+	if r := ResolverFromPlan(&trunking.DMRBandPlan{}); r != nil {
+		t.Errorf("ResolverFromPlan(empty) = %v, want nil", r)
+	}
+}
+
+func TestResolverFromPlanLinear(t *testing.T) {
+	r := ResolverFromPlan(&trunking.DMRBandPlan{
+		Linear: &trunking.DMRLinearBandPlan{BaseHz: 866_000_000, SpacingHz: 25_000, Offset: 1},
+	})
+	if r == nil {
+		t.Fatal("ResolverFromPlan(linear) = nil")
+	}
+	if _, ok := r.(LinearBandPlan); !ok {
+		t.Fatalf("resolver type = %T, want LinearBandPlan", r)
+	}
+	// LCN 8 on a 1-indexed 25 kHz grid: 866.000 MHz + 7×25 kHz = 866.175 MHz.
+	if hz, err := r.Frequency(8); err != nil || hz != 866_175_000 {
+		t.Errorf("Frequency(8) = %d, %v; want 866_175_000, nil", hz, err)
+	}
+}
+
+func TestResolverFromPlanTable(t *testing.T) {
+	r := ResolverFromPlan(&trunking.DMRBandPlan{
+		Table: []trunking.DMRBandPlanTableEntry{
+			{LCN: 1, FreqHz: 462_550_000},
+			{LCN: 4, FreqHz: 462_575_000},
+		},
+	})
+	if r == nil {
+		t.Fatal("ResolverFromPlan(table) = nil")
+	}
+	if _, ok := r.(TableBandPlan); !ok {
+		t.Fatalf("resolver type = %T, want TableBandPlan", r)
+	}
+	if hz, err := r.Frequency(4); err != nil || hz != 462_575_000 {
+		t.Errorf("Frequency(4) = %d, %v; want 462_575_000, nil", hz, err)
+	}
+	if _, err := r.Frequency(9); !errors.Is(err, ErrUnknownLCN) {
+		t.Errorf("Frequency(9) err = %v, want ErrUnknownLCN", err)
+	}
+}
+
+func TestResolverFromPlanLinearWinsWhenBothSet(t *testing.T) {
+	// Config validation forbids both, but ResolverFromPlan defensively
+	// prefers Linear so a malformed plan still yields a usable resolver.
+	r := ResolverFromPlan(&trunking.DMRBandPlan{
+		Linear: &trunking.DMRLinearBandPlan{BaseHz: 866_000_000, SpacingHz: 25_000, Offset: 1},
+		Table:  []trunking.DMRBandPlanTableEntry{{LCN: 1, FreqHz: 1}},
+	})
+	if _, ok := r.(LinearBandPlan); !ok {
+		t.Fatalf("resolver type = %T, want LinearBandPlan", r)
 	}
 }

--- a/internal/scanner/ccdecoder/pipelines.go
+++ b/internal/scanner/ccdecoder/pipelines.go
@@ -552,6 +552,10 @@ func newDMRTier3Pipeline(opts PipelineOptions) (ProtocolPipeline, error) {
 		Log:         opts.Log,
 		SystemName:  opts.SystemName,
 		FrequencyHz: opts.FrequencyHz,
+		// LCN→downlink resolver from the system's dmr_band_plan; nil
+		// when unconfigured, in which case T3 voice grants drop with
+		// decode.error stage=no-bandplan (the daemon warns at load).
+		Resolver: tier3.ResolverFromPlan(opts.System.DMRBandPlan),
 	})
 	rx := dmrrx.New(dmrrx.Options{
 		SampleRateHz: opts.SampleRateHz,

--- a/internal/scanner/widebandt2/engine.go
+++ b/internal/scanner/widebandt2/engine.go
@@ -29,9 +29,15 @@
 //     receiver and emits grants from the MAC PDU chain.
 //
 // Published grants flow through the trunking engine's existing
-// voice-pool allocator, which binds them to a physical role: voice
-// dongle. Voice grants are not (yet) decoded by the wideband dongle
-// itself — that's the "virtual voice pool" follow-up.
+// voice-pool allocator, which binds each to either a physical
+// role: voice dongle or a virtual voice tap (a per-grant DDC on this
+// same wideband IQ stream — see internal/sdr/wbvoice, enabled per
+// dongle via voice_taps). So a wideband dongle can decode its own
+// voice grants without a separate voice SDR, and falls back to a
+// physical voice SDR when the grant lands outside its IQ window or
+// every tap is busy. DMR Tier III grants reference channels by LCN,
+// so the system needs a dmr_band_plan to resolve LCN → frequency;
+// without it those grants are dropped (decode.error stage=no-bandplan).
 //
 // One Engine owns one wideband SDR. Multiple wideband dongles each
 // get their own Engine; they run independently and share only the
@@ -303,7 +309,12 @@ func buildChannel(sys trunking.System, ch ChannelConfig, bus *events.Bus, log *s
 			Log:         log.With("system", sys.Name, "freq_hz", freqHz, "tier", 3),
 			SystemName:  sys.Name,
 			FrequencyHz: freqHz,
-			Now:         now,
+			// The LCN→downlink resolver comes from the system's
+			// dmr_band_plan. Without it every T3 voice grant drops with
+			// decode.error stage=no-bandplan; the daemon already warns
+			// at load time. See internal/radio/dmr/tier3.ResolverFromPlan.
+			Resolver: tier3.ResolverFromPlan(sys.DMRBandPlan),
+			Now:      now,
 		})
 		rx := dmrrx.New(dmrrx.Options{
 			SampleRateHz: narrowbandRateHz,

--- a/internal/scanner/widebandt2/engine_e2e_test.go
+++ b/internal/scanner/widebandt2/engine_e2e_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/MattCheramie/GopherTrunk/internal/dsp/demod"
 	"github.com/MattCheramie/GopherTrunk/internal/events"
 	"github.com/MattCheramie/GopherTrunk/internal/radio/dmr"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/dmr/tier3"
 	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
 	"github.com/MattCheramie/GopherTrunk/internal/trunking"
 )
@@ -143,6 +144,222 @@ WaitLoop:
 	if grantFreq != repeaterHz {
 		t.Errorf("grant.FrequencyHz = %d, want %d", grantFreq, repeaterHz)
 	}
+}
+
+// TestEngineEndToEndT3GrantFromSynthesizedIQ proves the wideband
+// engine resolves a DMR Tier III voice grant's LCN to a downlink
+// frequency via the system's dmr_band_plan and publishes it on the
+// bus. Same synthesized-IQ path as the Tier II test, but the bursts
+// carry an OpTVGrant CSBK (DTCSBK) instead of a Voice LC Header, and
+// the system is given a LinearBandPlan so resolveLCN succeeds.
+//
+// LCN 8 on {base 866 MHz, spacing 25 kHz, offset 1} resolves to
+// 866.175 MHz — the same vector asserted by tier3's own
+// control_test.go, so this test pins the *wiring* (Options.Resolver
+// reaching the decoder), not the resolver math.
+func TestEngineEndToEndT3GrantFromSynthesizedIQ(t *testing.T) {
+	const (
+		widebandRateHz = 48_000.0
+		centerHz       = 851_000_000
+		ccFreqHz       = centerHz
+		spsWideband    = 10
+		spanSymbols    = 8
+		alpha          = 0.20
+		colorCode      = uint8(0x3)
+		burstRepeats   = 200
+		chunkSamples   = 4800
+		wantLCN        = uint16(8)
+		wantFreqHz     = uint32(866_175_000) // 866M + (8-1)×25k
+		wantGroup      = uint32(0x123456)
+		wantSource     = uint32(0xABCDEF)
+	)
+
+	sys := t3System("regional-t3", ccFreqHz)
+	sys.DMRBandPlan = &trunking.DMRBandPlan{
+		Linear: &trunking.DMRLinearBandPlan{BaseHz: 866_000_000, SpacingHz: 25_000, Offset: 1},
+	}
+
+	dibits := buildT3TVGrantDibits(burstRepeats, colorCode)
+	baseband := demod.ModulateC4FM(dibits, spsWideband, spanSymbols, alpha, widebandRateHz, dmrDeviationHz)
+	chunks := chunkComplex(baseband, chunkSamples)
+	dev := newMockDevice(chunks)
+
+	bus := events.NewBus(64)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	e, err := New(Options{
+		Log:          slog.New(slog.NewTextHandler(discardWriter{}, nil)),
+		Device:       dev,
+		Bus:          bus,
+		SampleRateHz: uint32(widebandRateHz),
+		CenterFreqHz: centerHz,
+		Channels:     []ChannelConfig{{FrequencyHz: ccFreqHz, SystemName: sys.Name}},
+		Systems:      []trunking.System{sys},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+	defer cancel()
+	runDone := make(chan error, 1)
+	go func() { runDone <- e.Run(ctx) }()
+
+	deadline := time.After(8 * time.Second)
+	var g trunking.Grant
+	var sawGrant bool
+WaitLoop:
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind != events.KindGrant {
+				continue
+			}
+			gg, ok := ev.Payload.(trunking.Grant)
+			if !ok {
+				t.Errorf("KindGrant payload type = %T", ev.Payload)
+				continue
+			}
+			g = gg
+			sawGrant = true
+			break WaitLoop
+		case <-deadline:
+			break WaitLoop
+		}
+	}
+	cancel()
+	<-runDone
+
+	if !sawGrant {
+		t.Fatal("no grant event observed within deadline")
+	}
+	if g.Protocol != "dmr-tier3" {
+		t.Errorf("grant.Protocol = %q, want dmr-tier3", g.Protocol)
+	}
+	if g.ChannelNum != wantLCN {
+		t.Errorf("grant.ChannelNum (LCN) = %d, want %d", g.ChannelNum, wantLCN)
+	}
+	if g.FrequencyHz != wantFreqHz {
+		t.Errorf("grant.FrequencyHz = %d, want %d (LCN→Hz resolver not wired?)", g.FrequencyHz, wantFreqHz)
+	}
+	if g.GroupID != wantGroup || g.SourceID != wantSource {
+		t.Errorf("grant group/source = %X/%X, want %X/%X", g.GroupID, g.SourceID, wantGroup, wantSource)
+	}
+}
+
+// TestEngineEndToEndT3GrantDroppedWithoutBandPlan is the negative
+// control for the test above: with no dmr_band_plan the decoder has no
+// resolver, so the same TVGrant CSBK must produce a decode.error with
+// stage=no-bandplan and NO grant event. This proves the band plan is
+// the load-bearing piece, not an incidental one.
+func TestEngineEndToEndT3GrantDroppedWithoutBandPlan(t *testing.T) {
+	const (
+		widebandRateHz = 48_000.0
+		centerHz       = 851_000_000
+		colorCode      = uint8(0x3)
+		burstRepeats   = 200
+		chunkSamples   = 4800
+	)
+
+	sys := t3System("regional-t3", centerHz) // no DMRBandPlan
+	dibits := buildT3TVGrantDibits(burstRepeats, colorCode)
+	baseband := demod.ModulateC4FM(dibits, 10, 8, 0.20, widebandRateHz, dmrDeviationHz)
+	dev := newMockDevice(chunkComplex(baseband, chunkSamples))
+
+	bus := events.NewBus(64)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	e, err := New(Options{
+		Log:          slog.New(slog.NewTextHandler(discardWriter{}, nil)),
+		Device:       dev,
+		Bus:          bus,
+		SampleRateHz: uint32(widebandRateHz),
+		CenterFreqHz: centerHz,
+		Channels:     []ChannelConfig{{FrequencyHz: centerHz, SystemName: sys.Name}},
+		Systems:      []trunking.System{sys},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+	defer cancel()
+	runDone := make(chan error, 1)
+	go func() { runDone <- e.Run(ctx) }()
+
+	deadline := time.After(8 * time.Second)
+	var sawNoBandPlan bool
+WaitLoop:
+	for {
+		select {
+		case ev := <-sub.C:
+			switch ev.Kind {
+			case events.KindGrant:
+				t.Fatalf("unexpected grant without a band plan: %+v", ev.Payload)
+			case events.KindDecodeError:
+				if de, ok := ev.Payload.(events.DecodeError); ok && de.Stage == events.StageNoBandPlan {
+					sawNoBandPlan = true
+					break WaitLoop
+				}
+			}
+		case <-deadline:
+			break WaitLoop
+		}
+	}
+	cancel()
+	<-runDone
+
+	if !sawNoBandPlan {
+		t.Fatal("expected a decode.error stage=no-bandplan event, got none")
+	}
+}
+
+// buildT3TVGrantDibits builds a dibit stream of repeated OpTVGrant CSBK
+// bursts (DTCSBK) for the synthesized-IQ end-to-end tests. The CSBK
+// payload mirrors tier3/control_test.go's TVGrant vector: service
+// options 0xC0, dst 0x123456, src 0xABCDEF, timeslot/LCN byte 0x88
+// (TS2, LCN 8). Burst framing matches buildT2VoiceLCHeaderDibits.
+func buildT3TVGrantDibits(repeats int, colorCode uint8) []uint8 {
+	info := tier3.AssembleCSBK(tier3.CSBK{
+		LB:      true,
+		Opcode:  tier3.OpTVGrant,
+		Payload: [8]byte{0xC0, 0x12, 0x34, 0x56, 0xAB, 0xCD, 0xEF, 0x88},
+	})
+	bits := make([]byte, 96)
+	for i := 0; i < 96; i++ {
+		bits[i] = (info[i>>3] >> uint(7-(i&7))) & 1
+	}
+	channelBits := framing.EncodeBPTC196_96(bits)
+	payloadDibits := framing.BitsToDibits(channelBits)
+
+	slotBits := dmr.AssembleSlotType(dmr.SlotType{ColorCode: colorCode, DataType: dmr.DTCSBK})
+	slotDibits := framing.BitsToDibits(slotBits)
+
+	burst := make([]uint8, 0, dmr.BurstDibits)
+	burst = append(burst, payloadDibits[:dmr.HalfPayloadDibits]...)
+	burst = append(burst, slotDibits[:dmr.SlotTypeDibits]...)
+	burst = append(burst, dmr.BSData.Dibits[:]...)
+	burst = append(burst, slotDibits[dmr.SlotTypeDibits:]...)
+	burst = append(burst, payloadDibits[dmr.HalfPayloadDibits:]...)
+
+	out := make([]uint8, 0, 800+repeats*(len(burst)+32)+100)
+	for i := 0; i < 800; i++ {
+		out = append(out, uint8(i&3))
+	}
+	for r := 0; r < repeats; r++ {
+		out = append(out, burst...)
+		for i := 0; i < 32; i++ {
+			out = append(out, uint8(i&3))
+		}
+	}
+	for i := 0; i < 100; i++ {
+		out = append(out, uint8(i&3))
+	}
+	return out
 }
 
 // buildT2VoiceLCHeaderDibits is a local copy of the

--- a/internal/trunking/site.go
+++ b/internal/trunking/site.go
@@ -112,6 +112,37 @@ type P25BandPlanEntry struct {
 	BandwidthHz uint32 // informational; not consulted by BandPlan.Frequency
 }
 
+// DMRBandPlan maps the 7-bit Logical Channel Number (LCN) carried in a
+// DMR Tier III voice-grant CSBK to its downlink frequency. T3 grants
+// reference a channel by LCN, never an absolute frequency, so the
+// decoder cannot follow a voice call without this plan — see
+// internal/radio/dmr/tier3 (Resolver / tier3.ResolverFromPlan). The
+// trunking package keeps its own LCN→Hz shape (rather than importing
+// tier3) the same way P25BandPlanEntry mirrors phase1.IdentifierUpdate.
+// Exactly one of Linear or Table is populated (enforced by config
+// validation).
+type DMRBandPlan struct {
+	Linear *DMRLinearBandPlan      // regular base+spacing grid
+	Table  []DMRBandPlanTableEntry // irregular hand-coded LCN→Hz map
+}
+
+// DMRLinearBandPlan lays channels out on a regular grid:
+// freq = BaseHz + (LCN - Offset) × SpacingHz. Offset lets sites that
+// number LCNs from 1 (the common case) pin BaseHz to the channel-1
+// downlink — set Offset=1 there.
+type DMRLinearBandPlan struct {
+	BaseHz    uint32
+	SpacingHz uint32
+	Offset    int8
+}
+
+// DMRBandPlanTableEntry is one explicit LCN→downlink-frequency mapping
+// for sites whose channels don't fall on a regular grid.
+type DMRBandPlanTableEntry struct {
+	LCN    uint8
+	FreqHz uint32
+}
+
 // System describes one trunked radio system the engine should track.
 type System struct {
 	Name            string
@@ -183,6 +214,12 @@ type System struct {
 	// BandPlan.Apply path; entries here are the floor, not the ceiling.
 	// Ignored for non-P25-Phase-1 protocols.
 	P25BandPlan []P25BandPlanEntry
+
+	// DMRBandPlan resolves the LCN in DMR Tier III voice grants to a
+	// downlink frequency. Required for T3 voice — without it every
+	// grant is dropped with decode.error stage=no-bandplan. Ignored
+	// for non-DMR-Tier-III protocols.
+	DMRBandPlan *DMRBandPlan
 
 	// P25Phase1DemodMode selects the symbol-recovery path for the
 	// P25 Phase 1 receiver. Recognised values (case-insensitive):


### PR DESCRIPTION
DMR Tier III voice grants reference their traffic channel by a 7-bit
Logical Channel Number (LCN), not an absolute frequency, so the tier3
decoder needs a Resolver to follow a voice call. That Resolver was only
ever set in tests: both production constructors (widebandt2 wideband
path and ccdecoder dedicated-dongle path) built the decoder with a nil
resolver, so every T3 voice grant was dropped with decode.error
stage=no-bandplan before it could reach the voice pool. The virtual
voice pool (internal/sdr/wbvoice voice_taps) was already generic and
wired end-to-end; this missing band plan was the real blocker for T3
voice on a wideband dongle.

Add an operator-supplied dmr_band_plan on a system (linear grid or
explicit LCN→Hz table), mirroring the P25BandPlan wiring, and feed it
into tier3.New on both decode paths via a shared tier3.ResolverFromPlan
helper. A dmr system with no band plan now warns at load and keeps the
soft-drop behaviour (CC monitoring still works).

- config: DMRBandPlanConfig (+ linear/table) with validation (exactly
  one of linear/table; nonzero base/spacing; nonzero freq; no dup LCN)
- trunking.System: DMRBandPlan field + mirror structs
- daemon: config→System copy + missing-plan warning for protocol: dmr
- widebandt2 + ccdecoder: pass Resolver: tier3.ResolverFromPlan(...)
- widebandt2 docstring: drop the stale "virtual voice pool is a
  follow-up" note
- tests: ResolverFromPlan unit tests, config validation cases, a
  wideband T3 grant e2e (resolved freq + no-bandplan negative control),
  and a tap-allocation test tying a resolved LCN to a virtual voice tap
- docs/config.example: document dmr_band_plan and T3 voice on wideband

https://claude.ai/code/session_01ParTi9V4czr2QCJYNWjc2d