### PR TITLE
tetra: soft-decision FEC for the SB-burst lock chain

### DIFF
--- a/internal/dsp/demod/dqpsk.go
+++ b/internal/dsp/demod/dqpsk.go
@@ -59,3 +59,47 @@ func (d *DQPSK) Decode(dst []uint8, src []complex64) []uint8 {
 	}
 	return dst
 }
+
+// DecodeBoth is Decode plus the complex differential d = s·conj(last)
+// per symbol, emitted into dstDiff. It is a single pass with one `last`
+// update, so the hard dibit and the soft differential stay consistent.
+// The differential carries the soft information: for π/4-DQPSK the two
+// on-air bits' reliabilities are Im(d) and Re(d). Callers that want
+// soft-decision decoding use dstDiff; the dibits remain identical to
+// Decode.
+func (d *DQPSK) DecodeBoth(dstDibits []uint8, dstDiff []complex64, src []complex64) ([]uint8, []complex64) {
+	if cap(dstDibits) < len(src) {
+		dstDibits = make([]uint8, len(src))
+	} else {
+		dstDibits = dstDibits[:len(src)]
+	}
+	if cap(dstDiff) < len(src) {
+		dstDiff = make([]complex64, len(src))
+	} else {
+		dstDiff = dstDiff[:len(src)]
+	}
+	for i, s := range src {
+		ar := real(s)*real(d.last) + imag(s)*imag(d.last)
+		ai := imag(s)*real(d.last) - real(s)*imag(d.last)
+		dstDiff[i] = complex(ar, ai)
+		phi := math.Atan2(float64(ai), float64(ar)) - d.rotation
+		for phi < -math.Pi {
+			phi += 2 * math.Pi
+		}
+		for phi >= math.Pi {
+			phi -= 2 * math.Pi
+		}
+		switch {
+		case phi >= -math.Pi/4 && phi < math.Pi/4:
+			dstDibits[i] = 0b00
+		case phi >= math.Pi/4 && phi < 3*math.Pi/4:
+			dstDibits[i] = 0b01
+		case phi >= -3*math.Pi/4 && phi < -math.Pi/4:
+			dstDibits[i] = 0b11
+		default:
+			dstDibits[i] = 0b10
+		}
+		d.last = s
+	}
+	return dstDibits, dstDiff
+}

--- a/internal/dsp/demod/piover4_dqpsk.go
+++ b/internal/dsp/demod/piover4_dqpsk.go
@@ -59,6 +59,12 @@ func (p *PiOver4DQPSK) Decode(dst []uint8, src []complex64) []uint8 {
 	return p.dqpsk.Decode(dst, src)
 }
 
