### PR TITLE
docs: post-release v0.3.9 — promote CHANGELOG, bump refs, announcement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,69 @@ for tagged releases.
 
 ## [Unreleased]
 
+## [v0.3.9] — 2026-06-11
+
+This release is about **live audio you can actually hear** and a friendlier
+config path. Digital voice (P25 Phase 1/2, DMR, NXDN) now reaches the web
+console's live stream — previously only analog FM and disk recordings carried
+sound, because digital frames are decoded to PCM only inside the recorder and
+were never fanned to the live consumers (#598). The browser player is rebuilt
+around an **AudioWorklet ring buffer** with a single continuous resampler, so
+chunk boundaries no longer click and network jitter degrades to brief silence
+instead of audible re-syncs (#629); the live `AudioContext` is pinned to 8 kHz
+to match the recorded WAV quality (#598), and a host-speaker echo from
+double-playing digital audio is gone (#598). The **Config Builder and web UI**
+get a shared RadioReference login (the SOAP app key is built into the binary),
+an in-place config-file browser and hot-swap/reload, and a smoother connect
+screen (#621). On the DSP side: the P25 IMBE vocoder is aligned with the
+OP25/JMBE references (pitch-dependent prediction, DC block, adaptive smoothing),
+over-driven P25/DMR voice clipping is fixed with a soft limiter and per-call
+voice telemetry, `voice_taps` is uncapped, Airspy real-ADC IQ conversion and
+rate/probe-gain bugs are fixed (#454), and a DC-spike-avoidance LO offset lands
+on the live control path (#402). Three new **Basics / Intermediate / Advanced**
+guides extend Getting Started (#620).
+
+### Added
+
+- **Three-level learning path: Basics / Intermediate / Advanced guides** (#620).
+  The Getting Started funnel now continues past your first recorded call with
+  three pages that build level by level and cross-link out to the existing
+  detailed docs rather than duplicating them: `guide-basics` (everyday web-
+  console operation, playback, talkgroup tidy-up, bookmarks/radio IDs, scanning,
+  feed sharing), `guide-intermediate` (`config.yaml`, multi-dongle pools, alias
+  files, paging/tone alerts, Hunt, network access/hardening), and
+  `guide-advanced` (TUI cockpit, signal scopes, SigLab, the other receivers,
+  remote SDRs, and the REST/gRPC/Prometheus/rigctld APIs). Wired into the
+  Getting Started nav group.
+- **Config Builder & web UI: RadioReference login, config browsing/hot-swap,
+  connect UX** (#621). The Config Builder gains a shared RadioReference login
+  block (username + password only — the SOAP app key is built into the binary),
+  surfaced inline in the "Add from RadioReference" modal so browsing prompts for
+  credentials in place, plus a prominent "Browse…" picker that lists available
+  and previously-created configs with folder, modified time, size, and validity.
+  The web console pre-fills the server URL with the device's own origin (with a
+  "Use this device's address" button), offers to open the Config Builder when
+  the daemon has no config file, and adds a Settings config-file picker that
+  hot-swaps the active config via live Reload or full Restart. Backed by a new
+  gated `POST /api/v1/config/activate`.
+- **DC-spike-avoidance LO offset on the live control channel** (#402). A new
+  opt-in `dc_avoid` flag (with optional `dc_avoid_offset_hz`) on a control
+  SDR's `sdr.devices` entry tunes the hardware LO a fixed offset *below* the
+  control-channel frequency and mixes the channel back to baseband in the
+  down-converter — so the live decode runs off the front-end DC spur, 1/f
+  noise and its own I/Q-imbalance image, the same offset tuning SDRTrunk/OP25
+  use. This closes the live-vs-replay gap on marginal urban sites where the
+  channel decodes cleanly off-channel (in replay) but accumulates TSBK-CRC /
+  NID-BCH failures live with the channel sitting at zero-IF. Off by default
+  (`dc_avoid: false`); `dc_avoid_offset_hz: 0` auto-selects `sample_rate/4`.
+- **Per-call voice audio-quality telemetry** for diagnosing decode/synthesis
+  problems. The IMBE decoder accumulates a `VoiceStats` summary (pitch/f0,
+  harmonic count, voiced fraction, AGC gain, output peak/RMS/crest, and
+  limited-sample percentage); the recorder logs it per call at `DEBUG` as
+  `recorder: voice audio quality`, escalating to `WARN` when the output is
+  clipping. `gophertrunk decode` prints the same summary for a captured `.raw`
+  sidecar (`-stats`, default on), so audio quality can be triaged offline.
+
 ### Changed
 
 - **`voice_taps` is no longer capped at 8.** A wideband dongle can now host any
@@ -81,26 +144,35 @@ for tagged releases.
   is a real-sampling front end: its samples are now converted to complex
   baseband on the host (Fs/4 translation + half-band Hilbert, decimate-by-two),
   matching libairspy's IQ modes and restoring image rejection (~70 dB).
-
-### Added
-
-- **DC-spike-avoidance LO offset on the live control channel** (#402). A new
-  opt-in `dc_avoid` flag (with optional `dc_avoid_offset_hz`) on a control
-  SDR's `sdr.devices` entry tunes the hardware LO a fixed offset *below* the
-  control-channel frequency and mixes the channel back to baseband in the
-  down-converter — so the live decode runs off the front-end DC spur, 1/f
-  noise and its own I/Q-imbalance image, the same offset tuning SDRTrunk/OP25
-  use. This closes the live-vs-replay gap on marginal urban sites where the
-  channel decodes cleanly off-channel (in replay) but accumulates TSBK-CRC /
-  NID-BCH failures live with the channel sitting at zero-IF. Off by default
-  (`dc_avoid: false`); `dc_avoid_offset_hz: 0` auto-selects `sample_rate/4`.
-- **Per-call voice audio-quality telemetry** for diagnosing decode/synthesis
-  problems. The IMBE decoder accumulates a `VoiceStats` summary (pitch/f0,
-  harmonic count, voiced fraction, AGC gain, output peak/RMS/crest, and
-  limited-sample percentage); the recorder logs it per call at `DEBUG` as
-  `recorder: voice audio quality`, escalating to `WARN` when the output is
-  clipping. `gophertrunk decode` prints the same summary for a captured `.raw`
-  sidecar (`-stats`, default on), so audio quality can be triaged offline.
+- **Live digital voice was silent in the web console** (#598). P25 Phase 1/2,
+  DMR, and NXDN reach the composer as raw vocoder frames (`WriteRawFrame`),
+  which only the recorder consumes and decodes to PCM; the tone-out detector,
+  live player, and audio publisher implement `WritePCM` only, so they never saw
+  digital audio and the live stream stayed silent even while disk recordings
+  were audible (analog FM worked because its chain calls `WritePCM` directly).
+  The recorder now exposes a decoded-PCM tap that the daemon fans to the live
+  consumers, so every decoded sample is streamed exactly once.
+- **Live stream dropped PCM when the publisher had no cached grant** (#598).
+  `AudioPublisher.WritePCM` discarded all PCM unless it held a cached grant for
+  the device serial, but that cache is fed by an events-bus subscription that
+  drops events into a momentarily-full channel — so on a busy control channel
+  (especially with multiple voice taps) a missed `CallStart` silenced the live
+  stream for the call. Neither stream consumer reads the frame's grant, so the
+  requirement was pure fragility; PCM now fans to unfiltered and serial-only
+  subscribers regardless of grant state (talkgroup-filtered subscribers still
+  need a grant to evaluate their predicate).
+- **Host-speaker echo from double-playing digital audio** (#598). Digital voice
+  was being played on the host speaker twice, producing an echo; the duplicate
+  playback path is removed.
+- **Web audio player rebuilt on an AudioWorklet ring buffer** (#629). The
+  per-chunk `AudioBufferSource` scheduler is replaced with an AudioWorklet that
+  reads from a ring buffer through a single `LinearResampler` spanning the whole
+  stream — so non-default analog rates (and browsers that reject the 8 kHz
+  context) no longer reintroduce per-chunk boundary artifacts, and underruns
+  emit brief silence instead of an audible cursor re-align under network jitter.
+  Falls back to the previous scheduler where AudioWorklet is unavailable.
+- **Live `AudioContext` pinned to 8 kHz** (#598) to match the recorded-WAV
+  quality, so the live stream and recordings sound the same.
 
 ## [v0.3.8] — 2026-06-10
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ this exist? Read **[The Story of GopherTrunk](https://gophertrunk.org/story.html
 
 ```sh
 # Linux x86_64 — see https://gophertrunk.org/downloads.html for macOS, Windows, ARM64.
-VERSION=v0.3.8
+VERSION=v0.3.9
 curl -L -o gophertrunk.tar.gz \
   https://github.com/MattCheramie/GopherTrunk/releases/download/${VERSION}/gophertrunk-${VERSION}-linux-amd64.tar.gz
 tar xzf gophertrunk.tar.gz && cd gophertrunk-${VERSION}-linux-amd64

--- a/docs/announcements/v0.3.9.md
+++ b/docs/announcements/v0.3.9.md
@@ -1,0 +1,51 @@
+# GopherTrunk v0.3.9 — social announcement drafts
+
+One-click copy-paste blurbs for posting the v0.3.9 release. Each block
+below is a fenced code block so the rendered-markdown "copy" button
+grabs exactly what you'd paste.
+
+Release: https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.3.9
+
+---
+
+## Reddit — title
+
+```
+GopherTrunk v0.3.9 — digital voice now plays in the live web console, a rebuilt gapless audio player, and an in-place Config Builder with RadioReference login
+```
+
+## Reddit — body
+
+```markdown
+**[GopherTrunk](https://gophertrunk.org) v0.3.9 is out** — pure-Go digital-trunking scanner for RTL-SDR / HackRF / Airspy. P25 (Phase 1+2), DMR (AMBE+2 voice), NXDN, Motorola Type II, EDACS, LTR, MPT 1327, dPMR, D-STAR, YSF, M17, plus APRS, POCSAG + FLEX paging, and AIS / DSC / ADS-B. No CGO, single static binary for Linux / macOS / Windows.
+
+**What's new since v0.3.8:**
+
+* **Live digital voice in the web console** (#598) — P25 Phase 1/2, DMR, and NXDN now stream to the live "Tap to enable audio" player, not just to disk recordings. Digital frames are decoded to PCM in the recorder and fanned to the live consumers, and the live stream no longer drops PCM when the publisher misses a grant on a busy control channel.
+* **Rebuilt browser audio player** (#629) — the per-chunk scheduler is replaced with an AudioWorklet ring buffer and a single continuous resampler, so chunk boundaries no longer click, non-default rates resample seamlessly, and network jitter degrades to brief silence instead of audible re-syncs. The live `AudioContext` is pinned to 8 kHz to match recordings, and a host-speaker echo from double-playing digital audio is fixed.
+* **Config Builder & web UI overhaul** (#621) — a shared RadioReference login (username + password; the SOAP app key is built into the binary) prompts for credentials in place, a "Browse…" picker lists your existing configs with folder/size/validity, and the web console can hot-swap the active config via live Reload or full Restart. The connect screen pre-fills the device's own address.
+* **DSP fixes** — the P25 IMBE vocoder is aligned with the OP25/JMBE references (pitch-dependent prediction, DC block, adaptive smoothing), over-driven P25/DMR voice clipping is replaced with a soft limiter plus per-call voice telemetry, `voice_taps` is uncapped, Airspy real-ADC IQ conversion and rate/probe-gain bugs are fixed (#454), and a DC-spike-avoidance LO offset lands on the live control path (#402).
+* **New guides** (#620) — Basics / Intermediate / Advanced pages extend Getting Started from your first recorded call out to multi-dongle pools, Hunt, the TUI cockpit, signal scopes, and the APIs.
+
+**Downloads** (Linux / macOS / Windows, x64 + ARM64): https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.3.9
+
+**Docs:** https://gophertrunk.org
+
+Heads-up: the v0.x line is still flagged prerelease — actively developed, feedback / captures / bug reports very welcome.
+```
+
+## Discord
+
+```markdown
+**GopherTrunk v0.3.9 is out** — pure-Go trunking scanner for RTL-SDR / HackRF / Airspy. P25, DMR, NXDN, M17, analog trunked, APRS, POCSAG + FLEX paging, AIS / DSC / ADS-B. Single static binary, zero CGO.
+
+**What's new since v0.3.8:**
+- **Live digital voice in the web console** (#598) — P25/DMR/NXDN now stream to the live player (decoded PCM fanned from the recorder), and the stream no longer drops audio when a grant is missed on a busy control channel.
+- **Rebuilt audio player** (#629) — AudioWorklet ring buffer + single continuous resampler: gapless chunks, jitter degrades to silence, 8 kHz context to match recordings, host-speaker echo fixed.
+- **Config Builder & web UI** (#621) — shared RadioReference login (built-in app key), in-place config browser, hot-swap/reload the active config, connect screen pre-fills the device address.
+- **DSP:** P25 IMBE aligned with OP25/JMBE, voice-clipping soft limiter + per-call telemetry, `voice_taps` uncapped, Airspy real-ADC IQ fix (#454), DC-spike-avoidance LO offset (#402).
+- **Docs:** new Basics / Intermediate / Advanced guides (#620).
+
+Download: <https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.3.9>
+Docs: <https://gophertrunk.org>
+```

--- a/docs/downloads.md
+++ b/docs/downloads.md
@@ -28,7 +28,7 @@ release state looks like:
 {%- elsif site.github.releases and site.github.releases[0] and site.github.releases[0].tag_name -%}
   {%- assign ver = site.github.releases[0].tag_name -%}
 {%- else -%}
-  {%- assign ver = "v0.3.8" -%}
+  {%- assign ver = "v0.3.9" -%}
 {%- endif -%}
 {%- assign rel_url = "https://github.com/MattCheramie/GopherTrunk/releases/download/" | append: ver -%}
 


### PR DESCRIPTION
Now that the daily release workflow tagged v0.3.9, sync the docs:

- CHANGELOG: promote [Unreleased] to [v0.3.9] (2026-06-11) with a release
  summary, and backfill the user-visible changes that shipped without a
  changelog entry — live digital voice now streaming to the web console
  (#598), the AudioWorklet ring-buffer player rebuild (#629), the Config
  Builder / web UI RR-login + config browsing/hot-swap (#621), and the new
  Basics/Intermediate/Advanced guides (#620).
- README: bump the Linux quick-install VERSION to v0.3.9.
- downloads.md: bump the GitHub Pages fallback version to v0.3.9.
- announcements: add the v0.3.9 social blurb drafts.