### PR TITLE
framing: make BCH(63,16) NID decode fast (issue #492)

### DIFF
--- a/internal/radio/framing/bch.go
+++ b/internal/radio/framing/bch.go
@@ -1,5 +1,7 @@
 package framing
 
+import "sync"
+
 // BCH(63,16,11) is the binary BCH code that protects the P25 Phase 1
 // Network ID (NID) field on every transmitted frame. The code carries 16
 // information bits in a 63-bit codeword (47 parity bits) and corrects up
@@ -44,6 +46,30 @@ func BCHEncode63_16(data uint16) uint64 {
 	return (info << 47) | (rem & ((uint64(1) << 47) - 1))
 }
 
+// bch6316Codewords lazily builds (once) and returns the table of all
+// 2^16 valid BCH(63,16,11) codewords, indexed by their 16-bit info
+// word. BCHDecode63_16's fallback search popcounts against this table
+// rather than re-encoding every candidate on each call — the encode is
+// a 16-iteration polynomial division, so caching the codewords turns
+// the search from ~65k encodes into ~65k popcounts (issue #492: the NID
+// decoder is called across searchNID's full alignment grid on every FSW
+// hit, so this is squarely on the hot path).
+var (
+	bch6316TableOnce sync.Once
+	bch6316Table     []uint64
+)
+
+func bch6316Codewords() []uint64 {
+	bch6316TableOnce.Do(func() {
+		t := make([]uint64, 1<<16)
+		for d := range t {
+			t[d] = BCHEncode63_16(uint16(d))
+		}
+		bch6316Table = t
+	})
+	return bch6316Table
+}
+
 // BCHDecode63_16 decodes a 63-bit BCH codeword by minimum-Hamming-
 // distance search across all 2^16 valid codewords. Returns (data,
 // errors) where errors is the bit-error count corrected, or -1 if the
@@ -51,23 +77,38 @@ func BCHEncode63_16(data uint16) uint64 {
 // is the best guess but should not be trusted).
 func BCHDecode63_16(cw uint64) (uint16, int) {
 	cw &= (uint64(1) << 63) - 1
+
+	// Fast path: a zero-error codeword. The code is systematic with the
+	// 16 info bits in positions 62..47, so a clean codeword decodes to
+	// its own high bits — re-encode those and compare. This is the
+	// dominant case on a locked signal and skips the table search.
+	info := uint16(cw >> 47)
+	if BCHEncode63_16(info) == cw {
+		return info, 0
+	}
+
+	// Minimum-Hamming-distance search over the precomputed codeword
+	// table. BCH(63,16) has minimum distance 23, so the radius-11 balls
+	// around codewords are disjoint: at most one codeword lies within 11
+	// bits of cw. The first one found inside the t=11 correction radius
+	// is therefore THE unique answer — return it immediately. This yields
+	// the same (data, errs) as a full scan; only the uncorrectable case
+	// (no codeword within 11) needs to walk the whole table to report the
+	// closest best-guess.
+	table := bch6316Codewords()
 	var bestData uint16
 	bestDist := 64
-	for d := uint32(0); d < 1<<16; d++ {
-		c := BCHEncode63_16(uint16(d))
+	for d, c := range table {
 		dist := PopCount64(c ^ cw)
+		if dist <= 11 {
+			return uint16(d), dist
+		}
 		if dist < bestDist {
 			bestDist = dist
 			bestData = uint16(d)
-			if dist == 0 {
-				return bestData, 0
-			}
 		}
 	}
-	if bestDist > 11 {
-		return bestData, -1
-	}
-	return bestData, bestDist
+	return bestData, -1
 }
 
 // BCH6316ParityBit returns the even-parity bit over the 63 codeword

--- a/internal/radio/framing/bch_test.go
+++ b/internal/radio/framing/bch_test.go
@@ -1,6 +1,98 @@
 package framing
 
-import "testing"
+import (
+	"math/rand"
+	"testing"
+)
+
+// bchDecode63_16Reference is the original brute-force minimum-Hamming-
+// distance decoder: re-encode every one of the 2^16 candidate info
+// words and keep the closest. It is the correctness oracle for the
+// optimized BCHDecode63_16 (issue #492) — the production decoder must
+// return identical (data, errs) for every input.
+func bchDecode63_16Reference(cw uint64) (uint16, int) {
+	cw &= (uint64(1) << 63) - 1
+	var bestData uint16
+	bestDist := 64
+	for d := uint32(0); d < 1<<16; d++ {
+		c := BCHEncode63_16(uint16(d))
+		dist := PopCount64(c ^ cw)
+		if dist < bestDist {
+			bestDist = dist
+			bestData = uint16(d)
+			if dist == 0 {
+				return bestData, 0
+			}
+		}
+	}
+	if bestDist > 11 {
+		return bestData, -1
+	}
+	return bestData, bestDist
+}
+
+// TestBCH6316MatchesReference: the optimized decoder must agree with the
+// brute-force oracle bit-for-bit. Sweep clean codewords plus randomized
+// error patterns of weight 0..13 (covering correctable, the t=11
+// boundary, and uncorrectable words) across random info values.
+func TestBCH6316MatchesReference(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x12345678))
+	check := func(cw uint64) {
+		t.Helper()
+		gotData, gotErrs := BCHDecode63_16(cw)
+		wantData, wantErrs := bchDecode63_16Reference(cw)
+		if gotErrs != wantErrs || gotData != wantData {
+			t.Fatalf("cw=%016x: got (%04x, %d), want (%04x, %d)",
+				cw, gotData, gotErrs, wantData, wantErrs)
+		}
+	}
+	// Sparse clean sweep (full would be 65536 oracle calls per check).
+	for d := uint32(0); d < 1<<16; d += 521 {
+		check(BCHEncode63_16(uint16(d)))
+	}
+	// Random data with random-weight error patterns.
+	for i := 0; i < 2000; i++ {
+		cw := BCHEncode63_16(uint16(rng.Intn(1 << 16)))
+		weight := rng.Intn(14) // 0..13 bit flips
+		flipped := map[int]bool{}
+		for len(flipped) < weight {
+			bit := rng.Intn(63)
+			if flipped[bit] {
+				continue
+			}
+			flipped[bit] = true
+			cw ^= uint64(1) << uint(bit)
+		}
+		check(cw)
+	}
+}
+
+func BenchmarkBCHDecode63_16(b *testing.B) {
+	clean := BCHEncode63_16(0xABCD)
+	corrected := clean
+	for bit := 0; bit < 5; bit++ { // 5 errors, within t=11
+		corrected ^= uint64(1) << uint(bit*11)
+	}
+	uncorrectable := clean
+	for bit := 0; bit < 20; bit++ { // > 11 errors: full-table walk
+		uncorrectable ^= uint64(1) << uint(bit*3)
+	}
+	b.Run("clean", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			BCHDecode63_16(clean)
+		}
+	})
+	b.Run("correctable", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			BCHDecode63_16(corrected)
+		}
+	})
+	b.Run("uncorrectable", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			BCHDecode63_16(uncorrectable)
+		}
+	})
+}
 
 // TestBCH6416RoundTrip: every clean BCH(64,16,11) codeword
 // decodes back to its source info with zero errors.


### PR DESCRIPTION
The NID BCH decoder did a brute-force minimum-Hamming-distance search,
re-encoding all 65,536 codewords on every call and only short-circuiting
on an exact match. searchNID calls it across its full alignment grid for
every FSW hit (104 hypotheses on the CQPSK path), so once the new
fractionally-spaced equalizer let CQPSK actually lock, this previously
dormant path ran on every frame and stalled the single-goroutine decode
pipeline for seconds at a time (laggy, bursty output).

Keep the exact (data, errs) contract but make it fast:
  - clean-codeword fast path: re-encode the systematic info bits and
    compare — the dominant locked-signal case, now O(1) (~1ms -> 26ns).
  - precompute the 65,536-codeword table once, so the fallback search
    popcounts instead of re-encoding (~10x).
  - return on the first codeword within the t=11 radius: BCH(63,16) has
    minimum distance 23, so at most one codeword is that close, making
    the early return provably identical to a full min-distance scan.

Add an equivalence test against a brute-force reference oracle (clean
sweep + random weight-0..13 error patterns) and a decode benchmark.

https://claude.ai/code/session_018VmNTGQRtEZyNnWqpG6tct