### PR TITLE
sdr: add pure-Go SoapyRemote network source for high-bit-depth SDRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ for tagged releases.
 
 ### Added
 
+- **SoapySDRServer remote SDRs — high-bit-depth network streaming + control
+  from professional hardware (issue #536).** A new pure-Go (zero-CGO)
+  `soapyremote` SDR backend connects to a remote `SoapySDRServer` (from
+  pothosware/SoapyRemote) and mounts it as a virtual tuner alongside local
+  USB dongles and `rtl_tcp` endpoints. Unlike `rtl_tcp`'s hardcoded 8-bit
+  stream, it carries the full dynamic range of high-end radios — USRP,
+  LimeSDR, bladeRF, HackRF, Airspy, RTL-SDR, SDRplay — as 16-bit (`CS16`) or
+  32-bit float (`CF32`) IQ, with native frequency / sample-rate / gain
+  control over SoapyRemote's RPC protocol. Configure under `sdr.soapy_remote`
+  (addr/driver/serial/role/format/gain/…); the IQ stream uses the in-order
+  TCP transport. Chosen over the originally-proposed VITA 49.2 (VRT) because
+  SoapyRemote reaches the same professional hardware with a real,
+  interoperable control plane and a single maintained server binary.
 - **`gophertrunk capture` — record raw IQ off a live SDR to a `.cfile`.**
   A first-class subcommand that opens a dongle directly (no daemon),
   records the requested number of seconds of raw IQ to a GNU Radio cfile

--- a/README.md
+++ b/README.md
@@ -171,6 +171,12 @@ Silicon and Intel. Full per-OS recipes at
   endpoints as virtual tuners alongside local USB dongles. The
   SDR can live on a Raspberry Pi at the antenna while the daemon
   runs on a beefier host; one entry per remote in `sdr.rtl_tcp`.
+- **Remote SoapySDRServer SDRs** — Mount professional / high-bit-depth
+  hardware (USRP, LimeSDR, bladeRF, HackRF, Airspy, SDRplay, …) over the
+  network via the [SoapyRemote](https://github.com/pothosware/SoapyRemote)
+  protocol, in pure Go with no CGO. Carries 16/32-bit IQ with native
+  frequency / sample-rate / gain control; one entry per remote in
+  `sdr.soapy_remote`. See [docs/hardware.md](docs/hardware.md).
 - **Live spectrum / waterfall** — In-browser FFT waterfall served
   off the same IQ stream the trunking decoder consumes. New
   `internal/sdr/iqtap` multi-consumer fan-out lets future

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -39,6 +39,7 @@ import (
 	"github.com/MattCheramie/GopherTrunk/internal/sdr/baseband"
 	"github.com/MattCheramie/GopherTrunk/internal/sdr/iqtap"
 	"github.com/MattCheramie/GopherTrunk/internal/sdr/rtltcp"
+	"github.com/MattCheramie/GopherTrunk/internal/sdr/soapyremote"
 	"github.com/MattCheramie/GopherTrunk/internal/sdr/wbvoice"
 	"github.com/MattCheramie/GopherTrunk/internal/storage"
 	"github.com/MattCheramie/GopherTrunk/internal/trunking"
@@ -699,6 +700,57 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 			if len(rspecs) > 0 {
 				sdr.Register(rtltcp.New(rspecs, log))
 				log.Info("rtl_tcp endpoints mounted", "count", len(rspecs))
+			}
+		}
+		// Mount SoapySDRServer endpoints as virtual tuners. Same lazy
+		// pattern as rtl_tcp: the driver dials inside Pool.Open, so a
+		// down/misconfigured server surfaces as a warning rather than
+		// blocking startup. Per-endpoint Hint carries role / ppm / gain /
+		// bias-tee through the shared hint matcher.
+		if len(cfg.SDR.SoapyRemote) > 0 {
+			sspecs := make([]soapyremote.Spec, 0, len(cfg.SDR.SoapyRemote))
+			for _, s := range cfg.SDR.SoapyRemote {
+				if s.Addr == "" {
+					log.Warn("daemon: soapy_remote entry missing addr; skipping")
+					continue
+				}
+				var args map[string]string
+				if s.Driver != "" {
+					args = map[string]string{"driver": s.Driver}
+				}
+				sspecs = append(sspecs, soapyremote.Spec{
+					Addr:           s.Addr,
+					Serial:         s.Serial,
+					Role:           s.Role,
+					DeviceArgs:     args,
+					Format:         s.Format,
+					StreamProtocol: s.StreamProtocol,
+					ConnectTimeout: time.Duration(s.ConnectTimeoutMs) * time.Millisecond,
+				})
+				if s.Serial != "" {
+					h := sdr.Hint{
+						Serial:  s.Serial,
+						Role:    sdr.ParseRole(s.Role),
+						PPM:     s.PPM,
+						BiasTee: s.BiasTee,
+					}
+					if s.Gain != "" {
+						gain, ok := parseGain(s.Gain)
+						if !ok {
+							log.Warn("daemon: ignoring unparseable soapy_remote gain",
+								"serial", s.Serial, "gain", s.Gain)
+						} else {
+							warnGainUnits(log, s.Serial, s.Gain, gain)
+							warnLowGain(log, s.Serial, h.Role, s.Gain, gain)
+							h = h.WithGain(gain)
+						}
+					}
+					hints = append(hints, h)
+				}
+			}
+			if len(sspecs) > 0 {
+				sdr.Register(soapyremote.New(sspecs, log))
+				log.Info("soapy_remote endpoints mounted", "count", len(sspecs))
 			}
 		}
 		if err := d.pool.OpenWith(sdr.PoolOpenOptions{

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -279,6 +279,30 @@ sdr:
   #     bias_tee: false
   #     connect_timeout_ms: 3000
 
+  # SoapySDRServer remote SDRs. Each entry mounts a host:port
+  # SoapySDRServer (from pothosware/SoapyRemote) as a virtual tuner.
+  # Unlike rtl_tcp's hardcoded 8-bit stream, SoapyRemote carries the
+  # full dynamic range of high-end hardware — USRP, LimeSDR, bladeRF,
+  # HackRF, Airspy, RTL-SDR, SDRplay — as 16-bit (CS16) or 32-bit
+  # float (CF32) IQ, with native frequency / sample-rate / gain
+  # control. Run `SoapySDRServer --bind` on the host with the radio.
+  # Plaintext like rtl_tcp — keep it on trusted networks or behind a
+  # tunnel.
+  #
+  # soapy_remote:
+  #   - addr: "192.168.1.60:55132"  # bare host gets :55132 appended
+  #     driver: "uhd"               # SoapySDR device key: uhd | lime |
+  #                                 #  bladerf | hackrf | airspy | rtlsdr
+  #                                 #  (blank = server's first device)
+  #     serial: "usrp-roof"         # generator fills this from addr if blank
+  #     role: control               # control | voice | auto
+  #     format: "CS16"              # CS16 (16-bit, default) or CF32 (float)
+  #     stream_protocol: "tcp"      # tcp (default/only for now)
+  #     ppm: 0                      # best-effort (driver-dependent)
+  #     gain: "auto"                # "auto" or tenths-of-dB ("300" = 30.0 dB)
+  #     bias_tee: false             # best-effort (driver-dependent)
+  #     connect_timeout_ms: 3000
+
 # Paging decoders. Each entry dedicates one SDR to a paging
 # frequency and runs the per-protocol receiver. The SDR is tuned
 # directly to FrequencyHz (full sample-rate IQ, no DDC) — multi-

--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -21,6 +21,7 @@ transport (USBDEVFS on Linux, IOKit on macOS, WinUSB on Windows).
 | **Airspy R2 / Airspy Mini** | `airspy` | `0x1d50:0x60a1` | Wire-protocol-complete; on-air validation against attached hardware is the documented follow-up. |
 | **Airspy HF+ Discovery / HF+ Dual Port / legacy HF+** | `airspyhf` | `0x03eb:0x800c` | Wire-protocol-complete; HF (9 kHz – 31 MHz) + VHF (60 – 260 MHz). On-air validation against attached hardware is the documented follow-up. |
 | **rtl_tcp remote** (any librtlsdr-shipped server) | `rtltcp` | TCP | Remote RTL-SDR mounted over the network. See [Remote rtl_tcp SDRs](#remote-rtl_tcp-sdrs). |
+| **SoapySDRServer remote** (USRP / LimeSDR / bladeRF / HackRF / Airspy / RTL-SDR / SDRplay …) | `soapyremote` | TCP | Any SoapySDR-supported radio mounted over the network with 16/32-bit IQ + control. Wire-protocol-complete; on-air validation against a live `SoapySDRServer` is the documented follow-up. See [Remote SoapySDRServer SDRs](#remote-soapysdrserver-sdrs). |
 
 The HackRF and Airspy / Airspy HF+ drivers speak the documented
 libhackrf, libairspy, and libairspyhf USB vendor protocols directly
@@ -557,6 +558,65 @@ decoder all work against remote sources.
 on each successful Open, `dial: connection refused` if the remote
 isn't listening, and `header magic = "..."` if the address points
 at something that isn't an `rtl_tcp` server.
+
+## Remote SoapySDRServer SDRs
+
+`rtl_tcp` is hardcoded to 8-bit unsigned IQ, so it throws away the
+dynamic range of professional hardware. For high-bit-depth radios —
+Ettus USRP, LimeSDR, bladeRF, HackRF, Airspy, RTL-SDR, SDRplay, and
+anything else with a SoapySDR driver — GopherTrunk's `soapyremote`
+driver speaks the [SoapyRemote](https://github.com/pothosware/SoapyRemote)
+wire protocol directly, in pure Go with no CGO and no SoapySDR C
+libraries. It carries 16-bit (`CS16`) or 32-bit float (`CF32`) IQ and
+controls frequency, sample rate, and gain over SoapyRemote's RPC.
+
+Typical layout:
+
+- **Antenna host**: install SoapySDR + the device's Soapy module and
+  run `SoapySDRServer --bind` against the local radio (default port
+  55132).
+- **Daemon host**: list the endpoint under `sdr.soapy_remote` in
+  `config.yaml`.
+
+```yaml
+sdr:
+  sample_rate: 2_400_000
+  soapy_remote:
+    - addr: "192.168.1.60:55132"  # bare host gets :55132 appended
+      driver: "uhd"               # SoapySDR device key (blank = first device)
+      serial: "usrp-roof"         # generator fills this from addr when blank
+      role: control               # control | voice | auto
+      format: "CS16"              # CS16 (16-bit, default) or CF32 (float)
+      stream_protocol: "tcp"      # tcp (default/only for now)
+      ppm: 0                      # best-effort (driver-dependent)
+      gain: "auto"                # "auto" or tenths-of-dB ("300" = 30.0 dB)
+      bias_tee: false             # best-effort (driver-dependent)
+      connect_timeout_ms: 3000
+```
+
+Each entry becomes a pool device alongside any local USB dongles and
+`rtl_tcp` endpoints, roled through the same hint matcher, with the same
+broker / fan-out path.
+
+**Limitations:**
+
+- Receive only, single channel (channel 0).
+- The IQ stream uses SoapyRemote's in-order **TCP** transport
+  (`stream_protocol: tcp`). UDP streaming with the windowed flow-control
+  is a planned follow-up.
+- `ppm` (frequency correction) and `bias_tee` map to SoapySDR's
+  `setFrequencyCorrection` / `writeSetting` and silently no-op on
+  drivers that don't implement them.
+- Plaintext over TCP. Keep it on a trusted network, or tunnel it
+  through SSH / WireGuard / Tailscale.
+- The RPC and stream framing are byte-verified against SoapyRemote's
+  source; the TCP stream connection choreography should be validated
+  against a live `SoapySDRServer` before production use.
+
+**Diagnostics:** the daemon logs `soapyremote: connected addr=...
+format=... proto=...` on each successful Open, `make device:` with the
+remote exception text when the server can't open the requested device,
+and `dial: connection refused` if the server isn't listening.
 
 ## USB disconnect recovery
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -547,6 +547,15 @@ type SDRConfig struct {
 	// a beefier machine for decode). rtl_tcp is plaintext — use it
 	// on trusted networks only or through an SSH/wireguard tunnel.
 	RTLTCP []RTLTCPConfig `yaml:"rtl_tcp"`
+	// SoapyRemote lists remote SoapySDRServer endpoints to mount as
+	// virtual tuners. SoapySDRServer (from pothosware/SoapyRemote)
+	// exposes any SoapySDR-supported radio — USRP, LimeSDR, bladeRF,
+	// HackRF, Airspy, RTL-SDR, SDRplay — over the network with a real
+	// control plane and high bit depth (16-bit CS16 / 32-bit CF32),
+	// unlike rtl_tcp's hardcoded 8-bit stream. Each entry becomes one
+	// pool device. Plaintext like rtl_tcp — use on trusted networks
+	// only or through an SSH/wireguard tunnel.
+	SoapyRemote []SoapyRemoteConfig `yaml:"soapy_remote"`
 	// WatchdogIntervalMs governs the periodic USB-disconnect
 	// watchdog that the SDR pool runs while the daemon is up. It
 	// polls the registered drivers, surfaces serials that vanish
@@ -586,6 +595,43 @@ type RTLTCPConfig struct {
 	BiasTee bool `yaml:"bias_tee"`
 	// ConnectTimeoutMs caps the TCP dial in milliseconds. Zero
 	// picks the driver default (3000).
+	ConnectTimeoutMs int `yaml:"connect_timeout_ms"`
+}
+
+// SoapyRemoteConfig describes one remote SoapySDRServer endpoint to expose
+// as a virtual tuner. Addr is required; Serial / Role / PPM / Gain / BiasTee
+// follow the same semantics as the local SDR devices and rtl_tcp blocks.
+type SoapyRemoteConfig struct {
+	// Addr is the SoapySDRServer host:port, e.g. "192.168.1.60:55132".
+	// A bare host gets the default port (55132) appended. Required.
+	Addr string `yaml:"addr"`
+	// Driver is the SoapySDR device key used to select the radio on the
+	// server (e.g. "uhd", "lime", "bladerf", "hackrf", "airspy",
+	// "rtlsdr"). Empty selects the server's first/only device.
+	Driver string `yaml:"driver"`
+	// Serial is the virtual device serial reported on the pool's
+	// /api/v1/devices snapshot. Empty generates one from Addr.
+	Serial string `yaml:"serial"`
+	// Role hints the pool's role assignment: control|voice|auto.
+	Role string `yaml:"role"`
+	// Format is the requested wire sample format: "CS16" (16-bit, the
+	// default) or "CF32" (32-bit float). The server converts from the
+	// device's native format as needed.
+	Format string `yaml:"format"`
+	// StreamProtocol selects the stream transport. Only "tcp" (the
+	// default) is currently implemented.
+	StreamProtocol string `yaml:"stream_protocol"`
+	// PPM is the frequency-correction tuning applied on open (best-effort;
+	// ignored by SoapySDR drivers without frequency-correction support).
+	PPM int `yaml:"ppm"`
+	// Gain follows the same rule as DeviceConfig.Gain — "auto"/"" selects
+	// AGC, any other value parses as tenths of dB.
+	Gain string `yaml:"gain"`
+	// BiasTee toggles the remote device's bias-tee (best-effort; mapped to
+	// a SoapySDR writeSetting and ignored by drivers without the knob).
+	BiasTee bool `yaml:"bias_tee"`
+	// ConnectTimeoutMs caps the TCP dial in milliseconds. Zero picks the
+	// driver default (3000).
 	ConnectTimeoutMs int `yaml:"connect_timeout_ms"`
 }
 
@@ -1208,6 +1254,37 @@ func (c Config) Validate() error {
 				i, r.Serial, prev)
 		}
 		seenSerials[r.Serial] = i
+	}
+	// Validate SoapySDRServer endpoints. Same rules as rtl_tcp, plus the
+	// stream protocol and sample format must be ones the driver supports.
+	for i, s := range c.SDR.SoapyRemote {
+		if s.Addr == "" {
+			return fmt.Errorf("sdr.soapy_remote[%d]: addr is required (host:port)", i)
+		}
+		switch s.Role {
+		case "", "control", "voice", "auto":
+		default:
+			return fmt.Errorf("sdr.soapy_remote[%d]: role must be control|voice|auto", i)
+		}
+		switch s.Format {
+		case "", "CS16", "cs16", "CF32", "cf32":
+		default:
+			return fmt.Errorf("sdr.soapy_remote[%d]: format must be CS16 or CF32", i)
+		}
+		switch s.StreamProtocol {
+		case "", "tcp":
+		default:
+			return fmt.Errorf("sdr.soapy_remote[%d]: stream_protocol must be tcp", i)
+		}
+		if s.Serial == "" {
+			continue
+		}
+		if prev, dup := seenSerials[s.Serial]; dup {
+			return fmt.Errorf(
+				"sdr.soapy_remote[%d]: serial %q collides with sdr.devices[%d]",
+				i, s.Serial, prev)
+		}
+		seenSerials[s.Serial] = i
 	}
 	if c.Trunking.CallTimeoutMs < 0 {
 		return fmt.Errorf("trunking.call_timeout_ms: %d ms must be ≥ 0", c.Trunking.CallTimeoutMs)

--- a/internal/sdr/soapyremote/driver.go
+++ b/internal/sdr/soapyremote/driver.go
@@ -1,0 +1,537 @@
+// Package soapyremote implements an sdr.Driver that talks to a remote
+// SoapySDRServer (from pothosware/SoapyRemote) in pure Go, with no CGO and no
+// SoapySDR C libraries. SoapySDRServer exposes any SoapySDR-supported radio —
+// USRP, LimeSDR, bladeRF, HackRF, Airspy, RTL-SDR, SDRplay and more — over the
+// network with a real control plane, so GopherTrunk can demodulate trunked
+// systems from high-dynamic-range hardware that rtl_tcp's hardcoded 8-bit
+// stream cannot carry (issue #536).
+//
+// Two channels are used, mirroring SoapyRemote itself:
+//
+//   - A TCP RPC control socket (default port 55132) carries device creation,
+//     tuning, gain and stream setup as length-framed, type-tagged packets
+//     (see rpc.go).
+//   - A separate stream socket carries 24-byte-framed IQ datagrams (see
+//     stream.go). This driver implements the TCP stream transport, which is
+//     in-order and needs no UDP flow-control; the operator selects it with
+//     `stream_protocol: tcp` (the default). UDP streaming is a future
+//     addition (issue #536 phase 2).
+//
+// The wire format was reverse-engineered from SoapyRemote@master. The RPC and
+// datagram framing are byte-verified against the source; the TCP stream
+// connection choreography should be validated against a live SoapySDRServer
+// before relying on it in production.
+//
+// Limitations:
+//   - Single channel (channel 0), receive only.
+//   - SetPPM / SetBiasTee are best-effort: SoapySDR has no universal call for
+//     either, so they map to setFrequencyCorrection / writeSetting and silently
+//     no-op when the underlying driver doesn't support them.
+//   - Plaintext, like rtl_tcp. Use on trusted networks or through a tunnel.
+package soapyremote
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/sdr"
+)
+
+// DriverName is the sdr.Driver name registered with the pool.
+const DriverName = "soapyremote"
+
+// DefaultServicePort is SoapyRemote's default RPC port (SOAPY_REMOTE_DEFAULT_SERVICE).
+const DefaultServicePort = "55132"
+
+// DefaultConnectTimeout caps RPC dials and per-call round-trips.
+const DefaultConnectTimeout = 3 * time.Second
+
+// maxTransfer bounds a single stream transfer so a corrupt length field can't
+// trigger a huge allocation.
+const maxTransfer = 1 << 22 // 4 MiB
+
+var errClosed = errors.New("soapyremote: device closed")
+
+// Spec names one SoapySDRServer endpoint to expose as a virtual tuner.
+type Spec struct {
+	// Addr is the server host:port, e.g. "192.168.1.60:55132". A bare host
+	// gets DefaultServicePort appended. Required.
+	Addr string
+	// Serial is the virtual device serial the pool reports. Empty generates
+	// one from Addr so multi-endpoint configs stay unique.
+	Serial string
+	// Role hints the pool's role assignment: "control" | "voice" | "auto".
+	Role string
+	// DeviceArgs are the SoapySDR device-selection kwargs passed to MAKE,
+	// e.g. {"driver":"lime"} or {"serial":"..."}. Empty selects the server's
+	// first/only device.
+	DeviceArgs map[string]string
+	// Format is the requested wire sample format: "CS16" (default) or "CF32".
+	Format string
+	// StreamProtocol selects the stream transport: "tcp" (default/only).
+	StreamProtocol string
+	// ConnectTimeout overrides DefaultConnectTimeout when non-zero.
+	ConnectTimeout time.Duration
+}
+
+// Driver implements sdr.Driver over a set of SoapySDRServer endpoints.
+type Driver struct {
+	specs []Spec
+	log   *slog.Logger
+}
+
+// New builds a Driver over the given endpoints.
+func New(specs []Spec, log *slog.Logger) *Driver {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &Driver{specs: specs, log: log}
+}
+
+// Name implements sdr.Driver.
+func (d *Driver) Name() string { return DriverName }
+
+// Enumerate returns one Info per configured endpoint without probing — a
+// remote that's momentarily down stays in the pool and surfaces its error at
+// Open, matching the rtltcp driver's behaviour.
+func (d *Driver) Enumerate() ([]sdr.Info, error) {
+	out := make([]sdr.Info, 0, len(d.specs))
+	for i, spec := range d.specs {
+		if spec.Addr == "" {
+			continue
+		}
+		out = append(out, sdr.Info{
+			Driver:    DriverName,
+			Index:     i,
+			Serial:    serialFor(spec, i),
+			Product:   "SoapyRemote",
+			TunerName: deviceArgKey(spec.DeviceArgs),
+			Gains:     genericGainLadder(),
+		})
+	}
+	return out, nil
+}
+
+// Open dials the SoapySDRServer at spec[idx], makes the device, and returns a
+// Device ready for setters and StreamIQ.
+func (d *Driver) Open(idx int) (sdr.Device, error) {
+	if idx < 0 || idx >= len(d.specs) {
+		return nil, fmt.Errorf("soapyremote: index %d out of range", idx)
+	}
+	spec := d.specs[idx]
+	if spec.Addr == "" {
+		return nil, errors.New("soapyremote: spec missing Addr")
+	}
+	format, err := parseFormat(spec.Format)
+	if err != nil {
+		return nil, err
+	}
+	proto := spec.StreamProtocol
+	if proto == "" {
+		proto = "tcp"
+	}
+	if proto != "tcp" {
+		return nil, fmt.Errorf("soapyremote: stream_protocol %q not supported (only \"tcp\")", proto)
+	}
+	timeout := spec.ConnectTimeout
+	if timeout <= 0 {
+		timeout = DefaultConnectTimeout
+	}
+	addr := withDefaultPort(spec.Addr)
+
+	conn, err := net.DialTimeout("tcp", addr, timeout)
+	if err != nil {
+		return nil, fmt.Errorf("soapyremote: dial %s: %w", addr, err)
+	}
+	dev := &device{
+		addr:    addr,
+		format:  format,
+		proto:   proto,
+		timeout: timeout,
+		conn:    conn,
+		log:     d.log,
+		info: sdr.Info{
+			Driver:    DriverName,
+			Index:     idx,
+			Serial:    serialFor(spec, idx),
+			Product:   "SoapyRemote",
+			TunerName: deviceArgKey(spec.DeviceArgs),
+			Gains:     genericGainLadder(),
+		},
+	}
+	// Create the remote device.
+	if err := dev.rpcVoid(func(p *packer) {
+		p.call(callMake)
+		p.kwargs(spec.DeviceArgs)
+	}); err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("soapyremote: make device: %w", err)
+	}
+	// Best-effort: learn the native format for diagnostics.
+	if native, ok := dev.nativeStreamFormat(); ok {
+		dev.info.TunerName = native
+	}
+	d.log.Info("soapyremote: connected",
+		"addr", addr,
+		"format", format.soapyName(),
+		"proto", proto)
+	return dev, nil
+}
+
+// device implements sdr.Device over an open SoapySDRServer RPC connection.
+type device struct {
+	addr    string
+	format  sampleFormat
+	proto   string
+	timeout time.Duration
+	log     *slog.Logger
+	info    sdr.Info
+
+	mu       sync.Mutex
+	conn     net.Conn // RPC control socket
+	dataConn net.Conn // stream data socket (set in StreamIQ)
+	streamID string
+	closed   bool
+}
+
+func (d *device) Info() sdr.Info { return d.info }
+
+// rpc serializes one RPC round-trip on the control socket.
+func (d *device) rpc(build func(*packer)) (*unpacker, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.closed || d.conn == nil {
+		return nil, errClosed
+	}
+	p := newPacker()
+	build(p)
+	if err := p.writeTo(d.conn, d.timeout); err != nil {
+		return nil, err
+	}
+	return readResponse(d.conn, d.timeout)
+}
+
+// rpcVoid issues a call whose only meaningful response is success/exception.
+func (d *device) rpcVoid(build func(*packer)) error {
+	u, err := d.rpc(build)
+	if err != nil {
+		return err
+	}
+	return u.checkException()
+}
+
+// rpcBestEffort issues a call and downgrades a remote exception to a debug log,
+// returning nil — used for knobs not every SoapySDR driver implements.
+func (d *device) rpcBestEffort(what string, build func(*packer)) error {
+	if err := d.rpcVoid(build); err != nil {
+		if errors.Is(err, errClosed) {
+			return err
+		}
+		d.log.Debug("soapyremote: "+what+" not applied", "addr", d.addr, "err", err)
+	}
+	return nil
+}
+
+func (d *device) SetCenterFreq(hz uint32) error {
+	return d.rpcVoid(func(p *packer) {
+		p.call(callSetFrequency)
+		p.char(dirRX)
+		p.i32(0)
+		p.f64(float64(hz))
+		p.kwargs(nil)
+	})
+}
+
+func (d *device) SetSampleRate(hz uint32) error {
+	return d.rpcVoid(func(p *packer) {
+		p.call(callSetSampleRate)
+		p.char(dirRX)
+		p.i32(0)
+		p.f64(float64(hz))
+	})
+}
+
+func (d *device) SetGain(tenthDB int) error {
+	if tenthDB < 0 {
+		// Automatic gain control.
+		return d.rpcVoid(func(p *packer) {
+			p.call(callSetGainMode)
+			p.char(dirRX)
+			p.i32(0)
+			p.boolean(true)
+		})
+	}
+	// Manual gain: disable AGC, then set the overall gain in dB.
+	if err := d.rpcVoid(func(p *packer) {
+		p.call(callSetGainMode)
+		p.char(dirRX)
+		p.i32(0)
+		p.boolean(false)
+	}); err != nil {
+		return err
+	}
+	return d.rpcVoid(func(p *packer) {
+		p.call(callSetGain)
+		p.char(dirRX)
+		p.i32(0)
+		p.f64(float64(tenthDB) / 10.0) // GopherTrunk tenths-dB → SoapySDR dB
+	})
+}
+
+func (d *device) SetPPM(ppm int) error {
+	return d.rpcBestEffort("ppm", func(p *packer) {
+		p.call(callSetFrequencyCorrection)
+		p.char(dirRX)
+		p.i32(0)
+		p.f64(float64(ppm))
+	})
+}
+
+func (d *device) SetBiasTee(enable bool) error {
+	val := "false"
+	if enable {
+		val = "true"
+	}
+	return d.rpcBestEffort("bias_tee", func(p *packer) {
+		p.call(callWriteSetting)
+		p.str("biastee")
+		p.str(val)
+	})
+}
+
+// nativeStreamFormat asks the server for the device's native RX format. Used
+// only for diagnostics; returns ok=false if the call fails.
+func (d *device) nativeStreamFormat() (string, bool) {
+	u, err := d.rpc(func(p *packer) {
+		p.call(callGetNativeStreamFormat)
+		p.char(dirRX)
+		p.i32(0)
+	})
+	if err != nil || u.checkException() != nil {
+		return "", false
+	}
+	name, err := u.str()
+	if err != nil {
+		return "", false
+	}
+	return name, true
+}
+
+// StreamIQ sets up and activates an RX stream, then emits complex64 chunks from
+// the TCP stream socket. The channel closes when the context cancels or the
+// socket closes.
+func (d *device) StreamIQ(ctx context.Context) (<-chan []complex64, error) {
+	if d.proto != "tcp" {
+		return nil, fmt.Errorf("soapyremote: stream_protocol %q not supported", d.proto)
+	}
+	// SETUP_STREAM. clientBindPort/statusBindPort are unused in TCP mode
+	// (the client dials the server), so "0" is sent for both.
+	u, err := d.rpc(func(p *packer) {
+		p.call(callSetupStream)
+		p.char(dirRX)
+		p.str(d.format.soapyName())
+		p.sizeList([]int{0})
+		p.kwargs(map[string]string{"remote:prot": "tcp"})
+		p.str("0")
+		p.str("0")
+	})
+	if err != nil {
+		return nil, err
+	}
+	if err := u.checkException(); err != nil {
+		return nil, err
+	}
+	streamID, err := u.str()
+	if err != nil {
+		return nil, fmt.Errorf("soapyremote: setup stream id: %w", err)
+	}
+	serverPort, err := u.str()
+	if err != nil {
+		return nil, fmt.Errorf("soapyremote: setup stream port: %w", err)
+	}
+
+	host, _, err := net.SplitHostPort(d.addr)
+	if err != nil {
+		return nil, fmt.Errorf("soapyremote: split addr %q: %w", d.addr, err)
+	}
+	dataAddr := net.JoinHostPort(host, serverPort)
+	dataConn, err := net.DialTimeout("tcp", dataAddr, d.timeout)
+	if err != nil {
+		return nil, fmt.Errorf("soapyremote: dial stream %s: %w", dataAddr, err)
+	}
+
+	d.mu.Lock()
+	if d.closed {
+		d.mu.Unlock()
+		dataConn.Close()
+		return nil, errClosed
+	}
+	d.dataConn = dataConn
+	d.streamID = streamID
+	d.mu.Unlock()
+
+	// ACTIVATE_STREAM (flags=0, timeNs=0, numElems=0).
+	if err := d.rpcVoid(func(p *packer) {
+		p.call(callActivateStream)
+		p.str(streamID)
+		p.i32(0)
+		p.i64(0)
+		p.i32(0)
+	}); err != nil {
+		dataConn.Close()
+		return nil, err
+	}
+
+	out := make(chan []complex64, 8)
+	go d.streamLoop(ctx, dataConn, streamID, out)
+	return out, nil
+}
+
+func (d *device) streamLoop(ctx context.Context, dataConn net.Conn, streamID string, out chan<- []complex64) {
+	defer close(out)
+	defer d.teardownStream(streamID)
+
+	hdr := make([]byte, streamHeaderSize)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+		// Bounded deadline so a wedged server is torn down on ctx cancel.
+		_ = dataConn.SetReadDeadline(time.Now().Add(30 * time.Second))
+		if _, err := io.ReadFull(dataConn, hdr); err != nil {
+			if !errors.Is(err, io.EOF) && !errors.Is(err, io.ErrUnexpectedEOF) {
+				d.log.Debug("soapyremote: stream header read", "addr", d.addr, "err", err)
+			}
+			return
+		}
+		h := decodeStreamHeader(hdr)
+		if h.bytes < streamHeaderSize || h.bytes > maxTransfer {
+			d.log.Debug("soapyremote: bad transfer size", "addr", d.addr, "bytes", h.bytes)
+			return
+		}
+		payloadLen := int(h.bytes) - streamHeaderSize
+		var payload []byte
+		if payloadLen > 0 {
+			payload = make([]byte, payloadLen)
+			if _, err := io.ReadFull(dataConn, payload); err != nil {
+				if !errors.Is(err, io.EOF) && !errors.Is(err, io.ErrUnexpectedEOF) {
+					d.log.Debug("soapyremote: stream payload read", "addr", d.addr, "err", err)
+				}
+				return
+			}
+		}
+		if h.elems < 0 {
+			// Negative elems is a SoapySDR status/error code, not samples.
+			d.log.Debug("soapyremote: stream status code", "addr", d.addr, "code", h.elems)
+			continue
+		}
+		if payloadLen == 0 {
+			continue
+		}
+		samples := d.format.convert(payload)
+		if len(samples) == 0 {
+			continue
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case out <- samples:
+		}
+	}
+}
+
+// teardownStream best-effort deactivates and closes the remote stream and the
+// local data socket. Errors are ignored — the connection may already be gone.
+func (d *device) teardownStream(streamID string) {
+	_ = d.rpcVoid(func(p *packer) {
+		p.call(callDeactivateStream)
+		p.str(streamID)
+		p.i32(0)
+		p.i64(0)
+	})
+	_ = d.rpcVoid(func(p *packer) {
+		p.call(callCloseStream)
+		p.str(streamID)
+	})
+	d.mu.Lock()
+	if d.dataConn != nil {
+		d.dataConn.Close()
+		d.dataConn = nil
+	}
+	d.mu.Unlock()
+}
+
+func (d *device) Close() error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.closed {
+		return nil
+	}
+	d.closed = true
+	if d.dataConn != nil {
+		d.dataConn.Close()
+		d.dataConn = nil
+	}
+	if d.conn != nil {
+		return d.conn.Close()
+	}
+	return nil
+}
+
+// withDefaultPort appends DefaultServicePort to a bare host.
+func withDefaultPort(addr string) string {
+	if _, _, err := net.SplitHostPort(addr); err == nil {
+		return addr
+	}
+	return net.JoinHostPort(addr, DefaultServicePort)
+}
+
+func serialFor(spec Spec, idx int) string {
+	if spec.Serial != "" {
+		return spec.Serial
+	}
+	return fmt.Sprintf("soapy-%s-%02d", sanitizeAddr(spec.Addr), idx)
+}
+
+func sanitizeAddr(addr string) string {
+	out := make([]byte, 0, len(addr))
+	for i := 0; i < len(addr); i++ {
+		c := addr[i]
+		switch {
+		case c >= 'a' && c <= 'z', c >= 'A' && c <= 'Z', c >= '0' && c <= '9':
+			out = append(out, c)
+		case c == '-' || c == '_':
+			out = append(out, c)
+		default:
+			out = append(out, '_')
+		}
+	}
+	return string(out)
+}
+
+// deviceArgKey returns the SoapySDR driver key for display, defaulting to the
+// driver name when no kwargs were given.
+func deviceArgKey(args map[string]string) string {
+	if d, ok := args["driver"]; ok && d != "" {
+		return d
+	}
+	return "soapy"
+}
+
+// genericGainLadder returns a coarse 0..50 dB ladder (tenths of dB). SoapySDR
+// gain is continuous; this is only a hint for UI/validation.
+func genericGainLadder() []int {
+	out := make([]int, 0, 11)
+	for g := 0; g <= 500; g += 50 {
+		out = append(out, g)
+	}
+	return out
+}

--- a/internal/sdr/soapyremote/driver_test.go
+++ b/internal/sdr/soapyremote/driver_test.go
@@ -89,6 +89,11 @@ func (s *fakeSoapyServer) handleRPC(conn net.Conn) {
 			return
 		}
 		rec := recordedCall{id: id}
+		// activateSID is signalled to the data goroutine only AFTER the
+		// call is recorded below; otherwise the client can receive IQ and
+		// the test can check sawCall(ACTIVATE) before this loop records it.
+		var activateSID string
+		var doActivate bool
 		switch id {
 		case callSetFrequency:
 			_, _ = u.char()
@@ -124,10 +129,8 @@ func (s *fakeSoapyServer) handleRPC(conn net.Conn) {
 		case callActivateStream:
 			sid, _ := u.str()
 			s.respond(conn, func(p *packer) { p.raw8(tVoid) })
-			select {
-			case activate <- sid:
-			default:
-			}
+			activateSID = sid
+			doActivate = true
 		default:
 			// MAKE, DEACTIVATE, CLOSE, WRITE_SETTING, FREQ_CORRECTION, ...
 			s.respond(conn, func(p *packer) { p.raw8(tVoid) })
@@ -135,6 +138,12 @@ func (s *fakeSoapyServer) handleRPC(conn net.Conn) {
 		s.mu.Lock()
 		s.calls = append(s.calls, rec)
 		s.mu.Unlock()
+		if doActivate {
+			select {
+			case activate <- activateSID:
+			default:
+			}
+		}
 	}
 }
 

--- a/internal/sdr/soapyremote/driver_test.go
+++ b/internal/sdr/soapyremote/driver_test.go
@@ -1,0 +1,344 @@
+package soapyremote
+
+import (
+	"context"
+	"encoding/binary"
+	"io"
+	"log/slog"
+	"net"
+	"sync"
+	"testing"
+	"time"
+)
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// fakeSoapyServer mimics a SoapySDRServer well enough to exercise the driver:
+// it speaks the RPC framing, records every call (with decoded numeric args for
+// the tuning calls), and on SETUP/ACTIVATE serves synthetic CS16 stream
+// datagrams over a TCP data socket.
+type fakeSoapyServer struct {
+	t  *testing.T
+	ln net.Listener
+
+	mu    sync.Mutex
+	calls []recordedCall
+
+	// samples streamed per datagram once activated.
+	streamSamples []complex64
+}
+
+type recordedCall struct {
+	id       int32
+	freqHz   float64
+	gainDB   float64
+	gainAuto bool
+}
+
+func newFakeSoapyServer(t *testing.T) *fakeSoapyServer {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	s := &fakeSoapyServer{t: t, ln: ln}
+	go s.acceptLoop()
+	t.Cleanup(func() { _ = ln.Close() })
+	return s
+}
+
+func (s *fakeSoapyServer) Addr() string { return s.ln.Addr().String() }
+
+func (s *fakeSoapyServer) recorded() []recordedCall {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]recordedCall, len(s.calls))
+	copy(out, s.calls)
+	return out
+}
+
+func (s *fakeSoapyServer) sawCall(id int32) bool {
+	for _, c := range s.recorded() {
+		if c.id == id {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *fakeSoapyServer) acceptLoop() {
+	conn, err := s.ln.Accept()
+	if err != nil {
+		return
+	}
+	go s.handleRPC(conn)
+}
+
+func (s *fakeSoapyServer) handleRPC(conn net.Conn) {
+	defer conn.Close()
+	activate := make(chan string, 1) // streamID -> start streaming
+	for {
+		u, err := readResponse(conn, 0)
+		if err != nil {
+			return
+		}
+		id, err := u.call()
+		if err != nil {
+			return
+		}
+		rec := recordedCall{id: id}
+		switch id {
+		case callSetFrequency:
+			_, _ = u.char()
+			_, _ = u.i32()
+			rec.freqHz, _ = u.f64()
+			s.respond(conn, func(p *packer) { p.raw8(tVoid) })
+		case callSetSampleRate:
+			_, _ = u.char()
+			_, _ = u.i32()
+			rec.freqHz, _ = u.f64()
+			s.respond(conn, func(p *packer) { p.raw8(tVoid) })
+		case callSetGain:
+			_, _ = u.char()
+			_, _ = u.i32()
+			rec.gainDB, _ = u.f64()
+			s.respond(conn, func(p *packer) { p.raw8(tVoid) })
+		case callSetGainMode:
+			_, _ = u.char()
+			_, _ = u.i32()
+			rec.gainAuto, _ = u.boolean()
+			s.respond(conn, func(p *packer) { p.raw8(tVoid) })
+		case callGetNativeStreamFormat:
+			s.respond(conn, func(p *packer) {
+				p.str("CS16")
+				p.f64(1.0)
+			})
+		case callSetupStream:
+			dataPort := s.startDataServer(activate)
+			s.respond(conn, func(p *packer) {
+				p.str("0") // streamId
+				p.str(dataPort)
+			})
+		case callActivateStream:
+			sid, _ := u.str()
+			s.respond(conn, func(p *packer) { p.raw8(tVoid) })
+			select {
+			case activate <- sid:
+			default:
+			}
+		default:
+			// MAKE, DEACTIVATE, CLOSE, WRITE_SETTING, FREQ_CORRECTION, ...
+			s.respond(conn, func(p *packer) { p.raw8(tVoid) })
+		}
+		s.mu.Lock()
+		s.calls = append(s.calls, rec)
+		s.mu.Unlock()
+	}
+}
+
+func (s *fakeSoapyServer) respond(conn net.Conn, build func(*packer)) {
+	p := newPacker()
+	build(p)
+	if err := p.writeTo(conn, 0); err != nil {
+		s.t.Logf("fake respond: %v", err)
+	}
+}
+
+// startDataServer binds a TCP data listener and, once activated, streams
+// repeating CS16 datagrams of s.streamSamples. Returns the bound port.
+func (s *fakeSoapyServer) startDataServer(activate <-chan string) string {
+	dataLn, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		s.t.Fatalf("data listen: %v", err)
+	}
+	_, port, _ := net.SplitHostPort(dataLn.Addr().String())
+	go func() {
+		defer dataLn.Close()
+		conn, err := dataLn.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		<-activate // wait until ACTIVATE_STREAM
+		seq := uint32(0)
+		for {
+			payload := encodeCS16(s.streamSamples)
+			hdr := encodeStreamHeader(streamHeader{
+				bytes:    uint32(streamHeaderSize + len(payload)),
+				sequence: seq,
+				elems:    int32(len(s.streamSamples)),
+			})
+			if _, err := conn.Write(append(hdr, payload...)); err != nil {
+				return
+			}
+			seq++
+			time.Sleep(time.Millisecond)
+		}
+	}()
+	return port
+}
+
+func encodeCS16(samples []complex64) []byte {
+	buf := make([]byte, 0, len(samples)*4)
+	for _, c := range samples {
+		iv := int16(real(c) * 32768)
+		qv := int16(imag(c) * 32768)
+		var b [4]byte
+		binary.LittleEndian.PutUint16(b[0:], uint16(iv))
+		binary.LittleEndian.PutUint16(b[2:], uint16(qv))
+		buf = append(buf, b[:]...)
+	}
+	return buf
+}
+
+func TestOpenAndSetters(t *testing.T) {
+	srv := newFakeSoapyServer(t)
+	drv := New([]Spec{{Addr: srv.Addr(), Format: "CS16"}}, testLogger())
+
+	infos, err := drv.Enumerate()
+	if err != nil || len(infos) != 1 {
+		t.Fatalf("Enumerate: infos=%d err=%v", len(infos), err)
+	}
+
+	dev, err := drv.Open(0)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer dev.Close()
+
+	if !srv.sawCall(callMake) {
+		t.Error("server did not see MAKE")
+	}
+
+	if err := dev.SetCenterFreq(851000000); err != nil {
+		t.Fatalf("SetCenterFreq: %v", err)
+	}
+	if err := dev.SetSampleRate(2400000); err != nil {
+		t.Fatalf("SetSampleRate: %v", err)
+	}
+	if err := dev.SetGain(300); err != nil { // 30.0 dB
+		t.Fatalf("SetGain: %v", err)
+	}
+	if err := dev.SetGain(-1); err != nil { // AGC
+		t.Fatalf("SetGain(AGC): %v", err)
+	}
+
+	var sawFreq, sawRate, sawGainManual, sawGainAuto bool
+	for _, c := range srv.recorded() {
+		switch c.id {
+		case callSetFrequency:
+			if c.freqHz == 851000000 {
+				sawFreq = true
+			}
+		case callSetSampleRate:
+			if c.freqHz == 2400000 {
+				sawRate = true
+			}
+		case callSetGain:
+			if c.gainDB == 30.0 {
+				sawGainManual = true
+			}
+		case callSetGainMode:
+			if c.gainAuto {
+				sawGainAuto = true
+			}
+		}
+	}
+	if !sawFreq {
+		t.Error("SET_FREQUENCY with 851 MHz not recorded")
+	}
+	if !sawRate {
+		t.Error("SET_SAMPLE_RATE with 2.4 MS/s not recorded")
+	}
+	if !sawGainManual {
+		t.Error("SET_GAIN with 30.0 dB not recorded")
+	}
+	if !sawGainAuto {
+		t.Error("SET_GAIN_MODE(auto=true) not recorded")
+	}
+}
+
+func TestStreamIQ(t *testing.T) {
+	srv := newFakeSoapyServer(t)
+	srv.streamSamples = []complex64{
+		complex(0.5, -0.5),
+		complex(0.25, 0.25),
+		complex(-1, 0.75),
+	}
+	drv := New([]Spec{{Addr: srv.Addr(), Format: "CS16"}}, testLogger())
+	dev, err := drv.Open(0)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer dev.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ch, err := dev.StreamIQ(ctx)
+	if err != nil {
+		t.Fatalf("StreamIQ: %v", err)
+	}
+
+	select {
+	case got, ok := <-ch:
+		if !ok {
+			t.Fatal("stream channel closed before any data")
+		}
+		if len(got) != len(srv.streamSamples) {
+			t.Fatalf("chunk len = %d, want %d", len(got), len(srv.streamSamples))
+		}
+		for i, want := range srv.streamSamples {
+			if absDiff(got[i], want) > 1e-3 {
+				t.Errorf("sample %d = %v, want ~%v", i, got[i], want)
+			}
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for IQ")
+	}
+
+	if !srv.sawCall(callSetupStream) {
+		t.Error("server did not see SETUP_STREAM")
+	}
+	if !srv.sawCall(callActivateStream) {
+		t.Error("server did not see ACTIVATE_STREAM")
+	}
+
+	// Cancelling the context must close the channel.
+	cancel()
+	drain := time.After(2 * time.Second)
+	for {
+		select {
+		case _, ok := <-ch:
+			if !ok {
+				return // closed — success
+			}
+		case <-drain:
+			t.Fatal("stream channel not closed after ctx cancel")
+		}
+	}
+}
+
+func TestOpenRejectsUDP(t *testing.T) {
+	srv := newFakeSoapyServer(t)
+	drv := New([]Spec{{Addr: srv.Addr(), StreamProtocol: "udp"}}, testLogger())
+	if _, err := drv.Open(0); err == nil {
+		t.Fatal("expected Open to reject udp stream_protocol")
+	}
+}
+
+func absDiff(a, b complex64) float64 {
+	dr := float64(real(a) - real(b))
+	di := float64(imag(a) - imag(b))
+	if dr < 0 {
+		dr = -dr
+	}
+	if di < 0 {
+		di = -di
+	}
+	if dr > di {
+		return dr
+	}
+	return di
+}

--- a/internal/sdr/soapyremote/rpc.go
+++ b/internal/sdr/soapyremote/rpc.go
@@ -1,0 +1,352 @@
+package soapyremote
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"net"
+	"sort"
+	"time"
+)
+
+// SoapyRemote RPC wire format (reverse-engineered from pothosware/SoapyRemote
+// @master, common/SoapyRPCPacket.hpp + SoapyRPCPacker.cpp + SoapyRPCUnpacker.cpp).
+//
+// Every RPC message is: 12-byte header + payload + 4-byte trailer, all framed
+// integers big-endian (network order):
+//
+//	header  = headerWord uint32 ("SRPC") | version uint32 | length uint32
+//	trailer = trailerWord uint32 ("CPRS")
+//
+// length is the TOTAL message size, INCLUDING header and trailer.
+//
+// The payload is a sequence of type-tagged values. Each value starts with a
+// 1-byte type tag (SoapyRemoteTypes) followed by a body. Crucially there are
+// no "bare" integers: every nested integer carries its own INT32/INT64 tag.
+// So e.g. a CALL is [CALL][INT32 tag][id], a STRING is [STRING][INT32 tag]
+// [len][raw bytes], and a FLOAT64 is [FLOAT64][INT32 tag][exp][INT64 tag][man].
+const (
+	rpcHeaderWord  uint32 = 0x53525043 // "SRPC"
+	rpcTrailerWord uint32 = 0x43505253 // "CPRS"
+	rpcVersion     uint32 = 0x000400
+	rpcHeaderSize         = 12
+	rpcTrailerSize        = 4
+)
+
+// SoapyRemoteTypes — the 1-byte value type tags.
+const (
+	tChar       byte = 0
+	tBool       byte = 1
+	tInt32      byte = 2
+	tInt64      byte = 3
+	tFloat64    byte = 4
+	tComplex128 byte = 5
+	tString     byte = 6
+	tRange      byte = 7
+	tRangeList  byte = 8
+	tStringList byte = 9
+	tFloat64Lst byte = 10
+	tKwargs     byte = 11
+	tKwargsList byte = 12
+	tException  byte = 13
+	tVoid       byte = 14
+	tCall       byte = 15
+	tSizeList   byte = 16
+	tArgInfo    byte = 17
+	tArgInfoLst byte = 18
+)
+
+// SoapyRemoteCalls — the subset of RPC call IDs this client issues.
+const (
+	callFind                   int32 = 0
+	callMake                   int32 = 1
+	callUnmake                 int32 = 2
+	callHangup                 int32 = 3
+	callGetServerID            int32 = 20
+	callGetHardwareKey         int32 = 101
+	callSetupStream            int32 = 300
+	callCloseStream            int32 = 301
+	callActivateStream         int32 = 302
+	callDeactivateStream       int32 = 303
+	callGetNativeStreamFormat  int32 = 305
+	callSetFrequencyCorrection int32 = 504
+	callSetGainMode            int32 = 701
+	callSetGain                int32 = 703
+	callSetFrequency           int32 = 800
+	callSetSampleRate          int32 = 900
+	callWriteSetting           int32 = 1400
+)
+
+// dirRX is SoapySDR's SOAPY_SDR_RX direction (TX is 0).
+const dirRX byte = 1
+
+// dblMantDig mirrors C's DBL_MANT_DIG used in the frexp/ldexp double codec.
+const dblMantDig = 53
+
+// packer builds one RPC message. The first rpcHeaderSize bytes are reserved
+// for the header (filled in by writeTo); values append after.
+type packer struct {
+	buf []byte
+}
+
+func newPacker() *packer {
+	return &packer{buf: make([]byte, rpcHeaderSize, 128)}
+}
+
+func (p *packer) raw8(b byte)     { p.buf = append(p.buf, b) }
+func (p *packer) rawU32(v uint32) { p.buf = binary.BigEndian.AppendUint32(p.buf, v) }
+func (p *packer) rawU64(v uint64) { p.buf = binary.BigEndian.AppendUint64(p.buf, v) }
+
+// taggedI32 / taggedI64 write a self-tagged integer, matching the C++
+// operator&(int) / operator&(long long).
+func (p *packer) taggedI32(v int32) { p.raw8(tInt32); p.rawU32(uint32(v)) }
+func (p *packer) taggedI64(v int64) { p.raw8(tInt64); p.rawU64(uint64(v)) }
+
+func (p *packer) call(id int32) { p.raw8(tCall); p.taggedI32(id) }
+func (p *packer) char(c byte)   { p.raw8(tChar); p.raw8(c) }
+
+func (p *packer) boolean(b bool) {
+	p.raw8(tBool)
+	if b {
+		p.raw8(1)
+	} else {
+		p.raw8(0)
+	}
+}
+
+func (p *packer) i32(v int32) { p.taggedI32(v) }
+func (p *packer) i64(v int64) { p.taggedI64(v) }
+
+// f64 packs a double exactly as SoapyRemote does: the raw frexp exponent as a
+// tagged int32 and the ldexp(frac, DBL_MANT_DIG) mantissa as a tagged int64.
+// The (long long) cast in C truncates toward zero; int64(float64) in Go does
+// the same, so the round-trip is bit-identical.
+func (p *packer) f64(v float64) {
+	p.raw8(tFloat64)
+	frac, exp := math.Frexp(v)
+	man := int64(math.Ldexp(frac, dblMantDig))
+	p.taggedI32(int32(exp))
+	p.taggedI64(man)
+}
+
+func (p *packer) str(s string) {
+	p.raw8(tString)
+	p.taggedI32(int32(len(s)))
+	p.buf = append(p.buf, s...)
+}
+
+func (p *packer) sizeList(v []int) {
+	p.raw8(tSizeList)
+	p.taggedI32(int32(len(v)))
+	for _, x := range v {
+		p.taggedI32(int32(x))
+	}
+}
+
+// kwargs packs a map. Keys are sorted so the wire bytes are deterministic
+// (the server rebuilds an unordered map, so order is purely cosmetic, but
+// determinism keeps tests stable).
+func (p *packer) kwargs(m map[string]string) {
+	p.raw8(tKwargs)
+	p.taggedI32(int32(len(m)))
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		p.str(k)
+		p.str(m[k])
+	}
+}
+
+// writeTo finalizes the message (length + trailer) and writes it to conn under
+// the given deadline.
+func (p *packer) writeTo(conn net.Conn, timeout time.Duration) error {
+	p.rawU32(rpcTrailerWord) // trailer
+	total := uint32(len(p.buf))
+	binary.BigEndian.PutUint32(p.buf[0:4], rpcHeaderWord)
+	binary.BigEndian.PutUint32(p.buf[4:8], rpcVersion)
+	binary.BigEndian.PutUint32(p.buf[8:12], total)
+	if timeout > 0 {
+		_ = conn.SetWriteDeadline(time.Now().Add(timeout))
+		defer conn.SetWriteDeadline(time.Time{})
+	}
+	if _, err := conn.Write(p.buf); err != nil {
+		return fmt.Errorf("soapyremote: write rpc: %w", err)
+	}
+	return nil
+}
+
+// unpacker reads tagged values out of an RPC response payload (header and
+// trailer already stripped).
+type unpacker struct {
+	buf []byte
+	off int
+}
+
+var errShortResponse = errors.New("soapyremote: short rpc response")
+
+func (u *unpacker) peekTag() (byte, bool) {
+	if u.off >= len(u.buf) {
+		return 0, false
+	}
+	return u.buf[u.off], true
+}
+
+func (u *unpacker) tag() (byte, error) {
+	if u.off >= len(u.buf) {
+		return 0, errShortResponse
+	}
+	t := u.buf[u.off]
+	u.off++
+	return t, nil
+}
+
+func (u *unpacker) expect(want byte) error {
+	t, err := u.tag()
+	if err != nil {
+		return err
+	}
+	if t != want {
+		return fmt.Errorf("soapyremote: rpc type tag %d, want %d", t, want)
+	}
+	return nil
+}
+
+func (u *unpacker) u32() (uint32, error) {
+	if u.off+4 > len(u.buf) {
+		return 0, errShortResponse
+	}
+	v := binary.BigEndian.Uint32(u.buf[u.off:])
+	u.off += 4
+	return v, nil
+}
+
+func (u *unpacker) i32() (int32, error) {
+	if err := u.expect(tInt32); err != nil {
+		return 0, err
+	}
+	v, err := u.u32()
+	return int32(v), err
+}
+
+func (u *unpacker) char() (byte, error) {
+	if err := u.expect(tChar); err != nil {
+		return 0, err
+	}
+	return u.tag() // a raw byte follows the CHAR tag; reuse tag() to read one
+}
+
+func (u *unpacker) boolean() (bool, error) {
+	if err := u.expect(tBool); err != nil {
+		return false, err
+	}
+	b, err := u.tag()
+	return b != 0, err
+}
+
+func (u *unpacker) call() (int32, error) {
+	if err := u.expect(tCall); err != nil {
+		return 0, err
+	}
+	return u.i32()
+}
+
+func (u *unpacker) u64() (uint64, error) {
+	if u.off+8 > len(u.buf) {
+		return 0, errShortResponse
+	}
+	v := binary.BigEndian.Uint64(u.buf[u.off:])
+	u.off += 8
+	return v, nil
+}
+
+func (u *unpacker) i64() (int64, error) {
+	if err := u.expect(tInt64); err != nil {
+		return 0, err
+	}
+	v, err := u.u64()
+	return int64(v), err
+}
+
+func (u *unpacker) f64() (float64, error) {
+	if err := u.expect(tFloat64); err != nil {
+		return 0, err
+	}
+	exp, err := u.i32()
+	if err != nil {
+		return 0, err
+	}
+	if err := u.expect(tInt64); err != nil {
+		return 0, err
+	}
+	man, err := u.u64()
+	if err != nil {
+		return 0, err
+	}
+	return math.Ldexp(float64(int64(man)), int(exp)-dblMantDig), nil
+}
+
+func (u *unpacker) str() (string, error) {
+	if err := u.expect(tString); err != nil {
+		return "", err
+	}
+	n, err := u.i32()
+	if err != nil {
+		return "", err
+	}
+	if n < 0 || u.off+int(n) > len(u.buf) {
+		return "", errShortResponse
+	}
+	s := string(u.buf[u.off : u.off+int(n)])
+	u.off += int(n)
+	return s, nil
+}
+
+// checkException returns a non-nil error if the response leads with a
+// SOAPY_REMOTE_EXCEPTION value (the server's way of reporting a failed call).
+// It is a no-op for VOID and normal return values.
+func (u *unpacker) checkException() error {
+	t, ok := u.peekTag()
+	if !ok || t != tException {
+		return nil
+	}
+	u.off++ // consume exception tag
+	msg, err := u.str()
+	if err != nil {
+		return fmt.Errorf("soapyremote: remote exception (unreadable): %w", err)
+	}
+	return fmt.Errorf("soapyremote: remote exception: %s", msg)
+}
+
+// readResponse reads one framed RPC response off conn and returns an unpacker
+// over its payload.
+func readResponse(conn net.Conn, timeout time.Duration) (*unpacker, error) {
+	if timeout > 0 {
+		_ = conn.SetReadDeadline(time.Now().Add(timeout))
+		defer conn.SetReadDeadline(time.Time{})
+	}
+	var hdr [rpcHeaderSize]byte
+	if _, err := io.ReadFull(conn, hdr[:]); err != nil {
+		return nil, fmt.Errorf("soapyremote: read rpc header: %w", err)
+	}
+	if got := binary.BigEndian.Uint32(hdr[0:4]); got != rpcHeaderWord {
+		return nil, fmt.Errorf("soapyremote: rpc header magic %#08x, want %#08x", got, rpcHeaderWord)
+	}
+	length := binary.BigEndian.Uint32(hdr[8:12])
+	if length < rpcHeaderSize+rpcTrailerSize {
+		return nil, fmt.Errorf("soapyremote: rpc length %d too small", length)
+	}
+	body := make([]byte, length-rpcHeaderSize)
+	if _, err := io.ReadFull(conn, body); err != nil {
+		return nil, fmt.Errorf("soapyremote: read rpc body: %w", err)
+	}
+	trailer := binary.BigEndian.Uint32(body[len(body)-rpcTrailerSize:])
+	if trailer != rpcTrailerWord {
+		return nil, fmt.Errorf("soapyremote: rpc trailer %#08x, want %#08x", trailer, rpcTrailerWord)
+	}
+	return &unpacker{buf: body[:len(body)-rpcTrailerSize]}, nil
+}

--- a/internal/sdr/soapyremote/rpc_test.go
+++ b/internal/sdr/soapyremote/rpc_test.go
@@ -1,0 +1,122 @@
+package soapyremote
+
+import (
+	"math"
+	"net"
+	"testing"
+)
+
+// roundtrip serializes the values written by build through the real framing
+// (header + trailer) over an in-memory pipe and returns an unpacker over the
+// decoded payload.
+func roundtrip(t *testing.T, build func(*packer)) *unpacker {
+	t.Helper()
+	c1, c2 := net.Pipe()
+	p := newPacker()
+	build(p)
+	go func() {
+		_ = p.writeTo(c1, 0)
+		_ = c1.Close()
+	}()
+	u, err := readResponse(c2, 0)
+	if err != nil {
+		t.Fatalf("readResponse: %v", err)
+	}
+	_ = c2.Close()
+	return u
+}
+
+func TestFloat64RoundTrip(t *testing.T) {
+	// Values that matter for tuning: center frequencies, sample rates,
+	// gains. Integers below 2^53 must round-trip bit-exactly through the
+	// frexp/ldexp codec; fractionals to within a tiny epsilon.
+	cases := []float64{0, 1, -1, 30.0, 49.6, 2400000, 851000000, 1296000000.5, -123.25}
+	for _, want := range cases {
+		u := roundtrip(t, func(p *packer) { p.f64(want) })
+		got, err := u.f64()
+		if err != nil {
+			t.Fatalf("f64(%v): %v", want, err)
+		}
+		if math.Abs(got-want) > 1e-6 {
+			t.Errorf("f64 round-trip: got %v, want %v", got, want)
+		}
+	}
+}
+
+func TestIntegerAndStringRoundTrip(t *testing.T) {
+	u := roundtrip(t, func(p *packer) {
+		p.call(callSetFrequency)
+		p.char(dirRX)
+		p.i32(-7)
+		p.i64(1 << 40)
+		p.str("")
+		p.str("hello world")
+		p.boolean(true)
+	})
+	if id, err := u.call(); err != nil || id != callSetFrequency {
+		t.Fatalf("call: id=%d err=%v", id, err)
+	}
+	if c, err := u.char(); err != nil || c != dirRX {
+		t.Fatalf("char: %d err=%v", c, err)
+	}
+	if v, err := u.i32(); err != nil || v != -7 {
+		t.Fatalf("i32: %d err=%v", v, err)
+	}
+	if v, err := u.i64(); err != nil || v != 1<<40 {
+		t.Fatalf("i64: %d err=%v", v, err)
+	}
+	if s, err := u.str(); err != nil || s != "" {
+		t.Fatalf("str empty: %q err=%v", s, err)
+	}
+	if s, err := u.str(); err != nil || s != "hello world" {
+		t.Fatalf("str: %q err=%v", s, err)
+	}
+	if b, err := u.boolean(); err != nil || !b {
+		t.Fatalf("boolean: %v err=%v", b, err)
+	}
+}
+
+func TestStringValues(t *testing.T) {
+	u := roundtrip(t, func(p *packer) {
+		p.str("CS16")
+		p.str("55140")
+	})
+	a, err := u.str()
+	if err != nil || a != "CS16" {
+		t.Fatalf("str a: %q err=%v", a, err)
+	}
+	b, err := u.str()
+	if err != nil || b != "55140" {
+		t.Fatalf("str b: %q err=%v", b, err)
+	}
+}
+
+func TestCheckExceptionDetectsRemoteError(t *testing.T) {
+	u := roundtrip(t, func(p *packer) {
+		p.raw8(tException)
+		p.str("device not found")
+	})
+	err := u.checkException()
+	if err == nil {
+		t.Fatal("checkException: expected error, got nil")
+	}
+	if want := "device not found"; !contains(err.Error(), want) {
+		t.Errorf("checkException error %q does not contain %q", err.Error(), want)
+	}
+}
+
+func TestCheckExceptionPassesVoid(t *testing.T) {
+	u := roundtrip(t, func(p *packer) { p.raw8(tVoid) })
+	if err := u.checkException(); err != nil {
+		t.Errorf("checkException on VOID: %v", err)
+	}
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/sdr/soapyremote/stream.go
+++ b/internal/sdr/soapyremote/stream.go
@@ -1,0 +1,103 @@
+package soapyremote
+
+import (
+	"encoding/binary"
+	"fmt"
+	"math"
+)
+
+// Stream datagram wire format (common/SoapyStreamEndpoint.cpp). Every transfer
+// (one UDP datagram, or one framed unit on a TCP stream socket) begins with a
+// 24-byte header. The header's integer fields are network byte order; the IQ
+// sample payload that follows is copied RAW (native little-endian on the
+// x86/ARM hosts that run SoapySDRServer) and is NOT byte-swapped.
+const streamHeaderSize = 24
+
+// streamHeader is the decoded 24-byte datagram header.
+type streamHeader struct {
+	bytes    uint32 // total transfer size including this header
+	sequence uint32 // sender's monotonically increasing sequence
+	elems    int32  // element count per channel, or a negative SoapySDR error code
+	flags    int32  // SOAPY_SDR_* stream flags
+	time     int64  // timestamp (ns)
+}
+
+func decodeStreamHeader(b []byte) streamHeader {
+	return streamHeader{
+		bytes:    binary.BigEndian.Uint32(b[0:4]),
+		sequence: binary.BigEndian.Uint32(b[4:8]),
+		elems:    int32(binary.BigEndian.Uint32(b[8:12])),
+		flags:    int32(binary.BigEndian.Uint32(b[12:16])),
+		time:     int64(binary.BigEndian.Uint64(b[16:24])),
+	}
+}
+
+// sampleFormat identifies the wire sample encoding the server was asked to send.
+type sampleFormat int
+
+const (
+	formatCS16 sampleFormat = iota // interleaved little-endian int16 I,Q
+	formatCF32                     // interleaved little-endian float32 I,Q
+)
+
+// soapyName returns the SoapySDR format string for the SETUP_STREAM call.
+func (f sampleFormat) soapyName() string {
+	if f == formatCF32 {
+		return "CF32"
+	}
+	return "CS16"
+}
+
+// bytesPerSample is the size of one complex sample on the wire.
+func (f sampleFormat) bytesPerSample() int {
+	if f == formatCF32 {
+		return 8
+	}
+	return 4
+}
+
+func parseFormat(s string) (sampleFormat, error) {
+	switch s {
+	case "", "CS16", "cs16":
+		return formatCS16, nil
+	case "CF32", "cf32":
+		return formatCF32, nil
+	default:
+		return 0, fmt.Errorf("soapyremote: unsupported format %q (want CS16 or CF32)", s)
+	}
+}
+
+// convert turns one raw sample-payload buffer into complex64 normalized to
+// roughly [-1, 1), matching every other GopherTrunk SDR backend.
+func (f sampleFormat) convert(buf []byte) []complex64 {
+	if f == formatCF32 {
+		return convertCF32(buf)
+	}
+	return convertCS16(buf)
+}
+
+// convertCS16 maps interleaved little-endian int16 I,Q to complex64.
+// Mirrors baseband.decodeIQ16 / rtltcp.convertU8 normalization.
+func convertCS16(buf []byte) []complex64 {
+	n := len(buf) / 4
+	out := make([]complex64, n)
+	for i := 0; i < n; i++ {
+		iv := int16(binary.LittleEndian.Uint16(buf[4*i:]))
+		qv := int16(binary.LittleEndian.Uint16(buf[4*i+2:]))
+		out[i] = complex(float32(iv)/32768, float32(qv)/32768)
+	}
+	return out
+}
+
+// convertCF32 maps interleaved little-endian float32 I,Q to complex64. The
+// server already delivers samples in the conventional [-1, 1] float range.
+func convertCF32(buf []byte) []complex64 {
+	n := len(buf) / 8
+	out := make([]complex64, n)
+	for i := 0; i < n; i++ {
+		iv := math.Float32frombits(binary.LittleEndian.Uint32(buf[8*i:]))
+		qv := math.Float32frombits(binary.LittleEndian.Uint32(buf[8*i+4:]))
+		out[i] = complex(iv, qv)
+	}
+	return out
+}

--- a/internal/sdr/soapyremote/stream_test.go
+++ b/internal/sdr/soapyremote/stream_test.go
@@ -1,0 +1,91 @@
+package soapyremote
+
+import (
+	"encoding/binary"
+	"math"
+	"testing"
+)
+
+// encodeStreamHeader builds the 24-byte datagram header (network byte order),
+// mirroring what a SoapySDRServer sends. Shared with the fake server in
+// driver_test.go.
+func encodeStreamHeader(h streamHeader) []byte {
+	b := make([]byte, streamHeaderSize)
+	binary.BigEndian.PutUint32(b[0:4], h.bytes)
+	binary.BigEndian.PutUint32(b[4:8], h.sequence)
+	binary.BigEndian.PutUint32(b[8:12], uint32(h.elems))
+	binary.BigEndian.PutUint32(b[12:16], uint32(h.flags))
+	binary.BigEndian.PutUint64(b[16:24], uint64(h.time))
+	return b
+}
+
+func TestStreamHeaderRoundTrip(t *testing.T) {
+	want := streamHeader{bytes: 1452, sequence: 42, elems: 357, flags: 4, time: 1234567890}
+	got := decodeStreamHeader(encodeStreamHeader(want))
+	if got != want {
+		t.Errorf("decodeStreamHeader: got %+v, want %+v", got, want)
+	}
+}
+
+func TestStreamHeaderNegativeElems(t *testing.T) {
+	// A negative elems is a SoapySDR error/status code, not a sample count.
+	want := streamHeader{bytes: 24, sequence: 7, elems: -4, flags: 0, time: 0}
+	got := decodeStreamHeader(encodeStreamHeader(want))
+	if got.elems != -4 {
+		t.Errorf("elems: got %d, want -4", got.elems)
+	}
+}
+
+func TestConvertCS16(t *testing.T) {
+	// Two samples: (16384, -16384) -> (0.5, -0.5); (32767, -32768) -> ~(1, -1).
+	buf := make([]byte, 8)
+	for i, v := range []int16{16384, -16384, 32767, -32768} {
+		binary.LittleEndian.PutUint16(buf[2*i:], uint16(v))
+	}
+	got := convertCS16(buf)
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2", len(got))
+	}
+	if real(got[0]) != 0.5 || imag(got[0]) != -0.5 {
+		t.Errorf("sample 0 = %v, want (0.5,-0.5)", got[0])
+	}
+	if math.Abs(float64(real(got[1]))-0.99997) > 1e-3 || imag(got[1]) != -1 {
+		t.Errorf("sample 1 = %v, want ~(1,-1)", got[1])
+	}
+}
+
+func TestConvertCF32(t *testing.T) {
+	buf := make([]byte, 8)
+	binary.LittleEndian.PutUint32(buf[0:], math.Float32bits(0.25))
+	binary.LittleEndian.PutUint32(buf[4:], math.Float32bits(-0.75))
+	got := convertCF32(buf)
+	if len(got) != 1 {
+		t.Fatalf("len = %d, want 1", len(got))
+	}
+	if real(got[0]) != 0.25 || imag(got[0]) != -0.75 {
+		t.Errorf("sample = %v, want (0.25,-0.75)", got[0])
+	}
+}
+
+func TestParseFormat(t *testing.T) {
+	for _, c := range []struct {
+		in   string
+		want sampleFormat
+		ok   bool
+	}{
+		{"", formatCS16, true},
+		{"CS16", formatCS16, true},
+		{"CF32", formatCF32, true},
+		{"cf32", formatCF32, true},
+		{"CU8", 0, false},
+	} {
+		got, err := parseFormat(c.in)
+		if c.ok != (err == nil) {
+			t.Errorf("parseFormat(%q): err=%v, wantOK=%v", c.in, err, c.ok)
+			continue
+		}
+		if c.ok && got != c.want {
+			t.Errorf("parseFormat(%q) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
Adds a soapyremote sdr.Driver that connects to a remote SoapySDRServer
(pothosware/SoapyRemote) and mounts it as a virtual tuner, addressing
issue #536's goal of high-bit-depth network streaming + control from
professional hardware (USRP, LimeSDR, bladeRF, HackRF, Airspy, RTL-SDR,
SDRplay).

Unlike rtl_tcp's hardcoded 8-bit stream, this carries 16-bit (CS16) or
32-bit float (CF32) IQ with native frequency/sample-rate/gain control,
implemented in pure Go (no CGO, no SoapySDR C libraries) over net +
encoding/binary. The RPC packet codec (frexp-encoded doubles, tagged
values, SRPC/CPRS framing) and the 24-byte stream datagram format are
byte-verified against the SoapyRemote source. The IQ stream uses the
in-order TCP transport; UDP is a planned follow-up.

Chosen over the originally-proposed VITA 49.2 (VRT): SoapyRemote reaches
the same professional hardware with a real, interoperable control plane
and a single maintained server binary, whereas VITA 49.2's control plane
is immature/non-interoperable and needs a per-device proxy regardless.

- internal/sdr/soapyremote: driver, rpc codec, stream decode + tests
  (fake SoapySDRServer exercises Open/setters/StreamIQ, race-clean)
- config: sdr.soapy_remote block + validation
- daemon: lazy registration mirroring the rtl_tcp wiring
- docs/README/CHANGELOG/config.example.yaml