### PR TITLE
config: resolve path fields against config dir

### DIFF
--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -109,8 +109,12 @@ jobs:
           STAGE=dist/staging
           cp README.md LICENSE config.example.yaml "$STAGE/"
           cp docs/install-windows.md "$STAGE/INSTALL-WINDOWS.md"
-          mkdir -p "$STAGE/gophertrunk-web"
+          # All three consoles nest under gophertrunk-web/; the Inno
+          # Setup script copies the whole tree into <DataRoot>\web.
+          mkdir -p "$STAGE/gophertrunk-web/siglab" "$STAGE/gophertrunk-web/configbuilder"
           cp -r web/dist/. "$STAGE/gophertrunk-web/"
+          cp -r web/siglab/dist/. "$STAGE/gophertrunk-web/siglab/"
+          cp -r web/configbuilder/dist/. "$STAGE/gophertrunk-web/configbuilder/"
 
       - name: Download Zadig (pinned + SHA256-verified)
         shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,12 +106,15 @@ jobs:
           STAGE=dist/staging
           cp README.md LICENSE config.example.yaml "$STAGE/"
           cp docs/install-windows.md "$STAGE/INSTALL-WINDOWS.md"
-          # Standalone browser console bundled into each release. The
-          # Inno Setup script consumes this directory and asks the
-          # user where to install it; the portable ZIP just includes
-          # it next to the binary.
-          mkdir -p "$STAGE/gophertrunk-web"
+          # Standalone browser consoles bundled into each release. All
+          # three UIs nest under gophertrunk-web/ (standard console at
+          # the top, siglab/ and configbuilder/ alongside). The Inno
+          # Setup script copies this whole tree into <DataRoot>\web; the
+          # portable ZIP just includes it next to the binary.
+          mkdir -p "$STAGE/gophertrunk-web/siglab" "$STAGE/gophertrunk-web/configbuilder"
           cp -r web/dist/. "$STAGE/gophertrunk-web/"
+          cp -r web/siglab/dist/. "$STAGE/gophertrunk-web/siglab/"
+          cp -r web/configbuilder/dist/. "$STAGE/gophertrunk-web/configbuilder/"
 
       - name: Download Zadig (pinned + SHA256-verified)
         shell: pwsh
@@ -174,8 +177,10 @@ jobs:
             ./cmd/gophertrunk
           cp README.md LICENSE config.example.yaml "dist/${NAME}/"
           cp docs/install-windows.md "dist/${NAME}/INSTALL-WINDOWS.md"
-          mkdir -p "dist/${NAME}/gophertrunk-web"
+          mkdir -p "dist/${NAME}/gophertrunk-web/siglab" "dist/${NAME}/gophertrunk-web/configbuilder"
           cp -r web/dist/. "dist/${NAME}/gophertrunk-web/"
+          cp -r web/siglab/dist/. "dist/${NAME}/gophertrunk-web/siglab/"
+          cp -r web/configbuilder/dist/. "dist/${NAME}/gophertrunk-web/configbuilder/"
           (cd dist && 7z a "${NAME}.zip" "${NAME}")
 
       - uses: actions/upload-artifact@v4
@@ -250,8 +255,10 @@ jobs:
               -o "dist/${NAME}/gophertrunk" \
               ./cmd/gophertrunk
             cp README.md LICENSE config.example.yaml "dist/${NAME}/"
-            mkdir -p "dist/${NAME}/gophertrunk-web"
+            mkdir -p "dist/${NAME}/gophertrunk-web/siglab" "dist/${NAME}/gophertrunk-web/configbuilder"
             cp -r web/dist/. "dist/${NAME}/gophertrunk-web/"
+            cp -r web/siglab/dist/. "dist/${NAME}/gophertrunk-web/siglab/"
+            cp -r web/configbuilder/dist/. "dist/${NAME}/gophertrunk-web/configbuilder/"
             (cd dist && tar -czf "${NAME}.tar.gz" "${NAME}")
           done
 
@@ -325,8 +332,10 @@ jobs:
               -o "dist/${NAME}/gophertrunk" \
               ./cmd/gophertrunk
             cp README.md LICENSE config.example.yaml "dist/${NAME}/"
-            mkdir -p "dist/${NAME}/gophertrunk-web"
+            mkdir -p "dist/${NAME}/gophertrunk-web/siglab" "dist/${NAME}/gophertrunk-web/configbuilder"
             cp -r web/dist/. "dist/${NAME}/gophertrunk-web/"
+            cp -r web/siglab/dist/. "dist/${NAME}/gophertrunk-web/siglab/"
+            cp -r web/configbuilder/dist/. "dist/${NAME}/gophertrunk-web/configbuilder/"
             (cd dist && tar -czf "${NAME}.tar.gz" "${NAME}")
           done
 
@@ -387,14 +396,14 @@ jobs:
           body: |
             ## Install
 
