### PR TITLE
observability: surface DMR timeslot in metrics + active-call views (phase 6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ for tagged releases.
 
 ### Added
 
+- **Per-timeslot observability for DMR calls.** A DMR carrier's two
+  concurrent calls are now distinguishable in the live views and
+  metrics: the TUI active-call Flags column shows `TS1` / `TS2`
+  (alongside `E` / `!`), the web active-call detail surfaces a
+  Timeslot field, and a new
+  `gophertrunk_dmr_voice_calls_total{system,timeslot}` Prometheus
+  counter splits DMR voice starts by slot so an operator can spot a
+  slot that never carries traffic (a routing/decode gap). Non-slotted
+  protocols are unaffected (no slot shown, counter not touched).
 - **DMR 2-slot interleaved voice wired into the composer (opt-in).** The
   interleaved decoder + embedded-LC labelling from the previous changes
   are now reachable end-to-end on the production voice path behind a new

--- a/README.md
+++ b/README.md
@@ -284,7 +284,10 @@ log, per-talkgroup policy) all ship.
   BPTC(128,72) → talkgroup/source) so a slot is routed to its call by
   talkgroup. The whole path is wired through the voice composer behind
   a per-system opt-in (`dmr_interleaved_voice: true`) and unit-tested
-  end-to-end against synthetic modulated IQ. It defaults off:
+  end-to-end against synthetic modulated IQ. Each slot's calls are
+  visible per-timeslot in the TUI / web active-call views and in the
+  `gophertrunk_dmr_voice_calls_total{system,timeslot}` metric. It
+  defaults off:
   confirming the exact on-air dibit cadence (CACH/guard) and the ETSI
   embedded-signalling interleave / EMB FEC / CRC against a real IQ
   capture is what's needed before it becomes the production default —

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -50,7 +50,7 @@ gophertrunk tui -server https://radio.example.com -insecure
 | 1 | Dashboard | At-a-glance health, active call count, recent events, recent tone alerts. Default landing panel. |
 | 2 | Systems | Configured trunking systems: name, protocol, control channels, IDs (WACN / SystemID / RFSS-Site). |
 | 3 | Talkgroups | Full talkgroup table from the daemon. Substring filter (`/`) and a sort cycle (`s`: ID → Alpha → Priority). |
-| 4 | Active calls | Calls currently being followed. Driven by a 1 s poll plus live `call.start` / `call.end` events for instant updates. |
+| 4 | Active calls | Calls currently being followed. Driven by a 1 s poll plus live `call.start` / `call.end` events for instant updates. The Flags column shows encryption (`E`), emergency (`!`), and — for DMR — the TDMA timeslot (`TS1` / `TS2`), so a carrier's two concurrent calls are distinguishable. |
 | 5 | Call history | Ended calls from `/api/v1/calls/history`. On-demand reload (`r`); the panel does not poll continuously. Row formatting runs off the Update goroutine so the reducer never blocks on history rebuilds. |
 | 6 | Events | The full SSE feed in chronological order. Substring filter (`/`), pause auto-scroll (`p`), clear filter (`c`). 500-entry ring buffer. |
 | 7 | Tone alerts | Just `tone.alert` events with profile / device / matched frequencies. 100-entry ring buffer. |

--- a/internal/metrics/prom.go
+++ b/internal/metrics/prom.go
@@ -13,6 +13,7 @@ package metrics
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"sync"
 
@@ -41,6 +42,7 @@ type Metrics struct {
 	callsTotal     *prometheus.CounterVec // by system,protocol,encrypted,reason
 	callsStarted   *prometheus.CounterVec // by system,protocol,encrypted
 	activeCalls    *prometheus.GaugeVec   // by system,protocol
+	dmrSlotCalls   *prometheus.CounterVec // DMR voice calls by system,timeslot (ts1/ts2)
 	ccLockedGauge  *prometheus.GaugeVec   // by system (1 when CC locked)
 	ccFrequencyHz  *prometheus.GaugeVec   // by system; deleted on CC loss
 	ccTransitions  *prometheus.CounterVec // by system,event (locked|lost)
@@ -96,6 +98,18 @@ func New(bus *events.Bus, pool Snapshotter, version string) (*Metrics, error) {
 		Name:      "calls_active",
 		Help:      "Active calls currently being followed, by system and protocol. Use sum() for the daemon-wide total.",
 	}, []string{"system", "protocol"})
