### PR TITLE
Constellation/Symbol scope: precise tuning + zoom (#557 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ for tagged releases.
 
 ## [Unreleased]
 
+### Changed
+
+- **Constellation & Symbol scope tuning refinements** (#557 follow-up). The
+  Symbol scope now shows the tuned frequency as soon as an SDR is selected,
+  instead of staying blank until symbols decode. Both panels gain precise
+  channel entry: the **kHz** offset field takes 1 Hz resolution (so 6.25 /
+  12.5 kHz channel grids land exactly) plus an absolute **MHz** frequency
+  field that stays in sync. The Constellation gains an adjustable **Zoom**
+  control (and a larger default dot size), and its auto-scale now targets the
+  ~95th-percentile radius so a stray outlier no longer shrinks the cloud.
+
 ## [v0.3.5] — 2026-06-07
 
 Site/system **hunting** grows up — `gophertrunk hunt` turns from a one-shot

--- a/docs/constellation.md
+++ b/docs/constellation.md
@@ -35,7 +35,10 @@ collapses into one fat blob. Three controls work around this:
   down to baseband *server-side, before decimation*, so an off-centre
   control or voice channel is pulled out from under the DC spike and
   rendered as a clean constellation. This is the same trick OP25 uses.
-  Drag the slider or type a kHz value.
+  Drag the slider for a coarse sweep, or type an exact value: the
+  **kHz** field takes 1 Hz resolution (so channel grids like 6.25 /
+  12.5 kHz land precisely), and the **MHz** field lets you type the
+  channel's absolute frequency — the two stay in sync.
 - **Hold** — when off, the Offset automatically follows the newest
   active call on the selected SDR (the "last locked channel"). Turn
   Hold on to pin the view on a specific offset and stop it from
@@ -43,7 +46,11 @@ collapses into one fat blob. Three controls work around this:
   **Centre** pins it too.
 - **DC block** / **Auto scale** — DC-block subtracts the rolling mean
   to remove any residual offset; auto-scale eases a gain so the cloud
-  fills the unit circle regardless of input amplitude. Both default on.
+  fills the unit circle (targeting the ~95th-percentile radius, so a
+  stray outlier doesn't shrink the whole cloud). Both default on.
+- **Zoom** — magnifies the plotted cloud and the dot size together, so
+  the scatter reads as dots rather than pin-pricks; dial it to taste.
+  The setting persists across visits.
 
 Common shapes:
 
@@ -104,7 +111,8 @@ Common shapes:
 | `internal/api/diag.go` | `DiagProvider` interface + `WS /api/v1/diag/iq` handler |
 | `cmd/gophertrunk/diag_provider.go` | Daemon-side `diagProvider` — wires the decimator to the iqtap broker for each WS subscriber |
 | `web/src/api/diag.ts` | Typed client with auto-reconnect / backoff |
-| `web/src/panels/Constellation.tsx` | Canvas scatter renderer |
+| `web/src/panels/Constellation.tsx` | Canvas scatter renderer + zoom |
+| `web/src/components/TuningControls.tsx` | Shared offset / frequency / Hold / Centre controls (also used by the Symbol scope) |
 
 The decimator runs on top of the iqtap broker (PR #365), so it
 fans out from the same IQ source the trunking decoder is reading

--- a/docs/symbol-scope.md
+++ b/docs/symbol-scope.md
@@ -35,9 +35,13 @@ a channel sitting on the SDR centre is buried under the DC spike. The
 same controls work around it:
 
 - **Mode** — the receiver / demod path (P25 C4FM or P25 CQPSK).
-- **Offset** — tunes a channel sitting at this offset (kHz, relative to
-  the SDR centre) down to baseband before the receiver channelizes it,
-  lifting an off-centre control/voice channel clear of the DC spike.
+- **Offset / Freq** — tunes a channel sitting at this offset (kHz,
+  relative to the SDR centre) down to baseband before the receiver
+  channelizes it, lifting an off-centre control/voice channel clear of
+  the DC spike. Type the **kHz** offset (1 Hz resolution, so 6.25 /
+  12.5 kHz grids land exactly) or the channel's absolute **MHz**
+  frequency — the two stay in sync. The tuned frequency is shown as soon
+  as an SDR is selected, before any symbols decode.
 - **Hold** — when off, the Offset automatically follows the newest
   active call on the selected SDR (the "last locked channel"); turn
   Hold on (or edit the Offset / press **Centre**) to pin it.
@@ -89,4 +93,5 @@ contract, so they read identically.
 | `cmd/gophertrunk/symbol_provider.go` | Daemon provider — wires the engine to the iqtap broker per subscriber |
 | `web/src/api/symbols.ts` | Typed client with auto-reconnect / backoff |
 | `web/src/components/SymbolScopeChart.tsx` | Canvas scope renderer (shared contract with the SigLab viz) |
+| `web/src/components/TuningControls.tsx` | Shared offset / frequency / Hold / Centre controls (also used by the Constellation) |
 | `web/src/panels/SymbolScope.tsx` | Panel: SDR + mode + offset/Hold/follow controls |

--- a/web/src/components/SymbolScopeChart.tsx
+++ b/web/src/components/SymbolScopeChart.tsx
@@ -153,7 +153,7 @@ function paint(
       y = y0 + plotH * (1 - (dibits[i] + 0.5) / rows);
     }
     ctx.fillStyle = `rgba(${TRACE_RGB}, 0.55)`;
-    ctx.fillRect(x - 1, y - 1, 2, 2);
+    ctx.fillRect(x - 1.5, y - 1.5, 3, 3);
   }
   ctx.globalCompositeOperation = "source-over";
 }

--- a/web/src/components/TuningControls.test.tsx
+++ b/web/src/components/TuningControls.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { TuningControls } from "./TuningControls";
+
+function setup(overrides: Partial<Parameters<typeof TuningControls>[0]> = {}) {
+  const onOffsetChange = vi.fn();
+  const onHoldChange = vi.fn();
+  const onCentre = vi.fn();
+  render(
+    <TuningControls
+      centerHz={851_000_000}
+      maxOffsetKHz={1024}
+      offsetKHz={0}
+      onOffsetChange={onOffsetChange}
+      hold={true}
+      onHoldChange={onHoldChange}
+      followingActive={false}
+      onCentre={onCentre}
+      {...overrides}
+    />,
+  );
+  return { onOffsetChange, onHoldChange, onCentre };
+}
+
+describe("TuningControls", () => {
+  it("accepts a fine kHz offset like 12.5 (channel-grid step)", () => {
+    const { onOffsetChange } = setup();
+    const input = screen.getByLabelText(
+      "View offset from SDR centre in kHz (numeric)",
+    );
+    fireEvent.change(input, { target: { value: "12.5" } });
+    expect(onOffsetChange).toHaveBeenCalledWith(12.5);
+  });
+
+  it("derives the offset from an absolute MHz frequency", () => {
+    const { onOffsetChange } = setup({ centerHz: 851_000_000 });
+    const freq = screen.getByLabelText("Tuned frequency, MHz");
+    // 851.0125 MHz is 12.5 kHz above the 851.0 MHz centre.
+    fireEvent.change(freq, { target: { value: "851.0125" } });
+    expect(onOffsetChange).toHaveBeenCalledWith(12.5);
+  });
+
+  it("shows the current frequency derived from centre + offset", () => {
+    setup({ centerHz: 851_000_000, offsetKHz: 25 });
+    const freq = screen.getByLabelText("Tuned frequency, MHz") as HTMLInputElement;
+    expect(Number(freq.value)).toBeCloseTo(851.025, 6);
+  });
+
+  it("disables the MHz field until the device centre is known", () => {
+    setup({ centerHz: null });
+    const freq = screen.getByLabelText("Tuned frequency, MHz") as HTMLInputElement;
+    expect(freq.disabled).toBe(true);
+  });
+
+  it("recentres via the Centre button", () => {
+    const { onCentre } = setup({ offsetKHz: 12.5 });
+    fireEvent.click(screen.getByRole("button", { name: "Centre" }));
+    expect(onCentre).toHaveBeenCalled();
+  });
+});

--- a/web/src/components/TuningControls.tsx
+++ b/web/src/components/TuningControls.tsx
@@ -1,0 +1,128 @@
+// TuningControls — the shared offset / frequency / Hold / Centre block
+// used by both the Constellation and Symbol scope panels. Pulling it into
+// one component keeps the two panels' tuning UX identical and gives a
+// single home for the fine-grained entry both panels need.
+//
+// Two equivalent ways to land on a channel:
+//   - Offset (kHz, relative to the SDR centre), with 1 Hz numeric
+//     resolution so channel grids like 6.25 / 12.5 kHz are reachable.
+//   - Frequency (absolute, MHz) — type the channel directly; the offset
+//     is derived from the SDR centre. Disabled until the device centre is
+//     known. Both fields read off the same offset state, so they stay in
+//     sync.
+//
+// The slider is for coarse dragging; the numeric fields are the precise
+// path. Editing any control pins the view (Hold on) via onOffsetChange —
+// the caller owns that side effect.
+
+interface TuningControlsProps {
+  // SDR centre in Hz, or null until the device is known. Gates the MHz
+  // field (which needs an absolute reference) but not the offset field.
+  centerHz: number | null;
+  // Nyquist bound for the offset, in kHz (|offset| <= sample_rate/2).
+  maxOffsetKHz: number;
+  // Current (already clamped) offset in kHz.
+  offsetKHz: number;
+  // Set a new offset. The caller is expected to pin the view (Hold on).
+  onOffsetChange: (khz: number) => void;
+  hold: boolean;
+  onHoldChange: (hold: boolean) => void;
+  // True when, with Hold off, the view is tracking an active call.
+  followingActive: boolean;
+  // Recentre on the SDR centre (offset 0). Caller pins the view.
+  onCentre: () => void;
+}
+
+// Trim a number to `digits` decimals without trailing zeros, so the
+// controlled inputs show "6.25" rather than "6.250" yet still accept the
+// fine values the reporter needs.
+function trim(n: number, digits: number): number {
+  return parseFloat(n.toFixed(digits));
+}
+
+export function TuningControls({
+  centerHz,
+  maxOffsetKHz,
+  offsetKHz,
+  onOffsetChange,
+  hold,
+  onHoldChange,
+  followingActive,
+  onCentre,
+}: TuningControlsProps) {
+  const freqMHz = centerHz != null ? (centerHz + offsetKHz * 1000) / 1e6 : null;
+
+  return (
+    <>
+      <label className="flex items-center gap-2">
+        <span className="text-muted">Offset</span>
+        <input
+          type="range"
+          min={-maxOffsetKHz}
+          max={maxOffsetKHz}
+          step={0.05}
+          value={offsetKHz}
+          onChange={(e) => onOffsetChange(Number(e.target.value))}
+          className="w-40 accent-sky-400"
+          aria-label="View offset from SDR centre, kHz"
+        />
+        <input
+          type="number"
+          step={0.001}
+          value={trim(offsetKHz, 3)}
+          onChange={(e) => onOffsetChange(Number(e.target.value))}
+          className="w-24 bg-surface border border-border rounded px-2 py-1 text-right font-mono"
+          aria-label="View offset from SDR centre in kHz (numeric)"
+        />
+        <span className="text-muted">kHz</span>
+      </label>
+
+      <label className="flex items-center gap-2">
+        <span className="text-muted">Freq</span>
+        <input
+          type="number"
+          step={0.000001}
+          value={freqMHz != null ? trim(freqMHz, 6) : ""}
+          disabled={centerHz == null}
+          onChange={(e) => {
+            if (centerHz == null) return;
+            const mhz = Number(e.target.value);
+            if (!Number.isFinite(mhz)) return;
+            onOffsetChange((mhz * 1e6 - centerHz) / 1000);
+          }}
+          className="w-32 bg-surface border border-border rounded px-2 py-1 text-right font-mono disabled:opacity-40"
+          aria-label="Tuned frequency, MHz"
+        />
+        <span className="text-muted">MHz</span>
+      </label>
+
+      <button
+        type="button"
+        className="rounded border border-border px-2 py-1 hover:bg-surface disabled:opacity-40"
+        disabled={offsetKHz === 0}
+        onClick={onCentre}
+        title="Recentre the view on the SDR centre frequency"
+      >
+        Centre
+      </button>
+
+      <label
+        className="flex items-center gap-1.5"
+        title="When off, the view follows the newest active call on this SDR"
+      >
+        <input
+          type="checkbox"
+          checked={hold}
+          onChange={(e) => onHoldChange(e.target.checked)}
+          className="accent-sky-400"
+        />
+        <span>
+          Hold
+          {!hold && followingActive && (
+            <span className="text-accent"> · following call</span>
+          )}
+        </span>
+      </label>
+    </>
+  );
+}

--- a/web/src/panels/Constellation.test.tsx
+++ b/web/src/panels/Constellation.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 
 vi.mock("../api/spectrum", () => ({
   fetchSpectrumDevices: vi.fn(),
@@ -37,6 +37,7 @@ describe("Constellation panel", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     resetStore();
+    window.localStorage.clear();
   });
 
   it("renders an empty-state when no SDRs are available", async () => {
@@ -131,6 +132,52 @@ describe("Constellation panel", () => {
       const calls = vi.mocked(openIQStream).mock.calls;
       const last = calls[calls.length - 1]?.[1];
       expect(last?.offset).toBe(25_000);
+    });
+  });
+
+  it("exposes a zoom control and an absolute-frequency (MHz) input", async () => {
+    vi.mocked(fetchSpectrumDevices).mockResolvedValue([
+      {
+        serial: "rtl-1",
+        driver: "rtlsdr",
+        role: "control",
+        center_hz: 851_000_000,
+        sample_rate_hz: 2_048_000,
+      },
+    ]);
+    vi.mocked(openIQStream).mockReturnValue({ close: vi.fn() });
+
+    render(<Constellation />);
+    await waitFor(() => {
+      expect(openIQStream).toHaveBeenCalled();
+    });
+    expect(screen.getByLabelText("Constellation zoom")).toBeInTheDocument();
+    expect(screen.getByLabelText("Tuned frequency, MHz")).toBeInTheDocument();
+  });
+
+  it("re-tunes when the operator enters a precise kHz offset", async () => {
+    vi.mocked(fetchSpectrumDevices).mockResolvedValue([
+      {
+        serial: "rtl-1",
+        driver: "rtlsdr",
+        role: "control",
+        center_hz: 851_000_000,
+        sample_rate_hz: 2_048_000,
+      },
+    ]);
+    vi.mocked(openIQStream).mockReturnValue({ close: vi.fn() });
+
+    render(<Constellation />);
+    await waitFor(() => {
+      expect(openIQStream).toHaveBeenCalled();
+    });
+    const input = screen.getByLabelText(
+      "View offset from SDR centre in kHz (numeric)",
+    );
+    fireEvent.change(input, { target: { value: "12.5" } });
+    await waitFor(() => {
+      const last = vi.mocked(openIQStream).mock.calls.at(-1)?.[1];
+      expect(last?.offset).toBe(12_500);
     });
   });
 

--- a/web/src/panels/Constellation.tsx
+++ b/web/src/panels/Constellation.tsx
@@ -10,6 +10,7 @@ import {
 } from "../api/diag";
 import { selectClientConfig, useShared } from "../store/shared";
 import { prefs } from "../store/prefs";
+import { TuningControls } from "../components/TuningControls";
 
 // Constellation panel — 2D scatter of decimated IQ samples. Useful
 // for spotting the symbol-domain shape of whatever the SDR is tuned
@@ -41,6 +42,9 @@ const TARGET_RATE_SPS = 2000;
 const POINT_BUFFER = 2000;       // how many recent points to render
 const CANVAS_PX = 420;           // square canvas; CSS scales to width
 const MARGIN = { top: 12, right: 12, bottom: 24, left: 34 };
+// Base dot edge in CSS px at zoom 1; scaled by the Zoom control so the
+// scatter reads clearly instead of as pin-pricks (issue #557 follow-up).
+const BASE_DOT_PX = 2;
 
 // GopherTrunk's sky-400 accent (matches --gt-accent and the Spectrum
 // waterfall's blue→cyan ramp), deliberately not OP25's phosphor green.
@@ -56,6 +60,7 @@ type ConnState = "connecting" | "open" | "closed";
 interface RenderOpts {
   dcBlock: boolean;
   autoScale: boolean;
+  zoom: number;
   scaleRef: { current: number };
 }
 
@@ -78,18 +83,19 @@ export function Constellation() {
   const [autoScale, setAutoScale] = useState<boolean>(() =>
     prefs.constellationAutoScale(),
   );
+  const [zoom, setZoom] = useState<number>(() => prefs.constellationZoom());
 
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const bufferRef = useRef<IQPoint[]>([]);
   const scaleRef = useRef<number>(1);
-  const optsRef = useRef<RenderOpts>({ dcBlock, autoScale, scaleRef });
+  const optsRef = useRef<RenderOpts>({ dcBlock, autoScale, zoom, scaleRef });
 
   // Keep the render-time options the WS callback reads in sync without
   // re-subscribing the stream when a toggle flips.
   useEffect(() => {
-    optsRef.current = { dcBlock, autoScale, scaleRef };
+    optsRef.current = { dcBlock, autoScale, zoom, scaleRef };
     renderConstellation(canvasRef.current, bufferRef.current, optsRef.current);
-  }, [dcBlock, autoScale]);
+  }, [dcBlock, autoScale, zoom]);
 
   // Reuse the spectrum devices endpoint — same broker pool.
   useEffect(() => {
@@ -160,6 +166,9 @@ export function Constellation() {
   useEffect(() => {
     prefs.setConstellationAutoScale(autoScale);
   }, [autoScale]);
+  useEffect(() => {
+    prefs.setConstellationZoom(zoom);
+  }, [zoom]);
 
   useEffect(() => {
     if (!selected) return;
@@ -190,15 +199,17 @@ export function Constellation() {
     // Re-subscribe when the offset changes so the server re-mixes.
   }, [cfg, selected, clampedOffsetKHz]);
 
-  const viewHz = useMemo(() => {
-    if (!latest) return null;
-    return latest.center_hz + clampedOffsetKHz * 1000;
-  }, [latest, clampedOffsetKHz]);
+  // Prefer the device centre so the frequency view shows before the first
+  // frame; fall back to the frame's stamped centre.
+  const centerHz = device?.center_hz ?? latest?.center_hz ?? null;
+  const viewHz = centerHz != null ? centerHz + clampedOffsetKHz * 1000 : null;
 
   const tuningLabel = useMemo(() => {
-    if (!latest) return "";
-    const off = clampedOffsetKHz === 0 ? "centre" : `${clampedOffsetKHz >= 0 ? "+" : ""}${clampedOffsetKHz.toFixed(1)} kHz`;
-    return `${((viewHz ?? latest.center_hz) / 1e6).toFixed(4)} MHz (${off}) · ${latest.sample_rate} sps · ${latest.energy_dbfs.toFixed(1)} dBFS`;
+    if (viewHz == null) return "";
+    const off = clampedOffsetKHz === 0 ? "centre" : `${clampedOffsetKHz >= 0 ? "+" : ""}${clampedOffsetKHz.toFixed(3).replace(/\.?0+$/, "")} kHz`;
+    const head = `${(viewHz / 1e6).toFixed(4)} MHz (${off})`;
+    if (!latest) return `${head} · waiting for samples…`;
+    return `${head} · ${latest.sample_rate} sps · ${latest.energy_dbfs.toFixed(1)} dBFS`;
   }, [latest, viewHz, clampedOffsetKHz]);
 
   return (
@@ -232,68 +243,22 @@ export function Constellation() {
 
       {/* View controls — offset / follow-locked-channel / cleanup. */}
       <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-xs">
-        <label className="flex items-center gap-2">
-          <span className="text-muted">Offset</span>
-          <input
-            type="range"
-            min={-maxOffsetKHz}
-            max={maxOffsetKHz}
-            step={Math.max(1, Math.round(maxOffsetKHz / 300))}
-            value={clampedOffsetKHz}
-            onChange={(e) => {
-              setHold(true);
-              setOffsetKHz(Number(e.target.value));
-            }}
-            className="w-40 accent-sky-400"
-            aria-label="View offset from SDR centre, kHz"
-          />
-          <input
-            type="number"
-            value={Number(clampedOffsetKHz.toFixed(1))}
-            onChange={(e) => {
-              setHold(true);
-              setOffsetKHz(Number(e.target.value));
-            }}
-            className="w-20 bg-surface border border-border rounded px-2 py-1 text-right font-mono"
-            aria-label="View offset from SDR centre in kHz (numeric)"
-          />
-          <span className="text-muted">kHz</span>
-        </label>
-
-        <button
-          type="button"
-          className="rounded border border-border px-2 py-1 hover:bg-surface disabled:opacity-40"
-          disabled={offsetKHz === 0}
-          onClick={() => {
+        <TuningControls
+          centerHz={centerHz}
+          maxOffsetKHz={maxOffsetKHz}
+          offsetKHz={clampedOffsetKHz}
+          onOffsetChange={(khz) => {
+            setHold(true);
+            setOffsetKHz(khz);
+          }}
+          hold={hold}
+          onHoldChange={setHold}
+          followingActive={followOffsetKHz != null}
+          onCentre={() => {
             setHold(true);
             setOffsetKHz(0);
           }}
-          title="Recentre the view on the SDR centre frequency"
-        >
-          Centre
-        </button>
-
-        <label
-          className="flex items-center gap-1.5"
-          title={
-            followOffsetKHz != null
-              ? `Follow the active call at ${(((viewHz ?? 0) || 0) / 1e6).toFixed(4)} MHz when off`
-              : "When off, the view follows the newest active call on this SDR"
-          }
-        >
-          <input
-            type="checkbox"
-            checked={hold}
-            onChange={(e) => setHold(e.target.checked)}
-            className="accent-sky-400"
-          />
-          <span>
-            Hold
-            {!hold && followOffsetKHz != null && (
-              <span className="text-accent"> · following call</span>
-            )}
-          </span>
-        </label>
+        />
 
         <label className="flex items-center gap-1.5">
           <input
@@ -313,6 +278,23 @@ export function Constellation() {
             className="accent-sky-400"
           />
           <span>Auto&nbsp;scale</span>
+        </label>
+
+        <label className="flex items-center gap-2">
+          <span className="text-muted">Zoom</span>
+          <input
+            type="range"
+            min={0.5}
+            max={4}
+            step={0.1}
+            value={zoom}
+            onChange={(e) => setZoom(Number(e.target.value))}
+            className="w-28 accent-sky-400"
+            aria-label="Constellation zoom"
+          />
+          <span className="w-10 text-right font-mono text-muted">
+            {zoom.toFixed(1)}×
+          </span>
         </label>
       </div>
 
@@ -423,18 +405,21 @@ function renderConstellation(
     mq /= n;
   }
 
-  // Auto-scale: target gain so the 95th-percentile radius reaches ~0.9
-  // of the unit circle. Eased toward the target to avoid frame jitter.
+  // Auto-scale: target gain so the ~95th-percentile radius reaches ~0.9
+  // of the unit circle. Using a percentile (not the absolute max) keeps a
+  // stray outlier from shrinking the whole cloud, so the scatter fills the
+  // circle like OP25's plot. Eased toward the target to avoid frame jitter.
   let gain = opts.scaleRef.current || 1;
   if (opts.autoScale) {
-    let maxR = 1e-6;
+    const radii = new Float64Array(n);
     for (let k = 0; k < n; k++) {
       const di = points[k].i - mi;
       const dq = points[k].q - mq;
-      const r = Math.hypot(di, dq);
-      if (r > maxR) maxR = r;
+      radii[k] = Math.hypot(di, dq);
     }
-    const target = Math.max(0.2, Math.min(8, 0.9 / maxR));
+    radii.sort();
+    const refR = Math.max(1e-6, radii[Math.min(n - 1, Math.floor(0.95 * n))]);
+    const target = Math.max(0.2, Math.min(8, 0.9 / refR));
     gain = gain + (target - gain) * 0.1;
     opts.scaleRef.current = gain;
   } else {
@@ -442,19 +427,26 @@ function renderConstellation(
     opts.scaleRef.current = 1;
   }
 
+  // Zoom magnifies both the cloud and the dot size so the scatter reads as
+  // dots, not pin-pricks, and can be dialled to taste (issue #557 follow-up).
+  const zoom = opts.zoom > 0 ? opts.zoom : 1;
+  const finalGain = gain * zoom;
+  const dotPx = Math.max(2, Math.min(8, Math.round(BASE_DOT_PX * zoom)));
+  const dotHalf = dotPx / 2;
+
   // Additive blending so overlapping symbols accumulate brightness.
   ctx.globalCompositeOperation = "lighter";
   for (let idx = 0; idx < n; idx++) {
     const p = points[idx];
-    const i = (p.i - mi) * gain;
-    const q = (p.q - mq) * gain;
+    const i = (p.i - mi) * finalGain;
+    const q = (p.q - mq) * finalGain;
     const x = cx + i * radius;
     const y = cy - q * radius; // canvas Y grows downward
     // Fade: oldest samples are dim, newest are bright.
     const age = idx / n; // 0..1
     const alpha = 0.05 + 0.5 * age * age;
     ctx.fillStyle = `rgba(${POINT_RGB}, ${alpha})`;
-    ctx.fillRect(x - 1, y - 1, 2, 2);
+    ctx.fillRect(x - dotHalf, y - dotHalf, dotPx, dotPx);
   }
   ctx.globalCompositeOperation = "source-over";
 }

--- a/web/src/panels/SymbolScope.test.tsx
+++ b/web/src/panels/SymbolScope.test.tsx
@@ -119,6 +119,22 @@ describe("Symbol scope panel", () => {
     });
   });
 
+  it("shows the tuned frequency before any symbol frame arrives", async () => {
+    vi.mocked(fetchSpectrumDevices).mockResolvedValue(oneDevice);
+    // Open the stream but never deliver a frame — a quiet channel.
+    vi.mocked(openSymbolStream).mockReturnValue({ close: vi.fn() });
+
+    render(<SymbolScope />);
+    await waitFor(() => {
+      expect(openSymbolStream).toHaveBeenCalled();
+    });
+    // The frequency view is derived from the device centre, not from a
+    // decoded frame, so it renders immediately. (851.000 MHz centre.)
+    expect(screen.getByText(/851\.0000 MHz/)).toBeInTheDocument();
+    const freq = screen.getByLabelText("Tuned frequency, MHz") as HTMLInputElement;
+    expect(Number(freq.value)).toBeCloseTo(851, 6);
+  });
+
   it("exposes the mode select and Hold / Centre controls", async () => {
     vi.mocked(fetchSpectrumDevices).mockResolvedValue(oneDevice);
     vi.mocked(openSymbolStream).mockReturnValue({ close: vi.fn() });

--- a/web/src/panels/SymbolScope.tsx
+++ b/web/src/panels/SymbolScope.tsx
@@ -7,6 +7,7 @@ import { openSymbolStream, type SymbolFrame } from "../api/symbols";
 import { selectClientConfig, useShared } from "../store/shared";
 import { prefs } from "../store/prefs";
 import { SymbolScopeChart } from "../components/SymbolScopeChart";
+import { TuningControls } from "../components/TuningControls";
 
 // Symbol scope panel — a live oscilloscope of the demodulated symbol
 // stream, GopherTrunk's take on OP25's "Symbol" plot. The daemon runs a
@@ -145,16 +146,22 @@ export function SymbolScope() {
     return () => stream.close();
   }, [cfg, selected, proto, clampedOffsetKHz]);
 
-  const viewHz = latest ? latest.center_hz + clampedOffsetKHz * 1000 : null;
+  // Centre comes from the selected device so the frequency view renders
+  // immediately — symbol frames only arrive once the receiver decodes, so
+  // gating the label on `latest` would leave it blank on a quiet channel.
+  const centerHz = device?.center_hz ?? latest?.center_hz ?? null;
+  const viewHz = centerHz != null ? centerHz + clampedOffsetKHz * 1000 : null;
 
   const tuningLabel = useMemo(() => {
-    if (!latest) return "";
+    if (viewHz == null) return "";
     const off =
       clampedOffsetKHz === 0
         ? "centre"
-        : `${clampedOffsetKHz >= 0 ? "+" : ""}${clampedOffsetKHz.toFixed(1)} kHz`;
+        : `${clampedOffsetKHz >= 0 ? "+" : ""}${clampedOffsetKHz.toFixed(3).replace(/\.?0+$/, "")} kHz`;
+    const head = `${(viewHz / 1e6).toFixed(4)} MHz (${off})`;
+    if (!latest) return `${head} · waiting for symbols…`;
     const soft = latest.soft && latest.soft.length > 0 ? "soft+dibits" : "dibits";
-    return `${((viewHz ?? latest.center_hz) / 1e6).toFixed(4)} MHz (${off}) · ${latest.symbol_rate_hz.toFixed(0)} sym/s · ${soft}`;
+    return `${head} · ${latest.symbol_rate_hz.toFixed(0)} sym/s · ${soft}`;
   }, [latest, viewHz, clampedOffsetKHz]);
 
   return (
@@ -203,64 +210,22 @@ export function SymbolScope() {
           </select>
         </label>
 
-        <label className="flex items-center gap-2">
-          <span className="text-muted">Offset</span>
-          <input
-            type="range"
-            min={-maxOffsetKHz}
-            max={maxOffsetKHz}
-            step={Math.max(1, Math.round(maxOffsetKHz / 300))}
-            value={clampedOffsetKHz}
-            onChange={(e) => {
-              setHold(true);
-              setOffsetKHz(Number(e.target.value));
-            }}
-            className="w-40 accent-sky-400"
-            aria-label="View offset from SDR centre, kHz"
-          />
-          <input
-            type="number"
-            value={Number(clampedOffsetKHz.toFixed(1))}
-            onChange={(e) => {
-              setHold(true);
-              setOffsetKHz(Number(e.target.value));
-            }}
-            className="w-20 bg-surface border border-border rounded px-2 py-1 text-right font-mono"
-            aria-label="View offset from SDR centre in kHz (numeric)"
-          />
-          <span className="text-muted">kHz</span>
-        </label>
-
-        <button
-          type="button"
-          className="rounded border border-border px-2 py-1 hover:bg-surface disabled:opacity-40"
-          disabled={offsetKHz === 0}
-          onClick={() => {
+        <TuningControls
+          centerHz={centerHz}
+          maxOffsetKHz={maxOffsetKHz}
+          offsetKHz={clampedOffsetKHz}
+          onOffsetChange={(khz) => {
+            setHold(true);
+            setOffsetKHz(khz);
+          }}
+          hold={hold}
+          onHoldChange={setHold}
+          followingActive={followOffsetKHz != null}
+          onCentre={() => {
             setHold(true);
             setOffsetKHz(0);
           }}
-          title="Recentre the view on the SDR centre frequency"
-        >
-          Centre
-        </button>
-
-        <label
-          className="flex items-center gap-1.5"
-          title="When off, the view follows the newest active call on this SDR"
-        >
-          <input
-            type="checkbox"
-            checked={hold}
-            onChange={(e) => setHold(e.target.checked)}
-            className="accent-sky-400"
-          />
-          <span>
-            Hold
-            {!hold && followOffsetKHz != null && (
-              <span className="text-accent"> · following call</span>
-            )}
-          </span>
-        </label>
+        />
       </div>
 
       <div className="font-mono text-xs text-muted">{tuningLabel || "—"}</div>

--- a/web/src/store/prefs.ts
+++ b/web/src/store/prefs.ts
@@ -19,6 +19,7 @@ const LS_KEYS = {
   constellationHold: "gt.constellation.hold",
   constellationDcBlock: "gt.constellation.dcBlock",
   constellationAutoScale: "gt.constellation.autoScale",
+  constellationZoom: "gt.constellation.zoom",
   symbolScopeOffsetKHz: "gt.symbolScope.offsetKHz",
   symbolScopeHold: "gt.symbolScope.hold",
   symbolScopeProto: "gt.symbolScope.proto",
@@ -163,6 +164,19 @@ export const prefs = {
   },
   setConstellationAutoScale(on: boolean) {
     writeLS(LS_KEYS.constellationAutoScale, on ? "1" : "0");
+  },
+  // Zoom magnifies the plotted cloud and dot size so the scatter fills the
+  // unit circle like OP25's plot. Clamped 0.5..4; defaults a touch above 1
+  // so the out-of-the-box view is already larger than 1:1.
+  constellationZoom(): number {
+    const raw = readLS(LS_KEYS.constellationZoom);
+    if (raw === null) return 1.5;
+    const n = Number(raw);
+    if (!Number.isFinite(n)) return 1.5;
+    return Math.max(0.5, Math.min(4, n));
+  },
+  setConstellationZoom(z: number) {
+    writeLS(LS_KEYS.constellationZoom, String(Math.max(0.5, Math.min(4, z))));
   },
 
   // Symbol-scope panel view options. Offset (kHz, relative to the SDR


### PR DESCRIPTION
Address the reporter's follow-up on #557:

- Symbol scope now shows the tuned frequency as soon as an SDR is
  selected. The frequency label was gated on a decoded SymbolFrame, so
  it stayed blank on a quiet channel; derive it from the device centre +
  offset instead, like the Constellation already does.
- Precise channel entry in both panels via a shared TuningControls
  component: the kHz offset field takes 1 Hz resolution (so 6.25/12.5 kHz
  grids land exactly) plus an absolute MHz frequency field kept in sync.
- Constellation gains an adjustable Zoom control (persisted) and a
  larger default dot size, and auto-scale now targets the ~95th-
  percentile radius so a stray outlier no longer shrinks the cloud.

Frontend-only: the offset already travels as Hz end-to-end and the
symbol frame already carries center_hz. Updated panel/component tests,
docs, and the changelog.