### PR TITLE
dmr/voice: stride-aware decoder separates interleaved 2-slot calls (phase 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ for tagged releases.
 
 ### Added
 
+- **DMR 2-slot interleaved voice decoder.** The DMR voice superframe
+  decoder previously assumed a single-slot stream — bursts A–F at a
+  contiguous 132-dibit cadence — which only holds for synthetic
+  single-slot vectors. A real DMR carrier is 2-slot TDMA: the two
+  timeslots' bursts interleave, so a call's own bursts are 264 dibits
+  apart. New `voice.NewInterleavedDecoder` (stride 2) handles that — it
+  locks each slot's burst A on its own voice sync, gathers that slot's
+  B–F by striding over the interleaved other-slot burst, and emits one
+  superframe per slot, told apart by the new `VoiceSuperframe.Phase`
+  field. `NewDecoder` (stride 1) is unchanged for single-slot streams.
+  The exact same-slot cadence on live BS-sourced air (CACH/guard
+  handling) still needs a real IQ capture before the interleaved path
+  replaces the single-slot decoder on the production composer, so it
+  stays opt-in at the library level for now — see
+  [docs/status.md](docs/status.md).
 - **DMR timeslot is now a first-class call attribute (TS1/TS2).** A DMR
   Tier III carrier interleaves two independent calls — one per TDMA
   timeslot — but the slot was parsed from the grant CSBK and then

--- a/README.md
+++ b/README.md
@@ -276,6 +276,14 @@ log, per-talkgroup policy) all ship.
 - **Digital-voice composer chains.** FM, DMR, P25 Phase 1 / 2 decode
   to audio. NXDN, dPMR, TETRA, YSF, D-STAR voice (plus EDACS
   ProVoice) are followed and logged but not yet turned into PCM.
+- **DMR 2-slot interleaved voice cadence.** Both timeslots of a
+  carrier are tracked, recorded, and logged as separate calls, and a
+  stride-2 interleaved superframe decoder
+  (`voice.NewInterleavedDecoder`) that separates the two slots is
+  implemented and unit-tested against synthetic vectors. Confirming
+  the exact same-slot burst cadence on live BS-sourced air (CACH /
+  guard handling) before it becomes the production default needs a
+  real IQ capture — see [docs/status.md](docs/status.md).
 - **Additional SDR validation.** HackRF / Airspy / HF+ drivers
   exercise the documented USB vendor protocols under unit tests
   against a mock transport; on-air validation against attached

--- a/docs/status.md
+++ b/docs/status.md
@@ -85,6 +85,19 @@ The inner FEC layers still pending real-air validation:
   fixtures end-to-end; on-air recovery margins (Viterbi
   correction depth vs. real co-channel + adjacent-channel
   interference) need a live capture to characterise.
+- **DMR 2-slot interleaved voice cadence.** A DMR carrier is
+  2-slot TDMA, so a real outbound stream interleaves both
+  timeslots' bursts. `voice.NewInterleavedDecoder` (stride 2)
+  decodes that: it locks each slot's burst A on its own voice
+  sync and gathers that slot's B–F 264 dibits apart, emitting one
+  superframe per slot tagged by `VoiceSuperframe.Phase`. It is
+  unit-tested against synthetic interleaved vectors. Before it
+  replaces the single-slot `NewDecoder` on the production voice
+  path, the exact same-slot dibit cadence on live BS-sourced air
+  — where a CACH may precede each burst, making the stride 288
+  rather than 264 dibits — needs a real IQ capture to confirm.
+  Until then the production composer keeps the single-slot
+  decoder and the interleaved path is opt-in at the library level.
 
 ### Digital-voice level calibration
 

--- a/internal/radio/dmr/voice/doc.go
+++ b/internal/radio/dmr/voice/doc.go
@@ -5,10 +5,17 @@
 // DMR voice is organised into 6-burst superframes (bursts A–F, 360 ms
 // of audio). Burst A is framed by a voice sync word (BS/MS/DM Voice);
 // bursts B–F replace the sync word with embedded signalling, so they
