### PR TITLE
Add DMR Tier III trunk autoconfiguration (LCN band-plan learning)

### DIFF
--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -30,6 +30,7 @@ import (
 	"github.com/MattCheramie/GopherTrunk/internal/scanner/ccdecoder"
 	"github.com/MattCheramie/GopherTrunk/internal/scanner/cchunt"
 	"github.com/MattCheramie/GopherTrunk/internal/scanner/conventional"
+	"github.com/MattCheramie/GopherTrunk/internal/scanner/dmrlcn"
 	"github.com/MattCheramie/GopherTrunk/internal/scanner/widebandt2"
 
 	adsbbeast "github.com/MattCheramie/GopherTrunk/internal/radio/adsb/beast"
@@ -381,6 +382,11 @@ type Daemon struct {
 	controlLOOffsetHz float64
 	convScan          *conventional.Scanner
 	widebandT2        []*widebandt2.Engine
+	// dmrLearners holds one DMR LCN autoconfig learner per wideband DMR
+	// Tier III control channel whose system ships without a dmr_band_plan.
+	// Each watches grants + RF onsets to learn the LCN→frequency plan and
+	// hot-swaps it into the running control channel. See internal/scanner/dmrlcn.
+	dmrLearners []*dmrlcn.Learner
 	// virtualVoiceTuners holds one VirtualTuner per voice tap on a
 	// wideband dongle. Each implements both trunking.Tuner (the voice
 	// pool calls SetCenterFreq on bind) and composer.IQSource (the
@@ -1449,6 +1455,16 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 			// serial so a single-channel decoder pinned to the same dongle
 			// Subscribes instead of opening a second stream (#547).
 			d.iqPrimary[entry.Info.Serial] = true
+
+			// DMR Tier III trunk autoconfiguration: for any control channel
+			// whose system has no dmr_band_plan, attach a learner that
+			// discovers the LCN→frequency plan from grants + RF onsets and
+			// hot-swaps it into the running control channel. Requires the
+			// dongle's iqtap broker (for onset detection + decode-confirmation
+			// taps); without it the learner can't run.
+			if br := d.iqBrokers[entry.Info.Serial]; br != nil {
+				d.attachDMRLearners(devCfg, channels, eng, br, effectiveRate, log)
+			}
 			// Virtual voice taps for this dongle are built earlier by
 			// buildVirtualVoiceTuners (before the voice pool and composer
 			// are constructed) so trunked grants inside the IQ window have
@@ -2250,6 +2266,16 @@ func (d *Daemon) Run(ctx context.Context) error {
 		name := fmt.Sprintf("widebandt2-%d", i)
 		d.spawn(runCtx, name, false, func(ctx context.Context) error {
 			return eng.Run(ctx)
+		})
+	}
+	// DMR Tier III autoconfig learners — one per wideband DMR control
+	// channel without a configured band plan. Non-essential: a learner
+	// failure must never bring down the trunking pipeline.
+	for i, lr := range d.dmrLearners {
+		lr := lr
+		name := fmt.Sprintf("dmrlcn-%d", i)
+		d.spawn(runCtx, name, false, func(ctx context.Context) error {
+			return lr.Run(ctx)
 		})
 	}
 	// POCSAG paging receivers — one per configured paging.pocsag
@@ -3103,6 +3129,87 @@ func (d *Daemon) spawn(ctx context.Context, name string, essential bool, fn func
 		}
 		d.log.Warn("daemon: component exited with error", "component", name, "err", err)
 	}()
+}
+
+// attachDMRLearners constructs a dmrlcn.Learner for each DMR Tier III
+// control channel on a wideband dongle whose system ships without a
+// dmr_band_plan. Each learner gets the dongle's iqtap broker (onset
+// detection + decode-confirmation taps), the bus, and a hot-swap binding
+// to the running control channel. When the daemon owns a config writer,
+// the learned plan is persisted so it survives a restart. Systems that
+// already carry a band plan are skipped — the operator's plan wins.
+func (d *Daemon) attachDMRLearners(devCfg config.DeviceConfig, channels []widebandt2.ChannelConfig, eng *widebandt2.Engine, br *iqtap.Broker, sampleRate uint32, log *slog.Logger) {
+	systemsByName := make(map[string]trunking.System, len(d.systems))
+	for _, s := range d.systems {
+		systemsByName[s.Name] = s
+	}
+
+	// Control-channel carriers are always on, so exclude them from onset
+	// detection to avoid phantom edges.
+	var exclude []uint32
+	for _, ch := range channels {
+		if sys, ok := systemsByName[ch.SystemName]; ok && isControlChannel(sys, ch.FrequencyHz) {
+			exclude = append(exclude, ch.FrequencyHz)
+		}
+	}
+
+	for _, ch := range channels {
+		sys, ok := systemsByName[ch.SystemName]
+		if !ok || sys.Protocol != trunking.ProtocolDMR {
+			continue
+		}
+		if sys.DMRBandPlan != nil {
+			continue // operator-configured plan is authoritative
+		}
+		if !isControlChannel(sys, ch.FrequencyHz) {
+			continue
+		}
+		cc := eng.DMRTier3ControlChannel(ch.FrequencyHz)
+		if cc == nil {
+			continue
+		}
+		sysName := sys.Name
+		persist := func(res dmrlcn.FitResult) {
+			if res.Linear == nil || d.writer == nil {
+				return
+			}
+			err := d.writer.WriteDMRLearnedBandPlan(sysName, config.DMRLinearBandPlanConfig{
+				BaseHz:    res.Linear.BaseHz,
+				SpacingHz: res.Linear.SpacingHz,
+				Offset:    res.Linear.Offset,
+			})
+			if err != nil {
+				log.Warn("dmrlcn: persisting learned band plan failed", "system", sysName, "err", err)
+				return
+			}
+			log.Info("dmrlcn: learned band plan written to config", "system", sysName)
+		}
+		learner := dmrlcn.New(dmrlcn.Options{
+			Log:          log,
+			Bus:          d.bus,
+			Broker:       br,
+			CenterHz:     devCfg.CenterFreqHz,
+			SampleRateHz: sampleRate,
+			System:       sysName,
+			SetResolver:  cc.SetResolver,
+			Persist:      persist,
+			ExcludeHz:    exclude,
+		})
+		d.dmrLearners = append(d.dmrLearners, learner)
+		log.Info("dmrlcn: DMR Tier III autoconfiguration enabled (no dmr_band_plan configured)",
+			"system", sysName, "cc_freq_hz", ch.FrequencyHz)
+	}
+}
+
+// isControlChannel reports whether freqHz is one of the system's declared
+// control_channels.
+func isControlChannel(sys trunking.System, freqHz uint32) bool {
+	for _, cc := range sys.ControlChannels {
+		if cc == freqHz {
+			return true
+		}
+	}
+	return false
 }
 
 // buildVirtualVoiceTuners spins up one wbvoice.VirtualTuner per voice tap

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -614,9 +614,21 @@ trunking:
     # DMR Tier III trunked system. A T3 voice-grant CSBK references its
     # traffic channel by a 7-bit Logical Channel Number (LCN), never an
     # absolute frequency, so the decoder needs a `dmr_band_plan` to map
-    # LCN → downlink Hz. WITHOUT it every voice grant is dropped with
-    # decode.error stage=no-bandplan (control-channel monitoring still
-    # works). Provide exactly one of `linear` or `table`.
+    # LCN → downlink Hz. Provide exactly one of `linear` or `table`.
+    #
+    # AUTOCONFIGURATION: if you OMIT `dmr_band_plan` on a `protocol: dmr`
+    # system that is monitored by a `role: wideband` dongle, GopherTrunk
+    # learns the plan automatically — it watches the LCNs the control
+    # channel grants, detects which RF carriers key up in response across
+    # the dongle's IQ band, confirms each is a live DMR burst, and fits
+    # the base frequency + channel spacing for the whole LCN enumeration.
+    # The learned plan is applied live (previously-dropped grants start
+    # following voice) and, when the daemon was started with a -config
+    # file, written back here so it survives a restart. A configured
+    # `dmr_band_plan` disables learning (your plan is authoritative).
+    # Without either a plan or a wideband dongle, T3 voice grants are
+    # dropped with decode.error stage=no-bandplan (CC monitoring still
+    # works).
     - name: "Example-DMR-T3"
       protocol: dmr
       control_channels:

--- a/internal/config/dmrbandplan_writeback.go
+++ b/internal/config/dmrbandplan_writeback.go
@@ -1,0 +1,131 @@
+package config
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"strconv"
+
+	"gopkg.in/yaml.v3"
+)
+
+// WriteDMRLearnedBandPlan persists a learned DMR Tier III linear band
+// plan into the named trunking system, preserving comments and unrelated
+// content the way WritePatch does. It is used by the DMR LCN autoconfig
+// learner so a plan discovered at runtime survives a restart. The system
+// must already exist in the file and must not already carry a
+// dmr_band_plan (the learner only runs when none is configured); both
+// conditions are enforced so the writeback never clobbers an operator's
+// hand-authored plan. The mtime guard refuses to overwrite an external
+// edit, matching WritePatch.
+func (w *Writer) WriteDMRLearnedBandPlan(systemName string, lin DMRLinearBandPlanConfig) error {
+	if w == nil {
+		return fmt.Errorf("config: no writer wired (daemon started without a -config file)")
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	info, err := os.Stat(w.path)
+	if err != nil {
+		return fmt.Errorf("config: writer: stat: %w", err)
+	}
+	if info.ModTime().UnixNano() != w.knownMtime {
+		return fmt.Errorf("config: %s was modified externally; reload the daemon before persisting a learned band plan", w.path)
+	}
+
+	data, err := os.ReadFile(w.path)
+	if err != nil {
+		return fmt.Errorf("config: writer: read: %w", err)
+	}
+
+	var doc yaml.Node
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return fmt.Errorf("config: writer: parse node: %w", err)
+	}
+	root := docRoot(&doc)
+	if root == nil {
+		return fmt.Errorf("config: writer: empty config document")
+	}
+
+	sysNode, err := findSystemNode(root, systemName)
+	if err != nil {
+		return err
+	}
+	if mappingChild(sysNode, "dmr_band_plan") != nil {
+		return fmt.Errorf("config: system %q already has a dmr_band_plan; refusing to overwrite", systemName)
+	}
+	setMappingPath(sysNode, []string{"dmr_band_plan", "linear", "base_hz"}, scalarUint(uint64(lin.BaseHz)))
+	setMappingPath(sysNode, []string{"dmr_band_plan", "linear", "spacing_hz"}, scalarUint(uint64(lin.SpacingHz)))
+	setMappingPath(sysNode, []string{"dmr_band_plan", "linear", "offset"}, scalarInt(int64(lin.Offset)))
+
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+	if err := enc.Encode(&doc); err != nil {
+		return fmt.Errorf("config: writer: encode: %w", err)
+	}
+	if err := enc.Close(); err != nil {
+		return err
+	}
+
+	// Validate the merged result before committing.
+	var merged Config
+	if err := yaml.Unmarshal(buf.Bytes(), &merged); err != nil {
+		return fmt.Errorf("config: writer: re-parse: %w", err)
+	}
+	if err := merged.Validate(); err != nil {
+		return fmt.Errorf("config: writer: validate: %w", err)
+	}
+
+	if err := writeFileAtomic(w.path, buf.Bytes(), 0o644); err != nil {
+		return err
+	}
+	if info, err := os.Stat(w.path); err == nil {
+		w.knownMtime = info.ModTime().UnixNano()
+	}
+	return nil
+}
+
+// findSystemNode walks root → trunking → systems[] and returns the
+// mapping node whose `name` equals systemName.
+func findSystemNode(root *yaml.Node, systemName string) (*yaml.Node, error) {
+	trunking := mappingChild(root, "trunking")
+	if trunking == nil {
+		return nil, fmt.Errorf("config: no trunking section to persist band plan into")
+	}
+	systems := mappingChild(trunking, "systems")
+	if systems == nil || systems.Kind != yaml.SequenceNode {
+		return nil, fmt.Errorf("config: no trunking.systems sequence")
+	}
+	for _, el := range systems.Content {
+		if el.Kind != yaml.MappingNode {
+			continue
+		}
+		name := mappingChild(el, "name")
+		if name != nil && name.Value == systemName {
+			return el, nil
+		}
+	}
+	return nil, fmt.Errorf("config: system %q not found in %s", systemName, "trunking.systems")
+}
+
+// mappingChild returns the value node for key in a mapping node, or nil.
+func mappingChild(m *yaml.Node, key string) *yaml.Node {
+	if m == nil || m.Kind != yaml.MappingNode {
+		return nil
+	}
+	for i := 0; i+1 < len(m.Content); i += 2 {
+		if m.Content[i].Value == key {
+			return m.Content[i+1]
+		}
+	}
+	return nil
+}
+
+func scalarUint(v uint64) *yaml.Node {
+	return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!int", Value: strconv.FormatUint(v, 10)}
+}
+
+func scalarInt(v int64) *yaml.Node {
+	return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!int", Value: strconv.FormatInt(v, 10)}
+}

