### PR TITLE
Fix P25 Phase 1 voice decode: IMBE channel conventions + LDU voice-frame offsets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ for tagged releases.
 
 ### Fixed
 
+- **P25 Phase 1 voice still garbled after the IMBE channel-decode fix —
+  wrong LDU voice-frame positions** (#489 follow-up). With the channel
+  decoder corrected, real-air voice was still noise: the LDU1/LDU2 field
+  layout in `ldu.go` placed a Link Control block between voice frames u_0 and
+  u_1 (`u0, LC1, u1, LC2, …`), but real P25 (per szechyjs/dsd `p25p1_ldu1.c`,
+  which reads IMBE frames 1 and 2 back-to-back) is `u0, u1, LC1, u2, LC2, …,
+  u7, LSD, u8`. This shifted voice subframes u_1..u_7 by one 40-bit block, so
+  only u_0 and u_8 landed on the right bits and the other seven decoded to
+  random pitch. `lduVoiceOffsets`, `lduLCESBlockOffsets`, and
+  `lduLSDBlockOffsets` are corrected to the real layout (also repairing
+  voice-channel Link Control / Encryption Sync / talker-alias metadata, which
+  read the same tables). The pre-existing layout test had the DSD order
+  inverted and is fixed; a new independent fixture
+  (`ldu_realair_test.go`), built from the mbelib/DSD reference with voice
+  frames at hard-coded canonical positions, now guards the layout end-to-end.
 - **P25 Phase 1 voice decoded to garbled noise** (#489). The IMBE 4400
   channel decoder was self-consistent (its own encode/decode round-tripped)
   but did not match the on-air convention real P25 transmitters use, so every

--- a/internal/radio/p25/phase1/ldu.go
+++ b/internal/radio/p25/phase1/ldu.go
@@ -121,15 +121,15 @@ var ErrLDULength = errors.New("p25/phase1: LDU input must be exactly 1728 bits (
 // LDU payload-bit offsets for each field inside the 1680-bit
 // post-status-strip payload.
 //
-// Field interleaving order is sourced from dsd-neo's
-// p25p1_ldu1.c collect_voice_and_data(): a Link Control (LDU1) /
-// Encryption Sync (LDU2) block is interposed *between every* voice
-// subframe from u_0 through u_6, then both 16-bit Low-Speed Data
-// blocks sit together between u_6 and u_7, and u_7 / u_8 are
-// adjacent at the tail:
+// Field interleaving order is sourced from szechyjs/dsd's
+// p25p1_ldu1.c (process_p25_ldu1): the decoder reads IMBE voice
+// frames 1 and 2 (u_0, u_1) back-to-back, THEN a Link Control (LDU1)
+// / Encryption Sync (LDU2) block after each of u_1 through u_6, with
+// both 16-bit Low-Speed Data blocks sitting together between u_7 and
+// u_8:
 //
-//	u_0, LC1, u_1, LC2, u_2, LC3, u_3, LC4, u_4, LC5,
-//	u_5, LC6, u_6, LSD1, LSD2, u_7, u_8
+//	u_0, u_1, LC1, u_2, LC2, u_3, LC3, u_4, LC4,
+//	u_5, LC5, u_6, LC6, u_7, LSD1, LSD2, u_8
 //
 // The 9 IMBE voice subframes are 144 bits each, the 6 LC/ES blocks
 // 40 bits each (240 total), and the 2 LSD blocks 16 bits each:
@@ -138,25 +138,32 @@ var ErrLDULength = errors.New("p25/phase1: LDU input must be exactly 1728 bits (
 //	Frame Sync (FS)             48       48
 //	Network ID (NID)            64      112
 //	Voice Frame 1 (u_0)        144      256
-//	LC / ES Block 1             40      296
-//	Voice Frame 2 (u_1)        144      440
-//	LC / ES Block 2             40      480
-//	Voice Frame 3 (u_2)        144      624
-//	LC / ES Block 3             40      664
-//	Voice Frame 4 (u_3)        144      808
-//	LC / ES Block 4             40      848
-//	Voice Frame 5 (u_4)        144      992
-//	LC / ES Block 5             40     1032
-//	Voice Frame 6 (u_5)        144     1176
-//	LC / ES Block 6             40     1216
-//	Voice Frame 7 (u_6)        144     1360
-//	LSD Block 1                 16     1376
-//	LSD Block 2                 16     1392
-//	Voice Frame 8 (u_7)        144     1536
+//	Voice Frame 2 (u_1)        144      400
+//	LC / ES Block 1             40      440
+//	Voice Frame 3 (u_2)        144      584
+//	LC / ES Block 2             40      624
+//	Voice Frame 4 (u_3)        144      768
+//	LC / ES Block 3             40      808
+//	Voice Frame 5 (u_4)        144      952
+//	LC / ES Block 4             40      992
+//	Voice Frame 6 (u_5)        144     1136
+//	LC / ES Block 5             40     1176
+//	Voice Frame 7 (u_6)        144     1320
+//	LC / ES Block 6             40     1360
+//	Voice Frame 8 (u_7)        144     1504
+//	LSD Block 1                 16     1520
+//	LSD Block 2                 16     1536
 //	Voice Frame 9 (u_8)        144     1680
 //
 // (LDU1 carries Link Control bits in the LC/ES slots; LDU2
 // carries Encryption Sync bits at the identical positions.)
+//
+// NOTE: the previous table placed an LC/ES block between u_0 and u_1
+// (and the LSD between u_6 and u_7), which shifted u_1..u_7 by one
+// 40-bit block. It round-tripped against InjectStatusSymbols but did
+// not match real on-air P25, so only u_0 and u_8 decoded — every
+// other voice subframe was read from the wrong bits (issue #489
+// follow-up).
 var (
 	// lduFSOffset, lduNIDOffset locate the two fixed-position
 	// fields at the start of every LDU.
@@ -168,33 +175,33 @@ var (
 	// subframe is LDUVoiceSubframeBits = 144 bits long.
 	lduVoiceOffsets = [LDUVoiceSubframeCount]int{
 		112,  // u_0 → ends at 256
-		296,  // u_1 → ends at 440  (post LC/ES Block 1)
-		480,  // u_2 → ends at 624  (post LC/ES Block 2)
-		664,  // u_3 → ends at 808  (post LC/ES Block 3)
-		848,  // u_4 → ends at 992  (post LC/ES Block 4)
-		1032, // u_5 → ends at 1176 (post LC/ES Block 5)
-		1216, // u_6 → ends at 1360 (post LC/ES Block 6)
-		1392, // u_7 → ends at 1536 (post LSD Blocks 1 & 2)
-		1536, // u_8 → ends at 1680
+		256,  // u_1 → ends at 400  (u_0 and u_1 are adjacent)
+		440,  // u_2 → ends at 584  (post LC/ES Block 1)
+		624,  // u_3 → ends at 768  (post LC/ES Block 2)
+		808,  // u_4 → ends at 952  (post LC/ES Block 3)
+		992,  // u_5 → ends at 1136 (post LC/ES Block 4)
+		1176, // u_6 → ends at 1320 (post LC/ES Block 5)
+		1360, // u_7 → ends at 1504 (post LC/ES Block 6)
+		1536, // u_8 → ends at 1680 (post LSD Blocks 1 & 2)
 	}
 
 	// lduLCESBlockOffsets[j] is the bit offset of LC/ES block j
 	// (0 ≤ j < 6) inside the 1680-bit payload. Each block is
 	// 40 bits = 4 × Hamming(10,6,3) short codewords.
 	lduLCESBlockOffsets = [6]int{
-		256,  // Block 1 (post u_0)
-		440,  // Block 2 (post u_1)
-		624,  // Block 3 (post u_2)
-		808,  // Block 4 (post u_3)
-		992,  // Block 5 (post u_4)
-		1176, // Block 6 (post u_5)
+		400,  // Block 1 (post u_1)
+		584,  // Block 2 (post u_2)
+		768,  // Block 3 (post u_3)
+		952,  // Block 4 (post u_4)
+		1136, // Block 5 (post u_5)
+		1320, // Block 6 (post u_6)
 	}
 
 	// lduLSDBlockOffsets[k] is the bit offset of LSD block k
 	// (0 ≤ k < 2). Each block is 16 bits = 1 cyclic codeword.
 	lduLSDBlockOffsets = [2]int{
-		1360, // Block 1 (post u_6)
-		1376, // Block 2 (contiguous with Block 1, before u_7)
+		1504, // Block 1 (post u_7)
+		1520, // Block 2 (contiguous with Block 1, before u_8)
 	}
 )
 

--- a/internal/radio/p25/phase1/ldu_e2e_test.go
+++ b/internal/radio/p25/phase1/ldu_e2e_test.go
@@ -174,5 +174,5 @@ func TestLDUEndToEndIntoRecorder(t *testing.T) {
 // package and the internal table is unexported. Keep in sync
 // with ldu.go's lduVoiceOffsets.
 func lduVoiceOffsetForTest(i int) int {
-	return []int{112, 296, 480, 664, 848, 1032, 1216, 1392, 1536}[i]
+	return []int{112, 256, 440, 624, 808, 992, 1176, 1360, 1536}[i]
 }

--- a/internal/radio/p25/phase1/ldu_realair_test.go
+++ b/internal/radio/p25/phase1/ldu_realair_test.go
@@ -1,0 +1,71 @@
+package phase1_test
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase1"
+)
+
+// Independent real-air LDU fixture for the full
+// dibits→StripStatusSymbols→voice-offset→IMBE-channel-decode path.
+//
+// Unlike ldu_e2e_test.go / TestExtractVoiceFramesRoundTrip — which
+// build the LDU from the package's own lduVoiceOffsets and so only
+// prove self-consistency — this fixture was generated entirely from
+// the canonical mbelib/DSD reference, OUTSIDE the GopherTrunk code:
+//
+//   - 9 random valid IMBE frames were channel-encoded (Golay(23,12)
+//     with golayGenerator, Hamming(15,11) with hammingGenerator, the
+//     §7.4 PRBS scramble, the §7.5 interleave);
+//   - placed at the canonical P25 LDU1 payload bit positions
+//     112,256,440,624,808,992,1176,1360,1536 (u_0 and u_1 adjacent,
+//     an LC block after each of u_1..u_6, LSD after u_7) — hard-coded
+//     here, NOT read from the package;
+//   - the rest of the 1680-bit payload filled with a deterministic
+//     pattern;
+//   - status symbols interleaved as "2 bits after every 70 bits".
+//
+// ExtractVoiceFrames must recover the 9 original frames bit-for-bit.
+// A wrong lduVoiceOffsets table (the issue-#489 follow-up bug, where
+// an LC block was placed between u_0 and u_1) makes u_1..u_7 decode
+// to garbage and fails this test.
+const realAirLDUHex = "aaaaaaaaaaaaaaaaa9aaaaaaaaaa8656a025264b9bfb8ce0b1e3e962183c03cfc827cc79b40c262e42cc33f341f6ad1cbb15e4eaaaa9aaaaa22cadd412fd79c6d3a89d2e4709e3d9bd6d78aaaaaaaaaa79fa77f63d42be2a4d9521653262a83bf4bf99aaaaaaaaaad9cdf0d12869d485f9f8a4203dba7b978001aaaaaaa9aaa37d439d49bcf48915662f83100f7cc8a19cffaaaaaaaaaac27de4492602dbf9eed3ad585389375f83250aa9aaaaaaa8a9f2144e85a58bc7027fc1539cddda519d9deaaaaaaaad2af9a1b6162f056319675f3499db4b97d1ed"
+
+var realAirExpectedFrames = []string{
+	"69e70d5a196a2c26836f17",
+	"5a0c44e99fcc97df9e6df9",
+	"37c5bfee3ddadc491a0cfe",
+	"78b608f1096bc68d6b6b5a",
+	"92916f692485d5b4f1a779",
+	"5a1c0a0d38daa2f140cc13",
+	"b2569b992c5ae387e7f7a6",
+	"24c8fb9eae031e0c8dffaf",
+	"b49a2a9a051001acfc76ff",
+}
+
+func TestExtractVoiceFramesRealAirFixture(t *testing.T) {
+	packed, err := hex.DecodeString(realAirLDUHex)
+	if err != nil {
+		t.Fatalf("bad LDU hex: %v", err)
+	}
+	// Expand 216 packed bytes → 1728 one-bit-per-byte LDU bits (MSB-first).
+	ldu := make([]byte, phase1.LDUTotalBits)
+	for b := 0; b < phase1.LDUTotalBits; b++ {
+		ldu[b] = (packed[b/8] >> (7 - uint(b)%8)) & 1
+	}
+
+	frames, errs, err := phase1.ExtractVoiceFrames(ldu)
+	if err != nil {
+		t.Fatalf("ExtractVoiceFrames: %v", err)
+	}
+	if errs != 0 {
+		t.Errorf("clean fixture decoded with %d corrected errors, want 0", errs)
+	}
+	for i, wantHex := range realAirExpectedFrames {
+		want, _ := hex.DecodeString(wantHex)
+		if got := frames[i]; hex.EncodeToString(got) != wantHex {
+			t.Errorf("voice subframe u_%d mismatch\n got %x\nwant %x", i, got, want)
+		}
+	}
+}

--- a/internal/radio/p25/phase1/ldu_test.go
+++ b/internal/radio/p25/phase1/ldu_test.go
@@ -254,13 +254,14 @@ func TestLDUFieldsCoverPayloadWithoutOverlap(t *testing.T) {
 // *interleaving sequence* inside the 1680-bit payload. The
 // coverage test above only proves the offsets tile the payload
 // with no gaps/overlaps — but many tilings do that, including the
-// pre-issue-#489 one that placed u_0 and u_1 back-to-back and
-// caused ~100% uncorrectable LDUs. This test walks the payload
-// from the end of the NID and asserts the order matches dsd-neo's
-// p25p1_ldu1.c collect_voice_and_data():
+// pre-fix one that placed an LC block between u_0 and u_1 and
+// shifted u_1..u_7, so only u_0 and u_8 decoded. This test walks the
+// payload from the end of the NID and asserts the order matches
+// szechyjs/dsd's p25p1_ldu1.c (process_p25_ldu1), which reads u_0
+// and u_1 back-to-back before the first LC block:
 //
-//	u_0, LC1, u_1, LC2, u_2, LC3, u_3, LC4, u_4, LC5,
-//	u_5, LC6, u_6, LSD1, LSD2, u_7, u_8
+//	u_0, u_1, LC1, u_2, LC2, u_3, LC3, u_4, LC4,
+//	u_5, LC5, u_6, LC6, u_7, LSD1, LSD2, u_8
 //
 // A change that reverts to a different interleaving (or shifts a
 // single field) fails here, forcing it to be deliberate.
@@ -273,21 +274,21 @@ func TestLDUVoiceLayoutMatchesDSDOrder(t *testing.T) {
 	// The expected sequence with each field's width, in order.
 	want := []field{
 		{"u_0", lduVoiceOffsets[0], LDUVoiceSubframeBits},
-		{"LC1", lduLCESBlockOffsets[0], LDULCESBlockBits},
 		{"u_1", lduVoiceOffsets[1], LDUVoiceSubframeBits},
-		{"LC2", lduLCESBlockOffsets[1], LDULCESBlockBits},
+		{"LC1", lduLCESBlockOffsets[0], LDULCESBlockBits},
 		{"u_2", lduVoiceOffsets[2], LDUVoiceSubframeBits},
-		{"LC3", lduLCESBlockOffsets[2], LDULCESBlockBits},
+		{"LC2", lduLCESBlockOffsets[1], LDULCESBlockBits},
 		{"u_3", lduVoiceOffsets[3], LDUVoiceSubframeBits},
-		{"LC4", lduLCESBlockOffsets[3], LDULCESBlockBits},
+		{"LC3", lduLCESBlockOffsets[2], LDULCESBlockBits},
 		{"u_4", lduVoiceOffsets[4], LDUVoiceSubframeBits},
-		{"LC5", lduLCESBlockOffsets[4], LDULCESBlockBits},
+		{"LC4", lduLCESBlockOffsets[3], LDULCESBlockBits},
 		{"u_5", lduVoiceOffsets[5], LDUVoiceSubframeBits},
-		{"LC6", lduLCESBlockOffsets[5], LDULCESBlockBits},
+		{"LC5", lduLCESBlockOffsets[4], LDULCESBlockBits},
 		{"u_6", lduVoiceOffsets[6], LDUVoiceSubframeBits},
+		{"LC6", lduLCESBlockOffsets[5], LDULCESBlockBits},
+		{"u_7", lduVoiceOffsets[7], LDUVoiceSubframeBits},
 		{"LSD1", lduLSDBlockOffsets[0], LDULSDBlockBits},
 		{"LSD2", lduLSDBlockOffsets[1], LDULSDBlockBits},
-		{"u_7", lduVoiceOffsets[7], LDUVoiceSubframeBits},
 		{"u_8", lduVoiceOffsets[8], LDUVoiceSubframeBits},
 	}
 


### PR DESCRIPTION
## Summary

P25 Phase 1 voice was decoding to garbled noise. Two distinct, coupled bugs — both **self-consistent against the project's own encoder** (so all synthetic round-trip tests passed) but **not matching real on-air P25** (issue #489). Diagnosed from user-supplied real-air captures and validated against the canonical mbelib / DSD references.

### Bug 1 — IMBE 4400 channel-decode conventions
The channel decoder round-tripped against its own encoder but didn't match what real transmitters send, so every recovered voice frame was effectively random (random `b₀` pitch → warbling noise). Three faults:
1. Each Golay/Hamming vector's channel bits were read in **reversed column order**.
2. The §7.4 PRBS descrambler took its **seed from the wrong end of u_0** and applied the keystream in reversed order.
3. The per-vector FEC borrowed `internal/radio/framing`'s Golay(24,12), which is a **different code** from the P25 IMBE Golay(23,12,7) and corrupted clean codewords.

**Fix:** P25-faithful Golay(23,12,7) + Hamming(15,11,3) (transcribed from mbelib/DSD) with correct column order, descrambler seed (from the Golay-corrected u_0, matching mbelib's `eccC0`-before-`demodulate` order), and keystream direction. `internal/radio/framing` is left untouched, so other protocols are unaffected.

### Bug 2 — wrong LDU voice-frame offsets
With Bug 1 fixed, real-air voice was *still* garbled. The per-LDU-position breakdown showed u_0 (offset 112) decoded 100% valid `b₀` while u_1…u_7 sat at the random rate — only u_0 and u_8 landed on the right bits. The LDU1/LDU2 layout placed a Link Control block between u_0 and u_1 (`u0, LC1, u1, …`); real P25 (per `szechyjs/dsd` `p25p1_ldu1.c`, which reads IMBE frames 1 and 2 back-to-back) is:

```
u0, u1, LC1, u2, LC2, u3, LC3, u4, LC4, u5, LC5, u6, LC6, u7, LSD, u8
```

This shifted u_1…u_7 by one 40-bit block.

**Fix:** corrected `lduVoiceOffsets`, `lduLCESBlockOffsets`, `lduLSDBlockOffsets` (also repairs voice-channel Link Control / Encryption Sync / talker-alias metadata, which read the same tables). The status-symbol phase, `DibitsToBits`, and `SymbolToDibit` were verified correct against DSD and the working control-channel path and are unchanged.

## Tests
- New `internal/voice/imbe/p25fec_refvec_test.go` — pins the channel decode against mbelib/DSD-derived real-air subframes (clean + single-bit-error correction).
- New `internal/radio/p25/phase1/ldu_realair_test.go` — independent end-to-end fixture: a full 1728-bit LDU built from the mbelib/DSD reference with voice frames at hard-coded canonical positions; `ExtractVoiceFrames` must recover all 9 frames bit-for-bit.
- Corrected `TestLDUVoiceLayoutMatchesDSDOrder` (it had the DSD order inverted) and the mirrored offsets in `ldu_e2e_test.go`.
- Updated `internal/voice/imbe` unit tests for the corrected conventions.
- `go build ./...`, `go vet`, and the `p25/...` + `voice/...` suites pass.

Together these resolve the long-standing "no real P25 voice fixture" validation gap (#489).

## Validation note
Decode is validated bit-for-bit against the authoritative mbelib/DSD reference. The `.raw`/`.wav` captures are *post-extraction*, so end-to-end confirmation on live signal is best done by the maintainer: after this change, `composer: p25p1 decode quality`'s `corrected_bit_errs` should drop sharply and audio should be intelligible. If residual garble remains, a voice-channel IQ capture would let us chase any demod/wideband-tap tuning as a separate step.

https://claude.ai/code/session_01EzZB4iPUujZRE2AhWpGmRV

---
_Generated by [Claude Code](https://claude.ai/code/session_01EzZB4iPUujZRE2AhWpGmRV)_