### PR TITLE
siglab: add offline signal replay/test/analysis core engine

### DIFF
--- a/cmd/gophertrunk/analyze.go
+++ b/cmd/gophertrunk/analyze.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/MattCheramie/GopherTrunk/internal/siglab"
+)
+
+// runAnalyze is the entry point for `gophertrunk analyze`. It runs an offline
+// IQ capture through the production pipeline for any protocol GopherTrunk
+// decodes, collects the protocol-agnostic signal-quality analysis, and emits
+// a clean structured report (JSON / JSONL / YAML / CSV) or a human-readable
+// summary. It is the all-protocol structured-output front door that
+// complements `replay` (whose P25/DMR paths carry deeper demod diagnostics).
+func runAnalyze(args []string) {
+	fs := flag.NewFlagSet("analyze", flag.ExitOnError)
+	verboseFlag := fs.Bool("verbose-errors", false, "print full error chain + stack on failures")
+	in := fs.String("in", "", "raw IQ input file (required)")
+	format := fs.String("format", "u8", "sample format: u8 | f32")
+	sampleRate := fs.Float64("sample-rate", 2_400_000, "IQ sample rate in Hz")
+	protocolFlag := fs.String("protocol", "p25p1", "protocol to decode (p25p1|p25-phase2|dmr|dmr-tier2|nxdn|dpmr|edacs|motorola|ltr|mpt1327|tetra|ysf|dstar)")
+	freq := fs.Uint64("freq", 0, "informational: the capture's nominal centre frequency in Hz")
+	tuneHz := fs.Float64("tune-hz", 0, "frequency-shift the capture so a channel at +tune-hz lands at 0 Hz before demod")
+	autoTune := fs.Bool("auto-tune", false, "estimate the dominant carrier offset from the start of the file and tune it to 0 Hz")
+	conjugate := fs.Bool("conjugate", false, "conjugate IQ (negate Q) before channelization (spectrum-inverted front-end, issue #264)")
+	iqCorrect := fs.Bool("iq-correct", false, "apply blind I/Q-imbalance correction to the raw IQ before decimation")
+	out := fs.String("out", "", "write structured output to this file (default: stdout)")
+	outFormat := fs.String("out-format", "text", "output format: text | json | jsonl | yaml | csv | csv-events")
+	fs.Usage = func() {
+		fmt.Fprintln(fs.Output(), `gophertrunk analyze — decode + analyze a raw IQ capture, with structured export.
+
+USAGE:
+  gophertrunk analyze -in <path> -protocol <p> [-format u8|f32] [-sample-rate Hz]
+                     [-out-format text|json|jsonl|yaml|csv|csv-events] [-out <path>]
+
+EXAMPLES:
+  # P25 Phase 1 capture, JSON report to a file
+  gophertrunk analyze -in cc.cfile -format f32 -sample-rate 2400000 -protocol p25p1 -out-format json -out cc.json
+
+  # TETRA capture, human-readable summary to stdout
+  gophertrunk analyze -in tetra.cfile -format f32 -sample-rate 2400000 -protocol tetra -auto-tune
+
+  # Streaming per-event JSONL
+  gophertrunk analyze -in dmr.cfile -format f32 -sample-rate 2400000 -protocol dmr -out-format jsonl
+
+FLAGS:`)
+		fs.PrintDefaults()
+	}
+	_ = fs.Parse(args)
+	resolveVerbose(*verboseFlag, false)
+	rep := newReporter("analyze")
+
+	if *in == "" {
+		fs.Usage()
+		rep.Fatalf(2, "-in is required")
+	}
+	proto, err := siglab.ParseProtocolCLI(*protocolFlag)
+	if err != nil {
+		rep.Fatal(2, err)
+	}
+	sampleFormat, err := siglab.ParseSampleFormat(*format)
+	if err != nil {
+		rep.Fatal(2, err)
+	}
+	of, err := siglab.ParseFormat(*outFormat)
+	if err != nil {
+		rep.Fatal(2, err)
+	}
+
+	cfg := siglab.Config{
+		Protocol:      proto,
+		SystemName:    "analyze",
+		FrequencyHz:   uint32(*freq),
+		SampleRateHz:  *sampleRate,
+		Format:        sampleFormat,
+		TuneHz:        *tuneHz,
+		AutoTune:      *autoTune,
+		Conjugate:     *conjugate,
+		IQCorrect:     *iqCorrect,
+		CollectIQDiag: true,
+	}
+
+	res, err := siglab.Run(*in, cfg)
+	if err != nil {
+		rep.Fatal(1, err)
+	}
+
+	if err := emitResult(res, of, *out); err != nil {
+		rep.Fatal(1, err)
+	}
+}
+
+// emitResult writes res in the requested format to outPath (or stdout when
+// empty). FormatTextSummary uses the shared human renderer; the rest go
+// through siglab.WriteResult.
+func emitResult(res *siglab.Result, of siglab.Format, outPath string) error {
+	w := os.Stdout
+	if outPath != "" {
+		f, err := os.Create(outPath)
+		if err != nil {
+			return fmt.Errorf("create %s: %w", outPath, err)
+		}
+		defer f.Close()
+		w = f
+	}
+	if of == siglab.FormatTextSummary {
+		renderResultText(w, res)
+		return nil
+	}
+	return siglab.WriteResult(w, res, of)
+}

--- a/cmd/gophertrunk/gen.go
+++ b/cmd/gophertrunk/gen.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"strings"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/demod"
+	"github.com/MattCheramie/GopherTrunk/internal/siglab"
+)
+
+// runGen is the entry point for `gophertrunk gen`. It synthesizes a
+// known-good (optionally impaired) IQ capture for a protocol plus a metadata
+// sidecar describing how to decode and grade it — the synthesize half of the
+// synthesize→decode→grade loop the `test` harness closes. Synthesis reuses
+// the production modulators (internal/dsp/demod) and the same locking symbol
+// streams the integration tests drive, so a generated capture is a faithful
+// stand-in for real-air traffic for everything above the RF front end.
+func runGen(args []string) {
+	fs := flag.NewFlagSet("gen", flag.ExitOnError)
+	verboseFlag := fs.Bool("verbose-errors", false, "print full error chain + stack on failures")
+	protocolFlag := fs.String("protocol", "", "protocol to synthesize (required; see -list)")
+	list := fs.Bool("list", false, "list the protocols with a synthesis fixture and exit")
+	out := fs.String("out", "", "output capture path (required)")
+	format := fs.String("format", "f32", "capture sample format: u8 | f32")
+	metaOut := fs.String("meta", "", "metadata sidecar path (default: <out stem>.metadata.json)")
+	snr := fs.Float64("snr", 0, "additive white Gaussian noise target SNR in dB (0 = clean)")
+	freqOffset := fs.Float64("freq-offset", 0, "residual carrier frequency offset in Hz")
+	dc := fs.Float64("dc", 0, "DC-offset magnitude relative to unit-scale output (0.1 ≈ -20 dBFS)")
+	gainImb := fs.Float64("iq-gain", 0, "I/Q gain imbalance (Q gain relative to I; 0 = none)")
+	phaseSkew := fs.Float64("iq-phase", 0, "I/Q quadrature phase skew in radians (0 = none)")
+	seed := fs.Int64("seed", 1, "RNG seed for reproducible AWGN")
+	fs.Usage = func() {
+		fmt.Fprintln(fs.Output(), `gophertrunk gen — synthesize a test IQ capture + metadata for a protocol.
+
+USAGE:
+  gophertrunk gen -protocol <p> -out <path> [-format u8|f32] [impairment flags]
+
+EXAMPLES:
+  # Clean P25 Phase 1 capture + sidecar metadata
+  gophertrunk gen -protocol p25p1 -out p25.cfile -format f32
+
+  # DMR Tier III capture degraded with 20 dB SNR and a 300 Hz carrier offset
+  gophertrunk gen -protocol dmr -out dmr.cfile -snr 20 -freq-offset 300
+
+  # List the protocols a fixture exists for
+  gophertrunk gen -list
+
+FLAGS:`)
+		fs.PrintDefaults()
+	}
+	_ = fs.Parse(args)
+	resolveVerbose(*verboseFlag, false)
+	rep := newReporter("gen")
+
+	if *list {
+		names := make([]string, 0)
+		for _, p := range siglab.Fixtures() {
+			names = append(names, p.String())
+		}
+		fmt.Println(strings.Join(names, "\n"))
+		return
+	}
+	if *protocolFlag == "" {
+		fs.Usage()
+		rep.Fatalf(2, "-protocol is required")
+	}
+	if *out == "" {
+		fs.Usage()
+		rep.Fatalf(2, "-out is required")
+	}
+	proto, err := siglab.ParseProtocolCLI(*protocolFlag)
+	if err != nil {
+		rep.Fatal(2, err)
+	}
+	sampleFormat, err := siglab.ParseSampleFormat(*format)
+	if err != nil {
+		rep.Fatal(2, err)
+	}
+
+	iq, meta, err := siglab.Synthesize(siglab.SynthOptions{
+		Protocol: proto,
+		Format:   sampleFormat,
+		Impairments: demod.Impairments{
+			SNRdB:           *snr,
+			FreqOffsetHz:    *freqOffset,
+			DCOffset:        complex(float32(*dc), 0),
+			IQGainImbalance: *gainImb,
+			IQPhaseSkewRad:  *phaseSkew,
+			Seed:            *seed,
+		},
+	})
+	if err != nil {
+		rep.Fatal(2, err)
+	}
+
+	if err := siglab.WriteCapture(*out, iq, sampleFormat); err != nil {
+		rep.Fatal(1, fmt.Errorf("write capture: %w", err))
+	}
+	metaPath := *metaOut
+	if metaPath == "" {
+		metaPath = strings.TrimSuffix(*out, ext(*out)) + ".metadata.json"
+	}
+	if err := siglab.WriteMetadata(metaPath, meta); err != nil {
+		rep.Fatal(1, fmt.Errorf("write metadata: %w", err))
+	}
+	fmt.Printf("gen: wrote %d samples → %s  (metadata → %s)\n", len(iq), *out, metaPath)
+}
+
+// ext returns the file extension including the dot, or "" if none.
+func ext(path string) string {
+	for i := len(path) - 1; i >= 0 && path[i] != '/'; i-- {
+		if path[i] == '.' {
+			return path[i:]
+		}
+	}
+	return ""
+}

--- a/cmd/gophertrunk/main.go
+++ b/cmd/gophertrunk/main.go
@@ -58,6 +58,14 @@ func main() {
 		runDecode(os.Args[2:])
 	case "replay":
 		runReplay(os.Args[2:])
+	case "analyze":
+		runAnalyze(os.Args[2:])
+	case "gen":
+		runGen(os.Args[2:])
+	case "test":
+		runSiglabTest(os.Args[2:])
+	case "siglab":
+		runSiglabTUI(os.Args[2:])
 	case "import-pdf":
 		runImport(os.Args[2:])
 	case "daemon", "run":
@@ -82,7 +90,11 @@ USAGE:
   gophertrunk audio list              list audio output devices
   gophertrunk tui [-server URL]       open the operator TUI against a remote daemon
   gophertrunk decode [flags]          decode a captured .raw frame stream into a WAV
-  gophertrunk replay [flags]          decode a raw IQ capture file offline through the P25 chain
+  gophertrunk replay [flags]          decode a raw IQ capture file offline (any protocol)
+  gophertrunk analyze [flags]         decode + analyze a capture with structured export (json/yaml/csv)
+  gophertrunk gen [flags]             synthesize a test IQ capture + metadata for a protocol
+  gophertrunk test [flags]            decode a capture and grade it against acceptance criteria
+  gophertrunk siglab [flags]          standalone replay/test/analysis TUI
   gophertrunk import-pdf [flags]      import a RadioReference PDF into config.yaml
   gophertrunk version                 print build version
   gophertrunk help                    show this message`)

--- a/cmd/gophertrunk/replay.go
+++ b/cmd/gophertrunk/replay.go
@@ -152,6 +152,20 @@ FLAGS:`)
 		rep.Fatalf(2, "-nid-search-span must be > 0")
 	}
 
+	// replay keeps three native deep-diagnostic paths (p25p1, dmr-tier3,
+	// dmr-tier2) with their receiver-state + soft-eye instrumentation. Every
+	// other protocol GopherTrunk decodes routes through the shared siglab
+	// engine, so `replay -protocol <any>` works across all 13 protocols
+	// while the headline P25/DMR debugging depth is preserved here.
+	switch protocol {
+	case "p25p1", "dmr-tier3", "dmr-tier2":
+		// fall through to the native paths below
+	default:
+		runReplayViaSiglab(protocol, *in, *format, *sampleRate, uint32(*freq),
+			*tuneHzFlag, *autoTune, *conjugate, *iqCorrect, *diag, rep)
+		return
+	}
+
 	decode, bytesPerSample, err := pickSampleDecoder(*format)
 	if err != nil {
 		rep.Fatal(2, err)

--- a/cmd/gophertrunk/replay_siglab.go
+++ b/cmd/gophertrunk/replay_siglab.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"os"
+
+	"github.com/MattCheramie/GopherTrunk/internal/diag"
+	"github.com/MattCheramie/GopherTrunk/internal/siglab"
+)
+
+// runReplayViaSiglab handles `replay` for every protocol beyond the three
+// native deep-diagnostic paths, driving the shared siglab engine and
+// rendering the same human-readable summary `analyze` uses. It is what lets
+// `gophertrunk replay -protocol tetra|nxdn|edacs|…` work without duplicating
+// the engine in the replay command.
+func runReplayViaSiglab(protocolName, in, format string, sampleRateHz float64, freqHz uint32, tuneHz float64, autoTune, conjugate, iqCorrect, collectDiag bool, rep *diag.Reporter) {
+	proto, err := siglab.ParseProtocolCLI(protocolName)
+	if err != nil {
+		rep.Fatal(2, err)
+	}
+	sampleFormat, err := siglab.ParseSampleFormat(format)
+	if err != nil {
+		rep.Fatal(2, err)
+	}
+	if in == "" {
+		rep.Fatalf(2, "-in is required")
+	}
+
+	res, err := siglab.Run(in, siglab.Config{
+		Protocol:      proto,
+		SystemName:    "replay",
+		FrequencyHz:   freqHz,
+		SampleRateHz:  sampleRateHz,
+		Format:        sampleFormat,
+		TuneHz:        tuneHz,
+		AutoTune:      autoTune,
+		Conjugate:     conjugate,
+		IQCorrect:     iqCorrect,
+		CollectIQDiag: collectDiag,
+	})
+	if err != nil {
+		rep.Fatal(1, err)
+	}
+	renderResultText(os.Stdout, res)
+}

--- a/cmd/gophertrunk/siglab_render.go
+++ b/cmd/gophertrunk/siglab_render.go
@@ -1,0 +1,147 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"sort"
+
+	"github.com/MattCheramie/GopherTrunk/internal/siglab"
+)
+
+// renderResultText writes a human-readable summary of a siglab.Result to w —
+// the shared text rendering for `analyze`, `test`, and `replay`'s
+// non-native-protocol path. It mirrors the layout of the historical replay
+// EOF summary so operator muscle memory carries over, while covering every
+// protocol uniformly off the structured model.
+func renderResultText(w io.Writer, r *siglab.Result) {
+	fmt.Fprintln(w, "----")
+	fmt.Fprintf(w, "siglab: %s — %s — %d samples (%.2fs at %.0f Hz), %d symbols emitted\n",
+		r.Source, r.Protocol, r.TotalSamples, r.DurationSec, r.SampleRateHz, r.Symbols)
+	if r.PipelineRateHz != r.SampleRateHz {
+		fmt.Fprintf(w, "siglab: ddc enabled  pipeline_rate_hz=%.0f  tune_hz=%.1f\n", r.PipelineRateHz, r.TuneHz)
+	}
+
+	if r.ExpectedBaud > 0 && r.EffectiveBaud > 0 {
+		warning := ""
+		if abs(r.BaudDeviationPct) > 2 {
+			warning = "  (>2% — capture sample rate may not match -sample-rate)"
+		}
+		fmt.Fprintf(w, "siglab: effective baud %.1f (expected %.0f, deviation %+.1f%%)%s\n",
+			r.EffectiveBaud, r.ExpectedBaud, r.BaudDeviationPct, warning)
+	}
+
+	if r.Locked {
+		fmt.Fprintf(w, "siglab: LOCKED  freq=%d  latency=%.2fs", lockFreq(r), r.LockLatencySec)
+		for _, k := range sortedKeys(lockFields(r)) {
+			fmt.Fprintf(w, "  %s=%v", k, lockFields(r)[k])
+		}
+		fmt.Fprintln(w)
+	} else {
+		fmt.Fprintln(w, "siglab: did NOT lock the control channel")
+	}
+
+	if len(r.Grants) > 0 {
+		freqs := map[uint32]struct{}{}
+		for _, g := range r.Grants {
+			freqs[g.FrequencyHz] = struct{}{}
+		}
+		fmt.Fprintf(w, "siglab: %d grant(s) across %d frequencies\n", len(r.Grants), len(freqs))
+	}
+
+	if len(r.DecodeErrors) > 0 {
+		fmt.Fprint(w, "siglab: decode errors:")
+		for _, stage := range siglab.SortedDecodeErrors(r.DecodeErrors) {
+			fmt.Fprintf(w, " %s=%d", stage, r.DecodeErrors[stage])
+		}
+		fmt.Fprintln(w)
+	}
+
+	if r.Signal != nil {
+		renderSignal(w, r.Signal)
+	}
+	if r.P25P1 != nil {
+		renderP25Detail(w, r.P25P1)
+	}
+	if r.Verdict != nil {
+		renderVerdict(w, r.Verdict)
+	}
+}
+
+func renderSignal(w io.Writer, s *siglab.SignalQuality) {
+	fmt.Fprintf(w, "siglab: signal  symbols=%d  cardinality=%d\n", sumInt64(s.SymbolHistogram), s.SymbolCardinality)
+	for i, n := range s.SymbolHistogram {
+		pct := 0.0
+		if i < len(s.SymbolHistogramPct) {
+			pct = s.SymbolHistogramPct[i]
+		}
+		fmt.Fprintf(w, "siglab:   symbol %d: %d (%.1f%%)\n", i, n, pct)
+	}
+	if s.IQObserved {
+		fmt.Fprintf(w, "siglab: raw IQ imbalance: gain=%+.3f dB  phase=%+.3f°  image_rejection=%.1f dB\n",
+			s.IQGainImbalanceDB, s.IQPhaseImbalanceDeg, s.IQImageRejectionDB)
+	}
+	fmt.Fprintf(w, "siglab: decode-error rate: %.2f per 1000 symbols\n", s.DecodeErrorRate)
+}
+
+func renderP25Detail(w io.Writer, d *siglab.P25P1Detail) {
+	fmt.Fprintf(w, "siglab: p25 detail  dibits=%d  winning_rotation=%d  hits=%d\n",
+		d.DibitsBuffered, d.WinningRotation, d.WinningHits)
+	fmt.Fprintf(w, "siglab:   dibit histogram: %d/%d/%d/%d\n",
+		d.DibitHistogram[0], d.DibitHistogram[1], d.DibitHistogram[2], d.DibitHistogram[3])
+	for rot := 0; rot < 4; rot++ {
+		rs := d.Rotations[rot]
+		fmt.Fprintf(w, "siglab:   rot %d: best_dist=%d (@%d) hits≤4=%d\n", rot, rs.BestDist, rs.BestPos, rs.Hits)
+	}
+	for _, nd := range d.NIDDecodes {
+		fmt.Fprintf(w, "siglab:   nid@%d errs=%d nac=%#x duid=%d ok=%v\n", nd.Pos, nd.Errs, nd.NAC, nd.DUID, nd.OK)
+	}
+}
+
+func renderVerdict(w io.Writer, v *siglab.Verdict) {
+	status := "PASS"
+	if !v.Pass {
+		status = "FAIL"
+	}
+	fmt.Fprintf(w, "siglab: verdict = %s\n", status)
+	for _, c := range v.Checks {
+		fmt.Fprintf(w, "siglab:   %s\n", c)
+	}
+}
+
+func lockFreq(r *siglab.Result) uint32 {
+	if r.Lock == nil {
+		return 0
+	}
+	return r.Lock.FrequencyHz
+}
+
+func lockFields(r *siglab.Result) map[string]any {
+	if r.Lock == nil {
+		return nil
+	}
+	return r.Lock.Fields
+}
+
+func sortedKeys(m map[string]any) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func sumInt64(v []int64) int64 {
+	var t int64
+	for _, n := range v {
+		t += n
+	}
+	return t
+}
+
+func abs(f float64) float64 {
+	if f < 0 {
+		return -f
+	}
+	return f
+}

