### PR TITLE
Constellation/Symbol scope: auto-detect demod mode + channel-step nudge (#557)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ for tagged releases.
 
 ## [Unreleased]
 
+### Added
+
+- **Constellation / Symbol scope auto-detect the demod mode** (#557). The
+  panels' **Mode** selector gains an **Auto** option (now the default) that
+  follows the modulation the selected SDR's system is configured to decode —
+  C4FM or CQPSK/LSM — instead of asking the operator to pick it. The daemon
+  reports this per device on `GET /api/v1/spectrum/devices` as `p25_modulation`,
+  resolved by matching the device's tuning against the configured P25 Phase 1
+  systems (with a single-system fallback). An explicit C4FM/CQPSK choice still
+  overrides Auto and persists.
+- **Channel-step nudge in the shared tuning controls** (#557). The
+  Constellation and Symbol scope offset field gains a **Step** selector
+  (6.25 / 12.5 / 25 kHz) with −/+ buttons and ArrowUp/ArrowDown stepping that
+  snap to the channel grid, so walking between adjacent channels no longer
+  needs manual kHz entry. The chosen step is shared across panels.
+
 ### Fixed
 
 - **Constellation / signal scopes stuck on "waiting for symbols"** (#557,

--- a/cmd/gophertrunk/capture_provider.go
+++ b/cmd/gophertrunk/capture_provider.go
@@ -28,7 +28,9 @@ type captureProvider struct {
 }
 
 func newCaptureProvider(pool *sdr.Pool, brokers map[string]*iqtap.Broker, log *slog.Logger) *captureProvider {
-	return &captureProvider{sp: newSpectrumProvider(pool, brokers, log), brokers: brokers}
+	// The capture picker doesn't use per-device modulation, so it omits
+	// the systems list (P25Modulation stays empty on its device list).
+	return &captureProvider{sp: newSpectrumProvider(pool, brokers, nil, log), brokers: brokers}
 }
 
 // Devices reuses the spectrum provider's broker walk.

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -1732,7 +1732,7 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 			TLSKey:         cfg.API.TLSKey,
 		}
 		if len(d.iqBrokers) > 0 {
-			opts.Spectrum = newSpectrumProvider(d.pool, d.iqBrokers, log)
+			opts.Spectrum = newSpectrumProvider(d.pool, d.iqBrokers, d.systems, log)
 			opts.Diag = newDiagProvider(d.pool, d.iqBrokers, cfg.SDR.SampleRate, log)
 			opts.Symbols = newSymbolProvider(d.pool, d.iqBrokers, cfg.SDR.SampleRate, log)
 			opts.Capture = newCaptureProvider(d.pool, d.iqBrokers, log)

--- a/cmd/gophertrunk/spectrum_provider.go
+++ b/cmd/gophertrunk/spectrum_provider.go
@@ -8,8 +8,10 @@ import (
 
 	"github.com/MattCheramie/GopherTrunk/internal/api"
 	"github.com/MattCheramie/GopherTrunk/internal/dsp/spectrum"
+	p25phase1rx "github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase1/receiver"
 	"github.com/MattCheramie/GopherTrunk/internal/sdr"
 	"github.com/MattCheramie/GopherTrunk/internal/sdr/iqtap"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
 )
 
 // spectrumProvider implements api.SpectrumProvider on top of the
@@ -31,14 +33,18 @@ import (
 type spectrumProvider struct {
 	pool    *sdr.Pool
 	brokers map[string]*iqtap.Broker
+	// systems is the configured trunking systems, consulted to label
+	// each device with the P25 Phase 1 modulation it is decoding so the
+	// web panels can auto-select C4FM vs CQPSK.
+	systems []trunking.System
 	log     *slog.Logger
 }
 
-func newSpectrumProvider(pool *sdr.Pool, brokers map[string]*iqtap.Broker, log *slog.Logger) *spectrumProvider {
+func newSpectrumProvider(pool *sdr.Pool, brokers map[string]*iqtap.Broker, systems []trunking.System, log *slog.Logger) *spectrumProvider {
 	if log == nil {
 		log = slog.Default()
 	}
-	return &spectrumProvider{pool: pool, brokers: brokers, log: log}
+	return &spectrumProvider{pool: pool, brokers: brokers, systems: systems, log: log}
 }
 
 // Devices walks the broker map and reports each device's current
@@ -56,16 +62,66 @@ func (p *spectrumProvider) Devices() []api.SpectrumDevice {
 		if !ok {
 			continue
 		}
+		centerHz := br.CenterHz()
+		sampleRateHz := br.SampleRateHz()
 		out = append(out, api.SpectrumDevice{
-			Serial:       e.Info.Serial,
-			Driver:       e.Info.Driver,
-			Product:      e.Info.Product,
-			Role:         e.Role.String(),
-			CenterHz:     br.CenterHz(),
-			SampleRateHz: br.SampleRateHz(),
+			Serial:        e.Info.Serial,
+			Driver:        e.Info.Driver,
+			Product:       e.Info.Product,
+			Role:          e.Role.String(),
+			CenterHz:      centerHz,
+			SampleRateHz:  sampleRateHz,
+			P25Modulation: p25ModulationFor(p.systems, centerHz, sampleRateHz),
 		})
 	}
 	return out
+}
+
+// p25ModulationFor reports the P25 Phase 1 demod mode ("c4fm"/"cqpsk")
+// of the system the device at (centerHz, sampleRateHz) is decoding, or
+// "" when no P25 Phase 1 system applies. A system matches when one of
+// its control channels falls inside the device passband
+// (|cc - centre| <= sample_rate/2) — the control SDR's centre sits on a
+// CC exactly, and a voice SDR's wideband front end usually still spans
+// it. For P25 Phase 1 the voice channels share the control channel's
+// modulation, so one per-device value is correct for both the CC and any
+// followed voice call. When no CC matches but exactly one P25 Phase 1
+// system is configured (the common single-system deployment), fall back
+// to it.
+func p25ModulationFor(systems []trunking.System, centerHz, sampleRateHz uint32) string {
+	var only *trunking.System
+	count := 0
+	for i := range systems {
+		if systems[i].Protocol != trunking.ProtocolP25 {
+			continue
+		}
+		count++
+		only = &systems[i]
+		half := int64(sampleRateHz) / 2
+		for _, cc := range systems[i].ControlChannels {
+			delta := int64(cc) - int64(centerHz)
+			if delta < 0 {
+				delta = -delta
+			}
+			if delta <= half {
+				return demodModeName(systems[i].P25Phase1DemodMode)
+			}
+		}
+	}
+	if count == 1 {
+		return demodModeName(only.P25Phase1DemodMode)
+	}
+	return ""
+}
+
+// demodModeName canonicalises a configured demod-mode string to the
+// receiver's lowercase name ("c4fm"/"cqpsk"), reusing the same parser
+// the decode pipeline applies so the panel sees exactly what the
+// receiver runs. Unknown values fall back to C4FM (ParseDemodMode's
+// default), matching the receiver's behaviour.
+func demodModeName(cfg string) string {
+	mode, _ := p25phase1rx.ParseDemodMode(cfg)
+	return mode.String()
 }
 
 // Tune programs the named SDR's centre frequency. Routes through

--- a/cmd/gophertrunk/spectrum_provider_test.go
+++ b/cmd/gophertrunk/spectrum_provider_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/MattCheramie/GopherTrunk/internal/sdr"
 	"github.com/MattCheramie/GopherTrunk/internal/sdr/iqtap"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
 )
 
 // streamingFakeDevice loops a synthetic IQ pattern on the StreamIQ
@@ -222,5 +223,96 @@ func TestSpectrumProviderOpenStreamBadFFTSize(t *testing.T) {
 	}
 	if !errors.Is(err, err) { // sanity placeholder
 		t.Fail()
+	}
+}
+
+// TestP25ModulationFor covers the per-device modulation resolution that
+// lets the web symbol/constellation panels auto-select C4FM vs CQPSK.
+func TestP25ModulationFor(t *testing.T) {
+	c4fm := trunking.System{
+		Name:               "C4FM-sys",
+		Protocol:           trunking.ProtocolP25,
+		ControlChannels:    []uint32{851_000_000},
+		P25Phase1DemodMode: "c4fm",
+	}
+	lsm := trunking.System{
+		Name:               "LSM-sys",
+		Protocol:           trunking.ProtocolP25,
+		ControlChannels:    []uint32{770_000_000},
+		P25Phase1DemodMode: "cqpsk",
+	}
+	dmr := trunking.System{
+		Name:            "DMR-sys",
+		Protocol:        trunking.ProtocolDMR,
+		ControlChannels: []uint32{451_000_000},
+	}
+
+	const sr = 2_048_000 // ±1.024 MHz passband
+
+	tests := []struct {
+		name       string
+		systems    []trunking.System
+		centerHz   uint32
+		sampleRate uint32
+		want       string
+	}{
+		{
+			name:       "control SDR parked on the C4FM control channel",
+			systems:    []trunking.System{c4fm, lsm},
+			centerHz:   851_000_000,
+			sampleRate: sr,
+			want:       "c4fm",
+		},
+		{
+			name:       "control SDR parked on the LSM control channel",
+			systems:    []trunking.System{c4fm, lsm},
+			centerHz:   770_000_000,
+			sampleRate: sr,
+			want:       "cqpsk",
+		},
+		{
+			name:       "voice channel inside the LSM passband matches by band",
+			systems:    []trunking.System{c4fm, lsm},
+			centerHz:   770_500_000, // 500 kHz off the CC, still < Nyquist
+			sampleRate: sr,
+			want:       "cqpsk",
+		},
+		{
+			name:       "single system falls back even when off-band",
+			systems:    []trunking.System{lsm},
+			centerHz:   900_000_000,
+			sampleRate: sr,
+			want:       "cqpsk",
+		},
+		{
+			name:       "multiple systems, none in band, is unknown",
+			systems:    []trunking.System{c4fm, lsm},
+			centerHz:   900_000_000,
+			sampleRate: sr,
+			want:       "",
+		},
+		{
+			name:       "no P25 systems configured is unknown",
+			systems:    []trunking.System{dmr},
+			centerHz:   451_000_000,
+			sampleRate: sr,
+			want:       "",
+		},
+		{
+			name:       "empty config mode normalises to c4fm",
+			systems:    []trunking.System{{Name: "S", Protocol: trunking.ProtocolP25, ControlChannels: []uint32{851_000_000}}},
+			centerHz:   851_000_000,
+			sampleRate: sr,
+			want:       "c4fm",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := p25ModulationFor(tc.systems, tc.centerHz, tc.sampleRate)
+			if got != tc.want {
+				t.Fatalf("p25ModulationFor() = %q, want %q", got, tc.want)
+			}
+		})
 	}
 }

--- a/internal/api/spectrum.go
+++ b/internal/api/spectrum.go
@@ -20,6 +20,13 @@ type SpectrumDevice struct {
 	Role         string `json:"role"`
 	CenterHz     uint32 `json:"center_hz"`
 	SampleRateHz uint32 `json:"sample_rate_hz"`
+	// P25Modulation is the configured P25 Phase 1 demod mode of the
+	// system this SDR is decoding ("c4fm" or "cqpsk"), resolved by
+	// matching the device's tuning against the configured systems. Lets
+	// the web symbol/constellation panels auto-select the right mode
+	// instead of asking the operator to pick it. Empty when no P25
+	// Phase 1 system matches (e.g. a DMR-only device).
+	P25Modulation string `json:"p25_modulation,omitempty"`
 }
 
 // SpectrumFrame is the wire shape of one frame on the WS stream.

--- a/web/src/api/spectrum.ts
+++ b/web/src/api/spectrum.ts
@@ -12,6 +12,11 @@ export interface SpectrumDevice {
   role: string;
   center_hz: number;
   sample_rate_hz: number;
+  // Configured P25 Phase 1 demod mode of the system this SDR is
+  // decoding ("c4fm" | "cqpsk"), or absent when no P25 Phase 1 system
+  // applies. The symbol/constellation panels' "Auto" mode reads this to
+  // pick the receiver without operator input.
+  p25_modulation?: string;
 }
 
 export interface SpectrumFrame {

--- a/web/src/api/symbols.ts
+++ b/web/src/api/symbols.ts
@@ -40,6 +40,23 @@ export interface SymbolFrame {
   cma_error: number;
 }
 
+// Map a device's reported P25 demod mode (from SpectrumDevice
+// .p25_modulation — the daemon's canonical "c4fm"/"cqpsk", with the
+// other ParseDemodMode spellings tolerated) to the symbol-stream proto
+// selector. Unknown / empty falls back to C4FM, matching the receiver's
+// default. Used by the panels' "Auto" mode to pick the receiver from the
+// system the SDR is actually decoding.
+export function demodModeToProto(mod: string | undefined | null): string {
+  switch ((mod ?? "").toLowerCase()) {
+    case "cqpsk":
+    case "lsm":
+    case "linear":
+      return "p25-cqpsk";
+    default:
+      return "p25-c4fm";
+  }
+}
+
 export type SymbolFrameHandler = (f: SymbolFrame) => void;
 export type StatusHandler = (s: "connecting" | "open" | "closed") => void;
 

--- a/web/src/components/TuningControls.test.tsx
+++ b/web/src/components/TuningControls.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { TuningControls } from "./TuningControls";
 
@@ -23,6 +23,12 @@ function setup(overrides: Partial<Parameters<typeof TuningControls>[0]> = {}) {
 }
 
 describe("TuningControls", () => {
+  beforeEach(() => {
+    // The channel-step selector persists to localStorage; clear it so the
+    // default (12.5 kHz) is in effect for each case.
+    window.localStorage.clear();
+  });
+
   it("accepts a fine kHz offset like 12.5 (channel-grid step)", () => {
     const { onOffsetChange } = setup();
     const input = screen.getByLabelText(
@@ -56,5 +62,46 @@ describe("TuningControls", () => {
     const { onCentre } = setup({ offsetKHz: 12.5 });
     fireEvent.click(screen.getByRole("button", { name: "Centre" }));
     expect(onCentre).toHaveBeenCalled();
+  });
+
+  it("nudges the offset by the selected channel step", () => {
+    const { onOffsetChange } = setup({ offsetKHz: 0 });
+    // Default step is 12.5 kHz.
+    fireEvent.click(
+      screen.getByRole("button", { name: "Step offset up by 12.5 kHz" }),
+    );
+    expect(onOffsetChange).toHaveBeenCalledWith(12.5);
+  });
+
+  it("snaps an off-grid offset to the grid when stepping down", () => {
+    // From 13.1 kHz a down-step on the 12.5 grid snaps to 0
+    // (round(13.1/12.5)=1, then -1 → 0).
+    const { onOffsetChange } = setup({ offsetKHz: 13.1 });
+    fireEvent.click(
+      screen.getByRole("button", { name: "Step offset down by 12.5 kHz" }),
+    );
+    expect(onOffsetChange).toHaveBeenCalledWith(0);
+  });
+
+  it("steps by the chosen grid when the step selector changes", () => {
+    const { onOffsetChange } = setup({ offsetKHz: 0 });
+    fireEvent.change(screen.getByLabelText("Channel step size, kHz"), {
+      target: { value: "6.25" },
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: "Step offset up by 6.25 kHz" }),
+    );
+    expect(onOffsetChange).toHaveBeenCalledWith(6.25);
+  });
+
+  it("walks the grid with ArrowUp/ArrowDown on the offset field", () => {
+    const { onOffsetChange } = setup({ offsetKHz: 0 });
+    const input = screen.getByLabelText(
+      "View offset from SDR centre in kHz (numeric)",
+    );
+    fireEvent.keyDown(input, { key: "ArrowUp" });
+    expect(onOffsetChange).toHaveBeenLastCalledWith(12.5);
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    expect(onOffsetChange).toHaveBeenLastCalledWith(-12.5);
   });
 });

--- a/web/src/components/TuningControls.tsx
+++ b/web/src/components/TuningControls.tsx
@@ -12,8 +12,19 @@
 //     sync.
 //
 // The slider is for coarse dragging; the numeric fields are the precise
-// path. Editing any control pins the view (Hold on) via onOffsetChange —
-// the caller owns that side effect.
+// path. For walking the channel grid there's a Step selector (6.25 /
+// 12.5 / 25 kHz) with −/+ buttons and ArrowUp/ArrowDown on the offset
+// field: each nudge snaps to the nearest grid point then steps, so it
+// lands on the grid even when starting off it (e.g. after following a
+// call). The chosen step is shared across panels via prefs.
+//
+// Editing any control pins the view (Hold on) via onOffsetChange — the
+// caller owns that side effect.
+
+import { useState } from "react";
+import { prefs } from "../store/prefs";
+
+const STEP_CHOICES = [6.25, 12.5, 25] as const;
 
 interface TuningControlsProps {
   // SDR centre in Hz, or null until the device is known. Gates the MHz
@@ -52,6 +63,19 @@ export function TuningControls({
 }: TuningControlsProps) {
   const freqMHz = centerHz != null ? (centerHz + offsetKHz * 1000) / 1e6 : null;
 
+  const [stepKHz, setStepKHz] = useState<number>(() =>
+    prefs.tuningControlsStepKHz(),
+  );
+
+  // Snap to the nearest grid point, step one grid cell in `dir`, clamp to
+  // the Nyquist bound, then commit (the parent pins Hold). Snapping first
+  // means a nudge lands on the channel grid even from an off-grid offset.
+  const nudge = (dir: -1 | 1) => {
+    const stepped = (Math.round(offsetKHz / stepKHz) + dir) * stepKHz;
+    const clamped = Math.max(-maxOffsetKHz, Math.min(maxOffsetKHz, stepped));
+    onOffsetChange(trim(clamped, 3));
+  };
+
   return (
     <>
       <label className="flex items-center gap-2">
@@ -66,15 +90,62 @@ export function TuningControls({
           className="w-40 accent-sky-400"
           aria-label="View offset from SDR centre, kHz"
         />
+        <button
+          type="button"
+          className="rounded border border-border px-2 py-1 font-mono hover:bg-surface"
+          onClick={() => nudge(-1)}
+          title={`Step down ${stepKHz} kHz`}
+          aria-label={`Step offset down by ${stepKHz} kHz`}
+        >
+          −
+        </button>
         <input
           type="number"
           step={0.001}
           value={trim(offsetKHz, 3)}
           onChange={(e) => onOffsetChange(Number(e.target.value))}
+          onKeyDown={(e) => {
+            // Arrow keys walk the channel grid (snap-then-step) rather
+            // than the input's native 1 Hz step, while typing still
+            // allows fine values.
+            if (e.key === "ArrowUp") {
+              e.preventDefault();
+              nudge(1);
+            } else if (e.key === "ArrowDown") {
+              e.preventDefault();
+              nudge(-1);
+            }
+          }}
           className="w-24 bg-surface border border-border rounded px-2 py-1 text-right font-mono"
           aria-label="View offset from SDR centre in kHz (numeric)"
         />
+        <button
+          type="button"
+          className="rounded border border-border px-2 py-1 font-mono hover:bg-surface"
+          onClick={() => nudge(1)}
+          title={`Step up ${stepKHz} kHz`}
+          aria-label={`Step offset up by ${stepKHz} kHz`}
+        >
+          +
+        </button>
         <span className="text-muted">kHz</span>
+        <select
+          className="bg-surface border border-border rounded px-1 py-1 font-mono"
+          value={stepKHz}
+          onChange={(e) => {
+            const next = Number(e.target.value);
+            setStepKHz(next);
+            prefs.setTuningControlsStepKHz(next);
+          }}
+          aria-label="Channel step size, kHz"
+          title="Channel grid for the ± / arrow-key nudge"
+        >
+          {STEP_CHOICES.map((s) => (
+            <option key={s} value={s}>
+              {s}
+            </option>
+          ))}
+        </select>
       </label>
 
       <label className="flex items-center gap-2">

--- a/web/src/panels/Constellation.test.tsx
+++ b/web/src/panels/Constellation.test.tsx
@@ -9,9 +9,10 @@ vi.mock("../api/diag", () => ({
   openIQStream: vi.fn(),
 }));
 
-vi.mock("../api/symbols", () => ({
-  openSymbolStream: vi.fn(),
-}));
+vi.mock("../api/symbols", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../api/symbols")>();
+  return { ...actual, openSymbolStream: vi.fn() };
+});
 
 import { fetchSpectrumDevices } from "../api/spectrum";
 import { openIQStream } from "../api/diag";
@@ -79,6 +80,21 @@ describe("Constellation panel", () => {
     expect(callArgs?.proto).toBeTruthy();
     // The raw IQ stream stays closed until the operator switches View.
     expect(openIQStream).not.toHaveBeenCalled();
+  });
+
+  it("auto-selects CQPSK from the device's reported modulation", async () => {
+    vi.mocked(fetchSpectrumDevices).mockResolvedValue([
+      { ...ONE_DEVICE[0], p25_modulation: "cqpsk" },
+    ] as never);
+
+    render(<Constellation />);
+    await waitFor(() => {
+      expect(openSymbolStream).toHaveBeenCalled();
+    });
+    // Default Mode is Auto; it follows the device's reported modulation.
+    expect(vi.mocked(openSymbolStream).mock.calls.at(-1)?.[1]?.proto).toBe(
+      "p25-cqpsk",
+    );
   });
 
   it("switches to the vector scope and opens a raw IQ stream", async () => {

--- a/web/src/panels/Constellation.tsx
+++ b/web/src/panels/Constellation.tsx
@@ -8,7 +8,11 @@ import {
   type IQFrame,
   type IQPoint,
 } from "../api/diag";
-import { openSymbolStream, type SymbolFrame } from "../api/symbols";
+import {
+  demodModeToProto,
+  openSymbolStream,
+  type SymbolFrame,
+} from "../api/symbols";
 import { selectClientConfig, useShared } from "../store/shared";
 import { prefs } from "../store/prefs";
 import { TuningControls } from "../components/TuningControls";
@@ -47,6 +51,7 @@ const TARGET_RATE_SPS = 2000;
 type View = "symbols" | "raw";
 
 const PROTOS: { value: string; label: string }[] = [
+  { value: "auto", label: "Auto" },
   { value: "p25-cqpsk", label: "P25 CQPSK" },
   { value: "p25-c4fm", label: "P25 C4FM" },
 ];
@@ -134,13 +139,28 @@ export function Constellation() {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const bufferRef = useRef<IQPoint[]>([]);
   const scaleRef = useRef<number>(1);
+
+  const device = useMemo(
+    () => devices.find((d) => d.serial === selected) ?? null,
+    [devices, selected],
+  );
+
+  // Resolve the Mode selection to a concrete receiver. "auto" follows the
+  // modulation the selected SDR's system is decoding (device.p25_modulation),
+  // falling back to C4FM when unknown; an explicit choice is used as-is.
+  // The symbol stream and ideal-cluster markers both key off this.
+  const effectiveProto = useMemo(
+    () => (proto === "auto" ? demodModeToProto(device?.p25_modulation) : proto),
+    [proto, device],
+  );
+
   // Ideal cluster markers depend on the active source: clusters on the
   // diagonals for CQPSK symbols, levels on the real axis for C4FM
   // symbols, none for the raw vector scope.
   const markers = useMemo<IQPoint[]>(() => {
     if (view !== "symbols") return [];
-    return proto === "p25-c4fm" ? C4FM_MARKERS : CQPSK_MARKERS;
-  }, [view, proto]);
+    return effectiveProto === "p25-c4fm" ? C4FM_MARKERS : CQPSK_MARKERS;
+  }, [view, effectiveProto]);
   const optsRef = useRef<RenderOpts>({
     dcBlock,
     autoScale,
@@ -211,11 +231,6 @@ export function Constellation() {
       cancel = true;
     };
   }, [cfg, selected]);
-
-  const device = useMemo(
-    () => devices.find((d) => d.serial === selected) ?? null,
-    [devices, selected],
-  );
 
   // Newest active call on the selected SDR, and the view offset (kHz)
   // that would centre it. This is the "last locked channel" the issue
@@ -313,7 +328,7 @@ export function Constellation() {
 
     const stream = openSymbolStream(cfg, {
       serial: selected,
-      proto,
+      proto: effectiveProto,
       offset: Math.round(clampedOffsetKHz * 1000),
       onFrame: (f) => {
         setSymLatest(f);
@@ -329,7 +344,7 @@ export function Constellation() {
       onStatus: setConn,
     });
     return () => stream.close();
-  }, [cfg, selected, view, proto, clampedOffsetKHz]);
+  }, [cfg, selected, view, effectiveProto, clampedOffsetKHz]);
 
   // Prefer the device centre so the frequency view shows before the first
   // frame; fall back to the frame's stamped centre.
@@ -415,6 +430,11 @@ export function Constellation() {
                 </option>
               ))}
             </select>
+            {proto === "auto" && (
+              <span className="text-muted">
+                ·&nbsp;{effectiveProto === "p25-c4fm" ? "C4FM" : "CQPSK"}
+              </span>
+            )}
           </label>
         )}
 
@@ -488,7 +508,7 @@ export function Constellation() {
 
       <div className="text-[11px] text-muted">
         {view === "symbols" ? (
-          proto === "p25-c4fm" ? (
+          effectiveProto === "p25-c4fm" ? (
             <>
               Plots the receiver's recovered C4FM symbols. C4FM has no
               complex constellation, so its four soft levels appear on the

--- a/web/src/panels/Plots.test.tsx
+++ b/web/src/panels/Plots.test.tsx
@@ -6,9 +6,10 @@ vi.mock("../api/spectrum", () => ({
   fetchSpectrumDevices: vi.fn(),
 }));
 
-vi.mock("../api/symbols", () => ({
-  openSymbolStream: vi.fn(),
-}));
+vi.mock("../api/symbols", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../api/symbols")>();
+  return { ...actual, openSymbolStream: vi.fn() };
+});
 
 vi.mock("../api/diag", () => ({
   openIQStream: vi.fn(),

--- a/web/src/panels/SymbolScope.test.tsx
+++ b/web/src/panels/SymbolScope.test.tsx
@@ -5,9 +5,10 @@ vi.mock("../api/spectrum", () => ({
   fetchSpectrumDevices: vi.fn(),
 }));
 
-vi.mock("../api/symbols", () => ({
-  openSymbolStream: vi.fn(),
-}));
+vi.mock("../api/symbols", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../api/symbols")>();
+  return { ...actual, openSymbolStream: vi.fn() };
+});
 
 import { fetchSpectrumDevices } from "../api/spectrum";
 import { openSymbolStream } from "../api/symbols";
@@ -69,7 +70,24 @@ describe("Symbol scope panel", () => {
     });
     const callArgs = vi.mocked(openSymbolStream).mock.calls.at(-1)?.[1];
     expect(callArgs?.serial).toBe("rtl-1");
+    // Default Mode is Auto; with no reported modulation it resolves to C4FM.
     expect(callArgs?.proto).toBe("p25-c4fm");
+  });
+
+  it("auto-selects CQPSK when the device reports an LSM system", async () => {
+    vi.mocked(fetchSpectrumDevices).mockResolvedValue([
+      { ...oneDevice[0], p25_modulation: "cqpsk" },
+    ]);
+    vi.mocked(openSymbolStream).mockReturnValue({ close: vi.fn() });
+
+    render(<SymbolScope />);
+    await waitFor(() => {
+      expect(openSymbolStream).toHaveBeenCalled();
+    });
+    // Auto (default) follows the device's reported modulation.
+    expect(vi.mocked(openSymbolStream).mock.calls.at(-1)?.[1]?.proto).toBe(
+      "p25-cqpsk",
+    );
   });
 
   it("shows the live status pill when the WS reports open", async () => {

--- a/web/src/panels/SymbolScope.tsx
+++ b/web/src/panels/SymbolScope.tsx
@@ -3,7 +3,11 @@ import {
   fetchSpectrumDevices,
   type SpectrumDevice,
 } from "../api/spectrum";
-import { openSymbolStream, type SymbolFrame } from "../api/symbols";
+import {
+  demodModeToProto,
+  openSymbolStream,
+  type SymbolFrame,
+} from "../api/symbols";
 import { selectClientConfig, useShared } from "../store/shared";
 import { prefs } from "../store/prefs";
 import { SymbolScopeChart } from "../components/SymbolScopeChart";
@@ -23,9 +27,10 @@ import { TuningControls } from "../components/TuningControls";
 
 const WINDOW_SYMBOLS = 2400; // rolling scope width
 
-const PROTOS: { value: string; label: string; soft: boolean }[] = [
-  { value: "p25-c4fm", label: "P25 C4FM", soft: true },
-  { value: "p25-cqpsk", label: "P25 CQPSK", soft: false },
+const PROTOS: { value: string; label: string }[] = [
+  { value: "auto", label: "Auto" },
+  { value: "p25-c4fm", label: "P25 C4FM" },
+  { value: "p25-cqpsk", label: "P25 CQPSK" },
 ];
 
 type ConnState = "connecting" | "open" | "closed";
@@ -79,6 +84,14 @@ export function SymbolScope() {
     [devices, selected],
   );
 
+  // Resolve the Mode selection: "auto" follows the modulation the
+  // selected SDR's system is decoding (device.p25_modulation, C4FM when
+  // unknown); an explicit choice is used verbatim.
+  const effectiveProto = useMemo(
+    () => (proto === "auto" ? demodModeToProto(device?.p25_modulation) : proto),
+    [proto, device],
+  );
+
   // Newest active call on the selected SDR → the offset (kHz) that
   // centres it. Followed live when Hold is off.
   const followOffsetKHz = useMemo(() => {
@@ -126,7 +139,7 @@ export function SymbolScope() {
 
     const stream = openSymbolStream(cfg, {
       serial: selected,
-      proto,
+      proto: effectiveProto,
       offset: Math.round(clampedOffsetKHz * 1000),
       onFrame: (f) => {
         setLatest(f);
@@ -144,7 +157,7 @@ export function SymbolScope() {
       onStatus: setConn,
     });
     return () => stream.close();
-  }, [cfg, selected, proto, clampedOffsetKHz]);
+  }, [cfg, selected, effectiveProto, clampedOffsetKHz]);
 
   // Centre comes from the selected device so the frequency view renders
   // immediately — symbol frames only arrive once the receiver decodes, so
@@ -208,6 +221,11 @@ export function SymbolScope() {
               </option>
             ))}
           </select>
+          {proto === "auto" && (
+            <span className="text-muted">
+              ·&nbsp;{effectiveProto === "p25-c4fm" ? "C4FM" : "CQPSK"}
+            </span>
+          )}
         </label>
 
         <TuningControls

--- a/web/src/store/prefs.ts
+++ b/web/src/store/prefs.ts
@@ -25,6 +25,9 @@ const LS_KEYS = {
   symbolScopeOffsetKHz: "gt.symbolScope.offsetKHz",
   symbolScopeHold: "gt.symbolScope.hold",
   symbolScopeProto: "gt.symbolScope.proto",
+  // Channel-step grid for the shared TuningControls ±/arrow-key nudge,
+  // shared across every panel that embeds it.
+  tuningControlsStepKHz: "gt.tuningControls.stepKHz",
   eyeOffsetKHz: "gt.eye.offsetKHz",
   eyeHold: "gt.eye.hold",
   tuningOffsetKHz: "gt.tuning.offsetKHz",
@@ -199,9 +202,11 @@ export const prefs = {
   setConstellationView(v: "symbols" | "raw") {
     writeLS(LS_KEYS.constellationView, v);
   },
-  // Receiver selector for the symbols view ("p25-c4fm" / "p25-cqpsk").
+  // Receiver selector for the symbols view: "auto" (default — follow the
+  // modulation the selected SDR's system is decoding), or an explicit
+  // "p25-c4fm" / "p25-cqpsk" override.
   constellationProto(): string {
-    return readLS(LS_KEYS.constellationProto) ?? "p25-cqpsk";
+    return readLS(LS_KEYS.constellationProto) ?? "auto";
   },
   setConstellationProto(p: string) {
     writeLS(LS_KEYS.constellationProto, p);
@@ -225,11 +230,24 @@ export const prefs = {
   setSymbolScopeHold(on: boolean) {
     writeLS(LS_KEYS.symbolScopeHold, on ? "1" : "0");
   },
+  // "auto" (default — follow the SDR's decoded modulation) or an
+  // explicit "p25-c4fm" / "p25-cqpsk" override.
   symbolScopeProto(): string {
-    return readLS(LS_KEYS.symbolScopeProto) ?? "p25-c4fm";
+    return readLS(LS_KEYS.symbolScopeProto) ?? "auto";
   },
   setSymbolScopeProto(p: string) {
     writeLS(LS_KEYS.symbolScopeProto, p);
+  },
+
+  // Channel-step grid (kHz) for the shared TuningControls ± / arrow-key
+  // nudge. Constrained to the common P25 grids; defaults to 12.5 kHz.
+  tuningControlsStepKHz(): number {
+    const raw = readLS(LS_KEYS.tuningControlsStepKHz);
+    const n = raw === null ? NaN : Number(raw);
+    return n === 6.25 || n === 12.5 || n === 25 ? n : 12.5;
+  },
+  setTuningControlsStepKHz(khz: number) {
+    writeLS(LS_KEYS.tuningControlsStepKHz, String(khz));
   },
 
   // Eye-diagram panel view options (C4FM datascope). Same offset/Hold


### PR DESCRIPTION
Follow-ups from issue #557. Two operator-facing improvements to the signal scopes.

## Auto-detect demod mode

The Constellation and Symbol scope **Mode** selector gains an **Auto** option (now the default) that follows the modulation the selected SDR's system is configured to decode — C4FM vs CQPSK/LSM — instead of asking the operator to pick it.

- The daemon resolves this per device and reports it on `GET /api/v1/spectrum/devices` as `p25_modulation`, by matching the device's tuning against the configured P25 Phase 1 systems' control channels (`|cc - centre| <= sample_rate/2`), with a single-system fallback. It reuses the receiver's own `ParseDemodMode`, so the panel sees exactly the mode the decoder runs.
- For P25 Phase 1 the voice channels share the control channel's modulation, so one per-device value is correct for both the CC-at-centre view and any followed voice call.
- The frontend maps `p25_modulation` to the receiver **before** connecting, so the symbol WS endpoint is unchanged. An explicit C4FM/CQPSK choice still overrides Auto and persists; the resolved mode is shown beside the selector ("· C4FM" / "· CQPSK").

## Channel-step nudge

The shared `TuningControls` offset field gains a **Step** selector (6.25 / 12.5 / 25 kHz) with −/+ buttons and ArrowUp/ArrowDown stepping that snap to the channel grid, so walking between adjacent channels no longer needs manual kHz entry. Fine 1 Hz typing still works; the chosen step is shared across panels via prefs.

## Scope note

This surfaces the **configured** modulation (`System.P25Phase1DemodMode`), not over-the-air signal detection — runtime auto-learning of C4FM vs LSM would be a much larger effort and is out of scope. Multi-system deployments where a voice SDR can't be matched to a control channel fall back to C4FM under Auto; the operator can still override.

## Tests

- **Backend:** `p25ModulationFor` table test — control-channel match, in-band voice channel, single-system fallback, multi-system/no-match → unknown, no-P25 → unknown, empty-mode normalisation.
- **Frontend:** auto-select-from-device on both panels; channel-step nudge (snap-to-grid up/down), step-selector change, and ArrowUp/ArrowDown grid stepping. Three `vi.mock("../api/symbols")` factories updated to keep the real `demodModeToProto` via `importOriginal`.
- `go build ./...`, `go vet`, `go test ./cmd/gophertrunk ./internal/api`; `tsc --noEmit`, `npm run build`, `npm run test` (158 passed).

https://claude.ai/code/session_01GfmsQTVscYv9i1uTrUka7E

---
_Generated by [Claude Code](https://claude.ai/code/session_01GfmsQTVscYv9i1uTrUka7E)_