### PR TITLE
soapyremote: send stream flow-control ACKs so RX actually streams (#542)

### DIFF
--- a/internal/sdr/soapyremote/driver.go
+++ b/internal/sdr/soapyremote/driver.go
@@ -346,6 +346,15 @@ func (d *device) StreamIQ(ctx context.Context) (<-chan []complex64, error) {
 		return nil, err
 	}
 
+	// Prime the server's sender with an initial flow-control ACK. The server
+	// blocks in waitSend() until it receives one and would otherwise never
+	// stream a sample (see encodeStreamACK / issue #542 follow-up). Sent before
+	// ACTIVATE, mirroring the upstream receiver constructor.
+	if err := d.sendStreamACK(dataConn, 0); err != nil {
+		d.clearStreamConns()
+		return nil, fmt.Errorf("soapyremote: initial stream ack: %w", err)
+	}
+
 	// ACTIVATE_STREAM (streamId, flags=0, timeNs=0, numElems=0).
 	if err := d.rpcVoid(func(p *packer) {
 		p.call(callActivateStream)
@@ -460,6 +469,14 @@ func (d *device) setupStreamTCP() (streamID int32, dataConn, statusConn net.Conn
 	return streamID, dataConn, statusConn, nil
 }
 
+// sendStreamACK writes a flow-control ACK for seq to the stream/data socket.
+// SoapyRemote requires these or the server never streams (see encodeStreamACK).
+func (d *device) sendStreamACK(conn net.Conn, seq uint32) error {
+	_ = conn.SetWriteDeadline(time.Now().Add(d.timeout))
+	_, err := conn.Write(encodeStreamACK(seq))
+	return err
+}
+
 // drainStatus reads and discards the stream's status socket. SoapyRemote's
 // server status thread may emit messages over it; leaving it unread can
 // back-pressure the server. It returns when the socket is closed (on teardown).
@@ -492,6 +509,10 @@ func (d *device) streamLoop(ctx context.Context, dataConn net.Conn, streamID int
 	defer d.teardownStream(streamID)
 
 	hdr := make([]byte, streamHeaderSize)
+	// Flow-control state: lastRecv tracks the next sequence we expect; lastAck
+	// is the sequence carried by our most recent ACK. The initial ACK (seq 0)
+	// was already sent in StreamIQ. uint32 wrap arithmetic matches upstream.
+	var lastRecv, lastAck uint32
 	for {
 		select {
 		case <-ctx.Done():
@@ -521,6 +542,17 @@ func (d *device) streamLoop(ctx context.Context, dataConn net.Conn, streamID int
 				}
 				return
 			}
+		}
+		// Flow control: advance the acked sequence and send a gratuitous ACK
+		// every triggerAckWindow datagrams so the server keeps streaming. Done
+		// for every datagram (including status codes), matching acquireRecv.
+		lastRecv = h.sequence + 1
+		if lastRecv-lastAck >= triggerAckWindow {
+			if err := d.sendStreamACK(dataConn, lastRecv); err != nil {
+				d.log.Debug("soapyremote: stream ack", "addr", d.addr, "err", err)
+				return
+			}
+			lastAck = lastRecv
 		}
 		if h.elems < 0 {
 			// Negative elems is a SoapySDR status/error code, not samples.

--- a/internal/sdr/soapyremote/driver_test.go
+++ b/internal/sdr/soapyremote/driver_test.go
@@ -25,6 +25,10 @@ type fakeSoapyServer struct {
 
 	mu    sync.Mutex
 	calls []recordedCall
+	// acks records the flow-control ACK datagrams received from the client on
+	// the stream socket (issue #542 follow-up). The first is the gratuitous
+	// initial ACK the server's waitSend() blocks on before streaming.
+	acks []streamHeader
 
 	// samples streamed per datagram once activated.
 	streamSamples []complex64
@@ -60,6 +64,20 @@ func (s *fakeSoapyServer) recorded() []recordedCall {
 	defer s.mu.Unlock()
 	out := make([]recordedCall, len(s.calls))
 	copy(out, s.calls)
+	return out
+}
+
+func (s *fakeSoapyServer) recordACK(h streamHeader) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.acks = append(s.acks, h)
+}
+
+func (s *fakeSoapyServer) recordedACKs() []streamHeader {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]streamHeader, len(s.acks))
+	copy(out, s.acks)
 	return out
 }
 
@@ -195,6 +213,28 @@ func (s *fakeSoapyServer) startDataServer(activate <-chan struct{}) (string, <-c
 		defer statusConn.Close()
 		close(bothConnected)
 		<-activate // wait until ACTIVATE_STREAM
+
+		// Real SoapyRemote blocks in waitSend() until the receiver sends an
+		// initial flow-control ACK; model that so the test fails if the client
+		// never ACKs (issue #542 follow-up). Subsequent ACKs are drained in the
+		// background so the client's writes never block.
+		ackHdr := make([]byte, streamHeaderSize)
+		_ = streamConn.SetReadDeadline(time.Now().Add(2 * time.Second))
+		if _, err := io.ReadFull(streamConn, ackHdr); err != nil {
+			return
+		}
+		_ = streamConn.SetReadDeadline(time.Time{})
+		s.recordACK(decodeStreamHeader(ackHdr))
+		go func() {
+			buf := make([]byte, streamHeaderSize)
+			for {
+				if _, err := io.ReadFull(streamConn, buf); err != nil {
+					return
+				}
+				s.recordACK(decodeStreamHeader(buf))
+			}
+		}()
+
 		seq := uint32(0)
 		for {
 			payload := encodeCS16(s.streamSamples)
@@ -366,6 +406,17 @@ func TestStreamIQ(t *testing.T) {
 	}
 	if !srv.sawCall(callActivateStream) {
 		t.Error("server did not see ACTIVATE_STREAM")
+	}
+
+	// The client must have sent the initial flow-control ACK (issue #542
+	// follow-up); without it a real server streams nothing. The ACK advertises
+	// the in-flight credit window in its elems field.
+	acks := srv.recordedACKs()
+	if len(acks) == 0 {
+		t.Fatal("server did not receive any flow-control ACK from client")
+	}
+	if acks[0].elems != int32(maxInFlightSeqs) {
+		t.Errorf("initial ACK elems = %d, want %d (advertised window)", acks[0].elems, maxInFlightSeqs)
 	}
 
 	// Cancelling the context must close the channel.

--- a/internal/sdr/soapyremote/stream.go
+++ b/internal/sdr/soapyremote/stream.go
@@ -22,6 +22,52 @@ type streamHeader struct {
 	time     int64  // timestamp (ns)
 }
 
+// SoapyRemote stream flow control (common/SoapyStreamEndpoint.cpp). On an RX
+// stream the *receiver* (this client) must send flow-control ACK datagrams back
+// to the server over the stream/data socket, or the server streams nothing:
+//
+//   - The server's sender thread blocks in waitSend() while
+//     "not _receiveInitial", so it will not transmit a single sample until it
+//     has received an initial ACK from us.
+//   - Thereafter it may only run _maxInFlightSeqs datagrams ahead of the last
+//     sequence we have ACKed, so we must keep ACKing as data arrives.
+//
+// The receiver normally sends the initial ACK in its constructor and a
+// gratuitous ACK every _triggerAckWindow = _maxInFlightSeqs/_numBuffs received
+// datagrams (acquireRecv). We mirror that cadence here. Without these ACKs the
+// server never sends, our reads time out with zero bytes, and the radio's RX
+// path overruns (issue #542 follow-up).
+const (
+	// streamMTU matches SoapyRemote's default endpoint MTU.
+	streamMTU = 1500
+	// streamNumBuffs mirrors SOAPY_REMOTE_ENDPOINT_NUM_BUFFS.
+	streamNumBuffs = 8
+	// streamWindowBytes is the receiver window we advertise as the in-flight
+	// credit ceiling. The server gates its sender on the value we send, not on
+	// any local buffer, so this only needs to be comfortably large.
+	streamWindowBytes = 8 * 1024 * 1024
+	// maxInFlightSeqs is the credit window advertised to the server (the ACK's
+	// elems field); it gates how far ahead the server may stream (window/mtu).
+	maxInFlightSeqs = streamWindowBytes / streamMTU // ≈5592
+	// triggerAckWindow is how many received datagrams elapse between ACKs
+	// (_maxInFlightSeqs/_numBuffs), matching upstream's gratuitous-ACK cadence.
+	triggerAckWindow = maxInFlightSeqs / streamNumBuffs // ≈699
+)
+
+// encodeStreamACK builds the 24-byte flow-control ACK datagram: a bare,
+// payload-less header whose sequence is the last received sequence and whose
+// elems carries the advertised in-flight window. Big-endian, byte-matching
+// SoapyStreamEndpoint::sendACK.
+func encodeStreamACK(seq uint32) []byte {
+	b := make([]byte, streamHeaderSize)
+	binary.BigEndian.PutUint32(b[0:4], streamHeaderSize)
+	binary.BigEndian.PutUint32(b[4:8], seq)
+	binary.BigEndian.PutUint32(b[8:12], maxInFlightSeqs)
+	binary.BigEndian.PutUint32(b[12:16], 0)
+	binary.BigEndian.PutUint64(b[16:24], 0)
+	return b
+}
+
 func decodeStreamHeader(b []byte) streamHeader {
 	return streamHeader{
 		bytes:    binary.BigEndian.Uint32(b[0:4]),


### PR DESCRIPTION
After the SETUP_STREAM handshake fix (#543), live X310/TwinRX testing showed
the stream now sets up but delivers zero IQ: the client's data-socket read
times out with no bytes (iq_observed=false, iq_samples=0) while the radio's
RX path overruns.

SoapyRemote's stream transport has an application-level flow-control ACK
protocol on the data socket (common/SoapyStreamEndpoint.cpp), used in TCP
mode too. The server's sender thread blocks in waitSend() until it receives
an initial ACK from the receiver, and afterward may only run a bounded number
of datagrams ahead of the last ACKed sequence. The driver never sent any ACK,
so the server streamed nothing and the device overran.

Implement the receiver side of the protocol:
  - send an initial gratuitous ACK (seq 0) right after stream setup, before
    ACTIVATE, to prime the server's sender;
  - in the stream loop, advance the acked sequence and send a gratuitous ACK
    every triggerAckWindow datagrams, advertising the in-flight credit window
    in the ACK's elems field.

Constants and ACK framing mirror SoapyStreamEndpoint (window/mtu in-flight
window, window/numBuffs ACK cadence, 24-byte big-endian header).

Update the fake test server to model the server's _receiveInitial gate: it
now blocks for the initial ACK before streaming and records ACKs. TestStreamIQ
asserts the client sends an initial ACK advertising the window; without the
fix the fake streams nothing and the test times out (the live symptom).