### PR TITLE
p25/phase1: add RS outer FEC to Link Control + Encryption Sync

### DIFF
--- a/docs/voice-calibration.md
+++ b/docs/voice-calibration.md
@@ -122,6 +122,24 @@ gain knob — check the spectral envelope decoder
 ([`internal/voice/mbe/synth.go`](../internal/voice/mbe/synth.go))
 and the prediction-residual gain path.
 
+## Reading P25 Phase 1 decode quality
+
+Each P25 voice chain logs a rolling `composer: p25p1 decode quality`
+line. Beyond `corrected_bit_errs` (IMBE FEC) it now reports the outer
+Reed-Solomon health of the signalling words:
+
+- `lc_rs_uncorrectable` — LDU1 Link Control words the RS(24,12,13) layer
+  could not recover. The talkgroup is read from the LC, so a high count
+  means talkgroups can't be trusted and the recorder's talkgroup gating
+  may drop or split audio.
+- `ess_rs_uncorrectable` — LDU2 Encryption Sync words the RS(24,16,9)
+  layer could not recover (would otherwise surface garbage algorithm IDs).
+
+Both rising together is the FEC-layer signature of marginal RF: raise or
+lower the voice SDR gain and re-check. Note some SDRs (e.g. UHD/SoapyRemote
+front-ends) reject `set_rx_agc` — the daemon logs `disable agc not
+applied` and the gain must then be set manually rather than relying on AGC.
+
 ## Knox / call-alert tones
 
 If your captured call contains AMBE+2 knox tones (b1 ∈ [144, 163]),

--- a/internal/radio/framing/rs_gf64.go
+++ b/internal/radio/framing/rs_gf64.go
@@ -1,5 +1,7 @@
 package framing
 
+import "errors"
+
 // Reed-Solomon codes over GF(2^6) per TIA-102.BAAA-A §5.9 — the
 // three shortened RS codes Project 25 uses for voice information
 // and link control protection, which P25 Phase 2 also reuses on
@@ -27,11 +29,14 @@ package framing
 //	                 |    |    |    |     | Phase 2 FACCH outer FEC
 //	RS(36, 20, 17)   | 20 | 36 | 17 | 8   | Header Data Unit (HDU)
 //
-// This pass implements encoder + syndrome verifier for all three
-// codes. Single-symbol error correction via Berlekamp-Massey +
-// Chien + Forney is a future follow-up — verification alone tells
-// the higher layer whether the inner trellis/Golay correction was
-// successful, which is the primary use of the outer RS layer.
+// This file implements the encoder, syndrome verifier, AND a
+// bounded-distance error corrector (Berlekamp-Massey for the error
+// locator, Chien search for the error positions, Forney for the error
+// magnitudes) for all three codes. The corrector cleans up the residual
+// symbol errors the inner Hamming/Golay/trellis layer leaves behind —
+// notably the P25 Link Control talkgroup and Encryption Sync algorithm
+// fields, whose inner-only decode is otherwise corrupted under marginal
+// SNR.
 
 // rsGF64 is the singleton GF(2^6) field. Built at init time.
 var rsGF64 *rsField64
@@ -245,17 +250,252 @@ func verifyRSGF64(cw []byte, n, r int) bool {
 			return false
 		}
 	}
