### PR TITLE
Fix live hunt failing when no control SDR is assigned

### DIFF
--- a/cmd/gophertrunk/hunt_acquire.go
+++ b/cmd/gophertrunk/hunt_acquire.go
@@ -21,9 +21,11 @@ import (
 //   - Otherwise it borrows the control SDR.
 //
 // hasBroker reports whether an iqtap broker exists for a serial (a live hunt
-// needs one). It returns an error when the chosen SDR has no broker, or when no
-// usable SDR exists at all.
-func chooseHuntSDR(requestedSerial, controlSerial string, voiceSerials []string, hasBroker func(string) bool) (serial string, borrow bool, err error) {
+// needs one). poolSerials is every pooled SDR's serial in deterministic order
+// (pool.Entries() insertion order) and backs a last-resort fallback. It returns
+// an error when the chosen SDR has no broker, or when no usable SDR exists at
+// all.
+func chooseHuntSDR(requestedSerial, controlSerial string, voiceSerials, poolSerials []string, hasBroker func(string) bool) (serial string, borrow bool, err error) {
 	if requestedSerial != "" {
 		if !hasBroker(requestedSerial) {
 			return "", false, fmt.Errorf("hunt: SDR %q has no IQ broker (not in the pool?)", requestedSerial)
@@ -40,6 +42,17 @@ func chooseHuntSDR(requestedSerial, controlSerial string, voiceSerials []string,
 	if controlSerial != "" && hasBroker(controlSerial) {
 		return controlSerial, true, nil
 	}
+	// Last resort: any pooled SDR with a broker. Covers configs with no
+	// trunked system yet (the discovery use case the Hunt feature exists
+	// for), wideband-only rigs, and dongles with a blank USB serial — all of
+	// which leave controlSerial unset even though a usable SDR is sitting
+	// idle. Borrow (pausing the cchunt supervisor) only when the pick is the
+	// control SDR.
+	for _, s := range poolSerials {
+		if hasBroker(s) {
+			return s, s == controlSerial, nil
+		}
+	}
 	return "", false, fmt.Errorf("hunt: no SDR with an IQ broker available for a live hunt")
 }
 
@@ -51,13 +64,16 @@ func chooseHuntSDR(requestedSerial, controlSerial string, voiceSerials []string,
 // restores it.
 func (d *Daemon) buildHuntAcquirer() hunt.Acquirer {
 	return func(ctx context.Context, opts hunt.LiveHuntOptions) (hunt.IQSource, func(), error) {
-		var voiceSerials []string
+		var voiceSerials, poolSerials []string
 		if d.pool != nil {
 			for _, e := range d.pool.AllByRole(sdr.RoleVoice) {
 				voiceSerials = append(voiceSerials, e.Info.Serial)
 			}
+			for _, e := range d.pool.Entries() {
+				poolSerials = append(poolSerials, e.Info.Serial)
+			}
 		}
-		serial, borrow, err := chooseHuntSDR(opts.Serial, d.controlSerial, voiceSerials, func(s string) bool {
+		serial, borrow, err := chooseHuntSDR(opts.Serial, d.controlSerial, voiceSerials, poolSerials, func(s string) bool {
 			return d.iqBrokers[s] != nil
 		})
 		if err != nil {

--- a/cmd/gophertrunk/hunt_acquire_test.go
+++ b/cmd/gophertrunk/hunt_acquire_test.go
@@ -3,7 +3,8 @@ package main
 import "testing"
 
 func TestChooseHuntSDR(t *testing.T) {
-	brokers := map[string]bool{"ctrl": true, "voice1": true, "voice2": true}
+	// "" is keyed so the blank-USB-serial fallback case has a broker.
+	brokers := map[string]bool{"ctrl": true, "voice1": true, "voice2": true, "": true}
 	has := func(s string) bool { return brokers[s] }
 
 	cases := []struct {
@@ -11,6 +12,7 @@ func TestChooseHuntSDR(t *testing.T) {
 		requested  string
 		control    string
 		voice      []string
+		pool       []string
 		wantSerial string
 		wantBorrow bool
 		wantErr    bool
@@ -50,10 +52,29 @@ func TestChooseHuntSDR(t *testing.T) {
 			requested: "", control: "", voice: nil,
 			wantErr: true,
 		},
+		{
+			// Discovery use case: an SDR is pooled but no trunked system is
+			// configured, so it has no control role and controlSerial is empty.
+			name:      "auto falls back to any pooled broker (no control)",
+			requested: "", control: "", voice: nil, pool: []string{"ctrl"},
+			wantSerial: "ctrl", wantBorrow: false,
+		},
+		{
+			// Blank USB serial: control SDR is keyed under "", so controlSerial
+			// is "" but the device is still borrowable via the pool fallback.
+			name:      "auto falls back to blank-serial control and borrows",
+			requested: "", control: "", voice: nil, pool: []string{""},
+			wantSerial: "", wantBorrow: true,
+		},
+		{
+			name:      "auto errors when pooled SDR has no broker",
+			requested: "", control: "", voice: nil, pool: []string{"nobroker"},
+			wantErr: true,
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			serial, borrow, err := chooseHuntSDR(c.requested, c.control, c.voice, has)
+			serial, borrow, err := chooseHuntSDR(c.requested, c.control, c.voice, c.pool, has)
 			if c.wantErr {
 				if err == nil {
 					t.Fatalf("expected error, got serial=%q borrow=%v", serial, borrow)


### PR DESCRIPTION
A live hunt always failed with "no SDR with an IQ broker available for a
live hunt" whenever no trunked system was configured. chooseHuntSDR's
auto-select path only considered a spare voice SDR (needs >=2) or the
control SDR (d.controlSerial), but controlSerial is only assigned when a
trunked system is configured and CC hunt is enabled. The hunt manager,
however, is created whenever any IQ broker exists, so the natural
discovery workflow -- point one SDR at the air to find an unknown system,
with no system configured -- left controlSerial empty and bailed out even
though a usable SDR with a broker was sitting idle. The same dead-end hit
wideband-only rigs and dongles with a blank USB serial.

Add a last-resort fallback that picks any pooled SDR with a broker,
borrowing (and pausing the cchunt supervisor) only when the pick is the
control SDR.