### PR TITLE
P25 Phase 1 demodulator measurement harness

### DIFF
--- a/cmd/gophertrunk/main.go
+++ b/cmd/gophertrunk/main.go
@@ -71,11 +71,15 @@ func main() {
 	case "test":
 		runSiglabTest(os.Args[2:])
 	case "siglab":
-		// `siglab serve` launches the standalone web console; bare
-		// `siglab` (and any other subarg) stays the offline TUI.
-		if len(os.Args) > 2 && os.Args[2] == "serve" {
+		// `siglab serve` launches the standalone web console; `siglab sweep`
+		// runs the demod EVM/SNR-vs-SNR benchmark; bare `siglab` (and any
+		// other subarg) stays the offline TUI.
+		switch {
+		case len(os.Args) > 2 && os.Args[2] == "serve":
 			runSiglabServe(os.Args[3:])
-		} else {
+		case len(os.Args) > 2 && os.Args[2] == "sweep":
+			runSiglabSweep(os.Args[3:])
+		default:
 			runSiglabTUI(os.Args[2:])
 		}
 	case "config":

--- a/cmd/gophertrunk/p25_realcapture_metrics_test.go
+++ b/cmd/gophertrunk/p25_realcapture_metrics_test.go
@@ -1,0 +1,189 @@
+//go:build integration
+
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	p25phase1 "github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase1"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase1/metrics"
+	p25phase1rx "github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase1/receiver"
+	"github.com/MattCheramie/GopherTrunk/internal/siglab"
+)
+
+// p25MetricsExpected is the "expected" payload for samples/p25/*.metadata.json.
+// Every bound is optional: a zero/absent field is reported but not asserted, so
+// a capture can be dropped in to *measure* the demod before anyone commits to a
+// pass/fail threshold. See samples/p25/README.md.
+type p25MetricsExpected struct {
+	DemodMode     string  `json:"demod_mode"` // "c4fm" (default) or "cqpsk"
+	NAC           string  `json:"nac"`        // hex, e.g. "0x167"
+	MinNIDTrusted int     `json:"min_nid_trusted"`
+	MinTSBK       int     `json:"min_tsbk"`
+	MaxEVMPct     float64 `json:"max_evm_pct"`
+	MinSNRdB      float64 `json:"min_snr_db"`
+	MinSyncMargin int     `json:"min_sync_margin"`
+}
+
+// TestReplayP25RealCaptureMetrics is the skip-gated field-truth companion to
+// the synthetic sweep (sweep_test.go). When a samples/p25/*.cfile +
+// *.metadata.json pair is present it runs the real capture through the
+// production receiver, reports the demod-quality metrics the harness
+// measures — pre-FEC EVM, estimated SNR, FSW sync-margin, NID/TSBK yields —
+// and asserts whichever bounds the metadata declares. With no capture present
+// it skips. See samples/p25/README.md for the schema and how to drop a capture.
+func TestReplayP25RealCaptureMetrics(t *testing.T) {
+	cfilePath, metaPath := findRealairCapture(t, "p25")
+	if cfilePath == "" {
+		t.Skip("samples/p25/: no *.cfile present — drop a capture + metadata pair to run this test (see samples/p25/README.md)")
+	}
+	meta := loadRealairMetadata(t, metaPath)
+
+	var exp p25MetricsExpected
+	if len(meta.Expected) > 0 {
+		if err := json.Unmarshal(meta.Expected, &exp); err != nil {
+			t.Fatalf("parse expected payload: %v", err)
+		}
+	}
+
+	demodMode := p25phase1rx.DemodC4FM
+	rotations := p25phase1.RotationsC4FM
+	if exp.DemodMode == "cqpsk" || exp.DemodMode == "lsm" {
+		demodMode = p25phase1rx.DemodCQPSK
+		rotations = p25phase1.RotationsAll
+	}
+
+	// Load the GNU Radio cfile (interleaved little-endian float32 IQ).
+	raw, err := os.ReadFile(cfilePath)
+	if err != nil {
+		t.Fatalf("read capture: %v", err)
+	}
+	pairs := len(raw) / 8
+	if pairs == 0 {
+		t.Fatalf("capture %s has no samples", cfilePath)
+	}
+	iq := make([]complex64, pairs)
+	dec, _ := siglab.FormatF32.Decoder()
+	dec(raw[:pairs*8], iq)
+
+	// Control channel: collect the locked NAC + NID/TSBK yield breakdown.
+	bus := events.NewBus(1024)
+	sub := bus.Subscribe()
+	nacs := make(map[uint16]int)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for ev := range sub.C {
+			if ev.Kind != events.KindCCLocked {
+				continue
+			}
+			if ls, ok := ev.Payload.(p25phase1.LockState); ok {
+				nacs[ls.NAC]++
+			}
+		}
+	}()
+	cc := p25phase1.New(p25phase1.Options{
+		Bus:        bus,
+		Log:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+		SystemName: "p25-metrics-test",
+		Rotations:  rotations,
+	})
+
+	// Receiver with the metrics taps wired in.
+	var recovered []uint8
+	var soft []float32
+	var syms []complex64
+	rx := p25phase1rx.New(p25phase1rx.Options{
+		SampleRateHz: float64(meta.SampleRateHz),
+		DeviationHz:  1800.0,
+		DemodMode:    demodMode,
+		SoftSink:     func(s []float32) { soft = append(soft, s...) },
+		SymbolSink:   func(c []complex64) { syms = append(syms, c...) },
+		DibitSink: func(d []uint8, baseIdx int) {
+			recovered = append(recovered, d...)
+			cc.Process(d, baseIdx)
+		},
+	})
+
+	const chunk = 4096
+	for i := 0; i < len(iq); i += chunk {
+		end := i + chunk
+		if end > len(iq) {
+			end = len(iq)
+		}
+		rx.Process(iq[i:end])
+	}
+	sub.Close()
+	<-done
+
+	// EVM + SNR from the demod taps (constellation for CQPSK, soft eye for C4FM).
+	const warmupSkip = 256
+	var evm, snrEst float64
+	var modName string
+	if demodMode == p25phase1rx.DemodCQPSK {
+		modName = "cqpsk"
+		if len(syms) > warmupSkip {
+			syms = syms[warmupSkip:]
+		}
+		evm = metrics.EVMConstellation(syms)
+		snrEst = metrics.SNRM2M4Constellation(syms)
+	} else {
+		modName = "c4fm"
+		if len(soft) > warmupSkip {
+			soft = soft[warmupSkip:]
+		}
+		outer := metrics.EstimateOuterRailC4FM(soft)
+		evm = metrics.EVMC4FM(soft, outer)
+		snrEst = metrics.SNRResidualC4FM(soft, outer)
+	}
+
+	// FSW sync-margin distribution: run a standalone detector over the
+	// recovered dibits and fold the per-hit margins into the collector.
+	var coll metrics.Collector
+	det := p25phase1.NewSyncDetector(-1) // default tolerance 4
+	det.SetRotations(rotations)
+	_, _, margins, _ := det.ProcessWithMargin(nil, nil, nil, recovered, 0)
+	for _, m := range margins {
+		coll.AddSyncMargin(m)
+	}
+	sum := coll.Summarize()
+
+	stats := cc.Stats()
+	t.Logf("p25 real-capture metrics (%s, %s):", cfilePath, modName)
+	t.Logf("  EVM=%.1f%%  SNR≈%.1f dB  (soft/sym n=%d)", evm, snrEst, len(soft)+len(syms))
+	t.Logf("  sync margin: hits=%d  min=%d  median=%d  mean=%.2f", sum.SyncHits, sum.SyncMarginMin, sum.SyncMarginMedian, sum.SyncMarginMean)
+	t.Logf("  NID: trusted=%d marginal=%d failed=%d", stats.NIDTrusted, stats.NIDMarginal, stats.NIDFailed)
+	t.Logf("  TSBK: decoded=%d trellis-failed=%d crc-failed=%d", stats.TSBKDecoded, stats.TSBKTrellisFailed, stats.TSBKCRCFailed)
+	t.Logf("  locked NACs: %v", nacs)
+
+	// Assert the bounds the metadata declares (all optional).
+	if exp.MinNIDTrusted > 0 && stats.NIDTrusted < int64(exp.MinNIDTrusted) {
+		t.Errorf("NID trusted = %d, want ≥ %d", stats.NIDTrusted, exp.MinNIDTrusted)
+	}
+	if exp.MinTSBK > 0 && stats.TSBKDecoded < int64(exp.MinTSBK) {
+		t.Errorf("TSBK decoded = %d, want ≥ %d", stats.TSBKDecoded, exp.MinTSBK)
+	}
+	if exp.MaxEVMPct > 0 && evm > exp.MaxEVMPct {
+		t.Errorf("EVM = %.1f%%, want ≤ %.1f%%", evm, exp.MaxEVMPct)
+	}
+	if exp.MinSNRdB > 0 && snrEst < exp.MinSNRdB {
+		t.Errorf("SNR estimate = %.1f dB, want ≥ %.1f dB", snrEst, exp.MinSNRdB)
+	}
+	if exp.MinSyncMargin > 0 && sum.SyncHits > 0 && sum.SyncMarginMin < exp.MinSyncMargin {
+		t.Errorf("min sync margin = %d, want ≥ %d", sum.SyncMarginMin, exp.MinSyncMargin)
+	}
+	if exp.NAC != "" {
+		want, err := parseHex16(exp.NAC)
+		if err != nil {
+			t.Fatalf("metadata expected.nac=%q: %v", exp.NAC, err)
+		}
+		if nacs[want] == 0 {
+			t.Errorf("expected NAC %#x never locked; saw %v", want, nacs)
+		}
+	}
+}

--- a/cmd/gophertrunk/p25_refcompare_test.go
+++ b/cmd/gophertrunk/p25_refcompare_test.go
@@ -1,0 +1,143 @@
+//go:build integration
+
+package main
+
+import (
+	"io"
+	"log/slog"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	p25phase1 "github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase1"
+	p25phase1rx "github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase1/receiver"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase1/refcompare"
+	"github.com/MattCheramie/GopherTrunk/internal/siglab"
+)
+
+// TestP25ReferenceCrossCheck runs an external reference decoder (OP25 /
+// DSD-FME) on the same samples/p25 capture GopherTrunk decodes and diffs the
+// two — the harness's GopherTrunk-vs-reference leg (see docs/demod-calibration.md).
+// It is doubly gated: it skips unless BOTH a samples/p25/*.cfile is present AND
+// P25_REFERENCE_CMD names how to invoke the reference. It never runs in normal
+// CI (external binary), so it is an operator/contributor instrument, not a gate.
+//
+// Configuration (environment):
+//
+//	P25_REFERENCE_CMD          shell command to decode the capture; the
+//	                           substring {} is replaced with the .cfile path.
+//	                           e.g. "dsd-fme -i {} -fp -o /dev/null"
+//	P25_REFERENCE_MIN_AGREE    NAC-set agreement required to pass (default 1.0)
+//	P25_REFERENCE_DEMOD        "c4fm" (default) or "cqpsk" for GopherTrunk's path
+func TestP25ReferenceCrossCheck(t *testing.T) {
+	cfilePath, metaPath := findRealairCapture(t, "p25")
+	if cfilePath == "" {
+		t.Skip("samples/p25/: no *.cfile present (see samples/p25/README.md)")
+	}
+	refCmd := os.Getenv("P25_REFERENCE_CMD")
+	if refCmd == "" {
+		t.Skip("P25_REFERENCE_CMD unset — set it to the reference decoder invocation (see docs/demod-calibration.md)")
+	}
+	meta := loadRealairMetadata(t, metaPath)
+
+	minAgree := 1.0
+	if s := os.Getenv("P25_REFERENCE_MIN_AGREE"); s != "" {
+		if v, err := strconv.ParseFloat(s, 64); err == nil {
+			minAgree = v
+		}
+	}
+	demodMode := p25phase1rx.DemodC4FM
+	rotations := p25phase1.RotationsC4FM
+	if os.Getenv("P25_REFERENCE_DEMOD") == "cqpsk" {
+		demodMode = p25phase1rx.DemodCQPSK
+		rotations = p25phase1.RotationsAll
+	}
+
+	// GopherTrunk decode → NAC set + TSBK frame yield.
+	gtNACs, gtFrames := gopherTrunkDecode(t, cfilePath, float64(meta.SampleRateHz), demodMode, rotations)
+
+	// Reference decode → scrape NACs from its output.
+	out := runReference(t, refCmd, cfilePath)
+	refNACs := refcompare.ParseNACs(out, nil)
+
+	rep := refcompare.Compare(gtNACs, refNACs, gtFrames, 0, minAgree, 0.8)
+	t.Logf("P25 GT-vs-reference cross-check (%s):", cfilePath)
+	t.Logf("  GopherTrunk NACs: %v (TSBKs=%d)", rep.GTNACs, rep.GTFrames)
+	t.Logf("  reference NACs:   %v", rep.RefNACs)
+	t.Logf("  %s", rep.Notes)
+	if !rep.Pass {
+		t.Errorf("cross-check failed: %s", rep.Notes)
+	}
+}
+
+// gopherTrunkDecode runs the production receiver + control channel on the
+// capture and returns the distinct locked NACs and the decoded-TSBK count.
+func gopherTrunkDecode(t *testing.T, cfilePath string, sampleRateHz float64, mode p25phase1rx.DemodMode, rot p25phase1.RotationSet) ([]uint16, int) {
+	t.Helper()
+	raw, err := os.ReadFile(cfilePath)
+	if err != nil {
+		t.Fatalf("read capture: %v", err)
+	}
+	pairs := len(raw) / 8
+	iq := make([]complex64, pairs)
+	dec, _ := siglab.FormatF32.Decoder()
+	dec(raw[:pairs*8], iq)
+
+	bus := events.NewBus(1024)
+	sub := bus.Subscribe()
+	nacSet := map[uint16]bool{}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for ev := range sub.C {
+			if ev.Kind != events.KindCCLocked {
+				continue
+			}
+			if ls, ok := ev.Payload.(p25phase1.LockState); ok {
+				nacSet[ls.NAC] = true
+			}
+		}
+	}()
+	cc := p25phase1.New(p25phase1.Options{
+		Bus: bus, Log: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		SystemName: "p25-refcompare", Rotations: rot,
+	})
+	rx := p25phase1rx.New(p25phase1rx.Options{
+		SampleRateHz: sampleRateHz, DeviationHz: 1800.0, DemodMode: mode,
+		DibitSink: func(d []uint8, baseIdx int) { cc.Process(d, baseIdx) },
+	})
+	const chunk = 4096
+	for i := 0; i < len(iq); i += chunk {
+		end := i + chunk
+		if end > len(iq) {
+			end = len(iq)
+		}
+		rx.Process(iq[i:end])
+	}
+	sub.Close()
+	<-done
+
+	nacs := make([]uint16, 0, len(nacSet))
+	for n := range nacSet {
+		nacs = append(nacs, n)
+	}
+	return nacs, int(cc.Stats().TSBKDecoded)
+}
+
+// runReference invokes the reference decoder, substituting {} with the capture
+// path, and returns its combined stdout+stderr.
+func runReference(t *testing.T, cmdTemplate, cfilePath string) string {
+	t.Helper()
+	cmdline := strings.ReplaceAll(cmdTemplate, "{}", cfilePath)
+	cmd := exec.Command("sh", "-c", cmdline)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		// Many reference tools exit non-zero at EOF; the output is still
+		// usable, so log rather than fail.
+		t.Logf("reference command exited with %v (output still parsed)", err)
+	}
+	return string(out)
+}

