### PR TITLE
dmr/voice: decode embedded Link Control to label timeslots by talkgroup (phase 4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ for tagged releases.
 
 ### Added
 
+- **DMR embedded Link Control decode → per-timeslot talkgroup labelling.**
+  On a BS-sourced carrier both timeslots use the identical burst-A voice
+  sync, so the sync alone cannot say which slot (and which talkgroup) a
+  superframe belongs to. The voice decoder now reassembles the embedded
+  Link Control carried by the sync field of bursts B–E — EMB split →
+  the new variable `framing` BPTC(128,72) (Hamming(16,11,4) rows + a
+  5-bit CRC) → the existing `dmr.FLC` parser — and, on a clean CRC,
+  surfaces the call's talkgroup + source on `VoiceSuperframe.LC`.
+  Combined with the interleaved decoder's `Phase`, that lets a consumer
+  bind each timeslot to a concrete talkgroup. New FEC primitives
+  (`framing.HammingEncode/Decode16_11`, `framing.Encode/DecodeEmbeddedLC`,
+  `dmr.SplitEmbeddedField` / `dmr.ReassembleEmbeddedLC`) are round-trip
+  + single-error-correction tested. The exact ETSI embedded-signalling
+  de-interleave order, EMB QR(16,7) FEC, and 5-bit CRC polynomial are
+  internally consistent but still pending a real-capture cross-check, so
+  the path stays opt-in at the library level — see
+  [docs/status.md](docs/status.md).
 - **DMR 2-slot interleaved voice decoder.** The DMR voice superframe
   decoder previously assumed a single-slot stream — bursts A–F at a
   contiguous 132-dibit cadence — which only holds for synthetic

--- a/README.md
+++ b/README.md
@@ -276,14 +276,17 @@ log, per-talkgroup policy) all ship.
 - **Digital-voice composer chains.** FM, DMR, P25 Phase 1 / 2 decode
   to audio. NXDN, dPMR, TETRA, YSF, D-STAR voice (plus EDACS
   ProVoice) are followed and logged but not yet turned into PCM.
-- **DMR 2-slot interleaved voice cadence.** Both timeslots of a
-  carrier are tracked, recorded, and logged as separate calls, and a
-  stride-2 interleaved superframe decoder
-  (`voice.NewInterleavedDecoder`) that separates the two slots is
-  implemented and unit-tested against synthetic vectors. Confirming
-  the exact same-slot burst cadence on live BS-sourced air (CACH /
-  guard handling) before it becomes the production default needs a
-  real IQ capture — see [docs/status.md](docs/status.md).
+- **DMR 2-slot interleaved voice + embedded-LC labelling.** Both
+  timeslots of a carrier are tracked, recorded, and logged as separate
+  calls; a stride-2 interleaved superframe decoder
+  (`voice.NewInterleavedDecoder`) separates the two slots and
+  reassembles each slot's embedded Link Control (EMB → variable
+  BPTC(128,72) → talkgroup/source) so a slot can be bound to its
+  talkgroup. The full chain is unit-tested against synthetic vectors;
+  confirming the exact on-air dibit cadence (CACH/guard) and the ETSI
+  embedded-signalling interleave / EMB FEC / CRC against a real IQ
+  capture is what's needed before it becomes the production default —
+  see [docs/status.md](docs/status.md).
 - **Additional SDR validation.** HackRF / Airspy / HF+ drivers
   exercise the documented USB vendor protocols under unit tests
   against a mock transport; on-air validation against attached

--- a/docs/status.md
+++ b/docs/status.md
@@ -85,19 +85,30 @@ The inner FEC layers still pending real-air validation:
   fixtures end-to-end; on-air recovery margins (Viterbi
   correction depth vs. real co-channel + adjacent-channel
   interference) need a live capture to characterise.
-- **DMR 2-slot interleaved voice cadence.** A DMR carrier is
-  2-slot TDMA, so a real outbound stream interleaves both
-  timeslots' bursts. `voice.NewInterleavedDecoder` (stride 2)
-  decodes that: it locks each slot's burst A on its own voice
-  sync and gathers that slot's B–F 264 dibits apart, emitting one
-  superframe per slot tagged by `VoiceSuperframe.Phase`. It is
-  unit-tested against synthetic interleaved vectors. Before it
-  replaces the single-slot `NewDecoder` on the production voice
-  path, the exact same-slot dibit cadence on live BS-sourced air
-  — where a CACH may precede each burst, making the stride 288
-  rather than 264 dibits — needs a real IQ capture to confirm.
-  Until then the production composer keeps the single-slot
-  decoder and the interleaved path is opt-in at the library level.
+- **DMR 2-slot interleaved voice cadence + embedded-LC labelling.**
+  A DMR carrier is 2-slot TDMA, so a real outbound stream
+  interleaves both timeslots' bursts. `voice.NewInterleavedDecoder`
+  (stride 2) decodes that: it locks each slot's burst A on its own
+  voice sync and gathers that slot's B–F 264 dibits apart, emitting
+  one superframe per slot tagged by `VoiceSuperframe.Phase`. The
+  decoder also reassembles the embedded Link Control carried by
+  bursts B–E (EMB split → variable BPTC(128,72) + Hamming(16,11,4)
+  rows + 5-bit CRC → `dmr.FLC`) and, on a clean CRC, surfaces the
+  call's talkgroup + source on `VoiceSuperframe.LC`, so a phase can
+  be bound to a concrete talkgroup — the absolute TS1/TS2 label the
+  identical BS-sourced burst-A sync cannot give. The whole chain is
+  unit-tested against synthetic interleaved + embedded-LC vectors.
+  Two pieces still need a real IQ capture before this replaces the
+  single-slot `NewDecoder` on the production voice path: (1) the
+  exact same-slot dibit cadence on live BS-sourced air — where a
+  CACH may precede each burst, making the stride 288 rather than 264
+  dibits; and (2) the exact ETSI embedded-signalling de-interleave
+  order, the EMB QR(16,7) FEC (read systematically for now), and the
+  5-bit CRC polynomial — all currently internally consistent
+  (encode↔decode round-trip) but not yet cross-checked against
+  captured traffic. Until then the production composer keeps the
+  single-slot decoder and the interleaved + LC path is opt-in at the
+  library level.
 
 ### Digital-voice level calibration
 

