### PR TITLE
Fix duplicate "Active calls" for the same talkgroup

### DIFF
--- a/internal/trunking/engine.go
+++ b/internal/trunking/engine.go
@@ -228,13 +228,44 @@ func (e *Engine) HandleGrant(g Grant) {
 	// sides, so the comparison is a no-op.
 	if g.GroupID != 0 {
 		for _, ac := range e.pool.Active() {
-			if ac.Grant.GroupID == g.GroupID && ac.Grant.FrequencyHz == g.FrequencyHz &&
-				ac.Grant.Timeslot == g.Timeslot {
+			// A logical call is identified by (System, talkgroup, timeslot),
+			// NOT by frequency: a call's frequency can change mid-call (a
+			// band-plan IdentifierUpdate re-maps the channel, or the system
+			// hands the call to a new channel). Matching on frequency made
+			// such a re-grant miss, so the engine bound a *second* tap to the
+			// same talkgroup — two "Active calls" rows for one call. System
+			// keeps two systems' identical TG numbers apart; Timeslot keeps a
+			// DMR Tier III carrier's two per-slot calls apart (issue #356).
+			if ac.Grant.System != g.System || ac.Grant.GroupID != g.GroupID ||
+				ac.Grant.Timeslot != g.Timeslot {
+				continue
+			}
+			if g.FrequencyHz == ac.Grant.FrequencyHz {
+				// Same channel: the CC is repeating the grant while the call
+				// runs (issue #356). Refresh LastHeardAt and we're done.
 				e.pool.Touch(ac.Device.Serial, e.now())
 				e.log.Debug("grant already active; refreshed",
 					"grant", g.String(), "device", ac.Device.Serial)
 				return
 			}
+			// Same call, new frequency — follow it. Retune the bound device
+			// in place when it can still reach the new channel; otherwise end
+			// the stale bind and fall through to allocate a capable device.
+			if fc, ok := ac.Device.Tuner.(FrequencyChecker); !ok || fc.CanTune(g.FrequencyHz) {
+				if err := e.pool.Retune(ac.Device.Serial, g, e.now()); err != nil {
+					e.log.Warn("voice retune failed; rebinding",
+						"err", err, "grant", g.String(), "device", ac.Device.Serial)
+					e.endCall(ac, EndReasonNormal)
+					break
+				}
+				e.log.Info("call followed to new frequency",
+					"device", ac.Device.Serial, "grant", g.String())
+				return
+			}
+			e.log.Info("call moved beyond device window; rebinding",
+				"device", ac.Device.Serial, "grant", g.String())
+			e.endCall(ac, EndReasonNormal)
+			break
 		}
 	}
 

--- a/internal/trunking/engine_test.go
+++ b/internal/trunking/engine_test.go
@@ -589,6 +589,124 @@ func TestEngineHandleGrantDeduplicatesDuplicateGrant(t *testing.T) {
 	}
 }
 
+// TestEngineHandleGrantFollowsFrequencyChange covers the duplicate-call bug:
+// a re-grant for an already-active talkgroup arriving on a NEW frequency (a
+// band-plan IdentifierUpdate re-mapped the channel, or the call was handed to
+// a new channel). The old code keyed the call on frequency, so the re-grant
+// missed the dedup and bound a SECOND tuner — two "Active calls" rows for the
+// same TG. Now the call is keyed on (System, GroupID, Timeslot) and the bound
+// device follows the call to the new frequency in place.
+func TestEngineHandleGrantFollowsFrequencyChange(t *testing.T) {
+	bus := events.NewBus(16)
+	defer bus.Close()
+	pool, tuners := mkPool(2) // universal tuners (no FrequencyChecker)
+	clock := &fakeClock{t: time.Unix(1000, 0)}
+	e, _ := NewEngine(EngineOptions{
+		Bus:         bus,
+		VoicePool:   pool,
+		Talkgroups:  NewTalkgroupDB(),
+		CallTimeout: 5 * time.Second,
+		Now:         clock.Now,
+	})
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	const f1, f2 = uint32(773_431_250), uint32(773_456_250)
+	e.HandleGrant(Grant{System: "X", Protocol: "p25", GroupID: 1412, FrequencyHz: f1})
+	if got := len(e.ActiveCalls()); got != 1 {
+		t.Fatalf("first grant: active calls = %d, want 1", got)
+	}
+	firstDevice := e.ActiveCalls()[0].Device.Serial
+	firstStarted := e.ActiveCalls()[0].StartedAt
+
+	// Same logical call, new frequency, 20 ms later.
+	clock.t = clock.t.Add(20 * time.Millisecond)
+	e.HandleGrant(Grant{System: "X", Protocol: "p25", GroupID: 1412, FrequencyHz: f2})
+
+	if got := len(e.ActiveCalls()); got != 1 {
+		t.Fatalf("after frequency change: active calls = %d, want 1 (duplicate-call bug)", got)
+	}
+	ac := e.ActiveCalls()[0]
+	if ac.Device.Serial != firstDevice {
+		t.Errorf("call moved devices: got %q, want %q (should follow in place)", ac.Device.Serial, firstDevice)
+	}
+	if ac.Grant.FrequencyHz != f2 {
+		t.Errorf("stored grant frequency = %d, want %d (retune did not update grant)", ac.Grant.FrequencyHz, f2)
+	}
+	if !ac.StartedAt.Equal(firstStarted) {
+		t.Errorf("StartedAt changed on follow: got %v, want %v (call continuity broken)", ac.StartedAt, firstStarted)
+	}
+	if got := tuners[0].tuned(); len(got) != 2 || got[0] != f1 || got[1] != f2 {
+		t.Errorf("device 0 tune sequence = %v, want [%d %d]", got, f1, f2)
+	}
+	if got := tuners[1].tuned(); len(got) != 0 {
+		t.Errorf("device 1 was bound on a frequency change: tuned=%v (should never happen)", got)
+	}
+
+	// Exactly one CallStart — following a call must not emit a new start.
+	deadline := time.Now().Add(200 * time.Millisecond)
+	starts := 0
+	for time.Now().Before(deadline) {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind == events.KindCallStart {
+				starts++
+			}
+		case <-time.After(50 * time.Millisecond):
+		}
+	}
+	if starts != 1 {
+		t.Errorf("CallStart events = %d, want 1", starts)
+	}
+}
+
+// TestEngineHandleGrantFollowsToCapableDevice covers the follow path when the
+// bound device CANNOT reach the new frequency (the call moved outside a
+// wideband tap's window). The stale bind is released and a capable device is
+// bound to the new frequency — still exactly one active call for the TG.
+func TestEngineHandleGrantFollowsToCapableDevice(t *testing.T) {
+	bus := events.NewBus(16)
+	defer bus.Close()
+	// Device order: a band-limited tap first, an unconstrained SDR second.
+	tap := &constrainedTuner{lo: 773_000_000, hi: 774_000_000}
+	universal := &fakeVoiceTuner{}
+	pool := NewVoicePool([]*VoiceDevice{
+		{Tuner: tap, Serial: "wb:dev:tap-0"},
+		{Tuner: universal, Serial: "phys"},
+	})
+	clock := &fakeClock{t: time.Unix(1000, 0)}
+	e, _ := NewEngine(EngineOptions{
+		Bus:         bus,
+		VoicePool:   pool,
+		Talkgroups:  NewTalkgroupDB(),
+		CallTimeout: 5 * time.Second,
+		Now:         clock.Now,
+	})
+
+	const fIn, fOut = uint32(773_431_250), uint32(850_000_000)
+	e.HandleGrant(Grant{System: "X", Protocol: "p25", GroupID: 1412, FrequencyHz: fIn})
+	if got := e.ActiveCalls(); len(got) != 1 || got[0].Device.Serial != "wb:dev:tap-0" {
+		t.Fatalf("first grant should bind the tap; got %+v", got)
+	}
+
+	clock.t = clock.t.Add(20 * time.Millisecond)
+	e.HandleGrant(Grant{System: "X", Protocol: "p25", GroupID: 1412, FrequencyHz: fOut})
+
+	got := e.ActiveCalls()
+	if len(got) != 1 {
+		t.Fatalf("after out-of-window move: active calls = %d, want 1", len(got))
+	}
+	if got[0].Device.Serial != "phys" {
+		t.Errorf("call did not rebind to a capable device: on %q, want phys", got[0].Device.Serial)
+	}
+	if got[0].Grant.FrequencyHz != fOut {
+		t.Errorf("rebound grant frequency = %d, want %d", got[0].Grant.FrequencyHz, fOut)
+	}
+	if len(universal.freqs) != 1 || universal.freqs[0] != fOut {
+		t.Errorf("universal device tune = %v, want [%d]", universal.freqs, fOut)
+	}
+}
+
 // TestEngineHandleGrantSeparatesTimeslots is the DMR Tier III guard:
 // two grants on the same carrier but different TDMA slots are two
 // independent calls and must each bind a device, while a repeat of a