-            **Windows 11 (x64):** download `gophertrunk-${{ steps.version.outputs.version }}-windows-amd64-setup.exe` and double-click. The installer adds GopherTrunk to your Start Menu — single static binary, no DLLs to ship — and **prompts for a folder to install the browser-based web operator console** (default: `Documents\GopherTrunk Web Console`). After install, follow [INSTALL-WINDOWS.md](https://github.com/MattCheramie/GopherTrunk/blob/main/docs/install-windows.md) to install the WinUSB driver via Zadig — the OS won't see your RTL-SDR until you do this once.
+            **Windows 11 (x64):** download `gophertrunk-${{ steps.version.outputs.version }}-windows-amd64-setup.exe` and double-click. The installer adds GopherTrunk to your Start Menu — single static binary, no DLLs to ship — and **prompts for one data folder** (default: `Documents\GopherTrunk`) that holds everything else: config, recordings, IQ captures, exports, the database, logs, and the browser-based consoles (standard, Signal Lab, Config Builder). After install, follow [INSTALL-WINDOWS.md](https://github.com/MattCheramie/GopherTrunk/blob/main/docs/install-windows.md) to install the WinUSB driver via Zadig — the OS won't see your RTL-SDR until you do this once.
 
-            **Windows on ARM:** extract `gophertrunk-${{ steps.version.outputs.version }}-windows-arm64.zip` (no installer for arm64 yet — portable ZIP only). The web console lives in the `gophertrunk-web\` subfolder inside the zip.
+            **Windows on ARM:** extract `gophertrunk-${{ steps.version.outputs.version }}-windows-arm64.zip` (no installer for arm64 yet — portable ZIP only). The web consoles live in the `gophertrunk-web\` subfolder inside the zip (`siglab\` and `configbuilder\` alongside the standard console).
 
             **macOS:** extract `gophertrunk-${{ steps.version.outputs.version }}-darwin-arm64.tar.gz` (Apple Silicon) or `gophertrunk-${{ steps.version.outputs.version }}-darwin-amd64.tar.gz` (Intel) and run `./gophertrunk`. Builds are unsigned — right-click → Open the first time to bypass Gatekeeper.
 
             **Linux:** extract `gophertrunk-${{ steps.version.outputs.version }}-linux-amd64.tar.gz` (x86_64) or `gophertrunk-${{ steps.version.outputs.version }}-linux-arm64.tar.gz` (aarch64, e.g. Raspberry Pi 4/5) and run `./gophertrunk`. Single static binary; no system dependencies needed.
 
-            **Web operator console:** every archive includes a standalone `gophertrunk-web/` folder. Open its `index.html` in any browser and point it at a running daemon. Setup walkthrough: [gophertrunk.org/web.html](https://gophertrunk.org/web.html).
+            **Web operator console:** every archive includes a standalone `gophertrunk-web/` folder with all three consoles — the standard console at the top, plus `siglab/` and `configbuilder/`. Open the relevant `index.html` in any browser and point it at a running daemon. Setup walkthrough: [gophertrunk.org/web.html](https://gophertrunk.org/web.html).
 
             All artifacts are SHA-256-checksummed in `SHA256SUMS`.

--- a/cmd/gophertrunk/launcher.go
+++ b/cmd/gophertrunk/launcher.go
@@ -327,6 +327,21 @@ func openWebUI(d *Daemon, log *slog.Logger) error {
 func findWebAssets() string {
 	candidates := []string{}
 
+	// Data-root layout the installer lays down: the standalone web
+	// consoles live at <DataRoot>\web. Prefer it, since on an installed
+	// box the executable sits in Program Files with no web assets
+	// beside it. GOPHERTRUNK_HOME points straight at the data root;
+	// GOPHERTRUNK_CONFIG points at <DataRoot>\config\config.yaml, so its
+	// grandparent is the data root.
+	if home := os.Getenv("GOPHERTRUNK_HOME"); home != "" {
+		candidates = append(candidates,
+			filepath.Join(home, "web", "index.html"))
+	}
+	if cfg := os.Getenv("GOPHERTRUNK_CONFIG"); cfg != "" {
+		candidates = append(candidates,
+			filepath.Join(filepath.Dir(filepath.Dir(cfg)), "web", "index.html"))
+	}
+
 	if exe, err := os.Executable(); err == nil {
 		dir := filepath.Dir(exe)
 		candidates = append(candidates,

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -2,6 +2,16 @@
 # whatever path you pass to `gophertrunk run -config`) and adjust to
 # match your hardware + systems.
 #
+# PATHS: every filesystem path below (storage, recordings, IQ, logs,
+# talkgroup/RID files, …) is resolved by the daemon RELATIVE TO THE
+# FOLDER CONTAINING THIS FILE. The Windows installer drops this file at
+# <DataRoot>\config\config.yaml, so the "../recordings", "../data",
+# "../iq", "../logs" defaults land in sibling folders under one data
+# root. You can still use an absolute path (/var/lib/gophertrunk/...,
+# C:\Data\..., \\server\share\...) or an environment variable
+# (${GOPHERTRUNK_HOME}/recordings, %USERPROFILE%\GopherTrunk\...) — those
+# are taken as-is.
+#
 # See internal/config/config.go for the authoritative list of accepted
 # keys and their defaults.
 
@@ -12,7 +22,7 @@ log:
   # event (grants, CC lock/loss, affiliations, patches, locations).
   # message_log:
   #   enabled: true
-  #   path: "logs/messages.log"
+  #   path: "../logs/messages.log"
   #   max_size_mb: 16          # rotates to messages.log.1 past this
 
 # diagnostics — error-reporting verbosity. Every error is prefixed with
@@ -73,7 +83,7 @@ api:
   auth:
     mode: "auto"
     # token: "inline-token-here"   # discouraged; use token_file
-    # token_file: "/etc/gophertrunk/api-token"
+    # token_file: "../config/api-token"
     # trusted_networks:
     #   - "10.0.0.0/8"
     #   - "192.168.0.0/16"
@@ -86,8 +96,8 @@ api:
   # Cross-origin browser access. Off by default — the daemon emits
   # no Access-Control-* headers and rejects WebSocket upgrades whose
   # Origin header isn't on the allow-list. Enable when serving the
-  # bundled web UI (gophertrunk-web/) from a different origin than
-  # the daemon. Common values:
+  # standalone web UI (the web\ folder under your data root) from a
+  # different origin than the daemon. Common values:
   #
   #   - "null"                          allow web UI opened via file://
   #   - "http://laptop.local:8000"      allow a specific static host
@@ -119,11 +129,11 @@ metrics:
   enabled: true     # mounts /metrics on the HTTP API
 
 storage:
-  path: "/var/lib/gophertrunk/calls.db"
-  cc_cache_file: "/var/lib/gophertrunk/cc-cache.json"
+  path: "../data/calls.db"
+  cc_cache_file: "../data/cc-cache.json"
 
 recordings:
-  dir: "/var/lib/gophertrunk/recordings"
+  dir: "../recordings"
   sample_rate: 8000
   write_raw: true   # also append a .raw sidecar with the vocoder frames
   equalizer:
@@ -527,7 +537,7 @@ trunking:
       control_channels:
         - 851_000_000
         - 852_000_000
-      talkgroup_file: "/etc/gophertrunk/talkgroups-p25.csv"
+      talkgroup_file: "../config/talkgroups-p25.csv"
       # Optional per-system radio-ID alias catalogue — the per-RID
       # equivalent of talkgroup_file. CSV (Decimal/DEC/ID column +
       # optional Alias/Description/Tag/Group/Owner/Priority/Lockout/
@@ -535,7 +545,7 @@ trunking:
       # accepted, dispatched by file extension. Leave commented out
       # to let the affiliation tracker surface RIDs live without any
       # operator-configured aliases.
-      # rid_alias_file: "/etc/gophertrunk/rids-p25.csv"
+      # rid_alias_file: "../config/rids-p25.csv"
 
     # DMR Tier III trunked system. A T3 voice-grant CSBK references its
     # traffic channel by a 7-bit Logical Channel Number (LCN), never an
@@ -547,7 +557,7 @@ trunking:
       protocol: dmr
       control_channels:
         - 851_037_500
-      talkgroup_file: "/etc/gophertrunk/talkgroups-dmr.csv"
+      talkgroup_file: "../config/talkgroups-dmr.csv"
       dmr_band_plan:
         # Linear grid: freq = base_hz + (lcn - offset) * spacing_hz.
         # offset: 1 matches the common case of sites that number LCNs
@@ -668,7 +678,7 @@ trunking:
   #   - name: "Example-DMR-Encrypted"
   #     protocol: dmr
   #     control_channels: [451_000_000]
-  #     talkgroup_file: "/etc/gophertrunk/talkgroups-dmr.csv"
+  #     talkgroup_file: "../config/talkgroups-dmr.csv"
   #     encryption_keys:
   #       - key_id: 1
   #         algorithm: rc4              # only "rc4" is supported today
@@ -882,9 +892,9 @@ broadcast:
 # baseband:
 #   record:
 #     - serial: "00000001"
-#       dir: "baseband/"
+#       dir: "../iq/"
 #   replay:
-#     - file: "baseband/00000001_20260521T120000Z.wav"
+#     - file: "../iq/00000001_20260521T120000Z.wav"
 #       serial: "replay-01"
 #       role: "control"
 #       loop: true

--- a/docs/downloads.md
+++ b/docs/downloads.md
@@ -141,7 +141,7 @@ Run the installer:
 .\gophertrunk-{{ ver }}-windows-amd64-setup.exe
 ```
 
-During setup the wizard asks where to install the **browser-based web operator console** (default `%USERPROFILE%\Documents\GopherTrunk Web Console`). A Start Menu shortcut opens `index.html` in your default browser; untick the "Install the web operator console" task on the Tasks page to skip it for a headless install.
+During setup the wizard asks for **one data folder** (default `%USERPROFILE%\Documents\GopherTrunk`) to hold everything that isn't the program: config, recordings, IQ captures, exports, the database, logs, and the **browser-based web consoles** (standard, Signal Lab, Config Builder) under its `web\` subfolder. Start Menu shortcuts open each console's `index.html` in your default browser.
 
 After install, complete the WinUSB driver swap via the bundled Zadig — see **[`install-windows.md`]({{ '/install-windows.html' | relative_url }})** for the full step-by-step (Start Menu → GopherTrunk → "Install RTL-SDR driver (Zadig)", or tick the postinstall option before clicking Finish). The OS won't see your RTL-SDR until that swap is done.
 

--- a/docs/install-windows.md
+++ b/docs/install-windows.md
@@ -36,20 +36,34 @@ anywhere — the contents are the same.
 Double-click `setup.exe` and accept the defaults. The installer:
 
 - Copies `gophertrunk.exe` to `C:\Program Files\GopherTrunk\` —
-  a single static binary, no DLLs to ship.
+  a single static binary, no DLLs to ship. **This is the only
+  thing that goes in Program Files.**
+- Asks you for **one data folder** (the "Select your GopherTrunk
+  data folder" page after the Tasks step, defaulting to
+  `%USERPROFILE%\Documents\GopherTrunk`). Everything that *isn't*
+  the program lives here, in a tidy subfolder tree Setup creates:
+
+  ```
+  Documents\GopherTrunk\
+    config\       config.yaml + your talkgroup / RID CSVs
+    recordings\   voice-call recordings (.wav / .raw)
+    iq\           raw IQ baseband captures
+    exports\      CSV / PDF exports
+    data\         calls.db + caches
+    logs\         decoded-message logs
+    web\          the browser consoles (standard + Signal Lab + Config Builder)
+  ```
+
+  You can point this anywhere you can write to — a USB stick, a
+  network drive, your desktop. Setup seeds a starter `config.yaml`
+  into `config\` (an existing one is never overwritten).
 - Bundles **Zadig** (the WinUSB driver-binding tool) next to the
   daemon and adds a Start Menu shortcut "Install RTL-SDR driver
   (Zadig)" so you don't have to chase a separate download.
 - Adds Start Menu entries for the daemon, the config template,
+  the three **browser-based web consoles** (open them straight
+  from `web\` — setup + quick-start guide: **[Web console]({{ '/web.html' | relative_url }})**),
   and these instructions.
-- Installs the **browser-based web operator console** (a static
-  HTML / JS folder you open in any browser) to a location you
-  pick — the wizard offers a "Select web operator console
-  location" page after the Tasks step, defaulting to
-  `%USERPROFILE%\Documents\GopherTrunk Web Console`. Untick the
-  "Install the web operator console" checkbox on the Tasks page
-  to skip it (e.g. for a headless server install). Setup +
-  quick-start guide for the console: **[Web console]({{ '/web.html' | relative_url }})**.
 - Optionally adds `C:\Program Files\GopherTrunk` to your system
   PATH so you can run `gophertrunk` from any PowerShell window
   (off by default — tick the "Add GopherTrunk to my PATH"
@@ -57,9 +71,8 @@ Double-click `setup.exe` and accept the defaults. The installer:
 
 When the wizard finishes, it'll offer to open this document, a
 console window, Zadig (to bind the WinUSB driver — see §3), and
-(if you installed the web console) the console itself in your
-default browser. All four are harmless to skip; the Zadig one
-defaults off.
+the web console in your default browser. All are harmless to skip;
+the Zadig one defaults off.
 
 ## 3. Install the WinUSB driver via Zadig (one-time, for each dongle)
 
@@ -124,13 +137,21 @@ cd "C:\Program Files\GopherTrunk"
 
 ## 5. Configure and start the daemon
 
-The installer asked you for an "editable files folder" (default
-`Documents\GopherTrunk`) and seeded a `config.yaml` there. It also
-set the `GOPHERTRUNK_CONFIG` user environment variable to point at
-that file, so the daemon discovers it automatically — no `-config`
-flag needed. Use the Start Menu shortcut "Edit my config.yaml
-(Notepad)" to open it, set your device serial + control-channel
-frequencies, and save.
+The installer asked you for a data folder (default
+`Documents\GopherTrunk`) and seeded a `config.yaml` in its
+`config\` subfolder. It also set the `GOPHERTRUNK_CONFIG` user
+environment variable to point at that file, so the daemon discovers
+it automatically — no `-config` flag needed. (A second variable,
+`GOPHERTRUNK_HOME`, points at the data folder itself.) Use the Start
+Menu shortcut "Edit my config.yaml (Notepad)" to open it, set your
+device serial + control-channel frequencies, and save.
+
+The seeded `config.yaml` uses **config-relative paths**
+(`../recordings`, `../data/calls.db`, `../iq`, `../logs`), so the
+daemon writes recordings, the database, IQ captures, and logs into
+the sibling folders under your data root automatically — no absolute
+paths to edit. You can still hard-code an absolute path (or use
+`%GOPHERTRUNK_HOME%\...`) if you want files somewhere else.
 
 Then start the daemon:
 
@@ -146,7 +167,7 @@ against a second config for testing), use `-config`:
 gophertrunk run -config "C:\path\to\other.yaml"
 ```
 
-If you drop multiple `*.yaml` files into the editable-files folder
+If you drop multiple `*.yaml` files into the `config\` folder
 (e.g. `config.yaml` + `prod.yaml` + `test.yaml`), the daemon prints
 a numbered menu on startup and asks which one to load. Pick the
 number, press Enter, and that file is used. Set `-config` or
@@ -166,20 +187,27 @@ native service manifest ships:
 
 ```powershell
 nssm install GopherTrunk "C:\Program Files\GopherTrunk\gophertrunk.exe" `
-  run -config "C:\ProgramData\GopherTrunk\config.yaml"
+  run -config "%USERPROFILE%\Documents\GopherTrunk\config\config.yaml"
 nssm set GopherTrunk AppDirectory "C:\Program Files\GopherTrunk"
 nssm start GopherTrunk
 ```
+
+> Point `-config` at the `config.yaml` inside your data folder's
+> `config\` subfolder. A service runs as a different account, so use
+> the absolute path here rather than relying on the per-user
+> `GOPHERTRUNK_CONFIG` variable.
 
 ## Uninstall
 
 **Settings → Apps → Installed apps → GopherTrunk → Uninstall.**
 The uninstaller removes the install folder and every Start Menu
 entry, strips GopherTrunk from your PATH (if you opted in), and
-clears the `GOPHERTRUNK_CONFIG` env var. It then asks whether to
-also delete your editable `config.yaml` and the `gophertrunk-web`
-folder Setup created — the default is **No** so you don't lose
-edits or per-system data.
+clears the `GOPHERTRUNK_CONFIG` / `GOPHERTRUNK_HOME` env vars. It
+then asks whether to also delete the Setup-managed parts of your
+data folder — the `config`, `data`, `logs`, and `web` subfolders.
+The default is **No**. Even if you say Yes, your **captures**
+(`recordings`, `iq`, `exports`) are always kept so you never lose
+recordings on an uninstall.
 
 ## Troubleshooting
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -67,8 +67,9 @@ tag. Anything failing means the tag isn't ready.
    - builds `gophertrunk.exe` (amd64 + arm64) and the Windows
      installer (Zadig-bundled, Inno Setup),
    - builds Linux + macOS tarballs for amd64 and arm64,
-   - builds the web console (`gophertrunk-web/`) and stages it
-     alongside every artifact,
+   - builds all three web consoles (standard + Signal Lab + Config
+     Builder) and stages them under `gophertrunk-web/` alongside
+     every artifact,
    - computes `SHA256SUMS` over every file,
    - attaches everything to a new GitHub Release with notes
      auto-extracted from the matching `CHANGELOG.md` section.

--- a/docs/user-guide-windows.md
+++ b/docs/user-guide-windows.md
@@ -91,17 +91,21 @@ The condensed version:
    does the following:
 
    - Copies `gophertrunk.exe` to `C:\Program Files\GopherTrunk\`
-     (single static binary, no DLLs).
+     (single static binary, no DLLs). That is the *only* thing in
+     Program Files.
+   - Asks for **one data folder** (default
+     `%USERPROFILE%\Documents\GopherTrunk`) that holds everything
+     else, in subfolders Setup creates — `config\`, `recordings\`,
+     `iq\`, `exports\`, `data\`, `logs\`, and `web\` (the three
+     browser consoles). Setup seeds a starter `config.yaml` into
+     `config\` (an existing one is never overwritten). Point it
+     anywhere you can write to.
    - Bundles **Zadig** next to the daemon and adds a Start Menu
      shortcut "Install RTL-SDR driver (Zadig)" so you don't have
      to chase a separate download.
    - Adds Start Menu entries for the daemon, the config template,
+     the three web consoles (standard, Signal Lab, Config Builder),
      and the install walkthrough.
-   - Offers to install the **browser-based web operator console** to
-     a folder of your choice (default
-     `%USERPROFILE%\Documents\GopherTrunk Web Console`). Untick the
-     "Install the web operator console" task on the Tasks page for
-     a headless install.
    - Optionally adds `C:\Program Files\GopherTrunk` to your **system
      PATH** so `gophertrunk` is reachable from any PowerShell window
      (off by default — tick the "Add GopherTrunk to my PATH" option
@@ -398,15 +402,23 @@ gophertrunk audio list
 
 ## 5. Build your first config
 
-The installer asked you for an "editable files folder" (default
-`Documents\GopherTrunk`), seeded a `config.yaml` there, and pinned
-the path in `HKCU\Environment\GOPHERTRUNK_CONFIG` so the daemon
-discovers it automatically. Open it from the Start Menu shortcut
-"Edit my config.yaml (Notepad)" or directly:
+The installer asked you for a data folder (default
+`Documents\GopherTrunk`), seeded a `config.yaml` in its `config\`
+subfolder, and pinned the path in `HKCU\Environment\GOPHERTRUNK_CONFIG`
+so the daemon discovers it automatically. Open it from the Start Menu
+shortcut "Edit my config.yaml (Notepad)" or directly:
 
 ```powershell
-notepad "$env:USERPROFILE\Documents\GopherTrunk\config.yaml"
+notepad "$env:USERPROFILE\Documents\GopherTrunk\config\config.yaml"
 ```
+
+The seeded config uses **config-relative paths** — `recordings.dir:
+../recordings`, `storage.path: ../data/calls.db`, `../iq`, `../logs`
+— which the daemon resolves against the folder holding `config.yaml`.
+So recordings, the database, IQ captures, and logs land in the
+sibling folders under your data root with nothing to edit. Absolute
+paths and `%GOPHERTRUNK_HOME%\...` references still work if you want
+files elsewhere.
 
 A read-only reference copy of the full annotated template stays at
 `C:\Program Files\GopherTrunk\config.example.yaml` (Start Menu →
@@ -455,16 +467,15 @@ Full reference: [`import.md`]({{ '/import.html' | relative_url }}).
 gophertrunk run
 ```
 
-The daemon walks `$GOPHERTRUNK_CONFIG` →
-`%APPDATA%\GopherTrunk\config.yaml` →
-`%USERPROFILE%\Documents\GopherTrunk\config.yaml` → `.\config.yaml`
-and loads the first one it finds, printing `config: loaded <path>`
-on startup so you can confirm the choice. If you keep multiple
-configs in the editable-files folder (e.g. `config.yaml` plus a
-`prod.yaml`), the daemon prints a numbered menu and asks which to
-load — Enter alone picks #1. A non-interactive launch (Windows
-service, Scheduled Task) auto-selects the first match with a
-stderr warning instead of hanging.
+The daemon walks `$GOPHERTRUNK_CONFIG` → `%APPDATA%\GopherTrunk` →
+`%USERPROFILE%\Documents\GopherTrunk` (each scanned at its top level
+and in its `config\` subfolder) → `.\config.yaml` and loads the first
+one it finds, printing `config: loaded <path>` on startup so you can
+confirm the choice. If you keep multiple configs in the `config\`
+folder (e.g. `config.yaml` plus a `prod.yaml`), the daemon prints a
+numbered menu and asks which to load — Enter alone picks #1. A
+non-interactive launch (Windows service, Scheduled Task) auto-selects
+the first match with a stderr warning instead of hanging.
 
 Override discovery any time:
 
@@ -482,7 +493,7 @@ exit.
 
 | Flag | Description |
 | --- | --- |
-| `-config <path>` | Path to `config.yaml`. Optional — when omitted the daemon walks `$GOPHERTRUNK_CONFIG` → `%APPDATA%\GopherTrunk` → `Documents\GopherTrunk` → cwd and loads the first match (built-in defaults if nothing found). |
+| `-config <path>` | Path to `config.yaml`. Optional — when omitted the daemon walks `$GOPHERTRUNK_CONFIG` → `%APPDATA%\GopherTrunk` → `Documents\GopherTrunk` (each at its top level and its `config\` subfolder) → cwd and loads the first match (built-in defaults if nothing found). |
 | `-log-level <lvl>` | Override `log.level` (`debug` / `info` / `warn` / `error`). |
 | `-log-format <fmt>` | Override `log.format` (`text` / `json`). |
 
@@ -500,7 +511,7 @@ until a native service manifest ships.
 ```powershell
 # Download and extract nssm from https://nssm.cc
 nssm install GopherTrunk "C:\Program Files\GopherTrunk\gophertrunk.exe" `
-  run -config "C:\ProgramData\GopherTrunk\config.yaml"
+  run -config "%USERPROFILE%\Documents\GopherTrunk\config\config.yaml"
 nssm set GopherTrunk AppDirectory "C:\Program Files\GopherTrunk"
 nssm set GopherTrunk DisplayName "GopherTrunk Trunking Daemon"
 nssm set GopherTrunk Start SERVICE_AUTO_START
@@ -636,10 +647,12 @@ server in the daemon). Every TUI panel has a browser counterpart.
 
 ### Launch on the same machine as the daemon
 
-Open File Explorer to the folder you picked during install
-(default `%USERPROFILE%\Documents\GopherTrunk Web Console`) and
-double-click `index.html`. The Start Menu shortcut points at the
-same file. On the connect screen, enter:
+Open File Explorer to the `web\` subfolder of your data root
+(default `%USERPROFILE%\Documents\GopherTrunk\web`) and double-click
+`index.html`. The Start Menu shortcut "Web operator console" points
+at the same file; "Signal Lab console" and "Config Builder console"
+open the `web\siglab\` and `web\configbuilder\` consoles alongside
+it. On the connect screen, enter:
 
 - **Server URL:** `http://127.0.0.1:8080`
 - **Bearer token:** the contents of `api.auth.token_file` (or empty
@@ -666,9 +679,9 @@ Canonical "headless box, operate from the couch" scenario.
 
 2. Restart the daemon.
 
-3. Copy the `GopherTrunk Web Console` folder to the operating device
-   (USB stick, file share, or download the matching release archive
-   on that device and use its `gophertrunk-web/` directory).
+3. Copy your data root's `web\` folder to the operating device (USB
+   stick, file share, or download the matching release archive on that
+   device and use its `gophertrunk-web/` directory).
 
 4. Double-click `index.html`, enter the daemon's LAN URL and the
    bearer token on the connect screen.
@@ -1427,17 +1440,19 @@ gophertrunk version
 ### Uninstall
 
 **Settings → Apps → Installed apps → GopherTrunk → Uninstall.**
-The uninstaller removes the install folder, every Start Menu
-entry, and undoes the PATH change if you opted in.
+The uninstaller removes the install folder, every Start Menu entry,
+undoes the PATH change if you opted in, and clears the
+`GOPHERTRUNK_CONFIG` / `GOPHERTRUNK_HOME` env vars.
 
-Recordings under your `recordings.dir`, the SQLite call log, and
-the CC cache file are **not** removed — they live under
-`ProgramData` or your home directory and remain on disk. Delete
-them manually if you want a clean slate:
+It then asks whether to also delete the Setup-managed parts of your
+data folder — the `config`, `data`, `logs`, and `web` subfolders
+(default **No**). Your **captures** — `recordings`, `iq`, and
+`exports` — are **always kept** so an uninstall never destroys
+recordings. Delete the whole data folder by hand if you want a
+clean slate:
 
 ```powershell
-Remove-Item -Recurse "C:\ProgramData\GopherTrunk"
-Remove-Item "$HOME\gophertrunk.yaml"
+Remove-Item -Recurse "$env:USERPROFILE\Documents\GopherTrunk"
 ```
 
 If you registered an NSSM service, remove it before uninstall:

--- a/docs/web.md
+++ b/docs/web.md
@@ -80,12 +80,14 @@ archive — same archive that contains the `gophertrunk` binary:
 ```
 gophertrunk-<version>-<os>-<arch>/
 ├── gophertrunk              # the daemon / CLI binary
-├── gophertrunk-web/         # standalone web console
-│   ├── index.html
+├── gophertrunk-web/         # standalone web consoles
+│   ├── index.html           # standard operator console
 │   ├── assets/…             # bundled React / Tailwind / Chart.js
 │   ├── favicon.svg
 │   ├── manifest.webmanifest
-│   └── sw.js                # PWA service worker
+│   ├── sw.js                # PWA service worker
+│   ├── siglab/              # Signal Lab (offline RF analysis) console
+│   └── configbuilder/       # Config Builder / editor console
 ├── config.example.yaml
 └── samples/…
 ```
@@ -94,6 +96,13 @@ Download the matching release archive from the
 **[Downloads page]({{ '/downloads.html' | relative_url }})** and unpack
 it. That's the only file you need on the device that will run the
 browser; nothing else is installed.
+
+> **Windows installer:** Setup copies this same tree into the `web\`
+> subfolder of your chosen data folder (default
+> `%USERPROFILE%\Documents\GopherTrunk\web`), and adds Start Menu
+> shortcuts for all three consoles. The paths below that say
+> `gophertrunk-web/` map to `…\GopherTrunk\web\` on an installed
+> Windows box.
 
 ## 2. Configure the daemon for browser access
 

--- a/installer/windows/gophertrunk.iss
+++ b/installer/windows/gophertrunk.iss
@@ -44,9 +44,7 @@ Name: "english"; MessagesFile: "compiler:Default.isl"
 
 [Tasks]
 Name: "addtopath"; Description: "Add GopherTrunk to my PATH (so I can run ""gophertrunk"" from any terminal)"; GroupDescription: "PATH"; Flags: unchecked
-Name: "desktopicon"; Description: "Create a &desktop shortcut"; GroupDescription: "Additional shortcuts:"; Flags: unchecked
-Name: "webui"; Description: "Install the &web operator console (a static HTML / JS folder you open in any browser)"; GroupDescription: "Web operator console:"
-Name: "webui\desktopicon"; Description: "Create a desktop shortcut for the web console"; GroupDescription: "Web operator console:"; Flags: unchecked
+Name: "desktopicon"; Description: "Create &desktop shortcuts (GopherTrunk console + web operator console)"; GroupDescription: "Additional shortcuts:"; Flags: unchecked
 
 [Files]
 Source: "..\..\dist\staging\gophertrunk.exe";  DestDir: "{app}"; Flags: ignoreversion
@@ -59,22 +57,42 @@ Source: "..\..\dist\staging\INSTALL-WINDOWS.md"; DestDir: "{app}"; Flags: ignore
 ; https://github.com/pbatard/libwdi (see THIRD_PARTY_LICENSES.md).
 ; Zadig's embedded manifest requests admin elevation on its own.
 Source: "..\..\dist\staging\zadig.exe"; DestDir: "{app}"; Flags: ignoreversion
-; Seed the operator's chosen editable-files folder with a starter
-; config.yaml the first time they install. onlyifdoesntexist
-; preserves any edits across re-installs; uninsneveruninstall
-; leaves the file behind on uninstall so the operator doesn't lose
-; the config (and any per-system trunking data alongside it).
+; Seed the config subfolder of the operator's chosen data root with a
+; starter config.yaml the first time they install. The shipped
+; config.example.yaml uses config-relative paths (../recordings,
+; ../data, ../iq, ../logs), so once it lands in <DataRoot>\config the
+; daemon writes every other file into the sibling folders created by
+; the [Dirs] section below. onlyifdoesntexist preserves any edits
+; across re-installs; uninsneveruninstall leaves the file behind on
+; uninstall so the operator doesn't lose their config.
 Source: "..\..\dist\staging\config.example.yaml"; \
   DestDir: "{code:ConfigDir}"; \
   DestName: "config.yaml"; \
   Flags: onlyifdoesntexist uninsneveruninstall
-; The web console is a standalone static folder — index.html plus the
-; bundled JS/CSS/manifest. The user picks the destination on the
-; custom WebUIPage below; {code:WebUIDir} resolves to that choice.
+; The web operator consoles are standalone static folders — index.html
+; plus bundled JS/CSS/manifest. The release staging nests all three
+; UIs under gophertrunk-web\ (standard console at the top,
+; gophertrunk-web\siglab\ and gophertrunk-web\configbuilder\
+; alongside), so this one recursive copy reproduces the whole tree
+; under <DataRoot>\web (web\index.html, web\siglab\, web\configbuilder\).
+; {code:WebDir} resolves to <DataRoot>\web.
 Source: "..\..\dist\staging\gophertrunk-web\*"; \
-  DestDir: "{code:WebUIDir}"; \
-  Flags: ignoreversion recursesubdirs createallsubdirs; \
-  Tasks: webui
+  DestDir: "{code:WebDir}"; \
+  Flags: ignoreversion recursesubdirs createallsubdirs
+
+[Dirs]
+; Logical subfolder tree under the operator's chosen data root. The
+; config-relative defaults in config.yaml resolve into these siblings,
+; so all of the operator's files live under one parent: config files,
+; voice-call recordings, raw IQ baseband captures, CSV/PDF exports, the
+; SQLite database + caches, decoded-message logs, and the web consoles.
+Name: "{code:DataDir}\config"
+Name: "{code:DataDir}\recordings"
+Name: "{code:DataDir}\iq"
+Name: "{code:DataDir}\exports"
+Name: "{code:DataDir}\data"
+Name: "{code:DataDir}\logs"
+Name: "{code:DataDir}\web"
 
 [Icons]
 Name: "{group}\GopherTrunk (PowerShell)"; Filename: "{cmd}"; \
@@ -101,17 +119,22 @@ Name: "{autodesktop}\GopherTrunk"; Filename: "{cmd}"; \
   Parameters: "/k cd /d ""{app}"" && gophertrunk help"; \
   WorkingDir: "{app}"; \
   Tasks: desktopicon
-; Web operator console shortcuts. shellexec opens the file in the
-; user's default browser; the entry resolves to whatever path the
-; user picked on the WebUIPage.
+; Web operator console shortcuts. The web\ folder under the data root
+; holds all three consoles; opening these index.html files launches
+; them in the user's default browser.
 Name: "{group}\Web operator console"; \
-  Filename: "{code:WebUIDir}\index.html"; \
-  Comment: "Open the GopherTrunk web operator console in your default browser"; \
-  Tasks: webui
+  Filename: "{code:WebDir}\index.html"; \
+  Comment: "Open the GopherTrunk web operator console in your default browser"
+Name: "{group}\Signal Lab console"; \
+  Filename: "{code:WebDir}\siglab\index.html"; \
+  Comment: "Open the GopherTrunk Signal Lab (offline RF analysis) console"
+Name: "{group}\Config Builder console"; \
+  Filename: "{code:WebDir}\configbuilder\index.html"; \
+  Comment: "Open the GopherTrunk Config Builder / editor in your default browser"
 Name: "{autodesktop}\GopherTrunk Web Console"; \
-  Filename: "{code:WebUIDir}\index.html"; \
+  Filename: "{code:WebDir}\index.html"; \
   Comment: "Open the GopherTrunk web operator console in your default browser"; \
-  Tasks: webui\desktopicon
+  Tasks: desktopicon
 
 [Registry]
 ; Append the install dir to the system PATH if the user opted in. Inno
@@ -133,18 +156,22 @@ Root: HKCU; Subkey: "Environment"; \
   ValueType: expandsz; ValueName: "GOPHERTRUNK_CONFIG"; \
   ValueData: "{code:ConfigDir}\config.yaml"; \
   Flags: uninsdeletevalue
-; Persist install-time ConfigDir / WebUIDir so the uninstaller can
-; find them. Inno's [Code] state from the install run does NOT
-; survive into the uninstall run, so the registry is the only
-; durable bridge. uninsdeletekeyifempty on the last entry sweeps
-; the parent Install subkey once both values are gone.
-Root: HKLM; Subkey: "Software\GopherTrunk\Install"; \
-  ValueType: string; ValueName: "ConfigDir"; \
-  ValueData: "{code:ConfigDir}"; \
+; Per-user env var pointing at the data root itself. Operators who
+; prefer env-var-based config paths can reference ${GOPHERTRUNK_HOME}
+; / %GOPHERTRUNK_HOME% in config.yaml, and external tooling can locate
+; the data folder without parsing config.yaml.
+Root: HKCU; Subkey: "Environment"; \
+  ValueType: expandsz; ValueName: "GOPHERTRUNK_HOME"; \
+  ValueData: "{code:DataDir}"; \
   Flags: uninsdeletevalue
+; Persist the install-time data root so the uninstaller can find it.
+; Inno's [Code] state from the install run does NOT survive into the
+; uninstall run, so the registry is the only durable bridge.
+; uninsdeletekeyifempty sweeps the parent Install subkey once the
+; value is gone.
 Root: HKLM; Subkey: "Software\GopherTrunk\Install"; \
-  ValueType: string; ValueName: "WebUIDir"; \
-  ValueData: "{code:WebUIDir}"; \
+  ValueType: string; ValueName: "DataDir"; \
+  ValueData: "{code:DataDir}"; \
   Flags: uninsdeletevalue uninsdeletekeyifempty
 
 [Run]
@@ -159,80 +186,61 @@ Filename: "{app}\zadig.exe"; \
   WorkingDir: "{app}"; \
   Description: "Run Zadig now to bind the WinUSB driver to your RTL-SDR"; \
   Flags: postinstall shellexec skipifsilent unchecked
-Filename: "{code:WebUIDir}\index.html"; \
+Filename: "{code:WebDir}\index.html"; \
   Description: "Open the web operator console now"; \
-  Flags: postinstall shellexec skipifsilent; \
-  Tasks: webui
+  Flags: postinstall shellexec skipifsilent
 
 [Code]
 var
-  ConfigPage: TInputDirWizardPage;
-  WebUIPage:  TInputDirWizardPage;
+  DataDirPage: TInputDirWizardPage;
 
 procedure InitializeWizard;
 begin
-  // Editable-files folder: where the operator's config.yaml (and
-  // any per-system data that lands next to it) lives. We default
-  // to Documents\GopherTrunk because it's the spot non-Admin
-  // Windows users can always write to without surprises — and the
-  // [Files] step seeds a starter config.yaml there. The path is
-  // also written to HKCU\Environment\GOPHERTRUNK_CONFIG so the
-  // daemon discovers it without needing -config on the command
-  // line. Placed first so the operator sees the most important
-  // path choice before anything else.
-  ConfigPage := CreateInputDirPage(
+  // Single data-folder choice. The executable always installs to
+  // {app} (Program Files); this page picks the SEPARATE, user-owned
+  // data root that holds everything else — config files, voice-call
+  // recordings, raw IQ baseband captures, CSV/PDF exports, the SQLite
+  // database + caches, decoded-message logs, and the web consoles —
+  // each in its own subfolder (created by the [Dirs] section). We
+  // default to Documents\GopherTrunk because it's the spot non-Admin
+  // Windows users can always write to without surprises. The chosen
+  // path is written to HKCU\Environment\GOPHERTRUNK_HOME, and
+  // GOPHERTRUNK_CONFIG points at <DataRoot>\config\config.yaml so the
+  // daemon discovers the seeded config without a -config flag.
+  DataDirPage := CreateInputDirPage(
     wpSelectTasks,
-    'Select your editable-files folder',
-    'Where should your config.yaml and per-system data live?',
-    'Pick a folder Setup can drop a starter config.yaml in. The ' +
-    'GopherTrunk daemon will look for config.yaml in this folder ' +
-    'automatically — no -config flag needed. The default is your ' +
-    'Documents folder so it''s easy to find and back up; you can ' +
-    'choose anywhere you can write to. If a config.yaml already ' +
-    'exists in the folder it will NOT be overwritten.',
+    'Select your GopherTrunk data folder',
+    'Where should GopherTrunk keep your files?',
+    'GopherTrunk installs its program to Program Files, but keeps all ' +
+    'of YOUR files in a separate data folder you choose here. Setup ' +
+    'creates config, recordings, iq, exports, data, logs, and web ' +
+    'subfolders under it and seeds a starter config.yaml. The default ' +
+    'is your Documents folder so it''s easy to find and back up; you ' +
+    'can choose anywhere you can write to — a USB stick, a network ' +
+    'drive, or your desktop. An existing config.yaml is never ' +
+    'overwritten.',
     False, '');
-  ConfigPage.Add('Editable files folder:');
-  ConfigPage.Values[0] :=
+  DataDirPage.Add('Data folder:');
+  DataDirPage.Values[0] :=
     ExpandConstant('{userdocs}\GopherTrunk');
-
-  // CreateInputDirPage gives us a "pick a folder" wizard step with a
-  // Browse button. Placed AFTER ConfigPage so the page order matches
-  // the order of importance — config first, web UI second. ShouldSkipPage
-  // hides this one entirely when the webui task is unchecked.
-  WebUIPage := CreateInputDirPage(
-    ConfigPage.ID,
-    'Select web operator console location',
-    'Where should Setup put the GopherTrunk web console?',
-    'Pick a folder for the standalone web UI. Setup will copy a ' +
-    'gophertrunk-web folder there containing an index.html you open ' +
-    'in any browser. The default is your Documents folder so it''s ' +
-    'easy to find later; you can choose anywhere — a USB stick, a ' +
-    'network drive, or your desktop. Use Browse to pick a different ' +
-    'folder.',
-    False, '');
-  WebUIPage.Add('Web console folder:');
-  WebUIPage.Values[0] :=
-    ExpandConstant('{userdocs}\GopherTrunk Web Console');
 end;
 
-function ShouldSkipPage(PageID: Integer): Boolean;
+// DataDir is the user-chosen data root. ConfigDir and WebDir return
+// the two subpaths the [Files]/[Icons]/[Registry] sections reference
+// by name ({code:ConfigDir}, {code:WebDir}).
+function DataDir(Param: string): string;
 begin
-  Result := False;
-  // Skip the web-UI directory page when the user unchecked the
-  // "Install the web operator console" task.
-  if PageID = WebUIPage.ID then begin
-    Result := not WizardIsTaskSelected('webui');
-  end;
+  Result := DataDirPage.Values[0];
 end;
 
 function ConfigDir(Param: string): string;
 begin
-  Result := ConfigPage.Values[0];
+  Result := AddBackslash(DataDirPage.Values[0]) + 'config';
 end;
 
-function WebUIDir(Param: string): string;
+function WebDir(Param: string): string;
 begin
-  Result := WebUIPage.Values[0];
+  Result := AddBackslash(DataDirPage.Values[0]) + 'web';
 end;
 
 function NeedsAddPath(Param: string): boolean;
@@ -255,23 +263,15 @@ end;
 // Uninstall helpers.
 //
 // Inno's [Code] state from the install run does NOT survive into
-// the uninstall run, so the install-time ConfigDir / WebUIDir
-// choices are read back from HKLM\Software\GopherTrunk\Install
-// (populated by the [Registry] section).
+// the uninstall run, so the install-time data root is read back from
+// HKLM\Software\GopherTrunk\Install (populated by the [Registry]
+// section).
 // ---------------------------------------------------------------
 
-function ReadInstalledConfigDir(): string;
+function ReadInstalledDataDir(): string;
 begin
   if not RegQueryStringValue(HKEY_LOCAL_MACHINE,
-    'Software\GopherTrunk\Install', 'ConfigDir', Result)
-  then
-    Result := '';
-end;
-
-function ReadInstalledWebUIDir(): string;
-begin
-  if not RegQueryStringValue(HKEY_LOCAL_MACHINE,
-    'Software\GopherTrunk\Install', 'WebUIDir', Result)
+    'Software\GopherTrunk\Install', 'DataDir', Result)
   then
     Result := '';
 end;
@@ -307,31 +307,22 @@ begin
     'Path', NewPath);
 end;
 
-procedure WipeConfig();
+// WipeManagedData deletes the Setup-managed parts of the data root —
+// config, the SQLite database + caches, logs, and the web consoles —
+// while DELIBERATELY preserving the operator's irreplaceable captures
+// (recordings, iq, exports). It never removes the data root itself, so
+// those preserved folders stay put.
+procedure WipeManagedData();
 var
-  Dir, Cfg: string;
+  Root: string;
 begin
-  Dir := ReadInstalledConfigDir();
-  if Dir = '' then exit;
-  Cfg := AddBackslash(Dir) + 'config.yaml';
-  if FileExists(Cfg) then
-    DeleteFile(Cfg);
-  // RemoveDir only succeeds on empty dirs — that's the right
-  // semantics: don't blow away a folder still holding the
-  // operator's call-log database or recordings.
-  if DirExists(Dir) then
-    RemoveDir(Dir);
-end;
-
-procedure WipeWebConsole();
-var
-  Dir, Sub: string;
-begin
-  Dir := ReadInstalledWebUIDir();
-  if Dir = '' then exit;
-  Sub := AddBackslash(Dir) + 'gophertrunk-web';
-  if DirExists(Sub) then
-    DelTree(Sub, True, True, True);
+  Root := ReadInstalledDataDir();
+  if Root = '' then exit;
+  Root := AddBackslash(Root);
+  DelTree(Root + 'config', True, True, True);
+  DelTree(Root + 'data',   True, True, True);
+  DelTree(Root + 'logs',   True, True, True);
+  DelTree(Root + 'web',    True, True, True);
 end;
 
 procedure CurUninstallStepChanged(CurUninstallStep: TUninstallStep);
@@ -341,19 +332,19 @@ begin
   if CurUninstallStep = usUninstall then begin
     // Always strip our PATH entry — the [Registry] section never
     // got a cleanup flag, so this is the only place it happens.
-    // The HKCU GOPHERTRUNK_CONFIG value and the
+    // The HKCU GOPHERTRUNK_CONFIG / GOPHERTRUNK_HOME values and the
     // Software\GopherTrunk\Install key clean themselves up via
     // uninsdeletevalue / uninsdeletekeyifempty.
     RemoveAppFromHKLMPath();
 
     WipeAnswer := MsgBox(
-      'Also remove your editable config.yaml and the web console folder?' + #13#10 + #13#10 +
-      'Yes = full wipe (delete config.yaml + the gophertrunk-web folder Setup created).' + #13#10 +
-      'No  = preserve your user data (recommended).',
+      'Also remove your config, database, logs, and web console?' + #13#10 + #13#10 +
+      'Yes = delete the config, data, logs, and web folders under your ' +
+      'data root. Your captures (recordings, iq, exports) are KEPT.' + #13#10 +
+      'No  = preserve everything (recommended).',
       mbConfirmation, MB_YESNO or MB_DEFBUTTON2);
     if WipeAnswer = IDYES then begin
-      WipeConfig();
-      WipeWebConsole();
+      WipeManagedData();
     end;
   end;
 end;

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,10 +5,12 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 	"time"
 
+	"github.com/MattCheramie/GopherTrunk/internal/pathutil"
 	"github.com/MattCheramie/GopherTrunk/internal/trunking"
 	"gopkg.in/yaml.v3"
 )
@@ -1328,10 +1330,54 @@ func Load(path string) (Config, error) {
 	if err := yaml.Unmarshal(data, &cfg); err != nil {
 		return cfg, fmt.Errorf("config %s: %w\n  hint: check YAML syntax (indentation must be spaces, keys end with ':'). Run `gophertrunk config` to build/repair a config interactively.", path, err)
 	}
+	// Resolve every filesystem path the config carries against the
+	// directory holding config.yaml, so a portable config can ship with
+	// config-relative defaults (../recordings, ../data/calls.db, …) that
+	// land under the operator's chosen data root regardless of platform
+	// or current working directory. Absolute and env-expanded-to-absolute
+	// paths pass through untouched (see resolvePaths).
+	cfg.resolvePaths(filepath.Dir(path))
 	if err := cfg.Validate(); err != nil {
 		return cfg, fmt.Errorf("config %s: %w", path, err)
 	}
 	return cfg, nil
+}
+
+// resolvePaths expands ~/$VAR/%VAR% references in every filesystem-path
+// field and, when the result is still relative, anchors it to base (the
+// directory containing the loaded config.yaml). Empty fields are left
+// empty — they are "feature disabled" sentinels (storage.path,
+// cc_cache_file, token_file, message_log.path) — and already-absolute
+// paths are preserved, so existing absolute-path configs are unaffected.
+func (c *Config) resolvePaths(base string) {
+	resolve := func(p string) string {
+		if p == "" {
+			return ""
+		}
+		// Expand first, THEN test IsAbs: an expanded ${HOME}/x or
+		// %USERPROFILE%\x is absolute and must not be re-anchored.
+		p = pathutil.Expand(p)
+		if p == "" || filepath.IsAbs(p) {
+			return p
+		}
+		return filepath.Join(base, p)
+	}
+
+	c.Storage.Path = resolve(c.Storage.Path)
+	c.Storage.CCCacheFile = resolve(c.Storage.CCCacheFile)
+	c.Recordings.Dir = resolve(c.Recordings.Dir)
+	c.Log.MessageLog.Path = resolve(c.Log.MessageLog.Path)
+	c.API.Auth.TokenFile = resolve(c.API.Auth.TokenFile)
+	for i := range c.Baseband.Record {
+		c.Baseband.Record[i].Dir = resolve(c.Baseband.Record[i].Dir)
+	}
+	for i := range c.Baseband.Replay {
+		c.Baseband.Replay[i].File = resolve(c.Baseband.Replay[i].File)
+	}
+	for i := range c.Trunking.Systems {
+		c.Trunking.Systems[i].TalkgroupFile = resolve(c.Trunking.Systems[i].TalkgroupFile)
+		c.Trunking.Systems[i].RIDAliasFile = resolve(c.Trunking.Systems[i].RIDAliasFile)
+	}
 }
 
 // sectionValidator pairs a config section's logical name (matching the

--- a/internal/config/discover.go
+++ b/internal/config/discover.go
@@ -37,11 +37,13 @@ func Discover() string {
 //     - 1 file → use it.
 //     - 2+ files → call opts.Pick; if nil, take the first.
 //
-// Candidate directories (in order):
-//   - <os.UserConfigDir()>/GopherTrunk
+// Candidate directories (in order). Each GopherTrunk root is scanned
+// at its top level AND in its config/ subfolder (the data-root layout
+// the installer lays down, config.yaml at <DataRoot>/config/config.yaml):
+//   - <os.UserConfigDir()>/GopherTrunk and .../GopherTrunk/config
 //     (%APPDATA%\GopherTrunk on Windows, ~/.config/GopherTrunk on
 //     Linux, ~/Library/Application Support/GopherTrunk on macOS).
-//   - <UserHomeDir>/Documents/GopherTrunk
+//   - <UserHomeDir>/Documents/GopherTrunk and .../GopherTrunk/config
 //     (the Windows installer's default — operators who accept it
 //     get auto-discovery without setting any env var).
 //   - the current working directory.
@@ -82,13 +84,23 @@ func DirConfigFiles(dir string) []string { return dirConfigFiles(dir) }
 // candidateDirs returns the directories DiscoverWith will scan, in
 // precedence order. Factored out so tests can assert the order
 // without touching the filesystem.
+//
+// Each GopherTrunk root is scanned both at its top level (the legacy
+// layout, config.yaml directly in the root) and in its config/
+// subfolder (the data-root layout the installer lays down, where
+// config.yaml lives at <DataRoot>/config/config.yaml). The top-level
+// entry is listed first so an old-style config still wins if both
+// exist.
 func candidateDirs() []string {
 	var out []string
+	add := func(root string) {
+		out = append(out, root, filepath.Join(root, "config"))
+	}
 	if dir, err := os.UserConfigDir(); err == nil {
-		out = append(out, filepath.Join(dir, "GopherTrunk"))
+		add(filepath.Join(dir, "GopherTrunk"))
 	}
 	if home, err := os.UserHomeDir(); err == nil {
-		out = append(out, filepath.Join(home, "Documents", "GopherTrunk"))
+		add(filepath.Join(home, "Documents", "GopherTrunk"))
 	}
 	out = append(out, ".")
 	return out

--- a/internal/config/discover_test.go
+++ b/internal/config/discover_test.go
@@ -155,6 +155,43 @@ func TestCandidateDirs_OrderIncludesCwdLast(t *testing.T) {
 	}
 }
 
+// TestCandidateDirs_ScansConfigSubfolder asserts every GopherTrunk
+// root is paired with its config/ subfolder (the data-root layout),
+// with the root listed first.
+func TestCandidateDirs_ScansConfigSubfolder(t *testing.T) {
+	got := candidateDirs()
+	var sawPair bool
+	for i := 0; i+1 < len(got); i++ {
+		if filepath.Base(got[i]) == "GopherTrunk" &&
+			got[i+1] == filepath.Join(got[i], "config") {
+			sawPair = true
+			break
+		}
+	}
+	if !sawPair {
+		t.Errorf("candidateDirs() = %v, want a <root>/GopherTrunk entry immediately followed by its config/ subfolder", got)
+	}
+}
+
+// TestDiscover_ConfigSubfolder finds a config.yaml seeded in the
+// data-root config/ subfolder (the installer's layout) when no env
+// var is set and the root itself holds no *.yaml.
+func TestDiscover_ConfigSubfolder(t *testing.T) {
+	t.Setenv("GOPHERTRUNK_CONFIG", "")
+	redirectUserDirs(t)
+	cfgDir, _ := os.UserConfigDir()
+	target := filepath.Join(cfgDir, "GopherTrunk", "config", "config.yaml")
+	mustWrite(t, target, "log:\n")
+
+	got, err := DiscoverWith(DiscoverOptions{})
+	if err != nil {
+		t.Fatalf("DiscoverWith: %v", err)
+	}
+	if got != target {
+		t.Errorf("Discover() = %q, want %q", got, target)
+	}
+}
+
 // redirectUserDirs points os.UserConfigDir / os.UserHomeDir at a
 // fresh tempdir for the duration of the test, returning the
 // tempdir for path-building. Sets every relevant env var so the

--- a/internal/config/resolvepaths_test.go
+++ b/internal/config/resolvepaths_test.go
@@ -1,0 +1,100 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestLoadResolvesRelativePaths verifies that config-relative path fields
+// are anchored to the directory holding config.yaml, while absolute and
+// empty fields pass through untouched.
+func TestLoadResolvesRelativePaths(t *testing.T) {
+	dir := t.TempDir()
+	cfgDir := filepath.Join(dir, "config")
+	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(cfgDir, "config.yaml")
+
+	abs := filepath.Join(dir, "elsewhere", "calls.db")
+	yaml := `
+storage:
+  path: "../data/calls.db"
+  cc_cache_file: "` + filepath.ToSlash(abs) + `"
+recordings:
+  dir: "../recordings"
+log:
+  message_log:
+    enabled: true
+    path: "../logs/messages.log"
+baseband:
+  record:
+    - serial: "00000001"
+      dir: "../iq/"
+trunking:
+  systems:
+    - name: TestSystem
+      protocol: p25
+      control_channels: [851000000]
+      talkgroup_file: "../config/talkgroups.csv"
+`
+	if err := writeFile(path, yaml); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	want := func(rel string) string { return filepath.Join(cfgDir, rel) }
+	cases := []struct{ name, got, want string }{
+		{"storage.path", cfg.Storage.Path, want("../data/calls.db")},
+		{"recordings.dir", cfg.Recordings.Dir, want("../recordings")},
+		{"message_log.path", cfg.Log.MessageLog.Path, want("../logs/messages.log")},
+		{"baseband.record[0].dir", cfg.Baseband.Record[0].Dir, want("../iq")},
+		{"talkgroup_file", cfg.Trunking.Systems[0].TalkgroupFile, want("../config/talkgroups.csv")},
+	}
+	for _, c := range cases {
+		if c.got != c.want {
+			t.Errorf("%s = %q, want %q", c.name, c.got, c.want)
+		}
+	}
+
+	// Absolute path passes through unchanged.
+	if cfg.Storage.CCCacheFile != abs {
+		t.Errorf("cc_cache_file = %q, want %q (absolute, unchanged)", cfg.Storage.CCCacheFile, abs)
+	}
+	// Empty field stays empty (token_file unset).
+	if cfg.API.Auth.TokenFile != "" {
+		t.Errorf("token_file = %q, want empty", cfg.API.Auth.TokenFile)
+	}
+}
+
+// TestLoadExpandsEnvThenAbsolute verifies an env var expanding to an
+// absolute path is NOT re-anchored to the config dir.
+func TestLoadExpandsEnvThenAbsolute(t *testing.T) {
+	dir := t.TempDir()
+	cfgDir := filepath.Join(dir, "config")
+	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	root := filepath.Join(dir, "rootdata")
+	t.Setenv("GOPHERTRUNK_TEST_ROOT", root)
+	path := filepath.Join(cfgDir, "config.yaml")
+	yaml := `
+recordings:
+  dir: "${GOPHERTRUNK_TEST_ROOT}/recordings"
+`
+	if err := writeFile(path, yaml); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	want := filepath.Join(root, "recordings")
+	if cfg.Recordings.Dir != want {
+		t.Errorf("recordings.dir = %q, want %q", cfg.Recordings.Dir, want)
+	}
+}

--- a/internal/configbuilder/paths.go
+++ b/internal/configbuilder/paths.go
@@ -3,55 +3,17 @@ package configbuilder
 import (
 	"os"
 	"path/filepath"
-	"strings"
+
+	"github.com/MattCheramie/GopherTrunk/internal/pathutil"
 )
 
 // ExpandConfigPath resolves ~, $VAR/${VAR}, and %VAR% references in a
 // config-file path (relocated from the old CLI wizard so the terminal Config
 // Builder accepts the same operator-typed paths). Unknown vars are preserved.
+// It delegates to pathutil.Expand, the shared leaf helper the daemon's config
+// loader uses for the same resolution.
 func ExpandConfigPath(p string) string {
-	switch {
-	case p == "~":
-		if home, err := os.UserHomeDir(); err == nil {
-			p = home
-		}
-	case strings.HasPrefix(p, "~/"), strings.HasPrefix(p, `~\`):
-		if home, err := os.UserHomeDir(); err == nil {
-			p = filepath.Join(home, p[2:])
-		}
-	}
-	p = os.ExpandEnv(p) // $VAR, ${VAR}
-	return expandWindowsEnv(p)
-}
-
-// expandWindowsEnv replaces %VAR% references with their env values (Go's
-// os.ExpandEnv only handles POSIX-style $VAR). Unknown vars are preserved.
-func expandWindowsEnv(p string) string {
-	var b strings.Builder
-	for {
-		i := strings.IndexByte(p, '%')
-		if i < 0 {
-			b.WriteString(p)
-			return b.String()
-		}
-		b.WriteString(p[:i])
-		rest := p[i+1:]
-		j := strings.IndexByte(rest, '%')
-		if j < 0 {
-			b.WriteByte('%')
-			b.WriteString(rest)
-			return b.String()
-		}
-		name := rest[:j]
-		if val, ok := os.LookupEnv(name); ok {
-			b.WriteString(val)
-		} else {
-			b.WriteByte('%')
-			b.WriteString(name)
-			b.WriteByte('%')
-		}
-		p = rest[j+1:]
-	}
+	return pathutil.Expand(p)
 }
 
 // DefaultConfigPath picks a sensible default config.yaml location:

--- a/internal/pathutil/paths.go
+++ b/internal/pathutil/paths.go
@@ -1,0 +1,61 @@
+// Package pathutil holds filesystem-path helpers shared across the
+// daemon without pulling in any other internal package, so packages
+// like internal/config and internal/configbuilder can both depend on
+// it without an import cycle.
+package pathutil
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Expand resolves ~, $VAR/${VAR}, and %VAR% references in a path.
+// Unknown variables are preserved verbatim. It does NOT make the path
+// absolute — callers that want config-relative resolution should test
+// filepath.IsAbs on the result and join against a base directory
+// themselves.
+func Expand(p string) string {
+	switch {
+	case p == "~":
+		if home, err := os.UserHomeDir(); err == nil {
+			p = home
+		}
+	case strings.HasPrefix(p, "~/"), strings.HasPrefix(p, `~\`):
+		if home, err := os.UserHomeDir(); err == nil {
+			p = filepath.Join(home, p[2:])
+		}
+	}
+	p = os.ExpandEnv(p) // $VAR, ${VAR}
+	return expandWindowsEnv(p)
+}
+
+// expandWindowsEnv replaces %VAR% references with their env values (Go's
+// os.ExpandEnv only handles POSIX-style $VAR). Unknown vars are preserved.
+func expandWindowsEnv(p string) string {
+	var b strings.Builder
+	for {
+		i := strings.IndexByte(p, '%')
+		if i < 0 {
+			b.WriteString(p)
+			return b.String()
+		}
+		b.WriteString(p[:i])
+		rest := p[i+1:]
+		j := strings.IndexByte(rest, '%')
+		if j < 0 {
+			b.WriteByte('%')
+			b.WriteString(rest)
+			return b.String()
+		}
+		name := rest[:j]
+		if val, ok := os.LookupEnv(name); ok {
+			b.WriteString(val)
+		} else {
+			b.WriteByte('%')
+			b.WriteString(name)
+			b.WriteByte('%')
+		}
+		p = rest[j+1:]
+	}
+}

--- a/internal/pathutil/paths_test.go
+++ b/internal/pathutil/paths_test.go
@@ -1,0 +1,38 @@
+package pathutil
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestExpand(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skipf("no home dir: %v", err)
+	}
+	t.Setenv("GT_PATHUTIL_VAR", "/opt/gt")
+
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain relative", "../recordings", "../recordings"},
+		{"plain absolute", "/var/lib/gt", "/var/lib/gt"},
+		{"tilde only", "~", home},
+		{"tilde slash", "~/data", filepath.Join(home, "data")},
+		{"posix var", "$GT_PATHUTIL_VAR/x", "/opt/gt/x"},
+		{"posix braces", "${GT_PATHUTIL_VAR}/x", "/opt/gt/x"},
+		{"windows var", "%GT_PATHUTIL_VAR%/x", "/opt/gt/x"},
+		{"unknown windows var preserved", "%GT_NOPE%/x", "%GT_NOPE%/x"},
+		{"dangling percent preserved", "50%done", "50%done"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := Expand(c.in); got != c.want {
+				t.Errorf("Expand(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add internal/pathutil leaf package with the shared path-expansion
helper (~, $VAR, %VAR%) and have config.Load anchor every relative
filesystem-path field to the directory holding config.yaml. Absolute
and empty paths pass through unchanged, so existing configs are
unaffected. This lets a single portable config ship with
config-relative defaults that land under the operator's chosen data
root on any OS.