--- a/internal/radio/dmr/emb.go
+++ b/internal/radio/dmr/emb.go
@@ -1,0 +1,130 @@
+package dmr
+
+import "github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+
+// Embedded signalling carried by the 48-bit sync field of DMR voice
+// bursts B–F (ETSI TS 102 361-1 §6.2, §9.1.4). The field is laid out as
+//
+//	bits  0..7   : EMB MSB half  (8 bits)
+//	bits  8..39  : embedded signalling fragment (32 bits)
+//	bits 40..47  : EMB LSB half  (8 bits)
+//
+// The 16-bit EMB (CC, PI, LCSS + FEC) frames the fragment; the four
+// fragments of bursts B–E reassemble into a 128-bit embedded Link
+// Control block — see framing.DecodeEmbeddedLC.
+//
+// NOTE: the EMB info bits are read systematically here; the EMB's own
+// QR(16,7) error-correction is not yet applied (the embedded-LC BPTC +
+// CRC downstream is the integrity gate). This mirrors the
+// capture-pending posture documented for the BPTC layers; see
+// docs/status.md.
+
+// LCSS is the 2-bit Link Control Start/Stop field in the EMB, marking a
+// fragment's position within a multi-burst embedded LC.
+type LCSS uint8
+
+const (
+	LCSSSingle LCSS = 0 // 00 — single-fragment LC (CSBK/RC) or null
+	LCSSFirst  LCSS = 1 // 01 — first fragment of a Full LC (burst B)
+	LCSSLast   LCSS = 2 // 10 — last fragment of a Full LC (burst E)
+	LCSSCont   LCSS = 3 // 11 — continuation fragment (bursts C, D)
+)
+
+// EMB is the decoded 16-bit Embedded signalling header.
+type EMB struct {
+	ColorCode uint8 // 4-bit
+	PI        bool  // privacy indicator
+	LCSS      LCSS  // 2-bit fragment position
+}
+
+// systematic EMB bit positions within the 16-bit field (MSB-first):
+// CC in bits 15..12, PI in bit 11, LCSS in bits 10..9, bits 8..0 spare.
+func encodeEMB(e EMB) uint16 {
+	return uint16(e.ColorCode&0x0F)<<12 |
+		boolToBit(e.PI)<<11 |
+		uint16(e.LCSS&0x03)<<9
+}
+
+func decodeEMB(v uint16) EMB {
+	return EMB{
+		ColorCode: uint8((v >> 12) & 0x0F),
+		PI:        (v>>11)&1 == 1,
+		LCSS:      LCSS((v >> 9) & 0x03),
+	}
+}
+
+func boolToBit(b bool) uint16 {
+	if b {
+		return 1
+	}
+	return 0
+}
+
+// SplitEmbeddedField splits the 48 bits of a voice burst's sync field
+// (one bit per byte, MSB-first — i.e. bitsFromDibits(burst.Sync())) into
+// the decoded EMB header and the 32-bit embedded-signalling fragment.
+func SplitEmbeddedField(field []byte) (EMB, []byte) {
+	if len(field) != SyncBitCount {
+		panic("dmr: embedded field requires 48 bits")
+	}
+	var emb uint16
+	for i := 0; i < 8; i++ { // EMB MSB half: field[0..7] → emb bits 15..8
+		emb |= uint16(field[i]&1) << uint(15-i)
+	}
+	for i := 0; i < 8; i++ { // EMB LSB half: field[40..47] → emb bits 7..0
+		emb |= uint16(field[40+i]&1) << uint(7-i)
+	}
+	frag := make([]byte, framing.EmbeddedFragmentBits) // field[8..39]
+	copy(frag, field[8:8+framing.EmbeddedFragmentBits])
+	return decodeEMB(emb), frag
+}
+
+// AssembleEmbeddedField is the inverse of SplitEmbeddedField: it packs an
+// EMB header and a 32-bit fragment into the 48-bit voice-burst sync
+// field. Used to build synthetic streams.
+func AssembleEmbeddedField(e EMB, frag []byte) []byte {
+	if len(frag) != framing.EmbeddedFragmentBits {
+		panic("dmr: embedded fragment requires 32 bits")
+	}
+	field := make([]byte, SyncBitCount)
+	emb := encodeEMB(e)
+	for i := 0; i < 8; i++ {
+		field[i] = byte((emb >> uint(15-i)) & 1)
+	}
+	copy(field[8:8+framing.EmbeddedFragmentBits], frag)
+	for i := 0; i < 8; i++ {
+		field[40+i] = byte((emb >> uint(7-i)) & 1)
+	}
+	return field
+}
+
+// ReassembleEmbeddedLC concatenates the four ordered 32-bit fragments
+// from bursts B, C, D and E into the 128-bit embedded Link Control
+// block, decodes it (variable BPTC(128,72) + CRC), and parses the
+// recovered 72 bits as a Full Link Control PDU. It returns ok=false when
+// any fragment is the wrong length, the BPTC/CRC check fails, or the FLC
+// cannot be parsed.
+func ReassembleEmbeddedLC(frags [4][]byte) (FLC, bool) {
+	channel := make([]byte, 0, framing.EmbChannelBits)
+	for _, f := range frags {
+		if len(f) != framing.EmbeddedFragmentBits {
+			return FLC{}, false
+		}
+		channel = append(channel, f...)
+	}
+	lcBits, corrected := framing.DecodeEmbeddedLC(channel)
+	if corrected < 0 {
+		return FLC{}, false
+	}
+	info := make([]byte, framing.EmbLCBits/8) // 9 octets
+	for i := 0; i < framing.EmbLCBits; i++ {
+		if lcBits[i]&1 != 0 {
+			info[i/8] |= 1 << uint(7-(i%8))
+		}
+	}
+	flc, err := ParseFLC(info)
+	if err != nil {
+		return FLC{}, false
+	}
+	return flc, true
+}

