### PR TITLE
Fix #598: play live audio via Web Audio instead of <audio> element

### DIFF
--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -213,13 +213,13 @@ export async function probe(cfg: ClientConfig): Promise<Health> {
   return await api.health(cfg);
 }
 
-// audioStreamURL composes the URL of the live PCM stream. Browsers
-// cannot attach an Authorization header to <audio> elements, so we
-// pass the token (if any) as a query parameter is *not* supported by
-// the daemon — instead, deployments that require auth must serve the
-// stream from a trusted-network bind (auto mode) or use the
-// fetch + AudioWorklet path which can supply headers. For the simple
-// <audio> tag path we rely on the daemon's "reads are open" policy.
+// audioStreamURL composes the URL of the live PCM stream. The WebUI
+// player (see ../audio/streamPlayer.ts) fetches this URL and decodes the
+// WAV body through the Web Audio API, so it can attach the
+// Authorization: Bearer header on auth-gated daemons — the old hidden
+// <audio> element could not, which is why the stream had to be served
+// from a trusted-network bind. The token is sent as a header by the
+// fetch, never as a query parameter, so it stays out of access logs.
 export function audioStreamURL(
   cfg: ClientConfig,
   filter: { device?: string; talkgroup?: number } = {},

--- a/web/src/audio/streamPlayer.test.ts
+++ b/web/src/audio/streamPlayer.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseWavHeader,
+  int16ToFloat32,
+  PcmFramer,
+  WAV_HEADER_SIZE,
+} from "./streamPlayer";
+
+// Build a canonical 44-byte RIFF/WAVE header byte-for-byte the way the
+// daemon does in internal/api/handlers_audio_stream.go
+// (streamingWAVHeader): 16-bit little-endian mono PCM at the given rate.
+// Pinning the layout here is the whole point — the framer's offsets must
+// match the server's.
+function makeHeader(sampleRate: number): Uint8Array {
+  const buf = new Uint8Array(WAV_HEADER_SIZE);
+  const dv = new DataView(buf.buffer);
+  const ascii = (off: number, s: string) => {
+    for (let i = 0; i < s.length; i++) buf[off + i] = s.charCodeAt(i);
+  };
+  const dataSize = 0x7fffffff;
+  ascii(0, "RIFF");
+  dv.setUint32(4, dataSize - 36, true);
+  ascii(8, "WAVE");
+  ascii(12, "fmt ");
+  dv.setUint32(16, 16, true);
+  dv.setUint16(20, 1, true); // PCM
+  dv.setUint16(22, 1, true); // mono
+  dv.setUint32(24, sampleRate, true);
+  dv.setUint32(28, (sampleRate * 1 * 16) / 8, true);
+  dv.setUint16(32, 2, true);
+  dv.setUint16(34, 16, true);
+  ascii(36, "data");
+  dv.setUint32(40, dataSize, true);
+  return buf;
+}
+
+// Encode int16 samples to a little-endian byte buffer.
+function pcmBytes(samples: number[]): Uint8Array {
+  const buf = new Uint8Array(samples.length * 2);
+  const dv = new DataView(buf.buffer);
+  samples.forEach((s, i) => dv.setInt16(i * 2, s, true));
+  return buf;
+}
+
+function concat(...parts: Uint8Array[]): Uint8Array {
+  const total = parts.reduce((n, p) => n + p.length, 0);
+  const out = new Uint8Array(total);
+  let off = 0;
+  for (const p of parts) {
+    out.set(p, off);
+    off += p.length;
+  }
+  return out;
+}
+
+describe("parseWavHeader", () => {
+  it("extracts the format from a canonical 8 kHz header", () => {
+    const fmt = parseWavHeader(makeHeader(8000));
+    expect(fmt).toEqual({ sampleRate: 8000, channels: 1, bitsPerSample: 16 });
+  });
+
+  it("reads the sample rate from the header (not hardcoded)", () => {
+    expect(parseWavHeader(makeHeader(16000))?.sampleRate).toBe(16000);
+  });
+
+  it("returns null when fewer than 44 bytes are buffered", () => {
+    expect(parseWavHeader(makeHeader(8000).subarray(0, 30))).toBeNull();
+  });
+
+  it("throws on bad RIFF magic", () => {
+    const bad = makeHeader(8000);
+    bad[0] = "X".charCodeAt(0);
+    expect(() => parseWavHeader(bad)).toThrow(/RIFF/);
+  });
+
+  it("throws on bad WAVE magic", () => {
+    const bad = makeHeader(8000);
+    bad[8] = "X".charCodeAt(0);
+    expect(() => parseWavHeader(bad)).toThrow(/WAVE/);
+  });
+});
+
+describe("int16ToFloat32", () => {
+  it("maps boundary values into [-1, 1)", () => {
+    const out = int16ToFloat32(pcmBytes([0, -32768, 32767, 1]));
+    expect(out[0]).toBe(0);
+    expect(out[1]).toBe(-1);
+    expect(out[2]).toBeCloseTo(0.99997, 4);
+    expect(out[3]).toBeCloseTo(1 / 32768, 8);
+  });
+
+  it("decodes little-endian byte order", () => {
+    // 0x0100 little-endian = 1.
+    const out = int16ToFloat32(new Uint8Array([0x01, 0x00]));
+    expect(out[0]).toBeCloseTo(1 / 32768, 8);
+  });
+});
+
+describe("PcmFramer", () => {
+  it("decodes header + samples delivered in one chunk", () => {
+    const f = new PcmFramer();
+    f.feed(concat(makeHeader(8000), pcmBytes([100, -100, 200])));
+    expect(f.format).toBeNull(); // not parsed until takeSamples
+    const got = f.takeSamples();
+    expect(f.format?.sampleRate).toBe(8000);
+    expect(Array.from(got!)).toEqual([100 / 32768, -100 / 32768, 200 / 32768]);
+  });
+
+  it("waits for the header to fully arrive across feeds", () => {
+    const f = new PcmFramer();
+    const header = makeHeader(8000);
+    f.feed(header.subarray(0, 30));
+    expect(f.takeSamples()).toBeNull();
+    expect(f.format).toBeNull();
+    f.feed(header.subarray(30));
+    f.feed(pcmBytes([7]));
+    const got = f.takeSamples();
+    expect(f.format?.sampleRate).toBe(8000);
+    expect(Array.from(got!)).toEqual([7 / 32768]);
+  });
+
+  it("carries a trailing odd byte to the next feed", () => {
+    const f = new PcmFramer();
+    const body = pcmBytes([300, 400]); // 4 bytes
+    f.feed(concat(makeHeader(8000), body.subarray(0, 3))); // header + 3 bytes
+    expect(Array.from(f.takeSamples()!)).toEqual([300 / 32768]); // 1 sample, 1 byte held
+    expect(f.takeSamples()).toBeNull(); // odd byte alone is not a sample
+    f.feed(body.subarray(3)); // completes the second sample
+    expect(Array.from(f.takeSamples()!)).toEqual([400 / 32768]);
+  });
+
+  it("reconstructs an int16 split across the chunk boundary", () => {
+    const f = new PcmFramer();
+    const body = pcmBytes([-12345]);
+    f.feed(concat(makeHeader(8000), body.subarray(0, 1))); // low byte only
+    expect(f.takeSamples()).toBeNull();
+    f.feed(body.subarray(1)); // high byte
+    expect(Array.from(f.takeSamples()!)).toEqual([-12345 / 32768]);
+  });
+
+  it("byte-by-byte feeds yield the same result as one big feed", () => {
+    const stream = concat(
+      makeHeader(8000),
+      pcmBytes([1, -2, 3, -4, 5, -6, 7, -8]),
+    );
+
+    const bulk = new PcmFramer();
+    bulk.feed(stream);
+    const bulkOut = Array.from(bulk.takeSamples()!);
+
+    const drip = new PcmFramer();
+    const dripOut: number[] = [];
+    for (const byte of stream) {
+      drip.feed(new Uint8Array([byte]));
+      const got = drip.takeSamples();
+      if (got) dripOut.push(...got);
+    }
+    expect(dripOut).toEqual(bulkOut);
+  });
+
+  it("ignores empty chunks", () => {
+    const f = new PcmFramer();
+    f.feed(new Uint8Array(0));
+    f.feed(concat(makeHeader(8000), pcmBytes([42])));
+    f.feed(new Uint8Array(0));
+    expect(Array.from(f.takeSamples()!)).toEqual([42 / 32768]);
+  });
+});

