### PR TITLE
hunt: TUI + web console panels for the live hunt

### DIFF
--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -1757,6 +1757,7 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 				log.Warn("daemon: hunt manager not started", "err", err)
 			} else {
 				d.huntMgr = mgr
+				opts.Hunt = huntCockpit{mgr: mgr, cfgPath: d.cfgPath}
 			}
 		}
 		if d.player != nil || d.recorder != nil {

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -19,6 +19,7 @@ import (
 	"github.com/MattCheramie/GopherTrunk/internal/config"
 	gtdiag "github.com/MattCheramie/GopherTrunk/internal/diag"
 	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/hunt"
 	gtlog "github.com/MattCheramie/GopherTrunk/internal/log"
 	"github.com/MattCheramie/GopherTrunk/internal/metrics"
 	"github.com/MattCheramie/GopherTrunk/internal/scanner/ccdecoder"
@@ -275,6 +276,7 @@ type Daemon struct {
 	retention    *storage.Retention
 	ccCache      *trunking.Cache
 	cchuntSup    *cchunt.Supervisor
+	huntMgr      *hunt.Manager
 	ccDecoder    *ccdecoder.Decoder
 	// ccDecoderOpts is captured at construction so the spawn closure
 	// can rebuild the decoder after an IQ-stream death — Decoder.Run
@@ -1741,6 +1743,21 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 			conv:       d.convScan,
 			engine:     d.engine,
 			talkgroups: d.talkgroups,
+		}
+		// Live system-discovery ("hunt") manager: operator-triggered blind
+		// spectrum sweep that shares the radio via spare-SDR-else-borrow
+		// acquisition. Constructed whenever an IQ broker exists so a live hunt
+		// is possible; the REST/TUI/web cockpit drives it.
+		if d.pool != nil && len(d.iqBrokers) > 0 {
+			if mgr, err := hunt.NewManager(hunt.ManagerOptions{
+				Acquire: d.buildHuntAcquirer(),
+				Bus:     d.bus,
+				Log:     log,
+			}); err != nil {
+				log.Warn("daemon: hunt manager not started", "err", err)
+			} else {
+				d.huntMgr = mgr
+			}
 		}
 		if d.player != nil || d.recorder != nil {
 			opts.Audio = audioCockpit{player: d.player, recorder: d.recorder}

--- a/cmd/gophertrunk/hunt_acquire.go
+++ b/cmd/gophertrunk/hunt_acquire.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/MattCheramie/GopherTrunk/internal/hunt"
+	"github.com/MattCheramie/GopherTrunk/internal/sdr"
+)
+
+// chooseHuntSDR decides which SDR a live hunt should sweep on and whether it
+// must borrow the control SDR (pausing the cchunt supervisor) to do so. It is
+// pure so the policy is unit-testable without a real pool.
+//
+// Policy ("prefer a spare/dedicated SDR; else borrow the control SDR"):
+//   - An explicit requestedSerial is honored: it borrows only when it is the
+//     control SDR, otherwise it dedicates that SDR.
+//   - With no request, a spare Voice SDR is dedicated when the pool has two or
+//     more (so at least one is genuinely spare beyond the voice fleet); the
+//     last one is used, mirroring the conventional scanner's spare heuristic.
+//   - Otherwise it borrows the control SDR.
+//
+// hasBroker reports whether an iqtap broker exists for a serial (a live hunt
+// needs one). It returns an error when the chosen SDR has no broker, or when no
+// usable SDR exists at all.
+func chooseHuntSDR(requestedSerial, controlSerial string, voiceSerials []string, hasBroker func(string) bool) (serial string, borrow bool, err error) {
+	if requestedSerial != "" {
+		if !hasBroker(requestedSerial) {
+			return "", false, fmt.Errorf("hunt: SDR %q has no IQ broker (not in the pool?)", requestedSerial)
+		}
+		return requestedSerial, requestedSerial == controlSerial, nil
+	}
+	// Auto: prefer a spare Voice SDR when one plausibly exists.
+	if len(voiceSerials) >= 2 {
+		spare := voiceSerials[len(voiceSerials)-1]
+		if hasBroker(spare) {
+			return spare, false, nil
+		}
+	}
+	if controlSerial != "" && hasBroker(controlSerial) {
+		return controlSerial, true, nil
+	}
+	return "", false, fmt.Errorf("hunt: no SDR with an IQ broker available for a live hunt")
+}
+
+// buildHuntAcquirer returns the hunt.Acquirer the daemon's hunt Manager uses to
+// obtain an IQ source per run. It auto-selects a spare SDR when available and
+// otherwise borrows the control SDR — pausing the cchunt supervisor for the
+// duration and resuming it on release. Borrowing blinds the control-channel
+// hunter while the sweep runs; the release (deferred by the Manager) always
+// restores it.
+func (d *Daemon) buildHuntAcquirer() hunt.Acquirer {
+	return func(ctx context.Context) (hunt.IQSource, func(), error) {
+		var voiceSerials []string
+		if d.pool != nil {
+			for _, e := range d.pool.AllByRole(sdr.RoleVoice) {
+				voiceSerials = append(voiceSerials, e.Info.Serial)
+			}
+		}
+		serial, borrow, err := chooseHuntSDR("", d.controlSerial, voiceSerials, func(s string) bool {
+			return d.iqBrokers[s] != nil
+		})
+		if err != nil {
+			return nil, nil, err
+		}
+		broker := d.iqBrokers[serial]
+		src, sub := newBrokerIQSource(broker)
+
+		if borrow && d.cchuntSup != nil {
+			d.cchuntSup.PauseAll()
+		}
+		release := func() {
+			sub.Close()
+			if borrow && d.cchuntSup != nil {
+				d.cchuntSup.ResumeAll()
+			}
+		}
+		return src, release, nil
+	}
+}

--- a/cmd/gophertrunk/hunt_acquire_test.go
+++ b/cmd/gophertrunk/hunt_acquire_test.go
@@ -1,0 +1,71 @@
+package main
+
+import "testing"
+
+func TestChooseHuntSDR(t *testing.T) {
+	brokers := map[string]bool{"ctrl": true, "voice1": true, "voice2": true}
+	has := func(s string) bool { return brokers[s] }
+
+	cases := []struct {
+		name       string
+		requested  string
+		control    string
+		voice      []string
+		wantSerial string
+		wantBorrow bool
+		wantErr    bool
+	}{
+		{
+			name:      "explicit non-control dedicates",
+			requested: "voice1", control: "ctrl", voice: []string{"voice1", "voice2"},
+			wantSerial: "voice1", wantBorrow: false,
+		},
+		{
+			name:      "explicit control borrows",
+			requested: "ctrl", control: "ctrl", voice: []string{"voice1", "voice2"},
+			wantSerial: "ctrl", wantBorrow: true,
+		},
+		{
+			name:      "explicit unknown serial errors",
+			requested: "nope", control: "ctrl", voice: []string{"voice1"},
+			wantErr: true,
+		},
+		{
+			name:      "auto prefers spare voice when >=2",
+			requested: "", control: "ctrl", voice: []string{"voice1", "voice2"},
+			wantSerial: "voice2", wantBorrow: false,
+		},
+		{
+			name:      "auto borrows control with <2 voice",
+			requested: "", control: "ctrl", voice: []string{"voice1"},
+			wantSerial: "ctrl", wantBorrow: true,
+		},
+		{
+			name:      "auto borrows control with no voice",
+			requested: "", control: "ctrl", voice: nil,
+			wantSerial: "ctrl", wantBorrow: true,
+		},
+		{
+			name:      "no sdr at all errors",
+			requested: "", control: "", voice: nil,
+			wantErr: true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			serial, borrow, err := chooseHuntSDR(c.requested, c.control, c.voice, has)
+			if c.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got serial=%q borrow=%v", serial, borrow)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if serial != c.wantSerial || borrow != c.wantBorrow {
+				t.Errorf("got (%q, %v), want (%q, %v)", serial, borrow, c.wantSerial, c.wantBorrow)
+			}
+		})
+	}
+}

