### PR TITLE
Fix #629: AudioWorklet ring-buffer player with continuous resampling

### DIFF
--- a/web/src/audio/resampler.test.ts
+++ b/web/src/audio/resampler.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import { LinearResampler } from "./resampler";
+
+// Resample `input` in one shot at the given rates (helper for the
+// continuity assertions below).
+function once(
+  input: number[],
+  inRate: number,
+  outRate: number,
+): number[] {
+  return Array.from(
+    new LinearResampler(inRate, outRate).process(Float32Array.from(input)),
+  );
+}
+
+describe("LinearResampler", () => {
+  it("rejects non-positive rates", () => {
+    expect(() => new LinearResampler(0, 8000)).toThrow(/positive/);
+    expect(() => new LinearResampler(8000, -1)).toThrow(/positive/);
+  });
+
+  it("is a zero-copy passthrough when the rates match", () => {
+    const r = new LinearResampler(8000, 8000);
+    expect(r.passthrough).toBe(true);
+    const input = Float32Array.from([0.1, -0.2, 0.3]);
+    // Same reference back: no work, no allocation.
+    expect(r.process(input)).toBe(input);
+  });
+
+  it("linearly interpolates when upsampling 2x", () => {
+    // ratio = inRate/outRate = 0.5: one output every half input sample.
+    expect(once([0, 10, 20, 30], 1, 2)).toEqual([0, 5, 10, 15, 20, 25]);
+  });
+
+  it("preserves a DC level (no boundary ripple)", () => {
+    const out = once([0.5, 0.5, 0.5, 0.5], 8000, 48000);
+    for (const v of out) expect(v).toBeCloseTo(0.5, 6);
+  });
+
+  it("joins chunks seamlessly — split feed equals one-shot feed", () => {
+    // The whole point of #629: continuous state across chunk boundaries.
+    const whole = once([0, 10, 20, 30, 40, 50], 1, 2);
+
+    const r = new LinearResampler(1, 2);
+    const split = [
+      ...r.process(Float32Array.from([0, 10])),
+      ...r.process(Float32Array.from([20, 30])),
+      ...r.process(Float32Array.from([40, 50])),
+    ];
+
+    expect(split).toEqual(whole);
+  });
+
+  it("carries fractional position across a downsample (3:1)", () => {
+    // Compare a split feed against the one-shot result for outRate<inRate too.
+    const whole = once([0, 3, 6, 9, 12, 15, 18], 3, 1);
+
+    const r = new LinearResampler(3, 1);
+    const split = [
+      ...r.process(Float32Array.from([0, 3, 6])),
+      ...r.process(Float32Array.from([9, 12])),
+      ...r.process(Float32Array.from([15, 18])),
+    ];
+
+    expect(split).toEqual(whole);
+  });
+
+  it("handles empty and single-sample chunks without emitting garbage", () => {
+    const r = new LinearResampler(8000, 16000);
+    expect(Array.from(r.process(new Float32Array(0)))).toEqual([]);
+    // A lone first sample has no upper neighbour yet, so nothing is emitted
+    // until the next sample arrives — then output is continuous.
+    expect(Array.from(r.process(Float32Array.from([1])))).toEqual([]);
+    const out = Array.from(r.process(Float32Array.from([1, 1])));
+    for (const v of out) expect(v).toBeCloseTo(1, 6);
+  });
+});

