### PR TITLE
siglab: Viterbi/Golay/RCPC FEC tallies for NXDN, P25 Phase 2, TETRA

### DIFF
--- a/internal/siglab/detail.go
+++ b/internal/siglab/detail.go
@@ -50,7 +50,7 @@ type detailSpec struct {
 	cardinality int
 	tolerance   int
 	syncFn      func() []SyncVariant
-	fec         func(stream []uint8, land *SyncLandscape) []FECStat
+	fec         func(stream []uint8, land *SyncLandscape, sys trunking.System) []FECStat
 	notes       string
 }
 
@@ -72,7 +72,7 @@ var detailSpecs = map[trunking.Protocol]detailSpec{
 				{Name: "inbound", Pattern: p25phase2.InboundSyncDibits()},
 			}
 		},
-		notes: "ISCH Golay / MAC trellis tallies are a follow-up (need superframe re-framing).",
+		fec: p25p2FEC,
 	},
 	trunking.ProtocolNXDN: {
 		cardinality: 4, tolerance: 1,
@@ -82,7 +82,7 @@ var detailSpecs = map[trunking.Protocol]detailSpec{
 				{Name: "inbound", Pattern: append([]uint8(nil), nxdn.FSWDibitsInbound...)},
 			}
 		},
-		notes: "LICH Hamming / CAC Viterbi tallies are a follow-up (need CAC de-interleave).",
+		fec: nxdnFEC,
 	},
 	trunking.ProtocolDPMR: {
 		cardinality: 4, tolerance: 4,
@@ -98,7 +98,7 @@ var detailSpecs = map[trunking.Protocol]detailSpec{
 	trunking.ProtocolYSF: {
 		cardinality: 4, tolerance: 3,
 		syncFn: func() []SyncVariant { return oneVariant("fsw", append([]uint8(nil), ysf.FSWPattern...)) },
-		notes:  "FICH Viterbi / CRC tally is a follow-up (need FICH depuncture).",
+		notes:  "FICH decode is not yet integrated in the YSF decoder (FICH-region symbol mapping undefined); sync landscape + histogram only.",
 	},
 	trunking.ProtocolTETRA: {
 		cardinality: 4, tolerance: 6,
@@ -108,7 +108,7 @@ var detailSpecs = map[trunking.Protocol]detailSpec{
 				{Name: "extended", Pattern: tetra.ExtendedSyncDibits()},
 			}
 		},
-		notes: "RCPC/RM/Viterbi tallies are a follow-up (need per-channel de-interleave).",
+		fec: tetraFEC,
 	},
 	trunking.ProtocolEDACS: {
 		cardinality: 2, tolerance: 3,
@@ -144,7 +144,7 @@ func hasDetailSpec(p trunking.Protocol) bool {
 
 // buildProtocolDetail computes the ProtocolDetail for p from the buffered
 // symbol stream. Returns nil when no spec is registered or the stream is empty.
-func buildProtocolDetail(p trunking.Protocol, symbols []uint8, isBits bool) any {
+func buildProtocolDetail(p trunking.Protocol, symbols []uint8, isBits bool, sys trunking.System) any {
 	spec, ok := detailSpecs[p]
 	if !ok || len(symbols) == 0 {
 		return nil
@@ -169,7 +169,7 @@ func buildProtocolDetail(p trunking.Protocol, symbols []uint8, isBits bool) any 
 	if spec.syncFn != nil {
 		d.Sync = computeSyncLandscape(symbols, spec.syncFn(), card, spec.tolerance)
 		if d.Sync != nil && spec.fec != nil {
-			d.FEC = spec.fec(symbols, d.Sync)
+			d.FEC = spec.fec(symbols, d.Sync, sys)
 		}
 	}
 	return d

--- a/internal/siglab/detail_test.go
+++ b/internal/siglab/detail_test.go
@@ -65,7 +65,7 @@ func TestComputeSyncLandscapeDetectsPolarityFlip(t *testing.T) {
 func TestBuildProtocolDetailHistogram(t *testing.T) {
 	// Bit protocol (cardinality 2).
 	bits := []uint8{0, 1, 0, 1, 1, 1}
-	d, ok := buildProtocolDetail(trunking.ProtocolEDACS, bits, true).(*ProtocolDetail)
+	d, ok := buildProtocolDetail(trunking.ProtocolEDACS, bits, true, trunking.System{}).(*ProtocolDetail)
 	if !ok || d == nil {
 		t.Fatal("EDACS detail not built")
 	}
@@ -77,7 +77,7 @@ func TestBuildProtocolDetailHistogram(t *testing.T) {
 	}
 
 	// Unregistered protocol (P25 P1 uses the deep path, not a spec) → nil.
-	if got := buildProtocolDetail(trunking.ProtocolP25, []uint8{0, 1, 2, 3}, false); got != nil {
+	if got := buildProtocolDetail(trunking.ProtocolP25, []uint8{0, 1, 2, 3}, false, trunking.System{}); got != nil {
 		t.Errorf("expected nil for P25 (no spec), got %T", got)
 	}
 }

--- a/internal/siglab/engine.go
+++ b/internal/siglab/engine.go
@@ -229,7 +229,7 @@ func runReader(r io.Reader, source string, decode SampleDecoder, bytesPerSample 
 		d.ReceiverStates = states
 		res.Detail = d
 	case an != nil && hasDetailSpec(cfg.Protocol):
-		if d := buildProtocolDetail(cfg.Protocol, an.symBuf, an.cardinality == 2); d != nil {
+		if d := buildProtocolDetail(cfg.Protocol, an.symBuf, an.cardinality == 2, cfg.System); d != nil {
 			res.Detail = d
 		}
 	}

--- a/internal/siglab/fec.go
+++ b/internal/siglab/fec.go
@@ -4,7 +4,33 @@ import (
 	"github.com/MattCheramie/GopherTrunk/internal/radio/dmr"
 	"github.com/MattCheramie/GopherTrunk/internal/radio/dstar"
 	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/nxdn"
+	p25phase2 "github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase2"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/tetra"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
 )
+
+// rotateDibits returns dibits with each symbol cyclically rotated by rot
+// (mod 4) — used to present a frame to a decoder under a candidate polarity.
+func rotateDibits(dibits []uint8, rot uint8) []uint8 {
+	out := make([]uint8, len(dibits))
+	for i, d := range dibits {
+		out[i] = (d + rot) & 3
+	}
+	return out
+}
+
+// dibitsToBitsRot de-rotates dibits by rot and expands to bits, MSB-first per
+// dibit (matching framing.BitsToDibits' (bits[2i]<<1 | bits[2i+1]) packing).
+func dibitsToBitsRot(dibits []uint8, rot uint8) []byte {
+	out := make([]byte, len(dibits)*2)
+	for i, d := range dibits {
+		dd := (d + rot) & 3
+		out[2*i] = (dd >> 1) & 1
+		out[2*i+1] = dd & 1
+	}
+	return out
+}
 
 // This file holds the per-protocol FEC-outcome tallies — the symbol-domain
 // analog of P25's NID-BCH probe. Each re-runs the protocol's exported FEC
@@ -48,7 +74,7 @@ func bestErrs(attempts []int) int {
 // burst-sync hit. The 10 slot-type dibits flank the 24-dibit sync (5 before,
 // 5 after — burst layout HalfPayload(49) + slot(5) + sync(24) + slot(5) +
 // HalfPayload(49)).
-func dmrSlotTypeFEC(stream []uint8, land *SyncLandscape) []FECStat {
+func dmrSlotTypeFEC(stream []uint8, land *SyncLandscape, _ trunking.System) []FECStat {
 	st := FECStat{Stage: "slot-type Hamming(20,8)"}
 	const half = dmr.SlotTypeDibits // 5
 	syncLen := land.SyncLen
@@ -79,7 +105,7 @@ func dmrSlotTypeFEC(stream []uint8, land *SyncLandscape) []FECStat {
 // edacsBCHFEC tallies the EDACS BCH(40,28,2) decode on the 40-bit CCW that
 // follows each clean outbound-sync hit. The on-wire bit i maps to codeword bit
 // (39−i) (see the fixture encoder).
-func edacsBCHFEC(stream []uint8, land *SyncLandscape) []FECStat {
+func edacsBCHFEC(stream []uint8, land *SyncLandscape, _ trunking.System) []FECStat {
 	st := FECStat{Stage: "BCH(40,28,2)"}
 	const cwLen = 40
 	syncLen := land.SyncLen
@@ -107,7 +133,7 @@ func edacsBCHFEC(stream []uint8, land *SyncLandscape) []FECStat {
 // motorolaBCHFEC tallies the Motorola BCH(64,16,11) decode on the two 64-bit
 // OSW halves (128 bits) that follow each clean outbound-sync hit. On-wire bit
 // i maps to codeword bit (63−i).
-func motorolaBCHFEC(stream []uint8, land *SyncLandscape) []FECStat {
+func motorolaBCHFEC(stream []uint8, land *SyncLandscape, _ trunking.System) []FECStat {
 	st := FECStat{Stage: "BCH(64,16,11)"}
 	syncLen := land.SyncLen
 	for _, pos := range land.positions {
@@ -137,7 +163,7 @@ func motorolaBCHFEC(stream []uint8, land *SyncLandscape) []FECStat {
 // dstarCRCFEC tallies the D-STAR header CRC-16 over the 41-byte (FEC-off)
 // header that follows each clean frame-sync hit. Bytes are packed MSB-first;
 // the CRC sits in bytes 39..40 (big-endian) over bytes 0..38.
-func dstarCRCFEC(stream []uint8, land *SyncLandscape) []FECStat {
+func dstarCRCFEC(stream []uint8, land *SyncLandscape, _ trunking.System) []FECStat {
 	st := FECStat{Stage: "header CRC-16"}
 	const hdrBits = 328
 	syncLen := land.SyncLen
@@ -170,4 +196,115 @@ func dstarCRCFEC(stream []uint8, land *SyncLandscape) []FECStat {
 		}
 	}
 	return []FECStat{st}
+}
+
+// nxdnFEC tallies the NXDN LICH Hamming-doubling decode and the CAC Viterbi +
+// CRC-16 decode. The frame after each clean FSW hit is LICH (8 wire dibits) +
+// CAC (CACChannelBits/2 = 150 dibits); the fixture omits the SACCH so the CAC
+// follows the LICH directly.
+func nxdnFEC(stream []uint8, land *SyncLandscape, _ trunking.System) []FECStat {
+	lich := FECStat{Stage: "LICH Hamming-doubling"}
+	cac := FECStat{Stage: "CAC Viterbi(K=5)+CRC-16"}
+	const lichDibits = 8
+	cacDibits := nxdn.CACChannelBits / 2
+	syncLen := land.SyncLen
+	for _, pos := range land.positions {
+		lichStart := pos + syncLen
+		cacStart := lichStart + lichDibits
+		if cacStart+cacDibits > len(stream) {
+			continue
+		}
+		bestDis := -1
+		for rot := uint8(0); rot < 4; rot++ {
+			_, dis := nxdn.DecodeLICHWire(dibitsToBitsRot(stream[lichStart:lichStart+lichDibits], rot))
+			if bestDis < 0 || dis < bestDis {
+				bestDis = dis
+			}
+		}
+		tallyErrs(&lich, bestDis)
+
+		pass := false
+		for rot := uint8(0); rot < 4; rot++ {
+			if _, ok := nxdn.DecodeCACChannel(dibitsToBitsRot(stream[cacStart:cacStart+cacDibits], rot)); ok {
+				pass = true
+				break
+			}
+		}
+		cac.Frames++
+		if pass {
+			cac.CRCPass++
+		} else {
+			cac.CRCFail++
+		}
+	}
+	return []FECStat{lich, cac}
+}
+
+// tetraFEC tallies the TETRA SCH/HD channel decode (descramble + deinterleave +
+// depuncture + RCPC Viterbi + CRC-16) over the 108-dibit type-5 burst that
+// follows each clean normal-sync hit. The colour code seeds the descrambler.
+func tetraFEC(stream []uint8, land *SyncLandscape, sys trunking.System) []FECStat {
+	st := FECStat{Stage: "SCH/HD RCPC+Viterbi+CRC-16"}
+	const schDibits = 108 // 216 type-5 bits
+	syncLen := land.SyncLen
+	cc := sys.TETRAColourCode
+	for _, pos := range land.positions {
+		start := pos + syncLen
+		if start+schDibits > len(stream) {
+			continue
+		}
+		pass := false
+		for rot := uint8(0); rot < 4; rot++ {
+			if _, ok := tetra.DecodeSCHHD(dibitsToBitsRot(stream[start:start+schDibits], rot), cc); ok {
+				pass = true
+				break
+			}
+		}
+		st.Frames++
+		if pass {
+			st.CRCPass++
+		} else {
+			st.CRCFail++
+		}
+	}
+	return []FECStat{st}
+}
+
+// p25p2FEC tallies the P25 Phase 2 ISCH Golay(24,12,8) decode and the MAC-PDU
+// ½-rate trellis decode. After each outbound-sync hit (only sub-frame 0 of a
+// superframe carries the sync) the ISCH is 12 dibits at offset SyncDibits and
+// the trellis-coded MAC payload is 146 dibits after that.
+func p25p2FEC(stream []uint8, land *SyncLandscape, _ trunking.System) []FECStat {
+	isch := FECStat{Stage: "ISCH Golay(24,12,8)"}
+	mac := FECStat{Stage: "MAC trellis(1/2)"}
+	const macDibits = 146
+	ischDibits := p25phase2.ISCHDibits
+	syncLen := land.SyncLen
+	for _, pos := range land.positions {
+		ischStart := pos + syncLen
+		if ischStart+ischDibits > len(stream) {
+			continue
+		}
+		best := -1
+		for rot := uint8(0); rot < 4; rot++ {
+			if _, errs, err := p25phase2.DecodeISCH(rotateDibits(stream[ischStart:ischStart+ischDibits], rot)); err == nil {
+				if best < 0 || errs < best {
+					best = errs
+				}
+			}
+		}
+		tallyErrs(&isch, best)
+
+		macStart := ischStart + ischDibits
+		if macStart+macDibits <= len(stream) {
+			bestM := -1
+			for rot := uint8(0); rot < 4; rot++ {
+				if _, metric := framing.DecodeP25Trellis(rotateDibits(stream[macStart:macStart+macDibits], rot)); bestM < 0 || metric < bestM {
+					bestM = metric
+				}
+			}
+			tallyErrs(&mac, bestM)
+		}
+	}
+	return []FECStat{isch, mac}
 }

--- a/internal/siglab/fec_test.go
+++ b/internal/siglab/fec_test.go
@@ -2,6 +2,7 @@ package siglab
 
 import (
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/MattCheramie/GopherTrunk/internal/trunking"
@@ -80,5 +81,66 @@ func TestFECTallyDMR(t *testing.T) {
 	f := d.FEC[0]
 	if f.Clean+f.Corrected == 0 {
 		t.Errorf("DMR: no recoverable slot-type frames (frames=%d uncorrectable=%d)", f.Frames, f.Uncorrectable)
+	}
+}
+
+// findFEC returns the FECStat whose Stage contains sub, or nil.
+func findFEC(d *ProtocolDetail, sub string) *FECStat {
+	for i := range d.FEC {
+		if strings.Contains(d.FEC[i].Stage, sub) {
+			return &d.FEC[i]
+		}
+	}
+	return nil
+}
+
+// TestFECTallyP25P2 asserts the P25 Phase 2 ISCH Golay and MAC trellis tallies
+// decode every frame clean on the synth (a strong check that the ISCH/MAC
+// offsets + dibit packing are correct).
+func TestFECTallyP25P2(t *testing.T) {
+	d := runSynthDetail(t, trunking.ProtocolP25Phase2)
+	for _, stage := range []string{"ISCH", "MAC trellis"} {
+		f := findFEC(d, stage)
+		if f == nil || f.Frames == 0 {
+			t.Fatalf("P25P2 %s tally missing/empty", stage)
+		}
+		if f.Clean != f.Frames || f.Uncorrectable != 0 {
+			t.Errorf("P25P2 %s: clean=%d uncorrectable=%d, want all %d clean", stage, f.Clean, f.Uncorrectable, f.Frames)
+		}
+	}
+}
+
+// TestFECTallyNXDN asserts the NXDN LICH decodes clean on the synth and the CAC
+// CRC passes for at least some frames (the CAC is long; C4FM symbol errors fail
+// some frames, which is itself the diagnostic).
+func TestFECTallyNXDN(t *testing.T) {
+	d := runSynthDetail(t, trunking.ProtocolNXDN)
+	lich := findFEC(d, "LICH")
+	if lich == nil || lich.Frames == 0 {
+		t.Fatal("NXDN LICH tally missing")
+	}
+	if lich.Uncorrectable != 0 {
+		t.Errorf("NXDN LICH: %d uncorrectable on a clean capture", lich.Uncorrectable)
+	}
+	cac := findFEC(d, "CAC")
+	if cac == nil || cac.Frames == 0 {
+		t.Fatal("NXDN CAC tally missing")
+	}
+	if cac.CRCPass == 0 {
+		t.Errorf("NXDN CAC: no frames passed CRC (frames=%d)", cac.Frames)
+	}
+}
+
+// TestFECTallyTETRA asserts the TETRA SCH/HD decode passes CRC for most frames
+// on the synth (the colour code from the fixture metadata seeds the
+// descrambler; a couple of in-tolerance false-positive sync hits may fail).
+func TestFECTallyTETRA(t *testing.T) {
+	d := runSynthDetail(t, trunking.ProtocolTETRA)
+	f := findFEC(d, "SCH/HD")
+	if f == nil || f.Frames == 0 {
+		t.Fatal("TETRA SCH/HD tally missing")
+	}
+	if f.CRCPass <= f.Frames/2 {
+		t.Errorf("TETRA: crc_pass=%d of %d frames, want a clear majority", f.CRCPass, f.Frames)
 	}
 }


### PR DESCRIPTION
## Summary

Completes the first scoped follow-up from #521: the **Viterbi / Golay / RCPC FEC-outcome tallies** for the protocols whose inner code can be re-run on the buffered recovered-dibit stream — the symbol-domain analog of P25 Phase 1's NID-BCH probe.

Each closure re-decodes the frame found at every clean sync hit, under every cyclic rotation (keeping the best outcome, so it's robust to the landscape's polarity ambiguity), and tallies clean / corrected / uncorrectable + CRC pass/fail:

| Protocol | FEC tally added | Decoder reused |
|---|---|---|
| **NXDN** | LICH Hamming-doubling + CAC Viterbi(K=5) + CRC-16 | `nxdn.DecodeLICHWire`, `nxdn.DecodeCACChannel` |
| **P25 Phase 2** | ISCH Golay(24,12,8) + MAC ½-rate trellis | `phase2.DecodeISCH`, `framing.DecodeP25Trellis` |
| **TETRA** | SCH/HD descramble + deinterleave + RCPC Viterbi + CRC-16 | `tetra.DecodeSCHHD` |

The FEC closures now receive the `trunking.System` (threaded through `buildProtocolDetail`) so TETRA's descrambler gets its colour code.

## Verification (clean synth captures)
- **P25 P2:** ISCH + MAC decode **clean for every frame** (8/8) — a strong check that the ISCH/MAC offsets + dibit packing are right.
- **NXDN:** LICH **clean for every frame** (20/20); the CAC surfaces the real C4FM symbol-error rate (CRC-pass 9/20 — same C4FM recovery imperfection DMR shows, which is itself the diagnostic).
- **TETRA:** **19/20 CRC-pass** (one in-tolerance false-positive sync hit), with the colour code from the fixture metadata.
- Full unit suite `go test ./...` ✅; `-tags integration … TestDaemonCCDecodes` ✅; 13-protocol `gen → test` sweep still 13/13.

New unit tests assert each of the above (`TestFECTallyP25P2`, `TestFECTallyNXDN`, `TestFECTallyTETRA`).

## YSF — deliberately left at sync-landscape + histogram
YSF's FICH decode is **not yet integrated in the YSF decoder** (the 100-dibit FICH region's symbol→bit mapping is undefined in the codebase — "future FICH decoder, not in this PR"). Adding a tally would mean fabricating a convention production doesn't define, so YSF keeps its landscape + histogram with an accurate note.

## Remaining follow-ups (unchanged)
- DMR Tier I decoder (still deferred — no receiver exists).
- YSF FICH tally — unblocked once FICH decode is integrated into the YSF decoder.

https://claude.ai/code/session_01P8Es75yBSfmW7xe2FErfuM

---
_Generated by [Claude Code](https://claude.ai/code/session_01P8Es75yBSfmW7xe2FErfuM)_