-	// Syndromes s_j = c(α^j) for j = 1..r. The spec defines
-	// g(x) = (x + α^1)(x + α^2)...(x + α^r), so roots start at α^1.
-	for j := 1; j <= r; j++ {
-		alphaJ := gf64Pow(j)
-		var s byte
-		for i := 0; i < n; i++ {
-			s = gf64Mul(s, alphaJ) ^ cw[i]
-		}
+	for _, s := range syndromesGF64(cw, n, r) {
 		if s != 0 {
 			return false
 		}
 	}
 	return true
+}
+
+// ErrRSUncorrectable is returned by the RS decoders when the received
+// codeword carries more symbol errors than the code can correct
+// (t = (n-k)/2), so the original information cannot be recovered. The
+// caller should treat the inner-decoded content as low-confidence.
+var ErrRSUncorrectable = errors.New("framing: Reed-Solomon codeword exceeds error-correction radius")
+
+// DecodeRS24_12 corrects up to t=6 symbol errors in a received
+// RS(24,12,13) codeword and returns the 12 recovered information
+// symbols, the number of symbol errors corrected, and ErrRSUncorrectable
+// when the codeword is beyond the correction radius. The codeword
+// convention matches EncodeRS24_12 / VerifyRS24_12 (roots α^1..α^12,
+// cw[0] highest degree). This protects P25 Link Control words.
+func DecodeRS24_12(cw []byte) ([12]byte, int, error) {
+	var info [12]byte
+	corrected, nErr, err := decodeRSGF64(cw, 24, 12)
+	if err != nil {
+		return info, 0, err
+	}
+	copy(info[:], corrected[:12])
+	return info, nErr, nil
+}
+
+// DecodeRS24_16 corrects up to t=4 symbol errors in a received
+// RS(24,16,9) codeword and returns the 16 recovered information symbols.
+// This protects P25 Encryption Sync words.
+func DecodeRS24_16(cw []byte) ([16]byte, int, error) {
+	var info [16]byte
+	corrected, nErr, err := decodeRSGF64(cw, 24, 16)
+	if err != nil {
+		return info, 0, err
+	}
+	copy(info[:], corrected[:16])
+	return info, nErr, nil
+}
+
+// DecodeRS36_20 corrects up to t=8 symbol errors in a received
+// RS(36,20,17) codeword and returns the 20 recovered information
+// symbols. This protects the P25 Header Data Unit.
+func DecodeRS36_20(cw []byte) ([20]byte, int, error) {
+	var info [20]byte
+	corrected, nErr, err := decodeRSGF64(cw, 36, 20)
+	if err != nil {
+		return info, 0, err
+	}
+	copy(info[:], corrected[:20])
+	return info, nErr, nil
+}
+
+// syndromesGF64 returns the r = n-k syndromes S_1..S_r of cw, where
+// S_j = c(α^j) evaluated by Horner from the leading coefficient (cw[0]
+// is the x^(n-1) term). The slice is indexed 0..r-1 holding S_1..S_r.
+func syndromesGF64(cw []byte, n, r int) []byte {
+	s := make([]byte, r)
+	for j := 1; j <= r; j++ {
+		alphaJ := gf64Pow(j)
+		var acc byte
+		for i := 0; i < n; i++ {
+			acc = gf64Mul(acc, alphaJ) ^ cw[i]
+		}
+		s[j-1] = acc
+	}
+	return s
+}
+
+// decodeRSGF64 performs bounded-distance decoding of a shortened RS code
+// over GF(2^6) with generator roots α^1..α^r (r = n-k). It returns the
+// corrected n-symbol codeword, the number of symbol errors corrected, and
+// ErrRSUncorrectable if the error count exceeds t = r/2. A defensive
+// re-syndrome after correction guarantees a returned codeword is always a
+// valid member of the code (so a >t error pattern fails cleanly rather
+// than silently miscorrecting).
+func decodeRSGF64(cw []byte, n, k int) ([]byte, int, error) {
+	if len(cw) != n {
+		return nil, 0, ErrRSUncorrectable
+	}
+	for _, s := range cw {
+		if s&^0x3F != 0 {
+			return nil, 0, ErrRSUncorrectable
+		}
+	}
+	r := n - k
+	t := r / 2
+	synd := syndromesGF64(cw, n, r)
+
+	allZero := true
+	for _, s := range synd {
+		if s != 0 {
+			allZero = false
+			break
+		}
+	}
+	out := append([]byte(nil), cw...)
+	if allZero {
+		return out, 0, nil
+	}
+
+	// Berlekamp-Massey: synthesise the shortest LFSR (error-locator
+	// polynomial Λ) that generates the syndrome sequence.
+	lambda := []byte{1}
+	bPoly := []byte{1}
+	L := 0
+	m := 1
+	b := byte(1)
+	for i := 0; i < r; i++ {
+		// Discrepancy delta = S_{i+1} + Σ_{j=1..L} Λ_j · S_{i+1-j}.
+		delta := synd[i]
+		for j := 1; j <= L; j++ {
+			if j < len(lambda) {
+				delta ^= gf64Mul(lambda[j], synd[i-j])
+			}
+		}
+		switch {
+		case delta == 0:
+			m++
+		case 2*L <= i:
+			tmp := append([]byte(nil), lambda...)
+			coef := gf64Mul(delta, gf64Inv(b))
+			lambda = polyAddShiftScaledGF64(lambda, bPoly, m, coef)
+			L = i + 1 - L
+			bPoly = tmp
+			b = delta
+			m = 1
+		default:
+			coef := gf64Mul(delta, gf64Inv(b))
+			lambda = polyAddShiftScaledGF64(lambda, bPoly, m, coef)
+			m++
+		}
+	}
+
+	if L > t {
+		return nil, 0, ErrRSUncorrectable
+	}
+
+	// Chien search: a symbol at codeword index i (polynomial degree
+	// p = n-1-i) is in error iff Λ(α^-p) = 0. Collect roots → positions.
+	type errPos struct {
+		idx int  // codeword index
+		x   byte // error locator X_l = α^p
+	}
+	var positions []errPos
+	for p := 0; p < n; p++ {
+		root := gf64Pow(-p) // α^-p
+		if polyEvalGF64(lambda, root) == 0 {
+			positions = append(positions, errPos{idx: n - 1 - p, x: gf64Pow(p)})
+		}
+	}
+	if len(positions) != L {
+		// Roots fell outside the transmitted positions, or fewer roots
+		// than the locator degree → more than t errors.
+		return nil, 0, ErrRSUncorrectable
+	}
+
+	// Forney: error magnitude e_l = Ω(X_l^-1) / Λ'(X_l^-1) for roots
+	// starting at α^1 (b=1, so the X_l^(1-b) factor is unity). Ω is the
+	// error-evaluator Ω(x) = S(x)·Λ(x) mod x^r.
+	omega := polyMulModGF64(syndromePolyGF64(synd), lambda, r)
+	lambdaPrime := formalDerivativeGF64(lambda)
+	for _, ep := range positions {
+		xInv := gf64Inv(ep.x)
+		num := polyEvalGF64(omega, xInv)
+		den := polyEvalGF64(lambdaPrime, xInv)
+		if den == 0 {
+			return nil, 0, ErrRSUncorrectable
+		}
+		out[ep.idx] ^= gf64Mul(num, gf64Inv(den))
+	}
+
+	// Defensive re-syndrome: a genuine >t error pattern that happened to
+	// produce a degree-≤t locator is rejected here rather than returned
+	// as a plausible-but-wrong codeword.
+	for _, s := range syndromesGF64(out, n, r) {
+		if s != 0 {
+			return nil, 0, ErrRSUncorrectable
+		}
+	}
+	return out, len(positions), nil
+}
+
+// syndromePolyGF64 builds S(x) = Σ_{j=1..r} S_j x^(j-1) from the syndrome
+// slice (synd[j-1] = S_j).
+func syndromePolyGF64(synd []byte) []byte {
+	return append([]byte(nil), synd...)
+}
+
+// polyAddShiftScaledGF64 returns a(x) + coef·x^shift·b(x) over GF(2^6).
+func polyAddShiftScaledGF64(a, b []byte, shift int, coef byte) []byte {
+	size := len(a)
+	if len(b)+shift > size {
+		size = len(b) + shift
+	}
+	out := make([]byte, size)
+	copy(out, a)
+	for i, bi := range b {
+		out[i+shift] ^= gf64Mul(coef, bi)
+	}
+	return out
+}
+
+// polyEvalGF64 evaluates poly (poly[i] = coefficient of x^i) at x.
+func polyEvalGF64(poly []byte, x byte) byte {
+	var acc byte
+	var xp byte = 1
+	for _, c := range poly {
+		acc ^= gf64Mul(c, xp)
+		xp = gf64Mul(xp, x)
+	}
+	return acc
+}
+
+// polyMulModGF64 returns a(x)·b(x) mod x^deg over GF(2^6).
+func polyMulModGF64(a, b []byte, deg int) []byte {
+	out := make([]byte, deg)
+	for i, ai := range a {
+		if ai == 0 || i >= deg {
+			continue
+		}
+		for j, bj := range b {
+			if i+j >= deg {
+				break
+			}
+			out[i+j] ^= gf64Mul(ai, bj)
+		}
+	}
+	return out
+}
+
+// formalDerivativeGF64 returns Λ'(x): over GF(2^m) the even-degree terms
+// vanish (multiplied by an even integer ≡ 0), leaving the odd-degree
+// coefficients shifted down by one.
+func formalDerivativeGF64(poly []byte) []byte {
+	if len(poly) <= 1 {
+		return []byte{0}
+	}
+	out := make([]byte, len(poly)-1)
+	for i := 1; i < len(poly); i++ {
+		if i%2 == 1 {
+			out[i-1] = poly[i]
+		}
+	}
+	return out
 }

