### PR TITLE
dmr: decode the Reverse Channel and stop mislabeling uplink CSBKs

### DIFF
--- a/internal/radio/dmr/rc.go
+++ b/internal/radio/dmr/rc.go
@@ -1,0 +1,92 @@
+package dmr
+
+import "github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+
+// Reverse Channel (RC) signalling — ETSI TS 102 361-1 §6.2, §9.1.4.
+//
+// The DMR Reverse Channel is in-call signalling, distinct from the CSBKs on
+// the trunking control channel. It rides one of two carriers:
+//
+//   - the 32-bit embedded-signalling fragment of an ordinary burst, when the
+//     framing EMB marks a single, non-LC fragment (LCSS == LCSSSingle); or
+//   - a short MS-sourced RC burst framed by the MS-RC sync (dmr.MSRC).
+//
+// In the 32-bit embedded field the RC is 11 bits of information protected by
+// 21 bits of FEC parity, framed by the 16-bit EMB (colour code, PI, LCSS;
+// itself QR(16,7)-protected). This file decodes the embedded carrier — the
+// one a downlink receiver actually observes, since it is already pulling the
+// embedded field out of every voice burst (see dmr/voice). The short MS-RC
+// burst is a mobile *uplink* transmission a downlink scanner does not normally
+// receive (its sync is detected by dmr.MSRC but the burst is not present on
+// the downlink — see sync_test.go), so no payload decode is attempted for it.
+//
+// Provenance / honesty: the 11-info + 21-parity split and the EMB framing are
+// pinned to ETSI TS 102 361-1, but GopherTrunk has no real off-air RC capture
+// and no open reference decoder (dsd-fme, pd0mz/go-dmr) implements the (32,11)
+// RC FEC, so the parity is preserved but not yet used to correct or validate
+// the 11 information bits. This mirrors the capture-pending posture already
+// documented for the EMB's own QR(16,7) (see emb.go) and the MBC last-block
+// CRC. The integrity gate is therefore the caller's EMB framing check
+// (LCSS == LCSSSingle) plus the null/idle rejection below; a future off-air
+// capture can promote the parity to a real FEC gate without changing callers.
+
+// RCInfoBits is the number of Reverse Channel information bits carried in the
+// 32-bit embedded fragment; the remaining RCParityBits are FEC parity.
+const (
+	RCInfoBits   = 11
+	RCParityBits = framing.EmbeddedFragmentBits - RCInfoBits // 21
+)
+
+// ReverseChannel is a decoded DMR Reverse Channel word.
+type ReverseChannel struct {
+	// Info is the 11-bit RC information field — the leading bits of the
+	// 32-bit embedded fragment, MSB-first. Its per-opcode sub-field semantics
+	// are left unparsed pending a real off-air RC capture.
+	Info uint16
+	// Parity is the 21-bit FEC parity protecting Info. Preserved raw; not yet
+	// applied (see the package note above).
+	Parity uint32
+}
+
+// DecodeReverseChannel parses the 32-bit embedded-signalling fragment (one bit
+// per byte, MSB-first — the fragment returned by SplitEmbeddedField) as a
+// Reverse Channel word. It returns ok=false when the fragment is the wrong
+// length or is the ETSI null/idle embedded message (all-zero). The caller must
+// confirm the framing EMB marks a single, non-LC fragment (its LCSS ==
+// LCSSSingle) before treating a fragment as RC.
+func DecodeReverseChannel(frag []byte) (ReverseChannel, bool) {
+	if len(frag) != framing.EmbeddedFragmentBits {
+		return ReverseChannel{}, false
+	}
+	ones := 0
+	for _, b := range frag {
+		ones += int(b & 1)
+	}
+	// The all-zero field is the ETSI "null embedded message" idle, not RC.
+	if ones == 0 {
+		return ReverseChannel{}, false
+	}
+	var rc ReverseChannel
+	for i := 0; i < RCInfoBits; i++ {
+		rc.Info = rc.Info<<1 | uint16(frag[i]&1)
+	}
+	for i := 0; i < RCParityBits; i++ {
+		rc.Parity = rc.Parity<<1 | uint32(frag[RCInfoBits+i]&1)
+	}
+	return rc, true
+}
+
+// AssembleReverseChannel is the inverse of DecodeReverseChannel: it packs a
+// Reverse Channel word into the 32-bit embedded fragment (11 info bits then 21
+// parity bits, MSB-first). Used to build synthetic streams and round-trip
+// tests.
+func AssembleReverseChannel(rc ReverseChannel) []byte {
+	frag := make([]byte, framing.EmbeddedFragmentBits)
+	for i := 0; i < RCInfoBits; i++ {
+		frag[i] = byte((rc.Info >> uint(RCInfoBits-1-i)) & 1)
+	}
+	for i := 0; i < RCParityBits; i++ {
+		frag[RCInfoBits+i] = byte((rc.Parity >> uint(RCParityBits-1-i)) & 1)
+	}
+	return frag
+}