--- a/internal/config/dmrbandplan_writeback_test.go
+++ b/internal/config/dmrbandplan_writeback_test.go
@@ -1,0 +1,107 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+const wbTestConfig = `# top comment
+trunking:
+  systems:
+    # the regional DMR system
+    - name: "Regional DMR"
+      protocol: dmr
+      control_channels:
+        - 851037500   # primary CC
+    - name: "Other P25"
+      protocol: p25
+      control_channels:
+        - 770000000
+`
+
+func writeTemp(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func TestWriteDMRLearnedBandPlanPreservesComments(t *testing.T) {
+	p := writeTemp(t, wbTestConfig)
+	w, err := NewWriter(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := w.WriteDMRLearnedBandPlan("Regional DMR", DMRLinearBandPlanConfig{
+		BaseHz: 851_037_500, SpacingHz: 12_500, Offset: 1,
+	}); err != nil {
+		t.Fatalf("WriteDMRLearnedBandPlan: %v", err)
+	}
+
+	out, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	for _, want := range []string{"# top comment", "# the regional DMR system", "# primary CC", "dmr_band_plan", "base_hz: 851037500", "spacing_hz: 12500", "offset: 1"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("output missing %q:\n%s", want, got)
+		}
+	}
+
+	// The plan must parse and resolve under the same shape the runtime uses.
+	var cfg Config
+	if err := yaml.Unmarshal(out, &cfg); err != nil {
+		t.Fatal(err)
+	}
+	var found *SystemConfig
+	for i := range cfg.Trunking.Systems {
+		if cfg.Trunking.Systems[i].Name == "Regional DMR" {
+			found = &cfg.Trunking.Systems[i]
+		}
+	}
+	if found == nil || found.DMRBandPlan == nil || found.DMRBandPlan.Linear == nil {
+		t.Fatalf("learned plan not present after round-trip: %+v", found)
+	}
+	if found.DMRBandPlan.Linear.SpacingHz != 12_500 || found.DMRBandPlan.Linear.BaseHz != 851_037_500 {
+		t.Errorf("linear = %+v", found.DMRBandPlan.Linear)
+	}
+}
+
+func TestWriteDMRLearnedBandPlanRefusesExisting(t *testing.T) {
+	body := wbTestConfig + "      dmr_band_plan:\n        linear:\n          base_hz: 1\n          spacing_hz: 12500\n          offset: 1\n"
+	// Append the plan under the second system instead to keep indentation
+	// valid; simpler: craft a config where the system already has a plan.
+	body = `trunking:
+  systems:
+    - name: "Has Plan"
+      protocol: dmr
+      control_channels: [851037500]
+      dmr_band_plan:
+        linear:
+          base_hz: 851037500
+          spacing_hz: 12500
+          offset: 1
+`
+	p := writeTemp(t, body)
+	w, _ := NewWriter(p)
+	err := w.WriteDMRLearnedBandPlan("Has Plan", DMRLinearBandPlanConfig{BaseHz: 1, SpacingHz: 12_500, Offset: 1})
+	if err == nil || !strings.Contains(err.Error(), "already has") {
+		t.Fatalf("expected refusal for existing plan, got %v", err)
+	}
+}
+
+func TestWriteDMRLearnedBandPlanUnknownSystem(t *testing.T) {
+	p := writeTemp(t, wbTestConfig)
+	w, _ := NewWriter(p)
+	if err := w.WriteDMRLearnedBandPlan("Nope", DMRLinearBandPlanConfig{BaseHz: 1, SpacingHz: 12_500, Offset: 1}); err == nil {
+		t.Fatal("expected error for unknown system")
+	}
+}

--- a/internal/events/bus.go
+++ b/internal/events/bus.go
@@ -198,6 +198,23 @@ const (
 	// the (de-whitened) payload bytes, plus any LoRaWAN MAC fields decoded
 	// from it. Surfaced over SSE / WS for the live LoRa panel.
 	KindLoRaFrame Kind = "lora.frame"
+
+	// KindDMRGrantObserved fires for every DMR Tier III voice-grant CSBK
+	// the control channel decodes, published BEFORE the LCN is resolved to
+	// a downlink frequency. It is emitted in addition to (not instead of)
+	// KindGrant on success / the no-bandplan KindDecodeError on failure, so
+	// the DMR LCN autoconfig learner (internal/scanner/dmrlcn) can observe
+	// the granted LCN even when no band plan is configured yet — which is
+	// exactly the case it is trying to fix. Payload is DMRGrantObserved.
+	KindDMRGrantObserved Kind = "dmr.grant.observed"
+
+	// KindDMRBandPlanLearned fires once the DMR LCN autoconfig learner has
+	// fit a band plan for a system from observed (LCN, frequency) pairs.
+	// The learner has already hot-swapped the resolver into the running
+	// control channel by the time this is published; subscribers use it for
+	// logging, operator surfacing, and optional config writeback. Payload is
+	// DMRBandPlanLearned.
+	KindDMRBandPlanLearned Kind = "dmr.bandplan.learned"
 )
 
 // Stage names a particular FEC / parser checkpoint inside a protocol
@@ -227,6 +244,46 @@ const (
 type DecodeError struct {
 	Protocol string
 	Stage    Stage
+}
+
+// DMRGrantObserved is the payload published with KindDMRGrantObserved.
+// It carries the raw fields of a DMR Tier III voice-grant CSBK before
+// the LCN is resolved to a frequency, so the LCN autoconfig learner can
+// correlate the granted LCN with the RF carrier that subsequently keys
+// up. Timeslot uses the raw CSBK encoding (0 = TS1, 1 = TS2).
+type DMRGrantObserved struct {
+	System    string
+	ColorCode uint8
+	LCN       uint8
+	Timeslot  uint8
+	GroupID   uint32
+	SourceID  uint32
+	CCFreqHz  uint32 // control-channel frequency that decoded this grant
+	At        time.Time
+}
+
+// DMRBandPlanLearned is the payload published with KindDMRBandPlanLearned.
+// A linear plan sets BaseHz/SpacingHz/Offset with a nil Table; an
+// irregular plan leaves the linear fields zero and populates Table. The
+// payload mirrors trunking.DMRBandPlan with primitive fields so the
+// events package stays free of a trunking import (the learner translates
+// its trunking-shaped fit result into this on publish).
+type DMRBandPlanLearned struct {
+	System     string
+	BaseHz     uint32
+	SpacingHz  uint32
+	Offset     int8
+	Table      []DMRBandPlanLCN // non-nil only for an irregular (table) plan
+	NumPairs   int
+	Confidence float64
+	ResidualHz uint32
+}
+
+// DMRBandPlanLCN is one explicit LCN→downlink-frequency entry in a
+// learned irregular (table) band plan.
+type DMRBandPlanLCN struct {
+	LCN    uint8
+	FreqHz uint32
 }
 
 type Event struct {

--- a/internal/radio/dmr/tier3/control.go
+++ b/internal/radio/dmr/tier3/control.go
@@ -2,6 +2,7 @@ package tier3
 
 import (
 	"log/slog"
+	"sync"
 	"time"
 
 	"github.com/MattCheramie/GopherTrunk/internal/events"
@@ -40,11 +41,18 @@ func (s LockState) LockedNAC() uint16         { return s.SystemID }
 // logged at debug and ignored — they're noise from the hunter's
 // perspective.
 type ControlChannel struct {
-	bus              *events.Bus
-	log              *slog.Logger
-	systemName       string
-	freqHz           uint32
-	resolver         Resolver
+	bus        *events.Bus
+	log        *slog.Logger
+	systemName string
+	freqHz     uint32
+
+	// resolver maps a granted LCN to its downlink frequency. It is read
+	// inline on the IQ-pump goroutine (resolveLCN) and may be swapped at
+	// runtime by the DMR LCN autoconfig learner from another goroutine, so
+	// access is guarded by resolverMu.
+	resolverMu sync.RWMutex
+	resolver   Resolver
+
 	now              func() time.Time
 	interleavedVoice bool
 	locked           bool
@@ -168,6 +176,22 @@ func (c *ControlChannel) handleCSBK(cc uint8, csbk CSBK) {
 // call identity — both slots of a 12.5 kHz carrier carry independent
 // calls.
 func (c *ControlChannel) publishGrant(cc, lcn, slot uint8, group, source uint32, serviceOptions uint8) (uint32, bool) {
+	// Observe the granted LCN before resolution so the autoconfig learner
+	// sees it even when no band plan is configured yet (the very case it
+	// exists to fix). Additive: success/no-bandplan behaviour is unchanged.
+	c.bus.Publish(events.Event{
+		Kind: events.KindDMRGrantObserved,
+		Payload: events.DMRGrantObserved{
+			System:    c.systemName,
+			ColorCode: cc,
+			LCN:       lcn,
+			Timeslot:  slot,
+			GroupID:   group,
+			SourceID:  source,
+			CCFreqHz:  c.freqHz,
+			At:        c.now(),
+		},
+	})
 	freq, ok := c.resolveLCN(lcn)
 	if !ok {
 		return 0, false
@@ -212,8 +236,30 @@ func (c *ControlChannel) publishPVGrant(cc uint8, g PVGrant) {
 		"lcn", g.LCN, "ts", g.Timeslot, "freq_hz", freq)
 }
 
+// SetResolver atomically swaps the LCN→frequency resolver. The DMR
+// Tier III LCN autoconfig learner calls this once it has fit a band
+// plan, so grants that were previously dropped with stage=no-bandplan
+// start resolving immediately. Safe to call from a goroutine other than
+// the one driving Process / IngestBurst.
+func (c *ControlChannel) SetResolver(r Resolver) {
+	c.resolverMu.Lock()
+	c.resolver = r
+	c.resolverMu.Unlock()
+}
+
+// HasResolver reports whether a band-plan resolver is currently set. The
+// autoconfig learner uses it to decide whether learning is still needed.
+func (c *ControlChannel) HasResolver() bool {
+	c.resolverMu.RLock()
+	defer c.resolverMu.RUnlock()
+	return c.resolver != nil
+}
+
 func (c *ControlChannel) resolveLCN(lcn uint8) (uint32, bool) {
-	if c.resolver == nil {
+	c.resolverMu.RLock()
+	resolver := c.resolver
+	c.resolverMu.RUnlock()
+	if resolver == nil {
 		c.log.Debug("dmr/tier3: grant dropped, no band-plan resolver configured", "lcn", lcn)
 		c.bus.Publish(events.Event{
 			Kind:    events.KindDecodeError,
@@ -221,7 +267,7 @@ func (c *ControlChannel) resolveLCN(lcn uint8) (uint32, bool) {
 		})
 		return 0, false
 	}
-	freq, err := c.resolver.Frequency(lcn)
+	freq, err := resolver.Frequency(lcn)
 	if err != nil {
 		c.log.Debug("dmr/tier3: band-plan miss", "lcn", lcn, "err", err)
 		c.bus.Publish(events.Event{

--- a/internal/radio/dmr/tier3/control_test.go
+++ b/internal/radio/dmr/tier3/control_test.go
@@ -327,3 +327,152 @@ func TestControlChannelMarkLost(t *testing.T) {
 		t.Fatal("no cc.lost")
 	}
 }
+
+// collectGrantObserved drains the bus until it sees a KindDMRGrantObserved
+// (returning it) or the deadline elapses. sawGrant/sawDecodeErr report
+// whether a resolved grant / no-bandplan decode error were also seen.
+func collectGrantObserved(t *testing.T, sub *events.Subscription) (obs events.DMRGrantObserved, sawObs, sawGrant, sawDecodeErr bool) {
+	t.Helper()
+	deadline := time.After(time.Second)
+	for {
+		select {
+		case ev := <-sub.C:
+			switch ev.Kind {
+			case events.KindDMRGrantObserved:
+				obs = ev.Payload.(events.DMRGrantObserved)
+				sawObs = true
+			case events.KindGrant:
+				sawGrant = true
+			case events.KindDecodeError:
+				if de, ok := ev.Payload.(events.DecodeError); ok && de.Stage == events.StageNoBandPlan {
+					sawDecodeErr = true
+				}
+			}
+		case <-deadline:
+			return
+		}
+	}
+}
+
+func TestControlChannelEmitsGrantObservedWithResolver(t *testing.T) {
+	bus := events.NewBus(16)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{
+		Bus:         bus,
+		SystemName:  "ObsSys",
+		FrequencyHz: 851_012_500,
+		Resolver:    LinearBandPlan{BaseHz: 866_000_000, SpacingHz: 25_000, Offset: 1},
+		Now:         func() time.Time { return time.Unix(1_700_000_001, 0).UTC() },
+	})
+	// dst 0x123456, src 0xABCDEF, byte 7 = 0x88 → TS2, LCN 8.
+	csbk := CSBK{LB: true, Opcode: OpTVGrant, Payload: [8]byte{0x00, 0x12, 0x34, 0x56, 0xAB, 0xCD, 0xEF, 0x88}}
+	cc.IngestBurst(burstWithCSBK(csbk), dmr.SlotType{ColorCode: 5, DataType: dmr.DTCSBK})
+
+	obs, sawObs, sawGrant, _ := collectGrantObserved(t, sub)
+	if !sawObs {
+		t.Fatal("no KindDMRGrantObserved published")
+	}
+	if !sawGrant {
+		t.Error("resolved grant (KindGrant) was not also published")
+	}
+	if obs.System != "ObsSys" || obs.ColorCode != 5 || obs.LCN != 8 || obs.Timeslot != 1 {
+		t.Errorf("obs = %+v", obs)
+	}
+	if obs.GroupID != 0x123456 || obs.SourceID != 0xABCDEF {
+		t.Errorf("group/source = %X/%X", obs.GroupID, obs.SourceID)
+	}
+	if obs.CCFreqHz != 851_012_500 {
+		t.Errorf("CCFreqHz = %d, want 851_012_500", obs.CCFreqHz)
+	}
+	if obs.At.Unix() != 1_700_000_001 {
+		t.Errorf("At = %v, want injected Now", obs.At)
+	}
+}
+
+func TestControlChannelEmitsGrantObservedWithoutResolver(t *testing.T) {
+	bus := events.NewBus(16)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	// nil Resolver: the LCN must still escape via KindDMRGrantObserved, and
+	// the existing no-bandplan decode error must still fire.
+	cc := New(Options{Bus: bus, SystemName: "ObsSys", FrequencyHz: 851_012_500})
+	csbk := CSBK{LB: true, Opcode: OpTVGrant, Payload: [8]byte{0x00, 0x00, 0x10, 0x00, 0x00, 0x20, 0x00, 0x0B}}
+	cc.IngestBurst(burstWithCSBK(csbk), dmr.SlotType{ColorCode: 2, DataType: dmr.DTCSBK})
+
+	obs, sawObs, sawGrant, sawDecodeErr := collectGrantObserved(t, sub)
+	if !sawObs {
+		t.Fatal("no KindDMRGrantObserved published with nil resolver")
+	}
+	if obs.LCN != 0x0B {
+		t.Errorf("LCN = %d, want 11", obs.LCN)
+	}
+	if sawGrant {
+		t.Error("KindGrant published despite nil resolver")
+	}
+	if !sawDecodeErr {
+		t.Error("no-bandplan decode error not published")
+	}
+}
+
+func TestControlChannelSetResolverHotSwap(t *testing.T) {
+	bus := events.NewBus(16)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	// Start with no resolver: the first grant drops with no-bandplan.
+	cc := New(Options{Bus: bus, SystemName: "SwapSys", FrequencyHz: 851_012_500})
+	if cc.HasResolver() {
+		t.Fatal("HasResolver true before SetResolver")
+	}
+	csbk := CSBK{LB: true, Opcode: OpTVGrant, Payload: [8]byte{0x00, 0x00, 0x10, 0x00, 0x00, 0x20, 0x00, 0x08}}
+	cc.IngestBurst(burstWithCSBK(csbk), dmr.SlotType{ColorCode: 1, DataType: dmr.DTCSBK})
+	if _, _, sawGrant, sawDecodeErr := collectGrantObserved(t, sub); sawGrant || !sawDecodeErr {
+		t.Fatalf("pre-swap: grant=%v decodeErr=%v, want grant=false decodeErr=true", sawGrant, sawDecodeErr)
+	}
+
+	// Hot-swap a learned resolver; the same grant now resolves.
+	cc.SetResolver(LinearBandPlan{BaseHz: 866_000_000, SpacingHz: 25_000, Offset: 1})
+	if !cc.HasResolver() {
+		t.Fatal("HasResolver false after SetResolver")
+	}
+	cc.IngestBurst(burstWithCSBK(csbk), dmr.SlotType{ColorCode: 1, DataType: dmr.DTCSBK})
+	_, _, sawGrant, _ := collectGrantObserved(t, sub)
+	if !sawGrant {
+		t.Fatal("post-swap: grant not resolved after SetResolver")
+	}
+}
+
+func TestControlChannelSetResolverConcurrent(t *testing.T) {
+	// Race detector: one goroutine ingests grants (reads resolver) while
+	// another swaps it. go test -race must stay clean.
+	bus := events.NewBus(256)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	go func() {
+		for range sub.C { // drain so Publish never blocks the producer
+		}
+	}()
+
+	cc := New(Options{Bus: bus, SystemName: "RaceSys", FrequencyHz: 851_012_500})
+	csbk := CSBK{LB: true, Opcode: OpTVGrant, Payload: [8]byte{0x00, 0x00, 0x10, 0x00, 0x00, 0x20, 0x00, 0x08}}
+	burst := burstWithCSBK(csbk)
+
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < 2000; i++ {
+			cc.IngestBurst(burst, dmr.SlotType{ColorCode: 1, DataType: dmr.DTCSBK})
+		}
+		close(done)
+	}()
+	for i := 0; i < 2000; i++ {
+		cc.SetResolver(LinearBandPlan{BaseHz: 866_000_000, SpacingHz: 25_000, Offset: 1})
+	}
+	<-done
+	sub.Close()
+}

--- a/internal/radio/dmr/tier3/vendor_test.go
+++ b/internal/radio/dmr/tier3/vendor_test.go
@@ -59,28 +59,34 @@ func TestMotorolaVendorGrantEmitted(t *testing.T) {
 	}
 	cc.IngestBurst(burstWithCSBK(csbk), dmr.SlotType{ColorCode: 1, DataType: dmr.DTCSBK})
 
-	select {
-	case ev := <-sub.C:
-		if ev.Kind != events.KindGrant {
-			t.Fatalf("kind = %s, want grant", ev.Kind)
+	// publishGrant emits KindDMRGrantObserved before resolution; skip past
+	// it (and any other noise) to the resolved KindGrant.
+	deadline := time.After(time.Second)
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind != events.KindGrant {
+				continue
+			}
+			g := ev.Payload.(trunking.Grant)
+			if g.GroupID != 0x1234 || g.SourceID != 0x5678 {
+				t.Errorf("grant ids = tg %d src %d", g.GroupID, g.SourceID)
+			}
+			if g.FrequencyHz != 462_550_000 {
+				t.Errorf("grant freq = %d, want 462550000", g.FrequencyHz)
+			}
+			if g.Protocol != "dmr-tier3" {
+				t.Errorf("grant protocol = %q", g.Protocol)
+			}
+			// tvGrantPayload masks byte 7 to lcn&0x7F, so the slot bit is
+			// clear → CSBK TS1 → 1-based Timeslot 1.
+			if g.Timeslot != 1 {
+				t.Errorf("grant Timeslot = %d, want 1 (TS1)", g.Timeslot)
+			}
+			return
+		case <-deadline:
+			t.Fatal("no grant event from a Motorola vendor CSBK")
 		}
-		g := ev.Payload.(trunking.Grant)
-		if g.GroupID != 0x1234 || g.SourceID != 0x5678 {
-			t.Errorf("grant ids = tg %d src %d", g.GroupID, g.SourceID)
-		}
-		if g.FrequencyHz != 462_550_000 {
-			t.Errorf("grant freq = %d, want 462550000", g.FrequencyHz)
-		}
-		if g.Protocol != "dmr-tier3" {
-			t.Errorf("grant protocol = %q", g.Protocol)
-		}
-		// tvGrantPayload masks byte 7 to lcn&0x7F, so the slot bit is
-		// clear → CSBK TS1 → 1-based Timeslot 1.
-		if g.Timeslot != 1 {
-			t.Errorf("grant Timeslot = %d, want 1 (TS1)", g.Timeslot)
-		}
-	case <-time.After(time.Second):
-		t.Fatal("no grant event from a Motorola vendor CSBK")
 	}
 }
 

--- a/internal/scanner/dmrlcn/confirm.go
+++ b/internal/scanner/dmrlcn/confirm.go
@@ -1,0 +1,133 @@
+package dmrlcn
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/tuner"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/dmr"
+	dmrrx "github.com/MattCheramie/GopherTrunk/internal/radio/dmr/receiver"
+	"github.com/MattCheramie/GopherTrunk/internal/sdr/iqtap"
+)
+
+// Confirmer decides whether the carrier at freqHz is a live DMR burst —
+// the decode-confirmation step that turns a temporal grant/onset
+// coincidence into a trusted (LCN, frequency) pair. confirmed reports
+// whether DMR was decoded; weight expresses the confidence (a voice
+// burst weighs more than a data burst).
+type Confirmer interface {
+	Confirm(ctx context.Context, freqHz uint32) (confirmed bool, weight float64)
+}
+
+// confirm.go's DMR receiver constants mirror the wideband Tier III path
+// (internal/scanner/widebandt2) so a probe tap decodes identically to the
+// dongle's primary control-channel tap.
+const (
+	confirmNarrowbandHz = 48_000.0
+	confirmDeviationHz  = 1944.0
+	confirmClockGain    = 0.025
+	confirmSyncTol      = 2 // dibit errors tolerated in a 24-dibit sync match
+)
+
+// ddcConfirmer confirms a candidate carrier by briefly DDC-tapping the
+// shared wideband IQ stream at the carrier's offset and running the DMR
+// receiver until it sees a sync word (or the probe times out). It holds
+// no long-lived state; each Confirm call subscribes, taps, and tears
+// down.
+type ddcConfirmer struct {
+	broker       *iqtap.Broker
+	centerHz     uint32
+	sampleRateHz uint32
+	guardFrac    float64
+	timeout      time.Duration
+	minSyncs     int
+}
+
+func newDDCConfirmer(broker *iqtap.Broker, centerHz, sampleRateHz uint32, guardFrac float64) *ddcConfirmer {
+	if guardFrac <= 0 {
+		guardFrac = 0.05
+	}
+	return &ddcConfirmer{
+		broker:       broker,
+		centerHz:     centerHz,
+		sampleRateHz: sampleRateHz,
+		guardFrac:    guardFrac,
+		timeout:      700 * time.Millisecond,
+		minSyncs:     1,
+	}
+}
+
+// Confirm taps the carrier and returns true once it decodes at least
+// minSyncs DMR sync words within the probe timeout. weight is 1.0 when a
+// voice sync is seen, 0.8 for a data-only burst, 0.7 otherwise.
+func (c *ddcConfirmer) Confirm(ctx context.Context, freqHz uint32) (bool, float64) {
+	offset := float64(freqHz) - float64(c.centerHz)
+	bank := tuner.NewDDCBank(float64(c.sampleRateHz), confirmNarrowbandHz, c.guardFrac)
+
+	var (
+		matches           []dmr.Match
+		sawVoice, sawData bool
+		syncCount         int
+		detector          = dmr.NewSyncDetector(nil, confirmSyncTol)
+	)
+	rx := dmrrx.New(dmrrx.Options{
+		SampleRateHz: confirmNarrowbandHz,
+		DeviationHz:  confirmDeviationHz,
+		ClockGain:    confirmClockGain,
+		DibitSink: dmr.DibitSink(func(d []uint8, base int) {
+			matches, _ = detector.Process(matches[:0], d, base)
+			for _, m := range matches {
+				syncCount++
+				name := m.Pattern.Name
+				switch {
+				case strings.Contains(name, "Voice"):
+					sawVoice = true
+				case strings.Contains(name, "Data"):
+					sawData = true
+				}
+			}
+		}),
+	})
+	if err := bank.AddTap(offset, func(out []complex64) {
+		if len(out) > 0 {
+			rx.Process(out)
+		}
+	}); err != nil {
+		// Carrier is outside the dongle's usable IQ window — can't probe it.
+		return false, 0
+	}
+
+	sub := c.broker.Subscribe()
+	defer sub.Close()
+
+	deadline := time.NewTimer(c.timeout)
+	defer deadline.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return false, 0
+		case <-deadline.C:
+			return false, 0
+		case chunk, ok := <-sub.C:
+			if !ok {
+				return false, 0
+			}
+			bank.Process(chunk)
+			if syncCount >= c.minSyncs {
+				return true, syncWeight(sawVoice, sawData)
+			}
+		}
+	}
+}
+
+func syncWeight(voice, data bool) float64 {
+	switch {
+	case voice:
+		return 1.0
+	case data:
+		return 0.8
+	default:
+		return 0.7
+	}
+}

--- a/internal/scanner/dmrlcn/confirm_test.go
+++ b/internal/scanner/dmrlcn/confirm_test.go
@@ -1,0 +1,93 @@
+package dmrlcn
+
+import (
+	"context"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/sdr"
+	"github.com/MattCheramie/GopherTrunk/internal/sdr/iqtap"
+)
+
+// loopDevice is a minimal sdr.Device that streams a fixed IQ buffer on
+// repeat until its context cancels — enough to exercise the confirmer's
+// DDC-tap + DMR-decode path through a real iqtap.Broker. The end-to-end
+// "synthetic DMR confirms" case lives with real/known-good captures (the
+// IQ→dibit→sync chain itself is covered by the dmr receiver + sync
+// package tests); here we pin the confirmer's control flow: it rejects
+// noise, rejects out-of-band carriers, and honours its timeout.
+type loopDevice struct {
+	buf   []complex64
+	chunk int
+}
+
+func (d *loopDevice) Info() sdr.Info             { return sdr.Info{Serial: "loop"} }
+func (d *loopDevice) SetCenterFreq(uint32) error { return nil }
+func (d *loopDevice) SetSampleRate(uint32) error { return nil }
+func (d *loopDevice) SetGain(int) error          { return nil }
+func (d *loopDevice) SetPPM(int) error           { return nil }
+func (d *loopDevice) SetBiasTee(bool) error      { return nil }
+func (d *loopDevice) Close() error               { return nil }
+
+func (d *loopDevice) StreamIQ(ctx context.Context) (<-chan []complex64, error) {
+	out := make(chan []complex64)
+	go func() {
+		defer close(out)
+		pos := 0
+		for {
+			end := pos + d.chunk
+			if end > len(d.buf) {
+				pos, end = 0, d.chunk
+			}
+			cp := make([]complex64, end-pos)
+			copy(cp, d.buf[pos:end])
+			pos = end
+			select {
+			case <-ctx.Done():
+				return
+			case out <- cp:
+			}
+		}
+	}()
+	return out, nil
+}
+
+func newLoopBroker(buf []complex64, chunk int) *iqtap.Broker {
+	return iqtap.New(&loopDevice{buf: buf, chunk: chunk}, 0, nil)
+}
+
+func TestDDCConfirmerRejectsNoise(t *testing.T) {
+	rng := rand.New(rand.NewSource(7))
+	noise := make([]complex64, 48_000)
+	for i := range noise {
+		noise[i] = complex64(complex(rng.Float64()*2-1, rng.Float64()*2-1) * 0.001)
+	}
+	br := newLoopBroker(noise, 1024)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if _, err := br.StreamIQ(ctx); err != nil {
+		t.Fatalf("StreamIQ: %v", err)
+	}
+
+	c := newDDCConfirmer(br, 450_000_000, uint32(confirmNarrowbandHz), 0.05)
+	c.timeout = 300 * time.Millisecond
+	if ok, _ := c.Confirm(ctx, 450_000_000); ok {
+		t.Error("noise should not confirm as DMR")
+	}
+}
+
+func TestDDCConfirmerRejectsOutOfBand(t *testing.T) {
+	br := newLoopBroker(make([]complex64, 4096), 1024)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if _, err := br.StreamIQ(ctx); err != nil {
+		t.Fatalf("StreamIQ: %v", err)
+	}
+	// Carrier 1.5 MHz off a 2.4 MS/s center sits outside the usable band.
+	c := newDDCConfirmer(br, 851_500_000, 2_400_000, 0.05)
+	c.timeout = 200 * time.Millisecond
+	if ok, _ := c.Confirm(ctx, 853_000_000); ok {
+		t.Error("out-of-band carrier should not confirm")
+	}
+}

--- a/internal/scanner/dmrlcn/correlate.go
+++ b/internal/scanner/dmrlcn/correlate.go
@@ -1,0 +1,135 @@
+package dmrlcn
+
+import (
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+)
+
+// Default correlation window: a carrier keys up shortly after the grant
+// CSBK is decoded on the control channel. A small negative floor absorbs
+// clock skew between the grant timestamp and the onset detector's frame
+// clock.
+const (
+	defaultMinDelay = -100 * time.Millisecond
+	defaultMaxDelay = 700 * time.Millisecond
+	defaultGrantTTL = 2 * time.Second
+)
+
+// Candidate is an unconfirmed (LCN, frequency) pairing the correlator
+// produced from a grant/onset coincidence. It still needs decode
+// confirmation before it is trusted as a fit Pair.
+type Candidate struct {
+	LCN    uint8
+	FreqHz uint32
+	Grant  events.DMRGrantObserved
+}
+
+// pendingGrant is a recently observed grant awaiting an onset.
+type pendingGrant struct {
+	obs     events.DMRGrantObserved
+	matched bool
+}
+
+// correlator pairs granted LCNs with the RF carriers that subsequently
+// key up. It only commits a pairing when the onset is unambiguous: the
+// window must contain grants for exactly one LCN. When several different
+// LCNs were granted near the same instant the onset is dropped rather
+// than guessed — repeated observations eventually yield an unambiguous
+// match for each LCN. It owns no goroutine and is not safe for concurrent
+// use; the learner drives it from a single loop.
+type correlator struct {
+	minDelay time.Duration
+	maxDelay time.Duration
+	ttl      time.Duration
+	grants   []pendingGrant
+}
+
+func newCorrelator(minDelay, maxDelay, ttl time.Duration) *correlator {
+	if minDelay == 0 {
+		minDelay = defaultMinDelay
+	}
+	if maxDelay == 0 {
+		maxDelay = defaultMaxDelay
+	}
+	if ttl == 0 {
+		ttl = defaultGrantTTL
+	}
+	return &correlator{minDelay: minDelay, maxDelay: maxDelay, ttl: ttl}
+}
+
+// addGrant records an observed grant for later onset matching.
+func (c *correlator) addGrant(obs events.DMRGrantObserved) {
+	c.grants = append(c.grants, pendingGrant{obs: obs})
+}
+
+// matchOnset returns the candidate pairing for an onset, or ok=false when
+// no grant matches or the match is ambiguous (grants for more than one
+// LCN fall in the window). Matched grants for the chosen LCN are consumed
+// so they don't re-match a later onset.
+func (c *correlator) matchOnset(o CarrierOnset) (Candidate, bool) {
+	var (
+		lcn      uint8
+		grant    events.DMRGrantObserved
+		idxs     []int
+		haveLCN  bool
+		multiLCN bool
+	)
+	for i := range c.grants {
+		g := &c.grants[i]
+		if g.matched {
+			continue
+		}
+		d := o.At.Sub(g.obs.At)
+		if d < c.minDelay || d > c.maxDelay {
+			continue
+		}
+		switch {
+		case !haveLCN:
+			lcn, grant, haveLCN = g.obs.LCN, g.obs, true
+			idxs = append(idxs, i)
+		case g.obs.LCN == lcn:
+			idxs = append(idxs, i)
+		default:
+			multiLCN = true
+		}
+	}
+	if !haveLCN || multiLCN {
+		return Candidate{}, false
+	}
+	for _, i := range idxs {
+		c.grants[i].matched = true
+	}
+	return Candidate{LCN: lcn, FreqHz: o.FreqHz, Grant: grant}, true
+}
+
+// expire drops grants older than the TTL relative to now. Called
+// periodically so the pending slice doesn't grow without bound.
+func (c *correlator) expire(now time.Time) {
+	if len(c.grants) == 0 {
+		return
+	}
+	kept := c.grants[:0]
+	for _, g := range c.grants {
+		if g.matched {
+			continue
+		}
+		if now.Sub(g.obs.At) > c.ttl {
+			continue
+		}
+		kept = append(kept, g)
+	}
+	c.grants = kept
+}
+
+// pendingCount reports how many unexpired, unmatched grants are queued
+// (test helper).
+func (c *correlator) pendingCount() int {
+	n := 0
+	for _, g := range c.grants {
+		if !g.matched {
+			n++
+		}
+	}
+	return n
+}

--- a/internal/scanner/dmrlcn/correlate_test.go
+++ b/internal/scanner/dmrlcn/correlate_test.go
@@ -1,0 +1,88 @@
+package dmrlcn
+
+import (
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+)
+
+func grantAt(lcn uint8, at time.Time) events.DMRGrantObserved {
+	return events.DMRGrantObserved{System: "S", LCN: lcn, GroupID: uint32(lcn) * 10, At: at}
+}
+
+func TestCorrelatorSingleMatch(t *testing.T) {
+	c := newCorrelator(0, 0, 0)
+	base := time.Unix(1_700_000_000, 0)
+	c.addGrant(grantAt(5, base))
+
+	// Onset 300 ms after the grant — inside [−100ms, 700ms].
+	cand, ok := c.matchOnset(CarrierOnset{FreqHz: 851_125_000, At: base.Add(300 * time.Millisecond)})
+	if !ok {
+		t.Fatal("expected a match")
+	}
+	if cand.LCN != 5 || cand.FreqHz != 851_125_000 {
+		t.Errorf("candidate = %+v", cand)
+	}
+	// The grant is consumed, so a second onset finds nothing.
+	if _, ok := c.matchOnset(CarrierOnset{FreqHz: 851_125_000, At: base.Add(350 * time.Millisecond)}); ok {
+		t.Error("matched grant should have been consumed")
+	}
+}
+
+func TestCorrelatorOnsetOutsideWindow(t *testing.T) {
+	c := newCorrelator(0, 0, 0)
+	base := time.Unix(1_700_000_000, 0)
+	c.addGrant(grantAt(5, base))
+
+	// Too late (> 700 ms) and too early (before the grant) → no match.
+	if _, ok := c.matchOnset(CarrierOnset{FreqHz: 1, At: base.Add(2 * time.Second)}); ok {
+		t.Error("onset 2s after grant should not match")
+	}
+	if _, ok := c.matchOnset(CarrierOnset{FreqHz: 1, At: base.Add(-time.Second)}); ok {
+		t.Error("onset before grant should not match")
+	}
+}
+
+func TestCorrelatorAmbiguousMultiLCNDropped(t *testing.T) {
+	c := newCorrelator(0, 0, 0)
+	base := time.Unix(1_700_000_000, 0)
+	c.addGrant(grantAt(5, base))
+	c.addGrant(grantAt(9, base.Add(50*time.Millisecond)))
+
+	// Two different LCNs in the window → ambiguous → no commit.
+	if _, ok := c.matchOnset(CarrierOnset{FreqHz: 851_125_000, At: base.Add(300 * time.Millisecond)}); ok {
+		t.Error("ambiguous multi-LCN window should not match")
+	}
+}
+
+func TestCorrelatorSameLCNTwiceIsUnambiguous(t *testing.T) {
+	c := newCorrelator(0, 0, 0)
+	base := time.Unix(1_700_000_000, 0)
+	// Same LCN granted twice near one onset — the LCN is still unambiguous.
+	c.addGrant(grantAt(7, base))
+	c.addGrant(grantAt(7, base.Add(40*time.Millisecond)))
+
+	cand, ok := c.matchOnset(CarrierOnset{FreqHz: 852_000_000, At: base.Add(200 * time.Millisecond)})
+	if !ok || cand.LCN != 7 {
+		t.Fatalf("expected unambiguous LCN 7 match, got %+v ok=%v", cand, ok)
+	}
+}
+
+func TestCorrelatorSpuriousOnsetNoGrant(t *testing.T) {
+	c := newCorrelator(0, 0, 0)
+	if _, ok := c.matchOnset(CarrierOnset{FreqHz: 851_000_000, At: time.Now()}); ok {
+		t.Error("onset with no pending grant should not match")
+	}
+}
+
+func TestCorrelatorExpire(t *testing.T) {
+	c := newCorrelator(0, 0, 500*time.Millisecond)
+	base := time.Unix(1_700_000_000, 0)
+	c.addGrant(grantAt(1, base))
+	c.addGrant(grantAt(2, base.Add(2*time.Second)))
+	c.expire(base.Add(2 * time.Second))
+	if c.pendingCount() != 1 {
+		t.Errorf("pendingCount = %d, want 1 after expiring the stale grant", c.pendingCount())
+	}
+}

--- a/internal/scanner/dmrlcn/dmrlcn.go
+++ b/internal/scanner/dmrlcn/dmrlcn.go
@@ -1,0 +1,318 @@
+package dmrlcn
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/dmr/tier3"
+	"github.com/MattCheramie/GopherTrunk/internal/sdr/iqtap"
+)
+
+const (
+	// maxConcurrentProbes bounds simultaneous decode-confirmation taps so
+	// the learner never spins up an unbounded number of DDC receivers.
+	maxConcurrentProbes = 2
+	// candidateBuffer is the depth of the onset→probe handoff queue.
+	candidateBuffer = 4
+	// expireInterval is how often stale pending grants are swept.
+	expireInterval = time.Second
+)
+
+// Options configures a Learner.
+type Options struct {
+	Log    *slog.Logger
+	Bus    *events.Bus
+	Broker *iqtap.Broker
+
+	// CenterHz / SampleRateHz describe the wideband dongle the broker
+	// fans out. Required.
+	CenterHz     uint32
+	SampleRateHz uint32
+	GuardFrac    float64
+
+	// System is the trunking system name this learner serves; only
+	// KindDMRGrantObserved events whose System matches are consumed.
+	System string
+
+	// SetResolver is bound to the running tier3.ControlChannel's
+	// SetResolver so a learned plan applies live. Required for live
+	// application; nil is allowed (learn + publish only).
+	SetResolver func(tier3.Resolver)
+
+	// Persist, if non-nil, is invoked once with the locked fit so the
+	// caller can write the plan back to config.
+	Persist func(FitResult)
+
+	// Confirmer overrides the decode-confirmation strategy. When nil a
+	// real DDC-tap confirmer is built from Broker/CenterHz/SampleRateHz.
+	Confirmer Confirmer
+
+	// FitOptions overrides the band-plan fitter tuning (zero = defaults).
+	FitOptions FitOptions
+
+	// ExcludeHz lists frequencies the onset detector must never report —
+	// typically the always-on control-channel carriers on this dongle, so
+	// they don't generate phantom onset edges.
+	ExcludeHz []uint32
+
+	Now func() time.Time
+}
+
+// Learner discovers a DMR Tier III system's LCN→frequency band plan from
+// observed voice grants and the RF carriers that key up in response, then
+// hot-swaps the learned plan into the running control channel. One
+// Learner serves one wideband dongle / system. Run owns its goroutines
+// and returns when its context is cancelled.
+type Learner struct {
+	log         *slog.Logger
+	bus         *events.Bus
+	broker      *iqtap.Broker
+	system      string
+	setResolver func(tier3.Resolver)
+	persist     func(FitResult)
+	confirmer   Confirmer
+	fitOpts     FitOptions
+	onsetCfg    onsetConfig
+	now         func() time.Time
+
+	corr *correlator
+
+	mu     sync.Mutex
+	pairs  []Pair
+	locked bool
+}
+
+// New constructs a Learner. Broker, CenterHz and SampleRateHz are
+// required.
+func New(opts Options) *Learner {
+	log := opts.Log
+	if log == nil {
+		log = slog.Default()
+	}
+	now := opts.Now
+	if now == nil {
+		now = time.Now
+	}
+	guard := opts.GuardFrac
+	if guard <= 0 {
+		guard = 0.05
+	}
+
+	confirmer := opts.Confirmer
+	if confirmer == nil && opts.Broker != nil {
+		confirmer = newDDCConfirmer(opts.Broker, opts.CenterHz, opts.SampleRateHz, guard)
+	}
+
+	oc := onsetConfig{
+		CenterHz:     opts.CenterHz,
+		SampleRateHz: opts.SampleRateHz,
+		GuardFrac:    guard,
+		Exclude:      opts.ExcludeHz,
+		Now:          now,
+	}
+
+	return &Learner{
+		log:         log.With("subsystem", "dmrlcn", "system", opts.System),
+		bus:         opts.Bus,
+		broker:      opts.Broker,
+		system:      opts.System,
+		setResolver: opts.SetResolver,
+		persist:     opts.Persist,
+		confirmer:   confirmer,
+		fitOpts:     opts.FitOptions,
+		onsetCfg:    oc,
+		now:         now,
+		corr:        newCorrelator(0, 0, 0),
+	}
+}
+
+// Run drives the learner until ctx is cancelled. It subscribes to the
+// wideband IQ broker (onset detection) and the event bus (grant
+// observations), schedules bounded decode-confirmation probes, and
+// applies the band plan once the fitter locks. Run never returns an
+// error; failures are logged and the learner degrades to a no-op.
+func (l *Learner) Run(ctx context.Context) error {
+	if l.bus == nil || l.broker == nil {
+		l.log.Warn("dmrlcn: missing bus or broker; learner disabled")
+		<-ctx.Done()
+		return nil
+	}
+
+	iqSub := l.broker.Subscribe()
+	defer iqSub.Close()
+	busSub := l.bus.Subscribe()
+	defer busSub.Close()
+
+	candidates := make(chan Candidate, candidateBuffer)
+	results := make(chan Pair, maxConcurrentProbes)
+
+	detector := newOnsetDetector(l.onsetCfg, func(o CarrierOnset) {
+		if l.isLocked() {
+			return
+		}
+		cand, ok := l.corr.matchOnset(o)
+		if !ok {
+			return
+		}
+		select {
+		case candidates <- cand:
+		default:
+			// Probe queue full; this LCN will be observed again.
+		}
+	})
+
+	// Probe workers: confirm candidates off the main loop so a ~700 ms
+	// DDC tap never stalls IQ pumping into the onset detector.
+	var wg sync.WaitGroup
+	for i := 0; i < maxConcurrentProbes; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case cand, ok := <-candidates:
+					if !ok {
+						return
+					}
+					if l.isLocked() {
+						continue
+					}
+					pair, ok := l.confirmCandidate(ctx, cand)
+					if !ok {
+						continue
+					}
+					select {
+					case results <- pair:
+					case <-ctx.Done():
+						return
+					}
+				}
+			}
+		}()
+	}
+
+	ticker := time.NewTicker(expireInterval)
+	defer ticker.Stop()
+
+	l.log.Info("dmrlcn: learning DMR band plan", "center_hz", l.onsetCfg.CenterHz, "sample_rate_hz", l.onsetCfg.SampleRateHz)
+
+	for {
+		select {
+		case <-ctx.Done():
+			wg.Wait()
+			return nil
+		case chunk, ok := <-iqSub.C:
+			if !ok {
+				wg.Wait()
+				return nil
+			}
+			if !l.isLocked() {
+				detector.Process(chunk)
+			}
+		case ev := <-busSub.C:
+			if ev.Kind != events.KindDMRGrantObserved {
+				continue
+			}
+			obs, ok := ev.Payload.(events.DMRGrantObserved)
+			if !ok || obs.System != l.system {
+				continue
+			}
+			l.corr.addGrant(obs)
+		case pair := <-results:
+			l.handlePair(pair)
+		case <-ticker.C:
+			l.corr.expire(l.now())
+		}
+	}
+}
+
+// confirmCandidate runs decode-confirmation on a candidate and returns
+// the trusted fit Pair. With no confirmer configured it accepts the
+// candidate at a reduced weight (temporal-only evidence).
+func (l *Learner) confirmCandidate(ctx context.Context, cand Candidate) (Pair, bool) {
+	if l.confirmer == nil {
+		return Pair{LCN: cand.LCN, FreqHz: cand.FreqHz, Weight: 0.4}, true
+	}
+	ok, weight := l.confirmer.Confirm(ctx, cand.FreqHz)
+	if !ok {
+		return Pair{}, false
+	}
+	return Pair{LCN: cand.LCN, FreqHz: cand.FreqHz, Weight: weight}, true
+}
+
+// handlePair records a confirmed pair and re-runs the fitter, applying
+// and publishing the plan the first time it locks.
+func (l *Learner) handlePair(p Pair) {
+	l.mu.Lock()
+	if l.locked {
+		l.mu.Unlock()
+		return
+	}
+	l.pairs = append(l.pairs, p)
+	res, ok := FitBandPlan(l.pairs, l.fitOpts)
+	if !ok {
+		l.mu.Unlock()
+		return
+	}
+	l.locked = true
+	l.mu.Unlock()
+
+	l.apply(res)
+}
+
+// apply hot-swaps the learned resolver, publishes the learned event,
+// logs, and triggers optional persistence.
+func (l *Learner) apply(res FitResult) {
+	plan := res.BandPlan()
+	if l.setResolver != nil {
+		l.setResolver(tier3.ResolverFromPlan(plan))
+	}
+	if l.bus != nil {
+		l.bus.Publish(events.Event{Kind: events.KindDMRBandPlanLearned, Payload: l.learnedPayload(res)})
+	}
+	if res.Linear != nil {
+		l.log.Info("dmrlcn: band plan learned (linear)",
+			"base_hz", res.Linear.BaseHz, "spacing_hz", res.Linear.SpacingHz,
+			"offset", res.Linear.Offset, "pairs", res.NumPairs,
+			"confidence", res.Confidence, "residual_hz", res.ResidualHz)
+	} else {
+		l.log.Info("dmrlcn: band plan learned (table)",
+			"entries", len(res.Table), "pairs", res.NumPairs, "confidence", res.Confidence)
+	}
+	if l.persist != nil {
+		l.persist(res)
+	}
+}
+
+func (l *Learner) learnedPayload(res FitResult) events.DMRBandPlanLearned {
+	p := events.DMRBandPlanLearned{
+		System:     l.system,
+		NumPairs:   res.NumPairs,
+		Confidence: res.Confidence,
+		ResidualHz: res.ResidualHz,
+	}
+	if res.Linear != nil {
+		p.BaseHz = res.Linear.BaseHz
+		p.SpacingHz = res.Linear.SpacingHz
+		p.Offset = res.Linear.Offset
+	} else {
+		for _, e := range res.Table {
+			p.Table = append(p.Table, events.DMRBandPlanLCN{LCN: e.LCN, FreqHz: e.FreqHz})
+		}
+	}
+	return p
+}
+
+func (l *Learner) isLocked() bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.locked
+}
+
+// Locked reports whether the learner has committed a band plan.
+func (l *Learner) Locked() bool { return l.isLocked() }

