### PR TITLE
Fix constellation "waiting for symbols": dibits wire encoding (#557)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ for tagged releases.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Constellation / signal scopes stuck on "waiting for symbols"** (#557,
+  #583). The `WS /api/v1/diag/symbols` frame encoded its `dibits` field as a
+  Go `[]uint8`, which `encoding/json` serialises as a base64 string rather than
+  a JSON number array. The web console drops any frame whose `dibits` isn't an
+  array, so every frame was silently discarded and the Constellation, Symbol
+  scope, Eye, Tuning, and Histogram panels never rendered. `dibits` now goes
+  out as a number array, with a regression test asserting the wire shape.
+
 ## [v0.3.6] — 2026-06-08
 
 This release is about **seeing the signal**. A new **Plots hub** (`/plots`)

--- a/cmd/gophertrunk/symbol_provider.go
+++ b/cmd/gophertrunk/symbol_provider.go
@@ -104,7 +104,7 @@ func (p *symbolProvider) OpenSymbolStream(ctx context.Context, serial, proto str
 				SymQ:         f.SymQ,
 				EyeSoft:      f.EyeSoft,
 				EyeSPS:       f.EyeSPS,
-				Dibits:       f.Dibits,
+				Dibits:       api.DibitArray(f.Dibits),
 				IsBits:       f.IsBits,
 				BaseIdx:      f.BaseIdx,
 

--- a/internal/api/symbols.go
+++ b/internal/api/symbols.go
@@ -4,10 +4,36 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/gorilla/websocket"
 )
+
+// DibitArray marshals a dibit stream as a JSON number array. Go's
+// encoding/json renders []byte/[]uint8 as a base64 string, which the web
+// client (expecting number[]) silently drops — this forces the array
+// form. Unmarshal uses the default []uint8 path (which accepts a JSON
+// number array), so round-trips still work.
+type DibitArray []uint8
+
+// MarshalJSON emits the dibits as [n,n,...]; a nil/empty slice becomes []
+// so the field is always an array, never null, on the wire.
+func (d DibitArray) MarshalJSON() ([]byte, error) {
+	if len(d) == 0 {
+		return []byte("[]"), nil
+	}
+	buf := make([]byte, 0, len(d)*3+1)
+	buf = append(buf, '[')
+	for i, v := range d {
+		if i > 0 {
+			buf = append(buf, ',')
+		}
+		buf = strconv.AppendUint(buf, uint64(v), 10)
+	}
+	buf = append(buf, ']')
+	return buf, nil
+}
 
 // SymbolFrame is the wire shape of one batch of recovered symbols for
 // the web "Symbol" scope. It mirrors symbolscope.Frame so the api
@@ -33,11 +59,11 @@ type SymbolFrame struct {
 	// EyeSoft is a bounded window of oversampled, AGC-scaled matched-
 	// filter output (EyeSPS samples per symbol) for the C4FM eye diagram;
 	// empty on CQPSK. Fold it over EyeSPS to render the 4-level eye.
-	EyeSoft []float32 `json:"eye_soft"`
-	EyeSPS  int       `json:"eye_sps"`
-	Dibits  []uint8   `json:"dibits"`
-	IsBits  bool      `json:"is_bits"`
-	BaseIdx int       `json:"base_idx"`
+	EyeSoft []float32  `json:"eye_soft"`
+	EyeSPS  int        `json:"eye_sps"`
+	Dibits  DibitArray `json:"dibits"`
+	IsBits  bool       `json:"is_bits"`
+	BaseIdx int        `json:"base_idx"`
 
 	// Receiver-state metrics for the Tuning panel (see symbolscope.Frame).
 	CarrierOffsetHz float64 `json:"carrier_offset_hz"`

--- a/internal/api/symbols_test.go
+++ b/internal/api/symbols_test.go
@@ -107,14 +107,14 @@ func TestSymbolStreamDeliversFrames(t *testing.T) {
 				Soft:         []float32{0.9, -0.3, -0.95, 0.31},
 				SymI:         []float32{0.7, -0.7, -0.7, 0.7},
 				SymQ:         []float32{0.7, 0.7, -0.7, -0.7},
-				Dibits:       []uint8{1, 0, 3, 2},
+				Dibits:       DibitArray{1, 0, 3, 2},
 				BaseIdx:      0,
 			},
 			{
 				TimestampNs:  2,
 				SymbolRateHz: 4800,
 				CenterHz:     851_012_500,
-				Dibits:       []uint8{2, 2},
+				Dibits:       DibitArray{2, 2},
 				BaseIdx:      4,
 			},
 		},
@@ -144,6 +144,31 @@ func TestSymbolStreamDeliversFrames(t *testing.T) {
 		}
 		if i == 0 && len(f.Dibits) != 4 {
 			t.Errorf("frame #%d dibits len = %d, want 4", i, len(f.Dibits))
+		}
+		// Regression guard for the "waiting for symbols" bug: dibits must be
+		// a JSON *number array* on the wire, not Go's default base64 string
+		// for []byte/[]uint8 — the web client drops any frame whose dibits
+		// isn't an array (Array.isArray). Inspect the raw JSON, not the
+		// re-unmarshalled struct (Go unmarshal would accept either form).
+		var raw map[string]json.RawMessage
+		if err := json.Unmarshal(msg, &raw); err != nil {
+			t.Fatalf("raw unmarshal #%d: %v", i, err)
+		}
+		if got := string(raw["dibits"]); len(got) == 0 || got[0] != '[' {
+			t.Errorf("frame #%d dibits wire form = %s, want a JSON array", i, got)
+		}
+		if i == 0 {
+			var dibits []int
+			if err := json.Unmarshal(raw["dibits"], &dibits); err != nil {
+				t.Fatalf("dibits not an int array: %v (raw=%s)", err, raw["dibits"])
+			}
+			want := []int{1, 0, 3, 2}
+			for k, v := range want {
+				if dibits[k] != v {
+					t.Errorf("dibits = %v, want %v", dibits, want)
+					break
+				}
+			}
 		}
 		if i == 0 {
 			if len(f.SymI) != 4 || len(f.SymQ) != 4 {


### PR DESCRIPTION
The WS /api/v1/diag/symbols frame encoded its `dibits` field as a Go
[]uint8. encoding/json special-cases []uint8/[]byte and marshals it as a
base64 string, so frames went out as "dibits":"AQAD..." instead of
[1,0,3,2]. The web client types dibits as number[] and gates every frame
on Array.isArray(frame.dibits); a base64 string fails that check, so all
frames were silently dropped. The Constellation panel (and the Symbol
scope, Eye, Tuning, and Histogram panels, which share the same stream)
therefore stayed on "waiting for symbols" forever while the socket showed
"live".

Add an api.DibitArray type whose MarshalJSON emits a JSON number array
(nil/empty -> []), keeping []uint8 semantics everywhere else; the
receiver/symbolscope dibit sinks are unchanged. Unmarshal still uses the
default []uint8 path, which accepts a number array, so round-trips hold.

The existing Go test missed this because it re-unmarshalled the message
into a struct (base64 <-> []uint8 round-trips cleanly); add a regression
assertion that inspects the raw JSON and requires dibits to be an array.