### PR TITLE
Add site/system hunting: discover, map & export unknown trunked systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,15 @@ Silicon and Intel. Full per-OS recipes at
   pure-browser React SPA web console, runtime config editing via
   `PATCH /api/v1/settings`, RadioReference PDF / CSV importer with
   a config-builder wizard.
+- **Site/system hunting** — `gophertrunk hunt` maps a previously
+  undocumented trunked system from one or more control-channel IQ
+  captures: auto-identifies the protocol, accumulates identity
+  (P25 NAC / WACN / SYSID / RFSS / Site, and per-protocol ids),
+  per-site control channels and observed talkgroups, then exports a
+  GopherTrunk import bundle, a trunk-recorder config stanza, and a
+  ready-to-paste RadioReference submission package — with an
+  optional read-only RadioReference duplicate check so you don't
+  submit a system that already exists. See [docs/hunt.md](docs/hunt.md).
 - **Location + affiliation** — NMEA-0183 GGA / RMC over the air
   decoded into a SQLite `location_log`; protocol-agnostic
   affiliation tracker fed from grants / registrations / affiliation
@@ -361,6 +370,7 @@ Operator-facing docs live at **[gophertrunk.org](https://gophertrunk.org)**
   [Web console](docs/web.md) ·
   [Live config editing](docs/live-edits.md) ·
   [Import (PDF / CSV)](docs/import.md) ·
+  [Hunt (discover unknown systems)](docs/hunt.md) ·
   [Hardening](docs/hardening.md)
 - **Reference** — [Architecture](docs/architecture.md) ·
   [Vocoders](docs/vocoders.md) ·

--- a/cmd/gophertrunk/hunt.go
+++ b/cmd/gophertrunk/hunt.go
@@ -1,0 +1,363 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/diag"
+	"github.com/MattCheramie/GopherTrunk/internal/hunt"
+	"github.com/MattCheramie/GopherTrunk/internal/radioreference"
+	"github.com/MattCheramie/GopherTrunk/internal/siglab"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// runHunt is the entry point for `gophertrunk hunt`. It maps a previously
+// unknown/undocumented trunked system from one or more IQ captures (each
+// centered on a suspected control channel), then exports the discovered system
+// to standardized files plus a RadioReference.com submission package.
+//
+// This is the offline path: each -in capture is identified, decoded, and
+// accumulated into one DiscoveredSystem. A live spectrum-sweep front-end that
+// finds the candidate control channels on the air is the planned follow-on;
+// today the operator supplies the captures (e.g. from `gophertrunk capture`).
+func runHunt(args []string) {
+	fs := flag.NewFlagSet("hunt", flag.ExitOnError)
+	verboseFlag := fs.Bool("verbose-errors", false, "print full error chain + stack on failures")
+
+	var inPaths repeatedString
+	var freqs repeatedString
+	fs.Var(&inPaths, "in", "raw IQ capture of a suspected control channel (repeatable)")
+	fs.Var(&freqs, "freq", "nominal center frequency in Hz for the matching -in capture (repeatable, positional)")
+	format := fs.String("format", "u8", "sample format: u8 | f32")
+	sampleRate := fs.Float64("sample-rate", 2_400_000, "IQ sample rate in Hz")
+	protocolFlag := fs.String("protocol", "", "force a protocol for every capture (default: auto-identify). One of p25,p25-phase2,dmr,dmr-tier2,nxdn,dpmr,edacs,motorola,ltr,mpt1327,tetra,ysf,dstar")
+	autoTune := fs.Bool("auto-tune", false, "estimate the dominant carrier offset and tune it to 0 Hz before demod")
+	conjugate := fs.Bool("conjugate", false, "conjugate IQ (negate Q) before channelization (spectrum-inverted front-end)")
+	iqCorrect := fs.Bool("iq-correct", false, "apply blind I/Q-imbalance correction to the raw IQ before decimation")
+	minConfidence := fs.Float64("min-confidence", 0.40, "skip auto-identified captures below this confidence (0..1)")
+
+	name := fs.String("name", "", "system name (default: synthesized from identity)")
+	state := fs.String("state", "", "US state (2-letter) — used in the RR submission package")
+	county := fs.String("county", "", "county name — used in the RR submission package")
+	location := fs.String("location", "", "free-form location (e.g. \"Phoenix, AZ\")")
+
+	out := fs.String("out", "", "output directory (default: ./hunt-<timestamp>)")
+	formats := fs.String("formats", "bundle,trunk-recorder,rr", "comma-separated export formats: bundle,trunk-recorder,rr")
+
+	noRR := fs.Bool("no-rr", false, "skip the RadioReference duplicate check even if a key is configured")
+	rrKey := fs.String("rr-key", "", "RadioReference API key (else GOPHERTRUNK_RR_KEY env). Enables the read-only duplicate check.")
+	rrCountyID := fs.Int("rr-county-id", 0, "RadioReference county id (ctid) to scan for existing systems")
+	var rrCheckSIDs repeatedString
+	fs.Var(&rrCheckSIDs, "rr-check-sid", "RadioReference system id to compare against (repeatable)")
+
+	commit := fs.Bool("commit", false, "merge the discovered system into config.yaml (like import-pdf)")
+	configPath := fs.String("config", "config.yaml", "config.yaml path for -commit")
+	csvDir := fs.String("csv-dir", "", "directory for generated talkgroup CSVs on -commit (default: alongside -config)")
+	force := fs.Bool("force", false, "overwrite an existing system with the same name on -commit")
+	dryRun := fs.Bool("dry-run", false, "with -commit, show what would change without writing")
+
+	fs.Usage = func() {
+		fmt.Fprintln(fs.Output(), `gophertrunk hunt — discover & map an unknown trunked system, then export it.
+
+USAGE:
+  gophertrunk hunt -in <capture> [-in <capture> …] [-format u8|f32] [-sample-rate Hz]
+                  [-protocol <p>] [-out <dir>] [-formats bundle,trunk-recorder,rr]
+                  [-name N] [-state XX] [-county C] [-commit -config config.yaml]
+
+EXAMPLES:
+  # Map an unknown P25 system from one control-channel capture and export everything
+  gophertrunk hunt -in cc.cfile -format f32 -sample-rate 2400000 -state AZ -county Maricopa
+
+  # Fold two sites of the same system into one map, auto-identifying each
+  gophertrunk hunt -in site1.cfile -freq 851012500 -in site2.cfile -freq 853512500 \
+                  -format f32 -sample-rate 2400000 -name "New County P25"
+
+  # Discover and merge straight into config.yaml
+  gophertrunk hunt -in cc.u8 -sample-rate 2400000 -commit -config ./config.yaml
+
+FLAGS:`)
+		fs.PrintDefaults()
+	}
+	_ = fs.Parse(args)
+	resolveVerbose(*verboseFlag, false)
+	rep := newReporter("hunt")
+
+	if len(inPaths) == 0 {
+		fs.Usage()
+		rep.Fatalf(2, "at least one -in capture is required")
+	}
+	if *sampleRate <= 0 {
+		rep.Fatalf(2, "-sample-rate must be > 0")
+	}
+	sampleFormat, err := siglab.ParseSampleFormat(*format)
+	if err != nil {
+		rep.Fatal(2, err)
+	}
+	if len(freqs) != 0 && len(freqs) != len(inPaths) {
+		rep.Fatalf(2, "-freq given %d times but -in given %d times — supply one -freq per -in or none", len(freqs), len(inPaths))
+	}
+
+	var proto trunking.Protocol
+	if *protocolFlag != "" {
+		proto, err = siglab.ParseProtocolCLI(*protocolFlag)
+		if err != nil {
+			rep.Fatal(2, err)
+		}
+	}
+
+	// Parse the requested export formats up front so a typo fails fast.
+	var outFormats []hunt.Format
+	for _, f := range strings.Split(*formats, ",") {
+		f = strings.TrimSpace(f)
+		if f == "" {
+			continue
+		}
+		hf, ferr := hunt.ParseFormat(f)
+		if ferr != nil {
+			rep.Fatal(2, ferr)
+		}
+		outFormats = append(outFormats, hf)
+	}
+	if len(outFormats) == 0 {
+		rep.Fatalf(2, "-formats listed no valid formats")
+	}
+
+	// Build the capture inputs.
+	captures := make([]hunt.CaptureInput, 0, len(inPaths))
+	for i, p := range inPaths {
+		ci := hunt.CaptureInput{
+			Path:         p,
+			Format:       sampleFormat,
+			SampleRateHz: *sampleRate,
+			AutoTune:     *autoTune,
+			Conjugate:    *conjugate,
+			IQCorrect:    *iqCorrect,
+			Protocol:     proto,
+		}
+		if len(freqs) == len(inPaths) {
+			hz, perr := strconv.ParseUint(strings.TrimSpace(freqs[i]), 10, 32)
+			if perr != nil {
+				rep.Fatalf(2, "-freq[%d] %q: %v", i, freqs[i], perr)
+			}
+			ci.FrequencyHz = uint32(hz)
+		}
+		captures = append(captures, ci)
+	}
+
+	fmt.Fprintf(os.Stderr, "hunt: mapping %d capture(s)…\n", len(captures))
+	sys, reports, derr := hunt.Discover(captures, hunt.DiscoverConfig{
+		Name:          *name,
+		State:         *state,
+		County:        *county,
+		Location:      *location,
+		MinConfidence: *minConfidence,
+	})
+	if derr != nil {
+		rep.Fatal(1, derr)
+	}
+
+	// Per-capture progress so the operator sees what locked vs. was skipped.
+	for _, r := range reports {
+		switch {
+		case r.Error != "":
+			fmt.Fprintf(os.Stderr, "hunt:   %s — ERROR: %s\n", r.Path, r.Error)
+		case r.Skipped:
+			fmt.Fprintf(os.Stderr, "hunt:   %s — skipped (%s)\n", r.Path, r.SkipReason)
+		default:
+			fmt.Fprintf(os.Stderr, "hunt:   %s — %s, locked=%v, +%d talkgroups\n",
+				r.Path, r.Protocol, r.Locked, r.Talkgroups)
+		}
+	}
+	if len(sys.Sites) == 0 && len(sys.Talkgroups) == 0 {
+		rep.Fatalf(1, "no trunked control channel was decoded from the supplied capture(s)")
+	}
+	fmt.Fprintf(os.Stderr, "hunt: discovered %q — %d site(s), %d talkgroup(s)\n",
+		sys.DisplayName(), len(sys.Sites), len(sys.Talkgroups))
+
+	// Optional read-only RadioReference duplicate check. Failures here are
+	// non-fatal: the export still happens, just without hints.
+	var hints []hunt.DuplicateHint
+	if !*noRR {
+		hints = gatherRRHints(sys, rrOptions{
+			key:       *rrKey,
+			countyID:  *rrCountyID,
+			checkSIDs: rrCheckSIDs,
+		})
+	}
+
+	// Write the export files.
+	outDir := *out
+	if outDir == "" {
+		outDir = fmt.Sprintf("hunt-%s", time.Now().Format("20060102-150405"))
+	}
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		rep.Fatal(1, fmt.Errorf("create out dir %s: %w", outDir, err))
+	}
+	base := slugName(sys.DisplayName())
+	for _, hf := range outFormats {
+		fname := filepath.Join(outDir, fmt.Sprintf("%s.%s", base, hf.FileExtension()))
+		if hf == hunt.FormatRR {
+			fname = filepath.Join(outDir, fmt.Sprintf("%s-radioreference.%s", base, hf.FileExtension()))
+		}
+		f, cerr := os.Create(fname)
+		if cerr != nil {
+			rep.Fatal(1, fmt.Errorf("create %s: %w", fname, cerr))
+		}
+		werr := hunt.Write(f, sys, hf, hints)
+		cerr = f.Close()
+		if werr != nil {
+			rep.Fatal(1, fmt.Errorf("write %s: %w", fname, werr))
+		}
+		if cerr != nil {
+			rep.Fatal(1, fmt.Errorf("close %s: %w", fname, cerr))
+		}
+		fmt.Fprintf(os.Stderr, "hunt: wrote %s (%s)\n", fname, hf)
+	}
+
+	// Optional: merge straight into config.yaml, reusing the importer's writer
+	// so a discovery lands exactly like a PDF/CSV import would.
+	if *commit {
+		commitDiscovery(rep, sys, *configPath, *csvDir, *force, *dryRun)
+	}
+}
+
+// commitDiscovery converts the discovery to the importer's parsedSystem and
+// merges it into config.yaml via the shared mergeIntoConfig path.
+func commitDiscovery(rep *diag.Reporter, sys *hunt.DiscoveredSystem, configPath, csvDir string, force, dryRun bool) {
+	ps := discoveredToParsed(sys)
+	res, err := mergeIntoConfig([]parsedSystem{ps}, mergeOptions{
+		ConfigPath: configPath,
+		CSVDir:     csvDir,
+		Force:      force,
+		DryRun:     dryRun,
+	})
+	if err != nil {
+		rep.Fatal(1, fmt.Errorf("commit: %w", err))
+	}
+	for _, c := range res.Changes {
+		fmt.Fprintf(os.Stderr, "hunt: %s\n", c)
+	}
+	if dryRun {
+		fmt.Fprintln(os.Stderr, "hunt: dry-run — config.yaml not modified")
+	}
+}
+
+// rrOptions carries the resolved RadioReference verify inputs.
+type rrOptions struct {
+	key       string
+	countyID  int
+	checkSIDs []string
+}
+
+// gatherRRHints runs the optional read-only RadioReference duplicate check.
+// The API key comes from -rr-key or the GOPHERTRUNK_RR_KEY env var; username/
+// password fall back to GOPHERTRUNK_RR_USER / GOPHERTRUNK_RR_PASS. With no key
+// the check is skipped (a note is printed) and the export proceeds without
+// hints. All RR errors are non-fatal.
+func gatherRRHints(sys *hunt.DiscoveredSystem, opts rrOptions) []hunt.DuplicateHint {
+	key := opts.key
+	if key == "" {
+		key = os.Getenv("GOPHERTRUNK_RR_KEY")
+	}
+	client, err := radioreference.NewClient(radioreference.Auth{
+		AppKey:   key,
+		Username: os.Getenv("GOPHERTRUNK_RR_USER"),
+		Password: os.Getenv("GOPHERTRUNK_RR_PASS"),
+	})
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "hunt: RadioReference duplicate check skipped (no API key configured — set -rr-key or GOPHERTRUNK_RR_KEY)")
+		return nil
+	}
+	if opts.countyID == 0 && len(opts.checkSIDs) == 0 {
+		fmt.Fprintln(os.Stderr, "hunt: RadioReference key present but no -rr-county-id or -rr-check-sid given; nothing to compare against")
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	// Collect candidate existing systems: explicit SIDs first, then every
+	// system registered in the given county (enriched with its identity).
+	var existing []radioreference.System
+	seen := map[int]bool{}
+	addDetails := func(sid int) {
+		if sid == 0 || seen[sid] {
+			return
+		}
+		seen[sid] = true
+		d, derr := client.GetTrsDetails(ctx, sid)
+		if derr != nil {
+			fmt.Fprintf(os.Stderr, "hunt: RadioReference getTrsDetails(%d): %v\n", sid, derr)
+			return
+		}
+		existing = append(existing, d)
+	}
+	for _, s := range opts.checkSIDs {
+		if sid, perr := strconv.Atoi(strings.TrimSpace(s)); perr == nil {
+			addDetails(sid)
+		}
+	}
+	if opts.countyID != 0 {
+		briefs, cerr := client.GetCountyInfo(ctx, opts.countyID)
+		if cerr != nil {
+			fmt.Fprintf(os.Stderr, "hunt: RadioReference getCountyInfo(%d): %v\n", opts.countyID, cerr)
+		}
+		for _, b := range briefs {
+			addDetails(b.SID)
+		}
+	}
+
+	cand := radioreference.Candidate{
+		WACN:     sys.WACN,
+		SystemID: sys.SystemID,
+		Name:     sys.DisplayName(),
+	}
+	for _, st := range sys.Sites {
+		for _, ch := range st.ControlChannels {
+			if ch.IsControl {
+				cand.ControlChannels = append(cand.ControlChannels, ch.FrequencyHz)
+			}
+		}
+	}
+
+	rrHints := radioreference.MatchAgainst(cand, existing)
+	if len(rrHints) == 0 {
+		fmt.Fprintf(os.Stderr, "hunt: RadioReference check found no existing match among %d system(s)\n", len(existing))
+		return nil
+	}
+	out := make([]hunt.DuplicateHint, 0, len(rrHints))
+	for _, h := range rrHints {
+		fmt.Fprintf(os.Stderr, "hunt: possible duplicate — RR SID %d (%s): %s\n", h.SID, h.Name, h.Reason)
+		out = append(out, hunt.DuplicateHint{SID: h.SID, Name: h.Name, Reason: h.Reason, Confidence: h.Confidence})
+	}
+	return out
+}
+
+// slugName lowercases a display name into a filesystem-safe stem.
+func slugName(s string) string {
+	var b strings.Builder
+	prevHyphen := false
+	for _, r := range strings.ToLower(s) {
+		switch {
+		case (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9'):
+			b.WriteRune(r)
+			prevHyphen = false
+		default:
+			if !prevHyphen && b.Len() > 0 {
+				b.WriteByte('-')
+				prevHyphen = true
+			}
+		}
+	}
+	out := strings.Trim(b.String(), "-")
+	if out == "" {
+		return "discovered-system"
+	}
+	return out
+}

--- a/cmd/gophertrunk/hunt_export.go
+++ b/cmd/gophertrunk/hunt_export.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/MattCheramie/GopherTrunk/internal/hunt"
+)
+
+// discoveredToParsed converts a hunt.DiscoveredSystem into the importer's
+// parsedSystem so a discovery can be merged into config.yaml through the exact
+// same mergeIntoConfig path a PDF/CSV import uses. Keeping the conversion here
+// (rather than in internal/hunt) avoids an import cycle: parsedSystem lives in
+// package main.
+func discoveredToParsed(sys *hunt.DiscoveredSystem) parsedSystem {
+	ps := parsedSystem{
+		Name:     sys.DisplayName(),
+		Protocol: sys.Protocol,
+		County:   sys.County,
+		Location: sys.Location,
+	}
+	if sys.SystemID != 0 {
+		ps.SysID = fmt.Sprintf("%X", sys.SystemID)
+	}
+	if sys.WACN != 0 {
+		ps.WACN = fmt.Sprintf("%X", sys.WACN)
+	}
+
+	for _, st := range sys.Sites {
+		name := st.SiteName
+		if name == "" {
+			name = fmt.Sprintf("Site %d-%d", st.RFSS, st.SiteID)
+		}
+		site := parsedSite{
+			RFSS:     int(st.RFSS),
+			SiteID:   int(st.SiteID),
+			SiteName: name,
+			Cty:      st.County,
+			Include:  true,
+		}
+		for _, ch := range st.ControlChannels {
+			site.Frequencies = append(site.Frequencies, parsedFreq{
+				Hz:             ch.FrequencyHz,
+				ControlChannel: ch.IsControl,
+			})
+		}
+		for _, hz := range st.Secondary {
+			site.Frequencies = append(site.Frequencies, parsedFreq{Hz: hz, ControlChannel: true})
+		}
+		ps.Sites = append(ps.Sites, site)
+	}
+
+	for _, tg := range sys.Talkgroups {
+		ps.Talkgroups = append(ps.Talkgroups, parsedTalkgroup{
+			Dec:       tg.Dec,
+			Hex:       tg.Hex,
+			Mode:      "D",
+			Encrypted: tg.Encrypted,
+			Scan:      true,
+		})
+	}
+	return ps
+}

