### PR TITLE
Fix #547: drive IQ pump for single-channel decoders on dedicated dongles

### DIFF
--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -364,10 +364,22 @@ type Daemon struct {
 	// the broker wraps the recorder when baseband recording is on
 	// for the same dongle.
 	iqBrokers map[string]*iqtap.Broker
-	metrics   *metrics.Metrics
-	httpAPI   *api.Server
-	grpcAPI   *api.GRPCServer
-	rigctld   *rigctld.Server
+	// iqPrimary is the set of SDR serials whose iqtap broker already has
+	// a primary StreamIQ pump driving fan-out — the CC decoder and each
+	// wideband engine (seeded at construction), plus the first
+	// single-channel decoder claimed per serial at run time. A broker
+	// only fans IQ to Subscribe() consumers while a primary stream runs,
+	// so a dongle dedicated to paging / AIS / ADS-B needs one of its
+	// decoders to own StreamIQ; otherwise every subscriber (the decoder
+	// itself, plus capture / spectrum / diagnostics) silently starves.
+	// See issue #547. Guarded by iqPrimaryMu — single-channel decoders
+	// claim concurrently from their spawn goroutines.
+	iqPrimaryMu sync.Mutex
+	iqPrimary   map[string]bool
+	metrics     *metrics.Metrics
+	httpAPI     *api.Server
+	grpcAPI     *api.GRPCServer
+	rigctld     *rigctld.Server
 
 	// startupWarnings collects non-fatal observations from
 	// NewDaemon / preflight (missing talkgroup CSV, SDR enumeration
@@ -481,11 +493,12 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 	}
 
 	d := &Daemon{
-		cfg:     cfg,
-		cfgPath: cfgPath,
-		log:     log,
-		bus:     events.NewBus(64),
-		ready:   make(chan struct{}),
+		cfg:       cfg,
+		cfgPath:   cfgPath,
+		log:       log,
+		bus:       events.NewBus(64),
+		ready:     make(chan struct{}),
+		iqPrimary: make(map[string]bool),
 	}
 	if cfgPath != "" {
 		w, err := config.NewWriter(cfgPath)
@@ -1109,6 +1122,10 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 					IQCorrect:    iqCorrect,
 				}
 				d.controlSerial = controlEntry.Info.Serial
+				// The CC decoder owns StreamIQ on this dongle's broker,
+				// so single-channel decoders that share it must Subscribe
+				// rather than open a conflicting second stream (#547).
+				d.iqPrimary[controlEntry.Info.Serial] = true
 				// Reacquire re-requests the configured rate (and re-quantizes
 				// on the fresh handle); the decoder, by contrast, is built from
 				// the delivered effectiveRate above.
@@ -1245,6 +1262,10 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 				return nil, fmt.Errorf("daemon: widebandt2 %q: %w", devCfg.Serial, err)
 			}
 			d.widebandT2 = append(d.widebandT2, eng)
+			// This engine owns StreamIQ on the dongle's broker; mark the
+			// serial so a single-channel decoder pinned to the same dongle
+			// Subscribes instead of opening a second stream (#547).
+			d.iqPrimary[entry.Info.Serial] = true
 			// Virtual voice taps for this dongle are built earlier by
 			// buildVirtualVoiceTuners (before the voice pool and composer
 			// are constructed) so trunked grants inside the IQ window have
@@ -1984,9 +2005,14 @@ func (d *Daemon) Run(ctx context.Context) error {
 					"serial", spec.serial, "freq_hz", spec.freq, "err", err)
 				return nil
 			}
-			sub := br.Subscribe()
-			defer sub.Close()
-			return rcv.Process(ctx, sub.C)
+			iqCh, cleanup, err := d.openSingleChannelIQ(ctx, br, spec.serial)
+			if err != nil {
+				d.log.Warn("pocsag: open IQ failed",
+					"serial", spec.serial, "freq_hz", spec.freq, "err", err)
+				return nil
+			}
+			defer cleanup()
+			return rcv.Process(ctx, iqCh)
 		})
 	}
 	// FLEX paging receivers — same shape as POCSAG above. Each
