### PR TITLE
Fix P25 Phase 1 voice recording fragmentation: correct LDU1 Link Control octet layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ for tagged releases.
 
 ## [Unreleased]
 
+### Fixed
+
+- **P25 Phase 1 voice recordings no longer fragment into tiny per-LDU files.**
+  A single continuous transmission was being chopped into many ~1-second
+  recordings (each `.raw` an exact multiple of one LDU), because the embedded
+  LDU1 Link Control was reading the talkgroup from the wrong content octets.
+  For the Group Voice Channel User LCO (0x00) the talkgroup lives at octets 4-5
+  and the source at 6-8 (TIA-102.AABF); the decoder was reading the talkgroup
+  from octets 2-3, so it always came back as the constant service-options byte
+  (0x0400 = 1024) while the real talkgroup landed inside the misread source
+  field. With the in-band talkgroup never matching the granted talkgroup, the
+  voice composer's foreign-talkgroup gate ended every call after ~2 LDU1s and
+  the control channel immediately re-granted, spawning a fresh file each time.
+  The Link Control octet layout is corrected (the FEC was always fine) and a
+  regression test now pins the absolute octet positions. As defense-in-depth,
+  the foreign-talkgroup gate now requires the *same* foreign talkgroup across
+  its debounce window so a lone RS-aliased mis-decode can't end a call.
+
 ### Added
 
 - **Signal survey — save it, decode it, run it offline.** Follow-up to the live

