### PR TITLE
DMR: decode real control channels (AGC, CSBK CRC mask, Aloha opcode, Tier II lock)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ for tagged releases.
 
 ## [Unreleased]
 
+### Fixed
+
+- **DMR now decodes real over-the-air control channels.** The DMR receiver
+  previously decoded only the zero-offset, level-matched synthesized fixtures;
+  on a real SDR capture every BPTC(196,96) payload came back uncorrectable, so
+  Tier III never locked ("dmr/tier3: BPTC uncorrectable") and Tier II reported a
+  bogus instant lock then nothing. Root cause: the unit-energy RRC matched
+  filter has a DC gain of ~3.1, so the 4-level symbol centres landed far above
+  the slicer's fixed thresholds and the inner symbols collapsed onto the outer
+  rails. A symbol-AGC now normalises the matched-filter level to the slicer's
+  scale (the same calibration the P25 Phase 1 receiver runs, #275), so a real
+  Tier III TSCC decodes cleanly and locks end-to-end through the wideband
+  channelizer.
+- **DMR CSBK CRC was rejecting every real burst.** The CSBK CRC-16 used the
+  wrong convention (init 0xFFFF, stored as the bitwise complement), which only
+  validated the synthesized round-trip fixtures. Real ETSI Tier III CSBKs use
+  CRC-CCITT (init 0x0000) XORed with the mask `0x5A5A` (TS 102 361-1 §B.3.11);
+  cleanly-decoded off-air Aloha and Preamble bursts now pass and are pinned by a
+  regression fixture.
+- **DMR Tier III C_ALOHA opcode corrected** from `0x04` to `0x19` (the value
+  real TSCC beacons carry), so the control channel locks on the Aloha CSBK.
+- **DMR Tier II "instalock".** Tier II declared `cc.locked` on any slot-type
+  Hamming decode, so a false sync match on noise forged an instant lock (often
+  `cc=15`) that then produced nothing. The lock is now gated on a FEC-validated
+  Voice LC Header (BPTC + RS both pass), mirroring Tier III's lock-after-CRC
+  discipline.
+- **`iq-capture` now warns on dropped chunks.** A non-zero `drops` count means
+  the capture writer fell behind the IQ stream (subscriber buffer full) — not an
+  SDR overflow — leaving time gaps that corrupt downstream decode. The finish
+  log now emits a `WARN` explaining the cause and the remedy (faster storage,
+  lower sample rate, fewer concurrent sinks) instead of only printing the count.
+
 ## [v0.3.9] — 2026-06-11
 
 This release is about **live audio you can actually hear** and a friendlier

--- a/cmd/gophertrunk/iqcapture.go
+++ b/cmd/gophertrunk/iqcapture.go
@@ -166,6 +166,22 @@ func finishIQCapture(log *slog.Logger, spec iqCaptureSpec, f io.Closer, samples 
 		return runErr
 	}
 	log.Info("iq-capture: finished", args...)
+	if drops > 0 {
+		// drops is the count of IQ chunks the capture subscriber dropped
+		// because its buffer was full — i.e. the writer fell behind the
+		// stream, NOT an SDR overflow. Each dropped chunk is a time gap
+		// of missing samples in the .cfile, which breaks symbol timing
+		// for any downstream decode (the DMR/P25 sync + clock loops
+		// assume a continuous stream). Surface it loudly with the
+		// remedy so a non-zero drop count is actionable rather than a
+		// silent corrupt capture. The per-device SDR-overflow counter is
+		// separate (Prometheus sdr_iq_underruns_total) — if that is also
+		// climbing the bottleneck is upstream of the writer.
+		log.Warn("iq-capture: dropped IQ chunks — the capture has time gaps that corrupt downstream decode",
+			"drops", drops, "path", spec.Path,
+			"cause", "capture writer fell behind the IQ stream (subscriber buffer full), not an SDR overflow",
+			"remedy", "write to faster storage, lower sdr.sample_rate, or reduce concurrent IQ sinks; check Prometheus sdr_iq_underruns_total to rule out an SDR overrun")
+	}
 	if closeErr != nil && !errors.Is(closeErr, os.ErrClosed) {
 		return closeErr
 	}

--- a/internal/radio/dmr/receiver/agc_test.go
+++ b/internal/radio/dmr/receiver/agc_test.go
@@ -1,0 +1,63 @@
+package receiver
+
+import (
+	"math"
+	"testing"
+)
+
+// TestC4FMSymbolAGCNormalisesLevel pins the symbol-AGC that lets the
+// receiver decode real captures: the RRC matched filter is unit-energy
+// (DC gain ~3.1), so on a real FM-discriminator stream the 4-level
+// symbol centres land well above the slicer's fixed thresholds and the
+// inner symbols collapse onto the outer rails. The AGC must pull the
+// running mean|x| back to its target (slicerScale·2/3) regardless of the
+// absolute input level, while preserving the relative 4-level structure
+// the slicer decides on.
+func TestC4FMSymbolAGCNormalisesLevel(t *testing.T) {
+	const target = 0.17
+	a := c4fmSymbolAGC{target: target, rate: 1.0 / 256.0}
+
+	// A balanced 4-level stream at ~3.1× the level the slicer expects —
+	// the over-scale a real matched-filter output carries.
+	const scale = 3.1
+	levels := []float32{scale * target, scale * target / 3, -scale * target / 3, -scale * target}
+	buf := make([]float32, 4096)
+	for i := range buf {
+		buf[i] = levels[i%4]
+	}
+	a.process(buf)
+
+	// After the EMA settles, mean|x| over the tail should track target.
+	var sum float64
+	tail := buf[len(buf)-1024:]
+	for _, x := range tail {
+		sum += math.Abs(float64(x))
+	}
+	got := sum / float64(len(tail))
+	// The AGC drives the running mean|x| of its output to target, so the
+	// settled tail mean|x| should be ≈ target regardless of input scale.
+	if math.Abs(got-target) > 0.02*target {
+		t.Errorf("settled mean|x| = %.4f, want ≈ %.4f (AGC not normalising)", got, target)
+	}
+
+	// Relative structure preserved: outer/inner magnitude ratio stays 3:1.
+	outer := math.Abs(float64(tail[0]))
+	inner := math.Abs(float64(tail[1]))
+	if r := outer / inner; math.Abs(r-3.0) > 0.05 {
+		t.Errorf("outer/inner ratio = %.3f, want ≈ 3.0 (AGC distorted the eye)", r)
+	}
+}
+
+// TestC4FMSymbolAGCDisabled confirms the legacy pre-scaled-fixture path
+// (target<=0) is a no-op so existing fixtures stay byte-identical.
+func TestC4FMSymbolAGCDisabled(t *testing.T) {
+	a := c4fmSymbolAGC{target: 0}
+	buf := []float32{0.5, -0.3, 1.2, -0.9}
+	want := append([]float32(nil), buf...)
+	a.process(buf)
+	for i := range buf {
+		if buf[i] != want[i] {
+			t.Errorf("buf[%d] = %v, want %v (disabled AGC must be a no-op)", i, buf[i], want[i])
+		}
+	}
+}

--- a/internal/radio/dmr/receiver/receiver.go
+++ b/internal/radio/dmr/receiver/receiver.go
@@ -5,10 +5,26 @@
 //
 //	IQ samples
 //	  → FM discriminator (internal/dsp/demod.FM)
-//	  → RRC matched filter + 4-level slicer (internal/dsp/demod.C4FM)
+//	  → RRC matched filter (internal/dsp/demod.C4FM)
+//	  → symbol AGC: level normalisation (c4fmSymbolAGC, local)
+//	  → 4-level slicer (internal/dsp/demod.C4FM)
 //	  → Mueller-Müller symbol clock recovery (internal/dsp/sync.MuellerMuller)
 //	  → 4-level symbol → 0..3 dibit (SymbolToDibit, local)
 //	  → dmr.DibitSink (cross-call indexed by absolute dibit position)
+//
+// The symbol-AGC stage is what lets the receiver decode a real SDR
+// capture rather than only the zero-offset, level-matched synthesized
+// fixtures. The RRC matched filter is normalised to unit *energy*, so it
+// has a DC gain of ~3.1: on a real FM-discriminator stream the matched
+// filter leaves the 4-level symbol centres well above the slicer's fixed
+// thresholds, the slicer collapses the inner (±1) symbols onto the outer
+// (±3) rails, and every BPTC(196,96) payload comes back uncorrectable
+// while the more forgiving sync + slot-type FEC still pass — exactly the
+// "Tier III BPTC uncorrectable / Tier II instalock then nothing" field
+// failure. The AGC renormalises the running mean|x| to the level a
+// balanced 4-level stream should sit at so the slicer decides correctly,
+// mirroring the same calibration the P25 Phase 1 C4FM receiver runs
+// (internal/radio/p25/phase1/receiver, issue #275).
 //
 // DMR runs the same 4800-baud 4-level C4FM modulation as P25 Phase 1
 // and YSF, so the matched-filter parameters (RRC α = 0.20, 4800
@@ -82,6 +98,7 @@ type Receiver struct {
 	fm        *demod.FM
 	mf        *demod.C4FM
 	clock     *sync.MuellerMuller
+	agc       c4fmSymbolAGC
 	dibitSink dmr.DibitSink
 	dibitBase int
 
@@ -129,11 +146,37 @@ func New(opts Options) *Receiver {
 	}
 
 	return &Receiver{
-		fm:        demod.NewFM(),
-		mf:        demod.NewC4FM(int(sps+0.5), span, alpha, slicerScale),
-		clock:     sync.NewMuellerMuller(sps, gain),
+		fm:    demod.NewFM(),
+		mf:    demod.NewC4FM(int(sps+0.5), span, alpha, slicerScale),
+		clock: sync.NewMuellerMuller(sps, gain),
+		// Symbol-AGC bridges the level mismatch between the unit-energy
+		// RRC matched filter and the 4-level slicer's fixed thresholds.
+		// The RRC has a DC gain of ~3.1 (it is normalised to unit
+		// energy, not unit DC), so on a real signal the matched-filter
+		// symbol centres land well above slicerScale and the fixed
+		// slicer collapses inner symbols onto the outer rails — every
+		// BPTC payload then comes back uncorrectable. The AGC normalises
+		// the running mean|x| to the level a balanced 4-level stream
+		// should sit at (slicerScale·2/3), so the slicer decides
+		// correctly regardless of the absolute matched-filter level.
+		// Same calibration the P25 Phase 1 C4FM receiver runs (issue
+		// #275). Disabled on the legacy DeviationHz<=0 path (slicerScale
+		// == 1.0) so pre-scaled fixtures stay byte-identical.
+		agc: c4fmSymbolAGC{
+			target: float32(agcTargetFor(slicerScale, opts.DeviationHz)),
+			rate:   1.0 / 256.0,
+		},
 		dibitSink: opts.DibitSink,
 	}
+}
+
+// agcTargetFor returns the symbol-AGC target mean|x|, or 0 to disable
+// the AGC on the legacy pre-scaled-fixture path (DeviationHz unset).
+func agcTargetFor(slicerScale, deviationHz float64) float64 {
+	if deviationHz <= 0 {
+		return 0
+	}
+	return slicerScale * 2.0 / 3.0
 }
 
 // Process pushes one chunk of complex64 IQ samples through the chain.
@@ -149,6 +192,11 @@ func (r *Receiver) Process(iq []complex64) {
 	if len(r.symbols) == 0 {
 		return
 	}
+	// Normalise the symbol level to the slicer's expected scale before
+	// slicing, so the unit-energy matched filter's ~3.1× DC gain doesn't
+	// push the 4-level eye past the slicer's fixed thresholds (no-op on
+	// the legacy DeviationHz<=0 path where target==0). See package doc.
+	r.agc.process(r.symbols)
 	r.sliced = r.mf.SliceMany(r.sliced, r.symbols)
 	if cap(r.dibits) < len(r.sliced) {
 		r.dibits = make([]uint8, len(r.sliced))
@@ -167,6 +215,57 @@ func (r *Receiver) Process(iq []complex64) {
 // the DibitSink baseIdx restarts at 0.
 func (r *Receiver) Reset() {
 	r.dibitBase = 0
+	r.agc.reset()
+}
+
+// c4fmSymbolAGC tracks a running estimate of mean|x| over the
+// per-symbol matched-filter output and scales each symbol so the
+// estimate matches a target reference. The 4-level slicer's fixed
+// thresholds are designed against a specific signal level; the AGC
+// reconciles that with whatever level the upstream RRC matched filter
+// actually produces. Ported from the P25 Phase 1 C4FM receiver (issue
+// #275); the loop is feed-forward (each output is the input scaled by
+// the current estimate), so an occasional near-zero sample cannot drive
+// the gain unbounded the way a feedback loop would.
+type c4fmSymbolAGC struct {
+	target float32 // desired mean|x| in the output stream; <=0 disables
+	rate   float32 // single-pole EMA coefficient
+	level  float32 // current mean|x| estimate of the input
+	seeded bool
+}
+
+// process scales symbols in place so the running mean|x| matches target.
+// Seeds the EMA from the first non-trivial sample's |x| so the recovered
+// stream is independent of how the IQ is chunked. A no-op when target<=0
+// (the legacy pre-scaled-fixture path).
+func (a *c4fmSymbolAGC) process(symbols []float32) {
+	if a.target <= 0 {
+		return
+	}
+	for i, x := range symbols {
+		ax := x
+		if ax < 0 {
+			ax = -ax
+		}
+		if !a.seeded {
+			if ax > 1e-12 {
+				a.level = ax
+				a.seeded = true
+			} else {
+				continue
+			}
+		} else {
+			a.level += a.rate * (ax - a.level)
+		}
+		if a.level > 1e-12 {
+			symbols[i] = x * (a.target / a.level)
+		}
+	}
+}
+
+func (a *c4fmSymbolAGC) reset() {
+	a.level = 0
+	a.seeded = false
 }
 
 // SymbolToDibit maps a C4FM slicer output ({-3, -1, +1, +3}) to a

--- a/internal/radio/dmr/tier2/conventional.go
+++ b/internal/radio/dmr/tier2/conventional.go
@@ -27,8 +27,9 @@ import (
 // LockState is the payload of cc.locked / cc.lost events emitted by
 // the Tier II per-repeater state machine. DMR Tier II is conventional
 // (no dedicated control channel), so "locked" here means "we've
-// received at least one burst with a valid slot-type codeword on the
-// tuned frequency."
+// received at least one FEC-validated Voice LC Header (BPTC + RS pass)
+// on the tuned frequency" — proof of a real DMR transmission, not just
+// a slot-type codeword that a noise burst can forge.
 type LockState struct {
 	FrequencyHz uint32
 	ColorCode   uint8 // from the first valid slot-type decode
@@ -122,17 +123,18 @@ func New(opts Options) *ConventionalChannel {
 }
 
 // IngestBurst hands one DMR burst (with its already-decoded slot type)
-// to the state machine. Any burst with a valid slot-type codeword
-// triggers cc.locked the first time it arrives on a freshly-tuned
-// device. Bursts whose data type isn't a Voice LC Header or
-// Terminator-with-LC otherwise only update the lock state: voice
-// payload bursts (B-F) don't carry a fresh FLC, and CSBK bursts
-// belong to Tier III.
+// to the state machine. The lock is NOT declared here on the slot type
+// alone: the slot-type Hamming(20,8) corrects up to 3 bit errors, so a
+// noise burst whose 24-dibit sync false-matched (the detector runs at
+// tolerance 2 against 9 patterns) routinely yields a "valid" slot type
+// — typically with the minimum-distance color code 0xF — and the old
+// unconditional lock here produced the field-reported "instalock cc=15
+// then nothing". Instead the lock is gated on a FEC-validated Voice LC
+// Header inside handleVoiceHeader (BPTC + RS both pass), mirroring Tier
+// III's lock-only-after-CRC discipline. Voice payload bursts (B-F)
+// don't carry a fresh FLC and CSBK bursts belong to Tier III, so they
+// fall through untouched.
 func (c *ConventionalChannel) IngestBurst(b *dmr.Burst, slot dmr.SlotType) {
-	c.maybeLock(LockState{
-		FrequencyHz: c.freqHz,
-		ColorCode:   slot.ColorCode,
-	})
 	switch slot.DataType {
 	case dmr.DTVoiceLCHeader:
 		c.handleVoiceHeader(b, slot)
@@ -222,6 +224,10 @@ func (c *ConventionalChannel) handleVoiceHeader(b *dmr.Burst, slot dmr.SlotType)
 		})
 		return
 	}
+	// BPTC + RS both passed: this is a genuine DMR transmission on the
+	// tuned frequency. Declare the lock here (not on the slot type alone)
+	// so a false sync / miscorrected slot type can't forge it.
+	c.maybeLock(LockState{FrequencyHz: c.freqHz, ColorCode: slot.ColorCode})
 	flc, err := dmr.ParseFLC(infoBytes)
 	if err != nil {
 		c.log.Debug("dmr/tier2: FLC parse failed", "err", err)

--- a/internal/radio/dmr/tier2/conventional_test.go
+++ b/internal/radio/dmr/tier2/conventional_test.go
@@ -260,25 +260,19 @@ func TestConventionalIgnoresNonHeaderBursts(t *testing.T) {
 	flc := dmr.FLC{FLCO: dmr.FLCOGroupVoiceUser, DstAddr: 0x42}
 	cc.IngestBurst(burstWithFLC(flc), dmr.SlotType{ColorCode: 1, DataType: dmr.DTCSBK})
 
-	// CSBK burst triggers cc.locked (any valid slot-type decode does)
-	// but should NOT trigger a grant — CSBK belongs to Tier III.
+	// A CSBK burst belongs to Tier III: Tier II must ignore it entirely
+	// — no grant, and (since the lock is gated on a FEC-validated Voice
+	// LC Header) no cc.locked either. Locking on a non-header slot-type
+	// alone is the false "instalock" this guards against.
 	timeout := time.After(50 * time.Millisecond)
-	var sawLock bool
 DrainCSBK:
 	for {
 		select {
 		case ev := <-sub.C:
-			if ev.Kind == events.KindCCLocked {
-				sawLock = true
-				continue
-			}
 			t.Errorf("unexpected event for CSBK burst: %s", ev.Kind)
 		case <-timeout:
 			break DrainCSBK
 		}
-	}
-	if !sawLock {
-		t.Errorf("expected cc.locked from valid CSBK burst, got none")
 	}
 }
 

--- a/internal/radio/dmr/tier3/csbk.go
+++ b/internal/radio/dmr/tier3/csbk.go
@@ -10,7 +10,8 @@
 //	bits 2-7  : CSBKO (Control Signaling Block Opcode, 6 bits)
 //	bits 8-15 : FID (Feature set ID; 0x00 = standard ETSI)
 //	bits 16-79: opcode-specific payload (64 bits, 8 octets)
-//	bits 80-95: CRC-16 (CCITT) of bits 0-79; transmitted bitwise-NOT.
+//	bits 80-95: CRC-16 (CCITT) of bits 0-79, XORed with the CSBK CRC
+//	            mask 0x5A5A (ETSI TS 102 361-1 §B.3.11, Table B.21).
 package tier3
 
 import (
@@ -28,7 +29,7 @@ const (
 	// Standard FID (0x00) opcodes — ETSI TS 102 361-4 §7. Only the most
 	// common opcodes are listed; vendor extensions live behind FID != 0.
 	OpUnknown   CSBKOpcode = 0x00
-	OpAloha     CSBKOpcode = 0x04 // ALOHA
+	OpAloha     CSBKOpcode = 0x19 // C_ALOHA — periodic TSCC beacon (ETSI TS 102 361-4 §7.2.1)
 	OpRAND      CSBKOpcode = 0x06 // Random access service request
 	OpAckResp   CSBKOpcode = 0x16 // ACK response
 	OpAhoy      CSBKOpcode = 0x18 // AHOY
@@ -88,6 +89,15 @@ type CSBK struct {
 // callers can log diagnostics.
 var CRCError = errors.New("dmr/tier3: CSBK CRC mismatch")
 
+// csbkCRCMask is the XOR mask applied to the 16-bit CRC-CCITT (poly
+// 0x1021, init 0x0000) of a CSBK's leading 80 bits before transmission
+// — ETSI TS 102 361-1 §B.3.11 / Table B.21. Verified against real
+// off-air ETSI Tier III control-channel CSBKs (Aloha + Preamble bursts
+// that decode cleanly through BPTC); the earlier "init 0xFFFF, store
+// the bitwise complement" convention rejected every real CSBK while
+// only passing the synthesized round-trip fixtures.
+const csbkCRCMask uint16 = 0x5A5A
+
 // ParseCSBK consumes 96 information bits (12 bytes, MSB-first) and returns
 // a parsed CSBK. The 16-bit trailer is the bitwise complement of the
 // CRC-CCITT of the leading 10 bytes; CRCError is returned on mismatch.
@@ -102,8 +112,8 @@ func ParseCSBK(info []byte) (CSBK, error) {
 	c.FID = info[1]
 	copy(c.Payload[:], info[2:10])
 
-	storedCRC := binary.BigEndian.Uint16(info[10:12]) ^ 0xFFFF
-	want := framing.CRCCCITT(info[:10])
+	storedCRC := binary.BigEndian.Uint16(info[10:12])
+	want := framing.CRCCCITTWithInit(info[:10], 0x0000) ^ csbkCRCMask
 	if storedCRC != want {
 		return c, CRCError
 	}
@@ -123,7 +133,7 @@ func AssembleCSBK(c CSBK) []byte {
 	out[0] |= byte(c.Opcode) & 0x3F
 	out[1] = c.FID
 	copy(out[2:10], c.Payload[:])
-	crc := framing.CRCCCITT(out[:10]) ^ 0xFFFF
+	crc := framing.CRCCCITTWithInit(out[:10], 0x0000) ^ csbkCRCMask
 	binary.BigEndian.PutUint16(out[10:12], crc)
 	return out
 }

--- a/internal/radio/dmr/tier3/csbk_realvectors_test.go
+++ b/internal/radio/dmr/tier3/csbk_realvectors_test.go
@@ -1,0 +1,54 @@
+package tier3
+
+import "testing"
+
+// TestParseCSBKRealOffAirVectors pins the CSBK CRC convention (CRC-CCITT
+// poly 0x1021, init 0x0000, XOR-out mask 0x5A5A) and the C_ALOHA opcode
+// against real off-air ETSI Tier III control-channel bursts.
+//
+// These 12-byte info blocks were recovered from a 2 MS/s SDR capture of
+// a live DMR Tier III TSCC (440.5625 MHz): they decode cleanly through
+// BPTC(196,96) — zero corrections — and repeat identically across the
+// capture, so they are genuine CSBKs, not noise. Under the previous
+// "init 0xFFFF, store the bitwise complement" convention every one of
+// them failed CRC (the control channel never locked); they validate
+// under the 0x5A5A mask. Keeping them here as a fixture means a future
+// regression of the CRC mask or the Aloha opcode trips this test offline
+// without needing the RF capture.
+func TestParseCSBKRealOffAirVectors(t *testing.T) {
+	cases := []struct {
+		name   string
+		bytes  []byte
+		opcode CSBKOpcode
+	}{
+		{
+			// C_ALOHA — the periodic TSCC beacon the CC state machine
+			// locks on.
+			name:   "aloha",
+			bytes:  []byte{0x99, 0x00, 0x49, 0x01, 0x16, 0x40, 0x03, 0x00, 0x00, 0x00, 0x05, 0x9f},
+			opcode: OpAloha,
+		},
+		{
+			// Preamble CSBK — announces following content; already had
+			// the correct opcode value, included so the fixture covers
+			// both repeating bursts in the capture.
+			name:   "preamble",
+			bytes:  []byte{0xa8, 0x00, 0x08, 0x7b, 0xd6, 0x40, 0x03, 0x06, 0x00, 0x60, 0x61, 0x5b},
+			opcode: OpPreamble,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			csbk, err := ParseCSBK(tc.bytes)
+			if err != nil {
+				t.Fatalf("ParseCSBK rejected a real off-air %s CSBK: %v (CRC mask regressed?)", tc.name, err)
+			}
+			if csbk.Opcode != tc.opcode {
+				t.Errorf("opcode = %#02x (%s), want %#02x", uint8(csbk.Opcode), csbk.Opcode, uint8(tc.opcode))
+			}
+			if csbk.FID != 0x00 {
+				t.Errorf("FID = %#02x, want 0x00 (standard ETSI)", csbk.FID)
+			}
+		})
+	}
+}


### PR DESCRIPTION
A field DMR capture exposed that the receiver only ever decoded the
synthesized fixtures: on a real SDR signal Tier III logged endless
"BPTC uncorrectable" and never locked, while forcing Tier II produced a
bogus instant lock (cc=15) then nothing. Replaying the capture through
the production pipeline isolated each stage:

- Front end: the unit-energy RRC matched filter has a DC gain of ~3.1,
  so the 4-level symbol centres landed far above the slicer's fixed
  thresholds and inner symbols collapsed onto the outer rails — every
  196-bit BPTC payload then failed while the more forgiving sync and
  slot-type FEC still passed. Add a symbol-AGC that normalises the
  matched-filter level to the slicer scale (the same calibration the
  P25 Phase 1 C4FM receiver runs). With it the real TSCC decodes
  cleanly and locks end-to-end through the wideband channelizer.

- CSBK CRC: the 16-bit CRC used init 0xFFFF stored as the bitwise
  complement, which only validated the round-trip fixtures. Real ETSI
  Tier III CSBKs use CRC-CCITT (init 0x0000) XORed with mask 0x5A5A.
  Verified against clean off-air Aloha + Preamble bursts and pinned by
  a regression fixture.

- C_ALOHA opcode was 0x04; real TSCC beacons carry 0x19, so the control
  channel never locked even once CRC passed. Corrected.

- Tier II "instalock": cc.locked fired on any slot-type Hamming decode,
  so a false sync match on noise forged an instant lock. Gate the lock
  on a FEC-validated Voice LC Header (BPTC + RS), mirroring Tier III.

- iq-capture: a non-zero drops count is a subscriber-side writer
  bottleneck (time gaps that corrupt decode), not an SDR overflow.
  Emit a WARN with the cause and remedy instead of only the count.

Tests: add c4fmSymbolAGC unit tests and a real-off-air CSBK CRC/opcode
fixture; update the Tier II test that encoded the old instalock.

https://claude.ai/code/session_016yRmryscckHBqe9atJYzYW