### PR TITLE
daemon: never stop silently + bound memory footprint (issue #492)

### DIFF
--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -2500,6 +2500,14 @@ func (d *Daemon) Run(ctx context.Context) error {
 		})
 	}
 
+	// Periodic runtime health log so a stop is never silent and a leak /
+	// hang / pre-kill footprint is visible in the timeline (issue #492).
+	if hb := heartbeatInterval(d.cfg.Diagnostics.HeartbeatSeconds); hb > 0 {
+		d.spawn(runCtx, "heartbeat", false, func(ctx context.Context) error {
+			return d.runHeartbeat(ctx, hb)
+		})
+	}
+
 	// Conservative readiness: give every spawn a brief grace window
 	// so the HTTP listener has time to bind. Components without an
 	// explicit "ready" hook share this same gate.
@@ -2842,6 +2850,12 @@ func (d *Daemon) spawn(ctx context.Context, name string, essential bool, fn func
 	d.wg.Add(1)
 	go func() {
 		defer d.wg.Done()
+		// A panic in any component goroutine would otherwise crash the
+		// whole process with only a stderr stack — the silent "log just
+		// stops" failure mode in issue #492. Recover it into a logged
+		// fatal + clean shutdown instead (a panic is never expected, so
+		// it escalates regardless of the essential flag).
+		defer gtlog.Recover(d.log, "spawn:"+name, d.recordFatal)
 		err := fn(ctx)
 		if err == nil || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			return

--- a/cmd/gophertrunk/main.go
+++ b/cmd/gophertrunk/main.go
@@ -216,6 +216,10 @@ func runDaemon(args []string) {
 
 	logger.Info("gophertrunk starting", "version", version.String())
 
+	// Bound the resident footprint so a long live run isn't SIGKILLed by
+	// the OS memory-pressure killer with no in-process trace (issue #492).
+	applyMemoryLimit(cfg, logger)
+
 	// Launcher pre-checks before we burn time spinning up the
 	// daemon: an operator who passed -tui or -web with no HTTP API
 	// in config should hear about it now, not after engine init.
@@ -285,6 +289,9 @@ func runDaemon(args []string) {
 	// to wait on once the launcher has decided what to do.
 	runErr := make(chan error, 1)
 	go func() {
+		// Convert a panic in the daemon run path into a logged error +
+		// clean main-goroutine exit rather than a silent crash (#492).
+		defer gtlog.Recover(logger, "daemon-run", func(err error) { runErr <- err })
 		runErr <- d.Run(ctx)
 	}()
 
@@ -320,6 +327,7 @@ func runDaemon(args []string) {
 				captureSpec.Serial, d.IQBrokerSerials())
 		}
 		go func() {
+			defer gtlog.Recover(logger, "iq-capture", nil)
 			if err := runIQCapture(ctx, br, captureSpec, logger); err != nil &&
 				!errors.Is(err, context.Canceled) {
 				logger.Warn("iq-capture: failed", "err", err)

--- a/cmd/gophertrunk/runtime_health.go
+++ b/cmd/gophertrunk/runtime_health.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"runtime"
+	"runtime/debug"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/config"
+	"github.com/MattCheramie/GopherTrunk/internal/diag"
+)
+
+// applyMemoryLimit installs a soft heap limit so the Go GC keeps the resident
+// footprint bounded instead of letting it balloon under sustained
+// high-allocation load. Without it a long-running daemon can be SIGKILLed by
+// the OS memory-pressure killer (Linux OOM-killer / macOS jetsam) after a few
+// minutes — leaving no in-process trace, the silent "the log just stops"
+// failure mode in issue #492.
+//
+// Precedence: the GOMEMLIMIT env var (already applied by the runtime before
+// main) always wins; then diagnostics.memory_limit_mb; then an auto-default of
+// ~70% of physical RAM when that is known; otherwise the runtime is left
+// unbounded (with a hint to set a limit).
+func applyMemoryLimit(cfg config.Config, log *slog.Logger) {
+	if os.Getenv("GOMEMLIMIT") != "" {
+		// debug.SetMemoryLimit(-1) returns the limit the runtime already
+		// installed from the env var without changing it.
+		log.Info("runtime: soft memory limit from GOMEMLIMIT env",
+			"limit_bytes", debug.SetMemoryLimit(-1))
+		return
+	}
+	var limit int64
+	switch {
+	case cfg.Diagnostics.MemoryLimitMB > 0:
+		limit = int64(cfg.Diagnostics.MemoryLimitMB) * 1024 * 1024
+	default:
+		if total := diag.CollectSysInfo().MemTotalMB; total > 0 {
+			limit = int64(total) * 1024 * 1024 * 7 / 10
+		}
+	}
+	if limit <= 0 {
+		log.Info("runtime: no soft memory limit (physical RAM unknown); set GOMEMLIMIT or diagnostics.memory_limit_mb to bound RSS against OOM/jetsam kills (issue #492)")
+		return
+	}
+	debug.SetMemoryLimit(limit)
+	log.Info("runtime: soft memory limit set", "limit_mb", limit/(1024*1024))
+}
+
+// heartbeatInterval resolves the diagnostics.heartbeat_seconds config knob:
+// negative disables, zero uses the 60 s default, positive is taken verbatim.
+func heartbeatInterval(sec int) time.Duration {
+	switch {
+	case sec < 0:
+		return 0
+	case sec == 0:
+		return 60 * time.Second
+	default:
+		return time.Duration(sec) * time.Second
+	}
+}
+
+// runHeartbeat logs a periodic runtime health line so a stop is never silent:
+// a climbing goroutine/heap curve points at a leak, a frozen heartbeat on a
+// still-live process points at a hang, and the last line before an abrupt log
+// cut pins the pre-kill footprint for an OOM/jetsam diagnosis (issue #492).
+func (d *Daemon) runHeartbeat(ctx context.Context, interval time.Duration) error {
+	start := time.Now()
+	t := time.NewTicker(interval)
+	defer t.Stop()
+	var ms runtime.MemStats
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-t.C:
+			runtime.ReadMemStats(&ms)
+			d.log.Info("runtime: heartbeat",
+				"uptime", time.Since(start).Round(time.Second).String(),
+				"goroutines", runtime.NumGoroutine(),
+				"heap_alloc_mb", ms.HeapAlloc/(1024*1024),
+				"heap_sys_mb", ms.HeapSys/(1024*1024),
+				"sys_mb", ms.Sys/(1024*1024),
+				"next_gc_mb", ms.NextGC/(1024*1024),
+				"num_gc", ms.NumGC)
+		}
+	}
+}

--- a/cmd/gophertrunk/runtime_health_test.go
+++ b/cmd/gophertrunk/runtime_health_test.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestHeartbeatInterval(t *testing.T) {
+	cases := []struct {
+		name string
+		sec  int
+		want time.Duration
+	}{
+		{"negative disables", -1, 0},
+		{"zero uses default", 0, 60 * time.Second},
+		{"positive verbatim", 5, 5 * time.Second},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := heartbeatInterval(tc.sec); got != tc.want {
+				t.Errorf("heartbeatInterval(%d) = %v, want %v", tc.sec, got, tc.want)
+			}
+		})
+	}
+}

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -37,6 +37,20 @@ diagnostics:
   # -verbose-errors or GOPHERTRUNK_VERBOSE_ERRORS=1.
   verbose_errors: false
 