--- a/internal/radio/dmr/rc_test.go
+++ b/internal/radio/dmr/rc_test.go
@@ -1,0 +1,69 @@
+package dmr
+
+import (
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+)
+
+// No real off-air DMR Reverse Channel capture exists; these tests pin the
+// 11-info / 21-parity framing and the embedded-field integration via synthetic
+// round-trips. See rc.go for the capture-pending FEC posture.
+
+func TestReverseChannelRoundTrip(t *testing.T) {
+	rc := ReverseChannel{Info: 0x5A3, Parity: 0x1F2A3}
+	frag := AssembleReverseChannel(rc)
+	if len(frag) != framing.EmbeddedFragmentBits {
+		t.Fatalf("fragment length = %d, want %d", len(frag), framing.EmbeddedFragmentBits)
+	}
+	got, ok := DecodeReverseChannel(frag)
+	if !ok {
+		t.Fatal("DecodeReverseChannel returned ok=false on a valid RC fragment")
+	}
+	if got != rc {
+		t.Errorf("round trip = %+v, want %+v", got, rc)
+	}
+}
+
+// TestReverseChannelInfoBitsMSBFirst confirms the 11-bit Info occupies the
+// leading bits of the 32-bit field, MSB-first, ahead of the 21 parity bits.
+func TestReverseChannelInfoBitsMSBFirst(t *testing.T) {
+	frag := AssembleReverseChannel(ReverseChannel{Info: 1})
+	if frag[RCInfoBits-1] != 1 {
+		t.Errorf("Info LSB landed at bit %d = %d, want it set", RCInfoBits-1, frag[RCInfoBits-1])
+	}
+	for i := 0; i < RCInfoBits-1; i++ {
+		if frag[i] != 0 {
+			t.Errorf("unexpected set bit %d in the info region", i)
+		}
+	}
+}
+
+func TestReverseChannelRejectsNull(t *testing.T) {
+	null := make([]byte, framing.EmbeddedFragmentBits) // all-zero = ETSI idle
+	if _, ok := DecodeReverseChannel(null); ok {
+		t.Error("DecodeReverseChannel accepted the all-zero null embedded message")
+	}
+}
+
+func TestReverseChannelRejectsWrongLength(t *testing.T) {
+	if _, ok := DecodeReverseChannel(make([]byte, 16)); ok {
+		t.Error("DecodeReverseChannel accepted a 16-bit fragment")
+	}
+}
+
+// TestReverseChannelThroughEmbeddedField confirms RC survives the same EMB
+// framing split a burst's 48-bit centre field goes through: pack an EMB
+// (LCSS=Single) + RC fragment, split it back out, and decode.
+func TestReverseChannelThroughEmbeddedField(t *testing.T) {
+	rc := ReverseChannel{Info: 0x2C7, Parity: 0x155AA}
+	field := AssembleEmbeddedField(EMB{ColorCode: 0xB, LCSS: LCSSSingle}, AssembleReverseChannel(rc))
+	emb, frag := SplitEmbeddedField(field)
+	if emb.LCSS != LCSSSingle {
+		t.Fatalf("LCSS = %d, want LCSSSingle", emb.LCSS)
+	}
+	got, ok := DecodeReverseChannel(frag)
+	if !ok || got != rc {
+		t.Errorf("RC through embedded field = %+v ok=%v, want %+v", got, ok, rc)
+	}
+}

