### PR TITLE
radioreference: built-in app key + edited-creds browse + verify subscription

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,14 +88,17 @@ jobs:
         shell: bash
         env:
           CGO_ENABLED: "0"
+          RR_APP_KEY: ${{ secrets.RR_APP_KEY }}
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           COMMIT="$(git rev-parse --short HEAD)"
           BUILD_TIME="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          RR_LDFLAGS=""
+          [ -n "${RR_APP_KEY:-}" ] && RR_LDFLAGS="-X github.com/MattCheramie/GopherTrunk/internal/radioreference.DefaultAppKey=${RR_APP_KEY}"
           mkdir -p dist/staging
           go build \
             -trimpath \
-            -ldflags "-X github.com/MattCheramie/GopherTrunk/internal/version.Version=${VERSION} -X github.com/MattCheramie/GopherTrunk/internal/version.Commit=${COMMIT} -X github.com/MattCheramie/GopherTrunk/internal/version.BuildTime=${BUILD_TIME}" \
+            -ldflags "-X github.com/MattCheramie/GopherTrunk/internal/version.Version=${VERSION} -X github.com/MattCheramie/GopherTrunk/internal/version.Commit=${COMMIT} -X github.com/MattCheramie/GopherTrunk/internal/version.BuildTime=${BUILD_TIME} ${RR_LDFLAGS}" \
             -o dist/staging/gophertrunk.exe \
             ./cmd/gophertrunk
 
@@ -163,16 +166,19 @@ jobs:
           CGO_ENABLED: "0"
           GOOS: windows
           GOARCH: arm64
+          RR_APP_KEY: ${{ secrets.RR_APP_KEY }}
         run: |
           set -eu
           VERSION="${{ steps.version.outputs.version }}"
           COMMIT="$(git rev-parse --short HEAD)"
           BUILD_TIME="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          RR_LDFLAGS=""
+          [ -n "${RR_APP_KEY:-}" ] && RR_LDFLAGS="-X github.com/MattCheramie/GopherTrunk/internal/radioreference.DefaultAppKey=${RR_APP_KEY}"
           NAME="gophertrunk-${VERSION}-windows-arm64"
           mkdir -p "dist/${NAME}"
           go build \
             -trimpath \
-            -ldflags "-X github.com/MattCheramie/GopherTrunk/internal/version.Version=${VERSION} -X github.com/MattCheramie/GopherTrunk/internal/version.Commit=${COMMIT} -X github.com/MattCheramie/GopherTrunk/internal/version.BuildTime=${BUILD_TIME}" \
+            -ldflags "-X github.com/MattCheramie/GopherTrunk/internal/version.Version=${VERSION} -X github.com/MattCheramie/GopherTrunk/internal/version.Commit=${COMMIT} -X github.com/MattCheramie/GopherTrunk/internal/version.BuildTime=${BUILD_TIME} ${RR_LDFLAGS}" \
             -o "dist/${NAME}/gophertrunk.exe" \
             ./cmd/gophertrunk
           cp README.md LICENSE config.example.yaml "dist/${NAME}/"
@@ -240,12 +246,15 @@ jobs:
         env:
           CGO_ENABLED: "0"
           GOOS: linux
+          RR_APP_KEY: ${{ secrets.RR_APP_KEY }}
         run: |
           set -eu
           VERSION="${{ steps.version.outputs.version }}"
           COMMIT="$(git rev-parse --short HEAD)"
           BUILD_TIME="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-          LDFLAGS="-X github.com/MattCheramie/GopherTrunk/internal/version.Version=${VERSION} -X github.com/MattCheramie/GopherTrunk/internal/version.Commit=${COMMIT} -X github.com/MattCheramie/GopherTrunk/internal/version.BuildTime=${BUILD_TIME}"
+          RR_LDFLAGS=""
+          [ -n "${RR_APP_KEY:-}" ] && RR_LDFLAGS=" -X github.com/MattCheramie/GopherTrunk/internal/radioreference.DefaultAppKey=${RR_APP_KEY}"
+          LDFLAGS="-X github.com/MattCheramie/GopherTrunk/internal/version.Version=${VERSION} -X github.com/MattCheramie/GopherTrunk/internal/version.Commit=${COMMIT} -X github.com/MattCheramie/GopherTrunk/internal/version.BuildTime=${BUILD_TIME}${RR_LDFLAGS}"
           for ARCH in amd64 arm64; do
             NAME="gophertrunk-${VERSION}-linux-${ARCH}"
             mkdir -p "dist/${NAME}"
@@ -317,12 +326,15 @@ jobs:
         env:
           CGO_ENABLED: "0"
           GOOS: darwin
+          RR_APP_KEY: ${{ secrets.RR_APP_KEY }}
         run: |
           set -eu
           VERSION="${{ steps.version.outputs.version }}"
           COMMIT="$(git rev-parse --short HEAD)"
           BUILD_TIME="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-          LDFLAGS="-X github.com/MattCheramie/GopherTrunk/internal/version.Version=${VERSION} -X github.com/MattCheramie/GopherTrunk/internal/version.Commit=${COMMIT} -X github.com/MattCheramie/GopherTrunk/internal/version.BuildTime=${BUILD_TIME}"
+          RR_LDFLAGS=""
+          [ -n "${RR_APP_KEY:-}" ] && RR_LDFLAGS=" -X github.com/MattCheramie/GopherTrunk/internal/radioreference.DefaultAppKey=${RR_APP_KEY}"
+          LDFLAGS="-X github.com/MattCheramie/GopherTrunk/internal/version.Version=${VERSION} -X github.com/MattCheramie/GopherTrunk/internal/version.Commit=${COMMIT} -X github.com/MattCheramie/GopherTrunk/internal/version.BuildTime=${BUILD_TIME}${RR_LDFLAGS}"
           for ARCH in amd64 arm64; do
             NAME="gophertrunk-${VERSION}-darwin-${ARCH}"
             mkdir -p "dist/${NAME}"

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,16 @@
 VERSION ?= $(shell git describe --tags --dirty --always 2>/dev/null || echo dev)
 COMMIT  ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "")
 BUILD_TIME ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
+# RR_APP_KEY is the built-in RadioReference app key, injected at link time so it
+# never lives in source. Supply it via the environment (CI secret / local env);
+# when unset the binary ships with no built-in key and RR falls back to
+# env/config, exactly as before. Never echo it.
+RR_APP_KEY ?=
+RR_LDFLAGS := $(if $(RR_APP_KEY),-X github.com/MattCheramie/GopherTrunk/internal/radioreference.DefaultAppKey=$(RR_APP_KEY),)
 LDFLAGS := -X github.com/MattCheramie/GopherTrunk/internal/version.Version=$(VERSION) \
            -X github.com/MattCheramie/GopherTrunk/internal/version.Commit=$(COMMIT) \
