### PR TITLE
Fix #598: support HTTP Range requests on live audio stream

### DIFF
--- a/internal/api/handlers_audio_stream.go
+++ b/internal/api/handlers_audio_stream.go
@@ -2,10 +2,22 @@ package api
 
 import (
 	"encoding/binary"
+	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
 	"time"
+)
+
+// WAV streaming envelope sizes. The header bakes in a near-2 GiB data
+// chunk so streaming consumers keep reading until the connection
+// closes; the Range responses below advertise a matching total so
+// Safari (which only plays media from a byte-serving server) accepts
+// the stream.
+const (
+	wavHeaderSize  = 44
+	wavMaxDataSize = uint32(0x7FFFFFFF) // declared data chunk size
+	wavTotalSize   = int64(wavHeaderSize) + int64(wavMaxDataSize)
 )
 
 // handleAudioStream emits a continuous WAV body assembled from PCM
@@ -26,6 +38,14 @@ import (
 // The handler disables the server-level WriteTimeout per-request via
 // http.ResponseController so the long-lived connection doesn't get
 // torn down mid-call.
+//
+// Range requests are honored so Safari (macOS/iOS) plays the stream:
+// its media element refuses to play unless the server answers a
+// `Range:` request with 206 + Accept-Ranges + Content-Range. Safari
+// first issues a small probe (e.g. `bytes=0-1`) to learn the size,
+// then an open-ended `bytes=0-` for the bulk body. Clients that don't
+// send a Range header (Chrome, Firefox, curl) keep the plain 200
+// streaming path.
 func (s *Server) handleAudioStream(w http.ResponseWriter, r *http.Request) {
 	if s.audioPub == nil {
 		s.writeError(w, http.StatusServiceUnavailable, "audio stream not wired")
@@ -36,11 +56,6 @@ func (s *Server) handleAudioStream(w http.ResponseWriter, r *http.Request) {
 		s.writeError(w, http.StatusInternalServerError, "streaming not supported")
 		return
 	}
-	_ = http.NewResponseController(w).SetWriteDeadline(time.Time{})
-
-	filter := parseAudioStreamFilter(r)
-	sub := s.audioPub.Subscribe(filter)
-	defer s.audioPub.Unsubscribe(sub)
 
 	// Sample rate is fixed at 8000 Hz today (matches the composer's
 	// recorder rate; see audio_publisher.go buildPCMFrame). When
@@ -51,17 +66,59 @@ func (s *Server) handleAudioStream(w http.ResponseWriter, r *http.Request) {
 		rate = s.audio.SampleRate()
 	}
 
+	start, end, hasRange := parseRange(r.Header.Get("Range"))
+
+	// Safari's size probe: a bounded range fully inside the
+	// deterministic WAV header. Serve the exact header bytes and
+	// close — no live subscription required.
+	if hasRange && end >= 0 && end < wavHeaderSize {
+		header := streamingWAVHeader(rate)
+		body := header[start : end+1]
+		w.Header().Set("Content-Type", "audio/wav")
+		w.Header().Set("Cache-Control", "no-cache, no-store")
+		w.Header().Set("Accept-Ranges", "bytes")
+		w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, wavTotalSize))
+		w.Header().Set("Content-Length", strconv.Itoa(len(body)))
+		w.WriteHeader(http.StatusPartialContent)
+		_, _ = w.Write(body)
+		return
+	}
+
+	// Long-lived response from here on: clear the write deadline so
+	// the connection isn't torn down mid-call.
+	_ = http.NewResponseController(w).SetWriteDeadline(time.Time{})
+
+	filter := parseAudioStreamFilter(r)
+	sub := s.audioPub.Subscribe(filter)
+	defer s.audioPub.Unsubscribe(sub)
+
 	w.Header().Set("Content-Type", "audio/wav")
 	w.Header().Set("Cache-Control", "no-cache, no-store")
 	w.Header().Set("X-Accel-Buffering", "no")
-	// No Content-Length: this is an open-ended stream. Chrome,
-	// Firefox, and Safari play streaming WAV when the data chunk
-	// claims a near-2 GiB length and the response uses chunked
-	// transfer encoding.
-	w.WriteHeader(http.StatusOK)
 
-	if _, err := w.Write(streamingWAVHeader(rate)); err != nil {
-		return
+	if hasRange {
+		// Open-ended `bytes=N-` (or a range extending past the
+		// header). A live stream has no real seek target, so we
+		// advertise a matching Content-Range and stream live; the
+		// only meaningful offset is whether the caller still needs
+		// the leading header bytes.
+		w.Header().Set("Accept-Ranges", "bytes")
+		w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, wavTotalSize-1, wavTotalSize))
+		w.WriteHeader(http.StatusPartialContent)
+		if start < wavHeaderSize {
+			if _, err := w.Write(streamingWAVHeader(rate)[start:]); err != nil {
+				return
+			}
+		}
+	} else {
+		// No Range: plain open-ended stream. Chrome, Firefox, and
+		// curl play streaming WAV when the data chunk claims a
+		// near-2 GiB length and the response uses chunked transfer
+		// encoding.
+		w.WriteHeader(http.StatusOK)
+		if _, err := w.Write(streamingWAVHeader(rate)); err != nil {
+			return
+		}
 	}
 	flusher.Flush()
 