--- a/internal/radio/dmr/tier3/control.go
+++ b/internal/radio/dmr/tier3/control.go
@@ -196,7 +196,7 @@ func (c *ControlChannel) handleCSBK(cc uint8, csbk CSBK) {
 		c.observeDataGrant(cc, ParseDataGrant(csbk.Payload, false))
 	case OpRAND:
 		r := ParseRandomAccess(csbk.Payload)
-		c.log.Debug("dmr/tier3: c-rand (inbound service request)",
+		c.log.Debug("dmr/tier3: c-rand (inbound uplink service request)",
 			"service", r.Service, "target", r.TargetID, "src", r.SourceID, "cc", cc)
 	case OpAhoy:
 		a := ParseAhoy(csbk.Payload)

--- a/internal/radio/dmr/tier3/inbound_test.go
+++ b/internal/radio/dmr/tier3/inbound_test.go
@@ -49,9 +49,10 @@ func TestParseRandomAccessRoundTrip(t *testing.T) {
 	}
 }
 
-// TestControlChannelInboundCSBKNoSideEffects confirms inbound / reverse-
-// channel CSBKs (C_RAND, C_AHOY, C_ACKD) are parsed for visibility only —
-// they never leak a voice grant or a control-channel lock.
+// TestControlChannelInboundCSBKNoSideEffects confirms inbound (uplink) CSBKs
+// (C_RAND, C_AHOY, C_ACKD) are parsed for visibility only — they never leak a
+// voice grant or a control-channel lock. (These are CSBKs, not the DMR Reverse
+// Channel; RC decode is covered in dmr/rc_test.go.)
 func TestControlChannelInboundCSBKNoSideEffects(t *testing.T) {
 	for _, op := range []CSBKOpcode{OpRAND, OpAhoy, OpAckD, OpNack} {
 		bus := events.NewBus(8)

--- a/internal/radio/dmr/tier3/payloads.go
+++ b/internal/radio/dmr/tier3/payloads.go
@@ -198,15 +198,20 @@ func ParseDataGrant(p [8]byte, private bool) DataGrant {
 	}
 }
 
-// Inbound / reverse-channel and acknowledgement CSBKs.
+// Inbound (uplink) and acknowledgement CSBKs.
 //
 // C_RAND (CSBKO 0x1F) is the random-access service request a mobile sends
-// to the TSCC on the reverse (uplink) channel — the inbound counterpart of
-// the outbound C_AHOY poll (CSBKO 0x1C). C_ACKVIT / C_ACKD / C_ACKU
-// (0x1E / 0x20 / 0x21) and the negative-ack (0x26) are the acknowledged-
-// response family. None of these key up voice and GopherTrunk does not act
-// on them; they are parsed for control-plane visibility (debug logging)
-// the way a reference decoder surfaces them.
+// to the TSCC on the uplink — the inbound counterpart of the outbound
+// C_AHOY poll (CSBKO 0x1C). C_ACKVIT / C_ACKD / C_ACKU (0x1E / 0x20 / 0x21)
+// and the negative-ack (0x26) are the acknowledged-response family. None of
+// these key up voice and GopherTrunk does not act on them; they are parsed
+// for control-plane visibility (debug logging) the way a reference decoder
+// surfaces them.
+//
+// These are full CSBKs carried in their own bursts. They are NOT the DMR
+// Reverse Channel (RC) — the in-call signalling that rides a burst's
+// embedded-signalling field or a short MS-sourced RC burst. RC is a separate
+// mechanism with its own FEC and is decoded in dmr/rc.go.
 //
 // Addressing follows the grant-family convention validated against the
 // dsd-neo decoder: a 24-bit target at octets 2-4 and a 24-bit source at

--- a/internal/radio/dmr/voice/rc_superframe_test.go
+++ b/internal/radio/dmr/voice/rc_superframe_test.go
@@ -1,0 +1,57 @@
+package voice
+
+import (
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/radio/dmr"
+)
+
+// No real off-air Reverse Channel capture exists; this drives a synthetic
+// single-slot superframe whose burst B carries a single-fragment
+// (LCSS=Single) embedded RC word and confirms the decoder surfaces it on the
+// VoiceSuperframe. See dmr/rc.go for the capture-pending FEC posture.
+func TestDecoderSurfacesReverseChannel(t *testing.T) {
+	rc := dmr.ReverseChannel{Info: 0x3A5, Parity: 0x14B2C}
+	rcSync := embeddedSync(dmr.EMB{ColorCode: 1, LCSS: dmr.LCSSSingle}, dmr.AssembleReverseChannel(rc))
+
+	frames := make([][]byte, FramesPerSuperframe)
+	for f := range frames {
+		frames[f] = mkFrame(f)
+	}
+	var stream []uint8
+	for b := 0; b < BurstsPerSuperframe; b++ {
+		sync := dmr.BSData.Dibits
+		switch b {
+		case 0:
+			sync = dmr.BSVoice.Dibits // burst A anchors the superframe
+		case 1:
+			sync = rcSync // burst B carries the embedded reverse channel
+		}
+		base := b * FramesPerBurst
+		stream = append(stream, makeVoiceBurst(frames[base:base+FramesPerBurst], sync)...)
+	}
+
+	got := NewDecoder().Process(stream, 0)
+	if len(got) != 1 {
+		t.Fatalf("got %d superframes, want 1", len(got))
+	}
+	if !got[0].HasRC {
+		t.Fatal("HasRC = false; want the burst-B reverse channel decoded")
+	}
+	if got[0].RC != rc {
+		t.Errorf("RC = %+v, want %+v", got[0].RC, rc)
+	}
+}
+
+// TestDecoderNoReverseChannelFromLC confirms an ordinary embedded Full LC
+// (LCSS First/Cont/Cont/Last) never surfaces a bogus RC.
+func TestDecoderNoReverseChannelFromLC(t *testing.T) {
+	aLC := dmr.FLC{FLCO: dmr.FLCOGroupVoiceUser, DstAddr: 1001, SrcAddr: 55}
+	bLC := dmr.FLC{FLCO: dmr.FLCOGroupVoiceUser, DstAddr: 2002, SrcAddr: 66}
+	stream, _, _ := buildInterleavedStreamWithLC(t, aLC, bLC)
+	for _, sf := range NewInterleavedDecoder().Process(stream, 0) {
+		if sf.HasRC {
+			t.Errorf("HasRC = true on an LC-only superframe (phase %d); want false", sf.Phase)
+		}
+	}
+}

--- a/internal/radio/dmr/voice/rc_superframe_test.go
+++ b/internal/radio/dmr/voice/rc_superframe_test.go
@@ -48,7 +48,7 @@ func TestDecoderSurfacesReverseChannel(t *testing.T) {
 func TestDecoderNoReverseChannelFromLC(t *testing.T) {
 	aLC := dmr.FLC{FLCO: dmr.FLCOGroupVoiceUser, DstAddr: 1001, SrcAddr: 55}
 	bLC := dmr.FLC{FLCO: dmr.FLCOGroupVoiceUser, DstAddr: 2002, SrcAddr: 66}
-	stream, _, _ := buildInterleavedStreamWithLC(t, aLC, bLC)
+	stream, _, _ := buildInterleavedStreamWithLC(t, aLC, bLC, 0)
 	for _, sf := range NewInterleavedDecoder().Process(stream, 0) {
 		if sf.HasRC {
 			t.Errorf("HasRC = true on an LC-only superframe (phase %d); want false", sf.Phase)

--- a/internal/radio/dmr/voice/superframe.go
+++ b/internal/radio/dmr/voice/superframe.go
@@ -33,6 +33,13 @@ type VoiceSuperframe struct {
 	// the timeslot (the BS-sourced burst-A sync alone cannot).
 	HasLC bool
 	LC    dmr.FLC
+	// HasRC reports that a Reverse Channel word was decoded from a single-
+	// fragment (LCSS == LCSSSingle) embedded-signalling field carried by one
+	// of bursts B–E; RC then holds the 11-bit RC information. This is in-call
+	// signalling independent of HasLC/LC — see dmr/rc.go, including the
+	// capture-pending FEC posture.
+	HasRC bool
+	RC    dmr.ReverseChannel
 }
 
 // voiceSyncs are the sync words that frame burst A of a voice
@@ -188,8 +195,19 @@ func (d *Decoder) sliceSuperframe(start int, syncName string) VoiceSuperframe {
 			frame++
 		}
 		if b >= 1 && b <= 4 {
-			_, frag := dmr.SplitEmbeddedField(dibitsToBits(burst.Sync()))
+			emb, frag := dmr.SplitEmbeddedField(dibitsToBits(burst.Sync()))
 			frags[b-1] = frag
+			// A single-fragment (LCSS==Single) embedded field is not part of
+			// the four-fragment Full LC: it carries either a Reverse Channel
+			// word or the null idle. Decode the first RC seen in the
+			// superframe; the LC reassembly below is gated by its own
+			// BPTC+CRC, so leaving the fragment in frags is harmless.
+			if emb.LCSS == dmr.LCSSSingle && !sf.HasRC {
+				if rc, ok := dmr.DecodeReverseChannel(frag); ok {
+					sf.HasRC = true
+					sf.RC = rc
+				}
+			}
 		}
 	}
 	if lc, ok := dmr.ReassembleEmbeddedLC(frags); ok {

--- a/internal/voice/composer/dmr_voice.go
+++ b/internal/voice/composer/dmr_voice.go
@@ -147,6 +147,13 @@ func (c *Composer) runDMRVoiceChain(ctx context.Context, serial string, iqCh <-c
 				}
 				superframes.Add(1)
 				bt.onVoice(0)
+				if sf.HasRC {
+					// In-call Reverse Channel signalling — control-plane
+					// visibility only (see dmr/rc.go); it does not affect the
+					// audio path.
+					c.log.Debug("composer: DMR reverse channel",
+						"serial", serial, "rc_info", sf.RC.Info, "phase", sf.Phase)
+				}
 				if rs == nil {
 					continue
 				}


### PR DESCRIPTION
## Summary

Follow-up to #626. The reporter correctly pointed out that the Round-1
C_RAND / C_AHOY / ACK additions — while genuinely *uplink/ack CSBKs* — were
labeled "inbound / reverse-channel," which overclaimed that the DMR **Reverse
Channel (RC)** itself was handled. The RC is not a CSBK: it rides a burst's
embedded-signalling field or a short MS-sourced RC burst. This PR fixes the
wording and implements the embedded RC decode so the claim becomes true.

## Part A — wording fix
Reword the overclaiming "reverse-channel" terminology on the uplink CSBKs to
"inbound (uplink)" and point at the real RC mechanism. Structs/parsers
unchanged; only framing/wording. (`payloads.go`, `control.go`,
`inbound_test.go`.)

## Part B — Reverse Channel decode (`internal/radio/dmr/rc.go`)
Decode the embedded RC carried in a single-fragment (`LCSS=Single`)
embedded-signalling field — the 32-bit field is 11 information bits + 21 FEC
parity, framed by the 16-bit EMB. Surfaced on `VoiceSuperframe` (`HasRC`/`RC`)
from the superframe decoder and debug-logged in the voice composer.

## Two deliberate deviations, both toward *less* fabrication
1. **MS-RC short burst is detect-only, not decoded.** The repo's own
   `sync_test.go` notes MS-RC "is not used on the downlink control channel" —
   it is a mobile *uplink* burst a downlink scanner does not receive. Adding a
   handler would be speculative dead code, so it is documented in `rc.go`
   rather than fabricated. The embedded RC (present in the BS voice bursts we
   already process) is the observable deliverable.
2. **The (32,11) FEC parity is preserved but not applied.** No off-air RC
   capture exists and no open reference decoder (dsd-fme, pd0mz/go-dmr)
   implements the (32,11) generator. Rather than invent a polynomial that
   would reject real frames, the gate is the EMB framing (`LCSS=Single`) plus
   all-zero null/idle rejection — the same capture-pending posture the repo
   already documents for the EMB QR(16,7) and the MBC last-block CRC.

## Tests
- `internal/radio/dmr/rc_test.go` — round-trip, MSB-first ordering, null
  rejection, wrong-length, and embedded-field integration.
- `internal/radio/dmr/voice/rc_superframe_test.go` — end-to-end superframe
  surfaces RC from burst B; an ordinary embedded Full LC never leaks a bogus
  RC.
- Comments note the absence of a real RC capture.

`gofmt`/`go vet`/`go build ./...` clean; `go test -race ./internal/radio/dmr/...
./internal/voice/composer/...` green.

## Remaining gaps (future scope, pending off-air captures)
UDT frames (SMS/DGNA/location/PBX), USBD location on the TSCC, and MBC-carried
grants for Flexible channel plans.

https://claude.ai/code/session_01XQKdhWVaXspv4zNoyFS4Jy

---
_Generated by [Claude Code](https://claude.ai/code/session_01XQKdhWVaXspv4zNoyFS4Jy)_