--- a/cmd/gophertrunk/hunt_roundtrip_test.go
+++ b/cmd/gophertrunk/hunt_roundtrip_test.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/hunt"
+)
+
+// TestHuntBundleRoundTrip is the load-bearing guarantee of the export: a
+// DiscoveredSystem rendered as a bundle must re-import cleanly through the
+// importer's parseCSVStream with its sites, control channels and talkgroups
+// intact. This couples the hunt exporter to the importer so the two formats
+// can't silently drift apart.
+func TestHuntBundleRoundTrip(t *testing.T) {
+	sys := &hunt.DiscoveredSystem{
+		Name:     "Roundtrip P25",
+		Protocol: "p25",
+		WACN:     0xBEE99,
+		SystemID: 0x49A,
+		County:   "Example County",
+		Location: "Example City, AZ",
+		Sites: []hunt.DiscoveredSite{{
+			RFSS: 1, SiteID: 2, SiteName: "Tower Alpha", County: "Example",
+			ControlChannels: []hunt.DiscoveredChannel{
+				{FrequencyHz: 851012500, IsControl: true},
+				{FrequencyHz: 851262500, IsControl: true},
+			},
+		}},
+		Talkgroups: []hunt.DiscoveredTalkgroup{
+			{Dec: 1000, Hex: "3e8", Count: 3},
+			{Dec: 1001, Hex: "3e9", Count: 1},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := hunt.Write(&buf, sys, hunt.FormatBundle, nil); err != nil {
+		t.Fatalf("write bundle: %v", err)
+	}
+
+	got, err := parseCSVStream(bytes.NewReader(buf.Bytes()))
+	if err != nil {
+		t.Fatalf("re-import bundle failed: %v\n--- bundle ---\n%s", err, buf.String())
+	}
+
+	if got.Name != "Roundtrip P25" {
+		t.Errorf("Name = %q, want Roundtrip P25", got.Name)
+	}
+	if got.Protocol != "p25" {
+		t.Errorf("Protocol = %q, want p25", got.Protocol)
+	}
+	if got.County != "Example County" {
+		t.Errorf("County = %q, want Example County", got.County)
+	}
+	if got.Location != "Example City, AZ" {
+		t.Errorf("Location = %q, want \"Example City, AZ\"", got.Location)
+	}
+	if len(got.Sites) != 1 {
+		t.Fatalf("len(Sites) = %d, want 1", len(got.Sites))
+	}
+	st := got.Sites[0]
+	if st.RFSS != 1 || st.SiteID != 2 {
+		t.Errorf("site = RFSS %d Site %d, want 1/2", st.RFSS, st.SiteID)
+	}
+	if len(st.Frequencies) != 2 {
+		t.Fatalf("len(Frequencies) = %d, want 2", len(st.Frequencies))
+	}
+	if st.Frequencies[0].Hz != 851012500 || !st.Frequencies[0].ControlChannel {
+		t.Errorf("freq[0] = %+v, want 851012500 control", st.Frequencies[0])
+	}
+	if len(got.Talkgroups) != 2 {
+		t.Fatalf("len(Talkgroups) = %d, want 2", len(got.Talkgroups))
+	}
+	if got.Talkgroups[0].Dec != 1000 {
+		t.Errorf("tg[0].Dec = %d, want 1000", got.Talkgroups[0].Dec)
+	}
+}
+
+func TestDiscoveredToParsed(t *testing.T) {
+	sys := &hunt.DiscoveredSystem{
+		Protocol: "dmr",
+		SystemID: 0x10,
+		Sites: []hunt.DiscoveredSite{{
+			RFSS: 0, SiteID: 0,
+			ControlChannels: []hunt.DiscoveredChannel{{FrequencyHz: 851000000, IsControl: true}},
+		}},
+		Talkgroups: []hunt.DiscoveredTalkgroup{{Dec: 5, Hex: "5", Encrypted: true}},
+	}
+	ps := discoveredToParsed(sys)
+	if ps.SysID != "10" {
+		t.Errorf("SysID = %q, want 10", ps.SysID)
+	}
+	if len(ps.Sites) != 1 || ps.Sites[0].SiteName == "" || !ps.Sites[0].Include {
+		t.Errorf("site mapping wrong: %+v", ps.Sites)
+	}
+	if len(ps.Talkgroups) != 1 || !ps.Talkgroups[0].Encrypted || ps.Talkgroups[0].Mode != "D" {
+		t.Errorf("talkgroup mapping wrong: %+v", ps.Talkgroups)
+	}
+}

--- a/cmd/gophertrunk/main.go
+++ b/cmd/gophertrunk/main.go
@@ -62,6 +62,8 @@ func main() {
 		runAnalyze(os.Args[2:])
 	case "identify":
 		runIdentify(os.Args[2:])
+	case "hunt":
+		runHunt(os.Args[2:])
 	case "gen":
 		runGen(os.Args[2:])
 	case "capture":
@@ -103,6 +105,7 @@ USAGE:
   gophertrunk replay [flags]          decode a raw IQ capture file offline (any protocol)
   gophertrunk analyze [flags]         decode + analyze a capture with structured export (json/yaml/csv)
   gophertrunk identify [flags]        auto-detect the protocol in a capture, then analyze it
+  gophertrunk hunt [flags]            discover & map an unknown trunked system, export it + an RR submission package
   gophertrunk gen [flags]             synthesize a test IQ capture + metadata for a protocol
   gophertrunk capture [flags]         record raw IQ off a live SDR to a .cfile + metadata sidecar
   gophertrunk test [flags]            decode a capture and grade it against acceptance criteria

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -27,6 +27,21 @@ diagnostics:
   # -verbose-errors or GOPHERTRUNK_VERBOSE_ERRORS=1.
   verbose_errors: false
 
+# radioreference — read-only credentials for RadioReference.com's SOAP web
+# service, used by `gophertrunk hunt` to check whether a discovered system
+# already exists in RadioReference before you submit it. RadioReference has
+# NO public write API — new systems go through a manual web Submit form
+# reviewed by administrators — so nothing is ever posted; this is purely a
+# read-only duplicate check. All fields are optional: with no api_key the
+# check is simply skipped and the hunt still exports its files. The values
+# are also overridable by GOPHERTRUNK_RR_KEY / GOPHERTRUNK_RR_USER /
+# GOPHERTRUNK_RR_PASS and the `hunt -rr-key` flag, so the secret need not
+# live in this file. Request an API key at https://www.radioreference.com/account/api
+# radioreference:
+#   api_key: ""
+#   username: ""
+#   password: ""
+
 api:
   http_addr: "127.0.0.1:8080"   # HTTP REST + SSE + WebSocket
   grpc_addr: "127.0.0.1:50051"  # gRPC

--- a/docs/hunt.md
+++ b/docs/hunt.md
@@ -1,0 +1,124 @@
+# Hunting & mapping unknown systems
+
+Many states and counties run trunked radio systems that are **not documented
+on RadioReference.com**. GopherTrunk can already follow and decode a system
+once you know its control-channel frequencies and identity; `gophertrunk hunt`
+closes the loop for the *undocumented* case — it turns one or more IQ captures
+of a suspected control channel into a structured **DiscoveredSystem** map and
+exports it to standardized files plus a ready-to-paste RadioReference
+submission package.
+
+## What it does
+
+For each capture you supply, `hunt`:
+
+1. **Identifies** the protocol (auto, across all 13 GopherTrunk decoders) — or
+   uses the protocol you pass with `-protocol`.
+2. **Decodes** the control channel and **accumulates** what it observes into a
+   single system map: identity (P25 NAC, plus WACN/SYSID/RFSS/Site and other
+   per-protocol identifiers when the decoder surfaces them), the site's control
+   channel, and every talkgroup seen in a grant.
+3. **De-duplicates** across captures — fold several sites or several captures
+   of the same system into one map (sites keyed by RFSS/Site, channels by
+   frequency, talkgroups by id).
+4. **Exports** to the formats you choose and, optionally, **merges straight
+   into `config.yaml`** so you can start scanning the new system immediately.
+
+## Quick start
+
+```sh
+# Capture a suspected control channel off a live SDR (see `gophertrunk capture`)
+gophertrunk capture -serial 00000001 -freq 851012500 -seconds 60 -out cc.cfile
+
+# Map it and export everything (bundle + trunk-recorder + RR package)
+gophertrunk hunt -in cc.cfile -freq 851012500 -format f32 -sample-rate 2400000 \
+  -name "New County P25" -state AZ -county Maricopa -out ./hunt-newcounty
+```
+
+Fold multiple sites of the same system into one map:
+
+```sh
+gophertrunk hunt \
+  -in site1.cfile -freq 851012500 \
+  -in site2.cfile -freq 853512500 \
+  -format f32 -sample-rate 2400000 -name "New County P25"
+```
+
+Discover and merge straight into `config.yaml` (same writer the PDF/CSV
+importer uses):
+
+```sh
+gophertrunk hunt -in cc.cfile -freq 851012500 -sample-rate 2400000 \
+  -commit -config ./config.yaml
+```
+
+> **Tip:** pass `-freq` (the capture's center frequency in Hz) for every
+> `-in` so the recorded control channel carries an absolute frequency.
+> Without it, a baseband capture locks at 0 Hz and the channel can't be
+> exported.
+
+## Export formats
+
+Select with `-formats` (comma-separated; default is all three):
+
+| Value | File | Contents |
+|---|---|---|
+| `bundle` | `<name>.csv` | GopherTrunk multi-section import bundle — round-trips back in via `import-pdf -csv` (and is what `-commit` writes). |
+| `trunk-recorder` | `<name>.json` | A trunk-recorder system config stanza (control channels + type + modulation). |
+| `rr` | `<name>-radioreference.md` | A human-readable RadioReference submission package (identity, sites, control channels, observed talkgroups) with the Submit link. |
+
+## RadioReference duplicate check (optional, read-only)
+
+RadioReference has **no public write API** — new systems are added through a
+web Submit form reviewed by administrators. GopherTrunk never posts anything.
+What it *can* do is use RadioReference's read-only SOAP web service to check
+whether your discovery already exists, so you don't submit a duplicate. The
+result is folded into the `rr` submission package as a warning banner.
+
+Provide an API key (request one at <https://www.radioreference.com/account/api>)
+via `-rr-key`, the `radioreference.api_key` config block, or the
+`GOPHERTRUNK_RR_KEY` environment variable (username/password via
+`GOPHERTRUNK_RR_USER` / `GOPHERTRUNK_RR_PASS`), then point the check at
+candidate systems:
+
+```sh
+# Compare against every system registered in a RadioReference county (ctid)
+gophertrunk hunt -in cc.cfile -freq 851012500 -sample-rate 2400000 \
+  -rr-key "$GOPHERTRUNK_RR_KEY" -rr-county-id 261
+
+# …or against specific suspected system ids
+gophertrunk hunt -in cc.cfile -freq 851012500 -sample-rate 2400000 \
+  -rr-check-sid 7715 -rr-check-sid 8123
+```
+
+With no key the check is skipped and the export still happens. Use `-no-rr`
+to force it off even when a key is configured.
+
+## Key flags
+
+| Flag | Meaning |
+|---|---|
+| `-in` (repeatable) | IQ capture of a suspected control channel |
+| `-freq` (repeatable) | Nominal center frequency in Hz for the matching `-in` |
+| `-format` / `-sample-rate` | IQ encoding (`u8`/`f32`) and sample rate |
+| `-protocol` | Force a decoder; default auto-identifies each capture |
+| `-min-confidence` | Skip auto-identified captures below this (default 0.40) |
+| `-name` / `-state` / `-county` / `-location` | System metadata for the exports |
+| `-out` / `-formats` | Output directory and which files to write |
+| `-commit` / `-config` / `-dry-run` / `-force` | Merge the discovery into `config.yaml` |
+| `-rr-key` / `-rr-county-id` / `-rr-check-sid` / `-no-rr` | RadioReference duplicate check |
+
+## Limitations & roadmap
+
+- **Operator-supplied captures.** Today you supply the captures (one per
+  suspected control channel). A live wideband **spectrum-sweep** front-end
+  that finds the candidate control channels on the air automatically — using
+  the existing FFT spectrum producer for peak detection — is the planned
+  follow-on, along with a live cockpit/TUI/web panel.
+- **Topology depth.** Full multi-site topology (WACN/SYSID/RFSS/Site,
+  neighbor/adjacent sites, band plan) is richest on **P25**; for other
+  protocols the map carries the identity the decoder surfaces plus the single
+  observed site and its talkgroups — enough to export and submit.
+- **Talkgroup names.** A blind discovery can only record talkgroup *numbers*
+  and activity; names/descriptions are filled in during RadioReference
+  submission.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,28 +14,44 @@ import (
 )
 
 type Config struct {
-	Log         LogConfig         `yaml:"log"`
-	SDR         SDRConfig         `yaml:"sdr"`
-	Trunking    TrunkingConfig    `yaml:"trunking"`
-	API         APIConfig         `yaml:"api"`
-	Storage     StorageConfig     `yaml:"storage"`
-	Recordings  RecordingsConfig  `yaml:"recordings"`
-	Metrics     MetricsConfig     `yaml:"metrics"`
-	Retention   RetentionConfig   `yaml:"retention"`
-	ToneOut     ToneOutConfig     `yaml:"tone_out"`
-	Scanner     ScannerConfig     `yaml:"scanner"`
-	Audio       AudioConfig       `yaml:"audio"`
-	Broadcast   BroadcastConfig   `yaml:"broadcast"`
-	Baseband    BasebandConfig    `yaml:"baseband"`
-	Paging      PagingConfig      `yaml:"paging"`
-	APRS        APRSConfig        `yaml:"aprs"`
-	AIS         AISConfig         `yaml:"ais"`
-	DSC         DSCConfig         `yaml:"dsc"`
-	MDC1200     MDC1200Config     `yaml:"mdc1200"`
-	ADSB        ADSBConfig        `yaml:"adsb"`
-	M17         M17Config         `yaml:"m17"`
-	Web         WebConfig         `yaml:"web"`
-	Diagnostics DiagnosticsConfig `yaml:"diagnostics"`
+	Log            LogConfig            `yaml:"log"`
+	SDR            SDRConfig            `yaml:"sdr"`
+	Trunking       TrunkingConfig       `yaml:"trunking"`
+	API            APIConfig            `yaml:"api"`
+	Storage        StorageConfig        `yaml:"storage"`
+	Recordings     RecordingsConfig     `yaml:"recordings"`
+	Metrics        MetricsConfig        `yaml:"metrics"`
+	Retention      RetentionConfig      `yaml:"retention"`
+	ToneOut        ToneOutConfig        `yaml:"tone_out"`
+	Scanner        ScannerConfig        `yaml:"scanner"`
+	Audio          AudioConfig          `yaml:"audio"`
+	Broadcast      BroadcastConfig      `yaml:"broadcast"`
+	Baseband       BasebandConfig       `yaml:"baseband"`
+	Paging         PagingConfig         `yaml:"paging"`
+	APRS           APRSConfig           `yaml:"aprs"`
+	AIS            AISConfig            `yaml:"ais"`
+	DSC            DSCConfig            `yaml:"dsc"`
+	MDC1200        MDC1200Config        `yaml:"mdc1200"`
+	ADSB           ADSBConfig           `yaml:"adsb"`
+	M17            M17Config            `yaml:"m17"`
+	Web            WebConfig            `yaml:"web"`
+	Diagnostics    DiagnosticsConfig    `yaml:"diagnostics"`
+	RadioReference RadioReferenceConfig `yaml:"radioreference"`
+}
+
+// RadioReferenceConfig holds credentials for RadioReference.com's read-only
+// SOAP web service. It is consumed by `gophertrunk hunt` to check whether a
+// discovered system already exists in RadioReference before producing a
+// submission package (RadioReference has no public write API, so nothing is
+// ever posted — this is a read-only duplicate check). All fields are optional;
+// when APIKey is empty the duplicate check is skipped and the hunt still
+// exports its files. The values are also overridable by the GOPHERTRUNK_RR_KEY
+// / GOPHERTRUNK_RR_USER / GOPHERTRUNK_RR_PASS environment variables and the
+// hunt -rr-key flag, so the secret need not live in config.yaml.
+type RadioReferenceConfig struct {
+	APIKey   string `yaml:"api_key"`
+	Username string `yaml:"username"`
+	Password string `yaml:"password"`
 }
 
 // DiagnosticsConfig controls error-reporting verbosity. When

--- a/internal/hunt/accumulate.go
+++ b/internal/hunt/accumulate.go
@@ -1,0 +1,211 @@
+package hunt
+
+import (
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/siglab"
+)
+
+// Observation is one control-channel decode folded into a DiscoveredSystem.
+// It is the bridge between the signal lab (which produces a siglab.Result per
+// capture) and the discovery model. One Observation typically corresponds to
+// one captured control channel of one site.
+type Observation struct {
+	// Protocol is the trunking.Protocol.String() spelling of the decoded CC.
+	Protocol string
+	// Confidence is the protocol-identification confidence (0..1). When the
+	// protocol was supplied by the operator rather than auto-identified, pass
+	// 1.0.
+	Confidence float64
+	// Result is the signal-lab decode of the capture. Lock + Grants + Events
+	// are mined for identity and talkgroups.
+	Result *siglab.Result
+	// FallbackFreqHz is the capture's nominal center frequency, used as the
+	// control-channel frequency when the decoder's lock payload doesn't carry
+	// one (e.g. a baseband capture). 0 ⇒ no fallback.
+	FallbackFreqHz uint32
+	// At is the wall-clock time the capture was taken (defaults to now).
+	At time.Time
+}
+
+// identityKeys are the per-protocol identity field names harvested from the
+// lock payload and from event payloads. flattenPayload exposes exported
+// struct fields by name, so any decoder that carries these surfaces them here
+// without a per-protocol switch. WACN/SystemID/RFSS/Site are P25; ColorCode
+// (DMR), RAN (NXDN), MCC/MNC (TETRA), SystemID (Motorola/EDACS) cover the rest.
+var identityKeys = []string{
+	"WACN", "SystemID", "RFSS", "Site", "NAC",
+	"ColorCode", "RAN", "MCC", "MNC", "LRA",
+}
+
+// Accumulate folds an Observation into dst, creating sites/talkgroups and
+// merging identity. It de-duplicates control channels by frequency, sites by
+// (RFSS, Site), and talkgroups by decimal id, so re-observing the same control
+// channel is idempotent (apart from bumping talkgroup activity counts).
+func Accumulate(dst *DiscoveredSystem, obs Observation) {
+	at := obs.At
+	if at.IsZero() {
+		at = time.Now()
+	}
+	if dst.FirstSeen.IsZero() || at.Before(dst.FirstSeen) {
+		dst.FirstSeen = at
+	}
+	if at.After(dst.LastSeen) {
+		dst.LastSeen = at
+	}
+	if dst.Protocol == "" {
+		dst.Protocol = obs.Protocol
+	}
+	if dst.Confidence == 0 || (obs.Confidence > 0 && obs.Confidence < dst.Confidence) {
+		dst.Confidence = obs.Confidence
+	}
+	if obs.Result == nil {
+		return
+	}
+
+	// Harvest identity from the lock payload first, then from every event
+	// payload (the network/RFSS-status TSBKs ride in events, not the lock).
+	if dst.Identity == nil {
+		dst.Identity = map[string]any{}
+	}
+	var ccFreq uint32
+	if lk := obs.Result.Lock; lk != nil {
+		ccFreq = lk.FrequencyHz
+		harvestIdentity(dst, lk.Fields)
+	}
+	for _, ev := range obs.Result.Events {
+		harvestIdentity(dst, ev.Fields)
+	}
+	// Fall back to the capture's nominal center when the lock didn't carry an
+	// absolute frequency (baseband captures lock at 0 Hz).
+	if ccFreq == 0 {
+		ccFreq = obs.FallbackFreqHz
+	}
+
+	// Place this control channel on its site. RFSS/Site come from the
+	// harvested identity (0,0 when the decoder didn't surface them). A lock
+	// with no usable frequency still records the site so identity and
+	// talkgroups attach — but only a non-zero frequency is recorded as a
+	// channel (a 0 Hz channel can't be exported).
+	rfss := uint8(dst.RFSS())
+	site := uint8(dst.SiteNum())
+	switch {
+	case ccFreq != 0:
+		dst.addControlChannel(rfss, site, ccFreq, obs.Confidence)
+	case obs.Result.Locked:
+		dst.site(rfss, site) // ensure the site exists for identity/talkgroups
+	}
+
+	// Talkgroups: every grant's destination group is an observed talkgroup.
+	for _, g := range obs.Result.Grants {
+		if g.GroupID == 0 {
+			continue
+		}
+		dst.addTalkgroup(g.GroupID, g.Encrypted, at)
+	}
+}
+
+// harvestIdentity copies recognised identity fields from a flattened payload
+// into the system's typed identity (WACN/SystemID/NAC) and Identity map. It
+// only overwrites a typed field when the current value is zero, so the first
+// non-zero observation wins and later ones don't clobber it with a 0.
+func harvestIdentity(dst *DiscoveredSystem, fields map[string]any) {
+	if fields == nil {
+		return
+	}
+	for _, k := range identityKeys {
+		v, ok := fields[k]
+		if !ok {
+			continue
+		}
+		u, ok := toUint64(v)
+		if !ok || u == 0 {
+			continue
+		}
+		switch k {
+		case "WACN":
+			if dst.WACN == 0 {
+				dst.WACN = uint32(u)
+			}
+		case "SystemID":
+			if dst.SystemID == 0 {
+				dst.SystemID = uint16(u)
+			}
+		case "NAC":
+			if dst.NAC == 0 {
+				dst.NAC = uint16(u)
+			}
+		}
+		if _, present := dst.Identity[k]; !present {
+			dst.Identity[k] = u
+		}
+	}
+}
+
+// RFSS returns the RFSS id harvested into the Identity map (0 when unknown).
+func (s *DiscoveredSystem) RFSS() uint64 { return identityUint(s.Identity, "RFSS") }
+
+// SiteNum returns the Site id harvested into the Identity map (0 when unknown).
+func (s *DiscoveredSystem) SiteNum() uint64 { return identityUint(s.Identity, "Site") }
+
+func identityUint(m map[string]any, key string) uint64 {
+	if m == nil {
+		return 0
+	}
+	u, _ := toUint64(m[key])
+	return u
+}
+
+// toUint64 coerces the numeric types reflect produces (and JSON's float64)
+// into a uint64. Returns ok=false for non-numeric or negative values.
+func toUint64(v any) (uint64, bool) {
+	switch n := v.(type) {
+	case uint:
+		return uint64(n), true
+	case uint8:
+		return uint64(n), true
+	case uint16:
+		return uint64(n), true
+	case uint32:
+		return uint64(n), true
+	case uint64:
+		return n, true
+	case int:
+		if n < 0 {
+			return 0, false
+		}
+		return uint64(n), true
+	case int8:
+		if n < 0 {
+			return 0, false
+		}
+		return uint64(n), true
+	case int16:
+		if n < 0 {
+			return 0, false
+		}
+		return uint64(n), true
+	case int32:
+		if n < 0 {
+			return 0, false
+		}
+		return uint64(n), true
+	case int64:
+		if n < 0 {
+			return 0, false
+		}
+		return uint64(n), true
+	case float64:
+		if n < 0 {
+			return 0, false
+		}
+		return uint64(n), true
+	case float32:
+		if n < 0 {
+			return 0, false
+		}
+		return uint64(n), true
+	default:
+		return 0, false
+	}
+}

--- a/internal/hunt/accumulate_test.go
+++ b/internal/hunt/accumulate_test.go
@@ -1,0 +1,123 @@
+package hunt
+
+import (
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/siglab"
+)
+
+// fakeResult builds a siglab.Result with a lock carrying the given identity
+// fields and the given grant group ids.
+func fakeResult(ccHz uint32, fields map[string]any, groups ...uint32) *siglab.Result {
+	r := &siglab.Result{
+		Locked: true,
+		Lock:   &siglab.LockInfo{FrequencyHz: ccHz, Fields: fields},
+	}
+	for _, g := range groups {
+		r.Grants = append(r.Grants, siglab.GrantRecord{GroupID: g})
+	}
+	return r
+}
+
+func TestAccumulate_IdentityAndTalkgroups(t *testing.T) {
+	sys := &DiscoveredSystem{}
+	at := time.Date(2026, 6, 6, 12, 0, 0, 0, time.UTC)
+
+	Accumulate(sys, Observation{
+		Protocol:   "p25",
+		Confidence: 0.9,
+		At:         at,
+		Result: fakeResult(851012500, map[string]any{
+			"NAC":      uint16(0x4D2),
+			"WACN":     uint32(0xBEE99),
+			"SystemID": uint16(0x49A),
+			"RFSS":     uint8(1),
+			"Site":     uint8(2),
+		}, 1000, 1001, 1000),
+	})
+
+	if sys.Protocol != "p25" {
+		t.Errorf("Protocol = %q, want p25", sys.Protocol)
+	}
+	if sys.WACN != 0xBEE99 {
+		t.Errorf("WACN = %X, want BEE99", sys.WACN)
+	}
+	if sys.SystemID != 0x49A {
+		t.Errorf("SystemID = %X, want 49A", sys.SystemID)
+	}
+	if sys.NAC != 0x4D2 {
+		t.Errorf("NAC = %X, want 4D2", sys.NAC)
+	}
+	if len(sys.Sites) != 1 {
+		t.Fatalf("len(Sites) = %d, want 1", len(sys.Sites))
+	}
+	st := sys.Sites[0]
+	if st.RFSS != 1 || st.SiteID != 2 {
+		t.Errorf("site = RFSS %d Site %d, want 1/2", st.RFSS, st.SiteID)
+	}
+	if len(st.ControlChannels) != 1 || st.ControlChannels[0].FrequencyHz != 851012500 {
+		t.Errorf("control channels = %+v, want one @ 851012500", st.ControlChannels)
+	}
+	// 1000 was granted twice → one talkgroup with count 2; 1001 once.
+	if len(sys.Talkgroups) != 2 {
+		t.Fatalf("len(Talkgroups) = %d, want 2", len(sys.Talkgroups))
+	}
+	for _, tg := range sys.Talkgroups {
+		if tg.Dec == 1000 && tg.Count != 2 {
+			t.Errorf("tg 1000 count = %d, want 2", tg.Count)
+		}
+	}
+}
+
+func TestAccumulate_Idempotent_DedupesSites(t *testing.T) {
+	sys := &DiscoveredSystem{}
+	obs := Observation{
+		Protocol:   "p25",
+		Confidence: 0.8,
+		Result: fakeResult(851012500, map[string]any{
+			"RFSS": uint8(1), "Site": uint8(1),
+		}, 2000),
+	}
+	Accumulate(sys, obs)
+	Accumulate(sys, obs) // re-observe the same control channel
+
+	if len(sys.Sites) != 1 {
+		t.Fatalf("len(Sites) = %d, want 1 (deduped)", len(sys.Sites))
+	}
+	if len(sys.Sites[0].ControlChannels) != 1 {
+		t.Fatalf("len(ControlChannels) = %d, want 1 (deduped by freq)", len(sys.Sites[0].ControlChannels))
+	}
+	if len(sys.Talkgroups) != 1 {
+		t.Fatalf("len(Talkgroups) = %d, want 1", len(sys.Talkgroups))
+	}
+	if sys.Talkgroups[0].Count != 2 {
+		t.Errorf("tg count = %d, want 2 (bumped on re-observe)", sys.Talkgroups[0].Count)
+	}
+}
+
+func TestAccumulate_ConfidenceTakesMinimum(t *testing.T) {
+	sys := &DiscoveredSystem{}
+	Accumulate(sys, Observation{Protocol: "p25", Confidence: 0.9, Result: fakeResult(1, nil)})
+	Accumulate(sys, Observation{Protocol: "p25", Confidence: 0.6, Result: fakeResult(2, nil)})
+	if sys.Confidence != 0.6 {
+		t.Errorf("Confidence = %v, want 0.6 (minimum across CCs)", sys.Confidence)
+	}
+}
+
+func TestDisplayName_Synthesized(t *testing.T) {
+	cases := []struct {
+		sys  DiscoveredSystem
+		want string
+	}{
+		{DiscoveredSystem{Name: "Real Name"}, "Real Name"},
+		{DiscoveredSystem{Protocol: "p25", WACN: 0xBEE99, SystemID: 0x49A}, "Unknown-p25-BEE99-49A"},
+		{DiscoveredSystem{Protocol: "dmr", SystemID: 0x10}, "Unknown-dmr-010"},
+		{DiscoveredSystem{Protocol: "nxdn"}, "Unknown-nxdn"},
+	}
+	for _, c := range cases {
+		if got := c.sys.DisplayName(); got != c.want {
+			t.Errorf("DisplayName(%+v) = %q, want %q", c.sys, got, c.want)
+		}
+	}
+}

--- a/internal/hunt/discover.go
+++ b/internal/hunt/discover.go
@@ -1,0 +1,156 @@
+package hunt
+
+import (
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/siglab"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// CaptureInput is one IQ capture to fold into a discovery — typically a
+// recording centered on a suspected control channel. The hunt orchestrator
+// identifies the protocol (unless Protocol is set), decodes it, and
+// accumulates the result into the running system map.
+type CaptureInput struct {
+	Path         string
+	Format       siglab.SampleFormat
+	SampleRateHz float64
+	// FrequencyHz is the capture's nominal center frequency (informational;
+	// the decoded lock frequency is what gets recorded).
+	FrequencyHz uint32
+	AutoTune    bool
+	Conjugate   bool
+	IQCorrect   bool
+	// Protocol forces a decoder; trunking.ProtocolUnknown (the zero value)
+	// triggers auto-identification across every protocol.
+	Protocol trunking.Protocol
+	// IdentifyMaxSamples caps the prefix the identifier scans (0 ⇒ a built-in
+	// default prefix). Only consulted when Protocol is unknown.
+	IdentifyMaxSamples int64
+}
+
+// DiscoverConfig carries operator metadata and thresholds for a discovery run.
+type DiscoverConfig struct {
+	Name          string
+	State         string
+	County        string
+	Location      string
+	MinConfidence float64 // skip auto-identified captures below this (0 ⇒ 0.40)
+	Log           *slog.Logger
+}
+
+// CaptureReport records what happened to one capture so the CLI/cockpit can
+// explain the outcome (decoded, skipped as not-trunked, errored).
+type CaptureReport struct {
+	Path       string  `json:"path"`
+	Protocol   string  `json:"protocol"`
+	Confidence float64 `json:"confidence"`
+	Locked     bool    `json:"locked"`
+	ControlHz  uint32  `json:"control_hz,omitempty"`
+	Talkgroups int     `json:"talkgroups"`
+	Skipped    bool    `json:"skipped"`
+	SkipReason string  `json:"skip_reason,omitempty"`
+	Error      string  `json:"error,omitempty"`
+}
+
+// Discover folds every capture into a single DiscoveredSystem. Captures whose
+// protocol can't be identified with sufficient confidence (and weren't given
+// an explicit protocol) are skipped, not errored, so a wideband sweep that
+// surfaced non-trunked carriers degrades gracefully. The per-capture reports
+// are always returned, even on a nil error, so the caller can show progress.
+func Discover(captures []CaptureInput, cfg DiscoverConfig) (*DiscoveredSystem, []CaptureReport, error) {
+	log := cfg.Log
+	if log == nil {
+		log = slog.New(slog.DiscardHandler)
+	}
+	minConf := cfg.MinConfidence
+	if minConf <= 0 {
+		minConf = 0.40
+	}
+
+	sys := &DiscoveredSystem{
+		Name:     cfg.Name,
+		State:    cfg.State,
+		County:   cfg.County,
+		Location: cfg.Location,
+	}
+	reports := make([]CaptureReport, 0, len(captures))
+
+	for _, cap := range captures {
+		rep := CaptureReport{Path: cap.Path}
+
+		proto := cap.Protocol
+		conf := 1.0 // operator-supplied protocol ⇒ full confidence
+		if proto == trunking.ProtocolUnknown {
+			idr, err := siglab.Identify(cap.Path, siglab.IdentifyConfig{
+				SampleRateHz: cap.SampleRateHz,
+				Format:       cap.Format,
+				AutoTune:     cap.AutoTune,
+				Conjugate:    cap.Conjugate,
+				IQCorrect:    cap.IQCorrect,
+				MaxSamples:   cap.IdentifyMaxSamples,
+				Log:          log,
+			})
+			if err != nil {
+				rep.Error = fmt.Sprintf("identify: %v", err)
+				reports = append(reports, rep)
+				continue
+			}
+			conf = idr.Confidence
+			if idr.Inconclusive || idr.Confidence < minConf {
+				rep.Protocol = idr.Winner
+				rep.Confidence = idr.Confidence
+				rep.Skipped = true
+				rep.SkipReason = fmt.Sprintf("no trunked control channel above confidence %.2f (best: %s @ %.2f)",
+					minConf, idr.Winner, idr.Confidence)
+				reports = append(reports, rep)
+				continue
+			}
+			p, err := idr.WinnerProtocol()
+			if err != nil {
+				rep.Error = fmt.Sprintf("winner protocol: %v", err)
+				reports = append(reports, rep)
+				continue
+			}
+			proto = p
+		}
+		rep.Protocol = proto.String()
+		rep.Confidence = conf
+
+		res, err := siglab.Run(cap.Path, siglab.Config{
+			Protocol:     proto,
+			FrequencyHz:  cap.FrequencyHz,
+			SampleRateHz: cap.SampleRateHz,
+			Format:       cap.Format,
+			AutoTune:     cap.AutoTune,
+			Conjugate:    cap.Conjugate,
+			IQCorrect:    cap.IQCorrect,
+			Log:          log,
+		})
+		if err != nil {
+			rep.Error = fmt.Sprintf("decode: %v", err)
+			reports = append(reports, rep)
+			continue
+		}
+
+		before := len(sys.Talkgroups)
+		Accumulate(sys, Observation{
+			Protocol:       proto.String(),
+			Confidence:     conf,
+			Result:         res,
+			FallbackFreqHz: cap.FrequencyHz,
+			At:             time.Now(),
+		})
+		rep.Locked = res.Locked
+		if res.Lock != nil {
+			rep.ControlHz = res.Lock.FrequencyHz
+		}
+		rep.Talkgroups = len(sys.Talkgroups) - before
+		reports = append(reports, rep)
+	}
+
+	sys.sortAll()
+	return sys, reports, nil
+}

--- a/internal/hunt/export.go
+++ b/internal/hunt/export.go
@@ -1,0 +1,85 @@
+package hunt
+
+import (
+	"fmt"
+	"io"
+	"strings"
+)
+
+// Format selects an export encoding for a DiscoveredSystem.
+type Format int
+
+const (
+	// FormatBundle is GopherTrunk's multi-section CSV import bundle (the exact
+	// reverse of cmd/gophertrunk/import_csv.go parseCSVStream — it round-trips
+	// straight back into config.yaml via `import-pdf -csv`).
+	FormatBundle Format = iota
+	// FormatTrunkRecorder is a trunk-recorder JSON system config stanza.
+	FormatTrunkRecorder
+	// FormatRR is a human-readable RadioReference.com submission package.
+	FormatRR
+)
+
+// String renders the format as the value operators type on the CLI.
+func (f Format) String() string {
+	switch f {
+	case FormatTrunkRecorder:
+		return "trunk-recorder"
+	case FormatRR:
+		return "rr"
+	default:
+		return "bundle"
+	}
+}
+
+// FileExtension is the conventional extension for a format's output file.
+func (f Format) FileExtension() string {
+	switch f {
+	case FormatTrunkRecorder:
+		return "json"
+	case FormatRR:
+		return "md"
+	default:
+		return "csv"
+	}
+}
+
+// ParseFormat maps a -formats list value to a Format.
+func ParseFormat(s string) (Format, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "", "bundle", "csv", "import":
+		return FormatBundle, nil
+	case "trunk-recorder", "trunkrecorder", "tr", "trunk_recorder":
+		return FormatTrunkRecorder, nil
+	case "rr", "radioreference", "submission":
+		return FormatRR, nil
+	default:
+		return FormatBundle, fmt.Errorf("hunt: unknown export format %q (want bundle|trunk-recorder|rr)", s)
+	}
+}
+
+// Write serializes sys to w in the requested format. RRHints, when non-empty,
+// are rendered into the RR submission package (ignored by the other formats).
+func Write(w io.Writer, sys *DiscoveredSystem, f Format, hints []DuplicateHint) error {
+	sys.sortAll()
+	switch f {
+	case FormatBundle:
+		return writeBundle(w, sys)
+	case FormatTrunkRecorder:
+		return writeTrunkRecorder(w, sys)
+	case FormatRR:
+		return writeRR(w, sys, hints)
+	default:
+		return fmt.Errorf("hunt: unsupported format %d", f)
+	}
+}
+
+// DuplicateHint is a possible pre-existing RadioReference system match,
+// surfaced by an optional read-only RR API lookup. It is rendered into the RR
+// submission package so an operator doesn't submit a duplicate.
+type DuplicateHint struct {
+	SID        int     // RadioReference system id
+	Name       string  // existing system name
+	Reason     string  // why it matched (WACN+SYSID, overlapping CC, name/county)
+	Confidence float64 // 0..1
+}

--- a/internal/hunt/export_bundle.go
+++ b/internal/hunt/export_bundle.go
@@ -1,0 +1,164 @@
+package hunt
+
+import (
+	"encoding/csv"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+)
+
+// writeBundle emits the multi-section CSV import bundle that
+// cmd/gophertrunk/import_csv.go parseCSVStream reads. The section markers and
+// column names match parseMetadataSection / parseSitesSection /
+// parseTalkgroupsSection exactly so a discovery round-trips back into
+// config.yaml without loss. Rows are written through encoding/csv, whose
+// dialect matches the importer's splitCSVLine (comma-separated, double-quote
+// escaping), so site names and locations with commas survive.
+func writeBundle(w io.Writer, sys *DiscoveredSystem) error {
+	bw := &bundleWriter{w: w}
+
+	// --- metadata ---
+	bw.section("metadata")
+	bw.row("key", "value")
+	bw.row("name", sys.DisplayName())
+	if sys.Protocol != "" {
+		bw.row("protocol", sys.Protocol)
+	}
+	if sys.SystemID != 0 {
+		bw.row("sysid", fmt.Sprintf("%X", sys.SystemID))
+	}
+	if sys.WACN != 0 {
+		bw.row("wacn", fmt.Sprintf("%X", sys.WACN))
+	}
+	if sys.Location != "" {
+		bw.row("location", sys.Location)
+	}
+	if sys.County != "" {
+		bw.row("county", sys.County)
+	}
+
+	// --- sites ---
+	if len(sys.Sites) > 0 {
+		bw.blank()
+		bw.section("sites")
+		bw.row("rfss", "site_id", "site_name", "county", "frequencies")
+		for _, st := range sys.Sites {
+			name := st.SiteName
+			if name == "" {
+				name = fmt.Sprintf("Site %d-%d", st.RFSS, st.SiteID)
+			}
+			bw.row(
+				strconv.Itoa(int(st.RFSS)),
+				strconv.Itoa(int(st.SiteID)),
+				name,
+				st.County,
+				freqList(st),
+			)
+		}
+	}
+
+	// --- talkgroups ---
+	if len(sys.Talkgroups) > 0 {
+		bw.blank()
+		bw.section("talkgroups")
+		bw.row("decimal", "hex", "mode", "alpha_tag", "description", "tag", "group", "priority", "lockout", "scan")
+		for _, tg := range sys.Talkgroups {
+			bw.row(
+				strconv.FormatUint(uint64(tg.Dec), 10),
+				tg.Hex,
+				"D", // blind discovery: default digital; operator/RR refine
+				"",  // alpha_tag unknown
+				"",  // description unknown
+				"",  // tag unknown
+				"",  // group unknown
+				"",  // priority unset
+				"",  // lockout off
+				"Y", // scan on
+			)
+		}
+	}
+
+	return bw.flush()
+}
+
+// freqList renders a site's channels as the `|`-separated MHz list the sites
+// section expects, with control channels carrying the trailing `c` flag.
+func freqList(st DiscoveredSite) string {
+	parts := make([]string, 0, len(st.ControlChannels)+len(st.Secondary))
+	for _, ch := range st.ControlChannels {
+		s := formatMHz(ch.FrequencyHz)
+		if ch.IsControl {
+			s += "c"
+		}
+		parts = append(parts, s)
+	}
+	for _, hz := range st.Secondary {
+		parts = append(parts, formatMHz(hz)+"c")
+	}
+	return strings.Join(parts, "|")
+}
+
+// formatMHz renders a frequency in Hz as a MHz string with trailing zeros
+// trimmed (e.g. 851012500 → "851.0125"), the spelling the importer parses.
+func formatMHz(hz uint32) string {
+	s := strconv.FormatFloat(float64(hz)/1_000_000, 'f', 6, 64)
+	s = strings.TrimRight(s, "0")
+	s = strings.TrimRight(s, ".")
+	return s
+}
+
+// bundleWriter buffers a single error and wraps an encoding/csv.Writer so the
+// per-row error handling stays out of writeBundle.
+type bundleWriter struct {
+	w   io.Writer
+	cw  *csv.Writer
+	err error
+}
+
+func (b *bundleWriter) section(name string) {
+	if b.err != nil {
+		return
+	}
+	if b.cw != nil {
+		b.cw.Flush()
+		b.err = b.cw.Error()
+		b.cw = nil
+	}
+	_, b.err = fmt.Fprintf(b.w, "# Section: %s\n", name)
+	if b.err == nil {
+		b.cw = csv.NewWriter(b.w)
+	}
+}
+
+func (b *bundleWriter) row(fields ...string) {
+	if b.err != nil || b.cw == nil {
+		return
+	}
+	b.err = b.cw.Write(fields)
+}
+
+func (b *bundleWriter) blank() {
+	if b.err != nil {
+		return
+	}
+	if b.cw != nil {
+		b.cw.Flush()
+		b.err = b.cw.Error()
+		b.cw = nil
+	}
+	if b.err == nil {
+		_, b.err = io.WriteString(b.w, "\n")
+	}
+}
+
+func (b *bundleWriter) flush() error {
+	if b.err != nil {
+		return b.err
+	}
+	if b.cw != nil {
+		b.cw.Flush()
+		b.err = b.cw.Error()
+	}
+	return b.err
+}

--- a/internal/hunt/export_rr.go
+++ b/internal/hunt/export_rr.go
@@ -1,0 +1,169 @@
+package hunt
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+)
+
+// rrSubmitURL is the RadioReference "submit a new system" entry point.
+// RadioReference has no public write API — new systems go through this web
+// form, reviewed by Global administrators — so the submission package links
+// here rather than POSTing anything.
+const rrSubmitURL = "https://www.radioreference.com/db/submit/"
+
+// writeRR renders a human-readable RadioReference.com submission package
+// (Markdown) the operator can paste into the RR Submit form. When hints are
+// supplied (from the optional read-only RR API duplicate check) they are
+// surfaced at the top so the operator doesn't submit a duplicate.
+func writeRR(w io.Writer, sys *DiscoveredSystem, hints []DuplicateHint) error {
+	p := &errWriter{w: w}
+
+	p.printf("# RadioReference submission: %s\n\n", sys.DisplayName())
+	p.printf("_Discovered by GopherTrunk. Review every field before submitting; " +
+		"a blind discovery cannot name talkgroups or confirm site geography._\n\n")
+
+	// Duplicate warnings first.
+	if len(hints) > 0 {
+		p.printf("## ⚠️ Possible existing systems\n\n")
+		p.printf("A RadioReference lookup found system(s) that may already cover this. " +
+			"**Verify before submitting.**\n\n")
+		sorted := append([]DuplicateHint(nil), hints...)
+		sort.Slice(sorted, func(i, j int) bool { return sorted[i].Confidence > sorted[j].Confidence })
+		for _, h := range sorted {
+			p.printf("- SID **%d** — %s (matched on %s, confidence %.0f%%)\n",
+				h.SID, nonEmpty(h.Name, "(unnamed)"), h.Reason, h.Confidence*100)
+		}
+		p.printf("\n")
+	} else {
+		p.printf("_No matching system was found in RadioReference (or the duplicate " +
+			"check was skipped — supply an API key to enable it)._\n\n")
+	}
+
+	// Identity.
+	p.printf("## System\n\n")
+	p.printf("| Field | Value |\n|---|---|\n")
+	p.printf("| Name | %s |\n", sys.DisplayName())
+	p.printf("| Type / protocol | %s |\n", nonEmpty(sys.Protocol, "(unknown)"))
+	if sys.WACN != 0 {
+		p.printf("| WACN | %05X (hex) / %d (dec) |\n", sys.WACN, sys.WACN)
+	}
+	if sys.SystemID != 0 {
+		p.printf("| System ID (SYSID) | %03X (hex) / %d (dec) |\n", sys.SystemID, sys.SystemID)
+	}
+	if sys.NAC != 0 {
+		p.printf("| NAC | %03X (hex) |\n", sys.NAC)
+	}
+	for _, k := range identityKeys {
+		if k == "WACN" || k == "SystemID" || k == "NAC" {
+			continue
+		}
+		if v, ok := sys.Identity[k]; ok {
+			p.printf("| %s | %v |\n", k, v)
+		}
+	}
+	if sys.Location != "" {
+		p.printf("| Location | %s |\n", sys.Location)
+	}
+	if sys.County != "" {
+		p.printf("| County | %s |\n", sys.County)
+	}
+	if sys.State != "" {
+		p.printf("| State | %s |\n", sys.State)
+	}
+	p.printf("| Identification confidence | %.0f%% |\n", sys.Confidence*100)
+	p.printf("\n")
+
+	// Sites + control channels.
+	p.printf("## Sites & control channels\n\n")
+	if len(sys.Sites) == 0 {
+		p.printf("_No sites observed._\n\n")
+	}
+	for _, st := range sys.Sites {
+		name := st.SiteName
+		if name == "" {
+			name = fmt.Sprintf("Site %d-%d", st.RFSS, st.SiteID)
+		}
+		p.printf("### %s (RFSS %d, Site %d)\n\n", name, st.RFSS, st.SiteID)
+		if st.County != "" {
+			p.printf("County: %s\n\n", st.County)
+		}
+		p.printf("Control channels (MHz):\n\n")
+		for _, ch := range st.ControlChannels {
+			flag := ""
+			if ch.IsControl {
+				flag = " (control)"
+			}
+			p.printf("- %s%s\n", formatMHz(ch.FrequencyHz), flag)
+		}
+		if len(st.Neighbors) > 0 {
+			p.printf("\nAdjacent sites: ")
+			refs := make([]string, 0, len(st.Neighbors))
+			for _, n := range st.Neighbors {
+				refs = append(refs, fmt.Sprintf("RFSS %d/Site %d", n.RFSS, n.Site))
+			}
+			p.printf("%s\n", strings.Join(refs, ", "))
+		}
+		p.printf("\n")
+	}
+
+	// Band plan.
+	if len(sys.BandPlan) > 0 {
+		p.printf("## Band plan\n\n")
+		p.printf("| Channel ID | Base (MHz) | Spacing (kHz) | TX offset (MHz) |\n|---|---|---|---|\n")
+		for _, e := range sys.BandPlan {
+			p.printf("| %d | %s | %.4g | %.4g |\n",
+				e.ChannelID,
+				formatMHz(uint32(e.BaseHz)),
+				float64(e.SpacingHz)/1000,
+				float64(e.TxOffsetHz)/1_000_000)
+		}
+		p.printf("\n")
+	}
+
+	// Talkgroups.
+	p.printf("## Observed talkgroups\n\n")
+	if len(sys.Talkgroups) == 0 {
+		p.printf("_None observed on the control channel during the hunt._\n\n")
+	} else {
+		p.printf("Observed live on the control channel — names/descriptions are unknown " +
+			"and must be added during submission.\n\n")
+		p.printf("| Decimal | Hex | Observed grants | Encrypted |\n|---|---|---|---|\n")
+		for _, tg := range sys.Talkgroups {
+			enc := ""
+			if tg.Encrypted {
+				enc = "yes"
+			}
+			p.printf("| %d | %s | %d | %s |\n", tg.Dec, tg.Hex, tg.Count, enc)
+		}
+		p.printf("\n")
+	}
+
+	p.printf("## Submit\n\n")
+	p.printf("RadioReference has no public write API; new systems are added via the " +
+		"web Submit form and reviewed by a database administrator:\n\n")
+	p.printf("%s\n", rrSubmitURL)
+
+	return p.err
+}
+
+func nonEmpty(s, fallback string) string {
+	if strings.TrimSpace(s) == "" {
+		return fallback
+	}
+	return s
+}
+
+// errWriter collects the first write error so the renderer stays linear.
+type errWriter struct {
+	w   io.Writer
+	err error
+}
+
+func (e *errWriter) printf(format string, args ...any) {
+	if e.err != nil {
+		return
+	}
+	_, e.err = fmt.Fprintf(e.w, format, args...)
+}

--- a/internal/hunt/export_test.go
+++ b/internal/hunt/export_test.go
@@ -1,0 +1,158 @@
+package hunt
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+// sampleSystem is a fully-populated discovery used across the exporter tests.
+func sampleSystem() *DiscoveredSystem {
+	at := time.Date(2026, 6, 6, 12, 0, 0, 0, time.UTC)
+	return &DiscoveredSystem{
+		Name:     "Example P25 System",
+		Protocol: "p25",
+		WACN:     0xBEE99,
+		SystemID: 0x49A,
+		NAC:      0x4D2,
+		County:   "Example County",
+		Location: "Example City, AZ",
+		Identity: map[string]any{"WACN": uint64(0xBEE99), "SystemID": uint64(0x49A), "NAC": uint64(0x4D2)},
+		Sites: []DiscoveredSite{{
+			RFSS: 1, SiteID: 1, SiteName: "Tower Alpha", County: "Example",
+			ControlChannels: []DiscoveredChannel{
+				{FrequencyHz: 851012500, IsControl: true, Confidence: 0.9},
+				{FrequencyHz: 851262500, IsControl: true},
+			},
+		}},
+		Talkgroups: []DiscoveredTalkgroup{
+			{Dec: 1000, Hex: "3e8", Count: 5, FirstSeen: at},
+			{Dec: 1001, Hex: "3e9", Count: 1, Encrypted: true, FirstSeen: at},
+		},
+		Confidence: 0.9,
+	}
+}
+
+func TestParseFormat(t *testing.T) {
+	cases := map[string]Format{
+		"bundle": FormatBundle, "csv": FormatBundle, "": FormatBundle,
+		"trunk-recorder": FormatTrunkRecorder, "tr": FormatTrunkRecorder,
+		"rr": FormatRR, "radioreference": FormatRR,
+	}
+	for in, want := range cases {
+		got, err := ParseFormat(in)
+		if err != nil {
+			t.Errorf("ParseFormat(%q) error: %v", in, err)
+			continue
+		}
+		if got != want {
+			t.Errorf("ParseFormat(%q) = %v, want %v", in, got, want)
+		}
+	}
+	if _, err := ParseFormat("nope"); err == nil {
+		t.Error("ParseFormat(nope) expected error")
+	}
+}
+
+func TestWriteBundle_StructureAndContent(t *testing.T) {
+	var buf bytes.Buffer
+	if err := Write(&buf, sampleSystem(), FormatBundle, nil); err != nil {
+		t.Fatalf("Write bundle: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{
+		"# Section: metadata",
+		"name,Example P25 System",
+		"protocol,p25",
+		"sysid,49A",
+		"wacn,BEE99",
+		"# Section: sites",
+		"rfss,site_id,site_name,county,frequencies",
+		"851.0125c|851.2625c",
+		"# Section: talkgroups",
+		"1000,3e8,D",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("bundle missing %q\n--- output ---\n%s", want, out)
+		}
+	}
+	// Location contains a comma → must be quoted by the CSV writer.
+	if !strings.Contains(out, `"Example City, AZ"`) {
+		t.Errorf("bundle did not quote comma-bearing location:\n%s", out)
+	}
+}
+
+func TestWriteTrunkRecorder_ValidJSON(t *testing.T) {
+	var buf bytes.Buffer
+	if err := Write(&buf, sampleSystem(), FormatTrunkRecorder, nil); err != nil {
+		t.Fatalf("Write trunk-recorder: %v", err)
+	}
+	var cfg struct {
+		Systems []struct {
+			ShortName       string  `json:"shortName"`
+			Type            string  `json:"type"`
+			ControlChannels []int64 `json:"control_channels"`
+		} `json:"systems"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &cfg); err != nil {
+		t.Fatalf("trunk-recorder output is not valid JSON: %v\n%s", err, buf.String())
+	}
+	if len(cfg.Systems) != 1 {
+		t.Fatalf("len(systems) = %d, want 1", len(cfg.Systems))
+	}
+	s := cfg.Systems[0]
+	if s.Type != "p25" {
+		t.Errorf("type = %q, want p25", s.Type)
+	}
+	if s.ShortName != "example-p25-system" {
+		t.Errorf("shortName = %q, want example-p25-system", s.ShortName)
+	}
+	if len(s.ControlChannels) != 2 || s.ControlChannels[0] != 851012500 {
+		t.Errorf("control_channels = %v, want [851012500 851262500]", s.ControlChannels)
+	}
+}
+
+func TestWriteRR_WithAndWithoutHints(t *testing.T) {
+	var buf bytes.Buffer
+	if err := Write(&buf, sampleSystem(), FormatRR, nil); err != nil {
+		t.Fatalf("Write rr: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{
+		"# RadioReference submission: Example P25 System",
+		"BEE99",
+		"Tower Alpha",
+		"851.0125",
+		rrSubmitURL,
+		"No matching system was found",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("RR package missing %q", want)
+		}
+	}
+
+	buf.Reset()
+	hints := []DuplicateHint{{SID: 1234, Name: "Existing Sys", Reason: "WACN+SYSID", Confidence: 0.95}}
+	if err := Write(&buf, sampleSystem(), FormatRR, hints); err != nil {
+		t.Fatalf("Write rr w/ hints: %v", err)
+	}
+	out = buf.String()
+	if !strings.Contains(out, "Possible existing systems") || !strings.Contains(out, "SID **1234**") {
+		t.Errorf("RR package did not surface duplicate hint:\n%s", out)
+	}
+}
+
+func TestFormatMHz(t *testing.T) {
+	cases := map[uint32]string{
+		851012500: "851.0125",
+		854000000: "854",
+		853512500: "853.5125",
+	}
+	for hz, want := range cases {
+		if got := formatMHz(hz); got != want {
+			t.Errorf("formatMHz(%d) = %q, want %q", hz, got, want)
+		}
+	}
+}

--- a/internal/hunt/export_trunkrecorder.go
+++ b/internal/hunt/export_trunkrecorder.go
@@ -1,0 +1,93 @@
+package hunt
+
+import (
+	"encoding/json"
+	"io"
+	"strings"
+)
+
+// trProtocol maps GopherTrunk protocol spellings onto trunk-recorder's
+// `type` enum. trunk-recorder only models a few trunked types; protocols it
+// doesn't support fall back to the GopherTrunk name so the stanza is still
+// informative (the operator edits it).
+func trProtocol(p string) string {
+	switch strings.ToLower(p) {
+	case "p25", "p25-phase2":
+		return "p25"
+	case "dmr", "dmr-tier2", "dmr-tier3":
+		return "dmr"
+	default:
+		return strings.ToLower(p)
+	}
+}
+
+// trSystem is the subset of a trunk-recorder system config GopherTrunk can
+// populate from a discovery. Fields the operator must still supply (recorders,
+// modulation tuning, talkgroupsFile path) are emitted with sensible defaults.
+type trSystem struct {
+	ShortName       string   `json:"shortName"`
+	Type            string   `json:"type"`
+	ControlChannels []int64  `json:"control_channels"`
+	Modulation      string   `json:"modulation"`
+	TalkgroupsFile  string   `json:"talkgroupsFile,omitempty"`
+	Comment         string   `json:"comment,omitempty"`
+	Sites           []string `json:"-"`
+}
+
+type trConfig struct {
+	Systems []trSystem `json:"systems"`
+}
+
+// writeTrunkRecorder emits a trunk-recorder JSON config stanza for the
+// discovered system. All discovered control channels (across sites) are
+// flattened into the single `control_channels` array trunk-recorder expects
+// per system; multi-site systems are noted in the comment.
+func writeTrunkRecorder(w io.Writer, sys *DiscoveredSystem) error {
+	var ccs []int64
+	for _, st := range sys.Sites {
+		for _, ch := range st.ControlChannels {
+			if ch.IsControl {
+				ccs = append(ccs, int64(ch.FrequencyHz))
+			}
+		}
+	}
+	mod := "qpsk"
+	if trProtocol(sys.Protocol) == "p25" {
+		mod = "qpsk"
+	}
+	comment := "Discovered by GopherTrunk hunt. Verify control channels and add recorders/talkgroupsFile before use."
+	if len(sys.Sites) > 1 {
+		comment += " Multi-site system: control_channels flattens all sites; split per-site if desired."
+	}
+	cfg := trConfig{Systems: []trSystem{{
+		ShortName:       slug(sys.DisplayName()),
+		Type:            trProtocol(sys.Protocol),
+		ControlChannels: ccs,
+		Modulation:      mod,
+		TalkgroupsFile:  slug(sys.DisplayName()) + "-talkgroups.csv",
+		Comment:         comment,
+	}}}
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(cfg)
+}
+
+// slug lowercases a name and replaces runs of non-alphanumeric characters
+// with a single hyphen — a filesystem/shortName-safe identifier.
+func slug(s string) string {
+	var b strings.Builder
+	prevHyphen := false
+	for _, r := range strings.ToLower(s) {
+		switch {
+		case (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9'):
+			b.WriteRune(r)
+			prevHyphen = false
+		default:
+			if !prevHyphen && b.Len() > 0 {
+				b.WriteByte('-')
+				prevHyphen = true
+			}
+		}
+	}
+	return strings.Trim(b.String(), "-")
+}

--- a/internal/hunt/system.go
+++ b/internal/hunt/system.go
@@ -1,0 +1,216 @@
+// Package hunt is GopherTrunk's site/system "hunting" layer: it turns the
+// output of the signal-lab decoders into a DiscoveredSystem — a structured
+// map of a trunked radio system observed off the air (or from a capture) —
+// and exports that map to standardized files plus a RadioReference.com
+// submission package.
+//
+// Why this exists: many states have trunked systems that are undocumented on
+// RadioReference. GopherTrunk can already decode a control channel once you
+// know its frequency and identity; this package closes the loop by
+// accumulating what the decoder observes (system identity, per-site control
+// channels, neighbor sites, talkgroups) into a single model that round-trips
+// straight back into GopherTrunk's import bundle and into other scanners.
+//
+// The model is intentionally protocol-neutral. Full multi-site topology
+// (WACN/SYSID/RFSS/Site/neighbors) is only available for P25 today; for the
+// other protocols the accumulator records the identity fields the decoder
+// surfaces plus the single observed site and its talkgroups, which is still
+// enough to export and submit.
+package hunt
+
+import (
+	"fmt"
+	"sort"
+	"time"
+)
+
+// DiscoveredSystem is the accumulated map of one trunked system. It is built
+// up incrementally as captures/observations are folded in (see Accumulator),
+// then handed to the exporters. Its fields are shaped to convert cleanly onto
+// the importer's parsedSystem (see cmd/gophertrunk/hunt_export.go) so a
+// discovery exported as a bundle re-imports without loss.
+type DiscoveredSystem struct {
+	// Name is operator-assigned, or synthesized from the identity when blank.
+	Name string `json:"name"`
+	// Protocol is the trunking.Protocol.String() spelling (e.g. "p25").
+	Protocol string `json:"protocol"`
+
+	// P25 / generic identity. Zero ⇒ unknown.
+	WACN     uint32 `json:"wacn,omitempty"`
+	SystemID uint16 `json:"system_id,omitempty"`
+	NAC      uint16 `json:"nac,omitempty"`
+
+	// Identity carries the remaining per-protocol identity fields the decoder
+	// surfaced (DMR ColorCode, NXDN RAN, TETRA MCC/MNC, Motorola/EDACS system
+	// id, …) keyed by the decoder's field name. It is informational and is
+	// rendered into the RR package.
+	Identity map[string]any `json:"identity,omitempty"`
+
+	// Geography — operator-supplied; used by the RR duplicate check and the
+	// submission package.
+	State    string `json:"state,omitempty"`
+	County   string `json:"county,omitempty"`
+	Location string `json:"location,omitempty"`
+
+	Sites      []DiscoveredSite      `json:"sites"`
+	Talkgroups []DiscoveredTalkgroup `json:"talkgroups"`
+	BandPlan   []BandPlanEntry       `json:"band_plan,omitempty"`
+
+	// Confidence is the min protocol-identification confidence across the
+	// control channels folded into this system (0..1).
+	Confidence float64   `json:"confidence"`
+	FirstSeen  time.Time `json:"first_seen"`
+	LastSeen   time.Time `json:"last_seen"`
+}
+
+// DiscoveredSite is one RF site of the system, keyed by (RFSS, SiteID).
+type DiscoveredSite struct {
+	RFSS            uint8               `json:"rfss"`
+	SiteID          uint8               `json:"site_id"`
+	SiteName        string              `json:"site_name"`
+	County          string              `json:"county,omitempty"`
+	ControlChannels []DiscoveredChannel `json:"control_channels"`
+	Secondary       []uint32            `json:"secondary,omitempty"`
+	Neighbors       []NeighborRef       `json:"neighbors,omitempty"`
+}
+
+// DiscoveredChannel is one observed frequency on a site.
+type DiscoveredChannel struct {
+	FrequencyHz uint32  `json:"frequency_hz"`
+	IsControl   bool    `json:"is_control"`
+	Confidence  float64 `json:"confidence,omitempty"`
+}
+
+// DiscoveredTalkgroup is one talkgroup observed on the control channel. On a
+// blind discovery only the numeric id and activity are known; the descriptive
+// fields are left blank for the operator (or RR) to fill in.
+type DiscoveredTalkgroup struct {
+	Dec       uint32    `json:"dec"`
+	Hex       string    `json:"hex"`
+	Encrypted bool      `json:"encrypted,omitempty"`
+	Count     int       `json:"count"`
+	FirstSeen time.Time `json:"first_seen"`
+}
+
+// NeighborRef is an adjacent site advertised by the control channel.
+type NeighborRef struct {
+	RFSS          uint8  `json:"rfss"`
+	Site          uint8  `json:"site"`
+	ChannelID     uint8  `json:"channel_id,omitempty"`
+	ChannelNumber uint16 `json:"channel_number,omitempty"`
+}
+
+// BandPlanEntry is one P25 IDEN_UP-equivalent band-plan mapping.
+type BandPlanEntry struct {
+	ChannelID   uint8  `json:"channel_id"`
+	BaseHz      uint64 `json:"base_hz"`
+	SpacingHz   uint32 `json:"spacing_hz"`
+	BandwidthHz uint32 `json:"bandwidth_hz,omitempty"`
+	TxOffsetHz  int64  `json:"tx_offset_hz,omitempty"`
+}
+
+// DisplayName returns Name when set, otherwise a synthesized identifier from
+// the protocol + system id so an unnamed discovery still has a stable handle.
+func (s *DiscoveredSystem) DisplayName() string {
+	if s.Name != "" {
+		return s.Name
+	}
+	proto := s.Protocol
+	if proto == "" {
+		proto = "unknown"
+	}
+	switch {
+	case s.WACN != 0 && s.SystemID != 0:
+		return fmt.Sprintf("Unknown-%s-%05X-%03X", proto, s.WACN, s.SystemID)
+	case s.SystemID != 0:
+		return fmt.Sprintf("Unknown-%s-%03X", proto, s.SystemID)
+	default:
+		return fmt.Sprintf("Unknown-%s", proto)
+	}
+}
+
+// site returns a pointer to the site with the given (rfss, siteID), creating
+// it if absent. Callers mutate the returned site in place.
+func (s *DiscoveredSystem) site(rfss, siteID uint8) *DiscoveredSite {
+	for i := range s.Sites {
+		if s.Sites[i].RFSS == rfss && s.Sites[i].SiteID == siteID {
+			return &s.Sites[i]
+		}
+	}
+	s.Sites = append(s.Sites, DiscoveredSite{RFSS: rfss, SiteID: siteID})
+	return &s.Sites[len(s.Sites)-1]
+}
+
+// addControlChannel records a control-channel frequency on (rfss, siteID),
+// de-duplicating by frequency and keeping the highest confidence seen.
+func (s *DiscoveredSystem) addControlChannel(rfss, siteID uint8, hz uint32, confidence float64) {
+	site := s.site(rfss, siteID)
+	for i := range site.ControlChannels {
+		if site.ControlChannels[i].FrequencyHz == hz {
+			site.ControlChannels[i].IsControl = true
+			if confidence > site.ControlChannels[i].Confidence {
+				site.ControlChannels[i].Confidence = confidence
+			}
+			return
+		}
+	}
+	site.ControlChannels = append(site.ControlChannels, DiscoveredChannel{
+		FrequencyHz: hz, IsControl: true, Confidence: confidence,
+	})
+}
+
+// addTalkgroup records (or bumps the activity count of) a talkgroup.
+func (s *DiscoveredSystem) addTalkgroup(dec uint32, encrypted bool, at time.Time) {
+	for i := range s.Talkgroups {
+		if s.Talkgroups[i].Dec == dec {
+			s.Talkgroups[i].Count++
+			if encrypted {
+				s.Talkgroups[i].Encrypted = true
+			}
+			return
+		}
+	}
+	s.Talkgroups = append(s.Talkgroups, DiscoveredTalkgroup{
+		Dec:       dec,
+		Hex:       fmt.Sprintf("%x", dec),
+		Encrypted: encrypted,
+		Count:     1,
+		FirstSeen: at,
+	})
+}
+
+// addNeighbor records an adjacent site on (rfss, siteID), de-duplicating by
+// the neighbor's (RFSS, Site).
+func (s *DiscoveredSystem) addNeighbor(rfss, siteID uint8, n NeighborRef) {
+	site := s.site(rfss, siteID)
+	for _, e := range site.Neighbors {
+		if e.RFSS == n.RFSS && e.Site == n.Site {
+			return
+		}
+	}
+	site.Neighbors = append(site.Neighbors, n)
+}
+
+// sortAll puts sites, channels and talkgroups in a deterministic order so the
+// exporters produce stable output (important for golden tests and diffs).
+func (s *DiscoveredSystem) sortAll() {
+	sort.Slice(s.Sites, func(i, j int) bool {
+		if s.Sites[i].RFSS != s.Sites[j].RFSS {
+			return s.Sites[i].RFSS < s.Sites[j].RFSS
+		}
+		return s.Sites[i].SiteID < s.Sites[j].SiteID
+	})
+	for i := range s.Sites {
+		cc := s.Sites[i].ControlChannels
+		sort.Slice(cc, func(a, b int) bool { return cc[a].FrequencyHz < cc[b].FrequencyHz })
+		nb := s.Sites[i].Neighbors
+		sort.Slice(nb, func(a, b int) bool {
+			if nb[a].RFSS != nb[b].RFSS {
+				return nb[a].RFSS < nb[b].RFSS
+			}
+			return nb[a].Site < nb[b].Site
+		})
+	}
+	sort.Slice(s.Talkgroups, func(i, j int) bool { return s.Talkgroups[i].Dec < s.Talkgroups[j].Dec })
+	sort.Slice(s.BandPlan, func(i, j int) bool { return s.BandPlan[i].ChannelID < s.BandPlan[j].ChannelID })
+}

--- a/internal/radioreference/client.go
+++ b/internal/radioreference/client.go
@@ -1,0 +1,272 @@
+package radioreference
+
+import (
+	"bytes"
+	"context"
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// DefaultEndpoint is the RadioReference SOAP web-service endpoint (v3.1).
+const DefaultEndpoint = "http://api.radioreference.com/soap2/"
+
+// ErrNoCredentials is returned by NewClient when no API key is configured, so
+// callers can cleanly skip the (optional) duplicate check.
+var ErrNoCredentials = errors.New("radioreference: no API key configured")
+
+// Auth carries the RadioReference web-service credentials.
+type Auth struct {
+	AppKey   string
+	Username string
+	Password string
+	Version  string // defaults to "latest"
+}
+
+// Client is a read-only RadioReference SOAP client. It is safe for sequential
+// use; create one per hunt run.
+type Client struct {
+	auth     Auth
+	endpoint string
+	http     *http.Client
+}
+
+// NewClient builds a client. It returns ErrNoCredentials when auth.AppKey is
+// empty so the hunt can degrade gracefully to "no duplicate check".
+func NewClient(auth Auth) (*Client, error) {
+	if strings.TrimSpace(auth.AppKey) == "" {
+		return nil, ErrNoCredentials
+	}
+	if auth.Version == "" {
+		auth.Version = "latest"
+	}
+	return &Client{
+		auth:     auth,
+		endpoint: DefaultEndpoint,
+		http:     &http.Client{Timeout: 20 * time.Second},
+	}, nil
+}
+
+// SetEndpoint overrides the SOAP endpoint (used by tests).
+func (c *Client) SetEndpoint(url string) { c.endpoint = url }
+
+// SetHTTPClient overrides the HTTP client (used by tests).
+func (c *Client) SetHTTPClient(h *http.Client) { c.http = h }
+
+// GetTrsDetails fetches a single trunked system by RadioReference system id.
+// The response is parsed namespace-agnostically (the RR WSDL wraps the return
+// in method-specific elements that vary by SOAP style), pulling the leaf
+// fields used for duplicate detection.
+func (c *Client) GetTrsDetails(ctx context.Context, sid int) (System, error) {
+	body := fmt.Sprintf(`<ns1:getTrsDetails>`+
+		`<sid xsi:type="xsd:int">%d</sid>`+
+		`%s`+
+		`</ns1:getTrsDetails>`, sid, c.authXML())
+	raw, err := c.call(ctx, body)
+	if err != nil {
+		return System{}, err
+	}
+	leaves := firstLeaves(raw, "sid", "sName", "sType", "sysid", "wacn")
+	sys := System{
+		SID:  atoiDefault(leaves["sid"], sid),
+		Name: leaves["sName"],
+		Type: leaves["sType"],
+	}
+	// RR returns sysid/wacn as hex strings on P25 systems.
+	if v, ok := parseHexOrDec(leaves["sysid"]); ok {
+		sys.SystemID = uint16(v)
+	}
+	if v, ok := parseHexOrDec(leaves["wacn"]); ok {
+		sys.WACN = uint32(v)
+	}
+	return sys, nil
+}
+
+// GetCountyInfo fetches the trunked systems registered in a RadioReference
+// county (by ctid). Only the brief identity of each system is returned; call
+// GetTrsDetails to enrich a candidate with its SYSID/WACN before matching.
+func (c *Client) GetCountyInfo(ctx context.Context, ctid int) ([]System, error) {
+	body := fmt.Sprintf(`<ns1:getCountyInfo>`+
+		`<ctid xsi:type="xsd:int">%d</ctid>`+
+		`%s`+
+		`</ns1:getCountyInfo>`, ctid, c.authXML())
+	raw, err := c.call(ctx, body)
+	if err != nil {
+		return nil, err
+	}
+	var out []System
+	for _, block := range blocks(raw, "trsList") {
+		leaves := firstLeaves(block, "sid", "sName", "sType")
+		if leaves["sid"] == "" {
+			continue
+		}
+		out = append(out, System{
+			SID:  atoiDefault(leaves["sid"], 0),
+			Name: leaves["sName"],
+			Type: leaves["sType"],
+		})
+	}
+	return out, nil
+}
+
+// authXML renders the shared authInfo SOAP block.
+func (c *Client) authXML() string {
+	return fmt.Sprintf(`<authInfo xsi:type="ns1:authInfo">`+
+		`<appKey xsi:type="xsd:string">%s</appKey>`+
+		`<username xsi:type="xsd:string">%s</username>`+
+		`<password xsi:type="xsd:string">%s</password>`+
+		`<version xsi:type="xsd:string">%s</version>`+
+		`<style xsi:type="xsd:string">rpc</style>`+
+		`</authInfo>`,
+		xmlEscape(c.auth.AppKey), xmlEscape(c.auth.Username),
+		xmlEscape(c.auth.Password), xmlEscape(c.auth.Version))
+}
+
+// call wraps a method body in a SOAP envelope, POSTs it, and returns the raw
+// response body (HTTP errors and SOAP faults become Go errors).
+func (c *Client) call(ctx context.Context, methodBody string) ([]byte, error) {
+	envelope := `<?xml version="1.0" encoding="UTF-8"?>` +
+		`<SOAP-ENV:Envelope ` +
+		`xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" ` +
+		`xmlns:ns1="urn:RadioReference" ` +
+		`xmlns:xsd="http://www.w3.org/2001/XMLSchema" ` +
+		`xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">` +
+		`<SOAP-ENV:Body>` + methodBody + `</SOAP-ENV:Body></SOAP-ENV:Envelope>`
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.endpoint, strings.NewReader(envelope))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "text/xml; charset=utf-8")
+	req.Header.Set("SOAPAction", "")
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("radioreference: request: %w", err)
+	}
+	defer resp.Body.Close()
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, 8<<20))
+	if err != nil {
+		return nil, fmt.Errorf("radioreference: read response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("radioreference: HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(raw)))
+	}
+	if fault := firstLeaves(raw, "faultstring")["faultstring"]; fault != "" {
+		return nil, fmt.Errorf("radioreference: SOAP fault: %s", fault)
+	}
+	return raw, nil
+}
+
+// firstLeaves walks the XML token stream and records the first text content of
+// each requested leaf element, matched by local name (namespace/prefix
+// ignored). This is resilient to the differing wrapper elements the RR WSDL
+// emits across SOAP styles.
+func firstLeaves(raw []byte, names ...string) map[string]string {
+	want := make(map[string]struct{}, len(names))
+	for _, n := range names {
+		want[n] = struct{}{}
+	}
+	out := make(map[string]string, len(names))
+	dec := xml.NewDecoder(bytes.NewReader(raw))
+	var cur string
+	for {
+		tok, err := dec.Token()
+		if err != nil {
+			break
+		}
+		switch t := tok.(type) {
+		case xml.StartElement:
+			if _, ok := want[t.Name.Local]; ok {
+				cur = t.Name.Local
+			} else {
+				cur = ""
+			}
+		case xml.CharData:
+			if cur != "" {
+				if _, seen := out[cur]; !seen {
+					if s := strings.TrimSpace(string(t)); s != "" {
+						out[cur] = s
+					}
+				}
+			}
+		case xml.EndElement:
+			cur = ""
+		}
+	}
+	return out
+}
+
+// blocks returns the raw XML of each element whose local name matches name,
+// so a list response (repeated <trsList>…</trsList> entries) can be parsed
+// one entry at a time with firstLeaves.
+func blocks(raw []byte, name string) [][]byte {
+	var out [][]byte
+	dec := xml.NewDecoder(bytes.NewReader(raw))
+	for {
+		tok, err := dec.Token()
+		if err != nil {
+			break
+		}
+		se, ok := tok.(xml.StartElement)
+		if !ok || se.Name.Local != name {
+			continue
+		}
+		var buf bytes.Buffer
+		enc := xml.NewEncoder(&buf)
+		_ = enc.EncodeToken(se)
+		depth := 1
+		for depth > 0 {
+			t, err := dec.Token()
+			if err != nil {
+				break
+			}
+			switch t.(type) {
+			case xml.StartElement:
+				depth++
+			case xml.EndElement:
+				depth--
+			}
+			if depth >= 0 {
+				_ = enc.EncodeToken(xml.CopyToken(t))
+			}
+		}
+		_ = enc.Flush()
+		out = append(out, buf.Bytes())
+	}
+	return out
+}
+
+func atoiDefault(s string, def int) int {
+	if v, err := strconv.Atoi(strings.TrimSpace(s)); err == nil {
+		return v
+	}
+	return def
+}
+
+// parseHexOrDec accepts RR's hex identity strings (sysid/wacn) and falls back
+// to decimal. Returns ok=false for empty/garbage input.
+func parseHexOrDec(s string) (uint64, bool) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, false
+	}
+	if v, err := strconv.ParseUint(s, 16, 64); err == nil {
+		return v, true
+	}
+	if v, err := strconv.ParseUint(s, 10, 64); err == nil {
+		return v, true
+	}
+	return 0, false
+}
+
+func xmlEscape(s string) string {
+	var b strings.Builder
+	_ = xml.EscapeText(&b, []byte(s))
+	return b.String()
+}

