### PR TITLE
Add spectrum hover readout, dual-pager DDC, and pager type labels (rebased on main + config builder support)

### DIFF
--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -18,6 +18,7 @@ import (
 	"github.com/MattCheramie/GopherTrunk/internal/broadcast"
 	"github.com/MattCheramie/GopherTrunk/internal/config"
 	gtdiag "github.com/MattCheramie/GopherTrunk/internal/diag"
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/tuner"
 	"github.com/MattCheramie/GopherTrunk/internal/events"
 	gtlog "github.com/MattCheramie/GopherTrunk/internal/log"
 	"github.com/MattCheramie/GopherTrunk/internal/metrics"
@@ -311,6 +312,13 @@ type Daemon struct {
 	// the pager_log table / panel, tagged protocol="flex".
 	flexReceivers []*flexrx.Receiver
 	flexSpecs     []flexSpec // index-aligned with flexReceivers
+	// pagingGroups holds one entry per configured paging.wideband group.
+	// Each group tunes a single SDR to a center frequency and fans its
+	// IQ through a DDC bank (internal/dsp/tuner) into one POCSAG / FLEX
+	// receiver per channel — letting two pagers a few hundred kHz apart
+	// share one dongle. Single-frequency paging.pocsag / paging.flex use
+	// the direct-tune path above and are unaffected.
+	pagingGroups []widebandPagingGroup
 	// m17Receivers holds one M17 link-layer receiver per configured
 	// m17.channels entry. Each subscribes to its SDR's iqtap broker and
 	// publishes link-setup metadata on KindM17LinkSetup.
@@ -1259,6 +1267,19 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 		d.flexSpecs = append(d.flexSpecs, spec)
 	}
 
+	// Wideband paging groups — one DDC bank per configured
+	// paging.wideband entry sharing a single SDR across several paging
+	// channels. Constructed here; the Run loop tunes the dongle to the
+	// group's center, builds the tuner.DDCBank, and feeds each tap into
+	// the receiver built below. Same skip-with-warning policy as the
+	// single-frequency paging loops: a bad group is logged and dropped
+	// without disturbing the rest of the pipeline.
+	for _, wg := range cfg.Paging.Wideband {
+		if group := d.buildWidebandPagingGroup(wg, cfg.SDR.SampleRate, log); group != nil {
+			d.pagingGroups = append(d.pagingGroups, *group)
+		}
+	}
+
 	// M17 link-layer receivers — one per configured m17.channels entry.
 	// Same construction shape as the paging receivers above; decoded
 	// link metadata publishes on KindM17LinkSetup.
@@ -1959,6 +1980,109 @@ func (d *Daemon) Run(ctx context.Context) error {
 			sub := br.Subscribe()
 			defer sub.Close()
 			return rcv.Process(ctx, sub.C)
+		})
+	}
+	// Wideband paging groups — one DDC bank per configured
+	// paging.wideband group. The group's SDR tunes once to the group
+	// center; a tuner.DDCBank splits its IQ into one narrow-band tap per
+	// channel, each feeding the matching POCSAG / FLEX receiver. This is
+	// what lets two pagers a few hundred kHz apart share one dongle.
+	// Non-essential: a missing SDR or an out-of-band channel is logged
+	// and skipped without bringing down the rest of the pipeline.
+	for _, g := range d.pagingGroups {
+		g := g
+		name := fmt.Sprintf("pager-wideband-%s-%d", g.serial, g.centerFreq)
+		d.spawn(runCtx, name, false, func(ctx context.Context) error {
+			br := d.iqBrokers[g.serial]
+			if br == nil {
+				d.log.Warn("paging.wideband: SDR not found, skipping group",
+					"serial", g.serial)
+				return nil
+			}
+			if err := br.SetCenterFreq(g.centerFreq); err != nil {
+				d.log.Warn("paging.wideband: SetCenterFreq failed",
+					"serial", g.serial, "center_hz", g.centerFreq, "err", err)
+				return nil
+			}
+			bank := tuner.NewDDCBank(
+				float64(d.cfg.SDR.SampleRate), pagingWidebandRateHz, 0.05)
+
+			// One buffered IQ channel per registered tap. The DDC sink
+			// copies each narrow-band chunk into the feed (the bank
+			// reuses its output slice across taps); a full feed drops the
+			// chunk rather than back-pressuring the shared bank and
+			// stalling the sibling taps. Paging is low-rate, so the
+			// 64-deep buffer is effectively never exhausted.
+			var (
+				wg    sync.WaitGroup
+				feeds []chan []complex64
+			)
+			for i := range g.channels {
+				ch := g.channels[i]
+				feed := make(chan []complex64, 64)
+				if err := bank.AddTap(ch.offsetHz, func(out []complex64) {
+					if len(out) == 0 {
+						return
+					}
+					cp := make([]complex64, len(out))
+					copy(cp, out)
+					select {
+					case feed <- cp:
+					default:
+					}
+				}); err != nil {
+					d.log.Warn("paging.wideband: channel offset out of band, skipping",
+						"serial", g.serial, "freq_hz", ch.freq,
+						"offset_hz", ch.offsetHz, "err", err)
+					close(feed)
+					continue
+				}
+				feeds = append(feeds, feed)
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					var perr error
+					switch {
+					case ch.pocsag != nil:
+						perr = ch.pocsag.Process(ctx, feed)
+					case ch.flex != nil:
+						perr = ch.flex.Process(ctx, feed)
+					}
+					if perr != nil && !errors.Is(perr, context.Canceled) {
+						d.log.Warn("paging.wideband: receiver exited with error",
+							"serial", g.serial, "freq_hz", ch.freq, "err", perr)
+					}
+				}()
+			}
+			if len(feeds) == 0 {
+				return nil // every channel fell outside the IQ window
+			}
+			closeFeeds := func() {
+				for _, f := range feeds {
+					close(f)
+				}
+			}
+
+			sub := br.Subscribe()
+			defer sub.Close()
+			// Pump wide-band IQ through the bank until the stream or
+			// context ends, then close the feeds so the per-channel
+			// receivers drain and exit.
+			for {
+				select {
+				case <-ctx.Done():
+					closeFeeds()
+					wg.Wait()
+					return ctx.Err()
+				case chunk, ok := <-sub.C:
+					if !ok {
+						closeFeeds()
+						wg.Wait()
+						return nil
+					}
+					bank.Process(chunk)
+				}
+			}
 		})
 	}
 	// M17 link-layer receivers — same shape as the paging receivers
