### PR TITLE
Fix #598: don't double-play digital audio on the host speaker (echo fix)

### DIFF
--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -1022,20 +1022,22 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 
 		// Digital protocols (P25, DMR, NXDN, …) reach the composer as
 		// raw vocoder frames and fan out only to the recorder — the
-		// lone decoder. The other live sinks here implement WritePCM
-		// only, so they never see digital audio. Tap the PCM the
-		// recorder decodes and forward it to those live consumers, so
-		// the web stream / host player / tone-out hear digital calls
-		// too, not just analog FM (issue #598). The recorder itself is
-		// excluded from this tap (it already wrote the WAV from its own
-		// decode); analog PCM still flows to these sinks via the
-		// composer fanout below, so each sink gets every sample once.
+		// lone decoder. Tap the PCM the recorder decodes and forward it
+		// to the live STREAM consumers — the network publisher
+		// (WebUI/gRPC) and the tone-out detector — so digital calls are
+		// heard live, not just analog FM (issue #598).
+		//
+		// The host speaker player is deliberately EXCLUDED from this
+		// tap: routing decoded digital PCM there plays the call on the
+		// local speaker while the WebUI streams the same PCM, and on one
+		// machine the two offset playbacks echo / comb-filter (issue
+		// #598 follow-up). Analog FM still reaches the host player via
+		// the composer's main `sinks` fanout below; digital
+		// host-speaker playback is out of scope. The recorder itself is
+		// also excluded (it already wrote the WAV from its own decode).
 		var liveSinks []composer.PCMSink
 		if d.toneout != nil {
 			liveSinks = append(liveSinks, d.toneout)
-		}
-		if d.player != nil {
-			liveSinks = append(liveSinks, playerSink{p: d.player, engine: d.engine})
 		}
 		liveSinks = append(liveSinks, d.audioPub)
 		d.recorder.SetDecodedPCMSink(fanoutSink(liveSinks))


### PR DESCRIPTION
Follow-up to #623. After digital live audio started streaming to the WebUI, a reporter heard C4FM (P25 Phase 1) calls "mixed, with echoing and pulsing" (`voice_taps=1`), recording the Mac speakers while listening via the WebUI on the same Mac.

## Cause

#623 fanned the recorder's decoded **digital** PCM to all live sinks, including the host-speaker `playerSink`. With `audio.enabled: true`, a digital call then played **twice on one machine** — out the local CoreAudio speaker (host player) **and** via the browser Web Audio stream (publisher) — and the two unsynchronized clocks produced echo + comb-filter "pulsing." Before #623, digital never reached the host player (digital fans out via `WriteRawFrame`, which only the recorder implements; `playerSink` implements `WritePCM` only), so this was a regression introduced there.

Ruled out: an in-stream double to the publisher (PCM arrives exactly once), the Web Audio scheduler (`streamPlayer.ts` is sound — one `AudioBufferSource` per chunk, lead-time clamps prevent overlap), and tone-out (detection-only, no audio output).

## Fix

Scope the decoded-digital-PCM tap to the live **stream** consumers only — the network publisher (WebUI/gRPC) and the tone-out detector. The host `playerSink` is excluded, restoring pre-regression behavior (digital was never on the host speaker). Analog FM still plays locally via the composer's main `sinks` fanout, which is unchanged.

`cmd/gophertrunk/daemon.go` — one block: drop `playerSink` from the `liveSinks` passed to `d.recorder.SetDecodedPCMSink(...)`.

## Tests

`go build ./...`, `go vet`, and the `internal/voice` / `internal/api` / `cmd/gophertrunk` suites all pass. `TestRecorderForwardsDecodedPCMToTap` still passes — it exercises the recorder tap mechanism, independent of which sinks the daemon wires.

## Verification

On the reporter's box (C4FM, `audio.enabled: true`): the WebUI plays the call cleanly with no echo, and the host speaker no longer double-plays the same digital call. Analog FM still plays locally, by design.

## Known limitation

Digital calls play via the stream only, not the host speaker. This avoids the WebUI/local echo; giving operators a real per-output choice without echo would need a config toggle / output-routing rework, deliberately out of scope.

https://claude.ai/code/session_01SNr1PL2ZnuSBZN9QQX1xqy

---
_Generated by [Claude Code](https://claude.ai/code/session_01SNr1PL2ZnuSBZN9QQX1xqy)_