### PR TITLE
rtlsdr: fix inverted mixer-AGC bit and missing VGA in R82xx SetGainMode

### DIFF
--- a/internal/sdr/rtlsdr/tuners/r82xx.go
+++ b/internal/sdr/rtlsdr/tuners/r82xx.go
@@ -535,10 +535,18 @@ func (r *R82xx) SetGain(tenthDB int) error {
 
 // SetGainMode flips between AGC (auto) and manual.
 //
-// AGC = bit 4 of register 0x05 and 0x07 set; manual = both clear.
-// LNA + Mixer in librtlsdr enable AGC by setting LNA_AGC_EN = 0
-// and MIXER_AGC_EN = 0 — register-bit semantics are inverted from
-// what you'd naively expect.
+// The LNA and mixer AGC-enable bits have OPPOSITE polarity in
+// librtlsdr's r82xx_set_gain, which is easy to get backwards:
+//
+//	             reg 0x05 bit4 (LNA)   reg 0x07 bit4 (mixer)
+//	manual:      1 (auto off)          0 (auto off)
+//	AGC:         0 (auto on)           1 (auto on)
+//
+// In AGC mode librtlsdr also pins the VGA at a fixed value (reg 0x0C =
+// 0x0B). SetGain handles the VGA in manual mode, but it is a no-op in
+// AGC mode, so the AGC branch must write it here — otherwise the VGA is
+// left at the init default and the front end runs ~17 dB low, deafening
+// marginal-signal dongles like the RTL-SDR Blog V4 (issue #264).
 func (r *R82xx) SetGainMode(manual bool) error {
 	if !r.initDone {
 		return errors.New("r82xx: Init not called")
@@ -548,7 +556,7 @@ func (r *R82xx) SetGainMode(manual bool) error {
 	}
 	defer r.demod.SetI2CRepeater(false)
 	r.manual = manual
-	// LNA gain mode: reg 0x05 bit 4 clear = AGC; set = manual.
+	// LNA gain mode: reg 0x05 bit 4 set = manual; clear = AGC.
 	lnaBit := byte(0x00)
 	if manual {
 		lnaBit = 0x10
@@ -556,13 +564,20 @@ func (r *R82xx) SetGainMode(manual bool) error {
 	if err := r.writeRegMask(0x05, lnaBit, 0x10); err != nil {
 		return err
 	}
-	// Mixer gain mode: reg 0x07 bit 4. Same polarity as LNA.
-	mixBit := byte(0x00)
+	// Mixer gain mode: reg 0x07 bit 4 — inverted from the LNA bit.
+	// set = AGC; clear = manual.
+	mixBit := byte(0x10)
 	if manual {
-		mixBit = 0x10
+		mixBit = 0x00
 	}
 	if err := r.writeRegMask(0x07, mixBit, 0x10); err != nil {
 		return err
+	}
+	// AGC mode: pin the VGA at librtlsdr's fixed default (+16.3 dB).
+	if !manual {
+		if err := r.writeRegMask(0x0C, 0x0B, 0x9F); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/internal/sdr/rtlsdr/tuners/r82xx_test.go
+++ b/internal/sdr/rtlsdr/tuners/r82xx_test.go
@@ -333,14 +333,18 @@ func TestR82xx_WriteRegMaskOnlyChangesMaskedBits(t *testing.T) {
 }
 
 func TestR82xx_SetGainModeManual(t *testing.T) {
-	// Manual mode sets bit 4 on regs 0x05 and 0x07.
-	// regs[0x05] = 0x83 post-init → 0x93 after set.
-	// regs[0x07] = 0x75 post-init → 0x75 (bit 4 already set!). Wait, 0x75 = 0111_0101, bit 4 = 1. Hmm.
-	// So writing manual mode (bit 4 = 1) to 0x07 is a no-op. We skip that write.
+	// Manual mode: LNA bit (0x05 bit4) set, mixer bit (0x07 bit4)
+	// CLEARED — the two AGC-enable bits have opposite polarity in
+	// librtlsdr's r82xx_set_gain.
+	//   regs[0x05] = 0x83 post-init → (0x83 &^ 0x10) | 0x10 = 0x93.
+	//   regs[0x07] = 0x75 post-init → (0x75 &^ 0x10)        = 0x65.
+	// Both land inside one repeater bracket; no VGA write in manual mode.
 	var script []usb.CtrlExchange
 	script = append(script, expectR82xxInitBurst()...)
-	// Only the 0x05 write should land (0x07's bit 4 is already 1 post-init).
-	script = append(script, expectI2CWrite(r82xxI2CAddr, []byte{0x05, 0x93})...)
+	script = append(script, expectRepeaterToggle(true)...)
+	script = append(script, expectI2CWriteRaw(r82xxI2CAddr, []byte{0x05, 0x93}))
+	script = append(script, expectI2CWriteRaw(r82xxI2CAddr, []byte{0x07, 0x65}))
+	script = append(script, expectRepeaterToggle(false)...)
 	r, m := newR82xxForTest(t, script)
 	if err := r.Init(); err != nil {
 		t.Fatalf("Init: %v", err)
@@ -350,6 +354,33 @@ func TestR82xx_SetGainModeManual(t *testing.T) {
 	}
 	if !r.manual {
 		t.Error("manual flag not set")
+	}
+	if m.Remaining() != 0 {
+		t.Errorf("remaining=%d, want 0 — script: %d steps consumed of %d", m.Remaining(), m.Step, len(script))
+	}
+}
+
+func TestR82xx_SetGainModeAGC(t *testing.T) {
+	// AGC mode is the daemon default. Post-init the LNA/mixer AGC bits
+	// are already in the auto state (0x05 bit4=0, 0x07 bit4=1), so those
+	// writes elide; the only write that lands is the fixed VGA, which
+	// librtlsdr pins at reg 0x0C = 0x0B and pre-fix GopherTrunk never set
+	// in AGC mode (leaving the front end ~17 dB low — issue #264).
+	//   regs[0x0C] = 0xF5 post-init → (0xF5 &^ 0x9F) | 0x0B = 0x6B.
+	var script []usb.CtrlExchange
+	script = append(script, expectR82xxInitBurst()...)
+	script = append(script, expectRepeaterToggle(true)...)
+	script = append(script, expectI2CWriteRaw(r82xxI2CAddr, []byte{0x0C, 0x6B}))
+	script = append(script, expectRepeaterToggle(false)...)
+	r, m := newR82xxForTest(t, script)
+	if err := r.Init(); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	if err := r.SetGainMode(false); err != nil {
+		t.Fatalf("SetGainMode(false): %v", err)
+	}
+	if r.manual {
+		t.Error("manual flag set after AGC mode")
 	}
 	if m.Remaining() != 0 {
 		t.Errorf("remaining=%d, want 0 — script: %d steps consumed of %d", m.Remaining(), m.Step, len(script))
@@ -440,28 +471,29 @@ func TestR82xx_AlternatingGainWalk(t *testing.T) {
 //
 // Post-init shadow values (from r82xxInitArray):
 //
-//	regs[0x05] = 0x83 → SetGainMode(true) writes 0x93 (bit 4 set)
-//	regs[0x07] = 0x75 (bit 4 already set, SetGainMode emits no write)
+//	regs[0x05] = 0x83 → SetGainMode(true) writes 0x93 (LNA bit 4 set)
+//	regs[0x07] = 0x75 → SetGainMode(true) writes 0x65 (mixer bit 4 cleared)
 //	regs[0x0C] = 0xF5
 //
 // SetGain(144) then writes (with shadow elision):
 //
 //	0x05: 0x93 → (0x93 &^ 0x0F) | 4 = 0x94
-//	0x07: 0x75 → (0x75 &^ 0x0F) | 4 = 0x74
+//	0x07: 0x65 → (0x65 &^ 0x0F) | 4 = 0x64
 //	0x0C: 0xF5 → (0xF5 &^ 0x9F) | 0x0B = 0x6B
 func TestR82xx_SetGain_BalancedSplit(t *testing.T) {
 	var script []usb.CtrlExchange
 	script = append(script, expectR82xxInitBurst()...)
-	// SetGainMode(true): one repeater on/off pair around the single
-	// 0x05 write (0x07 elided — bit 4 already set post-init).
+	// SetGainMode(true): one repeater on/off pair around the LNA (0x05)
+	// and mixer (0x07) AGC-bit writes (opposite polarity).
 	script = append(script, expectRepeaterToggle(true)...)
 	script = append(script, expectI2CWriteRaw(r82xxI2CAddr, []byte{0x05, 0x93}))
+	script = append(script, expectI2CWriteRaw(r82xxI2CAddr, []byte{0x07, 0x65}))
 	script = append(script, expectRepeaterToggle(false)...)
 	// SetGain(144): one repeater on/off pair around three writes
 	// (LNA 0x05, Mixer 0x07, VGA 0x0C).
 	script = append(script, expectRepeaterToggle(true)...)
 	script = append(script, expectI2CWriteRaw(r82xxI2CAddr, []byte{0x05, 0x94}))
-	script = append(script, expectI2CWriteRaw(r82xxI2CAddr, []byte{0x07, 0x74}))
+	script = append(script, expectI2CWriteRaw(r82xxI2CAddr, []byte{0x07, 0x64}))
 	script = append(script, expectI2CWriteRaw(r82xxI2CAddr, []byte{0x0C, 0x6B}))
 	script = append(script, expectRepeaterToggle(false)...)
 	r, m := newR82xxForTest(t, script)


### PR DESCRIPTION
R82xx.SetGainMode programmed the mixer AGC-enable bit (reg 0x07 bit 4)
with the same polarity as the LNA bit (reg 0x05 bit 4). In librtlsdr's
r82xx_set_gain the two bits are opposite: manual mode is LNA=1/mixer=0,
AGC mode is LNA=0/mixer=1. We had manual=1/1 and AGC=0/0, so AGC mode
disabled the mixer's auto-gain (freezing it at the init index) and
manual mode left the mixer on AGC.

AGC mode also never wrote the VGA. librtlsdr pins it at reg 0x0C = 0x0B;
SetGain sets the VGA only in manual mode (it is a no-op under AGC), so
in AGC the VGA stayed at the init default. Combined, the front end ran
well below its intended gain in AGC mode (the daemon default).

This degraded every R82xx tuner, but a strong-signal R820T2 tolerates it
while a marginal R828D (RTL-SDR Blog V4) falls below the resulting
intermod-elevated noise floor and decodes nothing — the symptom in
issue #264. Captures from the reporter show the V4 ~17 dB low with a
forest of intermod carriers and the real DMR control channel absent,
matching this gain deficit; librtlsdr-based tools work because they
program the mixer/VGA gain correctly.

Set the mixer bit with the correct inverted polarity and write the fixed
VGA in the AGC branch, mirroring r82xx_set_gain. Update the gain-mode
tests to the corrected register writes (manual now emits 0x07=0x65) and
add AGC-mode coverage (0x0C=0x6B), the path the daemon actually uses.

https://claude.ai/code/session_01USQDJE4LNSEvGHcYymNrNL