+// DecodeBoth emits one hard dibit and the complex differential
+// (soft information) per symbol in a single pass. See DQPSK.DecodeBoth.
+func (p *PiOver4DQPSK) DecodeBoth(dstDibits []uint8, dstDiff []complex64, src []complex64) ([]uint8, []complex64) {
+	return p.dqpsk.DecodeBoth(dstDibits, dstDiff, src)
+}
+
 // Reset clears the matched-filter history and the differential
 // reference sample. Call on stream re-sync.
 func (p *PiOver4DQPSK) Reset() {

--- a/internal/radio/framing/soft_tetra.go
+++ b/internal/radio/framing/soft_tetra.go
@@ -1,0 +1,135 @@
+package framing
+
+// Soft-decision (LLR) variants of the TETRA signalling channel-coding
+// primitives. They mirror the hard-decision functions in
+// scramble_tetra.go, interleave_tetra.go and rcpc_tetra_sig.go exactly,
+// but carry per-bit log-likelihood ratios (float32) instead of hard
+// bits. Convention throughout: LLR > 0 ⇒ bit 0, LLR < 0 ⇒ bit 1, and
+// magnitude is reliability (0 = erasure / no information). The soft
+// Viterbi's surviving path is scale-invariant, so the LLRs need no
+// normalisation — any consistent scaling works.
+
+// DescrambleTetraSoft is the soft-LLR analog of DescrambleTetra:
+// XOR-ing a bit with the scrambling PN becomes a conditional sign flip
+// of its LLR (PN bit 1 inverts the bit, hence the LLR sign). Reuses the
+// same LFSR (NewScramblerTetra). Scrambling is XOR-symmetric, so this
+// is both scramble and descramble in the soft domain.
+func DescrambleTetraSoft(in []float32, colourCode uint32) []float32 {
+	s := NewScramblerTetra(colourCode)
+	out := make([]float32, len(in))
+	for i, v := range in {
+		if s.Next() == 1 {
+			out[i] = -v
+		} else {
+			out[i] = v
+		}
+	}
+	return out
+}
+
+// BlockDeinterleaveTetraSoft is the soft-LLR analog of
+// BlockDeinterleaveTetra — the same (K, a) inverse permutation applied
+// to LLRs.
+func BlockDeinterleaveTetraSoft(b4 []float32, K, a int) []float32 {
+	if len(b4) != K {
+		return nil
+	}
+	out := make([]float32, K)
+	for i := 1; i <= K; i++ {
+		k := 1 + ((a * i) % K)
+		out[i-1] = b4[k-1]
+	}
+	return out
+}
+
+// DepunctureRCPCTetraSigSoft is the soft-LLR analog of
+// DepunctureRCPCTetraSig: it allocates a motherLen LLR buffer, leaves
+// punctured positions at 0 (a soft erasure — no information, zero
+// branch-metric contribution in the Viterbi), and copies received LLRs
+// at the puncture-map positions. Same index map as the hard version.
+func DepunctureRCPCTetraSigSoft(punctured []float32, puncture []int, motherLen int, indexShift func(j int) int) []float32 {
+	const period = 8
+	t := len(puncture)
+	if indexShift == nil {
+		indexShift = func(j int) int { return j }
+	}
+	out := make([]float32, motherLen) // zero-valued = erasure
+	for j := 1; j <= len(punctured); j++ {
+		i := indexShift(j)
+		blockIdx := (i - 1) / t
+		offset := i - t*blockIdx
+		k := period*blockIdx + puncture[offset-1]
+		if k-1 < motherLen {
+			out[k-1] = punctured[j-1]
+		}
+	}
+	return out
+}
+
+// DecodeRCPCTetraSigMotherSoft is the soft-decision analog of
+// DecodeRCPCTetraSigMother: the same 16-state K=5 R=1/4 mother-code
+// trellis, with the hard Hamming branch metric replaced by the soft
+// correlation cost. For an expected mother bit g and received LLR L,
+// the branch cost is L·(2g-1): a match (g=0 with L>0, or g=1 with L<0)
+// lowers the path metric, a mismatch raises it, and an erasure (L=0)
+// contributes nothing. The minimum-cost path is the maximum-likelihood
+// sequence. Returns the recovered stages-bit input plus the surviving
+// path metric.
+func DecodeRCPCTetraSigMotherSoft(channel []float32, stages int) ([]byte, float32) {
+	const numStates = 16
+	const inf = float32(1e30)
+	pm := make([]float32, numStates)
+	for i := range pm {
+		pm[i] = inf
+	}
+	pm[0] = 0
+	trace := make([][numStates]uint8, stages)
+
+	for s := 0; s < stages; s++ {
+		var npm [numStates]float32
+		for i := range npm {
+			npm[i] = inf
+		}
+		rxG1 := channel[4*s]
+		rxG2 := channel[4*s+1]
+		rxG3 := channel[4*s+2]
+		rxG4 := channel[4*s+3]
+		for cur := 0; cur < numStates; cur++ {
+			if pm[cur] >= inf {
+				continue
+			}
+			d1 := (cur >> 3) & 1
+			d2 := (cur >> 2) & 1
+			d3 := (cur >> 1) & 1
+			d4 := cur & 1
+			for input := 0; input < 2; input++ {
+				g1 := (input ^ d1 ^ d4) & 1
+				g2 := (input ^ d2 ^ d3 ^ d4) & 1
+				g3 := (input ^ d1 ^ d2 ^ d4) & 1
+				g4 := (input ^ d1 ^ d3 ^ d4) & 1
+				cost := pm[cur]
+				cost += rxG1 * float32(2*g1-1)
+				cost += rxG2 * float32(2*g2-1)
+				cost += rxG3 * float32(2*g3-1)
+				cost += rxG4 * float32(2*g4-1)
+				next := (input << 3) | (d1 << 2) | (d2 << 1) | d3
+				if cost < npm[next] {
+					npm[next] = cost
+					trace[s][next] = uint8((cur << 1) | input)
+				}
+			}
+		}
+		copy(pm, npm[:])
+	}
+
+	final := 0
+	metric := pm[final]
+	out := make([]byte, stages)
+	state := final
+	for s := stages - 1; s >= 0; s-- {
+		entry := trace[s][state]
+		out[s] = entry & 1
+		state = int(entry >> 1)
+	}
+	return out, metric
+}

--- a/internal/radio/tetra/channel_coding.go
+++ b/internal/radio/tetra/channel_coding.go
@@ -125,6 +125,55 @@ func signalingDecode(type5 []byte, interleaverK, interleaverA int, colourCode ui
 	return info, true
 }
 
+// decodeRCPCRate23Soft is the soft-decision analog of decodeRCPCRate23:
+// soft depuncture (erasures at punctured positions) + soft Viterbi over
+// len(type3LLR)*2/3 stages.
+func decodeRCPCRate23Soft(type3LLR []float32) []byte {
+	stages := (2 * len(type3LLR)) / 3
+	motherLen := 4 * stages
+	mother := framing.DepunctureRCPCTetraSigSoft(type3LLR, framing.RCPCTetraSigPuncture23, motherLen, nil)
+	out, _ := framing.DecodeRCPCTetraSigMotherSoft(mother, stages)
+	return out
+}
+
+// signalingDecodeSoft is the soft-decision analog of signalingDecode:
+// it runs the same descramble → deinterleave → depuncture → Viterbi
+// chain on per-bit LLRs (LLR > 0 ⇒ bit 0), then strips the tail and
+// verifies the CRC on the hard Viterbi output. type5LLR holds K3 LLRs.
+func signalingDecodeSoft(type5LLR []float32, interleaverK, interleaverA int, colourCode uint32, k1 int) ([]byte, bool) {
+	if len(type5LLR) != interleaverK {
+		return nil, false
+	}
+	type4 := framing.DescrambleTetraSoft(type5LLR, colourCode)
+	type3 := framing.BlockDeinterleaveTetraSoft(type4, interleaverK, interleaverA)
+	type2 := decodeRCPCRate23Soft(type3) // K1 + 20 hard bits
+	if len(type2) < k1+20 {
+		return nil, false
+	}
+	blockEncoded := type2[:k1+16]
+	info := blockEncoded[:k1]
+	receivedCRC := uint16(0)
+	for i := 0; i < 16; i++ {
+		receivedCRC = (receivedCRC << 1) | uint16(blockEncoded[k1+i]&1)
+	}
+	if crcTetraK1Plus16(info) != receivedCRC {
+		return info, false
+	}
+	return info, true
+}
+
+// DecodeSCHHDSoft is the soft-decision analog of DecodeSCHHD: 216 type-5
+// LLRs → 124 type-1 bits + CRC-pass flag.
+func DecodeSCHHDSoft(type5LLR []float32, colourCode uint32) ([]byte, bool) {
+	return signalingDecodeSoft(type5LLR, framing.InterleaveKSCHHD, framing.InterleaveASCHHD, colourCode, 124)
+}
+
+// DecodeBSCHSoft is the soft-decision analog of DecodeBSCH: 120 type-5
+// LLRs → 60 type-1 bits + CRC-pass flag. Colour code is 0 for BSCH.
+func DecodeBSCHSoft(type5LLR []float32) ([]byte, bool) {
+	return signalingDecodeSoft(type5LLR, framing.InterleaveKBSCH, framing.InterleaveABSCH, 0, 60)
+}
+
 // EncodeSCHHD runs 124 type-1 bits through the SCH/HD chain per
 // §8.3.1.4.1 — also valid for BNCH and STCH which share the same
 // coding. Returns 216 type-5 bits.

--- a/internal/radio/tetra/control.go
+++ b/internal/radio/tetra/control.go
@@ -57,6 +57,45 @@ type ControlChannel struct {
 	channelType      ChannelType
 	colourCode       uint32
 	colourLearned    bool
+
+	// pendingSoft holds the per-symbol complex differential (soft
+	// information) for the next Process call, stashed by StashSoft
+	// immediately before the matching dibit chunk arrives (see
+	// receiver SoftSink). Process consumes it via takeStashSoft.
+	pendingSoft     []complex64
+	pendingSoftBase int
+	pendingSoftSet  bool
+}
+
+// StashSoft records the soft per-symbol differentials for the dibit
+// chunk that arrives next at Process (same baseIdx). The receiver's
+// SoftSink calls this just before DibitSink → Process. diffs is copied
+// since the caller reuses its buffer.
+func (c *ControlChannel) StashSoft(diffs []complex64, baseIdx int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if cap(c.pendingSoft) < len(diffs) {
+		c.pendingSoft = make([]complex64, len(diffs))
+	} else {
+		c.pendingSoft = c.pendingSoft[:len(diffs)]
+	}
+	copy(c.pendingSoft, diffs)
+	c.pendingSoftBase = baseIdx
+	c.pendingSoftSet = true
+}
+
+// takeStashSoft returns the stashed soft differentials if they match the
+// chunk at baseIdx with length n, then clears the stash. Returns nil
+// when no matching soft data was stashed (hard-only path).
+func (c *ControlChannel) takeStashSoft(baseIdx, n int) []complex64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !c.pendingSoftSet || c.pendingSoftBase != baseIdx || len(c.pendingSoft) != n {
+		c.pendingSoftSet = false
+		return nil
+	}
+	c.pendingSoftSet = false
+	return c.pendingSoft
 }
 
 // SetStrictValidation toggles the strict frame-validity filter on the