--- a/internal/radio/framing/rs_gf64_test.go
+++ b/internal/radio/framing/rs_gf64_test.go
@@ -1,6 +1,8 @@
 package framing
 
 import (
+	"errors"
+	"math/rand"
 	"testing"
 )
 
@@ -158,5 +160,144 @@ func TestRSGF64InvalidSymbol(t *testing.T) {
 	cw[5] = 0x80 // bit 7 set, outside GF(2^6)
 	if VerifyRS24_12(cw) {
 		t.Errorf("VerifyRS24_12 accepted symbol with bits outside GF(2^6)")
+	}
+}
+
+// randInfo returns n random GF(2^6) symbols seeded deterministically.
+func randInfo(rng *rand.Rand, n int) []byte {
+	out := make([]byte, n)
+	for i := range out {
+		out[i] = byte(rng.Intn(64))
+	}
+	return out
+}
+
+// corruptSymbols flips `count` distinct codeword positions to random
+// *different* GF(2^6) values, returning the corrupted copy.
+func corruptSymbols(rng *rand.Rand, cw []byte, count int) []byte {
+	bad := append([]byte(nil), cw...)
+	perm := rng.Perm(len(cw))
+	for k := 0; k < count; k++ {
+		pos := perm[k]
+		for {
+			v := byte(rng.Intn(64))
+			if v != bad[pos] {
+				bad[pos] = v
+				break
+			}
+		}
+	}
+	return bad
+}
+
+// TestDecodeRS24_12_Correction sweeps random information vectors,
+// injects 0..t (t=6) symbol errors, and confirms the decoder recovers
+// the original information and reports the right error count. Injecting
+// t+1 errors must return ErrRSUncorrectable rather than a wrong word.
+func TestDecodeRS24_12_Correction(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x2412))
+	for iter := 0; iter < 400; iter++ {
+		info := randInfo(rng, 12)
+		var a [12]byte
+		copy(a[:], info)
+		cw := EncodeRS24_12(a)
+
+		for nerr := 0; nerr <= 6; nerr++ {
+			bad := corruptSymbols(rng, cw[:], nerr)
+			got, corrected, err := DecodeRS24_12(bad)
+			if err != nil {
+				t.Fatalf("iter %d nerr %d: unexpected error %v", iter, nerr, err)
+			}
+			if corrected != nerr {
+				t.Fatalf("iter %d: reported %d corrected, want %d", iter, corrected, nerr)
+			}
+			if got != a {
+				t.Fatalf("iter %d nerr %d: recovered %v, want %v", iter, nerr, got, a)
+			}
+		}
+	}
+}
+
+// TestDecodeRS24_12_Uncorrectable confirms t+1 errors are flagged rather
+// than silently miscorrected. (A small fraction of 7-error patterns can
+// land on another codeword; the defensive re-syndrome guarantees we
+// never return a word that fails to recover the original silently — we
+// assert it either errors or, in the rare aliasing case, does not return
+// the wrong info as if it were correct.)
+func TestDecodeRS24_12_Uncorrectable(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x99))
+	uncorrectable := 0
+	for iter := 0; iter < 500; iter++ {
+		info := randInfo(rng, 12)
+		var a [12]byte
+		copy(a[:], info)
+		cw := EncodeRS24_12(a)
+		bad := corruptSymbols(rng, cw[:], 7)
+		got, _, err := DecodeRS24_12(bad)
+		if err != nil {
+			if !errors.Is(err, ErrRSUncorrectable) {
+				t.Fatalf("iter %d: unexpected error %v", iter, err)
+			}
+			uncorrectable++
+			continue
+		}
+		// No error returned: the only acceptable outcome is that the
+		// decoder landed on a *valid* codeword (aliasing). It must not
+		// claim to have recovered our original from 7 errors via ≤6
+		// corrections, which would be a miscorrection bug.
+		if got == a {
+			t.Fatalf("iter %d: 7-error pattern 'recovered' the original — impossible within t=6", iter)
+		}
+	}
+	if uncorrectable == 0 {
+		t.Fatalf("expected most 7-error patterns to be flagged uncorrectable, got 0/500")
+	}
+}
+
+// TestDecodeRS24_16_Correction sweeps the ES code (t=4).
+func TestDecodeRS24_16_Correction(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x2416))
+	for iter := 0; iter < 400; iter++ {
+		info := randInfo(rng, 16)
+		var a [16]byte
+		copy(a[:], info)
+		cw := EncodeRS24_16(a)
+		for nerr := 0; nerr <= 4; nerr++ {
+			bad := corruptSymbols(rng, cw[:], nerr)
+			got, corrected, err := DecodeRS24_16(bad)
+			if err != nil {
+				t.Fatalf("iter %d nerr %d: unexpected error %v", iter, nerr, err)
+			}
+			if corrected != nerr {
+				t.Fatalf("iter %d: reported %d corrected, want %d", iter, corrected, nerr)
+			}
+			if got != a {
+				t.Fatalf("iter %d nerr %d: recovered %v, want %v", iter, nerr, got, a)
+			}
+		}
+	}
+}
+
+// TestDecodeRS36_20_Correction sweeps the HDU code (t=8).
+func TestDecodeRS36_20_Correction(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x3620))
+	for iter := 0; iter < 300; iter++ {
+		info := randInfo(rng, 20)
+		var a [20]byte
+		copy(a[:], info)
+		cw := EncodeRS36_20(a)
+		for nerr := 0; nerr <= 8; nerr++ {
+			bad := corruptSymbols(rng, cw[:], nerr)
+			got, corrected, err := DecodeRS36_20(bad)
+			if err != nil {
+				t.Fatalf("iter %d nerr %d: unexpected error %v", iter, nerr, err)
+			}
+			if corrected != nerr {
+				t.Fatalf("iter %d: reported %d corrected, want %d", iter, corrected, nerr)
+			}
+			if got != a {
+				t.Fatalf("iter %d nerr %d: recovered %v, want %v", iter, nerr, got, a)
+			}
+		}
 	}
 }

