### PR TITLE
p25/cqpsk: gate the carrier seed on multipath; un-skip the #492 repro

### DIFF
--- a/cmd/gophertrunk/gen.go
+++ b/cmd/gophertrunk/gen.go
@@ -3,6 +3,8 @@ package main
 import (
 	"flag"
 	"fmt"
+	"math"
+	"strconv"
 	"strings"
 
 	"github.com/MattCheramie/GopherTrunk/internal/dsp/demod"
@@ -20,12 +22,15 @@ func runGen(args []string) {
 	fs := flag.NewFlagSet("gen", flag.ExitOnError)
 	verboseFlag := fs.Bool("verbose-errors", false, "print full error chain + stack on failures")
 	protocolFlag := fs.String("protocol", "", "protocol to synthesize (required; see -list)")
+	modulation := fs.String("modulation", "", "override the fixture modulator (P25: \"c4fm\" default, or \"lsm\"/\"cqpsk\" for the linear waveform)")
 	list := fs.Bool("list", false, "list the protocols with a synthesis fixture and exit")
 	out := fs.String("out", "", "output capture path (required)")
 	format := fs.String("format", "f32", "capture sample format: u8 | f32")
 	metaOut := fs.String("meta", "", "metadata sidecar path (default: <out stem>.metadata.json)")
 	snr := fs.Float64("snr", 0, "additive white Gaussian noise target SNR in dB (0 = clean)")
 	freqOffset := fs.Float64("freq-offset", 0, "residual carrier frequency offset in Hz")
+	freqDrift := fs.Float64("drift", 0, "linear carrier-frequency drift in Hz per second (added to -freq-offset)")
+	multipath := fs.String("multipath", "", "multipath/simulcast channel: preset \"simulcast\" or comma-separated taps \"delay:mag:deg\" (e.g. \"0:1:0,5:0.95:70\")")
 	dc := fs.Float64("dc", 0, "DC-offset magnitude relative to unit-scale output (0.1 ≈ -20 dBFS)")
 	gainImb := fs.Float64("iq-gain", 0, "I/Q gain imbalance (Q gain relative to I; 0 = none)")
 	phaseSkew := fs.Float64("iq-phase", 0, "I/Q quadrature phase skew in radians (0 = none)")
@@ -77,17 +82,25 @@ FLAGS:`)
 	if err != nil {
 		rep.Fatal(2, err)
 	}
+	mpTaps, err := parseMultipath(*multipath)
+	if err != nil {
+		fs.Usage()
+		rep.Fatal(2, err)
+	}
 
 	iq, meta, err := siglab.Synthesize(siglab.SynthOptions{
-		Protocol: proto,
-		Format:   sampleFormat,
+		Protocol:   proto,
+		Format:     sampleFormat,
+		Modulation: *modulation,
 		Impairments: demod.Impairments{
-			SNRdB:           *snr,
-			FreqOffsetHz:    *freqOffset,
-			DCOffset:        complex(float32(*dc), 0),
-			IQGainImbalance: *gainImb,
-			IQPhaseSkewRad:  *phaseSkew,
-			Seed:            *seed,
+			Multipath:         mpTaps,
+			SNRdB:             *snr,
+			FreqOffsetHz:      *freqOffset,
+			FreqDriftHzPerSec: *freqDrift,
+			DCOffset:          complex(float32(*dc), 0),
+			IQGainImbalance:   *gainImb,
+			IQPhaseSkewRad:    *phaseSkew,
+			Seed:              *seed,
 		},
 	})
 	if err != nil {
@@ -105,6 +118,57 @@ FLAGS:`)
 		rep.Fatal(1, fmt.Errorf("write metadata: %w", err))
 	}
 	fmt.Printf("gen: wrote %d samples → %s  (metadata → %s)\n", len(iq), *out, metaPath)
