### PR TITLE
docs: add two-page Getting Started guide

### DIFF
--- a/docs/_data/nav.yml
+++ b/docs/_data/nav.yml
@@ -1,4 +1,10 @@
 groups:
+  - label: Getting Started
+    items:
+      - title: What is GopherTrunk?
+        url: /getting-started.html
+      - title: Get started
+        url: /getting-started-setup.html
   - label: About
     items:
       - title: The Story of GopherTrunk

--- a/docs/getting-started-setup.md
+++ b/docs/getting-started-setup.md
@@ -1,0 +1,129 @@
+---
+layout: page
+title: Get started
+description: From download to your first decoded call in a few steps
+nav_group: Getting Started
+---
+
+# Get started
+
+A straightforward path from a fresh download to your first decoded call. New to
+the project? Read [What is GopherTrunk?](getting-started.html) first for the
+big picture. The steps below use Linux x86_64; macOS, Windows, and ARM64 follow
+the same shape — see the per-OS pages linked in step 2.
+
+## 1. Connect a radio
+
+Plug in an SDR dongle. An **RTL-SDR** is the cheapest place to start. Attach an
+antenna suited to your band (for ~700–900 MHz public-safety trunking, a simple
+discone or a tuned whip works). Device-by-device guidance — gain, bias-tee,
+remote backends — is in the [Hardware guide](hardware.html).
+
+## 2. Download the binary
+
+```sh
+# Linux x86_64 — see https://gophertrunk.org/downloads.html for macOS, Windows, ARM64.
+VERSION=v0.3.5
+curl -L -o gophertrunk.tar.gz \
+  https://github.com/MattCheramie/GopherTrunk/releases/download/${VERSION}/gophertrunk-${VERSION}-linux-amd64.tar.gz
+tar xzf gophertrunk.tar.gz && cd gophertrunk-${VERSION}-linux-amd64
+```
+
+On other platforms, follow the per-OS recipe instead — Windows ships a one-click
+installer that bundles Zadig for WinUSB setup, and macOS ships notarised
+tarballs:
+
+- [Linux install](install-linux.html)
+- [macOS install](install-macos.html)
+- [Windows install](install-windows.html)
+- [All downloads & checksums](downloads.html)
+
+## 3. Verify the binary and your radio
+
+```sh
+./gophertrunk version          # confirms the binary runs
+./gophertrunk sdr list         # should list your dongle(s)
+```
+
+If `sdr list` doesn't see your dongle, run the diagnostics:
+
+```sh
+./gophertrunk sdr doctor -v    # explains why a dongle isn't recognized
+```
+
+## 4. Create your config
+
+```sh
+cp config.example.yaml config.yaml
+```
+
+`config.example.yaml` is heavily annotated. The one thing a newcomer must set is
+**at least one system** under `trunking:` — its protocol and control-channel
+frequency. The shape is simple:
+
+```yaml
+trunking:
+  systems:
+    - name: "Example-P25"
+      protocol: p25
+      control_channels:
+        - 851_000_000
+      talkgroup_file: "/etc/gophertrunk/talkgroups-p25.csv"   # optional alpha tags
+```
+
+Don't hand-edit if you don't have to:
+
+- **[Import (PDF / CSV)](import.html)** — pull a system straight from a
+  RadioReference PDF/CSV (`gophertrunk import-pdf`, or the Import panel in any
+  UI).
+- **Config Builder** — `gophertrunk config serve` opens a guided editor in your
+  browser.
+- **[Live edits](live-edits.html)** — most settings can be changed from a
+  running UI without restarting the daemon.
+
+## 5. Run it
+
+```sh
+./gophertrunk -config config.yaml
+```
+
+On a terminal this drops into the **launcher** — pick **[1] TUI**, **[2] Web**,
+or **[3] Headless**. Skip the prompt with a flag:
+
+```sh
+./gophertrunk -tui  -config config.yaml   # in-process terminal console
+./gophertrunk -web  -config config.yaml   # open the browser console
+./gophertrunk -headless -config config.yaml   # silent daemon
+```
+
+More on the menu and how each mode attaches: [Launcher](launcher.html).
+
+## 6. Watch your first call
+
+Once running, you're looking for this sequence:
+
+1. **CC locks** — the daemon synchronises to the control channel.
+2. **A grant fires** — the system assigns a talkgroup to a voice channel.
+3. **A call records** — audio is captured and written to your recordings
+   directory (set under `recordings:` in the config) and logged to the SQLite
+   call database.
+
+Read the panels — active calls, history, control-channel activity — via the
+[TUI](tui.html) or the [Web console](web.html).
+
+## 7. Next steps
+
+- **Share your feed** — stream completed calls to Broadcastify Calls,
+  RdioScanner, OpenMHz, or Icecast/ShoutCast (`broadcast:` config).
+- **[Hunt](hunt.html)** — discover and map an unknown trunked system.
+- **[Hardening](hardening.html)** — API auth, TLS, and safe remote access.
+- **[Opt-in features](opt-in-features.html)** — paging, APRS, AIS, ADS-B, and
+  other extras.
+
+## Troubleshooting
+
+- **Dongle not found** → `./gophertrunk sdr doctor -v`, then the
+  [Hardware guide](hardware.html).
+- **No audio on playback** → `./gophertrunk audio list` to check output devices.
+- **Voice grants dropped on DMR Tier III** → the system needs a `dmr_band_plan`
+  (see the annotated `config.example.yaml`).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -54,10 +54,15 @@ everything else is a view onto the same running daemon.
 | **TUI cockpit** | In-process [Bubbletea](tui.html) terminal console with 12 panels (dashboard, active calls, scanner, history, …). | `gophertrunk -tui` |
 | **Web console** | Bundled browser SPA served by the daemon — the same panels in a browser. | `gophertrunk -web` |
 | **Interactive launcher** | What plain `gophertrunk` shows on a TTY: pick **[1] TUI**, **[2] Web**, or **[3] Headless**. | `gophertrunk` |
