### PR TITLE
config/api: backend for builder gap-fill (multi-error, comment-merge, file mgmt, RR names, token)

### DIFF
--- a/cmd/gophertrunk/config_serve.go
+++ b/cmd/gophertrunk/config_serve.go
@@ -28,6 +28,8 @@ func runConfigServe(args []string) {
 	addr := fs.String("addr", "127.0.0.1:8077", "listen address")
 	open := fs.Bool("open", false, "open the builder in the system browser once it is up")
 	configDir := fs.String("config-dir", "", "directory to browse and save configs in (default: the standard discovery locations)")
+	token := fs.String("token", "", "bearer token required for save/mutations (needed on non-loopback binds)")
+	tokenFile := fs.String("token-file", "", "path to a file holding the bearer token (reloaded per request)")
 	verboseFlag := fs.Bool("verbose-errors", false, "print full error chain + stack on failures")
 	fs.Usage = func() {
 		fmt.Fprintln(fs.Output(), `gophertrunk config serve — standalone web Config Builder/Editor.
@@ -61,10 +63,11 @@ FLAGS:`)
 		Addr:    *addr,
 		Bus:     bus,
 		Version: version.String(),
-		// No explicit auth/AllowMutations: the default auth mode trusts
-		// loopback, so saves work on the default 127.0.0.1 bind. On a
-		// non-loopback -addr the save endpoint requires a bearer token
-		// (the SPA has a token field); reads stay open.
+		// Auth: default mode trusts loopback (saves work on 127.0.0.1
+		// out of the box). A -token / -token-file makes the save endpoint
+		// require that bearer token on non-loopback binds (the SPA has a
+		// token field); reads stay open either way.
+		Auth: api.AuthConfig{Token: strings.TrimSpace(*token), TokenFile: strings.TrimSpace(*tokenFile)},
 		// Parse-only importer: daemonImporter.Parse never touches the
 		// (nil) Daemon, so POST /api/v1/config/parse works standalone.
 		Importer: &daemonImporter{},

--- a/internal/api/config_builder.go
+++ b/internal/api/config_builder.go
@@ -107,6 +107,22 @@ func (svc *configBuilderService) resolveAllowed(reqPath string, exts ...string) 
 	return "", errPathOutsideRoots
 }
 
+// resolveDir validates a directory path for mkdir: symlink-resolved, it
+// must sit inside (or equal) an allowed root. No extension check.
+func (svc *configBuilderService) resolveDir(reqPath string) (string, error) {
+	reqPath = strings.TrimSpace(reqPath)
+	if reqPath == "" {
+		return "", errors.New("path is required")
+	}
+	canon := evalSymlinksBestEffort(reqPath)
+	for _, root := range svc.dirs {
+		if withinRoot(root, canon) {
+			return canon, nil
+		}
+	}
+	return "", errPathOutsideRoots
+}
+
 // withinRoot reports whether abs is root itself or nested beneath it,
 // using filepath.Rel so ".." escapes are rejected portably.
 func withinRoot(root, abs string) bool {

--- a/internal/api/handlers_config_builder.go
+++ b/internal/api/handlers_config_builder.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/MattCheramie/GopherTrunk/internal/config"
@@ -95,8 +96,8 @@ func (s *Server) handleConfigValidate(w http.ResponseWriter, r *http.Request) {
 	var errs []error
 	if req.Section == "" {
 		errs = req.Config.ValidateAll()
-	} else if e := req.Config.ValidateSection(req.Section); e != nil {
-		errs = []error{e}
+	} else {
+		errs = req.Config.ValidateSection(req.Section)
 	}
 	writeJSON(w, http.StatusOK, validationErrorsFrom(errs))
 }
@@ -240,6 +241,45 @@ func (s *Server) handleConfigRRSearch(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]any{"results": hits})
 }
 
+// handleConfigRRStates answers GET /api/v1/config/rr/states — the state
+// list (id+name) backing the name-based browse picker.
+func (s *Server) handleConfigRRStates(w http.ResponseWriter, r *http.Request) {
+	client, err := s.configBuilder.rrClient()
+	if err != nil {
+		s.writeError(w, http.StatusServiceUnavailable,
+			"config: RadioReference credentials not configured (set radioreference.* or GOPHERTRUNK_RR_KEY/USER/PASS)")
+		return
+	}
+	states, err := client.GetStateList(r.Context())
+	if err != nil {
+		s.writeError(w, http.StatusBadGateway, "config: RadioReference: "+err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"results": states})
+}
+
+// handleConfigRRCounties answers GET /api/v1/config/rr/counties?state=<stid>
+// — the counties in a state (id+name) for the browse picker.
+func (s *Server) handleConfigRRCounties(w http.ResponseWriter, r *http.Request) {
+	client, err := s.configBuilder.rrClient()
+	if err != nil {
+		s.writeError(w, http.StatusServiceUnavailable,
+			"config: RadioReference credentials not configured (set radioreference.* or GOPHERTRUNK_RR_KEY/USER/PASS)")
+		return
+	}
+	stid, serr := strconv.Atoi(r.URL.Query().Get("state"))
+	if serr != nil {
+		s.writeError(w, http.StatusBadRequest, "config: state must be a numeric RadioReference stid")
+		return
+	}
+	counties, err := client.GetCountyList(r.Context(), stid)
+	if err != nil {
+		s.writeError(w, http.StatusBadGateway, "config: RadioReference: "+err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"results": counties})
+}
+
 // handleConfigRRSystem answers GET /api/v1/config/rr/system/{sid} —
 // full system detail plus a config-ready projection.
 func (s *Server) handleConfigRRSystem(w http.ResponseWriter, r *http.Request) {
@@ -319,6 +359,171 @@ func (s *Server) handleConfigMarshal(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]string{"yaml": string(data)})
+}
+
+// handleConfigTalkgroups answers GET /api/v1/config/file/talkgroups?path=...
+// returning the rows of each system's TalkgroupFile sidecar so the builder
+// can view/edit the talkgroups of an existing config. Sidecars that are
+// missing, unreadable, or reference a path outside the allowed roots are
+// skipped silently (the system simply has no editable rows yet).
+func (s *Server) handleConfigTalkgroups(w http.ResponseWriter, r *http.Request) {
+	path, err := s.configBuilder.resolvePath(r.URL.Query().Get("path"))
+	if err != nil {
+		s.writeError(w, http.StatusBadRequest, "config: "+err.Error())
+		return
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		s.writeError(w, http.StatusNotFound, "config: "+err.Error())
+		return
+	}
+	var cfg config.Config
+	if err := config.Unmarshal(data, &cfg); err != nil {
+		s.writeError(w, http.StatusBadRequest, "config: parse: "+err.Error())
+		return
+	}
+	dir := filepath.Dir(path)
+	out := map[string][]TalkgroupCSVRow{}
+	for _, sysm := range cfg.Trunking.Systems {
+		rel := strings.TrimSpace(sysm.TalkgroupFile)
+		if rel == "" {
+			continue
+		}
+		csvPath, perr := s.configBuilder.resolveSidecarPath(filepath.Join(dir, rel))
+		if perr != nil {
+			continue
+		}
+		rows, rerr := readTalkgroupCSV(csvPath)
+		if rerr != nil {
+			continue
+		}
+		out[rel] = rows
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"talkgroups": out})
+}
+
+// handleConfigDelete answers DELETE /api/v1/config/file?path=... (gated).
+func (s *Server) handleConfigDelete(w http.ResponseWriter, r *http.Request) {
+	path, err := s.configBuilder.resolvePath(r.URL.Query().Get("path"))
+	if err != nil {
+		s.writeError(w, http.StatusBadRequest, "config: "+err.Error())
+		return
+	}
+	if err := os.Remove(path); err != nil {
+		s.writeError(w, http.StatusInternalServerError, "config: "+err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"deleted": path})
+}
+
+// handleConfigRename answers POST /api/v1/config/file/rename (gated). Both
+// paths are allow-list validated; refuses to clobber an existing target.
+func (s *Server) handleConfigRename(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		From string `json:"from"`
+		To   string `json:"to"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		s.writeError(w, http.StatusBadRequest, "config: "+err.Error())
+		return
+	}
+	from, err := s.configBuilder.resolvePath(req.From)
+	if err != nil {
+		s.writeError(w, http.StatusBadRequest, "config: from: "+err.Error())
+		return
+	}
+	to, err := s.configBuilder.resolvePath(req.To)
+	if err != nil {
+		s.writeError(w, http.StatusBadRequest, "config: to: "+err.Error())
+		return
+	}
+	if _, statErr := os.Stat(to); statErr == nil {
+		s.writeError(w, http.StatusConflict, "config: target already exists: "+to)
+		return
+	}
+	if err := os.Rename(from, to); err != nil {
+		s.writeError(w, http.StatusInternalServerError, "config: "+err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"from": from, "to": to})
+}
+
+// handleConfigMkdir answers POST /api/v1/config/dir (gated) — create a
+// subdirectory inside an allowed root so the operator can organize configs.
+func (s *Server) handleConfigMkdir(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Path string `json:"path"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		s.writeError(w, http.StatusBadRequest, "config: "+err.Error())
+		return
+	}
+	dir, err := s.configBuilder.resolveDir(req.Path)
+	if err != nil {
+		s.writeError(w, http.StatusBadRequest, "config: "+err.Error())
+		return
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		s.writeError(w, http.StatusInternalServerError, "config: "+err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"path": dir})
+}
+
+// readTalkgroupCSV parses a Trunk Recorder–style talkgroup CSV into rows,
+// mapping columns by (case/space-insensitive) header name so column order
+// and extra columns are tolerated. Rows without a numeric Decimal are
+// skipped.
+func readTalkgroupCSV(path string) ([]TalkgroupCSVRow, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	cr := csv.NewReader(f)
+	cr.FieldsPerRecord = -1
+	cr.TrimLeadingSpace = true
+	records, err := cr.ReadAll()
+	if err != nil {
+		return nil, err
+	}
+	if len(records) == 0 {
+		return nil, nil
+	}
+	idx := make(map[string]int, len(records[0]))
+	for i, h := range records[0] {
+		idx[normalizeHeader(h)] = i
+	}
+	col := func(rec []string, key string) string {
+		if j, ok := idx[key]; ok && j < len(rec) {
+			return strings.TrimSpace(rec[j])
+		}
+		return ""
+	}
+	var rows []TalkgroupCSVRow
+	for _, rec := range records[1:] {
+		decStr := col(rec, "decimal")
+		if decStr == "" {
+			continue
+		}
+		dec, err := strconv.ParseUint(decStr, 10, 32)
+		if err != nil {
+			continue
+		}
+		rows = append(rows, TalkgroupCSVRow{
+			Decimal:     uint32(dec),
+			AlphaTag:    col(rec, "alphatag"),
+			Description: col(rec, "description"),
+			Tag:         col(rec, "tag"),
+			Group:       col(rec, "group"),
+			Mode:        col(rec, "mode"),
+		})
+	}
+	return rows, nil
+}
+
+func normalizeHeader(h string) string {
+	return strings.ReplaceAll(strings.ToLower(strings.TrimSpace(h)), " ", "")
 }
 
 // writeTalkgroupCSV writes a Trunk Recorder–style talkgroup CSV that

--- a/internal/api/handlers_config_builder_test.go
+++ b/internal/api/handlers_config_builder_test.go
@@ -119,6 +119,86 @@ func TestConfigBuilder_ValidateAndSave(t *testing.T) {
 	}
 }
 