--- a/cmd/gophertrunk/siglab_render.go
+++ b/cmd/gophertrunk/siglab_render.go
@@ -118,6 +118,10 @@ func renderSignal(w io.Writer, s *siglab.SignalQuality) {
 			s.IQGainImbalanceDB, s.IQPhaseImbalanceDeg, s.IQImageRejectionDB)
 	}
 	fmt.Fprintf(w, "siglab: decode-error rate: %.2f per 1000 symbols\n", s.DecodeErrorRate)
+	if d := s.Demod; d != nil {
+		fmt.Fprintf(w, "siglab: demod (%s): EVM=%.1f%%  SNR≈%.1f dB  (n=%d symbols)\n",
+			d.Modulation, d.EVMPct, d.SNREstimateDB, d.SymbolsAnalyzed)
+	}
 }
 
 func renderP25Detail(w io.Writer, d *siglab.P25P1Detail) {

--- a/cmd/gophertrunk/siglab_sweep.go
+++ b/cmd/gophertrunk/siglab_sweep.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"encoding/csv"
+	"flag"
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/demod"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase1/metrics"
+	"github.com/MattCheramie/GopherTrunk/internal/siglab"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// runSiglabSweep is `gophertrunk siglab sweep`: it synthesizes P25 Phase 1 at a
+// ladder of injected SNRs on both demod paths, decodes each through the
+// production pipeline, and prints the measured demod-quality curve (lock, EVM,
+// estimated SNR) against the theoretical symbol-error-rate reference. It is the
+// ad-hoc, human-readable companion to the hard-gated sweep regression test —
+// the same instrument, on demand, for "did my demod change help?"
+func runSiglabSweep(args []string) {
+	fs := flag.NewFlagSet("siglab sweep", flag.ExitOnError)
+	snrMin := fs.Float64("snr-min", 2, "minimum injected SNR (dB)")
+	snrMax := fs.Float64("snr-max", 30, "maximum injected SNR (dB)")
+	snrStep := fs.Float64("snr-step", 2, "SNR step (dB)")
+	seed := fs.Int64("seed", 0x5175, "AWGN seed (reproducible draws)")
+	csvPath := fs.String("csv", "", "optional path to write the sweep as CSV")
+	fs.Parse(args)
+
+	if *snrStep <= 0 || *snrMax < *snrMin {
+		fmt.Fprintln(os.Stderr, "siglab sweep: need snr-step > 0 and snr-max >= snr-min")
+		os.Exit(2)
+	}
+
+	const sps = 48_000.0 / 4800.0 // P25 Phase 1 samples/symbol at 48 kHz
+	modes := []struct {
+		name       string
+		synthMod   string
+		demodMode  string
+		ref        func(esN0dB float64) float64
+		bitsPerSym float64
+	}{
+		{"c4fm", "c4fm", "", metrics.SER4PAM, 2},
+		{"cqpsk", "lsm", "cqpsk", metrics.SERCoherentQPSK, 2},
+	}
+
+	var rows []sweepRow
+
+	for _, m := range modes {
+		fmt.Printf("\n%s (vs theoretical reference):\n", m.name)
+		fmt.Printf("  %-8s %-8s %-7s %-8s %-9s\n", "SNR dB", "Es/N0", "lock", "EVM %", "SNR~ dB")
+		for snr := *snrMin; snr <= *snrMax+1e-9; snr += *snrStep {
+			synth := siglab.SynthOptions{
+				Protocol:    trunking.ProtocolP25,
+				Format:      siglab.FormatF32,
+				Modulation:  m.synthMod,
+				Impairments: demod.Impairments{SNRdB: snr, Seed: *seed},
+			}
+			cfg := siglab.Config{CollectIQDiag: true, DemodMode: m.demodMode}
+			res, _, err := siglab.SynthesizeAndAnalyze(synth, cfg, nil)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "siglab sweep: %s @ %.0f dB: %v\n", m.name, snr, err)
+				os.Exit(1)
+			}
+			r := sweepRow{mode: m.name, snrDB: snr, esN0dB: metrics.EsN0FromSNR(snr, sps), locked: res.Locked}
+			if res.Signal != nil && res.Signal.Demod != nil {
+				r.evmPct = res.Signal.Demod.EVMPct
+				r.snrEstDB = res.Signal.Demod.SNREstimateDB
+			}
+			rows = append(rows, r)
+			lock := "no"
+			if r.locked {
+				lock = "yes"
+			}
+			fmt.Printf("  %-8.1f %-8.1f %-7s %-8.1f %-9.1f\n", r.snrDB, r.esN0dB, lock, r.evmPct, r.snrEstDB)
+		}
+	}
+
+	if *csvPath != "" {
+		if err := writeSweepCSV(*csvPath, rows); err != nil {
+			fmt.Fprintf(os.Stderr, "siglab sweep: write csv: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Printf("\nwrote %s\n", *csvPath)
+	}
+}
+
+// sweepRow is one measured point of the demod sweep.
+type sweepRow struct {
+	mode             string
+	snrDB, esN0dB    float64
+	locked           bool
+	evmPct, snrEstDB float64
+}
+
+func writeSweepCSV(path string, rows []sweepRow) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	w := csv.NewWriter(f)
+	defer w.Flush()
+	if err := w.Write([]string{"mode", "snr_db", "es_n0_db", "locked", "evm_pct", "snr_est_db"}); err != nil {
+		return err
+	}
+	for _, r := range rows {
+		rec := []string{
+			r.mode,
+			strconv.FormatFloat(r.snrDB, 'f', 1, 64),
+			strconv.FormatFloat(r.esN0dB, 'f', 1, 64),
+			strconv.FormatBool(r.locked),
+			strconv.FormatFloat(r.evmPct, 'f', 2, 64),
+			strconv.FormatFloat(r.snrEstDB, 'f', 2, 64),
+		}
+		if err := w.Write(rec); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/cmd/gophertrunk/siglab_tui.go
+++ b/cmd/gophertrunk/siglab_tui.go
@@ -334,6 +334,10 @@ func (m siglabTUIModel) viewDashboard() string {
 				r.Signal.IQGainImbalanceDB, r.Signal.IQPhaseImbalanceDeg, r.Signal.IQImageRejectionDB))
 		}
 		b.WriteString(fmt.Sprintf("Decode-error rate: %.2f / 1000 symbols\n", r.Signal.DecodeErrorRate))
+		if d := r.Signal.Demod; d != nil {
+			b.WriteString(fmt.Sprintf("Demod (%s): EVM %.1f%%  SNR≈%.1f dB\n",
+				d.Modulation, d.EVMPct, d.SNREstimateDB))
+		}
 	}
 	b.WriteString("\n" + siglabDim.Render(m.status))
 	return b.String()

--- a/docs/demod-calibration.md
+++ b/docs/demod-calibration.md
@@ -1,0 +1,84 @@
+# P25 Phase 1 demodulator calibration & measurement
+
+This is the operator's guide to the P25 Phase 1 **demodulator measurement
+harness** — the instrument that answers, with numbers, whether a weak decode is
+the demodulator leaving SNR on the table or the signal simply being marginal.
+Before this harness the only signal was "the audio sounds bad" and a binary
+locked / not-locked; now every stage reports EVM, an SNR estimate, a pre-FEC
+error rate, and an FSW sync-margin, and the demod can be benchmarked against
+both the theoretical limit and a second real decoder.
+
+The harness has three legs. Each localizes the gap from a different direction.
+
+## 1. Versus theory — the synthetic sweep
+
+`internal/radio/p25/phase1/receiver/sweep_test.go` drives the real C4FM and
+CQPSK receivers across a seeded SNR ladder and measures the recovered
+symbol-error rate and SNR estimate at each step, comparing to the closed-form
+references in `internal/radio/p25/phase1/metrics` (coherent QPSK / 4-PAM).
+
+- `TestSweepImplementationLossBudget` is a **hard CI gate**: SER must fall
+  monotonically with SNR, the Es/N0 needed to reach 1% SER must stay within a
+  committed loss budget of theory, and the SNR estimator must track (CQPSK) or
+  rise with (C4FM) the injected SNR. The budgets are *regression ceilings*
+  calibrated from the measured baseline — re-run the test and read its `loss=`
+  log lines to re-derive them.
+
+Run it ad hoc, with a human-readable curve, via the CLI:
+
+```
+gophertrunk siglab sweep                       # both paths, default 2–30 dB
+gophertrunk siglab sweep -snr-min 6 -snr-max 20 -snr-step 1 -csv sweep.csv
+```
+
+Measured baseline at the time of writing: **CQPSK** sits ~3.85 dB off coherent
+QPSK at 1% SER (the ~2.3 dB π/4-DQPSK differential penalty plus ~1.5 dB
+implementation); **C4FM** sits ~24 dB off coherent 4-PAM — the FM-discriminator
+path is sharply noise-fragile and its soft-axis SNR estimate saturates near
+20 dB. That C4FM gap is the headroom any future demod work would target.
+
+## 2. Versus the field — real captures
+
+Drop a control-channel capture into `samples/p25/` (see `samples/p25/README.md`
+for the `.cfile` + `.metadata.json` schema). The integration-tagged, skip-gated
+`TestReplayP25RealCaptureMetrics` runs it through the production receiver and
+reports the pre-FEC EVM, estimated SNR, FSW sync-margin distribution, and
+NID/TSBK yields — asserting whichever `max_evm_pct` / `min_snr_db` /
+`min_sync_margin` bounds the metadata declares.
+
+```
+go test -tags integration -run TestReplayP25RealCaptureMetrics -v ./cmd/gophertrunk/
+```
+
+The same EVM/SNR appear on every `gophertrunk analyze` / `replay` run (and in
+the siglab web Compare tab) via the `demod` block of the result's signal
+quality, so you can read them off a live capture without writing a test.
+
+## 3. Versus another decoder — OP25 / DSD-FME cross-check
+
+`TestP25ReferenceCrossCheck` (integration-tagged, doubly skip-gated) runs an
+external reference decoder on the *same* capture and diffs the decoded NAC sets
+and frame yields, modelled on `internal/voice/calibrate`'s pass-bar. Combined
+with leg 1 it localizes a gap: if GopherTrunk trails both theory and the
+reference, the gap is GopherTrunk-specific; if GopherTrunk ≈ the reference and
+both trail theory, the signal is inherently marginal.
+
+Configure via environment and run:
+
+```
+export P25_REFERENCE_CMD='dsd-fme -i {} -fp -o /dev/null'   # {} = capture path
+export P25_REFERENCE_DEMOD=c4fm                              # or cqpsk
+export P25_REFERENCE_MIN_AGREE=1.0                           # NAC-set overlap bar
+go test -tags integration -run TestP25ReferenceCrossCheck -v ./cmd/gophertrunk/
+```
+
+The comparison math (`internal/radio/p25/phase1/refcompare`) is pure and
+unit-tested; only the binary invocation and output scraping live in the
+skip-gated test, so the tool/version-specific brittleness never reaches CI.
+
+## What this harness is *not*
+
+It does not re-architect the demodulator. It is the prerequisite that tells you
+whether — and precisely where — that is warranted. The large C4FM-vs-theory gap
+in leg 1 is the evidence such work would start from; the real-capture and
+reference legs say whether closing it would actually help a given site.

--- a/internal/radio/p25/phase1/metrics/collector.go
+++ b/internal/radio/p25/phase1/metrics/collector.go
@@ -1,0 +1,114 @@
+package metrics
+
+import (
+	"math"
+	"sort"
+)
+
+// Collector aggregates the pre-FEC error budget and sync-correlation margins
+// observed over a decode run into a Summary. It is the bridge between the
+// decoders' corrected-error counts (ParseNID, ParseLinkControl, DecodeTrellis,
+// imbe.DecodeChannelToFrame all return "how many symbols/bits the FEC had to
+// correct") and the SER/BER numbers a benchmark reports. The zero value is
+// ready to use; it is not safe for concurrent use.
+type Collector struct {
+	correctedSymbols int64 // FEC-corrected symbol errors across all units
+	totalSymbols     int64 // symbol budget those corrections were measured over
+	correctedBits    int64 // FEC-corrected bit errors across all units
+	totalBits        int64 // bit budget
+	uncorrectable    int64 // units the FEC could not resolve (CRC/parity still bad)
+	units            int64 // total units seen (for the uncorrectable rate)
+	margins          []int // per-FSW-hit correlation margin (tolerance+1 − bestMismatch)
+}
+
+// AddSymbolErrors records corrected symbol errors against a symbol budget
+// (e.g. a Trellis-decoded TSBK: corrected = the path metric, total = the coded
+// symbol count). Use for the symbol-domain pre-FEC SER.
+func (c *Collector) AddSymbolErrors(corrected, total int) {
+	if corrected < 0 {
+		corrected = 0
+	}
+	c.correctedSymbols += int64(corrected)
+	c.totalSymbols += int64(total)
+}
+
+// AddBitErrors records corrected bit errors against a bit budget (e.g. a
+// NID/BCH or Link-Control/RS unit: corrected = the decoder's error return,
+// total = the coded bit count). Use for the bit-domain pre-FEC BER.
+func (c *Collector) AddBitErrors(corrected, total int) {
+	if corrected < 0 {
+		corrected = 0
+	}
+	c.correctedBits += int64(corrected)
+	c.totalBits += int64(total)
+}
+
+// AddUnit records one decoded unit and whether the FEC failed to resolve it
+// (ok == false → uncorrectable). It drives the uncorrectable rate, which
+// distinguishes "many small corrections" (marginal but recoverable) from
+// "decode falling off a cliff."
+func (c *Collector) AddUnit(ok bool) {
+	c.units++
+	if !ok {
+		c.uncorrectable++
+	}
+}
+
+// AddSyncMargin records the correlation margin of one FSW hit: the number of
+// symbols by which the match cleared tolerance, margin = tolerance+1 −
+// bestMismatch (a perfect 24/24 hit at tolerance 4 gives margin 5). Higher is
+// healthier; a distribution pressed against 1 means sync is barely holding.
+func (c *Collector) AddSyncMargin(margin int) {
+	c.margins = append(c.margins, margin)
+}
+
+// Summary is the aggregated pre-FEC error and sync-margin report.
+type Summary struct {
+	// PreFECSymbolErrorRate is correctedSymbols / totalSymbols (NaN when no
+	// symbols were budgeted).
+	PreFECSymbolErrorRate float64 `json:"pre_fec_ser" yaml:"pre_fec_ser"`
+	// PreFECBitErrorRate is correctedBits / totalBits (NaN when no bits were
+	// budgeted).
+	PreFECBitErrorRate float64 `json:"pre_fec_ber" yaml:"pre_fec_ber"`
+	// UncorrectableRate is uncorrectable / units (NaN when no units seen).
+	UncorrectableRate float64 `json:"uncorrectable_rate" yaml:"uncorrectable_rate"`
+	// Units is the total decoded-unit count behind UncorrectableRate.
+	Units int64 `json:"units" yaml:"units"`
+	// SyncMarginMin / Mean / P50 summarize the FSW correlation-margin
+	// distribution; zero-valued when no FSW hits were recorded.
+	SyncMarginMin    int     `json:"sync_margin_min" yaml:"sync_margin_min"`
+	SyncMarginMean   float64 `json:"sync_margin_mean" yaml:"sync_margin_mean"`
+	SyncMarginMedian int     `json:"sync_margin_median" yaml:"sync_margin_median"`
+	SyncHits         int     `json:"sync_hits" yaml:"sync_hits"`
+}
+
+// Summarize computes the Summary. Rates with a zero denominator are reported
+// as NaN so a consumer can tell "measured zero" from "nothing measured."
+func (c *Collector) Summarize() Summary {
+	s := Summary{
+		PreFECSymbolErrorRate: ratioOrNaN(c.correctedSymbols, c.totalSymbols),
+		PreFECBitErrorRate:    ratioOrNaN(c.correctedBits, c.totalBits),
+		UncorrectableRate:     ratioOrNaN(c.uncorrectable, c.units),
+		Units:                 c.units,
+	}
+	if n := len(c.margins); n > 0 {
+		sorted := append([]int(nil), c.margins...)
+		sort.Ints(sorted)
+		s.SyncHits = n
+		s.SyncMarginMin = sorted[0]
+		s.SyncMarginMedian = sorted[n/2]
+		var sum int
+		for _, m := range sorted {
+			sum += m
+		}
+		s.SyncMarginMean = float64(sum) / float64(n)
+	}
+	return s
+}
+
+func ratioOrNaN(num, den int64) float64 {
+	if den <= 0 {
+		return math.NaN()
+	}
+	return float64(num) / float64(den)
+}

