### PR TITLE
sdr: add Blog V4 detection diagnostics + manual override (issue #264)

### DIFF
--- a/cmd/gophertrunk/config_template.go
+++ b/cmd/gophertrunk/config_template.go
@@ -273,6 +273,7 @@ sdr:
   #     ppm: 0                 # 0 is fine for TCXO-equipped units (NESDR Smart v5)
   #     gain: "auto"           # "auto" or tenths-of-dB ("496" = 49.6 dB)
   #     bias_tee: false
+  #     blog_v4: false         # force RTL-SDR Blog V4 mode if auto-detect misses it (issue #264)
 {{- end}}
 
 trunking:

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -617,10 +617,12 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 		var hints []sdr.Hint
 		for _, dev := range cfg.SDR.Devices {
 			h := sdr.Hint{
-				Serial:  dev.Serial,
-				Role:    sdr.ParseRole(dev.Role),
-				PPM:     dev.PPM,
-				BiasTee: dev.BiasTee,
+				Serial:          dev.Serial,
+				Role:            sdr.ParseRole(dev.Role),
+				PPM:             dev.PPM,
+				BiasTee:         dev.BiasTee,
+				ForceBlogV4:     dev.BlogV4,
+				ForceBlogV4Lite: dev.BlogV4Lite,
 			}
 			if dev.Gain != "" {
 				gain, ok := parseGain(dev.Gain)

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -142,6 +142,10 @@ sdr:
                            # OP25/gqrx users: multiply your dB figure by 10
                            # (32 dB → "320"). "auto" (AGC) is the safe default.
       bias_tee: false      # enable the 5V bias-tee output for an external LNA
+      # blog_v4: true      # force RTL-SDR Blog V4 mode (28.8 MHz xtal + input
+                           # routing) if the V4's USB strings don't auto-identify
+                           # it and every frequency mistunes by ~1.8× (issue #264).
+                           # Add `blog_v4_lite: true` instead on a V4L.
     - serial: "00000002"
       role: voice
       ppm: 0

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -607,6 +607,17 @@ type DeviceConfig struct {
 	// either way.
 	BiasTee bool `yaml:"bias_tee"`
 
+	// BlogV4 forces RTL-SDR Blog V4 mode (28.8 MHz reference crystal +
+	// per-band HF/VHF/UHF input routing) regardless of the dongle's USB
+	// iManufacturer/iProduct strings. Use it when a V4's EEPROM strings
+	// are blank or non-standard so auto-detection misses it and the
+	// R828D mistunes every frequency by ~1.8× (issue #264). Off by
+	// default; leave false for any non-V4 dongle. BlogV4Lite selects the
+	// two-band "Lite" variant — set it only on a V4L. When set, the
+	// config value wins over auto-detection (it is applied after open).
+	BlogV4     bool `yaml:"blog_v4"`
+	BlogV4Lite bool `yaml:"blog_v4_lite"`
+
 	// CenterFreqHz pins a `role: wideband` dongle to the centre of
 	// the IQ band it should cover. Every Channels[].FrequencyHz must
 	// fall within ±sample_rate/2 of this value, with a 5 % guard.

--- a/internal/sdr/device.go
+++ b/internal/sdr/device.go
@@ -75,6 +75,25 @@ type Device interface {
 	Close() error
 }
 
+// TunerDiagnoser is an optional Device extension that surfaces tuner
+// detection state for boot-time diagnostics. Callers type-assert for it
+// (like ActualSampleRate / SettleAfterRetune) so backends that don't
+// model a tuner crystal need not implement it. xtalHz of 16 MHz on an
+// R828D is the signature that RTL-SDR Blog V4 auto-detection missed and
+// the LO is mistuned by ~1.8× (issue #264).
+type TunerDiagnoser interface {
+	TunerDiag() (tunerName string, blogV4, blogV4Lite bool, xtalHz uint32)
+}
+
+// BlogV4Forcer is an optional Device extension that forces RTL-SDR Blog
+// V4 mode (28.8 MHz reference crystal + switched HF/VHF/UHF input bank)
+// regardless of USB-string auto-detection. Callers type-assert for it.
+// Used when a V4's EEPROM strings are blank/non-standard so the R828D
+// otherwise stays on the 16 MHz crystal and mistunes (issue #264).
+type BlogV4Forcer interface {
+	SetBlogV4(lite bool) error
+}
+
 // Driver is the factory each backend exposes.
 type Driver interface {
 	Name() string

--- a/internal/sdr/pool.go
+++ b/internal/sdr/pool.go
@@ -91,6 +91,12 @@ type Hint struct {
 	PPM     int
 	Gain    int // tenths of dB; negative = auto
 	BiasTee bool
+	// ForceBlogV4 forces RTL-SDR Blog V4 mode (28.8 MHz crystal +
+	// HF/VHF/UHF input routing) on a device whose USB strings don't
+	// auto-identify it as a V4, so the R828D stops mistuning by ~1.8×
+	// (issue #264). ForceBlogV4Lite selects the two-band Lite variant.
+	ForceBlogV4     bool
+	ForceBlogV4Lite bool
 	// gainSet distinguishes "Gain not configured" (apply auto) from
 	// the explicit "auto" choice. The daemon sets this when it parses
 	// the YAML; tests that don't care can leave Hint zero-valued and
@@ -274,6 +280,7 @@ func (p *Pool) OpenWith(opts PoolOpenOptions) error {
 			"rate_hz", rate,
 			"ppm", hint.PPM,
 			"bias_tee", hint.BiasTee)
+		p.logTunerDiag(dev, d.info)
 		p.publish(events.KindSDRAttached, entry.Snapshot(true))
 	}
 	for serial := range hintBySerial {
@@ -350,6 +357,24 @@ func (p *Pool) FindBySerial(serial string) *PoolEntry {
 // applyHintSettings runs the per-device tuners after Open. Caller
 // holds p.mu.
 func (p *Pool) applyHintSettings(dev Device, info Info, h Hint) {
+	// Force RTL-SDR Blog V4 mode first: it swaps the reference crystal
+	// that the PPM correction below biases, and it must land before any
+	// SetCenterFreq (the pool tunes later, when decoders bind). Idempotent
+	// with the driver's USB-string auto-detect — config wins, since it
+	// runs after open (issue #264).
+	if h.ForceBlogV4 {
+		if bf, ok := dev.(BlogV4Forcer); ok {
+			if err := bf.SetBlogV4(h.ForceBlogV4Lite); err != nil {
+				p.log.Warn("force blog_v4 failed", "serial", info.Serial, "err", err)
+			} else {
+				p.log.Info("sdr: forced RTL-SDR Blog V4 mode from config",
+					"serial", info.Serial, "lite", h.ForceBlogV4Lite)
+			}
+		} else {
+			p.log.Warn("blog_v4 override set but this driver does not support it; ignoring",
+				"serial", info.Serial)
+		}
+	}
 	if h.PPM != 0 {
 		if err := dev.SetPPM(h.PPM); err != nil {
 			p.log.Warn("set ppm failed", "serial", info.Serial, "ppm", h.PPM, "err", err)
@@ -390,6 +415,29 @@ func (p *Pool) applyHintSettings(dev Device, info Info, h Hint) {
 			p.log.Warn("set bias_tee failed", "serial", info.Serial, "err", err)
 		}
 	}
+}
+
+// logTunerDiag emits a per-device tuner-detection line when the driver
+// supports the optional TunerDiagnoser extension. The point is to make
+// the issue #264 failure self-diagnosing: ref_xtal_hz=16000000 on an
+// R828D means RTL-SDR Blog V4 auto-detection missed (so the LO mistunes
+// ~1.8×), while 28800000 means the V4 path armed. Manufacturer/Product
+// are echoed so a blank/non-standard EEPROM string — the reason auto-
+// detect misses — is visible in the same line.
+func (p *Pool) logTunerDiag(dev Device, info Info) {
+	td, ok := dev.(TunerDiagnoser)
+	if !ok {
+		return
+	}
+	name, v4, v4lite, xtal := td.TunerDiag()
+	p.log.Info("sdr tuner detected",
+		"serial", info.Serial,
+		"manufacturer", info.Manufacturer,
+		"product", info.Product,
+		"tuner", name,
+		"blog_v4", v4,
+		"blog_v4_lite", v4lite,
+		"ref_xtal_hz", xtal)
 }
 
 // publish is a non-blocking helper that fans an event to the optional
@@ -513,6 +561,7 @@ func (p *Pool) Reacquire(serial string, sampleRateHz uint32) (*PoolEntry, error)
 	// only logs failures — it is non-fatal in the original Open path and
 	// stays non-fatal here for the same reason.
 	p.applyHintSettings(dev, freshInfo, hint)
+	p.logTunerDiag(dev, freshInfo)
 
 	// Carry forward identity-stable Info fields (Serial, Driver,
 	// Manufacturer/Product/TunerName, Gains list) but accept the

--- a/internal/sdr/pool_settings_test.go
+++ b/internal/sdr/pool_settings_test.go
@@ -41,6 +41,64 @@ func TestPoolAppliesHintSettings(t *testing.T) {
 	}
 }
 
+// TestPoolForcesBlogV4FromHint pins the issue #264 override: a device
+// whose USB strings don't auto-identify it as a V4 still gets SetBlogV4
+// driven from config (ForceBlogV4), with the Lite flag propagated.
+func TestPoolForcesBlogV4FromHint(t *testing.T) {
+	drv := &fakeDriver{name: "fake-v4", infos: []Info{
+		{Driver: "fake-v4", Index: 0, Serial: "V4"},
+	}}
+	registryMu.Lock()
+	registry["fake-v4"] = drv
+	registryMu.Unlock()
+	t.Cleanup(func() {
+		registryMu.Lock()
+		delete(registry, "fake-v4")
+		registryMu.Unlock()
+	})
+
+	p := NewPool(nil)
+	if err := p.Open(0, []Hint{{Serial: "V4", ForceBlogV4: true, ForceBlogV4Lite: true}}); err != nil {
+		t.Fatal(err)
+	}
+	defer p.Close()
+
+	dev := p.Entries()[0].Device.(*fakeDevice)
+	if dev.blogV4Sets != 1 {
+		t.Errorf("SetBlogV4 invocations = %d, want 1", dev.blogV4Sets)
+	}
+	if !dev.blogV4Lite {
+		t.Errorf("blogV4Lite = false, want true (ForceBlogV4Lite not propagated)")
+	}
+}
+
+// TestPoolSkipsBlogV4WhenHintFalse confirms the override is opt-in: no
+// ForceBlogV4 means SetBlogV4 is never called, so non-V4 dongles and
+// auto-detected V4s are untouched by config.
+func TestPoolSkipsBlogV4WhenHintFalse(t *testing.T) {
+	drv := &fakeDriver{name: "fake-no-v4", infos: []Info{
+		{Driver: "fake-no-v4", Index: 0, Serial: "S3"},
+	}}
+	registryMu.Lock()
+	registry["fake-no-v4"] = drv
+	registryMu.Unlock()
+	t.Cleanup(func() {
+		registryMu.Lock()
+		delete(registry, "fake-no-v4")
+		registryMu.Unlock()
+	})
+
+	p := NewPool(nil)
+	if err := p.Open(0, []Hint{{Serial: "S3"}}); err != nil {
+		t.Fatal(err)
+	}
+	defer p.Close()
+	dev := p.Entries()[0].Device.(*fakeDevice)
+	if dev.blogV4Sets != 0 {
+		t.Errorf("SetBlogV4 called %d times when blog_v4 was false", dev.blogV4Sets)
+	}
+}
+
 func TestPoolSkipsBiasTeeWhenHintFalse(t *testing.T) {
 	drv := &fakeDriver{name: "fake-no-bias", infos: []Info{
 		{Driver: "fake-no-bias", Index: 0, Serial: "S2"},

--- a/internal/sdr/pool_test.go
+++ b/internal/sdr/pool_test.go
@@ -28,6 +28,8 @@ type fakeDevice struct {
 	rateErr     error
 	ppm         int
 	ppmSets     int
+	blogV4Sets  int
+	blogV4Lite  bool
 }
 
 func (d *fakeDevice) Info() Info                 { return d.info }
@@ -42,6 +44,7 @@ func (d *fakeDevice) SetSampleRate(hz uint32) error {
 func (d *fakeDevice) SetGain(int) error                                    { return nil }
 func (d *fakeDevice) SetPPM(ppm int) error                                 { d.ppm = ppm; d.ppmSets++; return nil }
 func (d *fakeDevice) SetBiasTee(on bool) error                             { d.biasTeeOn = on; d.biasTeeSets++; return nil }
+func (d *fakeDevice) SetBlogV4(lite bool) error                            { d.blogV4Sets++; d.blogV4Lite = lite; return nil }
 func (d *fakeDevice) StreamIQ(context.Context) (<-chan []complex64, error) { return nil, io.EOF }
 func (d *fakeDevice) Close() error {
 	if d.closed {

--- a/internal/sdr/rtlsdr/purego/device.go
+++ b/internal/sdr/rtlsdr/purego/device.go
@@ -184,6 +184,36 @@ func (d *Device) SetBiasTee(enable bool) error {
 	return nil
 }
 
+// SetBlogV4 forces the R82xx tuner into RTL-SDR Blog V4 mode (28.8 MHz
+// reference crystal + switched input bank) when USB-string auto-detection
+// misses a V4 — e.g. a unit whose EEPROM iManufacturer/iProduct strings
+// are blank or non-standard, which otherwise leaves the R828D on the
+// 16 MHz crystal and mistunes the LO by ~1.8× (issue #264). No-op on
+// non-R82xx tuners. Must run before the first SetCenterFreq; the pool
+// applies it from applyHintSettings, which runs before any tune.
+// Implements sdr.BlogV4Forcer.
+func (d *Device) SetBlogV4(lite bool) error {
+	if d.closed.Load() {
+		return ErrClosed
+	}
+	if r82, ok := d.tuner.(*tuners.R82xx); ok {
+		r82.SetBlogV4(lite)
+	}
+	return nil
+}
+
+// TunerDiag surfaces tuner detection state for the pool's boot-time
+// diagnostic line (issue #264). For the R82xx family it reports the
+// effective reference crystal and whether the Blog V4 path armed; other
+// tuners report just the chip name. Implements sdr.TunerDiagnoser.
+func (d *Device) TunerDiag() (tunerName string, blogV4, blogV4Lite bool, xtalHz uint32) {
+	if r82, ok := d.tuner.(*tuners.R82xx); ok {
+		v4, lite := r82.IsBlogV4()
+		return r82.Type().String(), v4, lite, r82.XtalHz()
+	}
+	return d.tuner.Type().String(), false, false, 0
+}
+
 // Close releases the tuner, powers off the demod, and closes the USB
 // transport. Idempotent; safe to call from any goroutine.
 func (d *Device) Close() error {
@@ -226,5 +256,10 @@ func (d *Device) cancelStream() {
 // StreamIQ is implemented in stream.go (kept separate so the IQ
 // conversion math sits next to its unit test).
 //
-// Compile-time assertion that Device satisfies sdr.Device.
-var _ sdr.Device = (*Device)(nil)
+// Compile-time assertion that Device satisfies sdr.Device and the
+// optional tuner-diagnostic / Blog-V4-force extensions (issue #264).
+var (
+	_ sdr.Device         = (*Device)(nil)
+	_ sdr.TunerDiagnoser = (*Device)(nil)
+	_ sdr.BlogV4Forcer   = (*Device)(nil)
+)

--- a/internal/sdr/rtlsdr/purego/device_blogv4_test.go
+++ b/internal/sdr/rtlsdr/purego/device_blogv4_test.go
@@ -1,0 +1,90 @@
+package purego
+
+import (
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/sdr"
+	"github.com/MattCheramie/GopherTrunk/internal/sdr/rtlsdr/rtl2832u"
+	"github.com/MattCheramie/GopherTrunk/internal/sdr/rtlsdr/tuners"
+	"github.com/MattCheramie/GopherTrunk/internal/sdr/rtlsdr/usb"
+)
+
+// newDeviceWithR828D builds a Device whose tuner is a real R82xx bound to
+// an R828D. The tuner does no USB I/O for the methods under test
+// (SetBlogV4 / TunerDiag only touch in-memory state), so the mock
+// transport is never exercised.
+func newDeviceWithR828D(t *testing.T) *Device {
+	t.Helper()
+	mock := usb.NewMockTransport()
+	demod := rtl2832u.New(mock)
+	r82 := tuners.NewR82xx(demod, 0x74, tuners.TypeR828D)
+	return &Device{
+		transport: mock,
+		demod:     demod,
+		tuner:     r82,
+		info:      sdr.Info{Driver: DriverName, Index: 0, Serial: "V4-TEST"},
+	}
+}
+
+// TestDeviceSetBlogV4FlipsCrystal is the issue #264 regression at the
+// Device layer: forcing Blog V4 mode must swap the R828D's reference
+// crystal from the generic 16 MHz default to 28.8 MHz, which is what
+// stops the LO mistuning by ~1.8×.
+func TestDeviceSetBlogV4FlipsCrystal(t *testing.T) {
+	d := newDeviceWithR828D(t)
+
+	// Before: an undetected R828D sits on the 16 MHz generic crystal —
+	// the mistune signature.
+	name, v4, lite, xtal := d.TunerDiag()
+	if name != "R828D" || v4 || lite || xtal != 16_000_000 {
+		t.Fatalf("pre-force TunerDiag = (%q, %v, %v, %d), want (\"R828D\", false, false, 16000000)",
+			name, v4, lite, xtal)
+	}
+
+	if err := d.SetBlogV4(false); err != nil {
+		t.Fatalf("SetBlogV4: %v", err)
+	}
+
+	// After: 28.8 MHz crystal and the V4 path armed.
+	name, v4, lite, xtal = d.TunerDiag()
+	if name != "R828D" || !v4 || lite || xtal != 28_800_000 {
+		t.Fatalf("post-force TunerDiag = (%q, %v, %v, %d), want (\"R828D\", true, false, 28800000)",
+			name, v4, lite, xtal)
+	}
+}
+
+// TestDeviceSetBlogV4Lite confirms the Lite flag reaches the tuner.
+func TestDeviceSetBlogV4Lite(t *testing.T) {
+	d := newDeviceWithR828D(t)
+	if err := d.SetBlogV4(true); err != nil {
+		t.Fatalf("SetBlogV4: %v", err)
+	}
+	if _, v4, lite, _ := d.TunerDiag(); !v4 || !lite {
+		t.Fatalf("after SetBlogV4(true): v4=%v lite=%v, want both true", v4, lite)
+	}
+}
+
+// TestDeviceSetBlogV4NonR82xxNoop verifies the force is a safe no-op on a
+// tuner that isn't an R82xx (so the optional interface can be wired
+// unconditionally in the pool without guarding on chip type).
+func TestDeviceSetBlogV4NonR82xxNoop(t *testing.T) {
+	d := newDeviceWithFakeTuner(usb.NewMockTransport(), &fakeTuner{})
+	if err := d.SetBlogV4(false); err != nil {
+		t.Fatalf("SetBlogV4 on non-R82xx tuner: %v", err)
+	}
+	// TunerDiag falls back to the chip name with no crystal info.
+	name, v4, lite, xtal := d.TunerDiag()
+	if v4 || lite || xtal != 0 {
+		t.Fatalf("non-R82xx TunerDiag = (%q, %v, %v, %d), want (..., false, false, 0)",
+			name, v4, lite, xtal)
+	}
+}
+
+// TestDeviceSetBlogV4Closed guards the closed path.
+func TestDeviceSetBlogV4Closed(t *testing.T) {
+	d := newDeviceWithR828D(t)
+	d.closed.Store(true)
+	if err := d.SetBlogV4(false); err != ErrClosed {
+		t.Fatalf("SetBlogV4 on closed device = %v, want ErrClosed", err)
+	}
+}

--- a/internal/sdr/rtlsdr/tuners/r82xx.go
+++ b/internal/sdr/rtlsdr/tuners/r82xx.go
@@ -148,6 +148,18 @@ func (r *R82xx) effectiveXtalHz() uint32 {
 // Type returns the detected chip family.
 func (r *R82xx) Type() Type { return r.chipType }
 
+// XtalHz returns the reference-crystal frequency currently in effect
+// (before any ppm correction). It exists for boot-time diagnostics:
+// 16 MHz on an R828D means the RTL-SDR Blog V4 path did NOT arm, so the
+// LO mistunes by ~28.8/16 = 1.8× (issue #264); 28.8 MHz means SetBlogV4
+// ran. See [R82xx.IsBlogV4].
+func (r *R82xx) XtalHz() uint32 { return r.xtalHz }
+
+// IsBlogV4 reports whether the RTL-SDR Blog V4 path is armed and, if so,
+// whether it's the two-band "Lite" variant. Surfaced for the pool's
+// per-device "sdr tuner detected" diagnostic line (issue #264).
+func (r *R82xx) IsBlogV4() (enabled, lite bool) { return r.blogV4, r.blogV4L }
+
 // IFFreqHz returns the 3.57 MHz intermediate frequency the R820T
 // emits.
 func (r *R82xx) IFFreqHz() uint32 { return r82xxIFFreqHz }


### PR DESCRIPTION
The RTL-SDR Blog V4 (R828D) reporter's latest captures showed the V4
receiving no signal where a NooElec on the same antenna cleanly decodes
DMR. Analysis: the wanted carrier is entirely absent (at the noise
floor), not merely attenuated, so the V4's LO is mistuned — the
signature of the R828D still running on the 16 MHz generic crystal
instead of 28.8 MHz, i.e. SetBlogV4 never fired because USB-string
auto-detection missed the unit.

This makes that failure observable and recoverable without code churn:

- Diagnostic log line "sdr tuner detected" at device open (and on
  watchdog reacquire) reporting the USB manufacturer/product strings,
  tuner chip, blog_v4 state, and effective reference crystal. ref_xtal_hz
  of 16 MHz on an R828D = auto-detect missed; 28.8 MHz = V4 path armed.
- Per-device `blog_v4` / `blog_v4_lite` config keys that force V4 mode
  regardless of EEPROM strings, plumbed config -> Hint -> pool ->
  Device.SetBlogV4. Applied at the top of applyHintSettings (before PPM
  and before any tune), idempotent with auto-detection.
- New optional sdr.Device extensions TunerDiagnoser and BlogV4Forcer,
  implemented by the purego rtlsdr Device; R82xx gains XtalHz()/IsBlogV4()
  accessors.

Tests: pool-level force + skip, Device-level crystal flip / Lite / no-op
on non-R82xx / closed guard. Existing V4 crystal + PLL-mistune + variant
tests still pass.

https://claude.ai/code/session_01QjyDFjh66L39knVKMzWZFj