### PR TITLE
soapyremote: add free-form device args config block (#542)

### DIFF
--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -714,9 +714,12 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 					log.Warn("daemon: soapy_remote entry missing addr; skipping")
 					continue
 				}
-				var args map[string]string
-				if s.Driver != "" {
-					args = map[string]string{"driver": s.Driver}
+				args, err := s.DeviceArgs()
+				if err != nil {
+					// Validated at config load; guard defensively.
+					log.Warn("daemon: soapy_remote entry has invalid args; skipping",
+						"addr", s.Addr, "err", err)
+					continue
 				}
 				sspecs = append(sspecs, soapyremote.Spec{
 					Addr:           s.Addr,

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -294,6 +294,9 @@ sdr:
   #     driver: "uhd"               # SoapySDR device key: uhd | lime |
   #                                 #  bladerf | hackrf | airspy | rtlsdr
   #                                 #  (blank = server's first device)
+  #     args: ""                    # extra make() kwargs, "k=v,k=v" (merged
+  #                                 #  with driver); e.g. for a USRP TwinRX:
+  #                                 #  "rx_subdev_spec=A:0,antenna=RX1"
   #     serial: "usrp-roof"         # generator fills this from addr if blank
   #     role: control               # control | voice | auto
   #     format: "CS16"              # CS16 (16-bit, default) or CF32 (float)

--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -584,6 +584,7 @@ sdr:
   soapy_remote:
     - addr: "192.168.1.60:55132"  # bare host gets :55132 appended
       driver: "uhd"               # SoapySDR device key (blank = first device)
+      args: ""                    # extra make() kwargs "k=v,k=v" (see below)
       serial: "usrp-roof"         # generator fills this from addr when blank
       role: control               # control | voice | auto
       format: "CS16"              # CS16 (16-bit, default) or CF32 (float)
@@ -605,6 +606,12 @@ broker / fan-out path.
   (`stream_protocol: tcp`), which opens two sockets to the server (a stream
   socket and a status socket, matching `SoapySDRServer`'s setup). UDP
   streaming with the windowed flow-control is a planned follow-up.
+- `args` passes extra SoapySDR device kwargs to the remote `make()` as a
+  `"key=value,key2=value2"` string, merged with `driver` (an explicit
+  `driver=` in `args` wins). Use it for server-side device selection and
+  configuration that `driver` alone can't express — e.g. a USRP TwinRX needs
+  `args: "rx_subdev_spec=A:0,antenna=RX1"`. This is distinct from the top-level
+  `serial`, which only names the virtual pool device locally.
 - `ppm` (frequency correction) and `bias_tee` map to SoapySDR's
   `setFrequencyCorrection` / `writeSetting` and silently no-op on
   drivers that don't implement them.
@@ -622,6 +629,15 @@ broker / fan-out path.
 format=... proto=...` on each successful Open, `make device:` with the
 remote exception text when the server can't open the requested device,
 and `dial: connection refused` if the server isn't listening.
+
+> **Note — upstream server crashes.** Some radios were observed crashing
+> `SoapySDRServer` itself (a `zsh: segmentation fault` inside `libuhd`) when the
+> client mis-spoke the stream protocol. A server should never crash on a client
+> RPC, so that is an upstream UHD / `SoapySDRServer` robustness bug. GopherTrunk
+> no longer provokes it now that the TCP `SETUP_STREAM` handshake and stream
+> flow-control ACKs are byte-matched to SoapyRemote (issue #542). If you can
+> still reproduce a server crash, please report it upstream at
+> <https://github.com/pothosware/SoapyRemote/issues> with the server-side log.
 
 ## USB disconnect recovery
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -609,6 +609,13 @@ type SoapyRemoteConfig struct {
 	// server (e.g. "uhd", "lime", "bladerf", "hackrf", "airspy",
 	// "rtlsdr"). Empty selects the server's first/only device.
 	Driver string `yaml:"driver"`
+	// Args are extra SoapySDR device kwargs passed to the remote make(),
+	// as a "key=value,key2=value2" string (e.g.
+	// "rx_subdev_spec=A:0,antenna=RX1" for a USRP TwinRX). They are merged
+	// with Driver; an explicit "driver=" here wins over the Driver field.
+	// This is server-side device selection/configuration and is distinct
+	// from the top-level Serial, which is the local virtual pool name.
+	Args string `yaml:"args"`
 	// Serial is the virtual device serial reported on the pool's
 	// /api/v1/devices snapshot. Empty generates one from Addr.
 	Serial string `yaml:"serial"`
@@ -633,6 +640,49 @@ type SoapyRemoteConfig struct {
 	// ConnectTimeoutMs caps the TCP dial in milliseconds. Zero picks the
 	// driver default (3000).
 	ConnectTimeoutMs int `yaml:"connect_timeout_ms"`
+}
+
+// parseDeviceArgs parses a SoapySDR-style "key=value,key2=value2" argument
+// string into a map. Empty input yields an empty map. Whitespace around keys
+// and values is trimmed and empty segments are skipped. A segment with no "="
+// or an empty key is an error.
+func parseDeviceArgs(s string) (map[string]string, error) {
+	out := map[string]string{}
+	for _, seg := range strings.Split(s, ",") {
+		seg = strings.TrimSpace(seg)
+		if seg == "" {
+			continue
+		}
+		k, v, ok := strings.Cut(seg, "=")
+		k = strings.TrimSpace(k)
+		v = strings.TrimSpace(v)
+		if !ok || k == "" {
+			return nil, fmt.Errorf("invalid arg %q (want key=value)", seg)
+		}
+		out[k] = v
+	}
+	return out, nil
+}
+
+// DeviceArgs returns the SoapySDR make() kwargs for this endpoint: any
+// key=value pairs from Args, merged with the Driver shorthand. An explicit
+// "driver=" in Args wins over the Driver field. It returns nil when no args
+// apply (matching the driver's "select the server's first device" default),
+// or an error when Args is malformed.
+func (s SoapyRemoteConfig) DeviceArgs() (map[string]string, error) {
+	args, err := parseDeviceArgs(s.Args)
+	if err != nil {
+		return nil, err
+	}
+	if s.Driver != "" {
+		if _, ok := args["driver"]; !ok {
+			args["driver"] = s.Driver
+		}
+	}
+	if len(args) == 0 {
+		return nil, nil
+	}
+	return args, nil
 }
 
 type DeviceConfig struct {
@@ -1275,6 +1325,9 @@ func (c Config) Validate() error {
 		case "", "tcp":
 		default:
 			return fmt.Errorf("sdr.soapy_remote[%d]: stream_protocol must be tcp", i)
+		}
+		if _, err := s.DeviceArgs(); err != nil {
+			return fmt.Errorf("sdr.soapy_remote[%d]: args: %w", i, err)
 		}
 		if s.Serial == "" {
 			continue

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -301,12 +302,64 @@ func TestValidate(t *testing.T) {
 		// fine; an unknown key is rejected so typos surface at load.
 		{"web tabs known ok", Config{Web: WebConfig{Tabs: map[string]bool{"pagers": false, "metrics": true}}}, false},
 		{"web tabs unknown key", Config{Web: WebConfig{Tabs: map[string]bool{"pagerz": false}}}, true},
+		// soapy_remote args: SoapySDR make() kwargs as "k=v,k=v" (issue #542).
+		{"soapy args ok", Config{SDR: SDRConfig{SoapyRemote: []SoapyRemoteConfig{{Addr: "h:1", Args: "rx_subdev_spec=A:0,antenna=RX1"}}}}, false},
+		{"soapy args malformed", Config{SDR: SDRConfig{SoapyRemote: []SoapyRemoteConfig{{Addr: "h:1", Args: "rx_subdev_spec"}}}}, true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			err := tc.cfg.Validate()
 			if (err != nil) != tc.wantErr {
 				t.Errorf("err = %v, wantErr = %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestSoapyRemoteDeviceArgs covers the device-args config block (issue #542):
+// the "k=v,k=v" Args string merges with the Driver shorthand into make() kwargs.
+func TestSoapyRemoteDeviceArgs(t *testing.T) {
+	cases := []struct {
+		name    string
+		cfg     SoapyRemoteConfig
+		want    map[string]string
+		wantErr bool
+	}{
+		{"empty", SoapyRemoteConfig{}, nil, false},
+		{"driver only", SoapyRemoteConfig{Driver: "uhd"}, map[string]string{"driver": "uhd"}, false},
+		{"args only", SoapyRemoteConfig{Args: "antenna=RX1"}, map[string]string{"antenna": "RX1"}, false},
+		{
+			"driver and args merge",
+			SoapyRemoteConfig{Driver: "uhd", Args: "rx_subdev_spec=A:0,antenna=RX1"},
+			map[string]string{"driver": "uhd", "rx_subdev_spec": "A:0", "antenna": "RX1"},
+			false,
+		},
+		{
+			"explicit driver in args wins",
+			SoapyRemoteConfig{Driver: "uhd", Args: "driver=lime"},
+			map[string]string{"driver": "lime"},
+			false,
+		},
+		{
+			"whitespace trimmed and empty segments skipped",
+			SoapyRemoteConfig{Args: " antenna = RX1 , , gain = 30 "},
+			map[string]string{"antenna": "RX1", "gain": "30"},
+			false,
+		},
+		{"malformed missing equals", SoapyRemoteConfig{Args: "rx_subdev_spec"}, nil, true},
+		{"malformed empty key", SoapyRemoteConfig{Args: "=value"}, nil, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := tc.cfg.DeviceArgs()
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("err = %v, wantErr = %v", err, tc.wantErr)
+			}
+			if tc.wantErr {
+				return
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("DeviceArgs() = %v, want %v", got, tc.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Implements the device-`args` feature request from [comment #4 on #542](https://github.com/MattCheramie/GopherTrunk/issues/542), the remaining follow-up after the stream flow-control fix (#545).

A USRP TwinRX (and similar SoapySDR radios) needs extra device kwargs passed to the remote `make()` — e.g. `rx_subdev_spec=A:0,antenna=RX1` — to avoid the server wiring multiple front-ends to one DDC. Until now the `soapy_remote` YAML only folded the single `driver` key into the MAKE kwargs, with no way to pass arbitrary device args.

The driver plumbing already carried `Spec.DeviceArgs` straight into the MAKE RPC kwargs (`packer.kwargs`), so **no driver change was needed** — this is purely config parsing, validation, the daemon mapping, docs, and tests.

## Changes

- **`internal/config/config.go`**
  - Add `Args string \`yaml:"args"\`` to `SoapyRemoteConfig` — a SoapySDR-style `"key=value,key2=value2"` string.
  - Add `parseDeviceArgs` (splits on `,`, cuts on `=`, trims whitespace, skips empty segments, errors on a missing `=` or empty key).
  - Add `SoapyRemoteConfig.DeviceArgs()` — parses `Args` and merges it with the `driver` shorthand (an explicit `driver=` in `args` wins); returns `nil` when empty to preserve the existing "select the server's first device" default. Single source of truth reused by validation and the daemon.
  - Validation rejects malformed `args` at config load with the standard `sdr.soapy_remote[i]:` prefix.
- **`cmd/gophertrunk/daemon.go`** — build the Spec's `DeviceArgs` from `s.DeviceArgs()` instead of the driver-only map.
- **`config.example.yaml` / `docs/hardware.md`** — document the option (with the TwinRX example) and note it's distinct from the top-level virtual `serial`. Also added a note that the server-side segfault some radios showed is an upstream UHD/`SoapySDRServer` robustness bug that GopherTrunk no longer provokes, with a pointer to report it upstream.

## Testing

- `TestSoapyRemoteDeviceArgs`: empty, driver-only, args-only, driver+args merge, explicit-`driver=` override, whitespace trimming, and two malformed (missing `=`, empty key) cases.
- `TestValidate`: a valid `args` and a malformed `args` case.
- `gofmt`, `go vet`, `go build ./...`, and `go test ./internal/config/...` + `./internal/sdr/soapyremote/...` all green.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01Q2zmKmF4zUyDDRUUmCazjN

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q2zmKmF4zUyDDRUUmCazjN)_