### PR TITLE
hunt/survey: isolate dense carriers so DMR isn't mislabeled am/wfm (#648)

### DIFF
--- a/internal/hunt/livesurvey.go
+++ b/internal/hunt/livesurvey.go
@@ -97,7 +97,7 @@ func RunLiveSurvey(ctx context.Context, opts LiveHuntOptions) (*SignalSurvey, []
 			return finishSurvey(sv), reports, err
 		}
 
-		ds, rep := classifyAndRoute(sv.System, iq, rate, cand, opts, log)
+		ds, rep := classifyAndRoute(sv.System, iq, rate, cand, nearestNeighborHz(candidates, i), opts, log)
 		if rep != nil {
 			reports = append(reports, *rep)
 		}
@@ -138,7 +138,9 @@ func RunOfflineSurvey(captures []CaptureInput, opts LiveHuntOptions) (*SignalSur
 			continue
 		}
 		cand := Candidate{FreqHz: ci.FrequencyHz}
-		ds, rep := classifyAndRoute(sv.System, iq, rate, cand, opts, log)
+		// Each offline capture is a lone baseband grab: no neighbour to bound
+		// against, so the occupied-bandwidth walk stays unbounded.
+		ds, rep := classifyAndRoute(sv.System, iq, rate, cand, 0, opts, log)
 		if rep != nil {
 			reports = append(reports, *rep)
 		}