+  # Soft heap limit (MiB) so the GC keeps the resident footprint bounded
+  # instead of letting it balloon under sustained high-allocation load — the
+  # guard against the daemon being SIGKILLed by the OS memory-pressure killer
+  # (Linux OOM-killer / macOS jetsam) after minutes with no log line. 0
+  # (default) auto-derives ~70% of physical RAM when known, else stays
+  # unbounded. The GOMEMLIMIT env var, if set, always wins.
+  memory_limit_mb: 0
+
+  # Period (seconds) of the runtime health log: uptime, goroutine count, and
+  # heap/sys bytes. Turns a silent stop into a timeline (a climbing curve =
+  # leak, a frozen line on a live process = hang, the last line before a cut =
+  # pre-kill footprint). 0 uses the 60 s default; negative disables it.
+  heartbeat_seconds: 0
+
 # radioreference — read-only credentials for RadioReference.com's SOAP web
 # service, used by `gophertrunk hunt` to check whether a discovered system
 # already exists in RadioReference before you submit it. RadioReference has

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -8,6 +8,8 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	httppprof "net/http/pprof"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -899,6 +901,20 @@ func (s *Server) routes() *http.ServeMux {
 	mux.HandleFunc("GET /api/v1/events/ws", s.handleWS)
 	if s.metrics != nil {
 		mux.Handle("GET /metrics", s.metrics)
+	}
+
+	// Opt-in live profiling for diagnosing leaks / hangs / footprint growth
+	// (issue #492). Off by default — it exposes profiling and host detail —
+	// and gated behind GOPHERTRUNK_PPROF so an operator can scrape
+	// /debug/pprof/{heap,goroutine,allocs,profile} during a repro without a
+	// rebuild. Bind the API to loopback when enabling.
+	if os.Getenv("GOPHERTRUNK_PPROF") != "" {
+		mux.HandleFunc("GET /debug/pprof/", httppprof.Index)
+		mux.HandleFunc("GET /debug/pprof/cmdline", httppprof.Cmdline)
+		mux.HandleFunc("GET /debug/pprof/profile", httppprof.Profile)
+		mux.HandleFunc("GET /debug/pprof/symbol", httppprof.Symbol)
+		mux.HandleFunc("GET /debug/pprof/trace", httppprof.Trace)
+		s.log.Warn("api: pprof debug endpoints enabled (GOPHERTRUNK_PPROF) — exposes profiling/host detail; bind to loopback only")
 	}
 
 	// Mutation routes — wrapped in s.gate so a non-AllowMutations

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -67,6 +67,24 @@ type RadioReferenceConfig struct {
 // flag and the GOPHERTRUNK_VERBOSE_ERRORS env var.
 type DiagnosticsConfig struct {
 	VerboseErrors bool `yaml:"verbose_errors"`
+
+	// MemoryLimitMB sets a soft heap limit (Go runtime/debug.SetMemoryLimit)
+	// so the GC keeps the resident footprint bounded instead of letting it
+	// balloon under sustained high-allocation load — the mitigation for a
+	// daemon being SIGKILLed by the OS memory-pressure killer / macOS jetsam
+	// after a few minutes with no in-process trace (issue #492). 0 (the
+	// default) auto-derives ~70% of physical RAM when that is known, or
+	// leaves the runtime unbounded when it is not. The GOMEMLIMIT env var,
+	// if set, always wins (the runtime applies it before this).
+	MemoryLimitMB int `yaml:"memory_limit_mb"`
+
+	// HeartbeatSeconds controls a periodic runtime health log (uptime,
+	// goroutine count, heap/sys bytes). It turns a silent stop into a
+	// timeline: a climbing goroutine/heap curve points at a leak, a frozen
+	// heartbeat on a live process points at a hang, and the last line before
+	// a cut pins the pre-kill footprint (issue #492). 0 uses the 60 s
+	// default; negative disables it.
+	HeartbeatSeconds int `yaml:"heartbeat_seconds"`
 }
 
 // WebConfig configures the bundled user interfaces (the embedded web SPA

--- a/internal/configbuilder/fieldmeta.go
+++ b/internal/configbuilder/fieldmeta.go
@@ -72,7 +72,9 @@ var fieldMetas = map[string]FieldMeta{
 	"MessageLogConfig.MaxSizeMB": {Help: "Rotate the message log at this size in MB. Default 16."},
 
 	// ---- Diagnostics -------------------------------------------------------
-	"DiagnosticsConfig.VerboseErrors": {Help: "Print full error chains + stack traces and expand API error envelopes (exposes host/dongle info). Enable only on trusted networks."},
+	"DiagnosticsConfig.VerboseErrors":    {Help: "Print full error chains + stack traces and expand API error envelopes (exposes host/dongle info). Enable only on trusted networks."},
+	"DiagnosticsConfig.MemoryLimitMB":    {Help: "Soft heap limit (MiB) so the GC keeps the resident footprint bounded, guarding against an OS memory-pressure kill (Linux OOM / macOS jetsam). 0 auto-derives ~70% of physical RAM when known, else unbounded. GOMEMLIMIT always wins."},
+	"DiagnosticsConfig.HeartbeatSeconds": {Help: "Period (seconds) of the runtime health log: uptime, goroutine count, and heap/sys bytes — turns a silent stop into a timeline. 0 uses the 60 s default; negative disables it."},
 
 	// ---- RadioReference ----------------------------------------------------
 	"RadioReferenceConfig.APIKey":   {Label: "API key", Help: "RadioReference.com SOAP app key. Optional — GopherTrunk ships with a built-in app key, so leave this blank unless you want to use your own (or set GOPHERTRUNK_RR_KEY)."},

--- a/internal/log/recover.go
+++ b/internal/log/recover.go
@@ -1,0 +1,41 @@
+package log
+
+import (
+	"fmt"
+	"log/slog"
+	"runtime/debug"
+)
+
+// Recover is a deferred panic guard for long-lived goroutines. Installed as
+// `defer log.Recover(logger, "component", onPanic)`, it converts a panic —
+// which would otherwise crash the entire process with only a stderr stack
+// trace, leaving operators with a log that simply stops mid-line (issue
+// #492) — into a logged ERROR carrying the recovered value and the
+// goroutine stack.
+//
+// onPanic is optional. When non-nil it is called with the recovered error so
+// the caller can escalate (e.g. the daemon records a fatal error and cancels
+// its run context for a clean, logged shutdown). When nil the goroutine
+// simply unwinds: its other deferred calls still run (e.g. closing an output
+// channel), so a panicked IQ/stream worker surfaces downstream as a logged,
+// recoverable stream-closed event instead of a silent process death.
+func Recover(logger *slog.Logger, component string, onPanic func(err error)) {
+	r := recover()
+	if r == nil {
+		return
+	}
+	err, ok := r.(error)
+	if !ok {
+		err = fmt.Errorf("panic: %v", r)
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	logger.Error("goroutine panic recovered",
+		"component", component,
+		"panic", r,
+		"stack", string(debug.Stack()))
+	if onPanic != nil {
+		onPanic(err)
+	}
+}

--- a/internal/log/recover_test.go
+++ b/internal/log/recover_test.go
@@ -1,0 +1,72 @@
+package log
+
+import (
+	"bytes"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+// recoverPanicHarness runs fn under `defer Recover(...)` and reports whether
+// the goroutine returned normally (panic contained) along with any error
+// handed to onPanic.
+func recoverPanicHarness(t *testing.T, logger *slog.Logger, fn func()) (survived bool, got error) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		defer Recover(logger, "test", func(err error) { got = err })
+		fn()
+		survived = true // only reached if fn did not panic
+	}()
+	<-done
+	return survived, got
+}
+
+func TestRecoverContainsPanicAndLogsStack(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, nil))
+
+	// A panicking goroutine must NOT crash the process: the harness
+	// goroutine returns normally because Recover swallowed the panic.
+	_, got := recoverPanicHarness(t, logger, func() { panic("boom") })
+
+	if got == nil || !strings.Contains(got.Error(), "boom") {
+		t.Fatalf("onPanic err = %v, want one mentioning \"boom\"", got)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "goroutine panic recovered") {
+		t.Errorf("log missing recovery line:\n%s", out)
+	}
+	if !strings.Contains(out, "component=test") {
+		t.Errorf("log missing component attr:\n%s", out)
+	}
+	if !strings.Contains(out, "stack=") {
+		t.Errorf("log missing stack attr:\n%s", out)
+	}
+}
+
+func TestRecoverPreservesErrorValue(t *testing.T) {
+	sentinel := errors.New("sentinel")
+	_, got := recoverPanicHarness(t, slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil)),
+		func() { panic(sentinel) })
+	if !errors.Is(got, sentinel) {
+		t.Fatalf("onPanic err = %v, want it to wrap/equal the panicked error", got)
+	}
+}
+
+func TestRecoverNoPanicIsNoop(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, nil))
+	called := false
+	func() {
+		defer Recover(logger, "test", func(error) { called = true })
+	}()
+	if called {
+		t.Error("onPanic called with no panic")
+	}
+	if buf.Len() != 0 {
+		t.Errorf("logged on the no-panic path: %s", buf.String())
+	}
+}

