### PR TITLE
composer: wire opt-in 2-slot interleaved DMR voice with per-slot routing (phase 5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ for tagged releases.
 
 ### Added
 
+- **DMR 2-slot interleaved voice wired into the composer (opt-in).** The
+  interleaved decoder + embedded-LC labelling from the previous changes
+  are now reachable end-to-end on the production voice path behind a new
+  per-system `dmr_interleaved_voice: true`. When set, the DMR Tier III
+  control channel tags its voice grants (`Grant.DMRInterleavedVoice`),
+  and the composer runs `voice.NewInterleavedDecoder` and routes each
+  call to its timeslot with a `slotRouter` — it keeps only the
+  superframes whose embedded Link Control names the grant's talkgroup,
+  binding that slot's phase so subsequent LC-less superframes still
+  route correctly. Defaults off (untouched configs keep the single-slot
+  decoder). Verified end-to-end against synthetic modulated 2-slot IQ
+  (one talkgroup per slot → only the granted talkgroup's audio reaches
+  the recorder). A skip-gated `-tags integration` harness
+  (`GOPHERTRUNK_DMR_2SLOT_CFILE`) is the place to validate the on-air
+  constants against a real capture before promoting it to the default —
+  see [docs/status.md](docs/status.md) and `config.example.yaml`.
 - **DMR embedded Link Control decode → per-timeslot talkgroup labelling.**
   On a BS-sourced carrier both timeslots use the identical burst-A voice
   sync, so the sync alone cannot say which slot (and which talkgroup) a

--- a/README.md
+++ b/README.md
@@ -281,8 +281,10 @@ log, per-talkgroup policy) all ship.
   calls; a stride-2 interleaved superframe decoder
   (`voice.NewInterleavedDecoder`) separates the two slots and
   reassembles each slot's embedded Link Control (EMB → variable
-  BPTC(128,72) → talkgroup/source) so a slot can be bound to its
-  talkgroup. The full chain is unit-tested against synthetic vectors;
+  BPTC(128,72) → talkgroup/source) so a slot is routed to its call by
+  talkgroup. The whole path is wired through the voice composer behind
+  a per-system opt-in (`dmr_interleaved_voice: true`) and unit-tested
+  end-to-end against synthetic modulated IQ. It defaults off:
   confirming the exact on-air dibit cadence (CACH/guard) and the ETSI
   embedded-signalling interleave / EMB FEC / CRC against a real IQ
   capture is what's needed before it becomes the production default —

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -556,6 +556,7 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 			ControlChannels:         sys.ControlChannels,
 			P25BandPlan:             p25BandPlan,
 			DMRBandPlan:             dmrBandPlan,
+			DMRInterleavedVoice:     sys.DMRInterleavedVoice,
 			TETRAColourCode:         sys.TETRAColourCode,
 			TETRAChannel:            sys.TETRAChannel,
 			TETRAChannelCoding:      sys.TETRAChannelCoding,

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -470,6 +470,16 @@ trunking:
         #   - { lcn: 1, freq_hz: 851_012_500 }
         #   - { lcn: 2, freq_hz: 851_037_500 }
         #   - { lcn: 9, freq_hz: 851_225_000 }
+      # EXPERIMENTAL: opt into the 2-slot interleaved voice decoder. A
+      # DMR carrier runs two calls at once (TS1 + TS2); with this on,
+      # each voice grant decodes its own timeslot from the carrier's
+      # interleaved burst stream and is routed to its call by matching
+      # the embedded Link Control's talkgroup. Default false keeps the
+      # single-slot decoder. The on-air same-slot cadence and the
+      # embedded-signalling FEC constants are still pending a real-
+      # capture cross-check (see docs/status.md), so leave this off
+      # unless you are validating against a known capture.
+      # dmr_interleaved_voice: true
 
   # Per-protocol FEC is on by default — every protocol the daemon
   # supports (TETRA, LTR, P25 Phase 2, NXDN, EDACS, MPT 1327,

--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -427,6 +427,14 @@ are disambiguated by a `_ts1` / `_ts2` suffix on the WAV filename, and
 the slot is carried through the call log (`timeslot` column) and the
 REST/SSE/gRPC call APIs.
 
+An experimental per-system `dmr_interleaved_voice: true` additionally
+turns on a 2-slot interleaved voice decoder: rather than relying on the
+tap to isolate one slot, each call decodes its own timeslot from the
+carrier's interleaved burst stream and is routed by the embedded Link
+Control's talkgroup. It defaults off and its on-air constants are still
+pending a real-capture cross-check (see
+[docs/status.md](status.md)) — leave it off for normal operation.
+
 How spillover works: when a grant's frequency lands *outside* the
 wideband IQ window (more common on geographically spread P25 systems
 than on a single-site DMR T3 cluster), the virtual tuner returns