--- a/internal/radio/dmr/emb_test.go
+++ b/internal/radio/dmr/emb_test.go
@@ -1,0 +1,90 @@
+package dmr
+
+import (
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+)
+
+func TestEMBSplitAssembleRoundTrip(t *testing.T) {
+	emb := EMB{ColorCode: 0xB, PI: true, LCSS: LCSSFirst}
+	frag := make([]byte, framing.EmbeddedFragmentBits)
+	for i := range frag {
+		frag[i] = byte((i*7 + 3) & 1)
+	}
+
+	field := AssembleEmbeddedField(emb, frag)
+	if len(field) != SyncBitCount {
+		t.Fatalf("field length = %d, want %d", len(field), SyncBitCount)
+	}
+	gotEMB, gotFrag := SplitEmbeddedField(field)
+	if gotEMB != emb {
+		t.Errorf("EMB round trip = %+v, want %+v", gotEMB, emb)
+	}
+	for i := range frag {
+		if gotFrag[i] != frag[i] {
+			t.Fatalf("fragment bit %d mismatch", i)
+		}
+	}
+}
+
+// flcToFragments encodes an FLC into the four 32-bit embedded fragments a
+// superframe's bursts B–E would carry.
+func flcToFragments(t *testing.T, f FLC) [4][]byte {
+	t.Helper()
+	info := AssembleFLC(f) // 9 octets
+	lc := make([]byte, framing.EmbLCBits)
+	for i := 0; i < framing.EmbLCBits; i++ {
+		lc[i] = (info[i/8] >> uint(7-(i%8))) & 1
+	}
+	channel := framing.EncodeEmbeddedLC(lc)
+	var frags [4][]byte
+	for i := range frags {
+		frags[i] = channel[i*framing.EmbeddedFragmentBits : (i+1)*framing.EmbeddedFragmentBits]
+	}
+	return frags
+}
+
+func TestReassembleEmbeddedLC(t *testing.T) {
+	want := FLC{
+		FLCO:           FLCOGroupVoiceUser,
+		FID:            0,
+		ServiceOptions: 0x80, // emergency
+		DstAddr:        0x00ABCD,
+		SrcAddr:        0x123456,
+	}
+	frags := flcToFragments(t, want)
+
+	got, ok := ReassembleEmbeddedLC(frags)
+	if !ok {
+		t.Fatal("ReassembleEmbeddedLC failed on a clean embedded LC")
+	}
+	if got.FLCO != want.FLCO || got.DstAddr != want.DstAddr || got.SrcAddr != want.SrcAddr {
+		t.Errorf("reassembled FLC = %+v, want %+v", got, want)
+	}
+	gv, isGroup := got.AsGroupVoiceUser()
+	if !isGroup || gv.GroupAddress != want.DstAddr || gv.SourceID != want.SrcAddr || !gv.Emergency {
+		t.Errorf("group voice user = %+v (ok=%v), want group %X src %X emergency", gv, isGroup, want.DstAddr, want.SrcAddr)
+	}
+}
+
+func TestReassembleEmbeddedLCRejectsCorruption(t *testing.T) {
+	frags := flcToFragments(t, FLC{FLCO: FLCOGroupVoiceUser, DstAddr: 100, SrcAddr: 7})
+	// Corrupt two bits in the first fragment's first row (on-air indices
+	// 0 and 8 both map to matrix row 0) → uncorrectable → rejected.
+	frags[0] = append([]byte(nil), frags[0]...)
+	frags[0][0] ^= 1
+	frags[0][8] ^= 1
+	if _, ok := ReassembleEmbeddedLC(frags); ok {
+		t.Error("corrupted embedded LC was accepted")
+	}
+}
+
+func TestReassembleEmbeddedLCWrongLength(t *testing.T) {
+	var frags [4][]byte
+	frags[0] = make([]byte, framing.EmbeddedFragmentBits)
+	// frags[1..3] left nil (wrong length) → must reject, not panic.
+	if _, ok := ReassembleEmbeddedLC(frags); ok {
+		t.Error("accepted fragments of the wrong length")
+	}
+}