-// carry no sync of their own and must be located by the fixed
-// 132-dibit TDMA cadence relative to burst A. Each burst carries 216
-// voice bits — three 72-bit on-air AMBE+2 frames — for 18 frames per
-// superframe.
+// carry no sync of their own and must be located by the TDMA cadence
+// relative to burst A. Each burst carries 216 voice bits — three
+// 72-bit on-air AMBE+2 frames — for 18 frames per superframe.
+//
+// DMR is 2-slot TDMA, so a carrier interleaves two independent calls.
+// The Decoder's stride controls the cadence between a call's own
+// consecutive bursts: NewDecoder (stride 1) expects a single-slot
+// stream with contiguous 132-dibit bursts; NewInterleavedDecoder
+// (stride 2) handles a real 2-slot carrier, gathering each slot's
+// bursts 264 dibits apart and emitting one superframe per slot, told
+// apart by VoiceSuperframe.Phase.
 //
 // This package produces the *on-air* AMBE frames (72 bits each, FEC
 // still applied). Decoding the AMBE forward-error-correction down to

--- a/internal/radio/dmr/voice/superframe.go
+++ b/internal/radio/dmr/voice/superframe.go
@@ -15,6 +15,16 @@ type VoiceSuperframe struct {
 	SyncName string
 	// StartDibit is the absolute dibit index of burst A's first dibit.
 	StartDibit int
+	// Phase distinguishes the two interleaved calls on a 2-slot TDMA
+	// carrier: it is the burst-A start's parity in burst units
+	// ((StartDibit / BurstDibits) mod stride), so the two timeslots —
+	// whose burst-A anchors sit exactly one physical burst (132 dibits)
+	// apart — always carry different, stable phases for the life of a
+	// call. It is a relative discriminator, NOT an absolute TS1/TS2
+	// label (the BS-sourced sync word is identical on both slots);
+	// binding a phase to a talkgroup is the embedded-LC decoder's job.
+	// Always 0 for a single-slot (stride 1) Decoder.
+	Phase uint8
 }
 
 // voiceSyncs are the sync words that frame burst A of a voice