--- a/docs/status.md
+++ b/docs/status.md
@@ -106,9 +106,17 @@ The inner FEC layers still pending real-air validation:
   order, the EMB QR(16,7) FEC (read systematically for now), and the
   5-bit CRC polynomial — all currently internally consistent
   (encode↔decode round-trip) but not yet cross-checked against
-  captured traffic. Until then the production composer keeps the
-  single-slot decoder and the interleaved + LC path is opt-in at the
-  library level.
+  captured traffic. The interleaved + LC path is now wired through the
+  production composer behind a per-system opt-in,
+  `dmr_interleaved_voice: true`: when set, each DMR voice grant is
+  tagged so the composer runs `NewInterleavedDecoder` and routes each
+  call to its timeslot by matching the embedded LC's talkgroup (a
+  `slotRouter`). It defaults off, so untouched configs keep the
+  single-slot decoder. The skip-gated harness
+  `internal/voice/composer/dmr_2slot_realair_test.go` (run with
+  `-tags integration` and `GOPHERTRUNK_DMR_2SLOT_CFILE`) is where a
+  contributor drops a real capture to confirm the on-air constants
+  and, once green, promote the interleaved decoder to the default.
 
 ### Digital-voice level calibration
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -753,6 +753,16 @@ type SystemConfig struct {
 	// call (issue #356 follow-up). Ignored for non-P25-Phase-1
 	// protocols.
 	P25Phase1DemodMode string `yaml:"p25_phase1_demod_mode"`
+	// DMRInterleavedVoice opts a DMR system into the experimental
+	// 2-slot interleaved voice decoder: each voice grant decodes its
+	// timeslot from the carrier's interleaved burst stream and is
+	// routed to its call by matching the embedded Link Control's
+	// talkgroup. Default false keeps the single-slot decoder. The
+	// on-air same-slot cadence (CACH/guard) and the embedded-signalling
+	// FEC constants are still pending a real-capture cross-check (see
+	// docs/status.md), so this is opt-in until validated. Ignored for
+	// non-DMR systems.
+	DMRInterleavedVoice bool `yaml:"dmr_interleaved_voice"`
 	// P25Phase2TrellisMode enables the 4-state ½-rate trellis FEC
 	// decoder on the P25 Phase 2 MAC PDU window. Recognised values:
 	// "" / "on" / "true" / "1" (the new default — 146 channel

--- a/internal/radio/dmr/tier3/control.go
+++ b/internal/radio/dmr/tier3/control.go
@@ -40,14 +40,15 @@ func (s LockState) LockedNAC() uint16         { return s.SystemID }
 // logged at debug and ignored — they're noise from the hunter's
 // perspective.
 type ControlChannel struct {
-	bus        *events.Bus
-	log        *slog.Logger
-	systemName string
-	freqHz     uint32
-	resolver   Resolver
-	now        func() time.Time
-	locked     bool
-	last       LockState
+	bus              *events.Bus
+	log              *slog.Logger
+	systemName       string
+	freqHz           uint32
+	resolver         Resolver
+	now              func() time.Time
+	interleavedVoice bool
+	locked           bool
+	last             LockState
 
 	// restChannel tracks the LCN a Capacity Plus system currently
 	// advertises as its rest (control) channel. Zero until a
@@ -69,6 +70,10 @@ type Options struct {
 	FrequencyHz uint32
 	Resolver    Resolver
 	Now         func() time.Time
+	// InterleavedVoice tags published voice grants with
+	// Grant.DMRInterleavedVoice so the composer uses the 2-slot
+	// interleaved decoder. Mirrors System.DMRInterleavedVoice.
+	InterleavedVoice bool
 }
 
 // New constructs a ControlChannel from Options.
@@ -82,12 +87,13 @@ func New(opts Options) *ControlChannel {
 		now = time.Now
 	}
 	return &ControlChannel{
-		bus:        opts.Bus,
-		log:        log,
-		systemName: opts.SystemName,
-		freqHz:     opts.FrequencyHz,
-		resolver:   opts.Resolver,
-		now:        now,
+		bus:              opts.Bus,
+		log:              log,
+		systemName:       opts.SystemName,
+		freqHz:           opts.FrequencyHz,
+		resolver:         opts.Resolver,
+		now:              now,
+		interleavedVoice: opts.InterleavedVoice,
 	}
 }
 
@@ -159,17 +165,18 @@ func (c *ControlChannel) publishGrant(cc, lcn, slot uint8, group, source uint32,
 	c.bus.Publish(events.Event{
 		Kind: events.KindGrant,
 		Payload: trunking.Grant{
-			System:      c.systemName,
-			Protocol:    "dmr-tier3",
-			GroupID:     group,
-			SourceID:    source,
-			FrequencyHz: freq,
-			ChannelID:   cc,
-			ChannelNum:  uint16(lcn),
-			Timeslot:    slot + 1,
-			Encrypted:   serviceOptions&0x40 != 0,
-			Emergency:   serviceOptions&0x80 != 0,
-			At:          c.now(),
+			System:              c.systemName,
+			Protocol:            "dmr-tier3",
+			GroupID:             group,
+			SourceID:            source,
+			FrequencyHz:         freq,
+			ChannelID:           cc,
+			ChannelNum:          uint16(lcn),
+			Timeslot:            slot + 1,
+			DMRInterleavedVoice: c.interleavedVoice,
+			Encrypted:           serviceOptions&0x40 != 0,
+			Emergency:           serviceOptions&0x80 != 0,
+			At:                  c.now(),
 		},
 	})
 	return freq, true

--- a/internal/radio/dmr/tier3/control_test.go
+++ b/internal/radio/dmr/tier3/control_test.go
@@ -156,6 +156,38 @@ func TestControlChannelPublishesTVGrant(t *testing.T) {
 	}
 }
 
+func TestControlChannelGrantCarriesInterleavedFlag(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{
+		Bus:              bus,
+		SystemName:       "TestSys",
+		Resolver:         TableBandPlan{8: 866_175_000},
+		InterleavedVoice: true,
+	})
+	csbk := CSBK{LB: true, Opcode: OpTVGrant, Payload: [8]byte{0xC0, 0x12, 0x34, 0x56, 0xAB, 0xCD, 0xEF, 0x88}}
+	cc.IngestBurst(burstWithCSBK(csbk), dmr.SlotType{ColorCode: 3, DataType: dmr.DTCSBK})
+
+	deadline := time.After(time.Second)
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind != events.KindGrant {
+				continue
+			}
+			if g := ev.Payload.(trunking.Grant); !g.DMRInterleavedVoice {
+				t.Errorf("DMRInterleavedVoice = false, want true when Options.InterleavedVoice is set")
+			}
+			return
+		case <-deadline:
+			t.Fatal("no grant event published")
+		}
+	}
+}
+
 func TestControlChannelPublishesPVGrant(t *testing.T) {
 	bus := events.NewBus(8)
 	defer bus.Close()

--- a/internal/scanner/ccdecoder/pipelines.go
+++ b/internal/scanner/ccdecoder/pipelines.go
@@ -555,7 +555,8 @@ func newDMRTier3Pipeline(opts PipelineOptions) (ProtocolPipeline, error) {
 		// LCN→downlink resolver from the system's dmr_band_plan; nil
 		// when unconfigured, in which case T3 voice grants drop with
 		// decode.error stage=no-bandplan (the daemon warns at load).
-		Resolver: tier3.ResolverFromPlan(opts.System.DMRBandPlan),
+		Resolver:         tier3.ResolverFromPlan(opts.System.DMRBandPlan),
+		InterleavedVoice: opts.System.DMRInterleavedVoice,
 	})
 	rx := dmrrx.New(dmrrx.Options{
 		SampleRateHz: opts.SampleRateHz,

--- a/internal/scanner/widebandt2/engine.go
+++ b/internal/scanner/widebandt2/engine.go
@@ -313,8 +313,9 @@ func buildChannel(sys trunking.System, ch ChannelConfig, bus *events.Bus, log *s
 			// dmr_band_plan. Without it every T3 voice grant drops with
 			// decode.error stage=no-bandplan; the daemon already warns
 			// at load time. See internal/radio/dmr/tier3.ResolverFromPlan.
-			Resolver: tier3.ResolverFromPlan(sys.DMRBandPlan),
-			Now:      now,
+			Resolver:         tier3.ResolverFromPlan(sys.DMRBandPlan),
+			Now:              now,
+			InterleavedVoice: sys.DMRInterleavedVoice,
 		})
 		rx := dmrrx.New(dmrrx.Options{
 			SampleRateHz: narrowbandRateHz,

--- a/internal/trunking/grant.go
+++ b/internal/trunking/grant.go
@@ -33,6 +33,14 @@ type Grant struct {
 	Timeslot  uint8
 	Encrypted bool
 	Emergency bool
+	// DMRInterleavedVoice mirrors the system-level
+	// trunking.System.DMRInterleavedVoice opt-in onto the grant so the
+	// voice composer selects the 2-slot interleaved decoder and routes
+	// this call to its timeslot by matching the embedded Link Control's
+	// talkgroup to GroupID. Set by the DMR Tier III control channel;
+	// false (the default) keeps the single-slot decoder. Ignored for
+	// non-DMR grants.
+	DMRInterleavedVoice bool
 	// AlgorithmID and KeyID carry the encryption parameters the
 	// protocol's privacy header advertises (the DMR PI header, etc.).
 	// They are meaningful only when Encrypted is true and stay zero

--- a/internal/trunking/site.go
+++ b/internal/trunking/site.go
@@ -221,6 +221,16 @@ type System struct {
 	// for non-DMR-Tier-III protocols.
 	DMRBandPlan *DMRBandPlan
 
+	// DMRInterleavedVoice opts the system into the experimental 2-slot
+	// interleaved voice decoder (mirrors config.System.DMRInterleavedVoice).
+	// When true the DMR Tier III control channel tags its voice grants
+	// so the composer decodes each timeslot from the carrier's
+	// interleaved burst stream and routes it to the call by embedded-LC
+	// talkgroup. Default false keeps the single-slot decoder. Pending a
+	// real-capture cross-check of the on-air constants — see
+	// docs/status.md. Ignored for non-DMR protocols.
+	DMRInterleavedVoice bool
+
 	// P25Phase1DemodMode selects the symbol-recovery path for the
 	// P25 Phase 1 receiver. Recognised values (case-insensitive):
 	// "" / "c4fm" / "fm" → DemodC4FM (the default — FM

--- a/internal/voice/composer/composer.go
+++ b/internal/voice/composer/composer.go
@@ -418,7 +418,7 @@ func (c *Composer) handleStart(parent context.Context, cs trunking.CallStart) {
 				"device", cs.DeviceSerial, "system", cs.Grant.System,
 				"group", cs.Grant.GroupID)
 		}
-		go c.runDMRVoiceChain(chainCtx, cs.DeviceSerial, iqCh, rateHz, ch.done)
+		go c.runDMRVoiceChain(chainCtx, cs.DeviceSerial, iqCh, rateHz, cs.Grant.GroupID, cs.Grant.DMRInterleavedVoice, ch.done)
 	case isP25P2Voice:
 		macCfg := p25p2.MACDecodeConfig{
 			Trellis:    p25p2.TrellisMode(cs.Grant.P25Phase2Decode.Trellis),

--- a/internal/voice/composer/dmr_2slot_realair_test.go
+++ b/internal/voice/composer/dmr_2slot_realair_test.go
@@ -1,0 +1,108 @@
+//go:build integration
+
+package composer
+
+import (
+	"context"
+	"encoding/binary"
+	"math"
+	"os"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// TestDMR2SlotRealairRoutesByEmbeddedLC validates the opt-in 2-slot
+// interleaved voice path against a real DMR capture — the cross-check
+// docs/status.md flags as the gate before the interleaved decoder can
+// replace the single-slot decoder as the production default.
+//
+// It is skip-gated on environment so CI (which has no capture) stays
+// green; a contributor with a recording runs it as:
+//
+//	GOPHERTRUNK_DMR_2SLOT_CFILE=cap.cfile \
+//	GOPHERTRUNK_DMR_2SLOT_RATE_HZ=48000 \
+//	GOPHERTRUNK_DMR_2SLOT_TG=12345 \
+//	go test -tags integration ./internal/voice/composer/ -run DMR2SlotRealair -v
+//
+// The cfile is GNU Radio interleaved float32 IQ at the given rate; TG is
+// the talkgroup of the call to follow on the carrier. A pass means the
+// interleaved decoder recovered that talkgroup's embedded LC and routed
+// its (and only its) audio to the sidecar.
+func TestDMR2SlotRealairRoutesByEmbeddedLC(t *testing.T) {
+	path := os.Getenv("GOPHERTRUNK_DMR_2SLOT_CFILE")
+	if path == "" {
+		t.Skip("set GOPHERTRUNK_DMR_2SLOT_CFILE (+ _RATE_HZ, _TG) to run the DMR 2-slot real-air check")
+	}
+	rate, err := strconv.ParseUint(os.Getenv("GOPHERTRUNK_DMR_2SLOT_RATE_HZ"), 10, 32)
+	if err != nil || rate == 0 {
+		t.Fatalf("GOPHERTRUNK_DMR_2SLOT_RATE_HZ must be a positive integer: %v", err)
+	}
+	tg, err := strconv.ParseUint(os.Getenv("GOPHERTRUNK_DMR_2SLOT_TG"), 10, 32)
+	if err != nil {
+		t.Fatalf("GOPHERTRUNK_DMR_2SLOT_TG must be an integer talkgroup: %v", err)
+	}
+	iq := readCfileF32(t, path)
+
+	src := newFakeSource()
+	bus := events.NewBus(8)
+	sink := &recordingSink{}
+	c, err := New(Options{
+		Bus:           bus,
+		Devices:       &fakeDevices{src: map[string]IQSource{"VOICE-1": src}},
+		Sink:          sink,
+		Engine:        &fakeEngine{},
+		IQSampleRate:  uint32(rate),
+		PCMSampleRate: 8000,
+		TouchInterval: 30 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go c.Run(ctx)
+	defer c.Close()
+	defer bus.Close()
+
+	bus.Publish(events.Event{Kind: events.KindCallStart, Payload: trunking.CallStart{
+		Grant: trunking.Grant{
+			System: "DMRSite", Protocol: "dmr-tier3",
+			GroupID: uint32(tg), FrequencyHz: 460_000_000,
+			Timeslot: 1, DMRInterleavedVoice: true,
+		},
+		DeviceSerial: "VOICE-1",
+		StartedAt:    time.Now().UTC(),
+	}})
+
+	waitFor(t, 2*time.Second, func() bool { return len(c.ActiveChains()) == 1 })
+	src.SendIQ(iq)
+	waitFor(t, 10*time.Second, func() bool { return len(sink.rawFrames("VOICE-1")) > 0 })
+
+	if got := len(sink.rawFrames("VOICE-1")); got == 0 {
+		t.Fatalf("no AMBE frames routed for talkgroup %d — interleaved decode/cadence/embedded-LC constants need adjustment against this capture", tg)
+	} else {
+		t.Logf("routed %d AMBE frames for talkgroup %d from %s", got, tg, path)
+	}
+}
+
+func readCfileF32(t *testing.T, path string) []complex64 {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read cfile: %v", err)
+	}
+	if len(raw)%8 != 0 {
+		t.Fatalf("cfile length %d is not a multiple of 8 (interleaved float32 IQ)", len(raw))
+	}
+	out := make([]complex64, len(raw)/8)
+	for i := range out {
+		re := math.Float32frombits(binary.LittleEndian.Uint32(raw[i*8:]))
+		im := math.Float32frombits(binary.LittleEndian.Uint32(raw[i*8+4:]))
+		out[i] = complex(re, im)
+	}
+	return out
+}

--- a/internal/voice/composer/dmr_slot_router_test.go
+++ b/internal/voice/composer/dmr_slot_router_test.go
@@ -1,0 +1,60 @@
+package composer
+
+import (
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/radio/dmr"
+	dmrvoice "github.com/MattCheramie/GopherTrunk/internal/radio/dmr/voice"
+)
+
+func sfWithLC(phase uint8, group uint32) dmrvoice.VoiceSuperframe {
+	return dmrvoice.VoiceSuperframe{
+		Phase: phase,
+		HasLC: true,
+		LC:    dmr.FLC{FLCO: dmr.FLCOGroupVoiceUser, DstAddr: group, SrcAddr: 7},
+	}
+}
+
+func sfNoLC(phase uint8) dmrvoice.VoiceSuperframe {
+	return dmrvoice.VoiceSuperframe{Phase: phase}
+}
+
+func TestSlotRouterRoutesByEmbeddedLC(t *testing.T) {
+	r := newSlotRouter(100)
+
+	// Before any LC binds our phase, a phase-only superframe can't be
+	// attributed and is dropped.
+	if r.accept(sfNoLC(0)) {
+		t.Error("accepted an unbound phase-only superframe")
+	}
+	// Our talkgroup's LC on phase 0 binds and is accepted.
+	if !r.accept(sfWithLC(0, 100)) {
+		t.Fatal("rejected our own talkgroup's LC")
+	}
+	// The other slot's LC (different TG, other phase) is dropped.
+	if r.accept(sfWithLC(1, 200)) {
+		t.Error("accepted the other talkgroup's LC")
+	}
+	// Once bound, a phase-0 superframe with no/garbled LC is ours.
+	if !r.accept(sfNoLC(0)) {
+		t.Error("rejected a bound-phase superframe missing its LC")
+	}
+	// A phase-1 superframe with no LC belongs to the other slot.
+	if r.accept(sfNoLC(1)) {
+		t.Error("accepted the other phase's LC-less superframe")
+	}
+}
+
+func TestSlotRouterDifferentTalkgroupNeverBinds(t *testing.T) {
+	r := newSlotRouter(100)
+	// Only ever see the other slot's talkgroup → nothing is accepted and
+	// no phase is bound (so a later LC-less frame still can't leak).
+	for _, ph := range []uint8{0, 1, 0, 1} {
+		if r.accept(sfWithLC(ph, 200)) {
+			t.Fatalf("accepted foreign talkgroup on phase %d", ph)
+		}
+	}
+	if r.accept(sfNoLC(0)) || r.accept(sfNoLC(1)) {
+		t.Error("accepted an LC-less superframe though our talkgroup was never seen")
+	}
+}

--- a/internal/voice/composer/dmr_voice.go
+++ b/internal/voice/composer/dmr_voice.go
@@ -37,7 +37,46 @@ type rawFrameSink interface {
 // to its 49-bit vocoder payload before being written. Vocoder decode
 // to PCM is still out of scope — the .raw sidecar carries the
 // post-FEC frames for out-of-band decode (issue #276).
-func (c *Composer) runDMRVoiceChain(ctx context.Context, serial string, iqCh <-chan []complex64, iqHz uint32, done chan<- struct{}) {
+//
+// When interleaved is true (System.DMRInterleavedVoice), the carrier is
+// decoded as 2-slot TDMA: the interleaved decoder emits a superframe per
+// timeslot and a slotRouter keeps only the ones belonging to this call's
+// groupID (by embedded-LC talkgroup, then by bound phase). Otherwise the
+// single-slot decoder runs and every superframe is written.
+//
+// slotRouter decides which superframes of a 2-slot interleaved DMR
+// carrier belong to this call. A carrier runs two calls (one per
+// timeslot) whose burst-A voice sync is identical, so the only reliable
+// discriminator is the embedded Link Control: once a superframe's LC
+// names this call's talkgroup, its Phase is bound and subsequent
+// superframes are routed by Phase even when their LC is absent or fails
+// CRC. Superframes whose LC names a different talkgroup are dropped.
+type slotRouter struct {
+	groupID uint32
+	bound   int // -1 until a matching LC binds this call's phase
+}
+
+func newSlotRouter(groupID uint32) *slotRouter {
+	return &slotRouter{groupID: groupID, bound: -1}
+}
+
+// accept reports whether sf belongs to this call's timeslot.
+func (r *slotRouter) accept(sf dmrvoice.VoiceSuperframe) bool {
+	if sf.HasLC {
+		if gv, ok := sf.LC.AsGroupVoiceUser(); ok {
+			if gv.GroupAddress == r.groupID {
+				r.bound = int(sf.Phase)
+				return true
+			}
+			return false // LC names a different talkgroup — the other slot
+		}
+	}
+	// No usable group LC this superframe: accept only once our phase is
+	// known, and only for that phase.
+	return r.bound >= 0 && int(sf.Phase) == r.bound
+}
+
+func (c *Composer) runDMRVoiceChain(ctx context.Context, serial string, iqCh <-chan []complex64, iqHz uint32, groupID uint32, interleaved bool, done chan<- struct{}) {
 	defer close(done)
 
 	decim := int(iqHz) / dmrVoiceIntermediateHz
@@ -58,6 +97,11 @@ func (c *Composer) runDMRVoiceChain(ctx context.Context, serial string, iqCh <-c
 
 	rs, _ := c.sink.(rawFrameSink)
 	voiceDec := dmrvoice.NewDecoder()
+	var router *slotRouter
+	if interleaved {
+		voiceDec = dmrvoice.NewInterleavedDecoder()
+		router = newSlotRouter(groupID)
+	}
 	// superframes counts DMR voice superframes the receiver delivered —
 	// i.e. real voice activity. The touch ticker (below) only refreshes
 	// the engine's LastHeardAt when this counter has advanced since the
@@ -80,6 +124,11 @@ func (c *Composer) runDMRVoiceChain(ctx context.Context, serial string, iqCh <-c
 		ClockGain:   0.025,
 		DibitSink: func(dibits []uint8, baseIdx int) {
 			for _, sf := range voiceDec.Process(dibits, baseIdx) {
+				if router != nil && !router.accept(sf) {
+					// A superframe from the other timeslot (or an
+					// as-yet-unbound phase) — not this call's audio.
+					continue
+				}
 				superframes.Add(1)
 				if rs == nil {
 					continue

--- a/internal/voice/composer/dmr_voice_test.go
+++ b/internal/voice/composer/dmr_voice_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/MattCheramie/GopherTrunk/internal/events"
 	"github.com/MattCheramie/GopherTrunk/internal/radio/dmr"
 	dmrvoice "github.com/MattCheramie/GopherTrunk/internal/radio/dmr/voice"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
 	"github.com/MattCheramie/GopherTrunk/internal/trunking"
 )
 
@@ -200,4 +201,165 @@ func matchesAnySuperframe(got [][]byte, infos [][]byte) bool {
 		}
 	}
 	return false
+}
+
+// flcFragments encodes a Full Link Control into the four 32-bit embedded
+// fragments carried by a superframe's bursts B–E.
+func flcFragments(t *testing.T, f dmr.FLC) [4][]byte {
+	t.Helper()
+	info := dmr.AssembleFLC(f)
+	lc := make([]byte, framing.EmbLCBits)
+	for i := 0; i < framing.EmbLCBits; i++ {
+		lc[i] = (info[i/8] >> uint(7-(i%8))) & 1
+	}
+	ch := framing.EncodeEmbeddedLC(lc)
+	var frags [4][]byte
+	for i := range frags {
+		frags[i] = ch[i*framing.EmbeddedFragmentBits : (i+1)*framing.EmbeddedFragmentBits]
+	}
+	return frags
+}
+
+// embeddedSyncDibits packs an EMB header + fragment into a burst's
+// 24-dibit centre field.
+func embeddedSyncDibits(emb dmr.EMB, frag []byte) [24]uint8 {
+	field := dmr.AssembleEmbeddedField(emb, frag)
+	var d [24]uint8
+	for i := 0; i < 24; i++ {
+		d[i] = field[2*i]<<1 | field[2*i+1]
+	}
+	return d
+}
+
+// buildInterleavedVoiceStreamLC builds a 2-slot interleaved DMR voice
+// dibit stream: each superframe's bursts weave slot A and slot B
+// (A.b, B.b), burst A of each carries BS-Voice sync, bursts B–E carry
+// that slot's own embedded Link Control (talkgroup aTG / bTG). Returns
+// the dibits plus each slot's ordered 49-bit AMBE payloads.
+func buildInterleavedVoiceStreamLC(t *testing.T, n int, aTG, bTG uint32) (dibits []uint8, aInfos, bInfos [][]byte) {
+	t.Helper()
+	dibits = make([]uint8, 240) // clock-settling lead
+	for i := range dibits {
+		dibits[i] = uint8(i % 4)
+	}
+	aFrags := flcFragments(t, dmr.FLC{FLCO: dmr.FLCOGroupVoiceUser, DstAddr: aTG, SrcAddr: 11})
+	bFrags := flcFragments(t, dmr.FLC{FLCO: dmr.FLCOGroupVoiceUser, DstAddr: bTG, SrcAddr: 22})
+
+	var aOnair, bOnair [][]byte
+	for f := 0; f < n*dmrvoice.FramesPerSuperframe; f++ {
+		ai, bi := mkInfo(f), mkInfo(f+100000)
+		aInfos = append(aInfos, ai)
+		bInfos = append(bInfos, bi)
+		af, err := dmrvoice.EncodeAMBEFrame(ai)
+		if err != nil {
+			t.Fatalf("EncodeAMBEFrame A: %v", err)
+		}
+		bf, err := dmrvoice.EncodeAMBEFrame(bi)
+		if err != nil {
+			t.Fatalf("EncodeAMBEFrame B: %v", err)
+		}
+		aOnair = append(aOnair, af)
+		bOnair = append(bOnair, bf)
+	}
+
+	lcss := func(b int) dmr.LCSS {
+		switch b {
+		case 1:
+			return dmr.LCSSFirst
+		case 4:
+			return dmr.LCSSLast
+		default:
+			return dmr.LCSSCont
+		}
+	}
+	for s := 0; s < n; s++ {
+		for b := 0; b < dmrvoice.BurstsPerSuperframe; b++ {
+			aSync, bSync := dmr.BSData.Dibits, dmr.BSData.Dibits
+			switch {
+			case b == 0:
+				aSync, bSync = dmr.BSVoice.Dibits, dmr.BSVoice.Dibits
+			case b >= 1 && b <= 4:
+				aSync = embeddedSyncDibits(dmr.EMB{ColorCode: 1, LCSS: lcss(b)}, aFrags[b-1])
+				bSync = embeddedSyncDibits(dmr.EMB{ColorCode: 1, LCSS: lcss(b)}, bFrags[b-1])
+			}
+			base := s*dmrvoice.FramesPerSuperframe + b*dmrvoice.FramesPerBurst
+			dibits = append(dibits, voiceBurstDibits(aOnair[base:base+dmrvoice.FramesPerBurst], aSync)...)
+			dibits = append(dibits, voiceBurstDibits(bOnair[base:base+dmrvoice.FramesPerBurst], bSync)...)
+		}
+	}
+	return dibits, aInfos, bInfos
+}
+
+// TestComposerDMRInterleavedRoutesBySlot drives the full opt-in 2-slot
+// path: a carrier with two concurrent calls (talkgroups 100 and 200,
+// each with its own embedded LC) is decoded for the call granted on
+// talkgroup 100. Only that slot's AMBE payloads must reach the sidecar;
+// the other slot's must not leak in.
+func TestComposerDMRInterleavedRoutesBySlot(t *testing.T) {
+	const (
+		sampleRate  = 48_000.0
+		sps         = 10
+		span        = 8
+		alpha       = 0.20
+		deviation   = 1944.0
+		superframes = 12
+		ourTG       = 100
+		otherTG     = 200
+	)
+	dibits, aInfos, bInfos := buildInterleavedVoiceStreamLC(t, superframes, ourTG, otherTG)
+	iq := demod.ModulateC4FM(dibits, sps, span, alpha, sampleRate, deviation)
+
+	src := newFakeSource()
+	bus := events.NewBus(8)
+	sink := &recordingSink{}
+	eng := &fakeEngine{}
+	c, err := New(Options{
+		Bus:           bus,
+		Devices:       &fakeDevices{src: map[string]IQSource{"VOICE-1": src}},
+		Sink:          sink,
+		Engine:        eng,
+		IQSampleRate:  uint32(sampleRate),
+		PCMSampleRate: 8000,
+		TouchInterval: 30 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go c.Run(ctx)
+	defer c.Close()
+	defer bus.Close()
+
+	bus.Publish(events.Event{
+		Kind: events.KindCallStart,
+		Payload: trunking.CallStart{
+			Grant: trunking.Grant{
+				System: "DMRSite", Protocol: "dmr-tier3",
+				GroupID: ourTG, FrequencyHz: 460_000_000,
+				Timeslot: 1, DMRInterleavedVoice: true,
+			},
+			DeviceSerial: "VOICE-1",
+			StartedAt:    time.Now().UTC(),
+		},
+	})
+
+	waitFor(t, 2*time.Second, func() bool { return len(c.ActiveChains()) == 1 })
+	src.SendIQ(iq)
+
+	waitFor(t, 4*time.Second, func() bool {
+		return len(sink.rawFrames("VOICE-1")) >= dmrvoice.FramesPerSuperframe
+	})
+
+	got := sink.rawFrames("VOICE-1")
+	got = got[:len(got)-len(got)%dmrvoice.FramesPerSuperframe]
+	if len(got) == 0 {
+		t.Fatal("no complete superframe routed to the sidecar")
+	}
+	if !matchesAnySuperframe(got, aInfos) {
+		t.Errorf("our talkgroup's (TG %d) audio did not reach the sidecar", ourTG)
+	}
+	if matchesAnySuperframe(got, bInfos) {
+		t.Errorf("the other timeslot's (TG %d) audio leaked into our call", otherTG)
+	}
 }


### PR DESCRIPTION
## Why

Phases 1–2 (#512, #513) track/route/record TS1+TS2 as distinct calls; phases 3–4 (#514, #515) built the interleaved decoder + embedded-LC labelling as **library** capabilities. They weren't reachable from the running daemon. This phase wires them through the production voice path — behind a per-system opt-in, because the on-air constants are still capture-pending — so a real DMR carrier's two concurrent calls can actually be decoded and routed to the correct call.

## What

- **Config / trunking**: new `System.DMRInterleavedVoice` (`dmr_interleaved_voice:` in YAML), default **false**, threaded into the daemon's `trunking.System` next to `DMRBandPlan`.
- **tier3**: `ControlChannel.Options.InterleavedVoice` tags published voice grants with `Grant.DMRInterleavedVoice`; both pipeline builders (`widebandt2`, `ccdecoder`) pass the system flag.
- **composer**: when the grant's flag is set, `runDMRVoiceChain` uses `dmrvoice.NewInterleavedDecoder` and a new **`slotRouter`** keeps only the superframes belonging to this call — it matches the embedded LC's talkgroup to the grant's `GroupID`, then **binds that slot's phase** so later LC-less/garbled superframes still route correctly. The default-off path is byte-for-byte unchanged (single-slot `NewDecoder`, every superframe written).
- **Skip-gated `-tags integration` harness** (`internal/voice/composer/dmr_2slot_realair_test.go`, `GOPHERTRUNK_DMR_2SLOT_CFILE`) runs the chain over a real f32 cfile — the gate to validate the on-air constants before promoting interleaved to the default.

## Tests (all green: `go test ./...` → 110 packages OK, 0 failures; `gofmt`/`go vet` clean, incl. `-tags integration`)

- `slotRouter` unit tests: LC match → phase bind → LC-less routes by bound phase; a foreign talkgroup never binds and never leaks.
- tier3: a published grant carries `DMRInterleavedVoice` when `Options.InterleavedVoice` is set.
- **End-to-end composer**: `TestComposerDMRInterleavedRoutesBySlot` — synthetic **modulated** 2-slot IQ with a different talkgroup per slot → only the granted talkgroup's AMBE payloads reach the recorder; the other slot does **not** leak in. The existing single-slot composer test is untouched and still passes.

## Docs

`README.md`, `docs/status.md`, `docs/hardware.md`, `config.example.yaml`, and `CHANGELOG.md` updated — all flagging the opt-in/experimental status and the capture-validation gate.

## Where the timeslot effort stands

End-to-end, against synthetic IQ, the daemon can now (with the flag on) follow a DMR carrier's two timeslots as separate, correctly-labelled, separately-recorded calls — identity (1–2), DSP separation (3), talkgroup labelling (4), and production wiring (5). The one remaining item is **real-capture validation** of the on-air constants (burst cadence/CACH, embedded interleave, EMB FEC, CRC), after which `dmr_interleaved_voice` can become the default. The harness added here is exactly where that validation runs.

https://claude.ai/code/session_01ParTi9V4czr2QCJYNWjc2d

---
_Generated by [Claude Code](https://claude.ai/code/session_01ParTi9V4czr2QCJYNWjc2d)_