### PR TITLE
hunt: surface P25 system topology on decode results + in-memory identify

### DIFF
--- a/docs/hunt.md
+++ b/docs/hunt.md
@@ -115,10 +115,13 @@ to force it off even when a key is configured.
   that finds the candidate control channels on the air automatically — using
   the existing FFT spectrum producer for peak detection — is the planned
   follow-on, along with a live cockpit/TUI/web panel.
-- **Topology depth.** Full multi-site topology (WACN/SYSID/RFSS/Site,
-  neighbor/adjacent sites, band plan) is richest on **P25**; for other
-  protocols the map carries the identity the decoder surfaces plus the single
-  observed site and its talkgroups — enough to export and submit.
+- **Topology depth.** For **P25** the hunt now recovers full topology —
+  WACN/SYSID, the camped RFSS/Site, advertised neighbor (adjacent) sites, and
+  the over-the-air band plan (IDEN_UP) — all surfaced in the exports. For other
+  protocols the map carries the identity the decoder surfaces (DMR ColorCode/
+  SystemID, NXDN Site/System, TETRA MCC/MNC/LA, …) plus the observed site and
+  talkgroups; neighbor accumulation for those protocols lands incrementally.
+  Band-plan-from-air is P25-only (others resolve channels via configured plans).
 - **Talkgroup names.** A blind discovery can only record talkgroup *numbers*
   and activity; names/descriptions are filled in during RadioReference
   submission.

--- a/internal/hunt/accumulate.go
+++ b/internal/hunt/accumulate.go
@@ -76,6 +76,11 @@ func Accumulate(dst *DiscoveredSystem, obs Observation) {
 	for _, ev := range obs.Result.Events {
 		harvestIdentity(dst, ev.Fields)
 	}
+	// Fold the decoder's accumulated topology (the only source of
+	// WACN/SYSID/RFSS/Site + neighbors + band plan — these never ride on
+	// events). This runs before site placement so RFSS/Site are authoritative.
+	foldTopology(dst, obs.Result.Topology)
+
 	// Fall back to the capture's nominal center when the lock didn't carry an
 	// absolute frequency (baseband captures lock at 0 Hz).
 	if ccFreq == 0 {
@@ -92,8 +97,29 @@ func Accumulate(dst *DiscoveredSystem, obs Observation) {
 	switch {
 	case ccFreq != 0:
 		dst.addControlChannel(rfss, site, ccFreq, obs.Confidence)
-	case obs.Result.Locked:
+	case obs.Result.Locked || obs.Result.Topology != nil:
 		dst.site(rfss, site) // ensure the site exists for identity/talkgroups
+	}
+
+	// Attach neighbor (adjacent) sites + secondary control channels advertised
+	// for the camped site, now that the site exists.
+	if t := obs.Result.Topology; t != nil {
+		for _, n := range t.Neighbors {
+			dst.addNeighbor(rfss, site, NeighborRef{
+				RFSS:          n.RFSS,
+				Site:          n.Site,
+				ChannelID:     n.ChannelID,
+				ChannelNumber: n.ChannelNumber,
+			})
+		}
+		if len(t.Secondary) > 0 {
+			st := dst.site(rfss, site)
+			for _, s := range t.Secondary {
+				if s.FrequencyHz != 0 {
+					st.Secondary = appendUniqueFreq(st.Secondary, s.FrequencyHz)
+				}
+			}
+		}
 	}
 
 	// Talkgroups: every grant's destination group is an observed talkgroup.
@@ -103,6 +129,58 @@ func Accumulate(dst *DiscoveredSystem, obs Observation) {
 		}
 		dst.addTalkgroup(g.GroupID, g.Encrypted, at)
 	}
+}
+
+// foldTopology merges a siglab TopologySnapshot into the discovered system:
+// typed identity (WACN/SystemID), the Identity map (RFSS/Site/LRA + the
+// per-protocol fields used for display and site placement), and the band plan.
+// First non-zero value wins, mirroring harvestIdentity.
+func foldTopology(dst *DiscoveredSystem, t *siglab.TopologySnapshot) {
+	if t == nil {
+		return
+	}
+	if dst.WACN == 0 && t.WACN != 0 {
+		dst.WACN = t.WACN
+	}
+	if dst.SystemID == 0 && t.SystemID != 0 {
+		dst.SystemID = uint16(t.SystemID)
+	}
+	setIdentity := func(key string, v uint64) {
+		if v == 0 {
+			return
+		}
+		if _, present := dst.Identity[key]; !present {
+			dst.Identity[key] = v
+		}
+	}
+	setIdentity("RFSS", uint64(t.RFSS))
+	setIdentity("Site", uint64(t.Site))
+	setIdentity("LRA", uint64(t.LRA))
+	setIdentity("ColorCode", uint64(t.ColorCode))
+	setIdentity("RAN", uint64(t.RAN))
+	setIdentity("MCC", uint64(t.MCC))
+	setIdentity("MNC", uint64(t.MNC))
+	setIdentity("LocationArea", uint64(t.LocationArea))
+
+	for _, e := range t.BandPlan {
+		dst.addBandPlanEntry(BandPlanEntry{
+			ChannelID:   e.ChannelID,
+			BaseHz:      e.BaseHz,
+			SpacingHz:   e.SpacingHz,
+			BandwidthHz: e.BandwidthHz,
+			TxOffsetHz:  e.TxOffsetHz,
+		})
+	}
+}
+
+// appendUniqueFreq appends hz to s unless already present.
+func appendUniqueFreq(s []uint32, hz uint32) []uint32 {
+	for _, e := range s {
+		if e == hz {
+			return s
+		}
+	}
+	return append(s, hz)
 }
 
 // harvestIdentity copies recognised identity fields from a flattened payload

--- a/internal/hunt/accumulate_test.go
+++ b/internal/hunt/accumulate_test.go
@@ -96,6 +96,71 @@ func TestAccumulate_Idempotent_DedupesSites(t *testing.T) {
 	}
 }
 
