### PR TITLE
sdr: default RTL-SDR tuner to AGC at open so no-gain configs aren't ~17 dB deaf

### DIFF
--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -767,16 +767,20 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 				ForceBlogV4:     dev.BlogV4,
 				ForceBlogV4Lite: dev.BlogV4Lite,
 			}
-			if dev.Gain != "" {
-				gain, ok := parseGain(dev.Gain)
-				if !ok {
-					log.Warn("daemon: ignoring unparseable gain",
-						"serial", dev.Serial, "gain", dev.Gain)
-				} else {
-					warnGainUnits(log, dev.Serial, dev.Gain, gain)
-					warnLowGain(log, dev.Serial, h.Role, dev.Gain, gain)
-					h = h.WithGain(gain)
-				}
+			// Always resolve a gain hint so the pool applies it explicitly:
+			// an empty/omitted `gain:` parses to -1 (auto/AGC), matching the
+			// documented default. Without this the device was left at the
+			// driver's raw post-init gain state — on the R82xx a ~17 dB-low
+			// VGA that deafens every protocol (issue #264). warnGainUnits /
+			// warnLowGain are no-ops for auto, so calling them is safe here.
+			gain, ok := parseGain(dev.Gain)
+			if !ok {
+				log.Warn("daemon: ignoring unparseable gain",
+					"serial", dev.Serial, "gain", dev.Gain)
+			} else {
+				warnGainUnits(log, dev.Serial, dev.Gain, gain)
+				warnLowGain(log, dev.Serial, h.Role, dev.Gain, gain)
+				h = h.WithGain(gain)
 			}
 			hints = append(hints, h)
 		}
@@ -825,16 +829,18 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 						PPM:     r.PPM,
 						BiasTee: r.BiasTee,
 					}
-					if r.Gain != "" {
-						gain, ok := parseGain(r.Gain)
-						if !ok {
-							log.Warn("daemon: ignoring unparseable rtl_tcp gain",
-								"serial", r.Serial, "gain", r.Gain)
-						} else {
-							warnGainUnits(log, r.Serial, r.Gain, gain)
-							warnLowGain(log, r.Serial, h.Role, r.Gain, gain)
-							h = h.WithGain(gain)
-						}
+					// Resolve a gain hint unconditionally: empty/omitted
+					// `gain:` parses to -1 (auto/AGC), the documented default,
+					// so the remote applies AGC explicitly rather than its
+					// raw post-open gain state (parity with local devices).
+					gain, ok := parseGain(r.Gain)
+					if !ok {
+						log.Warn("daemon: ignoring unparseable rtl_tcp gain",
+							"serial", r.Serial, "gain", r.Gain)
+					} else {
+						warnGainUnits(log, r.Serial, r.Gain, gain)
+						warnLowGain(log, r.Serial, h.Role, r.Gain, gain)
+						h = h.WithGain(gain)
 					}
 					hints = append(hints, h)
 				}

