### PR TITLE
p25/cqpsk: T/2 fractionally-spaced equalizer so the linear path decodes C4FM (#492)

### DIFF
--- a/internal/dsp/equalizer/fse.go
+++ b/internal/dsp/equalizer/fse.go
@@ -1,0 +1,155 @@
+package equalizer
+
+import "math"
+
+// FSE is a T/2 fractionally-spaced blind (CMA) adaptive equalizer. It
+// consumes two input samples per symbol — the half-symbol-earlier midpoint
+// interpolant and the on-time symbol sample produced by the timing loop — and
+// emits one equalized symbol.
+//
+// Why fractionally spaced: a symbol-spaced equalizer can only invert the
+// channel at the symbol rate, so it cannot repair a sub-symbol pulse-shape
+// mismatch. The P25 CQPSK/LSM receiver matched-filters with an RRC, but a real
+// P25 C4FM transmitter shapes a different (CPM) pulse, so the outer ±1800 Hz
+// rails arrive under-shot and the constellation closes — the symbol-spaced CMA
+// cannot open it (issue #492). A T/2 equalizer spans two phases per symbol and
+// therefore synthesizes the receive matched filter implicitly, correcting the
+// pulse mismatch (and any multipath ISI) and is insensitive to residual symbol
+// timing phase.
+//
+// Like CMA it is blind: the constant-modulus cost J = E[(|y|²−R²)²] needs no
+// training symbols and is rotation-invariant, so the FSE runs ahead of the
+// carrier (Costas) loop. The fractional spacing enlarges the cost's null space
+// (degrees of freedom that leave |y| unchanged), which lets the taps random-
+// walk on a clean, ISI-free channel; a small leakage term w←(1−leak)·w shrinks
+// unexcited taps toward zero so real ISI sustains the taps but noise alone does
+// not. The on-time centre tap is phase-pinned to the positive real axis after
+// each update (as in CMA) so the downstream carrier loop does not read tap-phase
+// drift as a frequency offset.
+type FSE struct {
+	taps     []complex64 // 2*symbolSpan taps at T/2 spacing
+	hist     []complex64 // ring of the last len(taps) input samples
+	histPos  int         // next write index into hist
+	stepSize float32     // CMA step μ
+	target   float32     // R²
+	leak     float32     // per-update leakage toward zero (0 = vanilla CMA)
+	center   int         // on-time centre-tap index (phase pin / output alignment)
+}
+
+// NewFSE builds a T/2 fractionally-spaced CMA equalizer. symbolSpan is the
+// equalizer length in symbols; the filter holds 2*symbolSpan T/2-spaced taps.
+// Use an even symbolSpan so the centre tap aligns with an on-time sample (the
+// emission order is [mid, on], so even tap indices are on-time samples).
+// stepSize is the CMA step; target is R² (1.0 for unit-modulus π/4-DQPSK after
+// AGC); leak is the leakage coefficient (0 disables it; ~1e-4..1e-3 typical).
+func NewFSE(symbolSpan int, stepSize, target, leak float32) *FSE {
+	if symbolSpan <= 0 {
+		panic("equalizer: FSE symbolSpan must be > 0")
+	}
+	if target <= 0 {
+		panic("equalizer: FSE target must be > 0")
+	}
+	n := 2 * symbolSpan
+	f := &FSE{
+		taps:     make([]complex64, n),
+		hist:     make([]complex64, n),
+		stepSize: stepSize,
+		target:   target,
+		leak:     leak,
+		center:   n / 2,
+	}
+	f.taps[f.center] = complex(1, 0)
+	return f
+}
+
+// Reset returns the equalizer to centre-spike initial state.
+func (f *FSE) Reset() {
+	for i := range f.taps {
+		f.taps[i] = 0
+	}
+	f.taps[f.center] = complex(1, 0)
+	for i := range f.hist {
+		f.hist[i] = 0
+	}
+	f.histPos = 0
+}
+
+// Taps returns a copy of the current weight vector.
+func (f *FSE) Taps() []complex64 {
+	out := make([]complex64, len(f.taps))
+	copy(out, f.taps)
+	return out
+}
+
+func (f *FSE) push(x complex64) {
+	f.hist[f.histPos] = x
+	f.histPos++
+	if f.histPos == len(f.hist) {
+		f.histPos = 0
+	}
+}
+
+// Process consumes the two T/2-spaced samples of one symbol period (mid = the
+// half-symbol-earlier interpolant, on = the symbol-time sample) and returns the
+// equalized symbol y plus the CMA error proxy |y|²−R². The output is computed
+// once, at the symbol instant, over the full 2-sps tap line; the gradient
+// updates every tap against its own aligned T/2 input sample so both new
+// samples participate.
+func (f *FSE) Process(mid, on complex64) (complex64, float32) {
+	// Shift both T/2 samples in, oldest first: the on-time sample becomes the
+	// newest, the mid sample one before it.
+	f.push(mid)
+	f.push(on)
+
+	n := len(f.taps)
+	newest := f.histPos - 1
+	if newest < 0 {
+		newest = n - 1
+	}
+
+	// FIR output y = Σ_k taps[k] · hist[newest-k].
+	var yr, yi float32
+	idx := newest
+	for k := 0; k < n; k++ {
+		hr, hi := real(f.hist[idx]), imag(f.hist[idx])
+		tr, ti := real(f.taps[k]), imag(f.taps[k])
+		yr += tr*hr - ti*hi
+		yi += tr*hi + ti*hr
+		idx--
+		if idx < 0 {
+			idx = n - 1
+		}
+	}
+	y := complex(yr, yi)
+
+	mag2 := yr*yr + yi*yi
+	err := mag2 - f.target
+
+	// Leaky CMA weight update: w_k ← (1-leak)·w_k − μ·err·y·conj(x[newest-k]).
+	mu := f.stepSize
+	keep := 1 - f.leak
+	idx = newest
+	for k := 0; k < n; k++ {
+		xr, xi := real(f.hist[idx]), imag(f.hist[idx])
+		// y · conj(x) = (yr*xr + yi*xi) + j(yi*xr - yr*xi)
+		ur := yr*xr + yi*xi
+		ui := yi*xr - yr*xi
+		tr, ti := real(f.taps[k]), imag(f.taps[k])
+		f.taps[k] = complex(keep*tr-mu*err*ur, keep*ti-mu*err*ui)
+		idx--
+		if idx < 0 {
+			idx = n - 1
+		}
+	}
+
+	// Pin the on-time centre tap to the positive real axis (removes the CMA
+	// rotation ambiguity so the carrier loop sees only the true residual).
+	if ct := f.taps[f.center]; ct != 0 {
+		mag := float32(math.Hypot(float64(real(ct)), float64(imag(ct))))
+		derot := complex(real(ct)/mag, -imag(ct)/mag)
+		for k := range f.taps {
+			f.taps[k] *= derot
+		}
+	}
+	return y, err
+}

--- a/internal/dsp/equalizer/fse_test.go
+++ b/internal/dsp/equalizer/fse_test.go
@@ -1,0 +1,74 @@
+package equalizer
+
+import (
+	"math"
+	"testing"
+)
+
+// TestFSECentreSpikePassthrough verifies the freshly-constructed FSE is the
+// identity: with the centre-spike taps and no adaptation pressure, the on-time
+// sample passes through (after the fixed group delay) unchanged.
+func TestFSECentreSpikePassthrough(t *testing.T) {
+	f := NewFSE(6, 0, 1.0, 0) // step 0 → taps never move
+	// Feed on-time samples; mids are zero. Output of symbol n appears after
+	// the centre-tap latency (center/2 symbols). Drive enough symbols to flush.
+	want := []complex64{complex(1, 0), complex(0, 1), complex(-1, 0), complex(0, -1)}
+	var got []complex64
+	for i := 0; i < 16; i++ {
+		on := want[i%len(want)]
+		y, _ := f.Process(0, on)
+		got = append(got, y)
+	}
+	// Once flushed, y must equal the on-time sample delayed by center/2 symbols
+	// (center taps span; each symbol pushes 2 samples). Find the constant delay.
+	delay := -1
+	for d := 0; d < 8; d++ {
+		ok := true
+		for i := d; i < len(got); i++ {
+			exp := want[(i-d)%len(want)]
+			if cmplxAbs(got[i]-exp) > 1e-5 {
+				ok = false
+				break
+			}
+		}
+		if ok {
+			delay = d
+			break
+		}
+	}
+	if delay < 0 {
+		t.Fatalf("centre-spike FSE is not a pure delayed passthrough; got=%v", got)
+	}
+}
+
+// TestFSEOpensFractionalISI checks the FSE adapts to undo a fractional (T/2)
+// channel a symbol-spaced equalizer could not: a half-symbol-delayed echo
+// applied at 2 sps. After adaptation the recovered symbol modulus settles near
+// the target (the CMA error proxy goes toward zero).
+func TestFSEOpensFractionalISI(t *testing.T) {
+	f := NewFSE(8, 0.01, 1.0, 1e-4)
+	// Unit-modulus QPSK symbols, each represented by [mid, on] T/2 samples.
+	// Channel: on-time = sym, mid = 0.6*previous-sym (a half-symbol echo).
+	syms := []complex64{complex(1, 0), complex(0, 1), complex(-1, 0), complex(0, -1)}
+	rng := uint32(12345)
+	next := func() complex64 {
+		rng = rng*1664525 + 1013904223
+		return syms[(rng>>16)&3]
+	}
+	var prev complex64
+	var lastErr float32
+	for i := 0; i < 8000; i++ {
+		s := next()
+		mid := complex(0.6*real(prev), 0.6*imag(prev))
+		_, e := f.Process(mid, s)
+		lastErr = e
+		prev = s
+	}
+	if math.Abs(float64(lastErr)) > 0.15 {
+		t.Errorf("FSE did not open the fractional-ISI channel: final |err|=%.4f, want <= 0.15", lastErr)
+	}
+}
+
+func cmplxAbs(c complex64) float64 {
+	return math.Hypot(float64(real(c)), float64(imag(c)))
+}

--- a/internal/dsp/sync/gardner.go
+++ b/internal/dsp/sync/gardner.go
@@ -147,6 +147,74 @@ func (g *Gardner) Process(dst, src []complex64) []complex64 {
 	return dst
 }
 
+// Process2x is identical to Process — same timing loop, error detector and
+// cross-call stash — but emits TWO samples per recovered symbol: the
+// half-symbol-earlier midpoint interpolant followed by the on-time symbol
+// sample, i.e. dst grows by [mid, sym] each symbol. This is the T/2 feed for
+// the fractionally-spaced equalizer (issue #492). When the midpoint look-back
+// is not yet available (stream start / chunk head) the pair is emitted with
+// mid = sym, a degenerate pre-lock symbol the equalizer's adaptation tolerates.
+// The symbol cadence is bit-for-bit the same as Process, so chunked consumers
+// stay in sync.
+func (g *Gardner) Process2x(dst, src []complex64) []complex64 {
+	if cap(dst) < 2*(len(src)/int(g.sps)+1) {
+		dst = make([]complex64, 0, 2*(len(src)/int(g.sps)+1))
+	} else {
+		dst = dst[:0]
+	}
+	var buf []complex64
+	if len(g.stashed) > 0 {
+		buf = make([]complex64, 0, len(g.stashed)+len(src))
+		buf = append(buf, g.stashed...)
+		buf = append(buf, src...)
+	} else {
+		buf = src
+	}
+
+	half := g.sps / 2
+
+	i := len(g.stashed)
+	if i < 1 {
+		i = 1
+	}
+	for i < len(buf) {
+		g.mu -= 1.0
+		if g.mu > 0 {
+			i++
+			continue
+		}
+		frac := 1.0 + g.mu
+		sym := interpComplex(buf[i-1], buf[i], frac)
+		midPos := float64(i) - 1.0 + frac - half
+		midSym, midOK := interpAt(buf, midPos)
+
+		if g.have && midOK {
+			diff := complex64(sym - g.prevSym)
+			err := float64(real(diff)*real(midSym) + imag(diff)*imag(midSym))
+			g.mu += g.sps + g.gain*err
+		} else {
+			g.mu += g.sps
+			g.have = true
+		}
+		g.prevSym = sym
+		g.prevMid = midSym
+		emitMid := midSym
+		if !midOK {
+			emitMid = sym // degenerate pre-lock pair
+		}
+		dst = append(dst, emitMid, sym) // [mid, on-time]
+		i++
+	}
+	keep := int(g.sps) + 1
+	if keep > len(buf) {
+		keep = len(buf)
+	}
+	stash := make([]complex64, keep)
+	copy(stash, buf[len(buf)-keep:])
+	g.stashed = stash
+	return dst
+}
+
 // Mu returns the loop's current sub-sample phase accumulator (it counts
 // down from sps toward 0 each input sample and resets by +sps at every
 // emitted symbol). Read-only; exposed for diagnostics so a CQPSK replay

--- a/internal/dsp/sync/gardner_test_2x_test.go
+++ b/internal/dsp/sync/gardner_test_2x_test.go
@@ -1,0 +1,40 @@
+package sync
+
+import "testing"
+
+// TestGardnerProcess2xCadence verifies Process2x emits exactly two samples per
+// recovered symbol — the same symbol cadence as Process — with the pair ordered
+// [mid, on-time] so the on-time sample equals what Process emits. Identical
+// cadence is required so chunked CQPSK consumers stay in sync (issue #275).
+func TestGardnerProcess2xCadence(t *testing.T) {
+	const sps = 10.0
+	mk := func() []complex64 {
+		out := make([]complex64, 0, 2000)
+		// A simple alternating pattern at sps so timing has something to track.
+		for i := 0; i < 2000; i++ {
+			if (i/int(sps))%2 == 0 {
+				out = append(out, complex(1, 0))
+			} else {
+				out = append(out, complex(-1, 0))
+			}
+		}
+		return out
+	}
+	src := mk()
+
+	g1 := NewGardner(sps, 0.01)
+	one := g1.Process(nil, src)
+
+	g2 := NewGardner(sps, 0.01)
+	two := g2.Process2x(nil, src)
+
+	if len(two) != 2*len(one) {
+		t.Fatalf("Process2x emitted %d samples; want 2*%d = %d", len(two), len(one), 2*len(one))
+	}
+	// The on-time sample of each pair (odd index) must match Process's symbol.
+	for i := range one {
+		if two[2*i+1] != one[i] {
+			t.Fatalf("pair %d on-time = %v, want %v (Process2x must emit [mid, on-time])", i, two[2*i+1], one[i])
+		}
+	}
+}

--- a/internal/radio/p25/phase1/receiver/cqpsk.go
+++ b/internal/radio/p25/phase1/receiver/cqpsk.go
@@ -31,20 +31,29 @@ const lsmRotation = math.Pi / 4
 // demodulation — no rotation search needed for the CQPSK path itself.
 var lsmDibitRemap = [4]uint8{0, 1, 3, 2}
 
-// cqpskEqualizerTaps / cqpskEqualizerStep configure the CMA blind
-// equalizer on the CQPSK symbol stream. The post-Gardner LSM symbols
-// are unit-modulus QPSK points, so the Constant Modulus Algorithm
-// applies: simulcast multipath blurs that constant magnitude and CMA
-// drives it back, opening the constellation so the FSW correlates.
+// cqpskFSE* configure the T/2 fractionally-spaced blind equalizer on the CQPSK
+// symbol stream. The post-Gardner symbols are unit-modulus π/4-DQPSK points, so
+// the Constant Modulus Algorithm applies. A *fractionally*-spaced equalizer (two
+// taps per symbol, fed the on-time and half-symbol interpolants from Gardner)
+// synthesizes the receive matched filter implicitly, so it opens both simulcast
+// multipath ISI AND the C4FM-transmit-vs-RRC-receive pulse mismatch that a
+// symbol-spaced equalizer cannot — the latter is what left a real C4FM signal's
+// constellation closed through the linear path (issue #492).
 //
-// cqpskEqualizerStep is tuned for the AGC-normalised symbol amplitude.
-// CMA convergence speed scales with the input power, so before the AGC
-// the equalizer leaned on the power a multipath echo itself adds; with
-// the level now fixed the step is set to converge at that normalised
-// amplitude instead.
+// cqpskFSESymbolSpan is the equalizer length in symbols (2*span T/2 taps; even,
+// so the centre tap aligns with an on-time sample). cqpskFSEStep is the CMA
+// step: brisk because real control-channel captures are short, so the blind
+// equalizer must open the constellation within a few hundred symbols of lead-in
+// before the FSW arrives; the leakage keeps that brisk step from over-adapting
+// at steady state. cqpskFSELeak pulls the equalizer's larger (fractionally-
+// spaced) null space toward identity so the taps do not wander on clean,
+// ISI-free input (where noise alone, with no ISI gradient, would drift them).
+// Tuned against real P25 C4FM captures (issue #492) while keeping the synthetic
+// offset-sweep, multipath and round-trip guards green.
 const (
-	cqpskEqualizerTaps = 11
-	cqpskEqualizerStep = 0.008
+	cqpskFSESymbolSpan = 6
+	cqpskFSEStep       = 0.025
+	cqpskFSELeak       = 5e-4
 )
 
 // cqpskAGC* configure the AGC that normalises the matched-filter output
@@ -245,7 +254,7 @@ type cqpskDemod struct {
 	dq      *demod.PiOver4DQPSK
 	gardner *sync.Gardner
 	agc     *dsp.AGC
-	cma     *equalizer.CMA
+	fse     *equalizer.FSE   // T/2 fractionally-spaced blind equalizer
 	nco     *dsp.NCO         // removes the coarse carrier seed from the raw IQ
 	costas  *sync.QPSKCostas // fine carrier tracking on the symbol stream
 
@@ -270,13 +279,14 @@ type cqpskDemod struct {
 	// the buffer is released once the seed fires.
 	seedBuf []complex64
 
-	// cmaErr is the CMA's most recent |y|²−R² convergence proxy,
+	// cmaErr is the equalizer's most recent |y|²−R² convergence proxy,
 	// retained for the replay receiver-state diagnostic (issue #492).
 	cmaErr float32
 
 	// Scratch buffers reused across calls.
 	rotated []complex64 // NCO-de-rotated IQ, fed to the matched filter
 	matched []complex64
+	twoSps  []complex64 // Gardner T/2 output: [mid, on-time] pairs, len = 2*nSymbols
 	symbols []complex64
 	dibits  []uint8
 }
@@ -296,7 +306,7 @@ func newCQPSKDemod(sampleRateHz float64, sps int, span int, alpha float64, gardn
 		dq:        demod.NewPiOver4DQPSK(sps, span, alpha, lsmRotation),
 		gardner:   sync.NewGardner(float64(sps), gardnerGain),
 		agc:       dsp.NewAGC(cqpskAGCReference, cqpskAGCRate, cqpskAGCMaxGain),
-		cma:       equalizer.NewCMA(cqpskEqualizerTaps, cqpskEqualizerStep, 1.0),
+		fse:       equalizer.NewFSE(cqpskFSESymbolSpan, cqpskFSEStep, 1.0, cqpskFSELeak),
 		nco:       dsp.NewNCO(0, sampleRateHz),
 		costas:    sync.NewQPSKCostas(SymbolRate, cqpskCostasLoopBWHz, cqpskCostasDamping),
 		fs:        sampleRateHz,
@@ -340,13 +350,13 @@ func (c *cqpskDemod) process(iq []complex64) []uint8 {
 			c.seedBuf = nil
 			// The pre-seed samples ran through with an identity NCO, so the
 			// Costas frequency integrator wound toward the uncorrected offset
-			// (railing at its ±baud/8 clamp) and the CMA adapted to a spinning
-			// constellation. Reset both so they re-acquire on the now-centred
-			// signal instead of over-de-rotating. Gardner is left running — it
-			// re-locks on clean input within a few symbols, and leaving it
-			// preserves symbol timing/alignment.
+			// (railing at its ±baud/8 clamp) and the equalizer adapted to a
+			// spinning constellation. Reset both so they re-acquire on the
+			// now-centred signal instead of over-de-rotating. Gardner is left
+			// running — it re-locks on clean input within a few symbols, and
+			// leaving it preserves symbol timing/alignment.
 			c.costas.Reset()
-			c.cma.Reset()
+			c.fse.Reset()
 		}
 	}
 	c.rotated = c.nco.Mix(c.rotated, iq)
@@ -359,21 +369,25 @@ func (c *cqpskDemod) process(iq []complex64) []uint8 {
 	// gain-sensitive and only locks in a narrow RTL-SDR gain window
 	// (issue #275 regression).
 	c.matched = c.agc.Process(c.matched, c.matched)
-	c.symbols = c.symbols[:0]
-	c.symbols = c.gardner.Process(c.symbols, c.matched)
-	if len(c.symbols) == 0 {
+	// Gardner emits the T/2 pair [mid, on-time] per symbol so the
+	// fractionally-spaced equalizer sees both sub-symbol phases.
+	c.twoSps = c.twoSps[:0]
+	c.twoSps = c.gardner.Process2x(c.twoSps, c.matched)
+	nSym := len(c.twoSps) / 2
+	if nSym == 0 {
 		c.dibits = c.dibits[:0]
 		return c.dibits
 	}
-	// Blind equalizer + fine carrier recovery. CMA pulls the symbols back
-	// to constant modulus, undoing the simulcast-multipath ISI that closes
-	// the constellation; the Costas loop then de-rotates each symbol to
-	// remove the residual per-symbol carrier rotation the coarse seed left
-	// behind, so the differential phases land on their nominal grid.
-	for i, s := range c.symbols {
-		y, e := c.cma.Process(s)
+	// Blind T/2 equalizer + fine carrier recovery. The FSE synthesizes the
+	// matched filter and undoes ISI (simulcast multipath and the C4FM-vs-RRC
+	// pulse mismatch) so the constellation opens; the Costas loop then
+	// de-rotates each symbol to remove the residual per-symbol carrier rotation
+	// the coarse seed left behind, so the differential phases land on grid.
+	c.symbols = c.symbols[:0]
+	for i := 0; i < nSym; i++ {
+		y, e := c.fse.Process(c.twoSps[2*i], c.twoSps[2*i+1])
 		c.cmaErr = e
-		c.symbols[i] = c.costas.Update(y)
+		c.symbols = append(c.symbols, c.costas.Update(y))
 	}
 	c.dibits = c.dq.Decode(c.dibits, c.symbols)
 	for i, d := range c.dibits {
@@ -394,7 +408,7 @@ func (c *cqpskDemod) reset() {
 	c.dq.Reset()
 	c.gardner.Reset()
 	c.agc.Reset()
-	c.cma.Reset()
+	c.fse.Reset()
 	c.nco.Reset()
 	c.costas.Reset()
 	c.seeded = false


### PR DESCRIPTION
## Summary

The merged carrier-rail fix (#529) stopped the CQPSK carrier loop from railing, but the reporter confirmed it was **incomplete**: live signals and their stress capture still failed (the dibit histogram collapsed onto one symbol, the FSW never correlated), while C4FM decoded perfectly.

**Root cause:** the linear/CQPSK path matched-filters a real P25 **C4FM** (FM/CPM) waveform with a fixed **RRC**, but the C4FM transmit pulse is not RRC — so the outer ±1800 Hz rails arrive under-shot, the constellation closes, and the **symbol-spaced** CMA (one sample/symbol, post-Gardner) cannot correct a sub-symbol pulse-shape mismatch.

This replaces the symbol-spaced CMA with a **T/2 fractionally-spaced blind equalizer (FSE)** fed two samples per symbol (Gardner's on-time + mid-symbol interpolants). A fractionally-spaced equalizer synthesizes the receive matched filter implicitly, so it opens both simulcast multipath ISI **and** the C4FM-vs-RRC pulse mismatch, and is insensitive to residual timing phase. It stays blind (CMA, rotation-invariant) ahead of the Costas loop, keeps the centre-tap phase pin, and adds small leakage so the larger fractionally-spaced null space doesn't let the taps wander on clean, ISI-free input.

## Changes

- **`internal/dsp/equalizer/fse.go`** (new): leaky T/2 CMA equalizer (`NewFSE`, `Process(mid, on)`, centre-tap phase pin, `Reset`/`Taps`). `cma.go` is untouched.
- **`internal/dsp/sync/gardner.go`**: `Process2x` emits `[mid, on-time]` per symbol — same timing loop and bit-for-bit symbol cadence as `Process`, so chunked consumers stay in sync (guards against an issue #275-style desync). The existing `Process` (used by the Phase 2 receiver) is unchanged.
- **`internal/radio/p25/phase1/receiver/cqpsk.go`**: feed `Gardner.Process2x` into the FSE; new `cqpskFSE*` constants (span 6 / step 0.025 / leak 5e-4). Diagnostic accessors (`CMAError`, `GardnerMu/SPS`, `CQPSKAGCGain`, `CQPSKCarrierOffsetHz`) unchanged, so `replay -diag` keeps working.
- Unit tests for the FSE (centre-spike passthrough, fractional-ISI convergence) and `Process2x` (cadence/ordering).

## Validation

Tested on **8 real P25 C4FM captures** (`15db_100hz_driftN.cfile`, replayed `-format f32 -sample-rate 2000000 -demod cqpsk`):

| Captures CQPSK locks | pre-any-fix | carrier fix (#529) | **+ FSE** |
|---|---|---|---|
| | 0/8 | 3/8 | **8/8** |

Per-capture decode (CQPSK TSBK vs C4FM TSBK): drift1 21/24, drift2 23/28, drift3 27/30, **drift4 28/28**, drift5 16/24, **drift6 28/28**, drift7 11/21, **drift8 17/16** — several at or above C4FM-demod parity, the rest decoding usefully.

Synthetic suites stay green: the CQPSK offset sweep (±200…±2500 Hz, single-buffer + 192-sample streaming), the multipath/carrier guard, the simulcast-equalizer harness, and the round-trip identity — plus `go test ./internal/dsp/... ./internal/radio/p25/phase1/...`, `go build ./...`, `go vet`.

## Notes

A synthetic `ModulateP25C4FM`-through-CQPSK regression test was **not** viable: raw synthetic C4FM at 48 kHz collapses ~94% onto one symbol — a single-point constellation no CMA can open (no modulus gradient), unlike the real captures (which the DDC makes equalizable). It was dropped rather than ship a misleading guard; the existing integration guards plus the real-capture results cover the FSE.

Relates to #492.

https://claude.ai/code/session_01RUavL6iAZAwBdGdvPoHmzY

---
_Generated by [Claude Code](https://claude.ai/code/session_01RUavL6iAZAwBdGdvPoHmzY)_