### PR TITLE
hunt: live spectrum-sweep discovery engine + CLI live mode

### DIFF
--- a/cmd/gophertrunk/hunt.go
+++ b/cmd/gophertrunk/hunt.go
@@ -18,14 +18,14 @@ import (
 )
 
 // runHunt is the entry point for `gophertrunk hunt`. It maps a previously
-// unknown/undocumented trunked system from one or more IQ captures (each
-// centered on a suspected control channel), then exports the discovered system
-// to standardized files plus a RadioReference.com submission package.
+// unknown/undocumented trunked system, then exports the discovered system to
+// standardized files plus a RadioReference.com submission package.
 //
-// This is the offline path: each -in capture is identified, decoded, and
-// accumulated into one DiscoveredSystem. A live spectrum-sweep front-end that
-// finds the candidate control channels on the air is the planned follow-on;
-// today the operator supplies the captures (e.g. from `gophertrunk capture`).
+// Two modes share the same identify→decode→map→export pipeline:
+//   - Offline (-in): each capture is identified, decoded, and accumulated.
+//   - Live (-serial): a wideband spectrum sweep across operator-given -band(s)
+//     (or an explicit -candidates list) finds carriers on the air, then each is
+//     identified, decoded, and accumulated.
 func runHunt(args []string) {
 	fs := flag.NewFlagSet("hunt", flag.ExitOnError)
 	verboseFlag := fs.Bool("verbose-errors", false, "print full error chain + stack on failures")
@@ -41,6 +41,21 @@ func runHunt(args []string) {
 	conjugate := fs.Bool("conjugate", false, "conjugate IQ (negate Q) before channelization (spectrum-inverted front-end)")
 	iqCorrect := fs.Bool("iq-correct", false, "apply blind I/Q-imbalance correction to the raw IQ before decimation")
 	minConfidence := fs.Float64("min-confidence", 0.40, "skip auto-identified captures below this confidence (0..1)")
+
+	// Live-mode flags (no -in): sweep an SDR across operator-given band(s) or
+	// probe an explicit candidate list.
+	serial := fs.String("serial", "", "SDR serial to sweep for a live hunt (omit -in). Empty + no -in ⇒ error")
+	var bands repeatedString
+	fs.Var(&bands, "band", "frequency band to sweep as low:high in MHz (repeatable; live mode)")
+	candidatesFlag := fs.String("candidates", "", "comma-separated control-channel frequencies in MHz to probe directly (skips the sweep)")
+	noSweep := fs.Bool("no-sweep", false, "with -candidates, probe only the listed frequencies (no spectrum sweep)")
+	sweepDwell := fs.Duration("sweep-dwell", 0, "accumulation time per sweep step (e.g. 200ms; 0 ⇒ one frame)")
+	peakThresholdDb := fs.Float64("peak-threshold-db", 10, "minimum dB above the noise floor for a carrier to count (live sweep)")
+	minSpacingHz := fs.Uint("min-spacing", 6250, "minimum Hz between detected carriers (live sweep)")
+	fftSize := fs.Int("fft-size", 4096, "FFT size per sweep step (power of two)")
+	dwellSeconds := fs.Float64("dwell-seconds", 3, "IQ seconds captured per candidate for identify+decode (live mode)")
+	gain := fs.Int("gain", -1, "SDR gain in tenths of dB for live mode (-1 = automatic)")
+	ppm := fs.Int("ppm", 0, "SDR frequency correction in PPM for live mode")
 
 	name := fs.String("name", "", "system name (default: synthesized from identity)")
 	state := fs.String("state", "", "US state (2-letter) — used in the RR submission package")
@@ -81,6 +96,12 @@ EXAMPLES:
   # Discover and merge straight into config.yaml
   gophertrunk hunt -in cc.u8 -sample-rate 2400000 -commit -config ./config.yaml
 
+  # LIVE: sweep the 851-869 MHz band on an SDR and map whatever it finds
+  gophertrunk hunt -serial 00000001 -sample-rate 2400000 -band 851:869 -state AZ
+
+  # LIVE: probe a known control-channel list directly (no sweep)
+  gophertrunk hunt -serial 00000001 -sample-rate 2400000 -no-sweep -candidates 851.0125,853.5125
+
 FLAGS:`)
 		fs.PrintDefaults()
 	}
@@ -88,9 +109,10 @@ FLAGS:`)
 	resolveVerbose(*verboseFlag, false)
 	rep := newReporter("hunt")
 
-	if len(inPaths) == 0 {
+	live := len(inPaths) == 0
+	if live && *serial == "" {
 		fs.Usage()
-		rep.Fatalf(2, "at least one -in capture is required")
+		rep.Fatalf(2, "supply -in <capture> for an offline hunt, or -serial <sdr> with -band/-candidates for a live hunt")
 	}
 	if *sampleRate <= 0 {
 		rep.Fatalf(2, "-sample-rate must be > 0")
@@ -99,7 +121,7 @@ FLAGS:`)
 	if err != nil {
 		rep.Fatal(2, err)
 	}
-	if len(freqs) != 0 && len(freqs) != len(inPaths) {
+	if !live && len(freqs) != 0 && len(freqs) != len(inPaths) {
 		rep.Fatalf(2, "-freq given %d times but -in given %d times — supply one -freq per -in or none", len(freqs), len(inPaths))
 	}
 
@@ -128,41 +150,100 @@ FLAGS:`)
 		rep.Fatalf(2, "-formats listed no valid formats")
 	}
 
-	// Build the capture inputs.
-	captures := make([]hunt.CaptureInput, 0, len(inPaths))
-	for i, p := range inPaths {
-		ci := hunt.CaptureInput{
-			Path:         p,
-			Format:       sampleFormat,
-			SampleRateHz: *sampleRate,
-			AutoTune:     *autoTune,
-			Conjugate:    *conjugate,
-			IQCorrect:    *iqCorrect,
-			Protocol:     proto,
-		}
-		if len(freqs) == len(inPaths) {
-			hz, perr := strconv.ParseUint(strings.TrimSpace(freqs[i]), 10, 32)
-			if perr != nil {
-				rep.Fatalf(2, "-freq[%d] %q: %v", i, freqs[i], perr)
+	var (
+		sys     *hunt.DiscoveredSystem
+		reports []hunt.CaptureReport
+	)
+	if live {
+		sys, reports = runHuntLive(rep, huntLiveParams{
+			serial:          *serial,
+			bands:           []string(bands),
+			candidatesMHz:   *candidatesFlag,
+			noSweep:         *noSweep,
+			sampleRateHz:    *sampleRate,
+			protocol:        proto,
+			fftSize:         *fftSize,
+			sweepDwell:      *sweepDwell,
+			peakThresholdDb: *peakThresholdDb,
+			minSpacingHz:    uint32(*minSpacingHz),
+			dwellSeconds:    *dwellSeconds,
+			autoTune:        *autoTune,
+			gain:            *gain,
+			ppm:             *ppm,
+			name:            *name,
+			state:           *state,
+			county:          *county,
+			location:        *location,
+			minConfidence:   *minConfidence,
+		})
+	} else {
+		// Build the capture inputs.
+		captures := make([]hunt.CaptureInput, 0, len(inPaths))
+		for i, p := range inPaths {
+			ci := hunt.CaptureInput{
+				Path:         p,
+				Format:       sampleFormat,
+				SampleRateHz: *sampleRate,
+				AutoTune:     *autoTune,
+				Conjugate:    *conjugate,
+				IQCorrect:    *iqCorrect,
+				Protocol:     proto,
 			}
-			ci.FrequencyHz = uint32(hz)
+			if len(freqs) == len(inPaths) {
+				hz, perr := strconv.ParseUint(strings.TrimSpace(freqs[i]), 10, 32)
+				if perr != nil {
+					rep.Fatalf(2, "-freq[%d] %q: %v", i, freqs[i], perr)
+				}
+				ci.FrequencyHz = uint32(hz)
+			}
+			captures = append(captures, ci)
 		}
-		captures = append(captures, ci)
+
+		fmt.Fprintf(os.Stderr, "hunt: mapping %d capture(s)…\n", len(captures))
+		var derr error
+		sys, reports, derr = hunt.Discover(captures, hunt.DiscoverConfig{
+			Name:          *name,
+			State:         *state,
+			County:        *county,
+			Location:      *location,
+			MinConfidence: *minConfidence,
+		})
+		if derr != nil {
+			rep.Fatal(1, derr)
+		}
 	}
 
-	fmt.Fprintf(os.Stderr, "hunt: mapping %d capture(s)…\n", len(captures))
-	sys, reports, derr := hunt.Discover(captures, hunt.DiscoverConfig{
-		Name:          *name,
-		State:         *state,
-		County:        *county,
-		Location:      *location,
-		MinConfidence: *minConfidence,
+	finishHunt(rep, sys, reports, huntExportParams{
+		outFormats: outFormats,
+		outDir:     *out,
+		noRR:       *noRR,
+		rr:         rrOptions{key: *rrKey, countyID: *rrCountyID, checkSIDs: rrCheckSIDs},
+		commit:     *commit,
+		configPath: *configPath,
+		csvDir:     *csvDir,
+		force:      *force,
+		dryRun:     *dryRun,
 	})
-	if derr != nil {
-		rep.Fatal(1, derr)
-	}
+}
 
-	// Per-capture progress so the operator sees what locked vs. was skipped.
+// huntExportParams carries the post-discovery export/RR/commit options shared
+// by the offline and live hunt paths.
+type huntExportParams struct {
+	outFormats []hunt.Format
+	outDir     string
+	noRR       bool
+	rr         rrOptions
+	commit     bool
+	configPath string
+	csvDir     string
+	force      bool
+	dryRun     bool
+}
+
+// finishHunt prints the per-candidate reports, runs the optional RadioReference
+// duplicate check, writes the export files, and optionally commits the
+// discovery into config.yaml. Shared by offline and live hunts.
+func finishHunt(rep *diag.Reporter, sys *hunt.DiscoveredSystem, reports []hunt.CaptureReport, p huntExportParams) {
 	for _, r := range reports {
 		switch {
 		case r.Error != "":
@@ -175,24 +256,19 @@ FLAGS:`)
 		}
 	}
 	if len(sys.Sites) == 0 && len(sys.Talkgroups) == 0 {
-		rep.Fatalf(1, "no trunked control channel was decoded from the supplied capture(s)")
+		rep.Fatalf(1, "no trunked control channel was decoded")
 	}
 	fmt.Fprintf(os.Stderr, "hunt: discovered %q — %d site(s), %d talkgroup(s)\n",
 		sys.DisplayName(), len(sys.Sites), len(sys.Talkgroups))
 
-	// Optional read-only RadioReference duplicate check. Failures here are
-	// non-fatal: the export still happens, just without hints.
+	// Optional read-only RadioReference duplicate check. Non-fatal: the export
+	// still happens, just without hints.
 	var hints []hunt.DuplicateHint
-	if !*noRR {
-		hints = gatherRRHints(sys, rrOptions{
-			key:       *rrKey,
-			countyID:  *rrCountyID,
-			checkSIDs: rrCheckSIDs,
-		})
+	if !p.noRR {
+		hints = gatherRRHints(sys, p.rr)
 	}
 
-	// Write the export files.
-	outDir := *out
+	outDir := p.outDir
 	if outDir == "" {
 		outDir = fmt.Sprintf("hunt-%s", time.Now().Format("20060102-150405"))
 	}
@@ -200,7 +276,7 @@ FLAGS:`)
 		rep.Fatal(1, fmt.Errorf("create out dir %s: %w", outDir, err))
 	}
 	base := slugName(sys.DisplayName())
-	for _, hf := range outFormats {
+	for _, hf := range p.outFormats {
 		fname := filepath.Join(outDir, fmt.Sprintf("%s.%s", base, hf.FileExtension()))
 		if hf == hunt.FormatRR {
 			fname = filepath.Join(outDir, fmt.Sprintf("%s-radioreference.%s", base, hf.FileExtension()))
@@ -220,10 +296,8 @@ FLAGS:`)
 		fmt.Fprintf(os.Stderr, "hunt: wrote %s (%s)\n", fname, hf)
 	}
 
-	// Optional: merge straight into config.yaml, reusing the importer's writer
-	// so a discovery lands exactly like a PDF/CSV import would.
-	if *commit {
-		commitDiscovery(rep, sys, *configPath, *csvDir, *force, *dryRun)
+	if p.commit {
+		commitDiscovery(rep, sys, p.configPath, p.csvDir, p.force, p.dryRun)
 	}
 }
 

--- a/cmd/gophertrunk/hunt_live.go
+++ b/cmd/gophertrunk/hunt_live.go
@@ -1,0 +1,219 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/diag"
+	"github.com/MattCheramie/GopherTrunk/internal/hunt"
+	"github.com/MattCheramie/GopherTrunk/internal/sdr"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// huntLiveParams are the resolved inputs for a live (on-air) hunt.
+type huntLiveParams struct {
+	serial          string
+	bands           []string // "low:high" in MHz
+	candidatesMHz   string   // comma-separated MHz
+	noSweep         bool
+	sampleRateHz    float64
+	protocol        trunking.Protocol
+	fftSize         int
+	sweepDwell      time.Duration
+	peakThresholdDb float64
+	minSpacingHz    uint32
+	dwellSeconds    float64
+	autoTune        bool
+	gain            int
+	ppm             int
+	name            string
+	state           string
+	county          string
+	location        string
+	minConfidence   float64
+}
+
+// runHuntLive opens the SDR directly (standalone, not through the daemon pool),
+// sweeps the requested band(s) — or probes an explicit candidate list — and
+// returns the discovered system plus per-candidate reports for the shared
+// export tail. The daemon-integrated live hunt (with spare-SDR-else-borrow
+// acquisition and a REST/TUI/web cockpit) is a later phase; this is the
+// one-shot CLI path.
+func runHuntLive(rep *diag.Reporter, p huntLiveParams) (*hunt.DiscoveredSystem, []hunt.CaptureReport) {
+	candidates := parseFreqListMHz(rep, p.candidatesMHz)
+	bands := parseBandsMHz(rep, p.bands)
+	if len(candidates) == 0 && len(bands) == 0 {
+		rep.Fatalf(2, "live hunt needs -band low:high (to sweep) or -candidates f,f (to probe)")
+	}
+	if p.noSweep && len(candidates) == 0 {
+		rep.Fatalf(2, "-no-sweep requires -candidates")
+	}
+	if p.noSweep {
+		bands = nil // probe only the listed candidates
+	}
+
+	dev, info, err := openCaptureDevice(p.serial)
+	if err != nil {
+		rep.Fatal(1, err)
+	}
+	defer dev.Close()
+	if err := dev.SetSampleRate(uint32(p.sampleRateHz)); err != nil {
+		rep.Fatal(1, fmt.Errorf("set sample rate: %w", err))
+	}
+	if p.ppm != 0 {
+		if err := dev.SetPPM(p.ppm); err != nil {
+			rep.Fatal(1, fmt.Errorf("set ppm: %w", err))
+		}
+	}
+	if err := dev.SetGain(p.gain); err != nil {
+		rep.Fatal(1, fmt.Errorf("set gain: %w", err))
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer stop()
+
+	src, err := newDeviceIQSource(ctx, dev, uint32(p.sampleRateHz))
+	if err != nil {
+		rep.Fatal(1, fmt.Errorf("start IQ stream: %w", err))
+	}
+
+	if len(bands) > 0 {
+		fmt.Fprintf(os.Stderr, "hunt: live sweep on %s[%s] @ %g MS/s across %d band(s)…\n",
+			info.Driver, info.Serial, p.sampleRateHz/1e6, len(bands))
+	} else {
+		fmt.Fprintf(os.Stderr, "hunt: live probe on %s[%s] of %d candidate(s)…\n",
+			info.Driver, info.Serial, len(candidates))
+	}
+
+	sys, reports, err := hunt.RunLiveHunt(ctx, hunt.LiveHuntOptions{
+		Source:        src,
+		Bands:         bands,
+		Candidates:    candidates,
+		Protocol:      p.protocol,
+		FFTSize:       p.fftSize,
+		SweepDwell:    p.sweepDwell,
+		PeakOpts:      hunt.PeakOptions{ThresholdDb: float32(p.peakThresholdDb), MinSpacingHz: p.minSpacingHz},
+		DwellSeconds:  p.dwellSeconds,
+		MinConfidence: p.minConfidence,
+		AutoTune:      p.autoTune,
+		Name:          p.name,
+		State:         p.state,
+		County:        p.county,
+		Location:      p.location,
+		OnProgress: func(pr hunt.LiveHuntProgress) {
+			switch pr.Phase {
+			case hunt.PhaseSweeping:
+				fmt.Fprintf(os.Stderr, "hunt: sweeping %.4f MHz — %s\n", float64(pr.CenterHz)/1e6, pr.Detail)
+			case hunt.PhaseIdentifying:
+				fmt.Fprintf(os.Stderr, "hunt: probing candidate %d/%d @ %s\n", pr.CandidateN, pr.Candidates, pr.Detail)
+			}
+		},
+	})
+	if err != nil {
+		rep.Fatal(1, fmt.Errorf("live hunt: %w", err))
+	}
+	return sys, reports
+}
+
+// parseFreqListMHz parses a comma-separated MHz list into Hz. Empty ⇒ nil.
+func parseFreqListMHz(rep *diag.Reporter, s string) []uint32 {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil
+	}
+	var out []uint32
+	for _, part := range strings.Split(s, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		mhz, err := strconv.ParseFloat(part, 64)
+		if err != nil {
+			rep.Fatalf(2, "-candidates: invalid frequency %q", part)
+		}
+		out = append(out, uint32(mhz*1e6+0.5))
+	}
+	return out
+}
+
+// parseBandsMHz parses "low:high" MHz band specs into hunt.Band (Hz).
+func parseBandsMHz(rep *diag.Reporter, specs []string) []hunt.Band {
+	var out []hunt.Band
+	for _, sp := range specs {
+		lo, hi, ok := strings.Cut(sp, ":")
+		if !ok {
+			rep.Fatalf(2, "-band %q: want low:high in MHz", sp)
+		}
+		loMHz, e1 := strconv.ParseFloat(strings.TrimSpace(lo), 64)
+		hiMHz, e2 := strconv.ParseFloat(strings.TrimSpace(hi), 64)
+		if e1 != nil || e2 != nil || hiMHz <= loMHz {
+			rep.Fatalf(2, "-band %q: invalid range", sp)
+		}
+		out = append(out, hunt.Band{LowHz: uint32(loMHz*1e6 + 0.5), HighHz: uint32(hiMHz*1e6 + 0.5)})
+	}
+	return out
+}
+
+// deviceIQSource adapts a live sdr.Device to hunt.IQSource. A background
+// goroutine drains the device's IQ stream into a channel; Capture pulls from a
+// rolling buffer and Tune retunes the device, flushing the transient.
+type deviceIQSource struct {
+	dev     sdr.Device
+	rate    uint32
+	ch      <-chan []complex64
+	pending []complex64
+	settle  time.Duration
+}
+
+func newDeviceIQSource(ctx context.Context, dev sdr.Device, rate uint32) (*deviceIQSource, error) {
+	ch, err := dev.StreamIQ(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &deviceIQSource{dev: dev, rate: rate, ch: ch, settle: 50 * time.Millisecond}, nil
+}
+
+func (s *deviceIQSource) SampleRateHz() uint32 { return s.rate }
+
+func (s *deviceIQSource) Tune(centerHz uint32) error {
+	if err := s.dev.SetCenterFreq(centerHz); err != nil {
+		return err
+	}
+	// Discard buffered + in-flight samples captured before/at the retune so the
+	// next Capture sees only settled IQ at the new center.
+	s.pending = nil
+	deadline := time.NewTimer(s.settle)
+	defer deadline.Stop()
+	for {
+		select {
+		case <-s.ch:
+			// drain
+		case <-deadline.C:
+			return nil
+		}
+	}
+}
+
+func (s *deviceIQSource) Capture(ctx context.Context, n int) ([]complex64, error) {
+	for len(s.pending) < n {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case chunk, ok := <-s.ch:
+			if !ok {
+				out := s.pending
+				s.pending = nil
+				return out, nil // stream ended
+			}
+			s.pending = append(s.pending, chunk...)
+		}
+	}
+	out := s.pending[:n:n]
+	s.pending = s.pending[n:]
+	return out, nil
+}

--- a/docs/hunt.md
+++ b/docs/hunt.md
@@ -57,6 +57,31 @@ gophertrunk hunt -in cc.cfile -freq 851012500 -sample-rate 2400000 \
 > Without it, a baseband capture locks at 0 Hz and the channel can't be
 > exported.
 
+## Live mode (spectrum sweep)
+
+Instead of supplying captures, point `hunt` at an SDR and let it find the
+control channels on the air. It sweeps the band(s) you give with an FFT,
+detects candidate carriers above the noise floor, then identifies, decodes,
+and maps each one through the same pipeline as the offline path.
+
+```sh
+# Sweep 851-869 MHz on an SDR and map whatever trunked systems it finds
+gophertrunk hunt -serial 00000001 -sample-rate 2400000 -band 851:869 \
+  -state AZ -county Maricopa -out ./hunt-live
+
+# Probe a known control-channel list directly (skip the sweep)
+gophertrunk hunt -serial 00000001 -sample-rate 2400000 \
+  -no-sweep -candidates 851.0125,853.5125
+```
+
+Live sweep tuning flags: `-band low:high` (MHz, repeatable), `-sweep-dwell`
+(accumulation per step), `-peak-threshold-db` (carrier detection threshold over
+the noise floor), `-min-spacing` (Hz between carriers), `-fft-size`,
+`-dwell-seconds` (IQ captured per candidate for identify+decode), plus
+`-gain`/`-ppm` for the SDR. This standalone CLI path opens the SDR directly; a
+daemon-integrated live hunt (spare-SDR-else-borrow acquisition, with a
+REST/TUI/web cockpit) is the next phase.
+
 ## Export formats
 
 Select with `-formats` (comma-separated; default is all three):
@@ -110,11 +135,10 @@ to force it off even when a key is configured.
 
 ## Limitations & roadmap
 
-- **Operator-supplied captures.** Today you supply the captures (one per
-  suspected control channel). A live wideband **spectrum-sweep** front-end
-  that finds the candidate control channels on the air automatically — using
-  the existing FFT spectrum producer for peak detection — is the planned
-  follow-on, along with a live cockpit/TUI/web panel.
+- **Live cockpit.** The standalone CLI live sweep (`-serial`) opens the SDR
+  directly. A daemon-integrated live hunt — sharing the running radio via
+  spare-SDR-else-borrow acquisition, driven from a REST API and the TUI/web
+  cockpit — is the next phase.
 - **Topology depth.** For **P25** the hunt now recovers full topology —
   WACN/SYSID, the camped RFSS/Site, advertised neighbor (adjacent) sites, and
   the over-the-air band plan (IDEN_UP) — all surfaced in the exports. For other

--- a/internal/hunt/decode.go
+++ b/internal/hunt/decode.go
@@ -1,0 +1,124 @@
+package hunt
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/siglab"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// decodeParams carries everything decodeAndAccumulate needs to identify and
+// decode one capture, independent of whether the IQ comes from a file (offline
+// Discover) or a live capture buffer (LiveHunter).
+type decodeParams struct {
+	// Protocol forces a decoder; trunking.ProtocolUnknown auto-identifies.
+	Protocol     trunking.Protocol
+	Format       siglab.SampleFormat
+	SampleRateHz float64
+	// FrequencyHz is the capture's nominal center (recorded as the control
+	// channel when the lock doesn't carry an absolute frequency).
+	FrequencyHz uint32
+	AutoTune    bool
+	Conjugate   bool
+	IQCorrect   bool
+	// IdentifyMaxSamples bounds the prefix the identifier scans (0 ⇒ default).
+	IdentifyMaxSamples int64
+	// MinConfidence gates auto-identified captures (0 ⇒ 0.40).
+	MinConfidence float64
+	Log           *slog.Logger
+}
+
+// decodeAndAccumulate identifies (unless a protocol is forced), decodes, and
+// folds one capture read from r into sys, returning a report of the outcome. r
+// must be seekable: identification rewinds it per candidate, and the decode
+// rewinds it once more. This is the single body shared by the offline Discover
+// (r is an *os.File) and the live hunter (r is a bytes.Reader over a captured
+// IQ buffer).
+func decodeAndAccumulate(sys *DiscoveredSystem, r io.ReadSeeker, source string, p decodeParams) CaptureReport {
+	log := p.Log
+	if log == nil {
+		log = slog.New(slog.DiscardHandler)
+	}
+	minConf := p.MinConfidence
+	if minConf <= 0 {
+		minConf = 0.40
+	}
+	rep := CaptureReport{Path: source}
+
+	proto := p.Protocol
+	conf := 1.0 // operator-forced protocol ⇒ full confidence
+	if proto == trunking.ProtocolUnknown {
+		idr, err := siglab.IdentifyReader(r, source, siglab.IdentifyConfig{
+			SampleRateHz: p.SampleRateHz,
+			Format:       p.Format,
+			AutoTune:     p.AutoTune,
+			Conjugate:    p.Conjugate,
+			IQCorrect:    p.IQCorrect,
+			MaxSamples:   p.IdentifyMaxSamples,
+			Log:          log,
+		})
+		if err != nil {
+			rep.Error = fmt.Sprintf("identify: %v", err)
+			return rep
+		}
+		conf = idr.Confidence
+		if idr.Inconclusive || idr.Confidence < minConf {
+			rep.Protocol = idr.Winner
+			rep.Confidence = idr.Confidence
+			rep.Skipped = true
+			rep.SkipReason = fmt.Sprintf("no trunked control channel above confidence %.2f (best: %s @ %.2f)",
+				minConf, idr.Winner, idr.Confidence)
+			return rep
+		}
+		wp, err := idr.WinnerProtocol()
+		if err != nil {
+			rep.Error = fmt.Sprintf("winner protocol: %v", err)
+			return rep
+		}
+		proto = wp
+	}
+	rep.Protocol = proto.String()
+	rep.Confidence = conf
+
+	if _, err := r.Seek(0, io.SeekStart); err != nil {
+		rep.Error = fmt.Sprintf("rewind: %v", err)
+		return rep
+	}
+	res, err := siglab.RunReader(r, source, siglab.Config{
+		Protocol:     proto,
+		FrequencyHz:  p.FrequencyHz,
+		SampleRateHz: p.SampleRateHz,
+		Format:       p.Format,
+		AutoTune:     p.AutoTune,
+		Conjugate:    p.Conjugate,
+		IQCorrect:    p.IQCorrect,
+		// CollectIQDiag engages P25 Phase 1's deep path, which is what snapshots
+		// the system topology (WACN/SYSID/RFSS/Site + neighbors + band plan)
+		// onto Result.Topology. Without it P25 runs the generic factory pipeline
+		// and the map would be NAC-only.
+		CollectIQDiag: true,
+		Log:           log,
+	})
+	if err != nil {
+		rep.Error = fmt.Sprintf("decode: %v", err)
+		return rep
+	}
+
+	before := len(sys.Talkgroups)
+	Accumulate(sys, Observation{
+		Protocol:       proto.String(),
+		Confidence:     conf,
+		Result:         res,
+		FallbackFreqHz: p.FrequencyHz,
+		At:             time.Now(),
+	})
+	rep.Locked = res.Locked
+	if res.Lock != nil {
+		rep.ControlHz = res.Lock.FrequencyHz
+	}
+	rep.Talkgroups = len(sys.Talkgroups) - before
+	return rep
+}

--- a/internal/hunt/discover.go
+++ b/internal/hunt/discover.go
@@ -3,7 +3,7 @@ package hunt
 import (
 	"fmt"
 	"log/slog"
-	"time"
+	"os"
 
 	"github.com/MattCheramie/GopherTrunk/internal/siglab"
 	"github.com/MattCheramie/GopherTrunk/internal/trunking"
@@ -79,81 +79,24 @@ func Discover(captures []CaptureInput, cfg DiscoverConfig) (*DiscoveredSystem, [
 	reports := make([]CaptureReport, 0, len(captures))
 
 	for _, cap := range captures {
-		rep := CaptureReport{Path: cap.Path}
-
-		proto := cap.Protocol
-		conf := 1.0 // operator-supplied protocol ⇒ full confidence
-		if proto == trunking.ProtocolUnknown {
-			idr, err := siglab.Identify(cap.Path, siglab.IdentifyConfig{
-				SampleRateHz: cap.SampleRateHz,
-				Format:       cap.Format,
-				AutoTune:     cap.AutoTune,
-				Conjugate:    cap.Conjugate,
-				IQCorrect:    cap.IQCorrect,
-				MaxSamples:   cap.IdentifyMaxSamples,
-				Log:          log,
-			})
-			if err != nil {
-				rep.Error = fmt.Sprintf("identify: %v", err)
-				reports = append(reports, rep)
-				continue
-			}
-			conf = idr.Confidence
-			if idr.Inconclusive || idr.Confidence < minConf {
-				rep.Protocol = idr.Winner
-				rep.Confidence = idr.Confidence
-				rep.Skipped = true
-				rep.SkipReason = fmt.Sprintf("no trunked control channel above confidence %.2f (best: %s @ %.2f)",
-					minConf, idr.Winner, idr.Confidence)
-				reports = append(reports, rep)
-				continue
-			}
-			p, err := idr.WinnerProtocol()
-			if err != nil {
-				rep.Error = fmt.Sprintf("winner protocol: %v", err)
-				reports = append(reports, rep)
-				continue
-			}
-			proto = p
-		}
-		rep.Protocol = proto.String()
-		rep.Confidence = conf
-
-		res, err := siglab.Run(cap.Path, siglab.Config{
-			Protocol:     proto,
-			FrequencyHz:  cap.FrequencyHz,
-			SampleRateHz: cap.SampleRateHz,
-			Format:       cap.Format,
-			AutoTune:     cap.AutoTune,
-			Conjugate:    cap.Conjugate,
-			IQCorrect:    cap.IQCorrect,
-			// CollectIQDiag engages P25 Phase 1's deep decode path, which is
-			// what accumulates and snapshots the system topology
-			// (WACN/SYSID/RFSS/Site + neighbors + band plan) onto Result.Topology.
-			// Without it P25 runs the generic factory pipeline and the map would
-			// be NAC-only.
-			CollectIQDiag: true,
-			Log:           log,
-		})
+		f, err := os.Open(cap.Path)
 		if err != nil {
-			rep.Error = fmt.Sprintf("decode: %v", err)
-			reports = append(reports, rep)
+			reports = append(reports, CaptureReport{Path: cap.Path, Error: fmt.Sprintf("open: %v", err)})
 			continue
 		}
-
-		before := len(sys.Talkgroups)
-		Accumulate(sys, Observation{
-			Protocol:       proto.String(),
-			Confidence:     conf,
-			Result:         res,
-			FallbackFreqHz: cap.FrequencyHz,
-			At:             time.Now(),
+		rep := decodeAndAccumulate(sys, f, cap.Path, decodeParams{
+			Protocol:           cap.Protocol,
+			Format:             cap.Format,
+			SampleRateHz:       cap.SampleRateHz,
+			FrequencyHz:        cap.FrequencyHz,
+			AutoTune:           cap.AutoTune,
+			Conjugate:          cap.Conjugate,
+			IQCorrect:          cap.IQCorrect,
+			IdentifyMaxSamples: cap.IdentifyMaxSamples,
+			MinConfidence:      minConf,
+			Log:                log,
 		})
-		rep.Locked = res.Locked
-		if res.Lock != nil {
-			rep.ControlHz = res.Lock.FrequencyHz
-		}
-		rep.Talkgroups = len(sys.Talkgroups) - before
+		f.Close()
 		reports = append(reports, rep)
 	}
 

--- a/internal/hunt/iqsource.go
+++ b/internal/hunt/iqsource.go
@@ -1,0 +1,100 @@
+package hunt
+
+import (
+	"context"
+	"fmt"
+)
+
+// IQSource is the tunable IQ provider the live sweeper and hunter drive. It
+// abstracts over a live SDR (broker-backed, wired in the daemon) and a
+// file/synthetic source (tests), so the sweep/identify/accumulate logic is the
+// same offline and on-air.
+type IQSource interface {
+	// Tune retunes the source to centerHz. Subsequent Capture calls return IQ
+	// centered there.
+	Tune(centerHz uint32) error
+	// Capture returns the next n complex samples at the current center, or an
+	// error (including ctx cancellation). Implementations may return fewer than
+	// n only at end-of-stream, in which case they return what remains.
+	Capture(ctx context.Context, n int) ([]complex64, error)
+	// SampleRateHz is the source's IQ sample rate.
+	SampleRateHz() uint32
+}
+
+// FileIQSource is a deterministic IQSource over an in-memory IQ buffer, used by
+// tests. Tune records the requested center (so captured slices can be stamped
+// with an absolute frequency) but does not alter the samples — the buffer is
+// assumed to already be baseband IQ for whatever carrier the test models.
+// Capture serves the buffer cyclically so a sweep with many steps never starves.
+type FileIQSource struct {
+	iq        []complex64
+	rateHz    uint32
+	center    uint32
+	pos       int
+	tuneCalls []uint32
+	perTune   map[uint32][]complex64 // optional: distinct IQ per center
+	cycle     bool
+}
+
+// NewFileIQSource builds a FileIQSource over one buffer served cyclically at
+// every tuned center.
+func NewFileIQSource(iq []complex64, rateHz uint32) *FileIQSource {
+	return &FileIQSource{iq: iq, rateHz: rateHz, cycle: true}
+}
+
+// NewMappedIQSource builds a FileIQSource that serves a distinct buffer per
+// tuned center frequency (and an empty/zero stream for untuned centers), so a
+// test can place a "carrier" at specific frequencies and verify the sweep finds
+// exactly those. rateHz is the common sample rate.
+func NewMappedIQSource(perCenter map[uint32][]complex64, rateHz uint32) *FileIQSource {
+	return &FileIQSource{perTune: perCenter, rateHz: rateHz, cycle: true}
+}
+
+func (f *FileIQSource) Tune(centerHz uint32) error {
+	f.center = centerHz
+	f.pos = 0
+	f.tuneCalls = append(f.tuneCalls, centerHz)
+	return nil
+}
+
+func (f *FileIQSource) SampleRateHz() uint32 { return f.rateHz }
+
+// TuneCalls returns the centers Tune was called with, in order (test helper).
+func (f *FileIQSource) TuneCalls() []uint32 { return f.tuneCalls }
+
+func (f *FileIQSource) Capture(ctx context.Context, n int) ([]complex64, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	src := f.iq
+	if f.perTune != nil {
+		src = f.perTune[f.center] // nil ⇒ silence at this center
+	}
+	out := make([]complex64, n)
+	if len(src) == 0 {
+		return out, nil // zero IQ (noise-free silence)
+	}
+	for i := 0; i < n; i++ {
+		out[i] = src[f.pos%len(src)]
+		f.pos++
+	}
+	return out, nil
+}
+
+// captureFrameSamples is the number of IQ samples one sweep FFT consumes. It is
+// max(fftSize, a small floor) so the FFT is always fully populated.
+func captureFrameSamples(fftSize int) int {
+	if fftSize < 256 {
+		return 256
+	}
+	return fftSize
+}
+
+// ensurePow2 returns n when it is a positive power of two, else an error — the
+// FFT requires it.
+func ensurePow2(n int) error {
+	if n <= 0 || n&(n-1) != 0 {
+		return fmt.Errorf("hunt: FFT size %d is not a positive power of two", n)
+	}
+	return nil
+}

--- a/internal/hunt/livehunt.go
+++ b/internal/hunt/livehunt.go
@@ -1,0 +1,199 @@
+package hunt
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log/slog"
+	"sort"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/siglab"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// LiveHuntPhase labels the stage a live hunt is in, for progress reporting.
+type LiveHuntPhase string
+
+const (
+	PhaseSweeping    LiveHuntPhase = "sweeping"
+	PhaseIdentifying LiveHuntPhase = "identifying"
+	PhaseDone        LiveHuntPhase = "done"
+)
+
+// LiveHuntProgress is one progress notification emitted during a live hunt.
+type LiveHuntProgress struct {
+	Phase      LiveHuntPhase `json:"phase"`
+	CenterHz   uint32        `json:"center_hz,omitempty"`
+	CandidateN int           `json:"candidate_n,omitempty"`
+	Candidates int           `json:"candidates,omitempty"`
+	Detail     string        `json:"detail,omitempty"`
+}
+
+// LiveHuntOptions configure a live hunt.
+type LiveHuntOptions struct {
+	Source IQSource
+	// Bands to sweep. Ignored when Candidates is non-empty.
+	Bands []Band
+	// Candidates, when set, are explicit control-channel frequencies to probe
+	// directly (the sweep is skipped). Mirrors the offline -no-sweep path.
+	Candidates []uint32
+	// Protocol forces a decoder; trunking.ProtocolUnknown auto-identifies.
+	Protocol trunking.Protocol
+
+	FFTSize    int
+	SweepDwell time.Duration
+	GuardFrac  float64
+	PeakOpts   PeakOptions
+
+	// DwellSeconds is how much IQ to capture per candidate for identify+decode.
+	// 0 ⇒ 3 s.
+	DwellSeconds  float64
+	MinConfidence float64
+	AutoTune      bool
+
+	// System metadata for the resulting map.
+	Name, State, County, Location string
+
+	OnProgress func(LiveHuntProgress)
+	Log        *slog.Logger
+}
+
+// RunLiveHunt sweeps (or probes a candidate list) on a live IQSource, then
+// identifies, decodes, and maps each candidate into a DiscoveredSystem. It is
+// the on-air sibling of Discover: the sweep replaces operator-supplied
+// captures, but the per-candidate identify→decode→accumulate body is shared
+// (decodeAndAccumulate). Returns the discovered system, a per-candidate report,
+// and an error only for fatal setup/sweep failures (per-candidate failures are
+// recorded in the reports).
+func RunLiveHunt(ctx context.Context, opts LiveHuntOptions) (*DiscoveredSystem, []CaptureReport, error) {
+	log := opts.Log
+	if log == nil {
+		log = slog.New(slog.DiscardHandler)
+	}
+	if opts.Source == nil {
+		return nil, nil, fmt.Errorf("hunt: live hunt requires an IQSource")
+	}
+	rate := opts.Source.SampleRateHz()
+	if rate == 0 {
+		return nil, nil, fmt.Errorf("hunt: IQSource has zero sample rate")
+	}
+	dwell := opts.DwellSeconds
+	if dwell <= 0 {
+		dwell = 3
+	}
+	progress := func(p LiveHuntProgress) {
+		if opts.OnProgress != nil {
+			opts.OnProgress(p)
+		}
+	}
+
+	// Phase 1: candidates — explicit list, or a spectrum sweep.
+	var candidates []Candidate
+	if len(opts.Candidates) > 0 {
+		for _, f := range opts.Candidates {
+			candidates = append(candidates, Candidate{FreqHz: f})
+		}
+	} else {
+		sw, err := NewSweeper(SweepOptions{
+			Source:     opts.Source,
+			Bands:      opts.Bands,
+			FFTSize:    opts.FFTSize,
+			SweepDwell: opts.SweepDwell,
+			GuardFrac:  opts.GuardFrac,
+			PeakOpts:   opts.PeakOpts,
+			Log:        log,
+		})
+		if err != nil {
+			return nil, nil, err
+		}
+		progress(LiveHuntProgress{Phase: PhaseSweeping, Detail: "scanning bands"})
+		candidates, err = sw.Sweep(ctx, func(centerHz uint32, peaks []Peak) {
+			progress(LiveHuntProgress{Phase: PhaseSweeping, CenterHz: centerHz,
+				Detail: fmt.Sprintf("%d peak(s)", len(peaks))})
+		})
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
+	sys := &DiscoveredSystem{
+		Name:     opts.Name,
+		State:    opts.State,
+		County:   opts.County,
+		Location: opts.Location,
+	}
+	reports := make([]CaptureReport, 0, len(candidates))
+	nSamples := int(dwell * float64(rate))
+
+	for i, cand := range candidates {
+		if err := ctx.Err(); err != nil {
+			return sys, reports, err
+		}
+		progress(LiveHuntProgress{
+			Phase: PhaseIdentifying, CenterHz: cand.FreqHz,
+			CandidateN: i + 1, Candidates: len(candidates),
+			Detail: fmt.Sprintf("%.3f MHz", float64(cand.FreqHz)/1e6),
+		})
+
+		if err := opts.Source.Tune(cand.FreqHz); err != nil {
+			reports = append(reports, CaptureReport{
+				Path:  fmt.Sprintf("%.4f MHz", float64(cand.FreqHz)/1e6),
+				Error: fmt.Sprintf("tune: %v", err),
+			})
+			continue
+		}
+		iq, err := captureN(ctx, opts.Source, nSamples)
+		if err != nil {
+			return sys, reports, err
+		}
+
+		// The candidate carrier is at DC of the tuned capture; decode at
+		// baseband. Encode once (F32, lossless from complex64) and feed the
+		// shared identify→decode→accumulate body over a seekable reader.
+		buf := siglab.EncodeCapture(iq, siglab.FormatF32)
+		rep := decodeAndAccumulate(sys, bytes.NewReader(buf),
+			fmt.Sprintf("%.4f MHz", float64(cand.FreqHz)/1e6), decodeParams{
+				Protocol:      opts.Protocol,
+				Format:        siglab.FormatF32,
+				SampleRateHz:  float64(rate),
+				FrequencyHz:   cand.FreqHz,
+				AutoTune:      opts.AutoTune,
+				MinConfidence: opts.MinConfidence,
+				Log:           log,
+			})
+		reports = append(reports, rep)
+	}
+
+	sys.sortAll()
+	progress(LiveHuntProgress{Phase: PhaseDone,
+		Detail: fmt.Sprintf("%d site(s), %d talkgroup(s)", len(sys.Sites), len(sys.Talkgroups))})
+	return sys, reports, nil
+}
+
+// captureN gathers exactly n samples from src (Capture may return fewer per
+// call). It stops early at end-of-stream, returning what it has.
+func captureN(ctx context.Context, src IQSource, n int) ([]complex64, error) {
+	out := make([]complex64, 0, n)
+	for len(out) < n {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		chunk, err := src.Capture(ctx, n-len(out))
+		if err != nil {
+			return nil, err
+		}
+		if len(chunk) == 0 {
+			break // end of stream
+		}
+		out = append(out, chunk...)
+	}
+	return out, nil
+}
+
+// SortedCandidates returns candidates sorted by descending SNR (test helper).
+func SortedCandidates(c []Candidate) []Candidate {
+	out := append([]Candidate(nil), c...)
+	sort.Slice(out, func(i, j int) bool { return out[i].SNRDb > out[j].SNRDb })
+	return out
+}

--- a/internal/hunt/livehunt_test.go
+++ b/internal/hunt/livehunt_test.go
@@ -1,0 +1,100 @@
+package hunt
+
+import (
+	"context"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/siglab"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// TestRunLiveHunt_CandidateList drives the live hunt over a synthesized P25
+// control-channel buffer served by a FileIQSource, skipping the sweep via an
+// explicit candidate list. It proves the candidate→identify→decode→accumulate
+// path produces the same kind of mapped system the offline Discover does.
+func TestRunLiveHunt_CandidateList(t *testing.T) {
+	iq, meta, err := siglab.Synthesize(siglab.SynthOptions{
+		Protocol: trunking.ProtocolP25,
+		Format:   siglab.FormatF32,
+	})
+	if err != nil {
+		t.Fatalf("Synthesize: %v", err)
+	}
+	rate := uint32(meta.SampleRateHz)
+	src := NewFileIQSource(iq, rate)
+
+	const candHz = 851_000_000
+	sys, reports, err := RunLiveHunt(context.Background(), LiveHuntOptions{
+		Source:        src,
+		Candidates:    []uint32{candHz},
+		DwellSeconds:  float64(len(iq)) / float64(rate),
+		MinConfidence: 0.3,
+		Name:          "Live Test",
+	})
+	if err != nil {
+		t.Fatalf("RunLiveHunt: %v", err)
+	}
+	if len(reports) != 1 {
+		t.Fatalf("len(reports) = %d, want 1", len(reports))
+	}
+	r := reports[0]
+	if r.Error != "" {
+		t.Fatalf("candidate errored: %s", r.Error)
+	}
+	if r.Skipped {
+		t.Fatalf("candidate skipped: %s", r.SkipReason)
+	}
+	if r.Protocol != "p25" {
+		t.Errorf("protocol = %q, want p25", r.Protocol)
+	}
+	if !r.Locked {
+		t.Errorf("expected a lock on the synthesized P25 control channel")
+	}
+	// The candidate frequency is recorded as the control channel on a site.
+	if len(sys.Sites) != 1 {
+		t.Fatalf("len(Sites) = %d, want 1", len(sys.Sites))
+	}
+	foundCC := false
+	for _, ch := range sys.Sites[0].ControlChannels {
+		if ch.FrequencyHz == candHz {
+			foundCC = true
+		}
+	}
+	if !foundCC {
+		t.Errorf("control channel %d not recorded; site = %+v", candHz, sys.Sites[0])
+	}
+	if sys.DisplayName() != "Live Test" {
+		t.Errorf("name = %q, want Live Test", sys.DisplayName())
+	}
+}
+
+// TestRunLiveHunt_Progress confirms progress callbacks fire through the
+// identifying/done phases on the candidate-list path.
+func TestRunLiveHunt_Progress(t *testing.T) {
+	iq, meta, err := siglab.Synthesize(siglab.SynthOptions{
+		Protocol: trunking.ProtocolP25,
+		Format:   siglab.FormatF32,
+	})
+	if err != nil {
+		t.Fatalf("Synthesize: %v", err)
+	}
+	rate := uint32(meta.SampleRateHz)
+
+	phases := map[LiveHuntPhase]int{}
+	_, _, err = RunLiveHunt(context.Background(), LiveHuntOptions{
+		Source:        NewFileIQSource(iq, rate),
+		Candidates:    []uint32{851_000_000},
+		DwellSeconds:  float64(len(iq)) / float64(rate),
+		MinConfidence: 0.3,
+		OnProgress:    func(p LiveHuntProgress) { phases[p.Phase]++ },
+	})
+	if err != nil {
+		t.Fatalf("RunLiveHunt: %v", err)
+	}
+	if phases[PhaseIdentifying] == 0 {
+		t.Error("expected at least one identifying-phase progress event")
+	}
+	if phases[PhaseDone] == 0 {
+		t.Error("expected a done-phase progress event")
+	}
+}

--- a/internal/hunt/peaks.go
+++ b/internal/hunt/peaks.go
@@ -1,0 +1,137 @@
+package hunt
+
+import (
+	"math"
+	"sort"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/spectrum"
+)
+
+// Peak is a candidate carrier found in a spectrum frame: its absolute
+// frequency, its power, and how far it stands above the estimated noise floor.
+type Peak struct {
+	FreqHz    uint32
+	PowerDbFS float32
+	SNRDb     float32
+}
+
+// PeakOptions tune the carrier detector.
+type PeakOptions struct {
+	// ThresholdDb is the minimum power above the estimated noise floor for a
+	// local maximum to count as a carrier. 0 ⇒ a sensible default (10 dB).
+	ThresholdDb float32
+	// MinSpacingHz is the minimum separation between reported peaks; when two
+	// maxima fall closer than this the stronger one wins. 0 ⇒ 6.25 kHz (the
+	// tightest trunking channel step).
+	MinSpacingHz uint32
+	// GuardBins drops this many bins at each band edge (rolloff) from
+	// consideration. 0 ⇒ a default proportional to the FFT size.
+	GuardBins int
+}
+
+// noiseFloorPercentile is the percentile of bin powers used as the noise-floor
+// estimate. The low quartile is robust to strong carriers occupying the upper
+// tail, unlike a mean.
+const noiseFloorPercentile = 0.25
+
+// DetectPeaks finds candidate carriers in a spectrum frame. It estimates a
+// robust noise floor (low-quartile of the bin powers), keeps local maxima that
+// stand ThresholdDb above it, drops the DC bin and the band-edge guard bins,
+// and enforces a minimum carrier spacing (stronger peak wins). Bin indices are
+// mapped to absolute Hz using the frame's center and sample rate. Returned
+// peaks are sorted by descending SNR.
+func DetectPeaks(frame spectrum.Frame, opts PeakOptions) []Peak {
+	n := len(frame.Bins)
+	if n < 8 || frame.SampleRate == 0 {
+		return nil
+	}
+	threshold := opts.ThresholdDb
+	if threshold <= 0 {
+		threshold = 10
+	}
+	minSpacing := opts.MinSpacingHz
+	if minSpacing == 0 {
+		minSpacing = 6_250
+	}
+	guard := opts.GuardBins
+	if guard <= 0 {
+		guard = n / 64 // ~1.5% of the band at each edge
+		if guard < 1 {
+			guard = 1
+		}
+	}
+
+	floor := percentile(frame.Bins, noiseFloorPercentile)
+	binHz := float64(frame.SampleRate) / float64(n)
+	dcBin := n / 2 // FFT-shifted: DC sits in the middle (see spectrum.frame)
+
+	var peaks []Peak
+	for i := guard; i < n-guard; i++ {
+		if i == dcBin {
+			continue
+		}
+		v := frame.Bins[i]
+		if v-floor < threshold {
+			continue
+		}
+		// Strict local maximum against immediate neighbors.
+		if v <= frame.Bins[i-1] || v < frame.Bins[i+1] {
+			continue
+		}
+		peaks = append(peaks, Peak{
+			FreqHz:    binToHz(frame, i, binHz),
+			PowerDbFS: v,
+			SNRDb:     v - floor,
+		})
+	}
+
+	// Strongest-first, then suppress weaker peaks within MinSpacingHz.
+	sort.Slice(peaks, func(a, b int) bool { return peaks[a].SNRDb > peaks[b].SNRDb })
+	var kept []Peak
+	for _, p := range peaks {
+		ok := true
+		for _, k := range kept {
+			if absDiff(p.FreqHz, k.FreqHz) < minSpacing {
+				ok = false
+				break
+			}
+		}
+		if ok {
+			kept = append(kept, p)
+		}
+	}
+	return kept
+}
+
+// binToHz maps an FFT-shifted bin index to its absolute center frequency.
+// Bins[0] = CenterHz - SampleRate/2; step = SampleRate/N.
+func binToHz(frame spectrum.Frame, bin int, binHz float64) uint32 {
+	base := float64(frame.CenterHz) - float64(frame.SampleRate)/2
+	return uint32(math.Round(base + float64(bin)*binHz))
+}
+
+// percentile returns the p-quantile (0..1) of bins using a copy+sort. Used for
+// the robust noise-floor estimate.
+func percentile(bins []float32, p float64) float32 {
+	if len(bins) == 0 {
+		return 0
+	}
+	cp := make([]float32, len(bins))
+	copy(cp, bins)
+	sort.Slice(cp, func(i, j int) bool { return cp[i] < cp[j] })
+	idx := int(p * float64(len(cp)-1))
+	if idx < 0 {
+		idx = 0
+	}
+	if idx >= len(cp) {
+		idx = len(cp) - 1
+	}
+	return cp[idx]
+}
+
+func absDiff(a, b uint32) uint32 {
+	if a > b {
+		return a - b
+	}
+	return b - a
+}

--- a/internal/hunt/peaks_test.go
+++ b/internal/hunt/peaks_test.go
@@ -1,0 +1,110 @@
+package hunt
+
+import (
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/spectrum"
+)
+
+// frameWithTones builds a synthetic spectrum frame: a flat noise floor with
+// elevated bins at the given indices. n must be even (DC sits at n/2).
+func frameWithTones(n int, centerHz, rateHz uint32, floor float32, tones map[int]float32) spectrum.Frame {
+	bins := make([]float32, n)
+	for i := range bins {
+		bins[i] = floor
+	}
+	for idx, db := range tones {
+		bins[idx] = db
+	}
+	return spectrum.Frame{CenterHz: centerHz, SampleRate: rateHz, Bins: bins}
+}
+
+func TestDetectPeaks_FindsTonesAtCorrectHz(t *testing.T) {
+	const n = 1024
+	const center = 851_000_000
+	const rate = 2_048_000
+	// Place tones at bins 300 and 800 (both off-DC, away from edges).
+	frame := frameWithTones(n, center, rate, -80, map[int]float32{300: -20, 800: -30})
+
+	peaks := DetectPeaks(frame, PeakOptions{ThresholdDb: 10})
+	if len(peaks) != 2 {
+		t.Fatalf("len(peaks) = %d, want 2: %+v", len(peaks), peaks)
+	}
+	// binToHz: base = center - rate/2, step = rate/n.
+	step := float64(rate) / n
+	base := float64(center) - float64(rate)/2
+	want := map[int]uint32{
+		300: uint32(base + 300*step),
+		800: uint32(base + 800*step),
+	}
+	got := map[uint32]bool{}
+	for _, p := range peaks {
+		got[p.FreqHz] = true
+	}
+	for _, w := range want {
+		if !nearAny(got, w, uint32(step)) {
+			t.Errorf("missing peak near %d Hz; got %v", w, got)
+		}
+	}
+	// Strongest (bin 300, -20) should sort first.
+	if peaks[0].FreqHz != want[300] {
+		t.Errorf("peaks[0] = %d Hz, want strongest tone at %d Hz", peaks[0].FreqHz, want[300])
+	}
+}
+
+func TestDetectPeaks_RejectsDCAndThreshold(t *testing.T) {
+	const n = 512
+	// A tone exactly at DC (bin n/2) must be ignored, and a tone only 5 dB over
+	// the floor must fail the 10 dB threshold.
+	frame := frameWithTones(n, 100_000_000, 1_000_000, -80, map[int]float32{
+		n / 2: -10, // DC spike — rejected
+		100:   -75, // only +5 dB — below threshold
+	})
+	peaks := DetectPeaks(frame, PeakOptions{ThresholdDb: 10})
+	if len(peaks) != 0 {
+		t.Errorf("expected no peaks (DC + sub-threshold), got %+v", peaks)
+	}
+}
+
+func TestDetectPeaks_MinSpacingKeepsStronger(t *testing.T) {
+	const n = 1024
+	const rate = 1_024_000 // 1000 Hz/bin
+	// Two tones 2 bins apart (2 kHz). With MinSpacingHz=12.5 kHz only the
+	// stronger survives.
+	frame := frameWithTones(n, 450_000_000, rate, -90, map[int]float32{
+		400: -40,
+		402: -20, // stronger
+	})
+	peaks := DetectPeaks(frame, PeakOptions{ThresholdDb: 10, MinSpacingHz: 12_500})
+	if len(peaks) != 1 {
+		t.Fatalf("len(peaks) = %d, want 1 (min-spacing): %+v", len(peaks), peaks)
+	}
+	step := float64(rate) / n
+	base := float64(450_000_000) - float64(rate)/2
+	wantStronger := uint32(base + 402*step)
+	if !nearAny(map[uint32]bool{peaks[0].FreqHz: true}, wantStronger, uint32(step)) {
+		t.Errorf("kept peak = %d Hz, want the stronger tone near %d Hz", peaks[0].FreqHz, wantStronger)
+	}
+}
+
+func TestDetectPeaks_GuardBinsRejectEdges(t *testing.T) {
+	const n = 1024
+	frame := frameWithTones(n, 1_000_000, 1_000_000, -80, map[int]float32{
+		2:     -20, // near low edge
+		n - 3: -20, // near high edge
+		500:   -20, // valid, mid-band
+	})
+	peaks := DetectPeaks(frame, PeakOptions{ThresholdDb: 10, GuardBins: 16})
+	if len(peaks) != 1 {
+		t.Fatalf("len(peaks) = %d, want 1 (edges guarded): %+v", len(peaks), peaks)
+	}
+}
+
+func nearAny(set map[uint32]bool, target, tol uint32) bool {
+	for f := range set {
+		if absDiff(f, target) <= tol {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/hunt/sweeper.go
+++ b/internal/hunt/sweeper.go
@@ -1,0 +1,246 @@
+package hunt
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"math"
+	"math/cmplx"
+	"sort"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/fft"
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/spectrum"
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/window"
+)
+
+// Band is an inclusive frequency range to sweep, in Hz.
+type Band struct {
+	LowHz  uint32
+	HighHz uint32
+}
+
+// SweepOptions configure a Sweeper.
+type SweepOptions struct {
+	Source IQSource
+	Bands  []Band
+	// FFTSize is the bins per step (power of two). 0 ⇒ 4096.
+	FFTSize int
+	// SweepDwell is how long to accumulate per step before detecting peaks.
+	// Captures one FFT frame per ~10 ms of dwell, averaged. 0 ⇒ one frame.
+	SweepDwell time.Duration
+	// GuardFrac reserves this fraction of each step's bandwidth at the edges
+	// (where the SDR rolloff lives) when advancing the center. 0 ⇒ 0.1.
+	GuardFrac float64
+	PeakOpts  PeakOptions
+	Log       *slog.Logger
+}
+
+// Candidate is a carrier the sweep found, worth identifying.
+type Candidate struct {
+	FreqHz uint32  `json:"freq_hz"`
+	SNRDb  float32 `json:"snr_db"`
+}
+
+// Sweeper walks operator-given bands on an IQSource and returns the candidate
+// carriers it finds. It is the discovery front-end: its candidates feed the
+// identify→decode→accumulate pipeline (see LiveHunter).
+type Sweeper struct {
+	opts      SweepOptions
+	fftSize   int
+	guardFrac float64
+	log       *slog.Logger
+
+	// FFT scratch reused across steps (single-goroutine use).
+	plan   fft.Plan
+	win    []float64
+	winSum float64
+	bufIQ  []complex128
+	bufOut []complex128
+}
+
+// NewSweeper validates options and builds a Sweeper.
+func NewSweeper(opts SweepOptions) (*Sweeper, error) {
+	if opts.Source == nil {
+		return nil, fmt.Errorf("hunt: sweeper requires an IQSource")
+	}
+	if len(opts.Bands) == 0 {
+		return nil, fmt.Errorf("hunt: sweeper requires at least one band")
+	}
+	if opts.Source.SampleRateHz() == 0 {
+		return nil, fmt.Errorf("hunt: sweeper IQSource has zero sample rate")
+	}
+	fftSize := opts.FFTSize
+	if fftSize == 0 {
+		fftSize = 4096
+	}
+	if err := ensurePow2(fftSize); err != nil {
+		return nil, err
+	}
+	guardFrac := opts.GuardFrac
+	if guardFrac <= 0 || guardFrac >= 0.5 {
+		guardFrac = 0.1
+	}
+	log := opts.Log
+	if log == nil {
+		log = slog.New(slog.DiscardHandler)
+	}
+	win := window.Hann(fftSize)
+	var winSum float64
+	for _, w := range win {
+		winSum += w * w
+	}
+	return &Sweeper{
+		opts:      opts,
+		fftSize:   fftSize,
+		guardFrac: guardFrac,
+		log:       log,
+		plan:      fft.New(fftSize),
+		win:       win,
+		winSum:    winSum,
+		bufIQ:     make([]complex128, fftSize),
+		bufOut:    make([]complex128, fftSize),
+	}, nil
+}
+
+// OnStep, when set, is called once per tuned step with the step center and the
+// peaks found there — used by the live hunt to publish progress.
+type OnStep func(centerHz uint32, peaks []Peak)
+
+// Sweep walks every band and returns the de-duplicated candidate carriers,
+// sorted by descending SNR. ctx cancellation stops the sweep and returns
+// ctx.Err(). onStep may be nil.
+func (s *Sweeper) Sweep(ctx context.Context, onStep OnStep) ([]Candidate, error) {
+	rate := s.opts.Source.SampleRateHz()
+	// Advance the center by the usable bandwidth (minus the guard) so adjacent
+	// steps overlap slightly and a carrier near a step edge is still seen
+	// somewhere away from the rolloff.
+	step := uint32(float64(rate) * (1 - 2*s.guardFrac))
+	if step == 0 {
+		step = rate
+	}
+	framesPerStep := 1
+	if s.opts.SweepDwell > 0 {
+		// ~one frame per 10 ms of dwell, capped so a long dwell can't run away.
+		framesPerStep = int(s.opts.SweepDwell / (10 * time.Millisecond))
+		if framesPerStep < 1 {
+			framesPerStep = 1
+		}
+		if framesPerStep > 64 {
+			framesPerStep = 64
+		}
+	}
+
+	// Accumulate candidates keyed to a quantized frequency bucket so the same
+	// carrier seen in two overlapping steps collapses to one (strongest wins).
+	bucket := s.opts.PeakOpts.MinSpacingHz
+	if bucket == 0 {
+		bucket = 6_250
+	}
+	best := map[uint32]Candidate{}
+
+	for _, band := range s.opts.Bands {
+		if band.HighHz < band.LowHz {
+			return nil, fmt.Errorf("hunt: band %d:%d is inverted", band.LowHz, band.HighHz)
+		}
+		// Center the first step half a usable-bandwidth above the low edge so
+		// the band's low edge is inside the first step (not at the rolloff).
+		halfUsable := step / 2
+		for center := band.LowHz + halfUsable; ; center += step {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+			if err := s.opts.Source.Tune(center); err != nil {
+				return nil, fmt.Errorf("hunt: tune %d Hz: %w", center, err)
+			}
+			frame, err := s.captureFrame(ctx, center, rate, framesPerStep)
+			if err != nil {
+				return nil, err
+			}
+			peaks := DetectPeaks(frame, s.opts.PeakOpts)
+			// Keep only peaks that fall within the requested band.
+			inBand := peaks[:0]
+			for _, p := range peaks {
+				if p.FreqHz >= band.LowHz && p.FreqHz <= band.HighHz {
+					inBand = append(inBand, p)
+				}
+			}
+			if onStep != nil {
+				onStep(center, inBand)
+			}
+			for _, p := range inBand {
+				key := p.FreqHz / bucket
+				if cur, ok := best[key]; !ok || p.SNRDb > cur.SNRDb {
+					best[key] = Candidate{FreqHz: p.FreqHz, SNRDb: p.SNRDb}
+				}
+			}
+			// Stop once this step's coverage reached the band's high edge.
+			if center+halfUsable >= band.HighHz {
+				break
+			}
+		}
+	}
+
+	out := make([]Candidate, 0, len(best))
+	for _, c := range best {
+		out = append(out, c)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].SNRDb > out[j].SNRDb })
+	return out, nil
+}
+
+// captureFrame captures framesPerStep FFT frames at the current center and
+// returns their power-averaged spectrum (averaging lifts a weak carrier out of
+// the noise). The returned Frame uses the spectrum.Frame bin convention.
+func (s *Sweeper) captureFrame(ctx context.Context, centerHz, rate uint32, frames int) (spectrum.Frame, error) {
+	n := s.fftSize
+	acc := make([]float64, n) // accumulated linear power per (shifted) bin
+	got := 0
+	for f := 0; f < frames; f++ {
+		iq, err := s.opts.Source.Capture(ctx, captureFrameSamples(n))
+		if err != nil {
+			return spectrum.Frame{}, err
+		}
+		if len(iq) < n {
+			if got == 0 {
+				return spectrum.Frame{}, fmt.Errorf("hunt: short capture (%d < %d) at %d Hz", len(iq), n, centerHz)
+			}
+			break
+		}
+		s.accumulatePower(acc, iq[:n])
+		got++
+	}
+	bins := make([]float32, n)
+	norm := 1.0 / (float64(n) * s.winSum)
+	for i := 0; i < n; i++ {
+		power := acc[i] / float64(got) * norm
+		if power < 1e-30 {
+			power = 1e-30
+		}
+		bins[i] = float32(10 * math.Log10(power))
+	}
+	return spectrum.Frame{
+		Timestamp:  time.Now(),
+		CenterHz:   centerHz,
+		SampleRate: rate,
+		Bins:       bins,
+	}, nil
+}
+
+// accumulatePower windows + FFTs one chunk and adds its per-bin |X|² into acc,
+// FFT-shifted so DC lands in the middle (matching spectrum.Frame).
+func (s *Sweeper) accumulatePower(acc []float64, iq []complex64) {
+	n := s.fftSize
+	for i := 0; i < n; i++ {
+		v := iq[i]
+		w := s.win[i]
+		s.bufIQ[i] = complex(float64(real(v))*w, float64(imag(v))*w)
+	}
+	out := s.plan.Forward(s.bufOut, s.bufIQ)
+	half := n / 2
+	for i := 0; i < n; i++ {
+		dst := (i + half) % n
+		mag := cmplx.Abs(out[i])
+		acc[dst] += mag * mag
+	}
+}

--- a/internal/hunt/sweeper_test.go
+++ b/internal/hunt/sweeper_test.go
@@ -1,0 +1,102 @@
+package hunt
+
+import (
+	"context"
+	"math"
+	"math/cmplx"
+	"testing"
+)
+
+// toneIQ generates a unit-amplitude complex exponential at offsetHz relative to
+// DC, sampled at rateHz, n samples long.
+func toneIQ(n int, offsetHz, rateHz float64) []complex64 {
+	out := make([]complex64, n)
+	for i := 0; i < n; i++ {
+		phase := 2 * math.Pi * offsetHz * float64(i) / rateHz
+		out[i] = complex64(cmplx.Exp(complex(0, phase)))
+	}
+	return out
+}
+
+func TestSweeper_FindsCarrierAtExpectedFreq(t *testing.T) {
+	const (
+		rate     = 2_048_000
+		fftSize  = 1024
+		guard    = 0.1
+		offsetHz = 400_000.0 // carrier 400 kHz above the step center (off-DC)
+	)
+	// One-step band: with guardFrac 0.1, step = rate*0.8, halfUsable = step/2.
+	step := uint32(float64(rate) * (1 - 2*guard))
+	halfUsable := step / 2
+	bandLow := uint32(450_000_000)
+	center := bandLow + halfUsable
+	bandHigh := bandLow + step - 1 // exactly one step wide
+	wantHz := center + uint32(offsetHz)
+
+	src := NewFileIQSource(toneIQ(fftSize*4, offsetHz, rate), rate)
+	sw, err := NewSweeper(SweepOptions{
+		Source:    src,
+		Bands:     []Band{{LowHz: bandLow, HighHz: bandHigh}},
+		FFTSize:   fftSize,
+		GuardFrac: guard,
+		PeakOpts:  PeakOptions{ThresholdDb: 10},
+	})
+	if err != nil {
+		t.Fatalf("NewSweeper: %v", err)
+	}
+	cands, err := sw.Sweep(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+	if len(cands) == 0 {
+		t.Fatalf("no candidates found")
+	}
+	binHz := uint32(float64(rate) / fftSize)
+	found := false
+	for _, c := range cands {
+		if absDiff(c.FreqHz, wantHz) <= 2*binHz {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("carrier near %d Hz not found; candidates=%+v (tol %d Hz)", wantHz, cands, 2*binHz)
+	}
+	// The source was tuned to the single step center.
+	if len(src.TuneCalls()) == 0 || src.TuneCalls()[0] != center {
+		t.Errorf("first tune = %v, want center %d", src.TuneCalls(), center)
+	}
+}
+
+func TestSweeper_SilenceYieldsNoCandidates(t *testing.T) {
+	const rate = 2_048_000
+	src := NewFileIQSource(make([]complex64, 4096), rate) // all-zero IQ
+	sw, err := NewSweeper(SweepOptions{
+		Source:   src,
+		Bands:    []Band{{LowHz: 450_000_000, HighHz: 451_000_000}},
+		FFTSize:  1024,
+		PeakOpts: PeakOptions{ThresholdDb: 10},
+	})
+	if err != nil {
+		t.Fatalf("NewSweeper: %v", err)
+	}
+	cands, err := sw.Sweep(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+	if len(cands) != 0 {
+		t.Errorf("silence produced candidates: %+v", cands)
+	}
+}
+
+func TestNewSweeper_Validation(t *testing.T) {
+	src := NewFileIQSource(toneIQ(2048, 1000, 48000), 48000)
+	if _, err := NewSweeper(SweepOptions{Source: src}); err == nil {
+		t.Error("expected error for no bands")
+	}
+	if _, err := NewSweeper(SweepOptions{Bands: []Band{{LowHz: 1, HighHz: 2}}}); err == nil {
+		t.Error("expected error for nil source")
+	}
+	if _, err := NewSweeper(SweepOptions{Source: src, Bands: []Band{{1, 2}}, FFTSize: 1000}); err == nil {
+		t.Error("expected error for non-power-of-two FFT size")
+	}
+}


### PR DESCRIPTION
Phase 2 of the hunt follow-ups: discover unknown systems **on the air**, not just from operator-supplied captures.

> Stacked on #(Phase 1, `claude/hunt-topology-identify`) — this PR targets that branch as its base, so its diff is just the Phase 2 changes. Retarget to `main` once Phase 1 merges.

## Engine (`internal/hunt`, all file-source testable)
- `peaks.go` — FFT peak detector: robust percentile noise floor, local-maxima detection, DC/edge-guard rejection, threshold gating, min-carrier-spacing suppression (stronger peak wins).
- `iqsource.go` — `IQSource` abstraction (`Tune`/`Capture`/`SampleRateHz`) with a deterministic `FileIQSource` for tests.
- `sweeper.go` — steps an `IQSource` across operator bands at `SampleRate*(1-guard)` increments, computes a power-averaged spectrum per step (window+FFT mirroring the `spectrum` package's dBFS/FFT-shift convention), returns de-duplicated candidates.
- `livehunt.go` — `RunLiveHunt` ties sweep (or explicit candidate list) → per-candidate tune/capture → in-memory `IdentifyIQ` → deep decode → accumulate, with progress callbacks.
- `decode.go` — factors the identify→decode→accumulate body shared by offline `Discover` and the live hunter (both drive an `io.ReadSeeker`), keeping the two paths in lockstep.

## CLI
- `gophertrunk hunt -serial <sdr> -band low:high …` sweeps a live SDR; `-no-sweep -candidates f,f` probes a known list. The offline `-in` path is unchanged; the post-discovery export/RR/commit tail is now shared by both.
- `hunt_live.go` opens the SDR standalone (reusing the capture command's device open) and adapts it to `IQSource` with retune-and-flush.

## Tests
Peak detection (tones/DC/threshold/spacing/guard), sweeper (carrier found at expected Hz; silence → none; validation), and an end-to-end live hunt over a synthesized P25 buffer (candidate list → lock → mapped site). `go build ./...`, `go vet`, `gofmt`, package tests green.

Next: Phase 3 (daemon-integrated live hunt + spare-SDR-else-borrow), Phase 4 (REST cockpit), Phase 5 (TUI + web panels).

https://claude.ai/code/session_01He917mJB4Kg4ZkHjyHtJ66

---
_Generated by [Claude Code](https://claude.ai/code/session_01He917mJB4Kg4ZkHjyHtJ66)_