+| **Config Builder** | Standalone guided editor for `config.yaml` — add systems, talkgroups, and feeds without hand-writing YAML. Comes as both a terminal app and a browser app. | `gophertrunk config` / `config serve` |
+| **SigLab** | Standalone signal workbench for offline captures — replay, analyze, identify, and grade decodes. Also a terminal app and a browser console. | `gophertrunk siglab` / `siglab serve` |
 
-Quitting the TUI or closing the browser does **not** stop the daemon — it keeps
-running in the same process until you send `Ctrl-C` / `SIGTERM`. See the
-[Launcher](launcher.html) page for the details.
+The first four surfaces are *views onto a running daemon*: quitting the TUI or
+closing the browser does **not** stop the daemon — it keeps running in the same
+process until you send `Ctrl-C` / `SIGTERM` (see the [Launcher](launcher.html)).
+**Config Builder** and **SigLab** are standalone — they run on their own,
+without a live daemon, each available as a terminal interface and a browser
+interface.
 
 ## APIs & integrations
 
@@ -80,10 +85,11 @@ captures and discovery:
   offline, auto-detect its protocol, export JSON/YAML/CSV.
 - `gophertrunk hunt` — discover and map an unknown trunked system
   ([Hunt](hunt.html)).
-- `gophertrunk siglab` — standalone signal-analysis TUI / web console.
-- `gophertrunk config` — terminal or browser **Config Builder**.
 - `gophertrunk import-pdf` — pull a RadioReference PDF straight into your config
   ([Import](import.html)).