--- a/web/src/audio/streamPlayer.ts
+++ b/web/src/audio/streamPlayer.ts
@@ -1,0 +1,332 @@
+// Live-audio player for the WebUI. Streams the daemon's continuous WAV
+// body (GET /api/v1/audio/stream) and plays it through the Web Audio
+// API instead of a hidden <audio> element.
+//
+// Issue #598: the <audio src=stream> approach failed silently in Chrome
+// on macOS — an open-ended chunked "infinite WAV" is unreliable for the
+// media element, and the failure was swallowed in a console.warn. A
+// fetch() reader + AudioContext is deterministic across Chrome / Firefox
+// / Safari, sidesteps the whole <audio>/Range/206/Content-Length class
+// of bugs, works the same whether or not a reverse proxy sits in front,
+// and (unlike <audio>) can send the Authorization: Bearer header for
+// auth-gated daemons.
+//
+// The wire format is a 44-byte canonical RIFF/WAVE header (16-bit
+// little-endian mono PCM, sample rate in header bytes 24-28) followed by
+// concatenated raw int16 samples — see streamingWAVHeader in
+// internal/api/handlers_audio_stream.go. The byte-framing logic below
+// must match that layout.
+
+// ---------------------------------------------------------------------------
+// Pure, testable framing helpers (no DOM / AudioContext).
+// ---------------------------------------------------------------------------
+
+export interface WavFormat {
+  sampleRate: number;
+  channels: number;
+  bitsPerSample: number;
+}
+
+/** Size of the canonical RIFF/WAVE header the daemon emits. */
+export const WAV_HEADER_SIZE = 44;
+
+// parseWavHeader validates the RIFF/WAVE magic and extracts the audio
+// format from the first 44 bytes. Returns null when fewer than 44 bytes
+// are buffered (the caller should wait for more), and throws when the
+// magic is wrong so a corrupt stream surfaces as a visible error rather
+// than playing noise.
+export function parseWavHeader(bytes: Uint8Array): WavFormat | null {
+  if (bytes.length < WAV_HEADER_SIZE) return null;
+  const ascii = (off: number, len: number) =>
+    String.fromCharCode(...bytes.subarray(off, off + len));
+  if (ascii(0, 4) !== "RIFF") {
+    throw new Error(`bad WAV header: expected RIFF, got "${ascii(0, 4)}"`);
+  }
+  if (ascii(8, 4) !== "WAVE") {
+    throw new Error(`bad WAV header: expected WAVE, got "${ascii(8, 4)}"`);
+  }
+  const dv = new DataView(bytes.buffer, bytes.byteOffset, WAV_HEADER_SIZE);
+  return {
+    channels: dv.getUint16(22, true),
+    sampleRate: dv.getUint32(24, true),
+    bitsPerSample: dv.getUint16(34, true),
+  };
+}
+
+// int16ToFloat32 converts a little-endian int16 PCM byte buffer to
+// Float32 samples in [-1, 1). The input length must be even; callers use
+// PcmFramer to guarantee that.
+export function int16ToFloat32(bytes: Uint8Array): Float32Array {
+  const count = bytes.length >> 1;
+  const out = new Float32Array(count);
+  const dv = new DataView(bytes.buffer, bytes.byteOffset, count * 2);
+  for (let i = 0; i < count; i++) {
+    out[i] = dv.getInt16(i * 2, true) / 32768;
+  }
+  return out;
+}
+
+// PcmFramer reassembles the WAV stream from arbitrarily-sized network
+// reads. A chunk boundary can fall anywhere — mid-header, or between the
+// two bytes of an int16 sample — so the framer accumulates bytes,
+// consumes the 44-byte header exactly once, and only ever yields whole
+// samples, carrying a trailing odd byte forward to the next chunk.
+export class PcmFramer {
+  private buf = new Uint8Array(0);
+  private fmt: WavFormat | null = null;
+
+  /** The parsed WAV format, or null until the 44-byte header arrives. */
+  get format(): WavFormat | null {
+    return this.fmt;
+  }
+
+  /** Append a network chunk. Cheap; decoding happens in takeSamples. */
+  feed(chunk: Uint8Array): void {
+    if (chunk.length === 0) return;
+    const next = new Uint8Array(this.buf.length + chunk.length);
+    next.set(this.buf, 0);
+    next.set(chunk, this.buf.length);
+    this.buf = next;
+  }
+
+  // takeSamples drains every whole int16 sample currently buffered (after
+  // the header) and returns it as Float32. Returns null when the header
+  // hasn't fully arrived yet or there isn't at least one whole sample.
+  takeSamples(): Float32Array | null {
+    if (this.fmt === null) {
+      const fmt = parseWavHeader(this.buf);
+      if (fmt === null) return null; // header still incomplete
+      this.fmt = fmt;
+      this.buf = this.buf.subarray(WAV_HEADER_SIZE);
+    }
+    const whole = this.buf.length - (this.buf.length % 2);
+    if (whole < 2) return null; // no complete sample yet
+    const samples = int16ToFloat32(this.buf.subarray(0, whole));
+    this.buf = this.buf.subarray(whole); // keep the trailing odd byte (if any)
+    return samples;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// AudioContext-backed streaming controller.
+// ---------------------------------------------------------------------------
+
+export type PlayerState =
+  | "idle"
+  | "connecting"
+  | "playing"
+  | "stopped"
+  | "error";
+
+export interface StreamPlayerOptions {
+  url: string;
+  token: string | null;
+  onError: (msg: string) => void;
+  onStateChange: (state: PlayerState) => void;
+}
+
+export interface StreamPlayer {
+  /** Must be invoked synchronously from a user-gesture handler so the
+   *  AudioContext resume isn't rejected by the autoplay policy. */
+  start(): void;
+  stop(): void;
+  setVolume(v: number): void;
+  setMuted(muted: boolean): void;
+}
+
+// Lead time before the first scheduled buffer — a small jitter cushion so
+// brief network hiccups don't cause audible gaps.
+const LEAD_SECONDS = 0.15;
+// Upper bound on scheduled-ahead audio; past this we realign so a burst
+// of buffered frames doesn't pin latency high for the rest of the call.
+const MAX_LEAD_SECONDS = 0.6;
+// Backoff before a single reconnect attempt when the stream ends on its
+// own (e.g. the daemon restarted) while the user still wants audio.
+const RECONNECT_DELAY_MS = 1000;
+
+type AudioContextCtor = typeof AudioContext;
+
+function resolveAudioContext(): AudioContextCtor | null {
+  const w = window as unknown as {
+    AudioContext?: AudioContextCtor;
+    webkitAudioContext?: AudioContextCtor;
+  };
+  return w.AudioContext ?? w.webkitAudioContext ?? null;
+}
+
+// createStreamPlayer wires a fetch reader to a GainNode → destination
+// graph. One instance owns one AudioContext (reused across reconnects)
+// and at most one in-flight fetch.
+export function createStreamPlayer(
+  opts: StreamPlayerOptions,
+): StreamPlayer {
+  let ctx: AudioContext | null = null;
+  let gain: GainNode | null = null;
+  let abort: AbortController | null = null;
+  let nextStartTime = 0;
+  let volume = 1;
+  let muted = false;
+  let userStopped = false;
+  let reconnectTimer: number | null = null;
+
+  const applyGain = () => {
+    if (gain && ctx) {
+      gain.gain.setTargetAtTime(muted ? 0 : volume, ctx.currentTime, 0.01);
+    }
+  };
+
+  const ensureGraph = (): boolean => {
+    if (ctx === null) {
+      const Ctor = resolveAudioContext();
+      if (Ctor === null) {
+        opts.onError("Web Audio is not supported in this browser");
+        opts.onStateChange("error");
+        return false;
+      }
+      ctx = new Ctor();
+    }
+    if (gain === null) {
+      gain = ctx.createGain();
+      gain.connect(ctx.destination);
+    }
+    applyGain();
+    return true;
+  };
+
+  const schedule = (samples: Float32Array, sampleRate: number) => {
+    if (ctx === null || gain === null || samples.length === 0) return;
+    const buffer = ctx.createBuffer(1, samples.length, sampleRate);
+    buffer.getChannelData(0).set(samples);
+    const src = ctx.createBufferSource();
+    src.buffer = buffer;
+    src.connect(gain);
+
+    const now = ctx.currentTime;
+    if (nextStartTime < now + 0.001) {
+      // Underrun (or first buffer): we've fallen behind real time. Resync
+      // forward with a fresh lead cushion rather than scheduling in the
+      // past (which the API clamps to "now" and stacks).
+      nextStartTime = now + LEAD_SECONDS;
+    } else if (nextStartTime > now + MAX_LEAD_SECONDS) {
+      // Too far ahead (a burst drained in one tick): pull the cursor back
+      // so latency doesn't grow unbounded for the rest of the call.
+      nextStartTime = now + MAX_LEAD_SECONDS;
+    }
+    src.start(nextStartTime);
+    nextStartTime += buffer.duration;
+  };
+
+  const run = async () => {
+    abort = new AbortController();
+    opts.onStateChange("connecting");
+    let res: Response;
+    try {
+      res = await fetch(opts.url, {
+        headers: opts.token
+          ? { Authorization: `Bearer ${opts.token}` }
+          : {},
+        credentials: "include",
+        signal: abort.signal,
+      });
+    } catch (err) {
+      if (isAbort(err)) return;
+      fail(`stream request failed: ${describe(err)}`);
+      return;
+    }
+    if (!res.ok) {
+      fail(`stream HTTP ${res.status}`);
+      return;
+    }
+    if (!res.body) {
+      fail("stream response had no body");
+      return;
+    }
+
+    const framer = new PcmFramer();
+    const reader = res.body.getReader();
+    nextStartTime = 0;
+    let started = false;
+    try {
+      for (;;) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        if (!value) continue;
+        framer.feed(value);
+        const fmt = framer.format;
+        for (;;) {
+          const samples = framer.takeSamples();
+          if (samples === null) break;
+          const rate = framer.format?.sampleRate ?? fmt?.sampleRate ?? 8000;
+          schedule(samples, rate);
+          if (!started) {
+            started = true;
+            opts.onStateChange("playing");
+          }
+        }
+      }
+    } catch (err) {
+      if (isAbort(err)) return;
+      fail(`stream read failed: ${describe(err)}`);
+      return;
+    }
+
+    // The stream ended on its own. If the user still wants audio (didn't
+    // press stop), try a single reconnect after a short backoff to ride
+    // out a daemon restart.
+    opts.onStateChange("stopped");
+    if (!userStopped) {
+      reconnectTimer = window.setTimeout(() => {
+        reconnectTimer = null;
+        if (!userStopped) void run();
+      }, RECONNECT_DELAY_MS);
+    }
+  };
+
+  const fail = (msg: string) => {
+    opts.onError(msg);
+    opts.onStateChange("error");
+  };
+
+  return {
+    start() {
+      userStopped = false;
+      if (reconnectTimer !== null) {
+        window.clearTimeout(reconnectTimer);
+        reconnectTimer = null;
+      }
+      if (!ensureGraph() || ctx === null) return;
+      // Resume synchronously within the gesture so the autoplay policy
+      // doesn't reject playback. fetch() is awaited inside run().
+      void ctx.resume();
+      void run();
+    },
+    stop() {
+      userStopped = true;
+      if (reconnectTimer !== null) {
+        window.clearTimeout(reconnectTimer);
+        reconnectTimer = null;
+      }
+      abort?.abort();
+      abort = null;
+      void ctx?.suspend();
+      opts.onStateChange("stopped");
+    },
+    setVolume(v: number) {
+      volume = Math.max(0, Math.min(1, v));
+      applyGain();
+    },
+    setMuted(m: boolean) {
+      muted = m;
+      applyGain();
+    },
+  };
+}
+
+function isAbort(err: unknown): boolean {
+  return err instanceof DOMException && err.name === "AbortError";
+}
+
+function describe(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}

--- a/web/src/components/AudioPlayer.tsx
+++ b/web/src/components/AudioPlayer.tsx
@@ -1,21 +1,26 @@
 import { useEffect, useRef, useState } from "react";
 import { audioStreamURL } from "../api/client";
+import { createStreamPlayer, type StreamPlayer } from "../audio/streamPlayer";
 import { writes } from "../api/write";
 import { selectClientConfig, useShared } from "../store/shared";
 import { prefs } from "../store/prefs";
 
 // AudioPlayer is a floating, dismissable mini-player that streams
-// /api/v1/audio/stream into a long-lived <audio> element. iOS and
-// Android both require a user gesture before audio starts playing,
-// so the first activation goes through a "Tap to enable audio"
-// button. Once unlocked the player auto-resumes whenever the SPA
-// regains focus or the daemon reconnects.
+// /api/v1/audio/stream through the Web Audio API. iOS and Android both
+// require a user gesture before audio starts playing, so the first
+// activation goes through a "Tap to enable audio" button.
+//
+// Issue #598: this used to point a hidden <audio> element at the stream
+// URL, which failed silently in Chrome on macOS (an open-ended chunked
+// "infinite WAV" is unreliable for the media element). We now fetch the
+// stream and play the decoded PCM through an AudioContext — see
+// ../audio/streamPlayer.ts — which is robust across browsers and lets us
+// send the Authorization header for auth-gated daemons. Failures surface
+// as a visible chip rather than a swallowed console.warn.
 //
 // Mobile niceties:
 //   - Media Session API lights up the OS lock-screen / control
 //     center with track-style metadata pulled from the active call.
-//   - The audio tag's `preload=none` + manual `src` swap keeps iOS
-//     from auto-starting the stream when the browser is reopened.
 export function AudioPlayer() {
   const cfg = useShared(selectClientConfig);
   const activeCalls = useShared((s) => s.activeCalls);
@@ -23,7 +28,8 @@ export function AudioPlayer() {
   const [muted, setMuted] = useState(false);
   const [volume, setVolume] = useState(prefs.audioVolume());
   const [recording, setRecording] = useState<boolean | null>(null);
-  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const playerRef = useRef<StreamPlayer | null>(null);
 
   // Reflect the daemon's current audio state into the local toggles.
   const daemonAudio = useShared((s) => s.audio);
@@ -50,44 +56,56 @@ export function AudioPlayer() {
     });
   }, [activeCalls]);
 