--- a/internal/radioreference/dedup.go
+++ b/internal/radioreference/dedup.go
@@ -1,0 +1,121 @@
+// Package radioreference is a read-only client for RadioReference.com's SOAP
+// web service, used by `gophertrunk hunt` to check whether a discovered
+// trunked system already exists in RadioReference before an operator submits
+// it. RadioReference has no public write API — new systems go through a manual
+// web form reviewed by administrators — so this package never writes anything;
+// it only reads, to avoid duplicate submissions.
+package radioreference
+
+import "fmt"
+
+// System is the subset of a RadioReference trunked-system record this package
+// reads for duplicate detection.
+type System struct {
+	SID      int    // RadioReference system id
+	Name     string // system name (sName)
+	Type     string // system type (sType), e.g. "Project 25 Phase II"
+	SystemID uint16 // decoded SYSID (0 when unknown)
+	WACN     uint32 // decoded WACN (0 when unknown)
+	// ControlChannels are control-channel frequencies in Hz across the
+	// system's sites (best-effort; may be empty if not fetched).
+	ControlChannels []uint32
+}
+
+// Candidate is the discovered system's identifying fields, passed to
+// MatchAgainst. It mirrors the parts of hunt.DiscoveredSystem relevant to
+// duplicate detection without importing that package (avoiding a dependency
+// cycle — the hunt CLI builds this from its DiscoveredSystem).
+type Candidate struct {
+	WACN            uint32
+	SystemID        uint16
+	Name            string
+	ControlChannels []uint32
+}
+
+// Hint is a possible duplicate match between a discovered system and an
+// existing RadioReference system.
+type Hint struct {
+	SID        int
+	Name       string
+	Reason     string
+	Confidence float64
+}
+
+// MatchAgainst compares a discovered system against a list of existing
+// RadioReference systems and returns ranked duplicate hints. The strongest
+// signal is a WACN+SYSID match (a P25 system's globally-unique identity);
+// failing that, an overlapping control-channel frequency; failing that, an
+// exact (case-insensitive) name match. Systems that match nothing are omitted.
+func MatchAgainst(c Candidate, existing []System) []Hint {
+	var hints []Hint
+	for _, e := range existing {
+		if c.WACN != 0 && c.SystemID != 0 && e.WACN == c.WACN && e.SystemID == c.SystemID {
+			hints = append(hints, Hint{
+				SID:        e.SID,
+				Name:       e.Name,
+				Reason:     fmt.Sprintf("WACN %05X + SYSID %03X", c.WACN, c.SystemID),
+				Confidence: 0.99,
+			})
+			continue
+		}
+		if n := overlapCount(c.ControlChannels, e.ControlChannels); n > 0 {
+			hints = append(hints, Hint{
+				SID:        e.SID,
+				Name:       e.Name,
+				Reason:     fmt.Sprintf("%d shared control-channel frequency(ies)", n),
+				Confidence: 0.80,
+			})
+			continue
+		}
+		if c.Name != "" && equalFold(c.Name, e.Name) {
+			hints = append(hints, Hint{
+				SID:        e.SID,
+				Name:       e.Name,
+				Reason:     "identical system name",
+				Confidence: 0.50,
+			})
+		}
+	}
+	return hints
+}
+
+// overlapCount returns how many frequencies appear in both lists (exact Hz).
+func overlapCount(a, b []uint32) int {
+	if len(a) == 0 || len(b) == 0 {
+		return 0
+	}
+	set := make(map[uint32]struct{}, len(a))
+	for _, f := range a {
+		set[f] = struct{}{}
+	}
+	n := 0
+	for _, f := range b {
+		if _, ok := set[f]; ok {
+			n++
+		}
+	}
+	return n
+}
+
+func equalFold(a, b string) bool {
+	if len(a) != len(b) {
+		// ASCII fast path differs in length only when bytes differ; fall back
+		// to the full comparison for multibyte safety.
+	}
+	return foldKey(a) == foldKey(b)
+}
+
+func foldKey(s string) string {
+	out := make([]byte, 0, len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c >= 'A' && c <= 'Z' {
+			c += 'a' - 'A'
+		}
+		if c == ' ' || c == '-' || c == '_' {
+			continue // ignore spacing/punctuation differences
+		}
+		out = append(out, c)
+	}
+	return string(out)
+}