@@ -648,19 +766,31 @@ func TestEngineHandleGrantSeparatesTimeslots(t *testing.T) {
 	}
 }
 
-// TestEngineHandleGrantAllowsDifferentFrequencyGrants is the
-// complement guard for the dedup: a same-TG grant on a different
-// frequency (rare but legitimate — e.g. site rebind on multi-site
-// systems) must NOT be suppressed.
-func TestEngineHandleGrantAllowsDifferentFrequencyGrants(t *testing.T) {
+// TestEngineHandleGrantSameTGNewFrequencyFollowsOneCall asserts the
+// logical-call identity: a same-system, same-TG (same-timeslot) grant on a
+// DIFFERENT frequency is the SAME call that moved channels — it must follow on
+// one device, NOT spawn a second active call. This previously asserted two
+// calls ("rare but legitimate site rebind"), which was exactly the duplicate-
+// "Active calls" bug operators reported (the same TG shown twice on two taps).
+func TestEngineHandleGrantSameTGNewFrequencyFollowsOneCall(t *testing.T) {
 	e, _, bus, _ := mkEngine(t, 2)
 	defer bus.Close()
 
 	e.HandleGrant(Grant{System: "X", Protocol: "p25", GroupID: 100, FrequencyHz: 851_000_000})
 	e.HandleGrant(Grant{System: "X", Protocol: "p25", GroupID: 100, FrequencyHz: 852_000_000})
 
+	if got := len(e.ActiveCalls()); got != 1 {
+		t.Errorf("active calls = %d, want 1 (one call followed to the new frequency)", got)
+	}
+	if got := e.ActiveCalls()[0].Grant.FrequencyHz; got != 852_000_000 {
+		t.Errorf("followed-call frequency = %d, want 852000000", got)
+	}
+
+	// A grant for the same TG on a DIFFERENT system is a distinct call and
+	// must still bind its own device.
+	e.HandleGrant(Grant{System: "Y", Protocol: "p25", GroupID: 100, FrequencyHz: 853_000_000})
 	if got := len(e.ActiveCalls()); got != 2 {
-		t.Errorf("active calls = %d, want 2 (different frequencies)", got)
+		t.Errorf("active calls = %d, want 2 (different systems are distinct calls)", got)
 	}
 }
 

--- a/internal/trunking/voicepool.go
+++ b/internal/trunking/voicepool.go
@@ -224,6 +224,50 @@ func (p *VoicePool) Bind(d *VoiceDevice, g Grant, tg *TalkGroup, now time.Time) 
 	return ac, nil
 }
 
