### PR TITLE
Fix #598: stream live audio even when the publisher has no cached grant

### DIFF
--- a/internal/api/audio_publisher.go
+++ b/internal/api/audio_publisher.go
@@ -69,6 +69,13 @@ type audioSubscriber struct {
 	// channel insight that lets clients tell whether they fell
 	// behind vs. the publisher being slow).
 	dropped atomic.Uint64
+	// loggedFan / loggedFull gate one-shot diagnostics so a hot
+	// WritePCM loop logs at most once per subscriber for "first
+	// frame delivered" and "channel full, dropping" — enough to
+	// confirm from the logs whether live audio is flowing without
+	// spamming every chunk.
+	loggedFan  atomic.Bool
+	loggedFull atomic.Bool
 }
 
 // NewAudioPublisher constructs a publisher backed by the supplied
@@ -154,35 +161,77 @@ func (p *AudioPublisher) Stats() AudioPublisherStats {
 	}
 }
 
-// WritePCM satisfies composer.PCMSink. Builds one AudioFrame per
-// call and fans it to every subscriber whose filter matches. A
-// missing Grant (composer wrote PCM before CallStart landed) drops
-// the frame silently — the publisher only emits frames that carry
-// full talkgroup context.
+// WritePCM satisfies composer.PCMSink. It fans live PCM to every
+// subscriber whose filter matches, INDEPENDENT of whether a CallStart
+// grant has been observed for this device.
+//
+// The grant cache is fed by the publisher's own events-bus
+// subscription, which the bus can drop under load (full channel) — and
+// on a busy control channel with multiple voice taps that happens often
+// enough that gating audio on it left the WebUI live stream silent
+// while disk recordings (a separate, grant-free PCM sink) kept working
+// (issue #598). Neither stream consumer reads the frame's Grant for its
+// payload: the HTTP handler writes raw PCM samples and gRPC StreamAudio
+// forwards the frame verbatim. So when the grant is unknown we still
+// emit the PCM with a zero Grant. Unfiltered and device-serial-only
+// subscribers receive it; only talkgroup-filtered subscribers are
+// skipped, since their predicate can't be evaluated without a known
+// GroupID and we must not leak another talkgroup's audio to them.
+//
+// The frame is built lazily on the first matching subscriber so the
+// no-subscriber and no-match paths stay allocation-free.
 func (p *AudioPublisher) WritePCM(deviceSerial string, samples []int16) error {
 	if p == nil || len(samples) == 0 {
 		return nil
 	}
 	p.mu.RLock()
-	grant, ok := p.grants[deviceSerial]
-	if !ok || len(p.subs) == 0 {
-		p.mu.RUnlock()
+	defer p.mu.RUnlock()
+	if len(p.subs) == 0 {
 		return nil
 	}
-	frame := buildPCMFrame(grant, deviceSerial, samples)
+	grant, haveGrant := p.grants[deviceSerial]
+
+	var frame *apiv1.AudioFrame // built on first match
 	for sub := range p.subs {
+		// A talkgroup filter needs a known GroupID to evaluate;
+		// without a grant we can't prove a match, so skip rather than
+		// risk leaking unrelated audio.
+		if len(sub.filter.TalkgroupIDs) > 0 && !haveGrant {
+			continue
+		}
 		if !sub.filter.matches(deviceSerial, grant.GroupID) {
 			continue
 		}
+		if frame == nil {
+			frame = buildPCMFrame(grant, deviceSerial, samples)
+		}
 		select {
 		case sub.ch <- frame:
+			p.markFanned(sub)
 		default:
 			sub.dropped.Add(uint64(len(samples)))
 			p.dropped.Add(uint64(len(samples)))
+			p.markChannelFull(sub)
 		}
 	}
-	p.mu.RUnlock()
 	return nil
+}
+
+// markFanned logs once, the first time a subscriber actually receives a
+// PCM frame — a cheap "live audio is flowing" signal for operators.
+func (p *AudioPublisher) markFanned(sub *audioSubscriber) {
+	if sub.loggedFan.CompareAndSwap(false, true) {
+		p.log.Debug("audio: first PCM frame fanned to subscriber")
+	}
+}
+
+// markChannelFull logs once, the first time a subscriber's bounded
+// channel overflows — surfaces a slow/stalled consumer without spamming
+// a log line per dropped chunk.
+func (p *AudioPublisher) markChannelFull(sub *audioSubscriber) {
+	if sub.loggedFull.CompareAndSwap(false, true) {
+		p.log.Warn("audio: subscriber channel full, dropping PCM (slow consumer)")
+	}
 }
 
 // Subscribe registers a new subscriber and returns its frame
@@ -197,7 +246,12 @@ func (p *AudioPublisher) Subscribe(filter AudioSubFilter) *audioSubscriber {
 	}
 	p.mu.Lock()
 	p.subs[sub] = struct{}{}
+	n := len(p.subs)
 	p.mu.Unlock()
+	p.log.Debug("audio subscriber connected",
+		"device_serials", filter.DeviceSerials,
+		"talkgroup_ids", filter.TalkgroupIDs,
+		"subscribers", n)
 	return sub
 }
 
