### PR TITLE
Raise sdr.sample_rate config ceiling to 20 MHz for wideband sources

### DIFF
--- a/cmd/gophertrunk/config_wizard.go
+++ b/cmd/gophertrunk/config_wizard.go
@@ -323,7 +323,7 @@ func wizardSteps() []wizardStep {
 			fields: []wizardField{
 				{
 					label: "SDR sample rate (Hz)",
-					help:  "225000–3200000. 2_400_000 is the sweet spot for RTL-SDR.",
+					help:  "225000–20000000. 2_400_000 is the sweet spot for RTL-SDR (which caps at 3.2 MHz); higher rates need a wideband source like soapy_remote.",
 					kind:  fieldInt,
 					get:   func(a *wizardAnswers) string { return strconv.Itoa(a.SDRSampleHz) },
 					set:   func(a *wizardAnswers, v string) { a.SDRSampleHz, _ = strconv.Atoi(v) },

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -140,6 +140,9 @@ retention:
   interval: "1h"      # how often the sweeper runs
 
 sdr:
+  # 225000–20000000 Hz. 2_400_000 is the RTL-SDR sweet spot; RTL dongles
+  # cap at 3.2 MHz. Higher rates (e.g. 10_000_000 / 20_000_000) are only
+  # usable with a wideband source like soapy_remote (USRP, LimeSDR, …).
   sample_rate: 2_400_000
   # watchdog_interval_ms: periodic USB-disconnect watchdog cadence
   # (default 30000 = 30 s). Catches dongles that vanish from the bus

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -545,9 +545,14 @@ type MessageLogConfig struct {
 
 type SDRConfig struct {
 	// SampleRate is the IQ rate (Hz) every tuner is programmed to.
-	// Default 2_400_000 (2.4 MS/s). Valid range 225_000..3_200_000; the
+	// Default 2_400_000 (2.4 MS/s). Valid range 225_000..20_000_000; the
 	// RTL2832U quantizes to its 28.4 fixed-point divisor so the streamed
-	// rate may differ slightly (see Device.ActualSampleRate). This is
+	// rate may differ slightly (see Device.ActualSampleRate). Note that
+	// RTL2832U hardware still caps at 3.2 MHz at the device level (the
+	// resampler produces garbage above that), so rates beyond 3.2 MHz are
+	// only usable with wideband sources such as soapy_remote (USRP, Lime,
+	// bladeRF, …) that can stream them — an RTL dongle handed a higher
+	// rate is rejected at open and skipped. This is
 	// also the primary load lever on CPU-bound hosts: convert + resample
 	// cost scales with it, so if the daemon logs "sdr: dropping live IQ
 	// chunks; consumer can't keep up" (iq_underruns_total climbing),
@@ -1273,8 +1278,8 @@ func Load(path string) (Config, error) {
 }
 
 func (c Config) Validate() error {
-	if c.SDR.SampleRate != 0 && (c.SDR.SampleRate < 225_000 || c.SDR.SampleRate > 3_200_000) {
-		return errors.New("sdr.sample_rate must be between 225 kHz and 3.2 MHz")
+	if c.SDR.SampleRate != 0 && (c.SDR.SampleRate < 225_000 || c.SDR.SampleRate > 20_000_000) {
+		return errors.New("sdr.sample_rate must be between 225 kHz and 20 MHz")
 	}
 	seenSerials := make(map[string]int, len(c.SDR.Devices))
 	for i, d := range c.SDR.Devices {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -65,6 +65,11 @@ func TestValidate(t *testing.T) {
 	}{
 		{"ok", Default(), false},
 		{"bad sample rate", Config{SDR: SDRConfig{SampleRate: 100}}, true},
+		// Wideband soapy_remote sources (issue #550): rates above the RTL
+		// 3.2 MHz hardware cap are valid config, bounded at 20 MHz.
+		{"wideband sample rate 10M", Config{SDR: SDRConfig{SampleRate: 10_000_000}}, false},
+		{"wideband sample rate 20M", Config{SDR: SDRConfig{SampleRate: 20_000_000}}, false},
+		{"sample rate above 20M", Config{SDR: SDRConfig{SampleRate: 20_000_001}}, true},
 		{"bad role", Config{SDR: SDRConfig{Devices: []DeviceConfig{{Role: "bogus"}}}}, true},
 		{"bad protocol", Config{Trunking: TrunkingConfig{Systems: []SystemConfig{{Name: "x", Protocol: "lte"}}}}, true},
 		{"tetra protocol", Config{Trunking: TrunkingConfig{Systems: []SystemConfig{{Name: "x", Protocol: "tetra"}}}}, false},


### PR DESCRIPTION
The 3.2 MHz max enforced at config load is an RTL2832U hardware limit,
but it was also blocking soapy_remote endpoints (USRP, LimeSDR, …) that
can stream 10–20 MSPS over RPC. Raise the global config ceiling to 20 MHz
while keeping the 225 kHz floor. RTL hardware is unaffected: its
device-level IsValidSampleRate guard still rejects >3.2 MHz at open, so a
dongle handed a higher rate is skipped with a logged error rather than
streaming garbage.

Update the SampleRate doc comment, wizard help text, and config.example
to explain the new range and that >3.2 MHz needs a wideband source. Add
validation tests for 10M/20M (accepted) and >20M (rejected).

Fixes #550

https://claude.ai/code/session_01WwzVc6e2UMy9S7kje9dHd6