### PR TITLE
docs: add two-page Getting Started guide

### DIFF
--- a/docs/getting-started-setup.md
+++ b/docs/getting-started-setup.md
@@ -1,129 +1,105 @@
 ---
 layout: page
 title: Get started
-description: From download to your first decoded call in a few steps
+description: Download GopherTrunk and run your first scan from the web interface — no command line required
 nav_group: Getting Started
 ---
 
 # Get started
 
-A straightforward path from a fresh download to your first decoded call. New to
-the project? Read [What is GopherTrunk?](getting-started.html) first for the
-big picture. The steps below use Linux x86_64; macOS, Windows, and ARM64 follow
-the same shape — see the per-OS pages linked in step 2.
+This is the simple, click-along path: download GopherTrunk, start it, and drive
+everything from the **web interface** in your browser — no command line, no Git,
+no editing config files by hand. New to the project? Read
+[What is GopherTrunk?](getting-started.html) first for the big picture.
 
-## 1. Connect a radio
+> Prefer the terminal, or running on a headless server / Raspberry Pi? The
+> per-OS install guides cover the command-line path:
+> [Linux](install-linux.html) · [macOS](install-macos.html) ·
+> [Windows](install-windows.html).
 
-Plug in an SDR dongle. An **RTL-SDR** is the cheapest place to start. Attach an
-antenna suited to your band (for ~700–900 MHz public-safety trunking, a simple
-discone or a tuned whip works). Device-by-device guidance — gain, bias-tee,
-remote backends — is in the [Hardware guide](hardware.html).
+## 1. Get a radio
 
-## 2. Download the binary
+You need an SDR dongle plugged into a USB port. An **RTL-SDR** (around $30) is
+the easiest and cheapest place to start. Connect an antenna suited to the band
+you want to listen to. Device-by-device advice is in the
+[Hardware guide](hardware.html).
 
-```sh
-# Linux x86_64 — see https://gophertrunk.org/downloads.html for macOS, Windows, ARM64.
-VERSION=v0.3.5
-curl -L -o gophertrunk.tar.gz \
-  https://github.com/MattCheramie/GopherTrunk/releases/download/${VERSION}/gophertrunk-${VERSION}-linux-amd64.tar.gz
-tar xzf gophertrunk.tar.gz && cd gophertrunk-${VERSION}-linux-amd64
-```
+## 2. Download GopherTrunk
 
-On other platforms, follow the per-OS recipe instead — Windows ships a one-click
-installer that bundles Zadig for WinUSB setup, and macOS ships notarised
-tarballs:
+Go to the **[Downloads page](downloads.html)** and click the button for your
+computer:
 
-- [Linux install](install-linux.html)
-- [macOS install](install-macos.html)
-- [Windows install](install-windows.html)
-- [All downloads & checksums](downloads.html)
+- **Windows** — click **x64 Installer (.exe)**, then run the downloaded file
+  (double-click it) and follow the wizard, just like any other program. It adds
+  a **GopherTrunk** shortcut to your Start Menu.
+- **macOS** — click the **Apple Silicon** (newer Macs) or **Intel** button,
+  open the downloaded file, and drag GopherTrunk out. The first time you open
+  it, **right-click the app and choose "Open"** to get past the security prompt.
+- **Linux** — download the file for your machine and unpack it.
 
-## 3. Verify the binary and your radio
+That's the whole install — GopherTrunk is one self-contained program.
 
-```sh
-./gophertrunk version          # confirms the binary runs
-./gophertrunk sdr list         # should list your dongle(s)
-```
+## 3. Windows only: turn on your radio driver
 
-If `sdr list` doesn't see your dongle, run the diagnostics:
+Windows needs a one-time driver step before it can see an RTL-SDR. The installer
+bundles a tool that does this for you:
 
-```sh
-./gophertrunk sdr doctor -v    # explains why a dongle isn't recognized
-```
+1. Open the Start Menu → **GopherTrunk** → **"Install RTL-SDR driver (Zadig)"**.
+2. In the window that opens, pick your dongle from the list and click the
+   install button.
 
-## 4. Create your config
+Do this once per dongle. (Full screenshots are in the
+[Windows install guide](install-windows.html).) macOS and Linux don't need this.
 
