### PR TITLE
dmr/tier3: handle data grants, MBC assembly, and inbound CSBKs

### DIFF
--- a/internal/radio/dmr/tier3/control.go
+++ b/internal/radio/dmr/tier3/control.go
@@ -69,6 +69,14 @@ type ControlChannel struct {
 	// Motorola vendor system-info CSBK has been seen.
 	restChannel uint8
 
+	// mbc accumulates Multi Block Control (MBC) messages mid-assembly,
+	// keyed by color code: a header burst (DTMBCHeader) opens an entry and
+	// continuation bursts (DTMBCContinuation) append to it until the block
+	// flagged LB=1 closes and dispatches it. Single-threaded with the rest
+	// of the decoder state (the Process goroutine), so no lock is needed.
+	// See mbc.go.
+	mbc map[uint8]*mbcAssembly
+
 	// proc is the cross-call dibit / sync state the Process adapter
 	// uses (see process.go). Lazily constructed on the first
 	// Process call so tests that drive IngestBurst directly don't
@@ -122,20 +130,36 @@ func NewControlChannel(bus *events.Bus, log *slog.Logger, freqHz uint32) *Contro
 // slot type must already be parsed by the caller; the 20-bit
 // Hamming(20,8) over the slot type lives in dmr/slottype.go.
 func (c *ControlChannel) IngestBurst(b *dmr.Burst, slot dmr.SlotType) {
-	if slot.DataType != dmr.DTCSBK {
-		return
+	switch slot.DataType {
+	case dmr.DTCSBK:
+		info, ok := c.decodeInfoBlock(b)
+		if !ok {
+			return
+		}
+		csbk, err := ParseCSBK(info)
+		if err != nil {
+			c.log.Debug("dmr/tier3: CSBK CRC failed")
+			return
+		}
+		c.handleCSBK(slot.ColorCode, csbk)
+	case dmr.DTMBCHeader, dmr.DTMBCContinuation:
+		// Multi Block Control: a CSBK-opcode message spread across a header
+		// burst + continuation bursts. Assembled in mbc.go.
+		c.handleMBC(slot.ColorCode, slot.DataType, b)
 	}
+}
+
+// decodeInfoBlock runs BPTC(196,96) over a burst's payload and packs the
+// 96 corrected information bits into the 12-byte block the CSBK / MBC
+// parsers consume. Reports false when the block is uncorrectable. Shared
+// by the CSBK and MBC paths.
+func (c *ControlChannel) decodeInfoBlock(b *dmr.Burst) ([]byte, bool) {
 	bits, errs := framing.DecodeBPTC196_96(b.PayloadBits())
 	if errs < 0 {
 		c.log.Debug("dmr/tier3: BPTC uncorrectable")
-		return
+		return nil, false
 	}
-	csbk, err := ParseCSBK(InfoBitsToBytes(bits))
-	if err != nil {
-		c.log.Debug("dmr/tier3: CSBK CRC failed")
-		return
-	}
-	c.handleCSBK(slot.ColorCode, csbk)
+	return InfoBitsToBytes(bits), true
 }
 
 func (c *ControlChannel) handleCSBK(cc uint8, csbk CSBK) {
@@ -162,6 +186,26 @@ func (c *ControlChannel) handleCSBK(cc uint8, csbk CSBK) {
 		c.publishTVGrant(cc, ParseTVGrant(csbk.Payload))
 	case OpPVGrant:
 		c.publishPVGrant(cc, ParsePVGrant(csbk.Payload))
+	case OpBTVGrant:
+		// Broadcast TalkGroup Voice — a one-to-many voice call; follow it
+		// like an ordinary TalkGroup Voice grant.
+		c.publishTVGrant(cc, ParseTVGrant(csbk.Payload))
+	case OpPDGrant:
+		c.observeDataGrant(cc, ParseDataGrant(csbk.Payload, true))
+	case OpTDGrant:
+		c.observeDataGrant(cc, ParseDataGrant(csbk.Payload, false))
+	case OpRAND:
+		r := ParseRandomAccess(csbk.Payload)
+		c.log.Debug("dmr/tier3: c-rand (inbound service request)",
+			"service", r.Service, "target", r.TargetID, "src", r.SourceID, "cc", cc)
+	case OpAhoy:
+		a := ParseAhoy(csbk.Payload)
+		c.log.Debug("dmr/tier3: c-ahoy (poll)",
+			"service", a.Service, "target", a.TargetID, "src", a.SourceID, "cc", cc)
+	case OpAckVit, OpAckD, OpAckU, OpNack:
+		a := ParseAck(csbk.Opcode, csbk.Payload)
+		c.log.Debug("dmr/tier3: ack",
+			"opcode", a.Opcode, "service", a.Service, "target", a.TargetID, "src", a.SourceID, "cc", cc)
 	}
 }
 
@@ -251,6 +295,35 @@ func (c *ControlChannel) publishPVGrant(cc uint8, g PVGrant) {
 	c.log.Debug("dmr/tier3: pv-grant",
 		"system", c.systemName, "cc", cc, "dst", g.DestinationID, "src", g.SourceID,
 		"lcn", g.LCN, "ts", g.Timeslot, "freq_hz", freq)
+}
+
+// observeDataGrant records a data-channel grant (PD_GRANT / TD_GRANT). A
+// data grant retunes no Voice device — packet data is not vocoded — so
+// only KindDMRGrantObserved is published (feeding the LCN autoconfig
+// learner the same LCN→carrier mapping a voice grant does) plus a debug
+// log. No trunking.Grant is published, so the engine never follows the
+// data call.
+func (c *ControlChannel) observeDataGrant(cc uint8, g DataGrant) {
+	c.bus.Publish(events.Event{
+		Kind: events.KindDMRGrantObserved,
+		Payload: events.DMRGrantObserved{
+			System:    c.systemName,
+			ColorCode: cc,
+			LCN:       g.LCN,
+			Timeslot:  g.Timeslot,
+			GroupID:   g.TargetID,
+			SourceID:  g.SourceID,
+			CCFreqHz:  c.freqHz,
+			At:        c.now(),
+		},
+	})
+	kind := "td-grant"
+	if g.Private {
+		kind = "pd-grant"
+	}
+	c.log.Debug("dmr/tier3: "+kind+" (data, not followed)",
+		"system", c.systemName, "cc", cc, "target", g.TargetID, "src", g.SourceID,
+		"lcn", g.LCN, "ts", g.Timeslot)
 }
 
 // SetResolver atomically swaps the LCN→frequency resolver. The DMR

--- a/internal/radio/dmr/tier3/control_test.go
+++ b/internal/radio/dmr/tier3/control_test.go
@@ -11,8 +11,11 @@ import (
 )
 
 // burstWithCSBK packs a CSBK into a DMR burst's payload halves.
-func burstWithCSBK(c CSBK) *dmr.Burst {
-	info := AssembleCSBK(c)
+func burstWithCSBK(c CSBK) *dmr.Burst { return burstWithInfoBlock(AssembleCSBK(c)) }
+
+// burstWithInfoBlock BPTC(196,96)-encodes a 12-byte information block into a
+// DMR burst's two payload halves. Shared by the CSBK and MBC tests.
+func burstWithInfoBlock(info []byte) *dmr.Burst {
 	bits := make([]byte, 96)
 	for i := 0; i < 96; i++ {
 		bits[i] = (info[i>>3] >> uint(7-(i&7))) & 1

--- a/internal/radio/dmr/tier3/datagrant_test.go
+++ b/internal/radio/dmr/tier3/datagrant_test.go
@@ -1,0 +1,111 @@
+package tier3
+
+import (
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/dmr"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// TestControlChannelPublishesBTVGrant proves a Broadcast TalkGroup Voice
+// grant (CSBKO 0x32) is followed as a voice call — it keys up voice, unlike
+// the data grants below.
+func TestControlChannelPublishesBTVGrant(t *testing.T) {
+	bus := events.NewBus(16)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{
+		Bus:         bus,
+		SystemName:  "TestSys",
+		FrequencyHz: 851_000_000,
+		Resolver:    TableBandPlan{8: 866_175_000},
+		Now:         func() time.Time { return time.Unix(1_700_000_000, 0).UTC() },
+	})
+	// LPCN 8 (p[1]=0x88 → TS2), group 0x123456, source 0xABCDEF — same
+	// channel-grant layout as TV_GRANT.
+	csbk := CSBK{LB: true, Opcode: OpBTVGrant, Payload: [8]byte{0x00, 0x88, 0x12, 0x34, 0x56, 0xAB, 0xCD, 0xEF}}
+	cc.IngestBurst(burstWithCSBK(csbk), dmr.SlotType{ColorCode: 3, DataType: dmr.DTCSBK})
+
+	deadline := time.After(time.Second)
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind != events.KindGrant {
+				continue
+			}
+			g := ev.Payload.(trunking.Grant)
+			if g.GroupID != 0x123456 || g.SourceID != 0xABCDEF {
+				t.Errorf("group/source = %X/%X", g.GroupID, g.SourceID)
+			}
+			if g.FrequencyHz != 866_175_000 || g.Timeslot != 2 {
+				t.Errorf("freq/ts = %d/%d, want 866_175_000/2", g.FrequencyHz, g.Timeslot)
+			}
+			return
+		case <-deadline:
+			t.Fatal("no voice grant published for BTV_GRANT")
+		}
+	}
+}
+
+// TestControlChannelDataGrantObservedNotFollowed is load-bearing: a data
+// channel grant (PD_GRANT / TD_GRANT) must publish KindDMRGrantObserved (so
+// the LCN learner still sees the carrier) but must NOT publish KindGrant —
+// the engine would otherwise retune a voice SDR onto a packet channel.
+func TestControlChannelDataGrantObservedNotFollowed(t *testing.T) {
+	cases := []struct {
+		name   string
+		opcode CSBKOpcode
+	}{
+		{"td_grant", OpTDGrant},
+		{"pd_grant", OpPDGrant},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			bus := events.NewBus(16)
+			defer bus.Close()
+			sub := bus.Subscribe()
+			defer sub.Close()
+
+			cc := New(Options{
+				Bus:         bus,
+				SystemName:  "DataSys",
+				FrequencyHz: 851_012_500,
+				// A resolver IS set: this proves the data grant is withheld
+				// by policy, not merely dropped for want of a band plan.
+				Resolver: TableBandPlan{8: 866_175_000},
+				Now:      func() time.Time { return time.Unix(1_700_000_002, 0).UTC() },
+			})
+			// LPCN 8 (p[1]=0x88 → TS2), target 0x123456, source 0xABCDEF.
+			csbk := CSBK{LB: true, Opcode: tc.opcode, Payload: [8]byte{0x00, 0x88, 0x12, 0x34, 0x56, 0xAB, 0xCD, 0xEF}}
+			cc.IngestBurst(burstWithCSBK(csbk), dmr.SlotType{ColorCode: 4, DataType: dmr.DTCSBK})
+
+			obs, sawObs, sawGrant, _ := collectGrantObserved(t, sub)
+			if !sawObs {
+				t.Fatal("no KindDMRGrantObserved for data grant")
+			}
+			if sawGrant {
+				t.Error("KindGrant published for a data grant — would retune a voice device")
+			}
+			if obs.LCN != 8 || obs.Timeslot != 1 || obs.GroupID != 0x123456 || obs.SourceID != 0xABCDEF {
+				t.Errorf("obs = %+v", obs)
+			}
+		})
+	}
+}
+
+func TestParseDataGrant(t *testing.T) {
+	// LPCN 8, TS2, target 0x123456, source 0xABCDEF.
+	p := [8]byte{0x00, 0x88, 0x12, 0x34, 0x56, 0xAB, 0xCD, 0xEF}
+	td := ParseDataGrant(p, false)
+	if td.LCN != 8 || td.Timeslot != 1 || td.TargetID != 0x123456 || td.SourceID != 0xABCDEF || td.Private {
+		t.Errorf("TD = %+v", td)
+	}
+	pd := ParseDataGrant(p, true)
+	if !pd.Private {
+		t.Error("Private flag not set for PD_GRANT")
+	}
+}

--- a/internal/radio/dmr/tier3/inbound_test.go
+++ b/internal/radio/dmr/tier3/inbound_test.go
@@ -1,0 +1,71 @@
+package tier3
+
+import (
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/dmr"
+)
+
+// TestParseInboundCSBKRealVectors pins the C_AHOY and C_ACKD address
+// offsets against the only real off-air vectors available (the same bursts
+// csbk_realvectors_test.go validates for CRC/opcode). The addressing
+// follows the grant-family convention (24-bit target at octets 2-4, source
+// at octets 5-7); a regression of the offsets trips this test offline. No
+// field is asserted that these two vectors don't confirm.
+func TestParseInboundCSBKRealVectors(t *testing.T) {
+	// C_AHOY (0x1C): payload {0x00,0x0e,0x00,0x02,0xd0,0xff,0xfe,0xca}.
+	ahoyCSBK, err := ParseCSBK([]byte{0x9c, 0x00, 0x00, 0x0e, 0x00, 0x02, 0xd0, 0xff, 0xfe, 0xca, 0x94, 0x25})
+	if err != nil {
+		t.Fatalf("ParseCSBK rejected real C_AHOY: %v", err)
+	}
+	if a := ParseAhoy(ahoyCSBK.Payload); a.TargetID != 0x0002D0 || a.SourceID != 0xFFFECA {
+		t.Errorf("C_AHOY target/source = %X/%X, want 0002D0/FFFECA", a.TargetID, a.SourceID)
+	}
+
+	// C_ACKD (0x20): payload {0x00,0xc4,0x00,0x03,0x45,0xff,0xfe,0xc6}.
+	ackCSBK, err := ParseCSBK([]byte{0xa0, 0x00, 0x00, 0xc4, 0x00, 0x03, 0x45, 0xff, 0xfe, 0xc6, 0x4a, 0x9c})
+	if err != nil {
+		t.Fatalf("ParseCSBK rejected real C_ACKD: %v", err)
+	}
+	ack := ParseAck(ackCSBK.Opcode, ackCSBK.Payload)
+	if ack.Opcode != OpAckD || ack.TargetID != 0x000345 || ack.SourceID != 0xFFFEC6 {
+		t.Errorf("C_ACKD = %+v, want opcode C_ACKD target 000345 source FFFEC6", ack)
+	}
+}
+
+func TestParseRandomAccessRoundTrip(t *testing.T) {
+	// C_RAND has no real off-air vector; this only pins the parser to the
+	// grant-family addressing convention via an AssembleCSBK round-trip.
+	csbk := CSBK{LB: true, Opcode: OpRAND, Payload: [8]byte{0x07, 0x00, 0x00, 0x12, 0x34, 0x00, 0xAB, 0xCD}}
+	parsed, err := ParseCSBK(AssembleCSBK(csbk))
+	if err != nil {
+		t.Fatalf("round-trip CRC: %v", err)
+	}
+	r := ParseRandomAccess(parsed.Payload)
+	if r.Service != 0x07 || r.TargetID != 0x001234 || r.SourceID != 0x00ABCD {
+		t.Errorf("C_RAND = %+v", r)
+	}
+}
+
+// TestControlChannelInboundCSBKNoSideEffects confirms inbound / reverse-
+// channel CSBKs (C_RAND, C_AHOY, C_ACKD) are parsed for visibility only —
+// they never leak a voice grant or a control-channel lock.
+func TestControlChannelInboundCSBKNoSideEffects(t *testing.T) {
+	for _, op := range []CSBKOpcode{OpRAND, OpAhoy, OpAckD, OpNack} {
+		bus := events.NewBus(8)
+		sub := bus.Subscribe()
+		cc := New(Options{Bus: bus, SystemName: "S", FrequencyHz: 1, Resolver: TableBandPlan{1: 1_000_000}})
+		csbk := CSBK{LB: true, Opcode: op, Payload: [8]byte{0x00, 0x00, 0x00, 0x12, 0x34, 0x00, 0xAB, 0xCD}}
+		cc.IngestBurst(burstWithCSBK(csbk), dmr.SlotType{ColorCode: 1, DataType: dmr.DTCSBK})
+
+		select {
+		case ev := <-sub.C:
+			t.Errorf("opcode %s produced unexpected event %s", op, ev.Kind)
+		case <-time.After(50 * time.Millisecond):
+		}
+		sub.Close()
+		bus.Close()
+	}
+}

--- a/internal/radio/dmr/tier3/mbc.go
+++ b/internal/radio/dmr/tier3/mbc.go
@@ -1,0 +1,150 @@
+package tier3
+
+import (
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/radio/dmr"
+)
+
+// Multi Block Control (MBC) — ETSI TS 102 361-1 §9.x / 361-4. An MBC
+// carries a CSBK-opcode control message too large for a single CSBK across
+// a header burst (Slot Type DTMBCHeader) followed by one or more
+// continuation bursts (DTMBCContinuation), the final block flagged LB=1.
+// Each block is a 96-bit information block carried by BPTC(196,96) exactly
+// like a CSBK, so decodeInfoBlock (control.go) recovers every block and its
+// per-block FEC already rejects uncorrectable bursts.
+//
+// Honesty note: there is no real off-air MBC capture pinning the last-block
+// CRC convention or the multi-block payload layouts (the CSBK CRC history
+// in csbk.go warns how an unverified CRC convention rejects every genuine
+// frame). So this assembler relies on the per-block BPTC FEC for
+// protection, surfaces the assembled opcode + payload at debug regardless,
+// and structurally parses only the opcodes whose header-block content
+// reuses the validated CSBK grant layout — everything else is assembled +
+// logged ("pending capture validation"), the same posture the vendor
+// (Connect Plus / Hytera) CSBKs get in vendor.go.
+
+const (
+	// mbcMaxBlocks bounds the per-color-code assembly against lost or noisy
+	// continuation bursts that never deliver an LB=1 terminator.
+	mbcMaxBlocks = 8
+	// mbcMaxAge drops a partial assembly whose terminator never arrived, so
+	// a stale header can't shadow a fresh message on the same color code.
+	mbcMaxAge = time.Second
+)
+
+// MBCBlock is one decoded MBC block. The header block (DTMBCHeader) carries
+// the CSBK-style leader — LB / PF / CSBKO opcode / FID — in its first two
+// octets; continuation blocks reuse the same struct but only LB and the raw
+// Content are meaningful for them.
+type MBCBlock struct {
+	LB      bool
+	PF      bool
+	Opcode  CSBKOpcode
+	FID     uint8
+	Content [12]byte // the full 96-bit block, MSB-first
+}
+
+// ParseMBCBlock interprets a 12-byte decoded block. LB (bit 0) is valid for
+// every block; Opcode/FID are only meaningful on a header block.
+func ParseMBCBlock(info []byte) MBCBlock {
+	var blk MBCBlock
+	blk.LB = info[0]&0x80 != 0
+	blk.PF = info[0]&0x40 != 0
+	blk.Opcode = CSBKOpcode(info[0] & 0x3F)
+	blk.FID = info[1]
+	copy(blk.Content[:], info)
+	return blk
+}
+
+// mbcAssembly is an MBC message under construction, keyed by color code on
+// ControlChannel.mbc. blocks holds each block's raw 12-byte content in
+// arrival order (header first).
+type mbcAssembly struct {
+	opcode  CSBKOpcode
+	fid     uint8
+	blocks  [][12]byte
+	started time.Time
+}
+
+// handleMBC routes one MBC burst (header or continuation). A header opens a
+// fresh assembly on the burst's color code (discarding any partial one),
+// continuations append, and the LB=1 block closes and dispatches the
+// message.
+func (c *ControlChannel) handleMBC(cc uint8, dt dmr.DataType, b *dmr.Burst) {
+	info, ok := c.decodeInfoBlock(b)
+	if !ok {
+		return
+	}
+	blk := ParseMBCBlock(info)
+
+	if c.mbc == nil {
+		c.mbc = make(map[uint8]*mbcAssembly)
+	}
+	// Evict a stale partial assembly on this color code first: a dropped
+	// terminator would otherwise wedge the slot until the next header.
+	if a, exists := c.mbc[cc]; exists && c.now().Sub(a.started) > mbcMaxAge {
+		delete(c.mbc, cc)
+	}
+
+	switch dt {
+	case dmr.DTMBCHeader:
+		c.mbc[cc] = &mbcAssembly{
+			opcode:  blk.Opcode,
+			fid:     blk.FID,
+			blocks:  [][12]byte{blk.Content},
+			started: c.now(),
+		}
+	case dmr.DTMBCContinuation:
+		a := c.mbc[cc]
+		if a == nil {
+			// Joined mid-message or lost the header — nothing to attach to.
+			c.log.Debug("dmr/tier3: MBC continuation without header", "cc", cc)
+			return
+		}
+		if len(a.blocks) >= mbcMaxBlocks {
+			c.log.Debug("dmr/tier3: MBC over block limit, dropping", "cc", cc, "blocks", len(a.blocks))
+			delete(c.mbc, cc)
+			return
+		}
+		a.blocks = append(a.blocks, blk.Content)
+	}
+
+	if blk.LB {
+		a := c.mbc[cc]
+		delete(c.mbc, cc)
+		if a != nil {
+			c.dispatchMBC(cc, a)
+		}
+	}
+}
+
+// dispatchMBC handles a fully-assembled MBC message. It logs the assembled
+// opcode/payload and structurally parses only the channel-grant opcodes,
+// whose header-block content reuses the validated 8-octet CSBK grant
+// layout (octets 2-9 of the header block). All other opcodes are surfaced
+// assembled-only, pending an off-air capture to validate their layout.
+func (c *ControlChannel) dispatchMBC(cc uint8, a *mbcAssembly) {
+	payload := make([]byte, 0, len(a.blocks)*12)
+	for _, blk := range a.blocks {
+		payload = append(payload, blk[:]...)
+	}
+	c.log.Debug("dmr/tier3: mbc assembled",
+		"opcode", a.opcode, "fid", a.fid, "blocks", len(a.blocks), "bytes", len(payload))
+
+	var grant [8]byte
+	copy(grant[:], a.blocks[0][2:10]) // header octets 2-9 = CSBK payload
+	switch a.opcode {
+	case OpTVGrant, OpBTVGrant:
+		c.publishTVGrant(cc, ParseTVGrant(grant))
+	case OpPVGrant:
+		c.publishPVGrant(cc, ParsePVGrant(grant))
+	case OpPDGrant:
+		c.observeDataGrant(cc, ParseDataGrant(grant, true))
+	case OpTDGrant:
+		c.observeDataGrant(cc, ParseDataGrant(grant, false))
+	default:
+		c.log.Debug("dmr/tier3: mbc payload decode pending capture validation",
+			"opcode", a.opcode, "fid", a.fid, "cc", cc)
+	}
+}

--- a/internal/radio/dmr/tier3/mbc_test.go
+++ b/internal/radio/dmr/tier3/mbc_test.go
@@ -1,0 +1,150 @@
+package tier3
+
+import (
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/dmr"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// NOTE: there are no real off-air MBC capture vectors, so these tests drive
+// the assembler with synthetic blocks (header octets 2-9 carry the
+// validated CSBK grant layout). They pin the multi-block state machine —
+// header opens, continuation appends, LB=1 closes — not an unverified wire
+// layout. See mbc.go for the honesty caveat on payload parsing / CRC.
+
+// mbcGrantHeader builds an MBC header block (not last) carrying a channel
+// grant in the CSBK payload octets.
+func mbcGrantHeader(op CSBKOpcode, payload [8]byte) []byte {
+	return AssembleCSBK(CSBK{LB: false, Opcode: op, Payload: payload})
+}
+
+// mbcBlock builds a raw 12-byte continuation/terminator block; last sets
+// the LB bit that closes the message.
+func mbcBlock(last bool) []byte {
+	b := make([]byte, 12)
+	if last {
+		b[0] = 0x80
+	}
+	return b
+}
+
+func TestControlChannelAssemblesMBCGrant(t *testing.T) {
+	bus := events.NewBus(16)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{
+		Bus:         bus,
+		SystemName:  "MBCSys",
+		FrequencyHz: 851_000_000,
+		Resolver:    TableBandPlan{8: 866_175_000},
+		Now:         func() time.Time { return time.Unix(1_700_000_000, 0).UTC() },
+	})
+
+	// Header: TV_GRANT, LPCN 8/TS2, group 0x123456, src 0xABCDEF.
+	header := mbcGrantHeader(OpTVGrant, [8]byte{0x00, 0x88, 0x12, 0x34, 0x56, 0xAB, 0xCD, 0xEF})
+	cc.IngestBurst(burstWithInfoBlock(header), dmr.SlotType{ColorCode: 3, DataType: dmr.DTMBCHeader})
+	// Continuation flagged LB=1 closes the message.
+	cc.IngestBurst(burstWithInfoBlock(mbcBlock(true)), dmr.SlotType{ColorCode: 3, DataType: dmr.DTMBCContinuation})
+
+	deadline := time.After(time.Second)
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind != events.KindGrant {
+				continue
+			}
+			g := ev.Payload.(trunking.Grant)
+			if g.GroupID != 0x123456 || g.FrequencyHz != 866_175_000 || g.Timeslot != 2 {
+				t.Errorf("grant = %+v", g)
+			}
+			return
+		case <-deadline:
+			t.Fatal("MBC did not assemble into a grant")
+		}
+	}
+}
+
+func TestControlChannelMBCContinuationWithoutHeaderDropped(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, SystemName: "S", FrequencyHz: 1, Resolver: TableBandPlan{1: 1_000_000}})
+	// A lone terminator with no opening header has nothing to attach to.
+	cc.IngestBurst(burstWithInfoBlock(mbcBlock(true)), dmr.SlotType{ColorCode: 1, DataType: dmr.DTMBCContinuation})
+
+	select {
+	case ev := <-sub.C:
+		t.Errorf("unexpected event from headerless MBC continuation: %s", ev.Kind)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestControlChannelMBCHeaderResetsStalePartial(t *testing.T) {
+	bus := events.NewBus(16)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{
+		Bus: bus, SystemName: "S", FrequencyHz: 1,
+		Resolver: TableBandPlan{8: 866_175_000},
+		Now:      func() time.Time { return time.Unix(1_700_000_000, 0).UTC() },
+	})
+	// First header never terminates; a second header on the same color code
+	// must discard it. The closing continuation then dispatches the SECOND
+	// header's grant (group 0xBBBBBB), not the first (0xAAAAAA).
+	h1 := mbcGrantHeader(OpTVGrant, [8]byte{0x00, 0x88, 0xAA, 0xAA, 0xAA, 0x00, 0x00, 0x00})
+	cc.IngestBurst(burstWithInfoBlock(h1), dmr.SlotType{ColorCode: 3, DataType: dmr.DTMBCHeader})
+	h2 := mbcGrantHeader(OpTVGrant, [8]byte{0x00, 0x88, 0xBB, 0xBB, 0xBB, 0x00, 0x00, 0x00})
+	cc.IngestBurst(burstWithInfoBlock(h2), dmr.SlotType{ColorCode: 3, DataType: dmr.DTMBCHeader})
+	cc.IngestBurst(burstWithInfoBlock(mbcBlock(true)), dmr.SlotType{ColorCode: 3, DataType: dmr.DTMBCContinuation})
+
+	deadline := time.After(time.Second)
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind != events.KindGrant {
+				continue
+			}
+			if g := ev.Payload.(trunking.Grant); g.GroupID != 0xBBBBBB {
+				t.Errorf("group = %X, want BBBBBB (second header should win)", g.GroupID)
+			}
+			return
+		case <-deadline:
+			t.Fatal("no grant after header reset")
+		}
+	}
+}
+
+func TestControlChannelMBCBlockLimitGuard(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{
+		Bus: bus, SystemName: "S", FrequencyHz: 1,
+		Resolver: TableBandPlan{8: 866_175_000},
+		Now:      func() time.Time { return time.Unix(1_700_000_000, 0).UTC() },
+	})
+	header := mbcGrantHeader(OpTVGrant, [8]byte{0x00, 0x88, 0x12, 0x34, 0x56, 0x00, 0x00, 0x00})
+	cc.IngestBurst(burstWithInfoBlock(header), dmr.SlotType{ColorCode: 3, DataType: dmr.DTMBCHeader})
+	// Flood non-terminating continuations past the block cap — must not
+	// panic and must not dispatch (no LB seen).
+	for i := 0; i < mbcMaxBlocks+4; i++ {
+		cc.IngestBurst(burstWithInfoBlock(mbcBlock(false)), dmr.SlotType{ColorCode: 3, DataType: dmr.DTMBCContinuation})
+	}
+
+	select {
+	case ev := <-sub.C:
+		t.Errorf("unexpected event from unterminated over-long MBC: %s", ev.Kind)
+	case <-time.After(50 * time.Millisecond):
+	}
+}

