### PR TITLE
Add Mixer plot (Raw + Tuned baseband FFT) to the Plots hub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ for tagged releases.
 
 ## [Unreleased]
 
+### Added
+
+- **Mixer plot — the last of OP25's Plots tabs.** A new **Mixer** plot
+  (web `/plots/mixer`) renders the channel-baseband power spectrum two
+  ways, completing parity with OP25's six Plots tabs (Spectrum,
+  Constellation, Symbol, Datascope/Eye, Raw Mixer, Tuned Mixer).
+  **Raw mixer** shows the channelized baseband as the receiver first sees
+  it, with an amber marker on the carrier-offset estimate; **Tuned mixer**
+  re-mixes that same window by the estimate so a locked loop pulls the
+  carrier onto the centre line. Comparing the two shows the
+  carrier-recovery correction at a glance. It runs the same parallel P25
+  receiver the other scopes use (`WS /api/v1/diag/mixer`), reuses the
+  wideband Spectrum FFT helper, and needs no new receiver tap — the tuned
+  view is reconstructed from the loop's own `carrier_offset_hz`, so it
+  works for both C4FM and CQPSK. See [docs/mixer.md](docs/mixer.md).
+
 ### Fixed
 
 - **DMR now decodes real over-the-air control channels.** The DMR receiver

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -1911,6 +1911,7 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 			opts.Spectrum = newSpectrumProvider(d.pool, d.iqBrokers, d.systems, log)
 			opts.Diag = newDiagProvider(d.pool, d.iqBrokers, cfg.SDR.SampleRate, log)
 			opts.Symbols = newSymbolProvider(d.pool, d.iqBrokers, cfg.SDR.SampleRate, log)
+			opts.Mixer = newMixerProvider(d.pool, d.iqBrokers, cfg.SDR.SampleRate, log)
 			opts.Capture = newCaptureProvider(d.pool, d.iqBrokers, log)
 		}
 		if d.bookmarks != nil {

--- a/cmd/gophertrunk/mixer_provider.go
+++ b/cmd/gophertrunk/mixer_provider.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/MattCheramie/GopherTrunk/internal/api"
+	"github.com/MattCheramie/GopherTrunk/internal/scanner/symbolscope"
+	"github.com/MattCheramie/GopherTrunk/internal/sdr"
+	"github.com/MattCheramie/GopherTrunk/internal/sdr/iqtap"
+)
+
+// mixerProvider implements api.MixerProvider on top of the daemon's iqtap
+// broker map. Each OpenMixerStream call attaches a fresh subscriber to
+// the requested device's broker and runs a per-request symbolscope.Engine
+// with the Mixer FFT taps enabled (DDC → receiver → raw/tuned spectra),
+// piping the spectrum frames out for the API's WS handler to drain.
+//
+// One engine per WS subscriber — the same trade-off symbolProvider makes.
+// The Mixer FFTs add a bounded, rate-limited cost on top of the receiver
+// the engine already runs; for the single-operator GopherTrunk audience
+// this is acceptable, and the broker fan-out never back-pressures the
+// production control-channel decode.
+type mixerProvider struct {
+	pool       *sdr.Pool
+	brokers    map[string]*iqtap.Broker
+	sampleRate uint32
+	log        *slog.Logger
+}
+
+func newMixerProvider(pool *sdr.Pool, brokers map[string]*iqtap.Broker, sampleRate uint32, log *slog.Logger) *mixerProvider {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &mixerProvider{pool: pool, brokers: brokers, sampleRate: sampleRate, log: log}
+}
+
+// OpenMixerStream is api.MixerProvider's only method. It builds a
+// symbolscope.Engine with MixerEmit set over the broker subscription and
+// runs it on a goroutine.
+func (p *mixerProvider) OpenMixerStream(ctx context.Context, serial, proto string, offsetHz int32) (<-chan api.MixerFrame, func(), error) {
+	if p == nil {
+		return nil, nil, errors.New("mixer: provider not wired")
+	}
+	br, ok := p.brokers[serial]
+	if !ok {
+		return nil, nil, fmt.Errorf("mixer: serial %q is not a known SDR", serial)
+	}
+	protocol, demod, err := symbolProtoToReceiver(proto)
+	if err != nil {
+		return nil, nil, err
+	}
+	inputRate := br.SampleRateHz()
+	if inputRate == 0 {
+		inputRate = p.sampleRate
+	}
+	if inputRate == 0 {
+		return nil, nil, errors.New("mixer: cannot determine input sample rate")
+	}
+	// Clamp the requested view offset to the device's Nyquist; a mix
+	// beyond +/- Fs/2 just aliases back into the band.
+	half := int32(inputRate / 2)
+	if offsetHz > half {
+		offsetHz = half
+	} else if offsetHz < -half {
+		offsetHz = -half
+	}
+
+	wireOut := make(chan api.MixerFrame, 8)
+	streamCtx, cancel := context.WithCancel(ctx)
+
+	eng, err := symbolscope.New(symbolscope.Options{
+		Protocol:  protocol,
+		DemodMode: demod,
+		InRateHz:  float64(inputRate),
+		OffsetHz:  offsetHz,
+		CenterHz:  br.CenterHz(),
+		// Symbol Emit is required by the engine; it batches dibits but we
+		// don't forward them on this stream — the Mixer plot only needs the
+		// FFT taps below.
+		Emit: func(symbolscope.Frame) {},
+		MixerEmit: func(f symbolscope.MixerFrame) {
+			wire := api.MixerFrame{
+				TimestampNs:     f.TimestampNs,
+				CenterHz:        f.CenterHz,
+				SampleRateHz:    f.SampleRateHz,
+				OffsetHz:        f.OffsetHz,
+				CarrierOffsetHz: f.CarrierOffsetHz,
+				RawBins:         f.RawBins,
+				TunedBins:       f.TunedBins,
+			}
+			// Non-blocking: drop on a wedged WS client rather than stalling
+			// the broker drain goroutine.
+			select {
+			case wireOut <- wire:
+			case <-streamCtx.Done():
+			default:
+			}
+		},
+	})
+	if err != nil {
+		cancel()
+		return nil, nil, fmt.Errorf("mixer: %w", err)
+	}
+
+	sub := br.Subscribe()
+
+	go func() {
+		defer close(wireOut)
+		defer eng.Close()
+		for {
+			select {
+			case <-streamCtx.Done():
+				return
+			case chunk, ok := <-sub.C:
+				if !ok {
+					return
+				}
+				eng.Process(chunk)
+			}
+		}
+	}()
+
+	cleanup := func() {
+		cancel()
+		sub.Close()
+	}
+	return wireOut, cleanup, nil
+}

--- a/docs/mixer.md
+++ b/docs/mixer.md
@@ -1,0 +1,83 @@
+---
+layout: page
+title: Mixer plot
+description: Channel-baseband power spectrum, raw vs tuned — GopherTrunk's take on OP25's Raw Mixer / Tuned Mixer tabs
+nav_group: Operate
+---
+
+# Mixer plot
+
+The **Mixer plot** (web `/plots/mixer`, or `/mixer`) shows the **power
+spectrum of the channel baseband** two ways — GopherTrunk's take on
+OP25's **Raw Mixer** and **Tuned Mixer** tabs. It answers "where is the
+carrier sitting, and is the receiver pulling it onto centre?"
+
+The daemon runs a parallel P25 receiver on the selected channel (the same
+engine the other [Plots](plots.html) use) and FFTs its channelized
+baseband, so the plot reflects exactly what the production demod is
+working with — not a re-implementation.
+
+## What you see
+
+Two stacked spectra, both **Power (dBFS) vs Frequency**, spanning the
+channel baseband (±½ the DDC output rate, ~±24 kHz on P25):
+
+- **Raw mixer** — the channelized baseband as the receiver first sees it.
+  The carrier sits wherever its residual frequency offset leaves it; the
+  **amber marker** flags the loop's carrier-offset estimate.
+- **Tuned mixer** — the *same* window re-mixed by that carrier-offset
+  estimate, so a locked loop pulls the carrier onto the **centre (0 Hz)
+  line**.
+
+Comparing the two is the whole point: the shift from the raw peak to the
+centred tuned peak *is* the carrier-recovery correction.
+
+| Symptom | Reading |
+| --- | --- |
+| Raw peak off-centre, **tuned peak centred** | Healthy lock — the loop is correcting the offset |
+| Raw peak near centre already | Little tuner error on this channel |
+| **Tuned peak still off-centre** | Loop hasn't acquired — weak signal or wrong Mode |
+| No peak, just noise floor | No active signal at this Offset, or wrong channel |
+
+A large, *steady* raw offset is your tuner's PPM error (a 420 MHz /
+50 ppm RTL-SDR can sit ~20 kHz off); the tuned view should still recentre
+it once the loop locks.
+
+## Controls
+
+Pick the receiver with **Mode** (C4FM or CQPSK — match the site), and use
+the **Offset / Hold / Centre** controls (shared with the other scopes) to
+point the receiver at a locked control or voice channel. With **Hold**
+off, the Offset follows the newest active call on the SDR. See the
+[Constellation panel](constellation.html) for the DC-spike explanation of
+why off-centre channels are mixed down before channelizing.
+
+## How it works
+
+- The panel opens
+  `WS /api/v1/diag/mixer?device=...&proto=<…>&offset=<hz>`. The daemon
+  runs a [symbolscope](plots.html) engine with its FFT taps enabled.
+- Each frame carries two FFT-shifted dBFS arrays: `raw_bins` (the DDC
+  output) and `tuned_bins` (that window multiplied by
+  `exp(-j·2π·f_off·n/Fs)`, where `f_off` is the receiver's own
+  `carrier_offset_hz`). Reconstructing the tuned view from the loop's
+  estimate needs no extra receiver tap and works identically for C4FM and
+  CQPSK.
+- The FFT math is the same `spectrum.PowerDB` helper the wideband
+  [Spectrum](spectrum.html) waterfall uses, so the two views are
+  normalized consistently.
+
+The numeric side of the same loop state — the carrier-error trend, AGC
+and clock meters — lives on the [Tuning panel](tuning.html); the Mixer
+plot is its graphical FFT counterpart.
+
+## Implementation
+
+| Path | Role |
+| --- | --- |
+| `internal/dsp/spectrum/spectrum.go` | `PowerDB` — shared windowed-FFT dBFS helper |
+| `internal/scanner/symbolscope/mixer.go` | Baseband accumulator → raw/tuned FFT frames |
+| `internal/scanner/symbolscope/scope.go` | Feeds the accumulator with the channelized baseband + carrier estimate |
+| `internal/api/mixer.go` | `MixerProvider` interface + `WS /api/v1/diag/mixer` handler |
+| `cmd/gophertrunk/mixer_provider.go` | Daemon provider over the iqtap broker |
+| `web/src/panels/Mixer.tsx` | Two stacked FFT line plots (raw + tuned) |

