### PR TITLE
docs: post-release v0.3.7 — promote CHANGELOG, bump refs, announcement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,47 @@ for tagged releases.
 
 ## [Unreleased]
 
+## [v0.3.7] — 2026-06-09
+
+This release sharpens **P25 Phase 1 voice** and consolidates the **install
+layout**. The decoder now error-corrects the outer Reed-Solomon layer on the
+LDU1 Link Control and LDU2 Encryption Sync (#589), so a real-air capture's
+talkgroup gating stops fragmenting calls into ~1 s files; on top of that the
+IMBE vocoder gets TIA-102.BABA §6.3 voiced-phase regeneration to kill the
+"robotic" buzz (#600), idle-carrier dead keys are muted (#599), and the LDU1
+Link Control octet layout is corrected (#596). The Windows installer now
+prompts for **one data folder** that holds config, recordings, IQ, exports,
+the database, logs, and all three browser consoles, with config path fields
+resolved relative to the config directory so a single portable config works on
+any OS (#602). The **Plots** scopes gain a selectable C4FM constellation (IQ
+ring vs. soft levels), an auto-detected demod mode, and a channel-step nudge
+(#557, #583); the **signal survey** becomes a saved, offline-decodable artifact
+(#590, #592); RadioReference picks up a built-in app key and a "verify
+subscription" check (#603); browser audio now seeks on Safari (#598); and the
+same talkgroup is no longer shown as two duplicate "Active calls" (#593).
+
+### Changed
+
+- **Single data root for installed builds** (#602). The Windows installer now
+  asks for one data folder (default `Documents\GopherTrunk`) instead of two,
+  and lays out `config/ recordings/ iq/ exports/ data/ logs/ web/` beneath it;
+  the executable still installs to Program Files. `config.example.yaml` ships
+  config-relative paths (`../recordings`, `../data`, …) and `config.Load` now
+  anchors every relative path field to the directory holding `config.yaml`
+  (absolute and empty paths are unchanged), so one portable config lands under
+  the operator's chosen root on any OS. `gophertrunk run -web` resolves the
+  bundled consoles under `<DataRoot>/web` via `GOPHERTRUNK_HOME` /
+  `GOPHERTRUNK_CONFIG`.
+
 ### Added
 
+- **RadioReference built-in app key + subscription verify** (#603). A developer
+  app key can be injected at build time (`-ldflags`, kept out of source) and is
+  resolved explicit > env > built-in, so browse/import works without each user
+  supplying a key; the subscriber's username/password (which gate premium) are
+  sent per request from the edited config in both the web and TUI Config
+  Builders. A new **Verify subscription** action (web button / TUI `[V]`,
+  `POST /api/v1/config/rr/verify`) reports premium status and expiry inline.
 - **Constellation: selectable C4FM display (IQ ring vs. soft levels)** (#557).
   C4FM is constant-envelope FM with no complex symbol constellation, so the
   Symbols view previously plotted its soft decisions as a thin horizontal line
@@ -18,6 +57,17 @@ for tagged releases.
 
 ### Fixed
 
+- **P25 Phase 1 calls no longer fragment from un-error-corrected control
+  words** (#589). LDU1 Link Control (talkgroup/source) and LDU2 Encryption Sync
+  (ALGID/KID) were decoded with only the inner Hamming(10,6,3) layer; the outer
+  Reed-Solomon codes were never corrected, so residual bit errors corrupted the
+  talkgroup the recorder's gating relies on — dropping ~71% of voice frames,
+  splitting calls into ~1 s files, and producing garbage ALGIDs. The framing
+  layer now does bounded-distance RS decoding over GF(2⁶) (Berlekamp-Massey +
+  Chien + Forney) for RS(24,12,13), RS(24,16,9) and RS(36,20,17), run as the
+  outer layer in `ParseLinkControl` / `ParseEncryptionSync`; when a word is
+  RS-uncorrectable the composer leaves `tg=0` so the boundary tracker inherits
+  the last match instead of ending the call on a mis-decode.
 - **P25 voice no longer sounds robotic / "wrongly pitched."** The pure-Go IMBE
   synthesizer generated every voiced harmonic with a fully phase-coherent
   model (each harmonic locked to an exact multiple of the fundamental, frame
@@ -123,6 +173,30 @@ for tagged releases.
   array, so every frame was silently discarded and the Constellation, Symbol
   scope, Eye, Tuning, and Histogram panels never rendered. `dibits` now goes
   out as a number array, with a regression test asserting the wire shape.
+- **Same talkgroup no longer shows as two duplicate "Active calls"** (#593).
+  The duplicate-grant guard keyed an in-progress call on frequency, but a call's
+  frequency can change mid-call (a P25 band-plan IdentifierUpdate re-maps the
+  channel, or the system hands the call to a new channel), so the guard missed
+  and a second `ActiveCall` was bound for the same talkgroup. A logical call is
+  now identified by (System, GroupID, Timeslot); on a same-call grant with a
+  changed frequency the engine retunes the bound device in place (preserving
+  `StartedAt`, no spurious CallStart), or releases it and binds a capable one —
+  still exactly one call.
+- **Browser audio now plays/seeks on Safari (macOS/iOS)** (#598). Safari's media
+  element refuses to play unless the server honors Range requests, but
+  `/api/v1/audio/stream` only ever returned a plain open-ended 200 WAV body, so
+  "Tap to enable audio" silently failed on macOS while Chrome/Firefox tolerated
+  it. The endpoint now answers Safari's bounded probe and open-ended
+  `bytes=N-` request with `206` + `Accept-Ranges` + `Content-Range`; requests
+  with no Range header keep the existing 200 path. The web player also logs
+  `play()` failures instead of swallowing them.
+- **Config Builder no longer opens a blank tab** (#595). Two independent defects
+  blanked `/config/`: release/installer CI only built the main console before
+  `go build`, so the binary embedded an empty `web/configbuilder/dist` and the
+  route was never mounted; and the main console's PWA service worker intercepted
+  `/config/` navigations via `navigateFallback`. CI now builds the Config
+  Builder (and siglab) in every release/installer job, and `/config/` is added
+  to the service worker's `navigateFallbackDenylist`.
 
 ## [v0.3.6] — 2026-06-08
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ this exist? Read **[The Story of GopherTrunk](https://gophertrunk.org/story.html
 
 ```sh
 # Linux x86_64 — see https://gophertrunk.org/downloads.html for macOS, Windows, ARM64.
-VERSION=v0.3.6
+VERSION=v0.3.7
 curl -L -o gophertrunk.tar.gz \
   https://github.com/MattCheramie/GopherTrunk/releases/download/${VERSION}/gophertrunk-${VERSION}-linux-amd64.tar.gz
 tar xzf gophertrunk.tar.gz && cd gophertrunk-${VERSION}-linux-amd64

--- a/docs/announcements/v0.3.7.md
+++ b/docs/announcements/v0.3.7.md
@@ -1,0 +1,51 @@
+# GopherTrunk v0.3.7 — social announcement drafts
+
+One-click copy-paste blurbs for posting the v0.3.7 release. Each block
+below is a fenced code block so the rendered-markdown "copy" button
+grabs exactly what you'd paste.
+
+Release: https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.3.7
+
+---
+
+## Reddit — title
+
+```
+GopherTrunk v0.3.7 — Reed-Solomon-corrected P25 Phase 1 voice, a single-folder Windows install, RadioReference built-in key, and Safari-friendly live audio
+```
+
+## Reddit — body
+
+```markdown
+**[GopherTrunk](https://gophertrunk.org) v0.3.7 is out** — pure-Go digital-trunking scanner for RTL-SDR / HackRF / Airspy. P25 (Phase 1+2), DMR (AMBE+2 voice), NXDN, Motorola Type II, EDACS, LTR, MPT 1327, dPMR, D-STAR, YSF, M17, plus APRS, POCSAG + FLEX paging, and AIS / DSC / ADS-B. No CGO, single static binary for Linux / macOS / Windows.
+
+**What's new since v0.3.6:**
+
+* **Reed-Solomon-corrected P25 Phase 1 voice** (#589) — the LDU1 Link Control and LDU2 Encryption Sync words are now error-corrected with their outer RS codes (RS(24,12,13)/RS(24,16,9)/RS(36,20,17) via Berlekamp-Massey + Chien + Forney), not just the inner Hamming layer. Residual bit errors used to corrupt the talkgroup the recorder gates on — dropping ~71% of voice frames and chopping calls into ~1 s files — so this is the big one for clean P25 recordings. On top of it: §6.3 voiced-phase regeneration kills the "robotic" IMBE buzz (#600), idle-carrier dead keys are muted (#599), and the LDU1 octet layout is corrected (#596).
+* **One-folder Windows install** (#602) — the installer now prompts for a single data folder (default `Documents\GopherTrunk`) that holds config, recordings, IQ, exports, the database, logs, and all three browser consoles, instead of two separate prompts. Config path fields resolve relative to the config directory, so one portable config works on any OS.
+* **Plots scopes: selectable C4FM constellation, auto demod, channel-step nudge** (#557, #583) — C4FM can show the raw IQ ring or the soft-level line, the Constellation/Symbol scope auto-detect the configured demod mode, and a Step selector (6.25 / 12.5 / 25 kHz) walks the channel grid. The "waiting for symbols" stall is fixed.
+* **Signal survey you can save, decode, and run offline** (#590, #592) — the live survey classifies every detected carrier by modulation family, decodes the conventional ones (POCSAG/FLEX + analog FM), and now writes `survey.json`/`survey.csv`, serves `GET /api/v1/hunt/survey`, runs offline against a capture (`hunt -survey -in`), and is downloadable from the web Hunt panel.
+* **RadioReference built-in key + subscription verify** (#603), **Safari-friendly live audio** (#598 — the audio stream now honors HTTP Range requests so macOS/iOS playback works), the **Config Builder no longer opens a blank tab** (#595), and the **same talkgroup is no longer shown as two duplicate active calls** (#593).
+
+**Downloads** (Linux / macOS / Windows, x64 + ARM64): https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.3.7
+
+**Docs:** https://gophertrunk.org
+
+Heads-up: the v0.x line is still flagged prerelease — actively developed, feedback / captures / bug reports very welcome.
+```
+
+## Discord
+
+```markdown
+**GopherTrunk v0.3.7 is out** — pure-Go trunking scanner for RTL-SDR / HackRF / Airspy. P25, DMR, NXDN, M17, analog trunked, APRS, POCSAG + FLEX paging, AIS / DSC / ADS-B. Single static binary, zero CGO.
+
+**What's new since v0.3.6:**
+- **RS-corrected P25 Phase 1 voice** (#589) — outer Reed-Solomon FEC on LDU1 Link Control + LDU2 Encryption Sync stops talkgroup corruption that was dropping ~71% of voice frames and fragmenting calls into ~1 s files. Plus §6.3 voiced-phase de-buzz (#600), muted idle dead keys (#599), fixed LDU1 octet layout (#596).
+- **One-folder Windows install** (#602) — single data folder for config, recordings, IQ, exports, DB, logs, and all three consoles; config-relative paths work on any OS.
+- **Plots scopes** (#557, #583) — selectable C4FM IQ ring vs. soft levels, auto-detected demod mode, channel-step nudge; "waiting for symbols" fixed.
+- **Saveable/offline signal survey** (#590, #592) — `survey.json`/`survey.csv`, `GET /api/v1/hunt/survey`, offline `hunt -survey -in`.
+- **RadioReference built-in key + verify** (#603), **Safari live audio** (#598), **Config Builder blank-tab fix** (#595), **duplicate active-calls fix** (#593).
+
+Download: <https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.3.7>
+Docs: <https://gophertrunk.org>
+```

--- a/docs/downloads.md
+++ b/docs/downloads.md
@@ -28,7 +28,7 @@ release state looks like:
 {%- elsif site.github.releases and site.github.releases[0] and site.github.releases[0].tag_name -%}
   {%- assign ver = site.github.releases[0].tag_name -%}
 {%- else -%}
-  {%- assign ver = "v0.3.6" -%}
+  {%- assign ver = "v0.3.7" -%}
 {%- endif -%}
 {%- assign rel_url = "https://github.com/MattCheramie/GopherTrunk/releases/download/" | append: ver -%}
 


### PR DESCRIPTION
Daily release v0.3.7 is published; sync the docs to match.

- CHANGELOG: promote [Unreleased] to [v0.3.7] (2026-06-09) with a
  release summary, and backfill the user-visible changes that shipped
  in the tag but lacked entries: RS outer FEC on P25 LC/Encryption Sync
  (#589), single data root for installed builds (#602), RadioReference
  built-in key + subscription verify (#603), Safari live-audio Range
  support (#598), Config Builder blank-tab fix (#595), and duplicate
  "Active calls" de-dup (#593).
- README: bump the Linux quick-install VERSION to v0.3.7.
- docs/downloads.md: bump the fallback release version to v0.3.7.
- docs/announcements/v0.3.7.md: social announcement drafts.