### PR TITLE
Add raw IQ capture (.cfile) creation + export on CLI and SigLab API/UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ for tagged releases.
 
 ## [Unreleased]
 
+### Added
+
+- **`gophertrunk capture` — record raw IQ off a live SDR to a `.cfile`.**
+  A first-class subcommand that opens a dongle directly (no daemon),
+  records the requested number of seconds of raw IQ to a GNU Radio cfile
+  (interleaved little-endian float32) or rtl_sdr-native `u8`, and writes a
+  siglab `.metadata.json` sidecar so the capture is a drop-in fixture for
+  `replay` / `analyze` / `test` and the `samples/` acceptance harness:
+  `gophertrunk capture -freq 460000000 -sample-rate 2400000 -seconds 30
+  -protocol p25 -out cc.cfile` (`gophertrunk capture -list` enumerates
+  SDRs). Complements the daemon's existing `--iq-capture` diagnostic,
+  which taps a control SDR already in the running pool.
+- **Capture-and-export from the SigLab web console.** A new "Capture from
+  tuner" control on the Captures panel records a fixed-length raw-IQ
+  capture off a live tuner through the daemon, stages it for immediate
+  analysis, and offers the raw `.cfile` as a browser download. Backed by
+  new HTTP routes `GET /api/v1/siglab/capture/devices`,
+  `POST /api/v1/siglab/capture`, and
+  `GET /api/v1/siglab/captures/{id}/download`. The routes return 503 when
+  the console is offline (`siglab serve`) or the daemon has no SDR, so a
+  build without a tuner doesn't pretend it can record.
+
 ## [v0.3.2] — 2026-06-04
 
 DMR grows up — multi-slot, Tier III band-plan voice, and license-free