--- a/internal/radio/dmr/voice/doc.go
+++ b/internal/radio/dmr/voice/doc.go
@@ -17,6 +17,14 @@
 // bursts 264 dibits apart and emitting one superframe per slot, told
 // apart by VoiceSuperframe.Phase.
 //
+// Alongside the AMBE frames, the decoder reassembles the embedded Link
+// Control carried by the sync field of bursts B–E (EMB + four BPTC
+// fragments → framing.DecodeEmbeddedLC → dmr.FLC) and, when it passes
+// its CRC, exposes the call's talkgroup + source on
+// VoiceSuperframe.LC. Combined with Phase, that lets a consumer label
+// which timeslot a superframe belongs to (the BS-sourced burst-A sync
+// is identical on both slots and cannot).
+//
 // This package produces the *on-air* AMBE frames (72 bits each, FEC
 // still applied). Decoding the AMBE forward-error-correction down to
 // the 49-bit vocoder payload, the ARC4 descramble for encrypted

--- a/internal/radio/dmr/voice/superframe.go
+++ b/internal/radio/dmr/voice/superframe.go
@@ -25,6 +25,14 @@ type VoiceSuperframe struct {
 	// binding a phase to a talkgroup is the embedded-LC decoder's job.
 	// Always 0 for a single-slot (stride 1) Decoder.
 	Phase uint8
+	// HasLC reports that a Full Link Control was reassembled from the
+	// embedded signalling carried by bursts B–E of this superframe and
+	// passed its BPTC + CRC check. When true, LC holds the decoded PDU —
+	// its destination/source addresses identify the call's talkgroup and
+	// radio, which a consumer binds to the superframe's Phase to label
+	// the timeslot (the BS-sourced burst-A sync alone cannot).
+	HasLC bool
+	LC    dmr.FLC
 }
 
 // voiceSyncs are the sync words that frame burst A of a voice
@@ -169,6 +177,9 @@ func (d *Decoder) sliceSuperframe(start int, syncName string) VoiceSuperframe {
 	off := start - d.bufStart
 	step := d.stride * dmr.BurstDibits
 	frame := 0
+	// fragIdx maps the four embedded-LC-bearing bursts B,C,D,E (burst
+	// indices 1..4) to their fragment slot 0..3; A and F carry none.
+	var frags [4][]byte
 	for b := 0; b < BurstsPerSuperframe; b++ {
 		var burst dmr.Burst
 		copy(burst.Dibits[:], d.buf[off+b*step:off+b*step+dmr.BurstDibits])
@@ -176,6 +187,23 @@ func (d *Decoder) sliceSuperframe(start int, syncName string) VoiceSuperframe {
 			sf.Frames[frame] = f
 			frame++
 		}
+		if b >= 1 && b <= 4 {
+			_, frag := dmr.SplitEmbeddedField(dibitsToBits(burst.Sync()))
+			frags[b-1] = frag
+		}
+	}
+	if lc, ok := dmr.ReassembleEmbeddedLC(frags); ok {
+		sf.HasLC = true
+		sf.LC = lc
 	}
 	return sf
+}
+
+// dibitsToBits expands dibits to bits, two per dibit, MSB-first.
+func dibitsToBits(dibits []uint8) []byte {
+	out := make([]byte, 0, len(dibits)*2)
+	for _, d := range dibits {
+		out = append(out, (d>>1)&1, d&1)
+	}
+	return out
 }

--- a/internal/radio/dmr/voice/superframe_test.go
+++ b/internal/radio/dmr/voice/superframe_test.go
@@ -5,7 +5,77 @@ import (
 	"testing"
 
 	"github.com/MattCheramie/GopherTrunk/internal/radio/dmr"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
 )
+
+// lcFragments encodes a Full Link Control into the four 32-bit embedded
+// fragments that bursts B–E of a superframe carry.
+func lcFragments(t *testing.T, f dmr.FLC) [4][]byte {
+	t.Helper()
+	info := dmr.AssembleFLC(f)
+	lc := make([]byte, framing.EmbLCBits)
+	for i := 0; i < framing.EmbLCBits; i++ {
+		lc[i] = (info[i/8] >> uint(7-(i%8))) & 1
+	}
+	ch := framing.EncodeEmbeddedLC(lc)
+	var frags [4][]byte
+	for i := range frags {
+		frags[i] = ch[i*framing.EmbeddedFragmentBits : (i+1)*framing.EmbeddedFragmentBits]
+	}
+	return frags
+}
+
+// embeddedSync packs an EMB header + 32-bit fragment into a burst's
+// 24-dibit centre field.
+func embeddedSync(emb dmr.EMB, frag []byte) [24]uint8 {
+	field := dmr.AssembleEmbeddedField(emb, frag)
+	var d [24]uint8
+	for i := 0; i < 24; i++ {
+		d[i] = field[2*i]<<1 | field[2*i+1]
+	}
+	return d
+}
+
+// burstLCSS gives the LCSS a voice burst carries when a Full LC is
+// spread across bursts B–E: B=First, C/D=Continuation, E=Last.
+func burstLCSS(b int) dmr.LCSS {
+	switch b {
+	case 1:
+		return dmr.LCSSFirst
+	case 4:
+		return dmr.LCSSLast
+	default:
+		return dmr.LCSSCont
+	}
+}
+
+// buildInterleavedStreamWithLC is buildInterleavedStream extended so each
+// slot's bursts B–E carry that slot's own embedded Link Control, so a
+// decoder can recover and label each timeslot's talkgroup.
+func buildInterleavedStreamWithLC(t *testing.T, aLC, bLC dmr.FLC) (stream []uint8, aFrames, bFrames [][]byte) {
+	t.Helper()
+	const bSeedOffset = 10000
+	aFrags := lcFragments(t, aLC)
+	bFrags := lcFragments(t, bLC)
+	for f := 0; f < FramesPerSuperframe; f++ {
+		aFrames = append(aFrames, mkFrame(f))
+		bFrames = append(bFrames, mkFrame(f+bSeedOffset))
+	}
+	for b := 0; b < BurstsPerSuperframe; b++ {
+		aSync, bSync := dmr.BSData.Dibits, dmr.BSData.Dibits
+		switch {
+		case b == 0:
+			aSync, bSync = dmr.BSVoice.Dibits, dmr.BSVoice.Dibits
+		case b >= 1 && b <= 4:
+			aSync = embeddedSync(dmr.EMB{ColorCode: 1, LCSS: burstLCSS(b)}, aFrags[b-1])
+			bSync = embeddedSync(dmr.EMB{ColorCode: 1, LCSS: burstLCSS(b)}, bFrags[b-1])
+		}
+		base := b * FramesPerBurst
+		stream = append(stream, makeVoiceBurst(aFrames[base:base+FramesPerBurst], aSync)...)
+		stream = append(stream, makeVoiceBurst(bFrames[base:base+FramesPerBurst], bSync)...)
+	}
+	return stream, aFrames, bFrames
+}
 
 // buildStream assembles a dibit stream of n voice superframes preceded
 // by lead dibits of filler. Frame f of the stream carries mkFrame(f),