-           -X github.com/MattCheramie/GopherTrunk/internal/version.BuildTime=$(BUILD_TIME)
+           -X github.com/MattCheramie/GopherTrunk/internal/version.BuildTime=$(BUILD_TIME) \
+           $(RR_LDFLAGS)
 TAGS    ?=
 
 GO      ?= go

--- a/cmd/gophertrunk/config_serve.go
+++ b/cmd/gophertrunk/config_serve.go
@@ -74,11 +74,11 @@ FLAGS:`)
 		ConfigBuilder: api.ConfigBuilderOptions{
 			Enabled:   true,
 			ConfigDir: *configDir,
-			RadioReference: radioreference.Auth{
+			RadioReference: radioreference.ResolveAuth(radioreference.Auth{
 				AppKey:   strings.TrimSpace(os.Getenv("GOPHERTRUNK_RR_KEY")),
 				Username: strings.TrimSpace(os.Getenv("GOPHERTRUNK_RR_USER")),
 				Password: strings.TrimSpace(os.Getenv("GOPHERTRUNK_RR_PASS")),
-			},
+			}),
 		},
 	}
 	// Standalone: serve the builder SPA at / (like `siglab serve`).

--- a/cmd/gophertrunk/config_tui.go
+++ b/cmd/gophertrunk/config_tui.go
@@ -53,11 +53,11 @@ FLAGS:`)
 		dirs = config.CandidateDirs()
 	}
 
