### PR TITLE
web: default symbol-domain panels to the control SDR (issue #402)

### DIFF
--- a/web/src/api/spectrum.test.ts
+++ b/web/src/api/spectrum.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { defaultSymbolDevice, type SpectrumDevice } from "./spectrum";
+
+// Issue #402: the symbol-domain panels (Eye Diagram, Symbol Scope,
+// Tuning, Histogram) must default to the control-role SDR so a panel
+// opened during active control-channel decoding lands on the dongle that
+// actually carries a decodable C4FM channel — not the enumeration's first
+// entry, which on a multi-SDR rig is often an idle voice dongle.
+function dev(serial: string, role: string): SpectrumDevice {
+  return {
+    serial,
+    driver: "rtlsdr",
+    role,
+    center_hz: 420_012_500,
+    sample_rate_hz: 2_400_000,
+  };
+}
+
+describe("defaultSymbolDevice", () => {
+  it("returns null for an empty list", () => {
+    expect(defaultSymbolDevice([])).toBeNull();
+  });
+
+  it("prefers the control-role device over earlier entries", () => {
+    const list = [dev("voice-1", "voice"), dev("ctrl-1", "control")];
+    expect(defaultSymbolDevice(list)?.serial).toBe("ctrl-1");
+  });
+
+  it("falls back to the first device when no control role is present", () => {
+    const list = [dev("voice-1", "voice"), dev("voice-2", "voice")];
+    expect(defaultSymbolDevice(list)?.serial).toBe("voice-1");
+  });
+
+  it("returns the sole device regardless of role", () => {
+    const list = [dev("only", "voice")];
+    expect(defaultSymbolDevice(list)?.serial).toBe("only");
+  });
+});

--- a/web/src/api/spectrum.ts
+++ b/web/src/api/spectrum.ts
@@ -19,6 +19,21 @@ export interface SpectrumDevice {
   p25_modulation?: string;
 }
 
+// defaultSymbolDevice picks the SDR the symbol-domain panels (Eye
+// Diagram, Symbol Scope, Tuning, Histogram) should select on first load.
+// It prefers the control-role device so a panel opened during active
+// control-channel decoding lands on the SDR that is actually carrying a
+// decodable C4FM channel, rather than the enumeration's first entry —
+// which on a multi-SDR rig is often an idle voice/aux dongle, leaving the
+// scope showing nothing (issue #402). Falls back to the first device when
+// no control role is present, and returns null for an empty list.
+export function defaultSymbolDevice(
+  list: SpectrumDevice[],
+): SpectrumDevice | null {
+  if (list.length === 0) return null;
+  return list.find((d) => d.role === "control") ?? list[0];
+}
+
 export interface SpectrumFrame {
   ts_ns: number;
   center_hz: number;

--- a/web/src/panels/EyeDiagram.test.tsx
+++ b/web/src/panels/EyeDiagram.test.tsx
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 
-vi.mock("../api/spectrum", () => ({
+vi.mock("../api/spectrum", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../api/spectrum")>()),
   fetchSpectrumDevices: vi.fn(),
 }));
 

--- a/web/src/panels/EyeDiagram.tsx
+++ b/web/src/panels/EyeDiagram.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import {
   fetchSpectrumDevices,
+  defaultSymbolDevice,
   type SpectrumDevice,
 } from "../api/spectrum";
 import { openSymbolStream, type SymbolFrame } from "../api/symbols";
@@ -54,7 +55,10 @@ export function EyeDiagram() {
         if (cancel) return;
         setDevices(list);
         setError(null);
-        if (list.length > 0 && selected == null) setSelected(list[0].serial);
+        if (selected == null) {
+          const def = defaultSymbolDevice(list);
+          if (def) setSelected(def.serial);
+        }
       } catch (e) {
         if (cancel) return;
         setError(e instanceof Error ? e.message : String(e));

--- a/web/src/panels/Histogram.test.tsx
+++ b/web/src/panels/Histogram.test.tsx
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 
-vi.mock("../api/spectrum", () => ({
+vi.mock("../api/spectrum", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../api/spectrum")>()),
   fetchSpectrumDevices: vi.fn(),
 }));
 

--- a/web/src/panels/Histogram.tsx
+++ b/web/src/panels/Histogram.tsx
@@ -11,6 +11,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { Bar } from "react-chartjs-2";
 import {
   fetchSpectrumDevices,
+  defaultSymbolDevice,
   type SpectrumDevice,
 } from "../api/spectrum";
 import { openSymbolStream, type SymbolFrame } from "../api/symbols";
@@ -125,7 +126,10 @@ export function Histogram() {
         if (cancel) return;
         setDevices(list);
         setError(null);
-        if (list.length > 0 && selected == null) setSelected(list[0].serial);
+        if (selected == null) {
+          const def = defaultSymbolDevice(list);
+          if (def) setSelected(def.serial);
+        }
       } catch (e) {
         if (cancel) return;
         setError(e instanceof Error ? e.message : String(e));

--- a/web/src/panels/SymbolScope.test.tsx
+++ b/web/src/panels/SymbolScope.test.tsx
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 
-vi.mock("../api/spectrum", () => ({
+vi.mock("../api/spectrum", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../api/spectrum")>()),
   fetchSpectrumDevices: vi.fn(),
 }));
 

--- a/web/src/panels/SymbolScope.tsx
+++ b/web/src/panels/SymbolScope.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import {
   fetchSpectrumDevices,
+  defaultSymbolDevice,
   type SpectrumDevice,
 } from "../api/spectrum";
 import {
@@ -68,7 +69,10 @@ export function SymbolScope() {
         if (cancel) return;
         setDevices(list);
         setError(null);
-        if (list.length > 0 && selected == null) setSelected(list[0].serial);
+        if (selected == null) {
+          const def = defaultSymbolDevice(list);
+          if (def) setSelected(def.serial);
+        }
       } catch (e) {
         if (cancel) return;
         setError(e instanceof Error ? e.message : String(e));

--- a/web/src/panels/Tuning.test.tsx
+++ b/web/src/panels/Tuning.test.tsx
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 
-vi.mock("../api/spectrum", () => ({
+vi.mock("../api/spectrum", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../api/spectrum")>()),
   fetchSpectrumDevices: vi.fn(),
 }));
 

--- a/web/src/panels/Tuning.tsx
+++ b/web/src/panels/Tuning.tsx
@@ -13,6 +13,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { Line } from "react-chartjs-2";
 import {
   fetchSpectrumDevices,
+  defaultSymbolDevice,
   type SpectrumDevice,
 } from "../api/spectrum";
 import { openSymbolStream, type SymbolFrame } from "../api/symbols";
@@ -75,7 +76,10 @@ export function Tuning() {
         if (cancel) return;
         setDevices(list);
         setError(null);
-        if (list.length > 0 && selected == null) setSelected(list[0].serial);
+        if (selected == null) {
+          const def = defaultSymbolDevice(list);
+          if (def) setSelected(def.serial);
+        }
       } catch (e) {
         if (cancel) return;
         setError(e instanceof Error ? e.message : String(e));


### PR DESCRIPTION
The Eye Diagram, Symbol Scope, Tuning, and Histogram panels each defaulted
their SDR selection to the first enumerated device. On a multi-SDR rig that
first entry is often an idle voice/aux dongle, so a panel opened during
active control-channel decoding showed nothing while the control RTL — the
one actually carrying a decodable C4FM channel — went unselected.

Add defaultSymbolDevice(), which prefers the control-role device and falls
back to the first entry, and use it for the initial selection in all four
panels. Panel test mocks now preserve the real (pure) helper via
importOriginal so the default-selection effect resolves under jsdom.