### PR TITLE
Close live-vs-recorded audio quality gap (resampling, buffering, loudness)

### DIFF
--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -347,6 +347,7 @@ type Daemon struct {
 	player       *player.Player
 	toneout      *toneout.Detector
 	audioPub     *api.AudioPublisher
+	liveLoudness *liveLoudnessSink
 	db           *storage.DB
 	callLog      *storage.CallLog
 	locationLog  *storage.LocationLog
@@ -1143,7 +1144,19 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 		if d.toneout != nil {
 			liveSinks = append(liveSinks, d.toneout)
 		}
-		liveSinks = append(liveSinks, d.audioPub)
+		// Optionally level the decoded digital PCM before it reaches the
+		// network stream so live loudness tracks the loudness-normalized
+		// recordings (audio.live_loudness, default off). Decoded vocoder
+		// audio is always 8 kHz. The tone-out detector is left on the raw
+		// PCM — its Goertzel matched filters key off absolute tone levels.
+		var liveStreamSink composer.PCMSink = d.audioPub
+		if cfg.Audio.LiveLoudness {
+			lls := newLiveLoudnessSink(d.audioPub, 8000, d.bus, log)
+			d.liveLoudness = lls
+			liveStreamSink = lls
+			log.Info("audio: live-loudness AGC enabled for digital stream")
+		}
+		liveSinks = append(liveSinks, liveStreamSink)
 		d.recorder.SetDecodedPCMSink(fanoutSink(liveSinks))
 
 		var sink composer.PCMSink = d.recorder
@@ -2263,6 +2276,11 @@ func (d *Daemon) Run(ctx context.Context) error {
 			return d.audioPub.Run(ctx)
 		})
 	}