-```sh
-cp config.example.yaml config.yaml
-```
+## 4. Start GopherTrunk and open the web interface
 
-`config.example.yaml` is heavily annotated. The one thing a newcomer must set is
-**at least one system** under `trunking:` — its protocol and control-channel
-frequency. The shape is simple:
+Launch GopherTrunk (on Windows, use the Start Menu shortcut). It asks how you
+want to drive it — **choose Web**. Your browser opens to the GopherTrunk
+console, where everything from here on happens with clicks.
 
-```yaml
-trunking:
-  systems:
-    - name: "Example-P25"
-      protocol: p25
-      control_channels:
-        - 851_000_000
-      talkgroup_file: "/etc/gophertrunk/talkgroups-p25.csv"   # optional alpha tags
-```
+The program keeps running in the background while you use the browser. To stop
+it later, close the GopherTrunk window (or press `Ctrl-C` in its window).
 
-Don't hand-edit if you don't have to:
+## 5. Add a system to listen to — from the browser
 
-- **[Import (PDF / CSV)](import.html)** — pull a system straight from a
-  RadioReference PDF/CSV (`gophertrunk import-pdf`, or the Import panel in any
-  UI).
-- **Config Builder** — `gophertrunk config serve` opens a guided editor in your
-  browser.
-- **[Live edits](live-edits.html)** — most settings can be changed from a
-  running UI without restarting the daemon.
+GopherTrunk needs to know *which* radio system to follow. You don't have to edit
+any files — set this up right in the web interface:
 
