### PR TITLE
Selectable C4FM constellation display (IQ ring vs soft levels)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ for tagged releases.
 
 ## [Unreleased]
 
+### Added
+
+- **Constellation: selectable C4FM display (IQ ring vs. soft levels)** (#557).
+  C4FM is constant-envelope FM with no complex symbol constellation, so the
+  Symbols view previously plotted its soft decisions as a thin horizontal line
+  on the real axis. A new **Display** control (shown for C4FM) chooses between
+  the **IQ ring** — the raw constant-envelope circle most operators expect,
+  now the default — and the legacy **Soft levels** line. CQPSK is unchanged.
+
 ### Fixed
 
 - **Constellation / signal scopes stuck on "waiting for symbols"** (#557,

--- a/web/src/panels/Constellation.test.tsx
+++ b/web/src/panels/Constellation.test.tsx
@@ -99,15 +99,47 @@ describe("Constellation panel", () => {
     expect(callArgs?.rate).toBeGreaterThan(0);
   });
 
-  it("re-subscribes the symbol stream when the demod mode changes", async () => {
+  it("re-subscribes the symbol stream when switching to CQPSK", async () => {
     vi.mocked(fetchSpectrumDevices).mockResolvedValue(ONE_DEVICE as never);
 
     render(<Constellation />);
     await waitFor(() => {
       expect(openSymbolStream).toHaveBeenCalledTimes(1);
     });
+    // Default Mode is CQPSK, so the symbol stream is already CQPSK; flip to
+    // C4FM and back to confirm CQPSK re-subscribes the symbol stream.
     fireEvent.change(screen.getByLabelText("Demodulation mode"), {
       target: { value: "p25-c4fm" },
+    });
+    fireEvent.change(screen.getByLabelText("Demodulation mode"), {
+      target: { value: "p25-cqpsk" },
+    });
+    await waitFor(() => {
+      const last = vi.mocked(openSymbolStream).mock.calls.at(-1)?.[1];
+      expect(last?.proto).toBe("p25-cqpsk");
+    });
+  });
+
+  it("shows the C4FM IQ ring by default and can switch to soft levels", async () => {
+    vi.mocked(fetchSpectrumDevices).mockResolvedValue(ONE_DEVICE as never);
+
+    render(<Constellation />);
+    await waitFor(() => {
+      expect(openSymbolStream).toHaveBeenCalledTimes(1);
+    });
+
+    // Switching Mode to C4FM (default Display = IQ ring) opens the raw IQ
+    // stream, not the symbol stream — C4FM has no symbol constellation.
+    fireEvent.change(screen.getByLabelText("Demodulation mode"), {
+      target: { value: "p25-c4fm" },
+    });
+    await waitFor(() => {
+      expect(openIQStream).toHaveBeenCalledTimes(1);
+    });
+
+    // Choosing "Soft levels" falls back to the symbol stream with C4FM.
+    fireEvent.change(screen.getByLabelText("C4FM display"), {
+      target: { value: "soft" },
     });
     await waitFor(() => {
       const last = vi.mocked(openSymbolStream).mock.calls.at(-1)?.[1];

--- a/web/src/panels/Constellation.tsx
+++ b/web/src/panels/Constellation.tsx
@@ -20,10 +20,12 @@ import { TuningControls } from "../components/TuningControls";
 //     *true* constellation: post matched-filter, timing recovery and
 //     carrier recovery, sampled once per symbol. P25 CQPSK reads as four
 //     tight clusters at ±45°/±135° (degrading to a smeared X as the eye
-//     closes); P25 C4FM has no complex symbol domain, so its four soft
-//     levels are plotted on the real axis (the open 4-level eye/symbol
-//     scope is C4FM's natural quality view). This is the modulation-
-//     quality picture OP25 shows on its Constellation tab.
+//     closes). P25 C4FM has no complex symbol domain, so the Display
+//     control picks how to show it: "IQ ring" (default) draws the raw
+//     constant-envelope circle the operator expects, while "Soft levels"
+//     plots the four soft decisions on the real axis (the open 4-level
+//     eye/symbol scope is C4FM's natural quality view). This is the
+//     modulation-quality picture OP25 shows on its Constellation tab.
 //
 //   • Vector scope (raw IQ) — the wideband decimated IQ trajectory,
 //     every sample including the transitions between symbols (no matched
@@ -45,6 +47,9 @@ const TARGET_RATE_SPS = 2000;
 
 // View source for the scatter (persisted in prefs).
 type View = "symbols" | "raw";
+// How the C4FM constellation is drawn (persisted in prefs): the raw IQ
+// "ring" (constant-envelope circle) or the four soft-decision "levels".
+type C4fmDisplay = "ring" | "soft";
 
 const PROTOS: { value: string; label: string }[] = [
   { value: "p25-cqpsk", label: "P25 CQPSK" },
@@ -118,6 +123,9 @@ export function Constellation() {
 
   const [view, setView] = useState<View>(() => prefs.constellationView());
   const [proto, setProto] = useState<string>(() => prefs.constellationProto());
+  const [c4fmDisplay, setC4fmDisplay] = useState<C4fmDisplay>(() =>
+    prefs.constellationC4fmDisplay(),
+  );
   const [offsetKHz, setOffsetKHz] = useState<number>(() =>
     prefs.constellationOffsetKHz(),
   );
@@ -134,13 +142,25 @@ export function Constellation() {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const bufferRef = useRef<IQPoint[]>([]);
   const scaleRef = useRef<number>(1);
+  // Which stream feeds the scatter. The raw View always uses the wideband
+  // IQ trajectory. In the symbols View, CQPSK uses the symbol-decision
+  // stream; C4FM has no symbol constellation, so it shows the raw IQ ring
+  // by default (the constant-envelope circle the operator expects) unless
+  // they pick "Soft levels" for the legacy real-axis decision points.
+  const source: "iq" | "symbols" =
+    view === "raw"
+      ? "iq"
+      : proto === "p25-c4fm" && c4fmDisplay === "ring"
+        ? "iq"
+        : "symbols";
+
   // Ideal cluster markers depend on the active source: clusters on the
-  // diagonals for CQPSK symbols, levels on the real axis for C4FM
-  // symbols, none for the raw vector scope.
+  // diagonals for CQPSK symbols, levels on the real axis for the C4FM
+  // soft-level view, none for the raw vector scope / IQ ring.
   const markers = useMemo<IQPoint[]>(() => {
-    if (view !== "symbols") return [];
+    if (source !== "symbols") return [];
     return proto === "p25-c4fm" ? C4FM_MARKERS : CQPSK_MARKERS;
-  }, [view, proto]);
+  }, [source, proto]);
   const optsRef = useRef<RenderOpts>({
     dcBlock,
     autoScale,
@@ -270,6 +290,9 @@ export function Constellation() {
   useEffect(() => {
     prefs.setConstellationProto(proto);
   }, [proto]);
+  useEffect(() => {
+    prefs.setConstellationC4fmDisplay(c4fmDisplay);
+  }, [c4fmDisplay]);
 
   // Push a fresh batch of points into the rolling buffer and repaint.
   const pushPoints = (pts: IQPoint[]) => {
@@ -281,9 +304,10 @@ export function Constellation() {
     renderConstellation(canvasRef.current, bufferRef.current, optsRef.current);
   };
 
-  // Raw vector-scope stream: wideband decimated IQ trajectory.
+  // Raw IQ stream: the wideband decimated IQ trajectory (vector scope, and
+  // the C4FM constant-envelope ring).
   useEffect(() => {
-    if (!selected || view !== "raw") return;
+    if (!selected || source !== "iq") return;
     bufferRef.current = [];
     scaleRef.current = 1;
     setLatest(null);
@@ -300,13 +324,13 @@ export function Constellation() {
     });
     return () => stream.close();
     // Re-subscribe when the offset changes so the server re-mixes.
-  }, [cfg, selected, view, clampedOffsetKHz]);
+  }, [cfg, selected, source, clampedOffsetKHz]);
 
   // Symbols stream: the receiver's symbol-decision points (true
   // constellation). CQPSK carries complex points (sym_i/sym_q); C4FM has
   // none, so its 4 soft levels are plotted on the real axis.
   useEffect(() => {
-    if (!selected || view !== "symbols") return;
+    if (!selected || source !== "symbols") return;
     bufferRef.current = [];
     scaleRef.current = 1;
     setSymLatest(null);
@@ -329,7 +353,7 @@ export function Constellation() {
       onStatus: setConn,
     });
     return () => stream.close();
-  }, [cfg, selected, view, proto, clampedOffsetKHz]);
+  }, [cfg, selected, source, proto, clampedOffsetKHz]);
 
   // Prefer the device centre so the frequency view shows before the first
   // frame; fall back to the frame's stamped centre.
@@ -344,7 +368,7 @@ export function Constellation() {
         ? "centre"
         : `${clampedOffsetKHz >= 0 ? "+" : ""}${clampedOffsetKHz.toFixed(3).replace(/\.?0+$/, "")} kHz`;
     const head = `${(viewHz / 1e6).toFixed(4)} MHz (${off})`;
-    if (view === "symbols") {
+    if (source === "symbols") {
       if (!symLatest) return `${head} · waiting for symbols…`;
       const kind =
         symLatest.sym_i && symLatest.sym_i.length > 0
@@ -354,7 +378,7 @@ export function Constellation() {
     }
     if (!latest) return `${head} · waiting for samples…`;
     return `${head} · ${latest.sample_rate} sps · ${latest.energy_dbfs.toFixed(1)} dBFS`;
-  }, [view, latest, symLatest, viewHz, clampedOffsetKHz]);
+  }, [source, latest, symLatest, viewHz, clampedOffsetKHz]);
 
   return (
     <div className="space-y-3">
@@ -414,6 +438,21 @@ export function Constellation() {
                   {p.label}
                 </option>
               ))}
+            </select>
+          </label>
+        )}
+
+        {view === "symbols" && proto === "p25-c4fm" && (
+          <label className="flex items-center gap-2">
+            <span className="text-muted">Display</span>
+            <select
+              className="bg-surface border border-border rounded px-2 py-1"
+              value={c4fmDisplay}
+              onChange={(e) => setC4fmDisplay(e.target.value as C4fmDisplay)}
+              aria-label="C4FM display"
+            >
+              <option value="ring">IQ ring (circle)</option>
+              <option value="soft">Soft levels (line)</option>
             </select>
           </label>
         )}
@@ -487,26 +526,36 @@ export function Constellation() {
       </div>
 
       <div className="text-[11px] text-muted">
-        {view === "symbols" ? (
-          proto === "p25-c4fm" ? (
+        {view === "symbols" && proto === "p25-c4fm" ? (
+          c4fmDisplay === "ring" ? (
+            <>
+              C4FM is constant-envelope FM with no symbol constellation, so
+              this shows the raw IQ vector scope — the constant-envelope
+              ring / concentric arcs the signal traces. Tune the{" "}
+              <em>Offset</em> onto a locked channel to lift it off the centre
+              DC spike. Switch <em>Display</em> to <em>Soft levels</em> for
+              the 4-level decision points, or use the <em>Eye</em> /{" "}
+              <em>Symbol scope</em> panel for C4FM modulation quality.
+            </>
+          ) : (
             <>
               Plots the receiver's recovered C4FM symbols. C4FM has no
               complex constellation, so its four soft levels appear on the
               real axis (rings mark the ideal ±1/±3 positions) — the open
               4-level eye on the <em>Symbol scope</em> is C4FM's natural
-              quality view. Switch <em>Mode</em> to CQPSK for a 2D
-              constellation, or <em>View</em> to the vector scope for the
-              raw IQ trajectory.
-            </>
-          ) : (
-            <>
-              Plots the receiver's symbol-decision points — the true
-              constellation. A clean CQPSK/LSM signal forms four tight
-              clusters on the ±45° diagonals (rings); a closing eye smears
-              them into an X. Tune the <em>Offset</em> onto a locked
-              channel; brightest = most recent.
+              quality view. Switch <em>Display</em> to <em>IQ ring</em> for
+              the constant-envelope circle, or <em>Mode</em> to CQPSK for a
+              2D constellation.
             </>
           )
+        ) : view === "symbols" ? (
+          <>
+            Plots the receiver's symbol-decision points — the true
+            constellation. A clean CQPSK/LSM signal forms four tight
+            clusters on the ±45° diagonals (rings); a closing eye smears
+            them into an X. Tune the <em>Offset</em> onto a locked
+            channel; brightest = most recent.
+          </>
         ) : (
           <>
             Vector scope: plots decimated IQ samples ({TARGET_RATE_SPS} sps,

--- a/web/src/store/prefs.ts
+++ b/web/src/store/prefs.ts
@@ -22,6 +22,7 @@ const LS_KEYS = {
   constellationZoom: "gt.constellation.zoom",
   constellationView: "gt.constellation.view",
   constellationProto: "gt.constellation.proto",
+  constellationC4fmDisplay: "gt.constellation.c4fmDisplay",
   symbolScopeOffsetKHz: "gt.symbolScope.offsetKHz",
   symbolScopeHold: "gt.symbolScope.hold",
   symbolScopeProto: "gt.symbolScope.proto",
@@ -205,6 +206,15 @@ export const prefs = {
   },
   setConstellationProto(p: string) {
     writeLS(LS_KEYS.constellationProto, p);
+  },
+  // How the C4FM constellation is drawn: "ring" shows the constant-envelope
+  // raw IQ circle (C4FM has no symbol constellation), "soft" shows the four
+  // soft-decision levels on the real axis. Default "ring".
+  constellationC4fmDisplay(): "ring" | "soft" {
+    return readLS(LS_KEYS.constellationC4fmDisplay) === "soft" ? "soft" : "ring";
+  },
+  setConstellationC4fmDisplay(v: "ring" | "soft") {
+    writeLS(LS_KEYS.constellationC4fmDisplay, v);
   },
 
   // Symbol-scope panel view options. Offset (kHz, relative to the SDR


### PR DESCRIPTION
## Why

C4FM is constant-envelope FM with no complex symbol constellation, so the Constellation panel plotted its soft decisions as a thin horizontal line on the real axis. That's technically correct but unhelpful — operators expect a 2D shape (the constant-envelope "circle"), as reported on Discord.

## What

Adds a **Display** control (shown only for C4FM in the Symbols view) that chooses between two visualizations, instead of silently replacing one:

- **IQ ring (circle)** — the raw constant-envelope circle from the existing `/api/v1/diag/iq` stream. **New default.**
- **Soft levels (line)** — the legacy four-level real-axis decision points.

CQPSK and the generic **Vector scope (raw IQ)** view are untouched.

## How

- A derived `source` (`"iq" | "symbols"`) decouples the data stream from the View toggle, routing C4FM to the existing raw IQ stream when "ring" is selected. The two stream effects, the ideal-cluster markers, and the tuning label all key off `source`.
- The choice persists via a new `constellationC4fmDisplay` pref (default `"ring"`).
- Help/description text updated for both C4FM modes, pointing operators to the Eye / Symbol scope for C4FM modulation quality.

Frontend-only — both data sources already existed in the panel; this just adds the control to pick between them.

## Files

- `web/src/panels/Constellation.tsx`
- `web/src/panels/Constellation.test.tsx`
- `web/src/store/prefs.ts`
- `CHANGELOG.md`

## Verification

- `npx tsc --noEmit` — clean
- `npm run test` (Constellation) — 11 passing, incl. new coverage that C4FM opens the IQ stream by default and switches to the symbol stream on "Soft levels"
- `npm run build` — succeeds

Relates to #557.

https://claude.ai/code/session_01GfmsQTVscYv9i1uTrUka7E

---
_Generated by [Claude Code](https://claude.ai/code/session_01GfmsQTVscYv9i1uTrUka7E)_