--- a/docs/plots.md
+++ b/docs/plots.md
@@ -19,6 +19,7 @@ production demodulator sees.
 | **Constellation** | How clean is the modulation? (symbol clusters / vector scope) | [Constellation](constellation.html) |
 | **Symbol scope** | What does the symbol waveform look like over time? | [Symbol scope](symbol-scope.html) |
 | **Eye diagram** | Is the C4FM eye open (symbol timing / SNR)? | [Eye diagram](eye-diagram.html) |
+| **Mixer** | Where does the carrier sit — and does the loop centre it? (raw vs tuned baseband FFT) | [Mixer](mixer.html) |
 | **Tuning** | Is the receiver locking — carrier error, AGC, clock? | [Tuning](tuning.html) |
 | **Histogram** | Is the symbol distribution healthy (balance / MER)? | [Histogram](histogram.html) |
 

--- a/internal/api/mixer.go
+++ b/internal/api/mixer.go
@@ -1,0 +1,139 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// MixerFrame is the wire shape of one channel-baseband spectrum snapshot
+// for the web Mixer plot (OP25's Raw Mixer / Tuned Mixer tabs). It
+// mirrors symbolscope.MixerFrame so the api package stays free of a
+// dependency on the DSP package; the MixerProvider interface bridges the
+// two.
+//
+// RawBins is the FFT of the channelized baseband as the receiver sees it
+// (the carrier sits at the residual offset); TunedBins is the same window
+// re-mixed by the receiver's carrier-offset estimate so a locked loop
+// centres the carrier. Both are dBFS, FFT-shifted (Bins[0] is the lowest
+// frequency, Bins[n/2] is DC), equal length.
+type MixerFrame struct {
+	TimestampNs     int64     `json:"ts_ns"`
+	CenterHz        uint32    `json:"center_hz"`
+	SampleRateHz    uint32    `json:"sample_rate_hz"`
+	OffsetHz        int32     `json:"offset_hz"`
+	CarrierOffsetHz float64   `json:"carrier_offset_hz"`
+	RawBins         []float32 `json:"raw_bins"`
+	TunedBins       []float32 `json:"tuned_bins"`
+}
+
+// MixerProvider is the daemon-side abstraction the mixer endpoint
+// consumes. The daemon implements it on top of the iqtap broker map +
+// internal/scanner/symbolscope; tests substitute a fake.
+type MixerProvider interface {
+	// OpenMixerStream starts a per-request symbol-recovery engine on the
+	// named device with the Mixer FFT taps enabled. proto selects the
+	// receiver ("p25-c4fm" / "p25-cqpsk"); offsetHz tunes an off-centre
+	// channel down to baseband before channelizing. Returns the wire-frame
+	// channel and a cleanup func the caller MUST invoke on disconnect.
+	OpenMixerStream(ctx context.Context, serial, proto string, offsetHz int32) (<-chan MixerFrame, func(), error)
+}
+
+// handleMixerStream answers WS /api/v1/diag/mixer?device=...&proto=...&offset=....
+//
+// Frames arrive as JSON text messages. Server pings every 30 s to keep
+// proxies from idling the socket. Connection stays open until the client
+// disconnects or the device disappears. Mirrors handleSymbolStream.
+func (s *Server) handleMixerStream(w http.ResponseWriter, r *http.Request) {
+	if s.mixer == nil {
+		s.writeError(w, http.StatusServiceUnavailable, "mixer subsystem not enabled")
+		return
+	}
+	q := r.URL.Query()
+	serial := q.Get("device")
+	if serial == "" {
+		s.writeError(w, http.StatusBadRequest, "device query parameter is required")
+		return
+	}
+	proto := q.Get("proto")
+	if proto == "" {
+		proto = "p25-c4fm"
+	}
+	if !symbolProtos[proto] {
+		s.writeError(w, http.StatusBadRequest, "unsupported proto (want p25-c4fm or p25-cqpsk)")
+		return
+	}
+	offset := int32(parseIntQuery(q, "offset", 0, -30_000_000, 30_000_000))
+
+	upgrader := wsUpgrader
+	if s.cors.enabled() {
+		cors := s.cors
+		upgrader.CheckOrigin = func(req *http.Request) bool {
+			origin := req.Header.Get("Origin")
+			if origin == "" {
+				return true
+			}
+			_, ok := cors.originAllowed(origin)
+			return ok
+		}
+	}
+	conn, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		s.log.Debug("api: mixer WS upgrade failed", "err", err)
+		return
+	}
+	defer conn.Close()
+
+	ctx, cancel := context.WithCancel(r.Context())
+	defer cancel()
+
+	frames, cleanup, err := s.mixer.OpenMixerStream(ctx, serial, proto, offset)
+	if err != nil {
+		s.log.Debug("api: mixer OpenMixerStream failed", "serial", serial, "err", err)
+		_ = conn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(
+			websocket.CloseInternalServerErr, err.Error()))
+		return
+	}
+	defer cleanup()
+
+	// Drain client → server messages so close frames are processed.
+	go func() {
+		for {
+			if _, _, err := conn.NextReader(); err != nil {
+				cancel()
+				return
+			}
+		}
+	}()
+
+	ping := time.NewTicker(30 * time.Second)
+	defer ping.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ping.C:
+			_ = conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+			if err := conn.WriteMessage(websocket.PingMessage, nil); err != nil {
+				return
+			}
+		case f, ok := <-frames:
+			if !ok {
+				return
+			}
+			body, err := json.Marshal(f)
+			if err != nil {
+				s.log.Debug("api: mixer frame marshal", "err", err)
+				continue
+			}
+			_ = conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+			if err := conn.WriteMessage(websocket.TextMessage, body); err != nil {
+				return
+			}
+		}
+	}
+}