--- a/cmd/gophertrunk/capture.go
+++ b/cmd/gophertrunk/capture.go
@@ -1,0 +1,275 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"os/signal"
+	"strings"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/sdr"
+	"github.com/MattCheramie/GopherTrunk/internal/siglab"
+)
+
+// runCapture is the entry point for `gophertrunk capture`. It opens a live
+// SDR directly (not through the daemon's pool), records the requested number
+// of seconds of raw IQ to a GNU Radio cfile (interleaved little-endian
+// float32) or the rtl_sdr-native unsigned-8-bit shape, and writes a siglab
+// metadata sidecar so the capture is a drop-in fixture for the
+// replay/analyze/test subcommands and the samples/ acceptance harness.
+//
+// Unlike the daemon's --iq-capture flag — which taps a control SDR already in
+// the running pool (issue #402) — this is a standalone one-shot for grabbing a
+// capture off a dedicated dongle without bringing the whole daemon up. Both
+// paths share the encodeF32/encodeU8 packers in iqcapture.go.
+func runCapture(args []string) {
+	fs := flag.NewFlagSet("capture", flag.ExitOnError)
+	verboseFlag := fs.Bool("verbose-errors", false, "print full error chain + stack on failures")
+	serial := fs.String("serial", "", "SDR serial to capture from (default: the sole enumerated device)")
+	freq := fs.Uint("freq", 0, "centre frequency in Hz (required)")
+	sampleRate := fs.Uint("sample-rate", 2_400_000, "sample rate in Hz")
+	gain := fs.Int("gain", -1, "tuner gain in tenths of a dB (-1 selects automatic gain control)")
+	ppm := fs.Int("ppm", 0, "frequency-correction in PPM")
+	seconds := fs.Float64("seconds", 10, "capture length in seconds (required, > 0)")
+	out := fs.String("out", "capture.cfile", "output capture path")
+	format := fs.String("format", "f32", "capture sample format: u8 | f32 (f32 = GNU Radio cfile)")
+	protocol := fs.String("protocol", "", "protocol name written to the metadata sidecar (enables `test`; see `gophertrunk gen -list`)")
+	source := fs.String("source", "", "free-text provenance written to the metadata sidecar")
+	tune := fs.Float64("tune", 0, "fine software tune offset in Hz written to the metadata sidecar")
+	autoTune := fs.Bool("auto-tune", false, "set auto_tune in the metadata sidecar")
+	conjugate := fs.Bool("conjugate", false, "set conjugate (spectrum-inverted / I-Q-swapped front end) in the metadata sidecar")
+	metaOut := fs.String("meta", "", "metadata sidecar path (default: <out stem>.metadata.json; \"none\" skips it)")
+	listDevices := fs.Bool("list", false, "list the SDRs available to capture from and exit")
+	fs.Usage = func() {
+		fmt.Fprintln(fs.Output(), `gophertrunk capture — record raw IQ off a live SDR to a .cfile + metadata sidecar.
+
+USAGE:
+  gophertrunk capture -freq <hz> [-serial <s>] [-sample-rate <hz>] -seconds <n> -out <path>
+
+EXAMPLES:
+  # 30 s of P25 control-channel IQ at 2.4 MS/s → cfile + sidecar
+  gophertrunk capture -freq 460000000 -sample-rate 2400000 -seconds 30 \
+    -protocol p25 -out p25-cc.cfile
+
+  # rtl_sdr-native u8 capture from a specific dongle
+  gophertrunk capture -serial 00000001 -freq 453000000 -seconds 10 \
+    -format u8 -out dmr.bin
+
+  # List the SDRs this binary can capture from
+  gophertrunk capture -list
+
+FLAGS:`)
+		fs.PrintDefaults()
+	}
+	_ = fs.Parse(args)
+	resolveVerbose(*verboseFlag, false)
+	rep := newReporter("capture")
+
+	if *listDevices {
+		infos, errs := sdr.EnumerateAll()
+		for _, in := range infos {
+			fmt.Printf("%s\t%s\t%s\n", in.Serial, in.Driver, in.Product)
+		}
+		if len(infos) == 0 {
+			fmt.Fprintln(os.Stderr, "capture: no SDRs found")
+			for _, e := range errs {
+				fmt.Fprintf(os.Stderr, "  driver error: %v\n", e)
+			}
+		}
+		return
+	}
+
+	if *freq == 0 {
+		fs.Usage()
+		rep.Fatalf(2, "-freq is required")
+	}
+	if *seconds <= 0 {
+		fs.Usage()
+		rep.Fatalf(2, "-seconds must be > 0")
+	}
+	sampleFormat, err := siglab.ParseSampleFormat(*format)
+	if err != nil {
+		rep.Fatal(2, err)
+	}
+
+	dev, info, err := openCaptureDevice(*serial)
+	if err != nil {
+		rep.Fatal(1, err)
+	}
+	defer dev.Close()
+
+	if err := dev.SetSampleRate(uint32(*sampleRate)); err != nil {
+		rep.Fatal(1, fmt.Errorf("set sample rate: %w", err))
+	}
+	if err := dev.SetCenterFreq(uint32(*freq)); err != nil {
+		rep.Fatal(1, fmt.Errorf("set centre frequency: %w", err))
+	}
+	if *ppm != 0 {
+		if err := dev.SetPPM(*ppm); err != nil {
+			rep.Fatal(1, fmt.Errorf("set ppm: %w", err))
+		}
+	}
+	if err := dev.SetGain(*gain); err != nil {
+		rep.Fatal(1, fmt.Errorf("set gain: %w", err))
+	}
+
+	// Ctrl-C ends the capture early but keeps whatever was written.
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer stop()
+
+	stream, err := dev.StreamIQ(ctx)
+	if err != nil {
+		rep.Fatal(1, fmt.Errorf("start IQ stream: %w", err))
+	}
+
+	fmt.Printf("capture: %s[%s] @ %d Hz, %g MS/s → %s for %gs…\n",
+		info.Driver, info.Serial, *freq, float64(*sampleRate)/1e6, *out, *seconds)
+
+	written, capErr := captureToFile(ctx, *out, sampleFormat, stream, uint32(*sampleRate), *seconds)
+	if capErr != nil && !errors.Is(capErr, context.Canceled) {
+		rep.Fatal(1, fmt.Errorf("capture: %w (wrote %d samples to %s)", capErr, written, *out))
+	}
+
+	metaPath := *metaOut
+	switch {
+	case strings.EqualFold(metaPath, "none"):
+		metaPath = ""
+	case metaPath == "":
+		metaPath = strings.TrimSuffix(*out, ext(*out)) + ".metadata.json"
+	}
+	if metaPath != "" {
+		meta := &siglab.Metadata{
+			Protocol:     *protocol,
+			Source:       *source,
+			SampleRateHz: float64(*sampleRate),
+			CenterFreqHz: uint32(*freq),
+			Format:       sampleFormat.String(),
+			TuneHz:       *tune,
+			AutoTune:     *autoTune,
+			Conjugate:    *conjugate,
+		}
+		if err := siglab.WriteMetadata(metaPath, meta); err != nil {
+			rep.Fatal(1, fmt.Errorf("write metadata: %w", err))
+		}
+	}
+
+	if metaPath != "" {
+		fmt.Printf("capture: wrote %d samples → %s  (metadata → %s)\n", written, *out, metaPath)
+	} else {
+		fmt.Printf("capture: wrote %d samples → %s\n", written, *out)
+	}
+	if *protocol == "" && metaPath != "" {
+		fmt.Fprintln(os.Stderr, "capture: note — no -protocol set; sidecar is informational only (the `test` harness needs a protocol).")
+	}
+}
+
+// openCaptureDevice enumerates the registered drivers and opens the device
+// matching serial (or the sole device when serial is empty). Returns the open
+// handle plus the chosen Info so the caller can report what it grabbed.
+func openCaptureDevice(serial string) (sdr.Device, sdr.Info, error) {
+	infos, errs := sdr.EnumerateAll()
+	if len(infos) == 0 {
+		if len(errs) > 0 {
+			return nil, sdr.Info{}, fmt.Errorf("capture: no SDRs found (%v)", errs[0])
+		}
+		return nil, sdr.Info{}, errors.New("capture: no SDRs found")
+	}
+	var chosen sdr.Info
+	if serial == "" {
+		if len(infos) > 1 {
+			return nil, sdr.Info{}, fmt.Errorf("capture: %d SDRs present; specify -serial (have: %s)", len(infos), serialsOf(infos))
+		}
+		chosen = infos[0]
+	} else {
+		found := false
+		for _, in := range infos {
+			if in.Serial == serial {
+				chosen, found = in, true
+				break
+			}
+		}
+		if !found {
+			return nil, sdr.Info{}, fmt.Errorf("capture: no SDR with serial %q (have: %s)", serial, serialsOf(infos))
+		}
+	}
+	drv, err := sdr.DriverByName(chosen.Driver)
+	if err != nil {
+		return nil, sdr.Info{}, err
+	}
+	dev, err := drv.Open(chosen.Index)
+	if err != nil {
+		return nil, sdr.Info{}, fmt.Errorf("capture: open %s[%d]: %w", chosen.Driver, chosen.Index, err)
+	}
+	return dev, chosen, nil
+}
+
+// captureToFile streams complex64 chunks from src, encodes them in the
+// requested on-disk format with the shared encodeF32/encodeU8 packers, and
+// writes them to path until it has collected seconds*rate samples, the stream
+// ends, ctx cancels, or a wall-clock safety deadline elapses. Returns the
+// number of IQ samples written.
+func captureToFile(ctx context.Context, path string, format siglab.SampleFormat, src <-chan []complex64, rate uint32, seconds float64) (int64, error) {
+	f, err := os.Create(path)
+	if err != nil {
+		return 0, fmt.Errorf("create %s: %w", path, err)
+	}
+
+	encode := encodeF32
+	bytesPerSample := 8
+	if format == siglab.FormatU8 {
+		encode = encodeU8
+		bytesPerSample = 2
+	}
+
+	target := int64(seconds * float64(rate))
+	// Safety deadline so a stalled/under-delivering device doesn't hang the
+	// command forever waiting to reach the sample target.
+	deadline := time.Now().Add(time.Duration(seconds*float64(time.Second)) + 5*time.Second)
+
+	var scratch []byte
+	var written int64
+	var loopErr error
+	for written < target {
+		select {
+		case <-ctx.Done():
+			loopErr = ctx.Err()
+		case chunk, ok := <-src:
+			if !ok {
+				loopErr = errors.New("IQ stream ended before capture finished")
+				break
+			}
+			n := len(chunk) * bytesPerSample
+			if cap(scratch) < n {
+				scratch = make([]byte, n)
+			} else {
+				scratch = scratch[:n]
+			}
+			encode(scratch, chunk)
+			if _, werr := f.Write(scratch); werr != nil {
+				loopErr = fmt.Errorf("write: %w", werr)
+				break
+			}
+			written += int64(len(chunk))
+		}
+		if loopErr != nil || time.Now().After(deadline) {
+			break
+		}
+	}
+
+	if cerr := f.Close(); cerr != nil && loopErr == nil {
+		loopErr = cerr
+	}
+	return written, loopErr
+}
+
+// serialsOf renders the serials of the discovered devices for a friendly hint.
+func serialsOf(infos []sdr.Info) string {
+	out := make([]string, 0, len(infos))
+	for _, in := range infos {
+		out = append(out, in.Serial)
+	}
+	return strings.Join(out, ", ")
+}