--- a/web/src/audio/resampler.ts
+++ b/web/src/audio/resampler.ts
@@ -1,0 +1,63 @@
+// Continuous linear-interpolation resampler for the live-audio path.
+//
+// The daemon streams PCM at the call's sample rate (8 kHz for digital and the
+// analog default; occasionally another rate for analog). The AudioWorklet that
+// plays it runs at the AudioContext rate — normally the 8 kHz we pin, but the
+// hardware rate (~48 kHz) when a browser rejects the explicit rate. When those
+// differ we must resample, and doing it per network chunk with no shared state
+// reintroduces the exact boundary artifacts issue #598 set out to remove. One
+// LinearResampler instance therefore spans the whole stream: it carries the
+// fractional read cursor and the last input sample across calls so consecutive
+// chunks join seamlessly. When the rates match it is a zero-work passthrough.
+
+export class LinearResampler {
+  // Input samples consumed per output sample (inputRate / outputRate).
+  private readonly ratio: number;
+  // Position of the next output, in input-sample coordinates relative to the
+  // current chunk, where index -1 is `prev` (the previous chunk's last sample).
+  // Starts at 0 so the first chunk never reads the (nonexistent) `prev`.
+  private t = 0;
+  private prev = 0;
+
+  constructor(inputRate: number, outputRate: number) {
+    if (inputRate <= 0 || outputRate <= 0) {
+      throw new Error("LinearResampler: sample rates must be positive");
+    }
+    this.ratio = inputRate / outputRate;
+  }
+
+  /** True when input and output rates match and process() is a no-op. */
+  get passthrough(): boolean {
+    return this.ratio === 1;
+  }
+
+  // process resamples one chunk, emitting every output sample whose
+  // interpolation window lies wholly within the samples seen so far. Any
+  // remaining fractional position and the chunk's last sample are carried into
+  // the next call, so feeding [a,b] then [c,d] yields exactly what feeding
+  // [a,b,c,d] at once would. Returns the input unchanged when passthrough.
+  process(input: Float32Array): Float32Array {
+    if (input.length === 0) return input;
+    if (this.ratio === 1) return input;
+
+    const len = input.length;
+    const out: number[] = [];
+    let t = this.t;
+    // Produce while the upper interpolation neighbour input[i+1] exists, i.e.
+    // while t < len - 1. Samples landing exactly on the final boundary are
+    // deferred to the next chunk (where this sample becomes `prev`).
+    while (t < len - 1) {
+      const i = Math.floor(t);
+      const frac = t - i;
+      const a = i < 0 ? this.prev : input[i];
+      const b = input[i + 1];
+      out.push(a + (b - a) * frac);
+      t += this.ratio;
+    }
+    // Carry: the next chunk's index -1 is this chunk's last sample, so shift the
+    // cursor by len to keep it continuous across the boundary.
+    this.prev = input[len - 1];
+    this.t = t - len;
+    return Float32Array.from(out);
+  }
+}

--- a/web/src/audio/ringBufferProcessor.js
+++ b/web/src/audio/ringBufferProcessor.js
@@ -1,0 +1,89 @@
+// AudioWorklet ring-buffer player for the live-audio stream (issue #629).
+//
+// The main thread resamples each network chunk to the context rate (see
+// resampler.ts) and posts the Float32 samples here via port.postMessage with a
+// transferred ArrayBuffer. This processor owns a fixed-size ring buffer and, on
+// every render quantum, copies samples out to the output — and crucially writes
+// SILENCE on underrun instead of stalling or repositioning the playback cursor.
+// That replaces the old per-chunk AudioBufferSource scheduler, whose
+// nextStartTime skip/realign produced audible glitches under network jitter.
+//
+// Plain JS with no imports/exports so addModule() can load it as a classic
+// AudioWorklet module untouched by the bundler. `sampleRate` is the global
+// AudioWorkletGlobalScope context rate.
+
+class RingBufferProcessor extends AudioWorkletProcessor {
+  constructor(options) {
+    super();
+    const opts = (options && options.processorOptions) || {};
+    // Upper bound on buffered audio: caps end-to-end latency and the memory the
+    // ring holds. Producer and consumer run at the same (context) rate, so the
+    // ring hovers near the prime level rather than filling.
+    this.capacity = Math.max(1, opts.capacityFrames || Math.ceil(sampleRate * 2));
+    // Jitter cushion: stay silent until this many frames are buffered, then
+    // drain. Re-primed after every underrun so playback resumes cleanly.
+    this.prime = Math.min(this.capacity, Math.max(1, opts.primeFrames || Math.ceil(sampleRate * 0.15)));
+    this.ring = new Float32Array(this.capacity);
+    this.read = 0;
+    this.write = 0;
+    this.available = 0; // frames currently buffered
+    this.draining = false; // false until primed; flips back on underrun
+
+    this.port.onmessage = (event) => {
+      const msg = event.data;
+      if (!msg) return;
+      if (msg.type === "reset") {
+        this.read = 0;
+        this.write = 0;
+        this.available = 0;
+        this.draining = false;
+        return;
+      }
+      if (msg.type === "push" && msg.samples) {
+        this.enqueue(msg.samples);
+      }
+    };
+  }
+
+  enqueue(samples) {
+    for (let i = 0; i < samples.length; i++) {
+      this.ring[this.write] = samples[i];
+      this.write = (this.write + 1) % this.capacity;
+      if (this.available < this.capacity) {
+        this.available++;
+      } else {
+        // Overflow (producer outran consumer): drop the oldest frame so latency
+        // stays bounded rather than letting the cursor lap itself.
+        this.read = (this.read + 1) % this.capacity;
+      }
+    }
+  }
+
+  process(_inputs, outputs) {
+    const channel = outputs[0] && outputs[0][0];
+    if (!channel) return true;
+
+    if (!this.draining && this.available >= this.prime) {
+      this.draining = true;
+    }
+    if (!this.draining) {
+      channel.fill(0);
+      return true;
+    }
+
+    for (let i = 0; i < channel.length; i++) {
+      if (this.available > 0) {
+        channel[i] = this.ring[this.read];
+        this.read = (this.read + 1) % this.capacity;
+        this.available--;
+      } else {
+        // Underrun: emit silence and re-prime before draining again.
+        channel[i] = 0;
+        this.draining = false;
+      }
+    }
+    return true;
+  }
+}
+
+registerProcessor("ringbuffer-player", RingBufferProcessor);