@@ -86,6 +143,42 @@ func (s *Server) handleAudioStream(w http.ResponseWriter, r *http.Request) {
 			flusher.Flush()
 		}
 	}
+}
+
+// parseRange parses a single "bytes=start-end" Range header. It
+// returns start, end (end == -1 for an open-ended "bytes=N-"), and ok.
+// ok is false for an empty header, a non-"bytes=" unit, suffix ranges
+// ("bytes=-N"), multi-range requests, or any malformed input — callers
+// then fall back to the plain 200 stream, which is safe for non-Safari
+// clients.
+func parseRange(h string) (start int64, end int64, ok bool) {
+	h = strings.TrimSpace(h)
+	const prefix = "bytes="
+	if !strings.HasPrefix(h, prefix) {
+		return 0, 0, false
+	}
+	spec := strings.TrimPrefix(h, prefix)
+	if strings.Contains(spec, ",") { // multi-range unsupported
+		return 0, 0, false
+	}
+	dash := strings.IndexByte(spec, '-')
+	if dash <= 0 { // missing start (suffix range) or no dash
+		return 0, 0, false
+	}
+	startStr := strings.TrimSpace(spec[:dash])
+	endStr := strings.TrimSpace(spec[dash+1:])
+	start, err := strconv.ParseInt(startStr, 10, 64)
+	if err != nil || start < 0 {
+		return 0, 0, false
+	}
+	if endStr == "" {
+		return start, -1, true
+	}
+	end, err = strconv.ParseInt(endStr, 10, 64)
+	if err != nil || end < start {
+		return 0, 0, false
+	}
+	return start, end, true
 }
 
 // parseAudioStreamFilter pulls the device + talkgroup filters off