@@ -284,4 +354,52 @@ func TestInterleavedDecoderChunkedInput(t *testing.T) {
 	}
 	checkFrames(t, got[0], aFrames, 0)
 	checkFrames(t, got[1], bFrames, 0)
+}
+
+// TestInterleavedDecoderLabelsSlotsByEmbeddedLC is the Phase 4 headline:
+// two concurrent calls interleaved on a carrier, each carrying its OWN
+// talkgroup's embedded Link Control in bursts B–E. The interleaved
+// decoder must hand back one superframe per slot whose recovered LC
+// names that slot's talkgroup — the label the identical BS-sourced
+// burst-A sync can't provide. This is what lets a consumer bind a
+// phase to a grant's talkgroup.
+func TestInterleavedDecoderLabelsSlotsByEmbeddedLC(t *testing.T) {
+	aLC := dmr.FLC{FLCO: dmr.FLCOGroupVoiceUser, DstAddr: 1001, SrcAddr: 55}
+	bLC := dmr.FLC{FLCO: dmr.FLCOGroupVoiceUser, DstAddr: 2002, SrcAddr: 66}
+	stream, aFrames, bFrames := buildInterleavedStreamWithLC(t, aLC, bLC)
+
+	d := NewInterleavedDecoder()
+	got := d.Process(stream, 0)
+	if len(got) != 2 {
+		t.Fatalf("got %d superframes, want 2", len(got))
+	}
+	a, b := got[0], got[1]
+
+	// Each slot's superframe carries its own talkgroup + source.
+	if !a.HasLC || a.LC.DstAddr != 1001 || a.LC.SrcAddr != 55 {
+		t.Errorf("slot A LC: hasLC=%v dst=%d src=%d, want dst=1001 src=55", a.HasLC, a.LC.DstAddr, a.LC.SrcAddr)
+	}
+	if !b.HasLC || b.LC.DstAddr != 2002 || b.LC.SrcAddr != 66 {
+		t.Errorf("slot B LC: hasLC=%v dst=%d src=%d, want dst=2002 src=66", b.HasLC, b.LC.DstAddr, b.LC.SrcAddr)
+	}
+	// Phases distinct, and audio still cleanly separated per slot.
+	if a.Phase == b.Phase {
+		t.Errorf("slots share Phase %d; want distinct", a.Phase)
+	}
+	checkFrames(t, a, aFrames, 0)
+	checkFrames(t, b, bFrames, 0)
+}
+
+// TestDecoderSuperframeNoLCWhenAbsent confirms a superframe whose B–E
+// bursts carry no valid embedded LC (the plain single-slot synth) leaves
+// HasLC false rather than surfacing a garbage talkgroup.
+func TestDecoderSuperframeNoLCWhenAbsent(t *testing.T) {
+	stream, _ := buildStream(t, 1, 0) // B–F use BS-Data filler, not an LC
+	got := NewDecoder().Process(stream, 0)
+	if len(got) != 1 {
+		t.Fatalf("got %d superframes, want 1", len(got))
+	}
+	if got[0].HasLC {
+		t.Errorf("HasLC = true on a stream with no embedded LC; want false")
+	}
 }