-	rrAuth := radioreference.Auth{
+	rrAuth := radioreference.ResolveAuth(radioreference.Auth{
 		AppKey:   strings.TrimSpace(os.Getenv("GOPHERTRUNK_RR_KEY")),
 		Username: strings.TrimSpace(os.Getenv("GOPHERTRUNK_RR_USER")),
 		Password: strings.TrimSpace(os.Getenv("GOPHERTRUNK_RR_PASS")),
-	}
+	})
 
 	initial := ""
 	if f := strings.TrimSpace(*cfgFile); f != "" {

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -1843,11 +1843,11 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 		// without -config). RR credentials: env overrides config.
 		cbOpts := api.ConfigBuilderOptions{
 			Enabled: true,
-			RadioReference: radioreference.Auth{
+			RadioReference: radioreference.ResolveAuth(radioreference.Auth{
 				AppKey:   firstNonEmptyStr(os.Getenv("GOPHERTRUNK_RR_KEY"), cfg.RadioReference.APIKey),
 				Username: firstNonEmptyStr(os.Getenv("GOPHERTRUNK_RR_USER"), cfg.RadioReference.Username),
 				Password: firstNonEmptyStr(os.Getenv("GOPHERTRUNK_RR_PASS"), cfg.RadioReference.Password),
-			},
+			}),
 		}
 		if d.cfgPath != "" {
 			cbOpts.ConfigDir = filepath.Dir(d.cfgPath)

--- a/cmd/gophertrunk/hunt.go
+++ b/cmd/gophertrunk/hunt.go
@@ -432,11 +432,11 @@ func gatherRRHints(sys *hunt.DiscoveredSystem, opts rrOptions) []hunt.DuplicateH
 	if key == "" {
 		key = os.Getenv("GOPHERTRUNK_RR_KEY")
 	}
-	client, err := radioreference.NewClient(radioreference.Auth{
+	client, err := radioreference.NewClient(radioreference.ResolveAuth(radioreference.Auth{
 		AppKey:   key,
 		Username: os.Getenv("GOPHERTRUNK_RR_USER"),
 		Password: os.Getenv("GOPHERTRUNK_RR_PASS"),
-	})
+	}))
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "hunt: RadioReference duplicate check skipped (no API key configured — set -rr-key or GOPHERTRUNK_RR_KEY)")
 		return nil

--- a/internal/api/config_builder.go
+++ b/internal/api/config_builder.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"net/http"
 	"path/filepath"
 	"strings"
 
@@ -11,6 +12,11 @@ import (
 	"github.com/MattCheramie/GopherTrunk/internal/configbuilder"
 	"github.com/MattCheramie/GopherTrunk/internal/radioreference"
 )
+
+// newRRClient builds a RadioReference client. It's a package var so tests can
+// stub a client pointed at a fake SOAP server (the handlers build clients
+// internally, so there's otherwise no endpoint-injection seam).
+var newRRClient = radioreference.NewClient
 
 // ConfigBuilderOptions configure the web Config Builder/Editor subsystem.
 type ConfigBuilderOptions struct {
@@ -171,11 +177,30 @@ func evalSymlinksBestEffort(path string) string {
 	}
 }
 
-// rrClient builds a RadioReference client from the configured credentials.
-// Returns radioreference.ErrNoCredentials when no key is set so the caller
-// can answer 503.
-func (svc *configBuilderService) rrClient() (*radioreference.Client, error) {
-	return radioreference.NewClient(svc.rrAuth)
+// rrAuthFromRequest overlays the per-request RR credentials carried in the
+// X-RR-Key / X-RR-User / X-RR-Pass headers (the username/password the operator
+// is editing in the builder) over the server's startup auth, then applies the
+// built-in default app key. Header values win so what the user types is what
+// gets sent to RadioReference and verifies their subscription.
+func (svc *configBuilderService) rrAuthFromRequest(r *http.Request) radioreference.Auth {
+	auth := svc.rrAuth
+	if v := strings.TrimSpace(r.Header.Get("X-RR-Key")); v != "" {
+		auth.AppKey = v
+	}
+	if v := strings.TrimSpace(r.Header.Get("X-RR-User")); v != "" {
+		auth.Username = v
+	}
+	if v := strings.TrimSpace(r.Header.Get("X-RR-Pass")); v != "" {
+		auth.Password = v
+	}
+	return radioreference.ResolveAuth(auth) // backstop the key with env/built-in
+}
+
+// rrClientFor builds a RadioReference client from the request-merged
+// credentials. Returns radioreference.ErrNoCredentials when no key is set
+// (built-in included) so the caller can answer 503.
+func (svc *configBuilderService) rrClientFor(r *http.Request) (*radioreference.Client, error) {
+	return newRRClient(svc.rrAuthFromRequest(r))
 }
 
 // ---- Wire DTOs -----------------------------------------------------------

--- a/internal/api/handlers_config_builder.go
+++ b/internal/api/handlers_config_builder.go
@@ -204,7 +204,7 @@ type RRSystemResponse struct {
 
 // handleConfigRRSearch answers GET /api/v1/config/rr/search?zip=|county=|state=.
 func (s *Server) handleConfigRRSearch(w http.ResponseWriter, r *http.Request) {
-	client, err := s.configBuilder.rrClient()
+	client, err := s.configBuilder.rrClientFor(r)
 	if err != nil {
 		s.writeError(w, http.StatusServiceUnavailable,
 			"config: RadioReference credentials not configured (set radioreference.* or GOPHERTRUNK_RR_KEY/USER/PASS)")
@@ -243,7 +243,7 @@ func (s *Server) handleConfigRRSearch(w http.ResponseWriter, r *http.Request) {
 // handleConfigRRStates answers GET /api/v1/config/rr/states — the state
 // list (id+name) backing the name-based browse picker.
 func (s *Server) handleConfigRRStates(w http.ResponseWriter, r *http.Request) {
-	client, err := s.configBuilder.rrClient()
+	client, err := s.configBuilder.rrClientFor(r)
 	if err != nil {
 		s.writeError(w, http.StatusServiceUnavailable,
 			"config: RadioReference credentials not configured (set radioreference.* or GOPHERTRUNK_RR_KEY/USER/PASS)")
@@ -260,7 +260,7 @@ func (s *Server) handleConfigRRStates(w http.ResponseWriter, r *http.Request) {
 // handleConfigRRCounties answers GET /api/v1/config/rr/counties?state=<stid>
 // — the counties in a state (id+name) for the browse picker.
 func (s *Server) handleConfigRRCounties(w http.ResponseWriter, r *http.Request) {
-	client, err := s.configBuilder.rrClient()
+	client, err := s.configBuilder.rrClientFor(r)
 	if err != nil {
 		s.writeError(w, http.StatusServiceUnavailable,
 			"config: RadioReference credentials not configured (set radioreference.* or GOPHERTRUNK_RR_KEY/USER/PASS)")
@@ -282,7 +282,7 @@ func (s *Server) handleConfigRRCounties(w http.ResponseWriter, r *http.Request) 
 // handleConfigRRSystem answers GET /api/v1/config/rr/system/{sid} —
 // full system detail plus a config-ready projection.
 func (s *Server) handleConfigRRSystem(w http.ResponseWriter, r *http.Request) {
-	client, err := s.configBuilder.rrClient()
+	client, err := s.configBuilder.rrClientFor(r)
 	if err != nil {
 		s.writeError(w, http.StatusServiceUnavailable,
 			"config: RadioReference credentials not configured (set radioreference.* or GOPHERTRUNK_RR_KEY/USER/PASS)")
@@ -307,6 +307,43 @@ func (s *Server) handleConfigRRSystem(w http.ResponseWriter, r *http.Request) {
 func rrToResponse(full radioreference.FullSystem) RRSystemResponse {
 	sys, rows := configbuilder.RRToSystemConfig(full)
 	return RRSystemResponse{System: full, Config: sys, Talkgroups: rows}
+}
+
+// RRVerifyResponse is the result of POST /api/v1/config/rr/verify. OK reports
+// that the supplied username/password authenticated; Premium reports whether
+// the account's subscription is currently active. Fault carries the RR error
+// message (bad login / expired) when OK is false.
+type RRVerifyResponse struct {
+	OK       bool   `json:"ok"`
+	Premium  bool   `json:"premium"`
+	Username string `json:"username,omitempty"`
+	Expires  string `json:"expires,omitempty"`
+	Fault    string `json:"fault,omitempty"`
+}
+
+// handleConfigRRVerify answers POST /api/v1/config/rr/verify — confirm the
+// edited RadioReference username/password (carried in the X-RR-* headers) and
+// report whether the subscription is premium. A bad login / expired membership
+// returns 200 with ok=false + a fault message so the builder shows it inline;
+// only a completely missing app key (built-in included) yields 503.
+func (s *Server) handleConfigRRVerify(w http.ResponseWriter, r *http.Request) {
+	client, err := s.configBuilder.rrClientFor(r)
+	if err != nil {
+		s.writeError(w, http.StatusServiceUnavailable,
+			"config: RadioReference app key not configured")
+		return
+	}
+	acct, err := client.VerifyCredentials(r.Context())
+	if err != nil {
+		writeJSON(w, http.StatusOK, RRVerifyResponse{OK: false, Fault: err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, RRVerifyResponse{
+		OK:       true,
+		Premium:  acct.Premium,
+		Username: acct.Username,
+		Expires:  acct.Expires,
+	})
 }
 
 // handleConfigDocs answers GET /api/v1/config/docs — a map of config section →

--- a/internal/api/handlers_config_builder_test.go
+++ b/internal/api/handlers_config_builder_test.go
@@ -5,13 +5,16 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"testing/fstest"
 
 	"github.com/MattCheramie/GopherTrunk/internal/config"
 	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/radioreference"
 )
 
 // cbServer spins up a Server with the Config Builder enabled, rooted at a
@@ -213,6 +216,9 @@ func TestConfigBuilder_PathTraversalRejected(t *testing.T) {
 }
 
 func TestConfigBuilder_RRWithoutCreds(t *testing.T) {
+	// No env key and no built-in key → the RR routes 503.
+	t.Setenv("GOPHERTRUNK_RR_KEY", "")
+	setDefaultAppKey(t, "")
 	base, _, teardown := cbServer(t)
 	defer teardown()
 
@@ -223,6 +229,122 @@ func TestConfigBuilder_RRWithoutCreds(t *testing.T) {
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusServiceUnavailable {
 		t.Fatalf("expected 503 without RR creds, got %d", resp.StatusCode)
+	}
+}
+
+// setDefaultAppKey overrides the build-time radioreference.DefaultAppKey for a
+// test and restores it afterwards.
+func setDefaultAppKey(t *testing.T, key string) {
+	t.Helper()
+	prev := radioreference.DefaultAppKey
+	radioreference.DefaultAppKey = key
+	t.Cleanup(func() { radioreference.DefaultAppKey = prev })
+}
+
+// fakeRRSOAP points the handlers' RR client at a local SOAP server returning
+// the given body, via the newRRClient seam. It returns the captured request
+// body pointer so a test can assert the edited creds reached RR.
+func fakeRRSOAP(t *testing.T, response string) *string {
+	t.Helper()
+	got := new(string)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		*got = string(b)
+		w.Header().Set("Content-Type", "text/xml")
+		_, _ = io.WriteString(w, response)
+	}))
+	t.Cleanup(srv.Close)
+	prev := newRRClient
+	newRRClient = func(a radioreference.Auth) (*radioreference.Client, error) {
+		c, err := radioreference.NewClient(a)
+		if err != nil {
+			return nil, err
+		}
+		c.SetEndpoint(srv.URL)
+		return c, nil
+	}
+	t.Cleanup(func() { newRRClient = prev })
+	return got
+}
+
+func TestConfigBuilder_RRVerify(t *testing.T) {
+	got := fakeRRSOAP(t, `<?xml version="1.0"?><E><username>alice</username>`+
+		`<subExpireDate>2999-01-01 00:00:00</subExpireDate></E>`)
+	base, _, teardown := cbServer(t)
+	defer teardown()
+
+	req, _ := http.NewRequest(http.MethodPost, base+"/api/v1/config/rr/verify", nil)
+	req.Header.Set("X-RR-Key", "KEY")
+	req.Header.Set("X-RR-User", "alice")
+	req.Header.Set("X-RR-Pass", "pw")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	var out RRVerifyResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatal(err)
+	}
+	if !out.OK || !out.Premium || out.Username != "alice" {
+		t.Fatalf("verify response = %+v, want ok+premium for alice", out)
+	}
+	// The edited username (from the header) must have reached RadioReference.
+	if !strings.Contains(*got, "alice") {
+		t.Errorf("RR request did not carry the edited username:\n%s", *got)
+	}
+}
+
+func TestConfigBuilder_RRVerifyFault(t *testing.T) {
+	fakeRRSOAP(t, `<?xml version="1.0"?><SOAP-ENV:Envelope `+
+		`xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"><SOAP-ENV:Body>`+
+		`<SOAP-ENV:Fault><faultstring>Invalid username or password</faultstring>`+
+		`</SOAP-ENV:Fault></SOAP-ENV:Body></SOAP-ENV:Envelope>`)
+	base, _, teardown := cbServer(t)
+	defer teardown()
+
+	req, _ := http.NewRequest(http.MethodPost, base+"/api/v1/config/rr/verify", nil)
+	req.Header.Set("X-RR-Key", "KEY")
+	req.Header.Set("X-RR-User", "alice")
+	req.Header.Set("X-RR-Pass", "bad")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	var out RRVerifyResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatal(err)
+	}
+	if out.OK || out.Fault == "" {
+		t.Fatalf("verify response = %+v, want ok=false with a fault", out)
+	}
+}
+
+func TestRRAuthFromRequest_HeaderMerge(t *testing.T) {
+	t.Setenv("GOPHERTRUNK_RR_KEY", "")
+	setDefaultAppKey(t, "builtin")
+	svc := &configBuilderService{rrAuth: radioreference.Auth{AppKey: "startup", Username: "startup-user"}}
+
+	// Headers override startup creds; an empty key still backstops to built-in.
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set("X-RR-User", "edited")
+	r.Header.Set("X-RR-Pass", "edited-pw")
+	auth := svc.rrAuthFromRequest(r)
+	if auth.Username != "edited" || auth.Password != "edited-pw" {
+		t.Errorf("user/pass = %q/%q, want edited", auth.Username, auth.Password)
+	}
+	if auth.AppKey != "startup" { // startup key present, so it wins over built-in
+		t.Errorf("AppKey = %q, want startup", auth.AppKey)
+	}
+
+	// With no startup key and no header key, the built-in default fills in.
+	svc.rrAuth = radioreference.Auth{}
+	if auth := svc.rrAuthFromRequest(httptest.NewRequest(http.MethodGet, "/", nil)); auth.AppKey != "builtin" {
+		t.Errorf("AppKey = %q, want builtin", auth.AppKey)
 	}
 }
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -1034,6 +1034,7 @@ func (s *Server) routes() *http.ServeMux {
 		mux.HandleFunc("GET /api/v1/config/rr/states", s.handleConfigRRStates)
 		mux.HandleFunc("GET /api/v1/config/rr/counties", s.handleConfigRRCounties)
 		mux.HandleFunc("GET /api/v1/config/rr/system/{sid}", s.handleConfigRRSystem)
+		mux.HandleFunc("POST /api/v1/config/rr/verify", s.handleConfigRRVerify)
 
 		// Secondary SPA at /config/ (daemon path). The standalone
 		// `config serve` puts the SPA in WebAssets (served at /) instead,

--- a/internal/configbuilder/fieldmeta.go
+++ b/internal/configbuilder/fieldmeta.go
@@ -75,9 +75,9 @@ var fieldMetas = map[string]FieldMeta{
 	"DiagnosticsConfig.VerboseErrors": {Help: "Print full error chains + stack traces and expand API error envelopes (exposes host/dongle info). Enable only on trusted networks."},
 
 	// ---- RadioReference ----------------------------------------------------
-	"RadioReferenceConfig.APIKey":   {Label: "API key", Help: "RadioReference.com SOAP API key (read-only). Used by the hunt duplicate check and this builder's browse/import. Can come from GOPHERTRUNK_RR_KEY instead."},
-	"RadioReferenceConfig.Username": {Help: "RadioReference.com account username. Can come from GOPHERTRUNK_RR_USER instead."},
-	"RadioReferenceConfig.Password": {Help: "RadioReference.com account password. Can come from GOPHERTRUNK_RR_PASS instead — prefer the env var to keeping the secret in config.yaml."},
+	"RadioReferenceConfig.APIKey":   {Label: "API key", Help: "RadioReference.com SOAP app key. Optional — GopherTrunk ships with a built-in app key, so leave this blank unless you want to use your own (or set GOPHERTRUNK_RR_KEY)."},
+	"RadioReferenceConfig.Username": {Help: "Your RadioReference.com account username. This and the password are what browse/import and 'Verify subscription' use to confirm your premium membership. Can come from GOPHERTRUNK_RR_USER instead."},
+	"RadioReferenceConfig.Password": {Help: "Your RadioReference.com account password (required with username for premium browse/import/verify). Can come from GOPHERTRUNK_RR_PASS instead — prefer the env var to keeping the secret in config.yaml."},
 
 	// ---- SDR ---------------------------------------------------------------
 	"SDRConfig.SampleRate":         {Label: "Sample rate", Hz: true, Help: "IQ rate every tuner is programmed to (225 kHz–20 MHz). RTL dongles cap ~3.2 MHz; higher needs a wideband soapy_remote source. Primary CPU-load lever."},

--- a/internal/configtui/modal_rr.go
+++ b/internal/configtui/modal_rr.go
@@ -44,10 +44,32 @@ type rrModal struct {
 	stid int
 }
 
+// effectiveRRAuth merges the RadioReference credentials being edited
+// (m.cfg.RadioReference) over the startup auth (env), then backstops the app
+// key with the built-in default. The edited config wins, so what the operator
+// types into the RadioReference section is what browse/import and verify send.
+func effectiveRRAuth(m *Model) radioreference.Auth {
+	return radioreference.ResolveAuth(radioreference.Auth{
+		AppKey:   firstNonEmptyStr(m.cfg.RadioReference.APIKey, m.rrAuth.AppKey),
+		Username: firstNonEmptyStr(m.cfg.RadioReference.Username, m.rrAuth.Username),
+		Password: firstNonEmptyStr(m.cfg.RadioReference.Password, m.rrAuth.Password),
+	})
+}
+
+// firstNonEmptyStr returns the first argument that is non-empty after trimming.
+func firstNonEmptyStr(vals ...string) string {
+	for _, v := range vals {
+		if strings.TrimSpace(v) != "" {
+			return v
+		}
+	}
+	return ""
+}
+
 func newRRModal(m *Model) modal {
-	c, err := radioreference.NewClient(m.rrAuth)
+	c, err := radioreference.NewClient(effectiveRRAuth(m))
 	if err != nil {
-		return &rrModal{step: rrError, err: "RadioReference credentials not configured (set GOPHERTRUNK_RR_KEY / _USER / _PASS)"}
+		return &rrModal{step: rrError, err: "RadioReference app key not configured (no built-in key in this build; set GOPHERTRUNK_RR_KEY or the api_key field)"}
 	}
 	zi := textinput.New()
 	zi.Prompt = "ZIP: "
@@ -293,4 +315,48 @@ func (r *rrModal) errLine() string {
 		return ""
 	}
 	return "\n" + stErr.Render("! "+r.err)
+}
+
+// ---- RadioReference verify ----
+
+// infoModal is a dismissable result box (any key closes it). Used to surface
+// the synchronous RadioReference subscription check.
+type infoModal struct {
+	title string
+	body  string
+	bad   bool
+}
+
+func (i *infoModal) Update(msg tea.KeyMsg, m *Model) (modal, tea.Cmd) { return nil, nil }
+
+func (i *infoModal) View(w, h int) string {
+	body := stOK.Render(i.body)
+	if i.bad {
+		body = stErr.Render(i.body)
+	}
+	return boxTitle("RadioReference", body+"\n\n[any key] close")
+}
+
+// newRRVerifyModal verifies the edited RadioReference credentials against the
+// account service and returns a dismissable result box reporting whether the
+// subscription is premium.
+func newRRVerifyModal(m *Model) modal {
+	c, err := radioreference.NewClient(effectiveRRAuth(m))
+	if err != nil {
+		return &infoModal{body: "App key not configured (no built-in key in this build; set GOPHERTRUNK_RR_KEY or the api_key field).", bad: true}
+	}
+	acct, err := c.VerifyCredentials(context.Background())
+	if err != nil {
+		return &infoModal{body: "Not verified: " + err.Error(), bad: true}
+	}
+	switch {
+	case acct.Premium && acct.Expires != "":
+		return &infoModal{body: "✓ Premium subscription active until " + acct.Expires + " (" + acct.Username + ")."}
+	case acct.Premium:
+		return &infoModal{body: "✓ Premium subscription active (" + acct.Username + ")."}
+	case acct.Expires != "":
+		return &infoModal{body: "Logged in as " + acct.Username + ", but the subscription is not active (expired " + acct.Expires + ").", bad: true}
+	default:
+		return &infoModal{body: "Logged in as " + acct.Username + ", but no active premium subscription was found.", bad: true}
+	}
 }

--- a/internal/configtui/update.go
+++ b/internal/configtui/update.go
@@ -142,6 +142,11 @@ func (m Model) updateStructForm(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.modal = newTalkgroupModal(&m)
 		return m, nil
 	}
+	// RadioReference subscription check (uses the edited creds).
+	if structNameOf(cur) == "RadioReferenceConfig" && msg.String() == "V" {
+		m.modal = newRRVerifyModal(&m)
+		return m, nil
+	}
 	switch msg.String() {
 	case "up", "k":
 		if m.cursor > 0 {

--- a/internal/configtui/view.go
+++ b/internal/configtui/view.go
@@ -131,6 +131,9 @@ func (m Model) viewStruct(cur reflect.Value) string {
 	if structNameOf(cur) == "SystemConfig" {
 		b.WriteString(stMuted.Render("[t] edit talkgroups") + "\n")
 	}
+	if structNameOf(cur) == "RadioReferenceConfig" {
+		b.WriteString(stMuted.Render("[V] verify subscription") + "\n")
+	}
 	lastAdvanced := false
 	for i, r := range rows {
 		if r.advanced && !lastAdvanced {

--- a/internal/radioreference/auth.go
+++ b/internal/radioreference/auth.go
@@ -1,0 +1,39 @@
+package radioreference
+
+import (
+	"os"
+	"strings"
+)
+
+// DefaultAppKey is the built-in RadioReference application key. It is injected
+// at BUILD time via the linker, e.g.:
+//
+//	go build -ldflags "-X github.com/MattCheramie/GopherTrunk/internal/radioreference.DefaultAppKey=<key>"
+//
+// (the Makefile wires this from the RR_APP_KEY environment variable, and the
+// release workflow from the RR_APP_KEY Actions secret). It is intentionally
+// empty in a bare `go build` / `go test` / `go run` and is never committed to
+// source — a build without the key simply falls back to env/config, exactly as
+// before this default existed.
+var DefaultAppKey = ""
+
+// ResolveAuth fills an empty AppKey from the GOPHERTRUNK_RR_KEY environment
+// variable and then the built-in DefaultAppKey, leaving an explicitly-supplied
+// key (and the username/password) untouched. The resulting key precedence is:
+// the value the caller already resolved (flag/config) > env > built-in. Every
+// place that assembles an Auth should pass it through here so the built-in key
+// flows everywhere uniformly.
+func ResolveAuth(a Auth) Auth {
+	a.AppKey = firstNonEmpty(
+		strings.TrimSpace(a.AppKey),
+		strings.TrimSpace(os.Getenv("GOPHERTRUNK_RR_KEY")),
+		strings.TrimSpace(DefaultAppKey),
+	)
+	return a
+}
+
+// EffectiveAppKey resolves just the app key (explicit > env > built-in) for
+// callers that don't have a full Auth in hand.
+func EffectiveAppKey(explicit string) string {
+	return ResolveAuth(Auth{AppKey: explicit}).AppKey
+}

--- a/internal/radioreference/auth_test.go
+++ b/internal/radioreference/auth_test.go
@@ -1,0 +1,57 @@
+package radioreference
+
+import "testing"
+
+func TestResolveAuth_KeyPrecedence(t *testing.T) {
+	// Explicit key wins over env and the built-in default.
+	t.Run("explicit wins", func(t *testing.T) {
+		t.Setenv("GOPHERTRUNK_RR_KEY", "env-key")
+		setDefaultAppKey(t, "builtin-key")
+		got := ResolveAuth(Auth{AppKey: "explicit", Username: "u", Password: "p"})
+		if got.AppKey != "explicit" {
+			t.Errorf("AppKey = %q, want explicit", got.AppKey)
+		}
+		if got.Username != "u" || got.Password != "p" {
+			t.Errorf("user/pass should be untouched, got %q/%q", got.Username, got.Password)
+		}
+	})
+
+	// Env beats the built-in default when no explicit key.
+	t.Run("env over builtin", func(t *testing.T) {
+		t.Setenv("GOPHERTRUNK_RR_KEY", "env-key")
+		setDefaultAppKey(t, "builtin-key")
+		if got := ResolveAuth(Auth{}).AppKey; got != "env-key" {
+			t.Errorf("AppKey = %q, want env-key", got)
+		}
+	})
+
+	// Built-in default is the last resort.
+	t.Run("builtin fallback", func(t *testing.T) {
+		t.Setenv("GOPHERTRUNK_RR_KEY", "")
+		setDefaultAppKey(t, "builtin-key")
+		if got := ResolveAuth(Auth{}).AppKey; got != "builtin-key" {
+			t.Errorf("AppKey = %q, want builtin-key", got)
+		}
+		if got := EffectiveAppKey(""); got != "builtin-key" {
+			t.Errorf("EffectiveAppKey = %q, want builtin-key", got)
+		}
+	})
+
+	// No key anywhere → empty (NewClient then returns ErrNoCredentials).
+	t.Run("none", func(t *testing.T) {
+		t.Setenv("GOPHERTRUNK_RR_KEY", "")
+		setDefaultAppKey(t, "")
+		if got := ResolveAuth(Auth{}).AppKey; got != "" {
+			t.Errorf("AppKey = %q, want empty", got)
+		}
+	})
+}
+
+// setDefaultAppKey overrides the build-time DefaultAppKey for the duration of a
+// test and restores it afterwards.
+func setDefaultAppKey(t *testing.T, key string) {
+	t.Helper()
+	prev := DefaultAppKey
+	DefaultAppKey = key
+	t.Cleanup(func() { DefaultAppKey = prev })
+}

--- a/internal/radioreference/verify.go
+++ b/internal/radioreference/verify.go
@@ -1,0 +1,74 @@
+package radioreference
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Account is the subset of a RadioReference user account returned by the
+// getUserData call. It is used to confirm that the supplied username/password
+// are valid and that the membership carries an active (premium) subscription —
+// the app key alone cannot prove premium access.
+type Account struct {
+	Username string `json:"username,omitempty"`
+	// Expires is the subscription expiry as RR reports it (left as the raw
+	// string so the UI can display whatever format the service returns).
+	Expires string `json:"expires,omitempty"`
+	Premium bool   `json:"premium"`
+}
+
+// ErrNoLogin is returned by VerifyCredentials when the username or password is
+// empty: with a built-in app key present, a "verify" can otherwise reach RR and
+// come back with an opaque authorization fault instead of a clear local error.
+var ErrNoLogin = errors.New("radioreference: username and password are required to verify a subscription")
+
+// VerifyCredentials confirms the configured username/password against the RR
+// account service (getUserData) and reports whether the account has an active
+// (premium) subscription. A SOAP fault (bad login / expired membership)
+// surfaces as an error so callers can show the message verbatim.
+func (c *Client) VerifyCredentials(ctx context.Context) (Account, error) {
+	if strings.TrimSpace(c.auth.Username) == "" || strings.TrimSpace(c.auth.Password) == "" {
+		return Account{}, ErrNoLogin
+	}
+	body := fmt.Sprintf(`<ns1:getUserData>%s</ns1:getUserData>`, c.authXML())
+	raw, err := c.call(ctx, body)
+	if err != nil {
+		return Account{}, err
+	}
+	leaves := firstLeaves(raw, "username", "userName", "uid", "subExpireDate", "expiration", "expires")
+	acct := Account{
+		Username: firstNonEmpty(leaves["username"], leaves["userName"]),
+		Expires:  firstNonEmpty(leaves["subExpireDate"], leaves["expiration"], leaves["expires"]),
+	}
+	acct.Premium = subscriptionActive(acct.Expires)
+	// A response with no identifying field means the call did not authenticate
+	// (RR sometimes returns an empty userInfo rather than a SOAP fault).
+	if acct.Username == "" && acct.Expires == "" && leaves["uid"] == "" {
+		return Account{}, errors.New("radioreference: could not verify account — check the username and password")
+	}
+	return acct, nil
+}
+
+// subscriptionActive reports whether an RR expiry timestamp is in the future.
+// RR returns dates like "2025-12-31 00:00:00" or "2025-12-31" (and some
+// accounts a UNIX-seconds value); unparseable or empty values are treated as
+// "not premium".
+func subscriptionActive(expires string) bool {
+	expires = strings.TrimSpace(expires)
+	if expires == "" {
+		return false
+	}
+	for _, layout := range []string{"2006-01-02 15:04:05", "2006-01-02T15:04:05", "2006-01-02", time.RFC3339} {
+		if t, err := time.Parse(layout, expires); err == nil {
+			return t.After(time.Now())
+		}
+	}
+	if n, err := strconv.ParseInt(expires, 10, 64); err == nil {
+		return time.Unix(n, 0).After(time.Now())
+	}
+	return false
+}

--- a/internal/radioreference/verify_test.go
+++ b/internal/radioreference/verify_test.go
@@ -1,0 +1,80 @@
+package radioreference
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// soapEnvelope wraps a getUserData body in a minimal SOAP envelope.
+func soapEnvelope(body string) string {
+	return `<?xml version="1.0" encoding="UTF-8"?>` +
+		`<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">` +
+		`<SOAP-ENV:Body><ns1:getUserDataResponse xmlns:ns1="urn:RadioReference"><return>` +
+		body +
+		`</return></ns1:getUserDataResponse></SOAP-ENV:Body></SOAP-ENV:Envelope>`
+}
+
+func verifyClient(t *testing.T, response string) *Client {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/xml")
+		_, _ = w.Write([]byte(response))
+	}))
+	t.Cleanup(srv.Close)
+	c, err := NewClient(Auth{AppKey: "KEY", Username: "alice", Password: "pw"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.SetEndpoint(srv.URL)
+	return c
+}
+
+func TestVerifyCredentials_Premium(t *testing.T) {
+	c := verifyClient(t, soapEnvelope(`<username>alice</username><subExpireDate>2999-01-01 00:00:00</subExpireDate>`))
+	acct, err := c.VerifyCredentials(context.Background())
+	if err != nil {
+		t.Fatalf("VerifyCredentials: %v", err)
+	}
+	if !acct.Premium {
+		t.Errorf("expected Premium=true for a future expiry, got %+v", acct)
+	}
+	if acct.Username != "alice" {
+		t.Errorf("Username = %q, want alice", acct.Username)
+	}
+}
+
+func TestVerifyCredentials_Expired(t *testing.T) {
+	c := verifyClient(t, soapEnvelope(`<username>bob</username><subExpireDate>2000-01-01 00:00:00</subExpireDate>`))
+	acct, err := c.VerifyCredentials(context.Background())
+	if err != nil {
+		t.Fatalf("VerifyCredentials: %v", err)
+	}
+	if acct.Premium {
+		t.Errorf("expected Premium=false for a past expiry, got %+v", acct)
+	}
+	if acct.Username != "bob" {
+		t.Errorf("Username = %q, want bob", acct.Username)
+	}
+}
+
+func TestVerifyCredentials_Fault(t *testing.T) {
+	fault := `<?xml version="1.0"?><SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">` +
+		`<SOAP-ENV:Body><SOAP-ENV:Fault><faultstring>Invalid username or password</faultstring></SOAP-ENV:Fault>` +
+		`</SOAP-ENV:Body></SOAP-ENV:Envelope>`
+	c := verifyClient(t, fault)
+	if _, err := c.VerifyCredentials(context.Background()); err == nil {
+		t.Fatal("expected an error on a SOAP fault")
+	}
+}
+
+func TestVerifyCredentials_RequiresLogin(t *testing.T) {
+	c, err := NewClient(Auth{AppKey: "KEY"}) // key only, no user/pass
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := c.VerifyCredentials(context.Background()); err != ErrNoLogin {
+		t.Errorf("err = %v, want ErrNoLogin", err)
+	}
+}

--- a/web/configbuilder/src/api/client.test.ts
+++ b/web/configbuilder/src/api/client.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { api } from "./client";
+
+afterEach(() => vi.restoreAllMocks());
+
+function mockFetch(bodyObj: unknown) {
+  const fn = vi.fn(
+    async (_input: RequestInfo | URL, _init?: RequestInit): Promise<Response> =>
+      new Response(JSON.stringify(bodyObj), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+  );
+  vi.stubGlobal("fetch", fn);
+  return fn;
+}
+
+describe("RR client credential headers", () => {
+  it("rrVerify POSTs with the X-RR-* creds the user is editing", async () => {
+    const fetchMock = mockFetch({ ok: true, premium: true, username: "alice" });
+    const r = await api.rrVerify({ key: "K", user: "alice", pass: "pw" });
+    expect(r.ok).toBe(true);
+    expect(r.premium).toBe(true);
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("/api/v1/config/rr/verify");
+    expect(init?.method).toBe("POST");
+    const h = init?.headers as Record<string, string>;
+    expect(h["X-RR-Key"]).toBe("K");
+    expect(h["X-RR-User"]).toBe("alice");
+    expect(h["X-RR-Pass"]).toBe("pw");
+  });
+
+  it("omits empty/blank cred headers", async () => {
+    const fetchMock = mockFetch({ results: [] });
+    await api.rrStates({ key: "", user: "  ", pass: undefined });
+    const h = fetchMock.mock.calls[0][1]?.headers as Record<string, string>;
+    expect(h["X-RR-Key"]).toBeUndefined();
+    expect(h["X-RR-User"]).toBeUndefined();
+    expect(h["X-RR-Pass"]).toBeUndefined();
+  });
+});

--- a/web/configbuilder/src/api/client.ts
+++ b/web/configbuilder/src/api/client.ts
@@ -9,6 +9,7 @@ import type {
   RRGeoRef,
   RRSearchHit,
   RRSystemResponse,
+  RRVerifyResponse,
   TalkgroupCSVRow,
   ValidationResult,
 } from "./types";
@@ -32,8 +33,13 @@ export class HTTPError extends Error {
   }
 }
 
-async function req<T>(method: string, path: string, body?: unknown): Promise<T> {
-  const headers: Record<string, string> = {};
+async function req<T>(
+  method: string,
+  path: string,
+  body?: unknown,
+  extraHeaders?: Record<string, string>,
+): Promise<T> {
+  const headers: Record<string, string> = { ...(extraHeaders ?? {}) };
   if (authToken) headers["Authorization"] = `Bearer ${authToken}`;
   let payload: BodyInit | undefined;
   if (body instanceof FormData) {
@@ -90,14 +96,37 @@ export const api = {
     for (const f of files) fd.append("files", f);
     return req<{ systems: ParsedSystemDTO[] }>("POST", "/config/parse", fd);
   },
-  rrSearch: (kind: "zip" | "county" | "state", value: string) =>
+  rrSearch: (kind: "zip" | "county" | "state", value: string, creds?: RRCreds) =>
     req<{ results: RRSearchHit[] | null }>(
       "GET",
       `/config/rr/search?${kind}=${encodeURIComponent(value)}`,
+      undefined,
+      rrHeaders(creds),
     ),
-  rrStates: () => req<{ results: RRGeoRef[] | null }>("GET", "/config/rr/states"),
-  rrCounties: (stid: number) =>
-    req<{ results: RRGeoRef[] | null }>("GET", `/config/rr/counties?state=${stid}`),
-  rrSystem: (sid: number) =>
-    req<RRSystemResponse>("GET", `/config/rr/system/${sid}`),
+  rrStates: (creds?: RRCreds) =>
+    req<{ results: RRGeoRef[] | null }>("GET", "/config/rr/states", undefined, rrHeaders(creds)),
+  rrCounties: (stid: number, creds?: RRCreds) =>
+    req<{ results: RRGeoRef[] | null }>(
+      "GET",
+      `/config/rr/counties?state=${stid}`,
+      undefined,
+      rrHeaders(creds),
+    ),
+  rrSystem: (sid: number, creds?: RRCreds) =>
+    req<RRSystemResponse>("GET", `/config/rr/system/${sid}`, undefined, rrHeaders(creds)),
+  rrVerify: (creds?: RRCreds) =>
+    req<RRVerifyResponse>("POST", "/config/rr/verify", undefined, rrHeaders(creds)),
 };
+
+// RRCreds are the RadioReference credentials the user is editing, sent on the
+// browse/verify calls as X-RR-* headers so what they type is what reaches RR
+// (and verifies their premium subscription) — kept out of the URL/query.
+export type RRCreds = { key?: string; user?: string; pass?: string };
+
+function rrHeaders(c?: RRCreds): Record<string, string> {
+  const h: Record<string, string> = {};
+  if (c?.key?.trim()) h["X-RR-Key"] = c.key.trim();
+  if (c?.user?.trim()) h["X-RR-User"] = c.user.trim();
+  if (c?.pass?.trim()) h["X-RR-Pass"] = c.pass.trim();
+  return h;
+}

--- a/web/configbuilder/src/api/types.ts
+++ b/web/configbuilder/src/api/types.ts
@@ -498,6 +498,16 @@ export interface RRSearchHit {
   state?: string;
 }
 
+// RRVerifyResponse is the result of POST /config/rr/verify: whether the edited
+// username/password authenticated (ok) and whether the subscription is premium.
+export interface RRVerifyResponse {
+  ok: boolean;
+  premium: boolean;
+  username?: string;
+  expires?: string;
+  fault?: string;
+}
+
 export interface RRSiteDetail {
   rfss?: number;
   site_number?: number;

--- a/web/configbuilder/src/sections/Trunking.tsx
+++ b/web/configbuilder/src/sections/Trunking.tsx
@@ -422,6 +422,11 @@ function RRBrowseModal(props: {
   onAdd: (sys: SystemConfig, tgs?: TalkgroupCSVRow[]) => void;
 }) {
   const setError = useStore((s) => s.setError);
+  // The RadioReference creds the user is editing — sent with every RR call so
+  // their premium login is what reaches the API (not just the server's startup
+  // creds).
+  const rr = useStore((s) => s.config?.RadioReference);
+  const creds = { key: rr?.APIKey, user: rr?.Username, pass: rr?.Password };
   const [mode, setMode] = useState<"name" | "zip" | "advanced">("name");
 
   // name mode: state → county dropdowns.
@@ -457,7 +462,7 @@ function RRBrowseModal(props: {
     if (!v) return;
     setBusy(true);
     try {
-      const r = await api.rrCounties(Number(v));
+      const r = await api.rrCounties(Number(v), creds);
       setCounties(r.results ?? []);
     } catch (e) {
       setError(`RadioReference: ${(e as Error).message}`);
@@ -482,7 +487,7 @@ function RRBrowseModal(props: {
   const importSystem = async (sid: number) => {
     setBusy(true);
     try {
-      const r = await api.rrSystem(sid);
+      const r = await api.rrSystem(sid, creds);
       props.onAdd(r.config, r.talkgroups ?? []);
       props.onClose();
     } catch (e) {
@@ -529,7 +534,7 @@ function RRBrowseModal(props: {
             disabled={!counties}
             onChange={(e) => {
               setCtid(e.target.value);
-              if (e.target.value) runSearch(() => api.rrSearch("county", e.target.value));
+              if (e.target.value) runSearch(() => api.rrSearch("county", e.target.value, creds));
             }}
           >
             <option value="">Select county…</option>
@@ -540,7 +545,7 @@ function RRBrowseModal(props: {
             ))}
           </select>
           {stid ? (
-            <button className="btn-ghost" disabled={busy} onClick={() => runSearch(() => api.rrSearch("state", stid))}>
+            <button className="btn-ghost" disabled={busy} onClick={() => runSearch(() => api.rrSearch("state", stid, creds))}>
               All systems in state
             </button>
           ) : null}
@@ -554,9 +559,9 @@ function RRBrowseModal(props: {
             value={zip}
             placeholder="78701"
             onChange={(e) => setZip(e.target.value)}
-            onKeyDown={(e) => e.key === "Enter" && runSearch(() => api.rrSearch("zip", zip.trim()))}
+            onKeyDown={(e) => e.key === "Enter" && runSearch(() => api.rrSearch("zip", zip.trim(), creds))}
           />
-          <button className="btn" disabled={busy || !zip.trim()} onClick={() => runSearch(() => api.rrSearch("zip", zip.trim()))}>
+          <button className="btn" disabled={busy || !zip.trim()} onClick={() => runSearch(() => api.rrSearch("zip", zip.trim(), creds))}>
             Search
           </button>
         </div>
@@ -573,9 +578,9 @@ function RRBrowseModal(props: {
             value={value}
             placeholder="numeric ctid / stid"
             onChange={(e) => setValue(e.target.value)}
-            onKeyDown={(e) => e.key === "Enter" && runSearch(() => api.rrSearch(kind, value.trim()))}
+            onKeyDown={(e) => e.key === "Enter" && runSearch(() => api.rrSearch(kind, value.trim(), creds))}
           />
-          <button className="btn" disabled={busy || !value.trim()} onClick={() => runSearch(() => api.rrSearch(kind, value.trim()))}>
+          <button className="btn" disabled={busy || !value.trim()} onClick={() => runSearch(() => api.rrSearch(kind, value.trim(), creds))}>
             Search
           </button>
         </div>

--- a/web/configbuilder/src/sections/simple.tsx
+++ b/web/configbuilder/src/sections/simple.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { Section } from "../components/Section";
 import {
   BoolField,
@@ -9,6 +10,7 @@ import {
 } from "../components/fields";
 import { ListEditor } from "../components/ListEditor";
 import { formatCommaList, parseCommaList } from "../lib/csvList";
+import { api } from "../api/client";
 import { useStore } from "../store/shared";
 import type {
   APIConfig,
@@ -108,6 +110,35 @@ export function DiagnosticsSection() {
 export function RadioReferenceSection() {
   const [v, set] = useSection("RadioReference");
   const cfg = v as RadioReferenceConfig;
+  const [verify, setVerify] = useState<{ busy: boolean; ok?: boolean; msg?: string }>({ busy: false });
+
+  // runVerify sends the edited username/password (+ the built-in/overridden app
+  // key) to the server, which calls RadioReference and reports whether the
+  // subscription is premium.
+  const runVerify = async () => {
+    setVerify({ busy: true });
+    try {
+      const r = await api.rrVerify({ key: cfg.APIKey, user: cfg.Username, pass: cfg.Password });
+      if (!r.ok) {
+        setVerify({ busy: false, ok: false, msg: r.fault || "Could not verify the account." });
+      } else if (r.premium) {
+        setVerify({
+          busy: false,
+          ok: true,
+          msg: `Premium subscription active${r.expires ? ` until ${r.expires}` : ""}${r.username ? ` (${r.username})` : ""}.`,
+        });
+      } else {
+        setVerify({
+          busy: false,
+          ok: false,
+          msg: `Logged in${r.username ? ` as ${r.username}` : ""}, but no active premium subscription was found.`,
+        });
+      }
+    } catch (e) {
+      setVerify({ busy: false, ok: false, msg: (e as Error).message });
+    }
+  };
+
   return (
     <Section
       sectionKey="radioreference"
@@ -121,6 +152,17 @@ export function RadioReferenceSection() {
         value={cfg.Password}
         onChange={(x) => set({ ...cfg, Password: x })}
       />
+      <div className="flex flex-wrap items-center gap-3">
+        <button className="btn" disabled={verify.busy} onClick={runVerify}>
+          {verify.busy ? "Verifying…" : "Verify subscription"}
+        </button>
+        {verify.msg ? (
+          <span className={verify.ok ? "text-sm text-ok" : "text-sm text-err"}>
+            {verify.ok ? "✓ " : "✗ "}
+            {verify.msg}
+          </span>
+        ) : null}
+      </div>
     </Section>
   );
 }


### PR DESCRIPTION
Per RadioReference's API model an app key (developer) plus the subscriber's
username/password are sent on every call; the username/password is what proves
a premium membership. This makes that work end to end in both Config Builders:

- Built-in app key injected at BUILD time: radioreference.DefaultAppKey +
  ResolveAuth (explicit > env > built-in). Wired via -ldflags from the
  RR_APP_KEY env var (Makefile) / Actions secret (release.yml); empty in bare
  builds so the key never lives in source. All cmd Auth call sites resolve it.
- Edited credentials reach RadioReference: the web browse/import sends the
  username/password the user is editing as X-RR-Key/User/Pass headers (kept out
  of the URL); the server merges them per request (rrAuthFromRequest/rrClientFor)
  and backstops the key with the built-in default. The TUI browse modal now
  builds auth from the edited config (effectiveRRAuth) instead of startup env.
- Verify subscription: radioreference.VerifyCredentials (getUserData) reports
  whether the account is premium. New POST /api/v1/config/rr/verify; a "Verify
  subscription" button in the web RR section and a [V] action in the TUI RR
  section, both showing premium/expiry or the auth fault inline.
- Shared RR field help updated to note the built-in key and that
  username/password gate premium browse/verify.

Tests: ResolveAuth precedence; VerifyCredentials premium/expired/fault/no-login
against a fake SOAP server; the verify endpoint + X-RR-* header merge (new
newRRClient seam); web client header construction. Existing RRWithoutCreds
hardened to pin an empty key.

https://claude.ai/code/session_017EGcBzuFkZSBXvgg6i14PF