--- a/cmd/gophertrunk/siglab_tui.go
+++ b/cmd/gophertrunk/siglab_tui.go
@@ -1,0 +1,365 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/MattCheramie/GopherTrunk/internal/scanner/ccdecoder"
+	"github.com/MattCheramie/GopherTrunk/internal/siglab"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+	"github.com/charmbracelet/bubbles/viewport"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// runSiglabTUI is the entry point for `gophertrunk siglab` — a standalone
+// (no-daemon) replay/test/analysis terminal UI. It picks a protocol, runs
+// the siglab engine against a capture file, streams live decode events, and
+// shows a signal-quality dashboard with one-key structured export. It is a
+// self-contained bubbletea app (modeled on import_tui.go), not wired into
+// the daemon operator TUI, because it runs entirely offline against a file.
+func runSiglabTUI(args []string) {
+	fs := flag.NewFlagSet("siglab", flag.ExitOnError)
+	verboseFlag := fs.Bool("verbose-errors", false, "print full error chain + stack on failures")
+	in := fs.String("in", "", "raw IQ capture file (required)")
+	format := fs.String("format", "f32", "sample format: u8 | f32")
+	sampleRate := fs.Float64("sample-rate", 2_400_000, "IQ sample rate in Hz")
+	protocolFlag := fs.String("protocol", "", "protocol to decode (empty ⇒ pick in the TUI)")
+	freq := fs.Uint64("freq", 0, "informational: the capture's nominal centre frequency in Hz")
+	autoTune := fs.Bool("auto-tune", false, "estimate the carrier offset and tune to 0 Hz before demod")
+	fs.Usage = func() {
+		fmt.Fprintln(fs.Output(), `gophertrunk siglab — standalone replay/test/analysis TUI.
+
+USAGE:
+  gophertrunk siglab -in <path> [-protocol <p>] [-format u8|f32] [-sample-rate Hz]
+
+Pick a protocol (if not given), run the decode, watch live events, view the
+signal-quality dashboard, and press e to export a JSON report.
+
+FLAGS:`)
+		fs.PrintDefaults()
+	}
+	_ = fs.Parse(args)
+	resolveVerbose(*verboseFlag, false)
+	rep := newReporter("siglab")
+
+	if *in == "" {
+		fs.Usage()
+		rep.Fatalf(2, "-in is required")
+	}
+	sampleFormat, err := siglab.ParseSampleFormat(*format)
+	if err != nil {
+		rep.Fatal(2, err)
+	}
+	var preProto trunking.Protocol
+	havePreProto := false
+	if *protocolFlag != "" {
+		p, perr := siglab.ParseProtocolCLI(*protocolFlag)
+		if perr != nil {
+			rep.Fatal(2, perr)
+		}
+		preProto = p
+		havePreProto = true
+	}
+
+	m := newSiglabTUI(*in, sampleFormat, *sampleRate, uint32(*freq), *autoTune, preProto, havePreProto)
+	if _, err := tea.NewProgram(m, tea.WithAltScreen()).Run(); err != nil {
+		rep.Fatal(1, fmt.Errorf("tui: %w", err))
+	}
+}
+
+type siglabView int
+
+const (
+	siglabPickProtocol siglabView = iota
+	siglabRunning
+	siglabDashboard
+)
+
+// siglabEventMsg / siglabDoneMsg carry engine progress back into the bubbletea
+// event loop from the worker goroutine.
+type siglabEventMsg siglab.EventRecord
+type siglabDoneMsg struct {
+	res *siglab.Result
+	err error
+}
+
+type siglabTUIModel struct {
+	// inputs
+	capture    string
+	format     siglab.SampleFormat
+	sampleRate float64
+	freqHz     uint32
+	autoTune   bool
+
+	// protocol selection
+	protos   []trunking.Protocol
+	cursor   int
+	protocol trunking.Protocol
+
+	view   siglabView
+	events []string
+	vp     viewport.Model
+	result *siglab.Result
+	runErr error
+	status string
+	width  int
+	height int
+
+	// eventCh is fed by the worker goroutine; waitEvent pumps it into Update.
+	eventCh chan siglab.EventRecord
+	doneCh  chan siglabDoneMsg
+}
+
+func newSiglabTUI(capture string, format siglab.SampleFormat, sampleRate float64, freqHz uint32, autoTune bool, proto trunking.Protocol, havePreProto bool) siglabTUIModel {
+	m := siglabTUIModel{
+		capture:    capture,
+		format:     format,
+		sampleRate: sampleRate,
+		freqHz:     freqHz,
+		autoTune:   autoTune,
+		protos:     ccdecoder.RegisteredProtocols(),
+		vp:         viewport.New(80, 16),
+		eventCh:    make(chan siglab.EventRecord, 256),
+		doneCh:     make(chan siglabDoneMsg, 1),
+	}
+	if havePreProto {
+		m.protocol = proto
+		m.view = siglabRunning
+	}
+	return m
+}
+
+func (m siglabTUIModel) Init() tea.Cmd {
+	if m.view == siglabRunning {
+		return tea.Batch(m.startRun(), m.waitEvent())
+	}
+	return nil
+}
+
+// startRun launches the engine in a goroutine, feeding EventRecords to
+// eventCh and the final Result to doneCh.
+func (m siglabTUIModel) startRun() tea.Cmd {
+	cfg := siglab.Config{
+		Protocol:      m.protocol,
+		SystemName:    "siglab",
+		FrequencyHz:   m.freqHz,
+		SampleRateHz:  m.sampleRate,
+		Format:        m.format,
+		AutoTune:      m.autoTune,
+		CollectIQDiag: true,
+	}
+	capture := m.capture
+	eventCh := m.eventCh
+	doneCh := m.doneCh
+	return func() tea.Msg {
+		go func() {
+			res, err := siglab.RunStream(capture, cfg, func(ev siglab.EventRecord) {
+				select {
+				case eventCh <- ev:
+				default: // drop on a slow UI rather than block the engine
+				}
+			})
+			doneCh <- siglabDoneMsg{res: res, err: err}
+		}()
+		return nil
+	}
+}
+
+// waitEvent blocks on the event/done channels and turns the next signal into
+// a bubbletea message, re-arming itself until the run completes.
+func (m siglabTUIModel) waitEvent() tea.Cmd {
+	eventCh := m.eventCh
+	doneCh := m.doneCh
+	return func() tea.Msg {
+		select {
+		case ev := <-eventCh:
+			return siglabEventMsg(ev)
+		case done := <-doneCh:
+			return done
+		}
+	}
+}
+
+func (m siglabTUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		m.vp.Width = msg.Width - 2
+		if msg.Height > 12 {
+			m.vp.Height = msg.Height - 10
+		}
+		return m, nil
+
+	case tea.KeyMsg:
+		return m.handleKey(msg)
+
+	case siglabEventMsg:
+		m.events = append(m.events, fmt.Sprintf("%7.2fs  %-16s %s", msg.OffsetSec, msg.Kind, briefFields(siglab.EventRecord(msg))))
+		m.vp.SetContent(strings.Join(m.events, "\n"))
+		m.vp.GotoBottom()
+		return m, m.waitEvent()
+
+	case siglabDoneMsg:
+		m.result = msg.res
+		m.runErr = msg.err
+		m.view = siglabDashboard
+		if msg.err != nil {
+			m.status = "run failed: " + msg.err.Error()
+		} else {
+			m.status = "decode complete — e: export JSON   q: quit"
+		}
+		return m, nil
+	}
+	return m, nil
+}
+
+func (m siglabTUIModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "ctrl+c", "q":
+		return m, tea.Quit
+	}
+	switch m.view {
+	case siglabPickProtocol:
+		switch msg.String() {
+		case "up", "k":
+			if m.cursor > 0 {
+				m.cursor--
+			}
+		case "down", "j":
+			if m.cursor < len(m.protos)-1 {
+				m.cursor++
+			}
+		case "enter":
+			if len(m.protos) > 0 {
+				m.protocol = m.protos[m.cursor]
+				m.view = siglabRunning
+				return m, tea.Batch(m.startRun(), m.waitEvent())
+			}
+		}
+	case siglabDashboard:
+		if msg.String() == "e" && m.result != nil {
+			m.status = m.exportJSON()
+		}
+	}
+	return m, nil
+}
+
+func (m siglabTUIModel) exportJSON() string {
+	path := strings.TrimSuffix(m.capture, ext(m.capture)) + ".siglab.json"
+	f, err := os.Create(path)
+	if err != nil {
+		return "export failed: " + err.Error()
+	}
+	defer f.Close()
+	if err := siglab.WriteResult(f, m.result, siglab.FormatJSON); err != nil {
+		return "export failed: " + err.Error()
+	}
+	return "exported → " + path
+}
+
+var (
+	siglabTitle  = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("12"))
+	siglabAccent = lipgloss.NewStyle().Foreground(lipgloss.Color("10"))
+	siglabDim    = lipgloss.NewStyle().Foreground(lipgloss.Color("8"))
+	siglabSelect = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("0")).Background(lipgloss.Color("12"))
+)
+
+func (m siglabTUIModel) View() string {
+	switch m.view {
+	case siglabPickProtocol:
+		return m.viewPick()
+	case siglabRunning:
+		return m.viewRunning()
+	default:
+		return m.viewDashboard()
+	}
+}
+
+func (m siglabTUIModel) viewPick() string {
+	var b strings.Builder
+	b.WriteString(siglabTitle.Render("GopherTrunk Signal Lab") + "  " + siglabDim.Render(m.capture) + "\n\n")
+	b.WriteString("Select a protocol to decode:\n\n")
+	for i, p := range m.protos {
+		line := "  " + p.String()
+		if i == m.cursor {
+			line = siglabSelect.Render("▸ " + p.String())
+		}
+		b.WriteString(line + "\n")
+	}
+	b.WriteString("\n" + siglabDim.Render("↑/↓ move   enter run   q quit"))
+	return b.String()
+}
+
+func (m siglabTUIModel) viewRunning() string {
+	var b strings.Builder
+	b.WriteString(siglabTitle.Render("Decoding "+m.protocol.String()) + "  " + siglabDim.Render(m.capture) + "\n\n")
+	b.WriteString(m.vp.View())
+	b.WriteString("\n" + siglabDim.Render(fmt.Sprintf("%d events   q quit", len(m.events))))
+	return b.String()
+}
+
+func (m siglabTUIModel) viewDashboard() string {
+	var b strings.Builder
+	b.WriteString(siglabTitle.Render("Signal Lab — Results") + "\n\n")
+	if m.runErr != nil {
+		b.WriteString(lipgloss.NewStyle().Foreground(lipgloss.Color("9")).Render(m.status) + "\n")
+		return b.String()
+	}
+	r := m.result
+	lockStr := "NOT LOCKED"
+	if r.Locked {
+		lockStr = siglabAccent.Render(fmt.Sprintf("LOCKED @ %d Hz (%.2fs)", lockFreq(r), r.LockLatencySec))
+	}
+	b.WriteString(fmt.Sprintf("Protocol:   %s\n", r.Protocol))
+	b.WriteString(fmt.Sprintf("Samples:    %d (%.2fs @ %.0f Hz)\n", r.TotalSamples, r.DurationSec, r.SampleRateHz))
+	b.WriteString(fmt.Sprintf("Symbols:    %d   effective baud %.1f (expected %.0f, %+.1f%%)\n",
+		r.Symbols, r.EffectiveBaud, r.ExpectedBaud, r.BaudDeviationPct))
+	b.WriteString(fmt.Sprintf("Lock:       %s\n", lockStr))
+	b.WriteString(fmt.Sprintf("Grants:     %d\n", len(r.Grants)))
+	if r.Signal != nil {
+		b.WriteString("\n" + siglabTitle.Render("Symbol histogram") + "\n")
+		for i := range r.Signal.SymbolHistogram {
+			pct := 0.0
+			if i < len(r.Signal.SymbolHistogramPct) {
+				pct = r.Signal.SymbolHistogramPct[i]
+			}
+			b.WriteString(fmt.Sprintf("  %d  %s %.1f%%\n", i, bar(pct), pct))
+		}
+		if r.Signal.IQObserved {
+			b.WriteString(fmt.Sprintf("\nIQ imbalance: gain %+.2f dB  phase %+.2f°  image rej %.1f dB\n",
+				r.Signal.IQGainImbalanceDB, r.Signal.IQPhaseImbalanceDeg, r.Signal.IQImageRejectionDB))
+		}
+		b.WriteString(fmt.Sprintf("Decode-error rate: %.2f / 1000 symbols\n", r.Signal.DecodeErrorRate))
+	}
+	b.WriteString("\n" + siglabDim.Render(m.status))
+	return b.String()
+}
+
+// bar renders a small percentage bar (0..100%) for the dashboard histogram.
+func bar(pct float64) string {
+	const width = 24
+	n := int(pct / 100 * width)
+	if n < 0 {
+		n = 0
+	}
+	if n > width {
+		n = width
+	}
+	return siglabAccent.Render(strings.Repeat("█", n)) + siglabDim.Render(strings.Repeat("·", width-n))
+}
+
+// briefFields renders a compact one-line view of an event's salient fields
+// for the live log.
+func briefFields(ev siglab.EventRecord) string {
+	var parts []string
+	for _, k := range []string{"NAC", "ColorCode", "SystemID", "FrequencyHz", "GroupID", "SourceID", "Stage"} {
+		if v, ok := ev.Fields[k]; ok {
+			parts = append(parts, fmt.Sprintf("%s=%v", k, v))
+		}
+	}
+	return strings.Join(parts, " ")
+}

--- a/cmd/gophertrunk/test.go
+++ b/cmd/gophertrunk/test.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/MattCheramie/GopherTrunk/internal/siglab"
+)
+
+// runSiglabTest is the entry point for `gophertrunk test`. It feeds a capture
+// (real-air or `gen`-synthesized) through the production pipeline described by
+// its metadata sidecar, grades the decode against the metadata's acceptance
+// criteria, and prints a pass/fail report. Exit code is 0 on pass, 1 on
+// fail — so it slots straight into CI as a regression gate over a corpus of
+// captures.
+func runSiglabTest(args []string) {
+	fs := flag.NewFlagSet("test", flag.ExitOnError)
+	verboseFlag := fs.Bool("verbose-errors", false, "print full error chain + stack on failures")
+	capture := fs.String("capture", "", "capture file to validate (required)")
+	metaPath := fs.String("meta", "", "metadata sidecar (default: auto-discovered by capture stem)")
+	outFormat := fs.String("out-format", "text", "report format: text | json | yaml")
+	out := fs.String("out", "", "write the report to this file (default: stdout)")
+	fs.Usage = func() {
+		fmt.Fprintln(fs.Output(), `gophertrunk test — decode a capture and grade it against acceptance criteria.
+
+USAGE:
+  gophertrunk test -capture <path> [-meta <path>] [-out-format text|json|yaml]
+
+EXAMPLES:
+  # Validate a gen-produced capture (metadata auto-discovered)
+  gophertrunk test -capture p25.cfile
+
+  # Validate a real-air capture with an explicit metadata file, JSON report
+  gophertrunk test -capture samples/dmr/site.cfile -meta samples/dmr/site.metadata.yaml -out-format json
+
+FLAGS:`)
+		fs.PrintDefaults()
+	}
+	_ = fs.Parse(args)
+	resolveVerbose(*verboseFlag, false)
+	rep := newReporter("test")
+
+	if *capture == "" {
+		fs.Usage()
+		rep.Fatalf(2, "-capture is required")
+	}
+	mp := *metaPath
+	if mp == "" {
+		mp = siglab.DiscoverMetadata(*capture)
+		if mp == "" {
+			rep.Fatalf(2, "no metadata found for %s (pass -meta or add a <stem>.metadata.json sidecar)", *capture)
+		}
+	}
+	meta, err := siglab.LoadMetadata(mp)
+	if err != nil {
+		rep.Fatal(2, err)
+	}
+	cfg, err := meta.Config(true)
+	if err != nil {
+		rep.Fatal(2, err)
+	}
+
+	res, err := siglab.Run(*capture, cfg)
+	if err != nil {
+		rep.Fatal(1, err)
+	}
+
+	of := siglab.FormatTextSummary
+	switch *outFormat {
+	case "json":
+		of = siglab.FormatJSON
+	case "yaml", "yml":
+		of = siglab.FormatYAML
+	case "text", "":
+		of = siglab.FormatTextSummary
+	default:
+		rep.Fatalf(2, "unknown -out-format %q (want text|json|yaml)", *outFormat)
+	}
+	if err := emitResult(res, of, *out); err != nil {
+		rep.Fatal(1, err)
+	}
+
+	// Exit non-zero on a failing verdict so CI can gate on it.
+	if res.Verdict != nil && !res.Verdict.Pass {
+		os.Exit(1)
+	}
+}