--- a/internal/radio/tetra/process.go
+++ b/internal/radio/tetra/process.go
@@ -18,9 +18,10 @@ type processState struct {
 	// BNCH after it). See processSB.
 	stsDet     *SyncDetector
 	stsScratch []int
-	buf        []uint8 // rolling dibit window
-	bufBase    int     // absolute dibit index of buf[0]
-	pendingSTS []int   // STS leading indices awaiting look-ahead
+	buf        []uint8     // rolling dibit window
+	softBuf    []complex64 // per-dibit soft differential, parallel to buf (nil ⇒ hard-only)
+	bufBase    int         // absolute dibit index of buf[0] / softBuf[0]
+	pendingSTS []int       // STS leading indices awaiting look-ahead
 }
 
 // Synchronisation downlink burst (SB) geometry in dibits, per ETSI
@@ -98,9 +99,12 @@ func (c *ControlChannel) Process(dibits []uint8, baseIdx int) int {
 
 	// SB-burst path: auto-learn the colour code from the BSCH and decode
 	// the BNCH SYSINFO. Only meaningful with channel coding on (real
-	// bursts); skipped for the synthetic raw-PDU fixtures.
+	// bursts); skipped for the synthetic raw-PDU fixtures. The soft
+	// differentials (when the receiver supplies them via StashSoft) ride
+	// alongside for soft-decision decoding.
 	if mode == ChannelCodingOn {
-		c.processSB(p, dibits, baseIdx)
+		diffs := c.takeStashSoft(baseIdx, len(dibits))
+		c.processSB(p, dibits, diffs, baseIdx)
 	}
 
 	p.matchScratch, _ = p.det.Process(p.matchScratch[:0], dibits, baseIdx)
@@ -141,18 +145,52 @@ func rotateDibits(dibits []uint8, rot uint8) []uint8 {
 	return out
 }
 
+// softType5FromDiffs converts a block of per-symbol complex differentials
+// into the soft type-5 LLR stream the soft channel decoders expect, under
+// constellation rotation rot. For the demod differential d, the two
+// on-air bits' LLRs are Im(d) (b1) and Re(d) (b2) (positive ⇒ bit 0);
+// rotating the constellation by rot·90° is d·e^{j·rot·π/2}. The output
+// hard-slices to exactly TetraDibitsToBits(rotateDibits(dibits, rot)).
+func softType5FromDiffs(diffs []complex64, rot uint8) []float32 {
+	out := make([]float32, len(diffs)*2)
+	for i, d := range diffs {
+		var dr complex64
+		switch rot & 3 {
+		case 0:
+			dr = d
+		case 1: // ×j
+			dr = complex(-imag(d), real(d))
+		case 2: // ×-1
+			dr = complex(-real(d), -imag(d))
+		case 3: // ×-j
+			dr = complex(imag(d), -real(d))
+		}
+		out[2*i] = imag(dr)   // b1 LLR
+		out[2*i+1] = real(dr) // b2 LLR
+	}
+	return out
+}
+
 // processSB maintains the rolling dibit buffer, detects the
 // synchronisation training sequence (STS), and once a buffer covers the
 // whole synchronisation burst around an STS hit, decodes the BSCH (to
 // learn the colour code) and the BNCH SYSINFO. The BSCH is scrambled
 // with colour code 0, so this works on a cold receiver with no
 // configured colour code (issue #553).
-func (c *ControlChannel) processSB(p *processState, dibits []uint8, baseIdx int) {
+func (c *ControlChannel) processSB(p *processState, dibits []uint8, diffs []complex64, baseIdx int) {
 	// Align the buffer base on the first call.
 	if len(p.buf) == 0 {
 		p.bufBase = baseIdx
 	}
 	p.buf = append(p.buf, dibits...)
+	// Keep the soft buffer strictly parallel to buf. It stays in lockstep
+	// only while soft data is supplied every call; if a call lacks it
+	// (len mismatch), drop the soft path rather than misalign.
+	if diffs != nil && len(diffs) == len(dibits) && len(p.softBuf) == len(p.buf)-len(dibits) {
+		p.softBuf = append(p.softBuf, diffs...)
+	} else if len(p.softBuf) != len(p.buf) {
+		p.softBuf = p.softBuf[:0]
+	}
 
 	var hits []int
 	hits, _ = p.stsDet.Process(p.stsScratch[:0], dibits, baseIdx)
@@ -190,6 +228,9 @@ func (c *ControlChannel) processSB(p *processState, dibits []uint8, baseIdx int)
 			drop = len(p.buf)
 		}
 		p.buf = append(p.buf[:0], p.buf[drop:]...)
+		if len(p.softBuf) >= drop {
+			p.softBuf = append(p.softBuf[:0], p.softBuf[drop:]...)
+		}
 		p.bufBase += drop
 	}
 }