-  const enable = async () => {
-    const el = audioRef.current;
-    if (!el || !cfg.baseURL) return;
-    el.src = audioStreamURL(cfg);
-    el.volume = volume;
-    el.muted = false;
-    try {
-      await el.play();
-      setEnabled(true);
-    } catch (err) {
-      // Autoplay blocked, or the media failed to load (e.g. a server
-      // without Range support trips Safari). Surface it so the failure
-      // isn't invisible; the next user gesture will retry.
-      console.warn("AudioPlayer: enable failed", err);
-      setEnabled(false);
-    }
+  // Tear the player down when the target daemon (URL or token) changes
+  // so a stale stream from the previous server doesn't keep playing.
+  useEffect(() => {
+    return () => {
+      playerRef.current?.stop();
+      playerRef.current = null;
+    };
+  }, [cfg]);
+
+  // enable must stay synchronous: createStreamPlayer().start() resumes
+  // the AudioContext inside this gesture so the autoplay policy doesn't
+  // reject playback.
+  const enable = () => {
+    if (!cfg.baseURL) return;
+    setError(null);
+    playerRef.current?.stop();
+    const player = createStreamPlayer({
+      url: audioStreamURL(cfg),
+      token: cfg.token,
+      onError: (msg) => {
+        setError(msg);
+        setEnabled(false);
+      },
+      onStateChange: (state) => {
+        setEnabled(state === "playing" || state === "connecting");
+      },
+    });
+    playerRef.current = player;
+    player.setVolume(volume);
+    player.setMuted(muted);
+    player.start();
+    setEnabled(true);
   };
 
   const disable = () => {
-    const el = audioRef.current;
-    if (el) {
-      el.pause();
-      el.removeAttribute("src");
-      el.load();
-    }
+    playerRef.current?.stop();
+    playerRef.current = null;
     setEnabled(false);
   };
 
   const onVolume = (v: number) => {
     setVolume(v);
     prefs.setAudioVolume(v);
-    if (audioRef.current) audioRef.current.volume = v;
+    playerRef.current?.setVolume(v);
   };
 
   const toggleMute = async () => {
     const next = !muted;
     setMuted(next);
-    if (audioRef.current) audioRef.current.muted = next;
+    playerRef.current?.setMuted(next);
     try {
       await writes.setAudio(cfg, { muted: next });
     } catch {
@@ -109,14 +127,26 @@ export function AudioPlayer() {
   return (
     <div className="fixed sm:bottom-3 bottom-16 right-3 z-30 panel p-3 flex items-center gap-2 max-w-[calc(100%-1.5rem)]">
       {!enabled ? (
-        <button
-          type="button"
-          onClick={enable}
-          className="btn-primary text-xs"
-          aria-label="Enable audio"
-        >
-          <span aria-hidden>▶</span> Tap to enable audio
-        </button>
+        <>
+          <button
+            type="button"
+            onClick={enable}
+            className="btn-primary text-xs"
+            aria-label="Enable audio"
+          >
+            <span aria-hidden>▶</span>{" "}
+            {error ? "Audio failed — tap to retry" : "Tap to enable audio"}
+          </button>
+          {error && (
+            <span
+              role="alert"
+              title={error}
+              className="text-xs text-red-400 max-w-[12rem] truncate"
+            >
+              ⚠ {error}
+            </span>
+          )}
+        </>
       ) : (
         <>
           <button
@@ -162,21 +192,6 @@ export function AudioPlayer() {
           </button>
         </>
       )}
-      <audio
-        ref={audioRef}
-        preload="none"
-        playsInline
-        onError={(e) => {
-          console.warn(
-            "AudioPlayer: media error",
-            e.currentTarget.error,
-          );
-        }}
-        // Keep the player on-screen but visually empty; controls are
-        // bespoke above so the lockscreen MediaSession is the only
-        // public surface.
-        className="hidden"
-      />
     </div>
   );
 }


### PR DESCRIPTION
The "Tap to enable audio" button did nothing in Chrome on macOS. The
hidden <audio src="/api/v1/audio/stream"> element cannot reliably play
the daemon's open-ended chunked "infinite WAV", and the failure was
swallowed in a console.warn, so the UI just sat still. The prior Range
fix (#601) targeted Safari and did not help Chrome — the issue predated
it and reproduced under both the 200 and 206 paths, confirming the HTTP
layer was not the cause.

Replace the <audio> element with a fetch()-based Web Audio player:

- New web/src/audio/streamPlayer.ts: pure framing helpers
  (parseWavHeader, int16ToFloat32, PcmFramer that reassembles the WAV
  header and int16 samples across arbitrary chunk boundaries) plus a
  createStreamPlayer controller that reads response.body, decodes PCM,
  and schedules gapless AudioBuffers through a GainNode with a small
  jitter buffer and underrun resync. Reads the sample rate from the WAV
  header rather than hardcoding 8 kHz.
- AudioPlayer.tsx: drive the controller; resume the AudioContext inside
  the click gesture; surface failures as a visible "Audio failed — tap
  to retry" chip instead of a silent console.warn; tear down on server
  switch.
- The fetch path sends Authorization: Bearer, so the stream now works on
  auth-gated daemons (the <audio> element could not attach the header).

No backend change: a plain fetch() sends no Range header and uses the
handler's existing 200 chunked path. Adds streamPlayer.test.ts covering
header/sample split boundaries and odd-byte carryover.

https://claude.ai/code/session_01AiMMEhvcBbwprw4G1Mu7fW