--- a/internal/scanner/ccdecoder/ddc.go
+++ b/internal/scanner/ccdecoder/ddc.go
@@ -49,6 +49,17 @@ func ddcTargetForProtocol(p trunking.Protocol) float64 {
 	return ddcTargetRateHz
 }
 
+// DDCTargetForProtocol is the exported wrapper over ddcTargetForProtocol.
+// The offline siglab toolkit (and the replay subcommand) call it to size
+// their own Downconverter to the SAME per-protocol channel rate the daemon
+// uses — critical for TETRA, whose 18000-baud π/4-DQPSK needs the 144 kHz
+// target rather than the 48 kHz C4FM-family default. Sizing replay's DDC
+// to the C4FM target for a TETRA capture would leave under 3 samples per
+// symbol and the Gardner loop would never lock.
+func DDCTargetForProtocol(p trunking.Protocol) float64 {
+	return ddcTargetForProtocol(p)
+}
+
 // ddcStopbandTaps sets the anti-alias prototype length as a multiple
 // of the decimation factor M (total taps ≈ ddcStopbandTaps·M). The
 // polyphase resampler runs its multiply-accumulates at the output

--- a/internal/scanner/ccdecoder/pipelines.go
+++ b/internal/scanner/ccdecoder/pipelines.go
@@ -2,6 +2,7 @@ package ccdecoder
 
 import (
 	"log/slog"
+	"sort"
 
 	"github.com/MattCheramie/GopherTrunk/internal/events"
 	"github.com/MattCheramie/GopherTrunk/internal/radio/dmr"
@@ -63,6 +64,34 @@ type PipelineOptions struct {
 	FrequencyHz  uint32
 	SampleRateHz float64
 	System       trunking.System
+
+	// SymbolTap, when non-nil, is invoked with every chunk of recovered
+	// symbols a pipeline's receiver emits, just before they enter the
+	// control-channel state machine. symbols holds dibits (values 0..3,
+	// isBits=false) for the 4-level protocols and bits (values 0..1,
+	// isBits=true) for the 2-level protocols; baseIdx is the absolute
+	// symbol index the chunk starts at. It is a pure observation hook —
+	// production never sets it. The offline siglab toolkit uses it to
+	// count symbols and feed its protocol-agnostic signal-quality
+	// analyzer for *every* protocol, without re-duplicating receiver
+	// construction outside this factory. nil ⇒ zero overhead.
+	SymbolTap func(symbols []uint8, isBits bool, baseIdx int)
+}
+
+// tapDibits / tapBits forward a recovered-symbol chunk to SymbolTap when
+// one is wired, normalising the dibit ([]uint8) and bit ([]byte) sink
+// shapes onto the single SymbolTap signature. byte and uint8 are the same
+// underlying type, so the bit slice passes through without a copy.
+func (o PipelineOptions) tapDibits(dibits []uint8, baseIdx int) {
+	if o.SymbolTap != nil {
+		o.SymbolTap(dibits, false, baseIdx)
+	}
+}
+
+func (o PipelineOptions) tapBits(bits []byte, baseIdx int) {
+	if o.SymbolTap != nil {
+		o.SymbolTap(bits, true, baseIdx)
+	}
 }
 
 // PipelineFactory constructs a fresh ProtocolPipeline for one tuned
@@ -112,6 +141,43 @@ func SetTestFactory(protocol trunking.Protocol, f PipelineFactory) (restore func
 			delete(factories, protocol)
 		}
 	}