--- a/cmd/gophertrunk/capture_provider.go
+++ b/cmd/gophertrunk/capture_provider.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/api"
+	"github.com/MattCheramie/GopherTrunk/internal/sdr"
+	"github.com/MattCheramie/GopherTrunk/internal/sdr/iqtap"
+)
+
+// captureProvider implements api.CaptureProvider over the daemon's iqtap
+// broker map. A capture subscribes a fresh observer to the requested device's
+// broker, collects the requested number of seconds of complex64 IQ, and
+// returns it with the broker's current sample rate + centre frequency.
+//
+// It taps the same live stream the control decoder runs on (the broker fans
+// out to every observer), so a capture never disturbs decoding — a slow drain
+// is dropped by the broker, not backpressured onto the primary consumer. The
+// Devices picker delegates to the spectrum provider so the capture and
+// spectrum device lists stay identical.
+type captureProvider struct {
+	sp      *spectrumProvider
+	brokers map[string]*iqtap.Broker
+}
+
+func newCaptureProvider(pool *sdr.Pool, brokers map[string]*iqtap.Broker, log *slog.Logger) *captureProvider {
+	return &captureProvider{sp: newSpectrumProvider(pool, brokers, log), brokers: brokers}
+}
+
+// Devices reuses the spectrum provider's broker walk.
+func (p *captureProvider) Devices() []api.SpectrumDevice { return p.sp.Devices() }
+
+// Capture records seconds worth of raw IQ from the named device's broker.
+func (p *captureProvider) Capture(ctx context.Context, serial string, seconds int) ([]complex64, uint32, uint32, error) {
+	if p == nil {
+		return nil, 0, 0, errors.New("capture: provider not wired")
+	}
+	br, ok := p.brokers[serial]
+	if !ok {
+		return nil, 0, 0, fmt.Errorf("capture: serial %q is not a known SDR", serial)
+	}
+	rate := br.SampleRateHz()
+	if rate == 0 {
+		return nil, 0, 0, errors.New("capture: device has no sample rate yet")
+	}
+	target := int64(seconds) * int64(rate)
+
+	sub := br.Subscribe()
+	defer sub.Close()
+
+	// Safety deadline so an under-delivering device can't hang the request
+	// waiting to reach the sample target.
+	deadline := time.Now().Add(time.Duration(seconds)*time.Second + 5*time.Second)
+	out := make([]complex64, 0, target)
+	for int64(len(out)) < target {
+		select {
+		case <-ctx.Done():
+			return out, rate, br.CenterHz(), ctx.Err()
+		case chunk, ok := <-sub.C:
+			if !ok {
+				return out, rate, br.CenterHz(), errors.New("capture: IQ stream ended before capture finished")
+			}
+			out = append(out, chunk...)
+		}
+		if time.Now().After(deadline) {
+			break
+		}
+	}
+	return out, rate, br.CenterHz(), nil
+}