--- a/internal/radio/framing/embedded_bptc.go
+++ b/internal/radio/framing/embedded_bptc.go
@@ -1,0 +1,142 @@
+// Variable-length BPTC(128,72) for DMR embedded signalling (ETSI TS 102
+// 361-1 Annex B.2.2 / C). The four 32-bit embedded fragments carried by
+// the sync field of voice bursts B–E concatenate into 128 channel bits
+// that protect a 72-bit Link Control PDU.
+//
+// Matrix layout (8 rows × 16 cols = 128 cells):
+//
+//   - rows 0..6 : 7 × 11 = 77 payload cells = 72-bit Link Control +
+//                 5-bit CRC, each row protected across its 16 cells by
+//                 Hamming(16,11,4).
+//   - row 7     : 16 column even-parity bits over rows 0..6.
+//
+// The 128 channel bits are read column-major: bit c*8+r = m[r][c].
+//
+// NOTE: like BPTC(196,96) (see bptc.go), this is internally consistent —
+// encode→decode round-trips and corrects single-bit row errors — but the
+// exact column-read order and the 5-bit CRC polynomial still need a final
+// cross-check against ETSI TS 102 361-1 Annex B/C before live DMR
+// captures; see docs/status.md.
+
+package framing
+
+const (
+	embRows        = 7
+	embCols        = 16
+	embInfoPerRow  = 11
+	EmbLCBits      = 72                     // a Full Link Control PDU
+	embCRCBits     = 5                      //
+	embPayloadBits = EmbLCBits + embCRCBits // 77 = 7 × 11
+	EmbChannelBits = embCols * 8            // 128 on-air bits
+	embFragmentLen = EmbChannelBits / 4     // 32 bits per burst B–E
+)
+
+// EmbeddedFragmentBits is the per-burst embedded-signalling fragment
+// length (bits) carried by voice bursts B–E.
+const EmbeddedFragmentBits = embFragmentLen
+
+// crc5 computes the embedded-LC 5-bit CRC over msg (one bit per byte,
+// MSB-first) with polynomial x^5 + x^2 + 1. Used identically by encode
+// and decode; the exact ETSI polynomial/mask is pending a capture
+// cross-check (see file header).
+func crc5(bits []byte) byte {
+	const poly = 0x05
+	var reg byte
+	for _, b := range bits {
+		msb := (reg >> 4) & 1
+		reg = (reg<<1 | (b & 1)) & 0x1F
+		if msb == 1 {
+			reg ^= poly
+		}
+	}
+	return reg & 0x1F
+}
+
+// EncodeEmbeddedLC packs a 72-bit Link Control PDU (one bit per byte,
+// MSB-first) into the 128 embedded-signalling channel bits.
+func EncodeEmbeddedLC(lc []byte) []byte {
+	if len(lc) != EmbLCBits {
+		panic("framing: EncodeEmbeddedLC requires 72 LC bits")
+	}
+	payload := make([]byte, embPayloadBits)
+	copy(payload, lc)
+	c := crc5(lc)
+	for i := 0; i < embCRCBits; i++ {
+		payload[EmbLCBits+i] = (c >> uint(embCRCBits-1-i)) & 1
+	}
+
+	var m [8][embCols]byte
+	for r := 0; r < embRows; r++ {
+		var d uint16
+		for c := 0; c < embInfoPerRow; c++ {
+			d |= uint16(payload[r*embInfoPerRow+c]) << uint(c)
+		}
+		cw := HammingEncode16_11(d)
+		for c := 0; c < embCols; c++ {
+			m[r][c] = byte((cw >> uint(c)) & 1)
+		}
+	}
+	for c := 0; c < embCols; c++ { // column parity row
+		var p byte
+		for r := 0; r < embRows; r++ {
+			p ^= m[r][c]
+		}
+		m[embRows][c] = p
+	}
+
+	onair := make([]byte, EmbChannelBits)
+	for c := 0; c < embCols; c++ {
+		for r := 0; r < 8; r++ {
+			onair[c*8+r] = m[r][c]
+		}
+	}
+	return onair
+}
+
+// DecodeEmbeddedLC reverses EncodeEmbeddedLC: 128 channel bits → the
+// 72-bit Link Control. Returns (lc, corrected); corrected is the number
+// of single-bit row corrections applied, or -1 if any row was
+// uncorrectable or the recovered CRC did not verify.
+func DecodeEmbeddedLC(onair []byte) ([]byte, int) {
+	if len(onair) != EmbChannelBits {
+		panic("framing: DecodeEmbeddedLC requires 128 channel bits")
+	}
+	var m [8][embCols]byte
+	for c := 0; c < embCols; c++ {
+		for r := 0; r < 8; r++ {
+			m[r][c] = onair[c*8+r] & 1
+		}
+	}
+
+	corrected := 0
+	failed := false
+	payload := make([]byte, embPayloadBits)
+	for r := 0; r < embRows; r++ {
+		var cw uint16
+		for c := 0; c < embCols; c++ {
+			cw |= uint16(m[r][c]) << uint(c)
+		}
+		data, errs := HammingDecode16_11(cw)
+		if errs == 1 {
+			corrected++
+		} else if errs < 0 {
+			failed = true
+		}
+		for c := 0; c < embInfoPerRow; c++ {
+			payload[r*embInfoPerRow+c] = byte((data >> uint(c)) & 1)
+		}
+	}
+
+	lc := payload[:EmbLCBits]
+	var got byte
+	for i := 0; i < embCRCBits; i++ {
+		got = got<<1 | payload[EmbLCBits+i]
+	}
+	if crc5(lc) != got {
+		failed = true
+	}
+	if failed {
+		return lc, -1
+	}
+	return lc, corrected
+}