@@ -203,14 +244,31 @@ func (c *ControlChannel) decodeSB(p *processState, L int) {
 		s := start - p.bufBase
 		return p.buf[s : s+n]
 	}
+	// softBlock returns the per-dibit soft differentials for a block, or
+	// nil when the receiver supplied no soft data (hard-only path).
+	softBlock := func(start, n int) []complex64 {
+		if len(p.softBuf) != len(p.buf) {
+			return nil
+		}
+		s := start - p.bufBase
+		return p.softBuf[s : s+n]
+	}
 
-	// BSCH (block 1), scrambled with colour code 0. Try all rotations.
+	// BSCH (block 1), scrambled with colour code 0. Try all rotations,
+	// soft-decision when soft differentials are available.
 	bsch := block(L-sbBSCHDibits, sbBSCHDibits)
+	bschSoft := softBlock(L-sbBSCHDibits, sbBSCHDibits)
 	var sync SyncPDU
 	found := false
 	for rot := uint8(0); rot < 4 && !found; rot++ {
-		bits := TetraDibitsToBits(rotateDibits(bsch, rot))
-		if recovered, ok := DecodeBSCH(bits); ok {
+		var recovered []byte
+		var ok bool
+		if bschSoft != nil {
+			recovered, ok = DecodeBSCHSoft(softType5FromDiffs(bschSoft, rot))
+		} else {
+			recovered, ok = DecodeBSCH(TetraDibitsToBits(rotateDibits(bsch, rot)))
+		}
+		if ok {
 			if s, ok := ParseSyncPDU(recovered); ok {
 				sync, found = s, true
 			}
@@ -232,9 +290,15 @@ func (c *ControlChannel) decodeSB(p *processState, L int) {
 	// them).
 	colour := c.ColourCode()
 	bnch := block(L+stsDibits+sbBroadcastDibits, sbBNCHDibits)
+	bnchSoft := softBlock(L+stsDibits+sbBroadcastDibits, sbBNCHDibits)
 	for rot := uint8(0); rot < 4; rot++ {
-		bits := TetraDibitsToBits(rotateDibits(bnch, rot))
-		recovered, ok := DecodeSCHHD(bits, colour)
+		var recovered []byte
+		var ok bool
+		if bnchSoft != nil {
+			recovered, ok = DecodeSCHHDSoft(softType5FromDiffs(bnchSoft, rot), colour)
+		} else {
+			recovered, ok = DecodeSCHHD(TetraDibitsToBits(rotateDibits(bnch, rot)), colour)
+		}
 		if !ok {
 			continue
 		}

--- a/internal/radio/tetra/receiver/receiver.go
+++ b/internal/radio/tetra/receiver/receiver.go
@@ -108,6 +108,13 @@ type Options struct {
 	// near-noop on a clean single-carrier synth); recommended for live /
 	// replayed captures. See ChannelCutoffHz.
 	EnableChannelFilter bool
+	// SoftSink, when non-nil, receives the complex π/4-DQPSK differential
+	// (s·conj(last)) for each symbol, aligned 1:1 with the dibits emitted
+	// to DibitSink and carrying the same baseIdx. It is the soft
+	// information for soft-decision channel decoding (the two on-air bits'
+	// LLRs are Im and Re of the differential). Emitted just before the
+	// matching DibitSink call. nil ⇒ no soft emission, zero overhead.
+	SoftSink func(diffs []complex64, baseIdx int)
 }
 
 // ClockMode selects how the receiver decimates the matched-filter
@@ -158,10 +165,12 @@ type Receiver struct {
 	gardner   *sync.Gardner
 	afc       *carrierAFC
 	chanFilt  *filter.FIR
+	softSink  func(diffs []complex64, baseIdx int)
 
 	matched   []complex64
 	filtered  []complex64
 	dibits    []uint8
+	diffs     []complex64
 	symbols   []complex64
 	derotated []complex64
 	pending   []complex64
@@ -192,6 +201,7 @@ func New(opts Options) *Receiver {
 		dq:        demod.NewPiOver4DQPSK(int(sps+0.5), span, alpha, Rotation),
 		sps:       int(sps + 0.5),
 		dibitSink: opts.DibitSink,
+		softSink:  opts.SoftSink,
 		clockMode: opts.ClockMode,
 	}
 	if r.clockMode == ClockGardner {
@@ -269,7 +279,14 @@ func (r *Receiver) Process(iq []complex64) {
 	if len(r.symbols) == 0 {
 		return
 	}
-	r.dibits = r.dq.Decode(r.dibits, r.symbols)
+	if r.softSink != nil {
+		// Emit the complex differential (soft info) just before the
+		// matching dibits, both keyed by r.dibitBase.
+		r.dibits, r.diffs = r.dq.DecodeBoth(r.dibits, r.diffs, r.symbols)
+		r.softSink(r.diffs, r.dibitBase)
+	} else {
+		r.dibits = r.dq.Decode(r.dibits, r.symbols)
+	}
 	r.dibitSink(r.dibits, r.dibitBase)
 	r.dibitBase += len(r.dibits)
 }

--- a/internal/radio/tetra/receiver/soft_e2e_test.go
+++ b/internal/radio/tetra/receiver/soft_e2e_test.go
@@ -1,0 +1,140 @@
+package receiver
+
+import (
+	"io"
+	"log/slog"
+	"math"
+	"math/rand"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/demod"
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/tetra"
+)
+
+// buildSoftSBStream assembles a repeated TETRA synchronisation burst
+// (BSCH SYNC + STS + broadcast + BNCH SYSINFO) as a dibit stream, with a
+// warmup so the receiver loops converge.
+func buildSoftSBStream(repeats int, cc6 uint8, mcc, mnc, la uint16) []uint8 {
+	syncInfo := make([]byte, 60)
+	put := func(off, n int, v uint32) {
+		for i := 0; i < n; i++ {
+			syncInfo[off+i] = byte((v >> uint(n-1-i)) & 1)
+		}
+	}
+	put(4, 6, uint32(cc6))
+	put(31, 10, uint32(mcc))
+	put(41, 14, uint32(mnc))
+	bsch := tetra.TetraBitsToDibits(tetra.EncodeBSCH(syncInfo))
+
+	ext := tetra.ExtendedColourCode(mcc, mnc, cc6)
+	payload := make([]byte, 11)
+	payload[3] = byte((la >> 6) & 0xFF)
+	payload[4] = byte((la & 0x3F) << 2)
+	pdu := tetra.PDU{Disc: tetra.DiscMLE, Type: uint8(tetra.MLESystemInfo), Payload: payload}
+	bnch := tetra.TetraBitsToDibits(tetra.EncodeSCHHD(pduToType1BitsTETRA(pdu, 124), ext))
+
+	var out []uint8
+	for i := 0; i < 600; i++ {
+		out = append(out, uint8(i&3))
+	}
+	for r := 0; r < repeats; r++ {
+		out = append(out, bsch...)
+		out = append(out, tetra.SyncTrainingDibits()...)
+		out = append(out, make([]uint8, 15)...)
+		out = append(out, bnch...)
+		out = append(out, make([]uint8, 40)...) // inter-burst gap
+	}
+	return out
+}
+
+// runSoftSB modulates the SB-burst dibit stream, adds complex Gaussian
+// noise, runs it through the receiver (soft path on iff soft==true) into
+// a TETRA ControlChannel, and reports whether it locked.
+func runSoftSB(t *testing.T, dibits []uint8, noise float64, seed int64, soft bool) bool {
+	t.Helper()
+	const sps, span, alpha, rate = 8, 8, 0.35, 144_000.0
+	iq := demod.ModulatePiOver4DQPSK(dibits, sps, span, alpha, math.Pi/4)
+	rng := rand.New(rand.NewSource(seed))
+	for i := range iq {
+		iq[i] += complex(float32(rng.NormFloat64()*noise), float32(rng.NormFloat64()*noise))
+	}
+
+	bus := events.NewBus(64)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+	cc := tetra.New(tetra.Options{
+		Bus: bus, Log: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		SystemName: "soft", FrequencyHz: 412_000_000,
+	})
+	cc.SetChannelCoding(tetra.ChannelCodingOn)
+
+	opts := Options{
+		SampleRateHz: rate, ClockMode: ClockGardner, GardnerGain: 0.005, EnableAFC: true,
+		DibitSink: func(d []uint8, base int) { cc.Process(d, base) },
+	}
+	if soft {
+		opts.SoftSink = func(diffs []complex64, base int) { cc.StashSoft(diffs, base) }
+	}
+	rx := New(opts)
+	for i := 0; i < len(iq); i += 4096 {
+		e := i + 4096
+		if e > len(iq) {
+			e = len(iq)
+		}
+		rx.Process(iq[i:e])
+	}
+
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind == events.KindCCLocked {
+				return true
+			}
+			continue
+		default:
+		}
+		return false
+	}
+}
+
+// TestSoftDecisionLocksWhereHardFails drives noisy SB bursts through the
+// full production receiver (channel decode via the SB-burst path) at a
+// noise level where the soft-decision path closes the BSCH/BNCH FEC far
+// more often than the hard path — the end-to-end demonstration of the
+// soft-decision coding gain (issue #553 follow-up). It is statistical
+// (lock rate across fixed seeds) because a single noisy run is binary
+// and seed-sensitive near the FEC threshold.
+func TestSoftDecisionLocksWhereHardFails(t *testing.T) {
+	dibits := buildSoftSBStream(30, 0x2D, 0x0CE, 0x1234, 0x2B7)
+	const (
+		noise = 0.42
+		N     = 16
+	)
+	hardLocks, softLocks := 0, 0
+	for seed := int64(0); seed < N; seed++ {
+		if runSoftSB(t, dibits, noise, seed, false) {
+			hardLocks++
+		}
+		if runSoftSB(t, dibits, noise, seed, true) {
+			softLocks++
+		}
+	}
+	t.Logf("noise=%.2f over %d seeds: hard locked %d, soft locked %d", noise, N, hardLocks, softLocks)
+	if softLocks <= hardLocks {
+		t.Errorf("soft (%d/%d) did not beat hard (%d/%d)", softLocks, N, hardLocks, N)
+	}
+	if softLocks < hardLocks+3 || softLocks < 11 {
+		t.Errorf("soft-decision gain too small: hard %d, soft %d of %d", hardLocks, softLocks, N)
+	}
+}
+
+// TestSoftDecisionCleanStillLocks confirms the soft path is correct on a
+// clean signal too (no regression vs hard).
+func TestSoftDecisionCleanStillLocks(t *testing.T) {
+	dibits := buildSoftSBStream(8, 0x11, 0x123, 0x2345, 0x0AB)
+	if !runSoftSB(t, dibits, 0, 1, true) {
+		t.Error("soft path failed to lock on a clean SB burst")
+	}
+}

--- a/internal/radio/tetra/soft_test.go
+++ b/internal/radio/tetra/soft_test.go
@@ -1,0 +1,157 @@
+package tetra
+
+import (
+	"math"
+	"math/rand"
+	"testing"
+)
+
+// dibitIdealDiff returns the ideal π/4-DQPSK differential the demod sees
+// for a given dibit value: angle = rotation(π/4) + the dibit's phase
+// increment. Matches demod.dibitToDQPSKPhase + the receiver rotation.
+func dibitIdealDiff(v uint8) complex64 {
+	theta := map[uint8]float64{0: math.Pi / 4, 1: 3 * math.Pi / 4, 2: -3 * math.Pi / 4, 3: -math.Pi / 4}[v&3]
+	return complex(float32(math.Cos(theta)), float32(math.Sin(theta)))
+}
+
+// TestSoftType5Polarity guards the load-bearing invariant: the soft
+// type-5 LLRs (softType5FromDiffs) hard-slice to exactly the hard bits
+// TetraDibitsToBits(rotateDibits(...)) produces, for every dibit value
+// and every constellation rotation. A polarity or rotation error here
+// would make the soft decoder silently disagree with the hard one.
+func TestSoftType5Polarity(t *testing.T) {
+	for v := uint8(0); v < 4; v++ {
+		d := []complex64{dibitIdealDiff(v)}
+		for rot := uint8(0); rot < 4; rot++ {
+			soft := softType5FromDiffs(d, rot)
+			hard := TetraDibitsToBits(rotateDibits([]uint8{v}, rot))
+			for i := range hard {
+				softBit := byte(0)
+				if soft[i] < 0 { // LLR < 0 ⇒ bit 1
+					softBit = 1
+				}
+				if softBit != hard[i] {
+					t.Errorf("dibit %d rot %d bit %d: soft slices to %d (llr %.2f), hard %d",
+						v, rot, i, softBit, soft[i], hard[i])
+				}
+			}
+		}
+	}
+}
+
+// schhdInfo builds a deterministic 124-bit SCH/HD type-1 block.
+func schhdInfo() []byte {
+	info := make([]byte, 124)
+	for i := range info {
+		info[i] = byte((i*7 + 3) & 1)
+	}
+	return info
+}
+
+// bitsToLLR maps hard type-5 bits to LLRs (bit 0 → +1, bit 1 → -1) plus
+// Gaussian noise of the given sigma. Returns the LLRs and the hard-sliced
+// bits (sign decision) so the hard and soft decoders see the same channel.
+func bitsToLLR(bits []byte, sigma float64, rng *rand.Rand) ([]float32, []byte) {
+	llr := make([]float32, len(bits))
+	hard := make([]byte, len(bits))
+	for i, b := range bits {
+		mean := 1.0
+		if b&1 == 1 {
+			mean = -1.0
+		}
+		v := mean + rng.NormFloat64()*sigma
+		llr[i] = float32(v)
+		if v < 0 {
+			hard[i] = 1
+		}
+	}
+	return llr, hard
+}
+
+// TestSoftSCHHDRoundTripCleanMatchesHard: with no noise, soft decode
+// recovers the info and passes CRC, identical to hard.
+func TestSoftSCHHDRoundTripClean(t *testing.T) {
+	info := schhdInfo()
+	const colour = 0x12345
+	type5 := EncodeSCHHD(info, colour)
+	llr, hard := bitsToLLR(type5, 0, rand.New(rand.NewSource(1)))
+
+	got, ok := DecodeSCHHDSoft(llr, colour)
+	if !ok {
+		t.Fatal("soft SCH/HD failed CRC on a clean channel")
+	}
+	for i := range info {
+		if got[i] != info[i] {
+			t.Fatalf("soft SCH/HD recovered bit %d = %d, want %d", i, got[i], info[i])
+		}
+	}
+	if _, ok := DecodeSCHHD(hard, colour); !ok {
+		t.Fatal("hard SCH/HD failed CRC on a clean channel (sanity)")
+	}
+}
+
+// TestSoftSCHHDOutperformsHardUnderNoise: at a noise level where the
+// hard decoder mostly fails, the soft decoder mostly succeeds —
+// demonstrating the ~2 dB soft-decision coding gain through the full
+// descramble → deinterleave → depuncture → Viterbi chain.
+func TestSoftSCHHDOutperformsHardUnderNoise(t *testing.T) {
+	info := schhdInfo()
+	const colour = 0x12345
+	type5 := EncodeSCHHD(info, colour)
+	rng := rand.New(rand.NewSource(42))
+	const (
+		sigma  = 0.7
+		trials = 200
+	)
+	hardPass, softPass := 0, 0
+	for tr := 0; tr < trials; tr++ {
+		llr, hard := bitsToLLR(type5, sigma, rng)
+		if _, ok := DecodeSCHHD(hard, colour); ok {
+			hardPass++
+		}
+		if got, ok := DecodeSCHHDSoft(llr, colour); ok {
+			softPass++
+			// A CRC pass must mean correct recovery.
+			for i := range info {
+				if got[i] != info[i] {
+					t.Fatalf("soft CRC passed but bit %d wrong", i)
+				}
+			}
+		}
+	}
+	t.Logf("sigma=%.2f: hard %d/%d, soft %d/%d", sigma, hardPass, trials, softPass, trials)
+	// Soft must be a clear win: at this noise the hard decoder mostly
+	// fails while soft mostly succeeds.
+	if softPass < 60 || softPass < 2*hardPass {
+		t.Errorf("soft gain insufficient: hard %d, soft %d of %d (want soft>=60 and >=2x hard)", hardPass, softPass, trials)
+	}
+}
+
+// TestSoftBSCHOutperformsHardUnderNoise: same gain on the colour-0 BSCH
+// (the cold-start lock chain).
+func TestSoftBSCHOutperformsHardUnderNoise(t *testing.T) {
+	info := make([]byte, 60)
+	for i := range info {
+		info[i] = byte((i*5 + 1) & 1)
+	}
+	type5 := EncodeBSCH(info)
+	rng := rand.New(rand.NewSource(7))
+	const (
+		sigma  = 0.7
+		trials = 200
+	)
+	hardPass, softPass := 0, 0
+	for tr := 0; tr < trials; tr++ {
+		llr, hard := bitsToLLR(type5, sigma, rng)
+		if _, ok := DecodeBSCH(hard); ok {
+			hardPass++
+		}
+		if _, ok := DecodeBSCHSoft(llr); ok {
+			softPass++
+		}
+	}
+	t.Logf("BSCH sigma=%.2f: hard %d/%d, soft %d/%d", sigma, hardPass, trials, softPass, trials)
+	if softPass < 60 || softPass < 2*hardPass {
+		t.Errorf("soft BSCH gain insufficient: hard %d, soft %d of %d", hardPass, softPass, trials)
+	}
+}

--- a/internal/scanner/ccdecoder/pipelines.go
+++ b/internal/scanner/ccdecoder/pipelines.go
@@ -518,6 +518,11 @@ func newTETRAPipeline(opts PipelineOptions) (ProtocolPipeline, error) {
 			opts.tapDibits(dibits, baseIdx)
 			cc.Process(dibits, baseIdx)
 		},
+		// Soft differentials for soft-decision channel decoding, stashed
+		// just before the matching DibitSink → Process call (issue #553).
+		SoftSink: func(diffs []complex64, baseIdx int) {
+			cc.StashSoft(diffs, baseIdx)
+		},
 		ClockMode: tetraClockMode,
 		// Tuned smaller than the 0.03 default — at TETRA's 18000
 		// sym/s the standard gain over-corrects on clean signals


### PR DESCRIPTION
Follow-up for issue #553. The TETRA channel coding decoded from hard bits,
discarding the demodulator's confidence — ~2 dB of loss that matters on marginal
captures (the reporter's recording never closes the hard BSCH/BNCH FEC). This
adds an end-to-end soft-decision path for the synchronisation-burst lock chain
(BSCH colour-learn + BNCH SYSINFO).

The π/4-DQPSK differential d = s·conj(last) carries the soft information: with
the demod's quadrant boundaries and the TETRA Gray mapping, the two on-air bits'
LLRs are exactly Im(d) and Re(d) (positive ⇒ bit 0), and the four constellation
rotations are d·e^{j·rot·π/2}. No trig or scaling is needed (the Viterbi argmin
is scale-invariant), and the soft LLRs hard-slice to precisely TetraDibitsToBits
(guarded by a polarity test across all dibit values and rotations).

- demod: DQPSK.DecodeBoth emits the hard dibit and the complex differential in
  one pass (single `last` update).
- receiver: opt-in SoftSink emits the per-symbol differentials aligned with the
  dibits; enabled in the production TETRA pipeline.
- control/process: the differentials are stashed and ride a soft buffer kept
  parallel to the SB-burst rolling dibit buffer; decodeSB uses the soft decoders
  when available, falling back to hard.
- framing: soft analogs of the chain — DescrambleTetraSoft (sign-flip),
  BlockDeinterleaveTetraSoft (reorder), DepunctureRCPCTetraSigSoft (erasures),
  DecodeRCPCTetraSigMotherSoft (16-state Viterbi with the correlation metric
  cost += LLR·(2g-1)).
- channel_coding: signalingDecodeSoft + DecodeSCHHDSoft / DecodeBSCHSoft (CRC on
  the hard Viterbi output).

Tests: soft-vs-hard coding gain on SCH/HD (hard 16/200 → soft 114/200 at the same
noise) and BSCH (53 → 151); a clean round-trip; the LLR-polarity/rotation guard;
and an end-to-end statistical test through the receiver where the soft path locks
far more often than hard (hard 7/16 → soft 13/16 at a noise the hard FEC can't
close). The existing hard path and all other protocols are unchanged. The
reporter's specific capture is still below the soft threshold, but the coding
gain is demonstrated and available for higher-SNR sites.

https://claude.ai/code/session_015AC2GqJumEvuJu7iGZgBkf