### PR TITLE
docs: post-release v0.3.3 + v0.3.4 + v0.3.5 — backfill CHANGELOG, bump refs, sync pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,30 +7,56 @@ for tagged releases.
 
 ## [Unreleased]
 
+## [v0.3.5] — 2026-06-07
+
+Site/system **hunting** grows up — `gophertrunk hunt` turns from a one-shot
+capture mapper into a live, daemon-integrated discovery engine driven from the
+CLI, the TUI, and a web panel with a REST cockpit (#549–#558) — alongside a
+live **Symbol scope** oscilloscope (#563) and a much-improved
+**Constellation** panel with a server-side frequency-offset view (#559). On
+the SDR side, `soapyremote` finally streams reliably (flow-control ACKs,
+#545), wideband sources can run up to 20 MHz (#560), and a per-device
+`iq_invert` lets spectrum-inverted front-ends lock TETRA (#562).
+
 ### Added
 
+- **Site/system hunting — live, daemon-integrated discovery of undocumented
+  trunked systems** (#549–#558). `gophertrunk hunt` now does far more than map
+  a pre-recorded capture: a live spectrum-sweep discovery engine scans for
+  control channels off a live SDR, with a CLI live mode driving it (#552); a
+  daemon-integrated hunt manager acquires a spare SDR — else borrows one from
+  the pool — to run the sweep inside the running daemon (#554); and the run is
+  surfaced through TUI + web-console panels (#556) backed by a REST cockpit
+  (#555). Each run honours a requested SDR serial (#558), exports by run id
+  with a bounded run history (#558), and can be started straight from the TUI
+  panel (#558). Discovery auto-identifies the protocol, accumulates a
+  `DiscoveredSystem` map, and resolves per-protocol **site topology** —
+  system id + adjacent sites — for P25 (#551), DMR Tier III, EDACS, Motorola
+  Type II, NXDN, and TETRA single-site identity (#558), exporting standardized
+  files plus a ready-to-paste RadioReference submission. See
+  [`docs/hunt.md`](docs/hunt.md).
 - **Symbol scope — live demodulated-symbol oscilloscope (OP25-style "Symbol"
-  plot).** A new web panel (`/symbols`) renders the demodulated symbol stream
-  off a live SDR: for **P25 C4FM** it shows the pre-slicer soft waveform (~4
-  noisy bands for a healthy channel, with rails at each decided level), and
-  for **P25 CQPSK** the sliced dibit decisions. It reuses the **production**
-  DSP — the same down-converter and P25 Phase 1 receiver the live decoder
-  uses, run as a *parallel* decode on the iqtap broker so production
-  control-channel decode is never touched — exposed through the receiver's
-  existing soft/dibit taps. The panel shares the Constellation panel's
-  offset / Hold / follow-active-call controls, so you can dial the scope onto
-  a locked control/voice channel and lift it clear of the SDR centre DC
-  spike. Backed by a new `WS /api/v1/diag/symbols?device=&proto=&offset=`
-  endpoint and the `internal/scanner/symbolscope` engine. The offline
-  **SigLab** analyzer gains the matching view: a capture run with
-  `collect IQ diag` + `capture IQ` now carries an aligned symbol series on
-  its `IQTaps`, rendered by a new SigLab Symbol-scope viz alongside the eye
-  diagram. TETRA and the rest of the C4FM family (DMR/NXDN/YSF/D-STAR) — and
-  a soft waveform for them — follow as per-receiver soft taps ship.
-
+  plot)** (#563). A new web panel (`/symbols`) renders the demodulated symbol
+  stream off a live SDR: for **P25 C4FM** it shows the pre-slicer soft
+  waveform (~4 noisy bands for a healthy channel, with rails at each decided
+  level), and for **P25 CQPSK** the sliced dibit decisions. It reuses the
+  **production** DSP — the same down-converter and P25 Phase 1 receiver the
+  live decoder uses, run as a *parallel* decode on the iqtap broker so
+  production control-channel decode is never touched — exposed through the
+  receiver's existing soft/dibit taps. The panel shares the Constellation
+  panel's offset / Hold / follow-active-call controls, so you can dial the
+  scope onto a locked control/voice channel and lift it clear of the SDR
+  centre DC spike. Backed by a new
+  `WS /api/v1/diag/symbols?device=&proto=&offset=` endpoint and the
+  `internal/scanner/symbolscope` engine. The offline **SigLab** analyzer gains
+  the matching view: a capture run with `collect IQ diag` + `capture IQ` now
+  carries an aligned symbol series on its `IQTaps`, rendered by a new SigLab
+  Symbol-scope viz alongside the eye diagram. TETRA and the rest of the C4FM
+  family (DMR/NXDN/YSF/D-STAR) — and a soft waveform for them — follow as
+  per-receiver soft taps ship. See [`docs/symbol-scope.md`](docs/symbol-scope.md).
 - **Constellation panel — frequency-offset view + cleaner render (issue
-  #557).** A centre-tuned constellation is dominated by the SDR's DC spike
-  (the DDC's residual carrier leakage at 0 Hz), which sits on top of any
+  #557)** (#559). A centre-tuned constellation is dominated by the SDR's DC
+  spike (the DDC's residual carrier leakage at 0 Hz), which sits on top of any
   signal in the middle of the band and reduces the plot to one fat blob. The
   panel now offers an **Offset** control that mixes an off-centre control or
   voice channel down to baseband *server-side, before decimation* (a new
@@ -43,9 +69,45 @@ for tagged releases.
   phosphor green) with labelled ±1 axes, a **DC-block**
   (subtract the rolling mean), and an **Auto-scale** that fills the unit
   circle.
+- **`soapyremote`: free-form device-args config block (issue #542)** (#546). A
+  `sdr.soapy_remote.device_args` map passes arbitrary key/value pairs straight
+  to SoapyRemote's device factory, so a remote front-end that needs
+  driver-specific arguments (antenna path, reference clock, channel) can be
+  configured without a code change.
+- **`ccdecoder`: per-device spectrum-inversion (`iq_invert`) option** (#562).
+  A new per-device `iq_invert` flips I/Q at the source so a spectrum-inverted
+  front-end (R828D / RTL-SDR Blog V4) locks TETRA and the other control
+  channels; shipped with a production-rate (144 kHz / 8 sps) TETRA
+  control-channel lock test (#561, #553).
+
+### Changed
+
+- **`sdr.sample_rate` config ceiling raised to 20 MHz** (#560) for wideband
+  sources (HackRF, Airspy, or a SoapyRemote-fronted USRP / LimeSDR) that can
+  feed a wider span than the previous cap allowed.
+
+### Fixed
+
+- **`soapyremote`: send stream flow-control ACKs so RX actually streams (issue
+  #542)** (#545). SoapyRemote's data stream is flow-controlled; without the
+  periodic ACKs the server throttled itself to a stop after the initial burst,
+  so the tuner appeared to connect but delivered no samples.
+- **Drive the IQ pump for single-channel decoders on dedicated dongles (issue
+  #547)** (#548). A single-channel decoder bound to its own dongle was not
+  pumping IQ through the channelizer, so a dedicated-dongle conventional /
+  single-system setup never produced samples; the pump now runs on that path.
+
+## [v0.3.4] — 2026-06-06
+
+High-bit-depth **SoapyRemote** network SDRs and a first-class raw-IQ
+**capture** toolchain land (#540, #541), plus a fast algebraic BCH(63,16) NID
+decoder that clears the P25 decode-lag (#492) and a batch of RTL-SDR R82xx /
+R828D gain and PLL fixes.
+
+### Added
 
 - **SoapySDRServer remote SDRs — high-bit-depth network streaming + control
-  from professional hardware (issue #536).** A new pure-Go (zero-CGO)
+  from professional hardware (issue #536)** (#541). A new pure-Go (zero-CGO)
   `soapyremote` SDR backend connects to a remote `SoapySDRServer` (from
   pothosware/SoapyRemote) and mounts it as a virtual tuner alongside local
   USB dongles and `rtl_tcp` endpoints. Unlike `rtl_tcp`'s hardcoded 8-bit
@@ -57,8 +119,8 @@ for tagged releases.
   TCP transport. Chosen over the originally-proposed VITA 49.2 (VRT) because
   SoapyRemote reaches the same professional hardware with a real,
   interoperable control plane and a single maintained server binary.
-- **`gophertrunk capture` — record raw IQ off a live SDR to a `.cfile`.**
-  A first-class subcommand that opens a dongle directly (no daemon),
+- **`gophertrunk capture` — record raw IQ off a live SDR to a `.cfile`**
+  (#540). A first-class subcommand that opens a dongle directly (no daemon),
   records the requested number of seconds of raw IQ to a GNU Radio cfile
   (interleaved little-endian float32) or rtl_sdr-native `u8`, and writes a
   siglab `.metadata.json` sidecar so the capture is a drop-in fixture for
@@ -67,8 +129,8 @@ for tagged releases.
   -protocol p25 -out cc.cfile` (`gophertrunk capture -list` enumerates
   SDRs). Complements the daemon's existing `--iq-capture` diagnostic,
   which taps a control SDR already in the running pool.
-- **Capture-and-export from the SigLab web console.** A new "Capture from
-  tuner" control on the Captures panel records a fixed-length raw-IQ
+- **Capture-and-export from the SigLab web console** (#540). A new "Capture
+  from tuner" control on the Captures panel records a fixed-length raw-IQ
   capture off a live tuner through the daemon, stages it for immediate
   analysis, and offers the raw `.cfile` as a browser download. Backed by
   new HTTP routes `GET /api/v1/siglab/capture/devices`,
@@ -76,12 +138,27 @@ for tagged releases.
   `GET /api/v1/siglab/captures/{id}/download`. The routes return 503 when
   the console is offline (`siglab serve`) or the daemon has no SDR, so a
   build without a tuner doesn't pretend it can record.
+- **DMR Tier II Voice LC Header FEC verified against MMDVM + off-air
+  diagnostics** (#539). The Tier II Voice LC Header decode path is now
+  cross-checked against MMDVM's reference FEC and gains off-air diagnostics so
+  a failing real-capture header reports where in the BPTC / RS chain it broke.
 
 ### Fixed
 
-- **`soapyremote`: stream setup now follows SoapyRemote's real TCP
-  handshake, fixing a crash against live `SoapySDRServer` hardware (issue
-  #542).** The TCP stream setup was a single-reply, single-socket guess; real
+- **framing: fast algebraic BCH(63,16) NID decoder clears the P25 decode lag
+  (issue #492)** (#534, #537). The NID decode is replaced with an algebraic
+  Berlekamp–Massey / Chien BCH(63,16) decoder, removing the per-frame latency
+  that was starving the P25 control-channel decoder.
+- **rtlsdr: fix inverted mixer-AGC bit and missing VGA in R82xx
+  `SetGainMode`** (#535). The R82xx gain-mode path inverted the mixer-AGC
+  control bit and never set the VGA, leaving manual-gain dongles deaf; both
+  are corrected.
+- **rtlsdr: use a VCO power reference of 1 for R828D (Blog V4) PLL fine-tune**
+  (#538). The R828D / RTL-SDR Blog V4 PLL fine-tune used the wrong VCO power
+  reference, hurting fine-tune accuracy on that tuner.
+- **`soapyremote`: stream setup now follows SoapyRemote's real TCP handshake,
+  fixing a crash against live `SoapySDRServer` hardware (issue #542)** (#543).
+  The TCP stream setup was a single-reply, single-socket guess; real
   SoapyRemote is a two-phase, two-socket exchange (the server replies with the
   data port, accepts both a stream **and** a status socket, then replies with
   the integer stream id). The old code misread the first reply (`setup stream
@@ -91,11 +168,48 @@ for tagged releases.
   devices that spend seconds compiling their RFNoC graph. Verified against the
   upstream source; smoke-test against live hardware before relying on it.
 - **`soapyremote`: a manual `gain` now applies on front-ends without AGC
-  (issue #542).** Setting a numeric gain first disabled automatic gain control;
-  on radios with no AGC at all (e.g. a USRP TwinRX) that call fails with
-  `set_rx_agc() is not supported on this radio` and used to abort the whole
-  gain set, leaving the device at its default. Disabling AGC is now best-effort,
-  so the manual gain value is still applied.
+  (issue #542)** (#543). Setting a numeric gain first disabled automatic gain
+  control; on radios with no AGC at all (e.g. a USRP TwinRX) that call fails
+  with `set_rx_agc() is not supported on this radio` and used to abort the
+  whole gain set, leaving the device at its default. Disabling AGC is now
+  best-effort, so the manual gain value is still applied.
+
+## [v0.3.3] — 2026-06-05
+
+The P25 CQPSK **linear path** now decodes C4FM — a T/2 fractionally-spaced
+equalizer (#532, #492) plus a multipath-gated carrier seed (#529) — and
+**SigLab** grows a standalone web SPA over an offline HTTP API (#530). Plus
+RTL-SDR Blog V4 detection diagnostics (#528) and a DMR Tier II BPTC/RS
+bit-layout fix (#527).
+
+### Added
+
+- **SigLab: standalone web SPA + offline HTTP API** (#530). `siglab serve`
+  exposes the offline signal-analysis engine over HTTP and ships a standalone
+  Signal Lab single-page app with multi-capture visualization, backed by a new
+  in-memory decode path and decimated-IQ taps so a capture can be analysed
+  without writing intermediate files.
+- **RTL-SDR Blog V4 detection diagnostics + manual override (issue #264)**
+  (#528). The tuner-detection path now reports why it did (or didn't) classify
+  a dongle as a Blog V4, with a manual override for the ambiguous R828D case.
+- **Docs: decoder live-capture requirements summary** (#526). A new summary of
+  what each decoder needs from a live capture (sample rate, span, SNR) to lock.
+  See [`docs/decoder-capture-needs.md`](docs/decoder-capture-needs.md).
+
+### Fixed
+
+- **DMR: BPTC/RS bit layout corrected so real Tier II Voice LC Headers decode**
+  (#527). The BPTC(196,96) + RS(12,9,4) bit ordering didn't match on-air Tier
+  II Voice LC Headers, so real captures failed FEC; the layout now matches
+  MMDVM and decodes live headers.
+- **p25/cqpsk: T/2 fractionally-spaced equalizer so the linear path decodes
+  C4FM (issue #492)** (#532). A symbol-spaced equalizer can't correct the
+  timing error a C4FM signal carries on the linear (CQPSK) path; the new T/2
+  fractionally-spaced equalizer does, so the linear demodulator recovers C4FM.
+- **p25/cqpsk: gate the carrier seed on multipath; un-skip the #492 repro**
+  (#529). The coarse carrier seed only helps under multipath, so it is now
+  gated on a multipath estimate (it was biasing clean-signal locks), and the
+  #492 reproduction test is un-skipped.
 
 ## [v0.3.2] — 2026-06-04
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ this exist? Read **[The Story of GopherTrunk](https://gophertrunk.org/story.html
 
 ```sh
 # Linux x86_64 — see https://gophertrunk.org/downloads.html for macOS, Windows, ARM64.
-VERSION=v0.3.2
+VERSION=v0.3.5
 curl -L -o gophertrunk.tar.gz \
   https://github.com/MattCheramie/GopherTrunk/releases/download/${VERSION}/gophertrunk-${VERSION}-linux-amd64.tar.gz
 tar xzf gophertrunk.tar.gz && cd gophertrunk-${VERSION}-linux-amd64
@@ -207,6 +207,12 @@ Silicon and Intel. Full per-OS recipes at
   noise), spotting frequency offset, and checking demod /
   equalizer health. Decimated to 2 ksps for the wire; canvas
   scatter with energy banner. Web panel at `/constellation`.
+- **Symbol scope** — live oscilloscope of the demodulated symbol
+  stream (OP25's "Symbol" plot): the pre-slicer soft waveform for
+  P25 C4FM and the sliced dibit decisions for CQPSK, driven off the
+  production receiver. Shares the constellation's offset / Hold /
+  follow-active-call controls. Web panel at `/symbols`; offline view
+  in SigLab. See [docs/symbol-scope.md](docs/symbol-scope.md).
 - **Bookmarks / frequency manager** — UI-managed conventional
   channel list (marine VHF, NOAA weather, FRS/GMRS, repeater
   outputs, public-safety fall-back channels) stored in the
@@ -371,6 +377,8 @@ Operator-facing docs live at **[gophertrunk.org](https://gophertrunk.org)**
   [Live config editing](docs/live-edits.md) ·
   [Import (PDF / CSV)](docs/import.md) ·
   [Hunt (discover unknown systems)](docs/hunt.md) ·
+  [Constellation](docs/constellation.md) ·
+  [Symbol scope](docs/symbol-scope.md) ·
   [Hardening](docs/hardening.md)
 - **Reference** — [Architecture](docs/architecture.md) ·
   [Vocoders](docs/vocoders.md) ·

--- a/docs/_data/nav.yml
+++ b/docs/_data/nav.yml
@@ -49,6 +49,10 @@ groups:
         url: /radio-ids.html
       - title: Constellation
         url: /constellation.html
+      - title: Symbol scope
+        url: /symbol-scope.html
+      - title: Hunt (discover systems)
+        url: /hunt.html
       - title: rigctld integration
         url: /rigctld.html
       - title: Hardening

--- a/docs/announcements/v0.3.5.md
+++ b/docs/announcements/v0.3.5.md
@@ -1,0 +1,53 @@
+# GopherTrunk v0.3.5 — social announcement drafts
+
+One-click copy-paste blurbs for posting the v0.3.5 release. Each block
+below is a fenced code block so the rendered-markdown "copy" button
+grabs exactly what you'd paste.
+
+Release: https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.3.5
+
+---
+
+## Reddit — title
+
+```
+GopherTrunk v0.3.5 — live site/system hunting for undocumented trunked systems, a Symbol-scope panel, high-bit-depth SoapyRemote SDRs, and raw-IQ capture
+```
+
+## Reddit — body
+
+```markdown
+**[GopherTrunk](https://gophertrunk.org) v0.3.5 is out** — pure-Go digital-trunking scanner for RTL-SDR / HackRF / Airspy. P25 (Phase 1+2), DMR (AMBE+2 voice), NXDN, Motorola Type II, EDACS, LTR, MPT 1327, dPMR, D-STAR, YSF, M17, plus APRS, POCSAG + FLEX paging, and AIS / DSC / ADS-B. No CGO, single static binary for Linux / macOS / Windows.
+
+**What's new since v0.3.2** (rolls up the v0.3.3–v0.3.5 daily releases):
+
+* **Live site/system hunting** (#549–#558) — `gophertrunk hunt` is now a live, daemon-integrated discovery engine, not just a capture mapper. It sweeps spectrum for control channels off a live SDR (acquiring a spare dongle, else borrowing one from the pool), auto-identifies the protocol, accumulates a `DiscoveredSystem` map, and resolves per-protocol site topology (system id + adjacent sites) for P25, DMR Tier III, EDACS, Motorola Type II, NXDN, and TETRA — exporting standardized files plus a ready-to-paste RadioReference submission. Drive it from the CLI, the TUI, or a web panel with a REST cockpit.
+* **Symbol scope** (#563) — a new web panel (`/symbols`) that renders the demodulated symbol stream live: the pre-slicer soft waveform for P25 C4FM and the sliced dibit decisions for CQPSK, off the production receiver. OP25's "Symbol" plot, with the constellation's offset / Hold / follow-active-call controls and a matching offline view in SigLab.
+* **Constellation panel — frequency-offset view** (#559, #557) — a server-side `offset` mixes an off-centre channel down to baseband before decimation so its symbols lift out from under the SDR's DC spike, plus DC-block, auto-scale, and a cleaner render.
+* **High-bit-depth SoapyRemote SDRs** (#536, #541–#546) — a pure-Go `soapyremote` backend mounts a remote `SoapySDRServer` (USRP, LimeSDR, bladeRF, HackRF, Airspy, SDRplay…) as a virtual tuner carrying full-dynamic-range 16-bit / float IQ, now with reliable flow-controlled streaming and a free-form device-args block.
+* **Raw-IQ capture toolchain** (#540) — `gophertrunk capture` records raw IQ off a live SDR to a `.cfile` with a siglab metadata sidecar (a drop-in `replay` / `analyze` / `test` fixture), plus capture-and-export straight from the SigLab web console.
+* **Decode + RF fixes** — fast algebraic BCH(63,16) NID decoder that clears the P25 decode lag (#492), a T/2 fractionally-spaced CQPSK equalizer so the linear path decodes C4FM (#532), a DMR Tier II BPTC/RS bit-layout fix (#527), RTL-SDR R82xx gain + R828D/Blog-V4 PLL fixes (#535, #538), a per-device `iq_invert` for spectrum-inverted TETRA front-ends (#562), and a wideband `sdr.sample_rate` ceiling raised to 20 MHz (#560).
+
+**Downloads** (Linux / macOS / Windows, x64 + ARM64): https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.3.5
+
+**Docs:** https://gophertrunk.org
+
+Heads-up: the v0.x line is still flagged prerelease — actively developed, feedback / captures / bug reports very welcome.
+```
+
+## Discord
+
+```markdown
+**GopherTrunk v0.3.5 is out** — pure-Go trunking scanner for RTL-SDR / HackRF / Airspy. P25, DMR, NXDN, M17, analog trunked, APRS, POCSAG + FLEX paging, AIS / DSC / ADS-B. Single static binary, zero CGO.
+
+**What's new since v0.3.2** (v0.3.3–v0.3.5 daily releases):
+- **Live site/system hunting** (#549–#558) — `gophertrunk hunt` sweeps for control channels off a live SDR, identifies the protocol, maps per-protocol site topology (P25 / DMR T3 / EDACS / Moto Type II / NXDN / TETRA), and exports it; CLI + TUI + web panel + REST cockpit.
+- **Symbol scope** (#563) — `/symbols` panel: live demodulated-symbol oscilloscope (soft waveform for C4FM, dibit decisions for CQPSK) + offline SigLab view.
+- **Constellation frequency-offset view** (#559) — server-side offset lifts symbols off the DC spike; DC-block + auto-scale.
+- **High-bit-depth SoapyRemote SDRs** (#536, #541) — mount a remote USRP / Lime / bladeRF / Airspy as a virtual 16-bit/float tuner, now with reliable flow-controlled streaming.
+- **Raw-IQ capture** (#540) — `gophertrunk capture` to `.cfile` + capture-and-export from the SigLab console.
+- **Decode/RF fixes** — fast BCH(63,16) NID decoder (#492), T/2 CQPSK equalizer for C4FM (#532), DMR Tier II BPTC/RS fix (#527), RTL-SDR R82xx/R828D fixes (#535, #538), per-device `iq_invert` for TETRA (#562), 20 MHz sample-rate ceiling (#560).
+
+Download: <https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.3.5>
+Docs: <https://gophertrunk.org>
+```

--- a/docs/downloads.md
+++ b/docs/downloads.md
@@ -28,7 +28,7 @@ release state looks like:
 {%- elsif site.github.releases and site.github.releases[0] and site.github.releases[0].tag_name -%}
   {%- assign ver = site.github.releases[0].tag_name -%}
 {%- else -%}
-  {%- assign ver = "v0.3.2" -%}
+  {%- assign ver = "v0.3.5" -%}
 {%- endif -%}
 {%- assign rel_url = "https://github.com/MattCheramie/GopherTrunk/releases/download/" | append: ver -%}
 

--- a/docs/hunt.md
+++ b/docs/hunt.md
@@ -1,3 +1,10 @@
+---
+layout: page
+title: Hunting & mapping unknown systems
+description: Discover, identify, map, and export undocumented trunked radio systems from live SDRs or IQ captures with gophertrunk hunt
+nav_group: Operate
+---
+
 # Hunting & mapping unknown systems
 
 Many states and counties run trunked radio systems that are **not documented


### PR DESCRIPTION
The v0.3.3-v0.3.5 daily releases shipped (PRs #526-#563) but the docs
still pointed at v0.3.2. Sync the docs tree to the released tags:

- CHANGELOG: promote the [Unreleased] soapyremote/capture work into a
  new [v0.3.4] section and the symbol-scope/constellation work into a
  new [v0.3.5] section, then backfill the missing [v0.3.3] (P25 CQPSK
  linear-path equalizer, SigLab web SPA, Blog V4 diagnostics, DMR Tier
  II BPTC/RS fix) and the rest of v0.3.4 (BCH NID decoder, rtlsdr gain/
  PLL fixes) and v0.3.5 (live site/system hunting, soapyremote stream
  fixes, 20 MHz ceiling, iq_invert). Reset [Unreleased] to empty.
- README / docs/downloads.md: bump the hardcoded version refs
  v0.3.2 -> v0.3.5; add the Symbol scope feature + doc links.
- docs: add front matter to hunt.md so it renders with the page layout,
  and add Hunt + Symbol scope to the site nav.
- docs/announcements: add the v0.3.5 social-announcement drafts.