### PR TITLE
siglab: complete gen fixtures for all 13 protocols + per-protocol deep analysis

### DIFF
--- a/cmd/gophertrunk/siglab_render.go
+++ b/cmd/gophertrunk/siglab_render.go
@@ -59,11 +59,48 @@ func renderResultText(w io.Writer, r *siglab.Result) {
 	if r.Signal != nil {
 		renderSignal(w, r.Signal)
 	}
-	if r.P25P1 != nil {
-		renderP25Detail(w, r.P25P1)
+	switch d := r.Detail.(type) {
+	case *siglab.P25P1Detail:
+		renderP25Detail(w, d)
+	case *siglab.ProtocolDetail:
+		renderProtocolDetail(w, d)
 	}
 	if r.Verdict != nil {
 		renderVerdict(w, r.Verdict)
+	}
+}
+
+// renderProtocolDetail prints the symbol-domain deep dive (histogram + sync
+// landscape + FEC tally) for the non-P25-P1 protocols.
+func renderProtocolDetail(w io.Writer, d *siglab.ProtocolDetail) {
+	fmt.Fprintf(w, "siglab: %s detail  symbols=%d  cardinality=%d\n", d.Protocol, d.SymbolsBuffered, d.SymbolCardinality)
+	for i, n := range d.SymbolHistogram {
+		pct := 0.0
+		if i < len(d.SymbolHistogramPct) {
+			pct = d.SymbolHistogramPct[i]
+		}
+		fmt.Fprintf(w, "siglab:   symbol %d: %d (%.1f%%)\n", i, n, pct)
+	}
+	if s := d.Sync; s != nil {
+		fmt.Fprintf(w, "siglab:   sync landscape (len=%d, tol=%d): winner=%s rot=%d hits=%d modal_spacing=%d\n",
+			s.SyncLen, s.Tolerance, s.WinnerVariant, s.WinnerRotation, s.WinnerHits, s.ModalSpacing)
+		for _, st := range s.Stats {
+			if st.Hits > 0 || st.BestDist <= s.Tolerance {
+				fmt.Fprintf(w, "siglab:     %s rot %d: best_dist=%d (@%d) hits=%d\n",
+					st.Variant, st.Rotation, st.BestDist, st.BestPos, st.Hits)
+			}
+		}
+	}
+	for _, f := range d.FEC {
+		fmt.Fprintf(w, "siglab:   fec %s: frames=%d clean=%d corrected=%d uncorrectable=%d",
+			f.Stage, f.Frames, f.Clean, f.Corrected, f.Uncorrectable)
+		if f.CRCPass+f.CRCFail > 0 {
+			fmt.Fprintf(w, " crc_pass=%d crc_fail=%d", f.CRCPass, f.CRCFail)
+		}
+		fmt.Fprintln(w)
+	}
+	if d.Notes != "" {
+		fmt.Fprintf(w, "siglab:   note: %s\n", d.Notes)
 	}
 }
 

--- a/internal/siglab/detail.go
+++ b/internal/siglab/detail.go
@@ -1,0 +1,190 @@
+package siglab
+
+import (
+	"github.com/MattCheramie/GopherTrunk/internal/radio/dmr"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/dpmr"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/dstar"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/edacs"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/motorola"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/nxdn"
+	p25phase2 "github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase2"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/tetra"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/ysf"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// ProtocolDetail is the protocol-specific deep dive for every protocol other
+// than P25 Phase 1 (which keeps its richer P25P1Detail with soft eye +
+// receiver state). It is computed from the buffered recovered-symbol stream:
+// a symbol histogram, a sync-correlation landscape against the protocol's own
+// sync word(s), and — where tractable — a per-stage FEC-decode tally. This is
+// the symbol-domain analog of P25's FSW landscape + NID-BCH probe, the most
+// valuable half of a deep dive, available without any receiver changes.
+type ProtocolDetail struct {
+	Protocol           string         `json:"protocol" yaml:"protocol"`
+	SymbolsBuffered    int            `json:"symbols_buffered" yaml:"symbols_buffered"`
+	SymbolCardinality  int            `json:"symbol_cardinality" yaml:"symbol_cardinality"`
+	SymbolHistogram    []int64        `json:"symbol_histogram" yaml:"symbol_histogram"`
+	SymbolHistogramPct []float64      `json:"symbol_histogram_pct" yaml:"symbol_histogram_pct"`
+	Sync               *SyncLandscape `json:"sync,omitempty" yaml:"sync,omitempty"`
+	FEC                []FECStat      `json:"fec,omitempty" yaml:"fec,omitempty"`
+	Notes              string         `json:"notes,omitempty" yaml:"notes,omitempty"`
+}
+
+// FECStat tallies one FEC stage's outcomes across the frames found at clean
+// sync hits — the direct analog of P25's NID trusted/marginal/uncorrectable.
+type FECStat struct {
+	Stage         string `json:"stage" yaml:"stage"`
+	Frames        int    `json:"frames" yaml:"frames"`
+	Clean         int    `json:"clean" yaml:"clean"`
+	Corrected     int    `json:"corrected" yaml:"corrected"`
+	Uncorrectable int    `json:"uncorrectable" yaml:"uncorrectable"`
+	CRCPass       int    `json:"crc_pass,omitempty" yaml:"crc_pass,omitempty"`
+	CRCFail       int    `json:"crc_fail,omitempty" yaml:"crc_fail,omitempty"`
+}
+
+// detailSpec describes how to build one protocol's ProtocolDetail: its symbol
+// cardinality, sync-correlation tolerance, the sync variant(s) to correlate
+// against, an optional FEC tally over the clean sync hits, and notes.
+type detailSpec struct {
+	cardinality int
+	tolerance   int
+	syncFn      func() []SyncVariant
+	fec         func(stream []uint8, land *SyncLandscape) []FECStat
+	notes       string
+}
+
+// detailSpecs is the per-protocol deep-analysis registry. P25 Phase 1 is
+// absent — it uses the dedicated deep path (P25P1Detail).
+var detailSpecs = map[trunking.Protocol]detailSpec{
+	trunking.ProtocolDMR: {
+		cardinality: 4, tolerance: 4, syncFn: dmrSyncVariants,
+	},
+	trunking.ProtocolDMRTier2: {
+		cardinality: 4, tolerance: 4, syncFn: dmrSyncVariants,
+		notes: "DMR Tier II is voice-only; sync + slot-type only (no CSBK path).",
+	},
+	trunking.ProtocolP25Phase2: {
+		cardinality: 4, tolerance: 3,
+		syncFn: func() []SyncVariant {
+			return []SyncVariant{
+				{Name: "outbound", Pattern: p25phase2.OutboundSyncDibits()},
+				{Name: "inbound", Pattern: p25phase2.InboundSyncDibits()},
+			}
+		},
+	},
+	trunking.ProtocolNXDN: {
+		cardinality: 4, tolerance: 1,
+		syncFn: func() []SyncVariant {
+			return []SyncVariant{
+				{Name: "outbound", Pattern: append([]uint8(nil), nxdn.FSWDibitsOutbound...)},
+				{Name: "inbound", Pattern: append([]uint8(nil), nxdn.FSWDibitsInbound...)},
+			}
+		},
+	},
+	trunking.ProtocolDPMR: {
+		cardinality: 4, tolerance: 4,
+		syncFn: func() []SyncVariant {
+			return []SyncVariant{
+				{Name: "fs1", Pattern: dpmr.FS1Dibits()},
+				{Name: "fs2", Pattern: dpmr.FS2Dibits()},
+				{Name: "fs3", Pattern: dpmr.FS3Dibits()},
+			}
+		},
+		notes: "dPMR CSBKs carry no inner FEC; sync landscape only.",
+	},
+	trunking.ProtocolYSF: {
+		cardinality: 4, tolerance: 3,
+		syncFn: func() []SyncVariant { return oneVariant("fsw", append([]uint8(nil), ysf.FSWPattern...)) },
+	},
+	trunking.ProtocolTETRA: {
+		cardinality: 4, tolerance: 6,
+		syncFn: func() []SyncVariant {
+			return []SyncVariant{
+				{Name: "normal", Pattern: tetra.NormalSyncDibits()},
+				{Name: "extended", Pattern: tetra.ExtendedSyncDibits()},
+			}
+		},
+	},
+	trunking.ProtocolEDACS: {
+		cardinality: 2, tolerance: 3,
+		syncFn: func() []SyncVariant { return oneVariant("outbound", edacs.OutboundSyncBits()) },
+	},
+	trunking.ProtocolMotorola: {
+		cardinality: 2, tolerance: 3,
+		syncFn: func() []SyncVariant { return oneVariant("outbound", motorola.OutboundSyncBits()) },
+	},
+	trunking.ProtocolDStar: {
+		cardinality: 2, tolerance: 2,
+		syncFn: func() []SyncVariant { return oneVariant("framesync", dstar.FrameSyncBitsSlice()) },
+	},
+	trunking.ProtocolMPT1327: {
+		cardinality: 2, tolerance: 2,
+		syncFn: func() []SyncVariant { return oneVariant("cwsc", mptCWSCBits()) },
+		notes:  "MPT codewords run back-to-back; a CWSC need not precede each.",
+	},
+	trunking.ProtocolLTR: {
+		cardinality: 2, tolerance: 0,
+		notes: "LTR has no frame-sync word; alignment is Sync-bit based — histogram only.",
+	},
+}
+
+// hasDetailSpec reports whether a symbol-domain detail builder is registered.
+func hasDetailSpec(p trunking.Protocol) bool {
+	_, ok := detailSpecs[p]
+	return ok
+}
+
+// buildProtocolDetail computes the ProtocolDetail for p from the buffered
+// symbol stream. Returns nil when no spec is registered or the stream is empty.
+func buildProtocolDetail(p trunking.Protocol, symbols []uint8, isBits bool) any {
+	spec, ok := detailSpecs[p]
+	if !ok || len(symbols) == 0 {
+		return nil
+	}
+	card := spec.cardinality
+	d := &ProtocolDetail{
+		Protocol:          p.String(),
+		SymbolsBuffered:   len(symbols),
+		SymbolCardinality: card,
+		SymbolHistogram:   make([]int64, card),
+		Notes:             spec.notes,
+	}
+	mask := uint8(card - 1)
+	for _, s := range symbols {
+		d.SymbolHistogram[s&mask]++
+	}
+	d.SymbolHistogramPct = make([]float64, card)
+	for i, n := range d.SymbolHistogram {
+		d.SymbolHistogramPct[i] = 100 * float64(n) / float64(len(symbols))
+	}
+
+	if spec.syncFn != nil {
+		d.Sync = computeSyncLandscape(symbols, spec.syncFn(), card, spec.tolerance)
+		if d.Sync != nil && spec.fec != nil {
+			d.FEC = spec.fec(symbols, d.Sync)
+		}
+	}
+	return d
+}
+
+// dmrSyncVariants converts the 9 ETSI DMR sync words to landscape variants.
+func dmrSyncVariants() []SyncVariant {
+	out := make([]SyncVariant, 0, len(dmr.AllSyncs))
+	for _, s := range dmr.AllSyncs {
+		d := s.Dibits
+		out = append(out, SyncVariant{Name: s.Name, Pattern: append([]uint8(nil), d[:]...)})
+	}
+	return out
+}
+
+// mptCWSCBits returns the 16-bit MPT 1327 Codeword Synchronisation Code
+// (0xC4D7, MSB-first) as a bit pattern.
+func mptCWSCBits() []uint8 {
+	const cwsc uint16 = 0xC4D7
+	out := make([]uint8, 16)
+	for i := 0; i < 16; i++ {
+		out[i] = uint8((cwsc >> uint(15-i)) & 1)
+	}
+	return out
+}

--- a/internal/siglab/detail.go
+++ b/internal/siglab/detail.go
@@ -58,10 +58,10 @@ type detailSpec struct {
 // absent — it uses the dedicated deep path (P25P1Detail).
 var detailSpecs = map[trunking.Protocol]detailSpec{
 	trunking.ProtocolDMR: {
-		cardinality: 4, tolerance: 4, syncFn: dmrSyncVariants,
+		cardinality: 4, tolerance: 4, syncFn: dmrSyncVariants, fec: dmrSlotTypeFEC,
 	},
 	trunking.ProtocolDMRTier2: {
-		cardinality: 4, tolerance: 4, syncFn: dmrSyncVariants,
+		cardinality: 4, tolerance: 4, syncFn: dmrSyncVariants, fec: dmrSlotTypeFEC,
 		notes: "DMR Tier II is voice-only; sync + slot-type only (no CSBK path).",
 	},
 	trunking.ProtocolP25Phase2: {
@@ -72,6 +72,7 @@ var detailSpecs = map[trunking.Protocol]detailSpec{
 				{Name: "inbound", Pattern: p25phase2.InboundSyncDibits()},
 			}
 		},
+		notes: "ISCH Golay / MAC trellis tallies are a follow-up (need superframe re-framing).",
 	},
 	trunking.ProtocolNXDN: {
 		cardinality: 4, tolerance: 1,
@@ -81,6 +82,7 @@ var detailSpecs = map[trunking.Protocol]detailSpec{
 				{Name: "inbound", Pattern: append([]uint8(nil), nxdn.FSWDibitsInbound...)},
 			}
 		},
+		notes: "LICH Hamming / CAC Viterbi tallies are a follow-up (need CAC de-interleave).",
 	},
 	trunking.ProtocolDPMR: {
 		cardinality: 4, tolerance: 4,
@@ -96,6 +98,7 @@ var detailSpecs = map[trunking.Protocol]detailSpec{
 	trunking.ProtocolYSF: {
 		cardinality: 4, tolerance: 3,
 		syncFn: func() []SyncVariant { return oneVariant("fsw", append([]uint8(nil), ysf.FSWPattern...)) },
+		notes:  "FICH Viterbi / CRC tally is a follow-up (need FICH depuncture).",
 	},
 	trunking.ProtocolTETRA: {
 		cardinality: 4, tolerance: 6,
@@ -105,18 +108,22 @@ var detailSpecs = map[trunking.Protocol]detailSpec{
 				{Name: "extended", Pattern: tetra.ExtendedSyncDibits()},
 			}
 		},
+		notes: "RCPC/RM/Viterbi tallies are a follow-up (need per-channel de-interleave).",
 	},
 	trunking.ProtocolEDACS: {
 		cardinality: 2, tolerance: 3,
 		syncFn: func() []SyncVariant { return oneVariant("outbound", edacs.OutboundSyncBits()) },
+		fec:    edacsBCHFEC,
 	},
 	trunking.ProtocolMotorola: {
 		cardinality: 2, tolerance: 3,
 		syncFn: func() []SyncVariant { return oneVariant("outbound", motorola.OutboundSyncBits()) },
+		fec:    motorolaBCHFEC,
 	},
 	trunking.ProtocolDStar: {
 		cardinality: 2, tolerance: 2,
 		syncFn: func() []SyncVariant { return oneVariant("framesync", dstar.FrameSyncBitsSlice()) },
+		fec:    dstarCRCFEC,
 	},
 	trunking.ProtocolMPT1327: {
 		cardinality: 2, tolerance: 2,

--- a/internal/siglab/detail_test.go
+++ b/internal/siglab/detail_test.go
@@ -1,0 +1,98 @@
+package siglab
+
+import (
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// TestComputeSyncLandscape plants a known dibit sync word at a fixed cadence
+// and asserts the landscape recovers the winning variant/rotation, the hit
+// count, and the modal inter-hit spacing.
+func TestComputeSyncLandscape(t *testing.T) {
+	sync := []uint8{0, 1, 2, 3, 3, 2, 1, 0}
+	const (
+		gap  = 40 // dibits of filler between syncs
+		hits = 25
+	)
+	var stream []uint8
+	for h := 0; h < hits; h++ {
+		stream = append(stream, sync...)
+		for i := 0; i < gap; i++ {
+			stream = append(stream, uint8((h*7+i)&3))
+		}
+	}
+
+	land := computeSyncLandscape(stream, oneVariant("fsw", sync), 4, 2)
+	if land == nil {
+		t.Fatal("nil landscape")
+	}
+	if land.WinnerRotation != 0 {
+		t.Errorf("winner rotation = %d, want 0", land.WinnerRotation)
+	}
+	if land.WinnerHits < hits {
+		t.Errorf("winner hits = %d, want >= %d", land.WinnerHits, hits)
+	}
+	if want := len(sync) + gap; land.ModalSpacing != want {
+		t.Errorf("modal spacing = %d, want %d", land.ModalSpacing, want)
+	}
+}
+
+// TestComputeSyncLandscapeDetectsPolarityFlip confirms a discriminator-polarity
+// inverted dibit stream (sym -> sym+2) is recovered at rotation 2.
+func TestComputeSyncLandscapeDetectsPolarityFlip(t *testing.T) {
+	// Non-symmetric sync (not invariant under any rotation) + constant filler
+	// (which only matches an all-equal sync), so the only hits come from the
+	// planted, polarity-flipped sync at rotation 2.
+	sync := []uint8{0, 3, 1, 2, 3, 0, 2, 1}
+	var stream []uint8
+	for h := 0; h < 20; h++ {
+		for _, s := range sync {
+			stream = append(stream, (s+2)&3) // discriminator-polarity flip
+		}
+		for i := 0; i < 30; i++ {
+			stream = append(stream, 0)
+		}
+	}
+	land := computeSyncLandscape(stream, oneVariant("fsw", sync), 4, 1)
+	if land == nil || land.WinnerRotation != 2 {
+		t.Fatalf("expected winner rotation 2 (polarity flip), got %+v", land)
+	}
+}
+
+// TestBuildProtocolDetailHistogram checks the symbol histogram + spec lookup
+// for a bit protocol and a dibit protocol.
+func TestBuildProtocolDetailHistogram(t *testing.T) {
+	// Bit protocol (cardinality 2).
+	bits := []uint8{0, 1, 0, 1, 1, 1}
+	d, ok := buildProtocolDetail(trunking.ProtocolEDACS, bits, true).(*ProtocolDetail)
+	if !ok || d == nil {
+		t.Fatal("EDACS detail not built")
+	}
+	if d.SymbolCardinality != 2 || len(d.SymbolHistogram) != 2 {
+		t.Errorf("cardinality/histogram wrong: %+v", d)
+	}
+	if d.SymbolHistogram[0] != 2 || d.SymbolHistogram[1] != 4 {
+		t.Errorf("histogram = %v, want [2 4]", d.SymbolHistogram)
+	}
+
+	// Unregistered protocol (P25 P1 uses the deep path, not a spec) → nil.
+	if got := buildProtocolDetail(trunking.ProtocolP25, []uint8{0, 1, 2, 3}, false); got != nil {
+		t.Errorf("expected nil for P25 (no spec), got %T", got)
+	}
+}
+
+// TestDetailSpecsCoverAllNonP25 asserts every registered protocol except P25
+// Phase 1 has a detail spec, so the deep dive is uniform.
+func TestDetailSpecsCoverAllNonP25(t *testing.T) {
+	for _, p := range []trunking.Protocol{
+		trunking.ProtocolDMR, trunking.ProtocolDMRTier2, trunking.ProtocolP25Phase2,
+		trunking.ProtocolNXDN, trunking.ProtocolDPMR, trunking.ProtocolYSF,
+		trunking.ProtocolTETRA, trunking.ProtocolEDACS, trunking.ProtocolMotorola,
+		trunking.ProtocolLTR, trunking.ProtocolMPT1327, trunking.ProtocolDStar,
+	} {
+		if !hasDetailSpec(p) {
+			t.Errorf("no detail spec for %s", p)
+		}
+	}
+}

--- a/internal/siglab/engine.go
+++ b/internal/siglab/engine.go
@@ -91,7 +91,10 @@ func runReader(r io.Reader, source string, decode SampleDecoder, bytesPerSample 
 	var an *analyzer
 	if cfg.CollectIQDiag {
 		an = newAnalyzer()
-		an.bufferSymbols = cfg.Protocol == trunking.ProtocolP25
+		// Buffer the recovered symbols when a protocol-specific detail builder
+		// needs the full stream: P25 (its deep path) or any protocol with a
+		// registered symbol-domain detail spec.
+		an.bufferSymbols = cfg.Protocol == trunking.ProtocolP25 || hasDetailSpec(cfg.Protocol)
 	}
 	var iqCorrector *rtlsdr.IQImbalanceCorrector
 	if cfg.IQCorrect {
@@ -203,11 +206,16 @@ func runReader(r io.Reader, source string, decode SampleDecoder, bytesPerSample 
 
 	res := assembleResult(source, cfg, totalSamples, symbolCount, receiverRate, tuneHz, coll, an)
 
-	// Attach the P25 Phase 1 deep detail when the deep path ran. CCStats and
-	// the receiver-state series are captured whenever the deep path is active
-	// (so `replay -protocol p25p1` shows them); the dibit/soft landscape is
-	// added only when the analyzer buffered symbols (CollectIQDiag).
-	if deep {
+	// Attach the protocol-specific deep dive. P25 Phase 1 uses its dedicated
+	// deep path (soft eye + receiver-state + native CCStats); every other
+	// protocol with a registered builder gets a symbol-domain detail (sync
+	// landscape + FEC tally) computed from the buffered recovered symbols.
+	switch {
+	case deep:
+		// CCStats and the receiver-state series are captured whenever the deep
+		// path is active (so `replay -protocol p25p1` shows them); the
+		// dibit/soft landscape is added only when the analyzer buffered
+		// symbols (CollectIQDiag).
 		var d *P25P1Detail
 		if an != nil {
 			d = buildP25Detail(an.symBuf, an.softBuf)
@@ -219,7 +227,11 @@ func runReader(r io.Reader, source string, decode SampleDecoder, bytesPerSample 
 			d.CCStats = bundle.ccStats()
 		}
 		d.ReceiverStates = states
-		res.P25P1 = d
+		res.Detail = d
+	case an != nil && hasDetailSpec(cfg.Protocol):
+		if d := buildProtocolDetail(cfg.Protocol, an.symBuf, an.cardinality == 2); d != nil {
+			res.Detail = d
+		}
 	}
 	return res, nil
 }

--- a/internal/siglab/engine_test.go
+++ b/internal/siglab/engine_test.go
@@ -85,11 +85,12 @@ func TestEngineThroughputAndAnalysis(t *testing.T) {
 		t.Error("expected IQ imbalance to be observed")
 	}
 	// The dibit-domain P25 detail should have been built from the buffered
-	// symbols.
-	if res.P25P1 == nil {
-		t.Fatal("P25P1 detail not built for a P25 run with CollectIQDiag")
+	// symbols and surfaced via the unified Detail field.
+	p25, ok := res.Detail.(*P25P1Detail)
+	if !ok || p25 == nil {
+		t.Fatalf("P25 detail not built for a P25 run with CollectIQDiag; Detail=%T", res.Detail)
 	}
-	if res.P25P1.DibitsBuffered == 0 {
+	if p25.DibitsBuffered == 0 {
 		t.Error("P25P1.DibitsBuffered = 0")
 	}
 }

--- a/internal/siglab/fec.go
+++ b/internal/siglab/fec.go
@@ -1,0 +1,173 @@
+package siglab
+
+import (
+	"github.com/MattCheramie/GopherTrunk/internal/radio/dmr"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/dstar"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+)
+
+// This file holds the per-protocol FEC-outcome tallies — the symbol-domain
+// analog of P25's NID-BCH probe. Each re-runs the protocol's exported FEC
+// decoder on the frame found at every clean sync hit and tallies
+// clean/corrected/uncorrectable (or CRC pass/fail). To stay robust against the
+// sync-landscape's rotation/polarity ambiguity (e.g. DMR BS-Voice rot2 ≡
+// BS-Data rot0), each frame is decoded under every cyclic rotation and the
+// best outcome is kept — so a clean capture tallies as clean regardless of
+// which equivalent rotation the landscape picked as winner.
+
+// tallyErrs folds one decoder error count (−1 = uncorrectable, 0 = clean,
+// >0 = corrected) into st.
+func tallyErrs(st *FECStat, errs int) {
+	st.Frames++
+	switch {
+	case errs < 0:
+		st.Uncorrectable++
+	case errs == 0:
+		st.Clean++
+	default:
+		st.Corrected++
+	}
+}
+
+// bestErrs returns the smallest non-negative error count from attempts, or −1
+// when every attempt was uncorrectable.
+func bestErrs(attempts []int) int {
+	best := -1
+	for _, e := range attempts {
+		if e < 0 {
+			continue
+		}
+		if best < 0 || e < best {
+			best = e
+		}
+	}
+	return best
+}
+
+// dmrSlotTypeFEC tallies the DMR slot-type Hamming(20,8) decode at each clean
+// burst-sync hit. The 10 slot-type dibits flank the 24-dibit sync (5 before,
+// 5 after — burst layout HalfPayload(49) + slot(5) + sync(24) + slot(5) +
+// HalfPayload(49)).
+func dmrSlotTypeFEC(stream []uint8, land *SyncLandscape) []FECStat {
+	st := FECStat{Stage: "slot-type Hamming(20,8)"}
+	const half = dmr.SlotTypeDibits // 5
+	syncLen := land.SyncLen
+	for _, pos := range land.positions {
+		if pos < half || pos+syncLen+half > len(stream) {
+			continue
+		}
+		slot := make([]uint8, 0, 2*half)
+		slot = append(slot, stream[pos-half:pos]...)
+		slot = append(slot, stream[pos+syncLen:pos+syncLen+half]...)
+
+		var attempts []int
+		for rot := uint8(0); rot < 4; rot++ {
+			var cw uint32
+			for i, d := range slot {
+				dd := (d + rot) & 3
+				cw |= uint32((dd>>1)&1) << uint(19-2*i)
+				cw |= uint32(dd&1) << uint(19-2*i-1)
+			}
+			_, errs := framing.HammingDecode20_8(cw)
+			attempts = append(attempts, errs)
+		}
+		tallyErrs(&st, bestErrs(attempts))
+	}
+	return []FECStat{st}
+}
+
+// edacsBCHFEC tallies the EDACS BCH(40,28,2) decode on the 40-bit CCW that
+// follows each clean outbound-sync hit. The on-wire bit i maps to codeword bit
+// (39−i) (see the fixture encoder).
+func edacsBCHFEC(stream []uint8, land *SyncLandscape) []FECStat {
+	st := FECStat{Stage: "BCH(40,28,2)"}
+	const cwLen = 40
+	syncLen := land.SyncLen
+	for _, pos := range land.positions {
+		start := pos + syncLen
+		if start+cwLen > len(stream) {
+			continue
+		}
+		var attempts []int
+		for rot := uint8(0); rot < 2; rot++ {
+			var cw uint64
+			for i := 0; i < cwLen; i++ {
+				if (stream[start+i]+rot)&1 != 0 {
+					cw |= uint64(1) << uint(39-i)
+				}
+			}
+			_, errs := framing.BCHDecodeEDACS(cw)
+			attempts = append(attempts, errs)
+		}
+		tallyErrs(&st, bestErrs(attempts))
+	}
+	return []FECStat{st}
+}
+
+// motorolaBCHFEC tallies the Motorola BCH(64,16,11) decode on the two 64-bit
+// OSW halves (128 bits) that follow each clean outbound-sync hit. On-wire bit
+// i maps to codeword bit (63−i).
+func motorolaBCHFEC(stream []uint8, land *SyncLandscape) []FECStat {
+	st := FECStat{Stage: "BCH(64,16,11)"}
+	syncLen := land.SyncLen
+	for _, pos := range land.positions {
+		start := pos + syncLen
+		if start+128 > len(stream) {
+			continue
+		}
+		for half := 0; half < 2; half++ {
+			base := start + half*64
+			var attempts []int
+			for rot := uint8(0); rot < 2; rot++ {
+				var cw uint64
+				for i := 0; i < 64; i++ {
+					if (stream[base+i]+rot)&1 != 0 {
+						cw |= uint64(1) << uint(63-i)
+					}
+				}
+				_, errs := framing.BCHDecode64_16(cw)
+				attempts = append(attempts, errs)
+			}
+			tallyErrs(&st, bestErrs(attempts))
+		}
+	}
+	return []FECStat{st}
+}
+
+// dstarCRCFEC tallies the D-STAR header CRC-16 over the 41-byte (FEC-off)
+// header that follows each clean frame-sync hit. Bytes are packed MSB-first;
+// the CRC sits in bytes 39..40 (big-endian) over bytes 0..38.
+func dstarCRCFEC(stream []uint8, land *SyncLandscape) []FECStat {
+	st := FECStat{Stage: "header CRC-16"}
+	const hdrBits = 328
+	syncLen := land.SyncLen
+	for _, pos := range land.positions {
+		start := pos + syncLen
+		if start+hdrBits > len(stream) {
+			continue
+		}
+		pass := false
+		for rot := uint8(0); rot < 2; rot++ {
+			var b [41]byte
+			for i := 0; i < 41; i++ {
+				var v byte
+				for j := 0; j < 8; j++ {
+					v = (v << 1) | ((stream[start+i*8+j] + rot) & 1)
+				}
+				b[i] = v
+			}
+			got := uint16(b[39])<<8 | uint16(b[40])
+			if dstar.ComputeCRC(b[:39]) == got {
+				pass = true
+				break
+			}
+		}
+		st.Frames++
+		if pass {
+			st.CRCPass++
+		} else {
+			st.CRCFail++
+		}
+	}
+	return []FECStat{st}
+}

--- a/internal/siglab/fec_test.go
+++ b/internal/siglab/fec_test.go
@@ -1,0 +1,84 @@
+package siglab
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// runSynthDetail synthesizes a clean capture for proto, decodes it with the
+// analyzer on, and returns the ProtocolDetail.
+func runSynthDetail(t *testing.T, proto trunking.Protocol) *ProtocolDetail {
+	t.Helper()
+	iq, meta, err := Synthesize(SynthOptions{Protocol: proto, Format: FormatF32})
+	if err != nil {
+		t.Fatalf("Synthesize(%s): %v", proto, err)
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, proto.String()+".cfile")
+	if err := WriteCapture(path, iq, FormatF32); err != nil {
+		t.Fatalf("WriteCapture: %v", err)
+	}
+	cfg, err := meta.Config(true) // CollectIQDiag
+	if err != nil {
+		t.Fatalf("meta.Config: %v", err)
+	}
+	res, err := Run(path, cfg)
+	if err != nil {
+		t.Fatalf("Run(%s): %v", proto, err)
+	}
+	d, ok := res.Detail.(*ProtocolDetail)
+	if !ok || d == nil {
+		t.Fatalf("Detail for %s is %T, want *ProtocolDetail", proto, res.Detail)
+	}
+	return d
+}
+
+// TestFECTallyCleanProtocols asserts the FEC tally decodes every frame on the
+// (GFSK / header) protocols whose synthesized recovered stream is symbol-clean:
+// no uncorrectable frames, and at least one frame found.
+func TestFECTallyCleanProtocols(t *testing.T) {
+	cases := []struct {
+		proto trunking.Protocol
+		crc   bool // graded via CRC pass rather than error count
+	}{
+		{trunking.ProtocolEDACS, false},
+		{trunking.ProtocolMotorola, false},
+		{trunking.ProtocolDStar, true},
+	}
+	for _, c := range cases {
+		t.Run(c.proto.String(), func(t *testing.T) {
+			d := runSynthDetail(t, c.proto)
+			if len(d.FEC) == 0 {
+				t.Fatalf("%s: no FEC tally", c.proto)
+			}
+			f := d.FEC[0]
+			if f.Frames == 0 {
+				t.Fatalf("%s: FEC found no frames", c.proto)
+			}
+			if c.crc {
+				if f.CRCPass != f.Frames || f.CRCFail != 0 {
+					t.Errorf("%s: crc_pass=%d crc_fail=%d, want all %d pass", c.proto, f.CRCPass, f.CRCFail, f.Frames)
+				}
+			} else if f.Uncorrectable != 0 {
+				t.Errorf("%s: %d uncorrectable frames on a clean capture", c.proto, f.Uncorrectable)
+			}
+		})
+	}
+}
+
+// TestFECTallyDMR asserts the DMR slot-type tally runs and finds frames. (DMR
+// C4FM recovery introduces correctable symbol errors on the synth, so we don't
+// require clean==frames — only that the tally is populated and most frames are
+// recoverable.)
+func TestFECTallyDMR(t *testing.T) {
+	d := runSynthDetail(t, trunking.ProtocolDMR)
+	if len(d.FEC) == 0 || d.FEC[0].Frames == 0 {
+		t.Fatal("DMR slot-type tally empty")
+	}
+	f := d.FEC[0]
+	if f.Clean+f.Corrected == 0 {
+		t.Errorf("DMR: no recoverable slot-type frames (frames=%d uncorrectable=%d)", f.Frames, f.Uncorrectable)
+	}
+}

--- a/internal/siglab/fixtures.go
+++ b/internal/siglab/fixtures.go
@@ -1,11 +1,24 @@
 package siglab
 
 import (
+	"encoding/binary"
+	"math"
+
 	"github.com/MattCheramie/GopherTrunk/internal/dsp/demod"
 	"github.com/MattCheramie/GopherTrunk/internal/radio/dmr"
 	"github.com/MattCheramie/GopherTrunk/internal/radio/dmr/tier3"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/dpmr"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/dstar"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/edacs"
 	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/ltr"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/motorola"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/mpt1327"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/nxdn"
 	p25phase1 "github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase1"
+	p25phase2 "github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase2"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/tetra"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/ysf"
 	"github.com/MattCheramie/GopherTrunk/internal/trunking"
 )
 
@@ -52,6 +65,105 @@ var fixtures = map[trunking.Protocol]fixture{
 			LockFields:       map[string]any{"color_code": 0xA},
 			BaudTolerancePct: 5,
 		},
+	},
+	trunking.ProtocolP25Phase2: {
+		build:       func() []uint8 { return buildP25Phase2MACPTTStream(8) },
+		modulate:    func(d []uint8, _ float64) []complex64 { return demod.ModulatePiOver4DQPSK(d, 8, 8, 0.20, math.Pi/8) },
+		sampleRate:  48_000,
+		systemKnobs: map[string]string{"p25_phase2_trellis_mode": "on"},
+		expected:    Acceptance{Lock: boolPtr(true)},
+	},
+	trunking.ProtocolDMRTier2: {
+		build:      func() []uint8 { return buildDMRTier2VoiceLCHeaderDibits(80, 0x7, 0x123, 0x456789) },
+		modulate:   func(d []uint8, sr float64) []complex64 { return demod.ModulateC4FM(d, 10, 8, 0.20, sr, 1944.0) },
+		sampleRate: 48_000,
+		expected: Acceptance{
+			Lock:       boolPtr(true),
+			LockFields: map[string]any{"color_code": 0x7},
+		},
+	},
+	trunking.ProtocolNXDN: {
+		build:       func() []uint8 { return buildNXDNSpecEncodedDibits(20, 0xBEEF, 0x0042) },
+		modulate:    func(d []uint8, sr float64) []complex64 { return demod.ModulateC4FM(d, 10, 8, 0.20, sr, 1800.0) },
+		sampleRate:  48_000,
+		systemKnobs: map[string]string{"nxdn_viterbi_mode": "spec"},
+		expected: Acceptance{
+			Lock:       boolPtr(true),
+			LockFields: map[string]any{"site_id": "0xBEEF", "system_id": "0x0042"},
+		},
+	},
+	trunking.ProtocolDPMR: {
+		build:      func() []uint8 { return buildDPMRSiteBroadcastDibits(30, 0x123456) },
+		modulate:   func(d []uint8, sr float64) []complex64 { return demod.ModulateC4FM(d, 20, 8, 0.20, sr, 900.0) },
+		sampleRate: 48_000,
+		expected: Acceptance{
+			Lock:       boolPtr(true),
+			LockFields: map[string]any{"system_id": "0x123456"},
+		},
+	},
+	trunking.ProtocolYSF: {
+		build:      func() []uint8 { return buildYSFFSWStream(30) },
+		modulate:   func(d []uint8, sr float64) []complex64 { return demod.ModulateC4FM(d, 10, 8, 0.20, sr, 1800.0) },
+		sampleRate: 48_000,
+		expected:   Acceptance{Lock: boolPtr(true)},
+	},
+	trunking.ProtocolTETRA: {
+		build:       func() []uint8 { return buildTETRASCHHDStream(100, 0x12345, 0x42) },
+		modulate:    func(d []uint8, _ float64) []complex64 { return demod.ModulatePiOver4DQPSK(d, 4, 8, 0.35, math.Pi/4) },
+		sampleRate:  72_000,
+		systemKnobs: map[string]string{"tetra_colour_code": "0x12345", "tetra_channel": "sch/hd"},
+		expected: Acceptance{
+			Lock:       boolPtr(true),
+			LockFields: map[string]any{"location_area": "0x42"},
+		},
+	},
+	trunking.ProtocolEDACS: {
+		build:       func() []uint8 { return buildEDACSSystemIDStream(30, 0x7B) },
+		modulate:    func(d []uint8, sr float64) []complex64 { return demod.ModulateGFSK(d, 10, 4, 0.3, sr, 2400.0) },
+		sampleRate:  96_000,
+		systemKnobs: map[string]string{"edacs_bch_mode": "on"},
+		expected: Acceptance{
+			Lock:       boolPtr(true),
+			LockFields: map[string]any{"system_id": "0x7B"},
+		},
+	},
+	trunking.ProtocolMotorola: {
+		build:       func() []uint8 { return buildMotorolaSystemIDStream(30, 0x4567) },
+		modulate:    func(d []uint8, sr float64) []complex64 { return demod.ModulateGFSK(d, 27, 4, 0.5, sr, 1500.0) },
+		sampleRate:  97_200,
+		systemKnobs: map[string]string{"motorola_bch_mode": "on"},
+		expected: Acceptance{
+			Lock:       boolPtr(true),
+			LockFields: map[string]any{"system_id": "0x4567"},
+		},
+	},
+	trunking.ProtocolLTR: {
+		build:       func() []uint8 { return buildLTRStatusStream(80, 7, 4) },
+		modulate:    func(d []uint8, sr float64) []complex64 { return demod.ModulateSubAudibleNRZ(d, sr, 300.0, 0.05) },
+		sampleRate:  48_000,
+		systemKnobs: map[string]string{"ltr_manchester_mode": "off", "ltr_fcs_mode": "off"},
+		expected: Acceptance{
+			Lock:       boolPtr(true),
+			LockFields: map[string]any{"area": 7, "repeater": 4},
+		},
+	},
+	trunking.ProtocolMPT1327: {
+		build:       func() []uint8 { return buildMPT1327AlohaStream(100, 0x5) },
+		modulate:    func(d []uint8, sr float64) []complex64 { return demod.ModulateFFSK(d, sr, 1200.0, 1200.0, 1800.0) },
+		sampleRate:  48_000,
+		systemKnobs: map[string]string{"mpt1327_bch_mode": "on"},
+		expected: Acceptance{
+			Lock:       boolPtr(true),
+			LockFields: map[string]any{"prefix": 0x5},
+		},
+	},
+	trunking.ProtocolDStar: {
+		build: func() []uint8 {
+			return buildDStarHeaderStream(30, "CQCQCQ  ", "WB7XYZ  ", "KD0AAA B", "KD0AAA G")
+		},
+		modulate:   func(d []uint8, sr float64) []complex64 { return demod.ModulateGFSK(d, 10, 4, 0.5, sr, 1200.0) },
+		sampleRate: 48_000,
+		expected:   Acceptance{Lock: boolPtr(true)},
 	},
 }
 
@@ -106,6 +218,397 @@ func buildP25LockedDibits(nac uint16, repeats int) []uint8 {
 	}
 	for i := 0; i < 100; i++ {
 		out = append(out, uint8(i&3))
+	}
+	return out
+}
+
+// buildP25Phase2MACPTTStream builds a P25 Phase 2 superframe stream of
+// MAC-signaling subframes. Lifted from integration_cc_p25p2_test.go.
+func buildP25Phase2MACPTTStream(repeats int) []uint8 {
+	pdu := p25phase2.MACPDU{Opcode: p25phase2.OpGroupVoiceChannelUserAbbreviated, Payload: make([]byte, 17)}
+	var subs [p25phase2.SubframesPerSuperframe][]uint8
+	for i := range subs {
+		subs[i] = p25phase2.EncodeMACSubframe(
+			p25phase2.SlotTypeMACSignaling, uint8(i), pdu,
+			p25phase2.TrellisOn, p25phase2.InterleaveOff)
+	}
+	superframe := p25phase2.EncodeSuperframe(subs)
+
+	out := make([]uint8, 0, 400+repeats*len(superframe)+100)
+	for i := 0; i < 400; i++ {
+		out = append(out, uint8(i&3))
+	}
+	for r := 0; r < repeats; r++ {
+		out = append(out, superframe...)
+	}
+	for i := 0; i < 100; i++ {
+		out = append(out, uint8(i&3))
+	}
+	return out
+}
+
+// buildDMRTier2VoiceLCHeaderDibits builds a DMR Tier II conventional stream of
+// repeated Voice LC Header bursts. Lifted from integration_cc_dmr_tier2_test.go.
+func buildDMRTier2VoiceLCHeaderDibits(repeats int, colorCode uint8, groupID, sourceID uint32) []uint8 {
+	flc := dmr.FLC{
+		FLCO:    dmr.FLCOGroupVoiceUser,
+		DstAddr: groupID,
+		SrcAddr: sourceID,
+	}
+	flcBytes := dmr.AssembleFLC(flc)
+	var data [9]byte
+	copy(data[:], flcBytes)
+	cw := framing.EncodeRS12_9(data)
+	for i := 0; i < 3; i++ {
+		cw[9+i] ^= framing.RS129SeedVoiceLCHeader[i]
+	}
+	info := cw[:]
+	bits := make([]byte, 96)
+	for i := 0; i < 96; i++ {
+		bits[i] = (info[i>>3] >> uint(7-(i&7))) & 1
+	}
+	channelBits := framing.EncodeBPTC196_96(bits)
+	payloadDibits := framing.BitsToDibits(channelBits)
+
+	slotBits := dmr.AssembleSlotType(dmr.SlotType{ColorCode: colorCode, DataType: dmr.DTVoiceLCHeader})
+	slotDibits := framing.BitsToDibits(slotBits)
+
+	burst := make([]uint8, 0, dmr.BurstDibits)
+	burst = append(burst, payloadDibits[:dmr.HalfPayloadDibits]...)
+	burst = append(burst, slotDibits[:dmr.SlotTypeDibits]...)
+	burst = append(burst, dmr.BSData.Dibits[:]...)
+	burst = append(burst, slotDibits[dmr.SlotTypeDibits:]...)
+	burst = append(burst, payloadDibits[dmr.HalfPayloadDibits:]...)
+
+	out := make([]uint8, 0, 800+repeats*(len(burst)+32)+100)
+	for i := 0; i < 800; i++ {
+		out = append(out, uint8(i&3))
+	}
+	for r := 0; r < repeats; r++ {
+		out = append(out, burst...)
+		for i := 0; i < 32; i++ {
+			out = append(out, uint8(i&3))
+		}
+	}
+	for i := 0; i < 100; i++ {
+		out = append(out, uint8(i&3))
+	}
+	return out
+}
+
+// buildNXDNSpecEncodedDibits builds an NXDN RCCH outbound control-channel
+// stream (FSW + LICH + spec-encoded CAC SITE_INFO). Lifted from
+// integration_cc_nxdn_test.go.
+func buildNXDNSpecEncodedDibits(repeats int, siteID, systemID uint16) []uint8 {
+	lichInfo := nxdn.AssembleLICH(nxdn.LICH{RFCh: nxdn.RFChControl})
+	lichWire := nxdn.EncodeLICHWire(lichInfo)
+	lichDibits := framing.BitsToDibits(lichWire)
+
+	var payload [8]byte
+	binary.BigEndian.PutUint16(payload[0:2], 0xAAAA)
+	binary.BigEndian.PutUint16(payload[2:4], siteID)
+	binary.BigEndian.PutUint16(payload[4:6], systemID)
+	l3 := make([]byte, 9)
+	l3[0] = byte(nxdn.RCCHSITEINFO)
+	copy(l3[1:9], payload[:])
+
+	info := make([]byte, nxdn.CACInfoBits)
+	l3Bits := framing.UnpackBitsMSB(l3, 72)
+	copy(info[8:8+72], l3Bits)
+
+	channel := nxdn.EncodeCACChannel(info)
+	cacDibits := framing.BitsToDibits(channel)
+
+	frame := make([]uint8, 0, 8+len(lichDibits)+len(cacDibits))
+	frame = append(frame, nxdn.FSWDibitsOutbound...)
+	frame = append(frame, lichDibits...)
+	frame = append(frame, cacDibits...)
+
+	out := make([]uint8, 0, 300+repeats*(len(frame)+50)+100)
+	for i := 0; i < 300; i++ {
+		out = append(out, uint8(i&3))
+	}
+	for r := 0; r < repeats; r++ {
+		out = append(out, frame...)
+		for i := 0; i < 50; i++ {
+			out = append(out, uint8(i&3))
+		}
+	}
+	for i := 0; i < 100; i++ {
+		out = append(out, uint8(i&3))
+	}
+	return out
+}
+
+// buildDPMRSiteBroadcastDibits builds a dPMR control-channel stream (FS3 +
+// CSBK standing-service-status). Lifted from integration_cc_dpmr_test.go.
+func buildDPMRSiteBroadcastDibits(repeats int, systemID uint32) []uint8 {
+	csbk := dpmr.CSBK{Type: dpmr.MsgStandingServiceStatus, DestID: systemID, Extra: 0x42}
+	csbkBits := dpmr.CSBKBits(csbk)
+	csbkDibits := framing.BitsToDibits(csbkBits)
+
+	frame := make([]uint8, 0, 24+len(csbkDibits))
+	frame = append(frame, dpmr.FS3Dibits()...)
+	frame = append(frame, csbkDibits...)
+
+	out := make([]uint8, 0, 400+repeats*(len(frame)+16)+100)
+	for i := 0; i < 400; i++ {
+		out = append(out, uint8(i&3))
+	}
+	for r := 0; r < repeats; r++ {
+		out = append(out, frame...)
+		for i := 0; i < 16; i++ {
+			out = append(out, uint8(i&3))
+		}
+	}
+	for i := 0; i < 100; i++ {
+		out = append(out, uint8(i&3))
+	}
+	return out
+}
+
+// buildYSFFSWStream builds a YSF stream of FSW-bearing frames. Lifted from
+// integration_cc_ysf_test.go.
+func buildYSFFSWStream(repeats int) []uint8 {
+	frame := make([]uint8, ysf.FrameDibits)
+	copy(frame[ysf.FSWOffset:], ysf.FSWPattern)
+
+	out := make([]uint8, 0, 400+repeats*len(frame)+100)
+	for i := 0; i < 400; i++ {
+		out = append(out, uint8(i&3))
+	}
+	for r := 0; r < repeats; r++ {
+		out = append(out, frame...)
+	}
+	for i := 0; i < 100; i++ {
+		out = append(out, uint8(i&3))
+	}
+	return out
+}
+
+// buildTETRASCHHDStream builds a TETRA SCH/HD broadcast stream (normal sync +
+// channel-coded MLE SYSINFO). Lifted from integration_cc_tetra_test.go.
+func buildTETRASCHHDStream(repeats int, colourCode uint32, locationArea uint16) []uint8 {
+	payload := []byte{0x00, 0x00, 0x00, 0, 0}
+	payload[3] = byte((locationArea >> 6) & 0xFF)
+	payload[4] = byte((locationArea & 0x3F) << 2)
+
+	pdu := tetra.PDU{
+		Disc:    tetra.DiscMLE,
+		Type:    uint8(tetra.MLESystemInfo),
+		Payload: payload,
+	}
+	info := pduToType1BitsTETRA(pdu, 124)
+	type5 := tetra.EncodeSCHHD(info, colourCode)
+	burstDibits := framing.BitsToDibits(type5)
+
+	frame := make([]uint8, 0, 38+len(burstDibits))
+	frame = append(frame, tetra.NormalSyncDibits()...)
+	frame = append(frame, burstDibits...)
+
+	out := make([]uint8, 0, 400+repeats*(len(frame)+50)+100)
+	for i := 0; i < 400; i++ {
+		out = append(out, uint8(i&3))
+	}
+	for r := 0; r < repeats; r++ {
+		out = append(out, frame...)
+		for i := 0; i < 50; i++ {
+			out = append(out, uint8(i&3))
+		}
+	}
+	for i := 0; i < 100; i++ {
+		out = append(out, uint8(i&3))
+	}
+	return out
+}
+
+// pduToType1BitsTETRA pads a PDU's header + bytes into exactly k1 bits,
+// MSB-first per byte, zero-padded. Lifted from integration_cc_tetra_test.go.
+func pduToType1BitsTETRA(pdu tetra.PDU, k1 int) []byte {
+	bytes := tetra.AssemblePDU(pdu)
+	if len(bytes)*8 > k1 {
+		return nil
+	}
+	out := make([]byte, k1)
+	for i, b := range bytes {
+		for j := 0; j < 8; j++ {
+			out[i*8+j] = (b >> uint(7-j)) & 1
+		}
+	}
+	return out
+}
+
+// buildEDACSSystemIDStream builds an EDACS control-channel stream (outbound
+// sync + BCH-encoded SystemID CCW). Lifted from integration_cc_edacs_test.go.
+func buildEDACSSystemIDStream(repeats int, systemID uint16) []byte {
+	info := uint32(edacs.CmdSystemID&0xF)<<24 |
+		uint32(systemID&0xFFFF)<<4
+	cw := framing.BCHEncodeEDACS(info)
+	wire := make([]byte, 40)
+	for i := 0; i < 40; i++ {
+		if cw&(uint64(1)<<uint(39-i)) != 0 {
+			wire[i] = 1
+		}
+	}
+
+	frame := make([]byte, 0, 24+40)
+	frame = append(frame, edacs.OutboundSyncBits()...)
+	frame = append(frame, wire...)
+
+	out := make([]byte, 0, 200+repeats*(len(frame)+16)+100)
+	for i := 0; i < 200; i++ {
+		out = append(out, byte(i&1))
+	}
+	for r := 0; r < repeats; r++ {
+		out = append(out, frame...)
+		for i := 0; i < 16; i++ {
+			out = append(out, byte(i&1))
+		}
+	}
+	for i := 0; i < 100; i++ {
+		out = append(out, byte(i&1))
+	}
+	return out
+}
+
+// buildMotorolaSystemIDStream builds a Motorola Type II control-channel stream
+// (outbound sync + two BCH(64,16) OSW halves). Lifted from
+// integration_cc_motorola_test.go.
+func buildMotorolaSystemIDStream(repeats int, systemID uint16) []byte {
+	command := uint16(motorola.OpSystemIDExtended) << 4
+
+	cw1 := framing.BCHEncode64_16(systemID)
+	cw2 := framing.BCHEncode64_16(command)
+	encoded := make([]byte, 128)
+	for i := 0; i < 64; i++ {
+		if cw1&(uint64(1)<<uint(63-i)) != 0 {
+			encoded[i] = 1
+		}
+	}
+	for i := 0; i < 64; i++ {
+		if cw2&(uint64(1)<<uint(63-i)) != 0 {
+			encoded[64+i] = 1
+		}
+	}
+
+	frame := make([]byte, 0, 24+128)
+	frame = append(frame, motorola.OutboundSyncBits()...)
+	frame = append(frame, encoded...)
+
+	out := make([]byte, 0, 200+repeats*(len(frame)+16)+100)
+	for i := 0; i < 200; i++ {
+		out = append(out, byte(i&1))
+	}
+	for r := 0; r < repeats; r++ {
+		out = append(out, frame...)
+		for i := 0; i < 16; i++ {
+			out = append(out, byte(i&1))
+		}
+	}
+	for i := 0; i < 100; i++ {
+		out = append(out, byte(i&1))
+	}
+	return out
+}
+
+// buildLTRStatusStream builds an LTR sub-audible Status stream. Lifted from
+// integration_cc_ltr_test.go.
+func buildLTRStatusStream(repeats int, area, repeater uint8) []byte {
+	status := ltr.Status{
+		Sync:    true,
+		Area:    area,
+		Channel: 3,
+		Home:    repeater,
+		Free:    5,
+	}
+	frame := ltr.StatusBits(status)
+
+	out := make([]byte, 0, 200+repeats*len(frame)+100)
+	out = append(out, make([]byte, 200)...)
+	for r := 0; r < repeats; r++ {
+		out = append(out, frame...)
+	}
+	out = append(out, make([]byte, 100)...)
+	return out
+}
+
+// buildMPT1327AlohaStream builds an MPT 1327 control-channel stream of
+// BCH-encoded Aloha codewords. Lifted from integration_cc_mpt1327_test.go.
+func buildMPT1327AlohaStream(repeats int, prefix uint8) []byte {
+	aloha := mpt1327.Codeword{
+		Type:     mpt1327.TypeAddress,
+		Prefix:   prefix,
+		Function: uint32(mpt1327.KindAloha) << 13,
+	}
+	wire48 := mpt1327.CodewordBits48(aloha)
+	var info48 uint64
+	for i := 0; i < 48; i++ {
+		if wire48[i]&1 != 0 {
+			info48 |= uint64(1) << uint(i)
+		}
+	}
+	cw := framing.BCHEncodeMPT1327(info48)
+	codeword := make([]byte, 64)
+	for i := 0; i < 64; i++ {
+		codeword[i] = byte((cw >> uint(i)) & 1)
+	}
+
+	out := make([]byte, 0, 200+repeats*(len(codeword)+16)+100)
+	for i := 0; i < 200; i++ {
+		out = append(out, byte(i&1))
+	}
+	for r := 0; r < repeats; r++ {
+		out = append(out, codeword...)
+		for i := 0; i < 16; i++ {
+			out = append(out, byte(i&1))
+		}
+	}
+	for i := 0; i < 100; i++ {
+		out = append(out, byte(i&1))
+	}
+	return out
+}
+
+// buildDStarHeaderStream builds a D-STAR header stream (frame sync + 41-byte
+// header with CRC, FEC-off). Lifted from integration_cc_dstar_test.go.
+func buildDStarHeaderStream(repeats int, ur, my1, rpt2, rpt1 string) []byte {
+	hdr := dstar.Header{
+		Flag1: 0,
+		Flag2: 0,
+		Flag3: 0,
+		RPT2:  rpt2,
+		RPT1:  rpt1,
+		UR:    ur,
+		MY1:   my1,
+		MY2:   "SUFX",
+	}
+	asm := dstar.AssembleHeader(hdr)
+	hdr.CRC = dstar.ComputeCRC(asm[:39])
+	asm = dstar.AssembleHeader(hdr)
+
+	headerBits := make([]byte, 0, 328)
+	for _, b := range asm {
+		for i := 0; i < 8; i++ {
+			headerBits = append(headerBits, (b>>uint(7-i))&1)
+		}
+	}
+
+	frame := make([]byte, 0, 32+328)
+	frame = append(frame, dstar.FrameSyncBitsSlice()...)
+	frame = append(frame, headerBits...)
+
+	out := make([]byte, 0, 256+repeats*(len(frame)+32)+100)
+	for i := 0; i < 256; i++ {
+		out = append(out, 1)
+	}
+	for r := 0; r < repeats; r++ {
+		out = append(out, frame...)
+		for i := 0; i < 32; i++ {
+			out = append(out, 1)
+		}
+	}
+	for i := 0; i < 100; i++ {
+		out = append(out, 1)
 	}
 	return out
 }

--- a/internal/siglab/result.go
+++ b/internal/siglab/result.go
@@ -40,7 +40,10 @@ type Result struct {
 
 	// Analysis (nil unless CollectIQDiag).
 	Signal *SignalQuality `json:"signal,omitempty" yaml:"signal,omitempty"`
-	P25P1  *P25P1Detail   `json:"p25p1,omitempty" yaml:"p25p1,omitempty"`
+	// Detail is the protocol-specific deep dive (a *P25P1Detail, *DMRDetail,
+	// *NXDNDetail, …) populated when CollectIQDiag is set and a per-protocol
+	// detail builder exists. Consumers type-switch on it (keyed by Protocol).
+	Detail any `json:"detail,omitempty" yaml:"detail,omitempty"`
 
 	// Verdict (nil unless Config.Acceptance supplied).
 	Verdict *Verdict `json:"verdict,omitempty" yaml:"verdict,omitempty"`

--- a/internal/siglab/synclandscape.go
+++ b/internal/siglab/synclandscape.go
@@ -1,0 +1,154 @@
+package siglab
+
+import "sort"
+
+// SyncVariant is one named candidate sync pattern (e.g. one of DMR's 9 ETSI
+// sync words, or a protocol's single FSW), as a slice of symbols (dibits in
+// 0..3, or bits in 0..1).
+type SyncVariant struct {
+	Name    string  `json:"name" yaml:"name"`
+	Pattern []uint8 `json:"-" yaml:"-"`
+}
+
+// SyncStat is the best correlation of one (variant, rotation) against the
+// recovered-symbol stream. rotation is the cyclic symbol offset applied to the
+// stream before comparison: for 4-level streams rotation 2 is the
+// discriminator-polarity flip and 1/3 the I/Q-swap rotations; for 2-level
+// streams rotation 1 is bit inversion.
+type SyncStat struct {
+	Variant  string `json:"variant" yaml:"variant"`
+	Rotation int    `json:"rotation" yaml:"rotation"`
+	BestDist int    `json:"best_dist" yaml:"best_dist"`
+	BestPos  int    `json:"best_pos" yaml:"best_pos"`
+	Hits     int    `json:"hits" yaml:"hits"`
+}
+
+// SyncLandscape summarizes sync-word correlation across a recovered-symbol
+// stream — the generalization of P25's FSW-correlation landscape. It answers
+// "does the demod produce canonical symbols, which sync/polarity aligns the
+// stream, and at what cadence" for any protocol.
+type SyncLandscape struct {
+	SyncLen        int        `json:"sync_len" yaml:"sync_len"`
+	Tolerance      int        `json:"tolerance" yaml:"tolerance"`
+	Stats          []SyncStat `json:"stats" yaml:"stats"`
+	WinnerVariant  string     `json:"winner_variant" yaml:"winner_variant"`
+	WinnerRotation int        `json:"winner_rotation" yaml:"winner_rotation"`
+	WinnerHits     int        `json:"winner_hits" yaml:"winner_hits"`
+	// ModalSpacing is the most common symbol delta between consecutive clean
+	// hits under the winner — a real control channel emits sync at a fixed
+	// frame interval, so a single dominant spacing means genuine frames while
+	// scattered spacings mean false positives.
+	ModalSpacing int `json:"modal_spacing" yaml:"modal_spacing"`
+	// positions holds the clean-hit positions under the winning (variant,
+	// rotation) for downstream FEC re-runs. Not serialized.
+	positions []int
+}
+
+// computeSyncLandscape correlates each variant against stream under every
+// cyclic rotation of the given symbol cardinality (2 or 4), within tolerance.
+// It returns the per-(variant,rotation) stats, picks the winner by hit count,
+// and records the winner's clean-hit positions + modal spacing.
+func computeSyncLandscape(stream []uint8, variants []SyncVariant, cardinality, tolerance int) *SyncLandscape {
+	if len(variants) == 0 || cardinality < 2 {
+		return nil
+	}
+	syncLen := len(variants[0].Pattern)
+	if syncLen == 0 || len(stream) < syncLen {
+		return nil
+	}
+	mask := uint8(cardinality - 1)
+	land := &SyncLandscape{SyncLen: syncLen, Tolerance: tolerance}
+
+	bestHits, bestDist := -1, syncLen+1
+	for _, v := range variants {
+		if len(v.Pattern) != syncLen {
+			continue
+		}
+		for rot := 0; rot < cardinality; rot++ {
+			st := SyncStat{Variant: v.Name, Rotation: rot, BestDist: syncLen + 1}
+			for pos := 0; pos+syncLen <= len(stream); pos++ {
+				mismatch := 0
+				for k := 0; k < syncLen; k++ {
+					if (stream[pos+k]+uint8(rot))&mask != v.Pattern[k] {
+						mismatch++
+						if mismatch > tolerance && mismatch >= st.BestDist {
+							break
+						}
+					}
+				}
+				if mismatch <= tolerance {
+					st.Hits++
+				}
+				if mismatch < st.BestDist {
+					st.BestDist = mismatch
+					st.BestPos = pos
+				}
+			}
+			land.Stats = append(land.Stats, st)
+			// Winner = most hits; ties break on lower best distance.
+			if st.Hits > bestHits || (st.Hits == bestHits && st.BestDist < bestDist) {
+				bestHits, bestDist = st.Hits, st.BestDist
+				land.WinnerVariant, land.WinnerRotation, land.WinnerHits = st.Variant, st.Rotation, st.Hits
+			}
+		}
+	}
+
+	// Recover the winner's clean-hit positions + modal inter-hit spacing.
+	if land.WinnerHits > 0 {
+		win := variants[0]
+		for _, v := range variants {
+			if v.Name == land.WinnerVariant {
+				win = v
+				break
+			}
+		}
+		rot := uint8(land.WinnerRotation)
+		for pos := 0; pos+syncLen <= len(stream); pos++ {
+			mismatch := 0
+			for k := 0; k < syncLen; k++ {
+				if (stream[pos+k]+rot)&mask != win.Pattern[k] {
+					mismatch++
+				}
+			}
+			if mismatch <= tolerance {
+				land.positions = append(land.positions, pos)
+			}
+		}
+		land.ModalSpacing = modalSpacing(land.positions)
+	}
+	return land
+}
+
+// modalSpacing returns the most-frequent delta between consecutive positions
+// (0 when fewer than two positions).
+func modalSpacing(positions []int) int {
+	if len(positions) < 2 {
+		return 0
+	}
+	deltas := make([]int, 0, len(positions)-1)
+	for i := 1; i < len(positions); i++ {
+		deltas = append(deltas, positions[i]-positions[i-1])
+	}
+	sort.Ints(deltas)
+	bestVal, bestCount := deltas[0], 1
+	curVal, curCount := deltas[0], 1
+	for i := 1; i < len(deltas); i++ {
+		if deltas[i] == curVal {
+			curCount++
+		} else {
+			if curCount > bestCount {
+				bestVal, bestCount = curVal, curCount
+			}
+			curVal, curCount = deltas[i], 1
+		}
+	}
+	if curCount > bestCount {
+		bestVal = curVal
+	}
+	return bestVal
+}
+
+// dibitVariants / bitVariants wrap fixed patterns as single-variant slices.
+func oneVariant(name string, pattern []uint8) []SyncVariant {
+	return []SyncVariant{{Name: name, Pattern: pattern}}
+}


### PR DESCRIPTION
## Summary

Two follow-ups to the merged siglab toolkit (#520):

1. **`gen` now covers all 13 protocols** (was P25 P1 + DMR Tier III only).
2. **Every protocol gets a deep-analysis dive** (was P25 Phase 1 only).

### Part A — Port the remaining 11 `gen` fixtures
Lifted the per-protocol locking symbol-stream builders verbatim from each `integration_cc_*_test.go` into the siglab fixture registry (plus the TETRA `pduToType1BitsTETRA` helper), with each protocol's modulator + constants, capture sample rate, decoder knobs, and expected lock fields:

> P25 Phase 2, DMR Tier II, NXDN, dPMR, YSF, TETRA, EDACS, Motorola, LTR, MPT 1327, D-STAR.

`TestSynthDecodeRoundTrip` now locks **and** grades all 13 through the real production pipelines; the `gophertrunk gen → test` sweep passes for every protocol (exit 0).

### Part B — Per-protocol deep analysis
A code review found that **only P25 Phase 1** exposes `Stats()`, a receiver `SoftSink`, or receiver-state accessors — so the other protocols' deep analysis is computed from the **buffered recovered-symbol stream** (via the existing `SymbolTap`), no receiver changes.

- **Unified detail field:** `Result.P25P1` → `Result.Detail any` (a `*P25P1Detail` on the P25 deep path, a `*ProtocolDetail` otherwise). Renderer type-switches; exporters already handle `any`.
- **Reusable sync-correlation landscape** (`synclandscape.go`) generalizing P25's FSW landscape: best Hamming distance, hits, winner variant+rotation, modal inter-hit spacing, across every cyclic rotation (4-level: polarity + I/Q; 2-level: inversion). It even surfaces the ETSI DMR polarity ambiguity (BS-Voice rot2 ≡ BS-Data rot0).
- **`ProtocolDetail` + per-protocol registry** (`detail.go`): symbol histogram + sync landscape against each protocol's own sync word(s) — DMR's 9 ETSI syncs, P25 P2 / NXDN / TETRA in+out, dPMR FS1/2/3, YSF, EDACS, Motorola, D-STAR, MPT CWSC. (LTR has no FSW → histogram + note.)
- **FEC-outcome tallies** (`fec.go`) — the analog of P25's NID-BCH probe — re-running the protocol's exported FEC decoder per frame, rotation-robust:
  - DMR T3/T2 slot-type Hamming(20,8), EDACS BCH(40,28,2), Motorola BCH(64,16,11), D-STAR header CRC-16.
  - Verified on clean synth: EDACS / Motorola / D-STAR tally clean (CRC-pass) == frames; DMR surfaces the real correctable symbol-error rate the C4FM recovery produces.
  - NXDN / YSF / P25 P2 / TETRA carry a note that their Viterbi/BPTC/RCPC tally (needs de-interleave/depuncture re-framing) is a follow-up; they still get the sync landscape + histogram.

The deep detail is rendered in `replay`/`analyze` text output and serialized by `analyze -out-format json|yaml|csv`.

## Verification
- `go test ./...` (full unit suite) ✅; `go test -tags integration ./cmd/gophertrunk/... -run TestDaemonCCDecodes` ✅ — production path untouched.
- New unit tests: sync-landscape (incl. polarity-flip detection), detail builders, FEC tallies (clean-protocol == frames; DMR recoverable).
- 13-protocol `gen → test` sweep all PASS; per-protocol `analyze` shows a populated `detail`.

## Out of scope
- DMR Tier I decoder (still deferred — no receiver exists).
- Viterbi/BPTC/RCPC FEC tallies for NXDN/YSF/P25 P2/TETRA (sync landscape + histogram shipped; FEC tally noted as follow-up).

https://claude.ai/code/session_01P8Es75yBSfmW7xe2FErfuM

---
_Generated by [Claude Code](https://claude.ai/code/session_01P8Es75yBSfmW7xe2FErfuM)_