--- a/cmd/gophertrunk/hunt_cockpit.go
+++ b/cmd/gophertrunk/hunt_cockpit.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/MattCheramie/GopherTrunk/internal/api"
+	"github.com/MattCheramie/GopherTrunk/internal/hunt"
+	"github.com/MattCheramie/GopherTrunk/internal/siglab"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// huntCockpit adapts the daemon's hunt.Manager to the api.HuntCockpit surface
+// (GET /api/v1/hunt + start/stop/export/commit). It mirrors scannerCockpit.
+type huntCockpit struct {
+	mgr     *hunt.Manager
+	cfgPath string
+}
+
+// Status builds the REST snapshot from the manager's run state + latest map.
+func (c huntCockpit) Status() api.HuntStatus {
+	st := c.mgr.Status()
+	out := api.HuntStatus{
+		RunID:      st.RunID,
+		State:      string(st.State),
+		Running:    st.Running,
+		Phase:      string(st.Progress.Phase),
+		Detail:     st.Progress.Detail,
+		Sites:      st.Sites,
+		Talkgroups: st.Talkgroups,
+		SystemName: st.SystemName,
+		Error:      st.Error,
+	}
+	if sys, reports, ok := c.mgr.Current(); ok {
+		out.System = sys
+		out.Reports = reports
+	}
+	return out
+}
+
+// Start translates the REST request into hunt.LiveHuntOptions and launches a run.
+func (c huntCockpit) Start(req api.HuntStartRequest) (int, error) {
+	bands, err := parseBandSpecs(req.Bands)
+	if err != nil {
+		return 0, err
+	}
+	var candidates []uint32
+	for _, mhz := range req.Candidates {
+		candidates = append(candidates, uint32(mhz*1e6+0.5))
+	}
+	if len(bands) == 0 && len(candidates) == 0 {
+		return 0, fmt.Errorf("hunt: provide bands to sweep or candidates to probe")
+	}
+	if req.NoSweep {
+		bands = nil
+	}
+
+	var proto trunking.Protocol
+	if req.Protocol != "" {
+		proto, err = siglab.ParseProtocolCLI(req.Protocol)
+		if err != nil {
+			return 0, err
+		}
+	}
+
+	opts := hunt.LiveHuntOptions{
+		Bands:         bands,
+		Candidates:    candidates,
+		Protocol:      proto,
+		FFTSize:       req.FFTSize,
+		DwellSeconds:  req.DwellSeconds,
+		MinConfidence: req.MinConfidence,
+		Name:          req.Name,
+		State:         req.State,
+		County:        req.County,
+		Location:      req.Location,
+		PeakOpts: hunt.PeakOptions{
+			ThresholdDb:  float32(req.PeakThresholdDb),
+			MinSpacingHz: req.MinSpacingHz,
+		},
+	}
+	if req.SweepDwellMs > 0 {
+		opts.SweepDwell = msToDuration(req.SweepDwellMs, 0)
+	}
+	return c.mgr.Start(opts)
+}
+
+func (c huntCockpit) Stop() bool { return c.mgr.Stop() }
+
+// Export serializes the latest discovered system in the requested format.
+func (c huntCockpit) Export(format string) ([]byte, string, error) {
+	hf, err := hunt.ParseFormat(format)
+	if err != nil {
+		return nil, "", err
+	}
+	sys, _, ok := c.mgr.Current()
+	if !ok {
+		return nil, "", fmt.Errorf("hunt: no discovered system to export yet")
+	}
+	var buf bytes.Buffer
+	if err := hunt.Write(&buf, sys, hf, nil); err != nil {
+		return nil, "", err
+	}
+	base := slugName(sys.DisplayName())
+	name := base + "." + hf.FileExtension()
+	if hf == hunt.FormatRR {
+		name = base + "-radioreference." + hf.FileExtension()
+	}
+	return buf.Bytes(), name, nil
+}
+
+// Commit merges the latest discovered system into config.yaml via the shared
+// importer writer.
+func (c huntCockpit) Commit(force, dryRun bool) ([]string, error) {
+	sys, _, ok := c.mgr.Current()
+	if !ok {
+		return nil, fmt.Errorf("hunt: no discovered system to commit yet")
+	}
+	if c.cfgPath == "" {
+		return nil, fmt.Errorf("hunt: daemon started without -config; nothing to merge into")
+	}
+	res, err := mergeIntoConfig([]parsedSystem{discoveredToParsed(sys)}, mergeOptions{
+		ConfigPath: c.cfgPath,
+		Force:      force,
+		DryRun:     dryRun,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.Changes, nil
+}
+
+// parseBandSpecs parses "low:high" MHz band strings into hunt.Band (Hz).
+func parseBandSpecs(specs []string) ([]hunt.Band, error) {
+	var out []hunt.Band
+	for _, sp := range specs {
+		lo, hi, ok := strings.Cut(sp, ":")
+		if !ok {
+			return nil, fmt.Errorf("hunt: band %q: want low:high in MHz", sp)
+		}
+		loMHz, e1 := strconv.ParseFloat(strings.TrimSpace(lo), 64)
+		hiMHz, e2 := strconv.ParseFloat(strings.TrimSpace(hi), 64)
+		if e1 != nil || e2 != nil || hiMHz <= loMHz {
+			return nil, fmt.Errorf("hunt: band %q: invalid range", sp)
+		}
+		out = append(out, hunt.Band{LowHz: uint32(loMHz*1e6 + 0.5), HighHz: uint32(hiMHz*1e6 + 0.5)})
+	}
+	return out, nil
+}

--- a/cmd/gophertrunk/hunt_iqsource.go
+++ b/cmd/gophertrunk/hunt_iqsource.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"context"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/sdr"
+	"github.com/MattCheramie/GopherTrunk/internal/sdr/iqtap"
+)
+
+// streamIQSource adapts a continuous <-chan []complex64 IQ stream (from a live
+// SDR device or an iqtap broker) to hunt.IQSource. A rolling buffer backs
+// Capture; Tune retunes the underlying source and flushes the in-flight
+// transient so the next Capture sees only settled IQ at the new center. It is
+// the shared core behind both the standalone device path and the daemon broker
+// path.
+type streamIQSource struct {
+	ch      <-chan []complex64
+	tune    func(uint32) error
+	rate    func() uint32
+	pending []complex64
+	settle  time.Duration
+}
+
+func (s *streamIQSource) SampleRateHz() uint32 { return s.rate() }
+
+func (s *streamIQSource) Tune(centerHz uint32) error {
+	if err := s.tune(centerHz); err != nil {
+		return err
+	}
+	// Discard buffered + in-flight samples captured before/at the retune.
+	s.pending = nil
+	deadline := time.NewTimer(s.settle)
+	defer deadline.Stop()
+	for {
+		select {
+		case <-s.ch:
+			// drain
+		case <-deadline.C:
+			return nil
+		}
+	}
+}
+
+func (s *streamIQSource) Capture(ctx context.Context, n int) ([]complex64, error) {
+	for len(s.pending) < n {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case chunk, ok := <-s.ch:
+			if !ok {
+				out := s.pending
+				s.pending = nil
+				return out, nil // stream ended
+			}
+			s.pending = append(s.pending, chunk...)
+		}
+	}
+	out := s.pending[:n:n]
+	s.pending = s.pending[n:]
+	return out, nil
+}
+
+// newDeviceIQSource opens a continuous IQ stream on a raw SDR device (standalone
+// CLI live hunt). The caller's ctx governs the stream lifetime.
+func newDeviceIQSource(ctx context.Context, dev sdr.Device, rate uint32) (*streamIQSource, error) {
+	ch, err := dev.StreamIQ(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &streamIQSource{
+		ch:     ch,
+		tune:   dev.SetCenterFreq,
+		rate:   func() uint32 { return rate },
+		settle: 50 * time.Millisecond,
+	}, nil
+}
+
+// newBrokerIQSource adapts a daemon iqtap.Broker (sharing a live SDR with the
+// rest of the pipeline) to hunt.IQSource via a secondary subscription. Tune
+// routes through the broker so its cached center stays consistent with the
+// spectrum/rigctld views. Close the returned subscriber when the run ends.
+func newBrokerIQSource(broker *iqtap.Broker) (*streamIQSource, *iqtap.Subscriber) {
+	sub := broker.Subscribe()
+	return &streamIQSource{
+		ch:     sub.C,
+		tune:   broker.SetCenterFreq,
+		rate:   broker.SampleRateHz,
+		settle: 50 * time.Millisecond,
+	}, sub
+}

--- a/cmd/gophertrunk/hunt_live.go
+++ b/cmd/gophertrunk/hunt_live.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/MattCheramie/GopherTrunk/internal/diag"
 	"github.com/MattCheramie/GopherTrunk/internal/hunt"
-	"github.com/MattCheramie/GopherTrunk/internal/sdr"
 	"github.com/MattCheramie/GopherTrunk/internal/trunking"
 )
 
@@ -157,63 +156,4 @@ func parseBandsMHz(rep *diag.Reporter, specs []string) []hunt.Band {
 		out = append(out, hunt.Band{LowHz: uint32(loMHz*1e6 + 0.5), HighHz: uint32(hiMHz*1e6 + 0.5)})
 	}
 	return out
-}
-
-// deviceIQSource adapts a live sdr.Device to hunt.IQSource. A background
-// goroutine drains the device's IQ stream into a channel; Capture pulls from a
-// rolling buffer and Tune retunes the device, flushing the transient.
-type deviceIQSource struct {
-	dev     sdr.Device
-	rate    uint32
-	ch      <-chan []complex64
-	pending []complex64
-	settle  time.Duration
-}
-
-func newDeviceIQSource(ctx context.Context, dev sdr.Device, rate uint32) (*deviceIQSource, error) {
-	ch, err := dev.StreamIQ(ctx)
-	if err != nil {
-		return nil, err
-	}
-	return &deviceIQSource{dev: dev, rate: rate, ch: ch, settle: 50 * time.Millisecond}, nil
-}
-
-func (s *deviceIQSource) SampleRateHz() uint32 { return s.rate }
-
-func (s *deviceIQSource) Tune(centerHz uint32) error {
-	if err := s.dev.SetCenterFreq(centerHz); err != nil {
-		return err
-	}
-	// Discard buffered + in-flight samples captured before/at the retune so the
-	// next Capture sees only settled IQ at the new center.
-	s.pending = nil
-	deadline := time.NewTimer(s.settle)
-	defer deadline.Stop()
-	for {
-		select {
-		case <-s.ch:
-			// drain
-		case <-deadline.C:
-			return nil
-		}
-	}
-}
-
-func (s *deviceIQSource) Capture(ctx context.Context, n int) ([]complex64, error) {
-	for len(s.pending) < n {
-		select {
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		case chunk, ok := <-s.ch:
-			if !ok {
-				out := s.pending
-				s.pending = nil
-				return out, nil // stream ended
-			}
-			s.pending = append(s.pending, chunk...)
-		}
-	}
-	out := s.pending[:n:n]
-	s.pending = s.pending[n:]
-	return out, nil
 }

