### PR TITLE
Fix Airspy IQ rate, probe gains, voice_taps cap, and silent audio failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ for tagged releases.
 
 ### Changed
 
+- **`voice_taps` is no longer capped at 8.** A wideband dongle can now host any
+  number of concurrent virtual voice DDC taps. Each tap runs its own DDC so CPU
+  scales roughly linearly per tap; the daemon logs a warning above 16 so an
+  accidental large value doesn't quietly peg a core.
+
 - **P25 IMBE voice quality: align the vocoder with the OP25 / JMBE reference
   decoders.** Three changes ported after comparing GopherTrunk's mbelib-lineage
   decoder against OP25's `imbe_vocoder` and DSheirer's JMBE:
@@ -33,6 +38,28 @@ for tagged releases.
 
 ### Fixed
 
+- **Airspy R2 / Mini received nothing — web spectrum showed only the DC spike.**
+  The Airspy is a real-sampling receiver whose host-side converter decimates by
+  two, so the delivered IQ rate is half the programmed device rate. The driver
+  was sending the requested rate straight to firmware, so `sample_rate:
+  3_000_000` ran the device at 3 MSPS (1.5 MHz of IQ) while the rest of the
+  pipeline assumed 3 MHz — a 2× mismatch that mis-tuned every decoder. The
+  driver now programs the device at twice the requested IQ rate, so a 3 MHz IQ
+  rate correctly selects the Airspy's 6 MSPS mode.
+- **`gophertrunk sdr list --probe` reported empty gains `[]` for Airspy and
+  HackRF.** The per-device open path rebuilt `sdr.Info` without copying the gain
+  ladder that `Enumerate` populates, so the probe (which reads the opened
+  device) saw nothing. Both drivers now carry the ladder onto the opened device,
+  matching RTL-SDR. Gain values are in tenths of dB (Airspy 0–500, HackRF
+  0–560); see `config.example.yaml`.
+- **Live audio failed silently.** When `audio.enabled: true` but the sink
+  couldn't open, the player logged a single WARN and ran headless, leaving no
+  signal as to why nothing played. Backend init failure now logs at ERROR with
+  the reason, and the cause is surfaced via `GET /api/v1/audio`
+  (`backend_error`) and `Stats`. The direct-ioctl path (`device:
+  "ioctl:hw:C,D"`) now explains that it pins S16_LE mono at the configured rate
+  — which onboard codecs typically reject — and points at the default libasound
+  device, which resamples.
 - **P25/DMR voice was over-driven into clipping (robotic, "female voices
   especially awful")**. The MBE-family AGC carried a `MinGain` floor of 10,
   forcing at least a 10× gain onto a synthesizer that already emits near-int16

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -3087,6 +3087,13 @@ func (d *Daemon) buildVirtualVoiceTuners(cfg config.Config, log *slog.Logger) er
 				"serial", devCfg.Serial, "voice_taps", taps)
 			taps = 0
 		}
