### PR TITLE
voice/mbe: cap per-frame AGC gain at the limiter knee to kill onset clipping

### DIFF
--- a/internal/voice/mbe/agc.go
+++ b/internal/voice/mbe/agc.go
@@ -85,7 +85,13 @@ type AGCConfig struct {
 
 	// MaxGain bounds the highest gain the AGC can apply, preventing
 	// silence from being amplified to full scale by a stale low
-	// envelope. Default 1e5.
+	// envelope. Default 1e5. NOTE: this is a coarse bound only — a
+	// genuinely quiet (but valid) synthesised frame can have a peak of a
+	// few units and legitimately needs a gain of several thousand to reach
+	// TargetPeak, so this cap cannot be tightened much without starving
+	// quiet speech. The per-frame output ceiling in Apply (not MaxGain) is
+	// what stops a stale low envelope from over-amplifying a *louder*
+	// following frame into the limiter.
 	MaxGain float64
 
 	// NoiseFloor is the per-frame peak threshold below which the
@@ -246,13 +252,16 @@ func (a *AGC) LastClipSamples() int { return a.lastClipSamples }
 // count) is accumulated for the VoiceStats summary.
 func (a *AGC) Apply(pcm []float64, out []int16, freezeEnvelope bool) {
 	cfg := a.cfg
-	if !freezeEnvelope {
-		var peak float64
-		for _, v := range pcm {
-			if abs := math.Abs(v); abs > peak {
-				peak = abs
-			}
+	// The per-frame peak is needed in both modes: to update the envelope
+	// (non-frozen) and to cap the gain so a frozen frame can't be amplified
+	// past the limiter by a stale envelope (the ceiling below).
+	var peak float64
+	for _, v := range pcm {
+		if abs := math.Abs(v); abs > peak {
+			peak = abs
 		}
+	}
+	if !freezeEnvelope {
 		if a.env == 0 && peak > cfg.NoiseFloor {
 			// First-frame seed: skip attack smoothing so the first
 			// frame lands at exactly TargetPeak instead of 1/Attack× over.
@@ -274,6 +283,23 @@ func (a *AGC) Apply(pcm []float64, out []int16, freezeEnvelope bool) {
 		gain = cfg.MinGain
 	} else if gain > cfg.MaxGain {
 		gain = cfg.MaxGain
+	}
+	// Per-frame output ceiling: never amplify THIS frame's own peak past the
+	// soft-limiter knee, regardless of how stale or low the smoothed envelope
+	// is. Without it, a near-silent onset frame seeds/holds a tiny envelope and
+	// the next louder frame — or a frozen bad-frame replay / idle-mute that
+	// reuses the held gain (Apply with freezeEnvelope=true does not update the
+	// envelope) — is multiplied by a gain up to MaxGain, slamming every sample
+	// into the limiter. Field captures showed mean_gain≈1e5, peak_preclip≈8e7,
+	// clip_pct≈65% on short call onsets from exactly this. The ceiling only
+	// engages when the AGC would otherwise push the output past the knee, so
+	// ordinary frames (output ≈ TargetPeak, well under the knee) and the
+	// inter-frame dynamics the fast-attack/slow-release loop produces are
+	// unchanged — it is a one-sided clamp that can only reduce clipping.
+	if peak > 0 {
+		if ceil := softLimitKnee / peak; gain > ceil {
+			gain = ceil
+		}
 	}
 	a.lastGain = gain
 	a.lastMaxPreClip = 0

--- a/internal/voice/mbe/agc_test.go
+++ b/internal/voice/mbe/agc_test.go
@@ -79,6 +79,45 @@ func TestAGCNeverHardClips(t *testing.T) {
 	}
 }
 
+// TestAGCFrozenFrameGainBounded reproduces the field gain-runaway: a
+// near-silent onset frame seeds a tiny envelope, then a loud frame arrives on
+// a FROZEN path (bad-frame replay / idle-mute / silence — Apply with
+// freezeEnvelope=true does not update the envelope). Before the per-frame
+// output ceiling, the stale-tiny envelope produced a gain near MaxGain and the
+// loud frame's output blew far past the int16 rail (mean_gain≈1e5,
+// peak_preclip≈8e7, clip_pct≈65% in the captures). The ceiling must keep the
+// frozen frame inside the limiter.
+func TestAGCFrozenFrameGainBounded(t *testing.T) {
+	a := NewAGC(DefaultAGCConfig())
+	pcm := make([]float64, SamplesPerFrame)
+	out := make([]int16, SamplesPerFrame)
+	// 1. Near-silent onset frame seeds the envelope very low (peak ≈ 0.5).
+	for i := range pcm {
+		pcm[i] = 0.5 * math.Sin(float64(i))
+	}
+	a.Apply(pcm, out, false)
+	// 2. A loud frame on a frozen path: envelope is NOT updated, so the gain is
+	//    computed from the stale tiny envelope.
+	for i := range pcm {
+		pcm[i] = 8000 * math.Sin(float64(i))
+	}
+	a.Apply(pcm, out, true)
+	// The per-frame ceiling caps gain at softLimitKnee/peak, so the loud
+	// frame's output peaks at the knee — never the rail — and almost no
+	// samples engage the limiter.
+	for _, s := range out {
+		if s == 32767 || s == -32768 {
+			t.Fatalf("frozen loud frame hit the int16 rail (%d) — AGC gain ran away on a stale envelope", s)
+		}
+	}
+	if g := a.LastGain(); g*8000 > softLimitRail {
+		t.Errorf("frozen-frame gain %.1f × peak 8000 = %.0f exceeds the rail %v — per-frame ceiling not applied", g, g*8000, softLimitRail)
+	}
+	if clipFrac := float64(a.LastClipSamples()) / float64(len(out)); clipFrac > 0.05 {
+		t.Errorf("frozen loud frame clip fraction = %.2f, want <= 0.05 (gain runaway into the limiter)", clipFrac)
+	}
+}
+
 // TestAGCAttenuatesLoudFrames confirms the AGC can apply gain < 1 to a
 // frame already louder than TargetPeak — impossible under the old
 // MinGain=10 floor, which forced amplification and clipping.


### PR DESCRIPTION
The IMBE/AMBE AGC computed gain = TargetPeak/envelope, bounded only by
MaxGain (1e5). When a call opened with a near-silent frame the envelope
seeded/held very low, and the next louder frame — or a frozen bad-frame
replay / idle-mute that reuses the held gain (Apply with
freezeEnvelope=true does not update the envelope) — was multiplied by a
gain up to 1e5, slamming every sample into the soft limiter. Field
captures showed mean_gain≈60000, peak_preclip≈8e7 and clip_pct≈65% on
short call onsets, audible as distorted bursts (one recorded talkgroup
WAV clipped 25.8% of its samples; the live WebUI stream carried the same
artifact).

Add a per-frame output ceiling in AGC.Apply: never amplify the frame's
own peak past the soft-limiter knee. It is a one-sided, content-aware
clamp that engages only when the AGC would otherwise push output past the
knee, so ordinary frames (output ≈ TargetPeak, well under the knee) and
the fast-attack/slow-release dynamics are unchanged — it can only reduce
clipping. The frame peak is now computed in both the frozen and
non-frozen paths so the ceiling applies to replays too.

MaxGain stays at 1e5: a genuinely quiet but valid synthesised frame can
have a peak of a few units and legitimately needs a gain of several
thousand to reach TargetPeak, so the cap cannot be tightened without
starving quiet speech (the AGC-convergence tests pin this).

TestAGCFrozenFrameGainBounded reproduces the runaway (a near-silent seed
frame then a loud frozen frame) and asserts the output stays inside the
limiter; it fails without the ceiling.

https://claude.ai/code/session_01W3rfmNjGqUS7PkaK2v739k