+func TestConfigBuilder_TalkgroupRoundTrip(t *testing.T) {
+	base, dir, teardown := cbServer(t)
+	defer teardown()
+
+	// Save a config with a system that references a talkgroup sidecar.
+	cfg := config.Default()
+	cfg.Trunking.Systems = []config.SystemConfig{{
+		Name: "Metro", Protocol: "p25", ControlChannels: []uint32{851_037_500},
+		TalkgroupFile: "metro-tgs.csv",
+	}}
+	path := filepath.Join(dir, "config.yaml")
+	code := postJSONStatus(t, base+"/api/v1/config/file", ConfigSaveRequest{
+		Path:   path,
+		Config: cfg,
+		Talkgroups: map[string][]TalkgroupCSVRow{
+			"metro-tgs.csv": {
+				{Decimal: 101, AlphaTag: "PD Disp", Tag: "Law Dispatch", Mode: "D"},
+				{Decimal: 202, AlphaTag: "FD Ops"},
+			},
+		},
+	}, nil)
+	if code != http.StatusOK {
+		t.Fatalf("save status=%d", code)
+	}
+
+	// Read the talkgroups back for that config.
+	var resp struct {
+		Talkgroups map[string][]TalkgroupCSVRow `json:"talkgroups"`
+	}
+	getJSON(t, base+"/api/v1/config/file/talkgroups?path="+path, &resp)
+	rows := resp.Talkgroups["metro-tgs.csv"]
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 talkgroups, got %+v", resp.Talkgroups)
+	}
+	if rows[0].Decimal != 101 || rows[0].AlphaTag != "PD Disp" || rows[0].Mode != "D" {
+		t.Fatalf("row0 mismatch: %+v", rows[0])
+	}
+}
+
+func TestConfigBuilder_FileManagement(t *testing.T) {
+	base, dir, teardown := cbServer(t)
+	defer teardown()
+
+	// mkdir a subdir, save into it, rename, then delete.
+	sub := filepath.Join(dir, "sites")
+	if postJSONStatus(t, base+"/api/v1/config/dir", map[string]string{"path": sub}, nil) != http.StatusOK {
+		t.Fatalf("mkdir failed")
+	}
+	if _, err := os.Stat(sub); err != nil {
+		t.Fatalf("subdir not created: %v", err)
+	}
+
+	src := filepath.Join(sub, "a.yaml")
+	if postJSONStatus(t, base+"/api/v1/config/file", ConfigSaveRequest{Path: src, Config: config.Default()}, nil) != http.StatusOK {
+		t.Fatalf("save into subdir failed")
+	}
+
+	dst := filepath.Join(sub, "b.yaml")
+	if postJSONStatus(t, base+"/api/v1/config/file/rename", map[string]string{"from": src, "to": dst}, nil) != http.StatusOK {
+		t.Fatalf("rename failed")
+	}
+	if _, err := os.Stat(dst); err != nil {
+		t.Fatalf("renamed file missing: %v", err)
+	}
+	if _, err := os.Stat(src); !os.IsNotExist(err) {
+		t.Fatalf("old name should be gone")
+	}
+
+	// Delete via DELETE.
+	reqDelete(t, base+"/api/v1/config/file?path="+dst)
+	if _, err := os.Stat(dst); !os.IsNotExist(err) {
+		t.Fatalf("file should be deleted")
+	}
+
+	// mkdir / rename outside the root are rejected.
+	if postJSONStatus(t, base+"/api/v1/config/dir", map[string]string{"path": "/etc/evil"}, nil) != http.StatusBadRequest {
+		t.Fatalf("mkdir outside root should be 400")
+	}
+}
+
 func TestConfigBuilder_PathTraversalRejected(t *testing.T) {
 	base, _, teardown := cbServer(t)
 	defer teardown()
@@ -220,6 +300,23 @@ func postJSON(t *testing.T, url string, body, out any) {
 	t.Helper()
 	if code := postJSONStatus(t, url, body, out); code != http.StatusOK {
 		t.Fatalf("POST %s: status=%d", url, code)
+	}
+}
+
+func reqDelete(t *testing.T, url string) {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodDelete, url, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("DELETE %s: status=%d body=%s", url, resp.StatusCode, b)
 	}
 }
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -1013,13 +1013,19 @@ func (s *Server) routes() *http.ServeMux {
 	if s.configBuilder != nil {
 		mux.HandleFunc("GET /api/v1/config/files", s.handleConfigList)
 		mux.HandleFunc("GET /api/v1/config/file", s.handleConfigLoad)
+		mux.HandleFunc("GET /api/v1/config/file/talkgroups", s.handleConfigTalkgroups)
 		mux.HandleFunc("GET /api/v1/config/defaults", s.handleConfigDefaults)
 		mux.HandleFunc("GET /api/v1/config/docs", s.handleConfigDocs)
 		mux.HandleFunc("POST /api/v1/config/validate", s.handleConfigValidate)
 		mux.HandleFunc("POST /api/v1/config/marshal", s.handleConfigMarshal)
 		mux.HandleFunc("POST /api/v1/config/file", s.gate(s.handleConfigSave))
+		mux.HandleFunc("DELETE /api/v1/config/file", s.gate(s.handleConfigDelete))
+		mux.HandleFunc("POST /api/v1/config/file/rename", s.gate(s.handleConfigRename))
+		mux.HandleFunc("POST /api/v1/config/dir", s.gate(s.handleConfigMkdir))
 		mux.HandleFunc("POST /api/v1/config/parse", s.gate(s.handleConfigParse))
 		mux.HandleFunc("GET /api/v1/config/rr/search", s.handleConfigRRSearch)
+		mux.HandleFunc("GET /api/v1/config/rr/states", s.handleConfigRRStates)
+		mux.HandleFunc("GET /api/v1/config/rr/counties", s.handleConfigRRCounties)
 		mux.HandleFunc("GET /api/v1/config/rr/system/{sid}", s.handleConfigRRSystem)
 
 		// Secondary SPA at /config/ (daemon path). The standalone

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1290,9 +1290,12 @@ func Load(path string) (Config, error) {
 
 // sectionValidator pairs a config section's logical name (matching the
 // keys the web Config Builder uses) with the helper that validates it.
+// Each helper returns every error it finds in its section (one per failing
+// list item plus any section-level checks) so the builder can surface them
+// all at once.
 type sectionValidator struct {
 	name string
-	fn   func(Config) error
+	fn   func(Config) []error
 }
 
 // sectionValidators returns the per-section validators in the same order
@@ -1318,37 +1321,35 @@ func sectionValidators() []sectionValidator {
 // (e.g. "trunking.systems[0]: name required"). It is the authoritative
 // gate run by Load and the config Writer. The checks are organised into
 // per-section helpers so the web Config Builder can validate one section
-// at a time (ValidateSection) or collect one error per section
-// (ValidateAll); Validate preserves the original first-error contract.
+// at a time (ValidateSection) or collect every error (ValidateAll);
+// Validate preserves the original first-error contract.
 func (c Config) Validate() error {
 	for _, v := range sectionValidators() {
-		if err := v.fn(c); err != nil {
-			return err
+		if errs := v.fn(c); len(errs) > 0 {
+			return errs[0]
 		}
 	}
 	return nil
 }
 
-// ValidateAll runs every section validator and returns one error per
-// failing section (the first error within each). An empty slice means the
-// whole config is valid. The web Config Builder uses this to light up
-// every section that needs attention in a single pass.
+// ValidateAll runs every section validator and returns every error found
+// across the whole config. An empty slice means the config is valid. The
+// web Config Builder uses this to light up every problem in one pass.
 func (c Config) ValidateAll() []error {
 	var errs []error
 	for _, v := range sectionValidators() {
-		if err := v.fn(c); err != nil {
-			errs = append(errs, err)
-		}
+		errs = append(errs, v.fn(c)...)
 	}
 	return errs
 }
 
 // ValidateSection validates a single section by name (the keys returned by
-// sectionValidators / used by the web Config Builder). An unknown or
-// rule-free section name yields nil (treated as valid). Cross-section
-// checks (e.g. wideband channels referencing trunking.systems) run against
-// the whole Config, so the caller should pass a fully-populated draft.
-func (c Config) ValidateSection(section string) error {
+// sectionValidators / used by the web Config Builder) and returns all of
+// that section's errors. An unknown or rule-free section name yields nil
+// (treated as valid). Cross-section checks (e.g. wideband channels
+// referencing trunking.systems) run against the whole Config, so the
+// caller should pass a fully-populated draft.
+func (c Config) ValidateSection(section string) []error {
 	for _, v := range sectionValidators() {
 		if v.name == section {
 			return v.fn(c)
@@ -1357,31 +1358,35 @@ func (c Config) ValidateSection(section string) error {
 	return nil
 }
 
-func (c Config) validateSDR() error {
+func (c Config) validateSDR() []error {
+	var errs []error
 	if c.SDR.SampleRate != 0 && (c.SDR.SampleRate < 225_000 || c.SDR.SampleRate > 20_000_000) {
-		return errors.New("sdr.sample_rate must be between 225 kHz and 20 MHz")
+		errs = append(errs, errors.New("sdr.sample_rate must be between 225 kHz and 20 MHz"))
 	}
 	seenSerials := make(map[string]int, len(c.SDR.Devices))
 	for i, d := range c.SDR.Devices {
 		switch d.Role {
 		case "", "control", "voice", "auto", "wideband":
 		default:
-			return fmt.Errorf("sdr.devices[%d]: role must be control|voice|auto|wideband", i)
+			errs = append(errs, fmt.Errorf("sdr.devices[%d]: role must be control|voice|auto|wideband", i))
+			continue
 		}
 		if d.Role == "wideband" {
 			if err := validateWidebandDevice(i, d, c.SDR.SampleRate, c.Trunking.Systems); err != nil {
-				return err
+				errs = append(errs, err)
+				continue
 			}
 		}
 		if d.Serial == "" {
 			continue
 		}
 		if prev, dup := seenSerials[d.Serial]; dup {
-			return fmt.Errorf(
+			errs = append(errs, fmt.Errorf(
 				"sdr.devices[%d]: duplicate serial %q (also at sdr.devices[%d]) — "+
 					"one physical SDR cannot serve multiple roles; P25 trunking needs "+
 					"separate dongles for control and voice",
-				i, d.Serial, prev)
+				i, d.Serial, prev))
+			continue
 		}
 		seenSerials[d.Serial] = i
 	}
@@ -1389,238 +1394,282 @@ func (c Config) validateSDR() error {
 	// the standard set; serial collisions with local devices are
 	// rejected for the same reason serial dedup runs above.
 	for i, r := range c.SDR.RTLTCP {
-		if r.Addr == "" {
-			return fmt.Errorf("sdr.rtl_tcp[%d]: addr is required (host:port)", i)
-		}
-		switch r.Role {
-		case "", "control", "voice", "auto":
-		default:
-			return fmt.Errorf("sdr.rtl_tcp[%d]: role must be control|voice|auto", i)
+		if err := validateRTLTCPFields(i, r); err != nil {
+			errs = append(errs, err)
+			continue
 		}
 		if r.Serial == "" {
 			continue
 		}
 		if prev, dup := seenSerials[r.Serial]; dup {
-			return fmt.Errorf(
+			errs = append(errs, fmt.Errorf(
 				"sdr.rtl_tcp[%d]: serial %q collides with sdr.devices[%d]",
-				i, r.Serial, prev)
+				i, r.Serial, prev))
+			continue
 		}
 		seenSerials[r.Serial] = i
 	}
 	// Validate SoapySDRServer endpoints. Same rules as rtl_tcp, plus the
 	// stream protocol and sample format must be ones the driver supports.
 	for i, s := range c.SDR.SoapyRemote {
-		if s.Addr == "" {
-			return fmt.Errorf("sdr.soapy_remote[%d]: addr is required (host:port)", i)
-		}
-		switch s.Role {
-		case "", "control", "voice", "auto":
-		default:
-			return fmt.Errorf("sdr.soapy_remote[%d]: role must be control|voice|auto", i)
-		}
-		switch s.Format {
-		case "", "CS16", "cs16", "CF32", "cf32":
-		default:
-			return fmt.Errorf("sdr.soapy_remote[%d]: format must be CS16 or CF32", i)
-		}
-		switch s.StreamProtocol {
-		case "", "tcp":
-		default:
-			return fmt.Errorf("sdr.soapy_remote[%d]: stream_protocol must be tcp", i)
-		}
-		if _, err := s.DeviceArgs(); err != nil {
-			return fmt.Errorf("sdr.soapy_remote[%d]: args: %w", i, err)
+		if err := validateSoapyFields(i, s); err != nil {
+			errs = append(errs, err)
+			continue
 		}
 		if s.Serial == "" {
 			continue
 		}
 		if prev, dup := seenSerials[s.Serial]; dup {
-			return fmt.Errorf(
+			errs = append(errs, fmt.Errorf(
 				"sdr.soapy_remote[%d]: serial %q collides with sdr.devices[%d]",
-				i, s.Serial, prev)
+				i, s.Serial, prev))
+			continue
 		}
 		seenSerials[s.Serial] = i
 	}
+	return errs
+}
+
+func validateRTLTCPFields(i int, r RTLTCPConfig) error {
+	if r.Addr == "" {
+		return fmt.Errorf("sdr.rtl_tcp[%d]: addr is required (host:port)", i)
+	}
+	switch r.Role {
+	case "", "control", "voice", "auto":
+	default:
+		return fmt.Errorf("sdr.rtl_tcp[%d]: role must be control|voice|auto", i)
+	}
 	return nil
 }
 
-func (c Config) validateTrunking() error {
+func validateSoapyFields(i int, s SoapyRemoteConfig) error {
+	if s.Addr == "" {
+		return fmt.Errorf("sdr.soapy_remote[%d]: addr is required (host:port)", i)
+	}
+	switch s.Role {
+	case "", "control", "voice", "auto":
+	default:
+		return fmt.Errorf("sdr.soapy_remote[%d]: role must be control|voice|auto", i)
+	}
+	switch s.Format {
+	case "", "CS16", "cs16", "CF32", "cf32":
+	default:
+		return fmt.Errorf("sdr.soapy_remote[%d]: format must be CS16 or CF32", i)
+	}
+	switch s.StreamProtocol {
+	case "", "tcp":
+	default:
+		return fmt.Errorf("sdr.soapy_remote[%d]: stream_protocol must be tcp", i)
+	}
+	if _, err := s.DeviceArgs(); err != nil {
+		return fmt.Errorf("sdr.soapy_remote[%d]: args: %w", i, err)
+	}
+	return nil
+}
+
+func (c Config) validateTrunking() []error {
+	var errs []error
 	if c.Trunking.CallTimeoutMs < 0 {
-		return fmt.Errorf("trunking.call_timeout_ms: %d ms must be ≥ 0", c.Trunking.CallTimeoutMs)
+		errs = append(errs, fmt.Errorf("trunking.call_timeout_ms: %d ms must be ≥ 0", c.Trunking.CallTimeoutMs))
 	}
 	for i, s := range c.Trunking.Systems {
-		if s.Name == "" {
-			return fmt.Errorf("trunking.systems[%d]: name required", i)
+		if err := validateSystem(i, s); err != nil {
+			errs = append(errs, err)
 		}
-		if _, err := trunking.ParseProtocol(s.Protocol); err != nil {
-			return fmt.Errorf("trunking.systems[%d]: %w", i, err)
+	}
+	return errs
+}
+
+// validateSystem returns the first error in one trunking system (the
+// builder reports one error per system; fix-and-revalidate surfaces the
+// next).
+func validateSystem(i int, s SystemConfig) error {
+	if s.Name == "" {
+		return fmt.Errorf("trunking.systems[%d]: name required", i)
+	}
+	if _, err := trunking.ParseProtocol(s.Protocol); err != nil {
+		return fmt.Errorf("trunking.systems[%d]: %w", i, err)
+	}
+	seenBandPlanIDs := make(map[uint8]int, len(s.P25BandPlan))
+	for k, e := range s.P25BandPlan {
+		if e.ChannelID > 15 {
+			return fmt.Errorf("trunking.systems[%d].p25_band_plan[%d]: channel_id %d outside 0..15", i, k, e.ChannelID)
 		}
-		seenBandPlanIDs := make(map[uint8]int, len(s.P25BandPlan))
-		for k, e := range s.P25BandPlan {
-			if e.ChannelID > 15 {
-				return fmt.Errorf("trunking.systems[%d].p25_band_plan[%d]: channel_id %d outside 0..15", i, k, e.ChannelID)
+		if prev, dup := seenBandPlanIDs[e.ChannelID]; dup {
+			return fmt.Errorf("trunking.systems[%d].p25_band_plan[%d]: duplicate channel_id %d (also at p25_band_plan[%d])", i, k, e.ChannelID, prev)
+		}
+		seenBandPlanIDs[e.ChannelID] = k
+		if e.SpacingHz == 0 {
+			return fmt.Errorf("trunking.systems[%d].p25_band_plan[%d]: spacing_hz required (nonzero)", i, k)
+		}
+		if e.BaseHz == 0 {
+			return fmt.Errorf("trunking.systems[%d].p25_band_plan[%d]: base_hz required (nonzero)", i, k)
+		}
+	}
+	if bp := s.DMRBandPlan; bp != nil {
+		hasLinear := bp.Linear != nil
+		hasTable := len(bp.Table) > 0
+		switch {
+		case hasLinear && hasTable:
+			return fmt.Errorf("trunking.systems[%d].dmr_band_plan: set either linear or table, not both", i)
+		case !hasLinear && !hasTable:
+			return fmt.Errorf("trunking.systems[%d].dmr_band_plan: one of linear or table is required", i)
+		}
+		if hasLinear {
+			if bp.Linear.SpacingHz == 0 {
+				return fmt.Errorf("trunking.systems[%d].dmr_band_plan.linear: spacing_hz required (nonzero)", i)
 			}
-			if prev, dup := seenBandPlanIDs[e.ChannelID]; dup {
-				return fmt.Errorf("trunking.systems[%d].p25_band_plan[%d]: duplicate channel_id %d (also at p25_band_plan[%d])", i, k, e.ChannelID, prev)
-			}
-			seenBandPlanIDs[e.ChannelID] = k
-			if e.SpacingHz == 0 {
-				return fmt.Errorf("trunking.systems[%d].p25_band_plan[%d]: spacing_hz required (nonzero)", i, k)
-			}
-			if e.BaseHz == 0 {
-				return fmt.Errorf("trunking.systems[%d].p25_band_plan[%d]: base_hz required (nonzero)", i, k)
+			if bp.Linear.BaseHz == 0 {
+				return fmt.Errorf("trunking.systems[%d].dmr_band_plan.linear: base_hz required (nonzero)", i)
 			}
 		}
-		if bp := s.DMRBandPlan; bp != nil {
-			hasLinear := bp.Linear != nil
-			hasTable := len(bp.Table) > 0
-			switch {
-			case hasLinear && hasTable:
-				return fmt.Errorf("trunking.systems[%d].dmr_band_plan: set either linear or table, not both", i)
-			case !hasLinear && !hasTable:
-				return fmt.Errorf("trunking.systems[%d].dmr_band_plan: one of linear or table is required", i)
-			}
-			if hasLinear {
-				if bp.Linear.SpacingHz == 0 {
-					return fmt.Errorf("trunking.systems[%d].dmr_band_plan.linear: spacing_hz required (nonzero)", i)
+		if hasTable {
+			seenLCN := make(map[uint8]int, len(bp.Table))
+			for k, e := range bp.Table {
+				if e.FreqHz == 0 {
+					return fmt.Errorf("trunking.systems[%d].dmr_band_plan.table[%d]: freq_hz required (nonzero)", i, k)
 				}
-				if bp.Linear.BaseHz == 0 {
-					return fmt.Errorf("trunking.systems[%d].dmr_band_plan.linear: base_hz required (nonzero)", i)
+				if prev, dup := seenLCN[e.LCN]; dup {
+					return fmt.Errorf("trunking.systems[%d].dmr_band_plan.table[%d]: duplicate lcn %d (also at table[%d])", i, k, e.LCN, prev)
 				}
-			}
-			if hasTable {
-				seenLCN := make(map[uint8]int, len(bp.Table))
-				for k, e := range bp.Table {
-					if e.FreqHz == 0 {
-						return fmt.Errorf("trunking.systems[%d].dmr_band_plan.table[%d]: freq_hz required (nonzero)", i, k)
-					}
-					if prev, dup := seenLCN[e.LCN]; dup {
-						return fmt.Errorf("trunking.systems[%d].dmr_band_plan.table[%d]: duplicate lcn %d (also at table[%d])", i, k, e.LCN, prev)
-					}
-					seenLCN[e.LCN] = k
-				}
+				seenLCN[e.LCN] = k
 			}
 		}
-		seenKeyIDs := make(map[uint16]struct{}, len(s.EncryptionKeys))
-		for k, ek := range s.EncryptionKeys {
-			switch strings.ToLower(strings.TrimSpace(ek.Algorithm)) {
-			case "rc4", "arc4":
-				// supported
-			case "":
-				return fmt.Errorf("trunking.systems[%d].encryption_keys[%d]: algorithm is required (use \"rc4\")", i, k)
-			case "aes", "des":
-				return fmt.Errorf("trunking.systems[%d].encryption_keys[%d]: algorithm %q is not supported yet (only \"rc4\")", i, k, ek.Algorithm)
-			default:
-				return fmt.Errorf("trunking.systems[%d].encryption_keys[%d]: unknown algorithm %q (use \"rc4\")", i, k, ek.Algorithm)
-			}
-			if _, dup := seenKeyIDs[ek.KeyID]; dup {
-				return fmt.Errorf("trunking.systems[%d].encryption_keys[%d]: duplicate key_id %d", i, k, ek.KeyID)
-			}
-			seenKeyIDs[ek.KeyID] = struct{}{}
-			b, err := decodeHexKey(ek.Key)
-			if err != nil {
-				return fmt.Errorf("trunking.systems[%d].encryption_keys[%d]: %w", i, k, err)
-			}
-			if len(b) > 32 {
-				return fmt.Errorf("trunking.systems[%d].encryption_keys[%d]: key is %d bytes, must be 1..32", i, k, len(b))
-			}
+	}
+	seenKeyIDs := make(map[uint16]struct{}, len(s.EncryptionKeys))
+	for k, ek := range s.EncryptionKeys {
+		switch strings.ToLower(strings.TrimSpace(ek.Algorithm)) {
+		case "rc4", "arc4":
+			// supported
+		case "":
+			return fmt.Errorf("trunking.systems[%d].encryption_keys[%d]: algorithm is required (use \"rc4\")", i, k)
+		case "aes", "des":
+			return fmt.Errorf("trunking.systems[%d].encryption_keys[%d]: algorithm %q is not supported yet (only \"rc4\")", i, k, ek.Algorithm)
+		default:
+			return fmt.Errorf("trunking.systems[%d].encryption_keys[%d]: unknown algorithm %q (use \"rc4\")", i, k, ek.Algorithm)
+		}
+		if _, dup := seenKeyIDs[ek.KeyID]; dup {
+			return fmt.Errorf("trunking.systems[%d].encryption_keys[%d]: duplicate key_id %d", i, k, ek.KeyID)
+		}
+		seenKeyIDs[ek.KeyID] = struct{}{}
+		b, err := decodeHexKey(ek.Key)
+		if err != nil {
+			return fmt.Errorf("trunking.systems[%d].encryption_keys[%d]: %w", i, k, err)
+		}
+		if len(b) > 32 {
+			return fmt.Errorf("trunking.systems[%d].encryption_keys[%d]: key is %d bytes, must be 1..32", i, k, len(b))
 		}
 	}
 	return nil
 }
 
-func (c Config) validateRecordings() error {
+func (c Config) validateRecordings() []error {
 	if c.Recordings.SampleRate != 0 && (c.Recordings.SampleRate < 4000 || c.Recordings.SampleRate > 48_000) {
-		return fmt.Errorf("recordings.sample_rate %d outside 4000..48000", c.Recordings.SampleRate)
+		return []error{fmt.Errorf("recordings.sample_rate %d outside 4000..48000", c.Recordings.SampleRate)}
 	}
 	return nil
 }
 
-func (c Config) validateRetention() error {
+func (c Config) validateRetention() []error {
 	if c.Retention.Interval != "" {
 		if _, err := parseDurationFlexible(c.Retention.Interval); err != nil {
-			return fmt.Errorf("retention.interval: %w", err)
+			return []error{fmt.Errorf("retention.interval: %w", err)}
 		}
 	}
 	return nil
 }
 
-func (c Config) validateAudio() error {
+func (c Config) validateAudio() []error {
+	var errs []error
 	if c.Audio.SampleRate != 0 && (c.Audio.SampleRate < 4000 || c.Audio.SampleRate > 48_000) {
-		return fmt.Errorf("audio.sample_rate %d outside 4000..48000", c.Audio.SampleRate)
+		errs = append(errs, fmt.Errorf("audio.sample_rate %d outside 4000..48000", c.Audio.SampleRate))
 	}
 	if c.Audio.Volume != 0 && (c.Audio.Volume < 0 || c.Audio.Volume > 1) {
-		return fmt.Errorf("audio.volume %f outside 0..1", c.Audio.Volume)
+		errs = append(errs, fmt.Errorf("audio.volume %f outside 0..1", c.Audio.Volume))
 	}
-	return nil
+	return errs
 }
 
-func (c Config) validateScanner() error {
+func (c Config) validateScanner() []error {
+	var errs []error
 	switch c.Scanner.ScanMode {
 	case "", "all", "list":
 	default:
-		return fmt.Errorf("scanner.scan_mode must be \"all\" or \"list\"")
+		errs = append(errs, fmt.Errorf("scanner.scan_mode must be \"all\" or \"list\""))
 	}
 	for i, ch := range c.Scanner.Conventional {
-		if ch.FrequencyHz == 0 {
-			return fmt.Errorf("scanner.conventional[%d]: frequency_hz required", i)
+		if err := validateConvChannel(i, ch); err != nil {
+			errs = append(errs, err)
 		}
-		switch ch.Mode {
-		case "", "fm", "nfm":
-		default:
-			return fmt.Errorf("scanner.conventional[%d]: mode must be fm|nfm", i)
+	}
+	return errs
+}
+
+func validateConvChannel(i int, ch ConvChannelConfig) error {
+	if ch.FrequencyHz == 0 {
+		return fmt.Errorf("scanner.conventional[%d]: frequency_hz required", i)
+	}
+	switch ch.Mode {
+	case "", "fm", "nfm":
+	default:
+		return fmt.Errorf("scanner.conventional[%d]: mode must be fm|nfm", i)
+	}
+	switch ch.Tone.Mode {
+	case "", "none":
+	case "ctcss":
+		if ch.Tone.CTCSSHz < 50 || ch.Tone.CTCSSHz > 300 {
+			return fmt.Errorf("scanner.conventional[%d].tone.ctcss_hz %v outside 50..300 Hz",
+				i, ch.Tone.CTCSSHz)
 		}
-		switch ch.Tone.Mode {
-		case "", "none":
-		case "ctcss":
-			if ch.Tone.CTCSSHz < 50 || ch.Tone.CTCSSHz > 300 {
-				return fmt.Errorf("scanner.conventional[%d].tone.ctcss_hz %v outside 50..300 Hz",
-					i, ch.Tone.CTCSSHz)
-			}
-		case "dcs":
-			if len(ch.Tone.DCSCode) != 3 {
-				return fmt.Errorf("scanner.conventional[%d].tone.dcs_code must be 3 octal digits", i)
-			}
-			for _, r := range ch.Tone.DCSCode {
-				if r < '0' || r > '7' {
-					return fmt.Errorf("scanner.conventional[%d].tone.dcs_code %q must be octal 0..7",
-						i, ch.Tone.DCSCode)
-				}
-			}
-		default:
-			return fmt.Errorf("scanner.conventional[%d].tone.mode must be ctcss|dcs|none", i)
+	case "dcs":
+		if len(ch.Tone.DCSCode) != 3 {
+			return fmt.Errorf("scanner.conventional[%d].tone.dcs_code must be 3 octal digits", i)
 		}
+		for _, r := range ch.Tone.DCSCode {
+			if r < '0' || r > '7' {
+				return fmt.Errorf("scanner.conventional[%d].tone.dcs_code %q must be octal 0..7",
+					i, ch.Tone.DCSCode)
+			}
+		}
+	default:
+		return fmt.Errorf("scanner.conventional[%d].tone.mode must be ctcss|dcs|none", i)
 	}
 	return nil
 }
 
-func (c Config) validateBroadcast() error {
-	return c.Broadcast.validate()
+func (c Config) validateBroadcast() []error {
+	if err := c.Broadcast.validate(); err != nil {
+		return []error{err}
+	}
+	return nil
 }
 
-func (c Config) validateBaseband() error {
+func (c Config) validateBaseband() []error {
+	var errs []error
 	for i, r := range c.Baseband.Record {
 		if r.Serial == "" {
-			return fmt.Errorf("baseband.record[%d]: serial required", i)
+			errs = append(errs, fmt.Errorf("baseband.record[%d]: serial required", i))
+			continue
 		}
 		if r.Dir == "" {
-			return fmt.Errorf("baseband.record[%d]: dir required", i)
+			errs = append(errs, fmt.Errorf("baseband.record[%d]: dir required", i))
 		}
 	}
 	for i, r := range c.Baseband.Replay {
 		if r.File == "" {
-			return fmt.Errorf("baseband.replay[%d]: file required", i)
+			errs = append(errs, fmt.Errorf("baseband.replay[%d]: file required", i))
+			continue
 		}
 		switch r.Role {
 		case "", "control", "voice", "auto":
 		default:
-			return fmt.Errorf("baseband.replay[%d]: role must be control|voice|auto", i)
+			errs = append(errs, fmt.Errorf("baseband.replay[%d]: role must be control|voice|auto", i))
 		}
 	}
-	return nil
+	return errs
 }
 
-func (c Config) validateWeb() error {
+func (c Config) validateWeb() []error {
 	for key := range c.Web.Tabs {
 		if !KnownUITabs[key] {
 			valid := make([]string, 0, len(KnownUITabs))
@@ -1628,7 +1677,7 @@ func (c Config) validateWeb() error {
 				valid = append(valid, k)
 			}
 			sort.Strings(valid)
-			return fmt.Errorf("web.tabs: unknown tab %q (valid: %s)", key, strings.Join(valid, ", "))
+			return []error{fmt.Errorf("web.tabs: unknown tab %q (valid: %s)", key, strings.Join(valid, ", "))}
 		}
 	}
 	return nil

--- a/internal/config/marshal.go
+++ b/internal/config/marshal.go
@@ -67,10 +67,12 @@ func WriteConfigFile(path string, cfg Config, guardMtime int64, overwrite bool) 
 		return 0, fmt.Errorf("config: refusing to write invalid config: %w", err)
 	}
 
+	exists := false
 	info, statErr := os.Stat(path)
 	switch {
 	case statErr == nil:
 		// File exists.
+		exists = true
 		if !overwrite {
 			return 0, fmt.Errorf("%w: %s", ErrFileExists, path)
 		}
@@ -81,7 +83,22 @@ func WriteConfigFile(path string, cfg Config, guardMtime int64, overwrite bool) 
 		return 0, fmt.Errorf("config: stat %s: %w", path, statErr)
 	}
 
-	data, err := Marshal(cfg)
+	// Overwriting an existing file merges onto its YAML node tree so
+	// hand-written comments + key order survive; a new file is a fresh
+	// marshal.
+	var (
+		data []byte
+		err  error
+	)
+	if exists {
+		original, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return 0, fmt.Errorf("config: read %s: %w", path, readErr)
+		}
+		data, err = MarshalMerge(original, cfg)
+	} else {
+		data, err = Marshal(cfg)
+	}
 	if err != nil {
 		return 0, err
 	}

--- a/internal/config/marshal_test.go
+++ b/internal/config/marshal_test.go
@@ -106,20 +106,47 @@ func TestValidateSection(t *testing.T) {
 	cfg := Default()
 	cfg.SDR.SampleRate = 100 // invalid
 
-	if err := cfg.ValidateSection("sdr"); err == nil {
+	if errs := cfg.ValidateSection("sdr"); len(errs) == 0 {
 		t.Fatalf("expected sdr section error")
 	}
 	// A section with no bearing on the sample-rate error is clean.
-	if err := cfg.ValidateSection("web"); err != nil {
-		t.Fatalf("web section should be valid: %v", err)
+	if errs := cfg.ValidateSection("web"); len(errs) != 0 {
+		t.Fatalf("web section should be valid: %v", errs)
 	}
 	// Unknown section names are treated as valid (nil).
-	if err := cfg.ValidateSection("nonexistent"); err != nil {
-		t.Fatalf("unknown section should be nil: %v", err)
+	if errs := cfg.ValidateSection("nonexistent"); len(errs) != 0 {
+		t.Fatalf("unknown section should be nil: %v", errs)
 	}
 	// ValidateAll surfaces the sdr error.
 	all := cfg.ValidateAll()
 	if len(all) == 0 {
 		t.Fatalf("expected ValidateAll to report the sdr error")
+	}
+}
+
+// TestValidateAllAccumulates confirms ValidateAll reports every problem at
+// once: one error per failing list item, across multiple sections.
+func TestValidateAllAccumulates(t *testing.T) {
+	cfg := Default()
+	cfg.SDR.SampleRate = 100 // sdr error #1
+	cfg.Trunking.Systems = []SystemConfig{
+		{Name: "", Protocol: "p25"},     // trunking systems[0]: name required
+		{Name: "ok", Protocol: "bogus"}, // trunking systems[1]: bad protocol
+	}
+	cfg.Scanner.Conventional = []ConvChannelConfig{
+		{FrequencyHz: 0}, // scanner conventional[0]: freq required
+		{FrequencyHz: 460_000_000, Mode: "weird"}, // scanner conventional[1]: bad mode
+	}
+	all := cfg.ValidateAll()
+	if len(all) < 5 {
+		t.Fatalf("expected ≥5 accumulated errors (1 sdr + 2 trunking + 2 scanner), got %d: %v", len(all), all)
+	}
+	// ValidateSection returns just that section's multiple errors.
+	if got := cfg.ValidateSection("scanner"); len(got) != 2 {
+		t.Fatalf("expected 2 scanner errors, got %d: %v", len(got), got)
+	}
+	// Validate() keeps its first-error contract (the sdr error, first section).
+	if err := cfg.Validate(); err == nil {
+		t.Fatalf("Validate should still return the first error")
 	}
 }

--- a/internal/config/merge.go
+++ b/internal/config/merge.go
@@ -1,0 +1,115 @@
+package config
+
+import (
+	"bytes"
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+// MarshalMerge renders cfg to YAML while preserving the comments and key
+// ordering of an existing file. It parses `original` into a yaml.Node tree
+// (which carries comments), parses a fresh Marshal(cfg) into an overlay
+// tree, then deep-merges the overlay onto the original:
+//
+//   - keys present in both: scalar/sequence values are replaced (the old
+//     value node's trailing comment is carried over); nested mappings are
+//     merged recursively, so section and key comments survive;
+//   - keys new to cfg are appended;
+//   - keys removed from cfg are dropped.
+//
+// Per-list-item comments inside a replaced sequence are not preserved
+// (sequences are swapped wholesale) — config comments are overwhelmingly
+// section/key level, so this keeps the annotated file readable after an
+// edit from the web Config Builder. If `original` isn't a YAML mapping
+// (empty/new file), it falls back to plain Marshal.
+func MarshalMerge(original []byte, cfg Config) ([]byte, error) {
+	overlayBytes, err := Marshal(cfg)
+	if err != nil {
+		return nil, err
+	}
+	if len(bytes.TrimSpace(original)) == 0 {
+		return overlayBytes, nil
+	}
+
+	var baseDoc, overlayDoc yaml.Node
+	if err := yaml.Unmarshal(original, &baseDoc); err != nil {
+		// Original isn't parseable; don't try to preserve it.
+		return overlayBytes, nil
+	}
+	if err := yaml.Unmarshal(overlayBytes, &overlayDoc); err != nil {
+		return nil, fmt.Errorf("config: merge: parse overlay: %w", err)
+	}
+	baseRoot := docRoot(&baseDoc)
+	overlayRoot := docRoot(&overlayDoc)
+	if baseRoot == nil || overlayRoot == nil {
+		return overlayBytes, nil
+	}
+	mergeMappingNodes(baseRoot, overlayRoot)
+
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+	if err := enc.Encode(&baseDoc); err != nil {
+		return nil, fmt.Errorf("config: merge: encode: %w", err)
+	}
+	if err := enc.Close(); err != nil {
+		return nil, fmt.Errorf("config: merge: encode: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
+// mergeMappingNodes merges overlay into base in place, preserving base's
+// key order + comments for retained keys, appending overlay-only keys, and
+// dropping base keys absent from overlay.
+func mergeMappingNodes(base, overlay *yaml.Node) {
+	type pair struct{ key, val *yaml.Node }
+	overlayPairs := make([]pair, 0, len(overlay.Content)/2)
+	overlayByKey := make(map[string]*yaml.Node, len(overlay.Content)/2)
+	for i := 0; i+1 < len(overlay.Content); i += 2 {
+		overlayPairs = append(overlayPairs, pair{overlay.Content[i], overlay.Content[i+1]})
+		overlayByKey[overlay.Content[i].Value] = overlay.Content[i+1]
+	}
+
+	merged := make([]*yaml.Node, 0, len(base.Content))
+	kept := make(map[string]bool, len(overlayByKey))
+	for i := 0; i+1 < len(base.Content); i += 2 {
+		keyNode := base.Content[i]
+		valNode := base.Content[i+1]
+		ov, ok := overlayByKey[keyNode.Value]
+		if !ok {
+			continue // removed from cfg
+		}
+		kept[keyNode.Value] = true
+		if valNode.Kind == yaml.MappingNode && ov.Kind == yaml.MappingNode {
+			mergeMappingNodes(valNode, ov)
+			merged = append(merged, keyNode, valNode)
+			continue
+		}
+		carryComments(valNode, ov)
+		merged = append(merged, keyNode, ov)
+	}
+	// Append keys new to cfg, in overlay order.
+	for _, p := range overlayPairs {
+		if kept[p.key.Value] {
+			continue
+		}
+		merged = append(merged, p.key, p.val)
+	}
+	base.Content = merged
+}
+
+// carryComments copies the old value node's comments onto the replacement
+// when the replacement has none, so a trailing `# note` survives a scalar
+// edit.
+func carryComments(old, new *yaml.Node) {
+	if new.HeadComment == "" {
+		new.HeadComment = old.HeadComment
+	}
+	if new.LineComment == "" {
+		new.LineComment = old.LineComment
+	}
+	if new.FootComment == "" {
+		new.FootComment = old.FootComment
+	}
+}

--- a/internal/config/merge_test.go
+++ b/internal/config/merge_test.go
@@ -1,0 +1,74 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestMarshalMergePreservesComments(t *testing.T) {
+	original := []byte(`# GopherTrunk config
+log:
+  level: info # current level
+  format: text
+sdr:
+  sample_rate: 2400000 # 2.4 MS/s
+trunking:
+  systems:
+    - name: Old
+      protocol: p25
+`)
+	cfg := Default()
+	cfg.Log.Level = "debug"
+	cfg.SDR.SampleRate = 1_024_000
+	cfg.Trunking.Systems = []SystemConfig{{Name: "New", Protocol: "p25"}}
+
+	out, err := MarshalMerge(original, cfg)
+	if err != nil {
+		t.Fatalf("MarshalMerge: %v", err)
+	}
+	s := string(out)
+
+	// Top-of-file and trailing comments survive.
+	if !strings.Contains(s, "# GopherTrunk config") {
+		t.Errorf("lost header comment:\n%s", s)
+	}
+	if !strings.Contains(s, "# current level") {
+		t.Errorf("lost line comment on log.level:\n%s", s)
+	}
+	if !strings.Contains(s, "# 2.4 MS/s") {
+		t.Errorf("lost line comment on sdr.sample_rate:\n%s", s)
+	}
+	// Edits are applied.
+	if !strings.Contains(s, "level: debug") {
+		t.Errorf("log.level edit not applied:\n%s", s)
+	}
+	if !strings.Contains(s, "sample_rate: 1024000") {
+		t.Errorf("sdr.sample_rate edit not applied:\n%s", s)
+	}
+	if !strings.Contains(s, "name: New") || strings.Contains(s, "name: Old") {
+		t.Errorf("system replacement not applied:\n%s", s)
+	}
+
+	// The merged output must still parse + validate.
+	var back Config
+	if err := Unmarshal(out, &back); err != nil {
+		t.Fatalf("merged output unparseable: %v", err)
+	}
+	if err := back.Validate(); err != nil {
+		t.Fatalf("merged output invalid: %v", err)
+	}
+	if back.Log.Level != "debug" || back.SDR.SampleRate != 1_024_000 {
+		t.Fatalf("round-trip mismatch: %+v", back.Log)
+	}
+}
+
+func TestMarshalMergeEmptyOriginalFallsBack(t *testing.T) {
+	out, err := MarshalMerge(nil, Default())
+	if err != nil {
+		t.Fatal(err)
+	}
+	var back Config
+	if err := Unmarshal(out, &back); err != nil {
+		t.Fatalf("fallback output unparseable: %v", err)
+	}
+}

--- a/internal/radioreference/browse.go
+++ b/internal/radioreference/browse.go
@@ -134,6 +134,58 @@ func (c *Client) SearchByState(ctx context.Context, stid int) ([]SearchHit, erro
 	return hits, nil
 }
 
+// GeoRef is a RadioReference geography entry (a state or county) used to
+// back name-based pickers so operators don't have to know numeric ctid/stid.
+type GeoRef struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+}
+
+// GetStateList returns the states RadioReference knows (stid + name) for a
+// name dropdown. Element names are matched tolerantly (the SOAP schema
+// labels vary); an unrecognised response yields an empty list.
+func (c *Client) GetStateList(ctx context.Context) ([]GeoRef, error) {
+	body := fmt.Sprintf(`<ns1:getStateList>%s</ns1:getStateList>`, c.authXML())
+	raw, err := c.call(ctx, body)
+	if err != nil {
+		return nil, err
+	}
+	var out []GeoRef
+	for _, block := range blocks(raw, "stateList") {
+		l := firstLeaves(block, "stateId", "stid", "stateName", "stateCode")
+		id := atoiDefault(firstNonEmpty(l["stateId"], l["stid"]), 0)
+		if id == 0 {
+			continue
+		}
+		out = append(out, GeoRef{ID: id, Name: firstNonEmpty(l["stateName"], l["stateCode"])})
+	}
+	return out, nil
+}
+
+// GetCountyList returns the counties in a state (ctid + name) via
+// getStateInfo (the same call SearchByState walks), so the UI can offer a
+// county dropdown after a state is chosen.
+func (c *Client) GetCountyList(ctx context.Context, stid int) ([]GeoRef, error) {
+	body := fmt.Sprintf(`<ns1:getStateInfo>`+
+		`<stid xsi:type="xsd:int">%d</stid>`+
+		`%s`+
+		`</ns1:getStateInfo>`, stid, c.authXML())
+	raw, err := c.call(ctx, body)
+	if err != nil {
+		return nil, err
+	}
+	var out []GeoRef
+	for _, block := range blocks(raw, "countyList") {
+		l := firstLeaves(block, "ctid", "countyName", "name")
+		id := atoiDefault(l["ctid"], 0)
+		if id == 0 {
+			continue
+		}
+		out = append(out, GeoRef{ID: id, Name: firstNonEmpty(l["countyName"], l["name"])})
+	}
+	return out, nil
+}
+
 // GetFullSystem fetches a system's identity, sites, and talkgroups and
 // returns an import-ready FullSystem with a mapped GopherTrunk protocol.
 func (c *Client) GetFullSystem(ctx context.Context, sid int) (FullSystem, error) {

--- a/web/configbuilder/src/App.tsx
+++ b/web/configbuilder/src/App.tsx
@@ -63,6 +63,21 @@ export function App() {
     for (const e of errList) m[e.section] = (m[e.section] ?? 0) + 1;
     return m;
   }, [errList]);
+
+  // Flag sections whose draft differs from a blank config so a from-scratch
+  // build shows at a glance what's been touched.
+  const defaults = useStore((s) => s.defaults);
+  const configured = useMemo(() => {
+    const set = new Set<string>();
+    if (!config || !defaults) return set;
+    for (const s of SECTIONS) {
+      if (JSON.stringify(config[s.cfgKey]) !== JSON.stringify(defaults[s.cfgKey])) {
+        set.add(s.key);
+      }
+    }
+    return set;
+  }, [config, defaults]);
+
   const current = SECTIONS.find((s) => s.key === active) ?? SECTIONS[0];
 
   const jumpToFirstError = () => {
@@ -125,24 +140,35 @@ export function App() {
                   active === s.key ? "bg-accent/20 text-fg" : "text-muted hover:bg-white/5"
                 }`}
               >
-                <span>{s.label}</span>
+                <span className="flex items-center gap-1.5">
+                  {configured.has(s.key) ? (
+                    <span className="text-accent" title="Configured (differs from defaults)">
+                      ●
+                    </span>
+                  ) : (
+                    <span className="text-white/20" title="Empty (defaults)">
+                      ○
+                    </span>
+                  )}
+                  {s.label}
+                </span>
                 {n > 0 ? <span className="text-xs text-err">{n}</span> : null}
               </button>
             );
           })}
         </nav>
 
-        {/* Editor */}
-        <main className="min-w-0 flex-1 overflow-y-auto p-4">
-          {config ? current.render() : <p className="help">Loading defaults…</p>}
-        </main>
-
-        {/* Preview */}
-        {showPreview ? (
-          <aside className="hidden w-96 shrink-0 overflow-hidden border-l border-white/10 p-4 lg:block">
-            <YamlPreview />
-          </aside>
-        ) : null}
+        {/* Editor + preview — side by side on lg, stacked on small screens */}
+        <div className="flex min-w-0 flex-1 flex-col lg:flex-row">
+          <main className="min-w-0 flex-1 overflow-y-auto p-4">
+            {config ? current.render() : <p className="help">Loading defaults…</p>}
+          </main>
+          {showPreview ? (
+            <aside className="max-h-72 w-full shrink-0 overflow-hidden border-t border-white/10 p-4 lg:max-h-none lg:w-96 lg:border-l lg:border-t-0">
+              <YamlPreview />
+            </aside>
+          ) : null}
+        </div>
       </div>
 
       {/* Toasts */}

--- a/web/configbuilder/src/App.tsx
+++ b/web/configbuilder/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { FileBar } from "./components/FileBar";
 import { YamlPreview } from "./components/YamlPreview";
 import { SECTIONS } from "./sections";
@@ -9,9 +9,11 @@ export function App() {
   const config = useStore((s) => s.config);
   const validation = useStore((s) => s.validation);
   const validateAll = useStore((s) => s.validateAll);
-  const lastError = useStore((s) => s.lastError);
+  const errors = useStore((s) => s.errors);
+  const busy = useStore((s) => s.busy);
   const lastSaved = useStore((s) => s.lastSaved);
   const setError = useStore((s) => s.setError);
+  const dismissError = useStore((s) => s.dismissError);
   const token = useStore((s) => s.token);
   const setTok = useStore((s) => s.setToken);
 
@@ -22,16 +24,50 @@ export function App() {
     init();
   }, [init]);
 
-  // Re-validate (whole config, one error per section) shortly after edits so
-  // the nav badges + section banners stay live.
+  // Re-validate shortly after edits so nav badges + section banners stay live.
   useEffect(() => {
     if (!config) return;
     const t = setTimeout(() => validateAll(), 400);
     return () => clearTimeout(t);
   }, [config, validateAll]);
 
-  const errorSections = new Set((validation?.errors ?? []).map((e) => e.section));
+  // Warn before leaving with unsaved changes.
+  useEffect(() => {
+    const h = (e: BeforeUnloadEvent) => {
+      if (useStore.getState().dirty) {
+        e.preventDefault();
+        e.returnValue = "";
+      }
+    };
+    window.addEventListener("beforeunload", h);
+    return () => window.removeEventListener("beforeunload", h);
+  }, []);
+
+  // Ctrl/Cmd+S → save (or ask the FileBar to open Save As when untitled).
+  useEffect(() => {
+    const h = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "s") {
+        e.preventDefault();
+        const st = useStore.getState();
+        if (st.path) void st.save(st.path, true);
+        else window.dispatchEvent(new CustomEvent("configbuilder:saveas"));
+      }
+    };
+    window.addEventListener("keydown", h);
+    return () => window.removeEventListener("keydown", h);
+  }, []);
+
+  const errList = validation?.errors ?? [];
+  const errorCounts = useMemo(() => {
+    const m: Record<string, number> = {};
+    for (const e of errList) m[e.section] = (m[e.section] ?? 0) + 1;
+    return m;
+  }, [errList]);
   const current = SECTIONS.find((s) => s.key === active) ?? SECTIONS[0];
+
+  const jumpToFirstError = () => {
+    if (errList.length > 0) setActive(errList[0].section);
+  };
 
   return (
     <div className="flex h-full flex-col">
@@ -39,8 +75,26 @@ export function App() {
         <div className="flex items-center gap-2">
           <img src="./favicon.svg" alt="" className="h-6 w-6" />
           <h1 className="text-base font-semibold">GopherTrunk Config Builder</h1>
+          {busy ? <span className="text-xs text-accent animate-pulse">working…</span> : null}
         </div>
         <div className="flex items-center gap-2">
+          {validation ? (
+            errList.length > 0 ? (
+              <button
+                className="rounded-md border border-err/40 bg-err/10 px-2 py-1 text-xs text-err"
+                onClick={jumpToFirstError}
+                title="Jump to the first error"
+              >
+                {errList.length} error{errList.length === 1 ? "" : "s"} in{" "}
+                {Object.keys(errorCounts).length} section
+                {Object.keys(errorCounts).length === 1 ? "" : "s"} ↗
+              </button>
+            ) : (
+              <span className="rounded-md border border-ok/30 bg-ok/10 px-2 py-1 text-xs text-ok">
+                ✓ valid
+              </span>
+            )
+          ) : null}
           <input
             className="input w-48"
             type="password"
@@ -61,18 +115,21 @@ export function App() {
       <div className="flex min-h-0 flex-1">
         {/* Section nav */}
         <nav className="w-44 shrink-0 overflow-y-auto border-r border-white/10 p-2">
-          {SECTIONS.map((s) => (
-            <button
-              key={s.key}
-              onClick={() => setActive(s.key)}
-              className={`mb-0.5 flex w-full items-center justify-between rounded px-2 py-1.5 text-left text-sm ${
-                active === s.key ? "bg-accent/20 text-fg" : "text-muted hover:bg-white/5"
-              }`}
-            >
-              <span>{s.label}</span>
-              {errorSections.has(s.key) ? <span className="text-err">●</span> : null}
-            </button>
-          ))}
+          {SECTIONS.map((s) => {
+            const n = errorCounts[s.key] ?? 0;
+            return (
+              <button
+                key={s.key}
+                onClick={() => setActive(s.key)}
+                className={`mb-0.5 flex w-full items-center justify-between rounded px-2 py-1.5 text-left text-sm ${
+                  active === s.key ? "bg-accent/20 text-fg" : "text-muted hover:bg-white/5"
+                }`}
+              >
+                <span>{s.label}</span>
+                {n > 0 ? <span className="text-xs text-err">{n}</span> : null}
+              </button>
+            );
+          })}
         </nav>
 
         {/* Editor */}
@@ -94,12 +151,24 @@ export function App() {
           {lastSaved}
         </div>
       ) : null}
-      {lastError ? (
-        <div className="fixed bottom-3 left-3 right-3 z-40 mx-auto max-w-md rounded-md border border-err/40 bg-err/15 px-3 py-2 text-sm text-err flex items-start gap-2">
-          <span className="flex-1">{lastError}</span>
-          <button className="underline" onClick={() => setError(null)}>
-            dismiss
-          </button>
+      {errors.length > 0 ? (
+        <div className="fixed bottom-3 left-3 right-3 z-40 mx-auto flex max-w-md flex-col gap-2">
+          {errors.map((msg, i) => (
+            <div
+              key={i}
+              className="flex items-start gap-2 rounded-md border border-err/40 bg-err/15 px-3 py-2 text-sm text-err"
+            >
+              <span className="flex-1">{msg}</span>
+              <button className="underline" onClick={() => dismissError(i)}>
+                dismiss
+              </button>
+            </div>
+          ))}
+          {errors.length > 1 ? (
+            <button className="self-end text-xs underline text-err" onClick={() => setError(null)}>
+              dismiss all
+            </button>
+          ) : null}
         </div>
       ) : null}
     </div>

--- a/web/configbuilder/src/api/client.ts
+++ b/web/configbuilder/src/api/client.ts
@@ -5,6 +5,7 @@ import type {
   DocLink,
   GTConfig,
   ParsedSystemDTO,
+  RRGeoRef,
   RRSearchHit,
   RRSystemResponse,
   TalkgroupCSVRow,
@@ -59,6 +60,16 @@ export const api = {
   listFiles: () => req<ConfigListResponse>("GET", "/config/files"),
   loadFile: (path: string) =>
     req<ConfigLoadResponse>("GET", `/config/file?path=${encodeURIComponent(path)}`),
+  talkgroups: (path: string) =>
+    req<{ talkgroups: Record<string, TalkgroupCSVRow[]> }>(
+      "GET",
+      `/config/file/talkgroups?path=${encodeURIComponent(path)}`,
+    ),
+  deleteFile: (path: string) =>
+    req<{ deleted: string }>("DELETE", `/config/file?path=${encodeURIComponent(path)}`),
+  renameFile: (from: string, to: string) =>
+    req<{ from: string; to: string }>("POST", "/config/file/rename", { from, to }),
+  mkdir: (path: string) => req<{ path: string }>("POST", "/config/dir", { path }),
   defaults: () => req<GTConfig>("GET", "/config/defaults"),
   docs: () => req<Record<string, DocLink>>("GET", "/config/docs"),
   validate: (config: GTConfig, section?: string) =>
@@ -82,6 +93,9 @@ export const api = {
       "GET",
       `/config/rr/search?${kind}=${encodeURIComponent(value)}`,
     ),
+  rrStates: () => req<{ results: RRGeoRef[] | null }>("GET", "/config/rr/states"),
+  rrCounties: (stid: number) =>
+    req<{ results: RRGeoRef[] | null }>("GET", `/config/rr/counties?state=${stid}`),
   rrSystem: (sid: number) =>
     req<RRSystemResponse>("GET", `/config/rr/system/${sid}`),
 };

--- a/web/configbuilder/src/api/types.ts
+++ b/web/configbuilder/src/api/types.ts
@@ -456,6 +456,11 @@ export interface DocLink {
   description: string;
 }
 
+export interface RRGeoRef {
+  id: number;
+  name: string;
+}
+
 export interface RRSearchHit {
   sid: number;
   name: string;

--- a/web/configbuilder/src/api/types.ts
+++ b/web/configbuilder/src/api/types.ts
@@ -4,10 +4,16 @@
 // Sections without a bespoke editor are typed as unknown and round-trip
 // untouched (seeded from GET /api/v1/config/defaults).
 
+export interface MessageLogConfig {
+  Enabled: boolean;
+  Path: string;
+  MaxSizeMB: number;
+}
+
 export interface LogConfig {
   Level: string;
   Format: string;
-  MessageLog?: unknown;
+  MessageLog: MessageLogConfig;
 }
 
 export interface DiagnosticsConfig {
@@ -20,13 +26,24 @@ export interface RadioReferenceConfig {
   Password: string;
 }
 
+export interface APIAuthConfig {
+  Mode: string;
+  Token: string;
+  TokenFile: string;
+  TrustedNetworks: string[] | null;
+}
+
+export interface APICORSConfig {
+  AllowedOrigins: string[] | null;
+}
+
 export interface APIConfig {
   HTTPAddr: string;
   GRPCAddr: string;
   AllowMutations: boolean;
   Rigctld: string;
-  Auth?: unknown;
-  CORS?: unknown;
+  Auth: APIAuthConfig;
+  CORS: APICORSConfig;
   TLSCert: string;
   TLSKey: string;
 }
@@ -88,11 +105,17 @@ export interface StorageConfig {
   CCCacheFile: string;
 }
 
+export interface EqualizerConfig {
+  Enabled: boolean;
+  Taps: number;
+  StepSize: number;
+}
+
 export interface RecordingsConfig {
   Dir: string;
   SampleRate: number;
   WriteRaw: boolean;
-  Equalizer?: unknown;
+  Equalizer: EqualizerConfig;
 }
 
 export interface MetricsConfig {
@@ -106,11 +129,35 @@ export interface RetentionConfig {
   Interval: string;
 }
 
+export interface CCHuntConfig {
+  Enabled: boolean;
+  DwellMs: number;
+  BackoffMs: number;
+  MaxBackoffMs: number;
+}
+
+export interface ConvToneConfig {
+  Mode: string; // "" | none | ctcss | dcs
+  CTCSSHz: number;
+  DCSCode: string;
+}
+
+export interface ConvChannelConfig {
+  Label: string;
+  FrequencyHz: number;
+  Mode: string; // "" | fm | nfm
+  SquelchDbFS: number;
+  HangtimeMs: number;
+  Priority: number;
+  Tone: ConvToneConfig;
+}
+
 export interface ScannerConfig {
   ScanMode: string;
-  CCHunt?: unknown;
-  Conventional?: unknown;
-  [k: string]: unknown;
+  CCHunt: CCHuntConfig;
+  Conventional: ConvChannelConfig[] | null;
+  ManualTuneEnabled: boolean;
+  ManualTuneDisabled: boolean;
 }
 
 export interface AudioConfig {

--- a/web/configbuilder/src/components/FileBar.tsx
+++ b/web/configbuilder/src/components/FileBar.tsx
@@ -63,21 +63,56 @@ export function FileBar() {
               <div className="help p-2">No config files found in the discovery directories.</div>
             ) : (
               files.map((f) => (
-                <button
+                <div
                   key={f.path}
-                  className="block w-full rounded px-2 py-1.5 text-left text-sm hover:bg-white/5"
-                  onClick={() => {
-                    setOpenMenu(false);
-                    load(f.path);
-                  }}
-                  title={f.path}
+                  className="group flex items-center gap-1 rounded px-2 py-1.5 text-sm hover:bg-white/5"
                 >
-                  <span className={f.valid ? "" : "text-warn"}>
-                    {f.valid ? "" : "⚠ "}
-                    {f.name}
-                  </span>
-                  <span className="help block truncate">{f.dir}</span>
-                </button>
+                  <button
+                    className="min-w-0 flex-1 text-left"
+                    onClick={() => {
+                      setOpenMenu(false);
+                      load(f.path);
+                    }}
+                    title={f.path}
+                  >
+                    <span className={f.valid ? "" : "text-warn"}>
+                      {f.valid ? "" : "⚠ "}
+                      {f.name}
+                    </span>
+                    <span className="help block truncate">{f.dir}</span>
+                  </button>
+                  <button
+                    className="hidden text-xs text-muted hover:text-fg group-hover:block"
+                    title="Rename"
+                    onClick={async () => {
+                      const to = window.prompt("Rename to (filename):", f.name);
+                      if (!to || to === f.name) return;
+                      try {
+                        await api.renameFile(f.path, joinPath(f.dir, to.trim()));
+                        refresh();
+                      } catch (e) {
+                        setError(`Rename failed: ${(e as Error).message}`);
+                      }
+                    }}
+                  >
+                    ✎
+                  </button>
+                  <button
+                    className="hidden text-xs text-err/80 hover:text-err group-hover:block"
+                    title="Delete"
+                    onClick={async () => {
+                      if (!window.confirm(`Delete ${f.path}?`)) return;
+                      try {
+                        await api.deleteFile(f.path);
+                        refresh();
+                      } catch (e) {
+                        setError(`Delete failed: ${(e as Error).message}`);
+                      }
+                    }}
+                  >
+                    ✕
+                  </button>
+                </div>
               ))
             )}
           </div>

--- a/web/configbuilder/src/components/FileBar.tsx
+++ b/web/configbuilder/src/components/FileBar.tsx
@@ -168,14 +168,32 @@ function SaveDialog(props: {
   onClose: () => void;
   onSave: (path: string, overwrite: boolean) => void;
 }) {
+  const setError = useStore((s) => s.setError);
   const lastError = useStore((s) => s.errors[s.errors.length - 1] ?? null);
-  const [dir, setDir] = useState(props.dirs[0] ?? "");
+  const [extraDirs, setExtraDirs] = useState<string[]>([]);
+  const allDirs = [...props.dirs, ...extraDirs];
+  const [dir, setDir] = useState(allDirs[0] ?? "");
   const [name, setName] = useState(
     props.defaultPath ? props.defaultPath.split(/[/\\]/).pop()! : "config.yaml",
   );
+  const [newFolder, setNewFolder] = useState("");
   const [overwrite, setOverwrite] = useState(false);
   const target = joinPath(dir, name.trim());
   const collides = !!name.trim() && pathCollides(props.files, target);
+
+  const createFolder = async () => {
+    const folder = newFolder.trim();
+    if (!folder || !dir) return;
+    const full = joinPath(dir, folder);
+    try {
+      const r = await api.mkdir(full);
+      setExtraDirs((d) => (d.includes(r.path) ? d : [...d, r.path]));
+      setDir(r.path);
+      setNewFolder("");
+    } catch (e) {
+      setError(`Create folder failed: ${(e as Error).message}`);
+    }
+  };
 
   return (
     <div className="fixed inset-0 z-50 flex items-start justify-center bg-black/60 p-4">
@@ -189,16 +207,32 @@ function SaveDialog(props: {
         <label className="block">
           <span className="label">Directory</span>
           <select className="input" value={dir} onChange={(e) => setDir(e.target.value)}>
-            {props.dirs.map((d) => (
+            {allDirs.map((d) => (
               <option key={d} value={d}>
                 {d}
               </option>
             ))}
           </select>
           <p className="help mt-1">
-            Saves are restricted to the server's config discovery directories.
+            Saves are restricted to the server's config directories (and
+            subfolders you create below).
           </p>
         </label>
+        <div className="flex items-end gap-2">
+          <label className="block flex-1">
+            <span className="label">New subfolder</span>
+            <input
+              className="input"
+              value={newFolder}
+              placeholder="e.g. clients/acme"
+              onChange={(e) => setNewFolder(e.target.value)}
+              onKeyDown={(e) => e.key === "Enter" && (e.preventDefault(), createFolder())}
+            />
+          </label>
+          <button className="btn-ghost" disabled={!newFolder.trim()} onClick={createFolder}>
+            Create
+          </button>
+        </div>
         <label className="block">
           <span className="label">Filename</span>
           <input

--- a/web/configbuilder/src/components/FileBar.tsx
+++ b/web/configbuilder/src/components/FileBar.tsx
@@ -10,8 +10,10 @@ export function FileBar() {
   const load = useStore((s) => s.load);
   const newConfig = useStore((s) => s.newConfig);
   const save = useStore((s) => s.save);
+  const revert = useStore((s) => s.revert);
   const validateAll = useStore((s) => s.validateAll);
   const setError = useStore((s) => s.setError);
+  const busy = useStore((s) => s.busy);
 
   const [files, setFiles] = useState<ConfigFileInfo[]>([]);
   const [dirs, setDirs] = useState<string[]>([]);
@@ -31,15 +33,23 @@ export function FileBar() {
     refresh();
   }, []);
 
+  // Ctrl+S on an untitled config asks us to open Save As (App dispatches it).
+  useEffect(() => {
+    const h = () => setSaveOpen(true);
+    window.addEventListener("configbuilder:saveas", h);
+    return () => window.removeEventListener("configbuilder:saveas", h);
+  }, []);
+
   return (
     <div className="flex flex-wrap items-center gap-2">
-      <button className="btn-ghost" onClick={() => newConfig()}>
+      <button className="btn-ghost" disabled={busy} onClick={() => newConfig()}>
         New
       </button>
 
       <div className="relative">
         <button
           className="btn-ghost"
+          disabled={busy}
           onClick={() => {
             setOpenMenu((o) => !o);
             if (!openMenu) refresh();
@@ -76,6 +86,7 @@ export function FileBar() {
 
       <button
         className="btn"
+        disabled={busy}
         onClick={async () => {
           if (!path) {
             setSaveOpen(true);
@@ -86,9 +97,21 @@ export function FileBar() {
       >
         Save
       </button>
-      <button className="btn-ghost" onClick={() => setSaveOpen(true)}>
+      <button className="btn-ghost" disabled={busy} onClick={() => setSaveOpen(true)}>
         Save As…
       </button>
+      {dirty ? (
+        <button
+          className="btn-ghost"
+          disabled={busy}
+          title="Discard unsaved changes and reload from disk"
+          onClick={() => {
+            if (window.confirm("Discard unsaved changes?")) void revert();
+          }}
+        >
+          Revert
+        </button>
+      ) : null}
       <button className="btn-ghost" onClick={() => validateAll()}>
         Validate all
       </button>
@@ -145,7 +168,7 @@ function SaveDialog(props: {
   onClose: () => void;
   onSave: (path: string, overwrite: boolean) => void;
 }) {
-  const lastError = useStore((s) => s.lastError);
+  const lastError = useStore((s) => s.errors[s.errors.length - 1] ?? null);
   const [dir, setDir] = useState(props.dirs[0] ?? "");
   const [name, setName] = useState(
     props.defaultPath ? props.defaultPath.split(/[/\\]/).pop()! : "config.yaml",

--- a/web/configbuilder/src/components/ListEditor.test.tsx
+++ b/web/configbuilder/src/components/ListEditor.test.tsx
@@ -46,11 +46,13 @@ describe("ListEditor", () => {
     expect(onChange).toHaveBeenCalledWith([{ name: "a" }, { name: "new" }]);
   });
 
-  it("removes the right index", () => {
+  it("removes the right index after confirmation", () => {
     const onChange = renderEditor([{ name: "a" }, { name: "b" }, { name: "c" }]);
-    // Three Remove buttons; click the middle one.
-    const removes = screen.getAllByText("Remove");
-    fireEvent.click(removes[1]);
+    // First click arms the confirm; nothing removed yet.
+    fireEvent.click(screen.getAllByText("Remove")[1]);
+    expect(onChange).not.toHaveBeenCalled();
+    // Confirm actually removes the middle item.
+    fireEvent.click(screen.getByText("Confirm remove"));
     expect(onChange).toHaveBeenCalledWith([{ name: "a" }, { name: "c" }]);
   });
 

--- a/web/configbuilder/src/components/ListEditor.tsx
+++ b/web/configbuilder/src/components/ListEditor.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import { useState, type ReactNode } from "react";
 
 // ListEditor is a generic add/remove editor for arrays of sub-objects
 // (trunking systems, SDR devices, channel/feed lists, band-plan entries,
@@ -17,13 +17,18 @@ export function ListEditor<T>(props: {
   emptyHint?: ReactNode;
 }) {
   const items = props.items ?? [];
+  // Index awaiting a remove confirmation (two-click guard).
+  const [confirm, setConfirm] = useState<number | null>(null);
 
   const setItem = (i: number, next: T) => {
     const copy = items.slice();
     copy[i] = next;
     props.onChange(copy);
   };
-  const remove = (i: number) => props.onChange(items.filter((_, k) => k !== i));
+  const remove = (i: number) => {
+    setConfirm(null);
+    props.onChange(items.filter((_, k) => k !== i));
+  };
   const add = () => props.onChange([...items, props.makeNew()]);
 
   return (
@@ -45,9 +50,20 @@ export function ListEditor<T>(props: {
             <span className="text-sm font-medium">
               {props.itemTitle ? props.itemTitle(item, i) : `Item ${i + 1}`}
             </span>
-            <button className="btn-danger" onClick={() => remove(i)}>
-              Remove
-            </button>
+            {confirm === i ? (
+              <span className="flex items-center gap-1">
+                <button className="btn-danger" onClick={() => remove(i)}>
+                  Confirm remove
+                </button>
+                <button className="btn-ghost" onClick={() => setConfirm(null)}>
+                  Cancel
+                </button>
+              </span>
+            ) : (
+              <button className="btn-danger" onClick={() => setConfirm(i)}>
+                Remove
+              </button>
+            )}
           </div>
           {props.renderItem(item, (next) => setItem(i, next), i)}
         </div>

--- a/web/configbuilder/src/components/ListEditor.tsx
+++ b/web/configbuilder/src/components/ListEditor.tsx
@@ -30,6 +30,18 @@ export function ListEditor<T>(props: {
     props.onChange(items.filter((_, k) => k !== i));
   };
   const add = () => props.onChange([...items, props.makeNew()]);
+  const duplicate = (i: number) => {
+    const copy = items.slice();
+    copy.splice(i + 1, 0, structuredClone(items[i]));
+    props.onChange(copy);
+  };
+  const move = (i: number, delta: number) => {
+    const j = i + delta;
+    if (j < 0 || j >= items.length) return;
+    const copy = items.slice();
+    [copy[i], copy[j]] = [copy[j], copy[i]];
+    props.onChange(copy);
+  };
 
   return (
     <div className="space-y-3">
@@ -60,9 +72,30 @@ export function ListEditor<T>(props: {
                 </button>
               </span>
             ) : (
-              <button className="btn-danger" onClick={() => setConfirm(i)}>
-                Remove
-              </button>
+              <span className="flex items-center gap-1">
+                <button
+                  className="btn-ghost"
+                  title="Move up"
+                  disabled={i === 0}
+                  onClick={() => move(i, -1)}
+                >
+                  ↑
+                </button>
+                <button
+                  className="btn-ghost"
+                  title="Move down"
+                  disabled={i === items.length - 1}
+                  onClick={() => move(i, 1)}
+                >
+                  ↓
+                </button>
+                <button className="btn-ghost" title="Duplicate" onClick={() => duplicate(i)}>
+                  Duplicate
+                </button>
+                <button className="btn-danger" onClick={() => setConfirm(i)}>
+                  Remove
+                </button>
+              </span>
             )}
           </div>
           {props.renderItem(item, (next) => setItem(i, next), i)}

--- a/web/configbuilder/src/components/Section.tsx
+++ b/web/configbuilder/src/components/Section.tsx
@@ -12,7 +12,7 @@ export function Section(props: {
 }) {
   const docs = useStore((s) => s.docs[props.sectionKey]);
   const validation = useStore((s) => s.validation);
-  const err = validation?.errors?.find((e) => e.section === props.sectionKey);
+  const errs = (validation?.errors ?? []).filter((e) => e.section === props.sectionKey);
 
   return (
     <div className="space-y-4">
@@ -34,9 +34,11 @@ export function Section(props: {
         ) : null}
       </div>
 
-      {err ? (
-        <div className="rounded-md border border-err/40 bg-err/10 px-3 py-2 text-sm text-err">
-          ✗ {err.message}
+      {errs.length > 0 ? (
+        <div className="space-y-1 rounded-md border border-err/40 bg-err/10 px-3 py-2 text-sm text-err">
+          {errs.map((e, i) => (
+            <div key={i}>✗ {e.message}</div>
+          ))}
         </div>
       ) : validation ? (
         <div className="rounded-md border border-ok/30 bg-ok/10 px-3 py-2 text-sm text-ok">

--- a/web/configbuilder/src/sections/Trunking.tsx
+++ b/web/configbuilder/src/sections/Trunking.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Section } from "../components/Section";
 import {
   Fieldset,
@@ -18,6 +18,7 @@ import type {
   EncryptionKey,
   P25BandPlanEntry,
   ParsedSystemDTO,
+  RRGeoRef,
   RRSearchHit,
   SystemConfig,
   TalkgroupCSVRow,
@@ -402,16 +403,55 @@ function RRBrowseModal(props: {
   onAdd: (sys: SystemConfig, tgs?: TalkgroupCSVRow[]) => void;
 }) {
   const setError = useStore((s) => s.setError);
-  const [kind, setKind] = useState<"zip" | "county" | "state">("zip");
+  const [mode, setMode] = useState<"name" | "zip" | "advanced">("name");
+
+  // name mode: state → county dropdowns.
+  const [states, setStates] = useState<RRGeoRef[] | null>(null);
+  const [counties, setCounties] = useState<RRGeoRef[] | null>(null);
+  const [stid, setStid] = useState("");
+  const [ctid, setCtid] = useState("");
+
+  // zip + advanced modes.
+  const [zip, setZip] = useState("");
+  const [kind, setKind] = useState<"county" | "state">("county");
   const [value, setValue] = useState("");
+
   const [hits, setHits] = useState<RRSearchHit[] | null>(null);
   const [busy, setBusy] = useState(false);
 
-  const search = async () => {
+  // Lazy-load the state list when name mode is first shown.
+  useEffect(() => {
+    if (mode !== "name" || states !== null) return;
+    setBusy(true);
+    api
+      .rrStates()
+      .then((r) => setStates(r.results ?? []))
+      .catch((e) => setError(`RadioReference: ${(e as Error).message}`))
+      .finally(() => setBusy(false));
+  }, [mode, states, setError]);
+
+  const onStateChange = async (v: string) => {
+    setStid(v);
+    setCtid("");
+    setCounties(null);
+    setHits(null);
+    if (!v) return;
+    setBusy(true);
+    try {
+      const r = await api.rrCounties(Number(v));
+      setCounties(r.results ?? []);
+    } catch (e) {
+      setError(`RadioReference: ${(e as Error).message}`);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const runSearch = async (fn: () => Promise<{ results: RRSearchHit[] | null }>) => {
     setBusy(true);
     setHits(null);
     try {
-      const r = await api.rrSearch(kind, value.trim());
+      const r = await fn();
       setHits(r.results ?? []);
     } catch (e) {
       setError(`RadioReference: ${(e as Error).message}`);
@@ -436,27 +476,92 @@ function RRBrowseModal(props: {
   return (
     <Modal title="Browse RadioReference.com" onClose={props.onClose}>
       <p className="help">
-        Search by ZIP code, county id (ctid), or state id (stid), then import a
-        system with its control channels and talkgroups. Requires RadioReference
-        credentials configured on the server.
+        Find a trunked system and import it with its control channels and
+        talkgroups. Requires RadioReference credentials configured on the server.
       </p>
-      <div className="flex gap-2">
-        <select className="input w-32" value={kind} onChange={(e) => setKind(e.target.value as "zip" | "county" | "state")}>
-          <option value="zip">ZIP</option>
-          <option value="county">County id</option>
-          <option value="state">State id</option>
-        </select>
-        <input
-          className="input"
-          value={value}
-          placeholder={kind === "zip" ? "78701" : "numeric id"}
-          onChange={(e) => setValue(e.target.value)}
-          onKeyDown={(e) => e.key === "Enter" && search()}
-        />
-        <button className="btn" disabled={busy || !value.trim()} onClick={search}>
-          Search
-        </button>
+      <div className="flex gap-2 text-sm">
+        {(["name", "zip", "advanced"] as const).map((m) => (
+          <button
+            key={m}
+            className={mode === m ? "btn" : "btn-ghost"}
+            onClick={() => {
+              setMode(m);
+              setHits(null);
+            }}
+          >
+            {m === "name" ? "By state/county" : m === "zip" ? "By ZIP" : "By ID"}
+          </button>
+        ))}
       </div>
+
+      {mode === "name" ? (
+        <div className="flex flex-wrap gap-2">
+          <select className="input w-44" value={stid} onChange={(e) => onStateChange(e.target.value)}>
+            <option value="">Select state…</option>
+            {(states ?? []).map((s) => (
+              <option key={s.id} value={s.id}>
+                {s.name}
+              </option>
+            ))}
+          </select>
+          <select
+            className="input w-48"
+            value={ctid}
+            disabled={!counties}
+            onChange={(e) => {
+              setCtid(e.target.value);
+              if (e.target.value) runSearch(() => api.rrSearch("county", e.target.value));
+            }}
+          >
+            <option value="">Select county…</option>
+            {(counties ?? []).map((c) => (
+              <option key={c.id} value={c.id}>
+                {c.name}
+              </option>
+            ))}
+          </select>
+          {stid ? (
+            <button className="btn-ghost" disabled={busy} onClick={() => runSearch(() => api.rrSearch("state", stid))}>
+              All systems in state
+            </button>
+          ) : null}
+        </div>
+      ) : null}
+
+      {mode === "zip" ? (
+        <div className="flex gap-2">
+          <input
+            className="input"
+            value={zip}
+            placeholder="78701"
+            onChange={(e) => setZip(e.target.value)}
+            onKeyDown={(e) => e.key === "Enter" && runSearch(() => api.rrSearch("zip", zip.trim()))}
+          />
+          <button className="btn" disabled={busy || !zip.trim()} onClick={() => runSearch(() => api.rrSearch("zip", zip.trim()))}>
+            Search
+          </button>
+        </div>
+      ) : null}
+
+      {mode === "advanced" ? (
+        <div className="flex gap-2">
+          <select className="input w-32" value={kind} onChange={(e) => setKind(e.target.value as "county" | "state")}>
+            <option value="county">County id</option>
+            <option value="state">State id</option>
+          </select>
+          <input
+            className="input"
+            value={value}
+            placeholder="numeric ctid / stid"
+            onChange={(e) => setValue(e.target.value)}
+            onKeyDown={(e) => e.key === "Enter" && runSearch(() => api.rrSearch(kind, value.trim()))}
+          />
+          <button className="btn" disabled={busy || !value.trim()} onClick={() => runSearch(() => api.rrSearch(kind, value.trim()))}>
+            Search
+          </button>
+        </div>
+      ) : null}
+
       {busy ? <p className="help">Working…</p> : null}
       {hits ? (
         hits.length === 0 ? (

--- a/web/configbuilder/src/sections/Trunking.tsx
+++ b/web/configbuilder/src/sections/Trunking.tsx
@@ -249,6 +249,8 @@ function SystemEditor(props: { sys: SystemConfig; onChange: (next: SystemConfig)
         />
       </Fieldset>
 
+      <TalkgroupsField sys={sys} onChange={onChange} />
+
       <AdvancedJSON<SystemConfig>
         label="Advanced protocol knobs (JSON)"
         value={sys}
@@ -257,6 +259,127 @@ function SystemEditor(props: { sys: SystemConfig; onChange: (next: SystemConfig)
         help="Protocol-specific decoder settings (TETRA/LTR/P25 Phase 1+2/NXDN/EDACS/MPT1327/Motorola/D-STAR). See the Trunking docs for accepted values; only set the keys you need."
       />
     </div>
+  );
+}
+
+// TalkgroupsField shows the per-system talkgroup count and opens an editor
+// modal. Rows are staged in the store keyed by the system's TalkgroupFile
+// (defaulted from the name) and written as a CSV sidecar on save.
+function TalkgroupsField(props: { sys: SystemConfig; onChange: (next: SystemConfig) => void }) {
+  const { sys, onChange } = props;
+  const talkgroups = useStore((s) => s.talkgroups);
+  const stage = useStore((s) => s.stageTalkgroups);
+  const [open, setOpen] = useState(false);
+  const rel = sys.TalkgroupFile || `${slug(sys.Name)}-talkgroups.csv`;
+  const rows = talkgroups[rel] ?? [];
+  return (
+    <Fieldset legend={`Talkgroups (${rows.length})`}>
+      <p className="help">Alias list written to the sidecar CSV <code>{rel}</code>.</p>
+      <button className="btn-ghost" onClick={() => setOpen(true)}>
+        Edit talkgroups
+      </button>
+      {open ? (
+        <TalkgroupModal
+          rel={rel}
+          rows={rows}
+          onClose={() => setOpen(false)}
+          onChange={(next) => {
+            stage(rel, next);
+            if (!sys.TalkgroupFile) onChange({ ...sys, TalkgroupFile: rel });
+          }}
+        />
+      ) : null}
+    </Fieldset>
+  );
+}
+
+function tgMatches(r: TalkgroupCSVRow, f: string): boolean {
+  if (!f) return true;
+  return (
+    String(r.decimal).includes(f) ||
+    (r.alpha_tag ?? "").toLowerCase().includes(f) ||
+    (r.tag ?? "").toLowerCase().includes(f) ||
+    (r.description ?? "").toLowerCase().includes(f)
+  );
+}
+
+function TalkgroupModal(props: {
+  rel: string;
+  rows: TalkgroupCSVRow[];
+  onClose: () => void;
+  onChange: (rows: TalkgroupCSVRow[]) => void;
+}) {
+  const { rows, onChange } = props;
+  const [filter, setFilter] = useState("");
+  const f = filter.trim().toLowerCase();
+  const set = (i: number, row: TalkgroupCSVRow) => {
+    const next = rows.slice();
+    next[i] = row;
+    onChange(next);
+  };
+  const remove = (i: number) => onChange(rows.filter((_, k) => k !== i));
+  const add = () => onChange([{ decimal: 0 }, ...rows]);
+
+  return (
+    <Modal title={`Talkgroups — ${props.rel}`} onClose={props.onClose}>
+      <div className="flex items-center gap-2">
+        <input
+          className="input"
+          placeholder="filter by decimal / alpha tag / tag / description"
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+        />
+        <button className="btn" onClick={add}>
+          + Add
+        </button>
+      </div>
+      <p className="help">
+        {rows.length} talkgroup{rows.length === 1 ? "" : "s"}
+        {f ? ` (filtered)` : ""}.
+      </p>
+      <div className="max-h-96 space-y-1 overflow-y-auto">
+        {rows.map((r, i) =>
+          tgMatches(r, f) ? (
+            <div key={i} className="grid grid-cols-12 items-center gap-1 text-sm">
+              <input
+                className="input col-span-2"
+                type="number"
+                value={r.decimal}
+                onChange={(e) => set(i, { ...r, decimal: Number(e.target.value) })}
+                placeholder="dec"
+              />
+              <input
+                className="input col-span-3"
+                value={r.alpha_tag ?? ""}
+                onChange={(e) => set(i, { ...r, alpha_tag: e.target.value })}
+                placeholder="alpha tag"
+              />
+              <input
+                className="input col-span-3"
+                value={r.description ?? ""}
+                onChange={(e) => set(i, { ...r, description: e.target.value })}
+                placeholder="description"
+              />
+              <input
+                className="input col-span-2"
+                value={r.tag ?? ""}
+                onChange={(e) => set(i, { ...r, tag: e.target.value })}
+                placeholder="tag"
+              />
+              <input
+                className="input col-span-1"
+                value={r.mode ?? ""}
+                onChange={(e) => set(i, { ...r, mode: e.target.value })}
+                placeholder="mode"
+              />
+              <button className="btn-danger col-span-1" onClick={() => remove(i)}>
+                ✕
+              </button>
+            </div>
+          ) : null,
+        )}
+      </div>
+    </Modal>
   );
 }
 

--- a/web/configbuilder/src/sections/index.tsx
+++ b/web/configbuilder/src/sections/index.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import type { GTConfig } from "../api/types";
 import { SDRSection } from "./SDR";
 import { TrunkingSection } from "./Trunking";
 import {
@@ -30,32 +31,35 @@ export interface SectionDef {
   // and the validator (so the badge + Docs link resolve). Components patch
   // the draft with the capitalized Go field name internally.
   key: string;
+  // cfgKey is the GTConfig (Go) field name this section edits, used to flag
+  // "configured" sections in the nav (draft differs from defaults).
+  cfgKey: keyof GTConfig;
   label: string;
   render: () => ReactNode;
 }
 
 export const SECTIONS: SectionDef[] = [
-  { key: "trunking", label: "Trunking", render: () => <TrunkingSection /> },
-  { key: "sdr", label: "SDR", render: () => <SDRSection /> },
-  { key: "api", label: "API & Web", render: () => <APISection /> },
-  { key: "scanner", label: "Scanner", render: () => <ScannerSection /> },
-  { key: "audio", label: "Audio", render: () => <AudioSection /> },
-  { key: "recordings", label: "Recordings", render: () => <RecordingsSection /> },
-  { key: "storage", label: "Storage", render: () => <StorageSection /> },
-  { key: "retention", label: "Retention", render: () => <RetentionSection /> },
-  { key: "metrics", label: "Metrics", render: () => <MetricsSection /> },
-  { key: "log", label: "Logging", render: () => <LogSection /> },
-  { key: "diagnostics", label: "Diagnostics", render: () => <DiagnosticsSection /> },
-  { key: "radioreference", label: "RadioReference", render: () => <RadioReferenceSection /> },
-  { key: "web", label: "Web UI", render: () => <WebSection /> },
-  { key: "tone_out", label: "Tone-out", render: () => <ToneOutSection /> },
-  { key: "broadcast", label: "Broadcast", render: () => <BroadcastSection /> },
-  { key: "baseband", label: "Baseband", render: () => <BasebandSection /> },
-  { key: "paging", label: "Paging", render: () => <PagingSection /> },
-  { key: "aprs", label: "APRS", render: () => <APRSSection /> },
-  { key: "ais", label: "AIS", render: () => <AISSection /> },
-  { key: "dsc", label: "DSC", render: () => <DSCSection /> },
-  { key: "mdc1200", label: "MDC1200", render: () => <MDC1200Section /> },
-  { key: "adsb", label: "ADS-B", render: () => <ADSBSection /> },
-  { key: "m17", label: "M17", render: () => <M17Section /> },
+  { key: "trunking", cfgKey: "Trunking", label: "Trunking", render: () => <TrunkingSection /> },
+  { key: "sdr", cfgKey: "SDR", label: "SDR", render: () => <SDRSection /> },
+  { key: "api", cfgKey: "API", label: "API & Web", render: () => <APISection /> },
+  { key: "scanner", cfgKey: "Scanner", label: "Scanner", render: () => <ScannerSection /> },
+  { key: "audio", cfgKey: "Audio", label: "Audio", render: () => <AudioSection /> },
+  { key: "recordings", cfgKey: "Recordings", label: "Recordings", render: () => <RecordingsSection /> },
+  { key: "storage", cfgKey: "Storage", label: "Storage", render: () => <StorageSection /> },
+  { key: "retention", cfgKey: "Retention", label: "Retention", render: () => <RetentionSection /> },
+  { key: "metrics", cfgKey: "Metrics", label: "Metrics", render: () => <MetricsSection /> },
+  { key: "log", cfgKey: "Log", label: "Logging", render: () => <LogSection /> },
+  { key: "diagnostics", cfgKey: "Diagnostics", label: "Diagnostics", render: () => <DiagnosticsSection /> },
+  { key: "radioreference", cfgKey: "RadioReference", label: "RadioReference", render: () => <RadioReferenceSection /> },
+  { key: "web", cfgKey: "Web", label: "Web UI", render: () => <WebSection /> },
+  { key: "tone_out", cfgKey: "ToneOut", label: "Tone-out", render: () => <ToneOutSection /> },
+  { key: "broadcast", cfgKey: "Broadcast", label: "Broadcast", render: () => <BroadcastSection /> },
+  { key: "baseband", cfgKey: "Baseband", label: "Baseband", render: () => <BasebandSection /> },
+  { key: "paging", cfgKey: "Paging", label: "Paging", render: () => <PagingSection /> },
+  { key: "aprs", cfgKey: "APRS", label: "APRS", render: () => <APRSSection /> },
+  { key: "ais", cfgKey: "AIS", label: "AIS", render: () => <AISSection /> },
+  { key: "dsc", cfgKey: "DSC", label: "DSC", render: () => <DSCSection /> },
+  { key: "mdc1200", cfgKey: "MDC1200", label: "MDC1200", render: () => <MDC1200Section /> },
+  { key: "adsb", cfgKey: "ADSB", label: "ADS-B", render: () => <ADSBSection /> },
+  { key: "m17", cfgKey: "M17", label: "M17", render: () => <M17Section /> },
 ];

--- a/web/configbuilder/src/sections/simple.tsx
+++ b/web/configbuilder/src/sections/simple.tsx
@@ -1,14 +1,19 @@
 import { Section } from "../components/Section";
 import {
   BoolField,
+  Fieldset,
+  HzField,
   NumberField,
   SelectField,
   TextField,
 } from "../components/fields";
+import { ListEditor } from "../components/ListEditor";
+import { formatCommaList, parseCommaList } from "../lib/csvList";
 import { useStore } from "../store/shared";
 import type {
   APIConfig,
   AudioConfig,
+  ConvChannelConfig,
   DiagnosticsConfig,
   GTConfig,
   LogConfig,
@@ -60,6 +65,26 @@ export function LogSection() {
           { value: "json", label: "json" },
         ]}
       />
+      <Fieldset legend="Decoded-message log">
+        <BoolField
+          label="Enabled"
+          value={!!cfg.MessageLog?.Enabled}
+          onChange={(x) => set({ ...cfg, MessageLog: { ...cfg.MessageLog, Enabled: x } })}
+          help="Human-readable per-event log of trunking activity (grants, lock/loss, affiliations)."
+        />
+        <TextField
+          label="Path"
+          value={cfg.MessageLog?.Path ?? ""}
+          onChange={(x) => set({ ...cfg, MessageLog: { ...cfg.MessageLog, Path: x } })}
+          placeholder="/var/log/gophertrunk/messages.log"
+        />
+        <NumberField
+          label="Max size (MB)"
+          value={cfg.MessageLog?.MaxSizeMB ?? 0}
+          onChange={(x) => set({ ...cfg, MessageLog: { ...cfg.MessageLog, MaxSizeMB: x } })}
+          placeholder="16"
+        />
+      </Fieldset>
     </Section>
   );
 }
@@ -138,6 +163,66 @@ export function APISection() {
         placeholder="127.0.0.1:4532 (optional)"
         help="Expose the control SDR over the Hamlib rigctld protocol. Leave empty to disable."
       />
+
+      <Fieldset legend="Authentication">
+        <SelectField
+          label="Mode"
+          value={cfg.Auth?.Mode ?? ""}
+          onChange={(x) => set({ ...cfg, Auth: { ...cfg.Auth, Mode: x } })}
+          options={[
+            { value: "", label: "(auto)" },
+            { value: "auto", label: "auto (loopback trusted, token on public binds)" },
+            { value: "required", label: "required (always need a token)" },
+            { value: "disabled", label: "disabled (wide open)" },
+          ]}
+        />
+        <TextField
+          label="Token"
+          type="password"
+          value={cfg.Auth?.Token ?? ""}
+          onChange={(x) => set({ ...cfg, Auth: { ...cfg.Auth, Token: x } })}
+          help="Inline bearer token. Prefer Token file so the secret stays out of config.yaml."
+        />
+        <TextField
+          label="Token file"
+          value={cfg.Auth?.TokenFile ?? ""}
+          onChange={(x) => set({ ...cfg, Auth: { ...cfg.Auth, TokenFile: x } })}
+          placeholder="/etc/gophertrunk/token"
+        />
+        <TextField
+          label="Trusted networks"
+          value={formatCommaList(cfg.Auth?.TrustedNetworks)}
+          onChange={(x) => set({ ...cfg, Auth: { ...cfg.Auth, TrustedNetworks: parseCommaList(x) } })}
+          placeholder="10.0.0.0/8, 192.168.1.0/24"
+          help="Comma-separated CIDRs that bypass the token in auto mode."
+        />
+      </Fieldset>
+
+      <Fieldset legend="CORS">
+        <TextField
+          label="Allowed origins"
+          value={formatCommaList(cfg.CORS?.AllowedOrigins)}
+          onChange={(x) => set({ ...cfg, CORS: { ...cfg.CORS, AllowedOrigins: parseCommaList(x) } })}
+          placeholder='null, http://laptop.local:8000, *'
+          help="Comma-separated origins echoed in Access-Control-Allow-Origin. Empty disables CORS."
+        />
+      </Fieldset>
+
+      <Fieldset legend="TLS">
+        <TextField
+          label="TLS cert (PEM path)"
+          value={cfg.TLSCert}
+          onChange={(x) => set({ ...cfg, TLSCert: x })}
+          placeholder="(optional) /etc/gophertrunk/cert.pem"
+        />
+        <TextField
+          label="TLS key (PEM path)"
+          value={cfg.TLSKey}
+          onChange={(x) => set({ ...cfg, TLSKey: x })}
+          placeholder="(optional) /etc/gophertrunk/key.pem"
+          help="Both cert and key must be set to enable TLS."
+        />
+      </Fieldset>
     </Section>
   );
 }
@@ -194,6 +279,27 @@ export function RecordingsSection() {
         value={cfg.WriteRaw}
         onChange={(x) => set({ ...cfg, WriteRaw: x })}
       />
+      <Fieldset legend="Equalizer (CMA blind equalizer)">
+        <BoolField
+          label="Enabled"
+          value={!!cfg.Equalizer?.Enabled}
+          onChange={(x) => set({ ...cfg, Equalizer: { ...cfg.Equalizer, Enabled: x } })}
+          help="Per-call CMA equalizer for simulcast systems (multiple TX at slightly different delays)."
+        />
+        <NumberField
+          label="Taps"
+          value={cfg.Equalizer?.Taps ?? 0}
+          onChange={(x) => set({ ...cfg, Equalizer: { ...cfg.Equalizer, Taps: x } })}
+          placeholder="8"
+        />
+        <NumberField
+          label="Step size"
+          step={0.0001}
+          value={cfg.Equalizer?.StepSize ?? 0}
+          onChange={(x) => set({ ...cfg, Equalizer: { ...cfg.Equalizer, StepSize: x } })}
+          placeholder="0.0001"
+        />
+      </Fieldset>
     </Section>
   );
 }
@@ -265,6 +371,102 @@ export function ScannerSection() {
           { value: "all", label: "all" },
           { value: "list", label: "list" },
         ]}
+      />
+
+      <Fieldset legend="Control-channel hunter">
+        <BoolField
+          label="Enabled"
+          value={!!cfg.CCHunt?.Enabled}
+          onChange={(x) => set({ ...cfg, CCHunt: { ...cfg.CCHunt, Enabled: x } })}
+          help="Multi-system control-channel hunter (cycles candidate CCs until one locks)."
+        />
+        <div className="grid gap-3 sm:grid-cols-3">
+          <NumberField label="Dwell (ms)" value={cfg.CCHunt?.DwellMs ?? 0} onChange={(x) => set({ ...cfg, CCHunt: { ...cfg.CCHunt, DwellMs: x } })} />
+          <NumberField label="Backoff (ms)" value={cfg.CCHunt?.BackoffMs ?? 0} onChange={(x) => set({ ...cfg, CCHunt: { ...cfg.CCHunt, BackoffMs: x } })} />
+          <NumberField label="Max backoff (ms)" value={cfg.CCHunt?.MaxBackoffMs ?? 0} onChange={(x) => set({ ...cfg, CCHunt: { ...cfg.CCHunt, MaxBackoffMs: x } })} />
+        </div>
+      </Fieldset>
+
+      <Fieldset legend="Conventional channels (analog FM scan list)">
+        <ListEditor<ConvChannelConfig>
+          label="Channels"
+          items={cfg.Conventional}
+          onChange={(x) => set({ ...cfg, Conventional: x })}
+          makeNew={() => ({
+            Label: "",
+            FrequencyHz: 0,
+            Mode: "nfm",
+            SquelchDbFS: 0,
+            HangtimeMs: 0,
+            Priority: 0,
+            Tone: { Mode: "", CTCSSHz: 0, DCSCode: "" },
+          })}
+          itemTitle={(ch) => ch.Label || "channel"}
+          emptyHint="Fixed-frequency analog channels the scanner sweeps alongside trunking."
+          renderItem={(ch, setCh) => (
+            <div className="space-y-3">
+              <div className="grid gap-3 sm:grid-cols-2">
+                <TextField label="Label" value={ch.Label} onChange={(x) => setCh({ ...ch, Label: x })} />
+                <HzField label="Frequency" value={ch.FrequencyHz} onChange={(x) => setCh({ ...ch, FrequencyHz: x })} />
+                <SelectField
+                  label="Mode"
+                  value={ch.Mode}
+                  onChange={(x) => setCh({ ...ch, Mode: x })}
+                  options={[
+                    { value: "", label: "(fm)" },
+                    { value: "fm", label: "fm" },
+                    { value: "nfm", label: "nfm" },
+                  ]}
+                />
+                <NumberField label="Squelch (dBFS)" value={ch.SquelchDbFS} onChange={(x) => setCh({ ...ch, SquelchDbFS: x })} />
+                <NumberField label="Hangtime (ms)" value={ch.HangtimeMs} onChange={(x) => setCh({ ...ch, HangtimeMs: x })} />
+                <NumberField label="Priority" value={ch.Priority} onChange={(x) => setCh({ ...ch, Priority: x })} />
+              </div>
+              <div className="grid gap-3 sm:grid-cols-2">
+                <SelectField
+                  label="Tone mode"
+                  value={ch.Tone?.Mode ?? ""}
+                  onChange={(x) => setCh({ ...ch, Tone: { ...ch.Tone, Mode: x } })}
+                  options={[
+                    { value: "", label: "none" },
+                    { value: "none", label: "none" },
+                    { value: "ctcss", label: "CTCSS" },
+                    { value: "dcs", label: "DCS" },
+                  ]}
+                />
+                {ch.Tone?.Mode === "ctcss" ? (
+                  <NumberField
+                    label="CTCSS (Hz, 50–300)"
+                    step={0.1}
+                    value={ch.Tone?.CTCSSHz ?? 0}
+                    onChange={(x) => setCh({ ...ch, Tone: { ...ch.Tone, CTCSSHz: x } })}
+                  />
+                ) : null}
+                {ch.Tone?.Mode === "dcs" ? (
+                  <TextField
+                    label="DCS code (3 octal digits)"
+                    value={ch.Tone?.DCSCode ?? ""}
+                    onChange={(x) => setCh({ ...ch, Tone: { ...ch.Tone, DCSCode: x } })}
+                    placeholder="023"
+                  />
+                ) : null}
+              </div>
+            </div>
+          )}
+        />
+      </Fieldset>
+
+      <BoolField
+        label="Manual tune enabled"
+        value={!!cfg.ManualTuneEnabled}
+        onChange={(x) => set({ ...cfg, ManualTuneEnabled: x })}
+        help="Force a VFO tuner so the TUI 'f' key / manual-tune API works even with no static channels (steals one Voice SDR)."
+      />
+      <BoolField
+        label="Manual tune disabled"
+        value={!!cfg.ManualTuneDisabled}
+        onChange={(x) => set({ ...cfg, ManualTuneDisabled: x })}
+        help="Opt out of the auto-detect rule that builds the scanner when ≥2 Voice SDRs are present."
       />
     </Section>
   );

--- a/web/configbuilder/src/store/shared.ts
+++ b/web/configbuilder/src/store/shared.ts
@@ -7,6 +7,11 @@ import type {
   ValidationResult,
 } from "../api/types";
 
+// pushErr appends a message to the error toast stack.
+function pushErr(set: (fn: (s: State) => Partial<State>) => void, msg: string) {
+  set((s) => ({ errors: [...s.errors, msg] }));
+}
+
 interface State {
   // The config being edited, plus where it came from.
   config: GTConfig | null;
@@ -19,8 +24,10 @@ interface State {
   talkgroups: Record<string, TalkgroupCSVRow[]>;
 
   docs: Record<string, DocLink>;
+  defaults: GTConfig | null; // config.Default() seed, for "configured" nav cues
   token: string;
-  lastError: string | null;
+  errors: string[]; // toast stack
+  busy: boolean; // an async op (load/save/validate) is in flight
   lastSaved: string | null;
   validation: ValidationResult | null;
 
@@ -28,11 +35,13 @@ interface State {
   init: () => Promise<void>;
   newConfig: () => Promise<void>;
   load: (path: string) => Promise<void>;
+  revert: () => Promise<void>;
   setConfig: (c: GTConfig) => void;
   patchSection: <K extends keyof GTConfig>(key: K, value: GTConfig[K]) => void;
   stageTalkgroups: (rel: string, rows: TalkgroupCSVRow[]) => void;
   setToken: (t: string) => void;
-  setError: (e: string | null) => void;
+  setError: (e: string | null) => void; // null clears all; string pushes
+  dismissError: (i: number) => void;
   validateAll: () => Promise<void>;
   save: (path: string, overwrite: boolean) => Promise<boolean>;
 }
@@ -44,8 +53,10 @@ export const useStore = create<State>((set, get) => ({
   dirty: false,
   talkgroups: {},
   docs: {},
+  defaults: null,
   token: "",
-  lastError: null,
+  errors: [],
+  busy: false,
   lastSaved: null,
   validation: null,
 
@@ -56,12 +67,29 @@ export const useStore = create<State>((set, get) => ({
     } catch {
       /* docs are best-effort */
     }
+    // Cache the defaults once so the nav can flag which sections differ
+    // from a blank config ("configured" cues).
+    try {
+      set({ defaults: await api.defaults() });
+    } catch {
+      /* best-effort */
+    }
     if (!get().config) {
       await get().newConfig();
     }
   },
 
+  revert: async () => {
+    const p = get().path;
+    if (p) {
+      await get().load(p);
+    } else {
+      await get().newConfig();
+    }
+  },
+
   newConfig: async () => {
+    set({ busy: true });
     try {
       const cfg = await api.defaults();
       set({
@@ -75,11 +103,14 @@ export const useStore = create<State>((set, get) => ({
       });
       await get().validateAll();
     } catch (e) {
-      set({ lastError: `Could not load defaults: ${(e as Error).message}` });
+      pushErr(set, `Could not load defaults: ${(e as Error).message}`);
+    } finally {
+      set({ busy: false });
     }
   },
 
   load: async (path) => {
+    set({ busy: true });
     try {
       const resp = await api.loadFile(path);
       set({
@@ -100,7 +131,9 @@ export const useStore = create<State>((set, get) => ({
         /* sidecars optional */
       }
     } catch (e) {
-      set({ lastError: `Load failed: ${(e as Error).message}` });
+      pushErr(set, `Load failed: ${(e as Error).message}`);
+    } finally {
+      set({ busy: false });
     }
   },
 
@@ -120,7 +153,9 @@ export const useStore = create<State>((set, get) => ({
     set({ token: t });
   },
 
-  setError: (e) => set({ lastError: e }),
+  setError: (e) =>
+    set((s) => (e === null ? { errors: [] } : { errors: [...s.errors, e] })),
+  dismissError: (i) => set((s) => ({ errors: s.errors.filter((_, k) => k !== i) })),
 
   validateAll: async () => {
     const cfg = get().config;
@@ -129,13 +164,14 @@ export const useStore = create<State>((set, get) => ({
       const v = await api.validate(cfg);
       set({ validation: v });
     } catch (e) {
-      set({ lastError: `Validate failed: ${(e as Error).message}` });
+      pushErr(set, `Validate failed: ${(e as Error).message}`);
     }
   },
 
   save: async (path, overwrite) => {
     const cfg = get().config;
     if (!cfg) return false;
+    set({ busy: true });
     try {
       const resp = await api.save({
         path,
@@ -149,7 +185,7 @@ export const useStore = create<State>((set, get) => ({
         mtime: resp.mtime,
         dirty: false,
         lastSaved: `Saved to ${resp.path}`,
-        lastError: null,
+        errors: [],
       });
       // Resync staged talkgroups with what's now on disk so the editor
       // reflects the persisted state (and a later unrelated save doesn't
@@ -162,8 +198,10 @@ export const useStore = create<State>((set, get) => ({
       }
       return true;
     } catch (e) {
-      set({ lastError: `Save failed: ${(e as Error).message}` });
+      pushErr(set, `Save failed: ${(e as Error).message}`);
       return false;
+    } finally {
+      set({ busy: false });
     }
   },
 }));

--- a/web/configbuilder/src/store/shared.ts
+++ b/web/configbuilder/src/store/shared.ts
@@ -91,6 +91,14 @@ export const useStore = create<State>((set, get) => ({
         validation: resp.validation,
         lastSaved: null,
       });
+      // Pull in the talkgroup sidecars so the per-system editor can show
+      // and edit them (best-effort — a config with none just stays empty).
+      try {
+        const tg = await api.talkgroups(resp.path);
+        if (tg.talkgroups) set({ talkgroups: tg.talkgroups });
+      } catch {
+        /* sidecars optional */
+      }
     } catch (e) {
       set({ lastError: `Load failed: ${(e as Error).message}` });
     }
@@ -143,6 +151,15 @@ export const useStore = create<State>((set, get) => ({
         lastSaved: `Saved to ${resp.path}`,
         lastError: null,
       });
+      // Resync staged talkgroups with what's now on disk so the editor
+      // reflects the persisted state (and a later unrelated save doesn't
+      // re-stage stale rows).
+      try {
+        const tg = await api.talkgroups(resp.path);
+        set({ talkgroups: tg.talkgroups ?? {} });
+      } catch {
+        /* best-effort */
+      }
       return true;
     } catch (e) {
       set({ lastError: `Save failed: ${(e as Error).message}` });


### PR DESCRIPTION
- Validators now accumulate: each section helper returns []error (one per
  failing list item + section checks). ValidateAll returns all; ValidateSection
  returns the section's slice; Validate() keeps first-error. Per-item logic is
  unchanged (extracted into validateSystem/validateConvChannel/validateSoapyFields/
  validateRTLTCPFields). Tests cover accumulation.
- MarshalMerge: comment/key-order-preserving YAML merge over an existing file
  (yaml.Node deep-merge); WriteConfigFile uses it when overwriting, plain
  Marshal for new files. Tests confirm comments survive + edits apply.
- New endpoints: GET .../file/talkgroups (read sidecars via a tolerant CSV
  reader so the UI can edit talkgroups of a loaded config); DELETE .../file,
  POST .../file/rename, POST .../dir (gated, allow-list + symlink validated via
  resolvePath/resolveDir); GET .../rr/states and .../rr/counties for name-based
  RadioReference browse (GetStateList/GetCountyList).
- config serve gains -token/-token-file, wiring ServerOptions.Auth so saves work
  on non-loopback binds.

https://claude.ai/code/session_017EGcBzuFkZSBXvgg6i14PF