@@ -2012,9 +2038,14 @@ func (d *Daemon) Run(ctx context.Context) error {
 					"serial", spec.serial, "freq_hz", spec.freq, "err", err)
 				return nil
 			}
-			sub := br.Subscribe()
-			defer sub.Close()
-			return rcv.Process(ctx, sub.C)
+			iqCh, cleanup, err := d.openSingleChannelIQ(ctx, br, spec.serial)
+			if err != nil {
+				d.log.Warn("flex: open IQ failed",
+					"serial", spec.serial, "freq_hz", spec.freq, "err", err)
+				return nil
+			}
+			defer cleanup()
+			return rcv.Process(ctx, iqCh)
 		})
 	}
 	// M17 link-layer receivers — same shape as the paging receivers
@@ -2039,9 +2070,14 @@ func (d *Daemon) Run(ctx context.Context) error {
 					"serial", spec.serial, "freq_hz", spec.freq, "err", err)
 				return nil
 			}
-			sub := br.Subscribe()
-			defer sub.Close()
-			return rcv.Process(ctx, sub.C)
+			iqCh, cleanup, err := d.openSingleChannelIQ(ctx, br, spec.serial)
+			if err != nil {
+				d.log.Warn("m17: open IQ failed",
+					"serial", spec.serial, "freq_hz", spec.freq, "err", err)
+				return nil
+			}
+			defer cleanup()
+			return rcv.Process(ctx, iqCh)
 		})
 	}
 	// APRS receivers — same shape as POCSAG above. Each subscribes
@@ -2071,9 +2107,14 @@ func (d *Daemon) Run(ctx context.Context) error {
 					"serial", spec.serial, "freq_hz", spec.freq, "err", err)
 				return nil
 			}
-			sub := br.Subscribe()
-			defer sub.Close()
-			return rcv.Process(ctx, sub.C)
+			iqCh, cleanup, err := d.openSingleChannelIQ(ctx, br, spec.serial)
+			if err != nil {
+				d.log.Warn("aprs: open IQ failed",
+					"serial", spec.serial, "freq_hz", spec.freq, "err", err)
+				return nil
+			}
+			defer cleanup()
+			return rcv.Process(ctx, iqCh)
 		})
 	}
 	// AIS receivers — same shape as APRS / POCSAG above. Each
@@ -2104,9 +2145,14 @@ func (d *Daemon) Run(ctx context.Context) error {
 					"serial", spec.serial, "freq_hz", spec.freq, "err", err)
 				return nil
 			}
-			sub := br.Subscribe()
-			defer sub.Close()
-			return rcv.Process(ctx, sub.C)
+			iqCh, cleanup, err := d.openSingleChannelIQ(ctx, br, spec.serial)
+			if err != nil {
+				d.log.Warn("ais: open IQ failed",
+					"serial", spec.serial, "freq_hz", spec.freq, "err", err)
+				return nil
+			}
+			defer cleanup()
+			return rcv.Process(ctx, iqCh)
 		})
 	}
 	// DSC receivers — same shape as AIS above. Each subscribes to its
@@ -2136,9 +2182,14 @@ func (d *Daemon) Run(ctx context.Context) error {
 					"serial", spec.serial, "freq_hz", spec.freq, "err", err)
 				return nil
 			}
-			sub := br.Subscribe()
-			defer sub.Close()
-			return rcv.Process(ctx, sub.C)
+			iqCh, cleanup, err := d.openSingleChannelIQ(ctx, br, spec.serial)
+			if err != nil {
+				d.log.Warn("dsc: open IQ failed",
+					"serial", spec.serial, "freq_hz", spec.freq, "err", err)
+				return nil
+			}
+			defer cleanup()
+			return rcv.Process(ctx, iqCh)
 		})
 	}
 	// MDC1200 receivers — same shape as APRS / AIS above. Each
