### PR TITLE
Warn when message decoders are configured without storage (#565)

### DIFF
--- a/cmd/gophertrunk/preflight.go
+++ b/cmd/gophertrunk/preflight.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/MattCheramie/GopherTrunk/internal/config"
 )
@@ -107,6 +108,43 @@ func preflight(cfg config.Config) ([]string, error) {
 			warnings = append(warnings,
 				fmt.Sprintf("trunking.systems[%s].rid_alias_file: %q is empty — radios on this system will have no operator aliases",
 					sys.Name, sys.RIDAliasFile))
+		}
+	}
+
+	// Message decoders that only surface their output through the
+	// SQLite-backed logs (pager / aprs / ais / dsc / mdc1200 / m17). With
+	// storage.path empty the daemon skips storage init entirely, so these
+	// decoders still run but their logs are never wired: the REST endpoints
+	// return 503 and the web panels stay empty. Operators hit this as a
+	// silent failure (see issue #565 — POCSAG configured, pager/messages 503
+	// until storage.path was added), so name the dependency loudly here.
+	if cfg.Storage.Path == "" {
+		var needs []string
+		if len(cfg.Paging.POCSAG) > 0 || len(cfg.Paging.FLEX) > 0 {
+			needs = append(needs, "paging")
+		}
+		if len(cfg.APRS.Channels) > 0 {
+			needs = append(needs, "aprs")
+		}
+		if len(cfg.AIS.Channels) > 0 {
+			needs = append(needs, "ais")
+		}
+		if len(cfg.DSC.Channels) > 0 {
+			needs = append(needs, "dsc")
+		}
+		if len(cfg.MDC1200.Channels) > 0 {
+			needs = append(needs, "mdc1200")
+		}
+		if len(cfg.M17.Channels) > 0 {
+			needs = append(needs, "m17")
+		}
+		if len(needs) > 0 {
+			warnings = append(warnings, fmt.Sprintf(
+				"storage.path is empty but these decoders need it to surface decoded "+
+					"messages: %s — they will run, but their REST endpoints (e.g. "+
+					"/api/v1/pager/messages) return 503 and the web panels stay empty. "+
+					"Set storage.path to enable persistence.",
+				strings.Join(needs, ", ")))
 		}
 	}
 

--- a/cmd/gophertrunk/preflight_test.go
+++ b/cmd/gophertrunk/preflight_test.go
@@ -90,6 +90,47 @@ func TestPreflightTalkgroupEmptyWarning(t *testing.T) {
 	}
 }
 
