### PR TITLE
rtlsdr: use VCO power ref of 1 for R828D (Blog V4) PLL fine-tune

### DIFF
--- a/internal/sdr/rtlsdr/tuners/r82xx.go
+++ b/internal/sdr/rtlsdr/tuners/r82xx.go
@@ -585,6 +585,19 @@ func (r *R82xx) SetGainMode(manual bool) error {
 // ----------------------------------------------------------------------
 // PLL synthesis
 
+// vcoPowerRef is the VCO fine-tune comparison threshold setPLL uses to
+// nudge the mixer divider. osmocom librtlsdr uses r82xxVCOPowerRef (2)
+// for every chip; the rtlsdr-blog fork's r82xx_set_pll lowers it to 1
+// for the R828D (rafael_chip == CHIP_R828D, which includes the Blog V4).
+// Without it the V4's LO mistunes and the front end receives only noise
+// while an R820T2 on the same signal decodes cleanly. See issue #264.
+func (r *R82xx) vcoPowerRef() byte {
+	if r.chipType == TypeR828D {
+		return 1
+	}
+	return r82xxVCOPowerRef
+}
+
 // setPLL programs the R820T's frequency synthesizer to land on the
 // requested LO frequency. Faithful port of osmocom r82xx_set_pll —
 // integer / sigma-delta fractional path, mixer divider sweep, VCO
@@ -629,9 +642,10 @@ func (r *R82xx) setPLL(freqHz uint32) error {
 		return fmt.Errorf("r82xx setPLL: read status: %w", err)
 	}
 	vcoFineTune := (rd[4] & 0x30) >> 4
-	if vcoFineTune > r82xxVCOPowerRef && divNum > 0 {
+	vcoPowerRef := r.vcoPowerRef()
+	if vcoFineTune > vcoPowerRef && divNum > 0 {
 		divNum--
-	} else if vcoFineTune < r82xxVCOPowerRef {
+	} else if vcoFineTune < vcoPowerRef {
 		divNum++
 	}
 	if err := r.writeRegMask(0x10, divNum<<5, 0xE0); err != nil {

--- a/internal/sdr/rtlsdr/tuners/r82xx_tables.go
+++ b/internal/sdr/rtlsdr/tuners/r82xx_tables.go
@@ -52,7 +52,9 @@ const (
 	r82xxVCOMax uint64 = 3_900_000_000
 
 	// vcoPowerRef is the comparison threshold for fine-tuning
-	// divNum based on the chip's VCO fine-tune status bits.
+	// divNum based on the chip's VCO fine-tune status bits. This is
+	// osmocom's stock value for R820T/R820T2; setPLL overrides it to 1
+	// for the R828D (incl. the Blog V4), matching the rtlsdr-blog fork.
 	r82xxVCOPowerRef = 2
 
 	// r82xxMaxNint is the largest nint value that fits the chip's PLL

--- a/internal/sdr/rtlsdr/tuners/r82xx_test.go
+++ b/internal/sdr/rtlsdr/tuners/r82xx_test.go
@@ -754,6 +754,43 @@ func TestR82xx_PLLNintWithinEncoding_R828D(t *testing.T) {
 	}
 }
 
+// TestR82xx_VCOPowerRefPerChip pins the issue #264 V4-deafness fix:
+// rtlsdr-blog's r82xx_set_pll lowers vco_power_ref from osmocom's stock
+// 2 to 1 for the R828D (rafael_chip == CHIP_R828D, incl. the Blog V4).
+// With the stock 2 the V4's mixer divider is nudged the wrong way and
+// the LO mistunes, so it receives only noise while an R820T2 decodes.
+// The R820T/R820T2 path must stay on 2 so working dongles are unchanged.
+func TestR82xx_VCOPowerRefPerChip(t *testing.T) {
+	cases := []struct {
+		chip Type
+		want byte
+	}{
+		{TypeR820T, r82xxVCOPowerRef},
+		{TypeR820T2, r82xxVCOPowerRef},
+		{TypeR828D, 1},
+	}
+	for _, c := range cases {
+		r := NewR82xx(nil, r82xxI2CAddr, c.chip)
+		if got := r.vcoPowerRef(); got != c.want {
+			t.Errorf("%v vcoPowerRef() = %d, want %d", c.chip, got, c.want)
+		}
+	}
+
+	// The threshold actually changes setPLL's divider decision: at the
+	// chip's VCO fine-tune value of 2, R828D (ref 1) decrements divNum
+	// (2 > 1) — the correction the V4 needs — while R820T2 (ref 2) leaves
+	// it unchanged (2 is neither > nor < 2), preserving the working path.
+	const vcoFineTune byte = 2
+	r828d := NewR82xx(nil, r828dI2CAddr, TypeR828D)
+	if !(vcoFineTune > r828d.vcoPowerRef()) {
+		t.Errorf("R828D: vcoFineTune(%d) > vcoPowerRef(%d) must hold so divNum decrements", vcoFineTune, r828d.vcoPowerRef())
+	}
+	r820t2 := NewR82xx(nil, r82xxI2CAddr, TypeR820T2)
+	if vcoFineTune != r820t2.vcoPowerRef() {
+		t.Errorf("R820T2: vcoFineTune(%d) must equal vcoPowerRef(%d) so divNum is unchanged", vcoFineTune, r820t2.vcoPowerRef())
+	}
+}
+
 // TestR82xx_PPMCorrectionShiftsPLLReference pins the issue #264 PPM fix:
 // SetPPM now reaches the tuner LO (not just the resampler) by biasing
 // setPLL's reference crystal. ppm == 0 must reproduce the raw crystal


### PR DESCRIPTION
setPLL ported osmocom librtlsdr's fixed vco_power_ref of 2 for every
chip. The rtlsdr-blog fork (the V4's official driver) lowers it to 1 for
the R828D in r82xx_set_pll; with the stock 2 the V4's mixer divider is
nudged the wrong way and the LO mistunes, so the V4 receives only noise
while an R820T2 on the same signal decodes cleanly.

Add a per-chip vcoPowerRef() that returns 1 for R828D and the stock 2
otherwise, matching the fork. The R820T/R820T2 path is byte-for-byte
unchanged. Covered by a new test pinning the threshold and the divider
decision per chip.

Fixes the V4-deafness reported in issue #264 (diagnosed by the reporter).