+}
+
+// parseMultipath builds a complex channel FIR from the -multipath flag. An
+// empty string is no multipath. The preset "simulcast" is the near-spectral-
+// null two-path channel issue #492 reproduces with (main path + a half-symbol
+// 0.95∠70° echo at 48 kHz / 10 sps). Otherwise the value is comma-separated
+// taps "delay:mag:deg" (delay in samples, magnitude, phase in degrees); the
+// returned FIR is sized to the largest delay with the named taps filled in.
+func parseMultipath(s string) ([]complex64, error) {
+	s = strings.TrimSpace(s)
+	switch s {
+	case "":
+		return nil, nil
+	case "simulcast":
+		echo := complex(float32(0.95*math.Cos(70*math.Pi/180)), float32(0.95*math.Sin(70*math.Pi/180)))
+		return []complex64{complex(1, 0), 0, 0, 0, 0, echo}, nil
+	}
+	type tap struct {
+		delay int
+		val   complex64
+	}
+	var taps []tap
+	maxDelay := 0
+	for _, field := range strings.Split(s, ",") {
+		parts := strings.Split(strings.TrimSpace(field), ":")
+		if len(parts) != 3 {
+			return nil, fmt.Errorf("multipath tap %q: want delay:mag:deg", field)
+		}
+		delay, err := strconv.Atoi(strings.TrimSpace(parts[0]))
+		if err != nil || delay < 0 {
+			return nil, fmt.Errorf("multipath tap %q: bad delay", field)
+		}
+		mag, err := strconv.ParseFloat(strings.TrimSpace(parts[1]), 64)
+		if err != nil {
+			return nil, fmt.Errorf("multipath tap %q: bad magnitude", field)
+		}
+		deg, err := strconv.ParseFloat(strings.TrimSpace(parts[2]), 64)
+		if err != nil {
+			return nil, fmt.Errorf("multipath tap %q: bad phase", field)
+		}
+		rad := deg * math.Pi / 180
+		taps = append(taps, tap{delay: delay, val: complex(float32(mag*math.Cos(rad)), float32(mag*math.Sin(rad)))})
+		if delay > maxDelay {
+			maxDelay = delay
+		}
+	}
+	fir := make([]complex64, maxDelay+1)
+	for _, t := range taps {
+		fir[t.delay] = t.val
+	}
+	return fir, nil
 }
 
 // ext returns the file extension including the dot, or "" if none.

--- a/internal/dsp/demod/impair.go
+++ b/internal/dsp/demod/impair.go
@@ -30,6 +30,12 @@ type Impairments struct {
 	// crystal ppm error, or a channel that is not exactly centred in
 	// the SDR passband. Applied as a per-sample phase ramp.
 	FreqOffsetHz float64
+	// FreqDriftHzPerSec is a linear carrier-frequency drift in Hz per
+	// second, added on top of FreqOffsetHz: the instantaneous offset is
+	// FreqOffsetHz + FreqDriftHzPerSec·t. It models a tuner whose LO
+	// wanders as it warms up — the slow drift a fixed coarse seed cannot
+	// track and a fine carrier loop must follow (issue #492). Zero = none.
+	FreqDriftHzPerSec float64
 	// DCOffset is a constant complex term added to every sample: the
 	// R820T2 / E4000 "DC spike". Magnitude is relative to the
 	// unit-scale modulator output (0.1 ≈ -20 dBFS).
@@ -110,11 +116,14 @@ func ApplyImpairments(iq []complex64, sampleRateHz float64, imp Impairments) []c
 		}
 	}
 