--- a/web/src/audio/streamPlayer.ts
+++ b/web/src/audio/streamPlayer.ts
@@ -17,6 +17,8 @@
 // internal/api/handlers_audio_stream.go. The byte-framing logic below
 // must match that layout.
 
+import { LinearResampler } from "./resampler";
+
 // ---------------------------------------------------------------------------
 // Pure, testable framing helpers (no DOM / AudioContext).
 // ---------------------------------------------------------------------------
@@ -143,6 +145,10 @@ const MAX_LEAD_SECONDS = 0.6;
 // Backoff before a single reconnect attempt when the stream ends on its
 // own (e.g. the daemon restarted) while the user still wants audio.
 const RECONNECT_DELAY_MS = 1000;
+// Capacity of the AudioWorklet ring buffer, in seconds of audio. The producer
+// and consumer run at the same rate so the ring hovers near the lead cushion;
+// this only bounds the worst case (and the memory the worklet holds).
+const MAX_RING_SECONDS = 2;
 
 type AudioContextCtor = typeof AudioContext;
 
@@ -177,16 +183,105 @@ export function createAudioContext(
   }
 }
 
-// createStreamPlayer wires a fetch reader to a GainNode → destination
-// graph. One instance owns one AudioContext (reused across reconnects)
-// and at most one in-flight fetch.
+// A PcmSink consumes the decoded Float32 stream and renders it. configure() is
+// called once per connection with the stream's sample rate (from the WAV
+// header); push() delivers whole-sample chunks; reset() drops any buffered
+// audio so a stop/reconnect doesn't replay stale frames.
+interface PcmSink {
+  configure(streamRate: number): void;
+  push(samples: Float32Array): void;
+  reset(): void;
+}
+
+// WorkletSink feeds the ring-buffer AudioWorklet (issue #629). It resamples the
+// stream to the context rate with one continuous LinearResampler (so chunk
+// boundaries don't glitch) and hands the samples to the audio thread via a
+// transferred buffer. The worklet emits silence on underrun, so network jitter
+// no longer skips/realigns the playback cursor the way the legacy scheduler did.
+class WorkletSink implements PcmSink {
+  private resampler: LinearResampler | null = null;
+
+  constructor(
+    private readonly node: AudioWorkletNode,
+    private readonly contextRate: number,
+  ) {}
+
+  configure(streamRate: number): void {
+    this.resampler = new LinearResampler(streamRate, this.contextRate);
+    this.node.port.postMessage({ type: "reset" });
+  }
+
+  reset(): void {
+    this.node.port.postMessage({ type: "reset" });
+  }
+
+  push(samples: Float32Array): void {
+    if (samples.length === 0) return;
+    const out = this.resampler ? this.resampler.process(samples) : samples;
+    if (out.length === 0) return;
+    // Transfer ownership to the audio thread — the run loop never reuses the
+    // buffer, and each takeSamples() returns a fresh one, so this is safe.
+    this.node.port.postMessage({ type: "push", samples: out }, [out.buffer]);
+  }
+}
+
+// LegacySink is the original per-chunk AudioBufferSource scheduler, kept as a
+// fallback for browsers without AudioWorklet (or when the worklet module can't
+// load). The context resamples each buffer to the device rate; the 8 kHz
+// context pin keeps that a no-op for the common case.
+class LegacySink implements PcmSink {
+  private nextStartTime = 0;
+  private streamRate = STREAM_SAMPLE_RATE;
+
+  constructor(
+    private readonly ctx: AudioContext,
+    private readonly gain: GainNode,
+  ) {}
+
+  configure(streamRate: number): void {
+    this.streamRate = streamRate;
+    this.nextStartTime = 0;
+  }
+
+  reset(): void {
+    this.nextStartTime = 0;
+  }
+
+  push(samples: Float32Array): void {
+    const { ctx, gain } = this;
+    if (samples.length === 0) return;
+    const buffer = ctx.createBuffer(1, samples.length, this.streamRate);
+    buffer.getChannelData(0).set(samples);
+    const src = ctx.createBufferSource();
+    src.buffer = buffer;
+    src.connect(gain);
+
+    const now = ctx.currentTime;
+    if (this.nextStartTime < now + 0.001) {
+      // Underrun (or first buffer): we've fallen behind real time. Resync
+      // forward with a fresh lead cushion rather than scheduling in the
+      // past (which the API clamps to "now" and stacks).
+      this.nextStartTime = now + LEAD_SECONDS;
+    } else if (this.nextStartTime > now + MAX_LEAD_SECONDS) {
+      // Too far ahead (a burst drained in one tick): pull the cursor back
+      // so latency doesn't grow unbounded for the rest of the call.
+      this.nextStartTime = now + MAX_LEAD_SECONDS;
+    }
+    src.start(this.nextStartTime);
+    this.nextStartTime += buffer.duration;
+  }
+}
+
+// createStreamPlayer wires a fetch reader to a PcmSink → GainNode → destination
+// graph. One instance owns one AudioContext (reused across reconnects), one
+// sink, and at most one in-flight fetch.
 export function createStreamPlayer(
   opts: StreamPlayerOptions,
 ): StreamPlayer {
   let ctx: AudioContext | null = null;
   let gain: GainNode | null = null;
   let abort: AbortController | null = null;
-  let nextStartTime = 0;
+  let sinkPromise: Promise<PcmSink> | null = null;
   let volume = 1;
   let muted = false;
   let userStopped = false;
@@ -216,27 +311,39 @@ export function createStreamPlayer(
     return true;
   };
 
-  const schedule = (samples: Float32Array, sampleRate: number) => {
-    if (ctx === null || gain === null || samples.length === 0) return;
-    const buffer = ctx.createBuffer(1, samples.length, sampleRate);
-    buffer.getChannelData(0).set(samples);
-    const src = ctx.createBufferSource();
-    src.buffer = buffer;
-    src.connect(gain);
-
-    const now = ctx.currentTime;
-    if (nextStartTime < now + 0.001) {
-      // Underrun (or first buffer): we've fallen behind real time. Resync
-      // forward with a fresh lead cushion rather than scheduling in the
-      // past (which the API clamps to "now" and stacks).
-      nextStartTime = now + LEAD_SECONDS;
-    } else if (nextStartTime > now + MAX_LEAD_SECONDS) {
-      // Too far ahead (a burst drained in one tick): pull the cursor back
-      // so latency doesn't grow unbounded for the rest of the call.
-      nextStartTime = now + MAX_LEAD_SECONDS;
-    }
-    src.start(nextStartTime);
-    nextStartTime += buffer.duration;
+  // getSink lazily loads the AudioWorklet module and builds the ring-buffer
+  // sink, caching it for reuse across reconnects. If worklets are unavailable
+  // or the module fails to load (old browser, a CSP that blocks worklets, or a
+  // proxy that mangles the asset) it falls back to per-chunk buffer scheduling
+  // so audio still plays. Either outcome is cached.
+  const getSink = (): Promise<PcmSink> => {
+    if (sinkPromise) return sinkPromise;
+    sinkPromise = (async (): Promise<PcmSink> => {
+      const audioCtx = ctx!;
+      const out = gain!;
+      if (audioCtx.audioWorklet) {
+        try {
+          await audioCtx.audioWorklet.addModule(
+            new URL("./ringBufferProcessor.js", import.meta.url),
+          );
+          const node = new AudioWorkletNode(audioCtx, "ringbuffer-player", {
+            processorOptions: {
+              capacityFrames: Math.ceil(audioCtx.sampleRate * MAX_RING_SECONDS),
+              primeFrames: Math.ceil(audioCtx.sampleRate * LEAD_SECONDS),
+            },
+          });
+          node.connect(out);
+          return new WorkletSink(node, audioCtx.sampleRate);
+        } catch (err) {
+          console.warn(
+            "GopherTrunk: AudioWorklet unavailable, using buffer scheduling:",
+            err,
+          );
+        }
+      }
+      return new LegacySink(audioCtx, out);
+    })();
+    return sinkPromise;
   };
 
   const run = async () => {
@@ -267,20 +374,25 @@ export function createStreamPlayer(
 
     const framer = new PcmFramer();
     const reader = res.body.getReader();
-    nextStartTime = 0;
+    const sink = await getSink();
+    sink.reset();
     let started = false;
+    let configured = false;
     try {
       for (;;) {
         const { value, done } = await reader.read();
         if (done) break;
         if (!value) continue;
         framer.feed(value);
-        const fmt = framer.format;
+        // Configure the sink's resampler as soon as the header's rate is known.
+        if (!configured && framer.format) {
+          sink.configure(framer.format.sampleRate);
+          configured = true;
+        }
         for (;;) {
           const samples = framer.takeSamples();
           if (samples === null) break;
-          const rate = framer.format?.sampleRate ?? fmt?.sampleRate ?? 8000;
-          schedule(samples, rate);
+          sink.push(samples);
           if (!started) {
             started = true;
             opts.onStateChange("playing");
@@ -321,6 +433,9 @@ export function createStreamPlayer(
       // Resume synchronously within the gesture so the autoplay policy
       // doesn't reject playback. fetch() is awaited inside run().
       void ctx.resume();
+      // Warm the worklet module now so it loads alongside the fetch rather
+      // than serially after it; run() awaits the same cached promise.
+      void getSink();
       void run();
     },
     stop() {
@@ -331,6 +446,8 @@ export function createStreamPlayer(
       }
       abort?.abort();
       abort = null;
+      // Drop buffered audio so a later resume doesn't replay stale frames.
+      void sinkPromise?.then((sink) => sink.reset());
       void ctx?.suspend();
       opts.onStateChange("stopped");
     },


### PR DESCRIPTION
Implements #629 — the AudioWorklet ring-buffer rework, the planned follow-up to the 8 kHz context pin in #628 (now merged).

## What & why

The 8 kHz context pin (#628) fixed the common digital case, but two gaps remained:

1. **Per-chunk resampling still glitches when rates differ** — a non-default analog `recordings.sample_rate`, or any browser that rejects the explicit 8 kHz context and falls back to the hardware rate (~48 kHz). Each chunk was resampled with no shared state — the exact boundary artifact #598 set out to remove.
2. **Underruns skipped/realigned the cursor** — the old `nextStartTime` logic repositioned playback audibly under network jitter.

## Approach

- **`resampler.ts` — `LinearResampler`**: one instance spans the whole stream, carrying the fractional read cursor and last sample across `process()` calls so consecutive chunks join seamlessly. Zero-work passthrough when stream rate == context rate. Pure and unit-tested (continuity, passthrough, DC, up/down-sample).
- **`ringBufferProcessor.js` — AudioWorklet**: owns a fixed-size ring buffer, primes a small jitter cushion, and **emits silence on underrun** instead of stalling/realigning. Latency is bounded by ring capacity. Kept as minimal plain JS so the testable logic stays on the main thread.
- **`streamPlayer.ts`**: a `PcmSink` abstraction with `WorkletSink` (resample → transfer to the worklet) and `LegacySink` (the previous scheduler). The worklet is selected at runtime with **graceful fallback** to `LegacySink` if `AudioWorklet` is missing or the module fails to load (old browser, CSP).

## Deployment notes
- **No `SharedArrayBuffer`** → no cross-origin-isolation (COOP/COEP) headers needed. Transport is `port.postMessage` with a transferred buffer; 8 kHz mono is a trivial data rate (~32 KB/s). This is the fallback transport flagged in #629.
- The worklet loads via `new URL('./ringBufferProcessor.js', import.meta.url)`; **Vite inlines it as a `data:` URL** in the bundle, so there's no separate asset for a reverse proxy to mangle or 404 — consistent with the #598 reliability goals. (The runtime fallback covers any CSP that blocks `data:` worklets.)
- Public API (`createStreamPlayer`) is unchanged; `AudioPlayer.tsx` needs no changes.

## Tests
- `npm test` → **185/185 pass** (7 new `resampler` cases). `npm run build` (tsc + vite) clean; confirmed the worklet inlines as a `data:` URL.

Closes #629.

https://claude.ai/code/session_01SNr1PL2ZnuSBZN9QQX1xqy

---
_Generated by [Claude Code](https://claude.ai/code/session_01SNr1PL2ZnuSBZN9QQX1xqy)_