### PR TITLE
configtui: enforce every config field is editable (dual-editor drift guard)

### DIFF
--- a/internal/api/config_builder_docs.go
+++ b/internal/api/config_builder_docs.go
@@ -1,44 +1,30 @@
 package api
 
-// DocLink points the web Config Builder at a documentation page for a
-// config section. URL is opened in a new tab from the section's help
-// affordance.
+import "github.com/MattCheramie/GopherTrunk/internal/configbuilder"
+
+// DocLink carries a config section's shared help for the web Config Builder:
+// the section Instructions plus a documentation link (Title/URL) opened in a
+// new tab from the section's help affordance. Both come from the single Go
+// source of truth in internal/configbuilder (Sections), so the web and the
+// terminal builder present identical section help.
 type DocLink struct {
-	Title       string `json:"title"`
-	URL         string `json:"url"`
-	Description string `json:"description"`
+	Title        string `json:"title"`
+	URL          string `json:"url"`
+	Description  string `json:"description"`
+	Instructions string `json:"instructions"`
 }
 
-// docsBase is the published documentation site. Jekyll renders docs/*.md
-// to /<name>.html.
-const docsBase = "https://gophertrunk.org/"
-
-// configDocs maps each config section (the keys the builder's section nav
-// uses) to its documentation link. Sections without a dedicated page point
-// at the closest relevant guide.
-var configDocs = map[string]DocLink{
-	"log":            {Title: "Logging", URL: docsBase + "live-edits.html", Description: "Log level and format."},
-	"diagnostics":    {Title: "Diagnostics", URL: docsBase + "hardening.html", Description: "Verbose error reporting."},
-	"radioreference": {Title: "RadioReference", URL: docsBase + "hunt.html", Description: "API credentials for browse/import and the hunt duplicate check."},
-	"api":            {Title: "API & Web", URL: docsBase + "web.html", Description: "HTTP/gRPC/WebSocket addresses, auth, CORS."},
-	"sdr":            {Title: "SDR Hardware", URL: docsBase + "hardware.html", Description: "Sample rate, devices, rtl_tcp and SoapyRemote sources."},
-	"trunking":       {Title: "Trunking Systems", URL: docsBase + "hunt.html", Description: "Systems, control channels, protocols, band plans, encryption keys."},
-	"storage":        {Title: "Storage", URL: docsBase + "live-edits.html", Description: "Call-log database and control-channel cache."},
-	"recordings":     {Title: "Recordings", URL: docsBase + "voice-calibration.html", Description: "Per-call WAV directory, sample rate, equalizer."},
-	"metrics":        {Title: "Metrics", URL: docsBase + "web.html", Description: "Prometheus /metrics endpoint."},
-	"retention":      {Title: "Retention", URL: docsBase + "live-edits.html", Description: "Data sweep intervals."},
-	"scanner":        {Title: "Scanner", URL: docsBase + "hunt.html", Description: "Scan mode, CC hunter, conventional channels."},
-	"tone_out":       {Title: "Tone-out", URL: docsBase + "pocsag.html", Description: "Two-tone / single-tone paging detection."},
-	"audio":          {Title: "Audio", URL: docsBase + "voice-calibration.html", Description: "Live playback device, sample rate, volume."},
-	"broadcast":      {Title: "Broadcast", URL: docsBase + "web.html", Description: "Broadcastify, RdioScanner, OpenMHz, Icecast feeds."},
-	"baseband":       {Title: "Baseband", URL: docsBase + "constellation.html", Description: "IQ capture and replay."},
-	"paging":         {Title: "Paging", URL: docsBase + "pocsag.html", Description: "POCSAG / FLEX decoders."},
-	"aprs":           {Title: "APRS", URL: docsBase + "aprs.html", Description: "APRS / AX.25 AFSK receiver."},
-	"ais":            {Title: "AIS", URL: docsBase + "ais.html", Description: "Marine AIS GMSK receiver."},
-	"dsc":            {Title: "DSC", URL: docsBase + "dsc.html", Description: "Marine Digital Selective Calling."},
-	"mdc1200":        {Title: "MDC1200", URL: docsBase + "mdc1200.html", Description: "Motorola MDC1200 signaling."},
-	"adsb":           {Title: "ADS-B", URL: docsBase + "adsb.html", Description: "Aircraft tracking."},
-	"m17":            {Title: "M17", URL: docsBase + "m17.html", Description: "M17 digital voice link-setup."},
-	"web":            {Title: "Web UI", URL: docsBase + "web.html", Description: "Tab visibility in the operator console."},
-	"import":         {Title: "Import", URL: docsBase + "import.html", Description: "Import systems from RadioReference PDF/CSV."},
+// configDocs projects configbuilder.Sections() into the section-keyed DocLink
+// map the web builder fetches over GET /api/v1/config/docs.
+func configDocs() map[string]DocLink {
+	out := make(map[string]DocLink, len(configbuilder.Sections()))
+	for _, s := range configbuilder.Sections() {
+		out[s.Key] = DocLink{
+			Title:        s.DocTitle,
+			URL:          s.DocURL,
+			Description:  s.Instructions,
+			Instructions: s.Instructions,
+		}
+	}
+	return out
 }

--- a/internal/api/handlers_config_builder.go
+++ b/internal/api/handlers_config_builder.go
@@ -309,10 +309,21 @@ func rrToResponse(full radioreference.FullSystem) RRSystemResponse {
 	return RRSystemResponse{System: full, Config: sys, Talkgroups: rows}
 }
 
-// handleConfigDocs answers GET /api/v1/config/docs — a static map of
-// config section → documentation link the builder opens in a new tab.
+// handleConfigDocs answers GET /api/v1/config/docs — a map of config section →
+// {instructions + documentation link} the builder renders and opens in a new
+// tab. Sourced from the shared configbuilder.Sections() registry so the web and
+// terminal builders show identical section help.
 func (s *Server) handleConfigDocs(w http.ResponseWriter, r *http.Request) {
-	writeJSON(w, http.StatusOK, configDocs)
+	writeJSON(w, http.StatusOK, configDocs())
+}
+
+// handleConfigFieldMeta answers GET /api/v1/config/fieldmeta — the shared
+// per-field metadata registry keyed "StructName.FieldName" (comprehensive help
+// plus select options / Hz / freq-list flags). The web builder feeds the help
+// into its field widgets so its per-field help is sourced from the same Go
+// registry the terminal builder uses.
+func (s *Server) handleConfigFieldMeta(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, configbuilder.FieldMetas())
 }
 
 // handleConfigMarshal answers POST /api/v1/config/marshal — render the

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -1016,6 +1016,7 @@ func (s *Server) routes() *http.ServeMux {
 		mux.HandleFunc("GET /api/v1/config/file/talkgroups", s.handleConfigTalkgroups)
 		mux.HandleFunc("GET /api/v1/config/defaults", s.handleConfigDefaults)
 		mux.HandleFunc("GET /api/v1/config/docs", s.handleConfigDocs)
+		mux.HandleFunc("GET /api/v1/config/fieldmeta", s.handleConfigFieldMeta)
 		mux.HandleFunc("POST /api/v1/config/validate", s.handleConfigValidate)
 		mux.HandleFunc("POST /api/v1/config/marshal", s.handleConfigMarshal)
 		mux.HandleFunc("POST /api/v1/config/file", s.gate(s.handleConfigSave))

--- a/internal/configbuilder/fieldmeta.go
+++ b/internal/configbuilder/fieldmeta.go
@@ -1,0 +1,373 @@
+package configbuilder
+
+// SelectOption is one choice in a select / dropdown field (stored value +
+// display label).
+type SelectOption struct {
+	Value string `json:"value"`
+	Label string `json:"label"`
+}
+
+// FieldMeta is the shared, per-field metadata BOTH Config Builders consume:
+// the terminal builder (internal/configtui) reads it directly; the web builder
+// reads it over GET /api/v1/config/fieldmeta. It is keyed "StructName.FieldName"
+// in the registry below.
+//
+//   - Label    overrides the humanized Go field name (empty ⇒ humanize).
+//   - Help     is the comprehensive per-field help shown under the focused row
+//     (TUI) / beside the widget (web). Every config leaf has one; the
+//     fieldmeta coverage test fails if a new field lands without it, so a
+//     schema change can't ship without updating the shared help (and thus
+//     both editors).
+//   - Options  turns a string/number into a select with these choices.
+//   - Hz       renders a uint/int as an MHz/Hz frequency widget.
+//   - FreqList renders a []uint32 as a frequency-list widget.
+type FieldMeta struct {
+	Label    string         `json:"label,omitempty"`
+	Help     string         `json:"help,omitempty"`
+	Options  []SelectOption `json:"options,omitempty"`
+	Hz       bool           `json:"hz,omitempty"`
+	FreqList bool           `json:"freqList,omitempty"`
+}
+
+func opts(pairs ...string) []SelectOption {
+	out := make([]SelectOption, 0, len(pairs)/2)
+	for i := 0; i+1 < len(pairs); i += 2 {
+		out = append(out, SelectOption{Value: pairs[i], Label: pairs[i+1]})
+	}
+	return out
+}
+
+// roleOpts is the control/voice/auto role selector shared by the remote SDR
+// sources and baseband replay (no "wideband" — only physical devices fan out).
+func roleOpts() []SelectOption {
+	return opts("", "(auto)", "control", "control", "voice", "voice", "auto", "auto")
+}
+
+// protocolOpts is the trunking protocol selector (mirrors the web SystemForm).
+func protocolOpts() []SelectOption {
+	ps := []string{"p25", "p25-phase2", "dmr", "dmr-tier2", "dmr-tier1", "nxdn", "dpmr",
+		"edacs", "motorola", "ltr", "mpt1327", "tetra", "ysf", "dstar"}
+	out := make([]SelectOption, len(ps))
+	for i, p := range ps {
+		out[i] = SelectOption{Value: p, Label: p}
+	}
+	return out
+}
+
+func baudOpts() []SelectOption {
+	return opts("512", "512", "1200", "1200", "2400", "2400")
+}
+
+// fieldMetas is the canonical per-field registry, keyed "StructName.FieldName".
+// Every exported leaf of config.Config has an entry with non-empty Help; the
+// container fields (lists / nested structs / maps) carry help too so the form
+// header explains what the operator is about to drill into.
+var fieldMetas = map[string]FieldMeta{
+	// ---- Logging -----------------------------------------------------------
+	"LogConfig.Level":            {Help: "Daemon log verbosity. Default info.", Options: opts("", "(default: info)", "debug", "debug", "info", "info", "warn", "warn", "error", "error")},
+	"LogConfig.Format":           {Help: "Log line format: human text or structured JSON. Default text.", Options: opts("", "(default: text)", "text", "text", "json", "json")},
+	"LogConfig.MessageLog":       {Help: "Optional human-readable per-event log of trunking activity (grants, lock/loss, affiliations, patches)."},
+	"MessageLogConfig.Enabled":   {Help: "Turn the decoded-message log on. Needs a Path to write to."},
+	"MessageLogConfig.Path":      {Help: "File the decoded-message log is written to. Empty disables it."},
+	"MessageLogConfig.MaxSizeMB": {Help: "Rotate the message log at this size in MB. Default 16."},
+
+	// ---- Diagnostics -------------------------------------------------------
+	"DiagnosticsConfig.VerboseErrors": {Help: "Print full error chains + stack traces and expand API error envelopes (exposes host/dongle info). Enable only on trusted networks."},
+
+	// ---- RadioReference ----------------------------------------------------
+	"RadioReferenceConfig.APIKey":   {Label: "API key", Help: "RadioReference.com SOAP API key (read-only). Used by the hunt duplicate check and this builder's browse/import. Can come from GOPHERTRUNK_RR_KEY instead."},
+	"RadioReferenceConfig.Username": {Help: "RadioReference.com account username. Can come from GOPHERTRUNK_RR_USER instead."},
+	"RadioReferenceConfig.Password": {Help: "RadioReference.com account password. Can come from GOPHERTRUNK_RR_PASS instead — prefer the env var to keeping the secret in config.yaml."},
+
+	// ---- SDR ---------------------------------------------------------------
+	"SDRConfig.SampleRate":         {Label: "Sample rate", Hz: true, Help: "IQ rate every tuner is programmed to (225 kHz–20 MHz). RTL dongles cap ~3.2 MHz; higher needs a wideband soapy_remote source. Primary CPU-load lever."},
+	"SDRConfig.Devices":            {Help: "Locally-attached USB SDR dongles, selected by serial."},
+	"SDRConfig.RTLTCP":             {Label: "rtl_tcp sources", Help: "Remote rtl_tcp endpoints mounted as virtual tuners. Plaintext — trusted networks / tunnels only."},
+	"SDRConfig.SoapyRemote":        {Label: "SoapyRemote sources", Help: "Remote SoapySDRServer endpoints (USRP, Lime, bladeRF, HackRF, Airspy, RTL) mounted as virtual tuners. Plaintext — trusted networks / tunnels only."},
+	"SDRConfig.WatchdogIntervalMs": {Help: "USB-disconnect watchdog poll interval (ms). 0 = default 30 s; negative disables it."},
+
+	"DeviceConfig.Serial":        {Help: "USB serial that selects this dongle. Run `gophertrunk sdr list` to see attached serials."},
+	"DeviceConfig.Role":          {Help: "Pool role hint. control/voice pin a P25-trunking dongle; wideband fans several channels off one stick; auto lets the pool decide.", Options: opts("", "(auto)", "control", "control", "voice", "voice", "auto", "auto", "wideband", "wideband")},
+	"DeviceConfig.PPM":           {Label: "PPM", Help: "Frequency-correction in parts-per-million. 0 suits any TCXO dongle."},
+	"DeviceConfig.Gain":          {Help: "Tuner gain. 'auto' (or empty) is AGC; otherwise tenths of a dB (e.g. 496 → 49.6 dB). `gophertrunk sdr list` shows supported steps."},
+	"DeviceConfig.BiasTee":       {Label: "Bias-tee", Help: "Enable the dongle's 5 V bias-tee to power an external LNA through the antenna SMA."},
+	"DeviceConfig.BlogV4":        {Label: "Blog V4 mode", Help: "Force RTL-SDR Blog V4 mode (28.8 MHz ref + per-band routing) when EEPROM strings are blank so auto-detect misses it."},
+	"DeviceConfig.BlogV4Lite":    {Label: "Blog V4 Lite", Help: "Select the two-band Blog V4 'Lite' variant. Set only on a V4L."},
+	"DeviceConfig.CenterFreqHz":  {Label: "Center frequency", Hz: true, Help: "Centre of the IQ band a wideband dongle covers. Every channel must fall within ± sample_rate/2 (5 % guard). Wideband only."},
+	"DeviceConfig.TunerStrategy": {Help: "DSP layout that extracts each narrow channel from the wide IQ. auto picks by channel count. Wideband only.", Options: opts("", "(auto)", "ddc", "ddc", "polyphase", "polyphase")},
+	"DeviceConfig.Channels":      {Help: "Repeater carriers a wideband dongle monitors; each binds a frequency to a trunking system name."},
+	"DeviceConfig.VoiceTaps":     {Help: "Per-grant DDC voice tuners carved from a wideband dongle so one SDR covers CC + voice. 0 = use the physical voice pool. Capped at 8."},
+	"DeviceConfig.IQCorrect":     {Label: "I/Q correct", Help: "Blind I/Q-imbalance correction before decimation. Validate with `gophertrunk replay -iq-correct -diag` before enabling."},
+	"DeviceConfig.IQInvert":      {Label: "I/Q invert", Help: "Conjugate raw IQ (negate Q) to undo a spectrum-inverted front end (needed by some Soapy/USRP chains; critical for π/4-DQPSK like TETRA)."},
+
+	"DeviceChannelConfig.FrequencyHz": {Label: "Frequency", Hz: true, Help: "Repeater carrier frequency. Must lie inside the dongle's IQ band."},
+	"DeviceChannelConfig.System":      {Help: "Name of the trunking.systems entry this carrier belongs to."},
+
+	"RTLTCPConfig.Addr":             {Label: "Address", Help: "host:port the rtl_tcp server listens on, e.g. 192.168.1.50:1234. Required."},
+	"RTLTCPConfig.Serial":           {Help: "Virtual device serial reported by the pool. Empty derives one from the address."},
+	"RTLTCPConfig.Role":             {Help: "Pool role hint: control / voice / auto.", Options: roleOpts()},
+	"RTLTCPConfig.PPM":              {Label: "PPM", Help: "Frequency-correction sent to the remote on open. 0 suits any TCXO dongle."},
+	"RTLTCPConfig.Gain":             {Help: "Tuner gain: 'auto'/empty for AGC, else tenths of a dB."},
+	"RTLTCPConfig.BiasTee":          {Label: "Bias-tee", Help: "Toggle the remote dongle's 5 V bias-tee (librtlsdr ≥ 0.7)."},
+	"RTLTCPConfig.ConnectTimeoutMs": {Help: "TCP dial timeout in ms. 0 = driver default (3000)."},
+
+	"SoapyRemoteConfig.Addr":             {Label: "Address", Help: "SoapySDRServer host:port, e.g. 192.168.1.60:55132 (bare host gets :55132). Required."},
+	"SoapyRemoteConfig.Driver":           {Help: "SoapySDR device key on the server (uhd, lime, bladerf, hackrf, airspy, rtlsdr). Empty picks the server's first device."},
+	"SoapyRemoteConfig.Args":             {Help: "Extra SoapySDR kwargs as key=value,key2=value2 (server-side device selection)."},
+	"SoapyRemoteConfig.Serial":           {Help: "Virtual device serial reported by the pool. Empty derives one from the address."},
+	"SoapyRemoteConfig.Role":             {Help: "Pool role hint: control / voice / auto.", Options: roleOpts()},
+	"SoapyRemoteConfig.Format":           {Help: "Wire sample format: CS16 (16-bit, default) or CF32 (32-bit float).", Options: opts("", "(default)", "CS16", "CS16", "CF32", "CF32")},
+	"SoapyRemoteConfig.StreamProtocol":   {Help: "Stream transport. Only tcp is implemented.", Options: opts("", "(default)", "tcp", "tcp")},
+	"SoapyRemoteConfig.PPM":              {Label: "PPM", Help: "Frequency-correction applied on open (best-effort)."},
+	"SoapyRemoteConfig.Gain":             {Help: "Tuner gain: 'auto'/empty for AGC, else tenths of a dB."},
+	"SoapyRemoteConfig.BiasTee":          {Label: "Bias-tee", Help: "Toggle the remote device's bias-tee (best-effort)."},
+	"SoapyRemoteConfig.ConnectTimeoutMs": {Help: "TCP dial timeout in ms. 0 = driver default (3000)."},
+
+	// ---- Trunking ----------------------------------------------------------
+	"TrunkingConfig.Systems":           {Help: "Trunked radio networks to follow. Add by hand, by RadioReference browse, or by PDF/CSV import."},
+	"TrunkingConfig.CallTimeoutMs":     {Help: "Inactivity window before the watchdog ends a call and frees its voice SDR. 0 = 30 s."},
+	"TrunkingConfig.VoiceHangtimeMs":   {Help: "End-of-transmission window for every voice protocol — ends a call this long after the last voice frame. 0 = 3.5 s."},
+	"TrunkingConfig.VoiceCallGrouping": {Help: "How recordings split: transmission (one file per over) or conversation (group same-TG overs). Empty = transmission.", Options: opts("", "(default: transmission)", "transmission", "transmission", "conversation", "conversation")},
+
+	"SystemConfig.Name":            {Help: "Unique label for this system. Used in the UI and to name its talkgroup sidecar."},
+	"SystemConfig.Protocol":        {Help: "Trunking protocol this system uses.", Options: protocolOpts()},
+	"SystemConfig.ControlChannels": {Label: "Control channels", FreqList: true, Help: "One or more control-channel frequencies. The hunter tries each until one locks."},
+	"SystemConfig.TalkgroupFile":   {Help: "Path to this system's talkgroup CSV sidecar (edit it with [t] / the talkgroup editor)."},
+	"SystemConfig.RIDAliasFile":    {Label: "RID alias file", Help: "Optional CSV/JSON catalogue of radio-ID (subscriber) aliases for this system."},
+	"SystemConfig.P25BandPlan":     {Label: "P25 band plan", Help: "Static IDEN_UP slot seeds for P25 Phase 1 sites that route grants through an unannounced channel ID. P25 Phase 1 only."},
+	"SystemConfig.DMRBandPlan":     {Label: "DMR band plan", Help: "LCN→frequency map REQUIRED for DMR Tier III voice grants. Pick linear (grid) or table (explicit list). DMR only."},
+	"SystemConfig.EncryptionKeys":  {Help: "Operator-held decryption keys (today DMR RC4 'Enhanced Privacy'). No key recovery is performed."},
+	// SystemConfig advanced protocol knobs (edited under the Advanced group).
+	"SystemConfig.TETRAColourCode":         {Label: "TETRA colour code", Help: "30-bit extended colour code seeding the TETRA descrambler. Set to the cell's colour code. TETRA only."},
+	"SystemConfig.TETRAChannel":            {Label: "TETRA channel", Help: "Which TETRA logical channel each burst carries (sch/hd, sch/f, sch/hu, bsch, aach). Empty = sch/hd. TETRA only."},
+	"SystemConfig.TETRAChannelCoding":      {Label: "TETRA channel coding", Help: "Gate the full ETSI channel-coding chain. on (default, live captures) or off (raw-dibit fixtures). TETRA only."},
+	"SystemConfig.TETRAClockMode":          {Label: "TETRA clock mode", Help: "Symbol-timing recovery: gardner (default, live SDR) or naive (sample-aligned fixtures). TETRA only."},
+	"SystemConfig.LTRFCSMode":              {Label: "LTR FCS mode", Help: "CRC-7 FCS check on LTR Status words. on (default) or off (un-populated fixtures). LTR only."},
+	"SystemConfig.LTRManchesterMode":       {Label: "LTR Manchester mode", Help: "LTR sub-audible decode: soft (default), strict, or off/nrz. LTR only."},
+	"SystemConfig.P25Phase1DemodMode":      {Label: "P25 Ph1 demod mode", Help: "Phase 1 symbol recovery: c4fm/fm (default) or cqpsk/lsm (simulcast LSM sites). P25 Phase 1 only."},
+	"SystemConfig.P25Phase2TrellisMode":    {Label: "P25 Ph2 trellis", Help: "½-rate trellis FEC on the Phase 2 MAC PDU. on (default) or off (pre-stripped fixtures). P25 Phase 2 only."},
+	"SystemConfig.P25Phase2RSMode":         {Label: "P25 Ph2 RS", Help: "Outer Reed-Solomon RS(24,16,9) verification. off (default) or on. P25 Phase 2 only."},
+	"SystemConfig.P25Phase2InterleaveMode": {Label: "P25 Ph2 interleave", Help: "Per-burst block deinterleave before trellis decode. off (default) or on. P25 Phase 2 only."},
+	"SystemConfig.P25Phase2ScramblerMode":  {Label: "P25 Ph2 scrambler", Help: "PN44 descrambling of the MAC PDU. on (default, all on-air) or off (unscrambled fixtures). P25 Phase 2 only."},
+	"SystemConfig.P25Phase2ClockMode":      {Label: "P25 Ph2 clock", Help: "Symbol-timing recovery: gardner (default, live SDR) or naive (fixtures). P25 Phase 2 only."},
+	"SystemConfig.DMRInterleavedVoice":     {Label: "DMR interleaved voice", Help: "Experimental 2-slot interleaved DMR voice decoder. Off keeps the single-slot decoder. DMR only."},
+	"SystemConfig.NXDNViterbiMode":         {Label: "NXDN Viterbi mode", Help: "K=5 Viterbi FEC on the NXDN CAC. spec (default), on (older fixtures), or off. NXDN only."},
+	"SystemConfig.NXDNDeviationHz":         {Label: "NXDN deviation", Help: "Peak FM deviation (Hz) the NXDN slicer is calibrated to. 0 = spec 1800 Hz; try 2400 for bimodal captures. NXDN only."},
+	"SystemConfig.EDACSBCHMode":            {Label: "EDACS BCH mode", Help: "BCH(40,28,2) FEC on the EDACS CCW. on (default) or off (pre-stripped fixtures). EDACS only."},
+	"SystemConfig.MPT1327BCHMode":          {Label: "MPT1327 BCH mode", Help: "BCH(63,38) FEC on the MPT1327 codeword. on (default) or off (pre-stripped fixtures). MPT1327 only."},
+	"SystemConfig.MPT1327CWSCTolerance":    {Label: "MPT1327 CWSC tolerance", Help: "Hamming-distance threshold for the MPT1327 sync code. Empty = 2; 0/exact, or 0–15. MPT1327 only."},
+	"SystemConfig.MotorolaBCHMode":         {Label: "Motorola BCH mode", Help: "BCH(64,16,11) FEC on the Motorola Type II OSW. on (default) or off (pre-stripped fixtures). Motorola only."},
+	"SystemConfig.DStarFECMode":            {Label: "D-STAR FEC mode", Help: "JARL DV-header FEC chain. off (default) or on. D-STAR only."},
+
+	"P25BandPlanEntryConfig.ChannelID":   {Help: "4-bit IDEN_UP slot index (0–15)."},
+	"P25BandPlanEntryConfig.BaseHz":      {Label: "Base frequency", Hz: true, Help: "IDEN_UP base frequency for this slot."},
+	"P25BandPlanEntryConfig.SpacingHz":   {Label: "Spacing", Hz: true, Help: "Channel spacing for this slot."},
+	"P25BandPlanEntryConfig.TxOffsetHz":  {Label: "TX offset (Hz)", Help: "Transmit offset per the on-air IDEN_UP field (signed Hz)."},
+	"P25BandPlanEntryConfig.BandwidthHz": {Label: "Bandwidth", Hz: true, Help: "Channel bandwidth (informational; not used to resolve frequencies)."},
+
+	"DMRBandPlanConfig.Linear":           {Help: "Regular base+spacing grid: freq = base + (lcn − offset) × spacing."},
+	"DMRBandPlanConfig.Table":            {Help: "Explicit LCN→frequency list for sites that don't fall on a regular grid."},
+	"DMRLinearBandPlanConfig.BaseHz":     {Label: "Base frequency", Hz: true, Help: "Downlink frequency of the first LCN."},
+	"DMRLinearBandPlanConfig.SpacingHz":  {Label: "Spacing", Hz: true, Help: "Frequency step between consecutive LCNs."},
+	"DMRLinearBandPlanConfig.Offset":     {Help: "LCN the grid starts numbering from. Set 1 for sites that number LCNs from 1."},
+	"DMRBandPlanTableEntryConfig.LCN":    {Label: "LCN", Help: "7-bit Logical Channel Number from the grant CSBK."},
+	"DMRBandPlanTableEntryConfig.FreqHz": {Label: "Frequency", Hz: true, Help: "Downlink frequency this LCN maps to."},
+
+	"EncryptionKeyConfig.KeyID":     {Label: "Key ID", Help: "Key identifier the radios carry in the privacy header, so a system that rotates keys still resolves."},
+	"EncryptionKeyConfig.Algorithm": {Help: "Decryption algorithm. Today only DMR RC4 (Enhanced Privacy).", Options: opts("rc4", "rc4 (DMR Enhanced Privacy)")},
+	"EncryptionKeyConfig.Key":       {Help: "Raw key, hex-encoded. Spaces and a 0x prefix are tolerated."},
+
+	// ---- API & Web ---------------------------------------------------------
+	"APIConfig.HTTPAddr":            {Label: "HTTP address", Help: "TCP listen address for REST/SSE/WebSocket, e.g. 127.0.0.1:8080. Empty disables it."},
+	"APIConfig.GRPCAddr":            {Label: "gRPC address", Help: "TCP listen address for the gRPC server. Empty disables it."},
+	"APIConfig.AllowMutations":      {Help: "Legacy wide-open gate. true logs a deprecation warning and maps to auth.mode: disabled. Prefer auth.mode."},
+	"APIConfig.Auth":                {Help: "Bearer-token policy gating the write endpoints."},
+	"APIConfig.Rigctld":             {Label: "rigctld address", Help: "Expose the control SDR's tuning over the Hamlib rigctld protocol, e.g. 127.0.0.1:4532. No auth — bind loopback."},
+	"APIConfig.CORS":                {Label: "CORS", Help: "Cross-origin browser access. Off by default; enable to serve the web UI from a different origin."},
+	"APIConfig.TLSCert":             {Label: "TLS cert", Help: "PEM certificate path. With TLSKey, switches HTTP+gRPC to TLS (restart to rotate)."},
+	"APIConfig.TLSKey":              {Label: "TLS key", Help: "PEM private-key path. Set together with TLSCert to enable TLS."},
+	"APICORSConfig.AllowedOrigins":  {Help: "Exact origins echoed in Access-Control-Allow-Origin. Use 'null' for file://, '*' for any (don't combine with credentials)."},
+	"APIAuthConfig.Mode":            {Help: "Auth policy: auto (token off loopback, on otherwise), required, or disabled.", Options: opts("", "(auto)", "auto", "auto", "required", "required", "disabled", "disabled")},
+	"APIAuthConfig.Token":           {Help: "Inline bearer token. Prefer TokenFile so the secret stays out of config.yaml."},
+	"APIAuthConfig.TokenFile":       {Help: "Path to a file holding the bearer token (re-read per request, so rotation needs no restart)."},
+	"APIAuthConfig.TrustedNetworks": {Help: "CIDRs whose source addresses bypass the token under auto mode. Loopback is always trusted."},
+
+	"WebConfig.Tabs": {Help: "Show/hide navigation tabs in the operator console. Hidden tabs stay reachable by URL."},
+
+	// ---- Storage -----------------------------------------------------------
+	"StorageConfig.Path":        {Help: "SQLite call-log database file. Empty disables call history (the daemon still runs)."},
+	"StorageConfig.CCCacheFile": {Label: "CC cache file", Help: "JSON cache the control-channel hunter uses to skip dead frequencies. Empty disables it."},
+
+	// ---- Recordings --------------------------------------------------------
+	"RecordingsConfig.Dir":        {Label: "Directory", Help: "Output directory for per-call WAV recordings."},
+	"RecordingsConfig.SampleRate": {Label: "Sample rate", Help: "Recorder PCM rate (4000–48000 Hz). Match audio.sample_rate to avoid a resample stage."},
+	"RecordingsConfig.WriteRaw":   {Help: "Also write the raw (un-equalized) audio alongside the processed WAV."},
+	"RecordingsConfig.Equalizer":  {Help: "Per-call CMA blind equalizer in the FM voice chain — useful on simulcast systems."},
+	"EqualizerConfig.Enabled":     {Help: "Turn the blind equalizer on."},
+	"EqualizerConfig.Taps":        {Help: "Equalizer FIR length. Default 8 when enabled."},
+	"EqualizerConfig.StepSize":    {Help: "CMA adaptation step size. Default 1e-4 when enabled."},
+
+	// ---- Metrics -----------------------------------------------------------
+	"MetricsConfig.Enabled": {Help: "Mount a Prometheus /metrics endpoint on the API HTTP server."},
+
+	// ---- Retention ---------------------------------------------------------
+	"RetentionConfig.CallLogDays": {Help: "Delete call-log rows older than this many days. 0 disables the call-log sweep."},
+	"RetentionConfig.LogDays":     {Help: "Delete decoder-log rows (pager, aprs, vessel, dsc, aircraft, mdc1200, m17) older than this. 0 disables."},
+	"RetentionConfig.FilesDays":   {Help: "Delete recorded WAV files older than this many days. 0 disables the file sweep."},
+	"RetentionConfig.Interval":    {Help: "How often the sweeper runs (Go duration string, e.g. 1h). Default 1h."},
+
+	// ---- Tone-out ----------------------------------------------------------
+	"ToneOutConfig.Profiles":               {Help: "Paging-tone alarms to monitor. Two tones (A then B) for sequential paging, one for single-tone supervision."},
+	"ToneProfileConfig.Name":               {Help: "Profile name (used in alerts and logs)."},
+	"ToneProfileConfig.AlphaTag":           {Help: "Short display tag shown when this profile fires."},
+	"ToneProfileConfig.Tones":              {Help: "Tone sequence: A-tone then B-tone for two-tone paging, or a single tone."},
+	"ToneProfileConfig.ToleranceHz":        {Label: "Tolerance (Hz)", Help: "Frequency match window around each tone, in Hz."},
+	"ToneProfileConfig.MagnitudeThreshold": {Help: "Minimum tone magnitude to count as present (squelches noise)."},
+	"ToneProfileConfig.MaxGap":             {Help: "Largest gap allowed between A and B tones (Go duration, e.g. 250ms)."},
+	"ToneProfileConfig.Cooldown":           {Help: "Minimum time between repeat alerts for this profile (Go duration)."},
+	"ToneProfileConfig.System":             {Help: "Optional system name this profile is associated with."},
+	"ToneProfileConfig.GroupID":            {Label: "Group ID", Help: "Optional talkgroup ID to tag the detection with."},
+	"ToneProfileToneConfig.FrequencyHz":    {Label: "Frequency (Hz)", Help: "Tone frequency in Hz (e.g. 1122.5)."},
+	"ToneProfileToneConfig.MinDuration":    {Help: "Minimum on-time to accept the tone (Go duration, e.g. 250ms)."},
+	"ToneProfileToneConfig.MaxDuration":    {Help: "Maximum on-time before the tone is rejected. 0 disables the upper bound."},
+
+	// ---- Scanner -----------------------------------------------------------
+	"ScannerConfig.ScanMode":           {Help: "Trunking scan mode: all (follow every grant) or list (only TGs flagged Scan). Empty = all.", Options: opts("", "(default: all)", "all", "all", "list", "list")},
+	"ScannerConfig.CCHunt":             {Label: "CC hunt", Help: "Multi-system control-channel hunter dwell + backoff tuning."},
+	"ScannerConfig.Conventional":       {Help: "Fixed-frequency analog FM scan list."},
+	"ScannerConfig.ManualTuneEnabled":  {Help: "Force-build the conventional scanner so the TUI 'f' key / manual_tune works even with no static channels (steals one voice SDR)."},
+	"ScannerConfig.ManualTuneDisabled": {Help: "Veto the auto-detect rule — build the conventional scanner only when channels are listed or ManualTuneEnabled is set."},
+	"CCHuntConfig.Enabled":             {Help: "Run the control-channel hunter. Defaults on when any trunked system is configured."},
+	"CCHuntConfig.DwellMs":             {Help: "Per-frequency wait before declaring no lock. Default 3000 ms."},
+	"CCHuntConfig.BackoffMs":           {Help: "Initial sleep after exhausting a system's CC list. Default 5000 ms; doubles per failure."},
+	"CCHuntConfig.MaxBackoffMs":        {Help: "Cap on the exponential backoff. Default 60000 ms."},
+	"ConvChannelConfig.Label":          {Help: "Display name for this conventional channel."},
+	"ConvChannelConfig.FrequencyHz":    {Label: "Frequency", Hz: true, Help: "Channel center frequency."},
+	"ConvChannelConfig.Mode":           {Help: "Demodulation: fm (wide) or nfm (narrow).", Options: opts("", "(fm)", "fm", "fm", "nfm", "nfm")},
+	"ConvChannelConfig.SquelchDbFS":    {Label: "Squelch (dBFS)", Help: "Squelch threshold in dBFS. Default -50."},
+	"ConvChannelConfig.HangtimeMs":     {Help: "Hold time after carrier drop before the channel is released. Default 1500 ms."},
+	"ConvChannelConfig.Priority":       {Help: "Scan priority 1–10 (higher wins). 0 = unset."},
+	"ConvChannelConfig.Tone":           {Help: "Optional CTCSS/DCS sub-audible squelch gate."},
+	"ConvToneConfig.Mode":              {Help: "Sub-audible gate: none, ctcss, or dcs.", Options: opts("", "none", "none", "none", "ctcss", "ctcss", "dcs", "dcs")},
+	"ConvToneConfig.CTCSSHz":           {Label: "CTCSS (Hz)", Help: "Target CTCSS frequency (50–300 Hz). Required when mode is ctcss."},
+	"ConvToneConfig.DCSCode":           {Label: "DCS code", Help: "3-digit octal DCS code. Required when mode is dcs."},
+
+	// ---- Audio -------------------------------------------------------------
+	"AudioConfig.Enabled":    {Help: "Enable live speaker playback of decoded voice. Off by default (headless-safe). Recordings are unaffected."},
+	"AudioConfig.Device":     {Help: "Backend output device. Empty/default = system sink; 'null' forces the no-op backend."},
+	"AudioConfig.SampleRate": {Label: "Sample rate", Help: "Playback rate (4000–48000 Hz). Default 8000; match recordings.sample_rate."},
+	"AudioConfig.BufferMs":   {Help: "Playback queue depth in ms. Default 80."},
+	"AudioConfig.Volume":     {Help: "Initial software gain, 0–1. Default 0.8."},
+	"AudioConfig.Muted":      {Help: "Start muted."},
+
+	// ---- Broadcast ---------------------------------------------------------
+	"BroadcastConfig.MinDurationMs":   {Help: "Drop calls shorter than this from every feed. 0 streams any length."},
+	"BroadcastConfig.Workers":         {Help: "Concurrent upload goroutines. 0 uses the package default."},
+	"BroadcastConfig.Broadcastify":    {Help: "Broadcastify Calls upload feeds."},
+	"BroadcastConfig.RdioScanner":     {Help: "RdioScanner call-upload feeds."},
+	"BroadcastConfig.OpenMHz":         {Label: "OpenMHz", Help: "OpenMHz upload feeds."},
+	"BroadcastConfig.Icecast":         {Help: "Live Icecast/ShoutCast mountpoint feeds."},
+	"BroadcastifyFeedConfig.Enabled":  {Help: "Enable this feed. false keeps it configured but skipped."},
+	"BroadcastifyFeedConfig.Name":     {Help: "Feed label for logs/metrics."},
+	"BroadcastifyFeedConfig.APIKey":   {Label: "API key", Help: "Broadcastify Calls API key."},
+	"BroadcastifyFeedConfig.SystemID": {Label: "System ID", Help: "Broadcastify system ID to upload under."},
+	"BroadcastifyFeedConfig.Systems":  {Help: "GopherTrunk system names to stream. Empty = every system."},
+	"RdioScannerFeedConfig.Enabled":   {Help: "Enable this feed. false keeps it configured but skipped."},
+	"RdioScannerFeedConfig.Name":      {Help: "Feed label for logs/metrics."},
+	"RdioScannerFeedConfig.URL":       {Label: "URL", Help: "RdioScanner ingest URL."},
+	"RdioScannerFeedConfig.APIKey":    {Label: "API key", Help: "RdioScanner API key."},
+	"RdioScannerFeedConfig.SystemID":  {Label: "System ID", Help: "RdioScanner system ID to upload under."},
+	"RdioScannerFeedConfig.Systems":   {Help: "GopherTrunk system names to stream. Empty = every system."},
+	"OpenMHzFeedConfig.Enabled":       {Help: "Enable this feed. false keeps it configured but skipped."},
+	"OpenMHzFeedConfig.Name":          {Help: "Feed label for logs/metrics."},
+	"OpenMHzFeedConfig.APIKey":        {Label: "API key", Help: "OpenMHz API key."},
+	"OpenMHzFeedConfig.ShortName":     {Help: "OpenMHz system short name."},
+	"OpenMHzFeedConfig.Systems":       {Help: "GopherTrunk system names to stream. Empty = every system."},
+	"IcecastFeedConfig.Enabled":       {Help: "Enable this feed. false keeps it configured but skipped."},
+	"IcecastFeedConfig.Name":          {Help: "Feed label for logs/metrics."},
+	"IcecastFeedConfig.Host":          {Help: "Icecast/ShoutCast server hostname."},
+	"IcecastFeedConfig.Port":          {Help: "Icecast/ShoutCast server port."},
+	"IcecastFeedConfig.Mount":         {Help: "Mountpoint path, e.g. /stream.mp3."},
+	"IcecastFeedConfig.Username":      {Help: "Source username (often 'source')."},
+	"IcecastFeedConfig.Password":      {Help: "Source password for the mountpoint."},
+	"IcecastFeedConfig.StreamName":    {Help: "Public stream name listeners see."},
+	"IcecastFeedConfig.Systems":       {Help: "GopherTrunk system names to stream. Empty = every system."},
+
+	// ---- Baseband ----------------------------------------------------------
+	"BasebandConfig.Record":       {Help: "Tap live tuners and write their wideband IQ to WAV."},
+	"BasebandConfig.Replay":       {Help: "Mount recorded WAVs as virtual tuners for offline decode."},
+	"BasebandRecordConfig.Serial": {Help: "SDR serial whose IQ stream is recorded."},
+	"BasebandRecordConfig.Dir":    {Label: "Directory", Help: "Directory the IQ recordings are written into."},
+	"BasebandReplayConfig.File":   {Help: "Path to the baseband WAV recording to replay."},
+	"BasebandReplayConfig.Serial": {Help: "Virtual device serial the pool reports. Empty generates one."},
+	"BasebandReplayConfig.Role":   {Help: "Pool role: control / voice / auto.", Options: roleOpts()},
+	"BasebandReplayConfig.Loop":   {Help: "Restart the recording on EOF for a continuous source. Default true."},
+
+	// ---- Paging ------------------------------------------------------------
+	"PagingConfig.POCSAG":               {Label: "POCSAG", Help: "POCSAG channels, each pinning one SDR to a paging frequency."},
+	"PagingConfig.FLEX":                 {Label: "FLEX", Help: "FLEX channels, each pinning one SDR to a paging frequency (1600 bps)."},
+	"PagingConfig.Wideband":             {Help: "Wideband groups fanning several paging channels off one SDR via a DDC bank."},
+	"PagingPOCSAGConfig.Serial":         {Help: "SDR serial to pin to this POCSAG channel."},
+	"PagingPOCSAGConfig.FrequencyHz":    {Label: "Frequency", Hz: true, Help: "POCSAG channel frequency."},
+	"PagingPOCSAGConfig.BaudHz":         {Label: "Baud", Help: "POCSAG bit rate. 1200 is most common; 512 legacy, 2400 high-throughput (DAPNET).", Options: baudOpts()},
+	"PagingFLEXConfig.Serial":           {Help: "SDR serial to pin to this FLEX channel."},
+	"PagingFLEXConfig.FrequencyHz":      {Label: "Frequency", Hz: true, Help: "FLEX channel frequency."},
+	"PagingWidebandConfig.Serial":       {Help: "SDR serial for this wideband paging group."},
+	"PagingWidebandConfig.CenterFreqHz": {Label: "Center frequency", Hz: true, Help: "Dongle centre frequency. 0 auto-computes the midpoint of the channels."},
+	"PagingWidebandConfig.Channels":     {Help: "Paging channels carved from this dongle's IQ band (any mix of POCSAG/FLEX)."},
+	"PagingWidebandChannel.Protocol":    {Help: "Decoder for this channel.", Options: opts("pocsag", "POCSAG", "flex", "FLEX")},
+	"PagingWidebandChannel.FrequencyHz": {Label: "Frequency", Hz: true, Help: "Channel frequency (must fall inside the group's IQ window)."},
+	"PagingWidebandChannel.BaudHz":      {Label: "Baud", Help: "POCSAG bit rate (FLEX ignores it).", Options: baudOpts()},
+
+	// ---- APRS --------------------------------------------------------------
+	"APRSConfig.Channels":           {Help: "APRS/AX.25 AFSK channels. 144.39 MHz is the North-America primary."},
+	"APRSChannelConfig.Serial":      {Help: "SDR serial to pin to this APRS channel."},
+	"APRSChannelConfig.FrequencyHz": {Label: "Frequency", Hz: true, Help: "APRS channel frequency (144.39 MHz NA primary)."},
+	"APRSChannelConfig.DropBadFCS":  {Label: "Drop bad FCS", Help: "Discard frames that fail the CRC instead of showing them flagged."},
+	"APRSChannelConfig.DropNonUI":   {Label: "Drop non-UI", Help: "Discard non-UI (connected-mode) AX.25 frames."},
+
+	// ---- AIS ---------------------------------------------------------------
+	"AISConfig.Channels":               {Help: "Marine AIS GMSK channels. Pin 161.975 (87B) and 162.025 (88B) to catch class-A alternation."},
+	"AISChannelConfig.Serial":          {Help: "SDR serial to pin to this AIS channel."},
+	"AISChannelConfig.FrequencyHz":     {Label: "Frequency", Hz: true, Help: "AIS channel frequency (161.975 / 162.025 MHz)."},
+	"AISChannelConfig.DropBadFCS":      {Label: "Drop bad FCS", Help: "Discard frames that fail the CRC instead of showing them flagged."},
+	"AISChannelConfig.DropNonPosition": {Help: "Keep only position reports, dropping other AIS message types."},
+
+	// ---- DSC ---------------------------------------------------------------
+	"DSCConfig.Channels":           {Help: "Marine DSC FFSK channels. VHF ch 70 = 156.525 MHz carries distress/safety alerts."},
+	"DSCChannelConfig.Serial":      {Help: "SDR serial to pin to this DSC channel."},
+	"DSCChannelConfig.FrequencyHz": {Label: "Frequency", Hz: true, Help: "DSC channel frequency (156.525 MHz = VHF ch 70)."},
+	"DSCChannelConfig.DropBadFCS":  {Label: "Drop bad FCS", Help: "Discard BCH-marginal sequences instead of showing them flagged."},
+
+	// ---- MDC1200 -----------------------------------------------------------
+	"MDC1200Config.Channels":           {Help: "Motorola MDC1200 FFSK channels. Target the conventional analog voice channels you monitor."},
+	"MDC1200ChannelConfig.Serial":      {Help: "SDR serial to pin to this MDC1200 channel."},
+	"MDC1200ChannelConfig.FrequencyHz": {Label: "Frequency", Hz: true, Help: "Analog voice channel frequency to watch for MDC1200 bursts."},
+	"MDC1200ChannelConfig.DropBadCRC":  {Label: "Drop bad CRC", Help: "Discard CRC-failed bursts instead of showing them flagged."},
+
+	// ---- ADS-B -------------------------------------------------------------
+	"ADSBConfig.BeastUpstreams":     {Help: "BEAST Mode-S upstreams (dump1090 / readsb), typically host:30005."},
+	"ADSBConfig.Channels":           {Help: "SDRs pinned to 1090 MHz for the native PPM Mode-S receiver."},
+	"ADSBBeastConfig.Addr":          {Label: "Address", Help: "BEAST upstream host:port (e.g. 127.0.0.1:30005)."},
+	"ADSBBeastConfig.Name":          {Help: "Label for logs/metrics."},
+	"ADSBChannelConfig.Serial":      {Help: "SDR serial to pin to 1090 MHz."},
+	"ADSBChannelConfig.FrequencyHz": {Label: "Frequency", Hz: true, Help: "Receiver frequency. 0 defaults to 1090 MHz. SDR must sample ≥ 2 Msps."},
+
+	// ---- M17 ---------------------------------------------------------------
+	"M17Config.Channels":           {Help: "M17 channels. Simplex calling is commonly 144.975 (2 m) / 433.475 MHz (70 cm)."},
+	"M17ChannelConfig.Serial":      {Help: "SDR serial to pin to this M17 channel."},
+	"M17ChannelConfig.FrequencyHz": {Label: "Frequency", Hz: true, Help: "M17 channel frequency."},
+}
+
+// FieldMetaFor returns the shared metadata for structName.field. An absent
+// entry yields the zero FieldMeta (humanized label, plain widget).
+func FieldMetaFor(structName, field string) FieldMeta {
+	return fieldMetas[structName+"."+field]
+}
+
+// FieldMetas returns the whole registry (the web builder serves it over
+// /api/v1/config/fieldmeta). The returned map is the live registry; callers
+// must not mutate it.
+func FieldMetas() map[string]FieldMeta {
+	return fieldMetas
+}

--- a/internal/configbuilder/fieldmeta_test.go
+++ b/internal/configbuilder/fieldmeta_test.go
@@ -1,0 +1,65 @@
+package configbuilder
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/config"
+)
+
+// TestFieldHelpCoverage is a load-bearing dual-editor guard: every exported
+// field of every config-package struct reachable from config.Config must have a
+// non-empty Help in the shared FieldMeta registry. A new field fails here until
+// help is authored — and because BOTH builders source their help from this
+// registry, the schema change can't ship without updating both.
+func TestFieldHelpCoverage(t *testing.T) {
+	seen := map[reflect.Type]bool{}
+	var missing []string
+	var walk func(rt reflect.Type)
+	walk = func(rt reflect.Type) {
+		for rt.Kind() == reflect.Ptr || rt.Kind() == reflect.Slice ||
+			rt.Kind() == reflect.Array || rt.Kind() == reflect.Map {
+			rt = rt.Elem()
+		}
+		if rt.Kind() != reflect.Struct || !strings.HasSuffix(rt.PkgPath(), "internal/config") {
+			return
+		}
+		if seen[rt] {
+			return
+		}
+		seen[rt] = true
+		// The top-level Config struct's fields are the 23 sections; their help
+		// is the section Instructions (checked by TestSectionMetaComplete), not
+		// a per-field entry. Recurse into them but don't require a FieldMeta.
+		isRoot := rt == reflect.TypeOf(config.Config{})
+		for i := 0; i < rt.NumField(); i++ {
+			f := rt.Field(i)
+			if !f.IsExported() {
+				continue
+			}
+			if !isRoot && FieldMetaFor(rt.Name(), f.Name).Help == "" {
+				missing = append(missing, rt.Name()+"."+f.Name+" ("+f.Type.String()+")")
+			}
+			walk(f.Type)
+		}
+	}
+	walk(reflect.TypeOf(config.Config{}))
+	if len(missing) > 0 {
+		t.Errorf("config fields missing Help in the shared FieldMeta registry (add an entry in fieldmeta.go for each — both Config Builders source help from it):\n  %s",
+			strings.Join(missing, "\n  "))
+	}
+}
+
+// TestSectionMetaComplete checks every Section has Instructions + a Docs link,
+// so the shared section help both builders render is never blank.
+func TestSectionMetaComplete(t *testing.T) {
+	for _, s := range Sections() {
+		if strings.TrimSpace(s.Instructions) == "" {
+			t.Errorf("section %q has no Instructions", s.Key)
+		}
+		if strings.TrimSpace(s.DocURL) == "" || strings.TrimSpace(s.DocTitle) == "" {
+			t.Errorf("section %q has no Docs link (DocTitle/DocURL)", s.Key)
+		}
+	}
+}

