### PR TITLE
DMR Tier I decoder + signal-identifier feature

### DIFF
--- a/cmd/gophertrunk/identify.go
+++ b/cmd/gophertrunk/identify.go
@@ -1,0 +1,171 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/MattCheramie/GopherTrunk/internal/siglab"
+)
+
+// runIdentify is the entry point for `gophertrunk identify`. It scans a capture
+// against every protocol GopherTrunk can decode (over a fast prefix), ranks
+// them by lock + sync-landscape + FEC evidence, names the most likely one, and
+// then runs the full analysis for that protocol over the whole capture — so a
+// single command answers "what is this signal, and how does it decode?".
+func runIdentify(args []string) {
+	fs := flag.NewFlagSet("identify", flag.ExitOnError)
+	verboseFlag := fs.Bool("verbose-errors", false, "print full error chain + stack on failures")
+	in := fs.String("in", "", "raw IQ input file (required)")
+	format := fs.String("format", "u8", "sample format: u8 | f32")
+	sampleRate := fs.Float64("sample-rate", 2_400_000, "IQ sample rate in Hz")
+	autoTune := fs.Bool("auto-tune", false, "estimate the dominant carrier offset and tune it to 0 Hz before demod")
+	conjugate := fs.Bool("conjugate", false, "conjugate IQ (negate Q) before channelization (spectrum-inverted front-end)")
+	iqCorrect := fs.Bool("iq-correct", false, "apply blind I/Q-imbalance correction to the raw IQ before decimation")
+	maxSeconds := fs.Float64("max-seconds", 3.0, "seconds of capture to scan per candidate (0 = whole capture)")
+	noAnalyze := fs.Bool("no-analyze", false, "only identify; skip the full analysis of the winning protocol")
+	out := fs.String("out", "", "write the structured report to this file (default: stdout)")
+	outFormat := fs.String("out-format", "text", "output format: text | json | yaml")
+	fs.Usage = func() {
+		fmt.Fprintln(fs.Output(), `gophertrunk identify — auto-detect the protocol in a capture, then analyze it.
+
+USAGE:
+  gophertrunk identify -in <path> [-format u8|f32] [-sample-rate Hz]
+                      [-max-seconds N] [-out-format text|json|yaml] [-out <file>]
+
+EXAMPLES:
+  # Identify an unknown wideband capture and analyze the winning protocol
+  gophertrunk identify -in unknown.cfile -format f32 -sample-rate 2400000 -auto-tune
+
+  # Just the ranked identification, as JSON
+  gophertrunk identify -in unknown.cfile -format f32 -sample-rate 2400000 -no-analyze -out-format json
+
+FLAGS:`)
+		fs.PrintDefaults()
+	}
+	_ = fs.Parse(args)
+	resolveVerbose(*verboseFlag, false)
+	rep := newReporter("identify")
+
+	if *in == "" {
+		fs.Usage()
+		rep.Fatalf(2, "-in is required")
+	}
+	if *sampleRate <= 0 {
+		rep.Fatalf(2, "-sample-rate must be > 0")
+	}
+	sampleFormat, err := siglab.ParseSampleFormat(*format)
+	if err != nil {
+		rep.Fatal(2, err)
+	}
+
+	var maxSamples int64
+	if *maxSeconds > 0 {
+		maxSamples = int64(*maxSeconds * *sampleRate)
+	}
+
+	idr, err := siglab.Identify(*in, siglab.IdentifyConfig{
+		SampleRateHz: *sampleRate,
+		Format:       sampleFormat,
+		AutoTune:     *autoTune,
+		Conjugate:    *conjugate,
+		IQCorrect:    *iqCorrect,
+		MaxSamples:   maxSamples,
+	})
+	if err != nil {
+		rep.Fatal(1, err)
+	}
+
+	// Run the full analysis for the winner over the whole capture, unless the
+	// identification was inconclusive or the operator opted out.
+	var analysis *siglab.Result
+	if !*noAnalyze && !idr.Inconclusive {
+		proto, perr := idr.WinnerProtocol()
+		if perr != nil {
+			rep.Fatal(1, perr)
+		}
+		analysis, err = siglab.Run(*in, siglab.Config{
+			Protocol:      proto,
+			SystemName:    "identify",
+			SampleRateHz:  *sampleRate,
+			Format:        sampleFormat,
+			AutoTune:      *autoTune,
+			Conjugate:     *conjugate,
+			IQCorrect:     *iqCorrect,
+			CollectIQDiag: true,
+		})
+		if err != nil {
+			rep.Fatal(1, err)
+		}
+	}
+
+	w := os.Stdout
+	if *out != "" {
+		f, cerr := os.Create(*out)
+		if cerr != nil {
+			rep.Fatal(1, fmt.Errorf("create %s: %w", *out, cerr))
+		}
+		defer f.Close()
+		w = f
+	}
+	if err := emitIdentify(w, idr, analysis, *outFormat); err != nil {
+		rep.Fatal(1, err)
+	}
+}
+
+// emitIdentify renders the identification verdict (and the winner's analysis,
+// when present) as text/json/yaml.
+func emitIdentify(w io.Writer, idr *siglab.IdentifyResult, analysis *siglab.Result, outFormat string) error {
+	switch outFormat {
+	case "json":
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		return enc.Encode(struct {
+			Identify *siglab.IdentifyResult `json:"identify"`
+			Analysis *siglab.Result         `json:"analysis,omitempty"`
+		}{idr, analysis})
+	case "yaml", "yml":
+		// Text verdict + the winner's analysis as YAML (the structured part
+		// operators pipe onward).
+		renderIdentifyText(w, idr)
+		if analysis != nil {
+			return siglab.WriteResult(w, analysis, siglab.FormatYAML)
+		}
+		return nil
+	case "text", "":
+		renderIdentifyText(w, idr)
+		if analysis != nil {
+			fmt.Fprintln(w, "----")
+			fmt.Fprintf(w, "identify: full analysis of %s ↓\n", idr.Winner)
+			renderResultText(w, analysis)
+		}
+		return nil
+	default:
+		return fmt.Errorf("unknown -out-format %q (want text|json|yaml)", outFormat)
+	}
+}
+
+// renderIdentifyText prints the ranked candidate table + verdict.
+func renderIdentifyText(w io.Writer, idr *siglab.IdentifyResult) {
+	fmt.Fprintf(w, "identify: %s @ %.0f Hz — %d candidates\n", idr.Source, idr.SampleRateHz, len(idr.Candidates))
+	fmt.Fprintf(w, "identify: %-12s %-7s %-7s %-14s %-9s %-6s %s\n",
+		"protocol", "locked", "hits", "sync", "fec_pass", "modal", "score")
+	for _, c := range idr.Candidates {
+		fmt.Fprintf(w, "identify:   %-10s %-7v %-7d %-14s %-9.2f %-6d %.3f\n",
+			c.Protocol, c.Locked, c.SyncHits, truncStr(c.SyncVariant, 14), c.FECPassRate, c.ModalSpacing, c.Score)
+	}
+	verdict := idr.Winner
+	if idr.Inconclusive {
+		verdict = "INCONCLUSIVE (best guess: " + idr.Winner + ")"
+	}
+	fmt.Fprintf(w, "identify: → %s  (confidence %.2f)\n", verdict, idr.Confidence)
+}
+
+func truncStr(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n]
+}