--- a/internal/radioreference/radioreference_test.go
+++ b/internal/radioreference/radioreference_test.go
@@ -1,0 +1,157 @@
+package radioreference
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestMatchAgainst(t *testing.T) {
+	cand := Candidate{
+		WACN: 0xBEE99, SystemID: 0x49A, Name: "New County P25",
+		ControlChannels: []uint32{851012500, 851262500},
+	}
+	existing := []System{
+		{SID: 100, Name: "Exact Identity", WACN: 0xBEE99, SystemID: 0x49A},
+		{SID: 200, Name: "Shared Freq", ControlChannels: []uint32{851262500}},
+		{SID: 300, Name: "new-county-p25"},
+		{SID: 400, Name: "Totally Different", WACN: 1, SystemID: 2, ControlChannels: []uint32{460000000}},
+	}
+	hints := MatchAgainst(cand, existing)
+	if len(hints) != 3 {
+		t.Fatalf("len(hints) = %d, want 3 (%+v)", len(hints), hints)
+	}
+	bySID := map[int]Hint{}
+	for _, h := range hints {
+		bySID[h.SID] = h
+	}
+	if h, ok := bySID[100]; !ok || h.Confidence < 0.9 {
+		t.Errorf("SID 100 should match strongly on WACN+SYSID, got %+v", h)
+	}
+	if h, ok := bySID[200]; !ok || h.Confidence != 0.80 {
+		t.Errorf("SID 200 should match on shared freq, got %+v", h)
+	}
+	if h, ok := bySID[300]; !ok || h.Confidence != 0.50 {
+		t.Errorf("SID 300 should match on name fold, got %+v", h)
+	}
+	if _, ok := bySID[400]; ok {
+		t.Error("SID 400 should not match")
+	}
+}
+
+func TestNewClient_NoCredentials(t *testing.T) {
+	if _, err := NewClient(Auth{}); err != ErrNoCredentials {
+		t.Errorf("NewClient(empty) err = %v, want ErrNoCredentials", err)
+	}
+	if _, err := NewClient(Auth{AppKey: "k"}); err != nil {
+		t.Errorf("NewClient(key) err = %v, want nil", err)
+	}
+}
+
+const trsDetailsResponse = `<?xml version="1.0" encoding="UTF-8"?>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
+ <SOAP-ENV:Body>
+  <ns1:getTrsDetailsResponse xmlns:ns1="urn:RadioReference">
+   <return>
+    <sid>7715</sid>
+    <sName>Example Regional P25</sName>
+    <sType>Project 25 Phase II</sType>
+    <sysid>49A</sysid>
+    <wacn>BEE99</wacn>
+   </return>
+  </ns1:getTrsDetailsResponse>
+ </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>`
+
+func TestGetTrsDetails_ParsesResponse(t *testing.T) {
+	var gotBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		buf := make([]byte, r.ContentLength)
+		_, _ = r.Body.Read(buf)
+		gotBody = string(buf)
+		w.Header().Set("Content-Type", "text/xml")
+		_, _ = w.Write([]byte(trsDetailsResponse))
+	}))
+	defer srv.Close()
+
+	c, err := NewClient(Auth{AppKey: "KEY", Username: "u", Password: "p"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.SetEndpoint(srv.URL)
+
+	sys, err := c.GetTrsDetails(context.Background(), 7715)
+	if err != nil {
+		t.Fatalf("GetTrsDetails: %v", err)
+	}
+	if sys.SID != 7715 || sys.Name != "Example Regional P25" {
+		t.Errorf("sys = %+v, want SID 7715 Example Regional P25", sys)
+	}
+	if sys.SystemID != 0x49A {
+		t.Errorf("SystemID = %X, want 49A", sys.SystemID)
+	}
+	if sys.WACN != 0xBEE99 {
+		t.Errorf("WACN = %X, want BEE99", sys.WACN)
+	}
+	// The request must carry the auth block + the sid.
+	for _, want := range []string{"getTrsDetails", "<appKey", "KEY", "<sid", "7715"} {
+		if !contains(gotBody, want) {
+			t.Errorf("request body missing %q:\n%s", want, gotBody)
+		}
+	}
+}
+
+const faultResponse = `<?xml version="1.0"?>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
+ <SOAP-ENV:Body><SOAP-ENV:Fault>
+  <faultcode>SOAP-ENV:Server</faultcode>
+  <faultstring>Invalid API key</faultstring>
+ </SOAP-ENV:Fault></SOAP-ENV:Body></SOAP-ENV:Envelope>`
+
+func TestCall_SurfacesSOAPFault(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(faultResponse))
+	}))
+	defer srv.Close()
+	c, _ := NewClient(Auth{AppKey: "BAD"})
+	c.SetEndpoint(srv.URL)
+	if _, err := c.GetTrsDetails(context.Background(), 1); err == nil {
+		t.Fatal("expected SOAP fault error, got nil")
+	}
+}
+
+func TestGetCountyInfo_ParsesList(t *testing.T) {
+	const resp = `<?xml version="1.0"?>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
+ <SOAP-ENV:Body><ns1:getCountyInfoResponse xmlns:ns1="urn:RadioReference"><return>
+  <trsList><sid>10</sid><sName>Alpha</sName><sType>P25</sType></trsList>
+  <trsList><sid>20</sid><sName>Bravo</sName><sType>DMR</sType></trsList>
+ </return></ns1:getCountyInfoResponse></SOAP-ENV:Body></SOAP-ENV:Envelope>`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(resp))
+	}))
+	defer srv.Close()
+	c, _ := NewClient(Auth{AppKey: "K"})
+	c.SetEndpoint(srv.URL)
+	sysList, err := c.GetCountyInfo(context.Background(), 42)
+	if err != nil {
+		t.Fatalf("GetCountyInfo: %v", err)
+	}
+	if len(sysList) != 2 || sysList[0].SID != 10 || sysList[1].Name != "Bravo" {
+		t.Errorf("county systems = %+v, want SID 10 Alpha + SID 20 Bravo", sysList)
+	}
+}
+
+func contains(haystack, needle string) bool {
+	return len(needle) == 0 || (len(haystack) >= len(needle) && indexOf(haystack, needle) >= 0)
+}
+
+func indexOf(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}