--- a/internal/configbuilder/sections.go
+++ b/internal/configbuilder/sections.go
@@ -1,44 +1,106 @@
 package configbuilder
 
-// SectionMeta names a top-level config section: Key is the snake/lowercase id
-// used by the nav, docs map, and validator buckets; CfgField is the Go
-// config.Config field name; Label is the display name. This is the Go source
-// of truth that the TUI's section list and the schema-drift test consume; the
-// web's SECTIONS array (web/configbuilder/src/sections/index.tsx) mirrors it.
+// SectionMeta names a top-level config section and carries its builder help:
+// Key is the snake/lowercase id (nav, docs, validator buckets); CfgField is the
+// Go config.Config field name; Label is the display name; Instructions is the
+// section help text; DocTitle/DocURL are the "open docs" link. This is the Go
+// source of truth that BOTH the web Config Builder (via /api/v1/config/docs)
+// and the terminal builder consume, so their section help stays identical.
 type SectionMeta struct {
-	Key      string
-	CfgField string
-	Label    string
+	Key          string
+	CfgField     string
+	Label        string
+	Instructions string
+	DocTitle     string
+	DocURL       string
 }
 
+const docsBase = "https://gophertrunk.org/"
+
 // Sections returns the canonical ordered section list (matching the web
-// builder's order).
+// builder's order) with help + docs.
 func Sections() []SectionMeta {
 	return []SectionMeta{
-		{"trunking", "Trunking", "Trunking"},
-		{"sdr", "SDR", "SDR"},
-		{"api", "API", "API & Web"},
-		{"scanner", "Scanner", "Scanner"},
-		{"audio", "Audio", "Audio"},
-		{"recordings", "Recordings", "Recordings"},
-		{"storage", "Storage", "Storage"},
-		{"retention", "Retention", "Retention"},
-		{"metrics", "Metrics", "Metrics"},
-		{"log", "Log", "Logging"},
-		{"diagnostics", "Diagnostics", "Diagnostics"},
-		{"radioreference", "RadioReference", "RadioReference"},
-		{"web", "Web", "Web UI"},
-		{"tone_out", "ToneOut", "Tone-out"},
-		{"broadcast", "Broadcast", "Broadcast"},
-		{"baseband", "Baseband", "Baseband"},
-		{"paging", "Paging", "Paging"},
-		{"aprs", "APRS", "APRS"},
-		{"ais", "AIS", "AIS"},
-		{"dsc", "DSC", "DSC"},
-		{"mdc1200", "MDC1200", "MDC1200"},
-		{"adsb", "ADSB", "ADS-B"},
-		{"m17", "M17", "M17"},
+		{"trunking", "Trunking", "Trunking",
+			"The trunked radio networks to follow. Each system needs a unique name, a protocol, and at least one control-channel frequency. Add systems by hand, by browsing RadioReference.com, or by importing a RadioReference PDF/CSV.",
+			"Trunking Systems", docsBase + "hunt.html"},
+		{"sdr", "SDR", "SDR",
+			"Sample rate (225 kHz–20 MHz) every tuner is programmed to, plus local devices and remote (rtl_tcp / SoapySDR) sources. P25 trunking needs separate control and voice dongles (distinct serials).",
+			"SDR Hardware", docsBase + "hardware.html"},
+		{"api", "API", "API & Web",
+			"HTTP/gRPC listen addresses and access control. allow_mutations lets the web UI write changes (talkgroup edits, settings, this builder's saves).",
+			"API & Web", docsBase + "web.html"},
+		{"scanner", "Scanner", "Scanner",
+			"Scan-list mode for the trunking engine plus the control-channel hunter and the conventional FM scan list.",
+			"Scanner", docsBase + "hunt.html"},
+		{"audio", "Audio", "Audio",
+			"Live playback of decoded voice. Sample rate (4000–48000 Hz) should match recordings.sample_rate. Volume is 0–1.",
+			"Audio", docsBase + "voice-calibration.html"},
+		{"recordings", "Recordings", "Recordings",
+			"Per-call WAV recorder output directory and sample rate (4000–48000 Hz), plus the optional blind equalizer.",
+			"Recordings", docsBase + "voice-calibration.html"},
+		{"storage", "Storage", "Storage",
+			"Where the call-log database and the control-channel cache live.",
+			"Storage", docsBase + "live-edits.html"},
+		{"retention", "Retention", "Retention",
+			"Background sweeper that ages out call-log rows and recorded files. Zero days disables the corresponding sweep.",
+			"Retention", docsBase + "live-edits.html"},
+		{"metrics", "Metrics", "Metrics",
+			"Mount a Prometheus /metrics endpoint on the API HTTP server.",
+			"Metrics", docsBase + "web.html"},
+		{"log", "Log", "Logging",
+			"Controls daemon log verbosity and output format, plus the optional decoded-message log.",
+			"Logging", docsBase + "live-edits.html"},
+		{"diagnostics", "Diagnostics", "Diagnostics",
+			"Verbose errors print full error chains + stack traces and expand API error envelopes (which expose host/dongle info). Enable only on trusted networks.",
+			"Diagnostics", docsBase + "hardening.html"},
+		{"radioreference", "RadioReference", "RadioReference",
+			"Read-only RadioReference.com API credentials. Used by the hunt duplicate check and by this builder's RadioReference browse/import. Can also be supplied via GOPHERTRUNK_RR_KEY / _USER / _PASS env vars instead of storing the secret here.",
+			"RadioReference", docsBase + "hunt.html"},
+		{"web", "Web", "Web UI",
+			"Show or hide navigation tabs in the operator console. Unchecked tabs are hidden from the nav (the route stays reachable by URL).",
+			"Web UI", docsBase + "web.html"},
+		{"tone_out", "ToneOut", "Tone-out",
+			"Two-tone / single-tone paging detection. Supply two tones (A then B) for sequential paging, or one for single-tone supervision. Durations are Go duration strings (e.g. 250ms, 1.5s).",
+			"Tone-out", docsBase + "pocsag.html"},
+		{"broadcast", "Broadcast", "Broadcast",
+			"Stream completed calls out to aggregators (Broadcastify, RdioScanner, OpenMHz) or a live Icecast/ShoutCast mount. A feed with enabled=false is kept but skipped.",
+			"Broadcast", docsBase + "web.html"},
+		{"baseband", "Baseband", "Baseband",
+			"Wideband IQ recording and offline replay. 'Record' taps live tuners to WAV; 'Replay' mounts recorded WAVs as virtual tuners (record at sdr.sample_rate for real-time-correct playback).",
+			"Baseband", docsBase + "constellation.html"},
+		{"paging", "Paging", "Paging",
+			"POCSAG and FLEX pager decoders. The POCSAG / FLEX lists each pin one SDR to a single paging frequency; a Wideband group fans several channels off one SDR via a DDC bank.",
+			"Paging", docsBase + "pocsag.html"},
+		{"aprs", "APRS", "APRS",
+			"APRS / AX.25 Bell-202 AFSK receiver. Each channel pins an SDR to an APRS frequency (144.39 MHz is the North-America primary).",
+			"APRS", docsBase + "aprs.html"},
+		{"ais", "AIS", "AIS",
+			"Marine AIS GMSK receiver. Class-A vessels alternate between 161.975 MHz (87B) and 162.025 MHz (88B); pin one SDR to each to catch both.",
+			"AIS", docsBase + "ais.html"},
+		{"dsc", "DSC", "DSC",
+			"Marine Digital Selective Calling receiver. VHF channel 70 (156.525 MHz) carries distress/urgency/safety alerts and routine call-ups.",
+			"DSC", docsBase + "dsc.html"},
+		{"mdc1200", "MDC1200", "MDC1200",
+			"Motorola MDC1200 FFSK signaling receiver. Target the conventional analog voice channels you monitor — bursts ride at the head/tail of each transmission.",
+			"MDC1200", docsBase + "mdc1200.html"},
+		{"adsb", "ADSB", "ADS-B",
+			"Aircraft tracking. Consume Mode-S frames from a BEAST upstream (dump1090 / readsb, typically host:30005), or pin an SDR to 1090 MHz for the native PPM receiver.",
+			"ADS-B", docsBase + "adsb.html"},
+		{"m17", "M17", "M17",
+			"M17 digital-voice link-layer receiver (decodes link-setup metadata). Simplex calling is commonly 144.975 MHz (2 m) / 433.475 MHz (70 cm).",
+			"M17", docsBase + "m17.html"},
 	}
+}
+
+// SectionByKey returns the section metadata for a snake/lowercase key.
+func SectionByKey(key string) (SectionMeta, bool) {
+	for _, s := range Sections() {
+		if s.Key == key {
+			return s, true
+		}
+	}
+	return SectionMeta{}, false
 }
 
 // SectionOf extracts the top-level config section key from a validation error

