### PR TITLE
Signal plots: true constellation + OP25/SDR plot parity (eye, tuning, histogram, hub)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,13 @@ for tagged releases.
   gates each LDU on its decoded Link Control talkgroup and ends the call when
   another talkgroup takes the channel. Recording filenames now carry the RF
   voice-channel frequency (`<stamp>_freq<Hz>_src<src>…`).
+- **Symbol histogram panel** (`/histogram`) — the recovered-symbol
+  distribution plus a derived signal-quality readout (#557 follow-up). A
+  scrambled P25 channel spreads evenly, so each of the four bins should
+  sit near 25%; a **Balance** meter flags a skewed (collapsed-eye)
+  distribution, and for C4FM an **SNR (MER)** estimate is derived from the
+  soft-level separation vs within-level spread. Computed client-side off
+  the existing symbol stream.
 - **Tuning panel** (`/tuning`) — live receiver-state meters, GopherTrunk's
   take on OP25's Mixer / Tuner (FLL) tabs (#557 follow-up). Trends the
   demod's residual carrier-frequency-offset estimate (should converge to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ for tagged releases.
   gates each LDU on its decoded Link Control talkgroup and ends the call when
   another talkgroup takes the channel. Recording filenames now carry the RF
   voice-channel frequency (`<stamp>_freq<Hz>_src<src>…`).
+- **Tuning panel** (`/tuning`) — live receiver-state meters, GopherTrunk's
+  take on OP25's Mixer / Tuner (FLL) tabs (#557 follow-up). Trends the
+  demod's residual carrier-frequency-offset estimate (should converge to
+  0 Hz on lock) and surfaces AGC level/target, symbol-clock μ/sps and (on
+  CQPSK) the equalizer's CMA-error convergence proxy — all read live from
+  the production receiver and carried on the existing symbol stream.
 - **Eye diagram panel** (`/eye`) — GopherTrunk's take on OP25's datascope
   (#557 follow-up). The daemon's C4FM receiver gains an oversampled,
   AGC-scaled eye tap; the panel folds it over the symbol period and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ for tagged releases.
   gates each LDU on its decoded Link Control talkgroup and ends the call when
   another talkgroup takes the channel. Recording filenames now carry the RF
   voice-channel frequency (`<stamp>_freq<Hz>_src<src>…`).
+- **Plots hub** (`/plots`) — one tabbed home for the per-channel signal
+  scopes (Constellation, Symbol scope, Eye diagram, Tuning, Histogram),
+  mirroring OP25's Plots tabs (#557 follow-up). The chosen sub-tab is
+  reflected in the URL (`/plots/<tab>`); the individual routes still work
+  for deep links, and the wideband Spectrum waterfall stays its own tab.
+  This replaces the five separate scope entries in the nav with one.
 - **Symbol histogram panel** (`/histogram`) — the recovered-symbol
   distribution plus a derived signal-quality readout (#557 follow-up). A
   scrambled P25 channel spreads evenly, so each of the four bins should

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,13 @@ for tagged releases.
   gates each LDU on its decoded Link Control talkgroup and ends the call when
   another talkgroup takes the channel. Recording filenames now carry the RF
   voice-channel frequency (`<stamp>_freq<Hz>_src<src>…`).
+- **Eye diagram panel** (`/eye`) — GopherTrunk's take on OP25's datascope
+  (#557 follow-up). The daemon's C4FM receiver gains an oversampled,
+  AGC-scaled eye tap; the panel folds it over the symbol period and
+  overlays the windows so the four-level eye is visible. A healthy channel
+  shows four open bands with clear gaps at the decision instant; a closed
+  eye flags symbol-timing or SNR trouble. C4FM only (CQPSK's quality view
+  is the constellation).
 - **True symbol constellation** on the Constellation panel (#557 follow-up).
   The panel gains a **View** toggle: **Symbols** (new default) plots the
   receiver's actual symbol-decision points — for **P25 CQPSK/LSM** a real

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,17 @@ for tagged releases.
   gates each LDU on its decoded Link Control talkgroup and ends the call when
   another talkgroup takes the channel. Recording filenames now carry the RF
   voice-channel frequency (`<stamp>_freq<Hz>_src<src>…`).
+- **True symbol constellation** on the Constellation panel (#557 follow-up).
+  The panel gains a **View** toggle: **Symbols** (new default) plots the
+  receiver's actual symbol-decision points — for **P25 CQPSK/LSM** a real
+  complex constellation that forms four tight clusters on the ±45°/±135°
+  diagonals on a clean signal and smears to an X as the eye closes; for
+  **P25 C4FM** the four recovered soft levels on the real axis (its open
+  4-level eye remains the Symbol scope's job). Amber rings mark the ideal
+  cluster centres. The previous wideband-IQ scatter is still available as
+  **Vector scope (raw IQ)** for identifying unknown signals. The symbols
+  stream reuses the live receiver (`WS /api/v1/diag/symbols`), so it shows
+  exactly what the production demod sees.
 
 ### Fixed
 

--- a/cmd/gophertrunk/symbol_provider.go
+++ b/cmd/gophertrunk/symbol_provider.go
@@ -102,6 +102,8 @@ func (p *symbolProvider) OpenSymbolStream(ctx context.Context, serial, proto str
 				Soft:         f.Soft,
 				SymI:         f.SymI,
 				SymQ:         f.SymQ,
+				EyeSoft:      f.EyeSoft,
+				EyeSPS:       f.EyeSPS,
 				Dibits:       f.Dibits,
 				IsBits:       f.IsBits,
 				BaseIdx:      f.BaseIdx,

--- a/cmd/gophertrunk/symbol_provider.go
+++ b/cmd/gophertrunk/symbol_provider.go
@@ -100,6 +100,8 @@ func (p *symbolProvider) OpenSymbolStream(ctx context.Context, serial, proto str
 				CenterHz:     f.CenterHz,
 				OffsetHz:     f.OffsetHz,
 				Soft:         f.Soft,
+				SymI:         f.SymI,
+				SymQ:         f.SymQ,
 				Dibits:       f.Dibits,
 				IsBits:       f.IsBits,
 				BaseIdx:      f.BaseIdx,

--- a/cmd/gophertrunk/symbol_provider.go
+++ b/cmd/gophertrunk/symbol_provider.go
@@ -107,6 +107,13 @@ func (p *symbolProvider) OpenSymbolStream(ctx context.Context, serial, proto str
 				Dibits:       f.Dibits,
 				IsBits:       f.IsBits,
 				BaseIdx:      f.BaseIdx,
+
+				CarrierOffsetHz: f.CarrierOffsetHz,
+				AGCLevel:        f.AGCLevel,
+				AGCTarget:       f.AGCTarget,
+				ClockMu:         f.ClockMu,
+				ClockSPS:        f.ClockSPS,
+				CMAError:        f.CMAError,
 			}
 			// Non-blocking: drop on a wedged WS client rather than
 			// stalling the broker drain goroutine.

--- a/docs/_data/nav.yml
+++ b/docs/_data/nav.yml
@@ -57,6 +57,8 @@ groups:
         url: /constellation.html
       - title: Symbol scope
         url: /symbol-scope.html
+      - title: Eye diagram
+        url: /eye-diagram.html
       - title: Hunt (discover systems)
         url: /hunt.html
       - title: rigctld integration

--- a/docs/_data/nav.yml
+++ b/docs/_data/nav.yml
@@ -61,6 +61,8 @@ groups:
         url: /eye-diagram.html
       - title: Tuning (receiver meters)
         url: /tuning.html
+      - title: Symbol histogram
+        url: /histogram.html
       - title: Hunt (discover systems)
         url: /hunt.html
       - title: rigctld integration

--- a/docs/_data/nav.yml
+++ b/docs/_data/nav.yml
@@ -59,6 +59,8 @@ groups:
         url: /symbol-scope.html
       - title: Eye diagram
         url: /eye-diagram.html
+      - title: Tuning (receiver meters)
+        url: /tuning.html
       - title: Hunt (discover systems)
         url: /hunt.html
       - title: rigctld integration

--- a/docs/_data/nav.yml
+++ b/docs/_data/nav.yml
@@ -53,6 +53,8 @@ groups:
         url: /cc-activity.html
       - title: Radio IDs
         url: /radio-ids.html
+      - title: Plots (signal scopes)
+        url: /plots.html
       - title: Constellation
         url: /constellation.html
       - title: Symbol scope

--- a/docs/constellation.md
+++ b/docs/constellation.md
@@ -1,28 +1,63 @@
 ---
 layout: page
 title: Constellation panel
-description: Live IQ scatter for visually identifying signal shape — PSK, FSK, AM, noise — without launching a separate SDR receiver
+description: Live symbol constellation and raw-IQ vector scope for judging modulation quality and identifying signal shape
 nav_group: Operate
 ---
 
 # Constellation panel
 
 The **Constellation panel** (web `/constellation`) renders a live
-2D scatter of the IQ samples coming off whichever SDR you pick.
-It's the "what does this signal *look* like" view — useful for
-identifying modulation shape, checking demod / equalizer health,
-and confirming that the SDR is actually receiving something you
-care about before committing to a deeper decode pipeline.
+2D scatter of the signal in the complex plane. It answers two
+different questions depending on the **View** you pick:
 
-## What you see
+- **Symbols** (the default) — *how clean is the modulation?* This is
+  the true symbol constellation: the receiver's symbol-decision points,
+  sampled once per symbol after matched filtering, timing recovery and
+  carrier recovery. It is the same modulation-quality picture OP25 shows
+  on its Constellation tab.
+- **Vector scope (raw IQ)** — *what kind of signal is this?* The
+  wideband decimated IQ trajectory, every sample including the
+  transitions between symbols. Useful as a general "what does this look
+  like" view before committing to a decode pipeline.
 
-The X axis is the in-phase (I) component, the Y axis is the
-quadrature (Q) component, both normalized to ±1, with labelled ticks
-at ±0.5 and ±1. Points are drawn additively in GopherTrunk's sky-blue
-accent (the same blue→cyan family as the Spectrum waterfall), so a
-dense symbol cluster blooms toward cyan-white while the noise floor
-stays dim; the newest samples are brightest. Reference rings show
-|z| = 0.5 and |z| = 1.0 so you can eyeball amplitude.
+## Two views
+
+Switch between them with the **View** control. The difference matters:
+a raw-IQ vector scope draws *every* sample (symbol centres **and** the
+curved transitions between them), so even a perfect signal looks like a
+web of arcs — it is not a constellation. A constellation samples only at
+the symbol-decision instants, so a clean signal collapses to a handful
+of tight dots. Use Symbols to judge demod/equalizer health; use the
+vector scope to identify an unknown signal.
+
+### Symbols view
+
+Pick the demodulator with the **Mode** selector:
+
+- **P25 CQPSK** (LSM / simulcast) — a true complex constellation. A
+  clean signal forms **four tight clusters** on the ±45°/±135°
+  diagonals; as the eye closes (noise, multipath, an unconverged
+  equalizer) the clusters smear toward a central **X**. Amber reference
+  rings mark the ideal cluster centres.
+- **P25 C4FM** — C4FM is a frequency modulation with no complex
+  constellation, so its **four soft levels** (±1, ±3) are plotted on the
+  real axis, with amber rings at the ideal positions. C4FM's natural
+  quality view is the open 4-level eye on the
+  [Symbol scope](symbol-scope.html); the constellation here is the
+  level-separation summary.
+
+The symbols stream comes from a parallel receiver the daemon runs on the
+selected channel — the same one that feeds the Symbol scope — so it
+reflects exactly what the production demod sees.
+
+### Vector scope (raw IQ) view
+
+The X axis is the in-phase (I) component, the Y axis the quadrature (Q),
+both normalized to ±1 with ticks at ±0.5 and ±1. Points are drawn
+additively in GopherTrunk's sky-blue accent so a dense cluster blooms
+toward cyan-white while the noise floor stays dim; the newest samples
+are brightest. Reference rings show |z| = 0.5 and |z| = 1.0.
 
 ## Getting a usable picture (the DC-spike problem)
 
@@ -58,7 +93,7 @@ The plot itself is a responsive square that fills the panel column (up to
 and it stays crisp at any size because the canvas is drawn at the display's
 device-pixel ratio.
 
-Common shapes:
+Common shapes in the **vector scope** view:
 
 | Shape | Likely signal |
 | --- | --- |
@@ -72,6 +107,16 @@ Common shapes:
 | Spiral expanding outward | Strong frequency offset (re-tune or fix PPM) |
 
 ## How it works
+
+In the **Symbols** view the panel opens
+`WS /api/v1/diag/symbols?device=...&proto=<p25-cqpsk|p25-c4fm>&offset=<hz>`.
+The daemon channelizes the selected offset and runs a parallel P25 Phase 1
+receiver; the CQPSK path emits the post-carrier-recovery complex symbols
+(`sym_i`/`sym_q`) and the C4FM path emits the recovered soft levels — both
+aligned with the sliced dibits. See the
+[Symbol scope](symbol-scope.html) for the shared receiver plumbing.
+
+The **Vector scope** view uses the raw IQ stream:
 
 - The panel opens a WebSocket to
   `WS /api/v1/diag/iq?device=...&rate=2000&offset=<hz>`.
@@ -94,12 +139,12 @@ Common shapes:
 
 ## Limitations
 
-- **Not a demodulator.** This is a sample-domain view of the raw
-  IQ — useful as a sanity check, not as a decoder. To actually
-  decode a signal, configure it as a `trunking.systems` entry or
-  `scanner.conventional` channel and let the per-protocol
-  pipeline take over.
-- **Decimation is brutal.** The stride decimator throws away
+- **Visualization, not decode.** The Symbols view runs a real receiver,
+  but the panel only *plots* the result — it doesn't log talkgroups or
+  play audio. To actually decode, configure the channel as a
+  `trunking.systems` entry or `scanner.conventional` channel and let the
+  per-protocol pipeline take over.
+- **Vector scope decimation is brutal.** The stride decimator throws away
   spectral content above `target_rate / 2`. Wideband signals
   appear smeared. The constellation is most useful for symbol-
   domain signals that have already been narrow-channelized — e.g.
@@ -113,11 +158,14 @@ Common shapes:
 
 | Path | Role |
 | --- | --- |
-| `internal/dsp/diag/iqstream.go` | `Decimator` — decimates IQ chunks by stride, computes per-frame energy, batches points into wire frames |
+| `internal/radio/p25/phase1/receiver/receiver.go` | `SymbolSink` — emits the per-symbol complex constellation points (CQPSK path) |
+| `internal/scanner/symbolscope/scope.go` | Channelizes + runs the receiver; carries `SymI`/`SymQ` alongside soft/dibits |
+| `internal/api/symbols.go` | `SymbolProvider` interface + `WS /api/v1/diag/symbols` handler |
+| `internal/dsp/diag/iqstream.go` | `Decimator` — vector-scope path: decimates IQ chunks by stride, computes per-frame energy |
 | `internal/api/diag.go` | `DiagProvider` interface + `WS /api/v1/diag/iq` handler |
-| `cmd/gophertrunk/diag_provider.go` | Daemon-side `diagProvider` — wires the decimator to the iqtap broker for each WS subscriber |
-| `web/src/api/diag.ts` | Typed client with auto-reconnect / backoff |
-| `web/src/panels/Constellation.tsx` | Canvas scatter renderer + zoom |
+| `cmd/gophertrunk/diag_provider.go` / `symbol_provider.go` | Daemon-side providers wiring each stream to the iqtap broker |
+| `web/src/api/diag.ts` / `web/src/api/symbols.ts` | Typed WS clients with auto-reconnect / backoff |
+| `web/src/panels/Constellation.tsx` | Canvas scatter renderer, View/Mode toggles, ideal-cluster markers, zoom |
 | `web/src/components/TuningControls.tsx` | Shared offset / frequency / Hold / Centre controls (also used by the Symbol scope) |
 
 The decimator runs on top of the iqtap broker (PR #365), so it

--- a/docs/eye-diagram.md
+++ b/docs/eye-diagram.md
@@ -1,0 +1,81 @@
+---
+layout: page
+title: Eye diagram panel
+description: Live P25 C4FM eye diagram (OP25's datascope) — fold the oversampled baseband over the symbol period to judge symbol timing and SNR
+nav_group: Operate
+---
+
+# Eye diagram panel
+
+The **Eye diagram panel** (web `/eye`) is GopherTrunk's take on OP25's
+**datascope**: it folds the oversampled, recovered C4FM baseband over the
+symbol period and overlays the windows, so the four-level *eye* is
+visible. It's the view for answering "is my symbol timing and signal
+quality good enough to decode?" — the question the 1-sample-per-symbol
+[Symbol scope](symbol-scope.html) can hint at but can't show directly.
+
+## What you see
+
+Each trace is a two-symbol window of the matched-filter output, drawn
+faintly and stacked on top of every other window. On a **healthy P25
+C4FM** channel they pile up into **four open horizontal bands** — the
+±1 / ±3 decision rails — with clear vertical gaps between them at the
+centre line (the symbol-decision instant). The wider and cleaner those
+gaps, the more margin the slicer has.
+
+A **closed eye** — bands smearing together, no gap at the centre, or a
+band collapsing — means trouble:
+
+| Symptom | Likely cause |
+| --- | --- |
+| All four bands present, gaps narrow | Low SNR / weak signal |
+| Bands smeared horizontally, centre fuzzy | Symbol-timing (clock) error |
+| Outer bands merge into inner | AGC / level miscalibration, compression |
+| Only two bands | Slicer collapsed to outer symbols (offset / AFC) |
+| Vertical eye walls slope / drift | Sample-rate vs baud mismatch (PPM) |
+
+The four rails are auto-scaled to the data, so the eye fills the plot
+regardless of front-end gain; the vertical line marks the symbol centre.
+
+## C4FM only
+
+The eye is a property of the FM-discriminated 4-level baseband, so this
+panel runs the **P25 C4FM** receiver. CQPSK / LSM (simulcast) has no
+4-level eye — its quality view is the complex **constellation** (four
+clusters), shown on the [Constellation panel](constellation.html).
+
+## Controls
+
+The **Offset / Hold / Centre** controls work exactly like the other
+scopes: dial the offset onto a locked control or voice channel (or leave
+Hold off to follow the newest active call) so the eye reflects a real
+transmission rather than the centre DC spike. See the
+[Constellation panel](constellation.html#getting-a-usable-picture-the-dc-spike-problem)
+for the DC-spike explanation.
+
+## How it works
+
+- The panel opens
+  `WS /api/v1/diag/symbols?device=...&proto=p25-c4fm&offset=<hz>` — the
+  same per-channel receiver the Symbol scope and Constellation use.
+- The receiver exposes an **eye tap**: the oversampled matched-filter
+  output (`eye_sps` samples per symbol, e.g. 10 at the 48 kHz channel
+  rate), scaled by the symbol-AGC gain so its rails line up with the
+  slicer levels. It is the same buffer the symbol-clock loop reads, so
+  the eye reflects exactly what the slicer decides on.
+- Each frame carries a bounded recent window (`eye_soft`) rather than the
+  full oversampled stream — the oversampled rate is `eye_sps`× the symbol
+  rate, so it is capped to keep the WebSocket payload modest while still
+  carrying enough windows for a stable eye.
+- The panel keeps a rolling buffer and the chart folds it over `eye_sps`,
+  overlaying two-symbol windows.
+
+## Implementation
+
+| Path | Role |
+| --- | --- |
+| `internal/radio/p25/phase1/receiver/receiver.go` | `EyeSink` — emits the AGC-scaled oversampled matched-filter output (C4FM) |
+| `internal/scanner/symbolscope/scope.go` | Carries the bounded eye window (`EyeSoft`/`EyeSPS`) on each frame |
+| `internal/api/symbols.go` | `eye_soft` / `eye_sps` on the symbol WS frame |
+| `web/src/components/EyeDiagramChart.tsx` | Canvas eye renderer (folds + overlays windows) |
+| `web/src/panels/EyeDiagram.tsx` | Panel: SDR + offset controls, C4FM stream |

--- a/docs/histogram.md
+++ b/docs/histogram.md
@@ -1,0 +1,64 @@
+---
+layout: page
+title: Symbol histogram panel
+description: Recovered-symbol distribution and a derived signal-quality (balance + MER/SNR) readout off the live demod
+nav_group: Operate
+---
+
+# Symbol histogram panel
+
+The **Symbol histogram panel** (web `/histogram`) shows the distribution
+of the recovered symbols off the live demod, plus a derived
+signal-quality readout. It's the quickest "is the slicer healthy?" check:
+a P25 control channel is scrambled, so its symbols are evenly spread, and
+a lopsided histogram immediately flags a problem.
+
+## What you see
+
+### The histogram
+
+A bar per symbol level (4 for both P25 C4FM and CQPSK). Because the
+on-air stream is scrambled, a healthy channel spreads the symbols
+**evenly — each bin near 25%**. Departures are diagnostic:
+
+| Histogram | Meaning |
+| --- | --- |
+| Four bins ≈ 25% | Healthy slicer, eye open |
+| Two bins dominant | Slicer collapsed to outer (±3) symbols — level / AFC trouble |
+| One bin dominant | No lock / unmodulated carrier / wrong offset |
+| Empty | No symbols decoding on this channel |
+
+### Quality meters
+
+- **Balance** — the largest deviation of any bin from the 25% ideal.
+  Low is good; a high value means the distribution is skewed (collapsed
+  eye, biased slicer).
+- **SNR (MER)** — for **C4FM** only, an estimate from the soft samples:
+  the separation between the four level means versus the spread *within*
+  each level (a modulation-error-ratio-style figure). Higher dB is
+  cleaner. CQPSK has no real soft track here, so this reads "—".
+- **Symbols** — the number of symbols in the current window.
+
+## Controls
+
+Pick the receiver with **Mode**, and use the **Offset / Hold / Centre**
+controls (shared with the other scopes) to point the demod at a locked
+channel. See the [Constellation panel](constellation.html) for the
+DC-spike explanation.
+
+## How it works
+
+- The panel opens
+  `WS /api/v1/diag/symbols?device=...&proto=<…>&offset=<hz>` — the same
+  per-channel receiver the other scopes use.
+- The histogram and quality figures are computed **client-side** over a
+  rolling window of the streamed `dibits` (and, for C4FM, the aligned
+  `soft` samples) — no extra backend work; it's a different view of the
+  symbol stream the Symbol scope and Constellation already consume.
+
+## Implementation
+
+| Path | Role |
+| --- | --- |
+| `internal/scanner/symbolscope/scope.go` | Streams the `dibits` / `soft` the histogram is computed from |
+| `web/src/panels/Histogram.tsx` | Bar chart (Chart.js) + balance / MER computation |

--- a/docs/plots.md
+++ b/docs/plots.md
@@ -1,0 +1,40 @@
+---
+layout: page
+title: Plots (signal scopes)
+description: The Plots hub — one tabbed home for GopherTrunk's per-channel signal scopes, mirroring OP25's Plots tabs
+nav_group: Operate
+---
+
+# Plots (signal scopes)
+
+The **Plots hub** (web `/plots`) gathers GopherTrunk's per-channel
+signal scopes under one tabbed page, mirroring OP25's Plots tabs. They
+are all **views of a single live decode**: each opens the same per-channel
+receiver (`WS /api/v1/diag/symbols`) on the selected SDR, so the symbol
+points, eye, tuning meters and histogram all reflect exactly what the
+production demodulator sees.
+
+| Sub-tab | What it answers | Page |
+| --- | --- | --- |
+| **Constellation** | How clean is the modulation? (symbol clusters / vector scope) | [Constellation](constellation.html) |
+| **Symbol scope** | What does the symbol waveform look like over time? | [Symbol scope](symbol-scope.html) |
+| **Eye diagram** | Is the C4FM eye open (symbol timing / SNR)? | [Eye diagram](eye-diagram.html) |
+| **Tuning** | Is the receiver locking — carrier error, AGC, clock? | [Tuning](tuning.html) |
+| **Histogram** | Is the symbol distribution healthy (balance / MER)? | [Histogram](histogram.html) |
+
+Each sub-tab is the standalone panel rendered inline; the chosen view is
+reflected in the URL (`/plots/<tab>`) so it's shareable and survives a
+refresh, and the individual routes (`/constellation`, `/eye`, …) still
+work for deep links. The wideband **[Spectrum](spectrum.html)** waterfall
+stays its own top-level tab.
+
+## Workflow
+
+1. Pick the **SDR** and dial the **Offset** onto a locked control or voice
+   channel (or leave Hold off to follow the newest active call) — the
+   offset and Mode persist across the scopes.
+2. **Constellation / Eye** to judge raw modulation quality.
+3. **Tuning** to confirm the loops are locking (carrier error → 0 Hz).
+4. **Histogram** for an at-a-glance balance / SNR sanity check.
+
+See each scope's own page (linked above) for the detail.

--- a/docs/tuning.md
+++ b/docs/tuning.md
@@ -1,0 +1,78 @@
+---
+layout: page
+title: Tuning panel
+description: Live receiver-state meters — carrier-frequency error, AGC, symbol-clock and equalizer state — GopherTrunk's take on OP25's Mixer / Tuner (FLL) tabs
+nav_group: Operate
+---
+
+# Tuning panel
+
+The **Tuning panel** (web `/tuning`) surfaces the live demodulator's
+internal loop state — GopherTrunk's take on OP25's **Mixer** and
+**Tuner (FLL)** tabs. It answers "is the receiver actually locking onto
+this channel, and how much tuner error is it fighting?" while the other
+scopes answer "what does the signal look like."
+
+The daemon runs a parallel P25 receiver on the selected channel and
+stamps its loop state onto every symbol frame, so this is the real state
+of the production demod, not a re-implementation.
+
+## What you see
+
+### Carrier-error trend (the FLL view)
+
+A rolling line of the receiver's **residual carrier-frequency-offset
+estimate** in Hz:
+
+- **C4FM** — the AFC's estimate of the true carrier offset.
+- **CQPSK / LSM** — the carrier-recovery loop's estimate (coarse seed
+  plus the fine Costas residual).
+
+On a healthy lock the trace **converges toward 0 Hz and holds**. A
+steady non-zero value is your tuner's PPM error (a 420 MHz / 50 ppm
+RTL-SDR can sit ~20 kHz off); a trace that wanders or never settles is a
+loop that hasn't acquired — usually a too-weak signal or the wrong demod
+mode for the site.
+
+### Loop-state meters
+
+| Meter | Meaning | Healthy |
+| --- | --- | --- |
+| **Carrier error** | Current residual offset (Hz) | Near 0, steady |
+| **AGC level** (C4FM) | Symbol-AGC mean\|x\|, vs its target | Tracks target |
+| **AGC gain** (CQPSK) | Matched-filter AGC gain | Settles, not pinned at 1.0 |
+| **Clock μ** | Symbol-clock sub-sample phase + nominal sps | Cycles steadily, no monotonic drift |
+| **CMA error** (CQPSK) | Blind-equalizer convergence proxy | Trends toward 0 |
+
+A **Clock μ** that drifts monotonically means the nominal samples-per-
+symbol disagrees with the stream's actual baud (a sample-rate / PPM
+issue); a **CMA error** stuck large means the equalizer never opened the
+constellation.
+
+## Controls
+
+Pick the receiver with **Mode** (C4FM or CQPSK — match the site), and use
+the **Offset / Hold / Centre** controls (shared with the other scopes) to
+point the receiver at a locked control or voice channel. See the
+[Constellation panel](constellation.html) for the DC-spike explanation.
+
+## How it works
+
+- The panel opens
+  `WS /api/v1/diag/symbols?device=...&proto=<…>&offset=<hz>` — the same
+  per-channel receiver the Constellation, Symbol scope and Eye diagram
+  use, so all four are views of one decode.
+- Each frame carries the receiver's state getters
+  (`carrier_offset_hz`, `agc_level`, `agc_target`, `clock_mu`,
+  `clock_sps`, `cma_error`), read live from the demod. The getters are
+  demod-specific (Mueller-Müller vs Gardner, AFC vs carrier recovery);
+  the daemon routes by the selected mode.
+
+## Implementation
+
+| Path | Role |
+| --- | --- |
+| `internal/radio/p25/phase1/receiver/receiver.go` | The state getters (`AFCOffsetHz`, `AGCLevel`, `MMClockMu`, `CQPSKCarrierOffsetHz`, `CMAError`, …) |
+| `internal/scanner/symbolscope/scope.go` | `stampMetrics` reads the getters into each frame |
+| `internal/api/symbols.go` | Metric fields on the symbol WS frame |
+| `web/src/panels/Tuning.tsx` | Carrier-error trend (Chart.js) + loop-state meters |

--- a/internal/api/symbols.go
+++ b/internal/api/symbols.go
@@ -30,9 +30,14 @@ type SymbolFrame struct {
 	Soft         []float32 `json:"soft"`
 	SymI         []float32 `json:"sym_i"`
 	SymQ         []float32 `json:"sym_q"`
-	Dibits       []uint8   `json:"dibits"`
-	IsBits       bool      `json:"is_bits"`
-	BaseIdx      int       `json:"base_idx"`
+	// EyeSoft is a bounded window of oversampled, AGC-scaled matched-
+	// filter output (EyeSPS samples per symbol) for the C4FM eye diagram;
+	// empty on CQPSK. Fold it over EyeSPS to render the 4-level eye.
+	EyeSoft []float32 `json:"eye_soft"`
+	EyeSPS  int       `json:"eye_sps"`
+	Dibits  []uint8   `json:"dibits"`
+	IsBits  bool      `json:"is_bits"`
+	BaseIdx int       `json:"base_idx"`
 }
 
 // SymbolProvider is the daemon-side abstraction the symbol endpoint

--- a/internal/api/symbols.go
+++ b/internal/api/symbols.go
@@ -38,6 +38,14 @@ type SymbolFrame struct {
 	Dibits  []uint8   `json:"dibits"`
 	IsBits  bool      `json:"is_bits"`
 	BaseIdx int       `json:"base_idx"`
+
+	// Receiver-state metrics for the Tuning panel (see symbolscope.Frame).
+	CarrierOffsetHz float64 `json:"carrier_offset_hz"`
+	AGCLevel        float64 `json:"agc_level"`
+	AGCTarget       float64 `json:"agc_target"`
+	ClockMu         float64 `json:"clock_mu"`
+	ClockSPS        float64 `json:"clock_sps"`
+	CMAError        float64 `json:"cma_error"`
 }
 
 // SymbolProvider is the daemon-side abstraction the symbol endpoint

--- a/internal/api/symbols.go
+++ b/internal/api/symbols.go
@@ -18,12 +18,18 @@ import (
 // soft tap, e.g. P25 CQPSK); Dibits are the sliced decisions (0..3 when
 // IsBits is false, 0..1 when true). When Soft is non-empty it is aligned
 // index-for-index with Dibits.
+//
+// SymI/SymQ carry the complex symbol-decision points (the true
+// constellation) on the linear/CQPSK path; empty on C4FM. When non-empty
+// they are aligned index-for-index with Dibits.
 type SymbolFrame struct {
 	TimestampNs  int64     `json:"ts_ns"`
 	SymbolRateHz float64   `json:"symbol_rate_hz"`
 	CenterHz     uint32    `json:"center_hz"`
 	OffsetHz     int32     `json:"offset_hz"`
 	Soft         []float32 `json:"soft"`
+	SymI         []float32 `json:"sym_i"`
+	SymQ         []float32 `json:"sym_q"`
 	Dibits       []uint8   `json:"dibits"`
 	IsBits       bool      `json:"is_bits"`
 	BaseIdx      int       `json:"base_idx"`

--- a/internal/api/symbols_test.go
+++ b/internal/api/symbols_test.go
@@ -105,6 +105,8 @@ func TestSymbolStreamDeliversFrames(t *testing.T) {
 				CenterHz:     851_012_500,
 				OffsetHz:     12_500,
 				Soft:         []float32{0.9, -0.3, -0.95, 0.31},
+				SymI:         []float32{0.7, -0.7, -0.7, 0.7},
+				SymQ:         []float32{0.7, 0.7, -0.7, -0.7},
 				Dibits:       []uint8{1, 0, 3, 2},
 				BaseIdx:      0,
 			},
@@ -142,6 +144,13 @@ func TestSymbolStreamDeliversFrames(t *testing.T) {
 		}
 		if i == 0 && len(f.Dibits) != 4 {
 			t.Errorf("frame #%d dibits len = %d, want 4", i, len(f.Dibits))
+		}
+		if i == 0 {
+			if len(f.SymI) != 4 || len(f.SymQ) != 4 {
+				t.Errorf("frame #0 symbol track len = (%d,%d), want (4,4)", len(f.SymI), len(f.SymQ))
+			} else if f.SymI[0] != 0.7 || f.SymQ[2] != -0.7 {
+				t.Errorf("frame #0 symbol track not round-tripped: SymI[0]=%v SymQ[2]=%v", f.SymI[0], f.SymQ[2])
+			}
 		}
 	}
 

--- a/internal/radio/p25/phase1/receiver/cqpsk_test.go
+++ b/internal/radio/p25/phase1/receiver/cqpsk_test.go
@@ -422,3 +422,109 @@ func TestParseDemodMode(t *testing.T) {
 		}
 	}
 }
+
+// TestCQPSKSymbolSinkAlignedAndClustered verifies the constellation tap:
+// the CQPSK path delivers one complex symbol per emitted dibit (aligned
+// for client colour-by-dibit), and on a clean LSM stream those symbols
+// settle into the four π/4-DQPSK constellation quadrants rather than a
+// blob at the origin.
+func TestCQPSKSymbolSinkAlignedAndClustered(t *testing.T) {
+	const sampleRate = 48_000.0
+	const sps = 10
+	const symbols = 1200
+
+	rng := uint32(0x1234abcd)
+	in := make([]uint8, symbols)
+	for i := range in {
+		rng = rng*1664525 + 1013904223
+		in[i] = uint8((rng >> 16) & 3)
+	}
+	iq := dibitsToLSMIQ(t, in, sps, PulseSpanSymbols, RolloffAlpha)
+
+	var dibits int
+	var syms []complex64
+	r := New(Options{
+		SampleRateHz: sampleRate,
+		DemodMode:    DemodCQPSK,
+		DibitSink:    func(d []uint8, _ int) { dibits += len(d) },
+		SymbolSink:   func(s []complex64) { syms = append(syms, s...) },
+	})
+	chunk := 4096
+	for i := 0; i < len(iq); i += chunk {
+		end := i + chunk
+		if end > len(iq) {
+			end = len(iq)
+		}
+		r.Process(iq[i:end])
+	}
+
+	if len(syms) == 0 {
+		t.Fatal("SymbolSink never fired on the CQPSK path")
+	}
+	// One symbol per dibit — the alignment a client relies on to colour
+	// each constellation point by its decided dibit.
+	if len(syms) != dibits {
+		t.Fatalf("symbol/dibit count mismatch: %d symbols, %d dibits", len(syms), dibits)
+	}
+
+	// After loop acquisition the points should populate all four
+	// quadrants (a real constellation), not collapse to the origin.
+	const settle = 200
+	var quad [4]int
+	var nonTrivial int
+	for _, s := range syms[min(settle, len(syms)):] {
+		if math.Hypot(float64(real(s)), float64(imag(s))) < 0.2 {
+			continue
+		}
+		nonTrivial++
+		q := 0
+		if real(s) < 0 {
+			q |= 1
+		}
+		if imag(s) < 0 {
+			q |= 2
+		}
+		quad[q]++
+	}
+	if nonTrivial < symbols/4 {
+		t.Fatalf("too few non-trivial symbol points: %d (constellation collapsed to origin)", nonTrivial)
+	}
+	for q := 0; q < 4; q++ {
+		if quad[q] == 0 {
+			t.Errorf("constellation quadrant %d empty — symbols did not form 4 clusters (quads=%v)", q, quad)
+		}
+	}
+}
+
+// TestC4FMSymbolSinkNeverFires confirms the complex symbol tap is a
+// CQPSK-only contract: the C4FM path's symbol domain is the real soft
+// waveform, so SymbolSink must stay uncalled there.
+func TestC4FMSymbolSinkNeverFires(t *testing.T) {
+	const sampleRate = 48_000.0
+	dibits := make([]uint8, 600)
+	for i := range dibits {
+		dibits[i] = uint8((i*7 + 3) & 3)
+	}
+	iq := demod.ModulateP25C4FM(dibits, sampleRate, 1800.0)
+	for i := range iq {
+		iq[i] *= 100
+	}
+
+	symbolCalls := 0
+	dibitCalls := 0
+	r := New(Options{
+		SampleRateHz: sampleRate,
+		DeviationHz:  1800.0,
+		DemodMode:    DemodC4FM,
+		DibitSink:    func(d []uint8, _ int) { dibitCalls += len(d) },
+		SymbolSink:   func(s []complex64) { symbolCalls += len(s) },
+	})
+	r.Process(iq)
+
+	if dibitCalls == 0 {
+		t.Fatal("C4FM path produced no dibits — fixture or path broken")
+	}
+	if symbolCalls != 0 {
+		t.Errorf("C4FM SymbolSink fired %d times, want 0 (C4FM has no complex symbol domain)", symbolCalls)
+	}
+}

--- a/internal/radio/p25/phase1/receiver/receiver.go
+++ b/internal/radio/p25/phase1/receiver/receiver.go
@@ -257,6 +257,17 @@ type Options struct {
 	// batch fired on the same Process call. Nil by default — meant for
 	// the web "Constellation" scope's symbol-domain view.
 	SymbolSink func(symbols []complex64)
+	// EyeSink, when non-nil, receives the *oversampled* matched-filter
+	// output (sps samples per symbol) on the C4FM path, scaled to the
+	// same soft units as SoftSink, together with the integer samples-
+	// per-symbol. Folding this stream over the symbol period yields the
+	// 4-level eye diagram (OP25's "datascope") — the open-eye view that
+	// reveals symbol-timing and SNR health a 1-sample-per-symbol soft
+	// track cannot. Only the C4FM path produces it; the CQPSK path leaves
+	// it uncalled (its quality view is the complex constellation). Nil by
+	// default — meant for the web eye-diagram scope. The slice is reused
+	// across calls; the callee must copy what it needs synchronously.
+	EyeSink func(oversampled []float32, sps int)
 }
 
 // Receiver is the composed IQ → dibit → LDU pipeline. Process is the
@@ -298,6 +309,9 @@ type Receiver struct {
 	dibitSink  phase1.DibitSink
 	softSink   func([]float32)
 	symbolSink func([]complex64)
+	eyeSink    func([]float32, int)
+	eyeSPS     int       // integer samples/symbol for the eye fold (C4FM)
+	eyeBuf     []float32 // scratch for the AGC-scaled oversampled eye output
 	dibitBase  int
 
 	// Reusable scratch slices so Process doesn't allocate per call
@@ -353,11 +367,16 @@ func New(opts Options) *Receiver {
 		dibitSink:  opts.DibitSink,
 		softSink:   opts.SoftSink,
 		symbolSink: opts.SymbolSink,
+		eyeSink:    opts.EyeSink,
 	}
 	switch opts.DemodMode {
 	case DemodCQPSK:
 		r.cq = newCQPSKDemod(opts.SampleRateHz, int(sps+0.5), span, alpha, opts.GardnerGain)
 	default:
+		// Integer samples/symbol for the eye-diagram fold. sps is
+		// SampleRateHz/SymbolRate (10 at the 48 kHz channel rate); the
+		// New guard above already ensured sps >= 2.
+		r.eyeSPS = int(sps + 0.5)
 		r.fm = demod.NewFM()
 		// P25 Phase 1 C4FM is not a root-raised-cosine matched-pair
 		// system: the transmitter shapes with a raised-cosine cascaded
@@ -522,6 +541,27 @@ func (r *Receiver) Process(iq []complex64) {
 		agcLevel := r.agc.process(r.symbols)
 		if r.softSink != nil {
 			r.softSink(r.symbols)
+		}
+		// Eye-diagram tap: emit the oversampled matched-filter output
+		// (which the clock loop read but did not consume), scaled by the
+		// batch's AGC gain so its rails line up with the soft levels the
+		// slicer decides on. Folding sps samples per symbol reconstructs
+		// the 4-level eye. r.matched is still the post-AFC/DDA oversampled
+		// buffer here — MuellerMuller.Process reads it read-only.
+		if r.eyeSink != nil && r.eyeSPS > 0 && len(r.matched) > 0 {
+			g := float32(1)
+			if r.agc.target > 0 && agcLevel > 0 {
+				g = r.agc.target / float32(agcLevel)
+			}
+			if cap(r.eyeBuf) < len(r.matched) {
+				r.eyeBuf = make([]float32, len(r.matched))
+			} else {
+				r.eyeBuf = r.eyeBuf[:len(r.matched)]
+			}
+			for i, x := range r.matched {
+				r.eyeBuf[i] = x * g
+			}
+			r.eyeSink(r.eyeBuf, r.eyeSPS)
 		}
 		// Slice to the 4-level alphabet. The adaptive slicer (when
 		// allocated — the calibrated path) tracks the observed eye and

--- a/internal/radio/p25/phase1/receiver/receiver.go
+++ b/internal/radio/p25/phase1/receiver/receiver.go
@@ -243,6 +243,20 @@ type Options struct {
 	// output level distribution when the slicer collapses to outer
 	// symbols only).
 	SoftSink func(softSamples []float32)
+	// SymbolSink, when non-nil, receives the per-symbol *complex*
+	// constellation points sampled at the symbol-decision instants — the
+	// true symbol-domain constellation (post matched-filter, timing
+	// recovery and carrier recovery, pre differential-decode). Only the
+	// CQPSK / linear path produces these: c.symbols, the post-Costas
+	// π/4-DQPSK points, which on a clean signal cluster at the four
+	// ±45°/±135° constellation positions and degrade to a smeared X as
+	// the eye closes. The C4FM path leaves it uncalled — its symbol
+	// domain is the real 4-level soft waveform, surfaced via SoftSink
+	// (a complex constellation there is just the 4 levels on the real
+	// axis). When called it is aligned index-for-index with the dibit
+	// batch fired on the same Process call. Nil by default — meant for
+	// the web "Constellation" scope's symbol-domain view.
+	SymbolSink func(symbols []complex64)
 }
 
 // Receiver is the composed IQ → dibit → LDU pipeline. Process is the
@@ -280,10 +294,11 @@ type Receiver struct {
 	// DemodCQPSK.
 	cq *cqpskDemod
 
-	assembler *phase1.LDUAssembler
-	dibitSink phase1.DibitSink
-	softSink  func([]float32)
-	dibitBase int
+	assembler  *phase1.LDUAssembler
+	dibitSink  phase1.DibitSink
+	softSink   func([]float32)
+	symbolSink func([]complex64)
+	dibitBase  int
 
 	// Reusable scratch slices so Process doesn't allocate per call
 	// on the C4FM path.
@@ -334,9 +349,10 @@ func New(opts Options) *Receiver {
 	}
 
 	r := &Receiver{
-		demodMode: opts.DemodMode,
-		dibitSink: opts.DibitSink,
-		softSink:  opts.SoftSink,
+		demodMode:  opts.DemodMode,
+		dibitSink:  opts.DibitSink,
+		softSink:   opts.SoftSink,
+		symbolSink: opts.SymbolSink,
 	}
 	switch opts.DemodMode {
 	case DemodCQPSK:
@@ -457,6 +473,15 @@ func (r *Receiver) Process(iq []complex64) {
 		// it directly to the sinks below — both consume
 		// synchronously before the next Process call.
 		r.dibits = r.cq.process(iq)
+		// Surface the complex symbol-decision points for the
+		// constellation scope. cq.symbols is the post-Costas
+		// π/4-DQPSK stream the dibits were decoded from, so it is
+		// aligned index-for-index with r.dibits (DQPSK.Decode emits
+		// one dibit per symbol). Fired before the dibit sinks so a
+		// consumer that pairs the two sees them on the same batch.
+		if r.symbolSink != nil && len(r.cq.symbols) > 0 {
+			r.symbolSink(r.cq.symbols)
+		}
 	} else {
 		r.disc = r.fm.Process(r.disc, iq)
 		r.matched = r.mf.MatchedFilter(r.matched, r.disc)

--- a/internal/scanner/symbolscope/scope.go
+++ b/internal/scanner/symbolscope/scope.go
@@ -80,6 +80,21 @@ type Frame struct {
 	Dibits  []uint8   `json:"dibits"`
 	IsBits  bool      `json:"is_bits"`
 	BaseIdx int       `json:"base_idx"`
+
+	// Receiver-state metrics, read from the live receiver each frame —
+	// the data behind the Tuning panel (OP25's Mixer / Tuner-FLL). The
+	// getters are demod-specific: CarrierOffsetHz is the AFC estimate on
+	// C4FM and the carrier-recovery estimate on CQPSK; ClockMu/ClockSPS
+	// come from Mueller-Müller (C4FM) or Gardner (CQPSK); AGCLevel is the
+	// C4FM symbol-AGC mean|x| or the CQPSK matched-filter AGC gain, with
+	// AGCTarget set only on C4FM; CMAError is the CQPSK equalizer
+	// convergence proxy (0 on C4FM).
+	CarrierOffsetHz float64 `json:"carrier_offset_hz"`
+	AGCLevel        float64 `json:"agc_level"`
+	AGCTarget       float64 `json:"agc_target"`
+	ClockMu         float64 `json:"clock_mu"`
+	ClockSPS        float64 `json:"clock_sps"`
+	CMAError        float64 `json:"cma_error"`
 }
 
 // Options configures an Engine.
@@ -140,6 +155,7 @@ type Engine struct {
 	// each flushed frame and cleared. eyeSPS is the fold period.
 	pendEye   []float32
 	eyeSPS    int
+	isCQPSK   bool // selects which receiver getters to read for metrics
 	isBits    bool
 	baseIdx   int // absolute symbol index of pendDibits[0]
 	totalSyms int // symbols seen across the whole stream
@@ -180,6 +196,7 @@ func New(opts Options) (*Engine, error) {
 		centerHz:     opts.CenterHz,
 		offsetHz:     opts.OffsetHz,
 		frameSymbols: frameSymbols,
+		isCQPSK:      demodMode == p25phase1rx.DemodCQPSK,
 		nowNs:        nowNs,
 		emit:         opts.Emit,
 	}
@@ -307,9 +324,32 @@ func (e *Engine) flush(n int) {
 		IsBits:       e.isBits,
 		BaseIdx:      e.baseIdx,
 	}
+	e.stampMetrics(&frame)
 	e.pendDibits = e.pendDibits[n:]
 	e.baseIdx += n
 	e.emit(frame)
+}
+
+// stampMetrics reads the live receiver's state getters into the frame.
+// The getters are demod-specific (Mueller-Müller vs Gardner, AFC vs
+// carrier-recovery), so this routes by the configured demod mode.
+func (e *Engine) stampMetrics(f *Frame) {
+	if e.rx == nil {
+		return
+	}
+	if e.isCQPSK {
+		f.CarrierOffsetHz = e.rx.CQPSKCarrierOffsetHz()
+		f.AGCLevel = e.rx.CQPSKAGCGain()
+		f.ClockMu = e.rx.GardnerMu()
+		f.ClockSPS = e.rx.GardnerSPS()
+		f.CMAError = e.rx.CMAError()
+		return
+	}
+	f.CarrierOffsetHz = e.rx.AFCOffsetHz()
+	f.AGCLevel = e.rx.AGCLevel()
+	f.AGCTarget = e.rx.AGCTarget()
+	f.ClockMu = e.rx.MMClockMu()
+	f.ClockSPS = e.rx.MMClockSPS()
 }
 
 // Close releases the engine. Idempotent.

--- a/internal/scanner/symbolscope/scope.go
+++ b/internal/scanner/symbolscope/scope.go
@@ -13,10 +13,12 @@
 //
 // Phase 1 supports P25 Phase 1: C4FM emits the FM-discriminator soft
 // waveform aligned index-for-index with the sliced dibits; CQPSK emits
-// the dibits only (the receiver has no soft tap on that path yet). Other
-// protocols — and a soft waveform for them — are a follow-up that adds a
-// uniform soft tap to the remaining receivers; the Frame shape and this
-// API are designed to absorb that without change.
+// the complex symbol-decision points (SymI/SymQ) — the true
+// constellation — alongside the dibits, but no real soft track (its
+// quality view is the constellation, not a 4-level eye). Other protocols
+// — and a soft waveform for them — are a follow-up that adds a uniform
+// soft tap to the remaining receivers; the Frame shape and this API are
+// designed to absorb that without change.
 package symbolscope
 
 import (
@@ -45,12 +47,22 @@ const defaultFrameSymbols = 256
 // false, 0..1 when true). When Soft is non-empty it is aligned
 // index-for-index with Dibits. BaseIdx is the absolute symbol index the
 // batch starts at, so a client can detect gaps.
+//
+// SymI/SymQ are the complex symbol-decision points — the true
+// symbol-domain constellation sampled at each recovered symbol instant.
+// They are populated only on the linear/CQPSK path (the post-Costas
+// π/4-DQPSK points, which cluster at the four ±45°/±135° positions on a
+// clean signal); the C4FM path leaves them empty because its symbol
+// domain is the real 4-level soft already carried in Soft. When
+// non-empty they are aligned index-for-index with Dibits.
 type Frame struct {
 	TimestampNs  int64     `json:"ts_ns"`
 	SymbolRateHz float64   `json:"symbol_rate_hz"`
 	CenterHz     uint32    `json:"center_hz"`
 	OffsetHz     int32     `json:"offset_hz"`
 	Soft         []float32 `json:"soft"`
+	SymI         []float32 `json:"sym_i"`
+	SymQ         []float32 `json:"sym_q"`
 	Dibits       []uint8   `json:"dibits"`
 	IsBits       bool      `json:"is_bits"`
 	BaseIdx      int       `json:"base_idx"`
@@ -103,8 +115,11 @@ type Engine struct {
 	chanBuf []complex64
 
 	// Per-frame accumulators. soft grows in lockstep with dibits on the
-	// C4FM path; it stays empty on paths without a soft tap.
+	// C4FM path; it stays empty on paths without a soft tap. pendSym
+	// grows in lockstep with dibits on the CQPSK path (the complex
+	// constellation points); it stays empty on the C4FM path.
 	pendSoft   []float32
+	pendSym    []complex64
 	pendDibits []uint8
 	isBits     bool
 	baseIdx    int // absolute symbol index of pendDibits[0]
@@ -159,6 +174,7 @@ func New(opts Options) (*Engine, error) {
 		DeviationHz:  p25DeviationHz,
 		DemodMode:    demodMode,
 		SoftSink:     e.onSoft,
+		SymbolSink:   e.onSymbols,
 		DibitSink:    e.onDibits,
 	})
 	return e, nil
@@ -178,6 +194,13 @@ func (e *Engine) Process(iq []complex64) {
 // the same batch, pairs them with the sliced decisions.
 func (e *Engine) onSoft(soft []float32) {
 	e.pendSoft = append(e.pendSoft, soft...)
+}
+
+// onSymbols stashes the complex symbol-decision points (CQPSK path);
+// onDibits pairs them with the sliced decisions, exactly as onSoft does
+// for the C4FM soft track.
+func (e *Engine) onSymbols(syms []complex64) {
+	e.pendSym = append(e.pendSym, syms...)
 }
 
 func (e *Engine) onDibits(dibits []uint8, _ int) {
@@ -216,12 +239,29 @@ func (e *Engine) flush(n int) {
 		e.pendSoft = e.pendSoft[:0]
 	}
 
+	// Complex symbol track (CQPSK), carried only when it stayed aligned
+	// with the dibit stream — the same guard the soft track uses.
+	var symI, symQ []float32
+	if len(e.pendSym) == len(e.pendDibits) {
+		symI = make([]float32, n)
+		symQ = make([]float32, n)
+		for i, s := range e.pendSym[:n] {
+			symI[i] = real(s)
+			symQ[i] = imag(s)
+		}
+		e.pendSym = e.pendSym[n:]
+	} else {
+		e.pendSym = e.pendSym[:0]
+	}
+
 	frame := Frame{
 		TimestampNs:  e.nowNs(),
 		SymbolRateHz: e.symbolRateHz,
 		CenterHz:     e.centerHz,
 		OffsetHz:     e.offsetHz,
 		Soft:         soft,
+		SymI:         symI,
+		SymQ:         symQ,
 		Dibits:       dibits,
 		IsBits:       e.isBits,
 		BaseIdx:      e.baseIdx,
@@ -234,6 +274,7 @@ func (e *Engine) flush(n int) {
 // Close releases the engine. Idempotent.
 func (e *Engine) Close() error {
 	e.pendSoft = nil
+	e.pendSym = nil
 	e.pendDibits = nil
 	return nil
 }

--- a/internal/scanner/symbolscope/scope.go
+++ b/internal/scanner/symbolscope/scope.go
@@ -41,6 +41,12 @@ const p25DeviationHz = 1800.0
 // matching the diag stream's ~50 ms cadence.
 const defaultFrameSymbols = 256
 
+// maxEyeSamples bounds the oversampled eye window carried per frame. At
+// 10 sps that is ~150 symbols of overlay — ample to render a stable eye —
+// while keeping the WS payload modest (the oversampled stream is sps×
+// the soft rate, so it is capped rather than sent in full).
+const maxEyeSamples = 1536
+
 // Frame is one batch of recovered symbols. Soft is the pre-slicer soft
 // waveform (empty when the demod path exposes no soft tap, e.g. P25
 // CQPSK); Dibits are the sliced decisions (values 0..3 when IsBits is
@@ -63,9 +69,17 @@ type Frame struct {
 	Soft         []float32 `json:"soft"`
 	SymI         []float32 `json:"sym_i"`
 	SymQ         []float32 `json:"sym_q"`
-	Dibits       []uint8   `json:"dibits"`
-	IsBits       bool      `json:"is_bits"`
-	BaseIdx      int       `json:"base_idx"`
+	// EyeSoft is a window of the oversampled, AGC-scaled matched-filter
+	// output (EyeSPS samples per symbol) on the C4FM path — fold it over
+	// the symbol period for the 4-level eye diagram. Empty on paths
+	// without an eye tap (CQPSK). It is NOT aligned with Dibits (it runs
+	// EyeSPS× faster) and is a bounded recent window, not the full
+	// stream. EyeSPS is the integer samples-per-symbol to fold on.
+	EyeSoft []float32 `json:"eye_soft"`
+	EyeSPS  int       `json:"eye_sps"`
+	Dibits  []uint8   `json:"dibits"`
+	IsBits  bool      `json:"is_bits"`
+	BaseIdx int       `json:"base_idx"`
 }
 
 // Options configures an Engine.
@@ -121,9 +135,14 @@ type Engine struct {
 	pendSoft   []float32
 	pendSym    []complex64
 	pendDibits []uint8
-	isBits     bool
-	baseIdx    int // absolute symbol index of pendDibits[0]
-	totalSyms  int // symbols seen across the whole stream
+	// pendEye accumulates oversampled eye samples (C4FM); it runs faster
+	// than the symbol stream and is a bounded recent window, attached to
+	// each flushed frame and cleared. eyeSPS is the fold period.
+	pendEye   []float32
+	eyeSPS    int
+	isBits    bool
+	baseIdx   int // absolute symbol index of pendDibits[0]
+	totalSyms int // symbols seen across the whole stream
 }
 
 // New constructs an Engine. Returns an error for an unsupported
@@ -175,6 +194,7 @@ func New(opts Options) (*Engine, error) {
 		DemodMode:    demodMode,
 		SoftSink:     e.onSoft,
 		SymbolSink:   e.onSymbols,
+		EyeSink:      e.onEye,
 		DibitSink:    e.onDibits,
 	})
 	return e, nil
@@ -201,6 +221,16 @@ func (e *Engine) onSoft(soft []float32) {
 // for the C4FM soft track.
 func (e *Engine) onSymbols(syms []complex64) {
 	e.pendSym = append(e.pendSym, syms...)
+}
+
+// onEye accumulates the oversampled eye samples (C4FM), keeping only the
+// most recent maxEyeSamples so the per-frame window stays bounded.
+func (e *Engine) onEye(samples []float32, sps int) {
+	e.eyeSPS = sps
+	e.pendEye = append(e.pendEye, samples...)
+	if len(e.pendEye) > maxEyeSamples {
+		e.pendEye = e.pendEye[len(e.pendEye)-maxEyeSamples:]
+	}
 }
 
 func (e *Engine) onDibits(dibits []uint8, _ int) {
@@ -254,6 +284,15 @@ func (e *Engine) flush(n int) {
 		e.pendSym = e.pendSym[:0]
 	}
 
+	// Eye window (C4FM): hand the current bounded window to this frame and
+	// clear it, so a later flush in the same drain doesn't duplicate it.
+	var eye []float32
+	if len(e.pendEye) > 0 {
+		eye = make([]float32, len(e.pendEye))
+		copy(eye, e.pendEye)
+		e.pendEye = e.pendEye[:0]
+	}
+
 	frame := Frame{
 		TimestampNs:  e.nowNs(),
 		SymbolRateHz: e.symbolRateHz,
@@ -262,6 +301,8 @@ func (e *Engine) flush(n int) {
 		Soft:         soft,
 		SymI:         symI,
 		SymQ:         symQ,
+		EyeSoft:      eye,
+		EyeSPS:       e.eyeSPS,
 		Dibits:       dibits,
 		IsBits:       e.isBits,
 		BaseIdx:      e.baseIdx,
@@ -275,6 +316,7 @@ func (e *Engine) flush(n int) {
 func (e *Engine) Close() error {
 	e.pendSoft = nil
 	e.pendSym = nil
+	e.pendEye = nil
 	e.pendDibits = nil
 	return nil
 }

--- a/internal/scanner/symbolscope/scope_test.go
+++ b/internal/scanner/symbolscope/scope_test.go
@@ -119,6 +119,20 @@ func TestC4FMRecoversSoftAndDibits(t *testing.T) {
 		t.Error("C4FM path emitted no eye window (EyeSoft empty on every frame)")
 	}
 
+	// Receiver-state metrics for the Tuning panel: the C4FM path reports a
+	// Mueller-Müller clock (ClockSPS > 0) and a calibrated symbol-AGC
+	// target (DeviationHz was set), but never a CMA error (CQPSK-only).
+	last := frames[len(frames)-1]
+	if last.ClockSPS <= 0 {
+		t.Errorf("C4FM ClockSPS = %v, want > 0 (Mueller-Müller nominal sps)", last.ClockSPS)
+	}
+	if last.AGCTarget <= 0 {
+		t.Errorf("C4FM AGCTarget = %v, want > 0 (calibrated from DeviationHz)", last.AGCTarget)
+	}
+	if last.CMAError != 0 {
+		t.Errorf("C4FM CMAError = %v, want 0 (no CMA stage on C4FM)", last.CMAError)
+	}
+
 	// All four levels should be populated, and their mean soft values
 	// must be mutually separated — the 4-band structure of the scope.
 	means := make([]float64, 0, 4)
@@ -193,6 +207,16 @@ func TestCQPSKEmitsComplexSymbolsWithoutSoft(t *testing.T) {
 	}
 	if !sawSymbols {
 		t.Fatal("CQPSK path emitted no complex symbol points")
+	}
+
+	// Tuning metrics on the CQPSK path: a Gardner clock (ClockSPS > 0) and
+	// no C4FM symbol-AGC target (that getter is C4FM-only).
+	last := frames[len(frames)-1]
+	if last.ClockSPS <= 0 {
+		t.Errorf("CQPSK ClockSPS = %v, want > 0 (Gardner nominal sps)", last.ClockSPS)
+	}
+	if last.AGCTarget != 0 {
+		t.Errorf("CQPSK AGCTarget = %v, want 0 (C4FM-only getter)", last.AGCTarget)
 	}
 }
 

--- a/internal/scanner/symbolscope/scope_test.go
+++ b/internal/scanner/symbolscope/scope_test.go
@@ -71,8 +71,18 @@ func TestC4FMRecoversSoftAndDibits(t *testing.T) {
 	// Per-dibit soft accumulators across all frames.
 	var sum [4]float64
 	var cnt [4]int
+	var sawEye bool
 	wantBase := 0
 	for fi, f := range frames {
+		if len(f.EyeSoft) > 0 {
+			sawEye = true
+			if f.EyeSPS < 2 {
+				t.Errorf("frame %d: EyeSPS = %d, want >= 2 (oversampled fold period)", fi, f.EyeSPS)
+			}
+			if len(f.EyeSoft) > maxEyeSamples {
+				t.Errorf("frame %d: EyeSoft len %d exceeds cap %d", fi, len(f.EyeSoft), maxEyeSamples)
+			}
+		}
 		if f.IsBits {
 			t.Errorf("frame %d: IsBits = true, want false for C4FM dibits", fi)
 		}
@@ -101,6 +111,12 @@ func TestC4FMRecoversSoftAndDibits(t *testing.T) {
 			sum[d] += float64(f.Soft[i])
 			cnt[d]++
 		}
+	}
+
+	// The C4FM path must surface the oversampled eye window for the
+	// datascope — the open 4-level eye view a 1/symbol soft track can't give.
+	if !sawEye {
+		t.Error("C4FM path emitted no eye window (EyeSoft empty on every frame)")
 	}
 
 	// All four levels should be populated, and their mean soft values
@@ -153,6 +169,9 @@ func TestCQPSKEmitsComplexSymbolsWithoutSoft(t *testing.T) {
 	for fi, f := range frames {
 		if len(f.Soft) != 0 {
 			t.Errorf("frame %d: CQPSK soft track should be empty, got %d", fi, len(f.Soft))
+		}
+		if len(f.EyeSoft) != 0 {
+			t.Errorf("frame %d: CQPSK eye track should be empty (C4FM-only), got %d", fi, len(f.EyeSoft))
 		}
 		// The complex symbol track, when present, must be aligned with the
 		// dibits on both axes — that pairing is what lets a client colour

--- a/internal/scanner/symbolscope/scope_test.go
+++ b/internal/scanner/symbolscope/scope_test.go
@@ -89,6 +89,11 @@ func TestC4FMRecoversSoftAndDibits(t *testing.T) {
 		if f.TimestampNs != 42 {
 			t.Errorf("frame %d: TimestampNs = %d, want 42 (injected clock)", fi, f.TimestampNs)
 		}
+		// C4FM's symbol domain is the real 4-level soft, not a complex
+		// constellation — the SymI/SymQ track stays empty on this path.
+		if len(f.SymI) != 0 || len(f.SymQ) != 0 {
+			t.Errorf("frame %d: C4FM should carry no complex symbol track, got SymI=%d SymQ=%d", fi, len(f.SymI), len(f.SymQ))
+		}
 		for i, d := range f.Dibits {
 			if d > 3 {
 				t.Fatalf("frame %d: dibit %d out of range", fi, d)
@@ -120,10 +125,12 @@ func TestC4FMRecoversSoftAndDibits(t *testing.T) {
 	}
 }
 
-// TestCQPSKEmitsDibitsWithoutSoft locks in the honest Phase-1 contract:
-// the CQPSK path has no soft tap, so frames carry dibits but an empty
-// soft track.
-func TestCQPSKEmitsDibitsWithoutSoft(t *testing.T) {
+// TestCQPSKEmitsComplexSymbolsWithoutSoft locks in the Phase-1 contract
+// for the linear path: CQPSK has no real soft tap (its quality view is
+// the constellation), so frames carry an empty Soft track but a complex
+// symbol-decision track (SymI/SymQ) aligned index-for-index with the
+// dibits.
+func TestCQPSKEmitsComplexSymbolsWithoutSoft(t *testing.T) {
 	iq, _ := makeC4FMIQ(960_000, 4000) // any IQ drives the Gardner loop
 
 	var frames []Frame
@@ -142,15 +149,31 @@ func TestCQPSKEmitsDibitsWithoutSoft(t *testing.T) {
 	if len(frames) == 0 {
 		t.Fatal("no frames emitted on CQPSK path")
 	}
+	sawSymbols := false
 	for fi, f := range frames {
 		if len(f.Soft) != 0 {
 			t.Errorf("frame %d: CQPSK soft track should be empty, got %d", fi, len(f.Soft))
+		}
+		// The complex symbol track, when present, must be aligned with the
+		// dibits on both axes — that pairing is what lets a client colour
+		// constellation points by their decided dibit.
+		if len(f.SymI) != len(f.SymQ) {
+			t.Fatalf("frame %d: SymI len %d != SymQ len %d", fi, len(f.SymI), len(f.SymQ))
+		}
+		if len(f.SymI) != 0 {
+			if len(f.SymI) != len(f.Dibits) {
+				t.Fatalf("frame %d: symbol track len %d != dibit len %d", fi, len(f.SymI), len(f.Dibits))
+			}
+			sawSymbols = true
 		}
 		for _, d := range f.Dibits {
 			if d > 3 {
 				t.Fatalf("frame %d: dibit %d out of range", fi, d)
 			}
 		}
+	}
+	if !sawSymbols {
+		t.Fatal("CQPSK path emitted no complex symbol points")
 	}
 }
 

--- a/node_modules/.vite/vitest/da39a3ee5e6b4b0d3255bfef95601890afd80709/results.json
+++ b/node_modules/.vite/vitest/da39a3ee5e6b4b0d3255bfef95601890afd80709/results.json
@@ -1,0 +1,1 @@
+{"version":"4.1.8","results":[[":web/src/panels/Histogram.test.tsx",{"duration":6.775311000000045,"failed":true}]]}

--- a/web/src/App.panels.test.tsx
+++ b/web/src/App.panels.test.tsx
@@ -112,11 +112,12 @@ vi.mock("./api/client", () => {
 
 // Metrics renders a Chart.js line chart; stub the chart libs so the
 // panel mounts under jsdom without a real <canvas> backend.
-vi.mock("react-chartjs-2", () => ({ Line: () => null }));
+vi.mock("react-chartjs-2", () => ({ Line: () => null, Bar: () => null }));
 vi.mock("chart.js", () => {
   const noop = class {};
   return {
     Chart: { register: () => {} },
+    BarElement: noop,
     CategoryScale: noop,
     Filler: noop,
     Legend: noop,

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -12,6 +12,7 @@ import { CCActivity } from "./panels/CCActivity";
 import { Constellation } from "./panels/Constellation";
 import { SymbolScope } from "./panels/SymbolScope";
 import { EyeDiagram } from "./panels/EyeDiagram";
+import { Tuning } from "./panels/Tuning";
 import { Dashboard } from "./panels/Dashboard";
 import { Devices } from "./panels/Devices";
 import { Events } from "./panels/Events";
@@ -59,6 +60,7 @@ const EXTRA_TABS: Tab[] = [
   { to: "/constellation", label: "Constellation", icon: "✦" },
   { to: "/symbols", label: "Symbol scope", icon: "⩘" },
   { to: "/eye", label: "Eye diagram", icon: "◉" },
+  { to: "/tuning", label: "Tuning", icon: "⊹" },
   { to: "/bookmarks", label: "Bookmarks", icon: "★" },
   { to: "/metrics", label: "Metrics", icon: "▰" },
   { to: "/devices", label: "Devices", icon: "⌗" },
@@ -203,6 +205,7 @@ export function App() {
           <Route path="/constellation" element={<Constellation />} />
           <Route path="/symbols" element={<SymbolScope />} />
           <Route path="/eye" element={<EyeDiagram />} />
+          <Route path="/tuning" element={<Tuning />} />
           <Route path="/bookmarks" element={<Bookmarks />} />
           <Route path="/systems" element={<Systems />} />
           <Route path="/talkgroups" element={<Talkgroups />} />

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -13,6 +13,7 @@ import { Constellation } from "./panels/Constellation";
 import { SymbolScope } from "./panels/SymbolScope";
 import { EyeDiagram } from "./panels/EyeDiagram";
 import { Tuning } from "./panels/Tuning";
+import { Histogram } from "./panels/Histogram";
 import { Dashboard } from "./panels/Dashboard";
 import { Devices } from "./panels/Devices";
 import { Events } from "./panels/Events";
@@ -61,6 +62,7 @@ const EXTRA_TABS: Tab[] = [
   { to: "/symbols", label: "Symbol scope", icon: "⩘" },
   { to: "/eye", label: "Eye diagram", icon: "◉" },
   { to: "/tuning", label: "Tuning", icon: "⊹" },
+  { to: "/histogram", label: "Histogram", icon: "▥" },
   { to: "/bookmarks", label: "Bookmarks", icon: "★" },
   { to: "/metrics", label: "Metrics", icon: "▰" },
   { to: "/devices", label: "Devices", icon: "⌗" },
@@ -206,6 +208,7 @@ export function App() {
           <Route path="/symbols" element={<SymbolScope />} />
           <Route path="/eye" element={<EyeDiagram />} />
           <Route path="/tuning" element={<Tuning />} />
+          <Route path="/histogram" element={<Histogram />} />
           <Route path="/bookmarks" element={<Bookmarks />} />
           <Route path="/systems" element={<Systems />} />
           <Route path="/talkgroups" element={<Talkgroups />} />

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -14,6 +14,7 @@ import { SymbolScope } from "./panels/SymbolScope";
 import { EyeDiagram } from "./panels/EyeDiagram";
 import { Tuning } from "./panels/Tuning";
 import { Histogram } from "./panels/Histogram";
+import { Plots } from "./panels/Plots";
 import { Dashboard } from "./panels/Dashboard";
 import { Devices } from "./panels/Devices";
 import { Events } from "./panels/Events";
@@ -58,11 +59,7 @@ const EXTRA_TABS: Tab[] = [
   { to: "/adsb", label: "ADS-B", icon: "✈" },
   { to: "/mdc1200", label: "MDC1200", icon: "📻" },
   { to: "/spectrum", label: "Spectrum", icon: "≈" },
-  { to: "/constellation", label: "Constellation", icon: "✦" },
-  { to: "/symbols", label: "Symbol scope", icon: "⩘" },
-  { to: "/eye", label: "Eye diagram", icon: "◉" },
-  { to: "/tuning", label: "Tuning", icon: "⊹" },
-  { to: "/histogram", label: "Histogram", icon: "▥" },
+  { to: "/plots", label: "Plots", icon: "✦" },
   { to: "/bookmarks", label: "Bookmarks", icon: "★" },
   { to: "/metrics", label: "Metrics", icon: "▰" },
   { to: "/devices", label: "Devices", icon: "⌗" },
@@ -204,6 +201,8 @@ export function App() {
           <Route path="/scanner" element={<Scanner />} />
           <Route path="/hunt" element={<Hunt />} />
           <Route path="/spectrum" element={<Spectrum />} />
+          <Route path="/plots" element={<Plots />} />
+          <Route path="/plots/:tab" element={<Plots />} />
           <Route path="/constellation" element={<Constellation />} />
           <Route path="/symbols" element={<SymbolScope />} />
           <Route path="/eye" element={<EyeDiagram />} />

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -11,6 +11,7 @@ import { Bookmarks } from "./panels/Bookmarks";
 import { CCActivity } from "./panels/CCActivity";
 import { Constellation } from "./panels/Constellation";
 import { SymbolScope } from "./panels/SymbolScope";
+import { EyeDiagram } from "./panels/EyeDiagram";
 import { Dashboard } from "./panels/Dashboard";
 import { Devices } from "./panels/Devices";
 import { Events } from "./panels/Events";
@@ -57,6 +58,7 @@ const EXTRA_TABS: Tab[] = [
   { to: "/spectrum", label: "Spectrum", icon: "≈" },
   { to: "/constellation", label: "Constellation", icon: "✦" },
   { to: "/symbols", label: "Symbol scope", icon: "⩘" },
+  { to: "/eye", label: "Eye diagram", icon: "◉" },
   { to: "/bookmarks", label: "Bookmarks", icon: "★" },
   { to: "/metrics", label: "Metrics", icon: "▰" },
   { to: "/devices", label: "Devices", icon: "⌗" },
@@ -200,6 +202,7 @@ export function App() {
           <Route path="/spectrum" element={<Spectrum />} />
           <Route path="/constellation" element={<Constellation />} />
           <Route path="/symbols" element={<SymbolScope />} />
+          <Route path="/eye" element={<EyeDiagram />} />
           <Route path="/bookmarks" element={<Bookmarks />} />
           <Route path="/systems" element={<Systems />} />
           <Route path="/talkgroups" element={<Talkgroups />} />

--- a/web/src/api/symbols.ts
+++ b/web/src/api/symbols.ts
@@ -12,6 +12,12 @@ export interface SymbolFrame {
   // (e.g. P25 CQPSK). When present it is aligned index-for-index with
   // dibits.
   soft: number[];
+  // Complex symbol-decision points (the true constellation): in-phase /
+  // quadrature components sampled at each symbol instant. Populated only
+  // on the linear/CQPSK path; empty on C4FM. When present they are
+  // aligned index-for-index with dibits.
+  sym_i: number[];
+  sym_q: number[];
   // Sliced decisions: 0..3 when is_bits is false, 0..1 when true.
   dibits: number[];
   is_bits: boolean;

--- a/web/src/api/symbols.ts
+++ b/web/src/api/symbols.ts
@@ -27,6 +27,17 @@ export interface SymbolFrame {
   dibits: number[];
   is_bits: boolean;
   base_idx: number;
+  // Receiver-state metrics for the Tuning panel. carrier_offset_hz is the
+  // AFC estimate (C4FM) or carrier-recovery estimate (CQPSK); agc_level
+  // the C4FM symbol-AGC mean|x| or CQPSK matched-filter gain; agc_target
+  // the C4FM AGC target (0 on CQPSK); clock_mu/clock_sps the symbol-clock
+  // loop state; cma_error the CQPSK equalizer convergence proxy (0 on C4FM).
+  carrier_offset_hz: number;
+  agc_level: number;
+  agc_target: number;
+  clock_mu: number;
+  clock_sps: number;
+  cma_error: number;
 }
 
 export type SymbolFrameHandler = (f: SymbolFrame) => void;

--- a/web/src/api/symbols.ts
+++ b/web/src/api/symbols.ts
@@ -18,6 +18,11 @@ export interface SymbolFrame {
   // aligned index-for-index with dibits.
   sym_i: number[];
   sym_q: number[];
+  // Bounded window of oversampled, AGC-scaled matched-filter output
+  // (eye_sps samples per symbol) for the C4FM eye diagram; empty on
+  // CQPSK. Fold over eye_sps to render the 4-level eye.
+  eye_soft: number[];
+  eye_sps: number;
   // Sliced decisions: 0..3 when is_bits is false, 0..1 when true.
   dibits: number[];
   is_bits: boolean;

--- a/web/src/components/EyeDiagramChart.tsx
+++ b/web/src/components/EyeDiagramChart.tsx
@@ -1,0 +1,124 @@
+import { useEffect, useRef } from "react";
+
+// EyeDiagramChart folds the oversampled, AGC-scaled matched-filter output
+// over the symbol period and overlays the resulting 2-symbol windows —
+// GopherTrunk's take on OP25's "datascope". A healthy P25 C4FM channel
+// shows four open horizontal bands (the ±1/±3 rails) with clear vertical
+// gaps between them at the symbol-decision instant; a closed eye (bands
+// merging, no gap) means symbol-timing or SNR trouble.
+//
+// Unlike the Symbol scope's 1-sample-per-symbol soft trace, this needs
+// the oversampled stream (eye_sps samples/symbol) so the intra-symbol
+// transitions — the eye's "lids" — are actually drawn.
+
+export interface EyeDiagramChartProps {
+  // Oversampled soft samples (sps per symbol), AGC-scaled to soft units.
+  eye: number[];
+  // Samples per symbol to fold on.
+  sps: number;
+  height?: number;
+  className?: string;
+}
+
+const CANVAS_W = 720;
+const DEFAULT_H = 260;
+const PAD = { top: 14, right: 12, bottom: 18, left: 30 };
+
+// Sky-400 accent / neutral slate grid, matching the other scopes.
+const TRACE_RGB = "56, 189, 248";
+const GRID_RGB = "148, 163, 184";
+
+// Cap overlaid traces so a large buffer can't stall the paint.
+const MAX_TRACES = 500;
+
+export function EyeDiagramChart({
+  eye,
+  sps,
+  height = DEFAULT_H,
+  className,
+}: EyeDiagramChartProps) {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+  useEffect(() => {
+    paint(canvasRef.current, eye, sps);
+  }, [eye, sps]);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      width={CANVAS_W}
+      height={height}
+      className={className ?? "block w-full"}
+      style={{ height }}
+      aria-label="C4FM eye diagram"
+    />
+  );
+}
+
+function paint(canvas: HTMLCanvasElement | null, eye: number[], sps: number) {
+  if (!canvas) return;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return;
+  const w = canvas.width;
+  const h = canvas.height;
+  const plotW = w - PAD.left - PAD.right;
+  const plotH = h - PAD.top - PAD.bottom;
+  const x0 = PAD.left;
+  const y0 = PAD.top;
+
+  ctx.fillStyle = "rgb(0, 0, 0)";
+  ctx.fillRect(0, 0, w, h);
+
+  // Y extent from the data, with headroom; symmetric about zero so the
+  // four rails sit at ±ext and ±ext/3.
+  let ext = 0;
+  for (const v of eye) {
+    const a = Math.abs(v);
+    if (a > ext) ext = a;
+  }
+  if (!(ext > 0)) ext = 1;
+  const top = ext * 1.15;
+  const toY = (v: number) => y0 + plotH * (1 - (v + top) / (2 * top));
+
+  // Decision rails at the four C4FM levels (±1, ±3 of the eye scale).
+  ctx.strokeStyle = `rgba(${GRID_RGB}, 0.18)`;
+  ctx.lineWidth = 1;
+  for (const lvl of [-ext, -ext / 3, ext / 3, ext]) {
+    const ry = toY(lvl);
+    ctx.beginPath();
+    ctx.moveTo(x0, ry);
+    ctx.lineTo(x0 + plotW, ry);
+    ctx.stroke();
+  }
+  // Zero line + symbol-centre marker (vertical, mid-window).
+  ctx.strokeStyle = `rgba(${GRID_RGB}, 0.30)`;
+  ctx.beginPath();
+  ctx.moveTo(x0, toY(0));
+  ctx.lineTo(x0 + plotW, toY(0));
+  ctx.moveTo(x0 + plotW / 2, y0);
+  ctx.lineTo(x0 + plotW / 2, y0 + plotH);
+  ctx.stroke();
+
+  const period = Math.max(2, Math.floor(sps) || 2);
+  const win = 2 * period; // 2-symbol eye window
+  if (eye.length < win) return;
+
+  // Step so we never draw more than MAX_TRACES overlaid windows.
+  const nWindows = Math.floor((eye.length - win) / period) + 1;
+  const stride = Math.max(period, Math.ceil(nWindows / MAX_TRACES) * period);
+
+  ctx.globalCompositeOperation = "lighter";
+  ctx.strokeStyle = `rgba(${TRACE_RGB}, 0.16)`;
+  ctx.lineWidth = 1;
+  for (let start = 0; start + win <= eye.length; start += stride) {
+    ctx.beginPath();
+    for (let k = 0; k < win; k++) {
+      const x = x0 + (k / (win - 1)) * plotW;
+      const y = toY(eye[start + k]);
+      if (k === 0) ctx.moveTo(x, y);
+      else ctx.lineTo(x, y);
+    }
+    ctx.stroke();
+  }
+  ctx.globalCompositeOperation = "source-over";
+}

--- a/web/src/panels/Constellation.test.tsx
+++ b/web/src/panels/Constellation.test.tsx
@@ -9,8 +9,13 @@ vi.mock("../api/diag", () => ({
   openIQStream: vi.fn(),
 }));
 
+vi.mock("../api/symbols", () => ({
+  openSymbolStream: vi.fn(),
+}));
+
 import { fetchSpectrumDevices } from "../api/spectrum";
 import { openIQStream } from "../api/diag";
+import { openSymbolStream } from "../api/symbols";
 import { useShared } from "../store/shared";
 import { Constellation } from "./Constellation";
 
@@ -33,11 +38,23 @@ function resetStore() {
   });
 }
 
+const ONE_DEVICE = [
+  {
+    serial: "rtl-1",
+    driver: "rtlsdr",
+    role: "control",
+    center_hz: 851_012_500,
+    sample_rate_hz: 2_048_000,
+  },
+];
+
 describe("Constellation panel", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     resetStore();
     window.localStorage.clear();
+    vi.mocked(openIQStream).mockReturnValue({ close: vi.fn() });
+    vi.mocked(openSymbolStream).mockReturnValue({ close: vi.fn() });
   });
 
   it("renders an empty-state when no SDRs are available", async () => {
@@ -46,22 +63,34 @@ describe("Constellation panel", () => {
     await waitFor(() => {
       expect(screen.getByText("No SDRs available")).toBeInTheDocument();
     });
+    expect(openSymbolStream).not.toHaveBeenCalled();
     expect(openIQStream).not.toHaveBeenCalled();
   });
 
-  it("opens a diag IQ stream against the first device", async () => {
-    vi.mocked(fetchSpectrumDevices).mockResolvedValue([
-      {
-        serial: "rtl-1",
-        driver: "rtlsdr",
-        role: "control",
-        center_hz: 851_012_500,
-        sample_rate_hz: 2_048_000,
-      },
-    ]);
-    vi.mocked(openIQStream).mockReturnValue({ close: vi.fn() });
+  it("defaults to the symbols view and opens a symbol stream", async () => {
+    vi.mocked(fetchSpectrumDevices).mockResolvedValue(ONE_DEVICE as never);
 
     render(<Constellation />);
+    await waitFor(() => {
+      expect(openSymbolStream).toHaveBeenCalledTimes(1);
+    });
+    const callArgs = vi.mocked(openSymbolStream).mock.calls[0]?.[1];
+    expect(callArgs?.serial).toBe("rtl-1");
+    expect(callArgs?.proto).toBeTruthy();
+    // The raw IQ stream stays closed until the operator switches View.
+    expect(openIQStream).not.toHaveBeenCalled();
+  });
+
+  it("switches to the vector scope and opens a raw IQ stream", async () => {
+    vi.mocked(fetchSpectrumDevices).mockResolvedValue(ONE_DEVICE as never);
+
+    render(<Constellation />);
+    await waitFor(() => {
+      expect(openSymbolStream).toHaveBeenCalled();
+    });
+    fireEvent.change(screen.getByLabelText("Constellation source"), {
+      target: { value: "raw" },
+    });
     await waitFor(() => {
       expect(openIQStream).toHaveBeenCalledTimes(1);
     });
@@ -70,17 +99,25 @@ describe("Constellation panel", () => {
     expect(callArgs?.rate).toBeGreaterThan(0);
   });
 
+  it("re-subscribes the symbol stream when the demod mode changes", async () => {
+    vi.mocked(fetchSpectrumDevices).mockResolvedValue(ONE_DEVICE as never);
+
+    render(<Constellation />);
+    await waitFor(() => {
+      expect(openSymbolStream).toHaveBeenCalledTimes(1);
+    });
+    fireEvent.change(screen.getByLabelText("Demodulation mode"), {
+      target: { value: "p25-c4fm" },
+    });
+    await waitFor(() => {
+      const last = vi.mocked(openSymbolStream).mock.calls.at(-1)?.[1];
+      expect(last?.proto).toBe("p25-c4fm");
+    });
+  });
+
   it("shows the live status pill when the WS reports open", async () => {
-    vi.mocked(fetchSpectrumDevices).mockResolvedValue([
-      {
-        serial: "rtl-1",
-        driver: "rtlsdr",
-        role: "control",
-        center_hz: 0,
-        sample_rate_hz: 2_048_000,
-      },
-    ]);
-    vi.mocked(openIQStream).mockImplementation((_cfg, opts) => {
+    vi.mocked(fetchSpectrumDevices).mockResolvedValue(ONE_DEVICE as never);
+    vi.mocked(openSymbolStream).mockImplementation((_cfg, opts) => {
       opts.onStatus?.("open");
       return { close: vi.fn() };
     });
@@ -108,8 +145,7 @@ describe("Constellation panel", () => {
         center_hz: 851_000_000,
         sample_rate_hz: 2_048_000,
       },
-    ]);
-    vi.mocked(openIQStream).mockReturnValue({ close: vi.fn() });
+    ] as never);
 
     // A locked voice call 25 kHz above centre → offset should be 25000 Hz.
     useShared.setState({
@@ -129,73 +165,46 @@ describe("Constellation panel", () => {
 
     render(<Constellation />);
     await waitFor(() => {
-      const calls = vi.mocked(openIQStream).mock.calls;
+      const calls = vi.mocked(openSymbolStream).mock.calls;
       const last = calls[calls.length - 1]?.[1];
       expect(last?.offset).toBe(25_000);
     });
   });
 
   it("exposes a zoom control and an absolute-frequency (MHz) input", async () => {
-    vi.mocked(fetchSpectrumDevices).mockResolvedValue([
-      {
-        serial: "rtl-1",
-        driver: "rtlsdr",
-        role: "control",
-        center_hz: 851_000_000,
-        sample_rate_hz: 2_048_000,
-      },
-    ]);
-    vi.mocked(openIQStream).mockReturnValue({ close: vi.fn() });
+    vi.mocked(fetchSpectrumDevices).mockResolvedValue(ONE_DEVICE as never);
 
     render(<Constellation />);
     await waitFor(() => {
-      expect(openIQStream).toHaveBeenCalled();
+      expect(openSymbolStream).toHaveBeenCalled();
     });
     expect(screen.getByLabelText("Constellation zoom")).toBeInTheDocument();
     expect(screen.getByLabelText("Tuned frequency, MHz")).toBeInTheDocument();
   });
 
   it("re-tunes when the operator enters a precise kHz offset", async () => {
-    vi.mocked(fetchSpectrumDevices).mockResolvedValue([
-      {
-        serial: "rtl-1",
-        driver: "rtlsdr",
-        role: "control",
-        center_hz: 851_000_000,
-        sample_rate_hz: 2_048_000,
-      },
-    ]);
-    vi.mocked(openIQStream).mockReturnValue({ close: vi.fn() });
+    vi.mocked(fetchSpectrumDevices).mockResolvedValue(ONE_DEVICE as never);
 
     render(<Constellation />);
     await waitFor(() => {
-      expect(openIQStream).toHaveBeenCalled();
+      expect(openSymbolStream).toHaveBeenCalled();
     });
     const input = screen.getByLabelText(
       "View offset from SDR centre in kHz (numeric)",
     );
     fireEvent.change(input, { target: { value: "12.5" } });
     await waitFor(() => {
-      const last = vi.mocked(openIQStream).mock.calls.at(-1)?.[1];
+      const last = vi.mocked(openSymbolStream).mock.calls.at(-1)?.[1];
       expect(last?.offset).toBe(12_500);
     });
   });
 
   it("exposes DC-block, auto-scale, and hold view controls", async () => {
-    vi.mocked(fetchSpectrumDevices).mockResolvedValue([
-      {
-        serial: "rtl-1",
-        driver: "rtlsdr",
-        role: "control",
-        center_hz: 851_000_000,
-        sample_rate_hz: 2_048_000,
-      },
-    ]);
-    vi.mocked(openIQStream).mockReturnValue({ close: vi.fn() });
+    vi.mocked(fetchSpectrumDevices).mockResolvedValue(ONE_DEVICE as never);
 
     render(<Constellation />);
     await waitFor(() => {
-      expect(openIQStream).toHaveBeenCalled();
+      expect(openSymbolStream).toHaveBeenCalled();
     });
     // Hold + DC-block + auto-scale checkboxes, plus a Centre button.
     expect(screen.getAllByRole("checkbox").length).toBeGreaterThanOrEqual(3);

--- a/web/src/panels/Constellation.tsx
+++ b/web/src/panels/Constellation.tsx
@@ -8,37 +8,66 @@ import {
   type IQFrame,
   type IQPoint,
 } from "../api/diag";
+import { openSymbolStream, type SymbolFrame } from "../api/symbols";
 import { selectClientConfig, useShared } from "../store/shared";
 import { prefs } from "../store/prefs";
 import { TuningControls } from "../components/TuningControls";
 
-// Constellation panel — 2D scatter of decimated IQ samples. Useful
-// for spotting the symbol-domain shape of whatever the SDR is tuned
-// to without launching a separate SDR receiver.
+// Constellation panel — a 2D scatter of the signal in the complex
+// plane. Two sources, switchable via the View control:
 //
-//   - DC bias / unmodulated carrier   →  one bright dot off-centre
-//   - PSK / QPSK                       →  two or four clusters at
-//                                         ±0.5+0i etc.
-//   - C4FM / FSK                       →  two or four arcs
-//   - AM voice                          →  rotating cluster, modulated
-//                                         in amplitude
-//   - Wideband noise                    →  diffuse circle around the
-//                                         origin
+//   • Symbols (default) — the receiver's symbol-decision points, the
+//     *true* constellation: post matched-filter, timing recovery and
+//     carrier recovery, sampled once per symbol. P25 CQPSK reads as four
+//     tight clusters at ±45°/±135° (degrading to a smeared X as the eye
+//     closes); P25 C4FM has no complex symbol domain, so its four soft
+//     levels are plotted on the real axis (the open 4-level eye/symbol
+//     scope is C4FM's natural quality view). This is the modulation-
+//     quality picture OP25 shows on its Constellation tab.
+//
+//   • Vector scope (raw IQ) — the wideband decimated IQ trajectory,
+//     every sample including the transitions between symbols (no matched
+//     filter, no symbol clock). Useful as a general what-is-this-signal
+//     view: a DC/unmodulated carrier is one off-centre dot, PSK draws
+//     clusters joined by transition arcs, C4FM/FSK draws concentric
+//     arcs, noise a diffuse circle.
 //
 // The catch with a centre-tuned view is the DC spike: an SDR's DDC
 // leaks a residual carrier at 0 Hz that lands on top of anything in
-// the middle of the band, so the constellation reads as one fat blob.
-// The offset control mixes an off-centre locked channel down to
-// baseband (server-side, before decimation) so its symbols can be
-// seen clear of the spike — the same approach OP25's plot takes. With
-// Hold off the offset follows the newest active call on the selected
-// SDR; Hold pins it. DC-block (subtract the residual mean) and
-// auto-scale (fill the unit circle) clean up the render further.
-//
-// 2 ksps decimated stream → ~50 ms / frame at 4 chunks per frame → a
-// canvas redraw every 50 ms is responsive without burning CPU.
+// the middle of the band. The offset control mixes an off-centre locked
+// channel down to baseband (server-side) so its symbols can be seen
+// clear of the spike — the same approach OP25's plot takes. With Hold
+// off the offset follows the newest active call on the selected SDR;
+// Hold pins it. DC-block (subtract the residual mean) and auto-scale
+// (fill the unit circle) clean up the render further.
 
 const TARGET_RATE_SPS = 2000;
+
+// View source for the scatter (persisted in prefs).
+type View = "symbols" | "raw";
+
+const PROTOS: { value: string; label: string }[] = [
+  { value: "p25-cqpsk", label: "P25 CQPSK" },
+  { value: "p25-c4fm", label: "P25 C4FM" },
+];
+
+// Reference markers (ideal post-normalisation cluster centres) drawn as
+// hollow rings to guide the eye. Coordinates are in unit-plot space
+// (1.0 = plot radius), placed where auto-scale lands a clean signal: the
+// CQPSK clusters sit at the auto-scale fill radius on the 45° diagonals;
+// the C4FM soft levels sit on the real axis at the 1:3 inner/outer ratio.
+const CQPSK_MARKERS: IQPoint[] = [
+  { i: 0.6, q: 0.6 },
+  { i: -0.6, q: 0.6 },
+  { i: -0.6, q: -0.6 },
+  { i: 0.6, q: -0.6 },
+].map((p) => ({ i: p.i / Math.SQRT2, q: p.q / Math.SQRT2 }));
+const C4FM_MARKERS: IQPoint[] = [
+  { i: -0.6, q: 0 },
+  { i: -0.2, q: 0 },
+  { i: 0.2, q: 0 },
+  { i: 0.6, q: 0 },
+];
 const POINT_BUFFER = 2000;       // how many recent points to render
 // The plot is a responsive square: it fills the panel column (so it's as
 // large as OP25's, not a fixed postage stamp) but stays bounded so it
@@ -73,6 +102,8 @@ interface RenderOpts {
   autoScale: boolean;
   zoom: number;
   scaleRef: { current: number };
+  // Ideal cluster-centre rings, in unit-plot space (not gain-scaled).
+  markers: IQPoint[];
 }
 
 export function Constellation() {
@@ -82,8 +113,11 @@ export function Constellation() {
   const [selected, setSelected] = useState<string | null>(null);
   const [conn, setConn] = useState<ConnState>("closed");
   const [latest, setLatest] = useState<IQFrame | null>(null);
+  const [symLatest, setSymLatest] = useState<SymbolFrame | null>(null);
   const [error, setError] = useState<string | null>(null);
 
+  const [view, setView] = useState<View>(() => prefs.constellationView());
+  const [proto, setProto] = useState<string>(() => prefs.constellationProto());
   const [offsetKHz, setOffsetKHz] = useState<number>(() =>
     prefs.constellationOffsetKHz(),
   );
@@ -100,7 +134,20 @@ export function Constellation() {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const bufferRef = useRef<IQPoint[]>([]);
   const scaleRef = useRef<number>(1);
-  const optsRef = useRef<RenderOpts>({ dcBlock, autoScale, zoom, scaleRef });
+  // Ideal cluster markers depend on the active source: clusters on the
+  // diagonals for CQPSK symbols, levels on the real axis for C4FM
+  // symbols, none for the raw vector scope.
+  const markers = useMemo<IQPoint[]>(() => {
+    if (view !== "symbols") return [];
+    return proto === "p25-c4fm" ? C4FM_MARKERS : CQPSK_MARKERS;
+  }, [view, proto]);
+  const optsRef = useRef<RenderOpts>({
+    dcBlock,
+    autoScale,
+    zoom,
+    scaleRef,
+    markers,
+  });
   // Live square edge of the plot in CSS px, tracked from the container.
   const [size, setSize] = useState<number>(MIN_CANVAS_PX);
 
@@ -141,9 +188,9 @@ export function Constellation() {
   // Keep the render-time options the WS callback reads in sync without
   // re-subscribing the stream when a toggle flips.
   useEffect(() => {
-    optsRef.current = { dcBlock, autoScale, zoom, scaleRef };
+    optsRef.current = { dcBlock, autoScale, zoom, scaleRef, markers };
     renderConstellation(canvasRef.current, bufferRef.current, optsRef.current);
-  }, [dcBlock, autoScale, zoom]);
+  }, [dcBlock, autoScale, zoom, markers]);
 
   // Reuse the spectrum devices endpoint — same broker pool.
   useEffect(() => {
@@ -217,9 +264,26 @@ export function Constellation() {
   useEffect(() => {
     prefs.setConstellationZoom(zoom);
   }, [zoom]);
-
   useEffect(() => {
-    if (!selected) return;
+    prefs.setConstellationView(view);
+  }, [view]);
+  useEffect(() => {
+    prefs.setConstellationProto(proto);
+  }, [proto]);
+
+  // Push a fresh batch of points into the rolling buffer and repaint.
+  const pushPoints = (pts: IQPoint[]) => {
+    const buf = bufferRef.current;
+    for (const p of pts) buf.push(p);
+    if (buf.length > POINT_BUFFER) {
+      bufferRef.current = buf.slice(buf.length - POINT_BUFFER);
+    }
+    renderConstellation(canvasRef.current, bufferRef.current, optsRef.current);
+  };
+
+  // Raw vector-scope stream: wideband decimated IQ trajectory.
+  useEffect(() => {
+    if (!selected || view !== "raw") return;
     bufferRef.current = [];
     scaleRef.current = 1;
     setLatest(null);
@@ -230,35 +294,67 @@ export function Constellation() {
       offset: Math.round(clampedOffsetKHz * 1000),
       onFrame: (f) => {
         setLatest(f);
-        const buf = bufferRef.current;
-        for (const p of f.points) buf.push(p);
-        if (buf.length > POINT_BUFFER) {
-          bufferRef.current = buf.slice(buf.length - POINT_BUFFER);
-        }
-        renderConstellation(
-          canvasRef.current,
-          bufferRef.current,
-          optsRef.current,
-        );
+        pushPoints(f.points);
       },
       onStatus: setConn,
     });
     return () => stream.close();
     // Re-subscribe when the offset changes so the server re-mixes.
-  }, [cfg, selected, clampedOffsetKHz]);
+  }, [cfg, selected, view, clampedOffsetKHz]);
+
+  // Symbols stream: the receiver's symbol-decision points (true
+  // constellation). CQPSK carries complex points (sym_i/sym_q); C4FM has
+  // none, so its 4 soft levels are plotted on the real axis.
+  useEffect(() => {
+    if (!selected || view !== "symbols") return;
+    bufferRef.current = [];
+    scaleRef.current = 1;
+    setSymLatest(null);
+
+    const stream = openSymbolStream(cfg, {
+      serial: selected,
+      proto,
+      offset: Math.round(clampedOffsetKHz * 1000),
+      onFrame: (f) => {
+        setSymLatest(f);
+        const pts: IQPoint[] = [];
+        if (f.sym_i && f.sym_i.length > 0) {
+          const n = Math.min(f.sym_i.length, f.sym_q?.length ?? 0);
+          for (let k = 0; k < n; k++) pts.push({ i: f.sym_i[k], q: f.sym_q[k] });
+        } else if (f.soft && f.soft.length > 0) {
+          for (const s of f.soft) pts.push({ i: s, q: 0 });
+        }
+        pushPoints(pts);
+      },
+      onStatus: setConn,
+    });
+    return () => stream.close();
+  }, [cfg, selected, view, proto, clampedOffsetKHz]);
 
   // Prefer the device centre so the frequency view shows before the first
   // frame; fall back to the frame's stamped centre.
-  const centerHz = device?.center_hz ?? latest?.center_hz ?? null;
+  const centerHz =
+    device?.center_hz ?? latest?.center_hz ?? symLatest?.center_hz ?? null;
   const viewHz = centerHz != null ? centerHz + clampedOffsetKHz * 1000 : null;
 
   const tuningLabel = useMemo(() => {
     if (viewHz == null) return "";
-    const off = clampedOffsetKHz === 0 ? "centre" : `${clampedOffsetKHz >= 0 ? "+" : ""}${clampedOffsetKHz.toFixed(3).replace(/\.?0+$/, "")} kHz`;
+    const off =
+      clampedOffsetKHz === 0
+        ? "centre"
+        : `${clampedOffsetKHz >= 0 ? "+" : ""}${clampedOffsetKHz.toFixed(3).replace(/\.?0+$/, "")} kHz`;
     const head = `${(viewHz / 1e6).toFixed(4)} MHz (${off})`;
+    if (view === "symbols") {
+      if (!symLatest) return `${head} · waiting for symbols…`;
+      const kind =
+        symLatest.sym_i && symLatest.sym_i.length > 0
+          ? "symbols"
+          : "soft levels";
+      return `${head} · ${symLatest.symbol_rate_hz.toFixed(0)} sym/s · ${kind}`;
+    }
     if (!latest) return `${head} · waiting for samples…`;
     return `${head} · ${latest.sample_rate} sps · ${latest.energy_dbfs.toFixed(1)} dBFS`;
-  }, [latest, viewHz, clampedOffsetKHz]);
+  }, [view, latest, symLatest, viewHz, clampedOffsetKHz]);
 
   return (
     <div className="space-y-3">
@@ -289,8 +385,39 @@ export function Constellation() {
         </div>
       )}
 
-      {/* View controls — offset / follow-locked-channel / cleanup. */}
+      {/* View controls — source / offset / follow-locked-channel / cleanup. */}
       <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-xs">
+        <label className="flex items-center gap-2">
+          <span className="text-muted">View</span>
+          <select
+            className="bg-surface border border-border rounded px-2 py-1"
+            value={view}
+            onChange={(e) => setView(e.target.value as View)}
+            aria-label="Constellation source"
+          >
+            <option value="symbols">Symbols</option>
+            <option value="raw">Vector scope (raw IQ)</option>
+          </select>
+        </label>
+
+        {view === "symbols" && (
+          <label className="flex items-center gap-2">
+            <span className="text-muted">Mode</span>
+            <select
+              className="bg-surface border border-border rounded px-2 py-1"
+              value={proto}
+              onChange={(e) => setProto(e.target.value)}
+              aria-label="Demodulation mode"
+            >
+              {PROTOS.map((p) => (
+                <option key={p.value} value={p.value}>
+                  {p.label}
+                </option>
+              ))}
+            </select>
+          </label>
+        )}
+
         <TuningControls
           centerHz={centerHz}
           maxOffsetKHz={maxOffsetKHz}
@@ -360,11 +487,36 @@ export function Constellation() {
       </div>
 
       <div className="text-[11px] text-muted">
-        Plots decimated IQ samples ({TARGET_RATE_SPS} sps), brightest =
-        most recent. Tune the <em>Offset</em> onto a locked voice/control
-        channel to lift its symbols off the centre DC spike; clusters at
-        ±0.5 suggest PSK, concentric arcs suggest C4FM/FSK, a diffuse
-        circle is noise.
+        {view === "symbols" ? (
+          proto === "p25-c4fm" ? (
+            <>
+              Plots the receiver's recovered C4FM symbols. C4FM has no
+              complex constellation, so its four soft levels appear on the
+              real axis (rings mark the ideal ±1/±3 positions) — the open
+              4-level eye on the <em>Symbol scope</em> is C4FM's natural
+              quality view. Switch <em>Mode</em> to CQPSK for a 2D
+              constellation, or <em>View</em> to the vector scope for the
+              raw IQ trajectory.
+            </>
+          ) : (
+            <>
+              Plots the receiver's symbol-decision points — the true
+              constellation. A clean CQPSK/LSM signal forms four tight
+              clusters on the ±45° diagonals (rings); a closing eye smears
+              them into an X. Tune the <em>Offset</em> onto a locked
+              channel; brightest = most recent.
+            </>
+          )
+        ) : (
+          <>
+            Vector scope: plots decimated IQ samples ({TARGET_RATE_SPS} sps,
+            transitions included), brightest = most recent. Tune the{" "}
+            <em>Offset</em> onto a locked channel to lift it off the centre
+            DC spike; clusters suggest PSK, concentric arcs suggest C4FM/FSK,
+            a diffuse circle is noise. Switch <em>View</em> to Symbols for
+            the symbol-timed constellation.
+          </>
+        )}
       </div>
     </div>
   );
@@ -376,11 +528,11 @@ function ConnPill({ state }: { state: ConnState }) {
   return <span className="pill-err">offline</span>;
 }
 
-// renderConstellation paints the rolling IQ buffer as a phosphor-green
-// vector scope: labelled ±1 axes, reference rings at 0.5 and 1.0, and
-// additively-blended points so dense symbol clusters bloom while the
-// noise floor stays dim. DC-block subtracts the buffer mean to kill
-// any residual centre offset; auto-scale eases a gain so the cloud
+// renderConstellation paints the rolling IQ buffer: labelled ±1 axes,
+// reference rings at 0.5 and 1.0, optional ideal-cluster markers (symbols
+// view), and additively-blended points so dense symbol clusters bloom
+// while the noise floor stays dim. DC-block subtracts the buffer mean to
+// kill any residual centre offset; auto-scale eases a gain so the cloud
 // fills the unit circle regardless of input amplitude.
 function renderConstellation(
   canvas: HTMLCanvasElement | null,
@@ -439,6 +591,24 @@ function renderConstellation(
   ctx.textBaseline = "middle";
   for (const t of [-1, -0.5, 0.5, 1]) {
     ctx.fillText(String(t), MARGIN.left - 6, cy - t * radius);
+  }
+
+  // Ideal cluster-centre markers (symbols view): hollow amber rings at
+  // the positions a clean signal settles on after auto-scale. Drawn in
+  // unit-plot space so they don't move with the data gain, giving the
+  // operator a fixed target to judge cluster tightness / rotation
+  // against. Drawn before the points so the live scatter sits on top.
+  if (opts.markers.length > 0) {
+    ctx.strokeStyle = "rgba(251, 191, 36, 0.55)"; // amber-400
+    ctx.lineWidth = 1.5;
+    const mr = Math.max(4, radius * 0.05);
+    for (const m of opts.markers) {
+      const x = cx + m.i * radius;
+      const y = cy - m.q * radius;
+      ctx.beginPath();
+      ctx.arc(x, y, mr, 0, Math.PI * 2);
+      ctx.stroke();
+    }
   }
 
   const n = points.length;

--- a/web/src/panels/EyeDiagram.test.tsx
+++ b/web/src/panels/EyeDiagram.test.tsx
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+
+vi.mock("../api/spectrum", () => ({
+  fetchSpectrumDevices: vi.fn(),
+}));
+
+vi.mock("../api/symbols", () => ({
+  openSymbolStream: vi.fn(),
+}));
+
+import { fetchSpectrumDevices } from "../api/spectrum";
+import { openSymbolStream } from "../api/symbols";
+import { useShared } from "../store/shared";
+import { EyeDiagram } from "./EyeDiagram";
+
+function resetStore() {
+  useShared.setState({
+    serverURL: "http://localhost:8080",
+    token: null,
+    connected: true,
+    wsStatus: "idle",
+    mutations: null,
+    lastError: null,
+    events: [],
+    activeCalls: [],
+    devices: [],
+    systems: [],
+    talkgroups: [],
+    health: null,
+    audio: null,
+    scanner: null,
+  });
+}
+
+const ONE_DEVICE = [
+  {
+    serial: "rtl-1",
+    driver: "rtlsdr",
+    role: "control",
+    center_hz: 851_012_500,
+    sample_rate_hz: 2_048_000,
+  },
+];
+
+describe("EyeDiagram panel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetStore();
+    window.localStorage.clear();
+    vi.mocked(openSymbolStream).mockReturnValue({ close: vi.fn() });
+  });
+
+  it("renders an empty-state when no SDRs are available", async () => {
+    vi.mocked(fetchSpectrumDevices).mockResolvedValue([]);
+    render(<EyeDiagram />);
+    await waitFor(() => {
+      expect(screen.getByText("No SDRs available")).toBeInTheDocument();
+    });
+    expect(openSymbolStream).not.toHaveBeenCalled();
+  });
+
+  it("opens a C4FM symbol stream against the first device", async () => {
+    vi.mocked(fetchSpectrumDevices).mockResolvedValue(ONE_DEVICE as never);
+
+    render(<EyeDiagram />);
+    await waitFor(() => {
+      expect(openSymbolStream).toHaveBeenCalledTimes(1);
+    });
+    const callArgs = vi.mocked(openSymbolStream).mock.calls[0]?.[1];
+    expect(callArgs?.serial).toBe("rtl-1");
+    // The eye is C4FM-only — the panel must request the C4FM receiver.
+    expect(callArgs?.proto).toBe("p25-c4fm");
+  });
+
+  it("shows the live status pill when the WS reports open", async () => {
+    vi.mocked(fetchSpectrumDevices).mockResolvedValue(ONE_DEVICE as never);
+    vi.mocked(openSymbolStream).mockImplementation((_cfg, opts) => {
+      opts.onStatus?.("open");
+      return { close: vi.fn() };
+    });
+
+    render(<EyeDiagram />);
+    await waitFor(() => {
+      expect(screen.getByText("live")).toBeInTheDocument();
+    });
+  });
+
+  it("reports the samples-per-symbol once eye frames arrive", async () => {
+    vi.mocked(fetchSpectrumDevices).mockResolvedValue(ONE_DEVICE as never);
+    vi.mocked(openSymbolStream).mockImplementation((_cfg, opts) => {
+      opts.onStatus?.("open");
+      opts.onFrame({
+        ts_ns: 1,
+        symbol_rate_hz: 4800,
+        center_hz: 851_012_500,
+        offset_hz: 0,
+        soft: [],
+        sym_i: [],
+        sym_q: [],
+        eye_soft: [0, 0.1, 0.2, 0.3, 0.2, 0.1, 0, -0.1, -0.2, -0.1],
+        eye_sps: 5,
+        dibits: [1],
+        is_bits: false,
+        base_idx: 0,
+      });
+      return { close: vi.fn() };
+    });
+
+    render(<EyeDiagram />);
+    await waitFor(() => {
+      expect(screen.getByText(/samples\/symbol/)).toBeInTheDocument();
+    });
+  });
+});

--- a/web/src/panels/EyeDiagram.tsx
+++ b/web/src/panels/EyeDiagram.tsx
@@ -1,0 +1,212 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  fetchSpectrumDevices,
+  type SpectrumDevice,
+} from "../api/spectrum";
+import { openSymbolStream, type SymbolFrame } from "../api/symbols";
+import { selectClientConfig, useShared } from "../store/shared";
+import { prefs } from "../store/prefs";
+import { EyeDiagramChart } from "../components/EyeDiagramChart";
+import { TuningControls } from "../components/TuningControls";
+
+// Eye diagram panel — GopherTrunk's take on OP25's "datascope". The
+// daemon runs a parallel P25 C4FM receiver on the selected channel and
+// streams the oversampled, AGC-scaled matched-filter output; we fold it
+// over the symbol period and overlay the windows so the four-level eye
+// is visible. A healthy channel shows four open bands with clear gaps at
+// the symbol-decision instant; a closed eye means timing / SNR trouble.
+//
+// C4FM only: the eye is a property of the FM-discriminated baseband.
+// CQPSK/LSM has no 4-level eye — its quality view is the complex
+// constellation on the Constellation panel.
+
+const WINDOW_SAMPLES = 4000; // rolling oversampled-sample buffer
+
+type ConnState = "connecting" | "open" | "closed";
+
+export function EyeDiagram() {
+  const cfg = useShared(selectClientConfig);
+  const activeCalls = useShared((s) => s.activeCalls);
+  const [devices, setDevices] = useState<SpectrumDevice[]>([]);
+  const [selected, setSelected] = useState<string | null>(null);
+  const [conn, setConn] = useState<ConnState>("closed");
+  const [latest, setLatest] = useState<SymbolFrame | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const [offsetKHz, setOffsetKHz] = useState<number>(() =>
+    prefs.eyeOffsetKHz(),
+  );
+  const [hold, setHold] = useState<boolean>(() => prefs.eyeHold());
+
+  // Rolling oversampled-sample window + its fold period, recreated per
+  // frame so the chart sees fresh references.
+  const [eye, setEye] = useState<{ samples: number[]; sps: number }>({
+    samples: [],
+    sps: 0,
+  });
+  const eyeRef = useRef<number[]>([]);
+
+  useEffect(() => {
+    let cancel = false;
+    (async () => {
+      try {
+        const list = await fetchSpectrumDevices(cfg);
+        if (cancel) return;
+        setDevices(list);
+        setError(null);
+        if (list.length > 0 && selected == null) setSelected(list[0].serial);
+      } catch (e) {
+        if (cancel) return;
+        setError(e instanceof Error ? e.message : String(e));
+      }
+    })();
+    return () => {
+      cancel = true;
+    };
+  }, [cfg, selected]);
+
+  const device = useMemo(
+    () => devices.find((d) => d.serial === selected) ?? null,
+    [devices, selected],
+  );
+
+  const followOffsetKHz = useMemo(() => {
+    if (!device) return null;
+    const mine = activeCalls.filter(
+      (c) => c.device_serial === selected && !c.ended_at,
+    );
+    if (mine.length === 0) return null;
+    const newest = mine.reduce((a, b) => (b.started_at > a.started_at ? b : a));
+    return (newest.grant.frequency_hz - device.center_hz) / 1000;
+  }, [activeCalls, device, selected]);
+
+  useEffect(() => {
+    if (hold || followOffsetKHz == null) return;
+    setOffsetKHz((cur) =>
+      Math.abs(cur - followOffsetKHz) < 0.05 ? cur : followOffsetKHz,
+    );
+  }, [hold, followOffsetKHz]);
+
+  const maxOffsetKHz = device ? device.sample_rate_hz / 2000 : 1500;
+  const clampedOffsetKHz = Math.max(
+    -maxOffsetKHz,
+    Math.min(maxOffsetKHz, offsetKHz),
+  );
+
+  useEffect(() => {
+    prefs.setEyeOffsetKHz(offsetKHz);
+  }, [offsetKHz]);
+  useEffect(() => {
+    prefs.setEyeHold(hold);
+  }, [hold]);
+
+  // The eye is C4FM-only; the stream proto is fixed accordingly.
+  useEffect(() => {
+    if (!selected) return;
+    eyeRef.current = [];
+    setEye({ samples: [], sps: 0 });
+    setLatest(null);
+
+    const stream = openSymbolStream(cfg, {
+      serial: selected,
+      proto: "p25-c4fm",
+      offset: Math.round(clampedOffsetKHz * 1000),
+      onFrame: (f) => {
+        setLatest(f);
+        if (!f.eye_soft || f.eye_soft.length === 0) return;
+        const buf = eyeRef.current.concat(f.eye_soft);
+        eyeRef.current = buf.slice(Math.max(0, buf.length - WINDOW_SAMPLES));
+        setEye({ samples: eyeRef.current, sps: f.eye_sps || 0 });
+      },
+      onStatus: setConn,
+    });
+    return () => stream.close();
+  }, [cfg, selected, clampedOffsetKHz]);
+
+  const centerHz = device?.center_hz ?? latest?.center_hz ?? null;
+  const viewHz = centerHz != null ? centerHz + clampedOffsetKHz * 1000 : null;
+
+  const tuningLabel = useMemo(() => {
+    if (viewHz == null) return "";
+    const off =
+      clampedOffsetKHz === 0
+        ? "centre"
+        : `${clampedOffsetKHz >= 0 ? "+" : ""}${clampedOffsetKHz.toFixed(3).replace(/\.?0+$/, "")} kHz`;
+    const head = `${(viewHz / 1e6).toFixed(4)} MHz (${off})`;
+    if (!latest) return `${head} · waiting for symbols…`;
+    if (eye.sps > 0) return `${head} · ${eye.sps} samples/symbol`;
+    return `${head} · waiting for eye samples…`;
+  }, [latest, eye.sps, viewHz, clampedOffsetKHz]);
+
+  return (
+    <div className="space-y-3">
+      <header className="flex flex-wrap items-center justify-between gap-3">
+        <h2 className="text-xl font-semibold">Eye diagram</h2>
+        <div className="flex items-center gap-2 text-xs">
+          <span className="text-muted">SDR:</span>
+          <select
+            className="bg-surface border border-border rounded px-2 py-1"
+            value={selected ?? ""}
+            onChange={(e) => setSelected(e.target.value || null)}
+            disabled={devices.length === 0}
+          >
+            {devices.length === 0 && <option value="">No SDRs available</option>}
+            {devices.map((d) => (
+              <option key={d.serial} value={d.serial}>
+                {d.serial} · {d.role}
+              </option>
+            ))}
+          </select>
+          <ConnPill state={conn} />
+        </div>
+      </header>
+
+      {error && (
+        <div className="rounded border border-red-700/40 bg-red-900/20 text-red-200 text-xs px-3 py-2">
+          {error}
+        </div>
+      )}
+
+      <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-xs">
+        <span className="text-muted">Mode: P25 C4FM</span>
+        <TuningControls
+          centerHz={centerHz}
+          maxOffsetKHz={maxOffsetKHz}
+          offsetKHz={clampedOffsetKHz}
+          onOffsetChange={(khz) => {
+            setHold(true);
+            setOffsetKHz(khz);
+          }}
+          hold={hold}
+          onHoldChange={setHold}
+          followingActive={followOffsetKHz != null}
+          onCentre={() => {
+            setHold(true);
+            setOffsetKHz(0);
+          }}
+        />
+      </div>
+
+      <div className="font-mono text-xs text-muted">{tuningLabel || "—"}</div>
+
+      <div className="rounded border border-border bg-black p-2">
+        <EyeDiagramChart eye={eye.samples} sps={eye.sps} />
+      </div>
+
+      <div className="text-[11px] text-muted">
+        Live C4FM eye, folded over the symbol period (OP25's datascope). A
+        healthy channel shows four open horizontal bands with clear gaps at
+        the centre line (the decision instant); merged bands or a closed
+        centre mean symbol-timing or SNR trouble. Dial the <em>Offset</em>{" "}
+        onto a locked control/voice channel. CQPSK/LSM has no 4-level eye —
+        use the Constellation panel for its complex constellation.
+      </div>
+    </div>
+  );
+}
+
+function ConnPill({ state }: { state: ConnState }) {
+  if (state === "open") return <span className="pill-ok">live</span>;
+  if (state === "connecting") return <span className="pill-warn">connecting</span>;
+  return <span className="pill-err">offline</span>;
+}

--- a/web/src/panels/Histogram.test.tsx
+++ b/web/src/panels/Histogram.test.tsx
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+
+vi.mock("../api/spectrum", () => ({
+  fetchSpectrumDevices: vi.fn(),
+}));
+
+vi.mock("../api/symbols", () => ({
+  openSymbolStream: vi.fn(),
+}));
+
+vi.mock("react-chartjs-2", () => ({ Bar: () => null }));
+vi.mock("chart.js", () => {
+  const noop = class {};
+  return {
+    Chart: { register: () => {} },
+    BarElement: noop,
+    CategoryScale: noop,
+    Legend: noop,
+    LinearScale: noop,
+    Title: noop,
+    Tooltip: noop,
+  };
+});
+
+import { fetchSpectrumDevices } from "../api/spectrum";
+import { openSymbolStream } from "../api/symbols";
+import { useShared } from "../store/shared";
+import { Histogram } from "./Histogram";
+
+function resetStore() {
+  useShared.setState({
+    serverURL: "http://localhost:8080",
+    token: null,
+    connected: true,
+    wsStatus: "idle",
+    mutations: null,
+    lastError: null,
+    events: [],
+    activeCalls: [],
+    devices: [],
+    systems: [],
+    talkgroups: [],
+    health: null,
+    audio: null,
+    scanner: null,
+  });
+}
+
+const ONE_DEVICE = [
+  {
+    serial: "rtl-1",
+    driver: "rtlsdr",
+    role: "control",
+    center_hz: 851_012_500,
+    sample_rate_hz: 2_048_000,
+  },
+];
+
+describe("Histogram panel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetStore();
+    window.localStorage.clear();
+    vi.mocked(openSymbolStream).mockReturnValue({ close: vi.fn() });
+  });
+
+  it("renders an empty-state when no SDRs are available", async () => {
+    vi.mocked(fetchSpectrumDevices).mockResolvedValue([]);
+    render(<Histogram />);
+    await waitFor(() => {
+      expect(screen.getByText("No SDRs available")).toBeInTheDocument();
+    });
+    expect(openSymbolStream).not.toHaveBeenCalled();
+  });
+
+  it("derives a balance metric and MER from a C4FM frame", async () => {
+    vi.mocked(fetchSpectrumDevices).mockResolvedValue(ONE_DEVICE as never);
+    vi.mocked(openSymbolStream).mockImplementation((_cfg, opts) => {
+      opts.onStatus?.("open");
+      // Four levels, evenly balanced, with tight clusters → finite SNR.
+      opts.onFrame({
+        ts_ns: 1,
+        symbol_rate_hz: 4800,
+        center_hz: 851_012_500,
+        offset_hz: 0,
+        soft: [-3.1, -0.9, 1.1, 2.9, -2.9, -1.1, 0.9, 3.1],
+        sym_i: [],
+        sym_q: [],
+        eye_soft: [],
+        eye_sps: 0,
+        dibits: [0, 1, 2, 3, 0, 1, 2, 3],
+        is_bits: false,
+        base_idx: 0,
+        carrier_offset_hz: 0,
+        agc_level: 0,
+        agc_target: 0,
+        clock_mu: 0,
+        clock_sps: 10,
+        cma_error: 0,
+      });
+      return { close: vi.fn() };
+    });
+
+    render(<Histogram />);
+    // Perfectly balanced → balance deviation 0.0%.
+    await waitFor(() => {
+      expect(screen.getByText("±0.0%")).toBeInTheDocument();
+    });
+    // A finite dB SNR readout is shown (clusters separated, zero variance
+    // → very high but finite once rendered).
+    expect(screen.getByText(/dB/)).toBeInTheDocument();
+  });
+});

--- a/web/src/panels/Histogram.tsx
+++ b/web/src/panels/Histogram.tsx
@@ -1,0 +1,376 @@
+import {
+  BarElement,
+  CategoryScale,
+  Chart as ChartJS,
+  Legend,
+  LinearScale,
+  Title,
+  Tooltip,
+} from "chart.js";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Bar } from "react-chartjs-2";
+import {
+  fetchSpectrumDevices,
+  type SpectrumDevice,
+} from "../api/spectrum";
+import { openSymbolStream, type SymbolFrame } from "../api/symbols";
+import { selectClientConfig, useShared } from "../store/shared";
+import { prefs } from "../store/prefs";
+import { TuningControls } from "../components/TuningControls";
+
+ChartJS.register(
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Title,
+  Tooltip,
+  Legend,
+);
+
+// Histogram panel — the recovered-symbol distribution plus a derived
+// signal-quality readout, off the live demod. A clean P25 control channel
+// is scrambled, so its symbols are evenly spread: each of the 4 (C4FM /
+// CQPSK) levels should sit near 25%. A collapsed slicer shows an empty or
+// single-dominant bin. For C4FM the soft samples also give a per-level
+// mean/spread and an MER-like SNR estimate (a "level meter").
+
+const WINDOW_SYMBOLS = 4000;
+const CARDINALITY = 4;
+
+const PROTOS: { value: string; label: string }[] = [
+  { value: "p25-c4fm", label: "P25 C4FM" },
+  { value: "p25-cqpsk", label: "P25 CQPSK" },
+];
+
+type ConnState = "connecting" | "open" | "closed";
+
+interface Quality {
+  pct: number[]; // % per dibit bin
+  total: number;
+  balanceDev: number; // max |bin% − ideal%|
+  snrDb: number | null; // MER-like estimate (C4FM soft only)
+  levels: { mean: number; std: number }[] | null;
+}
+
+function computeQuality(dibits: number[], soft: number[]): Quality {
+  const cnt = new Array(CARDINALITY).fill(0);
+  for (const d of dibits) if (d >= 0 && d < CARDINALITY) cnt[d]++;
+  const total = dibits.length;
+  const pct = cnt.map((c) => (total > 0 ? (100 * c) / total : 0));
+  const ideal = 100 / CARDINALITY;
+  const balanceDev = pct.reduce((m, p) => Math.max(m, Math.abs(p - ideal)), 0);
+
+  // Per-level soft stats + MER-like SNR, when the soft track is aligned.
+  let snrDb: number | null = null;
+  let levels: { mean: number; std: number }[] | null = null;
+  if (soft.length > 0 && soft.length === dibits.length) {
+    const sum = new Array(CARDINALITY).fill(0);
+    const sumsq = new Array(CARDINALITY).fill(0);
+    for (let i = 0; i < dibits.length; i++) {
+      const d = dibits[i];
+      if (d < 0 || d >= CARDINALITY) continue;
+      sum[d] += soft[i];
+      sumsq[d] += soft[i] * soft[i];
+    }
+    levels = [];
+    let grandSum = 0;
+    let noise = 0;
+    let signal = 0;
+    for (let d = 0; d < CARDINALITY; d++) {
+      const c = cnt[d];
+      const mean = c > 0 ? sum[d] / c : 0;
+      const varr = c > 0 ? Math.max(0, sumsq[d] / c - mean * mean) : 0;
+      levels.push({ mean, std: Math.sqrt(varr) });
+      grandSum += sum[d];
+      noise += c * varr;
+    }
+    const mu = total > 0 ? grandSum / total : 0;
+    for (let d = 0; d < CARDINALITY; d++) {
+      signal += cnt[d] * (levels[d].mean - mu) * (levels[d].mean - mu);
+    }
+    if (total > 0 && noise > 0) {
+      snrDb = 10 * Math.log10(signal / noise);
+    }
+  }
+  return { pct, total, balanceDev, snrDb, levels };
+}
+
+export function Histogram() {
+  const cfg = useShared(selectClientConfig);
+  const activeCalls = useShared((s) => s.activeCalls);
+  const [devices, setDevices] = useState<SpectrumDevice[]>([]);
+  const [selected, setSelected] = useState<string | null>(null);
+  const [conn, setConn] = useState<ConnState>("closed");
+  const [latest, setLatest] = useState<SymbolFrame | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const [proto, setProto] = useState<string>(() => prefs.histogramProto());
+  const [offsetKHz, setOffsetKHz] = useState<number>(() =>
+    prefs.histogramOffsetKHz(),
+  );
+  const [hold, setHold] = useState<boolean>(() => prefs.histogramHold());
+
+  const [win, setWin] = useState<{ soft: number[]; dibits: number[] }>({
+    soft: [],
+    dibits: [],
+  });
+  const softRef = useRef<number[]>([]);
+  const dibitRef = useRef<number[]>([]);
+
+  useEffect(() => {
+    let cancel = false;
+    (async () => {
+      try {
+        const list = await fetchSpectrumDevices(cfg);
+        if (cancel) return;
+        setDevices(list);
+        setError(null);
+        if (list.length > 0 && selected == null) setSelected(list[0].serial);
+      } catch (e) {
+        if (cancel) return;
+        setError(e instanceof Error ? e.message : String(e));
+      }
+    })();
+    return () => {
+      cancel = true;
+    };
+  }, [cfg, selected]);
+
+  const device = useMemo(
+    () => devices.find((d) => d.serial === selected) ?? null,
+    [devices, selected],
+  );
+
+  const followOffsetKHz = useMemo(() => {
+    if (!device) return null;
+    const mine = activeCalls.filter(
+      (c) => c.device_serial === selected && !c.ended_at,
+    );
+    if (mine.length === 0) return null;
+    const newest = mine.reduce((a, b) => (b.started_at > a.started_at ? b : a));
+    return (newest.grant.frequency_hz - device.center_hz) / 1000;
+  }, [activeCalls, device, selected]);
+
+  useEffect(() => {
+    if (hold || followOffsetKHz == null) return;
+    setOffsetKHz((cur) =>
+      Math.abs(cur - followOffsetKHz) < 0.05 ? cur : followOffsetKHz,
+    );
+  }, [hold, followOffsetKHz]);
+
+  const maxOffsetKHz = device ? device.sample_rate_hz / 2000 : 1500;
+  const clampedOffsetKHz = Math.max(
+    -maxOffsetKHz,
+    Math.min(maxOffsetKHz, offsetKHz),
+  );
+
+  useEffect(() => {
+    prefs.setHistogramOffsetKHz(offsetKHz);
+  }, [offsetKHz]);
+  useEffect(() => {
+    prefs.setHistogramHold(hold);
+  }, [hold]);
+  useEffect(() => {
+    prefs.setHistogramProto(proto);
+  }, [proto]);
+
+  useEffect(() => {
+    if (!selected) return;
+    softRef.current = [];
+    dibitRef.current = [];
+    setWin({ soft: [], dibits: [] });
+    setLatest(null);
+
+    const stream = openSymbolStream(cfg, {
+      serial: selected,
+      proto,
+      offset: Math.round(clampedOffsetKHz * 1000),
+      onFrame: (f) => {
+        setLatest(f);
+        const sb = softRef.current.concat(f.soft ?? []);
+        const db = dibitRef.current.concat(f.dibits ?? []);
+        const aligned = sb.length === db.length;
+        softRef.current = aligned
+          ? sb.slice(Math.max(0, sb.length - WINDOW_SYMBOLS))
+          : [];
+        dibitRef.current = db.slice(Math.max(0, db.length - WINDOW_SYMBOLS));
+        setWin({ soft: softRef.current, dibits: dibitRef.current });
+      },
+      onStatus: setConn,
+    });
+    return () => stream.close();
+  }, [cfg, selected, proto, clampedOffsetKHz]);
+
+  const quality = useMemo(
+    () => computeQuality(win.dibits, win.soft),
+    [win],
+  );
+
+  const centerHz = device?.center_hz ?? latest?.center_hz ?? null;
+  const viewHz = centerHz != null ? centerHz + clampedOffsetKHz * 1000 : null;
+  const tuningLabel = useMemo(() => {
+    if (viewHz == null) return "";
+    const off =
+      clampedOffsetKHz === 0
+        ? "centre"
+        : `${clampedOffsetKHz >= 0 ? "+" : ""}${clampedOffsetKHz.toFixed(3).replace(/\.?0+$/, "")} kHz`;
+    const head = `${(viewHz / 1e6).toFixed(4)} MHz (${off})`;
+    if (quality.total === 0) return `${head} · waiting for symbols…`;
+    return `${head} · ${quality.total} symbols`;
+  }, [quality.total, viewHz, clampedOffsetKHz]);
+
+  const chartData = useMemo(
+    () => ({
+      labels: quality.pct.map((_, i) => `sym ${i}`),
+      datasets: [
+        {
+          label: "% of symbols",
+          data: quality.pct,
+          backgroundColor: "rgba(56,189,248,0.6)",
+        },
+      ],
+    }),
+    [quality.pct],
+  );
+
+  const chartOptions = useMemo(
+    () => ({
+      responsive: true,
+      maintainAspectRatio: false,
+      animation: false as const,
+      plugins: { legend: { display: false } },
+      scales: {
+        x: { grid: { display: false }, ticks: { color: "rgba(148,163,184,0.8)" } },
+        y: {
+          beginAtZero: true,
+          title: { display: true, text: "%" },
+          grid: { color: "rgba(148,163,184,0.15)" },
+          ticks: { color: "rgba(148,163,184,0.8)" },
+        },
+      },
+    }),
+    [],
+  );
+
+  return (
+    <div className="space-y-3">
+      <header className="flex flex-wrap items-center justify-between gap-3">
+        <h2 className="text-xl font-semibold">Symbol histogram</h2>
+        <div className="flex items-center gap-2 text-xs">
+          <span className="text-muted">SDR:</span>
+          <select
+            className="bg-surface border border-border rounded px-2 py-1"
+            value={selected ?? ""}
+            onChange={(e) => setSelected(e.target.value || null)}
+            disabled={devices.length === 0}
+          >
+            {devices.length === 0 && <option value="">No SDRs available</option>}
+            {devices.map((d) => (
+              <option key={d.serial} value={d.serial}>
+                {d.serial} · {d.role}
+              </option>
+            ))}
+          </select>
+          <ConnPill state={conn} />
+        </div>
+      </header>
+
+      {error && (
+        <div className="rounded border border-red-700/40 bg-red-900/20 text-red-200 text-xs px-3 py-2">
+          {error}
+        </div>
+      )}
+
+      <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-xs">
+        <label className="flex items-center gap-2">
+          <span className="text-muted">Mode</span>
+          <select
+            className="bg-surface border border-border rounded px-2 py-1"
+            value={proto}
+            onChange={(e) => setProto(e.target.value)}
+            aria-label="Demodulation mode"
+          >
+            {PROTOS.map((p) => (
+              <option key={p.value} value={p.value}>
+                {p.label}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <TuningControls
+          centerHz={centerHz}
+          maxOffsetKHz={maxOffsetKHz}
+          offsetKHz={clampedOffsetKHz}
+          onOffsetChange={(khz) => {
+            setHold(true);
+            setOffsetKHz(khz);
+          }}
+          hold={hold}
+          onHoldChange={setHold}
+          followingActive={followOffsetKHz != null}
+          onCentre={() => {
+            setHold(true);
+            setOffsetKHz(0);
+          }}
+        />
+      </div>
+
+      <div className="font-mono text-xs text-muted">{tuningLabel || "—"}</div>
+
+      <div className="rounded border border-border bg-black p-2" style={{ height: 240 }}>
+        <Bar data={chartData} options={chartOptions} />
+      </div>
+
+      <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 text-xs">
+        <Meter
+          label="Balance"
+          value={
+            quality.total > 0 ? `±${quality.balanceDev.toFixed(1)}%` : "—"
+          }
+          sub="from 25% ideal"
+        />
+        <Meter
+          label="SNR (MER)"
+          value={quality.snrDb != null ? `${quality.snrDb.toFixed(1)} dB` : "—"}
+          sub={quality.snrDb == null ? "C4FM only" : undefined}
+        />
+        <Meter label="Symbols" value={quality.total > 0 ? String(quality.total) : "—"} />
+      </div>
+
+      <div className="text-[11px] text-muted">
+        Distribution of the recovered symbols. A scrambled P25 control
+        channel spreads evenly, so each bin should sit near 25% — a low{" "}
+        <strong>Balance</strong> deviation means a healthy slicer; a
+        dominant or empty bin means a collapsed eye. <strong>SNR (MER)</strong>{" "}
+        is an estimate from the C4FM soft levels (level separation vs
+        within-level spread); higher is cleaner. Dial the <em>Offset</em>{" "}
+        onto a locked channel.
+      </div>
+    </div>
+  );
+}
+
+function Meter({
+  label,
+  value,
+  sub,
+}: {
+  label: string;
+  value: string;
+  sub?: string;
+}) {
+  return (
+    <div className="rounded border border-border bg-surface px-3 py-2">
+      <div className="text-muted">{label}</div>
+      <div className="font-mono text-sm">{value}</div>
+      {sub && <div className="text-[10px] text-muted">{sub}</div>}
+    </div>
+  );
+}
+
+function ConnPill({ state }: { state: ConnState }) {
+  if (state === "open") return <span className="pill-ok">live</span>;
+  if (state === "connecting") return <span className="pill-warn">connecting</span>;
+  return <span className="pill-err">offline</span>;
+}

--- a/web/src/panels/Plots.test.tsx
+++ b/web/src/panels/Plots.test.tsx
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+
+vi.mock("../api/spectrum", () => ({
+  fetchSpectrumDevices: vi.fn(),
+}));
+
+vi.mock("../api/symbols", () => ({
+  openSymbolStream: vi.fn(),
+}));
+
+vi.mock("../api/diag", () => ({
+  openIQStream: vi.fn(),
+}));
+
+// Plots imports the chart-backed scopes (Tuning/Histogram), which register
+// Chart.js components at module load — stub the chart libs.
+vi.mock("react-chartjs-2", () => ({ Line: () => null, Bar: () => null }));
+vi.mock("chart.js", () => {
+  const noop = class {};
+  return {
+    Chart: { register: () => {} },
+    BarElement: noop,
+    CategoryScale: noop,
+    Filler: noop,
+    Legend: noop,
+    LinearScale: noop,
+    LineElement: noop,
+    PointElement: noop,
+    Title: noop,
+    Tooltip: noop,
+  };
+});
+
+import { fetchSpectrumDevices } from "../api/spectrum";
+import { openSymbolStream } from "../api/symbols";
+import { openIQStream } from "../api/diag";
+import { useShared } from "../store/shared";
+import { Plots } from "./Plots";
+
+function resetStore() {
+  useShared.setState({
+    serverURL: "http://localhost:8080",
+    token: null,
+    connected: true,
+    wsStatus: "idle",
+    mutations: null,
+    lastError: null,
+    events: [],
+    activeCalls: [],
+    devices: [],
+    systems: [],
+    talkgroups: [],
+    health: null,
+    audio: null,
+    scanner: null,
+  });
+}
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/plots" element={<Plots />} />
+        <Route path="/plots/:tab" element={<Plots />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe("Plots hub", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetStore();
+    window.localStorage.clear();
+    vi.mocked(fetchSpectrumDevices).mockResolvedValue([]);
+    vi.mocked(openSymbolStream).mockReturnValue({ close: vi.fn() });
+    vi.mocked(openIQStream).mockReturnValue({ close: vi.fn() });
+  });
+
+  it("shows all scope sub-tabs and defaults to the constellation", async () => {
+    renderAt("/plots");
+    const tablist = await screen.findByRole("tablist", { name: "Plots" });
+    expect(tablist).toBeInTheDocument();
+    for (const label of [
+      "Constellation",
+      "Symbol scope",
+      "Eye diagram",
+      "Tuning",
+      "Histogram",
+    ]) {
+      expect(screen.getByRole("tab", { name: label })).toBeInTheDocument();
+    }
+    // The default sub-tab is the Constellation (its heading renders).
+    expect(
+      screen.getByRole("heading", { name: "Constellation" }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the sub-tab named in the URL", async () => {
+    renderAt("/plots/eye");
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Eye diagram" }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("switches sub-tab on click", async () => {
+    renderAt("/plots");
+    fireEvent.click(screen.getByRole("tab", { name: "Histogram" }));
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Symbol histogram" }),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/web/src/panels/Plots.tsx
+++ b/web/src/panels/Plots.tsx
@@ -1,0 +1,67 @@
+import { useNavigate, useParams } from "react-router-dom";
+import { Constellation } from "./Constellation";
+import { SymbolScope } from "./SymbolScope";
+import { EyeDiagram } from "./EyeDiagram";
+import { Tuning } from "./Tuning";
+import { Histogram } from "./Histogram";
+
+// Plots hub — a single tabbed home for the signal-plot family, mirroring
+// OP25's Plots tabs. Each sub-tab is the standalone panel rendered inline;
+// the standalone routes (/constellation, /symbols, …) are kept for
+// deep-linking, and the sub-tab is reflected in the URL (/plots/<tab>) so
+// a chosen view is shareable and survives a refresh.
+//
+// Spectrum stays its own top-level tab (it's the heavier wideband view);
+// this hub gathers the per-channel symbol-domain scopes.
+
+const TABS = [
+  { key: "constellation", label: "Constellation", el: <Constellation /> },
+  { key: "symbols", label: "Symbol scope", el: <SymbolScope /> },
+  { key: "eye", label: "Eye diagram", el: <EyeDiagram /> },
+  { key: "tuning", label: "Tuning", el: <Tuning /> },
+  { key: "histogram", label: "Histogram", el: <Histogram /> },
+] as const;
+
+const DEFAULT_TAB = "constellation";
+
+export function Plots() {
+  const { tab } = useParams<{ tab?: string }>();
+  const navigate = useNavigate();
+  const active = TABS.find((t) => t.key === tab) ?? TABS[0];
+
+  return (
+    <div className="space-y-3">
+      <div
+        className="flex gap-1 overflow-x-auto border-b border-panel pb-1"
+        role="tablist"
+        aria-label="Plots"
+      >
+        {TABS.map((t) => {
+          const selected = t.key === active.key;
+          return (
+            <button
+              key={t.key}
+              role="tab"
+              aria-selected={selected}
+              onClick={() => navigate(`/plots/${t.key}`)}
+              className={
+                "px-3 py-1 rounded text-xs whitespace-nowrap " +
+                (selected
+                  ? "bg-panel text-fg font-semibold"
+                  : "text-muted hover:text-fg hover:bg-panel")
+              }
+            >
+              {t.label}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Remount on tab change (key) so each panel's stream subscription is
+          opened/closed cleanly rather than lingering behind a hidden tab. */}
+      <div key={active.key}>{active.el}</div>
+    </div>
+  );
+}
+
+export { DEFAULT_TAB };

--- a/web/src/panels/Tuning.test.tsx
+++ b/web/src/panels/Tuning.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 
 vi.mock("../api/spectrum", () => ({
   fetchSpectrumDevices: vi.fn(),
@@ -9,10 +9,28 @@ vi.mock("../api/symbols", () => ({
   openSymbolStream: vi.fn(),
 }));
 
+// Stub the chart libs so the panel mounts under jsdom without a real
+// <canvas> backend (mirrors App.panels.test.tsx).
+vi.mock("react-chartjs-2", () => ({ Line: () => null }));
+vi.mock("chart.js", () => {
+  const noop = class {};
+  return {
+    Chart: { register: () => {} },
+    CategoryScale: noop,
+    Filler: noop,
+    Legend: noop,
+    LinearScale: noop,
+    LineElement: noop,
+    PointElement: noop,
+    Title: noop,
+    Tooltip: noop,
+  };
+});
+
 import { fetchSpectrumDevices } from "../api/spectrum";
 import { openSymbolStream } from "../api/symbols";
 import { useShared } from "../store/shared";
-import { EyeDiagram } from "./EyeDiagram";
+import { Tuning } from "./Tuning";
 
 function resetStore() {
   useShared.setState({
@@ -43,7 +61,7 @@ const ONE_DEVICE = [
   },
 ];
 
-describe("EyeDiagram panel", () => {
+describe("Tuning panel", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     resetStore();
@@ -53,40 +71,30 @@ describe("EyeDiagram panel", () => {
 
   it("renders an empty-state when no SDRs are available", async () => {
     vi.mocked(fetchSpectrumDevices).mockResolvedValue([]);
-    render(<EyeDiagram />);
+    render(<Tuning />);
     await waitFor(() => {
       expect(screen.getByText("No SDRs available")).toBeInTheDocument();
     });
     expect(openSymbolStream).not.toHaveBeenCalled();
   });
 
-  it("opens a C4FM symbol stream against the first device", async () => {
+  it("opens a symbol stream and re-subscribes on mode change", async () => {
     vi.mocked(fetchSpectrumDevices).mockResolvedValue(ONE_DEVICE as never);
 
-    render(<EyeDiagram />);
+    render(<Tuning />);
     await waitFor(() => {
       expect(openSymbolStream).toHaveBeenCalledTimes(1);
     });
-    const callArgs = vi.mocked(openSymbolStream).mock.calls[0]?.[1];
-    expect(callArgs?.serial).toBe("rtl-1");
-    // The eye is C4FM-only — the panel must request the C4FM receiver.
-    expect(callArgs?.proto).toBe("p25-c4fm");
-  });
-
-  it("shows the live status pill when the WS reports open", async () => {
-    vi.mocked(fetchSpectrumDevices).mockResolvedValue(ONE_DEVICE as never);
-    vi.mocked(openSymbolStream).mockImplementation((_cfg, opts) => {
-      opts.onStatus?.("open");
-      return { close: vi.fn() };
+    fireEvent.change(screen.getByLabelText("Demodulation mode"), {
+      target: { value: "p25-cqpsk" },
     });
-
-    render(<EyeDiagram />);
     await waitFor(() => {
-      expect(screen.getByText("live")).toBeInTheDocument();
+      const last = vi.mocked(openSymbolStream).mock.calls.at(-1)?.[1];
+      expect(last?.proto).toBe("p25-cqpsk");
     });
   });
 
-  it("reports the samples-per-symbol once eye frames arrive", async () => {
+  it("shows the carrier-error meter once a frame arrives", async () => {
     vi.mocked(fetchSpectrumDevices).mockResolvedValue(ONE_DEVICE as never);
     vi.mocked(openSymbolStream).mockImplementation((_cfg, opts) => {
       opts.onStatus?.("open");
@@ -98,24 +106,24 @@ describe("EyeDiagram panel", () => {
         soft: [],
         sym_i: [],
         sym_q: [],
-        eye_soft: [0, 0.1, 0.2, 0.3, 0.2, 0.1, 0, -0.1, -0.2, -0.1],
-        eye_sps: 5,
+        eye_soft: [],
+        eye_sps: 0,
         dibits: [1],
         is_bits: false,
         base_idx: 0,
-        carrier_offset_hz: 0,
-        agc_level: 0,
-        agc_target: 0,
-        clock_mu: 0,
+        carrier_offset_hz: 137,
+        agc_level: 0.42,
+        agc_target: 0.16,
+        clock_mu: 0.5,
         clock_sps: 10,
         cma_error: 0,
       });
       return { close: vi.fn() };
     });
 
-    render(<EyeDiagram />);
+    render(<Tuning />);
     await waitFor(() => {
-      expect(screen.getByText(/samples\/symbol/)).toBeInTheDocument();
+      expect(screen.getByText("137 Hz")).toBeInTheDocument();
     });
   });
 });

--- a/web/src/panels/Tuning.tsx
+++ b/web/src/panels/Tuning.tsx
@@ -1,0 +1,336 @@
+import {
+  CategoryScale,
+  Chart as ChartJS,
+  Filler,
+  Legend,
+  LinearScale,
+  LineElement,
+  PointElement,
+  Title,
+  Tooltip,
+} from "chart.js";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Line } from "react-chartjs-2";
+import {
+  fetchSpectrumDevices,
+  type SpectrumDevice,
+} from "../api/spectrum";
+import { openSymbolStream, type SymbolFrame } from "../api/symbols";
+import { selectClientConfig, useShared } from "../store/shared";
+import { prefs } from "../store/prefs";
+import { TuningControls } from "../components/TuningControls";
+
+ChartJS.register(
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Title,
+  Tooltip,
+  Legend,
+  Filler,
+);
+
+// Tuning panel — receiver-state meters off the live demod: GopherTrunk's
+// take on OP25's Mixer / Tuner (FLL) tabs. The daemon runs a parallel P25
+// receiver on the selected channel and stamps its loop state onto every
+// symbol frame; here we trend the residual carrier-frequency error and
+// surface the AGC, symbol-clock and (CQPSK) equalizer state. A locked,
+// healthy receiver settles the carrier error toward 0 Hz and holds the
+// AGC / clock steady.
+
+const HISTORY_POINTS = 240; // ~12 s at the ~50 ms frame cadence
+
+const PROTOS: { value: string; label: string }[] = [
+  { value: "p25-c4fm", label: "P25 C4FM" },
+  { value: "p25-cqpsk", label: "P25 CQPSK" },
+];
+
+type ConnState = "connecting" | "open" | "closed";
+
+export function Tuning() {
+  const cfg = useShared(selectClientConfig);
+  const activeCalls = useShared((s) => s.activeCalls);
+  const [devices, setDevices] = useState<SpectrumDevice[]>([]);
+  const [selected, setSelected] = useState<string | null>(null);
+  const [conn, setConn] = useState<ConnState>("closed");
+  const [latest, setLatest] = useState<SymbolFrame | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const [proto, setProto] = useState<string>(() => prefs.tuningProto());
+  const [offsetKHz, setOffsetKHz] = useState<number>(() =>
+    prefs.tuningOffsetKHz(),
+  );
+  const [hold, setHold] = useState<boolean>(() => prefs.tuningHold());
+
+  // Rolling carrier-error history.
+  const histRef = useRef<number[]>([]);
+  const [hist, setHist] = useState<number[]>([]);
+
+  useEffect(() => {
+    let cancel = false;
+    (async () => {
+      try {
+        const list = await fetchSpectrumDevices(cfg);
+        if (cancel) return;
+        setDevices(list);
+        setError(null);
+        if (list.length > 0 && selected == null) setSelected(list[0].serial);
+      } catch (e) {
+        if (cancel) return;
+        setError(e instanceof Error ? e.message : String(e));
+      }
+    })();
+    return () => {
+      cancel = true;
+    };
+  }, [cfg, selected]);
+
+  const device = useMemo(
+    () => devices.find((d) => d.serial === selected) ?? null,
+    [devices, selected],
+  );
+
+  const followOffsetKHz = useMemo(() => {
+    if (!device) return null;
+    const mine = activeCalls.filter(
+      (c) => c.device_serial === selected && !c.ended_at,
+    );
+    if (mine.length === 0) return null;
+    const newest = mine.reduce((a, b) => (b.started_at > a.started_at ? b : a));
+    return (newest.grant.frequency_hz - device.center_hz) / 1000;
+  }, [activeCalls, device, selected]);
+
+  useEffect(() => {
+    if (hold || followOffsetKHz == null) return;
+    setOffsetKHz((cur) =>
+      Math.abs(cur - followOffsetKHz) < 0.05 ? cur : followOffsetKHz,
+    );
+  }, [hold, followOffsetKHz]);
+
+  const maxOffsetKHz = device ? device.sample_rate_hz / 2000 : 1500;
+  const clampedOffsetKHz = Math.max(
+    -maxOffsetKHz,
+    Math.min(maxOffsetKHz, offsetKHz),
+  );
+
+  useEffect(() => {
+    prefs.setTuningOffsetKHz(offsetKHz);
+  }, [offsetKHz]);
+  useEffect(() => {
+    prefs.setTuningHold(hold);
+  }, [hold]);
+  useEffect(() => {
+    prefs.setTuningProto(proto);
+  }, [proto]);
+
+  useEffect(() => {
+    if (!selected) return;
+    histRef.current = [];
+    setHist([]);
+    setLatest(null);
+
+    const stream = openSymbolStream(cfg, {
+      serial: selected,
+      proto,
+      offset: Math.round(clampedOffsetKHz * 1000),
+      onFrame: (f) => {
+        setLatest(f);
+        const h = histRef.current;
+        h.push(f.carrier_offset_hz ?? 0);
+        if (h.length > HISTORY_POINTS) h.splice(0, h.length - HISTORY_POINTS);
+        setHist(h.slice());
+      },
+      onStatus: setConn,
+    });
+    return () => stream.close();
+  }, [cfg, selected, proto, clampedOffsetKHz]);
+
+  const isCQPSK = proto === "p25-cqpsk";
+
+  const centerHz = device?.center_hz ?? latest?.center_hz ?? null;
+  const viewHz = centerHz != null ? centerHz + clampedOffsetKHz * 1000 : null;
+
+  const tuningLabel = useMemo(() => {
+    if (viewHz == null) return "";
+    const off =
+      clampedOffsetKHz === 0
+        ? "centre"
+        : `${clampedOffsetKHz >= 0 ? "+" : ""}${clampedOffsetKHz.toFixed(3).replace(/\.?0+$/, "")} kHz`;
+    const head = `${(viewHz / 1e6).toFixed(4)} MHz (${off})`;
+    if (!latest) return `${head} · waiting for receiver state…`;
+    return head;
+  }, [latest, viewHz, clampedOffsetKHz]);
+
+  const chartData = useMemo(
+    () => ({
+      labels: hist.map((_, i) => String(i)),
+      datasets: [
+        {
+          label: "Carrier error (Hz)",
+          data: hist,
+          borderColor: "rgb(56, 189, 248)",
+          backgroundColor: "rgba(56, 189, 248, 0.15)",
+          borderWidth: 1.5,
+          pointRadius: 0,
+          fill: true,
+          tension: 0.2,
+        },
+      ],
+    }),
+    [hist],
+  );
+
+  const chartOptions = useMemo(
+    () => ({
+      responsive: true,
+      maintainAspectRatio: false,
+      animation: false as const,
+      plugins: { legend: { display: false } },
+      scales: {
+        x: { display: false },
+        y: {
+          title: { display: true, text: "Hz" },
+          grid: { color: "rgba(148,163,184,0.15)" },
+          ticks: { color: "rgba(148,163,184,0.8)" },
+        },
+      },
+    }),
+    [],
+  );
+
+  return (
+    <div className="space-y-3">
+      <header className="flex flex-wrap items-center justify-between gap-3">
+        <h2 className="text-xl font-semibold">Tuning</h2>
+        <div className="flex items-center gap-2 text-xs">
+          <span className="text-muted">SDR:</span>
+          <select
+            className="bg-surface border border-border rounded px-2 py-1"
+            value={selected ?? ""}
+            onChange={(e) => setSelected(e.target.value || null)}
+            disabled={devices.length === 0}
+          >
+            {devices.length === 0 && <option value="">No SDRs available</option>}
+            {devices.map((d) => (
+              <option key={d.serial} value={d.serial}>
+                {d.serial} · {d.role}
+              </option>
+            ))}
+          </select>
+          <ConnPill state={conn} />
+        </div>
+      </header>
+
+      {error && (
+        <div className="rounded border border-red-700/40 bg-red-900/20 text-red-200 text-xs px-3 py-2">
+          {error}
+        </div>
+      )}
+
+      <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-xs">
+        <label className="flex items-center gap-2">
+          <span className="text-muted">Mode</span>
+          <select
+            className="bg-surface border border-border rounded px-2 py-1"
+            value={proto}
+            onChange={(e) => setProto(e.target.value)}
+            aria-label="Demodulation mode"
+          >
+            {PROTOS.map((p) => (
+              <option key={p.value} value={p.value}>
+                {p.label}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <TuningControls
+          centerHz={centerHz}
+          maxOffsetKHz={maxOffsetKHz}
+          offsetKHz={clampedOffsetKHz}
+          onOffsetChange={(khz) => {
+            setHold(true);
+            setOffsetKHz(khz);
+          }}
+          hold={hold}
+          onHoldChange={setHold}
+          followingActive={followOffsetKHz != null}
+          onCentre={() => {
+            setHold(true);
+            setOffsetKHz(0);
+          }}
+        />
+      </div>
+
+      <div className="font-mono text-xs text-muted">{tuningLabel || "—"}</div>
+
+      {/* Carrier-error trend (the FLL view). */}
+      <div className="rounded border border-border bg-black p-2" style={{ height: 220 }}>
+        <Line data={chartData} options={chartOptions} />
+      </div>
+
+      {/* Current loop state. */}
+      <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 text-xs">
+        <Meter
+          label="Carrier error"
+          value={latest ? `${latest.carrier_offset_hz.toFixed(0)} Hz` : "—"}
+        />
+        <Meter
+          label={isCQPSK ? "AGC gain" : "AGC level"}
+          value={latest ? latest.agc_level.toFixed(3) : "—"}
+          sub={
+            !isCQPSK && latest && latest.agc_target > 0
+              ? `target ${latest.agc_target.toFixed(3)}`
+              : undefined
+          }
+        />
+        <Meter
+          label="Clock μ"
+          value={latest ? latest.clock_mu.toFixed(3) : "—"}
+          sub={latest && latest.clock_sps > 0 ? `sps ${latest.clock_sps.toFixed(2)}` : undefined}
+        />
+        {isCQPSK && (
+          <Meter
+            label="CMA error"
+            value={latest ? latest.cma_error.toFixed(4) : "—"}
+          />
+        )}
+      </div>
+
+      <div className="text-[11px] text-muted">
+        Live receiver state off the selected channel (OP25's Mixer / Tuner
+        FLL). <strong>Carrier error</strong> is the loop's residual
+        frequency-offset estimate — it should trend toward 0 Hz and hold
+        once locked; a persistent offset is tuner PPM, a wandering one is a
+        loop that hasn't acquired. AGC, clock μ and (CQPSK) CMA error should
+        settle and stay steady. Dial the <em>Offset</em> onto a locked
+        channel; pick the <em>Mode</em> that matches the site.
+      </div>
+    </div>
+  );
+}
+
+function Meter({
+  label,
+  value,
+  sub,
+}: {
+  label: string;
+  value: string;
+  sub?: string;
+}) {
+  return (
+    <div className="rounded border border-border bg-surface px-3 py-2">
+      <div className="text-muted">{label}</div>
+      <div className="font-mono text-sm">{value}</div>
+      {sub && <div className="text-[10px] text-muted">{sub}</div>}
+    </div>
+  );
+}
+
+function ConnPill({ state }: { state: ConnState }) {
+  if (state === "open") return <span className="pill-ok">live</span>;
+  if (state === "connecting") return <span className="pill-warn">connecting</span>;
+  return <span className="pill-err">offline</span>;
+}

--- a/web/src/store/prefs.ts
+++ b/web/src/store/prefs.ts
@@ -20,6 +20,8 @@ const LS_KEYS = {
   constellationDcBlock: "gt.constellation.dcBlock",
   constellationAutoScale: "gt.constellation.autoScale",
   constellationZoom: "gt.constellation.zoom",
+  constellationView: "gt.constellation.view",
+  constellationProto: "gt.constellation.proto",
   symbolScopeOffsetKHz: "gt.symbolScope.offsetKHz",
   symbolScopeHold: "gt.symbolScope.hold",
   symbolScopeProto: "gt.symbolScope.proto",
@@ -178,6 +180,23 @@ export const prefs = {
   },
   setConstellationZoom(z: number) {
     writeLS(LS_KEYS.constellationZoom, String(Math.max(0.5, Math.min(8, z))));
+  },
+  // Constellation render source: "symbols" plots the receiver's
+  // symbol-decision points (the true constellation — tight clusters for
+  // CQPSK, the 4 soft levels for C4FM); "raw" plots the wideband
+  // decimated IQ trajectory (a vector scope). Default "symbols".
+  constellationView(): "symbols" | "raw" {
+    return readLS(LS_KEYS.constellationView) === "raw" ? "raw" : "symbols";
+  },
+  setConstellationView(v: "symbols" | "raw") {
+    writeLS(LS_KEYS.constellationView, v);
+  },
+  // Receiver selector for the symbols view ("p25-c4fm" / "p25-cqpsk").
+  constellationProto(): string {
+    return readLS(LS_KEYS.constellationProto) ?? "p25-cqpsk";
+  },
+  setConstellationProto(p: string) {
+    writeLS(LS_KEYS.constellationProto, p);
   },
 
   // Symbol-scope panel view options. Offset (kHz, relative to the SDR

--- a/web/src/store/prefs.ts
+++ b/web/src/store/prefs.ts
@@ -30,6 +30,9 @@ const LS_KEYS = {
   tuningOffsetKHz: "gt.tuning.offsetKHz",
   tuningHold: "gt.tuning.hold",
   tuningProto: "gt.tuning.proto",
+  histogramOffsetKHz: "gt.histogram.offsetKHz",
+  histogramHold: "gt.histogram.hold",
+  histogramProto: "gt.histogram.proto",
 } as const;
 
 const SS_KEYS = {
@@ -268,6 +271,29 @@ export const prefs = {
   },
   setTuningProto(p: string) {
     writeLS(LS_KEYS.tuningProto, p);
+  },
+
+  // Symbol-histogram panel view options.
+  histogramOffsetKHz(): number {
+    const raw = readLS(LS_KEYS.histogramOffsetKHz);
+    if (raw === null) return 0;
+    const n = Number(raw);
+    return Number.isFinite(n) ? n : 0;
+  },
+  setHistogramOffsetKHz(khz: number) {
+    writeLS(LS_KEYS.histogramOffsetKHz, String(khz));
+  },
+  histogramHold(): boolean {
+    return readLS(LS_KEYS.histogramHold) === "1";
+  },
+  setHistogramHold(on: boolean) {
+    writeLS(LS_KEYS.histogramHold, on ? "1" : "0");
+  },
+  histogramProto(): string {
+    return readLS(LS_KEYS.histogramProto) ?? "p25-c4fm";
+  },
+  setHistogramProto(p: string) {
+    writeLS(LS_KEYS.histogramProto, p);
   },
 
   /** Clear all GopherTrunk-owned keys. Used by Settings → "forget this device". */

--- a/web/src/store/prefs.ts
+++ b/web/src/store/prefs.ts
@@ -27,6 +27,9 @@ const LS_KEYS = {
   symbolScopeProto: "gt.symbolScope.proto",
   eyeOffsetKHz: "gt.eye.offsetKHz",
   eyeHold: "gt.eye.hold",
+  tuningOffsetKHz: "gt.tuning.offsetKHz",
+  tuningHold: "gt.tuning.hold",
+  tuningProto: "gt.tuning.proto",
 } as const;
 
 const SS_KEYS = {
@@ -242,6 +245,29 @@ export const prefs = {
   },
   setEyeHold(on: boolean) {
     writeLS(LS_KEYS.eyeHold, on ? "1" : "0");
+  },
+
+  // Tuning panel view options (receiver-state meters).
+  tuningOffsetKHz(): number {
+    const raw = readLS(LS_KEYS.tuningOffsetKHz);
+    if (raw === null) return 0;
+    const n = Number(raw);
+    return Number.isFinite(n) ? n : 0;
+  },
+  setTuningOffsetKHz(khz: number) {
+    writeLS(LS_KEYS.tuningOffsetKHz, String(khz));
+  },
+  tuningHold(): boolean {
+    return readLS(LS_KEYS.tuningHold) === "1";
+  },
+  setTuningHold(on: boolean) {
+    writeLS(LS_KEYS.tuningHold, on ? "1" : "0");
+  },
+  tuningProto(): string {
+    return readLS(LS_KEYS.tuningProto) ?? "p25-c4fm";
+  },
+  setTuningProto(p: string) {
+    writeLS(LS_KEYS.tuningProto, p);
   },
 
   /** Clear all GopherTrunk-owned keys. Used by Settings → "forget this device". */

--- a/web/src/store/prefs.ts
+++ b/web/src/store/prefs.ts
@@ -25,6 +25,8 @@ const LS_KEYS = {
   symbolScopeOffsetKHz: "gt.symbolScope.offsetKHz",
   symbolScopeHold: "gt.symbolScope.hold",
   symbolScopeProto: "gt.symbolScope.proto",
+  eyeOffsetKHz: "gt.eye.offsetKHz",
+  eyeHold: "gt.eye.hold",
 } as const;
 
 const SS_KEYS = {
@@ -222,6 +224,24 @@ export const prefs = {
   },
   setSymbolScopeProto(p: string) {
     writeLS(LS_KEYS.symbolScopeProto, p);
+  },
+
+  // Eye-diagram panel view options (C4FM datascope). Same offset/Hold
+  // semantics as the Symbol scope.
+  eyeOffsetKHz(): number {
+    const raw = readLS(LS_KEYS.eyeOffsetKHz);
+    if (raw === null) return 0;
+    const n = Number(raw);
+    return Number.isFinite(n) ? n : 0;
+  },
+  setEyeOffsetKHz(khz: number) {
+    writeLS(LS_KEYS.eyeOffsetKHz, String(khz));
+  },
+  eyeHold(): boolean {
+    return readLS(LS_KEYS.eyeHold) === "1";
+  },
+  setEyeHold(on: boolean) {
+    writeLS(LS_KEYS.eyeHold, on ? "1" : "0");
   },
 
   /** Clear all GopherTrunk-owned keys. Used by Settings → "forget this device". */


### PR DESCRIPTION
## Why

Two problems surfaced reviewing the diagnostic plots against OP25 / SDRTrunk:

1. **The "Constellation" wasn't a constellation.** It plotted raw, box-averaged,
   wideband **decimated IQ** (every sample including inter-symbol transitions, no
   matched filter, no symbol clock) — a *vector scope / IQ trajectory*, which can
   never show the tight symbol clusters that reveal modulation quality. A real
   constellation samples at the symbol-decision instants.
2. **Most quality plots only existed offline.** The rich SigLab analyzer (eye,
   tuning/AFC, histogram) had no live equivalent — even though the data was
   already computed in the receiver.

**Key enabler:** the per-channel `WS /api/v1/diag/symbols` stream already runs the
production receiver. This PR turns it into the single "channel analyzer" feed —
one receiver instance now drives every scope (one decode, many views), mirroring
OP25's model.

## What changed (phased, one commit per phase)

1. **True symbol constellation + raw toggle** — new `SymbolSink` on the receiver
   emits the per-symbol complex constellation points (CQPSK `c.symbols`, post-Costas
   π/4-DQPSK). The Constellation panel gets a **View** toggle: **Symbols** (default;
   CQPSK clusters on the ±45°/±135° diagonals, C4FM soft levels on the real axis,
   amber ideal-cluster rings) vs **Vector scope** (the prior raw-IQ trajectory).
2. **Eye diagram** (`/eye`) — OP25's datascope. New `EyeSink` taps the oversampled,
   AGC-scaled matched-filter output (C4FM); the panel folds it over the symbol period
   into the open 4-level eye.
3. **Tuning** (`/tuning`) — OP25's Mixer/Tuner-FLL. Stamps the receiver's existing
   state getters (carrier offset, AGC, clock μ, CMA error) onto each frame; rolling
   carrier-error trend + loop-state meters.
4. **Symbol histogram** (`/histogram`) — recovered-symbol distribution + a Balance
   meter and (C4FM) an MER-like SNR estimate, computed client-side off the stream.
5. **Plots hub** (`/plots`) — gathers the five per-channel scopes under one tabbed
   page (URL-driven sub-tabs, deep-link routes preserved); Spectrum stays its own tab.

Backend taps are additive and demod-aware: CQPSK produces complex symbols, C4FM
produces the eye; the wrong-path sinks stay uncalled.

## Tests / verification

- **Go:** `go build ./...`; receiver `SymbolSink` alignment/clustering + C4FM-never-fires;
  symbolscope eye + metric coverage (present/empty per demod, bounded, sps ≥ 2);
  API wire round-trip. All green.
- **Web:** 151 vitest tests pass; `tsc --noEmit` clean; `npm run build` OK. New panel
  tests for Constellation (both streams), Eye, Tuning, Histogram, and the Plots hub.

Docs added/updated (`constellation.md`, `eye-diagram.md`, `tuning.md`, `histogram.md`,
`plots.md` + nav) and CHANGELOG.

Follow-up to #557.

https://claude.ai/code/session_01SoLZgHc9snsyfchmmD61XA

---
_Generated by [Claude Code](https://claude.ai/code/session_01SoLZgHc9snsyfchmmD61XA)_