### PR TITLE
Fix DMR Tier III voice-grant LCN parsed from wrong bits (#639)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,23 @@ for tagged releases.
 
 ### Fixed
 
+- **DMR Tier III voice-grant LCN read from the wrong bits (#639).** The
+  TalkGroup/Private voice-grant CSBK parser used the wrong field layout: it
+  read the "LCN" from the last payload octet — which is actually the low byte
+  of the 24-bit source (subscriber) address — so the decoded Logical Channel
+  Number changed with every transmitting radio, even on a system with only a
+  couple of fixed channels. The grant content actually leads with a 12-bit
+  Logical Physical Channel Number (LPCN), followed by the target then source
+  addresses (per ETSI TS 102 361-4, cross-checked against the dsd-neo decoder).
+  The parser now extracts the LPCN from the leading payload bits and the
+  addresses from their correct octets, and the LCN is widened from 7 to 12 bits
+  end-to-end (parser, band-plan resolver, autoconfig learner, config, events).
+  This unbreaks both operator-supplied `dmr_band_plan` tables and the LCN
+  autoconfiguration learner, which previously never converged because it saw a
+  fresh LCN on every call. (Encrypted/Emergency are no longer reported from a
+  DMR grant — those are signaled in the voice Link Control, not the channel
+  grant CSBK.)
+
 - **DMR now decodes real over-the-air control channels.** The DMR receiver
   previously decoded only the zero-offset, level-matched synthesized fixtures;
   on a real SDR capture every BPTC(196,96) payload came back uncorrectable, so

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -612,7 +612,7 @@ trunking:
       # rid_alias_file: "../config/rids-p25.csv"
 
     # DMR Tier III trunked system. A T3 voice-grant CSBK references its
-    # traffic channel by a 7-bit Logical Channel Number (LCN), never an
+    # traffic channel by a 12-bit Logical Channel Number (LCN), never an
     # absolute frequency, so the decoder needs a `dmr_band_plan` to map
     # LCN → downlink Hz. Provide exactly one of `linear` or `table`.
     #

--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -329,7 +329,7 @@ The engine picks the right state machine per channel (Tier III's
 for `protocol: dmr-tier2`).
 
 A DMR Tier III voice-grant CSBK identifies its traffic channel by a
-7-bit Logical Channel Number (LCN), not an absolute frequency, so the
+12-bit Logical Channel Number (LCN), not an absolute frequency, so the
 T3 system **must** carry a `dmr_band_plan` to resolve LCN → downlink
 Hz. Provide exactly one of:
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1147,8 +1147,8 @@ type SystemConfig struct {
 	// Ignored for non-P25-Phase-1 protocols.
 	P25BandPlan []P25BandPlanEntryConfig `yaml:"p25_band_plan"`
 
-	// DMRBandPlan maps the 7-bit Logical Channel Number (LCN) carried
-	// in each DMR Tier III voice-grant CSBK to a downlink frequency.
+	// DMRBandPlan maps the 12-bit Logical (Physical) Channel Number (LCN)
+	// carried in each DMR Tier III voice-grant CSBK to a downlink frequency.
 	// REQUIRED for T3 voice — T3 grants reference a channel by LCN, not
 	// an absolute frequency, so without this plan every grant is
 	// dropped with decode.error stage=no-bandplan. Provide exactly one
@@ -1203,7 +1203,7 @@ type DMRLinearBandPlanConfig struct {
 // DMRBandPlanTableEntryConfig is one explicit LCN→downlink-frequency
 // mapping for sites whose channels don't fall on a regular grid.
 type DMRBandPlanTableEntryConfig struct {
-	LCN    uint8  `yaml:"lcn"`
+	LCN    uint16 `yaml:"lcn"`
 	FreqHz uint32 `yaml:"freq_hz"`
 }
 
@@ -1758,7 +1758,7 @@ func validateSystem(i int, s SystemConfig) error {
 			}
 		}
 		if hasTable {
-			seenLCN := make(map[uint8]int, len(bp.Table))
+			seenLCN := make(map[uint16]int, len(bp.Table))
 			for k, e := range bp.Table {
 				if e.FreqHz == 0 {
 					return fmt.Errorf("trunking.systems[%d].dmr_band_plan.table[%d]: freq_hz required (nonzero)", i, k)

--- a/internal/configbuilder/fieldmeta.go
+++ b/internal/configbuilder/fieldmeta.go
@@ -175,7 +175,7 @@ var fieldMetas = map[string]FieldMeta{
 	"DMRLinearBandPlanConfig.BaseHz":     {Label: "Base frequency", Hz: true, Help: "Downlink frequency of the first LCN."},
 	"DMRLinearBandPlanConfig.SpacingHz":  {Label: "Spacing", Hz: true, Help: "Frequency step between consecutive LCNs."},
 	"DMRLinearBandPlanConfig.Offset":     {Help: "LCN the grid starts numbering from. Set 1 for sites that number LCNs from 1."},
-	"DMRBandPlanTableEntryConfig.LCN":    {Label: "LCN", Help: "7-bit Logical Channel Number from the grant CSBK."},
+	"DMRBandPlanTableEntryConfig.LCN":    {Label: "LCN", Help: "12-bit Logical (Physical) Channel Number from the grant CSBK."},
 	"DMRBandPlanTableEntryConfig.FreqHz": {Label: "Frequency", Hz: true, Help: "Downlink frequency this LCN maps to."},
 
 	"EncryptionKeyConfig.KeyID":     {Label: "Key ID", Help: "Key identifier the radios carry in the privacy header, so a system that rotates keys still resolves."},

--- a/internal/events/bus.go
+++ b/internal/events/bus.go
@@ -254,7 +254,7 @@ type DecodeError struct {
 type DMRGrantObserved struct {
 	System    string
 	ColorCode uint8
-	LCN       uint8
+	LCN       uint16
 	Timeslot  uint8
 	GroupID   uint32
 	SourceID  uint32
@@ -282,7 +282,7 @@ type DMRBandPlanLearned struct {
 // DMRBandPlanLCN is one explicit LCN→downlink-frequency entry in a
 // learned irregular (table) band plan.
 type DMRBandPlanLCN struct {
-	LCN    uint8
+	LCN    uint16
 	FreqHz uint32
 }
 

--- a/internal/radio/dmr/tier3/bandplan.go
+++ b/internal/radio/dmr/tier3/bandplan.go
@@ -7,13 +7,14 @@ import (
 	"github.com/MattCheramie/GopherTrunk/internal/trunking"
 )
 
-// Resolver maps a 7-bit DMR Tier III LCN to its downlink frequency
-// in Hz. Two implementations ship: LinearBandPlan for sites that lay
-// channels out on a regular base+spacing grid, and TableBandPlan for
-// the irregular cases (where the operator hand-codes the LCN → Hz
-// mapping from a license / coordination database).
+// Resolver maps a 12-bit DMR Tier III LCN (Logical Physical Channel
+// Number) to its downlink frequency in Hz. Two implementations ship:
+// LinearBandPlan for sites that lay channels out on a regular
+// base+spacing grid, and TableBandPlan for the irregular cases (where
+// the operator hand-codes the LCN → Hz mapping from a license /
+// coordination database).
 type Resolver interface {
-	Frequency(lcn uint8) (uint32, error)
+	Frequency(lcn uint16) (uint32, error)
 }
 
 // ErrUnknownLCN is returned by a Resolver when the supplied LCN is
@@ -31,7 +32,7 @@ type LinearBandPlan struct {
 	Offset    int8 // typically 1 to match LCN-1-indexed sites
 }
 
-func (b LinearBandPlan) Frequency(lcn uint8) (uint32, error) {
+func (b LinearBandPlan) Frequency(lcn uint16) (uint32, error) {
 	if b.SpacingHz == 0 {
 		return 0, fmt.Errorf("dmr/tier3: linear band plan needs non-zero SpacingHz")
 	}
@@ -48,9 +49,9 @@ func (b LinearBandPlan) Frequency(lcn uint8) (uint32, error) {
 
 // TableBandPlan is a hand-coded LCN → Hz lookup. The map is consulted
 // directly; missing keys return ErrUnknownLCN.
-type TableBandPlan map[uint8]uint32
+type TableBandPlan map[uint16]uint32
 
-func (t TableBandPlan) Frequency(lcn uint8) (uint32, error) {
+func (t TableBandPlan) Frequency(lcn uint16) (uint32, error) {
 	hz, ok := t[lcn]
 	if !ok {
 		return 0, fmt.Errorf("%w: lcn=%d", ErrUnknownLCN, lcn)

--- a/internal/radio/dmr/tier3/control.go
+++ b/internal/radio/dmr/tier3/control.go
@@ -191,7 +191,7 @@ func (c *ControlChannel) handleBroadcast(cc uint8, b BroadcastAnnouncement) {
 // DMR call's slot becomes part of the engine's (frequency, timeslot)
 // call identity — both slots of a 12.5 kHz carrier carry independent
 // calls.
-func (c *ControlChannel) publishGrant(cc, lcn, slot uint8, group, source uint32, serviceOptions uint8) (uint32, bool) {
+func (c *ControlChannel) publishGrant(cc uint8, lcn uint16, slot uint8, group, source uint32) (uint32, bool) {
 	// Observe the granted LCN before resolution so the autoconfig learner
 	// sees it even when no band plan is configured yet (the very case it
 	// exists to fix). Additive: success/no-bandplan behaviour is unchanged.
@@ -221,19 +221,20 @@ func (c *ControlChannel) publishGrant(cc, lcn, slot uint8, group, source uint32,
 			SourceID:            source,
 			FrequencyHz:         freq,
 			ChannelID:           cc,
-			ChannelNum:          uint16(lcn),
+			ChannelNum:          lcn,
 			Timeslot:            slot + 1,
 			DMRInterleavedVoice: c.interleavedVoice,
-			Encrypted:           serviceOptions&0x40 != 0,
-			Emergency:           serviceOptions&0x80 != 0,
-			At:                  c.now(),
+			// Encrypted/Emergency are not carried in the ETSI channel-grant
+			// CSBK content (which leads with the LPCN, not service options);
+			// DMR privacy is signaled in the voice LC, not the grant.
+			At: c.now(),
 		},
 	})
 	return freq, true
 }
 
 func (c *ControlChannel) publishTVGrant(cc uint8, g TVGrant) {
-	freq, ok := c.publishGrant(cc, g.LCN, g.Timeslot, g.GroupAddress, g.SourceID, g.ServiceOptions)
+	freq, ok := c.publishGrant(cc, g.LCN, g.Timeslot, g.GroupAddress, g.SourceID)
 	if !ok {
 		return
 	}
@@ -243,7 +244,7 @@ func (c *ControlChannel) publishTVGrant(cc uint8, g TVGrant) {
 }
 
 func (c *ControlChannel) publishPVGrant(cc uint8, g PVGrant) {
-	freq, ok := c.publishGrant(cc, g.LCN, g.Timeslot, g.DestinationID, g.SourceID, g.ServiceOptions)
+	freq, ok := c.publishGrant(cc, g.LCN, g.Timeslot, g.DestinationID, g.SourceID)
 	if !ok {
 		return
 	}
@@ -271,7 +272,7 @@ func (c *ControlChannel) HasResolver() bool {
 	return c.resolver != nil
 }
 
-func (c *ControlChannel) resolveLCN(lcn uint8) (uint32, bool) {
+func (c *ControlChannel) resolveLCN(lcn uint16) (uint32, bool) {
 	c.resolverMu.RLock()
 	resolver := c.resolver
 	c.resolverMu.RUnlock()

--- a/internal/radio/dmr/tier3/control_test.go
+++ b/internal/radio/dmr/tier3/control_test.go
@@ -108,12 +108,12 @@ func TestControlChannelPublishesTVGrant(t *testing.T) {
 		Resolver:    LinearBandPlan{BaseHz: 866_000_000, SpacingHz: 25_000, Offset: 1},
 		Now:         func() time.Time { return time.Unix(1_700_000_000, 0).UTC() },
 	})
-	// Service options 0xC0 = encrypted+emergency, dst 0x123456, src 0xABCDEF,
-	// byte 7 = 0x88 → TS2, LCN 8.
+	// LPCN 8 (p[0]=0, p[1]=8<<4|1<<3=0x88 → TS2), group 0x123456 at
+	// octets 2-4, source 0xABCDEF at octets 5-7.
 	csbk := CSBK{
 		LB:      true,
 		Opcode:  OpTVGrant,
-		Payload: [8]byte{0xC0, 0x12, 0x34, 0x56, 0xAB, 0xCD, 0xEF, 0x88},
+		Payload: [8]byte{0x00, 0x88, 0x12, 0x34, 0x56, 0xAB, 0xCD, 0xEF},
 	}
 	cc.IngestBurst(burstWithCSBK(csbk), dmr.SlotType{ColorCode: 3, DataType: dmr.DTCSBK})
 
@@ -141,10 +141,12 @@ func TestControlChannelPublishesTVGrant(t *testing.T) {
 			if g.FrequencyHz != 866_175_000 {
 				t.Errorf("freq = %d, want 866_175_000", g.FrequencyHz)
 			}
-			if !g.Encrypted || !g.Emergency {
-				t.Errorf("flags = enc=%v emer=%v, want both", g.Encrypted, g.Emergency)
+			// The ETSI channel-grant CSBK carries no service-options octet,
+			// so Encrypted/Emergency are not derived from a grant.
+			if g.Encrypted || g.Emergency {
+				t.Errorf("flags = enc=%v emer=%v, want both false", g.Encrypted, g.Emergency)
 			}
-			// byte 7 bit 7 set → CSBK TS2 (0-based 1) → 1-based Timeslot 2.
+			// payload bit 12 set → CSBK TS2 (0-based 1) → 1-based Timeslot 2.
 			if g.Timeslot != 2 {
 				t.Errorf("Timeslot = %d, want 2 (TS2)", g.Timeslot)
 			}
@@ -170,7 +172,7 @@ func TestControlChannelGrantCarriesInterleavedFlag(t *testing.T) {
 		Resolver:         TableBandPlan{8: 866_175_000},
 		InterleavedVoice: true,
 	})
-	csbk := CSBK{LB: true, Opcode: OpTVGrant, Payload: [8]byte{0xC0, 0x12, 0x34, 0x56, 0xAB, 0xCD, 0xEF, 0x88}}
+	csbk := CSBK{LB: true, Opcode: OpTVGrant, Payload: [8]byte{0x00, 0x88, 0x12, 0x34, 0x56, 0xAB, 0xCD, 0xEF}}
 	cc.IngestBurst(burstWithCSBK(csbk), dmr.SlotType{ColorCode: 3, DataType: dmr.DTCSBK})
 
 	deadline := time.After(time.Second)
@@ -202,10 +204,12 @@ func TestControlChannelPublishesPVGrant(t *testing.T) {
 		FrequencyHz: 851_000_000,
 		Resolver:    TableBandPlan{4: 462_550_000},
 	})
+	// LPCN 4 (p[1]=4<<4=0x40, TS1), dst 0x001234 at octets 2-4, src
+	// 0x00ABCD at octets 5-7.
 	csbk := CSBK{
 		LB:      true,
 		Opcode:  OpPVGrant,
-		Payload: [8]byte{0x00, 0x00, 0x12, 0x34, 0x00, 0xAB, 0xCD, 0x04},
+		Payload: [8]byte{0x00, 0x40, 0x00, 0x12, 0x34, 0x00, 0xAB, 0xCD},
 	}
 	cc.IngestBurst(burstWithCSBK(csbk), dmr.SlotType{ColorCode: 1, DataType: dmr.DTCSBK})
 
@@ -223,7 +227,7 @@ func TestControlChannelPublishesPVGrant(t *testing.T) {
 			if g.FrequencyHz != 462_550_000 {
 				t.Errorf("freq = %d, want 462_550_000", g.FrequencyHz)
 			}
-			// byte 7 bit 7 clear → CSBK TS1 (0-based 0) → 1-based Timeslot 1.
+			// payload bit 12 clear → CSBK TS1 (0-based 0) → 1-based Timeslot 1.
 			if g.Timeslot != 1 {
 				t.Errorf("Timeslot = %d, want 1 (TS1)", g.Timeslot)
 			}
@@ -284,7 +288,7 @@ func TestControlChannelGrantOutsideBandPlanEmitsDecodeError(t *testing.T) {
 	csbk := CSBK{
 		LB:      true,
 		Opcode:  OpTVGrant,
-		Payload: [8]byte{0x00, 0x00, 0x00, 0x42, 0x00, 0x00, 0x01, 0x07}, // LCN 7
+		Payload: [8]byte{0x00, 0x70, 0x00, 0x00, 0x42, 0x00, 0x00, 0x01}, // LPCN 7
 	}
 	cc.IngestBurst(burstWithCSBK(csbk), dmr.SlotType{ColorCode: 1, DataType: dmr.DTCSBK})
 
@@ -369,8 +373,8 @@ func TestControlChannelEmitsGrantObservedWithResolver(t *testing.T) {
 		Resolver:    LinearBandPlan{BaseHz: 866_000_000, SpacingHz: 25_000, Offset: 1},
 		Now:         func() time.Time { return time.Unix(1_700_000_001, 0).UTC() },
 	})
-	// dst 0x123456, src 0xABCDEF, byte 7 = 0x88 → TS2, LCN 8.
-	csbk := CSBK{LB: true, Opcode: OpTVGrant, Payload: [8]byte{0x00, 0x12, 0x34, 0x56, 0xAB, 0xCD, 0xEF, 0x88}}
+	// LPCN 8 (p[1]=0x88 → TS2), group 0x123456, src 0xABCDEF.
+	csbk := CSBK{LB: true, Opcode: OpTVGrant, Payload: [8]byte{0x00, 0x88, 0x12, 0x34, 0x56, 0xAB, 0xCD, 0xEF}}
 	cc.IngestBurst(burstWithCSBK(csbk), dmr.SlotType{ColorCode: 5, DataType: dmr.DTCSBK})
 
 	obs, sawObs, sawGrant, _ := collectGrantObserved(t, sub)
@@ -403,7 +407,8 @@ func TestControlChannelEmitsGrantObservedWithoutResolver(t *testing.T) {
 	// nil Resolver: the LCN must still escape via KindDMRGrantObserved, and
 	// the existing no-bandplan decode error must still fire.
 	cc := New(Options{Bus: bus, SystemName: "ObsSys", FrequencyHz: 851_012_500})
-	csbk := CSBK{LB: true, Opcode: OpTVGrant, Payload: [8]byte{0x00, 0x00, 0x10, 0x00, 0x00, 0x20, 0x00, 0x0B}}
+	// LPCN 11 (p[1]=0x0B<<4=0xB0).
+	csbk := CSBK{LB: true, Opcode: OpTVGrant, Payload: [8]byte{0x00, 0xB0, 0x00, 0x10, 0x00, 0x00, 0x20, 0x00}}
 	cc.IngestBurst(burstWithCSBK(csbk), dmr.SlotType{ColorCode: 2, DataType: dmr.DTCSBK})
 
 	obs, sawObs, sawGrant, sawDecodeErr := collectGrantObserved(t, sub)
@@ -432,7 +437,7 @@ func TestControlChannelSetResolverHotSwap(t *testing.T) {
 	if cc.HasResolver() {
 		t.Fatal("HasResolver true before SetResolver")
 	}
-	csbk := CSBK{LB: true, Opcode: OpTVGrant, Payload: [8]byte{0x00, 0x00, 0x10, 0x00, 0x00, 0x20, 0x00, 0x08}}
+	csbk := CSBK{LB: true, Opcode: OpTVGrant, Payload: [8]byte{0x00, 0x80, 0x00, 0x10, 0x00, 0x00, 0x20, 0x00}}
 	cc.IngestBurst(burstWithCSBK(csbk), dmr.SlotType{ColorCode: 1, DataType: dmr.DTCSBK})
 	if _, _, sawGrant, sawDecodeErr := collectGrantObserved(t, sub); sawGrant || !sawDecodeErr {
 		t.Fatalf("pre-swap: grant=%v decodeErr=%v, want grant=false decodeErr=true", sawGrant, sawDecodeErr)
@@ -462,7 +467,7 @@ func TestControlChannelSetResolverConcurrent(t *testing.T) {
 	}()
 
 	cc := New(Options{Bus: bus, SystemName: "RaceSys", FrequencyHz: 851_012_500})
-	csbk := CSBK{LB: true, Opcode: OpTVGrant, Payload: [8]byte{0x00, 0x00, 0x10, 0x00, 0x00, 0x20, 0x00, 0x08}}
+	csbk := CSBK{LB: true, Opcode: OpTVGrant, Payload: [8]byte{0x00, 0x80, 0x00, 0x10, 0x00, 0x00, 0x20, 0x00}}
 	burst := burstWithCSBK(csbk)
 
 	done := make(chan struct{})

--- a/internal/radio/dmr/tier3/csbk_test.go
+++ b/internal/radio/dmr/tier3/csbk_test.go
@@ -34,20 +34,20 @@ func TestCSBKDetectsCRCError(t *testing.T) {
 }
 
 func TestParseTVGrant(t *testing.T) {
-	// byte 7 = 0x95 → bit 7 set (TS2) + low 7 bits = 0x15 = LCN 21.
-	p := [8]byte{0xC0, 0x12, 0x34, 0x56, 0xAB, 0xCD, 0xEF, 0x95}
+	// LPCN 0x015 (21) in payload bits 0-11, TS2 (bit 12 set), group
+	// 0x123456 at octets 2-4, source 0xABCDEF at octets 5-7.
+	//   p[0] = 0x015 >> 4              = 0x01
+	//   p[1] = (0x015 & 0xF)<<4 | 1<<3 = 0x58
+	p := [8]byte{0x01, 0x58, 0x12, 0x34, 0x56, 0xAB, 0xCD, 0xEF}
 	g := ParseTVGrant(p)
-	if g.ServiceOptions != 0xC0 {
-		t.Errorf("ServiceOptions = %02X", g.ServiceOptions)
-	}
 	if g.GroupAddress != 0x123456 {
 		t.Errorf("Group = %06X, want 123456", g.GroupAddress)
 	}
 	if g.SourceID != 0xABCDEF {
 		t.Errorf("Source = %06X, want ABCDEF", g.SourceID)
 	}
-	if g.LCN != 0x15 {
-		t.Errorf("LCN = %d, want 21 (0x15)", g.LCN)
+	if g.LCN != 0x015 {
+		t.Errorf("LCN = %d, want 21 (0x015)", g.LCN)
 	}
 	if g.Timeslot != 1 {
 		t.Errorf("Timeslot = %d, want 1 (TS2)", g.Timeslot)
@@ -55,17 +55,41 @@ func TestParseTVGrant(t *testing.T) {
 }
 
 func TestParsePVGrant(t *testing.T) {
-	// LCN 5, TS1.
-	p := [8]byte{0x40, 0x00, 0x12, 0x34, 0x00, 0x56, 0x78, 0x05}
+	// LPCN 5, TS1, dst 0x001234, src 0x005678.
+	//   p[0] = 5 >> 4         = 0x00
+	//   p[1] = (5 & 0xF) << 4 = 0x50
+	p := [8]byte{0x00, 0x50, 0x00, 0x12, 0x34, 0x00, 0x56, 0x78}
 	g := ParsePVGrant(p)
-	if g.ServiceOptions != 0x40 {
-		t.Errorf("ServiceOptions = %02X", g.ServiceOptions)
-	}
 	if g.DestinationID != 0x001234 || g.SourceID != 0x005678 {
 		t.Errorf("dst/src = %X/%X", g.DestinationID, g.SourceID)
 	}
 	if g.LCN != 5 || g.Timeslot != 0 {
 		t.Errorf("LCN/TS = %d/%d, want 5/0", g.LCN, g.Timeslot)
+	}
+}
+
+// TestParseTVGrantLCNIndependentOfSource is the regression guard for
+// issue #639: the LPCN lives in the leading payload bits, so two grants
+// for the same channel but different transmitting radios (different
+// source addresses) must decode to the SAME LCN. The pre-fix code read
+// the LCN from the source address's low byte, so it changed on every
+// transmission.
+func TestParseTVGrantLCNIndependentOfSource(t *testing.T) {
+	// LPCN 2, TS1, group 0x000064. Only the 24-bit source differs.
+	mk := func(source uint32) [8]byte {
+		return [8]byte{
+			0x00, 0x20, // LPCN 0x002, TS1
+			0x00, 0x00, 0x64,
+			byte(source >> 16), byte(source >> 8), byte(source),
+		}
+	}
+	g1 := ParseTVGrant(mk(0x111111))
+	g2 := ParseTVGrant(mk(0x222222))
+	if g1.LCN != 2 || g2.LCN != 2 {
+		t.Fatalf("LCN leaked from source: g1=%d g2=%d, want both 2", g1.LCN, g2.LCN)
+	}
+	if g1.SourceID == g2.SourceID {
+		t.Fatal("test bug: sources should differ")
 	}
 }
 

--- a/internal/radio/dmr/tier3/payloads.go
+++ b/internal/radio/dmr/tier3/payloads.go
@@ -2,53 +2,59 @@ package tier3
 
 import "encoding/binary"
 
-// TVGrant (CSBKO 0x30) is the TalkGroup Voice Channel Grant per ETSI
-// TS 102 361-4 §7.1.2.1. Payload layout (8 octets):
+// TVGrant (CSBKO 0x31) is the TalkGroup Voice Channel Grant per ETSI
+// TS 102 361-4 §7.2. The channel-grant CSBKs share a common content
+// layout that leads with the Logical Physical Channel Number, NOT with
+// service options. Within the 8-octet payload (bits 16-79 of the CSBK,
+// indexed here as payload bits 0-63):
 //
-//	octet 0   : Service Options
-//	octet 1-3 : Destination address (talkgroup, 24-bit)
-//	octet 4-6 : Source address (subscriber, 24-bit)
-//	octet 7   : bit 7 = Timeslot (0 = TS1, 1 = TS2)
-//	            bits 6-0 = LCN (Logical Channel Number, 7-bit)
+//	payload bits 0-11  : LPCN (Logical Physical Channel Number, 12-bit)
+//	payload bit  12    : Timeslot (0 = TS1, 1 = TS2) — the 13th bit of
+//	                     the combined LPCN+TS "logical slot number"
+//	payload bits 13-15 : status/flags (unused here)
+//	octets 2-4         : Target/Group address (24-bit)
+//	octets 5-7         : Source/subscriber address (24-bit)
+//
+// Cross-checked against the dsd-neo reference decoder (dmr_csbk_parse.c):
+// LPCN at bit 16, target at bit 32, source at bit 56 of the full CSBK.
+// The earlier layout read "LCN" from octet 7 — which is actually the low
+// byte of the 24-bit source address — so the decoded LCN changed with
+// every transmitting radio (issue #639).
 //
 // The LCN feeds a per-system band-plan resolver to recover the
 // downlink frequency the engine retunes a Voice device to.
 type TVGrant struct {
-	ServiceOptions uint8
-	GroupAddress   uint32 // 24-bit
-	SourceID       uint32 // 24-bit
-	LCN            uint8  // 7-bit logical channel number
-	Timeslot       uint8  // 0 = TS1, 1 = TS2
+	GroupAddress uint32 // 24-bit
+	SourceID     uint32 // 24-bit
+	LCN          uint16 // 12-bit logical physical channel number
+	Timeslot     uint8  // 0 = TS1, 1 = TS2
 }
 
 func ParseTVGrant(p [8]byte) TVGrant {
 	return TVGrant{
-		ServiceOptions: p[0],
-		GroupAddress:   uint32(p[1])<<16 | uint32(p[2])<<8 | uint32(p[3]),
-		SourceID:       uint32(p[4])<<16 | uint32(p[5])<<8 | uint32(p[6]),
-		LCN:            p[7] & 0x7F,
-		Timeslot:       (p[7] >> 7) & 0x01,
+		LCN:          uint16(p[0])<<4 | uint16(p[1])>>4,
+		Timeslot:     (p[1] >> 3) & 0x01,
+		GroupAddress: uint32(p[2])<<16 | uint32(p[3])<<8 | uint32(p[4]),
+		SourceID:     uint32(p[5])<<16 | uint32(p[6])<<8 | uint32(p[7]),
 	}
 }
 
-// PVGrant (CSBKO 0x31) is the Private Voice Channel Grant. Layout
+// PVGrant (CSBKO 0x30) is the Private Voice Channel Grant. Layout
 // matches TVGrant but the destination address is a subscriber rather
-// than a talkgroup. The same LCN + Timeslot encoding applies.
+// than a talkgroup. The same LPCN + Timeslot encoding applies.
 type PVGrant struct {
-	ServiceOptions uint8
-	DestinationID  uint32 // 24-bit
-	SourceID       uint32 // 24-bit
-	LCN            uint8
-	Timeslot       uint8
+	DestinationID uint32 // 24-bit
+	SourceID      uint32 // 24-bit
+	LCN           uint16
+	Timeslot      uint8
 }
 
 func ParsePVGrant(p [8]byte) PVGrant {
 	return PVGrant{
-		ServiceOptions: p[0],
-		DestinationID:  uint32(p[1])<<16 | uint32(p[2])<<8 | uint32(p[3]),
-		SourceID:       uint32(p[4])<<16 | uint32(p[5])<<8 | uint32(p[6]),
-		LCN:            p[7] & 0x7F,
-		Timeslot:       (p[7] >> 7) & 0x01,
+		LCN:           uint16(p[0])<<4 | uint16(p[1])>>4,
+		Timeslot:      (p[1] >> 3) & 0x01,
+		DestinationID: uint32(p[2])<<16 | uint32(p[3])<<8 | uint32(p[4]),
+		SourceID:      uint32(p[5])<<16 | uint32(p[6])<<8 | uint32(p[7]),
 	}
 }
 

--- a/internal/radio/dmr/tier3/vendor.go
+++ b/internal/radio/dmr/tier3/vendor.go
@@ -92,7 +92,7 @@ func (c *ControlChannel) handleVendorCSBK(vendor Vendor, cc uint8, csbk CSBK) {
 // layer, not the voice codec, so the engine / recorder / vocoder paths
 // are unaffected.
 func (c *ControlChannel) publishVendorTVGrant(vendor Vendor, cc uint8, g TVGrant) {
-	freq, ok := c.publishGrant(cc, g.LCN, g.Timeslot, g.GroupAddress, g.SourceID, g.ServiceOptions)
+	freq, ok := c.publishGrant(cc, g.LCN, g.Timeslot, g.GroupAddress, g.SourceID)
 	if !ok {
 		return
 	}
@@ -103,7 +103,7 @@ func (c *ControlChannel) publishVendorTVGrant(vendor Vendor, cc uint8, g TVGrant
 
 // publishVendorPVGrant emits a private voice grant from a vendor CSBK.
 func (c *ControlChannel) publishVendorPVGrant(vendor Vendor, cc uint8, g PVGrant) {
-	freq, ok := c.publishGrant(cc, g.LCN, g.Timeslot, g.DestinationID, g.SourceID, g.ServiceOptions)
+	freq, ok := c.publishGrant(cc, g.LCN, g.Timeslot, g.DestinationID, g.SourceID)
 	if !ok {
 		return
 	}

--- a/internal/radio/dmr/tier3/vendor_test.go
+++ b/internal/radio/dmr/tier3/vendor_test.go
@@ -28,13 +28,14 @@ func TestVendorFromFID(t *testing.T) {
 	}
 }
 
-// tvGrantPayload builds the 8-octet TVGrant CSBK payload.
-func tvGrantPayload(group, source uint32, lcn uint8) [8]byte {
+// tvGrantPayload builds the 8-octet TVGrant CSBK payload: LPCN in the
+// leading 12 bits (TS bit clear → TS1), target then source addresses.
+func tvGrantPayload(group, source uint32, lcn uint16) [8]byte {
 	return [8]byte{
-		0x00,
+		byte(lcn >> 4),
+		byte((lcn & 0x0F) << 4),
 		byte(group >> 16), byte(group >> 8), byte(group),
 		byte(source >> 16), byte(source >> 8), byte(source),
-		lcn & 0x7F,
 	}
 }
 
@@ -78,8 +79,8 @@ func TestMotorolaVendorGrantEmitted(t *testing.T) {
 			if g.Protocol != "dmr-tier3" {
 				t.Errorf("grant protocol = %q", g.Protocol)
 			}
-			// tvGrantPayload masks byte 7 to lcn&0x7F, so the slot bit is
-			// clear → CSBK TS1 → 1-based Timeslot 1.
+			// tvGrantPayload leaves the TS bit clear → CSBK TS1 → 1-based
+			// Timeslot 1.
 			if g.Timeslot != 1 {
 				t.Errorf("grant Timeslot = %d, want 1 (TS1)", g.Timeslot)
 			}

--- a/internal/scanner/dmrlcn/correlate.go
+++ b/internal/scanner/dmrlcn/correlate.go
@@ -20,7 +20,7 @@ const (
 // produced from a grant/onset coincidence. It still needs decode
 // confirmation before it is trusted as a fit Pair.
 type Candidate struct {
-	LCN    uint8
+	LCN    uint16
 	FreqHz uint32
 	Grant  events.DMRGrantObserved
 }
@@ -69,7 +69,7 @@ func (c *correlator) addGrant(obs events.DMRGrantObserved) {
 // so they don't re-match a later onset.
 func (c *correlator) matchOnset(o CarrierOnset) (Candidate, bool) {
 	var (
-		lcn      uint8
+		lcn      uint16
 		grant    events.DMRGrantObserved
 		idxs     []int
 		haveLCN  bool

--- a/internal/scanner/dmrlcn/correlate_test.go
+++ b/internal/scanner/dmrlcn/correlate_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/MattCheramie/GopherTrunk/internal/events"
 )
 
-func grantAt(lcn uint8, at time.Time) events.DMRGrantObserved {
+func grantAt(lcn uint16, at time.Time) events.DMRGrantObserved {
 	return events.DMRGrantObserved{System: "S", LCN: lcn, GroupID: uint32(lcn) * 10, At: at}
 }
 

--- a/internal/scanner/dmrlcn/dmrlcn_test.go
+++ b/internal/scanner/dmrlcn/dmrlcn_test.go
@@ -29,7 +29,7 @@ func (s stubConfirmer) Confirm(_ context.Context, freqHz uint32) (bool, float64)
 
 // feed drives one grant+onset coincidence through the learner's core
 // (correlator → confirm → fit), as Run would but synchronously.
-func (l *Learner) feed(t *testing.T, lcn uint8, freqHz uint32, at time.Time) {
+func (l *Learner) feed(t *testing.T, lcn uint16, freqHz uint32, at time.Time) {
 	t.Helper()
 	l.corr.addGrant(events.DMRGrantObserved{System: l.system, LCN: lcn, At: at})
 	cand, ok := l.corr.matchOnset(CarrierOnset{FreqHz: freqHz, At: at.Add(300 * time.Millisecond)})
@@ -64,7 +64,7 @@ func TestLearnerLocksAndAppliesPlan(t *testing.T) {
 
 	// Grid: base 851_000_000, spacing 12.5 kHz, offset 1.
 	base := time.Unix(1_700_000_000, 0)
-	for i, lcn := range []uint8{1, 2, 3, 4, 5} {
+	for i, lcn := range []uint16{1, 2, 3, 4, 5} {
 		freq := uint32(851_000_000 + int(lcn-1)*12_500)
 		l.feed(t, lcn, freq, base.Add(time.Duration(i)*time.Second))
 	}
@@ -112,7 +112,7 @@ func TestLearnerStaysOpenBelowMinLCNs(t *testing.T) {
 		Confirmer:    stubConfirmer{weight: 1},
 	})
 	base := time.Unix(1_700_000_000, 0)
-	for i, lcn := range []uint8{1, 2, 3} { // 3 < default MinLCNs (4)
+	for i, lcn := range []uint16{1, 2, 3} { // 3 < default MinLCNs (4)
 		l.feed(t, lcn, uint32(851_000_000+int(lcn-1)*12_500), base.Add(time.Duration(i)*time.Second))
 	}
 	if l.Locked() {

--- a/internal/scanner/dmrlcn/fit.go
+++ b/internal/scanner/dmrlcn/fit.go
@@ -25,7 +25,7 @@ import (
 // weighted higher than a bare energy-onset coincidence — and biases the
 // fitter's weighted-median estimates and confidence.
 type Pair struct {
-	LCN    uint8
+	LCN    uint16
 	FreqHz uint32
 	Weight float64
 }
@@ -98,7 +98,7 @@ func (r FitResult) BandPlan() *trunking.DMRBandPlan {
 // point is one deduplicated LCN observation: the single best frequency
 // chosen for an LCN plus the total weight backing it.
 type point struct {
-	lcn    uint8
+	lcn    uint16
 	freqHz uint32
 	weight float64
 }
@@ -157,7 +157,7 @@ func normalizeOptions(o FitOptions) FitOptions {
 // carried forward. Result is sorted by LCN.
 func aggregate(pairs []Pair) []point {
 	type freqWeight map[uint32]float64
-	byLCN := make(map[uint8]freqWeight)
+	byLCN := make(map[uint16]freqWeight)
 	for _, p := range pairs {
 		w := p.Weight
 		if w <= 0 {

--- a/internal/scanner/dmrlcn/fit_test.go
+++ b/internal/scanner/dmrlcn/fit_test.go
@@ -7,13 +7,13 @@ import (
 )
 
 // resolve evaluates a linear plan at an LCN the way tier3.LinearBandPlan does.
-func resolve(lp *trunking.DMRLinearBandPlan, lcn uint8) uint32 {
+func resolve(lp *trunking.DMRLinearBandPlan, lcn uint16) uint32 {
 	return uint32(int64(lp.BaseHz) + (int64(lcn)-int64(lp.Offset))*int64(lp.SpacingHz))
 }
 
 // linearPairs builds confirmed pairs on a regular grid:
 // freq = base + (lcn-offset)*spacing, weight 1.
-func linearPairs(base uint32, spacing uint32, offset int8, lcns ...uint8) []Pair {
+func linearPairs(base uint32, spacing uint32, offset int8, lcns ...uint16) []Pair {
 	out := make([]Pair, 0, len(lcns))
 	for _, l := range lcns {
 		f := int64(base) + (int64(l)-int64(offset))*int64(spacing)
@@ -34,7 +34,7 @@ func TestFitLinearCleanGrids(t *testing.T) {
 		{"6.25kHz offset0", 460_000_000, 6_250, 0},
 		{"12.5kHz offset0", 451_000_000, 12_500, 0},
 	}
-	lcns := []uint8{1, 2, 3, 5, 8, 12}
+	lcns := []uint16{1, 2, 3, 5, 8, 12}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			pairs := linearPairs(tc.base, tc.spacing, tc.offset, lcns...)
@@ -73,7 +73,7 @@ func TestFitLinearTolerATesSubBinJitter(t *testing.T) {
 	base, spacing := uint32(851_037_500), uint32(12_500)
 	jitter := []int32{+200, -150, +300, -250, +100, -300}
 	pairs := make([]Pair, 0, len(jitter))
-	for i, l := range []uint8{1, 2, 3, 4, 6, 9} {
+	for i, l := range []uint16{1, 2, 3, 4, 6, 9} {
 		f := int64(base) + (int64(l)-1)*int64(spacing) + int64(jitter[i])
 		pairs = append(pairs, Pair{LCN: l, FreqHz: uint32(f), Weight: 1})
 	}

--- a/internal/scanner/widebandt2/engine_e2e_test.go
+++ b/internal/scanner/widebandt2/engine_e2e_test.go
@@ -320,14 +320,15 @@ WaitLoop:
 
 // buildT3TVGrantDibits builds a dibit stream of repeated OpTVGrant CSBK
 // bursts (DTCSBK) for the synthesized-IQ end-to-end tests. The CSBK
-// payload mirrors tier3/control_test.go's TVGrant vector: service
-// options 0xC0, dst 0x123456, src 0xABCDEF, timeslot/LCN byte 0x88
-// (TS2, LCN 8). Burst framing matches buildT2VoiceLCHeaderDibits.
+// payload mirrors tier3/control_test.go's TVGrant vector: LPCN 8 in the
+// leading 12 bits (p[1]=0x88 → TS2), group 0x123456 at octets 2-4,
+// source 0xABCDEF at octets 5-7. Burst framing matches
+// buildT2VoiceLCHeaderDibits.
 func buildT3TVGrantDibits(repeats int, colorCode uint8) []uint8 {
 	info := tier3.AssembleCSBK(tier3.CSBK{
 		LB:      true,
 		Opcode:  tier3.OpTVGrant,
-		Payload: [8]byte{0xC0, 0x12, 0x34, 0x56, 0xAB, 0xCD, 0xEF, 0x88},
+		Payload: [8]byte{0x00, 0x88, 0x12, 0x34, 0x56, 0xAB, 0xCD, 0xEF},
 	})
 	bits := make([]byte, 96)
 	for i := 0; i < 96; i++ {

--- a/internal/trunking/site.go
+++ b/internal/trunking/site.go
@@ -117,8 +117,9 @@ type P25BandPlanEntry struct {
 	BandwidthHz uint32 // informational; not consulted by BandPlan.Frequency
 }
 
-// DMRBandPlan maps the 7-bit Logical Channel Number (LCN) carried in a
-// DMR Tier III voice-grant CSBK to its downlink frequency. T3 grants
+// DMRBandPlan maps the 12-bit Logical (Physical) Channel Number (LCN)
+// carried in a DMR Tier III voice-grant CSBK to its downlink
+// frequency. T3 grants
 // reference a channel by LCN, never an absolute frequency, so the
 // decoder cannot follow a voice call without this plan — see
 // internal/radio/dmr/tier3 (Resolver / tier3.ResolverFromPlan). The
@@ -144,7 +145,7 @@ type DMRLinearBandPlan struct {
 // DMRBandPlanTableEntry is one explicit LCN→downlink-frequency mapping
 // for sites whose channels don't fall on a regular grid.
 type DMRBandPlanTableEntry struct {
-	LCN    uint8
+	LCN    uint16
 	FreqHz uint32
 }
 


### PR DESCRIPTION
The TV/PV voice-grant CSBK parser used the wrong field layout: it read
the "LCN" from the last payload octet, which is actually the low byte of
the 24-bit source (subscriber) address. The decoded LCN therefore changed
with every transmitting radio, even on a system with only a couple of
fixed channels.

Per ETSI TS 102 361-4 (cross-checked against the dsd-neo reference
decoder), the channel-grant content leads with a 12-bit Logical Physical
Channel Number, followed by the target then source addresses. Parse the
LPCN from the leading payload bits and the addresses from their correct
octets, and widen the DMR LCN from 7 to 12 bits end-to-end (parser,
band-plan resolver, autoconfig learner, config, events, persistence).

This unbreaks both operator-supplied dmr_band_plan tables and the LCN
autoconfig learner, which previously never converged because it observed
a fresh LCN on every call. Encrypted/Emergency are no longer derived from
a grant (the ETSI grant carries no service-options octet; DMR privacy is
signaled in the voice Link Control).

Adds a regression guard asserting two grants for the same channel but
different source addresses decode to the same LCN.

https://claude.ai/code/session_01SadCH7Ptihygeh4NFTrUGw