--- a/internal/configtui/actions.go
+++ b/internal/configtui/actions.go
@@ -67,6 +67,12 @@ func (m Model) startSave() (tea.Model, tea.Cmd) {
 // comment-preserving on overwrite). Errors are surfaced as toasts.
 func (m *Model) doSave(path string) {
 	dir := dirOf(path)
+	// Create missing parent folders so saving to a new subdirectory just
+	// works (the web builder has an explicit create-folder dialog).
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		m.pushErr("create dir: " + err.Error())
+		return
+	}
 	for rel, rows := range m.talkgroups {
 		if err := configbuilder.WriteTalkgroupCSV(joinPath(dir, rel), rows); err != nil {
 			m.pushErr("talkgroup " + rel + ": " + err.Error())

--- a/internal/configtui/meta.go
+++ b/internal/configtui/meta.go
@@ -5,6 +5,10 @@
 // polish — labels, help, select options, Hz formatting, fieldset grouping and
 // the AdvancedJSON long-tail. It operates on the local filesystem via the
 // config package directly (no daemon, no browser).
+//
+// The labels / help / select options / Hz+freq-list flags all come from the
+// shared registry in internal/configbuilder (sections.go + fieldmeta.go) so the
+// terminal builder and the web builder present identical help from one source.
 package configtui
 
 import (
@@ -18,9 +22,9 @@ import (
 // selOpt is one select option (value + display label).
 type selOpt struct{ Value, Label string }
 
-// fieldMeta overrides the reflection defaults for one struct field, keyed
-// "StructName.FieldName". Absent ⇒ label is the humanized field name and the
-// widget is derived from the Go kind.
+// fieldMeta is the TUI-side view of a field's metadata, projected from the
+// shared configbuilder.FieldMeta. Absent ⇒ label is the humanized field name
+// and the widget is derived from the Go kind.
 type fieldMeta struct {
 	Label    string
 	Help     string
@@ -30,79 +34,16 @@ type fieldMeta struct {
 	Hidden   bool
 }
 
-func role4() []selOpt {
-	return []selOpt{{"", "(auto)"}, {"control", "control"}, {"voice", "voice"}, {"auto", "auto"}}
-}
-
-// metaTable mirrors the web sections' SelectField options, HzField/FreqList
-// usage, and labels. Only fields needing polish appear; everything else uses
-// reflection defaults (and is still fully editable).
-var metaTable = map[string]fieldMeta{
-	// Log
-	"LogConfig.Level":  {Options: []selOpt{{"", "(default: info)"}, {"debug", "debug"}, {"info", "info"}, {"warn", "warn"}, {"error", "error"}}},
-	"LogConfig.Format": {Options: []selOpt{{"", "(default: text)"}, {"text", "text"}, {"json", "json"}}},
-	// API auth / cors
-	"APIAuthConfig.Mode": {Options: []selOpt{{"", "(auto)"}, {"auto", "auto"}, {"required", "required"}, {"disabled", "disabled"}}},
-	// SDR devices
-	"DeviceConfig.Role":                {Options: []selOpt{{"", "(auto)"}, {"control", "control"}, {"voice", "voice"}, {"auto", "auto"}, {"wideband", "wideband"}}},
-	"DeviceConfig.CenterFreqHz":        {Hz: true},
-	"DeviceConfig.TunerStrategy":       {Options: []selOpt{{"", "(auto)"}, {"ddc", "ddc"}, {"polyphase", "polyphase"}}},
-	"DeviceChannelConfig.FrequencyHz":  {Hz: true, Label: "Frequency"},
-	"RTLTCPConfig.Role":                {Options: role4()},
-	"SoapyRemoteConfig.Role":           {Options: role4()},
-	"SoapyRemoteConfig.Format":         {Options: []selOpt{{"", "(default)"}, {"CS16", "CS16"}, {"CF32", "CF32"}}},
-	"SoapyRemoteConfig.StreamProtocol": {Options: []selOpt{{"", "(default)"}, {"tcp", "tcp"}}},
-	// Trunking systems
-	"SystemConfig.Protocol":              {Options: protocolOpts()},
-	"SystemConfig.ControlChannels":       {FreqList: true, Label: "Control channels"},
-	"P25BandPlanEntryConfig.BaseHz":      {Hz: true},
-	"P25BandPlanEntryConfig.SpacingHz":   {Hz: true},
-	"P25BandPlanEntryConfig.BandwidthHz": {Hz: true},
-	"DMRLinearBandPlanConfig.BaseHz":     {Hz: true},
-	"DMRLinearBandPlanConfig.SpacingHz":  {Hz: true},
-	"DMRBandPlanTableEntryConfig.FreqHz": {Hz: true},
-	"EncryptionKeyConfig.Algorithm":      {Options: []selOpt{{"rc4", "rc4 (DMR Enhanced Privacy)"}}},
-	// Scanner
-	"ScannerConfig.ScanMode":        {Options: []selOpt{{"", "(default: all)"}, {"all", "all"}, {"list", "list"}}},
-	"ConvChannelConfig.FrequencyHz": {Hz: true},
-	"ConvChannelConfig.Mode":        {Options: []selOpt{{"", "(fm)"}, {"fm", "fm"}, {"nfm", "nfm"}}},
-	"ConvToneConfig.Mode":           {Options: []selOpt{{"", "none"}, {"none", "none"}, {"ctcss", "ctcss"}, {"dcs", "dcs"}}},
-	// Baseband
-	"BasebandReplayConfig.Role": {Options: role4()},
-	// Paging
-	"PagingPOCSAGConfig.FrequencyHz":    {Hz: true},
-	"PagingPOCSAGConfig.BaudHz":         {Options: baudOpts()},
-	"PagingFLEXConfig.FrequencyHz":      {Hz: true},
-	"PagingWidebandConfig.CenterFreqHz": {Hz: true},
-	"PagingWidebandChannel.Protocol":    {Options: []selOpt{{"pocsag", "POCSAG"}, {"flex", "FLEX"}}},
-	"PagingWidebandChannel.FrequencyHz": {Hz: true},
-	"PagingWidebandChannel.BaudHz":      {Options: baudOpts()},
-	// Decoder channels
-	"APRSChannelConfig.FrequencyHz":    {Hz: true},
-	"AISChannelConfig.FrequencyHz":     {Hz: true},
-	"DSCChannelConfig.FrequencyHz":     {Hz: true},
-	"MDC1200ChannelConfig.FrequencyHz": {Hz: true},
-	"ADSBChannelConfig.FrequencyHz":    {Hz: true},
-	"M17ChannelConfig.FrequencyHz":     {Hz: true},
-}
-
-func protocolOpts() []selOpt {
-	ps := []string{"p25", "p25-phase2", "dmr", "dmr-tier2", "dmr-tier1", "nxdn", "dpmr",
-		"edacs", "motorola", "ltr", "mpt1327", "tetra", "ysf", "dstar"}
-	out := make([]selOpt, len(ps))
-	for i, p := range ps {
-		out[i] = selOpt{p, p}
+// metaFor returns the metadata for structName.field (zero value if none),
+// projected from the shared configbuilder registry so the TUI and web builder
+// stay identical.
+func metaFor(structName, field string) fieldMeta {
+	fm := configbuilder.FieldMetaFor(structName, field)
+	out := fieldMeta{Label: fm.Label, Help: fm.Help, Hz: fm.Hz, FreqList: fm.FreqList}
+	for _, o := range fm.Options {
+		out.Options = append(out.Options, selOpt{Value: o.Value, Label: o.Label})
 	}
 	return out
-}
-
-func baudOpts() []selOpt {
-	return []selOpt{{"512", "512"}, {"1200", "1200"}, {"2400", "2400"}}
-}
-
-// metaFor returns the metadata for structName.field (zero value if none).
-func metaFor(structName, field string) fieldMeta {
-	return metaTable[structName+"."+field]
 }
 
 // isAdvanced reports whether a field is in the AdvancedJSON long-tail.

--- a/internal/configtui/meta_drift_test.go
+++ b/internal/configtui/meta_drift_test.go
@@ -106,3 +106,53 @@ func TestReflectionReachesEverySection(t *testing.T) {
 		}
 	}
 }
+
+// TestEveryLeafEditable is the load-bearing dual-editor guard: it walks every
+// field of every config-package struct reachable from config.Config and
+// asserts the reflection form engine assigns a HANDLED widget kind (never
+// kindUnsupported). A new field of a kind the TUI can't edit (e.g.
+// map[string]string, []int, time.Duration, a foreign struct) fails here — so a
+// config-schema change cannot land without the TUI being taught to edit it
+// (the web side is guarded by configbuilder.TestConfigSchemaCoveredByWebBuilder).
+func TestEveryLeafEditable(t *testing.T) {
+	seen := map[reflect.Type]bool{}
+	var walk func(t reflect.Type)
+	var bad []string
+	walk = func(rt reflect.Type) {
+		for rt.Kind() == reflect.Ptr {
+			rt = rt.Elem()
+		}
+		if rt.Kind() != reflect.Struct || !strings.HasSuffix(rt.PkgPath(), "internal/config") {
+			return
+		}
+		if seen[rt] {
+			return
+		}
+		seen[rt] = true
+		for i := 0; i < rt.NumField(); i++ {
+			f := rt.Field(i)
+			if !f.IsExported() {
+				continue
+			}
+			m := metaFor(rt.Name(), f.Name)
+			if m.Hidden {
+				continue
+			}
+			if kindOf(f, m) == kindUnsupported {
+				bad = append(bad, rt.Name()+"."+f.Name+" ("+f.Type.String()+")")
+			}
+			// Recurse into nested config structs (incl. through slices/ptrs/maps).
+			ft := f.Type
+			for ft.Kind() == reflect.Ptr || ft.Kind() == reflect.Slice ||
+				ft.Kind() == reflect.Array || ft.Kind() == reflect.Map {
+				ft = ft.Elem()
+			}
+			walk(ft)
+		}
+	}
+	walk(reflect.TypeOf(config.Config{}))
+	if len(bad) > 0 {
+		t.Errorf("config fields the TUI cannot edit (add a widget kind in kindOf, or metadata, for each):\n  %s",
+			strings.Join(bad, "\n  "))
+	}
+}

--- a/internal/configtui/meta_drift_test.go
+++ b/internal/configtui/meta_drift_test.go
@@ -43,15 +43,15 @@ func collectConfigFields() map[string]map[string]bool {
 	return out
 }
 
-// TestMetaTableFieldsExist fails if a metadata override references a config
-// field that no longer exists (renamed/removed) — keeping the TUI's polish in
-// sync with the schema.
-func TestMetaTableFieldsExist(t *testing.T) {
+// TestFieldMetaKeysExist fails if the shared field-metadata registry references
+// a config field that no longer exists (renamed/removed) — keeping the builders'
+// polish in sync with the schema.
+func TestFieldMetaKeysExist(t *testing.T) {
 	fields := collectConfigFields()
-	for key := range metaTable {
+	for key := range configbuilder.FieldMetas() {
 		parts := strings.SplitN(key, ".", 2)
 		if len(parts) != 2 || !fields[parts[0]][parts[1]] {
-			t.Errorf("metaTable key %q does not match any config field", key)
+			t.Errorf("FieldMetas key %q does not match any config field", key)
 		}
 	}
 }

--- a/internal/configtui/modal.go
+++ b/internal/configtui/modal.go
@@ -1,6 +1,8 @@
 package configtui
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/charmbracelet/bubbles/textinput"
@@ -60,26 +62,80 @@ type fileEntry struct {
 	valid bool
 }
 
+type openMode int
+
+const (
+	openBrowse openMode = iota
+	openRename
+	openConfirmDelete
+)
+
 type openModal struct {
+	dirs  []string
 	files []fileEntry
 	idx   int
+	mode  openMode
+	input textinput.Model
+	err   string
 }
 
 func newOpenModal(m *Model) modal {
-	var files []fileEntry
-	for _, d := range m.dirs {
+	o := &openModal{dirs: m.dirs, input: textinput.New()}
+	o.refresh()
+	return o
+}
+
+func (o *openModal) refresh() {
+	o.files = nil
+	for _, d := range o.dirs {
 		for _, p := range config.DirConfigFiles(d) {
 			valid := true
 			if _, err := config.Load(p); err != nil {
 				valid = false
 			}
-			files = append(files, fileEntry{path: p, valid: valid})
+			o.files = append(o.files, fileEntry{path: p, valid: valid})
 		}
 	}
-	return &openModal{files: files}
+	if o.idx >= len(o.files) {
+		o.idx = max(0, len(o.files)-1)
+	}
 }
 
 func (o *openModal) Update(msg tea.KeyMsg, m *Model) (modal, tea.Cmd) {
+	switch o.mode {
+	case openRename:
+		switch msg.String() {
+		case "esc":
+			o.mode = openBrowse
+		case "enter":
+			from := o.files[o.idx].path
+			to := joinPath(dirOf(from), strings.TrimSpace(o.input.Value()))
+			if err := os.Rename(from, to); err != nil {
+				o.err = err.Error()
+			}
+			o.mode = openBrowse
+			o.refresh()
+		default:
+			var cmd tea.Cmd
+			o.input, cmd = o.input.Update(msg)
+			return o, cmd
+		}
+		return o, nil
+	case openConfirmDelete:
+		switch msg.String() {
+		case "y", "enter":
+			if err := os.Remove(o.files[o.idx].path); err != nil {
+				o.err = err.Error()
+			}
+			o.mode = openBrowse
+			o.refresh()
+		case "n", "esc":
+			o.mode = openBrowse
+		}
+		return o, nil
+	}
+
+	// browse
 	switch msg.String() {
 	case "esc", "q":
 		return nil, nil
@@ -94,13 +150,30 @@ func (o *openModal) Update(msg tea.KeyMsg, m *Model) (modal, tea.Cmd) {
 	case "enter":
 		if len(o.files) > 0 {
 			m.loadPath(o.files[o.idx].path)
+			return nil, nil
 		}
-		return nil, nil
+	case "r":
+		if len(o.files) > 0 {
+			o.mode = openRename
+			o.input.SetValue(filepath.Base(o.files[o.idx].path))
+			o.input.CursorEnd()
+			o.input.Focus()
+		}
+	case "d":
+		if len(o.files) > 0 {
+			o.mode = openConfirmDelete
+		}
 	}
 	return o, nil
 }
 
 func (o *openModal) View(w, h int) string {
+	if o.mode == openRename {
+		return boxTitle("Rename file", "rename: "+o.input.View()+"\n\n[enter] rename   [esc] cancel")
+	}
+	if o.mode == openConfirmDelete {
+		return boxTitle("Delete file", "Delete "+o.files[o.idx].path+" ?\n\n[y] yes   [n] no")
+	}
 	if len(o.files) == 0 {
 		return boxTitle("Open config", "No config files found in the discovery directories.\n\n[esc] cancel")
 	}
@@ -116,7 +189,11 @@ func (o *openModal) View(w, h int) string {
 		}
 		b.WriteString(cursor + f.path + flag + "\n")
 	}
-	b.WriteString("\n[↑↓] move   [enter] open   [esc] cancel")
+	if o.err != "" {
+		b.WriteString(stErr.Render("! " + o.err))
+		b.WriteString("\n")
+	}
+	b.WriteString("\n[↑↓] move   [enter] open   [r] rename   [d] delete   [esc] cancel")
 	return boxTitle("Open config", b.String())
 }
 
@@ -156,7 +233,8 @@ func (s *saveModal) Update(msg tea.KeyMsg, m *Model) (modal, tea.Cmd) {
 }
 
 func (s *saveModal) View(w, h int) string {
-	return boxTitle("Save config as", s.input.View()+"\n\n[enter] save   [esc] cancel")
+	return boxTitle("Save config as",
+		s.input.View()+"\n\nMissing parent folders are created automatically.\n[enter] save   [esc] cancel")
 }
 
 // ---- yaml preview ----

--- a/internal/configtui/modal_rr.go
+++ b/internal/configtui/modal_rr.go
@@ -3,6 +3,7 @@ package configtui
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/charmbracelet/bubbles/textinput"
@@ -19,6 +20,7 @@ const (
 	rrStates
 	rrCounties
 	rrZip
+	rrID
 	rrSystems
 	rrError
 )
@@ -32,6 +34,8 @@ type rrModal struct {
 
 	modeIdx int
 	zip     textinput.Model
+	idInput textinput.Model
+	idState bool // by-ID: true = state id (stid), false = county id (ctid)
 
 	geos []radioreference.GeoRef // states or counties
 	hits []radioreference.SearchHit
@@ -47,7 +51,9 @@ func newRRModal(m *Model) modal {
 	}
 	zi := textinput.New()
 	zi.Prompt = "ZIP: "
-	return &rrModal{client: c, step: rrMode, zip: zi}
+	ii := textinput.New()
+	ii.Prompt = "ID: "
+	return &rrModal{client: c, step: rrMode, zip: zi, idInput: ii}
 }
 
 func (r *rrModal) ctx() context.Context { return context.Background() }
@@ -59,7 +65,7 @@ func (r *rrModal) Update(msg tea.KeyMsg, m *Model) (modal, tea.Cmd) {
 		case rrCounties:
 			r.step, r.idx = rrStates, 0
 			return r, nil
-		case rrSystems:
+		case rrZip, rrID, rrSystems:
 			r.step, r.idx = rrMode, 0
 			return r, nil
 		default:
@@ -73,6 +79,8 @@ func (r *rrModal) Update(msg tea.KeyMsg, m *Model) (modal, tea.Cmd) {
 		return r.updateMode(msg, m)
 	case rrZip:
 		return r.updateZip(msg, m)
+	case rrID:
+		return r.updateID(msg, m)
 	case rrStates, rrCounties, rrSystems:
 		return r.updateList(msg, m)
 	}
@@ -86,23 +94,56 @@ func (r *rrModal) updateMode(msg tea.KeyMsg, m *Model) (modal, tea.Cmd) {
 			r.modeIdx--
 		}
 	case "down", "j":
-		if r.modeIdx < 1 {
+		if r.modeIdx < 2 {
 			r.modeIdx++
 		}
 	case "enter":
-		if r.modeIdx == 0 { // by state/county
+		switch r.modeIdx {
+		case 0: // by state/county
 			geos, err := r.client.GetStateList(r.ctx())
 			if err != nil {
 				r.err = err.Error()
 				return r, nil
 			}
 			r.geos, r.idx, r.step = geos, 0, rrStates
-		} else { // by ZIP
+		case 1: // by ZIP
 			r.zip.Focus()
 			r.step = rrZip
+		case 2: // by numeric ID
+			r.idInput.Focus()
+			r.step = rrID
 		}
 	}
 	return r, nil
+}
+
+func (r *rrModal) updateID(msg tea.KeyMsg, m *Model) (modal, tea.Cmd) {
+	switch msg.String() {
+	case "tab":
+		r.idState = !r.idState
+		return r, nil
+	case "enter":
+		n, err := strconv.Atoi(strings.TrimSpace(r.idInput.Value()))
+		if err != nil {
+			r.err = "id must be numeric"
+			return r, nil
+		}
+		var hits []radioreference.SearchHit
+		if r.idState {
+			hits, err = r.client.SearchByState(r.ctx(), n)
+		} else {
+			hits, err = r.client.SearchByCounty(r.ctx(), n)
+		}
+		if err != nil {
+			r.err = err.Error()
+			return r, nil
+		}
+		r.hits, r.idx, r.step = hits, 0, rrSystems
+		return r, nil
+	}
+	var cmd tea.Cmd
+	r.idInput, cmd = r.idInput.Update(msg)
+	return r, cmd
 }
 
 func (r *rrModal) updateZip(msg tea.KeyMsg, m *Model) (modal, tea.Cmd) {
@@ -177,7 +218,7 @@ func (r *rrModal) View(w, h int) string {
 	case rrError:
 		return boxTitle("RadioReference", stErr.Render(r.err)+"\n\n[esc] close")
 	case rrMode:
-		opts := []string{"By state / county", "By ZIP code"}
+		opts := []string{"By state / county", "By ZIP code", "By ID (county/state)"}
 		var b strings.Builder
 		for i, o := range opts {
 			cur := "  "
@@ -190,6 +231,13 @@ func (r *rrModal) View(w, h int) string {
 		return boxTitle("Browse RadioReference", b.String())
 	case rrZip:
 		return boxTitle("Browse RadioReference — ZIP", r.zip.View()+r.errLine()+"\n\n[enter] search  [esc] cancel")
+	case rrID:
+		kind := "county id (ctid)"
+		if r.idState {
+			kind = "state id (stid)"
+		}
+		return boxTitle("Browse RadioReference — ID",
+			r.idInput.View()+"\nlooking up: "+kind+r.errLine()+"\n\n[tab] county/state  [enter] search  [esc] back")
 	default:
 		return boxTitle("Browse RadioReference — "+r.stepLabel(), r.listView()+r.errLine())
 	}

--- a/internal/configtui/model_test.go
+++ b/internal/configtui/model_test.go
@@ -31,6 +31,8 @@ func key(s string) tea.KeyMsg {
 		return tea.KeyMsg{Type: tea.KeyUp}
 	case "space":
 		return tea.KeyMsg{Type: tea.KeySpace}
+	case "backspace":
+		return tea.KeyMsg{Type: tea.KeyBackspace}
 	}
 	return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(s)}
 }
@@ -207,5 +209,72 @@ func TestSaveReloadRoundTrip(t *testing.T) {
 	rows := m2.talkgroups["metro.csv"]
 	if len(rows) != 1 || rows[0].Decimal != 101 || rows[0].AlphaTag != "PD" {
 		t.Fatalf("talkgroups did not round-trip: %+v", rows)
+	}
+}
+
+func TestOpenModalFileOps(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := config.WriteConfigFile(dir+"/a.yaml", config.Default(), 0, true); err != nil {
+		t.Fatal(err)
+	}
+	m := New([]string{dir}, radioreference.Auth{}, nil, "")
+	m.width, m.height = 120, 40
+
+	m = send(m, "o") // open modal lists a.yaml
+	if m.modal == nil {
+		t.Fatalf("expected open modal")
+	}
+	// Rename a.yaml -> b.yaml.
+	m = send(m, "r")
+	for i := 0; i < len("a.yaml"); i++ {
+		m = send(m, "backspace")
+	}
+	m = send(m, "b", ".", "y", "a", "m", "l")
+	m = send(m, "enter")
+	if _, err := os.Stat(dir + "/b.yaml"); err != nil {
+		t.Fatalf("rename target missing: %v", err)
+	}
+	if _, err := os.Stat(dir + "/a.yaml"); !os.IsNotExist(err) {
+		t.Fatalf("old name should be gone")
+	}
+	// Delete b.yaml.
+	m = send(m, "d", "y")
+	if _, err := os.Stat(dir + "/b.yaml"); !os.IsNotExist(err) {
+		t.Fatalf("file should be deleted")
+	}
+}
+
+func TestListConfirmRemove(t *testing.T) {
+	m := newTestModel()
+	m.cfg.Trunking.Systems = []config.SystemConfig{
+		{Name: "A", Protocol: "p25"}, {Name: "B", Protocol: "p25"},
+	}
+	m = gotoSection(m, "trunking")
+	m = send(m, "enter") // drill into Systems list
+	m = send(m, "d")     // request remove of item 0
+	if m.modal == nil {
+		t.Fatalf("expected confirm modal before removal")
+	}
+	if len(m.cfg.Trunking.Systems) != 2 {
+		t.Fatalf("nothing should be removed before confirm")
+	}
+	m = send(m, "y") // confirm
+	if len(m.cfg.Trunking.Systems) != 1 || m.cfg.Trunking.Systems[0].Name != "B" {
+		t.Fatalf("expected only B to remain, got %+v", m.cfg.Trunking.Systems)
+	}
+}
+
+func TestRRModalByIDMode(t *testing.T) {
+	m := newTestModel() // empty RR auth → error step, but mode nav still safe
+	m = gotoSection(m, "trunking")
+	m = send(m, "enter") // Systems list
+	m = send(m, "r")     // RR modal
+	if m.modal == nil {
+		t.Fatalf("expected RR modal")
+	}
+	// Without creds the modal is in the error step; esc closes without panic.
+	m = send(m, "esc")
+	if m.modal != nil {
+		t.Fatalf("expected modal closed")
 	}
 }

--- a/internal/configtui/reflectform.go
+++ b/internal/configtui/reflectform.go
@@ -17,10 +17,11 @@ const (
 	kindBoolPtr // *bool tri-state (default/true/false)
 	kindStringList
 	kindFreqList
-	kindList   // []struct → drill into a list view
-	kindStruct // nested struct → drill into a sub-form
-	kindPtr    // *struct → enable/clear + drill
-	kindMap    // map[string]bool → drill into a toggle list
+	kindList        // []struct → drill into a list view
+	kindStruct      // nested struct → drill into a sub-form
+	kindPtr         // *struct → enable/clear + drill
+	kindMap         // map[string]bool → drill into a toggle list
+	kindUnsupported // a kind the engine can't edit (guarded by a test)
 )
 
 // formRow describes one editable row in a struct form view.
@@ -117,7 +118,10 @@ func kindOf(f reflect.StructField, m fieldMeta) rowKind {
 		if el.Kind() == reflect.Struct {
 			return kindList
 		}
-		return kindStringList
+		if el.Kind() == reflect.String {
+			return kindStringList
+		}
+		return kindUnsupported // e.g. []int — would corrupt on commit
 	case reflect.Ptr:
 		if ft.Elem().Kind() == reflect.Bool {
 			return kindBoolPtr
@@ -125,13 +129,17 @@ func kindOf(f reflect.StructField, m fieldMeta) rowKind {
 		if ft.Elem().Kind() == reflect.Struct {
 			return kindPtr
 		}
-		return kindText
+		return kindUnsupported
 	case reflect.Struct:
 		return kindStruct
 	case reflect.Map:
-		return kindMap
+		// Only map[string]bool (web.tabs) has a real editor today.
+		if ft.Key().Kind() == reflect.String && ft.Elem().Kind() == reflect.Bool {
+			return kindMap
+		}
+		return kindUnsupported
 	}
-	return kindText
+	return kindUnsupported
 }
 
 // structNameOf returns the element struct type name of a value (deref ptr).

--- a/internal/configtui/update.go
+++ b/internal/configtui/update.go
@@ -57,7 +57,7 @@ func (m Model) updateKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if m.focus == zoneSections {
 			return m.requestQuit()
 		}
-	case "s":
+	case "s", "ctrl+s":
 		return m.startSave()
 	case "n":
 		return m.requestNew()
@@ -236,8 +236,12 @@ func (m Model) updateList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.markDirty()
 	case "d":
 		if n > 0 {
-			removeItem(slice, m.cursor)
-			m.markDirty()
+			idx := m.cursor
+			m.modal = newConfirmModal("Remove this item?", func(mm *Model) tea.Cmd {
+				removeItem(mm.cur(), idx)
+				mm.markDirty()
+				return nil
+			})
 		}
 	case "D":
 		if n > 0 {

--- a/internal/configtui/view.go
+++ b/internal/configtui/view.go
@@ -70,6 +70,18 @@ func (m Model) viewForm() string {
 	var b strings.Builder
 	b.WriteString(stTitle.Render(m.breadcrumb(sec)) + "\n")
 
+	// Section instructions + docs link (only at the section root, so drilling
+	// into a sub-form doesn't repeat the banner). Sourced from the shared
+	// configbuilder registry, identical to the web builder.
+	if len(m.navpath) == 0 {
+		if sec.Instructions != "" {
+			b.WriteString(stMuted.Render(sec.Instructions) + "\n")
+		}
+		if sec.DocURL != "" {
+			b.WriteString(stMuted.Render("docs: "+sec.DocURL) + "\n")
+		}
+	}
+
 	// Per-section validation banner.
 	if errs := m.validation[sec.Key]; len(errs) > 0 {
 		for _, e := range errs {

--- a/internal/configtui/widgets.go
+++ b/internal/configtui/widgets.go
@@ -69,6 +69,8 @@ func displayValue(fv reflect.Value, r formRow) string {
 		return "set  →"
 	case kindMap:
 		return fmt.Sprintf("%d set  →", nonDefaultMapCount(fv))
+	case kindUnsupported:
+		return "(unsupported — edit in file)"
 	}
 	return ""
 }

--- a/web/configbuilder/src/api/client.ts
+++ b/web/configbuilder/src/api/client.ts
@@ -3,6 +3,7 @@ import type {
   ConfigLoadResponse,
   ConfigSaveResponse,
   DocLink,
+  FieldMeta,
   GTConfig,
   ParsedSystemDTO,
   RRGeoRef,
@@ -72,6 +73,7 @@ export const api = {
   mkdir: (path: string) => req<{ path: string }>("POST", "/config/dir", { path }),
   defaults: () => req<GTConfig>("GET", "/config/defaults"),
   docs: () => req<Record<string, DocLink>>("GET", "/config/docs"),
+  fieldmeta: () => req<Record<string, FieldMeta>>("GET", "/config/fieldmeta"),
   validate: (config: GTConfig, section?: string) =>
     req<ValidationResult>("POST", "/config/validate", { config, section: section ?? "" }),
   marshal: (config: GTConfig) =>

--- a/web/configbuilder/src/api/types.ts
+++ b/web/configbuilder/src/api/types.ts
@@ -467,6 +467,22 @@ export interface DocLink {
   title: string;
   url: string;
   description: string;
+  // instructions is the shared section help text, sourced from the Go
+  // configbuilder.Sections() registry so the web and terminal builders show
+  // identical section help. (description mirrors it for the Docs-link tooltip.)
+  instructions: string;
+}
+
+// FieldMeta is one entry of the shared per-field metadata registry served by
+// GET /api/v1/config/fieldmeta, keyed "StructName.FieldName". The web feeds
+// its help into the field widgets so per-field help comes from the same Go
+// source the terminal builder uses.
+export interface FieldMeta {
+  label?: string;
+  help?: string;
+  options?: { value: string; label: string }[];
+  hz?: boolean;
+  freqList?: boolean;
 }
 
 export interface RRGeoRef {

--- a/web/configbuilder/src/components/Section.tsx
+++ b/web/configbuilder/src/components/Section.tsx
@@ -4,22 +4,28 @@ import { useStore } from "../store/shared";
 // Section wraps a config section editor with its title, instructions, a
 // "Docs ↗" link (opens in a new tab), and a live validation badge driven
 // by the section's entry in the whole-config validation result.
+//
+// Instructions come from the shared docs registry (Go configbuilder.Sections,
+// served over /config/docs) so the web and terminal builders show identical
+// section help from one source. The optional `instructions` prop is only a
+// fallback for before the registry has loaded.
 export function Section(props: {
   sectionKey: string;
   title: string;
-  instructions: ReactNode;
+  instructions?: ReactNode;
   children: ReactNode;
 }) {
   const docs = useStore((s) => s.docs[props.sectionKey]);
   const validation = useStore((s) => s.validation);
   const errs = (validation?.errors ?? []).filter((e) => e.section === props.sectionKey);
+  const instructions = docs?.instructions ?? props.instructions;
 
   return (
     <div className="space-y-4">
       <div className="flex items-start justify-between gap-3">
         <div>
           <h2 className="text-lg font-semibold">{props.title}</h2>
-          <p className="help mt-1 max-w-2xl">{props.instructions}</p>
+          {instructions ? <p className="help mt-1 max-w-2xl">{instructions}</p> : null}
         </div>
         {docs ? (
           <a

--- a/web/configbuilder/src/sections/ADSB.tsx
+++ b/web/configbuilder/src/sections/ADSB.tsx
@@ -11,7 +11,6 @@ export function ADSBSection() {
     <Section
       sectionKey="adsb"
       title="ADS-B"
-      instructions="Aircraft tracking. Consume Mode-S frames from a BEAST upstream (dump1090 / readsb, typically host:30005), or pin an SDR to 1090 MHz for the native PPM receiver."
     >
       <Fieldset legend="BEAST upstreams" defaultOpen>
         <ListEditor<ADSBBeastConfig>

--- a/web/configbuilder/src/sections/AIS.tsx
+++ b/web/configbuilder/src/sections/AIS.tsx
@@ -11,7 +11,6 @@ export function AISSection() {
     <Section
       sectionKey="ais"
       title="AIS"
-      instructions="Marine AIS GMSK receiver. Class-A vessels alternate between 161.975 MHz (87B) and 162.025 MHz (88B); pin one SDR to each to catch both."
     >
       <ListEditor<AISChannelConfig>
         label="Channels"

--- a/web/configbuilder/src/sections/APRS.tsx
+++ b/web/configbuilder/src/sections/APRS.tsx
@@ -11,7 +11,6 @@ export function APRSSection() {
     <Section
       sectionKey="aprs"
       title="APRS"
-      instructions="APRS / AX.25 Bell-202 AFSK receiver. Each channel pins an SDR to an APRS frequency (144.39 MHz is the North-America primary)."
     >
       <ListEditor<APRSChannelConfig>
         label="Channels"

--- a/web/configbuilder/src/sections/Baseband.tsx
+++ b/web/configbuilder/src/sections/Baseband.tsx
@@ -28,7 +28,6 @@ export function BasebandSection() {
     <Section
       sectionKey="baseband"
       title="Baseband"
-      instructions="Wideband IQ recording and offline replay. 'Record' taps live tuners to WAV; 'Replay' mounts recorded WAVs as virtual tuners (record at sdr.sample_rate for real-time-correct playback)."
     >
       <Fieldset legend="Record (tap live tuners to WAV)" defaultOpen>
         <ListEditor<BasebandRecordConfig>

--- a/web/configbuilder/src/sections/Broadcast.tsx
+++ b/web/configbuilder/src/sections/Broadcast.tsx
@@ -22,7 +22,6 @@ export function BroadcastSection() {
     <Section
       sectionKey="broadcast"
       title="Broadcast"
-      instructions="Stream completed calls out to aggregators (Broadcastify, RdioScanner, OpenMHz) or a live Icecast/ShoutCast mount. A feed with enabled=false is kept but skipped."
     >
       <div className="grid gap-3 sm:grid-cols-2">
         <NumberField

--- a/web/configbuilder/src/sections/DSC.tsx
+++ b/web/configbuilder/src/sections/DSC.tsx
@@ -11,7 +11,6 @@ export function DSCSection() {
     <Section
       sectionKey="dsc"
       title="DSC"
-      instructions="Marine Digital Selective Calling receiver. VHF channel 70 (156.525 MHz) carries distress/urgency/safety alerts and routine call-ups."
     >
       <ListEditor<DSCChannelConfig>
         label="Channels"

--- a/web/configbuilder/src/sections/Generic.tsx
+++ b/web/configbuilder/src/sections/Generic.tsx
@@ -10,7 +10,7 @@ import type { GTConfig } from "../api/types";
 export function GenericSection(props: {
   sectionKey: keyof GTConfig;
   title: string;
-  instructions: string;
+  instructions?: string;
 }) {
   const value = useStore((s) => (s.config ? s.config[props.sectionKey] : null));
   const patch = useStore((s) => s.patchSection);

--- a/web/configbuilder/src/sections/M17.tsx
+++ b/web/configbuilder/src/sections/M17.tsx
@@ -11,7 +11,6 @@ export function M17Section() {
     <Section
       sectionKey="m17"
       title="M17"
-      instructions="M17 digital-voice link-layer receiver (decodes link-setup metadata). Simplex calling is commonly 144.975 MHz (2 m) / 433.475 MHz (70 cm)."
     >
       <ListEditor<M17ChannelConfig>
         label="Channels"

--- a/web/configbuilder/src/sections/MDC1200.tsx
+++ b/web/configbuilder/src/sections/MDC1200.tsx
@@ -11,7 +11,6 @@ export function MDC1200Section() {
     <Section
       sectionKey="mdc1200"
       title="MDC1200"
-      instructions="Motorola MDC1200 FFSK signaling receiver. Target the conventional analog voice channels you monitor — bursts ride at the head/tail of each transmission."
     >
       <ListEditor<MDC1200ChannelConfig>
         label="Channels"

--- a/web/configbuilder/src/sections/Paging.tsx
+++ b/web/configbuilder/src/sections/Paging.tsx
@@ -17,7 +17,6 @@ export function PagingSection() {
     <Section
       sectionKey="paging"
       title="Paging"
-      instructions="POCSAG and FLEX pager decoders. The POCSAG / FLEX lists each pin one SDR to a single paging frequency; a Wideband group fans several channels off one SDR via a DDC bank."
     >
       <Fieldset legend="POCSAG channels" defaultOpen>
         <ListEditor<PagingPOCSAGConfig>

--- a/web/configbuilder/src/sections/SDR.tsx
+++ b/web/configbuilder/src/sections/SDR.tsx
@@ -62,7 +62,6 @@ export function SDRSection() {
     <Section
       sectionKey="sdr"
       title="SDR Hardware"
-      instructions="Sample rate (225 kHz–20 MHz) every tuner is programmed to, plus local devices and remote (rtl_tcp / SoapySDR) sources. P25 trunking needs separate control and voice dongles (distinct serials)."
     >
       <NumberField
         label="Sample rate (Hz)"

--- a/web/configbuilder/src/sections/ToneOut.tsx
+++ b/web/configbuilder/src/sections/ToneOut.tsx
@@ -15,7 +15,6 @@ export function ToneOutSection() {
     <Section
       sectionKey="tone_out"
       title="Tone-out"
-      instructions="Two-tone / single-tone paging detection. Supply two tones (A then B) for sequential paging, or one for single-tone supervision. Durations are Go duration strings (e.g. 250ms, 1.5s)."
     >
       <ListEditor<ToneProfileConfig>
         label="Profiles"

--- a/web/configbuilder/src/sections/Trunking.tsx
+++ b/web/configbuilder/src/sections/Trunking.tsx
@@ -76,7 +76,6 @@ export function TrunkingSection() {
     <Section
       sectionKey="trunking"
       title="Trunking Systems"
-      instructions="The trunked radio networks to follow. Each system needs a unique name, a protocol, and at least one control-channel frequency. Add systems by hand, by browsing RadioReference.com, or by importing a RadioReference PDF/CSV."
     >
       <div className="grid gap-3 sm:grid-cols-2">
         <NumberField

--- a/web/configbuilder/src/sections/simple.tsx
+++ b/web/configbuilder/src/sections/simple.tsx
@@ -41,7 +41,6 @@ export function LogSection() {
     <Section
       sectionKey="log"
       title="Logging"
-      instructions="Controls daemon log verbosity and output format."
     >
       <SelectField
         label="Level"
@@ -96,7 +95,6 @@ export function DiagnosticsSection() {
     <Section
       sectionKey="diagnostics"
       title="Diagnostics"
-      instructions="Verbose errors print full error chains + stack traces and expand API error envelopes (which expose host/dongle info). Enable only on trusted networks."
     >
       <BoolField
         label="Verbose errors"
@@ -114,7 +112,6 @@ export function RadioReferenceSection() {
     <Section
       sectionKey="radioreference"
       title="RadioReference"
-      instructions="Read-only RadioReference.com API credentials. Used by the hunt duplicate check and by this builder's RadioReference browse/import. Can also be supplied via GOPHERTRUNK_RR_KEY / _USER / _PASS env vars instead of storing the secret here."
     >
       <TextField label="API key" value={cfg.APIKey} onChange={(x) => set({ ...cfg, APIKey: x })} />
       <TextField label="Username" value={cfg.Username} onChange={(x) => set({ ...cfg, Username: x })} />
@@ -135,7 +132,6 @@ export function APISection() {
     <Section
       sectionKey="api"
       title="API & Web"
-      instructions="HTTP/gRPC listen addresses and access control. allow_mutations lets the web UI write changes (talkgroup edits, settings, this builder's saves)."
     >
       <TextField
         label="HTTP address"
@@ -234,7 +230,6 @@ export function StorageSection() {
     <Section
       sectionKey="storage"
       title="Storage"
-      instructions="Where the call-log database and the control-channel cache live."
     >
       <TextField
         label="Database path"
@@ -260,7 +255,6 @@ export function RecordingsSection() {
     <Section
       sectionKey="recordings"
       title="Recordings"
-      instructions="Per-call WAV recorder output directory and sample rate (4000–48000 Hz)."
     >
       <TextField
         label="Directory"
@@ -311,7 +305,6 @@ export function MetricsSection() {
     <Section
       sectionKey="metrics"
       title="Metrics"
-      instructions="Mount a Prometheus /metrics endpoint on the API HTTP server."
     >
       <BoolField label="Enabled" value={cfg.Enabled} onChange={(x) => set({ ...cfg, Enabled: x })} />
     </Section>
@@ -325,7 +318,6 @@ export function RetentionSection() {
     <Section
       sectionKey="retention"
       title="Retention"
-      instructions="Background sweeper that ages out call-log rows and recorded files. Zero days disables the corresponding sweep."
     >
       <NumberField
         label="Call-log days"
@@ -360,7 +352,6 @@ export function ScannerSection() {
     <Section
       sectionKey="scanner"
       title="Scanner"
-      instructions="Scan-list mode for the trunking engine. 'all' follows every non-locked-out grant; 'list' follows only talkgroups marked Scan=true."
     >
       <SelectField
         label="Scan mode"
@@ -479,7 +470,6 @@ export function AudioSection() {
     <Section
       sectionKey="audio"
       title="Audio"
-      instructions="Live playback of decoded voice. Sample rate (4000–48000 Hz) should match recordings.sample_rate. Volume is 0–1."
     >
       <BoolField label="Enabled" value={cfg.Enabled} onChange={(x) => set({ ...cfg, Enabled: x })} />
       <TextField
@@ -532,7 +522,6 @@ export function WebSection() {
     <Section
       sectionKey="web"
       title="Web UI"
-      instructions="Show or hide navigation tabs in the operator console. Unchecked tabs are hidden from the nav (the route stays reachable by URL)."
     >
       <div className="grid grid-cols-2 gap-x-4 sm:grid-cols-3">
         {KNOWN_TABS.map((tab) => {

--- a/web/configbuilder/src/store/fieldHelp.test.ts
+++ b/web/configbuilder/src/store/fieldHelp.test.ts
@@ -1,0 +1,22 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { fieldHelp, useStore } from "./shared";
+
+// fieldHelp reads the shared per-field registry that init() fetches from
+// /config/fieldmeta — the same Go source the terminal builder uses — so web
+// field help can't drift from the registry.
+describe("fieldHelp", () => {
+  beforeEach(() => useStore.setState({ fieldmeta: {} }));
+
+  it("returns the registry help for a Struct.Field key", () => {
+    useStore.setState({
+      fieldmeta: { "SystemConfig.Name": { help: "Unique label for this system." } },
+    });
+    expect(fieldHelp("SystemConfig", "Name")).toBe("Unique label for this system.");
+  });
+
+  it("returns undefined when the registry has no entry / hasn't loaded", () => {
+    expect(fieldHelp("SystemConfig", "Name")).toBeUndefined();
+    useStore.setState({ fieldmeta: { "SystemConfig.Name": { help: "" } } });
+    expect(fieldHelp("SystemConfig", "Name")).toBeUndefined();
+  });
+});

--- a/web/configbuilder/src/store/shared.ts
+++ b/web/configbuilder/src/store/shared.ts
@@ -2,6 +2,7 @@ import { create } from "zustand";
 import { api, setToken } from "../api/client";
 import type {
   DocLink,
+  FieldMeta,
   GTConfig,
   TalkgroupCSVRow,
   ValidationResult,
@@ -24,6 +25,10 @@ interface State {
   talkgroups: Record<string, TalkgroupCSVRow[]>;
 
   docs: Record<string, DocLink>;
+  // fieldmeta is the shared per-field registry (keyed "StructName.FieldName")
+  // fetched from /config/fieldmeta; fieldHelp() reads it so web field help is
+  // sourced from the same Go registry the terminal builder uses.
+  fieldmeta: Record<string, FieldMeta>;
   defaults: GTConfig | null; // config.Default() seed, for "configured" nav cues
   token: string;
   errors: string[]; // toast stack
@@ -53,6 +58,7 @@ export const useStore = create<State>((set, get) => ({
   dirty: false,
   talkgroups: {},
   docs: {},
+  fieldmeta: {},
   defaults: null,
   token: "",
   errors: [],
@@ -66,6 +72,12 @@ export const useStore = create<State>((set, get) => ({
       set({ docs });
     } catch {
       /* docs are best-effort */
+    }
+    try {
+      const fieldmeta = await api.fieldmeta();
+      set({ fieldmeta });
+    } catch {
+      /* field help is best-effort */
     }
     // Cache the defaults once so the nav can flag which sections differ
     // from a blank config ("configured" cues).
@@ -205,3 +217,12 @@ export const useStore = create<State>((set, get) => ({
     }
   },
 }));
+
+// fieldHelp returns the shared per-field help for a "StructName"+"FieldName"
+// pair from the fieldmeta registry (fetched once at init), or undefined when
+// the registry hasn't loaded / has no entry. Non-reactive on purpose — the
+// registry is static for the session — so it can feed widget `help` props
+// inline. The Go side guarantees every config leaf has help (TestFieldHelpCoverage).
+export function fieldHelp(struct: string, field: string): string | undefined {
+  return useStore.getState().fieldmeta[`${struct}.${field}`]?.help || undefined;
+}


### PR DESCRIPTION
kindOf no longer silently falls back to text: unknown kinds (map[string]string,
[]int, foreign structs, etc.) return kindUnsupported, rendered read-only.
TestEveryLeafEditable walks every config.Config leaf and fails if any is
kindUnsupported. Together with configbuilder.TestConfigSchemaCoveredByWebBuilder
(web types.ts), a config-schema change now fails BOTH tests until both editors
are taught the field — guaranteeing the web and TUI builders stay in sync.

https://claude.ai/code/session_017EGcBzuFkZSBXvgg6i14PF