### PR TITLE
docs: post-release v0.3.8 — promote CHANGELOG, bump refs, announcement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,36 @@ for tagged releases.
 
 ## [Unreleased]
 
+## [v0.3.8] — 2026-06-10
+
+This release adds a pure-Go **LoRa / LoRaWAN receiver** (#586) and hardens the
+daemon and several hardware paths. One SDR is channelized into parallel LoRa
+sub-channels and decoded through the full PHY (dechirp/FFT, Gray/de-interleave/
+Hamming FEC, de-whitening, CRC) with SF7–SF12 auto-detection; LoRaWAN 1.0.x
+frames are MAC-decoded and, with operator session keys, MIC-verified and
+decrypted, persisted to `lora_log`, served at `GET /api/v1/lora/frames`, and
+rendered on a new `/lora` panel. Recording gains an opt-in
+`recordings.skip_encrypted` flag (#607). The daemon **never stops silently**
+anymore — component panics are recovered and logged, and a soft memory limit
+plus a runtime heartbeat bound and surface the process footprint (#606, #492).
+On the fix side: P25 IMBE female-voice intelligibility and a high-pitched
+recording onset (#605), Airspy USB initialisation (#454), HackRF
+interface-claim on macOS (#511), live-audio playback in Chrome via Web Audio
+(#598), and the symbol-domain scopes now default to the control SDR (#402).
+
 ### Added
 
+- **Skip recording encrypted calls** (#607). A new opt-in
+  `recordings.skip_encrypted` flag suppresses WAV/raw files for calls the
+  operator can't decode (default `false` keeps recording everything; the call
+  log still notes encryption). The recorder gates at call start when a
+  control-channel grant already flags encryption (P25 Phase 1, DMR, NXDN,
+  EDACS, TETRA), and mid-call when encryption only surfaces on the traffic
+  channel (P25 Phase 1 LDU2 Encryption Sync, or a P25 Phase 2 compressed
+  grant) — the in-progress files are closed and deleted and no `CallComplete`
+  is published, so the partial never reaches the upload feeds. Wired through
+  the YAML config, the settings PATCH API + YAML writer, the TUI settings
+  panel, and the web Config Builder.
 - **LoRa decoding** (#586). A new pure-Go, zero-CGO LoRa receiver decodes the
   LoRa physical layer (chirp dechirp/FFT demodulation, preamble/sync/SFD
   acquisition with carrier-offset and timing recovery, Gray/de-interleave/
@@ -20,6 +48,21 @@ for tagged releases.
   Configure under `lora.channels`; decoded frames persist to the `lora_log`
   table, are served at `GET /api/v1/lora/frames`, and render live on the new
   `/lora` web panel.
+
+### Changed
+
+- **Daemon never stops silently + bounded memory footprint** (#606, #492). A
+  live run could halt mid-decode with no shutdown/fatal/panic line — the
+  hallmark of an external SIGKILL (OS memory-pressure killer) or an unrecovered
+  goroutine panic. The daemon now installs a deferred `log.Recover()` panic
+  guard on the component spawn path, the daemon-run and IQ-capture goroutines,
+  the rtltcp reader, the iqtap fanout, and all four composer voice chains, so a
+  panic becomes a logged ERROR + clean shutdown instead of a process kill. A
+  soft memory limit is set at startup (`GOMEMLIMIT` → `diagnostics.memory_limit_mb`
+  → ~70 % of physical RAM), a periodic runtime heartbeat
+  (`diagnostics.heartbeat_seconds`, default 60 s) logs uptime/goroutines/heap so
+  a leak or pre-kill footprint is visible in the timeline, and `net/http/pprof`
+  is available behind `GOPHERTRUNK_PPROF`.
 
 ### Fixed
 
@@ -54,6 +97,30 @@ for tagged releases.
   hints. Includes opt-in real-hardware tests (`make test-airspy-real`) and a
   Windows WinUSB interface-recipient/associated-interface control-transfer
   fallback.
+- **HackRF now claims its USB interface on macOS** (#511). The pure-Go USB
+  backend enumerated a HackRF but failed to claim interface 0, returning
+  `kIOReturnUnsupported` — `ClaimInterface` passed the device user-client type
+  ID, but an interface service requires `kIOUSBInterfaceUserClientTypeID`. The
+  interface path now uses the interface UUID (the device-open path keeps the
+  device UUID).
+- **Live audio plays in Chrome via Web Audio** (#598). The "Tap to enable
+  audio" button did nothing in Chrome on macOS: the hidden `<audio>` element
+  couldn't reliably play the daemon's open-ended chunked "infinite WAV", and
+  the failure was swallowed. The web player now reads the stream with `fetch()`
+  and a Web Audio pipeline (a `PcmFramer` reassembles the WAV header and int16
+  samples across chunk boundaries, scheduling gapless buffers through a jitter
+  buffer with underrun resync), surfaces failures as a visible "Audio failed —
+  tap to retry" chip, reads the sample rate from the WAV header, and sends the
+  bearer token so auth-gated daemons work. No backend change.
+- **Symbol-domain scopes default to the control SDR** (#402). The Eye Diagram,
+  Symbol Scope, Tuning, and Histogram panels each defaulted to the first
+  enumerated device, which on a multi-SDR rig is often an idle voice/aux
+  dongle, so a panel opened during active control-channel decode showed
+  nothing. A new `defaultSymbolDevice()` prefers the control-role device
+  (falling back to the first entry) for the initial selection in all four
+  panels. Also adds an MMR City clean-decode regression fixture
+  (`TestReplayMMRCityDecodesCleanP25`) that guards the C4FM path against
+  future regressions.
 
 ## [v0.3.7] — 2026-06-09
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ this exist? Read **[The Story of GopherTrunk](https://gophertrunk.org/story.html
 
 ```sh
 # Linux x86_64 — see https://gophertrunk.org/downloads.html for macOS, Windows, ARM64.
-VERSION=v0.3.7
+VERSION=v0.3.8
 curl -L -o gophertrunk.tar.gz \
   https://github.com/MattCheramie/GopherTrunk/releases/download/${VERSION}/gophertrunk-${VERSION}-linux-amd64.tar.gz
 tar xzf gophertrunk.tar.gz && cd gophertrunk-${VERSION}-linux-amd64

--- a/docs/announcements/v0.3.8.md
+++ b/docs/announcements/v0.3.8.md
@@ -1,0 +1,51 @@
+# GopherTrunk v0.3.8 — social announcement drafts
+
+One-click copy-paste blurbs for posting the v0.3.8 release. Each block
+below is a fenced code block so the rendered-markdown "copy" button
+grabs exactly what you'd paste.
+
+Release: https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.3.8
+
+---
+
+## Reddit — title
+
+```
+GopherTrunk v0.3.8 — a pure-Go LoRa / LoRaWAN receiver, a daemon that never stops silently, skip-recording for encrypted calls, and intelligible P25 female voice
+```
+
+## Reddit — body
+
+```markdown
+**[GopherTrunk](https://gophertrunk.org) v0.3.8 is out** — pure-Go digital-trunking scanner for RTL-SDR / HackRF / Airspy. P25 (Phase 1+2), DMR (AMBE+2 voice), NXDN, Motorola Type II, EDACS, LTR, MPT 1327, dPMR, D-STAR, YSF, M17, plus APRS, POCSAG + FLEX paging, and AIS / DSC / ADS-B. No CGO, single static binary for Linux / macOS / Windows.
+
+**What's new since v0.3.7:**
+
+* **Pure-Go LoRa / LoRaWAN receiver** (#586) — a zero-CGO LoRa PHY (chirp dechirp/FFT demod, preamble/sync/SFD acquisition with carrier-offset and timing recovery, Gray/de-interleave/Hamming FEC, de-whitening, CRC) with spreading-factor auto-detection across SF7–SF12 and 125/250/500 kHz bandwidths. One SDR is split into several parallel LoRa sub-channels via the tuner channelizer/DDC bank. LoRaWAN 1.0.x frames are MAC-decoded and, when you supply operator session keys, the MIC is verified and the payload decrypted (no key recovery). Configure under `lora.channels`; frames persist to `lora_log`, serve at `GET /api/v1/lora/frames`, and render live on a new `/lora` panel.
+* **The daemon never stops silently anymore** (#606) — component panics are recovered and logged (clean shutdown instead of a process kill), a soft memory limit is set at startup (`GOMEMLIMIT` / `diagnostics.memory_limit_mb` / ~70% of RAM), and a periodic runtime heartbeat logs uptime/goroutines/heap so a leak or pre-kill footprint shows up in the timeline. Opt-in pprof behind `GOPHERTRUNK_PPROF`.
+* **Skip recording encrypted calls** (#607) — opt-in `recordings.skip_encrypted` suppresses WAV/raw files for calls you can't decode, gating both at the control-channel grant and mid-call when encryption surfaces on the traffic channel, so partials never reach the upload feeds. Default off keeps recording everything.
+* **Intelligible P25 IMBE female voice** (#605) — a follow-up to the §6.3 voiced-phase regeneration: the phase dispersion is now a bounded per-frame offset on a coherent phase memory, scaled by the unvoiced-harmonic fraction, so mostly-voiced (high-pitch) speech stays intelligible and the high-pitched recording onset is gone.
+* **Hardware + browser fixes** — Airspy USB initialisation corrected against libairspy's command set (#454), HackRF now claims its USB interface on macOS (#511), live audio plays in Chrome via a new Web Audio player (#598), and the Eye/Symbol/Tuning/Histogram scopes default to the control SDR instead of an idle dongle (#402).
+
+**Downloads** (Linux / macOS / Windows, x64 + ARM64): https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.3.8
+
+**Docs:** https://gophertrunk.org
+
+Heads-up: the v0.x line is still flagged prerelease — actively developed, feedback / captures / bug reports very welcome.
+```
+
+## Discord
+
+```markdown
+**GopherTrunk v0.3.8 is out** — pure-Go trunking scanner for RTL-SDR / HackRF / Airspy. P25, DMR, NXDN, M17, analog trunked, APRS, POCSAG + FLEX paging, AIS / DSC / ADS-B. Single static binary, zero CGO.
+
+**What's new since v0.3.7:**
+- **Pure-Go LoRa / LoRaWAN receiver** (#586) — full LoRa PHY (dechirp/FFT, FEC, de-whitening, CRC) with SF7–SF12 auto-detect and 125/250/500 kHz, one SDR channelized into parallel sub-channels; LoRaWAN 1.0.x MAC decode + optional MIC-verify/decrypt with session keys. New `/lora` panel + `GET /api/v1/lora/frames`.
+- **Daemon never stops silently** (#606) — panic recovery + clean shutdown, soft memory limit, runtime heartbeat, opt-in pprof.
+- **Skip recording encrypted calls** (#607) — opt-in `recordings.skip_encrypted`, gated at grant and mid-call.
+- **Intelligible P25 IMBE female voice** (#605) — coherent bounded phase dispersion scaled by the unvoiced fraction; high-pitched onset fixed.
+- **Fixes:** Airspy USB init (#454), HackRF interface-claim on macOS (#511), Chrome live audio via Web Audio (#598), symbol scopes default to the control SDR (#402).
+
+Download: <https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.3.8>
+Docs: <https://gophertrunk.org>
+```

--- a/docs/downloads.md
+++ b/docs/downloads.md
@@ -28,7 +28,7 @@ release state looks like:
 {%- elsif site.github.releases and site.github.releases[0] and site.github.releases[0].tag_name -%}
   {%- assign ver = site.github.releases[0].tag_name -%}
 {%- else -%}
-  {%- assign ver = "v0.3.7" -%}
+  {%- assign ver = "v0.3.8" -%}
 {%- endif -%}
 {%- assign rel_url = "https://github.com/MattCheramie/GopherTrunk/releases/download/" | append: ver -%}
 


### PR DESCRIPTION
Now that the daily release workflow tagged v0.3.8, sync the docs:

- CHANGELOG: promote [Unreleased] to [v0.3.8] (2026-06-10) with a release
  summary, and backfill the user-visible changes that shipped without a
  changelog entry — recordings.skip_encrypted (#607), the daemon
  never-stop-silently + bounded-memory work (#606), HackRF USB
  interface-claim on macOS (#511), Chrome live audio via Web Audio (#598),
  and symbol-domain scopes defaulting to the control SDR (#402).
- README: bump the Linux quick-install VERSION to v0.3.8.
- downloads.md: bump the GitHub Pages fallback version to v0.3.8.
- announcements: add the v0.3.8 social blurb drafts.