--- a/internal/radio/p25/phase1/metrics/collector_test.go
+++ b/internal/radio/p25/phase1/metrics/collector_test.go
@@ -1,0 +1,50 @@
+package metrics
+
+import (
+	"math"
+	"testing"
+)
+
+func TestCollectorRates(t *testing.T) {
+	var c Collector
+	c.AddBitErrors(2, 64) // NID-like unit
+	c.AddBitErrors(1, 64) // another
+	c.AddSymbolErrors(3, 196)
+	c.AddUnit(true)
+	c.AddUnit(true)
+	c.AddUnit(false) // one uncorrectable
+
+	s := c.Summarize()
+	approx(t, s.PreFECBitErrorRate, 3.0/128.0, 1e-12, "pre-FEC BER")
+	approx(t, s.PreFECSymbolErrorRate, 3.0/196.0, 1e-12, "pre-FEC SER")
+	approx(t, s.UncorrectableRate, 1.0/3.0, 1e-12, "uncorrectable rate")
+	if s.Units != 3 {
+		t.Errorf("units: got %d want 3", s.Units)
+	}
+}
+
+func TestCollectorEmptyRatesAreNaN(t *testing.T) {
+	var c Collector
+	s := c.Summarize()
+	if !math.IsNaN(s.PreFECBitErrorRate) || !math.IsNaN(s.PreFECSymbolErrorRate) || !math.IsNaN(s.UncorrectableRate) {
+		t.Error("zero-denominator rates should be NaN")
+	}
+}
+
+func TestCollectorSyncMargin(t *testing.T) {
+	var c Collector
+	for _, m := range []int{5, 3, 4, 1, 2} {
+		c.AddSyncMargin(m)
+	}
+	s := c.Summarize()
+	if s.SyncHits != 5 {
+		t.Errorf("hits: got %d want 5", s.SyncHits)
+	}
+	if s.SyncMarginMin != 1 {
+		t.Errorf("min: got %d want 1", s.SyncMarginMin)
+	}
+	if s.SyncMarginMedian != 3 { // sorted {1,2,3,4,5}, index 2
+		t.Errorf("median: got %d want 3", s.SyncMarginMedian)
+	}
+	approx(t, s.SyncMarginMean, 3.0, 1e-12, "mean margin")
+}

--- a/internal/radio/p25/phase1/metrics/estimator_test.go
+++ b/internal/radio/p25/phase1/metrics/estimator_test.go
@@ -1,0 +1,109 @@
+package metrics
+
+import (
+	"math"
+	"math/rand"
+	"testing"
+)
+
+// makeC4FMSoft builds n soft samples on the four ideal C4FM rails (outer,
+// ±outer/3) with additive Gaussian noise of the given sigma, seeded.
+func makeC4FMSoft(n int, outer, sigma float64, seed int64) []float32 {
+	rng := rand.New(rand.NewSource(seed))
+	inner := outer * c4fmInnerRatio
+	rails := [4]float64{-outer, -inner, inner, outer}
+	out := make([]float32, n)
+	for i := range out {
+		r := rails[rng.Intn(4)]
+		out[i] = float32(r + rng.NormFloat64()*sigma)
+	}
+	return out
+}
+
+func TestEVMC4FMCleanIsZero(t *testing.T) {
+	soft := makeC4FMSoft(4000, 1.0, 0, 1)
+	if evm := EVMC4FM(soft, 1.0); evm > 1e-6 {
+		t.Errorf("noise-free EVM should be ~0, got %g%%", evm)
+	}
+}
+
+func TestEVMC4FMTracksNoise(t *testing.T) {
+	// With outer=1 and sigma=0.05, the RMS residual is ~0.05, so EVM ≈ 5%.
+	soft := makeC4FMSoft(20000, 1.0, 0.05, 2)
+	evm := EVMC4FM(soft, 1.0)
+	approx(t, evm, 5.0, 0.5, "EVM at sigma=0.05")
+	// More noise → more EVM.
+	soft2 := makeC4FMSoft(20000, 1.0, 0.10, 3)
+	if EVMC4FM(soft2, 1.0) <= evm {
+		t.Error("EVM should grow with noise")
+	}
+}
+
+func TestEstimateOuterRailC4FM(t *testing.T) {
+	// Recover the outer rail from a moderately noisy stream.
+	soft := makeC4FMSoft(20000, 2.5, 0.10, 4)
+	got := EstimateOuterRailC4FM(soft)
+	approx(t, got, 2.5, 0.1, "recovered outer rail")
+}
+
+// makeQPSK builds n complex symbols on the ideal π/4 positions with circular
+// Gaussian noise of per-component sigma, scaled by an arbitrary gain.
+func makeQPSK(n int, gain, sigma float64, seed int64) []complex64 {
+	rng := rand.New(rand.NewSource(seed))
+	const s = math.Sqrt2 / 2
+	ideal := [4][2]float64{{s, s}, {-s, s}, {-s, -s}, {s, -s}}
+	out := make([]complex64, n)
+	for i := range out {
+		id := ideal[rng.Intn(4)]
+		out[i] = complex(
+			float32(gain*id[0]+rng.NormFloat64()*sigma),
+			float32(gain*id[1]+rng.NormFloat64()*sigma),
+		)
+	}
+	return out
+}
+
+func TestEVMConstellationCleanIsZero(t *testing.T) {
+	pts := makeQPSK(4000, 3.0, 0, 5) // arbitrary gain, no noise
+	if evm := EVMConstellation(pts); evm > 1e-3 {
+		t.Errorf("noise-free constellation EVM should be ~0, got %g%%", evm)
+	}
+}
+
+func TestEVMConstellationGainInvariant(t *testing.T) {
+	// Same noise relative to signal at two gains → same EVM (RMS-referenced).
+	a := EVMConstellation(makeQPSK(20000, 1.0, 0.05, 6))
+	b := EVMConstellation(makeQPSK(20000, 4.0, 0.20, 6)) // 4× gain, 4× sigma
+	approx(t, a, b, 0.5, "EVM gain-invariance")
+}
+
+func TestSNRFromEVMRoundTrip(t *testing.T) {
+	// EVM of 10% ⇒ SNR of 20 dB.
+	approx(t, SNRFromEVM(10), 20, 1e-9, "SNR from 10% EVM")
+	approx(t, SNRFromEVM(1), 40, 1e-9, "SNR from 1% EVM")
+}
+
+func TestSNRResidualC4FM(t *testing.T) {
+	// Construct a stream with a known SNR and check the estimate.
+	// Signal power of the rails {±1, ±1/3} is (1+1/9)/2 = 0.5556; with
+	// sigma=0.05 noise power is 0.0025, so SNR ≈ 10log10(0.5556/0.0025) ≈ 23.5 dB.
+	outer := 1.0
+	sigma := 0.05
+	soft := makeC4FMSoft(40000, outer, sigma, 7)
+	want := 10 * math.Log10(0.5555556/(sigma*sigma))
+	got := SNRResidualC4FM(soft, outer)
+	approx(t, got, want, 0.6, "C4FM residual SNR")
+}
+
+func TestSNRM2M4AgreesWithResidual(t *testing.T) {
+	// On a QPSK stream the moment estimator and the decision-directed
+	// residual estimator should land close.
+	pts := makeQPSK(40000, 1.0, 0.08, 8)
+	m2m4 := SNRM2M4Constellation(pts)
+	resid := SNRResidualConstellation(pts)
+	approx(t, m2m4, resid, 1.5, "M2M4 vs residual SNR")
+	// And both near the injected SNR: signal power per component sums to 1
+	// (unit modulus), noise power = 2·sigma² = 0.0128, SNR ≈ 19 dB.
+	want := 10 * math.Log10(1.0/(2*0.08*0.08))
+	approx(t, resid, want, 1.5, "residual SNR vs injected")
+}

--- a/internal/radio/p25/phase1/metrics/evm.go
+++ b/internal/radio/p25/phase1/metrics/evm.go
@@ -81,36 +81,67 @@ func EstimateOuterRailC4FM(soft []float32) float64 {
 	return a
 }
 
-// EVMConstellation returns the RMS error-vector magnitude of a complex symbol
-// constellation (the CQPSK / π/4-DQPSK path's post-carrier-recovery points) as
-// a percentage. Each point is normalized by the stream's RMS modulus to unit
-// reference, assigned to the nearest ideal QPSK position (±45°, ±135° on the
-// unit circle), and EVM is the RMS distance to that position in percent:
+// dqpskPhases is the number of distinct phase positions a π/4-DQPSK symbol
+// stream visits: the modulation alternates between two QPSK constellations
+// offset by 45°, so its pre-differential-decode points land on one of eight
+// evenly-spaced phases on the unit circle (0, 45, …, 315°). Assigning EVM
+// against only the four QPSK positions would charge a clean π/4-DQPSK signal
+// ~40% EVM for the symbols sitting on the *other* ring.
+const dqpskPhases = 8
+
+// EVMConstellation returns the RMS error-vector magnitude of a π/4-DQPSK
+// complex symbol constellation (the CQPSK path's post-carrier-recovery points,
+// pre differential decode) as a percentage. Each point is normalized by the
+// stream's RMS modulus to unit reference, assigned to the nearest of the eight
+// ideal π/4-DQPSK phases on the unit circle, and EVM is the RMS distance to
+// that position in percent:
 //
 //	EVM% = 100 · √(mean(|r̂ − ideal|²)),
 //
 // where r̂ is the point scaled so the reference radius is 1. Returns 0 for an
 // empty input. The reference is the RMS radius rather than a fixed scale, so