--- a/internal/scanner/dmrlcn/dmrlcn_test.go
+++ b/internal/scanner/dmrlcn/dmrlcn_test.go
@@ -1,0 +1,137 @@
+package dmrlcn
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/dmr/tier3"
+)
+
+// stubConfirmer confirms any carrier (optionally only a configured set).
+type stubConfirmer struct {
+	weight float64
+	only   map[uint32]bool
+}
+
+func (s stubConfirmer) Confirm(_ context.Context, freqHz uint32) (bool, float64) {
+	if s.only != nil && !s.only[freqHz] {
+		return false, 0
+	}
+	w := s.weight
+	if w == 0 {
+		w = 1
+	}
+	return true, w
+}
+
+// feed drives one grant+onset coincidence through the learner's core
+// (correlator → confirm → fit), as Run would but synchronously.
+func (l *Learner) feed(t *testing.T, lcn uint8, freqHz uint32, at time.Time) {
+	t.Helper()
+	l.corr.addGrant(events.DMRGrantObserved{System: l.system, LCN: lcn, At: at})
+	cand, ok := l.corr.matchOnset(CarrierOnset{FreqHz: freqHz, At: at.Add(300 * time.Millisecond)})
+	if !ok {
+		return
+	}
+	pair, ok := l.confirmCandidate(context.Background(), cand)
+	if !ok {
+		return
+	}
+	l.handlePair(pair)
+}
+
+func TestLearnerLocksAndAppliesPlan(t *testing.T) {
+	bus := events.NewBus(32)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	var applied atomic.Pointer[tier3.Resolver]
+	var persisted atomic.Int32
+
+	l := New(Options{
+		Bus:          bus,
+		System:       "S",
+		CenterHz:     851_500_000,
+		SampleRateHz: 2_400_000,
+		Confirmer:    stubConfirmer{weight: 1},
+		SetResolver:  func(r tier3.Resolver) { applied.Store(&r) },
+		Persist:      func(FitResult) { persisted.Add(1) },
+	})
+
+	// Grid: base 851_000_000, spacing 12.5 kHz, offset 1.
+	base := time.Unix(1_700_000_000, 0)
+	for i, lcn := range []uint8{1, 2, 3, 4, 5} {
+		freq := uint32(851_000_000 + int(lcn-1)*12_500)
+		l.feed(t, lcn, freq, base.Add(time.Duration(i)*time.Second))
+	}
+
+	if !l.Locked() {
+		t.Fatal("learner did not lock after 5 confirmed pairs")
+	}
+	rp := applied.Load()
+	if rp == nil {
+		t.Fatal("SetResolver was not called")
+	}
+	// The applied resolver must resolve a known LCN to its grid frequency.
+	got, err := (*rp).Frequency(3)
+	if err != nil || got != 851_025_000 {
+		t.Errorf("applied resolver: Frequency(3) = %d, %v; want 851025000", got, err)
+	}
+	if persisted.Load() != 1 {
+		t.Errorf("persist called %d times, want 1", persisted.Load())
+	}
+
+	// A KindDMRBandPlanLearned event must have been published.
+	deadline := time.After(time.Second)
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind != events.KindDMRBandPlanLearned {
+				continue
+			}
+			p := ev.Payload.(events.DMRBandPlanLearned)
+			if p.System != "S" || p.SpacingHz != 12_500 || p.BaseHz != 851_000_000 {
+				t.Errorf("learned payload = %+v", p)
+			}
+			return
+		case <-deadline:
+			t.Fatal("no KindDMRBandPlanLearned event")
+		}
+	}
+}
+
+func TestLearnerStaysOpenBelowMinLCNs(t *testing.T) {
+	l := New(Options{
+		System:       "S",
+		CenterHz:     851_500_000,
+		SampleRateHz: 2_400_000,
+		Confirmer:    stubConfirmer{weight: 1},
+	})
+	base := time.Unix(1_700_000_000, 0)
+	for i, lcn := range []uint8{1, 2, 3} { // 3 < default MinLCNs (4)
+		l.feed(t, lcn, uint32(851_000_000+int(lcn-1)*12_500), base.Add(time.Duration(i)*time.Second))
+	}
+	if l.Locked() {
+		t.Fatal("learner locked below MinLCNs")
+	}
+}
+
+func TestLearnerRunStopsOnContextCancel(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	// No broker → Run takes the disabled path and blocks until ctx done.
+	l := New(Options{Bus: bus, System: "S", CenterHz: 851_500_000, SampleRateHz: 2_400_000})
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- l.Run(ctx) }()
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return after context cancel")
+	}
+}