@@ -3104,6 +3228,125 @@ type flexSpec struct {
 type m17Spec struct {
 	serial string
 	freq   uint32
+}
+
+// widebandPagingGroup captures the broker-side wiring for one configured
+// paging.wideband group: a single SDR tuned to centerFreq, fanned through
+// a DDC bank into per-channel receivers. The Run loop builds the bank,
+// adds one tap per channel at (freq - centerFreq), and pumps the SDR's
+// iqtap subscription through it.
+type widebandPagingGroup struct {
+	serial     string
+	centerFreq uint32
+	channels   []widebandPagingChannel
+}
+
+// widebandPagingChannel binds one DDC tap to its decoder. Exactly one of
+// pocsag / flex is non-nil; the offset is the channel frequency relative
+// to the group's center.
+type widebandPagingChannel struct {
+	freq     uint32
+	offsetHz float64
+	pocsag   *pocsagrx.Receiver
+	flex     *flexrx.Receiver
+}
+
+// pagingWidebandRateHz is the per-tap narrow-band IQ rate the DDC bank
+// produces for wideband paging groups. 48 kHz matches the rest of the
+// tuner conventions and comfortably covers a paging channel's bandwidth;
+// each receiver resamples from here down to baud × oversample.
+const pagingWidebandRateHz = 48_000
+
+// buildWidebandPagingGroup constructs the receiver set for one
+// paging.wideband config entry. It resolves the group center (auto-
+// computed as the channel-frequency midpoint when CenterFreqHz is 0),
+// builds one POCSAG / FLEX receiver per channel at the DDC output rate,
+// and records each channel's offset from center. Invalid groups /
+// channels are logged via addWarning and dropped; returns nil when no
+// usable channel remains.
+func (d *Daemon) buildWidebandPagingGroup(wg config.PagingWidebandConfig, sampleRateHz uint32, log *slog.Logger) *widebandPagingGroup {
+	if wg.Serial == "" || len(wg.Channels) == 0 {
+		d.addWarning(fmt.Sprintf(
+			"paging.wideband: entry missing serial or channels (serial=%q channels=%d) — skipped",
+			wg.Serial, len(wg.Channels)))
+		return nil
+	}
+
+	// Resolve the center frequency. When unset, center on the midpoint
+	// of the channel frequencies so the taps sit symmetrically in the
+	// IQ window.
+	center := wg.CenterFreqHz
+	if center == 0 {
+		var min, max uint32
+		for i, ch := range wg.Channels {
+			if ch.FrequencyHz == 0 {
+				continue
+			}
+			if i == 0 || ch.FrequencyHz < min {
+				min = ch.FrequencyHz
+			}
+			if ch.FrequencyHz > max {
+				max = ch.FrequencyHz
+			}
+		}
+		if max == 0 {
+			d.addWarning(fmt.Sprintf(
+				"paging.wideband[%s]: no channel has frequency_hz — skipped", wg.Serial))
+			return nil
+		}
+		center = min + (max-min)/2
+	}
+
+	group := &widebandPagingGroup{serial: wg.Serial, centerFreq: center}
+	for _, ch := range wg.Channels {
+		if ch.FrequencyHz == 0 {
+			d.addWarning(fmt.Sprintf(
+				"paging.wideband[%s]: channel missing frequency_hz — skipped", wg.Serial))
+			continue
+		}
+		offset := float64(ch.FrequencyHz) - float64(center)
+		wbc := widebandPagingChannel{freq: ch.FrequencyHz, offsetHz: offset}
+		switch strings.ToLower(ch.Protocol) {
+		case "pocsag":
+			rcv, err := pocsagrx.New(pocsagrx.Options{
+				InputRateHz: pagingWidebandRateHz,
+				BaudHz:      ch.BaudHz,
+				SourceName:  wg.Serial,
+				Bus:         d.bus,
+				Log:         log,
+			})
+			if err != nil {
+				d.addWarning(fmt.Sprintf(
+					"paging.wideband[%s] pocsag %d Hz: %v — skipped", wg.Serial, ch.FrequencyHz, err))
+				continue
+			}
+			wbc.pocsag = rcv
+		case "flex":
+			rcv, err := flexrx.New(flexrx.Options{
+				InputRateHz: pagingWidebandRateHz,
+				SourceName:  wg.Serial,
+				Bus:         d.bus,
+				Log:         log,
+			})
+			if err != nil {
+				d.addWarning(fmt.Sprintf(
+					"paging.wideband[%s] flex %d Hz: %v — skipped", wg.Serial, ch.FrequencyHz, err))
+				continue
+			}
+			wbc.flex = rcv
+		default:
+			d.addWarning(fmt.Sprintf(
+				"paging.wideband[%s]: channel %d Hz has unknown protocol %q (want pocsag|flex) — skipped",
+				wg.Serial, ch.FrequencyHz, ch.Protocol))
+			continue
+		}
+		group.channels = append(group.channels, wbc)
+	}
+
+	if len(group.channels) == 0 {
+		return nil
+	}
+	return group
 }
 
 // aprsProvider adapts storage.APRSLog into api.APRSProvider so the

--- a/cmd/gophertrunk/daemon_wideband_paging_test.go
+++ b/cmd/gophertrunk/daemon_wideband_paging_test.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/config"
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+)
+
+// newPagingTestDaemon builds the minimal Daemon buildWidebandPagingGroup
+// needs: a live event bus (handed to each receiver) and a warnings slice
+// (addWarning just appends). No SDR pool / brokers are required at the
+// construction stage under test.
+func newPagingTestDaemon() *Daemon {
+	return &Daemon{bus: events.NewBus(64)}
+}
+
+// TestBuildWidebandPagingGroupAutoCenter covers the headline use case
+// from the feature request: FLEX on 153.0250 MHz + POCSAG on 153.3500 MHz
+// grouped onto one dongle. With no explicit center the daemon should pick
+// the midpoint and place each tap at its signed offset from it.
+func TestBuildWidebandPagingGroupAutoCenter(t *testing.T) {
+	d := newPagingTestDaemon()
+	wg := config.PagingWidebandConfig{
+		Serial: "pager-sdr",
+		Channels: []config.PagingWidebandChannel{
+			{Protocol: "flex", FrequencyHz: 153_025_000},
+			{Protocol: "pocsag", FrequencyHz: 153_350_000, BaudHz: 1200},
+		},
+	}
+
+	group := d.buildWidebandPagingGroup(wg, 2_048_000, slog.Default())
+	if group == nil {
+		t.Fatalf("buildWidebandPagingGroup returned nil; warnings=%v", d.StartupWarnings())
+	}
+	if len(d.StartupWarnings()) != 0 {
+		t.Fatalf("unexpected warnings: %v", d.StartupWarnings())
+	}
+
+	// Midpoint of 153.025 and 153.350 MHz.
+	const wantCenter = 153_187_500
+	if group.centerFreq != wantCenter {
+		t.Fatalf("center = %d Hz, want %d Hz", group.centerFreq, wantCenter)
+	}
+	if len(group.channels) != 2 {
+		t.Fatalf("channels = %d, want 2", len(group.channels))
+	}
+
+	flex := group.channels[0]
+	if flex.flex == nil || flex.pocsag != nil {
+		t.Fatalf("channel 0 should be FLEX, got pocsag=%v flex=%v", flex.pocsag, flex.flex)
+	}
+	if flex.offsetHz != float64(153_025_000-wantCenter) {
+		t.Fatalf("flex offset = %.0f Hz, want %d Hz", flex.offsetHz, 153_025_000-wantCenter)
+	}
+
+	poc := group.channels[1]
+	if poc.pocsag == nil || poc.flex != nil {
+		t.Fatalf("channel 1 should be POCSAG, got pocsag=%v flex=%v", poc.pocsag, poc.flex)
+	}
+	if poc.offsetHz != float64(153_350_000-wantCenter) {
+		t.Fatalf("pocsag offset = %.0f Hz, want %d Hz", poc.offsetHz, 153_350_000-wantCenter)
+	}
+}
+
+// TestBuildWidebandPagingGroupExplicitCenter verifies an operator-supplied
+// center is honoured verbatim and offsets are taken relative to it.
+func TestBuildWidebandPagingGroupExplicitCenter(t *testing.T) {
+	d := newPagingTestDaemon()
+	wg := config.PagingWidebandConfig{
+		Serial:       "pager-sdr",
+		CenterFreqHz: 153_200_000,
+		Channels: []config.PagingWidebandChannel{
+			{Protocol: "flex", FrequencyHz: 153_025_000},
+		},
+	}
+
+	group := d.buildWidebandPagingGroup(wg, 2_048_000, slog.Default())
+	if group == nil {
+		t.Fatalf("buildWidebandPagingGroup returned nil; warnings=%v", d.StartupWarnings())
+	}
+	if group.centerFreq != 153_200_000 {
+		t.Fatalf("center = %d Hz, want 153200000 Hz", group.centerFreq)
+	}
+	if group.channels[0].offsetHz != float64(153_025_000-153_200_000) {
+		t.Fatalf("offset = %.0f Hz, want %d Hz", group.channels[0].offsetHz, 153_025_000-153_200_000)
+	}
+}
+
+// TestBuildWidebandPagingGroupUnknownProtocol drops the bad channel with a
+// warning but keeps the group alive on the remaining valid channel.
+func TestBuildWidebandPagingGroupUnknownProtocol(t *testing.T) {
+	d := newPagingTestDaemon()
+	wg := config.PagingWidebandConfig{
+		Serial: "pager-sdr",
+		Channels: []config.PagingWidebandChannel{
+			{Protocol: "morse", FrequencyHz: 153_025_000},
+			{Protocol: "pocsag", FrequencyHz: 153_350_000},
+		},
+	}
+
+	group := d.buildWidebandPagingGroup(wg, 2_048_000, slog.Default())
+	if group == nil {
+		t.Fatalf("group should survive one bad channel; warnings=%v", d.StartupWarnings())
+	}
+	if len(group.channels) != 1 || group.channels[0].pocsag == nil {
+		t.Fatalf("expected one surviving POCSAG channel, got %+v", group.channels)
+	}
+	if len(d.StartupWarnings()) != 1 {
+		t.Fatalf("want 1 warning for the bad protocol, got %v", d.StartupWarnings())
+	}
+}
+
+// TestBuildWidebandPagingGroupRejectsEmpty drops groups with no serial or
+// no channels entirely (nil return, warning recorded).
+func TestBuildWidebandPagingGroupRejectsEmpty(t *testing.T) {
+	d := newPagingTestDaemon()
+	if g := d.buildWidebandPagingGroup(config.PagingWidebandConfig{}, 2_048_000, slog.Default()); g != nil {
+		t.Fatalf("empty group should return nil, got %+v", g)
+	}
+	if len(d.StartupWarnings()) != 1 {
+		t.Fatalf("want 1 warning for the empty group, got %v", d.StartupWarnings())
+	}
+}

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -279,10 +279,14 @@ sdr:
   #     bias_tee: false
   #     connect_timeout_ms: 3000
 
