### PR TITLE
Fix #598: stream live audio for digital voice (and make the stream grant-independent)

### DIFF
--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -1019,6 +1019,27 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 			sinks = append(sinks, playerSink{p: d.player, engine: d.engine})
 		}
 		sinks = append(sinks, d.audioPub)
+
+		// Digital protocols (P25, DMR, NXDN, …) reach the composer as
+		// raw vocoder frames and fan out only to the recorder — the
+		// lone decoder. The other live sinks here implement WritePCM
+		// only, so they never see digital audio. Tap the PCM the
+		// recorder decodes and forward it to those live consumers, so
+		// the web stream / host player / tone-out hear digital calls
+		// too, not just analog FM (issue #598). The recorder itself is
+		// excluded from this tap (it already wrote the WAV from its own
+		// decode); analog PCM still flows to these sinks via the
+		// composer fanout below, so each sink gets every sample once.
+		var liveSinks []composer.PCMSink
+		if d.toneout != nil {
+			liveSinks = append(liveSinks, d.toneout)
+		}
+		if d.player != nil {
+			liveSinks = append(liveSinks, playerSink{p: d.player, engine: d.engine})
+		}
+		liveSinks = append(liveSinks, d.audioPub)
+		d.recorder.SetDecodedPCMSink(fanoutSink(liveSinks))
+
 		var sink composer.PCMSink = d.recorder
 		if len(sinks) > 1 {
 			sink = fanoutSink(sinks)

--- a/internal/voice/recorder.go
+++ b/internal/voice/recorder.go
@@ -66,6 +66,15 @@ type Recorder struct {
 	runDone   chan struct{}
 	closeOnce sync.Once
 
+	// decodedTap, when set, receives the PCM decoded from digital
+	// vocoder frames in WriteRawFrame — the live consumers (web
+	// stream, host player, tone-out) that only implement WritePCM and
+	// so never see raw frames. Wired once at daemon construction via
+	// SetDecodedPCMSink before Run starts, so the hot path reads it
+	// without locking. nil = no live fan-out (analog-only callers,
+	// tests).
+	decodedTap DecodedPCMSink
+
 	// recordDisabled gates new sessions at runtime. Toggled from
 	// the API by operators who want to stop laying down WAVs
 	// without restarting the daemon. In-flight sessions are NOT
@@ -73,6 +82,25 @@ type Recorder struct {
 	// the head of a call isn't lost when the operator flips the
 	// switch mid-conversation.
 	recordDisabled atomic.Bool
+}
+
+// DecodedPCMSink receives PCM the recorder decodes from digital
+// vocoder frames, so live consumers (web stream, host player,
+// tone-out) hear digital calls — not just analog ones. The composer's
+// digital chains emit only raw vocoder frames, which fan out solely to
+// the recorder (the lone decoder); without this tap that decoded audio
+// never reaches the WritePCM-only live sinks. Mirrors composer.PCMSink's
+// WritePCM but is declared here to avoid a voice → composer import cycle.
+type DecodedPCMSink interface {
+	WritePCM(deviceSerial string, samples []int16) error
+}
+
+// SetDecodedPCMSink wires the live-audio tap that receives PCM decoded
+// from digital vocoder frames. Call once during daemon construction
+// before Run/any calls start; it is not safe to change concurrently
+// with WriteRawFrame.
+func (r *Recorder) SetDecodedPCMSink(s DecodedPCMSink) {
+	r.decodedTap = s
 }
 
 // RecorderOptions configure a new Recorder.
@@ -343,6 +371,16 @@ func (r *Recorder) WriteRawFrame(deviceSerial string, frame []byte) error {
 		}
 		if err := s.wav.WriteSamples(samples); err != nil {
 			return err
+		}
+		// Fan the freshly-decoded PCM to the live consumers (web
+		// stream, host player, tone-out). For digital protocols this
+		// is the only point where PCM exists — the composer never
+		// calls WritePCM for them — so without this the live audio
+		// path is silent while recordings play fine (issue #598). Runs
+		// outside r.mu (sessionForWrite released it), so the tap is
+		// free to take its own locks.
+		if r.decodedTap != nil {
+			_ = r.decodedTap.WritePCM(deviceSerial, samples)
 		}
 	}
 	return nil

--- a/internal/voice/recorder_test.go
+++ b/internal/voice/recorder_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -588,6 +589,101 @@ func TestRecorderWriteRawFrameDecodesIntoWav(t *testing.T) {
 	wantSize := int64(wavHeaderSize + 3*160*2)
 	if st.Size() != wantSize {
 		t.Errorf("wav size = %d, want %d", st.Size(), wantSize)
+	}
+}
+
+// fakeDecodedTap records the PCM the recorder forwards from its
+// digital decode path so a test can confirm live consumers are fed.
+type fakeDecodedTap struct {
+	mu    sync.Mutex
+	calls int
+	total int // total samples forwarded
+	last  string
+}
+
+func (f *fakeDecodedTap) WritePCM(serial string, samples []int16) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls++
+	f.total += len(samples)
+	f.last = serial
+	return nil
+}
+
+func (f *fakeDecodedTap) snapshot() (calls, total int, last string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls, f.total, f.last
+}
+
+// TestRecorderForwardsDecodedPCMToTap: PCM the recorder decodes from
+// digital vocoder frames in WriteRawFrame must be forwarded to the
+// live-audio tap (web stream / player / tone-out). Without this the
+// live audio path is silent for digital calls while recordings play
+// fine — issue #598. Also pins that the analog WritePCM path does NOT
+// re-invoke the tap (those sinks already get analog PCM via the
+// composer fanout; tapping there would double-send).
+func TestRecorderForwardsDecodedPCMToTap(t *testing.T) {
+	bus := events.NewBus(8)
+	dir := t.TempDir()
+	r, err := NewRecorder(RecorderOptions{
+		Bus:                bus,
+		OutDir:             dir,
+		SampleRate:         8000,
+		VocoderForProtocol: map[string]string{"test-null": "null"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+	defer bus.Close()
+
+	tap := &fakeDecodedTap{}
+	r.SetDecodedPCMSink(tap)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go r.Run(ctx)
+
+	cs := trunking.CallStart{
+		Grant:        trunking.Grant{System: "S", Protocol: "test-null", GroupID: 1, SourceID: 2},
+		DeviceSerial: "VOICE-1",
+		StartedAt:    time.Date(2026, 5, 5, 0, 0, 0, 0, time.UTC),
+	}
+	bus.Publish(events.Event{Kind: events.KindCallStart, Payload: cs})
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if r.HasSession("VOICE-1") {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	// NullVocoder.FrameSize is 11 and decodes to 160 samples/frame.
+	for i := 0; i < 3; i++ {
+		if err := r.WriteRawFrame("VOICE-1", make([]byte, 11)); err != nil {
+			t.Fatalf("WriteRawFrame: %v", err)
+		}
+	}
+
+	calls, total, last := tap.snapshot()
+	if calls != 3 {
+		t.Errorf("tap WritePCM calls = %d, want 3", calls)
+	}
+	if total != 3*160 {
+		t.Errorf("tap forwarded %d samples, want %d", total, 3*160)
+	}
+	if last != "VOICE-1" {
+		t.Errorf("tap serial = %q, want VOICE-1", last)
+	}
+
+	// The analog WritePCM path must not touch the tap (avoids
+	// double-sending: those sinks get analog PCM via the fanout).
+	if err := r.WritePCM("VOICE-1", []int16{1, 2, 3, 4}); err != nil {
+		t.Fatalf("WritePCM: %v", err)
+	}
+	if calls2, _, _ := tap.snapshot(); calls2 != 3 {
+		t.Errorf("tap calls after analog WritePCM = %d, want 3 (unchanged)", calls2)
 	}
 }
 


### PR DESCRIPTION
Fixes #598 — "Tap to enable audio" in the WebUI produced no sound (Chrome on macOS) even though disk recordings were audible. The prior fixes (#601 Safari Range support, #612 fetch + Web Audio) targeted the HTTP/frontend layer, but the backend was never sending PCM for the affected calls. This branch fixes that in two layers.

## 1. The live stream no longer depends on the publisher's grant cache

`AudioPublisher.WritePCM` used to drop **all** PCM unless it had a cached grant for the device serial. That cache rides the publisher's own events-bus subscription, which the bus can drop under load (full channel) — so the WebUI stream could go silent while the recorder (a separate, grant-free sink) kept working. Neither stream consumer reads the grant for its payload (the HTTP handler writes raw PCM; gRPC `StreamAudio` forwards the frame verbatim), so the grant requirement was pure fragility.

`WritePCM` now fans PCM to unfiltered and device-serial-only subscribers regardless of grant state (zero grant when none is cached); talkgroup-filtered subscribers are still skipped without a grant since their predicate can't be evaluated. Also added publisher health to `GET /api/v1/audio` (`stream_subscribers`, `stream_drops_total`, `stream_tracked_grants`) plus one-shot debug/warn logs on first-frame-delivered and channel-full — which is what let us pinpoint the second, real root cause below.

## 2. Digital voice is now decoded onto the live path

The reporter's diagnostics during an active P25 call (`stream_tracked_grants:1`, `stream_subscribers:1`, `stream_drops_total:0`, no bytes streamed) proved `WritePCM` was never being called for the call at all.

Root cause: digital protocols (P25 Phase 1/2, DMR, NXDN) reach the composer as **raw vocoder frames** and fan out via `WriteRawFrame` — which only the recorder implements. The recorder is the sole decoder (frame → PCM → WAV); the tone-out detector, host player, and audio publisher implement `WritePCM` only and were silently skipped. So digital calls recorded fine but produced **no live PCM** to the web stream, host speaker, or tone-out. Analog FM worked because its chain calls `WritePCM` directly — which is why this escaped the tests.

Fix: the recorder now forwards the PCM it already decodes to the live consumers.
- `internal/voice/recorder.go`: new `DecodedPCMSink` tap (`SetDecodedPCMSink`); after decoding a frame to PCM in `WriteRawFrame`, the samples are fanned to it. The analog `WritePCM` path is untouched, so every sample is sent exactly once.
- `cmd/gophertrunk/daemon.go`: wires the tap to a fanout of the non-recorder live sinks (tone-out, player, audio publisher). Digital calls now stream/play live with audio identical to the recordings — single decode, no duplication.

## Tests
- `internal/api`: grant-decoupling regressions (no-grant fan, device-filter, talkgroup-skip), an end-to-end HTTP stream test that delivers PCM without a `CallStart`, and a status-stats test. gRPC `StreamAudio` tests stay green (zero-grant frames tolerated).
- `internal/voice`: `TestRecorderForwardsDecodedPCMToTap` covers the digital decode forward and that the analog path does not double-invoke the tap.
- `go build ./...`, `go vet`, and the `internal/voice` / `internal/api` / `cmd/gophertrunk` suites all pass.

## Verification
During a decoding P25 call:
```
curl -sN http://127.0.0.1:8080/api/v1/audio/stream | head -c 4000 | wc -c   # ≫ 44 (header + live PCM)
curl -s  http://127.0.0.1:8080/api/v1/audio | jq '{stream_subscribers, stream_drops_total}'
```
"Tap to enable audio" in Chrome should produce sound.

## Known limitation (unchanged behavior)
Because the recorder is the decoder, live digital audio now rides the recording decode — so `record=false` talkgroups, runtime-disabled recording, and `skip_encrypted` calls still produce no live digital PCM. This matches prior behavior and is not a regression; fully decoupling live digital audio from recording would mean moving vocoder decode into the composer / a shared decoding sink, deliberately left out of scope.

https://claude.ai/code/session_01SNr1PL2ZnuSBZN9QQX1xqy

---
_Generated by [Claude Code](https://claude.ai/code/session_01SNr1PL2ZnuSBZN9QQX1xqy)_