+
+	// DMR carriers are 2-slot TDMA, so a single repeater runs two
+	// independent calls (TS1 + TS2). This counter splits DMR voice
+	// calls by timeslot so an operator can see the per-slot load and
+	// spot a slot that never produces traffic (a routing/decode gap).
+	// Only emitted for grants that carry a timeslot (DMR); the label is
+	// "ts1" / "ts2".
+	m.dmrSlotCalls = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: namespace,
+		Name:      "dmr_voice_calls_total",
+		Help:      "DMR voice calls started, split by TDMA timeslot (ts1/ts2), by system.",
+	}, []string{"system", "timeslot"})
 
 	m.ccLockedGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: namespace,
@@ -214,6 +228,7 @@ func New(bus *events.Bus, pool Snapshotter, version string) (*Metrics, error) {
 		m.callsTotal,
 		m.callsStarted,
 		m.activeCalls,
+		m.dmrSlotCalls,
 		m.ccLockedGauge,
 		m.ccFrequencyHz,
 		m.ccTransitions,
@@ -300,6 +315,9 @@ func (m *Metrics) observeEvent(ev events.Event) {
 			sys, proto, enc := callLabels(cs.Grant)
 			m.activeCalls.WithLabelValues(sys, proto).Inc()
 			m.callsStarted.WithLabelValues(sys, proto, enc).Inc()
+			if cs.Grant.Timeslot != 0 {
+				m.dmrSlotCalls.WithLabelValues(sys, fmt.Sprintf("ts%d", cs.Grant.Timeslot)).Inc()
+			}
 		}
 	case events.KindCallEnd:
 		if ce, ok := ev.Payload.(trunking.CallEnd); ok {

--- a/internal/metrics/prom_test.go
+++ b/internal/metrics/prom_test.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"math"
 	"net/http"
@@ -106,6 +107,49 @@ func TestCallsActiveTracksStartAndEnd(t *testing.T) {
 	}
 	if got := testutil.ToFloat64(callsTotal); got != 1 {
 		t.Errorf("calls_total{Alpha,unknown,false,normal} = %v, want 1", got)
+	}
+}
+
+func TestDMRSlotCallsCounter(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	m, _ := New(bus, nil, "test")
+	defer m.Close()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go m.Run(ctx)
+
+	// One TS1 call and two TS2 calls on a DMR system; plus a non-slotted
+	// (P25) call that must not touch the DMR slot counter.
+	starts := []trunking.Grant{
+		{System: "DMR3", Protocol: "dmr-tier3", GroupID: 1, FrequencyHz: 1, Timeslot: 1},
+		{System: "DMR3", Protocol: "dmr-tier3", GroupID: 2, FrequencyHz: 1, Timeslot: 2},
+		{System: "DMR3", Protocol: "dmr-tier3", GroupID: 3, FrequencyHz: 1, Timeslot: 2},
+		{System: "P25Sys", Protocol: "p25", GroupID: 4, FrequencyHz: 2}, // Timeslot 0
+	}
+	for i, g := range starts {
+		bus.Publish(events.Event{Kind: events.KindCallStart, Payload: trunking.CallStart{
+			Grant: g, DeviceSerial: fmt.Sprintf("D%d", i), StartedAt: time.Now(),
+		}})
+	}
+
+	ts2 := m.dmrSlotCalls.WithLabelValues("DMR3", "ts2")
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if testutil.ToFloat64(ts2) == 2 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if got := testutil.ToFloat64(m.dmrSlotCalls.WithLabelValues("DMR3", "ts1")); got != 1 {
+		t.Errorf("dmr_voice_calls_total{DMR3,ts1} = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(ts2); got != 2 {
+		t.Errorf("dmr_voice_calls_total{DMR3,ts2} = %v, want 2", got)
+	}
+	// The non-slotted P25 call must not have created any DMR-slot series.
+	if got := testutil.CollectAndCount(m.dmrSlotCalls); got != 2 {
+		t.Errorf("dmr_voice_calls_total series count = %d, want 2 (ts1+ts2 only)", got)
 	}
 }
 

--- a/internal/tui/client/types.go
+++ b/internal/tui/client/types.go
@@ -75,6 +75,7 @@ type GrantDTO struct {
 	FrequencyHz   uint32 `json:"frequency_hz"`
 	ChannelID     uint8  `json:"channel_id,omitempty"`
 	ChannelNumber uint16 `json:"channel_number,omitempty"`
+	Timeslot      uint8  `json:"timeslot,omitempty"`
 	Encrypted     bool   `json:"encrypted,omitempty"`
 	Emergency     bool   `json:"emergency,omitempty"`
 	DataCall      bool   `json:"data_call,omitempty"`

--- a/internal/tui/panels/active.go
+++ b/internal/tui/panels/active.go
@@ -95,6 +95,15 @@ func (p *ActivePanel) refresh(calls []client.ActiveCallDTO) {
 		if ac.Grant.Emergency {
 			flags += "!"
 		}
+		// DMR runs two calls per carrier; show which timeslot this one
+		// occupies so concurrent TS1/TS2 calls are distinguishable at a
+		// glance. Blank for non-slotted protocols.
+		if ac.Grant.Timeslot != 0 {
+			if flags != "" {
+				flags += " "
+			}
+			flags += fmt.Sprintf("TS%d", ac.Grant.Timeslot)
+		}
 		rows = append(rows, table.Row{
 			since(ac.StartedAt),
 			fmt.Sprintf("%d", ac.Grant.GroupID),

--- a/web/src/panels/Active.tsx
+++ b/web/src/panels/Active.tsx
@@ -182,6 +182,13 @@ export function Active() {
               mono
               value={formatHz(selected.grant.frequency_hz)}
             />
+            {selected.grant.timeslot ? (
+              <DetailField
+                label="Timeslot"
+                mono
+                value={`TS${selected.grant.timeslot}`}
+              />
+            ) : null}
             <DetailField
               label="Channel"
               mono


### PR DESCRIPTION
## Why

Phases 1–5 made a DMR carrier's two timeslots into separate, labelled, separately-recorded calls. But operationally they were still indistinguishable where an operator actually watches — the live views and the metrics. This phase closes that gap (the observability item from the original plan; the only other remaining work, real-capture validation, is blocked on hardware).

## What

- **Metrics**: new `gophertrunk_dmr_voice_calls_total{system,timeslot}` counter, incremented on `CallStart` for grants that carry a timeslot (`ts1` / `ts2`). Purpose-built rather than relabeling the existing call metrics, so non-DMR dashboards are untouched and non-slotted protocols never create a series. Lets an operator spot a slot that never carries traffic — a routing/decode gap.
- **TUI**: the active-call **Flags** column appends `TS1` / `TS2` (next to `E` / `!`). Also adds `Timeslot` to the TUI client `GrantDTO` so the field decodes from the API.
- **Web**: the active-call detail panel shows a **Timeslot** field when set.

## Tests (all green: `go test ./...` → 110 packages OK, 0 failures; `gofmt`/`go vet` clean)

- `TestDMRSlotCallsCounter`: a TS1 + two TS2 DMR calls → `{ts1}=1`, `{ts2}=2`; a non-slotted P25 call creates **no** DMR-slot series (asserted via `CollectAndCount`).
- Existing TUI and metrics tests unchanged and passing.

## Docs

`README.md`, `docs/tui.md`, and `CHANGELOG.md` updated.

## Status of the timeslot effort

With this, every layer an operator touches reflects the timeslot: config → grant → engine routing → recorder → call log → REST/SSE/gRPC → TUI/web → Prometheus, plus the opt-in interleaved DSP that separates and labels the two slots. The **only** outstanding item is real-capture validation of the on-air FEC/cadence constants (burst cadence/CACH, embedded interleave, EMB FEC, CRC) to promote `dmr_interleaved_voice` from opt-in to default — gated by the `-tags integration` harness added in #516, which needs a real DMR IQ capture to run.

https://claude.ai/code/session_01ParTi9V4czr2QCJYNWjc2d

---
_Generated by [Claude Code](https://claude.ai/code/session_01ParTi9V4czr2QCJYNWjc2d)_