### PR TITLE
docs: post-release v0.3.6 — promote CHANGELOG, bump refs, announcement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ for tagged releases.
 
 ## [Unreleased]
 
+## [v0.3.6] — 2026-06-08
+
+This release is about **seeing the signal**. A new **Plots hub** (`/plots`)
+gathers the per-channel scopes — Constellation, Symbol scope, Eye diagram,
+Tuning, Histogram — into one tabbed home that mirrors OP25's Plots tabs (#557,
+#583), now with a true symbol constellation, an open four-level eye, live
+receiver-state meters, and a symbol-distribution histogram. Underneath, **P25
+Phase 1 voice finally decodes** after the IMBE channel-convention and LDU
+voice-frame-offset fixes (#574, #578); **TETRA** gains real ETSI training
+sequences, a corrected control-channel sync layer with auto-learned colour
+code, and soft-decision SB-burst FEC (#569, #571, #573); and a shared
+**voice-recording boundary** controller tightly bounds every call by hangtime
+and talkgroup (#579). On the operator side, the web **Config Builder** reaches
+dual-editor parity with the TUI (#570–#582), the **spectrum** panel gains a
+hover readout and dual-pager DDC (#577), and a two-page **Getting Started**
+guide lands for non-technical users (#581).
+
 ### Added
 
 - **Universal voice recording boundaries — hangtime + per-transmission
@@ -59,8 +76,32 @@ for tagged releases.
   **Vector scope (raw IQ)** for identifying unknown signals. The symbols
   stream reuses the live receiver (`WS /api/v1/diag/symbols`), so it shows
   exactly what the production demod sees.
+- **Web Config Builder — dual-editor parity with the TUI** (#570, #572, #576,
+  #580, #582). The browser-based Config Builder gains the editor primitives it
+  was missing (ListEditor, AdvancedJSON, Fieldset, HzField), a shared
+  HTTP-free config core with whole-file marshal/write and per-section
+  validation, and backend gap-fill (multi-error reporting, comment-preserving
+  merge, file management, RadioReference name lookup). A dual-editor
+  schema-drift test now fails CI if any config field is editable in one editor
+  but not the other, so the web and TUI builders stay in lockstep.
+- **Two-page Getting Started guide** (#581) — a non-technical walkthrough
+  (`/getting-started-setup.html`) that takes a new user from download to a
+  running scan, featuring the Config Builder, plus refreshed interfaces and
+  source-section help sourced from the shared field registry.
+- **Spectrum hover readout + dual-pager DDC** (#577). The wideband Spectrum
+  waterfall now shows a live frequency/power readout under the cursor, the
+  paging DDC can run two channels at once, and decoded pages carry a
+  human-readable pager-type label.
 
 ### Fixed
+
+- **TETRA control channel would not lock on real signals** (#569, #571, #573).
+  The SB-burst lock chain used placeholder sync constants instead of the real
+  ETSI training sequences, the control-channel sync layer mis-framed bursts,
+  and the FEC was hard-decision only. The decoder now uses the ETSI normal/
+  synchronisation training sequences, a corrected sync layer that auto-learns
+  the colour code, and soft-decision FEC for the SB-burst, so a production
+  144 kHz / 8 sps TETRA control channel locks.
 
 - **P25 Phase 1 voice still garbled after the IMBE channel-decode fix —
   wrong LDU voice-frame positions** (#489 follow-up). With the channel
@@ -109,6 +150,10 @@ for tagged releases.
   and gains an adjustable **Zoom** control (up to 8×; dots scale with both
   zoom and plot size); its auto-scale now targets the ~95th-percentile radius
   so a stray outlier no longer shrinks the cloud.
+- **Warn when message decoders are configured without storage** (#568). A
+  decoder that produces messages (paging, MDC, DSC, …) but has no storage
+  backend configured silently dropped everything; the daemon now logs a
+  startup warning so the misconfiguration is visible.
 
 ## [v0.3.5] — 2026-06-07
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ this exist? Read **[The Story of GopherTrunk](https://gophertrunk.org/story.html
 
 ```sh
 # Linux x86_64 — see https://gophertrunk.org/downloads.html for macOS, Windows, ARM64.
-VERSION=v0.3.5
+VERSION=v0.3.6
 curl -L -o gophertrunk.tar.gz \
   https://github.com/MattCheramie/GopherTrunk/releases/download/${VERSION}/gophertrunk-${VERSION}-linux-amd64.tar.gz
 tar xzf gophertrunk.tar.gz && cd gophertrunk-${VERSION}-linux-amd64

--- a/docs/announcements/v0.3.6.md
+++ b/docs/announcements/v0.3.6.md
@@ -1,0 +1,51 @@
+# GopherTrunk v0.3.6 — social announcement drafts
+
+One-click copy-paste blurbs for posting the v0.3.6 release. Each block
+below is a fenced code block so the rendered-markdown "copy" button
+grabs exactly what you'd paste.
+
+Release: https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.3.6
+
+---
+
+## Reddit — title
+
+```
+GopherTrunk v0.3.6 — a tabbed Plots hub for the signal scopes, real P25 Phase 1 voice decode, TETRA control-channel lock, and dual-editor Config Builder parity
+```
+
+## Reddit — body
+
+```markdown
+**[GopherTrunk](https://gophertrunk.org) v0.3.6 is out** — pure-Go digital-trunking scanner for RTL-SDR / HackRF / Airspy. P25 (Phase 1+2), DMR (AMBE+2 voice), NXDN, Motorola Type II, EDACS, LTR, MPT 1327, dPMR, D-STAR, YSF, M17, plus APRS, POCSAG + FLEX paging, and AIS / DSC / ADS-B. No CGO, single static binary for Linux / macOS / Windows.
+
+**What's new since v0.3.5:**
+
+* **Plots hub** (`/plots`, #557, #583) — one tabbed home for the per-channel signal scopes that mirrors OP25's Plots tabs: a **true symbol constellation** (real complex clusters for CQPSK/LSM, the four soft levels for C4FM, with a raw-IQ vector-scope toggle), an **Eye diagram** (the four-level C4FM eye), a **Tuning** panel (live receiver-state meters — carrier offset, AGC, symbol clock, equalizer convergence), and a **Symbol histogram** with a derived MER / balance signal-quality readout. The chosen sub-tab is reflected in the URL.
+* **Real P25 Phase 1 voice decode** (#574, #578) — the IMBE 4400 channel decoder now matches the on-air convention (P25-faithful Golay(23,12,7) + Hamming, correct column order, descrambler seed and keystream direction), and the LDU voice-frame offsets are fixed to the real `u0, u1, LC1, …` layout, so real-air P25 voice decodes to audio instead of warbling noise.
+* **TETRA control-channel lock** (#569, #571, #573) — real ETSI training sequences, a corrected control-channel sync layer that auto-learns the colour code, and soft-decision SB-burst FEC, so a production 144 kHz / 8 sps TETRA control channel actually locks.
+* **Universal voice recording boundaries** (#579) — a shared composer boundary controller ends a call promptly on voice-stop (configurable hangtime, default 3.5 s) instead of waiting out the 30 s watchdog, splits per-transmission or per-conversation, and gates shared voice frequencies by decoded talkgroup so audio never lands in the wrong recording. Applies to FM, DMR, and P25 Phase 1/2.
+* **Web Config Builder — dual-editor parity** (#570–#582) — the browser config builder gains the editor primitives it was missing, a shared HTTP-free config core with per-section validation, and a schema-drift test that fails CI if any field is editable in one editor but not the other. Plus a two-page **Getting Started** guide for non-technical users (#581) and a Spectrum hover readout + dual-pager DDC (#577).
+
+**Downloads** (Linux / macOS / Windows, x64 + ARM64): https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.3.6
+
+**Docs:** https://gophertrunk.org
+
+Heads-up: the v0.x line is still flagged prerelease — actively developed, feedback / captures / bug reports very welcome.
+```
+
+## Discord
+
+```markdown
+**GopherTrunk v0.3.6 is out** — pure-Go trunking scanner for RTL-SDR / HackRF / Airspy. P25, DMR, NXDN, M17, analog trunked, APRS, POCSAG + FLEX paging, AIS / DSC / ADS-B. Single static binary, zero CGO.
+
+**What's new since v0.3.5:**
+- **Plots hub** (`/plots`, #557, #583) — tabbed home for the scopes: true symbol constellation (CQPSK/LSM + C4FM, raw-IQ toggle), eye diagram, tuning meters, and a symbol histogram with MER/balance readout. OP25's Plots tabs.
+- **Real P25 Phase 1 voice decode** (#574, #578) — IMBE channel-convention + LDU voice-frame-offset fixes turn warbling noise into actual audio.
+- **TETRA control-channel lock** (#569, #571, #573) — real ETSI training sequences, fixed sync layer + auto-learned colour code, soft-decision SB-burst FEC.
+- **Universal voice recording boundaries** (#579) — hangtime + per-transmission/conversation splitting + talkgroup gating across FM/DMR/P25.
+- **Config Builder dual-editor parity** (#570–#582) + two-page Getting Started guide (#581) + Spectrum hover readout & dual-pager DDC (#577).
+
+Download: <https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.3.6>
+Docs: <https://gophertrunk.org>
+```

--- a/docs/downloads.md
+++ b/docs/downloads.md
@@ -28,7 +28,7 @@ release state looks like:
 {%- elsif site.github.releases and site.github.releases[0] and site.github.releases[0].tag_name -%}
   {%- assign ver = site.github.releases[0].tag_name -%}
 {%- else -%}
-  {%- assign ver = "v0.3.5" -%}
+  {%- assign ver = "v0.3.6" -%}
 {%- endif -%}
 {%- assign rel_url = "https://github.com/MattCheramie/GopherTrunk/releases/download/" | append: ver -%}
 


### PR DESCRIPTION
The v0.3.6 daily release shipped (PRs #564-#583) but the docs still
pointed at v0.3.5. Sync the docs tree to the released tag:

- CHANGELOG: promote the [Unreleased] signal-plots / voice-recording /
  P25-voice work into a dated [v0.3.6] section with a summary, and
  backfill the remaining user-visible v0.3.6 items — web Config Builder
  dual-editor parity (#570-#582), TETRA control-channel lock (#569,
  #571, #573), Getting Started guide (#581), Spectrum hover + dual-pager
  DDC (#577), and the no-storage decoder warning (#568). Reset
  [Unreleased] to empty.
- README / docs/downloads.md: bump the hardcoded version refs
  v0.3.5 -> v0.3.6.
- docs/announcements: add the v0.3.6 social-announcement drafts.