### PR TITLE
Fix Airspy device initialisation: correct USB vendor opcodes (#454)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ for tagged releases.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Airspy device initialisation** (#454). The pure-Go Airspy driver's USB
+  vendor request opcodes were systematically wrong; they now match libairspy's
+  `airspy_commands` enum (`SET_SAMPLERATE`=12, `GET_SAMPLERATES`=25, gain/freq
+  opcodes, …). `SetSampleRate` is now a vendor-IN transfer with the rate carried
+  in `wIndex` (the firmware NAK'd the previous vendor-OUT, surfacing as "set
+  sample rate failed: protocol error"), the bogus host-side `SET_SAMPLE_TYPE`
+  command is gone, and the bias-tee uses a GPIO write. `Open` resets the
+  receiver and retries on transient device-gone errors, and the device pool now
+  normalises `AIRSPY SN:` / `airspy_sn:` serial aliases when matching config
+  hints. Includes opt-in real-hardware tests (`make test-airspy-real`) and a
+  Windows WinUSB interface-recipient/associated-interface control-transfer
+  fallback.
+
 ## [v0.3.7] — 2026-06-09
 
 This release sharpens **P25 Phase 1 voice** and consolidates the **install

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,11 +82,87 @@ existing code; a few items worth calling out:
 | `make integration` | Daemon end-to-end test (no SDR) — exercises the full IQ-replay path |
 | `make integration-cc-<proto>` | Per-protocol "lights up live trunked reception" check (P25 P1 / P25 P2 / DMR / NXDN / dPMR / EDACS / Motorola / LTR / MPT 1327 / TETRA / YSF) |
 | `make test-dvsi` | DVSI hardware backend tests under `-tags dvsi` |
+| `make test-airspy-real` | Opt-in Airspy R2/Mini hardware validation (enumerate → open → tune/sample-rate/gain → first IQ packet) |
+| `make test-airspy-real-bias` | Same as `test-airspy-real` plus real-hardware bias-tee on/off validation |
+| `make test-airspy-real-diag` | Real Airspy tests plus raw USB control-transfer probe (isolate transport vs driver failures) |
 | `make vet` | `go vet ./...` |
 | `make cross-build` | Static binaries for Linux / macOS / Windows × amd64 / arm64 |
 
 CI runs `make test`, `make integration`, and `make test-dvsi` on
 every PR. A green CI is required before merge.
+
+Real Airspy validation is intentionally opt-in and never runs in CI.
+The package-level test skips unless `GOPHERTRUNK_AIRSPY_REAL=1` is
+set. Optional overrides:
+
+- `GOPHERTRUNK_AIRSPY_REAL_SERIAL` — match one device by serial.
+- `GOPHERTRUNK_AIRSPY_REAL_CENTER_HZ` — center frequency in Hz
+  (default `144390000`).
+- `GOPHERTRUNK_AIRSPY_REAL_RATE_HZ` — sample rate in Hz
+  (default `2500000`).
+- `GOPHERTRUNK_AIRSPY_REAL_GAIN_TENTH_DB` — gain in 0.1 dB, use
+  `-1` for AGC (default `-1`).
+- `GOPHERTRUNK_AIRSPY_REAL_BIAS_TEE` — set to `1` to also run the
+  real-hardware bias-tee on/off test (leaves bias-tee off on exit).
+- `GOPHERTRUNK_AIRSPY_REAL_DIAG` — set to `1` to also run a lower-level
+  raw USB control-transfer probe (`receiver off` + `set sample type`).
+
+### Capturing Windows USB traces with Wireshark (Airspy)
+
+When a device works in other SDR apps but fails in GopherTrunk, we need
+packet-level USB evidence to diff request order and setup fields.
+
+1. Install **Wireshark** and **USBPcap** (USBPcap is offered during the
+   Wireshark installer). Reboot if prompted.
+
+1. Close SDR apps so only one app talks to the Airspy during each capture.
+
+1. Open Wireshark **as Administrator**.
+
+1. Start capture on the USBPcap interface for the controller/hub where the
+   Airspy is attached (usually `\\.\USBPcap1`, `\\.\USBPcap2`, etc.).
+
+1. In Wireshark, apply a display filter to focus on Airspy traffic:
+
+  ```text
+  usb.idVendor == 0x1d50 && usb.idProduct == 0x60a1
+  ```
+
+1. Record a short known-good capture (about 10-20 seconds): start capture,
+   launch a working SDR app, perform open/init (and one start/stop if
+   possible), then stop capture.
+
+1. Record a short GopherTrunk capture (about 10-20 seconds): start capture,
+   then run either:
+
+    ```powershell
+    $env:RTLSDR_DEBUG_USB='1'
+    $env:RTLSDR_DEBUG_USB_CSV='1'
+    $env:GOPHERTRUNK_AIRSPY_REAL='1'
+    $env:GOPHERTRUNK_AIRSPY_REAL_DIAG='1'
+    go test -count=1 -run TestRealHardware_USBControlTransferProbe ./internal/sdr/airspy -v
+    ```
+
+   or your normal daemon start path that reproduces the failure.
+
+1. Save captures as `.pcapng` files with clear names, for example
+   `airspy-good-app-init.pcapng` and `airspy-gophertrunk-init.pcapng`.
+
+1. Export matching GopherTrunk USB trace lines from terminal output:
+   human-readable lines prefixed `rtlsdr-usb [` and CSV lines prefixed
+   `rtlsdr-usb-csv,`.
+
+1. Attach all artifacts to the issue/PR: both `.pcapng` files, the
+   `rtlsdr-usb-csv` log excerpt, the exact command used, and device serial
+   plus Windows version.
+
+Notes:
+
+USB captures can include other peripherals on the same controller; review
+before sharing and redact unrelated traffic if needed.
+
+Keep captures short and focused on device open/init to simplify
+request-by-request diffing.
 
 ## Sending a pull request
 

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ TAGS    ?=
 GO      ?= go
 PKGS    := ./...
 
-.PHONY: all build dist test test-dvsi test-integration integration integration-cc integration-cc-grant integration-cc-nxdn integration-cc-dmr integration-cc-dpmr integration-cc-edacs integration-cc-motorola integration-cc-tetra integration-cc-p25p2 integration-cc-mpt1327 integration-cc-ltr integration-cc-ysf lint tidy vet vulncheck licenses clean run proto cross-build release-archives release-dry-run web-build web-dev web-clean web-test siglab-web-build siglab-web-dev siglab-web-clean siglab-web-test
+.PHONY: all build dist test test-dvsi test-airspy-real test-airspy-real-bias test-airspy-real-diag test-integration integration integration-cc integration-cc-grant integration-cc-nxdn integration-cc-dmr integration-cc-dpmr integration-cc-edacs integration-cc-motorola integration-cc-tetra integration-cc-p25p2 integration-cc-mpt1327 integration-cc-ltr integration-cc-ysf lint tidy vet vulncheck licenses clean run proto cross-build release-archives release-dry-run web-build web-dev web-clean web-test siglab-web-build siglab-web-dev siglab-web-clean siglab-web-test
 
 all: build
 
@@ -48,6 +48,24 @@ test:
 # conformance all exercise in CI without a real DVSI USB-3000.
 test-dvsi:
 	$(GO) test -tags "dvsi $(TAGS)" -race -count=1 ./internal/voice/dvsi/...
+
+# test-airspy-real runs an opt-in real-hardware probe against an attached
+# Airspy R2/Mini. The test package skips unless GOPHERTRUNK_AIRSPY_REAL=1 is
+# set; this target sets it automatically so accidental invocations fail fast
+# when no device is present.
+test-airspy-real:
+	GOPHERTRUNK_AIRSPY_REAL=1 $(GO) test -tags "$(TAGS)" -race -count=1 -run TestRealHardware_ ./internal/sdr/airspy
+
+# test-airspy-real-bias is the same real-hardware suite plus explicit
+# bias-tee toggle validation. Use only when a safe load is connected.
+test-airspy-real-bias:
+	GOPHERTRUNK_AIRSPY_REAL=1 GOPHERTRUNK_AIRSPY_REAL_BIAS_TEE=1 $(GO) test -tags "$(TAGS)" -race -count=1 -run TestRealHardware_ ./internal/sdr/airspy
+
+# test-airspy-real-diag runs a lower-level raw WinUSB/USB control-transfer
+# probe in addition to the driver-level real hardware tests, useful for
+# isolating where open-time failures occur.
+test-airspy-real-diag:
+	GOPHERTRUNK_AIRSPY_REAL=1 GOPHERTRUNK_AIRSPY_REAL_DIAG=1 $(GO) test -tags "$(TAGS)" -race -count=1 -run TestRealHardware_ ./internal/sdr/airspy
 
 # integration boots the wired daemon (no real SDR) end-to-end and asserts
 # the engine + recorder + call log + metrics + API agree on a synthetic

--- a/internal/sdr/airspy/airspy.go
+++ b/internal/sdr/airspy/airspy.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/MattCheramie/GopherTrunk/internal/sdr"
 	"github.com/MattCheramie/GopherTrunk/internal/sdr/rtlsdr/usb"
@@ -34,16 +35,15 @@ const (
 // libairspy vendor request opcodes (subset).
 const (
 	reqReceiverMode   uint8 = 1
-	reqSetSampleType  uint8 = 11
-	reqSetFreq        uint8 = 12
-	reqGetSamplerates uint8 = 13
-	reqSetSamplerate  uint8 = 14
-	reqSetLNAGain     uint8 = 19
-	reqSetMixerGain   uint8 = 20
-	reqSetVGAGain     uint8 = 21
-	reqSetLNAAGC      uint8 = 22
-	reqSetMixerAGC    uint8 = 23
-	reqSetRFBiasCmd   uint8 = 24
+	reqSetSamplerate  uint8 = 12
+	reqSetFreq        uint8 = 13
+	reqSetLNAGain     uint8 = 14
+	reqSetMixerGain   uint8 = 15
+	reqSetVGAGain     uint8 = 16
+	reqSetLNAAGC      uint8 = 17
+	reqSetMixerAGC    uint8 = 18
+	reqGPIOWrite      uint8 = 21
+	reqGetSamplerates uint8 = 25
 )
 
 // Sample-type values for reqSetSampleType.
@@ -55,13 +55,18 @@ const (
 const (
 	receiverModeOff uint16 = 0
 	receiverModeOn  uint16 = 1
+	biasTeeGPIOPort uint16 = 1
+	biasTeeGPIOPin  uint16 = 13
 
 	bulkInEP   byte = 0x81
 	driverName      = "airspy"
 
 	defaultVGAGain   = 10
 	controlTimeoutMs = 1000
+	minSamplerateHz  = 1_000_000
 )
+
+var openRetryBackoff = 250 * time.Millisecond
 
 // Driver implements sdr.Driver for Airspy.
 type Driver struct {
@@ -128,9 +133,8 @@ func tunerNameFor(product string) string {
 }
 
 // Open claims the device at idx and returns an sdr.Device. The
-// returned device defaults to INT16_IQ sample mode (applied lazily
-// at StreamIQ time, matching libairspy) and the highest rate the
-// firmware advertises.
+// returned device defaults to INT16_IQ sample mode and the highest
+// rate the firmware advertises.
 func (d *Driver) Open(idx int) (sdr.Device, error) {
 	d.mu.Lock()
 	cached := d.cached
@@ -147,6 +151,34 @@ func (d *Driver) Open(idx int) (sdr.Device, error) {
 		return nil, fmt.Errorf("airspy: index %d out of range", idx)
 	}
 	desc := cached[idx]
+	serial := fallbackSerial(desc.Serial, idx)
+
+	// Windows hosts occasionally surface a transient ErrDeviceGone on early
+	// post-open control transfers even though enumeration + WinUsb_Initialize
+	// just succeeded. Retry with a fresh open (and descriptor refresh by
+	// serial/path) before failing daemon startup.
+	const maxOpenAttempts = 5
+	var lastErr error
+	for attempt := 1; attempt <= maxOpenAttempts; attempt++ {
+		dev, err := d.openDevice(desc, idx, serial)
+		if err == nil {
+			return dev, nil
+		}
+		lastErr = err
+		if !errors.Is(err, usb.ErrDeviceGone) || attempt == maxOpenAttempts {
+			break
+		}
+		if refreshed, ok := d.refreshDescriptor(desc); ok {
+			desc = refreshed
+		}
+		if openRetryBackoff > 0 {
+			time.Sleep(openRetryBackoff)
+		}
+	}
+	return nil, lastErr
+}
+
+func (d *Driver) openDevice(desc usb.Descriptor, idx int, serial string) (*Device, error) {
 	t, err := d.enum.Open(desc)
 	if err != nil {
 		return nil, fmt.Errorf("airspy: open %s: %w", desc.Path, err)
@@ -160,17 +192,15 @@ func (d *Driver) Open(idx int) (sdr.Device, error) {
 		info: sdr.Info{
 			Driver:       driverName,
 			Index:        idx,
-			Serial:       fallbackSerial(desc.Serial, idx),
+			Serial:       serial,
 			Manufacturer: desc.Manufacturer,
 			Product:      desc.Product,
 			TunerName:    tunerNameFor(desc.Product),
 		},
 	}
-	// Read the supported-samplerate table. This is the first vendor
-	// transfer after claim — matching libairspy's open ordering
-	// (vendor IN first, no SET_SAMPLE_TYPE during open). Some firmware
-	// / Windows driver bindings reject a vendor OUT as the very first
-	// transfer (issue #270).
+	_ = t.ControlOut(reqReceiverMode, receiverModeOff, 0, nil, controlTimeoutMs)
+	// Read the supported-samplerate table so SetSampleRate can match
+	// the requested rate against an index.
 	rates, err := dev.fetchSampleRates()
 	if err != nil {
 		// Non-fatal: keep the device usable; SetSampleRate will fall
@@ -180,6 +210,34 @@ func (d *Driver) Open(idx int) (sdr.Device, error) {
 		dev.rates = rates
 	}
 	return dev, nil
+}
+
+func setSampleTypeInt16(usb.Transport) error {
+	// libairspy no longer issues a USB command here; it keeps sample type
+	// as host-side conversion state.
+	return nil
+}
+
+func (d *Driver) refreshDescriptor(current usb.Descriptor) (usb.Descriptor, bool) {
+	list, err := d.enum.List(vidAirspy, pidAirspy)
+	if err != nil || len(list) == 0 {
+		return current, false
+	}
+	if current.Serial != "" {
+		for _, cand := range list {
+			if cand.Serial == current.Serial {
+				return cand, true
+			}
+		}
+	}
+	if current.Path != "" {
+		for _, cand := range list {
+			if cand.Path == current.Path {
+				return cand, true
+			}
+		}
+	}
+	return list[0], true
 }
 
 func fallbackSerial(s string, idx int) string {
@@ -194,11 +252,10 @@ type Device struct {
 	t    usb.Transport
 	info sdr.Info
 
-	mu            sync.Mutex
-	closed        bool
-	streaming     bool
-	sampleTypeSet bool     // true once SET_SAMPLE_TYPE has been issued
-	rates         []uint32 // supported sample rates, Hz, descending order
+	mu        sync.Mutex
+	closed    bool
+	streaming bool
+	rates     []uint32 // supported sample rates, Hz, descending order
 }
 
 // Info implements sdr.Device.
@@ -214,14 +271,33 @@ func (d *Device) SetCenterFreq(hz uint32) error {
 	return d.t.ControlOut(reqSetFreq, 0, 0, payload, controlTimeoutMs)
 }
 
-// SetSampleRate selects the firmware-advertised rate closest to hz. If
-// the supported-rate table is unavailable, index 0 is used.
+// SetSampleRate follows libairspy semantics:
+// - exact known rates are sent by index
+// - otherwise values >= 1 MHz are encoded as (rate_hz*2)/1000 for IQ modes
+// and sent as wIndex on an IN vendor request.
 func (d *Device) SetSampleRate(hz uint32) error {
 	if d.isClosed() {
 		return usb.ErrClosed
 	}
-	idx := d.closestRateIndex(hz)
-	return d.t.ControlOut(reqSetSamplerate, uint16(idx), 0, nil, controlTimeoutMs)
+	param := d.sampleRateCommandParam(hz)
+	_, err := d.t.ControlIn(reqSetSamplerate, 0, param, 1, controlTimeoutMs)
+	return err
+}
+
+func (d *Device) sampleRateCommandParam(hz uint32) uint16 {
+	d.mu.Lock()
+	rates := d.rates
+	d.mu.Unlock()
+
+	if hz >= minSamplerateHz {
+		for i, r := range rates {
+			if hz == r {
+				return uint16(i)
+			}
+		}
+		return uint16((hz * 2) / 1000)
+	}
+	return uint16(hz)
 }
 
 // closestRateIndex returns the index of the supported sample rate
@@ -344,7 +420,8 @@ func (d *Device) SetBiasTee(enable bool) error {
 	if enable {
 		v = 1
 	}
-	return d.t.ControlOut(reqSetRFBiasCmd, v, 0, nil, controlTimeoutMs)
+	portPin := (biasTeeGPIOPort << 5) | biasTeeGPIOPin
+	return d.t.ControlOut(reqGPIOWrite, v, portPin, nil, controlTimeoutMs)
 }
 
 // StreamIQ flips the receiver on and starts the bulk-IN reaper,
@@ -360,23 +437,16 @@ func (d *Device) StreamIQ(ctx context.Context) (<-chan []complex64, error) {
 		return nil, errors.New("airspy: stream already active")
 	}
 	d.streaming = true
-	needSampleType := !d.sampleTypeSet
 	d.mu.Unlock()
 
-	// Pin the device to INT16_IQ — the format the StreamIQ decoder
-	// expects. libairspy issues this inside airspy_start_rx rather
-	// than during open; mirroring that ordering avoids a firmware /
-	// Windows-driver NAK on the first vendor OUT (issue #270).
-	if needSampleType {
-		if err := d.t.ControlOut(reqSetSampleType, sampleTypeInt16IQ, 0, nil, controlTimeoutMs); err != nil {
-			d.mu.Lock()
-			d.streaming = false
-			d.mu.Unlock()
-			return nil, fmt.Errorf("airspy: set sample type: %w", err)
-		}
+	// Apply INT16_IQ at stream start rather than open time. This keeps
+	// Open resilient on hosts that reject early vendor OUT transfers,
+	// while still pinning the wire format before bulk IQ starts.
+	if err := setSampleTypeInt16(d.t); err != nil {
 		d.mu.Lock()
-		d.sampleTypeSet = true
+		d.streaming = false
 		d.mu.Unlock()
+		return nil, fmt.Errorf("airspy: set sample type: %w", err)
 	}
 
 	if err := d.setReceiver(receiverModeOn); err != nil {

--- a/internal/sdr/airspy/airspy_core_probe_test.go
+++ b/internal/sdr/airspy/airspy_core_probe_test.go
@@ -1,0 +1,88 @@
+package airspy
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/sdr/rtlsdr/usb"
+)
+
+const (
+	reqBoardIDReadCoreProbe       uint8 = 9
+	reqVersionStringReadCoreProbe uint8 = 10
+)
+
+// TestRealHardware_USBCoreVendorReadProbe checks whether basic read-only
+// Airspy vendor requests succeed on the current host/device path.
+func TestRealHardware_USBCoreVendorReadProbe(t *testing.T) {
+	requireRealAirspy(t)
+	if !envBool(airspyRealDiagEnv) {
+		t.Skipf("set %s=1 to run core vendor read probe", airspyRealDiagEnv)
+	}
+
+	serialHint := strings.TrimSpace(os.Getenv(airspyRealSerialEnv))
+	enum := usb.DefaultEnumerator()
+	descs, err := enum.List(vidAirspy, pidAirspy)
+	if err != nil {
+		t.Fatalf("usb enumerate: %v", err)
+	}
+	if len(descs) == 0 {
+		t.Fatalf("usb enumerate returned no Airspy descriptors")
+	}
+
+	desc := descs[0]
+	if serialHint != "" {
+		matched := false
+		for _, d := range descs {
+			if d.Serial == serialHint || strings.Contains(d.Serial, serialHint) {
+				desc = d
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			t.Fatalf("no Airspy descriptor matched %q; found serials: %v", serialHint, collectUSBSerials(descs))
+		}
+	}
+
+	t.Logf("core probe backend=%s path=%q serial=%q", enum.Name(), desc.Path, desc.Serial)
+	tr, err := enum.Open(desc)
+	if err != nil {
+		t.Fatalf("usb open: %v", err)
+	}
+	defer tr.Close()
+	if err := tr.ClaimInterface(0); err != nil {
+		t.Fatalf("usb claim interface 0: %v", err)
+	}
+	defer tr.ReleaseInterface(0)
+
+	cases := []struct {
+		name           string
+		bRequest       uint8
+		wValue, wIndex uint16
+		n              int
+	}{
+		{name: "board-v0-i0", bRequest: reqBoardIDReadCoreProbe, wValue: 0, wIndex: 0, n: 1},
+		{name: "board-v0-i1", bRequest: reqBoardIDReadCoreProbe, wValue: 0, wIndex: 1, n: 1},
+		{name: "ver-v0-i0", bRequest: reqVersionStringReadCoreProbe, wValue: 0, wIndex: 0, n: 64},
+		{name: "ver-v0-i1", bRequest: reqVersionStringReadCoreProbe, wValue: 0, wIndex: 1, n: 64},
+	}
+
+	okCount := 0
+	var lastErr error
+	for _, tc := range cases {
+		buf, inErr := tr.ControlIn(tc.bRequest, tc.wValue, tc.wIndex, tc.n, controlTimeoutMs)
+		if inErr == nil {
+			okCount++
+			t.Logf("core IN %s ok: req=0x%02x wValue=0x%04x wIndex=0x%04x wLength=%d gotLen=%d", tc.name, tc.bRequest, tc.wValue, tc.wIndex, tc.n, len(buf))
+		} else {
+			lastErr = inErr
+			t.Logf("core IN %s failed: req=0x%02x wValue=0x%04x wIndex=0x%04x wLength=%d err=%v", tc.name, tc.bRequest, tc.wValue, tc.wIndex, tc.n, inErr)
+		}
+	}
+
+	if okCount == 0 {
+		t.Fatalf("core vendor probe failed for all variants (last err=%v)", lastErr)
+	}
+}

--- a/internal/sdr/airspy/airspy_real_test.go
+++ b/internal/sdr/airspy/airspy_real_test.go
@@ -1,0 +1,376 @@
+package airspy
+
+import (
+	"context"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/sdr"
+	"github.com/MattCheramie/GopherTrunk/internal/sdr/rtlsdr/usb"
+)
+
+const (
+	airspyRealEnv         = "GOPHERTRUNK_AIRSPY_REAL"
+	airspyRealSerialEnv   = "GOPHERTRUNK_AIRSPY_REAL_SERIAL"
+	airspyRealHzEnv       = "GOPHERTRUNK_AIRSPY_REAL_CENTER_HZ"
+	airspyRealRateEnv     = "GOPHERTRUNK_AIRSPY_REAL_RATE_HZ"
+	airspyRealGainEnv     = "GOPHERTRUNK_AIRSPY_REAL_GAIN_TENTH_DB"
+	airspyRealBiasEnv     = "GOPHERTRUNK_AIRSPY_REAL_BIAS_TEE"
+	airspyRealDiagEnv     = "GOPHERTRUNK_AIRSPY_REAL_DIAG"
+	airspyRealDiagRateEnv = "GOPHERTRUNK_AIRSPY_REAL_DIAG_SAMPLERATE"
+)
+
+func TestRealHardware_OpenConfigureStream(t *testing.T) {
+	requireRealAirspy(t)
+
+	centerHz := mustEnvUint32(t, airspyRealHzEnv, 144_390_000)
+	rateHz := mustEnvUint32(t, airspyRealRateEnv, 2_500_000)
+	gainTenthDB := mustEnvInt(t, airspyRealGainEnv, -1) // default auto AGC
+	serialHint := strings.TrimSpace(os.Getenv(airspyRealSerialEnv))
+
+	drv := New(nil)
+	infos, err := drv.Enumerate()
+	if err != nil {
+		t.Fatalf("Enumerate: %v", err)
+	}
+	if len(infos) == 0 {
+		t.Fatalf("Enumerate returned no devices (set %s only when hardware is attached)", airspyRealEnv)
+	}
+
+	idx := 0
+	if serialHint != "" {
+		match := -1
+		for i := range infos {
+			if infos[i].Serial == serialHint || strings.Contains(infos[i].Serial, serialHint) {
+				match = i
+				break
+			}
+		}
+		if match < 0 {
+			t.Fatalf("no enumerated Airspy serial matched %q; found: %v", serialHint, collectSerials(infos))
+		}
+		idx = match
+	}
+
+	dev, err := drv.Open(idx)
+	if err != nil {
+		t.Fatalf("Open(%d): %v", idx, err)
+	}
+	t.Cleanup(func() { _ = dev.Close() })
+
+	if err := dev.SetCenterFreq(centerHz); err != nil {
+		t.Fatalf("SetCenterFreq(%d): %v", centerHz, err)
+	}
+	if err := dev.SetSampleRate(rateHz); err != nil {
+		t.Fatalf("SetSampleRate(%d): %v", rateHz, err)
+	}
+	if err := dev.SetGain(gainTenthDB); err != nil {
+		t.Fatalf("SetGain(%d): %v", gainTenthDB, err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	iq, err := dev.StreamIQ(ctx)
+	if err != nil {
+		t.Fatalf("StreamIQ: %v", err)
+	}
+
+	select {
+	case chunk, ok := <-iq:
+		if !ok {
+			t.Fatal("StreamIQ channel closed before first packet")
+		}
+		if len(chunk) == 0 {
+			t.Fatal("StreamIQ produced an empty packet")
+		}
+	case <-ctx.Done():
+		t.Fatalf("timed out waiting for IQ packet: %v", ctx.Err())
+	}
+}
+
+func TestRealHardware_BiasTeeToggle(t *testing.T) {
+	requireRealAirspy(t)
+	if !envBool(airspyRealBiasEnv) {
+		t.Skipf("set %s=1 to run real Airspy bias-tee toggle validation", airspyRealBiasEnv)
+	}
+
+	serialHint := strings.TrimSpace(os.Getenv(airspyRealSerialEnv))
+
+	drv := New(nil)
+	infos, err := drv.Enumerate()
+	if err != nil {
+		t.Fatalf("Enumerate: %v", err)
+	}
+	if len(infos) == 0 {
+		t.Fatalf("Enumerate returned no devices (set %s only when hardware is attached)", airspyRealEnv)
+	}
+
+	idx := 0
+	if serialHint != "" {
+		match := -1
+		for i := range infos {
+			if infos[i].Serial == serialHint || strings.Contains(infos[i].Serial, serialHint) {
+				match = i
+				break
+			}
+		}
+		if match < 0 {
+			t.Fatalf("no enumerated Airspy serial matched %q; found: %v", serialHint, collectSerials(infos))
+		}
+		idx = match
+	}
+
+	dev, err := drv.Open(idx)
+	if err != nil {
+		t.Fatalf("Open(%d): %v", idx, err)
+	}
+	t.Cleanup(func() {
+		// Best-effort safety reset: leave bias-tee off when the test exits.
+		_ = dev.SetBiasTee(false)
+		_ = dev.Close()
+	})
+
+	if err := dev.SetBiasTee(true); err != nil {
+		t.Fatalf("SetBiasTee(true): %v", err)
+	}
+	if err := dev.SetBiasTee(false); err != nil {
+		t.Fatalf("SetBiasTee(false): %v", err)
+	}
+}
+
+func TestRealHardware_USBControlTransferProbe(t *testing.T) {
+	requireRealAirspy(t)
+	if !envBool(airspyRealDiagEnv) {
+		t.Skipf("set %s=1 to run raw USB control-transfer probe", airspyRealDiagEnv)
+	}
+
+	serialHint := strings.TrimSpace(os.Getenv(airspyRealSerialEnv))
+	enum := usb.DefaultEnumerator()
+	descs, err := enum.List(vidAirspy, pidAirspy)
+	if err != nil {
+		t.Fatalf("usb enumerate: %v", err)
+	}
+	if len(descs) == 0 {
+		t.Fatalf("usb enumerate returned no Airspy descriptors")
+	}
+
+	desc := descs[0]
+	if serialHint != "" {
+		matched := false
+		for _, d := range descs {
+			if d.Serial == serialHint || strings.Contains(d.Serial, serialHint) {
+				desc = d
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			t.Fatalf("no Airspy descriptor matched %q; found serials: %v", serialHint, collectUSBSerials(descs))
+		}
+	}
+
+	t.Logf("probing backend=%s path=%q serial=%q", enum.Name(), desc.Path, desc.Serial)
+	tr, err := enum.Open(desc)
+	if err != nil {
+		t.Fatalf("usb open: %v", err)
+	}
+	defer tr.Close()
+	if err := tr.ClaimInterface(0); err != nil {
+		t.Fatalf("usb claim interface 0: %v", err)
+	}
+	defer tr.ReleaseInterface(0)
+
+	candidates := []uint16{0, 1, 2}
+	var (
+		inOK, outModeOK           bool
+		inLastErr, outModeLastErr error
+	)
+	for _, idx := range candidates {
+		_, inErr := tr.ControlIn(reqGetSamplerates, 0, idx, 4, controlTimeoutMs)
+		modeErr := tr.ControlOut(reqReceiverMode, receiverModeOff, idx, nil, controlTimeoutMs)
+
+		if inErr == nil {
+			inOK = true
+			t.Logf("raw control in samplerate-count succeeded with wIndex=%d", idx)
+		} else {
+			inLastErr = inErr
+			t.Logf("raw control in samplerate-count failed: req=0x%02x wIndex=%d err=%v", reqGetSamplerates, idx, inErr)
+		}
+
+		if modeErr == nil {
+			outModeOK = true
+			t.Logf("raw control out receiver OFF succeeded with wIndex=%d", idx)
+		} else {
+			outModeLastErr = modeErr
+			t.Logf("raw control out receiver OFF failed: req=0x%02x wValue=%d wIndex=%d err=%v", reqReceiverMode, receiverModeOff, idx, modeErr)
+		}
+	}
+
+	if !inOK && !outModeOK {
+		t.Fatalf("raw control probe failed for all wIndex candidates %v (IN=%v receiverMode=%v)", candidates, inLastErr, outModeLastErr)
+	}
+}
+
+func TestRealHardware_USBSampleRateProbe(t *testing.T) {
+	requireRealAirspy(t)
+	if !envBool(airspyRealDiagRateEnv) {
+		t.Skipf("set %s=1 to run raw samplerate control probe", airspyRealDiagRateEnv)
+	}
+
+	serialHint := strings.TrimSpace(os.Getenv(airspyRealSerialEnv))
+	enum := usb.DefaultEnumerator()
+	descs, err := enum.List(vidAirspy, pidAirspy)
+	if err != nil {
+		t.Fatalf("usb enumerate: %v", err)
+	}
+	if len(descs) == 0 {
+		t.Fatalf("usb enumerate returned no Airspy descriptors")
+	}
+
+	desc := descs[0]
+	if serialHint != "" {
+		matched := false
+		for _, d := range descs {
+			if d.Serial == serialHint || strings.Contains(d.Serial, serialHint) {
+				desc = d
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			t.Fatalf("no Airspy descriptor matched %q; found serials: %v", serialHint, collectUSBSerials(descs))
+		}
+	}
+
+	t.Logf("samplerate probe backend=%s path=%q serial=%q", enum.Name(), desc.Path, desc.Serial)
+	tr, err := enum.Open(desc)
+	if err != nil {
+		t.Fatalf("usb open: %v", err)
+	}
+	defer tr.Close()
+	if err := tr.ClaimInterface(0); err != nil {
+		t.Fatalf("usb claim interface 0: %v", err)
+	}
+	defer tr.ReleaseInterface(0)
+
+	inCases := []struct {
+		name           string
+		wValue, wIndex uint16
+		n              int
+	}{
+		{name: "count-v0-i0", wValue: 0, wIndex: 0, n: 4},
+		{name: "count-v0-i1", wValue: 0, wIndex: 1, n: 4},
+		{name: "count-v0-i2", wValue: 0, wIndex: 2, n: 4},
+		{name: "count-v1-i0", wValue: 1, wIndex: 0, n: 4},
+		{name: "list-v0-i4", wValue: 0, wIndex: 4, n: 16},
+		{name: "list-v0-i16", wValue: 0, wIndex: 16, n: 64},
+	}
+	outCases := []struct {
+		name           string
+		wValue, wIndex uint16
+	}{
+		{name: "set-v0-i0", wValue: 0, wIndex: 0},
+		{name: "set-v1-i0", wValue: 1, wIndex: 0},
+		{name: "set-v2-i0", wValue: 2, wIndex: 0},
+		{name: "set-v0-i1", wValue: 0, wIndex: 1},
+		{name: "set-v1-i1", wValue: 1, wIndex: 1},
+		{name: "set-v2-i1", wValue: 2, wIndex: 1},
+	}
+
+	inOK, outOK := 0, 0
+	var inLastErr, outLastErr error
+
+	for _, tc := range inCases {
+		buf, inErr := tr.ControlIn(reqGetSamplerates, tc.wValue, tc.wIndex, tc.n, controlTimeoutMs)
+		if inErr == nil {
+			inOK++
+			t.Logf("samplerate IN %s ok: req=0x%02x wValue=0x%04x wIndex=0x%04x wLength=%d gotLen=%d", tc.name, reqGetSamplerates, tc.wValue, tc.wIndex, tc.n, len(buf))
+		} else {
+			inLastErr = inErr
+			t.Logf("samplerate IN %s failed: req=0x%02x wValue=0x%04x wIndex=0x%04x wLength=%d err=%v", tc.name, reqGetSamplerates, tc.wValue, tc.wIndex, tc.n, inErr)
+		}
+	}
+
+	for _, tc := range outCases {
+		outErr := tr.ControlOut(reqSetSamplerate, tc.wValue, tc.wIndex, nil, controlTimeoutMs)
+		if outErr == nil {
+			outOK++
+			t.Logf("samplerate OUT %s ok: req=0x%02x wValue=0x%04x wIndex=0x%04x wLength=0", tc.name, reqSetSamplerate, tc.wValue, tc.wIndex)
+		} else {
+			outLastErr = outErr
+			t.Logf("samplerate OUT %s failed: req=0x%02x wValue=0x%04x wIndex=0x%04x wLength=0 err=%v", tc.name, reqSetSamplerate, tc.wValue, tc.wIndex, outErr)
+		}
+	}
+
+	if inOK == 0 && outOK == 0 {
+		t.Fatalf("samplerate probe failed for all variants (last IN=%v last OUT=%v)", inLastErr, outLastErr)
+	}
+}
+
+func requireRealAirspy(t *testing.T) {
+	t.Helper()
+	v := strings.TrimSpace(os.Getenv(airspyRealEnv))
+	if v == "" || v == "0" || strings.EqualFold(v, "false") {
+		t.Skipf("set %s=1 to run real Airspy hardware validation", airspyRealEnv)
+	}
+	if testing.Short() {
+		t.Skip("skipping real Airspy hardware validation in -short mode")
+	}
+}
+
+func mustEnvUint32(t *testing.T, key string, fallback uint32) uint32 {
+	t.Helper()
+	raw := strings.TrimSpace(os.Getenv(key))
+	if raw == "" {
+		return fallback
+	}
+	v, err := strconv.ParseUint(raw, 10, 32)
+	if err != nil {
+		t.Fatalf("%s=%q is not a valid unsigned integer: %v", key, raw, err)
+	}
+	return uint32(v)
+}
+
+func mustEnvInt(t *testing.T, key string, fallback int) int {
+	t.Helper()
+	raw := strings.TrimSpace(os.Getenv(key))
+	if raw == "" {
+		return fallback
+	}
+	v, err := strconv.Atoi(raw)
+	if err != nil {
+		t.Fatalf("%s=%q is not a valid integer: %v", key, raw, err)
+	}
+	return v
+}
+
+func envBool(key string) bool {
+	v := strings.TrimSpace(os.Getenv(key))
+	if v == "" {
+		return false
+	}
+	if v == "1" || strings.EqualFold(v, "true") || strings.EqualFold(v, "yes") {
+		return true
+	}
+	return false
+}
+
+func collectSerials(infos []sdr.Info) []string {
+	out := make([]string, 0, len(infos))
+	for _, i := range infos {
+		out = append(out, i.Serial)
+	}
+	return out
+}
+
+func collectUSBSerials(descs []usb.Descriptor) []string {
+	out := make([]string, 0, len(descs))
+	for _, d := range descs {
+		out = append(out, d.Serial)
+	}
+	return out
+}

--- a/internal/sdr/airspy/airspy_test.go
+++ b/internal/sdr/airspy/airspy_test.go
@@ -16,10 +16,9 @@ func withDevice(t *testing.T) (*Device, *usb.MockTransport) {
 	return &Device{t: mt, info: sdr.Info{Driver: driverName, Serial: "test"}}, mt
 }
 
-func TestDriverOpenReadsSamplerates(t *testing.T) {
-	// On Open the driver reads the samplerate table (count first,
-	// then list) and does NOT issue SET_SAMPLE_TYPE — that's deferred
-	// to StreamIQ, matching libairspy's ordering (issue #270).
+func TestDriverEnumerateOpenReadsSamplerates(t *testing.T) {
+	// On Open the driver reads the samplerate table (count first, then
+	// list). SET_SAMPLE_TYPE is deferred until StreamIQ starts.
 	openCalled := false
 	enum := &usb.MockEnumerator{
 		Devices: []usb.Descriptor{
@@ -34,6 +33,7 @@ func TestDriverOpenReadsSamplerates(t *testing.T) {
 			binary.LittleEndian.PutUint32(list[0:4], 10_000_000)
 			binary.LittleEndian.PutUint32(list[4:8], 2_500_000)
 			mt.Script = []usb.CtrlExchange{
+				{BRequest: reqReceiverMode, WValue: receiverModeOff},
 				{In: true, BRequest: reqGetSamplerates, WValue: 0, WIndex: 0, Reply: count, N: 4},
 				{In: true, BRequest: reqGetSamplerates, WValue: 0, WIndex: 2, Reply: list, N: 8},
 			}
@@ -59,11 +59,63 @@ func TestDriverOpenReadsSamplerates(t *testing.T) {
 	if len(asDev.rates) != 2 || asDev.rates[0] != 10_000_000 {
 		t.Fatalf("samplerate table = %v", asDev.rates)
 	}
-	if asDev.sampleTypeSet {
-		t.Error("Open issued SET_SAMPLE_TYPE; expected it deferred to StreamIQ (#270)")
-	}
 	if err := dev.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
+	}
+}
+
+func TestDriverOpenRetriesTransientDeviceGoneOnOpen(t *testing.T) {
+	prevBackoff := openRetryBackoff
+	openRetryBackoff = 0
+	t.Cleanup(func() { openRetryBackoff = prevBackoff })
+
+	openCalls := 0
+	var second *usb.MockTransport
+
+	enum := &usb.MockEnumerator{
+		Devices: []usb.Descriptor{
+			{Bus: 1, Address: 4, VID: vidAirspy, PID: pidAirspy, Serial: "AS1", Product: "Airspy R2", Path: "mock/1"},
+		},
+		OpenFunc: func(d usb.Descriptor) (*usb.MockTransport, error) {
+			openCalls++
+			switch openCalls {
+			case 1:
+				return nil, usb.ErrDeviceGone
+			case 2:
+				mt := usb.NewMockTransport()
+				count := make([]byte, 4)
+				binary.LittleEndian.PutUint32(count, 1)
+				list := make([]byte, 4)
+				binary.LittleEndian.PutUint32(list, 10_000_000)
+				mt.Script = []usb.CtrlExchange{
+					{BRequest: reqReceiverMode, WValue: receiverModeOff},
+					{In: true, BRequest: reqGetSamplerates, WValue: 0, WIndex: 0, Reply: count, N: 4},
+					{In: true, BRequest: reqGetSamplerates, WValue: 0, WIndex: 1, Reply: list, N: 4},
+				}
+				second = mt
+				return mt, nil
+			default:
+				t.Fatalf("unexpected OpenFunc call #%d", openCalls)
+			}
+			return nil, nil
+		},
+	}
+
+	drv := New(enum)
+	if _, err := drv.Enumerate(); err != nil {
+		t.Fatalf("Enumerate: %v", err)
+	}
+	dev, err := drv.Open(0)
+	if err != nil {
+		t.Fatalf("Open after transient ErrDeviceGone: %v", err)
+	}
+	defer dev.Close()
+
+	if openCalls < 2 {
+		t.Fatalf("OpenFunc calls = %d, want at least 2", openCalls)
+	}
+	if second == nil {
+		t.Fatalf("second transport not captured")
 	}
 }
 
@@ -139,15 +191,30 @@ func TestClosestRateIndex(t *testing.T) {
 	}
 }
 
-func TestSetSampleRateSelectsClosest(t *testing.T) {
+func TestSetSampleRateEncodesByValueWhenNotIndexed(t *testing.T) {
 	dev := &Device{rates: []uint32{10_000_000, 2_500_000}}
 	mt := usb.NewMockTransport()
 	dev.t = mt
 	mt.Script = []usb.CtrlExchange{
-		{BRequest: reqSetSamplerate, WValue: 1}, // 4M is closer to 2.5M than 10M
+		{In: true, BRequest: reqSetSamplerate, WValue: 0, WIndex: 8000, Reply: []byte{0}, N: 1},
 	}
 	if err := dev.SetSampleRate(4_000_000); err != nil {
 		t.Fatalf("SetSampleRate: %v", err)
+	}
+	if mt.Err != nil {
+		t.Fatalf("transport: %v", mt.Err)
+	}
+}
+
+func TestSetSampleRateUsesIndexWhenExactMatch(t *testing.T) {
+	dev := &Device{rates: []uint32{10_000_000, 2_500_000}}
+	mt := usb.NewMockTransport()
+	dev.t = mt
+	mt.Script = []usb.CtrlExchange{
+		{In: true, BRequest: reqSetSamplerate, WValue: 0, WIndex: 1, Reply: []byte{0}, N: 1},
+	}
+	if err := dev.SetSampleRate(2_500_000); err != nil {
+		t.Fatalf("SetSampleRate exact: %v", err)
 	}
 	if mt.Err != nil {
 		t.Fatalf("transport: %v", mt.Err)
@@ -208,9 +275,10 @@ func TestSetGainManualDisablesAGC(t *testing.T) {
 
 func TestSetBiasTeeRoundTrips(t *testing.T) {
 	dev, mt := withDevice(t)
+	portPin := (biasTeeGPIOPort << 5) | biasTeeGPIOPin
 	mt.Script = []usb.CtrlExchange{
-		{BRequest: reqSetRFBiasCmd, WValue: 1},
-		{BRequest: reqSetRFBiasCmd, WValue: 0},
+		{BRequest: reqGPIOWrite, WValue: 1, WIndex: portPin},
+		{BRequest: reqGPIOWrite, WValue: 0, WIndex: portPin},
 	}
 	if err := dev.SetBiasTee(true); err != nil {
 		t.Fatalf("SetBiasTee(on): %v", err)
@@ -246,8 +314,6 @@ func TestDecodeInt16IQ(t *testing.T) {
 func TestStreamIQFlipsReceiverAndStops(t *testing.T) {
 	dev, mt := withDevice(t)
 	mt.Script = []usb.CtrlExchange{
-		// SET_SAMPLE_TYPE moved out of Open; first StreamIQ pins it.
-		{BRequest: reqSetSampleType, WValue: sampleTypeInt16IQ},
 		{BRequest: reqReceiverMode, WValue: receiverModeOn},
 		{BRequest: reqReceiverMode, WValue: receiverModeOff},
 	}
@@ -255,9 +321,6 @@ func TestStreamIQFlipsReceiverAndStops(t *testing.T) {
 	ch, err := dev.StreamIQ(ctx)
 	if err != nil {
 		t.Fatalf("StreamIQ: %v", err)
-	}
-	if !dev.sampleTypeSet {
-		t.Error("StreamIQ did not record sampleTypeSet")
 	}
 	cancel()
 	deadline := time.Now().Add(time.Second)

--- a/internal/sdr/pool.go
+++ b/internal/sdr/pool.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 	"sync"
 
 	"github.com/MattCheramie/GopherTrunk/internal/events"
@@ -215,7 +216,7 @@ func (p *Pool) OpenWith(opts PoolOpenOptions) error {
 			}
 			continue
 		}
-		hintBySerial[h.Serial] = h
+		hintBySerial[serialKey(h.Serial)] = h
 		if h.Role == RoleControl {
 			controlClaimed = true
 		}
@@ -223,7 +224,8 @@ func (p *Pool) OpenWith(opts PoolOpenOptions) error {
 
 	openedSerials := map[string]struct{}{}
 	for _, d := range all {
-		hint, hinted := hintBySerial[d.info.Serial]
+		key := serialKey(d.info.Serial)
+		hint, hinted := hintBySerial[key]
 		if opts.Strict && !hinted {
 			p.log.Info("skipping non-configured SDR; add its serial to sdr.devices to use it",
 				"driver", d.drv.Name(), "serial", d.info.Serial)
@@ -266,7 +268,7 @@ func (p *Pool) OpenWith(opts PoolOpenOptions) error {
 		}
 		entry := &PoolEntry{Driver: d.drv, Device: dev, Info: d.info, Role: role, Hint: hint}
 		p.entries = append(p.entries, entry)
-		openedSerials[d.info.Serial] = struct{}{}
+		openedSerials[key] = struct{}{}
 		// Include the per-device tuning in the open log so an
 		// operator can grep the boot log to confirm the value they
 		// put in config.yaml actually landed on this serial (issue
@@ -283,10 +285,10 @@ func (p *Pool) OpenWith(opts PoolOpenOptions) error {
 		p.logTunerDiag(dev, d.info)
 		p.publish(events.KindSDRAttached, entry.Snapshot(true))
 	}
-	for serial := range hintBySerial {
-		if _, ok := openedSerials[serial]; !ok {
+	for key, h := range hintBySerial {
+		if _, ok := openedSerials[key]; !ok {
 			p.log.Warn("configured SDR not present on the bus; check the cable / dmesg / lsusb",
-				"serial", serial)
+				"serial", h.Serial)
 		}
 	}
 	if len(p.entries) == 0 {
@@ -346,12 +348,26 @@ func (p *Pool) AllByRole(r Role) []*PoolEntry {
 func (p *Pool) FindBySerial(serial string) *PoolEntry {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
+	target := serialKey(serial)
 	for _, e := range p.entries {
-		if e.Info.Serial == serial {
+		if serialKey(e.Info.Serial) == target {
 			return e
 		}
 	}
 	return nil
+}
+
+func serialKey(s string) string {
+	s = strings.TrimSpace(s)
+	s = strings.ToLower(s)
+	switch {
+	case strings.HasPrefix(s, "airspy sn:"):
+		return strings.TrimPrefix(s, "airspy sn:")
+	case strings.HasPrefix(s, "airspy_sn:"):
+		return strings.TrimPrefix(s, "airspy_sn:")
+	default:
+		return s
+	}
 }
 
 // applyHintSettings runs the per-device tuners after Open. Caller

--- a/internal/sdr/pool_test.go
+++ b/internal/sdr/pool_test.go
@@ -95,6 +95,51 @@ func TestPoolAssignsRoles(t *testing.T) {
 	}
 }
 
+func TestPoolMatchesAirspySerialAliases(t *testing.T) {
+	drv := &fakeDriver{name: "fake-airspy-alias", infos: []Info{
+		{Driver: "fake-airspy-alias", Index: 0, Serial: "35AC63DC2D701C4F"},
+	}}
+	registryMu.Lock()
+	registry["fake-airspy-alias"] = drv
+	registryMu.Unlock()
+	t.Cleanup(func() {
+		registryMu.Lock()
+		delete(registry, "fake-airspy-alias")
+		registryMu.Unlock()
+	})
+
+	var buf bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	p := NewPool(log)
+	if err := p.OpenWith(PoolOpenOptions{
+		Hints:  []Hint{{Serial: "AIRSPY SN:35ac63dc2d701c4f", Role: RoleVoice}},
+		Strict: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	defer p.Close()
+
+	entries := p.Entries()
+	if len(entries) != 1 {
+		t.Fatalf("entries = %d, want 1; log was: %q", len(entries), buf.String())
+	}
+	if entries[0].Info.Serial != "35AC63DC2D701C4F" {
+		t.Errorf("opened serial = %q, want 35AC63DC2D701C4F", entries[0].Info.Serial)
+	}
+	if got := p.FindBySerial("airspy_sn:35ac63dc2d701c4f"); got == nil {
+		t.Fatalf("FindBySerial(alias) returned nil")
+	} else if got.Info.Serial != "35AC63DC2D701C4F" {
+		t.Errorf("FindBySerial(alias) = %q, want 35AC63DC2D701C4F", got.Info.Serial)
+	}
+	if got := p.FindBySerial("35ac63dc2d701c4f"); got == nil {
+		t.Fatalf("FindBySerial(raw) returned nil")
+	}
+	out := buf.String()
+	if strings.Contains(out, "configured SDR not present on the bus") {
+		t.Errorf("unexpected missing-serial warn; log was: %q", out)
+	}
+}
+
 // TestPoolProgramsSampleRate guards against the bug behind issue #275:
 // without a SetSampleRate call at pool-open time the chip streams at
 // whatever rate its resampler powered up at, the decoder pipeline runs

--- a/internal/sdr/rtlsdr/usb/usb_debug.go
+++ b/internal/sdr/rtlsdr/usb/usb_debug.go
@@ -6,12 +6,39 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
 // debugUSBEnv is the environment variable that toggles the debug
 // transport wrapper. Anything non-empty enables it.
 const debugUSBEnv = "RTLSDR_DEBUG_USB"
+
+// debugUSBCSVEnv enables compact CSV-style lines alongside human-readable
+// traces. Useful for diffing against USBPcap/Wireshark exports.
+const debugUSBCSVEnv = "RTLSDR_DEBUG_USB_CSV"
+
+// debugUSBCSVHeader is emitted once per process when CSV mode is enabled.
+//
+// Column order is fixed for script-friendly parsing:
+//  1. tx_id           monotonically increasing transfer sequence number
+//  2. ts_utc          RFC3339Nano timestamp in UTC
+//  3. rel             elapsed time since process-local trace epoch
+//  4. phase           request | payload | result
+//  5. dir             in | out
+//  6. bmReqType       hex or empty
+//  7. bRequest        hex or empty
+//  8. wValue          hex or empty
+//  9. wIndex          hex or empty
+//
+// 10) wLength         decimal or empty
+// 11) timeoutMs       decimal or empty
+// 12) status          ok | err or empty
+// 13) dataLen         decimal or empty
+// 14) payloadHex      quoted hex dump or empty
+// 15) err             quoted error text or empty
+// 16) duration        elapsed op duration string or empty
+const debugUSBCSVHeader = "tx_id,ts_utc,rel,phase,dir,bmReqType,bRequest,wValue,wIndex,wLength,timeoutMs,status,dataLen,payloadHex,err,duration"
 
 // Diagnoser is an optional Transport capability. Implementations that
 // can describe the underlying device — the bound driver, USB descriptors,
@@ -33,8 +60,11 @@ const debugMaxDataBytes = 64
 // debugSink is the io.Writer the debug transport logs to. Defaults
 // to os.Stderr; tests swap it via SetDebugSink.
 var (
-	debugSinkMu sync.Mutex
-	debugSink   io.Writer = os.Stderr
+	debugSinkMu           sync.Mutex
+	debugSink             io.Writer = os.Stderr
+	debugTrace0                     = time.Now()
+	debugTraceSeq         atomic.Uint64
+	debugCSVHeaderEmitted atomic.Bool
 )
 
 // SetDebugSink redirects debug-transport output. Returns the previous
@@ -52,6 +82,8 @@ func SetDebugSink(w io.Writer) io.Writer {
 // gate per-iteration FFI calls (e.g. IOObjectGetClass) on this so the
 // off-path stays free.
 func debugUSBEnabled() bool { return os.Getenv(debugUSBEnv) != "" }
+
+func debugUSBCSVEnabled() bool { return os.Getenv(debugUSBCSVEnv) != "" }
 
 // debugLogf writes one line to the debug sink with the standard
 // rtlsdr-usb prefix and a component label, when RTLSDR_DEBUG_USB is
@@ -131,34 +163,62 @@ func (d *debugTransport) logf(format string, args ...interface{}) {
 	d.writeLog("rtlsdr-usb [" + d.label + "]: " + fmt.Sprintf(format, args...))
 }
 
+func (d *debugTransport) logCSV(format string, args ...interface{}) {
+	if !debugUSBCSVEnabled() {
+		return
+	}
+	if !debugCSVHeaderEmitted.Load() {
+		if debugCSVHeaderEmitted.CompareAndSwap(false, true) {
+			d.writeLog("rtlsdr-usb-csv,#" + debugUSBCSVHeader)
+		}
+	}
+	d.writeLog("rtlsdr-usb-csv," + fmt.Sprintf(format, args...))
+}
+
+func nextDebugTrace() (uint64, time.Time, time.Duration) {
+	now := time.Now()
+	seq := debugTraceSeq.Add(1)
+	delta := now.Sub(debugTrace0).Round(time.Microsecond)
+	return seq, now, delta
+}
+
 func (d *debugTransport) ControlIn(bRequest uint8, wValue, wIndex uint16, n int, timeoutMs int) ([]byte, error) {
-	d.logf("ControlIn  bmReqType=0x%02x bReq=0x%02x wValue=0x%04x wIndex=0x%04x wLength=%d timeout=%dms",
-		VendorIn, bRequest, wValue, wIndex, n, timeoutMs)
+	txID, ts, rel := nextDebugTrace()
+	d.logf("tx=%06d ts=%s rel=%s ControlIn  bmReqType=0x%02x bReq=0x%02x wValue=0x%04x wIndex=0x%04x wLength=%d timeout=%dms",
+		txID, ts.UTC().Format(time.RFC3339Nano), rel, VendorIn, bRequest, wValue, wIndex, n, timeoutMs)
+	d.logCSV("%06d,%s,%s,request,in,0x%02x,0x%02x,0x%04x,0x%04x,%d,%d,,,,,", txID, ts.UTC().Format(time.RFC3339Nano), rel, VendorIn, bRequest, wValue, wIndex, n, timeoutMs)
 	start := time.Now()
 	out, err := d.inner.ControlIn(bRequest, wValue, wIndex, n, timeoutMs)
 	dur := time.Since(start)
 	if err != nil {
-		d.logf("  -> err=%v (after %s)", err, dur)
+		d.logf("tx=%06d -> err=%v (after %s)", txID, err, dur)
+		d.logCSV("%06d,%s,%s,result,in,,,,,,,err,,,%q,%s", txID, ts.UTC().Format(time.RFC3339Nano), rel, err.Error(), dur)
 		return out, err
 	}
-	d.logf("  -> data=%s (%d bytes, %s)", hexBytes(out, debugMaxDataBytes), len(out), dur)
+	d.logf("tx=%06d -> data=%s (%d bytes, %s)", txID, hexBytes(out, debugMaxDataBytes), len(out), dur)
+	d.logCSV("%06d,%s,%s,result,in,,,,,,,ok,%d,%q,,%s", txID, ts.UTC().Format(time.RFC3339Nano), rel, len(out), hexBytes(out, debugMaxDataBytes), dur)
 	return out, nil
 }
 
 func (d *debugTransport) ControlOut(bRequest uint8, wValue, wIndex uint16, data []byte, timeoutMs int) error {
-	d.logf("ControlOut bmReqType=0x%02x bReq=0x%02x wValue=0x%04x wIndex=0x%04x wLength=%d timeout=%dms",
-		VendorOut, bRequest, wValue, wIndex, len(data), timeoutMs)
+	txID, ts, rel := nextDebugTrace()
+	d.logf("tx=%06d ts=%s rel=%s ControlOut bmReqType=0x%02x bReq=0x%02x wValue=0x%04x wIndex=0x%04x wLength=%d timeout=%dms",
+		txID, ts.UTC().Format(time.RFC3339Nano), rel, VendorOut, bRequest, wValue, wIndex, len(data), timeoutMs)
+	d.logCSV("%06d,%s,%s,request,out,0x%02x,0x%02x,0x%04x,0x%04x,%d,%d,,,,,", txID, ts.UTC().Format(time.RFC3339Nano), rel, VendorOut, bRequest, wValue, wIndex, len(data), timeoutMs)
 	if len(data) > 0 {
-		d.logf("  data=%s", hexBytes(data, debugMaxDataBytes))
+		d.logf("tx=%06d data=%s", txID, hexBytes(data, debugMaxDataBytes))
+		d.logCSV("%06d,%s,%s,payload,out,,,,,,,,,%q,,", txID, ts.UTC().Format(time.RFC3339Nano), rel, hexBytes(data, debugMaxDataBytes))
 	}
 	start := time.Now()
 	err := d.inner.ControlOut(bRequest, wValue, wIndex, data, timeoutMs)
 	dur := time.Since(start)
 	if err != nil {
-		d.logf("  -> err=%v (after %s)", err, dur)
+		d.logf("tx=%06d -> err=%v (after %s)", txID, err, dur)
+		d.logCSV("%06d,%s,%s,result,out,,,,,,,err,,,%q,%s", txID, ts.UTC().Format(time.RFC3339Nano), rel, err.Error(), dur)
 		return err
 	}
-	d.logf("  -> ok (after %s)", dur)
+	d.logf("tx=%06d -> ok (after %s)", txID, dur)
+	d.logCSV("%06d,%s,%s,result,out,,,,,,,ok,,,,%s", txID, ts.UTC().Format(time.RFC3339Nano), rel, dur)
 	return nil
 }
 

--- a/internal/sdr/rtlsdr/usb/usb_debug_test.go
+++ b/internal/sdr/rtlsdr/usb/usb_debug_test.go
@@ -52,6 +52,9 @@ func TestMaybeWrapDebug_OnLogsControlTransfers(t *testing.T) {
 	logged := buf.String()
 	for _, want := range []string{
 		"bus=1 addr=7 serial=abc", // descriptor label
+		"tx=",
+		"ts=",
+		"rel=",
 		"ControlOut bmReqType=0x40",
 		"wValue=0x2000",
 		"wIndex=0x0110",
@@ -62,6 +65,37 @@ func TestMaybeWrapDebug_OnLogsControlTransfers(t *testing.T) {
 	} {
 		if !strings.Contains(logged, want) {
 			t.Errorf("log missing %q\nlog:\n%s", want, logged)
+		}
+	}
+}
+
+func TestMaybeWrapDebug_CSVMode(t *testing.T) {
+	t.Setenv(debugUSBEnv, "1")
+	t.Setenv(debugUSBCSVEnv, "1")
+	var buf bytes.Buffer
+	prev := SetDebugSink(&buf)
+	t.Cleanup(func() { SetDebugSink(prev) })
+
+	inner := NewMockTransport()
+	inner.Script = []CtrlExchange{{In: false, BRequest: 1, WValue: 0x0002, WIndex: 0x0001, Data: nil}}
+	t1 := MaybeWrapDebug(inner, Descriptor{Bus: 9, Address: 2, Serial: "csv"})
+
+	if err := t1.ControlOut(1, 0x0002, 0x0001, nil, 1000); err != nil {
+		t.Fatalf("ControlOut: %v", err)
+	}
+
+	logged := buf.String()
+	for _, want := range []string{
+		"rtlsdr-usb-csv,",
+		",request,out,",
+		",result,out,",
+		",ok,",
+		"0x01",
+		"0x0002",
+		"0x0001",
+	} {
+		if !strings.Contains(logged, want) {
+			t.Errorf("csv log missing %q\nlog:\n%s", want, logged)
 		}
 	}
 }

--- a/internal/sdr/rtlsdr/usb/usb_windows.go
+++ b/internal/sdr/rtlsdr/usb/usb_windows.go
@@ -5,6 +5,7 @@ package usb
 import (
 	"errors"
 	"fmt"
+	"os"
 	"runtime"
 	"strconv"
 	"strings"
@@ -31,15 +32,16 @@ var (
 	procSetupDiGetDeviceInterfaceDetailW = modSetupAPI.NewProc("SetupDiGetDeviceInterfaceDetailW")
 	procSetupDiDestroyDeviceInfoList     = modSetupAPI.NewProc("SetupDiDestroyDeviceInfoList")
 
-	procWinUsbInitialize          = modWinUSB.NewProc("WinUsb_Initialize")
-	procWinUsbFree                = modWinUSB.NewProc("WinUsb_Free")
-	procWinUsbControlTransfer     = modWinUSB.NewProc("WinUsb_ControlTransfer")
-	procWinUsbGetDescriptor       = modWinUSB.NewProc("WinUsb_GetDescriptor")
-	procWinUsbReadPipe            = modWinUSB.NewProc("WinUsb_ReadPipe")
-	procWinUsbAbortPipe           = modWinUSB.NewProc("WinUsb_AbortPipe")
-	procWinUsbResetPipe           = modWinUSB.NewProc("WinUsb_ResetPipe")
-	procWinUsbSetPipePolicy       = modWinUSB.NewProc("WinUsb_SetPipePolicy")
-	procWinUsbGetOverlappedResult = modWinUSB.NewProc("WinUsb_GetOverlappedResult")
+	procWinUsbInitialize             = modWinUSB.NewProc("WinUsb_Initialize")
+	procWinUsbFree                   = modWinUSB.NewProc("WinUsb_Free")
+	procWinUsbGetAssociatedInterface = modWinUSB.NewProc("WinUsb_GetAssociatedInterface")
+	procWinUsbControlTransfer        = modWinUSB.NewProc("WinUsb_ControlTransfer")
+	procWinUsbGetDescriptor          = modWinUSB.NewProc("WinUsb_GetDescriptor")
+	procWinUsbReadPipe               = modWinUSB.NewProc("WinUsb_ReadPipe")
+	procWinUsbAbortPipe              = modWinUSB.NewProc("WinUsb_AbortPipe")
+	procWinUsbResetPipe              = modWinUSB.NewProc("WinUsb_ResetPipe")
+	procWinUsbSetPipePolicy          = modWinUSB.NewProc("WinUsb_SetPipePolicy")
+	procWinUsbGetOverlappedResult    = modWinUSB.NewProc("WinUsb_GetOverlappedResult")
 )
 
 // GUID_DEVINTERFACE_USB_DEVICE — the class GUID every USB device exposes
@@ -79,6 +81,8 @@ type spDeviceInterfaceData struct {
 // hard-code.
 const spDeviceInterfaceDetailDataHeaderSize = 8
 
+const winusbIfaceGUIDEnv = "RTLSDR_WINUSB_IFACE_GUID"
+
 func platformEnumerator() Enumerator { return &winEnumerator{} }
 
 // winEnumerator walks every present USB device interface via SetupAPI
@@ -90,8 +94,14 @@ type winEnumerator struct{}
 func (w *winEnumerator) Name() string { return "winusb" }
 
 func (w *winEnumerator) List(vid, pid uint16) ([]Descriptor, error) {
+	ifaceGUID, guidLabel, err := winInterfaceClassGUID()
+	if err != nil {
+		return nil, err
+	}
+	debugLogf("winusb", "List start vid=0x%04x pid=0x%04x", vid, pid)
+	debugLogf("winusb", "List interface class guid=%s", guidLabel)
 	devSet, _, errno := procSetupDiGetClassDevsW.Call(
-		uintptr(unsafe.Pointer(&guidDevInterfaceUSBDevice)),
+		uintptr(unsafe.Pointer(&ifaceGUID)),
 		0,
 		0,
 		uintptr(digcfPresentDeviceInterface),
@@ -108,7 +118,7 @@ func (w *winEnumerator) List(vid, pid uint16) ([]Descriptor, error) {
 		ret, _, errno := procSetupDiEnumDeviceInterfaces.Call(
 			devSet,
 			0,
-			uintptr(unsafe.Pointer(&guidDevInterfaceUSBDevice)),
+			uintptr(unsafe.Pointer(&ifaceGUID)),
 			uintptr(memberIndex),
 			uintptr(unsafe.Pointer(&iface)),
 		)
@@ -120,16 +130,20 @@ func (w *winEnumerator) List(vid, pid uint16) ([]Descriptor, error) {
 		}
 		path, err := getDeviceInterfacePath(devSet, &iface)
 		if err != nil {
+			debugLogf("winusb", "List[%d] interface path error: %v", memberIndex, err)
 			continue
 		}
 		v, p, serial := parseDevicePath(path)
+		debugLogf("winusb", "List[%d] path=%q parsed vid=0x%04x pid=0x%04x serial=%q", memberIndex, path, v, p, serial)
 		if v == 0 && p == 0 {
 			continue
 		}
 		if vid != 0 && v != vid {
+			debugLogf("winusb", "List[%d] skip: vid mismatch (want 0x%04x)", memberIndex, vid)
 			continue
 		}
 		if pid != 0 && p != pid {
+			debugLogf("winusb", "List[%d] skip: pid mismatch (want 0x%04x)", memberIndex, pid)
 			continue
 		}
 		out = append(out, Descriptor{
@@ -141,6 +155,7 @@ func (w *winEnumerator) List(vid, pid uint16) ([]Descriptor, error) {
 			Path:    path,
 		})
 	}
+	debugLogf("winusb", "List done matches=%d", len(out))
 	return out, nil
 }
 
@@ -161,18 +176,20 @@ func createAndInitWinUSB(path string) (windows.Handle, uintptr, error) {
 	if err != nil {
 		return 0, 0, fmt.Errorf("%w %q: %w", errWinUSBCreateFile, path, err)
 	}
+	flags := winCreateFileFlags()
 	handle, err := windows.CreateFile(
 		wpath,
 		windows.GENERIC_READ|windows.GENERIC_WRITE,
 		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE,
 		nil,
 		windows.OPEN_EXISTING,
-		windows.FILE_ATTRIBUTE_NORMAL|windows.FILE_FLAG_OVERLAPPED,
+		flags,
 		0,
 	)
 	if err != nil {
 		return 0, 0, fmt.Errorf("%w %q: %w", errWinUSBCreateFile, path, err)
 	}
+	debugLogf("winusb", "Open CreateFile ok handle=0x%x flags=0x%x", uintptr(handle), flags)
 	var ifaceHandle uintptr
 	ret, _, errno := procWinUsbInitialize.Call(uintptr(handle), uintptr(unsafe.Pointer(&ifaceHandle)))
 	if ret == 0 {
@@ -183,11 +200,11 @@ func createAndInitWinUSB(path string) (windows.Handle, uintptr, error) {
 	// transfer timeout on the control endpoint at open time
 	// (winusbx_configure_endpoints in libusb/os/windows_winusb.c sets
 	// PIPE_TRANSFER_TIMEOUT=0 on pipe 0 as part of claim_interface).
-	// WinUSB's documented default is 5000 ms — without this call the
+	// WinUSB's documented default is 5000 ms; without this call, the
 	// brief window between open and the first ControlOut would inherit
 	// that default. The lazy applyControlTimeout still overrides this
 	// to CtrlTimeoutMs on the first user-level transfer; this call is
-	// pure parity / hardening, not the issue #395 fix.
+	// parity/hardening, not the issue #395 fix.
 	setControlPipeTimeout(ifaceHandle, 0)
 	return handle, ifaceHandle, nil
 }
@@ -196,9 +213,11 @@ func (w *winEnumerator) Open(d Descriptor) (Transport, error) {
 	if d.Path == "" {
 		return nil, errors.New("winusb: Descriptor.Path empty (re-enumerate)")
 	}
+	debugLogf("winusb", "Open path=%q serial=%q vid=0x%04x pid=0x%04x", d.Path, d.Serial, d.VID, d.PID)
 	handle, ifaceHandle, err := createAndInitWinUSB(d.Path)
 	if err == nil {
-		return &winTransport{fileHandle: handle, ifaceHandle: ifaceHandle, desc: d}, nil
+		debugLogf("winusb", "Open WinUsb_Initialize ok iface=0x%x", ifaceHandle)
+		return MaybeWrapDebug(&winTransport{fileHandle: handle, ifaceHandle: ifaceHandle, desc: d}, d), nil
 	}
 	// A CreateFile-stage failure (e.g. ERROR_ACCESS_DENIED — another process
 	// holds the dongle, issue #333) is not a driver-binding problem; surface it
@@ -218,13 +237,63 @@ func (w *winEnumerator) Open(d Descriptor) (Transport, error) {
 		if ch, cif, cerr := createAndInitWinUSB(childPath); cerr == nil {
 			cd := d
 			cd.Path = childPath
-			return &winTransport{fileHandle: ch, ifaceHandle: cif, desc: cd}, nil
+			debugLogf("winusb", "Open child WinUsb_Initialize ok iface=0x%x", cif)
+			return MaybeWrapDebug(&winTransport{fileHandle: ch, ifaceHandle: cif, desc: cd}, cd), nil
 		}
 	}
 	svc, descr := lookupBoundDriver(d.Path)
 	return nil, fmt.Errorf(
 		"winusb: WinUsb_Initialize failed for VID_%04X&PID_%04X (current driver: %s%s — expected WinUSB; run Zadig and rebind Interface 0, see `gophertrunk sdr doctor`): %w",
 		d.VID, d.PID, fallbackString(svc, "unknown"), parens(descr), err)
+}
+
+func winCreateFileFlags() uint32 {
+	flags := uint32(windows.FILE_ATTRIBUTE_NORMAL | windows.FILE_FLAG_OVERLAPPED)
+	if os.Getenv("RTLSDR_WINUSB_NO_OVERLAPPED") != "" {
+		flags = windows.FILE_ATTRIBUTE_NORMAL
+	}
+	return flags
+}
+
+func winInterfaceClassGUID() (windows.GUID, string, error) {
+	raw := strings.TrimSpace(os.Getenv(winusbIfaceGUIDEnv))
+	if raw == "" {
+		return guidDevInterfaceUSBDevice, guidToString(guidDevInterfaceUSBDevice), nil
+	}
+	g, err := parseGUID(raw)
+	if err != nil {
+		return windows.GUID{}, "", fmt.Errorf("winusb: invalid %s=%q: %w", winusbIfaceGUIDEnv, raw, err)
+	}
+	return g, guidToString(g), nil
+}
+
+func parseGUID(s string) (windows.GUID, error) {
+	var (
+		d1     uint32
+		d2, d3 uint16
+		d4     [8]uint8
+	)
+	formats := []string{
+		"{%08x-%04x-%04x-%02x%02x-%02x%02x%02x%02x%02x%02x}",
+		"%08x-%04x-%04x-%02x%02x-%02x%02x%02x%02x%02x%02x",
+	}
+	for _, f := range formats {
+		n, err := fmt.Sscanf(s, f,
+			&d1, &d2, &d3,
+			&d4[0], &d4[1], &d4[2], &d4[3], &d4[4], &d4[5], &d4[6], &d4[7],
+		)
+		if err == nil && n == 11 {
+			return windows.GUID{Data1: d1, Data2: d2, Data3: d3, Data4: d4}, nil
+		}
+	}
+	return windows.GUID{}, errors.New("expected GUID form {xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx}")
+}
+
+func guidToString(g windows.GUID) string {
+	return fmt.Sprintf("{%08x-%04x-%04x-%02x%02x-%02x%02x%02x%02x%02x%02x}",
+		g.Data1, g.Data2, g.Data3,
+		g.Data4[0], g.Data4[1], g.Data4[2], g.Data4[3], g.Data4[4], g.Data4[5], g.Data4[6], g.Data4[7],
+	)
 }
 
 // setControlPipeTimeout pushes a PIPE_TRANSFER_TIMEOUT policy on the
@@ -250,6 +319,9 @@ type winTransport struct {
 	ifaceHandle uintptr
 	desc        Descriptor
 	closed      atomic.Bool
+
+	assocMu      sync.Mutex
+	assocHandles map[uint8]uintptr
 
 	bulkMu       sync.Mutex
 	bulkActive   bool
@@ -278,6 +350,13 @@ type winusbSetupPacket struct {
 	Index       uint16
 	Length      uint16
 }
+
+// Some WinUSB-bound devices expose vendor control requests on interface
+// recipient scope (bmRequestType ...|RECIPIENT_INTERFACE) rather than
+// device scope. Most devices (including RTL-SDR) accept recipient-device,
+// so we try device first and fall back to interface only when the first
+// transfer reports ErrDeviceGone.
+const interfaceRecipientBit uint8 = 0x01
 
 // pack folds the setup packet into a single uintptr. This is load-bearing
 // and the reason vendor control transfers never worked on real Windows
@@ -326,8 +405,32 @@ func (t *winTransport) ControlIn(bRequest uint8, wValue, wIndex uint16, n int, t
 		return nil, fmt.Errorf("winusb: control IN length %d out of range", n)
 	}
 	t.applyControlTimeout(timeoutMs)
+	out, err := t.controlInWithType(VendorIn, bRequest, wValue, wIndex, n)
+	if err == nil {
+		return out, nil
+	}
+	if !shouldRetryInterfaceRecipient(err) {
+		return nil, err
+	}
+	debugLogf("winusb", "ControlIn retry with interface recipient req=0x%02x val=0x%04x idx=0x%04x", bRequest, wValue, wIndex)
+	out, err = t.controlInWithType(VendorIn|interfaceRecipientBit, bRequest, wValue, wIndex, n)
+	if err != nil {
+		debugLogf("winusb", "ControlIn interface-recipient retry failed: %v", err)
+		out, assocErr := t.controlInAssociatedFallback(bRequest, wValue, wIndex, n)
+		if assocErr == nil {
+			return out, nil
+		}
+	}
+	return out, err
+}
+
+func (t *winTransport) controlInWithType(reqType uint8, bRequest uint8, wValue, wIndex uint16, n int) ([]byte, error) {
+	return t.controlInWithTypeOnHandle(t.ifaceHandle, reqType, bRequest, wValue, wIndex, n)
+}
+
+func (t *winTransport) controlInWithTypeOnHandle(handle uintptr, reqType uint8, bRequest uint8, wValue, wIndex uint16, n int) ([]byte, error) {
 	pkt := winusbSetupPacket{
-		RequestType: VendorIn,
+		RequestType: reqType,
 		Request:     bRequest,
 		Value:       wValue,
 		Index:       wIndex,
@@ -341,7 +444,7 @@ func (t *winTransport) ControlIn(bRequest uint8, wValue, wIndex uint16, n int, t
 	}
 	var transferred uint32
 	ret, _, errno := procWinUsbControlTransfer.Call(
-		t.ifaceHandle,
+		handle,
 		pkt.pack(), // WINUSB_SETUP_PACKET is passed BY VALUE (see pack)
 		bufPtr,
 		uintptr(n),
@@ -354,6 +457,26 @@ func (t *winTransport) ControlIn(bRequest uint8, wValue, wIndex uint16, n int, t
 	return buf[:transferred], nil
 }
 
+func (t *winTransport) controlInAssociatedFallback(bRequest uint8, wValue, wIndex uint16, n int) ([]byte, error) {
+	h, ok, err := t.associatedInterfaceHandle(0)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, errors.New("winusb: no associated interface available")
+	}
+	debugLogf("winusb", "ControlIn retry with associated interface[0] req=0x%02x val=0x%04x idx=0x%04x", bRequest, wValue, wIndex)
+	out, err := t.controlInWithTypeOnHandle(h, VendorIn, bRequest, wValue, wIndex, n)
+	if err == nil {
+		return out, nil
+	}
+	out, err = t.controlInWithTypeOnHandle(h, VendorIn|interfaceRecipientBit, bRequest, wValue, wIndex, n)
+	if err != nil {
+		debugLogf("winusb", "ControlIn associated interface retry failed: %v", err)
+	}
+	return out, err
+}
+
 func (t *winTransport) ControlOut(bRequest uint8, wValue, wIndex uint16, data []byte, timeoutMs int) error {
 	if t.closed.Load() {
 		return ErrClosed
@@ -362,8 +485,41 @@ func (t *winTransport) ControlOut(bRequest uint8, wValue, wIndex uint16, data []
 		return fmt.Errorf("winusb: control OUT length %d out of range", len(data))
 	}
 	t.applyControlTimeout(timeoutMs)
+	err := t.controlOutWithType(VendorOut, bRequest, wValue, wIndex, data)
+	if err == nil {
+		return nil
+	}
+	if !shouldRetryInterfaceRecipient(err) {
+		return err
+	}
+	debugLogf("winusb", "ControlOut retry with interface recipient req=0x%02x val=0x%04x idx=0x%04x len=%d", bRequest, wValue, wIndex, len(data))
+	err = t.controlOutWithType(VendorOut|interfaceRecipientBit, bRequest, wValue, wIndex, data)
+	if err != nil {
+		debugLogf("winusb", "ControlOut interface-recipient retry failed: %v", err)
+		assocErr := t.controlOutAssociatedFallback(bRequest, wValue, wIndex, data)
+		if assocErr == nil {
+			return nil
+		}
+	}
+	return err
+}
+
+func shouldRetryInterfaceRecipient(err error) bool {
+	if errors.Is(err, ErrDeviceGone) {
+		return true
+	}
+	// Some WinUSB stacks surface recipient mismatches as ERROR_GEN_FAILURE
+	// rather than a disconnect-like code.
+	return strings.Contains(err.Error(), "ERROR_GEN_FAILURE")
+}
+
+func (t *winTransport) controlOutWithType(reqType uint8, bRequest uint8, wValue, wIndex uint16, data []byte) error {
+	return t.controlOutWithTypeOnHandle(t.ifaceHandle, reqType, bRequest, wValue, wIndex, data)
+}
+
+func (t *winTransport) controlOutWithTypeOnHandle(handle uintptr, reqType uint8, bRequest uint8, wValue, wIndex uint16, data []byte) error {
 	pkt := winusbSetupPacket{
-		RequestType: VendorOut,
+		RequestType: reqType,
 		Request:     bRequest,
 		Value:       wValue,
 		Index:       wIndex,
@@ -375,7 +531,7 @@ func (t *winTransport) ControlOut(bRequest uint8, wValue, wIndex uint16, data []
 	}
 	var transferred uint32
 	ret, _, errno := procWinUsbControlTransfer.Call(
-		t.ifaceHandle,
+		handle,
 		pkt.pack(), // WINUSB_SETUP_PACKET is passed BY VALUE (see pack)
 		dataPtr,
 		uintptr(len(data)),
@@ -411,6 +567,55 @@ func (t *winTransport) ControlOut(bRequest uint8, wValue, wIndex uint16, data []
 		}
 	}
 	return nil
+}
+
+func (t *winTransport) controlOutAssociatedFallback(bRequest uint8, wValue, wIndex uint16, data []byte) error {
+	h, ok, err := t.associatedInterfaceHandle(0)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return errors.New("winusb: no associated interface available")
+	}
+	debugLogf("winusb", "ControlOut retry with associated interface[0] req=0x%02x val=0x%04x idx=0x%04x len=%d", bRequest, wValue, wIndex, len(data))
+	err = t.controlOutWithTypeOnHandle(h, VendorOut, bRequest, wValue, wIndex, data)
+	if err == nil {
+		return nil
+	}
+	err = t.controlOutWithTypeOnHandle(h, VendorOut|interfaceRecipientBit, bRequest, wValue, wIndex, data)
+	if err != nil {
+		debugLogf("winusb", "ControlOut associated interface retry failed: %v", err)
+	}
+	return err
+}
+
+func (t *winTransport) associatedInterfaceHandle(index uint8) (uintptr, bool, error) {
+	t.assocMu.Lock()
+	defer t.assocMu.Unlock()
+	if t.assocHandles != nil {
+		if h, ok := t.assocHandles[index]; ok {
+			return h, true, nil
+		}
+	}
+	var h uintptr
+	ret, _, errno := procWinUsbGetAssociatedInterface.Call(
+		t.ifaceHandle,
+		uintptr(index),
+		uintptr(unsafe.Pointer(&h)),
+	)
+	if ret == 0 {
+		if errno == windows.ERROR_NO_MORE_ITEMS {
+			debugLogf("winusb", "WinUsb_GetAssociatedInterface[%d]: no more items", index)
+			return 0, false, nil
+		}
+		return 0, false, fmt.Errorf("winusb: WinUsb_GetAssociatedInterface[%d]: %w", index, winErr(errno))
+	}
+	if t.assocHandles == nil {
+		t.assocHandles = make(map[uint8]uintptr)
+	}
+	t.assocHandles[index] = h
+	debugLogf("winusb", "Associated interface[%d] acquired handle=0x%x", index, h)
+	return h, true, nil
 }
 
 // ClaimInterface is a no-op on Windows: WinUsb_Initialize already gave
@@ -752,6 +957,12 @@ func (t *winTransport) Close() error {
 		procWinUsbFree.Call(t.ifaceHandle)
 		t.ifaceHandle = 0
 	}
+	t.assocMu.Lock()
+	for idx, h := range t.assocHandles {
+		procWinUsbFree.Call(h)
+		delete(t.assocHandles, idx)
+	}
+	t.assocMu.Unlock()
 	if t.fileHandle != 0 {
 		windows.CloseHandle(t.fileHandle)
 		t.fileHandle = 0
@@ -994,7 +1205,7 @@ func winErr(errno error) error {
 	case windows.ERROR_GEN_FAILURE:
 		return fmt.Errorf("winusb: device rejected request (ERROR_GEN_FAILURE 0x1F — firmware NAK / stalled pipe / wrong driver bound; try re-binding to WinUSB via Zadig): %w (errno: %w)", ErrPipeStalled, errno)
 	case windows.ERROR_SEM_TIMEOUT, windows.ERROR_TIMEOUT:
-		return ErrTimeout
+		return fmt.Errorf("%w (windows errno=%v)", ErrTimeout, errno)
 	}
 	return errno
 }

--- a/scripts/airspy-windows-rebind-and-check.ps1
+++ b/scripts/airspy-windows-rebind-and-check.ps1
@@ -1,0 +1,152 @@
+param(
+    [string]$DeviceInstanceId = "USB\VID_1D50&PID_60A1\AIRSPY_SN:35AC63DC2D645A4F",
+    [string]$AirspyInfoPath = "tools\libairspy-v1.0.10\airspy_host_tools_win32_x86_x64_v1_0_10\x86\airspy_info.exe",
+    [Alias("RenumerationTimeoutSeconds")]
+    [int]$ReenumerationTimeoutSeconds = 30
+)
+
+$ErrorActionPreference = "Stop"
+$ScriptVersion = "2026-05-26b"
+
+function Test-IsAdmin {
+    $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+    $principal = New-Object Security.Principal.WindowsPrincipal($identity)
+    return $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+}
+
+function Invoke-AirspyInfo {
+    param([string]$Path)
+
+    if (-not (Test-Path -LiteralPath $Path)) {
+        throw "airspy_info.exe not found at: $Path"
+    }
+
+    Write-Host "=== Running airspy_info: $Path ==="
+    & $Path
+    Write-Host "airspy_info exit=$LASTEXITCODE"
+}
+
+function Resolve-RepoPath {
+    param([string]$RelativePath)
+
+    $repoRoot = Split-Path -Parent $PSScriptRoot
+    return Join-Path $repoRoot $RelativePath
+}
+
+function Resolve-AirspyInstanceId {
+    param([string]$PreferredInstanceId)
+
+    try {
+        Get-PnpDevice -InstanceId $PreferredInstanceId -ErrorAction Stop | Out-Null
+        return $PreferredInstanceId
+    }
+    catch {
+        # Continue to wildcard discovery.
+    }
+
+    $normalized = $PreferredInstanceId -replace "\\\\", "\\"
+    if ($normalized -ne $PreferredInstanceId) {
+        try {
+            Get-PnpDevice -InstanceId $normalized -ErrorAction Stop | Out-Null
+            return $normalized
+        }
+        catch {
+            # Continue to wildcard discovery.
+        }
+    }
+
+    $matches = Get-PnpDevice | Where-Object {
+        $_.InstanceId -like "USB\VID_1D50&PID_60A1\*"
+    }
+
+    if (-not $matches) {
+        throw "No connected Airspy device matched VID_1D50&PID_60A1."
+    }
+
+    if ($matches.Count -gt 1) {
+        throw "Multiple Airspy devices found. Re-run with -DeviceInstanceId using one of:`n$($matches.InstanceId -join "`n")"
+    }
+
+    return $matches[0].InstanceId
+}
+
+function Wait-ForDevicePresent {
+    param(
+        [string]$InstanceId,
+        [int]$TimeoutSeconds
+    )
+
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    while ((Get-Date) -lt $deadline) {
+        $dev = Get-PnpDevice -InstanceId $InstanceId -ErrorAction SilentlyContinue
+        if ($null -ne $dev -and $dev.Present) {
+            return $dev.InstanceId
+        }
+
+        $matches = Get-PnpDevice | Where-Object {
+            $_.InstanceId -like "USB\VID_1D50&PID_60A1\*" -and $_.Present
+        }
+        if ($matches.Count -eq 1) {
+            return $matches[0].InstanceId
+        }
+        if ($matches.Count -gt 1) {
+            throw "Multiple present Airspy devices found during re-enumeration. Re-run with -DeviceInstanceId using one of:`n$($matches.InstanceId -join "`n")"
+        }
+
+        Start-Sleep -Milliseconds 500
+    }
+
+    return $null
+}
+
+if (-not (Test-IsAdmin)) {
+    throw "Run this script from an elevated PowerShell session (Run as Administrator)."
+}
+
+$resolvedInstanceId = Resolve-AirspyInstanceId -PreferredInstanceId $DeviceInstanceId
+$resolvedAirspyInfoPath = Resolve-RepoPath -RelativePath $AirspyInfoPath
+
+Write-Host "ScriptVersion: $ScriptVersion"
+Write-Host "Effective ReenumerationTimeoutSeconds: $ReenumerationTimeoutSeconds"
+Write-Host "Using DeviceInstanceId: $resolvedInstanceId"
+Write-Host "Using airspy_info path: $resolvedAirspyInfoPath"
+
+Write-Host "=== Device status (before) ==="
+ $before = Get-PnpDevice -InstanceId $resolvedInstanceId | Select-Object Status, Class, FriendlyName, Service, Present, InstanceId
+ $before | Format-List
+
+$isPresent = $false
+if ($null -ne $before.Present) {
+    try {
+        $isPresent = [System.Convert]::ToBoolean($before.Present)
+    }
+    catch {
+        $isPresent = ($before.Present.ToString().Trim().ToLowerInvariant() -eq "true")
+    }
+}
+Write-Host "Evaluated Present: $isPresent"
+
+if ($isPresent) {
+    Write-Host "=== Attempting restart-device ==="
+    pnputil /restart-device "$resolvedInstanceId"
+}
+else {
+    Write-Host "=== Device is not currently present; skipping restart and waiting for re-enumeration/replug ==="
+}
+
+Write-Host "=== Scanning for devices ==="
+pnputil /scan-devices
+
+Write-Host "=== Waiting for re-enumeration (up to $ReenumerationTimeoutSeconds s) ==="
+$presentInstanceId = Wait-ForDevicePresent -InstanceId $resolvedInstanceId -TimeoutSeconds $ReenumerationTimeoutSeconds
+if (-not $presentInstanceId) {
+    throw "Device did not re-enumerate within timeout. Unplug/replug Airspy, then rerun this script with -ReenumerationTimeoutSeconds 60."
+}
+
+$resolvedInstanceId = $presentInstanceId
+Write-Host "Re-enumerated DeviceInstanceId: $resolvedInstanceId"
+
+Write-Host "=== Device status (after restart) ==="
+Get-PnpDevice -InstanceId $resolvedInstanceId | Select-Object Status, Class, FriendlyName, Service, Present | Format-List
+
+Invoke-AirspyInfo -Path $resolvedAirspyInfoPath


### PR DESCRIPTION
The pure-Go Airspy driver used a systematically wrong vendor request
opcode table, so opening an Airspy failed with "set sample rate failed:
protocol error". GET_SAMPLERATES hit SET_FREQ (opcode 13), leaving the
rate table empty, and SET_SAMPLERATE sent opcode 14 (really SET_LNA_GAIN)
as a vendor-OUT with no data, which the firmware NAK'd (EPROTO).

Adopt the fixes from PR #380 (by @VA7DBI, smoke-tested on real Airspy R2):

- Renumber the vendor opcodes to match libairspy's airspy_commands enum
  (SET_SAMPLERATE=12, SET_FREQ=13, gain opcodes 14-18, SET_RF_BIAS=20,
  GPIO_WRITE=21, GET_SAMPLERATES=25); drop the bogus SET_SAMPLE_TYPE.
- SetSampleRate is now a vendor-IN transfer with the rate index/value in
  wIndex, reading one byte back.
- Sample type is host-side only; bias-tee uses a GPIO write (port 1, pin 13).
- Open resets the receiver first and retries on transient device-gone errors.
- Pool serial matching normalises "AIRSPY SN:" / "airspy_sn:" aliases.
- Windows WinUSB interface-recipient / associated-interface control-transfer
  fallback, opt-in real-hardware tests, and CSV USB tracing.

Also fix a regression the serialKey normaliser introduced in the
missing-serial warning: log the operator's original serial, not the
lowercased key.

Co-authored-by: VA7DBI <92030801+VA7DBI@users.noreply.github.com>