--- a/internal/radio/framing/embedded_bptc_test.go
+++ b/internal/radio/framing/embedded_bptc_test.go
@@ -1,0 +1,107 @@
+package framing
+
+import (
+	"math/rand"
+	"testing"
+)
+
+func TestHamming16_11RoundTrip(t *testing.T) {
+	for d := uint16(0); d < 1<<11; d++ {
+		cw := HammingEncode16_11(d)
+		got, errs := HammingDecode16_11(cw)
+		if errs != 0 || got != d {
+			t.Fatalf("clean data %#x: got %#x errs %d", d, got, errs)
+		}
+	}
+}
+
+func TestHamming16_11CorrectsSingleBit(t *testing.T) {
+	for _, d := range []uint16{0, 1, 0x2AA, 0x555, 0x7FF, 0x123} {
+		cw := HammingEncode16_11(d)
+		for bit := 0; bit < 16; bit++ {
+			got, errs := HammingDecode16_11(cw ^ (1 << uint(bit)))
+			if got != d || errs != 1 {
+				t.Errorf("data %#x bit %d: got %#x errs %d, want %#x errs 1", d, bit, got, errs, d)
+			}
+		}
+	}
+}
+
+func TestHamming16_11DetectsDoubleBit(t *testing.T) {
+	// A genuine 2-bit error must never be silently mis-decoded to the
+	// wrong 11-bit value reported as clean/corrected.
+	d := uint16(0x2C5)
+	cw := HammingEncode16_11(d)
+	for i := 0; i < 15; i++ {
+		for j := i + 1; j < 16; j++ {
+			got, errs := HammingDecode16_11(cw ^ (1 << uint(i)) ^ (1 << uint(j)))
+			if errs >= 0 && got != d {
+				t.Errorf("2-bit error (%d,%d): decoded wrong data %#x as errs=%d", i, j, got, errs)
+			}
+		}
+	}
+}
+
+func randomLC(r *rand.Rand) []byte {
+	lc := make([]byte, EmbLCBits)
+	for i := range lc {
+		lc[i] = byte(r.Intn(2))
+	}
+	return lc
+}
+
+func TestEmbeddedLCRoundTrip(t *testing.T) {
+	r := rand.New(rand.NewSource(1))
+	for n := 0; n < 200; n++ {
+		lc := randomLC(r)
+		ch := EncodeEmbeddedLC(lc)
+		if len(ch) != EmbChannelBits {
+			t.Fatalf("channel length = %d, want %d", len(ch), EmbChannelBits)
+		}
+		got, corrected := DecodeEmbeddedLC(ch)
+		if corrected != 0 {
+			t.Fatalf("clean LC: corrected = %d, want 0", corrected)
+		}
+		for i := range lc {
+			if got[i] != lc[i] {
+				t.Fatalf("LC bit %d mismatch on clean round trip", i)
+			}
+		}
+	}
+}
+
+func TestEmbeddedLCCorrectsSingleBit(t *testing.T) {
+	r := rand.New(rand.NewSource(2))
+	lc := randomLC(r)
+	clean := EncodeEmbeddedLC(lc)
+	for bit := 0; bit < EmbChannelBits; bit++ {
+		ch := append([]byte(nil), clean...)
+		ch[bit] ^= 1
+		got, corrected := DecodeEmbeddedLC(ch)
+		if corrected < 0 {
+			t.Errorf("single bit %d flip: decode failed", bit)
+			continue
+		}
+		for i := range lc {
+			if got[i] != lc[i] {
+				t.Errorf("single bit %d flip: LC bit %d corrupted", bit, i)
+				break
+			}
+		}
+	}
+}
+
+func TestEmbeddedLCRejectsHeavyCorruption(t *testing.T) {
+	r := rand.New(rand.NewSource(3))
+	lc := randomLC(r)
+	ch := EncodeEmbeddedLC(lc)
+	// Put TWO errors in the same payload row (row 0 = on-air indices
+	// c*8+0): columns 0 and 1 → indices 0 and 8. That exceeds the row
+	// Hamming(16,11,4) single-error correction, so the SEC-DED row
+	// decode flags it uncorrectable and the block is rejected.
+	ch[0] ^= 1
+	ch[8] ^= 1
+	if _, corrected := DecodeEmbeddedLC(ch); corrected >= 0 {
+		t.Errorf("two errors in one row accepted (corrected=%d); SEC-DED/CRC gate not effective", corrected)
+	}
+}