-# Paging decoders. Each entry dedicates one SDR to a paging
-# frequency and runs the per-protocol receiver. The SDR is tuned
-# directly to FrequencyHz (full sample-rate IQ, no DDC) — multi-
-# channel-from-one-SDR is a planned follow-up.
+# Paging decoders. The pocsag / flex lists each dedicate one SDR to a
+# single paging frequency: the SDR is tuned directly to FrequencyHz
+# (full sample-rate IQ, no DDC). The wideband list groups several
+# paging channels (any mix of POCSAG / FLEX) onto ONE SDR — the daemon
+# tunes the dongle to a center frequency and a digital down-converter
+# splits out each channel, so two pagers a few hundred kHz apart fit on
+# one stick. All three share the pager_log table / panel; rows are
+# tagged protocol=pocsag or protocol=flex.
 #
 # paging:
 #   pocsag:
@@ -295,6 +299,18 @@ sdr:
 #     - serial: "antenna-pi2"      # SDR serial; shares the pager_log
 #                                  #  table / panel, tagged protocol=flex
 #       frequency_hz: 929_612_500  # local FLEX paging channel
+#   wideband:                      # two pagers on one dongle via DDC
+#     - serial: "pager-sdr"        # single SDR for the whole group
+#       center_freq_hz: 153_187_500 # optional; auto = midpoint of the
+#                                  #  channel freqs when omitted / 0
+#       channels:                  # each freq must sit within the
+#                                  #  dongle's IQ window (center ±
+#                                  #  sample_rate/2, minus a 5% guard)
+#         - protocol: flex
+#           frequency_hz: 153_025_000
+#         - protocol: pocsag
+#           frequency_hz: 153_350_000
+#           baud_hz: 1200
 
 # APRS / AX.25 Bell-202 AFSK receiver. Each entry pins one SDR to
 # an APRS frequency and runs the full DSP pipeline (FM demod →

