### PR TITLE
survey: add live signal classification + routing engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ for tagged releases.
 
 ## [Unreleased]
 
+### Added
+
+- **Live signal survey — `gophertrunk hunt -survey`.** The hunt sweep now does
+  more than chase trunking control channels: in survey mode it classifies
+  *every* detected carrier by modulation family (analog NBFM/WFM, AM, digital
+  FSK/C4FM/PSK, paging, trunking) plus an occupied-bandwidth estimate, then
+  decodes the conventional ones — POCSAG/FLEX paging and analog-FM activity
+  (carrier + CTCSS/DCS) — while still folding any trunking control channel into
+  the discovered-system map. The classifier is blind and cheap (FFT
+  occupied-bandwidth, envelope coefficient-of-variation, FM-discriminator
+  features, and a cyclostationary baud-line detector), reusing the existing dsp
+  primitives and the POCSAG/FLEX/conventional decoders rather than duplicating
+  them. The result is a `SignalSurvey` inventory surfaced across the CLI
+  (printed table), the daemon REST API (`hunt.survey` request flag, `mode` +
+  `signals` in `GET /api/v1/hunt`), the web Hunt panel (a Survey-mode checkbox
+  and a signals table), and the TUI Hunt panel (a `v` survey-start key and a
+  signal list).
+
 ### Fixed
 
 - **Constellation / signal scopes stuck on "waiting for symbols"** (#557,

--- a/cmd/gophertrunk/hunt.go
+++ b/cmd/gophertrunk/hunt.go
@@ -45,6 +45,7 @@ func runHunt(args []string) {
 	// Live-mode flags (no -in): sweep an SDR across operator-given band(s) or
 	// probe an explicit candidate list.
 	serial := fs.String("serial", "", "SDR serial to sweep for a live hunt (omit -in). Empty + no -in ⇒ error")
+	surveyMode := fs.Bool("survey", false, "signal-survey mode: classify every detected carrier (analog/digital/paging/trunking) and decode the conventional ones, not just trunking control channels (live only)")
 	var bands repeatedString
 	fs.Var(&bands, "band", "frequency band to sweep as low:high in MHz (repeatable; live mode)")
 	candidatesFlag := fs.String("candidates", "", "comma-separated control-channel frequencies in MHz to probe directly (skips the sweep)")
@@ -102,6 +103,9 @@ EXAMPLES:
   # LIVE: probe a known control-channel list directly (no sweep)
   gophertrunk hunt -serial 00000001 -sample-rate 2400000 -no-sweep -candidates 851.0125,853.5125
 
+  # SURVEY: sweep a band and classify+decode every signal (analog, paging, trunking)
+  gophertrunk hunt -survey -serial 00000001 -sample-rate 2400000 -band 460:470
+
 FLAGS:`)
 		fs.PrintDefaults()
 	}
@@ -157,6 +161,7 @@ FLAGS:`)
 	if live {
 		sys, reports = runHuntLive(rep, huntLiveParams{
 			serial:          *serial,
+			survey:          *surveyMode,
 			bands:           []string(bands),
 			candidatesMHz:   *candidatesFlag,
 			noSweep:         *noSweep,
@@ -214,6 +219,7 @@ FLAGS:`)
 	}
 
 	finishHunt(rep, sys, reports, huntExportParams{
+		surveyMode: *surveyMode,
 		outFormats: outFormats,
 		outDir:     *out,
 		noRR:       *noRR,
@@ -229,6 +235,7 @@ FLAGS:`)
 // huntExportParams carries the post-discovery export/RR/commit options shared
 // by the offline and live hunt paths.
 type huntExportParams struct {
+	surveyMode bool
 	outFormats []hunt.Format
 	outDir     string
 	noRR       bool
@@ -255,7 +262,14 @@ func finishHunt(rep *diag.Reporter, sys *hunt.DiscoveredSystem, reports []hunt.C
 				r.Path, r.Protocol, r.Locked, r.Talkgroups)
 		}
 	}
-	if len(sys.Sites) == 0 && len(sys.Talkgroups) == 0 {
+	if sys == nil || (len(sys.Sites) == 0 && len(sys.Talkgroups) == 0) {
+		// A survey can legitimately find no trunked system (only analog/paging/
+		// unclassified carriers); the inventory was already printed, so exit
+		// cleanly rather than treating "no system" as a hunt failure.
+		if p.surveyMode {
+			fmt.Fprintln(os.Stderr, "hunt: survey complete — no trunked system to export")
+			return
+		}
 		rep.Fatalf(1, "no trunked control channel was decoded")
 	}
 	fmt.Fprintf(os.Stderr, "hunt: discovered %q — %d site(s), %d talkgroup(s)\n",

--- a/cmd/gophertrunk/hunt_cockpit.go
+++ b/cmd/gophertrunk/hunt_cockpit.go
@@ -26,11 +26,13 @@ func (c huntCockpit) Status() api.HuntStatus {
 		RunID:      st.RunID,
 		State:      string(st.State),
 		Running:    st.Running,
+		Mode:       st.Mode,
 		Phase:      string(st.Progress.Phase),
 		Detail:     st.Progress.Detail,
 		Sites:      st.Sites,
 		Talkgroups: st.Talkgroups,
 		SystemName: st.SystemName,
+		Signals:    st.Signals,
 		Error:      st.Error,
 	}
 	if sys, reports, ok := c.mgr.Current(); ok {
@@ -69,6 +71,7 @@ func (c huntCockpit) Start(req api.HuntStartRequest) (int, error) {
 		Bands:         bands,
 		Candidates:    candidates,
 		Protocol:      proto,
+		Survey:        req.Survey,
 		Serial:        req.Serial,
 		FFTSize:       req.FFTSize,
 		DwellSeconds:  req.DwellSeconds,

--- a/cmd/gophertrunk/hunt_live.go
+++ b/cmd/gophertrunk/hunt_live.go
@@ -17,6 +17,7 @@ import (
 // huntLiveParams are the resolved inputs for a live (on-air) hunt.
 type huntLiveParams struct {
 	serial          string
+	survey          bool     // classify+decode every carrier, not just trunking CCs
 	bands           []string // "low:high" in MHz
 	candidatesMHz   string   // comma-separated MHz
 	noSweep         bool
@@ -81,15 +82,19 @@ func runHuntLive(rep *diag.Reporter, p huntLiveParams) (*hunt.DiscoveredSystem, 
 		rep.Fatal(1, fmt.Errorf("start IQ stream: %w", err))
 	}
 
+	mode := "hunt"
+	if p.survey {
+		mode = "survey"
+	}
 	if len(bands) > 0 {
-		fmt.Fprintf(os.Stderr, "hunt: live sweep on %s[%s] @ %g MS/s across %d band(s)…\n",
-			info.Driver, info.Serial, p.sampleRateHz/1e6, len(bands))
+		fmt.Fprintf(os.Stderr, "%s: live sweep on %s[%s] @ %g MS/s across %d band(s)…\n",
+			mode, info.Driver, info.Serial, p.sampleRateHz/1e6, len(bands))
 	} else {
-		fmt.Fprintf(os.Stderr, "hunt: live probe on %s[%s] of %d candidate(s)…\n",
-			info.Driver, info.Serial, len(candidates))
+		fmt.Fprintf(os.Stderr, "%s: live probe on %s[%s] of %d candidate(s)…\n",
+			mode, info.Driver, info.Serial, len(candidates))
 	}
 
-	sys, reports, err := hunt.RunLiveHunt(ctx, hunt.LiveHuntOptions{
+	opts := hunt.LiveHuntOptions{
 		Source:        src,
 		Bands:         bands,
 		Candidates:    candidates,
@@ -107,16 +112,63 @@ func runHuntLive(rep *diag.Reporter, p huntLiveParams) (*hunt.DiscoveredSystem, 
 		OnProgress: func(pr hunt.LiveHuntProgress) {
 			switch pr.Phase {
 			case hunt.PhaseSweeping:
-				fmt.Fprintf(os.Stderr, "hunt: sweeping %.4f MHz — %s\n", float64(pr.CenterHz)/1e6, pr.Detail)
+				fmt.Fprintf(os.Stderr, "%s: sweeping %.4f MHz — %s\n", mode, float64(pr.CenterHz)/1e6, pr.Detail)
 			case hunt.PhaseIdentifying:
-				fmt.Fprintf(os.Stderr, "hunt: probing candidate %d/%d @ %s\n", pr.CandidateN, pr.Candidates, pr.Detail)
+				fmt.Fprintf(os.Stderr, "%s: probing candidate %d/%d @ %s\n", mode, pr.CandidateN, pr.Candidates, pr.Detail)
 			}
 		},
-	})
+	}
+
+	if p.survey {
+		sv, reports, err := hunt.RunLiveSurvey(ctx, opts)
+		if err != nil {
+			rep.Fatal(1, fmt.Errorf("live survey: %w", err))
+		}
+		printSurvey(sv)
+		return sv.System, reports
+	}
+
+	sys, reports, err := hunt.RunLiveHunt(ctx, opts)
 	if err != nil {
 		rep.Fatal(1, fmt.Errorf("live hunt: %w", err))
 	}
 	return sys, reports
+}
+
+// printSurvey writes the classified signal inventory to stderr — the survey's
+// primary deliverable. The trunking export tail (finishHunt) runs afterwards on
+// sv.System when a trunked system was found.
+func printSurvey(sv *hunt.SignalSurvey) {
+	trunking, analog, paging, other := sv.Counts()
+	fmt.Fprintf(os.Stderr, "survey: %d signal(s) — %d trunking, %d analog, %d paging, %d other\n",
+		len(sv.Signals), trunking, analog, paging, other)
+	for _, s := range sv.Signals {
+		line := fmt.Sprintf("  %10.4f MHz  %-13s  bw %5.1f kHz  snr %4.1f dB",
+			float64(s.FreqHz)/1e6, s.Class, float64(s.OccupiedBwHz)/1e3, s.SNRDb)
+		switch {
+		case s.Trunking != nil:
+			line += fmt.Sprintf("  [%s", s.Trunking.Protocol)
+			if s.Trunking.Locked {
+				line += " locked"
+			}
+			line += "]"
+		case len(s.Pages) > 0:
+			line += fmt.Sprintf("  [%d page(s), %s]", len(s.Pages), s.Pages[0].Protocol)
+		case s.Analog != nil && s.Analog.Active:
+			line += "  [active"
+			if s.Analog.CTCSSHz > 0 {
+				line += fmt.Sprintf(", CTCSS %.1f Hz", s.Analog.CTCSSHz)
+			}
+			if s.Analog.DCSCode != "" {
+				line += fmt.Sprintf(", DCS %s", s.Analog.DCSCode)
+			}
+			line += "]"
+		}
+		if s.Error != "" {
+			line += "  ERROR: " + s.Error
+		}
+		fmt.Fprintln(os.Stderr, line)
+	}
 }
 
 // parseFreqListMHz parses a comma-separated MHz list into Hz. Empty ⇒ nil.

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -10,21 +10,21 @@ import (
 // HuntStatus is the JSON shape returned by GET /api/v1/hunt — the live
 // system-discovery run state plus the discovered system map once available.
 type HuntStatus struct {
-	RunID      int                    `json:"run_id"`
-	State      string                 `json:"state"`
-	Running    bool                   `json:"running"`
-	Mode       string                 `json:"mode,omitempty"` // "hunt" | "survey"
-	Phase      string                 `json:"phase,omitempty"`
-	Detail     string                 `json:"detail,omitempty"`
-	Sites      int                    `json:"sites"`
-	Talkgroups int                    `json:"talkgroups"`
-	SystemName string                 `json:"system_name,omitempty"`
+	RunID      int    `json:"run_id"`
+	State      string `json:"state"`
+	Running    bool   `json:"running"`
+	Mode       string `json:"mode,omitempty"` // "hunt" | "survey"
+	Phase      string `json:"phase,omitempty"`
+	Detail     string `json:"detail,omitempty"`
+	Sites      int    `json:"sites"`
+	Talkgroups int    `json:"talkgroups"`
+	SystemName string `json:"system_name,omitempty"`
 	// Signals is the classified-carrier inventory of a survey run (empty for a
 	// plain hunt) — the survey's primary result.
-	Signals    []hunt.DetectedSignal  `json:"signals,omitempty"`
-	Error      string                 `json:"error,omitempty"`
-	System     *hunt.DiscoveredSystem `json:"system,omitempty"`
-	Reports    []hunt.CaptureReport   `json:"reports,omitempty"`
+	Signals []hunt.DetectedSignal  `json:"signals,omitempty"`
+	Error   string                 `json:"error,omitempty"`
+	System  *hunt.DiscoveredSystem `json:"system,omitempty"`
+	Reports []hunt.CaptureReport   `json:"reports,omitempty"`
 }
 
 // HuntStartRequest is the POST /api/v1/hunt/start body. Frequencies are in MHz

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -13,11 +13,15 @@ type HuntStatus struct {
 	RunID      int                    `json:"run_id"`
 	State      string                 `json:"state"`
 	Running    bool                   `json:"running"`
+	Mode       string                 `json:"mode,omitempty"` // "hunt" | "survey"
 	Phase      string                 `json:"phase,omitempty"`
 	Detail     string                 `json:"detail,omitempty"`
 	Sites      int                    `json:"sites"`
 	Talkgroups int                    `json:"talkgroups"`
 	SystemName string                 `json:"system_name,omitempty"`
+	// Signals is the classified-carrier inventory of a survey run (empty for a
+	// plain hunt) — the survey's primary result.
+	Signals    []hunt.DetectedSignal  `json:"signals,omitempty"`
 	Error      string                 `json:"error,omitempty"`
 	System     *hunt.DiscoveredSystem `json:"system,omitempty"`
 	Reports    []hunt.CaptureReport   `json:"reports,omitempty"`
@@ -31,6 +35,7 @@ type HuntStartRequest struct {
 	Bands           []string  `json:"bands,omitempty"`      // "low:high" MHz
 	Candidates      []float64 `json:"candidates,omitempty"` // MHz
 	NoSweep         bool      `json:"no_sweep,omitempty"`
+	Survey          bool      `json:"survey,omitempty"` // classify+decode every carrier, not just trunking CCs
 	Protocol        string    `json:"protocol,omitempty"`
 	DwellSeconds    float64   `json:"dwell_seconds,omitempty"`
 	SweepDwellMs    int       `json:"sweep_dwell_ms,omitempty"`

--- a/internal/hunt/livehunt.go
+++ b/internal/hunt/livehunt.go
@@ -40,6 +40,10 @@ type LiveHuntOptions struct {
 	Candidates []uint32
 	// Protocol forces a decoder; trunking.ProtocolUnknown auto-identifies.
 	Protocol trunking.Protocol
+	// Survey selects the signal-survey pipeline (RunLiveSurvey): classify and
+	// decode every detected carrier, not just trunking control channels. The
+	// daemon Manager reads this to dispatch the right run.
+	Survey bool
 	// Serial requests a specific SDR for the run. Empty ⇒ the daemon
 	// auto-selects (spare SDR, else borrow the control SDR). Consumed by the
 	// daemon Acquirer; RunLiveHunt itself ignores it (the IQSource is already

--- a/internal/hunt/livesurvey.go
+++ b/internal/hunt/livesurvey.go
@@ -1,0 +1,238 @@
+package hunt
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp"
+	"github.com/MattCheramie/GopherTrunk/internal/siglab"
+	"github.com/MattCheramie/GopherTrunk/internal/survey"
+)
+
+// surveyChannelRateHz is the rate each detected carrier is decimated to before
+// classification and conventional decode. 48 kHz matches the narrowband rate
+// the wideband-T2 engine and the single-channel ccdecoder target, gives the
+// blind classifier fine spectral resolution, and band-limits the carrier so the
+// FM-demod chain isn't swamped by out-of-channel noise. The trunking decode
+// still runs on the full-rate capture (siglab channelises it itself).
+const surveyChannelRateHz = 48_000
+
+// RunLiveSurvey sweeps (or probes a candidate list) like RunLiveHunt, but
+// instead of only mapping trunking control channels it classifies every
+// detected carrier and routes it: trunking carriers fold into the discovered
+// system (the existing identify→decode→accumulate path), paging and analog
+// carriers run their conventional decoders, and the rest are recorded as
+// classified-only. It returns the full SignalSurvey (which embeds the trunking
+// map) plus the per-candidate trunking reports for the shared export tail.
+func RunLiveSurvey(ctx context.Context, opts LiveHuntOptions) (*SignalSurvey, []CaptureReport, error) {
+	log := opts.Log
+	if log == nil {
+		log = slog.New(slog.DiscardHandler)
+	}
+	if opts.Source == nil {
+		return nil, nil, fmt.Errorf("hunt: live survey requires an IQSource")
+	}
+	rate := opts.Source.SampleRateHz()
+	if rate == 0 {
+		return nil, nil, fmt.Errorf("hunt: IQSource has zero sample rate")
+	}
+	dwell := opts.DwellSeconds
+	if dwell <= 0 {
+		dwell = 3
+	}
+	progress := func(p LiveHuntProgress) {
+		if opts.OnProgress != nil {
+			opts.OnProgress(p)
+		}
+	}
+
+	candidates, err := surveyCandidates(ctx, opts, log, progress)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	sv := &SignalSurvey{
+		StartedAt: time.Now(),
+		System: &DiscoveredSystem{
+			Name:     opts.Name,
+			State:    opts.State,
+			County:   opts.County,
+			Location: opts.Location,
+		},
+	}
+	reports := make([]CaptureReport, 0, len(candidates))
+	nSamples := int(dwell * float64(rate))
+
+	for i, cand := range candidates {
+		if err := ctx.Err(); err != nil {
+			return finishSurvey(sv), reports, err
+		}
+		progress(LiveHuntProgress{
+			Phase: PhaseIdentifying, CenterHz: cand.FreqHz,
+			CandidateN: i + 1, Candidates: len(candidates),
+			Detail: fmt.Sprintf("%.4f MHz", float64(cand.FreqHz)/1e6),
+		})
+
+		ds := DetectedSignal{FreqHz: cand.FreqHz, SNRDb: cand.SNRDb}
+		if err := opts.Source.Tune(cand.FreqHz); err != nil {
+			ds.Error = fmt.Sprintf("tune: %v", err)
+			ds.Class = survey.ClassUnknown
+			sv.Signals = append(sv.Signals, ds)
+			continue
+		}
+		iq, err := captureN(ctx, opts.Source, nSamples)
+		if err != nil {
+			return finishSurvey(sv), reports, err
+		}
+
+		// Channelise to a narrow baseband stream for classification + the
+		// conventional (analog/paging) decoders.
+		chIQ, chRate := channelize(iq, rate, surveyChannelRateHz)
+		cls := survey.Classify(chIQ, float64(chRate))
+		ds.Class = cls.Class
+		ds.Confidence = cls.Confidence
+		ds.OccupiedBwHz = cls.OccupiedBwHz
+		ds.BaudHz = cls.Features.BaudHz
+		ds.Features = cls.Features
+
+		rep := routeSignal(sv.System, &ds, routeInputs{
+			fullIQ: iq, fullRate: float64(rate),
+			chIQ: chIQ, chRate: chRate,
+			cand: cand, opts: opts, log: log,
+		})
+		if rep != nil {
+			reports = append(reports, *rep)
+		}
+		sv.Signals = append(sv.Signals, ds)
+	}
+
+	return finishSurvey(sv), reports, nil
+}
+
+// routeInputs bundles the per-candidate buffers and config the router needs.
+type routeInputs struct {
+	fullIQ   []complex64
+	fullRate float64
+	chIQ     []complex64
+	chRate   uint32
+	cand     Candidate
+	opts     LiveHuntOptions
+	log      *slog.Logger
+}
+
+// routeSignal decodes ds according to its class, mutating ds with the decode
+// summary. For trunking-family carriers it runs the shared identify→decode→
+// accumulate body (returning its CaptureReport); for paging/analog it runs the
+// conventional decoders; everything else is left as classified-only. Returns a
+// non-nil CaptureReport only when the trunking path ran.
+func routeSignal(sys *DiscoveredSystem, ds *DetectedSignal, in routeInputs) *CaptureReport {
+	source := fmt.Sprintf("%.4f MHz", float64(in.cand.FreqHz)/1e6)
+
+	// Paging: a digital carrier at a POCSAG/FLEX baud — prove it by decoding.
+	if survey.IsDigital(ds.Class) && survey.IsPagingBaud(ds.Features.BaudHz) {
+		pages := survey.DecodePOCSAG(in.chIQ, in.chRate)
+		if flex := survey.DecodeFLEX(in.chIQ, in.chRate); len(flex) > len(pages) {
+			pages = flex
+		}
+		if len(pages) > 0 {
+			ds.Pages = pages
+			ds.Class = survey.ClassPaging
+			return nil
+		}
+		// No pages — fall through to a trunking identify (could be NXDN/DMR).
+	}
+
+	// Trunking: hand digital carriers to the authoritative siglab identify on
+	// the full-rate capture (siglab channelises and auto-tunes internally).
+	if survey.IsDigital(ds.Class) {
+		buf := siglab.EncodeCapture(in.fullIQ, siglab.FormatF32)
+		rep := decodeAndAccumulate(sys, bytes.NewReader(buf), source, decodeParams{
+			Protocol:      in.opts.Protocol,
+			Format:        siglab.FormatF32,
+			SampleRateHz:  in.fullRate,
+			FrequencyHz:   in.cand.FreqHz,
+			AutoTune:      in.opts.AutoTune,
+			MinConfidence: in.opts.MinConfidence,
+			Log:           in.log,
+		})
+		switch {
+		case rep.Locked:
+			ds.Class = survey.ClassTrunkControl
+			ds.Trunking = &TrunkingRef{Protocol: rep.Protocol, Confidence: rep.Confidence, Locked: true, ControlHz: rep.ControlHz}
+		case !rep.Skipped && rep.Error == "":
+			ds.Class = survey.ClassTrunkVoice
+			ds.Trunking = &TrunkingRef{Protocol: rep.Protocol, Confidence: rep.Confidence}
+		}
+		// Skipped/errored ⇒ keep the classifier's family label (generic FSK/etc.).
+		return &rep
+	}
+
+	// Analog FM / AM: carrier activity + sub-audible squelch identification.
+	switch ds.Class {
+	case survey.ClassNBFM, survey.ClassWideFM, survey.ClassAM:
+		ds.Analog = survey.AnalyzeAnalogFM(in.chIQ, in.chRate)
+	}
+	return nil
+}
+
+// surveyCandidates resolves the carriers to examine: an explicit candidate list
+// or a spectrum sweep (shared with RunLiveHunt's front-end).
+func surveyCandidates(ctx context.Context, opts LiveHuntOptions, log *slog.Logger, progress func(LiveHuntProgress)) ([]Candidate, error) {
+	if len(opts.Candidates) > 0 {
+		out := make([]Candidate, 0, len(opts.Candidates))
+		for _, f := range opts.Candidates {
+			out = append(out, Candidate{FreqHz: f})
+		}
+		return out, nil
+	}
+	sw, err := NewSweeper(SweepOptions{
+		Source:     opts.Source,
+		Bands:      opts.Bands,
+		FFTSize:    opts.FFTSize,
+		SweepDwell: opts.SweepDwell,
+		GuardFrac:  opts.GuardFrac,
+		PeakOpts:   opts.PeakOpts,
+		Log:        log,
+	})
+	if err != nil {
+		return nil, err
+	}
+	progress(LiveHuntProgress{Phase: PhaseSweeping, Detail: "scanning bands"})
+	return sw.Sweep(ctx, func(centerHz uint32, peaks []Peak) {
+		progress(LiveHuntProgress{Phase: PhaseSweeping, CenterHz: centerHz,
+			Detail: fmt.Sprintf("%d peak(s)", len(peaks))})
+	})
+}
+
+// finishSurvey stamps the finish time, sorts the inventory, and clears an empty
+// trunking map so callers can treat System==nil as "no system found".
+func finishSurvey(sv *SignalSurvey) *SignalSurvey {
+	sv.FinishedAt = time.Now()
+	sv.sortSignals()
+	if sv.System != nil {
+		sv.System.sortAll()
+		if len(sv.System.Sites) == 0 && len(sv.System.Talkgroups) == 0 {
+			sv.System = nil
+		}
+	}
+	return sv
+}
+
+// channelize decimates wideband IQ to ~targetHz by an integer factor, band-
+// limiting the carrier at DC. It returns the decimated buffer and its actual
+// rate. When the source is already at or below targetHz it is returned
+// unchanged (the test FileIQSource runs at the channel rate directly).
+func channelize(iq []complex64, rateHz, targetHz uint32) ([]complex64, uint32) {
+	if rateHz <= targetHz || len(iq) == 0 {
+		return iq, rateHz
+	}
+	m := int((float64(rateHz) / float64(targetHz)) + 0.5)
+	if m < 2 {
+		return iq, rateHz
+	}
+	out := dsp.NewResampler(1, m, 16, 7.0).Process(nil, iq)
+	return out, rateHz / uint32(m)
+}

--- a/internal/hunt/livesurvey_test.go
+++ b/internal/hunt/livesurvey_test.go
@@ -1,0 +1,109 @@
+package hunt
+
+import (
+	"context"
+	"math"
+	"math/rand"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/siglab"
+	"github.com/MattCheramie/GopherTrunk/internal/survey"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// fmNoise builds a constant-envelope analog-FM carrier modulated by deterministic
+// voice-like (low-pass noise) audio — a stand-in for a conventional FM channel.
+func fmNoise(n int, rateHz, deviationHz float64, seed int64) []complex64 {
+	r := rand.New(rand.NewSource(seed))
+	raw := make([]float64, n)
+	for i := range raw {
+		raw[i] = r.NormFloat64()
+	}
+	const win = 12
+	msg := make([]float64, n)
+	var acc float64
+	for i := 0; i < n; i++ {
+		acc += raw[i]
+		if i >= win {
+			acc -= raw[i-win]
+		}
+		msg[i] = acc / win
+	}
+	out := make([]complex64, n)
+	var phase float64
+	k := 2 * math.Pi * deviationHz / rateHz
+	for i, m := range msg {
+		phase += k * m
+		out[i] = complex(float32(math.Cos(phase)), float32(math.Sin(phase)))
+	}
+	return out
+}
+
+// TestRunLiveSurvey_MixedTraffic probes two carriers — a synthesized P25 control
+// channel and an analog FM voice channel — and asserts the survey classifies and
+// routes each correctly: the P25 carrier folds into the discovered system, the
+// analog carrier is reported as active NBFM.
+func TestRunLiveSurvey_MixedTraffic(t *testing.T) {
+	p25, meta, err := siglab.Synthesize(siglab.SynthOptions{
+		Protocol: trunking.ProtocolP25,
+		Format:   siglab.FormatF32,
+	})
+	if err != nil {
+		t.Fatalf("Synthesize: %v", err)
+	}
+	rate := uint32(meta.SampleRateHz)
+
+	const p25Hz = 851_000_000
+	const fmHz = 154_000_000
+	analog := fmNoise(len(p25), float64(rate), 3000, 7)
+
+	src := NewMappedIQSource(map[uint32][]complex64{
+		p25Hz: p25,
+		fmHz:  analog,
+	}, rate)
+
+	sv, reports, err := RunLiveSurvey(context.Background(), LiveHuntOptions{
+		Source:        src,
+		Candidates:    []uint32{p25Hz, fmHz},
+		DwellSeconds:  float64(len(p25)) / float64(rate),
+		MinConfidence: 0.3,
+		Name:          "Survey Test",
+	})
+	if err != nil {
+		t.Fatalf("RunLiveSurvey: %v", err)
+	}
+	if len(sv.Signals) != 2 {
+		t.Fatalf("len(Signals) = %d, want 2", len(sv.Signals))
+	}
+
+	byFreq := map[uint32]DetectedSignal{}
+	for _, s := range sv.Signals {
+		byFreq[s.FreqHz] = s
+	}
+
+	// P25 carrier → trunk control, folded into the system.
+	p25Sig := byFreq[p25Hz]
+	if p25Sig.Class != survey.ClassTrunkControl {
+		t.Errorf("p25 carrier class = %q, want trunk-control\n  features: %+v", p25Sig.Class, p25Sig.Features)
+	}
+	if p25Sig.Trunking == nil || !p25Sig.Trunking.Locked {
+		t.Errorf("p25 carrier: expected a locked trunking ref, got %+v", p25Sig.Trunking)
+	}
+	if sv.System == nil || len(sv.System.Sites) == 0 {
+		t.Fatalf("expected a discovered system with at least one site, got %+v", sv.System)
+	}
+
+	// Analog carrier → active NBFM.
+	fmSig := byFreq[fmHz]
+	if fmSig.Class != survey.ClassNBFM {
+		t.Errorf("fm carrier class = %q, want nbfm\n  features: %+v", fmSig.Class, fmSig.Features)
+	}
+	if fmSig.Analog == nil || !fmSig.Analog.Active {
+		t.Errorf("fm carrier: expected an active analog report, got %+v", fmSig.Analog)
+	}
+
+	// The trunking branch reports through the shared export tail.
+	if len(reports) == 0 {
+		t.Errorf("expected at least one trunking CaptureReport")
+	}
+}

--- a/internal/hunt/manager.go
+++ b/internal/hunt/manager.go
@@ -52,8 +52,10 @@ type Manager struct {
 	mu         sync.Mutex
 	runID      int
 	state      RunState
+	runSurvey  bool // the active/last run is a survey (drives RunStatus.Mode)
 	progress   LiveHuntProgress
 	sys        *DiscoveredSystem
+	survey     *SignalSurvey
 	reports    []CaptureReport
 	err        string
 	startedAt  time.Time
@@ -74,6 +76,7 @@ const maxRunHistory = 10
 type runRecord struct {
 	id      int
 	sys     *DiscoveredSystem
+	survey  *SignalSurvey
 	reports []CaptureReport
 }
 
@@ -98,13 +101,18 @@ type RunStatus struct {
 	RunID      int              `json:"run_id"`
 	State      RunState         `json:"state"`
 	Running    bool             `json:"running"`
+	Mode       string           `json:"mode"` // "hunt" | "survey"
 	Progress   LiveHuntProgress `json:"progress"`
 	Sites      int              `json:"sites"`
 	Talkgroups int              `json:"talkgroups"`
 	SystemName string           `json:"system_name,omitempty"`
-	Error      string           `json:"error,omitempty"`
-	StartedAt  time.Time        `json:"started_at,omitempty"`
-	FinishedAt time.Time        `json:"finished_at,omitempty"`
+	// Signals is the classified-carrier inventory of a survey run (nil for a
+	// plain hunt). It is the survey's primary result, rendered by the cockpit.
+	Signals []DetectedSignal `json:"signals,omitempty"`
+	Error   string           `json:"error,omitempty"`
+
+	StartedAt  time.Time `json:"started_at,omitempty"`
+	FinishedAt time.Time `json:"finished_at,omitempty"`
 }
 
 // Start launches a live hunt with opts. It returns the new run id, or an error
@@ -122,7 +130,9 @@ func (m *Manager) Start(opts LiveHuntOptions) (int, error) {
 	m.cancel = cancel
 	m.state = StateRunActive
 	m.progress = LiveHuntProgress{Phase: PhaseSweeping}
+	m.runSurvey = opts.Survey
 	m.sys = nil
+	m.survey = nil
 	m.reports = nil
 	m.err = ""
 	m.startedAt = time.Now()
@@ -145,18 +155,33 @@ func (m *Manager) Start(opts LiveHuntOptions) (int, error) {
 func (m *Manager) run(ctx context.Context, id int, opts LiveHuntOptions) {
 	src, release, err := m.acquire(ctx, opts)
 	if err != nil {
-		m.finish(id, nil, nil, fmt.Errorf("acquire SDR: %w", err))
+		m.finish(id, nil, nil, nil, fmt.Errorf("acquire SDR: %w", err))
 		return
 	}
 	defer release()
 	opts.Source = src
 
+	if opts.Survey {
+		sv, reports, serr := RunLiveSurvey(ctx, opts)
+		m.finish(id, surveySystem(sv), sv, reports, serr)
+		return
+	}
 	sys, reports, err := RunLiveHunt(ctx, opts)
-	m.finish(id, sys, reports, err)
+	m.finish(id, sys, nil, reports, err)
+}
+
+// surveySystem safely extracts the discovered system from a (possibly nil)
+// survey, so the export/commit tail sees the same *DiscoveredSystem a hunt run
+// produces.
+func surveySystem(sv *SignalSurvey) *DiscoveredSystem {
+	if sv == nil {
+		return nil
+	}
+	return sv.System
 }
 
 // finish records the terminal state of a run and publishes hunt.done.
-func (m *Manager) finish(id int, sys *DiscoveredSystem, reports []CaptureReport, err error) {
+func (m *Manager) finish(id int, sys *DiscoveredSystem, sv *SignalSurvey, reports []CaptureReport, err error) {
 	m.mu.Lock()
 	if id != m.runID {
 		m.mu.Unlock()
@@ -173,11 +198,12 @@ func (m *Manager) finish(id int, sys *DiscoveredSystem, reports []CaptureReport,
 	default:
 		m.state = StateRunDone
 	}
-	if sys != nil {
+	m.survey = sv
+	if sys != nil || sv != nil {
 		m.sys = sys
 		m.reports = reports
 		// Retain in the bounded history (newest last; drop oldest over cap).
-		m.history = append(m.history, runRecord{id: id, sys: sys, reports: reports})
+		m.history = append(m.history, runRecord{id: id, sys: sys, survey: sv, reports: reports})
 		if len(m.history) > maxRunHistory {
 			m.history = m.history[len(m.history)-maxRunHistory:]
 		}
@@ -212,6 +238,7 @@ func (m *Manager) statusLocked() RunStatus {
 		RunID:      m.runID,
 		State:      m.state,
 		Running:    m.state == StateRunActive,
+		Mode:       "hunt",
 		Progress:   m.progress,
 		Error:      m.err,
 		StartedAt:  m.startedAt,
@@ -222,7 +249,24 @@ func (m *Manager) statusLocked() RunStatus {
 		st.Talkgroups = len(m.sys.Talkgroups)
 		st.SystemName = m.sys.DisplayName()
 	}
+	if m.runSurvey {
+		st.Mode = "survey"
+	}
+	if m.survey != nil {
+		st.Signals = m.survey.Signals
+	}
 	return st
+}
+
+// CurrentSurvey returns the latest run's signal inventory, or (nil, false) when
+// the latest run was a plain hunt or none has produced one yet.
+func (m *Manager) CurrentSurvey() (*SignalSurvey, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.survey == nil {
+		return nil, false
+	}
+	return m.survey, true
 }
 
 // Current returns the latest discovered system and its per-candidate reports,

--- a/internal/hunt/manager_test.go
+++ b/internal/hunt/manager_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/MattCheramie/GopherTrunk/internal/events"
 	"github.com/MattCheramie/GopherTrunk/internal/siglab"
+	"github.com/MattCheramie/GopherTrunk/internal/survey"
 	"github.com/MattCheramie/GopherTrunk/internal/trunking"
 )
 
@@ -37,6 +38,44 @@ func waitUntil(t *testing.T, d time.Duration, cond func() bool) {
 		time.Sleep(5 * time.Millisecond)
 	}
 	t.Fatal("condition not met within deadline")
+}
+
+func TestManager_SurveyModeReportsSignals(t *testing.T) {
+	src, dwell := p25Source(t)
+	mgr, err := NewManager(ManagerOptions{
+		Acquire: func(context.Context, LiveHuntOptions) (IQSource, func(), error) { return src, func() {}, nil },
+	})
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	if _, err := mgr.Start(LiveHuntOptions{
+		Survey:        true,
+		Candidates:    []uint32{851_000_000},
+		DwellSeconds:  dwell,
+		MinConfidence: 0.3,
+	}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	waitUntil(t, 15*time.Second, func() bool { return !mgr.Status().Running })
+
+	st := mgr.Status()
+	if st.State != StateRunDone {
+		t.Fatalf("state = %q, want done", st.State)
+	}
+	if st.Mode != "survey" {
+		t.Errorf("mode = %q, want survey", st.Mode)
+	}
+	if len(st.Signals) != 1 {
+		t.Fatalf("len(Signals) = %d, want 1", len(st.Signals))
+	}
+	// The single P25 candidate should be mapped as a trunk-control carrier.
+	if st.Signals[0].Class != survey.ClassTrunkControl {
+		t.Errorf("signal class = %q, want trunk-control", st.Signals[0].Class)
+	}
+	if sv, ok := mgr.CurrentSurvey(); !ok || sv.System == nil {
+		t.Error("CurrentSurvey() returned no survey/system")
+	}
 }
 
 func TestManager_StartRunsAndMapsSystem(t *testing.T) {

--- a/internal/hunt/survey.go
+++ b/internal/hunt/survey.go
@@ -1,0 +1,78 @@
+package hunt
+
+import (
+	"sort"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/survey"
+)
+
+// SignalSurvey is the inventory a live survey produces: every carrier the sweep
+// detected, classified by modulation family and (where the class warranted it)
+// decoded. It is the peer artifact of DiscoveredSystem — where DiscoveredSystem
+// maps one trunked system, SignalSurvey catalogues everything on the air across
+// the swept band(s). When the survey finds a trunking control channel it still
+// folds it into System, so a survey is a strict superset of a hunt: it yields
+// the same system map plus the surrounding signal landscape.
+type SignalSurvey struct {
+	StartedAt  time.Time        `json:"started_at"`
+	FinishedAt time.Time        `json:"finished_at"`
+	Signals    []DetectedSignal `json:"signals"`
+	// System is the trunked system accumulated from the trunk-control carriers,
+	// or nil when none was found. It is exported exactly like a hunt result.
+	System *DiscoveredSystem `json:"system,omitempty"`
+}
+
+// DetectedSignal is one classified (and possibly decoded) carrier in a survey.
+// Exactly one of Trunking / Analog / Pages is populated, per the Class.
+type DetectedSignal struct {
+	FreqHz       uint32             `json:"freq_hz"`
+	SNRDb        float32            `json:"snr_db"`
+	OccupiedBwHz uint32             `json:"occupied_bw_hz"`
+	Class        survey.SignalClass `json:"class"`
+	Confidence   float64            `json:"confidence"`
+	BaudHz       float64            `json:"baud_hz,omitempty"`
+
+	// Decode summary — set by the router for the carriers it could decode.
+	Trunking *TrunkingRef        `json:"trunking,omitempty"`
+	Analog   *survey.AnalogReport `json:"analog,omitempty"`
+	Pages    []survey.PageRef    `json:"pages,omitempty"`
+
+	// Features carries the raw classifier measurements for diagnostics.
+	Features survey.ClassFeatures `json:"features"`
+	// Error notes a per-carrier failure (tune/capture), leaving Class as-is.
+	Error string `json:"error,omitempty"`
+}
+
+// TrunkingRef summarises the trunking decode of a carrier the router handed to
+// the siglab identify path. It mirrors the fields of a CaptureReport that are
+// meaningful at the inventory level; the full system map lives in Survey.System.
+type TrunkingRef struct {
+	Protocol   string  `json:"protocol"`
+	Confidence float64 `json:"confidence"`
+	Locked     bool    `json:"locked"`
+	ControlHz  uint32  `json:"control_hz,omitempty"`
+}
+
+// sortSignals orders the inventory by frequency so the output is deterministic
+// (golden tests, stable diffs), mirroring DiscoveredSystem.sortAll.
+func (s *SignalSurvey) sortSignals() {
+	sort.Slice(s.Signals, func(i, j int) bool { return s.Signals[i].FreqHz < s.Signals[j].FreqHz })
+}
+
+// Counts tallies the inventory by broad category for status summaries.
+func (s *SignalSurvey) Counts() (trunking, analog, paging, other int) {
+	for _, sig := range s.Signals {
+		switch {
+		case sig.Class == survey.ClassTrunkControl || sig.Class == survey.ClassTrunkVoice:
+			trunking++
+		case len(sig.Pages) > 0 || sig.Class == survey.ClassPaging:
+			paging++
+		case sig.Class == survey.ClassNBFM || sig.Class == survey.ClassWideFM || sig.Class == survey.ClassAM:
+			analog++
+		default:
+			other++
+		}
+	}
+	return
+}

--- a/internal/hunt/survey.go
+++ b/internal/hunt/survey.go
@@ -34,9 +34,9 @@ type DetectedSignal struct {
 	BaudHz       float64            `json:"baud_hz,omitempty"`
 
 	// Decode summary — set by the router for the carriers it could decode.
-	Trunking *TrunkingRef        `json:"trunking,omitempty"`
+	Trunking *TrunkingRef         `json:"trunking,omitempty"`
 	Analog   *survey.AnalogReport `json:"analog,omitempty"`
-	Pages    []survey.PageRef    `json:"pages,omitempty"`
+	Pages    []survey.PageRef     `json:"pages,omitempty"`
 
 	// Features carries the raw classifier measurements for diagnostics.
 	Features survey.ClassFeatures `json:"features"`

--- a/internal/survey/analog.go
+++ b/internal/survey/analog.go
@@ -10,10 +10,10 @@ import (
 // IQ-power squelch and CTCSS/DCS detectors that gate the live analog scanner —
 // so the survey's analog verdict matches what the scanner would do.
 type AnalogReport struct {
-	Active   bool    `json:"active"`            // carrier power above squelch
-	PowerDbFS float64 `json:"power_dbfs"`        // measured RMS power
-	CTCSSHz  float64 `json:"ctcss_hz,omitempty"` // detected CTCSS tone, 0 if none
-	DCSCode  string  `json:"dcs_code,omitempty"` // detected DCS code, "" if none
+	Active    bool    `json:"active"`             // carrier power above squelch
+	PowerDbFS float64 `json:"power_dbfs"`         // measured RMS power
+	CTCSSHz   float64 `json:"ctcss_hz,omitempty"` // detected CTCSS tone, 0 if none
+	DCSCode   string  `json:"dcs_code,omitempty"` // detected DCS code, "" if none
 }
 
 // analogSquelchDbFS is the carrier-present threshold (dBFS) for the survey. It

--- a/internal/survey/analog.go
+++ b/internal/survey/analog.go
@@ -1,0 +1,92 @@
+package survey
+
+import (
+	"github.com/MattCheramie/GopherTrunk/internal/scanner/conventional"
+)
+
+// AnalogReport summarises a conventional analog carrier: whether it is keyed up
+// (carrier present) and any sub-audible squelch tone/code identifying the
+// system. It reuses the conventional scanner's primitives — the same
+// IQ-power squelch and CTCSS/DCS detectors that gate the live analog scanner —
+// so the survey's analog verdict matches what the scanner would do.
+type AnalogReport struct {
+	Active   bool    `json:"active"`            // carrier power above squelch
+	PowerDbFS float64 `json:"power_dbfs"`        // measured RMS power
+	CTCSSHz  float64 `json:"ctcss_hz,omitempty"` // detected CTCSS tone, 0 if none
+	DCSCode  string  `json:"dcs_code,omitempty"` // detected DCS code, "" if none
+}
+
+// analogSquelchDbFS is the carrier-present threshold (dBFS) for the survey. It
+// matches the conventional scanner's default working point: a unity-amplitude
+// tone is 0 dBFS, and a keyed FM carrier sits well above the noise floor.
+const analogSquelchDbFS = -30
+
+// standardCTCSSTones is the 38-tone EIA CTCSS set, in Hz. Scanning all of them
+// blind is cheap (one Goertzel each) and identifies the repeater's tone.
+var standardCTCSSTones = []float64{
+	67.0, 69.3, 71.9, 74.4, 77.0, 79.7, 82.5, 85.4, 88.5, 91.5,
+	94.8, 97.4, 100.0, 103.5, 107.2, 110.9, 114.8, 118.8, 123.0, 127.3,
+	131.8, 136.5, 141.3, 146.2, 151.4, 156.7, 162.2, 167.9, 173.8, 179.9,
+	186.2, 192.8, 203.5, 210.7, 218.1, 225.7, 233.6, 241.8,
+}
+
+// standardDCSCodes is the common EIA DCS (DPL) code set, as 3-digit octal
+// strings. The blind scan tries each; a match identifies the digital squelch.
+var standardDCSCodes = []string{
+	"023", "025", "026", "031", "032", "043", "047", "051", "054", "065",
+	"071", "072", "073", "074", "114", "115", "116", "125", "131", "132",
+	"134", "143", "152", "155", "156", "162", "165", "172", "174", "205",
+	"223", "226", "243", "244", "245", "251", "261", "263", "265", "271",
+	"306", "311", "315", "331", "343", "346", "351", "364", "365", "371",
+	"411", "412", "413", "423", "431", "432", "445", "464", "465", "466",
+	"503", "506", "516", "532", "546", "565", "606", "612", "624", "627",
+	"631", "632", "654", "662", "664", "703", "712", "723", "731", "732",
+	"734", "743", "754",
+}
+
+// AnalyzeAnalogFM measures a baseband analog-FM carrier: carrier-present power
+// plus a blind CTCSS-tone and DCS-code scan. iq is the channelised baseband
+// capture and inputRateHz its sample rate. Returns the report (Active=false
+// when no carrier clears squelch).
+func AnalyzeAnalogFM(iq []complex64, inputRateHz uint32) *AnalogReport {
+	rep := &AnalogReport{PowerDbFS: conventional.PowerDbFS(iq)}
+	rep.Active = rep.PowerDbFS >= analogSquelchDbFS
+	if !rep.Active {
+		return rep
+	}
+	rep.CTCSSHz = scanCTCSS(iq, float64(inputRateHz))
+	rep.DCSCode = scanDCS(iq, float64(inputRateHz))
+	return rep
+}
+
+// scanCTCSS runs the standard CTCSS tones against the buffer and returns the
+// first that locks (0 when none). Detectors are independent, so the first
+// Present() wins; ties are rare because the reverse-bin rejection in
+// CTCSSDetector keeps adjacent tones from co-triggering.
+func scanCTCSS(iq []complex64, rateHz float64) float64 {
+	for _, hz := range standardCTCSSTones {
+		det := conventional.NewCTCSSDetector(conventional.CTCSSConfig{SampleHz: rateHz, TargetHz: hz})
+		if det == nil {
+			continue
+		}
+		if det.Process(iq) {
+			return hz
+		}
+	}
+	return 0
+}
+
+// scanDCS runs the common DCS codes against the buffer and returns the first
+// that locks ("" when none).
+func scanDCS(iq []complex64, rateHz float64) string {
+	for _, code := range standardDCSCodes {
+		det := conventional.NewDCSDetector(conventional.DCSConfig{SampleHz: rateHz, Code: code})
+		if det == nil {
+			continue
+		}
+		if det.Process(iq) {
+			return det.Code()
+		}
+	}
+	return ""
+}

--- a/internal/survey/classify.go
+++ b/internal/survey/classify.go
@@ -31,17 +31,17 @@ import (
 type SignalClass string
 
 const (
-	ClassUnknown        SignalClass = "unknown"        // no carrier / too weak to classify
-	ClassAM             SignalClass = "am"             // amplitude modulation (non-constant envelope)
-	ClassNBFM           SignalClass = "nbfm"           // narrowband analog FM (≤ ~16 kHz)
-	ClassWideFM         SignalClass = "wfm"            // wideband analog FM (broadcast / ~150–200 kHz)
-	ClassFSK            SignalClass = "fsk"            // 2-level frequency-shift keying
-	ClassC4FM           SignalClass = "c4fm"           // 4-level FSK (P25 C4FM / YSF family)
-	ClassPSK            SignalClass = "psk"            // phase-shift keying (π/4-DQPSK and friends)
-	ClassContinuousData SignalClass = "data"           // continuous digital carrier, family unresolved
-	ClassPaging         SignalClass = "paging"         // FSK at a paging baud (512/1200/1600/2400)
-	ClassTrunkControl   SignalClass = "trunk-control"  // assigned by the router after a CC lock
-	ClassTrunkVoice     SignalClass = "trunk-voice"    // assigned by the router: decoded, no CC lock
+	ClassUnknown        SignalClass = "unknown"       // no carrier / too weak to classify
+	ClassAM             SignalClass = "am"            // amplitude modulation (non-constant envelope)
+	ClassNBFM           SignalClass = "nbfm"          // narrowband analog FM (≤ ~16 kHz)
+	ClassWideFM         SignalClass = "wfm"           // wideband analog FM (broadcast / ~150–200 kHz)
+	ClassFSK            SignalClass = "fsk"           // 2-level frequency-shift keying
+	ClassC4FM           SignalClass = "c4fm"          // 4-level FSK (P25 C4FM / YSF family)
+	ClassPSK            SignalClass = "psk"           // phase-shift keying (π/4-DQPSK and friends)
+	ClassContinuousData SignalClass = "data"          // continuous digital carrier, family unresolved
+	ClassPaging         SignalClass = "paging"        // FSK at a paging baud (512/1200/1600/2400)
+	ClassTrunkControl   SignalClass = "trunk-control" // assigned by the router after a CC lock
+	ClassTrunkVoice     SignalClass = "trunk-voice"   // assigned by the router: decoded, no CC lock
 )
 
 // ClassFeatures are the raw DSP measurements behind a classification. They are

--- a/internal/survey/classify.go
+++ b/internal/survey/classify.go
@@ -1,0 +1,578 @@
+// Package survey turns a detected carrier into a classified signal. Where the
+// hunt package's sweeper finds where energy is (carriers above the noise
+// floor), survey answers what each carrier is: a cheap, blind, per-carrier
+// classifier that names the modulation family (analog NBFM/WFM, AM, digital
+// FSK/C4FM/PSK, continuous data) plus an occupied-bandwidth estimate, and the
+// conventional decoders (POCSAG/FLEX paging, analog-FM activity) that turn a
+// classified carrier into a decode summary.
+//
+// survey deliberately depends only downward — on the dsp primitives and the
+// existing radio decoders — and never on hunt, so the hunt package can import
+// it to route swept candidates without an import cycle. The trunking
+// identify→decode→map path stays in siglab/hunt; survey hands a candidate off
+// to it (via hunt) only when the class warrants the (expensive) full identify.
+package survey
+
+import (
+	"math"
+	"math/cmplx"
+	"sort"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/demod"
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/fft"
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/window"
+)
+
+// SignalClass names the modulation family the classifier assigns to a carrier.
+// It is intentionally coarse: the goal is to route a carrier to the right
+// decoder, not to fully demodulate it. A digital class that turns out to carry
+// a trunking control channel is refined to ClassTrunkControl/ClassTrunkVoice by
+// the router after the authoritative siglab identify.
+type SignalClass string
+
+const (
+	ClassUnknown        SignalClass = "unknown"        // no carrier / too weak to classify
+	ClassAM             SignalClass = "am"             // amplitude modulation (non-constant envelope)
+	ClassNBFM           SignalClass = "nbfm"           // narrowband analog FM (≤ ~16 kHz)
+	ClassWideFM         SignalClass = "wfm"            // wideband analog FM (broadcast / ~150–200 kHz)
+	ClassFSK            SignalClass = "fsk"            // 2-level frequency-shift keying
+	ClassC4FM           SignalClass = "c4fm"           // 4-level FSK (P25 C4FM / YSF family)
+	ClassPSK            SignalClass = "psk"            // phase-shift keying (π/4-DQPSK and friends)
+	ClassContinuousData SignalClass = "data"           // continuous digital carrier, family unresolved
+	ClassPaging         SignalClass = "paging"         // FSK at a paging baud (512/1200/1600/2400)
+	ClassTrunkControl   SignalClass = "trunk-control"  // assigned by the router after a CC lock
+	ClassTrunkVoice     SignalClass = "trunk-voice"    // assigned by the router: decoded, no CC lock
+)
+
+// ClassFeatures are the raw DSP measurements behind a classification. They are
+// carried on the result so a survey is debuggable and golden-testable (the
+// class is a thresholded view of these numbers).
+type ClassFeatures struct {
+	// OccupiedBwHz is the contiguous bandwidth around DC standing above the
+	// noise floor (the carrier was tuned to baseband before classification).
+	OccupiedBwHz uint32 `json:"occupied_bw_hz"`
+	// SNRDb is the peak-to-noise-floor ratio of the baseband spectrum.
+	SNRDb float64 `json:"snr_db"`
+	// EnvelopeCV is the coefficient of variation (std/mean) of |z[n]|. AM has
+	// a high CV; the constant-envelope angle modulations sit near zero.
+	EnvelopeCV float64 `json:"envelope_cv"`
+	// IFStd is the standard deviation of the FM-discriminator output
+	// (rad/sample), a proxy for peak deviation.
+	IFStd float64 `json:"if_std"`
+	// IFKurtosis is the excess kurtosis of the discriminator output. PSK is
+	// impulsive (high kurtosis: spikes at phase transitions, ~0 between);
+	// FSK/analog are flatter.
+	IFKurtosis float64 `json:"if_kurtosis"`
+	// BaudHz is the cyclostationary symbol-rate line found in the rectified
+	// discriminator spectrum, or 0 when none stands out (analog voice).
+	BaudHz float64 `json:"baud_hz"`
+	// BaudProminence is how far the baud line stands above the local median
+	// (ratio). Higher ⇒ a more confident digital call.
+	BaudProminence float64 `json:"baud_prominence"`
+	// IFModality is the number of levels detected in the discriminator
+	// histogram (2 ⇒ FSK, 4 ⇒ C4FM, 0/1 ⇒ analog or PSK-at-zero).
+	IFModality int `json:"if_modality"`
+}
+
+// Classification is the verdict for one carrier.
+type Classification struct {
+	Class        SignalClass   `json:"class"`
+	Confidence   float64       `json:"confidence"` // 0..1
+	OccupiedBwHz uint32        `json:"occupied_bw_hz"`
+	Features     ClassFeatures `json:"features"`
+}
+
+// minClassifySamples is the shortest baseband buffer worth classifying — below
+// this the spectral estimates are too noisy to trust.
+const minClassifySamples = 4096
+
+// nbfmMaxBwHz splits narrowband from wideband analog FM. 25 kHz channels (and
+// the ~16 kHz occupied bandwidth of 5 kHz-deviation voice) stay NBFM; broadcast
+// FM and other wide deviations land in WideFM.
+const nbfmMaxBwHz = 25_000
+
+// digitalProminence is the minimum rectified-discriminator baud-line prominence
+// (peak over band median) for a carrier to read as digital. Synthesised
+// FSK/C4FM lines run from the tens into the hundreds; analog voice stays in the
+// single digits, so the gap is wide.
+const digitalProminence = 15
+
+// pagingBauds are the symbol rates that route a 2-level FSK carrier to the
+// paging decoders. POCSAG runs at 512/1200/2400, FLEX at 1600.
+var pagingBauds = []float64{512, 1200, 1600, 2400}
+
+// Classify measures the baseband carrier in iq (already tuned to DC) and
+// returns its modulation family plus the features behind the call. It performs
+// no decoding and is cheap relative to a full siglab identify, so the router
+// can run it on every candidate and only pay for identify on the digital ones.
+func Classify(iq []complex64, rateHz float64) Classification {
+	feat := extractFeatures(iq, rateHz)
+	class, conf := decide(feat)
+	return Classification{
+		Class:        class,
+		Confidence:   conf,
+		OccupiedBwHz: feat.OccupiedBwHz,
+		Features:     feat,
+	}
+}
+
+// extractFeatures computes the full feature vector for a baseband capture.
+func extractFeatures(iq []complex64, rateHz float64) ClassFeatures {
+	var f ClassFeatures
+	if len(iq) < minClassifySamples || rateHz <= 0 {
+		return f
+	}
+
+	// 1. Occupied bandwidth + SNR from the windowed IQ power spectrum.
+	f.OccupiedBwHz, f.SNRDb = occupiedBandwidth(iq, rateHz)
+
+	// 2. Envelope coefficient of variation (AM vs constant-envelope).
+	f.EnvelopeCV = envelopeCV(iq)
+
+	// 3. FM-discriminator features: deviation, impulsiveness, the
+	//    cyclostationary baud line, and the level structure.
+	d := demod.NewFM().Process(nil, iq)
+	mean := meanF32(d)
+	f.IFStd = stddevF32(d, mean)
+	f.IFKurtosis = excessKurtosisF32(d, mean, f.IFStd)
+	f.BaudHz, f.BaudProminence = baudLine(d, mean, rateHz)
+	// Level count is only meaningful for a digital carrier; compute it by
+	// folding the discriminator at the detected symbol rate (integrate-and-dump
+	// over each symbol period) so the levels are clean, the way a slicer sees
+	// them — at the raw sample level a pulse-shaped carrier smears its levels.
+	if f.BaudHz > 0 {
+		f.IFModality = symbolModality(d, mean, rateHz, f.BaudHz)
+	}
+	return f
+}
+
+// decide maps the feature vector to a class and a 0..1 confidence. The cascade
+// mirrors siglab's weighted-evidence style: each branch reports how cleanly its
+// gate was met so a marginal call reads as low confidence and a clear one high.
+func decide(f ClassFeatures) (SignalClass, float64) {
+	// No usable carrier.
+	if f.OccupiedBwHz == 0 || f.SNRDb < 3 {
+		return ClassUnknown, 0
+	}
+
+	// AM: a non-constant envelope is the defining trait. Constant-envelope
+	// angle modulations sit near CV≈0; voice AM runs well above 0.15.
+	if f.EnvelopeCV > 0.15 {
+		conf := clamp01((f.EnvelopeCV - 0.15) / 0.3)
+		return ClassAM, 0.5 + 0.5*conf
+	}
+
+	// Digital: a strong cyclostationary baud line in the rectified
+	// discriminator is the key-independent marker of symbol transitions.
+	// Analog voice (continuous, speech-shaped) produces only a smooth
+	// roll-off whose largest bin barely clears the median. The classifier is
+	// the coarse router here — it names the family (PSK vs FSK) and carries the
+	// baud/level features; the authoritative fine call (which trunking protocol,
+	// 2-level vs C4FM) is made downstream by the paging decoders and the siglab
+	// identify the router hands a digital carrier to.
+	if f.BaudHz > 0 && f.BaudProminence >= digitalProminence {
+		conf := 0.5 + 0.5*clamp01((f.BaudProminence-digitalProminence)/30)
+		if f.IFKurtosis > 2 && f.IFModality <= 1 {
+			// Impulsive discriminator, energy piled at zero ⇒ phase modulation.
+			return ClassPSK, conf
+		}
+		if f.IFModality >= 4 {
+			return ClassC4FM, conf // clean 4-level fold (best-effort upgrade)
+		}
+		return ClassFSK, conf
+	}
+
+	// Analog FM: constant envelope, no baud line. Split by occupied bandwidth.
+	if f.OccupiedBwHz <= nbfmMaxBwHz {
+		return ClassNBFM, 0.6
+	}
+	return ClassWideFM, 0.6
+}
+
+// occupiedBandwidth returns the contiguous bandwidth around DC that stands
+// above the noise floor, and the carrier SNR. The capture is baseband (carrier
+// at DC), so the occupied span is the run of above-threshold bins bridging the
+// centre bin. Returns (0, 0) when no carrier stands out.
+func occupiedBandwidth(iq []complex64, rateHz float64) (uint32, float64) {
+	n := pow2Floor(len(iq))
+	if n > 8192 {
+		n = 8192
+	}
+	if n < 256 {
+		return 0, 0
+	}
+	pwr := powerSpectrumDb(iq[:n]) // FFT-shifted: DC in the middle
+	floor := percentile(pwr, 0.25)
+	peak := maxF32(pwr)
+	snr := float64(peak - floor)
+
+	const occThreshDb = 6
+	thresh := floor + occThreshDb
+	binHz := rateHz / float64(n)
+	dc := n / 2
+
+	// Walk outward from DC while bins stay above threshold.
+	lo, hi := dc, dc
+	for lo > 0 && pwr[lo-1] >= thresh {
+		lo--
+	}
+	for hi < n-1 && pwr[hi+1] >= thresh {
+		hi++
+	}
+	if pwr[dc] < thresh {
+		return 0, snr
+	}
+	bw := float64(hi-lo+1) * binHz
+	return uint32(math.Round(bw)), snr
+}
+
+// powerSpectrumDb windows iq, FFTs it, and returns per-bin power in dB,
+// FFT-shifted so DC lands at index n/2 (matching the sweeper's convention).
+func powerSpectrumDb(iq []complex64) []float32 {
+	n := len(iq)
+	win := window.Hann(n)
+	in := make([]complex128, n)
+	for i, s := range iq {
+		w := win[i]
+		in[i] = complex(float64(real(s))*w, float64(imag(s))*w)
+	}
+	out := fft.New(n).Forward(nil, in)
+	pwr := make([]float32, n)
+	half := n / 2
+	for i := 0; i < n; i++ {
+		dst := (i + half) % n
+		mag := cmplx.Abs(out[i])
+		p := mag * mag
+		if p < 1e-30 {
+			p = 1e-30
+		}
+		pwr[dst] = float32(10 * math.Log10(p))
+	}
+	return pwr
+}
+
+// baudLine searches the rectified-discriminator spectrum for a cyclostationary
+// symbol-rate line. Symbol transitions in a digital carrier recur at the baud
+// rate; rectifying the discriminator (|d - mean|) exposes that as a discrete
+// spectral line, while analog voice produces only a smooth roll-off. Returns
+// the line frequency in Hz and its prominence over the local median, or (0, 0).
+func baudLine(d []float32, mean float64, rateHz float64) (float64, float64) {
+	n := pow2Floor(len(d))
+	if n > 16384 {
+		n = 16384
+	}
+	if n < 1024 {
+		return 0, 0
+	}
+	// Rectify around the mean and remove DC so the transform isn't dominated
+	// by the (large) zero-frequency bin.
+	rect := make([]float64, n)
+	var rmean float64
+	for i := 0; i < n; i++ {
+		rect[i] = math.Abs(float64(d[i]) - mean)
+		rmean += rect[i]
+	}
+	rmean /= float64(n)
+	win := window.Hann(n)
+	in := make([]complex128, n)
+	for i := 0; i < n; i++ {
+		in[i] = complex((rect[i]-rmean)*win[i], 0)
+	}
+	out := fft.New(n).Forward(nil, in)
+
+	binHz := rateHz / float64(n)
+	// Plausible baud band: 300 Hz .. rate/3 (above any audio roll-off, below
+	// where a real baud line could fold).
+	loBin := int(300 / binHz)
+	if loBin < 1 {
+		loBin = 1
+	}
+	hiBin := n / 2
+	if maxBin := int((rateHz / 3) / binHz); maxBin < hiBin {
+		hiBin = maxBin
+	}
+	if hiBin <= loBin {
+		return 0, 0
+	}
+	mags := make([]float64, n/2)
+	for i := 0; i < n/2; i++ {
+		mags[i] = cmplx.Abs(out[i])
+	}
+	// Peak bin in the baud band.
+	peakBin, peakMag := loBin, 0.0
+	for i := loBin; i < hiBin; i++ {
+		if mags[i] > peakMag {
+			peakMag, peakBin = mags[i], i
+		}
+	}
+	if peakMag == 0 {
+		return 0, 0
+	}
+	// Prominence = peak / median of the band. A digital carrier's symbol-rate
+	// line stands far above the broadband floor; analog voice produces only a
+	// smooth roll-off whose largest bin barely clears the median.
+	med := medianOf(mags[loBin:hiBin])
+	if med <= 0 {
+		return 0, 0
+	}
+	return float64(peakBin) * binHz, peakMag / med
+}
+
+// symbolModality estimates the number of discrete levels a digital carrier
+// uses by folding the discriminator at the symbol rate: it integrates each
+// symbol period to one value (an integrate-and-dump, like the pager slicer),
+// then histograms those symbol values and counts the well-separated peaks.
+// 2 ⇒ binary FSK, 4 ⇒ C4FM, 1 ⇒ a carrier with no level structure (PSK/analog).
+func symbolModality(d []float32, mean, rateHz, baudHz float64) int {
+	sps := int(math.Round(rateHz / baudHz))
+	if sps < 2 || len(d) < sps*64 {
+		return 0
+	}
+	syms := make([]float32, 0, len(d)/sps)
+	for i := 0; i+sps <= len(d); i += sps {
+		var acc float64
+		for j := 0; j < sps; j++ {
+			acc += float64(d[i+j])
+		}
+		syms = append(syms, float32(acc/float64(sps)))
+	}
+	smean := meanF32(syms)
+	sstd := stddevF32(syms, smean)
+	if sstd <= 0 {
+		return 0
+	}
+
+	const bins = 64
+	const span = 3.0 // ±3σ
+	hist := make([]float64, bins)
+	for _, v := range syms {
+		x := (float64(v) - smean) / sstd // normalised
+		idx := int((x + span) / (2 * span) * float64(bins))
+		if idx < 0 || idx >= bins {
+			continue
+		}
+		hist[idx]++
+	}
+	// Heavy smoothing (three box passes) so the level clusters survive but
+	// quantisation ripple does not spawn spurious peaks.
+	sm := hist
+	for pass := 0; pass < 3; pass++ {
+		sm = boxSmooth3(sm)
+	}
+	peak := maxFloat(sm)
+	if peak == 0 {
+		return 0
+	}
+
+	// Collect candidate local maxima (strict max over ±2 bins) at least 12% of
+	// the global peak.
+	const minRel = 0.12
+	thresh := minRel * peak
+	type pk struct {
+		bin int
+		h   float64
+	}
+	var cands []pk
+	for i := 2; i < bins-2; i++ {
+		if sm[i] < thresh {
+			continue
+		}
+		if sm[i] >= sm[i-1] && sm[i] >= sm[i-2] && sm[i] > sm[i+1] && sm[i] >= sm[i+2] {
+			cands = append(cands, pk{i, sm[i]})
+		}
+	}
+	// Count peaks separated by a genuine valley: two adjacent candidates merge
+	// unless the minimum between them dips below 55% of the shorter peak. This
+	// yields 2 for binary FSK, 4 for C4FM, and 1 for a unimodal analog signal.
+	const valleyRatio = 0.55
+	modes := 0
+	var lastBin int
+	lastH := 0.0
+	for _, c := range cands {
+		if modes == 0 {
+			modes, lastBin, lastH = 1, c.bin, c.h
+			continue
+		}
+		valley := sm[lastBin]
+		for i := lastBin; i <= c.bin; i++ {
+			if sm[i] < valley {
+				valley = sm[i]
+			}
+		}
+		if valley < valleyRatio*math.Min(lastH, c.h) {
+			modes++
+			lastBin, lastH = c.bin, c.h
+		} else if c.h > lastH {
+			lastBin, lastH = c.bin, c.h // merge into the taller peak
+		}
+	}
+	return modes
+}
+
+// boxSmooth3 returns a 3-bin moving average of v (edge-clamped).
+func boxSmooth3(v []float64) []float64 {
+	out := make([]float64, len(v))
+	for i := range v {
+		s, c := v[i], 1.0
+		if i > 0 {
+			s += v[i-1]
+			c++
+		}
+		if i < len(v)-1 {
+			s += v[i+1]
+			c++
+		}
+		out[i] = s / c
+	}
+	return out
+}
+
+// IsPagingBaud reports whether baud is close to a POCSAG/FLEX signalling rate.
+// The router uses it to decide whether a digital FSK carrier is worth a paging
+// decode attempt before the (more expensive) trunking identify.
+func IsPagingBaud(baud float64) bool {
+	for _, b := range pagingBauds {
+		if math.Abs(baud-b)/b < 0.06 { // within 6%
+			return true
+		}
+	}
+	return false
+}
+
+// IsDigital reports whether c is one of the digital modulation families (the
+// classes the router forwards to the paging decoders or the trunking identify).
+func IsDigital(c SignalClass) bool {
+	switch c {
+	case ClassFSK, ClassC4FM, ClassPSK, ClassContinuousData, ClassPaging:
+		return true
+	default:
+		return false
+	}
+}
+
+// --- small numeric helpers (kept local so survey has no hunt dependency) ---
+
+func envelopeCV(iq []complex64) float64 {
+	if len(iq) == 0 {
+		return 0
+	}
+	var sum, sumSq float64
+	for _, s := range iq {
+		m := math.Hypot(float64(real(s)), float64(imag(s)))
+		sum += m
+		sumSq += m * m
+	}
+	n := float64(len(iq))
+	mean := sum / n
+	if mean <= 0 {
+		return 0
+	}
+	varr := sumSq/n - mean*mean
+	if varr < 0 {
+		varr = 0
+	}
+	return math.Sqrt(varr) / mean
+}
+
+func meanF32(d []float32) float64 {
+	if len(d) == 0 {
+		return 0
+	}
+	var s float64
+	for _, v := range d {
+		s += float64(v)
+	}
+	return s / float64(len(d))
+}
+
+func stddevF32(d []float32, mean float64) float64 {
+	if len(d) == 0 {
+		return 0
+	}
+	var s float64
+	for _, v := range d {
+		x := float64(v) - mean
+		s += x * x
+	}
+	return math.Sqrt(s / float64(len(d)))
+}
+
+func excessKurtosisF32(d []float32, mean, std float64) float64 {
+	if len(d) == 0 || std <= 0 {
+		return 0
+	}
+	var s float64
+	for _, v := range d {
+		x := (float64(v) - mean) / std
+		s += x * x * x * x
+	}
+	return s/float64(len(d)) - 3
+}
+
+// percentile returns the p-quantile (0..1) of vals.
+func percentile(vals []float32, p float64) float32 {
+	if len(vals) == 0 {
+		return 0
+	}
+	cp := append([]float32(nil), vals...)
+	sort.Slice(cp, func(i, j int) bool { return cp[i] < cp[j] })
+	idx := int(p * float64(len(cp)-1))
+	if idx < 0 {
+		idx = 0
+	}
+	if idx >= len(cp) {
+		idx = len(cp) - 1
+	}
+	return cp[idx]
+}
+
+func medianOf(vals []float64) float64 {
+	if len(vals) == 0 {
+		return 0
+	}
+	cp := append([]float64(nil), vals...)
+	sort.Float64s(cp)
+	return cp[len(cp)/2]
+}
+
+func maxF32(vals []float32) float32 {
+	m := float32(math.Inf(-1))
+	for _, v := range vals {
+		if v > m {
+			m = v
+		}
+	}
+	return m
+}
+
+func maxFloat(vals []float64) float64 {
+	m := math.Inf(-1)
+	for _, v := range vals {
+		if v > m {
+			m = v
+		}
+	}
+	return m
+}
+
+// pow2Floor returns the largest power of two ≤ n (0 for n < 1).
+func pow2Floor(n int) int {
+	if n < 1 {
+		return 0
+	}
+	p := 1
+	for p<<1 <= n {
+		p <<= 1
+	}
+	return p
+}
+
+func clamp01(v float64) float64 {
+	if v < 0 {
+		return 0
+	}
+	if v > 1 {
+		return 1
+	}
+	return v
+}

--- a/internal/survey/classify_test.go
+++ b/internal/survey/classify_test.go
@@ -1,0 +1,174 @@
+package survey
+
+import (
+	"math"
+	"math/rand"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/demod"
+)
+
+const testRateHz = 48_000.0
+
+// --- synthesis helpers (deterministic) ---
+
+func randDibits(n int, seed int64) []uint8 {
+	r := rand.New(rand.NewSource(seed))
+	out := make([]uint8, n)
+	for i := range out {
+		out[i] = uint8(r.Intn(4))
+	}
+	return out
+}
+
+func randBits(n int, seed int64) []byte {
+	r := rand.New(rand.NewSource(seed))
+	out := make([]byte, n)
+	for i := range out {
+		out[i] = byte(r.Intn(2))
+	}
+	return out
+}
+
+// lowpassNoise builds a deterministic voice-like message: white noise smoothed
+// by a moving average so its spectrum rolls off like speech (no discrete line).
+func lowpassNoise(n int, seed int64) []float64 {
+	r := rand.New(rand.NewSource(seed))
+	raw := make([]float64, n)
+	for i := range raw {
+		raw[i] = r.NormFloat64()
+	}
+	const win = 12 // ~moving average → low-pass
+	out := make([]float64, n)
+	var acc float64
+	for i := 0; i < n; i++ {
+		acc += raw[i]
+		if i >= win {
+			acc -= raw[i-win]
+		}
+		out[i] = acc / win
+	}
+	// Normalise to unit peak.
+	var peak float64
+	for _, v := range out {
+		if a := math.Abs(v); a > peak {
+			peak = a
+		}
+	}
+	if peak > 0 {
+		for i := range out {
+			out[i] /= peak
+		}
+	}
+	return out
+}
+
+// fmModulate frequency-modulates a real message into constant-envelope IQ.
+func fmModulate(msg []float64, rateHz, deviationHz float64) []complex64 {
+	out := make([]complex64, len(msg))
+	var phase float64
+	k := 2 * math.Pi * deviationHz / rateHz
+	for i, m := range msg {
+		phase += k * m
+		out[i] = complex(float32(math.Cos(phase)), float32(math.Sin(phase)))
+	}
+	return out
+}
+
+// amModulate builds a (DC-centred) AM signal: real-valued (1 + depth·msg).
+func amModulate(msg []float64, depth float64) []complex64 {
+	out := make([]complex64, len(msg))
+	for i, m := range msg {
+		out[i] = complex(float32(1+depth*m), 0)
+	}
+	return out
+}
+
+func TestClassify(t *testing.T) {
+	const nSamples = 24_000 // 0.5 s at 48 kHz
+
+	tests := []struct {
+		name    string
+		iq      []complex64
+		want    SignalClass     // exact class, or "" to skip the exact check
+		digital bool            // assert IsDigital(class) == digital
+		baud    float64         // if > 0, assert detected baud within 8%
+	}{
+		{
+			// 4-level C4FM reads as a digital FM-family carrier; siglab makes
+			// the precise "P25 C4FM" call downstream.
+			name:    "p25 c4fm",
+			iq:      demod.ModulateP25C4FM(randDibits(nSamples/10, 1), testRateHz, 1800),
+			digital: true,
+		},
+		{
+			name:    "gfsk 4800 baud",
+			iq:      demod.ModulateGFSK(randBits(nSamples/10, 2), 10, 4, 0.5, testRateHz, 2400),
+			want:    ClassFSK,
+			digital: true,
+			baud:    4800,
+		},
+		{
+			// A paging-baud FSK carrier; the router proves "paging" by decoding.
+			name:    "gfsk 1200 baud",
+			iq:      demod.ModulateGFSK(randBits(nSamples/40, 3), 40, 4, 0.5, testRateHz, 2400),
+			want:    ClassFSK,
+			digital: true,
+			baud:    1200,
+		},
+		{
+			name: "analog fm voice",
+			iq:   fmModulate(lowpassNoise(nSamples, 4), testRateHz, 3000),
+			want: ClassNBFM,
+		},
+		{
+			name: "am voice",
+			iq:   amModulate(lowpassNoise(nSamples, 5), 0.9),
+			want: ClassAM,
+		},
+		{
+			name: "silence → unknown",
+			iq:   make([]complex64, nSamples),
+			want: ClassUnknown,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Classify(tc.iq, testRateHz)
+			if tc.want != "" && got.Class != tc.want {
+				t.Errorf("Classify() = %q (conf %.2f), want %q\n  features: %+v",
+					got.Class, got.Confidence, tc.want, got.Features)
+			}
+			if IsDigital(got.Class) != tc.digital {
+				t.Errorf("IsDigital(%q) = %v, want %v\n  features: %+v",
+					got.Class, IsDigital(got.Class), tc.digital, got.Features)
+			}
+			if tc.baud > 0 {
+				if dev := math.Abs(got.Features.BaudHz-tc.baud) / tc.baud; dev > 0.08 {
+					t.Errorf("BaudHz = %.1f, want ≈%.0f (%.1f%% off)", got.Features.BaudHz, tc.baud, dev*100)
+				}
+			}
+		})
+	}
+}
+
+func TestClassifyShortInputIsUnknown(t *testing.T) {
+	got := Classify(make([]complex64, 100), testRateHz)
+	if got.Class != ClassUnknown {
+		t.Errorf("short input: got %q, want unknown", got.Class)
+	}
+}
+
+func TestIsPagingBaud(t *testing.T) {
+	for _, b := range []float64{512, 1200, 1600, 2400, 1180, 2450} {
+		if !IsPagingBaud(b) {
+			t.Errorf("IsPagingBaud(%g) = false, want true", b)
+		}
+	}
+	for _, b := range []float64{4800, 9600, 800} {
+		if IsPagingBaud(b) {
+			t.Errorf("IsPagingBaud(%g) = true, want false", b)
+		}
+	}
+}

--- a/internal/survey/classify_test.go
+++ b/internal/survey/classify_test.go
@@ -90,9 +90,9 @@ func TestClassify(t *testing.T) {
 	tests := []struct {
 		name    string
 		iq      []complex64
-		want    SignalClass     // exact class, or "" to skip the exact check
-		digital bool            // assert IsDigital(class) == digital
-		baud    float64         // if > 0, assert detected baud within 8%
+		want    SignalClass // exact class, or "" to skip the exact check
+		digital bool        // assert IsDigital(class) == digital
+		baud    float64     // if > 0, assert detected baud within 8%
 	}{
 		{
 			// 4-level C4FM reads as a digital FM-family carrier; siglab makes

--- a/internal/survey/pager.go
+++ b/internal/survey/pager.go
@@ -1,0 +1,145 @@
+package survey
+
+import (
+	"github.com/MattCheramie/GopherTrunk/internal/dsp"
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/demod"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/pager/flex"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/pager/pocsag"
+)
+
+// oversample is the resampled samples per bit the integrate-and-dump slicer
+// expects. It mirrors the live pager receivers (pocsag/flex receiver.Oversample
+// = 8) so a buffer decoded here behaves identically to the streaming path.
+const oversample = 8
+
+// pocsagBauds are the POCSAG signalling rates tried, fastest-first is not
+// important — the syncer rejects a wrong-rate stream (no sync codewords found),
+// so the rate that actually yields pages wins.
+var pocsagBauds = []uint32{1200, 512, 2400}
+
+// flexBaud is the single FLEX rate the decoder supports (1600 bps, 2-level).
+const flexBaud = 1600
+
+// PageRef is a protocol-neutral summary of one decoded pager message, suitable
+// for the survey inventory and JSON. It flattens the pocsag.Page / flex.Message
+// shapes the receivers publish to the bus.
+type PageRef struct {
+	Protocol  string `json:"protocol"`  // "pocsag" | "flex"
+	BaudHz    uint32 `json:"baud_hz"`   // signalling rate that decoded it
+	Capcode   uint32 `json:"capcode"`   // RIC (POCSAG) / capcode (FLEX)
+	Encoding  string `json:"encoding"`  // "alpha" | "numeric" | FLEX type name
+	Text      string `json:"text"`      // decoded payload
+	Corrected int    `json:"corrected"` // FEC bit corrections (signal-quality proxy)
+}
+
+// DecodePOCSAG runs the POCSAG decode pipeline over a baseband IQ buffer at each
+// candidate baud and returns the pages from the rate that decoded the most. It
+// reuses the exact FM→resample→slice→syncer chain the live receiver uses
+// (internal/radio/pager/pocsag/receiver), just over a fixed buffer instead of a
+// channel, so the protocol layer is unchanged.
+func DecodePOCSAG(iq []complex64, inputRateHz uint32) []PageRef {
+	var best []PageRef
+	for _, baud := range pocsagBauds {
+		bits := demodBits(iq, inputRateHz, baud)
+		if bits == nil {
+			continue
+		}
+		syncer := pocsag.NewSyncer()
+		var pages []pocsag.Page
+		for _, b := range bits {
+			pages = append(pages, syncer.Push(b)...)
+		}
+		if p := syncer.Flush(); p != nil {
+			pages = append(pages, *p)
+		}
+		if len(pages) <= len(best) {
+			continue
+		}
+		refs := make([]PageRef, 0, len(pages))
+		for _, p := range pages {
+			enc := "alpha"
+			if p.Encoding == pocsag.EncodingNumeric {
+				enc = "numeric"
+			}
+			refs = append(refs, PageRef{
+				Protocol: "pocsag", BaudHz: baud, Capcode: p.RIC,
+				Encoding: enc, Text: p.Text, Corrected: p.Corrected,
+			})
+		}
+		best = refs
+	}
+	return best
+}
+
+// DecodeFLEX runs the FLEX (1600 bps) decode pipeline over a baseband IQ buffer
+// and returns the decoded messages. It reuses the live FLEX receiver's pipeline
+// (internal/radio/pager/flex/receiver) over a fixed buffer.
+func DecodeFLEX(iq []complex64, inputRateHz uint32) []PageRef {
+	bits := demodBits(iq, inputRateHz, flexBaud)
+	if bits == nil {
+		return nil
+	}
+	dec := flex.NewDecoder()
+	var refs []PageRef
+	for _, b := range bits {
+		for _, m := range dec.Push(b) {
+			refs = append(refs, PageRef{
+				Protocol: "flex", BaudHz: flexBaud, Capcode: m.Capcode,
+				Encoding: m.Type.TypeName(), Text: m.Text, Corrected: m.Corrected,
+			})
+		}
+	}
+	return refs
+}
+
+// demodBits FM-demodulates iq, resamples to baud×oversample sps, and slices to
+// a bit stream with an integrate-and-dump + slow-mean slicer — the identical
+// front-end the pager receivers run. Returns nil when the input rate can't be
+// resampled to the requested bit rate.
+func demodBits(iq []complex64, inputRateHz uint32, baud uint32) []byte {
+	if len(iq) == 0 || inputRateHz == 0 || baud == 0 {
+		return nil
+	}
+	out := baud * oversample
+	g := gcdU32(out, inputRateHz)
+	L := int(out / g)
+	M := int(inputRateHz / g)
+	if L == 0 || M == 0 {
+		return nil
+	}
+	d := demod.NewFM().Process(nil, iq)
+	samples := dsp.NewRealResampler(L, M, 16, 7.0).Process(nil, d)
+
+	bits := make([]byte, 0, len(samples)/oversample)
+	var intAcc, meanEMA float32
+	var intCount int
+	var meanReady bool
+	for _, s := range samples {
+		intAcc += s
+		intCount++
+		if intCount < oversample {
+			continue
+		}
+		avg := intAcc / float32(oversample)
+		intAcc, intCount = 0, 0
+		if !meanReady {
+			meanEMA, meanReady = avg, true
+		} else {
+			meanEMA += (avg - meanEMA) * (1.0 / 64.0)
+		}
+		var bit byte
+		if avg > meanEMA {
+			bit = 1
+		}
+		bits = append(bits, bit)
+	}
+	return bits
+}
+
+// gcdU32 is Euclid's algorithm (mirrors the receivers' local gcd).
+func gcdU32(a, b uint32) uint32 {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}

--- a/internal/survey/pager_test.go
+++ b/internal/survey/pager_test.go
@@ -1,0 +1,58 @@
+package survey
+
+import (
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/demod"
+)
+
+// TestDemodBitsRoundTrip checks the buffer-mode FM→resample→slice adapter
+// recovers a known bit pattern from a GFSK-modulated carrier. It validates the
+// slicer that feeds the POCSAG/FLEX syncers without needing full page framing
+// (end-to-end page decode is covered against real fixtures).
+func TestDemodBitsRoundTrip(t *testing.T) {
+	const baud = 1200
+	const sps = testRateHz / baud // 40 samples/symbol at 48 kHz
+
+	want := randBits(2000, 42)
+	iq := demod.ModulateGFSK(want, int(sps), 4, 0.5, testRateHz, baud/2)
+
+	got := demodBits(iq, testRateHz, baud)
+	if len(got) < len(want)/2 {
+		t.Fatalf("recovered only %d bits from %d symbols", len(got), len(want))
+	}
+
+	// The slicer has filter/group delay and unknown polarity; find the best
+	// alignment (offset + inversion) and require a high match there.
+	best := bestBitMatch(want, got)
+	if best < 0.9 {
+		t.Errorf("best bit match = %.1f%%, want ≥ 90%%", best*100)
+	}
+}
+
+// bestBitMatch returns the highest fractional agreement between want and got
+// over a small offset search, considering both polarities.
+func bestBitMatch(want, got []byte) float64 {
+	best := 0.0
+	for _, invert := range []bool{false, true} {
+		for off := 0; off < 80 && off < len(got); off++ {
+			match, n := 0, 0
+			for i := 0; i+off < len(got) && i < len(want); i++ {
+				b := got[i+off]
+				if invert {
+					b ^= 1
+				}
+				if b == want[i] {
+					match++
+				}
+				n++
+			}
+			if n > 200 {
+				if f := float64(match) / float64(n); f > best {
+					best = f
+				}
+			}
+		}
+	}
+	return best
+}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -712,6 +712,7 @@ func (m *Model) dispatchWrite(r state.WriteRequest) tea.Cmd {
 			Bands:      r.Hunt.Bands,
 			Candidates: r.Hunt.Candidates,
 			NoSweep:    len(r.Hunt.Candidates) > 0 && len(r.Hunt.Bands) == 0,
+			Survey:     r.Hunt.Survey,
 			Name:       r.Hunt.Name,
 			Serial:     r.Hunt.Serial,
 			Protocol:   r.Hunt.Protocol,

--- a/internal/tui/client/types.go
+++ b/internal/tui/client/types.go
@@ -144,12 +144,25 @@ type HuntStatusDTO struct {
 	RunID      int    `json:"run_id"`
 	State      string `json:"state"`
 	Running    bool   `json:"running"`
+	Mode       string `json:"mode"` // "hunt" | "survey"
 	Phase      string `json:"phase"`
 	Detail     string `json:"detail"`
 	Sites      int    `json:"sites"`
 	Talkgroups int    `json:"talkgroups"`
 	SystemName string `json:"system_name"`
-	Error      string `json:"error"`
+	// Signals is the survey inventory (empty for a plain hunt). Only the
+	// fields the panel renders are decoded.
+	Signals []HuntSignalDTO `json:"signals"`
+	Error   string          `json:"error"`
+}
+
+// HuntSignalDTO mirrors the scalar fields of hunt.DetectedSignal the panel
+// renders — one classified carrier from a survey run.
+type HuntSignalDTO struct {
+	FreqHz       uint32  `json:"freq_hz"`
+	SNRDb        float32 `json:"snr_db"`
+	OccupiedBwHz uint32  `json:"occupied_bw_hz"`
+	Class        string  `json:"class"`
 }
 
 // ScannerStatusDTO mirrors api.ScannerStatus — the unified scanner

--- a/internal/tui/client/write.go
+++ b/internal/tui/client/write.go
@@ -91,6 +91,7 @@ type HuntStartRequest struct {
 	Bands      []string  `json:"bands,omitempty"`
 	Candidates []float64 `json:"candidates,omitempty"`
 	NoSweep    bool      `json:"no_sweep,omitempty"`
+	Survey     bool      `json:"survey,omitempty"`
 	Name       string    `json:"name,omitempty"`
 	Serial     string    `json:"serial,omitempty"`
 	Protocol   string    `json:"protocol,omitempty"`

--- a/internal/tui/panels/hunt.go
+++ b/internal/tui/panels/hunt.go
@@ -18,6 +18,7 @@ type HuntPanel struct {
 	bandsInput textinput.Model
 	nameInput  textinput.Model
 	editing    bool
+	survey     bool // the open form will start a survey rather than a hunt
 	focusName  bool // false ⇒ bands input focused, true ⇒ name input
 	inputErr   string
 }
@@ -39,12 +40,15 @@ func NewHunt() *HuntPanel {
 func (HuntPanel) Title() string { return "Hunt" }
 
 var (
-	huntStartKey = key.NewBinding(key.WithKeys("s"), key.WithHelp("s", "start run"))
-	huntStopKey  = key.NewBinding(key.WithKeys("x"), key.WithHelp("x", "stop run"))
-	huntEscKey   = key.NewBinding(key.WithKeys("esc"), key.WithHelp("esc", "cancel"))
+	huntStartKey  = key.NewBinding(key.WithKeys("s"), key.WithHelp("s", "start hunt"))
+	huntSurveyKey = key.NewBinding(key.WithKeys("v"), key.WithHelp("v", "start survey"))
+	huntStopKey   = key.NewBinding(key.WithKeys("x"), key.WithHelp("x", "stop run"))
+	huntEscKey    = key.NewBinding(key.WithKeys("esc"), key.WithHelp("esc", "cancel"))
 )
 
-func (HuntPanel) Keys() []key.Binding { return []key.Binding{huntStartKey, huntStopKey} }
+func (HuntPanel) Keys() []key.Binding {
+	return []key.Binding{huntStartKey, huntSurveyKey, huntStopKey}
+}
 
 func (p *HuntPanel) Update(msg tea.Msg, s *state.SharedState) (Panel, tea.Cmd) {
 	km, ok := msg.(tea.KeyMsg)
@@ -76,15 +80,24 @@ func (p *HuntPanel) Update(msg tea.Msg, s *state.SharedState) (Panel, tea.Cmd) {
 
 	switch {
 	case key.Matches(km, huntStartKey) && !s.Hunt.Running:
-		p.editing = true
-		p.focusName = false
-		p.inputErr = ""
-		p.bandsInput.Focus()
+		p.openForm(false)
+		return p, textinput.Blink
+	case key.Matches(km, huntSurveyKey) && !s.Hunt.Running:
+		p.openForm(true)
 		return p, textinput.Blink
 	case key.Matches(km, huntStopKey) && s.Hunt.Running:
 		return p, Emit(state.WriteRequest{Label: "stop hunt run", Kind: state.WriteKindHuntStop})
 	}
 	return p, nil
+}
+
+// openForm opens the start form for either a hunt or a survey run.
+func (p *HuntPanel) openForm(survey bool) {
+	p.editing = true
+	p.survey = survey
+	p.focusName = false
+	p.inputErr = ""
+	p.bandsInput.Focus()
 }
 
 func (p *HuntPanel) toggleFocus() {
@@ -115,11 +128,16 @@ func (p *HuntPanel) submit() tea.Cmd {
 		return nil
 	}
 	name := strings.TrimSpace(p.nameInput.Value())
+	survey := p.survey
+	label := "start hunt"
+	if survey {
+		label = "start survey"
+	}
 	p.closeForm()
 	return Emit(state.WriteRequest{
-		Label: "start hunt",
+		Label: label,
 		Kind:  state.WriteKindHuntStart,
-		Hunt:  &state.HuntStartReq{Bands: bands, Name: name},
+		Hunt:  &state.HuntStartReq{Bands: bands, Name: name, Survey: survey},
 	})
 }
 
@@ -175,17 +193,44 @@ func (p *HuntPanel) View(width, height int, focused bool, s *state.SharedState) 
 		fmt.Fprintf(&b, "Error:   %s\n", h.Error)
 	}
 
+	if h.Mode != "" {
+		fmt.Fprintf(&b, "Mode:    %s\n", h.Mode)
+	}
+
 	b.WriteString("\n")
 	if h.SystemName != "" {
 		fmt.Fprintf(&b, "Discovered: %s\n", h.SystemName)
 		fmt.Fprintf(&b, "  sites: %d   talkgroups: %d\n", h.Sites, h.Talkgroups)
-	} else {
+	} else if h.Mode != "survey" {
 		b.WriteString("No system discovered yet.\n")
+	}
+
+	// Survey inventory: list the classified carriers (most recent first up to
+	// a height-bounded cap so the panel doesn't overflow).
+	if len(h.Signals) > 0 {
+		fmt.Fprintf(&b, "Signals (%d):\n", len(h.Signals))
+		max := height - 12
+		if max < 1 {
+			max = 1
+		}
+		for i, sig := range h.Signals {
+			if i >= max {
+				fmt.Fprintf(&b, "  … %d more\n", len(h.Signals)-i)
+				break
+			}
+			fmt.Fprintf(&b, "  %9.4f MHz  %-13s  %4.1f kHz\n",
+				float64(sig.FreqHz)/1e6, sig.Class, float64(sig.OccupiedBwHz)/1e3)
+		}
 	}
 
 	b.WriteString("\n")
 	switch {
 	case p.editing:
+		mode := "hunt"
+		if p.survey {
+			mode = "survey"
+		}
+		fmt.Fprintf(&b, "(%s) ", mode)
 		b.WriteString(p.bandsInput.View() + "\n")
 		b.WriteString(p.nameInput.View() + "\n")
 		b.WriteString("[enter] start   [tab] next field   [esc] cancel\n")
@@ -195,7 +240,7 @@ func (p *HuntPanel) View(width, height int, focused bool, s *state.SharedState) 
 	case h.Running:
 		b.WriteString("[x] stop run\n")
 	default:
-		b.WriteString("[s] start a sweep   (or POST /api/v1/hunt/start)\n")
+		b.WriteString("[s] hunt   [v] survey\n")
 	}
 	if s.HuntErr != nil {
 		fmt.Fprintf(&b, "\n(status unavailable: %v)\n", s.HuntErr)

--- a/internal/tui/state/state.go
+++ b/internal/tui/state/state.go
@@ -181,6 +181,7 @@ type WriteRequest struct {
 type HuntStartReq struct {
 	Bands      []string  // "low:high" MHz
 	Candidates []float64 // MHz
+	Survey     bool      // classify+decode every carrier, not just trunking CCs
 	Name       string
 	Serial     string
 	Protocol   string

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -125,13 +125,29 @@ export interface HuntStatus {
   run_id: number;
   state: string;
   running: boolean;
+  mode?: string; // "hunt" | "survey"
   phase?: string;
   detail?: string;
   sites: number;
   talkgroups: number;
   system_name?: string;
+  signals?: DetectedSignal[];
   error?: string;
   system?: unknown;
+}
+
+// DetectedSignal mirrors hunt.DetectedSignal — one classified carrier in a
+// survey run.
+export interface DetectedSignal {
+  freq_hz: number;
+  snr_db: number;
+  occupied_bw_hz: number;
+  class: string;
+  confidence: number;
+  baud_hz?: number;
+  trunking?: { protocol: string; locked: boolean; control_hz?: number };
+  analog?: { active: boolean; ctcss_hz?: number; dcs_code?: string };
+  pages?: { protocol: string; capcode: number; text: string }[];
 }
 
 // HuntStartRequest mirrors api.HuntStartRequest (frequencies in MHz).
@@ -140,6 +156,7 @@ export interface HuntStartRequest {
   bands?: string[];
   candidates?: number[];
   no_sweep?: boolean;
+  survey?: boolean;
   protocol?: string;
   dwell_seconds?: number;
   name?: string;

--- a/web/src/panels/Hunt.tsx
+++ b/web/src/panels/Hunt.tsx
@@ -1,10 +1,29 @@
 import { useEffect, useState } from "react";
 import { api } from "../api/client";
 import { writes } from "../api/write";
-import type { HuntStatus } from "../api/types";
+import type { DetectedSignal, HuntStatus } from "../api/types";
 import { selectCanMutate, selectClientConfig, useShared } from "../store/shared";
 
 const POLL_INTERVAL_MS = 2_000;
+
+// signalDetail renders the per-class decode summary for one surveyed carrier.
+function signalDetail(sig: DetectedSignal): string {
+  if (sig.trunking) {
+    return `${sig.trunking.protocol}${sig.trunking.locked ? " (locked)" : ""}`;
+  }
+  if (sig.pages && sig.pages.length > 0) {
+    return `${sig.pages.length} page(s)`;
+  }
+  if (sig.analog?.active) {
+    const tone = sig.analog.ctcss_hz
+      ? ` CTCSS ${sig.analog.ctcss_hz.toFixed(1)}`
+      : sig.analog.dcs_code
+        ? ` DCS ${sig.analog.dcs_code}`
+        : "";
+    return `active${tone}`;
+  }
+  return "—";
+}
 
 // Hunt drives the live system-discovery (blind spectrum-sweep) cockpit: start a
 // run over operator-given bands (or a candidate list), watch its progress, and
@@ -23,6 +42,7 @@ export function Hunt() {
   const [county, setCounty] = useState("");
   const [serial, setSerial] = useState("");
   const [protocol, setProtocol] = useState("");
+  const [survey, setSurvey] = useState(false);
 
   useEffect(() => {
     let cancel = false;
@@ -56,6 +76,7 @@ export function Hunt() {
         bands: bandList.length ? bandList : undefined,
         candidates: candList.length ? candList : undefined,
         no_sweep: candList.length > 0 && bandList.length === 0,
+        survey: survey || undefined,
         name: name || undefined,
         state: stateCode || undefined,
         county: county || undefined,
@@ -94,15 +115,48 @@ export function Hunt() {
           </div>
         ) : null}
         {status?.error ? <div className="error">Error: {status.error}</div> : null}
+        {status?.mode ? (
+          <div>
+            Mode: <strong>{status.mode}</strong>
+          </div>
+        ) : null}
         {status?.system_name ? (
           <div>
             Discovered: <strong>{status.system_name}</strong> — {status.sites} site(s),{" "}
             {status.talkgroups} talkgroup(s)
           </div>
-        ) : (
+        ) : status?.mode === "survey" ? null : (
           <div>No system discovered yet.</div>
         )}
       </section>
+
+      {status?.signals && status.signals.length > 0 ? (
+        <section className="hunt-signals">
+          <h3>Signals ({status.signals.length})</h3>
+          <table>
+            <thead>
+              <tr>
+                <th>Frequency</th>
+                <th>Class</th>
+                <th>BW (kHz)</th>
+                <th>SNR (dB)</th>
+                <th>Decode</th>
+              </tr>
+            </thead>
+            <tbody>
+              {status.signals.map((sig) => (
+                <tr key={sig.freq_hz}>
+                  <td>{(sig.freq_hz / 1e6).toFixed(4)} MHz</td>
+                  <td>{sig.class}</td>
+                  <td>{(sig.occupied_bw_hz / 1e3).toFixed(1)}</td>
+                  <td>{sig.snr_db.toFixed(1)}</td>
+                  <td>{signalDetail(sig)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </section>
+      ) : null}
 
       <section className="hunt-controls">
         <label>
@@ -136,6 +190,10 @@ export function Hunt() {
         <label>
           Protocol (optional — default auto-identifies)
           <input value={protocol} onChange={(e) => setProtocol(e.target.value)} placeholder="p25" />
+        </label>
+        <label className="hunt-survey-toggle">
+          <input type="checkbox" checked={survey} onChange={(e) => setSurvey(e.target.checked)} />
+          Survey mode — classify &amp; decode every signal (analog, paging, trunking)
         </label>
         <div className="hunt-buttons">
           <button onClick={start} disabled={!canMutate || running}>


### PR DESCRIPTION
Add internal/survey: a blind per-carrier signal-type classifier (modulation
family + occupied bandwidth + cyclostationary baud line) plus buffer-mode
adapters around the existing POCSAG/FLEX slicers and the conventional CTCSS/DCS
detectors, reusing the dsp primitives and radio decoders rather than rebuilding
them.

Add hunt.SignalSurvey + RunLiveSurvey: the on-air sibling of RunLiveHunt that
sweeps a band, classifies every detected carrier, and routes it — trunking
carriers fold into the existing DiscoveredSystem map, paging/analog carriers
run their conventional decoders, the rest are recorded as classified-only.