### PR TITLE
Constellation & Symbol scope: frequency view, precise tuning, OP25-size plot (#557 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,12 @@ for tagged releases.
   instead of staying blank until symbols decode. Both panels gain precise
   channel entry: the **kHz** offset field takes 1 Hz resolution (so 6.25 /
   12.5 kHz channel grids land exactly) plus an absolute **MHz** frequency
-  field that stays in sync. The Constellation gains an adjustable **Zoom**
-  control (and a larger default dot size), and its auto-scale now targets the
-  ~95th-percentile radius so a stray outlier no longer shrinks the cloud.
+  field that stays in sync. The Constellation plot is now a responsive square
+  that fills the panel column (up to 880 px, drawn at device-pixel ratio for
+  crispness) instead of a fixed thumbnail, so it renders as large as OP25's,
+  and gains an adjustable **Zoom** control (up to 8×; dots scale with both
+  zoom and plot size); its auto-scale now targets the ~95th-percentile radius
+  so a stray outlier no longer shrinks the cloud.
 
 ## [v0.3.5] — 2026-06-07
 

--- a/docs/constellation.md
+++ b/docs/constellation.md
@@ -48,9 +48,15 @@ collapses into one fat blob. Three controls work around this:
   to remove any residual offset; auto-scale eases a gain so the cloud
   fills the unit circle (targeting the ~95th-percentile radius, so a
   stray outlier doesn't shrink the whole cloud). Both default on.
-- **Zoom** — magnifies the plotted cloud and the dot size together, so
-  the scatter reads as dots rather than pin-pricks; dial it to taste.
-  The setting persists across visits.
+- **Zoom** — magnifies the plotted cloud and the dot size together (up to
+  8×), so the scatter reads as dots rather than pin-pricks; dial it to
+  taste to punch in on the symbol structure. The setting persists across
+  visits.
+
+The plot itself is a responsive square that fills the panel column (up to
+880 px) rather than a fixed thumbnail, so it renders as large as OP25's —
+and it stays crisp at any size because the canvas is drawn at the display's
+device-pixel ratio.
 
 Common shapes:
 

--- a/web/src/panels/Constellation.tsx
+++ b/web/src/panels/Constellation.tsx
@@ -40,11 +40,22 @@ import { TuningControls } from "../components/TuningControls";
 
 const TARGET_RATE_SPS = 2000;
 const POINT_BUFFER = 2000;       // how many recent points to render
-const CANVAS_PX = 420;           // square canvas; CSS scales to width
+// The plot is a responsive square: it fills the panel column (so it's as
+// large as OP25's, not a fixed postage stamp) but stays bounded so it
+// can't run away on ultrawide layouts. Measured at runtime via
+// ResizeObserver; rendered at devicePixelRatio for crispness.
+const MIN_CANVAS_PX = 320;
+const MAX_CANVAS_PX = 880;
+const LEGACY_RADIUS_PX = 187;    // old 420px plot radius — dot-scale baseline
 const MARGIN = { top: 12, right: 12, bottom: 24, left: 34 };
-// Base dot edge in CSS px at zoom 1; scaled by the Zoom control so the
-// scatter reads clearly instead of as pin-pricks (issue #557 follow-up).
+// Base dot edge in CSS px at zoom 1 and the legacy plot size; scaled by
+// the Zoom control and the live plot size so the scatter reads clearly
+// instead of as pin-pricks (issue #557 follow-up).
 const BASE_DOT_PX = 2;
+// Auto-scale fills the ~95th-percentile radius to this fraction of the
+// unit circle at zoom 1 (a touch under OP25's ~0.75 so Zoom has headroom
+// to punch in without immediately clipping the cloud).
+const FILL_TARGET = 0.6;
 
 // GopherTrunk's sky-400 accent (matches --gt-accent and the Spectrum
 // waterfall's blue→cyan ramp), deliberately not OP25's phosphor green.
@@ -85,10 +96,47 @@ export function Constellation() {
   );
   const [zoom, setZoom] = useState<number>(() => prefs.constellationZoom());
 
+  const wrapRef = useRef<HTMLDivElement | null>(null);
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const bufferRef = useRef<IQPoint[]>([]);
   const scaleRef = useRef<number>(1);
   const optsRef = useRef<RenderOpts>({ dcBlock, autoScale, zoom, scaleRef });
+  // Live square edge of the plot in CSS px, tracked from the container.
+  const [size, setSize] = useState<number>(MIN_CANVAS_PX);
+
+  // Track the available width and keep the plot a square that fills it
+  // (bounded). Falls back to a one-shot measure where ResizeObserver is
+  // absent (e.g. jsdom under test).
+  useEffect(() => {
+    const el = wrapRef.current;
+    if (!el) return;
+    const measure = () => {
+      const inner = el.clientWidth - 16; // minus the p-2 padding
+      const next = Math.max(
+        MIN_CANVAS_PX,
+        Math.min(MAX_CANVAS_PX, Math.floor(inner)),
+      );
+      if (next > 0) setSize(next);
+    };
+    measure();
+    if (typeof ResizeObserver === "undefined") return;
+    const ro = new ResizeObserver(measure);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  // Size the canvas buffer to the displayed square × devicePixelRatio so
+  // the scatter stays crisp at any size, then repaint.
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const dpr = window.devicePixelRatio || 1;
+    canvas.width = Math.round(size * dpr);
+    canvas.height = Math.round(size * dpr);
+    canvas.style.width = `${size}px`;
+    canvas.style.height = `${size}px`;
+    renderConstellation(canvas, bufferRef.current, optsRef.current);
+  }, [size]);
 
   // Keep the render-time options the WS callback reads in sync without
   // re-subscribing the stream when a toggle flips.
@@ -285,7 +333,7 @@ export function Constellation() {
           <input
             type="range"
             min={0.5}
-            max={4}
+            max={8}
             step={0.1}
             value={zoom}
             onChange={(e) => setZoom(Number(e.target.value))}
@@ -300,13 +348,13 @@ export function Constellation() {
 
       <div className="font-mono text-xs text-muted">{tuningLabel || "—"}</div>
 
-      <div className="rounded border border-border bg-black flex items-center justify-center p-2">
+      <div
+        ref={wrapRef}
+        className="rounded border border-border bg-black flex items-center justify-center p-2"
+      >
         <canvas
           ref={canvasRef}
-          width={CANVAS_PX}
-          height={CANVAS_PX}
-          className="block max-w-full"
-          style={{ width: CANVAS_PX, height: CANVAS_PX }}
+          className="block"
           aria-label="IQ constellation scatter"
         />
       </div>
@@ -342,8 +390,12 @@ function renderConstellation(
   if (!canvas) return;
   const ctx = canvas.getContext("2d");
   if (!ctx) return;
-  const w = canvas.width;
-  const h = canvas.height;
+  // The buffer is sized at devicePixelRatio; draw in logical (CSS) px so
+  // margins, fonts and dot sizes stay consistent at any zoom/DPI.
+  const dpr = window.devicePixelRatio || 1;
+  ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+  const w = canvas.width / dpr;
+  const h = canvas.height / dpr;
 
   // Square plot region inside the label margins.
   const plot = Math.min(
@@ -419,7 +471,7 @@ function renderConstellation(
     }
     radii.sort();
     const refR = Math.max(1e-6, radii[Math.min(n - 1, Math.floor(0.95 * n))]);
-    const target = Math.max(0.2, Math.min(8, 0.9 / refR));
+    const target = Math.max(0.2, Math.min(8, FILL_TARGET / refR));
     gain = gain + (target - gain) * 0.1;
     opts.scaleRef.current = gain;
   } else {
@@ -429,9 +481,15 @@ function renderConstellation(
 
   // Zoom magnifies both the cloud and the dot size so the scatter reads as
   // dots, not pin-pricks, and can be dialled to taste (issue #557 follow-up).
+  // Dots also grow with the plot size so a large canvas keeps proportionate,
+  // OP25-sized points rather than the same few pixels on a much bigger ring.
   const zoom = opts.zoom > 0 ? opts.zoom : 1;
   const finalGain = gain * zoom;
-  const dotPx = Math.max(2, Math.min(8, Math.round(BASE_DOT_PX * zoom)));
+  const sizeScale = radius / LEGACY_RADIUS_PX;
+  const dotPx = Math.max(
+    2,
+    Math.min(14, Math.round(BASE_DOT_PX * zoom * sizeScale)),
+  );
   const dotHalf = dotPx / 2;
 
   // Additive blending so overlapping symbols accumulate brightness.

--- a/web/src/store/prefs.ts
+++ b/web/src/store/prefs.ts
@@ -166,17 +166,18 @@ export const prefs = {
     writeLS(LS_KEYS.constellationAutoScale, on ? "1" : "0");
   },
   // Zoom magnifies the plotted cloud and dot size so the scatter fills the
-  // unit circle like OP25's plot. Clamped 0.5..4; defaults a touch above 1
-  // so the out-of-the-box view is already larger than 1:1.
+  // unit circle like OP25's plot. Clamped 0.5..8 (wide range so the view can
+  // punch in hard); defaults a touch above 1 so the out-of-the-box view is
+  // already larger than 1:1.
   constellationZoom(): number {
     const raw = readLS(LS_KEYS.constellationZoom);
     if (raw === null) return 1.5;
     const n = Number(raw);
     if (!Number.isFinite(n)) return 1.5;
-    return Math.max(0.5, Math.min(4, n));
+    return Math.max(0.5, Math.min(8, n));
   },
   setConstellationZoom(z: number) {
-    writeLS(LS_KEYS.constellationZoom, String(Math.max(0.5, Math.min(4, z))));
+    writeLS(LS_KEYS.constellationZoom, String(Math.max(0.5, Math.min(8, z))));
   },
 
   // Symbol-scope panel view options. Offset (kHz, relative to the SDR


### PR DESCRIPTION
Addresses the reporter's follow-up notes on issue #557 (the OP25-style Constellation / Symbol scope work), plus the request to make the Constellation as large as OP25's.

## Reporter's notes → fixes

1. **Symbol scope was missing a frequency view.** Both panels build a `MHz (offset)` tuning label, but it was gated on a frame arriving. The Constellation's `IQFrame` streams continuously, so its frequency always showed; the Symbol scope's `SymbolFrame` only arrives once the P25 receiver emits dibits, so it stayed blank with nothing decoding. The frequency is now derived from the selected device's centre + offset, so it shows the moment an SDR is picked.

2. **Offset could only be entered in coarse kHz.** The numeric field rounded to 0.1 kHz and the slider stepped in whole kHz, so 6.25 / 12.5 kHz channel grids couldn't be hit. Both panels now share a `TuningControls` component with a 1 Hz-resolution **kHz** field *and* an absolute **MHz** frequency field that stays in sync. (Full Hz precision already travelled end-to-end; this was purely a frontend input-granularity problem.)

3. **Constellation dots/cloud too small vs OP25.** The plot was a fixed 420 px square and dots were a fixed 2 px; auto-scale used the absolute-max radius, so one outlier shrank the whole cloud.
   - The plot is now a **responsive square** that fills the panel column (clamped 320–880 px), measured via `ResizeObserver` and drawn at `devicePixelRatio` for crispness — so it renders as large as OP25's.
   - Adjustable **Zoom** control (0.5–8×); dot size scales with both zoom and plot size.
   - Auto-scale targets the **~95th-percentile** radius (with a fill target that leaves zoom headroom), so a stray outlier no longer shrinks the cloud.

## Files
- `web/src/components/TuningControls.tsx` (+ test) — shared offset/frequency/Hold/Centre block
- `web/src/panels/Constellation.tsx`, `web/src/panels/SymbolScope.tsx` (+ tests)
- `web/src/components/SymbolScopeChart.tsx`, `web/src/store/prefs.ts`
- `docs/constellation.md`, `docs/symbol-scope.md`, `CHANGELOG.md`

## Verification
- `npx vitest run` — 137/137 pass (24 files)
- `npm run typecheck` and `npm run build` — clean
- `go build ./...` — clean (no backend changes)

https://claude.ai/code/session_01SoLZgHc9snsyfchmmD61XA

---
_Generated by [Claude Code](https://claude.ai/code/session_01SoLZgHc9snsyfchmmD61XA)_