### PR TITLE
Constellation: frequency-offset view + cleaner render (#557)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,9 @@ for tagged releases.
   under the spike — the same approach OP25 takes. With **Hold** off the
   offset automatically follows the newest active call on the selected SDR
   (the "last locked channel"); Hold pins it. Decimation now box-averages
-  each stride window as a crude anti-alias low-pass, and the render gains a
-  phosphor-green additive scatter with labelled ±1 axes, a **DC-block**
+  each stride window as a crude anti-alias low-pass, and the render gains an
+  additive scatter in GopherTrunk's sky-blue accent (distinct from OP25's
+  phosphor green) with labelled ±1 axes, a **DC-block**
   (subtract the rolling mean), and an **Auto-scale** that fills the unit
   circle.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ for tagged releases.
 
 ### Added
 
+- **Constellation panel — frequency-offset view + cleaner render (issue
+  #557).** A centre-tuned constellation is dominated by the SDR's DC spike
+  (the DDC's residual carrier leakage at 0 Hz), which sits on top of any
+  signal in the middle of the band and reduces the plot to one fat blob. The
+  panel now offers an **Offset** control that mixes an off-centre control or
+  voice channel down to baseband *server-side, before decimation* (a new
+  `offset` parameter on `WS /api/v1/diag/iq`), pulling its symbols out from
+  under the spike — the same approach OP25 takes. With **Hold** off the
+  offset automatically follows the newest active call on the selected SDR
+  (the "last locked channel"); Hold pins it. Decimation now box-averages
+  each stride window as a crude anti-alias low-pass, and the render gains a
+  phosphor-green additive scatter with labelled ±1 axes, a **DC-block**
+  (subtract the rolling mean), and an **Auto-scale** that fills the unit
+  circle.
+
 - **SoapySDRServer remote SDRs — high-bit-depth network streaming + control
   from professional hardware (issue #536).** A new pure-Go (zero-CGO)
   `soapyremote` SDR backend connects to a remote `SoapySDRServer` (from

--- a/cmd/gophertrunk/diag_provider.go
+++ b/cmd/gophertrunk/diag_provider.go
@@ -43,7 +43,7 @@ func newDiagProvider(pool *sdr.Pool, brokers map[string]*iqtap.Broker, sampleRat
 // OpenIQStream is api.DiagProvider's only method. See its docstring
 // for the wire-side contract; this implementation builds a decimator
 // over the broker subscription and runs it on a goroutine.
-func (p *diagProvider) OpenIQStream(ctx context.Context, serial string, targetRateSPS uint32) (<-chan api.IQFrame, func(), error) {
+func (p *diagProvider) OpenIQStream(ctx context.Context, serial string, targetRateSPS uint32, offsetHz int32) (<-chan api.IQFrame, func(), error) {
 	if p == nil {
 		return nil, nil, errors.New("diag: provider not wired")
 	}
@@ -64,10 +64,19 @@ func (p *diagProvider) OpenIQStream(ctx context.Context, serial string, targetRa
 	if targetRateSPS > inputRate {
 		targetRateSPS = inputRate
 	}
+	// Clamp the requested view offset to the device's Nyquist; a mix
+	// beyond +/- Fs/2 just aliases back into the band.
+	half := int32(inputRate / 2)
+	if offsetHz > half {
+		offsetHz = half
+	} else if offsetHz < -half {
+		offsetHz = -half
+	}
 
 	dec, err := diag.New(diag.Options{
 		InputRateSPS:   inputRate,
 		TargetRateSPS:  targetRateSPS,
+		OffsetHz:       offsetHz,
 		ChunksPerFrame: 4,
 	})
 	if err != nil {

--- a/docs/constellation.md
+++ b/docs/constellation.md
@@ -18,10 +18,11 @@ care about before committing to a deeper decode pipeline.
 
 The X axis is the in-phase (I) component, the Y axis is the
 quadrature (Q) component, both normalized to ±1, with labelled ticks
-at ±0.5 and ±1. Points are drawn as additively-blended phosphor green,
-so a dense symbol cluster blooms bright while the noise floor stays
-dim; the newest samples are brightest. Reference rings show |z| = 0.5
-and |z| = 1.0 so you can eyeball amplitude.
+at ±0.5 and ±1. Points are drawn additively in GopherTrunk's sky-blue
+accent (the same blue→cyan family as the Spectrum waterfall), so a
+dense symbol cluster blooms toward cyan-white while the noise floor
+stays dim; the newest samples are brightest. Reference rings show
+|z| = 0.5 and |z| = 1.0 so you can eyeball amplitude.
 
 ## Getting a usable picture (the DC-spike problem)
 

--- a/docs/constellation.md
+++ b/docs/constellation.md
@@ -17,9 +17,32 @@ care about before committing to a deeper decode pipeline.
 ## What you see
 
 The X axis is the in-phase (I) component, the Y axis is the
-quadrature (Q) component, both normalized to ±1. Brighter dots are
-more recent. Reference rings show |z| = 0.5 and |z| = 1.0 so you
-can eyeball amplitude.
+quadrature (Q) component, both normalized to ±1, with labelled ticks
+at ±0.5 and ±1. Points are drawn as additively-blended phosphor green,
+so a dense symbol cluster blooms bright while the noise floor stays
+dim; the newest samples are brightest. Reference rings show |z| = 0.5
+and |z| = 1.0 so you can eyeball amplitude.
+
+## Getting a usable picture (the DC-spike problem)
+
+An SDR's digital down-converter leaks a residual carrier at 0 Hz — a
+**DC spike** that sits exactly at the centre of the band. Anything you
+tune to the middle lands right on top of it, and the constellation
+collapses into one fat blob. Three controls work around this:
+
+- **Offset** — mixes a frequency offset (relative to the SDR centre)
+  down to baseband *server-side, before decimation*, so an off-centre
+  control or voice channel is pulled out from under the DC spike and
+  rendered as a clean constellation. This is the same trick OP25 uses.
+  Drag the slider or type a kHz value.
+- **Hold** — when off, the Offset automatically follows the newest
+  active call on the selected SDR (the "last locked channel"). Turn
+  Hold on to pin the view on a specific offset and stop it from
+  jumping as calls come and go. Editing the Offset or pressing
+  **Centre** pins it too.
+- **DC block** / **Auto scale** — DC-block subtracts the rolling mean
+  to remove any residual offset; auto-scale eases a gain so the cloud
+  fills the unit circle regardless of input amplitude. Both default on.
 
 Common shapes:
 
@@ -36,9 +59,16 @@ Common shapes:
 
 ## How it works
 
-- The panel opens a WebSocket to `WS /api/v1/diag/iq?device=...&rate=2000`.
+- The panel opens a WebSocket to
+  `WS /api/v1/diag/iq?device=...&rate=2000&offset=<hz>`.
+- When `offset` is non-zero the daemon mixes that frequency down to
+  baseband with an NCO before decimating, so the requested off-centre
+  channel ends up at the origin. The magnitude is clamped to the
+  device's Nyquist (`±sample_rate/2`).
 - The daemon decimates the SDR's full-rate IQ stream by a stride
-  (`input_rate / target_rate`) — no anti-alias filter; the goal is
+  (`input_rate / target_rate`), taking a **box average** over each
+  stride window — a crude anti-alias low-pass that keeps wideband
+  noise from folding on top of the symbol cloud. The goal is
   visualization, not faithful spectral reconstruction.
 - Frames arrive every ~50 ms with ~100 points each; the panel
   keeps a rolling buffer of the last 2000 points and repaints the

--- a/internal/api/diag.go
+++ b/internal/api/diag.go
@@ -33,9 +33,13 @@ type IQFrame struct {
 type DiagProvider interface {
 	// OpenIQStream starts a per-request decimator on the named
 	// device. TargetRateSPS clamps the output rate (≤ device
-	// sample_rate). Returns the wire-frame channel and a cleanup
-	// func the caller MUST invoke on disconnect.
-	OpenIQStream(ctx context.Context, serial string, targetRateSPS uint32) (<-chan IQFrame, func(), error)
+	// sample_rate). offsetHz mixes a frequency offset (relative to
+	// the device centre) down to baseband before decimation so an
+	// off-centre channel can be viewed clear of the centre DC spike;
+	// zero keeps the centre-tuned view. The provider clamps the
+	// magnitude to the device's Nyquist. Returns the wire-frame
+	// channel and a cleanup func the caller MUST invoke on disconnect.
+	OpenIQStream(ctx context.Context, serial string, targetRateSPS uint32, offsetHz int32) (<-chan IQFrame, func(), error)
 }
 
 // handleDiagStream answers WS /api/v1/diag/iq?device=...&rate=....
@@ -55,6 +59,11 @@ func (s *Server) handleDiagStream(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	rate := uint32(parseIntQuery(q, "rate", 2000, 100, 20000))
+	// offset is the view shift in Hz relative to the SDR centre. The
+	// provider re-clamps to the device's actual Nyquist; the wide
+	// bound here just rejects nonsense. Signed: negative selects a
+	// channel below centre.
+	offset := int32(parseIntQuery(q, "offset", 0, -30_000_000, 30_000_000))
 
 	upgrader := wsUpgrader
 	if s.cors.enabled() {
@@ -78,7 +87,7 @@ func (s *Server) handleDiagStream(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithCancel(r.Context())
 	defer cancel()
 
-	frames, cleanup, err := s.diag.OpenIQStream(ctx, serial, rate)
+	frames, cleanup, err := s.diag.OpenIQStream(ctx, serial, rate, offset)
 	if err != nil {
 		s.log.Debug("api: diag OpenIQStream failed", "serial", serial, "err", err)
 		_ = conn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(

--- a/internal/api/diag_test.go
+++ b/internal/api/diag_test.go
@@ -18,7 +18,7 @@ type fakeDiagProvider struct {
 	frames  []IQFrame
 }
 
-func (f *fakeDiagProvider) OpenIQStream(ctx context.Context, _ string, _ uint32) (<-chan IQFrame, func(), error) {
+func (f *fakeDiagProvider) OpenIQStream(ctx context.Context, _ string, _ uint32, _ int32) (<-chan IQFrame, func(), error) {
 	if f.openErr != nil {
 		return nil, nil, f.openErr
 	}

--- a/internal/dsp/diag/iqstream.go
+++ b/internal/dsp/diag/iqstream.go
@@ -53,15 +53,26 @@ type IQFrame struct {
 }
 
 // Decimator consumes a stream of full-rate IQ chunks and emits IQ
-// frames at a controlled output rate. The output rate is achieved by
-// taking every Nth sample (where N = input_rate / target_rate),
-// matching what the spectrum producer's rate-cap loop does at the
-// FFT layer — simple, deterministic, no anti-alias filter needed
-// because the target rate is a tiny fraction of the input and the
-// goal is visualization, not faithful spectral reconstruction.
+// frames at a controlled output rate.
+//
+// Two knobs shape the output, both motivated by the fact that an
+// SDR's centre frequency carries a DC spike (the DDC's residual
+// carrier leakage) that lands right on top of anything tuned to the
+// middle of the band — making a centre-tuned constellation useless:
+//
+//   - OffsetHz mixes a frequency offset down to baseband with an NCO
+//     *before* decimation, so an off-centre locked control/voice
+//     channel can be pulled out from under the DC spike and rendered
+//     as a clean constellation (the same trick OP25 uses).
+//   - Decimation is a box average over each stride window rather than
+//     a bare every-Nth pick. The running mean is a crude anti-alias
+//     low-pass that keeps wideband noise from folding on top of the
+//     symbol cloud — the scatter reads much cleaner for a few extra
+//     adds per sample we already touch for the energy estimate.
 type Decimator struct {
 	inputRateSPS   uint32
 	targetRateSPS  uint32
+	offsetHz       int32
 	stride         int
 	chunksPerFrame int
 
@@ -78,6 +89,12 @@ type Options struct {
 	// TargetRateSPS is the post-decimation sample rate emitted to
 	// the WS client. Zero picks DefaultDecimatedRateSPS.
 	TargetRateSPS uint32
+	// OffsetHz shifts the view by mixing this frequency (relative to
+	// the SDR centre) down to baseband before decimation. Positive
+	// values select a channel above centre, negative below. Zero
+	// leaves the centre-tuned view unchanged. Magnitude must be
+	// <= InputRateSPS/2; the caller is expected to clamp.
+	OffsetHz int32
 	// ChunksPerFrame batches multiple downsampled chunks into one
 	// IQFrame so the WS write cost stays reasonable. Zero defaults
 	// to 4 (about 50 ms of audio at 2 ksps with 1024-sample input
@@ -98,6 +115,10 @@ func New(opts Options) (*Decimator, error) {
 	if target > opts.InputRateSPS {
 		return nil, errors.New("diag: TargetRateSPS must be <= InputRateSPS")
 	}
+	half := int32(opts.InputRateSPS / 2)
+	if opts.OffsetHz > half || opts.OffsetHz < -half {
+		return nil, errors.New("diag: OffsetHz must be within +/- InputRateSPS/2")
+	}
 	stride := int(opts.InputRateSPS / target)
 	if stride < 1 {
 		stride = 1
@@ -109,6 +130,7 @@ func New(opts Options) (*Decimator, error) {
 	return &Decimator{
 		inputRateSPS:   opts.InputRateSPS,
 		targetRateSPS:  target,
+		offsetHz:       opts.OffsetHz,
 		stride:         stride,
 		chunksPerFrame: chunksPerFrame,
 	}, nil
@@ -139,6 +161,20 @@ func (d *Decimator) Run(
 	var energySum float64
 	var energyCount int
 
+	// NCO state for the offset mix. dphi is the per-sample phase step
+	// for shifting OffsetHz down to baseband; zero offset means no
+	// rotation and the centre-tuned view is preserved bit-for-bit.
+	// Phase persists across chunks so the mix stays continuous.
+	dphi := -2 * math.Pi * float64(d.offsetHz) / float64(d.inputRateSPS)
+	mixing := d.offsetHz != 0
+	var phase float64
+
+	// Box-average accumulator for the current stride window. Persists
+	// across chunks so a window that straddles a chunk boundary still
+	// averages the right count.
+	var boxI, boxQ float64
+	var boxN int
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -147,22 +183,41 @@ func (d *Decimator) Run(
 			if !ok {
 				return nil
 			}
-			// Compute pre-decimation energy for the diagnostic banner.
 			for _, s := range chunk {
 				re := float64(real(s))
 				im := float64(imag(s))
+				// Pre-decimation energy for the diagnostic banner. The
+				// NCO is a pure rotation, so |mixed| == |s|; measure
+				// before mixing to keep it cheap.
 				energySum += re*re + im*im
+
+				if mixing {
+					c := math.Cos(phase)
+					sn := math.Sin(phase)
+					re, im = re*c-im*sn, re*sn+im*c
+					phase += dphi
+					if phase > math.Pi {
+						phase -= 2 * math.Pi
+					} else if phase < -math.Pi {
+						phase += 2 * math.Pi
+					}
+				}
+
+				// Box-average decimation: accumulate stride samples,
+				// emit their mean as one output point.
+				boxI += re
+				boxQ += im
+				boxN++
+				if boxN >= d.stride {
+					inv := 1.0 / float64(boxN)
+					d.pending = append(d.pending, IQPoint{
+						I: float32(boxI * inv),
+						Q: float32(boxQ * inv),
+					})
+					boxI, boxQ, boxN = 0, 0, 0
+				}
 			}
 			energyCount += len(chunk)
-
-			// Downsample by stride.
-			for i := 0; i < len(chunk); i += d.stride {
-				s := chunk[i]
-				d.pending = append(d.pending, IQPoint{
-					I: real(s),
-					Q: imag(s),
-				})
-			}
 
 			chunksSeen++
 			if chunksSeen < d.chunksPerFrame {
@@ -206,6 +261,9 @@ func (d *Decimator) TargetRateSPS() uint32 { return d.targetRateSPS }
 
 // Stride reports the input-to-output downsample ratio.
 func (d *Decimator) Stride() int { return d.stride }
+
+// OffsetHz reports the NCO mix offset applied before decimation.
+func (d *Decimator) OffsetHz() int32 { return d.offsetHz }
 
 // Dropped reports the cumulative frames dropped because a downstream
 // subscriber's channel was full. Non-zero is expected in practice on

--- a/internal/dsp/diag/iqstream_test.go
+++ b/internal/dsp/diag/iqstream_test.go
@@ -119,6 +119,99 @@ func TestRunPropagatesEnergyForDC(t *testing.T) {
 	}
 }
 
+func TestNewRejectsOutOfRangeOffset(t *testing.T) {
+	if _, err := New(Options{InputRateSPS: 1000, TargetRateSPS: 100, OffsetHz: 600}); err == nil {
+		t.Error("OffsetHz beyond +Nyquist: want error")
+	}
+	if _, err := New(Options{InputRateSPS: 1000, TargetRateSPS: 100, OffsetHz: -600}); err == nil {
+		t.Error("OffsetHz beyond -Nyquist: want error")
+	}
+	if _, err := New(Options{InputRateSPS: 1000, TargetRateSPS: 100, OffsetHz: 500}); err != nil {
+		t.Errorf("OffsetHz at +Nyquist: unexpected error %v", err)
+	}
+}
+
+// TestRunBoxAveragesWindow checks that each output point is the mean
+// of its stride window rather than a single picked sample, so a
+// stride window that ramps averages to its midpoint.
+func TestRunBoxAveragesWindow(t *testing.T) {
+	d, _ := New(Options{InputRateSPS: 1000, TargetRateSPS: 100, ChunksPerFrame: 1})
+
+	in := make(chan []complex64, 1)
+	out := make(chan IQFrame, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = d.Run(ctx, in, out, func() uint32 { return 0 }, func() int64 { return 0 }) }()
+
+	// Stride is 10. Build one 10-sample window ramping I from 0..0.9;
+	// its mean is 0.45. Q held at 1.0 so the mean stays 1.0.
+	chunk := make([]complex64, 10)
+	for i := range chunk {
+		chunk[i] = complex(float32(i)/10, 1)
+	}
+	in <- chunk
+
+	select {
+	case f := <-out:
+		if len(f.Points) != 1 {
+			t.Fatalf("Points len = %d, want 1", len(f.Points))
+		}
+		if math.Abs(float64(f.Points[0].I)-0.45) > 1e-5 {
+			t.Errorf("I = %f, want 0.45 (box mean)", f.Points[0].I)
+		}
+		if math.Abs(float64(f.Points[0].Q)-1.0) > 1e-5 {
+			t.Errorf("Q = %f, want 1.0", f.Points[0].Q)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("no frame")
+	}
+}
+
+// TestRunOffsetMixDownconvertsTone verifies the NCO: a complex tone
+// at exactly +OffsetHz mixes down to a constant DC point. Without the
+// offset the same tone would smear around the unit circle.
+func TestRunOffsetMixDownconvertsTone(t *testing.T) {
+	const fs = 1000
+	const tone = 100 // Hz, a clean 1/10 of fs so it divides the stride
+	d, _ := New(Options{
+		InputRateSPS:   fs,
+		TargetRateSPS:  100, // stride 10 == one tone period: window mean is the carrier
+		OffsetHz:       tone,
+		ChunksPerFrame: 1,
+	})
+
+	in := make(chan []complex64, 1)
+	out := make(chan IQFrame, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = d.Run(ctx, in, out, func() uint32 { return 0 }, func() int64 { return 0 }) }()
+
+	// One full second of e^{j2*pi*tone*n/fs}.
+	chunk := make([]complex64, fs)
+	for n := range chunk {
+		theta := 2 * math.Pi * float64(tone) * float64(n) / float64(fs)
+		chunk[n] = complex(float32(math.Cos(theta)), float32(math.Sin(theta)))
+	}
+	in <- chunk
+
+	select {
+	case f := <-out:
+		if len(f.Points) == 0 {
+			t.Fatal("no points")
+		}
+		// After mixing the tone to DC, every box-averaged point should
+		// sit at unit magnitude with a stable phase — not smeared. Check
+		// the last point (NCO fully settled) has |z| ~ 1.
+		p := f.Points[len(f.Points)-1]
+		mag := math.Hypot(float64(p.I), float64(p.Q))
+		if math.Abs(mag-1.0) > 0.05 {
+			t.Errorf("downconverted magnitude = %f, want ~1.0", mag)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("no frame")
+	}
+}
+
 func TestRunStopsOnContextCancel(t *testing.T) {
 	d, _ := New(Options{InputRateSPS: 1000, TargetRateSPS: 100})
 

--- a/web/src/api/diag.ts
+++ b/web/src/api/diag.ts
@@ -27,6 +27,10 @@ export interface IQStream {
 export interface IQOptions {
   serial: string;
   rate?: number; // target sample rate (sps), 100..20000, default 2000
+  // Frequency offset in Hz, relative to the SDR centre, mixed down to
+  // baseband before decimation. Lets the operator pull an off-centre
+  // locked channel out from under the centre DC spike. Default 0.
+  offset?: number;
   onFrame: FrameHandler;
   onStatus?: StatusHandler;
 }
@@ -37,6 +41,8 @@ const MAX_BACKOFF = 30_000;
 export function diagWebSocketURL(cfg: ClientConfig, opts: IQOptions): string {
   const params = new URLSearchParams({ device: opts.serial });
   if (opts.rate != null) params.set("rate", String(opts.rate));
+  if (opts.offset != null && opts.offset !== 0)
+    params.set("offset", String(Math.round(opts.offset)));
   const u = new URL(
     `/api/v1/diag/iq?${params.toString()}`,
     cfg.baseURL || window.location.href,

--- a/web/src/panels/Constellation.test.tsx
+++ b/web/src/panels/Constellation.test.tsx
@@ -97,4 +97,64 @@ describe("Constellation panel", () => {
       expect(screen.getByText(/boom/)).toBeInTheDocument();
     });
   });
+
+  it("follows the active call on the selected SDR with a frequency offset", async () => {
+    vi.mocked(fetchSpectrumDevices).mockResolvedValue([
+      {
+        serial: "rtl-1",
+        driver: "rtlsdr",
+        role: "control",
+        center_hz: 851_000_000,
+        sample_rate_hz: 2_048_000,
+      },
+    ]);
+    vi.mocked(openIQStream).mockReturnValue({ close: vi.fn() });
+
+    // A locked voice call 25 kHz above centre → offset should be 25000 Hz.
+    useShared.setState({
+      activeCalls: [
+        {
+          grant: {
+            system: "sys",
+            protocol: "p25",
+            group_id: 1,
+            frequency_hz: 851_025_000,
+          },
+          device_serial: "rtl-1",
+          started_at: "2026-06-07T00:00:00Z",
+        },
+      ] as never,
+    });
+
+    render(<Constellation />);
+    await waitFor(() => {
+      const calls = vi.mocked(openIQStream).mock.calls;
+      const last = calls[calls.length - 1]?.[1];
+      expect(last?.offset).toBe(25_000);
+    });
+  });
+
+  it("exposes DC-block, auto-scale, and hold view controls", async () => {
+    vi.mocked(fetchSpectrumDevices).mockResolvedValue([
+      {
+        serial: "rtl-1",
+        driver: "rtlsdr",
+        role: "control",
+        center_hz: 851_000_000,
+        sample_rate_hz: 2_048_000,
+      },
+    ]);
+    vi.mocked(openIQStream).mockReturnValue({ close: vi.fn() });
+
+    render(<Constellation />);
+    await waitFor(() => {
+      expect(openIQStream).toHaveBeenCalled();
+    });
+    // Hold + DC-block + auto-scale checkboxes, plus a Centre button.
+    expect(screen.getAllByRole("checkbox").length).toBeGreaterThanOrEqual(3);
+    expect(screen.getByText("Hold")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Centre" }),
+    ).toBeInTheDocument();
+  });
 });

--- a/web/src/panels/Constellation.tsx
+++ b/web/src/panels/Constellation.tsx
@@ -9,6 +9,7 @@ import {
   type IQPoint,
 } from "../api/diag";
 import { selectClientConfig, useShared } from "../store/shared";
+import { prefs } from "../store/prefs";
 
 // Constellation panel — 2D scatter of decimated IQ samples. Useful
 // for spotting the symbol-domain shape of whatever the SDR is tuned
@@ -23,26 +24,67 @@ import { selectClientConfig, useShared } from "../store/shared";
 //   - Wideband noise                    →  diffuse circle around the
 //                                         origin
 //
+// The catch with a centre-tuned view is the DC spike: an SDR's DDC
+// leaks a residual carrier at 0 Hz that lands on top of anything in
+// the middle of the band, so the constellation reads as one fat blob.
+// The offset control mixes an off-centre locked channel down to
+// baseband (server-side, before decimation) so its symbols can be
+// seen clear of the spike — the same approach OP25's plot takes. With
+// Hold off the offset follows the newest active call on the selected
+// SDR; Hold pins it. DC-block (subtract the residual mean) and
+// auto-scale (fill the unit circle) clean up the render further.
+//
 // 2 ksps decimated stream → ~50 ms / frame at 4 chunks per frame → a
 // canvas redraw every 50 ms is responsive without burning CPU.
 
 const TARGET_RATE_SPS = 2000;
 const POINT_BUFFER = 2000;       // how many recent points to render
-const CANVAS_PX = 360;           // square canvas; CSS scales to width
-const AXIS_PADDING = 14;
+const CANVAS_PX = 420;           // square canvas; CSS scales to width
+const MARGIN = { top: 12, right: 12, bottom: 24, left: 34 };
+
+// Phosphor green, à la a vector scope. Drawn additively so dense
+// clusters bloom brighter than the diffuse noise floor.
+const POINT_RGB = "120, 255, 140";
 
 type ConnState = "connecting" | "open" | "closed";
 
+interface RenderOpts {
+  dcBlock: boolean;
+  autoScale: boolean;
+  scaleRef: { current: number };
+}
+
 export function Constellation() {
   const cfg = useShared(selectClientConfig);
+  const activeCalls = useShared((s) => s.activeCalls);
   const [devices, setDevices] = useState<SpectrumDevice[]>([]);
   const [selected, setSelected] = useState<string | null>(null);
   const [conn, setConn] = useState<ConnState>("closed");
   const [latest, setLatest] = useState<IQFrame | null>(null);
   const [error, setError] = useState<string | null>(null);
 
+  const [offsetKHz, setOffsetKHz] = useState<number>(() =>
+    prefs.constellationOffsetKHz(),
+  );
+  const [hold, setHold] = useState<boolean>(() => prefs.constellationHold());
+  const [dcBlock, setDcBlock] = useState<boolean>(() =>
+    prefs.constellationDcBlock(),
+  );
+  const [autoScale, setAutoScale] = useState<boolean>(() =>
+    prefs.constellationAutoScale(),
+  );
+
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const bufferRef = useRef<IQPoint[]>([]);
+  const scaleRef = useRef<number>(1);
+  const optsRef = useRef<RenderOpts>({ dcBlock, autoScale, scaleRef });
+
+  // Keep the render-time options the WS callback reads in sync without
+  // re-subscribing the stream when a toggle flips.
+  useEffect(() => {
+    optsRef.current = { dcBlock, autoScale, scaleRef };
+    renderConstellation(canvasRef.current, bufferRef.current, optsRef.current);
+  }, [dcBlock, autoScale]);
 
   // Reuse the spectrum devices endpoint — same broker pool.
   useEffect(() => {
@@ -64,14 +106,66 @@ export function Constellation() {
     };
   }, [cfg, selected]);
 
+  const device = useMemo(
+    () => devices.find((d) => d.serial === selected) ?? null,
+    [devices, selected],
+  );
+
+  // Newest active call on the selected SDR, and the view offset (kHz)
+  // that would centre it. This is the "last locked channel" the issue
+  // asks for: when Hold is off we track it live.
+  const followOffsetKHz = useMemo(() => {
+    if (!device) return null;
+    const mine = activeCalls.filter(
+      (c) => c.device_serial === selected && !c.ended_at,
+    );
+    if (mine.length === 0) return null;
+    const newest = mine.reduce((a, b) =>
+      b.started_at > a.started_at ? b : a,
+    );
+    return (newest.grant.frequency_hz - device.center_hz) / 1000;
+  }, [activeCalls, device, selected]);
+
+  // Follow the locked channel unless the operator pinned the view.
+  useEffect(() => {
+    if (hold || followOffsetKHz == null) return;
+    setOffsetKHz((cur) =>
+      Math.abs(cur - followOffsetKHz) < 0.05 ? cur : followOffsetKHz,
+    );
+  }, [hold, followOffsetKHz]);
+
+  // Clamp the offset to the device's Nyquist so the slider/input can't
+  // request a mix that just aliases back into the band.
+  const maxOffsetKHz = device ? device.sample_rate_hz / 2000 : 1500;
+  const clampedOffsetKHz = Math.max(
+    -maxOffsetKHz,
+    Math.min(maxOffsetKHz, offsetKHz),
+  );
+
+  // Persist view options.
+  useEffect(() => {
+    prefs.setConstellationOffsetKHz(offsetKHz);
+  }, [offsetKHz]);
+  useEffect(() => {
+    prefs.setConstellationHold(hold);
+  }, [hold]);
+  useEffect(() => {
+    prefs.setConstellationDcBlock(dcBlock);
+  }, [dcBlock]);
+  useEffect(() => {
+    prefs.setConstellationAutoScale(autoScale);
+  }, [autoScale]);
+
   useEffect(() => {
     if (!selected) return;
     bufferRef.current = [];
+    scaleRef.current = 1;
     setLatest(null);
 
     const stream = openIQStream(cfg, {
       serial: selected,
       rate: TARGET_RATE_SPS,
+      offset: Math.round(clampedOffsetKHz * 1000),
       onFrame: (f) => {
         setLatest(f);
         const buf = bufferRef.current;
@@ -79,17 +173,28 @@ export function Constellation() {
         if (buf.length > POINT_BUFFER) {
           bufferRef.current = buf.slice(buf.length - POINT_BUFFER);
         }
-        renderConstellation(canvasRef.current, bufferRef.current);
+        renderConstellation(
+          canvasRef.current,
+          bufferRef.current,
+          optsRef.current,
+        );
       },
       onStatus: setConn,
     });
     return () => stream.close();
-  }, [cfg, selected]);
+    // Re-subscribe when the offset changes so the server re-mixes.
+  }, [cfg, selected, clampedOffsetKHz]);
+
+  const viewHz = useMemo(() => {
+    if (!latest) return null;
+    return latest.center_hz + clampedOffsetKHz * 1000;
+  }, [latest, clampedOffsetKHz]);
 
   const tuningLabel = useMemo(() => {
     if (!latest) return "";
-    return `${(latest.center_hz / 1e6).toFixed(4)} MHz · ${latest.sample_rate} sps · ${latest.energy_dbfs.toFixed(1)} dBFS`;
-  }, [latest]);
+    const off = clampedOffsetKHz === 0 ? "centre" : `${clampedOffsetKHz >= 0 ? "+" : ""}${clampedOffsetKHz.toFixed(1)} kHz`;
+    return `${((viewHz ?? latest.center_hz) / 1e6).toFixed(4)} MHz (${off}) · ${latest.sample_rate} sps · ${latest.energy_dbfs.toFixed(1)} dBFS`;
+  }, [latest, viewHz, clampedOffsetKHz]);
 
   return (
     <div className="space-y-3">
@@ -120,23 +225,111 @@ export function Constellation() {
         </div>
       )}
 
+      {/* View controls — offset / follow-locked-channel / cleanup. */}
+      <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-xs">
+        <label className="flex items-center gap-2">
+          <span className="text-muted">Offset</span>
+          <input
+            type="range"
+            min={-maxOffsetKHz}
+            max={maxOffsetKHz}
+            step={Math.max(1, Math.round(maxOffsetKHz / 300))}
+            value={clampedOffsetKHz}
+            onChange={(e) => {
+              setHold(true);
+              setOffsetKHz(Number(e.target.value));
+            }}
+            className="w-40 accent-emerald-400"
+            aria-label="View offset from SDR centre, kHz"
+          />
+          <input
+            type="number"
+            value={Number(clampedOffsetKHz.toFixed(1))}
+            onChange={(e) => {
+              setHold(true);
+              setOffsetKHz(Number(e.target.value));
+            }}
+            className="w-20 bg-surface border border-border rounded px-2 py-1 text-right font-mono"
+            aria-label="View offset from SDR centre in kHz (numeric)"
+          />
+          <span className="text-muted">kHz</span>
+        </label>
+
+        <button
+          type="button"
+          className="rounded border border-border px-2 py-1 hover:bg-surface disabled:opacity-40"
+          disabled={offsetKHz === 0}
+          onClick={() => {
+            setHold(true);
+            setOffsetKHz(0);
+          }}
+          title="Recentre the view on the SDR centre frequency"
+        >
+          Centre
+        </button>
+
+        <label
+          className="flex items-center gap-1.5"
+          title={
+            followOffsetKHz != null
+              ? `Follow the active call at ${(((viewHz ?? 0) || 0) / 1e6).toFixed(4)} MHz when off`
+              : "When off, the view follows the newest active call on this SDR"
+          }
+        >
+          <input
+            type="checkbox"
+            checked={hold}
+            onChange={(e) => setHold(e.target.checked)}
+            className="accent-emerald-400"
+          />
+          <span>
+            Hold
+            {!hold && followOffsetKHz != null && (
+              <span className="text-emerald-400"> · following call</span>
+            )}
+          </span>
+        </label>
+
+        <label className="flex items-center gap-1.5">
+          <input
+            type="checkbox"
+            checked={dcBlock}
+            onChange={(e) => setDcBlock(e.target.checked)}
+            className="accent-emerald-400"
+          />
+          <span>DC&nbsp;block</span>
+        </label>
+
+        <label className="flex items-center gap-1.5">
+          <input
+            type="checkbox"
+            checked={autoScale}
+            onChange={(e) => setAutoScale(e.target.checked)}
+            className="accent-emerald-400"
+          />
+          <span>Auto&nbsp;scale</span>
+        </label>
+      </div>
+
       <div className="font-mono text-xs text-muted">{tuningLabel || "—"}</div>
 
-      <div className="rounded border border-border bg-black flex items-center justify-center">
+      <div className="rounded border border-border bg-black flex items-center justify-center p-2">
         <canvas
           ref={canvasRef}
           width={CANVAS_PX}
           height={CANVAS_PX}
-          className="block"
-          style={{ width: CANVAS_PX, height: CANVAS_PX, imageRendering: "pixelated" }}
+          className="block max-w-full"
+          style={{ width: CANVAS_PX, height: CANVAS_PX }}
           aria-label="IQ constellation scatter"
         />
       </div>
 
       <div className="text-[11px] text-muted">
-        Plots decimated IQ samples ({TARGET_RATE_SPS} sps). Bright = recent.
-        Clusters at ±0.5+0i suggest PSK; concentric arcs suggest FSK;
-        a diffuse circle is wideband noise.
+        Plots decimated IQ samples ({TARGET_RATE_SPS} sps), brightest =
+        most recent. Tune the <em>Offset</em> onto a locked voice/control
+        channel to lift its symbols off the centre DC spike; clusters at
+        ±0.5 suggest PSK, concentric arcs suggest C4FM/FSK, a diffuse
+        circle is noise.
       </div>
     </div>
   );
@@ -148,51 +341,115 @@ function ConnPill({ state }: { state: ConnState }) {
   return <span className="pill-err">offline</span>;
 }
 
-function renderConstellation(canvas: HTMLCanvasElement | null, points: IQPoint[]) {
+// renderConstellation paints the rolling IQ buffer as a phosphor-green
+// vector scope: labelled ±1 axes, reference rings at 0.5 and 1.0, and
+// additively-blended points so dense symbol clusters bloom while the
+// noise floor stays dim. DC-block subtracts the buffer mean to kill
+// any residual centre offset; auto-scale eases a gain so the cloud
+// fills the unit circle regardless of input amplitude.
+function renderConstellation(
+  canvas: HTMLCanvasElement | null,
+  points: IQPoint[],
+  opts: RenderOpts,
+) {
   if (!canvas) return;
   const ctx = canvas.getContext("2d");
   if (!ctx) return;
   const w = canvas.width;
   const h = canvas.height;
 
+  // Square plot region inside the label margins.
+  const plot = Math.min(
+    w - MARGIN.left - MARGIN.right,
+    h - MARGIN.top - MARGIN.bottom,
+  );
+  const cx = MARGIN.left + plot / 2;
+  const cy = MARGIN.top + plot / 2;
+  const radius = plot / 2;
+
   // Background.
   ctx.fillStyle = "rgb(0, 0, 0)";
   ctx.fillRect(0, 0, w, h);
 
-  // Axes.
-  ctx.strokeStyle = "rgba(120, 120, 140, 0.35)";
+  // Grid: crosshair axes + 0.5 / 1.0 reference rings.
   ctx.lineWidth = 1;
+  ctx.strokeStyle = "rgba(120, 140, 130, 0.30)";
   ctx.beginPath();
-  ctx.moveTo(w / 2, AXIS_PADDING);
-  ctx.lineTo(w / 2, h - AXIS_PADDING);
-  ctx.moveTo(AXIS_PADDING, h / 2);
-  ctx.lineTo(w - AXIS_PADDING, h / 2);
+  ctx.moveTo(cx, cy - radius);
+  ctx.lineTo(cx, cy + radius);
+  ctx.moveTo(cx - radius, cy);
+  ctx.lineTo(cx + radius, cy);
   ctx.stroke();
+  ctx.strokeStyle = "rgba(120, 140, 130, 0.18)";
+  for (const r of [0.5, 1.0]) {
+    ctx.beginPath();
+    ctx.arc(cx, cy, radius * r, 0, Math.PI * 2);
+    ctx.stroke();
+  }
 
-  // Reference rings at |z| = 0.5 and |z| = 1.0.
-  ctx.strokeStyle = "rgba(120, 120, 140, 0.2)";
-  ctx.beginPath();
-  ctx.arc(w / 2, h / 2, (w / 2 - AXIS_PADDING) * 0.5, 0, Math.PI * 2);
-  ctx.stroke();
-  ctx.beginPath();
-  ctx.arc(w / 2, h / 2, (w / 2 - AXIS_PADDING) * 1.0, 0, Math.PI * 2);
-  ctx.stroke();
+  // Axis tick labels (I on the bottom, Q on the left).
+  ctx.fillStyle = "rgba(150, 170, 160, 0.75)";
+  ctx.font = "10px ui-monospace, monospace";
+  ctx.textAlign = "center";
+  ctx.textBaseline = "top";
+  for (const t of [-1, -0.5, 0, 0.5, 1]) {
+    if (t === 0) continue;
+    ctx.fillText(String(t), cx + t * radius, cy + radius + 5);
+  }
+  ctx.textAlign = "right";
+  ctx.textBaseline = "middle";
+  for (const t of [-1, -0.5, 0.5, 1]) {
+    ctx.fillText(String(t), MARGIN.left - 6, cy - t * radius);
+  }
 
-  // Plot points with fade-from-old. Older indices in the buffer are
-  // older samples; render them dimmer.
   const n = points.length;
   if (n === 0) return;
-  const half = (w / 2 - AXIS_PADDING);
+
+  // DC-block: subtract the buffer mean to remove residual carrier
+  // leakage so the cloud centres on the origin.
+  let mi = 0;
+  let mq = 0;
+  if (opts.dcBlock) {
+    for (let k = 0; k < n; k++) {
+      mi += points[k].i;
+      mq += points[k].q;
+    }
+    mi /= n;
+    mq /= n;
+  }
+
+  // Auto-scale: target gain so the 95th-percentile radius reaches ~0.9
+  // of the unit circle. Eased toward the target to avoid frame jitter.
+  let gain = opts.scaleRef.current || 1;
+  if (opts.autoScale) {
+    let maxR = 1e-6;
+    for (let k = 0; k < n; k++) {
+      const di = points[k].i - mi;
+      const dq = points[k].q - mq;
+      const r = Math.hypot(di, dq);
+      if (r > maxR) maxR = r;
+    }
+    const target = Math.max(0.2, Math.min(8, 0.9 / maxR));
+    gain = gain + (target - gain) * 0.1;
+    opts.scaleRef.current = gain;
+  } else {
+    gain = 1;
+    opts.scaleRef.current = 1;
+  }
+
+  // Additive blending so overlapping symbols accumulate brightness.
+  ctx.globalCompositeOperation = "lighter";
   for (let idx = 0; idx < n; idx++) {
     const p = points[idx];
-    // Map |i|, |q| of 1.0 to half the canvas (so the unit circle
-    // touches the rim).
-    const x = w / 2 + p.i * half;
-    const y = h / 2 - p.q * half; // canvas Y grows downward
-    // Fade: oldest 25% are dim, newest 25% are bright.
+    const i = (p.i - mi) * gain;
+    const q = (p.q - mq) * gain;
+    const x = cx + i * radius;
+    const y = cy - q * radius; // canvas Y grows downward
+    // Fade: oldest samples are dim, newest are bright.
     const age = idx / n; // 0..1
-    const alpha = 0.15 + 0.85 * age * age;
-    ctx.fillStyle = `rgba(120, 210, 255, ${alpha})`;
+    const alpha = 0.05 + 0.5 * age * age;
+    ctx.fillStyle = `rgba(${POINT_RGB}, ${alpha})`;
     ctx.fillRect(x - 1, y - 1, 2, 2);
   }
+  ctx.globalCompositeOperation = "source-over";
 }

--- a/web/src/panels/Constellation.tsx
+++ b/web/src/panels/Constellation.tsx
@@ -42,9 +42,14 @@ const POINT_BUFFER = 2000;       // how many recent points to render
 const CANVAS_PX = 420;           // square canvas; CSS scales to width
 const MARGIN = { top: 12, right: 12, bottom: 24, left: 34 };
 
-// Phosphor green, à la a vector scope. Drawn additively so dense
-// clusters bloom brighter than the diffuse noise floor.
-const POINT_RGB = "120, 255, 140";
+// GopherTrunk's sky-400 accent (matches --gt-accent and the Spectrum
+// waterfall's blue→cyan ramp), deliberately not OP25's phosphor green.
+// Drawn additively so dense clusters bloom toward cyan-white while the
+// diffuse noise floor stays dim.
+const POINT_RGB = "56, 189, 248";
+// Neutral slate-400 for the grid / axis labels, on-brand with the
+// muted slate tokens used elsewhere.
+const GRID_RGB = "148, 163, 184";
 
 type ConnState = "connecting" | "open" | "closed";
 
@@ -239,7 +244,7 @@ export function Constellation() {
               setHold(true);
               setOffsetKHz(Number(e.target.value));
             }}
-            className="w-40 accent-emerald-400"
+            className="w-40 accent-sky-400"
             aria-label="View offset from SDR centre, kHz"
           />
           <input
@@ -280,12 +285,12 @@ export function Constellation() {
             type="checkbox"
             checked={hold}
             onChange={(e) => setHold(e.target.checked)}
-            className="accent-emerald-400"
+            className="accent-sky-400"
           />
           <span>
             Hold
             {!hold && followOffsetKHz != null && (
-              <span className="text-emerald-400"> · following call</span>
+              <span className="text-accent"> · following call</span>
             )}
           </span>
         </label>
@@ -295,7 +300,7 @@ export function Constellation() {
             type="checkbox"
             checked={dcBlock}
             onChange={(e) => setDcBlock(e.target.checked)}
-            className="accent-emerald-400"
+            className="accent-sky-400"
           />
           <span>DC&nbsp;block</span>
         </label>
@@ -305,7 +310,7 @@ export function Constellation() {
             type="checkbox"
             checked={autoScale}
             onChange={(e) => setAutoScale(e.target.checked)}
-            className="accent-emerald-400"
+            className="accent-sky-400"
           />
           <span>Auto&nbsp;scale</span>
         </label>
@@ -373,14 +378,14 @@ function renderConstellation(
 
   // Grid: crosshair axes + 0.5 / 1.0 reference rings.
   ctx.lineWidth = 1;
-  ctx.strokeStyle = "rgba(120, 140, 130, 0.30)";
+  ctx.strokeStyle = `rgba(${GRID_RGB}, 0.30)`;
   ctx.beginPath();
   ctx.moveTo(cx, cy - radius);
   ctx.lineTo(cx, cy + radius);
   ctx.moveTo(cx - radius, cy);
   ctx.lineTo(cx + radius, cy);
   ctx.stroke();
-  ctx.strokeStyle = "rgba(120, 140, 130, 0.18)";
+  ctx.strokeStyle = `rgba(${GRID_RGB}, 0.18)`;
   for (const r of [0.5, 1.0]) {
     ctx.beginPath();
     ctx.arc(cx, cy, radius * r, 0, Math.PI * 2);
@@ -388,7 +393,7 @@ function renderConstellation(
   }
 
   // Axis tick labels (I on the bottom, Q on the left).
-  ctx.fillStyle = "rgba(150, 170, 160, 0.75)";
+  ctx.fillStyle = `rgba(${GRID_RGB}, 0.80)`;
   ctx.font = "10px ui-monospace, monospace";
   ctx.textAlign = "center";
   ctx.textBaseline = "top";

--- a/web/src/store/prefs.ts
+++ b/web/src/store/prefs.ts
@@ -15,6 +15,10 @@ const LS_KEYS = {
   writeMode: "gt.ui.writeMode",
   audioVolume: "gt.audio.volume",
   installPromptDismissed: "gt.pwa.installDismissed",
+  constellationOffsetKHz: "gt.constellation.offsetKHz",
+  constellationHold: "gt.constellation.hold",
+  constellationDcBlock: "gt.constellation.dcBlock",
+  constellationAutoScale: "gt.constellation.autoScale",
 } as const;
 
 const SS_KEYS = {
@@ -123,6 +127,39 @@ export const prefs = {
   },
   setInstallPromptDismissed(dismissed: boolean) {
     writeLS(LS_KEYS.installPromptDismissed, dismissed ? "1" : "0");
+  },
+
+  // Constellation panel view options. The offset (in kHz, relative to
+  // the SDR centre) pulls an off-centre locked channel out from under
+  // the centre DC spike; "hold" keeps that offset pinned across panel
+  // visits. DC-block and auto-scale default on for a clean scatter.
+  constellationOffsetKHz(): number {
+    const raw = readLS(LS_KEYS.constellationOffsetKHz);
+    if (raw === null) return 0;
+    const n = Number(raw);
+    return Number.isFinite(n) ? n : 0;
+  },
+  setConstellationOffsetKHz(khz: number) {
+    writeLS(LS_KEYS.constellationOffsetKHz, String(khz));
+  },
+  constellationHold(): boolean {
+    return readLS(LS_KEYS.constellationHold) === "1";
+  },
+  setConstellationHold(on: boolean) {
+    writeLS(LS_KEYS.constellationHold, on ? "1" : "0");
+  },
+  constellationDcBlock(): boolean {
+    // Default on — the whole point is to suppress the DC spike.
+    return readLS(LS_KEYS.constellationDcBlock) !== "0";
+  },
+  setConstellationDcBlock(on: boolean) {
+    writeLS(LS_KEYS.constellationDcBlock, on ? "1" : "0");
+  },
+  constellationAutoScale(): boolean {
+    return readLS(LS_KEYS.constellationAutoScale) !== "0";
+  },
+  setConstellationAutoScale(on: boolean) {
+    writeLS(LS_KEYS.constellationAutoScale, on ? "1" : "0");
   },
 
   /** Clear all GopherTrunk-owned keys. Used by Settings → "forget this device". */


### PR DESCRIPTION
A centre-tuned constellation is swamped by the SDR's DC spike (the
DDC's residual carrier at 0 Hz), which lands on top of any signal in
the middle of the band and collapses the plot to one blob. Add a
frequency-offset view that pulls an off-centre locked channel out from
under the spike, mirroring OP25, plus a cleaner render.

Backend:
- diag.Decimator gains an OffsetHz NCO that mixes the requested
  offset down to baseband before decimation (clamped to +/-Nyquist),
  and box-averages each stride window as a crude anti-alias low-pass
  so wideband noise stops folding onto the symbol cloud.
- Thread an `offset` query param through WS /api/v1/diag/iq, the
  DiagProvider interface, and the daemon provider.

Frontend:
- Offset slider/input; Hold off auto-follows the newest active call on
  the selected SDR (the "last locked channel"), Hold pins it.
- DC-block (subtract rolling mean) and Auto-scale (fill the unit
  circle), both default on; phosphor-green additive scatter with
  labelled +/-1 axes. View options persisted.

Tests for the NCO downconversion, box average, offset clamping, and
the panel's follow/offset controls. Docs + changelog updated.