-// the estimate is independent of the AGC gain the points arrive at.
+// the estimate is independent of the AGC gain the points arrive at. (A plain
+// 4-point QPSK stream is a subset of the eight phases, so this stays correct
+// for it too.)
 func EVMConstellation(points []complex64) float64 {
 	if len(points) == 0 {
 		return 0
 	}
 	var sumSq float64
+	// 8th-power phase estimator: Σ exp(j·8·θ) concentrates the eight-phase
+	// modulation onto one tone, so its argument /8 is the common carrier-phase
+	// offset the recovery loop happened to lock at. Removing it makes the EVM
+	// invariant to that offset — without it a loop locked a few degrees off the
+	// grid would be charged sin(offset) of bogus dispersion (the clean signal
+	// reading tens of percent EVM that *fell* when noise was added).
+	var pwrReal, pwrImag float64
 	for _, p := range points {
-		sumSq += float64(real(p))*float64(real(p)) + float64(imag(p))*float64(imag(p))
+		i, q := float64(real(p)), float64(imag(p))
+		sumSq += i*i + q*q
+		ang := dqpskPhases * math.Atan2(q, i)
+		pwrReal += math.Cos(ang)
+		pwrImag += math.Sin(ang)
 	}
 	rms := math.Sqrt(sumSq / float64(len(points)))
 	if rms <= 0 {
 		return 0
 	}
-	// Ideal π/4-DQPSK / QPSK positions on the unit circle.
-	const s = math.Sqrt2 / 2 // sin(45°)=cos(45°)
-	ideal := [4][2]float64{{s, s}, {-s, s}, {-s, -s}, {s, -s}}
+	offset := math.Atan2(pwrImag, pwrReal) / dqpskPhases
+	cosO, sinO := math.Cos(-offset), math.Sin(-offset)
+
+	// Ideal π/4-DQPSK phase positions on the unit circle.
+	var ideal [dqpskPhases][2]float64
+	for k := range ideal {
+		ang := float64(k) * 2 * math.Pi / dqpskPhases
+		ideal[k] = [2]float64{math.Cos(ang), math.Sin(ang)}
+	}
 	var errSq float64
 	for _, p := range points {
-		i := float64(real(p)) / rms
-		q := float64(imag(p)) / rms
+		// Normalize to unit reference and derotate by the recovered offset.
+		ri := float64(real(p)) / rms
+		rq := float64(imag(p)) / rms
+		i := ri*cosO - rq*sinO
+		q := ri*sinO + rq*cosO
 		best := math.Inf(1)
 		for _, id := range ideal {
 			di := i - id[0]

--- a/internal/radio/p25/phase1/metrics/evm.go
+++ b/internal/radio/p25/phase1/metrics/evm.go
@@ -1,0 +1,126 @@
+package metrics
+
+import "math"
+
+// C4FM ideal rail ratios. The 4-level eye sits at ±outer and ±outer/3 (the
+// dibit centres +3,+1,−1,−3 scaled to the soft-sample units). innerRatio is
+// the inner rail as a fraction of the outer.
+const c4fmInnerRatio = 1.0 / 3.0
+
+// EVMC4FM returns the RMS error-vector magnitude of a C4FM soft-symbol stream
+// as a percentage, given the outer-rail reference level (the soft value an
+// ideal +3 symbol lands on — AGCTarget()·3/2, or the known modulator level).
+//
+// Each soft sample is assigned to the nearest of the four ideal rails
+// {−outer, −outer/3, +outer/3, +outer}; EVM is the RMS distance to that rail,
+// normalized to the outer rail and expressed in percent:
+//
+//	EVM% = 100 · √(mean((x − nearestRail)²)) / outer.
+//
+// A clean eye sits near a few percent; as the eye closes toward the slicer
+// thresholds EVM climbs past ~33% (the half-spacing between rails). Returns 0
+// for an empty input or a non-positive reference.
+func EVMC4FM(soft []float32, outer float64) float64 {
+	if len(soft) == 0 || outer <= 0 {
+		return 0
+	}
+	inner := outer * c4fmInnerRatio
+	rails := [4]float64{-outer, -inner, inner, outer}
+	var sumSq float64
+	for _, s := range soft {
+		x := float64(s)
+		best := math.Inf(1)
+		for _, r := range rails {
+			d := x - r
+			if d*d < best {
+				best = d * d
+			}
+		}
+		sumSq += best
+	}
+	return 100 * math.Sqrt(sumSq/float64(len(soft))) / outer
+}
+
+// EstimateOuterRailC4FM recovers the outer-rail reference from a C4FM soft
+// stream when the caller does not know it (e.g. the synthetic sweep, where the
+// soft level depends on the modulator and AGC). It runs a few fixed-point
+// iterations of "assign each sample to the nearest of {±a/3, ±a}, then set a to
+// the mean magnitude of the outer-assigned samples," seeded from the mean
+// magnitude. Returns 0 for an empty input.
+func EstimateOuterRailC4FM(soft []float32) float64 {
+	if len(soft) == 0 {
+		return 0
+	}
+	// Seed: mean|x| on a balanced 4-level stream is (outer + inner)·... ≈
+	// (1 + 1/3)/2·outer = 2/3·outer, so outer ≈ 1.5·mean|x|.
+	var meanAbs float64
+	for _, s := range soft {
+		meanAbs += math.Abs(float64(s))
+	}
+	meanAbs /= float64(len(soft))
+	a := 1.5 * meanAbs
+	if a <= 0 {
+		return 0
+	}
+	for iter := 0; iter < 8; iter++ {
+		var outerSum float64
+		var outerN int
+		mid := a * (1 + c4fmInnerRatio) / 2 // boundary between inner and outer rail
+		for _, s := range soft {
+			ax := math.Abs(float64(s))
+			if ax >= mid {
+				outerSum += ax
+				outerN++
+			}
+		}
+		if outerN == 0 {
+			break
+		}
+		a = outerSum / float64(outerN)
+	}
+	return a
+}
+
+// EVMConstellation returns the RMS error-vector magnitude of a complex symbol
+// constellation (the CQPSK / π/4-DQPSK path's post-carrier-recovery points) as
+// a percentage. Each point is normalized by the stream's RMS modulus to unit
+// reference, assigned to the nearest ideal QPSK position (±45°, ±135° on the
+// unit circle), and EVM is the RMS distance to that position in percent:
+//
+//	EVM% = 100 · √(mean(|r̂ − ideal|²)),
+//
+// where r̂ is the point scaled so the reference radius is 1. Returns 0 for an
+// empty input. The reference is the RMS radius rather than a fixed scale, so
+// the estimate is independent of the AGC gain the points arrive at.
+func EVMConstellation(points []complex64) float64 {
+	if len(points) == 0 {
+		return 0
+	}
+	var sumSq float64
+	for _, p := range points {
+		sumSq += float64(real(p))*float64(real(p)) + float64(imag(p))*float64(imag(p))
+	}
+	rms := math.Sqrt(sumSq / float64(len(points)))
+	if rms <= 0 {
+		return 0
+	}
+	// Ideal π/4-DQPSK / QPSK positions on the unit circle.
+	const s = math.Sqrt2 / 2 // sin(45°)=cos(45°)
+	ideal := [4][2]float64{{s, s}, {-s, s}, {-s, -s}, {s, -s}}
+	var errSq float64
+	for _, p := range points {
+		i := float64(real(p)) / rms
+		q := float64(imag(p)) / rms
+		best := math.Inf(1)
+		for _, id := range ideal {
+			di := i - id[0]
+			dq := q - id[1]
+			d := di*di + dq*dq
+			if d < best {
+				best = d
+			}
+		}
+		errSq += best
+	}
+	return 100 * math.Sqrt(errSq/float64(len(points)))
+}

--- a/internal/radio/p25/phase1/metrics/snr.go
+++ b/internal/radio/p25/phase1/metrics/snr.go
@@ -1,0 +1,109 @@
+package metrics
+
+import "math"
+
+// SNRFromEVM converts an error-vector-magnitude percentage to an SNR in dB
+// under the standard assumption that the residual error vector is the noise:
+//
+//	SNR ≈ 1 / EVM²  ⇒  SNR(dB) = −20·log10(EVM_fraction) = −20·log10(EVM%/100).
+//
+// It is the quick cross-check on the residual-variance estimators below — they
+// should agree to within a fraction of a dB on a clean AWGN stream. Returns
+// +Inf for a zero EVM (a noise-free constellation).
+func SNRFromEVM(evmPct float64) float64 {
+	if evmPct <= 0 {
+		return math.Inf(1)
+	}
+	return -20 * math.Log10(evmPct/100)
+}
+
+// SNRResidualC4FM estimates the symbol SNR of a C4FM soft stream in dB from
+// the residual of each sample about its nearest ideal rail. Signal power is
+// the mean square of the rails the samples were assigned to; noise power is
+// the mean square residual:
+//
+//	SNR(dB) = 10·log10( meanSquare(assignedRail) / meanSquare(x − assignedRail) ).
+//
+// outer is the outer-rail reference (see EstimateOuterRailC4FM when unknown).
+// This is modulation-aware (it knows the 4-level structure), so unlike a
+// blind moment estimator it stays unbiased on the non-constant-modulus C4FM
+// eye. Returns +Inf when the residual is zero and 0 for an empty input.
+func SNRResidualC4FM(soft []float32, outer float64) float64 {
+	if len(soft) == 0 || outer <= 0 {
+		return 0
+	}
+	inner := outer * c4fmInnerRatio
+	rails := [4]float64{-outer, -inner, inner, outer}
+	var sigSq, noiseSq float64
+	for _, s := range soft {
+		x := float64(s)
+		bestRail := rails[0]
+		best := math.Inf(1)
+		for _, r := range rails {
+			d := x - r
+			if d*d < best {
+				best = d * d
+				bestRail = r
+			}
+		}
+		sigSq += bestRail * bestRail
+		noiseSq += best
+	}
+	if noiseSq <= 0 {
+		return math.Inf(1)
+	}
+	return 10 * math.Log10(sigSq/noiseSq)
+}
+
+// SNRResidualConstellation estimates the symbol SNR of a complex constellation
+// in dB from the residual about the nearest ideal QPSK point. Signal power is
+// the reference radius squared (the RMS modulus); noise power is the mean
+// square distance to the assigned ideal point, in the same normalized units.
+// Returns +Inf for a zero residual and 0 for an empty input.
+func SNRResidualConstellation(points []complex64) float64 {
+	evm := EVMConstellation(points)
+	if evm <= 0 {
+		if len(points) == 0 {
+			return 0
+		}
+		return math.Inf(1)
+	}
+	return SNRFromEVM(evm)
+}
+
+// SNRM2M4Constellation estimates the SNR of a constant-modulus complex
+// constellation (QPSK / π/4-DQPSK) in dB using the modulation-agnostic
+// second/fourth-moment (M2M4) estimator. For a constant-modulus signal in
+// AWGN with M2 = E[|r|²] and M4 = E[|r|⁴]:
+//
+//	S = √(2·M2² − M4),   N = M2 − S,   SNR = S/N.
+//
+// It needs no decisions, so it cross-checks the decision-directed residual
+// estimator: the two should agree on a QPSK stream. It is *not* valid on the
+// non-constant-modulus C4FM soft axis (the kurtosis assumption breaks), so
+// there is deliberately no C4FM M2M4 variant. Returns 0 for an empty input or
+// when the moments fall outside the estimator's valid region.
+func SNRM2M4Constellation(points []complex64) float64 {
+	n := len(points)
+	if n == 0 {
+		return 0
+	}
+	var m2, m4 float64
+	for _, p := range points {
+		pwr := float64(real(p))*float64(real(p)) + float64(imag(p))*float64(imag(p))
+		m2 += pwr
+		m4 += pwr * pwr
+	}
+	m2 /= float64(n)
+	m4 /= float64(n)
+	disc := 2*m2*m2 - m4
+	if disc <= 0 {
+		return math.Inf(1) // essentially noise-free (M4 → M2²·... region)
+	}
+	s := math.Sqrt(disc)
+	noise := m2 - s
+	if noise <= 0 {
+		return math.Inf(1)
+	}
+	return 10 * math.Log10(s/noise)
+}

--- a/internal/radio/p25/phase1/metrics/theory.go
+++ b/internal/radio/p25/phase1/metrics/theory.go
@@ -103,6 +103,32 @@ func BER4PAM(ebN0dB float64) float64 {
 	return 0.75 * QFunc(math.Sqrt(0.8*g))
 }
 
+// SERCoherentQPSK is the symbol-error probability of ideal coherent QPSK in
+// AWGN, the symbol-domain companion to BERCoherentQPSK:
+//
+//	Ps = 2·Q(√(Es/N0)) − Q(√(Es/N0))²  ≈  2·Q(√(Es/N0)),
+//
+// expressed in Es/N0 (= 2·Eb/N0). The exact two-term form is used so the
+// reference stays accurate at low Es/N0 where the union-bound approximation
+// over-counts. This is the symbol-domain reference for the CQPSK sweep, whose
+// measured quantity is the recovered dibit (symbol) error rate.
+func SERCoherentQPSK(esN0dB float64) float64 {
+	q := QFunc(math.Sqrt(dBToLinear(esN0dB)))
+	return 2*q - q*q
+}
+
+// SER4PAM is the symbol-error probability of ideal coherent 4-PAM in AWGN,
+// the symbol-domain companion to BER4PAM:
+//
+//	Ps = 2(M−1)/M · Q(√(6/(M²−1)·Es/N0)) = 1.5·Q(√(0.4·Es/N0))  for M=4,
+//
+// in Es/N0. The C4FM sweep measures the recovered dibit (symbol) error rate,
+// so this — not the bit-domain BER4PAM — is the curve its loss budget is taken
+// against.
+func SER4PAM(esN0dB float64) float64 {
+	return 1.5 * QFunc(math.Sqrt(0.4*dBToLinear(esN0dB)))
+}
+
 // C4FMReferenceLossDB is the nominal Eb/N0 gap a non-coherent FM-discriminator
 // detector of C4FM carries over the coherent 4-PAM bound (BER4PAM). It is a
 // documentation/centering constant only — the actual CI loss budget is taken

--- a/internal/radio/p25/phase1/metrics/theory.go
+++ b/internal/radio/p25/phase1/metrics/theory.go
@@ -1,0 +1,129 @@
+// Package metrics measures P25 Phase 1 demodulator quality. It turns the
+// soft-symbol and corrected-error observations the receiver already exposes
+// into the four numbers that localize a weak-decode problem:
+//
+//   - EVM (error-vector magnitude / constellation dispersion),
+//   - SNR (estimated from the symbol residuals),
+//   - pre-FEC SER/BER (corrected-error counts over the bit/symbol budget),
+//   - sync-correlation margin (how far the FSW match cleared tolerance).
+//
+// Paired with the closed-form BER-vs-Eb/N0 references in this file, these let
+// a benchmark answer the question the field captures cannot: is the demod
+// leaving SNR on the table (an implementation gap, measurable as loss versus
+// the theoretical curve) or is the signal simply marginal (the demod tracks
+// the reference and there is nothing more to recover)?
+//
+// All functions here are pure: they take observations and return numbers.
+// The siglab integration wires them to the live receiver taps; the synthetic
+// sweep compares the measured curve to the references below.
+package metrics
+
+import "math"
+
+// QFunc is the Gaussian tail probability Q(x) = P(Z > x) for a standard
+// normal Z, expressed via the complementary error function:
+//
+//	Q(x) = ½·erfc(x / √2).
+//
+// It is the building block of every coherent-detection BER expression below.
+func QFunc(x float64) float64 {
+	return 0.5 * math.Erfc(x/math.Sqrt2)
+}
+
+// dBToLinear converts a dB power ratio to a linear ratio.
+func dBToLinear(dB float64) float64 { return math.Pow(10, dB/10) }
+
+// EsN0FromSNR converts the per-sample in-band SNR that the synthetic
+// impairment model injects (demod.Impairments.SNRdB — signal power over noise
+// power across the full sampled bandwidth Fs) into the per-symbol Es/N0.
+//
+// Noise power in bandwidth Fs is N0·Fs, so with Rsym symbols/s and
+// sps = Fs/Rsym samples/symbol:
+//
+//	Es/N0 = (S/Rsym)/N0 = (S / (N0·Fs)) · (Fs/Rsym) = SNR · sps.
+//
+// In dB: Es/N0(dB) = SNRdB + 10·log10(sps).
+func EsN0FromSNR(snrDB, sps float64) float64 {
+	if sps <= 0 {
+		return snrDB
+	}
+	return snrDB + 10*math.Log10(sps)
+}
+
+// EbN0FromEsN0 converts Es/N0 to Eb/N0 for a modulation carrying
+// bitsPerSymbol bits per symbol: Eb/N0 = Es/N0 / log2(M), i.e.
+// Eb/N0(dB) = Es/N0(dB) − 10·log10(bitsPerSymbol).
+func EbN0FromEsN0(esN0dB, bitsPerSymbol float64) float64 {
+	if bitsPerSymbol <= 0 {
+		return esN0dB
+	}
+	return esN0dB - 10*math.Log10(bitsPerSymbol)
+}
+
+// BERCoherentQPSK is the bit-error probability of ideal coherent,
+// Gray-coded QPSK (and BPSK — they share the curve) in AWGN:
+//
+//	Pb = Q(√(2·Eb/N0)).
+//
+// This is the matched-filter lower bound for the linear CQPSK path. The
+// production receiver detects π/4-DQPSK *differentially*, which costs a
+// fixed penalty over this bound (see DQPSKDifferentialPenaltyDB); use this
+// as the absolute reference and account for the penalty in the loss budget.
+func BERCoherentQPSK(ebN0dB float64) float64 {
+	g := dBToLinear(ebN0dB)
+	return QFunc(math.Sqrt(2 * g))
+}
+
+// DQPSKDifferentialPenaltyDB is the approximate Eb/N0 penalty differentially
+// coherent π/4-DQPSK pays over ideal coherent QPSK at the BER values of
+// interest (~10⁻²–10⁻³): roughly 2.3 dB (Proakis, differential vs coherent
+// QPSK). The CQPSK loss budget is taken relative to BERCoherentQPSK shifted
+// right by this amount, so the gate measures *implementation* loss on top of
+// the unavoidable differential-detection loss rather than charging the demod
+// for a penalty inherent to the chosen scheme.
+const DQPSKDifferentialPenaltyDB = 2.3
+
+// BER4PAM is the bit-error probability of ideal coherent, Gray-coded 4-level
+// PAM in AWGN — the absolute reference for the C4FM path's 4-level eye.
+//
+// Symbol-error probability of M-PAM is
+//
+//	Ps = 2(M−1)/M · Q(√(6/(M²−1) · Es/N0)),
+//
+// and with Gray coding adjacent symbols differ by one bit, so at the SNRs of
+// interest Pb ≈ Ps/log2(M). For M=4, log2(M)=2 and Es/N0 = 2·Eb/N0:
+//
+//	Pb ≈ (3/4)·Q(√(0.8·Eb/N0)).
+//
+// C4FM is detected through an FM discriminator, not a coherent 4-PAM matched
+// filter, so the real path sits well to the right of this bound; it is the
+// theoretical floor the loss budget is measured against (see C4FMReferenceLossDB).
+func BER4PAM(ebN0dB float64) float64 {
+	g := dBToLinear(ebN0dB)
+	return 0.75 * QFunc(math.Sqrt(0.8*g))
+}
+
+// C4FMReferenceLossDB is the nominal Eb/N0 gap a non-coherent FM-discriminator
+// detector of C4FM carries over the coherent 4-PAM bound (BER4PAM). It is a
+// documentation/centering constant only — the actual CI loss budget is taken
+// against BER4PAM and calibrated from a measured baseline (the budget absorbs
+// this and the residual modeling gap). Literature places FM-discriminator C4FM
+// detection several dB off the coherent bound; ~6 dB centers the expectation.
+const C4FMReferenceLossDB = 6.0
+
+// InverseBERForEbN0 solves a monotonic BER(Eb/N0) curve for the Eb/N0 (dB) at
+// which it crosses targetBER, by bisection over [loDB, hiDB]. ber must be
+// strictly decreasing in Eb/N0 (all curves here are). It is how the sweep gate
+// compares a measured curve to a reference: find the Eb/N0 each reaches a given
+// BER and take the horizontal gap (the implementation loss, in dB).
+func InverseBERForEbN0(ber func(float64) float64, targetBER, loDB, hiDB float64) float64 {
+	for i := 0; i < 200; i++ {
+		mid := 0.5 * (loDB + hiDB)
+		if ber(mid) > targetBER {
+			loDB = mid // BER still too high → need more Eb/N0
+		} else {
+			hiDB = mid
+		}
+	}
+	return 0.5 * (loDB + hiDB)
+}

--- a/internal/radio/p25/phase1/metrics/theory_test.go
+++ b/internal/radio/p25/phase1/metrics/theory_test.go
@@ -1,0 +1,63 @@
+package metrics
+
+import (
+	"math"
+	"testing"
+)
+
+func approx(t *testing.T, got, want, tol float64, what string) {
+	t.Helper()
+	if math.Abs(got-want) > tol {
+		t.Errorf("%s: got %.6g, want %.6g (±%.2g)", what, got, want, tol)
+	}
+}
+
+func TestQFunc(t *testing.T) {
+	// Reference values for the standard-normal tail.
+	approx(t, QFunc(0), 0.5, 1e-9, "Q(0)")
+	approx(t, QFunc(1), 0.158655, 1e-5, "Q(1)")
+	approx(t, QFunc(2), 0.0227501, 1e-6, "Q(2)")
+	approx(t, QFunc(3), 0.00134990, 1e-7, "Q(3)")
+}
+
+func TestBERCoherentQPSK(t *testing.T) {
+	// Textbook BPSK/QPSK reference points (BER = Q(√(2·Eb/N0))).
+	approx(t, BERCoherentQPSK(0), 0.0786496, 1e-5, "BER @0dB")  // Q(√2)
+	approx(t, BERCoherentQPSK(10), 3.872e-6, 1e-7, "BER @10dB") // Q(√20)
+	// Monotone decreasing in Eb/N0.
+	if BERCoherentQPSK(5) <= BERCoherentQPSK(6) {
+		t.Error("BER must decrease with Eb/N0")
+	}
+}
+
+func TestBER4PAM(t *testing.T) {
+	// 4-PAM is worse than QPSK at equal Eb/N0 (more levels, tighter spacing).
+	for _, ebn0 := range []float64{4, 8, 12} {
+		if BER4PAM(ebn0) <= BERCoherentQPSK(ebn0) {
+			t.Errorf("4-PAM BER should exceed QPSK at %g dB: 4PAM=%g QPSK=%g",
+				ebn0, BER4PAM(ebn0), BERCoherentQPSK(ebn0))
+		}
+	}
+	// Sanity: a recognizable value. At 8 dB, 0.75·Q(√(0.8·6.31)) = 0.75·Q(2.247).
+	approx(t, BER4PAM(8), 0.75*QFunc(math.Sqrt(0.8*dBToLinear(8))), 1e-12, "BER4PAM @8dB form")
+}
+
+func TestEsN0EbN0Conversions(t *testing.T) {
+	// sps=10 → +10 dB from SNR to Es/N0.
+	approx(t, EsN0FromSNR(5, 10), 15, 1e-9, "Es/N0 from SNR sps=10")
+	// 2 bits/symbol → −3.01 dB from Es/N0 to Eb/N0.
+	approx(t, EbN0FromEsN0(15, 2), 15-10*math.Log10(2), 1e-9, "Eb/N0 from Es/N0")
+}
+
+func TestInverseBERForEbN0(t *testing.T) {
+	// The Eb/N0 at which coherent QPSK hits 1e-2, recovered by bisection,
+	// should reproduce the forward curve at that point.
+	const target = 1e-2
+	ebn0 := InverseBERForEbN0(BERCoherentQPSK, target, -10, 30)
+	approx(t, BERCoherentQPSK(ebn0), target, 1e-4, "inverse BER round-trip")
+	// And 4-PAM needs a higher Eb/N0 than QPSK to reach the same BER.
+	ebn0PAM := InverseBERForEbN0(BER4PAM, target, -10, 40)
+	if ebn0PAM <= ebn0 {
+		t.Errorf("4-PAM should need more Eb/N0 for %g: 4PAM=%.2f QPSK=%.2f", target, ebn0PAM, ebn0)
+	}
+}

--- a/internal/radio/p25/phase1/receiver/sweep_test.go
+++ b/internal/radio/p25/phase1/receiver/sweep_test.go
@@ -1,0 +1,266 @@
+package receiver
+
+// Synthetic BER-vs-SNR sweep + hard CI gate (measurement-harness component C).
+//
+// This drives the real receiver across a range of injected SNRs on both demod
+// paths, measures the recovered-symbol (dibit) error rate and the
+// metrics-package SNR estimate at each, and compares the measured curve to the
+// closed-form theoretical reference. It answers the harness's founding
+// question deterministically: is the demod tracking the theoretical limit
+// (signal-limited) or sitting far off it (implementation-limited)?
+//
+// TestSweepImplementationLossBudget is the hard gate: the Es/N0 each path needs
+// to reach a target symbol-error rate must stay within a committed loss budget
+// of the reference, the measured SER must fall monotonically with SNR, and the
+// SNR estimator must track (or at least rise with) the injected SNR. It is
+// deterministic (seeded synthesis, fixed SNR ladder).
+
+import (
+	"math"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/demod"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase1/metrics"
+)
+
+// sweepPoint is one (injected-SNR → measured) sample of the demod's behaviour.
+type sweepPoint struct {
+	snrDB    float64 // injected per-sample in-band SNR (Impairments.SNRdB)
+	esN0dB   float64 // derived per-symbol Es/N0 = snrDB + 10log10(sps)
+	ser      float64 // measured recovered-symbol (dibit) error rate
+	snrEstDB float64 // metrics-package SNR estimate from the soft taps
+	softSyms int     // soft/constellation samples the estimate was formed over
+}
+
+// sweepSeed fixes the AWGN draw so the whole sweep is reproducible.
+const sweepSeed = 0x5175
+
+// runSweepPoint modulates the canonical control-channel stream for one demod
+// path, overlays AWGN at snrDB, runs it through the real receiver, and returns
+// the measured symbol-error rate plus the metrics-package SNR estimate taken
+// from the receiver's soft (C4FM) or constellation (CQPSK) taps.
+func runSweepPoint(mode DemodMode, snrDB float64) sweepPoint {
+	canonical := buildHarnessDibits(harnessNAC, harnessFrameRepeats)
+	iq := demod.ApplyImpairments(modulateHarness(canonical, mode), harnessSampleRateHz,
+		demod.Impairments{SNRdB: snrDB, Seed: sweepSeed})
+
+	var recovered []uint8
+	var soft []float32
+	var syms []complex64
+	opts := Options{
+		SampleRateHz: harnessSampleRateHz,
+		DeviationHz:  harnessDeviationHz,
+		DemodMode:    mode,
+		DibitSink:    func(d []uint8, _ int) { recovered = append(recovered, d...) },
+		SoftSink:     func(s []float32) { soft = append(soft, s...) },
+		SymbolSink:   func(c []complex64) { syms = append(syms, c...) },
+	}
+	r := New(opts)
+	for i := 0; i < len(iq); i += harnessChunk {
+		end := i + harnessChunk
+		if end > len(iq) {
+			end = len(iq)
+		}
+		r.Process(iq[i:end])
+	}
+
+	p := sweepPoint{snrDB: snrDB, esN0dB: metrics.EsN0FromSNR(snrDB, harnessSPS)}
+	p.ser = dibitErrorRate(canonical, recovered)
+
+	// Estimate SNR from the demod taps, skipping the AGC/clock warmup so the
+	// statistic reflects steady state. The C4FM path surfaces the real
+	// 4-level soft axis (SoftSink); the CQPSK path surfaces the complex
+	// constellation (SymbolSink).
+	const warmupSkip = 256
+	if mode == DemodCQPSK {
+		if len(syms) > warmupSkip {
+			syms = syms[warmupSkip:]
+		}
+		p.softSyms = len(syms)
+		p.snrEstDB = metrics.SNRM2M4Constellation(syms)
+	} else {
+		if len(soft) > warmupSkip {
+			soft = soft[warmupSkip:]
+		}
+		p.softSyms = len(soft)
+		outer := metrics.EstimateOuterRailC4FM(soft)
+		p.snrEstDB = metrics.SNRResidualC4FM(soft, outer)
+	}
+	return p
+}
+
+// sweepSNRs is the injected-SNR ladder. It spans the regime from a closed eye
+// (high SER) up through a clean lock, so the measured SER crosses the target
+// somewhere inside the range on both paths.
+var sweepSNRs = []float64{2, 4, 6, 8, 10, 12, 15, 18, 20, 25, 30, 35, 40}
+
+// runSweep collects a sweepPoint at every SNR for one demod path.
+func runSweep(mode DemodMode) []sweepPoint {
+	pts := make([]sweepPoint, len(sweepSNRs))
+	for i, snr := range sweepSNRs {
+		pts[i] = runSweepPoint(mode, snr)
+	}
+	return pts
+}
+
+// esN0AtSER returns the Es/N0 (dB) at which the measured SER curve crosses
+// targetSER, by linear interpolation in (Es/N0, log10 SER). Returns NaN if the
+// curve never brackets the target within the swept range.
+func esN0AtSER(pts []sweepPoint, targetSER float64) float64 {
+	lt := math.Log10(targetSER)
+	for i := 1; i < len(pts); i++ {
+		hi, lo := pts[i-1], pts[i] // SER decreases as Es/N0 rises
+		if hi.ser <= 0 || lo.ser <= 0 {
+			continue
+		}
+		lhi, llo := math.Log10(hi.ser), math.Log10(lo.ser)
+		if (lhi-lt)*(llo-lt) <= 0 && lhi != llo { // target bracketed
+			f := (lt - lhi) / (llo - lhi)
+			return hi.esN0dB + f*(lo.esN0dB-hi.esN0dB)
+		}
+	}
+	return math.NaN()
+}
+
+// sweepGate is the per-path acceptance configuration for the hard gate.
+type sweepGate struct {
+	mode DemodMode
+	name string
+	// ref is the closed-form symbol-error-rate reference the loss is taken
+	// against (coherent QPSK for CQPSK, coherent 4-PAM for C4FM).
+	ref func(esN0dB float64) float64
+	// targetSER is the symbol-error rate at which the measured and reference
+	// Es/N0 are compared.
+	targetSER float64
+	// lossBudgetDB is the maximum tolerated gap between the Es/N0 the demod
+	// needs to reach targetSER and the reference's. It is a *regression
+	// ceiling* calibrated from the measured baseline plus margin — NOT a
+	// claim that the gap is small. The C4FM budget is large precisely
+	// because the FM-discriminator path's noise fragility (compounded by
+	// timing-slip behaviour the single-lag SER measurement folds in) sits
+	// it ~24 dB off the coherent bound; enshrining that as a ceiling is what
+	// stops it silently getting worse, and quantifies the headroom that
+	// would justify future demod work.
+	lossBudgetDB float64
+	// estTrackBand is the Es/N0 window where the SNR estimate should track
+	// the injected Es/N0 (thermal-noise-dominated, below the implementation
+	// EVM floor). Zero-valued (both 0) skips the absolute-tracking check —
+	// used for C4FM, whose nonlinear FM discrimination makes the soft-axis
+	// SNR a different, lower quantity than the input Es/N0, so only
+	// monotonicity is meaningful there.
+	estTrackBand  [2]float64
+	estTrackTolDB float64
+}
+
+// sweepGates calibrate the gate from the committed baseline measured by
+// TestSweepImplementationLossBudget's own logs (re-run it and read the "loss="
+// lines to re-derive these). CQPSK lands ~3.85 dB off coherent QPSK at 1% SER;
+// C4FM ~23.8 dB off coherent 4-PAM. Budgets add ~2–3 dB of margin.
+var sweepGates = []sweepGate{
+	{
+		mode: DemodCQPSK, name: "cqpsk",
+		ref: metrics.SERCoherentQPSK, targetSER: 1e-2, lossBudgetDB: 6.0,
+		estTrackBand: [2]float64{12, 20}, estTrackTolDB: 3.0,
+	},
+	{
+		mode: DemodC4FM, name: "c4fm",
+		ref: metrics.SER4PAM, targetSER: 1e-2, lossBudgetDB: 27.0,
+		// FM discrimination decouples soft-axis SNR from input Es/N0:
+		// monotonicity only.
+		estTrackBand: [2]float64{}, estTrackTolDB: 0,
+	},
+}
+
+// TestSweepImplementationLossBudget is the hard CI gate. For each demod path it
+// sweeps injected SNR through the real receiver, logs the measured SER and SNR
+// estimate at each step (the calibration record), and asserts:
+//
+//   - the measured SER is monotone non-increasing in Es/N0 (a demod whose
+//     errors climb with SNR is broken);
+//   - the Es/N0 needed to reach the path's target SER stays within the
+//     committed loss budget of the theoretical reference (the regression
+//     ceiling), so the demod can never silently fall further behind theory;
+//   - the SNR estimator tracks (CQPSK) or at least rises monotonically with
+//     (C4FM) the injected SNR over the locked regime — validating the
+//     estimator itself, not just the demod.
+//
+// Deterministic: seeded synthesis, fixed SNR ladder.
+func TestSweepImplementationLossBudget(t *testing.T) {
+	for _, g := range sweepGates {
+		t.Run(g.name, func(t *testing.T) {
+			pts := runSweep(g.mode)
+			for _, p := range pts {
+				t.Logf("sweep %-5s  SNR=%+5.1f dB  Es/N0=%+5.1f dB  SER=%.5f  SNRest=%5.1f dB (n=%d)",
+					g.name, p.snrDB, p.esN0dB, p.ser, p.snrEstDB, p.softSyms)
+			}
+
+			// 1. SER monotone non-increasing in Es/N0 (small epsilon absorbs
+			//    the seed's run-to-run noise wiggle at a fixed eye).
+			const serWiggle = 0.03
+			for i := 1; i < len(pts); i++ {
+				if pts[i].ser > pts[i-1].ser+serWiggle {
+					t.Errorf("SER rose with SNR: Es/N0 %.0f→%.0f dB gave SER %.4f→%.4f",
+						pts[i-1].esN0dB, pts[i].esN0dB, pts[i-1].ser, pts[i].ser)
+				}
+			}
+
+			// 2. Implementation loss within the committed ceiling.
+			meas := esN0AtSER(pts, g.targetSER)
+			theory := metrics.InverseBERForEbN0(g.ref, g.targetSER, -10, 60)
+			if math.IsNaN(meas) {
+				t.Fatalf("measured SER never reached the target %g within the swept range — "+
+					"extend sweepSNRs or the demod regressed below the gate's reach", g.targetSER)
+			}
+			loss := meas - theory
+			t.Logf("%s SER=%g: measured Es/N0=%.2f dB, theory=%.2f dB, loss=%.2f dB (budget %.1f dB)",
+				g.name, g.targetSER, meas, theory, loss, g.lossBudgetDB)
+			if loss > g.lossBudgetDB {
+				t.Errorf("%s implementation loss %.2f dB exceeds budget %.1f dB at SER=%g — "+
+					"the demod fell behind theory; investigate before raising the budget",
+					g.name, loss, g.lossBudgetDB, g.targetSER)
+			}
+
+			// 3. SNR estimator behaviour over the locked regime.
+			assertEstimator(t, g, pts)
+		})
+	}
+}
+
+// assertEstimator checks the SNR estimate against the injected Es/N0: absolute
+// tracking within tolerance for paths with a defined estTrackBand (CQPSK), and
+// monotone-non-decreasing over the locked regime otherwise (C4FM).
+func assertEstimator(t *testing.T, g sweepGate, pts []sweepPoint) {
+	t.Helper()
+	if g.estTrackBand[1] > g.estTrackBand[0] {
+		var prev float64
+		var have bool
+		for _, p := range pts {
+			if p.esN0dB < g.estTrackBand[0] || p.esN0dB > g.estTrackBand[1] {
+				continue
+			}
+			if d := math.Abs(p.snrEstDB - p.esN0dB); d > g.estTrackTolDB {
+				t.Errorf("%s SNR estimate %.1f dB strays %.1f dB from injected Es/N0 %.1f dB (tol %.1f)",
+					g.name, p.snrEstDB, d, p.esN0dB, g.estTrackTolDB)
+			}
+			if have && p.snrEstDB < prev-0.5 {
+				t.Errorf("%s SNR estimate fell as injected SNR rose: %.1f→%.1f dB", g.name, prev, p.snrEstDB)
+			}
+			prev, have = p.snrEstDB, true
+		}
+		return
+	}
+	// Monotonicity over the locked regime (where SER < 0.5 — the eye is open
+	// enough that the estimate measures signal, not noise).
+	var prev float64
+	var have bool
+	for _, p := range pts {
+		if p.ser >= 0.5 {
+			continue
+		}
+		if have && p.snrEstDB < prev-1.0 {
+			t.Errorf("%s SNR estimate fell as injected SNR rose over the locked regime: %.1f→%.1f dB",
+				g.name, prev, p.snrEstDB)
+		}
+		prev, have = p.snrEstDB, true
+	}
+}

--- a/internal/radio/p25/phase1/refcompare/refcompare.go
+++ b/internal/radio/p25/phase1/refcompare/refcompare.go
@@ -1,0 +1,148 @@
+// Package refcompare cross-checks GopherTrunk's P25 Phase 1 decode against an
+// external reference decoder (OP25 / DSD-FME) run on the *same* IQ capture. It
+// is the third leg of the measurement harness: the synthetic sweep says how
+// far GopherTrunk is from the theoretical limit, and this says how far it is
+// from another real decoder on identical input — which together localize a
+// weak-decode gap. If GopherTrunk trails both theory and the reference the gap
+// is GopherTrunk-specific; if GopherTrunk ≈ the reference and both trail theory
+// the signal is inherently marginal and no demod change recovers it.
+//
+// The comparison is deliberately tool-agnostic: it diffs the set of decoded
+// NACs (the most robust, format-independent signal a reference emits) and a
+// coarse decoded-frame yield, modelled on internal/voice/calibrate's Result +
+// pass-bar. The brittle part — invoking the external binary and scraping its
+// output — lives in the skip-gated integration test that calls ParseNACs; the
+// math here is pure and unit-tested.
+package refcompare
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// Report is the outcome of comparing GopherTrunk to a reference decoder on one
+// capture. NAC sets are the primary signal; frame counts are a coarse yield
+// proxy.
+type Report struct {
+	GTNACs     []uint16 // distinct NACs GopherTrunk decoded (sorted)
+	RefNACs    []uint16 // distinct NACs the reference decoded (sorted)
+	CommonNACs []uint16 // NACs both agreed on (sorted)
+	GTOnly     []uint16 // NACs only GopherTrunk found
+	RefOnly    []uint16 // NACs only the reference found
+	GTFrames   int      // GopherTrunk decoded-frame yield
+	RefFrames  int      // reference decoded-frame yield
+	// Agreement is |common| / |union| of the NAC sets, in [0,1]. 1.0 means
+	// the two decoders saw exactly the same systems.
+	Agreement float64
+	// Pass is true when Agreement ≥ the minAgreement bar and (when the
+	// reference reported frames) GopherTrunk's yield is at least the required
+	// fraction of the reference's.
+	Pass  bool
+	Notes string
+}
+
+// Compare diffs the two decoders' NAC sets and frame yields into a Report.
+// minAgreement is the NAC-set overlap required to pass (e.g. 1.0 = identical
+// systems); minYieldFrac is the fraction of the reference's decoded-frame
+// count GopherTrunk must reach (e.g. 0.8). minYieldFrac is ignored when the
+// reference reported no frames (frame scraping unavailable for that tool).
+func Compare(gtNACs, refNACs []uint16, gtFrames, refFrames int, minAgreement, minYieldFrac float64) Report {
+	gt := uniqueSorted(gtNACs)
+	ref := uniqueSorted(refNACs)
+	gtSet := toSet(gt)
+	refSet := toSet(ref)
+
+	var common, gtOnly, refOnly []uint16
+	for _, n := range gt {
+		if refSet[n] {
+			common = append(common, n)
+		} else {
+			gtOnly = append(gtOnly, n)
+		}
+	}
+	for _, n := range ref {
+		if !gtSet[n] {
+			refOnly = append(refOnly, n)
+		}
+	}
+
+	union := len(common) + len(gtOnly) + len(refOnly)
+	agreement := 1.0
+	if union > 0 {
+		agreement = float64(len(common)) / float64(union)
+	}
+
+	r := Report{
+		GTNACs: gt, RefNACs: ref, CommonNACs: common,
+		GTOnly: gtOnly, RefOnly: refOnly,
+		GTFrames: gtFrames, RefFrames: refFrames,
+		Agreement: agreement,
+	}
+
+	r.Pass = agreement >= minAgreement
+	switch {
+	case !r.Pass:
+		r.Notes = fmt.Sprintf("NAC-set agreement %.2f < required %.2f (GT-only=%v, ref-only=%v)",
+			agreement, minAgreement, gtOnly, refOnly)
+	case refFrames > 0 && float64(gtFrames) < minYieldFrac*float64(refFrames):
+		r.Pass = false
+		r.Notes = fmt.Sprintf("frame yield %d < %.0f%% of reference %d", gtFrames, minYieldFrac*100, refFrames)
+	default:
+		r.Notes = fmt.Sprintf("agreement %.2f, GT/ref frames %d/%d", agreement, gtFrames, refFrames)
+	}
+	return r
+}
+
+// ParseNACs extracts every NAC value from a reference decoder's textual output
+// using re, whose first capture group must hold the NAC as a hex ("0x167" or
+// "167") or decimal string. A nil re uses DefaultNACPattern, which matches the
+// common "NAC 0x167" / "nac=0x167" renderings OP25 and DSD-FME emit. Duplicate
+// and unparseable matches are dropped.
+func ParseNACs(output string, re *regexp.Regexp) []uint16 {
+	if re == nil {
+		re = DefaultNACPattern
+	}
+	var out []uint16
+	for _, m := range re.FindAllStringSubmatch(output, -1) {
+		if len(m) < 2 {
+			continue
+		}
+		tok := strings.TrimSpace(m[1])
+		base := 10
+		if strings.HasPrefix(strings.ToLower(tok), "0x") {
+			tok = tok[2:]
+			base = 16
+		}
+		v, err := strconv.ParseUint(tok, base, 16)
+		if err != nil {
+			continue
+		}
+		out = append(out, uint16(v))
+	}
+	return out
+}
+
+// DefaultNACPattern matches "NAC 0x167", "nac=0x167", "NAC: 167" and similar,
+// capturing the hex/decimal NAC token. Case-insensitive.
+var DefaultNACPattern = regexp.MustCompile(`(?i)nac[\s:=]+((?:0x)?[0-9a-f]+)`)
+
+func uniqueSorted(in []uint16) []uint16 {
+	set := toSet(in)
+	out := make([]uint16, 0, len(set))
+	for n := range set {
+		out = append(out, n)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	return out
+}
+
+func toSet(in []uint16) map[uint16]bool {
+	s := make(map[uint16]bool, len(in))
+	for _, n := range in {
+		s[n] = true
+	}
+	return s
+}

--- a/internal/radio/p25/phase1/refcompare/refcompare_test.go
+++ b/internal/radio/p25/phase1/refcompare/refcompare_test.go
@@ -1,0 +1,67 @@
+package refcompare
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestCompareIdenticalPasses(t *testing.T) {
+	r := Compare([]uint16{0x167, 0x293}, []uint16{0x293, 0x167}, 40, 42, 1.0, 0.8)
+	if !r.Pass {
+		t.Errorf("identical NAC sets should pass: %s", r.Notes)
+	}
+	if r.Agreement != 1.0 {
+		t.Errorf("agreement = %v, want 1.0", r.Agreement)
+	}
+	if !reflect.DeepEqual(r.CommonNACs, []uint16{0x167, 0x293}) {
+		t.Errorf("common = %v", r.CommonNACs)
+	}
+}
+
+func TestCompareDisagreementFails(t *testing.T) {
+	// GT found 0x167; reference found 0x167 and 0x200 → agreement 1/2 = 0.5.
+	r := Compare([]uint16{0x167}, []uint16{0x167, 0x200}, 40, 40, 1.0, 0.8)
+	if r.Pass {
+		t.Error("partial NAC agreement should fail at minAgreement=1.0")
+	}
+	if r.Agreement != 0.5 {
+		t.Errorf("agreement = %v, want 0.5", r.Agreement)
+	}
+	if !reflect.DeepEqual(r.RefOnly, []uint16{0x200}) {
+		t.Errorf("ref-only = %v, want [0x200]", r.RefOnly)
+	}
+}
+
+func TestCompareYieldBar(t *testing.T) {
+	// NACs agree but GT's frame yield is far below the reference's.
+	r := Compare([]uint16{0x167}, []uint16{0x167}, 10, 100, 1.0, 0.8)
+	if r.Pass {
+		t.Errorf("low frame yield should fail: %s", r.Notes)
+	}
+	// Reference reported no frames → yield bar is skipped.
+	r2 := Compare([]uint16{0x167}, []uint16{0x167}, 10, 0, 1.0, 0.8)
+	if !r2.Pass {
+		t.Errorf("yield bar should be skipped when reference reports 0 frames: %s", r2.Notes)
+	}
+}
+
+func TestParseNACs(t *testing.T) {
+	out := `
+		[OP25] tuned to 420.050 MHz
+		NAC 0x167 found, DUID=TSDU
+		nac=0x167 (repeat)
+		NAC: 659 decimal form
+		random NACK line should not match a hex token
+	`
+	got := ParseNACs(out, nil)
+	// 0x167 twice, 659 (=0x293) once, plus "NACK" → the "K" makes the token
+	// non-hex after the separator, so it should be dropped or parsed as the
+	// following token; assert the real NACs are present.
+	want := map[uint16]bool{0x167: true, 0x293: true}
+	for _, n := range got {
+		delete(want, n)
+	}
+	if len(want) != 0 {
+		t.Errorf("ParseNACs missed %v (got %v)", want, got)
+	}
+}

--- a/internal/radio/p25/phase1/sync.go
+++ b/internal/radio/p25/phase1/sync.go
@@ -131,6 +131,20 @@ func (s *SyncDetector) Process(dst []int, src []uint8, baseIndex int) ([]int, in
 // Pass nil for rots to let the detector allocate; the returned rots
 // slice is non-nil whenever dst is non-empty after this call.
 func (s *SyncDetector) ProcessWithRotation(dst []int, rots []uint8, src []uint8, baseIndex int) ([]int, []uint8, int) {
+	dst, rots, _, next := s.ProcessWithMargin(dst, rots, nil, src, baseIndex)
+	return dst, rots, next
+}
+
+// ProcessWithMargin behaves like ProcessWithRotation but additionally returns,
+// per emitted hit, the correlation margin: tolerance+1 − bestMismatch, where
+// bestMismatch is the fewest dibit-symbol mismatches the FSW matched at across
+// the tried rotations. A perfect 24/24 hit at tolerance 4 has margin 5; a hit
+// that only just cleared tolerance has margin 1. The distribution of this
+// number over a capture is the sync-health metric the measurement harness
+// reports — a margin pressed against 1 means sync is barely holding and a
+// little more noise would drop the lock. dst, rots and margins stay in
+// lockstep; pass nil for any to let the detector allocate.
+func (s *SyncDetector) ProcessWithMargin(dst []int, rots []uint8, margins []int, src []uint8, baseIndex int) ([]int, []uint8, []int, int) {
 	rotations := resolveRotations(s.rotations)
 	for i, d := range src {
 		s.hist[s.pos] = d
@@ -164,7 +178,8 @@ func (s *SyncDetector) ProcessWithRotation(dst []int, rots []uint8, src []uint8,
 		if bestMis <= s.tolerance {
 			dst = append(dst, baseIndex+i)
 			rots = append(rots, bestRot)
+			margins = append(margins, s.tolerance+1-bestMis)
 		}
 	}
-	return dst, rots, baseIndex + len(src)
+	return dst, rots, margins, baseIndex + len(src)
 }

--- a/internal/radio/p25/phase1/sync_test.go
+++ b/internal/radio/p25/phase1/sync_test.go
@@ -22,6 +22,30 @@ func TestSyncDetectorMatchesCleanFSW(t *testing.T) {
 	}
 }
 
+func TestSyncDetectorProcessWithMargin(t *testing.T) {
+	// A perfect FSW at tolerance 4 has margin = tolerance+1 − 0 = 5; a
+	// 2-error FSW has margin = 5 − 2 = 3.
+	det := NewSyncDetector(4)
+	stream := make([]uint8, 120)
+	copy(stream[10:], FrameSyncWord[:]) // clean → margin 5
+	var two [24]uint8
+	copy(two[:], FrameSyncWord[:])
+	two[3] = (two[3] + 1) % 4
+	two[7] = (two[7] + 1) % 4
+	copy(stream[60:], two[:]) // 2 errors → margin 3
+
+	hits, _, margins, _ := det.ProcessWithMargin(nil, nil, nil, stream, 0)
+	if len(hits) != 2 || len(margins) != 2 {
+		t.Fatalf("hits=%v margins=%v, want 2 each", hits, margins)
+	}
+	if margins[0] != 5 {
+		t.Errorf("clean FSW margin = %d, want 5", margins[0])
+	}
+	if margins[1] != 3 {
+		t.Errorf("2-error FSW margin = %d, want 3", margins[1])
+	}
+}
+
 func TestSyncDetectorTolerates2Errors(t *testing.T) {
 	det := NewSyncDetector(2)
 	stream := make([]uint8, 100)

--- a/internal/siglab/demodmetrics_test.go
+++ b/internal/siglab/demodmetrics_test.go
@@ -1,0 +1,81 @@
+package siglab
+
+import (
+	"math"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/demod"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// TestDemodMetricsPopulated confirms the demod-quality metrics are surfaced on
+// the P25 deep path for both modulations, with the right estimator selected,
+// and that injecting noise degrades EVM and lowers the SNR estimate — the
+// end-to-end proof that the metrics package is wired into siglab correctly.
+func TestDemodMetricsPopulated(t *testing.T) {
+	cases := []struct {
+		name string
+		mod  string
+		want string // expected DemodMetrics.Modulation
+	}{
+		{"c4fm", "c4fm", "c4fm"},
+		{"cqpsk", "lsm", "cqpsk"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			clean := analyzeDemod(t, tc.mod, 0)
+			if clean == nil {
+				t.Fatalf("%s: clean run produced no DemodMetrics", tc.name)
+			}
+			if clean.Modulation != tc.want {
+				t.Errorf("Modulation = %q, want %q", clean.Modulation, tc.want)
+			}
+			if clean.SymbolsAnalyzed == 0 {
+				t.Error("SymbolsAnalyzed = 0")
+			}
+			if clean.EVMPct < 0 || math.IsNaN(clean.EVMPct) {
+				t.Errorf("EVM = %v, want finite non-negative", clean.EVMPct)
+			}
+			if math.IsInf(clean.SNREstimateDB, 0) {
+				t.Errorf("SNR estimate is infinite; cap not applied: %v", clean.SNREstimateDB)
+			}
+
+			// A noisy run should disperse the constellation more and read a
+			// lower SNR than the clean run.
+			noisy := analyzeDemod(t, tc.mod, 8)
+			if noisy == nil {
+				t.Fatalf("%s: noisy run produced no DemodMetrics", tc.name)
+			}
+			t.Logf("%s: clean EVM=%.1f%% SNR=%.1f dB | noisy(8dB) EVM=%.1f%% SNR=%.1f dB",
+				tc.name, clean.EVMPct, clean.SNREstimateDB, noisy.EVMPct, noisy.SNREstimateDB)
+			if noisy.EVMPct <= clean.EVMPct {
+				t.Errorf("noise did not raise EVM: clean=%.2f%% noisy=%.2f%%", clean.EVMPct, noisy.EVMPct)
+			}
+			if noisy.SNREstimateDB >= clean.SNREstimateDB {
+				t.Errorf("noise did not lower SNR estimate: clean=%.2f noisy=%.2f", clean.SNREstimateDB, noisy.SNREstimateDB)
+			}
+		})
+	}
+}
+
+// analyzeDemod synthesizes a P25 signal in the given modulation at the given
+// injected SNR (0 = clean) and returns the DemodMetrics from the deep path.
+func analyzeDemod(t *testing.T, mod string, snrDB float64) *DemodMetrics {
+	t.Helper()
+	synth := SynthOptions{Protocol: trunking.ProtocolP25, Format: FormatF32, Modulation: mod}
+	if snrDB > 0 {
+		synth.Impairments = demod.Impairments{SNRdB: snrDB, Seed: 1}
+	}
+	decode := Config{CollectIQDiag: true}
+	if mod == "lsm" || mod == "cqpsk" {
+		decode.DemodMode = "cqpsk"
+	}
+	res, _, err := SynthesizeAndAnalyze(synth, decode, nil)
+	if err != nil {
+		t.Fatalf("SynthesizeAndAnalyze(%s, %g dB): %v", mod, snrDB, err)
+	}
+	if res.Signal == nil {
+		t.Fatalf("%s: no SignalQuality", mod)
+	}
+	return res.Signal.Demod
+}

--- a/internal/siglab/engine.go
+++ b/internal/siglab/engine.go
@@ -141,11 +141,19 @@ func runReader(r io.Reader, source string, decode SampleDecoder, bytesPerSample 
 			iqTap.observeSoft(soft)
 		}
 	}
+	// constTap carries the complex symbol-decision points (CQPSK / linear
+	// path) into the analyzer so the demod-quality metrics can use the
+	// constellation estimators. Only the P25 deep path's CQPSK mode fires it.
+	constTap := func(pts []complex64) {
+		if an != nil {
+			an.observeConstellation(pts)
+		}
+	}
 
 	// Build the run bundle: either a generic factory pipeline (any protocol)
 	// or the P25 Phase 1 deep path (direct receiver + control channel with
 	// soft/state capture and the experimental bisect knobs).
-	bundle, err := buildBundle(cfg, bus, logger, receiverRate, symbolTap, softTap)
+	bundle, err := buildBundle(cfg, bus, logger, receiverRate, symbolTap, softTap, constTap)
 	if err != nil {
 		sub.Close()
 		bus.Close()
@@ -373,9 +381,9 @@ type runBundle struct {
 // when requested, otherwise the generic factory pipeline (any protocol). Both
 // publish lock/grant/decode-error events to bus and feed symbolTap; only the
 // deep path feeds softTap and exposes state/ccStats.
-func buildBundle(cfg Config, bus *events.Bus, logger *slog.Logger, receiverRate float64, symbolTap func([]uint8, bool, int), softTap func([]float32)) (*runBundle, error) {
+func buildBundle(cfg Config, bus *events.Bus, logger *slog.Logger, receiverRate float64, symbolTap func([]uint8, bool, int), softTap func([]float32), constTap func([]complex64)) (*runBundle, error) {
 	if cfg.wantP25Deep() {
-		return buildP25DeepBundle(cfg, bus, logger, receiverRate, symbolTap, softTap)
+		return buildP25DeepBundle(cfg, bus, logger, receiverRate, symbolTap, softTap, constTap)
 	}
 	pipe, ok, err := ccdecoder.NewPipeline(cfg.Protocol, ccdecoder.PipelineOptions{
 		Bus:          bus,

--- a/internal/siglab/engine_p25.go
+++ b/internal/siglab/engine_p25.go
@@ -22,7 +22,7 @@ const p25DeviationHz = 1800.0
 // the production newP25Phase1Pipeline construction so a deep replay lock still
 // implies an on-air lock, while surfacing the diagnostics the factory path
 // cannot.
-func buildP25DeepBundle(cfg Config, bus *events.Bus, logger *slog.Logger, receiverRate float64, symbolTap func([]uint8, bool, int), softTap func([]float32)) (*runBundle, error) {
+func buildP25DeepBundle(cfg Config, bus *events.Bus, logger *slog.Logger, receiverRate float64, symbolTap func([]uint8, bool, int), softTap func([]float32), constTap func([]complex64)) (*runBundle, error) {
 	demodMode := p25phase1rx.DemodC4FM
 	if cfg.DemodMode != "" {
 		m, ok := p25phase1rx.ParseDemodMode(cfg.DemodMode)
@@ -57,6 +57,12 @@ func buildP25DeepBundle(cfg Config, bus *events.Bus, logger *slog.Logger, receiv
 		EnableDecisionDirectedAFC: cfg.EnableDDA,
 		EnableAdaptiveC4FMSlicer:  cfg.EnableAdaptiveSlicer,
 		SoftSink:                  softTap,
+		// The CQPSK path fires SymbolSink with the post-carrier-recovery
+		// complex constellation points; the C4FM path leaves it uncalled
+		// (its quality view is the real soft eye via SoftSink). Feeding it to
+		// the analyzer lets the demod-quality metrics use the constellation
+		// EVM/SNR estimators on the linear path.
+		SymbolSink: constTap,
 		DibitSink: func(dibits []uint8, baseIdx int) {
 			symbolTap(dibits, false, baseIdx)
 			cc.Process(dibits, baseIdx)

--- a/internal/siglab/signal.go
+++ b/internal/siglab/signal.go
@@ -1,6 +1,11 @@
 package siglab
 
-import "github.com/MattCheramie/GopherTrunk/internal/sdr/rtlsdr"
+import (
+	"math"
+
+	"github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase1/metrics"
+	"github.com/MattCheramie/GopherTrunk/internal/sdr/rtlsdr"
+)
 
 // SignalQuality is the protocol-agnostic demod-quality summary the analyzer
 // produces when Config.CollectIQDiag is set. It generalizes the parts of the
@@ -32,7 +37,46 @@ type SignalQuality struct {
 	// DecodeErrorRate is decode-error events per recovered 1000 symbols — a
 	// protocol-neutral proxy for FEC stress.
 	DecodeErrorRate float64 `json:"decode_error_rate_per_ksym" yaml:"decode_error_rate_per_ksym"`
+
+	// Demod is the demodulator-quality measurement (EVM + estimated SNR)
+	// derived from the per-symbol soft samples on the P25 deep path. Nil for
+	// protocols / runs that do not surface the soft stream. It is what turns
+	// "the audio sounds bad" into "the eye is N% open / the demod is M dB from
+	// the noise floor."
+	Demod *DemodMetrics `json:"demod,omitempty" yaml:"demod,omitempty"`
 }
+
+// DemodMetrics is the demodulator-quality summary computed from the recovered
+// soft symbols: error-vector magnitude (constellation dispersion) and the SNR
+// implied by the residual about the ideal symbol positions. It is the
+// siglab-surfaced face of internal/radio/p25/phase1/metrics.
+type DemodMetrics struct {
+	// Modulation names the estimator that produced these numbers: "c4fm" (the
+	// 4-level soft eye) or "cqpsk" (the complex π/4-DQPSK constellation).
+	Modulation string `json:"modulation" yaml:"modulation"`
+	// EVMPct is the RMS error-vector magnitude as a percentage of the ideal
+	// symbol level. A clean lock sits at a few percent; it climbs toward the
+	// inter-rail half-spacing (~33% for C4FM) as the eye closes.
+	EVMPct float64 `json:"evm_pct" yaml:"evm_pct"`
+	// SNREstimateDB is the symbol SNR implied by the residual, in dB. For
+	// C4FM this is the post-discriminator soft-axis SNR (lower than the input
+	// Es/N0 by the FM detection loss); for CQPSK it is the constellation SNR.
+	// Capped at demodSNRCapDB for a noise-free synthetic input.
+	SNREstimateDB float64 `json:"snr_estimate_db" yaml:"snr_estimate_db"`
+	// SymbolsAnalyzed is the soft-sample count the estimate was formed over
+	// (after the warmup skip).
+	SymbolsAnalyzed int64 `json:"symbols_analyzed" yaml:"symbols_analyzed"`
+}
+
+// demodWarmupSkip drops the leading soft samples so the AGC/clock/AFC
+// acquisition transient does not bias the EVM/SNR estimate toward the closed
+// eye it starts from. Matches the sweep harness's warmup skip.
+const demodWarmupSkip = 256
+
+// demodSNRCapDB bounds the reported SNR so a noise-free synthetic input (whose
+// residual is ~0 → SNR → +Inf) yields a finite, JSON-marshalable number rather
+// than an infinity encoding/json refuses to emit.
+const demodSNRCapDB = 99.0
 
 // analyzer accumulates the observations behind a SignalQuality. It is fed
 // from the engine's SymbolTap (symbols) and read loop (raw IQ), so it works
@@ -53,6 +97,17 @@ type analyzer struct {
 	// path, fed from the receiver's SoftSink), aligned index-for-index with
 	// symBuf, for the true-symbol eye analysis.
 	softBuf []float32
+	// constBuf retains the per-symbol complex constellation points (deep P25
+	// CQPSK path, fed from the receiver's SymbolSink). Populated only on the
+	// linear path; its presence is what tells result() to use the
+	// constellation estimators rather than the C4FM soft-axis ones.
+	constBuf []complex64
+}
+
+// observeConstellation appends a chunk of complex symbol-decision points to
+// the rolling buffer (deep P25 CQPSK path only).
+func (a *analyzer) observeConstellation(pts []complex64) {
+	a.constBuf = append(a.constBuf, pts...)
 }
 
 // observeSoft appends a chunk of pre-slicer soft samples to the rolling
@@ -112,5 +167,49 @@ func (a *analyzer) result(decodeErrors int64) *SignalQuality {
 		sq.IQPhaseImbalanceDeg = a.iqStats.PhaseImbalanceDeg()
 		sq.IQImageRejectionDB = a.iqStats.ImageRejectionDB()
 	}
+	sq.Demod = a.demodMetrics()
 	return sq
+}
+
+// demodMetrics computes the EVM + estimated SNR from the buffered soft symbols,
+// choosing the estimator by which buffer the receiver populated: the complex
+// constellation (CQPSK / linear path) when present, otherwise the 4-level soft
+// eye (C4FM). Returns nil when neither buffer holds enough post-warmup samples
+// to form a stable estimate.
+func (a *analyzer) demodMetrics() *DemodMetrics {
+	if len(a.constBuf) > demodWarmupSkip {
+		pts := a.constBuf[demodWarmupSkip:]
+		return &DemodMetrics{
+			Modulation:      "cqpsk",
+			EVMPct:          metrics.EVMConstellation(pts),
+			SNREstimateDB:   capSNR(metrics.SNRM2M4Constellation(pts)),
+			SymbolsAnalyzed: int64(len(pts)),
+		}
+	}
+	if len(a.softBuf) > demodWarmupSkip {
+		soft := a.softBuf[demodWarmupSkip:]
+		outer := metrics.EstimateOuterRailC4FM(soft)
+		if outer <= 0 {
+			return nil
+		}
+		return &DemodMetrics{
+			Modulation:      "c4fm",
+			EVMPct:          metrics.EVMC4FM(soft, outer),
+			SNREstimateDB:   capSNR(metrics.SNRResidualC4FM(soft, outer)),
+			SymbolsAnalyzed: int64(len(soft)),
+		}
+	}
+	return nil
+}
+
+// capSNR clamps a possibly-infinite SNR estimate (noise-free input) to a
+// finite, JSON-safe value.
+func capSNR(db float64) float64 {
+	if math.IsInf(db, 1) || db > demodSNRCapDB {
+		return demodSNRCapDB
+	}
+	if math.IsInf(db, -1) {
+		return -demodSNRCapDB
+	}
+	return db
 }

--- a/internal/siglab/verdict.go
+++ b/internal/siglab/verdict.go
@@ -28,6 +28,13 @@ type Acceptance struct {
 	BaudTolerancePct float64 `json:"baud_tolerance_pct,omitempty" yaml:"baud_tolerance_pct,omitempty"`
 	// MaxDecodeErrorRate caps decode errors per 1000 symbols (0 ⇒ unchecked).
 	MaxDecodeErrorRate float64 `json:"max_decode_error_rate,omitempty" yaml:"max_decode_error_rate,omitempty"`
+	// MaxEVMPct caps the demod error-vector magnitude percentage (0 ⇒
+	// unchecked). Grades demod quality directly — a capture whose eye is too
+	// closed fails even if it happens to lock.
+	MaxEVMPct float64 `json:"max_evm_pct,omitempty" yaml:"max_evm_pct,omitempty"`
+	// MinSNRdB requires the estimated demod SNR to be at least this many dB
+	// (0 ⇒ unchecked).
+	MinSNRdB float64 `json:"min_snr_db,omitempty" yaml:"min_snr_db,omitempty"`
 }
 
 // Verdict is the pass/fail outcome of grading a Result against an Acceptance.
@@ -103,6 +110,26 @@ func evaluateAcceptance(r *Result, a *Acceptance) *Verdict {
 			fail(fmt.Sprintf("decode-error rate: %.2f/ksym > %.2f/ksym", rate, a.MaxDecodeErrorRate))
 		} else {
 			pass(fmt.Sprintf("decode-error rate %.2f/ksym ≤ %.2f/ksym", rate, a.MaxDecodeErrorRate))
+		}
+	}
+	if a.MaxEVMPct > 0 {
+		switch {
+		case r.Signal == nil || r.Signal.Demod == nil:
+			fail(fmt.Sprintf("EVM: required ≤ %.1f%% but no demod metrics were produced", a.MaxEVMPct))
+		case r.Signal.Demod.EVMPct > a.MaxEVMPct:
+			fail(fmt.Sprintf("EVM: %.1f%% > %.1f%%", r.Signal.Demod.EVMPct, a.MaxEVMPct))
+		default:
+			pass(fmt.Sprintf("EVM %.1f%% ≤ %.1f%%", r.Signal.Demod.EVMPct, a.MaxEVMPct))
+		}
+	}
+	if a.MinSNRdB > 0 {
+		switch {
+		case r.Signal == nil || r.Signal.Demod == nil:
+			fail(fmt.Sprintf("SNR: required ≥ %.1f dB but no demod metrics were produced", a.MinSNRdB))
+		case r.Signal.Demod.SNREstimateDB < a.MinSNRdB:
+			fail(fmt.Sprintf("SNR: %.1f dB < %.1f dB", r.Signal.Demod.SNREstimateDB, a.MinSNRdB))
+		default:
+			pass(fmt.Sprintf("SNR %.1f dB ≥ %.1f dB", r.Signal.Demod.SNREstimateDB, a.MinSNRdB))
 		}
 	}
 	return v

--- a/internal/siglab/verdict_test.go
+++ b/internal/siglab/verdict_test.go
@@ -57,3 +57,23 @@ func TestEvaluateAcceptance(t *testing.T) {
 		t.Errorf("expected 2 failures, got %d: %v", len(fail.Failures), fail.Failures)
 	}
 }
+
+func TestEvaluateAcceptanceDemodBounds(t *testing.T) {
+	r := &Result{
+		Signal: &SignalQuality{Demod: &DemodMetrics{Modulation: "c4fm", EVMPct: 12.0, SNREstimateDB: 18.0}},
+	}
+	if v := evaluateAcceptance(r, &Acceptance{MaxEVMPct: 15, MinSNRdB: 15}); !v.Pass {
+		t.Errorf("expected pass within EVM/SNR bounds, got %v", v.Failures)
+	}
+	if v := evaluateAcceptance(r, &Acceptance{MaxEVMPct: 10}); v.Pass {
+		t.Error("expected EVM failure (12%% > 10%%)")
+	}
+	if v := evaluateAcceptance(r, &Acceptance{MinSNRdB: 20}); v.Pass {
+		t.Error("expected SNR failure (18 dB < 20 dB)")
+	}
+	// Missing demod metrics fails a required bound rather than silently passing.
+	bare := &Result{Signal: &SignalQuality{}}
+	if v := evaluateAcceptance(bare, &Acceptance{MaxEVMPct: 15}); v.Pass {
+		t.Error("expected failure when demod metrics absent but EVM bound set")
+	}
+}

--- a/samples/p25/README.md
+++ b/samples/p25/README.md
@@ -1,0 +1,68 @@
+# P25 Phase 1 captures (demod-quality measurement)
+
+Drop **P25 Phase 1** control-channel IQ recordings here to feed the
+demodulator measurement harness
+([`internal/radio/p25/phase1/metrics`](../../internal/radio/p25/phase1/metrics/)).
+The synthetic sweep
+([`internal/radio/p25/phase1/receiver/sweep_test.go`](../../internal/radio/p25/phase1/receiver/sweep_test.go))
+benchmarks the demod against the theoretical limit; a capture dropped here is
+the **field truth** — it runs the real signal through the receiver and reports
+the pre-FEC error rate, EVM, estimated SNR, and FSW sync-margin so a weak-decode
+report becomes a number you can act on.
+
+Two captures are most valuable, and you can drop either or both:
+
+- a **C4FM** site (the FM-discriminator path — the one the harness shows is the
+  most noise-fragile), and
+- an **LSM / CQPSK simulcast** site (the linear path).
+
+## Capture format
+
+| Property | Expected value |
+| --- | --- |
+| File format | Complex float32 IQ (`*.cfile`, GNU Radio interleaved little-endian) |
+| Sample rate | Any rate ≥ 48 kHz; channelise to 48 kHz nominal so it decodes standalone |
+| Modulation | C4FM (4-level FSK, 4800 sym/s) **or** LSM/CQPSK (π/4-DQPSK) |
+| Centre | Tuned on the control-channel carrier (small DC offset OK; the AFC re-tunes) |
+| Duration | ≥ 1 second — enough for several FSW+NID+TSBK frames |
+
+Keep it small enough to commit (a ~1 s 48 kHz slice is ~400 KB), like the
+existing `cmd/gophertrunk/testdata/mmr-s9-cc.cfile` regression fixture.
+
+## Metadata schema
+
+Alongside each `*.cfile`, place a `*.metadata.json`:
+
+```json
+{
+  "source": "RTL-SDR @ <site>, channelised to 48 kHz",
+  "tool_cross_check": "OP25 / DSD-FME (optional, for the cross-check)",
+  "sample_rate_hz": 48000,
+  "center_freq_hz": 420050000,
+  "expected": {
+    "demod_mode": "c4fm",
+    "nac": "0x167",
+    "min_nid_trusted": 8,
+    "min_tsbk": 24,
+    "max_evm_pct": 30.0,
+    "min_snr_db": 12.0,
+    "min_sync_margin": 2
+  },
+  "notes": "Optional: capture conditions, antenna, observed RF SNR, etc."
+}
+```
+
+- `demod_mode` selects the receiver path: `"c4fm"` (default) or `"cqpsk"`.
+- `nac` (hex) is asserted against the locked NAC when present.
+- `min_nid_trusted` / `min_tsbk` are decode-yield floors (see the
+  `mmr-s9-cc.cfile` regression test for the shape).
+- `max_evm_pct` / `min_snr_db` / `min_sync_margin` are the **demod-quality**
+  bounds the harness grades — leave them out to only *report* the metrics
+  without asserting. As the demod improves, tighten them (they are floors,
+  not targets).
+
+The metrics are always logged by
+`TestReplayP25RealCaptureMetrics`
+([`cmd/gophertrunk/p25_realcapture_metrics_test.go`](../../cmd/gophertrunk/p25_realcapture_metrics_test.go));
+the bounds above turn the log lines into a pass/fail gate. With no capture
+present the test skips.

--- a/web/siglab/src/api/types.ts
+++ b/web/siglab/src/api/types.ts
@@ -52,6 +52,17 @@ export interface SignalQuality {
   iq_image_rejection_db: number;
   iq_observed: boolean;
   decode_error_rate_per_ksym: number;
+  demod?: DemodMetrics;
+}
+
+// DemodMetrics is the demodulator-quality summary (EVM + estimated SNR) the
+// P25 deep path derives from the recovered soft symbols. Mirrors
+// siglab.DemodMetrics.
+export interface DemodMetrics {
+  modulation: string;
+  evm_pct: number;
+  snr_estimate_db: number;
+  symbols_analyzed: number;
 }
 
 export interface RailStat {

--- a/web/siglab/src/panels/Compare.tsx
+++ b/web/siglab/src/panels/Compare.tsx
@@ -144,6 +144,16 @@ function MetricsTable({ items }: { items: Item[] }) {
         a?.result?.signal ? a.result.signal.decode_error_rate_per_ksym.toFixed(2) : "—",
     },
     {
+      label: "Demod EVM (%)",
+      get: (a) =>
+        a?.result?.signal?.demod ? a.result.signal.demod.evm_pct.toFixed(1) : "—",
+    },
+    {
+      label: "Demod SNR (dB)",
+      get: (a) =>
+        a?.result?.signal?.demod ? a.result.signal.demod.snr_estimate_db.toFixed(1) : "—",
+    },
+    {
       label: "IQ gain imb (dB)",
       get: (a) =>
         a?.result?.signal?.iq_observed

--- a/web/siglab/src/viz/SymbolHistogram.tsx
+++ b/web/siglab/src/viz/SymbolHistogram.tsx
@@ -40,6 +40,13 @@ export function SymbolHistogram({ signal }: { signal: SignalQuality }) {
             {signal.iq_image_rejection_db.toFixed(1)} dB
           </>
         )}
+        {signal.demod && (
+          <>
+            {" "}· demod ({signal.demod.modulation}) EVM{" "}
+            {signal.demod.evm_pct.toFixed(1)}% · SNR≈{" "}
+            {signal.demod.snr_estimate_db.toFixed(1)} dB
+          </>
+        )}
       </p>
     </div>
   );


### PR DESCRIPTION
## Why

The recent RS-FEC fix closed the *signalling-FEC* gap but couldn't answer the deeper question behind weak decodes: is the C4FM/CQPSK **demodulator leaving SNR on the table** (an implementation gap we should fix), or is the **signal simply marginal** (no code change helps)? There was no pre-FEC BER/EVM/SNR metric on either path, the field `.raw` captures are post-IMBE (the constellation is gone), and a blind demod re-architecture has burned us before (the adaptive slicer/DDA were built and then disabled because simpler paths beat them).

This PR builds the instrument to answer that question with numbers — turning "the audio sounds bad" into "stage X is N dB from optimal" — so any future demod work is evidence-driven and regression-guarded. It deliberately does **not** re-architect the demod; it's the prerequisite that tells us whether, and where, that's warranted.

## What

Five components, each self-contained and verified:

- **A — metrics package** (`internal/radio/p25/phase1/metrics/`): pure, unit-tested EVM/SNR estimators (C4FM soft-eye + π/4-DQPSK constellation; residual + M2M4), closed-form BER/SER references (coherent QPSK, 4-PAM), SNR→Es/N0→Eb/N0 conversions matching the impairment model, and a pre-FEC error / sync-margin collector.
- **C — synthetic sweep + hard CI gate** (`receiver/sweep_test.go`) and a `gophertrunk siglab sweep` CLI: drives the real receivers across a seeded SNR ladder and asserts SER monotonicity, an implementation-loss ceiling vs theory, and SNR-estimator tracking — deterministic.
- **B — siglab surfacing**: a `DemodMetrics` block on every analyze/replay result (JSON/YAML/CSV, text summary, TUI, web Compare tab) and `MaxEVMPct`/`MinSNRdB` verdict bounds so metadata-driven `test` runs grade demod quality.
- **D — field truth**: `SyncDetector.ProcessWithMargin` (surfaces the FSW correlation margin) + a skip-gated real-capture test that reports/grades EVM/SNR/sync-margin/yields, with the `samples/p25/` capture schema documented.
- **E — reference cross-check**: a unit-tested `refcompare` package + a doubly skip-gated OP25/DSD-FME comparison, documented in `docs/demod-calibration.md`.

## Key findings surfaced

- The founding question now has a number: **C4FM sits ~24 dB off coherent 4-PAM at 1% SER** (FM-discriminator noise fragility; the soft-axis SNR estimate saturates near 20 dB), while **CQPSK sits ~3.85 dB off coherent QPSK** (the ~2.3 dB π/4-DQPSK differential penalty + ~1.5 dB implementation). That C4FM gap is the headroom future demod work would target.
- Two real bugs fixed while wiring: `Impairments.SNRdB ≤ 0` adds *no* noise (corrected the sweep's low end), and the CQPSK constellation EVM was reading bogus offset-induced dispersion — fixed with 8-phase assignment + an 8th-power carrier-phase-removal step.

## Design note for review

The hard-gate budgets are **regression ceilings calibrated from the measured baseline**, not claims of good performance — the large C4FM ceiling (~27 dB) is the evidence the harness exists to surface, and the gate stops it silently widening. If you'd prefer gating C4FM purely on monotonicity rather than the absolute ceiling, that's a one-line change.

## Verification

- `go build ./...`, `go vet` (default + `-tags integration`), and `gofmt` are clean.
- New unit tests pass: metrics estimators/theory, refcompare, sync-margin, verdict bounds, end-to-end `DemodMetrics` surfacing.
- The hard-gate sweep passes on both paths; the real-capture and reference cross-check tests are skip-gated (no capture / no external binary present).

https://claude.ai/code/session_012wwH3xYMAAXgtaPkoAcEYY

---
_Generated by [Claude Code](https://claude.ai/code/session_012wwH3xYMAAXgtaPkoAcEYY)_