--- a/internal/radio/p25/phase1/link_control.go
+++ b/internal/radio/p25/phase1/link_control.go
@@ -19,17 +19,27 @@ import (
 // errors that survive the single-error Hamming layer corrupt the
 // talkgroup/source under marginal SNR.
 //
-// LC content layout is the project's working model — TIA-102.BAAA's
-// per-LCO field tables are not in the repo. It is confined here with a
-// symmetric encoder so a spec correction stays local.
+// LC content layout for the Group Voice Channel User LCO (0x00), per
+// TIA-102.AABF. A symmetric encoder (AssembleLinkControl) keeps the
+// on-wire mapping in one place:
 //
 //	octet 0   : Link Control Format (the LCO opcode)
-//	octet 1   : service options
-//	octets 2-3: talkgroup / destination group
-//	octets 4-6: source unit ID (24 bits)
-//	octets 7-8: reserved
+//	octet 1   : manufacturer's ID (MFID)
+//	octet 2   : service options
+//	octet 3   : reserved
+//	octets 4-5: talkgroup / destination group address (16 bits)
+//	octets 6-8: source unit ID (24 bits)
+//
+// NOTE: a previous working model placed the talkgroup at octets 2-3 and
+// the source at octets 4-6. That shifted both fields: the talkgroup
+// decoded to the (constant) service-options byte — e.g. 0x0400 = 1024 —
+// while the real talkgroup landed inside the misread source field. With
+// the on-air talkgroup never matching the granted talkgroup, the voice
+// composer's foreign-TG gate ended every call after ~2 LDU1s, fragmenting
+// a single transmission into many tiny recordings (the field capture).
 type LinkControl struct {
 	LCFormat       uint8
+	MFID           uint8
 	ServiceOptions uint8
 	TalkgroupID    uint16
 	SourceID       uint32
@@ -176,9 +186,10 @@ func ParseLinkControl(blocks [LDULCESBlockCount][]byte) (LinkControl, int, error
 	oct := bitsToOctets(content)
 	return LinkControl{
 		LCFormat:       oct[0],
-		ServiceOptions: oct[1],
-		TalkgroupID:    uint16(oct[2])<<8 | uint16(oct[3]),
-		SourceID:       uint32(oct[4])<<16 | uint32(oct[5])<<8 | uint32(oct[6]),
+		MFID:           oct[1],
+		ServiceOptions: oct[2],
+		TalkgroupID:    uint16(oct[4])<<8 | uint16(oct[5]),
+		SourceID:       uint32(oct[6])<<16 | uint32(oct[7])<<8 | uint32(oct[8]),
 	}, innerErrs + rsErrs, nil
 }
 
@@ -209,9 +220,11 @@ func ParseLinkControlContent(blocks [LDULCESBlockCount][]byte) ([lcContentOctets
 func AssembleLinkControl(lc LinkControl) [LDULCESBlockCount][]byte {
 	oct := make([]byte, lcContentOctets)
 	oct[0] = lc.LCFormat
-	oct[1] = lc.ServiceOptions
-	oct[2], oct[3] = byte(lc.TalkgroupID>>8), byte(lc.TalkgroupID)
-	oct[4], oct[5], oct[6] = byte(lc.SourceID>>16), byte(lc.SourceID>>8), byte(lc.SourceID)
+	oct[1] = lc.MFID
+	oct[2] = lc.ServiceOptions
+	// oct[3] reserved (0)
+	oct[4], oct[5] = byte(lc.TalkgroupID>>8), byte(lc.TalkgroupID)
+	oct[6], oct[7], oct[8] = byte(lc.SourceID>>16), byte(lc.SourceID>>8), byte(lc.SourceID)
 
 	return lcInnerEncode(rsEncodeContentBits(octetsToBits(oct), 12))
 }

--- a/internal/radio/p25/phase1/link_control_test.go
+++ b/internal/radio/p25/phase1/link_control_test.go
@@ -45,6 +45,7 @@ func TestHamming10_6CorrectsSingleError(t *testing.T) {
 func TestLinkControlRoundTrip(t *testing.T) {
 	in := LinkControl{
 		LCFormat:       0x44,
+		MFID:           0x90,
 		ServiceOptions: 0xC0,
 		TalkgroupID:    0x1234,
 		SourceID:       0x00ABCD,
@@ -58,6 +59,43 @@ func TestLinkControlRoundTrip(t *testing.T) {
 	}
 	if got != in {
 		t.Errorf("round-trip = %+v, want %+v", got, in)
+	}
+}
+
+// TestLinkControlOctetLayout pins the absolute TIA-102.AABF Group Voice
+// Channel User (LCO 0x00) octet positions: TG at octets 4-5, source at
+// octets 6-8, service options at octet 2, MFID at octet 1. It builds the
+// 9 content octets DIRECTLY (not via AssembleLinkControl) so a symmetric
+// encoder/decoder swap can't mask a wrong layout — exactly the failure
+// that fragmented field recordings, where the on-air TG (e.g. 0x086A =
+// 2154) was misread out of octets 4-5 and the decoded talkgroup came back
+// as the constant service-options byte (0x0400 = 1024).
+func TestLinkControlOctetLayout(t *testing.T) {
+	oct := make([]byte, lcContentOctets)
+	oct[0] = LCOGroupVoiceChannelUser         // LCF
+	oct[1] = 0x90                             // MFID
+	oct[2] = 0x04                             // service options
+	oct[3] = 0x00                             // reserved
+	oct[4], oct[5] = 0x08, 0x6A               // talkgroup 0x086A = 2154
+	oct[6], oct[7], oct[8] = 0x12, 0x34, 0x56 // source 0x123456
+
+	// Encode the content bits through the layout-agnostic outer RS +
+	// inner Hamming layers to produce valid on-wire blocks.
+	blocks := lcInnerEncode(rsEncodeContentBits(octetsToBits(oct), 12))
+
+	got, _, err := ParseLinkControl(blocks)
+	if err != nil {
+		t.Fatalf("ParseLinkControl: %v", err)
+	}
+	want := LinkControl{
+		LCFormat:       LCOGroupVoiceChannelUser,
+		MFID:           0x90,
+		ServiceOptions: 0x04,
+		TalkgroupID:    2154,
+		SourceID:       0x123456,
+	}
+	if got != want {
+		t.Errorf("parsed %+v, want %+v", got, want)
 	}
 }
 

--- a/internal/voice/composer/boundary.go
+++ b/internal/voice/composer/boundary.go
@@ -48,18 +48,20 @@ type boundaryTracker struct {
 	sawVoice      atomic.Bool
 
 	// Chain-goroutine-only state.
-	lastMatch      bool // most recent talkgroup-match decision (LDU2 etc. inherit it)
-	foreignRun     int  // consecutive frames with a known foreign talkgroup
-	voiceSinceRoll bool // wrote audio since the last segment roll / start
+	lastMatch      bool   // most recent talkgroup-match decision (LDU2 etc. inherit it)
+	foreignRun     int    // consecutive frames carrying the SAME foreign talkgroup
+	lastForeignTG  uint32 // the foreign talkgroup foreignRun is counting
+	voiceSinceRoll bool   // wrote audio since the last segment roll / start
 	lastTouchNano  int64
 	endOnce        sync.Once
 }
 
-// foreignRunToEnd is how many consecutive frames carrying a known
+// foreignRunToEnd is how many consecutive frames carrying the SAME known
 // foreign talkgroup end the call. A couple of frames debounces a single
 // mis-decoded Link Control word without letting a real foreign
 // transmission append more than ~one LDU of audio (which is gated out
-// anyway).
+// anyway). Requiring the same value across the run guards against a
+// one-off RS-aliased mis-decode (a garbage-but-valid LC) ending a call.
 const foreignRunToEnd = 2
 
 func (c *Composer) newBoundaryTracker(serial string, grantTG uint32, patched []uint32) *boundaryTracker {
@@ -94,6 +96,13 @@ func (bt *boundaryTracker) onVoice(tg uint32) bool {
 		if bt.lastMatch {
 			bt.foreignRun = 0
 		} else {
+			// Only count a sustained run of the SAME foreign talkgroup;
+			// a different value restarts the debounce so a lone mis-decode
+			// can't tip the count over the edge.
+			if tg != bt.lastForeignTG {
+				bt.lastForeignTG = tg
+				bt.foreignRun = 0
+			}
 			bt.foreignRun++
 			if bt.foreignRun >= foreignRunToEnd {
 				// A different talkgroup has taken this (shared) frequency;


### PR DESCRIPTION
A continuous P25 Phase 1 voice transmission was being chopped into many
~1-second recordings (each .raw an exact multiple of one 99-byte LDU),
because the embedded LDU1 Link Control read the talkgroup from the wrong
content octets.

For the Group Voice Channel User LCO (0x00), TIA-102.AABF places the
talkgroup at octets 4-5 and the source at 6-8. The decoder was reading the
talkgroup from octets 2-3, so it always decoded to the constant
service-options byte (0x0400 = 1024) while the real talkgroup landed inside
the misread 24-bit source field. The FEC (inner Hamming + outer RS) was
always correct — only the field mapping was wrong, which is why the
encoder/decoder round-trip tests (sharing the same wrong layout) never
caught it.

With the in-band talkgroup never matching the granted talkgroup, the voice
composer's foreign-talkgroup gate (boundary.go) ended every call after ~2
LDU1s; the control channel immediately re-granted the same TG and a fresh
recording opened each time, producing "tons of small files".

Changes:
- Correct the LinkControl octet layout in ParseLinkControl /
  AssembleLinkControl and add an MFID field; update the doc comment to the
  real TIA-102.AABF LCO-0 table.
- Add TestLinkControlOctetLayout, which pins the absolute octet positions by
  building content octets directly (a symmetric encoder/decoder round-trip
  cannot catch a layout swap).
- Harden the foreign-talkgroup gate to require the same foreign talkgroup
  across its debounce window, so a lone RS-aliased mis-decode can't end a
  call (defense-in-depth).

https://claude.ai/code/session_01G1ueHk3H5dx3LEh2ehSLtt