--- a/internal/radio/dmr/tier3/payloads.go
+++ b/internal/radio/dmr/tier3/payloads.go
@@ -168,3 +168,97 @@ func ParseSystemInfoBroadcast(p [8]byte) SystemInfoBroadcast {
 		NetMask:  p[4],
 	}
 }
+
+// DataGrant is the parsed content of a data-channel grant CSBK —
+// PD_GRANT (CSBKO 0x33, private data) or TD_GRANT (CSBKO 0x34, talkgroup
+// data). The on-air content matches the voice channel-grant layout
+// (LPCN + Timeslot + 24-bit target + 24-bit source); only the granted
+// service (data vs voice) differs, so the parser is shared with TVGrant's
+// bit layout and a Private discriminator. Unlike a voice grant a data
+// grant does NOT cause the engine to retune a Voice device — packet data
+// is not vocoded — so the control channel records the LCN observation for
+// the band-plan learner but does not follow the call (see observeDataGrant).
+type DataGrant struct {
+	TargetID uint32 // 24-bit: talkgroup (TD) or subscriber (PD)
+	SourceID uint32 // 24-bit subscriber
+	LCN      uint16 // 12-bit logical physical channel number
+	Timeslot uint8  // 0 = TS1, 1 = TS2
+	Private  bool   // true = PD_GRANT (private), false = TD_GRANT (talkgroup)
+}
+
+// ParseDataGrant decodes a PD_GRANT / TD_GRANT payload. The bit layout is
+// identical to ParseTVGrant; private selects PD (true) vs TD (false).
+func ParseDataGrant(p [8]byte, private bool) DataGrant {
+	return DataGrant{
+		LCN:      uint16(p[0])<<4 | uint16(p[1])>>4,
+		Timeslot: (p[1] >> 3) & 0x01,
+		TargetID: uint32(p[2])<<16 | uint32(p[3])<<8 | uint32(p[4]),
+		SourceID: uint32(p[5])<<16 | uint32(p[6])<<8 | uint32(p[7]),
+		Private:  private,
+	}
+}
+
+// Inbound / reverse-channel and acknowledgement CSBKs.
+//
+// C_RAND (CSBKO 0x1F) is the random-access service request a mobile sends
+// to the TSCC on the reverse (uplink) channel — the inbound counterpart of
+// the outbound C_AHOY poll (CSBKO 0x1C). C_ACKVIT / C_ACKD / C_ACKU
+// (0x1E / 0x20 / 0x21) and the negative-ack (0x26) are the acknowledged-
+// response family. None of these key up voice and GopherTrunk does not act
+// on them; they are parsed for control-plane visibility (debug logging)
+// the way a reference decoder surfaces them.
+//
+// Addressing follows the grant-family convention validated against the
+// dsd-neo decoder: a 24-bit target at octets 2-4 and a 24-bit source at
+// octets 5-7, with a leading Service octet (payload[0]) carrying the
+// opcode-specific service kind. Pinned against the only real off-air
+// vectors available — the C_AHOY and C_ACKD bursts in
+// csbk_realvectors_test.go (C_AHOY: target 0x0002D0, source 0xFFFECA;
+// C_ACKD: target 0x000345, source 0xFFFEC6). The finer per-opcode service
+// sub-fields are left unparsed pending dedicated reverse-channel captures;
+// no field here is invented beyond what those two vectors confirm.
+
+// csbkTarget / csbkSource read the grant-family 24-bit target (octets 2-4)
+// and source (octets 5-7) addresses shared by the addressed CSBKs.
+func csbkTarget(p [8]byte) uint32 { return uint32(p[2])<<16 | uint32(p[3])<<8 | uint32(p[4]) }
+func csbkSource(p [8]byte) uint32 { return uint32(p[5])<<16 | uint32(p[6])<<8 | uint32(p[7]) }
+
+// RandomAccess is a parsed C_RAND (CSBKO 0x1F) inbound service request.
+type RandomAccess struct {
+	Service  uint8  // payload[0]: opcode-specific service kind
+	TargetID uint32 // 24-bit
+	SourceID uint32 // 24-bit requesting subscriber
+}
+
+// ParseRandomAccess decodes a C_RAND payload.
+func ParseRandomAccess(p [8]byte) RandomAccess {
+	return RandomAccess{Service: p[0], TargetID: csbkTarget(p), SourceID: csbkSource(p)}
+}
+
+// Ahoy is a parsed C_AHOY (CSBKO 0x1C) outbound poll / service request.
+type Ahoy struct {
+	Service  uint8
+	TargetID uint32
+	SourceID uint32
+}
+
+// ParseAhoy decodes a C_AHOY payload.
+func ParseAhoy(p [8]byte) Ahoy {
+	return Ahoy{Service: p[0], TargetID: csbkTarget(p), SourceID: csbkSource(p)}
+}
+
+// Ack is a parsed acknowledged-response CSBK (C_ACKVIT / C_ACKD / C_ACKU)
+// or a negative acknowledgement (CSBKO 0x26). Opcode retains which variant
+// it was so a single handler can log it.
+type Ack struct {
+	Opcode   CSBKOpcode
+	Service  uint8
+	TargetID uint32
+	SourceID uint32
+}
+
+// ParseAck decodes an acknowledged-response / NACK payload, tagging it with
+// the originating opcode.
+func ParseAck(op CSBKOpcode, p [8]byte) Ack {
+	return Ack{Opcode: op, Service: p[0], TargetID: csbkTarget(p), SourceID: csbkSource(p)}
+}