--- a/internal/scanner/dmrlcn/fit.go
+++ b/internal/scanner/dmrlcn/fit.go
@@ -1,0 +1,369 @@
+// Package dmrlcn implements DMR Tier III trunk autoconfiguration: it
+// learns the LCN→downlink-frequency band plan of a trunked system from
+// observed voice grants (which carry only a Logical Channel Number) and
+// the RF carriers that key up in response, then hot-swaps the learned
+// plan into the running control channel.
+//
+// This file holds the pure band-plan fitter. Given a set of confirmed
+// (LCN, frequency) pairs it solves the regular base+spacing grid most
+// DMR Tier III sites use, snapping spacing to a known channel grid and
+// rejecting outliers; when the pairs don't fall on a regular grid it
+// falls back to an explicit per-LCN table. It performs no I/O and owns
+// no state, so it is exhaustively unit-testable in isolation.
+package dmrlcn
+
+import (
+	"math"
+	"sort"
+
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// Pair is one observed mapping from a Logical Channel Number to the
+// downlink frequency the system used for it. Weight expresses how much
+// the correlator trusts the observation — e.g. an embedded-LC match is
+// weighted higher than a bare energy-onset coincidence — and biases the
+// fitter's weighted-median estimates and confidence.
+type Pair struct {
+	LCN    uint8
+	FreqHz uint32
+	Weight float64
+}
+
+// FitOptions tunes FitBandPlan. The zero value is not valid; callers
+// should start from DefaultFitOptions and adjust.
+type FitOptions struct {
+	// MinLCNs is the number of distinct LCNs that must be confirmed
+	// before a plan (linear or table) is declared learned.
+	MinLCNs int
+	// SpacingGrids lists the channel spacings (Hz) the fitter will snap a
+	// linear estimate to, in any order.
+	SpacingGrids []uint32
+	// SpacingTolHz is how close the estimated spacing must be to a grid
+	// value to snap to it; beyond this the fit falls back to a table.
+	SpacingTolHz uint32
+	// ResidualTolHz is the largest |observed-predicted| frequency error a
+	// linear fit may carry after outlier rejection.
+	ResidualTolHz uint32
+}
+
+// fitOffset is the canonical LCN the emitted BaseHz is pinned to
+// (freq = BaseHz + (LCN-fitOffset)*SpacingHz). Offset is purely a
+// representation choice — the base absorbs any shift — so the fitter
+// always emits the common LCN-1-indexed convention.
+const fitOffset int8 = 1
+
+// DefaultFitOptions returns sensible defaults: at least 4 confirmed
+// LCNs, the standard DMR 6.25/12.5/25 kHz grids, ±600 Hz snap tolerance,
+// and a 1.5 kHz residual ceiling.
+func DefaultFitOptions() FitOptions {
+	return FitOptions{
+		MinLCNs:       4,
+		SpacingGrids:  []uint32{6250, 12500, 25000},
+		SpacingTolHz:  600,
+		ResidualTolHz: 1500,
+	}
+}
+
+// FitResult is the outcome of a fit. Exactly one of Linear / Table is
+// populated when ok is true: Linear for a regular base+spacing grid,
+// Table for an irregular layout. Confidence is in [0,1]; ResidualHz is
+// the worst |observed-predicted| error of an accepted linear fit (0 for
+// a table).
+type FitResult struct {
+	Linear     *trunking.DMRLinearBandPlan
+	Table      []trunking.DMRBandPlanTableEntry
+	Confidence float64
+	NumPairs   int // distinct LCNs the result is built from
+	ResidualHz uint32
+}
+
+// BandPlan renders the result as a trunking.DMRBandPlan, ready for
+// tier3.ResolverFromPlan or config writeback. Returns nil for an empty
+// result.
+func (r FitResult) BandPlan() *trunking.DMRBandPlan {
+	switch {
+	case r.Linear != nil:
+		lp := *r.Linear
+		return &trunking.DMRBandPlan{Linear: &lp}
+	case len(r.Table) > 0:
+		tbl := make([]trunking.DMRBandPlanTableEntry, len(r.Table))
+		copy(tbl, r.Table)
+		return &trunking.DMRBandPlan{Table: tbl}
+	default:
+		return nil
+	}
+}
+
+// point is one deduplicated LCN observation: the single best frequency
+// chosen for an LCN plus the total weight backing it.
+type point struct {
+	lcn    uint8
+	freqHz uint32
+	weight float64
+}
+
+// FitBandPlan attempts to fit a band plan to the observed pairs. It
+// returns ok=false (with a zero FitResult) until enough consistent
+// observations accumulate to meet opts.MinLCNs. A regular grid yields a
+// Linear plan; an irregular but well-populated layout yields a Table.
+func FitBandPlan(pairs []Pair, opts FitOptions) (FitResult, bool) {
+	opts = normalizeOptions(opts)
+
+	pts := aggregate(pairs)
+	if len(pts) < opts.MinLCNs || distinctFreqs(pts) < 2 {
+		return FitResult{}, false
+	}
+
+	if lin, ok := fitLinear(pts, opts); ok {
+		return lin, true
+	}
+
+	// Irregular layout: fall back to an explicit per-LCN table built from
+	// every confirmed observation.
+	table := make([]trunking.DMRBandPlanTableEntry, 0, len(pts))
+	for _, p := range pts {
+		table = append(table, trunking.DMRBandPlanTableEntry{LCN: p.lcn, FreqHz: p.freqHz})
+	}
+	return FitResult{
+		Table:      table,
+		Confidence: tableConfidence(pts),
+		NumPairs:   len(pts),
+	}, true
+}
+
+// normalizeOptions fills zero fields with DefaultFitOptions values so a
+// partially-specified FitOptions still works.
+func normalizeOptions(o FitOptions) FitOptions {
+	d := DefaultFitOptions()
+	if o.MinLCNs <= 0 {
+		o.MinLCNs = d.MinLCNs
+	}
+	if len(o.SpacingGrids) == 0 {
+		o.SpacingGrids = d.SpacingGrids
+	}
+	if o.SpacingTolHz == 0 {
+		o.SpacingTolHz = d.SpacingTolHz
+	}
+	if o.ResidualTolHz == 0 {
+		o.ResidualTolHz = d.ResidualTolHz
+	}
+	return o
+}
+
+// aggregate reduces raw pairs to one point per LCN, choosing the
+// frequency with the greatest summed weight (ties broken by lowest
+// frequency for determinism). The chosen frequency's total weight is
+// carried forward. Result is sorted by LCN.
+func aggregate(pairs []Pair) []point {
+	type freqWeight map[uint32]float64
+	byLCN := make(map[uint8]freqWeight)
+	for _, p := range pairs {
+		w := p.Weight
+		if w <= 0 {
+			w = 1
+		}
+		fw := byLCN[p.LCN]
+		if fw == nil {
+			fw = make(freqWeight)
+			byLCN[p.LCN] = fw
+		}
+		fw[p.FreqHz] += w
+	}
+
+	pts := make([]point, 0, len(byLCN))
+	for lcn, fw := range byLCN {
+		var bestFreq uint32
+		var bestWeight float64
+		first := true
+		for f, w := range fw {
+			if first || w > bestWeight || (w == bestWeight && f < bestFreq) {
+				bestFreq, bestWeight, first = f, w, false
+			}
+		}
+		pts = append(pts, point{lcn: lcn, freqHz: bestFreq, weight: bestWeight})
+	}
+	sort.Slice(pts, func(i, j int) bool { return pts[i].lcn < pts[j].lcn })
+	return pts
+}
+
+func distinctFreqs(pts []point) int {
+	seen := make(map[uint32]struct{}, len(pts))
+	for _, p := range pts {
+		seen[p.freqHz] = struct{}{}
+	}
+	return len(seen)
+}
+
+// fitLinear tries to fit pts to BaseHz + (LCN-Offset)*SpacingHz. It
+// estimates spacing from the median per-LCN slope, snaps it to a known
+// grid, solves the base by weighted median, then iteratively rejects the
+// worst-residual point until all residuals fall within tolerance (or too
+// few points remain to meet MinLCNs).
+func fitLinear(pts []point, opts FitOptions) (FitResult, bool) {
+	spacing, ok := estimateSpacing(pts, opts)
+	if !ok {
+		return FitResult{}, false
+	}
+
+	work := append([]point(nil), pts...)
+	for {
+		base, okBase := solveBase(work, spacing, fitOffset)
+		if !okBase {
+			return FitResult{}, false
+		}
+		worst, maxRes := worstResidual(work, base, spacing, fitOffset)
+		if maxRes <= opts.ResidualTolHz {
+			if len(work) < opts.MinLCNs {
+				return FitResult{}, false
+			}
+			return FitResult{
+				Linear: &trunking.DMRLinearBandPlan{
+					BaseHz:    base,
+					SpacingHz: spacing,
+					Offset:    fitOffset,
+				},
+				Confidence: linearConfidence(work, maxRes, opts),
+				NumPairs:   len(work),
+				ResidualHz: maxRes,
+			}, true
+		}
+		// Drop the worst outlier and refit; bail once we can't meet MinLCNs.
+		if len(work)-1 < opts.MinLCNs {
+			return FitResult{}, false
+		}
+		work = append(work[:worst], work[worst+1:]...)
+	}
+}
+
+// estimateSpacing computes the median of the per-adjacent-LCN slopes and
+// snaps it to the nearest configured grid within tolerance. Returns
+// ok=false when the layout is descending/degenerate or no grid is close
+// enough.
+func estimateSpacing(pts []point, opts FitOptions) (uint32, bool) {
+	slopes := make([]float64, 0, len(pts)-1)
+	for i := 1; i < len(pts); i++ {
+		dl := int(pts[i].lcn) - int(pts[i-1].lcn)
+		if dl == 0 {
+			continue
+		}
+		df := float64(pts[i].freqHz) - float64(pts[i-1].freqHz)
+		slopes = append(slopes, df/float64(dl))
+	}
+	if len(slopes) == 0 {
+		return 0, false
+	}
+	est := medianFloat(slopes)
+	if est <= 0 {
+		return 0, false
+	}
+	bestGrid := uint32(0)
+	bestErr := math.MaxFloat64
+	for _, g := range opts.SpacingGrids {
+		if e := math.Abs(est - float64(g)); e < bestErr {
+			bestErr, bestGrid = e, g
+		}
+	}
+	if bestErr > float64(opts.SpacingTolHz) {
+		return 0, false
+	}
+	return bestGrid, true
+}
+
+// solveBase picks the BaseHz that, for the given spacing and offset, best
+// fits the points — the weighted median of each point's implied base.
+// Returns ok=false if the implied base is negative or overflows uint32.
+func solveBase(pts []point, spacing uint32, offset int8) (uint32, bool) {
+	type bw struct {
+		base   int64
+		weight float64
+	}
+	bws := make([]bw, 0, len(pts))
+	for _, p := range pts {
+		idx := int64(p.lcn) - int64(offset)
+		base := int64(p.freqHz) - idx*int64(spacing)
+		bws = append(bws, bw{base: base, weight: p.weight})
+	}
+	sort.Slice(bws, func(i, j int) bool { return bws[i].base < bws[j].base })
+	var total float64
+	for _, b := range bws {
+		total += b.weight
+	}
+	half := total / 2
+	var cum float64
+	chosen := bws[len(bws)-1].base
+	for _, b := range bws {
+		cum += b.weight
+		if cum >= half {
+			chosen = b.base
+			break
+		}
+	}
+	if chosen < 0 || chosen > math.MaxUint32 {
+		return 0, false
+	}
+	return uint32(chosen), true
+}
+
+// worstResidual returns the index and magnitude of the point whose
+// frequency is furthest from the prediction.
+func worstResidual(pts []point, base, spacing uint32, offset int8) (idx int, maxRes uint32) {
+	for i, p := range pts {
+		predicted := int64(base) + (int64(p.lcn)-int64(offset))*int64(spacing)
+		res := int64(p.freqHz) - predicted
+		if res < 0 {
+			res = -res
+		}
+		if uint32(res) > maxRes {
+			maxRes, idx = uint32(res), i
+		}
+	}
+	return idx, maxRes
+}
+
+// linearConfidence blends residual tightness, LCN coverage, and the mean
+// observation weight into a [0,1] score.
+func linearConfidence(pts []point, maxRes uint32, opts FitOptions) float64 {
+	residualScore := 1 - float64(maxRes)/float64(opts.ResidualTolHz)
+	coverageScore := math.Min(1, float64(len(pts))/float64(opts.MinLCNs))
+	weightScore := meanWeightScore(pts)
+	return clamp01(residualScore * coverageScore * weightScore)
+}
+
+// tableConfidence scores an irregular fit: residual is exact by
+// construction, so it depends only on coverage and weight.
+func tableConfidence(pts []point) float64 {
+	coverageScore := math.Min(1, float64(len(pts))/float64(DefaultFitOptions().MinLCNs))
+	return clamp01(coverageScore * meanWeightScore(pts))
+}
+
+func meanWeightScore(pts []point) float64 {
+	if len(pts) == 0 {
+		return 0
+	}
+	var sum float64
+	for _, p := range pts {
+		sum += clamp01(p.weight)
+	}
+	return sum / float64(len(pts))
+}
+
+func medianFloat(xs []float64) float64 {
+	s := append([]float64(nil), xs...)
+	sort.Float64s(s)
+	n := len(s)
+	if n%2 == 1 {
+		return s[n/2]
+	}
+	return (s[n/2-1] + s[n/2]) / 2
+}
+
+func clamp01(x float64) float64 {
+	if x < 0 {
+		return 0
+	}
+	if x > 1 {
+		return 1
+	}
+	return x
+}

--- a/internal/scanner/dmrlcn/fit_test.go
+++ b/internal/scanner/dmrlcn/fit_test.go
@@ -1,0 +1,195 @@
+package dmrlcn
+
+import (
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// resolve evaluates a linear plan at an LCN the way tier3.LinearBandPlan does.
+func resolve(lp *trunking.DMRLinearBandPlan, lcn uint8) uint32 {
+	return uint32(int64(lp.BaseHz) + (int64(lcn)-int64(lp.Offset))*int64(lp.SpacingHz))
+}
+
+// linearPairs builds confirmed pairs on a regular grid:
+// freq = base + (lcn-offset)*spacing, weight 1.
+func linearPairs(base uint32, spacing uint32, offset int8, lcns ...uint8) []Pair {
+	out := make([]Pair, 0, len(lcns))
+	for _, l := range lcns {
+		f := int64(base) + (int64(l)-int64(offset))*int64(spacing)
+		out = append(out, Pair{LCN: l, FreqHz: uint32(f), Weight: 1})
+	}
+	return out
+}
+
+func TestFitLinearCleanGrids(t *testing.T) {
+	cases := []struct {
+		name    string
+		base    uint32
+		spacing uint32
+		offset  int8
+	}{
+		{"12.5kHz offset1", 851_037_500, 12_500, 1},
+		{"25kHz offset1", 866_000_000, 25_000, 1},
+		{"6.25kHz offset0", 460_000_000, 6_250, 0},
+		{"12.5kHz offset0", 451_000_000, 12_500, 0},
+	}
+	lcns := []uint8{1, 2, 3, 5, 8, 12}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pairs := linearPairs(tc.base, tc.spacing, tc.offset, lcns...)
+			res, ok := FitBandPlan(pairs, FitOptions{})
+			if !ok {
+				t.Fatal("expected a learned plan")
+			}
+			if res.Linear == nil {
+				t.Fatalf("expected linear plan, got table %+v", res.Table)
+			}
+			if res.Linear.SpacingHz != tc.spacing {
+				t.Errorf("spacing = %d, want %d", res.Linear.SpacingHz, tc.spacing)
+			}
+			// Offset/base are a representation choice; verify the plan
+			// resolves every input LCN back to its exact input frequency.
+			for _, l := range lcns {
+				want := uint32(int64(tc.base) + (int64(l)-int64(tc.offset))*int64(tc.spacing))
+				if got := resolve(res.Linear, l); got != want {
+					t.Errorf("resolve(lcn=%d) = %d, want %d", l, got, want)
+				}
+			}
+			if res.ResidualHz != 0 {
+				t.Errorf("residual = %d, want 0 for an exact grid", res.ResidualHz)
+			}
+			if res.Confidence <= 0 {
+				t.Errorf("confidence = %f, want > 0", res.Confidence)
+			}
+		})
+	}
+}
+
+func TestFitLinearTolerATesSubBinJitter(t *testing.T) {
+	// Energy-onset frequency estimates land on FFT bins, so observed
+	// frequencies carry a few hundred Hz of jitter. The fit should still
+	// snap spacing and recover a base within the residual ceiling.
+	base, spacing := uint32(851_037_500), uint32(12_500)
+	jitter := []int32{+200, -150, +300, -250, +100, -300}
+	pairs := make([]Pair, 0, len(jitter))
+	for i, l := range []uint8{1, 2, 3, 4, 6, 9} {
+		f := int64(base) + (int64(l)-1)*int64(spacing) + int64(jitter[i])
+		pairs = append(pairs, Pair{LCN: l, FreqHz: uint32(f), Weight: 1})
+	}
+	res, ok := FitBandPlan(pairs, FitOptions{})
+	if !ok || res.Linear == nil {
+		t.Fatalf("expected linear plan, ok=%v res=%+v", ok, res)
+	}
+	if res.Linear.SpacingHz != spacing {
+		t.Errorf("spacing = %d, want %d", res.Linear.SpacingHz, spacing)
+	}
+	if res.ResidualHz > 1500 {
+		t.Errorf("residual = %d, want <= 1500", res.ResidualHz)
+	}
+}
+
+func TestFitLinearRejectsOutlier(t *testing.T) {
+	pairs := linearPairs(851_037_500, 12_500, 1, 1, 2, 3, 4, 5)
+	// Corrupt LCN 3 with a wildly wrong frequency (a mis-paired carrier).
+	for i := range pairs {
+		if pairs[i].LCN == 3 {
+			pairs[i].FreqHz += 5_000_000
+		}
+	}
+	res, ok := FitBandPlan(pairs, FitOptions{})
+	if !ok || res.Linear == nil {
+		t.Fatalf("expected linear plan after outlier rejection, ok=%v res=%+v", ok, res)
+	}
+	if res.Linear.BaseHz != 851_037_500 || res.Linear.SpacingHz != 12_500 {
+		t.Errorf("plan = base %d spacing %d, want 851037500/12500", res.Linear.BaseHz, res.Linear.SpacingHz)
+	}
+	if res.NumPairs != 4 {
+		t.Errorf("NumPairs = %d, want 4 (outlier dropped)", res.NumPairs)
+	}
+}
+
+func TestFitFallsBackToTableForIrregularGrid(t *testing.T) {
+	// Frequencies not on any 6.25/12.5/25 kHz grid relative to LCN.
+	pairs := []Pair{
+		{LCN: 1, FreqHz: 451_012_500, Weight: 1},
+		{LCN: 2, FreqHz: 451_031_300, Weight: 1}, // +18.8 kHz
+		{LCN: 3, FreqHz: 451_077_900, Weight: 1}, // +46.6 kHz
+		{LCN: 4, FreqHz: 451_093_700, Weight: 1}, // +15.8 kHz
+	}
+	res, ok := FitBandPlan(pairs, FitOptions{})
+	if !ok {
+		t.Fatal("expected a table plan")
+	}
+	if res.Linear != nil {
+		t.Fatalf("expected table fallback, got linear %+v", res.Linear)
+	}
+	if len(res.Table) != 4 {
+		t.Errorf("table len = %d, want 4", len(res.Table))
+	}
+}
+
+func TestFitFallsBackToTableForUnsnappableSpacing(t *testing.T) {
+	// Regular 9 kHz spacing: not a DMR grid, so linear must be rejected
+	// even though the layout is perfectly linear.
+	pairs := linearPairs(451_000_000, 9_000, 1, 1, 2, 3, 4, 5)
+	res, ok := FitBandPlan(pairs, FitOptions{})
+	if !ok {
+		t.Fatal("expected a table plan")
+	}
+	if res.Linear != nil {
+		t.Errorf("9 kHz spacing should not snap to a DMR grid; got linear %+v", res.Linear)
+	}
+}
+
+func TestFitNotLearnedBelowMinLCNs(t *testing.T) {
+	pairs := linearPairs(851_037_500, 12_500, 1, 1, 2, 3) // only 3, default MinLCNs=4
+	if _, ok := FitBandPlan(pairs, FitOptions{}); ok {
+		t.Fatal("expected ok=false below MinLCNs")
+	}
+}
+
+func TestFitNotLearnedSingleFrequency(t *testing.T) {
+	// Many observations but all the same frequency → cannot be a plan.
+	pairs := []Pair{
+		{LCN: 1, FreqHz: 851_000_000, Weight: 1},
+		{LCN: 2, FreqHz: 851_000_000, Weight: 1},
+		{LCN: 3, FreqHz: 851_000_000, Weight: 1},
+		{LCN: 4, FreqHz: 851_000_000, Weight: 1},
+		{LCN: 5, FreqHz: 851_000_000, Weight: 1},
+	}
+	if _, ok := FitBandPlan(pairs, FitOptions{}); ok {
+		t.Fatal("expected ok=false with a single distinct frequency")
+	}
+}
+
+func TestFitAggregatesConflictingObservationsByWeight(t *testing.T) {
+	// LCN 3 was paired to a wrong frequency once (low weight) and the
+	// right one twice (high weight). The weighted mode wins.
+	pairs := linearPairs(851_037_500, 12_500, 1, 1, 2, 4, 5)
+	pairs = append(pairs,
+		Pair{LCN: 3, FreqHz: 851_037_500 + 2*12_500, Weight: 2}, // correct, weight 2
+		Pair{LCN: 3, FreqHz: 999_000_000, Weight: 0.4},          // wrong, low weight
+	)
+	res, ok := FitBandPlan(pairs, FitOptions{})
+	if !ok || res.Linear == nil {
+		t.Fatalf("expected linear plan, ok=%v res=%+v", ok, res)
+	}
+	if res.Linear.BaseHz != 851_037_500 || res.Linear.SpacingHz != 12_500 {
+		t.Errorf("plan = base %d spacing %d", res.Linear.BaseHz, res.Linear.SpacingHz)
+	}
+}
+
+func TestFitResultBandPlanRoundTrip(t *testing.T) {
+	res, ok := FitBandPlan(linearPairs(851_037_500, 12_500, 1, 1, 2, 3, 4, 5), FitOptions{})
+	if !ok {
+		t.Fatal("expected learned plan")
+	}
+	bp := res.BandPlan()
+	if bp == nil || bp.Linear == nil {
+		t.Fatalf("BandPlan() = %+v, want linear", bp)
+	}
+	if bp.Linear.BaseHz != 851_037_500 || bp.Linear.SpacingHz != 12_500 || bp.Linear.Offset != 1 {
+		t.Errorf("round-tripped plan = %+v", bp.Linear)
+	}
+}