@@ -29,20 +39,29 @@ var voiceSyncs = []dmr.SyncPattern{
 // dibits + 24 sync dibits − 1.
 const burstLookback = VoiceHalfDibits + 24 - 1 // 77
 
-// superframeDibits is the dibit span of a full A–F superframe.
+// superframeDibits is the dibit span of a full A–F superframe on a
+// single-slot (stride 1) stream — six contiguous 132-dibit bursts.
 const superframeDibits = dmr.BurstDibits * BurstsPerSuperframe // 792
-
-// bufKeep retains enough dibits that two pending burst-A anchors can
-// each still slice a complete superframe once their trailing bursts
-// arrive. Dibits are one byte each, so the buffer cost is trivial.
-const bufKeep = 2*superframeDibits + dmr.BurstDibits
 
 // Decoder extracts DMR voice superframes from a dibit stream. It is
 // the voice-burst counterpart of the tier2 / tier3 control-channel
 // Process adapters: those slice a burst on every sync match, but
 // voice bursts B–F carry no sync, so the Decoder locks onto burst A
-// via its voice sync word and slices B–F at the fixed 132-dibit TDMA
-// cadence.
+// via its voice sync word and slices B–F at a fixed TDMA cadence.
+//
+// stride is the number of physical 132-dibit bursts between two
+// consecutive bursts of the SAME logical call:
+//
+//   - stride 1 — a single-slot / direct stream where a call's bursts
+//     A–F are contiguous (132-dibit cadence). This is NewDecoder and
+//     matches synthetic single-slot vectors.
+//   - stride 2 — a real 2-slot TDMA carrier (NewInterleavedDecoder),
+//     where the other timeslot's burst sits between each of a call's
+//     bursts, so same-slot bursts are 264 dibits apart. One such
+//     Decoder transparently emits superframes for BOTH slots: it locks
+//     each slot's burst A on its own voice sync and gathers that slot's
+//     B–F by striding over the interleaved burst. The two slots' output
+//     is told apart by VoiceSuperframe.Phase.
 //
 // A Decoder is stateful and not safe for concurrent use; construct
 // one per voice-call decode chain.
@@ -51,15 +70,46 @@ type Decoder struct {
 	buf      []uint8
 	bufStart int // absolute dibit index of buf[0]
 	pending  []dmr.Match
+	stride   int // physical bursts between consecutive same-slot bursts
+	span     int // dibit span of a full A–F superframe at this stride
+	bufKeep  int // dibits retained so two in-flight anchors can complete
 }
 
-// NewDecoder returns a Decoder ready to consume dibits.
-func NewDecoder() *Decoder {
-	return &Decoder{det: dmr.NewSyncDetector(voiceSyncs, 2)}
+func newDecoder(stride int) *Decoder {
+	// Bursts sit at start + b*stride*BurstDibits for b in 0..5, so the
+	// span runs from burst A's first dibit to burst F's last.
+	span := ((BurstsPerSuperframe-1)*stride + 1) * dmr.BurstDibits
+	return &Decoder{
+		det:    dmr.NewSyncDetector(voiceSyncs, 2),
+		stride: stride,
+		span:   span,
+		// Retain two full superframe spans plus a burst so the two
+		// interleaved slots' anchors can each complete without the
+		// trailing bursts being trimmed out from under them.
+		bufKeep: 2*span + dmr.BurstDibits,
+	}
 }
+
+// NewDecoder returns a single-slot Decoder (stride 1): a call's bursts
+// A–F are expected back-to-back at the 132-dibit cadence.
+func NewDecoder() *Decoder { return newDecoder(1) }
+
+// NewInterleavedDecoder returns a Decoder for a real 2-slot DMR TDMA
+// carrier (stride 2): a call's bursts are 264 dibits apart because the
+// other timeslot's burst is interleaved between them. It emits
+// superframes for both slots, tagged by VoiceSuperframe.Phase.
+//
+// NOTE: stride 2 assumes the two slots' bursts are adjacent 132-dibit
+// units with no inter-burst CACH / guard dibits in the demodulated
+// stream. The exact same-slot cadence on live BS-sourced outbound air
+// (where a CACH may precede each burst) should be confirmed against a
+// real IQ capture before this replaces NewDecoder on the production
+// voice path; see docs/status.md.
+func NewInterleavedDecoder() *Decoder { return newDecoder(2) }
 
 // Reset clears all buffered state. Call on a stream re-sync so a stale
-// burst-A anchor does not slice across the discontinuity.
+// burst-A anchor does not slice across the discontinuity. The stride
+// the Decoder was constructed with is preserved.
 func (d *Decoder) Reset() {
 	d.buf = d.buf[:0]
 	d.bufStart = 0
@@ -85,7 +135,7 @@ func (d *Decoder) Process(dibits []uint8, baseIdx int) []VoiceSuperframe {
 	keep := d.pending[:0]
 	for _, m := range d.pending {
 		start := m.Index - burstLookback
-		if start+superframeDibits > bufEnd {
+		if start+d.span > bufEnd {
 			keep = append(keep, m) // trailing bursts not buffered yet
 			continue
 		}
@@ -96,25 +146,32 @@ func (d *Decoder) Process(dibits []uint8, baseIdx int) []VoiceSuperframe {
 	}
 	d.pending = keep
 
-	if len(d.buf) > bufKeep {
-		drop := len(d.buf) - bufKeep
+	if len(d.buf) > d.bufKeep {
+		drop := len(d.buf) - d.bufKeep
 		copy(d.buf, d.buf[drop:])
-		d.buf = d.buf[:bufKeep]
+		d.buf = d.buf[:d.bufKeep]
 		d.bufStart += drop
 	}
 	return out
 }
 
-// sliceSuperframe cuts the six 132-dibit bursts starting at absolute
-// dibit index start and extracts their 18 AMBE frames. The caller has
-// already confirmed the full span is buffered.
+// sliceSuperframe cuts the six 132-dibit bursts of one logical call
+// starting at absolute dibit index start and extracts their 18 AMBE
+// frames. Consecutive bursts are stride*132 dibits apart, so on a
+// 2-slot stream the interleaved other-slot burst is skipped. The caller
+// has already confirmed the full span is buffered.
 func (d *Decoder) sliceSuperframe(start int, syncName string) VoiceSuperframe {
-	sf := VoiceSuperframe{SyncName: syncName, StartDibit: start}
+	sf := VoiceSuperframe{
+		SyncName:   syncName,
+		StartDibit: start,
+		Phase:      uint8((start / dmr.BurstDibits) % d.stride),
+	}
 	off := start - d.bufStart
+	step := d.stride * dmr.BurstDibits
 	frame := 0
 	for b := 0; b < BurstsPerSuperframe; b++ {
 		var burst dmr.Burst
-		copy(burst.Dibits[:], d.buf[off+b*dmr.BurstDibits:off+(b+1)*dmr.BurstDibits])
+		copy(burst.Dibits[:], d.buf[off+b*step:off+b*step+dmr.BurstDibits])
 		for _, f := range AMBEFrames(&burst) {
 			sf.Frames[frame] = f
 			frame++

--- a/internal/radio/dmr/voice/superframe_test.go
+++ b/internal/radio/dmr/voice/superframe_test.go
@@ -33,6 +33,37 @@ func buildStream(t *testing.T, n, lead int) (stream []uint8, frames [][]byte) {
 	return stream, frames
 }
 
+// buildInterleavedStream assembles a real 2-slot TDMA dibit stream: for
+// each of n superframes the six bursts of slot A and slot B are woven
+// burst-by-burst (A.b0, B.b0, A.b1, B.b1, … A.b5, B.b5), so each slot's
+// own bursts are 264 dibits (two physical bursts) apart. Burst A of each
+// slot's superframe carries BS-Voice sync; the rest carry BS-Data
+// (standing in for embedded signalling). Slot B's frames seed from a
+// large offset so the two slots' AMBE payloads are unmistakably
+// distinct. lead prepends filler dibits to exercise non-aligned starts.
+func buildInterleavedStream(t *testing.T, n, lead int) (stream []uint8, aFrames, bFrames [][]byte) {
+	t.Helper()
+	const bSeedOffset = 10000
+	stream = make([]uint8, lead)
+	total := n * FramesPerSuperframe
+	for f := 0; f < total; f++ {
+		aFrames = append(aFrames, mkFrame(f))
+		bFrames = append(bFrames, mkFrame(f+bSeedOffset))
+	}
+	for s := 0; s < n; s++ {
+		for b := 0; b < BurstsPerSuperframe; b++ {
+			sync := dmr.BSData.Dibits
+			if b == 0 {
+				sync = dmr.BSVoice.Dibits
+			}
+			base := s*FramesPerSuperframe + b*FramesPerBurst
+			stream = append(stream, makeVoiceBurst(aFrames[base:base+FramesPerBurst], sync)...)
+			stream = append(stream, makeVoiceBurst(bFrames[base:base+FramesPerBurst], sync)...)
+		}
+	}
+	return stream, aFrames, bFrames
+}
+
 func checkFrames(t *testing.T, sf VoiceSuperframe, frames [][]byte, firstFrame int) {
 	t.Helper()
 	for i := 0; i < FramesPerSuperframe; i++ {
@@ -138,4 +169,119 @@ func TestDecoderResetClearsState(t *testing.T) {
 		t.Fatalf("got %d superframes after reset, want 1", len(got))
 	}
 	checkFrames(t, got[0], frames, 0)
+}
+
+// TestInterleavedDecoderSeparatesSlots is the core 2-slot guard: fed a
+// carrier whose two timeslots interleave burst-by-burst, the interleaved
+// Decoder must emit one clean superframe per slot — each slice gathering
+// only its own slot's bursts (264-dibit stride) and skipping the other
+// slot's interleaved burst — tagged with distinct phases.
+func TestInterleavedDecoderSeparatesSlots(t *testing.T) {
+	stream, aFrames, bFrames := buildInterleavedStream(t, 1, 0)
+
+	d := NewInterleavedDecoder()
+	got := d.Process(stream, 0)
+
+	if len(got) != 2 {
+		t.Fatalf("got %d superframes, want 2 (one per timeslot)", len(got))
+	}
+	// Stream order: slot A's burst A (StartDibit 0) is detected before
+	// slot B's (StartDibit 132, one physical burst later).
+	a, b := got[0], got[1]
+	if a.StartDibit != 0 || b.StartDibit != dmr.BurstDibits {
+		t.Fatalf("StartDibits = %d, %d; want 0, %d", a.StartDibit, b.StartDibit, dmr.BurstDibits)
+	}
+	if a.Phase == b.Phase {
+		t.Errorf("both slots reported Phase %d; want distinct phases", a.Phase)
+	}
+	// Each superframe must contain ONLY its own slot's AMBE frames — the
+	// whole point of the stride. A single-slot (stride 1) decoder would
+	// instead interleave A and B frames here and fail this check.
+	checkFrames(t, a, aFrames, 0)
+	checkFrames(t, b, bFrames, 0)
+}
+
+// TestLegacyDecoderMixesInterleavedSlots documents the bug the
+// interleaved decoder fixes: a stride-1 Decoder run over a 2-slot stream
+// locks burst A correctly but then grabs the WRONG (other-slot) bursts
+// for B–F, so its output does not match either pure slot.
+func TestLegacyDecoderMixesInterleavedSlots(t *testing.T) {
+	stream, aFrames, bFrames := buildInterleavedStream(t, 1, 0)
+
+	d := NewDecoder() // stride 1 — wrong cadence for an interleaved carrier
+	got := d.Process(stream, 0)
+	if len(got) == 0 {
+		t.Fatal("expected at least one (mis-assembled) superframe")
+	}
+	// got[0] anchors on slot A's burst A but slices contiguous bursts,
+	// so its frames are an A/B interleave — equal to neither pure slot.
+	mixed := got[0]
+	aClean, bClean := true, true
+	for i := 0; i < FramesPerSuperframe; i++ {
+		if !bytes.Equal(mixed.Frames[i], aFrames[i]) {
+			aClean = false
+		}
+		if !bytes.Equal(mixed.Frames[i], bFrames[i]) {
+			bClean = false
+		}
+	}
+	if aClean || bClean {
+		t.Errorf("stride-1 decode unexpectedly matched a pure slot (aClean=%v bClean=%v); the interleaving guard is not exercised", aClean, bClean)
+	}
+}
+
+// TestInterleavedDecoderPhaseStable confirms that across several
+// superframes — and from a non-burst-aligned start offset — every
+// superframe of a given slot carries the same Phase, so a downstream
+// consumer can group a call's superframes by Phase for the call's
+// lifetime.
+func TestInterleavedDecoderPhaseStable(t *testing.T) {
+	const n, lead = 3, 17
+	stream, aFrames, bFrames := buildInterleavedStream(t, n, lead)
+
+	d := NewInterleavedDecoder()
+	got := d.Process(stream, 0)
+	if len(got) != 2*n {
+		t.Fatalf("got %d superframes, want %d (%d per slot)", len(got), 2*n, n)
+	}
+
+	// Partition by phase; every superframe sharing slot A's phase must
+	// carry slot A's frames, and likewise for B.
+	aPhase := got[0].Phase
+	var ai, bi int
+	for _, sf := range got {
+		if sf.Phase == aPhase {
+			checkFrames(t, sf, aFrames, ai*FramesPerSuperframe)
+			ai++
+		} else {
+			checkFrames(t, sf, bFrames, bi*FramesPerSuperframe)
+			bi++
+		}
+	}
+	if ai != n || bi != n {
+		t.Errorf("phase partition = %d/%d superframes, want %d/%d", ai, bi, n, n)
+	}
+}
+
+// TestInterleavedDecoderChunkedInput feeds the 2-slot stream in small
+// chunks to exercise the cross-Process buffering of two simultaneously
+// in-flight superframe anchors.
+func TestInterleavedDecoderChunkedInput(t *testing.T) {
+	stream, aFrames, bFrames := buildInterleavedStream(t, 1, 0)
+
+	d := NewInterleavedDecoder()
+	var got []VoiceSuperframe
+	const chunk = 137
+	for off := 0; off < len(stream); off += chunk {
+		end := off + chunk
+		if end > len(stream) {
+			end = len(stream)
+		}
+		got = append(got, d.Process(stream[off:end], off)...)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d superframes across chunks, want 2", len(got))
+	}
+	checkFrames(t, got[0], aFrames, 0)
+	checkFrames(t, got[1], bFrames, 0)
 }


### PR DESCRIPTION
## Why

Phases 1–2 (#512, #513, merged) made timeslot a first-class call attribute and route TS1/TS2 as concurrent calls. But the **DSP underneath still couldn't actually separate the two slots' audio**: the voice superframe decoder located bursts B–F at a contiguous **132-dibit** cadence, which assumes a *single-slot* stream — true only for the synthetic single-slot test vectors. A real DMR carrier is **2-slot TDMA**: the two timeslots' bursts interleave, so one call's own bursts are **264 dibits** apart and the contiguous slicing folds both slots into one garbled superframe.

## What

Parameterise `voice.Decoder` by a **burst stride** — the number of physical 132-dibit bursts between two consecutive bursts of the *same* logical call:

- **`NewDecoder` (stride 1)** — unchanged. Single-slot / direct streams; all existing tests pass untouched.
- **`NewInterleavedDecoder` (stride 2)** — a real 2-slot carrier. It locks each slot's burst A on its own voice sync and gathers that slot's B–F by striding *over* the interleaved other-slot burst, so **one decoder emits a clean superframe per slot**. The two slots are told apart by the new **`VoiceSuperframe.Phase`** (burst-A start parity) — a stable *relative* discriminator for a call's lifetime. (It is deliberately **not** an absolute TS1/TS2 label: the BS-sourced sync word is identical on both slots, so binding a phase → absolute slot + talkgroup is the embedded-LC decoder's job in phase 4.)

`span` / `bufKeep` are now derived from the stride so two interleaved anchors can each complete without trimming the other out of the ring buffer.

## Important caveat (why this is opt-in, not yet the production default)

The stride-2 constant (264 dibits) assumes the two slots' bursts are adjacent 132-dibit units with no inter-burst CACH/guard dibits in the demodulated stream. On live **BS-sourced outbound** air a CACH may precede each burst, which would make the same-slot cadence **288** dibits, not 264. Nailing that down needs a **real IQ capture**. Until then the production composer keeps `NewDecoder`, and the interleaved path is reachable at the library level. This is documented in `docs/status.md`.

## Tests (all green: `go test ./...` → 110 packages OK, 0 failures; `gofmt`/`go vet` clean)

New `internal/radio/dmr/voice/superframe_test.go` coverage, built on a new `buildInterleavedStream` 2-slot synth:
- `TestInterleavedDecoderSeparatesSlots` — interleaved carrier → two superframes, each containing **only** its own slot's AMBE frames, with distinct phases.
- `TestLegacyDecoderMixesInterleavedSlots` — proves a stride-1 decoder over the same stream produces frames matching **neither** pure slot (the bug this fixes).
- `TestInterleavedDecoderPhaseStable` — phase is stable per slot across multiple superframes from a non-burst-aligned start.
- `TestInterleavedDecoderChunkedInput` — two simultaneously in-flight anchors complete correctly across small chunk boundaries.

## Docs

`README.md`, `docs/status.md`, `internal/radio/dmr/voice/doc.go`, and `CHANGELOG.md` updated.

## Follow-up

4. Embedded-LC (EMB/LCSS) decode → reassemble each superframe's Link Control → bind a phase to its talkgroup, giving correctly **labeled** TS1/TS2 separation and the basis for wiring the interleaved decoder into the production composer (alongside real-capture cadence validation).

https://claude.ai/code/session_01ParTi9V4czr2QCJYNWjc2d

---
_Generated by [Claude Code](https://claude.ai/code/session_01ParTi9V4czr2QCJYNWjc2d)_