### PR TITLE
Fix #598: pin live-stream AudioContext to 8 kHz to match recorded WAV quality

### DIFF
--- a/web/src/audio/streamPlayer.test.ts
+++ b/web/src/audio/streamPlayer.test.ts
@@ -4,6 +4,8 @@ import {
   int16ToFloat32,
   PcmFramer,
   WAV_HEADER_SIZE,
+  createAudioContext,
+  STREAM_SAMPLE_RATE,
 } from "./streamPlayer";
 
 // Build a canonical 44-byte RIFF/WAVE header byte-for-byte the way the
@@ -164,5 +166,42 @@ describe("PcmFramer", () => {
     f.feed(concat(makeHeader(8000), pcmBytes([42])));
     f.feed(new Uint8Array(0));
     expect(Array.from(f.takeSamples()!)).toEqual([42 / 32768]);
+  });
+});
+
+describe("createAudioContext", () => {
+  // Pinning the context to the stream's 8 kHz rate is what lets Web Audio skip
+  // per-chunk resampling (#598); assert the rate is actually requested.
+  it("builds the context at the requested sample rate", () => {
+    const seen: (AudioContextOptions | undefined)[] = [];
+    class FakeCtx {
+      constructor(opts?: AudioContextOptions) {
+        seen.push(opts);
+      }
+    }
+    const ctx = createAudioContext(
+      FakeCtx as unknown as typeof AudioContext,
+      STREAM_SAMPLE_RATE,
+    );
+    expect(ctx).toBeInstanceOf(FakeCtx);
+    expect(seen).toEqual([{ sampleRate: 8000 }]);
+  });
+
+  // Older Safari throws when handed an explicit sampleRate; we must still get a
+  // usable (hardware-default) context rather than failing playback outright.
+  it("falls back to a default context when the rate is rejected", () => {
+    let calls = 0;
+    class PickyCtx {
+      constructor(opts?: AudioContextOptions) {
+        calls++;
+        if (opts) throw new Error("sampleRate not supported");
+      }
+    }
+    const ctx = createAudioContext(
+      PickyCtx as unknown as typeof AudioContext,
+      STREAM_SAMPLE_RATE,
+    );
+    expect(ctx).toBeInstanceOf(PickyCtx);
+    expect(calls).toBe(2); // first (with opts) throws, second (no opts) succeeds
   });
 });

--- a/web/src/audio/streamPlayer.ts
+++ b/web/src/audio/streamPlayer.ts
@@ -146,12 +146,35 @@ const RECONNECT_DELAY_MS = 1000;
 
 type AudioContextCtor = typeof AudioContext;
 
+// The daemon streams 8 kHz PCM (vocoder-native for digital; the analog
+// default). Creating the AudioContext at this rate makes Web Audio do ZERO
+// per-chunk resampling — every scheduled buffer matches the context rate and
+// plays back-to-back seamlessly, and the OS does one continuous resample to the
+// output device, exactly like a recorded .wav. Without it, every small chunk is
+// resampled 8k->48k independently with no interpolation state across chunk
+// boundaries, the artifacts that make live sound worse than the file (#598).
+export const STREAM_SAMPLE_RATE = 8000;
+
 function resolveAudioContext(): AudioContextCtor | null {
   const w = window as unknown as {
     AudioContext?: AudioContextCtor;
     webkitAudioContext?: AudioContextCtor;
   };
   return w.AudioContext ?? w.webkitAudioContext ?? null;
+}
+
+// createAudioContext pins the context to the stream rate, falling back to the
+// hardware-default context if the browser rejects an explicit sampleRate (older
+// Safari throws). Pure except for the Ctor it is handed, so it is unit-testable.
+export function createAudioContext(
+  Ctor: AudioContextCtor,
+  rate: number,
+): AudioContext {
+  try {
+    return new Ctor({ sampleRate: rate });
+  } catch {
+    return new Ctor();
+  }
 }
 
 // createStreamPlayer wires a fetch reader to a GainNode → destination
@@ -183,7 +206,7 @@ export function createStreamPlayer(
         opts.onStateChange("error");
         return false;
       }
-      ctx = new Ctor();
+      ctx = createAudioContext(Ctor, STREAM_SAMPLE_RATE);
     }
     if (gain === null) {
       gain = ctx.createGain();


### PR DESCRIPTION
## Problem

A reporter noted the WebUI **live** stream sounds grainier / more artifact-y than the **recorded `.wav`** of the same call, and asked "shouldn't they use the same endpoint?"

The surprising part: **they already use the same data.** For digital calls the recorder hands the *exact same* decoded int16/8 kHz buffer to both the WAV writer and the live tap, and the stream endpoint emits that PCM verbatim. The bytes the browser receives equal the bytes in the file. The divergence was entirely in **browser playback**:

- A recorded `.wav` is decoded as **one continuous buffer** → resampled 8 kHz → device rate (~48 kHz) **once**, seamlessly.
- The live player (`web/src/audio/streamPlayer.ts`) created its `AudioContext` at the **hardware rate** and scheduled **each small network chunk as its own 8 kHz `AudioBuffer`**, so Web Audio resampled **every chunk independently** with no interpolation state across boundaries → periodic boundary artifacts.

## Fix

Pin the `AudioContext` to the stream's **8 kHz** rate (vocoder-native for every digital call, and the analog default) so Web Audio does **zero** per-chunk resampling. Buffers now match the context rate and play back-to-back seamlessly, and the OS does a single continuous resample to the output device — the same clean path a recorded WAV takes.

- New pure `createAudioContext(Ctor, rate)` helper pins the rate and **falls back** to the hardware-default context if a browser rejects an explicit `sampleRate` (older Safari throws). Being pure, it's covered by unit tests.
- `AudioPlayer.tsx` is unchanged (it only passes callbacks to `createStreamPlayer`).

### Known edge case (no regression)
A non-default analog `recordings.sample_rate` (≠ 8000) still incurs a resample, no worse than today's all-resampled behavior. The digital case — the reported problem — is fully fixed. This is fully resolved by the documented AudioWorklet ring-buffer follow-up, which resamples continuously to any context rate.

## Tests
- `web/src/audio/streamPlayer.test.ts`: new `createAudioContext` cases (rate is requested; falls back when rejected). `npm run test` → 15/15 pass.
- `npm run build` (tsc + vite) clean.

Note: this is the playback-quality follow-up to #598; the echo/double-play fix landed separately in #625.

https://claude.ai/code/session_01SNr1PL2ZnuSBZN9QQX1xqy

---
_Generated by [Claude Code](https://claude.ai/code/session_01SNr1PL2ZnuSBZN9QQX1xqy)_