--- a/cmd/gophertrunk/capture_test.go
+++ b/cmd/gophertrunk/capture_test.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/sdr"
+	"github.com/MattCheramie/GopherTrunk/internal/siglab"
+)
+
+// feedChunks streams n chunks of the given size onto a fresh channel and
+// closes it, so captureToFile sees a finite IQ source.
+func feedChunks(n, size int) <-chan []complex64 {
+	src := make(chan []complex64, n)
+	for i := 0; i < n; i++ {
+		chunk := make([]complex64, size)
+		for j := range chunk {
+			chunk[j] = complex(float32(i), float32(j))
+		}
+		src <- chunk
+	}
+	close(src)
+	return src
+}
+
+func TestCaptureToFileF32(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "cap.cfile")
+	// 1000-sample target at rate=1000, 1 s; 5×300 = 1500 ≥ 1000.
+	written, err := captureToFile(context.Background(), path, siglab.FormatF32, feedChunks(5, 300), 1000, 1.0)
+	if err != nil {
+		t.Fatalf("captureToFile: %v", err)
+	}
+	if written < 1000 {
+		t.Fatalf("written = %d, want ≥ 1000", written)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if info.Size() != written*8 { // f32 = 8 bytes/sample
+		t.Errorf("file size = %d, want %d", info.Size(), written*8)
+	}
+}
+
+func TestCaptureToFileU8(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "cap.bin")
+	written, err := captureToFile(context.Background(), path, siglab.FormatU8, feedChunks(4, 300), 1000, 1.0)
+	if err != nil {
+		t.Fatalf("captureToFile: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if info.Size() != written*2 { // u8 = 2 bytes/sample
+		t.Errorf("file size = %d, want %d", info.Size(), written*2)
+	}
+}
+
+func TestCaptureToFileStreamEndsEarly(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "short.cfile")
+	// Only 600 samples available but target is 1000 → returns the partial
+	// capture plus an error so the caller can report it.
+	written, err := captureToFile(context.Background(), path, siglab.FormatF32, feedChunks(2, 300), 1000, 1.0)
+	if err == nil {
+		t.Fatalf("expected an error when the stream ends before the target")
+	}
+	if written != 600 {
+		t.Errorf("written = %d, want 600", written)
+	}
+}
+
+func TestCaptureToFileContextCancel(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "cancelled.cfile")
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancelled before the first read
+	_, err := captureToFile(ctx, path, siglab.FormatF32, feedChunks(5, 300), 1_000_000, 1.0)
+	if err == nil {
+		t.Fatalf("expected ctx.Err() when the context is already cancelled")
+	}
+}
+
+func TestSerialsOf(t *testing.T) {
+	got := serialsOf([]sdr.Info{{Serial: "AAA"}, {Serial: "BBB"}})
+	if got != "AAA, BBB" {
+		t.Errorf("serialsOf = %q, want \"AAA, BBB\"", got)
+	}
+}

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -1613,6 +1613,7 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 		if len(d.iqBrokers) > 0 {
 			opts.Spectrum = newSpectrumProvider(d.pool, d.iqBrokers, log)
 			opts.Diag = newDiagProvider(d.pool, d.iqBrokers, cfg.SDR.SampleRate, log)
+			opts.Capture = newCaptureProvider(d.pool, d.iqBrokers, log)
 		}
 		if d.bookmarks != nil {
 			opts.Bookmarks = bookmarkProvider{store: d.bookmarks}

--- a/cmd/gophertrunk/main.go
+++ b/cmd/gophertrunk/main.go
@@ -64,6 +64,8 @@ func main() {
 		runIdentify(os.Args[2:])
 	case "gen":
 		runGen(os.Args[2:])
+	case "capture":
+		runCapture(os.Args[2:])
 	case "test":
 		runSiglabTest(os.Args[2:])
 	case "siglab":
@@ -102,6 +104,7 @@ USAGE:
   gophertrunk analyze [flags]         decode + analyze a capture with structured export (json/yaml/csv)
   gophertrunk identify [flags]        auto-detect the protocol in a capture, then analyze it
   gophertrunk gen [flags]             synthesize a test IQ capture + metadata for a protocol
+  gophertrunk capture [flags]         record raw IQ off a live SDR to a .cfile + metadata sidecar
   gophertrunk test [flags]            decode a capture and grade it against acceptance criteria
   gophertrunk siglab [flags]          standalone replay/test/analysis TUI
   gophertrunk siglab serve [flags]    offline signal-analysis web console (browser UI)

--- a/internal/api/capture.go
+++ b/internal/api/capture.go
@@ -1,0 +1,183 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/siglab"
+)
+
+// maxCaptureSeconds bounds a single live capture so an operator can't pin a
+// tuner (and pile up hundreds of MB of staged IQ) with one request.
+const maxCaptureSeconds = 30
+
+// CaptureProvider taps a live SDR for a fixed-length raw-IQ capture. The
+// daemon (cmd/gophertrunk) implements it over its iqtap.Broker map; nil keeps
+// the POST /api/v1/siglab/capture route returning 503 so a build without SDRs
+// (or the offline `siglab serve` console) doesn't pretend to have a tuner to
+// record from. Kept narrow — and reusing the SpectrumDevice DTO — so the api
+// package stays free of dependencies on internal/sdr, mirroring SpectrumProvider.
+type CaptureProvider interface {
+	// Devices returns the SDRs that can be captured from.
+	Devices() []SpectrumDevice
+	// Capture records seconds worth of raw IQ from the named device and
+	// returns the complex samples plus the device's current sample rate and
+	// centre frequency. ctx cancels an in-flight capture.
+	Capture(ctx context.Context, serial string, seconds int) (iq []complex64, sampleRateHz, centerHz uint32, err error)
+}
+
+// captureRequest is the body of POST /api/v1/siglab/capture.
+type captureRequest struct {
+	Serial   string `json:"serial"`
+	Seconds  int    `json:"seconds"`
+	Format   string `json:"format"`
+	Protocol string `json:"protocol,omitempty"`
+	Source   string `json:"source,omitempty"`
+}
+
+// captureResponse is returned by a successful capture: the staged capture
+// (runnable/identifiable immediately), the metadata sidecar describing it, and
+// a relative URL to download the raw .cfile.
+type captureResponse struct {
+	Capture     siglabCaptureDTO `json:"capture"`
+	Metadata    *siglab.Metadata `json:"metadata"`
+	DownloadURL string           `json:"download_url"`
+}
+
+// handleSiglabCaptureDevices answers GET /api/v1/siglab/capture/devices with
+// the SDRs available to record from. 503 when no CaptureProvider is wired.
+func (s *Server) handleSiglabCaptureDevices(w http.ResponseWriter, r *http.Request) {
+	if s.capture == nil {
+		s.writeError(w, http.StatusServiceUnavailable, "siglab: live capture not available (no SDR)")
+		return
+	}
+	writeJSON(w, http.StatusOK, s.capture.Devices())
+}
+
+// handleSiglabCapture records a fixed-length raw-IQ capture off a live SDR,
+// stages it into the siglab capture store (so it can be run/identified
+// immediately), writes a metadata sidecar next to it, and returns the staged
+// capture DTO plus a download URL for the raw .cfile. This is the runtime
+// equivalent of the `gophertrunk capture` subcommand.
+func (s *Server) handleSiglabCapture(w http.ResponseWriter, r *http.Request) {
+	if s.capture == nil {
+		s.writeError(w, http.StatusServiceUnavailable, "siglab: live capture not available (no SDR)")
+		return
+	}
+	var req captureRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		s.writeError(w, http.StatusBadRequest, "siglab: "+err.Error())
+		return
+	}
+	if req.Serial == "" {
+		s.writeError(w, http.StatusBadRequest, "siglab: serial is required")
+		return
+	}
+	if req.Seconds <= 0 || req.Seconds > maxCaptureSeconds {
+		s.writeError(w, http.StatusBadRequest, fmt.Sprintf("siglab: seconds must be 1..%d", maxCaptureSeconds))
+		return
+	}
+	format, err := siglab.ParseSampleFormat(req.Format)
+	if err != nil {
+		s.writeError(w, http.StatusBadRequest, "siglab: "+err.Error())
+		return
+	}
+
+	iq, sampleRateHz, centerHz, err := s.capture.Capture(r.Context(), req.Serial, req.Seconds)
+	if err != nil {
+		s.writeError(w, http.StatusBadGateway, "siglab: capture: "+err.Error())
+		return
+	}
+	if len(iq) == 0 {
+		s.writeError(w, http.StatusBadGateway, "siglab: capture produced no samples")
+		return
+	}
+
+	id := randomID(16)
+	path := s.siglab.newCapturePath(id)
+	if err := os.WriteFile(path, siglab.EncodeCapture(iq, format), 0o644); err != nil {
+		s.writeError(w, http.StatusInternalServerError, "siglab: stage capture: "+err.Error())
+		return
+	}
+
+	meta := &siglab.Metadata{
+		Protocol:     req.Protocol,
+		Source:       req.Source,
+		SampleRateHz: float64(sampleRateHz),
+		CenterFreqHz: centerHz,
+		Format:       format.String(),
+	}
+	// Best-effort sidecar at the path siglab.DiscoverMetadata probes
+	// (<stem>.metadata.json) so the staged file is a drop-in fixture.
+	metaPath := strings.TrimSuffix(path, filepath.Ext(path)) + ".metadata.json"
+	if err := siglab.WriteMetadata(metaPath, meta); err != nil {
+		s.log.Warn("api: siglab capture metadata write failed", "err", err)
+	}
+
+	c := &siglabCapture{
+		ID:           id,
+		Name:         captureName(req.Serial, centerHz),
+		Path:         path,
+		Format:       format,
+		SampleRateHz: float64(sampleRateHz),
+		Size:         int64(len(iq)) * int64(bytesPerSample(format)),
+		Created:      time.Now(),
+	}
+	s.siglab.putCapture(c)
+
+	writeJSON(w, http.StatusOK, captureResponse{
+		Capture:     captureDTO(c),
+		Metadata:    meta,
+		DownloadURL: fmt.Sprintf("/api/v1/siglab/captures/%s/download", id),
+	})
+}
+
+// handleSiglabCaptureDownload streams a staged capture's raw bytes as a file
+// download. Works for any staged capture (uploaded, synthesized, or live), but
+// is wired primarily so a live capture can be saved to the operator's disk.
+func (s *Server) handleSiglabCaptureDownload(w http.ResponseWriter, r *http.Request) {
+	c, ok := s.siglab.getCapture(r.PathValue("id"))
+	if !ok {
+		s.writeError(w, http.StatusNotFound, "siglab: capture not found")
+		return
+	}
+	f, err := os.Open(c.Path)
+	if err != nil {
+		s.writeError(w, http.StatusNotFound, "siglab: capture file missing")
+		return
+	}
+	defer f.Close()
+
+	ext := "cfile"
+	if c.Format == siglab.FormatU8 {
+		ext = "bin"
+	}
+	w.Header().Set("Content-Type", "application/octet-stream")
+	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%s.%s", c.ID, ext))
+	if _, err := io.Copy(w, f); err != nil {
+		s.log.Warn("api: siglab capture download failed", "err", err)
+	}
+}
+
+// captureName builds a friendly staged-capture name from the device + tuning.
+func captureName(serial string, centerHz uint32) string {
+	if centerHz > 0 {
+		return fmt.Sprintf("capture-%s-%.3fMHz", serial, float64(centerHz)/1e6)
+	}
+	return "capture-" + serial
+}
+
+// bytesPerSample returns the on-disk size of one IQ sample in the format.
+func bytesPerSample(format siglab.SampleFormat) int {
+	if format == siglab.FormatF32 {
+		return 8
+	}
+	return 2
+}