--- a/internal/radio/framing/hamming16_11.go
+++ b/internal/radio/framing/hamming16_11.go
@@ -1,0 +1,61 @@
+package framing
+
+// Hamming(16,11,4): the DMR variable-length BPTC row code (ETSI TS 102
+// 361-1 Annex B.2.2 / C, embedded-signalling Link Control). It is the
+// (15,11,3) single-error-correcting Hamming code extended with one
+// overall even-parity bit, raising the minimum distance to 4 (SEC-DED:
+// it corrects any single-bit error and detects any double-bit error).
+//
+// Codeword layout (low 16 bits): bits 1..15 hold the 15-bit
+// Hamming(15,11) codeword (data in bits 5..15, parity in bits 1..4 —
+// i.e. the HammingEncode15_11 output shifted up by one), and bit 0 is
+// the overall even parity computed over those 15 bits.
+
+func parityLow15(v uint16) uint16 {
+	v &= 0x7FFF
+	v ^= v >> 8
+	v ^= v >> 4
+	v ^= v >> 2
+	v ^= v >> 1
+	return v & 1
+}
+
+// HammingEncode16_11 encodes 11 data bits (low 11 bits of input) into the
+// 16-bit codeword.
+func HammingEncode16_11(data uint16) uint16 {
+	cw15 := HammingEncode15_11(data) & 0x7FFF
+	return cw15<<1 | parityLow15(cw15)
+}
+
+// HammingDecode16_11 decodes a 16-bit codeword. Returns (data, errors):
+// 0 = clean, 1 = a single-bit error was corrected (in the 15-bit body or
+// the overall-parity bit), -1 = uncorrectable (double-bit error detected
+// by the overall parity).
+func HammingDecode16_11(cw uint16) (uint16, int) {
+	cw &= 0xFFFF
+	body := (cw >> 1) & 0x7FFF
+	recvOverall := cw & 1
+	// p is the overall-parity consistency of the *received* word: 0 when
+	// the received overall bit matches the received body's parity.
+	p := parityLow15(body) ^ recvOverall
+
+	data, errs := HammingDecode15_11(body)
+	switch {
+	case errs < 0:
+		return data, -1
+	case errs == 0 && p == 0:
+		// No Hamming syndrome and overall parity consistent → clean.
+		return data, 0
+	case errs == 1 && p == 1:
+		// Hamming syndrome points at one body bit and overall parity is
+		// inconsistent — the classic single-bit error. Corrected.
+		return data, 1
+	case errs == 0 && p == 1:
+		// Body consistent but overall parity off → the error is in the
+		// overall-parity bit itself; the recovered data is clean.
+		return data, 1
+	default: // errs == 1 && p == 0 — syndrome set but overall consistent
+		// Two bit errors: SEC-DED detects but cannot correct.
+		return data, -1
+	}
+}


### PR DESCRIPTION
## Why

Phase 3 (#514, merged) gave the decoder a stride-2 mode that separates a carrier's two interleaved timeslots and tags each superframe with a `Phase`. But on a **BS-sourced** carrier both timeslots use the **identical burst-A voice sync**, so phase alone is only a *relative* discriminator — it can't say which slot is TS1 vs TS2, or which **talkgroup** each carries. That label lives in the **embedded signalling** carried by the sync field of bursts B–E.

This phase decodes it, so each superframe can be bound to a concrete talkgroup — the last major DSP piece of the timeslot effort.

## What

The full embedded Link Control chain, bottom-up:

- **`framing`**
  - `Hamming(16,11,4)` — the SEC-DED row code (the (15,11,3) Hamming + overall parity), corrects any single-bit error and detects double-bit errors.
  - **Variable `BPTC(128,72)`** (`Encode/DecodeEmbeddedLC`) — 7 Hamming(16,11) rows carrying a 72-bit Link Control + 5-bit CRC, plus a column-parity row, read column-major into the four 32-bit fragments of bursts B–E.
- **`dmr`**
  - `SplitEmbeddedField` / `AssembleEmbeddedField` — split a voice burst's 48-bit sync field into the EMB header (CC/PI/LCSS) + the 32-bit fragment.
  - `ReassembleEmbeddedLC` — four ordered fragments → `DecodeEmbeddedLC` → the existing `dmr.ParseFLC`.
- **`voice`**
  - `Decoder.sliceSuperframe` reassembles bursts B–E per superframe and, on a clean CRC, exposes the call's talkgroup + source on the new **`VoiceSuperframe.LC` / `HasLC`**. With `Phase`, a consumer can now bind each interleaved timeslot to a concrete talkgroup.

## Caveat (why still opt-in)

The exact ETSI embedded-signalling de-interleave order, the EMB QR(16,7) FEC (read systematically for now), and the 5-bit CRC polynomial are **internally consistent** (encode↔decode round-trip, single-bit correction) but **not yet cross-checked against captured traffic** — the same posture the repo already takes for `BPTC(196,96)` and the phase-3 stride cadence. So the production composer still uses the single-slot decoder; this lands the capability + tests. Documented in `docs/status.md`.

## Tests (all green: `go test ./...` → 110 packages OK, 0 failures; `gofmt`/`go vet` clean)

- `framing`: `Hamming(16,11)` exhaustive round-trip, single-bit correction, double-bit detection; `EmbeddedLC` round-trip, single-bit correction, and two-errors-in-one-row rejection (CRC/SEC-DED gate).
- `dmr`: EMB split/assemble round-trip; `ReassembleEmbeddedLC` from a Group Voice FLC → talkgroup/source recovered; corruption + wrong-length rejection.
- `voice` headline: **`TestInterleavedDecoderLabelsSlotsByEmbeddedLC`** — two calls interleaved on one carrier, each carrying its **own** talkgroup's embedded LC → one superframe per slot whose `LC` names that slot's talkgroup, audio still cleanly separated, phases distinct. Plus `TestDecoderSuperframeNoLCWhenAbsent` (no embedded LC ⇒ `HasLC` false, no garbage TG).

## Docs

`README.md`, `docs/status.md`, the `voice` package doc, and `CHANGELOG.md` updated.

## Where this leaves the timeslot effort

The DSP can now (against synthetic vectors) separate **and label** the two slots of a carrier end-to-end. The remaining work is **real-capture validation** of the on-air constants (burst cadence / CACH, embedded interleave, EMB FEC, CRC polynomial), after which the interleaved + LC decoder can replace the single-slot decoder on the production composer and feed phase→talkgroup→grant binding into the engine/recorder routing from phases 1–2.

https://claude.ai/code/session_01ParTi9V4czr2QCJYNWjc2d

---
_Generated by [Claude Code](https://claude.ai/code/session_01ParTi9V4czr2QCJYNWjc2d)_