-## 5. Run it
+- **Easiest: import it.** Find your area's system on
+  [RadioReference](https://www.radioreference.com/) and download its PDF, then
+  use the console's **Import** page to load it. GopherTrunk fills in the
+  frequencies and talkgroups for you. See [Import](import.html).
+- **Or add it by hand** on the **Settings** page: add a system, choose its
+  protocol (for example P25 or DMR), and enter its control-channel frequency.
 
-```sh
-./gophertrunk -config config.yaml
-```
-
-On a terminal this drops into the **launcher** — pick **[1] TUI**, **[2] Web**,
-or **[3] Headless**. Skip the prompt with a flag:
-
-```sh
-./gophertrunk -tui  -config config.yaml   # in-process terminal console
-./gophertrunk -web  -config config.yaml   # open the browser console
-./gophertrunk -headless -config config.yaml   # silent daemon
-```
-
-More on the menu and how each mode attaches: [Launcher](launcher.html).
+Changes you make in the browser are saved automatically, and most take effect
+without restarting. See [Live edits](live-edits.html).
 
 ## 6. Watch your first call
 
-Once running, you're looking for this sequence:
+Back on the dashboard, you're looking for this to happen on its own:
 
-1. **CC locks** — the daemon synchronises to the control channel.
-2. **A grant fires** — the system assigns a talkgroup to a voice channel.
-3. **A call records** — audio is captured and written to your recordings
-   directory (set under `recordings:` in the config) and logged to the SQLite
-   call database.
+1. The control channel **locks** (GopherTrunk has tuned in to the system).
+2. A **call** appears in the active-calls list as people talk.
+3. The call is **recorded** and shows up in your history.
 
-Read the panels — active calls, history, control-channel activity — via the
-[TUI](tui.html) or the [Web console](web.html).
+The [Web console guide](web.html) walks through what every panel shows.
 
-## 7. Next steps
+## 7. Where to go next
 
-- **Share your feed** — stream completed calls to Broadcastify Calls,
-  RdioScanner, OpenMHz, or Icecast/ShoutCast (`broadcast:` config).
-- **[Hunt](hunt.html)** — discover and map an unknown trunked system.
-- **[Hardening](hardening.html)** — API auth, TLS, and safe remote access.
-- **[Opt-in features](opt-in-features.html)** — paging, APRS, AIS, ADS-B, and
-  other extras.
+- **Share your feed** — stream calls to Broadcastify Calls, RdioScanner, or
+  OpenMHz from the Settings page.
+- **[Hunt](hunt.html)** — let GopherTrunk discover an unknown system for you.
+- **[Hardening](hardening.html)** — turn on passwords/encryption if you'll reach
+  the console from other devices on your network.
+- **[Opt-in features](opt-in-features.html)** — paging, aircraft (ADS-B), boats
+  (AIS), and more.
 
-## Troubleshooting
+## If something's not working
 
-- **Dongle not found** → `./gophertrunk sdr doctor -v`, then the
-  [Hardware guide](hardware.html).
-- **No audio on playback** → `./gophertrunk audio list` to check output devices.
-- **Voice grants dropped on DMR Tier III** → the system needs a `dmr_band_plan`
-  (see the annotated `config.example.yaml`).
+- **GopherTrunk can't find your dongle** — on Windows, re-run the Zadig driver
+  step (#3); on any system, check the [Hardware guide](hardware.html).
+- **No sound when playing a call** — make sure your computer's audio output is
+  selected and turned up.
+- **Nothing is decoding** — double-check the control-channel frequency and
+  protocol you entered for the system in step 5.

--- a/docs/getting-started-setup.md
+++ b/docs/getting-started-setup.md
@@ -60,20 +60,29 @@ console, where everything from here on happens with clicks.
 The program keeps running in the background while you use the browser. To stop
 it later, close the GopherTrunk window (or press `Ctrl-C` in its window).
 
-## 5. Add a system to listen to — from the browser
+## 5. Add a system to listen to — with the Config Builder
 
-GopherTrunk needs to know *which* radio system to follow. You don't have to edit
-any files — set this up right in the web interface:
+GopherTrunk needs to know *which* radio system to follow. The friendliest way to
+set this up is the **Config Builder** — a guided, browser-based editor. You never
+touch a config file.
 
-- **Easiest: import it.** Find your area's system on
-  [RadioReference](https://www.radioreference.com/) and download its PDF, then
-  use the console's **Import** page to load it. GopherTrunk fills in the
-  frequencies and talkgroups for you. See [Import](import.html).
-- **Or add it by hand** on the **Settings** page: add a system, choose its
-  protocol (for example P25 or DMR), and enter its control-channel frequency.
+Open it from the web console by clicking the **🛠 Config Builder** button (top of
+the page) — it opens in a new tab. Inside, you can:
 
-Changes you make in the browser are saved automatically, and most take effect
-without restarting. See [Live edits](live-edits.html).
+- **Browse RadioReference** for your county/agency and pull a system straight in,
+  or **import a PDF/CSV** you downloaded from
+  [RadioReference](https://www.radioreference.com/) — the builder fills in the
+  frequencies and talkgroups for you.
+- **Build a system by hand** — add a system, pick its protocol (for example P25
+  or DMR), and type in its control-channel frequency.
+
+The builder checks your settings as you go and **saves** them when you're done.
+More detail is in the [Import guide](import.html).
+
+> Quick alternative: the web console's own **Settings** page can also add a
+> system inline, and small tweaks made anywhere in the console save
+> automatically and mostly apply without a restart — see
+> [Live edits](live-edits.html).
 
 ## 6. Watch your first call
 


### PR DESCRIPTION
## Summary

Adds a consolidated, two-page **Getting Started** on-ramp to the docs site, wired into a new "Getting Started" nav group at the top of the sidebar.

- **Page 1 — What is GopherTrunk?** (`docs/getting-started.md`): a concise conceptual map — what it is, supported hardware, what it decodes, and an **interfaces table** covering the headless daemon, TUI cockpit, web console, interactive launcher, **Config Builder**, and **SigLab** (clarifying which are daemon views vs standalone apps), plus APIs/integrations and how the parts fit together.
- **Page 2 — Get started** (`docs/getting-started-setup.md`): a beginner-friendly, click-along path for non-technical users — download from the Downloads page, run the installer (with the one-time Windows Zadig driver step called out), launch and choose the **web interface**, then add a system using the **Config Builder** (RadioReference browse / PDF-CSV import / build by hand) — no Git, no command line, no hand-edited YAML. CLI/server users get a pointer to the per-OS install guides up top.
- **Nav** (`docs/_data/nav.yml`): new "Getting Started" group at the top of the sidebar.

## Verification

- `nav.yml` parses as valid YAML.
- All internal `.html` links resolve to existing `docs/*.md` pages.
- Front-matter matches the existing Jekyll page convention.

https://claude.ai/code/session_012rt1b6586vfok2HgRMwXb2

---
_Generated by [Claude Code](https://claude.ai/code/session_012rt1b6586vfok2HgRMwXb2)_