+
+The **SigLab** and **Config Builder** interfaces above wrap this workbench in
+terminal and browser front-ends.
 
 ## How the parts fit together
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,102 @@
+---
+layout: page
+title: What is GopherTrunk?
+description: A concise tour of GopherTrunk and its interfaces and parts
+nav_group: Getting Started
+---
+
+# What is GopherTrunk?
+
+**GopherTrunk is a software-defined-radio (SDR) scanner that follows digital
+trunked-radio voice calls and decodes them to audio.** It is written in pure
+Go with **zero CGO** — no `librtlsdr`, `libhackrf`, `libusb`, `libasound2`, or
+`libmp3lame` at build or runtime — and ships as a single ~10 MB static binary
+for Linux, macOS, and Windows. Drop the binary on a box with a dongle, point a
+YAML file at a control channel, and it starts recording calls.
+
+This page is the conceptual map: what GopherTrunk decodes, the interfaces you
+drive it with, and how the parts fit together. When you're ready to run it,
+jump to **[Get started](getting-started-setup.html)**.
+
+## Supported hardware
+
+GopherTrunk drives a *pool* of SDR dongles — one engine, many radios:
+
+- **RTL-SDR** — every osmocom-compatible tuner (the cheapest way to start).
+- **HackRF** — One / Jawbreaker / Rad1o.
+- **Airspy** — R2 / Mini, and **Airspy HF+**.
+- **Remote backends** — `rtl_tcp` and SoapyRemote, so the radio can live on
+  another host.
+
+Full device matrix, antenna notes, and gain tips are in the
+[Hardware guide](hardware.html).
+
+## What it decodes
+
+- **Trunked voice** — P25 Phase 1 + Phase 2, DMR Tier II + Tier III, NXDN,
+  Motorola Type II / SmartZone, EDACS / GE-Marc, LTR, MPT 1327, dPMR Mode 3,
+  TETRA TMO; amateur D-STAR and Yaesu System Fusion.
+- **Paging & signaling** — POCSAG + FLEX paging, MDC1200.
+- **Position & safety** — APRS / AX.25 packet, AIS marine, ADS-B aircraft,
+  DSC marine distress.
+
+A live shipping-vs-pending checklist per protocol lives in
+[Status](status.html).
+
+## The interfaces (the parts you drive)
+
+GopherTrunk is **one binary and one config file**. The *daemon* is the engine;
+everything else is a view onto the same running daemon.
+
+| Part | What it is | Reach it with |
+|------|------------|---------------|
+| **Headless daemon** | The engine — owns the SDR pool, decoders, recorder, and APIs. Runs silent (systemd, Docker, Windows service). | `gophertrunk -headless` |
+| **TUI cockpit** | In-process [Bubbletea](tui.html) terminal console with 12 panels (dashboard, active calls, scanner, history, …). | `gophertrunk -tui` |
+| **Web console** | Bundled browser SPA served by the daemon — the same panels in a browser. | `gophertrunk -web` |
+| **Interactive launcher** | What plain `gophertrunk` shows on a TTY: pick **[1] TUI**, **[2] Web**, or **[3] Headless**. | `gophertrunk` |
+
+Quitting the TUI or closing the browser does **not** stop the daemon — it keeps
+running in the same process until you send `Ctrl-C` / `SIGTERM`. See the
+[Launcher](launcher.html) page for the details.
+
+## APIs & integrations
+
+- **HTTP REST + SSE + WebSocket** on `127.0.0.1:8080` (configurable) — drives
+  the web console and any custom tooling.
+- **gRPC** on `127.0.0.1:50051` for typed clients.
+- **Prometheus `/metrics`** for scraping.
+- **Hamlib `rigctld`** wire protocol for amateur-radio tooling — see
+  [rigctld integration](rigctld.html).
+- **Outbound call streaming** to Broadcastify Calls, RdioScanner, OpenMHz, and
+  live Icecast / ShoutCast mountpoints, out of the box.
+
+## Offline & analysis tooling
+
+Beyond the live daemon, the same binary carries a workbench of subcommands for
+captures and discovery:
+
+- `gophertrunk capture` — record live SDR IQ to a file.
+- `gophertrunk replay` / `analyze` / `identify` — decode and inspect a capture
+  offline, auto-detect its protocol, export JSON/YAML/CSV.
+- `gophertrunk hunt` — discover and map an unknown trunked system
+  ([Hunt](hunt.html)).
+- `gophertrunk siglab` — standalone signal-analysis TUI / web console.
+- `gophertrunk config` — terminal or browser **Config Builder**.
+- `gophertrunk import-pdf` — pull a RadioReference PDF straight into your config
+  ([Import](import.html)).
+
+## How the parts fit together
+
+One daemon owns the radios and the decoders. The TUI, the web console, and the
+REST/gRPC APIs are all just *views and controls* over that one running daemon —
+which is why you can start headless and attach a UI later, or run the TUI
+locally while a browser on your phone watches the same calls. Edits made in a
+UI flow back to `config.yaml` and many apply without a restart
+([Live edits](live-edits.html)).
+
+For the full design — the multi-consumer IQ fan-out, the DSP chain, the voice
+pipeline — read the [Architecture](architecture.html) reference.
+
+---
+
+**Ready to run it? → [Get started](getting-started-setup.html)**


### PR DESCRIPTION
Add a consolidated on-ramp split into two pages:
- getting-started.md: what GopherTrunk is and its interfaces/parts
- getting-started-setup.md: download-to-first-call setup path

Wire both into a new 'Getting Started' nav group at the top of the
docs sidebar.

https://claude.ai/code/session_012rt1b6586vfok2HgRMwXb2