--- a/internal/scanner/dmrlcn/onset.go
+++ b/internal/scanner/dmrlcn/onset.go
@@ -1,0 +1,269 @@
+package dmrlcn
+
+import (
+	"math"
+	"math/cmplx"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/fft"
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/window"
+)
+
+// CarrierOnset reports that a carrier on the DMR channel grid transitioned
+// from idle to active — i.e. a voice/data call keyed up on it. The
+// correlator pairs the onset time with a recently granted LCN.
+type CarrierOnset struct {
+	FreqHz uint32
+	At     time.Time
+	PeakDb float32
+}
+
+// onsetConfig parameterizes the onset detector. CenterHz/SampleRateHz come
+// from the wideband dongle; GridHz is the DMR channel spacing the detector
+// scans (12.5 kHz). The defaults in newOnsetDetector cover the rest.
+type onsetConfig struct {
+	CenterHz     uint32
+	SampleRateHz uint32
+	GuardFrac    float64
+	GridHz       uint32
+	FFTSize      int
+	FrameRate    float64  // target FFTs per second
+	OnThreshDb   float64  // rise this far above the noise floor to key up
+	OffThreshDb  float64  // fall below floor+this to key down (hysteresis)
+	Debounce     int      // consecutive frames required to flip state
+	NoiseAlpha   float64  // EWMA factor for the per-channel noise floor
+	Exclude      []uint32 // frequencies never reported (e.g. the CC carrier)
+	Now          func() time.Time
+}
+
+// gridChannel is one candidate carrier on the DMR channel grid plus its
+// onset/offset state.
+type gridChannel struct {
+	freqHz   uint32
+	bins     []int // FFT-shifted bin indices that fall inside this channel
+	excluded bool
+
+	floorDb    float64
+	floorInit  bool
+	active     bool
+	aboveCount int
+	belowCount int
+}
+
+// onsetDetector runs windowed FFTs over a wideband IQ stream, integrates
+// power onto the DMR channel grid, and emits a CarrierOnset on each
+// channel's idle→active edge. It is fed IQ chunks via Process and reports
+// onsets through the emit callback. Not safe for concurrent Process calls.
+type onsetDetector struct {
+	cfg  onsetConfig
+	emit func(CarrierOnset)
+
+	plan   fft.Plan
+	win    []float64
+	winSum float64
+	size   int
+	half   int
+
+	bufIQ   []complex128
+	bufOut  []complex128
+	powBuf  []float64 // FFT-shifted linear power per bin
+	pending []complex64
+
+	channels []*gridChannel
+
+	frameSkip int // run one FFT per (frameSkip+1) full windows
+	winCount  int
+}
+
+func newOnsetDetector(cfg onsetConfig, emit func(CarrierOnset)) *onsetDetector {
+	if cfg.GridHz == 0 {
+		cfg.GridHz = 12_500
+	}
+	if cfg.FFTSize <= 0 || cfg.FFTSize&(cfg.FFTSize-1) != 0 {
+		cfg.FFTSize = 4096
+	}
+	if cfg.FrameRate <= 0 {
+		cfg.FrameRate = 30
+	}
+	if cfg.GuardFrac <= 0 {
+		cfg.GuardFrac = 0.05
+	}
+	if cfg.OnThreshDb <= 0 {
+		cfg.OnThreshDb = 10
+	}
+	if cfg.OffThreshDb <= 0 {
+		cfg.OffThreshDb = 6
+	}
+	if cfg.Debounce <= 0 {
+		cfg.Debounce = 3
+	}
+	if cfg.NoiseAlpha <= 0 {
+		cfg.NoiseAlpha = 0.02
+	}
+	if cfg.Now == nil {
+		cfg.Now = time.Now
+	}
+
+	size := cfg.FFTSize
+	d := &onsetDetector{
+		cfg:    cfg,
+		emit:   emit,
+		plan:   fft.New(size),
+		win:    window.Hann(size),
+		size:   size,
+		half:   size / 2,
+		bufIQ:  make([]complex128, size),
+		bufOut: make([]complex128, size),
+		powBuf: make([]float64, size),
+	}
+	for _, w := range d.win {
+		d.winSum += w * w
+	}
+
+	// One FFT per (frameSkip+1) windows hits ~FrameRate FFTs/sec.
+	winRate := float64(cfg.SampleRateHz) / float64(size)
+	if skip := int(math.Round(winRate/cfg.FrameRate)) - 1; skip > 0 {
+		d.frameSkip = skip
+	}
+
+	d.buildGrid()
+	return d
+}
+
+// buildGrid enumerates the DMR-grid channels inside the usable band and
+// precomputes the FFT-shifted bins that fall within each channel's
+// occupied bandwidth.
+func (d *onsetDetector) buildGrid() {
+	center := float64(d.cfg.CenterHz)
+	rate := float64(d.cfg.SampleRateHz)
+	binW := rate / float64(d.size)
+	usableHalf := rate * (0.5 - d.cfg.GuardFrac)
+	// Occupied half-bandwidth per channel: a touch under half the grid so
+	// adjacent channels don't bleed into each other.
+	halfBW := 0.45 * float64(d.cfg.GridHz)
+
+	excluded := make(map[uint32]struct{}, len(d.cfg.Exclude))
+	for _, f := range d.cfg.Exclude {
+		excluded[f] = struct{}{}
+	}
+
+	grid := int64(d.cfg.GridHz)
+	lo := int64(math.Ceil((center - usableHalf) / float64(grid)))
+	hi := int64(math.Floor((center + usableHalf) / float64(grid)))
+	for k := lo; k <= hi; k++ {
+		freq := k * grid
+		// Channel center must sit comfortably inside the usable band.
+		if math.Abs(float64(freq)-center) > usableHalf-halfBW {
+			continue
+		}
+		gc := &gridChannel{freqHz: uint32(freq)}
+		if _, ok := excluded[gc.freqHz]; ok {
+			gc.excluded = true
+		}
+		// FFT-shifted bin index for a frequency f:
+		//   k = half + round((f-center)/binW)
+		loBin := d.half + int(math.Ceil((float64(freq)-halfBW-center)/binW))
+		hiBin := d.half + int(math.Floor((float64(freq)+halfBW-center)/binW))
+		for b := loBin; b <= hiBin; b++ {
+			if b >= 0 && b < d.size {
+				gc.bins = append(gc.bins, b)
+			}
+		}
+		if len(gc.bins) > 0 {
+			d.channels = append(d.channels, gc)
+		}
+	}
+}
+
+// channels reporting helper for tests.
+func (d *onsetDetector) channelCount() int { return len(d.channels) }
+
+// Process accumulates IQ and runs a rate-limited FFT, advancing each
+// grid channel's onset state machine per frame.
+func (d *onsetDetector) Process(chunk []complex64) {
+	d.pending = append(d.pending, chunk...)
+	for len(d.pending) >= d.size {
+		frameWin := d.pending[:d.size]
+		d.pending = d.pending[d.size:]
+		d.winCount++
+		if d.frameSkip > 0 && (d.winCount-1)%(d.frameSkip+1) != 0 {
+			continue
+		}
+		d.frame(frameWin)
+	}
+	// Bound pending growth if a consumer stalls.
+	if len(d.pending) > 4*d.size {
+		d.pending = d.pending[len(d.pending)-d.size:]
+	}
+}
+
+// frame runs one FFT and updates every channel's state.
+func (d *onsetDetector) frame(samples []complex64) {
+	for i := 0; i < d.size; i++ {
+		s := samples[i]
+		w := d.win[i]
+		d.bufIQ[i] = complex(float64(real(s))*w, float64(imag(s))*w)
+	}
+	out := d.plan.Forward(d.bufOut, d.bufIQ)
+	norm := 1.0 / (float64(d.size) * d.winSum)
+	for i := 0; i < d.size; i++ {
+		dst := (i + d.half) % d.size
+		mag := cmplx.Abs(out[i])
+		d.powBuf[dst] = mag * mag * norm
+	}
+
+	now := d.cfg.Now()
+	for _, gc := range d.channels {
+		var p float64
+		for _, b := range gc.bins {
+			p += d.powBuf[b]
+		}
+		if p < 1e-30 {
+			p = 1e-30
+		}
+		db := 10 * math.Log10(p)
+		d.updateChannel(gc, db, now)
+	}
+}
+
+// updateChannel runs the per-channel onset/offset state machine with
+// hysteresis and an adaptive noise floor.
+func (d *onsetDetector) updateChannel(gc *gridChannel, db float64, now time.Time) {
+	if !gc.floorInit {
+		gc.floorDb = db
+		gc.floorInit = true
+		return
+	}
+
+	onLevel := gc.floorDb + d.cfg.OnThreshDb
+	offLevel := gc.floorDb + d.cfg.OffThreshDb
+
+	switch {
+	case db >= onLevel:
+		gc.aboveCount++
+		gc.belowCount = 0
+		if !gc.active && gc.aboveCount >= d.cfg.Debounce {
+			gc.active = true
+			if !gc.excluded {
+				d.emit(CarrierOnset{FreqHz: gc.freqHz, At: now, PeakDb: float32(db)})
+			}
+		}
+	case db <= offLevel:
+		gc.belowCount++
+		gc.aboveCount = 0
+		if gc.active && gc.belowCount >= d.cfg.Debounce {
+			gc.active = false
+		}
+	default:
+		// Inside the hysteresis band: relax both edge counters.
+		gc.aboveCount = 0
+		gc.belowCount = 0
+	}
+
+	// Track the noise floor only while idle so an active carrier doesn't
+	// drag the floor up and mask itself.
+	if !gc.active {
+		a := d.cfg.NoiseAlpha
+		gc.floorDb = (1-a)*gc.floorDb + a*db
+	}
+}