--- a/internal/sdr/iqtap/broker.go
+++ b/internal/sdr/iqtap/broker.go
@@ -36,6 +36,7 @@ import (
 	"sync"
 	"sync/atomic"
 
+	gtlog "github.com/MattCheramie/GopherTrunk/internal/log"
 	"github.com/MattCheramie/GopherTrunk/internal/sdr"
 )
 
@@ -257,6 +258,10 @@ func (b *Broker) StreamIQ(ctx context.Context) (<-chan []complex64, error) {
 	go func() {
 		defer close(out)
 		defer b.streamActive.Store(false)
+		// A panic in fanout would otherwise crash the daemon silently
+		// (issue #492); recover into a logged close so the primary
+		// consumer sees a clean stream end instead.
+		defer gtlog.Recover(b.log, "iqtap-fanout", nil)
 		for chunk := range in {
 			b.fanout(chunk)
 			select {

--- a/internal/sdr/rtltcp/driver.go
+++ b/internal/sdr/rtltcp/driver.go
@@ -46,6 +46,7 @@ import (
 	"sync"
 	"time"
 
+	gtlog "github.com/MattCheramie/GopherTrunk/internal/log"
 	"github.com/MattCheramie/GopherTrunk/internal/sdr"
 )
 
@@ -288,6 +289,10 @@ func (d *device) StreamIQ(ctx context.Context) (<-chan []complex64, error) {
 
 	go func() {
 		defer close(out)
+		// Guard the reader against a panic so it surfaces as a logged
+		// stream close (→ ccdecoder retry) instead of crashing the
+		// whole daemon with no log line (issue #492).
+		defer gtlog.Recover(d.log, "rtltcp-stream", nil)
 		buf := make([]byte, chunkSamples*2)
 		for {
 			// Allow ctx to interrupt a stalled read.

--- a/internal/voice/composer/composer.go
+++ b/internal/voice/composer/composer.go
@@ -34,6 +34,7 @@ import (
 	"github.com/MattCheramie/GopherTrunk/internal/dsp/equalizer"
 	"github.com/MattCheramie/GopherTrunk/internal/dsp/filter"
 	"github.com/MattCheramie/GopherTrunk/internal/events"
+	gtlog "github.com/MattCheramie/GopherTrunk/internal/log"
 	p25p2 "github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase2"
 	"github.com/MattCheramie/GopherTrunk/internal/trunking"
 )
@@ -486,6 +487,7 @@ func (c *Composer) cancelAll() {
 // the wiring end-to-end and to land the operator-visible plumbing.
 func (c *Composer) runFMChain(ctx context.Context, serial string, iqCh <-chan []complex64, iqHz uint32, done chan<- struct{}) {
 	defer close(done)
+	defer gtlog.Recover(c.log, "voice-chain-fm:"+serial, nil)
 
 	// Shared boundary controller: Touch heartbeat + hangtime end-of-call,
 	// uniform with the digital chains. Analog FM has no in-band talkgroup
@@ -615,6 +617,12 @@ func (c *Composer) runFMChain(ctx context.Context, serial string, iqCh <-chan []
 		_ = c.sink.WritePCM(serial, tail)
 	}
 
+	// Reusable equalizer scratch — the equalized slice is fully consumed by
+	// fm.Process within the same iteration, so a single grow-and-reslice
+	// buffer per chain avoids a per-chunk allocation for the whole call
+	// (issue #492 footprint reduction).
+	var eqScratch []complex64
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -631,12 +639,15 @@ func (c *Composer) runFMChain(ctx context.Context, serial string, iqCh <-chan []
 			filtered := lpf.Process(nil, iq)
 			decimated := decimateComplex(filtered, decim1)
 			if eq != nil {
-				equalized := make([]complex64, len(decimated))
+				if cap(eqScratch) < len(decimated) {
+					eqScratch = make([]complex64, len(decimated))
+				}
+				eqScratch = eqScratch[:len(decimated)]
 				for i, x := range decimated {
 					y, _ := eq.Process(x)
-					equalized[i] = y
+					eqScratch[i] = y
 				}
-				decimated = equalized
+				decimated = eqScratch
 			}
 			audio := fm.Process(nil, decimated)
 			if deemph != nil {

--- a/internal/voice/composer/dmr_voice.go
+++ b/internal/voice/composer/dmr_voice.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/MattCheramie/GopherTrunk/internal/dsp/filter"
+	gtlog "github.com/MattCheramie/GopherTrunk/internal/log"
 	dmrrx "github.com/MattCheramie/GopherTrunk/internal/radio/dmr/receiver"
 	dmrvoice "github.com/MattCheramie/GopherTrunk/internal/radio/dmr/voice"
 )
@@ -78,6 +79,7 @@ func (r *slotRouter) accept(sf dmrvoice.VoiceSuperframe) bool {
 
 func (c *Composer) runDMRVoiceChain(ctx context.Context, serial string, iqCh <-chan []complex64, iqHz uint32, groupID uint32, interleaved bool, done chan<- struct{}) {
 	defer close(done)
+	defer gtlog.Recover(c.log, "voice-chain-dmr:"+serial, nil)
 
 	// Shared boundary controller: universal hangtime end-of-call + Touch
 	// heartbeat. Talkgroup gating is left disabled (grantTG 0) until the

--- a/internal/voice/composer/p25p1_voice.go
+++ b/internal/voice/composer/p25p1_voice.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/MattCheramie/GopherTrunk/internal/dsp/filter"
 	"github.com/MattCheramie/GopherTrunk/internal/events"
+	gtlog "github.com/MattCheramie/GopherTrunk/internal/log"
 	"github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase1"
 	p25p1rx "github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase1/receiver"
 	"github.com/MattCheramie/GopherTrunk/internal/trunking"
@@ -57,6 +58,7 @@ func (c *Composer) resolveP25Phase1DemodMode(serial, mode string) p25p1rx.DemodM
 // 11-byte frame to PCM and into the call's WAV.
 func (c *Composer) runP25Phase1VoiceChain(ctx context.Context, serial string, iqCh <-chan []complex64, iqHz uint32, demodMode string, grantTG uint32, patched []uint32, done chan<- struct{}) {
 	defer close(done)
+	defer gtlog.Recover(c.log, "voice-chain-p25p1:"+serial, nil)
 
 	// Shared boundary controller: universal hangtime end-of-call,
 	// talkgroup gating (so a different talkgroup on a shared voice

--- a/internal/voice/composer/p25p2_voice.go
+++ b/internal/voice/composer/p25p2_voice.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/MattCheramie/GopherTrunk/internal/dsp/filter"
 	"github.com/MattCheramie/GopherTrunk/internal/events"
+	gtlog "github.com/MattCheramie/GopherTrunk/internal/log"
 	p25p2 "github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase2"
 	p25p2rx "github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase2/receiver"
 	"github.com/MattCheramie/GopherTrunk/internal/trunking"
@@ -45,6 +46,7 @@ const p25p2VoiceGardnerGain = 0.005
 // DMR chain, whose pre-FEC frames the vocoder cannot consume.
 func (c *Composer) runP25Phase2VoiceChain(ctx context.Context, serial string, system string, macCfg p25p2.MACDecodeConfig, iqCh <-chan []complex64, iqHz uint32, done chan<- struct{}) {
 	defer close(done)
+	defer gtlog.Recover(c.log, "voice-chain-p25p2:"+serial, nil)
 
 	// Shared boundary controller: universal hangtime end-of-call + Touch
 	// heartbeat. Talkgroup gating is left disabled (grantTG 0) until the

--- a/web/configbuilder/src/api/types.ts
+++ b/web/configbuilder/src/api/types.ts
@@ -18,6 +18,8 @@ export interface LogConfig {
 
 export interface DiagnosticsConfig {
   VerboseErrors: boolean;
+  MemoryLimitMB: number;
+  HeartbeatSeconds: number;
 }
 
 export interface RadioReferenceConfig {

--- a/web/configbuilder/src/sections/simple.tsx
+++ b/web/configbuilder/src/sections/simple.tsx
@@ -103,6 +103,18 @@ export function DiagnosticsSection() {
         value={cfg.VerboseErrors}
         onChange={(x) => set({ ...cfg, VerboseErrors: x })}
       />
+      <NumberField
+        label="Memory limit (MB)"
+        value={cfg.MemoryLimitMB ?? 0}
+        onChange={(x) => set({ ...cfg, MemoryLimitMB: x })}
+        placeholder="0"
+      />
+      <NumberField
+        label="Heartbeat (seconds)"
+        value={cfg.HeartbeatSeconds ?? 0}
+        onChange={(x) => set({ ...cfg, HeartbeatSeconds: x })}
+        placeholder="0"
+      />
     </Section>
   );
 }


### PR DESCRIPTION
## Summary

Surfaces silent daemon stops and bounds the process memory footprint, following up on the #492 CQPSK work.

The #492 CQPSK fixes (FSE lock, fast BCH NID decode) were confirmed via offline siglab replay, but a live run still halted after ~5 minutes with the log just ending mid-decode — no shutdown, fatal, retry, or panic line. Since the slog sink is `os.Stderr` and that fd was captured, every in-process exit path would have logged; their absence points to an external SIGKILL, overwhelmingly the OS memory-pressure killer (Linux OOM / macOS jetsam). The daemon had no way to surface or survive that or a goroutine panic: `spawn()` ran component goroutines with no `recover()`, and there was no footprint telemetry or limit.

## Changes

- **`internal/log`: add `Recover()`** — a deferred panic guard that turns a process-killing panic (stderr stack only) into a logged ERROR + optional escalation. Wired into `spawn()` (→ `recordFatal` → clean shutdown), the daemon-run and iq-capture goroutines, the rtltcp reader, the iqtap fanout, and all four composer voice chains.
- **Soft memory limit at startup** (`debug.SetMemoryLimit`): honors `GOMEMLIMIT`, then `diagnostics.memory_limit_mb`, then ~70% of physical RAM when known.
- **Periodic runtime heartbeat log** (uptime, goroutines, heap/sys bytes) via `diagnostics.heartbeat_seconds` (default 60s) so a leak/hang/pre-kill footprint is visible in the timeline.
- **Opt-in `net/http/pprof`** on the API mux behind `GOPHERTRUNK_PPROF`.
- **Reuse the equalizer scratch buffer** in the FM voice chain to cut per-chunk heap churn.

## Tests

`Recover` + `heartbeatInterval` unit tests; full suite + `go vet` green.

## Note

This branch is currently ~175 commits behind `main` and will likely need a rebase/conflict resolution before merge (notably the FM voice chain buffer reuse may overlap with later voice-path changes).

https://claude.ai/code/session_019Kh2smZ9Hk6j6RXDCGXs9p

---
_Generated by [Claude Code](https://claude.ai/code/session_019Kh2smZ9Hk6j6RXDCGXs9p)_