### PR TITLE
Fix Config Builder opening a blank tab

### DIFF
--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -73,6 +73,22 @@ jobs:
           npm ci --no-audit --no-fund
           npm run build
 
+      - name: Build config builder (/config)
+        shell: bash
+        run: |
+          set -eu
+          cd web/configbuilder
+          npm ci --no-audit --no-fund
+          npm run build
+
+      - name: Build siglab console (/siglab)
+        shell: bash
+        run: |
+          set -eu
+          cd web/siglab
+          npm ci --no-audit --no-fund
+          npm run build
+
       - name: Build gophertrunk.exe
         shell: bash
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,22 @@ jobs:
           npm ci --no-audit --no-fund
           npm run build
 
+      - name: Build config builder (/config)
+        shell: bash
+        run: |
+          set -eu
+          cd web/configbuilder
+          npm ci --no-audit --no-fund
+          npm run build
+
+      - name: Build siglab console (/siglab)
+        shell: bash
+        run: |
+          set -eu
+          cd web/siglab
+          npm ci --no-audit --no-fund
+          npm run build
+
       - name: Build gophertrunk.exe
         shell: bash
         env:
@@ -192,6 +208,20 @@ jobs:
           npm ci --no-audit --no-fund
           npm run build
 
+      - name: Build config builder (/config)
+        run: |
+          set -eu
+          cd web/configbuilder
+          npm ci --no-audit --no-fund
+          npm run build
+
+      - name: Build siglab console (/siglab)
+        run: |
+          set -eu
+          cd web/siglab
+          npm ci --no-audit --no-fund
+          npm run build
+
       - name: Compute version
         id: version
         run: |
@@ -250,6 +280,20 @@ jobs:
         run: |
           set -eu
           cd web
+          npm ci --no-audit --no-fund
+          npm run build
+
+      - name: Build config builder (/config)
+        run: |
+          set -eu
+          cd web/configbuilder
+          npm ci --no-audit --no-fund
+          npm run build
+
+      - name: Build siglab console (/siglab)
+        run: |
+          set -eu
+          cd web/siglab
           npm ci --no-audit --no-fund
           npm run build
 

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -53,8 +53,11 @@ export default defineConfig({
         // works without a network round-trip for the assets).
         globPatterns: ["**/*.{js,css,html,svg,png,ico,webmanifest}"],
         // API responses are always fetched live; the SW never caches
-        // /api/* or /metrics responses.
-        navigateFallbackDenylist: [/^\/api\//, /^\/metrics/],
+        // /api/* or /metrics responses. The Config Builder SPA mounted at
+        // /config/ on the daemon is also denied so this console's SW
+        // (scope "/") doesn't shadow its navigations with our own
+        // index.html — otherwise the Config Builder tab opens blank.
+        navigateFallbackDenylist: [/^\/api\//, /^\/metrics/, /^\/config\//],
       },
       devOptions: { enabled: false },
     }),


### PR DESCRIPTION
The "🛠 Config Builder ↗" button (web/src/App.tsx) opens /config/, served
by the daemon from the SPA embedded via web/configbuilder/embed.go. Two
independent defects each blanked that tab:

1. Release/installer CI only built the main console (cd web && npm run
   build) before `go build`, so the binary embedded an empty
   web/configbuilder/dist (just .gitkeep). HasAssets() was false, the
   GET /config/ route was never mounted, and /config/ fell through to the
   main SPA's index.html — which has no /config/ route. Build the config
   builder (and siglab, which had the same omission) in every release/
   installer job before the Go build, mirroring the main-console step.

2. The main console's PWA service worker (scope "/") uses navigateFallback
   to index.html, so even when the assets were embedded (local `make dist`)
   it intercepted /config/ navigations and served the main app's HTML.
   Deny /config/ in navigateFallbackDenylist so those navigations reach
   the server / the Config Builder's own service worker.

https://claude.ai/code/session_01CA675uweUhfiKbMiRmeW2R