### PR TITLE
docs: add Basics/Intermediate/Advanced guides extending Getting Started

### DIFF
--- a/docs/_data/nav.yml
+++ b/docs/_data/nav.yml
@@ -5,6 +5,12 @@ groups:
         url: /getting-started.html
       - title: Get started
         url: /getting-started-setup.html
+      - title: Basics
+        url: /guide-basics.html
+      - title: Intermediate
+        url: /guide-intermediate.html
+      - title: Advanced
+        url: /guide-advanced.html
   - label: About
     items:
       - title: The Story of GopherTrunk

--- a/docs/getting-started-setup.md
+++ b/docs/getting-started-setup.md
@@ -96,13 +96,21 @@ The [Web console guide](web.html) walks through what every panel shows.
 
 ## 7. Where to go next
 
-- **Share your feed** — stream calls to Broadcastify Calls, RdioScanner, or
-  OpenMHz from the Settings page.
-- **[Hunt](hunt.html)** — let GopherTrunk discover an unknown system for you.
-- **[Hardening](hardening.html)** — turn on passwords/encryption if you'll reach
-  the console from other devices on your network.
-- **[Opt-in features](opt-in-features.html)** — paging, aircraft (ADS-B), boats
-  (AIS), and more.
+From here, the guides pick up where this page leaves off and walk you through
+the rest of GopherTrunk, one step at a time:
+
+- **[Everyday basics](guide-basics.html)** — drive the console, listen and play
+  back calls, tidy up your talkgroups, and share a feed. **Start here.**
+- **[Going further](guide-intermediate.html)** — multiple dongles, paging alerts,
+  alias files, discovering unknown systems, and reaching the console from your
+  phone.
+- **[Advanced](guide-advanced.html)** — the terminal cockpit, signal scopes,
+  offline analysis, every receiver, and the APIs.
+
+In a hurry to reach a specific feature? Jump straight to
+**[Hunt](hunt.html)** (discover an unknown system),
+**[Hardening](hardening.html)** (passwords/encryption for network access), or
+**[Opt-in features](opt-in-features.html)** (paging, aircraft, boats, and more).
 
 ## If something's not working
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -106,3 +106,7 @@ pipeline — read the [Architecture](architecture.html) reference.
 ---
 
 **Ready to run it? → [Get started](getting-started-setup.html)**
+
+Once it's running, the guides continue the tour from your first call all the way
+to the APIs: [Basics](guide-basics.html) →
+[Intermediate](guide-intermediate.html) → [Advanced](guide-advanced.html).

