### PR TITLE
web: add spectrum-analyzer line plot above the waterfall

### DIFF
--- a/web/src/panels/Spectrum.test.tsx
+++ b/web/src/panels/Spectrum.test.tsx
@@ -130,7 +130,7 @@ describe("Spectrum panel", () => {
 
     render(<Spectrum />);
 
-    const canvas = await screen.findByLabelText(/hover to read the frequency/i);
+    const canvas = await screen.findByLabelText(/spectrum waterfall — hover/i);
     // Map cursor → frequency: at the canvas midpoint (xRatio 0.5) the
     // frequency equals the center, and the matching bin (index 4) is -40.
     canvas.getBoundingClientRect = () =>
@@ -145,6 +145,40 @@ describe("Spectrum panel", () => {
     fireEvent.mouseLeave(canvas);
     await waitFor(() => {
       expect(screen.queryByText(/153\.0000 MHz · -40\.0 dBFS/)).toBeNull();
+    });
+  });
+
+  it("renders the spectrum analyzer line plot and reads out on hover", async () => {
+    vi.mocked(fetchSpectrumDevices).mockResolvedValue([
+      {
+        serial: "rtl-1",
+        driver: "rtlsdr",
+        role: "control",
+        center_hz: 153_000_000,
+        sample_rate_hz: 2_048_000,
+      },
+    ]);
+    vi.mocked(openSpectrumStream).mockImplementation((_cfg, opts) => {
+      opts.onFrame?.({
+        ts_ns: 0,
+        center_hz: 153_000_000,
+        sample_rate_hz: 2_048_000,
+        bins: [-80, -70, -60, -50, -40, -30, -20, -10],
+      });
+      return { close: vi.fn() };
+    });
+
+    render(<Spectrum />);
+
+    // The analyzer canvas sits above the waterfall and shares the same
+    // X→frequency mapping, so hovering it produces the same readout.
+    const analyzer = await screen.findByLabelText(/spectrum analyzer/i);
+    analyzer.getBoundingClientRect = () =>
+      ({ left: 0, top: 0, width: 100, height: 160 }) as DOMRect;
+    fireEvent.mouseMove(analyzer, { clientX: 50, clientY: 10 });
+
+    await waitFor(() => {
+      expect(screen.getByText(/153\.0000 MHz · -40\.0 dBFS/)).toBeInTheDocument();
     });
   });
 

--- a/web/src/panels/Spectrum.tsx
+++ b/web/src/panels/Spectrum.tsx
@@ -26,6 +26,11 @@ const FPS = 15;
 const HISTORY_ROWS = 256;
 const DB_FLOOR = -100;
 const DB_CEIL = 0;
+// Internal pixel height of the spectrum-analyzer line plot drawn above
+// the waterfall. Shares the waterfall's full-width layout and FFT-shifted
+// bin→x mapping so a peak in the analyzer lines up vertically with its
+// streak in the waterfall below.
+const ANALYZER_H = 160;
 
 type ConnState = "connecting" | "open" | "closed";
 
@@ -41,6 +46,7 @@ export function Spectrum() {
   const [hover, setHover] = useState<{ hz: number; db: number } | null>(null);
 
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const analyzerRef = useRef<HTMLCanvasElement | null>(null);
   const rowsRef = useRef<Float32Array[]>([]);
   const latestRef = useRef<SpectrumFrame | null>(null);
   const bookmarksRef = useRef<Bookmark[]>([]);
@@ -106,7 +112,11 @@ export function Spectrum() {
     // Clear history on device change so we don't render bins from a
     // different centre frequency on the same canvas row.
     rowsRef.current = [];
+    latestRef.current = null;
     setLatest(null);
+    // Blank the analyzer trace immediately; it otherwise keeps the last
+    // device's curve painted until the first new frame lands.
+    renderAnalyzer(analyzerRef.current, null);
 
     const stream = openSpectrumStream(cfg, {
       serial: selected,
@@ -117,6 +127,7 @@ export function Spectrum() {
         latestRef.current = f;
         const row = new Float32Array(f.bins);
         rowsRef.current = [row, ...rowsRef.current.slice(0, HISTORY_ROWS - 1)];
+        renderAnalyzer(analyzerRef.current, f);
         renderWaterfall(
           canvasRef.current,
           rowsRef.current,
@@ -135,7 +146,10 @@ export function Spectrum() {
   // sampleRate/2), rightmost = (centerHz + sampleRate/2 -
   // sampleRate/N).
   const handleCanvasClick = async (e: React.MouseEvent<HTMLCanvasElement>) => {
-    const canvas = canvasRef.current;
+    // currentTarget is whichever canvas was clicked — the analyzer line
+    // plot or the waterfall. Both share the same full-width X→frequency
+    // mapping, so click-to-tune works identically on either.
+    const canvas = e.currentTarget;
     const frame = latestRef.current;
     if (!canvas || !frame || !selected) return;
     const xRatio = cursorXRatio(canvas, e.clientX);
@@ -156,7 +170,7 @@ export function Spectrum() {
   // value comes from the newest waterfall row (rowsRef.current[0])
   // using the same nearest-neighbor bin index renderWaterfall draws.
   const handleCanvasMove = (e: React.MouseEvent<HTMLCanvasElement>) => {
-    const canvas = canvasRef.current;
+    const canvas = e.currentTarget;
     const frame = latestRef.current;
     if (!canvas || !frame) {
       setHover(null);
@@ -224,6 +238,17 @@ export function Spectrum() {
 
       <div className="rounded border border-border bg-black overflow-hidden">
         <canvas
+          ref={analyzerRef}
+          width={FFT_BINS}
+          height={ANALYZER_H}
+          className="block w-full cursor-crosshair border-b border-border"
+          style={{ height: 160 }}
+          onClick={handleCanvasClick}
+          onMouseMove={handleCanvasMove}
+          onMouseLeave={() => setHover(null)}
+          aria-label="Spectrum analyzer — live signal power across frequency. Hover to read the frequency and signal level, click to tune the SDR to that frequency"
+        />
+        <canvas
           ref={canvasRef}
           width={FFT_BINS}
           height={HISTORY_ROWS}
@@ -237,11 +262,13 @@ export function Spectrum() {
       </div>
 
       <div className="text-[11px] text-muted">
-        {DB_FLOOR} dBFS (cold) → {DB_CEIL} dBFS (hot). New frames render at
-        the top; the canvas scrolls down as history accumulates. Hover the
-        waterfall to read the frequency and signal level under the cursor;
-        click anywhere to retune the SDR to that frequency. Bookmark markers
-        ({bookmarkList.length} visible) appear as cyan ticks along the top.
+        Top: live signal power vs frequency ({DB_FLOOR} to {DB_CEIL} dBFS,
+        grid every 20 dB). Bottom: waterfall history — {DB_FLOOR} dBFS (cold)
+        → {DB_CEIL} dBFS (hot); new frames render at the top and scroll down.
+        Hover either view to read the frequency and signal level under the
+        cursor; click anywhere to retune the SDR to that frequency. Bookmark
+        markers ({bookmarkList.length} visible) appear as cyan ticks along the
+        top of the waterfall.
       </div>
     </div>
   );
@@ -279,6 +306,78 @@ function ConnPill({ state }: { state: ConnState }) {
   if (state === "connecting")
     return <span className="pill-warn">connecting</span>;
   return <span className="pill-err">offline</span>;
+}
+
+// dbToY maps a dBFS magnitude to a canvas Y coordinate for the analyzer
+// line plot: DB_CEIL (0 dBFS, strongest) sits at the top (y=0), DB_FLOOR
+// (weakest) at the bottom (y=height). Out-of-range values clamp to the
+// edges. Same [-100, 0] dB span as the waterfall colormap so the two
+// views read consistently.
+function dbToY(db: number, height: number): number {
+  let t = (db - DB_FLOOR) / (DB_CEIL - DB_FLOOR);
+  if (t < 0) t = 0;
+  else if (t > 1) t = 1;
+  return (1 - t) * height;
+}
+
+// renderAnalyzer draws the live power-vs-frequency trace (the "spectrum
+// analyzer" curve, like SDR#'s top panel) for the most recent frame.
+// Horizontal grid lines mark every 20 dB across the [-100, 0] dBFS span;
+// the trace is the frame's dBFS bins resampled to the canvas width with
+// the same nearest-neighbor mapping the waterfall uses, so a peak here
+// lines up vertically with its streak in the waterfall below. A null
+// frame blanks the plot (device change / no data yet).
+function renderAnalyzer(
+  canvas: HTMLCanvasElement | null,
+  frame: SpectrumFrame | null,
+) {
+  if (!canvas) return;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return;
+  const width = canvas.width;
+  const height = canvas.height;
+
+  ctx.fillStyle = "#000";
+  ctx.fillRect(0, 0, width, height);
+
+  // Horizontal dB grid every 20 dB.
+  ctx.strokeStyle = "rgba(255, 255, 255, 0.08)";
+  ctx.lineWidth = 1;
+  for (let db = DB_CEIL; db >= DB_FLOOR; db -= 20) {
+    const y = Math.round(dbToY(db, height)) + 0.5;
+    ctx.beginPath();
+    ctx.moveTo(0, y);
+    ctx.lineTo(width, y);
+    ctx.stroke();
+  }
+
+  const bins = frame?.bins;
+  if (!bins || bins.length === 0) return;
+
+  // Trace path (reused for the fill and the stroke).
+  const trace = () => {
+    ctx.beginPath();
+    for (let x = 0; x < width; x++) {
+      const srcIdx = Math.floor((x * bins.length) / width);
+      const y = dbToY(bins[srcIdx], height);
+      if (x === 0) ctx.moveTo(x, y);
+      else ctx.lineTo(x, y);
+    }
+  };
+
+  // Subtle fill under the curve.
+  trace();
+  ctx.lineTo(width, height);
+  ctx.lineTo(0, height);
+  ctx.closePath();
+  ctx.fillStyle = "rgba(52, 211, 153, 0.12)";
+  ctx.fill();
+
+  // Trace stroke on top.
+  trace();
+  ctx.strokeStyle = "#34d399";
+  ctx.lineWidth = 2;
+  ctx.stroke();
 }
 
 // renderWaterfall draws the current history onto the canvas. Newest row


### PR DESCRIPTION
## What

Adds a live power-vs-frequency trace — the "spectrum analyzer" curve, like SDR#'s top panel — above the existing waterfall in the web Spectrum panel.

## Why

Operator request (Discord): the waterfall alone makes it hard to judge instantaneous signal level across the band the way SDR# / SDRTrunk do with their top-of-window analyzer trace. This adds the equivalent frequency-domain view.

## How

- A new `<canvas>` rendering the latest frame's dBFS bins as a line trace, placed directly above the waterfall in the same bordered container.
- `renderAnalyzer()` draws a 20 dB horizontal grid, a subtle fill under the curve, and the trace stroke. New `dbToY()` shares the same `[-100, 0]` dBFS scale as the waterfall colormap.
- Reuses the **same** `SpectrumFrame` WebSocket stream and the FFT-shifted bin→x mapping, so a peak in the analyzer lines up vertically with its streak in the waterfall below.
- Hover readout and click-to-tune now work on **either** view: the canvas handlers key off `e.currentTarget` instead of a single ref and share the existing `xRatioToHz` mapping.
- A null frame (device change) blanks the plot.

No backend changes — the existing `/api/v1/spectrum/stream` frames already carry everything needed. No new dependencies (raw canvas, matching the existing waterfall style).

## Testing

- `npm run typecheck` clean; `npm run build` produces the SPA bundle.
- Updated the existing hover test to target the waterfall label specifically (the analyzer shares the "hover to read the frequency" phrasing) and added a test asserting the analyzer renders and reads out on hover.
- Full frontend suite green: **186/186**.

> Note: `web/dist` is gitignored and built by CI (`make web-build`), so only the two source files are in this PR.

https://claude.ai/code/session_01Cinu7cykdxMCpJmP93jL8A

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cinu7cykdxMCpJmP93jL8A)_