### PR TITLE
hunt: daemon-integrated live hunt manager + spare-SDR-else-borrow acquisition

### DIFF
--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -19,6 +19,7 @@ import (
 	"github.com/MattCheramie/GopherTrunk/internal/config"
 	gtdiag "github.com/MattCheramie/GopherTrunk/internal/diag"
 	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/hunt"
 	gtlog "github.com/MattCheramie/GopherTrunk/internal/log"
 	"github.com/MattCheramie/GopherTrunk/internal/metrics"
 	"github.com/MattCheramie/GopherTrunk/internal/scanner/ccdecoder"
@@ -275,6 +276,7 @@ type Daemon struct {
 	retention    *storage.Retention
 	ccCache      *trunking.Cache
 	cchuntSup    *cchunt.Supervisor
+	huntMgr      *hunt.Manager
 	ccDecoder    *ccdecoder.Decoder
 	// ccDecoderOpts is captured at construction so the spawn closure
 	// can rebuild the decoder after an IQ-stream death — Decoder.Run
@@ -1741,6 +1743,21 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 			conv:       d.convScan,
 			engine:     d.engine,
 			talkgroups: d.talkgroups,
+		}
+		// Live system-discovery ("hunt") manager: operator-triggered blind
+		// spectrum sweep that shares the radio via spare-SDR-else-borrow
+		// acquisition. Constructed whenever an IQ broker exists so a live hunt
+		// is possible; the REST/TUI/web cockpit drives it.
+		if d.pool != nil && len(d.iqBrokers) > 0 {
+			if mgr, err := hunt.NewManager(hunt.ManagerOptions{
+				Acquire: d.buildHuntAcquirer(),
+				Bus:     d.bus,
+				Log:     log,
+			}); err != nil {
+				log.Warn("daemon: hunt manager not started", "err", err)
+			} else {
+				d.huntMgr = mgr
+			}
 		}
 		if d.player != nil || d.recorder != nil {
 			opts.Audio = audioCockpit{player: d.player, recorder: d.recorder}

--- a/cmd/gophertrunk/hunt_acquire.go
+++ b/cmd/gophertrunk/hunt_acquire.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/MattCheramie/GopherTrunk/internal/hunt"
+	"github.com/MattCheramie/GopherTrunk/internal/sdr"
+)
+
+// chooseHuntSDR decides which SDR a live hunt should sweep on and whether it
+// must borrow the control SDR (pausing the cchunt supervisor) to do so. It is
+// pure so the policy is unit-testable without a real pool.
+//
+// Policy ("prefer a spare/dedicated SDR; else borrow the control SDR"):
+//   - An explicit requestedSerial is honored: it borrows only when it is the
+//     control SDR, otherwise it dedicates that SDR.
+//   - With no request, a spare Voice SDR is dedicated when the pool has two or
+//     more (so at least one is genuinely spare beyond the voice fleet); the
+//     last one is used, mirroring the conventional scanner's spare heuristic.
+//   - Otherwise it borrows the control SDR.
+//
+// hasBroker reports whether an iqtap broker exists for a serial (a live hunt
+// needs one). It returns an error when the chosen SDR has no broker, or when no
+// usable SDR exists at all.
+func chooseHuntSDR(requestedSerial, controlSerial string, voiceSerials []string, hasBroker func(string) bool) (serial string, borrow bool, err error) {
+	if requestedSerial != "" {
+		if !hasBroker(requestedSerial) {
+			return "", false, fmt.Errorf("hunt: SDR %q has no IQ broker (not in the pool?)", requestedSerial)
+		}
+		return requestedSerial, requestedSerial == controlSerial, nil
+	}
+	// Auto: prefer a spare Voice SDR when one plausibly exists.
+	if len(voiceSerials) >= 2 {
+		spare := voiceSerials[len(voiceSerials)-1]
+		if hasBroker(spare) {
+			return spare, false, nil
+		}
+	}
+	if controlSerial != "" && hasBroker(controlSerial) {
+		return controlSerial, true, nil
+	}
+	return "", false, fmt.Errorf("hunt: no SDR with an IQ broker available for a live hunt")
+}
+
+// buildHuntAcquirer returns the hunt.Acquirer the daemon's hunt Manager uses to
+// obtain an IQ source per run. It auto-selects a spare SDR when available and
+// otherwise borrows the control SDR — pausing the cchunt supervisor for the
+// duration and resuming it on release. Borrowing blinds the control-channel
+// hunter while the sweep runs; the release (deferred by the Manager) always
+// restores it.
+func (d *Daemon) buildHuntAcquirer() hunt.Acquirer {
+	return func(ctx context.Context) (hunt.IQSource, func(), error) {
+		var voiceSerials []string
+		if d.pool != nil {
+			for _, e := range d.pool.AllByRole(sdr.RoleVoice) {
+				voiceSerials = append(voiceSerials, e.Info.Serial)
+			}
+		}
+		serial, borrow, err := chooseHuntSDR("", d.controlSerial, voiceSerials, func(s string) bool {
+			return d.iqBrokers[s] != nil
+		})
+		if err != nil {
+			return nil, nil, err
+		}
+		broker := d.iqBrokers[serial]
+		src, sub := newBrokerIQSource(broker)
+
+		if borrow && d.cchuntSup != nil {
+			d.cchuntSup.PauseAll()
+		}
+		release := func() {
+			sub.Close()
+			if borrow && d.cchuntSup != nil {
+				d.cchuntSup.ResumeAll()
+			}
+		}
+		return src, release, nil
+	}
+}

--- a/cmd/gophertrunk/hunt_acquire_test.go
+++ b/cmd/gophertrunk/hunt_acquire_test.go
@@ -1,0 +1,71 @@
+package main
+
+import "testing"
+
+func TestChooseHuntSDR(t *testing.T) {
+	brokers := map[string]bool{"ctrl": true, "voice1": true, "voice2": true}
+	has := func(s string) bool { return brokers[s] }
+
+	cases := []struct {
+		name       string
+		requested  string
+		control    string
+		voice      []string
+		wantSerial string
+		wantBorrow bool
+		wantErr    bool
+	}{
+		{
+			name:      "explicit non-control dedicates",
+			requested: "voice1", control: "ctrl", voice: []string{"voice1", "voice2"},
+			wantSerial: "voice1", wantBorrow: false,
+		},
+		{
+			name:      "explicit control borrows",
+			requested: "ctrl", control: "ctrl", voice: []string{"voice1", "voice2"},
+			wantSerial: "ctrl", wantBorrow: true,
+		},
+		{
+			name:      "explicit unknown serial errors",
+			requested: "nope", control: "ctrl", voice: []string{"voice1"},
+			wantErr: true,
+		},
+		{
+			name:      "auto prefers spare voice when >=2",
+			requested: "", control: "ctrl", voice: []string{"voice1", "voice2"},
+			wantSerial: "voice2", wantBorrow: false,
+		},
+		{
+			name:      "auto borrows control with <2 voice",
+			requested: "", control: "ctrl", voice: []string{"voice1"},
+			wantSerial: "ctrl", wantBorrow: true,
+		},
+		{
+			name:      "auto borrows control with no voice",
+			requested: "", control: "ctrl", voice: nil,
+			wantSerial: "ctrl", wantBorrow: true,
+		},
+		{
+			name:      "no sdr at all errors",
+			requested: "", control: "", voice: nil,
+			wantErr: true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			serial, borrow, err := chooseHuntSDR(c.requested, c.control, c.voice, has)
+			if c.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got serial=%q borrow=%v", serial, borrow)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if serial != c.wantSerial || borrow != c.wantBorrow {
+				t.Errorf("got (%q, %v), want (%q, %v)", serial, borrow, c.wantSerial, c.wantBorrow)
+			}
+		})
+	}
+}