--- a/internal/api/mixer_test.go
+++ b/internal/api/mixer_test.go
@@ -1,0 +1,162 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/gorilla/websocket"
+)
+
+type fakeMixerProvider struct {
+	openErr error
+	frames  []MixerFrame
+	gotPro  string
+	gotOff  int32
+}
+
+func (f *fakeMixerProvider) OpenMixerStream(ctx context.Context, _ string, proto string, offset int32) (<-chan MixerFrame, func(), error) {
+	f.gotPro = proto
+	f.gotOff = offset
+	if f.openErr != nil {
+		return nil, nil, f.openErr
+	}
+	out := make(chan MixerFrame, 4)
+	streamCtx, cancel := context.WithCancel(ctx)
+	go func() {
+		defer close(out)
+		for _, fr := range f.frames {
+			select {
+			case <-streamCtx.Done():
+				return
+			case out <- fr:
+			}
+			time.Sleep(5 * time.Millisecond)
+		}
+		<-streamCtx.Done()
+	}()
+	return out, cancel, nil
+}
+
+func newMixerTestServer(t *testing.T, prov MixerProvider) *httptest.Server {
+	t.Helper()
+	bus := events.NewBus(8)
+	t.Cleanup(bus.Close)
+	srv, err := NewServer(ServerOptions{
+		Addr:  "127.0.0.1:0",
+		Bus:   bus,
+		Mixer: prov,
+	})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	ts := httptest.NewServer(srv.routes())
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+func TestMixerStreamReturns503WhenNotWired(t *testing.T) {
+	ts := newMixerTestServer(t, nil)
+	resp, err := http.Get(ts.URL + "/api/v1/diag/mixer?device=foo")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want 503", resp.StatusCode)
+	}
+}
+
+func TestMixerStreamRejectsMissingDevice(t *testing.T) {
+	ts := newMixerTestServer(t, &fakeMixerProvider{})
+	resp, err := http.Get(ts.URL + "/api/v1/diag/mixer")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", resp.StatusCode)
+	}
+}
+
+func TestMixerStreamRejectsUnknownProto(t *testing.T) {
+	ts := newMixerTestServer(t, &fakeMixerProvider{})
+	resp, err := http.Get(ts.URL + "/api/v1/diag/mixer?device=foo&proto=bogus")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400 for unknown proto", resp.StatusCode)
+	}
+}
+
+func TestMixerStreamDeliversFrames(t *testing.T) {
+	prov := &fakeMixerProvider{
+		frames: []MixerFrame{
+			{
+				TimestampNs:     1,
+				CenterHz:        851_012_500,
+				SampleRateHz:    48_000,
+				OffsetHz:        12_500,
+				CarrierOffsetHz: -120.5,
+				RawBins:         []float32{-90, -40, -10, -45},
+				TunedBins:       []float32{-92, -50, -8, -51},
+			},
+			{
+				TimestampNs:  2,
+				CenterHz:     851_012_500,
+				SampleRateHz: 48_000,
+				RawBins:      []float32{-88, -42},
+				TunedBins:    []float32{-89, -43},
+			},
+		},
+	}
+	ts := newMixerTestServer(t, prov)
+
+	u, _ := url.Parse(ts.URL)
+	wsURL := "ws://" + u.Host + "/api/v1/diag/mixer?device=any&proto=p25-cqpsk&offset=12500"
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	defer conn.Close()
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+
+	for i := 0; i < 2; i++ {
+		_, msg, err := conn.ReadMessage()
+		if err != nil {
+			t.Fatalf("ReadMessage #%d: %v", i, err)
+		}
+		var f MixerFrame
+		if err := json.Unmarshal(msg, &f); err != nil {
+			t.Fatalf("unmarshal #%d: %v (raw=%s)", i, err, string(msg))
+		}
+		if f.SampleRateHz != 48_000 {
+			t.Errorf("frame #%d SampleRateHz = %d, want 48000", i, f.SampleRateHz)
+		}
+		if len(f.RawBins) == 0 || len(f.TunedBins) == 0 {
+			t.Errorf("frame #%d empty bins: raw=%d tuned=%d", i, len(f.RawBins), len(f.TunedBins))
+		}
+		if i == 0 {
+			if len(f.RawBins) != 4 || f.RawBins[2] != -10 {
+				t.Errorf("frame #0 raw bins not round-tripped: %v", f.RawBins)
+			}
+			if f.CarrierOffsetHz != -120.5 {
+				t.Errorf("frame #0 carrier offset = %v, want -120.5", f.CarrierOffsetHz)
+			}
+		}
+	}
+
+	if prov.gotPro != "p25-cqpsk" {
+		t.Errorf("provider got proto %q, want p25-cqpsk", prov.gotPro)
+	}
+	if prov.gotOff != 12_500 {
+		t.Errorf("provider got offset %d, want 12500", prov.gotOff)
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -317,6 +317,12 @@ type Server struct {
 	// daemon over the iqtap broker + internal/scanner/symbolscope.
 	symbols SymbolProvider
 
+	// mixer is the optional provider backing the WS /api/v1/diag/mixer
+	// channel-baseband spectrum stream for the Mixer plot (OP25's Raw /
+	// Tuned Mixer tabs). nil disables the route (503). Implemented by the
+	// daemon over the iqtap broker + internal/scanner/symbolscope.
+	mixer MixerProvider
+
 	// pager is the optional provider backing /api/v1/pager/...
 	// routes (pager log). nil disables the routes. Implemented
 	// by the daemon over the SQLite-backed storage.PagerLog.
@@ -603,6 +609,11 @@ type ServerOptions struct {
 	// panel. The daemon implements this over the iqtap broker +
 	// internal/scanner/symbolscope; nil keeps the route returning 503.
 	Symbols SymbolProvider
+	// Mixer, when non-nil, enables the WS /api/v1/diag/mixer
+	// channel-baseband spectrum stream that backs the web Mixer plot.
+	// The daemon implements this over the iqtap broker +
+	// internal/scanner/symbolscope; nil keeps the route returning 503.
+	Mixer MixerProvider
 	// Siglab, when Enabled, mounts the offline signal-analysis routes
 	// (/api/v1/siglab/*) and constructs the in-memory job/capture store.
 	// The daemon and the standalone `siglab serve` command both set it.
@@ -785,6 +796,7 @@ func NewServer(opts ServerOptions) (*Server, error) {
 		bookmarks:      opts.Bookmarks,
 		diag:           opts.Diag,
 		symbols:        opts.Symbols,
+		mixer:          opts.Mixer,
 		siglab:         siglabSvc,
 		siglabStop:     siglabStop,
 		configBuilder:  configBuilderSvc,
@@ -1026,6 +1038,7 @@ func (s *Server) routes() *http.ServeMux {
 	// via this path. Returns 503 when no SDR is in the pool.
 	mux.HandleFunc("GET /api/v1/diag/iq", s.handleDiagStream)
 	mux.HandleFunc("GET /api/v1/diag/symbols", s.handleSymbolStream)
+	mux.HandleFunc("GET /api/v1/diag/mixer", s.handleMixerStream)
 
 	// Siglab — offline signal-analysis console. Read routes (protocols,
 	// job result/stream/iq, export) are open; routes that stage data or

--- a/internal/dsp/spectrum/spectrum.go
+++ b/internal/dsp/spectrum/spectrum.go
@@ -193,39 +193,53 @@ func (p *Producer) Run(ctx context.Context, in <-chan []complex64, out chan<- Fr
 // frame runs one FFT over the accumulated samples, returning a fresh
 // Frame with FFT-shifted dBFS bins.
 func (p *Producer) frame(samples []complex64) Frame {
-	// Window + convert complex64 → complex128.
-	for i := 0; i < p.size; i++ {
-		s := samples[i]
-		w := p.win[i]
-		p.bufIQ[i] = complex(float64(real(s))*w, float64(imag(s))*w)
-	}
-	out := p.plan.Forward(p.bufOut, p.bufIQ)
-
-	// Magnitude (dBFS), FFT-shifted so DC is in the middle.
 	bins := make([]float32, p.size)
-	// Normalization: power per bin = |X|² / (FFTSize · Σ(w²)). For
-	// a unit-amplitude input this gives 0 dBFS at the corresponding
-	// bin.
-	norm := 1.0 / (float64(p.size) * p.winSum)
-	half := p.size / 2
-	for i := 0; i < p.size; i++ {
-		// FFT-shift: bin i in the output maps to index (i + half) mod N
-		// so DC (i=0 in unshifted) lands at index `half`.
-		src := i
-		dst := (i + half) % p.size
-		mag := cmplx.Abs(out[src])
-		power := mag * mag * norm
-		// Clamp before log to avoid -Inf.
-		if power < 1e-30 {
-			power = 1e-30
-		}
-		bins[dst] = float32(10 * math.Log10(power))
-	}
-
+	PowerDB(p.plan, p.win, p.winSum, samples, p.bufIQ, p.bufOut, bins)
 	return Frame{
 		Timestamp:  time.Now(),
 		CenterHz:   p.centerHz.Load(),
 		SampleRate: p.rateHz.Load(),
 		Bins:       bins,
+	}
+}
+
+// PowerDB computes the FFT-shifted dBFS power spectrum of in into dst.
+// It is the single source of truth for the spectrum math, shared by the
+// streaming Producer and one-shot callers (the Mixer plot's per-window
+// FFTs).
+//
+// All of in, dst, win, bufIn and bufOut must have the same length n — a
+// power of two — and plan must be fft.New(n). bufIn/bufOut are caller-
+// owned FFT scratch (reused across calls to stay allocation-free); their
+// contents are overwritten. winSum is Σ(win²), precomputed once.
+//
+// Bins are FFT-shifted so dst[0] is the lowest frequency (-Fs/2) and
+// dst[n/2] is DC, matching Frame's documented layout. Normalization is
+// power = |X|² / (n · Σ(w²)), so a unit-amplitude tone reads ~0 dBFS at
+// its bin.
+func PowerDB(plan fft.Plan, win []float64, winSum float64, in []complex64, bufIn, bufOut []complex128, dst []float32) {
+	n := len(win)
+	// Window + convert complex64 → complex128.
+	for i := 0; i < n; i++ {
+		s := in[i]
+		w := win[i]
+		bufIn[i] = complex(float64(real(s))*w, float64(imag(s))*w)
+	}
+	out := plan.Forward(bufOut, bufIn)
+
+	// Magnitude (dBFS), FFT-shifted so DC is in the middle.
+	norm := 1.0 / (float64(n) * winSum)
+	half := n / 2
+	for i := 0; i < n; i++ {
+		// FFT-shift: bin i in the output maps to index (i + half) mod N
+		// so DC (i=0 in unshifted) lands at index `half`.
+		dstIdx := (i + half) % n
+		mag := cmplx.Abs(out[i])
+		power := mag * mag * norm
+		// Clamp before log to avoid -Inf.
+		if power < 1e-30 {
+			power = 1e-30
+		}
+		dst[dstIdx] = float32(10 * math.Log10(power))
 	}
 }

--- a/internal/dsp/spectrum/spectrum_test.go
+++ b/internal/dsp/spectrum/spectrum_test.go
@@ -5,6 +5,9 @@ import (
 	"math"
 	"testing"
 	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/fft"
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/window"
 )
 
 func TestNewRejectsBadFFTSize(t *testing.T) {
@@ -221,5 +224,53 @@ func TestProducerCounteractsBinTones(t *testing.T) {
 	}
 	if peakBin != 48 {
 		t.Errorf("+Fs/4 peak at bin %d, want 48 (centre + N/4)", peakBin)
+	}
+}
+
+// TestPowerDBPeaksAtTone checks the shared helper: a unit-amplitude
+// complex tone reads ~0 dBFS at its FFT-shifted bin and well below
+// elsewhere, with DC landing at the centre bin.
+func TestPowerDBPeaksAtTone(t *testing.T) {
+	const (
+		size     = 256
+		sampleHz = 48000.0
+		toneHz   = 6000.0
+	)
+	plan := fft.New(size)
+	win := window.Hann(size)
+	var winSum float64
+	for _, v := range win {
+		winSum += v * v
+	}
+
+	in := make([]complex64, size)
+	w := 2 * math.Pi * toneHz / sampleHz
+	for n := 0; n < size; n++ {
+		in[n] = complex64(complex(math.Cos(w*float64(n)), math.Sin(w*float64(n))))
+	}
+
+	bufIn := make([]complex128, size)
+	bufOut := make([]complex128, size)
+	dst := make([]float32, size)
+	PowerDB(plan, win, winSum, in, bufIn, bufOut, dst)
+
+	center := size / 2
+	wantBin := center + int(math.Round(toneHz*size/sampleHz))
+	peak, peakVal := 0, float32(math.Inf(-1))
+	for i, v := range dst {
+		if v > peakVal {
+			peak, peakVal = i, v
+		}
+	}
+	if peak != wantBin {
+		t.Errorf("peak bin = %d, want %d", peak, wantBin)
+	}
+	// A windowed unit tone should peak near 0 dBFS.
+	if peakVal < -3 || peakVal > 1 {
+		t.Errorf("peak level = %.2f dBFS, want ~0", peakVal)
+	}
+	// An off-peak bin should be far down.
+	if dst[center] > -20 {
+		t.Errorf("centre (DC) bin = %.2f dBFS, want well below the +6 kHz peak", dst[center])
 	}
 }

--- a/internal/scanner/symbolscope/mixer.go
+++ b/internal/scanner/symbolscope/mixer.go
@@ -1,0 +1,176 @@
+package symbolscope
+
+import (
+	"errors"
+	"math"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/fft"
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/spectrum"
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/window"
+)
+
+// defaultMixerFFTSize is the Mixer plot's FFT length. At the P25 DDC
+// output rate (~48 kHz) 1024 bins is ~47 Hz/bin over the channel
+// baseband — fine enough to see the carrier sit off-centre and snap back
+// once the loop tunes it, without an over-large wire payload.
+const defaultMixerFFTSize = 1024
+
+// defaultMixerFPS caps how often the Mixer plot computes its two FFTs.
+// The plot is a slow human-readable view, so 10 fps keeps the per-stream
+// CPU cost negligible next to the receiver itself.
+const defaultMixerFPS = 10.0
+
+// MixerFrame is one snapshot of the channel baseband spectrum, the data
+// behind GopherTrunk's Mixer plot (OP25's Raw Mixer / Tuned Mixer tabs).
+//
+// RawBins is the FFT of the channelized baseband as the receiver sees it
+// — the carrier sits wherever the residual offset leaves it. TunedBins is
+// the same window re-mixed by the receiver's own carrier-offset estimate,
+// so a locked loop pulls the carrier to 0 Hz (centre bin). Both are dBFS,
+// FFT-shifted (index 0 = -SampleRateHz/2, index n/2 = DC), length the
+// configured FFT size. The slices are freshly allocated per frame; the
+// callee owns them.
+type MixerFrame struct {
+	TimestampNs     int64
+	CenterHz        uint32
+	SampleRateHz    uint32
+	OffsetHz        int32
+	CarrierOffsetHz float64
+	RawBins         []float32
+	TunedBins       []float32
+}
+
+// mixerOptions configures a mixerAccum.
+type mixerOptions struct {
+	fftSize  int
+	fps      float64
+	sampleHz float64
+	centerHz uint32
+	offsetHz int32
+	nowNs    func() int64
+	emit     func(MixerFrame)
+}
+
+// mixerAccum buffers channelized baseband into FFT-sized windows and, at
+// the configured frame rate, emits a raw + tuned spectrum pair. It is
+// driven from the Engine's single Process goroutine — not safe for
+// concurrent feed calls.
+type mixerAccum struct {
+	fftSize  int
+	sampleHz float64
+	centerHz uint32
+	offsetHz int32
+	periodNs int64
+	nowNs    func() int64
+	emit     func(MixerFrame)
+
+	plan   fft.Plan
+	win    []float64
+	winSum float64
+	bufIn  []complex128 // FFT scratch, reused
+	bufOut []complex128 // FFT scratch, reused
+
+	pending []complex64 // window accumulator (len → fftSize)
+	mixBuf  []complex64 // tuned re-mix scratch, reused
+	nextNs  int64       // earliest nowNs at which to emit the next frame
+}
+
+// newMixerAccum builds a mixerAccum, validating the FFT size is a
+// positive power of two and the rate is usable.
+func newMixerAccum(opts mixerOptions) (*mixerAccum, error) {
+	if opts.emit == nil {
+		return nil, errors.New("symbolscope: mixer emit is required")
+	}
+	if opts.sampleHz <= 0 {
+		return nil, errors.New("symbolscope: mixer sampleHz must be > 0")
+	}
+	size := opts.fftSize
+	if size <= 0 {
+		size = defaultMixerFFTSize
+	}
+	if size&(size-1) != 0 {
+		return nil, errors.New("symbolscope: mixer FFT size must be a power of two")
+	}
+	fps := opts.fps
+	if fps <= 0 {
+		fps = defaultMixerFPS
+	}
+	nowNs := opts.nowNs
+	if nowNs == nil {
+		return nil, errors.New("symbolscope: mixer nowNs is required")
+	}
+
+	win := window.Hann(size)
+	var winSum float64
+	for _, w := range win {
+		winSum += w * w
+	}
+	return &mixerAccum{
+		fftSize:  size,
+		sampleHz: opts.sampleHz,
+		centerHz: opts.centerHz,
+		offsetHz: opts.offsetHz,
+		periodNs: int64(float64(1e9) / fps),
+		nowNs:    nowNs,
+		emit:     opts.emit,
+		plan:     fft.New(size),
+		win:      win,
+		winSum:   winSum,
+		bufIn:    make([]complex128, size),
+		bufOut:   make([]complex128, size),
+		pending:  make([]complex64, 0, size),
+		mixBuf:   make([]complex64, size),
+	}, nil
+}
+
+// feed appends a baseband chunk, emitting a MixerFrame each time a full
+// FFT window has accumulated and the frame interval has elapsed. The
+// carrier-offset estimate (read fresh from the receiver after this
+// chunk) drives the tuned re-mix. baseband is consumed synchronously
+// (copied into the window), so the caller may reuse it afterwards.
+func (m *mixerAccum) feed(baseband []complex64, carrierOffsetHz float64) {
+	src := baseband
+	for len(src) > 0 {
+		need := m.fftSize - len(m.pending)
+		if len(src) < need {
+			m.pending = append(m.pending, src...)
+			return
+		}
+		m.pending = append(m.pending, src[:need]...)
+		src = src[need:]
+		now := m.nowNs()
+		if now >= m.nextNs {
+			m.emitFrame(carrierOffsetHz, now)
+			m.nextNs = now + m.periodNs
+		}
+		m.pending = m.pending[:0]
+	}
+}
+
+// emitFrame runs the two FFTs over the current full window and delivers
+// the MixerFrame. The tuned view multiplies sample n by
+// exp(-j·2π·f_off·n/Fs) so a carrier at +f_off lands on the centre bin;
+// resetting the mix phase per window is harmless for a magnitude spectrum.
+func (m *mixerAccum) emitFrame(carrierOffsetHz float64, nowNs int64) {
+	raw := make([]float32, m.fftSize)
+	spectrum.PowerDB(m.plan, m.win, m.winSum, m.pending, m.bufIn, m.bufOut, raw)
+
+	w := -2 * math.Pi * carrierOffsetHz / m.sampleHz
+	for n := 0; n < m.fftSize; n++ {
+		ph := w * float64(n)
+		rot := complex(float32(math.Cos(ph)), float32(math.Sin(ph)))
+		m.mixBuf[n] = m.pending[n] * rot
+	}
+	tuned := make([]float32, m.fftSize)
+	spectrum.PowerDB(m.plan, m.win, m.winSum, m.mixBuf, m.bufIn, m.bufOut, tuned)
+
+	m.emit(MixerFrame{
+		TimestampNs:     nowNs,
+		CenterHz:        m.centerHz,
+		SampleRateHz:    uint32(m.sampleHz + 0.5),
+		OffsetHz:        m.offsetHz,
+		CarrierOffsetHz: carrierOffsetHz,
+		RawBins:         raw,
+		TunedBins:       tuned,
+	})
+}

--- a/internal/scanner/symbolscope/mixer_test.go
+++ b/internal/scanner/symbolscope/mixer_test.go
@@ -1,0 +1,153 @@
+package symbolscope
+
+import (
+	"math"
+	"math/cmplx"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// argmax returns the index of the largest value in bins.
+func argmax(bins []float32) int {
+	best, bestI := float32(math.Inf(-1)), 0
+	for i, v := range bins {
+		if v > best {
+			best, bestI = v, i
+		}
+	}
+	return bestI
+}
+
+// TestMixerRawAndTunedPeaks feeds a pure off-centre complex tone and
+// checks that the raw spectrum peaks at the tone's frequency while the
+// tuned spectrum — re-mixed by a carrier-offset estimate equal to the
+// tone — peaks at DC (centre bin). This is the core Mixer-plot behaviour:
+// a locked loop pulls the carrier back to centre.
+func TestMixerRawAndTunedPeaks(t *testing.T) {
+	const (
+		sampleHz = 48000.0
+		fftSize  = 1024
+		toneHz   = 5000.0
+	)
+
+	var frames []MixerFrame
+	m, err := newMixerAccum(mixerOptions{
+		fftSize:  fftSize,
+		fps:      1000, // generous; we drive emit via nowNs below
+		sampleHz: sampleHz,
+		centerHz: 851_000_000,
+		offsetHz: 0,
+		nowNs:    func() int64 { return 0 },
+		emit:     func(f MixerFrame) { frames = append(frames, f) },
+	})
+	if err != nil {
+		t.Fatalf("newMixerAccum: %v", err)
+	}
+
+	// One full FFT window of a unit complex tone at +toneHz.
+	tone := make([]complex64, fftSize)
+	w := 2 * math.Pi * toneHz / sampleHz
+	for n := 0; n < fftSize; n++ {
+		c := cmplx.Rect(1, w*float64(n))
+		tone[n] = complex64(c)
+	}
+
+	// Feed with a carrier-offset estimate equal to the tone, so the tuned
+	// re-mix should centre it.
+	m.feed(tone, toneHz)
+
+	if len(frames) != 1 {
+		t.Fatalf("got %d frames, want 1", len(frames))
+	}
+	f := frames[0]
+	if len(f.RawBins) != fftSize || len(f.TunedBins) != fftSize {
+		t.Fatalf("bin lengths = (%d,%d), want %d", len(f.RawBins), len(f.TunedBins), fftSize)
+	}
+	if f.SampleRateHz != uint32(sampleHz) {
+		t.Errorf("SampleRateHz = %d, want %d", f.SampleRateHz, uint32(sampleHz))
+	}
+
+	// Expected raw peak bin: FFT-shifted, centre (DC) at fftSize/2, the
+	// tone sitting toneHz above it.
+	center := fftSize / 2
+	wantRaw := center + int(math.Round(toneHz*fftSize/sampleHz))
+	rawPeak := argmax(f.RawBins)
+	if abs(rawPeak-wantRaw) > 2 {
+		t.Errorf("raw peak bin = %d, want ~%d", rawPeak, wantRaw)
+	}
+
+	// Tuned peak should land on the centre bin (within a bin or two).
+	tunedPeak := argmax(f.TunedBins)
+	if abs(tunedPeak-center) > 2 {
+		t.Errorf("tuned peak bin = %d, want ~%d (centre)", tunedPeak, center)
+	}
+}
+
+func abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+// TestMixerAccumValidation covers the constructor guards.
+func TestMixerAccumValidation(t *testing.T) {
+	now := func() int64 { return 0 }
+	emit := func(MixerFrame) {}
+	if _, err := newMixerAccum(mixerOptions{sampleHz: 48000, nowNs: now}); err == nil {
+		t.Error("missing emit: want error")
+	}
+	if _, err := newMixerAccum(mixerOptions{emit: emit, nowNs: now}); err == nil {
+		t.Error("zero sampleHz: want error")
+	}
+	if _, err := newMixerAccum(mixerOptions{emit: emit, sampleHz: 48000, fftSize: 1000, nowNs: now}); err == nil {
+		t.Error("non-power-of-two FFT size: want error")
+	}
+	if _, err := newMixerAccum(mixerOptions{emit: emit, sampleHz: 48000}); err == nil {
+		t.Error("missing nowNs: want error")
+	}
+	if _, err := newMixerAccum(mixerOptions{emit: emit, sampleHz: 48000, nowNs: now}); err != nil {
+		t.Errorf("valid options: unexpected error %v", err)
+	}
+}
+
+// TestEngineMixerEmits checks the Engine wires the mixer through Process
+// end-to-end: a C4FM IQ stream produces MixerFrames with populated bins.
+func TestEngineMixerEmits(t *testing.T) {
+	const inRate = 960_000.0
+	iq, _ := makeC4FMIQ(inRate, 4000)
+
+	var mixFrames []MixerFrame
+	eng, err := New(Options{
+		Protocol:  trunking.ProtocolP25,
+		DemodMode: "c4fm",
+		InRateHz:  inRate,
+		Emit:      func(Frame) {},
+		MixerEmit: func(f MixerFrame) { mixFrames = append(mixFrames, f) },
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer eng.Close()
+
+	// Chunk the stream so Process runs repeatedly, like the broker drain.
+	for off := 0; off < len(iq); off += 4096 {
+		end := off + 4096
+		if end > len(iq) {
+			end = len(iq)
+		}
+		eng.Process(iq[off:end])
+	}
+
+	if len(mixFrames) == 0 {
+		t.Fatal("no mixer frames emitted")
+	}
+	f := mixFrames[0]
+	if len(f.RawBins) == 0 || len(f.TunedBins) == 0 {
+		t.Errorf("empty bins: raw=%d tuned=%d", len(f.RawBins), len(f.TunedBins))
+	}
+	if f.SampleRateHz == 0 {
+		t.Error("SampleRateHz = 0, want the DDC output rate")
+	}
+}

--- a/internal/scanner/symbolscope/scope.go
+++ b/internal/scanner/symbolscope/scope.go
@@ -124,6 +124,18 @@ type Options struct {
 	// Emit receives each completed Frame. Required. The slices it
 	// carries are freshly allocated per frame; the callee owns them.
 	Emit func(Frame)
+
+	// MixerEmit, when non-nil, enables the Mixer plot: the engine runs a
+	// rate-limited FFT over the channelized baseband (raw) and over that
+	// baseband re-mixed by the receiver's carrier-offset estimate (tuned),
+	// delivering each pair as a MixerFrame. Nil disables the work entirely.
+	MixerEmit func(MixerFrame)
+	// MixerFFTSize is the FFT length for the Mixer plot (power of two).
+	// Zero picks defaultMixerFFTSize. Ignored when MixerEmit is nil.
+	MixerFFTSize int
+	// MixerFPS caps the Mixer frame rate. Zero picks defaultMixerFPS.
+	// Ignored when MixerEmit is nil.
+	MixerFPS float64
 }
 
 // Engine channelizes a wideband IQ feed and runs a protocol receiver,
@@ -159,6 +171,11 @@ type Engine struct {
 	isBits    bool
 	baseIdx   int // absolute symbol index of pendDibits[0]
 	totalSyms int // symbols seen across the whole stream
+
+	// mixer, when non-nil, accumulates channelized baseband into FFT
+	// windows and emits raw/tuned spectra (the Mixer plot). Built only
+	// when Options.MixerEmit is set.
+	mixer *mixerAccum
 }
 
 // New constructs an Engine. Returns an error for an unsupported
@@ -214,6 +231,22 @@ func New(opts Options) (*Engine, error) {
 		EyeSink:      e.onEye,
 		DibitSink:    e.onDibits,
 	})
+
+	if opts.MixerEmit != nil {
+		mx, err := newMixerAccum(mixerOptions{
+			fftSize:  opts.MixerFFTSize,
+			fps:      opts.MixerFPS,
+			sampleHz: ddc.OutRateHz(),
+			centerHz: opts.CenterHz,
+			offsetHz: opts.OffsetHz,
+			nowNs:    nowNs,
+			emit:     opts.MixerEmit,
+		})
+		if err != nil {
+			return nil, err
+		}
+		e.mixer = mx
+	}
 	return e, nil
 }
 
@@ -225,6 +258,13 @@ func (e *Engine) Process(iq []complex64) {
 	}
 	e.chanBuf = e.ddc.Process(e.chanBuf, iq)
 	e.rx.Process(e.chanBuf)
+	// Feed the Mixer accumulator after the receiver has updated its
+	// carrier-offset estimate, so the "tuned" re-mix uses this chunk's
+	// loop state. chanBuf is consumed synchronously (copied into the
+	// FFT window), so reusing it as scratch next Process is safe.
+	if e.mixer != nil {
+		e.mixer.feed(e.chanBuf, e.carrierOffsetHz())
+	}
 }
 
 // onSoft stashes the pre-slicer soft samples; onDibits, fired next on
@@ -350,6 +390,20 @@ func (e *Engine) stampMetrics(f *Frame) {
 	f.AGCTarget = e.rx.AGCTarget()
 	f.ClockMu = e.rx.MMClockMu()
 	f.ClockSPS = e.rx.MMClockSPS()
+}
+
+// carrierOffsetHz returns the receiver's current residual carrier-offset
+// estimate (the AFC estimate on C4FM, the carrier-recovery estimate on
+// CQPSK). The Mixer plot uses it to re-mix the raw baseband onto centre
+// for the "tuned" view; it mirrors the routing stampMetrics uses.
+func (e *Engine) carrierOffsetHz() float64 {
+	if e.rx == nil {
+		return 0
+	}
+	if e.isCQPSK {
+		return e.rx.CQPSKCarrierOffsetHz()
+	}
+	return e.rx.AFCOffsetHz()
 }
 
 // Close releases the engine. Idempotent.

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -12,6 +12,7 @@ import { CCActivity } from "./panels/CCActivity";
 import { Constellation } from "./panels/Constellation";
 import { SymbolScope } from "./panels/SymbolScope";
 import { EyeDiagram } from "./panels/EyeDiagram";
+import { Mixer } from "./panels/Mixer";
 import { Tuning } from "./panels/Tuning";
 import { Histogram } from "./panels/Histogram";
 import { Plots } from "./panels/Plots";
@@ -248,6 +249,7 @@ export function App() {
           <Route path="/constellation" element={<Constellation />} />
           <Route path="/symbols" element={<SymbolScope />} />
           <Route path="/eye" element={<EyeDiagram />} />
+          <Route path="/mixer" element={<Mixer />} />
           <Route path="/tuning" element={<Tuning />} />
           <Route path="/histogram" element={<Histogram />} />
           <Route path="/bookmarks" element={<Bookmarks />} />

--- a/web/src/api/mixer.test.ts
+++ b/web/src/api/mixer.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { mixerWebSocketURL } from "./mixer";
+import { type ClientConfig } from "./client";
+
+const cfg: ClientConfig = { baseURL: "https://radio.example:8443", token: null };
+
+describe("mixerWebSocketURL", () => {
+  it("targets the diag/mixer endpoint and upgrades https → wss", () => {
+    const url = mixerWebSocketURL(cfg, { serial: "abc", onFrame: () => {} });
+    const u = new URL(url);
+    expect(u.protocol).toBe("wss:");
+    expect(u.pathname).toBe("/api/v1/diag/mixer");
+    expect(u.searchParams.get("device")).toBe("abc");
+  });
+
+  it("includes proto and offset when set", () => {
+    const url = mixerWebSocketURL(cfg, {
+      serial: "abc",
+      proto: "p25-cqpsk",
+      offset: 12500.4,
+      onFrame: () => {},
+    });
+    const u = new URL(url);
+    expect(u.searchParams.get("proto")).toBe("p25-cqpsk");
+    // Offsets are rounded to an integer Hz on the wire.
+    expect(u.searchParams.get("offset")).toBe("12500");
+  });
+
+  it("omits a zero offset", () => {
+    const url = mixerWebSocketURL(cfg, {
+      serial: "abc",
+      offset: 0,
+      onFrame: () => {},
+    });
+    expect(new URL(url).searchParams.has("offset")).toBe(false);
+  });
+});

--- a/web/src/api/mixer.ts
+++ b/web/src/api/mixer.ts
@@ -1,0 +1,120 @@
+// Channel-baseband spectrum stream client. Mirrors WS /api/v1/diag/mixer
+// (see internal/api/mixer.go). Same connect/reconnect scaffolding the
+// symbol stream uses; the wire shape is one JSON MixerFrame per message.
+
+import { type ClientConfig } from "./client";
+
+export interface MixerFrame {
+  ts_ns: number;
+  center_hz: number;
+  sample_rate_hz: number;
+  offset_hz: number;
+  // The receiver's residual carrier-offset estimate (Hz). The tuned view
+  // is the raw window re-mixed by this, so a locked loop centres it.
+  carrier_offset_hz: number;
+  // FFT-shifted dBFS bins of the channelized baseband. raw_bins shows the
+  // carrier at its residual offset; tuned_bins shows it after the
+  // carrier-recovery correction. Both equal length; index 0 is the lowest
+  // frequency, index n/2 is DC.
+  raw_bins: number[];
+  tuned_bins: number[];
+}
+
+export type MixerFrameHandler = (f: MixerFrame) => void;
+export type StatusHandler = (s: "connecting" | "open" | "closed") => void;
+
+export interface MixerStream {
+  close(): void;
+}
+
+export interface MixerOptions {
+  serial: string;
+  // Receiver selector: "p25-c4fm" or "p25-cqpsk". Default "p25-c4fm".
+  proto?: string;
+  // Frequency offset in Hz, relative to the SDR centre, tuned down to
+  // baseband before channelizing. Default 0.
+  offset?: number;
+  onFrame: MixerFrameHandler;
+  onStatus?: StatusHandler;
+}
+
+const INITIAL_BACKOFF = 500;
+const MAX_BACKOFF = 30_000;
+
+export function mixerWebSocketURL(cfg: ClientConfig, opts: MixerOptions): string {
+  const params = new URLSearchParams({ device: opts.serial });
+  if (opts.proto) params.set("proto", opts.proto);
+  if (opts.offset != null && opts.offset !== 0)
+    params.set("offset", String(Math.round(opts.offset)));
+  const u = new URL(
+    `/api/v1/diag/mixer?${params.toString()}`,
+    cfg.baseURL || window.location.href,
+  );
+  u.protocol = u.protocol === "https:" ? "wss:" : "ws:";
+  return u.toString();
+}
+
+export function openMixerStream(cfg: ClientConfig, opts: MixerOptions): MixerStream {
+  let closed = false;
+  let ws: WebSocket | null = null;
+  let backoff = INITIAL_BACKOFF;
+  let reconnectTimer: number | undefined;
+
+  const setStatus = (s: "connecting" | "open" | "closed") => {
+    if (!closed) opts.onStatus?.(s);
+  };
+
+  const jittered = (base: number) => base / 2 + Math.random() * (base / 2);
+
+  const connect = () => {
+    if (closed) return;
+    setStatus("connecting");
+    const url = mixerWebSocketURL(cfg, opts);
+    ws = new WebSocket(url);
+
+    ws.onopen = () => {
+      backoff = INITIAL_BACKOFF;
+      setStatus("open");
+    };
+
+    ws.onmessage = (ev) => {
+      if (closed) return;
+      try {
+        const frame = JSON.parse(ev.data) as MixerFrame;
+        if (frame && Array.isArray(frame.raw_bins)) {
+          opts.onFrame(frame);
+        }
+      } catch {
+        // Drop malformed.
+      }
+    };
+
+    const onDown = () => {
+      if (closed) return;
+      ws = null;
+      setStatus("closed");
+      const wait = jittered(backoff);
+      backoff = Math.min(backoff * 2, MAX_BACKOFF);
+      reconnectTimer = window.setTimeout(connect, wait);
+    };
+    ws.onerror = onDown;
+    ws.onclose = onDown;
+  };
+
+  connect();
+
+  return {
+    close() {
+      closed = true;
+      setStatus("closed");
+      if (reconnectTimer !== undefined) window.clearTimeout(reconnectTimer);
+      if (ws) {
+        try {
+          ws.close();
+        } catch {
+          // ignore
+        }
+      }
+    },
+  };
+}

--- a/web/src/panels/Mixer.tsx
+++ b/web/src/panels/Mixer.tsx
@@ -1,0 +1,356 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  fetchSpectrumDevices,
+  defaultSymbolDevice,
+  type SpectrumDevice,
+} from "../api/spectrum";
+import { openMixerStream, type MixerFrame } from "../api/mixer";
+import { selectClientConfig, useShared } from "../store/shared";
+import { prefs } from "../store/prefs";
+import { TuningControls } from "../components/TuningControls";
+
+// Mixer plot — GopherTrunk's take on OP25's Raw Mixer / Tuned Mixer tabs.
+// The daemon runs a parallel P25 receiver on the selected channel and
+// FFTs the channelized baseband two ways: "raw" (the carrier wherever its
+// residual offset leaves it) and "tuned" (the same window re-mixed by the
+// receiver's carrier-offset estimate, so a locked loop pulls the carrier
+// to centre). Comparing the two shows the carrier-recovery correction at a
+// glance: a raw peak that sits off-centre and a tuned peak that snaps back
+// to 0 Hz is a healthy lock.
+
+const DB_FLOOR = -100;
+const DB_CEIL = 0;
+const PLOT_W = 1024; // internal canvas width (bins resample to this)
+const PLOT_H = 200;
+
+const PROTOS: { value: string; label: string }[] = [
+  { value: "p25-c4fm", label: "P25 C4FM" },
+  { value: "p25-cqpsk", label: "P25 CQPSK" },
+];
+
+type ConnState = "connecting" | "open" | "closed";
+
+export function Mixer() {
+  const cfg = useShared(selectClientConfig);
+  const activeCalls = useShared((s) => s.activeCalls);
+  const [devices, setDevices] = useState<SpectrumDevice[]>([]);
+  const [selected, setSelected] = useState<string | null>(null);
+  const [conn, setConn] = useState<ConnState>("closed");
+  const [latest, setLatest] = useState<MixerFrame | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const [proto, setProto] = useState<string>(() => prefs.mixerProto());
+  const [offsetKHz, setOffsetKHz] = useState<number>(() =>
+    prefs.mixerOffsetKHz(),
+  );
+  const [hold, setHold] = useState<boolean>(() => prefs.mixerHold());
+
+  const rawRef = useRef<HTMLCanvasElement | null>(null);
+  const tunedRef = useRef<HTMLCanvasElement | null>(null);
+
+  useEffect(() => {
+    let cancel = false;
+    (async () => {
+      try {
+        const list = await fetchSpectrumDevices(cfg);
+        if (cancel) return;
+        setDevices(list);
+        setError(null);
+        if (selected == null) {
+          const def = defaultSymbolDevice(list);
+          if (def) setSelected(def.serial);
+        }
+      } catch (e) {
+        if (cancel) return;
+        setError(e instanceof Error ? e.message : String(e));
+      }
+    })();
+    return () => {
+      cancel = true;
+    };
+  }, [cfg, selected]);
+
+  const device = useMemo(
+    () => devices.find((d) => d.serial === selected) ?? null,
+    [devices, selected],
+  );
+
+  // Follow the newest active call on this SDR (unless Hold is on), exactly
+  // like the Tuning panel — so the plot lands on a live channel.
+  const followOffsetKHz = useMemo(() => {
+    if (!device) return null;
+    const mine = activeCalls.filter(
+      (c) => c.device_serial === selected && !c.ended_at,
+    );
+    if (mine.length === 0) return null;
+    const newest = mine.reduce((a, b) => (b.started_at > a.started_at ? b : a));
+    return (newest.grant.frequency_hz - device.center_hz) / 1000;
+  }, [activeCalls, device, selected]);
+
+  useEffect(() => {
+    if (hold || followOffsetKHz == null) return;
+    setOffsetKHz((cur) =>
+      Math.abs(cur - followOffsetKHz) < 0.05 ? cur : followOffsetKHz,
+    );
+  }, [hold, followOffsetKHz]);
+
+  const maxOffsetKHz = device ? device.sample_rate_hz / 2000 : 1500;
+  const clampedOffsetKHz = Math.max(
+    -maxOffsetKHz,
+    Math.min(maxOffsetKHz, offsetKHz),
+  );
+
+  useEffect(() => {
+    prefs.setMixerOffsetKHz(offsetKHz);
+  }, [offsetKHz]);
+  useEffect(() => {
+    prefs.setMixerHold(hold);
+  }, [hold]);
+  useEffect(() => {
+    prefs.setMixerProto(proto);
+  }, [proto]);
+
+  useEffect(() => {
+    if (!selected) return;
+    setLatest(null);
+    renderFftLine(rawRef.current, null, 0, null);
+    renderFftLine(tunedRef.current, null, 0, 0);
+
+    const stream = openMixerStream(cfg, {
+      serial: selected,
+      proto,
+      offset: Math.round(clampedOffsetKHz * 1000),
+      onFrame: (f) => {
+        setLatest(f);
+        renderFftLine(
+          rawRef.current,
+          f.raw_bins,
+          f.sample_rate_hz,
+          f.carrier_offset_hz,
+        );
+        renderFftLine(tunedRef.current, f.tuned_bins, f.sample_rate_hz, 0);
+      },
+      onStatus: setConn,
+    });
+    return () => stream.close();
+  }, [cfg, selected, proto, clampedOffsetKHz]);
+
+  const centerHz = device?.center_hz ?? latest?.center_hz ?? null;
+  const viewHz = centerHz != null ? centerHz + clampedOffsetKHz * 1000 : null;
+
+  const tuningLabel = useMemo(() => {
+    if (viewHz == null) return "";
+    const off =
+      clampedOffsetKHz === 0
+        ? "centre"
+        : `${clampedOffsetKHz >= 0 ? "+" : ""}${clampedOffsetKHz.toFixed(3).replace(/\.?0+$/, "")} kHz`;
+    const head = `${(viewHz / 1e6).toFixed(4)} MHz (${off})`;
+    if (!latest) return `${head} · waiting for receiver…`;
+    const span = latest.sample_rate_hz / 1000;
+    return `${head} · ±${(span / 2).toFixed(1)} kHz span · carrier ${latest.carrier_offset_hz.toFixed(0)} Hz`;
+  }, [latest, viewHz, clampedOffsetKHz]);
+
+  return (
+    <div className="space-y-3">
+      <header className="flex flex-wrap items-center justify-between gap-3">
+        <h2 className="text-xl font-semibold">Mixer</h2>
+        <div className="flex items-center gap-2 text-xs">
+          <span className="text-muted">SDR:</span>
+          <select
+            className="bg-surface border border-border rounded px-2 py-1"
+            value={selected ?? ""}
+            onChange={(e) => setSelected(e.target.value || null)}
+            disabled={devices.length === 0}
+          >
+            {devices.length === 0 && <option value="">No SDRs available</option>}
+            {devices.map((d) => (
+              <option key={d.serial} value={d.serial}>
+                {d.serial} · {d.role}
+              </option>
+            ))}
+          </select>
+          <ConnPill state={conn} />
+        </div>
+      </header>
+
+      {error && (
+        <div className="rounded border border-red-700/40 bg-red-900/20 text-red-200 text-xs px-3 py-2">
+          {error}
+        </div>
+      )}
+
+      <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-xs">
+        <label className="flex items-center gap-2">
+          <span className="text-muted">Mode</span>
+          <select
+            className="bg-surface border border-border rounded px-2 py-1"
+            value={proto}
+            onChange={(e) => setProto(e.target.value)}
+            aria-label="Demodulation mode"
+          >
+            {PROTOS.map((p) => (
+              <option key={p.value} value={p.value}>
+                {p.label}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <TuningControls
+          centerHz={centerHz}
+          maxOffsetKHz={maxOffsetKHz}
+          offsetKHz={clampedOffsetKHz}
+          onOffsetChange={(khz) => {
+            setHold(true);
+            setOffsetKHz(khz);
+          }}
+          hold={hold}
+          onHoldChange={setHold}
+          followingActive={followOffsetKHz != null}
+          onCentre={() => {
+            setHold(true);
+            setOffsetKHz(0);
+          }}
+        />
+      </div>
+
+      <div className="font-mono text-xs text-muted">{tuningLabel || "—"}</div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-3">
+        <figure className="rounded border border-border bg-black overflow-hidden">
+          <figcaption className="px-2 py-1 text-xs text-muted border-b border-border">
+            Raw mixer — carrier at residual offset (amber marker)
+          </figcaption>
+          <canvas
+            ref={rawRef}
+            width={PLOT_W}
+            height={PLOT_H}
+            className="block w-full"
+            style={{ height: PLOT_H }}
+            aria-label="Raw mixer spectrum — channel baseband before carrier recovery"
+          />
+        </figure>
+        <figure className="rounded border border-border bg-black overflow-hidden">
+          <figcaption className="px-2 py-1 text-xs text-muted border-b border-border">
+            Tuned mixer — carrier pulled to centre
+          </figcaption>
+          <canvas
+            ref={tunedRef}
+            width={PLOT_W}
+            height={PLOT_H}
+            className="block w-full"
+            style={{ height: PLOT_H }}
+            aria-label="Tuned mixer spectrum — channel baseband after carrier recovery"
+          />
+        </figure>
+      </div>
+
+      <div className="text-[11px] text-muted">
+        Channel-baseband power spectrum off the live receiver (OP25's Raw /
+        Tuned Mixer). <strong>Raw</strong> shows the carrier where its
+        residual frequency offset leaves it — the amber line marks the
+        loop's carrier-offset estimate. <strong>Tuned</strong> re-mixes that
+        same window by the estimate, so a locked receiver snaps the carrier
+        onto the centre (0&nbsp;Hz) line. A raw peak that sits off-centre and
+        a tuned peak at centre is a healthy lock; a tuned peak still off
+        centre means the loop hasn't acquired. Dial the <em>Offset</em> onto
+        an active channel and pick the <em>Mode</em> that matches the site.
+      </div>
+    </div>
+  );
+}
+
+// dbToY maps a dBFS magnitude to a canvas Y coordinate: DB_CEIL at the top
+// (y=0), DB_FLOOR at the bottom. Out-of-range clamps to the edges.
+function dbToY(db: number, height: number): number {
+  let t = (db - DB_FLOOR) / (DB_CEIL - DB_FLOOR);
+  if (t < 0) t = 0;
+  else if (t > 1) t = 1;
+  return (1 - t) * height;
+}
+
+// renderFftLine draws one FFT power-vs-frequency trace. bins are dBFS,
+// FFT-shifted (index 0 = -sampleRate/2, centre = DC). A dim vertical line
+// marks DC; markerHz (when non-null) draws an amber marker at that
+// frequency — used to flag the carrier offset on the raw plot. A null
+// bins blanks the plot (device change / no data yet).
+function renderFftLine(
+  canvas: HTMLCanvasElement | null,
+  bins: number[] | null,
+  sampleRateHz: number,
+  markerHz: number | null,
+) {
+  if (!canvas) return;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return;
+  const width = canvas.width;
+  const height = canvas.height;
+
+  ctx.fillStyle = "#000";
+  ctx.fillRect(0, 0, width, height);
+
+  // Horizontal dB grid every 20 dB.
+  ctx.strokeStyle = "rgba(255, 255, 255, 0.08)";
+  ctx.lineWidth = 1;
+  for (let db = DB_CEIL; db >= DB_FLOOR; db -= 20) {
+    const y = Math.round(dbToY(db, height)) + 0.5;
+    ctx.beginPath();
+    ctx.moveTo(0, y);
+    ctx.lineTo(width, y);
+    ctx.stroke();
+  }
+
+  // Centre (0 Hz) reference line.
+  const cx = Math.round(width / 2) + 0.5;
+  ctx.strokeStyle = "rgba(148, 163, 184, 0.35)";
+  ctx.beginPath();
+  ctx.moveTo(cx, 0);
+  ctx.lineTo(cx, height);
+  ctx.stroke();
+
+  // Carrier-offset marker (amber) on the raw plot.
+  if (markerHz != null && markerHz !== 0 && sampleRateHz > 0) {
+    const ratio = markerHz / sampleRateHz + 0.5;
+    if (ratio >= 0 && ratio <= 1) {
+      const mx = Math.round(ratio * width) + 0.5;
+      ctx.strokeStyle = "rgba(251, 191, 36, 0.8)";
+      ctx.beginPath();
+      ctx.moveTo(mx, 0);
+      ctx.lineTo(mx, height);
+      ctx.stroke();
+    }
+  }
+
+  if (!bins || bins.length === 0) return;
+
+  const trace = () => {
+    ctx.beginPath();
+    for (let x = 0; x < width; x++) {
+      const srcIdx = Math.floor((x * bins.length) / width);
+      const y = dbToY(bins[srcIdx], height);
+      if (x === 0) ctx.moveTo(x, y);
+      else ctx.lineTo(x, y);
+    }
+  };
+
+  // Subtle fill under the curve.
+  trace();
+  ctx.lineTo(width, height);
+  ctx.lineTo(0, height);
+  ctx.closePath();
+  ctx.fillStyle = "rgba(52, 211, 153, 0.12)";
+  ctx.fill();
+
+  // Trace stroke on top.
+  trace();
+  ctx.strokeStyle = "#34d399";
+  ctx.lineWidth = 2;
+  ctx.stroke();
+}
+
+function ConnPill({ state }: { state: ConnState }) {
+  if (state === "open") return <span className="pill-ok">live</span>;
+  if (state === "connecting")
+    return <span className="pill-warn">connecting</span>;
+  return <span className="pill-err">offline</span>;
+}

--- a/web/src/panels/Plots.tsx
+++ b/web/src/panels/Plots.tsx
@@ -2,6 +2,7 @@ import { useNavigate, useParams } from "react-router-dom";
 import { Constellation } from "./Constellation";
 import { SymbolScope } from "./SymbolScope";
 import { EyeDiagram } from "./EyeDiagram";
+import { Mixer } from "./Mixer";
 import { Tuning } from "./Tuning";
 import { Histogram } from "./Histogram";
 
@@ -18,6 +19,7 @@ const TABS = [
   { key: "constellation", label: "Constellation", el: <Constellation /> },
   { key: "symbols", label: "Symbol scope", el: <SymbolScope /> },
   { key: "eye", label: "Eye diagram", el: <EyeDiagram /> },
+  { key: "mixer", label: "Mixer", el: <Mixer /> },
   { key: "tuning", label: "Tuning", el: <Tuning /> },
   { key: "histogram", label: "Histogram", el: <Histogram /> },
 ] as const;

--- a/web/src/store/prefs.ts
+++ b/web/src/store/prefs.ts
@@ -34,6 +34,9 @@ const LS_KEYS = {
   tuningOffsetKHz: "gt.tuning.offsetKHz",
   tuningHold: "gt.tuning.hold",
   tuningProto: "gt.tuning.proto",
+  mixerOffsetKHz: "gt.mixer.offsetKHz",
+  mixerHold: "gt.mixer.hold",
+  mixerProto: "gt.mixer.proto",
   histogramOffsetKHz: "gt.histogram.offsetKHz",
   histogramHold: "gt.histogram.hold",
   histogramProto: "gt.histogram.proto",
@@ -309,6 +312,29 @@ export const prefs = {
   },
   setTuningProto(p: string) {
     writeLS(LS_KEYS.tuningProto, p);
+  },
+
+  // Mixer plot view options (channel-baseband FFT — raw vs tuned).
+  mixerOffsetKHz(): number {
+    const raw = readLS(LS_KEYS.mixerOffsetKHz);
+    if (raw === null) return 0;
+    const n = Number(raw);
+    return Number.isFinite(n) ? n : 0;
+  },
+  setMixerOffsetKHz(khz: number) {
+    writeLS(LS_KEYS.mixerOffsetKHz, String(khz));
+  },
+  mixerHold(): boolean {
+    return readLS(LS_KEYS.mixerHold) === "1";
+  },
+  setMixerHold(on: boolean) {
+    writeLS(LS_KEYS.mixerHold, on ? "1" : "0");
+  },
+  mixerProto(): string {
+    return readLS(LS_KEYS.mixerProto) ?? "p25-c4fm";
+  },
+  setMixerProto(p: string) {
+    writeLS(LS_KEYS.mixerProto, p);
   },
 
   // Symbol-histogram panel view options.


### PR DESCRIPTION
OP25's "Plots" view has six tabs: Spectrum, Constellation, Symbol,
Datascope/Eye, Raw Mixer and Tuned Mixer. GopherTrunk already had the
first four (plus Tuning and Histogram); the two graphical Mixer spectra
were the only missing pieces — the Tuning panel covered the numeric loop
state but not the FFT view.

Add a Mixer plot that renders the channel-baseband power spectrum two
ways: "raw" (the channelized baseband as the receiver first sees it, with
a marker on the carrier-offset estimate) and "tuned" (the same window
re-mixed by that estimate so a locked loop pulls the carrier onto centre).
Comparing the two shows the carrier-recovery correction at a glance.

The tuned view is reconstructed from the receiver's own carrier_offset_hz
(no new receiver tap), so it works uniformly for C4FM and CQPSK. The FFT
math is factored into a shared spectrum.PowerDB helper reused by the
wideband Spectrum waterfall. The plot runs the existing symbolscope engine
over a new WS /api/v1/diag/mixer endpoint, mirroring the symbol stream.

- dsp/spectrum: extract PowerDB (windowed-FFT dBFS) helper
- symbolscope: mixer accumulator + Engine MixerEmit option
- api: MixerFrame, MixerProvider, WS /api/v1/diag/mixer handler
- cmd/gophertrunk: mixerProvider over the iqtap broker
- web: api/mixer.ts client, Mixer.tsx panel, Plots tab + /mixer route
- docs/mixer.md + plots.md + CHANGELOG; Go + web tests

https://claude.ai/code/session_01X7FnAuF7r1JwEnKcqQ6J8G