### PR DESCRIPTION
Many states/counties run trunked systems that are undocumented on
RadioReference.com. GopherTrunk could already follow and decode a system
once you knew its control channels and identity, but had no way to map an
unknown one from scratch and get it into a standard format.

This adds `gophertrunk hunt`, which turns one or more control-channel IQ
captures into a structured DiscoveredSystem and exports it:

- internal/hunt: DiscoveredSystem model + accumulator (folds siglab decode
  results into identity, per-site control channels, and observed talkgroups,
  de-duplicating across captures) + an offline Discover orchestrator that
  auto-identifies each capture's protocol (siglab.Identify) and decodes it
  (siglab.Run).
- Three exporters: the GopherTrunk multi-section import bundle (round-trips
  back in via import-pdf -csv, verified by a test against the importer's
  parseCSVStream), a trunk-recorder JSON config stanza, and a human-readable
  RadioReference submission package.
- internal/radioreference: optional read-only SOAP client for a duplicate
  check (RadioReference has no public write API), plus pure dedup matching
  on WACN+SYSID / shared control channels / name. Folds warnings into the
  RR submission package. Key-gated; degrades gracefully when absent.
- cmd/gophertrunk: `hunt` subcommand (offline -in captures, auto/forced
  protocol, format selection, optional -commit into config.yaml reusing the
  importer's mergeIntoConfig, and RR verify flags), wired into main dispatch
  and usage.
- config: optional radioreference credentials block (env-overridable).
- docs/hunt.md + README feature bullet.

Live wideband spectrum-sweep discovery and a cockpit/TUI/web surface are
the planned follow-ons; full multi-site topology is richest on P25 today.

https://claude.ai/code/session_01He917mJB4Kg4ZkHjyHtJ66