--- a/docs/pocsag.md
+++ b/docs/pocsag.md
@@ -52,11 +52,27 @@ section below.
   swapping the running-mean slicer for a proper Mueller-Müller +
   matched-filter combination once we have signal to calibrate
   against.
-- **Multi-channel POCSAG from one wideband SDR.** Today each
-  paging.pocsag entry pins one SDR to one frequency. A follow-up
-  will add a DDC tap so several narrow POCSAG channels inside
-  one wideband SDR's bandwidth decode concurrently — the same
-  primitive `role: wideband` uses for DMR Tier II.
+  Multi-channel POCSAG / FLEX from one wideband SDR is now shipped —
+  see **Multi-channel (wideband) paging** below.
+
+## Multi-channel (wideband) paging
+
+A `paging.wideband` group puts several paging channels — any mix of
+POCSAG and FLEX — on a **single** SDR. The daemon tunes the dongle to
+a center frequency and runs an `internal/dsp/tuner.DDCBank`: one NCO
+mixer + decimating resampler per channel pulls each narrow paging
+channel down to a 48 kHz baseband stream, which feeds the same
+per-protocol receiver the single-frequency path uses. This is the
+same DDC primitive `role: wideband` uses for DMR Tier II.
+
+So two pagers a few hundred kHz apart (e.g. FLEX on 153.0250 MHz and
+POCSAG on 153.3500 MHz, 325 kHz apart) share one stick instead of
+needing two. Each channel frequency must sit inside the dongle's IQ
+window (`center ± sample_rate/2`, minus a 5% guard); a channel outside
+the window is logged and skipped without disturbing its siblings. When
+`center_freq_hz` is omitted (or 0) the daemon centers on the midpoint
+of the channel frequencies.
+
 ## FLEX
 
 FLEX is the higher-rate Motorola pager protocol that shares POCSAG's
@@ -99,12 +115,24 @@ paging:
   flex:
     - serial: "antenna-pi2"      # SDR serial
       frequency_hz: 929_612_500  # local FLEX paging channel