--- a/cmd/gophertrunk/hunt_iqsource.go
+++ b/cmd/gophertrunk/hunt_iqsource.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"context"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/sdr"
+	"github.com/MattCheramie/GopherTrunk/internal/sdr/iqtap"
+)
+
+// streamIQSource adapts a continuous <-chan []complex64 IQ stream (from a live
+// SDR device or an iqtap broker) to hunt.IQSource. A rolling buffer backs
+// Capture; Tune retunes the underlying source and flushes the in-flight
+// transient so the next Capture sees only settled IQ at the new center. It is
+// the shared core behind both the standalone device path and the daemon broker
+// path.
+type streamIQSource struct {
+	ch      <-chan []complex64
+	tune    func(uint32) error
+	rate    func() uint32
+	pending []complex64
+	settle  time.Duration
+}
+
+func (s *streamIQSource) SampleRateHz() uint32 { return s.rate() }
+
+func (s *streamIQSource) Tune(centerHz uint32) error {
+	if err := s.tune(centerHz); err != nil {
+		return err
+	}
+	// Discard buffered + in-flight samples captured before/at the retune.
+	s.pending = nil
+	deadline := time.NewTimer(s.settle)
+	defer deadline.Stop()
+	for {
+		select {
+		case <-s.ch:
+			// drain
+		case <-deadline.C:
+			return nil
+		}
+	}
+}
+
+func (s *streamIQSource) Capture(ctx context.Context, n int) ([]complex64, error) {
+	for len(s.pending) < n {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case chunk, ok := <-s.ch:
+			if !ok {
+				out := s.pending
+				s.pending = nil
+				return out, nil // stream ended
+			}
+			s.pending = append(s.pending, chunk...)
+		}
+	}
+	out := s.pending[:n:n]
+	s.pending = s.pending[n:]
+	return out, nil
+}
+
+// newDeviceIQSource opens a continuous IQ stream on a raw SDR device (standalone
+// CLI live hunt). The caller's ctx governs the stream lifetime.
+func newDeviceIQSource(ctx context.Context, dev sdr.Device, rate uint32) (*streamIQSource, error) {
+	ch, err := dev.StreamIQ(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &streamIQSource{
+		ch:     ch,
+		tune:   dev.SetCenterFreq,
+		rate:   func() uint32 { return rate },
+		settle: 50 * time.Millisecond,
+	}, nil
+}
+
+// newBrokerIQSource adapts a daemon iqtap.Broker (sharing a live SDR with the
+// rest of the pipeline) to hunt.IQSource via a secondary subscription. Tune
+// routes through the broker so its cached center stays consistent with the
+// spectrum/rigctld views. Close the returned subscriber when the run ends.
+func newBrokerIQSource(broker *iqtap.Broker) (*streamIQSource, *iqtap.Subscriber) {
+	sub := broker.Subscribe()
+	return &streamIQSource{
+		ch:     sub.C,
+		tune:   broker.SetCenterFreq,
+		rate:   broker.SampleRateHz,
+		settle: 50 * time.Millisecond,
+	}, sub
+}

--- a/cmd/gophertrunk/hunt_live.go
+++ b/cmd/gophertrunk/hunt_live.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/MattCheramie/GopherTrunk/internal/diag"
 	"github.com/MattCheramie/GopherTrunk/internal/hunt"
-	"github.com/MattCheramie/GopherTrunk/internal/sdr"
 	"github.com/MattCheramie/GopherTrunk/internal/trunking"
 )
 