--- a/internal/scanner/dmrlcn/onset_test.go
+++ b/internal/scanner/dmrlcn/onset_test.go
@@ -1,0 +1,113 @@
+package dmrlcn
+
+import (
+	"math"
+	"math/cmplx"
+	"math/rand"
+	"testing"
+	"time"
+)
+
+// makeIQ builds n complex samples: low-amplitude white noise, plus an
+// optional tone at toneOffsetHz when tone is true.
+func makeIQ(n int, fs float64, toneOffsetHz float64, toneAmp float64, noiseAmp float64, tone bool, phase *float64, rng *rand.Rand) []complex64 {
+	out := make([]complex64, n)
+	w := 2 * math.Pi * toneOffsetHz / fs
+	for i := 0; i < n; i++ {
+		var s complex128
+		s += complex(noiseAmp*(rng.Float64()*2-1), noiseAmp*(rng.Float64()*2-1))
+		if tone {
+			s += complex(toneAmp, 0) * cmplx.Exp(complex(0, *phase))
+			*phase += w
+		}
+		out[i] = complex64(s)
+	}
+	return out
+}
+
+func TestOnsetDetectorEmitsOnKeyup(t *testing.T) {
+	const (
+		fs           = 2_400_000.0
+		center       = uint32(851_500_000)
+		targetFreq   = uint32(851_650_000) // +150 kHz, on the 12.5 kHz grid
+		frameSize    = 4096
+		toneOffsetHz = 150_000.0
+	)
+	rng := rand.New(rand.NewSource(1))
+	clock := time.Unix(1_700_000_000, 0)
+
+	var onsets []CarrierOnset
+	det := newOnsetDetector(onsetConfig{
+		CenterHz:     center,
+		SampleRateHz: uint32(fs),
+		FFTSize:      frameSize,
+		FrameRate:    1e9, // force one FFT per window for a deterministic test
+		Debounce:     2,
+		Now:          func() time.Time { return clock },
+	}, func(o CarrierOnset) { onsets = append(onsets, o) })
+
+	if det.channelCount() < 5 {
+		t.Fatalf("grid has too few channels: %d", det.channelCount())
+	}
+
+	// Idle phase: noise only, lets the noise floor settle.
+	phase := 0.0
+	for i := 0; i < 40; i++ {
+		clock = clock.Add(time.Millisecond)
+		det.Process(makeIQ(frameSize, fs, toneOffsetHz, 0, 0.002, false, &phase, rng))
+	}
+	if len(onsets) != 0 {
+		t.Fatalf("onset emitted during idle: %+v", onsets)
+	}
+
+	// Key-up: strong carrier on the target channel.
+	keyAt := clock.Add(time.Millisecond)
+	for i := 0; i < 20; i++ {
+		clock = clock.Add(time.Millisecond)
+		det.Process(makeIQ(frameSize, fs, toneOffsetHz, 0.3, 0.002, true, &phase, rng))
+	}
+
+	if len(onsets) != 1 {
+		t.Fatalf("got %d onsets, want exactly 1: %+v", len(onsets), onsets)
+	}
+	if onsets[0].FreqHz != targetFreq {
+		t.Errorf("onset freq = %d, want %d", onsets[0].FreqHz, targetFreq)
+	}
+	if onsets[0].At.Before(keyAt) {
+		t.Errorf("onset time %v predates key-up %v", onsets[0].At, keyAt)
+	}
+}
+
+func TestOnsetDetectorExcludesControlChannel(t *testing.T) {
+	const (
+		fs           = 2_400_000.0
+		center       = uint32(851_500_000)
+		targetFreq   = uint32(851_650_000)
+		frameSize    = 4096
+		toneOffsetHz = 150_000.0
+	)
+	rng := rand.New(rand.NewSource(2))
+	clock := time.Unix(1_700_000_000, 0)
+
+	var onsets []CarrierOnset
+	det := newOnsetDetector(onsetConfig{
+		CenterHz:     center,
+		SampleRateHz: uint32(fs),
+		FFTSize:      frameSize,
+		FrameRate:    1e9,
+		Debounce:     2,
+		Exclude:      []uint32{targetFreq}, // pretend this is the CC carrier
+		Now:          func() time.Time { return clock },
+	}, func(o CarrierOnset) { onsets = append(onsets, o) })
+
+	phase := 0.0
+	for i := 0; i < 40; i++ {
+		det.Process(makeIQ(frameSize, fs, toneOffsetHz, 0, 0.002, false, &phase, rng))
+	}
+	for i := 0; i < 20; i++ {
+		det.Process(makeIQ(frameSize, fs, toneOffsetHz, 0.3, 0.002, true, &phase, rng))
+	}
+	if len(onsets) != 0 {
+		t.Fatalf("excluded channel emitted onsets: %+v", onsets)
+	}
+}

