### PR TITLE
dmr/tier3: correct CSBK opcode table and surface the control stream

### DIFF
--- a/internal/radio/dmr/tier3/control.go
+++ b/internal/radio/dmr/tier3/control.go
@@ -28,17 +28,19 @@ func (s LockState) LockedNAC() uint16         { return s.SystemID }
 // identifies a CSBK, runs BPTC(196,96) decode + CRC, and dispatches
 // each opcode:
 //
-//   - OpAloha / OpSysInfo announce the trunked system → CCLocked
-//     events fan out the first time we see one.
+//   - OpAloha announces the trunked system → CCLocked events fan out
+//     the first time we see one. OpBcast (C_BCAST) carries the site's
+//     Gen_Site_Params and Adjacent_Site announcements, folded into the
+//     topology model.
 //   - OpTVGrant / OpPVGrant carry voice grants. The LCN is resolved
 //     through the supplied band plan; on success a trunking.Grant is
 //     published with Protocol = "dmr-tier3". A grant whose LCN has no
 //     entry in the band plan publishes a `decode.error` with
 //     stage="no-bandplan" so operators can spot configuration gaps.
 //
-// Every other opcode (preamble, ACK, Ahoy, neighbor lists, …) is
-// logged at debug and ignored — they're noise from the hunter's
-// perspective.
+// Every CSBK is logged at debug (so the control stream is visible the
+// way dsd-neo shows it); opcodes without a dedicated handler (ACK,
+// Ahoy, Move, Preamble, …) are otherwise ignored.
 type ControlChannel struct {
 	bus              *events.Bus
 	log              *slog.Logger
@@ -136,24 +138,38 @@ func (c *ControlChannel) handleCSBK(cc uint8, csbk CSBK) {
 		c.handleVendorCSBK(vendor, cc, csbk)
 		return
 	}
+	// Log every standard CSBK so the control-channel stream is visible
+	// in the debug log the way a reference decoder (dsd-neo) shows it —
+	// the dominant Aloha beacon is otherwise consumed silently once the
+	// CC is locked, which made GopherTrunk look idle.
+	c.log.Debug("dmr/tier3: csbk", "opcode", csbk.Opcode, "fid", csbk.FID, "cc", cc)
 	switch csbk.Opcode {
 	case OpAloha:
 		sysID := ParseAloha(csbk.Payload).SystemID
 		c.topo.applyIdentity(sysID, cc)
 		c.maybeLock(LockState{FrequencyHz: c.freqHz, ColorCode: cc, SystemID: sysID})
-	case OpSysInfo:
-		si := ParseSystemInfoBroadcast(csbk.Payload)
-		c.topo.applySystemInfo(si)
-		c.topo.applyIdentity(si.SystemID, cc)
-		c.maybeLock(LockState{FrequencyHz: c.freqHz, ColorCode: cc, SystemID: si.SystemID})
-	case OpAdjStatus:
-		c.topo.applyAdjacent(ParseAdjacentSiteStatus(csbk.Payload))
+	case OpBcast:
+		c.handleBroadcast(cc, ParseBroadcast(csbk.Payload))
 	case OpTVGrant:
 		c.publishTVGrant(cc, ParseTVGrant(csbk.Payload))
 	case OpPVGrant:
 		c.publishPVGrant(cc, ParsePVGrant(csbk.Payload))
-	default:
-		c.log.Debug("dmr/tier3: csbk", "opcode", csbk.Opcode, "cc", cc)
+	}
+}
+
+// handleBroadcast folds a C_BCAST announcement into the topology model.
+// Gen_Site_Params contributes the camped site's identity + RFSS/Site;
+// Adjacent_Site adds a neighbour. Locking stays Aloha-driven: the
+// Gen_Site_Params identity field differs from the Aloha raw identity, so
+// driving maybeLock from both would churn the lock state every burst.
+func (c *ControlChannel) handleBroadcast(cc uint8, b BroadcastAnnouncement) {
+	switch b.Type {
+	case AnncGenSiteParms:
+		gs := ParseGenSiteParams(b.Payload)
+		c.topo.applyIdentity(gs.SystemID, cc)
+		c.topo.applySiteParams(gs.RFSSID, gs.SiteID)
+	case AnncAdjacentSite:
+		c.topo.applyAdjacent(ParseAdjacentSite(b.Payload))
 	}
 }
 

