### PR TITLE
Config Builder & web UI: RR login, config browsing/hot-swap, connect UX

### DIFF
--- a/cmd/gophertrunk/activate.go
+++ b/cmd/gophertrunk/activate.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/config"
+)
+
+// The daemon implements api.ConfigActivator (ActivateReload /
+// ActivateRestart) and api.ConfigWriter (WritePatch / Path) so the web
+// Config Builder can load/hot-swap the active config file. The writer
+// methods delegate to the *current* d.writer under the config lock so a
+// reload that re-points the file is reflected by later settings edits.
+
+// Path returns the active config file path (api.ConfigWriter). Empty when
+// no config file backs the daemon.
+func (d *Daemon) Path() string { return d.ConfigPath() }
+
+// WritePatch applies a settings patch to the active config.yaml
+// (api.ConfigWriter), delegating to whichever writer is currently
+// installed so a hot-swapped file is the one that gets edited.
+func (d *Daemon) WritePatch(p config.Patch) (config.Config, error) {
+	d.cfgMu.RLock()
+	w := d.writer
+	d.cfgMu.RUnlock()
+	if w == nil {
+		return config.Config{}, fmt.Errorf("no config file backs this daemon")
+	}
+	return w.WritePatch(p)
+}
+
+// ActivateReload re-points the daemon at path and reloads it in place,
+// hot-applying what it can and returning the applied / restart-required
+// field keys (api.ConfigActivator). Restart-required fields (SDR,
+// trunking systems, recordings, …) need a full restart to take effect —
+// the caller surfaces them so the operator can choose to restart.
+func (d *Daemon) ActivateReload(path string) (applied, restartRequired []string, err error) {
+	applied, restartRequired, err = d.reloadFrom(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	d.log.Info("config activated (reload)", "path", path,
+		"applied", applied, "restart_required", restartRequired)
+	return applied, restartRequired, nil
+}
+
+// ActivateRestart re-execs the daemon into the config at path so every
+// field takes effect (api.ConfigActivator). It validates the new config
+// loads, records the target, and schedules the run context to unwind
+// shortly after returning so the HTTP response flushes first; main then
+// re-execs the binary with the new -config once Run has cleanly returned.
+func (d *Daemon) ActivateRestart(path string) error {
+	if _, err := config.Load(path); err != nil {
+		return fmt.Errorf("new config does not load: %w", err)
+	}
+	d.mu.Lock()
+	d.restartTo = path
+	cancel := d.cancel
+	d.mu.Unlock()
+
+	// Defer the unwind so the handler's 202 reaches the client before the
+	// API server is torn down.
+	go func() {
+		time.Sleep(300 * time.Millisecond)
+		if cancel != nil {
+			cancel()
+		}
+	}()
+	d.log.Info("config activation requested (restart)", "path", path)
+	return nil
+}
+
+// RestartPath returns the config path a restart was requested for, or ""
+// when no restart is pending. main checks this after Run returns to decide
+// whether to re-exec.
+func (d *Daemon) RestartPath() string {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.restartTo
+}
+
+// buildRestartArgs rewrites the process argv so the successor loads
+// newPath: every existing -config / --config token (in either "-config X"
+// or "-config=X" form) is dropped and a single "-config <newPath>" is
+// appended. An explicit -config flag beats $GOPHERTRUNK_CONFIG, so editing
+// the flag is the only reliable way to force the new file.
+func buildRestartArgs(orig []string, newPath string) []string {
+	out := make([]string, 0, len(orig)+2)
+	skipNext := false
+	for i, a := range orig {
+		if skipNext {
+			skipNext = false
+			continue
+		}
+		if i == 0 {
+			out = append(out, a) // argv[0] (program name)
+			continue
+		}
+		if a == "-config" || a == "--config" {
+			skipNext = true // drop the following value too
+			continue
+		}
+		if hasConfigEqPrefix(a) {
+			continue // "-config=X" / "--config=X"
+		}
+		out = append(out, a)
+	}
+	return append(out, "-config", newPath)
+}
+
+// hasConfigEqPrefix reports whether arg is a "-config=" / "--config="
+// inline-value flag.
+func hasConfigEqPrefix(arg string) bool {
+	for _, p := range []string{"-config=", "--config="} {
+		if len(arg) >= len(p) && arg[:len(p)] == p {
+			return true
+		}
+	}
+	return false
+}
+
+// performRestart re-execs the daemon into newPath. Called by main after Run
+// returns with a pending RestartPath and after the instance lock + SDRs are
+// released. Returns only on failure (success replaces the process image on
+// Unix / exits after spawning the successor on Windows).
+func performRestart(newPath string) error {
+	exe, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("restart: locate executable: %w", err)
+	}
+	return execSelf(exe, buildRestartArgs(os.Args, newPath), os.Environ())
+}

--- a/cmd/gophertrunk/activate_restart_unix.go
+++ b/cmd/gophertrunk/activate_restart_unix.go
@@ -1,0 +1,14 @@
+//go:build !windows
+
+package main
+
+import "syscall"
+
+// execSelf replaces the current process image with a fresh invocation of
+// the daemon (argv/env already rewritten to carry the new -config). Because
+// it keeps the same PID and re-runs from scratch, every config field —
+// including restart-required ones like SDR and trunking systems — takes
+// effect. Returns only if exec fails.
+func execSelf(exe string, argv, env []string) error {
+	return syscall.Exec(exe, argv, env)
+}