+// Retune follows an already-bound call to a new frequency without ending it:
+// it retunes the device to g.FrequencyHz and replaces the stored Grant and
+// LastHeardAt, preserving StartedAt so the call's duration and identity stay
+// continuous. The engine calls this when a control channel moves an
+// in-progress call to a new channel (a real handoff, or a P25 band-plan
+// IdentifierUpdate re-mapping the channel) — the call is matched by
+// (System, GroupID, Timeslot), so following it here is what stops a second
+// tuner being bound for the same talkgroup.
+//
+// The SetReacquire retry applies exactly as in Bind. Returns an error if the
+// device isn't currently bound or the tune fails after the retry; on error the
+// caller should end the call and rebind a capable device. Note the returned
+// ActiveCall pointer is the same instance Bind handed out, so the engine's
+// mirror sees the updated Grant without any extra bookkeeping.
+func (p *VoicePool) Retune(serial string, g Grant, now time.Time) error {
+	p.mu.Lock()
+	ac, ok := p.active[serial]
+	if !ok {
+		p.mu.Unlock()
+		return errors.New("trunking: device not bound")
+	}
+	d := ac.Device
+	reacquire := p.reacquire
+	p.mu.Unlock()
+	if err := d.Tuner.SetCenterFreq(g.FrequencyHz); err != nil {
+		if reacquire == nil {
+			return err
+		}
+		newTuner, rerr := reacquire(serial)
+		if rerr != nil {
+			return errors.Join(err, rerr)
+		}
+		d.Tuner = newTuner
+		if err2 := d.Tuner.SetCenterFreq(g.FrequencyHz); err2 != nil {
+			return err2
+		}
+	}
+	p.mu.Lock()
+	ac.Grant = g
+	ac.LastHeardAt = now
+	p.mu.Unlock()
+	return nil
+}
+
 // Release marks the device free. Returns the freed ActiveCall (or nil if
 // the device wasn't busy).
 func (p *VoicePool) Release(serial string) *ActiveCall {


### PR DESCRIPTION
## Problem

Operators see the **same talkgroup listed as two simultaneous active calls** on one system — e.g. TG 1412 on `Main_Site_1` shown on two wideband taps (`tap-1` and `tap-2`), elapsed 00:25 and 00:05. A talkgroup is only ever in one call at a time on a system, so this is a tracking bug that also wastes a second tuner and produces a duplicate recording.

## Root cause

The engine's duplicate-grant guard (`internal/trunking/engine.go` `HandleGrant`) keyed an in-progress call on **frequency** (`GroupID + FrequencyHz + Timeslot`). But a call's frequency can change mid-call:

- a P25 Phase 1 `IdentifierUpdate` re-maps the channel→frequency band plan (`BandPlan.Apply` replaces the slot; the grant resolves against the *current* plan), or
- the system hands the call to a new voice channel.

When the frequency changed, the guard's `FrequencyHz` compare missed, `FindFreeForFrequency` returned the *next* free tap, and `startCall`/`Bind` created a **second** `ActiveCall` for the same talkgroup. The original tap kept being grant-refreshed, so both rows persisted.

## Fix

- **Re-key the logical call to `System + GroupID + Timeslot`** (not frequency). `System` keeps two systems' identical TG numbers apart; `Timeslot` preserves the DMR Tier III two-independent-calls-per-carrier rule and the issue #356 same-frequency CC-repeat dedup.
- **Follow the call on a frequency change.** New `VoicePool.Retune` retunes the bound device in place and updates the stored grant, preserving `StartedAt` (no spurious `CallStart`/`CallEnd`). If that device can't reach the new frequency (e.g. outside a wideband tap's window), the stale bind is released and normal allocation binds a capable device — still exactly one call.

