### PR TITLE
soapyremote: fix TCP stream setup handshake and manual gain (#542)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,26 @@ for tagged releases.
   the console is offline (`siglab serve`) or the daemon has no SDR, so a
   build without a tuner doesn't pretend it can record.
 
+### Fixed
+
+- **`soapyremote`: stream setup now follows SoapyRemote's real TCP
+  handshake, fixing a crash against live `SoapySDRServer` hardware (issue
+  #542).** The TCP stream setup was a single-reply, single-socket guess; real
+  SoapyRemote is a two-phase, two-socket exchange (the server replies with the
+  data port, accepts both a stream **and** a status socket, then replies with
+  the integer stream id). The old code misread the first reply (`setup stream
+  port: short rpc response`), which kicked the daemon into a reconnect storm
+  that could segfault the remote UHD/USRP server. Setup now opens both sockets,
+  reads the stream id as an int, and allows a longer deadline for cold high-end
+  devices that spend seconds compiling their RFNoC graph. Verified against the
+  upstream source; smoke-test against live hardware before relying on it.
+- **`soapyremote`: a manual `gain` now applies on front-ends without AGC
+  (issue #542).** Setting a numeric gain first disabled automatic gain control;
+  on radios with no AGC at all (e.g. a USRP TwinRX) that call fails with
+  `set_rx_agc() is not supported on this radio` and used to abort the whole
+  gain set, leaving the device at its default. Disabling AGC is now best-effort,
+  so the manual gain value is still applied.
+
 ## [v0.3.2] — 2026-06-04
 
 DMR grows up — multi-slot, Tier III band-plan voice, and license-free

--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -602,15 +602,20 @@ broker / fan-out path.
 
 - Receive only, single channel (channel 0).
 - The IQ stream uses SoapyRemote's in-order **TCP** transport
-  (`stream_protocol: tcp`). UDP streaming with the windowed flow-control
-  is a planned follow-up.
+  (`stream_protocol: tcp`), which opens two sockets to the server (a stream
+  socket and a status socket, matching `SoapySDRServer`'s setup). UDP
+  streaming with the windowed flow-control is a planned follow-up.
 - `ppm` (frequency correction) and `bias_tee` map to SoapySDR's
   `setFrequencyCorrection` / `writeSetting` and silently no-op on
   drivers that don't implement them.
+- `gain` is applied as a manual overall gain. AGC is disabled first on a
+  best-effort basis, so a numeric gain still applies on front-ends that have
+  no AGC at all (e.g. a USRP TwinRX, which rejects `set_rx_agc()`); use
+  `gain: "auto"` to request AGC where the radio supports it.
 - Plaintext over TCP. Keep it on a trusted network, or tunnel it
   through SSH / WireGuard / Tailscale.
-- The RPC and stream framing are byte-verified against SoapyRemote's
-  source; the TCP stream connection choreography should be validated
+- The RPC, stream framing, and TCP stream-setup choreography are byte-matched
+  to SoapyRemote's source and exercised by the driver's tests; validate
   against a live `SoapySDRServer` before production use.
 
 **Diagnostics:** the daemon logs `soapyremote: connected addr=...

--- a/internal/sdr/soapyremote/driver.go
+++ b/internal/sdr/soapyremote/driver.go
@@ -12,15 +12,16 @@
 //     tuning, gain and stream setup as length-framed, type-tagged packets
 //     (see rpc.go).
 //   - A separate stream socket carries 24-byte-framed IQ datagrams (see
-//     stream.go). This driver implements the TCP stream transport, which is
-//     in-order and needs no UDP flow-control; the operator selects it with
+//     stream.go), plus a second "status" socket the server requires alongside
+//     it. This driver implements the TCP stream transport, which is in-order
+//     and needs no UDP flow-control; the operator selects it with
 //     `stream_protocol: tcp` (the default). UDP streaming is a future
 //     addition (issue #536 phase 2).
 //
-// The wire format was reverse-engineered from SoapyRemote@master. The RPC and
-// datagram framing are byte-verified against the source; the TCP stream
-// connection choreography should be validated against a live SoapySDRServer
-// before relying on it in production.
+// The wire format was reverse-engineered from SoapyRemote@master and the RPC,
+// datagram framing, and TCP stream setup choreography are byte-matched to the
+// source (client/Streaming.cpp + server/ClientHandler.cpp). It is exercised by
+// a fake server in the tests; validate against live hardware before release.
 //
 // Limitations:
 //   - Single channel (channel 0), receive only.
@@ -51,6 +52,12 @@ const DefaultServicePort = "55132"
 
 // DefaultConnectTimeout caps RPC dials and per-call round-trips.
 const DefaultConnectTimeout = 3 * time.Second
+
+// streamSetupTimeout bounds the per-frame reads during TCP stream setup. It is
+// deliberately longer than the per-call RPC timeout because a cold high-end
+// device (e.g. a USRP X310) spends several seconds compiling its RFNoC graph
+// inside the server's setupStream before it replies (issue #542).
+const streamSetupTimeout = 30 * time.Second
 
 // maxTransfer bounds a single stream transfer so a corrupt length field can't
 // trigger a huge allocation.
@@ -193,11 +200,12 @@ type device struct {
 	log     *slog.Logger
 	info    sdr.Info
 
-	mu       sync.Mutex
-	conn     net.Conn // RPC control socket
-	dataConn net.Conn // stream data socket (set in StreamIQ)
-	streamID string
-	closed   bool
+	mu         sync.Mutex
+	conn       net.Conn // RPC control socket
+	dataConn   net.Conn // stream data socket (set in StreamIQ)
+	statusConn net.Conn // stream status socket (the server requires it; we drain it)
+	streamID   int32
+	closed     bool
 }
 
 func (d *device) Info() sdr.Info { return d.info }
@@ -267,15 +275,18 @@ func (d *device) SetGain(tenthDB int) error {
 			p.boolean(true)
 		})
 	}
-	// Manual gain: disable AGC, then set the overall gain in dB.
-	if err := d.rpcVoid(func(p *packer) {
+	// Manual gain: best-effort disable AGC, then set the overall gain in dB.
+	// Disabling AGC maps to setGainMode(false); on front-ends with no AGC at
+	// all (e.g. a USRP TwinRX) the server rejects it with "set_rx_agc() is not
+	// supported on this radio". That must not abort the manual setGain that
+	// follows — setGain is the call that actually applies the configured gain
+	// (issue #542).
+	_ = d.rpcBestEffort("disable agc", func(p *packer) {
 		p.call(callSetGainMode)
 		p.char(dirRX)
 		p.i32(0)
 		p.boolean(false)
-	}); err != nil {
-		return err
-	}
+	})
 	return d.rpcVoid(func(p *packer) {
 		p.call(callSetGain)
 		p.char(dirRX)
@@ -330,70 +341,153 @@ func (d *device) StreamIQ(ctx context.Context) (<-chan []complex64, error) {
 	if d.proto != "tcp" {
 		return nil, fmt.Errorf("soapyremote: stream_protocol %q not supported", d.proto)
 	}
-	// SETUP_STREAM. clientBindPort/statusBindPort are unused in TCP mode
-	// (the client dials the server), so "0" is sent for both.
-	u, err := d.rpc(func(p *packer) {
-		p.call(callSetupStream)
-		p.char(dirRX)
-		p.str(d.format.soapyName())
-		p.sizeList([]int{0})
-		p.kwargs(map[string]string{"remote:prot": "tcp"})
-		p.str("0")
-		p.str("0")
-	})
+	streamID, dataConn, statusConn, err := d.setupStreamTCP()
 	if err != nil {
 		return nil, err
 	}
-	if err := u.checkException(); err != nil {
-		return nil, err
-	}
-	streamID, err := u.str()
-	if err != nil {
-		return nil, fmt.Errorf("soapyremote: setup stream id: %w", err)
-	}
-	serverPort, err := u.str()
-	if err != nil {
-		return nil, fmt.Errorf("soapyremote: setup stream port: %w", err)
-	}
 
-	host, _, err := net.SplitHostPort(d.addr)
-	if err != nil {
-		return nil, fmt.Errorf("soapyremote: split addr %q: %w", d.addr, err)
-	}
-	dataAddr := net.JoinHostPort(host, serverPort)
-	dataConn, err := net.DialTimeout("tcp", dataAddr, d.timeout)
-	if err != nil {
-		return nil, fmt.Errorf("soapyremote: dial stream %s: %w", dataAddr, err)
-	}
-
-	d.mu.Lock()
-	if d.closed {
-		d.mu.Unlock()
-		dataConn.Close()
-		return nil, errClosed
-	}
-	d.dataConn = dataConn
-	d.streamID = streamID
-	d.mu.Unlock()
-
-	// ACTIVATE_STREAM (flags=0, timeNs=0, numElems=0).
+	// ACTIVATE_STREAM (streamId, flags=0, timeNs=0, numElems=0).
 	if err := d.rpcVoid(func(p *packer) {
 		p.call(callActivateStream)
-		p.str(streamID)
+		p.i32(streamID)
 		p.i32(0)
 		p.i64(0)
 		p.i32(0)
 	}); err != nil {
-		dataConn.Close()
+		d.clearStreamConns()
 		return nil, err
 	}
 
+	go d.drainStatus(statusConn)
 	out := make(chan []complex64, 8)
 	go d.streamLoop(ctx, dataConn, streamID, out)
 	return out, nil
 }
 
-func (d *device) streamLoop(ctx context.Context, dataConn net.Conn, streamID string, out chan<- []complex64) {
+// setupStreamTCP performs SoapyRemote's two-phase TCP stream setup. The wire
+// choreography is byte-matched to upstream (client/Streaming.cpp +
+// server/ClientHandler.cpp):
+//
+//  1. send SETUP_STREAM;
+//  2. read reply #1 — the server's bound data port (a single string);
+//  3. dial TWO sockets to that port, the data socket then the status socket:
+//     the server does listen(2) and blocks accepting both, in that order;
+//  4. read reply #2 — the int stream id (plus a repeated port string we
+//     discard).
+//
+// The whole exchange holds d.mu so no other RPC interleaves on the control
+// socket between the two reply frames. On success the data/status sockets and
+// stream id are stored on the device for teardown.
+func (d *device) setupStreamTCP() (streamID int32, dataConn, statusConn net.Conn, err error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.closed || d.conn == nil {
+		return 0, nil, nil, errClosed
+	}
+
+	// (1) SETUP_STREAM. clientBindPort/statusBindPort are unused in TCP mode
+	// (the client dials the server), so "0" is sent for both.
+	p := newPacker()
+	p.call(callSetupStream)
+	p.char(dirRX)
+	p.str(d.format.soapyName())
+	p.sizeList([]int{0})
+	p.kwargs(map[string]string{"remote:prot": "tcp"})
+	p.str("0")
+	p.str("0")
+	if err := p.writeTo(d.conn, streamSetupTimeout); err != nil {
+		return 0, nil, nil, err
+	}
+
+	// (2) Reply #1: the server's bound data port.
+	u, err := readResponse(d.conn, streamSetupTimeout)
+	if err != nil {
+		return 0, nil, nil, err
+	}
+	if err := u.checkException(); err != nil {
+		return 0, nil, nil, err
+	}
+	serverPort, err := u.str()
+	if err != nil {
+		return 0, nil, nil, fmt.Errorf("soapyremote: setup stream port: %w", err)
+	}
+
+	host, _, err := net.SplitHostPort(d.addr)
+	if err != nil {
+		return 0, nil, nil, fmt.Errorf("soapyremote: split addr %q: %w", d.addr, err)
+	}
+	dataAddr := net.JoinHostPort(host, serverPort)
+
+	// (3) Dial the data socket then the status socket. The server's two accepts
+	// are ordered: first connection is the stream, second is the status channel.
+	dataConn, err = net.DialTimeout("tcp", dataAddr, d.timeout)
+	if err != nil {
+		return 0, nil, nil, fmt.Errorf("soapyremote: dial stream %s: %w", dataAddr, err)
+	}
+	statusConn, err = net.DialTimeout("tcp", dataAddr, d.timeout)
+	if err != nil {
+		dataConn.Close()
+		return 0, nil, nil, fmt.Errorf("soapyremote: dial status %s: %w", dataAddr, err)
+	}
+
+	// (4) Reply #2: the int stream id (and a repeated port string we ignore).
+	u2, err := readResponse(d.conn, streamSetupTimeout)
+	if err != nil {
+		dataConn.Close()
+		statusConn.Close()
+		return 0, nil, nil, err
+	}
+	if err := u2.checkException(); err != nil {
+		dataConn.Close()
+		statusConn.Close()
+		return 0, nil, nil, err
+	}
+	streamID, err = u2.i32()
+	if err != nil {
+		dataConn.Close()
+		statusConn.Close()
+		return 0, nil, nil, fmt.Errorf("soapyremote: setup stream id: %w", err)
+	}
+
+	if d.closed {
+		dataConn.Close()
+		statusConn.Close()
+		return 0, nil, nil, errClosed
+	}
+	d.dataConn = dataConn
+	d.statusConn = statusConn
+	d.streamID = streamID
+	return streamID, dataConn, statusConn, nil
+}
+
+// drainStatus reads and discards the stream's status socket. SoapyRemote's
+// server status thread may emit messages over it; leaving it unread can
+// back-pressure the server. It returns when the socket is closed (on teardown).
+func (d *device) drainStatus(statusConn net.Conn) {
+	buf := make([]byte, 256)
+	for {
+		if _, err := statusConn.Read(buf); err != nil {
+			return
+		}
+	}
+}
+
+// clearStreamConns closes and forgets the data/status sockets. Used when
+// activation fails after setup; teardownStream handles the normal path.
+func (d *device) clearStreamConns() {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.dataConn != nil {
+		d.dataConn.Close()
+		d.dataConn = nil
+	}
+	if d.statusConn != nil {
+		d.statusConn.Close()
+		d.statusConn = nil
+	}
+}
+
+func (d *device) streamLoop(ctx context.Context, dataConn net.Conn, streamID int32, out chan<- []complex64) {
 	defer close(out)
 	defer d.teardownStream(streamID)
 
@@ -449,24 +543,20 @@ func (d *device) streamLoop(ctx context.Context, dataConn net.Conn, streamID str
 }
 
 // teardownStream best-effort deactivates and closes the remote stream and the
-// local data socket. Errors are ignored — the connection may already be gone.
-func (d *device) teardownStream(streamID string) {
+// local data/status sockets. Errors are ignored — the connection may already be
+// gone.
+func (d *device) teardownStream(streamID int32) {
 	_ = d.rpcVoid(func(p *packer) {
 		p.call(callDeactivateStream)
-		p.str(streamID)
+		p.i32(streamID)
 		p.i32(0)
 		p.i64(0)
 	})
 	_ = d.rpcVoid(func(p *packer) {
 		p.call(callCloseStream)
-		p.str(streamID)
+		p.i32(streamID)
 	})
-	d.mu.Lock()
-	if d.dataConn != nil {
-		d.dataConn.Close()
-		d.dataConn = nil
-	}
-	d.mu.Unlock()
+	d.clearStreamConns()
 }
 
 func (d *device) Close() error {
@@ -479,6 +569,10 @@ func (d *device) Close() error {
 	if d.dataConn != nil {
 		d.dataConn.Close()
 		d.dataConn = nil
+	}
+	if d.statusConn != nil {
+		d.statusConn.Close()
+		d.statusConn = nil
 	}
 	if d.conn != nil {
 		return d.conn.Close()

--- a/internal/sdr/soapyremote/driver_test.go
+++ b/internal/sdr/soapyremote/driver_test.go
@@ -28,6 +28,10 @@ type fakeSoapyServer struct {
 
 	// samples streamed per datagram once activated.
 	streamSamples []complex64
+
+	// failGainMode makes SET_GAIN_MODE reply with a remote exception, mimicking
+	// a UHD front-end with no AGC ("set_rx_agc() is not supported"). Issue #542.
+	failGainMode bool
 }
 
 type recordedCall struct {
@@ -78,7 +82,7 @@ func (s *fakeSoapyServer) acceptLoop() {
 
 func (s *fakeSoapyServer) handleRPC(conn net.Conn) {
 	defer conn.Close()
-	activate := make(chan string, 1) // streamID -> start streaming
+	activate := make(chan struct{}, 1) // signal: start streaming
 	for {
 		u, err := readResponse(conn, 0)
 		if err != nil {
@@ -89,10 +93,9 @@ func (s *fakeSoapyServer) handleRPC(conn net.Conn) {
 			return
 		}
 		rec := recordedCall{id: id}
-		// activateSID is signalled to the data goroutine only AFTER the
+		// doActivate is signalled to the data goroutine only AFTER the
 		// call is recorded below; otherwise the client can receive IQ and
 		// the test can check sawCall(ACTIVATE) before this loop records it.
-		var activateSID string
 		var doActivate bool
 		switch id {
 		case callSetFrequency:
@@ -114,22 +117,33 @@ func (s *fakeSoapyServer) handleRPC(conn net.Conn) {
 			_, _ = u.char()
 			_, _ = u.i32()
 			rec.gainAuto, _ = u.boolean()
-			s.respond(conn, func(p *packer) { p.raw8(tVoid) })
+			if s.failGainMode {
+				s.respond(conn, func(p *packer) {
+					p.raw8(tException)
+					p.str("RuntimeError: NotImplementedError: set_rx_agc() is not supported on this radio!")
+				})
+			} else {
+				s.respond(conn, func(p *packer) { p.raw8(tVoid) })
+			}
 		case callGetNativeStreamFormat:
 			s.respond(conn, func(p *packer) {
 				p.str("CS16")
 				p.f64(1.0)
 			})
 		case callSetupStream:
-			dataPort := s.startDataServer(activate)
-			s.respond(conn, func(p *packer) {
-				p.str("0") // streamId
+			// Real SoapyRemote TCP setup is two-phase: reply #1 is the bound
+			// data port, the server then accepts two client sockets (stream +
+			// status), and reply #2 carries the int stream id. Issue #542.
+			dataPort, bothConnected := s.startDataServer(activate)
+			s.respond(conn, func(p *packer) { p.str(dataPort) }) // reply #1
+			<-bothConnected
+			s.respond(conn, func(p *packer) { // reply #2
+				p.i32(0) // streamId (int)
 				p.str(dataPort)
 			})
 		case callActivateStream:
-			sid, _ := u.str()
+			_, _ = u.i32() // streamId (int)
 			s.respond(conn, func(p *packer) { p.raw8(tVoid) })
-			activateSID = sid
 			doActivate = true
 		default:
 			// MAKE, DEACTIVATE, CLOSE, WRITE_SETTING, FREQ_CORRECTION, ...
@@ -140,7 +154,7 @@ func (s *fakeSoapyServer) handleRPC(conn net.Conn) {
 		s.mu.Unlock()
 		if doActivate {
 			select {
-			case activate <- activateSID:
+			case activate <- struct{}{}:
 			default:
 			}
 		}
@@ -155,21 +169,31 @@ func (s *fakeSoapyServer) respond(conn net.Conn, build func(*packer)) {
 	}
 }
 
-// startDataServer binds a TCP data listener and, once activated, streams
-// repeating CS16 datagrams of s.streamSamples. Returns the bound port.
-func (s *fakeSoapyServer) startDataServer(activate <-chan string) string {
+// startDataServer binds a TCP data listener that accepts the stream socket then
+// the status socket (matching the server's listen(2) / two-accept choreography),
+// and once activated streams repeating CS16 datagrams of s.streamSamples on the
+// stream socket while draining the status socket. Returns the bound port and a
+// channel closed once both sockets have connected. Issue #542.
+func (s *fakeSoapyServer) startDataServer(activate <-chan struct{}) (string, <-chan struct{}) {
 	dataLn, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		s.t.Fatalf("data listen: %v", err)
 	}
 	_, port, _ := net.SplitHostPort(dataLn.Addr().String())
+	bothConnected := make(chan struct{})
 	go func() {
 		defer dataLn.Close()
-		conn, err := dataLn.Accept()
+		streamConn, err := dataLn.Accept()
 		if err != nil {
 			return
 		}
-		defer conn.Close()
+		defer streamConn.Close()
+		statusConn, err := dataLn.Accept()
+		if err != nil {
+			return
+		}
+		defer statusConn.Close()
+		close(bothConnected)
 		<-activate // wait until ACTIVATE_STREAM
 		seq := uint32(0)
 		for {
@@ -179,14 +203,14 @@ func (s *fakeSoapyServer) startDataServer(activate <-chan string) string {
 				sequence: seq,
 				elems:    int32(len(s.streamSamples)),
 			})
-			if _, err := conn.Write(append(hdr, payload...)); err != nil {
+			if _, err := streamConn.Write(append(hdr, payload...)); err != nil {
 				return
 			}
 			seq++
 			time.Sleep(time.Millisecond)
 		}
 	}()
-	return port
+	return port, bothConnected
 }
 
 func encodeCS16(samples []complex64) []byte {
@@ -266,6 +290,36 @@ func TestOpenAndSetters(t *testing.T) {
 	}
 	if !sawGainAuto {
 		t.Error("SET_GAIN_MODE(auto=true) not recorded")
+	}
+}
+
+// TestSetGainManualSurvivesAGCException covers issue #542: on a front-end with
+// no AGC (e.g. a USRP TwinRX), disabling gain mode throws "set_rx_agc() is not
+// supported". The manual setGain that follows must still run and succeed so the
+// configured gain is actually applied — the AGC-disable is best-effort.
+func TestSetGainManualSurvivesAGCException(t *testing.T) {
+	srv := newFakeSoapyServer(t)
+	srv.failGainMode = true
+	drv := New([]Spec{{Addr: srv.Addr(), Format: "CS16"}}, testLogger())
+
+	dev, err := drv.Open(0)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer dev.Close()
+
+	if err := dev.SetGain(750); err != nil { // 75.0 dB, like the issue's gain=750
+		t.Fatalf("SetGain must not fail when AGC-disable is unsupported: %v", err)
+	}
+
+	var sawGainManual bool
+	for _, c := range srv.recorded() {
+		if c.id == callSetGain && c.gainDB == 75.0 {
+			sawGainManual = true
+		}
+	}
+	if !sawGainManual {
+		t.Error("SET_GAIN with 75.0 dB not applied after SET_GAIN_MODE exception")
 	}
 }
 


### PR DESCRIPTION
The TCP stream setup was a single-reply, single-socket guess and never
validated against a live SoapySDRServer. Real SoapyRemote is a two-phase,
two-socket exchange: the server replies with the bound data port, does
listen(2) and blocks accepting both a stream and a status socket, then
replies with the integer stream id. The old client misread the first reply
as two strings (producing "setup stream port: short rpc response"), opened
only one socket, and packed the stream id as a string.

Against a real USRP X310 this first-stream failure drove the daemon's
reacquire/retry loop into a reconnect storm that re-ran SETUP_STREAM on a
graph the server still had bound, segfaulting the remote UHD process.

Rewrite the setup to match upstream (client/Streaming.cpp +
server/ClientHandler.cpp): read the data port, dial the stream then status
socket, read the int stream id, drain the status socket, and pack the id as
an int in ACTIVATE/DEACTIVATE/CLOSE. Use a longer read deadline for setup
since a cold high-end device spends seconds compiling its RFNoC graph.

Also fix manual gain: disabling AGC (setGainMode(false)) is now best-effort,
so a numeric gain still applies on front-ends with no AGC at all (e.g. a
USRP TwinRX, which rejects set_rx_agc()). Previously the unsupported AGC
call aborted the whole gain set.

The fake test server now models the real two-phase/two-socket choreography,
and a new test covers manual gain surviving an AGC-mode exception.

https://claude.ai/code/session_01SCNZSbrNFcCYfG3Dzqqp4E