+  wideband:                      # two pagers on one dongle via DDC
+    - serial: "pager-sdr"
+      center_freq_hz: 153_187_500 # optional; auto = midpoint when 0
+      channels:
+        - protocol: flex
+          frequency_hz: 153_025_000
+        - protocol: pocsag
+          frequency_hz: 153_350_000
+          baud_hz: 1200
 ```
 
-The daemon retunes the named SDR to `frequency_hz` on startup and
-runs the receiver against its IQ stream via the iqtap broker.
-Pages flow onto `events.KindPagerMessage`, land in the SQLite
-`pager_log` table, and render on the web `/pagers` panel.
+For `pocsag` / `flex` entries the daemon retunes the named SDR to
+`frequency_hz` on startup and runs the receiver against its full IQ
+stream via the iqtap broker. For a `wideband` group the SDR is tuned
+to the group center and a DDC tap feeds each channel's receiver (see
+**Multi-channel (wideband) paging** above). Either way, pages flow
+onto `events.KindPagerMessage`, land in the SQLite `pager_log` table,
+and render on the web `/pagers` panel tagged by protocol.
 
 ## What's shipped now
 
@@ -128,8 +156,10 @@ Pages flow onto `events.KindPagerMessage`, land in the SQLite
   returns the most recent N pages (default 200, max 5000),
   newest first.
 - **Web panel** — `/pagers` renders the live page list:
-  Received / RIC / Function / Encoding / Body / BER columns,
-  polled every 5 s. Non-zero BER is highlighted yellow.
+  Received / Type / RIC / Function / Encoding / Body / BER columns,
+  polled every 5 s. The Type column shows a POCSAG / FLEX badge so
+  mixed traffic (including a wideband group) is distinguishable at a
+  glance. Non-zero BER is highlighted yellow.
 
 ## Testing
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -276,12 +276,39 @@ type MDC1200ChannelConfig struct {
 	DropBadCRC  bool   `yaml:"drop_bad_crc"`
 }
 
-// PagingConfig configures pager decoders (POCSAG today, FLEX
-// follow-up). Each entry pins an SDR to a paging frequency and
-// runs the per-protocol receiver against its IQ stream.
+// PagingConfig configures pager decoders. POCSAG and FLEX each pin an
+// SDR to a single paging frequency and run the per-protocol receiver
+// against its full IQ stream. Wideband groups several paging channels
+// (any mix of POCSAG / FLEX) onto one dongle: the daemon tunes the SDR
+// to a center frequency and a digital down-converter splits out each
+// channel, so two pagers a few hundred kHz apart fit on one stick.
 type PagingConfig struct {
-	POCSAG []PagingPOCSAGConfig `yaml:"pocsag"`
-	FLEX   []PagingFLEXConfig   `yaml:"flex"`
+	POCSAG   []PagingPOCSAGConfig   `yaml:"pocsag"`
+	FLEX     []PagingFLEXConfig     `yaml:"flex"`
+	Wideband []PagingWidebandConfig `yaml:"wideband"`
+}
+
+// PagingWidebandConfig groups multiple paging channels onto a single
+// SDR. The daemon tunes the dongle to CenterFreqHz (auto-computed as the
+// midpoint of the channel frequencies when left 0), then runs an
+// internal/dsp/tuner DDC bank with one tap per channel — each tap feeds
+// the matching POCSAG / FLEX receiver. Every channel frequency must fall
+// within CenterFreqHz ± sample_rate/2 (with a small guard band); channels
+// outside the usable IQ window are skipped with a startup warning.
+type PagingWidebandConfig struct {
+	Serial       string                  `yaml:"serial"`
+	CenterFreqHz uint32                  `yaml:"center_freq_hz"`
+	Channels     []PagingWidebandChannel `yaml:"channels"`
+}
+
+// PagingWidebandChannel is one paging channel inside a wideband group.
+// Protocol selects the decoder ("pocsag" or "flex"). BaudHz applies to
+// POCSAG only (defaults to 1200); FLEX is fixed at 1600 bps and ignores
+// it.
+type PagingWidebandChannel struct {
+	Protocol    string `yaml:"protocol"`
+	FrequencyHz uint32 `yaml:"frequency_hz"`
+	BaudHz      uint32 `yaml:"baud_hz"`
 }
 
 // PagingFLEXConfig describes one FLEX paging channel to decode. Serial

--- a/internal/radio/pager/pocsag/receiver/receiver.go
+++ b/internal/radio/pager/pocsag/receiver/receiver.go
@@ -214,6 +214,7 @@ func (r *Receiver) publishPage(p pocsag.Page) {
 		enc = "numeric"
 	}
 	msg := storage.PagerMessage{
+		Protocol:  "pocsag",
 		RIC:       p.RIC,
 		Func:      uint8(p.Func),
 		Encoding:  enc,

--- a/web/configbuilder/src/api/types.ts
+++ b/web/configbuilder/src/api/types.ts
@@ -310,9 +310,20 @@ export interface PagingFLEXConfig {
   Serial: string;
   FrequencyHz: number;
 }
+export interface PagingWidebandChannel {
+  Protocol: string;
+  FrequencyHz: number;
+  BaudHz: number;
+}
+export interface PagingWidebandConfig {
+  Serial: string;
+  CenterFreqHz: number;
+  Channels: PagingWidebandChannel[] | null;
+}
 export interface PagingConfig {
   POCSAG: PagingPOCSAGConfig[] | null;
   FLEX: PagingFLEXConfig[] | null;
+  Wideband: PagingWidebandConfig[] | null;
 }
 
 export interface APRSChannelConfig {

--- a/web/configbuilder/src/sections/Paging.tsx
+++ b/web/configbuilder/src/sections/Paging.tsx
@@ -1,17 +1,23 @@
 import { Section } from "../components/Section";
-import { Fieldset, HzField, SelectField, TextField } from "../components/fields";
+import { Fieldset, HzField, NumberField, SelectField, TextField } from "../components/fields";
 import { ListEditor } from "../components/ListEditor";
 import { useSection } from "./useSection";
-import type { PagingConfig, PagingFLEXConfig, PagingPOCSAGConfig } from "../api/types";
+import type {
+  PagingConfig,
+  PagingFLEXConfig,
+  PagingPOCSAGConfig,
+  PagingWidebandChannel,
+  PagingWidebandConfig,
+} from "../api/types";
 
 export function PagingSection() {
   const [cfg, set] = useSection("Paging");
-  const c = (cfg as PagingConfig) ?? { POCSAG: null, FLEX: null };
+  const c = (cfg as PagingConfig) ?? { POCSAG: null, FLEX: null, Wideband: null };
   return (
     <Section
       sectionKey="paging"
       title="Paging"
-      instructions="POCSAG and FLEX pager decoders. Each channel pins an SDR to a paging frequency."
+      instructions="POCSAG and FLEX pager decoders. The POCSAG / FLEX lists each pin one SDR to a single paging frequency; a Wideband group fans several channels off one SDR via a DDC bank."
     >
       <Fieldset legend="POCSAG channels" defaultOpen>
         <ListEditor<PagingPOCSAGConfig>
@@ -51,6 +57,59 @@ export function PagingSection() {
             <div className="grid gap-3 sm:grid-cols-2">
               <TextField label="Serial" value={ch.Serial} onChange={(v) => setCh({ ...ch, Serial: v })} />
               <HzField label="Frequency" value={ch.FrequencyHz} onChange={(v) => setCh({ ...ch, FrequencyHz: v })} />
+            </div>
+          )}
+        />
+      </Fieldset>
+      <Fieldset legend="Wideband groups">
+        <ListEditor<PagingWidebandConfig>
+          label="Wideband"
+          items={c.Wideband}
+          onChange={(x) => set({ ...c, Wideband: x })}
+          makeNew={() => ({ Serial: "", CenterFreqHz: 0, Channels: null })}
+          itemTitle={(g) => g.Serial || "group"}
+          emptyHint="No wideband groups. A group puts several POCSAG / FLEX channels on one SDR via a DDC bank."
+          renderItem={(g, setG) => (
+            <div className="space-y-3">
+              <div className="grid gap-3 sm:grid-cols-2">
+                <TextField label="Serial" value={g.Serial} onChange={(v) => setG({ ...g, Serial: v })} help="Single SDR shared by the whole group." />
+                <HzField
+                  label="Center frequency"
+                  value={g.CenterFreqHz}
+                  onChange={(v) => setG({ ...g, CenterFreqHz: v })}
+                  help="Optional; auto = midpoint of the channel frequencies when 0."
+                />
+              </div>
+              <Fieldset legend="Channels" defaultOpen>
+                <ListEditor<PagingWidebandChannel>
+                  label="Channels"
+                  items={g.Channels}
+                  onChange={(x) => setG({ ...g, Channels: x })}
+                  makeNew={() => ({ Protocol: "pocsag", FrequencyHz: 0, BaudHz: 1200 })}
+                  itemTitle={(ch) => (ch.Protocol || "channel").toUpperCase()}
+                  emptyHint="Each frequency must sit within the dongle's IQ window (center ± sample_rate/2)."
+                  renderItem={(ch, setCh) => {
+                    const proto = (ch.Protocol || "pocsag").toLowerCase();
+                    return (
+                      <div className="grid gap-3 sm:grid-cols-3">
+                        <SelectField
+                          label="Protocol"
+                          value={proto}
+                          onChange={(v) => setCh({ ...ch, Protocol: v })}
+                          options={[
+                            { value: "pocsag", label: "POCSAG" },
+                            { value: "flex", label: "FLEX" },
+                          ]}
+                        />
+                        <HzField label="Frequency" value={ch.FrequencyHz} onChange={(v) => setCh({ ...ch, FrequencyHz: v })} />
+                        {proto === "flex" ? null : (
+                          <NumberField label="Baud" value={ch.BaudHz || 1200} onChange={(v) => setCh({ ...ch, BaudHz: v })} help="512 / 1200 / 2400; default 1200." />
+                        )}
+                      </div>
+                    );
+                  }}
+                />
+              </Fieldset>
             </div>
           )}
         />

--- a/web/configbuilder/src/sections/sections.smoke.test.tsx
+++ b/web/configbuilder/src/sections/sections.smoke.test.tsx
@@ -4,6 +4,7 @@ import { useStore } from "../store/shared";
 import type { GTConfig } from "../api/types";
 import { APRSSection } from "./APRS";
 import { BroadcastSection } from "./Broadcast";
+import { PagingSection } from "./Paging";
 
 // Seed the store with a minimal draft so section editors can read/patch.
 function seed(partial: Partial<GTConfig>) {
@@ -33,5 +34,22 @@ describe("section editors patch the draft with capitalized Go keys", () => {
     const b = useStore.getState().config!.Broadcast;
     expect(b.Broadcastify).toHaveLength(1);
     expect(b.Broadcastify![0].Enabled).toBe(true);
+  });
+
+  it("Paging add wideband group + channel writes config.Paging.Wideband", () => {
+    seed({ Paging: { POCSAG: null, FLEX: null, Wideband: null } });
+    render(<PagingSection />);
+    // Last "+ Add" button belongs to the Wideband list (after POCSAG, FLEX).
+    const adds = screen.getAllByText("+ Add");
+    fireEvent.click(adds[adds.length - 1]);
+    let wb = useStore.getState().config!.Paging.Wideband;
+    expect(wb).toHaveLength(1);
+    expect(wb![0].Channels).toBeNull();
+    // The freshly-added group exposes its own nested channels "+ Add".
+    fireEvent.click(screen.getAllByText("+ Add").pop()!);
+    wb = useStore.getState().config!.Paging.Wideband;
+    expect(wb![0].Channels).toHaveLength(1);
+    expect(wb![0].Channels![0].Protocol).toBe("pocsag");
+    expect(wb![0].Channels![0].BaudHz).toBe(1200);
   });
 });

--- a/web/src/api/pagers.ts
+++ b/web/src/api/pagers.ts
@@ -5,6 +5,7 @@ import { type ClientConfig, joinURL } from "./client";
 export interface PagerMessage {
   id: number;
   received_at: string;
+  protocol: string;
   ric: number;
   func: number;
   encoding: string;

--- a/web/src/panels/Pagers.test.tsx
+++ b/web/src/panels/Pagers.test.tsx
@@ -44,11 +44,12 @@ describe("Pagers panel", () => {
     });
   });
 
-  it("renders rows with RIC, function, and body", async () => {
+  it("renders rows with type, RIC, function, and body", async () => {
     vi.mocked(fetchPagerMessages).mockResolvedValue([
       {
         id: 1,
         received_at: "2026-05-26T12:34:56Z",
+        protocol: "pocsag",
         ric: 1234567,
         func: 2,
         encoding: "alpha",
@@ -58,6 +59,7 @@ describe("Pagers panel", () => {
       {
         id: 2,
         received_at: "2026-05-26T12:35:00Z",
+        protocol: "flex",
         ric: 7654321,
         func: 1,
         encoding: "numeric",
@@ -72,6 +74,8 @@ describe("Pagers panel", () => {
       expect(screen.getByText("1234567")).toBeInTheDocument();
       expect(screen.getByText("C")).toBeInTheDocument(); // function 2 = C
       expect(screen.getByText("B")).toBeInTheDocument(); // function 1 = B
+      expect(screen.getByText("POCSAG")).toBeInTheDocument();
+      expect(screen.getByText("FLEX")).toBeInTheDocument();
     });
   });
 

--- a/web/src/panels/Pagers.tsx
+++ b/web/src/panels/Pagers.tsx
@@ -6,10 +6,10 @@ import {
 } from "../api/pagers";
 import { selectClientConfig, useShared } from "../store/shared";
 
-// Pagers panel — list of recent POCSAG (and eventually FLEX) pages
-// decoded by the daemon. Each row carries RIC, function code (A/B/C/D),
-// numeric / alphanumeric encoding, decoded body, and the BCH bit-error
-// count (a non-zero value indicates the page was marginal).
+// Pagers panel — list of recent POCSAG and FLEX pages decoded by the
+// daemon. Each row carries its protocol (POCSAG / FLEX), RIC, function
+// code (A/B/C/D), numeric / alphanumeric encoding, decoded body, and the
+// BCH bit-error count (a non-zero value indicates the page was marginal).
 //
 // Live updates piggyback on the events bus once SSE delivery is wired;
 // for v1 the panel polls /api/v1/pager/messages every 5 s.
@@ -62,6 +62,7 @@ export function Pagers() {
           <thead className="bg-surface text-muted">
             <tr>
               <th className="text-left px-3 py-1 font-normal w-32">Received</th>
+              <th className="text-left px-3 py-1 font-normal w-20">Type</th>
               <th className="text-right px-3 py-1 font-normal w-24">RIC</th>
               <th className="text-left px-3 py-1 font-normal w-12">Fn</th>
               <th className="text-left px-3 py-1 font-normal w-16">Enc</th>
@@ -72,7 +73,7 @@ export function Pagers() {
           <tbody>
             {messages.length === 0 ? (
               <tr>
-                <td colSpan={6} className="px-3 py-4 text-center text-muted">
+                <td colSpan={7} className="px-3 py-4 text-center text-muted">
                   No pager messages yet. POCSAG pages decoded by the
                   daemon will appear here as they arrive — typical
                   workflow is to point one SDR at the local paging
@@ -86,6 +87,9 @@ export function Pagers() {
                 <tr key={m.id} className="border-t border-border/60">
                   <td className="px-3 py-1 font-mono text-muted">
                     {formatTime(m.received_at)}
+                  </td>
+                  <td className="px-3 py-1">
+                    <ProtocolBadge protocol={m.protocol} />
                   </td>
                   <td className="px-3 py-1 text-right font-mono text-accent">
                     {m.ric}
@@ -109,6 +113,24 @@ export function Pagers() {
         </table>
       </div>
     </div>
+  );
+}
+
+// ProtocolBadge renders the page's signalling protocol as a small colored
+// pill so POCSAG and FLEX rows are distinguishable at a glance. Falls back
+// to "POCSAG" when the backend left the field empty (older rows persisted
+// before the protocol column was populated default to POCSAG server-side).
+function ProtocolBadge({ protocol }: { protocol: string }) {
+  const proto = (protocol || "pocsag").toLowerCase();
+  const label = proto.toUpperCase();
+  const cls =
+    proto === "flex"
+      ? "bg-purple-900/40 text-purple-200 border-purple-700/40"
+      : "bg-sky-900/40 text-sky-200 border-sky-700/40";
+  return (
+    <span className={`inline-block rounded border px-1.5 py-0.5 text-[10px] font-medium ${cls}`}>
+      {label}
+    </span>
   );
 }
 

--- a/web/src/panels/Spectrum.test.tsx
+++ b/web/src/panels/Spectrum.test.tsx
@@ -120,6 +120,7 @@ describe("Spectrum panel", () => {
     // and a waterfall row to read the bin power from.
     vi.mocked(openSpectrumStream).mockImplementation((_cfg, opts) => {
       opts.onFrame?.({
+        ts_ns: 0,
         center_hz: 153_000_000,
         sample_rate_hz: 2_048_000,
         bins: [-80, -70, -60, -50, -40, -30, -20, -10],

--- a/web/src/panels/Spectrum.test.tsx
+++ b/web/src/panels/Spectrum.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 
 vi.mock("../api/spectrum", () => ({
   fetchSpectrumDevices: vi.fn(),
@@ -103,6 +103,47 @@ describe("Spectrum panel", () => {
     render(<Spectrum />);
     await waitFor(() => {
       expect(screen.getByText("live")).toBeInTheDocument();
+    });
+  });
+
+  it("shows the frequency and signal level under the cursor on hover", async () => {
+    vi.mocked(fetchSpectrumDevices).mockResolvedValue([
+      {
+        serial: "rtl-1",
+        driver: "rtlsdr",
+        role: "control",
+        center_hz: 153_000_000,
+        sample_rate_hz: 2_048_000,
+      },
+    ]);
+    // Push one frame so the panel has a center/sample-rate to map against
+    // and a waterfall row to read the bin power from.
+    vi.mocked(openSpectrumStream).mockImplementation((_cfg, opts) => {
+      opts.onFrame?.({
+        center_hz: 153_000_000,
+        sample_rate_hz: 2_048_000,
+        bins: [-80, -70, -60, -50, -40, -30, -20, -10],
+      });
+      return { close: vi.fn() };
+    });
+
+    render(<Spectrum />);
+
+    const canvas = await screen.findByLabelText(/hover to read the frequency/i);
+    // Map cursor → frequency: at the canvas midpoint (xRatio 0.5) the
+    // frequency equals the center, and the matching bin (index 4) is -40.
+    canvas.getBoundingClientRect = () =>
+      ({ left: 0, top: 0, width: 100, height: 320 }) as DOMRect;
+    fireEvent.mouseMove(canvas, { clientX: 50, clientY: 10 });
+
+    await waitFor(() => {
+      expect(screen.getByText(/153\.0000 MHz · -40\.0 dBFS/)).toBeInTheDocument();
+    });
+
+    // Leaving the canvas clears the readout.
+    fireEvent.mouseLeave(canvas);
+    await waitFor(() => {
+      expect(screen.queryByText(/153\.0000 MHz · -40\.0 dBFS/)).toBeNull();
     });
   });
 

--- a/web/src/panels/Spectrum.tsx
+++ b/web/src/panels/Spectrum.tsx
@@ -38,6 +38,8 @@ export function Spectrum() {
   const [error, setError] = useState<string | null>(null);
   const [bookmarkList, setBookmarkList] = useState<Bookmark[]>([]);
 
+  const [hover, setHover] = useState<{ hz: number; db: number } | null>(null);
+
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const rowsRef = useRef<Float32Array[]>([]);
   const latestRef = useRef<SpectrumFrame | null>(null);
@@ -136,14 +138,9 @@ export function Spectrum() {
     const canvas = canvasRef.current;
     const frame = latestRef.current;
     if (!canvas || !frame || !selected) return;
-    const rect = canvas.getBoundingClientRect();
-    const xRatio = (e.clientX - rect.left) / rect.width;
+    const xRatio = cursorXRatio(canvas, e.clientX);
     if (xRatio < 0 || xRatio > 1) return;
-    const sampleRate = frame.sample_rate_hz;
-    const halfBand = sampleRate / 2;
-    const targetHz = Math.round(
-      frame.center_hz - halfBand + sampleRate * xRatio,
-    );
+    const targetHz = Math.round(xRatioToHz(frame, xRatio));
     if (targetHz <= 0) return;
     try {
       await tuneSpectrumDevice(cfg, selected, targetHz);
@@ -151,6 +148,33 @@ export function Spectrum() {
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
     }
+  };
+
+  // Track the cursor over the waterfall and surface the frequency it
+  // sits over plus the signal level of the underlying bin. Reuses the
+  // same FFT-shifted X→frequency mapping as click-to-tune; the dBFS
+  // value comes from the newest waterfall row (rowsRef.current[0])
+  // using the same nearest-neighbor bin index renderWaterfall draws.
+  const handleCanvasMove = (e: React.MouseEvent<HTMLCanvasElement>) => {
+    const canvas = canvasRef.current;
+    const frame = latestRef.current;
+    if (!canvas || !frame) {
+      setHover(null);
+      return;
+    }
+    const xRatio = cursorXRatio(canvas, e.clientX);
+    if (xRatio < 0 || xRatio > 1) {
+      setHover(null);
+      return;
+    }
+    const hz = xRatioToHz(frame, xRatio);
+    const row = rowsRef.current[0];
+    let db = NaN;
+    if (row && row.length > 0) {
+      const idx = Math.min(row.length - 1, Math.floor(xRatio * row.length));
+      db = row[idx];
+    }
+    setHover({ hz, db });
   };
 
   const tuningLabel = useMemo(() => {
@@ -187,7 +211,16 @@ export function Spectrum() {
         </div>
       )}
 
-      <div className="font-mono text-xs text-muted">{tuningLabel || "—"}</div>
+      <div className="flex items-center justify-between gap-3 font-mono text-xs">
+        <span className="text-muted">{tuningLabel || "—"}</span>
+        <span className="text-accent">
+          {hover
+            ? `${formatHz(hover.hz)}${
+                Number.isFinite(hover.db) ? ` · ${hover.db.toFixed(1)} dBFS` : ""
+              }`
+            : ""}
+        </span>
+      </div>
 
       <div className="rounded border border-border bg-black overflow-hidden">
         <canvas
@@ -197,19 +230,47 @@ export function Spectrum() {
           className="block w-full cursor-crosshair"
           style={{ imageRendering: "pixelated", height: 320 }}
           onClick={handleCanvasClick}
-          aria-label="Spectrum waterfall — click to tune the SDR to that frequency"
+          onMouseMove={handleCanvasMove}
+          onMouseLeave={() => setHover(null)}
+          aria-label="Spectrum waterfall — hover to read the frequency and signal level, click to tune the SDR to that frequency"
         />
       </div>
 
       <div className="text-[11px] text-muted">
         {DB_FLOOR} dBFS (cold) → {DB_CEIL} dBFS (hot). New frames render at
-        the top; the canvas scrolls down as history accumulates.
-        Click anywhere on the waterfall to retune the SDR to that
-        frequency. Bookmark markers ({bookmarkList.length} visible)
-        appear as cyan ticks along the top.
+        the top; the canvas scrolls down as history accumulates. Hover the
+        waterfall to read the frequency and signal level under the cursor;
+        click anywhere to retune the SDR to that frequency. Bookmark markers
+        ({bookmarkList.length} visible) appear as cyan ticks along the top.
       </div>
     </div>
   );
+}
+
+// cursorXRatio maps a pointer's clientX to a 0..1 position across the
+// canvas. Values outside [0, 1] mean the pointer is off the canvas edge.
+function cursorXRatio(canvas: HTMLCanvasElement, clientX: number): number {
+  const rect = canvas.getBoundingClientRect();
+  return (clientX - rect.left) / rect.width;
+}
+
+// xRatioToHz maps a 0..1 X position across the waterfall back through the
+// FFT-shifted bin layout to a frequency in Hz: leftmost edge =
+// (center - sampleRate/2), rightmost edge = (center + sampleRate/2).
+// Shared by click-to-tune and the hover readout so both agree.
+function xRatioToHz(frame: SpectrumFrame, xRatio: number): number {
+  const sampleRate = frame.sample_rate_hz;
+  return frame.center_hz - sampleRate / 2 + sampleRate * xRatio;
+}
+
+// formatHz renders a frequency for the hover readout. Mirrors the
+// formatter used by the scanner panels (MHz with 4 decimals in the
+// VHF/UHF range operators care about here).
+function formatHz(hz: number): string {
+  if (!Number.isFinite(hz)) return "—";
+  if (hz >= 1_000_000) return `${(hz / 1_000_000).toFixed(4)} MHz`;
+  if (hz >= 1_000) return `${(hz / 1_000).toFixed(3)} kHz`;
+  return `${Math.round(hz)} Hz`;
 }
 
 function ConnPill({ state }: { state: ConnState }) {


### PR DESCRIPTION
Supersedes #531. That branch was cut from an older `main` and had a `config.example.yaml` merge conflict; this branch carries the same three features merged cleanly onto current `main`, plus config-builder support for the new section. Close #531 once this lands.

## Features (from #531)

1. **Spectrum hover readout** — moving the cursor over the waterfall shows the
   frequency and signal level (dBFS) under it, reusing the click-to-tune
   X→frequency mapping (extracted into shared helpers).

2. **Two pagers on one dongle** — new `paging.wideband` config group tunes a
   single SDR to a center frequency and runs a `tuner.DDCBank` with one tap per
   channel, feeding each tap into the existing POCSAG/FLEX receiver at the 48 kHz
   DDC output rate. Auto-centers on the channel midpoint when `center_freq_hz` is
   omitted. Existing single-frequency `paging.pocsag` / `paging.flex` configs are
   unaffected.

3. **Pager type labels** — the Pagers panel now shows a Type column with a
   POCSAG/FLEX badge; the POCSAG receiver stamps `protocol="pocsag"` at the source.

## Added on top of #531

- **Clean merge with current `main`** — resolves the `config.example.yaml`
  conflict (the SoapyRemote doc block and the rewritten paging comment now
  coexist); `daemon.go` / `config.go` auto-merged.
- **Config Builder support for `paging.wideband`** — the builder shipped after
  #531 was branched and only knew `paging.pocsag` / `paging.flex`. Adds the
  `PagingWidebandConfig` / `PagingWidebandChannel` TypeScript types and a
  **Wideband groups** editor (serial + optional center frequency, nested
  per-channel list with protocol/frequency/baud), mirroring the SDR
  wideband-channels nested-`ListEditor` pattern, plus a smoke test.

## Tests

- `go build ./...`, `go test ./cmd/gophertrunk/...` (incl. 4 wideband paging tests)
- web `vitest` for the Spectrum hover readout and the POCSAG/FLEX badge
- configbuilder `typecheck` + `vitest` (33 tests, incl. new wideband smoke test)

https://claude.ai/code/session_01N9ihfpf4pP3fmT2uxf9ePJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01N9ihfpf4pP3fmT2uxf9ePJ)_