+func TestAccumulate_FoldsTopology(t *testing.T) {
+	sys := &DiscoveredSystem{}
+	r := fakeResult(851012500, map[string]any{"NAC": uint16(0x293)}, 1000)
+	r.Topology = &siglab.TopologySnapshot{
+		WACN:     0xBEE99,
+		SystemID: 0x49A,
+		RFSS:     1,
+		Site:     2,
+		Neighbors: []siglab.NeighborRef{
+			{RFSS: 1, Site: 3},
+			{RFSS: 1, Site: 4},
+		},
+		BandPlan: []siglab.BandPlanSlot{
+			{ChannelID: 1, BaseHz: 851_000_000, SpacingHz: 12_500},
+		},
+	}
+	Accumulate(sys, Observation{Protocol: "p25", Confidence: 0.9, Result: r})
+
+	if sys.WACN != 0xBEE99 || sys.SystemID != 0x49A {
+		t.Errorf("identity = %X/%X, want BEE99/49A", sys.WACN, sys.SystemID)
+	}
+	if len(sys.Sites) != 1 {
+		t.Fatalf("len(Sites) = %d, want 1", len(sys.Sites))
+	}
+	st := sys.Sites[0]
+	if st.RFSS != 1 || st.SiteID != 2 {
+		t.Errorf("camped site = %d/%d, want 1/2", st.RFSS, st.SiteID)
+	}
+	if len(st.ControlChannels) != 1 || st.ControlChannels[0].FrequencyHz != 851012500 {
+		t.Errorf("control channels = %+v", st.ControlChannels)
+	}
+	if len(st.Neighbors) != 2 {
+		t.Errorf("neighbors = %+v, want 2", st.Neighbors)
+	}
+	if len(sys.BandPlan) != 1 || sys.BandPlan[0].BaseHz != 851_000_000 {
+		t.Errorf("band plan = %+v, want one entry base 851M", sys.BandPlan)
+	}
+	// Talkgroup from the grant still lands alongside the topology.
+	if len(sys.Talkgroups) != 1 || sys.Talkgroups[0].Dec != 1000 {
+		t.Errorf("talkgroups = %+v, want [1000]", sys.Talkgroups)
+	}
+}
+
+func TestAccumulate_TopologyDedupesAcrossObservations(t *testing.T) {
+	sys := &DiscoveredSystem{}
+	mk := func() Observation {
+		r := fakeResult(851012500, nil)
+		r.Topology = &siglab.TopologySnapshot{
+			RFSS: 1, Site: 1,
+			Neighbors: []siglab.NeighborRef{{RFSS: 1, Site: 2}},
+			BandPlan:  []siglab.BandPlanSlot{{ChannelID: 1, BaseHz: 851_000_000, SpacingHz: 12_500}},
+		}
+		return Observation{Protocol: "p25", Confidence: 0.8, Result: r}
+	}
+	Accumulate(sys, mk())
+	Accumulate(sys, mk())
+
+	if len(sys.Sites) != 1 || len(sys.Sites[0].Neighbors) != 1 {
+		t.Errorf("neighbors should dedupe: %+v", sys.Sites)
+	}
+	if len(sys.BandPlan) != 1 {
+		t.Errorf("band plan should dedupe by channel id: %+v", sys.BandPlan)
+	}
+}
+
 func TestAccumulate_ConfidenceTakesMinimum(t *testing.T) {
 	sys := &DiscoveredSystem{}
 	Accumulate(sys, Observation{Protocol: "p25", Confidence: 0.9, Result: fakeResult(1, nil)})

--- a/internal/hunt/discover.go
+++ b/internal/hunt/discover.go
@@ -127,7 +127,13 @@ func Discover(captures []CaptureInput, cfg DiscoverConfig) (*DiscoveredSystem, [
 			AutoTune:     cap.AutoTune,
 			Conjugate:    cap.Conjugate,
 			IQCorrect:    cap.IQCorrect,
-			Log:          log,
+			// CollectIQDiag engages P25 Phase 1's deep decode path, which is
+			// what accumulates and snapshots the system topology
+			// (WACN/SYSID/RFSS/Site + neighbors + band plan) onto Result.Topology.
+			// Without it P25 runs the generic factory pipeline and the map would
+			// be NAC-only.
+			CollectIQDiag: true,
+			Log:           log,
 		})
 		if err != nil {
 			rep.Error = fmt.Sprintf("decode: %v", err)

--- a/internal/hunt/system.go
+++ b/internal/hunt/system.go
@@ -191,6 +191,17 @@ func (s *DiscoveredSystem) addNeighbor(rfss, siteID uint8, n NeighborRef) {
 	site.Neighbors = append(site.Neighbors, n)
 }
 
+// addBandPlanEntry records a band-plan slot, de-duplicating by channel ID
+// (the first observation of a channel ID wins).
+func (s *DiscoveredSystem) addBandPlanEntry(e BandPlanEntry) {
+	for _, existing := range s.BandPlan {
+		if existing.ChannelID == e.ChannelID {
+			return
+		}
+	}
+	s.BandPlan = append(s.BandPlan, e)
+}
+
 // sortAll puts sites, channels and talkgroups in a deterministic order so the
 // exporters produce stable output (important for golden tests and diffs).
 func (s *DiscoveredSystem) sortAll() {

--- a/internal/radio/p25/phase1/bandplan_snapshot_test.go
+++ b/internal/radio/p25/phase1/bandplan_snapshot_test.go
@@ -1,0 +1,24 @@
+package phase1
+
+import "testing"
+
+func TestBandPlanSnapshot(t *testing.T) {
+	var bp BandPlan
+	if len(bp.Snapshot()) != 0 {
+		t.Fatalf("empty band plan should snapshot to nothing")
+	}
+	// Apply out of ID order; Snapshot must return ascending channel-ID order.
+	bp.Apply(IdentifierUpdate{ChannelID: 3, BaseHz: 853_000_000, SpacingHz: 12_500})
+	bp.Apply(IdentifierUpdate{ChannelID: 1, BaseHz: 851_000_000, SpacingHz: 12_500, AccessTDMA: true})
+
+	got := bp.Snapshot()
+	if len(got) != 2 {
+		t.Fatalf("len(snapshot) = %d, want 2", len(got))
+	}
+	if got[0].ChannelID != 1 || got[1].ChannelID != 3 {
+		t.Errorf("snapshot order = %d,%d, want 1,3", got[0].ChannelID, got[1].ChannelID)
+	}
+	if got[0].BaseHz != 851_000_000 || !got[0].AccessTDMA {
+		t.Errorf("slot 1 = %+v, want base 851M TDMA", got[0])
+	}
+}

--- a/internal/radio/p25/phase1/control.go
+++ b/internal/radio/p25/phase1/control.go
@@ -159,6 +159,13 @@ func (c *ControlChannel) NetworkSnapshot() NetworkConfig {
 	return c.netModel.Snapshot()
 }
 
+// BandPlanSnapshot returns the IDEN_UP band-plan entries the control channel
+// accumulated, in ascending channel-ID order. Combined with NetworkSnapshot it
+// lets the signal-lab / hunt layers fully document a discovered P25 system.
+func (c *ControlChannel) BandPlanSnapshot() []IdentifierUpdate {
+	return c.bandPlan.Snapshot()
+}
+
 // Stats returns a snapshot of the per-frame outcome counters. Safe
 // for concurrent calls — each counter is read with atomic.LoadInt64.
 // See CCStats for the meaning of each field. Issue #402.

--- a/internal/radio/p25/phase1/identifier.go
+++ b/internal/radio/p25/phase1/identifier.go
@@ -403,3 +403,17 @@ func (b *BandPlan) IsTDMA(channelID uint8) bool {
 	}
 	return b.slots[channelID].AccessTDMA
 }
+
+// Snapshot returns the IdentifierUpdate entries for every known channel ID,
+// in ascending channel-ID order. Used by the signal-lab / hunt layers to
+// surface the band plan a control channel advertised so a discovered system
+// can be documented and exported.
+func (b *BandPlan) Snapshot() []IdentifierUpdate {
+	var out []IdentifierUpdate
+	for id := 0; id < len(b.slots); id++ {
+		if b.known[id] {
+			out = append(out, b.slots[id])
+		}
+	}
+	return out
+}

--- a/internal/siglab/engine.go
+++ b/internal/siglab/engine.go
@@ -271,6 +271,15 @@ func runReader(r io.Reader, source string, decode SampleDecoder, bytesPerSample 
 		}
 	}
 
+	// Attach accumulated system topology (identity / neighbors / band plan).
+	// This is the only path that surfaces WACN/SYSID/RFSS/Site etc., which
+	// never ride on event payloads.
+	if bundle.topology != nil {
+		if t := bundle.topology(); !t.Empty() {
+			res.Topology = t
+		}
+	}
+
 	if iqTap != nil {
 		res.IQTaps = iqTap.result(receiverRate)
 	}
@@ -340,12 +349,15 @@ type processor interface {
 }
 
 // runBundle is what the read loop drives plus the optional deep-path hooks.
-// stateAt/ccStats are nil for the generic factory path.
+// stateAt/ccStats are nil for the generic factory path. topology is set when
+// the pipeline can report accumulated system topology (P25 deep path always;
+// any factory pipeline implementing TopologyProvider).
 type runBundle struct {
-	proc    processor
-	closeFn func()
-	stateAt func(t float64) ReceiverState
-	ccStats func() *CCStatsBreakdown
+	proc     processor
+	closeFn  func()
+	stateAt  func(t float64) ReceiverState
+	ccStats  func() *CCStatsBreakdown
+	topology func() *TopologySnapshot
 }
 
 // buildBundle constructs the run bundle for cfg: the P25 Phase 1 deep path
@@ -371,5 +383,11 @@ func buildBundle(cfg Config, bus *events.Bus, logger *slog.Logger, receiverRate 
 	if !ok {
 		return nil, fmt.Errorf("siglab: no pipeline registered for protocol %s", cfg.Protocol)
 	}
-	return &runBundle{proc: pipe, closeFn: func() { _ = pipe.Close() }}, nil
+	rb := &runBundle{proc: pipe, closeFn: func() { _ = pipe.Close() }}
+	// Any factory pipeline may expose accumulated topology (identity / neighbor
+	// sites). Snapshot it at EOF when the protocol implements the hook.
+	if tp, ok := pipe.(TopologyProvider); ok {
+		rb.topology = tp.TopologySnapshot
+	}
+	return rb, nil
 }

--- a/internal/siglab/engine_p25.go
+++ b/internal/siglab/engine_p25.go
@@ -80,7 +80,42 @@ func buildP25DeepBundle(cfg Config, bus *events.Bus, logger *slog.Logger, receiv
 				TSBKCRCFailed:     s.TSBKCRCFailed,
 			}
 		},