--- a/internal/sdr/pool.go
+++ b/internal/sdr/pool.go
@@ -414,16 +414,15 @@ func (p *Pool) applyHintSettings(dev Device, info Info, h Hint) {
 				"gain_db", float64(h.Gain)/10.0)
 		}
 	} else {
-		// Surface the "no `gain:` in config" path explicitly. Without
-		// this warn, a device whose driver default happens to be too
-		// low for the user's antenna + LNA chain reads as completely
-		// deaf — the field symptom in issue #356 (v0.2.4 follow-up,
-		// reporter @v2maldo). The driver-default gain varies between
-		// chips and even firmware revisions; surfacing it once at open
-		// gives the operator a chance to set `gain: auto` (AGC) or a
-		// specific tenth-dB value before chasing harder hypotheses
-		// like a broken voice chain.
-		p.log.Warn("sdr: no gain configured for device; using driver default — set `gain: auto` for AGC or a specific tenth-dB value (e.g. \"496\" = 49.6 dB) if reception is weak",
+		// No explicit gain hint reached the pool. The daemon now resolves an
+		// empty `gain:` to auto (-1) so this branch is normally bypassed; it
+		// still fires for callers that build hints directly without a gain
+		// (e.g. baseband replay / tests). The RTL-SDR driver establishes AGC
+		// at open (runBringup), so this is informational, not a deafness
+		// hazard — historically (issue #356) the raw driver default could
+		// read deaf, which is why a specific tenth-dB value is still worth
+		// surfacing for weak-signal sites.
+		p.log.Info("sdr: no explicit gain hint; relying on the driver's AGC default — set a specific tenth-dB `gain:` (e.g. \"496\" = 49.6 dB) if reception is weak",
 			"serial", info.Serial, "role", h.Role.String())
 	}
 	if h.BiasTee {

--- a/internal/sdr/pool_test.go
+++ b/internal/sdr/pool_test.go
@@ -230,16 +230,16 @@ func TestPoolFirstByRole(t *testing.T) {
 	}
 }
 
-// TestPoolWarnsOnHintWithoutGain guards the issue #356 follow-up
-// observation: a device that's listed in config but without a `gain:`
-// key was opened with whatever the driver default chose, with no
-// startup log to tell the operator. On clones whose default is too
-// low for the user's LNA + antenna chain the SDR reads as completely
-// deaf and the operator has no path from the symptom ("voice grants
-// time out with no audio") to the root cause ("no gain configured").
-// The warn must fire on every role, since a deaf control / wideband
-// device is just as bad as a deaf voice device.
-func TestPoolWarnsOnHintWithoutGain(t *testing.T) {
+// TestPoolLogsOnHintWithoutGain guards the no-gain path: a hint that
+// reaches the pool without a gain set (e.g. baseband replay / direct
+// callers — the daemon now resolves an empty `gain:` to auto upstream)
+// must still surface a startup line so the operator knows no explicit
+// gain was applied. It is INFO, not WARN: the RTL-SDR driver establishes
+// AGC at open (runBringup), so "no explicit gain hint" is no longer the
+// deafness hazard it was in issue #356 — it just falls back to AGC. The
+// line must include the serial and point at setting a specific gain for
+// weak-signal sites, on every role.
+func TestPoolLogsOnHintWithoutGain(t *testing.T) {
 	drv := &fakeDriver{name: "fake-nogain", infos: []Info{
 		{Driver: "fake-nogain", Index: 0, Serial: "NOGAIN-1"},
 	}}
@@ -253,7 +253,7 @@ func TestPoolWarnsOnHintWithoutGain(t *testing.T) {
 	})
 
 	var buf bytes.Buffer
-	log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
 	p := NewPool(log)
 	// Hint with serial only — gain is unset.
 	if err := p.Open(0, []Hint{{Serial: "NOGAIN-1", Role: RoleVoice}}); err != nil {
@@ -262,14 +262,14 @@ func TestPoolWarnsOnHintWithoutGain(t *testing.T) {
 	defer p.Close()
 
 	out := buf.String()
-	if !strings.Contains(out, "no gain configured") {
-		t.Errorf("expected no-gain warn for NOGAIN-1; log was: %q", out)
+	if !strings.Contains(out, "no explicit gain hint") {
+		t.Errorf("expected no-gain info line for NOGAIN-1; log was: %q", out)
 	}
 	if !strings.Contains(out, "NOGAIN-1") {
-		t.Errorf("warn should include the device serial; log was: %q", out)
+		t.Errorf("line should include the device serial; log was: %q", out)
 	}
-	if !strings.Contains(out, "gain: auto") {
-		t.Errorf("warn should suggest `gain: auto`; log was: %q", out)
+	if !strings.Contains(out, "AGC default") {
+		t.Errorf("line should mention the AGC default; log was: %q", out)
 	}
 }
 
@@ -299,8 +299,8 @@ func TestPoolSilentOnHintWithGain(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer p.Close()
-	if out := buf.String(); strings.Contains(out, "no gain configured") {
-		t.Errorf("hints with gain set should not warn; log was: %q", out)
+	if out := buf.String(); strings.Contains(out, "no explicit gain hint") {
+		t.Errorf("hints with gain set should not log the no-gain line; log was: %q", out)
 	}
 }
 

--- a/internal/sdr/rtlsdr/purego/driver.go
+++ b/internal/sdr/rtlsdr/purego/driver.go
@@ -377,6 +377,19 @@ func runBringup(demod *rtl2832u.Demod) (tuners.Tuner, error) {
 	if err := tuner.SetBandwidth(actual); err != nil {
 		return nil, fmt.Errorf("rtlsdr: default tuner bandwidth: %w%s", err, tunerBringupHint(err))
 	}
+	// Establish AGC as the default gain state, mirroring librtlsdr/osmocom
+	// which run r82xx_set_gain at open. tuner.Init() loads the osmocom init
+	// array but leaves the gain stages half-configured: for the R82xx the
+	// LNA + mixer AGC bits are on, yet the VGA is left at the init default
+	// (reg 0x0C = 0xF5) instead of its AGC operating point (0x0B, +16.3 dB).
+	// SetGainMode(false) pins it; without this the front end runs ~17 dB low
+	// and decode fails on every protocol when no `gain:` is configured (the
+	// VGA pin otherwise only ran via a config-driven SetGain). See issue #264
+	// and tuners.R82xx.SetGainMode. A later config gain (manual or auto) still
+	// overrides this, since pool.applyHintSettings runs after Open.
+	if err := tuner.SetGainMode(false); err != nil {
+		return nil, fmt.Errorf("rtlsdr: default AGC gain mode: %w%s", err, tunerBringupHint(err))
+	}
 	return tuner, nil
 }
 


### PR DESCRIPTION
When no `gain:` is configured, the pure-Go RTL-SDR front end was left in an
undefined gain state: runBringup ran tuner.Init() (osmocom init array, which
leaves the R82xx VGA at reg 0x0C = 0xF5) but never called SetGainMode/SetGain,
and the daemon only applied a gain when `gain:` was non-empty. The R82xx needs
its VGA pinned to 0x0B (+16.3 dB) in AGC mode — that write only happens inside
SetGainMode(false) — so an out-of-the-box dongle ran ~17 dB low (issue #264)
and failed to decode on every protocol (DMR T2, FM scanning, pagers, TETRA)
while the same dongle worked in SDR#/PDW/TTT, which always run r82xx_set_gain.

Fixes:
- runBringup now calls tuner.SetGainMode(false) after Init, establishing AGC
  (and the VGA pin) as the default for every opened device — local, auto-
  detected, and non-daemon consumers. A config-driven gain still overrides it.
- The daemon resolves an empty/omitted `gain:` to auto (-1) for both local and
  rtl_tcp devices, matching the documented behavior (parseGain already maps
  ""/"auto" -> -1); it previously skipped the call entirely.
- pool.applyHintSettings: the no-gain branch is now an informational INFO note
  rather than a deafness WARN, since the driver establishes AGC at open.

Tests: update the pool no-gain log test to the new INFO/message; existing
TestR82xx_SetGainModeAGC already pins the 0x0C->0x0B VGA write and TestParseGain
covers ""->-1.

https://claude.ai/code/session_01DEqNwbWckb3oJThqQJeR71