--- a/docs/guide-advanced.md
+++ b/docs/guide-advanced.md
@@ -1,0 +1,117 @@
+---
+layout: page
+title: Advanced
+description: The full GopherTrunk surface — the TUI cockpit, signal scopes, offline analysis, every receiver, remote SDRs, and the APIs
+nav_group: Getting Started
+---
+
+# Advanced & power-user features
+
+This is the rest of GopherTrunk — the parts you reach for once you're running a
+serious setup or want to integrate it with other tooling. The same single binary
+that's been recording your calls also carries a terminal cockpit, a bench of
+signal scopes, an offline analysis workbench, a dozen more decoders, and typed
+APIs.
+
+> **Before you start.** This guide assumes [Going further](guide-intermediate.html)
+> — comfort with `config.yaml`, the terminal, and a multi-dongle pool. It's
+> comfortable with command-line subcommands and a little signal-processing
+> vocabulary.
+
+## The terminal cockpit and signal scopes
+
+The web console isn't the only front end. The **[TUI](tui.html)** is a
+full-screen terminal cockpit with the same panels — ideal over SSH or on a
+headless box. It also exposes GopherTrunk's **signal scopes**, the tools for
+seeing *why* a signal does or doesn't decode:
+
+- **[Constellation](constellation.html)** — the IQ scatter plot; tight clusters
+  mean a clean signal.
+- **[Eye diagram](eye-diagram.html)** and **[Symbol scope](symbol-scope.html)** —
+  watch the demodulated symbols and how open the "eye" is.
+- **[Plots](plots.html)**, **[Symbol histogram](histogram.html)**, and
+  **[Tuning meters](tuning.html)** — spectrum, symbol distribution, and
+  receiver health at a glance.
+
+Use these to chase down a marginal site: too much gain, a frequency-error
+offset, or a simulcast signal that needs a different demodulator.
+
+## Offline analysis: SigLab and the workbench
+
+Beyond the live daemon, the binary carries a workbench of subcommands for
+working with **recorded captures** instead of a live radio:
+
+- `gophertrunk capture` records raw IQ off a live dongle to a file.
+- `gophertrunk replay` / `analyze` / `identify` decode a capture offline,
+  auto-detect its protocol, and export the results to JSON / YAML / CSV.
+- `gophertrunk test` grades a decode against expected results.
+
+**SigLab** wraps this workbench in a terminal and a browser console
+(`gophertrunk siglab` / `siglab serve`) so you can replay, inspect, and grade
+decodes without a radio attached — the natural home for diagnosing a tricky
+capture or building a regression fixture. The
+[Architecture reference](architecture.html) describes the decode pipeline these
+tools drive.
+
+## Many more receivers
+
+Trunked voice is just the start. GopherTrunk also decodes, each as an opt-in
+receiver with its own log and console panel:
+
+- **[ADS-B](adsb.html)** — aircraft transponders, with a live map.
+- **[AIS](ais.html)** — marine vessel positions.
+- **[APRS / AX.25](aprs.html)** — amateur packet, beacons, and messages.
+- **[DSC](dsc.html)** — marine digital selective calling, including distress.
+- **[MDC1200](mdc1200.html)** — Motorola in-band signaling (PTT IDs, emergency).
+- **[M17](m17.html)** — the open digital-voice link layer.
+
+Which of these are on by default, and how to enable the rest, lives in
+[Opt-in features](opt-in-features.html).
+
+## Remote and recorded sources
+
+Your dongle doesn't have to be on the same machine — or even a physical radio:
+
+- **Remote SDRs** — drive a dongle on another host over `rtl_tcp`, or
+  professional hardware (USRP, LimeSDR, bladeRF, SDRplay) over SoapyRemote.
+- **Baseband IQ record / replay** — capture the wideband IQ stream to disk and
+  later mount the recording as a *virtual* dongle, so you can re-run decodes
+  against the exact same RF.
+
+## APIs and integrations
+
+The daemon is built to be driven by other tools. Everything the consoles do runs
+over public APIs:
+
+- **HTTP REST + Server-Sent Events + WebSocket** — the same API the web console
+  uses; point your own scripts and dashboards at it.
+- **gRPC** — typed clients for calls, talkgroups, and radio IDs.
+- **Prometheus `/metrics`** — scrape GopherTrunk into your monitoring stack.
+- **[rigctld integration](rigctld.html)** — speak the Hamlib wire protocol so
+  amateur-radio logging tools (Cloudlog, GridTracker, satellite trackers) can
+  read and set frequency.
+
+## Squeeze out every decode
+
+When you're chasing the last few percent of a difficult system:
+
+- **[Vocoders](vocoders.html)** and **[Voice calibration](voice-calibration.html)**
+  — how GopherTrunk turns digital voice frames into audio, and how to tune it.
+- **[DMR encryption](dmr-encryption.html)** — supply keys to decode protected
+  DMR traffic you're authorised to monitor.
+- **FEC opt-outs** — per-protocol error-correction toggles, documented in
+  [Opt-in features](opt-in-features.html), for matching pre-stripped captures.
+
+## You now have the complete picture
+
+From "what is this?" to driving the APIs, you've seen the whole of GopherTrunk:
+the conceptual map, a first call, everyday operation, a richer setup, and the
+power-user surface. Where to from here:
+
+- **[Architecture](architecture.html)** — the full design: the multi-consumer IQ
+  fan-out, the DSP chain, the voice pipeline.
+- **[Status](status.html)** and **[Roadmap](roadmap.html)** — what ships today
+  and what's coming.
+- **[Support](support.html)** — where to get help and how to report issues.
+
+← Back to the start: [What is GopherTrunk?](getting-started.html)

