### PR TITLE
Fix decimal entry for frequency/tone fields in config builder

### DIFF
--- a/web/configbuilder/src/components/NumberField.test.tsx
+++ b/web/configbuilder/src/components/NumberField.test.tsx
@@ -1,0 +1,67 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { NumberField } from "./fields";
+
+describe("NumberField (integer path)", () => {
+  it("renders a number spinbutton and emits numbers", () => {
+    const onChange = vi.fn();
+    render(<NumberField label="Port" value={8080} onChange={onChange} />);
+    const input = screen.getByRole("spinbutton") as HTMLInputElement;
+    expect(input.value).toBe("8080");
+    fireEvent.change(input, { target: { value: "9090" } });
+    expect(onChange).toHaveBeenLastCalledWith(9090);
+  });
+
+  it("emits 0 for empty input", () => {
+    const onChange = vi.fn();
+    render(<NumberField label="Port" value={1} onChange={onChange} />);
+    fireEvent.change(screen.getByRole("spinbutton"), { target: { value: "" } });
+    expect(onChange).toHaveBeenLastCalledWith(0);
+  });
+});
+
+describe("NumberField (decimal path)", () => {
+  it("uses a text input when given a fractional step", () => {
+    render(<NumberField label="CTCSS" step={0.1} value={131.8} onChange={vi.fn()} />);
+    expect((screen.getByRole("textbox") as HTMLInputElement).value).toBe("131.8");
+  });
+
+  it("emits the parsed decimal and keeps the raw text", () => {
+    const onChange = vi.fn();
+    render(<NumberField label="CTCSS" step={0.1} value={0} onChange={onChange} />);
+    const input = screen.getByRole("textbox") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "131.8" } });
+    expect(onChange).toHaveBeenLastCalledWith(131.8);
+    expect(input.value).toBe("131.8");
+  });
+
+  it("preserves an in-progress decimal like '1500.' without wiping to 0", () => {
+    const onChange = vi.fn();
+    render(<NumberField label="Freq" step={0.1} value={0} onChange={onChange} />);
+    const input = screen.getByRole("textbox") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "1500." } });
+    // The raw text is kept so the user can finish typing the fraction.
+    expect(input.value).toBe("1500.");
+    // And the parsed numeric value (1500) is emitted, not 0.
+    expect(onChange).toHaveBeenLastCalledWith(1500);
+  });
+
+  it("emits 0 for empty or unparseable input", () => {
+    const onChange = vi.fn();
+    render(<NumberField label="Freq" step={0.1} value={5} onChange={onChange} />);
+    const input = screen.getByRole("textbox");
+    fireEvent.change(input, { target: { value: "" } });
+    expect(onChange).toHaveBeenLastCalledWith(0);
+    fireEvent.change(input, { target: { value: "abc" } });
+    expect(onChange).toHaveBeenLastCalledWith(0);
+  });
+
+  it("resyncs the text buffer when the bound value changes out-of-band", () => {
+    const { rerender } = render(
+      <NumberField label="Freq" step={0.1} value={131.8} onChange={vi.fn()} />,
+    );
+    expect((screen.getByRole("textbox") as HTMLInputElement).value).toBe("131.8");
+    rerender(<NumberField label="Freq" step={0.1} value={146.2} onChange={vi.fn()} />);
+    expect((screen.getByRole("textbox") as HTMLInputElement).value).toBe("146.2");
+  });
+});

