### PR TITLE
dmr/tier3: carry voice-call timeslot (TS1/TS2) through grants and API (phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ for tagged releases.
 
 ## [Unreleased]
 
+### Added
+
+- **DMR Tier III band plan → T3 voice on the wideband dongle.** A
+  Tier III voice-grant CSBK references its traffic channel by a 7-bit
+  Logical Channel Number (LCN), not an absolute frequency, so the
+  decoder needs an LCN→frequency map to follow a call. That resolver
+  was never wired from config — both the wideband (`widebandt2`) and
+  dedicated-dongle (`ccdecoder`) decode paths built the Tier III
+  `ControlChannel` with a nil resolver, so every T3 voice grant was
+  dropped with `decode.error stage=no-bandplan` before it reached the
+  voice pool. New per-system `dmr_band_plan` config (`linear`
+  base/spacing/offset grid **or** an explicit `table` of `{lcn,
+  freq_hz}`) is converted to a `tier3.Resolver` and threaded into both
+  paths via `tier3.ResolverFromPlan`. Resolved grants are served by the
+  existing virtual voice pool (`voice_taps` DDC taps on the wideband
+  dongle) or a physical `role: voice` SDR. A `protocol: dmr` system with
+  no band plan warns at start-up and keeps decoding the control channel.
+  See [`docs/hardware.md`](docs/hardware.md) and `config.example.yaml`.
+
 ## [v0.3.1] — 2026-06-03
 
 RTL-SDR Blog V4 reception finally works and the issue #402 live-decode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ for tagged releases.
 
 ### Added
 
+- **DMR timeslot is now a first-class call attribute (TS1/TS2).** A DMR
+  Tier III carrier interleaves two independent calls — one per TDMA
+  timeslot — but the slot was parsed from the grant CSBK and then
+  thrown away, so the two calls could not be told apart downstream. The
+  grant now carries a 1-based `Timeslot` (0 = not applicable, 1 = TS1,
+  2 = TS2), mapped from the CSBK's slot bit on both the standard and
+  vendor (Capacity Plus / Connect Plus) grant paths, and surfaced
+  through the JSON/SSE API, the gRPC `Grant` message, and the web DTO.
+  This is the foundation for separating concurrent same-carrier calls;
+  engine/recorder routing and per-slot voice decode land in follow-ups.
+
 - **DMR Tier III band plan → T3 voice on the wideband dongle.** A
   Tier III voice-grant CSBK references its traffic channel by a 7-bit
   Logical Channel Number (LCN), not an absolute frequency, so the

--- a/internal/api/grant_timeslot_test.go
+++ b/internal/api/grant_timeslot_test.go
@@ -1,0 +1,41 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// TestGrantTimeslotMapping verifies the DMR timeslot survives the
+// trunking.Grant → JSON DTO and → protobuf conversions the API layer
+// performs, so SSE/REST and gRPC consumers can distinguish a carrier's
+// two concurrent calls.
+func TestGrantTimeslotMapping(t *testing.T) {
+	g := trunking.Grant{
+		System:      "Sys",
+		Protocol:    "dmr-tier3",
+		GroupID:     0x123456,
+		SourceID:    0xABCDEF,
+		FrequencyHz: 866_175_000,
+		ChannelID:   3,
+		ChannelNum:  8,
+		Timeslot:    2,
+	}
+
+	if dto := grantToDTO(g); dto.Timeslot != 2 {
+		t.Errorf("grantToDTO Timeslot = %d, want 2", dto.Timeslot)
+	}
+	if pb := grantToPB(g); pb.GetTimeslot() != 2 {
+		t.Errorf("grantToPB Timeslot = %d, want 2", pb.GetTimeslot())
+	}
+
+	// A non-slotted grant (P25 Phase 1) leaves Timeslot zero, which the
+	// DTO omits from JSON (omitempty) and the PB carries as 0.
+	clear := trunking.Grant{System: "Sys", Protocol: "p25", FrequencyHz: 851_000_000}
+	if dto := grantToDTO(clear); dto.Timeslot != 0 {
+		t.Errorf("grantToDTO Timeslot = %d, want 0 for non-slotted grant", dto.Timeslot)
+	}
+	if pb := grantToPB(clear); pb.GetTimeslot() != 0 {
+		t.Errorf("grantToPB Timeslot = %d, want 0 for non-slotted grant", pb.GetTimeslot())
+	}
+}

--- a/internal/api/grpc.go
+++ b/internal/api/grpc.go
@@ -506,6 +506,7 @@ func grantToPB(g trunking.Grant) *apiv1.Grant {
 		GroupId: g.GroupID, SourceId: g.SourceID,
 		FrequencyHz: g.FrequencyHz,
 		ChannelId:   uint32(g.ChannelID), ChannelNumber: uint32(g.ChannelNum),
+		Timeslot:  uint32(g.Timeslot),
 		Encrypted: g.Encrypted, Emergency: g.Emergency, DataCall: g.DataCall,
 		AlgorithmId: uint32(g.AlgorithmID), KeyId: uint32(g.KeyID),
 	}

--- a/internal/api/pb/v1/events.pb.go
+++ b/internal/api/pb/v1/events.pb.go
@@ -341,8 +341,14 @@ type Grant struct {
 	// for encrypted calls whose ALGID/KID has not landed yet
 	// (Phase 1 grants publish before the first LDU2 — the engine
 	// backfills the values via KindCallEncryption).
-	AlgorithmId   uint32 `protobuf:"varint,11,opt,name=algorithm_id,json=algorithmId,proto3" json:"algorithm_id,omitempty"`
-	KeyId         uint32 `protobuf:"varint,12,opt,name=key_id,json=keyId,proto3" json:"key_id,omitempty"`
+	AlgorithmId uint32 `protobuf:"varint,11,opt,name=algorithm_id,json=algorithmId,proto3" json:"algorithm_id,omitempty"`
+	KeyId       uint32 `protobuf:"varint,12,opt,name=key_id,json=keyId,proto3" json:"key_id,omitempty"`
+	// TDMA timeslot the call occupies on its carrier, 1-based:
+	// 0 = not applicable / unknown (P25 Phase 1, NXDN, analog),
+	// 1 = TS1, 2 = TS2. DMR Tier III carries two independent calls on
+	// one 12.5 kHz carrier, so (frequency_hz, timeslot) identifies a
+	// call rather than frequency alone.
+	Timeslot      uint32 `protobuf:"varint,13,opt,name=timeslot,proto3" json:"timeslot,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -457,6 +463,13 @@ func (x *Grant) GetAlgorithmId() uint32 {
 func (x *Grant) GetKeyId() uint32 {
 	if x != nil {
 		return x.KeyId
+	}
+	return 0
+}
+
+func (x *Grant) GetTimeslot() uint32 {
+	if x != nil {
+		return x.Timeslot
 	}
 	return 0
 }
@@ -859,7 +872,7 @@ const file_events_proto_rawDesc = "" +
 	"\n" +
 	"AttrsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xef\x02\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x8b\x03\n" +
 	"\x05Grant\x12\x16\n" +
 	"\x06system\x18\x01 \x01(\tR\x06system\x12\x1a\n" +
 	"\bprotocol\x18\x02 \x01(\tR\bprotocol\x12\x19\n" +
@@ -874,7 +887,8 @@ const file_events_proto_rawDesc = "" +
 	"\tdata_call\x18\n" +
 	" \x01(\bR\bdataCall\x12!\n" +
 	"\falgorithm_id\x18\v \x01(\rR\valgorithmId\x12\x15\n" +
-	"\x06key_id\x18\f \x01(\rR\x05keyId\"\x96\x01\n" +
+	"\x06key_id\x18\f \x01(\rR\x05keyId\x12\x1a\n" +
+	"\btimeslot\x18\r \x01(\rR\btimeslot\"\x96\x01\n" +
 	"\tCallStart\x12+\n" +
 	"\x05grant\x18\x01 \x01(\v2\x15.gophertrunk.v1.GrantR\x05grant\x127\n" +
 	"\ttalkgroup\x18\x02 \x01(\v2\x19.gophertrunk.v1.TalkGroupR\ttalkgroup\x12#\n" +

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -195,9 +195,13 @@ type GrantDTO struct {
 	FrequencyHz   uint32 `json:"frequency_hz"`
 	ChannelID     uint8  `json:"channel_id,omitempty"`
 	ChannelNumber uint16 `json:"channel_number,omitempty"`
-	Encrypted     bool   `json:"encrypted,omitempty"`
-	Emergency     bool   `json:"emergency,omitempty"`
-	DataCall      bool   `json:"data_call,omitempty"`
+	// Timeslot is the 1-based TDMA slot (0 = n/a, 1 = TS1, 2 = TS2).
+	// Non-zero only for slotted protocols (DMR Tier III); identifies
+	// which of a carrier's two calls this is.
+	Timeslot  uint8 `json:"timeslot,omitempty"`
+	Encrypted bool  `json:"encrypted,omitempty"`
+	Emergency bool  `json:"emergency,omitempty"`
+	DataCall  bool  `json:"data_call,omitempty"`
 	// AlgorithmID / KeyID surface the P25 encryption parameters
 	// recovered from the in-call signalling. Zero when Encrypted is
 	// false; also zero on a Phase 1 grant until the LDU2 Encryption
@@ -213,6 +217,7 @@ func grantToDTO(g trunking.Grant) GrantDTO {
 		GroupID: g.GroupID, SourceID: g.SourceID,
 		FrequencyHz: g.FrequencyHz,
 		ChannelID:   g.ChannelID, ChannelNumber: g.ChannelNum,
+		Timeslot:  g.Timeslot,
 		Encrypted: g.Encrypted, Emergency: g.Emergency,
 		DataCall:    g.DataCall,
 		AlgorithmID: g.AlgorithmID, KeyID: g.KeyID,

--- a/internal/radio/dmr/tier3/control.go
+++ b/internal/radio/dmr/tier3/control.go
@@ -145,7 +145,13 @@ func (c *ControlChannel) handleCSBK(cc uint8, csbk CSBK) {
 // voice grant on the bus. Shared by the standard and vendor CSBK
 // paths. Returns the resolved frequency and false when the LCN has no
 // band-plan entry (resolveLCN has already published the decode error).
-func (c *ControlChannel) publishGrant(cc, lcn uint8, group, source uint32, serviceOptions uint8) (uint32, bool) {
+//
+// slot is the CSBK's 0-based timeslot bit (0 = TS1, 1 = TS2); it is
+// mapped to trunking.Grant's 1-based Timeslot (1 = TS1, 2 = TS2) so a
+// DMR call's slot becomes part of the engine's (frequency, timeslot)
+// call identity — both slots of a 12.5 kHz carrier carry independent
+// calls.
+func (c *ControlChannel) publishGrant(cc, lcn, slot uint8, group, source uint32, serviceOptions uint8) (uint32, bool) {
 	freq, ok := c.resolveLCN(lcn)
 	if !ok {
 		return 0, false
@@ -160,6 +166,7 @@ func (c *ControlChannel) publishGrant(cc, lcn uint8, group, source uint32, servi
 			FrequencyHz: freq,
 			ChannelID:   cc,
 			ChannelNum:  uint16(lcn),
+			Timeslot:    slot + 1,
 			Encrypted:   serviceOptions&0x40 != 0,
 			Emergency:   serviceOptions&0x80 != 0,
 			At:          c.now(),
@@ -169,7 +176,7 @@ func (c *ControlChannel) publishGrant(cc, lcn uint8, group, source uint32, servi
 }
 
 func (c *ControlChannel) publishTVGrant(cc uint8, g TVGrant) {
-	freq, ok := c.publishGrant(cc, g.LCN, g.GroupAddress, g.SourceID, g.ServiceOptions)
+	freq, ok := c.publishGrant(cc, g.LCN, g.Timeslot, g.GroupAddress, g.SourceID, g.ServiceOptions)
 	if !ok {
 		return
 	}
@@ -179,7 +186,7 @@ func (c *ControlChannel) publishTVGrant(cc uint8, g TVGrant) {
 }
 
 func (c *ControlChannel) publishPVGrant(cc uint8, g PVGrant) {
-	freq, ok := c.publishGrant(cc, g.LCN, g.DestinationID, g.SourceID, g.ServiceOptions)
+	freq, ok := c.publishGrant(cc, g.LCN, g.Timeslot, g.DestinationID, g.SourceID, g.ServiceOptions)
 	if !ok {
 		return
 	}

--- a/internal/radio/dmr/tier3/control_test.go
+++ b/internal/radio/dmr/tier3/control_test.go
@@ -142,6 +142,10 @@ func TestControlChannelPublishesTVGrant(t *testing.T) {
 			if !g.Encrypted || !g.Emergency {
 				t.Errorf("flags = enc=%v emer=%v, want both", g.Encrypted, g.Emergency)
 			}
+			// byte 7 bit 7 set → CSBK TS2 (0-based 1) → 1-based Timeslot 2.
+			if g.Timeslot != 2 {
+				t.Errorf("Timeslot = %d, want 2 (TS2)", g.Timeslot)
+			}
 			if g.At.Unix() != 1_700_000_000 {
 				t.Errorf("At = %v, want injected Now", g.At)
 			}
@@ -184,6 +188,10 @@ func TestControlChannelPublishesPVGrant(t *testing.T) {
 			}
 			if g.FrequencyHz != 462_550_000 {
 				t.Errorf("freq = %d, want 462_550_000", g.FrequencyHz)
+			}
+			// byte 7 bit 7 clear → CSBK TS1 (0-based 0) → 1-based Timeslot 1.
+			if g.Timeslot != 1 {
+				t.Errorf("Timeslot = %d, want 1 (TS1)", g.Timeslot)
 			}
 			return
 		case <-deadline:

--- a/internal/radio/dmr/tier3/vendor.go
+++ b/internal/radio/dmr/tier3/vendor.go
@@ -92,22 +92,22 @@ func (c *ControlChannel) handleVendorCSBK(vendor Vendor, cc uint8, csbk CSBK) {
 // layer, not the voice codec, so the engine / recorder / vocoder paths
 // are unaffected.
 func (c *ControlChannel) publishVendorTVGrant(vendor Vendor, cc uint8, g TVGrant) {
-	freq, ok := c.publishGrant(cc, g.LCN, g.GroupAddress, g.SourceID, g.ServiceOptions)
+	freq, ok := c.publishGrant(cc, g.LCN, g.Timeslot, g.GroupAddress, g.SourceID, g.ServiceOptions)
 	if !ok {
 		return
 	}
 	c.log.Debug("dmr/tier3: vendor tv-grant",
 		"vendor", vendor.String(), "system", c.systemName, "cc", cc,
-		"tg", g.GroupAddress, "src", g.SourceID, "lcn", g.LCN, "freq_hz", freq)
+		"tg", g.GroupAddress, "src", g.SourceID, "lcn", g.LCN, "ts", g.Timeslot, "freq_hz", freq)
 }
 
 // publishVendorPVGrant emits a private voice grant from a vendor CSBK.
 func (c *ControlChannel) publishVendorPVGrant(vendor Vendor, cc uint8, g PVGrant) {
-	freq, ok := c.publishGrant(cc, g.LCN, g.DestinationID, g.SourceID, g.ServiceOptions)
+	freq, ok := c.publishGrant(cc, g.LCN, g.Timeslot, g.DestinationID, g.SourceID, g.ServiceOptions)
 	if !ok {
 		return
 	}
 	c.log.Debug("dmr/tier3: vendor pv-grant",
 		"vendor", vendor.String(), "system", c.systemName, "cc", cc,
-		"dst", g.DestinationID, "src", g.SourceID, "lcn", g.LCN, "freq_hz", freq)
+		"dst", g.DestinationID, "src", g.SourceID, "lcn", g.LCN, "ts", g.Timeslot, "freq_hz", freq)
 }

--- a/internal/radio/dmr/tier3/vendor_test.go
+++ b/internal/radio/dmr/tier3/vendor_test.go
@@ -74,6 +74,11 @@ func TestMotorolaVendorGrantEmitted(t *testing.T) {
 		if g.Protocol != "dmr-tier3" {
 			t.Errorf("grant protocol = %q", g.Protocol)
 		}
+		// tvGrantPayload masks byte 7 to lcn&0x7F, so the slot bit is
+		// clear → CSBK TS1 → 1-based Timeslot 1.
+		if g.Timeslot != 1 {
+			t.Errorf("grant Timeslot = %d, want 1 (TS1)", g.Timeslot)
+		}
 	case <-time.After(time.Second):
 		t.Fatal("no grant event from a Motorola vendor CSBK")
 	}

--- a/internal/trunking/grant.go
+++ b/internal/trunking/grant.go
@@ -21,8 +21,18 @@ type Grant struct {
 	FrequencyHz uint32 // voice channel frequency
 	ChannelID   uint8  // raw channel ID (P25 band-plan ID, DMR LCN high)
 	ChannelNum  uint16 // raw channel number within the ID
-	Encrypted   bool
-	Emergency   bool
+	// Timeslot identifies the TDMA logical channel a call occupies on
+	// its carrier, 1-based: 0 = not applicable / unknown (P25 Phase 1,
+	// NXDN, analog — frequency alone identifies the call), 1 = TS1,
+	// 2 = TS2. DMR Tier III carries two independent calls on one
+	// 12.5 kHz carrier (TS1 + TS2), so the engine treats
+	// (FrequencyHz, Timeslot) as the call identity rather than
+	// frequency alone. Populated by the protocol layer; the DMR CSBK
+	// parser maps its 0-based slot bit (0 = TS1, 1 = TS2) onto this
+	// 1-based convention so 0 stays reserved for "no slot".
+	Timeslot  uint8
+	Encrypted bool
+	Emergency bool
 	// AlgorithmID and KeyID carry the encryption parameters the
 	// protocol's privacy header advertises (the DMR PI header, etc.).
 	// They are meaningful only when Encrypted is true and stay zero
@@ -100,7 +110,11 @@ func (g Grant) String() string {
 	if g.ProVoice {
 		flags += "P"
 	}
-	return fmt.Sprintf("%s/%s tg=%d src=%d freq=%d %s", g.System, g.Protocol, g.GroupID, g.SourceID, g.FrequencyHz, flags)
+	ts := ""
+	if g.Timeslot != 0 {
+		ts = fmt.Sprintf(" ts%d", g.Timeslot)
+	}
+	return fmt.Sprintf("%s/%s tg=%d src=%d freq=%d%s %s", g.System, g.Protocol, g.GroupID, g.SourceID, g.FrequencyHz, ts, flags)
 }
 
 // EndReason classifies why a call ended; carried in CallEnd events so the

--- a/internal/trunking/grant_test.go
+++ b/internal/trunking/grant_test.go
@@ -1,0 +1,34 @@
+package trunking
+
+import "testing"
+
+func TestGrantStringTimeslot(t *testing.T) {
+	tests := []struct {
+		name string
+		g    Grant
+		want string
+	}{
+		{
+			name: "no timeslot omits the ts token",
+			g:    Grant{System: "Sys", Protocol: "p25", GroupID: 100, SourceID: 7, FrequencyHz: 851_000_000},
+			want: "Sys/p25 tg=100 src=7 freq=851000000 ",
+		},
+		{
+			name: "ts1 renders ts1",
+			g:    Grant{System: "Sys", Protocol: "dmr-tier3", GroupID: 1, SourceID: 2, FrequencyHz: 460_000_000, Timeslot: 1},
+			want: "Sys/dmr-tier3 tg=1 src=2 freq=460000000 ts1 ",
+		},
+		{
+			name: "ts2 renders ts2 alongside flags",
+			g:    Grant{System: "Sys", Protocol: "dmr-tier3", GroupID: 1, SourceID: 2, FrequencyHz: 460_000_000, Timeslot: 2, Emergency: true},
+			want: "Sys/dmr-tier3 tg=1 src=2 freq=460000000 ts2 !",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.g.String(); got != tc.want {
+				t.Errorf("String() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/proto/events.proto
+++ b/proto/events.proto
@@ -67,6 +67,12 @@ message Grant {
   // backfills the values via KindCallEncryption).
   uint32 algorithm_id    = 11;
   uint32 key_id          = 12;
+  // TDMA timeslot the call occupies on its carrier, 1-based:
+  // 0 = not applicable / unknown (P25 Phase 1, NXDN, analog),
+  // 1 = TS1, 2 = TS2. DMR Tier III carries two independent calls on
+  // one 12.5 kHz carrier, so (frequency_hz, timeslot) identifies a
+  // call rather than frequency alone.
+  uint32 timeslot        = 13;
 }
 
 message CallStart {

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -77,6 +77,10 @@ export interface GrantDTO {
   frequency_hz: number;
   channel_id?: number;
   channel_number?: number;
+  // TDMA timeslot, 1-based: 1 = TS1, 2 = TS2 (DMR Tier III). Absent /
+  // 0 for non-slotted protocols, where frequency alone identifies the
+  // call.
+  timeslot?: number;
   encrypted?: boolean;
   emergency?: boolean;
   data_call?: boolean;


### PR DESCRIPTION
## Why

A DMR Tier III carrier interleaves **two independent voice calls** — one per TDMA timeslot (TS1/TS2) of a single 12.5 kHz carrier. The grant CSBK parsers (`ParseTVGrant`/`ParsePVGrant`) already extracted the slot bit, but `publishGrant` **dropped it** — it was only logged. As a result the slot was invisible to the rest of the system, so the two concurrent calls on one carrier could not be told apart anywhere downstream (engine dedup, recorder, API, voice decode).

This is **phase 1 of a multi-phase timeslot effort**: it establishes timeslot as a first-class *call-identity* attribute. It does not yet change call routing or audio decode — those build on this foundation in follow-up PRs.

## What

- **`trunking.Grant.Timeslot uint8`** — 1-based: `0` = not applicable/unknown (P25 Phase 1, NXDN, analog — frequency alone identifies the call), `1` = TS1, `2` = TS2. Keeping `0` reserved for "no slot" lets later phases treat `(FrequencyHz, Timeslot)` as the call key without ambiguity.
- **Producer** (`internal/radio/dmr/tier3`): `publishGrant` takes the CSBK's 0-based slot bit and maps it to the 1-based field; wired on the standard (`publishTVGrant`/`publishPVGrant`) **and** vendor (Capacity Plus / Connect Plus) grant paths.
- **Surfacing:** `Grant.String()` renders ` ts1`/` ts2`; JSON/SSE `GrantDTO`, the gRPC `Grant` message (regenerated from `proto/events.proto`), and the web `GrantDTO` type all carry it.
- DMR Tier II conventional has no slot number at the Voice LC header, so it correctly stays `Timeslot = 0`.

## Tests

- `control_test.go` / `vendor_test.go`: TV (TS2), PV (TS1), and vendor (TS1) grant publishes assert the mapped `Timeslot`.
- `grant_test.go`: `String()` slot rendering (none / ts1 / ts2 + flags).
- `grant_timeslot_test.go`: `grantToDTO` and `grantToPB` round-trip, including the non-slotted (`Timeslot 0`) case.
- Full suite green (`go test ./...`: 110 packages OK, 0 failures); `go vet` clean on touched packages. Protobuf regenerated with the repo's pinned `protoc v3.21.12` + `protoc-gen-go v1.36.11` (matching the existing generated header); unrelated grpc-plugin version churn reverted.

## Follow-up phases (not in this PR)

2. Engine/pool routing: dedup + preempt + bind on `(frequency, timeslot)` so TS1+TS2 are two distinct calls; recorder filenames/metadata per slot.
3. Slot-phase-aware voice superframe decode + 2-slot interleaved test vectors.
4. Embedded-LC (EMB/LCSS) decode to bind each superframe to its talkgroup for correctly *labeled* concurrent-call separation.

https://claude.ai/code/session_01ParTi9V4czr2QCJYNWjc2d

---
_Generated by [Claude Code](https://claude.ai/code/session_01ParTi9V4czr2QCJYNWjc2d)_