@@ -209,11 +263,17 @@ func (p *AudioPublisher) Unsubscribe(sub *audioSubscriber) {
 		return
 	}
 	p.mu.Lock()
+	removed := false
 	if _, ok := p.subs[sub]; ok {
 		delete(p.subs, sub)
 		close(sub.ch)
+		removed = true
 	}
+	n := len(p.subs)
 	p.mu.Unlock()
+	if removed {
+		p.log.Debug("audio subscriber disconnected", "subscribers", n)
+	}
 }
 
 // matches reports whether this subscriber wants a frame for the

--- a/internal/api/audio_publisher_test.go
+++ b/internal/api/audio_publisher_test.go
@@ -80,20 +80,84 @@ func TestAudioPublisher_WritePCMFansToMatchingSubs(t *testing.T) {
 	}
 }
 
-func TestAudioPublisher_DropsWhenNoGrant(t *testing.T) {
+// Issue #598 regression: PCM must reach an unfiltered subscriber even
+// when no CallStart grant has been observed for the device. The grant
+// cache rides a lossy bus subscription; gating audio on it left the
+// WebUI live stream silent while disk recordings worked. The frame
+// carries a zero Grant in that case.
+func TestAudioPublisher_FansUnfilteredWithoutGrant(t *testing.T) {
 	pub, _ := mkPublisher(t)
 	sub := pub.Subscribe(AudioSubFilter{})
 	defer pub.Unsubscribe(sub)
 
 	// No CallStart published — the publisher's grant map is empty.
-	if err := pub.WritePCM("VOICE-1", []int16{1, 2, 3}); err != nil {
+	if err := pub.WritePCM("VOICE-1", []int16{1, -2, 3}); err != nil {
 		t.Fatalf("WritePCM: %v", err)
 	}
 	select {
+	case frame := <-sub.ch:
+		if frame.DeviceSerial != "VOICE-1" {
+			t.Errorf("device_serial = %q, want VOICE-1", frame.DeviceSerial)
+		}
+		if pcm := frame.GetPcm(); pcm == nil || len(pcm.Samples) != 6 {
+			t.Errorf("samples = %v, want 6 bytes (3 int16)", pcm.GetSamples())
+		}
+		if gid := frame.GetGrant().GetGroupId(); gid != 0 {
+			t.Errorf("grant.group_id = %d, want 0 (zero grant)", gid)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("subscriber received no frame despite open stream")
+	}
+}
+
+// A device-serial-only filter still works without a grant: matching
+// serials are delivered, non-matching serials are not.
+func TestAudioPublisher_DeviceFilterFansWithoutGrant(t *testing.T) {
+	pub, _ := mkPublisher(t)
+	sub := pub.Subscribe(AudioSubFilter{DeviceSerials: []string{"VOICE-1"}})
+	defer pub.Unsubscribe(sub)
+
+	pub.WritePCM("VOICE-2", []int16{9, 9}) // filtered out
+	pub.WritePCM("VOICE-1", []int16{1, 2}) // delivered
+
+	select {
+	case frame := <-sub.ch:
+		if frame.DeviceSerial != "VOICE-1" {
+			t.Errorf("got serial %q, want VOICE-1", frame.DeviceSerial)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("device-filtered subscriber received no frame")
+	}
+	select {
 	case f := <-sub.ch:
-		t.Errorf("got frame %v despite no Grant", f)
+		t.Errorf("got unexpected frame for %q", f.DeviceSerial)
 	case <-time.After(50 * time.Millisecond):
 		// pass
+	}
+}
+
+// A talkgroup filter cannot be evaluated without a grant, so frames are
+// withheld until a matching CallStart lands — then they flow.
+func TestAudioPublisher_TalkgroupFilterSkippedWithoutGrant(t *testing.T) {
+	pub, bus := mkPublisher(t)
+	sub := pub.Subscribe(AudioSubFilter{TalkgroupIDs: []uint32{100}})
+	defer pub.Unsubscribe(sub)
+
+	pub.WritePCM("VOICE-1", []int16{1, 2})
+	select {
+	case f := <-sub.ch:
+		t.Fatalf("TG-filtered subscriber got frame %v before any grant", f)
+	case <-time.After(50 * time.Millisecond):
+		// pass — no grant, can't match talkgroup
+	}
+
+	publishCallStart(t, pub, bus, "VOICE-1", trunking.Grant{GroupID: 100})
+	pub.WritePCM("VOICE-1", []int16{3, 4})
+	select {
+	case <-sub.ch:
+		// pass — grant now known, talkgroup matches
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("TG-filtered subscriber got no frame after matching grant")
 	}
 }
 

--- a/internal/api/handlers_audio.go
+++ b/internal/api/handlers_audio.go
@@ -30,6 +30,21 @@ type AudioStatusDTO struct {
 	// DropsTotal is a monotonically increasing counter of PCM
 	// samples lost because the playback queue was full.
 	DropsTotal uint64 `json:"drops_total"`
+	// StreamSubscribers is the number of live /audio/stream + gRPC
+	// StreamAudio consumers currently connected. A WebUI "Tap to
+	// enable audio" tap that produced no sound should still show >=1
+	// here while the tab is open — letting an operator tell a wiring
+	// problem apart from "no call is active". Zero when no publisher
+	// is wired.
+	StreamSubscribers int `json:"stream_subscribers"`
+	// StreamDropsTotal is the cumulative PCM samples dropped to slow
+	// stream subscribers (distinct from DropsTotal, which counts the
+	// host playback queue).
+	StreamDropsTotal uint64 `json:"stream_drops_total"`
+	// StreamTrackedGrants is the number of device serials the
+	// publisher currently has call context for. PCM still streams
+	// without a tracked grant (issue #598); this is a diagnostic.
+	StreamTrackedGrants int `json:"stream_tracked_grants"`
 }
 
 // audioPatchRequest is the body of PATCH /api/v1/audio. Every field
@@ -54,7 +69,14 @@ func (s *Server) handleAudioStatus(w http.ResponseWriter, _ *http.Request) {
 		s.writeError(w, http.StatusServiceUnavailable, "audio not wired")
 		return
 	}
-	writeJSON(w, http.StatusOK, audioStatusDTO(s.audio))
+	dto := audioStatusDTO(s.audio)
+	if s.audioPub != nil {
+		st := s.audioPub.Stats()
+		dto.StreamSubscribers = st.Subscribers
+		dto.StreamDropsTotal = st.DroppedTotal
+		dto.StreamTrackedGrants = st.TrackedGrants
+	}
+	writeJSON(w, http.StatusOK, dto)
 }
 
 // handleAudioPatch applies one or more cockpit mutations and returns

--- a/internal/api/handlers_audio_stream_test.go
+++ b/internal/api/handlers_audio_stream_test.go
@@ -158,6 +158,72 @@ func TestAudioStream_EmitsWAVHeaderAndPCM(t *testing.T) {
 	}
 }
 
+// Issue #598 end-to-end: the live HTTP stream must deliver PCM bytes
+// even when no CallStart grant was observed (the WebUI player opens an
+// unfiltered stream and the grant cache rides a lossy bus). Mirrors
+// TestAudioStream_EmitsWAVHeaderAndPCM but deliberately omits the
+// CallStart publish.
+func TestAudioStream_EmitsPCMWithoutCallStart(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	pub, err := NewAudioPublisher(bus, slog.Default())
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = pub.Run(ctx) }()
+	defer pub.Close()
+
+	fa := newFakeAudio()
+	base, teardown := mkServer(t, ServerOptions{Bus: bus, Audio: fa, AudioPublisher: pub})
+	defer teardown()
+
+	reqCtx, reqCancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer reqCancel()
+	req, _ := http.NewRequestWithContext(reqCtx, http.MethodGet, base+"/api/v1/audio/stream", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d want 200", resp.StatusCode)
+	}
+
+	header := make([]byte, 44)
+	if _, err := io.ReadFull(resp.Body, header); err != nil {
+		t.Fatalf("read header: %v", err)
+	}
+
+	// No CallStart — write PCM straight away. Give the open stream a
+	// moment to register its subscription, then drive samples.
+	time.Sleep(50 * time.Millisecond)
+	samples := []int16{1, -1, 2, -2, 3, -3, 4, -4}
+	for i := 0; i < 4; i++ {
+		_ = pub.WritePCM("unmapped-sdr", samples)
+	}
+
+	got := make([]byte, 0, 256)
+	buf := make([]byte, 256)
+	deadline := time.Now().Add(1 * time.Second)
+	for time.Now().Before(deadline) {
+		n, err := resp.Body.Read(buf)
+		if n > 0 {
+			got = append(got, buf[:n]...)
+		}
+		if err != nil {
+			break
+		}
+		if len(got) >= len(samples)*2 {
+			break
+		}
+	}
+	if len(got) < 2 {
+		t.Fatalf("did not receive PCM bytes without a CallStart (got %d)", len(got))
+	}
+}
+
 func TestParseRange(t *testing.T) {
 	cases := []struct {
 		name      string

--- a/internal/api/handlers_audio_test.go
+++ b/internal/api/handlers_audio_test.go
@@ -2,7 +2,9 @@ package api
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"log/slog"
 	"math"
 	"net/http"
 	"sync/atomic"
@@ -94,6 +96,40 @@ func TestAudioStatus_OK(t *testing.T) {
 	}
 	if !body.RecordingEnabled {
 		t.Errorf("recording_enabled = false")
+	}
+}
+
+// GET /api/v1/audio surfaces live-stream publisher health so an
+// operator can confirm consumers are attached (issue #598 diagnostics).
+func TestAudioStatus_ExposesPublisherStats(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	pub, err := NewAudioPublisher(bus, slog.Default())
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = pub.Run(ctx) }()
+	defer pub.Close()
+
+	base, teardown := mkServer(t, ServerOptions{Bus: bus, Audio: newFakeAudio(), AudioPublisher: pub})
+	defer teardown()
+
+	sub := pub.Subscribe(AudioSubFilter{})
+	defer pub.Unsubscribe(sub)
+
+	resp, err := http.Get(base + "/api/v1/audio")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	var body AudioStatusDTO
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.StreamSubscribers < 1 {
+		t.Errorf("stream_subscribers = %d, want >= 1", body.StreamSubscribers)
 	}
 }
 


### PR DESCRIPTION
The WebUI "Tap to enable audio" produced no sound (Chrome on macOS),
while disk recordings worked and the status showed 8.0 kHz. The two
prior fixes (HTTP Range/206, fetch+Web Audio) targeted the wrong layer:
the backend was never sending PCM bytes for the affected calls.

Root cause: AudioPublisher.WritePCM dropped all PCM unless it had a
cached grant for the device serial. That grant cache is fed by the
publisher's own events-bus subscription, and events.Bus.Publish drops
events into any subscriber channel that is momentarily full (buffer 64).
On a busy control channel — especially with more than one voice tap,
which raises the concurrent call/event rate — the publisher can miss a
CallStart, leaving grants[serial] unset and silencing the live stream
for that call. The disk recorder is a separate, grant-free PCM sink,
which is why recordings kept working.

Neither stream consumer reads the frame's Grant for its payload (the
HTTP handler writes raw PCM samples; gRPC StreamAudio forwards the frame
verbatim), so the grant requirement was pure fragility. WritePCM now
fans PCM to unfiltered and device-serial-only subscribers regardless of
grant state, emitting a zero Grant when none is cached. Talkgroup-
filtered subscribers are still skipped without a grant, since their
predicate can't be evaluated without a known GroupID.

Also surface publisher health on GET /api/v1/audio (stream_subscribers,
stream_drops_total, stream_tracked_grants) and add one-shot debug/warn
logs on first-frame-delivered and channel-full, so a silent stream can
be diagnosed from the status JSON and logs instead of guesswork.

Tests: replace TestAudioPublisher_DropsWhenNoGrant (asserted the old,
now-incorrect behavior) with no-grant fan, device-filter, and
talkgroup-skip regressions; add an end-to-end HTTP stream test that
delivers PCM without a CallStart and a status-stats test. gRPC
StreamAudio tests stay green, confirming zero-grant frames are tolerated.