@@ -153,14 +155,18 @@ func RunOfflineSurvey(captures []CaptureInput, opts LiveHuntOptions) (*SignalSur
 // classifyAndRoute is the shared per-candidate body of the live and offline
 // surveys: measure occupied bandwidth on the full-rate capture, channelise to a
 // narrow baseband stream, classify, and route to the matching decoder.
-func classifyAndRoute(sys *DiscoveredSystem, fullIQ []complex64, fullRate uint32, cand Candidate, opts LiveHuntOptions, log *slog.Logger) (DetectedSignal, *CaptureReport) {
+func classifyAndRoute(sys *DiscoveredSystem, fullIQ []complex64, fullRate uint32, cand Candidate, neighborHz uint32, opts LiveHuntOptions, log *slog.Logger) (DetectedSignal, *CaptureReport) {
 	ds := DetectedSignal{FreqHz: cand.FreqHz, SNRDb: cand.SNRDb}
 
 	// Occupied bandwidth from the full-rate capture (a wideband signal isn't
-	// truncated by the channel decimation); modulation features + conventional
-	// decoders run on the narrow channel.
-	wideBw, wideSnr := survey.OccupiedBandwidth(fullIQ, float64(fullRate), opts.ClassifyConfig)
-	chIQ, chRate := channelize(fullIQ, fullRate, surveyChannelRateHz)
+	// truncated by the channel decimation), but bounded by the nearest-neighbour
+	// spacing so a dense band (DMR on a 12.5 kHz grid) doesn't bridge its
+	// neighbours into one giant span. Modulation features + conventional decoders
+	// run on the carrier isolated to its own channel by the same bound, so an
+	// adjacent carrier 12.5 kHz away can't leak into the discriminator and defeat
+	// the digital/baud detection (which is what mislabels DMR as am/wfm).
+	wideBw, wideSnr := survey.OccupiedBandwidth(fullIQ, float64(fullRate), neighborHz, opts.ClassifyConfig)
+	chIQ, chRate := channelize(fullIQ, fullRate, classifyChannelRate(neighborHz))
 	cls := survey.ClassifyWith(chIQ, float64(chRate), wideBw, wideSnr, opts.ClassifyConfig)
 	ds.Class = cls.Class
 	ds.Confidence = cls.Confidence
@@ -375,4 +381,48 @@ func channelize(iq []complex64, rateHz, targetHz uint32) ([]complex64, uint32) {
 	}
 	out := dsp.NewResampler(1, m, 16, 7.0).Process(nil, iq)
 	return out, rateHz / uint32(m)
+}
+
+// nearestNeighborHz returns the smallest absolute frequency distance from
+// candidates[i] to any other candidate, or 0 when there is no other candidate
+// (a lone carrier — nothing to isolate against).
+func nearestNeighborHz(candidates []Candidate, i int) uint32 {
+	if i < 0 || i >= len(candidates) {
+		return 0
+	}
+	fi := candidates[i].FreqHz
+	var best uint32
+	for j, c := range candidates {
+		if j == i || c.FreqHz == fi {
+			continue
+		}
+		d := c.FreqHz - fi
+		if c.FreqHz < fi {
+			d = fi - c.FreqHz
+		}
+		if best == 0 || d < best {
+			best = d
+		}
+	}
+	return best
+}
+
+// classifyChannelRate picks the channel rate to isolate a carrier for
+// classification. The default surveyChannelRateHz (48 kHz, ±24 kHz passband) is
+// wide enough that on a dense grid (DMR at 12.5 kHz spacing) several neighbours
+// leak in and beat together — the discriminator then carries no clean baud line
+// and the carrier is mis-read as analog am/wfm (issue #648). When a neighbour
+// sits inside that passband we halve the channel to 24 kHz (±12 kHz): the gentle
+// decimation pushes the neighbour out to / past the passband edge, leaving the
+// centre carrier dominant, while staying wide enough to keep the carrier's own
+// energy intact (unlike a sharp brick-wall filter, which clips the constant-
+// envelope carrier and spikes the discriminator). A lone carrier, or one whose
+// nearest neighbour is already outside the wide passband, keeps the full channel
+// so a genuinely wideband signal isn't truncated.
+func classifyChannelRate(neighborHz uint32) uint32 {
+	const narrow = surveyChannelRateHz / 2 // 24 kHz
+	if neighborHz == 0 || neighborHz >= narrow {
+		return surveyChannelRateHz
+	}
+	return narrow
 }

--- a/internal/hunt/livesurvey_test.go
+++ b/internal/hunt/livesurvey_test.go
@@ -2,10 +2,13 @@ package hunt
 
 import (
 	"context"
+	"log/slog"
 	"math"
 	"math/rand"
 	"testing"
 
+	"github.com/MattCheramie/GopherTrunk/internal/dsp"
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/demod"
 	"github.com/MattCheramie/GopherTrunk/internal/siglab"
 	"github.com/MattCheramie/GopherTrunk/internal/survey"
 	"github.com/MattCheramie/GopherTrunk/internal/trunking"
@@ -37,6 +40,111 @@ func fmNoise(n int, rateHz, deviationHz float64, seed int64) []complex64 {
 		out[i] = complex(float32(math.Cos(phase)), float32(math.Sin(phase)))
 	}
 	return out
+}
+
+// randDibits builds a deterministic 0..3 dibit stream for C4FM synthesis.
+func randDibits(n int, seed int64) []uint8 {
+	r := rand.New(rand.NewSource(seed))
+	out := make([]uint8, n)
+	for i := range out {
+		out[i] = uint8(r.Intn(4))
+	}
+	return out
+}
+
+// dmrCarrierAt synthesises a DMR-like 4800-baud C4FM carrier (deviation 1944 Hz)
+// at sampleRate and frequency-shifts it so its centre lands at offsetHz.
+func dmrCarrierAt(nSyms int, sampleRate, offsetHz float64, seed int64) []complex64 {
+	iq := demod.ModulateP25C4FM(randDibits(nSyms, seed), sampleRate, 1944)
+	if offsetHz != 0 {
+		// NewNCO(offsetHz) shifts +offsetHz down to DC; negating shifts a DC
+		// carrier up to +offsetHz.
+		iq = dsp.NewNCO(-offsetHz, sampleRate).Mix(nil, iq)
+	}
+	return iq
+}
+
+// TestClassifyDenseDMRBand is the regression guard for issue #648: a DMR carrier
+// surrounded by neighbours on a 12.5 kHz grid must classify as digital (C4FM),
+// not be smeared by its neighbours into am/wfm with an absurd occupied bandwidth.
+// It exercises the multi-adjacent-carrier wideband path that the survey package's
+// isolated-carrier tests never reach.
+func TestClassifyDenseDMRBand(t *testing.T) {
+	const (
+		rate   = 480_000 // integer multiple of the 48 kHz survey channel
+		nSyms  = 960     // 960 symbols → 0.2 s at 4800 baud
+		grid   = 12_500  // DMR channel spacing
+		center = 440_000_000
+	)
+	// Five carriers on a 12.5 kHz grid; the centre one (DC) is under test.
+	offsets := []float64{-2 * grid, -grid, 0, grid, 2 * grid}
+	var sum []complex64
+	for i, off := range offsets {
+		c := dmrCarrierAt(nSyms, rate, off, int64(i+1))
+		if sum == nil {
+			sum = make([]complex64, len(c))
+		}
+		for j := range sum {
+			sum[j] += c[j]
+		}
+	}
+	// Light AWGN so the fixture isn't unrealistically clean.
+	full := demod.ApplyImpairments(sum, rate, demod.Impairments{SNRdB: 25, Seed: 42})
+
+	ds, _ := classifyAndRoute(
+		&DiscoveredSystem{}, full, rate,
+		Candidate{FreqHz: center}, grid,
+		LiveHuntOptions{ClassifyOnly: true}, slog.New(slog.DiscardHandler),
+	)
+
+	// The crux of #648: the centre DMR carrier must read as digital, not be
+	// smeared by its neighbours into analog am/wfm (which would then be routed to
+	// the analog-FM analyser and emit bogus "active / CTCSS").
+	if ds.Class == survey.ClassAM || ds.Class == survey.ClassWideFM {
+		t.Errorf("dense DMR centre carrier mis-classified as %q (the #648 bug)\n  features: %+v",
+			ds.Class, ds.Features)
+	}
+	if !survey.IsDigital(ds.Class) {
+		t.Errorf("dense DMR centre carrier class = %q, want a digital class\n  features: %+v",
+			ds.Class, ds.Features)
+	}
+	if ds.OccupiedBwHz > 25_000 {
+		t.Errorf("occupied bandwidth = %d Hz, want ≤ 25 kHz (neighbours bridged)", ds.OccupiedBwHz)
+	}
+}
+
+// TestClassifyLoneWidebandNotTruncated is the control for the #648 fix: a
+// genuinely isolated wideband carrier (no neighbour → neighborHz 0) must keep its
+// full measured bandwidth, proving the neighbour-aware bound never truncates a
+// real wide signal.
+func TestClassifyLoneWidebandNotTruncated(t *testing.T) {
+	const rate = 480_000
+	full := fmNoise(96_000, rate, 75_000, 11) // wide deviation → broadband FM
+
+	ds, _ := classifyAndRoute(
+		&DiscoveredSystem{}, full, rate,
+		Candidate{FreqHz: 100_000_000}, 0, // lone candidate: unbounded
+		LiveHuntOptions{ClassifyOnly: true}, slog.New(slog.DiscardHandler),
+	)
+
+	if ds.OccupiedBwHz < 60_000 {
+		t.Errorf("lone wideband occupied bandwidth = %d Hz, want wide (not truncated)\n  features: %+v",
+			ds.OccupiedBwHz, ds.Features)
+	}
+
+	// The bound is opt-in via the neighbour distance: on this same continuously-
+	// occupied wideband signal, a small maxBwHz caps the measured width while the
+	// unbounded walk (maxBwHz 0) spans the whole signal. This is the mechanism
+	// that stops a dense band's bridged spectrum from reporting 1000+ kHz.
+	cfg := survey.DefaultClassifyConfig()
+	unbounded, _ := survey.OccupiedBandwidth(full, rate, 0, cfg)
+	capped, _ := survey.OccupiedBandwidth(full, rate, 20_000, cfg)
+	if capped > 22_000 {
+		t.Errorf("capped occupied bandwidth = %d Hz, want ≤ ~20 kHz", capped)
+	}
+	if unbounded <= capped {
+		t.Errorf("expected unbounded width %d Hz to exceed the capped width %d Hz", unbounded, capped)
+	}
 }
 
 // TestRunLiveSurvey_MixedTraffic probes two carriers — a synthesized P25 control

--- a/internal/survey/classify.go
+++ b/internal/survey/classify.go
@@ -188,8 +188,9 @@ func extractFeatures(iq []complex64, rateHz float64, cfg ClassifyConfig) ClassFe
 		return f
 	}
 
-	// 1. Occupied bandwidth + SNR from the windowed IQ power spectrum.
-	f.OccupiedBwHz, f.SNRDb = OccupiedBandwidth(iq, rateHz, cfg)
+	// 1. Occupied bandwidth + SNR from the windowed IQ power spectrum. The
+	//    blind (isolated-carrier) path is already band-limited, so no cap.
+	f.OccupiedBwHz, f.SNRDb = OccupiedBandwidth(iq, rateHz, 0, cfg)
 
 	// 2. Envelope coefficient of variation (AM vs constant-envelope).
 	f.EnvelopeCV = envelopeCV(iq)
@@ -264,7 +265,14 @@ func decide(f ClassFeatures, cfg ClassifyConfig) (SignalClass, float64) {
 // centre bin. Returns (0, 0) when no carrier stands out. The survey router
 // calls this on the full-rate (un-decimated) capture so a wideband signal's
 // bandwidth isn't truncated by the narrow channel decimation.
-func OccupiedBandwidth(iq []complex64, rateHz float64, cfg ClassifyConfig) (uint32, float64) {
+//
+// maxBwHz caps the measured width: the outward walk from DC stops at ±maxBwHz/2
+// even if the gap tolerance would otherwise bridge into an adjacent carrier.
+// This keeps a dense band (e.g. DMR carriers on a 12.5 kHz grid, whose edges sit
+// inside the small gap tolerance) from chaining its neighbours into one giant
+// span. maxBwHz == 0 leaves the walk unbounded (a genuinely isolated wideband
+// signal, where nothing adjacent can bridge in).
+func OccupiedBandwidth(iq []complex64, rateHz float64, maxBwHz uint32, cfg ClassifyConfig) (uint32, float64) {
 	cfg = cfg.withDefaults()
 	n := pow2Floor(len(iq))
 	if n > 8192 {
@@ -291,15 +299,30 @@ func OccupiedBandwidth(iq []complex64, rateHz float64, cfg ClassifyConfig) (uint
 	if maxGap < 3 {
 		maxGap = 3
 	}
+	// Cap the outward walk at ±maxBwHz/2 bins so a dense band's adjacent
+	// carriers can't bridge across the gap tolerance into one span.
+	loLimit, hiLimit := 0, n-1
+	if maxBwHz > 0 {
+		half := int(math.Round((float64(maxBwHz) / 2) / binHz))
+		if half < 1 {
+			half = 1
+		}
+		if dc-half > loLimit {
+			loLimit = dc - half
+		}
+		if dc+half < hiLimit {
+			hiLimit = dc + half
+		}
+	}
 	lo, hi := dc, dc
-	for i, gap := dc-1, 0; i >= 0; i-- {
+	for i, gap := dc-1, 0; i >= loLimit; i-- {
 		if pwr[i] >= thresh {
 			lo, gap = i, 0
 		} else if gap++; gap > maxGap {
 			break
 		}
 	}
-	for i, gap := dc+1, 0; i < n; i++ {
+	for i, gap := dc+1, 0; i <= hiLimit; i++ {
 		if pwr[i] >= thresh {
 			hi, gap = i, 0
 		} else if gap++; gap > maxGap {


### PR DESCRIPTION
In a band where carriers sit on a tight grid (DMR at 12.5 kHz spacing),
the survey mis-read nearly every signal as am/wfm with absurd occupied
bandwidths (1000-2200 kHz) and then ran the analog-FM analyser on them,
emitting bogus "active / CTCSS" results.

Two coupled causes, both from never isolating a candidate from its
neighbours:

- OccupiedBandwidth ran on the full-rate (2.4 MHz) capture and its
  outward-from-DC walk bridged adjacent carriers into one giant span,
  pushing the width past the wfm threshold.
- Modulation features were extracted on the 48 kHz channel (+/-24 kHz
  passband), so several neighbours leaked into the FM discriminator,
  destroying the cyclostationary baud line. With no digital marker the
  carrier fell through to the AM / wide-FM gates.

Fix: thread each candidate's nearest-neighbour spacing into the survey.
OccupiedBandwidth now takes a maxBwHz cap that stops the walk at
+/-maxBwHz/2 (unbounded when 0, preserving the isolated-carrier and
lone-wideband paths). When a neighbour sits inside the wide channel the
classifier isolates the carrier by decimating to 24 kHz (+/-12 kHz) with
the existing gentle resampler, which attenuates the neighbour at the
passband edge without the envelope-null / discriminator-spike artifact a
sharp brick-wall filter would introduce. A digital carrier is then
correctly handed to the siglab identify -> DMR, as intended.

Adds a regression test exercising the multi-adjacent-carrier wideband
path (which the isolated-carrier classify tests never reached) plus a
lone-wideband control proving the bound never truncates a real wide
signal.

https://claude.ai/code/session_014GYhNi3au44Sr2Ai9DJ7DK