+}
+
+// NewPipeline constructs the registered pipeline for protocol p with the
+// given options. ok is false (and the pipeline nil) when no factory is
+// registered for p — callers should treat that as "this protocol cannot
+// be driven offline yet" rather than an error. err propagates a factory's
+// own construction failure (e.g. incomplete per-system wiring).
+//
+// This is the out-of-package entry point the offline siglab toolkit uses
+// to drive any protocol through the same production pipelines the daemon
+// runs; the daemon itself keeps using the internal factory map directly.
+func NewPipeline(p trunking.Protocol, opts PipelineOptions) (pipe ProtocolPipeline, ok bool, err error) {
+	f, ok := factories[p]
+	if !ok {
+		return nil, false, nil
+	}
+	pipe, err = f(opts)
+	return pipe, true, err
+}
+
+// HasFactory reports whether a pipeline factory is registered for p.
+func HasFactory(p trunking.Protocol) bool {
+	_, ok := factories[p]
+	return ok
+}
+
+// RegisteredProtocols returns the protocols with a registered pipeline
+// factory, in a stable (ascending Protocol-value) order so callers — the
+// siglab TUI's protocol picker, a gen→test sweep — render a deterministic
+// list.
+func RegisteredProtocols() []trunking.Protocol {
+	out := make([]trunking.Protocol, 0, len(factories))
+	for p := range factories {
+		out = append(out, p)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	return out
 }
 
 var factories = map[trunking.Protocol]PipelineFactory{
@@ -241,6 +307,7 @@ func newP25Phase1Pipeline(opts PipelineOptions) (ProtocolPipeline, error) {
 		// it and was a net regression on the issue #402 capture; keep
 		// it off here until the eye-skew root cause is pinned.
 		DibitSink: func(dibits []uint8, baseIdx int) {
+			opts.tapDibits(dibits, baseIdx)
 			cc.Process(dibits, baseIdx)
 		},
 	})
@@ -362,6 +429,7 @@ func newP25Phase2Pipeline(opts PipelineOptions) (ProtocolPipeline, error) {
 	rx := p25phase2rx.New(p25phase2rx.Options{
 		SampleRateHz: opts.SampleRateHz,
 		DibitSink: func(dibits []uint8, baseIdx int) {
+			opts.tapDibits(dibits, baseIdx)
 			for _, sf := range sfDec.Process(dibits, baseIdx) {
 				cc.IngestSuperframe(sf)
 			}
@@ -446,6 +514,7 @@ func newTETRAPipeline(opts PipelineOptions) (ProtocolPipeline, error) {
 	rx := tetrarx.New(tetrarx.Options{
 		SampleRateHz: opts.SampleRateHz,
 		DibitSink: func(dibits []uint8, baseIdx int) {
+			opts.tapDibits(dibits, baseIdx)
 			cc.Process(dibits, baseIdx)
 		},
 		ClockMode: tetraClockMode,
@@ -489,6 +558,7 @@ func newYSFPipeline(opts PipelineOptions) (ProtocolPipeline, error) {
 		// captures slice correctly out of the box.
 		DeviationHz: 1800.0,
 		DibitSink: func(dibits []uint8, baseIdx int) {
+			opts.tapDibits(dibits, baseIdx)
 			cc.Process(dibits, baseIdx)
 		},
 	})
@@ -525,6 +595,7 @@ func newDPMRPipeline(opts PipelineOptions) (ProtocolPipeline, error) {
 		// level so live captures slice correctly.
 		DeviationHz: 900.0,
 		DibitSink: func(dibits []uint8, baseIdx int) {
+			opts.tapDibits(dibits, baseIdx)
 			cc.Process(dibits, baseIdx)
 		},
 	})
@@ -574,6 +645,7 @@ func newDMRTier3Pipeline(opts PipelineOptions) (ProtocolPipeline, error) {
 		// live captures.
 		ClockGain: 0.025,
 		DibitSink: func(dibits []uint8, baseIdx int) {
+			opts.tapDibits(dibits, baseIdx)
 			cc.Process(dibits, baseIdx)
 		},
 	})
@@ -632,6 +704,7 @@ func newDMRTier2Pipeline(opts PipelineOptions) (ProtocolPipeline, error) {
 		// margin per the MM stability bound.
 		ClockGain: 0.015,
 		DibitSink: func(dibits []uint8, baseIdx int) {
+			opts.tapDibits(dibits, baseIdx)
 			cc.Process(dibits, baseIdx)
 		},
 	})
@@ -677,6 +750,7 @@ func newNXDNPipeline(opts PipelineOptions) (ProtocolPipeline, error) {
 		SampleRateHz: opts.SampleRateHz,
 		DeviationHz:  deviationHz,
 		DibitSink: func(dibits []uint8, baseIdx int) {
+			opts.tapDibits(dibits, baseIdx)
 			cc.Process(dibits, baseIdx)
 		},
 	})
@@ -716,6 +790,7 @@ func newEDACSPipeline(opts PipelineOptions) (ProtocolPipeline, error) {
 	rx := edacsrx.New(edacsrx.Options{
 		SampleRateHz: opts.SampleRateHz,
 		BitSink: func(bits []byte, baseIdx int) {
+			opts.tapBits(bits, baseIdx)
 			cc.Process(bits, baseIdx)
 		},
 	})
@@ -760,6 +835,7 @@ func newMotorolaPipeline(opts PipelineOptions) (ProtocolPipeline, error) {
 	rx := motorolarx.New(motorolarx.Options{
 		SampleRateHz: opts.SampleRateHz,
 		BitSink: func(bits []byte, baseIdx int) {
+			opts.tapBits(bits, baseIdx)
 			cc.Process(bits, baseIdx)
 		},
 	})
@@ -814,6 +890,7 @@ func newLTRPipeline(opts PipelineOptions) (ProtocolPipeline, error) {
 	rx := ltrrx.New(ltrrx.Options{
 		SampleRateHz: opts.SampleRateHz,
 		BitSink: func(bits []byte, baseIdx int) {
+			opts.tapBits(bits, baseIdx)
 			cc.Process(bits, baseIdx)
 		},
 	})
@@ -860,6 +937,7 @@ func newMPT1327Pipeline(opts PipelineOptions) (ProtocolPipeline, error) {
 	rx := mpt1327rx.New(mpt1327rx.Options{
 		SampleRateHz: opts.SampleRateHz,
 		BitSink: func(bits []byte, baseIdx int) {
+			opts.tapBits(bits, baseIdx)
 			cc.Process(bits, baseIdx)
 		},
 	})
@@ -907,6 +985,7 @@ func newDStarPipeline(opts PipelineOptions) (ProtocolPipeline, error) {
 	rx := dstarrx.New(dstarrx.Options{
 		SampleRateHz: opts.SampleRateHz,
 		BitSink: func(bits []byte, baseIdx int) {
+			opts.tapBits(bits, baseIdx)
 			cc.Process(bits, baseIdx)
 		},
 	})

--- a/internal/scanner/ccdecoder/pipelines_accessor_test.go
+++ b/internal/scanner/ccdecoder/pipelines_accessor_test.go
@@ -1,0 +1,141 @@
+package ccdecoder
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// discardLogger is a no-op logger the construction tests hand to factories
+// that warn-log on unrecognised (here: zero-valued) per-system config.
+func discardLogger() *slog.Logger { return slog.New(slog.DiscardHandler) }
+
+// TestRegisteredProtocolsConstruct asserts every protocol the factory map
+// advertises via RegisteredProtocols() can actually be constructed through
+// the public NewPipeline accessor — the contract the offline siglab toolkit
+// (and its protocol picker) relies on. A factory that errors on a minimal
+// PipelineOptions would silently drop that protocol from the toolkit; this
+// catches that at unit-test time.
+func TestRegisteredProtocolsConstruct(t *testing.T) {
+	bus := events.NewBus(16)
+	defer bus.Close()
+
+	protos := RegisteredProtocols()
+	if len(protos) == 0 {
+		t.Fatal("RegisteredProtocols returned no protocols")
+	}
+
+	for _, p := range protos {
+		if !HasFactory(p) {
+			t.Errorf("RegisteredProtocols listed %v but HasFactory is false", p)
+		}
+		pipe, ok, err := NewPipeline(p, PipelineOptions{
+			Bus:          bus,
+			Log:          discardLogger(),
+			SystemName:   "test",
+			FrequencyHz:  851_000_000,
+			SampleRateHz: DDCTargetForProtocol(p),
+		})
+		if !ok {
+			t.Errorf("NewPipeline(%v): ok=false for a registered protocol", p)
+			continue
+		}
+		if err != nil {
+			t.Errorf("NewPipeline(%v): %v", p, err)
+			continue
+		}
+		if pipe == nil {
+			t.Errorf("NewPipeline(%v): nil pipeline with nil error", p)
+			continue
+		}
+		// Reset + Close must be safe no-ops on a freshly built pipeline.
+		pipe.Reset()
+		if cerr := pipe.Close(); cerr != nil {
+			t.Errorf("Close(%v): %v", p, cerr)
+		}
+	}
+}
+
+// TestNewPipelineUnregistered confirms an unregistered protocol reports
+// ok=false (not an error) so callers can distinguish "not supported yet"
+// from "construction failed".
+func TestNewPipelineUnregistered(t *testing.T) {
+	pipe, ok, err := NewPipeline(trunking.ProtocolUnknown, PipelineOptions{})
+	if ok {
+		t.Fatal("expected ok=false for ProtocolUnknown")
+	}
+	if err != nil {
+		t.Fatalf("expected nil error for unregistered protocol, got %v", err)
+	}
+	if pipe != nil {
+		t.Fatal("expected nil pipeline for unregistered protocol")
+	}
+}
+
+// TestDDCTargetForProtocol pins the protocol-dependent channel rate the
+// siglab engine must size its down-converter to: TETRA needs the wide
+// 144 kHz target, everything else the 48 kHz C4FM-family default.
+func TestDDCTargetForProtocol(t *testing.T) {
+	if got := DDCTargetForProtocol(trunking.ProtocolTETRA); got != tetraDDCTargetRateHz {
+		t.Errorf("TETRA DDC target = %g, want %g", got, tetraDDCTargetRateHz)
+	}
+	for _, p := range []trunking.Protocol{
+		trunking.ProtocolP25, trunking.ProtocolDMR, trunking.ProtocolP25Phase2,
+		trunking.ProtocolNXDN, trunking.ProtocolYSF,
+	} {
+		if got := DDCTargetForProtocol(p); got != DDCTargetRateHz {
+			t.Errorf("%v DDC target = %g, want %g", p, got, DDCTargetRateHz)
+		}
+	}
+}
+
+// TestSymbolTapForwarding confirms a wired SymbolTap observes recovered
+// symbols for a representative dibit protocol (P25 P1) and a representative
+// bit protocol (EDACS) — the hook the analyzer depends on for every
+// protocol. It drives synthesized IQ through the real pipeline and asserts
+// the tap fired with the expected symbol cardinality flag.
+func TestSymbolTapForwarding(t *testing.T) {
+	cases := []struct {
+		name   string
+		proto  trunking.Protocol
+		isBits bool
+	}{
+		{"p25p1 dibits", trunking.ProtocolP25, false},
+		{"edacs bits", trunking.ProtocolEDACS, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			bus := events.NewBus(16)
+			defer bus.Close()
+
+			var taps int
+			var sawBits bool
+			pipe, ok, err := NewPipeline(tc.proto, PipelineOptions{
+				Bus:          bus,
+				Log:          discardLogger(),
+				SystemName:   "test",
+				SampleRateHz: DDCTargetForProtocol(tc.proto),
+				SymbolTap: func(symbols []uint8, isBits bool, baseIdx int) {
+					taps++
+					sawBits = isBits
+				},
+			})
+			if !ok || err != nil {
+				t.Fatalf("NewPipeline(%v): ok=%v err=%v", tc.proto, ok, err)
+			}
+			// Feed enough zero IQ to flush several symbol periods through
+			// the receiver's matched filter + clock loop. We only assert
+			// the tap mechanism fires, not a lock.
+			iq := make([]complex64, 48000)
+			pipe.Process(iq)
+			if taps == 0 {
+				t.Fatalf("SymbolTap never fired for %v", tc.proto)
+			}
+			if sawBits != tc.isBits {
+				t.Errorf("SymbolTap isBits = %v, want %v", sawBits, tc.isBits)
+			}
+		})
+	}
+}

--- a/internal/siglab/config.go
+++ b/internal/siglab/config.go
@@ -1,0 +1,124 @@
+package siglab
+
+import (
+	"log/slog"
+	"strings"
+
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// Config drives a single offline run of the engine over one capture (or a
+// synthesized stream). The zero value is not runnable — Protocol, a sample
+// source, and SampleRateHz must be set.
+type Config struct {
+	// Protocol selects the production pipeline to drive. Every protocol the
+	// ccdecoder factory map registers is supported.
+	Protocol trunking.Protocol
+	// System carries per-protocol knobs (demod mode, colour code, band
+	// plan, FEC modes, …) exactly as the daemon reads them off a configured
+	// trunking.System. SystemName/FrequencyHz are surfaced separately
+	// because every factory consumes them.
+	System      trunking.System
+	SystemName  string
+	FrequencyHz uint32
+
+	// SampleRateHz is the capture's IQ sample rate (input rate, before any
+	// down-conversion). Required.
+	SampleRateHz float64
+	// Format is the on-disk sample encoding.
+	Format SampleFormat
+
+	// TuneHz frequency-shifts the capture so a channel at +TuneHz lands at
+	// 0 Hz before demod. AutoTune estimates it from a prefix of the file
+	// (and overrides TuneHz when set).
+	TuneHz   float64
+	AutoTune bool
+
+	// Conjugate negates Q before channelization (spectrum-inverted /
+	// I-Q-swapped front-end, issue #264). IQCorrect applies blind
+	// I/Q-imbalance correction to the raw IQ before decimation (issue #402).
+	Conjugate bool
+	IQCorrect bool
+
+	// CollectIQDiag enables the protocol-agnostic signal-quality analyzer
+	// (symbol histogram, IQ imbalance, soft-sample distribution where
+	// available). Off by default since it buffers per-symbol observations.
+	CollectIQDiag bool
+
+	// ChunkSamples is the read-loop chunk size in IQ samples; 0 ⇒ default.
+	ChunkSamples int
+
+	// Acceptance, when non-nil, is evaluated against the Result to produce a
+	// pass/fail Verdict (the `test` harness sets it).
+	Acceptance *Acceptance
+
+	// Log receives the production pipeline's structured diagnostics. nil ⇒
+	// a discard logger (the engine never wants a nil *slog.Logger reaching a
+	// factory that does not nil-guard it).
+	Log *slog.Logger
+}
+
+const defaultChunkSamples = 8192
+
+func (c Config) logger() *slog.Logger {
+	if c.Log != nil {
+		return c.Log
+	}
+	return slog.New(slog.DiscardHandler)
+}
+
+func (c Config) chunkSamples() int {
+	if c.ChunkSamples > 0 {
+		return c.ChunkSamples
+	}
+	return defaultChunkSamples
+}
+
+// ParseProtocolCLI maps a command-line protocol name to a trunking.Protocol.
+// It first honours the legacy replay aliases ("p25p1" → P25 Phase 1,
+// "dmr-tier3" → DMR Tier III) so existing replay invocations keep working,
+// then falls back to the canonical trunking.ParseProtocol (which covers all
+// config spellings: p25, p25-phase2, dmr, dmr-tier2, nxdn, dpmr, edacs,
+// motorola, ltr, mpt1327, tetra, ysf, dstar).
+func ParseProtocolCLI(s string) (trunking.Protocol, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "p25p1", "p25-phase1", "p25_phase1":
+		return trunking.ProtocolP25, nil
+	case "dmr-tier3", "dmr_tier3", "dmr-t3", "dmrtier3", "tier3":
+		return trunking.ProtocolDMR, nil
+	}
+	return trunking.ParseProtocol(s)
+}
+
+// expectedSymbolRate returns the nominal recovered-symbol rate (dibits/s for
+// the 4-level protocols, bits/s for the 2-level ones) the receiver emits for
+// a protocol, used for the effective-baud self-diagnostic that flags a
+// mislabeled capture (a capture whose true sample rate differs from the one
+// the operator passed reports a symbol rate far from this value). Returns 0
+// when no nominal rate is pinned, in which case the deviation check is
+// skipped rather than reported against a guess.
+func expectedSymbolRate(p trunking.Protocol) float64 {
+	switch p {
+	case trunking.ProtocolP25, trunking.ProtocolDMR, trunking.ProtocolDMRTier2,
+		trunking.ProtocolNXDN, trunking.ProtocolYSF:
+		return 4800
+	case trunking.ProtocolP25Phase2:
+		return 6000
+	case trunking.ProtocolDPMR:
+		return 2400
+	case trunking.ProtocolTETRA:
+		return 18000
+	case trunking.ProtocolEDACS:
+		return 9600
+	case trunking.ProtocolMotorola:
+		return 3600
+	case trunking.ProtocolMPT1327:
+		return 1200
+	case trunking.ProtocolDStar:
+		return 4800
+	case trunking.ProtocolLTR:
+		return 300
+	default:
+		return 0
+	}
+}

--- a/internal/siglab/decode.go
+++ b/internal/siglab/decode.go
@@ -1,0 +1,93 @@
+// Package siglab is the offline signal replay / testing / analysis core
+// shared by the gophertrunk replay, analyze, gen, test and siglab-TUI
+// subcommands. It drives any protocol GopherTrunk can decode through the
+// same production receiver + control-channel pipelines the daemon runs
+// (via the ccdecoder factory map), collects a protocol-agnostic structured
+// Result, and exposes signal-quality analysis, synthesis, and a
+// metadata-driven acceptance harness on top of it.
+//
+// The engine deliberately mirrors the daemon's IQ → DDC → pipeline chain
+// so a replay lock implies an on-air lock and a replay failure makes the
+// offline capture a reproducible fixture (the same contract the original
+// replay subcommand established for P25 in issue #402).
+package siglab
+
+import (
+	"encoding/binary"
+	"fmt"
+	"math"
+	"strings"
+)
+
+// SampleFormat is the on-disk IQ encoding of a capture file.
+type SampleFormat int
+
+const (
+	// FormatU8 is rtl_sdr's 8-bit unsigned interleaved IQ.
+	FormatU8 SampleFormat = iota
+	// FormatF32 is GNU Radio's interleaved little-endian float32 cfile.
+	FormatF32
+)
+
+// String renders the format as the flag value operators type.
+func (f SampleFormat) String() string {
+	switch f {
+	case FormatF32:
+		return "f32"
+	default:
+		return "u8"
+	}
+}
+
+// ParseSampleFormat maps a -format flag value to a SampleFormat. It accepts
+// the same spellings the replay subcommand always has (u8, f32, plus the
+// float32/cfile aliases) so existing muscle memory keeps working.
+func ParseSampleFormat(s string) (SampleFormat, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "u8", "":
+		return FormatU8, nil
+	case "f32", "float32", "cfile":
+		return FormatF32, nil
+	default:
+		return FormatU8, fmt.Errorf("siglab: unknown sample format %q (want u8 or f32)", s)
+	}
+}
+
+// SampleDecoder converts a byte chunk to complex64 IQ in-place into out.
+type SampleDecoder func(buf []byte, out []complex64)
+
+// Decoder returns the sample decoder + bytes-per-IQ-pair for the format.
+// This is the shared replacement for replay.go's pickSampleDecoder /
+// decodeU8Replay / decodeF32Replay so the replay subcommand and the siglab
+// engine read captures through one implementation.
+func (f SampleFormat) Decoder() (SampleDecoder, int) {
+	switch f {
+	case FormatF32:
+		return decodeF32, 8
+	default:
+		return decodeU8, 2
+	}
+}
+
+// decodeU8 converts rtl_sdr 8-bit unsigned interleaved IQ to complex64 in
+// [-1, +1]. Mirrors the historical replay decodeU8Replay byte-for-byte.
+func decodeU8(buf []byte, out []complex64) {
+	n := len(buf) / 2
+	for i := 0; i < n; i++ {
+		ir := float32(buf[2*i]) - 127.5
+		qr := float32(buf[2*i+1]) - 127.5
+		out[i] = complex(ir/127.5, qr/127.5)
+	}
+}
+
+// decodeF32 converts an interleaved little-endian float32 GNU Radio cfile
+// to complex64. Matches the format gnuradio-companion emits on every
+// platform GopherTrunk supports.
+func decodeF32(buf []byte, out []complex64) {
+	n := len(buf) / 8
+	for i := 0; i < n; i++ {
+		ir := math.Float32frombits(binary.LittleEndian.Uint32(buf[8*i:]))
+		qr := math.Float32frombits(binary.LittleEndian.Uint32(buf[8*i+4:]))
+		out[i] = complex(ir, qr)
+	}
+}

--- a/internal/siglab/engine.go
+++ b/internal/siglab/engine.go
@@ -1,0 +1,247 @@
+package siglab
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/scanner/ccdecoder"
+	"github.com/MattCheramie/GopherTrunk/internal/sdr/rtlsdr"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// Run decodes the capture at path through the production pipeline for
+// cfg.Protocol and returns the structured Result. It is the batch entry
+// point behind the replay/analyze/test subcommands.
+func Run(path string, cfg Config) (*Result, error) {
+	return RunStream(path, cfg, nil)
+}
+
+// RunStream is Run with a live per-event sink: onEvent (when non-nil) is
+// called for every captured EventRecord as it is observed, in stream order.
+// It backs the JSONL exporter and the TUI's live event feed. The full
+// Result is still returned at EOF.
+func RunStream(path string, cfg Config, onEvent func(EventRecord)) (*Result, error) {
+	if cfg.SampleRateHz <= 0 {
+		return nil, fmt.Errorf("siglab: sample rate must be > 0")
+	}
+	if !ccdecoder.HasFactory(cfg.Protocol) {
+		return nil, fmt.Errorf("siglab: no pipeline registered for protocol %s", cfg.Protocol)
+	}
+
+	decode, bytesPerSample := cfg.Format.Decoder()
+
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open %s: %w", path, err)
+	}
+	defer f.Close()
+
+	// Resolve the tuning offset (auto-tune estimates from a prefix then
+	// rewinds; manual TuneHz is the override).
+	tuneHz := cfg.TuneHz
+	if cfg.AutoTune {
+		est, terr := estimateCaptureCarrierHz(f, decode, bytesPerSample, cfg.SampleRateHz)
+		if terr != nil {
+			return nil, fmt.Errorf("auto-tune failed: %w", terr)
+		}
+		tuneHz = est
+	}
+
+	res, err := runReader(f, path, decode, bytesPerSample, tuneHz, cfg, onEvent)
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+// runReader is the format-agnostic core: it mirrors the daemon's DDC →
+// pipeline chain (so a replay lock implies an on-air lock), drains the bus
+// into a Result, and runs the optional analyzer. Split out so a future
+// in-memory source (synthesized IQ) can share it.
+func runReader(r io.Reader, source string, decode SampleDecoder, bytesPerSample int, tuneHz float64, cfg Config, onEvent func(EventRecord)) (*Result, error) {
+	logger := cfg.logger()
+
+	// Mirror the production ccdecoder DDC: decimate to the per-protocol
+	// channel rate (TETRA → 144 kHz, else 48 kHz) whenever the input is
+	// wider, and apply the tuning shift. An already-channelized capture
+	// (rate ≤ target) with no tuning passes straight through.
+	target := ccdecoder.DDCTargetForProtocol(cfg.Protocol)
+	ddcTarget := cfg.SampleRateHz
+	if cfg.SampleRateHz > target {
+		ddcTarget = target
+	}
+	var ddc *ccdecoder.Downconverter
+	receiverRate := cfg.SampleRateHz
+	if tuneHz != 0 || ddcTarget < cfg.SampleRateHz {
+		ddc = ccdecoder.NewDownconverterWithOffset(cfg.SampleRateHz, ddcTarget, tuneHz)
+		receiverRate = ddc.OutRateHz()
+	}
+
+	bus := events.NewBus(1024)
+	sub := bus.Subscribe()
+
+	// Optional protocol-agnostic analyzer + raw-IQ imbalance corrector.
+	var an *analyzer
+	if cfg.CollectIQDiag {
+		an = newAnalyzer()
+		an.bufferSymbols = cfg.Protocol == trunking.ProtocolP25
+	}
+	var iqCorrector *rtlsdr.IQImbalanceCorrector
+	if cfg.IQCorrect {
+		iqCorrector = rtlsdr.NewIQImbalanceCorrector()
+	}
+
+	var symbolCount int64
+	pipe, ok, err := ccdecoder.NewPipeline(cfg.Protocol, ccdecoder.PipelineOptions{
+		Bus:          bus,
+		Log:          logger,
+		SystemName:   cfg.SystemName,
+		FrequencyHz:  cfg.FrequencyHz,
+		SampleRateHz: receiverRate,
+		System:       cfg.System,
+		SymbolTap: func(symbols []uint8, isBits bool, _ int) {
+			symbolCount += int64(len(symbols))
+			if an != nil {
+				an.observeSymbols(symbols, isBits)
+			}
+		},
+	})
+	if err != nil {
+		sub.Close()
+		bus.Close()
+		return nil, fmt.Errorf("construct %s pipeline: %w", cfg.Protocol, err)
+	}
+	if !ok { // guarded above, but keep the invariant explicit
+		sub.Close()
+		bus.Close()
+		return nil, fmt.Errorf("siglab: no pipeline registered for protocol %s", cfg.Protocol)
+	}
+	defer pipe.Close()
+
+	// Drain the bus in the background so events are collected as they fire.
+	start := time.Now()
+	coll := newCollector(start, onEvent)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for ev := range sub.C {
+			coll.observe(ev)
+		}
+	}()
+
+	chunk := cfg.chunkSamples()
+	buf := make([]byte, chunk*bytesPerSample)
+	samples := make([]complex64, chunk)
+	var ddcOut []complex64
+	var totalSamples int64
+	var readErr error
+	for {
+		n, rerr := io.ReadFull(r, buf)
+		if n > 0 {
+			pairs := n / bytesPerSample
+			if pairs > len(samples) {
+				samples = make([]complex64, pairs)
+			}
+			decode(buf[:pairs*bytesPerSample], samples[:pairs])
+			feed := samples[:pairs]
+			if cfg.Conjugate {
+				for i, s := range feed {
+					feed[i] = complex(real(s), -imag(s))
+				}
+			}
+			if an != nil {
+				an.observeIQ(feed)
+			}
+			if iqCorrector != nil {
+				iqCorrector.Process(feed)
+			}
+			if ddc != nil {
+				ddcOut = ddc.Process(ddcOut, feed)
+				feed = ddcOut
+			}
+			pipe.Process(feed)
+			totalSamples += int64(pairs)
+		}
+		if errors.Is(rerr, io.EOF) || errors.Is(rerr, io.ErrUnexpectedEOF) {
+			break
+		}
+		if rerr != nil {
+			readErr = fmt.Errorf("read %s: %w", source, rerr)
+			break
+		}
+	}
+
+	// Release the drainer and wait for it so totals are complete.
+	bus.Close()
+	<-done
+	sub.Close()
+	if readErr != nil {
+		return nil, readErr
+	}
+
+	res := assembleResult(source, cfg, totalSamples, symbolCount, receiverRate, tuneHz, coll, an)
+	return res, nil
+}
+
+// assembleResult builds the final Result from the read-loop totals and the
+// drained collector.
+func assembleResult(source string, cfg Config, totalSamples, symbols int64, receiverRate, tuneHz float64, coll *collector, an *analyzer) *Result {
+	duration := 0.0
+	if cfg.SampleRateHz > 0 {
+		duration = float64(totalSamples) / cfg.SampleRateHz
+	}
+	res := &Result{
+		Source:         filepath.Base(source),
+		Protocol:       cfg.Protocol.String(),
+		SampleRateHz:   cfg.SampleRateHz,
+		PipelineRateHz: receiverRate,
+		TuneHz:         tuneHz,
+		DurationSec:    duration,
+		TotalSamples:   totalSamples,
+		Symbols:        symbols,
+		ExpectedBaud:   expectedSymbolRate(cfg.Protocol),
+		Locked:         coll.locked,
+		Lock:           coll.lock,
+		Grants:         coll.grants,
+		Events:         coll.events,
+		EventCounts:    coll.eventCounts,
+		DecodeErrors:   coll.decodeErr,
+	}
+	if coll.locked {
+		res.LockLatencySec = coll.lockLatency
+	}
+	if res.Grants == nil {
+		res.Grants = []GrantRecord{}
+	}
+	if res.Events == nil {
+		res.Events = []EventRecord{}
+	}
+	if duration > 0 && symbols > 0 {
+		res.EffectiveBaud = float64(symbols) / duration
+		if res.ExpectedBaud > 0 {
+			res.BaudDeviationPct = (res.EffectiveBaud - res.ExpectedBaud) / res.ExpectedBaud * 100
+		}
+	}
+
+	// Total decode errors across stages → analyzer error rate.
+	var decodeErrTotal int64
+	for _, n := range coll.decodeErr {
+		decodeErrTotal += int64(n)
+	}
+	if an != nil {
+		res.Signal = an.result(decodeErrTotal)
+		if cfg.Protocol == trunking.ProtocolP25 {
+			res.P25P1 = buildP25Detail(an.symBuf)
+		}
+	}
+
+	if cfg.Acceptance != nil {
+		res.Verdict = evaluateAcceptance(res, cfg.Acceptance)
+	}
+	return res
+}

--- a/internal/siglab/engine_test.go
+++ b/internal/siglab/engine_test.go
@@ -1,0 +1,105 @@
+package siglab
+
+import (
+	"encoding/binary"
+	"math"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/demod"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// writeF32 writes interleaved little-endian float32 IQ to path (GNU Radio
+// cfile format) — the on-disk shape FormatF32 reads back.
+func writeF32(t *testing.T, path string, iq []complex64) {
+	t.Helper()
+	buf := make([]byte, len(iq)*8)
+	for i, s := range iq {
+		binary.LittleEndian.PutUint32(buf[8*i:], math.Float32bits(real(s)))
+		binary.LittleEndian.PutUint32(buf[8*i+4:], math.Float32bits(imag(s)))
+	}
+	if err := os.WriteFile(path, buf, 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+// TestEngineThroughputAndAnalysis drives a synthesized C4FM stream through
+// the engine and asserts the protocol-agnostic plumbing: the receiver emits
+// symbols at ~4800 baud, the effective-baud self-diagnostic lands near the
+// P25 nominal, and the analyzer produces a 4-level symbol histogram. It does
+// not require a full control-channel lock — that is covered by the gen→Run
+// round-trip once the fixture library lands.
+func TestEngineThroughputAndAnalysis(t *testing.T) {
+	const (
+		sampleRate = 48_000.0
+		deviation  = 1800.0
+	)
+	// A long stream cycling through all four symbols so the Mueller-Müller
+	// clock has plenty of transitions to lock onto.
+	dibits := make([]uint8, 24_000)
+	for i := range dibits {
+		dibits[i] = uint8(i % 4)
+	}
+	iq := demod.ModulateP25C4FM(dibits, sampleRate, deviation)
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "synth.cfile")
+	writeF32(t, path, iq)
+
+	res, err := Run(path, Config{
+		Protocol:      trunking.ProtocolP25,
+		SystemName:    "test",
+		SampleRateHz:  sampleRate,
+		Format:        FormatF32,
+		CollectIQDiag: true,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if res.Protocol != "p25" {
+		t.Errorf("Protocol = %q, want p25", res.Protocol)
+	}
+	if res.Symbols == 0 {
+		t.Fatal("engine recovered no symbols")
+	}
+	if res.ExpectedBaud != 4800 {
+		t.Errorf("ExpectedBaud = %v, want 4800", res.ExpectedBaud)
+	}
+	// Effective baud should sit within 10% of the 4800 nominal.
+	if dev := math.Abs(res.BaudDeviationPct); dev > 10 {
+		t.Errorf("baud deviation %.1f%% > 10%% (effective=%.1f)", dev, res.EffectiveBaud)
+	}
+	if res.Signal == nil {
+		t.Fatal("CollectIQDiag set but Signal is nil")
+	}
+	if res.Signal.SymbolCardinality != 4 {
+		t.Errorf("SymbolCardinality = %d, want 4", res.Signal.SymbolCardinality)
+	}
+	if got := len(res.Signal.SymbolHistogram); got != 4 {
+		t.Errorf("SymbolHistogram len = %d, want 4", got)
+	}
+	if !res.Signal.IQObserved {
+		t.Error("expected IQ imbalance to be observed")
+	}
+	// The dibit-domain P25 detail should have been built from the buffered
+	// symbols.
+	if res.P25P1 == nil {
+		t.Fatal("P25P1 detail not built for a P25 run with CollectIQDiag")
+	}
+	if res.P25P1.DibitsBuffered == 0 {
+		t.Error("P25P1.DibitsBuffered = 0")
+	}
+}
+
+// TestEngineRejectsBadConfig covers the guard rails.
+func TestEngineRejectsBadConfig(t *testing.T) {
+	if _, err := Run("/nonexistent", Config{Protocol: trunking.ProtocolP25}); err == nil {
+		t.Error("expected error for zero sample rate")
+	}
+	if _, err := Run("/nonexistent", Config{Protocol: trunking.ProtocolUnknown, SampleRateHz: 48000}); err == nil {
+		t.Error("expected error for unregistered protocol")
+	}
+}

--- a/internal/siglab/export.go
+++ b/internal/siglab/export.go
@@ -1,0 +1,183 @@
+package siglab
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+	"strconv"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Format selects an output encoding for a Result.
+type Format int
+
+const (
+	// FormatTextSummary is the human-readable summary (handled by the
+	// caller's renderer, not WriteResult). Defined so callers share one
+	// Format enum.
+	FormatTextSummary Format = iota
+	// FormatJSON is a single indented JSON object.
+	FormatJSON
+	// FormatJSONL is one JSON object per line: every captured event, then a
+	// final summary object tagged "summary".
+	FormatJSONL
+	// FormatYAML is a single YAML document.
+	FormatYAML
+	// FormatCSVSummary is a two-line CSV (header + one summary row).
+	FormatCSVSummary
+	// FormatCSVEvents is a CSV with one row per captured event.
+	FormatCSVEvents
+)
+
+// ParseFormat maps a -format flag value to a Format. csv defaults to the
+// summary shape; use "csv-events" for the per-event shape.
+func ParseFormat(s string) (Format, error) {
+	switch s {
+	case "", "text":
+		return FormatTextSummary, nil
+	case "json":
+		return FormatJSON, nil
+	case "jsonl":
+		return FormatJSONL, nil
+	case "yaml", "yml":
+		return FormatYAML, nil
+	case "csv", "csv-summary":
+		return FormatCSVSummary, nil
+	case "csv-events":
+		return FormatCSVEvents, nil
+	default:
+		return FormatTextSummary, fmt.Errorf("siglab: unknown format %q (want json|jsonl|yaml|csv|csv-events)", s)
+	}
+}
+
+// WriteResult serializes r to w in the requested format. FormatTextSummary
+// is not handled here (the subcommands own their text rendering); it returns
+// an error so a miswired caller is caught.
+func WriteResult(w io.Writer, r *Result, f Format) error {
+	switch f {
+	case FormatJSON:
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		return enc.Encode(r)
+	case FormatJSONL:
+		return writeJSONL(w, r)
+	case FormatYAML:
+		enc := yaml.NewEncoder(w)
+		enc.SetIndent(2)
+		if err := enc.Encode(r); err != nil {
+			return err
+		}
+		return enc.Close()
+	case FormatCSVSummary:
+		return writeCSVSummary(w, r)
+	case FormatCSVEvents:
+		return writeCSVEvents(w, r)
+	case FormatTextSummary:
+		return fmt.Errorf("siglab: text summary is rendered by the caller, not WriteResult")
+	default:
+		return fmt.Errorf("siglab: unsupported format %d", f)
+	}
+}
+
+// writeJSONL emits one JSON line per captured event followed by a summary
+// line. The summary reuses the Result with its (already-streamed) Events
+// elided so the trailing object stays compact.
+func writeJSONL(w io.Writer, r *Result) error {
+	enc := json.NewEncoder(w)
+	for _, ev := range r.Events {
+		if err := enc.Encode(jsonlLine{Type: "event", Event: &ev}); err != nil {
+			return err
+		}
+	}
+	summary := *r
+	summary.Events = nil
+	return enc.Encode(jsonlLine{Type: "summary", Summary: &summary})
+}
+
+type jsonlLine struct {
+	Type    string       `json:"type"`
+	Event   *EventRecord `json:"event,omitempty"`
+	Summary *Result      `json:"summary,omitempty"`
+}
+
+// writeCSVSummary writes a stable single-row summary CSV.
+func writeCSVSummary(w io.Writer, r *Result) error {
+	cw := csv.NewWriter(w)
+	header := []string{
+		"source", "protocol", "sample_rate_hz", "pipeline_rate_hz", "duration_sec",
+		"total_samples", "symbols", "effective_baud", "expected_baud", "baud_deviation_pct",
+		"locked", "lock_latency_sec", "lock_frequency_hz", "grants", "decode_errors", "verdict_pass",
+	}
+	if err := cw.Write(header); err != nil {
+		return err
+	}
+	lockFreq := ""
+	if r.Lock != nil {
+		lockFreq = strconv.FormatUint(uint64(r.Lock.FrequencyHz), 10)
+	}
+	verdict := ""
+	if r.Verdict != nil {
+		verdict = strconv.FormatBool(r.Verdict.Pass)
+	}
+	row := []string{
+		r.Source, r.Protocol,
+		ftoa(r.SampleRateHz), ftoa(r.PipelineRateHz), ftoa(r.DurationSec),
+		strconv.FormatInt(r.TotalSamples, 10), strconv.FormatInt(r.Symbols, 10),
+		ftoa(r.EffectiveBaud), ftoa(r.ExpectedBaud), ftoa(r.BaudDeviationPct),
+		strconv.FormatBool(r.Locked), ftoa(r.LockLatencySec), lockFreq,
+		strconv.Itoa(len(r.Grants)), strconv.Itoa(sumCounts(r.DecodeErrors)), verdict,
+	}
+	if err := cw.Write(row); err != nil {
+		return err
+	}
+	cw.Flush()
+	return cw.Error()
+}
+
+// writeCSVEvents writes one row per captured event; the protocol-specific
+// payload fields are JSON-encoded into a single stable column so the column
+// set is identical across all protocols.
+func writeCSVEvents(w io.Writer, r *Result) error {
+	cw := csv.NewWriter(w)
+	if err := cw.Write([]string{"seq", "offset_sec", "kind", "fields_json"}); err != nil {
+		return err
+	}
+	for _, ev := range r.Events {
+		fields, err := json.Marshal(ev.Fields)
+		if err != nil {
+			return err
+		}
+		row := []string{
+			strconv.Itoa(ev.Seq), ftoa(ev.OffsetSec), ev.Kind, string(fields),
+		}
+		if err := cw.Write(row); err != nil {
+			return err
+		}
+	}
+	cw.Flush()
+	return cw.Error()
+}
+
+func ftoa(f float64) string { return strconv.FormatFloat(f, 'f', -1, 64) }
+
+func sumCounts(m map[string]int) int {
+	total := 0
+	for _, n := range m {
+		total += n
+	}
+	return total
+}
+
+// SortedDecodeErrors returns the decode-error stages in a stable order, for
+// deterministic text/CSV rendering by callers.
+func SortedDecodeErrors(m map[string]int) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/internal/siglab/export_test.go
+++ b/internal/siglab/export_test.go
@@ -1,0 +1,141 @@
+package siglab
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// sampleResult is a fixed Result used to exercise every exporter.
+func sampleResult() *Result {
+	pass := true
+	return &Result{
+		Source:           "synth.cfile",
+		Protocol:         "p25",
+		SampleRateHz:     48000,
+		PipelineRateHz:   48000,
+		DurationSec:      5,
+		TotalSamples:     240000,
+		Symbols:          24000,
+		EffectiveBaud:    4800,
+		ExpectedBaud:     4800,
+		BaudDeviationPct: 0,
+		Locked:           true,
+		LockLatencySec:   0.5,
+		Lock:             &LockInfo{FrequencyHz: 851000000, Fields: map[string]any{"NAC": uint16(0x293)}},
+		Grants: []GrantRecord{
+			{OffsetSec: 1.2, GroupID: 100, SourceID: 5, FrequencyHz: 852000000},
+		},
+		Events: []EventRecord{
+			{Seq: 0, OffsetSec: 0.5, Kind: "cc.locked", Fields: map[string]any{"NAC": uint16(0x293)}},
+			{Seq: 1, OffsetSec: 1.2, Kind: "grant", Fields: map[string]any{"GroupID": uint32(100)}},
+		},
+		EventCounts:  map[string]int{"cc.locked": 1, "grant": 1},
+		DecodeErrors: map[string]int{"nid-bch": 3},
+		Verdict:      &Verdict{Pass: pass, Checks: []string{"ok: lock = true"}},
+	}
+}
+
+func TestExportJSONRoundTrip(t *testing.T) {
+	var buf bytes.Buffer
+	if err := WriteResult(&buf, sampleResult(), FormatJSON); err != nil {
+		t.Fatalf("WriteResult JSON: %v", err)
+	}
+	var got Result
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal: %v\n%s", err, buf.String())
+	}
+	if got.Protocol != "p25" || !got.Locked || got.Symbols != 24000 {
+		t.Errorf("round-trip mismatch: %+v", got)
+	}
+	if got.Lock == nil || got.Lock.FrequencyHz != 851000000 {
+		t.Errorf("lock not preserved: %+v", got.Lock)
+	}
+}
+
+func TestExportYAMLRoundTrip(t *testing.T) {
+	var buf bytes.Buffer
+	if err := WriteResult(&buf, sampleResult(), FormatYAML); err != nil {
+		t.Fatalf("WriteResult YAML: %v", err)
+	}
+	var got Result
+	if err := yaml.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal: %v\n%s", err, buf.String())
+	}
+	if got.Protocol != "p25" || len(got.Grants) != 1 {
+		t.Errorf("yaml round-trip mismatch: %+v", got)
+	}
+}
+
+func TestExportJSONL(t *testing.T) {
+	var buf bytes.Buffer
+	if err := WriteResult(&buf, sampleResult(), FormatJSONL); err != nil {
+		t.Fatalf("WriteResult JSONL: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	// 2 events + 1 summary line.
+	if len(lines) != 3 {
+		t.Fatalf("JSONL line count = %d, want 3:\n%s", len(lines), buf.String())
+	}
+	var last jsonlLine
+	if err := json.Unmarshal([]byte(lines[2]), &last); err != nil {
+		t.Fatalf("summary line: %v", err)
+	}
+	if last.Type != "summary" || last.Summary == nil {
+		t.Errorf("last line not a summary: %s", lines[2])
+	}
+	if last.Summary != nil && len(last.Summary.Events) != 0 {
+		t.Error("summary line should elide Events")
+	}
+}
+
+func TestExportCSVSummary(t *testing.T) {
+	var buf bytes.Buffer
+	if err := WriteResult(&buf, sampleResult(), FormatCSVSummary); err != nil {
+		t.Fatalf("WriteResult CSV: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("CSV summary lines = %d, want 2:\n%s", len(lines), buf.String())
+	}
+	if !strings.Contains(lines[0], "protocol") || !strings.Contains(lines[0], "effective_baud") {
+		t.Errorf("header missing columns: %s", lines[0])
+	}
+	if !strings.Contains(lines[1], "p25") {
+		t.Errorf("data row missing protocol: %s", lines[1])
+	}
+}
+
+func TestExportCSVEvents(t *testing.T) {
+	var buf bytes.Buffer
+	if err := WriteResult(&buf, sampleResult(), FormatCSVEvents); err != nil {
+		t.Fatalf("WriteResult CSV events: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	// header + 2 events.
+	if len(lines) != 3 {
+		t.Fatalf("CSV events lines = %d, want 3:\n%s", len(lines), buf.String())
+	}
+	if !strings.Contains(lines[1], "cc.locked") {
+		t.Errorf("first event row wrong: %s", lines[1])
+	}
+}
+
+func TestParseFormat(t *testing.T) {
+	cases := map[string]Format{
+		"json": FormatJSON, "jsonl": FormatJSONL, "yaml": FormatYAML,
+		"csv": FormatCSVSummary, "csv-events": FormatCSVEvents, "": FormatTextSummary,
+	}
+	for in, want := range cases {
+		got, err := ParseFormat(in)
+		if err != nil || got != want {
+			t.Errorf("ParseFormat(%q) = %v, %v; want %v", in, got, err, want)
+		}
+	}
+	if _, err := ParseFormat("bogus"); err == nil {
+		t.Error("expected error for bogus format")
+	}
+}

--- a/internal/siglab/fixtures.go
+++ b/internal/siglab/fixtures.go
@@ -1,0 +1,150 @@
+package siglab
+
+import (
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/demod"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/dmr"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/dmr/tier3"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+	p25phase1 "github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase1"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// fixture describes how to synthesize a known-good locking capture for one
+// protocol: a symbol-stream builder, the modulator that shapes it to IQ, the
+// capture sample rate, the decoder knobs needed to decode it, and the
+// acceptance criteria a correct decode must satisfy. The `gen` subcommand
+// uses these to emit a capture + metadata sidecar that the `test` harness
+// then validates — a closed synthesize→decode→grade loop.
+//
+// The symbol-stream builders are lifted from the per-protocol
+// integration_cc_*_test.go fixtures so synthesis exercises exactly the
+// streams the production decoders are tested against. Protocols not yet in
+// the registry are reported by Fixtures(); porting their builders is a
+// mechanical follow-up (each lives in its integration_cc_<proto>_test.go).
+type fixture struct {
+	build       func() []uint8
+	modulate    func(symbols []uint8, sampleRateHz float64) []complex64
+	sampleRate  float64
+	systemKnobs map[string]string
+	expected    Acceptance
+}
+
+func boolPtr(b bool) *bool { return &b }
+
+// fixtures is the synthesis registry keyed by protocol.
+var fixtures = map[trunking.Protocol]fixture{
+	trunking.ProtocolP25: {
+		build:      func() []uint8 { return buildP25LockedDibits(0x293, 40) },
+		modulate:   func(d []uint8, sr float64) []complex64 { return demod.ModulateP25C4FM(d, sr, 1800.0) },
+		sampleRate: 48_000,
+		expected: Acceptance{
+			Lock:             boolPtr(true),
+			LockFields:       map[string]any{"nac": "0x293"},
+			BaudTolerancePct: 5,
+		},
+	},
+	trunking.ProtocolDMR: {
+		build:      func() []uint8 { return buildDMRTier3CSBKDibits(80, 0xA, 0x1234) },
+		modulate:   func(d []uint8, sr float64) []complex64 { return demod.ModulateC4FM(d, 10, 8, 0.20, sr, 1944.0) },
+		sampleRate: 48_000,
+		expected: Acceptance{
+			Lock:             boolPtr(true),
+			LockFields:       map[string]any{"color_code": 0xA},
+			BaudTolerancePct: 5,
+		},
+	},
+}
+
+// Fixtures returns the protocols with a registered synthesis fixture, in
+// stable order, for the `gen` usage message and protocol picker.
+func Fixtures() []trunking.Protocol {
+	out := make([]trunking.Protocol, 0, len(fixtures))
+	for p := range fixtures {
+		out = append(out, p)
+	}
+	// Reuse the ccdecoder ordering convention (ascending Protocol value).
+	for i := 1; i < len(out); i++ {
+		for j := i; j > 0 && out[j] < out[j-1]; j-- {
+			out[j], out[j-1] = out[j-1], out[j]
+		}
+	}
+	return out
+}
+
+// HasFixture reports whether a synthesis fixture is registered for p.
+func HasFixture(p trunking.Protocol) bool {
+	_, ok := fixtures[p]
+	return ok
+}
+
+// --- Lifted builders (from cmd/gophertrunk/integration_cc_*_test.go) ---
+
+// buildP25LockedDibits builds a P25 Phase 1 control-channel dibit stream:
+// a warmup ramp, then repeated FSW + NID(TSDU) + RFSS-status-broadcast TSBK
+// frames with on-air status symbols injected. Lifted verbatim from
+// integration_cc_test.go's buildP25LockedIQDibits.
+func buildP25LockedDibits(nac uint16, repeats int) []uint8 {
+	frame := make([]uint8, 0, 24+32+98)
+	frame = append(frame, p25phase1.FrameSyncWord[:]...)
+	nidBits := p25phase1.EncodeNIDBits(nac, p25phase1.DUIDTrunkingSignaling)
+	for i := 0; i < 32; i++ {
+		frame = append(frame, (nidBits[2*i]<<1)|nidBits[2*i+1])
+	}
+	tsbk := p25phase1.AssembleTSBK(p25phase1.TSBK{LB: true, Opcode: p25phase1.OpRFSSStatusBroadcast})
+	frame = append(frame, p25phase1.EncodeTSBKChannel(tsbk)...)
+	frame = p25phase1.InjectControlStatusSymbols(frame)
+
+	out := make([]uint8, 0, 200+repeats*(len(frame)+50)+100)
+	for i := 0; i < 200; i++ {
+		out = append(out, uint8(i&3))
+	}
+	for r := 0; r < repeats; r++ {
+		out = append(out, frame...)
+		for i := 0; i < 50; i++ {
+			out = append(out, uint8(i&3))
+		}
+	}
+	for i := 0; i < 100; i++ {
+		out = append(out, uint8(i&3))
+	}
+	return out
+}
+
+// buildDMRTier3CSBKDibits builds a DMR Tier III control-channel dibit stream
+// of repeated CSBK Aloha bursts (BPTC(196,96) payload + slot-type Hamming),
+// with a long warmup for the lower-gain clock loop. Lifted verbatim from
+// integration_cc_dmr_test.go.
+func buildDMRTier3CSBKDibits(repeats int, colorCode uint8, systemID uint16) []uint8 {
+	csbk := tier3.CSBK{Opcode: tier3.OpAloha, LB: true}
+	csbk.Payload[2] = byte(systemID >> 8)
+	csbk.Payload[3] = byte(systemID & 0xFF)
+	csbkBytes := tier3.AssembleCSBK(csbk)
+	infoBits := framing.UnpackBitsMSB(csbkBytes, 96)
+	channelBits := framing.EncodeBPTC196_96(infoBits)
+	payloadDibits := framing.BitsToDibits(channelBits)
+
+	slotBits := dmr.AssembleSlotType(dmr.SlotType{ColorCode: colorCode, DataType: dmr.DTCSBK})
+	slotDibits := framing.BitsToDibits(slotBits)
+
+	burst := make([]uint8, 0, dmr.BurstDibits)
+	burst = append(burst, payloadDibits[:dmr.HalfPayloadDibits]...)
+	burst = append(burst, slotDibits[:dmr.SlotTypeDibits]...)
+	burst = append(burst, dmr.BSData.Dibits[:]...)
+	burst = append(burst, slotDibits[dmr.SlotTypeDibits:]...)
+	burst = append(burst, payloadDibits[dmr.HalfPayloadDibits:]...)
+
+	out := make([]uint8, 0, 800+repeats*(len(burst)+32)+100)
+	for i := 0; i < 800; i++ {
+		out = append(out, uint8(i&3))
+	}
+	for r := 0; r < repeats; r++ {
+		out = append(out, burst...)
+		for i := 0; i < 32; i++ {
+			out = append(out, uint8(i&3))
+		}
+	}
+	for i := 0; i < 100; i++ {
+		out = append(out, uint8(i&3))
+	}
+	return out
+}

--- a/internal/siglab/metadata.go
+++ b/internal/siglab/metadata.go
@@ -1,0 +1,188 @@
+package siglab
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+	"gopkg.in/yaml.v3"
+)
+
+// Metadata is the sidecar that accompanies a capture (real-air or
+// synthesized) and describes how to decode it plus what a correct decode
+// must produce. It generalizes the ad-hoc per-test loaders and the
+// acceptance-criteria documented in samples/README.md into one schema the
+// `test` harness consumes. It loads from JSON or YAML.
+type Metadata struct {
+	// Protocol is the CLI/config protocol name (p25, p25-phase2, dmr,
+	// dmr-tier2, nxdn, dpmr, edacs, motorola, ltr, mpt1327, tetra, ysf,
+	// dstar; the replay aliases p25p1/dmr-tier3 are also accepted).
+	Protocol string `json:"protocol" yaml:"protocol"`
+	// Source / ToolCrossCheck are free-text provenance (where the capture
+	// came from, which reference receiver it was validated against).
+	Source         string `json:"source,omitempty" yaml:"source,omitempty"`
+	ToolCrossCheck string `json:"tool_cross_check,omitempty" yaml:"tool_cross_check,omitempty"`
+	// SampleRateHz is required — a raw cfile/u8 carries no rate of its own.
+	SampleRateHz float64 `json:"sample_rate_hz" yaml:"sample_rate_hz"`
+	// CenterFreqHz is informational (the capture's nominal centre).
+	CenterFreqHz uint32 `json:"center_freq_hz,omitempty" yaml:"center_freq_hz,omitempty"`
+	// Format is the on-disk encoding (u8|f32); empty defaults to u8.
+	Format string `json:"format,omitempty" yaml:"format,omitempty"`
+	// TuneHz / AutoTune / Conjugate / IQCorrect mirror the engine knobs for
+	// captures that need them.
+	TuneHz    float64 `json:"tune_hz,omitempty" yaml:"tune_hz,omitempty"`
+	AutoTune  bool    `json:"auto_tune,omitempty" yaml:"auto_tune,omitempty"`
+	Conjugate bool    `json:"conjugate,omitempty" yaml:"conjugate,omitempty"`
+	IQCorrect bool    `json:"iq_correct,omitempty" yaml:"iq_correct,omitempty"`
+	// System carries per-protocol decoder knobs by their YAML config-key
+	// names (e.g. "tetra_colour_code": "1", "p25_phase1_demod_mode":
+	// "cqpsk"), applied onto the trunking.System the engine drives.
+	System map[string]string `json:"system,omitempty" yaml:"system,omitempty"`
+	// Expected is the acceptance contract graded against the decode.
+	Expected Acceptance `json:"expected" yaml:"expected"`
+}
+
+// LoadMetadata reads a Metadata document from path (JSON or YAML, chosen by
+// extension; .json → JSON, everything else → YAML).
+func LoadMetadata(path string) (*Metadata, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var m Metadata
+	if strings.EqualFold(filepath.Ext(path), ".json") {
+		if err := json.Unmarshal(raw, &m); err != nil {
+			return nil, fmt.Errorf("parse %s: %w", path, err)
+		}
+	} else {
+		if err := yaml.Unmarshal(raw, &m); err != nil {
+			return nil, fmt.Errorf("parse %s: %w", path, err)
+		}
+	}
+	if m.Protocol == "" {
+		return nil, fmt.Errorf("%s: metadata missing required \"protocol\"", path)
+	}
+	if m.SampleRateHz <= 0 {
+		return nil, fmt.Errorf("%s: metadata missing required \"sample_rate_hz\"", path)
+	}
+	return &m, nil
+}
+
+// DiscoverMetadata finds the sidecar for a capture by stem: it tries
+// <stem>.metadata.json, <stem>.metadata.yaml, then <capture>.json/.yaml.
+// Returns "" when none exists.
+func DiscoverMetadata(capturePath string) string {
+	stem := strings.TrimSuffix(capturePath, filepath.Ext(capturePath))
+	for _, cand := range []string{
+		stem + ".metadata.json",
+		stem + ".metadata.yaml",
+		stem + ".metadata.yml",
+		capturePath + ".json",
+		capturePath + ".yaml",
+	} {
+		if _, err := os.Stat(cand); err == nil {
+			return cand
+		}
+	}
+	return ""
+}
+
+// Config builds an engine Config from the metadata for the given capture.
+// collectIQDiag is threaded through because the harness wants the analyzer's
+// decode-error rate available to the verdict.
+func (m *Metadata) Config(collectIQDiag bool) (Config, error) {
+	proto, err := ParseProtocolCLI(m.Protocol)
+	if err != nil {
+		return Config{}, err
+	}
+	format, err := ParseSampleFormat(m.Format)
+	if err != nil {
+		return Config{}, err
+	}
+	sys := trunking.System{Name: "siglab", Protocol: proto}
+	applySystemKnobs(&sys, m.System)
+	acc := m.Expected
+	return Config{
+		Protocol:      proto,
+		System:        sys,
+		SystemName:    "siglab",
+		FrequencyHz:   m.CenterFreqHz,
+		SampleRateHz:  m.SampleRateHz,
+		Format:        format,
+		TuneHz:        m.TuneHz,
+		AutoTune:      m.AutoTune,
+		Conjugate:     m.Conjugate,
+		IQCorrect:     m.IQCorrect,
+		CollectIQDiag: collectIQDiag,
+		Acceptance:    &acc,
+	}, nil
+}
+
+// applySystemKnobs maps the metadata's config-key/value pairs onto the
+// trunking.System fields the pipeline factories read. Unknown keys are
+// ignored (forward-compatible). Keys match the YAML config names operators
+// already know from config.example.yaml.
+func applySystemKnobs(sys *trunking.System, knobs map[string]string) {
+	for k, v := range knobs {
+		switch strings.ToLower(strings.TrimSpace(k)) {
+		case "p25_phase1_demod_mode":
+			sys.P25Phase1DemodMode = v
+		case "p25_phase2_trellis_mode":
+			sys.P25Phase2TrellisMode = v
+		case "p25_phase2_rs_mode":
+			sys.P25Phase2RSMode = v
+		case "p25_phase2_interleave_mode":
+			sys.P25Phase2InterleaveMode = v
+		case "p25_phase2_scrambler_mode":
+			sys.P25Phase2ScramblerMode = v
+		case "p25_phase2_clock_mode":
+			sys.P25Phase2ClockMode = v
+		case "wacn":
+			sys.WACN = uint32(parseUintKnob(v, 32))
+		case "system_id", "sysid":
+			sys.SystemID = uint16(parseUintKnob(v, 16))
+		case "site":
+			sys.Site = uint8(parseUintKnob(v, 8))
+		case "tetra_colour_code", "tetra_color_code":
+			sys.TETRAColourCode = uint32(parseUintKnob(v, 32))
+		case "tetra_channel":
+			sys.TETRAChannel = v
+		case "tetra_channel_coding":
+			sys.TETRAChannelCoding = v
+		case "tetra_clock_mode":
+			sys.TETRAClockMode = v
+		case "nxdn_viterbi_mode":
+			sys.NXDNViterbiMode = v
+		case "nxdn_deviation_hz":
+			sys.NXDNDeviationHz, _ = strconv.ParseFloat(v, 64)
+		case "edacs_bch_mode":
+			sys.EDACSBCHMode = v
+		case "motorola_bch_mode":
+			sys.MotorolaBCHMode = v
+		case "mpt1327_bch_mode":
+			sys.MPT1327BCHMode = v
+		case "mpt1327_cwsc_tolerance":
+			sys.MPT1327CWSCTolerance = v
+		case "ltr_fcs_mode":
+			sys.LTRFCSMode = v
+		case "ltr_manchester_mode":
+			sys.LTRManchesterMode = v
+		case "dstar_fec_mode":
+			sys.DStarFECMode = v
+		}
+	}
+}
+
+func parseUintKnob(s string, bits int) uint64 {
+	s = strings.TrimSpace(s)
+	if strings.HasPrefix(strings.ToLower(s), "0x") {
+		u, _ := strconv.ParseUint(s[2:], 16, bits)
+		return u
+	}
+	u, _ := strconv.ParseUint(s, 10, bits)
+	return u
+}

--- a/internal/siglab/p25detail.go
+++ b/internal/siglab/p25detail.go
@@ -1,0 +1,116 @@
+package siglab
+
+import p25phase1 "github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase1"
+
+// P25P1Detail is the P25-Phase-1-specific demod deep-dive, surfaced in
+// Result.P25P1 when the protocol is P25 Phase 1 and CollectIQDiag is set. It
+// reuses the dibit-domain analysis the historical iqdiag report pioneered
+// (issue #275): a per-rotation Frame-Sync-Word correlation landscape that
+// tells whether the demod produces canonical dibits at all and which
+// rotation aligns the stream, plus NID decode attempts at the cleanest FSW
+// hits. It operates purely on the recovered dibit stream (no soft samples),
+// so it is available through the generic SymbolTap for every P25 P1 capture.
+type P25P1Detail struct {
+	DibitsBuffered  int             `json:"dibits_buffered" yaml:"dibits_buffered"`
+	DibitHistogram  [4]int64        `json:"dibit_histogram" yaml:"dibit_histogram"`
+	Rotations       [4]RotationStat `json:"rotations" yaml:"rotations"`
+	WinningRotation int             `json:"winning_rotation" yaml:"winning_rotation"`
+	WinningHits     int             `json:"winning_hits" yaml:"winning_hits"`
+	// NIDDecodes are the NAC/DUID results from BCH-decoding the NID at the
+	// cleanest (distance-0) FSW hits under the winning rotation. A mix of
+	// successes and failures points at signal quality; zero successes
+	// despite perfect FSW alignment points at framing.
+	NIDDecodes []NIDDecode `json:"nid_decodes" yaml:"nid_decodes"`
+}
+
+// RotationStat summarizes the FSW Hamming-distance landscape for one of the
+// four cyclic dibit rotations.
+type RotationStat struct {
+	BestDist int `json:"best_dist" yaml:"best_dist"`
+	BestPos  int `json:"best_pos" yaml:"best_pos"`
+	Hits     int `json:"hits" yaml:"hits"` // positions with distance ≤ tolerance
+}
+
+// NIDDecode is one NID BCH decode attempt at an FSW hit.
+type NIDDecode struct {
+	Pos  int    `json:"pos" yaml:"pos"`
+	Errs int    `json:"errs" yaml:"errs"`
+	NAC  uint16 `json:"nac" yaml:"nac"`
+	DUID uint8  `json:"duid" yaml:"duid"`
+	OK   bool   `json:"ok" yaml:"ok"`
+}
+
+const (
+	p25FSWLen     = 24
+	p25FSWTol     = 4
+	maxNIDDecodes = 5
+)
+
+// buildP25Detail walks a recovered dibit stream and produces the P25 deep
+// dive. Returns nil when there are too few dibits to analyze.
+func buildP25Detail(dibits []uint8) *P25P1Detail {
+	if len(dibits) < p25FSWLen {
+		return nil
+	}
+	d := &P25P1Detail{DibitsBuffered: len(dibits)}
+	for _, db := range dibits {
+		d.DibitHistogram[db&3]++
+	}
+
+	for i := range d.Rotations {
+		d.Rotations[i].BestDist = p25FSWLen + 1
+	}
+	for pos := 0; pos+p25FSWLen <= len(dibits); pos++ {
+		for rot := uint8(0); rot < 4; rot++ {
+			mismatch := 0
+			for kk := 0; kk < p25FSWLen; kk++ {
+				if ((dibits[pos+kk] + rot) & 3) != p25phase1.FrameSyncWord[kk] {
+					mismatch++
+				}
+			}
+			rs := &d.Rotations[rot]
+			if mismatch <= p25FSWTol {
+				rs.Hits++
+			}
+			if mismatch < rs.BestDist {
+				rs.BestDist = mismatch
+				rs.BestPos = pos
+			}
+		}
+	}
+
+	d.WinningRotation = 0
+	for rot := 1; rot < 4; rot++ {
+		if d.Rotations[rot].Hits > d.Rotations[d.WinningRotation].Hits {
+			d.WinningRotation = rot
+		}
+	}
+	d.WinningHits = d.Rotations[d.WinningRotation].Hits
+
+	// Decode the NID at the cleanest (distance-0) hits under the winner.
+	win := uint8(d.WinningRotation)
+	for pos := 0; pos+p25FSWLen+32 <= len(dibits) && len(d.NIDDecodes) < maxNIDDecodes; pos++ {
+		mismatch := 0
+		for kk := 0; kk < p25FSWLen; kk++ {
+			if ((dibits[pos+kk] + win) & 3) != p25phase1.FrameSyncWord[kk] {
+				mismatch++
+			}
+		}
+		if mismatch != 0 {
+			continue
+		}
+		nid := make([]uint8, 32)
+		for j := 0; j < 32; j++ {
+			nid[j] = (dibits[pos+p25FSWLen+j] + win) & 3
+		}
+		n, errs, _, err := p25phase1.NIDFromDibitsWithErrors(nid)
+		d.NIDDecodes = append(d.NIDDecodes, NIDDecode{
+			Pos:  pos,
+			Errs: errs,
+			NAC:  n.NAC,
+			DUID: uint8(n.DUID),
+			OK:   err == nil,
+		})
+	}
+	return d
+}

--- a/internal/siglab/p25detail.go
+++ b/internal/siglab/p25detail.go
@@ -87,9 +87,15 @@ func buildP25Detail(dibits []uint8) *P25P1Detail {
 	}
 	d.WinningHits = d.Rotations[d.WinningRotation].Hits
 
-	// Decode the NID at the cleanest (distance-0) hits under the winner.
+	// Decode the NID at the cleanest (distance-0) hits under the winner. A
+	// real transmitter interleaves a status symbol every 36 on-air dibits,
+	// so the 32-dibit NID carries one extra symbol (at window index 11 when
+	// the FSW sits at frame position 0). Try the direct 32-dibit window and
+	// the status-stripped variant (skip index 11 of a 33-dibit window), and
+	// keep whichever BCH-decodes — mirroring the original iqdiag dual-mode
+	// probe so a status-bearing stream still resolves a NAC.
 	win := uint8(d.WinningRotation)
-	for pos := 0; pos+p25FSWLen+32 <= len(dibits) && len(d.NIDDecodes) < maxNIDDecodes; pos++ {
+	for pos := 0; pos+p25FSWLen+33 <= len(dibits) && len(d.NIDDecodes) < maxNIDDecodes; pos++ {
 		mismatch := 0
 		for kk := 0; kk < p25FSWLen; kk++ {
 			if ((dibits[pos+kk] + win) & 3) != p25phase1.FrameSyncWord[kk] {
@@ -99,18 +105,37 @@ func buildP25Detail(dibits []uint8) *P25P1Detail {
 		if mismatch != 0 {
 			continue
 		}
-		nid := make([]uint8, 32)
-		for j := 0; j < 32; j++ {
-			nid[j] = (dibits[pos+p25FSWLen+j] + win) & 3
+		raw := make([]uint8, 33)
+		for j := 0; j < 33; j++ {
+			raw[j] = (dibits[pos+p25FSWLen+j] + win) & 3
 		}
-		n, errs, _, err := p25phase1.NIDFromDibitsWithErrors(nid)
-		d.NIDDecodes = append(d.NIDDecodes, NIDDecode{
-			Pos:  pos,
-			Errs: errs,
-			NAC:  n.NAC,
-			DUID: uint8(n.DUID),
-			OK:   err == nil,
-		})
+		nd := decodeNIDBoth(raw)
+		nd.Pos = pos
+		d.NIDDecodes = append(d.NIDDecodes, nd)
 	}
 	return d
+}
+
+// decodeNIDBoth tries the direct 32-dibit NID and the status-stripped variant
+// (skip index 11), returning the better outcome (a clean decode wins; else
+// the lower error count).
+func decodeNIDBoth(raw []uint8) NIDDecode {
+	n0, e0, _, err0 := p25phase1.NIDFromDibitsWithErrors(raw[:32])
+	stripped := make([]uint8, 0, 32)
+	stripped = append(stripped, raw[:11]...)
+	stripped = append(stripped, raw[12:33]...)
+	n1, e1, _, err1 := p25phase1.NIDFromDibitsWithErrors(stripped)
+
+	direct := NIDDecode{Errs: e0, NAC: n0.NAC, DUID: uint8(n0.DUID), OK: err0 == nil}
+	strip := NIDDecode{Errs: e1, NAC: n1.NAC, DUID: uint8(n1.DUID), OK: err1 == nil}
+	switch {
+	case strip.OK && !direct.OK:
+		return strip
+	case direct.OK && !strip.OK:
+		return direct
+	case e1 >= 0 && (e0 < 0 || e1 < e0):
+		return strip
+	default:
+		return direct
+	}
 }

--- a/internal/siglab/result.go
+++ b/internal/siglab/result.go
@@ -1,0 +1,226 @@
+package siglab
+
+import (
+	"reflect"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// Result is the protocol-agnostic structured outcome of one engine run. It
+// is the single model every exporter (JSON / JSONL / YAML / CSV) and the
+// acceptance harness render — populated identically for all 13 protocols.
+type Result struct {
+	// Provenance.
+	Source         string  `json:"source" yaml:"source"`
+	Protocol       string  `json:"protocol" yaml:"protocol"`
+	SampleRateHz   float64 `json:"sample_rate_hz" yaml:"sample_rate_hz"`
+	PipelineRateHz float64 `json:"pipeline_rate_hz" yaml:"pipeline_rate_hz"`
+	TuneHz         float64 `json:"tune_hz" yaml:"tune_hz"`
+	DurationSec    float64 `json:"duration_sec" yaml:"duration_sec"`
+
+	// Throughput.
+	TotalSamples     int64   `json:"total_samples" yaml:"total_samples"`
+	Symbols          int64   `json:"symbols" yaml:"symbols"`
+	EffectiveBaud    float64 `json:"effective_baud" yaml:"effective_baud"`
+	ExpectedBaud     float64 `json:"expected_baud" yaml:"expected_baud"`
+	BaudDeviationPct float64 `json:"baud_deviation_pct" yaml:"baud_deviation_pct"`
+
+	// Lock.
+	Locked         bool      `json:"locked" yaml:"locked"`
+	LockLatencySec float64   `json:"lock_latency_sec" yaml:"lock_latency_sec"`
+	Lock           *LockInfo `json:"lock,omitempty" yaml:"lock,omitempty"`
+
+	// Grants + events.
+	Grants       []GrantRecord  `json:"grants" yaml:"grants"`
+	Events       []EventRecord  `json:"events" yaml:"events"`
+	EventCounts  map[string]int `json:"event_counts" yaml:"event_counts"`
+	DecodeErrors map[string]int `json:"decode_errors" yaml:"decode_errors"`
+
+	// Analysis (nil unless CollectIQDiag).
+	Signal *SignalQuality `json:"signal,omitempty" yaml:"signal,omitempty"`
+	P25P1  *P25P1Detail   `json:"p25p1,omitempty" yaml:"p25p1,omitempty"`
+
+	// Verdict (nil unless Config.Acceptance supplied).
+	Verdict *Verdict `json:"verdict,omitempty" yaml:"verdict,omitempty"`
+}
+
+// LockInfo is the flattened, protocol-agnostic view of a KindCCLocked
+// payload: the frequency every LockState carries, plus a Fields map of the
+// remaining protocol-specific fields (NAC/DUID, ColorCode/SystemID, MCC/MNC,
+// RAN, …) so one struct represents all 13 protocols' distinct LockState
+// types.
+type LockInfo struct {
+	FrequencyHz uint32         `json:"frequency_hz" yaml:"frequency_hz"`
+	Fields      map[string]any `json:"fields" yaml:"fields"`
+}
+
+// GrantRecord mirrors trunking.Grant, flattened with the stream-time offset
+// at which it was observed.
+type GrantRecord struct {
+	OffsetSec   float64 `json:"offset_sec" yaml:"offset_sec"`
+	GroupID     uint32  `json:"group_id" yaml:"group_id"`
+	SourceID    uint32  `json:"source_id" yaml:"source_id"`
+	ChannelID   uint8   `json:"channel_id" yaml:"channel_id"`
+	ChannelNum  uint16  `json:"channel_num" yaml:"channel_num"`
+	Timeslot    uint8   `json:"timeslot" yaml:"timeslot"`
+	FrequencyHz uint32  `json:"frequency_hz" yaml:"frequency_hz"`
+	Encrypted   bool    `json:"encrypted" yaml:"encrypted"`
+	Emergency   bool    `json:"emergency" yaml:"emergency"`
+}
+
+// EventRecord is one bus event captured generically — Kind plus the
+// reflection-flattened payload — so the JSONL stream and the events CSV
+// represent every protocol's events without a typed switch per protocol.
+type EventRecord struct {
+	Seq       int            `json:"seq" yaml:"seq"`
+	OffsetSec float64        `json:"offset_sec" yaml:"offset_sec"`
+	Kind      string         `json:"kind" yaml:"kind"`
+	Fields    map[string]any `json:"fields" yaml:"fields"`
+}
+
+// collector accumulates bus events into the Result-facing slices/maps. It is
+// driven by a single goroutine draining one subscription, so it needs no
+// locking; the engine reads the assembled fields after the drainer exits.
+type collector struct {
+	startWall   time.Time
+	seq         int
+	events      []EventRecord
+	grants      []GrantRecord
+	eventCounts map[string]int
+	decodeErr   map[string]int
+	locked      bool
+	lockLatency float64
+	lock        *LockInfo
+	// onEvent, when set, is called for every EventRecord as it is built —
+	// the streaming sink behind RunStream / JSONL.
+	onEvent func(EventRecord)
+}
+
+func newCollector(start time.Time, onEvent func(EventRecord)) *collector {
+	return &collector{
+		startWall:   start,
+		eventCounts: map[string]int{},
+		decodeErr:   map[string]int{},
+		onEvent:     onEvent,
+	}
+}
+
+// observe folds one bus event into the running totals.
+func (c *collector) observe(ev events.Event) {
+	offset := ev.Timestamp.Sub(c.startWall).Seconds()
+	if offset < 0 {
+		offset = 0
+	}
+	kind := string(ev.Kind)
+	c.eventCounts[kind]++
+
+	rec := EventRecord{Seq: c.seq, OffsetSec: offset, Kind: kind, Fields: flattenPayload(ev.Payload)}
+	c.seq++
+	c.events = append(c.events, rec)
+	if c.onEvent != nil {
+		c.onEvent(rec)
+	}
+
+	switch ev.Kind {
+	case events.KindCCLocked:
+		if !c.locked {
+			c.locked = true
+			c.lockLatency = offset
+			c.lock = lockInfoFromFields(rec.Fields)
+		}
+	case events.KindGrant:
+		if g, ok := ev.Payload.(trunking.Grant); ok {
+			c.grants = append(c.grants, GrantRecord{
+				OffsetSec:   offset,
+				GroupID:     g.GroupID,
+				SourceID:    g.SourceID,
+				ChannelID:   g.ChannelID,
+				ChannelNum:  g.ChannelNum,
+				Timeslot:    g.Timeslot,
+				FrequencyHz: g.FrequencyHz,
+				Encrypted:   g.Encrypted,
+				Emergency:   g.Emergency,
+			})
+		}
+	case events.KindDecodeError:
+		if de, ok := ev.Payload.(events.DecodeError); ok {
+			c.decodeErr[string(de.Stage)]++
+		}
+	}
+}
+
+// lockInfoFromFields pulls the common FrequencyHz out of a flattened lock
+// payload and keeps the remainder as protocol-specific Fields.
+func lockInfoFromFields(fields map[string]any) *LockInfo {
+	li := &LockInfo{Fields: map[string]any{}}
+	for k, v := range fields {
+		if k == "FrequencyHz" {
+			li.FrequencyHz = toUint32(v)
+			continue
+		}
+		li.Fields[k] = v
+	}
+	return li
+}
+
+// flattenPayload reflects an event payload into a JSON/YAML-friendly map of
+// its exported fields. Pointers are dereferenced; func/chan/unsafe fields
+// are skipped. A non-struct payload is wrapped as {"value": payload}. This
+// is what lets the collector capture all 13 protocols' distinct LockState
+// types (and every other payload) without a per-type switch.
+func flattenPayload(v any) map[string]any {
+	out := map[string]any{}
+	if v == nil {
+		return out
+	}
+	rv := reflect.ValueOf(v)
+	for rv.Kind() == reflect.Pointer {
+		if rv.IsNil() {
+			return out
+		}
+		rv = rv.Elem()
+	}
+	if rv.Kind() != reflect.Struct {
+		out["value"] = v
+		return out
+	}
+	rt := rv.Type()
+	for i := 0; i < rt.NumField(); i++ {
+		f := rt.Field(i)
+		if !f.IsExported() {
+			continue
+		}
+		switch rv.Field(i).Kind() {
+		case reflect.Func, reflect.Chan, reflect.UnsafePointer:
+			continue
+		}
+		out[f.Name] = rv.Field(i).Interface()
+	}
+	return out
+}
+
+// toUint32 best-effort coerces a reflected numeric field to uint32.
+func toUint32(v any) uint32 {
+	switch n := v.(type) {
+	case uint32:
+		return n
+	case uint16:
+		return uint32(n)
+	case uint8:
+		return uint32(n)
+	case uint64:
+		return uint32(n)
+	case uint:
+		return uint32(n)
+	case int:
+		return uint32(n)
+	case int32:
+		return uint32(n)
+	case int64:
+		return uint32(n)
+	default:
+		return 0
+	}
+}

--- a/internal/siglab/signal.go
+++ b/internal/siglab/signal.go
@@ -1,0 +1,105 @@
+package siglab
+
+import "github.com/MattCheramie/GopherTrunk/internal/sdr/rtlsdr"
+
+// SignalQuality is the protocol-agnostic demod-quality summary the analyzer
+// produces when Config.CollectIQDiag is set. It generalizes the parts of the
+// historical P25-only iqdiag report that apply to every protocol: the
+// recovered-symbol distribution (which exposes a collapsed or mis-calibrated
+// slicer) and the raw front-end I/Q imbalance (the leading cause of an
+// asymmetric eye). The deeper P25-specific FSW/NID landscape lives in
+// P25P1Detail.
+type SignalQuality struct {
+	// SymbolCardinality is 4 for the dibit (4-level) protocols and 2 for
+	// the bit (2-level) protocols.
+	SymbolCardinality int `json:"symbol_cardinality" yaml:"symbol_cardinality"`
+	// SymbolHistogram counts recovered symbols per value (len ==
+	// SymbolCardinality). A clean 4-level C4FM control channel sits near
+	// 25% per bin; a near-empty bin means the slicer collapsed, a single
+	// dominant bin means the signal is below the slicer thresholds.
+	SymbolHistogram []int64 `json:"symbol_histogram" yaml:"symbol_histogram"`
+	// SymbolHistogramPct is SymbolHistogram normalised to percentages.
+	SymbolHistogramPct []float64 `json:"symbol_histogram_pct" yaml:"symbol_histogram_pct"`
+
+	// Raw (pre-DDC) front-end I/Q imbalance. A clean front-end is balanced
+	// (≈0 dB gain, ≈0° phase) with image rejection ≳ 40 dB. Populated only
+	// when raw IQ was observed.
+	IQGainImbalanceDB   float64 `json:"iq_gain_imbalance_db" yaml:"iq_gain_imbalance_db"`
+	IQPhaseImbalanceDeg float64 `json:"iq_phase_imbalance_deg" yaml:"iq_phase_imbalance_deg"`
+	IQImageRejectionDB  float64 `json:"iq_image_rejection_db" yaml:"iq_image_rejection_db"`
+	IQObserved          bool    `json:"iq_observed" yaml:"iq_observed"`
+
+	// DecodeErrorRate is decode-error events per recovered 1000 symbols — a
+	// protocol-neutral proxy for FEC stress.
+	DecodeErrorRate float64 `json:"decode_error_rate_per_ksym" yaml:"decode_error_rate_per_ksym"`
+}
+
+// analyzer accumulates the observations behind a SignalQuality. It is fed
+// from the engine's SymbolTap (symbols) and read loop (raw IQ), so it works
+// for every protocol the factory map drives.
+type analyzer struct {
+	cardinality int
+	hist        []int64
+	symbols     int64
+	iqStats     rtlsdr.IQImbalanceStats
+	iqObserved  bool
+
+	// bufferSymbols retains the full recovered-symbol stream for the
+	// protocol-specific deep dive (P25 P1's FSW/NID landscape). Off by
+	// default since it is O(symbols) memory.
+	bufferSymbols bool
+	symBuf        []uint8
+}
+
+func newAnalyzer() *analyzer { return &analyzer{} }
+
+// observeSymbols folds a recovered-symbol chunk into the histogram. The
+// cardinality (2 vs 4) is inferred from the isBits flag the SymbolTap
+// carries; it is set on the first chunk and stays fixed thereafter.
+func (a *analyzer) observeSymbols(symbols []uint8, isBits bool) {
+	if a.hist == nil {
+		if isBits {
+			a.cardinality = 2
+		} else {
+			a.cardinality = 4
+		}
+		a.hist = make([]int64, a.cardinality)
+	}
+	mask := uint8(a.cardinality - 1)
+	for _, s := range symbols {
+		a.hist[s&mask]++
+	}
+	a.symbols += int64(len(symbols))
+	if a.bufferSymbols {
+		a.symBuf = append(a.symBuf, symbols...)
+	}
+}
+
+// observeIQ folds a chunk of raw (pre-DDC) IQ into the imbalance moments.
+func (a *analyzer) observeIQ(raw []complex64) {
+	a.iqStats.Observe(raw)
+	a.iqObserved = true
+}
+
+// result builds the SignalQuality from the accumulated observations.
+// decodeErrors / symbols give the per-ksym error rate.
+func (a *analyzer) result(decodeErrors int64) *SignalQuality {
+	sq := &SignalQuality{
+		SymbolCardinality:  a.cardinality,
+		SymbolHistogram:    a.hist,
+		SymbolHistogramPct: make([]float64, len(a.hist)),
+	}
+	if a.symbols > 0 {
+		for i, n := range a.hist {
+			sq.SymbolHistogramPct[i] = 100 * float64(n) / float64(a.symbols)
+		}
+		sq.DecodeErrorRate = 1000 * float64(decodeErrors) / float64(a.symbols)
+	}
+	if a.iqObserved && a.iqStats.Count() > 0 {
+		sq.IQObserved = true
+		sq.IQGainImbalanceDB = a.iqStats.GainImbalanceDB()
+		sq.IQPhaseImbalanceDeg = a.iqStats.PhaseImbalanceDeg()
+		sq.IQImageRejectionDB = a.iqStats.ImageRejectionDB()
+	}
+	return sq
+}

--- a/internal/siglab/synth.go
+++ b/internal/siglab/synth.go
@@ -1,0 +1,99 @@
+package siglab
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"math"
+	"os"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/demod"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// SynthOptions configures a synthesis run: which protocol to build, the
+// front-end impairments to overlay on the ideal modulator output, and the
+// on-disk capture format.
+type SynthOptions struct {
+	Protocol trunking.Protocol
+	Format   SampleFormat
+	// Impairments applied to the ideal IQ (SNR, carrier offset, DC spike,
+	// I/Q imbalance, multipath). The zero value is a clean capture.
+	Impairments demod.Impairments
+}
+
+// Synthesize builds a known-good (optionally impaired) capture for a
+// protocol and returns the IQ plus the Metadata describing how to decode and
+// grade it. Returns an error when no synthesis fixture is registered for the
+// protocol (see Fixtures for the supported set).
+func Synthesize(opts SynthOptions) ([]complex64, *Metadata, error) {
+	fx, ok := fixtures[opts.Protocol]
+	if !ok {
+		return nil, nil, fmt.Errorf("siglab: no synthesis fixture for protocol %s (have: %v)", opts.Protocol, Fixtures())
+	}
+	symbols := fx.build()
+	iq := fx.modulate(symbols, fx.sampleRate)
+	iq = demod.ApplyImpairments(iq, fx.sampleRate, opts.Impairments)
+
+	meta := &Metadata{
+		Protocol:     opts.Protocol.String(),
+		Source:       "synthesized",
+		SampleRateHz: fx.sampleRate,
+		Format:       opts.Format.String(),
+		System:       fx.systemKnobs,
+		Expected:     fx.expected,
+	}
+	return iq, meta, nil
+}
+
+// WriteCapture writes IQ to path in the given format (u8 or f32).
+func WriteCapture(path string, iq []complex64, format SampleFormat) error {
+	switch format {
+	case FormatF32:
+		return writeCaptureF32(path, iq)
+	default:
+		return writeCaptureU8(path, iq)
+	}
+}
+
+// WriteMetadata writes m to path as JSON (the sidecar `test` auto-discovers).
+func WriteMetadata(path string, m *Metadata) error {
+	raw, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, append(raw, '\n'), 0o644)
+}
+
+// writeCaptureF32 writes interleaved little-endian float32 IQ (GNU Radio
+// cfile). Inverse of decodeF32.
+func writeCaptureF32(path string, iq []complex64) error {
+	buf := make([]byte, len(iq)*8)
+	for i, s := range iq {
+		binary.LittleEndian.PutUint32(buf[8*i:], math.Float32bits(real(s)))
+		binary.LittleEndian.PutUint32(buf[8*i+4:], math.Float32bits(imag(s)))
+	}
+	return os.WriteFile(path, buf, 0o644)
+}
+
+// writeCaptureU8 writes rtl_sdr 8-bit unsigned interleaved IQ. Inverse of
+// decodeU8: maps [-1,+1] back to [0,255] centred on 127.5, clamped.
+func writeCaptureU8(path string, iq []complex64) error {
+	buf := make([]byte, len(iq)*2)
+	for i, s := range iq {
+		buf[2*i] = floatToU8(real(s))
+		buf[2*i+1] = floatToU8(imag(s))
+	}
+	return os.WriteFile(path, buf, 0o644)
+}
+
+func floatToU8(v float32) byte {
+	x := float64(v)*127.5 + 127.5
+	if x < 0 {
+		x = 0
+	}
+	if x > 255 {
+		x = 255
+	}
+	return byte(math.Round(x))
+}

--- a/internal/siglab/synth_test.go
+++ b/internal/siglab/synth_test.go
@@ -1,0 +1,92 @@
+package siglab
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// TestSynthDecodeRoundTrip is the closed synthesize→decode→grade loop: for
+// every registered fixture, generate a clean capture + metadata, run it back
+// through the engine, and assert the metadata's acceptance criteria pass.
+// This is the strongest end-to-end check that the engine drives each
+// protocol's production pipeline correctly.
+func TestSynthDecodeRoundTrip(t *testing.T) {
+	for _, proto := range Fixtures() {
+		proto := proto
+		t.Run(proto.String(), func(t *testing.T) {
+			iq, meta, err := Synthesize(SynthOptions{Protocol: proto, Format: FormatF32})
+			if err != nil {
+				t.Fatalf("Synthesize(%s): %v", proto, err)
+			}
+			dir := t.TempDir()
+			capPath := filepath.Join(dir, proto.String()+".cfile")
+			if err := WriteCapture(capPath, iq, FormatF32); err != nil {
+				t.Fatalf("WriteCapture: %v", err)
+			}
+
+			cfg, err := meta.Config(true)
+			if err != nil {
+				t.Fatalf("meta.Config: %v", err)
+			}
+			res, err := Run(capPath, cfg)
+			if err != nil {
+				t.Fatalf("Run: %v", err)
+			}
+			if res.Verdict == nil {
+				t.Fatal("expected a verdict (acceptance was set)")
+			}
+			if !res.Verdict.Pass {
+				t.Errorf("synth round-trip failed acceptance for %s: %v\n  locked=%v lock=%+v",
+					proto, res.Verdict.Failures, res.Locked, res.Lock)
+			}
+		})
+	}
+}
+
+// TestSynthUnsupportedProtocol confirms a protocol without a fixture reports
+// a helpful error rather than panicking.
+func TestSynthUnsupportedProtocol(t *testing.T) {
+	if _, _, err := Synthesize(SynthOptions{Protocol: trunking.ProtocolLTR}); HasFixture(trunking.ProtocolLTR) == (err != nil) {
+		// If LTR has no fixture, err must be non-nil; if it has one, err nil.
+		t.Errorf("Synthesize/HasFixture disagree for LTR: hasFixture=%v err=%v", HasFixture(trunking.ProtocolLTR), err)
+	}
+}
+
+// TestMetadataRoundTrip writes a synthesized fixture's metadata to JSON and
+// reloads it, confirming the loader and Config builder agree.
+func TestMetadataRoundTrip(t *testing.T) {
+	_, meta, err := Synthesize(SynthOptions{Protocol: trunking.ProtocolP25, Format: FormatF32})
+	if err != nil {
+		t.Fatalf("Synthesize: %v", err)
+	}
+	dir := t.TempDir()
+	mp := filepath.Join(dir, "p25.metadata.json")
+	if err := WriteMetadata(mp, meta); err != nil {
+		t.Fatalf("WriteMetadata: %v", err)
+	}
+	got, err := LoadMetadata(mp)
+	if err != nil {
+		t.Fatalf("LoadMetadata: %v", err)
+	}
+	if got.Protocol != "p25" || got.SampleRateHz != 48000 {
+		t.Errorf("metadata mismatch: %+v", got)
+	}
+	if got.Expected.Lock == nil || !*got.Expected.Lock {
+		t.Errorf("expected lock acceptance preserved, got %+v", got.Expected)
+	}
+}
+
+// TestDiscoverMetadata confirms sidecar discovery by stem.
+func TestDiscoverMetadata(t *testing.T) {
+	dir := t.TempDir()
+	capPath := filepath.Join(dir, "cap.cfile")
+	metaPath := filepath.Join(dir, "cap.metadata.json")
+	if err := WriteMetadata(metaPath, &Metadata{Protocol: "p25", SampleRateHz: 48000}); err != nil {
+		t.Fatalf("WriteMetadata: %v", err)
+	}
+	if got := DiscoverMetadata(capPath); got != metaPath {
+		t.Errorf("DiscoverMetadata = %q, want %q", got, metaPath)
+	}
+}

--- a/internal/siglab/tune.go
+++ b/internal/siglab/tune.go
@@ -1,0 +1,44 @@
+package siglab
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp"
+)
+
+// estimateCaptureCarrierHz reads a prefix of f, estimates the dominant
+// carrier offset across the full band, then rewinds f to the start so the
+// prefix is still decoded by the main read loop. It is the shared
+// implementation behind -auto-tune (lifted verbatim from replay.go so the
+// replay subcommand and the engine share one estimator).
+func estimateCaptureCarrierHz(f *os.File, decode SampleDecoder, bytesPerSample int, sampleRateHz float64) (float64, error) {
+	const prefixSamples = 262144
+	buf := make([]byte, prefixSamples*bytesPerSample)
+	n, err := io.ReadFull(f, buf)
+	if err != nil && !errors.Is(err, io.ErrUnexpectedEOF) && !errors.Is(err, io.EOF) {
+		return 0, err
+	}
+	if _, serr := f.Seek(0, io.SeekStart); serr != nil {
+		return 0, serr
+	}
+	pairs := n / bytesPerSample
+	if pairs == 0 {
+		return 0, fmt.Errorf("capture has no samples to estimate from")
+	}
+	iq := make([]complex64, pairs)
+	decode(buf[:pairs*bytesPerSample], iq)
+	return dsp.EstimateCarrierOffsetHz(iq, sampleRateHz, sampleRateHz*0.5), nil
+}
+
+// ratioOrZero returns num/den, or 0 when den is too small to divide safely.
+// Shared with the replay state log (avoids a divide-by-zero / +Inf on a
+// not-yet-seeded value).
+func ratioOrZero(num, den float64) float64 {
+	if den < 1e-12 && den > -1e-12 {
+		return 0
+	}
+	return num / den
+}

--- a/internal/siglab/verdict.go
+++ b/internal/siglab/verdict.go
@@ -1,0 +1,188 @@
+package siglab
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+)
+
+// Acceptance is the expected-outcome contract a capture is graded against by
+// the `test` harness. A nil field means "don't check this dimension". It
+// generalizes the per-test assertions the integration_cc_*_test.go files
+// and samples/README.md acceptance criteria describe into one schema.
+type Acceptance struct {
+	// Lock, when non-nil, requires the run to (true) or to not (false) lock
+	// the control channel.
+	Lock *bool `json:"lock,omitempty" yaml:"lock,omitempty"`
+	// LockLatencyMaxSec caps the time-to-first-lock (0 ⇒ unchecked).
+	LockLatencyMaxSec float64 `json:"lock_latency_max_sec,omitempty" yaml:"lock_latency_max_sec,omitempty"`
+	// LockFields are expected lock-payload fields (NAC, ColorCode,
+	// SystemID, …). Values may be given as numbers or hex strings
+	// ("0x293"); comparison is hex-tolerant. Matched as a subset of the
+	// observed lock fields (and the common frequency_hz).
+	LockFields map[string]any `json:"lock_fields,omitempty" yaml:"lock_fields,omitempty"`
+	// MinGrants requires at least this many grants (0 ⇒ unchecked).
+	MinGrants int `json:"min_grants,omitempty" yaml:"min_grants,omitempty"`
+	// BaudTolerancePct caps |effective − expected| / expected (0 ⇒ unchecked).
+	BaudTolerancePct float64 `json:"baud_tolerance_pct,omitempty" yaml:"baud_tolerance_pct,omitempty"`
+	// MaxDecodeErrorRate caps decode errors per 1000 symbols (0 ⇒ unchecked).
+	MaxDecodeErrorRate float64 `json:"max_decode_error_rate,omitempty" yaml:"max_decode_error_rate,omitempty"`
+}
+
+// Verdict is the pass/fail outcome of grading a Result against an Acceptance.
+type Verdict struct {
+	Pass     bool     `json:"pass" yaml:"pass"`
+	Failures []string `json:"failures" yaml:"failures"`
+	Checks   []string `json:"checks" yaml:"checks"`
+}
+
+// evaluateAcceptance grades r against a, returning a Verdict. Every checked
+// dimension contributes a line to Checks; failures also append to Failures.
+func evaluateAcceptance(r *Result, a *Acceptance) *Verdict {
+	v := &Verdict{Pass: true}
+	fail := func(msg string) {
+		v.Pass = false
+		v.Failures = append(v.Failures, msg)
+		v.Checks = append(v.Checks, "FAIL: "+msg)
+	}
+	pass := func(msg string) { v.Checks = append(v.Checks, "ok: "+msg) }
+
+	if a.Lock != nil {
+		want := *a.Lock
+		if r.Locked != want {
+			fail(fmt.Sprintf("lock: want %v, got %v", want, r.Locked))
+		} else {
+			pass(fmt.Sprintf("lock = %v", want))
+		}
+	}
+	if a.LockLatencyMaxSec > 0 {
+		switch {
+		case !r.Locked:
+			fail(fmt.Sprintf("lock latency: required ≤ %.2fs but never locked", a.LockLatencyMaxSec))
+		case r.LockLatencySec > a.LockLatencyMaxSec:
+			fail(fmt.Sprintf("lock latency: %.2fs > %.2fs", r.LockLatencySec, a.LockLatencyMaxSec))
+		default:
+			pass(fmt.Sprintf("lock latency %.2fs ≤ %.2fs", r.LockLatencySec, a.LockLatencyMaxSec))
+		}
+	}
+	for k, want := range a.LockFields {
+		got, ok := lookupLockField(r.Lock, k)
+		if !ok {
+			fail(fmt.Sprintf("lock field %q: missing (no lock or field absent)", k))
+			continue
+		}
+		if !fieldMatches(want, got) {
+			fail(fmt.Sprintf("lock field %q: want %v, got %v", k, want, got))
+		} else {
+			pass(fmt.Sprintf("lock field %q = %v", k, want))
+		}
+	}
+	if a.MinGrants > 0 {
+		if len(r.Grants) < a.MinGrants {
+			fail(fmt.Sprintf("grants: %d < %d", len(r.Grants), a.MinGrants))
+		} else {
+			pass(fmt.Sprintf("grants %d ≥ %d", len(r.Grants), a.MinGrants))
+		}
+	}
+	if a.BaudTolerancePct > 0 {
+		if r.ExpectedBaud <= 0 {
+			pass("baud tolerance: skipped (no nominal baud for protocol)")
+		} else if math.Abs(r.BaudDeviationPct) > a.BaudTolerancePct {
+			fail(fmt.Sprintf("baud deviation: %.2f%% > %.2f%%", math.Abs(r.BaudDeviationPct), a.BaudTolerancePct))
+		} else {
+			pass(fmt.Sprintf("baud deviation %.2f%% ≤ %.2f%%", math.Abs(r.BaudDeviationPct), a.BaudTolerancePct))
+		}
+	}
+	if a.MaxDecodeErrorRate > 0 {
+		rate := 0.0
+		if r.Signal != nil {
+			rate = r.Signal.DecodeErrorRate
+		}
+		if rate > a.MaxDecodeErrorRate {
+			fail(fmt.Sprintf("decode-error rate: %.2f/ksym > %.2f/ksym", rate, a.MaxDecodeErrorRate))
+		} else {
+			pass(fmt.Sprintf("decode-error rate %.2f/ksym ≤ %.2f/ksym", rate, a.MaxDecodeErrorRate))
+		}
+	}
+	return v
+}
+
+// lookupLockField finds a lock field by name, tolerating the snake_case the
+// metadata schema uses vs the Go field names the flattener emits (e.g.
+// "system_id" ↔ "SystemID", "frequency_hz" ↔ the dedicated FrequencyHz).
+func lookupLockField(lock *LockInfo, key string) (any, bool) {
+	if lock == nil {
+		return nil, false
+	}
+	if normKey(key) == "frequencyhz" {
+		return lock.FrequencyHz, true
+	}
+	for k, v := range lock.Fields {
+		if normKey(k) == normKey(key) {
+			return v, true
+		}
+	}
+	return nil, false
+}
+
+func normKey(s string) string {
+	return strings.ToLower(strings.ReplaceAll(s, "_", ""))
+}
+
+// fieldMatches compares an expected acceptance value (number or hex/decimal
+// string) to an observed value (typically a reflected integer), coercing
+// both to uint64 when possible so 0x293, "659" and uint16(659) all match.
+// Falls back to string equality for non-numeric values.
+func fieldMatches(expected, got any) bool {
+	en, eok := toUint64(expected)
+	gn, gok := toUint64(got)
+	if eok && gok {
+		return en == gn
+	}
+	return fmt.Sprintf("%v", expected) == fmt.Sprintf("%v", got)
+}
+
+// toUint64 coerces numbers and hex/decimal strings to uint64.
+func toUint64(v any) (uint64, bool) {
+	switch n := v.(type) {
+	case uint64:
+		return n, true
+	case uint:
+		return uint64(n), true
+	case uint32:
+		return uint64(n), true
+	case uint16:
+		return uint64(n), true
+	case uint8:
+		return uint64(n), true
+	case int:
+		return uint64(n), true
+	case int64:
+		return uint64(n), true
+	case int32:
+		return uint64(n), true
+	case int16:
+		return uint64(n), true
+	case int8:
+		return uint64(n), true
+	case float64:
+		return uint64(n), true
+	case float32:
+		return uint64(n), true
+	case string:
+		s := strings.TrimSpace(n)
+		if strings.HasPrefix(strings.ToLower(s), "0x") {
+			if u, err := strconv.ParseUint(s[2:], 16, 64); err == nil {
+				return u, true
+			}
+			return 0, false
+		}
+		if u, err := strconv.ParseUint(s, 10, 64); err == nil {
+			return u, true
+		}
+		return 0, false
+	default:
+		return 0, false
+	}
+}

--- a/internal/siglab/verdict_test.go
+++ b/internal/siglab/verdict_test.go
@@ -1,0 +1,59 @@
+package siglab
+
+import "testing"
+
+func TestFieldMatchesHexTolerant(t *testing.T) {
+	cases := []struct {
+		expected any
+		got      any
+		want     bool
+	}{
+		{"0x293", uint16(0x293), true},
+		{"659", uint16(0x293), true}, // 0x293 == 659
+		{0x293, uint16(0x293), true},
+		{"0xA", uint8(10), true},
+		{"0x294", uint16(0x293), false},
+		{"sch/hd", "sch/hd", true},
+		{"sch/hd", "bsch", false},
+	}
+	for _, c := range cases {
+		if got := fieldMatches(c.expected, c.got); got != c.want {
+			t.Errorf("fieldMatches(%v, %v) = %v, want %v", c.expected, c.got, got, c.want)
+		}
+	}
+}
+
+func TestEvaluateAcceptance(t *testing.T) {
+	r := &Result{
+		Locked:         true,
+		LockLatencySec: 0.5,
+		Lock:           &LockInfo{FrequencyHz: 851000000, Fields: map[string]any{"NAC": uint16(0x293)}},
+		Grants:         []GrantRecord{{}, {}},
+		ExpectedBaud:   4800,
+		EffectiveBaud:  4800,
+		Signal:         &SignalQuality{DecodeErrorRate: 1.0},
+	}
+	pass := evaluateAcceptance(r, &Acceptance{
+		Lock:               boolPtr(true),
+		LockLatencyMaxSec:  1.0,
+		LockFields:         map[string]any{"nac": "0x293", "frequency_hz": 851000000},
+		MinGrants:          2,
+		BaudTolerancePct:   1,
+		MaxDecodeErrorRate: 5,
+	})
+	if !pass.Pass {
+		t.Errorf("expected pass, got failures: %v", pass.Failures)
+	}
+
+	fail := evaluateAcceptance(r, &Acceptance{
+		Lock:       boolPtr(true),
+		LockFields: map[string]any{"nac": "0x999"},
+		MinGrants:  5,
+	})
+	if fail.Pass {
+		t.Error("expected failure for wrong NAC + too-few grants")
+	}
+	if len(fail.Failures) != 2 {
+		t.Errorf("expected 2 failures, got %d: %v", len(fail.Failures), fail.Failures)
+	}
+}

--- a/samples/README.md
+++ b/samples/README.md
@@ -152,6 +152,59 @@ output is fine for "does the decoder not crash" smoke tests but
 isn't enough to **validate** correctness — the schema each subfolder
 documents is what unblocks the corresponding follow-up.
 
+## Signal Lab: replay / analyze / gen / test
+
+The `gophertrunk` binary ships an offline signal toolkit (the `internal/siglab`
+engine) that drives **any** protocol GopherTrunk decodes through the same
+production pipelines the daemon runs, with clean structured output:
+
+```
+gophertrunk replay  -in cap.cfile -format f32 -sample-rate 2400000 -protocol tetra -auto-tune
+gophertrunk analyze -in cap.cfile -format f32 -sample-rate 2400000 -protocol p25p1 -out-format json -out cap.json
+gophertrunk gen     -protocol dmr  -out dmr.cfile -snr 20 -freq-offset 300
+gophertrunk test    -capture dmr.cfile          # grades against the sidecar metadata; exit 0/1
+gophertrunk siglab  -in cap.cfile -protocol p25p1 -format f32 -sample-rate 2400000   # standalone TUI
+```
+
+- **`analyze`** emits `text` / `json` / `jsonl` / `yaml` / `csv` / `csv-events`
+  over a protocol-agnostic result model (lock state, grants, per-event records,
+  symbol histogram, IQ imbalance, decode-error rate; plus a P25-Phase-1
+  FSW/NID deep dive).
+- **`gen`** synthesizes a known-good (optionally impaired) capture plus a
+  `*.metadata.json` sidecar, using the production modulators.
+- **`test`** decodes a capture (real-air or synthesized) and grades it against
+  the sidecar's acceptance criteria — a CI-ready regression gate.
+
+### Unified metadata schema
+
+A capture is graded via a sidecar (`<stem>.metadata.json` or `.yaml`,
+auto-discovered by `test`). Minimal example:
+
+```json
+{
+  "protocol": "dmr",
+  "source": "real-air, Site 4",
+  "sample_rate_hz": 2400000,
+  "center_freq_hz": 460000000,
+  "format": "f32",
+  "auto_tune": true,
+  "system": { "tetra_colour_code": "1", "tetra_channel": "bsch" },
+  "expected": {
+    "lock": true,
+    "lock_latency_max_sec": 5.0,
+    "lock_fields": { "color_code": 10, "system_id": "0x1234" },
+    "min_grants": 0,
+    "baud_tolerance_pct": 5,
+    "max_decode_error_rate": 50
+  }
+}
+```
+
+`lock_fields` values may be decimal or hex strings; matching is hex-tolerant.
+`system` keys are the YAML config-key names from `config.example.yaml`
+(`p25_phase1_demod_mode`, `tetra_colour_code`, `edacs_bch_mode`, …). This is
+the schema the per-protocol acceptance criteria above map onto.
+
 ## Wiring captures into tests
 
 Captures dropped here aren't auto-loaded. To exercise one through a


### PR DESCRIPTION
Introduce internal/siglab, a protocol-agnostic offline engine that drives
any protocol GopherTrunk decodes through the production ccdecoder pipelines
and collects a structured Result with exporters and a metadata-driven
acceptance harness.

- ccdecoder: add public NewPipeline/HasFactory/RegisteredProtocols
  accessors, export DDCTargetForProtocol (fixes TETRA's 144 kHz channel
  target for offline use), and add an optional SymbolTap to PipelineOptions
  so recovered symbols are observable for every protocol.
- siglab core: Config + Result model, generic reflection-based bus-event
  capture (works across all 13 LockState types), engine Run/RunStream
  mirroring the daemon's DDC -> pipeline chain.
- analysis: protocol-agnostic signal-quality analyzer (symbol histogram,
  IQ imbalance, decode-error rate) plus a P25 Phase 1 dibit-domain deep
  dive (FSW correlation, NID decode).
- exporters: JSON, JSONL (streaming), YAML, CSV (summary + events).
- synthesis: gen fixtures (P25 P1 + DMR Tier III) + impairments + capture
  writers; unified metadata schema/loader + acceptance verdict.

Tests cover accessor construction for all registered protocols, the
synth->decode->grade round-trip (P25 + DMR T3 lock through real pipelines),
exporters, metadata, and verdict matching.

https://claude.ai/code/session_01P8Es75yBSfmW7xe2FErfuM