--- a/cmd/gophertrunk/integration_cc_dmr_tier1_test.go
+++ b/cmd/gophertrunk/integration_cc_dmr_tier1_test.go
@@ -1,0 +1,178 @@
+//go:build integration
+
+package main
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/config"
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/demod"
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/dmr"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/dmr/tier2"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+	"github.com/MattCheramie/GopherTrunk/internal/sdr"
+)
+
+// TestDaemonCCDecodesDMRTier1 is the Tier I direct-mode counterpart of the
+// Tier II conventional test. DMR Tier I is license-free simplex (PMR446): the
+// wire format is identical to Tier II (Voice LC Header via BPTC(196,96) +
+// RS(12,9)), but the burst carries a *direct-mode* sync word (DM-Voice-TS1)
+// rather than the base-station sync. The production newDMRTier1Pipeline drives
+// a DM-sync-restricted ConventionalChannel tagged "dmr-tier1"; this asserts the
+// full daemon + supervisor + API + metrics chain recovers the lock.
+func TestDaemonCCDecodesDMRTier1(t *testing.T) {
+	const (
+		controlFreqHz = 446_006_250 // PMR446 channel 1
+		sampleRateHz  = 48_000
+		sps           = 10
+		span          = 8
+		alpha         = 0.20
+		deviationHz   = 1944.0
+		colorCode     = 0x7
+		groupID       = 0x123
+		sourceID      = 0x456789
+		burstRepeats  = 80
+	)
+
+	dibits := buildDMRTier1VoiceLCHeaderDibits(burstRepeats, colorCode, groupID, sourceID)
+	iq := demod.ModulateC4FM(dibits, sps, span, alpha, sampleRateHz, deviationHz)
+
+	dir := t.TempDir()
+	iqPath := filepath.Join(dir, "dmr-tier1-cc.cfile")
+	if err := writeIQToU8File(iqPath, iq); err != nil {
+		t.Fatalf("write IQ: %v", err)
+	}
+	sdr.Register(&sdr.MockDriver{Files: []string{iqPath}})
+
+	cfg := config.Default()
+	cfg.SDR.SampleRate = sampleRateHz
+	cfg.SDR.Devices = []config.DeviceConfig{
+		{Serial: "mock-00", Role: "control"},
+	}
+	cfg.Trunking.Systems = []config.SystemConfig{
+		{Name: "DMRTier1Direct", Protocol: "dmr-tier1", ControlChannels: []uint32{controlFreqHz}},
+	}
+	cfg.API.HTTPAddr = freeAddr(t)
+	cfg.Metrics.Enabled = true
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	d, err := NewDaemon(cfg, "integration-cc-dmr-tier1", logger)
+	if err != nil {
+		t.Fatalf("NewDaemon: %v", err)
+	}
+	if d.ccDecoder == nil {
+		t.Fatalf("ccDecoder is nil; daemon should have constructed one")
+	}
+
+	sub := d.Bus().Subscribe()
+	defer sub.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	runErrCh := make(chan error, 1)
+	go func() { runErrCh <- d.Run(ctx) }()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case <-runErrCh:
+		case <-time.After(3 * time.Second):
+		}
+	})
+
+	base := "http://" + cfg.API.HTTPAddr
+	waitReachable(t, base+"/api/v1/health", 3*time.Second)
+
+	deadline := time.After(10 * time.Second)
+	var sawLock bool
+WaitLoop:
+	for !sawLock {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind != events.KindCCLocked {
+				continue
+			}
+			ls, ok := ev.Payload.(tier2.LockState)
+			if !ok {
+				t.Errorf("CCLocked payload type = %T, want tier2.LockState", ev.Payload)
+				continue
+			}
+			if ls.ColorCode != colorCode {
+				t.Errorf("LockState.ColorCode = %#x, want %#x", ls.ColorCode, colorCode)
+			}
+			if ls.FrequencyHz != controlFreqHz {
+				t.Errorf("LockState.FrequencyHz = %d, want %d", ls.FrequencyHz, controlFreqHz)
+			}
+			sawLock = true
+			break WaitLoop
+		case <-deadline:
+			t.Fatalf("no cc.locked event arrived within 10s")
+		}
+	}
+
+	waitForScannerLock(t, base, "DMRTier1Direct", 2*time.Second)
+
+	body := scrape(t, base+"/metrics")
+	if !strings.Contains(body, "gophertrunk_control_channel_locked{") {
+		t.Errorf("/metrics missing gophertrunk_control_channel_locked gauge family:\n%s", body)
+	}
+	if !strings.Contains(body, `gophertrunk_events_total{kind="cc.locked"} 1`) {
+		t.Errorf("/metrics did not count one cc.locked event:\n%s", body)
+	}
+}
+
+// buildDMRTier1VoiceLCHeaderDibits builds a DMR Tier I direct-mode Voice LC
+// Header burst stream — identical to the Tier II builder but with the
+// direct-mode DM-Voice-TS1 sync word in place of the base-station sync, so the
+// DM-sync-restricted Tier I pipeline locks on it.
+func buildDMRTier1VoiceLCHeaderDibits(repeats int, colorCode uint8, groupID, sourceID uint32) []uint8 {
+	flc := dmr.FLC{
+		FLCO:    dmr.FLCOGroupVoiceUser,
+		DstAddr: groupID,
+		SrcAddr: sourceID,
+	}
+	flcBytes := dmr.AssembleFLC(flc)
+	var data [9]byte
+	copy(data[:], flcBytes)
+	cw := framing.EncodeRS12_9(data)
+	for i := 0; i < 3; i++ {
+		cw[9+i] ^= framing.RS129SeedVoiceLCHeader[i]
+	}
+	info := cw[:]
+	bits := make([]byte, 96)
+	for i := 0; i < 96; i++ {
+		bits[i] = (info[i>>3] >> uint(7-(i&7))) & 1
+	}
+	channelBits := framing.EncodeBPTC196_96(bits)
+	payloadDibits := framing.BitsToDibits(channelBits)
+
+	slotBits := dmr.AssembleSlotType(dmr.SlotType{ColorCode: colorCode, DataType: dmr.DTVoiceLCHeader})
+	slotDibits := framing.BitsToDibits(slotBits)
+
+	burst := make([]uint8, 0, dmr.BurstDibits)
+	burst = append(burst, payloadDibits[:dmr.HalfPayloadDibits]...)
+	burst = append(burst, slotDibits[:dmr.SlotTypeDibits]...)
+	burst = append(burst, dmr.DMVoice1.Dibits[:]...)
+	burst = append(burst, slotDibits[dmr.SlotTypeDibits:]...)
+	burst = append(burst, payloadDibits[dmr.HalfPayloadDibits:]...)
+
+	out := make([]uint8, 0, 800+repeats*(len(burst)+32)+100)
+	for i := 0; i < 800; i++ {
+		out = append(out, uint8(i&3))
+	}
+	for r := 0; r < repeats; r++ {
+		out = append(out, burst...)
+		for i := 0; i < 32; i++ {
+			out = append(out, uint8(i&3))
+		}
+	}
+	for i := 0; i < 100; i++ {
+		out = append(out, uint8(i&3))
+	}
+	return out
+}