--- a/cmd/gophertrunk/activate_restart_windows.go
+++ b/cmd/gophertrunk/activate_restart_windows.go
@@ -1,0 +1,26 @@
+//go:build windows
+
+package main
+
+import (
+	"os"
+	"os/exec"
+)
+
+// execSelf starts a fresh detached daemon process (argv/env already
+// rewritten to carry the new -config) and exits the current one. Windows
+// has no syscall.Exec image-replace, so the successor is a new process;
+// the caller has already released the instance lock + SDRs so the new
+// process can claim them. Returns only if the spawn fails.
+func execSelf(exe string, argv, env []string) error {
+	cmd := exec.Command(exe, argv[1:]...)
+	cmd.Env = env
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	os.Exit(0)
+	return nil // unreachable
+}

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -499,6 +499,11 @@ type Daemon struct {
 	mu       sync.Mutex
 	fatalErr error
 	cancel   context.CancelFunc
+	// restartTo, when non-empty, is the config path the daemon should
+	// re-exec into after Run unwinds — set by ActivateRestart when the
+	// operator hot-swaps the config file with "restart" mode. Guarded
+	// by mu and read by main after the run goroutine returns.
+	restartTo string
 
 	wg        sync.WaitGroup
 	closeOnce sync.Once
@@ -1955,10 +1960,18 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 		// started with a -config (otherwise there's no file to write
 		// back to).
 		if d.writer != nil {
-			opts.ConfigWriter = d.writer
+			// Pass the daemon itself as the writer (not the concrete
+			// d.writer) so a config hot-swap that re-points the writer is
+			// reflected by later settings edits.
+			opts.ConfigWriter = d
 			opts.SettingsApplier = newDaemonSettingsApplier(d, version)
 			opts.Importer = newDaemonImporter(d)
 		}
+		// Config hot-swap (reload/restart) from the web Config Builder.
+		// Wired unconditionally so a daemon started on built-in defaults
+		// can still load a freshly-created config file (restart mode
+		// re-execs with -config; reload mode installs the writer).
+		opts.ConfigActivator = d
 		// Embed the SPA when the build linked in real assets
 		// (see web/embed.go). HasAssets is false for fresh
 		// checkouts without `make web-build` — the launcher falls

--- a/cmd/gophertrunk/main.go
+++ b/cmd/gophertrunk/main.go
@@ -340,8 +340,26 @@ func runDaemon(args []string) {
 
 	// Wait for the daemon goroutine to finish (SIGINT/SIGTERM →
 	// ctx cancels → Run unwinds → returns).
-	if err := <-runErr; err != nil && !errors.Is(err, context.Canceled) {
-		logErr(logger, verboseErrors, "daemon exited", err)
+	runExitErr := <-runErr
+
+	// Config hot-swap with "restart" mode: the operator picked a new
+	// config file in the web Config Builder and asked for a full restart.
+	// Tear the daemon down, free the single-instance lock + SDRs, then
+	// re-exec into the new -config so every field (SDR, systems, …) takes
+	// effect. performRestart replaces the process image on success.
+	if newPath := d.RestartPath(); newPath != "" {
+		d.Close()
+		releaseLock()
+		logger.Info("restarting into new config", "path", newPath)
+		if err := performRestart(newPath); err != nil {
+			logErr(logger, verboseErrors, "config restart failed", err)
+			os.Exit(1)
+		}
+		return // unreachable on success (process image replaced)
+	}
+
+	if runExitErr != nil && !errors.Is(runExitErr, context.Canceled) {
+		logErr(logger, verboseErrors, "daemon exited", runExitErr)
 		os.Exit(1)
 	}
 }

--- a/cmd/gophertrunk/reload.go
+++ b/cmd/gophertrunk/reload.go
@@ -13,15 +13,39 @@ import (
 // has to bounce the daemon to pick them up. Returns a one-line
 // summary suitable for the headless console / events bus.
 //
-// Used by the SIGHUP handler in main and (in the future) by the
-// /api/v1/runtime/reload endpoint when that lands.
+// Used by the SIGHUP handler in main and by the config-builder
+// "load this config" action (via ActivateReload) when the operator
+// switches the active config file from the web UI.
 func (d *Daemon) Reload() (string, error) {
 	if d.cfgPath == "" {
 		return "", fmt.Errorf("reload: no config file backs this daemon")
 	}
-	newCfg, err := config.Load(d.cfgPath)
+	applied, restartRequired, err := d.reloadFrom(d.cfgPath)
 	if err != nil {
 		return "", err
+	}
+	summary := fmt.Sprintf("config reloaded: applied=%d restart_required=%d", len(applied), len(restartRequired))
+	if len(applied) > 0 {
+		summary += " (applied: " + joinComma(applied) + ")"
+	}
+	if len(restartRequired) > 0 {
+		summary += " (restart needed: " + joinComma(restartRequired) + ")"
+	}
+	return summary, nil
+}
+
+// reloadFrom loads the config at path, diff-applies the hot-reloadable
+// fields against the in-memory config, and returns the applied vs
+// restart-required field keys. When path differs from the daemon's
+// current config file the writer + cfgPath are re-pointed so future
+// PATCH /api/v1/settings edits and the runtime DTO's config_path track
+// the now-active file — this is what lets the web UI "hot-swap" the
+// config file the daemon uses. Restart-required fields (SDR, trunking
+// systems, recordings, …) still need a full restart to take effect.
+func (d *Daemon) reloadFrom(path string) (applied, restartRequired []string, err error) {
+	newCfg, err := config.Load(path)
+	if err != nil {
+		return nil, nil, err
 	}
 
 	// Serialise the diff-apply phase against concurrent Cfg() reads
@@ -29,8 +53,18 @@ func (d *Daemon) Reload() (string, error) {
 	d.cfgMu.Lock()
 	defer d.cfgMu.Unlock()
 
+	// Re-point the writer + path when switching to a different file so
+	// the rest of the daemon (settings writer, ConfigPath) follows.
+	if path != d.cfgPath {
+		w, werr := config.NewWriter(path)
+		if werr != nil {
+			return nil, nil, fmt.Errorf("reload: open writer for %s: %w", path, werr)
+		}
+		d.writer = w
+		d.cfgPath = path
+	}
+
 	app := newDaemonSettingsApplier(d, "")
-	var applied, restartRequired []string
 
 	// Compare hot-reloadable fields against the in-memory config.
 	old := d.cfg
@@ -79,6 +113,10 @@ func (d *Daemon) Reload() (string, error) {
 		"storage.cc_cache_file":   newCfg.Storage.CCCacheFile != old.Storage.CCCacheFile,
 		"metrics.enabled":         newCfg.Metrics.Enabled != old.Metrics.Enabled,
 		"scanner.cc_hunt.enabled": newCfg.Scanner.CCHunt.Enabled != old.Scanner.CCHunt.Enabled,
+		// When switching to a different file, the set of trunking systems
+		// almost always changes — surface it as restart-required so the
+		// operator knows decoding won't repoint without a bounce.
+		"trunking.systems": !sameSystemNames(newCfg, old),
 	}
 	for key, changed := range coldDiffs {
 		if changed {
@@ -92,14 +130,29 @@ func (d *Daemon) Reload() (string, error) {
 
 	sort.Strings(applied)
 	sort.Strings(restartRequired)
-	summary := fmt.Sprintf("config reloaded: applied=%d restart_required=%d", len(applied), len(restartRequired))
-	if len(applied) > 0 {
-		summary += " (applied: " + joinComma(applied) + ")"
+	return applied, restartRequired, nil
+}
+
+// sameSystemNames reports whether the two configs declare the same set of
+// trunking system names, used to flag a system-list change as
+// restart-required when hot-swapping config files.
+func sameSystemNames(a, b config.Config) bool {
+	if len(a.Trunking.Systems) != len(b.Trunking.Systems) {
+		return false
 	}
-	if len(restartRequired) > 0 {
-		summary += " (restart needed: " + joinComma(restartRequired) + ")"
+	seen := make(map[string]int, len(a.Trunking.Systems))
+	for _, s := range a.Trunking.Systems {
+		seen[s.Name]++
 	}
-	return summary, nil
+	for _, s := range b.Trunking.Systems {
+		seen[s.Name]--
+	}
+	for _, n := range seen {
+		if n != 0 {
+			return false
+		}
+	}
+	return true
 }
 
 func joinComma(s []string) string {

--- a/cmd/gophertrunk/reload_test.go
+++ b/cmd/gophertrunk/reload_test.go
@@ -80,3 +80,94 @@ func TestDaemonReload_NoConfigPath(t *testing.T) {
 		t.Fatal("expected error for daemon without config file")
 	}
 }
+
+// TestDaemonActivateReload_SwitchesFile confirms ActivateReload re-points the
+// daemon at a different config file: the writer/path follow and the
+// hot-reloadable diff is applied against the new file's values.
+func TestDaemonActivateReload_SwitchesFile(t *testing.T) {
+	dir := t.TempDir()
+	pathA := filepath.Join(dir, "a.yaml")
+	pathB := filepath.Join(dir, "b.yaml")
+	if err := os.WriteFile(pathA, []byte(reloadInitialYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(pathB, []byte(reloadUpdatedYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := config.Load(pathA)
+	if err != nil {
+		t.Fatalf("load a: %v", err)
+	}
+	d, err := NewDaemonWithPath(cfg, pathA, "test", slog.New(slog.NewTextHandler(os.Stderr, nil)))
+	if err != nil {
+		t.Fatalf("new daemon: %v", err)
+	}
+
+	applied, restartReq, err := d.ActivateReload(pathB)
+	if err != nil {
+		t.Fatalf("activate reload: %v", err)
+	}
+	if !contains(applied, "scanner.scan_mode") || !contains(applied, "audio.volume") {
+		t.Errorf("expected scan_mode + audio.volume applied, got %v", applied)
+	}
+	if !contains(restartReq, "recordings.dir") {
+		t.Errorf("expected recordings.dir restart-required, got %v", restartReq)
+	}
+	// The daemon now tracks b.yaml as its active config + writer.
+	if d.cfgPath != pathB {
+		t.Errorf("cfgPath = %q want %q", d.cfgPath, pathB)
+	}
+	if d.Path() != pathB {
+		t.Errorf("Path() = %q want %q", d.Path(), pathB)
+	}
+	if d.cfg.Scanner.ScanMode != "list" {
+		t.Errorf("in-memory scan_mode = %q want list", d.cfg.Scanner.ScanMode)
+	}
+}
+
+func TestBuildRestartArgs(t *testing.T) {
+	cases := []struct {
+		name string
+		orig []string
+		want []string
+	}{
+		{
+			name: "appends when absent",
+			orig: []string{"gophertrunk", "run"},
+			want: []string{"gophertrunk", "run", "-config", "/new.yaml"},
+		},
+		{
+			name: "replaces -config value form",
+			orig: []string{"gophertrunk", "run", "-config", "/old.yaml", "-web"},
+			want: []string{"gophertrunk", "run", "-web", "-config", "/new.yaml"},
+		},
+		{
+			name: "replaces --config=eq form",
+			orig: []string{"gophertrunk", "--config=/old.yaml"},
+			want: []string{"gophertrunk", "-config", "/new.yaml"},
+		},
+		{
+			name: "bare invocation",
+			orig: []string{"gophertrunk"},
+			want: []string{"gophertrunk", "-config", "/new.yaml"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := buildRestartArgs(tc.orig, "/new.yaml")
+			if strings.Join(got, " ") != strings.Join(tc.want, " ") {
+				t.Errorf("buildRestartArgs(%v) = %v, want %v", tc.orig, got, tc.want)
+			}
+		})
+	}
+}
+
+func contains(ss []string, want string) bool {
+	for _, s := range ss {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/api/handlers_config_activate.go
+++ b/internal/api/handlers_config_activate.go
@@ -1,0 +1,96 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+)
+
+// ConfigActivator loads/hot-swaps the config file the daemon runs on.
+// Supplied by the daemon; nil on the standalone `config serve` (which has
+// no live daemon to reconfigure), so the activate endpoint returns 503.
+type ConfigActivator interface {
+	// ActivateReload re-points the daemon at path and reloads it in
+	// place, returning the field keys it hot-applied vs. those that need
+	// a restart to take effect.
+	ActivateReload(path string) (applied, restartRequired []string, err error)
+	// ActivateRestart re-execs the daemon into path so every field takes
+	// effect. It returns once the restart is scheduled (the process tears
+	// down and re-execs shortly after); an error means the restart could
+	// not be initiated (e.g. the new config does not load).
+	ActivateRestart(path string) error
+}
+
+// ConfigActivateRequest is the body of POST /api/v1/config/activate.
+type ConfigActivateRequest struct {
+	Path string `json:"path"`
+	// Mode is "reload" (default — hot-apply what it can) or "restart"
+	// (re-exec the daemon so every field takes effect).
+	Mode string `json:"mode,omitempty"`
+}
+
+// ConfigActivateResponse reports the outcome. For reload it carries the
+// applied / restart-required field keys; for restart it just echoes the
+// target (the daemon is tearing down to re-exec).
+type ConfigActivateResponse struct {
+	Path            string   `json:"path"`
+	Mode            string   `json:"mode"`
+	Applied         []string `json:"applied,omitempty"`
+	RestartRequired []string `json:"restart_required,omitempty"`
+	Restarting      bool     `json:"restarting,omitempty"`
+}
+
+// handleConfigActivate answers POST /api/v1/config/activate (gated). It
+// validates the requested path against the builder's allow-list and then
+// either reloads the daemon in place or schedules a restart into the new
+// config file.
+func (s *Server) handleConfigActivate(w http.ResponseWriter, r *http.Request) {
+	if s.configActiv == nil {
+		s.writeError(w, http.StatusServiceUnavailable,
+			"config: activation not supported (no daemon backs this server)")
+		return
+	}
+	var req ConfigActivateRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		s.writeError(w, http.StatusBadRequest, "config: "+err.Error())
+		return
+	}
+	path, err := s.configBuilder.resolvePath(req.Path)
+	if err != nil {
+		s.writeError(w, http.StatusBadRequest, "config: "+err.Error())
+		return
+	}
+	if _, err := os.Stat(path); err != nil {
+		s.writeError(w, http.StatusNotFound, "config: "+err.Error())
+		return
+	}
+
+	switch req.Mode {
+	case "", "reload":
+		applied, restartRequired, aerr := s.configActiv.ActivateReload(path)
+		if aerr != nil {
+			s.writeError(w, http.StatusBadRequest, "config: "+aerr.Error())
+			return
+		}
+		writeJSON(w, http.StatusOK, ConfigActivateResponse{
+			Path:            path,
+			Mode:            "reload",
+			Applied:         applied,
+			RestartRequired: restartRequired,
+		})
+	case "restart":
+		if aerr := s.configActiv.ActivateRestart(path); aerr != nil {
+			s.writeError(w, http.StatusBadRequest, "config: "+aerr.Error())
+			return
+		}
+		// 202: the daemon accepted the restart and is tearing down to
+		// re-exec; the SPA should expect a disconnect + reconnect.
+		writeJSON(w, http.StatusAccepted, ConfigActivateResponse{
+			Path:       path,
+			Mode:       "restart",
+			Restarting: true,
+		})
+	default:
+		s.writeError(w, http.StatusBadRequest, `config: mode must be "reload" or "restart"`)
+	}
+}

--- a/internal/api/handlers_config_activate_test.go
+++ b/internal/api/handlers_config_activate_test.go
@@ -1,0 +1,143 @@
+package api
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/config"
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+)
+
+// fakeActivator records the activate calls so the handler tests can assert
+// the right path/mode reached the daemon without a real re-exec.
+type fakeActivator struct {
+	reloadPath  string
+	restartPath string
+	applied     []string
+	restartReq  []string
+	reloadErr   error
+}
+
+func (f *fakeActivator) ActivateReload(path string) ([]string, []string, error) {
+	f.reloadPath = path
+	return f.applied, f.restartReq, f.reloadErr
+}
+
+func (f *fakeActivator) ActivateRestart(path string) error {
+	f.restartPath = path
+	return nil
+}
+
+func cbActivateServer(t *testing.T, act ConfigActivator) (string, string, func()) {
+	t.Helper()
+	dir := t.TempDir()
+	bus := events.NewBus(8)
+	base, teardown := mkServer(t, ServerOptions{
+		Bus:             bus,
+		AllowMutations:  true,
+		ConfigBuilder:   ConfigBuilderOptions{Enabled: true, ConfigDir: dir},
+		ConfigActivator: act,
+	})
+	return base, dir, func() {
+		teardown()
+		bus.Close()
+	}
+}
+
+func seedDefaultConfig(t *testing.T, dir, name string) string {
+	t.Helper()
+	data, err := config.Marshal(config.Default())
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func TestConfigActivate_Reload(t *testing.T) {
+	act := &fakeActivator{applied: []string{"log.level"}, restartReq: []string{"sdr.sample_rate"}}
+	base, dir, teardown := cbActivateServer(t, act)
+	defer teardown()
+	p := seedDefaultConfig(t, dir, "config.yaml")
+
+	var resp ConfigActivateResponse
+	postJSON(t, base+"/api/v1/config/activate", ConfigActivateRequest{Path: p, Mode: "reload"}, &resp)
+	if act.reloadPath != p {
+		t.Fatalf("ActivateReload got %q, want %q", act.reloadPath, p)
+	}
+	if resp.Mode != "reload" || len(resp.Applied) != 1 || len(resp.RestartRequired) != 1 {
+		t.Fatalf("unexpected response: %+v", resp)
+	}
+}
+
+func TestConfigActivate_DefaultModeIsReload(t *testing.T) {
+	act := &fakeActivator{}
+	base, dir, teardown := cbActivateServer(t, act)
+	defer teardown()
+	p := seedDefaultConfig(t, dir, "config.yaml")
+
+	var resp ConfigActivateResponse
+	postJSON(t, base+"/api/v1/config/activate", ConfigActivateRequest{Path: p}, &resp)
+	if act.reloadPath != p || act.restartPath != "" {
+		t.Fatalf("empty mode should reload: reload=%q restart=%q", act.reloadPath, act.restartPath)
+	}
+}
+
+func TestConfigActivate_Restart(t *testing.T) {
+	act := &fakeActivator{}
+	base, dir, teardown := cbActivateServer(t, act)
+	defer teardown()
+	p := seedDefaultConfig(t, dir, "config.yaml")
+
+	code := postJSONStatus(t, base+"/api/v1/config/activate", ConfigActivateRequest{Path: p, Mode: "restart"}, nil)
+	if code != http.StatusAccepted {
+		t.Fatalf("restart status=%d, want 202", code)
+	}
+	if act.restartPath != p {
+		t.Fatalf("ActivateRestart got %q, want %q", act.restartPath, p)
+	}
+}
+
+func TestConfigActivate_NoActivatorIs503(t *testing.T) {
+	base, dir, teardown := cbActivateServer(t, nil)
+	defer teardown()
+	p := seedDefaultConfig(t, dir, "config.yaml")
+
+	code := postJSONStatus(t, base+"/api/v1/config/activate", ConfigActivateRequest{Path: p}, nil)
+	if code != http.StatusServiceUnavailable {
+		t.Fatalf("status=%d, want 503", code)
+	}
+}
+
+func TestConfigActivate_RejectsPathOutsideRoots(t *testing.T) {
+	act := &fakeActivator{}
+	base, _, teardown := cbActivateServer(t, act)
+	defer teardown()
+
+	code := postJSONStatus(t, base+"/api/v1/config/activate",
+		ConfigActivateRequest{Path: "/etc/elsewhere.yaml", Mode: "reload"}, nil)
+	if code != http.StatusBadRequest {
+		t.Fatalf("status=%d, want 400", code)
+	}
+	if act.reloadPath != "" {
+		t.Fatalf("activator must not be called for a rejected path (got %q)", act.reloadPath)
+	}
+}
+
+func TestConfigActivate_RejectsUnknownMode(t *testing.T) {
+	act := &fakeActivator{}
+	base, dir, teardown := cbActivateServer(t, act)
+	defer teardown()
+	p := seedDefaultConfig(t, dir, "config.yaml")
+
+	code := postJSONStatus(t, base+"/api/v1/config/activate",
+		ConfigActivateRequest{Path: p, Mode: "bogus"}, nil)
+	if code != http.StatusBadRequest {
+		t.Fatalf("status=%d, want 400", code)
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -250,6 +250,7 @@ type Server struct {
 	broadcast    BroadcastStatusProvider
 	runtime      RuntimeProvider
 	configWriter ConfigWriter
+	configActiv  ConfigActivator
 	settings     SettingsApplier
 	importer     Importer
 	imports      *importStaging
@@ -534,6 +535,13 @@ type ServerOptions struct {
 	// (returns 503) so daemons started without a -config file don't
 	// pretend the SPA's edits will persist.
 	ConfigWriter ConfigWriter
+	// ConfigActivator, when supplied, enables POST /api/v1/config/activate:
+	// the daemon loads/hot-swaps the config file the operator picks in the
+	// web Config Builder, either reloading in place (hot-applying what it
+	// can) or re-execing into the new file. nil disables the endpoint
+	// (returns 503) — e.g. the standalone `config serve`, which has no
+	// daemon to reconfigure.
+	ConfigActivator ConfigActivator
 	// SettingsApplier is the in-process hot-reload surface invoked
 	// by handleSettingsPatch after the on-disk write succeeds.
 	// Optional: when nil, every field is reported as
@@ -746,6 +754,7 @@ func NewServer(opts ServerOptions) (*Server, error) {
 		broadcast:      opts.Broadcast,
 		runtime:        opts.Runtime,
 		configWriter:   opts.ConfigWriter,
+		configActiv:    opts.ConfigActivator,
 		settings:       opts.SettingsApplier,
 		importer:       opts.Importer,
 		imports:        newImportStaging(5 * time.Minute),
@@ -1055,6 +1064,7 @@ func (s *Server) routes() *http.ServeMux {
 		mux.HandleFunc("DELETE /api/v1/config/file", s.gate(s.handleConfigDelete))
 		mux.HandleFunc("POST /api/v1/config/file/rename", s.gate(s.handleConfigRename))
 		mux.HandleFunc("POST /api/v1/config/dir", s.gate(s.handleConfigMkdir))
+		mux.HandleFunc("POST /api/v1/config/activate", s.gate(s.handleConfigActivate))
 		mux.HandleFunc("POST /api/v1/config/parse", s.gate(s.handleConfigParse))
 		mux.HandleFunc("GET /api/v1/config/rr/search", s.handleConfigRRSearch)
 		mux.HandleFunc("GET /api/v1/config/rr/states", s.handleConfigRRStates)

--- a/web/configbuilder/src/App.tsx
+++ b/web/configbuilder/src/App.tsx
@@ -14,8 +14,6 @@ export function App() {
   const lastSaved = useStore((s) => s.lastSaved);
   const setError = useStore((s) => s.setError);
   const dismissError = useStore((s) => s.dismissError);
-  const token = useStore((s) => s.token);
-  const setTok = useStore((s) => s.setToken);
 
   const [active, setActive] = useState("trunking");
   const [showPreview, setShowPreview] = useState(true);
@@ -110,13 +108,6 @@ export function App() {
               </span>
             )
           ) : null}
-          <input
-            className="input w-48"
-            type="password"
-            placeholder="API token (if required)"
-            value={token}
-            onChange={(e) => setTok(e.target.value)}
-          />
           <button className="btn-ghost" onClick={() => setShowPreview((p) => !p)}>
             {showPreview ? "Hide preview" : "Show preview"}
           </button>

--- a/web/configbuilder/src/api/client.test.ts
+++ b/web/configbuilder/src/api/client.test.ts
@@ -16,9 +16,9 @@ function mockFetch(bodyObj: unknown) {
 }
 
 describe("RR client credential headers", () => {
-  it("rrVerify POSTs with the X-RR-* creds the user is editing", async () => {
+  it("rrVerify POSTs with the X-RR-* login the user is editing (no app key)", async () => {
     const fetchMock = mockFetch({ ok: true, premium: true, username: "alice" });
-    const r = await api.rrVerify({ key: "K", user: "alice", pass: "pw" });
+    const r = await api.rrVerify({ user: "alice", pass: "pw" });
     expect(r.ok).toBe(true);
     expect(r.premium).toBe(true);
 
@@ -26,14 +26,15 @@ describe("RR client credential headers", () => {
     expect(url).toBe("/api/v1/config/rr/verify");
     expect(init?.method).toBe("POST");
     const h = init?.headers as Record<string, string>;
-    expect(h["X-RR-Key"]).toBe("K");
+    // The SOAP app key is built into the binary — never sent from the browser.
+    expect(h["X-RR-Key"]).toBeUndefined();
     expect(h["X-RR-User"]).toBe("alice");
     expect(h["X-RR-Pass"]).toBe("pw");
   });
 
   it("omits empty/blank cred headers", async () => {
     const fetchMock = mockFetch({ results: [] });
-    await api.rrStates({ key: "", user: "  ", pass: undefined });
+    await api.rrStates({ user: "  ", pass: undefined });
     const h = fetchMock.mock.calls[0][1]?.headers as Record<string, string>;
     expect(h["X-RR-Key"]).toBeUndefined();
     expect(h["X-RR-User"]).toBeUndefined();

--- a/web/configbuilder/src/api/client.ts
+++ b/web/configbuilder/src/api/client.ts
@@ -118,14 +118,15 @@ export const api = {
     req<RRVerifyResponse>("POST", "/config/rr/verify", undefined, rrHeaders(creds)),
 };
 
-// RRCreds are the RadioReference credentials the user is editing, sent on the
+// RRCreds is the RadioReference login the user is editing, sent on the
 // browse/verify calls as X-RR-* headers so what they type is what reaches RR
-// (and verifies their premium subscription) — kept out of the URL/query.
-export type RRCreds = { key?: string; user?: string; pass?: string };
+// (and verifies their premium subscription) — kept out of the URL/query. The
+// SOAP app key is baked into the binary at build time, so it is never sent
+// from the browser.
+export type RRCreds = { user?: string; pass?: string };
 
 function rrHeaders(c?: RRCreds): Record<string, string> {
   const h: Record<string, string> = {};
-  if (c?.key?.trim()) h["X-RR-Key"] = c.key.trim();
   if (c?.user?.trim()) h["X-RR-User"] = c.user.trim();
   if (c?.pass?.trim()) h["X-RR-Pass"] = c.pass.trim();
   return h;

--- a/web/configbuilder/src/components/BrowseConfigs.tsx
+++ b/web/configbuilder/src/components/BrowseConfigs.tsx
@@ -1,0 +1,143 @@
+import { useEffect, useMemo, useState } from "react";
+import { api } from "../api/client";
+import { useStore } from "../store/shared";
+import type { ConfigFileInfo } from "../api/types";
+
+// BrowseConfigs is a prominent, full file browser for the config files
+// discovered in the server's allowed directories — available and
+// previously-created configs alike. It groups files by directory and shows
+// name, last-modified time, size, and a valid/⚠ badge so an operator can find
+// and open the right one at a glance. Opening a file delegates to the store's
+// load(); the lightweight "Open ▾" dropdown in the FileBar stays for quick
+// switches.
+export function BrowseConfigs(props: { onClose: () => void }) {
+  const load = useStore((s) => s.load);
+  const setError = useStore((s) => s.setError);
+  const current = useStore((s) => s.path);
+  const busy = useStore((s) => s.busy);
+
+  const [files, setFiles] = useState<ConfigFileInfo[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [filter, setFilter] = useState("");
+
+  useEffect(() => {
+    let cancel = false;
+    (async () => {
+      try {
+        const r = await api.listFiles();
+        if (!cancel) setFiles(r.files ?? []);
+      } catch (e) {
+        if (!cancel) setError(`List failed: ${(e as Error).message}`);
+      } finally {
+        if (!cancel) setLoading(false);
+      }
+    })();
+    return () => {
+      cancel = true;
+    };
+  }, [setError]);
+
+  const f = filter.trim().toLowerCase();
+  // Group the (filtered) files by their containing directory, preserving the
+  // discovery order the server returned.
+  const groups = useMemo(() => {
+    const out: { dir: string; files: ConfigFileInfo[] }[] = [];
+    for (const file of files) {
+      if (f && !file.name.toLowerCase().includes(f) && !file.dir.toLowerCase().includes(f)) {
+        continue;
+      }
+      let g = out.find((x) => x.dir === file.dir);
+      if (!g) {
+        g = { dir: file.dir, files: [] };
+        out.push(g);
+      }
+      g.files.push(file);
+    }
+    return out;
+  }, [files, f]);
+
+  const openFile = async (path: string) => {
+    props.onClose();
+    await load(path);
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-start justify-center bg-black/60 p-4 overflow-y-auto">
+      <div className="card w-full max-w-2xl space-y-4">
+        <div className="flex items-center justify-between">
+          <h3 className="text-base font-semibold">Browse config files</h3>
+          <button className="btn-ghost" onClick={props.onClose}>
+            Close
+          </button>
+        </div>
+
+        <input
+          className="input"
+          placeholder="filter by file name or folder"
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+        />
+
+        {loading ? (
+          <p className="help">Loading…</p>
+        ) : groups.length === 0 ? (
+          <p className="help">
+            {files.length === 0
+              ? "No config files found in the discovery directories. Use “New” to start one."
+              : "No files match the filter."}
+          </p>
+        ) : (
+          <div className="max-h-[60vh] space-y-4 overflow-y-auto">
+            {groups.map((g) => (
+              <div key={g.dir} className="space-y-1">
+                <div className="help truncate font-mono text-xs">{g.dir}</div>
+                {g.files.map((file) => (
+                  <button
+                    key={file.path}
+                    disabled={busy}
+                    onClick={() => openFile(file.path)}
+                    title={file.path}
+                    className={`flex w-full items-center justify-between gap-3 rounded border px-3 py-2 text-left text-sm hover:bg-white/5 ${
+                      file.path === current ? "border-accent/50 bg-accent/10" : "border-white/10"
+                    }`}
+                  >
+                    <span className="min-w-0">
+                      <span className={file.valid ? "" : "text-warn"}>
+                        {file.valid ? "" : "⚠ "}
+                        {file.name}
+                      </span>
+                      {file.path === current ? (
+                        <span className="ml-2 text-xs text-accent">current</span>
+                      ) : null}
+                      <span className="help block truncate">
+                        {fmtModified(file.modified)} · {fmtSize(file.size)}
+                        {file.valid ? "" : " · invalid"}
+                      </span>
+                    </span>
+                    <span className="shrink-0 text-xs text-muted">Open</span>
+                  </button>
+                ))}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// fmtModified renders the RFC3339 timestamp as a compact local date-time,
+// falling back to the raw string if it can't be parsed.
+function fmtModified(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso || "—";
+  return d.toLocaleString();
+}
+
+// fmtSize renders a byte count in human units.
+function fmtSize(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes < 0) return "—";
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}

--- a/web/configbuilder/src/components/FileBar.tsx
+++ b/web/configbuilder/src/components/FileBar.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { api } from "../api/client";
 import { useStore } from "../store/shared";
+import { BrowseConfigs } from "./BrowseConfigs";
 import { downloadName, joinPath, pathCollides } from "../lib/fileName";
 import type { ConfigFileInfo } from "../api/types";
 
@@ -19,6 +20,7 @@ export function FileBar() {
   const [dirs, setDirs] = useState<string[]>([]);
   const [openMenu, setOpenMenu] = useState(false);
   const [saveOpen, setSaveOpen] = useState(false);
+  const [browseOpen, setBrowseOpen] = useState(false);
 
   const refresh = async () => {
     try {
@@ -120,6 +122,15 @@ export function FileBar() {
       </div>
 
       <button
+        className="btn-ghost"
+        disabled={busy}
+        title="Browse available and previously-created config files"
+        onClick={() => setBrowseOpen(true)}
+      >
+        Browse…
+      </button>
+
+      <button
         className="btn"
         disabled={busy}
         onClick={async () => {
@@ -176,6 +187,8 @@ export function FileBar() {
         {path ? path : "untitled (new config)"}
         {dirty ? " — unsaved changes" : ""}
       </span>
+
+      {browseOpen ? <BrowseConfigs onClose={() => setBrowseOpen(false)} /> : null}
 
       {saveOpen ? (
         <SaveDialog

--- a/web/configbuilder/src/components/RRCredentials.tsx
+++ b/web/configbuilder/src/components/RRCredentials.tsx
@@ -1,0 +1,84 @@
+import { useState } from "react";
+import { TextField } from "./fields";
+import { useSection } from "../sections/useSection";
+import { api } from "../api/client";
+import type { RadioReferenceConfig } from "../api/types";
+
+// RRCredentials is the shared RadioReference sign-in block: just a
+// username + password (the SOAP app key is built into the binary at link
+// time, so operators never see or supply it) plus a "Verify subscription"
+// button. It reads/writes the draft's RadioReference section directly, so
+// whatever is typed here is sent on every RR browse/import call and is
+// persisted to radioreference.* when the config is saved.
+//
+// Used both in the dedicated RadioReference Login section and inline at the
+// top of the "Add from RadioReference" browse modal, so credentials can be
+// entered right where they're needed.
+export function RRCredentials() {
+  const [v, set] = useSection("RadioReference");
+  const cfg = v as RadioReferenceConfig;
+  const [verify, setVerify] = useState<{ busy: boolean; ok?: boolean; msg?: string }>({
+    busy: false,
+  });
+
+  // runVerify sends the edited username/password (the built-in app key is
+  // applied server-side) to the server, which calls RadioReference and
+  // reports whether the subscription is premium.
+  const runVerify = async () => {
+    setVerify({ busy: true });
+    try {
+      const r = await api.rrVerify({ user: cfg.Username, pass: cfg.Password });
+      if (!r.ok) {
+        setVerify({ busy: false, ok: false, msg: r.fault || "Could not verify the account." });
+      } else if (r.premium) {
+        setVerify({
+          busy: false,
+          ok: true,
+          msg: `Premium subscription active${r.expires ? ` until ${r.expires}` : ""}${r.username ? ` (${r.username})` : ""}.`,
+        });
+      } else {
+        setVerify({
+          busy: false,
+          ok: false,
+          msg: `Logged in${r.username ? ` as ${r.username}` : ""}, but no active premium subscription was found.`,
+        });
+      }
+    } catch (e) {
+      setVerify({ busy: false, ok: false, msg: (e as Error).message });
+    }
+  };
+
+  return (
+    <div className="space-y-3">
+      <TextField
+        label="Username"
+        value={cfg.Username}
+        onChange={(x) => set({ ...cfg, Username: x })}
+        placeholder="your RadioReference.com username"
+      />
+      <TextField
+        label="Password"
+        type="password"
+        value={cfg.Password}
+        onChange={(x) => set({ ...cfg, Password: x })}
+        placeholder="your RadioReference.com password"
+      />
+      <p className="help">
+        GopherTrunk ships with a built-in RadioReference app key — just sign in
+        with your RadioReference.com username and password. A premium
+        subscription is required for trunked-system browse/import.
+      </p>
+      <div className="flex flex-wrap items-center gap-3">
+        <button className="btn" disabled={verify.busy} onClick={runVerify}>
+          {verify.busy ? "Verifying…" : "Verify subscription"}
+        </button>
+        {verify.msg ? (
+          <span className={verify.ok ? "text-sm text-ok" : "text-sm text-err"}>
+            {verify.ok ? "✓ " : "✗ "}
+            {verify.msg}
+          </span>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/web/configbuilder/src/main.tsx
+++ b/web/configbuilder/src/main.tsx
@@ -2,10 +2,25 @@ import React from "react";
 import { createRoot } from "react-dom/client";
 import { registerSW } from "virtual:pwa-register";
 import { App } from "./App";
+import { setToken } from "./api/client";
 import "./styles.css";
 
 document.documentElement.classList.add("dark");
 registerSW({ immediate: true });
+
+// Bearer-token bootstrap for non-loopback `config serve` binds. The default
+// loopback bind needs no token, so the top bar has no token field; remote
+// deployments hand out a one-click link carrying `#token=...`. Strip the hash
+// immediately so the token isn't left in the URL/bookmarks/screenshots.
+(() => {
+  if (!window.location.hash.includes("=")) return;
+  const params = new URLSearchParams(window.location.hash.slice(1));
+  const token = params.get("token");
+  if (token) {
+    setToken(token);
+    history.replaceState(null, "", window.location.pathname + window.location.search);
+  }
+})();
 
 const root = document.getElementById("root");
 if (!root) throw new Error("missing #root");

--- a/web/configbuilder/src/sections/Trunking.tsx
+++ b/web/configbuilder/src/sections/Trunking.tsx
@@ -10,9 +10,10 @@ import {
 } from "../components/fields";
 import { ListEditor } from "../components/ListEditor";
 import { AdvancedJSON } from "../components/AdvancedJSON";
+import { RRCredentials } from "../components/RRCredentials";
 import { dmrBandPlanForMode, dmrBandPlanMode } from "../lib/dmrBandPlan";
 import { useStore } from "../store/shared";
-import { api } from "../api/client";
+import { api, HTTPError } from "../api/client";
 import type {
   DMRBandPlanTableEntry,
   EncryptionKey,
@@ -422,11 +423,28 @@ function RRBrowseModal(props: {
   onAdd: (sys: SystemConfig, tgs?: TalkgroupCSVRow[]) => void;
 }) {
   const setError = useStore((s) => s.setError);
-  // The RadioReference creds the user is editing — sent with every RR call so
-  // their premium login is what reaches the API (not just the server's startup
-  // creds).
+  // The RadioReference login the user is editing — sent with every RR call so
+  // their premium login is what reaches the API (the SOAP app key is built into
+  // the binary, so only username/password travel from here).
   const rr = useStore((s) => s.config?.RadioReference);
-  const creds = { key: rr?.APIKey, user: rr?.Username, pass: rr?.Password };
+  const creds = { user: rr?.Username, pass: rr?.Password };
+  const hasLogin = !!(rr?.Username?.trim() && rr?.Password?.trim());
+  // The credentials block auto-expands when no login is set (or after a 503),
+  // so "Add from RadioReference" asks for a login in place instead of throwing
+  // the bare "credentials not configured" error.
+  const [credsOpen, setCredsOpen] = useState(!hasLogin);
+  const [credsHint, setCredsHint] = useState<string | null>(null);
+  // handleRRError turns a "not configured" 503 into an inline prompt for the
+  // login (expanding the block) instead of a red toast; everything else still
+  // surfaces as a toast.
+  const handleRRError = (e: unknown) => {
+    if (e instanceof HTTPError && e.status === 503) {
+      setCredsOpen(true);
+      setCredsHint("Sign in with your RadioReference.com username and password to browse systems.");
+      return;
+    }
+    setError(`RadioReference: ${(e as Error).message}`);
+  };
   const [mode, setMode] = useState<"name" | "zip" | "advanced">("name");
 
   // name mode: state → county dropdowns.
@@ -448,11 +466,12 @@ function RRBrowseModal(props: {
     if (mode !== "name" || states !== null) return;
     setBusy(true);
     api
-      .rrStates()
+      .rrStates(creds)
       .then((r) => setStates(r.results ?? []))
-      .catch((e) => setError(`RadioReference: ${(e as Error).message}`))
+      .catch(handleRRError)
       .finally(() => setBusy(false));
-  }, [mode, states, setError]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mode, states]);
 
   const onStateChange = async (v: string) => {
     setStid(v);
@@ -465,7 +484,7 @@ function RRBrowseModal(props: {
       const r = await api.rrCounties(Number(v), creds);
       setCounties(r.results ?? []);
     } catch (e) {
-      setError(`RadioReference: ${(e as Error).message}`);
+      handleRRError(e);
     } finally {
       setBusy(false);
     }
@@ -478,7 +497,7 @@ function RRBrowseModal(props: {
       const r = await fn();
       setHits(r.results ?? []);
     } catch (e) {
-      setError(`RadioReference: ${(e as Error).message}`);
+      handleRRError(e);
     } finally {
       setBusy(false);
     }
@@ -491,7 +510,7 @@ function RRBrowseModal(props: {
       props.onAdd(r.config, r.talkgroups ?? []);
       props.onClose();
     } catch (e) {
-      setError(`RadioReference: ${(e as Error).message}`);
+      handleRRError(e);
     } finally {
       setBusy(false);
     }
@@ -501,8 +520,29 @@ function RRBrowseModal(props: {
     <Modal title="Browse RadioReference.com" onClose={props.onClose}>
       <p className="help">
         Find a trunked system and import it with its control channels and
-        talkgroups. Requires RadioReference credentials configured on the server.
+        talkgroups. Sign in with your RadioReference.com account below — a
+        premium subscription is required.
       </p>
+
+      <div className="rounded-md border border-white/10 p-3">
+        <button
+          className="flex w-full items-center justify-between text-left text-sm font-medium"
+          onClick={() => setCredsOpen((o) => !o)}
+        >
+          <span>
+            RadioReference login{hasLogin ? "" : " — required"}
+            {hasLogin ? <span className="ml-2 text-xs text-ok">✓ set</span> : null}
+          </span>
+          <span className="text-muted">{credsOpen ? "▾" : "▸"}</span>
+        </button>
+        {credsHint ? <p className="mt-2 text-sm text-warn">{credsHint}</p> : null}
+        {credsOpen ? (
+          <div className="mt-3">
+            <RRCredentials />
+          </div>
+        ) : null}
+      </div>
+
       <div className="flex gap-2 text-sm">
         {(["name", "zip", "advanced"] as const).map((m) => (
           <button

--- a/web/configbuilder/src/sections/index.tsx
+++ b/web/configbuilder/src/sections/index.tsx
@@ -40,6 +40,7 @@ export interface SectionDef {
 
 export const SECTIONS: SectionDef[] = [
   { key: "trunking", cfgKey: "Trunking", label: "Trunking", render: () => <TrunkingSection /> },
+  { key: "radioreference", cfgKey: "RadioReference", label: "RadioReference Login", render: () => <RadioReferenceSection /> },
   { key: "sdr", cfgKey: "SDR", label: "SDR", render: () => <SDRSection /> },
   { key: "api", cfgKey: "API", label: "API & Web", render: () => <APISection /> },
   { key: "scanner", cfgKey: "Scanner", label: "Scanner", render: () => <ScannerSection /> },
@@ -50,7 +51,6 @@ export const SECTIONS: SectionDef[] = [
   { key: "metrics", cfgKey: "Metrics", label: "Metrics", render: () => <MetricsSection /> },
   { key: "log", cfgKey: "Log", label: "Logging", render: () => <LogSection /> },
   { key: "diagnostics", cfgKey: "Diagnostics", label: "Diagnostics", render: () => <DiagnosticsSection /> },
-  { key: "radioreference", cfgKey: "RadioReference", label: "RadioReference", render: () => <RadioReferenceSection /> },
   { key: "web", cfgKey: "Web", label: "Web UI", render: () => <WebSection /> },
   { key: "tone_out", cfgKey: "ToneOut", label: "Tone-out", render: () => <ToneOutSection /> },
   { key: "broadcast", cfgKey: "Broadcast", label: "Broadcast", render: () => <BroadcastSection /> },

--- a/web/configbuilder/src/sections/simple.tsx
+++ b/web/configbuilder/src/sections/simple.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import { Section } from "../components/Section";
 import {
   BoolField,
@@ -9,8 +8,8 @@ import {
   TextField,
 } from "../components/fields";
 import { ListEditor } from "../components/ListEditor";
+import { RRCredentials } from "../components/RRCredentials";
 import { formatCommaList, parseCommaList } from "../lib/csvList";
-import { api } from "../api/client";
 import { useStore } from "../store/shared";
 import type {
   APIConfig,
@@ -20,7 +19,6 @@ import type {
   GTConfig,
   LogConfig,
   MetricsConfig,
-  RadioReferenceConfig,
   RecordingsConfig,
   RetentionConfig,
   ScannerConfig,
@@ -120,61 +118,12 @@ export function DiagnosticsSection() {
 }
 
 export function RadioReferenceSection() {
-  const [v, set] = useSection("RadioReference");
-  const cfg = v as RadioReferenceConfig;
-  const [verify, setVerify] = useState<{ busy: boolean; ok?: boolean; msg?: string }>({ busy: false });
-
-  // runVerify sends the edited username/password (+ the built-in/overridden app
-  // key) to the server, which calls RadioReference and reports whether the
-  // subscription is premium.
-  const runVerify = async () => {
-    setVerify({ busy: true });
-    try {
-      const r = await api.rrVerify({ key: cfg.APIKey, user: cfg.Username, pass: cfg.Password });
-      if (!r.ok) {
-        setVerify({ busy: false, ok: false, msg: r.fault || "Could not verify the account." });
-      } else if (r.premium) {
-        setVerify({
-          busy: false,
-          ok: true,
-          msg: `Premium subscription active${r.expires ? ` until ${r.expires}` : ""}${r.username ? ` (${r.username})` : ""}.`,
-        });
-      } else {
-        setVerify({
-          busy: false,
-          ok: false,
-          msg: `Logged in${r.username ? ` as ${r.username}` : ""}, but no active premium subscription was found.`,
-        });
-      }
-    } catch (e) {
-      setVerify({ busy: false, ok: false, msg: (e as Error).message });
-    }
-  };
-
   return (
     <Section
       sectionKey="radioreference"
-      title="RadioReference"
+      title="RadioReference Login"
     >
-      <TextField label="API key" value={cfg.APIKey} onChange={(x) => set({ ...cfg, APIKey: x })} />
-      <TextField label="Username" value={cfg.Username} onChange={(x) => set({ ...cfg, Username: x })} />
-      <TextField
-        label="Password"
-        type="password"
-        value={cfg.Password}
-        onChange={(x) => set({ ...cfg, Password: x })}
-      />
-      <div className="flex flex-wrap items-center gap-3">
-        <button className="btn" disabled={verify.busy} onClick={runVerify}>
-          {verify.busy ? "Verifying…" : "Verify subscription"}
-        </button>
-        {verify.msg ? (
-          <span className={verify.ok ? "text-sm text-ok" : "text-sm text-err"}>
-            {verify.ok ? "✓ " : "✗ "}
-            {verify.msg}
-          </span>
-        ) : null}
-      </div>
+      <RRCredentials />
     </Section>
   );
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Navigate, Route, Routes, useNavigate } from "react-router-dom";
 import { api, HTTPError } from "./api/client";
 import { openEventStream } from "./api/events";
@@ -37,6 +37,7 @@ import { Systems } from "./panels/Systems";
 import { Talkgroups } from "./panels/Talkgroups";
 import { Tones } from "./panels/Tones";
 import { useShared } from "./store/shared";
+import { prefs } from "./store/prefs";
 
 const TABS: Tab[] = [
   { to: "/dashboard", label: "Dashboard", icon: "▤" },
@@ -81,10 +82,19 @@ export function App() {
   const setWSStatus = useShared((s) => s.setWSStatus);
   const hiddenTabs = useShared((s) => s.hiddenTabs);
   const setHiddenTabs = useShared((s) => s.setHiddenTabs);
+  const setConfigPath = useShared((s) => s.setConfigPath);
+  const configPath = useShared((s) => s.configPath);
   const appendEvents = useShared((s) => s.appendEvents);
   const lastError = useShared((s) => s.lastError);
   const setError = useShared((s) => s.setError);
   const navigate = useNavigate();
+
+  // No-config nudge: when the daemon runs without a -config file
+  // (config_path === ""), offer the Config Builder. Dismissal is
+  // per-tab so it doesn't nag after the operator waves it off.
+  const [noConfigDismissed, setNoConfigDismissed] = useState(
+    prefs.noConfigDismissed(),
+  );
 
   // On mount, if we already have a server URL stored, try to validate
   // and skip the connect screen.
@@ -123,11 +133,16 @@ export function App() {
       .catch(() => setMutations(null));
 
     // Pull the runtime snapshot once to learn which nav tabs the
-    // operator turned off via web.tabs in config. On failure we leave
-    // the nav untouched (everything visible) rather than blank it.
+    // operator turned off via web.tabs in config, and whether a config
+    // file backs the daemon (empty config_path → offer the Config
+    // Builder). On failure we leave the nav untouched (everything
+    // visible) rather than blank it.
     api
       .runtime(cfg)
-      .then((rt) => setHiddenTabs(rt.hidden_tabs ?? []))
+      .then((rt) => {
+        setHiddenTabs(rt.hidden_tabs ?? []);
+        setConfigPath(rt.config_path ?? "");
+      })
       .catch(() => setHiddenTabs([]));
 
     const stream = openEventStream(cfg, {
@@ -145,6 +160,7 @@ export function App() {
     setMutations,
     setWSStatus,
     setHiddenTabs,
+    setConfigPath,
   ]);
 
   // A hidden tab is dropped from both the main strip and the desktop
@@ -169,6 +185,30 @@ export function App() {
   return (
     <div className="min-h-full flex flex-col">
       <TabBar tabs={visibleTabs} />
+
+      {configPath === "" && !noConfigDismissed && (
+        <div className="flex items-start gap-2 border-b border-warn/40 bg-warn/15 px-4 py-2 text-sm text-warn">
+          <span className="flex-1">
+            No config file is loaded — the daemon is running on built-in
+            defaults. Open the Config Builder to create or load one.
+          </span>
+          <button
+            className="btn-ghost shrink-0 text-xs"
+            onClick={() => window.open("/config/", "_blank", "noopener")}
+          >
+            Open Config Builder ↗
+          </button>
+          <button
+            className="shrink-0 text-xs underline"
+            onClick={() => {
+              prefs.setNoConfigDismissed(true);
+              setNoConfigDismissed(true);
+            }}
+          >
+            dismiss
+          </button>
+        </div>
+      )}
 
       {/* Desktop overflow tabs sit beneath the main strip so the
           bottom-nav-friendly four-tab limit still leaves room for

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -8,6 +8,7 @@ import type {
   ActiveCallDTO,
   AudioStatusDTO,
   CallRow,
+  ConfigListResponse,
   DeviceDTO,
   Health,
   HuntStatus,
@@ -201,6 +202,11 @@ export const api = {
     request<AudioStatusDTO>(c, "GET", "/api/v1/audio"),
   metricsText: (c: ClientConfig) =>
     request<string>(c, "GET", "/metrics", undefined, 5_000),
+  // Config files discovered by the Config Builder subsystem, for the
+  // Settings config-file picker. Returns 503 (caught by the caller) when
+  // the daemon was built/started without the config-builder subsystem.
+  configFiles: (c: ClientConfig) =>
+    request<ConfigListResponse>(c, "GET", "/api/v1/config/files"),
 };
 
 // Re-export the request helper for the write module.

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -314,6 +314,33 @@ export interface SettingsResponse {
   runtime: RuntimeDTO;
 }
 
+// ConfigFileInfo describes one discovered config file (GET
+// /api/v1/config/files), used by the Settings config-file picker.
+export interface ConfigFileInfo {
+  path: string;
+  dir: string;
+  name: string;
+  size: number;
+  modified: string; // RFC3339
+  valid: boolean;
+  error?: string;
+}
+
+export interface ConfigListResponse {
+  dirs: string[];
+  files: ConfigFileInfo[];
+}
+
+// ConfigActivateResponse is the outcome of loading/hot-swapping the active
+// config file (POST /api/v1/config/activate).
+export interface ConfigActivateResponse {
+  path: string;
+  mode: "reload" | "restart";
+  applied?: string[];
+  restart_required?: string[];
+  restarting?: boolean;
+}
+
 // ParsedSystemDTO is one row in an import preview.
 export interface ParsedSystemDTO {
   name: string;

--- a/web/src/api/write.ts
+++ b/web/src/api/write.ts
@@ -3,6 +3,7 @@
 import { type ClientConfig, joinURL, HTTPError, request } from "./client";
 import type {
   AudioStatusDTO,
+  ConfigActivateResponse,
   HuntStartRequest,
   ImportPreview,
   ImportResult,
@@ -119,6 +120,16 @@ export const writes = {
 
   updateSettings: (c: ClientConfig, patch: SettingsPatch) =>
     request<SettingsResponse>(c, "PATCH", "/api/v1/settings", patch),
+
+  // Load / hot-swap the config file the daemon runs on. "reload"
+  // hot-applies what it can and flags the rest as restart-required;
+  // "restart" re-execs the daemon into the new file (the connection
+  // drops and the SPA reconnects).
+  activateConfig: (c: ClientConfig, path: string, mode: "reload" | "restart") =>
+    request<ConfigActivateResponse>(c, "POST", "/api/v1/config/activate", {
+      path,
+      mode,
+    }),
 
   importUpload: (c: ClientConfig, files: File[]) =>
     importMultipart(c, files),

--- a/web/src/components/ConnectScreen.tsx
+++ b/web/src/components/ConnectScreen.tsx
@@ -14,7 +14,7 @@ export function ConnectScreen() {
   const setConnected = useShared((s) => s.setConnected);
   const rememberDefault = useShared((s) => s.rememberToken);
 
-  const [url, setUrl] = useState(useShared.getState().serverURL ?? "");
+  const [url, setUrl] = useState(useShared.getState().serverURL ?? suggestedServerURL());
   const [token, setToken] = useState(useShared.getState().token ?? "");
   const [remember, setRemember] = useState(rememberDefault);
   const [busy, setBusy] = useState(false);
@@ -93,6 +93,15 @@ export function ConnectScreen() {
             spellCheck={false}
             inputMode="url"
           />
+          {canFillThisDevice() && (
+            <button
+              type="button"
+              className="text-xs text-accent underline"
+              onClick={() => setUrl(window.location.origin)}
+            >
+              Use this device's address ({window.location.origin})
+            </button>
+          )}
         </label>
 
         <label className="block space-y-1">
@@ -141,4 +150,21 @@ export function ConnectScreen() {
       </form>
     </div>
   );
+}
+
+// suggestedServerURL pre-fills the field with this device's origin when the
+// SPA is served over http(s) by the daemon (origin === the daemon's address),
+// so the common "open the daemon URL" case is one click. Opened from a
+// file:// bundle there's no useful origin, so fall back to empty (the
+// #server= hash bootstrap covers that path).
+function suggestedServerURL(): string {
+  return canFillThisDevice() ? window.location.origin : "";
+}
+
+// canFillThisDevice reports whether window.location.origin is a usable daemon
+// address (the page was served over http/https, not file://).
+function canFillThisDevice(): boolean {
+  if (typeof window === "undefined") return false;
+  const p = window.location.protocol;
+  return p === "http:" || p === "https:";
 }

--- a/web/src/panels/Settings.test.tsx
+++ b/web/src/panels/Settings.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 vi.mock("../api/client", () => ({
-  api: { runtime: vi.fn() },
+  api: { runtime: vi.fn(), configFiles: vi.fn() },
   HTTPError: class HTTPError extends Error {
     status: number;
     body: string;
@@ -63,6 +63,9 @@ describe("Settings inline-edit (Live config)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     resetStore();
+    // The config-file picker lists files on mount; default to an empty
+    // list so it stays quiet for the live-config tests.
+    vi.mocked(api.configFiles).mockResolvedValue({ dirs: [], files: [] });
   });
 
   it("hides editable rows and shows the no-config banner when daemon has no -config", async () => {

--- a/web/src/panels/Settings.tsx
+++ b/web/src/panels/Settings.tsx
@@ -1,7 +1,12 @@
 import { useEffect, useState } from "react";
 import { api, HTTPError } from "../api/client";
 import { writes } from "../api/write";
-import type { RuntimeDTO, SettingsPatch } from "../api/types";
+import type {
+  ConfigActivateResponse,
+  ConfigFileInfo,
+  RuntimeDTO,
+  SettingsPatch,
+} from "../api/types";
 import { prefs, type Theme } from "../store/prefs";
 import {
   selectCanMutate,
@@ -109,6 +114,8 @@ export function Settings() {
           available.
         </p>
       </section>
+
+      <ConfigFileSection />
 
       <LiveConfigSection />
 
@@ -431,4 +438,206 @@ function parseBool(v: string): boolean {
       return false;
   }
   throw new Error("expected true/false (also accepts on/off, yes/no, 1/0)");
+}
+
+// --- Config file (load / hot-swap) ---
+//
+// ConfigFileSection lists the config files the daemon discovered and lets
+// the operator switch the active one. "Reload" hot-applies what it can and
+// flags the rest as restart-required; "Restart" re-execs the daemon into the
+// new file (every field takes effect) — the connection drops, so we poll
+// health and reload the page once it's back.
+function ConfigFileSection() {
+  const cfg = useShared(selectClientConfig);
+  const canMutate = useShared(selectCanMutate);
+  const currentPath = useShared((s) => s.configPath);
+
+  const [files, setFiles] = useState<ConfigFileInfo[] | null>(null);
+  const [unavailable, setUnavailable] = useState(false);
+  const [pending, setPending] = useState<string | null>(null); // path awaiting reload/restart choice
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<ConfigActivateResponse | null>(null);
+  const [restarting, setRestarting] = useState(false);
+
+  useEffect(() => {
+    let cancel = false;
+    (async () => {
+      try {
+        const r = await api.configFiles(cfg);
+        if (!cancel) setFiles(r.files ?? []);
+      } catch (e) {
+        // 503 → the config-builder subsystem isn't wired (shouldn't happen
+        // on the daemon, but be defensive); hide the section in that case.
+        if (!cancel) {
+          if (e instanceof HTTPError && e.status === 503) setUnavailable(true);
+          else setError((e as Error).message);
+          setFiles([]);
+        }
+      }
+    })();
+    return () => {
+      cancel = true;
+    };
+  }, [cfg]);
+
+  if (unavailable) return null;
+
+  async function activate(path: string, mode: "reload" | "restart") {
+    setError(null);
+    setResult(null);
+    setBusy(true);
+    try {
+      const r = await writes.activateConfig(cfg, path, mode);
+      setPending(null);
+      if (mode === "restart") {
+        setRestarting(true);
+        void waitForDaemonAndReload(cfg);
+      } else {
+        setResult(r);
+      }
+    } catch (e) {
+      if (e instanceof HTTPError) setError(e.message);
+      else setError(String(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <section className="panel p-4 space-y-3">
+      <h3 className="panel-title">Config file</h3>
+      <p className="text-xs text-muted">
+        {currentPath
+          ? <>Active: <code className="font-mono">{currentPath}</code></>
+          : "The daemon is running on built-in defaults (no config file)."}
+      </p>
+
+      {!canMutate && (
+        <div className="text-sm panel bg-warn/15 border-warn/40 text-warn p-3">
+          Mutations are disabled — daemon auth blocks switching config files.
+        </div>
+      )}
+      {error && (
+        <div role="alert" className="text-sm panel bg-err/15 border-err/40 text-err p-3">
+          {error}
+        </div>
+      )}
+      {restarting && (
+        <div className="text-sm panel bg-accent/15 border-accent/40 p-3">
+          Daemon restarting into the new config… this page will reload once
+          it's back.
+        </div>
+      )}
+      {result && (
+        <div className="text-sm panel bg-ok/15 border-ok/40 p-3 space-y-1">
+          <div>
+            Loaded <code className="font-mono">{result.path}</code>.
+          </div>
+          {result.applied && result.applied.length > 0 && (
+            <div>Applied live: {result.applied.join(", ")}.</div>
+          )}
+          {result.restart_required && result.restart_required.length > 0 && (
+            <div className="text-warn">
+              Restart required for: {result.restart_required.join(", ")} — use
+              “Restart” to apply these.
+            </div>
+          )}
+        </div>
+      )}
+
+      {files === null ? (
+        <p className="text-sm text-muted">Loading…</p>
+      ) : files.length === 0 ? (
+        <p className="text-sm text-muted">
+          No config files found in the discovery directories.
+        </p>
+      ) : (
+        <ul className="space-y-1">
+          {files.map((f) => (
+            <li
+              key={f.path}
+              className={`rounded border p-2 text-sm ${
+                f.path === currentPath ? "border-accent/50 bg-accent/10" : "border-panel"
+              }`}
+            >
+              <div className="flex items-center justify-between gap-2">
+                <span className="min-w-0">
+                  <span className={f.valid ? "" : "text-warn"}>
+                    {f.valid ? "" : "⚠ "}
+                    {f.name}
+                  </span>
+                  {f.path === currentPath && (
+                    <span className="ml-2 text-xs text-accent">active</span>
+                  )}
+                  <span className="block truncate text-xs text-muted">{f.dir}</span>
+                </span>
+                {f.path !== currentPath &&
+                  (pending === f.path ? (
+                    <span className="flex shrink-0 gap-1">
+                      <button
+                        className="btn-ghost text-xs"
+                        disabled={busy || !f.valid}
+                        title={f.valid ? "Reload live (hot-apply what it can)" : "Fix validation errors first"}
+                        onClick={() => activate(f.path, "reload")}
+                      >
+                        Reload
+                      </button>
+                      <button
+                        className="btn-ghost text-xs text-warn"
+                        disabled={busy || !f.valid}
+                        title="Restart the daemon into this config (drops the session briefly)"
+                        onClick={() => activate(f.path, "restart")}
+                      >
+                        Restart
+                      </button>
+                      <button
+                        className="text-xs underline"
+                        disabled={busy}
+                        onClick={() => setPending(null)}
+                      >
+                        cancel
+                      </button>
+                    </span>
+                  ) : (
+                    <button
+                      className="btn-ghost shrink-0 text-xs"
+                      disabled={!canMutate || busy}
+                      onClick={() => {
+                        setResult(null);
+                        setError(null);
+                        setPending(f.path);
+                      }}
+                    >
+                      Load this config
+                    </button>
+                  ))}
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+// waitForDaemonAndReload polls /api/v1/health until the restarted daemon is
+// reachable again (or a cap is hit), then reloads the page so the SPA
+// re-bootstraps cleanly against the new config.
+async function waitForDaemonAndReload(cfg: { baseURL: string; token: string | null }) {
+  const deadline = Date.now() + 60_000;
+  // Give the daemon a moment to tear down before we start probing.
+  await new Promise((r) => setTimeout(r, 1_500));
+  while (Date.now() < deadline) {
+    try {
+      await api.health(cfg);
+      window.location.reload();
+      return;
+    } catch {
+      await new Promise((r) => setTimeout(r, 1_500));
+    }
+  }
+  // Gave up waiting — reload anyway so the operator sees the connect screen
+  // (or a recovered session) rather than a stuck "restarting…" banner.
+  window.location.reload();
 }

--- a/web/src/store/prefs.ts
+++ b/web/src/store/prefs.ts
@@ -42,6 +42,9 @@ const LS_KEYS = {
 const SS_KEYS = {
   tokenSession: "gt.token.session",
   lastTab: "gt.ui.lastTab",
+  // Per-tab dismissal of the "daemon has no config — open the Config
+  // Builder?" banner, so it doesn't nag after the operator waves it off.
+  noConfigDismissed: "gt.ui.noConfigDismissed",
 } as const;
 
 export type Theme = "dark" | "monochrome";
@@ -138,6 +141,13 @@ export const prefs = {
   },
   setLastTab(name: string | null) {
     writeSS(SS_KEYS.lastTab, name);
+  },
+
+  noConfigDismissed(): boolean {
+    return readSS(SS_KEYS.noConfigDismissed) === "1";
+  },
+  setNoConfigDismissed(dismissed: boolean) {
+    writeSS(SS_KEYS.noConfigDismissed, dismissed ? "1" : null);
   },
 
   installPromptDismissed(): boolean {

--- a/web/src/store/shared.ts
+++ b/web/src/store/shared.ts
@@ -47,6 +47,11 @@ interface SharedState {
    *  nav bar filters these out. Sourced from /api/v1/runtime. */
   hiddenTabs: string[];
 
+  /** Absolute path of the config.yaml backing the daemon, or "" when it
+   *  runs on built-in defaults (no -config). null until the runtime
+   *  snapshot has been fetched. Sourced from /api/v1/runtime. */
+  configPath: string | null;
+
   /** Last error surfaced from any request, for the toast strip. */
   lastError: string | null;
 
@@ -64,6 +69,7 @@ interface SharedState {
   setDevices(d: DeviceDTO[]): void;
   setScanner(s: ScannerStatusDTO | null): void;
   setHiddenTabs(tabs: string[]): void;
+  setConfigPath(path: string | null): void;
   appendEvents(evs: EventDTO[]): void;
   setError(msg: string | null): void;
   reset(): void;
@@ -89,6 +95,7 @@ export const useShared = create<SharedState>((set, get) => ({
   events: [],
   eventCap: 500,
   hiddenTabs: [],
+  configPath: null,
 
   lastError: null,
 
@@ -136,6 +143,9 @@ export const useShared = create<SharedState>((set, get) => ({
   },
   setHiddenTabs(tabs) {
     set({ hiddenTabs: tabs });
+  },
+  setConfigPath(path) {
+    set({ configPath: path });
   },
   appendEvents(evs) {
     if (evs.length === 0) return;
@@ -191,6 +201,7 @@ export const useShared = create<SharedState>((set, get) => ({
       events: [],
       mutations: null,
       hiddenTabs: [],
+      configPath: null,
       lastError: null,
     });
   },


### PR DESCRIPTION
Config Builder:
- Add a shared RadioReference login block (username + password only; the
  SOAP app key is built into the binary via the RR_APP_KEY secret, so it's
  no longer shown). Surface it inline in the "Add from RadioReference"
  modal — auto-expanded when no login is set or after a 503 — so browsing
  prompts for credentials in place instead of throwing "credentials not
  configured". Move the RadioReference Login section near the top of the nav.
- Remove the "API token (if required)" field from the top bar; non-loopback
  binds can still pass a bearer token via a #token= URL hash on load.
- Add a prominent "Browse…" config-file browser listing available and
  previously-created configs with folder, modified time, size, and validity.

Web interface:
- Connect screen pre-fills the server URL with this device's origin and adds
  a "Use this device's address" button, still editable before connecting.
- When the daemon runs without a config file, show a dismissible banner
  offering to open the Config Builder.
- Settings gains a Config file picker to load/hot-swap the active config,
  with a choice of live Reload (hot-applies what it can, flags the rest as
  restart-required) or full Restart (re-execs the daemon into the new file).

Backend:
- New POST /api/v1/config/activate (gated) + ConfigActivator seam. The
  daemon implements ActivateReload (re-points writer/cfgPath and diff-applies
  via the shared reload path) and ActivateRestart (re-execs with the new
  -config). Pass the daemon itself as ConfigWriter so a hot-swap is reflected
  by later settings edits.

https://claude.ai/code/session_01Bksmdy976s1hUfuKDo8q9u