@@ -2168,9 +2219,14 @@ func (d *Daemon) Run(ctx context.Context) error {
 					"serial", spec.serial, "freq_hz", spec.freq, "err", err)
 				return nil
 			}
-			sub := br.Subscribe()
-			defer sub.Close()
-			return rcv.Process(ctx, sub.C)
+			iqCh, cleanup, err := d.openSingleChannelIQ(ctx, br, spec.serial)
+			if err != nil {
+				d.log.Warn("mdc1200: open IQ failed",
+					"serial", spec.serial, "freq_hz", spec.freq, "err", err)
+				return nil
+			}
+			defer cleanup()
+			return rcv.Process(ctx, iqCh)
 		})
 	}
 	// ADS-B BEAST upstream clients — each consumes Mode-S
@@ -2210,9 +2266,14 @@ func (d *Daemon) Run(ctx context.Context) error {
 					"serial", spec.serial, "freq_hz", spec.freq, "err", err)
 				return nil
 			}
-			sub := br.Subscribe()
-			defer sub.Close()
-			return rcv.Process(ctx, sub.C)
+			iqCh, cleanup, err := d.openSingleChannelIQ(ctx, br, spec.serial)
+			if err != nil {
+				d.log.Warn("adsb/ppm: open IQ failed",
+					"serial", spec.serial, "freq_hz", spec.freq, "err", err)
+				return nil
+			}
+			defer cleanup()
+			return rcv.Process(ctx, iqCh)
 		})
 	}
 	if d.pool != nil {
@@ -2914,6 +2975,45 @@ func (d *Daemon) wrapIQBrokers(cfg config.Config, log *slog.Logger) {
 		br.Seed(0, rate)
 		d.iqBrokers[e.Info.Serial] = br
 	}
+}
+
+// openSingleChannelIQ returns an IQ channel for a single-channel decoder
+// (POCSAG, FLEX, M17, APRS, AIS, DSC, MDC1200, ADS-B/PPM) pinned to serial.
+//
+// An iqtap.Broker only fans IQ out to Subscribe() consumers while a primary
+// StreamIQ session is running. Trunking / wideband dongles get that primary
+// from the CC decoder or wideband engine, but a dongle dedicated to a
+// single-channel decoder has none — so the first such decoder per serial must
+// drive StreamIQ itself. Doing so also feeds every other Subscribe() consumer
+// on that dongle (capture / spectrum / diagnostics), which previously starved
+// too (issue #547).
+//
+// The first caller per serial (when no trunking/wideband primary already owns
+// the broker) becomes the primary and gets StreamIQ; later callers on the same
+// serial Subscribe. The returned cleanup must be deferred. StreamIQ
+// self-terminates on ctx cancel, so the primary's cleanup is a no-op.
+func (d *Daemon) openSingleChannelIQ(ctx context.Context, br *iqtap.Broker, serial string) (<-chan []complex64, func(), error) {
+	d.iqPrimaryMu.Lock()
+	primary := !d.iqPrimary[serial]
+	if primary {
+		d.iqPrimary[serial] = true
+	}
+	d.iqPrimaryMu.Unlock()
+
+	if primary {
+		ch, err := br.StreamIQ(ctx)
+		if err != nil {
+			// Release the claim so a retry (or another decoder) can drive
+			// the pump instead of wedging the serial on a dead primary.
+			d.iqPrimaryMu.Lock()
+			delete(d.iqPrimary, serial)
+			d.iqPrimaryMu.Unlock()
+			return nil, func() {}, err
+		}
+		return ch, func() {}, nil
+	}
+	sub := br.Subscribe()
+	return sub.C, sub.Close, nil
 }
 
 // convFanoutRecorder lets the conventional scanner drive both the