--- a/cmd/gophertrunk/main.go
+++ b/cmd/gophertrunk/main.go
@@ -60,6 +60,8 @@ func main() {
 		runReplay(os.Args[2:])
 	case "analyze":
 		runAnalyze(os.Args[2:])
+	case "identify":
+		runIdentify(os.Args[2:])
 	case "gen":
 		runGen(os.Args[2:])
 	case "test":
@@ -92,6 +94,7 @@ USAGE:
   gophertrunk decode [flags]          decode a captured .raw frame stream into a WAV
   gophertrunk replay [flags]          decode a raw IQ capture file offline (any protocol)
   gophertrunk analyze [flags]         decode + analyze a capture with structured export (json/yaml/csv)
+  gophertrunk identify [flags]        auto-detect the protocol in a capture, then analyze it
   gophertrunk gen [flags]             synthesize a test IQ capture + metadata for a protocol
   gophertrunk test [flags]            decode a capture and grade it against acceptance criteria
   gophertrunk siglab [flags]          standalone replay/test/analysis TUI

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1421,9 +1421,11 @@ func validateWidebandDevice(idx int, d DeviceConfig, sampleRateHz uint32, system
 			return fmt.Errorf("sdr.devices[%d].channels[%d]: system %q is not declared in trunking.systems", idx, j, ch.System)
 		}
 		switch sys.Protocol {
-		case "dmr-tier2", "dmr_tier2", "dmr-t2", "dmrtier2":
-			// Tier II conventional - channel freq is a repeater carrier,
-			// no relationship to system.ControlChannels required.
+		case "dmr-tier2", "dmr_tier2", "dmr-t2", "dmrtier2",
+			"dmr-tier1", "dmr_tier1", "dmr-t1", "dmrtier1":
+			// Tier II conventional / Tier I direct-mode — channel freq is a
+			// repeater or simplex carrier, no relationship to
+			// system.ControlChannels required.
 		case "dmr", "p25", "p25-phase2", "p25_phase2", "p25p2":
 			// Trunked control-channel protocols — the wideband channel
 			// MUST be one of the system's declared control channels.

--- a/internal/radio/dmr/tier2/conventional.go
+++ b/internal/radio/dmr/tier2/conventional.go
@@ -54,6 +54,17 @@ type ConventionalChannel struct {
 	freqHz     uint32
 	now        func() time.Time
 
+	// protocolTag is the grant / decode-error Protocol string. It is
+	// "dmr-tier2" for base-station conventional decode and "dmr-tier1" for
+	// direct-mode decode — the wire format is identical, so the same state
+	// machine serves both, distinguished by tag + sync-word set.
+	protocolTag string
+	// syncPatterns restricts the burst-sync detector to a subset of the 9
+	// ETSI sync words. nil ⇒ all syncs (Tier II default). Tier I passes the
+	// direct-mode syncs (DM-Voice/Data) so it doesn't false-lock on
+	// base-station traffic.
+	syncPatterns []dmr.SyncPattern
+
 	// proc is the cross-call dibit / sync state the Process adapter
 	// uses (see process.go). Lazily constructed on the first
 	// Process call.
@@ -75,6 +86,12 @@ type Options struct {
 	SystemName  string
 	FrequencyHz uint32
 	Now         func() time.Time
+	// ProtocolTag overrides the grant / decode-error Protocol string.
+	// Empty ⇒ "dmr-tier2". Set to "dmr-tier1" for direct-mode decode.
+	ProtocolTag string
+	// SyncPatterns restricts the burst-sync detector to these sync words.
+	// nil ⇒ all 9 ETSI syncs (Tier II). Tier I passes the direct-mode set.
+	SyncPatterns []dmr.SyncPattern
 }
 
 // New constructs a ConventionalChannel.
@@ -87,12 +104,18 @@ func New(opts Options) *ConventionalChannel {
 	if now == nil {
 		now = time.Now
 	}
+	tag := opts.ProtocolTag
+	if tag == "" {
+		tag = "dmr-tier2"
+	}
 	return &ConventionalChannel{
-		bus:        opts.Bus,
-		log:        log,
-		systemName: opts.SystemName,
-		freqHz:     opts.FrequencyHz,
-		now:        now,
+		bus:          opts.Bus,
+		log:          log,
+		systemName:   opts.SystemName,
+		freqHz:       opts.FrequencyHz,
+		now:          now,
+		protocolTag:  tag,
+		syncPatterns: opts.SyncPatterns,
 	}
 }
 
@@ -159,7 +182,7 @@ func (c *ConventionalChannel) handleVoiceHeader(b *dmr.Burst, slot dmr.SlotType)
 		c.log.Debug("dmr/tier2: voice header BPTC uncorrectable")
 		c.bus.Publish(events.Event{
 			Kind:    events.KindDecodeError,
-			Payload: events.DecodeError{Protocol: "dmr-tier2", Stage: events.StageVoiceHeaderBPTC},
+			Payload: events.DecodeError{Protocol: c.protocolTag, Stage: events.StageVoiceHeaderBPTC},
 		})
 		return
 	}
@@ -173,7 +196,7 @@ func (c *ConventionalChannel) handleVoiceHeader(b *dmr.Burst, slot dmr.SlotType)
 		c.log.Debug("dmr/tier2: voice header RS(12,9) parity mismatch")
 		c.bus.Publish(events.Event{
 			Kind:    events.KindDecodeError,
-			Payload: events.DecodeError{Protocol: "dmr-tier2", Stage: events.StageVoiceHeaderRS},
+			Payload: events.DecodeError{Protocol: c.protocolTag, Stage: events.StageVoiceHeaderRS},
 		})
 		return
 	}
@@ -200,7 +223,7 @@ func (c *ConventionalChannel) handleVoiceHeader(b *dmr.Burst, slot dmr.SlotType)
 		Kind: events.KindGrant,
 		Payload: trunking.Grant{
 			System:      c.systemName,
-			Protocol:    "dmr-tier2",
+			Protocol:    c.protocolTag,
 			GroupID:     gv.GroupAddress,
 			SourceID:    gv.SourceID,
 			FrequencyHz: c.freqHz,

--- a/internal/radio/dmr/tier2/conventional_test.go
+++ b/internal/radio/dmr/tier2/conventional_test.go
@@ -41,6 +41,44 @@ func burstWithFLC(f dmr.FLC) *dmr.Burst {
 	return &b
 }
 
+// TestConventionalProtocolTagDirectMode pins the Tier I direct-mode
+// parameterization: a ConventionalChannel constructed with
+// ProtocolTag="dmr-tier1" must publish grants tagged "dmr-tier1" (the wire
+// decode is identical to Tier II — only the tag + sync set differ).
+func TestConventionalProtocolTagDirectMode(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{
+		Bus:         bus,
+		SystemName:  "DirectMode",
+		FrequencyHz: 446_006_250,
+		ProtocolTag: "dmr-tier1",
+		Now:         func() time.Time { return time.Unix(1_700_000_000, 0).UTC() },
+	})
+	flc := dmr.FLC{FLCO: dmr.FLCOGroupVoiceUser, DstAddr: 0x000064, SrcAddr: 0x100200}
+	cc.IngestBurst(burstWithFLC(flc), dmr.SlotType{ColorCode: 7, DataType: dmr.DTVoiceLCHeader})
+
+	deadline := time.After(time.Second)
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind != events.KindGrant {
+				continue
+			}
+			g := ev.Payload.(trunking.Grant)
+			if g.Protocol != "dmr-tier1" {
+				t.Errorf("grant Protocol = %q, want dmr-tier1", g.Protocol)
+			}
+			return
+		case <-deadline:
+			t.Fatal("no grant event")
+		}
+	}
+}
+
 func TestConventionalPublishesGrantOnVoiceLCHeader(t *testing.T) {
 	bus := events.NewBus(8)
 	defer bus.Close()

--- a/internal/radio/dmr/tier2/process.go
+++ b/internal/radio/dmr/tier2/process.go
@@ -50,7 +50,7 @@ type processState struct {
 func (c *ConventionalChannel) Process(dibits []uint8, baseIdx int) int {
 	if c.proc == nil {
 		c.proc = &processState{
-			det: dmr.NewSyncDetector(nil, 2),
+			det: dmr.NewSyncDetector(c.syncPatterns, 2),
 		}
 	}
 	p := c.proc

--- a/internal/scanner/ccdecoder/pipelines.go
+++ b/internal/scanner/ccdecoder/pipelines.go
@@ -194,6 +194,7 @@ var factories = map[trunking.Protocol]PipelineFactory{
 	trunking.ProtocolYSF:       newYSFPipeline,
 	trunking.ProtocolDStar:     newDStarPipeline,
 	trunking.ProtocolDMRTier2:  newDMRTier2Pipeline,
+	trunking.ProtocolDMRTier1:  newDMRTier1Pipeline,
 }
 
 // newP25Phase1Pipeline wires the existing
@@ -719,6 +720,47 @@ type dmrTier2Pipeline struct {
 func (p *dmrTier2Pipeline) Process(iq []complex64) { p.rx.Process(iq) }
 func (p *dmrTier2Pipeline) Reset()                 { p.rx.Reset() }
 func (p *dmrTier2Pipeline) Close() error           { return nil }
+
+// newDMRTier1Pipeline wires the shared DMR receiver into the
+// tier2.ConventionalChannel state machine in *direct-mode* configuration:
+// the same wire format as Tier II (C4FM dibits → burst → slot-type
+// Hamming → Voice LC Header BPTC(196,96) + RS(12,9,4) → grant), but the
+// burst-sync detector is restricted to the four ETSI direct-mode sync
+// words (DM-Voice/Data, TS1/TS2) and grants/decode-errors are tagged
+// "dmr-tier1". DMR Tier I is license-free simplex (PMR446); it has no
+// repeater or control channel, so a Voice LC Header marks each
+// transmission start exactly as in Tier II conventional.
+func newDMRTier1Pipeline(opts PipelineOptions) (ProtocolPipeline, error) {
+	cc := tier2.New(tier2.Options{
+		Bus:         opts.Bus,
+		Log:         opts.Log,
+		SystemName:  opts.SystemName,
+		FrequencyHz: opts.FrequencyHz,
+		ProtocolTag: "dmr-tier1",
+		SyncPatterns: []dmr.SyncPattern{
+			dmr.DMVoice1, dmr.DMVoice2, dmr.DMData1, dmr.DMData2,
+		},
+	})
+	rx := dmrrx.New(dmrrx.Options{
+		SampleRateHz: opts.SampleRateHz,
+		DeviationHz:  1944.0,
+		ClockGain:    0.015, // same as Tier II (identical burst symbol statistics)
+		DibitSink: func(dibits []uint8, baseIdx int) {
+			opts.tapDibits(dibits, baseIdx)
+			cc.Process(dibits, baseIdx)
+		},
+	})
+	return &dmrTier1Pipeline{rx: rx, cc: cc}, nil
+}
+
+type dmrTier1Pipeline struct {
+	rx *dmrrx.Receiver
+	cc *tier2.ConventionalChannel
+}
+
+func (p *dmrTier1Pipeline) Process(iq []complex64) { p.rx.Process(iq) }
+func (p *dmrTier1Pipeline) Reset()                 { p.rx.Reset() }
+func (p *dmrTier1Pipeline) Close() error           { return nil }
 
 // newNXDNPipeline wires internal/radio/nxdn/receiver into
 // nxdn.ControlChannel.Process. The receiver's DibitSink forwards

--- a/internal/siglab/config.go
+++ b/internal/siglab/config.go
@@ -73,6 +73,11 @@ type Config struct {
 	// ChunkSamples is the read-loop chunk size in IQ samples; 0 ⇒ default.
 	ChunkSamples int
 
+	// MaxSamples caps the number of input IQ samples processed (0 ⇒ whole
+	// file). The signal identifier sets this to scan only a prefix of a
+	// capture, bounding per-candidate cost regardless of capture length.
+	MaxSamples int64
+
 	// Acceptance, when non-nil, is evaluated against the Result to produce a
 	// pass/fail Verdict (the `test` harness sets it).
 	Acceptance *Acceptance

--- a/internal/siglab/detail.go
+++ b/internal/siglab/detail.go
@@ -64,6 +64,10 @@ var detailSpecs = map[trunking.Protocol]detailSpec{
 		cardinality: 4, tolerance: 4, syncFn: dmrSyncVariants, fec: dmrSlotTypeFEC,
 		notes: "DMR Tier II is voice-only; sync + slot-type only (no CSBK path).",
 	},
+	trunking.ProtocolDMRTier1: {
+		cardinality: 4, tolerance: 4, syncFn: dmrSyncVariants, fec: dmrSlotTypeFEC,
+		notes: "DMR Tier I direct-mode; sync + slot-type only (no CSBK path).",
+	},
 	trunking.ProtocolP25Phase2: {
 		cardinality: 4, tolerance: 3,
 		syncFn: func() []SyncVariant {

--- a/internal/siglab/engine.go
+++ b/internal/siglab/engine.go
@@ -194,6 +194,12 @@ func runReader(r io.Reader, source string, decode SampleDecoder, bytesPerSample 
 			readErr = fmt.Errorf("read %s: %w", source, rerr)
 			break
 		}
+		// Prefix cap (identifier fast scan): stop once enough input samples
+		// have been processed. Checked after a whole chunk, so it may
+		// overshoot by up to one chunk — fine for a bounded scan.
+		if cfg.MaxSamples > 0 && totalSamples >= cfg.MaxSamples {
+			break
+		}
 	}
 
 	// Release the drainer and wait for it so totals are complete.

--- a/internal/siglab/fixtures.go
+++ b/internal/siglab/fixtures.go
@@ -74,7 +74,20 @@ var fixtures = map[trunking.Protocol]fixture{
 		expected:    Acceptance{Lock: boolPtr(true)},
 	},
 	trunking.ProtocolDMRTier2: {
-		build:      func() []uint8 { return buildDMRTier2VoiceLCHeaderDibits(80, 0x7, 0x123, 0x456789) },
+		build: func() []uint8 {
+			return buildDMRConventionalVoiceLCHeaderDibits(80, 0x7, 0x123, 0x456789, dmr.BSData.Dibits[:])
+		},
+		modulate:   func(d []uint8, sr float64) []complex64 { return demod.ModulateC4FM(d, 10, 8, 0.20, sr, 1944.0) },
+		sampleRate: 48_000,
+		expected: Acceptance{
+			Lock:       boolPtr(true),
+			LockFields: map[string]any{"color_code": 0x7},
+		},
+	},
+	trunking.ProtocolDMRTier1: {
+		build: func() []uint8 {
+			return buildDMRConventionalVoiceLCHeaderDibits(80, 0x7, 0x123, 0x456789, dmr.DMVoice1.Dibits[:])
+		},
 		modulate:   func(d []uint8, sr float64) []complex64 { return demod.ModulateC4FM(d, 10, 8, 0.20, sr, 1944.0) },
 		sampleRate: 48_000,
 		expected: Acceptance{
@@ -249,7 +262,11 @@ func buildP25Phase2MACPTTStream(repeats int) []uint8 {
 
 // buildDMRTier2VoiceLCHeaderDibits builds a DMR Tier II conventional stream of
 // repeated Voice LC Header bursts. Lifted from integration_cc_dmr_tier2_test.go.
-func buildDMRTier2VoiceLCHeaderDibits(repeats int, colorCode uint8, groupID, sourceID uint32) []uint8 {
+// buildDMRConventionalVoiceLCHeaderDibits builds a DMR conventional /
+// direct-mode Voice LC Header stream. The sync word distinguishes Tier II
+// (base-station, dmr.BSData) from Tier I (direct-mode, dmr.DMVoice1); the rest
+// of the wire format is identical. Lifted from integration_cc_dmr_tier2_test.go.
+func buildDMRConventionalVoiceLCHeaderDibits(repeats int, colorCode uint8, groupID, sourceID uint32, sync []uint8) []uint8 {
 	flc := dmr.FLC{
 		FLCO:    dmr.FLCOGroupVoiceUser,
 		DstAddr: groupID,
@@ -276,7 +293,7 @@ func buildDMRTier2VoiceLCHeaderDibits(repeats int, colorCode uint8, groupID, sou
 	burst := make([]uint8, 0, dmr.BurstDibits)
 	burst = append(burst, payloadDibits[:dmr.HalfPayloadDibits]...)
 	burst = append(burst, slotDibits[:dmr.SlotTypeDibits]...)
-	burst = append(burst, dmr.BSData.Dibits[:]...)
+	burst = append(burst, sync...)
 	burst = append(burst, slotDibits[dmr.SlotTypeDibits:]...)
 	burst = append(burst, payloadDibits[dmr.HalfPayloadDibits:]...)
 

--- a/internal/siglab/identify.go
+++ b/internal/siglab/identify.go
@@ -1,0 +1,254 @@
+package siglab
+
+import (
+	"fmt"
+	"log/slog"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/MattCheramie/GopherTrunk/internal/scanner/ccdecoder"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// IdentifyConfig configures a signal-identification scan over a capture.
+type IdentifyConfig struct {
+	SampleRateHz float64
+	Format       SampleFormat
+	AutoTune     bool
+	Conjugate    bool
+	IQCorrect    bool
+	// MaxSamples caps the input samples each candidate processes (0 ⇒ whole
+	// capture). Set it to scan a fast prefix when identifying.
+	MaxSamples int64
+	// Candidates restricts the protocols tried. nil ⇒ every registered
+	// protocol whose channel rate fits the capture sample rate.
+	Candidates []trunking.Protocol
+	Log        *slog.Logger
+}
+
+// CandidateScore is one protocol's identification evidence and composite score.
+type CandidateScore struct {
+	Protocol       string  `json:"protocol"`
+	Locked         bool    `json:"locked"`
+	LockLatencySec float64 `json:"lock_latency_sec"`
+	SyncHits       int     `json:"sync_hits"`
+	SyncVariant    string  `json:"sync_variant"`
+	ModalSpacing   int     `json:"modal_spacing"`
+	FECPassRate    float64 `json:"fec_pass_rate"`
+	Score          float64 `json:"score"`
+
+	result *Result // the candidate's run result, reused by callers
+}
+
+// IdentifyResult ranks the candidates and names the most likely protocol.
+type IdentifyResult struct {
+	Source       string           `json:"source"`
+	SampleRateHz float64          `json:"sample_rate_hz"`
+	Winner       string           `json:"winner"`
+	Confidence   float64          `json:"confidence"`
+	Inconclusive bool             `json:"inconclusive"`
+	Candidates   []CandidateScore `json:"candidates"`
+}
+
+// identifyConfidenceFloor is the minimum confidence below which an
+// identification is reported as inconclusive — a winner with weak,
+// uncorroborated evidence (a bare cross-protocol false lock, or a protocol
+// whose sync GopherTrunk can't see) lands here, surfaced as a best guess.
+const identifyConfidenceFloor = 0.40
+
+// Identify scans path against candidate protocols and returns a ranked result.
+// Each candidate is run through the engine — over a bounded prefix when
+// MaxSamples is set — and scored on lock + sync-landscape evidence + FEC pass
+// rate. The winner's run result is retained for WinnerResult.
+func Identify(path string, cfg IdentifyConfig) (*IdentifyResult, error) {
+	if cfg.SampleRateHz <= 0 {
+		return nil, fmt.Errorf("siglab: identify sample rate must be > 0")
+	}
+	candidates := cfg.Candidates
+	if candidates == nil {
+		// Try every registered protocol. A protocol whose channel rate is far
+		// above the capture rate simply won't lock (too few samples/symbol
+		// after the DDC pass-through), so it scores itself out rather than
+		// needing an explicit rate filter — and a capture sampled at or below
+		// a protocol's target (e.g. a 72 kHz TETRA grab) still decodes.
+		candidates = ccdecoder.RegisteredProtocols()
+	}
+
+	out := &IdentifyResult{Source: filepath.Base(path), SampleRateHz: cfg.SampleRateHz}
+	for _, p := range candidates {
+		r, err := Run(path, Config{
+			Protocol:      p,
+			SystemName:    "identify",
+			SampleRateHz:  cfg.SampleRateHz,
+			Format:        cfg.Format,
+			AutoTune:      cfg.AutoTune,
+			Conjugate:     cfg.Conjugate,
+			IQCorrect:     cfg.IQCorrect,
+			MaxSamples:    cfg.MaxSamples,
+			CollectIQDiag: true,
+			Log:           cfg.Log,
+		})
+		if err != nil {
+			continue // a candidate that errors out is simply dropped
+		}
+		out.Candidates = append(out.Candidates, scoreCandidate(p, r))
+	}
+	if len(out.Candidates) == 0 {
+		return nil, fmt.Errorf("siglab: identify produced no candidate scores")
+	}
+	sort.SliceStable(out.Candidates, func(i, j int) bool {
+		return out.Candidates[i].Score > out.Candidates[j].Score
+	})
+	out.Winner = out.Candidates[0].Protocol
+	out.Confidence = confidenceOf(out.Candidates)
+	out.Inconclusive = out.Confidence < identifyConfidenceFloor
+	return out, nil
+}
+
+// WinnerResult returns the run Result for the winning candidate (the prefix
+// scan), or nil. Callers wanting a full-capture analysis should re-run
+// siglab.Run with MaxSamples=0 for the winning protocol.
+func (r *IdentifyResult) WinnerResult() *Result {
+	for i := range r.Candidates {
+		if r.Candidates[i].Protocol == r.Winner {
+			return r.Candidates[i].result
+		}
+	}
+	return nil
+}
+
+// WinnerProtocol parses the winning protocol name back to a trunking.Protocol.
+func (r *IdentifyResult) WinnerProtocol() (trunking.Protocol, error) {
+	return trunking.ParseProtocol(r.Winner)
+}
+
+// scoreCandidate computes a 0..~1 composite score from a candidate's run.
+// Weighting: lock (0.35) + sync evidence (0.40) + FEC pass (0.25), plus a small
+// DMR-conventional tie-break so a direct-mode (DM-sync) capture prefers Tier I
+// and a base-station (BS-sync) capture prefers Tier II when both lock.
+func scoreCandidate(p trunking.Protocol, r *Result) CandidateScore {
+	hits, syncLen, modal, variant, fecPass := detailEvidence(r)
+
+	normHits := float64(hits) / 20.0
+	if normHits > 1 {
+		normHits = 1
+	}
+	// Sync hits only count as real evidence when they recur at a genuine
+	// frame cadence — a modal spacing at least as large as the sync word
+	// itself. The false-lock failure mode is many chance correlations at a
+	// tiny/degenerate spacing (e.g. every 2 symbols), which is heavily
+	// discounted here.
+	modalGate := 0.1
+	switch {
+	case modal >= syncLen && syncLen > 0:
+		modalGate = 1.0
+	case modal > 0:
+		modalGate = 0.3
+	}
+	syncScore := normHits * modalGate
+
+	// Sync cadence is the most reliable, key-independent evidence (a
+	// descrambled protocol like TETRA can't lock or pass CRC without its
+	// colour code, but its sync still stands out); weight it highest.
+	score := 0.0
+	if r.Locked {
+		score += 0.25
+	}
+	score += 0.45 * syncScore
+	score += 0.30 * fecPass
+	// A recovered grant is strong, higher-layer evidence the decode is real
+	// (e.g. a DMR Voice LC Header that passed BPTC + RS + FLC parse) — it
+	// distinguishes Tier II conventional (grants on VLC) from a Tier III
+	// broadcast capture (no grant) when both lock on the shared slot type.
+	if len(r.Grants) > 0 {
+		score += 0.10
+	}
+	score += dmrVariantBonus(p, variant)
+
+	return CandidateScore{
+		Protocol:       p.String(),
+		Locked:         r.Locked,
+		LockLatencySec: r.LockLatencySec,
+		SyncHits:       hits,
+		SyncVariant:    variant,
+		ModalSpacing:   modal,
+		FECPassRate:    fecPass,
+		Score:          score,
+		result:         r,
+	}
+}
+
+// detailEvidence pulls the sync-landscape + FEC evidence out of a run's Detail,
+// handling both the generic *ProtocolDetail and P25 Phase 1's *P25P1Detail.
+func detailEvidence(r *Result) (hits, syncLen, modal int, variant string, fecPass float64) {
+	switch d := r.Detail.(type) {
+	case *ProtocolDetail:
+		if d.Sync != nil {
+			hits, syncLen, modal, variant = d.Sync.WinnerHits, d.Sync.SyncLen, d.Sync.ModalSpacing, d.Sync.WinnerVariant
+		}
+		// Count only cleanly-decoded or CRC-validated frames as FEC evidence
+		// — NOT "corrected". A short FEC like the DMR slot-type Hamming(20,8)
+		// "corrects" almost any 20-bit input to some valid codeword, so
+		// crediting corrections would inflate a cross-protocol false lock.
+		var frames, ok float64
+		for _, f := range d.FEC {
+			frames += float64(f.Frames)
+			ok += float64(f.Clean + f.CRCPass)
+		}
+		if frames > 0 {
+			fecPass = ok / frames
+		}
+	case *P25P1Detail:
+		// The P25 FSW landscape already filters to genuine frame hits, so a
+		// non-trivial WinningHits implies a real cadence; signal that with a
+		// modal ≥ syncLen sentinel so it clears the cadence gate.
+		hits, syncLen, variant = d.WinningHits, p25FSWLen, fmt.Sprintf("rot%d", d.WinningRotation)
+		if d.WinningHits > 2 {
+			modal = p25FSWLen
+		}
+		if cc := d.CCStats; cc != nil {
+			att := cc.NIDTrusted + cc.NIDMarginal + cc.NIDFailed
+			if att > 0 {
+				fecPass = float64(cc.NIDTrusted+cc.NIDMarginal) / float64(att)
+			}
+		}
+	}
+	return hits, syncLen, modal, variant, fecPass
+}
+
+// dmrVariantBonus breaks the Tier I / Tier II tie on a direct-mode capture:
+// when the winning sync is a DM (direct-mode) word, prefer Tier I — Tier II's
+// permissive all-sync detector also locks it, but a DM sync means direct mode.
+// (Tier III vs Tier II is broken instead by the grant bonus + registration
+// order, since both use the base-station sync.)
+func dmrVariantBonus(p trunking.Protocol, variant string) float64 {
+	if p == trunking.ProtocolDMRTier1 && strings.HasPrefix(variant, "DM-") {
+		return 0.05
+	}
+	return 0
+}
+
+// confidenceOf blends the top score with its margin over the runner-up so a
+// clear, well-separated winner reads as high confidence.
+func confidenceOf(cands []CandidateScore) float64 {
+	if len(cands) == 0 {
+		return 0
+	}
+	top := clamp01(cands[0].Score)
+	if len(cands) == 1 {
+		return top
+	}
+	margin := clamp01((cands[0].Score - cands[1].Score) / 0.3)
+	return clamp01(0.7*top + 0.3*margin)
+}
+
+func clamp01(v float64) float64 {
+	if v < 0 {
+		return 0
+	}
+	if v > 1 {
+		return 1
+	}
+	return v
+}

--- a/internal/siglab/identify_test.go
+++ b/internal/siglab/identify_test.go
@@ -1,0 +1,92 @@
+package siglab
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// TestIdentifyPicksCorrectProtocol synthesizes a clean capture for several
+// strong-evidence protocols and asserts the identifier names the right one
+// with non-inconclusive confidence. The set spans the modulation families
+// (C4FM dibit, GFSK bit, direct-mode DMR) and the DMR Tier-distinction.
+func TestIdentifyPicksCorrectProtocol(t *testing.T) {
+	for _, proto := range []trunking.Protocol{
+		trunking.ProtocolP25,
+		trunking.ProtocolNXDN,
+		trunking.ProtocolEDACS,
+		trunking.ProtocolMotorola,
+		trunking.ProtocolDStar,
+		trunking.ProtocolDMRTier1,
+		trunking.ProtocolDMRTier2,
+	} {
+		proto := proto
+		t.Run(proto.String(), func(t *testing.T) {
+			iq, meta, err := Synthesize(SynthOptions{Protocol: proto, Format: FormatF32})
+			if err != nil {
+				t.Fatalf("Synthesize: %v", err)
+			}
+			dir := t.TempDir()
+			path := filepath.Join(dir, proto.String()+".cfile")
+			if err := WriteCapture(path, iq, FormatF32); err != nil {
+				t.Fatalf("WriteCapture: %v", err)
+			}
+
+			idr, err := Identify(path, IdentifyConfig{
+				SampleRateHz: meta.SampleRateHz,
+				Format:       FormatF32,
+			})
+			if err != nil {
+				t.Fatalf("Identify: %v", err)
+			}
+			if idr.Winner != proto.String() {
+				t.Errorf("winner = %q (conf %.2f), want %q\n  candidates: %v",
+					idr.Winner, idr.Confidence, proto.String(), topN(idr, 3))
+			}
+			if idr.Inconclusive {
+				t.Errorf("%s flagged inconclusive (conf %.2f)", proto, idr.Confidence)
+			}
+		})
+	}
+}
+
+// TestIdentifyTETRAByCadence confirms a key-gated protocol (TETRA needs its
+// colour code to lock/CRC, which identify doesn't supply) is still identified
+// from its sync cadence alone.
+func TestIdentifyTETRAByCadence(t *testing.T) {
+	iq, meta, err := Synthesize(SynthOptions{Protocol: trunking.ProtocolTETRA, Format: FormatF32})
+	if err != nil {
+		t.Fatalf("Synthesize: %v", err)
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tetra.cfile")
+	if err := WriteCapture(path, iq, FormatF32); err != nil {
+		t.Fatalf("WriteCapture: %v", err)
+	}
+	idr, err := Identify(path, IdentifyConfig{SampleRateHz: meta.SampleRateHz, Format: FormatF32})
+	if err != nil {
+		t.Fatalf("Identify: %v", err)
+	}
+	if idr.Winner != "tetra" {
+		t.Errorf("winner = %q (conf %.2f), want tetra\n  candidates: %v", idr.Winner, idr.Confidence, topN(idr, 3))
+	}
+}
+
+// TestIdentifyRejectsBadConfig covers the guard rails.
+func TestIdentifyRejectsBadConfig(t *testing.T) {
+	if _, err := Identify("/nonexistent", IdentifyConfig{SampleRateHz: 0}); err == nil {
+		t.Error("expected error for zero sample rate")
+	}
+}
+
+func topN(idr *IdentifyResult, n int) []string {
+	out := []string{}
+	for i, c := range idr.Candidates {
+		if i >= n {
+			break
+		}
+		out = append(out, c.Protocol)
+	}
+	return out
+}

--- a/internal/trunking/site.go
+++ b/internal/trunking/site.go
@@ -27,6 +27,7 @@ const (
 	ProtocolYSF                // System Fusion (C4FM, amateur trunked variant — config "ysf")
 	ProtocolDStar              // D-STAR (GMSK 4800 bps, amateur — header-only repeater protocol; config "dstar")
 	ProtocolDMRTier2           // DMR Tier II conventional (per-repeater; config "dmr-tier2")
+	ProtocolDMRTier1           // DMR Tier I direct-mode (license-free simplex; config "dmr-tier1")
 )
 
 func (p Protocol) String() string {
@@ -57,6 +58,8 @@ func (p Protocol) String() string {
 		return "dstar"
 	case ProtocolDMRTier2:
 		return "dmr-tier2"
+	case ProtocolDMRTier1:
+		return "dmr-tier1"
 	default:
 		return "unknown"
 	}
@@ -93,9 +96,11 @@ func ParseProtocol(s string) (Protocol, error) {
 		return ProtocolDStar, nil
 	case "dmr-tier2", "dmr_tier2", "dmr-t2", "dmrtier2":
 		return ProtocolDMRTier2, nil
+	case "dmr-tier1", "dmr_tier1", "dmr-t1", "dmrtier1":
+		return ProtocolDMRTier1, nil
 	default:
 		return ProtocolUnknown, fmt.Errorf("trunking: unknown protocol %q "+
-			"(want p25|p25-phase2|dmr|dmr-tier2|nxdn|dpmr|edacs|motorola|ltr|mpt1327|tetra|ysf|dstar)", s)
+			"(want p25|p25-phase2|dmr|dmr-tier2|dmr-tier1|nxdn|dpmr|edacs|motorola|ltr|mpt1327|tetra|ysf|dstar)", s)
 	}
 }
 
@@ -375,7 +380,7 @@ func (s System) Validate() error {
 		return errors.New("trunking: system name is required")
 	}
 	if s.Protocol == ProtocolUnknown {
-		return errors.New("trunking: protocol must be p25|p25-phase2|dmr|dmr-tier2|nxdn|dpmr|edacs|motorola|ltr|mpt1327|tetra|ysf|dstar")
+		return errors.New("trunking: protocol must be p25|p25-phase2|dmr|dmr-tier2|dmr-tier1|nxdn|dpmr|edacs|motorola|ltr|mpt1327|tetra|ysf|dstar")
 	}
 	if len(s.ControlChannels) == 0 {
 		return errors.New("trunking: at least one control_channel frequency is required")

--- a/internal/voice/composer/composer.go
+++ b/internal/voice/composer/composer.go
@@ -360,7 +360,7 @@ func (c *Composer) handleStart(parent context.Context, cs trunking.CallStart) {
 	isAnalogTrunk := proto == "motorola" || proto == "ltr" || proto == "mpt1327" ||
 		(proto == "edacs" && !cs.Grant.ProVoice)
 	isFM := proto == "" || proto == "fm" || proto == "analog" || isAnalogTrunk
-	isDMRVoice := proto == "dmr-tier2" || proto == "dmr-tier3"
+	isDMRVoice := proto == "dmr-tier1" || proto == "dmr-tier2" || proto == "dmr-tier3"
 	isP25P2Voice := proto == "p25-phase2"
 	isP25P1Voice := proto == "p25"
 	if !isFM && !isDMRVoice && !isP25P2Voice && !isP25P1Voice {

--- a/internal/voice/recorder.go
+++ b/internal/voice/recorder.go
@@ -109,6 +109,7 @@ func DefaultVocoderForProtocol() map[string]string {
 	return map[string]string{
 		"p25":        "imbe",      // P25 Phase 1 — IMBE 4400
 		"p25-phase2": "ambe2",     // P25 Phase 2 — AMBE+2 3600x2400
+		"dmr-tier1":  "ambe2-dmr", // DMR Tier I direct-mode — AMBE+2 3600x2450
 		"dmr-tier2":  "ambe2-dmr", // DMR Tier II — AMBE+2 3600x2450
 		"dmr-tier3":  "ambe2-dmr", // DMR Tier III — AMBE+2 3600x2450
 		"nxdn":       "ambe2",
@@ -122,7 +123,7 @@ func DefaultVocoderForProtocol() map[string]string {
 // WAV) so the on-air AMBE frames remain available for out-of-band
 // tools even though the in-process vocoder now renders them.
 func dmrVoiceProtocol(protocol string) bool {
-	return protocol == "dmr-tier2" || protocol == "dmr-tier3"
+	return protocol == "dmr-tier1" || protocol == "dmr-tier2" || protocol == "dmr-tier3"
 }
 
 // NewRecorder validates options and returns a recorder ready to Run.

--- a/internal/voice/recorder_test.go
+++ b/internal/voice/recorder_test.go
@@ -729,6 +729,7 @@ func TestDefaultVocoderForProtocolMappings(t *testing.T) {
 	want := map[string]string{
 		"p25":        "imbe",
 		"p25-phase2": "ambe2",
+		"dmr-tier1":  "ambe2-dmr",
 		"dmr-tier2":  "ambe2-dmr",
 		"dmr-tier3":  "ambe2-dmr",
 		"nxdn":       "ambe2",


### PR DESCRIPTION
## Summary

Two additions to the siglab toolkit:

1. **DMR Tier I decoder** — the last deferred protocol (license-free direct-mode, PMR446 simplex).
2. **Signal identifier** — input a capture, auto-detect the protocol, then run the full analysis for it.

## Part A — DMR Tier I

Investigation confirmed Tier I is **wire-identical to Tier II conventional** (same 132-dibit burst, BPTC(196,96) + RS(12,9,4) Voice LC Header, slot-type Hamming) — the only differences are the **direct-mode sync words** (`DM-Voice/Data TS1/TS2`) and the protocol tag. So rather than duplicate ~250 lines, I **parameterized** the Tier II `ConventionalChannel`:

- `tier2.Options` gains `ProtocolTag` (default `dmr-tier2`) and `SyncPatterns` (default = all syncs). Tier I passes `ProtocolTag="dmr-tier1"` + the four ETSI direct-mode syncs, so it tags grants `dmr-tier1` and won't false-lock on base-station traffic.
- Registered `ProtocolDMRTier1` everywhere: trunking enum/`String`/`ParseProtocol`/`Validate`, the ccdecoder factory (`newDMRTier1Pipeline`, DM-sync-restricted), config wideband validation, and the voice recorder/composer DMR-voice maps (`ambe2-dmr`).
- siglab: parameterized the DMR conventional fixture builder by sync word, added a `dmr-tier1` fixture (DM-Voice-TS1) + detail spec.

**Verified:** `dmr-tier1` gen→test locks on DM-Voice-TS1 with 80/80 clean slot-type FEC; a Tier II (BS-sync) capture correctly does **not** lock the Tier I decoder; new unit test (ProtocolTag→grant) + integration test (`TestDaemonCCDecodesDMRTier1`) pass; **14-protocol gen→test sweep green**.

## Part B — Signal identifier

- **engine:** `Config.MaxSamples` caps the read loop so the identifier scans a bounded prefix per candidate.
- **`siglab.Identify`:** runs every registered protocol through the engine over the prefix and scores each on **lock + sync-cadence + FEC evidence**. The scoring is tuned to avoid the cross-protocol false-lock failure mode:
  - sync hits only count at a **genuine frame cadence** (modal spacing ≥ sync length) — degenerate every-few-symbol correlations are discounted;
  - FEC credit counts only **clean / CRC-validated** frames, not "corrected" (a short code like DMR slot-type Hamming "corrects" almost any input);
  - a **recovered grant** and the **DM-vs-BS sync family** break the DMR Tier I/II/III ties;
  - **sync cadence is weighted highest** so a key-gated protocol (TETRA — can't lock/CRC without its colour code) is still identified by its sync alone.
  Low-confidence winners are flagged **Inconclusive** rather than asserted.
- **`identify` subcommand:** ranks candidates, prints the verdict + confidence, then runs and renders the full analysis of the winner (text/json/yaml).

**Verified over the 14 synthesized protocols: 12 identified correctly with zero false positives**; the two without visible sync evidence (MPT 1327's synth fixture omits the CWSC; LTR has no frame-sync word) are honestly flagged inconclusive:

```
p25p1 → p25 (1.00)        dmr → dmr (0.49)         dmr-tier1 → dmr-tier1 (0.75)
dmr-tier2 → dmr-tier2     nxdn → nxdn (0.94)       edacs → edacs (1.00)
motorola → motorola       dstar → dstar (1.00)     p25-phase2 → p25-phase2 (0.81)
tetra → tetra (0.45)      ysf → ysf (0.79)         dpmr → dpmr (0.69)
mpt1327 → INCONCLUSIVE    ltr → INCONCLUSIVE
```

## Verification
- `go test ./...` (full unit suite) ✅; `go test -tags integration … TestDaemonCCDecodes` ✅ (incl. new Tier I).
- New unit tests: Tier I ProtocolTag→grant; identifier over the strong-evidence protocols + TETRA-by-cadence.
- End-to-end: 14-protocol `gen → test` sweep green; `identify` correctly resolves a 72 kHz TETRA grab and 48 kHz captures, then auto-runs the analysis.

## Out of scope / known limits
- DMR Tier III vs Tier II is indistinguishable from a short slot-type-only broadcast capture (both are DMR); resolved by grant presence where available.
- MPT 1327 / LTR identification is limited by absent sync evidence (fixture / protocol), and is flagged inconclusive rather than guessed.
- IQ sample-format (u8 vs f32) stays a required flag — raw captures carry no header.

https://claude.ai/code/session_01P8Es75yBSfmW7xe2FErfuM

---
_Generated by [Claude Code](https://claude.ai/code/session_01P8Es75yBSfmW7xe2FErfuM)_