### PR TITLE
fix(airspy): convert real ADC stream to complex IQ (#454)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ for tagged releases.
 
 ## [Unreleased]
 
+### Fixed
+- Airspy R2 / Mini now decode correctly (#454). The driver treated the
+  receiver's real ADC stream as interleaved I/Q, producing a huge quadrature
+  imbalance (~78°) and no image rejection (~3 dB) so nothing locked. The Airspy
+  is a real-sampling front end: its samples are now converted to complex
+  baseband on the host (Fs/4 translation + half-band Hilbert, decimate-by-two),
+  matching libairspy's IQ modes and restoring image rejection (~70 dB).
+
 ## [v0.3.8] — 2026-06-10
 
 This release adds a pure-Go **LoRa / LoRaWAN receiver** (#586) and hardens the

--- a/internal/sdr/airspy/airspy.go
+++ b/internal/sdr/airspy/airspy.go
@@ -8,9 +8,12 @@
 // documented follow-up; the in-package tests exercise the wire
 // protocol against a usb.MockTransport.
 //
-// Sample format: this driver pins the device to INT16_IQ — signed
-// 16-bit interleaved IQ pairs (4 bytes per sample) — and converts each
-// pair to a complex64 with components in [-1, 1].
+// Sample format: the Airspy R2 / Mini are real-sampling receivers — the
+// firmware streams bare ADC samples (unpacked little-endian uint16, 12-bit,
+// DC at 2048) at twice the configured IQ rate. This driver converts that real
+// stream to complex64 baseband on the host via the [iqConverter] (an Fs/4
+// translation plus a half-band Hilbert pair, decimating by two), matching what
+// libairspy does in its IQ sample modes.
 package airspy
 
 import (
@@ -44,12 +47,6 @@ const (
 	reqSetMixerAGC    uint8 = 18
 	reqGPIOWrite      uint8 = 21
 	reqGetSamplerates uint8 = 25
-)
-
-// Sample-type values for reqSetSampleType.
-const (
-	sampleTypeFloat32IQ uint16 = 0
-	sampleTypeInt16IQ   uint16 = 2
 )
 
 const (
@@ -212,12 +209,6 @@ func (d *Driver) openDevice(desc usb.Descriptor, idx int, serial string) (*Devic
 	return dev, nil
 }
 
-func setSampleTypeInt16(usb.Transport) error {
-	// libairspy no longer issues a USB command here; it keeps sample type
-	// as host-side conversion state.
-	return nil
-}
-
 func (d *Driver) refreshDescriptor(current usb.Descriptor) (usb.Descriptor, bool) {
 	list, err := d.enum.List(vidAirspy, pidAirspy)
 	if err != nil || len(list) == 0 {
@@ -255,7 +246,8 @@ type Device struct {
 	mu        sync.Mutex
 	closed    bool
 	streaming bool
-	rates     []uint32 // supported sample rates, Hz, descending order
+	rates     []uint32     // supported sample rates, Hz, descending order
+	cnv       *iqConverter // real-to-IQ converter, fresh per stream
 }
 
 // Info implements sdr.Device.
@@ -439,15 +431,10 @@ func (d *Device) StreamIQ(ctx context.Context) (<-chan []complex64, error) {
 	d.streaming = true
 	d.mu.Unlock()
 
-	// Apply INT16_IQ at stream start rather than open time. This keeps
-	// Open resilient on hosts that reject early vendor OUT transfers,
-	// while still pinning the wire format before bulk IQ starts.
-	if err := setSampleTypeInt16(d.t); err != nil {
-		d.mu.Lock()
-		d.streaming = false
-		d.mu.Unlock()
-		return nil, fmt.Errorf("airspy: set sample type: %w", err)
-	}
+	// Fresh real-to-IQ converter per stream so filter memory never carries
+	// over from a previous session. The device streams bare real samples;
+	// the converter turns them into complex baseband (see iqconverter.go).
+	d.cnv = newIQConverter()
 
 	if err := d.setReceiver(receiverModeOn); err != nil {
 		d.mu.Lock()
@@ -458,7 +445,7 @@ func (d *Device) StreamIQ(ctx context.Context) (<-chan []complex64, error) {
 
 	out := make(chan []complex64, 8)
 	onPacket := func(buf []byte) {
-		samples := decodeInt16IQ(buf)
+		samples := d.cnv.processRaw(buf)
 		select {
 		case out <- samples:
 		case <-ctx.Done():
@@ -552,17 +539,4 @@ func (d *Device) fetchSampleRates() ([]uint32, error) {
 		rates[i] = binary.LittleEndian.Uint32(listBytes[4*i:])
 	}
 	return rates, nil
-}
-
-// decodeInt16IQ converts a libairspy INT16_IQ payload (interleaved
-// little-endian signed 16-bit I,Q) into normalised complex64.
-func decodeInt16IQ(buf []byte) []complex64 {
-	n := len(buf) / 4
-	out := make([]complex64, n)
-	for i := 0; i < n; i++ {
-		iv := int16(binary.LittleEndian.Uint16(buf[4*i:]))
-		qv := int16(binary.LittleEndian.Uint16(buf[4*i+2:]))
-		out[i] = complex(float32(iv)/32768, float32(qv)/32768)
-	}
-	return out
 }

--- a/internal/sdr/airspy/airspy_test.go
+++ b/internal/sdr/airspy/airspy_test.go
@@ -3,10 +3,13 @@ package airspy
 import (
 	"context"
 	"encoding/binary"
+	"math"
+	"math/cmplx"
 	"testing"
 	"time"
 
 	"github.com/MattCheramie/GopherTrunk/internal/sdr"
+	"github.com/MattCheramie/GopherTrunk/internal/sdr/rtlsdr"
 	"github.com/MattCheramie/GopherTrunk/internal/sdr/rtlsdr/usb"
 )
 
@@ -291,23 +294,81 @@ func TestSetBiasTeeRoundTrips(t *testing.T) {
 	}
 }
 
-func TestDecodeInt16IQ(t *testing.T) {
-	// Two samples: (+32767, -32768) → ~(1,-1); (0,0) → (0,0).
-	buf := make([]byte, 8)
-	binary.LittleEndian.PutUint16(buf[0:2], uint16(int16(32767)))
-	var minI16 int16 = -32768
-	binary.LittleEndian.PutUint16(buf[2:4], uint16(minI16))
-	binary.LittleEndian.PutUint16(buf[4:6], 0)
-	binary.LittleEndian.PutUint16(buf[6:8], 0)
-	got := decodeInt16IQ(buf)
-	if len(got) != 2 {
-		t.Fatalf("len = %d, want 2", len(got))
+// realToneBuf renders n real ADC samples (unpacked little-endian uint16,
+// 12-bit, DC at 2048) of a cosine at fHz given sampleHz, as the device would
+// stream them.
+func realToneBuf(n int, fHz, sampleHz float64) []byte {
+	buf := make([]byte, 2*n)
+	for i := 0; i < n; i++ {
+		v := math.Cos(2 * math.Pi * fHz * float64(i) / sampleHz)
+		s := uint16(2048 + 2000*v) // stay inside the 12-bit range
+		binary.LittleEndian.PutUint16(buf[2*i:], s)
 	}
-	if real(got[0]) <= 0.99 || imag(got[0]) > -0.99 {
-		t.Errorf("sample 0 = (%f,%f); want near (1,-1)", real(got[0]), imag(got[0]))
+	return buf
+}
+
+func TestIQConverterDecimatesByTwo(t *testing.T) {
+	// 4096 real samples (8192 bytes) → 2048 complex samples.
+	buf := realToneBuf(4096, 1_000_000, 5_000_000)
+	got := newIQConverter().processRaw(buf)
+	if len(got) != 2048 {
+		t.Fatalf("processRaw len = %d, want 2048", len(got))
 	}
-	if got[1] != 0 {
-		t.Errorf("sample 1 = %v; want 0", got[1])
+}
+
+// TestIQConverterRejectsImage is the regression gate for issue #454: feeding a
+// real tone through the converter must yield a clean analytic (single-sided)
+// complex stream. Before the fix the driver read real samples as interleaved
+// I/Q, which the reporter saw as ~+78° phase imbalance and ~3.3 dB image
+// rejection. We measure the same quantities here and require quadrature.
+func TestIQConverterRejectsImage(t *testing.T) {
+	const (
+		hwRate = 5_000_000 // hardware rate (2× the 2.5 MSPS IQ rate)
+		tone   = 1_000_000 // real tone inside the half-band passband
+		nReal  = 1 << 18
+	)
+	out := newIQConverter().processRaw(realToneBuf(nReal, tone, hwRate))
+
+	// Skip the filter warm-up so transient settling doesn't skew the stats.
+	out = out[hbTaps:]
+
+	var st rtlsdr.IQImbalanceStats
+	st.Observe(out)
+
+	if phase := math.Abs(st.PhaseImbalanceDeg()); phase > 1.0 {
+		t.Errorf("phase imbalance = %.3f°, want < 1° (issue #454 saw +78°)", phase)
+	}
+	if rej := st.ImageRejectionDB(); rej < 40 {
+		t.Errorf("image rejection = %.1f dB, want > 40 dB (issue #454 saw 3.3 dB)", rej)
+	}
+}
+
+// TestIQConverterContinuousAcrossPackets confirms the converter's filter state
+// carries across packet boundaries: streaming a tone in many small packets
+// must match converting it in one shot.
+func TestIQConverterContinuousAcrossPackets(t *testing.T) {
+	buf := realToneBuf(1<<16, 700_000, 5_000_000)
+
+	oneShot := newIQConverter().processRaw(buf)
+
+	split := newIQConverter()
+	var chunked []complex64
+	const step = 1024 // bytes per packet (512 real samples, multiple of 4)
+	for off := 0; off < len(buf); off += step {
+		end := off + step
+		if end > len(buf) {
+			end = len(buf)
+		}
+		chunked = append(chunked, split.processRaw(buf[off:end])...)
+	}
+
+	if len(chunked) != len(oneShot) {
+		t.Fatalf("chunked len = %d, one-shot len = %d", len(chunked), len(oneShot))
+	}
+	for i := range oneShot {
+		if d := cmplx.Abs(complex128(oneShot[i] - chunked[i])); d > 1e-6 {
+			t.Fatalf("sample %d differs by %g: one-shot=%v chunked=%v", i, d, oneShot[i], chunked[i])
+		}
 	}
 }
 

--- a/internal/sdr/airspy/iqconverter.go
+++ b/internal/sdr/airspy/iqconverter.go
@@ -1,0 +1,133 @@
+package airspy
+
+import "encoding/binary"
+
+// The Airspy R2 / Mini are real-sampling receivers: the firmware streams the
+// bare ADC output — unpacked little-endian uint16 real samples (12-bit, DC at
+// 2048) — at twice the advertised IQ rate. Producing complex baseband is a
+// host-side job. This file implements that conversion from first principles
+// using the standard real-to-IQ technique for a real-IF front end:
+//
+//  1. remove the ADC DC bias with a leaky high-pass,
+//  2. translate by Fs/4 (a free, multiplier-less mix by (-j)^n),
+//  3. split into the two polyphase half-rate streams and apply a half-band
+//     filter pair — a symmetric low-pass on the in-phase branch, a matched
+//     integer delay on the quadrature branch — which together reject the
+//     mirror image, and
+//  4. decimate by two.
+//
+// N real input samples therefore yield N/2 complex64 outputs at half the
+// hardware rate, i.e. the configured IQ sample rate. The converter is
+// stateful: its filter memory and DC tracker carry across USB packets so
+// there is no discontinuity at buffer boundaries.
+//
+// The half-band coefficients below are a standard 47-tap half-band design
+// (zero on the odd taps except the unity-ish centre); only the 24 non-trivial
+// taps participate in the in-phase FIR, with the 0.5 centre tap folded into
+// the quadrature branch during the Fs/4 mix.
+
+const (
+	hbTaps = 24   // non-trivial half-band taps used by the in-phase FIR
+	hbHalf = 12   // quadrature delay length (hbTaps / 2)
+	dcLeak = 0.01 // leaky DC-blocker coefficient
+	dcBias = 2048 // 12-bit unsigned ADC midpoint
+	dcFull = 2048 // normalisation to roughly [-1, 1)
+)
+
+// hbKernel is the symmetric half-band low-pass applied to the in-phase branch
+// (the even-indexed taps of the canonical 47-tap half-band; the largest taps
+// sit in the middle, giving the filter its group delay).
+var hbKernel = [hbTaps]float32{
+	-0.000998606272947510, 0.001695637278417295, -0.003054430179754289,
+	0.005055504379767936, -0.007901319195893647, 0.011873357051047719,
+	-0.017411159379930066, 0.025304817427568772, -0.037225225204559217,
+	0.057533286997004301, -0.102327462004259350, 0.317034472508947400,
+	0.317034472508947400, -0.102327462004259350, 0.057533286997004301,
+	-0.037225225204559217, 0.025304817427568772, -0.017411159379930066,
+	0.011873357051047719, -0.007901319195893647, 0.005055504379767936,
+	-0.003054430179754289, 0.001695637278417295, -0.000998606272947510,
+}
+
+// iqConverter holds the running state of the real-to-IQ conversion.
+type iqConverter struct {
+	avg     float32          // leaky DC-blocker accumulator
+	phase   int              // Fs/4 mix phase, 0..3, persists across packets
+	iwin    [hbTaps]float32  // in-phase FIR window (newest written at iwinPos)
+	iwinPos int              // next write position in iwin
+	lastI   float32          // in-phase output awaiting its paired quadrature
+	qline   [hbHalf]float32  // quadrature delay line
+	qpos    int              // delay-line read/write cursor
+}
+
+// newIQConverter returns a converter in its reset state. The zero value is a
+// valid starting point (silent filter memory, phase 0).
+func newIQConverter() *iqConverter { return &iqConverter{} }
+
+// processRaw decodes one bulk-IN payload of little-endian uint16 real samples
+// into complex64 baseband. It returns len(buf)/4 complex samples (two real
+// samples collapse to one complex sample).
+func (c *iqConverter) processRaw(buf []byte) []complex64 {
+	nReal := len(buf) / 2
+	out := make([]complex64, 0, nReal/2+1)
+	for i := 0; i < nReal; i++ {
+		x := (float32(binary.LittleEndian.Uint16(buf[2*i:])) - dcBias) / dcFull
+
+		// Leaky DC blocker: removes the residual ADC bias before the mix.
+		x -= c.avg
+		c.avg += dcLeak * x
+
+		switch c.phase {
+		case 0, 2:
+			// In-phase branch. The Fs/4 mix alternates the sign of the
+			// even samples; push into the FIR and recompute its output.
+			if c.phase == 0 {
+				x = -x
+			}
+			c.pushI(x)
+			c.lastI = c.firI()
+		case 1, 3:
+			// Quadrature branch. The mix alternates sign and folds in the
+			// 0.5 half-band centre tap; the matched delay aligns it with
+			// the in-phase FIR's group delay, then we emit one sample.
+			q := 0.5 * x
+			if c.phase == 1 {
+				q = -q
+			}
+			qOut := c.qline[c.qpos]
+			c.qline[c.qpos] = q
+			if c.qpos++; c.qpos >= hbHalf {
+				c.qpos = 0
+			}
+			out = append(out, complex(c.lastI, qOut))
+		}
+		if c.phase++; c.phase >= 4 {
+			c.phase = 0
+		}
+	}
+	return out
+}
+
+// pushI stores the newest in-phase sample in the circular FIR window.
+func (c *iqConverter) pushI(v float32) {
+	c.iwin[c.iwinPos] = v
+	if c.iwinPos++; c.iwinPos >= hbTaps {
+		c.iwinPos = 0
+	}
+}
+
+// firI evaluates the symmetric half-band FIR over the current window, with
+// hbKernel[0] weighting the newest sample and hbKernel[hbTaps-1] the oldest.
+func (c *iqConverter) firI() float32 {
+	var acc float32
+	idx := c.iwinPos - 1
+	if idx < 0 {
+		idx += hbTaps
+	}
+	for j := 0; j < hbTaps; j++ {
+		acc += hbKernel[j] * c.iwin[idx]
+		if idx--; idx < 0 {
+			idx += hbTaps
+		}
+	}
+	return acc
+}

--- a/internal/sdr/airspy/iqconverter.go
+++ b/internal/sdr/airspy/iqconverter.go
@@ -50,13 +50,13 @@ var hbKernel = [hbTaps]float32{
 
 // iqConverter holds the running state of the real-to-IQ conversion.
 type iqConverter struct {
-	avg     float32          // leaky DC-blocker accumulator
-	phase   int              // Fs/4 mix phase, 0..3, persists across packets
-	iwin    [hbTaps]float32  // in-phase FIR window (newest written at iwinPos)
-	iwinPos int              // next write position in iwin
-	lastI   float32          // in-phase output awaiting its paired quadrature
-	qline   [hbHalf]float32  // quadrature delay line
-	qpos    int              // delay-line read/write cursor
+	avg     float32         // leaky DC-blocker accumulator
+	phase   int             // Fs/4 mix phase, 0..3, persists across packets
+	iwin    [hbTaps]float32 // in-phase FIR window (newest written at iwinPos)
+	iwinPos int             // next write position in iwin
+	lastI   float32         // in-phase output awaiting its paired quadrature
+	qline   [hbHalf]float32 // quadrature delay line
+	qpos    int             // delay-line read/write cursor
 }
 
 // newIQConverter returns a converter in its reset state. The zero value is a


### PR DESCRIPTION
The Airspy R2 / Mini are real-sampling receivers: the firmware streams
bare ADC samples (unpacked uint16, 12-bit, DC at 2048) at twice the
configured IQ rate. The driver was reading those real samples as
interleaved I/Q pairs, so two adjacent real samples were paired as I
and Q. The reporter saw the signature exactly: ~+78 deg quadrature
imbalance and ~3.3 dB image rejection, and nothing locked.

Add a host-side real-to-IQ converter (Fs/4 translation + half-band
Hilbert pair, decimate-by-two) and feed the bulk-IN stream through it,
matching what libairspy does in its IQ sample modes. The converter is
stateful across USB packets so there is no discontinuity at buffer
boundaries. Implemented independently from standard DSP; the half-band
coefficients are a canonical filter design.

Drops the dead INT16_IQ path (setSampleTypeInt16, sample-type consts,
decodeInt16IQ). New unit tests assert 2:1 decimation, packet-boundary
continuity, and — reproducing the issue's metrics — phase imbalance
< 1 deg and image rejection > 40 dB (measured ~70 dB).