--- a/internal/radio/p25/phase1/encryption_sync.go
+++ b/internal/radio/p25/phase1/encryption_sync.go
@@ -1,5 +1,11 @@
 package phase1
 
+import (
+	"errors"
+
+	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+)
+
 // P25 LDU2 Encryption Sync word.
 //
 // An LDU2 carries an Encryption Sync (ES) word in the same 6 × 40-bit
@@ -17,8 +23,11 @@ package phase1
 // algorithm and key — but does not decrypt.
 //
 // The 96-bit ES content layout is the project's working model (the
-// 144-bit Hamming-recovered field's first 12 octets); the RS(24,12,13)
-// outer verification is a documented follow-up, as for Link Control.
+// 144-bit Hamming-recovered field's first 12 octets). As for Link
+// Control, the inner Hamming layer is followed by an outer RS code —
+// here RS(24,16,9) (framing.DecodeRS24_16, t=4) — which ParseEncryptionSync
+// runs to correct the residual symbol errors that otherwise produce
+// garbage Algorithm IDs under marginal SNR.
 //
 //	octets 0-8 : Message Indicator (72 bits)
 //	octet 9    : Algorithm ID
@@ -40,32 +49,45 @@ const AlgorithmClear uint8 = 0x80
 // Algorithm ID other than the clear-voice value).
 func (e EncryptionSync) Encrypted() bool { return e.AlgorithmID != AlgorithmClear }
 
+// ErrEncryptionSyncUncorrectable is returned when the outer RS(24,16,9)
+// layer cannot correct the Encryption Sync word — more than t=4 symbol
+// errors survived the inner Hamming layer. The decoded algorithm/key are
+// then low-confidence and should not be surfaced as a real encryption
+// change.
+var ErrEncryptionSyncUncorrectable = errors.New("p25/phase1: Encryption Sync RS-uncorrectable")
+
 // ParseEncryptionSync decodes the 6 LC/ES blocks of an LDU2 into a
-// structured EncryptionSync, returning the inner-FEC corrected-error
-// count.
+// structured EncryptionSync. The inner Hamming(10,6,3) layer is decoded
+// first, then the outer RS(24,16,9) layer corrects the residual symbol
+// errors that otherwise produce garbage Algorithm IDs under marginal
+// SNR. It returns the total corrected-error count and
+// ErrEncryptionSyncUncorrectable when the RS layer cannot recover the word.
 func ParseEncryptionSync(blocks [LDULCESBlockCount][]byte) (EncryptionSync, int, error) {
-	data, errs, err := lcInnerDecode(blocks)
+	data, innerErrs, err := lcInnerDecode(blocks)
 	if err != nil {
 		return EncryptionSync{}, 0, err
 	}
-	oct := bitsToOctets(data[:esContentOctets*8])
+	cw := bitsToRSSymbols(data)
+	info, rsErrs, rerr := framing.DecodeRS24_16(cw[:])
+	if rerr != nil {
+		return EncryptionSync{}, innerErrs, ErrEncryptionSyncUncorrectable
+	}
+	oct := bitsToOctets(rsSymbolsToBits(info[:]))
 	var es EncryptionSync
 	copy(es.MessageIndicator[:], oct[0:9])
 	es.AlgorithmID = oct[9]
 	es.KeyID = uint16(oct[10])<<8 | uint16(oct[11])
-	return es, errs, nil
+	return es, innerErrs + rsErrs, nil
 }
 
 // AssembleEncryptionSync is the inverse of ParseEncryptionSync; it