@@ -157,63 +156,4 @@ func parseBandsMHz(rep *diag.Reporter, specs []string) []hunt.Band {
 		out = append(out, hunt.Band{LowHz: uint32(loMHz*1e6 + 0.5), HighHz: uint32(hiMHz*1e6 + 0.5)})
 	}
 	return out
-}
-
-// deviceIQSource adapts a live sdr.Device to hunt.IQSource. A background
-// goroutine drains the device's IQ stream into a channel; Capture pulls from a
-// rolling buffer and Tune retunes the device, flushing the transient.
-type deviceIQSource struct {
-	dev     sdr.Device
-	rate    uint32
-	ch      <-chan []complex64
-	pending []complex64
-	settle  time.Duration
-}
-
-func newDeviceIQSource(ctx context.Context, dev sdr.Device, rate uint32) (*deviceIQSource, error) {
-	ch, err := dev.StreamIQ(ctx)
-	if err != nil {
-		return nil, err
-	}
-	return &deviceIQSource{dev: dev, rate: rate, ch: ch, settle: 50 * time.Millisecond}, nil
-}
-
-func (s *deviceIQSource) SampleRateHz() uint32 { return s.rate }
-
-func (s *deviceIQSource) Tune(centerHz uint32) error {
-	if err := s.dev.SetCenterFreq(centerHz); err != nil {
-		return err
-	}
-	// Discard buffered + in-flight samples captured before/at the retune so the
-	// next Capture sees only settled IQ at the new center.
-	s.pending = nil
-	deadline := time.NewTimer(s.settle)
-	defer deadline.Stop()
-	for {
-		select {
-		case <-s.ch:
-			// drain
-		case <-deadline.C:
-			return nil
-		}
-	}
-}
-
-func (s *deviceIQSource) Capture(ctx context.Context, n int) ([]complex64, error) {
-	for len(s.pending) < n {
-		select {
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		case chunk, ok := <-s.ch:
-			if !ok {
-				out := s.pending
-				s.pending = nil
-				return out, nil // stream ended
-			}
-			s.pending = append(s.pending, chunk...)
-		}
-	}
-	out := s.pending[:n:n]
-	s.pending = s.pending[n:]
-	return out, nil
 }