+		// Each tap runs its own DDC, so CPU scales ~linearly per tap.
+		// There's no hard cap, but flag a high count so an accidental
+		// large value doesn't quietly peg a core.
+		if taps > 16 {
+			log.Warn("daemon: wideband: high voice_taps count; CPU scales ~linearly per tap (each is an independent DDC)",
+				"serial", devCfg.Serial, "voice_taps", taps)
+		}
 		for i := 0; i < taps; i++ {
 			vt, err := wbvoice.New(wbvoice.Options{
 				Serial:           fmt.Sprintf("wb:%s:tap-%d", entry.Info.Serial, i),
@@ -3481,6 +3488,13 @@ func (a audioCockpit) BackendEnabled() bool {
 		return false
 	}
 	return a.player.Stats().Enabled
+}
+
+func (a audioCockpit) BackendError() string {
+	if a.player == nil {
+		return ""
+	}
+	return a.player.Stats().BackendError
 }
 
 // poolDevices adapts *sdr.Pool to composer.Devices. The composer

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -188,6 +188,12 @@ sdr:
       gain: "auto"         # TENTHS of a dB — NOT dB. "496" = 49.6 dB. SDRTrunk/
                            # OP25/gqrx users: multiply your dB figure by 10
                            # (32 dB → "320"). "auto" (AGC) is the safe default.
+                           # Run `gophertrunk sdr list --probe` to print each
+                           # device's supported gain ladder (tenths of dB).
+                           # Typical ranges: RTL-SDR R820T 0–496; Airspy R2/Mini
+                           # 0–500 (~0–50 dB, spread across LNA/mixer/VGA);
+                           # HackRF One 0–560 (~0–56 dB). HackRF has no true AGC,
+                           # so "auto" maps to a fixed LNA 16 / VGA 20 dB split.
       bias_tee: false      # enable the 5V bias-tee output for an external LNA
       # blog_v4: true      # force RTL-SDR Blog V4 mode (28.8 MHz xtal + input
                            # routing) if the V4's USB strings don't auto-identify
@@ -269,10 +275,12 @@ sdr:
     # Honours `p25_phase1_demod_mode` (c4fm vs cqpsk / LSM) on the
     # system entry just like a dedicated CC dongle.
     #
-    # `voice_taps: N` (0-8) lets the same SDR host N concurrent
-    # voice grants without a separate `role: voice` dongle: each
-    # grant whose frequency falls inside the wideband IQ window
-    # gets its own per-call DDC tap on this dongle's IQ stream.
+    # `voice_taps: N` (0 disables; no hard upper bound) lets the
+    # same SDR host N concurrent voice grants without a separate
+    # `role: voice` dongle: each grant whose frequency falls inside
+    # the wideband IQ window gets its own per-call DDC tap on this
+    # dongle's IQ stream. CPU scales ~linearly per tap, so the daemon
+    # logs a warning above 16 to catch an accidental large value.
     # Out-of-window grants spill over to a physical voice SDR
     # when one is configured, or drop with the standard
     # "no voice device available" log otherwise. This works for

--- a/internal/api/handlers_audio.go
+++ b/internal/api/handlers_audio.go
@@ -18,6 +18,11 @@ type AudioStatusDTO struct {
 	// failed to init; PATCH still works but takes effect only on
 	// the recorder gate.
 	BackendEnabled bool `json:"backend_enabled"`
+	// BackendError carries the reason the sink failed to open when
+	// audio was enabled (e.g. the ioctl device rejected S16_LE mono).
+	// Omitted when audio is healthy or intentionally disabled, so a
+	// "Tap to enable audio" that produced no sound can show the cause.
+	BackendError string `json:"backend_error,omitempty"`
 	// SampleRate is the host playback rate in Hz.
 	SampleRate uint32 `json:"sample_rate"`
 	// Volume is the software gain (0..1).
@@ -139,6 +144,7 @@ func (s *Server) handleAudioPatch(w http.ResponseWriter, r *http.Request) {
 func audioStatusDTO(a AudioController) AudioStatusDTO {
 	return AudioStatusDTO{
 		BackendEnabled:   a.BackendEnabled(),
+		BackendError:     a.BackendError(),
 		SampleRate:       a.SampleRate(),
 		Volume:           a.Volume(),
 		Muted:            a.Muted(),

--- a/internal/api/handlers_audio_test.go
+++ b/internal/api/handlers_audio_test.go
@@ -18,15 +18,16 @@ import (
 // SetMuted / SetRecordingEnabled calls so assertions can confirm
 // the PATCH handler routed each knob correctly.
 type fakeAudio struct {
-	volume   atomic.Uint32 // float32 bits
-	muted    atomic.Bool
-	rec      atomic.Bool
-	drops    uint64
-	rate     uint32
-	backend  bool
-	setVolN  atomic.Int32
-	setMuteN atomic.Int32
-	setRecN  atomic.Int32
+	volume     atomic.Uint32 // float32 bits
+	muted      atomic.Bool
+	rec        atomic.Bool
+	drops      uint64
+	rate       uint32
+	backend    bool
+	backendErr string
+	setVolN    atomic.Int32
+	setMuteN   atomic.Int32
+	setRecN    atomic.Int32
 }
 
 func newFakeAudio() *fakeAudio {
@@ -62,6 +63,7 @@ func (f *fakeAudio) SetRecordingEnabled(enabled bool) {
 func (f *fakeAudio) DropsTotal() uint64   { return f.drops }
 func (f *fakeAudio) SampleRate() uint32   { return f.rate }
 func (f *fakeAudio) BackendEnabled() bool { return f.backend }
+func (f *fakeAudio) BackendError() string { return f.backendErr }
 
 func float32bits32(f float32) uint32     { return math.Float32bits(f) }
 func float32frombits32(u uint32) float32 { return math.Float32frombits(u) }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -90,6 +90,12 @@ type AudioController interface {
 	// attached. False means audio.enabled was off in config or the
 	// backend failed to init, and writes are silently dropped.
 	BackendEnabled() bool
+	// BackendError returns the reason the backend isn't attached when
+	// audio was enabled but the sink failed to open (e.g. the ioctl
+	// device rejected the pinned format). Empty when audio is healthy
+	// or was intentionally disabled — lets the UI distinguish "off by
+	// config" from "tried to start and failed".
+	BackendError() string
 }
 
 // BroadcastStatusProvider is the read side of the outbound

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -868,8 +868,10 @@ type DeviceConfig struct {
 	// hosting a trunked CC tap (DMR T3, P25 Phase 1, P25 Phase 2)
 	// so one SDR can cover the full system end-to-end. Out-of-
 	// window grants surface ErrOutOfBand and fall back to a
-	// physical voice SDR when one is configured. Capped at 8 to
-	// keep CPU bounded.
+	// physical voice SDR when one is configured. No hard upper
+	// bound, but each tap runs an independent DDC so CPU scales
+	// roughly linearly per tap — the daemon logs a warning above
+	// 16 so a typo doesn't silently peg a core.
 	VoiceTaps int `yaml:"voice_taps"`
 
 	// IQCorrect enables blind I/Q-imbalance correction on this device's
@@ -1902,8 +1904,8 @@ func validateWidebandDevice(idx int, d DeviceConfig, sampleRateHz uint32, system
 	if d.Serial == "" {
 		return fmt.Errorf("sdr.devices[%d]: role: wideband requires serial (the daemon binds the channel list to the device by USB serial)", idx)
 	}
-	if d.VoiceTaps < 0 || d.VoiceTaps > 8 {
-		return fmt.Errorf("sdr.devices[%d]: voice_taps %d out of range; 0 disables, 1-8 allocate that many virtual voice DDC taps on the dongle",
+	if d.VoiceTaps < 0 {
+		return fmt.Errorf("sdr.devices[%d]: voice_taps %d out of range; 0 disables, a positive value allocates that many virtual voice DDC taps on the dongle",
 			idx, d.VoiceTaps)
 	}
 	if d.CenterFreqHz == 0 {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -249,9 +249,11 @@ func TestValidate(t *testing.T) {
 				ControlChannels: []uint32{851_037_500},
 			}}},
 		}, false},
-		{"wideband voice_taps too large", Config{
+		// No hard upper bound on voice_taps: a high count validates
+		// (the daemon warns about CPU above 16 at tap-build time).
+		{"wideband voice_taps high count allowed", Config{
 			SDR: SDRConfig{SampleRate: 2_400_000, Devices: []DeviceConfig{{
-				Serial: "00000010", Role: "wideband", CenterFreqHz: 851_500_000, VoiceTaps: 99,
+				Serial: "00000010", Role: "wideband", CenterFreqHz: 851_500_000, VoiceTaps: 28,
 				Channels: []DeviceChannelConfig{
 					{FrequencyHz: 851_037_500, System: "regional-p25"},
 				},
@@ -260,7 +262,7 @@ func TestValidate(t *testing.T) {
 				Name: "regional-p25", Protocol: "p25",
 				ControlChannels: []uint32{851_037_500},
 			}}},
-		}, true},
+		}, false},
 		{"wideband voice_taps negative", Config{
 			SDR: SDRConfig{SampleRate: 2_400_000, Devices: []DeviceConfig{{
 				Serial: "00000010", Role: "wideband", CenterFreqHz: 851_500_000, VoiceTaps: -1,

--- a/internal/sdr/airspy/airspy.go
+++ b/internal/sdr/airspy/airspy.go
@@ -65,6 +65,15 @@ const (
 
 var openRetryBackoff = 250 * time.Millisecond
 
+// gainPresetsTenthDB are indicative tenth-dB gain values surfaced in
+// sdr.Info.Gains so `sdr list --probe` and the web UI can offer the
+// operator a ladder to pick from (0–50 dB). SetGain also accepts any
+// free-form tenth-dB value between these rungs. Shared by Enumerate
+// and openDevice so a probed (opened) device reports the same ladder
+// an enumerated one does — otherwise `--probe` shows an empty list
+// (issue: airspy/hackrf probe gains came back []).
+var gainPresetsTenthDB = []int{0, 100, 200, 300, 400, 500}
+
 // Driver implements sdr.Driver for Airspy.
 type Driver struct {
 	enum usb.Enumerator
@@ -108,9 +117,7 @@ func (d *Driver) Enumerate() ([]sdr.Info, error) {
 			Manufacturer: desc.Manufacturer,
 			Product:      desc.Product,
 			TunerName:    tunerNameFor(desc.Product),
-			// Indicative tenth-dB presets; the driver also accepts
-			// a free-form SetGain value.
-			Gains: []int{0, 100, 200, 300, 400, 500},
+			Gains:        gainPresetsTenthDB,
 		}
 	}
 	return out, nil
@@ -193,6 +200,10 @@ func (d *Driver) openDevice(desc usb.Descriptor, idx int, serial string) (*Devic
 			Manufacturer: desc.Manufacturer,
 			Product:      desc.Product,
 			TunerName:    tunerNameFor(desc.Product),
+			// Carry the gain ladder onto the opened device so
+			// dev.Info() (used by `sdr list --probe`) reports it
+			// instead of an empty list.
+			Gains: gainPresetsTenthDB,
 		},
 	}
 	_ = t.ControlOut(reqReceiverMode, receiverModeOff, 0, nil, controlTimeoutMs)
@@ -263,10 +274,19 @@ func (d *Device) SetCenterFreq(hz uint32) error {
 	return d.t.ControlOut(reqSetFreq, 0, 0, payload, controlTimeoutMs)
 }
 
-// SetSampleRate follows libairspy semantics:
-// - exact known rates are sent by index
-// - otherwise values >= 1 MHz are encoded as (rate_hz*2)/1000 for IQ modes
-// and sent as wIndex on an IN vendor request.
+// SetSampleRate programs the firmware so the host-side IQ stream comes
+// out at the requested IQ rate (hz).
+//
+// The Airspy is a real-sampling receiver: the firmware streams bare ADC
+// samples at the *device* rate, and the host converter (iqconverter.go)
+// translates by Fs/4 and decimates by two, so the delivered complex-IQ
+// rate is HALF the device rate. The firmware's rate table
+// (fetchSampleRates) is therefore in device rates (e.g. 3 MSPS, 6 MSPS).
+// To deliver an IQ rate of hz we must program the device at 2×hz — a
+// requested IQ rate of 3 MHz selects the 6 MSPS device mode, 1.5 MHz
+// selects 3 MSPS. Sending hz directly (the prior behaviour) under-ran
+// the pipeline by 2×, so every downstream decoder mis-tuned and only
+// the DC spike survived.
 func (d *Device) SetSampleRate(hz uint32) error {
 	if d.isClosed() {
 		return usb.ErrClosed
@@ -276,38 +296,50 @@ func (d *Device) SetSampleRate(hz uint32) error {
 	return err
 }
 
-func (d *Device) sampleRateCommandParam(hz uint32) uint16 {
+// sampleRateCommandParam maps a requested IQ rate to the wIndex the
+// firmware expects: an index into the device-rate table when 2×iqHz
+// matches a known device rate, the nearest table index when it doesn't,
+// or a by-value encoding (deviceHz/1000) when no table was read.
+func (d *Device) sampleRateCommandParam(iqHz uint32) uint16 {
 	d.mu.Lock()
 	rates := d.rates
 	d.mu.Unlock()
 
-	if hz >= minSamplerateHz {
+	if iqHz >= minSamplerateHz {
+		deviceHz := iqHz * 2 // converter decimates by two; see SetSampleRate
 		for i, r := range rates {
-			if hz == r {
+			if deviceHz == r {
 				return uint16(i)
 			}
 		}
-		return uint16((hz * 2) / 1000)
+		if len(rates) > 0 {
+			// Snap to the nearest advertised device rate rather than
+			// emitting a by-value encoding the firmware may reject.
+			return uint16(d.closestRateIndex(iqHz))
+		}
+		return uint16(deviceHz / 1000)
 	}
-	return uint16(hz)
+	return uint16(iqHz)
 }
 
-// closestRateIndex returns the index of the supported sample rate
-// nearest hz. If no table is known, it returns 0.
-func (d *Device) closestRateIndex(hz uint32) int {
+// closestRateIndex returns the index of the supported DEVICE sample
+// rate nearest 2×iqHz (the device streams at twice the IQ rate; see
+// SetSampleRate). If no table is known, it returns 0.
+func (d *Device) closestRateIndex(iqHz uint32) int {
 	d.mu.Lock()
 	rates := d.rates
 	d.mu.Unlock()
 	if len(rates) == 0 {
 		return 0
 	}
+	deviceHz := iqHz * 2
 	best, bestDiff := 0, ^uint32(0)
 	for i, r := range rates {
-		diff := r
-		if hz > r {
-			diff = hz - r
+		var diff uint32
+		if deviceHz > r {
+			diff = deviceHz - r
 		} else {
-			diff = r - hz
+			diff = r - deviceHz
 		}
 		if diff < bestDiff {
 			best, bestDiff = i, diff

--- a/internal/sdr/airspy/airspy_test.go
+++ b/internal/sdr/airspy/airspy_test.go
@@ -62,6 +62,11 @@ func TestDriverEnumerateOpenReadsSamplerates(t *testing.T) {
 	if len(asDev.rates) != 2 || asDev.rates[0] != 10_000_000 {
 		t.Fatalf("samplerate table = %v", asDev.rates)
 	}
+	// The opened device must carry the gain ladder so `sdr list --probe`
+	// (which reads dev.Info() post-open) doesn't report an empty list.
+	if got := dev.Info().Gains; len(got) == 0 {
+		t.Errorf("opened device Info().Gains is empty; want the gain ladder")
+	}
 	if err := dev.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
 	}
@@ -173,19 +178,21 @@ func TestSetCenterFreqEncoding(t *testing.T) {
 }
 
 func TestClosestRateIndex(t *testing.T) {
+	// Table holds DEVICE rates; closestRateIndex takes an IQ rate and
+	// matches 2×IQ against the table (the converter decimates by two).
 	dev := &Device{rates: []uint32{10_000_000, 2_500_000}}
 	cases := []struct {
-		hz   uint32
+		iqHz uint32
 		want int
 	}{
-		{10_000_000, 0},
-		{9_000_000, 0},
-		{4_000_000, 1},
-		{2_500_000, 1},
+		{5_000_000, 0}, // device 10M — exact
+		{4_500_000, 0}, // device 9M — nearer 10M than 2.5M
+		{2_000_000, 1}, // device 4M — nearer 2.5M
+		{1_250_000, 1}, // device 2.5M — exact
 	}
 	for _, c := range cases {
-		if got := dev.closestRateIndex(c.hz); got != c.want {
-			t.Errorf("closestRateIndex(%d) = %d, want %d", c.hz, got, c.want)
+		if got := dev.closestRateIndex(c.iqHz); got != c.want {
+			t.Errorf("closestRateIndex(%d) = %d, want %d", c.iqHz, got, c.want)
 		}
 	}
 	// No table → falls back to index 0.
@@ -194,8 +201,10 @@ func TestClosestRateIndex(t *testing.T) {
 	}
 }
 
-func TestSetSampleRateEncodesByValueWhenNotIndexed(t *testing.T) {
-	dev := &Device{rates: []uint32{10_000_000, 2_500_000}}
+func TestSetSampleRateEncodesByValueWhenNoTable(t *testing.T) {
+	// With no device-rate table the param is a by-value encoding of the
+	// device rate (2×IQ) in kHz: IQ 4 MHz → device 8 MHz → 8000.
+	dev := &Device{rates: nil}
 	mt := usb.NewMockTransport()
 	dev.t = mt
 	mt.Script = []usb.CtrlExchange{
@@ -210,17 +219,48 @@ func TestSetSampleRateEncodesByValueWhenNotIndexed(t *testing.T) {
 }
 
 func TestSetSampleRateUsesIndexWhenExactMatch(t *testing.T) {
+	// Device table {10 MSPS, 2.5 MSPS}; requesting IQ 1.25 MHz selects
+	// the 2.5 MSPS device rate (index 1).
 	dev := &Device{rates: []uint32{10_000_000, 2_500_000}}
 	mt := usb.NewMockTransport()
 	dev.t = mt
 	mt.Script = []usb.CtrlExchange{
 		{In: true, BRequest: reqSetSamplerate, WValue: 0, WIndex: 1, Reply: []byte{0}, N: 1},
 	}
-	if err := dev.SetSampleRate(2_500_000); err != nil {
+	if err := dev.SetSampleRate(1_250_000); err != nil {
 		t.Fatalf("SetSampleRate exact: %v", err)
 	}
 	if mt.Err != nil {
 		t.Fatalf("transport: %v", mt.Err)
+	}
+}
+
+// TestSetSampleRateSelectsDeviceRateAtTwiceIQ is the regression gate for
+// the real-sampling 2× rate bug: a requested IQ rate must program the
+// device at twice that rate so the host converter delivers the IQ rate
+// the rest of the pipeline assumes.
+func TestSetSampleRateSelectsDeviceRateAtTwiceIQ(t *testing.T) {
+	// A real Airspy R2/Mini advertises 6 MSPS and 3 MSPS device rates.
+	cases := []struct {
+		iqHz      uint32
+		wantIndex uint16
+	}{
+		{3_000_000, 0}, // → device 6 MSPS (index 0)
+		{1_500_000, 1}, // → device 3 MSPS (index 1)
+	}
+	for _, c := range cases {
+		dev := &Device{rates: []uint32{6_000_000, 3_000_000}}
+		mt := usb.NewMockTransport()
+		dev.t = mt
+		mt.Script = []usb.CtrlExchange{
+			{In: true, BRequest: reqSetSamplerate, WValue: 0, WIndex: c.wantIndex, Reply: []byte{0}, N: 1},
+		}
+		if err := dev.SetSampleRate(c.iqHz); err != nil {
+			t.Fatalf("SetSampleRate(%d): %v", c.iqHz, err)
+		}
+		if mt.Err != nil {
+			t.Fatalf("SetSampleRate(%d) transport: %v (wanted device index %d)", c.iqHz, mt.Err, c.wantIndex)
+		}
 	}
 }
 

--- a/internal/sdr/hackrf/hackrf.go
+++ b/internal/sdr/hackrf/hackrf.go
@@ -85,6 +85,14 @@ const (
 	controlTimeoutMs           = 1000
 )
 
+// gainPresetsTenthDB are indicative tenth-dB gain values surfaced in
+// sdr.Info.Gains so `sdr list --probe` and the web UI can offer the
+// operator a ladder to pick from (0–56 dB). SetGain also accepts any
+// free-form tenth-dB value. Shared by Enumerate and Open so a probed
+// (opened) device reports the same ladder an enumerated one does —
+// otherwise `--probe` showed an empty list.
+var gainPresetsTenthDB = []int{0, 80, 160, 240, 320, 400, 480, 560}
+
 // Driver implements sdr.Driver for HackRF.
 type Driver struct {
 	enum usb.Enumerator
@@ -134,9 +142,7 @@ func (d *Driver) Enumerate() ([]sdr.Info, error) {
 			Manufacturer: desc.Manufacturer,
 			Product:      productForPID(desc.PID, desc.Product),
 			TunerName:    "MAX2839+MAX5864",
-			// Tenth-dB presets the operator can pick from in the UI;
-			// the driver also accepts a free-form value via SetGain.
-			Gains: []int{0, 80, 160, 240, 320, 400, 480, 560},
+			Gains:        gainPresetsTenthDB,
 		}
 	}
 	return out, nil
@@ -212,6 +218,9 @@ func (d *Driver) Open(idx int) (sdr.Device, error) {
 			Manufacturer: desc.Manufacturer,
 			Product:      product,
 			TunerName:    tuner,
+			// Carry the gain ladder onto the opened device so dev.Info()
+			// (used by `sdr list --probe`) reports it, not an empty list.
+			Gains: gainPresetsTenthDB,
 		},
 	}, nil
 }

--- a/internal/sdr/hackrf/hackrf_test.go
+++ b/internal/sdr/hackrf/hackrf_test.go
@@ -60,6 +60,11 @@ func TestDriverEnumerateAndOpen(t *testing.T) {
 	if !strings.Contains(dev.Info().TunerName, "git-2024.02.1") {
 		t.Errorf("Info.TunerName = %q, want firmware suffix", dev.Info().TunerName)
 	}
+	// The opened device must carry the gain ladder so `sdr list --probe`
+	// (which reads dev.Info() post-open) doesn't report an empty list.
+	if got := dev.Info().Gains; len(got) == 0 {
+		t.Errorf("opened device Info().Gains is empty; want the gain ladder")
+	}
 	if err := dev.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
 	}

--- a/internal/voice/player/ioctl_linux.go
+++ b/internal/voice/player/ioctl_linux.go
@@ -300,7 +300,14 @@ func (b *ioctlBackend) setHWParams(rate, periodSize, bufferSize uint32) error {
 	// actually constrained).
 	p.Rmask = 0xFFFFFFFF
 	if err := b.ioctl(ioctlHwParams, uintptr(unsafe.Pointer(&p))); err != nil {
-		return fmt.Errorf("ioctl-alsa: HW_PARAMS: %w", err)
+		// The ioctl backend pins S16_LE / mono / the configured rate
+		// (it can't resample). Onboard codecs typically only expose
+		// 44.1/48 kHz stereo, so an 8 kHz-mono request is rejected here
+		// (errno=22 EINVAL). Point the operator at the default
+		// libasound path, which negotiates + soft-resamples.
+		return fmt.Errorf("ioctl-alsa: HW_PARAMS (S16_LE mono @ %d Hz rejected; "+
+			"onboard codecs usually need 44.1/48 kHz stereo — drop the \"ioctl:\" prefix "+
+			"and use the default libasound device, which resamples): %w", rate, err)
 	}
 	return nil
 }

--- a/internal/voice/player/player.go
+++ b/internal/voice/player/player.go
@@ -75,6 +75,13 @@ type Player struct {
 	backend    Backend
 	sampleRate uint32
 
+	// initErr records why the real backend isn't attached when audio
+	// was enabled: the device failed to open. Set once at construction
+	// before any goroutine starts (so it needs no synchronisation) and
+	// surfaced via Stats so the API/UI can tell the operator audio is
+	// dead and why, instead of silently dropping every sample.
+	initErr string
+
 	// Software gain stage. Stored as the float32 bit pattern in a
 	// uint32 atomic so SetVolume is lock-free.
 	volume atomic.Uint32 // math.Float32bits
@@ -138,7 +145,14 @@ func New(cfg Config, log *slog.Logger) (*Player, error) {
 
 	be, err := defaultBackendFactory(cfg)
 	if err != nil {
-		log.Warn("player: backend init failed; running headless", "err", err)
+		// audio.enabled was true and a device was requested, but the
+		// sink wouldn't open. Log at ERROR (not WARN) and remember the
+		// reason — a silent WARN-and-headless leaves the operator with
+		// no signal as to why live audio produces nothing. Surfaced via
+		// Stats().BackendError and the GET /api/v1/audio endpoint.
+		log.Error("player: live audio backend failed to initialise; no sound will play",
+			"device", cfg.Device, "err", err)
+		p.initErr = err.Error()
 		close(p.done)
 		return p, nil
 	}
@@ -242,15 +256,21 @@ type Stats struct {
 	Volume     float32
 	Muted      bool
 	DropsTotal uint64
+	// BackendError is non-empty when audio was enabled but the sink
+	// failed to open (e.g. the ioctl device rejected the pinned format,
+	// or libasound2 was missing). Empty when audio is healthy or was
+	// intentionally disabled.
+	BackendError string
 }
 
 func (p *Player) Stats() Stats {
 	return Stats{
-		Enabled:    p.backend != nil,
-		SampleRate: p.sampleRate,
-		Volume:     p.getVolume(),
-		Muted:      p.muted.Load(),
-		DropsTotal: p.drops.Load(),
+		Enabled:      p.backend != nil,
+		SampleRate:   p.sampleRate,
+		Volume:       p.getVolume(),
+		Muted:        p.muted.Load(),
+		DropsTotal:   p.drops.Load(),
+		BackendError: p.initErr,
 	}
 }
 

--- a/internal/voice/player/player_test.go
+++ b/internal/voice/player/player_test.go
@@ -1,6 +1,7 @@
 package player
 
 import (
+	"errors"
 	"io"
 	"log/slog"
 	"sync"
@@ -130,6 +131,35 @@ func TestPlayerNullBackend(t *testing.T) {
 	}
 	if st := p.Stats(); st.Enabled {
 		t.Fatalf("expected Enabled=false on null player")
+	}
+}
+
+func TestPlayerBackendInitFailureSurfacesError(t *testing.T) {
+	// When audio is enabled but the backend factory fails, the Player
+	// must stay usable (no-op writes) AND report the failure reason via
+	// Stats so the API/UI can tell the operator why nothing plays —
+	// rather than silently dropping every sample.
+	prev := defaultBackendFactory
+	defaultBackendFactory = func(Config) (Backend, error) {
+		return nil, errors.New("boom: device rejected format")
+	}
+	t.Cleanup(func() { defaultBackendFactory = prev })
+
+	p, err := New(Config{Enabled: true, Device: "ioctl:hw:1,0"}, slog.Default())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer p.Close()
+	// Writes are accepted and dropped without error.
+	if err := p.WritePCM("dev", []int16{1, 2, 3}); err != nil {
+		t.Fatalf("WritePCM: %v", err)
+	}
+	st := p.Stats()
+	if st.Enabled {
+		t.Error("Stats.Enabled = true, want false after backend init failure")
+	}
+	if st.BackendError == "" {
+		t.Error("Stats.BackendError is empty; want the init failure reason")
 	}
 }
 


### PR DESCRIPTION
Addresses a cluster of operator-reported issues with Airspy/HackRF and
live audio:

- Airspy received nothing (DC spike only). The Airspy is a real-sampling
  receiver whose host converter decimates by two, so the delivered IQ
  rate is half the device rate. SetSampleRate sent the requested rate
  straight to firmware, under-running the pipeline by 2x and mis-tuning
  every decoder. It now programs the device at 2x the requested IQ rate,
  so e.g. sample_rate: 3_000_000 correctly selects the 6 MSPS mode.

- `sdr list --probe` reported empty gains [] for Airspy and HackRF: the
  per-device open path rebuilt sdr.Info without copying the gain ladder
  that Enumerate populates. Both drivers now carry it onto the opened
  device, matching RTL-SDR. Documented the tenth-dB unit and per-device
  ranges in config.example.yaml.

- voice_taps was hard-capped at 8. Removed the cap; the daemon now warns
  above 16 since CPU scales ~linearly per DDC tap.

- Live audio failed silently: a backend init failure logged a WARN and
  ran headless. It now logs at ERROR with the reason, surfaces the cause
  via GET /api/v1/audio (backend_error) and player Stats, and the
  direct-ioctl path explains its fixed S16_LE-mono format and points at
  the resampling libasound default.

Adds/updates unit tests for the 2x rate selection, probe gains,
uncapped voice_taps, and the audio backend-error surface.

https://claude.ai/code/session_01S9K6qEgJ4ncSY1x2o3h5Bj