-// builds the 6 on-wire ES blocks. The RS-parity half of the 144-bit
-// data field is left zero (see the package note above).
+// builds the 6 on-wire ES blocks, computing the outer RS(24,16,9) parity
+// so the word round-trips through the RS-correcting parser.
 func AssembleEncryptionSync(es EncryptionSync) [LDULCESBlockCount][]byte {
 	oct := make([]byte, esContentOctets)
 	copy(oct[0:9], es.MessageIndicator[:])
 	oct[9] = es.AlgorithmID
 	oct[10], oct[11] = byte(es.KeyID>>8), byte(es.KeyID)
 
-	data := make([]byte, 144)
-	copy(data, octetsToBits(oct))
-	return lcInnerEncode(data)
+	return lcInnerEncode(rsEncodeContentBits(octetsToBits(oct), 16))
 }

--- a/internal/radio/p25/phase1/encryption_sync_test.go
+++ b/internal/radio/p25/phase1/encryption_sync_test.go
@@ -53,3 +53,45 @@ func TestEncryptionSyncCorrectsBitError(t *testing.T) {
 		t.Errorf("ES after correction = %+v, want %+v", got, in)
 	}
 }
+
+// TestEncryptionSyncRSCorrection confirms the outer RS(24,16,9) layer
+// recovers the correct algorithm/key after up to t=4 symbol errors — the
+// residual corruption that, before the RS layer, produced the scatter of
+// garbage Algorithm IDs seen in the field capture.
+func TestEncryptionSyncRSCorrection(t *testing.T) {
+	es := EncryptionSync{
+		MessageIndicator: [9]byte{0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99},
+		AlgorithmID:      0x84, // AES-256
+		KeyID:            0xBEEF,
+	}
+	clean := AssembleEncryptionSync(es)
+	for nerr := 0; nerr <= 4; nerr++ {
+		positions := make([]int, nerr)
+		for i := range positions {
+			positions[i] = i * 3
+		}
+		got, _, err := ParseEncryptionSync(injectRSSymbolErrors(clean, positions))
+		if err != nil {
+			t.Fatalf("nerr %d: unexpected error %v", nerr, err)
+		}
+		if got != es {
+			t.Fatalf("nerr %d: recovered %+v, want %+v", nerr, got, es)
+		}
+	}
+}
+
+// TestEncryptionSyncRSUncorrectable confirms a >t=4 burst is flagged.
+func TestEncryptionSyncRSUncorrectable(t *testing.T) {
+	es := EncryptionSync{AlgorithmID: 0x81, KeyID: 0x1234}
+	clean := AssembleEncryptionSync(es)
+	got, _, err := ParseEncryptionSync(injectRSSymbolErrors(clean, []int{0, 2, 4, 6, 8}))
+	if err == nil {
+		if got == es {
+			t.Fatalf("5 symbol errors 'recovered' the original — impossible within t=4")
+		}
+		return
+	}
+	if err != ErrEncryptionSyncUncorrectable {
+		t.Fatalf("unexpected error %v, want ErrEncryptionSyncUncorrectable", err)
+	}
+}

--- a/internal/radio/p25/phase1/link_control.go
+++ b/internal/radio/p25/phase1/link_control.go
@@ -1,18 +1,23 @@
 package phase1
 
-import "errors"
+import (
+	"errors"
+
+	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+)
 
 // P25 LDU1 Link Control word.
 //
 // The 240-bit LC field (6 × 40-bit LC/ES blocks, as returned by
-// ExtractLCESBlocks) carries a 72-bit Link Control word wrapped in FEC:
-// 24 shortened Hamming(10,6,3) codewords protect 144 bits, of which the
-// first 72 are the LC content and the remaining 72 are an RS(24,12,13)
-// outer parity (TIA-102.BAAA). This file decodes the inner Hamming
-// layer and parses the 72-bit LC content; the RS outer verification is
-// a documented follow-up — without the spec's RS generator polynomial
-// it cannot be done reliably, and the inner Hamming layer already
-// single-error-corrects each codeword.
+// ExtractLCESBlocks) carries a 72-bit Link Control word wrapped in two
+// FEC layers: 24 shortened Hamming(10,6,3) codewords protect 144 bits,
+// which are then the 24 six-bit symbols of an outer RS(24,12,13) code
+// (TIA-102.BAAA). The first 12 symbols (72 bits) are the LC content; the
+// trailing 12 are RS parity. ParseLinkControl decodes the inner Hamming
+// layer and then runs the outer RS layer (framing.DecodeRS24_12) to
+// correct up to t=6 residual symbol errors — without this, residual bit
+// errors that survive the single-error Hamming layer corrupt the
+// talkgroup/source under marginal SNR.
 //
 // LC content layout is the project's working model — TIA-102.BAAA's
 // per-LCO field tables are not in the repo. It is confined here with a