--- a/internal/events/bus.go
+++ b/internal/events/bus.go
@@ -42,6 +42,16 @@ const (
 	//     so operators can see "retry in 5 s".
 	KindHuntProgress Kind = "cchunt.progress"
 	KindHuntFailed   Kind = "cchunt.failed"
+	// Live system-discovery ("hunt") events, published by the daemon's hunt
+	// Manager (internal/hunt). Distinct from the cchunt.* control-channel
+	// hunter above: these track a blind discovery run (spectrum sweep →
+	// identify → map). Payloads are hunt package types carried as `any`.
+	//   KindHuntLiveProgress fires as the sweep/identify phases advance.
+	//   KindHuntLiveCandidate fires once per candidate carrier mapped.
+	//   KindHuntLiveDone fires when a run finishes (or is stopped).
+	KindHuntLiveProgress  Kind = "hunt.progress"
+	KindHuntLiveCandidate Kind = "hunt.candidate"
+	KindHuntLiveDone      Kind = "hunt.done"
 	// KindAffiliation fires when a radio unit affiliates with a
 	// talkgroup. P25 control-channel publishes one per Group
 	// Affiliation Response TSBK (opcode 0x28); the payload identifies

--- a/internal/hunt/manager.go
+++ b/internal/hunt/manager.go
@@ -1,0 +1,227 @@
+package hunt
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+)
+
+// RunState is the lifecycle of a live hunt run, surfaced to the cockpit/REST.
+type RunState string
+
+const (
+	StateRunIdle    RunState = "idle"    // no run has started yet
+	StateRunActive  RunState = "running" // a sweep/identify run is in progress
+	StateRunDone    RunState = "done"    // last run finished and produced a map
+	StateRunStopped RunState = "stopped" // last run was cancelled by the operator
+	StateRunFailed  RunState = "failed"  // last run errored (e.g. SDR acquisition)
+)
+
+// Acquirer obtains an IQSource for one run plus a release callback (resume the
+// control-channel hunter, close the SDR subscription, …). The daemon supplies
+// this so the hunt package stays free of SDR/pool dependencies; release is
+// invoked exactly once when the run ends (success, error, or stop).
+type Acquirer func(ctx context.Context) (src IQSource, release func(), err error)
+
+// ManagerOptions configure a Manager.
+type ManagerOptions struct {
+	// Acquire obtains the run's IQSource. Required.
+	Acquire Acquirer
+	Bus     *events.Bus
+	Log     *slog.Logger
+}
+
+// Manager owns the daemon's single live-hunt run: it acquires an SDR, runs the
+// sweep→identify→map pipeline in the background, publishes hunt.* bus events,
+// and holds the latest discovered system for export/commit. Safe for
+// concurrent use by the REST/TUI cockpit.
+type Manager struct {
+	acquire Acquirer
+	bus     *events.Bus
+	log     *slog.Logger
+
+	mu         sync.Mutex
+	runID      int
+	state      RunState
+	progress   LiveHuntProgress
+	sys        *DiscoveredSystem
+	reports    []CaptureReport
+	err        string
+	startedAt  time.Time
+	finishedAt time.Time
+	cancel     context.CancelFunc
+}
+
+// NewManager builds a Manager. Acquire is required.
+func NewManager(opts ManagerOptions) (*Manager, error) {
+	if opts.Acquire == nil {
+		return nil, errors.New("hunt: Manager requires an Acquirer")
+	}
+	log := opts.Log
+	if log == nil {
+		log = slog.New(slog.DiscardHandler)
+	}
+	return &Manager{acquire: opts.Acquire, bus: opts.Bus, log: log, state: StateRunIdle}, nil
+}
+
+// RunStatus is the read snapshot the cockpit/REST renders.
+type RunStatus struct {
+	RunID      int              `json:"run_id"`
+	State      RunState         `json:"state"`
+	Running    bool             `json:"running"`
+	Progress   LiveHuntProgress `json:"progress"`
+	Sites      int              `json:"sites"`
+	Talkgroups int              `json:"talkgroups"`
+	SystemName string           `json:"system_name,omitempty"`
+	Error      string           `json:"error,omitempty"`
+	StartedAt  time.Time        `json:"started_at,omitempty"`
+	FinishedAt time.Time        `json:"finished_at,omitempty"`
+}
+
+// Start launches a live hunt with opts. It returns the new run id, or an error
+// if a run is already active. The run executes in the background; observe it via
+// Status and the hunt.* bus events.
+func (m *Manager) Start(opts LiveHuntOptions) (int, error) {
+	m.mu.Lock()
+	if m.state == StateRunActive {
+		m.mu.Unlock()
+		return 0, errors.New("hunt: a run is already in progress")
+	}
+	m.runID++
+	id := m.runID
+	ctx, cancel := context.WithCancel(context.Background())
+	m.cancel = cancel
+	m.state = StateRunActive
+	m.progress = LiveHuntProgress{Phase: PhaseSweeping}
+	m.sys = nil
+	m.reports = nil
+	m.err = ""
+	m.startedAt = time.Now()
+	m.finishedAt = time.Time{}
+	m.mu.Unlock()
+
+	// Wire progress events onto the bus + the live snapshot.
+	opts.Log = m.log
+	opts.OnProgress = func(p LiveHuntProgress) {
+		m.mu.Lock()
+		m.progress = p
+		m.mu.Unlock()
+		m.publish(events.KindHuntLiveProgress, p)
+	}
+
+	go m.run(ctx, id, opts)
+	return id, nil
+}
+
+func (m *Manager) run(ctx context.Context, id int, opts LiveHuntOptions) {
+	src, release, err := m.acquire(ctx)
+	if err != nil {
+		m.finish(id, nil, nil, fmt.Errorf("acquire SDR: %w", err))
+		return
+	}
+	defer release()
+	opts.Source = src
+
+	sys, reports, err := RunLiveHunt(ctx, opts)
+	m.finish(id, sys, reports, err)
+}
+
+// finish records the terminal state of a run and publishes hunt.done.
+func (m *Manager) finish(id int, sys *DiscoveredSystem, reports []CaptureReport, err error) {
+	m.mu.Lock()
+	if id != m.runID {
+		m.mu.Unlock()
+		return // a newer run superseded this one
+	}
+	m.finishedAt = time.Now()
+	m.cancel = nil
+	switch {
+	case err != nil && errors.Is(err, context.Canceled):
+		m.state = StateRunStopped
+	case err != nil:
+		m.state = StateRunFailed
+		m.err = err.Error()
+	default:
+		m.state = StateRunDone
+	}
+	if sys != nil {
+		m.sys = sys
+		m.reports = reports
+	}
+	st := m.statusLocked()
+	m.mu.Unlock()
+	m.publish(events.KindHuntLiveDone, st)
+}
+
+// Stop cancels the active run. Returns false if no run is active.
+func (m *Manager) Stop() bool {
+	m.mu.Lock()
+	cancel := m.cancel
+	active := m.state == StateRunActive
+	m.mu.Unlock()
+	if !active || cancel == nil {
+		return false
+	}
+	cancel()
+	return true
+}
+
+// Status returns the current run snapshot.
+func (m *Manager) Status() RunStatus {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.statusLocked()
+}
+
+func (m *Manager) statusLocked() RunStatus {
+	st := RunStatus{
+		RunID:      m.runID,
+		State:      m.state,
+		Running:    m.state == StateRunActive,
+		Progress:   m.progress,
+		Error:      m.err,
+		StartedAt:  m.startedAt,
+		FinishedAt: m.finishedAt,
+	}
+	if m.sys != nil {
+		st.Sites = len(m.sys.Sites)
+		st.Talkgroups = len(m.sys.Talkgroups)
+		st.SystemName = m.sys.DisplayName()
+	}
+	return st
+}
+
+// Current returns the latest discovered system and its per-candidate reports,
+// or (nil, nil, false) when no run has produced a map yet. The returned system
+// is the live pointer; callers must not mutate it.
+func (m *Manager) Current() (*DiscoveredSystem, []CaptureReport, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.sys == nil {
+		return nil, nil, false
+	}
+	return m.sys, m.reports, true
+}
+
+// Export writes the latest discovered system to w in the given format. Returns
+// an error when no system has been discovered yet.
+func (m *Manager) Export(w io.Writer, f Format, hints []DuplicateHint) error {
+	sys, _, ok := m.Current()
+	if !ok {
+		return errors.New("hunt: no discovered system to export yet")
+	}
+	return Write(w, sys, f, hints)
+}
+
+func (m *Manager) publish(kind events.Kind, payload any) {
+	if m.bus == nil {
+		return
+	}
+	m.bus.Publish(events.Event{Kind: kind, Timestamp: time.Now(), Payload: payload})
+}