Both reuse existing primitives (`Tuner.SetCenterFreq` + the reacquire retry, `FrequencyChecker.CanTune`, `endCall`); no new device/decode machinery.

## Tests

- `TestEngineHandleGrantFollowsFrequencyChange` — same TG, new frequency → one call, same device retuned to the new freq, `StartedAt` preserved, exactly one `CallStart`, second device never bound.
- `TestEngineHandleGrantFollowsToCapableDevice` — when the bound (band-limited) tap can't reach the new freq, the call rebinds to a capable device; still one call.
- Updated the former `…AllowsDifferentFrequencyGrants` test (which asserted the buggy two-call behavior) to assert one *followed* call, and that a different **system** still gets its own call.
- The issue #356 same-frequency dedup and DMR-timeslot guards stay green; full `go test ./internal/trunking/...` passes (`go build ./...`, `go vet`, `gofmt` clean).

## Notes

This makes the engine robust to a changing grant frequency regardless of *why* it changed (a possibly-spurious mid-call `IdentifierUpdate` is left as a separate question). Independent of PR #591 (the demod measurement harness).

https://claude.ai/code/session_012wwH3xYMAAXgtaPkoAcEYY

---
_Generated by [Claude Code](https://claude.ai/code/session_012wwH3xYMAAXgtaPkoAcEYY)_