### PR TITLE
Fix #402: LO-offset (DC-spike-avoidance) tuning on the live control path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ for tagged releases.
 
 ## [Unreleased]
 
+### Added
+
+- **DC-spike-avoidance LO offset on the live control channel** (#402). A new
+  opt-in `dc_avoid` flag (with optional `dc_avoid_offset_hz`) on a control
+  SDR's `sdr.devices` entry tunes the hardware LO a fixed offset *below* the
+  control-channel frequency and mixes the channel back to baseband in the
+  down-converter — so the live decode runs off the front-end DC spur, 1/f
+  noise and its own I/Q-imbalance image, the same offset tuning SDRTrunk/OP25
+  use. This closes the live-vs-replay gap on marginal urban sites where the
+  channel decodes cleanly off-channel (in replay) but accumulates TSBK-CRC /
+  NID-BCH failures live with the channel sitting at zero-IF. Off by default
+  (`dc_avoid: false`); `dc_avoid_offset_hz: 0` auto-selects `sample_rate/4`.
+
 ## [v0.3.8] — 2026-06-10
 
 This release adds a pure-Go **LoRa / LoRaWAN receiver** (#586) and hardens the

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -206,6 +206,65 @@ func effectiveControlRate(log *slog.Logger, dev sdr.Device, serial string, reque
 	return actual
 }
 
+// minControlDDCTarget returns the narrowest per-protocol down-converter
+// channel rate over the configured control systems (issue #402). The
+// DC-spike-avoidance LO offset is a single fixed shift applied to whatever
+// control system the decoder is currently hunting, so the "is there room to
+// offset?" gate must use the smallest channel rate among them (e.g. a mixed
+// C4FM 48 kHz / TETRA 144 kHz control SDR gates on 48 kHz). Defaults to the
+// 48 kHz C4FM-family rate when no systems are configured.
+func minControlDDCTarget(systems []trunking.System) float64 {
+	min := ccdecoder.DDCTargetRateHz
+	first := true
+	for _, sys := range systems {
+		t := ccdecoder.DDCTargetForProtocol(sys.Protocol)
+		if first || t < min {
+			min, first = t, false
+		}
+	}
+	return min
+}
+
+// controlLOOffsetHz computes the DC-spike-avoidance LO offset for the control
+// SDR (issue #402). The hardware LO is tuned this many Hz BELOW each logical
+// control-channel frequency and the ccdecoder DDC is built with the same
+// +offset so the channel is mixed back to baseband, off the front-end DC
+// spur / 1-f noise / self-image. Returns 0 (disabled, byte-exact pre-#402
+// behaviour) when: DCAvoid is off; the delivered rate is at/below the
+// narrowest channel rate (no room — e.g. the 48 kHz pass-through the
+// integration test uses); or an explicit override exceeds Nyquist. A zero
+// explicitHz auto-selects rate/4, which keeps the channel maximally clear of
+// both DC (at 0) and its image (at -rate/4) while leaving rate/4 of headroom
+// to the Nyquist edge.
+func controlLOOffsetHz(effectiveRate uint32, minDDCTarget float64, dcAvoid bool, explicitHz int) float64 {
+	if !dcAvoid || float64(effectiveRate) <= minDDCTarget {
+		return 0
+	}
+	if explicitHz > 0 {
+		if float64(explicitHz) < float64(effectiveRate)/2 {
+			return float64(explicitHz)
+		}
+		return 0 // override exceeds Nyquist — reject (caller warns)
+	}
+	return float64(effectiveRate) / 4
+}
+
+// offsetTuner wraps a control Tuner so the physical LO lands offsetHz below
+// every logical frequency the cchunt supervisor / hunter request (issue #402
+// DC-spike avoidance). cchunt, the CC state machine, HuntProgress and
+// waitForLock all stay in LOGICAL frequency space; only the hardware
+// SetCenterFreq is shifted. It sits OUTSIDE the iqtap broker, so broker.SetInner
+// and pool.Reacquire keep operating on the broker unchanged. Subtracting on a
+// uint32 is safe: control frequencies are hundreds of MHz, the offset sub-MHz.
+type offsetTuner struct {
+	inner    interface{ SetCenterFreq(uint32) error }
+	offsetHz uint32
+}
+
+func (t offsetTuner) SetCenterFreq(hz uint32) error {
+	return t.inner.SetCenterFreq(hz - t.offsetHz)
+}
+
 // looksDriveRootedOnWindows reports whether p, when used on Windows,
 // would resolve to the root of the *current* drive (e.g. the Unix-style
 // default "/var/lib/gophertrunk/recordings" becomes "C:\var\lib\...")
@@ -311,6 +370,10 @@ type Daemon struct {
 	// against a fresh Device handle (issue #345).
 	controlSerial     string
 	controlSampleRate uint32
+	// controlLOOffsetHz is the DC-spike-avoidance LO offset wrapped around
+	// the control tuner (issue #402); kept so the USB-reacquire path can
+	// re-wrap the fresh tuner handle and preserve the offset. Zero disables.
+	controlLOOffsetHz float64
 	convScan          *conventional.Scanner
 	widebandT2        []*widebandt2.Engine
 	// virtualVoiceTuners holds one VirtualTuner per voice tap on a
@@ -1085,6 +1148,41 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 		if cchEnabled {
 			controlEntry := d.pool.FirstByRole(sdr.RoleControl)
 			if controlEntry != nil {
+				// Per-device front-end corrections + DC-spike-avoidance
+				// opt-in for this control SDR (matched by serial).
+				iqCorrect := false
+				iqInvert := false
+				dcAvoid := false
+				dcAvoidOffsetHz := 0
+				for _, dev := range cfg.SDR.Devices {
+					if dev.Serial == controlEntry.Info.Serial {
+						iqCorrect = dev.IQCorrect
+						iqInvert = dev.IQInvert
+						dcAvoid = dev.DCAvoid
+						dcAvoidOffsetHz = dev.DCAvoidOffsetHz
+						break
+					}
+				}
+				// Build the down-converter from the rate the hardware
+				// actually delivers, not the requested one (issue #402).
+				effectiveRate := effectiveControlRate(log, controlEntry.Device, controlEntry.Info.Serial, cfg.SDR.SampleRate)
+				// DC-spike-avoidance LO offset (issue #402). The same value
+				// feeds the cchunt tuner wrapper (shifts the physical LO) and
+				// the ccdecoder DDC (mixes the channel back to baseband); the
+				// two MUST match. Zero when disabled / no room.
+				loOffsetHz := controlLOOffsetHz(effectiveRate, minControlDDCTarget(d.systems), dcAvoid, dcAvoidOffsetHz)
+				d.controlLOOffsetHz = loOffsetHz
+				if dcAvoid && loOffsetHz == 0 {
+					log.Warn("daemon: dc_avoid enabled but no LO offset applied — sample rate has no room above the channel rate, or the explicit dc_avoid_offset_hz exceeds Nyquist (issue #402)",
+						"serial", controlEntry.Info.Serial,
+						"effective_rate_hz", effectiveRate,
+						"dc_avoid_offset_hz", dcAvoidOffsetHz)
+				} else if loOffsetHz != 0 {
+					log.Info("daemon: DC-spike-avoidance LO offset enabled on control SDR (issue #402)",
+						"serial", controlEntry.Info.Serial,
+						"lo_offset_hz", int(loOffsetHz))
+				}
+
 				// Route the supervisor's retunes through the broker
 				// (when present) so SetCenterFreq follows the same
 				// broker.SetInner swap path the ccdecoder uses after
@@ -1094,6 +1192,12 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 				var cchTuner cchunt.Tuner = controlEntry.Device
 				if br := d.iqBrokers[controlEntry.Info.Serial]; br != nil {
 					cchTuner = br
+				}
+				// Wrap the tuner so the physical LO lands loOffsetHz below
+				// the logical control-channel frequency (issue #402). cchunt /
+				// HuntProgress / the CC state machine stay in logical Hz.
+				if loOffsetHz != 0 {
+					cchTuner = offsetTuner{inner: cchTuner, offsetHz: uint32(loOffsetHz)}
 				}
 				sup, err := cchunt.New(cchunt.Options{
 					Bus:            d.bus,
@@ -1143,18 +1247,6 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 					iqSrc = br
 					tuner = br
 				}
-				iqCorrect := false
-				iqInvert := false
-				for _, dev := range cfg.SDR.Devices {
-					if dev.Serial == controlEntry.Info.Serial {
-						iqCorrect = dev.IQCorrect
-						iqInvert = dev.IQInvert
-						break
-					}
-				}
-				// Build the down-converter from the rate the hardware
-				// actually delivers, not the requested one (issue #402).
-				effectiveRate := effectiveControlRate(log, controlEntry.Device, controlEntry.Info.Serial, cfg.SDR.SampleRate)
 				d.ccDecoderOpts = ccdecoder.Options{
 					Bus:          d.bus,
 					Log:          log,
@@ -1165,6 +1257,7 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 					Metrics:      iqObs,
 					IQCorrect:    iqCorrect,
 					Conjugate:    iqInvert,
+					LOOffsetHz:   loOffsetHz,
 				}
 				d.controlSerial = controlEntry.Info.Serial
 				// The CC decoder owns StreamIQ on this dongle's broker,
@@ -2902,7 +2995,15 @@ func (d *Daemon) runCCDecoderWithRetry(ctx context.Context) error {
 				d.ccDecoderOpts.IQ = iqSrc
 				d.ccDecoderOpts.Tuner = tuner
 				if d.cchuntSup != nil {
-					if serr := d.cchuntSup.SwapTuner(tuner); serr != nil {
+					// Re-wrap with the DC-spike-avoidance offset so the
+					// reacquired handle keeps tuning the LO off-channel
+					// (issue #402); the decoder's DDC offset is preserved in
+					// d.ccDecoderOpts.LOOffsetHz, untouched here.
+					var swapTuner cchunt.Tuner = tuner
+					if d.controlLOOffsetHz != 0 {
+						swapTuner = offsetTuner{inner: tuner, offsetHz: uint32(d.controlLOOffsetHz)}
+					}
+					if serr := d.cchuntSup.SwapTuner(swapTuner); serr != nil {
 						d.log.Warn("daemon: cchunt: SwapTuner failed",
 							"err", serr)
 					}

--- a/cmd/gophertrunk/daemon_test.go
+++ b/cmd/gophertrunk/daemon_test.go
@@ -1,6 +1,11 @@
 package main
 
-import "testing"
+import (
+	"errors"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
 
 func TestLooksDriveRootedOnWindows(t *testing.T) {
 	cases := []struct {
@@ -25,5 +30,96 @@ func TestLooksDriveRootedOnWindows(t *testing.T) {
 		if got := looksDriveRootedOnWindows(c.path); got != c.want {
 			t.Errorf("looksDriveRootedOnWindows(%q) = %v, want %v", c.path, got, c.want)
 		}
+	}
+}
+
+// recordingTuner records the last SetCenterFreq argument and optionally
+// returns a fixed error, so the offsetTuner wrapper can be asserted in
+// isolation (issue #402).
+type recordingTuner struct {
+	last uint32
+	err  error
+}
+
+func (r *recordingTuner) SetCenterFreq(hz uint32) error {
+	r.last = hz
+	return r.err
+}
+
+func TestOffsetTunerShiftsLO(t *testing.T) {
+	inner := &recordingTuner{}
+	tn := offsetTuner{inner: inner, offsetHz: 512_000}
+	if err := tn.SetCenterFreq(851_000_000); err != nil {
+		t.Fatalf("SetCenterFreq: %v", err)
+	}
+	if inner.last != 850_488_000 {
+		t.Errorf("inner LO = %d, want %d (logical freq minus offset)", inner.last, 850_488_000)
+	}
+
+	// Errors from the inner tuner propagate unchanged.
+	wantErr := errors.New("tune failed")
+	inner2 := &recordingTuner{err: wantErr}
+	tn2 := offsetTuner{inner: inner2, offsetHz: 250_000}
+	if err := tn2.SetCenterFreq(420_012_500); !errors.Is(err, wantErr) {
+		t.Errorf("err = %v, want %v", err, wantErr)
+	}
+	if inner2.last != 419_762_500 {
+		t.Errorf("inner LO = %d, want %d", inner2.last, 419_762_500)
+	}
+}
+
+func TestControlLOOffsetHz(t *testing.T) {
+	const c4fm = 48_000.0
+	const tetra = 144_000.0
+	cases := []struct {
+		name         string
+		effectiveHz  uint32
+		minDDCTarget float64
+		dcAvoid      bool
+		explicitHz   int
+		want         float64
+	}{
+		{"disabled_by_default", 2_048_000, c4fm, false, 0, 0},
+		{"passthrough_rate_no_room", 48_000, c4fm, true, 0, 0},
+		{"auto_quarter_rate", 2_048_000, c4fm, true, 0, 512_000},
+		{"auto_960k", 960_000, c4fm, true, 0, 240_000},
+		{"explicit_honored", 2_048_000, c4fm, true, 300_000, 300_000},
+		{"explicit_exceeds_nyquist_rejected", 2_048_000, c4fm, true, 2_000_000, 0},
+		{"tetra_target_has_room", 2_048_000, tetra, true, 0, 512_000},
+		{"disabled_ignores_explicit", 2_048_000, c4fm, false, 300_000, 0},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := controlLOOffsetHz(c.effectiveHz, c.minDDCTarget, c.dcAvoid, c.explicitHz)
+			if got != c.want {
+				t.Errorf("controlLOOffsetHz(%d, %v, %v, %d) = %v, want %v",
+					c.effectiveHz, c.minDDCTarget, c.dcAvoid, c.explicitHz, got, c.want)
+			}
+		})
+	}
+}
+
+func TestMinControlDDCTarget(t *testing.T) {
+	// No systems → default C4FM 48 kHz.
+	if got := minControlDDCTarget(nil); got != 48_000 {
+		t.Errorf("minControlDDCTarget(nil) = %v, want 48000", got)
+	}
+	// A pure P25 control SDR gates on 48 kHz.
+	p25 := []trunking.System{{Name: "A", Protocol: trunking.ProtocolP25}}
+	if got := minControlDDCTarget(p25); got != 48_000 {
+		t.Errorf("minControlDDCTarget(P25) = %v, want 48000", got)
+	}
+	// A mixed C4FM + TETRA control SDR must gate on the narrower 48 kHz.
+	mixed := []trunking.System{
+		{Name: "A", Protocol: trunking.ProtocolTETRA},
+		{Name: "B", Protocol: trunking.ProtocolP25},
+	}
+	if got := minControlDDCTarget(mixed); got != 48_000 {
+		t.Errorf("minControlDDCTarget(mixed) = %v, want 48000 (narrowest)", got)
+	}
+	// A pure TETRA control SDR gates on 144 kHz.
+	tetra := []trunking.System{{Name: "A", Protocol: trunking.ProtocolTETRA}}
+	if got := minControlDDCTarget(tetra); got != 144_000 {
+		t.Errorf("minControlDDCTarget(TETRA) = %v, want 144000", got)
 	}
 }

--- a/docs/constellation.md
+++ b/docs/constellation.md
@@ -64,7 +64,21 @@ are brightest. Reference rings show |z| = 0.5 and |z| = 1.0.
 An SDR's digital down-converter leaks a residual carrier at 0 Hz — a
 **DC spike** that sits exactly at the centre of the band. Anything you
 tune to the middle lands right on top of it, and the constellation
-collapses into one fat blob. Three controls work around this:
+collapses into one fat blob. The same zero-IF region also folds a
+direct-conversion front end's I/Q-imbalance image back onto a channel
+sitting at DC, so even a clean-looking signal can decode with elevated
+TSBK-CRC / NID-BCH failures (issue #402).
+
+For the **live control channel** specifically, set `dc_avoid: true` on the
+control SDR's `sdr.devices` entry: the daemon then tunes the hardware LO a
+fixed offset *below* the control-channel frequency and mixes the channel
+back to baseband in the down-converter — so the live decode runs off the
+DC spike and its image, exactly like an off-channel capture replays
+cleanly. It is off by default; `dc_avoid_offset_hz` pins the offset (0 =
+auto, `sample_rate/4`). This is the same offset tuning SDRTrunk/OP25 use.
+
+For the *panels* (Constellation / Eye / Symbol scope), three controls work
+around the same problem:
 
 - **Offset** — mixes a frequency offset (relative to the SDR centre)
   down to baseband *server-side, before decimation*, so an off-centre

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -890,6 +890,22 @@ type DeviceConfig struct {
 	// capture with `gophertrunk replay -conjugate -diag` before enabling.
 	// Equivalent to the replay subcommand's -conjugate flag (issue #264).
 	IQInvert bool `yaml:"iq_invert"`
+
+	// DCAvoid enables live LO-offset (DC-spike-avoidance) tuning on a
+	// control-role SDR (issue #402): the hardware LO is tuned below the
+	// control-channel frequency and the channel is mixed back to baseband in
+	// the down-converter, off the front-end DC spur, 1/f noise and the
+	// channel's own I/Q-imbalance image (all of which corrupt a C4FM channel
+	// sitting at zero-IF on an RTL-SDR). This is the same offset tuning
+	// SDRTrunk/OP25 apply. Off by default; enable per control device and
+	// confirm the tsbk-crc/nid-bch rates drop while the channel stays locked.
+	DCAvoid bool `yaml:"dc_avoid"`
+
+	// DCAvoidOffsetHz pins the LO offset in Hz used when DCAvoid is set.
+	// 0 (the default) auto-selects sample_rate/4. Must be < sample_rate/2;
+	// ignored when DCAvoid is false, for non-control roles, or when the
+	// delivered sample rate is at/below the channel rate (no room to offset).
+	DCAvoidOffsetHz int `yaml:"dc_avoid_offset_hz"`
 }
 
 // DeviceChannelConfig is one repeater carrier carried by a
@@ -1539,6 +1555,15 @@ func (c Config) validateSDR() []error {
 			if err := validateWidebandDevice(i, d, c.SDR.SampleRate, c.Trunking.Systems); err != nil {
 				errs = append(errs, err)
 				continue
+			}
+		}
+		if d.DCAvoidOffsetHz != 0 {
+			if d.DCAvoidOffsetHz < 0 {
+				errs = append(errs, fmt.Errorf("sdr.devices[%d]: dc_avoid_offset_hz must be >= 0 (0 = auto)", i))
+			} else if c.SDR.SampleRate != 0 && d.DCAvoidOffsetHz >= int(c.SDR.SampleRate)/2 {
+				errs = append(errs, fmt.Errorf(
+					"sdr.devices[%d]: dc_avoid_offset_hz (%d) must be < sample_rate/2 (%d)",
+					i, d.DCAvoidOffsetHz, int(c.SDR.SampleRate)/2))
 			}
 		}
 		if d.Serial == "" {

--- a/internal/configbuilder/advanced.go
+++ b/internal/configbuilder/advanced.go
@@ -8,7 +8,7 @@ package configbuilder
 // tests, so adding a protocol knob is a one-line, reviewed decision.
 var AdvancedFields = map[string][]string{
 	"DeviceConfig": {
-		"BlogV4", "BlogV4Lite", "IQCorrect", "IQInvert",
+		"BlogV4", "BlogV4Lite", "IQCorrect", "IQInvert", "DCAvoid", "DCAvoidOffsetHz",
 	},
 	"SystemConfig": {
 		// TETRA

--- a/internal/configbuilder/fieldmeta.go
+++ b/internal/configbuilder/fieldmeta.go
@@ -102,6 +102,9 @@ var fieldMetas = map[string]FieldMeta{
 	"DeviceConfig.IQCorrect":     {Label: "I/Q correct", Help: "Blind I/Q-imbalance correction before decimation. Validate with `gophertrunk replay -iq-correct -diag` before enabling."},
 	"DeviceConfig.IQInvert":      {Label: "I/Q invert", Help: "Conjugate raw IQ (negate Q) to undo a spectrum-inverted front end (needed by some Soapy/USRP chains; critical for π/4-DQPSK like TETRA)."},
 
+	"DeviceConfig.DCAvoid":         {Label: "DC-spike avoid", Help: "Tune a control SDR's LO off-channel and mix the channel back to baseband, off the front-end DC spur and its I/Q-image (the offset tuning SDRTrunk/OP25 use). Helps marginal sites; off by default (issue #402)."},
+	"DeviceConfig.DCAvoidOffsetHz": {Label: "DC-avoid offset", Hz: true, Help: "LO offset in Hz when DC-spike avoid is on. 0 = auto (sample_rate/4). Must be < sample_rate/2."},
+
 	"DeviceChannelConfig.FrequencyHz": {Label: "Frequency", Hz: true, Help: "Repeater carrier frequency. Must lie inside the dongle's IQ band."},
 	"DeviceChannelConfig.System":      {Help: "Name of the trunking.systems entry this carrier belongs to."},
 

--- a/internal/scanner/ccdecoder/decoder.go
+++ b/internal/scanner/ccdecoder/decoder.go
@@ -194,6 +194,16 @@ type Options struct {
 	// protocol such as TETRA cannot lock an inverted spectrum because the
 	// inversion reverses every differential phase transition.
 	Conjugate bool
+	// LOOffsetHz is the live LO-offset (DC-spike-avoidance) tuning the daemon
+	// applies on the control SDR (issue #402). The hardware LO is tuned
+	// LOOffsetHz BELOW the logical control-channel frequency, so the wanted
+	// channel sits at +LOOffsetHz in the delivered baseband; the
+	// down-converter is built with this same offset so the channel is mixed
+	// back to 0 Hz, off the front-end DC spur / 1/f noise / self-image. Zero
+	// (the default) builds no NCO and is byte-exact with the pre-offset
+	// behaviour — used when the path is disabled or at pass-through rates
+	// where there is no room to offset.
+	LOOffsetHz float64
 }
 
 // Decoder is the long-lived component that converts the control
@@ -204,7 +214,11 @@ type Decoder struct {
 	log          *slog.Logger
 	iq           IQSource
 	sampleRateHz float64
-	systems      map[string]trunking.System
+	// loOffsetHz is the DC-spike-avoidance LO offset (issue #402): the
+	// channel sits at +loOffsetHz in the delivered baseband and the DDC is
+	// built with this offset to mix it back to 0 Hz. Zero disables it.
+	loOffsetHz float64
+	systems    map[string]trunking.System
 
 	// ddc decimates the raw SDR IQ stream to pipelineRateHz before
 	// the active pipeline sees a chunk; ddcTarget records the
@@ -339,6 +353,7 @@ func New(opts Options) (*Decoder, error) {
 		log:          log,
 		iq:           opts.IQ,
 		sampleRateHz: opts.SampleRateHz,
+		loOffsetHz:   opts.LOOffsetHz,
 		systems:      make(map[string]trunking.System, len(opts.Systems)),
 		sub:          opts.Bus.Subscribe(),
 		metrics:      opts.Metrics,
@@ -599,12 +614,13 @@ func (d *Decoder) ensureDownconverterLocked(targetHz float64) {
 	if d.ddc != nil && d.ddcTarget == targetHz {
 		return
 	}
-	d.ddc = NewDownconverter(d.sampleRateHz, targetHz)
+	d.ddc = NewDownconverterWithOffset(d.sampleRateHz, targetHz, d.loOffsetHz)
 	d.ddcTarget = targetHz
 	d.pipelineRateHz = d.ddc.outRateHz
 	d.log.Info("ccdecoder: digital down-converter configured",
 		"sdr_rate_hz", d.sampleRateHz,
-		"pipeline_rate_hz", d.pipelineRateHz)
+		"pipeline_rate_hz", d.pipelineRateHz,
+		"lo_offset_hz", d.loOffsetHz)
 }
 
 // pump down-converts a raw IQ chunk and forwards it to the active

--- a/internal/scanner/ccdecoder/decoder_test.go
+++ b/internal/scanner/ccdecoder/decoder_test.go
@@ -1442,6 +1442,116 @@ func TestDecoderLocksP25Phase1ThroughWidebandDDC(t *testing.T) {
 	}
 }
 
+// TestDecoderLocksP25Phase1WithLOOffset is the live↔replay parity guard for
+// issue #402: it proves the DC-spike-avoidance LO offset actually recovers a
+// channel the daemon deliberately tuned OFF-centre, and — in the negative
+// sub-case — that without the matching DDC offset the same off-centre channel
+// never locks. This mirrors the production wiring: the daemon tunes the
+// hardware LO `O` Hz below the logical channel (so the wanted channel sits at
+// +O in the delivered baseband) and builds the DDC with Options.LOOffsetHz=O
+// to mix it back to 0. Here we synthesize a wideband stream with the channel
+// shifted up to +O and feed it through a real Decoder.
+func TestDecoderLocksP25Phase1WithLOOffset(t *testing.T) {
+	const (
+		nac          = 0x293
+		controlFreq  = 851_000_000
+		sdrRateHz    = 2_048_000.0
+		narrowRateHz = 48_000.0
+		deviationHz  = 1800.0
+		frameRepeats = 30
+		offsetHz     = sdrRateHz / 4 // 512 kHz — the production auto value
+	)
+
+	// Centred wideband control channel, then frequency-shifted UP to +offsetHz
+	// to simulate an LO tuned offsetHz below the channel. NCO.Mix applies
+	// exp(-j2π·offsetHz·n/Fs), so NewNCO(-offsetHz) multiplies by
+	// exp(+j2π·offsetHz·n/Fs) — i.e. shifts the centred channel up to +offsetHz.
+	dibits := buildP25CCDibits(nac, frameRepeats)
+	narrow := demod.ModulateP25C4FM(dibits, narrowRateHz, deviationHz)
+	centred := dsp.NewResampler(128, 3, 8, 8.0).Process(nil, narrow)
+	offChannel := dsp.NewNCO(-offsetHz, sdrRateHz).Mix(nil, centred)
+
+	// pumpUntilLock builds a Decoder with the given LO offset, installs the real
+	// P25 pipeline, pumps the off-channel stream, and reports whether it locked.
+	pumpUntilLock := func(t *testing.T, loOffsetHz float64) (bool, p25phase1.LockState) {
+		t.Helper()
+		bus := events.NewBus(256)
+		defer bus.Close()
+		d, err := New(Options{
+			Bus: bus, IQ: &fakeIQSource{},
+			Systems: []trunking.System{{
+				Name: "WBSys", Protocol: trunking.ProtocolP25,
+				ControlChannels: []uint32{controlFreq},
+			}},
+			SampleRateHz: sdrRateHz,
+			LOOffsetHz:   loOffsetHz,
+		})
+		if err != nil {
+			t.Fatalf("New: %v", err)
+		}
+		defer d.Close()
+		sub := bus.Subscribe()
+		defer sub.Close()
+
+		d.handleProgress(trunking.HuntProgress{System: "WBSys", AttemptedFreqHz: controlFreq})
+		if d.active == nil {
+			t.Fatalf("handleProgress did not install a pipeline")
+		}
+
+		const chunk = 8_192
+		var lockState p25phase1.LockState
+		locked := false
+		for off := 0; off < len(offChannel) && !locked; off += chunk {
+			end := off + chunk
+			if end > len(offChannel) {
+				end = len(offChannel)
+			}
+			d.pump(offChannel[off:end])
+			for drained := false; !drained; {
+				select {
+				case ev := <-sub.C:
+					if ev.Kind != events.KindCCLocked {
+						continue
+					}
+					if ls, ok := ev.Payload.(p25phase1.LockState); ok {
+						lockState = ls
+						locked = true
+					}
+				default:
+					drained = true
+				}
+			}
+		}
+		return locked, lockState
+	}
+
+	// Positive: with the matching DDC offset the off-channel signal is mixed
+	// back to baseband and locks at the LOGICAL frequency (the offset is
+	// invisible above the DDC).
+	t.Run("offset_locks", func(t *testing.T) {
+		locked, ls := pumpUntilLock(t, offsetHz)
+		if !locked {
+			t.Fatalf("no cc.locked with LOOffsetHz=%v — DC-spike-avoidance offset failed to recover the off-channel signal", offsetHz)
+		}
+		if ls.NAC != nac {
+			t.Errorf("LockState.NAC = %#x, want %#x", ls.NAC, nac)
+		}
+		if ls.FrequencyHz != controlFreq {
+			t.Errorf("LockState.FrequencyHz = %d, want %d (logical freq, offset must be invisible above the DDC)", ls.FrequencyHz, controlFreq)
+		}
+	})
+
+	// Negative / regression guard: without the offset the channel stays at
+	// +offsetHz, outside the 48 kHz channel the DDC keeps, and never locks.
+	// This is what proves the offset — not luck — is what fixes issue #402.
+	t.Run("no_offset_does_not_lock", func(t *testing.T) {
+		locked, _ := pumpUntilLock(t, 0)
+		if locked {
+			t.Fatalf("locked with LOOffsetHz=0 on an off-channel signal — the negative control is invalid (the channel should be unrecoverable without the DDC offset)")
+		}
+	})
+}
+
 // TestClearActiveClearsIQPowerSeries: when the decoder swaps pipelines
 // it must drop the gauge series for the system the previous pipeline
 // owned, so stale dBFS doesn't outlive the active system.

--- a/web/configbuilder/src/api/types.ts
+++ b/web/configbuilder/src/api/types.ts
@@ -65,8 +65,9 @@ export interface DeviceConfig {
   Channels?: DeviceChannelConfig[] | null;
   TunerStrategy?: string;
   VoiceTaps?: number;
-  // Other device flags (BlogV4, IQCorrect, IQInvert, …) round-trip via the
-  // index signature and are reachable through AdvancedJSON.
+  // Other device flags (BlogV4, IQCorrect, IQInvert, DCAvoid,
+  // DCAvoidOffsetHz, …) round-trip via the index signature and are
+  // reachable through AdvancedJSON.
   [k: string]: unknown;
 }
 

--- a/web/configbuilder/src/sections/SDR.tsx
+++ b/web/configbuilder/src/sections/SDR.tsx
@@ -35,7 +35,7 @@ const REMOTE_ROLES = [
 ];
 
 const DEVICE_ADVANCED: (keyof DeviceConfig)[] = [
-  "BlogV4", "BlogV4Lite", "IQCorrect", "IQInvert",
+  "BlogV4", "BlogV4Lite", "IQCorrect", "IQInvert", "DCAvoid", "DCAvoidOffsetHz",
 ];
 
 export function SDRSection() {


### PR DESCRIPTION
The live control decode accumulated elevated TSBK-CRC / NID-BCH failures on
marginal urban sites (MMR City) while the same site's IQ captures replayed
essentially clean. The captures were all recorded deliberately off-channel and
the replay path shifts them back to baseband with a DDC frequency offset; the
live path does the opposite — the cchunt Hunter tunes the SDR LO directly onto
the control-channel center and the live DDC is built with zero offset, so the
C4FM channel sits at zero-IF on the RTL-SDR R820T2, exposed to the DC spur, 1/f
noise and its own I/Q-imbalance image (which folds onto a channel centered at
DC). That degrades EVM enough to fail TSBK CRC intermittently while NID's
stronger BCH survives — the reported symptom, and why a clean site (Mt Anakie)
tolerates it while a marginal one does not. The on-channel-vs-off-channel
variable was never separated from live-vs-replay, so "replay is clean" had been
read as "live control flow is the problem" when it actually meant "off-channel
is clean".

Implement the offset tuning SDRTrunk/OP25 use, reusing the DDC's existing
NewDownconverterWithOffset machinery (byte-exact at offset 0):

- ccdecoder: thread Options.LOOffsetHz into ensureDownconverterLocked so the
  live DDC mixes a channel sitting at +offset back to baseband.
- daemon: an offsetTuner wrapper shifts only the physical SetCenterFreq (LO =
  logicalFreq - offset) so cchunt / HuntProgress / waitForLock / the CC state
  machine all stay in logical frequency; a single controlLOOffsetHz helper
  feeds both the wrapper and the decoder Options so they always match; the
  offset is preserved across USB reacquire.
- config: opt-in per control device via dc_avoid (+ optional dc_avoid_offset_hz,
  0 = auto sample_rate/4). Off by default for one release. Auto-disabled when
  the delivered rate is at/below the channel rate (no room — the 48 kHz
  pass-through the integration test uses).

Tests: a live<->replay parity test in the ccdecoder package feeds an
off-channel C4FM stream through a real Decoder and asserts it locks with the
matching offset and does NOT lock without it; offsetTuner + controlLOOffsetHz +
minControlDDCTarget unit tests; the existing integration test stays green
(offset auto-0 at 48 kHz). Config-builder coverage (FieldMeta + advanced
round-trip) updated for the two new device fields.

https://claude.ai/code/session_01Hq9JgguA9WpAvdDy7dYTNN