--- a/internal/hunt/manager_test.go
+++ b/internal/hunt/manager_test.go
@@ -1,0 +1,164 @@
+package hunt
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/siglab"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// p25Source builds a FileIQSource over a synthesized P25 control channel plus
+// the run dwell that captures the whole buffer once.
+func p25Source(t *testing.T) (*FileIQSource, float64) {
+	t.Helper()
+	iq, meta, err := siglab.Synthesize(siglab.SynthOptions{
+		Protocol: trunking.ProtocolP25,
+		Format:   siglab.FormatF32,
+	})
+	if err != nil {
+		t.Fatalf("Synthesize: %v", err)
+	}
+	rate := uint32(meta.SampleRateHz)
+	return NewFileIQSource(iq, rate), float64(len(iq)) / float64(rate)
+}
+
+func waitUntil(t *testing.T, d time.Duration, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(d)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal("condition not met within deadline")
+}
+
+func TestManager_StartRunsAndMapsSystem(t *testing.T) {
+	bus := events.NewBus(256)
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	src, dwell := p25Source(t)
+	mgr, err := NewManager(ManagerOptions{
+		Acquire: func(context.Context) (IQSource, func(), error) { return src, func() {}, nil },
+		Bus:     bus,
+	})
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	id, err := mgr.Start(LiveHuntOptions{
+		Candidates:    []uint32{851_000_000},
+		DwellSeconds:  dwell,
+		MinConfidence: 0.3,
+		Name:          "Daemon Hunt",
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if id != 1 {
+		t.Errorf("run id = %d, want 1", id)
+	}
+
+	// Starting again while active must be refused.
+	if _, err := mgr.Start(LiveHuntOptions{Candidates: []uint32{1}}); err == nil {
+		t.Error("expected error starting a second run while active")
+	}
+
+	waitUntil(t, 15*time.Second, func() bool { return !mgr.Status().Running })
+
+	st := mgr.Status()
+	if st.State != StateRunDone {
+		t.Fatalf("state = %q, want done", st.State)
+	}
+	if st.Sites < 1 {
+		t.Errorf("sites = %d, want >= 1", st.Sites)
+	}
+	sys, _, ok := mgr.Current()
+	if !ok || sys == nil {
+		t.Fatal("Current() returned no system")
+	}
+
+	// Bus carried progress + done events.
+	var sawProgress, sawDone bool
+	for {
+		select {
+		case ev := <-sub.C:
+			switch ev.Kind {
+			case events.KindHuntLiveProgress:
+				sawProgress = true
+			case events.KindHuntLiveDone:
+				sawDone = true
+			}
+		default:
+			if !sawProgress {
+				t.Error("no hunt.progress event observed")
+			}
+			if !sawDone {
+				t.Error("no hunt.done event observed")
+			}
+			return
+		}
+	}
+}
+
+func TestManager_AcquireErrorFailsRun(t *testing.T) {
+	mgr, err := NewManager(ManagerOptions{
+		Acquire: func(context.Context) (IQSource, func(), error) {
+			return nil, nil, errors.New("no spare SDR")
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	if _, err := mgr.Start(LiveHuntOptions{Candidates: []uint32{1}}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	waitUntil(t, 5*time.Second, func() bool { return !mgr.Status().Running })
+	st := mgr.Status()
+	if st.State != StateRunFailed {
+		t.Errorf("state = %q, want failed", st.State)
+	}
+	if st.Error == "" {
+		t.Error("expected an error message on a failed run")
+	}
+}
+
+func TestManager_StopIdleReturnsFalse(t *testing.T) {
+	mgr, _ := NewManager(ManagerOptions{
+		Acquire: func(context.Context) (IQSource, func(), error) { return nil, nil, errors.New("x") },
+	})
+	if mgr.Stop() {
+		t.Error("Stop() on an idle manager should return false")
+	}
+}
+
+func TestNewManager_RequiresAcquirer(t *testing.T) {
+	if _, err := NewManager(ManagerOptions{}); err == nil {
+		t.Error("expected error when Acquire is nil")
+	}
+}
+
+// release must run on completion so a borrowed SDR is always returned.
+func TestManager_ReleaseRunsOnCompletion(t *testing.T) {
+	src, dwell := p25Source(t)
+	released := make(chan struct{})
+	mgr, _ := NewManager(ManagerOptions{
+		Acquire: func(context.Context) (IQSource, func(), error) {
+			return src, func() { close(released) }, nil
+		},
+	})
+	if _, err := mgr.Start(LiveHuntOptions{Candidates: []uint32{851_000_000}, DwellSeconds: dwell, MinConfidence: 0.3}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	select {
+	case <-released:
+	case <-time.After(15 * time.Second):
+		t.Fatal("release was not called after the run finished")
+	}
+}

--- a/internal/scanner/cchunt/supervisor.go
+++ b/internal/scanner/cchunt/supervisor.go
@@ -547,6 +547,51 @@ func (s *Supervisor) isHeld(name string) bool {
 
 // --- operator mutation surface ---
 
+// PauseAll holds every configured system and bails any in-flight hunt, so the
+// supervisor stops retuning the control SDR. It is used by the live hunt's
+// "borrow the control SDR" path (when no spare SDR is available) to quiesce
+// cchunt before sweeping, then ResumeAll restores normal scanning. Idempotent.
+func (s *Supervisor) PauseAll() {
+	s.mu.Lock()
+	var toCancel []chan struct{}
+	for _, rt := range s.states {
+		if rt == nil {
+			continue
+		}
+		rt.heldByOp = true
+		rt.state = StateHeld
+		if rt.retuneCh != nil {
+			toCancel = append(toCancel, rt.retuneCh)
+			rt.retuneCh = nil
+		}
+	}
+	s.mu.Unlock()
+	// Cancel in-flight hunts outside the lock so they bail promptly; the next
+	// Run round then skips every (held) system and stops touching the tuner.
+	for _, ch := range toCancel {
+		select {
+		case <-ch:
+		default:
+			close(ch)
+		}
+	}
+}
+
+// ResumeAll undoes PauseAll, returning every system to the round-robin with a
+// fresh backoff. Idempotent.
+func (s *Supervisor) ResumeAll() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, rt := range s.states {
+		if rt == nil {
+			continue
+		}
+		rt.heldByOp = false
+		rt.state = StateIdle
+		rt.backoffWindow = s.initBO
+	}
+}
+
 // Hold pins the supervisor on the named system's current state — no
 // further retunes happen until Resume. Returns false if the system
 // isn't configured.

--- a/internal/scanner/cchunt/supervisor_test.go
+++ b/internal/scanner/cchunt/supervisor_test.go
@@ -178,6 +178,43 @@ func TestSupervisorHoldAndResume(t *testing.T) {
 	}
 }
 
+func TestSupervisorPauseAllResumeAll(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sup, err := New(Options{
+		Bus:   bus,
+		Tuner: &fakeTuner{},
+		Systems: []trunking.System{
+			{Name: "A", Protocol: trunking.ProtocolP25, ControlChannels: []uint32{1}},
+			{Name: "B", Protocol: trunking.ProtocolP25, ControlChannels: []uint32{2}},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sup.PauseAll()
+	for _, st := range sup.Snapshot() {
+		if st.State != StateHeld {
+			t.Errorf("system %s state after PauseAll = %q, want held", st.Name, st.State)
+		}
+	}
+	// Idempotent.
+	sup.PauseAll()
+	for _, st := range sup.Snapshot() {
+		if st.State != StateHeld {
+			t.Errorf("system %s not held after second PauseAll", st.Name)
+		}
+	}
+
+	sup.ResumeAll()
+	for _, st := range sup.Snapshot() {
+		if st.State != StateIdle {
+			t.Errorf("system %s state after ResumeAll = %q, want idle", st.Name, st.State)
+		}
+	}
+}
+
 func TestSupervisorForceRetuneClearsBackoff(t *testing.T) {
 	bus := events.NewBus(8)
 	defer bus.Close()


### PR DESCRIPTION
Phase 3 of the hunt follow-ups: wire the live spectrum sweep (Phase 2) into the daemon so it runs on the shared radio, coordinated with the control-channel hunter.

## What's here
- **`internal/hunt/manager.go`** — `Manager` owns the daemon's single live-hunt run: acquires an SDR via an injected `Acquirer`, runs the sweep→identify→map pipeline in the background, publishes `hunt.*` bus events, and holds the latest discovered system for export. `Start`/`Stop`/`Status`/`Current`/`Export`; run-state machine (idle/running/done/stopped/failed) with a monotonic run id. The `Acquirer` indirection keeps the hunt package free of SDR/pool deps.
- **`internal/events/bus.go`** — new `hunt.progress` / `hunt.candidate` / `hunt.done` kinds (distinct from the `cchunt.*` control-channel hunter events).
- **`internal/scanner/cchunt`** — `PauseAll`/`ResumeAll`: hold every system and bail any in-flight hunt so the supervisor stops retuning the control SDR while a live hunt borrows it; idempotent, restores on resume.
- **`cmd/gophertrunk/hunt_iqsource.go`** — shared `streamIQSource` backing both the standalone device path (Phase 2) and a new broker-backed source; the Phase 2 `deviceIQSource` is refactored onto it (no duplication).
- **`cmd/gophertrunk/hunt_acquire.go`** — pure `chooseHuntSDR` policy (prefer a spare Voice SDR; else borrow the control SDR) + the daemon `Acquirer` that subscribes to the chosen broker and, when borrowing, pauses/resumes `cchunt` around the run.
- **`daemon.go`** — construct `d.huntMgr` whenever an IQ broker exists.

The **operator trigger** (REST/TUI/web cockpit) lands in Phase 4 — this PR builds the engine-side machinery and is self-contained/tested.

## Tests
Manager (run→map, already-running guard, acquire-error→failed, release always runs), cchunt `PauseAll`/`ResumeAll` (idempotent, restores), and a table-driven `chooseHuntSDR` policy test. `go build ./...`, `go vet`, `gofmt`, package tests green.

Stacked conceptually on the merged Phase 1/2; branches off `main`.

https://claude.ai/code/session_01He917mJB4Kg4ZkHjyHtJ66

---
_Generated by [Claude Code](https://claude.ai/code/session_01He917mJB4Kg4ZkHjyHtJ66)_