--- a/internal/radio/dmr/tier3/control_test.go
+++ b/internal/radio/dmr/tier3/control_test.go
@@ -55,24 +55,26 @@ func TestControlChannelEmitsLockOnAloha(t *testing.T) {
 	}
 }
 
-func TestControlChannelEmitsLockOnSysInfo(t *testing.T) {
+func TestControlChannelBroadcastPopulatesTopology(t *testing.T) {
 	bus := events.NewBus(8)
 	defer bus.Close()
-	sub := bus.Subscribe()
-	defer sub.Close()
 
 	cc := NewControlChannel(bus, nil, 851_000_000)
-	c := CSBK{LB: true, Opcode: OpSysInfo, Payload: [8]byte{0xCA, 0xFE, 0x01, 0x05, 0xFF, 0, 0, 0}}
+	// C_BCAST Gen_Site_Params (anncd_type 7 → payload[0] = 7<<3 = 0x38):
+	// SystemID 0xCAFE, RFSS 1, Site 7. Standard-FID broadcasts feed the
+	// topology model; locking stays Aloha-driven.
+	c := CSBK{LB: true, Opcode: OpBcast, Payload: [8]byte{0x38, 0xCA, 0xFE, 0x01, 0x07, 0, 0, 0}}
 	cc.IngestBurst(burstWithCSBK(c), dmr.SlotType{ColorCode: 0xC, DataType: dmr.DTCSBK})
 
-	select {
-	case ev := <-sub.C:
-		ls := ev.Payload.(LockState)
-		if ls.SystemID != 0xCAFE {
-			t.Errorf("sysid = %X, want CAFE", ls.SystemID)
-		}
-	case <-time.After(time.Second):
-		t.Fatal("no event")
+	topo := cc.Topology()
+	if topo.SystemID != 0xCAFE {
+		t.Errorf("SystemID = %X, want CAFE", topo.SystemID)
+	}
+	if topo.RFSS != 1 || topo.Site != 7 {
+		t.Errorf("RFSS/Site = %d/%d, want 1/7", topo.RFSS, topo.Site)
+	}
+	if topo.ColorCode != 0xC {
+		t.Errorf("ColorCode = %d, want 12", topo.ColorCode)
 	}
 }
 
@@ -313,7 +315,7 @@ func TestControlChannelMarkLost(t *testing.T) {
 	defer sub.Close()
 
 	cc := NewControlChannel(bus, nil, 851_000_000)
-	c := CSBK{LB: true, Opcode: OpSysInfo, Payload: [8]byte{0x42, 0x00, 0x01, 0x01, 0, 0, 0, 0}}
+	c := CSBK{LB: true, Opcode: OpAloha, Payload: [8]byte{0x00, 0x00, 0x42, 0x00, 0, 0, 0, 0}}
 	cc.IngestBurst(burstWithCSBK(c), dmr.SlotType{ColorCode: 7, DataType: dmr.DTCSBK})
 	<-sub.C
 

--- a/internal/radio/dmr/tier3/csbk.go
+++ b/internal/radio/dmr/tier3/csbk.go
@@ -26,50 +26,74 @@ import (
 type CSBKOpcode uint8
 
 const (
-	// Standard FID (0x00) opcodes — ETSI TS 102 361-4 §7. Only the most
-	// common opcodes are listed; vendor extensions live behind FID != 0.
-	OpUnknown   CSBKOpcode = 0x00
-	OpAloha     CSBKOpcode = 0x19 // C_ALOHA — periodic TSCC beacon (ETSI TS 102 361-4 §7.2.1)
-	OpRAND      CSBKOpcode = 0x06 // Random access service request
-	OpAckResp   CSBKOpcode = 0x16 // ACK response
-	OpAhoy      CSBKOpcode = 0x18 // AHOY
-	OpProtect   CSBKOpcode = 0x1A // Protect message
-	OpMoveTSCC  CSBKOpcode = 0x1B // Move trunked-system control channel
-	OpPreamble  CSBKOpcode = 0x28 // Preamble CSBK
-	OpTVGrant   CSBKOpcode = 0x30 // TalkGroup voice channel grant
-	OpPVGrant   CSBKOpcode = 0x31 // Private voice channel grant
-	OpTDGrant   CSBKOpcode = 0x32 // TalkGroup data channel grant
-	OpPDGrant   CSBKOpcode = 0x33 // Private data channel grant
-	OpAdjStatus CSBKOpcode = 0x38 // Adjacent site status
-	OpSysInfo   CSBKOpcode = 0x39 // System information broadcast
+	// Standard FID (0x00) CSBKO opcodes — ETSI TS 102 361-4 §7.1.1
+	// (Table 7.1), cross-checked against real off-air decodes and the
+	// IanWraith/DMRDecode opcode map. Names mirror the ETSI / dsd-neo
+	// spelling so logs line up with reference decoders.
+	//
+	// NOTE: the trunking system parameters, general site parameters,
+	// adjacent-site lists, and call-timer values are NOT standalone
+	// opcodes — they are sub-types (anncd_type) carried inside C_BCAST
+	// (OpBcast, 0x28). See payloads.go BroadcastAnnouncement.
+	OpUnknown  CSBKOpcode = 0x00
+	OpAloha    CSBKOpcode = 0x19 // C_ALOHA — periodic TSCC beacon the CC locks on
+	OpAhoy     CSBKOpcode = 0x1C // C_AHOY — outbound poll / service request
+	OpAckVit   CSBKOpcode = 0x1E // C_ACKVIT — acknowledged response (vital)
+	OpRAND     CSBKOpcode = 0x1F // C_RAND — random-access service request
+	OpAckD     CSBKOpcode = 0x20 // C_ACKD — acknowledged downlink response
+	OpAckU     CSBKOpcode = 0x21 // C_ACKU — acknowledged uplink response
+	OpNack     CSBKOpcode = 0x26 // negative-acknowledge response
+	OpBcast    CSBKOpcode = 0x28 // C_BCAST — broadcast/announcement (Gen_Site, CallTimer, Adjacent_Site, …)
+	OpMaint    CSBKOpcode = 0x2A // P_MAINT — maintenance
+	OpClear    CSBKOpcode = 0x2E // P_CLEAR — channel clear
+	OpProtect  CSBKOpcode = 0x2F // P_PROTECT — protect
+	OpPVGrant  CSBKOpcode = 0x30 // Private Voice Channel Grant
+	OpTVGrant  CSBKOpcode = 0x31 // TalkGroup Voice Channel Grant
+	OpBTVGrant CSBKOpcode = 0x32 // Broadcast TalkGroup Voice Channel Grant
+	OpPDGrant  CSBKOpcode = 0x33 // Private Data Channel Grant
+	OpTDGrant  CSBKOpcode = 0x34 // TalkGroup Data Channel Grant
+	OpMove     CSBKOpcode = 0x39 // C_MOVE — move to another control channel
+	OpPreamble CSBKOpcode = 0x3D // Preamble CSBK — precedes a following CSBK/MBC chain
 )
 
 func (o CSBKOpcode) String() string {
 	switch o {
 	case OpAloha:
-		return "Aloha"
-	case OpRAND:
-		return "RAND"
-	case OpAckResp:
-		return "AckResponse"
+		return "C_ALOHA"
 	case OpAhoy:
-		return "Ahoy"
-	case OpMoveTSCC:
-		return "MoveTSCC"
+		return "C_AHOY"
+	case OpAckVit:
+		return "C_ACKVIT"
+	case OpRAND:
+		return "C_RAND"
+	case OpAckD:
+		return "C_ACKD"
+	case OpAckU:
+		return "C_ACKU"
+	case OpNack:
+		return "C_NACK"
+	case OpBcast:
+		return "C_BCAST"
+	case OpMaint:
+		return "P_MAINT"
+	case OpClear:
+		return "P_CLEAR"
+	case OpProtect:
+		return "P_PROTECT"
+	case OpPVGrant:
+		return "PV_GRANT"
+	case OpTVGrant:
+		return "TV_GRANT"
+	case OpBTVGrant:
+		return "BTV_GRANT"
+	case OpPDGrant:
+		return "PD_GRANT"
+	case OpTDGrant:
+		return "TD_GRANT"
+	case OpMove:
+		return "C_MOVE"
 	case OpPreamble:
 		return "Preamble"
-	case OpTVGrant:
-		return "TalkGroupVoiceChannelGrant"
-	case OpPVGrant:
-		return "PrivateVoiceChannelGrant"
-	case OpTDGrant:
-		return "TalkGroupDataChannelGrant"
-	case OpPDGrant:
-		return "PrivateDataChannelGrant"
-	case OpAdjStatus:
-		return "AdjacentSiteStatus"
-	case OpSysInfo:
-		return "SystemInfoBroadcast"
 	default:
 		return fmt.Sprintf("CSBKOpcode(%02X)", uint8(o))
 	}

--- a/internal/radio/dmr/tier3/csbk_realvectors_test.go
+++ b/internal/radio/dmr/tier3/csbk_realvectors_test.go
@@ -3,18 +3,19 @@ package tier3
 import "testing"
 
 // TestParseCSBKRealOffAirVectors pins the CSBK CRC convention (CRC-CCITT
-// poly 0x1021, init 0x0000, XOR-out mask 0x5A5A) and the C_ALOHA opcode
-// against real off-air ETSI Tier III control-channel bursts.
+// poly 0x1021, init 0x0000, XOR-out mask 0x5A5A) and the standard CSBKO
+// opcode values against real off-air ETSI Tier III control-channel bursts.
 //
-// These 12-byte info blocks were recovered from a 2 MS/s SDR capture of
-// a live DMR Tier III TSCC (440.5625 MHz): they decode cleanly through
-// BPTC(196,96) — zero corrections — and repeat identically across the
-// capture, so they are genuine CSBKs, not noise. Under the previous
-// "init 0xFFFF, store the bitwise complement" convention every one of
-// them failed CRC (the control channel never locked); they validate
-// under the 0x5A5A mask. Keeping them here as a fixture means a future
-// regression of the CRC mask or the Aloha opcode trips this test offline
-// without needing the RF capture.
+// These 12-byte info blocks were recovered from 2 MS/s SDR captures of
+// live DMR Tier III TSCCs (440.5625 MHz and 440.2625 MHz): they decode
+// cleanly through BPTC(196,96) — zero corrections — and repeat identically
+// across the capture, so they are genuine CSBKs, not noise. Under the
+// previous "init 0xFFFF, store the bitwise complement" convention every
+// one of them failed CRC (the control channel never locked); they validate
+// under the 0x5A5A mask. The opcode bytes also pin the corrected opcode
+// table: 0x28 is C_BCAST (was mislabelled "Preamble"), 0x1C is C_AHOY,
+// 0x20 is C_ACKD. A regression of the CRC mask or the opcode constants
+// trips this test offline without needing the RF capture.
 func TestParseCSBKRealOffAirVectors(t *testing.T) {
 	cases := []struct {
 		name   string
@@ -23,18 +24,40 @@ func TestParseCSBKRealOffAirVectors(t *testing.T) {
 	}{
 		{
 			// C_ALOHA — the periodic TSCC beacon the CC state machine
-			// locks on.
+			// locks on (440.5625 MHz capture).
 			name:   "aloha",
 			bytes:  []byte{0x99, 0x00, 0x49, 0x01, 0x16, 0x40, 0x03, 0x00, 0x00, 0x00, 0x05, 0x9f},
 			opcode: OpAloha,
 		},
 		{
-			// Preamble CSBK — announces following content; already had
-			// the correct opcode value, included so the fixture covers
-			// both repeating bursts in the capture.
-			name:   "preamble",
-			bytes:  []byte{0xa8, 0x00, 0x08, 0x7b, 0xd6, 0x40, 0x03, 0x06, 0x00, 0x60, 0x61, 0x5b},
-			opcode: OpPreamble,
+			// C_BCAST (Gen_Site_Params) — previously decoded as the
+			// non-existent "Preamble" opcode because 0x28 was wrongly
+			// mapped. dsd-neo decodes the identical burst as
+			// "Announcements (C_BCAST) General Site Parameters".
+			name:   "bcast_gen_site",
+			bytes:  []byte{0xa8, 0x00, 0x3a, 0x00, 0xb1, 0x40, 0x15, 0x00, 0x00, 0x80, 0x83, 0x86},
+			opcode: OpBcast,
+		},
+		{
+			// C_BCAST (CallTimer_Parms) — same 0x28 opcode, different
+			// anncd_type sub-field.
+			name:   "bcast_call_timer",
+			bytes:  []byte{0xa8, 0x00, 0x0f, 0xff, 0xf1, 0x40, 0x15, 0xff, 0xff, 0xff, 0x01, 0x61},
+			opcode: OpBcast,
+		},
+		{
+			// C_AHOY — outbound poll; previously surfaced as the unnamed
+			// CSBKOpcode(1C) because OpAhoy was wrongly 0x18.
+			name:   "ahoy",
+			bytes:  []byte{0x9c, 0x00, 0x00, 0x0e, 0x00, 0x02, 0xd0, 0xff, 0xfe, 0xca, 0x94, 0x25},
+			opcode: OpAhoy,
+		},
+		{
+			// C_ACKD — acknowledged downlink response; previously the
+			// unnamed CSBKOpcode(20).
+			name:   "ackd",
+			bytes:  []byte{0xa0, 0x00, 0x00, 0xc4, 0x00, 0x03, 0x45, 0xff, 0xfe, 0xc6, 0x4a, 0x9c},
+			opcode: OpAckD,
 		},
 	}
 	for _, tc := range cases {

--- a/internal/radio/dmr/tier3/csbk_test.go
+++ b/internal/radio/dmr/tier3/csbk_test.go
@@ -100,10 +100,13 @@ func TestInfoBitsToBytes(t *testing.T) {
 
 func TestOpcodeString(t *testing.T) {
 	cases := map[CSBKOpcode]string{
-		OpAloha:          "Aloha",
-		OpTVGrant:        "TalkGroupVoiceChannelGrant",
-		OpSysInfo:        "SystemInfoBroadcast",
-		OpAdjStatus:      "AdjacentSiteStatus",
+		OpAloha:          "C_ALOHA",
+		OpAhoy:           "C_AHOY",
+		OpAckD:           "C_ACKD",
+		OpBcast:          "C_BCAST",
+		OpTVGrant:        "TV_GRANT",
+		OpPVGrant:        "PV_GRANT",
+		OpPreamble:       "Preamble",
 		CSBKOpcode(0xFE): "CSBKOpcode(FE)",
 	}
 	for op, want := range cases {

--- a/internal/radio/dmr/tier3/payloads.go
+++ b/internal/radio/dmr/tier3/payloads.go
@@ -52,9 +52,11 @@ func ParsePVGrant(p [8]byte) PVGrant {
 	}
 }
 
-// Aloha (CSBKO 0x04) — outbound Aloha message advertising the trunked
-// control channel. Payload first nibble is the Site Time Slot (STS) bitmap;
-// the remainder carries CC information.
+// Aloha (CSBKO 0x19, C_ALOHA) — outbound Aloha message advertising the
+// trunked control channel. Payload first nibble is the Site Time Slot
+// (STS) bitmap; the remainder carries CC information. SystemID is the raw
+// 16-bit network/site identity field (not dsd-neo's decoded syscode); the
+// CC state machine uses it as a stable lock key.
 type Aloha struct {
 	SyncRandom    uint8 // 4 bits
 	NRandWaits    uint8 // 4 bits
@@ -75,43 +77,88 @@ func ParseAloha(p [8]byte) Aloha {
 	}
 }
 
-// AdjacentSiteStatus (CSBKO 0x38). Carries an adjacent-site descriptor:
-// the site identifier, its control-channel LCN, color code, and a
-// quality / availability flag set.
+// Broadcast announcement sub-types carried inside C_BCAST (CSBKO 0x28,
+// OpBcast). The 5-bit anncd_type occupies the top of the first payload
+// octet — ETSI TS 102 361-4 §7.2.x / IanWraith DMRDecode. Validated
+// against real off-air C_BCAST bursts: Gen_Site_Params (7) decodes from
+// payload[0]=0x3A, CallTimer_Parms (1) from payload[0]=0x0F.
+const (
+	AnncWDTSCC         uint8 = 0 // announce / withdraw TSCC
+	AnncCallTimerParms uint8 = 1 // specify call-timer parameters
+	AnncVoteNow        uint8 = 2 // vote-now advice
+	AnncLocalTime      uint8 = 3 // broadcast local time
+	AnncMassReg        uint8 = 4 // mass registration
+	AnncChanFreq       uint8 = 5 // logical-channel / frequency relationship
+	AnncAdjacentSite   uint8 = 6 // adjacent-site information
+	AnncGenSiteParms   uint8 = 7 // general site parameters
+)
+
+// BroadcastAnnouncement is a parsed C_BCAST CSBK. Type selects how the
+// remaining octets are interpreted; Payload retains the full 8-octet
+// broadcast payload so type-specific helpers can re-read it.
+type BroadcastAnnouncement struct {
+	Type    uint8
+	Payload [8]byte
+}
+
+// ParseBroadcast extracts the anncd_type from a C_BCAST payload.
+func ParseBroadcast(p [8]byte) BroadcastAnnouncement {
+	return BroadcastAnnouncement{Type: p[0] >> 3, Payload: p}
+}
+
+// AdjacentSiteStatus is an adjacent-site descriptor carried as the
+// Adjacent_Site (anncd_type 6) sub-type of C_BCAST: the neighbour's
+// system + site identifier, its control-channel LCN, and color code.
+// The sub-fields follow the anncd_type octet, so they are read from
+// payload[1:].
 type AdjacentSiteStatus struct {
 	SystemID  uint16
 	SiteID    uint16
 	LCN       uint16
 	ColorCode uint8
-	Status    uint8
 }
 
-func ParseAdjacentSiteStatus(p [8]byte) AdjacentSiteStatus {
+func ParseAdjacentSite(p [8]byte) AdjacentSiteStatus {
 	return AdjacentSiteStatus{
-		SystemID:  binary.BigEndian.Uint16(p[0:2]),
-		SiteID:    binary.BigEndian.Uint16(p[2:4]),
-		LCN:       binary.BigEndian.Uint16(p[4:6]),
-		ColorCode: p[6] >> 4,
-		Status:    p[6] & 0x0F,
+		SystemID:  binary.BigEndian.Uint16(p[1:3]),
+		SiteID:    binary.BigEndian.Uint16(p[3:5]),
+		LCN:       binary.BigEndian.Uint16(p[5:7]),
+		ColorCode: p[7] >> 4,
 	}
 }
 
-// SystemInfoBroadcast (CSBKO 0x39). Announces the System ID, RFSS, and
-// site number associated with the listening channel.
+// SystemInfoBroadcast announces the System ID, RFSS, and site number for
+// the camped site. For standard ETSI traffic this rides in the
+// Gen_Site_Params (anncd_type 7) sub-type of C_BCAST (fields read from
+// payload[1:] via ParseGenSiteParams). The Motorola Capacity Plus / Max
+// vendor path reuses the struct over a raw 8-octet payload
+// (ParseSystemInfoBroadcast).
 type SystemInfoBroadcast struct {
 	SystemID uint16
 	RFSSID   uint8
 	SiteID   uint8
 	NetMask  uint8
-	Reserved uint16
 }
 
+// ParseGenSiteParams reads the camped-site identity from a C_BCAST
+// Gen_Site_Params payload (sub-fields after the anncd_type octet).
+func ParseGenSiteParams(p [8]byte) SystemInfoBroadcast {
+	return SystemInfoBroadcast{
+		SystemID: binary.BigEndian.Uint16(p[1:3]),
+		RFSSID:   p[3],
+		SiteID:   p[4],
+		NetMask:  p[5],
+	}
+}
+
+// ParseSystemInfoBroadcast reads a vendor (Motorola Cap+) system-info
+// payload where the identity begins at octet 0. The SiteID octet doubles
+// as the Capacity Plus rest-channel LCN pointer.
 func ParseSystemInfoBroadcast(p [8]byte) SystemInfoBroadcast {
 	return SystemInfoBroadcast{
 		SystemID: binary.BigEndian.Uint16(p[0:2]),
 		RFSSID:   p[2],
 		SiteID:   p[3],
 		NetMask:  p[4],
-		Reserved: binary.BigEndian.Uint16(p[6:8]),
 	}
 }

--- a/internal/radio/dmr/tier3/topology.go
+++ b/internal/radio/dmr/tier3/topology.go
@@ -2,8 +2,8 @@ package tier3
 
 import "sync"
 
-// NeighborSite is one adjacent site advertised by an Adjacent Site Status CSBK
-// (0x38), de-duplicated by SiteID.
+// NeighborSite is one adjacent site advertised by a C_BCAST Adjacent_Site
+// announcement (CSBKO 0x28, anncd_type 6), de-duplicated by SiteID.
 type NeighborSite struct {
 	SystemID  uint16
 	SiteID    uint16
@@ -32,8 +32,8 @@ type topologyModel struct {
 	cfg TopologyConfig
 }
 
-// applySystemInfo folds a System Information Broadcast (0x39): the camped
-// site's SystemID/RFSS/Site. First non-zero values win.
+// applySystemInfo folds a vendor (Motorola Cap+) System Information CSBK:
+// the camped site's SystemID/RFSS/Site. First non-zero values win.
 func (m *topologyModel) applySystemInfo(si SystemInfoBroadcast) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -48,7 +48,23 @@ func (m *topologyModel) applySystemInfo(si SystemInfoBroadcast) {
 	}
 }
 
-// applyIdentity folds the SystemID + ColorCode seen on an Aloha / SysInfo CSBK.
+// applySiteParams folds the RFSS + Site number from a C_BCAST
+// Gen_Site_Params announcement without disturbing the SystemID established
+// by the Aloha beacon (whose raw identity field is the authoritative lock
+// key). First non-zero values win.
+func (m *topologyModel) applySiteParams(rfss, site uint8) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.cfg.RFSS == 0 && rfss != 0 {
+		m.cfg.RFSS = rfss
+	}
+	if m.cfg.Site == 0 && site != 0 {
+		m.cfg.Site = site
+	}
+}
+
+// applyIdentity folds the SystemID + ColorCode seen on an Aloha / C_BCAST
+// Gen_Site_Params CSBK.
 func (m *topologyModel) applyIdentity(systemID uint16, colorCode uint8) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -60,8 +76,8 @@ func (m *topologyModel) applyIdentity(systemID uint16, colorCode uint8) {
 	}
 }
 
-// applyAdjacent folds an Adjacent Site Status CSBK (0x38), de-duplicating by
-// SiteID (last write wins for a given site's details).
+// applyAdjacent folds a C_BCAST Adjacent_Site announcement, de-duplicating
+// by SiteID (last write wins for a given site's details).
 func (m *topologyModel) applyAdjacent(a AdjacentSiteStatus) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/internal/radio/dmr/tier3/topology_test.go
+++ b/internal/radio/dmr/tier3/topology_test.go
@@ -11,12 +11,14 @@ func TestTopologyAccumulation(t *testing.T) {
 	defer bus.Close()
 	c := New(Options{Bus: bus, FrequencyHz: 851_000_000})
 
-	// System Information Broadcast (0x39): SystemID=0x1234, RFSS=5, Site=7.
-	c.handleCSBK(3, CSBK{Opcode: OpSysInfo, Payload: [8]byte{0x12, 0x34, 0x05, 0x07}})
-	// Two adjacent sites (0x38); the second repeats site 3 → de-duped.
-	c.handleCSBK(3, CSBK{Opcode: OpAdjStatus, Payload: [8]byte{0x12, 0x34, 0x00, 0x03, 0x00, 0x09, 0x10}})
-	c.handleCSBK(3, CSBK{Opcode: OpAdjStatus, Payload: [8]byte{0x12, 0x34, 0x00, 0x04, 0x00, 0x0A, 0x10}})
-	c.handleCSBK(3, CSBK{Opcode: OpAdjStatus, Payload: [8]byte{0x12, 0x34, 0x00, 0x03, 0x00, 0x09, 0x10}})
+	// C_BCAST Gen_Site_Params (anncd_type 7 → payload[0]=0x38):
+	// SystemID=0x1234, RFSS=5, Site=7.
+	c.handleCSBK(3, CSBK{Opcode: OpBcast, Payload: [8]byte{0x38, 0x12, 0x34, 0x05, 0x07}})
+	// Two adjacent sites via C_BCAST Adjacent_Site (anncd_type 6 →
+	// payload[0]=0x30); the second repeats site 3 → de-duped.
+	c.handleCSBK(3, CSBK{Opcode: OpBcast, Payload: [8]byte{0x30, 0x12, 0x34, 0x00, 0x03, 0x00, 0x09, 0x10}})
+	c.handleCSBK(3, CSBK{Opcode: OpBcast, Payload: [8]byte{0x30, 0x12, 0x34, 0x00, 0x04, 0x00, 0x0A, 0x10}})
+	c.handleCSBK(3, CSBK{Opcode: OpBcast, Payload: [8]byte{0x30, 0x12, 0x34, 0x00, 0x03, 0x00, 0x09, 0x10}})
 
 	topo := c.Topology()
 	if topo.SystemID != 0x1234 {

--- a/internal/radio/dmr/tier3/vendor.go
+++ b/internal/radio/dmr/tier3/vendor.go
@@ -70,10 +70,10 @@ func (c *ControlChannel) handleVendorCSBK(vendor Vendor, cc uint8, csbk CSBK) {
 			c.publishVendorTVGrant(vendor, cc, ParseTVGrant(csbk.Payload))
 		case OpPVGrant:
 			c.publishVendorPVGrant(vendor, cc, ParsePVGrant(csbk.Payload))
-		case OpSysInfo, OpAloha:
+		case OpBcast, OpAloha:
 			// Capacity Plus advertises its current rest channel in
-			// the system-info CSBK; the LCN field doubles as the
-			// rest-channel pointer.
+			// the system-info / broadcast CSBK; the LCN field doubles
+			// as the rest-channel pointer.
 			rest := ParseSystemInfoBroadcast(csbk.Payload)
 			c.restChannel = rest.SiteID // LCN of the rest channel
 			c.maybeLock(LockState{FrequencyHz: c.freqHz, ColorCode: cc, SystemID: rest.SystemID})

--- a/internal/radio/dmr/tier3/vendor_test.go
+++ b/internal/radio/dmr/tier3/vendor_test.go
@@ -101,7 +101,7 @@ func TestVendorCSBKNotMisparsedAsStandard(t *testing.T) {
 	})
 	csbk := CSBK{
 		LB:      true,
-		Opcode:  OpTVGrant, // 0x30 — collides with the standard opcode
+		Opcode:  OpTVGrant, // collides with the standard grant opcode
 		FID:     FIDConnectPlus,
 		Payload: tvGrantPayload(0x1234, 0x5678, 4),
 	}
@@ -125,7 +125,7 @@ func TestMotorolaVendorSysInfoLocks(t *testing.T) {
 	cc := New(Options{Bus: bus, FrequencyHz: 851_000_000})
 	csbk := CSBK{
 		LB:      true,
-		Opcode:  OpSysInfo,
+		Opcode:  OpBcast,
 		FID:     FIDMotorola,
 		Payload: [8]byte{0xCA, 0xFE, 0x01, 0x07, 0xFF, 0, 0, 0},
 	}


### PR DESCRIPTION
The Tier III CSBKO constants were wrong in several places, so the
control-channel debug log mislabelled traffic and looked sparse/laggy
next to dsd-neo:

- 0x28 was mapped to "Preamble" but is actually C_BCAST (broadcast
  announcements: Gen_Site_Params, CallTimer_Parms, Adjacent_Site).
  Every "opcode=Preamble" line was really a broadcast.
- C_AHOY (0x1C) and C_ACKD (0x20) had no/wrong entries, so they showed
  as the unnamed CSBKOpcode(1C) / CSBKOpcode(20).
- The voice-grant opcodes were swapped (0x30 is PV_GRANT, 0x31 is
  TV_GRANT) and TD_GRANT belongs at 0x34 (0x32 is BTV_GRANT).
- SystemInfo (0x39) and AdjStatus (0x38) were invented standalone
  opcodes; in ETSI those are anncd_type sub-types of C_BCAST, and 0x39
  is really C_MOVE — they never matched real traffic.

Rebuild the opcode table to ETSI TS 102 361-4 values (names mirror
dsd-neo: C_ALOHA, C_AHOY, C_ACKD, C_BCAST, PV/TV/BTV/PD/TD_GRANT,
C_MOVE, real Preamble at 0x3D). Decode C_BCAST announcements and fold
Gen_Site_Params / Adjacent_Site into the topology model; locking stays
Aloha-driven to avoid lock churn. Log every standard CSBK at debug so
the dominant Aloha beacon is visible instead of being silently consumed
after lock.

Pin the corrected opcodes + CRC convention with real off-air vectors
(C_BCAST, C_AHOY, C_ACKD) and migrate the topology/vendor tests onto
the C_BCAST sub-type path.

https://claude.ai/code/session_01TzLNWb1jPCfazwY1WcGWYK