--- a/docs/hunt.md
+++ b/docs/hunt.md
@@ -148,8 +148,9 @@ to force it off even when a key is configured.
   | `POST /api/v1/hunt/commit` | Merge the discovery into `config.yaml` (`{force, dry_run}`) |
 
   Progress streams over the event bus (`hunt.progress` / `hunt.candidate` /
-  `hunt.done`) via `GET /api/v1/events`. Dedicated TUI and web-console panels
-  are the remaining phase.
+  `hunt.done`) via `GET /api/v1/events`. The **web console** has a *Hunt* tab
+  (start a run, watch progress, download/commit the result) and the **TUI** has
+  a *Hunt* panel that monitors the run and can stop it.
 - **Topology depth.** For **P25** the hunt now recovers full topology —
   WACN/SYSID, the camped RFSS/Site, advertised neighbor (adjacent) sites, and
   the over-the-air band plan (IDEN_UP) — all surfaced in the exports. For other

--- a/docs/hunt.md
+++ b/docs/hunt.md
@@ -135,10 +135,21 @@ to force it off even when a key is configured.
 
 ## Limitations & roadmap
 
-- **Live cockpit.** The standalone CLI live sweep (`-serial`) opens the SDR
-  directly. A daemon-integrated live hunt — sharing the running radio via
-  spare-SDR-else-borrow acquisition, driven from a REST API and the TUI/web
-  cockpit — is the next phase.
+- **Live cockpit.** Besides the standalone CLI live sweep (`-serial`), the
+  daemon exposes a live hunt over REST that shares the running radio via
+  spare-SDR-else-borrow acquisition:
+
+  | Method & path | Purpose |
+  |---|---|
+  | `GET /api/v1/hunt` | Run status + the discovered system map |
+  | `POST /api/v1/hunt/start` | Start a run (`{bands, candidates, no_sweep, protocol, name, …}`) |
+  | `POST /api/v1/hunt/stop` | Cancel the active run |
+  | `GET /api/v1/hunt/export?format=bundle\|trunk-recorder\|rr` | Download the discovery |
+  | `POST /api/v1/hunt/commit` | Merge the discovery into `config.yaml` (`{force, dry_run}`) |
+
+  Progress streams over the event bus (`hunt.progress` / `hunt.candidate` /
+  `hunt.done`) via `GET /api/v1/events`. Dedicated TUI and web-console panels
+  are the remaining phase.
 - **Topology depth.** For **P25** the hunt now recovers full topology —
   WACN/SYSID, the camped RFSS/Site, advertised neighbor (adjacent) sites, and
   the over-the-air band plan (IDEN_UP) — all surfaced in the exports. For other