@@ -64,6 +69,57 @@ func IsTalkerAliasLCO(lcf uint8) bool {
 // blocks that are not each LDULCESBlockBits long.
 var ErrLinkControlLength = errors.New("p25/phase1: LC blocks must each be 40 bits")
 
+// ErrLinkControlUncorrectable is returned when the outer RS(24,12,13)
+// layer cannot correct the Link Control word — more than t=6 symbol
+// errors survived the inner Hamming layer. The decoded content is then
+// low-confidence and callers should not trust its talkgroup/source.
+var ErrLinkControlUncorrectable = errors.New("p25/phase1: Link Control RS-uncorrectable")
+
+// lcesSymbolCount is the number of 6-bit GF(2^6) symbols in the 144-bit
+// inner-decoded LC/ES field: 24 symbols, the RS codeword. Each symbol
+// occupies exactly one inner Hamming(10,6,3) codeword's data bits.
+const lcesSymbolCount = 24
+
+// bitsToRSSymbols groups the 144 inner-decoded data bits (one bit per
+// byte, MSB-first) into the 24 six-bit GF(2^6) RS symbols. The 6-bit
+// grouping aligns with the inner Hamming(10,6,3) codeword boundaries.
+func bitsToRSSymbols(bits []byte) [lcesSymbolCount]byte {
+	var sym [lcesSymbolCount]byte
+	for i := 0; i < lcesSymbolCount; i++ {
+		var s byte
+		for j := 0; j < 6; j++ {
+			s = s<<1 | (bits[i*6+j] & 1)
+		}
+		sym[i] = s
+	}
+	return sym
+}
+
+// rsSymbolsToBits is the inverse of bitsToRSSymbols for the first k
+// symbols, producing k*6 content bits (MSB-first).
+func rsSymbolsToBits(sym []byte) []byte {
+	out := make([]byte, len(sym)*6)
+	for i, s := range sym {
+		for j := 0; j < 6; j++ {
+			out[i*6+j] = (s >> uint(5-j)) & 1
+		}
+	}
+	return out
+}
+
+// rsCorrectLC applies the outer RS(24,12,13) layer to the 144 data bits
+// returned by lcInnerDecode and returns the corrected 72 content bits
+// (the 12 information symbols), the symbol-error count, and
+// ErrLinkControlUncorrectable when beyond the correction radius.
+func rsCorrectLC(data []byte) ([]byte, int, error) {
+	cw := bitsToRSSymbols(data)
+	info, nErr, err := framing.DecodeRS24_12(cw[:])
+	if err != nil {
+		return nil, 0, ErrLinkControlUncorrectable
+	}
+	return rsSymbolsToBits(info[:]), nErr, nil
+}
+
 // lcInnerDecode runs the 24 Hamming(10,6,3) inner codewords over the
 // 240-bit LC/ES field and returns the 144 recovered data bits plus the
 // total corrected-error count. It is shared by ParseLinkControl and the
@@ -102,41 +158,54 @@ func lcInnerEncode(data []byte) [LDULCESBlockCount][]byte {
 }
 
 // ParseLinkControl decodes the 6 LC blocks of an LDU1 into a structured
-// LinkControl. It returns the parsed word and the inner-FEC corrected-
-// error count.
+// LinkControl. The inner Hamming(10,6,3) layer is decoded first, then the
+// outer RS(24,12,13) layer corrects the residual symbol errors that
+// otherwise corrupt the talkgroup/source under marginal SNR. It returns
+// the parsed word, the total corrected-error count (inner bit errors plus
+// outer symbol errors), and ErrLinkControlUncorrectable when the RS layer
+// cannot recover the word.
 func ParseLinkControl(blocks [LDULCESBlockCount][]byte) (LinkControl, int, error) {
-	data, errs, err := lcInnerDecode(blocks)
+	data, innerErrs, err := lcInnerDecode(blocks)
 	if err != nil {
 		return LinkControl{}, 0, err
 	}
-	oct := bitsToOctets(data[:lcContentOctets*8])
+	content, rsErrs, rerr := rsCorrectLC(data)
+	if rerr != nil {
+		return LinkControl{}, innerErrs, rerr
+	}
+	oct := bitsToOctets(content)
 	return LinkControl{
 		LCFormat:       oct[0],
 		ServiceOptions: oct[1],
 		TalkgroupID:    uint16(oct[2])<<8 | uint16(oct[3]),
 		SourceID:       uint32(oct[4])<<16 | uint32(oct[5])<<8 | uint32(oct[6]),
-	}, errs, nil
+	}, innerErrs + rsErrs, nil
 }
 
 // ParseLinkControlContent decodes the 6 LC blocks of an LDU1 into the
-// raw 9 LC content octets plus the inner-FEC corrected-error count.
-// Used by the talker-alias path so opcodes other than 0x00 (group
-// voice channel user) can read their own octet layout without going
-// through ParseLinkControl's LCO-0-shaped struct.
+// raw 9 LC content octets plus the corrected-error count, applying the
+// same inner Hamming + outer RS correction as ParseLinkControl. Used by
+// the talker-alias path so opcodes other than 0x00 (group voice channel
+// user) can read their own octet layout without going through
+// ParseLinkControl's LCO-0-shaped struct.
 func ParseLinkControlContent(blocks [LDULCESBlockCount][]byte) ([lcContentOctets]byte, int, error) {
 	var out [lcContentOctets]byte
-	data, errs, err := lcInnerDecode(blocks)
+	data, innerErrs, err := lcInnerDecode(blocks)
 	if err != nil {
 		return out, 0, err
 	}
-	oct := bitsToOctets(data[:lcContentOctets*8])
-	copy(out[:], oct)
-	return out, errs, nil
+	content, rsErrs, rerr := rsCorrectLC(data)
+	if rerr != nil {
+		return out, innerErrs, rerr
+	}
+	copy(out[:], bitsToOctets(content))
+	return out, innerErrs + rsErrs, nil
 }
 
 // AssembleLinkControl is the inverse of ParseLinkControl; it builds the
