### PR TITLE
dmr/tier2: verify Voice LC Header FEC vs MMDVM + add off-air diagnostics

### DIFF
--- a/docs/decoder-capture-needs.md
+++ b/docs/decoder-capture-needs.md
@@ -95,6 +95,33 @@ real-air confirmation**. A single labeled capture closes each one.
 - **Pass bar:** the followed talkgroup's embedded LC is recovered and its
   (and only its) audio is routed to the sidecar.
 
+### DMR Tier II Voice LC Header (conventional repeater)
+- **What to capture:** A live conventional DMR repeater carrying voice —
+  key-up to un-key, so the capture spans a **Voice LC Header** and the
+  **Terminator-with-LC** that bracket a transmission.
+- **Format:** complex int16 `.bin` or GNU Radio float32 `.cfile` under
+  `samples/dmr-tier2/`. **Not** demodulated audio.
+- **Sample rate:** ≥ 48 kHz. C4FM @ 4800 sym/s, ~1944 Hz deviation, 12.5 kHz.
+- **Duration / size:** ≥ 5 s (~1 MB int16) — one call is enough.
+- **Why this is blocking (field report, issue #527 follow-up):** off-air
+  decode emits a constant stream of `decode.error` at the
+  `voiceheader-bptc` and `voiceheader-rs` stages even though the synthetic
+  fixture passes end to end. Sync + slot-type Hamming(20,8) succeed on air
+  (the pipeline reaches the Voice LC Header handler), and the BPTC(196,96),
+  Hamming(13,9)/(15,11) and RS(12,9) layers are verified equal to the
+  de-facto MMDVM reference (see `TestRS129MatchesIndependentReferenceEncoder`
+  and `TestBPTCCanonicalLayoutGolden`). What is **not** proven on air is the
+  receiver's dibit recovery on a real BPTC-heavy payload and the
+  end-to-end bit ordering — every existing test round-trips our own
+  encoder, so a real-air-only mismatch passes CI and fails on the air. A
+  single labelled capture closes that gap. `handleVoiceHeader` now Debug-logs
+  the failing burst's dibits + payload hex so the exact bits can be replayed
+  through DSD-FME / MMDVMHost.
+- **Cross-check:** MMDVMHost log / DSD-FME / radio display.
+- **Pass bar:** the captured Voice LC Header decodes to the expected
+  talkgroup + source ID + color code, with no decode.error stream on a
+  clean-SNR call.
+
 ---
 
 ## 🟡 Tier 2 — Calibration: works on synthetic, needs real to lock constants
@@ -179,11 +206,6 @@ calibrates timing/deviation/level constants or confirms bit order.
 Already validated end-to-end (synthetic fixture passes through the
 production pipeline). Real captures are *welcome* for burst-error /
 false-positive coverage but **not blocking**.
-
-### DMR Tier II (conventional repeater)
-- complex int16 `.bin` / `.cfile`, 48 kHz, C4FM @ 4800 sym/s,
-  1944 Hz deviation, 12.5 kHz. ≥ 5 s (~1 MB) — captures a Voice LC
-  Header + Terminator-with-LC pair. Adds real burst-error structure.
 
 ### MPT 1327 (control channel)
 - 48 kHz IQ `.cfile` **or** 8 kHz demod-audio `.wav` (FFSK is audio-band,

--- a/internal/radio/dmr/tier2/conventional.go
+++ b/internal/radio/dmr/tier2/conventional.go
@@ -12,7 +12,9 @@
 package tier2
 
 import (
+	"encoding/hex"
 	"log/slog"
+	"strings"
 	"sync"
 	"time"
 
@@ -177,9 +179,20 @@ func (c *ConventionalChannel) MarkLost() {
 }
 
 func (c *ConventionalChannel) handleVoiceHeader(b *dmr.Burst, slot dmr.SlotType) {
-	bits, errs := framing.DecodeBPTC196_96(b.PayloadBits())
+	payload := b.PayloadBits()
+	bits, errs := framing.DecodeBPTC196_96(payload)
 	if errs < 0 {
-		c.log.Debug("dmr/tier2: voice header BPTC uncorrectable")
+		// Dump the exact on-air bits so a single real failing burst can
+		// be replayed through a reference decoder (DSD-FME / MMDVMHost)
+		// offline. RS(12,9) and BPTC/Hamming match the MMDVM reference,
+		// so an off-air-only BPTC failure points at the receiver's dibit
+		// recovery or a bit-ordering detail a real capture would expose —
+		// see docs/decoder-capture-needs.md. Debug level keeps it
+		// opt-in.
+		c.log.Debug("dmr/tier2: voice header BPTC uncorrectable",
+			"cc", slot.ColorCode,
+			"burst_dibits", dibitDigits(b.Dibits[:]),
+			"payload_hex", hex.EncodeToString(packBitsMSB(payload)))
 		c.bus.Publish(events.Event{
 			Kind:    events.KindDecodeError,
 			Payload: events.DecodeError{Protocol: c.protocolTag, Stage: events.StageVoiceHeaderBPTC},
@@ -193,7 +206,16 @@ func (c *ConventionalChannel) handleVoiceHeader(b *dmr.Burst, slot dmr.SlotType)
 	// confidence. ETSI applies a per-context XOR seed to the parity
 	// before transmission; for Voice LC Header it's 0x96 0x96 0x96.
 	if !framing.VerifyRS12_9(infoBytes, framing.RS129SeedVoiceLCHeader) {
-		c.log.Debug("dmr/tier2: voice header RS(12,9) parity mismatch")
+		// BPTC succeeded but the RS(12,9) parity disagrees: the recovered
+		// 12 octets (9 FLC + 3 seeded parity) are dumped so the exact
+		// bytes can be checked against a reference decoder. Our RS(12,9)
+		// is verified equal to MMDVMHost CRS129 (generator {64,56,14},
+		// roots alpha^1..3, seed 0x96) by TestRS129MatchesIndependent-
+		// ReferenceEncoder, so a real mismatch here implicates the BPTC
+		// info-bit recovery feeding it rather than the RS field itself.
+		c.log.Debug("dmr/tier2: voice header RS(12,9) parity mismatch",
+			"cc", slot.ColorCode,
+			"info_hex", hex.EncodeToString(infoBytes))
 		c.bus.Publish(events.Event{
 			Kind:    events.KindDecodeError,
 			Payload: events.DecodeError{Protocol: c.protocolTag, Stage: events.StageVoiceHeaderRS},
@@ -264,4 +286,29 @@ func infoBitsToBytes(bits []byte) []byte {
 		}
 	}
 	return out
+}
+
+// packBitsMSB packs a 0/1 bit slice MSB-first into bytes (the final byte
+// is zero-padded if len(bits) isn't a multiple of 8). Used only to render
+// a failing burst's payload bits as hex for the diagnostic Debug log.
+func packBitsMSB(bits []byte) []byte {
+	out := make([]byte, (len(bits)+7)/8)
+	for i, b := range bits {
+		if b&1 != 0 {
+			out[i>>3] |= 1 << uint(7-(i&7))
+		}
+	}
+	return out
+}
+
+// dibitDigits renders a dibit slice as a compact base-4 digit string
+// (e.g. "0312...") so a failing burst's exact 132 symbols can be copied
+// out of the Debug log and replayed through a reference decoder.
+func dibitDigits(dibits []uint8) string {
+	var sb strings.Builder
+	sb.Grow(len(dibits))
+	for _, d := range dibits {
+		sb.WriteByte('0' + (d & 3))
+	}
+	return sb.String()
 }

--- a/internal/radio/framing/rs12_9_refvec_test.go
+++ b/internal/radio/framing/rs12_9_refvec_test.go
@@ -1,0 +1,79 @@
+package framing
+
+import "testing"
+
+// rsRefMul is a self-contained russian-peasant GF(2^8) multiply
+// (reduction polynomial 0x11D) used only by this test. It is wholly
+// independent of rs12_9.go's log/exp tables, so agreement below
+// confirms our table-based gfMul and the RS encode are mathematically
+// correct rather than merely self-consistent.
+func rsRefMul(a, b byte) byte {
+	var p byte
+	for i := 0; i < 8; i++ {
+		if b&1 != 0 {
+			p ^= a
+		}
+		hi := a & 0x80
+		a <<= 1
+		if hi != 0 {
+			a ^= 0x1D
+		}
+		b >>= 1
+	}
+	return p
+}
+
+// rsRefEncode reproduces the de-facto on-air DMR RS(12,9) parity LFSR
+// (MMDVMHost CRS129::encode, dmr_utils rs129.encode) from scratch with
+// the independent rsRefMul and the canonical generator
+// g(x) = (x+α)(x+α²)(x+α³) = x³ + 14x² + 56x + 64 (coeffs low→high
+// {64,56,14}). MMDVMHost stores the same POLY = {64U,56U,14U,...} and
+// emits parity as in[9]=p2, in[10]=p1, in[11]=p0 — matched here.
+func rsRefEncode(msg [9]byte) [3]byte {
+	gen := [3]byte{64, 56, 14} // {g0,g1,g2}
+	var p [3]byte
+	for _, d := range msg {
+		fb := d ^ p[2]
+		p[2] = p[1] ^ rsRefMul(fb, gen[2])
+		p[1] = p[0] ^ rsRefMul(fb, gen[1])
+		p[0] = rsRefMul(fb, gen[0])
+	}
+	return [3]byte{p[2], p[1], p[0]} // cw[9], cw[10], cw[11]
+}
+
+// TestRS129MatchesIndependentReferenceEncoder pins our RS(12,9) to the
+// MMDVMHost / dmr_utils on-air convention without going through our own
+// EncodeRS12_9 — it rebuilds the parity from an independent GF multiply
+// and generator. This is the non-self-referential cross-check called
+// for in the issue #527 follow-up: a systematic field/generator/seed
+// error would diverge here even though every round-trip test passes.
+//
+// It also confirms the Voice LC Header seed handling end to end:
+// EncodeRS12_9 (unmasked) XOR seed must verify under that seed.
+func TestRS129MatchesIndependentReferenceEncoder(t *testing.T) {
+	msgs := [][9]byte{
+		{0x00, 0x10, 0x20, 0x00, 0x0c, 0x30, 0x2f, 0x9b, 0xe5}, // a real-shaped group-voice LC
+		{0x00, 0x00, 0x00, 0x00, 0x01, 0x23, 0x45, 0x67, 0x89}, // the tuple our fixtures use
+		{0xFF, 0xFE, 0xFD, 0xFC, 0xFB, 0xFA, 0xF9, 0xF8, 0xF7},
+		{0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE, 0xBA, 0xBE, 0x55},
+	}
+	for _, msg := range msgs {
+		want := rsRefEncode(msg)
+		cw := EncodeRS12_9(msg)
+		got := [3]byte{cw[9], cw[10], cw[11]}
+		if got != want {
+			t.Errorf("EncodeRS12_9 parity = % x, independent reference = % x (msg % x)",
+				got[:], want[:], msg[:])
+			continue
+		}
+		// Seeded on-air codeword (Voice LC Header) must verify.
+		onair := make([]byte, 12)
+		copy(onair[:9], msg[:])
+		for i := 0; i < 3; i++ {
+			onair[9+i] = got[i] ^ RS129SeedVoiceLCHeader[i]
+		}
+		if !VerifyRS12_9(onair, RS129SeedVoiceLCHeader) {
+			t.Errorf("VerifyRS12_9 rejected a valid seeded codeword % x", onair)
+		}
+	}
+}

--- a/samples/README.md
+++ b/samples/README.md
@@ -19,7 +19,7 @@ protocol subfolder has a `README.md` that describes:
 | [`nxdn/`](nxdn/) | NXDN (NXDN-TS-1-A) | ⏳ Real-air capture pending (harness ready: [`integration_cc_nxdn_realair_test.go`](../cmd/gophertrunk/integration_cc_nxdn_realair_test.go)) | ≥ 80% CRC-verified CAC bursts + SystemID match + 3 s lock latency |
 | [`ysf/`](ysf/) | Yaesu System Fusion | ⏳ Real-air capture pending | Validates MMDVMHost schedule choice for `EncodeFICHOnAir` / `DecodeFICHOnAir`; swap to DSDcc alternate if CRC fails |
 | [`tetra/`](tetra/) | ETSI TETRA | ⏳ Real-air capture pending | 5 s lock latency + ≥ 90% frame recovery + Viterbi correction-depth histogram |
-| [`dmr-tier2/`](dmr-tier2/) | DMR Tier II (conventional) | ✅ Pipeline closed (PR-C); captures optional | Burst-error structure validation + per-call payload diversity |
+| [`dmr-tier2/`](dmr-tier2/) | DMR Tier II (conventional) | ⏳ Real-air capture **blocking** — off-air decode fails at `voiceheader-bptc`/`voiceheader-rs` (issue #527 follow-up) despite the synthetic fixture passing | Confirms real-air dibit recovery + end-to-end bit ordering; decodes to expected TG/source/CC |
 | [`mpt1327/`](mpt1327/) | MPT 1327 | ✅ CWSC tolerance closed (PR-A); captures optional | Empirical false-positive count + per-vendor sync bit-error patterns |
 
 Each subfolder's README documents the capture format, metadata

--- a/samples/dmr-tier2/README.md
+++ b/samples/dmr-tier2/README.md
@@ -1,17 +1,25 @@
 # DMR Tier II (conventional) captures
 
-`TestDaemonCCDecodesDMRTier2` is **no longer skipped** — the
-synthesized-fixture path was fixed by lowering the Tier II
-pipeline's Mueller-Müller `ClockGain` from 0.025 to 0.015 (see
+> ⚠️ **Real-air decode is unconfirmed and currently failing (issue #527
+> follow-up).** A field report shows a constant stream of `decode.error`
+> at the `voiceheader-bptc` and `voiceheader-rs` stages on a live signal,
+> even though the synthesized fixture passes. Sync + slot-type decode on
+> air, and the BPTC(196,96) / Hamming / RS(12,9) layers are verified equal
+> to the de-facto MMDVM reference (`TestRS129MatchesIndependentReference-
+> Encoder`, `TestBPTCCanonicalLayoutGolden`) — so the open question is the
+> receiver's real-air dibit recovery and end-to-end bit ordering, which
+> only a labelled capture can settle. **A capture here is now blocking, not
+> optional.** `handleVoiceHeader` Debug-logs the failing burst's dibits +
+> payload hex so the exact bits can be replayed through a reference decoder.
+
+`TestDaemonCCDecodesDMRTier2` (the **synthesized** fixture) is no longer
+skipped — that path was fixed by lowering the Tier II pipeline's
+Mueller-Müller `ClockGain` from 0.025 to 0.015 (see
 [`internal/scanner/ccdecoder/pipelines.go`](../../internal/scanner/ccdecoder/pipelines.go)'s
 `newDMRTier2Pipeline` + the diagnostic test at
 [`cmd/gophertrunk/dmr_tier2_diagnostic_test.go`](../../cmd/gophertrunk/dmr_tier2_diagnostic_test.go)).
-
-Real-air **DMR Tier II repeater** captures are still useful for
-secondary validation — the synthesized fixture confirms the
-pipeline plumbs IQ → C4FM → state-machine end-to-end, but
-real RF exercises the burst-error structure that synthesized IQ
-doesn't model.
+But that fixture round-trips our own encoder, so it cannot catch an
+on-air-only divergence — which is exactly what the field report shows.
 
 ## Capture format
 


### PR DESCRIPTION
Follow-up to #527: a field report shows constant decode.error events at
the voiceheader-bptc and voiceheader-rs stages on real off-air signals
even though the synthetic fixture passes. Every existing test round-trips
our own encoder, so a real-air-only mismatch passes CI and fails on air.

Pin the FEC layers to an independent reference rather than to ourselves:

- Add TestRS129MatchesIndependentReferenceEncoder, which rebuilds the
  RS(12,9) parity from a self-contained russian-peasant GF(2^8) multiply
  and the canonical generator g(x)=(x+a)(x+a^2)(x+a^3)={64,56,14}, then
  cross-checks our table-based EncodeRS12_9. This confirms our RS(12,9)
  equals the de-facto MMDVMHost CRS129 convention (POLY {64,56,14}, roots
  alpha^1..3, parity order p2,p1,p0, seed 0x96) — so RS is NOT the bug.
  BPTC/Hamming already match MMDVM (CBPTC19696, encode1393, encode15113_2).

- handleVoiceHeader now Debug-logs the failing burst's 132 dibits and the
  196-bit payload hex on a BPTC failure, and the 12 recovered octets on an
  RS failure, so a single real failing burst can be replayed through
  DSD-FME / MMDVMHost to localize the on-air divergence. Helpers
  packBitsMSB + dibitDigits.

- Correct the docs that wrongly call this path "validated / pipeline
  closed": decoder-capture-needs.md moves DMR Tier II to the blocking
  tier, and the samples READMEs flag a real capture as blocking.

The remaining unknown is real-air-only (receiver dibit recovery on a
BPTC-heavy payload and/or end-to-end bit ordering); closing it needs a
labelled off-air capture. No changes were made to the verified-correct
codecs.