+	if d.liveLoudness != nil {
+		d.spawn(runCtx, "live-loudness", false, func(ctx context.Context) error {
+			return d.liveLoudness.Run(ctx)
+		})
+	}
 	if d.metrics != nil {
 		d.spawn(runCtx, "metrics", false, func(ctx context.Context) error {
 			return d.metrics.Run(ctx)
@@ -2849,6 +2867,9 @@ func (d *Daemon) Close() {
 		}
 		if d.audioPub != nil {
 			_ = d.audioPub.Close()
+		}
+		if d.liveLoudness != nil {
+			_ = d.liveLoudness.Close()
 		}
 		if d.player != nil {
 			_ = d.player.Close()

--- a/cmd/gophertrunk/live_loudness.go
+++ b/cmd/gophertrunk/live_loudness.go
@@ -1,0 +1,181 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"math"
+	"sync"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp"
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+	"github.com/MattCheramie/GopherTrunk/internal/voice/composer"
+)
+
+// liveLoudnessSink is an optional composer.PCMSink decorator that runs a
+// real-time envelope-follower AGC over decoded digital-voice PCM before
+// forwarding it to the live network stream (the audio publisher). It gives the
+// live stream consistent loudness so it tracks the loudness-normalized on-disk
+// recordings instead of arriving raw and quieter/inconsistent (the third gap in
+// the live-vs-recorded parity work).
+//
+// It is gated behind audio.live_loudness (default off) and wraps ONLY the
+// digital decoded-PCM tap, so:
+//   - the on-disk WAV is untouched (the recorder writes from its own decode and
+//     applies its own per-call EBU R128 normalization) — no double-processing;
+//   - analog FM live audio is untouched (its loudness is shaped upstream by the
+//     composer's own optional audio AGC), preserving analog live==recorded.
+//
+// R128 *integrated* loudness needs the whole call, so this can't reproduce the
+// recorder's offline result bit-for-bit; the envelope AGC is the real-time
+// approximation that matches what the listener actually perceives.
+type liveLoudnessSink struct {
+	next       composer.PCMSink
+	sampleRate float64
+	log        *slog.Logger
+
+	bus    *events.Bus
+	busSub *events.Subscription
+
+	mu   sync.Mutex
+	agcs map[string]*serialAGC
+
+	runDone   chan struct{}
+	closeOnce sync.Once
+}
+
+// serialAGC pins one AudioAGC (and its scratch buffer) to a device serial.
+// AudioAGC.Process is not concurrency-safe, so each entry carries its own lock;
+// a given serial is normally driven by a single decode goroutine, but the lock
+// keeps a CallStart-triggered Reset from racing an in-flight WritePCM.
+type serialAGC struct {
+	mu      sync.Mutex
+	agc     *dsp.AudioAGC
+	scratch []float32
+	out     []int16
+}
+
+// newLiveLoudnessSink builds the decorator. sampleRate is the PCM rate of the
+// decoded digital audio (8 kHz today). next is the downstream sink (the audio
+// publisher). The bus subscription is taken at construction so CallStart events
+// fired before Run begins still reset the right serial.
+func newLiveLoudnessSink(next composer.PCMSink, sampleRate float64, bus *events.Bus, log *slog.Logger) *liveLoudnessSink {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &liveLoudnessSink{
+		next:       next,
+		sampleRate: sampleRate,
+		log:        log,
+		bus:        bus,
+		busSub:     bus.Subscribe(),
+		agcs:       make(map[string]*serialAGC),
+		runDone:    make(chan struct{}),
+	}
+}
+
+// entry returns the per-serial AGC, creating it on first use.
+func (s *liveLoudnessSink) entry(serial string) *serialAGC {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	e := s.agcs[serial]
+	if e == nil {
+		e = &serialAGC{
+			agc: dsp.NewAudioAGC(dsp.AudioAGCConfig{SampleRate: s.sampleRate}),
+		}
+		s.agcs[serial] = e
+	}
+	return e
+}
+
+// WritePCM levels the samples for deviceSerial and forwards them downstream.
+// The input slice is never mutated; a fresh int16 buffer is handed to next.
+func (s *liveLoudnessSink) WritePCM(deviceSerial string, samples []int16) error {
+	if len(samples) == 0 {
+		return s.next.WritePCM(deviceSerial, samples)
+	}
+	e := s.entry(deviceSerial)
+
+	e.mu.Lock()
+	if cap(e.scratch) < len(samples) {
+		e.scratch = make([]float32, len(samples))
+		e.out = make([]int16, len(samples))
+	}
+	in := e.scratch[:len(samples)]
+	for i, v := range samples {
+		in[i] = float32(v) / 32768
+	}
+	in = e.agc.Process(in, in)
+	out := e.out[:len(samples)]
+	for i, v := range in {
+		out[i] = clampToInt16(v)
+	}
+	e.mu.Unlock()
+
+	return s.next.WritePCM(deviceSerial, out)
+}
+
+// Run drains the bus, resetting a serial's AGC envelope at CallStart (so a loud
+// prior call doesn't under-amplify the next call's onset through the slow
+// release) and dropping it at CallEnd to bound the map. Returns ctx.Err() on
+// shutdown. Spawned on a goroutine by the daemon like other long-lived parts.
+func (s *liveLoudnessSink) Run(ctx context.Context) error {
+	defer close(s.runDone)
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case ev, ok := <-s.busSub.C:
+			if !ok {
+				return nil
+			}
+			switch ev.Kind {
+			case events.KindCallStart:
+				if cs, ok := ev.Payload.(trunking.CallStart); ok {
+					if e := s.lookup(cs.DeviceSerial); e != nil {
+						e.mu.Lock()
+						e.agc.Reset()
+						e.mu.Unlock()
+					}
+				}
+			case events.KindCallEnd:
+				if ce, ok := ev.Payload.(trunking.CallEnd); ok {
+					s.mu.Lock()
+					delete(s.agcs, ce.DeviceSerial)
+					s.mu.Unlock()
+				}
+			}
+		}
+	}
+}
+
+// lookup returns the existing entry for a serial without creating one.
+func (s *liveLoudnessSink) lookup(serial string) *serialAGC {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.agcs[serial]
+}
+
+// Close releases the bus subscription. Safe to call multiple times.
+func (s *liveLoudnessSink) Close() error {
+	s.closeOnce.Do(func() {
+		if s.busSub != nil {
+			s.busSub.Close()
+		}
+	})
+	return nil
+}
+
+// clampToInt16 converts a float sample in roughly [-1, 1] to int16, saturating
+// rather than wrapping on overshoot so AGC transients don't produce harsh
+// wrap-around clicks.
+func clampToInt16(v float32) int16 {
+	scaled := math.Round(float64(v) * 32767)
+	if scaled > math.MaxInt16 {
+		return math.MaxInt16
+	}
+	if scaled < math.MinInt16 {
+		return math.MinInt16
+	}
+	return int16(scaled)
+}

--- a/cmd/gophertrunk/live_loudness_test.go
+++ b/cmd/gophertrunk/live_loudness_test.go
@@ -1,0 +1,182 @@
+package main
+
+import (
+	"context"
+	"math"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// captureSink records the samples forwarded to it, per serial.
+type captureSink struct {
+	mu      sync.Mutex
+	serial  string
+	samples []int16
+}
+
+func (c *captureSink) WritePCM(serial string, samples []int16) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.serial = serial
+	c.samples = append(c.samples[:0], samples...)
+	return nil
+}
+
+func (c *captureSink) last() (string, []int16) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]int16, len(c.samples))
+	copy(out, c.samples)
+	return c.serial, out
+}
+
+func rms(samples []int16) float64 {
+	if len(samples) == 0 {
+		return 0
+	}
+	var sum float64
+	for _, s := range samples {
+		sum += float64(s) * float64(s)
+	}
+	return math.Sqrt(sum / float64(len(samples)))
+}
+
+func sineInt16(n int, freq, rate float64, amp float64) []int16 {
+	out := make([]int16, n)
+	for i := range out {
+		out[i] = int16(amp * 32767 * math.Sin(2*math.Pi*freq*float64(i)/rate))
+	}
+	return out
+}
+
+func TestLiveLoudnessSinkSilenceStaysSilent(t *testing.T) {
+	bus := events.NewBus(16)
+	cap := &captureSink{}
+	s := newLiveLoudnessSink(cap, 8000, bus, nil)
+	defer s.Close()
+
+	in := make([]int16, 320)
+	if err := s.WritePCM("dev1", in); err != nil {
+		t.Fatalf("WritePCM: %v", err)
+	}
+	serial, out := cap.last()
+	if serial != "dev1" {
+		t.Fatalf("serial = %q, want dev1", serial)
+	}
+	for i, v := range out {
+		if v != 0 {
+			t.Fatalf("silence produced non-zero sample %d at %d", v, i)
+		}
+	}
+}
+
+func TestLiveLoudnessSinkBoostsQuietAudio(t *testing.T) {
+	bus := events.NewBus(16)
+	cap := &captureSink{}
+	s := newLiveLoudnessSink(cap, 8000, bus, nil)
+	defer s.Close()
+
+	// A quiet tone (~2% full scale) should be lifted toward the AGC
+	// reference (0.3 ≈ 9830 int16 peak) over a few hundred ms.
+	quiet := sineInt16(320, 1000, 8000, 0.02)
+	inRMS := rms(quiet)
+	for i := 0; i < 20; i++ { // ~0.8 s, past the attack/release settle
+		_ = s.WritePCM("dev1", quiet)
+	}
+	_, out := cap.last()
+	if rms(out) <= inRMS*2 {
+		t.Fatalf("quiet audio not boosted: in rms %.1f, out rms %.1f", inRMS, rms(out))
+	}
+}
+
+func TestLiveLoudnessSinkDoesNotClipPastInt16(t *testing.T) {
+	bus := events.NewBus(16)
+	cap := &captureSink{}
+	s := newLiveLoudnessSink(cap, 8000, bus, nil)
+	defer s.Close()
+
+	// A near-full-scale tone should be ATTENUATED toward the AGC reference,
+	// not amplified — so once the envelope settles the output is quieter than
+	// the input and never wraps (clampToInt16 saturates by construction; the
+	// int16 type bounds the range, so the meaningful check is attenuation).
+	loud := sineInt16(320, 1000, 8000, 0.99)
+	inRMS := rms(loud)
+	for i := 0; i < 20; i++ {
+		_ = s.WritePCM("dev1", loud)
+	}
+	_, out := cap.last()
+	if rms(out) >= inRMS {
+		t.Fatalf("loud audio not attenuated: in rms %.1f, out rms %.1f", inRMS, rms(out))
+	}
+}
+
+func TestLiveLoudnessSinkResetsOnCallStart(t *testing.T) {
+	bus := events.NewBus(16)
+	cap := &captureSink{}
+	s := newLiveLoudnessSink(cap, 8000, bus, nil)
+	defer s.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go func() { _ = s.Run(ctx); close(done) }()
+
+	// Drive a loud call so the envelope level climbs high.
+	loud := sineInt16(320, 1000, 8000, 0.9)
+	for i := 0; i < 10; i++ {
+		_ = s.WritePCM("dev1", loud)
+	}
+
+	// CallEnd should drop the per-serial entry.
+	bus.Publish(events.Event{Kind: events.KindCallEnd, Payload: trunking.CallEnd{DeviceSerial: "dev1"}})
+	deadline := time.Now().Add(time.Second)
+	for {
+		if s.lookup("dev1") == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("CallEnd did not drop the serial entry")
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	// CallStart resets the envelope so the next call's quiet onset isn't
+	// under-amplified by a stale high level. After reset, a quiet tone is
+	// boosted, exactly as if the serial were fresh.
+	bus.Publish(events.Event{Kind: events.KindCallStart, Payload: trunking.CallStart{DeviceSerial: "dev1"}})
+	quiet := sineInt16(320, 1000, 8000, 0.02)
+	inRMS := rms(quiet)
+	for i := 0; i < 20; i++ {
+		_ = s.WritePCM("dev1", quiet)
+	}
+	_, out := cap.last()
+	if rms(out) <= inRMS*2 {
+		t.Fatalf("after reset, quiet audio not boosted: in %.1f out %.1f", inRMS, rms(out))
+	}
+
+	cancel()
+	<-done
+}
+
+func TestClampToInt16(t *testing.T) {
+	cases := []struct {
+		in   float32
+		want int16
+	}{
+		{0, 0},
+		{1, math.MaxInt16},  // 1.0 * 32767
+		{-1, -32767},        // symmetric ×32767 scaling
+		{2, math.MaxInt16},  // saturate, don't wrap
+		{-2, math.MinInt16}, // saturate, don't wrap
+		{0.5, 16384},        // round(0.5 * 32767)
+	}
+	for _, c := range cases {
+		if got := clampToInt16(c.in); got != c.want {
+			t.Errorf("clampToInt16(%v) = %d, want %d", c.in, got, c.want)
+		}
+	}
+}

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -824,6 +824,12 @@ audio:
   buffer_ms: 80        # playback queue depth; higher = more jitter-tolerant
   volume: 0.8          # 0..1 software gain
   muted: false
+  live_loudness: false # real-time AGC on the live network stream (WebUI /
+                       # gRPC) so its loudness tracks the normalized
+                       # recordings instead of arriving raw/quieter. Only
+                       # touches digital decoded audio on the live path; the
+                       # on-disk WAV keeps its own recordings.normalize and is
+                       # never double-processed. Default off.
 
 # tone_out fires events.KindToneAlert when the configured paging tones
 # are detected on a Voice device's PCM stream. An empty `profiles`

--- a/internal/api/audio_publisher.go
+++ b/internal/api/audio_publisher.go
@@ -45,6 +45,16 @@ type AudioPublisher struct {
 	closeOnce sync.Once
 }
 
+// audioSubChanCap bounds each subscriber's frame channel. The HTTP/gRPC
+// stream handler drains it to the wire; when a network write stalls
+// (slow client, proxy buffer flush) the publisher's WritePCM drops on
+// full rather than blocking the composer. 256 frames (a few seconds of
+// slack at typical chunk sizes) rides out transient stalls without
+// permanently losing audio, while drop-on-full still protects the
+// daemon from a genuinely dead consumer pinning memory. The frames are
+// pointers to small structs, so the memory cost is trivial.
+const audioSubChanCap = 256
+
 // AudioSubFilter is what callers pass to Subscribe to scope the
 // frames they receive. Empty fields match everything.
 type AudioSubFilter struct {
@@ -237,12 +247,12 @@ func (p *AudioPublisher) markChannelFull(sub *audioSubscriber) {
 // Subscribe registers a new subscriber and returns its frame
 // channel. Caller MUST call Unsubscribe(ret) before letting the
 // channel go out of scope — leaked subscribers keep the publisher
-// fanning frames into them forever. Channel capacity defaults to
-// 64 frames (≈ 1 second of audio at typical chunk sizes).
+// fanning frames into them forever. Channel capacity is audioSubChanCap
+// frames (a few seconds of audio at typical chunk sizes).
 func (p *AudioPublisher) Subscribe(filter AudioSubFilter) *audioSubscriber {
 	sub := &audioSubscriber{
 		filter: filter,
-		ch:     make(chan *apiv1.AudioFrame, 64),
+		ch:     make(chan *apiv1.AudioFrame, audioSubChanCap),
 	}
 	p.mu.Lock()
 	p.subs[sub] = struct{}{}

--- a/internal/api/audio_publisher_test.go
+++ b/internal/api/audio_publisher_test.go
@@ -225,8 +225,8 @@ func TestAudioPublisher_SlowSubscriberDropsNotBlocks(t *testing.T) {
 	defer pub.Unsubscribe(sub)
 
 	// Fill the bounded channel by writing more than its capacity
-	// without draining. Channel cap is 64; write 128 frames.
-	for range 128 {
+	// without draining, so drop-on-full kicks in.
+	for range audioSubChanCap * 2 {
 		pub.WritePCM("VOICE-1", []int16{1})
 	}
 	if pub.Stats().DroppedTotal == 0 {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -541,6 +541,17 @@ type AudioConfig struct {
 	Volume float32 `yaml:"volume"`
 	// Muted is the initial mute state. Default false.
 	Muted bool `yaml:"muted"`
+	// LiveLoudness applies a real-time envelope-follower AGC to the
+	// decoded digital-voice PCM fed to the live network stream
+	// (WebUI / gRPC), so live loudness tracks the loudness-normalized
+	// recordings instead of arriving raw and quieter/inconsistent.
+	// Default false. Note: this only touches the live stream — the
+	// on-disk WAV keeps its own per-call EBU R128 normalization
+	// (recordings.normalize) and is never double-processed. It is a
+	// real-time approximation, not bit-exact R128 (which needs the
+	// whole call), and only affects digital decoded audio; analog FM
+	// loudness is shaped by the composer's own optional audio AGC.
+	LiveLoudness bool `yaml:"live_loudness"`
 }
 
 // ScannerConfig controls the police-scanner subsystems: the CC hunter,

--- a/internal/configbuilder/fieldmeta.go
+++ b/internal/configbuilder/fieldmeta.go
@@ -265,12 +265,13 @@ var fieldMetas = map[string]FieldMeta{
 	"ConvToneConfig.DCSCode":           {Label: "DCS code", Help: "3-digit octal DCS code. Required when mode is dcs."},
 
 	// ---- Audio -------------------------------------------------------------
-	"AudioConfig.Enabled":    {Help: "Enable live speaker playback of decoded voice. Off by default (headless-safe). Recordings are unaffected."},
-	"AudioConfig.Device":     {Help: "Backend output device. Empty/default = system sink; 'null' forces the no-op backend."},
-	"AudioConfig.SampleRate": {Label: "Sample rate", Help: "Playback rate (4000–48000 Hz). Default 8000; match recordings.sample_rate."},
-	"AudioConfig.BufferMs":   {Help: "Playback queue depth in ms. Default 80."},
-	"AudioConfig.Volume":     {Help: "Initial software gain, 0–1. Default 0.8."},
-	"AudioConfig.Muted":      {Help: "Start muted."},
+	"AudioConfig.Enabled":      {Help: "Enable live speaker playback of decoded voice. Off by default (headless-safe). Recordings are unaffected."},
+	"AudioConfig.Device":       {Help: "Backend output device. Empty/default = system sink; 'null' forces the no-op backend."},
+	"AudioConfig.SampleRate":   {Label: "Sample rate", Help: "Playback rate (4000–48000 Hz). Default 8000; match recordings.sample_rate."},
+	"AudioConfig.BufferMs":     {Help: "Playback queue depth in ms. Default 80."},
+	"AudioConfig.Volume":       {Help: "Initial software gain, 0–1. Default 0.8."},
+	"AudioConfig.Muted":        {Help: "Start muted."},
+	"AudioConfig.LiveLoudness": {Label: "Live loudness", Help: "Real-time AGC on the live network stream (WebUI/gRPC) so its loudness tracks the normalized recordings. Digital live audio only; the on-disk WAV keeps its own normalization. Off by default."},
 
 	// ---- Broadcast ---------------------------------------------------------
 	"BroadcastConfig.MinDurationMs":   {Help: "Drop calls shorter than this from every feed. 0 streams any length."},

--- a/web/configbuilder/src/api/types.ts
+++ b/web/configbuilder/src/api/types.ts
@@ -180,6 +180,7 @@ export interface AudioConfig {
   BufferMs: number;
   Volume: number;
   Muted: boolean;
+  LiveLoudness: boolean;
 }
 
 export interface WebConfig {

--- a/web/src/audio/ringBufferProcessor.js
+++ b/web/src/audio/ringBufferProcessor.js
@@ -22,7 +22,7 @@ class RingBufferProcessor extends AudioWorkletProcessor {
     this.capacity = Math.max(1, opts.capacityFrames || Math.ceil(sampleRate * 2));
     // Jitter cushion: stay silent until this many frames are buffered, then
     // drain. Re-primed after every underrun so playback resumes cleanly.
-    this.prime = Math.min(this.capacity, Math.max(1, opts.primeFrames || Math.ceil(sampleRate * 0.15)));
+    this.prime = Math.min(this.capacity, Math.max(1, opts.primeFrames || Math.ceil(sampleRate * 0.25)));
     this.ring = new Float32Array(this.capacity);
     this.read = 0;
     this.write = 0;

--- a/web/src/audio/sincResampler.test.ts
+++ b/web/src/audio/sincResampler.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from "vitest";
+import { SincResampler } from "./sincResampler";
+
+// Resample `input` in one shot at the given rates (helper for the continuity
+// assertions below).
+function once(
+  input: number[],
+  inRate: number,
+  outRate: number,
+): number[] {
+  return Array.from(
+    new SincResampler(inRate, outRate).process(Float32Array.from(input)),
+  );
+}
+
+// goertzelMag returns the magnitude of frequency `freq` (Hz) in `samples`
+// taken at `rate` Hz — a single-bin DFT, enough to compare in-band signal
+// energy against out-of-band image energy.
+function goertzelMag(samples: number[], rate: number, freq: number): number {
+  const w = (2 * Math.PI * freq) / rate;
+  const cos = Math.cos(w);
+  const coeff = 2 * cos;
+  let s0 = 0;
+  let s1 = 0;
+  let s2 = 0;
+  for (const x of samples) {
+    s0 = x + coeff * s1 - s2;
+    s2 = s1;
+    s1 = s0;
+  }
+  const real = s1 - s2 * cos;
+  const imag = s2 * Math.sin(w);
+  return Math.sqrt(real * real + imag * imag) / samples.length;
+}
+
+describe("SincResampler", () => {
+  it("rejects non-positive rates", () => {
+    expect(() => new SincResampler(0, 8000)).toThrow(/positive/);
+    expect(() => new SincResampler(8000, -1)).toThrow(/positive/);
+  });
+
+  it("is a zero-copy passthrough when the rates match", () => {
+    const r = new SincResampler(8000, 8000);
+    expect(r.passthrough).toBe(true);
+    const input = Float32Array.from([0.1, -0.2, 0.3]);
+    // Same reference back: no work, no allocation.
+    expect(r.process(input)).toBe(input);
+  });
+
+  it("preserves a DC level (per-phase unity-gain normalization)", () => {
+    const out = once(new Array(256).fill(0.5), 8000, 48000);
+    // Skip the leading samples that still blend in the zero-padded history:
+    // the kernel reaches full real-sample support only past output ~96
+    // (input position >= HALF_WIDTH). Past that, every phase row sums to 1.
+    for (const v of out.slice(120)) expect(v).toBeCloseTo(0.5, 4);
+  });
+
+  it("joins chunks seamlessly — split feed equals one-shot feed", () => {
+    // The load-bearing #629 property: continuous state across chunk boundaries.
+    // Use an exact 2x ratio (like the LinearResampler test) so the assertion is
+    // bit-exact and not muddied by floating-point drift at the chunk boundary.
+    const input = Array.from({ length: 600 }, (_, i) =>
+      Math.sin((2 * Math.PI * 1000 * i) / 8000),
+    );
+    const whole = once(input, 8000, 16000);
+
+    const r = new SincResampler(8000, 16000);
+    const split: number[] = [];
+    for (let i = 0; i < input.length; i += 37) {
+      split.push(
+        ...r.process(Float32Array.from(input.slice(i, i + 37))),
+      );
+    }
+
+    expect(split.length).toBe(whole.length);
+    for (let i = 0; i < whole.length; i++) {
+      expect(split[i]).toBe(whole[i]);
+    }
+  });
+
+  it("handles empty and short chunks without emitting garbage", () => {
+    const r = new SincResampler(8000, 16000);
+    expect(Array.from(r.process(new Float32Array(0)))).toEqual([]);
+    // A lone first sample has no right-side kernel support yet, so nothing is
+    // emitted until enough lookahead arrives — then output stays continuous.
+    expect(Array.from(r.process(Float32Array.from([1])))).toEqual([]);
+    expect(() =>
+      r.process(Float32Array.from(new Array(64).fill(1))),
+    ).not.toThrow();
+  });
+
+  it("band-limits an 8k->48k upsample (suppresses images linear interp leaks)", () => {
+    // A 3.4 kHz tone is in-band (below the 4 kHz input Nyquist). After ideal
+    // band-limited upsampling to 48 kHz its only spectral images sit at
+    // 8k +/- 3.4k = 4.6k / 11.4k etc. — all above 4 kHz and must be heavily
+    // attenuated. Linear interpolation leaks the 4.6 kHz image badly; sinc
+    // does not.
+    const n = 4096;
+    const tone = Array.from({ length: n }, (_, i) =>
+      Math.sin((2 * Math.PI * 3400 * i) / 8000),
+    );
+    const out = once(tone, 8000, 48000).slice(64); // drop the warm-up
+
+    const signal = goertzelMag(out, 48000, 3400); // in-band tone
+    const image = goertzelMag(out, 48000, 4600); // first alias image
+    // Image at least 40 dB below the passband tone.
+    expect(20 * Math.log10(image / signal)).toBeLessThan(-40);
+  });
+});

--- a/web/src/audio/sincResampler.ts
+++ b/web/src/audio/sincResampler.ts
@@ -1,0 +1,158 @@
+// High-quality band-limited resampler for the live-audio worklet path.
+//
+// The daemon streams PCM at the call's sample rate (8 kHz for digital and the
+// analog default). The AudioWorklet that plays it runs at the AudioContext
+// rate — normally the 8 kHz we pin, but the hardware rate (~44.1/48 kHz) when a
+// browser rejects the explicit rate (older Safari throws). When those differ we
+// must resample 8k -> 48k, and the cheap LinearResampler does it with linear
+// interpolation: weak anti-imaging that leaks audible aliases above the 4 kHz
+// input Nyquist, the "harsh / tinny" character that makes live sound worse than
+// the recorded .wav (the file is resampled by the browser's native sinc path).
+//
+// SincResampler closes that gap with a windowed-sinc polyphase kernel — the
+// same class of filter the browser uses for a recorded buffer — while keeping
+// the two properties issue #629 depends on:
+//   1. Continuous state across network chunks: one instance spans the whole
+//      stream, carrying a history tail and a fractional read cursor so feeding
+//      [a,b] then [c,d] yields exactly what feeding [a,b,c,d] at once would.
+//   2. Zero-work passthrough when input and output rates match (the common
+//      8 kHz-context case), returning the input buffer unchanged.
+//
+// It is a drop-in for LinearResampler: same constructor, `passthrough` getter,
+// and process() contract.
+
+// Zero-crossings of the sinc retained on each side of the interpolation point.
+// 16 (a 32-tap effective window) gives a clean stopband for telephone-band
+// speech without being expensive at ~48 kHz mono.
+const HALF_WIDTH = 16;
+// Sub-sample resolution of the precomputed polyphase table. The fractional
+// position is quantized to the nearest of these phases, so 256 keeps the
+// quantization error well below the int16 noise floor.
+const PHASES = 256;
+// Pull the cutoff slightly below the lower Nyquist so the transition band has
+// room and the kernel doesn't ring against the very edge.
+const ROLLOFF = 0.9;
+
+// blackman returns the Blackman window weight at position x in [0, 1].
+// Endpoints are 0; centre is 1. ~-58 dB peak sidelobe — ample for voice.
+function blackman(x: number): number {
+  return 0.42 - 0.5 * Math.cos(2 * Math.PI * x) + 0.08 * Math.cos(4 * Math.PI * x);
+}
+
+// sinc returns the normalized sinc sin(pi*x)/(pi*x), with the removable
+// singularity at x = 0 handled explicitly.
+function sinc(x: number): number {
+  if (x === 0) return 1;
+  const px = Math.PI * x;
+  return Math.sin(px) / px;
+}
+
+export class SincResampler {
+  // Input samples consumed per output sample (inputRate / outputRate).
+  private readonly ratio: number;
+  // kernel[phase] is a length-(2*HALF_WIDTH) row of filter taps for that
+  // fractional offset, ordered from the leftmost neighbour to the rightmost.
+  private readonly kernel: Float32Array[];
+  // The last 2*HALF_WIDTH input samples seen, zero-filled at stream start so
+  // the first outputs blend in silence — identical whether fed split or whole.
+  private readonly history: Float32Array;
+  // Position of the next output in input-sample coordinates, relative to the
+  // start of the current chunk. Index -1 is history[last], -2 the one before,
+  // etc. Starts at 0 so the first output is centred on the first real sample.
+  private t = 0;
+
+  constructor(inputRate: number, outputRate: number) {
+    if (inputRate <= 0 || outputRate <= 0) {
+      throw new Error("SincResampler: sample rates must be positive");
+    }
+    this.ratio = inputRate / outputRate;
+    // Cutoff in input-sample cycles. When downsampling (outputRate < inputRate)
+    // the band limit is the output Nyquist, so scale the cutoff down by the
+    // rate ratio; when upsampling it stays at the input Nyquist.
+    const cutoff = ROLLOFF * Math.min(1, outputRate / inputRate);
+    this.kernel = SincResampler.buildKernel(cutoff);
+    this.history = new Float32Array(2 * HALF_WIDTH);
+  }
+
+  // buildKernel precomputes one windowed-sinc tap row per fractional phase.
+  // Each row is normalized to unity DC gain so a constant input is reproduced
+  // exactly (no amplitude drift, and the DC-preservation test passes).
+  private static buildKernel(cutoff: number): Float32Array[] {
+    const rows: Float32Array[] = new Array(PHASES);
+    const taps = 2 * HALF_WIDTH;
+    for (let p = 0; p < PHASES; p++) {
+      const frac = p / PHASES; // sub-sample offset of the output, in [0, 1)
+      const row = new Float32Array(taps);
+      let sum = 0;
+      for (let k = 0; k < taps; k++) {
+        // Tap k covers input neighbour (k - HALF_WIDTH + 1); its distance from
+        // the output point is that index minus the fractional offset.
+        const x = k - HALF_WIDTH + 1 - frac;
+        const w = blackman((x + HALF_WIDTH) / taps);
+        const h = cutoff * sinc(cutoff * x) * w;
+        row[k] = h;
+        sum += h;
+      }
+      const norm = sum !== 0 ? 1 / sum : 1;
+      for (let k = 0; k < taps; k++) row[k] *= norm;
+      rows[p] = row;
+    }
+    return rows;
+  }
+
+  /** True when input and output rates match and process() is a no-op. */
+  get passthrough(): boolean {
+    return this.ratio === 1;
+  }
+
+  // process resamples one chunk, emitting every output sample whose full kernel
+  // support lies within the samples seen so far. Any output whose right edge
+  // would read past this chunk's end is deferred to the next call, and the
+  // chunk's tail is folded into the history so consecutive chunks join
+  // seamlessly. Returns the input unchanged when passthrough.
+  process(input: Float32Array): Float32Array {
+    if (input.length === 0) return input;
+    if (this.ratio === 1) return input;
+
+    const { history, kernel } = this;
+    const hist = history.length; // == 2 * HALF_WIDTH
+    const len = input.length;
+    // Read from the logical stream [history ... input]; index 0 is the first
+    // history sample, `hist` the first input sample. A sample at history-frame
+    // `f` (the input-sample coordinate, where -1 is history's last) maps to
+    // logical index f + hist.
+    const sampleAt = (logical: number): number =>
+      logical < hist ? history[logical] : input[logical - hist];
+
+    const out: number[] = [];
+    let t = this.t;
+    // The kernel centred at frame `t` (its right neighbour is ceil-side) reads
+    // neighbours [floor(t) - HALF_WIDTH + 1 ... floor(t) + HALF_WIDTH]. We can
+    // emit while the rightmost neighbour still exists, i.e. floor(t)+HALF_WIDTH
+    // is within the input chunk: floor(t) <= len - 1 - HALF_WIDTH.
+    while (Math.floor(t) <= len - 1 - HALF_WIDTH) {
+      const i = Math.floor(t);
+      const frac = t - i;
+      const row = kernel[(frac * PHASES) | 0];
+      // Leftmost neighbour index (in input-sample coordinates) is i-HALF_WIDTH+1;
+      // its logical index adds `hist`.
+      const base = i - HALF_WIDTH + 1 + hist;
+      let acc = 0;
+      for (let k = 0; k < row.length; k++) acc += row[k] * sampleAt(base + k);
+      out.push(acc);
+      t += this.ratio;
+    }
+
+    // Fold the chunk tail into history: the new history is the last `hist`
+    // samples of [history ... input]. Shift the cursor by len so it stays
+    // continuous across the boundary (next chunk's frame -1 is this tail's end).
+    if (len >= hist) {
+      history.set(input.subarray(len - hist));
+    } else {
+      history.copyWithin(0, len); // drop the `len` oldest history samples
+      history.set(input, hist - len);
+    }
+    this.t = t - len;
+    return Float32Array.from(out);
+  }
+}

--- a/web/src/audio/streamPlayer.ts
+++ b/web/src/audio/streamPlayer.ts
@@ -17,7 +17,7 @@
 // internal/api/handlers_audio_stream.go. The byte-framing logic below
 // must match that layout.
 
-import { LinearResampler } from "./resampler";
+import { SincResampler } from "./sincResampler";
 
 // ---------------------------------------------------------------------------
 // Pure, testable framing helpers (no DOM / AudioContext).
@@ -136,9 +136,12 @@ export interface StreamPlayer {
   setMuted(muted: boolean): void;
 }
 
-// Lead time before the first scheduled buffer — a small jitter cushion so
-// brief network hiccups don't cause audible gaps.
-const LEAD_SECONDS = 0.15;
+// Lead time before the first scheduled buffer — a jitter cushion so brief
+// network hiccups and bursty chunk delivery don't cause audible gaps. 0.25 s
+// roughly doubles the tolerance (and the ring's re-prime depth after an
+// underrun) vs. the original 0.15 s while staying well under MAX_LEAD_SECONDS,
+// so steady-state latency stays low.
+const LEAD_SECONDS = 0.25;
 // Upper bound on scheduled-ahead audio; past this we realign so a burst
 // of buffered frames doesn't pin latency high for the rest of the call.
 const MAX_LEAD_SECONDS = 0.6;
@@ -194,12 +197,14 @@ interface PcmSink {
 }
 
 // WorkletSink feeds the ring-buffer AudioWorklet (issue #629). It resamples the
-// stream to the context rate with one continuous LinearResampler (so chunk
-// boundaries don't glitch) and hands the samples to the audio thread via a
-// transferred buffer. The worklet emits silence on underrun, so network jitter
-// no longer skips/realigns the playback cursor the way the legacy scheduler did.
+// stream to the context rate with one continuous SincResampler (so chunk
+// boundaries don't glitch and the 8k->48k fallback path is band-limited like a
+// recorded .wav, not the harsh linear interpolation of the old resampler) and
+// hands the samples to the audio thread via a transferred buffer. The worklet
+// emits silence on underrun, so network jitter no longer skips/realigns the
+// playback cursor the way the legacy scheduler did.
 class WorkletSink implements PcmSink {
-  private resampler: LinearResampler | null = null;
+  private resampler: SincResampler | null = null;
 
   constructor(
     private readonly node: AudioWorkletNode,
@@ -207,7 +212,7 @@ class WorkletSink implements PcmSink {
   ) {}
 
   configure(streamRate: number): void {
-    this.resampler = new LinearResampler(streamRate, this.contextRate);
+    this.resampler = new SincResampler(streamRate, this.contextRate);
     this.node.port.postMessage({ type: "reset" });
   }
 


### PR DESCRIPTION
Live and recorded audio start from identical decoded 8 kHz/16-bit/mono PCM,
so the quality gap was entirely in the live transport + browser playback
chain. Three targeted fixes:

1. Fidelity (harsh/tinny/aliased): when a browser rejects the explicit 8 kHz
   AudioContext and falls back to 44.1/48 kHz, the WorkletSink resampled 8k->48k
   with linear interpolation, leaking audible images above the 4 kHz input
   Nyquist. Add SincResampler — a Blackman-windowed polyphase resampler with
   continuous cross-chunk state (preserving the #629 seamless-join property) and
   a zero-copy passthrough — and use it in the WorkletSink so the fallback path
   is band-limited like the browser's native .wav resampling. A unit test
   asserts the first alias image is >40 dB down (which linear interp fails).

2. Continuity (choppy/gaps/dropouts): raise the ring-buffer prime cushion from
   0.15s to 0.25s (roughly doubling jitter tolerance, still well under the
   realign bound) and the per-subscriber publisher channel capacity from 64 to
   256 frames so transient HTTP-write stalls no longer drop audio permanently.

3. Loudness (quieter/inconsistent): recordings are loudness-normalized post-call
   but the live stream got raw PCM. Add an optional real-time envelope-follower
   AGC (audio.live_loudness, default off) on the digital decoded-PCM live tap so
   live loudness tracks the normalized recordings. It wraps only the digital
   stream path — the on-disk WAV keeps its own EBU R128 normalization and is
   never double-processed, and analog FM live audio (shaped upstream by the
   composer's own AGC) is untouched.

https://claude.ai/code/session_018mT8FQpNL2SReQzv2Yn5B6