--- a/internal/radio/dmr/tier3/vendor.go
+++ b/internal/radio/dmr/tier3/vendor.go
@@ -66,10 +66,14 @@ func (c *ControlChannel) handleVendorCSBK(vendor Vendor, cc uint8, csbk CSBK) {
 	switch vendor {
 	case VendorMotorola:
 		switch csbk.Opcode {
-		case OpTVGrant:
+		case OpTVGrant, OpBTVGrant:
 			c.publishVendorTVGrant(vendor, cc, ParseTVGrant(csbk.Payload))
 		case OpPVGrant:
 			c.publishVendorPVGrant(vendor, cc, ParsePVGrant(csbk.Payload))
+		case OpPDGrant:
+			c.observeDataGrant(cc, ParseDataGrant(csbk.Payload, true))
+		case OpTDGrant:
+			c.observeDataGrant(cc, ParseDataGrant(csbk.Payload, false))
 		case OpBcast, OpAloha:
 			// Capacity Plus advertises its current rest channel in
 			// the system-info / broadcast CSBK; the LCN field doubles


### PR DESCRIPTION
Issue #626 asked whether all DMR Tier III data types are implemented.
Several CSBK opcodes and the MBC data types were recognized but never
acted on. This closes the highest-value gaps:

- Data-channel grants: BTV_GRANT (0x32) is a broadcast *voice* call and is
  now followed like a TV grant; PD_GRANT (0x33) / TD_GRANT (0x34) are
  *data* grants and are observed (KindDMRGrantObserved feeds the LCN
  learner) but deliberately not published as KindGrant, so the engine
  never retunes a voice device onto a packet channel. Wired into both the
  standard and Motorola vendor CSBK paths.

- MBC: DTMBCHeader / DTMBCContinuation bursts were dropped at the
  IngestBurst gate. A per-color-code assembler now buffers the header +
  continuation blocks, closes on the LB=1 terminator, and dispatches
  channel-grant opcodes. Per-block BPTC FEC gates each block; the
  whole-message CRC is not enforced (no off-air MBC capture), and non-grant
  payloads are assembled + logged "pending capture validation".

- Inbound / reverse-channel CSBKs: C_RAND (0x1F), C_AHOY (0x1C), and the
  C_ACKVIT/C_ACKD/C_ACKU/NACK family are now parsed and surfaced at debug.
  Address offsets are pinned to the real off-air C_AHOY / C_ACKD vectors.

USBD / packet-data payloads remain out of scope (trunking scanner, not a
data decoder) and are documented as a known limitation.

https://claude.ai/code/session_01XQKdhWVaXspv4zNoyFS4Jy