--- a/cmd/gophertrunk/iqpump_test.go
+++ b/cmd/gophertrunk/iqpump_test.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/sdr"
+	"github.com/MattCheramie/GopherTrunk/internal/sdr/iqtap"
+)
+
+// failStreamDevice is an sdr.Device whose StreamIQ always errors, used to
+// exercise the claim-release path in openSingleChannelIQ.
+type failStreamDevice struct{ serial string }
+
+func (f *failStreamDevice) Info() sdr.Info             { return sdr.Info{Driver: "fail", Serial: f.serial} }
+func (f *failStreamDevice) SetCenterFreq(uint32) error { return nil }
+func (f *failStreamDevice) SetSampleRate(uint32) error { return nil }
+func (f *failStreamDevice) SetGain(int) error          { return nil }
+func (f *failStreamDevice) SetPPM(int) error           { return nil }
+func (f *failStreamDevice) SetBiasTee(bool) error      { return nil }
+func (f *failStreamDevice) Close() error               { return nil }
+func (f *failStreamDevice) StreamIQ(context.Context) (<-chan []complex64, error) {
+	return nil, errors.New("fail: StreamIQ unavailable")
+}
+
+// TestOpenSingleChannelIQDrivesPrimary locks the issue #547 fix: a
+// single-channel decoder on a dongle with no trunking/wideband primary must
+// itself drive the broker's StreamIQ pump so the broker actually fans IQ out
+// to its subscribers. Before the fix the decoder only Subscribe()d and the
+// broker — never pumped — delivered nothing.
+func TestOpenSingleChannelIQDrivesPrimary(t *testing.T) {
+	dev := newStreamingFake("dev-primary")
+	br := iqtap.New(dev, 0, nil)
+	d := &Daemon{log: slog.New(slog.DiscardHandler), iqPrimary: map[string]bool{}}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ch, cleanup, err := d.openSingleChannelIQ(ctx, br, "dev-primary")
+	if err != nil {
+		t.Fatalf("openSingleChannelIQ: %v", err)
+	}
+	defer cleanup()
+
+	// The first caller becomes the primary: StreamIQ is now driving the
+	// broker, so Stats reports Streaming and IQ actually flows to the
+	// returned channel.
+	if !br.Stats().Streaming {
+		t.Fatal("broker not Streaming after first openSingleChannelIQ — pump not driven (issue #547)")
+	}
+	select {
+	case chunk, ok := <-ch:
+		if !ok {
+			t.Fatal("primary IQ channel closed prematurely")
+		}
+		if len(chunk) == 0 {
+			t.Fatal("primary delivered an empty chunk")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("no IQ delivered to the primary decoder within 2s")
+	}
+}
+
+// TestOpenSingleChannelIQSecondConsumerSubscribes verifies that once a serial
+// has a primary, a later consumer on the same serial Subscribes rather than
+// opening a second (conflicting) StreamIQ.
+func TestOpenSingleChannelIQSecondConsumerSubscribes(t *testing.T) {
+	dev := newStreamingFake("dev-shared")
+	br := iqtap.New(dev, 0, nil)
+	d := &Daemon{log: slog.New(slog.DiscardHandler), iqPrimary: map[string]bool{}}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// First consumer: primary. No subscribers registered yet.
+	_, cleanup1, err := d.openSingleChannelIQ(ctx, br, "dev-shared")
+	if err != nil {
+		t.Fatalf("first openSingleChannelIQ: %v", err)
+	}
+	defer cleanup1()
+	if got := br.Stats().Subscribers; got != 0 {
+		t.Fatalf("after primary: Subscribers = %d, want 0", got)
+	}
+
+	// Second consumer on the same serial: must Subscribe (one subscriber),
+	// not open another stream.
+	ch2, cleanup2, err := d.openSingleChannelIQ(ctx, br, "dev-shared")
+	if err != nil {
+		t.Fatalf("second openSingleChannelIQ: %v", err)
+	}
+	defer cleanup2()
+	if got := br.Stats().Subscribers; got != 1 {
+		t.Fatalf("after second consumer: Subscribers = %d, want 1 (should Subscribe, not re-StreamIQ)", got)
+	}
+	// The subscriber still receives fanned-out IQ because the primary pump
+	// is running.
+	select {
+	case chunk, ok := <-ch2:
+		if !ok || len(chunk) == 0 {
+			t.Fatal("subscriber received no usable IQ")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("no IQ fanned out to the second consumer within 2s")
+	}
+}
+
+// TestOpenSingleChannelIQRespectsExistingPrimary verifies that a serial
+// already owned by a trunking/wideband primary (pre-seeded in iqPrimary)
+// makes the single-channel decoder Subscribe instead of opening a second
+// StreamIQ on the same dongle.
+func TestOpenSingleChannelIQRespectsExistingPrimary(t *testing.T) {
+	dev := newStreamingFake("dev-trunk")
+	br := iqtap.New(dev, 0, nil)
+	d := &Daemon{
+		log:       slog.New(slog.DiscardHandler),
+		iqPrimary: map[string]bool{"dev-trunk": true}, // CC/wideband already owns it
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	_, cleanup, err := d.openSingleChannelIQ(ctx, br, "dev-trunk")
+	if err != nil {
+		t.Fatalf("openSingleChannelIQ: %v", err)
+	}
+	defer cleanup()
+
+	if got := br.Stats().Subscribers; got != 1 {
+		t.Fatalf("Subscribers = %d, want 1 (must Subscribe when a primary already owns the serial)", got)
+	}
+	if br.Stats().Streaming {
+		t.Fatal("single-channel decoder opened its own StreamIQ on a dongle already owned by a primary")
+	}
+}
+
+// TestOpenSingleChannelIQReleasesClaimOnError verifies that a failed StreamIQ
+// releases the primary claim so a later consumer (or retry) can drive the
+// pump instead of the serial being wedged forever on a dead primary.
+func TestOpenSingleChannelIQReleasesClaimOnError(t *testing.T) {
+	br := iqtap.New(&failStreamDevice{serial: "dev-fail"}, 0, nil)
+	d := &Daemon{log: slog.New(slog.DiscardHandler), iqPrimary: map[string]bool{}}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if _, _, err := d.openSingleChannelIQ(ctx, br, "dev-fail"); err == nil {
+		t.Fatal("openSingleChannelIQ: want error from failing StreamIQ, got nil")
+	}
+
+	d.iqPrimaryMu.Lock()
+	claimed := d.iqPrimary["dev-fail"]
+	d.iqPrimaryMu.Unlock()
+	if claimed {
+		t.Fatal("primary claim not released after StreamIQ error — serial is wedged")
+	}
+}


### PR DESCRIPTION
POCSAG, FLEX, M17, APRS, AIS, DSC, MDC1200 and ADS-B/PPM decoders never
received IQ on a dongle dedicated to them, and IQ-capture/spectrum/
diagnostics also failed on those dongles.

The iqtap.Broker only fans IQ out to Subscribe() consumers while a
primary StreamIQ session is running (fanout runs inside the StreamIQ
goroutine). Trunking/wideband dongles get that primary from the CC
decoder or wideband engine, but the single-channel decoders only called
Subscribe() and never StreamIQ. On a dedicated dongle nothing pumped the
device, so every subscriber on it silently starved.

Make the first single-channel decoder per SDR serial drive the broker's
StreamIQ pump (which then feeds all other subscribers on that dongle);
later consumers on the same serial Subscribe. A mutex-guarded iqPrimary
set tracks claimed serials and is pre-seeded with the control and
wideband serials so a decoder sharing such a dongle Subscribes rather
than opening a conflicting second stream. A failed StreamIQ releases the
claim so the serial isn't wedged.

Adds openSingleChannelIQ and table-driven regression tests covering the
primary/subscribe/pre-claimed/error-release paths.

https://claude.ai/code/session_01NNLxzZJguGqjU7hsKBBHmG