-	// Carrier frequency offset: a per-sample phase ramp.
-	if imp.FreqOffsetHz != 0 && sampleRateHz > 0 {
-		w := 2 * math.Pi * imp.FreqOffsetHz / sampleRateHz
+	// Carrier frequency offset (+ optional linear drift). A constant offset
+	// is a per-sample phase ramp; a drift d (Hz/s) makes the instantaneous
+	// frequency FreqOffsetHz + d·t, whose integral adds a quadratic phase
+	// term ½·(2π·d)·t² (t = i/sampleRateHz).
+	if (imp.FreqOffsetHz != 0 || imp.FreqDriftHzPerSec != 0) && sampleRateHz > 0 {
 		for i := range out {
-			ph := w * float64(i)
+			t := float64(i) / sampleRateHz
+			ph := 2 * math.Pi * (imp.FreqOffsetHz*t + 0.5*imp.FreqDriftHzPerSec*t*t)
 			out[i] *= complex(float32(math.Cos(ph)), float32(math.Sin(ph)))
 		}
 	}

--- a/internal/dsp/sync/costas.go
+++ b/internal/dsp/sync/costas.go
@@ -32,9 +32,19 @@ type QPSKCostas struct {
 	freq    float64 // integrator state: estimated offset, rad/symbol
 	phase   float64 // running de-rotation phase, rad
 	maxFreq float64 // clamp on |freq| (rad/symbol) — keeps a noisy start bounded
+	rail    int     // consecutive symbols pinned at ±maxFreq pushing further in
 	prev    complex64
 	have    bool
 }
+
+// costasRailReacquire is how many consecutive symbols the integrator may sit
+// pinned at its ±maxFreq clamp — with the error still driving it further into
+// the rail — before the loop gives up that estimate and re-acquires from zero.
+// A coarse carrier mis-seed (e.g. a multipath-biased estimate, issue #492) can
+// otherwise drive the integrator into the clamp and hold it there, stuck, so
+// the FSW never correlates. Genuine acquisition settles in tens of symbols,
+// well under this, so a converging loop is never disturbed.
+const costasRailReacquire = 256
 
 // NewQPSKCostas builds a loop tuned to loopBWHz (the loop's noise
 // bandwidth) at the given symbol rate, with the supplied damping
@@ -94,6 +104,19 @@ func (c *QPSKCostas) Update(y complex64) complex64 {
 		} else if c.freq < -c.maxFreq {
 			c.freq = -c.maxFreq
 		}
+		// Anti-windup / re-acquire: if the integrator stays pinned at the clamp
+		// with the error still pushing it further in, the estimate is wrong, not
+		// merely large — collapse it back toward zero so the loop re-acquires
+		// instead of staying railed for the whole capture (issue #492).
+		if (c.freq == c.maxFreq && e > 0) || (c.freq == -c.maxFreq && e < 0) {
+			c.rail++
+			if c.rail >= costasRailReacquire {
+				c.freq = 0
+				c.rail = 0
+			}
+		} else {
+			c.rail = 0
+		}
 		c.phase += c.freq + c.kp*e
 	} else {
 		c.phase += c.freq
@@ -113,6 +136,7 @@ func (c *QPSKCostas) OffsetHz() float64 { return c.freq * c.baud / (2 * math.Pi)
 func (c *QPSKCostas) Reset() {
 	c.freq = 0
 	c.phase = 0
+	c.rail = 0
 	c.prev = 0
 	c.have = false
 }

--- a/internal/radio/p25/phase1/receiver/cqpsk.go
+++ b/internal/radio/p25/phase1/receiver/cqpsk.go
@@ -76,52 +76,151 @@ const (
 // cqpskSeedClampHz bounds the one-shot coarse seed; a residual that needs
 // more than this is an un-channelised / mis-tuned stream the upstream DDC
 // + PPM correction should have handled (the channel would not even fit the
-// 48 kHz passband otherwise). cqpskSeedMinSamples is the matched-filter
-// sample count the coarse estimate needs to be usable. cqpskCostasLoopBWHz
-// / cqpskCostasDamping tune the fine tracking loop: ~2.5% of baud gives a
-// few-hundred-symbol acquisition, well inside the control-channel warmup.
+// 48 kHz passband otherwise). cqpskSeedMinSamples is the sample count the
+// coarse estimate needs to be usable. cqpskCostasLoopBWHz / cqpskCostasDamping
+// tune the fine tracking loop: ~2.5% of baud gives a few-hundred-symbol
+// acquisition, well inside the control-channel warmup.
+//
+// cqpskSeedMaxLag / cqpskSeedMinCoherence / cqpskSeedMaxModulusCV gate the
+// coarse estimate (issue #492). The bare lag-1 (Kay) estimate reads a
+// multipath / simulcast channel's autocorrelation phase as a spurious carrier
+// offset (~650–750 Hz on the reported captures) because a deep simulcast null
+// shifts the spectral centroid — a bias an autocorrelation estimator cannot
+// tell from a real offset. robustSeedHz therefore (a) sharpens the estimate
+// with a short multi-lag phase-ramp fit and (b) *gates* it: de-rotate by the
+// estimate, run the matched filter, and measure the coefficient of variation
+// of the symbol modulus. A pure carrier offset only rotates the constant-
+// modulus π/4-DQPSK symbols (low CV); multipath ISI blurs the modulus (high
+// CV). When the CV is high the offset is multipath bias, not a carrier offset,
+// so the estimate is rejected and the NCO left identity — the CMA→Costas loop
+// then acquires the (necessarily in-range) true offset on its own.
 const (
-	cqpskSeedClampHz    = 6000.0
-	cqpskSeedMinSamples = 2048
-	cqpskCostasLoopBWHz = 120.0
-	cqpskCostasDamping  = 0.707
+	cqpskSeedClampHz      = 6000.0
+	cqpskSeedMinSamples   = 2048
+	cqpskSeedMaxLag       = 4
+	cqpskSeedMinCoherence = 0.30
+	cqpskSeedMaxModulusCV = 0.24
+	cqpskCostasLoopBWHz   = 120.0
+	cqpskCostasDamping    = 0.707
 )
 
-// seedCarrierOffsetHz returns a coarse estimate of the residual carrier
-// offset (Hz) of an oversampled complex stream, via the lag-1
-// autocorrelation (Kay) frequency estimator: the angle of Σ x[n]·conj(x[n−1])
-// is the mean per-sample phase increment, which for a suppressed-carrier
-// symmetric modulation is the carrier rotation (the data's phase changes
-// are symmetric and average out). Unlike peak-picking the PSD, this is
-// unbiased on the flat-topped RRC spectrum of an already-channelised
-// signal, and unambiguous to ±Fs/2 rather than ±baud/8.
-func seedCarrierOffsetHz(x []complex64, fs float64) float64 {
-	if len(x) < 2 || fs <= 0 {
-		return 0
+// robustSeedHz estimates the residual carrier offset (Hz) of an oversampled
+// complex stream and reports whether the estimate is trustworthy. A pure
+// carrier offset Δf rotates the stream by a constant kΔω at autocorrelation
+// lag k, so angle(R_k) = k·Δω is linear in k; fitting a least-squares slope
+// through lags 1..cqpskSeedMaxLag is a lower-variance estimate than the
+// single-lag (Kay) angle. The estimate is then validated against the failure
+// mode behind issue #492 (modulusCV): a multipath / simulcast channel shifts
+// the spectral centroid so the angle reads as a spurious offset, but de-
+// rotating by it and matched-filtering leaves the symbol modulus blurred by
+// ISI, which a clean offset never does. Weak lag-1 coherence (noise) or a
+// high modulus CV (multipath) marks the seed untrustworthy; the caller then
+// leaves the NCO identity rather than de-rotating by a spurious offset.
+func (c *cqpskDemod) robustSeedHz(x []complex64) (hz float64, ok bool) {
+	fs := c.fs
+	if len(x) <= cqpskSeedMaxLag || fs <= 0 {
+		return 0, false
 	}
-	var accR, accI float64
-	for n := 1; n < len(x); n++ {
-		ar, ai := float64(real(x[n])), float64(imag(x[n]))
-		br, bi := float64(real(x[n-1])), float64(imag(x[n-1]))
-		// x[n] · conj(x[n-1])
-		accR += ar*br + ai*bi
-		accI += ai*br - ar*bi
+	var energy float64
+	for _, s := range x {
+		energy += float64(real(s))*float64(real(s)) + float64(imag(s))*float64(imag(s))
 	}
-	return seedHzFromAcc(accR, accI, fs)
-}
-
-// seedHzFromAcc converts running lag-1 autocorrelation accumulators
-// (Σ x[n]·conj(x[n−1])) to a clamped coarse carrier estimate in Hz. Shared
-// by seedCarrierOffsetHz (slice) and the streaming seed that accumulates
-// across process() calls, so both use identical math.
-func seedHzFromAcc(accR, accI, fs float64) float64 {
-	hz := math.Atan2(accI, accR) * fs / (2 * math.Pi)
+	if energy == 0 {
+		return 0, false
+	}
+	// Autocorrelation angle at each lag: R_k = Σ x[n]·conj(x[n−k]).
+	var ang [cqpskSeedMaxLag + 1]float64
+	var coh float64
+	for k := 1; k <= cqpskSeedMaxLag; k++ {
+		var accR, accI float64
+		for n := k; n < len(x); n++ {
+			ar, ai := float64(real(x[n])), float64(imag(x[n]))
+			br, bi := float64(real(x[n-k])), float64(imag(x[n-k]))
+			accR += ar*br + ai*bi
+			accI += ai*br - ar*bi
+		}
+		if k == 1 {
+			coh = math.Hypot(accR, accI) / energy
+		}
+		ang[k] = math.Atan2(accI, accR)
+	}
+	if coh < cqpskSeedMinCoherence {
+		return 0, false // too weak / noisy to seed from — let the fine loop acquire
+	}
+	// Unwrap each lag around k·(lag-1 angle), then least-squares fit a slope
+	// θ (rad/sample) through (k, angle_k) constrained through the origin.
+	a1 := ang[1]
+	var num, den float64
+	for k := 1; k <= cqpskSeedMaxLag; k++ {
+		ak := float64(k)*a1 + math.Remainder(ang[k]-float64(k)*a1, 2*math.Pi)
+		num += float64(k) * ak
+		den += float64(k * k)
+	}
+	slope := num / den
+	if c.seedModulusCV(x, slope) > cqpskSeedMaxModulusCV {
+		return 0, false // ISI after de-rotation ⇒ multipath bias, not a carrier offset
+	}
+	hz = slope * fs / (2 * math.Pi)
 	if hz > cqpskSeedClampHz {
 		hz = cqpskSeedClampHz
 	} else if hz < -cqpskSeedClampHz {
 		hz = -cqpskSeedClampHz
 	}
-	return hz
+	return hz, true
+}
+
+// seedModulusCV de-rotates x by the candidate per-sample carrier rotation
+// slopeRadPerSample, runs the RRC matched filter, decimates at the best of
+// sps timing phases (max mean modulus), and returns the coefficient of
+// variation (std/mean) of the symbol modulus. It is the multipath gate for
+// robustSeedHz: a correct carrier estimate centres the channel and leaves the
+// π/4-DQPSK symbols at constant modulus (low CV), whereas a multipath-biased
+// estimate leaves the ISI that blurs the modulus (high CV).
+func (c *cqpskDemod) seedModulusCV(x []complex64, slopeRadPerSample float64) float64 {
+	der := make([]complex64, len(x))
+	for n := range x {
+		ph := -slopeRadPerSample * float64(n)
+		cs, sn := math.Cos(ph), math.Sin(ph)
+		xr, xi := float64(real(x[n])), float64(imag(x[n]))
+		der[n] = complex(float32(xr*cs-xi*sn), float32(xr*sn+xi*cs))
+	}
+	mf := demod.NewPiOver4DQPSK(c.seedSps, c.seedSpan, c.seedAlpha, lsmRotation)
+	y := mf.MatchedFilter(nil, der)
+	if len(y) < c.seedSps {
+		return 0
+	}
+	bestPhase, bestMean := 0, -1.0
+	for ph := 0; ph < c.seedSps; ph++ {
+		var sum float64
+		var n int
+		for i := ph; i < len(y); i += c.seedSps {
+			sum += math.Hypot(float64(real(y[i])), float64(imag(y[i])))
+			n++
+		}
+		if n > 0 && sum/float64(n) > bestMean {
+			bestMean, bestPhase = sum/float64(n), ph
+		}
+	}
+	var sum, sum2 float64
+	var n int
+	for i := bestPhase; i < len(y); i += c.seedSps {
+		m := math.Hypot(float64(real(y[i])), float64(imag(y[i])))
+		sum += m
+		sum2 += m * m
+		n++
+	}
+	if n == 0 {
+		return 0
+	}
+	mean := sum / float64(n)
+	if mean == 0 {
+		return 0
+	}
+	varr := sum2/float64(n) - mean*mean
+	if varr < 0 {
+		varr = 0
+	}
+	return math.Sqrt(varr) / mean
 }
 
 // cqpskDemod is the LSM / linear-CQPSK symbol recovery chain for P25
@@ -154,18 +253,22 @@ type cqpskDemod struct {
 	seeded bool    // coarse carrier seed applied
 	seedHz float64 // coarse carrier offset the NCO removes (Hz)
 
-	// Coarse-seed accumulators. Production feeds the receiver only
-	// ~160–200 complex samples per process() call (the ccdecoder DDC
-	// output), far below cqpskSeedMinSamples, so the seed cannot key off a
-	// single chunk's length — it must accumulate the lag-1 autocorrelation
-	// Σ x[n]·conj(x[n−1]) across calls until it has seen enough raw samples,
-	// then fire once. Without this the per-call gate never trips on a
-	// streamed input and the NCO stays an identity mix (issue #492).
-	seedAccR     float64   // running Re Σ x[n]·conj(x[n−1])
-	seedAccI     float64   // running Im Σ x[n]·conj(x[n−1])
-	seedCount    int       // lag-1 products folded into the accumulators
-	seedHavePrev bool      // seedPrev holds a valid cross-call boundary sample
-	seedPrev     complex64 // last raw IQ sample of the previous chunk
+	// RRC parameters, retained so the seed's multipath gate can build a
+	// throwaway matched filter to measure post-de-rotation ISI (issue #492).
+	seedSps   int
+	seedSpan  int
+	seedAlpha float64
+
+	// seedBuf collects raw IQ until cqpskSeedMinSamples are available for the
+	// one-shot coarse carrier estimate. Production feeds the receiver only
+	// ~160–200 complex samples per process() call (the ccdecoder DDC output),
+	// far below cqpskSeedMinSamples, so the estimate cannot key off a single
+	// chunk's length — it must accumulate across calls, then fire once. Without
+	// this the per-call gate never trips on a streamed input and the NCO stays
+	// an identity mix (issue #492). The buffer is an estimation tap only: the
+	// live stream is still de-rotated and demodulated chunk by chunk below, and
+	// the buffer is released once the seed fires.
+	seedBuf []complex64
 
 	// cmaErr is the CMA's most recent |y|²−R² convergence proxy,
 	// retained for the replay receiver-state diagnostic (issue #492).
@@ -190,13 +293,16 @@ func newCQPSKDemod(sampleRateHz float64, sps int, span int, alpha float64, gardn
 		gardnerGain = defaultGardnerGain
 	}
 	return &cqpskDemod{
-		dq:      demod.NewPiOver4DQPSK(sps, span, alpha, lsmRotation),
-		gardner: sync.NewGardner(float64(sps), gardnerGain),
-		agc:     dsp.NewAGC(cqpskAGCReference, cqpskAGCRate, cqpskAGCMaxGain),
-		cma:     equalizer.NewCMA(cqpskEqualizerTaps, cqpskEqualizerStep, 1.0),
-		nco:     dsp.NewNCO(0, sampleRateHz),
-		costas:  sync.NewQPSKCostas(SymbolRate, cqpskCostasLoopBWHz, cqpskCostasDamping),
-		fs:      sampleRateHz,
+		dq:        demod.NewPiOver4DQPSK(sps, span, alpha, lsmRotation),
+		gardner:   sync.NewGardner(float64(sps), gardnerGain),
+		agc:       dsp.NewAGC(cqpskAGCReference, cqpskAGCRate, cqpskAGCMaxGain),
+		cma:       equalizer.NewCMA(cqpskEqualizerTaps, cqpskEqualizerStep, 1.0),
+		nco:       dsp.NewNCO(0, sampleRateHz),
+		costas:    sync.NewQPSKCostas(SymbolRate, cqpskCostasLoopBWHz, cqpskCostasDamping),
+		fs:        sampleRateHz,
+		seedSps:   sps,
+		seedSpan:  span,
+		seedAlpha: alpha,
 	}
 }
 
@@ -213,29 +319,25 @@ func (c *cqpskDemod) process(iq []complex64) []uint8 {
 	// would bias the estimate toward zero. De-rotating before the matched
 	// filter also presents the filter a centred channel.
 	//
-	// Production delivers only ~160–200 samples per call, so the seed must
-	// accumulate the lag-1 autocorrelation across calls (carrying the
-	// boundary sample) until it has enough, rather than keying off one
-	// chunk's length — otherwise the gate never trips on a streamed input
-	// and the NCO stays an identity mix (issue #492). Until seeded the NCO
-	// is identity, so a centred/zero-offset stream is unaffected; the fine
-	// Costas loop then cleans up the residual and tracks drift.
+	// Production delivers only ~160–200 samples per call, so the estimate must
+	// accumulate across calls until it has enough, rather than keying off one
+	// chunk's length — otherwise the gate never trips on a streamed input and
+	// the NCO stays an identity mix (issue #492). Until seeded the NCO is
+	// identity, so a centred/zero-offset stream is unaffected; the fine Costas
+	// loop then cleans up the residual and tracks drift. robustSeedHz only
+	// trusts the estimate when its multi-lag phase fit is clean — a multipath /
+	// simulcast channel biases the bare lag-1 angle into a spurious offset that
+	// would mis-tune the NCO and rail the loop (issue #492), so on that signal
+	// the NCO is left identity and the in-range offset is recovered by the loop.
 	if !c.seeded {
-		for n := 0; n < len(iq); n++ {
-			if c.seedHavePrev {
-				ar, ai := float64(real(iq[n])), float64(imag(iq[n]))
-				br, bi := float64(real(c.seedPrev)), float64(imag(c.seedPrev))
-				c.seedAccR += ar*br + ai*bi // Re x[n]·conj(x[n−1])
-				c.seedAccI += ai*br - ar*bi // Im x[n]·conj(x[n−1])
-				c.seedCount++
+		c.seedBuf = append(c.seedBuf, iq...)
+		if len(c.seedBuf) >= cqpskSeedMinSamples {
+			if hz, ok := c.robustSeedHz(c.seedBuf); ok {
+				c.seedHz = hz
+				c.nco.SetOffset(c.seedHz, c.fs)
 			}
-			c.seedPrev = iq[n]
-			c.seedHavePrev = true
-		}
-		if c.seedCount >= cqpskSeedMinSamples {
-			c.seedHz = seedHzFromAcc(c.seedAccR, c.seedAccI, c.fs)
-			c.nco.SetOffset(c.seedHz, c.fs)
 			c.seeded = true
+			c.seedBuf = nil
 			// The pre-seed samples ran through with an identity NCO, so the
 			// Costas frequency integrator wound toward the uncorrected offset
 			// (railing at its ±baud/8 clamp) and the CMA adapted to a spinning
@@ -297,9 +399,5 @@ func (c *cqpskDemod) reset() {
 	c.costas.Reset()
 	c.seeded = false
 	c.seedHz = 0
-	c.seedAccR = 0
-	c.seedAccI = 0
-	c.seedCount = 0
-	c.seedHavePrev = false
-	c.seedPrev = 0
+	c.seedBuf = nil
 }

--- a/internal/radio/p25/phase1/receiver/cqpsk_test.go
+++ b/internal/radio/p25/phase1/receiver/cqpsk_test.go
@@ -302,15 +302,12 @@ func runCQPSKCarrierOffsetSweep(t *testing.T, chunk int) {
 // CMA→Costas ordering and pass once carrier recovery runs ahead of the
 // equalizer (and the CMA's phase null is pinned).
 func TestCQPSKDemodRecoversFSWWithMultipathAndOffset(t *testing.T) {
-	// Skipped pending the carrier-seed fix. This reproduces the confirmed
-	// issue #492 failure mode — a near-spectral-null simulcast channel biases
-	// the raw-IQ lag-1 coarse seed into a spurious ~750 Hz "offset" that
-	// mis-tunes the NCO and rails the loop, even though the CMA→Costas loop
-	// alone (no seed) recovers this same signal. The robust seed fix is being
-	// validated against a real capture (issue #492) before landing; un-skip
-	// this test as its regression guard once that fix is in.
-	t.Skip("issue #492: coarse-seed multipath robustness fix pending real-capture validation")
-
+	// Reproduces the confirmed issue #492 failure mode — a near-spectral-null
+	// simulcast channel biases the raw-IQ lag-1 coarse seed into a spurious
+	// ~750 Hz "offset" that mis-tunes the NCO and rails the Costas loop, even
+	// though the CMA→Costas loop alone (no seed) recovers this same signal.
+	// This is a fully synthetic stand-in for the live captures on #492, so the
+	// seed-robustness fix can be validated without a private recording.
 	const sampleRate = 48_000.0
 	const sps = 10
 

--- a/internal/siglab/synth.go
+++ b/internal/siglab/synth.go
@@ -20,6 +20,11 @@ type SynthOptions struct {
 	// Impairments applied to the ideal IQ (SNR, carrier offset, DC spike,
 	// I/Q imbalance, multipath). The zero value is a clean capture.
 	Impairments demod.Impairments
+	// Modulation optionally overrides the fixture's default modulator. Empty
+	// uses the per-protocol default. For P25 Phase 1, "lsm" (or "cqpsk")
+	// selects the linear π/4-DQPSK (LSM) waveform instead of C4FM, so a
+	// capture can exercise the linear CQPSK demod path (issue #492).
+	Modulation string
 }
 
 // Synthesize builds a known-good (optionally impaired) capture for a
@@ -31,8 +36,16 @@ func Synthesize(opts SynthOptions) ([]complex64, *Metadata, error) {
 	if !ok {
 		return nil, nil, fmt.Errorf("siglab: no synthesis fixture for protocol %s (have: %v)", opts.Protocol, Fixtures())
 	}
+	modulate := fx.modulate
+	if opts.Modulation != "" {
+		m, err := modulatorFor(opts.Protocol, opts.Modulation)
+		if err != nil {
+			return nil, nil, err
+		}
+		modulate = m
+	}
 	symbols := fx.build()
-	iq := fx.modulate(symbols, fx.sampleRate)
+	iq := modulate(symbols, fx.sampleRate)
 	iq = demod.ApplyImpairments(iq, fx.sampleRate, opts.Impairments)
 
 	meta := &Metadata{
@@ -44,6 +57,27 @@ func Synthesize(opts SynthOptions) ([]complex64, *Metadata, error) {
 		Expected:     fx.expected,
 	}
 	return iq, meta, nil
+}
+
+// modulatorFor resolves a SynthOptions.Modulation override to a modulator.
+// Only the combinations a fixture can sensibly re-shape are supported; an
+// unknown protocol/modulation pair is an error rather than a silent default.
+func modulatorFor(proto trunking.Protocol, mod string) (func([]uint8, float64) []complex64, error) {
+	switch proto {
+	case trunking.ProtocolP25:
+		switch mod {
+		case "c4fm":
+			return func(d []uint8, sr float64) []complex64 { return demod.ModulateP25C4FM(d, sr, 1800.0) }, nil
+		case "lsm", "cqpsk":
+			// Linear simulcast modulation: π/4-DQPSK at 10 sps / 48 kHz with the
+			// P25 RRC (span 8, α=0.20) and the LSM π/4 constellation rotation —
+			// the waveform the linear CQPSK demod is designed for (issue #492).
+			return func(d []uint8, _ float64) []complex64 {
+				return demod.ModulatePiOver4DQPSK(d, 10, 8, 0.20, math.Pi/4)
+			}, nil
+		}
+	}
+	return nil, fmt.Errorf("siglab: no %q modulation for protocol %s", mod, proto)
 }
 
 // WriteCapture writes IQ to path in the given format (u8 or f32).


### PR DESCRIPTION
The CQPSK control-channel demod still railed on the issue #492 captures
after the CMA centre-tap pin (008efbd): a deep simulcast spectral null
shifts the lag-1 (Kay) autocorrelation centroid, which the coarse seed
reads as a spurious ~650-750 Hz "offset", mis-tunes the NCO, and pins the
Costas integrator at its +/-baud/8 clamp. An autocorrelation estimator
cannot tell that centroid shift from a real offset, so estimate-side
hardening alone is not enough.

Gate the seed instead: de-rotate by the candidate estimate, run the
matched filter, and measure the coefficient of variation of the symbol
modulus. A pure carrier offset only rotates the constant-modulus
pi/4-DQPSK symbols (low CV); multipath ISI blurs the modulus (high CV).
When the CV is high the estimate is multipath bias, not a carrier offset,
so the NCO is left identity and the CMA->Costas loop acquires the
(in-range) true offset on its own. Also sharpen the trusted estimate with
a short multi-lag phase-ramp fit, and add Costas anti-windup so a loop
left pinned at the clamp re-acquires instead of staying railed.

This reproduces and is validated entirely on synthetic signals, so the
fix no longer waits on a private capture:
- Un-skip TestCQPSKDemodRecoversFSWWithMultipathAndOffset (red before,
  green after) as the regression guard; the offset sweep stays green.
- gophertrunk gen gains -multipath (preset/taps), -drift (Hz/s, via a new
  Impairments.FreqDriftHzPerSec) and -modulation lsm so a linear stress
  capture can be regenerated for end-to-end replay.

https://claude.ai/code/session_01RUavL6iAZAwBdGdvPoHmzY