+		topology: func() *TopologySnapshot { return p25Topology(cc.NetworkSnapshot(), cc.BandPlanSnapshot()) },
 	}, nil
+}
+
+// p25Topology converts the P25 Phase 1 network + band-plan snapshots into the
+// protocol-neutral TopologySnapshot the engine attaches to Result.
+func p25Topology(net p25phase1.NetworkConfig, plan []p25phase1.IdentifierUpdate) *TopologySnapshot {
+	t := &TopologySnapshot{
+		WACN:     net.WACN,
+		SystemID: uint32(net.SystemID),
+		RFSS:     net.RFSS,
+		Site:     net.Site,
+		LRA:      net.LRA,
+	}
+	for _, s := range net.Secondary {
+		t.Secondary = append(t.Secondary, ChannelRef{ChannelID: s.ChannelID, ChannelNumber: s.ChannelNumber})
+	}
+	for _, n := range net.Neighbors {
+		t.Neighbors = append(t.Neighbors, NeighborRef{
+			RFSS:          n.RFSS,
+			Site:          n.Site,
+			ChannelID:     n.ChannelID,
+			ChannelNumber: n.ChannelNumber,
+		})
+	}
+	for _, u := range plan {
+		t.BandPlan = append(t.BandPlan, BandPlanSlot{
+			ChannelID:   u.ChannelID,
+			BaseHz:      u.BaseHz,
+			SpacingHz:   u.SpacingHz,
+			BandwidthHz: u.BandwidthHz,
+			TxOffsetHz:  u.TxOffsetHz,
+			AccessTDMA:  u.AccessTDMA,
+		})
+	}
+	return t
 }
 
 // snapshotP25Receiver reads the P25 receiver's internal-loop state at stream