-// 6 on-wire LC blocks for a LinkControl word. The RS-parity half of the
-// 144-bit data field is left zero (see the package note above).
+// 6 on-wire LC blocks for a LinkControl word, computing the outer
+// RS(24,12,13) parity so the word round-trips through the RS-correcting
+// parsers (and so synthetic test signals carry valid outer FEC).
 func AssembleLinkControl(lc LinkControl) [LDULCESBlockCount][]byte {
 	oct := make([]byte, lcContentOctets)
 	oct[0] = lc.LCFormat
@@ -144,9 +213,36 @@ func AssembleLinkControl(lc LinkControl) [LDULCESBlockCount][]byte {
 	oct[2], oct[3] = byte(lc.TalkgroupID>>8), byte(lc.TalkgroupID)
 	oct[4], oct[5], oct[6] = byte(lc.SourceID>>16), byte(lc.SourceID>>8), byte(lc.SourceID)
 
-	data := make([]byte, 144)
-	copy(data, octetsToBits(oct))
-	return lcInnerEncode(data)
+	return lcInnerEncode(rsEncodeContentBits(octetsToBits(oct), 12))
+}
+
+// rsEncodeContentBits takes the leading content bits (k*6 of them) of an
+// LC/ES word and returns the full 144-bit inner-data field with the
+// outer RS parity symbols appended. k is 12 for Link Control
+// (RS(24,12,13)) and 16 for Encryption Sync (RS(24,16,9)).
+func rsEncodeContentBits(content []byte, k int) []byte {
+	switch k {
+	case 12:
+		var info [12]byte
+		for i := 0; i < 12; i++ {
+			for j := 0; j < 6; j++ {
+				info[i] = info[i]<<1 | (content[i*6+j] & 1)
+			}
+		}
+		cw := framing.EncodeRS24_12(info)
+		return rsSymbolsToBits(cw[:])
+	case 16:
+		var info [16]byte
+		for i := 0; i < 16; i++ {
+			for j := 0; j < 6; j++ {
+				info[i] = info[i]<<1 | (content[i*6+j] & 1)
+			}
+		}
+		cw := framing.EncodeRS24_16(info)
+		return rsSymbolsToBits(cw[:])
+	default:
+		return make([]byte, 144)
+	}
 }
 
 // LDUDuid returns the DUID encoded in an on-air LDU's NID — used to

--- a/internal/radio/p25/phase1/link_control_test.go
+++ b/internal/radio/p25/phase1/link_control_test.go
@@ -105,3 +105,80 @@ func TestIsTalkerAliasLCO(t *testing.T) {
 		}
 	}
 }
+
+// injectRSSymbolErrors replaces whole inner Hamming(10,6,3) codewords in
+// the assembled LC/ES field with valid codewords carrying a *different*
+// 6-bit value, so the inner layer decodes cleanly (0 inner errors) while
+// exactly len(positions) outer RS symbols are wrong. This isolates the
+// outer RS layer's correction behaviour from the inner Hamming layer.
+func injectRSSymbolErrors(blocks [LDULCESBlockCount][]byte, positions []int) [LDULCESBlockCount][]byte {
+	var field []byte
+	for _, b := range blocks {
+		field = append(field, b...)
+	}
+	for _, p := range positions {
+		cur, _ := decodeHamming10_6(field[p*10 : p*10+10])
+		var v byte
+		for _, bit := range cur {
+			v = v<<1 | bit&1
+		}
+		v = (v + 1) & 0x3F // a guaranteed-different 6-bit value
+		nd := make([]byte, 6)
+		for j := 0; j < 6; j++ {
+			nd[j] = (v >> uint(5-j)) & 1
+		}
+		copy(field[p*10:p*10+10], encodeHamming10_6(nd))
+	}
+	var out [LDULCESBlockCount][]byte
+	for j := range out {
+		out[j] = append([]byte(nil), field[j*LDULCESBlockBits:(j+1)*LDULCESBlockBits]...)
+	}
+	return out
+}
+
+// TestLinkControlRSCorrection confirms the outer RS(24,12,13) layer
+// recovers the correct talkgroup/source after up to t=6 symbol errors —
+// the residual corruption that, before the RS layer, produced bogus
+// talkgroups and false foreign-TG gating in the field capture.
+func TestLinkControlRSCorrection(t *testing.T) {
+	lc := LinkControl{
+		LCFormat:       LCOGroupVoiceChannelUser,
+		ServiceOptions: 0x00,
+		TalkgroupID:    1234,
+		SourceID:       567890,
+	}
+	clean := AssembleLinkControl(lc)
+	for nerr := 0; nerr <= 6; nerr++ {
+		positions := make([]int, nerr)
+		for i := range positions {
+			positions[i] = i * 3 // spread across distinct symbols
+		}
+		got, _, err := ParseLinkControl(injectRSSymbolErrors(clean, positions))
+		if err != nil {
+			t.Fatalf("nerr %d: unexpected error %v", nerr, err)
+		}
+		if got.TalkgroupID != lc.TalkgroupID || got.SourceID != lc.SourceID || got.LCFormat != lc.LCFormat {
+			t.Fatalf("nerr %d: recovered %+v, want %+v", nerr, got, lc)
+		}
+	}
+}
+
+// TestLinkControlRSUncorrectable confirms a >t error burst is flagged
+// rather than yielding a plausible-but-wrong talkgroup.
+func TestLinkControlRSUncorrectable(t *testing.T) {
+	lc := LinkControl{LCFormat: LCOGroupVoiceChannelUser, TalkgroupID: 4321, SourceID: 99}
+	clean := AssembleLinkControl(lc)
+	// 7 distinct symbol errors > t=6.
+	got, _, err := ParseLinkControl(injectRSSymbolErrors(clean, []int{0, 2, 4, 6, 8, 10, 12}))
+	if err == nil {
+		// Aliasing onto another codeword is acceptable only if it does not
+		// masquerade as the original.
+		if got.TalkgroupID == lc.TalkgroupID && got.SourceID == lc.SourceID {
+			t.Fatalf("7 symbol errors 'recovered' the original — impossible within t=6")
+		}
+		return
+	}
+	if err != ErrLinkControlUncorrectable {
+		t.Fatalf("unexpected error %v, want ErrLinkControlUncorrectable", err)
+	}
+}