--- a/docs/guide-basics.md
+++ b/docs/guide-basics.md
@@ -1,0 +1,99 @@
+---
+layout: page
+title: Basics
+description: Everyday GopherTrunk — drive the web console, listen to calls, tidy up your talkgroups, and share a feed
+nav_group: Getting Started
+---
+
+# Everyday basics
+
+You've got GopherTrunk running and your first call in the history list. This
+page is the next step: the everyday skills for *operating* a scanner you've
+already set up — all from the **web console**, no command line, no config files.
+
+> **Before you start.** This page assumes you've finished
+> [Get started](getting-started-setup.html) and have one system recording. If a
+> control channel isn't locking and calls aren't appearing, go back there first.
+
+## A tour of the console
+
+Everything you do lives in the browser console the daemon opens for you. The
+panels along the top (or the bottom on a phone) are different views of the same
+running scanner. The five you'll use most:
+
+- **Dashboard** — your home base. Live event feed, the audio controls, and an
+  at-a-glance health readout.
+- **Active** — every call happening *right now*, with a live timer. This is the
+  panel to watch when a system is busy.
+- **History** — the searchable call log. Filter by talkgroup, time, or system to
+  find a call you missed.
+- **Systems** — the trunked systems you've added and whether each one is locked.
+- **Talkgroups** — the channels within a system: dispatch, tactical, fireground,
+  and so on.
+
+The full panel-by-panel reference is the [Web console guide](web.html).
+
+## Listening and playback
+
+GopherTrunk records calls whether or not your speakers are on, so there are two
+ways to listen:
+
+- **Live.** The **audio cockpit** at the top of the Dashboard plays calls as they
+  happen. Set the volume, mute, or toggle recording from there. (On a phone or
+  tablet you tap once to enable audio — a browser rule, not a GopherTrunk one.)
+- **From history.** Open any past call in the **History** panel and play it back.
+  Every recording is saved with its talkgroup and timestamp, so you can always
+  go back and re-listen.
+
+## Tidy up your talkgroups
+
+Out of the box GopherTrunk follows *everything* a system carries. Once you know
+which channels you actually care about, the **Talkgroups** panel lets you shape
+what you hear:
+
+- **Scan / lockout** — lock out a talkgroup to skip it entirely (data channels,
+  test ranges, the chatty ones you don't want).
+- **Priority** — mark the important channels so they're easy to spot.
+- **Record / mute** — *record* keeps writing a talkgroup's calls to disk;
+  *mute* keeps it recording but silences it in the live player. Handy for a busy
+  channel you want logged but not blaring.
+
+Changes you make here save on their own and mostly take effect without a
+restart — see [Live edits](live-edits.html).
+
+## Bookmarks and Radio IDs
+
+Two more panels round out day-to-day use:
+
+- **[Bookmarks](bookmarks.html)** — save interesting frequencies and jump back to
+  them later.
+- **[Radio IDs](radio-ids.html)** — see *which radio* is talking, not just which
+  talkgroup. GopherTrunk tracks each radio's recent activity, and you can attach
+  a friendly name (alias) to the ones you recognise.
+
+## Scan more than one system
+
+You're not limited to a single system. Add more from the Config Builder (the
+same guided editor from [Get started](getting-started-setup.html)), and
+GopherTrunk will hunt across them. The **scan mode** decides how much it follows:
+
+- **All** — follow every call on every system (the default).
+- **List** — follow only the talkgroups you've put on your scan list, so a busy
+  system doesn't drown out the channels you came for.
+
+## Share your feed
+
+Want others to hear what you hear? From the **Settings** panel you can stream
+your calls out to the popular aggregators — **Broadcastify Calls**,
+**RdioScanner**, or **OpenMHz** — by pasting in the credentials they give you.
+GopherTrunk handles the encoding and upload. (The finer controls — per-system
+and per-talkgroup filtering, live Icecast/ShoutCast mountpoints — are covered in
+the [next guide](guide-intermediate.html).)
+
+## Where to go next
+
+You can now run GopherTrunk as a scanner day to day. When you're ready to go
+beyond the console — multiple dongles, paging alerts, discovering unknown
+systems, and opening the console to your phone — keep going:
+
+**Next up → [Going further (Intermediate)](guide-intermediate.html)**