--- a/internal/siglab/identify.go
+++ b/internal/siglab/identify.go
@@ -1,8 +1,11 @@
 package siglab
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"log/slog"
+	"os"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -61,7 +64,34 @@ const identifyConfidenceFloor = 0.40
 // Each candidate is run through the engine — over a bounded prefix when
 // MaxSamples is set — and scored on lock + sync-landscape evidence + FEC pass
 // rate. The winner's run result is retained for WinnerResult.
+//
+// It is a thin wrapper over IdentifyReader: the file is opened once and each
+// candidate seeks back to the start, so the capture is read from disk a single
+// time rather than re-opened per protocol.
 func Identify(path string, cfg IdentifyConfig) (*IdentifyResult, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open %s: %w", path, err)
+	}
+	defer f.Close()
+	return IdentifyReader(f, path, cfg)
+}
+
+// IdentifyIQ identifies an in-memory IQ buffer without any disk round-trip. It
+// encodes the samples once in cfg.Format and delegates to IdentifyReader. This
+// is the path the live hunt sweeper uses: capture a short slice off the SDR at
+// a candidate frequency, then identify it in memory.
+func IdentifyIQ(iq []complex64, source string, cfg IdentifyConfig) (*IdentifyResult, error) {
+	buf := EncodeCapture(iq, cfg.Format)
+	return IdentifyReader(bytes.NewReader(buf), source, cfg)
+}
+
+// IdentifyReader scans the capture read from r against candidate protocols and
+// returns a ranked result. r is read once per candidate and rewound between
+// candidates via Seek, so the underlying bytes are materialized a single time
+// (an *os.File or *bytes.Reader both satisfy io.ReadSeeker, and the seek keeps
+// AutoTune working). It is the shared core behind Identify and IdentifyIQ.
+func IdentifyReader(r io.ReadSeeker, source string, cfg IdentifyConfig) (*IdentifyResult, error) {
 	if cfg.SampleRateHz <= 0 {
 		return nil, fmt.Errorf("siglab: identify sample rate must be > 0")
 	}
@@ -75,9 +105,12 @@ func Identify(path string, cfg IdentifyConfig) (*IdentifyResult, error) {
 		candidates = ccdecoder.RegisteredProtocols()
 	}
 
-	out := &IdentifyResult{Source: filepath.Base(path), SampleRateHz: cfg.SampleRateHz}
+	out := &IdentifyResult{Source: filepath.Base(source), SampleRateHz: cfg.SampleRateHz}
 	for _, p := range candidates {
-		r, err := Run(path, Config{
+		if _, err := r.Seek(0, io.SeekStart); err != nil {
+			return nil, fmt.Errorf("siglab: identify rewind: %w", err)
+		}
+		res, err := RunReader(r, source, Config{
 			Protocol:      p,
 			SystemName:    "identify",
 			SampleRateHz:  cfg.SampleRateHz,
@@ -92,7 +125,7 @@ func Identify(path string, cfg IdentifyConfig) (*IdentifyResult, error) {
 		if err != nil {
 			continue // a candidate that errors out is simply dropped
 		}
-		out.Candidates = append(out.Candidates, scoreCandidate(p, r))
+		out.Candidates = append(out.Candidates, scoreCandidate(p, res))
 	}
 	if len(out.Candidates) == 0 {
 		return nil, fmt.Errorf("siglab: identify produced no candidate scores")

--- a/internal/siglab/result.go
+++ b/internal/siglab/result.go
@@ -45,6 +45,14 @@ type Result struct {
 	// detail builder exists. Consumers type-switch on it (keyed by Protocol).
 	Detail any `json:"detail,omitempty" yaml:"detail,omitempty"`
 
+	// Topology is the protocol-neutral system topology accumulated from the
+	// control channel during the run — identity (WACN/SYSID/RFSS/Site or the
+	// per-protocol equivalent), neighbor sites, and band plan. It is the only
+	// path by which a caller learns WACN/SYSID/RFSS/Site, which never appear in
+	// event payloads (they live in the decoder's network model). nil when the
+	// protocol's pipeline does not implement TopologyProvider.
+	Topology *TopologySnapshot `json:"topology,omitempty" yaml:"topology,omitempty"`
+
 	// Verdict (nil unless Config.Acceptance supplied).
 	Verdict *Verdict `json:"verdict,omitempty" yaml:"verdict,omitempty"`
 

--- a/internal/siglab/topology.go
+++ b/internal/siglab/topology.go
@@ -1,0 +1,21 @@
+package siglab
+
+import "github.com/MattCheramie/GopherTrunk/internal/trunking"
+
+// The protocol-neutral topology types live in package trunking so the
+// per-protocol control-channel decoders (which siglab imports) can implement
+// TopologyProvider without an import cycle. siglab re-exports them as aliases
+// so existing siglab/hunt call sites keep using siglab.TopologySnapshot etc.
+type (
+	// TopologySnapshot is the accumulated system topology attached to a
+	// Result.Topology. See trunking.TopologySnapshot.
+	TopologySnapshot = trunking.TopologySnapshot
+	// ChannelRef is a band-plan channel coordinate. See trunking.TopoChannelRef.
+	ChannelRef = trunking.TopoChannelRef
+	// NeighborRef is an adjacent site. See trunking.TopoNeighborRef.
+	NeighborRef = trunking.TopoNeighborRef
+	// BandPlanSlot is one band-plan entry. See trunking.TopoBandPlanSlot.
+	BandPlanSlot = trunking.TopoBandPlanSlot
+	// TopologyProvider is the optional pipeline hook. See trunking.TopologyProvider.
+	TopologyProvider = trunking.TopologyProvider
+)

--- a/internal/siglab/topology_test.go
+++ b/internal/siglab/topology_test.go
@@ -1,0 +1,99 @@
+package siglab
+
+import (
+	"testing"
+
+	p25phase1 "github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase1"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+func TestP25TopologyMapping(t *testing.T) {
+	net := p25phase1.NetworkConfig{
+		WACN:     0xBEE99,
+		SystemID: 0x49A,
+		RFSS:     1,
+		Site:     2,
+		LRA:      0x0C,
+		Secondary: []p25phase1.Channel{
+			{ChannelID: 1, ChannelNumber: 100},
+		},
+		Neighbors: []p25phase1.NeighborSite{
+			{RFSS: 1, Site: 3, ChannelID: 1, ChannelNumber: 200},
+			{RFSS: 1, Site: 4, ChannelID: 1, ChannelNumber: 300},
+		},
+	}
+	plan := []p25phase1.IdentifierUpdate{
+		{ChannelID: 1, BaseHz: 851_000_000, SpacingHz: 12_500, BandwidthHz: 12_500, TxOffsetHz: -45_000_000},
+	}
+
+	got := p25Topology(net, plan)
+	if got.WACN != 0xBEE99 || got.SystemID != 0x49A {
+		t.Errorf("identity = WACN %X SYSID %X, want BEE99/49A", got.WACN, got.SystemID)
+	}
+	if got.RFSS != 1 || got.Site != 2 || got.LRA != 0x0C {
+		t.Errorf("RFSS/Site/LRA = %d/%d/%d, want 1/2/12", got.RFSS, got.Site, got.LRA)
+	}
+	if len(got.Secondary) != 1 || got.Secondary[0].ChannelNumber != 100 {
+		t.Errorf("secondary = %+v, want one channel 100", got.Secondary)
+	}
+	if len(got.Neighbors) != 2 || got.Neighbors[0].Site != 3 || got.Neighbors[1].Site != 4 {
+		t.Errorf("neighbors = %+v, want sites 3,4", got.Neighbors)
+	}
+	if len(got.BandPlan) != 1 || got.BandPlan[0].BaseHz != 851_000_000 || got.BandPlan[0].SpacingHz != 12_500 {
+		t.Errorf("band plan = %+v, want base 851M spacing 12.5k", got.BandPlan)
+	}
+	if got.Empty() {
+		t.Error("snapshot reported Empty despite populated fields")
+	}
+}
+
+func TestTopologySnapshotEmpty(t *testing.T) {
+	if !(&TopologySnapshot{}).Empty() {
+		t.Error("zero TopologySnapshot should be Empty")
+	}
+	if (*TopologySnapshot)(nil).Empty() != true {
+		t.Error("nil TopologySnapshot should be Empty")
+	}
+	if (&TopologySnapshot{Neighbors: []NeighborRef{{Site: 1}}}).Empty() {
+		t.Error("snapshot with a neighbor should not be Empty")
+	}
+}
+
+// TestIdentifyReaderMatchesIdentify confirms the in-memory IdentifyReader
+// produces the same winner as the file-based Identify over the same capture —
+// the parity guarantee the live sweep relies on.
+func TestIdentifyReaderMatchesIdentify(t *testing.T) {
+	iq, meta, err := Synthesize(SynthOptions{Protocol: trunking.ProtocolP25, Format: FormatF32})
+	if err != nil {
+		t.Fatalf("Synthesize: %v", err)
+	}
+
+	cfg := IdentifyConfig{SampleRateHz: meta.SampleRateHz, Format: FormatF32}
+	fromIQ, err := IdentifyIQ(iq, "p25.iq", cfg)
+	if err != nil {
+		t.Fatalf("IdentifyIQ: %v", err)
+	}
+	if fromIQ.Winner != trunking.ProtocolP25.String() {
+		t.Errorf("IdentifyIQ winner = %q, want p25", fromIQ.Winner)
+	}
+	if fromIQ.Inconclusive {
+		t.Errorf("IdentifyIQ inconclusive (conf %.2f)", fromIQ.Confidence)
+	}
+
+	// Same buffer through a file → Identify should agree on the winner.
+	dir := t.TempDir()
+	path := dir + "/p25.cfile"
+	if err := WriteCapture(path, iq, FormatF32); err != nil {
+		t.Fatalf("WriteCapture: %v", err)
+	}
+	fromFile, err := Identify(path, cfg)
+	if err != nil {
+		t.Fatalf("Identify: %v", err)
+	}
+	if fromIQ.Winner != fromFile.Winner {
+		t.Errorf("winner mismatch: IdentifyIQ=%q Identify=%q", fromIQ.Winner, fromFile.Winner)
+	}
+	if len(fromIQ.Candidates) != len(fromFile.Candidates) {
+		t.Errorf("candidate count mismatch: IQ=%d file=%d", len(fromIQ.Candidates), len(fromFile.Candidates))
+	}
+}

--- a/internal/trunking/topology.go
+++ b/internal/trunking/topology.go
@@ -1,0 +1,92 @@
+package trunking
+
+// TopologySnapshot is the protocol-neutral system topology a control-channel
+// decoder accumulates over a run: the system/site identity, the neighbor
+// (adjacent) sites it advertised, and its band plan. The signal-lab engine
+// attaches it to a decode Result, and the hunt accumulator folds it into a
+// discovered system.
+//
+// It lives in package trunking (not siglab) so the per-protocol control-channel
+// decoders — which siglab imports — can implement TopologyProvider without an
+// import cycle. siglab re-exports these as type aliases for ergonomics.
+//
+// Why this exists separately from per-event payloads: the identifying fields
+// (WACN/SYSID/RFSS/Site for P25, and the per-protocol equivalents) are
+// accumulated from periodic status broadcasts inside the decoder's network
+// model — they are NOT carried on any per-event payload, so a consumer cannot
+// recover them from the event stream. This snapshot is the bridge.
+//
+// All fields are optional; a protocol fills in only what it can observe.
+// Capability varies: P25 surfaces full identity + neighbors + band plan;
+// DMR Tier III / EDACS / Motorola can add identity + neighbors; NXDN / TETRA
+// give single-site identity; the rest give minimal identity. Band-plan-from-air
+// is P25-only today.
+type TopologySnapshot struct {
+	// P25 identity.
+	WACN     uint32 `json:"wacn,omitempty" yaml:"wacn,omitempty"`
+	SystemID uint32 `json:"system_id,omitempty" yaml:"system_id,omitempty"`
+	RFSS     uint8  `json:"rfss,omitempty" yaml:"rfss,omitempty"`
+	Site     uint8  `json:"site,omitempty" yaml:"site,omitempty"`
+	LRA      uint8  `json:"lra,omitempty" yaml:"lra,omitempty"`
+
+	// Per-protocol identity (populated where applicable).
+	ColorCode    uint8  `json:"color_code,omitempty" yaml:"color_code,omitempty"`       // DMR
+	RAN          uint8  `json:"ran,omitempty" yaml:"ran,omitempty"`                     // NXDN
+	MCC          uint16 `json:"mcc,omitempty" yaml:"mcc,omitempty"`                     // TETRA
+	MNC          uint16 `json:"mnc,omitempty" yaml:"mnc,omitempty"`                     // TETRA
+	LocationArea uint16 `json:"location_area,omitempty" yaml:"location_area,omitempty"` // TETRA LA / NXDN location
+
+	// Secondary control channels advertised for the camped site.
+	Secondary []TopoChannelRef `json:"secondary,omitempty" yaml:"secondary,omitempty"`
+	// Neighbors are adjacent sites the control channel advertised.
+	Neighbors []TopoNeighborRef `json:"neighbors,omitempty" yaml:"neighbors,omitempty"`
+	// BandPlan maps channel IDs to frequencies (P25 IDEN_UP and equivalents).
+	BandPlan []TopoBandPlanSlot `json:"band_plan,omitempty" yaml:"band_plan,omitempty"`
+}
+
+// TopoChannelRef is a channel identified by its band-plan (id, number)
+// coordinates and, when resolvable, an absolute frequency.
+type TopoChannelRef struct {
+	ChannelID     uint8  `json:"channel_id" yaml:"channel_id"`
+	ChannelNumber uint16 `json:"channel_number" yaml:"channel_number"`
+	FrequencyHz   uint32 `json:"frequency_hz,omitempty" yaml:"frequency_hz,omitempty"`
+}
+
+// TopoNeighborRef is an adjacent site advertised by the control channel.
+type TopoNeighborRef struct {
+	RFSS          uint8  `json:"rfss" yaml:"rfss"`
+	Site          uint8  `json:"site" yaml:"site"`
+	ChannelID     uint8  `json:"channel_id,omitempty" yaml:"channel_id,omitempty"`
+	ChannelNumber uint16 `json:"channel_number,omitempty" yaml:"channel_number,omitempty"`
+	FrequencyHz   uint32 `json:"frequency_hz,omitempty" yaml:"frequency_hz,omitempty"`
+}
+
+// TopoBandPlanSlot is one entry of a P25-style band plan (IDEN_UP): a channel
+// ID mapped to a base frequency, channel spacing, and transmit offset.
+type TopoBandPlanSlot struct {
+	ChannelID   uint8  `json:"channel_id" yaml:"channel_id"`
+	BaseHz      uint64 `json:"base_hz" yaml:"base_hz"`
+	SpacingHz   uint32 `json:"spacing_hz" yaml:"spacing_hz"`
+	BandwidthHz uint32 `json:"bandwidth_hz,omitempty" yaml:"bandwidth_hz,omitempty"`
+	TxOffsetHz  int64  `json:"tx_offset_hz,omitempty" yaml:"tx_offset_hz,omitempty"`
+	AccessTDMA  bool   `json:"access_tdma,omitempty" yaml:"access_tdma,omitempty"`
+}
+
+// TopologyProvider is the optional hook a control-channel pipeline implements
+// to expose its accumulated topology after a run. The siglab engine queries it
+// once at EOF and attaches the snapshot to the Result. Returning nil (or an
+// empty snapshot) is fine for protocols/runs that observed no topology.
+type TopologyProvider interface {
+	TopologySnapshot() *TopologySnapshot
+}
+
+// Empty reports whether the snapshot carries no usable information, so callers
+// can avoid attaching a hollow snapshot to a Result.
+func (t *TopologySnapshot) Empty() bool {
+	if t == nil {
+		return true
+	}
+	return t.WACN == 0 && t.SystemID == 0 && t.RFSS == 0 && t.Site == 0 && t.LRA == 0 &&
+		t.ColorCode == 0 && t.RAN == 0 && t.MCC == 0 && t.MNC == 0 && t.LocationArea == 0 &&
+		len(t.Secondary) == 0 && len(t.Neighbors) == 0 && len(t.BandPlan) == 0
+}


### PR DESCRIPTION
Phase 1 of the hunt follow-ups. Two enhancements, no SDR, fully unit-tested.

Topology enrichment:
- New protocol-neutral trunking.TopologySnapshot (identity + neighbor sites +
  band plan) + TopologyProvider hook, living in package trunking so the
  per-protocol control-channel decoders siglab imports can implement it without
  an import cycle. siglab re-exports the types as aliases.
- siglab.Result gains a Topology field. The P25 Phase 1 deep path snapshots the
  control channel's NetworkModel (WACN/SYSID/RFSS/Site/LRA + neighbors) and the
  new BandPlan.Snapshot() (IDEN_UP entries) into it; the generic factory path
  attaches topology from any pipeline implementing TopologyProvider (the
  extension point for non-P25 protocols, which land incrementally).
- The hunt accumulator folds Result.Topology into the discovered system —
  authoritative WACN/SYSID/RFSS/Site, neighbor sites, and band plan — instead
  of the NAC-only identity it could previously recover from events. Discover
  now runs P25 via the deep path so the map is populated.

In-memory identify:
- siglab.IdentifyReader(io.ReadSeeker) and IdentifyIQ([]complex64) read the
  buffer once and rewind between candidates instead of re-opening a file per
  protocol; Identify(path) is now a thin wrapper. This is what the upcoming
  live spectrum sweep will use to identify candidates without temp files.

Verified end-to-end on the real mmr-s9-cc.cfile capture: the exports now carry
WACN 0xBEE, SYSID 0x001, RFSS 100/Site 2, the advertised neighbor site, and the
full over-the-air band plan.

https://claude.ai/code/session_01He917mJB4Kg4ZkHjyHtJ66