### PR TITLE
hunt: complete deferred items — per-run SDR, run-id export, TUI start, multi-protocol topology

### DIFF
--- a/cmd/gophertrunk/hunt_acquire.go
+++ b/cmd/gophertrunk/hunt_acquire.go
@@ -50,14 +50,14 @@ func chooseHuntSDR(requestedSerial, controlSerial string, voiceSerials []string,
 // hunter while the sweep runs; the release (deferred by the Manager) always
 // restores it.
 func (d *Daemon) buildHuntAcquirer() hunt.Acquirer {
-	return func(ctx context.Context) (hunt.IQSource, func(), error) {
+	return func(ctx context.Context, opts hunt.LiveHuntOptions) (hunt.IQSource, func(), error) {
 		var voiceSerials []string
 		if d.pool != nil {
 			for _, e := range d.pool.AllByRole(sdr.RoleVoice) {
 				voiceSerials = append(voiceSerials, e.Info.Serial)
 			}
 		}
-		serial, borrow, err := chooseHuntSDR("", d.controlSerial, voiceSerials, func(s string) bool {
+		serial, borrow, err := chooseHuntSDR(opts.Serial, d.controlSerial, voiceSerials, func(s string) bool {
 			return d.iqBrokers[s] != nil
 		})
 		if err != nil {

--- a/cmd/gophertrunk/hunt_cockpit.go
+++ b/cmd/gophertrunk/hunt_cockpit.go
@@ -69,6 +69,7 @@ func (c huntCockpit) Start(req api.HuntStartRequest) (int, error) {
 		Bands:         bands,
 		Candidates:    candidates,
 		Protocol:      proto,
+		Serial:        req.Serial,
 		FFTSize:       req.FFTSize,
 		DwellSeconds:  req.DwellSeconds,
 		MinConfidence: req.MinConfidence,

--- a/cmd/gophertrunk/hunt_cockpit.go
+++ b/cmd/gophertrunk/hunt_cockpit.go
@@ -91,12 +91,15 @@ func (c huntCockpit) Start(req api.HuntStartRequest) (int, error) {
 func (c huntCockpit) Stop() bool { return c.mgr.Stop() }
 
 // Export serializes the latest discovered system in the requested format.
-func (c huntCockpit) Export(format string) ([]byte, string, error) {
+func (c huntCockpit) Export(id int, format string) ([]byte, string, error) {
 	hf, err := hunt.ParseFormat(format)
 	if err != nil {
 		return nil, "", err
 	}
-	sys, _, ok := c.mgr.Current()
+	sys, ok, err := c.runSystem(id)
+	if err != nil {
+		return nil, "", err
+	}
 	if !ok {
 		return nil, "", fmt.Errorf("hunt: no discovered system to export yet")
 	}
@@ -114,8 +117,25 @@ func (c huntCockpit) Export(format string) ([]byte, string, error) {
 
 // Commit merges the latest discovered system into config.yaml via the shared
 // importer writer.
-func (c huntCockpit) Commit(force, dryRun bool) ([]string, error) {
-	sys, _, ok := c.mgr.Current()
+// runSystem resolves a run id (0 = latest) to its discovered system. It returns
+// hunt.ErrNoSuchRun for an unknown/evicted id, and ok=false when the run is
+// known but produced no system yet.
+func (c huntCockpit) runSystem(id int) (*hunt.DiscoveredSystem, bool, error) {
+	sys, _, ok := c.mgr.Run(id)
+	if ok {
+		return sys, true, nil
+	}
+	if id != 0 && !c.mgr.KnownRun(id) {
+		return nil, false, hunt.ErrNoSuchRun
+	}
+	return nil, false, nil
+}
+
+func (c huntCockpit) Commit(id int, force, dryRun bool) ([]string, error) {
+	sys, ok, err := c.runSystem(id)
+	if err != nil {
+		return nil, err
+	}
 	if !ok {
 		return nil, fmt.Errorf("hunt: no discovered system to commit yet")
 	}

--- a/docs/hunt.md
+++ b/docs/hunt.md
@@ -151,13 +151,22 @@ to force it off even when a key is configured.
   `hunt.done`) via `GET /api/v1/events`. The **web console** has a *Hunt* tab
   (start a run, watch progress, download/commit the result) and the **TUI** has
   a *Hunt* panel that monitors the run and can stop it.
-- **Topology depth.** For **P25** the hunt now recovers full topology —
-  WACN/SYSID, the camped RFSS/Site, advertised neighbor (adjacent) sites, and
-  the over-the-air band plan (IDEN_UP) — all surfaced in the exports. For other
-  protocols the map carries the identity the decoder surfaces (DMR ColorCode/
-  SystemID, NXDN Site/System, TETRA MCC/MNC/LA, …) plus the observed site and
-  talkgroups; neighbor accumulation for those protocols lands incrementally.
-  Band-plan-from-air is P25-only (others resolve channels via configured plans).
+- **Topology depth.** What the hunt recovers per protocol:
+
+  | Protocol | Identity | Neighbor sites | Band plan |
+  |---|---|---|---|
+  | P25 | WACN/SYSID/RFSS/Site/LRA | yes (adjacent-site) | yes (IDEN_UP, over-the-air) |
+  | DMR Tier III | SystemID/RFSS/Site/ColorCode | yes (adjacent-site CSBK) | configured plan |
+  | EDACS | SystemID | yes (adjacent-site CCW) | configured plan |
+  | Motorola Type II | SystemID | yes (adjacent-site OSW) | configured plan |
+  | NXDN | SystemID/Site/Location | — | configured plan |
+  | TETRA | MCC/MNC/LA/colour code | — | configured plan |
+  | MPT1327 / dPMR | SystemID | — | configured plan |
+  | LTR / YSF / D-STAR | — (no system identity broadcast) | — | — |
+
+  Band-plan-from-air is P25-only; the others resolve channels via the
+  configured band plan. Neighbor accumulation beyond the protocols above (e.g.
+  TETRA neighbour cells) lands incrementally.
 - **Talkgroup names.** A blind discovery can only record talkgroup *numbers*
   and activity; names/descriptions are filled in during RadioReference
   submission.

--- a/internal/api/handlers_hunt.go
+++ b/internal/api/handlers_hunt.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 )
 
 // handleHuntStatus returns the live system-discovery snapshot. Always 200 —
@@ -63,11 +64,19 @@ func (s *Server) handleHuntExport(w http.ResponseWriter, r *http.Request) {
 	if format == "" {
 		format = "bundle"
 	}
-	data, filename, err := s.hunt.Export(format)
+	id, ok := huntRunID(r)
+	if !ok {
+		s.writeError(w, http.StatusBadRequest, "invalid run id")
+		return
+	}
+	data, filename, err := s.hunt.Export(id, format)
 	if err != nil {
-		// No discovered system yet → 409; a bad format → 400.
+		// Unknown id → 404; bad format → 400; otherwise no-system → 409.
 		status := http.StatusConflict
-		if isHuntBadFormat(err) {
+		switch {
+		case isHuntNoSuchRun(err):
+			status = http.StatusNotFound
+		case isHuntBadFormat(err):
 			status = http.StatusBadRequest
 		}
 		s.writeError(w, status, err.Error())
@@ -98,12 +107,35 @@ func (s *Server) handleHuntCommit(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	changes, err := s.hunt.Commit(req.Force, req.DryRun)
+	id, ok := huntRunID(r)
+	if !ok {
+		s.writeError(w, http.StatusBadRequest, "invalid run id")
+		return
+	}
+	changes, err := s.hunt.Commit(id, req.Force, req.DryRun)
 	if err != nil {
-		s.writeError(w, http.StatusConflict, err.Error())
+		status := http.StatusConflict
+		if isHuntNoSuchRun(err) {
+			status = http.StatusNotFound
+		}
+		s.writeError(w, status, err.Error())
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "dry_run": req.DryRun, "changes": changes})
+}
+
+// huntRunID parses the optional {id} path value; empty ⇒ 0 (current). ok=false
+// for a non-numeric id so the handler can return 400.
+func huntRunID(r *http.Request) (int, bool) {
+	raw := r.PathValue("id")
+	if raw == "" {
+		return 0, true
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n < 0 {
+		return 0, false
+	}
+	return n, true
 }
 
 func contentTypeForExport(format string) string {
@@ -125,6 +157,10 @@ func isHuntConflict(err error) bool {
 
 func isHuntBadFormat(err error) bool {
 	return err != nil && containsAny(err.Error(), "unknown export format", "unknown format")
+}
+
+func isHuntNoSuchRun(err error) bool {
+	return err != nil && containsAny(err.Error(), "no such run")
 }
 
 func containsAny(s string, subs ...string) bool {

--- a/internal/api/handlers_hunt_test.go
+++ b/internal/api/handlers_hunt_test.go
@@ -23,6 +23,7 @@ type fakeHuntCockpit struct {
 
 	lastStart  HuntStartRequest
 	lastFormat string
+	lastID     int
 }
 
 func (f *fakeHuntCockpit) Status() HuntStatus { return f.status }
@@ -31,11 +32,13 @@ func (f *fakeHuntCockpit) Start(req HuntStartRequest) (int, error) {
 	return f.startID, f.startErr
 }
 func (f *fakeHuntCockpit) Stop() bool { return f.stopped }
-func (f *fakeHuntCockpit) Export(format string) ([]byte, string, error) {
+func (f *fakeHuntCockpit) Export(id int, format string) ([]byte, string, error) {
+	f.lastID = id
 	f.lastFormat = format
 	return f.exportData, f.exportName, f.exportErr
 }
-func (f *fakeHuntCockpit) Commit(force, dryRun bool) ([]string, error) {
+func (f *fakeHuntCockpit) Commit(id int, force, dryRun bool) ([]string, error) {
+	f.lastID = id
 	return f.commitChg, f.commitErr
 }
 
@@ -161,6 +164,57 @@ func TestHuntExport_StreamsBytes(t *testing.T) {
 	}
 	if cock.lastFormat != "bundle" {
 		t.Errorf("format=%q", cock.lastFormat)
+	}
+}
+
+func TestHuntExport_ByRunID(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	cock := &fakeHuntCockpit{exportData: []byte("x"), exportName: "sys.csv"}
+	base, teardown := mkServer(t, ServerOptions{Bus: bus, Hunt: cock})
+	defer teardown()
+	resp, err := http.Get(base + "/api/v1/hunt/7/export?format=rr")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("status=%d", resp.StatusCode)
+	}
+	if cock.lastID != 7 || cock.lastFormat != "rr" {
+		t.Errorf("forwarded id=%d format=%q, want 7/rr", cock.lastID, cock.lastFormat)
+	}
+}
+
+func TestHuntExport_UnknownRunID404(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	cock := &fakeHuntCockpit{exportErr: errors.New("hunt: no such run id")}
+	base, teardown := mkServer(t, ServerOptions{Bus: bus, Hunt: cock})
+	defer teardown()
+	resp, err := http.Get(base + "/api/v1/hunt/999/export")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("status=%d, want 404", resp.StatusCode)
+	}
+}
+
+func TestHuntExport_BadRunID400(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	cock := &fakeHuntCockpit{exportData: []byte("x"), exportName: "s.csv"}
+	base, teardown := mkServer(t, ServerOptions{Bus: bus, Hunt: cock})
+	defer teardown()
+	resp, err := http.Get(base + "/api/v1/hunt/abc/export")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status=%d, want 400", resp.StatusCode)
 	}
 }
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -111,12 +111,13 @@ type HuntCockpit interface {
 	Start(req HuntStartRequest) (runID int, err error)
 	// Stop cancels the active run; false when nothing is running.
 	Stop() bool
-	// Export serializes the latest discovered system in the named format
+	// Export serializes a run's discovered system in the named format
 	// (bundle|trunk-recorder|rr), returning the bytes + a suggested filename.
-	Export(format string) (data []byte, filename string, err error)
-	// Commit merges the latest discovered system into config.yaml, returning a
-	// human-readable list of changes.
-	Commit(force, dryRun bool) (changes []string, err error)
+	// id 0 = the latest run. Returns ErrHuntNoSuchRun for an unknown id.
+	Export(id int, format string) (data []byte, filename string, err error)
+	// Commit merges a run's discovered system into config.yaml (id 0 = latest),
+	// returning a human-readable list of changes.
+	Commit(id int, force, dryRun bool) (changes []string, err error)
 }
 
 // ScannerCockpit is the API surface for the police-scanner subsystem:
@@ -881,7 +882,9 @@ func (s *Server) routes() *http.ServeMux {
 	mux.HandleFunc("POST /api/v1/hunt/start", s.gate(s.handleHuntStart))
 	mux.HandleFunc("POST /api/v1/hunt/stop", s.gate(s.handleHuntStop))
 	mux.HandleFunc("GET /api/v1/hunt/export", s.handleHuntExport)
+	mux.HandleFunc("GET /api/v1/hunt/{id}/export", s.handleHuntExport)
 	mux.HandleFunc("POST /api/v1/hunt/commit", s.gate(s.handleHuntCommit))
+	mux.HandleFunc("POST /api/v1/hunt/{id}/commit", s.gate(s.handleHuntCommit))
 
 	mux.HandleFunc("GET /api/v1/scanner", s.handleScannerStatus)
 	mux.HandleFunc("PATCH /api/v1/scanner", s.gate(s.handleScannerSetMode))

--- a/internal/hunt/livehunt.go
+++ b/internal/hunt/livehunt.go
@@ -40,6 +40,11 @@ type LiveHuntOptions struct {
 	Candidates []uint32
 	// Protocol forces a decoder; trunking.ProtocolUnknown auto-identifies.
 	Protocol trunking.Protocol
+	// Serial requests a specific SDR for the run. Empty ⇒ the daemon
+	// auto-selects (spare SDR, else borrow the control SDR). Consumed by the
+	// daemon Acquirer; RunLiveHunt itself ignores it (the IQSource is already
+	// resolved by the time RunLiveHunt runs).
+	Serial string
 
 	FFTSize    int
 	SweepDwell time.Duration

--- a/internal/hunt/manager.go
+++ b/internal/hunt/manager.go
@@ -59,7 +59,27 @@ type Manager struct {
 	startedAt  time.Time
 	finishedAt time.Time
 	cancel     context.CancelFunc
+
+	// history retains the last maxRunHistory finished runs that produced a
+	// system, keyed implicitly by id, so /api/v1/hunt/{id}/export|commit can
+	// reach a prior run after a newer one starts.
+	history []runRecord
 }
+
+// maxRunHistory bounds the retained finished-run records.
+const maxRunHistory = 10
+
+// runRecord is one finished run's discovered system + reports, kept in the
+// Manager's bounded history.
+type runRecord struct {
+	id      int
+	sys     *DiscoveredSystem
+	reports []CaptureReport
+}
+
+// ErrNoSuchRun is returned by id-addressed lookups when the run id is unknown
+// or has been evicted from the bounded history.
+var ErrNoSuchRun = errors.New("hunt: no such run id")
 
 // NewManager builds a Manager. Acquire is required.
 func NewManager(opts ManagerOptions) (*Manager, error) {
@@ -156,6 +176,11 @@ func (m *Manager) finish(id int, sys *DiscoveredSystem, reports []CaptureReport,
 	if sys != nil {
 		m.sys = sys
 		m.reports = reports
+		// Retain in the bounded history (newest last; drop oldest over cap).
+		m.history = append(m.history, runRecord{id: id, sys: sys, reports: reports})
+		if len(m.history) > maxRunHistory {
+			m.history = m.history[len(m.history)-maxRunHistory:]
+		}
 	}
 	st := m.statusLocked()
 	m.mu.Unlock()
@@ -212,11 +237,60 @@ func (m *Manager) Current() (*DiscoveredSystem, []CaptureReport, bool) {
 	return m.sys, m.reports, true
 }
 
+// Run returns a specific run's discovered system + reports. id 0 means the
+// latest (same as Current). Returns ok=false for an unknown/evicted id, or for
+// a run that produced no system.
+func (m *Manager) Run(id int) (*DiscoveredSystem, []CaptureReport, bool) {
+	if id == 0 {
+		return m.Current()
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	// The live current run may not be in history yet (still in flight, or it's
+	// the most recent finished one) — check it first.
+	if id == m.runID && m.sys != nil {
+		return m.sys, m.reports, true
+	}
+	for i := len(m.history) - 1; i >= 0; i-- {
+		if m.history[i].id == id {
+			return m.history[i].sys, m.history[i].reports, true
+		}
+	}
+	return nil, nil, false
+}
+
+// KnownRun reports whether id refers to any run the Manager has seen (active or
+// in history), so callers can distinguish "unknown id" (404) from "run exists
+// but produced nothing" (409).
+func (m *Manager) KnownRun(id int) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if id == 0 || id == m.runID {
+		return m.runID > 0
+	}
+	for _, r := range m.history {
+		if r.id == id {
+			return true
+		}
+	}
+	return false
+}
+
 // Export writes the latest discovered system to w in the given format. Returns
 // an error when no system has been discovered yet.
 func (m *Manager) Export(w io.Writer, f Format, hints []DuplicateHint) error {
-	sys, _, ok := m.Current()
+	return m.ExportRun(0, w, f, hints)
+}
+
+// ExportRun writes a specific run's discovered system (id 0 = latest). Returns
+// ErrNoSuchRun for an unknown/evicted id, or a "no system" error when the run
+// exists but produced nothing.
+func (m *Manager) ExportRun(id int, w io.Writer, f Format, hints []DuplicateHint) error {
+	sys, _, ok := m.Run(id)
 	if !ok {
+		if id != 0 && !m.KnownRun(id) {
+			return ErrNoSuchRun
+		}
 		return errors.New("hunt: no discovered system to export yet")
 	}
 	return Write(w, sys, f, hints)

--- a/internal/hunt/manager.go
+++ b/internal/hunt/manager.go
@@ -27,7 +27,10 @@ const (
 // control-channel hunter, close the SDR subscription, …). The daemon supplies
 // this so the hunt package stays free of SDR/pool dependencies; release is
 // invoked exactly once when the run ends (success, error, or stop).
-type Acquirer func(ctx context.Context) (src IQSource, release func(), err error)
+// Acquirer obtains an IQSource for one run plus a release callback. opts
+// carries the run's parameters — notably opts.Serial, so the daemon can honor
+// an operator-requested SDR — and is passed by the Manager when a run starts.
+type Acquirer func(ctx context.Context, opts LiveHuntOptions) (src IQSource, release func(), err error)
 
 // ManagerOptions configure a Manager.
 type ManagerOptions struct {
@@ -120,7 +123,7 @@ func (m *Manager) Start(opts LiveHuntOptions) (int, error) {
 }
 
 func (m *Manager) run(ctx context.Context, id int, opts LiveHuntOptions) {
-	src, release, err := m.acquire(ctx)
+	src, release, err := m.acquire(ctx, opts)
 	if err != nil {
 		m.finish(id, nil, nil, fmt.Errorf("acquire SDR: %w", err))
 		return

--- a/internal/hunt/manager_test.go
+++ b/internal/hunt/manager_test.go
@@ -45,7 +45,7 @@ func TestManager_StartRunsAndMapsSystem(t *testing.T) {
 
 	src, dwell := p25Source(t)
 	mgr, err := NewManager(ManagerOptions{
-		Acquire: func(context.Context) (IQSource, func(), error) { return src, func() {}, nil },
+		Acquire: func(context.Context, LiveHuntOptions) (IQSource, func(), error) { return src, func() {}, nil },
 		Bus:     bus,
 	})
 	if err != nil {
@@ -109,7 +109,7 @@ func TestManager_StartRunsAndMapsSystem(t *testing.T) {
 
 func TestManager_AcquireErrorFailsRun(t *testing.T) {
 	mgr, err := NewManager(ManagerOptions{
-		Acquire: func(context.Context) (IQSource, func(), error) {
+		Acquire: func(context.Context, LiveHuntOptions) (IQSource, func(), error) {
 			return nil, nil, errors.New("no spare SDR")
 		},
 	})
@@ -131,7 +131,7 @@ func TestManager_AcquireErrorFailsRun(t *testing.T) {
 
 func TestManager_StopIdleReturnsFalse(t *testing.T) {
 	mgr, _ := NewManager(ManagerOptions{
-		Acquire: func(context.Context) (IQSource, func(), error) { return nil, nil, errors.New("x") },
+		Acquire: func(context.Context, LiveHuntOptions) (IQSource, func(), error) { return nil, nil, errors.New("x") },
 	})
 	if mgr.Stop() {
 		t.Error("Stop() on an idle manager should return false")
@@ -144,12 +144,38 @@ func TestNewManager_RequiresAcquirer(t *testing.T) {
 	}
 }
 
+// TestManager_PassesOptionsToAcquirer confirms the run's options (notably the
+// requested SDR serial) reach the Acquirer, so the daemon can honor it.
+func TestManager_PassesOptionsToAcquirer(t *testing.T) {
+	src, dwell := p25Source(t)
+	gotSerial := make(chan string, 1)
+	mgr, _ := NewManager(ManagerOptions{
+		Acquire: func(_ context.Context, opts LiveHuntOptions) (IQSource, func(), error) {
+			gotSerial <- opts.Serial
+			return src, func() {}, nil
+		},
+	})
+	if _, err := mgr.Start(LiveHuntOptions{
+		Candidates: []uint32{851_000_000}, DwellSeconds: dwell, MinConfidence: 0.3, Serial: "dongle-7",
+	}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	select {
+	case s := <-gotSerial:
+		if s != "dongle-7" {
+			t.Errorf("Acquirer saw serial %q, want dongle-7", s)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Acquirer was not called")
+	}
+}
+
 // release must run on completion so a borrowed SDR is always returned.
 func TestManager_ReleaseRunsOnCompletion(t *testing.T) {
 	src, dwell := p25Source(t)
 	released := make(chan struct{})
 	mgr, _ := NewManager(ManagerOptions{
-		Acquire: func(context.Context) (IQSource, func(), error) {
+		Acquire: func(context.Context, LiveHuntOptions) (IQSource, func(), error) {
 			return src, func() { close(released) }, nil
 		},
 	})

--- a/internal/hunt/manager_test.go
+++ b/internal/hunt/manager_test.go
@@ -3,6 +3,7 @@ package hunt
 import (
 	"context"
 	"errors"
+	"io"
 	"testing"
 	"time"
 
@@ -167,6 +168,46 @@ func TestManager_PassesOptionsToAcquirer(t *testing.T) {
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("Acquirer was not called")
+	}
+}
+
+// TestManager_RunHistoryAndExportRun covers the bounded run history: a finished
+// run is reachable by id, an unknown id yields ErrNoSuchRun, and the oldest is
+// evicted past the cap.
+func TestManager_RunHistoryAndExportRun(t *testing.T) {
+	src, dwell := p25Source(t)
+	mgr, _ := NewManager(ManagerOptions{
+		Acquire: func(context.Context, LiveHuntOptions) (IQSource, func(), error) {
+			return src, func() {}, nil
+		},
+	})
+	runOnce := func() int {
+		id, err := mgr.Start(LiveHuntOptions{Candidates: []uint32{851_000_000}, DwellSeconds: dwell, MinConfidence: 0.3})
+		if err != nil {
+			t.Fatalf("Start: %v", err)
+		}
+		waitUntil(t, 15*time.Second, func() bool { return !mgr.Status().Running })
+		return id
+	}
+
+	first := runOnce()
+	if _, _, ok := mgr.Run(first); !ok {
+		t.Fatalf("run %d not in history", first)
+	}
+	// Unknown id → ExportRun returns ErrNoSuchRun.
+	if err := mgr.ExportRun(99999, io.Discard, FormatBundle, nil); !errors.Is(err, ErrNoSuchRun) {
+		t.Errorf("ExportRun(unknown) = %v, want ErrNoSuchRun", err)
+	}
+	if err := mgr.ExportRun(first, io.Discard, FormatBundle, nil); err != nil {
+		t.Errorf("ExportRun(first) = %v, want nil", err)
+	}
+
+	// Exceed the cap → the first run is evicted.
+	for i := 0; i < maxRunHistory; i++ {
+		runOnce()
+	}
+	if mgr.KnownRun(first) {
+		t.Errorf("run %d should have been evicted past cap %d", first, maxRunHistory)
 	}
 }
 

--- a/internal/radio/dmr/tier3/control.go
+++ b/internal/radio/dmr/tier3/control.go
@@ -50,6 +50,10 @@ type ControlChannel struct {
 	locked           bool
 	last             LockState
 
+	// topo accumulates the system topology (identity + adjacent sites) for the
+	// hunt/discovery layer; read via Topology().
+	topo topologyModel
+
 	// restChannel tracks the LCN a Capacity Plus system currently
 	// advertises as its rest (control) channel. Zero until a
 	// Motorola vendor system-info CSBK has been seen.
@@ -134,10 +138,16 @@ func (c *ControlChannel) handleCSBK(cc uint8, csbk CSBK) {
 	}
 	switch csbk.Opcode {
 	case OpAloha:
-		c.maybeLock(LockState{FrequencyHz: c.freqHz, ColorCode: cc, SystemID: ParseAloha(csbk.Payload).SystemID})
+		sysID := ParseAloha(csbk.Payload).SystemID
+		c.topo.applyIdentity(sysID, cc)
+		c.maybeLock(LockState{FrequencyHz: c.freqHz, ColorCode: cc, SystemID: sysID})
 	case OpSysInfo:
 		si := ParseSystemInfoBroadcast(csbk.Payload)
+		c.topo.applySystemInfo(si)
+		c.topo.applyIdentity(si.SystemID, cc)
 		c.maybeLock(LockState{FrequencyHz: c.freqHz, ColorCode: cc, SystemID: si.SystemID})
+	case OpAdjStatus:
+		c.topo.applyAdjacent(ParseAdjacentSiteStatus(csbk.Payload))
 	case OpTVGrant:
 		c.publishTVGrant(cc, ParseTVGrant(csbk.Payload))
 	case OpPVGrant:
@@ -241,3 +251,8 @@ func (c *ControlChannel) MarkLost() {
 	c.locked = false
 	c.bus.Publish(events.Event{Kind: events.KindCCLost, Payload: c.last})
 }
+
+// Topology returns a snapshot of the system topology accumulated from the
+// site's Aloha / System-Info / Adjacent-Site CSBKs. Used by the signal-lab /
+// hunt layers to document a discovered DMR Tier III system.
+func (c *ControlChannel) Topology() TopologyConfig { return c.topo.snapshot() }

--- a/internal/radio/dmr/tier3/topology.go
+++ b/internal/radio/dmr/tier3/topology.go
@@ -1,0 +1,85 @@
+package tier3
+
+import "sync"
+
+// NeighborSite is one adjacent site advertised by an Adjacent Site Status CSBK
+// (0x38), de-duplicated by SiteID.
+type NeighborSite struct {
+	SystemID  uint16
+	SiteID    uint16
+	LCN       uint16
+	ColorCode uint8
+}
+
+// TopologyConfig is a snapshot of the system topology a DMR Tier III control
+// channel accumulates over a run: the camped site's identity and the adjacent
+// sites it advertised. It is mapped to the protocol-neutral
+// trunking.TopologySnapshot by the ccdecoder pipeline.
+type TopologyConfig struct {
+	SystemID  uint16
+	RFSS      uint8
+	Site      uint8
+	ColorCode uint8
+	Neighbors []NeighborSite
+}
+
+// topologyModel is the mutex-guarded accumulator behind TopologyConfig. The
+// control channel feeds it from the CSBK dispatch (decode goroutine); the
+// signal-lab snapshots it at EOF (engine goroutine), so access is locked. The
+// zero value is ready to use.
+type topologyModel struct {
+	mu  sync.Mutex
+	cfg TopologyConfig
+}
+
+// applySystemInfo folds a System Information Broadcast (0x39): the camped
+// site's SystemID/RFSS/Site. First non-zero values win.
+func (m *topologyModel) applySystemInfo(si SystemInfoBroadcast) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if si.SystemID != 0 {
+		m.cfg.SystemID = si.SystemID
+	}
+	if si.RFSSID != 0 {
+		m.cfg.RFSS = si.RFSSID
+	}
+	if si.SiteID != 0 {
+		m.cfg.Site = si.SiteID
+	}
+}
+
+// applyIdentity folds the SystemID + ColorCode seen on an Aloha / SysInfo CSBK.
+func (m *topologyModel) applyIdentity(systemID uint16, colorCode uint8) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.cfg.SystemID == 0 && systemID != 0 {
+		m.cfg.SystemID = systemID
+	}
+	if m.cfg.ColorCode == 0 && colorCode != 0 {
+		m.cfg.ColorCode = colorCode
+	}
+}
+
+// applyAdjacent folds an Adjacent Site Status CSBK (0x38), de-duplicating by
+// SiteID (last write wins for a given site's details).
+func (m *topologyModel) applyAdjacent(a AdjacentSiteStatus) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	n := NeighborSite{SystemID: a.SystemID, SiteID: a.SiteID, LCN: a.LCN, ColorCode: a.ColorCode}
+	for i := range m.cfg.Neighbors {
+		if m.cfg.Neighbors[i].SiteID == n.SiteID {
+			m.cfg.Neighbors[i] = n
+			return
+		}
+	}
+	m.cfg.Neighbors = append(m.cfg.Neighbors, n)
+}
+
+// snapshot returns a deep copy of the accumulated topology.
+func (m *topologyModel) snapshot() TopologyConfig {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := m.cfg
+	out.Neighbors = append([]NeighborSite(nil), m.cfg.Neighbors...)
+	return out
+}

--- a/internal/radio/dmr/tier3/topology_test.go
+++ b/internal/radio/dmr/tier3/topology_test.go
@@ -1,0 +1,49 @@
+package tier3
+
+import (
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+)
+
+func TestTopologyAccumulation(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	c := New(Options{Bus: bus, FrequencyHz: 851_000_000})
+
+	// System Information Broadcast (0x39): SystemID=0x1234, RFSS=5, Site=7.
+	c.handleCSBK(3, CSBK{Opcode: OpSysInfo, Payload: [8]byte{0x12, 0x34, 0x05, 0x07}})
+	// Two adjacent sites (0x38); the second repeats site 3 → de-duped.
+	c.handleCSBK(3, CSBK{Opcode: OpAdjStatus, Payload: [8]byte{0x12, 0x34, 0x00, 0x03, 0x00, 0x09, 0x10}})
+	c.handleCSBK(3, CSBK{Opcode: OpAdjStatus, Payload: [8]byte{0x12, 0x34, 0x00, 0x04, 0x00, 0x0A, 0x10}})
+	c.handleCSBK(3, CSBK{Opcode: OpAdjStatus, Payload: [8]byte{0x12, 0x34, 0x00, 0x03, 0x00, 0x09, 0x10}})
+
+	topo := c.Topology()
+	if topo.SystemID != 0x1234 {
+		t.Errorf("SystemID = %X, want 1234", topo.SystemID)
+	}
+	if topo.RFSS != 5 || topo.Site != 7 {
+		t.Errorf("RFSS/Site = %d/%d, want 5/7", topo.RFSS, topo.Site)
+	}
+	if topo.ColorCode != 3 {
+		t.Errorf("ColorCode = %d, want 3", topo.ColorCode)
+	}
+	if len(topo.Neighbors) != 2 {
+		t.Fatalf("neighbors = %d, want 2 (deduped): %+v", len(topo.Neighbors), topo.Neighbors)
+	}
+	if topo.Neighbors[0].SiteID != 3 || topo.Neighbors[0].LCN != 9 {
+		t.Errorf("neighbor[0] = %+v, want site 3 LCN 9", topo.Neighbors[0])
+	}
+}
+
+func TestTopologyIdentityFirstWins(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	c := New(Options{Bus: bus})
+	// Aloha sets SystemID + ColorCode first; a later SysInfo with SystemID 0
+	// must not clobber the identity.
+	c.handleCSBK(7, CSBK{Opcode: OpAloha, Payload: [8]byte{0x00, 0x00, 0xAB, 0xCD}})
+	if got := c.Topology(); got.SystemID != 0xABCD || got.ColorCode != 7 {
+		t.Errorf("after Aloha: %+v, want SystemID ABCD ColorCode 7", got)
+	}
+}

--- a/internal/radio/edacs/control.go
+++ b/internal/radio/edacs/control.go
@@ -41,6 +41,9 @@ type ControlChannel struct {
 	resolver   Resolver
 	now        func() time.Time
 
+	// topo accumulates system identity + adjacent sites for the hunt layer.
+	topo topologyModel
+
 	// proc is the cross-call bit / sync state the Process adapter
 	// uses (see process.go). Lazily constructed on the first
 	// Process call.
@@ -185,7 +188,12 @@ func (c *ControlChannel) Ingest(w CCW) {
 		return
 	}
 	if sys, ok := w.AsSystemID(); ok {
+		c.topo.applySystemID(sys.ID)
 		c.maybeLock(LockState{FrequencyHz: c.freqHz, SystemID: sys.ID})
+		return
+	}
+	if adj, ok := w.AsAdjacentSite(); ok {
+		c.topo.applyAdjacent(adj)
 		return
 	}
 	if grant, ok := w.AsGroupVoiceGrant(); ok {
@@ -193,6 +201,10 @@ func (c *ControlChannel) Ingest(w CCW) {
 		return
 	}
 }
+
+// Topology returns a snapshot of the system topology (identity + adjacent
+// sites) accumulated from the control channel, for the hunt/discovery layer.
+func (c *ControlChannel) Topology() TopologyConfig { return c.topo.snapshot() }
 
 func (c *ControlChannel) publishGrant(g GroupVoiceGrant) {
 	if c.bus == nil {

--- a/internal/radio/edacs/topology.go
+++ b/internal/radio/edacs/topology.go
@@ -1,0 +1,57 @@
+package edacs
+
+import "sync"
+
+// NeighborSite is one adjacent site advertised by a CmdAdjacentSite CCW,
+// de-duplicated by SiteID.
+type NeighborSite struct {
+	SiteID uint16
+	LCN    uint8
+}
+
+// TopologyConfig is a snapshot of the EDACS system topology accumulated over a
+// run: the opaque system identifier and the adjacent sites it advertised.
+// EDACS has no RFSS concept, so only SystemID + neighbors are populated.
+type TopologyConfig struct {
+	SystemID  uint16
+	Neighbors []NeighborSite
+}
+
+// topologyModel is the mutex-guarded accumulator behind TopologyConfig — fed
+// from Ingest (decode goroutine), snapshotted at EOF (engine goroutine).
+type topologyModel struct {
+	mu  sync.Mutex
+	cfg TopologyConfig
+}
+
+// applySystemID records the system identifier (first non-zero wins).
+func (m *topologyModel) applySystemID(id uint16) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.cfg.SystemID == 0 && id != 0 {
+		m.cfg.SystemID = id
+	}
+}
+
+// applyAdjacent folds an adjacent-site announcement, de-duplicating by SiteID.
+func (m *topologyModel) applyAdjacent(a AdjacentSite) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	n := NeighborSite{SiteID: a.SiteID, LCN: a.LCN}
+	for i := range m.cfg.Neighbors {
+		if m.cfg.Neighbors[i].SiteID == n.SiteID {
+			m.cfg.Neighbors[i] = n
+			return
+		}
+	}
+	m.cfg.Neighbors = append(m.cfg.Neighbors, n)
+}
+
+// snapshot returns a deep copy of the accumulated topology.
+func (m *topologyModel) snapshot() TopologyConfig {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := m.cfg
+	out.Neighbors = append([]NeighborSite(nil), m.cfg.Neighbors...)
+	return out
+}

--- a/internal/radio/edacs/topology_test.go
+++ b/internal/radio/edacs/topology_test.go
@@ -1,0 +1,29 @@
+package edacs
+
+import (
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+)
+
+func TestTopologyAccumulation(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	c := New(Options{Bus: bus, FrequencyHz: 851_000_000})
+
+	c.Ingest(CCW{Command: CmdSystemID, Address: 0x2A})
+	c.Ingest(CCW{Command: CmdAdjacentSite, Address: 11, LCN: 4})
+	c.Ingest(CCW{Command: CmdAdjacentSite, Address: 12, LCN: 5})
+	c.Ingest(CCW{Command: CmdAdjacentSite, Address: 11, LCN: 4}) // dup → deduped
+
+	topo := c.Topology()
+	if topo.SystemID != 0x2A {
+		t.Errorf("SystemID = %X, want 2A", topo.SystemID)
+	}
+	if len(topo.Neighbors) != 2 {
+		t.Fatalf("neighbors = %d, want 2: %+v", len(topo.Neighbors), topo.Neighbors)
+	}
+	if topo.Neighbors[0].SiteID != 11 || topo.Neighbors[0].LCN != 4 {
+		t.Errorf("neighbor[0] = %+v, want site 11 LCN 4", topo.Neighbors[0])
+	}
+}

--- a/internal/radio/motorola/control.go
+++ b/internal/radio/motorola/control.go
@@ -45,6 +45,9 @@ type ControlChannel struct {
 	resolver   Resolver
 	now        func() time.Time
 
+	// topo accumulates system identity + adjacent sites for the hunt layer.
+	topo topologyModel
+
 	// proc is the cross-call bit / sync state the Process adapter
 	// uses (see process.go). Lazily constructed on the first
 	// Process call.
@@ -124,7 +127,12 @@ func (c *ControlChannel) Ingest(o OSW) {
 	}
 
 	if sys, ok := o.AsSystemID(); ok {
+		c.topo.applySystemID(sys.ID)
 		c.maybeLock(LockState{FrequencyHz: c.freqHz, SystemID: sys.ID})
+		return
+	}
+	if adj, ok := o.AsAdjacentSite(); ok {
+		c.topo.applyAdjacent(adj)
 		return
 	}
 	if grant, ok := o.AsGroupVoiceChannelGrant(); ok {
@@ -132,6 +140,10 @@ func (c *ControlChannel) Ingest(o OSW) {
 		return
 	}
 }
+
+// Topology returns a snapshot of the system topology (identity + adjacent
+// sites) accumulated from the control channel, for the hunt/discovery layer.
+func (c *ControlChannel) Topology() TopologyConfig { return c.topo.snapshot() }
 
 func (c *ControlChannel) publishGrant(g GroupVoiceChannelGrant) {
 	if c.bus == nil {

--- a/internal/radio/motorola/topology.go
+++ b/internal/radio/motorola/topology.go
@@ -1,0 +1,57 @@
+package motorola
+
+import "sync"
+
+// NeighborSite is one adjacent site advertised by an Adjacent Site Status OSW,
+// de-duplicated by SiteID.
+type NeighborSite struct {
+	SiteID uint16
+	LCN    uint16
+}
+
+// TopologyConfig is a snapshot of the Motorola Type II / SmartZone system
+// topology accumulated over a run: the opaque system identifier and the
+// adjacent sites it advertised. Motorola has no RFSS concept.
+type TopologyConfig struct {
+	SystemID  uint16
+	Neighbors []NeighborSite
+}
+
+// topologyModel is the mutex-guarded accumulator behind TopologyConfig — fed
+// from Ingest (decode goroutine), snapshotted at EOF (engine goroutine).
+type topologyModel struct {
+	mu  sync.Mutex
+	cfg TopologyConfig
+}
+
+// applySystemID records the system identifier (first non-zero wins).
+func (m *topologyModel) applySystemID(id uint16) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.cfg.SystemID == 0 && id != 0 {
+		m.cfg.SystemID = id
+	}
+}
+
+// applyAdjacent folds an adjacent-site announcement, de-duplicating by SiteID.
+func (m *topologyModel) applyAdjacent(a AdjacentSite) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	n := NeighborSite{SiteID: a.SiteID, LCN: a.LCN}
+	for i := range m.cfg.Neighbors {
+		if m.cfg.Neighbors[i].SiteID == n.SiteID {
+			m.cfg.Neighbors[i] = n
+			return
+		}
+	}
+	m.cfg.Neighbors = append(m.cfg.Neighbors, n)
+}
+
+// snapshot returns a deep copy of the accumulated topology.
+func (m *topologyModel) snapshot() TopologyConfig {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := m.cfg
+	out.Neighbors = append([]NeighborSite(nil), m.cfg.Neighbors...)
+	return out
+}

--- a/internal/radio/motorola/topology_test.go
+++ b/internal/radio/motorola/topology_test.go
@@ -1,0 +1,31 @@
+package motorola
+
+import (
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+)
+
+func TestTopologyAccumulation(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	c := New(Options{Bus: bus, FrequencyHz: 851_000_000})
+
+	// System ID Extended (opcode 0x080 = Command>>4): ID 0x2A.
+	c.Ingest(OSW{Address: 0x2A, Command: 0x0800})
+	// Adjacent Site Status (opcode 0x31B): site/LCN in Address/LCN nibble.
+	c.Ingest(OSW{Address: 11, Command: 0x31B4})
+	c.Ingest(OSW{Address: 12, Command: 0x31B5})
+	c.Ingest(OSW{Address: 11, Command: 0x31B4}) // dup → deduped
+
+	topo := c.Topology()
+	if topo.SystemID != 0x2A {
+		t.Errorf("SystemID = %X, want 2A", topo.SystemID)
+	}
+	if len(topo.Neighbors) != 2 {
+		t.Fatalf("neighbors = %d, want 2: %+v", len(topo.Neighbors), topo.Neighbors)
+	}
+	if topo.Neighbors[0].SiteID != 11 || topo.Neighbors[0].LCN != 4 {
+		t.Errorf("neighbor[0] = %+v, want site 11 LCN 4", topo.Neighbors[0])
+	}
+}

--- a/internal/radio/nxdn/control.go
+++ b/internal/radio/nxdn/control.go
@@ -44,6 +44,7 @@ type ControlChannel struct {
 	rate   BaudRate
 	locked bool
 	last   LockState
+	topo   topologyModel
 
 	// proc is the cross-call dibit / sync state the Process
 	// adapter uses (see process.go). Lazily constructed on the
@@ -163,6 +164,7 @@ func (c *ControlChannel) IngestFrame(lich LICH, cac *CACMessage) {
 	switch cac.Type {
 	case RCCHSITEINFO:
 		s := ParseSiteInfo(cac.Payload)
+		c.topo.applySiteInfo(s.SystemID, s.SiteID, s.LocationID)
 		c.maybeLock(LockState{FrequencyHz: c.freqHz, BaudRate: c.rate, SiteID: s.SiteID, SystemID: s.SystemID})
 	case RCCHCCH:
 		c.maybeLock(LockState{FrequencyHz: c.freqHz, BaudRate: c.rate})
@@ -177,6 +179,9 @@ func (c *ControlChannel) maybeLock(s LockState) {
 		c.log.Info("nxdn cc locked", "freq", s.FrequencyHz, "rate", s.BaudRate.String(), "site", s.SiteID, "sys", s.SystemID)
 	}
 }
+
+// Topology returns the accumulated single-site identity for the hunt layer.
+func (c *ControlChannel) Topology() TopologyConfig { return c.topo.snapshot() }
 
 // MarkLost publishes cc.lost and resets the locked flag.
 func (c *ControlChannel) MarkLost() {

--- a/internal/radio/nxdn/topology.go
+++ b/internal/radio/nxdn/topology.go
@@ -1,0 +1,39 @@
+package nxdn
+
+import "sync"
+
+// TopologyConfig is a snapshot of the NXDN single-site identity accumulated
+// from RCCH Site Information. NXDN doesn't broadcast adjacent sites in a form
+// this decoder accumulates, so only identity is surfaced.
+type TopologyConfig struct {
+	SystemID   uint16
+	SiteID     uint16
+	LocationID uint16
+}
+
+// topologyModel is the mutex-guarded accumulator behind TopologyConfig.
+type topologyModel struct {
+	mu  sync.Mutex
+	cfg TopologyConfig
+}
+
+// applySiteInfo records the site identity (first non-zero of each field wins).
+func (m *topologyModel) applySiteInfo(systemID, siteID, locationID uint16) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.cfg.SystemID == 0 && systemID != 0 {
+		m.cfg.SystemID = systemID
+	}
+	if m.cfg.SiteID == 0 && siteID != 0 {
+		m.cfg.SiteID = siteID
+	}
+	if m.cfg.LocationID == 0 && locationID != 0 {
+		m.cfg.LocationID = locationID
+	}
+}
+
+func (m *topologyModel) snapshot() TopologyConfig {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.cfg
+}

--- a/internal/radio/nxdn/topology_test.go
+++ b/internal/radio/nxdn/topology_test.go
@@ -1,0 +1,25 @@
+package nxdn
+
+import (
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+)
+
+func TestTopologyFromSiteInfo(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	c := NewControlChannel(bus, nil, 851_000_000, Rate9600)
+
+	// SITE_INFO payload: LocationID=p[0:2], SiteID=p[2:4], SystemID=p[4:6].
+	var p [8]byte
+	p[0], p[1] = 0x00, 0x2A // LocationID 42
+	p[2], p[3] = 0x00, 0x05 // SiteID 5
+	p[4], p[5] = 0x12, 0x34 // SystemID 0x1234
+	c.IngestFrame(LICH{RFCh: RFChControl, ParityOK: true}, &CACMessage{Type: RCCHSITEINFO, Payload: p})
+
+	topo := c.Topology()
+	if topo.SystemID != 0x1234 || topo.SiteID != 5 || topo.LocationID != 42 {
+		t.Errorf("topology = %+v, want SystemID 1234 Site 5 Location 42", topo)
+	}
+}

--- a/internal/radio/tetra/control.go
+++ b/internal/radio/tetra/control.go
@@ -225,6 +225,29 @@ func (c *ControlChannel) ColourCode() uint32 {
 	return c.colourCode
 }
 
+// TopologyConfig is a snapshot of the TETRA single-cell identity for the hunt
+// layer: the MCC/MNC/Location Area learned from MLE-SYSINFO plus the colour
+// code. Neighbor-cell broadcasts are not accumulated, so identity only.
+type TopologyConfig struct {
+	MCC          uint16
+	MNC          uint16
+	LocationArea uint16
+	ColourCode   uint32
+}
+
+// Topology returns the accumulated single-cell identity. Safe for concurrent
+// use (reads the lock state + colour code under the control-channel mutex).
+func (c *ControlChannel) Topology() TopologyConfig {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return TopologyConfig{
+		MCC:          c.last.MCC,
+		MNC:          c.last.MNC,
+		LocationArea: c.last.LocationArea,
+		ColourCode:   c.colourCode,
+	}
+}
+
 // Options configure a ControlChannel.
 type Options struct {
 	Bus         *events.Bus

--- a/internal/radio/tetra/topology_test.go
+++ b/internal/radio/tetra/topology_test.go
@@ -1,0 +1,31 @@
+package tetra
+
+import (
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+)
+
+func TestTopologyFromSystemBroadcast(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	c := New(Options{Bus: bus, FrequencyHz: 390_000_000})
+	c.SetColourCode(7)
+
+	// MLE SYSINFO payload: 10b MCC + 14b MNC + 14b LA. This encodes
+	// MCC=3, MNC=5, LocationArea=64 (see AsSystemBroadcast bit layout).
+	pdu := PDU{
+		Disc:    DiscMLE,
+		Type:    uint8(MLESystemInfo),
+		Payload: []byte{0x00, 0xC0, 0x05, 0x01, 0x00},
+	}
+	c.Ingest(pdu)
+
+	topo := c.Topology()
+	if topo.MCC != 3 || topo.MNC != 5 || topo.LocationArea != 64 {
+		t.Errorf("topology = %+v, want MCC 3 MNC 5 LA 64", topo)
+	}
+	if topo.ColourCode != 7 {
+		t.Errorf("ColourCode = %d, want 7", topo.ColourCode)
+	}
+}

--- a/internal/scanner/ccdecoder/pipelines.go
+++ b/internal/scanner/ccdecoder/pipelines.go
@@ -540,6 +540,18 @@ func (p *tetraPipeline) Process(iq []complex64) { p.rx.Process(iq) }
 func (p *tetraPipeline) Reset()                 { p.rx.Reset() }
 func (p *tetraPipeline) Close() error           { return nil }
 
+// TopologySnapshot surfaces the TETRA single-cell identity (MCC/MNC/LA + colour
+// code) the control channel learned. No adjacent cells for TETRA.
+func (p *tetraPipeline) TopologySnapshot() *trunking.TopologySnapshot {
+	t := p.cc.Topology()
+	return &trunking.TopologySnapshot{
+		MCC:          t.MCC,
+		MNC:          t.MNC,
+		LocationArea: t.LocationArea,
+		ColorCode:    uint8(t.ColourCode & 0xFF),
+	}
+}
+
 // newYSFPipeline wires the existing internal/radio/ysf/receiver
 // into ysf.ControlChannel.Process. YSF is the System Fusion
 // (Yaesu) C4FM amateur trunked variant — same 4800-baud
@@ -828,6 +840,17 @@ type nxdnPipeline struct {
 func (p *nxdnPipeline) Process(iq []complex64) { p.rx.Process(iq) }
 func (p *nxdnPipeline) Reset()                 { p.rx.Reset() }
 func (p *nxdnPipeline) Close() error           { return nil }
+
+// TopologySnapshot surfaces the NXDN single-site identity (System/Site/Location)
+// the control channel accumulated. No adjacent sites for NXDN.
+func (p *nxdnPipeline) TopologySnapshot() *trunking.TopologySnapshot {
+	t := p.cc.Topology()
+	return &trunking.TopologySnapshot{
+		SystemID:     uint32(t.SystemID),
+		Site:         uint8(t.SiteID),
+		LocationArea: t.LocationID,
+	}
+}
 
 // newEDACSPipeline wires internal/radio/edacs/receiver into
 // edacs.ControlChannel.Process. The receiver's BitSink forwards

--- a/internal/scanner/ccdecoder/pipelines.go
+++ b/internal/scanner/ccdecoder/pipelines.go
@@ -666,6 +666,26 @@ func (p *dmrPipeline) Process(iq []complex64) { p.rx.Process(iq) }
 func (p *dmrPipeline) Reset()                 { p.rx.Reset() }
 func (p *dmrPipeline) Close() error           { return nil }
 
+// TopologySnapshot surfaces the DMR Tier III system topology (identity +
+// adjacent sites) the control channel accumulated, mapped to the neutral
+// trunking shape so the signal-lab engine attaches it to the decode Result.
+func (p *dmrPipeline) TopologySnapshot() *trunking.TopologySnapshot {
+	t := p.cc.Topology()
+	snap := &trunking.TopologySnapshot{
+		SystemID:  uint32(t.SystemID),
+		RFSS:      t.RFSS,
+		Site:      t.Site,
+		ColorCode: t.ColorCode,
+	}
+	for _, n := range t.Neighbors {
+		snap.Neighbors = append(snap.Neighbors, trunking.TopoNeighborRef{
+			Site:          uint8(n.SiteID),
+			ChannelNumber: n.LCN,
+		})
+	}
+	return snap
+}
+
 // newDMRTier2Pipeline wires internal/radio/dmr/receiver into
 // dmr/tier2.ConventionalChannel.Process. DMR Tier II is conventional
 // (per-repeater) rather than trunked — there's no dedicated control

--- a/internal/scanner/ccdecoder/pipelines.go
+++ b/internal/scanner/ccdecoder/pipelines.go
@@ -868,6 +868,20 @@ func (p *edacsPipeline) Process(iq []complex64) { p.rx.Process(iq) }
 func (p *edacsPipeline) Reset()                 { p.rx.Reset() }
 func (p *edacsPipeline) Close() error           { return nil }
 
+// TopologySnapshot surfaces the EDACS system identity + adjacent sites the
+// control channel accumulated. EDACS has no RFSS; only SystemID + neighbors.
+func (p *edacsPipeline) TopologySnapshot() *trunking.TopologySnapshot {
+	t := p.cc.Topology()
+	snap := &trunking.TopologySnapshot{SystemID: uint32(t.SystemID)}
+	for _, n := range t.Neighbors {
+		snap.Neighbors = append(snap.Neighbors, trunking.TopoNeighborRef{
+			Site:          uint8(n.SiteID),
+			ChannelNumber: uint16(n.LCN),
+		})
+	}
+	return snap
+}
+
 // newMotorolaPipeline wires internal/radio/motorola/receiver into
 // motorola.ControlChannel.Process. The receiver's BitSink forwards
 // bits + baseIdx into the state machine (24-bit sync detect →

--- a/internal/scanner/ccdecoder/pipelines.go
+++ b/internal/scanner/ccdecoder/pipelines.go
@@ -927,6 +927,20 @@ func (p *motorolaPipeline) Process(iq []complex64) { p.rx.Process(iq) }
 func (p *motorolaPipeline) Reset()                 { p.rx.Reset() }
 func (p *motorolaPipeline) Close() error           { return nil }
 
+// TopologySnapshot surfaces the Motorola system identity + adjacent sites the
+// control channel accumulated. Motorola has no RFSS; only SystemID + neighbors.
+func (p *motorolaPipeline) TopologySnapshot() *trunking.TopologySnapshot {
+	t := p.cc.Topology()
+	snap := &trunking.TopologySnapshot{SystemID: uint32(t.SystemID)}
+	for _, n := range t.Neighbors {
+		snap.Neighbors = append(snap.Neighbors, trunking.TopoNeighborRef{
+			Site:          uint8(n.SiteID),
+			ChannelNumber: n.LCN,
+		})
+	}
+	return snap
+}
+
 // newLTRPipeline wires internal/radio/ltr/receiver into
 // ltr.ControlChannel.Process. The receiver's BitSink forwards
 // sub-audible bits into the state machine, which slides a 41-bit

--- a/internal/siglab/topology_test.go
+++ b/internal/siglab/topology_test.go
@@ -1,11 +1,49 @@
 package siglab
 
 import (
+	"bytes"
 	"testing"
 
 	p25phase1 "github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase1"
+	"github.com/MattCheramie/GopherTrunk/internal/scanner/ccdecoder"
 	"github.com/MattCheramie/GopherTrunk/internal/trunking"
 )
+
+// fakeTopoPipeline is a no-op pipeline that reports a fixed topology, used to
+// guard the generic factory path's pipe.(TopologyProvider) hook in engine.go
+// (the P25 path uses the deep-bundle closure instead).
+type fakeTopoPipeline struct{}
+
+func (fakeTopoPipeline) Process([]complex64) {}
+func (fakeTopoPipeline) Reset()              {}
+func (fakeTopoPipeline) Close() error        { return nil }
+func (fakeTopoPipeline) TopologySnapshot() *trunking.TopologySnapshot {
+	return &trunking.TopologySnapshot{SystemID: 0x49A, ColorCode: 5}
+}
+
+func TestGenericPipelineTopologyAttached(t *testing.T) {
+	restore := ccdecoder.SetTestFactory(trunking.ProtocolNXDN,
+		func(ccdecoder.PipelineOptions) (ccdecoder.ProtocolPipeline, error) {
+			return fakeTopoPipeline{}, nil
+		})
+	defer restore()
+
+	buf := EncodeCapture(make([]complex64, 4096), FormatF32)
+	res, err := RunReader(bytes.NewReader(buf), "fake", Config{
+		Protocol:     trunking.ProtocolNXDN,
+		SampleRateHz: 48_000,
+		Format:       FormatF32,
+	})
+	if err != nil {
+		t.Fatalf("RunReader: %v", err)
+	}
+	if res.Topology == nil {
+		t.Fatal("Result.Topology not attached from the generic TopologyProvider hook")
+	}
+	if res.Topology.SystemID != 0x49A || res.Topology.ColorCode != 5 {
+		t.Errorf("topology = %+v, want SystemID 49A ColorCode 5", res.Topology)
+	}
+}
 
 func TestP25TopologyMapping(t *testing.T) {
 	net := p25phase1.NetworkConfig{

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -704,6 +704,18 @@ func (m *Model) dispatchWrite(r state.WriteRequest) tea.Cmd {
 		return cmdScannerHuntRetune(m.cli, r.ScannerHunt.System, r.Label)
 	case state.WriteKindHuntStop:
 		return cmdHuntStop(m.cli, r.Label)
+	case state.WriteKindHuntStart:
+		if r.Hunt == nil {
+			return nil
+		}
+		return cmdHuntStart(m.cli, client.HuntStartRequest{
+			Bands:      r.Hunt.Bands,
+			Candidates: r.Hunt.Candidates,
+			NoSweep:    len(r.Hunt.Candidates) > 0 && len(r.Hunt.Bands) == 0,
+			Name:       r.Hunt.Name,
+			Serial:     r.Hunt.Serial,
+			Protocol:   r.Hunt.Protocol,
+		}, r.Label)
 	case state.WriteKindScannerConvHold:
 		return cmdScannerConvHold(m.cli, r.Label)
 	case state.WriteKindScannerConvResume:

--- a/internal/tui/client/write.go
+++ b/internal/tui/client/write.go
@@ -85,6 +85,22 @@ func (c *Client) ScannerSetMode(ctx context.Context, mode string) error {
 		map[string]string{"scan_mode": mode}, nil)
 }
 
+// HuntStartRequest is the POST /api/v1/hunt/start body the TUI sends. It
+// mirrors the subset of api.HuntStartRequest the panel collects.
+type HuntStartRequest struct {
+	Bands      []string  `json:"bands,omitempty"`
+	Candidates []float64 `json:"candidates,omitempty"`
+	NoSweep    bool      `json:"no_sweep,omitempty"`
+	Name       string    `json:"name,omitempty"`
+	Serial     string    `json:"serial,omitempty"`
+	Protocol   string    `json:"protocol,omitempty"`
+}
+
+// HuntStart launches a live system-discovery run.
+func (c *Client) HuntStart(ctx context.Context, req HuntStartRequest) error {
+	return c.do(ctx, http.MethodPost, "/api/v1/hunt/start", req, nil)
+}
+
 // HuntStop cancels the active live system-discovery run.
 func (c *Client) HuntStop(ctx context.Context) error {
 	return c.do(ctx, http.MethodPost, "/api/v1/hunt/stop", nil, nil)

--- a/internal/tui/cmds.go
+++ b/internal/tui/cmds.go
@@ -90,6 +90,13 @@ func cmdPollHunt(cli *client.Client) tea.Cmd {
 	}
 }
 
+func cmdHuntStart(cli *client.Client, req client.HuntStartRequest, label string) tea.Cmd {
+	return func() tea.Msg {
+		err := cli.HuntStart(context.Background(), req)
+		return writeResultMsg{Label: label, Err: err}
+	}
+}
+
 func cmdHuntStop(cli *client.Client, label string) tea.Cmd {
 	return func() tea.Msg {
 		err := cli.HuntStop(context.Background())

--- a/internal/tui/panels/hunt.go
+++ b/internal/tui/panels/hunt.go
@@ -5,37 +5,147 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/bubbles/key"
+	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/MattCheramie/GopherTrunk/internal/tui/state"
 )
 
-// HuntPanel renders the live system-discovery ("hunt") run: its state, sweep/
-// identify progress, and the discovered system summary. A blind discovery is
-// started from the web/API (where band/candidate parameters are entered); the
-// TUI monitors the run and can stop it.
-type HuntPanel struct{}
+// HuntPanel renders the live system-discovery ("hunt") run — its state, sweep/
+// identify progress, and the discovered system summary — and lets the operator
+// start a run (bands to sweep + an optional name) or stop the active one.
+type HuntPanel struct {
+	bandsInput textinput.Model
+	nameInput  textinput.Model
+	editing    bool
+	focusName  bool // false ⇒ bands input focused, true ⇒ name input
+	inputErr   string
+}
 
-func NewHunt() *HuntPanel { return &HuntPanel{} }
+func NewHunt() *HuntPanel {
+	bands := textinput.New()
+	bands.Placeholder = "bands MHz e.g. 851:869,769:775"
+	bands.CharLimit = 64
+	bands.Width = 30
+	bands.Prompt = "bands> "
+	name := textinput.New()
+	name.Placeholder = "name (optional)"
+	name.CharLimit = 48
+	name.Width = 30
+	name.Prompt = "name>  "
+	return &HuntPanel{bandsInput: bands, nameInput: name}
+}
 
 func (HuntPanel) Title() string { return "Hunt" }
 
-var huntStopKey = key.NewBinding(key.WithKeys("x"), key.WithHelp("x", "stop run"))
+var (
+	huntStartKey = key.NewBinding(key.WithKeys("s"), key.WithHelp("s", "start run"))
+	huntStopKey  = key.NewBinding(key.WithKeys("x"), key.WithHelp("x", "stop run"))
+	huntEscKey   = key.NewBinding(key.WithKeys("esc"), key.WithHelp("esc", "cancel"))
+)
 
-func (HuntPanel) Keys() []key.Binding { return []key.Binding{huntStopKey} }
+func (HuntPanel) Keys() []key.Binding { return []key.Binding{huntStartKey, huntStopKey} }
 
 func (p *HuntPanel) Update(msg tea.Msg, s *state.SharedState) (Panel, tea.Cmd) {
 	km, ok := msg.(tea.KeyMsg)
 	if !ok {
 		return p, nil
 	}
-	if key.Matches(km, huntStopKey) && s.Hunt.Running {
-		return p, Emit(state.WriteRequest{
-			Label: "stop hunt run",
-			Kind:  state.WriteKindHuntStop,
-		})
+
+	// While the start form is open, keys drive the inputs. Enter submits,
+	// Esc cancels, Tab switches focus.
+	if p.editing {
+		switch {
+		case key.Matches(km, huntEscKey):
+			p.closeForm()
+			return p, nil
+		case km.String() == "tab":
+			p.toggleFocus()
+			return p, nil
+		case km.String() == "enter":
+			return p, p.submit()
+		}
+		var cmd tea.Cmd
+		if p.focusName {
+			p.nameInput, cmd = p.nameInput.Update(msg)
+		} else {
+			p.bandsInput, cmd = p.bandsInput.Update(msg)
+		}
+		return p, cmd
+	}
+
+	switch {
+	case key.Matches(km, huntStartKey) && !s.Hunt.Running:
+		p.editing = true
+		p.focusName = false
+		p.inputErr = ""
+		p.bandsInput.Focus()
+		return p, textinput.Blink
+	case key.Matches(km, huntStopKey) && s.Hunt.Running:
+		return p, Emit(state.WriteRequest{Label: "stop hunt run", Kind: state.WriteKindHuntStop})
 	}
 	return p, nil
+}
+
+func (p *HuntPanel) toggleFocus() {
+	p.focusName = !p.focusName
+	if p.focusName {
+		p.bandsInput.Blur()
+		p.nameInput.Focus()
+	} else {
+		p.nameInput.Blur()
+		p.bandsInput.Focus()
+	}
+}
+
+func (p *HuntPanel) closeForm() {
+	p.editing = false
+	p.inputErr = ""
+	p.bandsInput.SetValue("")
+	p.nameInput.SetValue("")
+	p.bandsInput.Blur()
+	p.nameInput.Blur()
+}
+
+// submit validates the bands input and emits a WriteKindHuntStart.
+func (p *HuntPanel) submit() tea.Cmd {
+	bands, err := parseBandList(p.bandsInput.Value())
+	if err != nil {
+		p.inputErr = err.Error()
+		return nil
+	}
+	name := strings.TrimSpace(p.nameInput.Value())
+	p.closeForm()
+	return Emit(state.WriteRequest{
+		Label: "start hunt",
+		Kind:  state.WriteKindHuntStart,
+		Hunt:  &state.HuntStartReq{Bands: bands, Name: name},
+	})
+}
+
+// parseBandList parses a comma-separated list of "low:high" MHz specs, lightly
+// validating each so an obviously-malformed entry is caught before dispatch.
+func parseBandList(s string) ([]string, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil, fmt.Errorf("enter at least one band (low:high MHz)")
+	}
+	var out []string
+	for _, part := range strings.Split(s, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		lo, hi, ok := strings.Cut(part, ":")
+		if !ok || strings.TrimSpace(lo) == "" || strings.TrimSpace(hi) == "" {
+			return nil, fmt.Errorf("band %q: want low:high in MHz", part)
+		}
+		out = append(out, part)
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("enter at least one band (low:high MHz)")
+	}
+	return out, nil
 }
 
 func (p *HuntPanel) View(width, height int, focused bool, s *state.SharedState) string {
@@ -74,10 +184,18 @@ func (p *HuntPanel) View(width, height int, focused bool, s *state.SharedState) 
 	}
 
 	b.WriteString("\n")
-	if h.Running {
+	switch {
+	case p.editing:
+		b.WriteString(p.bandsInput.View() + "\n")
+		b.WriteString(p.nameInput.View() + "\n")
+		b.WriteString("[enter] start   [tab] next field   [esc] cancel\n")
+		if p.inputErr != "" {
+			fmt.Fprintf(&b, "! %s\n", p.inputErr)
+		}
+	case h.Running:
 		b.WriteString("[x] stop run\n")
-	} else {
-		b.WriteString("Start a run from the web console or POST /api/v1/hunt/start.\n")
+	default:
+		b.WriteString("[s] start a sweep   (or POST /api/v1/hunt/start)\n")
 	}
 	if s.HuntErr != nil {
 		fmt.Fprintf(&b, "\n(status unavailable: %v)\n", s.HuntErr)

--- a/internal/tui/panels/hunt_test.go
+++ b/internal/tui/panels/hunt_test.go
@@ -1,0 +1,59 @@
+package panels
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/MattCheramie/GopherTrunk/internal/tui/client"
+	"github.com/MattCheramie/GopherTrunk/internal/tui/state"
+)
+
+func TestHuntPanel_StartFormEmitsRequest(t *testing.T) {
+	p := NewHunt()
+	s := &state.SharedState{Hunt: client.HuntStatusDTO{}} // idle
+
+	// Open the form, type a band spec, submit.
+	_, _ = p.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("s")}, s)
+	_, _ = p.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("851:869")}, s)
+	_, cmd := p.Update(tea.KeyMsg{Type: tea.KeyEnter}, s)
+	if cmd == nil {
+		t.Fatal("enter should emit a start WriteRequest")
+	}
+	wa, ok := cmd().(WriteActionMsg)
+	if !ok {
+		t.Fatalf("msg = %T, want WriteActionMsg", cmd())
+	}
+	if wa.Request.Kind != state.WriteKindHuntStart {
+		t.Errorf("kind = %v, want HuntStart", wa.Request.Kind)
+	}
+	if wa.Request.Hunt == nil || len(wa.Request.Hunt.Bands) != 1 || wa.Request.Hunt.Bands[0] != "851:869" {
+		t.Errorf("bands = %+v, want [851:869]", wa.Request.Hunt)
+	}
+}
+
+func TestHuntPanel_EmptyBandsShowsError(t *testing.T) {
+	p := NewHunt()
+	s := &state.SharedState{}
+	_, _ = p.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("s")}, s)
+	_, cmd := p.Update(tea.KeyMsg{Type: tea.KeyEnter}, s) // submit empty
+	if cmd != nil {
+		t.Errorf("empty bands should not emit a request")
+	}
+	if p.inputErr == "" {
+		t.Errorf("expected an input error for empty bands")
+	}
+}
+
+func TestHuntPanel_StopEmitsWhenRunning(t *testing.T) {
+	p := NewHunt()
+	s := &state.SharedState{Hunt: client.HuntStatusDTO{Running: true, State: "running"}}
+	_, cmd := p.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("x")}, s)
+	if cmd == nil {
+		t.Fatal("x should emit a stop request while running")
+	}
+	wa := cmd().(WriteActionMsg)
+	if wa.Request.Kind != state.WriteKindHuntStop {
+		t.Errorf("kind = %v, want HuntStop", wa.Request.Kind)
+	}
+}

--- a/internal/tui/state/state.go
+++ b/internal/tui/state/state.go
@@ -172,6 +172,18 @@ type WriteRequest struct {
 	ScannerManualTune *ScannerManualTuneReq
 	Audio             *AudioReq
 	Settings          *SettingsReq
+	Hunt              *HuntStartReq
+}
+
+// HuntStartReq is the payload for WriteKindHuntStart — a live system-discovery
+// run started from the TUI. Frequencies are in MHz (matching the operator's
+// input); the client converts to the wire shape.
+type HuntStartReq struct {
+	Bands      []string  // "low:high" MHz
+	Candidates []float64 // MHz
+	Name       string
+	Serial     string
+	Protocol   string
 }
 
 // WriteKind discriminates a WriteRequest's payload.
@@ -196,6 +208,7 @@ const (
 	WriteKindScannerManualTune
 	WriteKindSettings
 	WriteKindHuntStop
+	WriteKindHuntStart
 )
 
 // ScannerManualTuneReq adds a temp VFO channel and forces dwell.

--- a/web/src/panels/Hunt.test.tsx
+++ b/web/src/panels/Hunt.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+vi.mock("../api/client", () => ({
+  api: { hunt: vi.fn() },
+}));
+
+vi.mock("../api/write", () => ({
+  writes: {
+    huntStart: vi.fn(),
+    huntStop: vi.fn(),
+  },
+}));
+
+import { api } from "../api/client";
+import { writes } from "../api/write";
+import { useShared } from "../store/shared";
+import { Hunt } from "./Hunt";
+
+function resetStore() {
+  useShared.setState({
+    serverURL: "http://localhost:8080",
+    token: null,
+    writeMode: true,
+    mutations: { allow_mutations: true },
+    lastError: null,
+  });
+}
+
+describe("Hunt panel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetStore();
+    vi.mocked(api.hunt).mockResolvedValue({
+      run_id: 0,
+      state: "idle",
+      running: false,
+      sites: 0,
+      talkgroups: 0,
+    });
+    vi.mocked(writes.huntStart).mockResolvedValue({ run_id: 1 });
+  });
+
+  it("forwards the serial and protocol inputs on start", async () => {
+    render(<Hunt />);
+    // Wait for the initial status poll to settle.
+    await waitFor(() => expect(api.hunt).toHaveBeenCalled());
+
+    await userEvent.type(screen.getByPlaceholderText("00000001"), "dongle-7");
+    await userEvent.type(screen.getByPlaceholderText("p25"), "p25");
+    await userEvent.click(screen.getByRole("button", { name: /start hunt/i }));
+
+    await waitFor(() => expect(writes.huntStart).toHaveBeenCalled());
+    const body = vi.mocked(writes.huntStart).mock.calls[0][1];
+    expect(body.serial).toBe("dongle-7");
+    expect(body.protocol).toBe("p25");
+    expect(body.bands).toEqual(["851:869"]); // default band, comma-split
+  });
+});

--- a/web/src/panels/Hunt.tsx
+++ b/web/src/panels/Hunt.tsx
@@ -21,6 +21,8 @@ export function Hunt() {
   const [name, setName] = useState("");
   const [stateCode, setStateCode] = useState("");
   const [county, setCounty] = useState("");
+  const [serial, setSerial] = useState("");
+  const [protocol, setProtocol] = useState("");
 
   useEffect(() => {
     let cancel = false;
@@ -57,6 +59,8 @@ export function Hunt() {
         name: name || undefined,
         state: stateCode || undefined,
         county: county || undefined,
+        serial: serial || undefined,
+        protocol: protocol || undefined,
       });
     } catch (e: unknown) {
       setError(e instanceof Error ? `start hunt failed: ${e.message}` : "start hunt failed");
@@ -124,6 +128,14 @@ export function Hunt() {
         <label>
           County
           <input value={county} onChange={(e) => setCounty(e.target.value)} placeholder="Maricopa" />
+        </label>
+        <label>
+          SDR serial (optional — auto-selects a spare, else borrows control)
+          <input value={serial} onChange={(e) => setSerial(e.target.value)} placeholder="00000001" />
+        </label>
+        <label>
+          Protocol (optional — default auto-identifies)
+          <input value={protocol} onChange={(e) => setProtocol(e.target.value)} placeholder="p25" />
         </label>
         <div className="hunt-buttons">
           <button onClick={start} disabled={!canMutate || running}>


### PR DESCRIPTION
Completes the deferred follow-up items from the hunt feature review, as one PR with phased commits (C1–C9).

## What's here
**C1 — per-run SDR serial.** `HuntStartRequest.Serial` was silently dropped; the daemon always auto-selected. The `Acquirer` now receives the run's options and forwards the serial to the already-pure `chooseHuntSDR`. (REST + TUI + web can now pin the SDR.)

**C2 — run-id export/commit + history.** Bounded run history (last 10) in the Manager; `GET /api/v1/hunt/{id}/export` + `POST /api/v1/hunt/{id}/commit` alongside the path-less (current) routes; `ErrNoSuchRun` → 404, no-system → 409, bad id → 400.

**C3 — TUI Start form.** The TUI Hunt panel can now *start* a sweep (bands + name inline form), not just monitor/stop.

**C4 — web serial/protocol inputs.** The web Hunt panel gains optional SDR-serial and protocol fields.

**C5–C9 — multi-protocol topology (neighbors + identity).** Per-protocol accumulators feed the protocol-neutral `TopologyProvider`, auto-surfaced onto `siglab.Result.Topology` and folded into the hunt map/exports (no siglab/accumulate edits needed):
- **DMR Tier III, EDACS, Motorola Type II** — identity **+ adjacent sites** (the adjacency PDUs were parsed but never dispatched; now accumulated, de-duped).
- **NXDN, TETRA** — single-site identity (NXDN System/Site/Location; TETRA MCC/MNC/LA + colour code).
- **C9** — docs only: MPT1327/dPMR already expose SystemID via the lock payload; LTR/YSF/D-STAR broadcast no system identity. Final capability matrix in `docs/hunt.md`.

## Verification
`go build ./...`, `go vet ./...`, and the affected package tests pass; the topology accumulators are `-race`-clean. Web `tsc` + `vite build` + `vitest` (121) green. End-to-end: the offline `gophertrunk hunt` over the real `mmr-s9-cc.cfile` still emits full P25 topology (WACN/RFSS/Site/neighbor/band-plan).

Branches off `main` (all five hunt phases already merged).

https://claude.ai/code/session_01He917mJB4Kg4ZkHjyHtJ66

---
_Generated by [Claude Code](https://claude.ai/code/session_01He917mJB4Kg4ZkHjyHtJ66)_