### PR TITLE
Fix garbled DMR Tier III recorded audio: default to interleaved voice (#644)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,19 @@ for tagged releases.
 
 ### Fixed
 
+- **Garbled audio on recorded DMR Tier III voice (#644).** A DMR carrier is
+  2-slot TDMA, so the demodulated dibit stream interleaves both timeslots'
+  bursts. The per-call voice chain decoded it with the single-slot decoder,
+  which locks burst A correctly but then grabs the *other* timeslot's bursts
+  for B–F — splicing two unrelated calls' AMBE frames into each superframe, so
+  the vocoder rendered structured noise that "sounds encrypted" on a clear
+  channel. DMR Tier III now defaults to the 2-slot interleaved decoder, which
+  pulls each call's own timeslot out and routes it to its talkgroup by the
+  embedded Link Control. The decoder auto-detects the on-air same-slot cadence
+  — 264 dibits (no inter-burst CACH) vs 288 (a CACH precedes each burst on
+  outbound air) — by locking onto the cadence whose bursts B–E reassemble a
+  CRC-valid embedded LC. `dmr_interleaved_voice` is now a tri-state override
+  (unset = protocol default — on for Tier III; set true/false to force).
 - **DMR Tier III voice-grant LCN read from the wrong bits (#639).** The
   TalkGroup/Private voice-grant CSBK parser used the wrong field layout: it
   read the "LCN" from the last payload octet — which is actually the low byte

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -603,6 +603,19 @@ func NewDaemon(cfg config.Config, version string, log *slog.Logger) (*Daemon, er
 // NewDaemonWithPath is the constructor used by main when a config
 // file backs the daemon: the path is installed as a config.Writer
 // so PATCH /api/v1/settings can re-write the file in place.
+// resolveDMRInterleavedVoice turns the tri-state config.SystemConfig.
+// DMRInterleavedVoice override into the concrete bool the trunking layer
+// carries. nil (unset) takes the per-protocol default — interleaved ON for
+// DMR Tier III (ProtocolDMR), where the 2-slot TDMA carrier otherwise
+// decodes as garbled audio (issue #644); single-slot for everything else.
+// An explicit value forces it on or off.
+func resolveDMRInterleavedVoice(proto trunking.Protocol, override *bool) bool {
+	if override != nil {
+		return *override
+	}
+	return proto == trunking.ProtocolDMR
+}
+
 func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *slog.Logger) (*Daemon, error) {
 	if log == nil {
 		return nil, errors.New("daemon: logger is required")
@@ -686,7 +699,7 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 			ControlChannels:         sys.ControlChannels,
 			P25BandPlan:             p25BandPlan,
 			DMRBandPlan:             dmrBandPlan,
-			DMRInterleavedVoice:     sys.DMRInterleavedVoice,
+			DMRInterleavedVoice:     resolveDMRInterleavedVoice(proto, sys.DMRInterleavedVoice),
 			TETRAColourCode:         sys.TETRAColourCode,
 			TETRAChannel:            sys.TETRAChannel,
 			TETRAChannelCoding:      sys.TETRAChannelCoding,

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -648,16 +648,16 @@ trunking:
         #   - { lcn: 1, freq_hz: 851_012_500 }
         #   - { lcn: 2, freq_hz: 851_037_500 }
         #   - { lcn: 9, freq_hz: 851_225_000 }
-      # EXPERIMENTAL: opt into the 2-slot interleaved voice decoder. A
-      # DMR carrier runs two calls at once (TS1 + TS2); with this on,
-      # each voice grant decodes its own timeslot from the carrier's
-      # interleaved burst stream and is routed to its call by matching
-      # the embedded Link Control's talkgroup. Default false keeps the
-      # single-slot decoder. The on-air same-slot cadence and the
-      # embedded-signalling FEC constants are still pending a real-
-      # capture cross-check (see docs/status.md), so leave this off
-      # unless you are validating against a known capture.
-      # dmr_interleaved_voice: true
+      # Override the 2-slot interleaved voice decoder. A DMR carrier runs
+      # two calls at once (TS1 + TS2); the interleaved decoder pulls each
+      # voice grant's own timeslot out of the carrier's interleaved burst
+      # stream (auto-detecting the on-air cadence, with or without an
+      # inter-burst CACH) and routes it to its call by the embedded Link
+      # Control's talkgroup — where the single-slot decoder would splice
+      # the two slots into garbled audio (issue #644). Leave UNSET to use
+      # the per-protocol default: on for DMR Tier III, single-slot for
+      # everything else. Set true/false only to force it for this system.
+      # dmr_interleaved_voice: false
 
   # Per-protocol FEC is on by default — every protocol the daemon
   # supports (TETRA, LTR, P25 Phase 2, NXDN, EDACS, MPT 1327,

--- a/docs/status.md
+++ b/docs/status.md
@@ -85,38 +85,37 @@ The inner FEC layers still pending real-air validation:
   fixtures end-to-end; on-air recovery margins (Viterbi
   correction depth vs. real co-channel + adjacent-channel
   interference) need a live capture to characterise.
-- **DMR 2-slot interleaved voice cadence + embedded-LC labelling.**
-  A DMR carrier is 2-slot TDMA, so a real outbound stream
-  interleaves both timeslots' bursts. `voice.NewInterleavedDecoder`
-  (stride 2) decodes that: it locks each slot's burst A on its own
-  voice sync and gathers that slot's B–F 264 dibits apart, emitting
-  one superframe per slot tagged by `VoiceSuperframe.Phase`. The
-  decoder also reassembles the embedded Link Control carried by
-  bursts B–E (EMB split → variable BPTC(128,72) + Hamming(16,11,4)
-  rows + 5-bit CRC → `dmr.FLC`) and, on a clean CRC, surfaces the
-  call's talkgroup + source on `VoiceSuperframe.LC`, so a phase can
-  be bound to a concrete talkgroup — the absolute TS1/TS2 label the
-  identical BS-sourced burst-A sync cannot give. The whole chain is
-  unit-tested against synthetic interleaved + embedded-LC vectors.
-  Two pieces still need a real IQ capture before this replaces the
-  single-slot `NewDecoder` on the production voice path: (1) the
-  exact same-slot dibit cadence on live BS-sourced air — where a
-  CACH may precede each burst, making the stride 288 rather than 264
-  dibits; and (2) the exact ETSI embedded-signalling de-interleave
-  order, the EMB QR(16,7) FEC (read systematically for now), and the
-  5-bit CRC polynomial — all currently internally consistent
-  (encode↔decode round-trip) but not yet cross-checked against
-  captured traffic. The interleaved + LC path is now wired through the
-  production composer behind a per-system opt-in,
-  `dmr_interleaved_voice: true`: when set, each DMR voice grant is
-  tagged so the composer runs `NewInterleavedDecoder` and routes each
-  call to its timeslot by matching the embedded LC's talkgroup (a
-  `slotRouter`). It defaults off, so untouched configs keep the
-  single-slot decoder. The skip-gated harness
+- **DMR 2-slot interleaved voice — now the Tier III default
+  (issue #644).** A DMR carrier is 2-slot TDMA, so a real outbound
+  stream interleaves both timeslots' bursts. The single-slot
+  `voice.NewDecoder` splices the two slots together into garbled,
+  encrypted-sounding audio — the #644 report. `voice.NewInterleavedDecoder`
+  decodes the carrier correctly: it locks each slot's burst A on its own
+  voice sync and gathers that slot's B–F by the same-slot stride,
+  emitting one superframe per slot tagged by `VoiceSuperframe.Phase`.
+  It now **auto-detects the on-air same-slot cadence** per call —
+  264 dibits (no inter-burst CACH) vs 288 (a 12-dibit CACH precedes
+  each burst on live BS-sourced outbound air) — by slicing bursts B–E
+  at each candidate and locking onto the one that reassembles a
+  CRC-valid embedded Link Control (a wrong cadence cannot). The decoder
+  also surfaces that LC's talkgroup + source on `VoiceSuperframe.LC`, so
+  a phase binds to a concrete talkgroup — the absolute TS1/TS2 label the
+  identical BS-sourced burst-A sync cannot give. The chain is unit-tested
+  against synthetic interleaved + embedded-LC vectors at **both** cadences
+  (`TestInterleavedDecoderAutoDetects{CACH,NoCACH}Cadence`).
+  As of #644 the interleaved + LC path is the **default for DMR Tier III**:
+  the daemon tags Tier III voice grants so the composer runs
+  `NewInterleavedDecoder` and routes each call to its timeslot by the
+  embedded LC's talkgroup (a `slotRouter`). `dmr_interleaved_voice` is now
+  a tri-state override (unset = protocol default; true/false to force).
+  One piece still wants a real IQ capture to cross-check: the exact ETSI
+  embedded-signalling de-interleave order, the EMB QR(16,7) FEC (read
+  systematically for now), and the 5-bit CRC polynomial — currently
+  internally consistent (encode↔decode round-trip) but not yet validated
+  against captured traffic. The skip-gated harness
   `internal/voice/composer/dmr_2slot_realair_test.go` (run with
   `-tags integration` and `GOPHERTRUNK_DMR_2SLOT_CFILE`) is where a
-  contributor drops a real capture to confirm the on-air constants
-  and, once green, promote the interleaved decoder to the default.
+  contributor drops a real capture to confirm those remaining constants.
 
 ### Digital-voice level calibration
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1025,16 +1025,19 @@ type SystemConfig struct {
 	// call (issue #356 follow-up). Ignored for non-P25-Phase-1
 	// protocols.
 	P25Phase1DemodMode string `yaml:"p25_phase1_demod_mode"`
-	// DMRInterleavedVoice opts a DMR system into the experimental
-	// 2-slot interleaved voice decoder: each voice grant decodes its
-	// timeslot from the carrier's interleaved burst stream and is
-	// routed to its call by matching the embedded Link Control's
-	// talkgroup. Default false keeps the single-slot decoder. The
-	// on-air same-slot cadence (CACH/guard) and the embedded-signalling
-	// FEC constants are still pending a real-capture cross-check (see
-	// docs/status.md), so this is opt-in until validated. Ignored for
-	// non-DMR systems.
-	DMRInterleavedVoice bool `yaml:"dmr_interleaved_voice"`
+	// DMRInterleavedVoice overrides the 2-slot interleaved voice decoder.
+	// A DMR carrier is 2-slot TDMA, so the demodulated stream interleaves
+	// both timeslots' bursts; the interleaved decoder pulls each call's own
+	// timeslot out (auto-detecting the on-air same-slot cadence, with or
+	// without inter-burst CACH) and routes it by embedded-LC talkgroup,
+	// where the single-slot decoder would splice the two slots together
+	// into garbled audio (issue #644).
+	//
+	// It is a tri-state: nil (unset) uses the per-protocol default —
+	// interleaved ON for DMR Tier III, single-slot for everything else.
+	// An explicit true/false forces interleaved on or off for that system.
+	// Ignored for non-DMR systems.
+	DMRInterleavedVoice *bool `yaml:"dmr_interleaved_voice,omitempty"`
 	// P25Phase2TrellisMode enables the 4-state ½-rate trellis FEC
 	// decoder on the P25 Phase 2 MAC PDU window. Recognised values:
 	// "" / "on" / "true" / "1" (the new default — 146 channel

--- a/internal/configbuilder/fieldmeta.go
+++ b/internal/configbuilder/fieldmeta.go
@@ -155,7 +155,7 @@ var fieldMetas = map[string]FieldMeta{
 	"SystemConfig.P25Phase2InterleaveMode": {Label: "P25 Ph2 interleave", Help: "Per-burst block deinterleave before trellis decode. off (default) or on. P25 Phase 2 only."},
 	"SystemConfig.P25Phase2ScramblerMode":  {Label: "P25 Ph2 scrambler", Help: "PN44 descrambling of the MAC PDU. on (default, all on-air) or off (unscrambled fixtures). P25 Phase 2 only."},
 	"SystemConfig.P25Phase2ClockMode":      {Label: "P25 Ph2 clock", Help: "Symbol-timing recovery: gardner (default, live SDR) or naive (fixtures). P25 Phase 2 only."},
-	"SystemConfig.DMRInterleavedVoice":     {Label: "DMR interleaved voice", Help: "Experimental 2-slot interleaved DMR voice decoder. Off keeps the single-slot decoder. DMR only."},
+	"SystemConfig.DMRInterleavedVoice":     {Label: "DMR interleaved voice", Help: "Override the 2-slot interleaved DMR voice decoder. Unset = on for DMR Tier III (single-slot otherwise); set true/false to force. DMR only."},
 	"SystemConfig.NXDNViterbiMode":         {Label: "NXDN Viterbi mode", Help: "K=5 Viterbi FEC on the NXDN CAC. spec (default), on (older fixtures), or off. NXDN only."},
 	"SystemConfig.NXDNDeviationHz":         {Label: "NXDN deviation", Help: "Peak FM deviation (Hz) the NXDN slicer is calibrated to. 0 = spec 1800 Hz; try 2400 for bimodal captures. NXDN only."},
 	"SystemConfig.EDACSBCHMode":            {Label: "EDACS BCH mode", Help: "BCH(40,28,2) FEC on the EDACS CCW. on (default) or off (pre-stripped fixtures). EDACS only."},

--- a/internal/radio/dmr/voice/superframe.go
+++ b/internal/radio/dmr/voice/superframe.go
@@ -16,14 +16,15 @@ type VoiceSuperframe struct {
 	// StartDibit is the absolute dibit index of burst A's first dibit.
 	StartDibit int
 	// Phase distinguishes the two interleaved calls on a 2-slot TDMA
-	// carrier: it is the burst-A start's parity in burst units
-	// ((StartDibit / BurstDibits) mod stride), so the two timeslots —
-	// whose burst-A anchors sit exactly one physical burst (132 dibits)
-	// apart — always carry different, stable phases for the life of a
-	// call. It is a relative discriminator, NOT an absolute TS1/TS2
+	// carrier: it is the burst-A start's parity over the physical-burst
+	// period ((StartDibit / (step/2)) mod 2), so the two timeslots —
+	// whose burst-A anchors sit exactly one physical burst apart (132
+	// dibits, or 144 with an inter-burst CACH) — always carry different,
+	// stable phases for the life of a call. It is a relative discriminator,
+	// NOT an absolute TS1/TS2
 	// label (the BS-sourced sync word is identical on both slots);
 	// binding a phase to a talkgroup is the embedded-LC decoder's job.
-	// Always 0 for a single-slot (stride 1) Decoder.
+	// Always 0 for a single-slot Decoder.
 	Phase uint8
 	// HasLC reports that a Full Link Control was reassembled from the
 	// embedded signalling carried by bursts B–E of this superframe and
@@ -51,25 +52,31 @@ const burstLookback = VoiceHalfDibits + 24 - 1 // 77
 // single-slot (stride 1) stream — six contiguous 132-dibit bursts.
 const superframeDibits = dmr.BurstDibits * BurstsPerSuperframe // 792
 
+// cachDibits is the Common Announcement Channel that precedes each burst
+// on a DMR outbound (BS-sourced) carrier — 24 bits = 12 dibits (ETSI
+// TS 102 361-1 §6.2). It sits between the demodulated bursts, so on
+// outbound air a call's same-slot bursts are 2*(132+12)=288 dibits apart
+// rather than the 2*132=264 of a CACH-free (e.g. direct-mode replayed)
+// stream. The interleaved decoder auto-detects which of the two is in use.
+const cachDibits = 12
+
 // Decoder extracts DMR voice superframes from a dibit stream. It is
 // the voice-burst counterpart of the tier2 / tier3 control-channel
 // Process adapters: those slice a burst on every sync match, but
 // voice bursts B–F carry no sync, so the Decoder locks onto burst A
-// via its voice sync word and slices B–F at a fixed TDMA cadence.
+// via its voice sync word and slices B–F at a fixed TDMA cadence — the
+// same-slot stride, in dibits, between two consecutive bursts of the
+// SAME logical call:
 //
-// stride is the number of physical 132-dibit bursts between two
-// consecutive bursts of the SAME logical call:
-//
-//   - stride 1 — a single-slot / direct stream where a call's bursts
-//     A–F are contiguous (132-dibit cadence). This is NewDecoder and
-//     matches synthetic single-slot vectors.
-//   - stride 2 — a real 2-slot TDMA carrier (NewInterleavedDecoder),
+//   - single-slot — a direct / single-timeslot stream where a call's
+//     bursts A–F are contiguous (132-dibit cadence). This is NewDecoder.
+//   - interleaved — a real 2-slot TDMA carrier (NewInterleavedDecoder),
 //     where the other timeslot's burst sits between each of a call's
-//     bursts, so same-slot bursts are 264 dibits apart. One such
-//     Decoder transparently emits superframes for BOTH slots: it locks
-//     each slot's burst A on its own voice sync and gathers that slot's
-//     B–F by striding over the interleaved burst. The two slots' output
-//     is told apart by VoiceSuperframe.Phase.
+//     bursts. Same-slot bursts are 264 dibits apart with no inter-burst
+//     CACH, or 288 when a CACH precedes each burst on outbound air; the
+//     decoder auto-detects which is in use per call (see resolveAndSlice)
+//     and locks it. One such Decoder transparently emits superframes for
+//     BOTH slots and tells them apart by VoiceSuperframe.Phase.
 //
 // A Decoder is stateful and not safe for concurrent use; construct
 // one per voice-call decode chain.
@@ -78,46 +85,72 @@ type Decoder struct {
 	buf      []uint8
 	bufStart int // absolute dibit index of buf[0]
 	pending  []dmr.Match
-	stride   int // physical bursts between consecutive same-slot bursts
-	span     int // dibit span of a full A–F superframe at this stride
-	bufKeep  int // dibits retained so two in-flight anchors can complete
+	// cadenceCandidates holds the same-slot burst stride(s) in dibits the
+	// decoder may use, smallest first. A single-slot decoder has exactly
+	// one (132). An interleaved decoder lists the 2-slot cadences it
+	// auto-detects between: 264 (no inter-burst CACH) and 288 (a 12-dibit
+	// CACH precedes each burst on live BS-sourced outbound air).
+	cadenceCandidates []int
+	// lockedStep is the same-slot stride (dibits) the decoder has committed
+	// to for the rest of the call, or 0 while still undetected. Detection
+	// picks the candidate whose bursts B–E reassemble a CRC-valid embedded
+	// Link Control (sliceAt → HasLC); a wrong cadence cannot.
+	lockedStep int
+	// maxSpan is the dibit span of a full A–F superframe at the LARGEST
+	// candidate stride. The Process gate waits for this many dibits past an
+	// anchor before slicing, so every candidate is fully buffered when
+	// detection runs.
+	maxSpan int
+	bufKeep int // dibits retained so two in-flight anchors can complete
 }
 
-func newDecoder(stride int) *Decoder {
-	// Bursts sit at start + b*stride*BurstDibits for b in 0..5, so the
-	// span runs from burst A's first dibit to burst F's last.
-	span := ((BurstsPerSuperframe-1)*stride + 1) * dmr.BurstDibits
-	return &Decoder{
-		det:    dmr.NewSyncDetector(voiceSyncs, 2),
-		stride: stride,
-		span:   span,
-		// Retain two full superframe spans plus a burst so the two
-		// interleaved slots' anchors can each complete without the
-		// trailing bursts being trimmed out from under them.
-		bufKeep: 2*span + dmr.BurstDibits,
+// spanFor is the dibit span from a superframe's burst-A first dibit to its
+// burst-F last dibit when consecutive same-slot bursts are step dibits apart.
+func spanFor(step int) int { return (BurstsPerSuperframe-1)*step + dmr.BurstDibits }
+
+func newDecoder(candidates []int) *Decoder {
+	maxStep := candidates[0]
+	for _, c := range candidates {
+		if c > maxStep {
+			maxStep = c
+		}
 	}
+	maxSpan := spanFor(maxStep)
+	d := &Decoder{
+		det:               dmr.NewSyncDetector(voiceSyncs, 2),
+		cadenceCandidates: candidates,
+		maxSpan:           maxSpan,
+		// Retain two full (largest-cadence) superframe spans plus a burst
+		// so the two interleaved slots' anchors can each complete without
+		// the trailing bursts being trimmed out from under them.
+		bufKeep: 2*maxSpan + dmr.BurstDibits,
+	}
+	// A single-cadence decoder has nothing to detect: lock immediately.
+	if len(candidates) == 1 {
+		d.lockedStep = candidates[0]
+	}
+	return d
 }
 
-// NewDecoder returns a single-slot Decoder (stride 1): a call's bursts
-// A–F are expected back-to-back at the 132-dibit cadence.
-func NewDecoder() *Decoder { return newDecoder(1) }
+// NewDecoder returns a single-slot Decoder: a call's bursts A–F are
+// expected back-to-back at the 132-dibit cadence.
+func NewDecoder() *Decoder { return newDecoder([]int{dmr.BurstDibits}) }
 
 // NewInterleavedDecoder returns a Decoder for a real 2-slot DMR TDMA
-// carrier (stride 2): a call's bursts are 264 dibits apart because the
-// other timeslot's burst is interleaved between them. It emits
-// superframes for both slots, tagged by VoiceSuperframe.Phase.
-//
-// NOTE: stride 2 assumes the two slots' bursts are adjacent 132-dibit
-// units with no inter-burst CACH / guard dibits in the demodulated
-// stream. The exact same-slot cadence on live BS-sourced outbound air
-// (where a CACH may precede each burst) should be confirmed against a
-// real IQ capture before this replaces NewDecoder on the production
-// voice path; see docs/status.md.
-func NewInterleavedDecoder() *Decoder { return newDecoder(2) }
+// carrier: a call's bursts are interleaved with the other timeslot's, so
+// same-slot bursts are 264 dibits apart with no inter-burst CACH, or 288
+// when a 12-dibit CACH precedes each burst on live BS-sourced outbound air.
+// The decoder auto-detects which cadence is in use per call — the one whose
+// bursts B–E reassemble a CRC-valid embedded Link Control — locks it, then
+// emits superframes for both slots tagged by VoiceSuperframe.Phase.
+func NewInterleavedDecoder() *Decoder {
+	return newDecoder([]int{2 * dmr.BurstDibits, 2 * (dmr.BurstDibits + cachDibits)})
+}
 
 // Reset clears all buffered state. Call on a stream re-sync so a stale
-// burst-A anchor does not slice across the discontinuity. The stride
-// the Decoder was constructed with is preserved.
+// burst-A anchor does not slice across the discontinuity. The cadence
+// candidates and any already-locked cadence are preserved — the same
+// call's same-slot stride does not change across a re-sync.
 func (d *Decoder) Reset() {
 	d.buf = d.buf[:0]
 	d.bufStart = 0
@@ -143,14 +176,14 @@ func (d *Decoder) Process(dibits []uint8, baseIdx int) []VoiceSuperframe {
 	keep := d.pending[:0]
 	for _, m := range d.pending {
 		start := m.Index - burstLookback
-		if start+d.span > bufEnd {
+		if start+d.maxSpan > bufEnd {
 			keep = append(keep, m) // trailing bursts not buffered yet
 			continue
 		}
 		if start < d.bufStart {
 			continue // anchor fell off the front of the buffer
 		}
-		out = append(out, d.sliceSuperframe(start, m.Pattern.Name))
+		out = append(out, d.resolveAndSlice(start, m.Pattern.Name))
 	}
 	d.pending = keep
 
@@ -163,21 +196,48 @@ func (d *Decoder) Process(dibits []uint8, baseIdx int) []VoiceSuperframe {
 	return out
 }
 
-// sliceSuperframe cuts the six 132-dibit bursts of one logical call
-// starting at absolute dibit index start and extracts their 18 AMBE
-// frames. Consecutive bursts are stride*132 dibits apart, so on a
-// 2-slot stream the interleaved other-slot burst is skipped. The caller
-// has already confirmed the full span is buffered.
-func (d *Decoder) sliceSuperframe(start int, syncName string) VoiceSuperframe {
+// resolveAndSlice produces the superframe anchored at start. A decoder with
+// a locked cadence slices at it directly; an undetected interleaved decoder
+// tries each candidate cadence and locks onto the first whose bursts B–E
+// yield a CRC-valid embedded Link Control. If none validate (e.g. a
+// superframe carrying no clean LC) it falls back to the smallest candidate
+// without locking, so a later LC-bearing superframe can still detect the
+// true cadence. The caller has guaranteed maxSpan dibits past start are
+// buffered, so every candidate is sliceable.
+func (d *Decoder) resolveAndSlice(start int, syncName string) VoiceSuperframe {
+	if d.lockedStep != 0 {
+		return d.sliceAt(start, d.lockedStep, syncName)
+	}
+	for _, step := range d.cadenceCandidates {
+		sf := d.sliceAt(start, step, syncName)
+		if sf.HasLC {
+			d.lockedStep = step
+			return sf
+		}
+	}
+	return d.sliceAt(start, d.cadenceCandidates[0], syncName)
+}
+
+// sliceAt cuts the six 132-dibit bursts of one logical call whose burst A
+// starts at absolute dibit index start, with consecutive same-slot bursts
+// step dibits apart, and extracts their 18 AMBE frames + embedded LC. On a
+// 2-slot stream step skips the interleaved other-slot burst (and any CACH).
+// The caller has already confirmed the full span is buffered.
+func (d *Decoder) sliceAt(start, step int, syncName string) VoiceSuperframe {
 	sf := VoiceSuperframe{
 		SyncName:   syncName,
 		StartDibit: start,
-		Phase:      uint8((start / dmr.BurstDibits) % d.stride),
+	}
+	// Phase distinguishes the two interleaved calls: their burst-A anchors
+	// sit one physical-burst period (step/2 dibits) apart, so this parity is
+	// stable and distinct per slot. A single-cadence (single-slot) decoder
+	// has no second slot, so Phase stays 0.
+	if len(d.cadenceCandidates) > 1 {
+		sf.Phase = uint8((start / (step / 2)) % 2)
 	}
 	off := start - d.bufStart
-	step := d.stride * dmr.BurstDibits
 	frame := 0
-	// fragIdx maps the four embedded-LC-bearing bursts B,C,D,E (burst
+	// frags maps the four embedded-LC-bearing bursts B,C,D,E (burst
 	// indices 1..4) to their fragment slot 0..3; A and F carry none.
 	var frags [4][]byte
 	for b := 0; b < BurstsPerSuperframe; b++ {

--- a/internal/radio/dmr/voice/superframe_test.go
+++ b/internal/radio/dmr/voice/superframe_test.go
@@ -49,10 +49,19 @@ func burstLCSS(b int) dmr.LCSS {
 	}
 }
 
+// interleaveTail is trailing filler appended to a synthetic interleaved
+// stream so both slots' burst-A anchors have a full largest-cadence
+// superframe span buffered behind them (the auto-detecting decoder waits
+// for that before slicing). A live carrier is continuous, so on air this
+// trailing data is always present; the fixtures must mimic it.
+const interleaveTail = 2 * (dmr.BurstDibits + cachDibits) // 288
+
 // buildInterleavedStreamWithLC is buildInterleavedStream extended so each
 // slot's bursts B–E carry that slot's own embedded Link Control, so a
-// decoder can recover and label each timeslot's talkgroup.
-func buildInterleavedStreamWithLC(t *testing.T, aLC, bLC dmr.FLC) (stream []uint8, aFrames, bFrames [][]byte) {
+// decoder can recover and label each timeslot's talkgroup. cach dibits of
+// filler are inserted before each woven burst, modelling the outbound CACH
+// (cach=0 reproduces a CACH-free 264-dibit-cadence stream).
+func buildInterleavedStreamWithLC(t *testing.T, aLC, bLC dmr.FLC, cach int) (stream []uint8, aFrames, bFrames [][]byte) {
 	t.Helper()
 	const bSeedOffset = 10000
 	aFrags := lcFragments(t, aLC)
@@ -61,6 +70,7 @@ func buildInterleavedStreamWithLC(t *testing.T, aLC, bLC dmr.FLC) (stream []uint
 		aFrames = append(aFrames, mkFrame(f))
 		bFrames = append(bFrames, mkFrame(f+bSeedOffset))
 	}
+	cachFiller := make([]uint8, cach)
 	for b := 0; b < BurstsPerSuperframe; b++ {
 		aSync, bSync := dmr.BSData.Dibits, dmr.BSData.Dibits
 		switch {
@@ -71,9 +81,12 @@ func buildInterleavedStreamWithLC(t *testing.T, aLC, bLC dmr.FLC) (stream []uint
 			bSync = embeddedSync(dmr.EMB{ColorCode: 1, LCSS: burstLCSS(b)}, bFrags[b-1])
 		}
 		base := b * FramesPerBurst
+		stream = append(stream, cachFiller...)
 		stream = append(stream, makeVoiceBurst(aFrames[base:base+FramesPerBurst], aSync)...)
+		stream = append(stream, cachFiller...)
 		stream = append(stream, makeVoiceBurst(bFrames[base:base+FramesPerBurst], bSync)...)
 	}
+	stream = append(stream, make([]uint8, interleaveTail)...)
 	return stream, aFrames, bFrames
 }
 
@@ -131,6 +144,7 @@ func buildInterleavedStream(t *testing.T, n, lead int) (stream []uint8, aFrames,
 			stream = append(stream, makeVoiceBurst(bFrames[base:base+FramesPerBurst], sync)...)
 		}
 	}
+	stream = append(stream, make([]uint8, interleaveTail)...)
 	return stream, aFrames, bFrames
 }
 
@@ -366,7 +380,7 @@ func TestInterleavedDecoderChunkedInput(t *testing.T) {
 func TestInterleavedDecoderLabelsSlotsByEmbeddedLC(t *testing.T) {
 	aLC := dmr.FLC{FLCO: dmr.FLCOGroupVoiceUser, DstAddr: 1001, SrcAddr: 55}
 	bLC := dmr.FLC{FLCO: dmr.FLCOGroupVoiceUser, DstAddr: 2002, SrcAddr: 66}
-	stream, aFrames, bFrames := buildInterleavedStreamWithLC(t, aLC, bLC)
+	stream, aFrames, bFrames := buildInterleavedStreamWithLC(t, aLC, bLC, 0)
 
 	d := NewInterleavedDecoder()
 	got := d.Process(stream, 0)
@@ -388,6 +402,61 @@ func TestInterleavedDecoderLabelsSlotsByEmbeddedLC(t *testing.T) {
 	}
 	checkFrames(t, a, aFrames, 0)
 	checkFrames(t, b, bFrames, 0)
+}
+
+// TestInterleavedDecoderAutoDetectsCACHCadence is the #644 guard: on a real
+// outbound DMR carrier a 12-dibit CACH precedes each burst, so a call's
+// same-slot bursts are 288 dibits apart, not 264. Fed such a stream, the
+// interleaved decoder must auto-detect the 288 cadence (the one whose bursts
+// B–E reassemble a CRC-valid embedded LC), lock it, and still separate the
+// two slots cleanly. Slicing at the wrong 264 cadence is exactly what
+// produced the garbled, encrypted-sounding audio reported in #644.
+func TestInterleavedDecoderAutoDetectsCACHCadence(t *testing.T) {
+	aLC := dmr.FLC{FLCO: dmr.FLCOGroupVoiceUser, DstAddr: 1001, SrcAddr: 55}
+	bLC := dmr.FLC{FLCO: dmr.FLCOGroupVoiceUser, DstAddr: 2002, SrcAddr: 66}
+	stream, aFrames, bFrames := buildInterleavedStreamWithLC(t, aLC, bLC, cachDibits)
+
+	d := NewInterleavedDecoder()
+	got := d.Process(stream, 0)
+	if len(got) != 2 {
+		t.Fatalf("got %d superframes, want 2 (one per timeslot)", len(got))
+	}
+	if d.lockedStep != 2*(dmr.BurstDibits+cachDibits) {
+		t.Errorf("lockedStep = %d, want %d (288, the CACH cadence)", d.lockedStep, 2*(dmr.BurstDibits+cachDibits))
+	}
+	a, b := got[0], got[1]
+	if !a.HasLC || a.LC.DstAddr != 1001 || a.LC.SrcAddr != 55 {
+		t.Errorf("slot A LC: hasLC=%v dst=%d src=%d, want dst=1001 src=55", a.HasLC, a.LC.DstAddr, a.LC.SrcAddr)
+	}
+	if !b.HasLC || b.LC.DstAddr != 2002 || b.LC.SrcAddr != 66 {
+		t.Errorf("slot B LC: hasLC=%v dst=%d src=%d, want dst=2002 src=66", b.HasLC, b.LC.DstAddr, b.LC.SrcAddr)
+	}
+	if a.Phase == b.Phase {
+		t.Errorf("slots share Phase %d; want distinct", a.Phase)
+	}
+	// Audio cleanly separated per slot despite the inter-burst CACH.
+	checkFrames(t, a, aFrames, 0)
+	checkFrames(t, b, bFrames, 0)
+}
+
+// TestInterleavedDecoderAutoDetectsNoCACHCadence is the symmetric case: a
+// CACH-free carrier (e.g. a hotspot / replayed stream) has its same-slot
+// bursts 264 dibits apart, and the decoder must lock that cadence instead.
+func TestInterleavedDecoderAutoDetectsNoCACHCadence(t *testing.T) {
+	aLC := dmr.FLC{FLCO: dmr.FLCOGroupVoiceUser, DstAddr: 1001, SrcAddr: 55}
+	bLC := dmr.FLC{FLCO: dmr.FLCOGroupVoiceUser, DstAddr: 2002, SrcAddr: 66}
+	stream, aFrames, bFrames := buildInterleavedStreamWithLC(t, aLC, bLC, 0)
+
+	d := NewInterleavedDecoder()
+	got := d.Process(stream, 0)
+	if len(got) != 2 {
+		t.Fatalf("got %d superframes, want 2", len(got))
+	}
+	if d.lockedStep != 2*dmr.BurstDibits {
+		t.Errorf("lockedStep = %d, want %d (264, the CACH-free cadence)", d.lockedStep, 2*dmr.BurstDibits)
+	}
+	checkFrames(t, got[0], aFrames, 0)
+	checkFrames(t, got[1], bFrames, 0)
 }
 
 // TestDecoderSuperframeNoLCWhenAbsent confirms a superframe whose B–E


### PR DESCRIPTION
A DMR carrier is 2-slot TDMA, so the demodulated dibit stream interleaves
both timeslots' bursts. The per-call voice chain decoded it with the
single-slot decoder, which locks burst A correctly but then grabs the other
timeslot's bursts for B-F, splicing two unrelated calls' AMBE frames into
each superframe. The vocoder then rendered structured noise that "sounds
encrypted" on a clear channel -- the symptom reported in #644.

DMR Tier III now defaults to the 2-slot interleaved decoder, which pulls
each call's own timeslot out of the carrier and routes it to its talkgroup
by the embedded Link Control.

The interleaved decoder now auto-detects the on-air same-slot cadence per
call -- 264 dibits (no inter-burst CACH) vs 288 (a 12-dibit CACH precedes
each burst on live outbound air) -- by slicing bursts B-E at each candidate
and locking onto the one that reassembles a CRC-valid embedded LC. A wrong
cadence cannot pass BPTC+CRC, so this is self-correcting and needs no
capture to calibrate.

dmr_interleaved_voice becomes a tri-state override (*bool): unset uses the
per-protocol default (on for Tier III, single-slot otherwise); true/false
forces it. Synthetic round-trip tests cover both cadences; real-capture
validation of the remaining embedded-signalling constants stays in the
skip-gated dmr_2slot_realair_test.go harness.