@@ -131,8 +224,7 @@ func streamingWAVHeader(sampleRate uint32) []byte {
 	byteRate := sampleRate * uint32(numChannels) * uint32(bitsPerSample) / 8
 	blockAlign := numChannels * bitsPerSample / 8
 
-	const maxDataSize uint32 = 0x7FFFFFFF
-	chunkSize := maxDataSize - 36 // best-effort: data chunk + header overhead
+	chunkSize := wavMaxDataSize - 36 // best-effort: data chunk + header overhead
 
 	buf := make([]byte, 44)
 	copy(buf[0:4], "RIFF")
@@ -147,6 +239,6 @@ func streamingWAVHeader(sampleRate uint32) []byte {
 	binary.LittleEndian.PutUint16(buf[32:34], blockAlign)
 	binary.LittleEndian.PutUint16(buf[34:36], bitsPerSample)
 	copy(buf[36:40], "data")
-	binary.LittleEndian.PutUint32(buf[40:44], maxDataSize)
+	binary.LittleEndian.PutUint32(buf[40:44], wavMaxDataSize)
 	return buf
 }

--- a/internal/api/handlers_audio_stream_test.go
+++ b/internal/api/handlers_audio_stream_test.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -154,6 +155,134 @@ func TestAudioStream_EmitsWAVHeaderAndPCM(t *testing.T) {
 	}
 	if len(got) < 2 {
 		t.Fatalf("did not receive any PCM bytes after header (got %d)", len(got))
+	}
+}
+
+func TestParseRange(t *testing.T) {
+	cases := []struct {
+		name      string
+		header    string
+		wantStart int64
+		wantEnd   int64
+		wantOK    bool
+	}{
+		{"probe", "bytes=0-1", 0, 1, true},
+		{"open ended", "bytes=0-", 0, -1, true},
+		{"past header", "bytes=44-", 44, -1, true},
+		{"bounded mid", "bytes=10-20", 10, 20, true},
+		{"empty", "", 0, 0, false},
+		{"suffix", "bytes=-100", 0, 0, false},
+		{"multi range", "bytes=0-1,2-3", 0, 0, false},
+		{"bad unit", "items=0-1", 0, 0, false},
+		{"garbage", "bytes=abc", 0, 0, false},
+		{"end before start", "bytes=20-10", 0, 0, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			start, end, ok := parseRange(tc.header)
+			if ok != tc.wantOK {
+				t.Fatalf("ok=%v want %v", ok, tc.wantOK)
+			}
+			if !ok {
+				return
+			}
+			if start != tc.wantStart || end != tc.wantEnd {
+				t.Errorf("got (%d,%d) want (%d,%d)", start, end, tc.wantStart, tc.wantEnd)
+			}
+		})
+	}
+}
+
+// Safari probes the size with a small bounded Range. The endpoint must
+// answer 206 with Accept-Ranges + Content-Range and the exact header
+// bytes, then close — without a live subscription.
+func TestAudioStream_ProbeRange(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	pub, err := NewAudioPublisher(bus, slog.Default())
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = pub.Run(ctx) }()
+	defer pub.Close()
+
+	fa := newFakeAudio()
+	base, teardown := mkServer(t, ServerOptions{Bus: bus, Audio: fa, AudioPublisher: pub})
+	defer teardown()
+
+	req, _ := http.NewRequest(http.MethodGet, base+"/api/v1/audio/stream", nil)
+	req.Header.Set("Range", "bytes=0-1")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusPartialContent {
+		t.Fatalf("status=%d want 206", resp.StatusCode)
+	}
+	if ar := resp.Header.Get("Accept-Ranges"); ar != "bytes" {
+		t.Errorf("Accept-Ranges=%q want bytes", ar)
+	}
+	wantCR := "bytes 0-1/" + strconv.FormatInt(wavTotalSize, 10)
+	if cr := resp.Header.Get("Content-Range"); cr != wantCR {
+		t.Errorf("Content-Range=%q want %q", cr, wantCR)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	if !bytes.Equal(body, []byte("RI")) {
+		t.Errorf("body=%q want first 2 header bytes %q", body, "RI")
+	}
+}
+
+// Safari's bulk fetch is an open-ended Range. The endpoint must answer
+// 206 with Accept-Ranges and a valid WAV header before live PCM.
+func TestAudioStream_OpenEndedRange(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	pub, err := NewAudioPublisher(bus, slog.Default())
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = pub.Run(ctx) }()
+	defer pub.Close()
+
+	fa := newFakeAudio()
+	base, teardown := mkServer(t, ServerOptions{Bus: bus, Audio: fa, AudioPublisher: pub})
+	defer teardown()
+
+	reqCtx, reqCancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer reqCancel()
+	req, _ := http.NewRequestWithContext(reqCtx, http.MethodGet, base+"/api/v1/audio/stream", nil)
+	req.Header.Set("Range", "bytes=0-")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusPartialContent {
+		t.Fatalf("status=%d want 206", resp.StatusCode)
+	}
+	if ar := resp.Header.Get("Accept-Ranges"); ar != "bytes" {
+		t.Errorf("Accept-Ranges=%q want bytes", ar)
+	}
+	if cr := resp.Header.Get("Content-Range"); cr == "" {
+		t.Error("Content-Range missing")
+	}
+	header := make([]byte, 44)
+	if _, err := io.ReadFull(resp.Body, header); err != nil {
+		t.Fatalf("read header: %v", err)
+	}
+	if !bytes.Equal(header[0:4], []byte("RIFF")) {
+		t.Errorf("response magic=%q want RIFF", header[0:4])
+	}
+	if !bytes.Equal(header[8:12], []byte("WAVE")) {
+		t.Errorf("response type=%q want WAVE", header[8:12])
 	}
 }
 

--- a/web/src/components/AudioPlayer.tsx
+++ b/web/src/components/AudioPlayer.tsx
@@ -59,8 +59,11 @@ export function AudioPlayer() {
     try {
       await el.play();
       setEnabled(true);
-    } catch {
-      // Autoplay blocked. The next user gesture will retry.
+    } catch (err) {
+      // Autoplay blocked, or the media failed to load (e.g. a server
+      // without Range support trips Safari). Surface it so the failure
+      // isn't invisible; the next user gesture will retry.
+      console.warn("AudioPlayer: enable failed", err);
       setEnabled(false);
     }
   };
@@ -163,6 +166,12 @@ export function AudioPlayer() {
         ref={audioRef}
         preload="none"
         playsInline
+        onError={(e) => {
+          console.warn(
+            "AudioPlayer: media error",
+            e.currentTarget.error,
+          );
+        }}
         // Keep the player on-screen but visually empty; controls are
         // bespoke above so the lockscreen MediaSession is the only
         // public surface.


### PR DESCRIPTION
Safari's media element (macOS/iOS) refuses to play audio unless the
server honors Range requests with 206 + Accept-Ranges + Content-Range.
The /api/v1/audio/stream endpoint only ever returned a plain 200
open-ended WAV body, so "Tap to enable audio" silently failed on macOS
(el.play() rejected and the catch block swallowed the error), while
Chrome/Firefox tolerated the plain stream.

handleAudioStream now handles the two requests Safari makes: a small
bounded probe (e.g. bytes=0-1) served from the deterministic WAV header
with 206, and an open-ended bytes=N- request that streams live PCM with
a matching Content-Range. Requests without a Range header keep the
existing 200 path. Promote the WAV size to shared constants so the
header and Content-Range agree, and add a parseRange helper.

Frontend: log enable() failures and add an <audio> onError handler so
playback failures surface in the console instead of dying silently.