### PR TITLE
Fix P25/DMR voice quality: AGC anti-clipping + OP25/JMBE IMBE alignment + voice telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ for tagged releases.
 
 ## [Unreleased]
 
+### Changed
+
+- **P25 IMBE voice quality: align the vocoder with the OP25 / JMBE reference
+  decoders.** Three changes ported after comparing GopherTrunk's mbelib-lineage
+  decoder against OP25's `imbe_vocoder` and DSheirer's JMBE:
+  - **Pitch-dependent spectral-amplitude prediction.** The cross-frame
+    log-amplitude prediction coefficient is now a function of the harmonic
+    count L (`ρ = 0.4` for L≤15, `0.03·L−0.05` for 16–24, `0.7` for L≥25),
+    matching both reference decoders, instead of a fixed 0.65. The old constant
+    over-predicted high-pitch / low-L frames and smeared the previous frame's
+    spectral envelope onto them — the main remaining cause of poor female-voice
+    intelligibility. Measured on the field capture, the female call's crest
+    factor rose from ~7.8 to ~9.8 (closer to the raw synthesizer's ~11).
+  - **DC-removal high-pass** on the synthesized PCM (first-order, pole 0.99),
+    matching OP25's `dc_rmv.cc`, so a DC offset no longer wastes AGC headroom.
+  - **Adaptive smoothing** driven by the channel FEC error rate (ported in
+    spirit from JMBE `IMBEModelParameters`): a running ε_R estimate caps
+    error-induced amplitude spikes, reclaims obviously-voiced harmonics, and
+    mutes hopeless frames (ε_R > 0.0875). Thresholds are expressed relative to a
+    running local-energy estimate (vs the reference's fixed-point absolute
+    constants) and are inert on a clean channel, so well-decoded audio is
+    byte-identical. The P25 Phase 1 chain now threads the per-frame corrected-bit
+    count to the decoder (`voice.ErrorAware`); other protocols are unaffected.
+
 ### Fixed
 
 - **P25/DMR voice was over-driven into clipping (robotic, "female voices

--- a/internal/radio/p25/phase1/ldu.go
+++ b/internal/radio/p25/phase1/ldu.go
@@ -317,12 +317,24 @@ func InjectStatusSymbols(payload []byte, status [LDUStatusSymbolCount]uint8) ([]
 // Bit positions sourced from TIA-102.BAAA-A § 8 (Logical Link
 // Data Unit 1 / 2 voice-frame layout).
 func ExtractVoiceFrames(ldu []byte) (frames [LDUVoiceSubframeCount][]byte, totalErrs int, err error) {
+	frames, _, totalErrs, err = ExtractVoiceFramesDetailed(ldu)
+	return frames, totalErrs, err
+}
+
+// ExtractVoiceFramesDetailed is ExtractVoiceFrames plus the per-subframe
+// corrected-bit count. The IMBE adaptive-smoothing path uses the per-frame
+// count to maintain a running channel error-rate estimate (ε_R) that drives
+// amplitude/voicing cleanup and muting on weak signals; the plain
+// ExtractVoiceFrames wrapper is kept for callers that only need the
+// aggregate. frameErrs[i] is the Golay+Hamming corrected-bit count for
+// voice subframe u_i.
+func ExtractVoiceFramesDetailed(ldu []byte) (frames [LDUVoiceSubframeCount][]byte, frameErrs [LDUVoiceSubframeCount]int, totalErrs int, err error) {
 	if len(ldu) != LDUTotalBits {
-		return frames, 0, fmt.Errorf("%w: got %d bits", ErrLDULength, len(ldu))
+		return frames, frameErrs, 0, fmt.Errorf("%w: got %d bits", ErrLDULength, len(ldu))
 	}
 	payload, err := StripStatusSymbols(ldu)
 	if err != nil {
-		return frames, 0, err
+		return frames, frameErrs, 0, err
 	}
 
 	var firstErr error
@@ -330,12 +342,13 @@ func ExtractVoiceFrames(ldu []byte) (frames [LDUVoiceSubframeCount][]byte, total
 		channel := payload[off : off+LDUVoiceSubframeBits]
 		frame, errs, decErr := imbe.DecodeChannelToFrame(channel)
 		frames[i] = frame
+		frameErrs[i] = errs
 		totalErrs += errs
 		if decErr != nil && firstErr == nil {
 			firstErr = fmt.Errorf("subframe %d: %w", i, decErr)
 		}
 	}
-	return frames, totalErrs, firstErr
+	return frames, frameErrs, totalErrs, firstErr
 }
 
 // ExtractLCESBlocks returns the 6 LC (LDU1) / ES (LDU2) blocks

--- a/internal/voice/composer/dmr_voice.go
+++ b/internal/voice/composer/dmr_voice.go
@@ -26,6 +26,14 @@ type rawFrameSink interface {
 	WriteRawFrame(deviceSerial string, frame []byte) error
 }
 
+// errAwareRawSink is the optional richer sink the P25 Phase 1 voice chain
+// uses to pass the per-frame FEC corrected-bit count to the IMBE decoder's
+// adaptive smoothing. The recorder implements it; sinks that don't are
+// handled via the plain rawFrameSink path.
+type errAwareRawSink interface {
+	WriteRawFrameWithErrors(deviceSerial string, frame []byte, correctedBits int) error
+}
+
 // runDMRVoiceChain consumes IQ for one DMR voice call. It decimates
 // the wideband IQ to a DMR-symbol-friendly rate, recovers the dibit
 // stream with the shared DMR receiver, assembles A–F voice

--- a/internal/voice/composer/p25p1_voice.go
+++ b/internal/voice/composer/p25p1_voice.go
@@ -97,6 +97,9 @@ func (c *Composer) runP25Phase1VoiceChain(ctx context.Context, serial string, iq
 	lpf := filter.NewFIR(filter.LowpassKaiser(81, cutoff, 8.6))
 
 	rs, _ := c.sink.(rawFrameSink)
+	// ers, when the sink supports it, carries the per-frame FEC corrected-bit
+	// count to the IMBE decoder's adaptive smoothing (P25 Phase 1 only).
+	ers, _ := c.sink.(errAwareRawSink)
 	// lastES is the last Encryption Sync this chain published on the
 	// bus. The voice frame stream carries one ES per LDU2 (every ~180
 	// ms), but ALGID/KID rarely change inside a single call — gate the
@@ -194,7 +197,7 @@ func (c *Composer) runP25Phase1VoiceChain(ctx context.Context, serial string, iq
 			write := bt.onVoice(tg)
 
 			if write && rs != nil {
-				fs, errBits, err := phase1.ExtractVoiceFrames(ldu)
+				fs, frameErrs, errBits, err := phase1.ExtractVoiceFramesDetailed(ldu)
 				if errBits > 0 {
 					corrErrBits.Add(uint64(errBits))
 				}
@@ -203,11 +206,21 @@ func (c *Composer) runP25Phase1VoiceChain(ctx context.Context, serial string, iq
 					c.log.Debug("composer: p25p1 voice extract uncorrectable subframe",
 						"serial", serial, "err", err)
 				}
-				for _, f := range fs {
+				for i, f := range fs {
 					if f == nil {
 						continue
 					}
-					if werr := rs.WriteRawFrame(serial, f); werr != nil {
+					// Hand the per-frame corrected-bit count to the IMBE
+					// decoder (via the recorder) so its adaptive smoothing can
+					// track the channel error rate; fall back to the plain
+					// write for sinks that don't support it.
+					var werr error
+					if ers != nil {
+						werr = ers.WriteRawFrameWithErrors(serial, f, frameErrs[i])
+					} else {
+						werr = rs.WriteRawFrame(serial, f)
+					}
+					if werr != nil {
 						c.log.Warn("composer: p25p1 raw-frame write failed",
 							"serial", serial, "err", werr)
 					}

--- a/internal/voice/imbe/decoder.go
+++ b/internal/voice/imbe/decoder.go
@@ -116,6 +116,17 @@ type Decoder struct {
 	// unaffected. Both are deterministic for a given constructor seed.
 	phaseRng *rand.Rand
 	agc      *mbe.AGC
+	// dc is the DC-removal high-pass applied to the synthesized PCM before
+	// the AGC (matches OP25 dc_rmv.cc). Continuous across frames; reset only
+	// on stream re-sync via Reset.
+	dc mbe.DCBlock
+
+	// smoother holds the IMBE adaptive-smoothing memory (running channel
+	// error rate + local energy). frameErrs is the FEC corrected-bit count
+	// for the next Decode, supplied via SetFrameErrors (voice.ErrorAware);
+	// 0 when the caller doesn't track it, leaving smoothing inert.
+	smoother  mbe.Smoother
+	frameErrs int
 
 	// One-frame cache for the frame-repeat path. Holds the shared
 	// mbe.Params shape since the synthesis path consumes only that
@@ -259,6 +270,14 @@ func (d *Decoder) Decode(frame []byte) ([]int16, error) {
 	pcm := make([]float64, mbe.SamplesPerFrame)
 	d.stats.frames++
 
+	// Consume the corrected-bit count set by SetFrameErrors (0 if the caller
+	// doesn't supply one) and advance the adaptive-smoothing error-rate
+	// estimate. muteByER is true when the channel is so degraded the frame
+	// should be silenced.
+	correctedBits := d.frameErrs
+	d.frameErrs = 0
+	muteByER := d.smoother.UpdateErrorRate(correctedBits)
+
 	p, err := UnpackParams(info)
 
 	// Idle-tone run accounting. Done before the switch (a Go switch
@@ -294,7 +313,7 @@ func (d *Decoder) Decode(frame []byte) ([]int16, error) {
 			repeatedM[l] *= atten
 		}
 		d.synthFrame(d.lastGoodParams, &d.lastGoodLog2M, &repeatedM, pcm)
-		d.agc.Apply(pcm, out, true)
+		d.applyOutput(pcm, out, true)
 		d.stats.repeated++
 		d.accumStats(out)
 		return out, nil
@@ -308,11 +327,14 @@ func (d *Decoder) Decode(frame []byte) ([]int16, error) {
 		// back in at 0.4 → 0.7 → 1.0 amplitude rather than jumping
 		// straight to full level.
 		d.state.Reset()
+		d.dc.Reset()
 		d.clearLastGood()
 		d.recoveryFramesRemaining = len(recoveryRampFactors)
 		// Bad-streak clear ends the current voiced segment — re-arm the
 		// onset idle-mute so the next over opens without a buzz leak.
 		d.voiceStarted = false
+		// Silence frame: no synthesized speech to DC-filter (the blocker was
+		// reset above so the next over starts clean); go straight to the AGC.
 		d.agc.Apply(pcm, out, true)
 		d.stats.bad++
 		d.accumStats(out)
@@ -326,10 +348,13 @@ func (d *Decoder) Decode(frame []byte) ([]int16, error) {
 		// next non-silent frame starts from a clean baseline.
 		mbe.SynthUnvoicedOverlapAdd(&d.state, p.MBE(), nil, nil, pcm)
 		d.state.Reset()
+		d.dc.Reset()
 		d.clearLastGood()
 		// Silence window marks a transmission gap — re-arm the onset
 		// idle-mute so the next over opens without a buzz leak.
 		d.voiceStarted = false
+		// Silence/OA-tail frame: bypass the (reset) DC blocker so the tail's
+		// non-overlap region stays clean; go straight to the AGC.
 		d.agc.Apply(pcm, out, true)
 		d.stats.silent++
 		d.accumStats(out)
@@ -344,7 +369,9 @@ func (d *Decoder) Decode(frame []byte) ([]int16, error) {
 		// (managed above) so the rest of the run keeps muting.
 		mbe.SynthUnvoicedOverlapAdd(&d.state, p.MBE(), nil, nil, pcm)
 		d.state.Reset()
+		d.dc.Reset()
 		d.clearLastGood()
+		// Idle-tone mute / OA-tail frame: bypass the (reset) DC blocker.
 		d.agc.Apply(pcm, out, true)
 		d.stats.idleMuted++
 		d.accumStats(out)
@@ -367,6 +394,18 @@ func (d *Decoder) Decode(frame []byte) ([]int16, error) {
 	var M [mbe.MaxL + 1]float64
 	mbe.AmplitudesFromLog2Ml(&log2M, m.L, &M)
 	mbe.EnhanceAmplitudes(m, &M)
+
+	// IMBE adaptive smoothing: on a degraded channel, cap error-induced
+	// amplitude spikes and reclaim obviously-voiced harmonics (modifies M and
+	// m.Vl in place); a clean channel is left untouched. A frame whose error
+	// rate exceeds the mute threshold is silenced by zeroing the amplitudes,
+	// which the voiced generator's amplitude tilt fades out cleanly.
+	d.smoother.Smooth(&m, &M, correctedBits)
+	if muteByER {
+		for l := 1; l <= m.L; l++ {
+			M[l] = 0
+		}
+	}
 
 	// Recovery ramp after a bad-streak state clear: scale the post-
 	// enhancement amplitudes by recoveryRampFactors over the next
@@ -399,7 +438,7 @@ func (d *Decoder) Decode(frame []byte) ([]int16, error) {
 	d.lastGoodLog2M = log2M
 	d.lastGoodM = M
 
-	d.agc.Apply(pcm, out, recoveryFreezeAGC)
+	d.applyOutput(pcm, out, recoveryFreezeAGC)
 	d.accumGood(m, d.agc.LastGain())
 	d.accumStats(out)
 	return out, nil
@@ -453,6 +492,18 @@ func (d *Decoder) synthFrame(p mbe.Params, log2M *[mbe.MaxL + 1]float64, M *[mbe
 // 20 ms frame). Used to convert the fundamental W0 (rad/sample) to Hz for
 // the VoiceStats pitch summary.
 const pcmSampleRateHz = 8000
+
+// applyOutput runs the DC-removal high-pass over the synthesized PCM and
+// then the AGC into out. Used by the paths that emit real synthesized
+// speech (the good-frame path and the frame-repeat path) so the DC filter
+// runs continuously over voiced audio and the AGC sizes against the DC-free
+// signal. The silence / idle-mute / bad-streak paths bypass it (and Reset
+// the blocker) since they emit no speech. freezeEnvelope is forwarded to
+// the AGC.
+func (d *Decoder) applyOutput(pcm []float64, out []int16, freezeEnvelope bool) {
+	d.dc.Process(pcm)
+	d.agc.Apply(pcm, out, freezeEnvelope)
+}
 
 // accumStats folds the just-applied frame's AGC telemetry and output
 // samples into the per-call stats. Call immediately after agc.Apply on
@@ -557,6 +608,13 @@ func (d *Decoder) VoiceStats() (voice.VoiceStats, bool) {
 	return vs, true
 }
 
+// SetFrameErrors supplies the FEC corrected-bit count for the NEXT Decode
+// call, driving the adaptive-smoothing error-rate estimate. Implements
+// voice.ErrorAware; the recorder calls it (for P25 Phase 1) immediately
+// before Decode. Callers that don't track errors simply never call it, and
+// smoothing stays inert.
+func (d *Decoder) SetFrameErrors(correctedBits int) { d.frameErrs = correctedBits }
+
 // ResetStats clears the per-call telemetry. The recorder calls it at
 // call / segment boundaries. Kept separate from Reset (which clears
 // synthesis state on mid-call re-sync) so a re-sync doesn't discard the
@@ -595,6 +653,9 @@ func unpackInfoBits(frame []byte) []byte {
 func (d *Decoder) Reset() {
 	d.state.Reset()
 	d.agc.Reset()
+	d.dc.Reset()
+	d.smoother.Reset()
+	d.frameErrs = 0
 	d.clearLastGood()
 	d.recoveryFramesRemaining = 0
 	d.lowB0RunCount = 0
@@ -610,6 +671,7 @@ func (d *Decoder) Close() error { return nil }
 var (
 	_ voice.Vocoder      = (*Decoder)(nil)
 	_ voice.StatProvider = (*Decoder)(nil)
+	_ voice.ErrorAware   = (*Decoder)(nil)
 )
 
 func init() {

--- a/internal/voice/imbe/decoder_test.go
+++ b/internal/voice/imbe/decoder_test.go
@@ -422,10 +422,11 @@ func TestAGCConvergesTowardTarget(t *testing.T) {
 		}
 		lastPeak = agcPeak(out)
 	}
-	// After convergence the peak should be within ~30% of the target
-	// (loose because the §6.4 noise draw varies per frame).
+	// After convergence the peak should be within ~35% of the target
+	// (loose because the §6.4 noise draw varies per frame and the DC
+	// blocker trims a little near-DC energy from this synthetic frame).
 	target := mbe.DefaultAGCConfig().TargetPeak
-	const tol = 0.3
+	const tol = 0.35
 	lo := int(target * (1 - tol))
 	hi := int(target * (1 + tol))
 	if lastPeak < lo || lastPeak > hi {

--- a/internal/voice/imbe/smoothing_test.go
+++ b/internal/voice/imbe/smoothing_test.go
@@ -1,0 +1,48 @@
+package imbe
+
+import "testing"
+
+// TestSetFrameErrorsZeroIsInert: feeding 0 corrected bits before each
+// Decode produces output byte-identical to never calling SetFrameErrors —
+// adaptive smoothing must not perturb clean audio.
+func TestSetFrameErrorsZeroIsInert(t *testing.T) {
+	frame := goodVoiceFrame()
+	a := New()
+	b := New()
+	for i := 0; i < 30; i++ {
+		oa, err := a.Decode(frame)
+		if err != nil {
+			t.Fatal(err)
+		}
+		b.SetFrameErrors(0)
+		ob, err := b.Decode(frame)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for j := range oa {
+			if oa[j] != ob[j] {
+				t.Fatalf("frame %d sample %d differs: %d vs %d (smoothing not inert at 0 errors)", i, j, oa[j], ob[j])
+			}
+		}
+	}
+}
+
+// TestSustainedErrorsMute: feeding the max corrected-bit count before every
+// Decode eventually drives the error rate past the mute threshold, so the
+// output decays to silence.
+func TestSustainedErrorsMute(t *testing.T) {
+	d := New()
+	frame := goodVoiceFrame()
+	var lastPeak int
+	for i := 0; i < 300; i++ {
+		d.SetFrameErrors(15)
+		out, err := d.Decode(frame)
+		if err != nil {
+			t.Fatal(err)
+		}
+		lastPeak = agcPeak(out)
+	}
+	if lastPeak != 0 {
+		t.Errorf("after sustained max errors, output peak = %d, want 0 (muted)", lastPeak)
+	}
+}

--- a/internal/voice/mbe/dcblock.go
+++ b/internal/voice/mbe/dcblock.go
@@ -1,0 +1,41 @@
+package mbe
+
+// DCBlock is a first-order DC-removal high-pass filter applied to the
+// synthesized PCM before the AGC, matching OP25's imbe_vocoder dc_rmv.cc.
+// The MBE synthesizer can leave a small DC / very-low-frequency offset in
+// the output (the voiced cosine sum and the §6.4 overlap-add noise are not
+// guaranteed zero-mean over a frame); left in place that offset wastes AGC
+// headroom and adds inaudible rumble that the limiter then has to absorb.
+//
+// Difference equation (pole at z ≈ 0.99):
+//
+//	y[n] = x[n] − x[n−1] + 0.99·y[n−1]
+//
+// The filter is continuous across frames — the caller keeps one DCBlock
+// per decode stream and Resets it only on stream re-sync, never per frame.
+type DCBlock struct {
+	prevX float64
+	prevY float64
+}
+
+// dcBlockPole is the feedback coefficient (OP25 uses 0.99 in Q1.15).
+const dcBlockPole = 0.99
+
+// Reset clears the filter memory so the next sample starts from zero
+// state. Called on stream re-sync alongside the rest of the synth state.
+func (d *DCBlock) Reset() {
+	d.prevX = 0
+	d.prevY = 0
+}
+
+// Process applies the DC blocker in place over pcm, carrying state across
+// calls so successive frames filter continuously.
+func (d *DCBlock) Process(pcm []float64) {
+	prevX, prevY := d.prevX, d.prevY
+	for i, x := range pcm {
+		y := x - prevX + dcBlockPole*prevY
+		prevX, prevY = x, y
+		pcm[i] = y
+	}
+	d.prevX, d.prevY = prevX, prevY
+}

--- a/internal/voice/mbe/dcblock_test.go
+++ b/internal/voice/mbe/dcblock_test.go
@@ -1,0 +1,53 @@
+package mbe
+
+import (
+	"math"
+	"testing"
+)
+
+// TestDCBlockRemovesConstantOffset: a constant input decays to ~0 (DC is
+// removed) after the filter settles.
+func TestDCBlockRemovesConstantOffset(t *testing.T) {
+	var d DCBlock
+	in := make([]float64, 2000)
+	for i := range in {
+		in[i] = 5000 // pure DC
+	}
+	d.Process(in)
+	// After settling, output should be near zero.
+	tail := in[len(in)-1]
+	if math.Abs(tail) > 1.0 {
+		t.Errorf("DC not removed: tail sample = %v, want ~0", tail)
+	}
+}
+
+// TestDCBlockPassesAC: a mid-band sinusoid passes with most of its
+// amplitude intact (the high-pass only removes near-DC).
+func TestDCBlockPassesAC(t *testing.T) {
+	var d DCBlock
+	const n = 1600
+	in := make([]float64, n)
+	for i := range in {
+		in[i] = 10000 * math.Sin(2*math.Pi*float64(i)/16) // 500 Hz at 8 kHz
+	}
+	d.Process(in)
+	var peak float64
+	for _, v := range in[n/2:] { // after settling
+		if a := math.Abs(v); a > peak {
+			peak = a
+		}
+	}
+	if peak < 9000 {
+		t.Errorf("AC over-attenuated: peak = %v, want > 9000", peak)
+	}
+}
+
+// TestDCBlockReset clears state.
+func TestDCBlockReset(t *testing.T) {
+	var d DCBlock
+	d.Process([]float64{1, 2, 3})
+	d.Reset()
+	if d.prevX != 0 || d.prevY != 0 {
+		t.Errorf("Reset left state %v/%v", d.prevX, d.prevY)
+	}
+}

--- a/internal/voice/mbe/smoothing.go
+++ b/internal/voice/mbe/smoothing.go
@@ -1,0 +1,126 @@
+package mbe
+
+import "math"
+
+// IMBE adaptive smoothing — error-rate-driven cleanup of the decoded model
+// parameters, ported in spirit from the reference decoders (JMBE
+// IMBEModelParameters / MBEModelParameters, OP25 imbe_vocoder). On a weak
+// channel, bit errors that the FEC corrected (or could not) leave the
+// spectral amplitudes and voicing decisions noisy; adaptive smoothing uses
+// a running estimate of the channel error rate to tame amplitude spikes,
+// reclaim obviously-voiced harmonics, and mute hopeless frames.
+//
+// The reference implementations use fixed-point absolute thresholds
+// (e.g. JMBE's 20480 / 6000 / 300 amplitude-sum constants and 10000 energy
+// floor) that are tied to their internal amplitude scale. GopherTrunk's
+// linear amplitudes M_l live on a different scale, so the amplitude and
+// voicing thresholds here are expressed RELATIVE to a running local-energy
+// estimate instead. The error-rate recursion and the mute threshold are
+// scale-free and match the reference exactly.
+//
+// Crucially, on a clean channel (low error rate, few corrected bits) Smooth
+// modifies nothing — it only advances the local-energy tracker — so
+// well-decoded audio is bit-identical with and without this stage.
+
+const (
+	// Error-rate recursion (JMBE): er = 0.95·er_prev + 0.000365·correctedBits.
+	smoothErrorRateDecay = 0.95
+	smoothErrorRateGain  = 0.000365
+
+	// SmoothMuteErrorRate is the error rate above which a frame is muted
+	// (JMBE uses 0.0875). At the IMBE FEC budget (~15 correctable bits/frame)
+	// this requires a sustained ~12+ corrected bits per frame — i.e. the
+	// channel is so bad the audio is unintelligible anyway.
+	SmoothMuteErrorRate = 0.0875
+
+	// A frame at/below this error rate AND corrected-bit count is treated as
+	// clean: amplitude/voicing smoothing is skipped entirely (matches JMBE's
+	// clean-frame test). This is what guarantees no regression on good audio.
+	smoothCleanErrorRate = 0.005
+	smoothCleanBits      = 6
+
+	// Local-energy tracker: le = 0.95·le_prev + 0.05·RM0, with a small floor
+	// to avoid divide-by-zero before any energy has accumulated.
+	smoothEnergyDecay = 0.95
+	smoothEnergyFloor = 1.0
+
+	// smoothAmpCapFactor caps a noisy frame's energy at this multiple of the
+	// smoothed local energy, suppressing error-induced amplitude spikes
+	// relative to the recent speech level.
+	smoothAmpCapFactor = 2.0
+
+	// smoothVoicingFactor forces a harmonic voiced when its amplitude exceeds
+	// this multiple of the per-harmonic RMS — a harmonic that strong is
+	// almost certainly voiced, so a corrupted voicing bit is overridden.
+	smoothVoicingFactor = 2.0
+)
+
+// Smoother holds the per-call adaptive-smoothing memory (running error rate
+// + local energy). One per decoder; cleared by Reset on stream re-sync.
+type Smoother struct {
+	errorRate   float64
+	localEnergy float64
+}
+
+// Reset clears the smoothing memory.
+func (s *Smoother) Reset() {
+	s.errorRate = 0
+	s.localEnergy = 0
+}
+
+// ErrorRate returns the current running channel error-rate estimate.
+func (s *Smoother) ErrorRate() float64 { return s.errorRate }
+
+// UpdateErrorRate folds the frame's FEC corrected-bit count into the running
+// error-rate estimate and reports whether the rate is high enough to mute
+// the frame. Call once per frame, on every path, so the estimate advances
+// uniformly.
+func (s *Smoother) UpdateErrorRate(correctedBits int) (mute bool) {
+	s.errorRate = smoothErrorRateDecay*s.errorRate + smoothErrorRateGain*float64(correctedBits)
+	return s.errorRate > SmoothMuteErrorRate
+}
+
+// Smooth applies error-gated adaptive smoothing to the post-enhancement
+// amplitudes M[1..L] and the voicing decisions p.Vl in place, using a
+// running local-energy estimate. correctedBits is the current frame's FEC
+// corrected-bit count. On a clean channel it only advances the local-energy
+// tracker and returns, leaving M and Vl untouched.
+func (s *Smoother) Smooth(p *Params, M *[MaxL + 1]float64, correctedBits int) {
+	if p.Silent || p.L == 0 {
+		return
+	}
+	rm0 := FrameEnergy(M, p.L)
+	if s.localEnergy == 0 {
+		s.localEnergy = rm0
+	} else {
+		s.localEnergy = smoothEnergyDecay*s.localEnergy + (1-smoothEnergyDecay)*rm0
+	}
+	if s.localEnergy < smoothEnergyFloor {
+		s.localEnergy = smoothEnergyFloor
+	}
+
+	// Clean channel: leave the model parameters exactly as decoded.
+	if s.errorRate <= smoothCleanErrorRate && correctedBits <= smoothCleanBits {
+		return
+	}
+
+	// Amplitude cap: pull down a frame whose energy spikes well above the
+	// recent local energy (a hallmark of bit-error corruption).
+	if ceil := smoothAmpCapFactor * s.localEnergy; rm0 > ceil {
+		scale := math.Sqrt(ceil / rm0)
+		for l := 1; l <= p.L; l++ {
+			M[l] *= scale
+		}
+	}
+
+	// Voicing cleanup: reclaim harmonics that are clearly voiced (amplitude
+	// well above the per-harmonic RMS) but were marked unvoiced, likely by a
+	// corrupted voicing bit.
+	rms := math.Sqrt(s.localEnergy / float64(p.L))
+	vm := smoothVoicingFactor * rms
+	for l := 1; l <= p.L; l++ {
+		if M[l] > vm {
+			p.Vl[l] = 1
+		}
+	}
+}

--- a/internal/voice/mbe/smoothing_test.go
+++ b/internal/voice/mbe/smoothing_test.go
@@ -1,0 +1,94 @@
+package mbe
+
+import (
+	"math"
+	"testing"
+)
+
+// TestSmootherCleanIsInert: at zero corrected bits the error rate stays
+// clean and Smooth leaves amplitudes + voicing untouched.
+func TestSmootherCleanIsInert(t *testing.T) {
+	var s Smoother
+	p := Params{Header: Header{W0: math.Pi / 30, L: 16}}
+	var M [MaxL + 1]float64
+	for l := 1; l <= p.L; l++ {
+		M[l] = float64(l) // arbitrary
+		p.Vl[l] = 0       // all unvoiced
+	}
+	want := M
+	for i := 0; i < 50; i++ {
+		if mute := s.UpdateErrorRate(0); mute {
+			t.Fatalf("frame %d: muted on clean channel", i)
+		}
+		s.Smooth(&p, &M, 0)
+	}
+	if M != want {
+		t.Error("Smooth modified amplitudes on a clean channel")
+	}
+	for l := 1; l <= p.L; l++ {
+		if p.Vl[l] != 0 {
+			t.Errorf("Smooth forced voicing on clean channel at l=%d", l)
+		}
+	}
+}
+
+// TestSmootherMutesOnHighErrorRate: a sustained high corrected-bit count
+// drives the error rate past the mute threshold.
+func TestSmootherMutesOnHighErrorRate(t *testing.T) {
+	var s Smoother
+	muted := false
+	for i := 0; i < 200; i++ {
+		if s.UpdateErrorRate(15) { // max FEC corrections, sustained
+			muted = true
+			break
+		}
+	}
+	if !muted {
+		t.Errorf("error rate never crossed mute threshold %.4f (got %.4f)",
+			SmoothMuteErrorRate, s.ErrorRate())
+	}
+	// And a clean stream never mutes.
+	var s2 Smoother
+	for i := 0; i < 1000; i++ {
+		if s2.UpdateErrorRate(0) {
+			t.Fatal("clean stream muted")
+		}
+	}
+}
+
+// TestSmootherCapsAmplitudeSpike: once the channel is noisy, a frame whose
+// energy spikes far above the running local energy is pulled down.
+func TestSmootherCapsAmplitudeSpike(t *testing.T) {
+	var s Smoother
+	p := Params{Header: Header{W0: math.Pi / 30, L: 16}}
+	// Establish a local-energy baseline over several modest noisy frames.
+	for i := 0; i < 20; i++ {
+		var M [MaxL + 1]float64
+		for l := 1; l <= p.L; l++ {
+			M[l] = 100
+		}
+		s.UpdateErrorRate(8) // noisy enough to leave the clean regime
+		s.Smooth(&p, &M, 8)
+	}
+	// Now a huge spike frame.
+	var spike [MaxL + 1]float64
+	for l := 1; l <= p.L; l++ {
+		spike[l] = 100000
+	}
+	before := FrameEnergy(&spike, p.L)
+	s.UpdateErrorRate(8)
+	s.Smooth(&p, &spike, 8)
+	after := FrameEnergy(&spike, p.L)
+	if after >= before {
+		t.Errorf("spike not capped: energy before=%.0f after=%.0f", before, after)
+	}
+}
+
+func TestSmootherReset(t *testing.T) {
+	var s Smoother
+	s.UpdateErrorRate(10)
+	s.Reset()
+	if s.ErrorRate() != 0 || s.localEnergy != 0 {
+		t.Errorf("Reset left state er=%v le=%v", s.ErrorRate(), s.localEnergy)
+	}
+}

--- a/internal/voice/mbe/synth.go
+++ b/internal/voice/mbe/synth.go
@@ -17,12 +17,32 @@ package mbe
 // Algorithmic reference: szechyjs/mbelib's mbe_spectralAmpDecode
 // (ISC-licensed; attribution preserved at the bottom of tables.go).
 
-// PredictionGain is the inter-frame prediction coefficient γ from
-// eq. 75 (TIA-102.BABA §6.1). The spec fixes it at 0.65: high
-// enough that the harmonic envelope evolves smoothly across frames,
-// low enough that a pathological prev frame can't dominate the
-// current spectrum.
-const PredictionGain = 0.65
+// predictionGain returns the inter-frame log-amplitude prediction
+// coefficient ρ from §6.1, as a function of the harmonic count L. The
+// IMBE algorithm makes ρ pitch-dependent — low for high-pitch / low-L
+// frames so the previous frame's (differently-spaced) spectral envelope
+// is not over-smeared onto the current one, higher for low-pitch / high-L
+// frames where the envelope is more stationary. The breakpoints match the
+// reference decoders (OP25 imbe_vocoder sa_decode.cc and JMBE
+// IMBEFrame.java):
+//
+//	ρ = 0.4               for L ≤ 15   (high pitch, e.g. female voices)
+//	ρ = 0.03·L − 0.05     for 16 ≤ L ≤ 24
+//	ρ = 0.7               for L ≥ 25   (low pitch)
+//
+// GopherTrunk previously hardcoded 0.65 for every frame, which
+// over-predicts high-pitch frames and was the dominant cause of poor
+// female-voice intelligibility versus OP25 / Trunk Recorder.
+func predictionGain(L int) float64 {
+	switch {
+	case L <= 15:
+		return 0.4
+	case L <= 24:
+		return 0.03*float64(L) - 0.05
+	default:
+		return 0.7
+	}
+}
 
 // SynthState carries inter-frame memory needed by the synthesizer.
 // Step 4a uses PrevW0 / PrevL / PrevLog2Ml for the eq. 75-77
@@ -82,6 +102,7 @@ func PredictLog2Ml(s *SynthState, p Params, dst *[57]float64) {
 
 	var pred [57]float64
 	if s.PrevL > 0 && s.PrevW0 > 0 {
+		gain := predictionGain(L)
 		ratio := p.W0 / s.PrevW0
 		for l := 1; l <= L; l++ {
 			pos := float64(l) * ratio
@@ -100,7 +121,7 @@ func PredictLog2Ml(s *SynthState, p Params, dst *[57]float64) {
 			if k1 > s.PrevL {
 				k1 = s.PrevL
 			}
-			pred[l] = PredictionGain *
+			pred[l] = gain *
 				((1-frac)*s.PrevLog2Ml[k] + frac*s.PrevLog2Ml[k1])
 		}
 	}

--- a/internal/voice/mbe/synth_test.go
+++ b/internal/voice/mbe/synth_test.go
@@ -32,7 +32,7 @@ func TestPredictLog2MlFirstFrameIsTl(t *testing.T) {
 }
 
 // TestPredictLog2MlConstantPrevCancels: when prev-frame log2(Ml) is
-// constant c, the prediction is 0.65*c at every l and ave = 0.65*c
+// constant c, the prediction is ρ*c at every l and ave = ρ*c
 // — they cancel in eq. 77 and dst = Tl. This pins the eq. 77 mean
 // subtraction (a flat-spectrum prev frame contributes no tilt to
 // the current frame).
@@ -59,8 +59,8 @@ func TestPredictLog2MlConstantPrevCancels(t *testing.T) {
 // TestPredictLog2MlSamePitchExactInterp: when ω₀_curr == ω₀_prev and
 // L_curr == L_prev, the interpolation index pos = l × 1.0 lands on
 // integer l for every harmonic — no fractional blending. Each
-// dst[l] = 0.65 × prev[l] + Tl[l] − mean(0.65 × prev). Checks the
-// integer-index path.
+// dst[l] = ρ × prev[l] + Tl[l] − mean(ρ × prev), where ρ =
+// predictionGain(L). Checks the integer-index path.
 func TestPredictLog2MlSamePitchExactInterp(t *testing.T) {
 	s := SynthState{PrevW0: math.Pi / 30, PrevL: 4}
 	prev := [5]float64{0, 1.0, 2.0, 3.0, 4.0} // 1-indexed
@@ -72,9 +72,10 @@ func TestPredictLog2MlSamePitchExactInterp(t *testing.T) {
 	var dst [57]float64
 	PredictLog2Ml(&s, p, &dst)
 
-	predMean := PredictionGain * (1.0 + 2.0 + 3.0 + 4.0) / 4.0
+	g := predictionGain(p.L)
+	predMean := g * (1.0 + 2.0 + 3.0 + 4.0) / 4.0
 	for l := 1; l <= p.L; l++ {
-		want := PredictionGain*prev[l] - predMean
+		want := g*prev[l] - predMean
 		if !almostEqual(dst[l], want) {
 			t.Errorf("same-pitch dst[%d] = %v, want %v", l, dst[l], want)
 		}
@@ -104,13 +105,14 @@ func TestPredictLog2MlInterpolationFraction(t *testing.T) {
 	//  l=5 → pos=2.5 → 0.5×prev[2] + 0.5×prev[3] = 5
 	//  l=6 → pos=3.0 → prev[3] = 6
 	rawPred := [7]float64{0, 2, 2, 3, 4, 5, 6}
+	g := predictionGain(p.L)
 	var sum float64
 	for l := 1; l <= 6; l++ {
-		sum += PredictionGain * rawPred[l]
+		sum += g * rawPred[l]
 	}
 	mean := sum / 6.0
 	for l := 1; l <= p.L; l++ {
-		want := PredictionGain*rawPred[l] - mean // Tl is zero
+		want := g*rawPred[l] - mean // Tl is zero
 		if !almostEqual(dst[l], want) {
 			t.Errorf("interp dst[%d] = %v, want %v", l, dst[l], want)
 		}
@@ -240,13 +242,14 @@ func TestPredictLog2MlTwoFrameSequence(t *testing.T) {
 	s.UpdateLog2Ml(p1, &dst1)
 
 	// Frame 2: same pitch + L; prev = {1,2,3,4}. With Tl2 = 0,
-	// dst2[l] = 0.65*l - mean(0.65*{1,2,3,4}) = 0.65*l - 0.65*2.5.
+	// dst2[l] = ρ*l - mean(ρ*{1,2,3,4}) = ρ*l - ρ*2.5, ρ=predictionGain(L).
 	p2 := Params{Header: Header{W0: math.Pi / 30, L: 4}}
 	var dst2 [57]float64
 	PredictLog2Ml(&s, p2, &dst2)
-	predMean := PredictionGain * (1.0 + 2.0 + 3.0 + 4.0) / 4.0
+	g := predictionGain(p2.L)
+	predMean := g * (1.0 + 2.0 + 3.0 + 4.0) / 4.0
 	for l := 1; l <= p2.L; l++ {
-		want := PredictionGain*float64(l) - predMean
+		want := g*float64(l) - predMean
 		if !almostEqual(dst2[l], want) {
 			t.Errorf("frame 2 dst[%d] = %v, want %v", l, dst2[l], want)
 		}
@@ -277,5 +280,23 @@ func TestPredictLog2MlMeanCenteredOutput(t *testing.T) {
 	}
 	if !almostEqual(sum, 0) {
 		t.Errorf("mean-centered Tl: sum(dst) = %v, want 0", sum)
+	}
+}
+
+// TestPredictionGainBreakpoints pins the pitch-dependent prediction
+// coefficient ρ(L) against the OP25 / JMBE reference breakpoints.
+func TestPredictionGainBreakpoints(t *testing.T) {
+	cases := []struct {
+		L    int
+		want float64
+	}{
+		{9, 0.4}, {15, 0.4}, // high pitch (e.g. female)
+		{16, 0.43}, {20, 0.55}, {24, 0.67}, // ramp
+		{25, 0.7}, {40, 0.7}, {56, 0.7}, // low pitch
+	}
+	for _, c := range cases {
+		if got := predictionGain(c.L); !almostEqual(got, c.want) {
+			t.Errorf("predictionGain(%d) = %v, want %v", c.L, got, c.want)
+		}
 	}
 }

--- a/internal/voice/recorder.go
+++ b/internal/voice/recorder.go
@@ -326,6 +326,19 @@ func (r *Recorder) sessionForWrite(serial string) *recordingSession {
 // Frames for a session without either output (no sidecar, no
 // vocoder) are dropped silently.
 func (r *Recorder) WriteRawFrame(deviceSerial string, frame []byte) error {
+	return r.writeRawFrame(deviceSerial, frame, 0, false)
+}
+
+// WriteRawFrameWithErrors is WriteRawFrame plus the channel FEC
+// corrected-bit count for the frame. When the session's vocoder implements
+// voice.ErrorAware (the pure-Go IMBE decoder), the count is handed to it
+// before Decode so adaptive smoothing can estimate the channel error rate.
+// Callers without an error count use WriteRawFrame.
+func (r *Recorder) WriteRawFrameWithErrors(deviceSerial string, frame []byte, correctedBits int) error {
+	return r.writeRawFrame(deviceSerial, frame, correctedBits, true)
+}
+
+func (r *Recorder) writeRawFrame(deviceSerial string, frame []byte, correctedBits int, haveErrs bool) error {
 	s := r.sessionForWrite(deviceSerial)
 	if s == nil {
 		return nil
@@ -336,6 +349,11 @@ func (r *Recorder) WriteRawFrame(deviceSerial string, frame []byte) error {
 		}
 	}
 	if s.vocoder != nil {
+		if haveErrs {
+			if ea, ok := s.vocoder.(ErrorAware); ok {
+				ea.SetFrameErrors(correctedBits)
+			}
+		}
 		samples, err := s.vocoder.Decode(frame)
 		if err != nil {
 			r.log.Warn("recorder: vocoder decode failed; dropping frame from PCM",

--- a/internal/voice/stats.go
+++ b/internal/voice/stats.go
@@ -67,3 +67,13 @@ type StatProvider interface {
 	VoiceStats() (VoiceStats, bool)
 	ResetStats()
 }
+
+// ErrorAware is implemented by vocoders that can use the channel FEC
+// corrected-bit count for the upcoming frame to drive adaptive smoothing
+// (currently the pure-Go IMBE decoder). The recorder calls SetFrameErrors
+// with the per-frame corrected-bit count immediately before Decode when the
+// caller supplies it (P25 Phase 1); a vocoder that doesn't implement this
+// simply ignores the channel error rate.
+type ErrorAware interface {
+	SetFrameErrors(correctedBits int)
+}


### PR DESCRIPTION
## Why

A field tester reported P25 voice sounding "robotic", with **female (high-pitch) voices especially awful**, far behind OP25 / Trunk Recorder for the same speaker. They supplied C4FM + CQPSK captures with `.raw` IMBE sidecars and debug logs. Diagnosis from the captures: **decode is bit-clean** (`uncorrectable_ldus=0`), so every artifact is in the shared IMBE→audio vocoder, not the demod.

This PR fixes the dominant clipping problem, adds the diagnostics that pinned it, and then aligns the vocoder math with the reference decoders (OP25 `imbe_vocoder`, DSheirer JMBE).

## What changed

### 1. AGC was over-driving the audio into clipping (the dominant cause)
The MBE AGC carried a `MinGain` floor of **10**, forcing ≥10× gain onto a synthesizer that already emits near-int16 scale (raw crest factor ≈11). Every loud frame was slammed into the hard clip, flattening speech to crest ≈3.3, railed at ±32767.
- `MinGain` 10 → **0.05** (the AGC may now attenuate) — the actual root cause.
- Hard clip at ±32767 → **tanh soft limiter** (no abrupt clip corners).
- Retuned `TargetPeak` 24000 → **18000**, `Attack` 0.4 → **0.5**, chosen by a sweep over the field captures.
- Result: female speech lands at crest ≈7.8, ~0.02% limited samples (was ≈3.3, railed).

### 2. Per-call voice telemetry (the requested "more verbose debugging")
- New `voice.VoiceStats` / `StatProvider`: pitch/f0, harmonic count, voiced fraction, AGC gain, output peak/RMS/crest, clip %.
- Recorder logs `recorder: voice audio quality` per call at DEBUG, escalating to **WARN when clipping**.
- `gophertrunk decode -stats` prints the same summary for a captured `.raw` sidecar, for offline triage.

### 3. Align the IMBE vocoder with OP25 / JMBE
After comparing GopherTrunk's mbelib-lineage decoder against OP25 `imbe_vocoder` and JMBE:
- **Pitch-dependent spectral-amplitude prediction.** ρ is now a function of harmonic count L (`0.4` for L≤15, `0.03·L−0.05` for 16–24, `0.7` for L≥25), matching both reference decoders, instead of a fixed 0.65. The old constant over-predicted high-pitch / low-L frames and smeared the previous frame's spectral envelope onto them — the main remaining cause of poor female-voice intelligibility. Female crest rose ~7.8 → ~9.8.
- **DC-removal high-pass** on synthesized speech (1st-order, pole 0.99), matching OP25 `dc_rmv.cc`.
- **Adaptive smoothing** driven by the channel FEC error rate (ported in spirit from JMBE `IMBEModelParameters`): a running ε_R estimate caps error-induced amplitude spikes, reclaims obviously-voiced harmonics, and mutes hopeless frames (ε_R > 0.0875). Thresholds are energy-relative (not the reference's fixed-point absolutes) and **inert on a clean channel**, so well-decoded audio is byte-identical. The P25 Phase 1 chain threads the per-frame corrected-bit count to the decoder via a new `voice.ErrorAware` interface; other protocols are unaffected.

### 4. Bonus: shutdown crash fix
Finalizing a dormant post-segment recording session dereferenced a nil `WavWriter` (`wav.go`), panicking on Ctrl-C. Both the session close and `WavWriter.Close` now guard nil.

## Verification
- `go test ./...` and `go vet ./...` pass; new unit tests cover the AGC soft-limit/attenuation/dynamics, dormant-session close, `VoiceStats` accumulation, ρ(L) breakpoints, the DC blocker, and the adaptive smoother (inert when clean, caps spikes, mutes at high error rate; decoder byte-identical at zero errors).
- Real captures re-decoded with `gophertrunk decode -stats`: female crest 9.76 / clip 0.02%, CQPSK male crest 11.10 / clip 0.01% (was crest ≈3.3, railed).

## Notes for review
- The AGC change is shared with AMBE+2, so it also slightly **lowers DMR/NXDN output level** (the intended de-clipping) — the one behavior change beyond P25.
- The adaptive-smoothing *error-path* thresholds couldn't be tuned against a weak-signal reference (the supplied captures decode clean); they're conservative and inert on clean audio, only engaging on already-degraded calls.

https://claude.ai/code/session_01LWPFNLieqKTPUzQYxcZDq8

---
_Generated by [Claude Code](https://claude.ai/code/session_01LWPFNLieqKTPUzQYxcZDq8)_