--- a/web/configbuilder/src/components/fields.tsx
+++ b/web/configbuilder/src/components/fields.tsx
@@ -31,6 +31,13 @@ export function NumberField(props: {
   help?: ReactNode;
   step?: number;
 }) {
+  // A fractional step (e.g. 0.1) opts a field into decimal entry. Controlled
+  // type="number" inputs can't be typed with decimals — the browser reports an
+  // intermediate value like "131." as "", which would reset the field to 0 and
+  // wipe the keystroke — so decimal fields use a buffered text input instead.
+  if (props.step != null && !Number.isInteger(props.step)) {
+    return <DecimalField {...props} />;
+  }
   return (
     <label className="block">
       <span className="label">{props.label}</span>
@@ -41,6 +48,49 @@ export function NumberField(props: {
         value={Number.isFinite(props.value) ? props.value : 0}
         placeholder={props.placeholder}
         onChange={(e) => props.onChange(e.target.value === "" ? 0 : Number(e.target.value))}
+      />
+      {props.help ? <p className="help mt-1">{props.help}</p> : null}
+    </label>
+  );
+}
+
+// DecimalField backs the decimal NumberField path. Like HzField it keeps a
+// local text buffer so mid-edit values like "131." or "-" aren't reformatted or
+// wiped on every keystroke, resyncing when the bound value changes out-of-band
+// (e.g. switching items in a ListEditor). Emits a finite number, or 0 for
+// empty/unparseable input, matching the integer path's contract.
+function DecimalField(props: {
+  label: string;
+  value: number;
+  onChange: (v: number) => void;
+  placeholder?: string;
+  help?: ReactNode;
+}) {
+  const [text, setText] = useState(Number.isFinite(props.value) ? String(props.value) : "");
+  const emitted = useRef(props.value);
+  useEffect(() => {
+    if (props.value !== emitted.current) {
+      emitted.current = props.value;
+      setText(Number.isFinite(props.value) ? String(props.value) : "");
+    }
+  }, [props.value]);
+  const onText = (raw: string) => {
+    setText(raw);
+    const n = raw.trim() === "" ? 0 : Number(raw);
+    const v = Number.isFinite(n) ? n : 0;
+    emitted.current = v;
+    props.onChange(v);
+  };
+  return (
+    <label className="block">
+      <span className="label">{props.label}</span>
+      <input
+        className="input"
+        type="text"
+        inputMode="decimal"
+        value={text}
+        placeholder={props.placeholder}
+        onChange={(e) => onText(e.target.value)}
       />
       {props.help ? <p className="help mt-1">{props.help}</p> : null}
     </label>

--- a/web/configbuilder/src/sections/ToneOut.tsx
+++ b/web/configbuilder/src/sections/ToneOut.tsx
@@ -38,8 +38,8 @@ export function ToneOutSection() {
             <div className="grid gap-3 sm:grid-cols-2">
               <TextField label="Name" value={p.Name} onChange={(v) => setP({ ...p, Name: v })} />
               <TextField label="Alpha tag" value={p.AlphaTag} onChange={(v) => setP({ ...p, AlphaTag: v })} />
-              <NumberField label="Tolerance (Hz)" value={p.ToleranceHz} onChange={(v) => setP({ ...p, ToleranceHz: v })} />
-              <NumberField label="Magnitude threshold" value={p.MagnitudeThreshold} onChange={(v) => setP({ ...p, MagnitudeThreshold: v })} />
+              <NumberField label="Tolerance (Hz)" step={0.1} value={p.ToleranceHz} onChange={(v) => setP({ ...p, ToleranceHz: v })} />
+              <NumberField label="Magnitude threshold" step={0.1} value={p.MagnitudeThreshold} onChange={(v) => setP({ ...p, MagnitudeThreshold: v })} />
               <TextField label="Max gap" value={p.MaxGap} onChange={(v) => setP({ ...p, MaxGap: v })} placeholder="250ms" />
               <TextField label="Cooldown" value={p.Cooldown} onChange={(v) => setP({ ...p, Cooldown: v })} placeholder="5s" />
               {systemNames.length > 0 ? (
@@ -63,7 +63,7 @@ export function ToneOutSection() {
               emptyHint="Add one tone (single-tone) or two (A then B)."
               renderItem={(t, setT) => (
                 <div className="grid gap-3 sm:grid-cols-3">
-                  <NumberField label="Frequency (Hz, audio)" value={t.FrequencyHz} onChange={(v) => setT({ ...t, FrequencyHz: v })} />
+                  <NumberField label="Frequency (Hz, audio)" step={0.1} value={t.FrequencyHz} onChange={(v) => setT({ ...t, FrequencyHz: v })} />
                   <TextField label="Min duration" value={t.MinDuration} onChange={(v) => setT({ ...t, MinDuration: v })} placeholder="250ms" />
                   <TextField label="Max duration" value={t.MaxDuration} onChange={(v) => setT({ ...t, MaxDuration: v })} placeholder="(0 = no max)" />
                 </div>

--- a/web/configbuilder/src/sections/simple.tsx
+++ b/web/configbuilder/src/sections/simple.tsx
@@ -456,7 +456,7 @@ export function ScannerSection() {
                     { value: "nfm", label: "nfm" },
                   ]}
                 />
-                <NumberField label="Squelch (dBFS)" value={ch.SquelchDbFS} onChange={(x) => setCh({ ...ch, SquelchDbFS: x })} />
+                <NumberField label="Squelch (dBFS)" step={0.1} value={ch.SquelchDbFS} onChange={(x) => setCh({ ...ch, SquelchDbFS: x })} />
                 <NumberField label="Hangtime (ms)" value={ch.HangtimeMs} onChange={(x) => setCh({ ...ch, HangtimeMs: x })} />
                 <NumberField label="Priority" value={ch.Priority} onChange={(x) => setCh({ ...ch, Priority: x })} />
               </div>


### PR DESCRIPTION
Controlled <input type="number"> can't be typed with decimals: the
browser reports an intermediate value like "131." as "", which reset the
field to 0 and wiped the keystroke. Users reported being unable to enter
fractional frequencies/tones.

NumberField now routes fields with a fractional step to a buffered text
input (modeled on HzField) that preserves mid-edit text like "1500." and
emits the parsed number. Integer fields keep the native number spinner.

Opt the float64/float32-backed fields into the decimal path: audio tone
Frequency, Tolerance, Magnitude threshold, and Squelch (dBFS). CTCSS and
Volume already pass a fractional step and are covered automatically.

https://claude.ai/code/session_01SNgcPm9FWF8amQB1aXAqMX