--- a/internal/scanner/widebandt2/engine.go
+++ b/internal/scanner/widebandt2/engine.go
@@ -203,6 +203,10 @@ type engineChannel struct {
 	protoTag  string // e.g. "dmr-tier2", "dmr-tier3", "p25-phase1", "p25-phase2"
 	processor channelProcessor
 	receiver  narrowbandReceiver
+	// dmrTier3 is the typed Tier III control channel for "dmr-tier3"
+	// channels (nil otherwise). Exposed via DMRTier3ControlChannel so the
+	// DMR LCN autoconfig learner can hot-swap a learned band-plan resolver.
+	dmrTier3 *tier3.ControlChannel
 }
 
 // New constructs an Engine. The device is not opened or streamed
@@ -323,7 +327,7 @@ func buildChannel(sys trunking.System, ch ChannelConfig, bus *events.Bus, log *s
 			DeviationHz:  dmrDeviationHz,
 			ClockGain:    dmrClockGainTier3,
 		})
-		return &engineChannel{freqHz: freqHz, sysName: sys.Name, protoTag: "dmr-tier3", processor: cc, receiver: rx}, nil
+		return &engineChannel{freqHz: freqHz, sysName: sys.Name, protoTag: "dmr-tier3", processor: cc, receiver: rx, dmrTier3: cc}, nil
 
 	case trunking.ProtocolDMRTier2:
 		cc := tier2.New(tier2.Options{
@@ -504,6 +508,19 @@ func (e *Engine) ChannelProtocolTags() map[uint32]string {
 // construction ("ddc" or "polyphase"). Used for diagnostics /
 // startup logging.
 func (e *Engine) Strategy() string { return e.strategyTag }
+
+// DMRTier3ControlChannel returns the Tier III control channel monitoring
+// the given frequency, or nil if no such "dmr-tier3" channel exists. The
+// daemon uses it to bind a dmrlcn.Learner's resolver hot-swap to the
+// running control channel.
+func (e *Engine) DMRTier3ControlChannel(freqHz uint32) *tier3.ControlChannel {
+	for _, c := range e.channels {
+		if c.freqHz == freqHz && c.dmrTier3 != nil {
+			return c.dmrTier3
+		}
+	}
+	return nil
+}
 
 // Run programs the dongle's centre frequency, opens its IQ stream,
 // and pumps chunks through the tuner bank until ctx cancels. The


### PR DESCRIPTION
DMR Tier III control channels transmit only a 7-bit Logical Channel
Number (LCN) in voice grants, never an absolute frequency, so following
voice previously required a hand-configured dmr_band_plan. Without it,
every grant was dropped with decode.error stage=no-bandplan.

GopherTrunk can now learn that band plan automatically using its wideband
acquisition: it observes the LCNs the control channel grants, detects
which RF carriers key up in response across the dongle's IQ band,
decode-confirms each is a live DMR burst, and fits the base frequency +
channel spacing for the whole LCN enumeration. The learned plan is
hot-swapped into the running control channel (previously-dropped grants
start following voice immediately) and written back to the config file
(comment-preserving) so it survives a restart. It auto-enables for any
protocol: dmr system on a wideband dongle that has no dmr_band_plan; a
configured plan is authoritative and disables learning.

Implementation:
- events: KindDMRGrantObserved (leaks the granted LCN before resolution)
  and KindDMRBandPlanLearned + payloads.
- radio/dmr/tier3: emit KindDMRGrantObserved from publishGrant; guard the
  resolver with an RWMutex and add SetResolver for runtime hot-swap.
- scanner/widebandt2: expose the typed Tier III control channel per
  frequency so the daemon can bind SetResolver.
- scanner/dmrlcn (new): the learner. fit.go fits a LinearBandPlan (snaps
  spacing to 6.25/12.5/25 kHz grids, rejects outliers, falls back to a
  table); onset.go detects carrier key-ups on the DMR grid via FFT energy
  with adaptive noise floor + hysteresis; correlate.go pairs granted LCNs
  to onsets and never guesses under ambiguity; confirm.go DDC-taps the
  candidate carrier and confirms a live DMR sync burst; dmrlcn.go
  orchestrates the loop, bounded confirmation probes, and live apply.
- config: WriteDMRLearnedBandPlan persists the learned linear plan into
  the matching system, preserving comments, with an mtime guard.
- daemon: construct + spawn one learner per planless wideband DMR Tier III
  control channel (non-essential), wired to the iqtap broker, the bus, and
  the control channel's SetResolver, with config writeback.

Tests cover the fitter (clean grids, jitter, outliers, table fallback,
thresholds), the correlator (windows, ambiguity, expiry), the onset
detector (synthesized key-up, CC exclusion), the learner orchestration
(lock + apply + publish + persist), the confirmer control flow (noise and
out-of-band rejection), the tier3 emission + SetResolver race, and the
comment-preserving config writeback.

https://claude.ai/code/session_01496rMHqXnGw1jiP1igXXEv