--- a/internal/api/capture_test.go
+++ b/internal/api/capture_test.go
@@ -1,0 +1,155 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+)
+
+// fakeCaptureProvider is an in-memory CaptureProvider for handler tests.
+type fakeCaptureProvider struct {
+	devices []SpectrumDevice
+	iq      []complex64
+	rate    uint32
+	center  uint32
+	err     error
+}
+
+func (f *fakeCaptureProvider) Devices() []SpectrumDevice { return f.devices }
+
+func (f *fakeCaptureProvider) Capture(_ context.Context, _ string, _ int) ([]complex64, uint32, uint32, error) {
+	if f.err != nil {
+		return nil, 0, 0, f.err
+	}
+	return f.iq, f.rate, f.center, nil
+}
+
+func newCaptureTestServer(t *testing.T, prov CaptureProvider) *httptest.Server {
+	t.Helper()
+	bus := events.NewBus(8)
+	t.Cleanup(bus.Close)
+	srv, err := NewServer(ServerOptions{
+		Addr:           "127.0.0.1:0",
+		Bus:            bus,
+		AllowMutations: true,
+		Siglab:         SiglabOptions{Enabled: true, TempDir: t.TempDir()},
+		Capture:        prov,
+	})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	t.Cleanup(func() { _ = srv.Close() })
+	ts := httptest.NewServer(srv.routes())
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+func TestSiglabCaptureUnavailableWhenNotWired(t *testing.T) {
+	ts := newSiglabTestServer(t) // no Capture provider
+	resp, err := http.Post(ts.URL+"/api/v1/siglab/capture", "application/json",
+		bytes.NewBufferString(`{"serial":"x","seconds":1,"format":"f32"}`))
+	if err != nil {
+		t.Fatalf("POST capture: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", resp.StatusCode)
+	}
+}
+
+func TestSiglabCaptureStagesAndDownloads(t *testing.T) {
+	iq := make([]complex64, 4800)
+	for i := range iq {
+		iq[i] = complex(float32(i%7)/7, float32(i%3)/3)
+	}
+	prov := &fakeCaptureProvider{
+		devices: []SpectrumDevice{{Serial: "SDR1", Driver: "mock"}},
+		iq:      iq,
+		rate:    2_400_000,
+		center:  460_000_000,
+	}
+	ts := newCaptureTestServer(t, prov)
+
+	// Device picker lists the fake device.
+	dResp, err := http.Get(ts.URL + "/api/v1/siglab/capture/devices")
+	if err != nil {
+		t.Fatalf("GET capture/devices: %v", err)
+	}
+	defer dResp.Body.Close()
+	var devices []SpectrumDevice
+	if err := json.NewDecoder(dResp.Body).Decode(&devices); err != nil {
+		t.Fatalf("decode devices: %v", err)
+	}
+	if len(devices) != 1 || devices[0].Serial != "SDR1" {
+		t.Fatalf("devices = %+v, want one SDR1", devices)
+	}
+
+	// Capture → staged DTO + metadata + download URL.
+	cResp, err := http.Post(ts.URL+"/api/v1/siglab/capture", "application/json",
+		bytes.NewBufferString(`{"serial":"SDR1","seconds":2,"format":"f32","protocol":"p25"}`))
+	if err != nil {
+		t.Fatalf("POST capture: %v", err)
+	}
+	defer cResp.Body.Close()
+	if cResp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(cResp.Body)
+		t.Fatalf("status = %d, want 200 (%s)", cResp.StatusCode, b)
+	}
+	var cr captureResponse
+	if err := json.NewDecoder(cResp.Body).Decode(&cr); err != nil {
+		t.Fatalf("decode capture response: %v", err)
+	}
+	if cr.Capture.ID == "" || cr.Capture.SampleRateHz != 2_400_000 {
+		t.Fatalf("capture DTO = %+v, want id + 2.4M rate", cr.Capture)
+	}
+	if cr.Metadata == nil || cr.Metadata.Protocol != "p25" || cr.Metadata.CenterFreqHz != 460_000_000 {
+		t.Fatalf("metadata = %+v, want p25 @ 460 MHz", cr.Metadata)
+	}
+	wantBytes := int64(len(iq)) * 8 // f32 = 8 bytes/sample
+	if cr.Capture.Size != wantBytes {
+		t.Fatalf("capture size = %d, want %d", cr.Capture.Size, wantBytes)
+	}
+
+	// Download streams the raw bytes as an attachment of the right length.
+	dlResp, err := http.Get(ts.URL + cr.DownloadURL)
+	if err != nil {
+		t.Fatalf("GET download: %v", err)
+	}
+	defer dlResp.Body.Close()
+	if dlResp.StatusCode != http.StatusOK {
+		t.Fatalf("download status = %d, want 200", dlResp.StatusCode)
+	}
+	if cd := dlResp.Header.Get("Content-Disposition"); cd == "" {
+		t.Errorf("missing Content-Disposition header")
+	}
+	got, _ := io.ReadAll(dlResp.Body)
+	if int64(len(got)) != wantBytes {
+		t.Errorf("downloaded %d bytes, want %d", len(got), wantBytes)
+	}
+}
+
+func TestSiglabCaptureRejectsBadSeconds(t *testing.T) {
+	prov := &fakeCaptureProvider{iq: []complex64{complex(1, 0)}, rate: 48000}
+	ts := newCaptureTestServer(t, prov)
+	for _, body := range []string{
+		`{"serial":"SDR1","seconds":0,"format":"f32"}`,
+		`{"serial":"SDR1","seconds":9999,"format":"f32"}`,
+		`{"seconds":1,"format":"f32"}`, // missing serial
+	} {
+		resp, err := http.Post(ts.URL+"/api/v1/siglab/capture", "application/json",
+			bytes.NewBufferString(body))
+		if err != nil {
+			t.Fatalf("POST capture: %v", err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Errorf("body %s → status %d, want 400", body, resp.StatusCode)
+		}
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -259,6 +259,12 @@ type Server struct {
 	// over its iqtap broker map.
 	spectrum SpectrumProvider
 
+	// capture is the optional provider backing the runtime
+	// POST /api/v1/siglab/capture route (record raw IQ off a live
+	// tuner). nil keeps the route returning 503. Implemented by the
+	// daemon over the same iqtap broker map as spectrum.
+	capture CaptureProvider
+
 	// bookmarks is the optional provider backing /api/v1/bookmarks/...
 	// routes. nil disables the routes (503). Implemented by the
 	// daemon over storage.BookmarkStore.
@@ -510,6 +516,13 @@ type ServerOptions struct {
 	// routes returning 503 so a build without SDRs doesn't pretend
 	// to have a waterfall.
 	Spectrum SpectrumProvider
+	// Capture, when non-nil, enables the runtime
+	// POST /api/v1/siglab/capture route and its GET
+	// /api/v1/siglab/capture/devices picker — record a fixed-length
+	// raw-IQ capture off a live tuner, stage it into siglab, and hand
+	// back a .cfile download URL. The daemon implements this over its
+	// iqtap.Broker map; nil keeps the routes returning 503.
+	Capture CaptureProvider
 	// Bookmarks, when non-nil, enables the
 	// GET/POST/PATCH/DELETE /api/v1/bookmarks routes for operator-
 	// managed conventional channel bookmarks. nil keeps the routes
@@ -679,6 +692,7 @@ func NewServer(opts ServerOptions) (*Server, error) {
 		cors:           opts.CORS,
 		audioPub:       opts.AudioPublisher,
 		spectrum:       opts.Spectrum,
+		capture:        opts.Capture,
 		bookmarks:      opts.Bookmarks,
 		diag:           opts.Diag,
 		siglab:         siglabSvc,
@@ -911,6 +925,13 @@ func (s *Server) routes() *http.ServeMux {
 		mux.HandleFunc("GET /api/v1/siglab/jobs/{id}/export", s.handleSiglabExport)
 		mux.HandleFunc("POST /api/v1/siglab/identify", s.gate(s.handleSiglabIdentify))
 		mux.HandleFunc("POST /api/v1/siglab/synthesize", s.gate(s.handleSiglabSynthesize))
+		// Live raw-IQ capture off a tuner: list devices (read), record a
+		// fixed-length capture (gated mutation — it spends an SDR + CPU),
+		// and download a staged capture's raw bytes. 503 when no
+		// CaptureProvider is wired (offline `siglab serve`, or no SDRs).
+		mux.HandleFunc("GET /api/v1/siglab/capture/devices", s.handleSiglabCaptureDevices)
+		mux.HandleFunc("POST /api/v1/siglab/capture", s.gate(s.handleSiglabCapture))
+		mux.HandleFunc("GET /api/v1/siglab/captures/{id}/download", s.handleSiglabCaptureDownload)
 	}
 
 	// Pager log — recent POCSAG (and eventually FLEX) messages.

--- a/samples/README.md
+++ b/samples/README.md
@@ -49,7 +49,14 @@ information:
 - **DMR Tier II** is C4FM at 4800 sym/s; same caveat as NXDN.
 
 For the protocols that need IQ, drop a `*.cfile` / `*.bin` / `*.iq`
-recording rather than an MP3.
+recording rather than an MP3. To grab a fresh IQ capture (plus a
+matching `.metadata.json` sidecar) straight off a dongle, use
+`gophertrunk capture`:
+
+```
+gophertrunk capture -freq 460000000 -sample-rate 2400000 -seconds 30 \
+  -protocol p25 -out samples/p25/cc.cfile
+```
 
 ## Smoke-test harness
 

--- a/web/siglab/README.md
+++ b/web/siglab/README.md
@@ -13,8 +13,11 @@ browser — no Node.js at runtime. The built bundle is embedded into the
 
 Parity with the siglab CLI/TUI plus visualization and comparison:
 
-- Upload a raw IQ capture (u8/f32) or **synthesize** an idealized/impaired one
-  (the `gen` surface: SNR, carrier offset/drift, multipath, DC, I/Q imbalance).
+- Upload a raw IQ capture (u8/f32), **synthesize** an idealized/impaired one
+  (the `gen` surface: SNR, carrier offset/drift, multipath, DC, I/Q imbalance),
+  or **capture from a live tuner** when the console is served by a running
+  daemon with an SDR — record a fixed-length raw-IQ capture, stage it for
+  immediate analysis, and download the raw `.cfile` (the `capture` surface).
 - Configure and **run** the engine (protocol, sample rate, tune, auto-tune,
   conjugate, IQ-correct, P25 deep knobs) with a **live SSE event stream**.
 - **Identify** the protocol of an unknown capture (ranked candidates).

--- a/web/siglab/src/api/client.ts
+++ b/web/siglab/src/api/client.ts
@@ -5,6 +5,9 @@
 
 import type {
   CaptureDTO,
+  CaptureDevice,
+  CaptureRequest,
+  CaptureResponse,
   IQTaps,
   IdentifyResult,
   JobDTO,
@@ -133,6 +136,16 @@ export const api = {
       body,
     ),
 
+  // captureDevices lists the SDRs available to record from. 503 (HTTPError)
+  // when the console is offline (`siglab serve`) or the daemon has no SDR.
+  captureDevices: (c: ClientConfig) =>
+    req<CaptureDevice[]>(c, "GET", "/api/v1/siglab/capture/devices"),
+
+  // capture records a fixed-length raw-IQ capture off a live tuner, stages it,
+  // and returns the staged capture + a download URL for the raw .cfile.
+  capture: (c: ClientConfig, body: CaptureRequest) =>
+    req<CaptureResponse>(c, "POST", "/api/v1/siglab/capture", body),
+
   // URLs for browser-native consumers (EventSource, <a download>).
   jobEventsURL: (c: ClientConfig, id: string) =>
     joinURL(c.baseURL, `/api/v1/siglab/jobs/${id}/events`),
@@ -140,4 +153,6 @@ export const api = {
     joinURL(c.baseURL, `/api/v1/siglab/jobs/${id}/export?format=${format}`),
   synthDownloadURL: (c: ClientConfig) =>
     joinURL(c.baseURL, "/api/v1/siglab/synthesize?download=1"),
+  captureDownloadURL: (c: ClientConfig, id: string) =>
+    joinURL(c.baseURL, `/api/v1/siglab/captures/${id}/download`),
 };

--- a/web/siglab/src/api/types.ts
+++ b/web/siglab/src/api/types.ts
@@ -216,6 +216,32 @@ export interface ProtocolsDTO {
   formats: string[];
 }
 
+// CaptureDevice mirrors api.SpectrumDevice — an SDR available to record from.
+export interface CaptureDevice {
+  serial: string;
+  driver: string;
+  product?: string;
+  role: string;
+  center_hz: number;
+  sample_rate_hz: number;
+}
+
+// CaptureRequest is the body of POST /api/v1/siglab/capture.
+export interface CaptureRequest {
+  serial: string;
+  seconds: number;
+  format: string;
+  protocol?: string;
+  source?: string;
+}
+
+// CaptureResponse is returned by a successful live capture.
+export interface CaptureResponse {
+  capture: CaptureDTO;
+  metadata: unknown;
+  download_url: string;
+}
+
 // RunConfig mirrors siglabRunConfig (the engine knobs).
 export interface RunConfig {
   protocol: string;

--- a/web/siglab/src/panels/Captures.tsx
+++ b/web/siglab/src/panels/Captures.tsx
@@ -1,7 +1,8 @@
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useStore } from "../store/shared";
-import type { CaptureDTO, RunConfig } from "../api/types";
+import { api } from "../api/client";
+import type { CaptureDTO, CaptureDevice, RunConfig } from "../api/types";
 
 export function Captures() {
   const captures = useStore((s) => s.captures);
@@ -16,6 +17,7 @@ export function Captures() {
     <div className="grid gap-4 lg:grid-cols-[360px_1fr]">
       <div className="space-y-4">
         <UploadForm />
+        <CaptureForm />
         <div className="card">
           <h3 className="mb-2 text-sm font-semibold">Captures ({captures.length})</h3>
           {captures.length === 0 ? (
@@ -122,6 +124,136 @@ function UploadForm() {
       </button>
       {err && <p className="text-xs text-err">{err}</p>}
     </form>
+  );
+}
+
+// CaptureForm records a fixed-length raw-IQ capture off a live tuner, stages
+// it (so it appears in the capture list and is immediately runnable), and
+// surfaces a .cfile download link. Only functional when the SigLab console is
+// served by a running daemon with an SDR; the offline `siglab serve` host (and
+// a daemon with no SDR) returns 503, which we render as a disabled hint.
+function CaptureForm() {
+  const config = useStore((s) => s.config);
+  const captureFromTuner = useStore((s) => s.captureFromTuner);
+  const formats = useStore((s) => s.formats);
+  const protocols = useStore((s) => s.protocols);
+
+  const [devices, setDevices] = useState<CaptureDevice[] | null>(null);
+  const [unavailable, setUnavailable] = useState<string | null>(null);
+  const [serial, setSerial] = useState("");
+  const [seconds, setSeconds] = useState("10");
+  const [format, setFormat] = useState("f32");
+  const [protocol, setProtocol] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+  const [downloadID, setDownloadID] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    api
+      .captureDevices(config)
+      .then((d) => {
+        if (cancelled) return;
+        setDevices(d);
+        if (d.length > 0) setSerial((s) => s || d[0].serial);
+      })
+      .catch((e) => {
+        if (cancelled) return;
+        setUnavailable(e instanceof Error ? e.message : String(e));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [config]);
+
+  async function onCapture() {
+    setBusy(true);
+    setErr(null);
+    setDownloadID(null);
+    try {
+      const res = await captureFromTuner({
+        serial,
+        seconds: Number(seconds) || 1,
+        format,
+        protocol: protocol || undefined,
+      });
+      setDownloadID(res.capture.id);
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  if (unavailable) {
+    return (
+      <div className="card space-y-1">
+        <h3 className="text-sm font-semibold">Capture from tuner</h3>
+        <p className="text-xs text-muted">
+          Live capture is unavailable — connect the console to a running daemon with an SDR.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="card space-y-2">
+      <h3 className="text-sm font-semibold">Capture from tuner</h3>
+      <div>
+        <label className="label">SDR</label>
+        <select className="input" value={serial} onChange={(e) => setSerial(e.target.value)}>
+          {(devices ?? []).map((d) => (
+            <option key={d.serial} value={d.serial}>
+              {d.serial} · {d.driver}
+              {d.center_hz ? ` · ${(d.center_hz / 1e6).toFixed(3)} MHz` : ""}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div className="grid grid-cols-3 gap-2">
+        <div>
+          <label className="label">Seconds</label>
+          <input className="input" value={seconds} onChange={(e) => setSeconds(e.target.value)} />
+        </div>
+        <div>
+          <label className="label">Format</label>
+          <select className="input" value={format} onChange={(e) => setFormat(e.target.value)}>
+            {formats.map((f) => (
+              <option key={f} value={f}>
+                {f}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="label">Protocol</label>
+          <select
+            className="input"
+            value={protocol}
+            onChange={(e) => setProtocol(e.target.value)}
+          >
+            <option value="">(none)</option>
+            {protocols.map((p) => (
+              <option key={p} value={p}>
+                {p}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+      <button className="btn" disabled={busy || !serial} onClick={onCapture}>
+        {busy ? "Capturing…" : "Capture"}
+      </button>
+      {downloadID && (
+        <a
+          className="btn-ghost block text-center"
+          href={api.captureDownloadURL(config, downloadID)}
+        >
+          Download .cfile
+        </a>
+      )}
+      {err && <p className="text-xs text-err">{err}</p>}
+    </div>
   );
 }
 

--- a/web/siglab/src/store/shared.ts
+++ b/web/siglab/src/store/shared.ts
@@ -2,6 +2,8 @@ import { create } from "zustand";
 import { api, type ClientConfig } from "../api/client";
 import type {
   CaptureDTO,
+  CaptureRequest,
+  CaptureResponse,
   EventRecord,
   IQTaps,
   IdentifyResult,
@@ -41,6 +43,7 @@ interface Store {
   addCapture: (c: CaptureDTO) => void;
   uploadCapture: (file: File, format: string, sampleRateHz?: number) => Promise<CaptureDTO>;
   synthesize: (body: SynthRequest) => Promise<CaptureDTO>;
+  captureFromTuner: (req: CaptureRequest) => Promise<CaptureResponse>;
   removeCapture: (id: string) => Promise<void>;
   select: (id: string) => void;
   toggleCompare: (id: string) => void;
@@ -87,6 +90,12 @@ export const useStore = create<Store>((set, get) => ({
     const res = await api.synthesize(get().config, body);
     get().addCapture(res.capture);
     return res.capture;
+  },
+
+  captureFromTuner: async (req) => {
+    const res = await api.capture(get().config, req);
+    get().addCapture(res.capture);
+    return res;
   },
 
   removeCapture: async (id) => {


### PR DESCRIPTION
Close the gap where raw .cfile capture existed only as the daemon's
startup-only --iq-capture diagnostic (server-side path, no download).

CLI: new `gophertrunk capture` subcommand opens an SDR directly, records
N seconds of raw IQ to a GNU Radio f32 cfile (or rtl_sdr u8), and writes
a siglab .metadata.json sidecar so the capture is a drop-in fixture for
replay/analyze/test. Reuses the encodeF32/encodeU8 packers.

Runtime API + web UI: a CaptureProvider (mirroring SpectrumProvider over
the iqtap broker map) plus POST /api/v1/siglab/capture, GET
/api/v1/siglab/capture/devices, and GET
/api/v1/siglab/captures/{id}/download. A capture taps a live tuner,
stages the result into SigLab for immediate analysis, writes a metadata
sidecar, and hands back a .cfile download URL. A new "Capture from tuner"
control on the SigLab Captures panel drives it; routes return 503 when no
SDR is wired (offline `siglab serve`).

Adds tests for the capture stream loop, the API handler (stage + download
+ validation), and docs/CHANGELOG.

https://claude.ai/code/session_014r7pyW6S1fHqFkqA6QkuSm