+func TestPreflightStorageDecoderWarning(t *testing.T) {
+	// A message decoder (POCSAG here) configured without storage.path
+	// must surface a preflight warning naming the storage dependency —
+	// otherwise the decoder runs but pager/messages returns 503 with no
+	// hint why (issue #565).
+	cfg := config.Config{
+		Paging: config.PagingConfig{
+			POCSAG: []config.PagingPOCSAGConfig{{
+				Serial:      "antenna-pi",
+				FrequencyHz: 152_007_500,
+			}},
+		},
+	}
+	warnings, err := preflight(cfg)
+	if err != nil {
+		t.Fatalf("preflight: %v", err)
+	}
+	if len(warnings) == 0 {
+		t.Fatal("expected a warning for paging configured without storage.path")
+	}
+	w := warnings[0]
+	if !strings.Contains(w, "storage.path") {
+		t.Errorf("warning %q missing 'storage.path' tag", w)
+	}
+	if !strings.Contains(w, "paging") {
+		t.Errorf("warning %q should name the 'paging' decoder", w)
+	}
+
+	// With storage.path set, the warning must not fire.
+	cfg.Storage = config.StorageConfig{Path: filepath.Join(t.TempDir(), "calls.db")}
+	warnings, err = preflight(cfg)
+	if err != nil {
+		t.Fatalf("preflight (with storage): %v", err)
+	}
+	for _, w := range warnings {
+		if strings.Contains(w, "storage.path is empty") {
+			t.Errorf("unexpected storage warning when storage.path is set: %q", w)
+		}
+	}
+}
+
 func TestPreflightTLSMissing(t *testing.T) {
 	cfg := config.Config{
 		API: config.APIConfig{

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -329,6 +329,12 @@ sdr:
 # directly to FrequencyHz (full sample-rate IQ, no DDC) — multi-
 # channel-from-one-SDR is a planned follow-up.
 #
+# NOTE: paging (and the other message decoders: aprs, ais, dsc,
+# mdc1200, m17) surface decoded messages only through the SQLite
+# log. You must set a `storage:` section (see the storage example
+# above) — without it the decoder runs but /api/v1/pager/messages
+# returns 503 and the web panel stays empty.
+#
 # paging:
 #   pocsag:
 #     - serial: "antenna-pi"       # SDR serial (must be in sdr.devices

--- a/internal/api/handlers_ais.go
+++ b/internal/api/handlers_ais.go
@@ -71,7 +71,7 @@ func aisMessageToDTO(m storage.AISMessage) AISMessageDTO {
 // isn't wired (daemon started without storage.path).
 func (s *Server) handleAISMessages(w http.ResponseWriter, r *http.Request) {
 	if s.ais == nil {
-		s.writeError(w, http.StatusServiceUnavailable, "ais subsystem not enabled")
+		s.writeError(w, http.StatusServiceUnavailable, "ais subsystem not enabled (set storage.path in config to persist and view decoded messages)")
 		return
 	}
 	limit := 200

--- a/internal/api/handlers_aprs.go
+++ b/internal/api/handlers_aprs.go
@@ -50,7 +50,7 @@ func aprsPacketToDTO(p storage.APRSPacket) APRSPacketDTO {
 // ?limit= (default 200, max 5000).
 func (s *Server) handleAPRSPackets(w http.ResponseWriter, r *http.Request) {
 	if s.aprs == nil {
-		s.writeError(w, http.StatusServiceUnavailable, "aprs subsystem not enabled")
+		s.writeError(w, http.StatusServiceUnavailable, "aprs subsystem not enabled (set storage.path in config to persist and view decoded messages)")
 		return
 	}
 	limit := 200

--- a/internal/api/handlers_dsc.go
+++ b/internal/api/handlers_dsc.go
@@ -59,7 +59,7 @@ func dscMessageToDTO(m storage.DSCMessage) DSCMessageDTO {
 // isn't wired (daemon started without storage.path).
 func (s *Server) handleDSCMessages(w http.ResponseWriter, r *http.Request) {
 	if s.dsc == nil {
-		s.writeError(w, http.StatusServiceUnavailable, "dsc subsystem not enabled")
+		s.writeError(w, http.StatusServiceUnavailable, "dsc subsystem not enabled (set storage.path in config to persist and view decoded messages)")
 		return
 	}
 	limit := 200

--- a/internal/api/handlers_m17.go
+++ b/internal/api/handlers_m17.go
@@ -47,7 +47,7 @@ func m17LinkSetupToDTO(l storage.M17LinkSetup) M17LinkSetupDTO {
 // wired (daemon started without storage.path).
 func (s *Server) handleM17LinkSetups(w http.ResponseWriter, r *http.Request) {
 	if s.m17 == nil {
-		s.writeError(w, http.StatusServiceUnavailable, "m17 subsystem not enabled")
+		s.writeError(w, http.StatusServiceUnavailable, "m17 subsystem not enabled (set storage.path in config to persist and view decoded messages)")
 		return
 	}
 	limit := 200

--- a/internal/api/handlers_mdc1200.go
+++ b/internal/api/handlers_mdc1200.go
@@ -49,7 +49,7 @@ func mdc1200MessageToDTO(m storage.MDC1200Message) MDC1200MessageDTO {
 // wired (daemon started without storage.path).
 func (s *Server) handleMDC1200Messages(w http.ResponseWriter, r *http.Request) {
 	if s.mdc1200 == nil {
-		s.writeError(w, http.StatusServiceUnavailable, "mdc1200 subsystem not enabled")
+		s.writeError(w, http.StatusServiceUnavailable, "mdc1200 subsystem not enabled (set storage.path in config to persist and view decoded messages)")
 		return
 	}
 	limit := 200

--- a/internal/api/handlers_pager.go
+++ b/internal/api/handlers_pager.go
@@ -48,7 +48,7 @@ func pagerMessageToDTO(m storage.PagerMessage) PagerMessageDTO {
 // Optional ?limit= (default 200, max 5000).
 func (s *Server) handlePagerMessages(w http.ResponseWriter, r *http.Request) {
 	if s.pager == nil {
-		s.writeError(w, http.StatusServiceUnavailable, "pager subsystem not enabled")
+		s.writeError(w, http.StatusServiceUnavailable, "pager subsystem not enabled (set storage.path in config to persist and view decoded messages)")
 		return
 	}
 	limit := 200


### PR DESCRIPTION
POCSAG (and the other SQLite-backed decoders: aprs, ais, dsc, mdc1200,
m17) surface decoded messages only through the storage log. When
storage.path is empty the daemon skips storage init entirely, so the
decoder runs but its log is never wired: the REST endpoint returns 503
and the web panel stays empty. Operators hit this as a silent failure
(pager/messages 503 with no hint that storage was the missing piece).

- preflight: emit a loud, actionable warning naming the affected
  decoders when storage.path is unset but a decoder is configured.
- api: 503 messages now point at storage.path as the cause.
- config.example.yaml: document the paging -> storage dependency.

https://claude.ai/code/session_01LT7r2PkK7pPAd6ch9eM7Jr