--- a/internal/voice/composer/p25p1_voice.go
+++ b/internal/voice/composer/p25p1_voice.go
@@ -2,6 +2,7 @@ package composer
 
 import (
 	"context"
+	"errors"
 	"sync/atomic"
 	"time"
 
@@ -132,6 +133,15 @@ func (c *Composer) runP25Phase1VoiceChain(ctx context.Context, serial string, iq
 		uncorrectableLDUs atomic.Uint64
 		corrErrBits       atomic.Uint64
 	)
+	// Outer-RS telemetry for the Link Control (LDU1) and Encryption Sync
+	// (LDU2) words. A rising RS-uncorrectable rate is the measurable
+	// signature of marginal signal at the FEC layer that drives the
+	// talkgroup-gating decision — high values mean talkgroups can't be
+	// trusted and the operator should improve gain/antenna.
+	var (
+		lcRSUncorrectable  atomic.Uint64
+		essRSUncorrectable atomic.Uint64
+	)
 	rx := p25p1rx.New(p25p1rx.Options{
 		SampleRateHz: symbolHz,
 		DeviationHz:  p25p1DeviationHz,
@@ -165,7 +175,17 @@ func (c *Composer) runP25Phase1VoiceChain(ctx context.Context, serial string, iq
 			// and we drop that audio rather than append it.
 			tg := uint32(0)
 			if duid == phase1.DUIDLogicalLink1 && haveBlocks {
-				if lc, _, lerr := phase1.ParseLinkControl(blocks); lerr == nil && lc.LCFormat == phase1.LCOGroupVoiceChannelUser {
+				lc, _, lerr := phase1.ParseLinkControl(blocks)
+				switch {
+				case errors.Is(lerr, phase1.ErrLinkControlUncorrectable):
+					// The outer RS layer could not recover the LC, so its
+					// talkgroup is untrustworthy. Leave tg=0 so the boundary
+					// tracker INHERITS the last match instead of gating audio
+					// (or ending the call) on a garbage talkgroup — the
+					// dominant cause of dropped/fragmented recordings in the
+					// field capture.
+					lcRSUncorrectable.Add(1)
+				case lerr == nil && lc.LCFormat == phase1.LCOGroupVoiceChannelUser:
 					tg = uint32(lc.TalkgroupID)
 				}
 			}
@@ -235,7 +255,13 @@ func (c *Composer) runP25Phase1VoiceChain(ctx context.Context, serial string, iq
 					}
 				}
 			case phase1.DUIDLogicalLink2:
-				if es, _, lerr := phase1.ParseEncryptionSync(blocks); lerr == nil && es.Encrypted() {
+				es, _, lerr := phase1.ParseEncryptionSync(blocks)
+				if errors.Is(lerr, phase1.ErrEncryptionSyncUncorrectable) {
+					// Outer RS could not recover the ES; do not surface a
+					// garbage algorithm/key as a real encryption change.
+					essRSUncorrectable.Add(1)
+				}
+				if lerr == nil && es.Encrypted() {
 					c.log.Debug("composer: p25p1 encryption sync",
 						"serial", serial, "alg", es.AlgorithmID, "key", es.KeyID)
 					// Publish on the bus so the trunking engine
@@ -277,7 +303,9 @@ func (c *Composer) runP25Phase1VoiceChain(ctx context.Context, serial string, iq
 		c.log.Info("composer: p25p1 decode quality",
 			"serial", serial, "demod_mode", mode,
 			"ldus", n, "uncorrectable_ldus", uncorrectableLDUs.Load(),
-			"corrected_bit_errs", corrErrBits.Load())
+			"corrected_bit_errs", corrErrBits.Load(),
+			"lc_rs_uncorrectable", lcRSUncorrectable.Load(),
+			"ess_rs_uncorrectable", essRSUncorrectable.Load())
 	}
 
 	for {


### PR DESCRIPTION
Field review of an 8-Jun P25 Phase 1 voice capture (1304 recordings +
debug.log) found ~71% of decoded voice frames were never written and
calls fragmented into ~1s files, with ~19% empty. Root cause: LDU1 Link
Control (talkgroup/source) and LDU2 Encryption Sync (ALGID/KID) were
decoded with only the inner Hamming(10,6,3) layer — the outer
Reed-Solomon codes were never error-corrected. Residual bit errors
corrupted the talkgroup the recorder's gating relies on (false
foreign-TG drops + premature call-end) and produced garbage ALGIDs.

- framing: implement bounded-distance RS decoding over GF(2^6)
  (Berlekamp-Massey + Chien + Forney) for RS(24,12,13), RS(24,16,9) and
  RS(36,20,17), reusing the existing field/encoder/verifier. Add a
  defensive re-syndrome so >t patterns fail cleanly instead of
  miscorrecting. ErrRSUncorrectable signals an unrecoverable word.
- p25/phase1: run the outer RS layer in ParseLinkControl /
  ParseLinkControlContent (t=6) and ParseEncryptionSync (t=4); compute
  RS parity in the assemblers so words round-trip. New sentinels
  ErrLinkControlUncorrectable / ErrEncryptionSyncUncorrectable.
- composer: when the LC is RS-uncorrectable, leave tg=0 so the boundary
  tracker inherits the last match instead of gating/ending the call on a
  garbage talkgroup. Surface lc_rs_uncorrectable / ess_rs_uncorrectable
  in the decode-quality log as the FEC-layer marginal-signal signal.
- docs: explain the new decode-quality metrics and manual-gain note.

Tests: RS encode→corrupt(≤t)→decode recovery + uncorrectable detection
for all three codes; LC/ES symbol-error recovery of talkgroup/ALGID.

https://claude.ai/code/session_012wwH3xYMAAXgtaPkoAcEYY