--- a/docs/guide-intermediate.md
+++ b/docs/guide-intermediate.md
@@ -1,0 +1,110 @@
+---
+layout: page
+title: Intermediate
+description: Going further with GopherTrunk — the config file, multiple dongles, alias files, paging alerts, system discovery, and network access
+nav_group: Getting Started
+---
+
+# Going further
+
+The console gets you a long way, but GopherTrunk has more under the hood. This
+guide is for when you're ready to open the **config file** and a **terminal** —
+to run more than one dongle, decode paging, discover a system you don't have
+details for, and reach the console from your phone.
+
+> **Before you start.** This builds on [Everyday basics](guide-basics.html) — you
+> should already be comfortable driving the web console and shaping talkgroups.
+
+## The config file
+
+Everything GopherTrunk does is described by one file, `config.yaml`. You have
+two ways to edit it, and you can mix them freely:
+
+- **Config Builder** — the guided, browser-based editor you met in
+  [Get started](getting-started-setup.html). Best for adding systems and
+  talkgroups without learning the YAML layout. It can also pull systems in from a
+  RadioReference PDF or CSV — see [Import (PDF / CSV)](import.html).
+- **By hand** — open `config.yaml` in any text editor. Once you know the layout,
+  this is the fastest way to reach the settings the builder doesn't surface.
+
+Many edits apply **without a restart**. On Linux and macOS you can also send the
+daemon a `SIGHUP` to reload the file on the fly, and small tweaks made in the
+console write straight back to the file — both covered in
+[Live edits](live-edits.html).
+
+## Run more than one dongle
+
+A single dongle follows one control channel and records one call at a time. Add
+a second (or third) dongle and GopherTrunk records **several calls at once** and
+keeps watching the control channel while it does. Each dongle gets a **role**:
+
+- **control** — stays parked on the control channel.
+- **voice** — tunes to call frequencies as grants come in.
+- **auto** — let GopherTrunk decide based on the pool.
+
+On a system with two timeslots (DMR), a voice dongle can capture both slots as
+separate recordings. Getting clean decodes also means **calibrating** each
+dongle — its frequency error (PPM) and gain. The
+[Hardware guide](hardware.html) covers dongle-by-dongle gain and PPM advice; if
+you're on Windows, the [Windows user guide](user-guide-windows.html) walks
+through the driver and device steps.
+
+### One dongle, many channels
+
+If you'd rather cover several carriers with a *single* dongle, the **wideband
+channelizer** digitally slices one wide chunk of spectrum into multiple receivers
+— you can even mix protocols inside the same window. It's a more advanced
+allocation; the [Architecture reference](architecture.html) explains how the
+tuner pool and channelizer fit together.
+
+## Name your channels and radios
+
+GopherTrunk reads **alias files** — CSV or JSON — that map raw numbers to
+friendly names:
+
+- **Talkgroup aliases** turn `1001` into "City Dispatch", and carry the scan,
+  lockout, priority, and stream flags per channel.
+- **Radio ID (RID) aliases** name individual radios. Paired with the live
+  affiliation tracker, you can follow exactly who's on the air — see
+  [Radio IDs](radio-ids.html).
+
+RadioReference exports drop straight in through the [Import](import.html)
+workflow, so you rarely type these by hand.
+
+## Paging and tone alerts
+
+GopherTrunk decodes more than trunked voice:
+
+- **Paging** — turn on the [POCSAG](pocsag.html) and FLEX decoders to log pager
+  traffic, including a wideband mode that catches several pagers on one dongle.
+- **Tone-out alerts** — detect Motorola **Quick Call II** two-tone pages (the
+  fire/EMS dispatch tones) and raise an alert, scoped to the systems and
+  talkgroups you choose.
+
+These and the other opt-in receivers — along with exactly which defaults apply
+— are catalogued in [Opt-in features](opt-in-features.html).
+
+## Discover an unknown system
+
+Don't have the control-channel frequency or protocol for a system near you?
+**Hunt** scans the band, finds trunked control channels, identifies the protocol
+and system IDs, and hands you a ready-to-use config block (it can even prepare a
+RadioReference submission). Full workflow in [Hunt](hunt.html).
+
+## Reach the console from your phone
+
+So far the console has been on the same machine as the daemon. To open it from a
+laptop, tablet, or phone elsewhere on your network — the classic "headless
+Raspberry Pi in the closet, watch from the couch" setup — you'll bind the daemon
+to your network and **turn on authentication** so only you can reach it. Do this
+deliberately: [Hardening](hardening.html) covers passwords, tokens, trusted
+networks, and TLS.
+
+## Where to go next
+
+You can now run a multi-dongle setup, decode paging, name everything, find
+systems on your own, and operate over the network. The last guide opens up the
+power-user surface — the terminal cockpit, signal scopes, offline analysis, the
+other receivers (aircraft, boats, packet), and the APIs:
+
+**Next up → [Advanced & power-user features](guide-advanced.html)**


### PR DESCRIPTION
Continue the Getting Started funnel past the first recorded call with a
three-page learning path that builds level by level and cross-links out to
the existing detailed pages rather than duplicating them:

- guide-basics.md: everyday web-console operation, playback, talkgroup
  tidy-up, bookmarks/radio IDs, scanning, feed sharing
- guide-intermediate.md: config.yaml, multi-dongle pools, alias files,
  paging/tone alerts, Hunt, network access/hardening
- guide-advanced.md: TUI cockpit, signal scopes, SigLab/offline workbench,
  the other receivers, remote SDRs, and the REST/gRPC/Prometheus/rigctld APIs

Wire the three pages into the Getting Started nav group and point the setup
guide's "Where to go next" and the concept page's footer into the new path.