--- a/internal/api/handlers_hunt.go
+++ b/internal/api/handlers_hunt.go
@@ -1,0 +1,146 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// handleHuntStatus returns the live system-discovery snapshot. Always 200 —
+// when the cockpit is nil (no SDR / hunt not wired) an idle status is returned
+// so the UI renders "no run" rather than a 503.
+func (s *Server) handleHuntStatus(w http.ResponseWriter, _ *http.Request) {
+	if s.hunt == nil {
+		writeJSON(w, http.StatusOK, HuntStatus{State: "idle"})
+		return
+	}
+	writeJSON(w, http.StatusOK, s.hunt.Status())
+}
+
+// handleHuntStart launches a live hunt run.
+func (s *Server) handleHuntStart(w http.ResponseWriter, r *http.Request) {
+	if s.hunt == nil {
+		s.writeError(w, http.StatusServiceUnavailable, "hunt not wired (no SDR available)")
+		return
+	}
+	var req HuntStartRequest
+	if r.Body != nil && r.ContentLength != 0 {
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil && err != io.EOF {
+			s.writeError(w, http.StatusBadRequest, "invalid json body")
+			return
+		}
+	}
+	runID, err := s.hunt.Start(req)
+	if err != nil {
+		// "already in progress" is a conflict; everything else is a bad request.
+		status := http.StatusBadRequest
+		if isHuntConflict(err) {
+			status = http.StatusConflict
+		}
+		s.writeError(w, status, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "run_id": runID})
+}
+
+// handleHuntStop cancels the active run.
+func (s *Server) handleHuntStop(w http.ResponseWriter, _ *http.Request) {
+	if s.hunt == nil {
+		s.writeError(w, http.StatusServiceUnavailable, "hunt not wired")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "stopped": s.hunt.Stop()})
+}
+
+// handleHuntExport streams the discovered system in the requested format.
+func (s *Server) handleHuntExport(w http.ResponseWriter, r *http.Request) {
+	if s.hunt == nil {
+		s.writeError(w, http.StatusServiceUnavailable, "hunt not wired")
+		return
+	}
+	format := r.URL.Query().Get("format")
+	if format == "" {
+		format = "bundle"
+	}
+	data, filename, err := s.hunt.Export(format)
+	if err != nil {
+		// No discovered system yet → 409; a bad format → 400.
+		status := http.StatusConflict
+		if isHuntBadFormat(err) {
+			status = http.StatusBadRequest
+		}
+		s.writeError(w, status, err.Error())
+		return
+	}
+	w.Header().Set("Content-Type", contentTypeForExport(format))
+	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%q", filename))
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(data)
+}
+
+// huntCommitRequest is the optional POST /api/v1/hunt/commit body.
+type huntCommitRequest struct {
+	Force  bool `json:"force,omitempty"`
+	DryRun bool `json:"dry_run,omitempty"`
+}
+
+// handleHuntCommit merges the discovered system into config.yaml.
+func (s *Server) handleHuntCommit(w http.ResponseWriter, r *http.Request) {
+	if s.hunt == nil {
+		s.writeError(w, http.StatusServiceUnavailable, "hunt not wired")
+		return
+	}
+	var req huntCommitRequest
+	if r.Body != nil && r.ContentLength != 0 {
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil && err != io.EOF {
+			s.writeError(w, http.StatusBadRequest, "invalid json body")
+			return
+		}
+	}
+	changes, err := s.hunt.Commit(req.Force, req.DryRun)
+	if err != nil {
+		s.writeError(w, http.StatusConflict, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "dry_run": req.DryRun, "changes": changes})
+}
+
+func contentTypeForExport(format string) string {
+	switch format {
+	case "trunk-recorder", "trunkrecorder", "tr":
+		return "application/json"
+	case "rr", "radioreference":
+		return "text/markdown; charset=utf-8"
+	default:
+		return "text/csv; charset=utf-8"
+	}
+}
+
+// isHuntConflict / isHuntBadFormat classify cockpit errors for HTTP status
+// mapping without coupling the handler to the hunt package's error values.
+func isHuntConflict(err error) bool {
+	return err != nil && containsAny(err.Error(), "already in progress", "in progress")
+}
+
+func isHuntBadFormat(err error) bool {
+	return err != nil && containsAny(err.Error(), "unknown export format", "unknown format")
+}
+
+func containsAny(s string, subs ...string) bool {
+	for _, sub := range subs {
+		if len(sub) > 0 && indexOfSub(s, sub) >= 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func indexOfSub(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/api/handlers_hunt_test.go
+++ b/internal/api/handlers_hunt_test.go
@@ -1,0 +1,204 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+)
+
+type fakeHuntCockpit struct {
+	status     HuntStatus
+	startID    int
+	startErr   error
+	stopped    bool
+	exportData []byte
+	exportName string
+	exportErr  error
+	commitChg  []string
+	commitErr  error
+
+	lastStart  HuntStartRequest
+	lastFormat string
+}
+
+func (f *fakeHuntCockpit) Status() HuntStatus { return f.status }
+func (f *fakeHuntCockpit) Start(req HuntStartRequest) (int, error) {
+	f.lastStart = req
+	return f.startID, f.startErr
+}
+func (f *fakeHuntCockpit) Stop() bool { return f.stopped }
+func (f *fakeHuntCockpit) Export(format string) ([]byte, string, error) {
+	f.lastFormat = format
+	return f.exportData, f.exportName, f.exportErr
+}
+func (f *fakeHuntCockpit) Commit(force, dryRun bool) ([]string, error) {
+	return f.commitChg, f.commitErr
+}
+
+func TestHuntStatus_NoCockpitReturnsIdle(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	base, teardown := mkServer(t, ServerOptions{Bus: bus})
+	defer teardown()
+	resp, err := http.Get(base + "/api/v1/hunt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("status=%d", resp.StatusCode)
+	}
+	var st HuntStatus
+	if err := json.NewDecoder(resp.Body).Decode(&st); err != nil {
+		t.Fatal(err)
+	}
+	if st.State != "idle" {
+		t.Errorf("state=%q, want idle", st.State)
+	}
+}
+
+func TestHuntStatus_ReportsRun(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	cock := &fakeHuntCockpit{status: HuntStatus{RunID: 3, State: "running", Running: true, Sites: 2, Talkgroups: 7}}
+	base, teardown := mkServer(t, ServerOptions{Bus: bus, Hunt: cock})
+	defer teardown()
+	resp, err := http.Get(base + "/api/v1/hunt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	var st HuntStatus
+	if err := json.NewDecoder(resp.Body).Decode(&st); err != nil {
+		t.Fatal(err)
+	}
+	if st.RunID != 3 || !st.Running || st.Sites != 2 || st.Talkgroups != 7 {
+		t.Errorf("decoded = %+v", st)
+	}
+}
+
+func TestHuntStart_GatedAndApplies(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	cock := &fakeHuntCockpit{startID: 5}
+	base, teardown := mkServer(t, ServerOptions{Bus: bus, Hunt: cock, AllowMutations: true})
+	defer teardown()
+	resp, err := http.Post(base+"/api/v1/hunt/start", "application/json",
+		strings.NewReader(`{"bands":["851:869"],"name":"X"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("status=%d", resp.StatusCode)
+	}
+	var body struct {
+		OK    bool `json:"ok"`
+		RunID int  `json:"run_id"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatal(err)
+	}
+	if !body.OK || body.RunID != 5 {
+		t.Errorf("body = %+v", body)
+	}
+	if len(cock.lastStart.Bands) != 1 || cock.lastStart.Name != "X" {
+		t.Errorf("request not forwarded: %+v", cock.lastStart)
+	}
+}
+
+func TestHuntStart_NoCockpit503(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	base, teardown := mkServer(t, ServerOptions{Bus: bus, AllowMutations: true})
+	defer teardown()
+	resp, err := http.Post(base+"/api/v1/hunt/start", "application/json", strings.NewReader(`{}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("status=%d, want 503", resp.StatusCode)
+	}
+}
+
+func TestHuntStart_AlreadyRunningConflict(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	cock := &fakeHuntCockpit{startErr: errors.New("hunt: a run is already in progress")}
+	base, teardown := mkServer(t, ServerOptions{Bus: bus, Hunt: cock, AllowMutations: true})
+	defer teardown()
+	resp, err := http.Post(base+"/api/v1/hunt/start", "application/json", strings.NewReader(`{"bands":["1:2"]}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("status=%d, want 409", resp.StatusCode)
+	}
+}
+
+func TestHuntExport_StreamsBytes(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	cock := &fakeHuntCockpit{exportData: []byte("# Section: metadata\n"), exportName: "sys.csv"}
+	base, teardown := mkServer(t, ServerOptions{Bus: bus, Hunt: cock})
+	defer teardown()
+	resp, err := http.Get(base + "/api/v1/hunt/export?format=bundle")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("status=%d", resp.StatusCode)
+	}
+	if cd := resp.Header.Get("Content-Disposition"); !strings.Contains(cd, "sys.csv") {
+		t.Errorf("content-disposition=%q", cd)
+	}
+	if cock.lastFormat != "bundle" {
+		t.Errorf("format=%q", cock.lastFormat)
+	}
+}
+
+func TestHuntExport_NoSystemConflict(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	cock := &fakeHuntCockpit{exportErr: errors.New("hunt: no discovered system to export yet")}
+	base, teardown := mkServer(t, ServerOptions{Bus: bus, Hunt: cock})
+	defer teardown()
+	resp, err := http.Get(base + "/api/v1/hunt/export?format=bundle")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("status=%d, want 409", resp.StatusCode)
+	}
+}
+
+func TestHuntStop_OK(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	cock := &fakeHuntCockpit{stopped: true}
+	base, teardown := mkServer(t, ServerOptions{Bus: bus, Hunt: cock, AllowMutations: true})
+	defer teardown()
+	resp, err := http.Post(base+"/api/v1/hunt/stop", "application/json", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("status=%d", resp.StatusCode)
+	}
+	var body struct {
+		Stopped bool `json:"stopped"`
+	}
+	_ = json.NewDecoder(resp.Body).Decode(&body)
+	if !body.Stopped {
+		t.Error("stopped=false, want true")
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -99,6 +99,26 @@ type BroadcastStatusProvider interface {
 	BroadcastStats() any
 }
 
+// HuntCockpit is the API surface for the live system-discovery ("hunt")
+// subsystem: read the current run state + discovered map, start/stop a blind
+// spectrum-sweep run, and export or commit the result. The daemon supplies a
+// single implementation wrapping the hunt.Manager; tests can stub it.
+type HuntCockpit interface {
+	// Status returns the current run snapshot (+ discovered system when ready).
+	Status() HuntStatus
+	// Start launches a live hunt; returns the new run id, or an error (e.g. a
+	// run is already active, or no SDR is available).
+	Start(req HuntStartRequest) (runID int, err error)
+	// Stop cancels the active run; false when nothing is running.
+	Stop() bool
+	// Export serializes the latest discovered system in the named format
+	// (bundle|trunk-recorder|rr), returning the bytes + a suggested filename.
+	Export(format string) (data []byte, filename string, err error)
+	// Commit merges the latest discovered system into config.yaml, returning a
+	// human-readable list of changes.
+	Commit(force, dryRun bool) (changes []string, err error)
+}
+
 // ScannerCockpit is the API surface for the police-scanner subsystem:
 // reads the current state (per-system CC hunt, conventional channel
 // list, talkgroup-scan stats) and applies operator mutations from
@@ -218,6 +238,7 @@ type Server struct {
 	tones        ToneDetectorReset
 	devices      DevicesProvider
 	scanner      ScannerCockpit
+	hunt         HuntCockpit
 	audio        AudioController
 	broadcast    BroadcastStatusProvider
 	runtime      RuntimeProvider
@@ -465,6 +486,10 @@ type ServerOptions struct {
 	// /api/v1/scanner and the related mutation routes. Optional;
 	// when nil, the routes return 503.
 	Scanner ScannerCockpit
+	// Hunt exposes the live system-discovery cockpit for GET /api/v1/hunt and
+	// its start/stop/export/commit routes. Optional; when nil, the routes
+	// return 503 (or an empty idle status for the read).
+	Hunt HuntCockpit
 	// Audio exposes the live-audio player + recorder gate for
 	// GET + PATCH /api/v1/audio. Optional; when nil, the routes
 	// return 503.
@@ -668,6 +693,7 @@ func NewServer(opts ServerOptions) (*Server, error) {
 		tones:          opts.Tones,
 		devices:        opts.Devices,
 		scanner:        opts.Scanner,
+		hunt:           opts.Hunt,
 		audio:          opts.Audio,
 		broadcast:      opts.Broadcast,
 		runtime:        opts.Runtime,
@@ -850,6 +876,13 @@ func (s *Server) routes() *http.ServeMux {
 	// Scanner cockpit — read endpoint is always open; mutations are
 	// gated behind allow_mutations like every other write route.
 	mux.HandleFunc("GET /api/v1/broadcast", s.handleBroadcastStatus)
+	// Live system-discovery (hunt) cockpit — read is open; mutations gated.
+	mux.HandleFunc("GET /api/v1/hunt", s.handleHuntStatus)
+	mux.HandleFunc("POST /api/v1/hunt/start", s.gate(s.handleHuntStart))
+	mux.HandleFunc("POST /api/v1/hunt/stop", s.gate(s.handleHuntStop))
+	mux.HandleFunc("GET /api/v1/hunt/export", s.handleHuntExport)
+	mux.HandleFunc("POST /api/v1/hunt/commit", s.gate(s.handleHuntCommit))
+
 	mux.HandleFunc("GET /api/v1/scanner", s.handleScannerStatus)
 	mux.HandleFunc("PATCH /api/v1/scanner", s.gate(s.handleScannerSetMode))
 	mux.HandleFunc("POST /api/v1/scanner/hunt/{system}/hold", s.gate(s.handleHuntHold))

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -3,8 +3,46 @@ package api
 import (
 	"time"
 
+	"github.com/MattCheramie/GopherTrunk/internal/hunt"
 	"github.com/MattCheramie/GopherTrunk/internal/trunking"
 )
+
+// HuntStatus is the JSON shape returned by GET /api/v1/hunt — the live
+// system-discovery run state plus the discovered system map once available.
+type HuntStatus struct {
+	RunID      int                    `json:"run_id"`
+	State      string                 `json:"state"`
+	Running    bool                   `json:"running"`
+	Phase      string                 `json:"phase,omitempty"`
+	Detail     string                 `json:"detail,omitempty"`
+	Sites      int                    `json:"sites"`
+	Talkgroups int                    `json:"talkgroups"`
+	SystemName string                 `json:"system_name,omitempty"`
+	Error      string                 `json:"error,omitempty"`
+	System     *hunt.DiscoveredSystem `json:"system,omitempty"`
+	Reports    []hunt.CaptureReport   `json:"reports,omitempty"`
+}
+
+// HuntStartRequest is the POST /api/v1/hunt/start body. Frequencies are in MHz
+// for operator convenience. With Bands set the hunt sweeps; with Candidates +
+// NoSweep it probes the listed control channels directly.
+type HuntStartRequest struct {
+	Serial          string    `json:"serial,omitempty"`
+	Bands           []string  `json:"bands,omitempty"`      // "low:high" MHz
+	Candidates      []float64 `json:"candidates,omitempty"` // MHz
+	NoSweep         bool      `json:"no_sweep,omitempty"`
+	Protocol        string    `json:"protocol,omitempty"`
+	DwellSeconds    float64   `json:"dwell_seconds,omitempty"`
+	SweepDwellMs    int       `json:"sweep_dwell_ms,omitempty"`
+	PeakThresholdDb float64   `json:"peak_threshold_db,omitempty"`
+	MinSpacingHz    uint32    `json:"min_spacing_hz,omitempty"`
+	FFTSize         int       `json:"fft_size,omitempty"`
+	MinConfidence   float64   `json:"min_confidence,omitempty"`
+	Name            string    `json:"name,omitempty"`
+	State           string    `json:"state,omitempty"`
+	County          string    `json:"county,omitempty"`
+	Location        string    `json:"location,omitempty"`
+}
 
 // EventDTO is the JSON envelope for every event streamed to clients.
 // Kind matches the events.Kind constant; Payload is the kind-specific

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -89,6 +89,7 @@ var KnownUITabs = map[string]bool{
 	"dashboard":     true,
 	"active":        true,
 	"scanner":       true,
+	"hunt":          true,
 	"settings":      true,
 	"systems":       true,
 	"talkgroups":    true,

--- a/internal/events/bus.go
+++ b/internal/events/bus.go
@@ -42,6 +42,16 @@ const (
 	//     so operators can see "retry in 5 s".
 	KindHuntProgress Kind = "cchunt.progress"
 	KindHuntFailed   Kind = "cchunt.failed"
+	// Live system-discovery ("hunt") events, published by the daemon's hunt
+	// Manager (internal/hunt). Distinct from the cchunt.* control-channel
+	// hunter above: these track a blind discovery run (spectrum sweep →
+	// identify → map). Payloads are hunt package types carried as `any`.
+	//   KindHuntLiveProgress fires as the sweep/identify phases advance.
+	//   KindHuntLiveCandidate fires once per candidate carrier mapped.
+	//   KindHuntLiveDone fires when a run finishes (or is stopped).
+	KindHuntLiveProgress  Kind = "hunt.progress"
+	KindHuntLiveCandidate Kind = "hunt.candidate"
+	KindHuntLiveDone      Kind = "hunt.done"
 	// KindAffiliation fires when a radio unit affiliates with a
 	// talkgroup. P25 control-channel publishes one per Group
 	// Affiliation Response TSBK (opcode 0x28); the payload identifies

--- a/internal/hunt/manager.go
+++ b/internal/hunt/manager.go
@@ -1,0 +1,227 @@
+package hunt
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+)
+
+// RunState is the lifecycle of a live hunt run, surfaced to the cockpit/REST.
+type RunState string
+
+const (
+	StateRunIdle    RunState = "idle"    // no run has started yet
+	StateRunActive  RunState = "running" // a sweep/identify run is in progress
+	StateRunDone    RunState = "done"    // last run finished and produced a map
+	StateRunStopped RunState = "stopped" // last run was cancelled by the operator
+	StateRunFailed  RunState = "failed"  // last run errored (e.g. SDR acquisition)
+)
+
+// Acquirer obtains an IQSource for one run plus a release callback (resume the
+// control-channel hunter, close the SDR subscription, …). The daemon supplies
+// this so the hunt package stays free of SDR/pool dependencies; release is
+// invoked exactly once when the run ends (success, error, or stop).
+type Acquirer func(ctx context.Context) (src IQSource, release func(), err error)
+
+// ManagerOptions configure a Manager.
+type ManagerOptions struct {
+	// Acquire obtains the run's IQSource. Required.
+	Acquire Acquirer
+	Bus     *events.Bus
+	Log     *slog.Logger
+}
+
+// Manager owns the daemon's single live-hunt run: it acquires an SDR, runs the
+// sweep→identify→map pipeline in the background, publishes hunt.* bus events,
+// and holds the latest discovered system for export/commit. Safe for
+// concurrent use by the REST/TUI cockpit.
+type Manager struct {
+	acquire Acquirer
+	bus     *events.Bus
+	log     *slog.Logger
+
+	mu         sync.Mutex
+	runID      int
+	state      RunState
+	progress   LiveHuntProgress
+	sys        *DiscoveredSystem
+	reports    []CaptureReport
+	err        string
+	startedAt  time.Time
+	finishedAt time.Time
+	cancel     context.CancelFunc
+}
+
+// NewManager builds a Manager. Acquire is required.
+func NewManager(opts ManagerOptions) (*Manager, error) {
+	if opts.Acquire == nil {
+		return nil, errors.New("hunt: Manager requires an Acquirer")
+	}
+	log := opts.Log
+	if log == nil {
+		log = slog.New(slog.DiscardHandler)
+	}
+	return &Manager{acquire: opts.Acquire, bus: opts.Bus, log: log, state: StateRunIdle}, nil
+}
+
+// RunStatus is the read snapshot the cockpit/REST renders.
+type RunStatus struct {
+	RunID      int              `json:"run_id"`
+	State      RunState         `json:"state"`
+	Running    bool             `json:"running"`
+	Progress   LiveHuntProgress `json:"progress"`
+	Sites      int              `json:"sites"`
+	Talkgroups int              `json:"talkgroups"`
+	SystemName string           `json:"system_name,omitempty"`
+	Error      string           `json:"error,omitempty"`
+	StartedAt  time.Time        `json:"started_at,omitempty"`
+	FinishedAt time.Time        `json:"finished_at,omitempty"`
+}
+
+// Start launches a live hunt with opts. It returns the new run id, or an error
+// if a run is already active. The run executes in the background; observe it via
+// Status and the hunt.* bus events.
+func (m *Manager) Start(opts LiveHuntOptions) (int, error) {
+	m.mu.Lock()
+	if m.state == StateRunActive {
+		m.mu.Unlock()
+		return 0, errors.New("hunt: a run is already in progress")
+	}
+	m.runID++
+	id := m.runID
+	ctx, cancel := context.WithCancel(context.Background())
+	m.cancel = cancel
+	m.state = StateRunActive
+	m.progress = LiveHuntProgress{Phase: PhaseSweeping}
+	m.sys = nil
+	m.reports = nil
+	m.err = ""
+	m.startedAt = time.Now()
+	m.finishedAt = time.Time{}
+	m.mu.Unlock()
+
+	// Wire progress events onto the bus + the live snapshot.
+	opts.Log = m.log
+	opts.OnProgress = func(p LiveHuntProgress) {
+		m.mu.Lock()
+		m.progress = p
+		m.mu.Unlock()
+		m.publish(events.KindHuntLiveProgress, p)
+	}
+
+	go m.run(ctx, id, opts)
+	return id, nil
+}
+
+func (m *Manager) run(ctx context.Context, id int, opts LiveHuntOptions) {
+	src, release, err := m.acquire(ctx)
+	if err != nil {
+		m.finish(id, nil, nil, fmt.Errorf("acquire SDR: %w", err))
+		return
+	}
+	defer release()
+	opts.Source = src
+
+	sys, reports, err := RunLiveHunt(ctx, opts)
+	m.finish(id, sys, reports, err)
+}
+
+// finish records the terminal state of a run and publishes hunt.done.
+func (m *Manager) finish(id int, sys *DiscoveredSystem, reports []CaptureReport, err error) {
+	m.mu.Lock()
+	if id != m.runID {
+		m.mu.Unlock()
+		return // a newer run superseded this one
+	}
+	m.finishedAt = time.Now()
+	m.cancel = nil
+	switch {
+	case err != nil && errors.Is(err, context.Canceled):
+		m.state = StateRunStopped
+	case err != nil:
+		m.state = StateRunFailed
+		m.err = err.Error()
+	default:
+		m.state = StateRunDone
+	}
+	if sys != nil {
+		m.sys = sys
+		m.reports = reports
+	}
+	st := m.statusLocked()
+	m.mu.Unlock()
+	m.publish(events.KindHuntLiveDone, st)
+}
+
+// Stop cancels the active run. Returns false if no run is active.
+func (m *Manager) Stop() bool {
+	m.mu.Lock()
+	cancel := m.cancel
+	active := m.state == StateRunActive
+	m.mu.Unlock()
+	if !active || cancel == nil {
+		return false
+	}
+	cancel()
+	return true
+}
+
+// Status returns the current run snapshot.
+func (m *Manager) Status() RunStatus {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.statusLocked()
+}
+
+func (m *Manager) statusLocked() RunStatus {
+	st := RunStatus{
+		RunID:      m.runID,
+		State:      m.state,
+		Running:    m.state == StateRunActive,
+		Progress:   m.progress,
+		Error:      m.err,
+		StartedAt:  m.startedAt,
+		FinishedAt: m.finishedAt,
+	}
+	if m.sys != nil {
+		st.Sites = len(m.sys.Sites)
+		st.Talkgroups = len(m.sys.Talkgroups)
+		st.SystemName = m.sys.DisplayName()
+	}
+	return st
+}
+
+// Current returns the latest discovered system and its per-candidate reports,
+// or (nil, nil, false) when no run has produced a map yet. The returned system
+// is the live pointer; callers must not mutate it.
+func (m *Manager) Current() (*DiscoveredSystem, []CaptureReport, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.sys == nil {
+		return nil, nil, false
+	}
+	return m.sys, m.reports, true
+}
+
+// Export writes the latest discovered system to w in the given format. Returns
+// an error when no system has been discovered yet.
+func (m *Manager) Export(w io.Writer, f Format, hints []DuplicateHint) error {
+	sys, _, ok := m.Current()
+	if !ok {
+		return errors.New("hunt: no discovered system to export yet")
+	}
+	return Write(w, sys, f, hints)
+}
+
+func (m *Manager) publish(kind events.Kind, payload any) {
+	if m.bus == nil {
+		return
+	}
+	m.bus.Publish(events.Event{Kind: kind, Timestamp: time.Now(), Payload: payload})
+}

--- a/internal/hunt/manager_test.go
+++ b/internal/hunt/manager_test.go
@@ -1,0 +1,164 @@
+package hunt
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/siglab"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// p25Source builds a FileIQSource over a synthesized P25 control channel plus
+// the run dwell that captures the whole buffer once.
+func p25Source(t *testing.T) (*FileIQSource, float64) {
+	t.Helper()
+	iq, meta, err := siglab.Synthesize(siglab.SynthOptions{
+		Protocol: trunking.ProtocolP25,
+		Format:   siglab.FormatF32,
+	})
+	if err != nil {
+		t.Fatalf("Synthesize: %v", err)
+	}
+	rate := uint32(meta.SampleRateHz)
+	return NewFileIQSource(iq, rate), float64(len(iq)) / float64(rate)
+}
+
+func waitUntil(t *testing.T, d time.Duration, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(d)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal("condition not met within deadline")
+}
+
+func TestManager_StartRunsAndMapsSystem(t *testing.T) {
+	bus := events.NewBus(256)
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	src, dwell := p25Source(t)
+	mgr, err := NewManager(ManagerOptions{
+		Acquire: func(context.Context) (IQSource, func(), error) { return src, func() {}, nil },
+		Bus:     bus,
+	})
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	id, err := mgr.Start(LiveHuntOptions{
+		Candidates:    []uint32{851_000_000},
+		DwellSeconds:  dwell,
+		MinConfidence: 0.3,
+		Name:          "Daemon Hunt",
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if id != 1 {
+		t.Errorf("run id = %d, want 1", id)
+	}
+
+	// Starting again while active must be refused.
+	if _, err := mgr.Start(LiveHuntOptions{Candidates: []uint32{1}}); err == nil {
+		t.Error("expected error starting a second run while active")
+	}
+
+	waitUntil(t, 15*time.Second, func() bool { return !mgr.Status().Running })
+
+	st := mgr.Status()
+	if st.State != StateRunDone {
+		t.Fatalf("state = %q, want done", st.State)
+	}
+	if st.Sites < 1 {
+		t.Errorf("sites = %d, want >= 1", st.Sites)
+	}
+	sys, _, ok := mgr.Current()
+	if !ok || sys == nil {
+		t.Fatal("Current() returned no system")
+	}
+
+	// Bus carried progress + done events.
+	var sawProgress, sawDone bool
+	for {
+		select {
+		case ev := <-sub.C:
+			switch ev.Kind {
+			case events.KindHuntLiveProgress:
+				sawProgress = true
+			case events.KindHuntLiveDone:
+				sawDone = true
+			}
+		default:
+			if !sawProgress {
+				t.Error("no hunt.progress event observed")
+			}
+			if !sawDone {
+				t.Error("no hunt.done event observed")
+			}
+			return
+		}
+	}
+}
+
+func TestManager_AcquireErrorFailsRun(t *testing.T) {
+	mgr, err := NewManager(ManagerOptions{
+		Acquire: func(context.Context) (IQSource, func(), error) {
+			return nil, nil, errors.New("no spare SDR")
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	if _, err := mgr.Start(LiveHuntOptions{Candidates: []uint32{1}}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	waitUntil(t, 5*time.Second, func() bool { return !mgr.Status().Running })
+	st := mgr.Status()
+	if st.State != StateRunFailed {
+		t.Errorf("state = %q, want failed", st.State)
+	}
+	if st.Error == "" {
+		t.Error("expected an error message on a failed run")
+	}
+}
+
+func TestManager_StopIdleReturnsFalse(t *testing.T) {
+	mgr, _ := NewManager(ManagerOptions{
+		Acquire: func(context.Context) (IQSource, func(), error) { return nil, nil, errors.New("x") },
+	})
+	if mgr.Stop() {
+		t.Error("Stop() on an idle manager should return false")
+	}
+}
+
+func TestNewManager_RequiresAcquirer(t *testing.T) {
+	if _, err := NewManager(ManagerOptions{}); err == nil {
+		t.Error("expected error when Acquire is nil")
+	}
+}
+
+// release must run on completion so a borrowed SDR is always returned.
+func TestManager_ReleaseRunsOnCompletion(t *testing.T) {
+	src, dwell := p25Source(t)
+	released := make(chan struct{})
+	mgr, _ := NewManager(ManagerOptions{
+		Acquire: func(context.Context) (IQSource, func(), error) {
+			return src, func() { close(released) }, nil
+		},
+	})
+	if _, err := mgr.Start(LiveHuntOptions{Candidates: []uint32{851_000_000}, DwellSeconds: dwell, MinConfidence: 0.3}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	select {
+	case <-released:
+	case <-time.After(15 * time.Second):
+		t.Fatal("release was not called after the run finished")
+	}
+}

--- a/internal/scanner/cchunt/supervisor.go
+++ b/internal/scanner/cchunt/supervisor.go
@@ -547,6 +547,51 @@ func (s *Supervisor) isHeld(name string) bool {
 
 // --- operator mutation surface ---
 
+// PauseAll holds every configured system and bails any in-flight hunt, so the
+// supervisor stops retuning the control SDR. It is used by the live hunt's
+// "borrow the control SDR" path (when no spare SDR is available) to quiesce
+// cchunt before sweeping, then ResumeAll restores normal scanning. Idempotent.
+func (s *Supervisor) PauseAll() {
+	s.mu.Lock()
+	var toCancel []chan struct{}
+	for _, rt := range s.states {
+		if rt == nil {
+			continue
+		}
+		rt.heldByOp = true
+		rt.state = StateHeld
+		if rt.retuneCh != nil {
+			toCancel = append(toCancel, rt.retuneCh)
+			rt.retuneCh = nil
+		}
+	}
+	s.mu.Unlock()
+	// Cancel in-flight hunts outside the lock so they bail promptly; the next
+	// Run round then skips every (held) system and stops touching the tuner.
+	for _, ch := range toCancel {
+		select {
+		case <-ch:
+		default:
+			close(ch)
+		}
+	}
+}
+
+// ResumeAll undoes PauseAll, returning every system to the round-robin with a
+// fresh backoff. Idempotent.
+func (s *Supervisor) ResumeAll() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, rt := range s.states {
+		if rt == nil {
+			continue
+		}
+		rt.heldByOp = false
+		rt.state = StateIdle
+		rt.backoffWindow = s.initBO
+	}
+}
+
 // Hold pins the supervisor on the named system's current state — no
 // further retunes happen until Resume. Returns false if the system
 // isn't configured.

--- a/internal/scanner/cchunt/supervisor_test.go
+++ b/internal/scanner/cchunt/supervisor_test.go
@@ -178,6 +178,43 @@ func TestSupervisorHoldAndResume(t *testing.T) {
 	}
 }
 
+func TestSupervisorPauseAllResumeAll(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sup, err := New(Options{
+		Bus:   bus,
+		Tuner: &fakeTuner{},
+		Systems: []trunking.System{
+			{Name: "A", Protocol: trunking.ProtocolP25, ControlChannels: []uint32{1}},
+			{Name: "B", Protocol: trunking.ProtocolP25, ControlChannels: []uint32{2}},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sup.PauseAll()
+	for _, st := range sup.Snapshot() {
+		if st.State != StateHeld {
+			t.Errorf("system %s state after PauseAll = %q, want held", st.Name, st.State)
+		}
+	}
+	// Idempotent.
+	sup.PauseAll()
+	for _, st := range sup.Snapshot() {
+		if st.State != StateHeld {
+			t.Errorf("system %s not held after second PauseAll", st.Name)
+		}
+	}
+
+	sup.ResumeAll()
+	for _, st := range sup.Snapshot() {
+		if st.State != StateIdle {
+			t.Errorf("system %s state after ResumeAll = %q, want idle", st.Name, st.State)
+		}
+	}
+}
+
 func TestSupervisorForceRetuneClearsBackoff(t *testing.T) {
 	bus := events.NewBus(8)
 	defer bus.Close()

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -87,6 +87,7 @@ func New(cli *client.Client, opts Options) *Model {
 			panels.NewMetrics(),
 			panels.NewDevices(),
 			panels.NewScanner(),
+			panels.NewHunt(),
 			panels.NewSettings(),
 			panels.NewImport(),
 		},
@@ -106,6 +107,7 @@ func (m *Model) Init() tea.Cmd {
 		cmdPollHistory(m.cli, client.HistoryFilter{Limit: 100}),
 		cmdPollDevices(m.cli),
 		cmdPollScanner(m.cli),
+		cmdPollHunt(m.cli),
 		cmdPollAudio(m.cli),
 		cmdPollRuntime(m.cli),
 		cmdMutationStatus(m.cli),
@@ -283,6 +285,13 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.shared.ScannerErr = msg.err
 		cmds = append(cmds, scheduleAfter(pollScannerEvery, cmdPollScanner(m.cli)))
+
+	case pollHuntMsg:
+		if msg.err == nil {
+			m.shared.Hunt = msg.s
+		}
+		m.shared.HuntErr = msg.err
+		cmds = append(cmds, scheduleAfter(pollHuntEvery, cmdPollHunt(m.cli)))
 
 	case pollAudioMsg:
 		if msg.err == nil {
@@ -693,6 +702,8 @@ func (m *Model) dispatchWrite(r state.WriteRequest) tea.Cmd {
 			return nil
 		}
 		return cmdScannerHuntRetune(m.cli, r.ScannerHunt.System, r.Label)
+	case state.WriteKindHuntStop:
+		return cmdHuntStop(m.cli, r.Label)
 	case state.WriteKindScannerConvHold:
 		return cmdScannerConvHold(m.cli, r.Label)
 	case state.WriteKindScannerConvResume:

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -82,12 +82,17 @@ func TestPanelSwitch_DigitAndTab(t *testing.T) {
 			t.Errorf("after %q active=%v, want %v", c.key, m.active, c.want)
 		}
 	}
-	// Tab cycles forward — Scanner advances to Settings, then to
-	// Import (the new last panel after the live-import work).
+	// Tab cycles forward — Scanner advances to Hunt, then Settings, then
+	// Import (the last panel).
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyTab})
 	m = updated.(*Model)
+	if m.active != state.PanelHunt {
+		t.Errorf("Tab from Scanner: active=%v, want Hunt", m.active)
+	}
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	m = updated.(*Model)
 	if m.active != state.PanelSettings {
-		t.Errorf("Tab from Scanner: active=%v, want Settings", m.active)
+		t.Errorf("Tab from Hunt: active=%v, want Settings", m.active)
 	}
 	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
 	m = updated.(*Model)

--- a/internal/tui/client/client.go
+++ b/internal/tui/client/client.go
@@ -188,6 +188,16 @@ func (c *Client) Scanner(ctx context.Context) (ScannerStatusDTO, error) {
 	return s, nil
 }
 
+// Hunt calls GET /api/v1/hunt and returns the live system-discovery snapshot.
+// Always succeeds with an empty (idle) status when no hunt subsystem is wired.
+func (c *Client) Hunt(ctx context.Context) (HuntStatusDTO, error) {
+	var s HuntStatusDTO
+	if err := c.getJSON(ctx, "/api/v1/hunt", &s); err != nil {
+		return HuntStatusDTO{}, err
+	}
+	return s, nil
+}
+
 // Devices calls GET /api/v1/devices.
 func (c *Client) Devices(ctx context.Context) ([]SDRStatus, error) {
 	var r devicesResp

--- a/internal/tui/client/types.go
+++ b/internal/tui/client/types.go
@@ -137,6 +137,21 @@ type Event struct {
 	Raw  json.RawMessage
 }
 
+// HuntStatusDTO mirrors the scalar fields of api.HuntStatus — the live
+// system-discovery run snapshot from GET /api/v1/hunt. The full discovered
+// system map is omitted here; the panel renders the summary counts.
+type HuntStatusDTO struct {
+	RunID      int    `json:"run_id"`
+	State      string `json:"state"`
+	Running    bool   `json:"running"`
+	Phase      string `json:"phase"`
+	Detail     string `json:"detail"`
+	Sites      int    `json:"sites"`
+	Talkgroups int    `json:"talkgroups"`
+	SystemName string `json:"system_name"`
+	Error      string `json:"error"`
+}
+
 // ScannerStatusDTO mirrors api.ScannerStatus — the unified scanner
 // snapshot returned by GET /api/v1/scanner. Fields are zero-valued
 // when the underlying subsystem isn't wired (e.g. no CC hunter →

--- a/internal/tui/client/write.go
+++ b/internal/tui/client/write.go
@@ -85,6 +85,11 @@ func (c *Client) ScannerSetMode(ctx context.Context, mode string) error {
 		map[string]string{"scan_mode": mode}, nil)
 }
 
+// HuntStop cancels the active live system-discovery run.
+func (c *Client) HuntStop(ctx context.Context) error {
+	return c.do(ctx, http.MethodPost, "/api/v1/hunt/stop", nil, nil)
+}
+
 // ScannerHuntHold / ScannerHuntResume / ScannerHuntRetune call the
 // per-system hunt mutation endpoints. system must match a configured
 // trunked system name.

--- a/internal/tui/cmds.go
+++ b/internal/tui/cmds.go
@@ -22,6 +22,7 @@ const (
 	pollMetricsEvery    = 5 * time.Second
 	pollDevicesEvery    = 10 * time.Second
 	pollScannerEvery    = 2 * time.Second
+	pollHuntEvery       = 2 * time.Second
 	pollAudioEvery      = 3 * time.Second
 	pollRuntimeEvery    = 30 * time.Second
 )
@@ -79,6 +80,20 @@ func cmdPollScanner(cli *client.Client) tea.Cmd {
 	return func() tea.Msg {
 		s, err := cli.Scanner(context.Background())
 		return pollScannerMsg{s: s, err: err}
+	}
+}
+
+func cmdPollHunt(cli *client.Client) tea.Cmd {
+	return func() tea.Msg {
+		s, err := cli.Hunt(context.Background())
+		return pollHuntMsg{s: s, err: err}
+	}
+}
+
+func cmdHuntStop(cli *client.Client, label string) tea.Cmd {
+	return func() tea.Msg {
+		err := cli.HuntStop(context.Background())
+		return writeResultMsg{Label: label, Err: err}
 	}
 }
 

--- a/internal/tui/msgs.go
+++ b/internal/tui/msgs.go
@@ -47,6 +47,10 @@ type pollScannerMsg struct {
 	s   client.ScannerStatusDTO
 	err error
 }
+type pollHuntMsg struct {
+	s   client.HuntStatusDTO
+	err error
+}
 type pollAudioMsg struct {
 	a   client.AudioStatusDTO
 	err error

--- a/internal/tui/panels/hunt.go
+++ b/internal/tui/panels/hunt.go
@@ -1,0 +1,87 @@
+package panels
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/key"
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/MattCheramie/GopherTrunk/internal/tui/state"
+)
+
+// HuntPanel renders the live system-discovery ("hunt") run: its state, sweep/
+// identify progress, and the discovered system summary. A blind discovery is
+// started from the web/API (where band/candidate parameters are entered); the
+// TUI monitors the run and can stop it.
+type HuntPanel struct{}
+
+func NewHunt() *HuntPanel { return &HuntPanel{} }
+
+func (HuntPanel) Title() string { return "Hunt" }
+
+var huntStopKey = key.NewBinding(key.WithKeys("x"), key.WithHelp("x", "stop run"))
+
+func (HuntPanel) Keys() []key.Binding { return []key.Binding{huntStopKey} }
+
+func (p *HuntPanel) Update(msg tea.Msg, s *state.SharedState) (Panel, tea.Cmd) {
+	km, ok := msg.(tea.KeyMsg)
+	if !ok {
+		return p, nil
+	}
+	if key.Matches(km, huntStopKey) && s.Hunt.Running {
+		return p, Emit(state.WriteRequest{
+			Label: "stop hunt run",
+			Kind:  state.WriteKindHuntStop,
+		})
+	}
+	return p, nil
+}
+
+func (p *HuntPanel) View(width, height int, focused bool, s *state.SharedState) string {
+	if width < 30 || height < 6 {
+		return panelFrame("Hunt", width, height, focused, "")
+	}
+	h := s.Hunt
+	var b strings.Builder
+
+	runState := h.State
+	if runState == "" {
+		runState = "idle"
+	}
+	fmt.Fprintf(&b, "State:   %s", runState)
+	if h.Running {
+		b.WriteString("  ●")
+	}
+	b.WriteString("\n")
+	if h.Phase != "" {
+		fmt.Fprintf(&b, "Phase:   %s", h.Phase)
+		if h.Detail != "" {
+			fmt.Fprintf(&b, " — %s", h.Detail)
+		}
+		b.WriteString("\n")
+	}
+	if h.Error != "" {
+		fmt.Fprintf(&b, "Error:   %s\n", h.Error)
+	}
+
+	b.WriteString("\n")
+	if h.SystemName != "" {
+		fmt.Fprintf(&b, "Discovered: %s\n", h.SystemName)
+		fmt.Fprintf(&b, "  sites: %d   talkgroups: %d\n", h.Sites, h.Talkgroups)
+	} else {
+		b.WriteString("No system discovered yet.\n")
+	}
+
+	b.WriteString("\n")
+	if h.Running {
+		b.WriteString("[x] stop run\n")
+	} else {
+		b.WriteString("Start a run from the web console or POST /api/v1/hunt/start.\n")
+	}
+	if s.HuntErr != nil {
+		fmt.Fprintf(&b, "\n(status unavailable: %v)\n", s.HuntErr)
+	}
+
+	return panelFrame("Hunt", width, height, focused, b.String())
+}

--- a/internal/tui/state/state.go
+++ b/internal/tui/state/state.go
@@ -24,6 +24,7 @@ const (
 	PanelMetrics
 	PanelDevices
 	PanelScanner
+	PanelHunt
 	PanelSettings
 	PanelImport
 	PanelCount
@@ -51,6 +52,8 @@ func (p PanelKind) String() string {
 		return "Devices"
 	case PanelScanner:
 		return "Scanner"
+	case PanelHunt:
+		return "Hunt"
 	case PanelSettings:
 		return "Settings"
 	case PanelImport:
@@ -85,6 +88,8 @@ func (p PanelKind) Key() string {
 		return "devices"
 	case PanelScanner:
 		return "scanner"
+	case PanelHunt:
+		return "hunt"
 	case PanelSettings:
 		return "settings"
 	case PanelImport:
@@ -118,6 +123,8 @@ type SharedState struct {
 	DevicesErr  error
 	Scanner     client.ScannerStatusDTO
 	ScannerErr  error
+	Hunt        client.HuntStatusDTO
+	HuntErr     error
 	Audio       client.AudioStatusDTO
 	AudioErr    error
 	Runtime     client.RuntimeDTO
@@ -188,6 +195,7 @@ const (
 	WriteKindAudio
 	WriteKindScannerManualTune
 	WriteKindSettings
+	WriteKindHuntStop
 )
 
 // ScannerManualTuneReq adds a temp VFO channel and forces dwell.

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -24,6 +24,7 @@ import { Metrics } from "./panels/Metrics";
 import { Pagers } from "./panels/Pagers";
 import { RadioIDs } from "./panels/RadioIDs";
 import { Scanner } from "./panels/Scanner";
+import { Hunt } from "./panels/Hunt";
 import { Settings } from "./panels/Settings";
 import { Spectrum } from "./panels/Spectrum";
 import { Systems } from "./panels/Systems";
@@ -38,6 +39,7 @@ const TABS: Tab[] = [
   { to: "/settings", label: "Settings", icon: "⚙" },
 ];
 const EXTRA_TABS: Tab[] = [
+  { to: "/hunt", label: "Hunt", icon: "🔍" },
   { to: "/systems", label: "Systems", icon: "❖" },
   { to: "/talkgroups", label: "Talkgroups", icon: "☷" },
   { to: "/rids", label: "Radio IDs", icon: "⌖" },
@@ -182,6 +184,7 @@ export function App() {
           <Route path="/dashboard" element={<Dashboard />} />
           <Route path="/active" element={<Active />} />
           <Route path="/scanner" element={<Scanner />} />
+          <Route path="/hunt" element={<Hunt />} />
           <Route path="/spectrum" element={<Spectrum />} />
           <Route path="/constellation" element={<Constellation />} />
           <Route path="/bookmarks" element={<Bookmarks />} />

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -10,6 +10,7 @@ import type {
   CallRow,
   DeviceDTO,
   Health,
+  HuntStatus,
   Mutations,
   RIDDTO,
   RuntimeDTO,
@@ -195,6 +196,7 @@ export const api = {
     ),
   scanner: (c: ClientConfig) =>
     request<ScannerStatusDTO>(c, "GET", "/api/v1/scanner"),
+  hunt: (c: ClientConfig) => request<HuntStatus>(c, "GET", "/api/v1/hunt"),
   audio: (c: ClientConfig) =>
     request<AudioStatusDTO>(c, "GET", "/api/v1/audio"),
   metricsText: (c: ClientConfig) =>

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -119,6 +119,35 @@ export interface AudioStatusDTO {
   drops_total: number;
 }
 
+// HuntStatus mirrors api.HuntStatus — the live system-discovery run snapshot
+// from GET /api/v1/hunt. `system` carries the full discovered map when ready.
+export interface HuntStatus {
+  run_id: number;
+  state: string;
+  running: boolean;
+  phase?: string;
+  detail?: string;
+  sites: number;
+  talkgroups: number;
+  system_name?: string;
+  error?: string;
+  system?: unknown;
+}
+
+// HuntStartRequest mirrors api.HuntStartRequest (frequencies in MHz).
+export interface HuntStartRequest {
+  serial?: string;
+  bands?: string[];
+  candidates?: number[];
+  no_sweep?: boolean;
+  protocol?: string;
+  dwell_seconds?: number;
+  name?: string;
+  state?: string;
+  county?: string;
+  location?: string;
+}
+
 export interface ScannerStatusDTO {
   scan_mode: string;
   systems: SystemHuntStatusDTO[];

--- a/web/src/api/write.ts
+++ b/web/src/api/write.ts
@@ -3,6 +3,7 @@
 import { type ClientConfig, joinURL, HTTPError, request } from "./client";
 import type {
   AudioStatusDTO,
+  HuntStartRequest,
   ImportPreview,
   ImportResult,
   RIDDTO,
@@ -60,6 +61,11 @@ export const writes = {
 
   setScanMode: (c: ClientConfig, mode: "all" | "list") =>
     request<void>(c, "PATCH", "/api/v1/scanner", { scan_mode: mode }),
+
+  // Live system-discovery (hunt) controls.
+  huntStart: (c: ClientConfig, req: HuntStartRequest) =>
+    request<{ run_id: number }>(c, "POST", "/api/v1/hunt/start", req),
+  huntStop: (c: ClientConfig) => request<void>(c, "POST", "/api/v1/hunt/stop"),
 
   huntHold: (c: ClientConfig, system: string) =>
     request<void>(

--- a/web/src/panels/Hunt.tsx
+++ b/web/src/panels/Hunt.tsx
@@ -1,0 +1,152 @@
+import { useEffect, useState } from "react";
+import { api } from "../api/client";
+import { writes } from "../api/write";
+import type { HuntStatus } from "../api/types";
+import { selectCanMutate, selectClientConfig, useShared } from "../store/shared";
+
+const POLL_INTERVAL_MS = 2_000;
+
+// Hunt drives the live system-discovery (blind spectrum-sweep) cockpit: start a
+// run over operator-given bands (or a candidate list), watch its progress, and
+// download / commit the discovered system. Mutations are gated behind
+// selectCanMutate.
+export function Hunt() {
+  const cfg = useShared(selectClientConfig);
+  const canMutate = useShared(selectCanMutate);
+  const setError = useShared((s) => s.setError);
+
+  const [status, setStatus] = useState<HuntStatus | null>(null);
+  const [bands, setBands] = useState("851:869");
+  const [candidates, setCandidates] = useState("");
+  const [name, setName] = useState("");
+  const [stateCode, setStateCode] = useState("");
+  const [county, setCounty] = useState("");
+
+  useEffect(() => {
+    let cancel = false;
+    const refresh = async () => {
+      try {
+        const data = await api.hunt(cfg);
+        if (!cancel) setStatus(data);
+      } catch {
+        // keep the previous snapshot
+      }
+    };
+    refresh();
+    const t = window.setInterval(refresh, POLL_INTERVAL_MS);
+    return () => {
+      cancel = true;
+      window.clearInterval(t);
+    };
+  }, [cfg]);
+
+  async function start() {
+    const bandList = bands
+      .split(",")
+      .map((b) => b.trim())
+      .filter(Boolean);
+    const candList = candidates
+      .split(",")
+      .map((c) => parseFloat(c.trim()))
+      .filter((n) => !Number.isNaN(n));
+    try {
+      await writes.huntStart(cfg, {
+        bands: bandList.length ? bandList : undefined,
+        candidates: candList.length ? candList : undefined,
+        no_sweep: candList.length > 0 && bandList.length === 0,
+        name: name || undefined,
+        state: stateCode || undefined,
+        county: county || undefined,
+      });
+    } catch (e: unknown) {
+      setError(e instanceof Error ? `start hunt failed: ${e.message}` : "start hunt failed");
+    }
+  }
+
+  async function stop() {
+    try {
+      await writes.huntStop(cfg);
+    } catch (e: unknown) {
+      setError(e instanceof Error ? `stop hunt failed: ${e.message}` : "stop hunt failed");
+    }
+  }
+
+  const running = status?.running ?? false;
+  const exportBase = `${cfg.baseURL}/api/v1/hunt/export`;
+
+  return (
+    <div className="panel hunt-panel">
+      <h2>Hunt — discover an unknown system</h2>
+
+      <section className="hunt-status">
+        <div>
+          State: <strong>{status?.state ?? "idle"}</strong>
+          {running ? " ●" : ""}
+        </div>
+        {status?.phase ? (
+          <div>
+            Phase: {status.phase}
+            {status.detail ? ` — ${status.detail}` : ""}
+          </div>
+        ) : null}
+        {status?.error ? <div className="error">Error: {status.error}</div> : null}
+        {status?.system_name ? (
+          <div>
+            Discovered: <strong>{status.system_name}</strong> — {status.sites} site(s),{" "}
+            {status.talkgroups} talkgroup(s)
+          </div>
+        ) : (
+          <div>No system discovered yet.</div>
+        )}
+      </section>
+
+      <section className="hunt-controls">
+        <label>
+          Bands (MHz, low:high, comma-separated)
+          <input value={bands} onChange={(e) => setBands(e.target.value)} placeholder="851:869" />
+        </label>
+        <label>
+          Candidates (MHz, comma-separated — skips the sweep)
+          <input
+            value={candidates}
+            onChange={(e) => setCandidates(e.target.value)}
+            placeholder="851.0125, 853.5125"
+          />
+        </label>
+        <label>
+          Name
+          <input value={name} onChange={(e) => setName(e.target.value)} placeholder="New County P25" />
+        </label>
+        <label>
+          State
+          <input value={stateCode} onChange={(e) => setStateCode(e.target.value)} placeholder="AZ" />
+        </label>
+        <label>
+          County
+          <input value={county} onChange={(e) => setCounty(e.target.value)} placeholder="Maricopa" />
+        </label>
+        <div className="hunt-buttons">
+          <button onClick={start} disabled={!canMutate || running}>
+            Start hunt
+          </button>
+          <button onClick={stop} disabled={!canMutate || !running}>
+            Stop
+          </button>
+        </div>
+      </section>
+
+      {status?.system_name ? (
+        <section className="hunt-export">
+          <span>Export:</span>
+          <a href={`${exportBase}?format=bundle`}>GopherTrunk bundle</a>
+          <a href={`${exportBase}?format=trunk-recorder`}>trunk-recorder</a>
+          <a href={`${exportBase}?format=rr`}>RadioReference package</a>
+        </section>
+      ) : null}
+
+      {!canMutate ? (
+        <p className="hint">Mutations are read-only on this connection (no auth token).</p>
+      ) : null}
+    </div>
+  );
+}


### PR DESCRIPTION
Phase 5 (final) of the hunt follow-ups: operator-facing surfaces for the daemon-integrated live discovery, mirroring the scanner cockpit.

## TUI
- New **Hunt** panel (`internal/tui/panels/hunt.go`) showing run state, sweep/identify progress, and the discovered-system summary, with `x` to stop the active run.
- Wired into the panel list, `PanelKind` enum (String/Key), the 2 s poll loop (`cmdPollHunt`/`pollHuntMsg`), `SharedState` (`Hunt`/`HuntErr`), and the `WriteRequest` machinery (`WriteKindHuntStop` → `cmdHuntStop`). Client gains `Hunt()`/`HuntStop()` + `HuntStatusDTO`. Tab-cycle test updated for the new panel.

## Web console
- New **Hunt** tab + `/hunt` route + `panels/Hunt.tsx`: start a run over operator bands (or a candidate list, skipping the sweep), watch live status, and download the bundle / trunk-recorder / RadioReference exports.
- `api.hunt()` GET + `writes.huntStart`/`huntStop` + `HuntStatus`/`HuntStartRequest` types.
- `"hunt"` added to `config.KnownUITabs` so the tab honors `web.tabs` visibility in both UIs.

## Verification
`go build`/`vet`/`test` green (incl. the updated TUI tab-cycle test); web `tsc` typecheck + `vite build` clean; `vitest` 120/120 pass. `node_modules`/`dist` artifacts kept out of the commit.

This **completes the hunt follow-up plan**: live sweep + topology enrichment + in-memory identify (#551, #552) → daemon integration (#554) → REST cockpit (#555) → TUI/web panels (this PR). Branches off `main`.

https://claude.ai/code/session_01He917mJB4Kg4ZkHjyHtJ66

---
_Generated by [Claude Code](https://claude.ai/code/session_01He917mJB4Kg4ZkHjyHtJ66)_