### PR TITLE
Symbol scope: live + offline demodulated-symbol view (OP25-style, Phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,12 @@ for tagged releases.
   offset / Hold / follow-active-call controls, so you can dial the scope onto
   a locked control/voice channel and lift it clear of the SDR centre DC
   spike. Backed by a new `WS /api/v1/diag/symbols?device=&proto=&offset=`
-  endpoint and the `internal/scanner/symbolscope` engine. TETRA and the rest
-  of the C4FM family (DMR/NXDN/YSF/D-STAR) — and a soft waveform for them —
-  follow as per-receiver soft taps ship.
+  endpoint and the `internal/scanner/symbolscope` engine. The offline
+  **SigLab** analyzer gains the matching view: a capture run with
+  `collect IQ diag` + `capture IQ` now carries an aligned symbol series on
+  its `IQTaps`, rendered by a new SigLab Symbol-scope viz alongside the eye
+  diagram. TETRA and the rest of the C4FM family (DMR/NXDN/YSF/D-STAR) — and
+  a soft waveform for them — follow as per-receiver soft taps ship.
 
 - **Constellation panel — frequency-offset view + cleaner render (issue
   #557).** A centre-tuned constellation is dominated by the SDR's DC spike

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ for tagged releases.
 
 ### Added
 
+- **Symbol scope — live demodulated-symbol oscilloscope (OP25-style "Symbol"
+  plot).** A new web panel (`/symbols`) renders the demodulated symbol stream
+  off a live SDR: for **P25 C4FM** it shows the pre-slicer soft waveform (~4
+  noisy bands for a healthy channel, with rails at each decided level), and
+  for **P25 CQPSK** the sliced dibit decisions. It reuses the **production**
+  DSP — the same down-converter and P25 Phase 1 receiver the live decoder
+  uses, run as a *parallel* decode on the iqtap broker so production
+  control-channel decode is never touched — exposed through the receiver's
+  existing soft/dibit taps. The panel shares the Constellation panel's
+  offset / Hold / follow-active-call controls, so you can dial the scope onto
+  a locked control/voice channel and lift it clear of the SDR centre DC
+  spike. Backed by a new `WS /api/v1/diag/symbols?device=&proto=&offset=`
+  endpoint and the `internal/scanner/symbolscope` engine. TETRA and the rest
+  of the C4FM family (DMR/NXDN/YSF/D-STAR) — and a soft waveform for them —
+  follow as per-receiver soft taps ship.
+
 - **Constellation panel — frequency-offset view + cleaner render (issue
   #557).** A centre-tuned constellation is dominated by the SDR's DC spike
   (the DDC's residual carrier leakage at 0 Hz), which sits on top of any

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -1691,6 +1691,7 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 		if len(d.iqBrokers) > 0 {
 			opts.Spectrum = newSpectrumProvider(d.pool, d.iqBrokers, log)
 			opts.Diag = newDiagProvider(d.pool, d.iqBrokers, cfg.SDR.SampleRate, log)
+			opts.Symbols = newSymbolProvider(d.pool, d.iqBrokers, cfg.SDR.SampleRate, log)
 			opts.Capture = newCaptureProvider(d.pool, d.iqBrokers, log)
 		}
 		if d.bookmarks != nil {

--- a/cmd/gophertrunk/symbol_provider.go
+++ b/cmd/gophertrunk/symbol_provider.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/MattCheramie/GopherTrunk/internal/api"
+	"github.com/MattCheramie/GopherTrunk/internal/scanner/symbolscope"
+	"github.com/MattCheramie/GopherTrunk/internal/sdr"
+	"github.com/MattCheramie/GopherTrunk/internal/sdr/iqtap"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// symbolProvider implements api.SymbolProvider on top of the daemon's
+// iqtap broker map. Each OpenSymbolStream call attaches a fresh
+// subscriber to the requested device's broker and runs a per-request
+// symbolscope.Engine (DDC → protocol receiver → soft/dibit taps),
+// piping the recovered-symbol frames out for the API's WS handler to
+// drain. Cleanup tears the subscription and engine goroutine down.
+//
+// One engine per WS subscriber — same trade-off diagProvider makes. The
+// engine runs a full down-converter + receiver, so it is heavier than
+// the diag decimator; for the single-operator GopherTrunk audience this
+// is acceptable, and the broker fan-out never back-pressures the
+// production control-channel decode.
+type symbolProvider struct {
+	pool       *sdr.Pool
+	brokers    map[string]*iqtap.Broker
+	sampleRate uint32
+	log        *slog.Logger
+}
+
+func newSymbolProvider(pool *sdr.Pool, brokers map[string]*iqtap.Broker, sampleRate uint32, log *slog.Logger) *symbolProvider {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &symbolProvider{pool: pool, brokers: brokers, sampleRate: sampleRate, log: log}
+}
+
+// symbolProtoToReceiver maps the WS proto selector onto a protocol +
+// P25 demod mode. Phase 1 ships P25 Phase 1 only.
+func symbolProtoToReceiver(proto string) (trunking.Protocol, string, error) {
+	switch proto {
+	case "", "p25-c4fm":
+		return trunking.ProtocolP25, "c4fm", nil
+	case "p25-cqpsk":
+		return trunking.ProtocolP25, "cqpsk", nil
+	default:
+		return trunking.ProtocolUnknown, "", fmt.Errorf("symbol: unsupported proto %q", proto)
+	}
+}
+
+// OpenSymbolStream is api.SymbolProvider's only method. See its
+// docstring for the wire-side contract; this implementation builds a
+// symbolscope.Engine over the broker subscription and runs it on a
+// goroutine.
+func (p *symbolProvider) OpenSymbolStream(ctx context.Context, serial, proto string, offsetHz int32) (<-chan api.SymbolFrame, func(), error) {
+	if p == nil {
+		return nil, nil, errors.New("symbol: provider not wired")
+	}
+	br, ok := p.brokers[serial]
+	if !ok {
+		return nil, nil, fmt.Errorf("symbol: serial %q is not a known SDR", serial)
+	}
+	protocol, demod, err := symbolProtoToReceiver(proto)
+	if err != nil {
+		return nil, nil, err
+	}
+	inputRate := br.SampleRateHz()
+	if inputRate == 0 {
+		inputRate = p.sampleRate
+	}
+	if inputRate == 0 {
+		return nil, nil, errors.New("symbol: cannot determine input sample rate")
+	}
+	// Clamp the requested view offset to the device's Nyquist; a mix
+	// beyond +/- Fs/2 just aliases back into the band.
+	half := int32(inputRate / 2)
+	if offsetHz > half {
+		offsetHz = half
+	} else if offsetHz < -half {
+		offsetHz = -half
+	}
+
+	wireOut := make(chan api.SymbolFrame, 8)
+	streamCtx, cancel := context.WithCancel(ctx)
+
+	eng, err := symbolscope.New(symbolscope.Options{
+		Protocol:  protocol,
+		DemodMode: demod,
+		InRateHz:  float64(inputRate),
+		OffsetHz:  offsetHz,
+		CenterHz:  br.CenterHz(),
+		Emit: func(f symbolscope.Frame) {
+			wire := api.SymbolFrame{
+				TimestampNs:  f.TimestampNs,
+				SymbolRateHz: f.SymbolRateHz,
+				CenterHz:     f.CenterHz,
+				OffsetHz:     f.OffsetHz,
+				Soft:         f.Soft,
+				Dibits:       f.Dibits,
+				IsBits:       f.IsBits,
+				BaseIdx:      f.BaseIdx,
+			}
+			// Non-blocking: drop on a wedged WS client rather than
+			// stalling the broker drain goroutine.
+			select {
+			case wireOut <- wire:
+			case <-streamCtx.Done():
+			default:
+			}
+		},
+	})
+	if err != nil {
+		cancel()
+		return nil, nil, fmt.Errorf("symbol: %w", err)
+	}
+
+	sub := br.Subscribe()
+
+	go func() {
+		defer close(wireOut)
+		defer eng.Close()
+		for {
+			select {
+			case <-streamCtx.Done():
+				return
+			case chunk, ok := <-sub.C:
+				if !ok {
+					return
+				}
+				eng.Process(chunk)
+			}
+		}
+	}()
+
+	cleanup := func() {
+		cancel()
+		sub.Close()
+	}
+	return wireOut, cleanup, nil
+}

--- a/docs/symbol-scope.md
+++ b/docs/symbol-scope.md
@@ -57,6 +57,15 @@ same controls work around it:
   ~256 symbols per frame and ships them over the WS. Soft and dibit are
   aligned index-for-index on the C4FM path.
 
+## Offline (SigLab)
+
+The offline [SigLab](siglab) analyzer has the same view. Run a capture
+with **collect IQ diag** + **capture IQ** enabled and the Result carries
+an aligned symbol series (`IQTaps.symbol_dibits` / `symbol_soft`); the
+SigLab Results page renders it as a **Symbol scope** card next to the eye
+diagram. The live panel and the offline viz share the same props
+contract, so they read identically.
+
 ## Limitations
 
 - **P25 Phase 1 only, today.** C4FM gets the soft waveform + dibits;

--- a/docs/symbol-scope.md
+++ b/docs/symbol-scope.md
@@ -1,0 +1,83 @@
+---
+layout: page
+title: Symbol scope panel
+description: Live oscilloscope of the demodulated symbol stream — the pre-slicer soft waveform and the sliced dibit decisions — GopherTrunk's take on OP25's Symbol plot
+nav_group: Operate
+---
+
+# Symbol scope panel
+
+The **Symbol scope** (web `/symbols`) renders a live oscilloscope of
+the demodulated symbol stream coming off whichever SDR you pick — the
+"are the symbols clean?" view, complementing the Constellation panel's
+IQ scatter. It is GopherTrunk's take on OP25's *Symbol* plot.
+
+## What you see
+
+The X axis is symbol index (time, left→right); the Y axis is the
+symbol level. Two render modes are chosen automatically:
+
+- **P25 C4FM** streams the **pre-slicer soft waveform** — the
+  FM-discriminator + matched-filter + clock-recovered samples, just
+  before slicing. A healthy 4-level channel reads as ~4 noisy
+  horizontal bands; faint rails mark the mean of each decided level.
+- **P25 CQPSK** has no soft tap yet, so it streams the **sliced dibit
+  decisions** only, drawn as discrete rows.
+
+Brighter (additively-blended) regions are denser symbol populations.
+The trace is GopherTrunk's sky-blue accent, matching the Constellation
+and Spectrum panels.
+
+## Getting a usable picture (offset / Hold / follow)
+
+Like the Constellation panel, the scope taps the SDR's wideband IQ, so
+a channel sitting on the SDR centre is buried under the DC spike. The
+same controls work around it:
+
+- **Mode** — the receiver / demod path (P25 C4FM or P25 CQPSK).
+- **Offset** — tunes a channel sitting at this offset (kHz, relative to
+  the SDR centre) down to baseband before the receiver channelizes it,
+  lifting an off-centre control/voice channel clear of the DC spike.
+- **Hold** — when off, the Offset automatically follows the newest
+  active call on the selected SDR (the "last locked channel"); turn
+  Hold on (or edit the Offset / press **Centre**) to pin it.
+
+## How it works
+
+- The panel opens a WebSocket to
+  `WS /api/v1/diag/symbols?device=...&proto=...&offset=...`.
+- The daemon attaches a **parallel** decode to the SDR's iqtap broker —
+  the same broker the Constellation and Spectrum panels use — so it
+  never disturbs the production control-channel decoder. The parallel
+  decode reuses the production down-converter
+  (`ccdecoder.Downconverter`, channelizing to 48 kHz for the C4FM
+  family) and the production P25 Phase 1 receiver.
+- The receiver's `SoftSink` (pre-slicer waveform) and `DibitSink`
+  (sliced decisions) feed `internal/scanner/symbolscope`, which batches
+  ~256 symbols per frame and ships them over the WS. Soft and dibit are
+  aligned index-for-index on the C4FM path.
+
+## Limitations
+
+- **P25 Phase 1 only, today.** C4FM gets the soft waveform + dibits;
+  CQPSK gets dibits only. TETRA and the rest of the C4FM family
+  (DMR / NXDN / YSF / D-STAR) — and a soft waveform for them — land as
+  the per-receiver soft taps ship.
+- **Not a demodulator UI.** This is a diagnostic view; to actually
+  decode, configure the channel as a `trunking.systems` entry and let
+  the production pipeline take over.
+- **One engine per panel.** Each open scope runs a full
+  down-converter + receiver on its own broker subscription; CPU scales
+  with the number of open scopes (the broker fan-out never
+  back-pressures the production decoder).
+
+## Implementation
+
+| Path | Role |
+| --- | --- |
+| `internal/scanner/symbolscope/scope.go` | `Engine` — DDC + P25 receiver + soft/dibit taps → `Frame`s |
+| `internal/api/symbols.go` | `SymbolProvider` interface + `WS /api/v1/diag/symbols` handler |
+| `cmd/gophertrunk/symbol_provider.go` | Daemon provider — wires the engine to the iqtap broker per subscriber |
+| `web/src/api/symbols.ts` | Typed client with auto-reconnect / backoff |
+| `web/src/components/SymbolScopeChart.tsx` | Canvas scope renderer (shared contract with the SigLab viz) |
+| `web/src/panels/SymbolScope.tsx` | Panel: SDR + mode + offset/Hold/follow controls |

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -298,6 +298,12 @@ type Server struct {
 	// over the iqtap broker + internal/dsp/diag.
 	diag DiagProvider
 
+	// symbols is the optional provider backing the
+	// WS /api/v1/diag/symbols recovered-symbol stream for the Symbol
+	// scope panel. nil disables the route (503). Implemented by the
+	// daemon over the iqtap broker + internal/scanner/symbolscope.
+	symbols SymbolProvider
+
 	// pager is the optional provider backing /api/v1/pager/...
 	// routes (pager log). nil disables the routes. Implemented
 	// by the daemon over the SQLite-backed storage.PagerLog.
@@ -561,6 +567,11 @@ type ServerOptions struct {
 	// the iqtap broker + internal/dsp/diag; nil keeps the route
 	// returning 503.
 	Diag DiagProvider
+	// Symbols, when non-nil, enables the WS /api/v1/diag/symbols
+	// recovered-symbol live stream that backs the web Symbol scope
+	// panel. The daemon implements this over the iqtap broker +
+	// internal/scanner/symbolscope; nil keeps the route returning 503.
+	Symbols SymbolProvider
 	// Siglab, when Enabled, mounts the offline signal-analysis routes
 	// (/api/v1/siglab/*) and constructs the in-memory job/capture store.
 	// The daemon and the standalone `siglab serve` command both set it.
@@ -722,6 +733,7 @@ func NewServer(opts ServerOptions) (*Server, error) {
 		capture:        opts.Capture,
 		bookmarks:      opts.Bookmarks,
 		diag:           opts.Diag,
+		symbols:        opts.Symbols,
 		siglab:         siglabSvc,
 		siglabStop:     siglabStop,
 		diagnostics:    opts.Diagnostics,
@@ -944,6 +956,7 @@ func (s *Server) routes() *http.ServeMux {
 	// Read-only; the daemon doesn't expose any way to inject IQ
 	// via this path. Returns 503 when no SDR is in the pool.
 	mux.HandleFunc("GET /api/v1/diag/iq", s.handleDiagStream)
+	mux.HandleFunc("GET /api/v1/diag/symbols", s.handleSymbolStream)
 
 	// Siglab — offline signal-analysis console. Read routes (protocols,
 	// job result/stream/iq, export) are open; routes that stage data or

--- a/internal/api/symbols.go
+++ b/internal/api/symbols.go
@@ -1,0 +1,146 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// SymbolFrame is the wire shape of one batch of recovered symbols for
+// the web "Symbol" scope. It mirrors symbolscope.Frame so the api
+// package stays free of a dependency on the DSP package; the
+// SymbolProvider interface bridges the two.
+//
+// Soft is the pre-slicer soft waveform (empty when the demod path has no
+// soft tap, e.g. P25 CQPSK); Dibits are the sliced decisions (0..3 when
+// IsBits is false, 0..1 when true). When Soft is non-empty it is aligned
+// index-for-index with Dibits.
+type SymbolFrame struct {
+	TimestampNs  int64     `json:"ts_ns"`
+	SymbolRateHz float64   `json:"symbol_rate_hz"`
+	CenterHz     uint32    `json:"center_hz"`
+	OffsetHz     int32     `json:"offset_hz"`
+	Soft         []float32 `json:"soft"`
+	Dibits       []uint8   `json:"dibits"`
+	IsBits       bool      `json:"is_bits"`
+	BaseIdx      int       `json:"base_idx"`
+}
+
+// SymbolProvider is the daemon-side abstraction the symbol endpoint
+// consumes. The daemon implements it on top of the iqtap broker map +
+// internal/scanner/symbolscope; tests substitute a fake.
+type SymbolProvider interface {
+	// OpenSymbolStream starts a per-request symbol-recovery engine on
+	// the named device. proto selects the receiver ("p25-c4fm" /
+	// "p25-cqpsk"); offsetHz tunes an off-centre channel down to
+	// baseband before channelizing. Returns the wire-frame channel and
+	// a cleanup func the caller MUST invoke on disconnect.
+	OpenSymbolStream(ctx context.Context, serial, proto string, offsetHz int32) (<-chan SymbolFrame, func(), error)
+}
+
+// symbolProtos is the set of receiver selectors the symbol scope
+// accepts today. Phase 1 ships P25 Phase 1 (C4FM soft+dibit, CQPSK
+// dibit-only); more land as the per-receiver soft taps do.
+var symbolProtos = map[string]bool{
+	"p25-c4fm":  true,
+	"p25-cqpsk": true,
+}
+
+// handleSymbolStream answers WS /api/v1/diag/symbols?device=...&proto=...&offset=....
+//
+// Frames arrive as JSON text messages. Server pings every 30 s to keep
+// proxies from idling the socket. Connection stays open until the client
+// disconnects or the device disappears. Mirrors handleDiagStream.
+func (s *Server) handleSymbolStream(w http.ResponseWriter, r *http.Request) {
+	if s.symbols == nil {
+		s.writeError(w, http.StatusServiceUnavailable, "symbol subsystem not enabled")
+		return
+	}
+	q := r.URL.Query()
+	serial := q.Get("device")
+	if serial == "" {
+		s.writeError(w, http.StatusBadRequest, "device query parameter is required")
+		return
+	}
+	proto := q.Get("proto")
+	if proto == "" {
+		proto = "p25-c4fm"
+	}
+	if !symbolProtos[proto] {
+		s.writeError(w, http.StatusBadRequest, "unsupported proto (want p25-c4fm or p25-cqpsk)")
+		return
+	}
+	offset := int32(parseIntQuery(q, "offset", 0, -30_000_000, 30_000_000))
+
+	upgrader := wsUpgrader
+	if s.cors.enabled() {
+		cors := s.cors
+		upgrader.CheckOrigin = func(req *http.Request) bool {
+			origin := req.Header.Get("Origin")
+			if origin == "" {
+				return true
+			}
+			_, ok := cors.originAllowed(origin)
+			return ok
+		}
+	}
+	conn, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		s.log.Debug("api: symbol WS upgrade failed", "err", err)
+		return
+	}
+	defer conn.Close()
+
+	ctx, cancel := context.WithCancel(r.Context())
+	defer cancel()
+
+	frames, cleanup, err := s.symbols.OpenSymbolStream(ctx, serial, proto, offset)
+	if err != nil {
+		s.log.Debug("api: symbol OpenSymbolStream failed", "serial", serial, "err", err)
+		_ = conn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(
+			websocket.CloseInternalServerErr, err.Error()))
+		return
+	}
+	defer cleanup()
+
+	// Drain client → server messages so close frames are processed.
+	go func() {
+		for {
+			if _, _, err := conn.NextReader(); err != nil {
+				cancel()
+				return
+			}
+		}
+	}()
+
+	ping := time.NewTicker(30 * time.Second)
+	defer ping.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ping.C:
+			_ = conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+			if err := conn.WriteMessage(websocket.PingMessage, nil); err != nil {
+				return
+			}
+		case f, ok := <-frames:
+			if !ok {
+				return
+			}
+			body, err := json.Marshal(f)
+			if err != nil {
+				s.log.Debug("api: symbol frame marshal", "err", err)
+				continue
+			}
+			_ = conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+			if err := conn.WriteMessage(websocket.TextMessage, body); err != nil {
+				return
+			}
+		}
+	}
+}

--- a/internal/api/symbols_test.go
+++ b/internal/api/symbols_test.go
@@ -1,0 +1,154 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/gorilla/websocket"
+)
+
+type fakeSymbolProvider struct {
+	openErr error
+	frames  []SymbolFrame
+	gotPro  string
+	gotOff  int32
+}
+
+func (f *fakeSymbolProvider) OpenSymbolStream(ctx context.Context, _ string, proto string, offset int32) (<-chan SymbolFrame, func(), error) {
+	f.gotPro = proto
+	f.gotOff = offset
+	if f.openErr != nil {
+		return nil, nil, f.openErr
+	}
+	out := make(chan SymbolFrame, 4)
+	streamCtx, cancel := context.WithCancel(ctx)
+	go func() {
+		defer close(out)
+		for _, fr := range f.frames {
+			select {
+			case <-streamCtx.Done():
+				return
+			case out <- fr:
+			}
+			time.Sleep(5 * time.Millisecond)
+		}
+		<-streamCtx.Done()
+	}()
+	return out, cancel, nil
+}
+
+func newSymbolTestServer(t *testing.T, prov SymbolProvider) *httptest.Server {
+	t.Helper()
+	bus := events.NewBus(8)
+	t.Cleanup(bus.Close)
+	srv, err := NewServer(ServerOptions{
+		Addr:    "127.0.0.1:0",
+		Bus:     bus,
+		Symbols: prov,
+	})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	ts := httptest.NewServer(srv.routes())
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+func TestSymbolStreamReturns503WhenNotWired(t *testing.T) {
+	ts := newSymbolTestServer(t, nil)
+	resp, err := http.Get(ts.URL + "/api/v1/diag/symbols?device=foo")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want 503", resp.StatusCode)
+	}
+}
+
+func TestSymbolStreamRejectsMissingDevice(t *testing.T) {
+	ts := newSymbolTestServer(t, &fakeSymbolProvider{})
+	resp, err := http.Get(ts.URL + "/api/v1/diag/symbols")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", resp.StatusCode)
+	}
+}
+
+func TestSymbolStreamRejectsUnknownProto(t *testing.T) {
+	ts := newSymbolTestServer(t, &fakeSymbolProvider{})
+	resp, err := http.Get(ts.URL + "/api/v1/diag/symbols?device=foo&proto=bogus")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400 for unknown proto", resp.StatusCode)
+	}
+}
+
+func TestSymbolStreamDeliversFrames(t *testing.T) {
+	prov := &fakeSymbolProvider{
+		frames: []SymbolFrame{
+			{
+				TimestampNs:  1,
+				SymbolRateHz: 4800,
+				CenterHz:     851_012_500,
+				OffsetHz:     12_500,
+				Soft:         []float32{0.9, -0.3, -0.95, 0.31},
+				Dibits:       []uint8{1, 0, 3, 2},
+				BaseIdx:      0,
+			},
+			{
+				TimestampNs:  2,
+				SymbolRateHz: 4800,
+				CenterHz:     851_012_500,
+				Dibits:       []uint8{2, 2},
+				BaseIdx:      4,
+			},
+		},
+	}
+	ts := newSymbolTestServer(t, prov)
+
+	u, _ := url.Parse(ts.URL)
+	wsURL := "ws://" + u.Host + "/api/v1/diag/symbols?device=any&proto=p25-cqpsk&offset=12500"
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	defer conn.Close()
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+
+	for i := 0; i < 2; i++ {
+		_, msg, err := conn.ReadMessage()
+		if err != nil {
+			t.Fatalf("ReadMessage #%d: %v", i, err)
+		}
+		var f SymbolFrame
+		if err := json.Unmarshal(msg, &f); err != nil {
+			t.Fatalf("unmarshal #%d: %v (raw=%s)", i, err, string(msg))
+		}
+		if f.SymbolRateHz != 4800 {
+			t.Errorf("frame #%d SymbolRateHz = %v", i, f.SymbolRateHz)
+		}
+		if i == 0 && len(f.Dibits) != 4 {
+			t.Errorf("frame #%d dibits len = %d, want 4", i, len(f.Dibits))
+		}
+	}
+
+	if prov.gotPro != "p25-cqpsk" {
+		t.Errorf("provider got proto %q, want p25-cqpsk", prov.gotPro)
+	}
+	if prov.gotOff != 12_500 {
+		t.Errorf("provider got offset %d, want 12500", prov.gotOff)
+	}
+}

--- a/internal/scanner/symbolscope/scope.go
+++ b/internal/scanner/symbolscope/scope.go
@@ -1,0 +1,242 @@
+// Package symbolscope recovers a live stream of demodulated symbols
+// (the pre-slicer soft waveform plus the sliced dibit decisions) from a
+// wideband IQ feed, for the web console's "Symbol" scope — GopherTrunk's
+// take on OP25's Symbol plot.
+//
+// It deliberately reuses the production DSP rather than re-implementing
+// demod: the same down-converter the live decoder channelizes with
+// (ccdecoder.Downconverter) feeds the same protocol receiver, and the
+// receiver's existing SoftSink / DibitSink taps surface the symbols.
+// Run a separate Engine on an iqtap broker subscription (the
+// diag_provider.go pattern) and production control-channel decode is
+// never touched.
+//
+// Phase 1 supports P25 Phase 1: C4FM emits the FM-discriminator soft
+// waveform aligned index-for-index with the sliced dibits; CQPSK emits
+// the dibits only (the receiver has no soft tap on that path yet). Other
+// protocols — and a soft waveform for them — are a follow-up that adds a
+// uniform soft tap to the remaining receivers; the Frame shape and this
+// API are designed to absorb that without change.
+package symbolscope
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	p25phase1rx "github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase1/receiver"
+	"github.com/MattCheramie/GopherTrunk/internal/scanner/ccdecoder"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// p25DeviationHz is the P25 Phase 1 nominal peak deviation (TIA-102),
+// the slicer-scale the production pipeline calibrates against. Mirrors
+// the siglab deep-path constant.
+const p25DeviationHz = 1800.0
+
+// defaultFrameSymbols batches recovered symbols into one Frame so the WS
+// write cost stays reasonable — ~256 symbols is ~53 ms at 4800 baud,
+// matching the diag stream's ~50 ms cadence.
+const defaultFrameSymbols = 256
+
+// Frame is one batch of recovered symbols. Soft is the pre-slicer soft
+// waveform (empty when the demod path exposes no soft tap, e.g. P25
+// CQPSK); Dibits are the sliced decisions (values 0..3 when IsBits is
+// false, 0..1 when true). When Soft is non-empty it is aligned
+// index-for-index with Dibits. BaseIdx is the absolute symbol index the
+// batch starts at, so a client can detect gaps.
+type Frame struct {
+	TimestampNs  int64     `json:"ts_ns"`
+	SymbolRateHz float64   `json:"symbol_rate_hz"`
+	CenterHz     uint32    `json:"center_hz"`
+	OffsetHz     int32     `json:"offset_hz"`
+	Soft         []float32 `json:"soft"`
+	Dibits       []uint8   `json:"dibits"`
+	IsBits       bool      `json:"is_bits"`
+	BaseIdx      int       `json:"base_idx"`
+}
+
+// Options configures an Engine.
+type Options struct {
+	// Protocol selects the receiver. Phase 1 supports trunking.ProtocolP25.
+	Protocol trunking.Protocol
+	// DemodMode is the P25 demod path: "c4fm" (default) or "cqpsk".
+	// Ignored for other protocols.
+	DemodMode string
+	// InRateHz is the wideband input rate (the SDR's sample rate).
+	InRateHz float64
+	// OffsetHz tunes a channel sitting at this offset (relative to the
+	// SDR centre) down to baseband before channelizing — pulls an
+	// off-centre control/voice channel out from under the DC spike.
+	OffsetHz int32
+	// CenterHz stamps each frame with the SDR centre (informational).
+	CenterHz uint32
+	// SystemName / FrequencyHz are informational labels passed to the
+	// receiver construction.
+	SystemName  string
+	FrequencyHz uint32
+	// FrameSymbols is the per-frame symbol batch size. Zero picks
+	// defaultFrameSymbols.
+	FrameSymbols int
+	// NowNs is an injectable clock for tests. Nil uses time.Now.
+	NowNs func() int64
+	// Emit receives each completed Frame. Required. The slices it
+	// carries are freshly allocated per frame; the callee owns them.
+	Emit func(Frame)
+}
+
+// Engine channelizes a wideband IQ feed and runs a protocol receiver,
+// surfacing the recovered symbols as Frames. Not safe for concurrent
+// Process calls — drive it from a single goroutine (the broker drain
+// loop), exactly like diag.Decimator.
+type Engine struct {
+	ddc          *ccdecoder.Downconverter
+	rx           *p25phase1rx.Receiver
+	symbolRateHz float64
+	centerHz     uint32
+	offsetHz     int32
+	frameSymbols int
+	nowNs        func() int64
+	emit         func(Frame)
+
+	// Channelized-IQ scratch, reused across Process calls.
+	chanBuf []complex64
+
+	// Per-frame accumulators. soft grows in lockstep with dibits on the
+	// C4FM path; it stays empty on paths without a soft tap.
+	pendSoft   []float32
+	pendDibits []uint8
+	isBits     bool
+	baseIdx    int // absolute symbol index of pendDibits[0]
+	totalSyms  int // symbols seen across the whole stream
+}
+
+// New constructs an Engine. Returns an error for an unsupported
+// protocol, an absent Emit, or a non-positive input rate.
+func New(opts Options) (*Engine, error) {
+	if opts.Emit == nil {
+		return nil, errors.New("symbolscope: Emit is required")
+	}
+	if opts.InRateHz <= 0 {
+		return nil, errors.New("symbolscope: InRateHz must be > 0")
+	}
+	if opts.Protocol != trunking.ProtocolP25 {
+		return nil, fmt.Errorf("symbolscope: protocol %s is not supported yet (P25 Phase 1 only)", opts.Protocol)
+	}
+	demodMode, ok := p25phase1rx.ParseDemodMode(opts.DemodMode)
+	if !ok {
+		return nil, fmt.Errorf("symbolscope: unknown demod mode %q (want c4fm or cqpsk)", opts.DemodMode)
+	}
+
+	frameSymbols := opts.FrameSymbols
+	if frameSymbols <= 0 {
+		frameSymbols = defaultFrameSymbols
+	}
+	nowNs := opts.NowNs
+	if nowNs == nil {
+		nowNs = func() int64 { return time.Now().UnixNano() }
+	}
+
+	target := ccdecoder.DDCTargetForProtocol(trunking.ProtocolP25)
+	ddc := ccdecoder.NewDownconverterWithOffset(opts.InRateHz, target, float64(opts.OffsetHz))
+
+	e := &Engine{
+		ddc:          ddc,
+		symbolRateHz: p25phase1rx.SymbolRate,
+		centerHz:     opts.CenterHz,
+		offsetHz:     opts.OffsetHz,
+		frameSymbols: frameSymbols,
+		nowNs:        nowNs,
+		emit:         opts.Emit,
+	}
+
+	// Build the receiver directly (no control channel) so the SoftSink
+	// surfaces the pre-slicer waveform. The DibitSink drives the frame
+	// accumulator; soft↔dibit alignment holds because the receiver
+	// fires SoftSink then DibitSink on the same symbol batch.
+	e.rx = p25phase1rx.New(p25phase1rx.Options{
+		SampleRateHz: ddc.OutRateHz(),
+		DeviationHz:  p25DeviationHz,
+		DemodMode:    demodMode,
+		SoftSink:     e.onSoft,
+		DibitSink:    e.onDibits,
+	})
+	return e, nil
+}
+
+// Process channelizes one raw IQ chunk and runs the receiver over it.
+// Completed frames are delivered via the Emit callback.
+func (e *Engine) Process(iq []complex64) {
+	if len(iq) == 0 {
+		return
+	}
+	e.chanBuf = e.ddc.Process(e.chanBuf, iq)
+	e.rx.Process(e.chanBuf)
+}
+
+// onSoft stashes the pre-slicer soft samples; onDibits, fired next on
+// the same batch, pairs them with the sliced decisions.
+func (e *Engine) onSoft(soft []float32) {
+	e.pendSoft = append(e.pendSoft, soft...)
+}
+
+func (e *Engine) onDibits(dibits []uint8, _ int) {
+	if e.pendDibits == nil {
+		e.baseIdx = e.totalSyms
+	}
+	e.pendDibits = append(e.pendDibits, dibits...)
+	e.totalSyms += len(dibits)
+	for len(e.pendDibits) >= e.frameSymbols {
+		e.flush(e.frameSymbols)
+	}
+}
+
+// flush emits the first n accumulated symbols as a Frame and shifts the
+// accumulators down. Soft is carried only when it stayed aligned with
+// the dibit stream (C4FM); a length mismatch (a soft-less path) emits an
+// empty soft track rather than a misaligned one.
+func (e *Engine) flush(n int) {
+	if n > len(e.pendDibits) {
+		n = len(e.pendDibits)
+	}
+	if n == 0 {
+		return
+	}
+	dibits := make([]uint8, n)
+	copy(dibits, e.pendDibits[:n])
+
+	var soft []float32
+	if len(e.pendSoft) == len(e.pendDibits) {
+		soft = make([]float32, n)
+		copy(soft, e.pendSoft[:n])
+		e.pendSoft = e.pendSoft[n:]
+	} else {
+		// Soft track absent or out of step — drop it for this batch and
+		// resync so a one-off mismatch can't wedge the stream.
+		e.pendSoft = e.pendSoft[:0]
+	}
+
+	frame := Frame{
+		TimestampNs:  e.nowNs(),
+		SymbolRateHz: e.symbolRateHz,
+		CenterHz:     e.centerHz,
+		OffsetHz:     e.offsetHz,
+		Soft:         soft,
+		Dibits:       dibits,
+		IsBits:       e.isBits,
+		BaseIdx:      e.baseIdx,
+	}
+	e.pendDibits = e.pendDibits[n:]
+	e.baseIdx += n
+	e.emit(frame)
+}
+
+// Close releases the engine. Idempotent.
+func (e *Engine) Close() error {
+	e.pendSoft = nil
+	e.pendDibits = nil
+	return nil
+}
+
+// SymbolRateHz reports the recovered symbol rate (informational).
+func (e *Engine) SymbolRateHz() float64 { return e.symbolRateHz }

--- a/internal/scanner/symbolscope/scope_test.go
+++ b/internal/scanner/symbolscope/scope_test.go
@@ -1,0 +1,182 @@
+package symbolscope
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/demod"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// makeC4FMIQ synthesizes a wideband P25 C4FM IQ stream at inRate for a
+// repeating 4-symbol pattern, scaled up so the receiver's symbol-AGC has
+// headroom (mirrors the receiver package's own fixtures).
+func makeC4FMIQ(inRate float64, nSymbols int) ([]complex64, []uint8) {
+	dibits := make([]uint8, nSymbols)
+	for i := range dibits {
+		dibits[i] = uint8((i*7 + 3) & 3)
+	}
+	iq := demod.ModulateP25C4FM(dibits, inRate, p25DeviationHz)
+	for i := range iq {
+		iq[i] *= 100
+	}
+	return iq, dibits
+}
+
+func TestNewValidates(t *testing.T) {
+	if _, err := New(Options{InRateHz: 960_000, Protocol: trunking.ProtocolP25}); err == nil {
+		t.Error("missing Emit: want error")
+	}
+	emit := func(Frame) {}
+	if _, err := New(Options{Emit: emit, Protocol: trunking.ProtocolP25}); err == nil {
+		t.Error("zero InRateHz: want error")
+	}
+	if _, err := New(Options{Emit: emit, InRateHz: 960_000, Protocol: trunking.ProtocolDMR}); err == nil {
+		t.Error("unsupported protocol: want error")
+	}
+	if _, err := New(Options{Emit: emit, InRateHz: 960_000, Protocol: trunking.ProtocolP25, DemodMode: "bogus"}); err == nil {
+		t.Error("bad demod mode: want error")
+	}
+	if _, err := New(Options{Emit: emit, InRateHz: 960_000, Protocol: trunking.ProtocolP25}); err != nil {
+		t.Errorf("valid C4FM options: unexpected error %v", err)
+	}
+}
+
+// TestC4FMRecoversSoftAndDibits is the headline check: a C4FM stream
+// produces frames whose dibits cover the 4-level alphabet and whose soft
+// waveform is aligned with — and separates into — four distinct levels
+// keyed by the sliced decision. That separability is what makes it a
+// usable symbol scope.
+func TestC4FMRecoversSoftAndDibits(t *testing.T) {
+	iq, _ := makeC4FMIQ(960_000, 6000)
+
+	var frames []Frame
+	e, err := New(Options{
+		Emit:         func(f Frame) { frames = append(frames, f) },
+		InRateHz:     960_000,
+		Protocol:     trunking.ProtocolP25,
+		DemodMode:    "c4fm",
+		FrameSymbols: 64,
+		NowNs:        func() int64 { return 42 },
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	e.Process(iq)
+
+	if len(frames) == 0 {
+		t.Fatal("no frames emitted")
+	}
+
+	// Per-dibit soft accumulators across all frames.
+	var sum [4]float64
+	var cnt [4]int
+	wantBase := 0
+	for fi, f := range frames {
+		if f.IsBits {
+			t.Errorf("frame %d: IsBits = true, want false for C4FM dibits", fi)
+		}
+		if len(f.Soft) != len(f.Dibits) {
+			t.Fatalf("frame %d: soft len %d != dibit len %d", fi, len(f.Soft), len(f.Dibits))
+		}
+		if f.BaseIdx != wantBase {
+			t.Errorf("frame %d: BaseIdx = %d, want %d (contiguous)", fi, f.BaseIdx, wantBase)
+		}
+		wantBase += len(f.Dibits)
+		if f.SymbolRateHz != 4800 {
+			t.Errorf("frame %d: SymbolRateHz = %v, want 4800", fi, f.SymbolRateHz)
+		}
+		if f.TimestampNs != 42 {
+			t.Errorf("frame %d: TimestampNs = %d, want 42 (injected clock)", fi, f.TimestampNs)
+		}
+		for i, d := range f.Dibits {
+			if d > 3 {
+				t.Fatalf("frame %d: dibit %d out of range", fi, d)
+			}
+			sum[d] += float64(f.Soft[i])
+			cnt[d]++
+		}
+	}
+
+	// All four levels should be populated, and their mean soft values
+	// must be mutually separated — the 4-band structure of the scope.
+	means := make([]float64, 0, 4)
+	for v := 0; v < 4; v++ {
+		if cnt[v] == 0 {
+			t.Fatalf("dibit value %d never decided — slicer collapsed", v)
+		}
+		means = append(means, sum[v]/float64(cnt[v]))
+	}
+	sort.Float64s(means)
+	spread := means[3] - means[0]
+	if spread <= 0 {
+		t.Fatalf("soft levels not separated: means=%v", means)
+	}
+	for i := 1; i < 4; i++ {
+		gap := means[i] - means[i-1]
+		if gap < 0.1*spread {
+			t.Errorf("adjacent soft levels too close: means=%v (gap %.4f < 10%% of spread %.4f)", means, gap, spread)
+		}
+	}
+}
+
+// TestCQPSKEmitsDibitsWithoutSoft locks in the honest Phase-1 contract:
+// the CQPSK path has no soft tap, so frames carry dibits but an empty
+// soft track.
+func TestCQPSKEmitsDibitsWithoutSoft(t *testing.T) {
+	iq, _ := makeC4FMIQ(960_000, 4000) // any IQ drives the Gardner loop
+
+	var frames []Frame
+	e, err := New(Options{
+		Emit:         func(f Frame) { frames = append(frames, f) },
+		InRateHz:     960_000,
+		Protocol:     trunking.ProtocolP25,
+		DemodMode:    "cqpsk",
+		FrameSymbols: 64,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	e.Process(iq)
+
+	if len(frames) == 0 {
+		t.Fatal("no frames emitted on CQPSK path")
+	}
+	for fi, f := range frames {
+		if len(f.Soft) != 0 {
+			t.Errorf("frame %d: CQPSK soft track should be empty, got %d", fi, len(f.Soft))
+		}
+		for _, d := range f.Dibits {
+			if d > 3 {
+				t.Fatalf("frame %d: dibit %d out of range", fi, d)
+			}
+		}
+	}
+}
+
+// TestFrameBatching checks the per-frame symbol batch size is honored
+// and frames tile the symbol stream without gaps or overlap.
+func TestFrameBatching(t *testing.T) {
+	iq, _ := makeC4FMIQ(960_000, 3000)
+
+	var total, frameCount int
+	e, _ := New(Options{
+		Emit: func(f Frame) {
+			frameCount++
+			// Every emitted frame is exactly FrameSymbols except possibly
+			// a trailing partial — but we never flush partials here, so
+			// all are full.
+			if len(f.Dibits) != 128 {
+				t.Errorf("frame %d: size %d, want 128", frameCount, len(f.Dibits))
+			}
+			total += len(f.Dibits)
+		},
+		InRateHz:     960_000,
+		Protocol:     trunking.ProtocolP25,
+		FrameSymbols: 128,
+	})
+	e.Process(iq)
+	if frameCount == 0 {
+		t.Fatal("no frames")
+	}
+}

--- a/internal/siglab/engine.go
+++ b/internal/siglab/engine.go
@@ -282,6 +282,15 @@ func runReader(r io.Reader, source string, decode SampleDecoder, bytesPerSample 
 
 	if iqTap != nil {
 		res.IQTaps = iqTap.result(receiverRate)
+		// Attach the aligned symbol series (dibits + pre-slicer soft) for
+		// the Symbol-scope viz, decimated to the same cap as the IQ. The
+		// analyzer already buffers them in lockstep on the deep P25 path.
+		if an != nil && len(an.symBuf) > 0 {
+			d, s := decimateSymbolSeries(an.symBuf, an.softBuf, cfg.captureIQMaxPoints())
+			res.IQTaps.SymbolDibits = d
+			res.IQTaps.SymbolSoft = s
+			res.IQTaps.SymbolCardinality = an.cardinality
+		}
 	}
 	return res, nil
 }

--- a/internal/siglab/engine_reader_test.go
+++ b/internal/siglab/engine_reader_test.go
@@ -94,6 +94,49 @@ func TestRunReaderCaptureIQ(t *testing.T) {
 	}
 }
 
+// TestRunReaderCaptureSymbolSeries confirms the aligned symbol series
+// (dibits + soft) that backs the offline Symbol-scope viz is populated,
+// aligned, bounded by the cap, and reports cardinality 4 for P25 C4FM.
+func TestRunReaderCaptureSymbolSeries(t *testing.T) {
+	iq, meta, err := Synthesize(SynthOptions{Protocol: trunking.ProtocolP25, Format: FormatF32})
+	if err != nil {
+		t.Fatalf("Synthesize: %v", err)
+	}
+	cfg, err := meta.Config(true)
+	if err != nil {
+		t.Fatalf("meta.Config: %v", err)
+	}
+	cfg.CollectIQDiag = true
+	cfg.CaptureIQ = true
+	cfg.CaptureIQMaxPoints = 4000
+
+	data := EncodeCapture(iq, FormatF32)
+	res, err := RunReader(bytes.NewReader(data), "p25.cfile", cfg)
+	if err != nil {
+		t.Fatalf("RunReader: %v", err)
+	}
+	if res.IQTaps == nil {
+		t.Fatal("expected IQTaps when CaptureIQ is set")
+	}
+	if len(res.IQTaps.SymbolDibits) == 0 {
+		t.Fatal("expected a symbol series when CollectIQDiag + CaptureIQ are set on P25")
+	}
+	if res.IQTaps.SymbolCardinality != 4 {
+		t.Errorf("SymbolCardinality = %d, want 4 for P25 C4FM", res.IQTaps.SymbolCardinality)
+	}
+	if len(res.IQTaps.SymbolDibits) > cfg.CaptureIQMaxPoints {
+		t.Errorf("symbol series exceeds cap: %d > %d", len(res.IQTaps.SymbolDibits), cfg.CaptureIQMaxPoints)
+	}
+	if n := len(res.IQTaps.SymbolSoft); n != 0 && n != len(res.IQTaps.SymbolDibits) {
+		t.Errorf("soft track len %d not aligned with dibits len %d", n, len(res.IQTaps.SymbolDibits))
+	}
+	for i, d := range res.IQTaps.SymbolDibits {
+		if d > 3 {
+			t.Fatalf("dibit %d at %d out of range", d, i)
+		}
+	}
+}
+
 // TestRunReaderAutoTuneNonSeekable confirms auto-tune over a non-seekable
 // reader fails with a clear error rather than silently mis-decoding.
 func TestRunReaderAutoTuneNonSeekable(t *testing.T) {

--- a/internal/siglab/iqtaps.go
+++ b/internal/siglab/iqtaps.go
@@ -32,6 +32,43 @@ type IQTaps struct {
 	// Stride is the input-to-output downsample ratio applied to the
 	// channelized stream.
 	Stride int `json:"stride" yaml:"stride"`
+
+	// SymbolDibits is the recovered-symbol decision stream (values
+	// 0..SymbolCardinality-1), decimated to the same cap as the IQ. It
+	// backs the offline Symbol-scope viz (the OP25-style time series).
+	// Empty for protocols/paths that buffer no symbols.
+	SymbolDibits []uint8 `json:"symbol_dibits,omitempty" yaml:"symbol_dibits,omitempty"`
+	// SymbolSoft is the pre-slicer soft waveform aligned index-for-index
+	// with SymbolDibits (deep P25 C4FM path). Empty when the demod path
+	// emits no soft samples (e.g. CQPSK); the viz then shows the dibit
+	// rows only.
+	SymbolSoft []float32 `json:"symbol_soft,omitempty" yaml:"symbol_soft,omitempty"`
+	// SymbolCardinality is 4 for the dibit (4-level) protocols, 2 for the
+	// bit (2-level) protocols.
+	SymbolCardinality int `json:"symbol_cardinality,omitempty" yaml:"symbol_cardinality,omitempty"`
+}
+
+// decimateSymbolSeries stride-decimates an aligned dibit + soft stream
+// down to at most maxPoints points, preserving alignment. The soft track
+// is carried only when it matches the dibit length (a soft-less path
+// returns dibits with a nil soft slice).
+func decimateSymbolSeries(dibits []uint8, soft []float32, maxPoints int) (outD []uint8, outS []float32) {
+	n := len(dibits)
+	if n == 0 || maxPoints <= 0 {
+		return nil, nil
+	}
+	hasSoft := len(soft) == n
+	stride := 1
+	if n > maxPoints {
+		stride = (n + maxPoints - 1) / maxPoints
+	}
+	for i := 0; i < n; i += stride {
+		outD = append(outD, dibits[i])
+		if hasSoft {
+			outS = append(outS, soft[i])
+		}
+	}
+	return outD, outS
 }
 
 // iqTapBuffer accumulates the decimated channelized IQ and soft samples for

--- a/web/siglab/src/api/types.ts
+++ b/web/siglab/src/api/types.ts
@@ -12,6 +12,11 @@ export interface IQTaps {
   soft_samples: number[];
   decimated_rate_hz: number;
   stride: number;
+  // Aligned symbol series for the Symbol-scope viz. soft is aligned
+  // index-for-index with dibits (empty on soft-less paths, e.g. CQPSK).
+  symbol_dibits?: number[];
+  symbol_soft?: number[];
+  symbol_cardinality?: number;
 }
 
 export interface LockInfo {

--- a/web/siglab/src/panels/Results.tsx
+++ b/web/siglab/src/panels/Results.tsx
@@ -7,6 +7,7 @@ import { Constellation } from "../viz/Constellation";
 import { PSD } from "../viz/PSD";
 import { Spectrogram } from "../viz/Spectrogram";
 import { EyeDiagram } from "../viz/EyeDiagram";
+import { SymbolScope } from "../viz/SymbolScope";
 import { SyncLandscape } from "../viz/SyncLandscape";
 import { ReceiverStates } from "../viz/ReceiverStates";
 import { GrantsTable, EventTimeline } from "../viz/Tables";
@@ -132,6 +133,13 @@ function VizGrid({ r, iq }: { r: Result; iq?: Result["iq_taps"] }) {
       )}
       {(soft.length > 1 || detail.soft_eye) && (
         <EyeDiagram soft={soft} eye={detail.soft_eye} />
+      )}
+      {iq && (iq.symbol_dibits?.length ?? 0) > 0 && (
+        <SymbolScope
+          soft={iq.symbol_soft ?? []}
+          dibits={iq.symbol_dibits ?? []}
+          cardinality={iq.symbol_cardinality}
+        />
       )}
       {detail.sync && <SyncLandscape sync={detail.sync} />}
       {detail.receiver_states && detail.receiver_states.length > 0 && (

--- a/web/siglab/src/viz/SymbolScope.tsx
+++ b/web/siglab/src/viz/SymbolScope.tsx
@@ -1,0 +1,104 @@
+import { useEffect, useRef } from "react";
+import * as d3 from "d3";
+
+// SymbolScope renders the recovered-symbol stream as an oscilloscope-style
+// time series — the offline twin of the live web console's Symbol scope,
+// and GopherTrunk's take on OP25's "Symbol" plot. Props contract is shared
+// verbatim with the live component (web/src/components/SymbolScopeChart):
+//
+//   - soft present (C4FM): scatter the pre-slicer soft samples; a 4-level
+//     channel reads as ~4 bands, with rails at each decided level's mean.
+//   - soft absent (dibit-only): plot the decisions as `cardinality` rows.
+export function SymbolScope({
+  soft,
+  dibits,
+  cardinality = 4,
+}: {
+  soft: number[];
+  dibits: number[];
+  cardinality?: number;
+}) {
+  const ref = useRef<SVGSVGElement | null>(null);
+
+  useEffect(() => {
+    const svg = d3.select(ref.current);
+    svg.selectAll("*").remove();
+    const n = dibits.length;
+    if (n === 0) return;
+
+    const w = 720;
+    const h = 240;
+    const m = 24;
+    const hasSoft = soft.length === n && n > 0;
+
+    svg.attr("width", w).attr("height", h).attr("viewBox", `0 0 ${w} ${h}`);
+
+    const x = d3.scaleLinear().domain([0, Math.max(1, n - 1)]).range([m, w - m]);
+
+    let y: d3.ScaleLinear<number, number>;
+    let rails: number[];
+    if (hasSoft) {
+      const ext = d3.max(soft, (s) => Math.abs(s)) ?? 1;
+      y = d3.scaleLinear().domain([-ext * 1.1, ext * 1.1]).range([h - m, m]);
+      // Rails at each decided level's mean soft value.
+      const sum = new Array(cardinality).fill(0);
+      const cnt = new Array(cardinality).fill(0);
+      for (let i = 0; i < n; i++) {
+        const d = dibits[i];
+        if (d >= 0 && d < cardinality) {
+          sum[d] += soft[i];
+          cnt[d]++;
+        }
+      }
+      rails = [];
+      for (let d = 0; d < cardinality; d++) {
+        if (cnt[d] > 0) rails.push(sum[d] / cnt[d]);
+      }
+    } else {
+      y = d3.scaleLinear().domain([-0.5, cardinality - 0.5]).range([h - m, m]);
+      rails = d3.range(cardinality);
+    }
+
+    rails.forEach((lvl) => {
+      svg
+        .append("line")
+        .attr("x1", m)
+        .attr("x2", w - m)
+        .attr("y1", y(lvl))
+        .attr("y2", y(lvl))
+        .attr("stroke", "rgba(148,163,184,0.18)");
+    });
+
+    // Scatter, decimated to a sane point count.
+    const max = 2500;
+    const step = Math.max(1, Math.floor(n / max));
+    const g = svg.append("g");
+    for (let i = 0; i < n; i += step) {
+      const yv = hasSoft ? soft[i] : dibits[i];
+      g.append("rect")
+        .attr("x", x(i) - 1)
+        .attr("y", y(yv) - 1)
+        .attr("width", 2)
+        .attr("height", 2)
+        .attr("fill", "rgba(56,189,248,0.55)");
+    }
+  }, [soft, dibits, cardinality]);
+
+  return (
+    <div className="card">
+      <h3 className="mb-2 text-sm font-semibold">Symbol scope</h3>
+      {dibits.length === 0 ? (
+        <p className="text-xs text-muted">
+          No symbols captured. Run with “collect IQ diag” + “capture IQ”.
+        </p>
+      ) : (
+        <svg ref={ref} className="mx-auto block w-full" />
+      )}
+      <p className="mt-2 text-xs text-muted">
+        {soft.length === dibits.length && dibits.length > 0
+          ? "Pre-slicer soft waveform with rails at each decided level."
+          : "Sliced dibit decisions (no soft track on this path)."}
+      </p>
+    </div>
+  );
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -10,6 +10,7 @@ import { Active } from "./panels/Active";
 import { Bookmarks } from "./panels/Bookmarks";
 import { CCActivity } from "./panels/CCActivity";
 import { Constellation } from "./panels/Constellation";
+import { SymbolScope } from "./panels/SymbolScope";
 import { Dashboard } from "./panels/Dashboard";
 import { Devices } from "./panels/Devices";
 import { Events } from "./panels/Events";
@@ -55,6 +56,7 @@ const EXTRA_TABS: Tab[] = [
   { to: "/mdc1200", label: "MDC1200", icon: "📻" },
   { to: "/spectrum", label: "Spectrum", icon: "≈" },
   { to: "/constellation", label: "Constellation", icon: "✦" },
+  { to: "/symbols", label: "Symbol scope", icon: "⩘" },
   { to: "/bookmarks", label: "Bookmarks", icon: "★" },
   { to: "/metrics", label: "Metrics", icon: "▰" },
   { to: "/devices", label: "Devices", icon: "⌗" },
@@ -187,6 +189,7 @@ export function App() {
           <Route path="/hunt" element={<Hunt />} />
           <Route path="/spectrum" element={<Spectrum />} />
           <Route path="/constellation" element={<Constellation />} />
+          <Route path="/symbols" element={<SymbolScope />} />
           <Route path="/bookmarks" element={<Bookmarks />} />
           <Route path="/systems" element={<Systems />} />
           <Route path="/talkgroups" element={<Talkgroups />} />

--- a/web/src/api/symbols.ts
+++ b/web/src/api/symbols.ts
@@ -1,0 +1,119 @@
+// Recovered-symbol stream client. Mirrors WS /api/v1/diag/symbols.
+// Same connect/reconnect scaffolding openIQStream (api/diag.ts) uses.
+
+import { type ClientConfig } from "./client";
+
+export interface SymbolFrame {
+  ts_ns: number;
+  symbol_rate_hz: number;
+  center_hz: number;
+  offset_hz: number;
+  // Pre-slicer soft waveform; empty when the demod path has no soft tap
+  // (e.g. P25 CQPSK). When present it is aligned index-for-index with
+  // dibits.
+  soft: number[];
+  // Sliced decisions: 0..3 when is_bits is false, 0..1 when true.
+  dibits: number[];
+  is_bits: boolean;
+  base_idx: number;
+}
+
+export type SymbolFrameHandler = (f: SymbolFrame) => void;
+export type StatusHandler = (s: "connecting" | "open" | "closed") => void;
+
+export interface SymbolStream {
+  close(): void;
+}
+
+export interface SymbolOptions {
+  serial: string;
+  // Receiver selector: "p25-c4fm" (soft + dibits) or "p25-cqpsk"
+  // (dibits only). Default "p25-c4fm".
+  proto?: string;
+  // Frequency offset in Hz, relative to the SDR centre, tuned down to
+  // baseband before channelizing. Default 0.
+  offset?: number;
+  onFrame: SymbolFrameHandler;
+  onStatus?: StatusHandler;
+}
+
+const INITIAL_BACKOFF = 500;
+const MAX_BACKOFF = 30_000;
+
+export function symbolWebSocketURL(cfg: ClientConfig, opts: SymbolOptions): string {
+  const params = new URLSearchParams({ device: opts.serial });
+  if (opts.proto) params.set("proto", opts.proto);
+  if (opts.offset != null && opts.offset !== 0)
+    params.set("offset", String(Math.round(opts.offset)));
+  const u = new URL(
+    `/api/v1/diag/symbols?${params.toString()}`,
+    cfg.baseURL || window.location.href,
+  );
+  u.protocol = u.protocol === "https:" ? "wss:" : "ws:";
+  return u.toString();
+}
+
+export function openSymbolStream(cfg: ClientConfig, opts: SymbolOptions): SymbolStream {
+  let closed = false;
+  let ws: WebSocket | null = null;
+  let backoff = INITIAL_BACKOFF;
+  let reconnectTimer: number | undefined;
+
+  const setStatus = (s: "connecting" | "open" | "closed") => {
+    if (!closed) opts.onStatus?.(s);
+  };
+
+  const jittered = (base: number) => base / 2 + Math.random() * (base / 2);
+
+  const connect = () => {
+    if (closed) return;
+    setStatus("connecting");
+    const url = symbolWebSocketURL(cfg, opts);
+    ws = new WebSocket(url);
+
+    ws.onopen = () => {
+      backoff = INITIAL_BACKOFF;
+      setStatus("open");
+    };
+
+    ws.onmessage = (ev) => {
+      if (closed) return;
+      try {
+        const frame = JSON.parse(ev.data) as SymbolFrame;
+        if (frame && Array.isArray(frame.dibits)) {
+          opts.onFrame(frame);
+        }
+      } catch {
+        // Drop malformed.
+      }
+    };
+
+    const onDown = () => {
+      if (closed) return;
+      ws = null;
+      setStatus("closed");
+      const wait = jittered(backoff);
+      backoff = Math.min(backoff * 2, MAX_BACKOFF);
+      reconnectTimer = window.setTimeout(connect, wait);
+    };
+    ws.onerror = onDown;
+    ws.onclose = onDown;
+  };
+
+  connect();
+
+  return {
+    close() {
+      closed = true;
+      setStatus("closed");
+      if (reconnectTimer !== undefined) window.clearTimeout(reconnectTimer);
+      if (ws) {
+        try {
+          ws.close();
+        } catch {
+          // ignore
+        }
+      }
+    },
+  };
+}

--- a/web/src/components/SymbolScopeChart.tsx
+++ b/web/src/components/SymbolScopeChart.tsx
@@ -1,0 +1,159 @@
+import { useEffect, useRef } from "react";
+
+// SymbolScopeChart renders the demodulated symbol stream as an
+// oscilloscope-style time series — GopherTrunk's take on OP25's "Symbol"
+// plot. Two modes, picked automatically from the data:
+//
+//   - Soft waveform present (C4FM): scatter the pre-slicer soft samples
+//     (x = symbol index, y = soft level). A 4-level signal reads as ~4
+//     noisy horizontal bands; faint rails mark each decided level's mean.
+//   - Soft absent (dibit-only, e.g. CQPSK): plot the sliced decisions as
+//     `cardinality` discrete rows.
+//
+// The contract (props below) is shared verbatim with the offline SigLab
+// viz so the two separate web builds render identically.
+
+export interface SymbolScopeChartProps {
+  soft: number[];
+  dibits: number[];
+  cardinality?: number;
+  height?: number;
+  className?: string;
+}
+
+// Drawing geometry — wide canvas; CSS scales to container width.
+const CANVAS_W = 720;
+const DEFAULT_H = 220;
+const PAD = { top: 12, right: 12, bottom: 18, left: 28 };
+
+// GopherTrunk sky-400 accent (matches the recolored Constellation and
+// the Spectrum waterfall), with neutral slate grid/labels.
+const TRACE_RGB = "56, 189, 248";
+const GRID_RGB = "148, 163, 184";
+
+export function SymbolScopeChart({
+  soft,
+  dibits,
+  cardinality = 4,
+  height = DEFAULT_H,
+  className,
+}: SymbolScopeChartProps) {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+  useEffect(() => {
+    paint(canvasRef.current, soft, dibits, cardinality);
+  }, [soft, dibits, cardinality]);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      width={CANVAS_W}
+      height={height}
+      className={className ?? "block w-full"}
+      style={{ height }}
+      aria-label="Demodulated symbol scope"
+    />
+  );
+}
+
+// paint draws one frame of the scope. Exported-by-reference through the
+// component; kept pure so the offline viz can reuse the identical body.
+function paint(
+  canvas: HTMLCanvasElement | null,
+  soft: number[],
+  dibits: number[],
+  cardinality: number,
+) {
+  if (!canvas) return;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return;
+  const w = canvas.width;
+  const h = canvas.height;
+  const plotW = w - PAD.left - PAD.right;
+  const plotH = h - PAD.top - PAD.bottom;
+  const x0 = PAD.left;
+  const y0 = PAD.top;
+
+  ctx.fillStyle = "rgb(0, 0, 0)";
+  ctx.fillRect(0, 0, w, h);
+
+  const n = dibits.length;
+  const hasSoft = soft.length > 0 && soft.length === dibits.length;
+
+  // Y mapper. Soft mode maps the soft range to the plot with padding;
+  // dibit mode maps 0..cardinality-1 onto evenly-spaced rows.
+  let toY: (i: number) => number;
+  let rails: number[] = [];
+
+  if (hasSoft) {
+    let lo = Infinity;
+    let hi = -Infinity;
+    for (const v of soft) {
+      if (v < lo) lo = v;
+      if (v > hi) hi = v;
+    }
+    if (!(hi > lo)) {
+      hi = lo + 1;
+      lo -= 1;
+    }
+    const span = hi - lo;
+    const pad = span * 0.12;
+    const top = hi + pad;
+    const bot = lo - pad;
+    toY = (v) => y0 + plotH * (1 - (v - bot) / (top - bot));
+
+    // Rails at each decided level's mean soft value.
+    const sum = new Array(cardinality).fill(0);
+    const cnt = new Array(cardinality).fill(0);
+    for (let i = 0; i < n; i++) {
+      const d = dibits[i];
+      if (d >= 0 && d < cardinality) {
+        sum[d] += soft[i];
+        cnt[d]++;
+      }
+    }
+    for (let d = 0; d < cardinality; d++) {
+      if (cnt[d] > 0) rails.push(toY(sum[d] / cnt[d]));
+    }
+  } else {
+    const rows = Math.max(1, cardinality);
+    const rowY = (d: number) =>
+      y0 + plotH * (1 - (d + 0.5) / rows);
+    toY = () => 0; // unused in dibit mode
+    for (let d = 0; d < rows; d++) rails.push(rowY(d));
+  }
+
+  // Grid: faint rails + a baseline frame.
+  ctx.strokeStyle = `rgba(${GRID_RGB}, 0.18)`;
+  ctx.lineWidth = 1;
+  for (const ry of rails) {
+    ctx.beginPath();
+    ctx.moveTo(x0, ry);
+    ctx.lineTo(x0 + plotW, ry);
+    ctx.stroke();
+  }
+  ctx.strokeStyle = `rgba(${GRID_RGB}, 0.30)`;
+  ctx.beginPath();
+  ctx.moveTo(x0, y0 + plotH);
+  ctx.lineTo(x0 + plotW, y0 + plotH);
+  ctx.stroke();
+
+  if (n === 0) return;
+
+  // Plot points. Additive blend so dense bands bloom.
+  ctx.globalCompositeOperation = "lighter";
+  const stepX = n > 1 ? plotW / (n - 1) : 0;
+  for (let i = 0; i < n; i++) {
+    const x = x0 + i * stepX;
+    let y: number;
+    if (hasSoft) {
+      y = toY(soft[i]);
+    } else {
+      const rows = Math.max(1, cardinality);
+      y = y0 + plotH * (1 - (dibits[i] + 0.5) / rows);
+    }
+    ctx.fillStyle = `rgba(${TRACE_RGB}, 0.55)`;
+    ctx.fillRect(x - 1, y - 1, 2, 2);
+  }
+  ctx.globalCompositeOperation = "source-over";
+}

--- a/web/src/panels/SymbolScope.test.tsx
+++ b/web/src/panels/SymbolScope.test.tsx
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+
+vi.mock("../api/spectrum", () => ({
+  fetchSpectrumDevices: vi.fn(),
+}));
+
+vi.mock("../api/symbols", () => ({
+  openSymbolStream: vi.fn(),
+}));
+
+import { fetchSpectrumDevices } from "../api/spectrum";
+import { openSymbolStream } from "../api/symbols";
+import { useShared } from "../store/shared";
+import { SymbolScope } from "./SymbolScope";
+
+function resetStore() {
+  useShared.setState({
+    serverURL: "http://localhost:8080",
+    token: null,
+    connected: true,
+    wsStatus: "idle",
+    mutations: null,
+    lastError: null,
+    events: [],
+    activeCalls: [],
+    devices: [],
+    systems: [],
+    talkgroups: [],
+    health: null,
+    audio: null,
+    scanner: null,
+  });
+}
+
+const oneDevice = [
+  {
+    serial: "rtl-1",
+    driver: "rtlsdr",
+    role: "control",
+    center_hz: 851_000_000,
+    sample_rate_hz: 2_048_000,
+  },
+];
+
+describe("Symbol scope panel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetStore();
+    window.localStorage.clear();
+  });
+
+  it("renders an empty-state when no SDRs are available", async () => {
+    vi.mocked(fetchSpectrumDevices).mockResolvedValue([]);
+    render(<SymbolScope />);
+    await waitFor(() => {
+      expect(screen.getByText("No SDRs available")).toBeInTheDocument();
+    });
+    expect(openSymbolStream).not.toHaveBeenCalled();
+  });
+
+  it("opens a symbol stream against the first device with a proto", async () => {
+    vi.mocked(fetchSpectrumDevices).mockResolvedValue(oneDevice);
+    vi.mocked(openSymbolStream).mockReturnValue({ close: vi.fn() });
+
+    render(<SymbolScope />);
+    await waitFor(() => {
+      expect(openSymbolStream).toHaveBeenCalled();
+    });
+    const callArgs = vi.mocked(openSymbolStream).mock.calls.at(-1)?.[1];
+    expect(callArgs?.serial).toBe("rtl-1");
+    expect(callArgs?.proto).toBe("p25-c4fm");
+  });
+
+  it("shows the live status pill when the WS reports open", async () => {
+    vi.mocked(fetchSpectrumDevices).mockResolvedValue(oneDevice);
+    vi.mocked(openSymbolStream).mockImplementation((_cfg, opts) => {
+      opts.onStatus?.("open");
+      return { close: vi.fn() };
+    });
+
+    render(<SymbolScope />);
+    await waitFor(() => {
+      expect(screen.getByText("live")).toBeInTheDocument();
+    });
+  });
+
+  it("surfaces device-discovery errors", async () => {
+    vi.mocked(fetchSpectrumDevices).mockRejectedValue(new Error("boom"));
+    render(<SymbolScope />);
+    await waitFor(() => {
+      expect(screen.getByText(/boom/)).toBeInTheDocument();
+    });
+  });
+
+  it("follows the active call on the selected SDR with an offset", async () => {
+    vi.mocked(fetchSpectrumDevices).mockResolvedValue(oneDevice);
+    vi.mocked(openSymbolStream).mockReturnValue({ close: vi.fn() });
+
+    useShared.setState({
+      activeCalls: [
+        {
+          grant: {
+            system: "sys",
+            protocol: "p25",
+            group_id: 1,
+            frequency_hz: 851_025_000,
+          },
+          device_serial: "rtl-1",
+          started_at: "2026-06-07T00:00:00Z",
+        },
+      ] as never,
+    });
+
+    render(<SymbolScope />);
+    await waitFor(() => {
+      const last = vi.mocked(openSymbolStream).mock.calls.at(-1)?.[1];
+      expect(last?.offset).toBe(25_000);
+    });
+  });
+
+  it("exposes the mode select and Hold / Centre controls", async () => {
+    vi.mocked(fetchSpectrumDevices).mockResolvedValue(oneDevice);
+    vi.mocked(openSymbolStream).mockReturnValue({ close: vi.fn() });
+
+    render(<SymbolScope />);
+    await waitFor(() => {
+      expect(openSymbolStream).toHaveBeenCalled();
+    });
+    expect(screen.getByText("Hold")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Centre" })).toBeInTheDocument();
+    // Mode select offers both P25 demod paths.
+    expect(screen.getByRole("option", { name: "P25 C4FM" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "P25 CQPSK" })).toBeInTheDocument();
+  });
+});

--- a/web/src/panels/SymbolScope.tsx
+++ b/web/src/panels/SymbolScope.tsx
@@ -1,0 +1,287 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  fetchSpectrumDevices,
+  type SpectrumDevice,
+} from "../api/spectrum";
+import { openSymbolStream, type SymbolFrame } from "../api/symbols";
+import { selectClientConfig, useShared } from "../store/shared";
+import { prefs } from "../store/prefs";
+import { SymbolScopeChart } from "../components/SymbolScopeChart";
+
+// Symbol scope panel — a live oscilloscope of the demodulated symbol
+// stream, GopherTrunk's take on OP25's "Symbol" plot. The daemon runs a
+// parallel decode (down-convert → protocol receiver) on the selected
+// SDR and streams the pre-slicer soft waveform + sliced dibit decisions;
+// we render a rolling window. For P25 C4FM a healthy channel reads as
+// ~4 noisy bands; CQPSK streams the dibit decisions only.
+//
+// The offset / Hold / follow-active-call controls mirror the
+// Constellation panel: dial the offset onto a locked control/voice
+// channel (or let Hold-off follow the newest active call) to lift its
+// symbols clear of the SDR centre DC spike.
+
+const WINDOW_SYMBOLS = 2400; // rolling scope width
+
+const PROTOS: { value: string; label: string; soft: boolean }[] = [
+  { value: "p25-c4fm", label: "P25 C4FM", soft: true },
+  { value: "p25-cqpsk", label: "P25 CQPSK", soft: false },
+];
+
+type ConnState = "connecting" | "open" | "closed";
+
+export function SymbolScope() {
+  const cfg = useShared(selectClientConfig);
+  const activeCalls = useShared((s) => s.activeCalls);
+  const [devices, setDevices] = useState<SpectrumDevice[]>([]);
+  const [selected, setSelected] = useState<string | null>(null);
+  const [conn, setConn] = useState<ConnState>("closed");
+  const [latest, setLatest] = useState<SymbolFrame | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const [proto, setProto] = useState<string>(() => prefs.symbolScopeProto());
+  const [offsetKHz, setOffsetKHz] = useState<number>(() =>
+    prefs.symbolScopeOffsetKHz(),
+  );
+  const [hold, setHold] = useState<boolean>(() => prefs.symbolScopeHold());
+
+  // Rolling window of recovered symbols, recreated per frame so the
+  // chart sees fresh array references.
+  const [window, setWindow] = useState<{ soft: number[]; dibits: number[] }>({
+    soft: [],
+    dibits: [],
+  });
+  const softRef = useRef<number[]>([]);
+  const dibitRef = useRef<number[]>([]);
+
+  // Discover SDRs (reuse the spectrum devices endpoint — same pool).
+  useEffect(() => {
+    let cancel = false;
+    (async () => {
+      try {
+        const list = await fetchSpectrumDevices(cfg);
+        if (cancel) return;
+        setDevices(list);
+        setError(null);
+        if (list.length > 0 && selected == null) setSelected(list[0].serial);
+      } catch (e) {
+        if (cancel) return;
+        setError(e instanceof Error ? e.message : String(e));
+      }
+    })();
+    return () => {
+      cancel = true;
+    };
+  }, [cfg, selected]);
+
+  const device = useMemo(
+    () => devices.find((d) => d.serial === selected) ?? null,
+    [devices, selected],
+  );
+
+  // Newest active call on the selected SDR → the offset (kHz) that
+  // centres it. Followed live when Hold is off.
+  const followOffsetKHz = useMemo(() => {
+    if (!device) return null;
+    const mine = activeCalls.filter(
+      (c) => c.device_serial === selected && !c.ended_at,
+    );
+    if (mine.length === 0) return null;
+    const newest = mine.reduce((a, b) => (b.started_at > a.started_at ? b : a));
+    return (newest.grant.frequency_hz - device.center_hz) / 1000;
+  }, [activeCalls, device, selected]);
+
+  useEffect(() => {
+    if (hold || followOffsetKHz == null) return;
+    setOffsetKHz((cur) =>
+      Math.abs(cur - followOffsetKHz) < 0.05 ? cur : followOffsetKHz,
+    );
+  }, [hold, followOffsetKHz]);
+
+  const maxOffsetKHz = device ? device.sample_rate_hz / 2000 : 1500;
+  const clampedOffsetKHz = Math.max(
+    -maxOffsetKHz,
+    Math.min(maxOffsetKHz, offsetKHz),
+  );
+
+  // Persist view options.
+  useEffect(() => {
+    prefs.setSymbolScopeOffsetKHz(offsetKHz);
+  }, [offsetKHz]);
+  useEffect(() => {
+    prefs.setSymbolScopeHold(hold);
+  }, [hold]);
+  useEffect(() => {
+    prefs.setSymbolScopeProto(proto);
+  }, [proto]);
+
+  // Open the symbol stream. Re-subscribe on device / proto / offset
+  // change so the server re-tunes and re-channelizes.
+  useEffect(() => {
+    if (!selected) return;
+    softRef.current = [];
+    dibitRef.current = [];
+    setWindow({ soft: [], dibits: [] });
+    setLatest(null);
+
+    const stream = openSymbolStream(cfg, {
+      serial: selected,
+      proto,
+      offset: Math.round(clampedOffsetKHz * 1000),
+      onFrame: (f) => {
+        setLatest(f);
+        const sb = softRef.current.concat(f.soft ?? []);
+        const db = dibitRef.current.concat(f.dibits ?? []);
+        // Keep soft aligned with dibits only when this frame carried a
+        // full soft track; otherwise the scope shows the dibit rows.
+        const aligned = sb.length === db.length;
+        softRef.current = aligned
+          ? sb.slice(Math.max(0, sb.length - WINDOW_SYMBOLS))
+          : [];
+        dibitRef.current = db.slice(Math.max(0, db.length - WINDOW_SYMBOLS));
+        setWindow({ soft: softRef.current, dibits: dibitRef.current });
+      },
+      onStatus: setConn,
+    });
+    return () => stream.close();
+  }, [cfg, selected, proto, clampedOffsetKHz]);
+
+  const viewHz = latest ? latest.center_hz + clampedOffsetKHz * 1000 : null;
+
+  const tuningLabel = useMemo(() => {
+    if (!latest) return "";
+    const off =
+      clampedOffsetKHz === 0
+        ? "centre"
+        : `${clampedOffsetKHz >= 0 ? "+" : ""}${clampedOffsetKHz.toFixed(1)} kHz`;
+    const soft = latest.soft && latest.soft.length > 0 ? "soft+dibits" : "dibits";
+    return `${((viewHz ?? latest.center_hz) / 1e6).toFixed(4)} MHz (${off}) · ${latest.symbol_rate_hz.toFixed(0)} sym/s · ${soft}`;
+  }, [latest, viewHz, clampedOffsetKHz]);
+
+  return (
+    <div className="space-y-3">
+      <header className="flex flex-wrap items-center justify-between gap-3">
+        <h2 className="text-xl font-semibold">Symbol scope</h2>
+        <div className="flex items-center gap-2 text-xs">
+          <span className="text-muted">SDR:</span>
+          <select
+            className="bg-surface border border-border rounded px-2 py-1"
+            value={selected ?? ""}
+            onChange={(e) => setSelected(e.target.value || null)}
+            disabled={devices.length === 0}
+          >
+            {devices.length === 0 && <option value="">No SDRs available</option>}
+            {devices.map((d) => (
+              <option key={d.serial} value={d.serial}>
+                {d.serial} · {d.role}
+              </option>
+            ))}
+          </select>
+          <ConnPill state={conn} />
+        </div>
+      </header>
+
+      {error && (
+        <div className="rounded border border-red-700/40 bg-red-900/20 text-red-200 text-xs px-3 py-2">
+          {error}
+        </div>
+      )}
+
+      <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-xs">
+        <label className="flex items-center gap-2">
+          <span className="text-muted">Mode</span>
+          <select
+            className="bg-surface border border-border rounded px-2 py-1"
+            value={proto}
+            onChange={(e) => setProto(e.target.value)}
+            aria-label="Demodulation mode"
+          >
+            {PROTOS.map((p) => (
+              <option key={p.value} value={p.value}>
+                {p.label}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className="flex items-center gap-2">
+          <span className="text-muted">Offset</span>
+          <input
+            type="range"
+            min={-maxOffsetKHz}
+            max={maxOffsetKHz}
+            step={Math.max(1, Math.round(maxOffsetKHz / 300))}
+            value={clampedOffsetKHz}
+            onChange={(e) => {
+              setHold(true);
+              setOffsetKHz(Number(e.target.value));
+            }}
+            className="w-40 accent-sky-400"
+            aria-label="View offset from SDR centre, kHz"
+          />
+          <input
+            type="number"
+            value={Number(clampedOffsetKHz.toFixed(1))}
+            onChange={(e) => {
+              setHold(true);
+              setOffsetKHz(Number(e.target.value));
+            }}
+            className="w-20 bg-surface border border-border rounded px-2 py-1 text-right font-mono"
+            aria-label="View offset from SDR centre in kHz (numeric)"
+          />
+          <span className="text-muted">kHz</span>
+        </label>
+
+        <button
+          type="button"
+          className="rounded border border-border px-2 py-1 hover:bg-surface disabled:opacity-40"
+          disabled={offsetKHz === 0}
+          onClick={() => {
+            setHold(true);
+            setOffsetKHz(0);
+          }}
+          title="Recentre the view on the SDR centre frequency"
+        >
+          Centre
+        </button>
+
+        <label
+          className="flex items-center gap-1.5"
+          title="When off, the view follows the newest active call on this SDR"
+        >
+          <input
+            type="checkbox"
+            checked={hold}
+            onChange={(e) => setHold(e.target.checked)}
+            className="accent-sky-400"
+          />
+          <span>
+            Hold
+            {!hold && followOffsetKHz != null && (
+              <span className="text-accent"> · following call</span>
+            )}
+          </span>
+        </label>
+      </div>
+
+      <div className="font-mono text-xs text-muted">{tuningLabel || "—"}</div>
+
+      <div className="rounded border border-border bg-black p-2">
+        <SymbolScopeChart soft={window.soft} dibits={window.dibits} />
+      </div>
+
+      <div className="text-[11px] text-muted">
+        Live demodulated symbols off the selected SDR. P25 C4FM shows the
+        pre-slicer soft waveform (~4 bands for a healthy channel) with
+        rails at each decided level; CQPSK shows the sliced dibit rows.
+        Dial the <em>Offset</em> onto a locked channel to lift it off the
+        centre DC spike.
+      </div>
+    </div>
+  );
+}
+
+function ConnPill({ state }: { state: ConnState }) {
+  if (state === "open") return <span className="pill-ok">live</span>;
+  if (state === "connecting") return <span className="pill-warn">connecting</span>;
+  return <span className="pill-err">offline</span>;
+}

--- a/web/src/store/prefs.ts
+++ b/web/src/store/prefs.ts
@@ -19,6 +19,9 @@ const LS_KEYS = {
   constellationHold: "gt.constellation.hold",
   constellationDcBlock: "gt.constellation.dcBlock",
   constellationAutoScale: "gt.constellation.autoScale",
+  symbolScopeOffsetKHz: "gt.symbolScope.offsetKHz",
+  symbolScopeHold: "gt.symbolScope.hold",
+  symbolScopeProto: "gt.symbolScope.proto",
 } as const;
 
 const SS_KEYS = {
@@ -160,6 +163,31 @@ export const prefs = {
   },
   setConstellationAutoScale(on: boolean) {
     writeLS(LS_KEYS.constellationAutoScale, on ? "1" : "0");
+  },
+
+  // Symbol-scope panel view options. Offset (kHz, relative to the SDR
+  // centre) tunes a locked channel under the scope; Hold pins it (off =
+  // follow the newest active call). Proto selects the receiver.
+  symbolScopeOffsetKHz(): number {
+    const raw = readLS(LS_KEYS.symbolScopeOffsetKHz);
+    if (raw === null) return 0;
+    const n = Number(raw);
+    return Number.isFinite(n) ? n : 0;
+  },
+  setSymbolScopeOffsetKHz(khz: number) {
+    writeLS(LS_KEYS.symbolScopeOffsetKHz, String(khz));
+  },
+  symbolScopeHold(): boolean {
+    return readLS(LS_KEYS.symbolScopeHold) === "1";
+  },
+  setSymbolScopeHold(on: boolean) {
+    writeLS(LS_KEYS.symbolScopeHold, on ? "1" : "0");
+  },
+  symbolScopeProto(): string {
+    return readLS(LS_KEYS.symbolScopeProto) ?? "p25-c4fm";
+  },
+  setSymbolScopeProto(p: string) {
+    writeLS(LS_KEYS.symbolScopeProto, p);
   },
 
   /** Clear all GopherTrunk-owned keys. Used by Settings → "forget this device". */


### PR DESCRIPTION
## What & why

Adds a **Symbol scope** — GopherTrunk's take on OP25's "Symbol" plot — both as a live web-console panel and as an offline SigLab viz. It shows the demodulated symbol stream over time: for P25 C4FM the pre-slicer **soft waveform** (~4 noisy bands for a healthy channel, with rails at each decided level), and for P25 CQPSK the **sliced dibit decisions**.

This follows the merged Constellation work (#559) and reuses its offset / Hold / follow-active-call UX, so you can dial the scope onto a locked control/voice channel and lift it clear of the SDR centre DC spike.

## Approach

Reuse the **production** DSP instead of re-implementing demod: a new `internal/scanner/symbolscope` engine wraps the production `ccdecoder.Downconverter` + P25 Phase 1 receiver and surfaces symbols through the receiver's existing `SoftSink`/`DibitSink` taps. It runs as a **parallel** decode on an `iqtap` broker subscription (the `diag_provider.go` pattern), so production control-channel decode is never touched. Soft and dibit are aligned index-for-index on the C4FM path.

## Changes

**Live path**
- `internal/scanner/symbolscope/scope.go` — shared `Engine` + `Frame` DTO (DDC → P25 receiver → soft/dibit taps), with tests.
- `internal/api/symbols.go` + `server.go` — `SymbolProvider` + `WS /api/v1/diag/symbols?device=&proto=&offset=`, with handler tests.
- `cmd/gophertrunk/symbol_provider.go` — daemon provider, wired next to the diag provider.
- `web/src/`: `api/symbols.ts` client, `components/SymbolScopeChart.tsx` (shared render contract), `panels/SymbolScope.tsx` (SDR + mode + offset/Hold/follow controls), App route/tab, prefs, panel test.

**Offline (SigLab)**
- `internal/siglab`: extend the already-served `IQTaps` with an aligned `symbol_dibits`/`symbol_soft`/`symbol_cardinality` series (decimated + capped), populated from the analyzer on the P25 deep path under `collect IQ diag` + `capture IQ`. Test asserts it's populated, aligned, capped, and cardinality 4.
- `web/siglab`: `IQTaps` types + a new `viz/SymbolScope.tsx` (d3 time series, same `{soft, dibits, cardinality}` props contract as the live chart), registered on the Results page next to the eye diagram.

- `docs/symbol-scope.md` + `CHANGELOG.md`.

## Scope / fidelity (honest)

This is **Phase 1: P25 Phase 1**. C4FM gets soft + dibits; CQPSK gets dibits only (the receiver has no soft tap on that path yet). **Phase 2** — TETRA π/4-DQPSK and the rest of the C4FM family (DMR/NXDN/YSF/D-STAR), and a soft waveform for them — adds a uniform `SoftTap` to those receivers and reuses this exact engine, DTO, provider, panel, and viz unchanged.

## Verification

- `go build ./...`, `go vet`, `gofmt -l` clean.
- Go tests: `symbolscope` (synth C4FM → 4 separable soft levels aligned to dibits; CQPSK dibit-only; frame batching), `api` (503 / 400 / unknown-proto / frame delivery), `siglab` (offline series populated, aligned, capped, cardinality 4) — pass.
- Both web apps: `tsc --noEmit` clean; vitest green (incl. a 6-case `SymbolScope` panel test).

https://claude.ai/code/session_01LDqnd95fQP7ojzq1LkeQT7

---
_Generated by [Claude Code](https://claude.ai/code/session_01LDqnd95fQP7ojzq1LkeQT7)_